### PR TITLE
i#2300 reuse distance tool: fix memory leak

### DIFF
--- a/clients/drcachesim/tools/reuse_distance.cpp
+++ b/clients/drcachesim/tools/reuse_distance.cpp
@@ -79,6 +79,7 @@ reuse_distance_t::reuse_distance_t(unsigned int line_size,
 
 reuse_distance_t::~reuse_distance_t()
 {
+    delete ref_list;
 }
 
 bool


### PR DESCRIPTION
Fixes a memory leak that was present in the original reuse distance code.