### PR TITLE
i#2157 re-attach: add best-effort re-attach support

### DIFF
--- a/clients/drcachesim/tests/burst_threads.cpp
+++ b/clients/drcachesim/tests/burst_threads.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -86,22 +86,30 @@ thread_func(void *arg)
     static const int iter_start = outer_iters/3;
     static const int iter_stop = iter_start + 4;
 
-    for (int i = 0; i < outer_iters; ++i) {
-        if (idx == burst_owner && i == iter_start) {
-            std::cerr << "pre-DR start\n";
-            dr_app_start();
-        }
-        if (idx == burst_owner) {
-            if (i >= iter_start && i <= iter_stop)
-                assert(dr_app_running_under_dynamorio());
-            else
-                assert(!dr_app_running_under_dynamorio());
-        }
-        if (do_some_work(i) < 0)
-            std::cerr << "error in computation\n";
-        if (idx == burst_owner && i == iter_stop) {
-            std::cerr << "pre-DR detach\n";
-            dr_app_stop_and_cleanup();
+    /* We use an outer loop to test re-attaching (i#2157), except
+     * there is an unfixed bug i#2175.
+     * XXX i#2175: up the iter count once we fix the bug.
+     */
+    for (int j = 0; j < 1; ++j) {
+        if (j > 0 && idx == burst_owner)
+            dr_app_setup();
+        for (int i = 0; i < outer_iters; ++i) {
+            if (idx == burst_owner && i == iter_start) {
+                std::cerr << "pre-DR start\n";
+                dr_app_start();
+            }
+            if (idx == burst_owner) {
+                if (i >= iter_start && i <= iter_stop)
+                    assert(dr_app_running_under_dynamorio());
+                else
+                    assert(!dr_app_running_under_dynamorio());
+            }
+            if (do_some_work(i) < 0)
+                std::cerr << "error in computation\n";
+            if (idx == burst_owner && i == iter_stop) {
+                std::cerr << "pre-DR detach\n";
+                dr_app_stop_and_cleanup();
+            }
         }
     }
     finished[idx] = true;

--- a/clients/drcachesim/tests/offline-burst_static.templatex
+++ b/clients/drcachesim/tests/offline-burst_static.templatex
@@ -2,6 +2,14 @@ pre-DR init
 pre-DR start
 pre-DR detach
 all done
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
 Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -786,6 +786,7 @@ event_exit(void)
                                                       event_bb_instru2instru) ||
         drreg_exit() != DRREG_SUCCESS)
         DR_ASSERT(false);
+    dr_unregister_exit_event(event_exit);
 
     dr_mutex_destroy(mutex);
     drutil_exit();

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -880,6 +880,20 @@ arch_exit(IF_WINDOWS_ELSE_NP(bool detach_stacked_callbacks, void))
 #endif
     interp_exit();
     mangle_exit();
+
+    if (doing_detach) {
+        /* Clear for possible re-attach. */
+        shared_code = NULL;
+#if defined(X86) && defined(X64)
+        shared_code_x86 = NULL;
+        shared_code_x86_to_x64 = NULL;
+#endif
+        syscall_method = SYSCALL_METHOD_UNINITIALIZED;
+        app_sysenter_instr_addr = NULL;
+#ifdef LINUX
+        sysenter_hook_failed = false;
+#endif
+    }
 }
 
 static byte *

--- a/core/config.c
+++ b/core/config.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -692,7 +692,11 @@ config_heap_exit(void)
 void
 config_exit(void)
 {
-    /* nothing -- so not called on fast exit */
+#if !defined(NOT_DYNAMORIO_CORE) && !defined(NOT_DYNAMORIO_CORE_PROPER)
+    if (doing_detach)
+        memset(&config, 0, sizeof config); /* for possible re-attach */
+#endif
+    /* nothing -- so not called on fast exit (is called on detach) */
 }
 
 /* Our parameters (option string, logdir, etc.) can be configured

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -1474,6 +1474,33 @@ dynamo_process_exit(void)
 #endif /* !DEBUG */
 }
 
