### PR TITLE
i#2225: fix drmgr-test on win10

### DIFF
--- a/suite/tests/client-interface/drmgr-test.c
+++ b/suite/tests/client-interface/drmgr-test.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,8 +39,8 @@ static char table[2] = {'A', 'B'};
 #include <windows.h>
 #include <stdio.h>
 
-static bool thread_ready = false;
-static bool past_crash = false;
+static volatile bool thread_ready = false;
+static volatile bool past_crash = false;
 static uint last_received = 0;
 static HWND hwnd;
 static uint msgdata;

--- a/suite/tests/client-interface/drmgr-test.templatex
+++ b/suite/tests/client-interface/drmgr-test.templatex
@@ -19,12 +19,10 @@ About to crash
 Inside handler
 in wnd_callback 0x0*0008001 0 2
 Got message 0x0*0008001 1 3
-in event_thread_exit
-in event_thread_exit_ex
 All done
 #else
-in event_thread_exit
-in event_thread_exit_ex
 Estimation of pi is 3.142425985001098
 #endif
+saw event_thread_exit
+saw event_thread_exit_ex
 all done


### PR DESCRIPTION
Makes drmgr-test robust to extra threads, which are present on win10.

Fixes #2225