### PR TITLE
i#2275 fix drfront_bufprint fmt argument

### DIFF
--- a/libutil/dr_frontend.h
+++ b/libutil/dr_frontend.h
@@ -162,7 +162,7 @@ drfront_searchenv(const char *fname, const char *env_var, OUT char *full_path,
  */
 drfront_status_t
 drfront_bufprint(INOUT char *buf, size_t bufsz, INOUT size_t *sofar,
-                 OUT ssize_t *len, char *fmt, ...);
+                 OUT ssize_t *len, const char *fmt, ...);
 
 /**
  * Converts from UTF-16 to UTF-8.

--- a/libutil/dr_frontend_common.c
+++ b/libutil/dr_frontend_common.c
@@ -54,7 +54,7 @@
 
 drfront_status_t
 drfront_bufprint(char *buf, size_t bufsz, INOUT size_t *sofar, OUT ssize_t *len,
-                 char *fmt, ...)
+                 const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);


### PR DESCRIPTION
Fix drfront_bufprint's fmt argument to avoid warnings when the
interface is called from C++ application.

Fixes #2275