### PR TITLE
i#2277: add support for reading compressed trace files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2016 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2017 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -1615,6 +1615,15 @@ if (BUILD_TESTS AND UNIX)
       message(FATAL_ERROR "cannot find required libs m, dl, and/or pthread")
     endif ()
   endif ()
+endif ()
+
+# zlib is used for some clients/ and tests.
+if (CMAKE_CROSSCOMPILING)
+  # find_package looks at the host system.
+  # XXX i#2285: we should re-visit the CMAKE_FIND_ROOT_PATH settings!
+  set(ZLIB_FOUND OFF)
+else ()
+  find_package(ZLIB)
 endif ()
 
 if (BUILD_CLIENTS)

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -45,7 +45,6 @@ endif ()
 # i#2277: we use zlib if available to read compressed trace files.
 # XXX: we could ship with a zlib for Windows: today we simply don't support
 # compressed traces on Windows.
-find_package(ZLIB)
 if (ZLIB_FOUND)
   add_definitions(-DHAS_ZLIB)
   include_directories(${ZLIB_INCLUDE_DIRS})

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -42,6 +42,18 @@ else ()
   add_definitions(-DUNIX)
 endif ()
 
+# i#2277: we use zlib if available to read compressed trace files.
+# XXX: we could ship with a zlib for Windows: today we simply don't support
+# compressed traces on Windows.
+find_package(ZLIB)
+if (ZLIB_FOUND)
+  add_definitions(-DHAS_ZLIB)
+  include_directories(${ZLIB_INCLUDE_DIRS})
+  set(zlib_reader reader/compressed_file_reader.cpp)
+else ()
+  set(zlib_reader "")
+endif()
+
 set(client_and_sim_srcs
   common/named_pipe_${os_name}.cpp
   common/options.cpp
@@ -54,6 +66,7 @@ add_executable(drcachesim
   ${client_and_sim_srcs}
   reader/reader.cpp
   reader/file_reader.cpp
+  ${zlib_reader}
   reader/ipc_reader.cpp
   simulator/analyzer_interface.cpp
   simulator/simulator.cpp
@@ -92,6 +105,7 @@ set(file_analyzer_tool_srcs
   common/trace_entry.cpp
   reader/reader.cpp
   reader/file_reader.cpp
+  ${zlib_reader}
   )
 
 # We show one example of how to create a standalone analyzer of trace
@@ -105,6 +119,11 @@ add_executable(drmemtrace_histogram
 target_link_libraries(drmemtrace_histogram drfrontendlib)
 use_DynamoRIO_extension(drmemtrace_histogram droption)
 add_dependencies(drmemtrace_histogram api_headers)
+
+if (ZLIB_FOUND)
+  target_link_libraries(drcachesim ${ZLIB_LIBRARIES})
+  target_link_libraries(drmemtrace_histogram ${ZLIB_LIBRARIES})
+endif ()
 
 macro(add_drmemtrace name type)
   if (${type} STREQUAL "STATIC")

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -33,6 +33,9 @@
 #include "analysis_tool.h"
 #include "analyzer.h"
 #include "reader/file_reader.h"
+#ifdef HAS_ZLIB
+# include "reader/compressed_file_reader.h"
+#endif
 #include "common/utils.h"
 
 analyzer_t::analyzer_t() :
@@ -58,8 +61,16 @@ analyzer_t::analyzer_t(const std::string &trace_file, analysis_tool_t **tools_in
         ERRMSG("Trace file name is empty\n");
         return;
     }
+#ifdef HAS_ZLIB
+    // Even if the file is uncompressed, zlib's gzip interface is faster than
+    // file_reader_t's fstream in our measurements, so we always use it when
+    // available.
+    trace_iter = new compressed_file_reader_t(trace_file.c_str());
+    trace_end = new compressed_file_reader_t();
+#else
     trace_iter = new file_reader_t(trace_file.c_str());
     trace_end = new file_reader_t();
+#endif
 }
 
 analyzer_t::~analyzer_t()

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -77,15 +77,43 @@ the simulator via a pipe.
 Any child processes will be followed into and profiled, with their
 memory references passed to the simulator as well.
 
+To simulate TLB devices instead of caches, use the \p -simulator_type
+parameter:
+
+\code
+bin64/drrun -t drcachesim -simulator_type TLB -- /path/to/target/app <args> <for> <app>
+\endcode
+
+Several other trace analysis tools are under development.
+
 To dump the trace for future offline analysis:
 \code
 bin64/drrun -t drcachesim -offline -- /path/to/target/app <args> <for> <app>
 \endcode
 
-The collected traces will be dumpped into a newly created directory,
-which can be passed to drcachesim for offline cache simulation.
+The collected traces will be dumped into a newly created directory,
+which can be passed to drcachesim for offline cache simulation with the \p
+-indir option:
 \code
 bin64/drrun -t drcachesim -indir drmemtrace.app.pid.xxxx.dir/
+\endcode
+
+The direct results of the \p -offline run are raw, compacted files, stored
+in a \p raw subdirectory of the \p drmemtrace.app.pid.xxxx.dir directory.
+The \p -indir option both converts the data to a canonical trace form and
+passes the resulting data to the cache simulator.  The canonical trace data
+is stored by \p -indir in a file named \p drmemtrace.trace inside the \p
+drmemtrace.app.pid.xxxx.dir/ directory.  Future runs can point directly at
+this file using the \p -infile option:
+\code
+bin64/drrun -t drcachesim -infile drmemtrace.app.pid.xxxx.dir/drmemtrace.trace
+\endcode
+
+The \p -infile option supports reading a gzipped trace file, allowing
+compression of the \p drmemtrace.trace file to save space:
+\code
+gzip drmemtrace.app.pid.xxxx.dir/drmemtrace.trace
+bin64/drrun -t drcachesim -infile drmemtrace.app.pid.xxxx.dir/drmemtrace.trace.gz
 \endcode
 
 \section sec_drcachesim_sim Simulator Details

--- a/clients/drcachesim/reader/compressed_file_reader.cpp
+++ b/clients/drcachesim/reader/compressed_file_reader.cpp
@@ -40,7 +40,7 @@
 # include <iostream>
 #endif
 
-compressed_file_reader_t::compressed_file_reader_t()
+compressed_file_reader_t::compressed_file_reader_t() : file(NULL)
 {
     /* Empty. */
 }
@@ -70,7 +70,8 @@ compressed_file_reader_t::init()
 
 compressed_file_reader_t::~compressed_file_reader_t()
 {
-    gzclose(file);
+    if (file != NULL)
+        gzclose(file);
 }
 
 trace_entry_t *

--- a/clients/drcachesim/reader/compressed_file_reader.cpp
+++ b/clients/drcachesim/reader/compressed_file_reader.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -31,8 +31,8 @@
  */
 
 #include <assert.h>
-#include <fstream>
-#include "file_reader.h"
+#include <zlib.h>
+#include "compressed_file_reader.h"
 #include "../common/memref.h"
 #include "../common/utils.h"
 
@@ -40,22 +40,21 @@
 # include <iostream>
 #endif
 
-file_reader_t::file_reader_t()
+compressed_file_reader_t::compressed_file_reader_t()
 {
     /* Empty. */
 }
 
-file_reader_t::file_reader_t(const char *file_name) :
-    fstream(file_name, std::ifstream::binary)
+compressed_file_reader_t::compressed_file_reader_t(const char *file_name)
 {
-    /* Empty. */
+    file = gzopen(file_name, "rb");
 }
 
 bool
-file_reader_t::init()
+compressed_file_reader_t::init()
 {
     at_eof = false;
-    if (!fstream)
+    if (file == NULL)
         return false;
     trace_entry_t *first_entry = read_next_entry();
     if (first_entry == NULL)
@@ -69,31 +68,28 @@ file_reader_t::init()
     return true;
 }
 
-file_reader_t::~file_reader_t()
+compressed_file_reader_t::~compressed_file_reader_t()
 {
-    fstream.close();
+    gzclose(file);
 }
 
 trace_entry_t *
-file_reader_t::read_next_entry()
+compressed_file_reader_t::read_next_entry()
 {
-    if (!fstream.read((char*)&entry_copy, sizeof(entry_copy)))
+    int len = gzread(file, (char*)&entry_copy, sizeof(entry_copy));
+    // Returns less than asked-for for end of file, or –1 for error.
+    if (len < (int)sizeof(entry_copy))
         return NULL;
     return &entry_copy;
 }
 
 bool
-file_reader_t::is_complete()
+compressed_file_reader_t::is_complete()
 {
-    if (!fstream)
-        return false;
-    bool res = false;
-    std::streampos pos = fstream.tellg();
-    fstream.seekg(-(int)sizeof(trace_entry_t), fstream.end);
-    // Avoid reaching eof b/c we can't seek away from it.
-    if (fstream.read((char*)&entry_copy.type, sizeof(entry_copy.type)) &&
-        entry_copy.type == TRACE_TYPE_FOOTER)
-        res = true;
-    fstream.seekg(pos);
-    return res;
+    // The gzip reading interface does not support seeking to SEEK_END so there
+    // is no efficient way to read the footer.
+    // We could have the trace file writer seek back and set a bit at the start.
+    // Or we can just not supported -indir with a gzipped file, which is what we
+    // do for now: the user must pass in -infile for a gzipped file.
+    return false;
 }

--- a/clients/drcachesim/reader/compressed_file_reader.h
+++ b/clients/drcachesim/reader/compressed_file_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -30,70 +30,31 @@
  * DAMAGE.
  */
 
-#include <assert.h>
-#include <fstream>
-#include "file_reader.h"
+/* compressed_file_reader: reads compressed files containing memory traces. */
+
+#ifndef _COMPRESSED_FILE_READER_H_
+#define _COMPRESSED_FILE_READER_H_ 1
+
+#include <zlib.h>
+#include "reader.h"
 #include "../common/memref.h"
-#include "../common/utils.h"
+#include "../common/trace_entry.h"
 
-#ifdef VERBOSE
-# include <iostream>
-#endif
-
-file_reader_t::file_reader_t()
+class compressed_file_reader_t : public reader_t
 {
-    /* Empty. */
-}
+ public:
+    compressed_file_reader_t();
+    explicit compressed_file_reader_t(const char *file_name);
+    virtual ~compressed_file_reader_t();
+    virtual bool init();
+    bool is_complete();
 
-file_reader_t::file_reader_t(const char *file_name) :
-    fstream(file_name, std::ifstream::binary)
-{
-    /* Empty. */
-}
+ protected:
+    virtual trace_entry_t * read_next_entry();
 
-bool
-file_reader_t::init()
-{
-    at_eof = false;
-    if (!fstream)
-        return false;
-    trace_entry_t *first_entry = read_next_entry();
-    if (first_entry == NULL)
-        return false;
-    if (first_entry->type != TRACE_TYPE_HEADER ||
-        first_entry->addr != TRACE_ENTRY_VERSION) {
-        ERRMSG("missing header or version mismatch\n");
-        return false;
-    }
-    ++*this;
-    return true;
-}
+ private:
+    gzFile file;
+    trace_entry_t entry_copy;
+};
 
-file_reader_t::~file_reader_t()
-{
-    fstream.close();
-}
-
-trace_entry_t *
-file_reader_t::read_next_entry()
-{
-    if (!fstream.read((char*)&entry_copy, sizeof(entry_copy)))
-        return NULL;
-    return &entry_copy;
-}
-
-bool
-file_reader_t::is_complete()
-{
-    if (!fstream)
-        return false;
-    bool res = false;
-    std::streampos pos = fstream.tellg();
-    fstream.seekg(-(int)sizeof(trace_entry_t), fstream.end);
-    // Avoid reaching eof b/c we can't seek away from it.
-    if (fstream.read((char*)&entry_copy.type, sizeof(entry_copy.type)) &&
-        entry_copy.type == TRACE_TYPE_FOOTER)
-        res = true;
-    fstream.seekg(pos);
-    return res;
-}
+#endif /* _COMPRESSED_FILE_READER_H_ */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1294,14 +1294,12 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out)
     if (NOT DEFINED ${key}_postcmd)
       set(${key}_postcmd "")
     endif ()
-    if (NOT DEFINED ${key}_postcmd2)
-      set(${key}_postcmd2 "")
-    endif ()
     add_test(${test} ${CMAKE_COMMAND}
       -D precmd=${${key}_precmd}
       -D cmd=${cmd_with_at}
       -D postcmd=${${key}_postcmd}
       -D postcmd2=${${key}_postcmd2}
+      -D postcmd3=${${key}_postcmd3}
       -D cmp=${CMAKE_CURRENT_BINARY_DIR}/${expectbase}.expect
       -P ${runcmp_script})
     # No support for regex here (ctest can't handle large regex)
@@ -2515,6 +2513,32 @@ if (CLIENT_INTERFACE)
       set(tool.histogram.offline_postcmd2
         "${histo_path}@-trace@drmemtrace.${histo_app}.*.dir/drmemtrace.trace")
 
+      find_program(GZIP gzip "gzip compression utility")
+      if (UNIX AND GZIP)
+        # Test the gzip file reader.  It does not work with -indir.
+        # We're using the same app name, so we serialize to avoid file conflicts:
+        set(tool.histogram.gzip_depends tool.histogram.offline)
+        torunonly_ci(tool.histogram.gzip ${histo_app} drcachesim
+          "histogram-offline.c" "-offline" "" "")
+        set(tool.histogram.gzip_toolname "drcachesim")
+        set(tool.histogram.gzip_basedir
+          "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+        set(tool.histogram.gzip_rawtemp ON) # no preprocessor
+        get_target_path_for_execution(histo_path drmemtrace_histogram)
+        prefix_cmd_if_necessary(histo_path ON ${histo_path})
+        set(tool.histogram.gzip_runcmp
+          "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
+        set(tool.histogram.gzip_precmd
+          "foreach@${CMAKE_COMMAND}@-E@remove_directory@drmemtrace.${histo_app}.*.dir")
+        set(tool.histogram.gzip_postcmd
+          "${drcachesim_path}@-indir@drmemtrace.${histo_app}.*.dir")
+        set(tool.histogram.gzip_postcmd2
+          "${GZIP}@drmemtrace.${histo_app}.*.dir/drmemtrace.trace")
+        set(tool.histogram.gzip_postcmd3
+          "${histo_path}@-trace@drmemtrace.${histo_app}.*.dir/drmemtrace.trace.gz")
+      elseif (UNIX)
+        message(STATUS "gzip not found: disabling tool.histogram.gzip test")
+      endif ()
     endif (NOT ANDROID)
 
     if (X86) # i#1732: no ARM/AArch64 support for drcpusim yet

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2514,7 +2514,7 @@ if (CLIENT_INTERFACE)
         "${histo_path}@-trace@drmemtrace.${histo_app}.*.dir/drmemtrace.trace")
 
       find_program(GZIP gzip "gzip compression utility")
-      if (UNIX AND GZIP)
+      if (UNIX AND ZLIB AND GZIP)
         # Test the gzip file reader.  It does not work with -indir.
         # We're using the same app name, so we serialize to avoid file conflicts:
         set(tool.histogram.gzip_depends tool.histogram.offline)
@@ -2537,7 +2537,7 @@ if (CLIENT_INTERFACE)
         set(tool.histogram.gzip_postcmd3
           "${histo_path}@-trace@drmemtrace.${histo_app}.*.dir/drmemtrace.trace.gz")
       elseif (UNIX)
-        message(STATUS "gzip not found: disabling tool.histogram.gzip test")
+        message(STATUS "gzip or zlib not found: disabling tool.histogram.gzip test")
       endif ()
     endif (NOT ANDROID)
 

--- a/suite/tests/runmulti.cmake
+++ b/suite/tests/runmulti.cmake
@@ -33,7 +33,7 @@
 # * cmd = command to run
 #     should have intra-arg space=@@ and inter-arg space=@ and ;=!
 # * postcmd = post processing command to run
-# * postcmd2 = additional post processing command to run
+# * postcmdN (for N=2+) = additional post processing commands to run
 # * cmp = the file containing the expected output
 #
 # A "*" in any command line will be glob-expanded right before running.
@@ -90,7 +90,7 @@ macro(process_cmdline line skip_empty err_and_out)
   endif ()
   if (NOT ${line} MATCHES "^foreach;")
     if (NOT ${skip_empty} OR NOT ${line} STREQUAL "" AND NOT globempty)
-      message("Running |${${line}}|")
+      message("Running ${line} |${${line}}|")
       execute_process(COMMAND ${${line}}
         RESULT_VARIABLE cmd_result
         ERROR_VARIABLE cmd_err
@@ -107,11 +107,13 @@ process_cmdline(precmd ON ignore)
 
 process_cmdline(cmd OFF tomatch)
 
-if (NOT postcmd STREQUAL "")
+if (NOT "${postcmd}" STREQUAL "")
   process_cmdline(postcmd OFF tomatch)
-  if (NOT postcmd2 STREQUAL "")
-    process_cmdline(postcmd2 OFF tomatch)
-  endif ()
+  set(num 2)
+  while (NOT "${postcmd${num}}" STREQUAL "")
+    process_cmdline(postcmd${num} OFF tomatch)
+    math(EXPR num "${num} + 1")
+  endwhile ()
 endif()
 
 # get expected output (must already be processed w/ regex => literal, etc.)


### PR DESCRIPTION
If zlib is found at build time (should be everywhere but Windows), we use
zlib's gzip file reading interface for reading trace files in the separated
analyzer_t as well as analyzer_multi_t for -infile (for -indir we do not
support compressed files, as there is no efficient way to check the end of
the file).  We do this regardless of whether the specified file is
compressed or not, as zlib outperforms fstream for uncompressed files.

Adds a test of the histogram tool generating, gzipping, and then reading
the gzipped file.

Updates the drcachesim documentation.

Fixes #2277