### PR TITLE
Avoid potentially derefencing a null pointer in a call to memcpy.

### DIFF
--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1791,7 +1791,7 @@ create_and_initialize_module_data(app_pc start, app_pc end, app_pc entry_point,
             copy->segments[i].end = os_segments[i].end;
             copy->segments[i].prot = os_segments[i].prot;
         }
-    } else
+    } else if (segments != NULL)
         memcpy(copy->segments, segments, num_segments*sizeof(module_segment_data_t));
     copy->timestamp = timestamp;
 # ifdef MACOS

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1786,13 +1786,17 @@ create_and_initialize_module_data(app_pc start, app_pc end, app_pc entry_point,
         HEAP_ARRAY_ALLOC(GLOBAL_DCONTEXT, module_segment_data_t,
                          num_segments, ACCT_VMAREAS, PROTECTED);
     if (os_segments != NULL) {
+        ASSERT(segments == NULL);
         for (i = 0; i < num_segments; i++) {
             copy->segments[i].start = os_segments[i].start;
             copy->segments[i].end = os_segments[i].end;
             copy->segments[i].prot = os_segments[i].prot;
         }
-    } else if (segments != NULL)
-        memcpy(copy->segments, segments, num_segments*sizeof(module_segment_data_t));
+    } else {
+        ASSERT(segments != NULL);
+        if (segments != NULL)
+            memcpy(copy->segments, segments, num_segments*sizeof(module_segment_data_t));
+    }
     copy->timestamp = timestamp;
 # ifdef MACOS
     copy->current_version = current_version;


### PR DESCRIPTION
GCC 7 objects to a memcpy in create_and_initialize_module_data().

(It seems that C99 requires the pointers dest and src to be valid in
memcpy(dest, src, n) even if n is zero.)