### PR TITLE
Relax burst_threads golden output threads-per-core

### DIFF
--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -3,7 +3,7 @@ pre-DR start
 pre-DR detach
 all done
 Cache simulation results:
-Core #0 \([1-3] thread\(s\)\)
+Core #0 \([0-4] thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*.
@@ -12,7 +12,7 @@ Core #0 \([1-3] thread\(s\)\)
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*.
 .*   Miss rate:                   *[0-9,\.]*%
-Core #1 \([0-2] thread\(s\)\)
+Core #1 \([0-4] thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*.
@@ -21,7 +21,7 @@ Core #1 \([0-2] thread\(s\)\)
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*.
 .*   Miss rate:                   *[0-9,\.]*%
-Core #2 \([0-2] thread\(s\)\)
+Core #2 \([0-4] thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*.
@@ -30,7 +30,7 @@ Core #2 \([0-2] thread\(s\)\)
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*.
 .*   Miss rate:                   *[0-9,\.]*%
-Core #3 \([0-2] thread\(s\)\)
+Core #3 \([0-4] thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*.


### PR DESCRIPTION
Relaxes the tool.drcacheoff.burst_threads test output to allow more
variation in thread scheduling on cores as seen on CDash:
http://dynamorio.org/CDash/testDetails.php?test=227131&build=20497