### PR TITLE
i#2300 reuse distance: fixes bugs in the existing tool

### DIFF
--- a/clients/drcachesim/tests/histogram-offline.templatex
+++ b/clients/drcachesim/tests/histogram-offline.templatex
@@ -1,8 +1,8 @@
 .*
-Cache Histogram result:
-Cache Histogram: icache = [0-9]+ unique cache lines
-Cache Histogram: dcache = [0-9]+ unique cache lines
-Cache Histogram: icache top 10
+Cache histogram tool results:
+icache: [0-9]+ unique cache lines
+dcache: [0-9]+ unique cache lines
+icache top 10
 .*
-Cache Histogram: dcache top 10
+dcache top 10
 .*

--- a/clients/drcachesim/tests/histogram.templatex
+++ b/clients/drcachesim/tests/histogram.templatex
@@ -1,9 +1,9 @@
 Hello, world!
 ---- <application exited with code 0> ----
-Cache Histogram result:
-Cache Histogram: icache = [0-9]+ unique cache lines
-Cache Histogram: dcache = [0-9]+ unique cache lines
-Cache Histogram: icache top 20
+Cache histogram tool results:
+icache: [0-9]+ unique cache lines
+dcache: [0-9]+ unique cache lines
+icache top 20
 .*
-Cache Histogram: dcache top 20
+dcache top 20
 .*

--- a/clients/drcachesim/tests/reuse_distance.templatex
+++ b/clients/drcachesim/tests/reuse_distance.templatex
@@ -1,10 +1,12 @@
 Hello, world!
 ---- <application exited with code 0> ----
-cache reuse distance result:
-[0-9]+ total accesses
-[0-9]+ unique cache lines accessed
-reuse distance threshold = [0-9]+ cache lines
-top 10 frequently referenced cache lines
+Reuse distance tool results:
+Total accesses: [0-9]+
+Unique accesses: [0-9]+
+Unique cache lines accessed: [0-9]+
 .*
-top 10 distant repeatedly referenced cache lines
+Reuse distance threshold = [0-9]+ cache lines
+Top 10 frequently referenced cache lines
+.*
+Top 10 distant repeatedly referenced cache lines
 .*

--- a/clients/drcachesim/tools/histogram.cpp
+++ b/clients/drcachesim/tools/histogram.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,7 +37,7 @@
 #include "../common/options.h"
 #include "../common/utils.h"
 
-const std::string histogram_t::TOOL_NAME = "Cache Histogram";
+const std::string histogram_t::TOOL_NAME = "Cache histogram tool";
 
 histogram_t::histogram_t()
 {
@@ -74,15 +74,13 @@ bool cmp(const std::pair<addr_t, uint64_t> &l,
 bool
 histogram_t::print_results()
 {
-    std::cerr << TOOL_NAME << " result:\n";
-    std::cerr << TOOL_NAME << ": icache = " << icache_map.size()
-              << " unique cache lines\n";
-    std::cerr << TOOL_NAME << ": dcache = " << dcache_map.size()
-              << " unique cache lines\n";
+    std::cerr << TOOL_NAME << " results:\n";
+    std::cerr << "icache: " << icache_map.size() << " unique cache lines\n";
+    std::cerr << "dcache: " << dcache_map.size() << " unique cache lines\n";
     std::vector<std::pair<addr_t, uint64_t> > top(report_top);
     std::partial_sort_copy(icache_map.begin(), icache_map.end(),
                            top.begin(), top.end(), cmp);
-    std::cerr << TOOL_NAME << ": icache top " << top.size() << "\n";
+    std::cerr << "icache top " << top.size() << "\n";
     for (std::vector<std::pair<addr_t, uint64_t> >::iterator it = top.begin();
          it != top.end(); ++it) {
         std::cerr << std::setw(18) << std::hex << std::showbase << (it->first << 6)
@@ -92,7 +90,7 @@ histogram_t::print_results()
     top.resize(report_top);
     std::partial_sort_copy(dcache_map.begin(), dcache_map.end(),
                            top.begin(), top.end(), cmp);
-    std::cerr << TOOL_NAME << ": dcache top " << top.size() << "\n";
+    std::cerr << "dcache top " << top.size() << "\n";
     for (std::vector<std::pair<addr_t, uint64_t> >::iterator it = top.begin();
          it != top.end(); ++it) {
         std::cerr << std::setw(18) << std::hex << std::showbase << (it->first << 6)

--- a/clients/drcachesim/tools/reuse_distance.h
+++ b/clients/drcachesim/tools/reuse_distance.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -174,6 +174,7 @@ class reuse_distance_t : public analysis_tool_t
     uint64_t time_stamp;
     size_t line_size;
     size_t line_size_bits;
+    int_least64_t total_refs;
     size_t report_top;  /* most accessed lines */
     static const std::string TOOL_NAME;
 };


### PR DESCRIPTION
Fixes several bugs in the existing reuse distance tool:
+ Crash on small datasets
+ Incorrect total ref count
+ Skipping branch instructions

Also normalizes output among non-simulator tools.