### PR TITLE
i#2224: handle win10's change in partial memory writes

### DIFF
--- a/api/samples/syscall.c
+++ b/api/samples/syscall.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -215,9 +215,7 @@ event_pre_syscall(void *drcontext, int sysnum)
          */
         byte *output = (byte *) dr_syscall_get_param(drcontext, 5);
         byte first;
-        size_t read;
-        bool ok = dr_safe_read(output, 1, &first, &read);
-        if (!ok || read != 1)
+        if (!dr_safe_read(output, 1, &first, NULL))
             return true; /* data unreadable: execute normally */
         if (dr_is_wow64()) {
             /* store the xcx emulation parameter for wow64 */

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -2304,8 +2304,9 @@ DR_API
 /**
  * Safely reads \p size bytes from address \p base into buffer \p
  * out_buf.  Reading is done without the possibility of an exception
- * occurring.  Optionally returns the actual number of bytes copied
- * into \p bytes_read.  Returns true if successful.
+ * occurring.  Returns true if the entire \p size bytes were read;
+ * otherwise returns false and if \p bytes_read is non-NULL returns the
+ * partial number of bytes read in \p bytes_read.
  * \note See also DR_TRY_EXCEPT().
  */
 bool
@@ -2315,8 +2316,9 @@ DR_API
 /**
  * Safely writes \p size bytes from buffer \p in_buf to address \p
  * base.  Writing is done without the possibility of an exception
- * occurring.  Optionally returns the actual number of bytes copied
- * into \p bytes_written.  Returns true if successful.
+ * occurring.    Returns true if the entire \p size bytes were written;
+ * otherwise returns false and if \p bytes_written is non-NULL returns the
+ * partial number of bytes written in \p bytes_written.
  * \note See also DR_TRY_EXCEPT().
  */
 bool

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1667,9 +1667,7 @@ handle_post_sigaction(dcontext_t *dcontext, bool success, int sig,
             if (fault)
                 return EFAULT;
 #else
-            size_t written;
-            if (!safe_write_ex(oact, sizeof(*oact), &info->prior_app_sigaction, &written)
-                || written != sizeof(*oact)) {
+            if (!safe_write_ex(oact, sizeof(*oact), &info->prior_app_sigaction, NULL)) {
                 /* We actually don't have to undo installing any passed action
                  * b/c the Linux kernel does that *before* checking oact perms.
                  */

--- a/core/utils.c
+++ b/core/utils.c
@@ -2473,6 +2473,56 @@ is_string_readable_without_exception(char *str, size_t *str_length /* OPTIONAL O
     }
 }
 
+bool
+safe_write_try_except(void *base, size_t size, const void *in_buf, size_t *bytes_written)
+{
+    uint prot;
+    byte *region_base;
+    size_t region_size;
+    dcontext_t *dcontext = get_thread_private_dcontext();
+    bool res = false;
+    if (bytes_written != NULL)
+        *bytes_written = 0;
+
+    if (dcontext != NULL) {
+        TRY_EXCEPT(dcontext, {
+            /* We abort on the 1st fault, just like safe_read */
+            memcpy(base, in_buf, size);
+            res = true;
+        } , { /* EXCEPT */
+            /* nothing: res is already false */
+        });
+    } else {
+        /* this is subject to races, but should only happen at init/attach when
+         * there should only be one live thread.
+         */
+        /* on x86 must be readable to be writable so start with that */
+        if (is_readable_without_exception(base, size) &&
+            IF_UNIX_ELSE(get_memory_info_from_os, get_memory_info)
+            (base, &region_base, &region_size, &prot) &&
+            TEST(MEMPROT_WRITE, prot)) {
+            size_t bytes_checked = region_size - ((byte *)base - region_base);
+            while (bytes_checked < size) {
+                if (!IF_UNIX_ELSE(get_memory_info_from_os, get_memory_info)
+                    (region_base + region_size, &region_base, &region_size, &prot) ||
+                    !TEST(MEMPROT_WRITE, prot))
+                    return false;
+                bytes_checked += region_size;
+            }
+        } else {
+            return false;
+        }
+        /* ok, checks passed do the copy, FIXME - because of races this isn't safe! */
+        memcpy(base, in_buf, size);
+        res = true;
+    }
+
+    if (res) {
+        if (bytes_written != NULL)
+            *bytes_written = size;
+    }
+    return res;
+}
 
 const char *
 memprot_string(uint prot)

--- a/core/utils.h
+++ b/core/utils.h
@@ -2054,6 +2054,10 @@ is_readable_without_exception_try(byte *pc, size_t size);
 bool
 is_string_readable_without_exception(char *str, size_t *str_length /* OPTIONAL OUT */);
 
+bool
+safe_write_try_except(void *base, size_t size, const void *in_buf,
+                      size_t *bytes_written);
+
 #ifdef DEBUG
 bool
 is_valid_xml_char(char c);

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -174,7 +174,7 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle,
             goto error;
         }
         if (!nt_write_virtual_memory(phandle, load_dynamo_code, buf,
-                                     SIZE_OF_LOAD_DYNAMO, &nbytes)) {
+                                     SIZE_OF_LOAD_DYNAMO, NULL)) {
             display_error("WriteMemory failed");
             goto error;
         }
