### PR TITLE
i#2145 appveyor: fix failing detach tests on win8+

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -888,7 +888,6 @@ arch_exit(IF_WINDOWS_ELSE_NP(bool detach_stacked_callbacks, void))
         shared_code_x86 = NULL;
         shared_code_x86_to_x64 = NULL;
 #endif
-        syscall_method = SYSCALL_METHOD_UNINITIALIZED;
         app_sysenter_instr_addr = NULL;
 #ifdef LINUX
         sysenter_hook_failed = false;
@@ -3151,7 +3150,9 @@ does_syscall_ret_to_callsite(void)
 void
 set_syscall_method(int method)
 {
-    ASSERT(syscall_method == SYSCALL_METHOD_UNINITIALIZED
+    ASSERT(syscall_method == SYSCALL_METHOD_UNINITIALIZED ||
+           /* on re-attach this happens */
+           syscall_method == method
            IF_UNIX(|| syscall_method == SYSCALL_METHOD_INT/*PR 286922*/));
     syscall_method = method;
 }

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -112,15 +112,10 @@ for (my $i = 0; $i < $#lines; ++$i) {
         my %ignore_failures_32 = ('unit_tests' => 1,
                                   'code_api|security-common.retnonexisting' => 1,
                                   'code_api|win32.reload-newaddr' => 1,
-                                  'code_api|win32.tls' => 1,
                                   'code_api|client.loader' => 1,
                                   'code_api|client.thread' => 1,
                                   'code_api|client.pcache-use' => 1,
-                                  'code_api|client.nudge_ex' => 1,
-                                  'code_api|tool.drcacheoff.burst_static' => 1,
-                                  'code_api|tool.drcacheoff.burst_replace' => 1,
-                                  'code_api|api.detach' => 1,
-                                  'code_api|api.static_detach' => 1);
+                                  'code_api|client.nudge_ex' => 1);
         my %ignore_failures_64 = ('unit_tests' => 1,
                                   'code_api|common.floatpc_xl8all' => 1,
                                   'code_api|win32.reload-newaddr' => 1,
@@ -131,7 +126,6 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                   'code_api|client.loader' => 1,
                                   'code_api|client.thread' => 1,
                                   'code_api|client.nudge_ex' => 1,
-                                  'code_api|api.detach' => 1,
                                   'code_api|api.static_noclient' => 1,
                                   'code_api|api.static_noinit' => 1);
         # Read ahead to examine the test failures:

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -814,11 +814,11 @@ function(add_api_exe test source use_decoder use_static_DR)
           -E touch "${drcopy_stamp}"
         COMMAND ${CMAKE_COMMAND} ARGS
           -E copy "${MAIN_LIBRARY_OUTPUT_DIRECTORY}/dynamorio.dll"
-          "${CMAKE_CURRENT_BINARY_DIR}/dynamorio.dll"
+          "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll"
         # We copy drsyms.dll too, for api.symtest
         COMMAND ${CMAKE_COMMAND} ARGS
           -E copy "${PROJECT_BINARY_DIR}/ext/${INSTALL_LIB}/drsyms.dll"
-          "${CMAKE_CURRENT_BINARY_DIR}/drsyms.dll"
+          "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/drsyms.dll"
         VERBATIM)
       add_custom_target(drcopy DEPENDS "${drcopy_stamp}")
       set(created_drcopy_target ON PARENT_SCOPE)


### PR DESCRIPTION
Fixes several failing detach tests through two changes:

1) Copy dynamorio.dll into suite/tests/bin instead of suite/tests.
It's not clear how tests were working on other machines before!

2) Adjust an assert on re-attach rather than clearing syscall_method
on exit, as the latter causes a crash on detach on win8+.