### PR TITLE
i#2006 generalize drcachesim: split analyzer to support leaner tools

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -100,6 +100,7 @@ add_executable(drmemtrace_histogram
   )
 target_link_libraries(drmemtrace_histogram drfrontendlib)
 use_DynamoRIO_extension(drmemtrace_histogram droption)
+add_dependencies(drmemtrace_histogram api_headers)
 
 macro(add_drmemtrace name type)
   if (${type} STREQUAL "STATIC")

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -34,9 +34,11 @@ include(../../make/policies.cmake NO_POLICY_SCOPE)
 
 if (WIN32)
   set(os_name "win")
+  # Our non-client files assume this is set, yet don't include headers that set it.
+  add_definitions(-DWINDOWS)
 else ()
   set(os_name "unix")
-  # Our non-client files assume this is set, yet don't include headers that set it.
+  # Ditto.
   add_definitions(-DUNIX)
 endif ()
 
@@ -158,6 +160,7 @@ endmacro()
 
 restore_nonclient_flags(drcachesim)
 restore_nonclient_flags(drraw2trace)
+restore_nonclient_flags(drmemtrace_histogram)
 
 # We need to pass /EHsc and we pull in libcmtd into drcachesim from a dep lib.
 # Thus we need to override the /MT with /MTd.
@@ -165,7 +168,7 @@ macro(add_win32_flags target)
   if (WIN32)
     if (DEBUG)
       get_property(cur TARGET ${target} PROPERTY COMPILE_FLAGS)
-      string(REPLACE "/MT " "" cur ${cur}) # Avoid override warning.
+      string(REPLACE "/MT " "" cur "${cur}") # Avoid override warning.
       set_target_properties(${target} PROPERTIES COMPILE_FLAGS "${cur} /EHsc /MTd")
       append_property_string(TARGET ${target} LINK_FLAGS "/nodefaultlib:libcmt")
     else ()
@@ -176,6 +179,7 @@ endmacro ()
 
 add_win32_flags(drcachesim)
 add_win32_flags(drraw2trace)
