### PR TITLE
i#2161, i#2270: ignore alarms during attach and detach

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -2645,7 +2645,8 @@ dr_app_cleanup(void)
      */
     tr = thread_lookup(get_thread_id());
     if (tr != NULL && tr->dcontext != NULL) {
-        os_process_under_dynamorio(tr->dcontext);
+        os_process_under_dynamorio_initiate(tr->dcontext);
+        os_process_under_dynamorio_complete(tr->dcontext);
         dynamo_thread_under_dynamo(tr->dcontext);
     }
     return dynamorio_app_exit();
@@ -2764,7 +2765,7 @@ dynamorio_take_over_threads(dcontext_t *dcontext)
     bool found_threads;
     uint attempts = 0;
 
-    os_process_under_dynamorio(dcontext);
+    os_process_under_dynamorio_initiate(dcontext);
     /* XXX i#1305: we should suspend all the other threads for DR init to
      * satisfy the parts of the init process that assume there are no races.
      */
@@ -2774,6 +2775,7 @@ dynamorio_take_over_threads(dcontext_t *dcontext)
         if (found_threads && !bb_lock_start)
             bb_lock_start = true;
     } while (found_threads && attempts < MAX_TAKE_OVER_ATTEMPTS);
+    os_process_under_dynamorio_complete(dcontext);
 
     if (found_threads) {
         SYSLOG(SYSLOG_WARNING, INTERNAL_SYSLOG_WARNING,

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -64,7 +64,8 @@ void os_thread_exit(dcontext_t *dcontext, bool other_thread);
 void os_thread_under_dynamo(dcontext_t *dcontext);
 /* must only be called for the executing thread */
 void os_thread_not_under_dynamo(dcontext_t *dcontext);
-void os_process_under_dynamorio(dcontext_t *dcontext);
+void os_process_under_dynamorio_initiate(dcontext_t *dcontext);
+void os_process_under_dynamorio_complete(dcontext_t *dcontext);
 void os_process_not_under_dynamorio(dcontext_t *dcontext);
 
 bool os_take_over_all_unknown_threads(dcontext_t *dcontext);

--- a/core/synch.c
+++ b/core/synch.c
@@ -1965,6 +1965,9 @@ detach_on_permanent_stack(bool internal, bool do_cleanup)
     /* Release the APC init lock and let any threads waiting there go native */
     LOG(GLOBAL, LOG_ALL, 1, "Detach : Releasing init_apc_go_native_pause\n");
     init_apc_go_native_pause = false;
+#else
+    /* i#2270: we ignore alarm signals during detach to reduce races. */
+    signal_remove_alarm_handlers(my_dcontext);
 #endif
 
     /* perform exit tasks that require full thread data structs */

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -2539,12 +2539,20 @@ os_thread_not_under_dynamo(dcontext_t *dcontext)
 }
 
 void
-os_process_under_dynamorio(dcontext_t *dcontext)
+os_process_under_dynamorio_initiate(dcontext_t *dcontext)
 {
     LOG(GLOBAL, LOG_THREADS, 1, "process now under DR\n");
     /* We only support regular process-wide signal handlers for delayed takeover. */
-    signal_reinstate_handlers(dcontext);
+    /* i#2161: we ignore alarm signals during the attach process to avoid races. */
+    signal_reinstate_handlers(dcontext, true/*ignore alarm*/);
     hook_vsyscall(dcontext, false);
+}
+
+void
+os_process_under_dynamorio_complete(dcontext_t *dcontext)
+{
+    /* i#2161: only now do we un-ignore alarm signals. */
+    signal_reinstate_alarm_handlers(dcontext);
 }
 
 void

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -409,10 +409,7 @@ void
 signal_fork_init(dcontext_t *dcontext);
 
 void
-signal_remove_handlers(dcontext_t *dcontext);
-
-void
-signal_reinstate_handlers(dcontext_t *dcontext);
+signal_remove_alarm_handlers(dcontext_t *dcontext);
 
 bool
 set_itimer_callback(dcontext_t *dcontext, int which, uint millisec,

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -253,6 +253,9 @@ void signal_exit(void);
 void signal_thread_init(dcontext_t *dcontext);
 void signal_thread_exit(dcontext_t *dcontext, bool other_thread);
 bool is_thread_signal_info_initialized(dcontext_t *dcontext);
+void signal_remove_handlers(dcontext_t *dcontext);
+void signal_reinstate_handlers(dcontext_t *dcontext, bool ignore_alarm);
+void signal_reinstate_alarm_handlers(dcontext_t *dcontext);
 void handle_clone(dcontext_t *dcontext, uint flags);
 /* If returns false to skip the syscall, the result is in "result". */
 bool handle_sigaction(dcontext_t *dcontext, int sig,

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -1702,11 +1702,17 @@ os_thread_not_under_dynamo(dcontext_t *dcontext)
 }
 
 void
-os_process_under_dynamorio(dcontext_t *dcontext)
+os_process_under_dynamorio_initiate(dcontext_t *dcontext)
 {
     SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
     init_apc_go_native = false;
     SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
+}
+
+void
+os_process_under_dynamorio_complete(dcontext_t *dcontext)
+{
+    /* Nothing. */
 }
 
 void

--- a/suite/tests/api/static_signal.expect
+++ b/suite/tests/api/static_signal.expect
@@ -11,7 +11,7 @@ pre-raise SIGSEGV under DR
 Got SIGSEGV
 pre-DR stop
 Saw some bb events
-Saw 2 signal(s)
+Saw >2 signals
 Sending SIGUSR1 post-DR-stop
 Got SIGUSR1
 pre-raise SIGSEGV native


### PR DESCRIPTION
Sets the signal handler for the 3 alarm signals to SIG_IGN during attach
and detach, to reduce problems with races while we try to coordinate taking
over or sending native all of the app threads.

This is not a panacea, as timer_create can send out any signal, not just
the 3 classic alarm signals, on timer expiration.  Plus, non-timer-related
signals could arrive during attach or detach.  However, this will help with
the most typical cases.

Adds an itimer to the api.static_signal test, though it is not easy to
reproduce these problems in small applications.

I'm considering this to fix the filed issues despite the above-mentioned
remaining corner cases as I'm considering those to be pathological:

Fixes #2161
Fixes #2270