### PR TITLE
i#2006 generalize drcachesim: add custom field support to drmodtrack

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -171,6 +171,8 @@ Further non-compatibility-affecting changes include:
  - Added drx_buf_insert_buf_memcpy().
  - Added thread synchronization events via dr_event_create(), dr_event_destroy(),
    dr_event_wait(), dr_event_signal(), and dr_event_reset().
+ - Added drmodtrack customization via drmodtrack_add_custom_data() and
+   post-processing support via drmodtrack_offline_write().
 
 **************************************************
 <hr>

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -114,8 +114,8 @@ raw2trace_t::read_and_map_modules(void)
     for (uint i = 0; i < num_mods; i++) {
         app_pc modbase;
         size_t modsize;
-        const char *path;
-        if (drmodtrack_offline_lookup(modhandle, i, &modbase, &modsize, &path) !=
+        char *path;
+        if (drmodtrack_offline_lookup(modhandle, i, &modbase, &modsize, &path, NULL) !=
             DRCOVLIB_SUCCESS)
             FATAL_ERROR("Failed to query module file");
         if (strcmp(path, "<unknown>") == 0 ||

--- a/clients/drcov/postprocess/drcov2lcov.cpp
+++ b/clients/drcov/postprocess/drcov2lcov.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -752,7 +752,7 @@ module_is_from_tool(const char * path)
 static const char *
 read_module_list(const char *buf, module_table_t ***tables, uint *num_mods)
 {
-    const char *path;
+    char *path;
     const char *modpath;
     char subst[MAXIMUM_PATH];
     uint i;
@@ -771,7 +771,7 @@ read_module_list(const char *buf, module_table_t ***tables, uint *num_mods)
         size_t mod_size;
         module_table_t *mod_table;
 
-        if (drmodtrack_offline_lookup(handle, i, NULL, &mod_size, &path) !=
+        if (drmodtrack_offline_lookup(handle, i, NULL, &mod_size, &path, NULL) !=
             DRCOVLIB_SUCCESS)
             ASSERT(false, "Failed to read module table");
         PRINT(5, "Module: %u, " PFX", %s\n", i, (ptr_uint_t)mod_size, path);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2093,6 +2093,10 @@ if (CLIENT_INTERFACE)
     target_link_libraries(client.drutil-test ${libpthread})
   endif ()
 
+  tobuild_ci(client.drmodtrack-test client-interface/drmodtrack-test.cpp "" "" "")
+  use_DynamoRIO_extension(client.drmodtrack-test.dll drcovlib)
+  use_DynamoRIO_extension(client.drmodtrack-test.dll drx)
+
   if (X86) # FIXME i#1551, i#1569: port to ARM and AArch64
     # We need to load w/ the same base so the test passes
     set(DynamoRIO_SET_PREFERRED_BASE ON)

--- a/suite/tests/client-interface/drmodtrack-test.dll.cpp
+++ b/suite/tests/client-interface/drmodtrack-test.dll.cpp
@@ -1,0 +1,171 @@
+/* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+
+/* Tests the drmodtrack extension. */
+
+#include "dr_api.h"
+#include "drcovlib.h"
+#include "drx.h"
+#include "client_tools.h"
+#include "string.h"
+
+#ifdef WINDOWS
+# pragma warning( disable : 4100) /* unreferenced formal parameter */
+# pragma warning( disable : 4127) /* conditional expression is constant */
+#endif
+
+#define CHECK(x, msg) do {               \
+    if (!(x)) {                          \
+        dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
+        dr_abort();                      \
+    }                                    \
+} while (0);
+
+static client_id_t client_id;
+
+static void *
+load_cb(module_data_t *module)
+{
+    return (void *)module->start;
+}
+
+static int
+print_cb(void *data, char *dst, size_t max_len)
+{
+    return dr_snprintf(dst, max_len, PFX",", data);
+}
+
+static const char *
+parse_cb(const char *src, OUT void **data)
+{
+    const char *res;
+    if (dr_sscanf(src, PIFX",", data) != 1)
+        return NULL;
+    res = strchr(src, ',');
+    return (res == NULL) ? NULL : res + 1;
+}
+
+static void
+free_cb(void *data)
+{
+    /* Nothing. */
+}
+
+static void
+event_exit(void)
+{
+    /* First test online features. */
+    char cwd[MAXIMUM_PATH];
+    char fname[MAXIMUM_PATH];
+    bool ok = dr_get_current_directory(cwd, BUFFER_SIZE_ELEMENTS(cwd));
+    CHECK(ok, "dr_get_current_directory failed");
+#ifdef ANDROID
+    /* On Android cwd is / where we have no write privs. */
+    const char *cpath = dr_get_client_path(client_id);
+    const char *dir = strrchr(cpath, '/');
+    dr_snprintf(cwd, BUFFER_SIZE_ELEMENTS(cwd), "%.*s", dir - cpath, cpath);
+    NULL_TERMINATE_BUFFER(cwd);
+#endif
+    file_t f = drx_open_unique_file(cwd, "drmodtrack-test", "log", 0,
+                                    fname, BUFFER_SIZE_ELEMENTS(fname));
+    CHECK(f != INVALID_FILE, "drx_open_unique_file failed");
+
+    drcovlib_status_t res = drmodtrack_dump(f);
+    CHECK(res == DRCOVLIB_SUCCESS, "module dump failed");
+    dr_close_file(f);
+
+    char *buf_online;
+    size_t size_online = 8192;
+    do {
+        buf_online = (char *)dr_global_alloc(size_online);
+        res = drmodtrack_dump_buf(buf_online, size_online);
+        if (res == DRCOVLIB_SUCCESS)
+            break;
+        dr_global_free(buf_online, size_online);
+        size_online *= 2;
+    } while (res == DRCOVLIB_ERROR_BUF_TOO_SMALL);
+    CHECK(res == DRCOVLIB_SUCCESS, "module dump to buf failed");
+
+    /* Now test offline features. */
+    void *modhandle;
+    uint num_mods;
+    f = dr_open_file(fname, DR_FILE_READ);
+    res = drmodtrack_offline_read(f, NULL, &modhandle, &num_mods);
+    CHECK(res == DRCOVLIB_SUCCESS, "read failed");
+
+    for (uint i = 0; i < num_mods; ++i) {
+        app_pc modbase;
+        void *custom;
+        res = drmodtrack_offline_lookup(modhandle, i, &modbase, NULL, NULL, &custom);
+        CHECK(res == DRCOVLIB_SUCCESS, "lookup failed");
+        CHECK(((app_pc)custom) == modbase, "custom field doesn't match");
+    }
+
+    char *buf_offline;
+    size_t size_offline = 8192;
+    do {
+        buf_offline = (char *)dr_global_alloc(size_offline);
+        res = drmodtrack_offline_write(modhandle, buf_offline, size_offline);
+        if (res == DRCOVLIB_SUCCESS)
+            break;
+        dr_global_free(buf_offline, size_offline);
+        size_offline *= 2;
+    } while (res == DRCOVLIB_ERROR_BUF_TOO_SMALL);
+    CHECK(res == DRCOVLIB_SUCCESS, "offline write failed");
+    CHECK(size_online == size_offline, "sizes do not match");
+    CHECK(strcmp(buf_online, buf_offline) == 0, "buffers do not match");
+
+    dr_close_file(f);
+    ok = dr_delete_file(fname);
+    CHECK(ok, "failed to delete file");
+
+    res = drmodtrack_offline_exit(modhandle);
+    CHECK(res == DRCOVLIB_SUCCESS, "exit failed");
+
+    dr_global_free(buf_online, size_online);
+    dr_global_free(buf_offline, size_offline);
+
+    res = drmodtrack_exit();
+    CHECK(res == DRCOVLIB_SUCCESS, "module exit failed");
+}
+
+DR_EXPORT void
+dr_init(client_id_t id)
+{
+    client_id = id;
+    drcovlib_status_t res = drmodtrack_init();
+    CHECK(res == DRCOVLIB_SUCCESS, "init failed");
+    res = drmodtrack_add_custom_data(load_cb, print_cb, parse_cb, free_cb);
+    CHECK(res == DRCOVLIB_SUCCESS, "customization failed");
+    dr_register_exit_event(event_exit);
+}

--- a/suite/tests/client-interface/drmodtrack-test.expect
+++ b/suite/tests/client-interface/drmodtrack-test.expect
@@ -1,0 +1,1 @@
+Hello, world!


### PR DESCRIPTION
Adds a set of callbacks for customizing drmodtrack's per-module information
with custom fields during online processing.  Adds callbacks for retrieving
the custom information during offline processing.

Adds support for modifying the path of each module during offline
processing, and support for re-writing the module data out afterward.

Adds a new test for drmodtrack.