### PR TITLE
i#1962 travis: split 32-bit and 64-bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,22 +59,31 @@ compiler:
   - clang
   - gcc
 
-# With or without cross-compiling:
 env:
+  # With or without cross-compiling:
   - DYNAMORIO_CROSS_ONLY=yes
   - DYNAMORIO_CROSS_ONLY=no
+  # We run 32-bit and 64-bit in parallel to speed things up.
+  - EXTRA_ARGS=32_only
+  - EXTRA_ARGS=64_only
 
 matrix:
   exclude:
     # gcc on Travis claims to not be CMAKE_COMPILER_IS_GNUCC so we disable:
     - os: osx
       compiler: gcc
+    # We do not have 64-bit support on OSX yet.
+    - os: osx
+      env: EXTRA_ARGS=64_only
     # Cross-compile only on Linux:
     - os: osx
       env: DYNAMORIO_CROSS_ONLY=yes
     # Cross-compile only with GCC:
     - compiler: clang
       env: DYNAMORIO_CROSS_ONLY=yes
+    # Only split 32 and 64 for non-cross-compiling:
+    - env: DYNAMORIO_CROSS_ONLY=yes
+      env: EXTRA_ARGS=64_only # Blanked out in runsuite_wrapper.pl.
 
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:
@@ -92,4 +101,4 @@ install:
       sudo apt-get -y install g++-arm-linux-gnueabihf g++-aarch64-linux-gnu; fi
 
 script:
-  - suite/runsuite_wrapper.pl travis
+  - suite/runsuite_wrapper.pl travis %EXTRA_ARGS%

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
     # gcc on Travis claims to not be CMAKE_COMPILER_IS_GNUCC so we disable:
     - os: osx
       compiler: gcc
-    # We do not have 64-bit support on OSX yet.
+    # We do not have 64-bit support on OSX yet (i#1979).
     - os: osx
       env: DYNAMORIO_CROSS_ONLY=no EXTRA_ARGS=64_only
     # Cross-compile only on Linux:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,10 +62,9 @@ compiler:
 env:
   # With or without cross-compiling:
   - DYNAMORIO_CROSS_ONLY=yes
-  - DYNAMORIO_CROSS_ONLY=no
   # We run 32-bit and 64-bit in parallel to speed things up.
-  - EXTRA_ARGS=32_only
-  - EXTRA_ARGS=64_only
+  - DYNAMORIO_CROSS_ONLY=no EXTRA_ARGS=32_only
+  - DYNAMORIO_CROSS_ONLY=no EXTRA_ARGS=64_only
 
 matrix:
   exclude:
@@ -74,16 +73,13 @@ matrix:
       compiler: gcc
     # We do not have 64-bit support on OSX yet.
     - os: osx
-      env: EXTRA_ARGS=64_only
+      env: DYNAMORIO_CROSS_ONLY=no EXTRA_ARGS=64_only
     # Cross-compile only on Linux:
     - os: osx
       env: DYNAMORIO_CROSS_ONLY=yes
     # Cross-compile only with GCC:
     - compiler: clang
       env: DYNAMORIO_CROSS_ONLY=yes
-    # Only split 32 and 64 for non-cross-compiling:
-    - env: DYNAMORIO_CROSS_ONLY=yes
-      env: EXTRA_ARGS=64_only # Blanked out in runsuite_wrapper.pl.
 
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,4 +97,4 @@ install:
       sudo apt-get -y install g++-arm-linux-gnueabihf g++-aarch64-linux-gnu; fi
 
 script:
-  - suite/runsuite_wrapper.pl travis %EXTRA_ARGS%
+  - suite/runsuite_wrapper.pl travis $EXTRA_ARGS

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -194,12 +194,17 @@ if (NOT cross_only)
     BUILD_TESTS:BOOL=ON
     ${install_path_cache}
     " OFF ON "${install_build_args}")
