### PR TITLE
i#2130 Android: Disable samples on Android.

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2256,25 +2256,27 @@ if (CLIENT_INTERFACE)
     # We run common.eflags mainly for memtrace and other big clients which
     # are quite slow on common.fib or common.broadfun: just a sanity check
     # after all.
-    get_property(sample_list GLOBAL PROPERTY DynamoRIO_sample_list)
-    foreach (sample ${sample_list})
-      torunonly_ci(sample.${sample} common.${control_flags}
-        ${sample} common/${control_flags}.c "" "" "")
-      if (sample STREQUAL "inscount")
-        # test out-of-line clean call
-        torunonly_ci(sample.${sample}.cleancall common.${control_flags} ${sample}
-          common/${control_flags}.c "" "-opt_cleancall 0" "")
-        if (UNIX AND NOT ARM) # FIXME i#1551: fix bugs on ARM
-          torunonly_ci(sample.${sample}.prof-pcs.cleancall common.${control_flags}
-            ${sample} common/${control_flags}.c "" "-prof_pcs -opt_cleancall 0" "")
-          if (NOT X64) # FIXME i#2160: "-thread_private -prof_pcs" support on AArch64
-            torunonly_ci(sample.${sample}.prof-pcs.thread-private.cleancall
-              common.${control_flags} ${sample} common/${control_flags}.c ""
-              "-thread_private -prof_pcs -opt_cleancall 0" "")
-          endif (NOT X64)
-        endif (UNIX AND NOT ARM)
-      endif ()
-    endforeach ()
+    if (NOT ANDROID) # FIXME i#2130: On Android, copy samples to device and test.
+      get_property(sample_list GLOBAL PROPERTY DynamoRIO_sample_list)
+      foreach (sample ${sample_list})
+        torunonly_ci(sample.${sample} common.${control_flags}
+          ${sample} common/${control_flags}.c "" "" "")
+        if (sample STREQUAL "inscount")
+          # test out-of-line clean call
+          torunonly_ci(sample.${sample}.cleancall common.${control_flags} ${sample}
+            common/${control_flags}.c "" "-opt_cleancall 0" "")
+          if (UNIX AND NOT ARM) # FIXME i#1551: fix bugs on ARM
+            torunonly_ci(sample.${sample}.prof-pcs.cleancall common.${control_flags}
+              ${sample} common/${control_flags}.c "" "-prof_pcs -opt_cleancall 0" "")
+            if (NOT X64) # FIXME i#2160: "-thread_private -prof_pcs" support on AArch64
+              torunonly_ci(sample.${sample}.prof-pcs.thread-private.cleancall
+                common.${control_flags} ${sample} common/${control_flags}.c ""
+                "-thread_private -prof_pcs -opt_cleancall 0" "")
+            endif (NOT X64)
+          endif (UNIX AND NOT ARM)
+        endif ()
+      endforeach ()
+    endif (NOT ANDROID)
 
     # Test building the samples as an external project (i#1586).
     # This is not a perfect test as the build dir is not an install dir,


### PR DESCRIPTION
Making these tests pass on Android will require copying them to
the device. That may be all that is required.