### PR TITLE
i#1680 large pages: Add code to discover page size on Unix.

### DIFF
--- a/core/arch/aarchxx/aarchxx.asm
+++ b/core/arch/aarchxx/aarchxx.asm
@@ -47,7 +47,7 @@ GLOBAL_LABEL(_start:)
          * We call this here to ensure it's safe to access globals once in C code
          * (xref i#1865).
          */
-        CALLC2(GLOBAL_REF(relocate_dynamorio), #0, #0)
+        CALLC3(GLOBAL_REF(relocate_dynamorio), #0, #0, sp)
 
         /* Clear 2nd & 3rd args to distinguish from xfer_to_new_libdr */
         mov      ARG2, #0

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -1162,7 +1162,7 @@ GLOBAL_LABEL(_start:)
          */
         cmp     REG_XDI, 0 /* if reloaded, skip for speed + preserve xdi and xsi */
         jne     reloaded_xfer
-        CALLC2(GLOBAL_REF(relocate_dynamorio), 0, 0)
+        CALLC3(GLOBAL_REF(relocate_dynamorio), 0, 0, REG_XSP)
 
 reloaded_xfer:
         xor     REG_XBP, REG_XBP  /* Terminate stack traces at NULL. */

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -367,6 +367,9 @@ dynamorio_app_init(void)
 
     if (!dynamo_initialized /* we do enter if nullcalls is on */) {
 
+#ifdef UNIX
+        os_page_size_init((const char **)our_environ);
+#endif
 #ifdef WINDOWS
         /* MUST do this before making any system calls */
         syscalls_init();
@@ -836,6 +839,9 @@ standalone_init(void)
 #if defined(INTERNAL) && defined(DEADLOCK_AVOIDANCE)
     /* avoid issues w/ GLOBAL_DCONTEXT instead of thread dcontext */
     dynamo_options.deadlock_avoidance = false;
+#endif
+#ifdef UNIX
+    os_page_size_init((const char **)our_environ);
 #endif
 #ifdef WINDOWS
     /* MUST do this before making any system calls */

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -512,6 +512,9 @@ typedef struct _dr_mem_info_t {
 #define PAGE_START(x) (((ptr_uint_t)(x)) & ~(os_page_size()-1))
 
 size_t os_page_size(void);
+#ifdef UNIX
+void os_page_size_init(const char **env);
+#endif
 bool get_memory_info(const byte *pc, byte **base_pc, size_t *size, uint *prot);
 bool query_memory_ex(const byte *pc, OUT dr_mem_info_t *info);
 /* We provide this b/c getting the bounds is expensive on Windows (i#1462) */

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1579,9 +1579,14 @@ privload_mem_is_elf_so_header(byte *mem)
  * fragile state and thus no globals access or use of ASSERT/LOG/STATS!
  */
 void
-relocate_dynamorio(byte *dr_map, size_t dr_size)
+relocate_dynamorio(byte *dr_map, size_t dr_size, byte *sp)
 {
+    ptr_uint_t argc = *(ptr_uint_t *)sp;
+    /* Plus 2 to skip argc and null pointer that terminates argv[]. */
+    const char **env = (const char **)sp + argc + 2;
     os_privmod_data_t opd = { {0}};
+
+    os_page_size_init(env);
 
     if (dr_map == NULL) {
         /* we do not know where dynamorio is, so check backward page by page */


### PR DESCRIPTION
The stack pointer is passed as a third argument to relocate_dynamorio
and on Linux this is used to search the auxiliary vector for AT_PAGESZ.
Similarly, there are calls to os_page_size_init in dynamorio_app_init
and standalone_init to do the same thing. On MacOS, and on Linux if
for some reason os_page_size is called before these initialisations,
the page size is discovered using the system calls mmap and munmap,
which should work on any POSIX system.

A later commit should get Mac OSX to use sysctl_query on hw.pagesize.

Review-URL: https://codereview.appspot.com/313800043