### PR TITLE
i#2272 drsyms uses the wrong criteria to distinguish imports on aarch64

### DIFF
--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -882,7 +882,9 @@ elf_hash_lookup(const char   *name,
             ASSERT(false && "malformed ELF symbol entry");
             continue;
         }
-        /* Keep this consistent with symbol_is_import. */
+        /* Keep this consistent with symbol_is_import()  at this file and
+         * drsym_obj_symbol_offs() at ext/drsyms/drsyms_elf.c
+         */
         if (sym->st_value == 0 && ELF_ST_TYPE(sym->st_info) != STT_TLS)
             continue; /* no value */
         if (elf_sym_matches(sym, strtab, name, is_indirect_code))
@@ -1540,7 +1542,8 @@ symbol_iterator_stop(elf_symbol_iterator_t *iter)
 static bool
 symbol_is_import(ELF_SYM_TYPE *sym)
 {
-    /* Keep this consistent with elf_hash_lookup.
+    /* Keep this consistent with elf_hash_lookup() at this file and
+     * drsym_obj_symbol_offs() at ext/drsyms/drsyms_elf.c.
      * With some older ARM and AArch64 tool chains we have st_shndx == STN_UNDEF
      * with a non-zero st_value pointing at the PLT. See i#2008.
      */

--- a/ext/drsyms/drsyms_elf.c
+++ b/ext/drsyms/drsyms_elf.c
@@ -354,6 +354,9 @@ drsym_obj_symbol_offs(void *mod_in, uint idx, size_t *offs_start OUT,
     elf_info_t *mod = (elf_info_t *) mod_in;
     if (offs_start == NULL || mod == NULL || idx >= mod->num_syms || mod->syms == NULL)
         return DRSYM_ERROR_INVALID_PARAMETER;
+    /* Keep this consistent with symbol_is_import() and elf_hash_lookup(), both at
+     * core/unix/module_elf.c
+     */
     if ((mod->syms[idx].st_value == 0 &&
         ELF_ST_TYPE(mod->syms[idx].st_info) != STT_TLS) ||
         mod->syms[idx].st_shndx == 0) {

--- a/ext/drsyms/drsyms_elf.c
+++ b/ext/drsyms/drsyms_elf.c
@@ -102,6 +102,7 @@ static bool verbose = 0;
 # define Elf_Phdr Elf64_Phdr
 # define Elf_Shdr Elf64_Shdr
 # define Elf_Sym  Elf64_Sym
+# define ELF_ST_TYPE ELF64_ST_TYPE
 #else
 # define elf_getehdr elf32_getehdr
 # define elf_getphdr elf32_getphdr
@@ -110,6 +111,7 @@ static bool verbose = 0;
 # define Elf_Phdr Elf32_Phdr
 # define Elf_Shdr Elf32_Shdr
 # define Elf_Sym  Elf32_Sym
+# define ELF_ST_TYPE ELF32_ST_TYPE
 #endif
 
 typedef struct _elf_info_t {
@@ -352,7 +354,9 @@ drsym_obj_symbol_offs(void *mod_in, uint idx, size_t *offs_start OUT,
     elf_info_t *mod = (elf_info_t *) mod_in;
     if (offs_start == NULL || mod == NULL || idx >= mod->num_syms || mod->syms == NULL)
         return DRSYM_ERROR_INVALID_PARAMETER;
-    if (mod->syms[idx].st_value == 0) {
+    if ((mod->syms[idx].st_value == 0 &&
+        ELF_ST_TYPE(mod->syms[idx].st_info) != STT_TLS) ||
+        mod->syms[idx].st_shndx == 0) {
         /* We're looking at .dynsym and this is an import */
         *offs_start = 0;
         if (offs_end != NULL)


### PR DESCRIPTION
Fixed the logic used to detect imports on ext/drsyms/drsyms_elf.c.
Now we use the same logic as in core/unix/module_elf.c symbol_is_import.

Fixes issue #2272