### PR TITLE
i#2006 generalize drcachesim: add drmemtrace_buffer_handoff()

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -254,6 +254,14 @@ if (BUILD_TESTS)
     use_DynamoRIO_extension(tool.drcacheoff.burst_replace drmemtrace_static)
     use_DynamoRIO_extension(tool.drcacheoff.burst_replace drcovlib_static)
 
+    add_executable(tool.drcacheoff.burst_replaceall tests/burst_replaceall.cpp)
+    configure_DynamoRIO_static(tool.drcacheoff.burst_replaceall)
+    use_DynamoRIO_static_client(tool.drcacheoff.burst_replaceall drmemtrace_static)
+    add_win32_flags(tool.drcacheoff.burst_replaceall)
+    use_DynamoRIO_extension(tool.drcacheoff.burst_replaceall drcontainers)
+    # Not really using an extension, just for including drmemtrace.h.
+    use_DynamoRIO_extension(tool.drcacheoff.burst_replaceall drmemtrace_static)
+
     add_executable(tool.drcacheoff.burst_threads tests/burst_threads.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_threads)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_threads drmemtrace_static)

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*

--- a/clients/drcachesim/tests/burst_replaceall.cpp
+++ b/clients/drcachesim/tests/burst_replaceall.cpp
@@ -1,0 +1,247 @@
+/* **********************************************************
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* This application links in drmemtrace_static and acquires a trace during
+ * a "burst" of execution in the middle of the application.  It then detaches.
+ */
+
+/* We deliberately do not include configure.h here to simulate what an
+ * actual app will look like.  configure_DynamoRIO_static sets DR_APP_EXPORTS
+ * for us.
+ */
+#include "dr_api.h"
+#include "drmemtrace.h"
+#include "drvector.h"
+#include "../../../suite/tests/client_tools.h"
+#include <assert.h>
+#include <iostream>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+bool
+my_setenv(const char *var, const char *value)
+{
+#ifdef UNIX
+    return setenv(var, value, 1/*override*/) == 0;
+#else
+    return SetEnvironmentVariable(var, value) == TRUE;
+#endif
+}
+
+/* We have combine all the chunks into one global list, and at process exit
+ * we split them into thread files.  To identify which file we map a sentinel
+ * for the module list and the thread id's to file_t.
+ */
+
+drvector_t all_buffers;
+#define ALL_BUFFERS_INIT_SIZE 256
+
+#define MODULE_FILENO 0
+
+typedef struct _buf_entry_t {
+    file_t id; /* MODULE_FILENO or thread id */
+    void *data;
+    size_t data_size;
+    size_t alloc_size;
+} buf_entry_t;
+
+static void
+free_entry(void *e) {
+    buf_entry_t *entry = (buf_entry_t *) e;
+    dr_global_free(entry, sizeof(*entry));
+}
+
+static int
+do_some_work(int i)
+{
+    static int iters = 512;
+    double val = (double)i;
+    for (int i = 0; i < iters; ++i) {
+        val += sin(val);
+    }
+    return (val > 0);
+}
+
+static file_t
+local_open_file(const char *fname, uint mode_flags)
+{
+    static bool called;
+    if (!called) {
+        called = true;
+        /* This is where we initialize because DR is now initialized. */
+        drvector_init(&all_buffers, ALL_BUFFERS_INIT_SIZE, false, free_entry);
+        return MODULE_FILENO;
+    }
+    return (file_t)dr_get_thread_id(dr_get_current_drcontext());
+}
+
+static ssize_t
+local_read_file(file_t file, void *data, size_t count)
+{
+    return 0; /* not used */
+}
+
+static ssize_t
+local_write_file(file_t file, const void *data, size_t size)
+{
+    if (file == MODULE_FILENO) {
+        void *copy = dr_raw_mem_alloc(size, DR_MEMPROT_READ | DR_MEMPROT_WRITE, NULL);
+        memcpy(copy, data, size);
+        drvector_lock(&all_buffers);
+        buf_entry_t *entry = (buf_entry_t *) dr_global_alloc(sizeof(*entry));
+        entry->id = file;
+        entry->data = copy;
+        entry->data_size = size;
+        entry->alloc_size = size;
+        drvector_append(&all_buffers, entry);
+        drvector_unlock(&all_buffers);
+        return size;
+    }
+    ASSERT(false); /* Shouldn't be called. */
+    return 0;
+}
+
+static bool
+handoff_cb(file_t file, void *data, size_t data_size, size_t alloc_size)
+{
+    drvector_lock(&all_buffers);
+    buf_entry_t *entry = (buf_entry_t *) dr_global_alloc(sizeof(*entry));
+    entry->id = file;
+    entry->data = data;
+    entry->data_size = data_size;
+    entry->alloc_size = alloc_size;
+    drvector_append(&all_buffers, entry);
+    drvector_unlock(&all_buffers);
+    return true;
+}
+
+static void
+local_close_file(file_t file)
+{
+    /* Nothing. */
+}
+
+static bool
+local_create_dir(const char *dir)
+{
+    return dr_create_dir(dir);
+}
+
+static void
+exit_cb(void *arg)
+{
+    assert(arg == (void *)&all_buffers);
+    uint i;
+    file_t f;
+    char path[MAXIMUM_PATH];
+    const char *modlist_path;
+    drmemtrace_status_t mem_res = drmemtrace_get_modlist_path(&modlist_path);
+    assert(mem_res == DRMEMTRACE_SUCCESS);
+    const char *slash = strrchr(modlist_path, '/');
+#ifdef WINDOWS
+    const char *bslash = strrchr(modlist_path, '\\');
+    if (bslash != NULL && bslash > slash)
+        slash = bslash;
+#endif
+    assert(slash != NULL);
+    int len = dr_snprintf(path, BUFFER_SIZE_ELEMENTS(path), "%.*s", slash - modlist_path,
+                          modlist_path);
+    assert(len > 0);
+    NULL_TERMINATE_BUFFER(path);
+
+    std::cerr << "processing " << all_buffers.entries << " buffers\n";
+    drvector_lock(&all_buffers);
+    for (i = 0; i < all_buffers.entries; ++i) {
+        buf_entry_t *entry = (buf_entry_t *)drvector_get_entry(&all_buffers, i);
+        if (entry->id == MODULE_FILENO) {
+            std::cerr << "creating module file " << modlist_path << "\n";
+            f = dr_open_file(modlist_path, DR_FILE_WRITE_OVERWRITE);
+        } else {
+            char fname[MAXIMUM_PATH];
+            len = dr_snprintf(fname, BUFFER_SIZE_ELEMENTS(fname), "%s/%d.raw",
+                              path, entry->id);
+            assert(len > 0);
+            NULL_TERMINATE_BUFFER(fname);
+            f = dr_open_file(fname, DR_FILE_WRITE_APPEND);
+        }
+        assert(f != INVALID_FILE);
+        dr_write_file(f, entry->data, entry->data_size);
+        dr_close_file(f);
+        dr_raw_mem_free(entry->data, entry->alloc_size);
+    }
+    drvector_unlock(&all_buffers);
+    drvector_delete(&all_buffers);
+}
+
+int
+main(int argc, const char *argv[])
+{
+    static int outer_iters = 2048;
+    /* We trace a 4-iter burst of execution. */
+    static int iter_start = outer_iters/3;
+    static int iter_stop = iter_start + 4;
+
+    if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -client_lib ';;-offline'"))
+        std::cerr << "failed to set env var!\n";
+
+    std::cerr << "replace all file functions\n";
+    drmemtrace_status_t res =
+        drmemtrace_replace_file_ops(local_open_file, local_read_file, local_write_file,
+                                    local_close_file, local_create_dir);
+    assert(res == DRMEMTRACE_SUCCESS);
+    res = drmemtrace_buffer_handoff(handoff_cb, exit_cb, (void *)&all_buffers);
+    assert(res == DRMEMTRACE_SUCCESS);
+    std::cerr << "pre-DR init\n";
+    dr_app_setup();
+    assert(!dr_app_running_under_dynamorio());
+
+    for (int i = 0; i < outer_iters; ++i) {
+        if (i == iter_start) {
+            std::cerr << "pre-DR start\n";
+            dr_app_start();
+        }
+        if (i >= iter_start && i <= iter_stop)
+            assert(dr_app_running_under_dynamorio());
+        else
+            assert(!dr_app_running_under_dynamorio());
+        if (do_some_work(i) < 0)
+            std::cerr << "error in computation\n";
+        if (i == iter_stop) {
+            std::cerr << "pre-DR detach\n";
+            dr_app_stop_and_cleanup();
+        }
+    }
+
+    std::cerr << "all done\n";
+    return 0;
+}