+  if (last_build_dir MATCHES "-32")
+    set(32bit_path "TEST_32BIT_PATH:PATH=${last_build_dir}/suite/tests/bin")
+  else ()
+    set(32bit_path "")
+  endif ()
   testbuild_ex("debug-internal-64" ON "
     DEBUG:BOOL=ON
     INTERNAL:BOOL=ON
     BUILD_TESTS:BOOL=ON
     ${install_path_cache}
-    TEST_32BIT_PATH:PATH=${last_build_dir}/suite/tests/bin
+    ${32bit_path}
     " OFF ON "${install_build_args}")
   # we don't really support debug-external anymore
   if (DO_ALL_BUILDS_NOT_SUPPORTED)
@@ -217,11 +222,16 @@ if (NOT cross_only)
     INTERNAL:BOOL=OFF
     ${install_path_cache}
     " OFF OFF "${install_build_args}")
+  if (last_build_dir MATCHES "-32")
+    set(32bit_path "TEST_32BIT_PATH:PATH=${last_build_dir}/suite/tests/bin")
+  else ()
+    set(32bit_path "")
+  endif ()
   testbuild_ex("release-external-64" ON "
     DEBUG:BOOL=OFF
     INTERNAL:BOOL=OFF
     ${install_path_cache}
-    TEST_32BIT_PATH:PATH=${last_build_dir}/suite/tests/bin
+    ${32bit_path}
     " OFF OFF "${install_build_args}")
   if (DO_ALL_BUILDS)
     # we rarely use internal release builds but keep them working in long
@@ -303,12 +313,12 @@ if (UNIX AND ARCH_IS_X86)
     INTERNAL:BOOL=OFF
     CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
     " OFF OFF "")
-  testbuild_ex("arm-debug-internal-64" OFF "
+  testbuild_ex("arm-debug-internal-64" ON "
     DEBUG:BOOL=ON
     INTERNAL:BOOL=ON
     CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
     " OFF OFF "")
-  testbuild_ex("arm-release-external-64" OFF "
+  testbuild_ex("arm-release-external-64" ON "
     DEBUG:BOOL=OFF
     INTERNAL:BOOL=OFF
     CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake

--- a/suite/runsuite_common_pre.cmake
+++ b/suite/runsuite_common_pre.cmake
@@ -660,7 +660,7 @@ function(testbuild_ex name is64 initial_cache test_only_in_long
         ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}" ${ctest_test_args})
       endif (RUN_PARALLEL)
     endif (NOT test_only_in_long OR ${TEST_LONG})
-  endif (build_success EQUAL 0 AND run_tests)
+  endif (build_success EQUAL 0 AND run_tests AND NOT arg_build_only)
 
   if (DO_SUBMIT)
     # include any notes via set(CTEST_NOTES_FILES )?

--- a/suite/runsuite_common_pre.cmake
+++ b/suite/runsuite_common_pre.cmake
@@ -86,6 +86,7 @@ set(arg_already_built OFF) # for testing w/ already-built suite
 set(arg_exclude "")   # regex of tests to exclude
 set(arg_verbose OFF)  # extra output
 set(arg_32_only OFF)  # do not include 64-bit
+set(arg_64_only OFF)  # do not include 64-bit
 set(arg_build_only OFF) # do not run tests
 
 foreach (arg ${CTEST_SCRIPT_ARG})
@@ -137,6 +138,9 @@ foreach (arg ${CTEST_SCRIPT_ARG})
   endif (${arg} MATCHES "^exclude=")
   if (${arg} MATCHES "^32_only")
     set(arg_32_only ON)
+  endif ()
+  if (${arg} MATCHES "^64_only")
+    set(arg_64_only ON)
   endif ()
   if (${arg} MATCHES "^build_only")
     set(arg_build_only ON)
@@ -407,6 +411,9 @@ function(testbuild_ex name is64 initial_cache test_only_in_long
     return()
   endif ()
   if (is64 AND arg_32_only)
+    return()
+  endif ()
+  if (NOT is64 AND arg_64_only)
     return()
   endif ()
 

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -49,6 +49,8 @@ for (my $i = 0; $i <= $#ARGV; $i++) {
     $is_CI = 1 if ($ARGV[$i] eq 'travis');
     if ($i == 0) {
         $args .= ",$ARGV[$i]";
+    } elsif ($ARGV[$i] eq '64_only' && $ENV{'DYNAMORIO_CROSS_ONLY'} eq 'yes') {
+        # Skip the arg.
     } else {
         # We don't use a backslash to escape ; b/c we'll quote below, and
         # the backslash is problematically converted to / by Cygwin perl.

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -49,8 +49,6 @@ for (my $i = 0; $i <= $#ARGV; $i++) {
     $is_CI = 1 if ($ARGV[$i] eq 'travis');
     if ($i == 0) {
         $args .= ",$ARGV[$i]";
-    } elsif ($ARGV[$i] eq '64_only' && $ENV{'DYNAMORIO_CROSS_ONLY'} eq 'yes') {
-        # Skip the arg.
     } else {
         # We don't use a backslash to escape ; b/c we'll quote below, and
         # the backslash is problematically converted to / by Cygwin perl.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1054,16 +1054,18 @@ endfunction(template2expect)
 
 ##################################################
 
+if (UNIX)
+  set(dr_os_ops -dumpcore_mask 0)
+else ()
+  # Turn on core dumps for most fatal errors.  Don't dump for curiosities or
+  # security violations.
+  set(dr_os_ops -msgbox_mask 0 -dumpcore_mask 0x7d -staged)
+endif ()
+set(dr_test_ops -stderr_mask 0xC ${dr_os_ops})
+
 function(runtest_cmd outcmd outops key native standalone_dr dr_ops_aux separate_script)
   # assumes tools have been built: enforced at top level
-  if (UNIX)
-    set(os_ops -dumpcore_mask 0)
-  else ()
-    # Turn on core dumps for most fatal errors.  Don't dump for curiosities or
-    # security violations.
-    set(os_ops -msgbox_mask 0 -dumpcore_mask 0x7d -staged)
-  endif ()
-  set(dr_ops -stderr_mask 0xC ${os_ops} ${dr_ops_aux} ${TEST_OPTIONS})
+  set(dr_ops ${dr_test_ops} ${dr_ops_aux} ${TEST_OPTIONS})
   if (NOT CLIENT_INTERFACE)
     # XXX i#1802: non-CI builds have a bug w/ early injection which we work around:
     set(dr_ops ${dr_ops} -no_early_inject)
@@ -1212,7 +1214,7 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out)
     set(expectbase ${srcbase})
   endif ()
 
-  if (${test} MATCHES "linux.execve32")
+  if (TEST_SUITE AND TEST_32BIT_PATH AND ${test} MATCHES "linux.execve32")
     # We're an x64 build, but we need to launch a 32-bit app under DR.  The
     # suite sets -dr_home to the full install dir with both archs, but we're
     # invoking bin64/drrun.  Ideally drrun would detect which ELF class we're
@@ -2546,6 +2548,14 @@ if (CLIENT_INTERFACE)
 endif (CLIENT_INTERFACE)
 
 if (UNIX)
+  macro(make_symlink src dst)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${src} ${dst}
+      RESULT_VARIABLE ln_result ERROR_VARIABLE ln_err)
+    if (ln_result OR ln_err)
+      message(FATAL_ERROR "*** symlink failed: ***\n${ln_err}")
+    endif ()
+  endmacro()
+
   if (NOT APPLE)
     tobuild(linux.clone linux/clone.c)
 
@@ -2558,18 +2568,60 @@ if (UNIX)
   # Cross-arch execve test: can only be done via a suite of tests that
   # build both 32-bit and 64-bit.  We have 32-bit just build, and
   # 64-bit then builds and runs both directions.
-  if (X86 AND (TEST_SUITE OR TEST_32BIT_PATH))
+  if (X86)
     if (X64)
       add_exe(linux.execve-sub64 linux/execve-sub.c)
-      tobuild_ops(linux.execve64 linux/execve.c ""
-        "${TEST_32BIT_PATH}/linux.execve-sub32")
-      torunonly(linux.execve32 ${TEST_32BIT_PATH}/linux.execve32 linux/execve.c ""
-        "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/linux.execve-sub64")
+      if (TEST_SUITE AND TEST_32BIT_PATH)
+        tobuild_ops(linux.execve64 linux/execve.c ""
+          "${TEST_32BIT_PATH}/linux.execve-sub32")
+        torunonly(linux.execve32 ${TEST_32BIT_PATH}/linux.execve32 linux/execve.c ""
+          "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/linux.execve-sub64")
+      else ()
+        # If we didn't just build the entire 32-bit and so don't have an
+        # install dir handy, we still perform a cross-arch test by building
+        # just the few binaries we need and faking a multi-arch install.
+        set(32dir ${CMAKE_CURRENT_BINARY_DIR}/32bit)
+        set(test_bindir suite/tests/bin)
+        file(MAKE_DIRECTORY ${32dir})
+        make_symlink(${PROJECT_BINARY_DIR}/${INSTALL_LIB_BASE}
+          ${32dir}/${INSTALL_LIB_BASE})
+        make_symlink(${32dir}/${INSTALL_LIB_X86}
+          ${PROJECT_BINARY_DIR}/${INSTALL_LIB_X86})
+        get_target_path_for_execution(drrun_path drrun)
+        add_test(linux.execve32 ${CMAKE_CTEST_COMMAND} -V
+          --build-and-test ${PROJECT_SOURCE_DIR} ${32dir}
+          --build-generator ${CMAKE_GENERATOR}
+          --build-target dynamorio
+          --build-target linux.execve32
+          --build-target linux.execve-sub32
+          --build-noclean # else it tries to clean between each target!
+          --build-makeprogram ${CMAKE_MAKE_PROGRAM}
+          --build-options -DDEBUG=ON -DBUILD_TESTS=ON -DBUILD_DOCS=OFF
+          -DBUILD_SAMPLES=OFF -DBUILD_EXT=OFF -DBUILD_CLIENTS=OFF
+          --test-command ${drrun_path} -32
+          -dr_home ${32dir} ${dr_test_ops} -- ${32dir}/${test_bindir}/linux.execve32
+          "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/linux.execve-sub64")
+        file(READ linux/execve.expect expect)
+        set_tests_properties(linux.execve32 PROPERTIES ENVIRONMENT
+          "CFLAGS=-m32;CXXFLAGS=-m32"
+          # We do not try to indirect this so we have to read .expect manually.
+          # We simplify and assume no regex chars.
+          # We start with .* for all the config and build stuff.
+          PASS_REGULAR_EXPRESSION ".*${expect}[ \n]*$")
+        # We can't get the depends property right b/c execve32 has no prefix,
+        # so we do this one directly too.
+        add_exe(linux.execve64 linux/execve.c)
+        add_test(linux.execve64 ${drrun_path} ${dr_test_ops} --
+          ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/linux.execve64
+          "${32dir}/${test_bindir}/linux.execve-sub32")
+        set_tests_properties(linux.execve64 PROPERTIES DEPENDS linux.execve32
+          PASS_REGULAR_EXPRESSION "^${expect}$")
+      endif ()
     else (X64)
       add_exe(linux.execve-sub32 linux/execve-sub.c)
       add_exe(linux.execve32 linux/execve.c)
     endif (X64)
-  endif (X86 AND (TEST_SUITE OR TEST_32BIT_PATH))
+  endif (X86)
 
   # helper app for execve-null
   add_exe(linux.execve-sub linux/execve-sub.c)

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -462,13 +462,10 @@ static bool check_dr_root(const char *dr_root, bool debug,
         "lib64/release/libdrpreload.dylib",
         "lib64/release/libdynamorio.dylib"
 #else /* LINUX */
-        "lib32/debug/libdrpreload.so",
+        /* With early injection the default, we don't require preload to exist. */
         "lib32/debug/libdynamorio.so",
-        "lib32/release/libdrpreload.so",
         "lib32/release/libdynamorio.so",
-        "lib64/debug/libdrpreload.so",
         "lib64/debug/libdynamorio.so",
-        "lib64/release/libdrpreload.so",
         "lib64/release/libdynamorio.so"
 #endif
     };


### PR DESCRIPTION
Splits 32-bit and 64-bit into separate matrix entries, for parallel runs to
shorten the total time and for shorter logs for easier failure diagnosis.