### PR TITLE
i#2006 generalize drcachesim: fix locale and other multi-tool issues

### DIFF
--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -65,7 +65,6 @@ caching_device_stats_t::child_access(const memref_t &memref, bool hit)
 void
 caching_device_stats_t::print_counts(std::string prefix)
 {
-    std::cerr.imbue(std::locale("")); // Add commas, at least for my locale
     std::cerr << prefix << std::setw(18) << std::left << "Hits:" <<
         std::setw(20) << std::right << num_hits << std::endl;
     std::cerr << prefix << std::setw(18) << std::left << "Misses:" <<
@@ -101,9 +100,11 @@ caching_device_stats_t::print_child_stats(std::string prefix)
 void
 caching_device_stats_t::print_stats(std::string prefix)
 {
+    std::cerr.imbue(std::locale("")); // Add commas, at least for my locale
     print_counts(prefix);
     print_rates(prefix);
     print_child_stats(prefix);
+    std::cerr.imbue(std::locale("C")); // Reset to avoid affecting later prints.
 }
 
 void

--- a/clients/drcachesim/tests/histogram-offline.templatex
+++ b/clients/drcachesim/tests/histogram-offline.templatex
@@ -1,5 +1,5 @@
 .*
-Cache histogram tool results:
+Cache line histogram tool results:
 icache: [0-9]+ unique cache lines
 dcache: [0-9]+ unique cache lines
 icache top 10

--- a/clients/drcachesim/tests/histogram.templatex
+++ b/clients/drcachesim/tests/histogram.templatex
@@ -1,6 +1,6 @@
 Hello, world!
 ---- <application exited with code 0> ----
-Cache histogram tool results:
+Cache line histogram tool results:
 icache: [0-9]+ unique cache lines
 dcache: [0-9]+ unique cache lines
 icache top 20

--- a/clients/drcachesim/tools/histogram.cpp
+++ b/clients/drcachesim/tools/histogram.cpp
@@ -37,7 +37,7 @@
 #include "histogram.h"
 #include "../common/utils.h"
 
-const std::string histogram_t::TOOL_NAME = "Cache histogram tool";
+const std::string histogram_t::TOOL_NAME = "Cache line histogram tool";
 
 analysis_tool_t *
 histogram_tool_create(unsigned int line_size = 64,


### PR DESCRIPTION
Fixes issues that appear when running multiple trace analysis tools on the
same trace: primarily that locale changes for printing must be local.
Tweaks the histogram tool's name to "Cache line histogram tool" to clearly
distinguish from a reuse distance histogram.