### PR TITLE
i#2006 generalize drcachesim: fix errors in success checks

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -152,7 +152,7 @@ analyzer_t::create_analysis_tools()
                HISTOGRAM ", or " REUSE_DIST ".\n");
         return false;
     }
-    if (!tools[0])
+    if (!*tools[0])
         return false;
     num_tools = 1;
     return true;

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -167,8 +167,9 @@ droption_t<std::string> op_TLB_replace_policy
 
 droption_t<std::string> op_simulator_type
 (DROPTION_SCOPE_FRONTEND, "simulator_type", CPU_CACHE,
- "Simulator type", "Specifies the type of the simulator. "
- "Supported types: " CPU_CACHE", " TLB".");
+ "Simulator type (" CPU_CACHE", " TLB", " REUSE_DIST", or " HISTOGRAM").",
+ "Specifies the type of the simulator. "
+ "Supported types: " CPU_CACHE", " TLB", " REUSE_DIST", or " HISTOGRAM".");
 
 droption_t<unsigned int> op_verbose
 (DROPTION_SCOPE_ALL, "verbose", 0, 0, 64, "Verbosity level",

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -185,7 +185,7 @@ _tmain(int argc, const TCHAR *targv[])
                                        (const char **) argv,
                                        &parse_err, &app_idx)) {
         // We try to support no "--" separating the app
-        if (argv[app_idx][0] != '-') {
+        if (argv[app_idx] != NULL && argv[app_idx][0] != '-') {
             // Treat as the app name
         } else {
             FATAL_ERROR("Usage error: %s\nUsage:\n%s", parse_err.c_str(),
@@ -235,7 +235,7 @@ _tmain(int argc, const TCHAR *targv[])
     } else {
         // declare the analyzer based on its type
         analyzer = new analyzer_t;
-        if (!analyzer) {
+        if (!*analyzer) {
             FATAL_ERROR("failed to initialize analyzer");
         }
     }


### PR DESCRIPTION
Fixes bugs where the ! operator is used incorrectly when checking for
analyzer and tool instantiation success.

Adds missing simulator types to the usage messages.