### PR TITLE
i#2221: ignore private combase.dll entry failure

### DIFF
--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -1321,7 +1321,6 @@ privload_call_entry(privmod_t *privmod, uint reason)
         });
 
         if (!res && get_os_version() >= WINDOWS_VERSION_7 &&
-            str_case_prefix(privmod->name, "kernel")) {
             /* i#364: win7 _BaseDllInitialize fails to initialize a new console
              * (0xc0000041 (3221225537) - The NtConnectPort request is refused)
              * which we ignore for now.  DR always had trouble writing to the
@@ -1329,8 +1328,13 @@ privload_call_entry(privmod_t *privmod, uint reason)
              * Update: for i#440, this should now succeed, but we leave this
              * in place just in case.
              */
+            (str_case_prefix(privmod->name, "kernel") ||
+             /* i#2221: combase's entry fails on win10.  So far ignoring it
+              * hasn't cause any problems with simple clients.
+              */
+             str_case_prefix(privmod->name, "combase"))) {
             LOG(GLOBAL, LOG_LOADER, 1,
-                "%s: ignoring failure of kernel32!_BaseDllInitialize\n", __FUNCTION__);
+                "%s: ignoring failure of %s entry\n", __FUNCTION__, privmod->name);
             res = TRUE;
         }
         return CAST_TO_bool(res);

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -112,7 +112,6 @@ for (my $i = 0; $i < $#lines; ++$i) {
         my %ignore_failures_32 = ('unit_tests' => 1,
                                   'code_api|security-common.retnonexisting' => 1,
                                   'code_api|win32.reload-newaddr' => 1,
-                                  'code_api|client.loader' => 1,
                                   'code_api|client.thread' => 1,
                                   'code_api|client.pcache-use' => 1,
                                   'code_api|client.nudge_ex' => 1);
@@ -123,7 +122,6 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                   'code_api|win32.x86_to_x64' => 1,
                                   'code_api|win32.x86_to_x64_ibl_opt' => 1,
                                   'code_api|win32.mixedmode_late' => 1,
-                                  'code_api|client.loader' => 1,
                                   'code_api|client.thread' => 1,
                                   'code_api|client.nudge_ex' => 1,
                                   'code_api|api.static_noclient' => 1,

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -122,6 +122,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                   'code_api|win32.x86_to_x64' => 1,
                                   'code_api|win32.x86_to_x64_ibl_opt' => 1,
                                   'code_api|win32.mixedmode_late' => 1,
+                                  'code_api|client.loader' => 1,
                                   'code_api|client.thread' => 1,
                                   'code_api|client.nudge_ex' => 1,
                                   'code_api|api.static_noclient' => 1,


### PR DESCRIPTION
On win10, a private combase.dll's entry fails, but ignoring it lets at
least simple clients continue with no visible problems, so we go with
that for now.

This fixes the client.loader test on recent Windows versions.