### PR TITLE
i#58: misc fixes for MacOS 64-bit support

### DIFF
--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -1392,10 +1392,12 @@
     /* We hardcode an address in the mmap_text region here, but verify via
      * in vmk_init().
      * For Linux we start higher to avoid limiting the brk (i#766).
+     * For a 64-bit process on MacOS __PAGEZERO takes up the first 4GB by default.
      */
     OPTION_DEFAULT(uint_addr, vm_base,
                    IF_VMX86_ELSE(IF_X64_ELSE(0x40000000,0x10800000),
-                                 IF_WINDOWS_ELSE(0x16000000, 0x46000000)),
+                                 IF_WINDOWS_ELSE(0x16000000, IF_MACOS_ELSE(
+                                 IF_X64_ELSE(0x120000000,0x46000000),0x46000000))),
                    "preferred base address hint (ignored for 64-bit linux)")
      /* FIXME: we need to find a good location with no conflict with DLLs or apps allocations */
     OPTION_DEFAULT(uint_addr, vm_max_offset,

--- a/core/unix/memquery.h
+++ b/core/unix/memquery.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2013-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -64,7 +64,7 @@ typedef struct _memquery_iter_t {
      * without using static data and limiting to one iterator (and having
      * to unprotect and reprotect if in .data).
      */
-#   define MEMQUERY_INTERNAL_DATA_LEN 96 /* 84 bytes needed for Mac 10.9.1 */
+#   define MEMQUERY_INTERNAL_DATA_LEN 116 /* 104 bytes needed for MacOS 64-bit */
     char internal[MEMQUERY_INTERNAL_DATA_LEN];
 } memquery_iter_t;
 

--- a/core/unix/module_macho.c
+++ b/core/unix/module_macho.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2013-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -178,7 +178,7 @@ module_walk_program_headers(app_pc base, size_t view_size, bool at_map, bool dyn
     cmd = (struct load_command *)(hdr + 1);
     cmd_stop = (struct load_command *)((byte *)cmd + hdr->sizeofcmds);
     while (cmd < cmd_stop) {
-        if (cmd->cmd == LC_SEGMENT) {
+        if (cmd->cmd == LC_SEGMENT || cmd->cmd == LC_SEGMENT_64) {
             segment_command_t *seg = (segment_command_t *) cmd;
             found_seg = true;
             LOG(GLOBAL, LOG_VMAREAS, 4,
@@ -253,7 +253,7 @@ module_walk_program_headers(app_pc base, size_t view_size, bool at_map, bool dyn
             /* Now that we have the load delta, we can add the abs addr segments */
             cmd = (struct load_command *)(hdr + 1);
             while (cmd < cmd_stop) {
-                if (cmd->cmd == LC_SEGMENT) {
+                if (cmd->cmd == LC_SEGMENT || cmd->cmd == LC_SEGMENT_64) {
                     segment_command_t *seg = (segment_command_t *) cmd;
                     if (strcmp(seg->segname, "__PAGEZERO") == 0 && seg->initprot == 0) {
                         /* skip */


### PR DESCRIPTION
+ Move -vm_base above 4GB since __PAGEZERO takes up first 4GB by default
+ Increase MEMQUERY_INTERNAL_DATA_LEN
+ Update Mach-O parsing to check for LC_SEGMENT_64