### PR TITLE
i#1345 mixed elf: fails other-arch elf for standalone too

### DIFF
--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -210,14 +210,17 @@ is_elf_so_header_common(app_pc base, size_t size, bool memory)
          * i.e. 32/64-bit libraries.
          * We check again in privload_map_and_relocate() in loader for nice
          * error message.
+         * Xref i#1345 for supporting mixed libs, which makes more sense for
+         * standalone mode tools like those using drsyms (i#1532) or
+         * dr_map_executable_file, but we just don't support that yet until we
+         * remove our hardcoded type defines in module_elf.h.
          */
-        if (INTERNAL_OPTION(private_loader) &&
-            ((elf_header.e_version != 1) ||
-             (memory && elf_header.e_ehsize != sizeof(ELF_HEADER_TYPE)) ||
-             (memory && elf_header.e_machine != IF_X86_ELSE(IF_X64_ELSE(EM_X86_64,
-                                                                        EM_386),
-                                                            IF_X64_ELSE(EM_AARCH64,
-                                                                        EM_ARM)))))
+        if ((elf_header.e_version != 1) ||
+            (memory && elf_header.e_ehsize != sizeof(ELF_HEADER_TYPE)) ||
+            (memory && elf_header.e_machine != IF_X86_ELSE(IF_X64_ELSE(EM_X86_64,
+                                                                       EM_386),
+                                                           IF_X64_ELSE(EM_AARCH64,
+                                                                       EM_ARM))))
             return false;
 #endif
         /* FIXME - should we add any of these to the check? For real


### PR DESCRIPTION
Explicitly fails other-arch elf header checks to avoid hangs in standalone
mode.  We'd like to support other-arch for standalone and drsyms (i#1345,
i#1532) but we need to redo our hardcoded elf typedefs.