### PR TITLE
In drreg-test, use r12 instead of r4 as TEST_REG on ARM.

### DIFF
--- a/suite/tests/client-interface/drreg-test-shared.h
+++ b/suite/tests/client-interface/drreg-test-shared.h
@@ -39,9 +39,9 @@
 #endif
 
 #ifdef ARM
-# define TEST_REG DR_REG_R4
-# define TEST_REG_ASM r4
-# define TEST_REG_SIG arm_r4
+# define TEST_REG DR_REG_R12
+# define TEST_REG_ASM r12
+# define TEST_REG_SIG arm_ip
 #endif
 
 #ifdef AARCH64


### PR DESCRIPTION
There was the same problem in drreg-test as was fixed in
drx_buf-test by c169d8c: a callee-saved register was corrupted
by an assembler function called from C.