### PR TITLE
i#2145 AppVeyor: VS2010 + VS2013 build setup

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,18 +30,32 @@
 
 # AppVeyor CI configuration:
 
-# Download source archive instead of cloning entire repository history.
-shallow_clone: true
+notifications:
+  - provider: Email
+    to:
+      - dynamorio-devs@googlegroups.com
+    on_build_success: false
+    on_build_failure: true
+    on_build_status_changed: true
+
+# We don't do a shallow clone of just the source archive as we want to get
+# the diff for source file checks.
+# We do limit to the last few commits to speed things up:
+clone_depth: 10
 
 platform: x64
 
-os:
-  - Visual Studio 2010 Service Pack 1
+image: Visual Studio 2013
 
 build:
   verbosity: detailed
 
+configuration:
+  - 2010
+  - 2013
+
 install:
+  ##################################################
   # Install ninja so we have readable output.
   - mkdir c:\projects\install
   - cd c:\projects\install
@@ -49,9 +63,31 @@ install:
   - 7z x ninja-win.zip -oc:\projects\install\ninja > nul
   - set PATH=c:\projects\install\ninja;%PATH%
 
+  ##################################################
+  # Install packages for docs.
+  - choco install -y doxygen.portable imagemagick.tool ghostscript
+  # The ghostscript package is an install that doesn't add to PATH.
+  # FIXME i#2145: fig2dev is failing to launch ghostscript, so for now
+  # we're disabling to get the initial AppVeyor to be green.
+  #- set PATH=C:\Program Files\gs\gs9.20\bin;%PATH%
+  # Install fig2dev.
+  - appveyor DownloadFile http://www.winfig.com/WinFIG-Dateien/WinFIG62.zip
+  - 7z x WinFIG62.zip > nul
+  - set PATH=c:\projects\install\WinFig;%PATH%
+
+  ##################################################
+  # XXX i#2145: point at Qt5 for testing drgui build.
+
 before_build:
-  - call "c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
+  - if "%configuration%"=="2010" call "c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
+  - if "%configuration%"=="2013" call "c:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86
   - cd c:\projects\dynamorio
 
 build_script:
-  - perl suite/runsuite_wrapper.pl travis use_ninja
+  - mkdir build
+  - cd build
+  - echo %PATH%
+  # AppVeyor does not have the 64-bit toolchain installed for 2010.
+  - if "%configuration%"=="2010" set EXTRA_ARGS=32_only
+  # The perl in c:\perl can't open a pipe so we use cygwin perl.
+  - c:\cygwin\bin\perl ../suite/runsuite_wrapper.pl travis use_ninja %EXTRA_ARGS%

--- a/make/FindGhostscript.cmake
+++ b/make/FindGhostscript.cmake
@@ -1,4 +1,5 @@
 # **********************************************************
+# Copyright (c) 2017 Google, Inc.  All rights reserved.
 # Copyright (c) 2009 Derek Bruening    All rights reserved.
 # **********************************************************
 
@@ -28,7 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 find_program(GHOSTSCRIPT_EXECUTABLE
-  NAMES gs gswin32c
+  NAMES gs gswin32c gswin64c
   PATHS
   # implicitly searches in ENV PATH first
   ${CYGWIN_INSTALL_PATH}/bin

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2016 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2017 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -58,7 +58,7 @@ endforeach (arg)
 if (arg_travis)
   # XXX i#1801, i#1962: under clang we have several failing tests.  Until those are
   # fixed, our Travis clang suite only builds and does not run tests.
-  if (NOT APPLE AND $ENV{CC} MATCHES "clang")
+  if (UNIX AND NOT APPLE AND "$ENV{CC}" MATCHES "clang")
     set(run_tests OFF)
     message("Detected a Travis clang suite: disabling running of tests")
   endif ()


### PR DESCRIPTION
Adds 32-bit VS2010 and full VS2013 AppVeyor setup, both with ninja, which
we install beforehand.  Sends notifications to the devs list.

Fixes several issues blocking AppVeyor from running before:
+ Set the image to 2013 as there is no 2010 image.
+ Use an absolute path for cygpath to avoid picking up git's version.
+ Quote the CC env var to avoid AppVeyor's cmake from complaining.

Adds gswin64c to make/FindGhostscript.cmake.

Adds explicit failure on pre-commit diff content checks.

Qt5 is there but not yet pointed at.

Disables the docs for now as the ghostscript installed with chocolately
fails to be properly launched by fig2dev.

Most importantly, temporarily ignores test failures, keeping AppVeyor
green, until we've fixed the handful of base test failures in this
environment.