### PR TITLE
Don't run CI on pushes to non-master

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,6 +43,11 @@ notifications:
 # We do limit to the last few commits to speed things up:
 clone_depth: 10
 
+# Don't run on pushes to feature branches: pull requests cover those.
+branches:
+  only:
+    - master
+
 platform: x64
 
 image: Visual Studio 2013

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2016 Google, Inc.  All rights reserved.
+# Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -37,6 +37,11 @@ notifications:
       - dynamorio-devs@googlegroups.com
     on_success: change
     on_failure: always
+
+# Don't run Travis on pushes to feature branches: pull requests cover those.
+branches:
+  only:
+  - master
 
 # We use Trusty to get cmake 2.8.12 instead of 2.8.7 from Precise:
 sudo: required


### PR DESCRIPTION
Avoids double-CI-runs on pushes to non-master followed immediately by pull
requests.