### PR TITLE
Add set_value to droption

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -175,6 +175,7 @@ Further non-compatibility-affecting changes include:
    post-processing support via drmodtrack_offline_write().
  - Added drcachesim customization via drmemtrace_replace_file_ops(),
    drmemtrace_custom_module_data(), and drmemtrace_get_modlist_path().
+ - Added a set_value() function to the \ref page_droption.
 
 **************************************************
 <hr>
@@ -315,7 +316,7 @@ Further non-compatibility-affecting changes include:
    The \p drreg Extension is still considered experimental and its
    interface is subject to change in the next release.
  - Added easy-to-use option declaration and parsing for C++ clients
-   and standalone applications via a new Extension, \p droption,
+   and standalone applications via a new Extension, the \ref page_droption
    and the #droption_t class.
  - Added a new tool: \ref page_drcachesim, a multi-process cache simulator.
  - Added a new tool: \ref page_drcpusim, a CPU simulator for illegal

--- a/ext/droption/droption.dox
+++ b/ext/droption/droption.dox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.   All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -107,6 +107,23 @@ if (!dr_parse_options(id, &parse_err)) {
 }
 \endcode
 
+A boolean option \p foo can be negated on the command line using any of the
+following prefixes:
+
+- -nofoo
+- -no_foo
+- --nofoo
+- --no_foo
+
+Option values are retrieved with \p get_value:
+
+\code
+if (op_x.get_value() > 4) {
+}
+\endcode
+
+The value set on the command line can be overridden with the \p set_value
+function.
 
 \section sec_droption_special Special Types
 

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -352,6 +352,9 @@ template <typename T> class droption_t : public droption_parser_t
 
     /** Returns the value of this option. */
     T get_value() const { return value; }
+
+    /** Sets the value of this option, overriding the command line. */
+    void set_value(T new_value) { value = new_value; }
 
  protected:
     bool clamp_value()

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -127,6 +127,11 @@ dr_client_main(client_id_t client_id, int argc, const char *argv[])
                op_takes2.get_value().first.c_str(), op_takes2.get_value().second.c_str());
     ASSERT(!op_foo.specified());
     ASSERT(!op_bar.specified());
+
+    // Test set_value.
+    unsigned int old_x = op_x.get_value();
+    op_x.set_value(old_x + 3);
+    ASSERT(op_x.get_value() == old_x + 3);
 
     // Minimal sanity check that dr_parse_options() works, but 2nd parsing is
     // not really supported by droption.


### PR DESCRIPTION
Adds a set_value() option to droption_t to enable overriding the value set
on the command line.  Updates the documentation, including clarifying how
to negate a boolean option.  Adds a test case.