### PR TITLE
i#2131 droption: fix stale inscount.c references

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Tools built on DynamoRIO include:
 - The library tracing tool [drltrace](http://dynamorio.org/docs/page_drltrace.html)
 - The memory tracing tool [memtrace](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/memtrace.c)
 - The basic block tracing tool [bbbuf](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/bbbuf.c)
-- The instruction counting tool [inscount](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/inscount.c)
+- The instruction counting tool [inscount](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/inscount.cpp)
 
 ## Building your own custom tools
 

--- a/api/docs/samples.dox
+++ b/api/docs/samples.dox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -83,9 +83,10 @@ The sample <a href="../../samples/inline.c">inline.c</a>
 performs an optimization that uses the custom trace API to inline
 entire callees into traces.
 
-The sample <a href="../../samples/inscount.c">inscount.c</a>
+The sample <a href="../../samples/inscount.cpp">inscount.cpp</a>
 reports the dynamic count of the total number of instructions executed via
 inserting performant clean calls which are auto-inlined by DynamoRIO.
+It also illustrates use of the \ref page_droption.
 
 The sample <a href="../../samples/instrace_simple.c">instrace_simple.c</a>
 is provided as an example client that illustrates how to gather an instruction


### PR DESCRIPTION
74d1190 renamed inscount.c to inscount.cpp but failed to update a few
references, which we fix here.