### PR TITLE
i#1834 Misc fixes: Use r12 instead of r4 as TEST_REG on ARM.

### DIFF
--- a/suite/tests/client-interface/drx_buf-test-shared.h
+++ b/suite/tests/client-interface/drx_buf-test-shared.h
@@ -44,8 +44,8 @@
 #endif
 
 #ifdef ARM
-# define TEST_REG DR_REG_R4
-# define TEST_REG_ASM r4
+# define TEST_REG DR_REG_R12
+# define TEST_REG_ASM r12
 #endif
 
 #ifdef AARCH64

--- a/suite/tests/client-interface/drx_buf-test.c
+++ b/suite/tests/client-interface/drx_buf-test.c
@@ -184,7 +184,6 @@ GLOBAL_LABEL(FUNCNAME:)
         pop      REG_XBX
         ret
 #elif defined(AARCHXX)
-        push     {TEST_REG_ASM}
         b        test1
         /* Test 1: test the fast circular buffer */
      test1:
@@ -202,7 +201,6 @@ GLOBAL_LABEL(FUNCNAME:)
         MOV16    TEST_REG_ASM, DRX_BUF_TEST_3_ASM
         b        epilog1
     epilog1:
-        pop      {TEST_REG_ASM}
         RETURN
 #else
 # error NYI
@@ -246,7 +244,6 @@ GLOBAL_LABEL(FUNCNAME:)
         pop      REG_XBX
         ret
 #elif defined(AARCHXX)
-        push     {TEST_REG_ASM}
         b        test4
         /* Test 4: test store registers */
      test4:
@@ -264,7 +261,6 @@ GLOBAL_LABEL(FUNCNAME:)
         MOV16    TEST_REG_ASM, DRX_BUF_TEST_6_ASM
         b        epilog2
     epilog2:
-        pop      {TEST_REG_ASM}
         RETURN
 #else
 # error NYI

--- a/suite/tests/client-interface/drx_buf-test.dll.c
+++ b/suite/tests/client-interface/drx_buf-test.dll.c
@@ -180,7 +180,7 @@ static dr_emit_flags_t
 event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
                       bool for_trace, bool translating, void *user_data)
 {
-    reg_id_t reg_ptr = IF_X86_ELSE(DR_REG_XDX, DR_REG_R4);
+    reg_id_t reg_ptr = IF_X86_ELSE(DR_REG_XDX, TEST_REG);
     reg_id_t reg_tmp = IF_X86_ELSE(DR_REG_XCX, DR_REG_R3);
     /* We need a third register on ARM, because updating the buf pointer
      * requires a second scratch reg.


### PR DESCRIPTION
Commit 4f4a5ac broke AArch64. It is easier to use a register that
does not need to be preserved than to save and restore registers.