### PR TITLE
i#1834 memval Part 1: drx_tail_pad_block

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -164,6 +164,7 @@ Further non-compatibility-affecting changes include:
  - Added #DR_CLEANCALL_ALWAYS_OUT_OF_LINE.
  - Added instr_create_4dst_2src().
  - Added drreg_restore_app_values().
+ - Added drx_tail_pad_block().
 
 **************************************************
 <hr>

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -1372,3 +1372,16 @@ drx_open_unique_appid_dir(const char *dir, ptr_int_t id,
     }
     return false;
 }
+
+bool
+drx_tail_pad_block(void *drcontext, instrlist_t *ilist)
+{
+    instr_t *last = instrlist_last_app(ilist);
+
+    if (instr_is_cti(last) || instr_is_syscall(last)) {
+        /* This basic block is already branch or syscall-terminated */
+        return false;
+    }
+    instrlist_meta_postinsert(ilist, last, INSTR_CREATE_label(drcontext));
+    return true;
+}

--- a/ext/drx/drx.h
+++ b/ext/drx/drx.h
@@ -435,6 +435,22 @@ DR_EXPORT
 size_t
 drx_buf_get_buffer_size(void *drcontext, drx_buf_t *buf);
 
+
+DR_EXPORT
+/**
+ * Pads a basic block with a label at the end for routines which rely on inserting
+ * instrumentation after every instruction. Note that users of this routine must act on
+ * the previous instruction in basic block events before skipping non-app instructions
+ * because the label is not marked as an app instruction.
+ *
+ * \note the padding label is not introduced if the basic block is already branch
+ * terminated.
+ *
+ * \returns whether padding was introduced.
+ */
+bool
+drx_tail_pad_block(void *drcontext, instrlist_t *ilist);
+
 /*@}*/ /* end doxygen group */
 
 #ifdef __cplusplus

--- a/suite/tests/client-interface/drx-test.dll.c
+++ b/suite/tests/client-interface/drx-test.dll.c
@@ -85,6 +85,7 @@ event_basic_block(void *drcontext, void *tag, instrlist_t *bb,
                   bool for_trace, bool translating)
 {
     instr_t *first = instrlist_first_app(bb);
+    instr_t *last;
     /* Exercise drx's adjacent increment aflags spill removal code */
     drx_insert_counter_update(drcontext, bb, first,
                               SPILL_SLOT_1, IF_NOT_X86_(SPILL_SLOT_2)
@@ -94,6 +95,11 @@ event_basic_block(void *drcontext, void *tag, instrlist_t *bb,
     drx_insert_counter_update(drcontext, bb, first,
                               SPILL_SLOT_1, IF_NOT_X86_(SPILL_SLOT_2)
                               &counterB, 2, IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
+    /* Exercise drx's basic block termination with a zero-cost label */
+    drx_tail_pad_block(drcontext, bb);
+    last = instrlist_last(bb);
+    CHECK(instr_is_syscall(last) || instr_is_cti(last) || instr_is_label(last),
+          "did not correctly pad basic block");
     return DR_EMIT_DEFAULT;
 }
 


### PR DESCRIPTION
Adds a drx_tail_pad_block() method which constructs a zero-cost label at
the end of any basic block which is not already branch-terminated. This
facilitates the ability to add instrumentation after the current
instruction even if the basic block is not branch-terminated.