--- a/clients/drcachesim/tests/offline-burst_replaceall.templatex
+++ b/clients/drcachesim/tests/offline-burst_replaceall.templatex
@@ -1,0 +1,25 @@
+replace all file functions
+pre-DR init
+pre-DR start
+pre-DR detach
+processing [0-9]* buffers
+creating module file .*
+all done
+Core #0 \(1 thread\(s\)\)
+  L1I stats:
+    Hits:                         *[0-9,\.]*.....
+    Misses:                       *[0-9,\.]*...
+.*    Miss rate:                        0[,\.]..%
+  L1D stats:
+    Hits:                         *[0-9,\.]*.....
+    Misses:                       *[0-9,\.]*.
+.*   Miss rate:                        0[,\.]..%
+Core #1 \(0 thread\(s\)\)
+Core #2 \(0 thread\(s\)\)
+Core #3 \(0 thread\(s\)\)
+LL stats:
+    Hits:                         *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*..
+.*   Local miss rate:                *[0-9]*[,\.]..%
+    Child hits:                   *[0-9,\.]*...
+    Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -224,10 +224,10 @@ create_buffer(per_thread_t *data)
     if (data->buf_base == NULL) {
         /* Switch to "reserve" buffer. */
         if (data->reserve_buf == NULL) {
-            NOTIFY(0, "Fatal error: out of memory and cannot recover.");
+            NOTIFY(0, "Fatal error: out of memory and cannot recover.\n");
             dr_abort();
         }
-        NOTIFY(0, "Out of memory: truncating further tracing.");
+        NOTIFY(0, "Out of memory: truncating further tracing.\n");
         data->buf_base = data->reserve_buf;
         /* Avoid future buffer output. */
         op_max_trace_size.set_value(data->bytes_written - 1);
@@ -275,11 +275,11 @@ write_trace_data(void *drcontext, byte *towrite_start, byte *towrite_end)
         if (file_ops_func.handoff_buf != NULL) {
             if (!file_ops_func.handoff_buf(data->file, towrite_start, size,
                                            max_buf_size)) {
-                NOTIFY(0, "Fatal error: failed to hand off trace");
+                NOTIFY(0, "Fatal error: failed to hand off trace\n");
                 dr_abort();
             }
         } else if (file_ops_func.write_file(data->file, towrite_start, size) < size) {
-            NOTIFY(0, "Fatal error: failed to write trace");
+            NOTIFY(0, "Fatal error: failed to write trace\n");
             dr_abort();
         }
         return towrite_start;
@@ -367,7 +367,7 @@ memtrace(void *drcontext, bool skip_size_cap)
         }
     }
 
