### PR TITLE
i#2145 appveyor: exclude 32-bit nudge_ex

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -130,6 +130,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                   'code_api|client.loader' => 1,
                                   'code_api|client.thread' => 1,
                                   'code_api|client.nudge_ex' => 1,
+                                  'code_api|api.detach' => 1,
                                   'code_api|api.static_noclient' => 1,
                                   'code_api|api.static_noinit' => 1);
         # Read ahead to examine the test failures:

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -115,6 +115,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                   'code_api|client.loader' => 1,
                                   'code_api|client.thread' => 1,
                                   'code_api|client.pcache-use' => 1,
+                                  'code_api|client.nudge_ex' => 1,
                                   'code_api|tool.drcacheoff.burst_static' => 1,
                                   'code_api|tool.drcacheoff.burst_replace' => 1,
                                   'code_api|api.detach' => 1,
@@ -130,8 +131,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                   'code_api|client.thread' => 1,
                                   'code_api|client.nudge_ex' => 1,
                                   'code_api|api.static_noclient' => 1,
-                                  'code_api|api.static_noinit' => 1,
-                                  'code_api|client.nudge_ex' => 1);
+                                  'code_api|api.static_noinit' => 1);
         # Read ahead to examine the test failures:
         $fail = 0;
         my $num_ignore = 0;


### PR DESCRIPTION
Splits the accidental double-exclusion of nudge_ex for 64-bit to the
intendend exclusion on 32-bit and 64-bit.