@@ -190,7 +190,7 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle,
         cxt->CXT_XSP -= ALIGN_FORWARD(nbytes, XSP_SZ);
         dynamo_entry_esp = cxt->CXT_XSP;
         if (!nt_write_virtual_memory(phandle, (LPVOID)cxt->CXT_XSP,
-                                     buf, nbytes, &nbytes)) {
+                                     buf, nbytes, NULL)) {
             display_error("WriteMemory failed");
             goto error;
         }
@@ -203,7 +203,7 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle,
         cxt->CXT_XSP -= ALIGN_FORWARD(nbytes, XSP_SZ);
         dynamo_path_esp = cxt->CXT_XSP;
         if (!nt_write_virtual_memory(phandle, (LPVOID)cxt->CXT_XSP,
-                                     buf, nbytes, &nbytes)) {
+                                     buf, nbytes, NULL)) {
             display_error("WriteMemory failed");
             goto error;
         }
@@ -272,7 +272,7 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle,
         cxt->CXT_XSP = ALIGN_BACKWARD(cxt->CXT_XSP, 16);
 #endif
         if (!nt_write_virtual_memory(phandle, (LPVOID)cxt->CXT_XSP,
-                                     buf, nbytes, &nbytes)) {
+                                     buf, nbytes, NULL)) {
             display_error("WriteMemory failed");
             goto error;
         }
@@ -291,7 +291,7 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle,
         addr = addr_getprocaddr;
         cxt->CXT_XSP -= XSP_SZ;
         if (!nt_write_virtual_memory(phandle, (LPVOID)cxt->CXT_XSP,
-                                     &addr, sizeof(addr), &nbytes)) {
+                                     &addr, sizeof(addr), NULL)) {
             display_error("WriteMemory failed");
             goto error;
         }
@@ -310,7 +310,7 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle,
         addr = addr_loadlibrarya;
         cxt->CXT_XSP -= XSP_SZ;
         if (!nt_write_virtual_memory(phandle, (LPVOID)cxt->CXT_XSP,
-                                     &addr, sizeof(addr), &nbytes)) {
+                                     &addr, sizeof(addr), NULL)) {
             display_error("WriteMemory failed");
             goto error;
         }
@@ -321,7 +321,7 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle,
         addr = addr_debugbreak;
         cxt->CXT_XSP -= XSP_SZ;
         if (!nt_write_virtual_memory(phandle, (LPVOID)cxt->CXT_XSP,
-                                     &addr, sizeof(addr), &nbytes)) {
+                                     &addr, sizeof(addr), NULL)) {
             display_error("WriteMemory failed");
             goto error;
         }

--- a/core/win32/ntdll.c
+++ b/core/win32/ntdll.c
@@ -4520,7 +4520,6 @@ create_thread_common(HANDLE hProcess, bool target_64bit, void *start_addr,
     byte context_buf[sizeof(CONTEXT)+16] = {0};
     CONTEXT *context = (CONTEXT *)ALIGN_FORWARD(context_buf, 16);
     void *thread_arg = arg;
-    size_t written;
     ptr_uint_t final_stack = 0;
     NTSTATUS res;
     GET_RAW_SYSCALL(CreateThread,
@@ -4551,8 +4550,7 @@ create_thread_common(HANDLE hProcess, bool target_64bit, void *start_addr,
         context->CXT_XSP -= arg_buf_size;
         thread_arg = (void *)context->CXT_XSP;
         if (!nt_write_virtual_memory(hProcess, thread_arg, arg_buf,
-                                     arg_buf_size, &written) ||
-            written != arg_buf_size) {
+                                     arg_buf_size, NULL)) {
             NTPRINT("create_thread: failed to write arguments\n");
             return INVALID_HANDLE_VALUE;
         }
@@ -4573,8 +4571,7 @@ create_thread_common(HANDLE hProcess, bool target_64bit, void *start_addr,
         buf[0] = NULL; /* would be return address */
         context->CXT_XSP -= sizeof(buf);
         if (!nt_write_virtual_memory(hProcess, (void *)context->CXT_XSP, buf,
-                                     sizeof(buf), &written) ||
-            written != sizeof(buf)) {
+                                     sizeof(buf), NULL)) {
             NTPRINT("create_thread: failed to write argument\n");
             return INVALID_HANDLE_VALUE;
         }

--- a/core/win32/syscall.c
+++ b/core/win32/syscall.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1532,7 +1532,7 @@ add_dr_env_vars(dcontext_t *dcontext, HANDLE phandle, wchar_t **env_ptr)
                        wenv_to_propagate[i], get_config_val(env_to_propagate[i]));
             NULL_TERMINATE_BUFFER(buf);
             if (!nt_write_virtual_memory(phandle, new_env + sz/sizeof(*env),
-                                         buf, sz_var[i], &got))
+                                         buf, sz_var[i], NULL))
                 goto add_dr_env_failure;
             sz += sz_var[i];
         }
