### PR TITLE
i#2173: Fix failure to restore REG_PRESERVED_1 in test_nzcv_pos.

### DIFF
--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -366,18 +366,23 @@ ASSUME fs:_DATA @N@\
 # define ARG9_NORETADDR  ARG9
 # define ARG10_NORETADDR ARG10
 
+/* The macros SAVE_PRESERVED_REGS and RESTORE_PRESERVED_REGS save and restore the link
+ * register and REG_PRESERVED_* so must be updated if more REG_PRESERVED_ regs are added.
+ */
 # ifndef AARCH64
 #  define FP r11
 #  define LR r14
 #  define INDJMP bx
 #  define REG_PRESERVED_1 r4
-#  define REG_PRESERVED_2 r5
+#  define SAVE_PRESERVED_REGS    push {REG_PRESERVED_1, LR}
+#  define RESTORE_PRESERVED_REGS pop  {REG_PRESERVED_1, LR}
 # else
 #  define FP x29
 #  define LR x30
 #  define INDJMP br
 #  define REG_PRESERVED_1 x19
-#  define REG_PRESERVED_2 x20
+#  define SAVE_PRESERVED_REGS    stp REG_PRESERVED_1, LR, [sp, #-16]!
+#  define RESTORE_PRESERVED_REGS ldp REG_PRESERVED_1, LR, [sp], #16
 # endif
 
 #else /* Intel X86 */

--- a/suite/tests/common/nzcv.c
+++ b/suite/tests/common/nzcv.c
@@ -101,17 +101,15 @@ DECL_EXTERN(test_flag)
 #define FUNCNAME test_nzcv_pos
         DECLARE_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
+        SAVE_PRESERVED_REGS
         mov      REG_PRESERVED_1, ARG1
-        mov      REG_PRESERVED_2, LR
         CALLC1(GLOBAL_REF(set_flag), REG_PRESERVED_1)
         READ_NZCV(ARG1)
-        mov      ARG2, REG_PRESERVED_1
-        CALLC3(GLOBAL_REF(test_flag), ARG1, ARG2, #1)
+        CALLC3(GLOBAL_REF(test_flag), ARG1, REG_PRESERVED_1, #1)
         CALLC1(GLOBAL_REF(clear_flag), REG_PRESERVED_1)
         READ_NZCV(ARG1)
-        mov      ARG2, REG_PRESERVED_1
-        CALLC3(GLOBAL_REF(test_flag), ARG1, ARG2, #0)
-        mov      LR, REG_PRESERVED_2
+        CALLC3(GLOBAL_REF(test_flag), ARG1, REG_PRESERVED_1, #0)
+        RESTORE_PRESERVED_REGS
         RETURN
         END_FUNC(FUNCNAME)
 


### PR DESCRIPTION
On ARM and AArch64 we use the macros SAVE_PRESERVED_REGS and
RESTORE_PRESERVED_REGS to save and restore REG_PRESERVED_1 and the link
register, LR. The function test_nzcv_pos no longer uses REG_PRESERVED_2,
so that macro is removed, for now.

Fixes #2173