### PR TITLE
i#1993: add new win10 pseudo-dlls

### DIFF
--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.   All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.   All rights reserved.
  * Copyright (c) 2009-2010 Derek Bruening   All rights reserved.
  * **********************************************************/
 
@@ -1448,42 +1448,35 @@ map_api_set_dll(const char *name, privmod_t *dependent)
     /* Added in Win8 */
     else if (str_case_prefix(name, "API-MS-Win-Core-Kernel32-Legacy-L1"))
         return "kernel32.dll";
-    else if (str_case_prefix(name, "API-MS-Win-Core-Registry-L1-1") ||
+    else if (str_case_prefix(name, "API-MS-Win-Core-Appcompat-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-BEM-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Comm-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Console-L2-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-File-L2-1") ||
              str_case_prefix(name, "API-MS-Win-Core-Job-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Localization-L2-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Localization-Private-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Namespace-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Normalization-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-ProcessTopology-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Psapi-Ansi-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Psapi-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Psapi-Obsolete-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Realtime-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Registry-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-SideBySide-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-String-Obsolete-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-SystemTopology-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-Threadpool-Legacy-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-Threadpool-Private-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-Timezone-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Localization-Private-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Comm-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-WOW64-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Realtime-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-SystemTopology-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-ProcessTopology-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Namespace-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-File-L2-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Localization-L2-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Normalization-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-SideBySide-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Appcompat-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-WindowsErrorReporting-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Console-L2-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Psapi-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Psapi-Ansi-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Psapi-Obsolete-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Security-Appcontainer-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Registry-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-String-Obsolete-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Heap-Obsolete-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Timezone-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Threadpool-Legacy-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Registry-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-String-Obsolete-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Heap-Obsolete-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Timezone-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Threadpool-Legacy-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-BEM-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Security-Base-Private-L1-1"))
         return "kernelbase.dll";
+    else if (str_case_prefix(name, "API-MS-Win-Core-Heap-Obsolete-L1-1"))
+        return "kernel32.dll";
     else if (str_case_prefix(name, "API-MS-Win-Core-CRT-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-CRT-L2-1"))
         return "msvcrt.dll";
@@ -1506,16 +1499,38 @@ map_api_set_dll(const char *name, privmod_t *dependent)
     else if (str_case_prefix(name, "API-MS-WIN-SECURITY-LSAPOLICY-L1"))
         return "advapi32.dll";
     /**************************************************/
-    /* Added in Win10 */
-    else if (str_case_prefix(name, "API-MS-Win-Eventing-Provider-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Heap-L2-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-LibraryLoader-L2-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-ProcessSnapshot-L1-1") ||
+    /* Added in Win10 (some may be 8.1 too) */
+    else if (str_case_prefix(name, "API-MS-Win-Core-Enclave-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-Fibers-L2-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Heap-L2-1") ||
              str_case_prefix(name, "API-MS-Win-Core-LargeInteger-L1-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-Enclave-L1-1"))
+             str_case_prefix(name, "API-MS-Win-Core-LibraryLoader-L2-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Localization-Obsolete-L1-3") ||
+             str_case_prefix(name, "API-MS-Win-Core-Path-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-PerfCounters-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-ProcessSnapshot-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Quirks-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-RegistryUserSpecific-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-SHLWAPI-Legacy-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-SHLWAPI-Obsolete-L1-2") ||
+             str_case_prefix(name, "API-MS-Win-Core-String-L2-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-StringAnsi-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-URL-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Version-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-VersionAnsi-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Eventing-Provider-L1-1"))
         return "kernelbase.dll";
-    else {
+    else if (str_case_prefix(name, "API-MS-Win-Core-PrivateProfile-L1-1"))
+        return "kernel32.dll";
+    else if (str_case_prefix(name, "API-MS-Win-Core-WinRT-Error-L1-1"))
+        return "combase.dll";
+    else if (str_case_prefix(name, "API-MS-Win-GDI-")) {
+        /* We've seen many different GDI-* */
+        return "gdi32full.dll";
+    } else if (str_case_prefix(name, "API-MS-Win-CRT-")) {
+        /* We've seen CRT-{String,Runtime,Private} */
+        return "ucrtbase.dll";
+    } else {
         SYSLOG_INTERNAL_WARNING("unknown API-MS-Win pseudo-dll %s", name);
         /* good guess */
         return "kernelbase.dll";


### PR DESCRIPTION
Adds a set of new pseudo-dlls seen running the unit_tests and
client.loader tests on Windows 10.

Fixes #1993