### PR TITLE
i#1834 memval Part 2: XINST_CREATE_load_1byte_zextend

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -165,6 +165,7 @@ Further non-compatibility-affecting changes include:
  - Added instr_create_4dst_2src().
  - Added drreg_restore_app_values().
  - Added drx_tail_pad_block().
+ - Added XINST_CREATE_load_1byte_zext4().
 
 **************************************************
 <hr>

--- a/core/arch/arm/instr_create.h
+++ b/core/arch/arm/instr_create.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -113,6 +113,16 @@
  * \param m   The source memory opnd.
  */
 #define XINST_CREATE_load(dc, r, m)  INSTR_CREATE_ldr((dc), (r), (m))
+
+/**
+ * This platform-independent macro creates an instr_t which loads 1 byte
+ * from memory, zero-extends it to 4 bytes, and writes it to a 4 byte
+ * destination register.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param r   The destination register opnd.
+ * \param m   The source memory opnd.
+ */
+#define XINST_CREATE_load_1byte_zext4(dc, r, m)  INSTR_CREATE_ldrb((dc), (r), (m))
 
 /**
  * This platform-independent macro creates an instr_t for a 1-byte

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -167,6 +167,16 @@
 #define XINST_CREATE_load(dc, r, m)  INSTR_CREATE_mov_ld(dc, r, m)
 
 /**
+ * This platform-independent macro creates an instr_t which loads 1 byte
+ * from memory, zero-extends it to 4 bytes, and writes it to a 4 byte
+ * destination register.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param r   The destination register opnd.
+ * \param m   The source memory opnd.
+ */
+#define XINST_CREATE_load_1byte_zext4(dc, r, m)  INSTR_CREATE_movzx(dc, r, m)
+
+/**
  * This platform-independent macro creates an instr_t for a 1-byte
  * memory load instruction.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1314,6 +1314,16 @@ test_xinst_create(void *dc)
     byte *pc;
     reg_id_t reg = DR_REG_XDX;
     instr_t *ins1, *ins2;
+    /* load 1 byte zextend */
+    ins1 = XINST_CREATE_load_1byte_zext4
+        (dc, opnd_create_reg(reg_resize_to_opsz(reg, OPSZ_4)), MEMARG(OPSZ_1));
+    pc = instr_encode(dc, ins1, buf);
+    ASSERT(pc != NULL);
+    ins2 = instr_create(dc);
+    decode(dc, buf, ins2);
+    ASSERT(instr_same(ins1, ins2));
+    instr_reset(dc, ins1);
+    instr_reset(dc, ins2);
     /* load 1 byte */
     ins1 = XINST_CREATE_load_1byte
         (dc, opnd_create_reg(reg_resize_to_opsz(reg, OPSZ_1)), MEMARG(OPSZ_1));


### PR DESCRIPTION
Adds XINST_CREATE_load_1byte_zextend() method which on x86 performs a
movzx so that we can effectively perform single byte loads even if given
a register which cannot be resized appropriately. On ARM this emits a
traditional ldrb instruction.