### PR TITLE
i#1962 Travis: Try using the already-present nasm on Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:
   - uname -a
-  - if [[ "`uname`" == "Darwin" ]]; then brew install nasm; fi
+  - if [[ "`uname`" == "Darwin" ]]; then nasm -v; fi
   # ImageMagick is present but these are not:
   - if [[ "`uname`" == "Linux" ]]; then sudo apt-get -y install g++-multilib doxygen transfig; fi
 


### PR DESCRIPTION
Testing using a pull request from a forked repository as a "trybot" to test on Travis before pushing to the main repository.  This tries to fix the recent Mac nasm install failure.