+add_win32_flags(drmemtrace_histogram)
 if (WIN32 AND DEBUG)
   get_target_property(sim_srcs drcachesim SOURCES)
   get_target_property(raw2trace_srcs drraw2trace SOURCES)

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -48,10 +48,12 @@ set(client_and_sim_srcs
 add_executable(drcachesim
   launcher.cpp
   analyzer.cpp
+  analyzer_multi.cpp
   ${client_and_sim_srcs}
   reader/reader.cpp
   reader/file_reader.cpp
   reader/ipc_reader.cpp
+  simulator/analyzer_interface.cpp
   simulator/simulator.cpp
   simulator/cache.cpp
   simulator/cache_lru.cpp
@@ -78,6 +80,24 @@ use_DynamoRIO_extension(drcachesim droption)
 # These are also for raw2trace:
 use_DynamoRIO_extension(drcachesim drcovlib_static)
 use_DynamoRIO_extension(drcachesim drutil_static)
+
+set(file_analyzer_tool_srcs
+  analyzer.cpp
+  common/trace_entry.cpp
+  reader/reader.cpp
+  reader/file_reader.cpp
+  )
+
+# We show one example of how to create a standalone analyzer of trace
+# files that does not need to link with DR.
+# i#2006: the final method for supporting 3rd-party tools is not yet decided.
+add_executable(drmemtrace_histogram
+  ${file_analyzer_tool_srcs}
+  tools/histogram.cpp
+  tools/histogram_launcher.cpp
+  )
+target_link_libraries(drmemtrace_histogram drfrontendlib)
+use_DynamoRIO_extension(drmemtrace_histogram droption)
 
 macro(add_drmemtrace name type)
   if (${type} STREQUAL "STATIC")

--- a/clients/drcachesim/analysis_tool_interface.h
+++ b/clients/drcachesim/analysis_tool_interface.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -30,44 +30,21 @@
  * DAMAGE.
  */
 
-/* analyzer: represent a memory trace analysis tool that operates only
- * on a file.  We separate this from analyzer_multi, which can operate online
- * or on a raw trace file, to avoid needing to link in DR itself.
+/* Static library support for memory trace analysis tools.
+ * Usage: supply implementations of these routines in a static library and link
+ * with the tool_launcher library to create a new tool executable.
  */
 
-#ifndef _ANALYZER_H_
-#define _ANALYZER_H_ 1
+#ifndef _ANALYSIS_TOOL_INTERFACE_H_
+#define _ANALYSIS_TOOL_INTERFACE_H_ 1
 
 #include "analysis_tool.h"
-#include "reader/reader.h"
-#include <string>
 
-class analyzer_t
-{
- public:
-    // Usage: errors encountered during the constructor will set a flag that should
-    // be queried via operator!.
-    analyzer_t();
-    // The analyzer will reference the tools array passed in during its lifetime:
-    // it does not make a copy.
-    // The user must free them afterward.
-    analyzer_t(const std::string &trace_file, analysis_tool_t **tools,
-               int num_tools);
-    virtual ~analyzer_t();
-    virtual bool operator!();
-    virtual bool run();
-    virtual bool print_stats();
+/* The return value from this routine is passed to the other routines in
+ * this interface.
+ * Returning NULL, or returning an analysis_tool_t for which the ! operator
+ * returns false, indicates failure.
+ */
+analysis_tool_t *drmemtrace_analysis_tool_create();
 
- protected:
-    // This finalizes the trace_iter setup.  It can block and is meant to be
-    // called at the top of run().
-    bool start_reading();
-
-    bool success;
-    reader_t *trace_iter;
-    reader_t *trace_end;
-    int num_tools;
-    analysis_tool_t **tools;
-};
-
-#endif /* _ANALYZER_H_ */
+#endif /* _ANALYSIS_TOOL_INTERFACE_H_ */

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -32,67 +32,56 @@
 
 #include "analysis_tool.h"
 #include "analyzer.h"
-#include "common/options.h"
-#include "common/utils.h"
 #include "reader/file_reader.h"
-#include "reader/ipc_reader.h"
-#include "simulator/cache_simulator.h"
-#include "simulator/tlb_simulator.h"
-#include "tools/histogram.h"
-#include "tools/reuse_distance.h"
-#include "tracer/raw2trace.h"
-#include <fstream>
+#include "common/utils.h"
 
 analyzer_t::analyzer_t() :
-    success(true), trace_iter(NULL), trace_end(NULL), num_tools(0)
+    success(true), trace_iter(NULL), trace_end(NULL), num_tools(0), tools(NULL)
 {
-    if (!create_analysis_tools()) {
-        success = false;
-        ERRMSG("Failed to create analysis tool\n");
-        return;
-    }
-    // XXX: add a "required" flag to droption to avoid needing this here
-    if (op_infile.get_value().empty() && op_ipc_name.get_value().empty()) {
-        ERRMSG("Usage error: -ipc_name or -infile is required\nUsage:\n%s",
-               droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
-        success = false;
-        return;
-    }
-    if (!op_indir.get_value().empty()) {
-        // XXX: better to put in app name + pid, or rely on staying inside subdir?
-        std::string tracefile = op_indir.get_value() + std::string(DIRSEP) +
-            TRACE_FILENAME;
-        file_reader_t *existing = new file_reader_t(tracefile.c_str());
-        if (existing->is_complete())
-            trace_iter = existing;
-        else {
-            delete existing;
-            raw2trace_t raw2trace(op_indir.get_value(), tracefile);
-            raw2trace.do_conversion();
-            trace_iter = new file_reader_t(tracefile.c_str());
+    /* Nothing else: child class needs to initialize. */
+}
+
+analyzer_t::analyzer_t(const std::string &trace_file, analysis_tool_t **tools_in,
+                       int num_tools_in) :
+    success(true), trace_iter(NULL), trace_end(NULL), num_tools(num_tools_in),
+    tools(tools_in)
+{
+    for (int i = 0; i < num_tools; ++i) {
+        if (tools[i] == NULL || !*tools[i]) {
+            success = false;
+            ERRMSG("Tool is not successfully initialized\n");
+            return;
         }
-        trace_end = new file_reader_t();
-    } else if (op_infile.get_value().empty()) {
-        trace_iter = new ipc_reader_t(op_ipc_name.get_value().c_str());
-        trace_end = new ipc_reader_t();
-    } else {
-        trace_iter = new file_reader_t(op_infile.get_value().c_str());
-        trace_end = new file_reader_t();
     }
-    // We can't call trace_iter->init() here as it blocks for ipc_reader_t.
+    if (trace_file.empty()) {
+        success = false;
+        ERRMSG("Trace file name is empty\n");
+        return;
+    }
+    trace_iter = new file_reader_t(trace_file.c_str());
+    trace_end = new file_reader_t();
 }
 
 analyzer_t::~analyzer_t()
 {
     delete trace_iter;
     delete trace_end;
-    destroy_analysis_tools();
 }
 
 bool
 analyzer_t::operator!()
 {
     return !success;
+}
+
+bool
+analyzer_t::start_reading()
+{
+    if (!trace_iter->init()) {
+        ERRMSG("failed to read from trace\n");
+        return false;
+    }
+    return true;
 }
 
 bool
@@ -103,7 +92,7 @@ analyzer_t::run()
         return false;
 
     for (; *trace_iter != *trace_end; ++(*trace_iter)) {
-        for (int i = 0; i < num_tools; i++) {
+        for (int i = 0; i < num_tools; ++i) {
             memref_t memref = **trace_iter;
             res = tools[i]->process_memref(memref) && res;
         }
@@ -115,54 +104,7 @@ bool
 analyzer_t::print_stats()
 {
     bool res = true;
-    for (int i = 0; i < num_tools; i++)
+    for (int i = 0; i < num_tools; ++i)
         res = tools[i]->print_results() && res;
     return res;
-}
-
-bool
-analyzer_t::start_reading()
-{
-    if (!trace_iter->init()) {
-        ERRMSG("failed to read from %s\n", op_infile.get_value().empty() ?
-               op_ipc_name.get_value().c_str() : op_infile.get_value().c_str());
-        return false;
-    }
-    return true;
-}
-
-bool
-analyzer_t::create_analysis_tools()
-{
-    /* FIXME i#2006: add multiple tool support. */
-    /* FIXME i#2006: create a single top-level tool for multi-component
-     * tools.
-     */
-    if (op_simulator_type.get_value() == CPU_CACHE)
-        tools[0] = new cache_simulator_t;
-    else if (op_simulator_type.get_value() == TLB)
-        tools[0] = new tlb_simulator_t;
-    else if (op_simulator_type.get_value() == HISTOGRAM)
-        tools[0] = new histogram_t;
-    else if (op_simulator_type.get_value() == REUSE_DIST)
-        tools[0] = new reuse_distance_t;
-    else {
-        ERRMSG("Usage error: unsupported analyzer type. "
-               "Please choose " CPU_CACHE ", " TLB ", "
-               HISTOGRAM ", or " REUSE_DIST ".\n");
-        return false;
-    }
-    if (!*tools[0])
-        return false;
-    num_tools = 1;
-    return true;
-}
-
-void
-analyzer_t::destroy_analysis_tools()
-{
-    if (!success)
-        return;
-    for (int i = 0; i < num_tools; i++)
-        delete tools[i];
 }

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -1,0 +1,113 @@
+/* **********************************************************
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "analyzer.h"
+#include "analyzer_multi.h"
+#include "analysis_tool_interface.h"
+#include "common/options.h"
+#include "common/utils.h"
+#include "reader/file_reader.h"
+#include "reader/ipc_reader.h"
+#include "tracer/raw2trace.h"
+
+analyzer_multi_t::analyzer_multi_t()
+{
+    if (!create_analysis_tools()) {
+        success = false;
+        ERRMSG("Failed to create analysis tool\n");
+        return;
+    }
+    // XXX: add a "required" flag to droption to avoid needing this here
+    if (op_infile.get_value().empty() && op_ipc_name.get_value().empty()) {
+        ERRMSG("Usage error: -ipc_name or -infile is required\nUsage:\n%s",
+               droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
+        success = false;
+        return;
+    }
+    if (!op_indir.get_value().empty()) {
+        // XXX: better to put in app name + pid, or rely on staying inside subdir?
+        std::string tracefile = op_indir.get_value() + std::string(DIRSEP) +
+            TRACE_FILENAME;
+        file_reader_t *existing = new file_reader_t(tracefile.c_str());
+        if (existing->is_complete())
+            trace_iter = existing;
+        else {
+            delete existing;
+            raw2trace_t raw2trace(op_indir.get_value(), tracefile);
+            raw2trace.do_conversion();
+            trace_iter = new file_reader_t(tracefile.c_str());
+        }
+        trace_end = new file_reader_t();
+    } else if (op_infile.get_value().empty()) {
+        trace_iter = new ipc_reader_t(op_ipc_name.get_value().c_str());
+        trace_end = new ipc_reader_t();
+    } else {
+        trace_iter = new file_reader_t(op_infile.get_value().c_str());
+        trace_end = new file_reader_t();
+    }
+    // We can't call trace_iter->init() here as it blocks for ipc_reader_t.
+}
+
+analyzer_multi_t::~analyzer_multi_t()
+{
+    destroy_analysis_tools();
+}
+
+
+bool
+analyzer_multi_t::create_analysis_tools()
+{
+    /* FIXME i#2006: add multiple tool support. */
+    /* FIXME i#2006: create a single top-level tool for multi-component
+     * tools.
+     */
+    tools = new analysis_tool_t*[max_num_tools];
+    tools[0] = drmemtrace_analysis_tool_create();
+    if (tools[0] != NULL && !*tools[0]) {
+        delete tools[0];
+        tools[0] = NULL;
+    }
+    if (tools[0] == NULL)
+        return false;
+    num_tools = 1;
+    return true;
+}
+
+void
+analyzer_multi_t::destroy_analysis_tools()
+{
+    if (!success)
+        return;
+    for (int i = 0; i < num_tools; i++)
+        delete tools[i];
+    delete [] tools;
+}

--- a/clients/drcachesim/analyzer_multi.h
+++ b/clients/drcachesim/analyzer_multi.h
@@ -30,44 +30,28 @@
  * DAMAGE.
  */
 
-/* analyzer: represent a memory trace analysis tool that operates only
- * on a file.  We separate this from analyzer_multi, which can operate online
- * or on a raw trace file, to avoid needing to link in DR itself.
+/* analyzer_multi: represent a memory trace analysis tool that can process
+ * a trace from multiple inputs: a file, from a raw file, or over a pipe online.
  */
 
-#ifndef _ANALYZER_H_
-#define _ANALYZER_H_ 1
+#ifndef _ANALYZER_MULTI_H_
+#define _ANALYZER_MULTI_H_ 1
 
-#include "analysis_tool.h"
-#include "reader/reader.h"
-#include <string>
+#include "analyzer.h"
 
-class analyzer_t
+class analyzer_multi_t : public analyzer_t
 {
  public:
     // Usage: errors encountered during the constructor will set a flag that should
     // be queried via operator!.
-    analyzer_t();
-    // The analyzer will reference the tools array passed in during its lifetime:
-    // it does not make a copy.
-    // The user must free them afterward.
-    analyzer_t(const std::string &trace_file, analysis_tool_t **tools,
-               int num_tools);
-    virtual ~analyzer_t();
-    virtual bool operator!();
-    virtual bool run();
-    virtual bool print_stats();
+    analyzer_multi_t();
+    virtual ~analyzer_multi_t();
 
  protected:
-    // This finalizes the trace_iter setup.  It can block and is meant to be
-    // called at the top of run().
-    bool start_reading();
+    bool create_analysis_tools();
+    void destroy_analysis_tools();
 
-    bool success;
-    reader_t *trace_iter;
-    reader_t *trace_end;
-    int num_tools;
-    analysis_tool_t **tools;
-};
+    static const int max_num_tools = 8;
+ };
 
-#endif /* _ANALYZER_H_ */
+#endif /* _ANALYZER_MULTI_H_ */

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -217,11 +217,13 @@ droption_t<bytesize_t> op_sim_refs
  "The simulated references come after the skipped and warmup references, "
  "and the references following the simulated ones are dropped.");
 
+// XXX: if we separate histogram + reuse_distance we should move this with them.
 droption_t<unsigned int> op_report_top
 (DROPTION_SCOPE_FRONTEND, "report_top", 10,
  "Number of top results to be reported",
  "Specifies the number of top results to be reported.");
 
+// XXX: if we separate histogram + reuse_distance we should move this with them.
 droption_t<unsigned int> op_reuse_distance_threshold
 (DROPTION_SCOPE_FRONTEND, "reuse_distance_threshold", 100,
  "The reuse distance threshold for reporting the distant repeated references.",

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -49,7 +49,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <iostream>
-#include "analyzer.h"
+#include "analyzer_multi.h"
 #include "dr_api.h"
 #include "dr_inject.h"
 #include "dr_config.h"
@@ -233,8 +233,7 @@ _tmain(int argc, const TCHAR *targv[])
             FATAL_ERROR("invalid -outdir %s", op_outdir.get_value().c_str());
         }
     } else {
-        // declare the analyzer based on its type
-        analyzer = new analyzer_t;
+        analyzer = new analyzer_multi_t;
         if (!*analyzer) {
             FATAL_ERROR("failed to initialize analyzer");
         }

--- a/clients/drcachesim/tests/histogram-offline.templatex
+++ b/clients/drcachesim/tests/histogram-offline.templatex
@@ -1,0 +1,8 @@
+.*
+Cache Histogram result:
+Cache Histogram: icache = [0-9]+ unique cache lines
+Cache Histogram: dcache = [0-9]+ unique cache lines
+Cache Histogram: icache top 10
+.*
+Cache Histogram: dcache top 10
+.*

--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -1,0 +1,91 @@
+/* **********************************************************
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Standalone histogram analysis tool launcher for file traces. */
+
+#include "droption.h"
+#include "dr_frontend.h"
+#include "../analyzer.h"
+#include "histogram.h"
+
+#define FATAL_ERROR(msg, ...) do { \
+    fprintf(stderr, "ERROR: " msg "\n", ##__VA_ARGS__);    \
+    fflush(stderr); \
+    exit(1); \
+} while (0)
+
+static droption_t<std::string> op_trace
+(DROPTION_SCOPE_FRONTEND, "trace", "", "[Required] Trace input file",
+ "Specifies the file containing the trace to be analyzed.");
+
+// XXX i#2006: these are duplicated from drcachesim's options.
+// Once we decide on the final tool generalization approach we should
+// either share these options in a single location or split them.
+
+droption_t<unsigned int> op_line_size
+(DROPTION_SCOPE_FRONTEND, "line_size", 64, "Cache line size",
+ "Specifies the cache line size, which is assumed to be identical for L1 and L2 "
+ "caches.");
+
+droption_t<unsigned int> op_report_top
+(DROPTION_SCOPE_FRONTEND, "report_top", 10,
+ "Number of top results to be reported",
+ "Specifies the number of top results to be reported.");
+
+int
+main(int argc, const TCHAR *targv[])
+{
+    // Convert to UTF-8 if necessary
+    char **argv;
+    drfront_status_t sc = drfront_convert_args(targv, &argv, argc);
+    if (sc != DRFRONT_SUCCESS)
+        FATAL_ERROR("Failed to process args: %d", sc);
+
+    std::string parse_err;
+    if (!droption_parser_t::parse_argv(DROPTION_SCOPE_FRONTEND, argc, (const char **)argv,
+                                       &parse_err, NULL) ||
+        op_trace.get_value().empty()) {
+        FATAL_ERROR("Usage error: %s\nUsage:\n%s", parse_err.c_str(),
+                    droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
+    }
+
+    histogram_t tool;
+    analysis_tool_t *tool_list = &tool;
+    analyzer_t analyzer(op_trace.get_value(), &tool_list, 1);
+    if (!analyzer)
+        FATAL_ERROR("failed to initialize analyzer");
+    if (!analyzer.run())
+        FATAL_ERROR("failed to run analyzer");
+    analyzer.print_stats();
+
+    return 0;
+}

--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -32,6 +32,13 @@
 
 /* Standalone histogram analysis tool launcher for file traces. */
 
+#ifdef WINDOWS
+# define UNICODE
+# define _UNICODE
+# define WIN32_LEAN_AND_MEAN
+# include <windows.h>
+#endif
+
 #include "droption.h"
 #include "dr_frontend.h"
 #include "../analyzer.h"
@@ -62,7 +69,7 @@ droption_t<unsigned int> op_report_top
  "Specifies the number of top results to be reported.");
 
 int
-main(int argc, const TCHAR *targv[])
+_tmain(int argc, const TCHAR *targv[])
 {
     // Convert to UTF-8 if necessary
     char **argv;

--- a/clients/drcachesim/tracer/raw2trace_launcher.cpp
+++ b/clients/drcachesim/tracer/raw2trace_launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -32,6 +32,13 @@
 
 /* Standalone raw2trace converter. */
 
+#ifdef WINDOWS
+# define UNICODE
+# define _UNICODE
+# define WIN32_LEAN_AND_MEAN
+# include <windows.h>
+#endif
+
 #include "dr_api.h"
 #include "droption.h"
 #include "dr_frontend.h"
@@ -57,7 +64,7 @@ droption_t<unsigned int> op_verbose
  "Verbosity level for diagnostic output.");
 
 int
-main(int argc, const TCHAR *targv[])
+_tmain(int argc, const TCHAR *targv[])
 {
     // Convert to UTF-8 if necessary
     char **argv;

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -242,6 +242,7 @@ typedef __int64 ssize_t;
 #  else
 typedef int ssize_t;
 #  endif
+#  define _SSIZE_T_DEFINED
 #  define INT64_FORMAT "I64"
 #else /* Linux */
 #  ifdef X64

--- a/libutil/dr_frontend.h
+++ b/libutil/dr_frontend.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -65,6 +65,16 @@
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+#ifndef IN
+# define IN /* marks input param */
+#endif
+#ifndef OUT
+# define OUT /* marks output param */
+#endif
+#ifndef INOUT
+# define INOUT /* marks input+output param */
 #endif
 
 #ifdef WINDOWS

--- a/libutil/dr_frontend.h
+++ b/libutil/dr_frontend.h
@@ -67,6 +67,8 @@
 extern "C" {
 #endif
 
+/* DR_API EXPORT VERBATIM */
+/* Support use independently from dr_api.h */
 #ifndef IN
 # define IN /* marks input param */
 #endif
@@ -76,6 +78,14 @@ extern "C" {
 #ifndef INOUT
 # define INOUT /* marks input+output param */
 #endif
+#if defined(WINDOWS) && !defined(_DR_API_H) && !defined(_SSIZE_T_DEFINED)
+# if defined(_WIN64)
+typedef __int64 ssize_t;
+# else
+typedef int ssize_t;
+# endif
+#endif
+/* DR_API EXPORT END */
 
 #ifdef WINDOWS
 # include <tchar.h>

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1294,10 +1294,14 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out)
     if (NOT DEFINED ${key}_postcmd)
       set(${key}_postcmd "")
     endif ()
+    if (NOT DEFINED ${key}_postcmd2)
+      set(${key}_postcmd2 "")
+    endif ()
     add_test(${test} ${CMAKE_COMMAND}
       -D precmd=${${key}_precmd}
       -D cmd=${cmd_with_at}
       -D postcmd=${${key}_postcmd}
+      -D postcmd2=${${key}_postcmd2}
       -D cmp=${CMAKE_CURRENT_BINARY_DIR}/${expectbase}.expect
       -P ${runcmp_script})
     # No support for regex here (ctest can't handle large regex)
@@ -2443,6 +2447,9 @@ if (CLIENT_INTERFACE)
       # Test offline traces.
       # XXX: we could exclude the pipe files and build the offline trace
       # support by itself for Android.
+      get_target_path_for_execution(drcachesim_path drcachesim)
+      prefix_cmd_if_necessary(drcachesim_path ON ${drcachesim_path})
+
       macro (torunonly_drcacheoff testname exetgt)
         torunonly_ci(tool.drcacheoff.${testname} ${exetgt} drcachesim
           "offline-${testname}.c" # for templatex basename
@@ -2451,8 +2458,6 @@ if (CLIENT_INTERFACE)
         set(tool.drcacheoff.${testname}_basedir
           "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
         set(tool.drcacheoff.${testname}_rawtemp ON) # no preprocessor
-        get_target_path_for_execution(drcachesim_path drcachesim)
-        prefix_cmd_if_necessary(drcachesim_path ON ${drcachesim_path})
         set(tool.drcacheoff.${testname}_runcmp
           "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
         set(tool.drcacheoff.${testname}_precmd
@@ -2488,6 +2493,24 @@ if (CLIENT_INTERFACE)
           set(tool.drcacheoff.burst_client_nodr ON)
         endif ()
       endif ()
+
+      # Test the standalone histogram tool.
+      torunonly_ci(tool.histogram.offline ${ci_shared_app} drcachesim
+        "histogram-offline.c" "-offline" "" "")
+      set(tool.histogram.offline_toolname "drcachesim")
+      set(tool.histogram.offline_basedir
+        "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+      set(tool.histogram.offline_rawtemp ON) # no preprocessor
+      get_target_path_for_execution(histo_path drmemtrace_histogram)
+      prefix_cmd_if_necessary(histo_path ON ${histo_path})
+      set(tool.histogram.offline_runcmp
+        "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
+      set(tool.histogram.offline_precmd
+        "foreach@${CMAKE_COMMAND}@-E@remove_directory@drmemtrace.${ci_shared_app}.*.dir")
+      set(tool.histogram.offline_postcmd
+        "${drcachesim_path}@-indir@drmemtrace.${ci_shared_app}.*.dir")
+      set(tool.histogram.offline_postcmd2
+        "${histo_path}@-trace@drmemtrace.${ci_shared_app}.*.dir/drmemtrace.trace")
 
     endif (NOT ANDROID)
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2495,7 +2495,10 @@ if (CLIENT_INTERFACE)
       endif ()
 
       # Test the standalone histogram tool.
-      torunonly_ci(tool.histogram.offline ${ci_shared_app} drcachesim
+      # ${ci_shared_app} is already used for an offline test, and we're deleting a
+      # dir with that name, so we run common.eflags to avoid having to serialize.
+      set(histo_app common.${control_flags})
+      torunonly_ci(tool.histogram.offline ${histo_app} drcachesim
         "histogram-offline.c" "-offline" "" "")
       set(tool.histogram.offline_toolname "drcachesim")
       set(tool.histogram.offline_basedir
@@ -2506,11 +2509,11 @@ if (CLIENT_INTERFACE)
       set(tool.histogram.offline_runcmp
         "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
       set(tool.histogram.offline_precmd
-        "foreach@${CMAKE_COMMAND}@-E@remove_directory@drmemtrace.${ci_shared_app}.*.dir")
+        "foreach@${CMAKE_COMMAND}@-E@remove_directory@drmemtrace.${histo_app}.*.dir")
       set(tool.histogram.offline_postcmd
-        "${drcachesim_path}@-indir@drmemtrace.${ci_shared_app}.*.dir")
+        "${drcachesim_path}@-indir@drmemtrace.${histo_app}.*.dir")
       set(tool.histogram.offline_postcmd2
-        "${histo_path}@-trace@drmemtrace.${ci_shared_app}.*.dir/drmemtrace.trace")
+        "${histo_path}@-trace@drmemtrace.${histo_app}.*.dir/drmemtrace.trace")
 
     endif (NOT ANDROID)
 

--- a/suite/tests/runmulti.cmake
+++ b/suite/tests/runmulti.cmake
@@ -33,6 +33,7 @@
 # * cmd = command to run
 #     should have intra-arg space=@@ and inter-arg space=@ and ;=!
 # * postcmd = post processing command to run
+# * postcmd2 = additional post processing command to run
 # * cmp = the file containing the expected output
 #
 # A "*" in any command line will be glob-expanded right before running.
@@ -106,7 +107,12 @@ process_cmdline(precmd ON ignore)
 
 process_cmdline(cmd OFF tomatch)
 
-process_cmdline(postcmd OFF tomatch)
+if (NOT postcmd STREQUAL "")
+  process_cmdline(postcmd OFF tomatch)
+  if (NOT postcmd2 STREQUAL "")
+    process_cmdline(postcmd2 OFF tomatch)
+  endif ()
+endif()
 
 # get expected output (must already be processed w/ regex => literal, etc.)
 file(READ "${cmp}" str)


### PR DESCRIPTION
Splits the analyzer into a base that only reads from an offline (non-raw)
trace file, to support building offline analysis tools that do not need to
link with DR.  The tools to be used are passed in, simplifying tool
creation and lifetime management.

The derived analyzer, analyzer_multi_t, supports online, raw offline, and
transformed offline files.

For analyzer_multi_t, adds a separated interface for instantiating the tool
to be run, supporting linking in a separately built static library.

Adds a sample offline-only tool that runs the histogram analysis.
Adds a test of the new standalone tool.