### PR TITLE
i#2213 modgap: add module gap handling to drmodtrack

### DIFF
--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -189,7 +189,8 @@ post_process()
         drmodtrack_info_t info = {sizeof(info),};
         res = drmodtrack_offline_lookup(modhandle, i, &info);
         assert(res == DRCOVLIB_SUCCESS);
-        assert(((app_pc)info.custom) == info.start);
+        assert(((app_pc)info.custom) == info.start ||
+               info.containing_index != i);
     }
 
     char *buf_offline;

--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -257,8 +257,10 @@ DR_EXPORT
  * Returns the base address in \p mod_base and the unique index identifier in \p
  * mod_index for the module that contains \p pc.  If there is no such module,
  * returns DRCOVLIB_ERROR_NOT_FOUND.  For modules that containing multiple
- * non-contiguous mapped segments, each segment has its own unique identifier.
- * The #drmodtrack_info_t.containing_index field can be used to aggregate them.
+ * non-contiguous mapped segments, each segment has its own unique identifier, and
+ * this routine returns the appropriate identifier, but \p mod_base contains the
+ * lowest address of any segment in the module, not the start address of the
+ * segment that contains pc.
  */
 drcovlib_status_t
 drmodtrack_lookup(void *drcontext, app_pc pc, OUT uint *mod_index, OUT app_pc *mod_base);
@@ -344,6 +346,10 @@ DR_EXPORT
  * \p parse_cb, which returns the point in the input string past the custom data,
  * and writes the parsed data to its output parameter, which can subsequently be
  * retrieved from drmodtrack_offline_lookup()'s \p custom output parameter.
+ *
+ * If a module contains non-contiguous segments, \p load_cb is called
+ * only once, and the resulting custom field is shared among all
+ * separate entries returned by drmodtrack_offline_lookup().
  *
  * Only one value for each callback is supported.  Calling this routine again
  * with a different value will replace the existing callbacks.

--- a/suite/tests/client-interface/drmodtrack-test.dll.cpp
+++ b/suite/tests/client-interface/drmodtrack-test.dll.cpp
@@ -127,7 +127,8 @@ event_exit(void)
         drmodtrack_info_t info = {sizeof(info),};
         res = drmodtrack_offline_lookup(modhandle, i, &info);
         CHECK(res == DRCOVLIB_SUCCESS, "lookup failed");
-        CHECK(((app_pc)info.custom) == info.start, "custom field doesn't match");
+        CHECK(((app_pc)info.custom) == info.start ||
+              info.containing_index != i, "custom field doesn't match");
     }
 
     char *buf_offline;


### PR DESCRIPTION
Adds handling of gaps inside ELF libraries to drmodtrack.
Additional entries are added both to the online vector and the written
file.  The containing_index field added previously is used to point to the
main entry from sub-entries.

It's not easy to write a test without making a linker script, but on many
recent Linux distros there are gaps in some or even all system libraries,
including some of my machines, so we'll get at least some future regression
coverage.

Fixes #2213