@@ -1541,7 +1541,7 @@ add_dr_env_vars(dcontext_t *dcontext, HANDLE phandle, wchar_t **env_ptr)
     /* write final 0 */
     buf[0] = 0;
     if (!nt_write_virtual_memory(phandle, new_env + sz/sizeof(*env), buf,
-                                 sizeof(*env), &got))
+                                 sizeof(*env), NULL))
         goto add_dr_env_failure;
 
     /* install new env */
@@ -1551,7 +1551,7 @@ add_dr_env_vars(dcontext_t *dcontext, HANDLE phandle, wchar_t **env_ptr)
             "%s: failed to mark "PFX" writable\n", __FUNCTION__, env_ptr);
         goto add_dr_env_failure;
     }
-    if (!nt_write_virtual_memory(phandle, env_ptr, &new_env, sizeof(new_env), &got))
+    if (!nt_write_virtual_memory(phandle, env_ptr, &new_env, sizeof(new_env), NULL))
         goto add_dr_env_failure;
     if (!nt_remote_protect_virtual_memory(phandle, (byte*)PAGE_START(env_ptr), PAGE_SIZE,
                                           old_prot, &old_prot)) {

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -233,10 +233,7 @@ fast_safe_read(void *base, size_t size, void *out_buf)
     });
     return res;
 #else
-    /* dr_safe_read() uses try/except */
-    size_t bytes_read = 0;
-    return (dr_safe_read(base, size, out_buf, &bytes_read) &&
-            bytes_read == size);
+    return dr_safe_read(base, size, out_buf, NULL);
 #endif
 }
 
@@ -724,9 +721,7 @@ drwrap_set_arg(void *wrapcxt_opaque, int arg, void *val)
         if (!in_memory)
             wrapcxt->mc_modified = true;
         if (in_memory && TEST(DRWRAP_SAFE_READ_ARGS, global_flags)) {
-            size_t written;
-            if (!dr_safe_write((void *)addr, sizeof(val), val, &written) ||
-                written != sizeof(val))
+            if (!dr_safe_write((void *)addr, sizeof(val), val, NULL))
                 return false;
         } else
             *addr = (reg_t) val;

--- a/ext/drx/drx_buf.c
+++ b/ext/drx/drx_buf.c
@@ -693,14 +693,11 @@ safe_memcpy(drx_buf_t *buf, void *src, size_t len)
     void *drcontext = dr_get_current_drcontext();
     per_thread_t *data = drmgr_get_tls_field(drcontext, buf->tls_idx);
     byte *cli_ptr = BUF_PTR(data->seg_base, buf->tls_offs);
-    size_t written;
-    bool ok;
 
     DR_ASSERT_MSG(buf->buf_size >= len,
                   "buffer was too small to fit requested memcpy() operation");
     /* try to perform a safe memcpy */
-    ok = dr_safe_write(cli_ptr, len, src, &written);
-    if (!ok || written != len) {
+    if (!dr_safe_write(cli_ptr, len, src, NULL)) {
         /* we overflowed the client buffer, so flush it and try again */
         byte *cli_base = data->cli_base;
         BUF_PTR(data->seg_base, buf->tls_offs) = cli_base;

--- a/suite/tests/client-interface/strace.dll.c
+++ b/suite/tests/client-interface/strace.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -222,9 +222,7 @@ event_pre_syscall(void *drcontext, int sysnum)
          */
         byte *output = (byte *) dr_syscall_get_param(drcontext, 5);
         byte first;
-        size_t read;
-        bool ok = dr_safe_read(output, 1, &first, &read);
-        if (!ok || read != 1)
+        if (!dr_safe_read(output, 1, &first, NULL))
             return true; /* data unreadable: execute normally */
         if (dr_is_wow64()) {
             /* store the xcx emulation parameter for wow64 */


### PR DESCRIPTION
On win10, NtWriteVirtualMemory no longer returns the number of bytes
written and instead returns -1!  Thus, if the caller of safe_write_ex()
cares about that, we fall back to a try-except version rather than using
the system call.

Clarifies the dr_safe_read and dr_safe_write functions: that they fail if
the bytes read or written is partial.  Updates all callers who want to fail
on a partial read or write to pass NULL instead of taking time to check the
size read/written.

Fixes #2224