### PR TITLE
i#2145 appveyor: fix and ignore more tests

### DIFF
--- a/clients/drcachesim/tests/drcachesim-TLB-simple.templatex
+++ b/clients/drcachesim/tests/drcachesim-TLB-simple.templatex
@@ -8,7 +8,7 @@ Core #0 \(1 thread\(s\)\)
   L1D stats:
     Hits:                      *[0-9,\.]*
     Misses:                    *[0-9,\.]*
-    Miss rate:                        [0-9][,\.]..%
+    Miss rate:                 *[0-9]*[,\.]..%
   LL stats:
     Hits:                      *[0-9,\.]*
     Misses:                           *[0-9]..?

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -127,6 +127,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                   'code_api|win32.mixedmode_late' => 1,
                                   'code_api|client.loader' => 1,
                                   'code_api|client.thread' => 1,
+                                  'code_api|client.nudge_ex' => 1,
                                   'code_api|api.static_noclient' => 1,
                                   'code_api|api.static_noinit' => 1,
                                   'code_api|client.nudge_ex' => 1);

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -110,6 +110,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
         my $is_32 = $line =~ /-32/;
         my %ignore_failures_32 = ('unit_tests' => 1,
                                   'code_api|security-common.retnonexisting' => 1,
+                                  'code_api|win32.reload-newaddr' => 1,
                                   'code_api|win32.tls' => 1,
                                   'code_api|client.loader' => 1,
                                   'code_api|client.thread' => 1,

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -109,6 +109,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
         # we get all tests passing.
         my $is_32 = $line =~ /-32/;
         my %ignore_failures_32 = ('unit_tests' => 1,
+                                  'code_api|security-common.retnonexisting' => 1,
                                   'code_api|win32.tls' => 1,
                                   'code_api|client.loader' => 1,
                                   'code_api|client.thread' => 1,
@@ -118,6 +119,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                   'code_api|api.detach' => 1,
                                   'code_api|api.static_detach' => 1);
         my %ignore_failures_64 = ('unit_tests' => 1,
+                                  'code_api|common.floatpc_xl8all' => 1,
                                   'code_api|win32.reload-newaddr' => 1,
                                   'code_api|win32.mixedmode' => 1,
                                   'code_api|win32.x86_to_x64' => 1,


### PR DESCRIPTION
Fixes tool.drcachesim.TLB-simple failues by allowing double-digit miss
rates.

Ignores failures in common.floatpc_xl8all, client.nudge_ex, and
security-common.retnonexisting until we can repro and try to fix on Win8.1.