### PR TITLE
i#2138: fix crash in Win10 x64 clients requesting extra syscall inter…

### DIFF
--- a/core/win32/os_private.h
+++ b/core/win32/os_private.h
@@ -329,7 +329,8 @@ os_rename_file_in_directory(IN HANDLE rootdir,
 /* in callback.c ***************************************************/
 
 /* thread-shared only needs 4 pages on 32-bit but -thread_private needs 5
- * in case we hook the image entry on an early cbret
+ * in case we hook the image entry on an early cbret.
+ * i#2138: on Win10-x64 extra space is needed for dr_syscall_intercept_natively.
  */
 #define INTERCEPTION_CODE_SIZE IF_X64_ELSE(9*4096,7*4096)
 
@@ -461,11 +462,11 @@ extern uint context_xstate;
 
 #define XSTATE_HEADER_SIZE 0x40  /* 512 bits */
 #define YMMH_AREA(ymmh_area, i) (((dr_xmm_t*)ymmh_area)[i])
-#define MAX_CONTEXT_64_SIZE     0x6ef /* 0x66f from win-7 sp1 */
+#define MAX_CONTEXT_64_SIZE     0x6ef /* as observed on win10-x64 */
 #ifdef X64
 # define MAX_CONTEXT_SIZE       MAX_CONTEXT_64_SIZE
 #else
-# define MAX_CONTEXT_SIZE       0x4e3 /* 0x463 from win-7 sp1 */
+# define MAX_CONTEXT_SIZE       0x4e3 /* as observed on win10-x64 */
 #endif
 #define CONTEXT_DYNAMICALLY_LAID_OUT(flags) (TESTALL(CONTEXT_XSTATE, flags))
 

--- a/core/win32/os_private.h
+++ b/core/win32/os_private.h
@@ -331,7 +331,7 @@ os_rename_file_in_directory(IN HANDLE rootdir,
 /* thread-shared only needs 4 pages on 32-bit but -thread_private needs 5
  * in case we hook the image entry on an early cbret
  */
-#define INTERCEPTION_CODE_SIZE IF_X64_ELSE(8*4096,7*4096)
+#define INTERCEPTION_CODE_SIZE IF_X64_ELSE(9*4096,7*4096)
 
 /* see notes in intercept_new_thread() about these values */
 #define THREAD_START_ADDR IF_X64_ELSE(CXT_XCX, CXT_XAX)
@@ -461,11 +461,11 @@ extern uint context_xstate;
 
 #define XSTATE_HEADER_SIZE 0x40  /* 512 bits */
 #define YMMH_AREA(ymmh_area, i) (((dr_xmm_t*)ymmh_area)[i])
-#define MAX_CONTEXT_64_SIZE     0x680 /* 0x66f from win-7 sp1 */
+#define MAX_CONTEXT_64_SIZE     0x6ef /* 0x66f from win-7 sp1 */
 #ifdef X64
 # define MAX_CONTEXT_SIZE       MAX_CONTEXT_64_SIZE
 #else
-# define MAX_CONTEXT_SIZE       0x480 /* 0x463 from win-7 sp1 */
+# define MAX_CONTEXT_SIZE       0x4e3 /* 0x463 from win-7 sp1 */
 #endif
 #define CONTEXT_DYNAMICALLY_LAID_OUT(flags) (TESTALL(CONTEXT_XSTATE, flags))
 


### PR DESCRIPTION
…ception

Extend the size of the 64-bit interception buffer, as it is exceeded by
a client requesting extra syscalls be intercepted while native.

Increase the MAX_CONTEXT_LEN, as it was observed higher on Windows 10 x64

Fixes #2138