### PR TITLE
i#2145 appveyor: fix mixedmode test asserts

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -516,6 +516,8 @@ dynamorio_app_init(void)
          * N.B.: we never de-allocate initstack (see comments in app_exit)
          */
         initstack = (byte *) stack_alloc(DYNAMORIO_STACK_SIZE, NULL);
+        LOG(GLOBAL, LOG_SYNCH, 2, "initstack is "PFX"-"PFX"\n",
+            initstack - DYNAMORIO_STACK_SIZE, initstack);
 
 #if defined(WINDOWS) && defined(STACK_GUARD_PAGE)
         /* PR203701: separate stack for error reporting when the
@@ -2233,7 +2235,8 @@ dynamo_thread_init(byte *dstack_in, priv_mcontext_t *mc
         IF_CLIENT_INTERFACE_ELSE(client_thread ? "CLIENT " : "", ""),
         get_thread_id(), dcontext);
     LOG(THREAD, LOG_TOP|LOG_THREADS, 1,
-        "DR stack is "PFX"-"PFX"\n", dcontext->dstack - DYNAMORIO_STACK_SIZE, dcontext->dstack);
+        "DR stack is "PFX"-"PFX"\n", dcontext->dstack - DYNAMORIO_STACK_SIZE,
+        dcontext->dstack);
 #endif
 
 #ifdef DEADLOCK_AVOIDANCE

--- a/core/heap.c
+++ b/core/heap.c
@@ -1407,12 +1407,14 @@ vmm_heap_exit()
                    heapmgt->vmheap.num_free_blocks == heapmgt->vmheap.num_blocks
                    - unfreed_blocks ||
                    /* >=, not ==, b/c if we hit the vmm limit the cur dstack
-                    * could be outside of vmm (i#1164)
+                    * could be outside of vmm (i#1164).
                     */
-                   (ever_beyond_vmm && heapmgt->vmheap.num_free_blocks >=
+                   ((ever_beyond_vmm
+                     /* This also happens for dstacks up high for DrMi#1723. */
+                     IF_WINDOWS(|| get_os_version() >= WINDOWS_VERSION_8_1)) &&
+                    heapmgt->vmheap.num_free_blocks >=
                     heapmgt->vmheap.num_blocks - unfreed_blocks));
         });
-
         /* FIXME: On process exit we are currently executing off a
          *  stack in this region so we cannot free the whole allocation.
 

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -8500,17 +8500,21 @@ early_inject_init()
         case WINDOWS_VERSION_8:
         case WINDOWS_VERSION_8_1:
         case WINDOWS_VERSION_10:
+        case WINDOWS_VERSION_10_1511:
+        case WINDOWS_VERSION_10_1607:
             /* LdrLoadDll is best but LdrpLoadDll seems to work just as well
-             * (FIXME would it be better just to use that so matches XP?),
+             * (XXX: would it be better just to use that so matches XP?),
              * LdrpLoadImportModule also works but it misses the load of
-             * kernel32. */
+             * kernel32.
+             */
             early_inject_location = INJECT_LOCATION_LdrLoadDll;
             break;
         default:
             /* is prob. a newer windows version so the 2003 location is the
-             * most likely to work */
+             * most likely to work
+             */
             early_inject_location = INJECT_LOCATION_LdrLoadDll;
-            ASSERT_NOT_REACHED();
+            ASSERT(os_version > WINDOWS_VERSION_10);
         }
     }
     ASSERT(early_inject_location != INJECT_LOCATION_LdrDefault);

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -115,10 +115,6 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                   'code_api|client.nudge_ex' => 1);
         my %ignore_failures_64 = ('code_api|common.floatpc_xl8all' => 1,
                                   'code_api|win32.reload-newaddr' => 1,
-                                  'code_api|win32.mixedmode' => 1,
-                                  'code_api|win32.x86_to_x64' => 1,
-                                  'code_api|win32.x86_to_x64_ibl_opt' => 1,
-                                  'code_api|win32.mixedmode_late' => 1,
                                   'code_api|client.loader' => 1,
                                   'code_api|client.nudge_ex' => 1,
                                   'code_api|api.static_noclient' => 1,


### PR DESCRIPTION
In mixed mode on win8.1+ we end up allocating the dstack up high (for
DrM-i#1723), which means it does not show up in the unfreed blocks at exit.
This raises an assert, which we relax here.