-    if (file_ops_func.handoff_buf != NULL) {
+    if (do_write && file_ops_func.handoff_buf != NULL) {
         // The owner of the handoff callback now owns the buffer, and we get a new one.
         create_buffer(data);
     } else {
@@ -624,7 +624,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb,
     if (drreg_reserve_register(drcontext, bb, instr, &rvec, &reg_ptr) != DRREG_SUCCESS ||
         drreg_reserve_register(drcontext, bb, instr, NULL, &reg_tmp) != DRREG_SUCCESS) {
         // We can't recover.
-        NOTIFY(0, "Fatal error: failed to reserve scratch registers");
+        NOTIFY(0, "Fatal error: failed to reserve scratch registers\n");
         dr_abort();
     }
     drvector_delete(&rvec);
@@ -810,7 +810,7 @@ event_thread_init(void *drcontext)
                 break;
         }
         if (i == NUM_OF_TRIES) {
-            NOTIFY(0, "Fatal error: failed to create trace file %s", buf);
+            NOTIFY(0, "Fatal error: failed to create trace file %s\n", buf);
             dr_abort();
         }
         NOTIFY(2, "Created thread trace file %s\n", buf);
@@ -984,7 +984,7 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
     if (op_offline.get_value()) {
         void *buf;
         if (!init_offline_dir()) {
-            NOTIFY(0, "Failed to create a subdir in %s", op_outdir.get_value().c_str());
+            NOTIFY(0, "Failed to create a subdir in %s\n", op_outdir.get_value().c_str());
             dr_abort();
         }
         /* we use placement new for better isolation */

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -98,6 +98,9 @@ typedef struct {
     /* For offline traces */
     file_t file;
     size_t init_header_size;
+    /* For file_ops_func.handoff_buf */
+    uint num_buffers;
+    byte *reserve_buf;
 } per_thread_t;
 
 #define MAX_NUM_DELAY_INSTRS 32
@@ -132,6 +135,9 @@ struct file_ops_func_t {
     drmemtrace_write_file_func_t write_file;
     drmemtrace_close_file_func_t close_file;
     drmemtrace_create_dir_func_t create_dir;
+    drmemtrace_handoff_func_t handoff_buf;
+    drmemtrace_exit_func_t exit_cb;
+    void *exit_arg;
 };
 static struct file_ops_func_t file_ops_func = {
     dr_open_file, dr_read_file, dr_write_file, dr_close_file, dr_create_dir,
@@ -144,6 +150,7 @@ drmemtrace_replace_file_ops(drmemtrace_open_file_func_t  open_file_func,
                             drmemtrace_close_file_func_t close_file_func,
                             drmemtrace_create_dir_func_t create_dir_func)
 {
+    /* We don't check op_offline b/c option parsing may not have happened yet. */
     if (open_file_func != NULL)
         file_ops_func.open_file = open_file_func;
     if (read_file_func != NULL)
@@ -154,6 +161,18 @@ drmemtrace_replace_file_ops(drmemtrace_open_file_func_t  open_file_func,
         file_ops_func.close_file = close_file_func;
     if (create_dir_func != NULL)
         file_ops_func.create_dir = create_dir_func;
+    return DRMEMTRACE_SUCCESS;
+}
+
+drmemtrace_status_t
+drmemtrace_buffer_handoff(drmemtrace_handoff_func_t handoff_func,
+                          drmemtrace_exit_func_t exit_func,
+                          void *exit_func_arg)
+{
+    /* We don't check op_offline b/c option parsing may not have happened yet. */
+    file_ops_func.handoff_buf = handoff_func;
+    file_ops_func.exit_cb = exit_func;
+    file_ops_func.exit_arg = exit_func_arg;
     return DRMEMTRACE_SUCCESS;
 }
 
@@ -196,6 +215,42 @@ static int      tls_idx;
 #define BUF_HDR_SLOTS 1
 static size_t buf_hdr_slots_size;
 
+static void
+create_buffer(per_thread_t *data)
+{
+    data->buf_base = (byte *)
+        dr_raw_mem_alloc(max_buf_size, DR_MEMPROT_READ | DR_MEMPROT_WRITE, NULL);
+    /* For file_ops_func.handoff_buf we have to handle failure as OOM is not unlikely. */
+    if (data->buf_base == NULL) {
+        /* Switch to "reserve" buffer. */
+        if (data->reserve_buf == NULL) {
+            NOTIFY(0, "Fatal error: out of memory and cannot recover.");
+            dr_abort();
+        }
+        NOTIFY(0, "Out of memory: truncating further tracing.");
+        data->buf_base = data->reserve_buf;
+        /* Avoid future buffer output. */
+        op_max_trace_size.set_value(data->bytes_written - 1);
+        return;
+    }
+    /* dr_raw_mem_alloc guarantees to give us zeroed memory, so no need for a memset */
+    /* set sentinel (non-zero) value in redzone */
+    memset(data->buf_base + trace_buf_size, -1, redzone_size);
+    data->num_buffers++;
+    if (data->num_buffers == 2) {
+        /* Create a "reserve" buffer so we can continue after hitting OOM later.
+         * It is much simpler to keep running the same instru that writes to a
+         * buffer and just never write it out, similarly to how we handle
+         * -max_trace_size.  This costs us some memory (not for idle threads: that's
+         * why we wait for the 2nd buffer) but we gain simplicity.
+         */
+        data->reserve_buf = (byte *)
+            dr_raw_mem_alloc(max_buf_size, DR_MEMPROT_READ | DR_MEMPROT_WRITE, NULL);
+        if (data->reserve_buf != NULL)
+            memset(data->reserve_buf + trace_buf_size, -1, redzone_size);
+    }
+}
+
 static inline byte *
 atomic_pipe_write(void *drcontext, byte *pipe_start, byte *pipe_end)
 {
@@ -217,7 +272,13 @@ write_trace_data(void *drcontext, byte *towrite_start, byte *towrite_end)
     if (op_offline.get_value()) {
         per_thread_t *data = (per_thread_t *) drmgr_get_tls_field(drcontext, tls_idx);
         ssize_t size = towrite_end - towrite_start;
-        if (file_ops_func.write_file(data->file, towrite_start, size) < size) {
+        if (file_ops_func.handoff_buf != NULL) {
+            if (!file_ops_func.handoff_buf(data->file, towrite_start, size,
+                                           max_buf_size)) {
+                NOTIFY(0, "Fatal error: failed to hand off trace");
+                dr_abort();
+            }
+        } else if (file_ops_func.write_file(data->file, towrite_start, size) < size) {
             NOTIFY(0, "Fatal error: failed to write trace");
             dr_abort();
         }
@@ -306,14 +367,19 @@ memtrace(void *drcontext, bool skip_size_cap)
         }
     }
 
-    // Our instrumentation reads from buffer and skips the clean call if the
-    // content is 0, so we need set zero in the trace buffer and set non-zero
-    // in redzone.
-    memset(data->buf_base, 0, trace_buf_size);
-    redzone = data->buf_base + trace_buf_size;
-    if (buf_ptr > redzone) {
-        // Set sentinel (non-zero) value in redzone
-        memset(redzone, -1, buf_ptr - redzone);
+    if (file_ops_func.handoff_buf != NULL) {
+        // The owner of the handoff callback now owns the buffer, and we get a new one.
+        create_buffer(data);
+    } else {
+        // Our instrumentation reads from buffer and skips the clean call if the
+        // content is 0, so we need set zero in the trace buffer and set non-zero
+        // in redzone.
+        memset(data->buf_base, 0, trace_buf_size);
+        redzone = data->buf_base + trace_buf_size;
+        if (buf_ptr > redzone) {
+            // Set sentinel (non-zero) value in redzone
+            memset(redzone, -1, buf_ptr - redzone);
+        }
     }
     BUF_PTR(data->seg_base) = data->buf_base + buf_hdr_slots_size;
 }
@@ -696,7 +762,8 @@ event_pre_syscall(void *drcontext, int sysnum)
         }
     }
 #endif
-    memtrace(drcontext, false);
+    if (file_ops_func.handoff_buf == NULL)
+        memtrace(drcontext, false);
     return true;
 }
 
@@ -708,21 +775,15 @@ event_thread_init(void *drcontext)
     per_thread_t *data = (per_thread_t *)
         dr_thread_alloc(drcontext, sizeof(per_thread_t));
     DR_ASSERT(data != NULL);
+    memset(data, 0, sizeof(*data));
     drmgr_set_tls_field(drcontext, tls_idx, data);
 
     /* Keep seg_base in a per-thread data structure so we can get the TLS
      * slot and find where the pointer points to in the buffer.
      */
     data->seg_base = (byte *) dr_get_dr_segment_base(tls_seg);
-    data->buf_base = (byte *)
-        dr_raw_mem_alloc(max_buf_size, DR_MEMPROT_READ | DR_MEMPROT_WRITE, NULL);
-    DR_ASSERT(data->seg_base != NULL && data->buf_base != NULL);
-    /* clear trace buffer */
-    memset(data->buf_base, 0, trace_buf_size);
-    /* set sentinel (non-zero) value in redzone */
-    memset(data->buf_base + trace_buf_size, -1, redzone_size);
-    data->num_refs = 0;
-    data->bytes_written = 0;
+    DR_ASSERT(data->seg_base != NULL);
+    create_buffer(data);
 
     if (op_offline.get_value()) {
         /* We do not need to call drx_init before using drx_open_unique_appid_file.
@@ -800,6 +861,8 @@ event_thread_exit(void *drcontext)
     num_refs += data->num_refs;
     dr_mutex_unlock(mutex);
     dr_raw_mem_free(data->buf_base, max_buf_size);
+    if (data->reserve_buf != NULL)
+        dr_raw_mem_free(data->reserve_buf, max_buf_size);
     dr_thread_free(drcontext, data, sizeof(per_thread_t));
 }
 
@@ -817,6 +880,10 @@ event_exit(void)
         file_ops_func.close_file(module_file);
     else
         ipc_pipe.close();
+
+    if (file_ops_func.exit_cb != NULL)
+        (*file_ops_func.exit_cb)(file_ops_func.exit_arg);
+
     if (!dr_raw_tls_cfree(tls_offs, MEMTRACE_TLS_COUNT))
         DR_ASSERT(false);
 

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -2099,6 +2099,8 @@ DR_API
  * thus is not kept separate from the application. Use of this memory is at the
  * client's own risk.
  *
+ * The resulting memory is guaranteed to be initialized to all zeroes.
+ *
  * Returns the actual address allocated or NULL if memory allocation at
  * preferred base fails.
  */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2475,6 +2475,9 @@ if (CLIENT_INTERFACE)
         torunonly_drcacheoff(burst_replace tool.drcacheoff.burst_replace)
         set(tool.drcacheoff.burst_replace_nodr ON)
 
+        torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall)
+        set(tool.drcacheoff.burst_replaceall_nodr ON)
+
         if (UNIX)
           # FIXME i#2040: this hits static client issues on Windows
           torunonly_drcacheoff(burst_threads tool.drcacheoff.burst_threads)


### PR DESCRIPTION
Adds a new mode of operation where each full buffer is handed over to
external code.  A new buffer is allocated and the thread continues
instrumentation using the new buffer, with the external code responsible
for writing it out and freeing it.

This mode is enabled via a new API routine drmemtrace_buffer_handoff(),
which takes a buffer handoff routine, called instead of the write cb, and
an exit routine.  The exit routine provides a control point after other
threads are native but before DR exits, when using
dr_app_stop_and_cleanup().  Without it it would be impossible to use DR
memory in the handoff and we'd need a hack like putting next pointers inside the
redzones or something.

When the handoff is enabled, we disable dumping buffers at syscalls: they
are only dumped (i.e., handed over) when full or at thread exit.

Out-of-memory is handled by keeping a buffer "in reserve" which is swapped
to once we fail to allocate a buffer, at which point we switch to the
size-cap protocol where we instrument but don't send the results anywhere.

Adds a test that accumulates all buffers and writes them all out at process
exit.