+void
+dynamo_exit_post_detach(void)
+{
+    /* i#2157: best-effort re-init in case of re-attach */
+
+    do_once_generation++; /* Increment the generation in case we re-attach */
+
+    dynamo_initialized = false;
+    dynamo_heap_initialized = false;
+    automatic_startup = false;
+    control_all_threads = false;
+    dr_api_entry = false;
+    dr_api_exit  = false;
+#ifdef UNIX
+    dynamo_exiting = false;
+#endif
+    dynamo_exited = false;
+    dynamo_exited_and_cleaned = false;
+#ifdef DEBUG
+    dynamo_exited_log_and_stats = false;
+#endif
+    dynamo_resetting = false;
+#ifdef UNIX
+    post_execve = false;
+#endif
+}
+
 dcontext_t *
 create_new_dynamo_context(bool initial, byte *dstack_in, priv_mcontext_t *mc)
 {

--- a/core/globals.h
+++ b/core/globals.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -569,6 +569,7 @@ int dynamo_shared_exit(thread_record_t *toexit
 void dynamo_process_exit_with_thread_info(void);
 /* thread cleanup prior to clean exit event */
 void dynamo_thread_exit_pre_client(dcontext_t *dcontext, thread_id_t id);
+void dynamo_exit_post_detach(void);
 
 /* enter/exit DR hooks */
 void entering_dynamorio(void);

--- a/core/heap.c
+++ b/core/heap.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1672,6 +1672,9 @@ heap_exit()
 #ifdef X64
     DELETE_LOCK(request_region_be_heap_reachable_lock);
 #endif
+
+    if (doing_detach)
+        heapmgt = &temp_heapmgt;
 }
 
 /* FIXME:

--- a/core/lib/dr_app.h
+++ b/core/lib/dr_app.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -117,7 +117,13 @@ dr_app_setup_and_start(void);
 /**
  * Causes all of the application's threads to run directly on the machine upon
  * return from this call, and additionally frees the resources used by DR.
- * Once this is invoked, calling dr_app_start() or dr_app_setup() is not supported.
+ * Once this is invoked, calling dr_app_start() is not supported until
+ * dr_app_setup() or dr_app_setup_and_start() is called for a re-attach.
+ * Re-attach, however, is considered an experimental feature and is
+ * not guaranteed to be without problems, in particular when DR or
+ * extension libraries are static and there is no simple way to reset
+ * the state of global variables.
+ *
  * This call has no effect if the application is not currently running
  * under DR control.
  */

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -798,6 +798,7 @@ instrument_exit(void)
 
     vmvector_delete_vector(GLOBAL_DCONTEXT, client_aux_libs);
     client_aux_libs = NULL;
+    num_client_libs = 0;
 #ifdef WINDOWS
     DELETE_LOCK(client_aux_lib64_lock);
 #endif

--- a/core/moduledb.c
+++ b/core/moduledb.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -277,6 +277,8 @@ moduledb_exit()
     global_heap_free(exemption_lists, (MODULEDB_EXEMPT_NUM_LISTS) * sizeof(char *)
                      HEAPACCT(ACCT_OTHER));
     DELETE_READWRITE_LOCK(moduledb_lock);
+    if (doing_detach)
+        exemption_lists = NULL;
 }
 
 bool

--- a/core/synch.c
+++ b/core/synch.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2108,7 +2108,10 @@ detach_on_permanent_stack(bool internal, bool do_cleanup)
 
     stack_free(initstack, DYNAMORIO_STACK_SIZE);
 
+    dynamo_exit_post_detach();
+
     doing_detach = false;
+
     SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
     dynamo_detaching_flag = LOCK_FREE_STATE;
     EXITING_DR();

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * *******************************************************************************/
 
@@ -327,6 +327,13 @@ os_loader_exit(void)
         HEAP_TYPE_FREE(GLOBAL_DCONTEXT, libdr_opd,
                        os_privmod_data_t, ACCT_OTHER, PROTECTED);
     }
+
+#if defined(LINUX) && (defined(INTERNAL) || defined(CLIENT_INTERFACE))
+    /* Put printed_gdb_commands into its original state for potential
+     * re-attaching and os_loader_init_epilogue().
+     */
+    printed_gdb_commands = false;
+#endif
 }
 
 void

--- a/core/utils.h
+++ b/core/utils.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1231,12 +1231,13 @@ const char *get_short_name(const char *exename);
  * FIXME: this means that if the protection routines call a routine that has
  * a do-once, we have a deadlock!  Could switch to a recursive lock.
  */
+extern int do_once_generation; /* for possible re-attach */
 #define DO_ONCE(statement) {                                    \
         /* no mutual exclusion, should be used only with logging */      \
         static int do_once = 0;                                 \
