### PR TITLE
i#2135: fix crash in check_thread_vm_area for guard pages

### DIFF
--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -291,6 +291,7 @@ typedef enum {
     ILLEGAL_INSTRUCTION_EXCEPTION,
     UNREADABLE_MEMORY_EXECUTION_EXCEPTION,
     IN_PAGE_ERROR_EXCEPTION,
+    GUARD_PAGE_EXCEPTION,
 } dr_exception_type_t;
 
 void os_forge_exception(app_pc exception_address, dr_exception_type_t type);

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -7440,7 +7440,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
         ASSERT(!ok || area != NULL);
         is_allocated_mem = get_memory_info(pc, &base_pc, &size, &prot);
         /* i#2135 : it can be a guard page if either ok or not ok
-         * so we have to get protection value right now 
+         * so we have to get protection value right now
          */
 #ifdef WINDOWS
         if (TEST(DR_MEMPROT_GUARD, prot)) {

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -7446,12 +7446,12 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
         if (TEST(DR_MEMPROT_GUARD, prot)) {
             /* remove protection so as to go on */
             if (unmark_page_as_guard(pc, prot)) {
-                /* we test that there was still the guard protection to remove.
+                /* We test that there was still the guard protection to remove.
                  * Otherwise, there could be a race condition with
                  * two threads trying to execute from the guarded page
-                 * and we would raise two exceptions instead of one
+                 * and we would raise two exceptions instead of one.
                  */
-                SYSLOG_INTERNAL_WARNING("Application tries to execute "
+                SYSLOG_INTERNAL_WARNING("Application tried to execute "
                                         "from guard memory "PFX".\n", pc);
                 check_thread_vm_area_cleanup(dcontext, true/*abort*/,
                                              true/*clean bb*/, data, vmlist,

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -7367,6 +7367,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
             read_lock(&executable_areas->lock);
         ok = lookup_addr(executable_areas, pc, &area);
         if (ok && TEST(VM_DELAY_READONLY, area->vm_flags)) {
+            bool is_allocated_mem;
             /* need to mark region read only for consistency
              * need to upgrade to write lock, have to release lock first
              * then recheck conditions after grabbing hotp + write lock */
@@ -7437,7 +7438,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
                       IF_HOTP(&& (!DYNAMO_OPTION(hot_patching) ||
                                   self_owns_write_lock(hotp_get_lock())))));
         ASSERT(!ok || area != NULL);
-        bool is_allocated_mem = get_memory_info(pc, &base_pc, &size, &prot);
+        is_allocated_mem = get_memory_info(pc, &base_pc, &size, &prot);
         /* i#2135 : it can be a guard page if either ok or not ok
          * so we have to get protection value right now */
 #ifdef WINDOWS

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -5837,6 +5837,12 @@ initialize_exception_record(EXCEPTION_RECORD* rec, app_pc exception_address,
     case ILLEGAL_INSTRUCTION_EXCEPTION:
         rec->ExceptionCode = EXCEPTION_ILLEGAL_INSTRUCTION;
         break;
+    case GUARD_PAGE_EXCEPTION:
+        rec->ExceptionCode = STATUS_GUARD_PAGE_VIOLATION;
+        rec->NumberParameters = 2;
+        rec->ExceptionInformation[0]=8 /* execution tried */;
+        rec->ExceptionInformation[1]=(ptr_uint_t)exception_address;
+        break;
     default:
         ASSERT_NOT_REACHED();
     }

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -5840,7 +5840,7 @@ initialize_exception_record(EXCEPTION_RECORD* rec, app_pc exception_address,
     case GUARD_PAGE_EXCEPTION:
         rec->ExceptionCode = STATUS_GUARD_PAGE_VIOLATION;
         rec->NumberParameters = 2;
-        rec->ExceptionInformation[0]=8 /* execution tried */;
+        rec->ExceptionInformation[0]=EXCEPTION_EXECUTE_FAULT /* execution tried */;
         rec->ExceptionInformation[1]=(ptr_uint_t)exception_address;
         break;
     default:

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -5840,8 +5840,8 @@ initialize_exception_record(EXCEPTION_RECORD* rec, app_pc exception_address,
     case GUARD_PAGE_EXCEPTION:
         rec->ExceptionCode = STATUS_GUARD_PAGE_VIOLATION;
         rec->NumberParameters = 2;
-        rec->ExceptionInformation[0]=EXCEPTION_EXECUTE_FAULT /* execution tried */;
-        rec->ExceptionInformation[1]=(ptr_uint_t)exception_address;
+        rec->ExceptionInformation[0] = EXCEPTION_EXECUTE_FAULT /* execution tried */;
+        rec->ExceptionInformation[1] = (ptr_uint_t)exception_address;
         break;
     default:
         ASSERT_NOT_REACHED();

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -5762,7 +5762,7 @@ mark_page_as_guard(byte *pc)
 }
 
 /* Removes guard protection from page containing pc */
-void
+bool
 unmark_page_as_guard(byte *pc, uint prot)
 {
     uint old_prot;
@@ -5771,7 +5771,11 @@ unmark_page_as_guard(byte *pc, uint prot)
 
     uint flags = memprot_to_osprot(prot & ~MEMPROT_GUARD);
     res = protect_virtual_memory(start_page, PAGE_SIZE, flags, &old_prot);
+    /* it is likely that another thread accessed the guarded page
+     * while we wanted to remove this protection
+     */
     ASSERT(res);
+    return TEST(PAGE_GUARD, old_prot);
 }
 
 /* Change page protection for pc:pc+size.

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -5771,10 +5771,11 @@ unmark_page_as_guard(byte *pc, uint prot)
 
     uint flags = memprot_to_osprot(prot & ~MEMPROT_GUARD);
     res = protect_virtual_memory(start_page, PAGE_SIZE, flags, &old_prot);
-    /* it is likely that another thread accessed the guarded page
-     * while we wanted to remove this protection
-     */
     ASSERT(res);
+    /* It is possible that another thread accessed the guarded page
+     * while we wanted to remove this protection. The returned value
+     * can be checked for such a case.
+     */
     return TEST(PAGE_GUARD, old_prot);
 }
 

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -5761,6 +5761,19 @@ mark_page_as_guard(byte *pc)
     ASSERT(res);
 }
 
+/* Removes guard protection from page containing pc */
+void
+unmark_page_as_guard(byte *pc, uint prot)
+{
+    uint old_prot;
+    int res;
+    byte *start_page = (byte *)ALIGN_BACKWARD(pc, PAGE_SIZE);
+
+    uint flags = memprot_to_osprot(prot & ~MEMPROT_GUARD);
+    res = protect_virtual_memory(start_page, PAGE_SIZE, flags, &old_prot);
+    ASSERT(res);
+}
+
 /* Change page protection for pc:pc+size.
  * If set is false, makes [un]writable depending on add_writable argument,
  * preserving other flags; else, sets protection to new_prot.

--- a/core/win32/os_exports.h
+++ b/core/win32/os_exports.h
@@ -217,7 +217,7 @@ void print_dynamo_regions(void);
 size_t get_allocation_size(byte *pc, byte **base_pc);
 byte *get_allocation_base(byte *pc);
 void mark_page_as_guard(byte *pc);
-void unmark_page_as_guard(byte *pc, uint prot);
+bool unmark_page_as_guard(byte *pc, uint prot);
 
 bool
 os_find_free_code_space_in_libs(void **start OUT, void **end OUT);

--- a/core/win32/os_exports.h
+++ b/core/win32/os_exports.h
@@ -217,6 +217,7 @@ void print_dynamo_regions(void);
 size_t get_allocation_size(byte *pc, byte **base_pc);
 byte *get_allocation_base(byte *pc);
 void mark_page_as_guard(byte *pc);
+void unmark_page_as_guard(byte *pc);
 
 bool
 os_find_free_code_space_in_libs(void **start OUT, void **end OUT);

--- a/core/win32/os_exports.h
+++ b/core/win32/os_exports.h
@@ -217,7 +217,7 @@ void print_dynamo_regions(void);
 size_t get_allocation_size(byte *pc, byte **base_pc);
 byte *get_allocation_base(byte *pc);
 void mark_page_as_guard(byte *pc);
-void unmark_page_as_guard(byte *pc);
+void unmark_page_as_guard(byte *pc, uint prot);
 
 bool
 os_find_free_code_space_in_libs(void **start OUT, void **end OUT);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2943,6 +2943,7 @@ else (UNIX)
     # we match exe addresses in output so no ASLR
     append_link_flags(security-win32.except-execution "/dynamicbase:no")
 
+    tobuild(security-win32.except-guard security-win32/except-guard.c)
     tobuild(security-win32.except-thread security-win32/except-thread.c)
     tobuild(security-win32.gbop-test security-win32/gbop-test.c)
 

--- a/suite/tests/security-win32/except-guard.c
+++ b/suite/tests/security-win32/except-guard.c
@@ -31,12 +31,13 @@
  */
 
 
-#include "tools.h"
+# include "tools.h"
+# include <windows.h>
+
 
 static int count = 0;
 
 
-# include <windows.h>
 /* top-level exception handler */
 static LONG
 our_top_handler(struct _EXCEPTION_POINTERS * pExceptionInfo)

--- a/suite/tests/security-win32/except-guard.c
+++ b/suite/tests/security-win32/except-guard.c
@@ -31,8 +31,8 @@
  */
 
 
-# include "tools.h"
-# include <windows.h>
+#include "tools.h"
+#include <windows.h>
 
 
 static int count = 0;

--- a/suite/tests/security-win32/except-guard.c
+++ b/suite/tests/security-win32/except-guard.c
@@ -1,0 +1,99 @@
+/* **********************************************************
+ * Copyright (c) 2017 Simorfo, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Simorfo nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+
+#include "tools.h"
+
+static int count = 0;
+
+
+# include <windows.h>
+/* top-level exception handler */
+static LONG
+our_top_handler(struct _EXCEPTION_POINTERS * pExceptionInfo)
+{
+    if (pExceptionInfo->ExceptionRecord->ExceptionCode == STATUS_GUARD_PAGE_VIOLATION) {
+        count++;
+        print("guard page exception\n");
+        return EXCEPTION_CONTINUE_EXECUTION;
+    }
+    return EXCEPTION_EXECUTE_HANDLER; /* => global unwind and silent death */
+}
+
+void
+bar(int guard) {
+    if (guard > 0) {
+        print("test guard without alloc\n");
+    }
+    else {
+        print("test without guard\n");
+    }
+    return;
+}
+
+int
+main(void)
+{
+    unsigned char * buf ;
+    void (*foo)(void);
+    int old_prot;
+
+    INIT();
+
+    SetUnhandledExceptionFilter((LPTOP_LEVEL_EXCEPTION_FILTER) our_top_handler);
+
+    print("start of test, count = %d\n", count);
+
+    buf = VirtualAlloc(NULL,4096,MEM_COMMIT|MEM_RESERVE,PAGE_EXECUTE_READWRITE);
+    /* 3 nops and a ret */
+    buf[0] = '\x90';
+    buf[1] = '\x90';
+    buf[2] = '\x90';
+    buf[3] = '\xc3';
+    foo = (void*) buf;
+
+    /* sets allocated buffer with guard page status */
+    VirtualProtect(buf, 4096, PAGE_EXECUTE_READWRITE | PAGE_GUARD, &old_prot);
+    foo();
+
+    bar(0);
+    /* sets static code with guard page status */
+    VirtualProtect((unsigned char *) bar, 8, PAGE_EXECUTE_READWRITE | PAGE_GUARD, &old_prot);
+    bar(1);
+    /* to check that we do not get any more excpetions */
+    bar(0);
+
+    print("end of test, count = %d\n", count);
+
+    return 0;
+}
+

--- a/suite/tests/security-win32/except-guard.c
+++ b/suite/tests/security-win32/except-guard.c
@@ -90,7 +90,7 @@ main(void)
     /* sets static code with guard page status */
     VirtualProtect((unsigned char *) bar, 8, PAGE_EXECUTE_READWRITE | PAGE_GUARD, &old_prot);
     bar(1);
-    /* to check that we do not get any more excpetions */
+    /* to check that we do not get any more exceptions */
     bar(0);
 
     print("end of test, count = %d\n", count);

--- a/suite/tests/security-win32/except-guard.expect
+++ b/suite/tests/security-win32/except-guard.expect
@@ -1,0 +1,7 @@
+start of test, count = 0
+guard page exception
+test without guard
+guard page exception
+test guard without alloc
+test without guard
+end of test, count = 2


### PR DESCRIPTION
We check the memory protection for the page about to be executed
If there is the guard flag, we forge a guard exception.

Fixes i#2135