### PR TITLE
i#2006 generalize drcachesim: facilitate tool header installation

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -83,6 +83,10 @@ use_DynamoRIO_extension(drcachesim droption)
 use_DynamoRIO_extension(drcachesim drcovlib_static)
 use_DynamoRIO_extension(drcachesim drutil_static)
 
+# This is to avoid common/ in analysis_tool.h's include of memref.h, to make
+# it easier for installation of needed tool headers into a single dir.
+include_directories(common)
+
 set(file_analyzer_tool_srcs
   analyzer.cpp
   common/trace_entry.cpp

--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -36,7 +36,9 @@
 #ifndef _ANALYSIS_TOOL_H_
 #define _ANALYSIS_TOOL_H_ 1
 
-#include "common/memref.h"
+// To support installation of headers for analysis tools into a single
+// separate directory we omit common/ here and rely on -I.
+#include "memref.h"
 
 class analysis_tool_t
 {

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -39,8 +39,11 @@
 #define _ANALYZER_H_ 1
 
 #include "analysis_tool.h"
-#include "reader/reader.h"
 #include <string>
+
+// We avoid reader.h here to make it easier for standalone tools
+// along the lines of histogram_launcher.
+class reader_t;
 
 class analyzer_t
 {


### PR DESCRIPTION
Removes subdir references from the key headers needed for offline-only
tools to make it easier to install the headers for third-party tools.