### PR TITLE
i#1729 offline traces: merge thread init header into first buffer

### DIFF
--- a/clients/drcachesim/tests/offline-burst_replace.templatex
+++ b/clients/drcachesim/tests/offline-burst_replace.templatex
@@ -5,8 +5,8 @@ create dir .*
 create dir .*
 open file .*
 open file .*
-0: writing [0-9]+ bytes .*
 pre-DR start
+0: writing [0-9]+ bytes .*
 1: writing [0-9]+ bytes .*
 restore the write file function
 pre-DR detach


### PR DESCRIPTION
Rather than issuing a separate write for each thread's initial header, we
merge it into its first buffer at the cost of a conditional in the buffer
dump routine.  This will help with strategies where writing smaller units
than a full buffer are costly.