### PR TITLE
Make -verbose option for drcov output a more verbose module table.

### DIFF
--- a/clients/drcov/drcov.c
+++ b/clients/drcov/drcov.c
@@ -156,6 +156,7 @@ options_init(client_id_t id, int argc, const char *argv[], drcovlib_options_t *o
             if (dr_sscanf(token, "%u", &verbose) != 1) {
                 USAGE_CHECK(false, "invalid -verbose number");
             }
+            ops->verbose_module_table = true;
         }
         else {
             NOTIFY(0, "UNRECOGNIZED OPTION: \"%s\"\n", token);

--- a/ext/drcovlib/drcovlib.c
+++ b/ext/drcovlib/drcovlib.c
@@ -213,7 +213,7 @@ static void
 dump_drcov_data(void *drcontext, per_thread_t *data)
 {
     version_print(data->log);
-    module_table_print(module_table, data->log, false);
+    module_table_print(module_table, data->log, options.verbose_module_table);
     bb_table_print(drcontext, data);
 }
 

--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -95,6 +95,10 @@ typedef struct _drcovlib_options_t {
      * option, is created.  This option only works under Windows.
      */
     int native_until_thread;
+    /**
+     * By default, information like base module address are omitted.
+     */
+    bool verbose_module_table;
 } drcovlib_options_t;
 
 /***************************************************************************


### PR DESCRIPTION
Add command-line switch (`-verbose_module_table` - naming highly open to suggestions) to `drcov` to enable verbose dumping of the module table (including base address for each module).
