### PR TITLE
i#2237: fix client.thread test on win8.1

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -1645,6 +1645,9 @@ initialize_dynamo_context(dcontext_t *dcontext)
 #ifdef WINDOWS
 #ifdef CLIENT_INTERFACE
     dcontext->app_errno = 0;
+# ifdef DEBUG
+    dcontext->is_client_thread_exiting = false;
+# endif
 #endif
     dcontext->sys_param_base = NULL;
     /* always initialize aslr_context */

--- a/core/globals.h
+++ b/core/globals.h
@@ -365,8 +365,13 @@ typedef struct _client_flush_req_t {
  * NULL during thread startup or teardown (i.e. mutex_wait_contended_lock() usage) */
 #define IS_CLIENT_THREAD(dcontext) \
     ((dcontext) != NULL && dcontext != GLOBAL_DCONTEXT && \
-     (dcontext)->client_data != NULL && \
-     (dcontext)->client_data->is_client_thread)
+     (dcontext)->client_data != NULL && (dcontext)->client_data->is_client_thread)
+#ifdef DEBUG
+/* For use after dcontext->client_data is NULL */
+# define IS_CLIENT_THREAD_EXITING(dcontext)               \
+    ((dcontext) != NULL && dcontext != GLOBAL_DCONTEXT && \
+     (dcontext)->is_client_thread_exiting)
+#endif
 
 /* Client interface-specific data for dcontexts */
 typedef struct _client_data_t {
@@ -935,6 +940,10 @@ struct _dcontext_t {
 #ifdef CLIENT_INTERFACE
     /* client interface-specific data */
     client_data_t *client_data;
+# ifdef DEBUG
+    /* i#2237: on exit we delete client_data before some IS_CLIENT_THREAD asserts. */
+    bool is_client_thread_exiting;
+# endif
 #endif
 
     /* FIXME trace_sysenter_exit is used to capture an exit from a trace that

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1372,6 +1372,7 @@ instrument_thread_exit(dcontext_t *dcontext)
     HEAP_TYPE_FREE(dcontext, dcontext->client_data, client_data_t,
                    ACCT_OTHER, UNPROTECTED);
     dcontext->client_data = NULL; /* for mutex_wait_contended_lock() */
+    dcontext->is_client_thread_exiting = true; /* for is_using_app_peb() */
 
 #endif /* DEBUG */
 }

--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -511,9 +511,9 @@ is_using_app_peb(dcontext_t *dcontext)
          * not have the app value!
          */
         ASSERT(!is_dynamo_address(dcontext->app_stack_limit) ||
-               IS_CLIENT_THREAD(dcontext));
+               IS_CLIENT_THREAD(dcontext) || IS_CLIENT_THREAD_EXITING(dcontext));
         ASSERT(!is_dynamo_address((byte *)dcontext->app_stack_base-1) ||
-               IS_CLIENT_THREAD(dcontext));
+               IS_CLIENT_THREAD(dcontext) || IS_CLIENT_THREAD_EXITING(dcontext));
         ASSERT(cur_nls_cache == NULL ||
                cur_nls_cache != dcontext->app_nls_cache);
         ASSERT(cur_fls == NULL ||

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -112,7 +112,6 @@ for (my $i = 0; $i < $#lines; ++$i) {
         my %ignore_failures_32 = ('unit_tests' => 1,
                                   'code_api|security-common.retnonexisting' => 1,
                                   'code_api|win32.reload-newaddr' => 1,
-                                  'code_api|client.thread' => 1,
                                   'code_api|client.pcache-use' => 1,
                                   'code_api|client.nudge_ex' => 1);
         my %ignore_failures_64 = ('unit_tests' => 1,
@@ -123,7 +122,6 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                   'code_api|win32.x86_to_x64_ibl_opt' => 1,
                                   'code_api|win32.mixedmode_late' => 1,
                                   'code_api|client.loader' => 1,
-                                  'code_api|client.thread' => 1,
                                   'code_api|client.nudge_ex' => 1,
                                   'code_api|api.static_noclient' => 1,
                                   'code_api|api.static_noinit' => 1);

--- a/suite/tests/client-interface/thread.c
+++ b/suite/tests/client-interface/thread.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -67,8 +67,9 @@ int main()
         /* PR 210591: test transparency by having client create a thread here
          * and ensuring DllMain of the lib isn't notified.
          * 7 nops isn't enough: win7's kernelbase!MultiByteToWideChar has 7.
+         * 9 isn't either: win8.1's ntdll!RtlCompareUnicodeStrings has 9.
          */
-        NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP;
+        NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP;
         FreeLibrary(lib);
     }
     /* Test i#1489 by querying for last thread while client thread is active */
@@ -77,7 +78,7 @@ int main()
         print("thread transparency error\n");
 #else
     /* test creating thread here */
-    NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP;
+    NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP;
 #endif
     print("thank you for testing the client interface\n");
 }

