### PR TITLE
i#2006 generalize drcachesim: add custom module processing

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -173,6 +173,8 @@ Further non-compatibility-affecting changes include:
    dr_event_wait(), dr_event_signal(), and dr_event_reset().
  - Added drmodtrack customization via drmodtrack_add_custom_data() and
    post-processing support via drmodtrack_offline_write().
+ - Added drcachesim customization via drmemtrace_replace_file_ops(),
+   drmemtrace_custom_module_data(), and drmemtrace_get_modlist_path().
 
 **************************************************
 <hr>

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -252,6 +252,7 @@ if (BUILD_TESTS)
     add_win32_flags(tool.drcacheoff.burst_replace)
     # Not really using an extension, just for including drmemtrace.h.
     use_DynamoRIO_extension(tool.drcacheoff.burst_replace drmemtrace_static)
+    use_DynamoRIO_extension(tool.drcacheoff.burst_replace drcovlib_static)
 
     add_executable(tool.drcacheoff.burst_threads tests/burst_threads.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_threads)

--- a/clients/drcachesim/tests/offline-burst_replace.templatex
+++ b/clients/drcachesim/tests/offline-burst_replace.templatex
@@ -1,4 +1,5 @@
 replace all file functions
+add custom module data
 pre-DR init
 create dir .*
 create dir .*
@@ -12,6 +13,7 @@ pre-DR detach
 close file .*
 2: writing [0-9]+ bytes .*
 close file .*
+processing .*
 all done
 Core #0 \(1 thread\(s\)\)
   L1I stats:

--- a/clients/drcachesim/tracer/drmemtrace.h
+++ b/clients/drcachesim/tracer/drmemtrace.h
@@ -133,6 +133,46 @@ drmemtrace_replace_file_ops(drmemtrace_open_file_func_t  open_file_func,
                             drmemtrace_close_file_func_t close_file_func,
                             drmemtrace_create_dir_func_t create_dir_func);
 
+/**
+ * The name of the file in -offline mode where module data is written.
+ * Its creation can be customized using drmemtrace_custom_module_data()
+ * and then modified before passing to raw2trace via
+ * drmodtrack_add_custom_data() and drmodtrack_offline_write().
+ */
+#define DRMEMTRACE_MODULE_LIST_FILENAME "modules.log"
+
+DR_EXPORT
+/**
+ * Retrieves the full path to the file in -offline mode where module data is written.
+ * Its creation can be customized using drmemtrace_custom_module_data()
+ * and then modified before passing to raw2trace via
+ * drmodtrack_add_custom_data() with a parse and free callback
+ * and drmodtrack_offline_write() to produce new file contents.
+ */
+drmemtrace_status_t
+drmemtrace_get_modlist_path(OUT const char **path);
+
+DR_EXPORT
+/**
+ * Adds custom data stored with each module in the module list produced for
+ * offline trace post-processing.  The \p load_cb is called for each new module,
+ * and its return value is the data that is stored.  That data is later printed
+ * to a string with \p print_cb, which should return the number of characters
+ * printed or -1 on error.  The data is freed with \p free_cb.
+ *
+ * The user can read and modify the resulting \p modules.log file, prior to
+ * passing through the raw2trace post-processor.  Its path can be obtained from
+ * drmemtrace_get_modlist_path() (unless drmemtrace_replace_file_ops() moved it:
+ * then it's up to the caller to locate and process it), and the \p drmodtrack
+ * API can be used to remove the custom field, update the path, and rewrite the
+ * file: drmodtrack_add_custom_data(), drmodtrack_offline_read(),
+ * drmodtrack_offline_lookup(), drmodtrack_offline_write().
+ */
+drmemtrace_status_t
+drmemtrace_custom_module_data(void * (*load_cb)(module_data_t *module),
+                              int (*print_cb)(void *data, char *dst, size_t max_len),
+                              void (*free_cb)(void *data));
+
 #ifdef __cplusplus
 }
 #endif

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -179,6 +179,11 @@ public:
 
     virtual void bb_analysis(void *drcontext, void *tag, void **bb_field,
                              instrlist_t *ilist, bool repstr_expanded);
+
+    static bool custom_module_data(void * (*load_cb)(module_data_t *module),
+                                   int (*print_cb)(void *data, char *dst,
+                                                   size_t max_len),
+                                   void (*free_cb)(void *data));
 
 private:
     void insert_save_pc(void *drcontext, instrlist_t *ilist, instr_t *where,

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -77,6 +77,16 @@ offline_instru_t::~offline_instru_t()
     } while (res == DRCOVLIB_ERROR_BUF_TOO_SMALL);
     res = drmodtrack_exit();
     DR_ASSERT(res == DRCOVLIB_SUCCESS);
+}
+
+bool
+offline_instru_t::custom_module_data
+(void * (*load_cb)(module_data_t *module),
+ int (*print_cb)(void *data, char *dst, size_t max_len),
+ void (*free_cb)(void *data))
+{
+    drcovlib_status_t res = drmodtrack_add_custom_data(load_cb, print_cb, NULL, free_cb);
+    return res == DRCOVLIB_SUCCESS;
 }
 
 size_t

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -102,7 +102,8 @@ void
 raw2trace_t::read_and_map_modules(void)
 {
     // Read and load all of the modules.
-    std::string modfilename = indir + std::string(DIRSEP) + MODULE_LIST_FILENAME;
+    std::string modfilename = indir + std::string(DIRSEP) +
+        DRMEMTRACE_MODULE_LIST_FILENAME;
     uint num_mods;
     VPRINT(1, "Reading module file %s\n", modfilename.c_str());
     file_t modfile = dr_open_file(modfilename.c_str(), DR_FILE_READ);
@@ -174,7 +175,7 @@ raw2trace_t::open_thread_log_file(const char *basename)
     CHECK(basename[0] != '/',
           "dir iterator entry %s should not be an absolute path\n", basename);
     // Skip the module list log.
-    if (strcmp(basename, MODULE_LIST_FILENAME) == 0)
+    if (strcmp(basename, DRMEMTRACE_MODULE_LIST_FILENAME) == 0)
         return;
     // Skip any non-.raw in case someone put some other file in there.
     if (strstr(basename, OUTFILE_SUFFIX) == NULL)

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,6 +37,7 @@
 #define _RAW2TRACE_H_ 1
 
 #include "dr_api.h"
+#include "drmemtrace.h"
 #include "../common/trace_entry.h"
 #include <fstream>
 #include <vector>
@@ -44,7 +45,6 @@
 #define OUTFILE_PREFIX "drmemtrace"
 #define OUTFILE_SUFFIX "raw"
 #define OUTFILE_SUBDIR "raw"
-#define MODULE_LIST_FILENAME "modules.log"
 #define TRACE_FILENAME "drmemtrace.trace"
 
 struct module_t {


### PR DESCRIPTION
Adds a set of callbacks for customizing the module list created during
tracing, leveraging drcovlib's customization.

Exports the module log name and the path for customization, in conjunction
with recent drmodtrack features.

Adds a test to burst_replace.