### PR TITLE
i#2006 generalize drcachesim: improve drmodtrack efficiency

### DIFF
--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -65,11 +65,12 @@ offline_instru_t::~offline_instru_t()
     drcovlib_status_t res;
     size_t size = 8192;
     char *buf;
+    size_t wrote;
     do {
         buf = (char *)dr_global_alloc(size);
-        res = drmodtrack_dump_buf(buf, size);
+        res = drmodtrack_dump_buf(buf, size, &wrote);
         if (res == DRCOVLIB_SUCCESS) {
-            ssize_t written = write_file_func(modfile, buf, strlen(buf));
+            ssize_t written = write_file_func(modfile, buf, wrote - 1/*no null*/);
             DR_ASSERT(written == (ssize_t)strlen(buf));
         }
         dr_global_free(buf, size);

--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -282,11 +282,12 @@ drmodtrack_dump(file_t file);
 DR_EXPORT
 /**
  * Writes the complete module information to \p buf as a null-terminated string.
- * Returns DRCOVLIB_SUCCESS on success.
+ * Returns DRCOVLIB_SUCCESS on success and stores the number of bytes written to
+ * \p buf (including the terminating null) in \p wrote if \p wrote is not NULL.
  * If the buffer is too small, returns DRCOVLIB_ERROR_BUF_TOO_SMALL.
  */
 drcovlib_status_t
-drmodtrack_dump_buf(char *buf, size_t size);
+drmodtrack_dump_buf(char *buf, size_t size, OUT size_t *wrote);
 
 DR_EXPORT
 /**

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -506,11 +506,12 @@ drmodtrack_dump_buf_headers(char *buf_in, size_t size, uint count, OUT int *len_
 }
 
 drcovlib_status_t
-drmodtrack_dump_buf(char *buf, size_t size)
+drmodtrack_dump_buf(char *buf_start, size_t size, OUT size_t *wrote)
 {
     uint i;
     module_entry_t *entry;
     int len;
+    char *buf = buf_start;
     drcovlib_status_t res =
         drmodtrack_dump_buf_headers(buf, size, module_table.vector.entries, &len);
     if (res != DRCOVLIB_SUCCESS)
@@ -530,6 +531,8 @@ drmodtrack_dump_buf(char *buf, size_t size)
      }
     buf[0] = '\0';
     drvector_unlock(&module_table.vector);
+    if (wrote != NULL)
+        *wrote = buf + 1/*null*/ - buf_start;
     return DRCOVLIB_SUCCESS;
 }
 
@@ -541,7 +544,7 @@ drmodtrack_dump(file_t log)
     char *buf;
     do {
         buf = dr_global_alloc(size);
-        res = drmodtrack_dump_buf(buf, size);
+        res = drmodtrack_dump_buf(buf, size, NULL);
         if (res == DRCOVLIB_SUCCESS)
             dr_write_file(log, buf, strlen(buf));
         dr_global_free(buf, size);

--- a/suite/tests/client-interface/drmodtrack-test.dll.cpp
+++ b/suite/tests/client-interface/drmodtrack-test.dll.cpp
@@ -106,15 +106,17 @@ event_exit(void)
 
     char *buf_online;
     size_t size_online = 8192;
+    size_t wrote;
     do {
         buf_online = (char *)dr_global_alloc(size_online);
-        res = drmodtrack_dump_buf(buf_online, size_online);
+        res = drmodtrack_dump_buf(buf_online, size_online, &wrote);
         if (res == DRCOVLIB_SUCCESS)
             break;
         dr_global_free(buf_online, size_online);
         size_online *= 2;
     } while (res == DRCOVLIB_ERROR_BUF_TOO_SMALL);
     CHECK(res == DRCOVLIB_SUCCESS, "module dump to buf failed");
+    CHECK(wrote == strlen(buf_online) + 1/*null*/, "returned size off");
 
     /* Now test offline features. */
     void *modhandle;
@@ -133,7 +135,6 @@ event_exit(void)
 
     char *buf_offline;
     size_t size_offline = 8192;
-    size_t wrote;
     do {
         buf_offline = (char *)dr_global_alloc(size_offline);
         res = drmodtrack_offline_write(modhandle, buf_offline, size_offline, &wrote);


### PR DESCRIPTION
Adds a size-written OUT parameter to drmodtrack_dump_buf() to avoid callers
needing an expensive strlen() to figure out how much to write from the
buffer to a file.  Updates the test and drcachesim to use the new parameter.