### PR TITLE
i#2213 modgap: switch drmodtrack to a struct for easier expansion

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -154,7 +154,7 @@ Further non-compatibility-affecting changes include:
    auto-takeover or the start/stop API.  The configure_DynamoRIO_static()
    and use_DynamoRIO_static_client() CMake utilities facilitate this.
  - Enabled \ref page_drcachesim for Windows for single-process applications.
- - Added a module tracking feature for quick identification of which
+ - Added a module tracking feature \p drmodtrack for quick identification of which
    library a program counter belongs to and for persistent labeling of
    modules for post-processing and across library reloads.  This is part of
    the \p drcovlib Extension.  See #drmodtrack_init() and related functions.

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -186,11 +186,10 @@ post_process()
     assert(res == DRCOVLIB_SUCCESS);
 
     for (uint i = 0; i < num_mods; ++i) {
-        app_pc modbase;
-        void *custom;
-        res = drmodtrack_offline_lookup(modhandle, i, &modbase, NULL, NULL, &custom);
+        drmodtrack_info_t info = {sizeof(info),};
+        res = drmodtrack_offline_lookup(modhandle, i, &info);
         assert(res == DRCOVLIB_SUCCESS);
-        assert(((app_pc)custom) == modbase);
+        assert(((app_pc)info.custom) == info.start);
     }
 
     char *buf_offline;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -113,35 +113,32 @@ raw2trace_t::read_and_map_modules(void)
         DRCOVLIB_SUCCESS)
         FATAL_ERROR("Failed to parse module file %s", modfilename.c_str());
     for (uint i = 0; i < num_mods; i++) {
-        app_pc modbase;
-        size_t modsize;
-        char *path;
-        if (drmodtrack_offline_lookup(modhandle, i, &modbase, &modsize, &path, NULL) !=
-            DRCOVLIB_SUCCESS)
+        drmodtrack_info_t info = {sizeof(info),};
+        if (drmodtrack_offline_lookup(modhandle, i, &info) != DRCOVLIB_SUCCESS)
             FATAL_ERROR("Failed to query module file");
-        if (strcmp(path, "<unknown>") == 0 ||
+        if (strcmp(info.path, "<unknown>") == 0 ||
             // i#2062: VDSO is hard to decode so for now we treat is as non-module.
             // FIXME: currently we're dropping the ifetch data: we need the tracer
             // to identify it instead of us, which requires drmodtrack changes.
-            strcmp(path, "[vdso]") == 0) {
+            strcmp(info.path, "[vdso]") == 0) {
             // We won't be able to decode.
-            modvec.push_back(module_t(path, modbase, NULL, 0));
+            modvec.push_back(module_t(info.path, info.start, NULL, 0));
         } else {
             size_t map_size;
-            byte *base_pc = dr_map_executable_file(path, DR_MAPEXE_SKIP_WRITABLE,
+            byte *base_pc = dr_map_executable_file(info.path, DR_MAPEXE_SKIP_WRITABLE,
                                                    &map_size);
             if (base_pc == NULL) {
                 // We expect to fail to map dynamorio.dll for x64 Windows as it
                 // is built /fixed.  (We could try to have the map succeed w/o relocs,
                 // but we expect to not care enough about code in DR).
-                if (strstr(path, "dynamorio") != NULL)
-                    modvec.push_back(module_t(path, modbase, NULL, 0));
+                if (strstr(info.path, "dynamorio") != NULL)
+                    modvec.push_back(module_t(info.path, info.start, NULL, 0));
                 else
-                    FATAL_ERROR("Failed to map module %s", path);
+                    FATAL_ERROR("Failed to map module %s", info.path);
             } else {
                 VPRINT(1, "Mapped module %d @" PFX " = %s\n", (int)modvec.size(),
-                       (ptr_uint_t)base_pc, path);
-                modvec.push_back(module_t(path, modbase, base_pc, map_size));
+                       (ptr_uint_t)base_pc, info.path);
+                modvec.push_back(module_t(info.path, info.start, base_pc, map_size));
             }
         }
     }

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -609,21 +609,17 @@ drmodtrack_offline_read(file_t file, const char **map,
 }
 
 drcovlib_status_t
-drmodtrack_offline_lookup(void *handle, uint index, OUT app_pc *mod_base,
-                          OUT size_t *mod_size, OUT char **mod_path,
-                          OUT void **custom)
+drmodtrack_offline_lookup(void *handle, uint index, OUT drmodtrack_info_t *out)
 {
     module_read_info_t *info = (module_read_info_t *)handle;
-    if (info == NULL || index >= info->num_mods)
+    if (info == NULL || index >= info->num_mods || out->struct_size != sizeof(*out))
         return DRCOVLIB_ERROR_INVALID_PARAMETER;
-    if (mod_base != NULL)
-        *mod_base = info->mod[index].base;
-    if (mod_size != NULL)
-        *mod_size = (size_t)info->mod[index].size;
-    if (mod_path != NULL)
-        *mod_path = info->mod[index].path;
-    if (custom != NULL)
-        *custom = info->mod[index].custom;
+    /* FIXME i#2213: use this for non-contiguous modules */
+    out->containing_index = index;
+    out->start = info->mod[index].base;
+    out->size = (size_t)info->mod[index].size;
+    out->path = info->mod[index].path;
+    out->custom = info->mod[index].custom;
     return DRCOVLIB_SUCCESS;
 }
 

--- a/suite/tests/client-interface/drmodtrack-test.dll.cpp
+++ b/suite/tests/client-interface/drmodtrack-test.dll.cpp
@@ -124,11 +124,10 @@ event_exit(void)
     CHECK(res == DRCOVLIB_SUCCESS, "read failed");
 
     for (uint i = 0; i < num_mods; ++i) {
-        app_pc modbase;
-        void *custom;
-        res = drmodtrack_offline_lookup(modhandle, i, &modbase, NULL, NULL, &custom);
+        drmodtrack_info_t info = {sizeof(info),};
+        res = drmodtrack_offline_lookup(modhandle, i, &info);
         CHECK(res == DRCOVLIB_SUCCESS, "lookup failed");
-        CHECK(((app_pc)custom) == modbase, "custom field doesn't match");
+        CHECK(((app_pc)info.custom) == info.start, "custom field doesn't match");
     }
 
     char *buf_offline;


### PR DESCRIPTION
Changes drmodtrack_offline_looup() to return a struct where the user sets
the size, to make it easier to add new fields in the future without
breaking compatibility.  Adds a containing_index field now to lay the
groundwork for handling module gaps, but it simply equals the index for
now.