-        if (!do_once) {                                         \
+        if (do_once < do_once_generation) {                                         \
                 SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);\
-                do_once = 1;                                    \
+                do_once++;                                    \
                 SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);  \
                 statement;                                      \
         }                                                       \

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1786,6 +1786,10 @@ vm_areas_exit()
 #endif
     vmvector_delete_vector(GLOBAL_DCONTEXT, IAT_areas);
     IAT_areas = NULL;
+
+    tamper_resistant_region_start = NULL;
+    tamper_resistant_region_end = NULL;
+
     return 0;
 }
 

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -7658,6 +7658,11 @@ callback_interception_unintercept()
 
     free_intercept_list();
 
+    if (doing_detach) {
+        DEBUG_DECLARE(bool ok =)
+            make_writable(interception_code, INTERCEPTION_CODE_SIZE);
+        ASSERT(ok);
+    }
     DODEBUG(callback_interception_unintercepted = true;);
 }
 

--- a/core/win32/module.c
+++ b/core/win32/module.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -3853,11 +3853,13 @@ os_modules_init(void)
                             (void(*)(dcontext_t*, void*)) section_to_file_free
                             _IF_DEBUG("section-to-file table"));
 
+#ifndef STATIC_LIBRARY
     if (DYNAMO_OPTION(hide) && !dr_earliest_injected) {
         /* retrieve path before hiding, since this is called before os_init() */
         get_dynamorio_library_path();
         hide_from_module_lists();
     }
+#endif
 }
 
 void

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -1226,6 +1226,8 @@ os_slow_exit(void)
     aslr_exit();
     eventlog_slow_exit();
     os_take_over_exit();
+
+    tls_dcontext_offs = TLS_UNINITIALIZED;
 }
 
 

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -1573,6 +1573,9 @@ drreg_exit(void)
             return DRREG_ERROR;
     }
 
+    /* Support re-attach */
+    memset(&ops, 0, sizeof(ops));
+
     return DRREG_SUCCESS;
 }
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2451,7 +2451,7 @@ if (CLIENT_INTERFACE)
         set(tool.drcacheoff.${testname}_runcmp
           "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
         set(tool.drcacheoff.${testname}_precmd
-          "${CMAKE_COMMAND}@-E@remove_directory@drmemtrace.${exetgt}.*.dir")
+          "foreach@${CMAKE_COMMAND}@-E@remove_directory@drmemtrace.${exetgt}.*.dir")
         set(tool.drcacheoff.${testname}_postcmd
           "${drcachesim_path}@-indir@drmemtrace.${exetgt}.*.dir")
       endmacro()

--- a/suite/tests/api/static_detach.c
+++ b/suite/tests/api/static_detach.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -94,6 +94,17 @@ main(int argc, const char *argv[])
     print("pre-DR detach\n");
     dr_app_stop_and_cleanup();
     assert(!dr_app_running_under_dynamorio());
+
+    /* i#2157: test re-attach */
+    print("re-attach attempt\n");
+    if (dr_app_running_under_dynamorio())
+        print("ERROR: should not be under DynamoRIO after dr_app_stop!\n");
+    dr_app_setup_and_start();
+    if (!dr_app_running_under_dynamorio())
+        print("ERROR: should be under DynamoRIO after dr_app_start!\n");
+    dr_app_stop_and_cleanup();
+    if (dr_app_running_under_dynamorio())
+        print("ERROR: should not be under DynamoRIO after dr_app_stop!\n");
 
     if (do_some_work() < 0)
         print("error in computation\n");

--- a/suite/tests/api/static_detach.expect
+++ b/suite/tests/api/static_detach.expect
@@ -3,4 +3,7 @@ in dr_client_main
 pre-DR start
 pre-DR detach
 Saw some bb events
+re-attach attempt
+in dr_client_main
+Saw some bb events
 all done


### PR DESCRIPTION
While there are many globals that are not reset, we take a best-effort
approach here and reset the ones that matter, allowing us to re-attach with
a memtrace client and static DR.

Portions of this were initially based on
https://codereview.appspot.com/13314047/ from Peter Goodman.

For DO_ONCE, an incremented counter is used.

For numerous other globals, at exit time if doing_detach is set we reset
them to NULL.

For locks, we simply reset count_times_acquired but leave the deleted field
as it does not matter much (part of the whole theme here: this may never be
rock-solid for unusual option combinations but our goal is supporting the
common case).

For drreg, with the new multi-init feature we have to zero the options at
exit time.

Adds several tests by adding loops around existing start/stop tests, but
stops short on burst_threads until i#2175 is fixed.

Review-URL: https://codereview.appspot.com/318520043