--- a/suite/tests/client-interface/thread.c
+++ b/suite/tests/client-interface/thread.c
@@ -67,9 +67,10 @@ int main()
         /* PR 210591: test transparency by having client create a thread here
          * and ensuring DllMain of the lib isn't notified.
          * 7 nops isn't enough: win7's kernelbase!MultiByteToWideChar has 7.
-         * 9 isn't either: win8.1's ntdll!RtlCompareUnicodeStrings has 9.
+         * 13 isn't either: win8.1's KERNELBASE!GetEnvironmentStringsW has 13.
          */
         NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP;
+        NOP; NOP; NOP; NOP;
         FreeLibrary(lib);
     }
     /* Test i#1489 by querying for last thread while client thread is active */
@@ -79,6 +80,7 @@ int main()
 #else
     /* test creating thread here */
     NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP; NOP;
+    NOP; NOP; NOP; NOP;
 #endif
     print("thank you for testing the client interface\n");
 }

--- a/suite/tests/client-interface/thread.dll.c
+++ b/suite/tests/client-interface/thread.dll.c
@@ -152,7 +152,7 @@ bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool trans
         } else
             in_nops = false;
     }
-    if (num_nops == 13 && !nops_matched) {
+    if (num_nops == 17 && !nops_matched) {
         /* PR 210591: test transparency by having client create a thread after
          * app has loaded a library and ensure its DllMain is not notified
          */

--- a/suite/tests/client-interface/thread.dll.c
+++ b/suite/tests/client-interface/thread.dll.c
@@ -203,6 +203,7 @@ static void
 thread_init_event(void *drcontext)
 {
     int i;
+    dr_set_tls_field(drcontext, (void *)(ptr_uint_t) dr_get_process_id());
     for (i = 0; i < NUM_TLS_SLOTS; i++) {
         int idx = tls_offs + i*sizeof(void*);
         ptr_uint_t val = (ptr_uint_t) (CANARY+i);
@@ -266,8 +267,6 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 #else /* UNIX - append .exe so can use same expect file. */
     dr_fprintf(STDERR, "inside app %s.exe\n", dr_get_application_name());
 #endif
-    dr_set_tls_field(dr_get_current_drcontext(),
-                     (void *)(ptr_uint_t) dr_get_process_id());
 
     {
         /* test PR 198871: client locks are all at same rank */

--- a/suite/tests/client-interface/thread.dll.c
+++ b/suite/tests/client-interface/thread.dll.c
@@ -152,7 +152,7 @@ bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool trans
         } else
             in_nops = false;
     }
-    if (num_nops == 9 && !nops_matched) {
+    if (num_nops == 13 && !nops_matched) {
         /* PR 210591: test transparency by having client create a thread after
          * app has loaded a library and ensure its DllMain is not notified
          */

--- a/suite/tests/client-interface/thread.dll.c
+++ b/suite/tests/client-interface/thread.dll.c
@@ -92,8 +92,8 @@ thread_func(void *arg)
      * ensure we're treating it as a true native thread
      */
     ASSERT(arg == THREAD_ARG);
-    dr_event_signal(child_alive);
     dr_fprintf(STDERR, "client thread is alive\n");
+    dr_event_signal(child_alive);
 #ifdef UNIX
     if (!dr_set_itimer(ITIMER_REAL, 10, event_timer))
         dr_fprintf(STDERR, "unable to set timer callback\n");


### PR DESCRIPTION
Fixes an assert on client thread exit on win8.1 by adding a special
dcontext debug-only field for exiting client threads.

Fixes an assert inside the client.thread test itself by setting the TLS for
all threads, not just the main one.

Fixes #2237