### PR TITLE
i#1569 AArch64: Print instruction if encoding fails.

### DIFF
--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -46,7 +46,6 @@
 
 #include "codec.h"
 
-#define ENCFAIL (uint)0 /* a value that is not a valid instruction */
 
 /* Decode immediate argument of bitwise operations.
  * Returns zero if the encoding is invalid.
@@ -2592,7 +2591,5 @@ uint encode_common(byte *pc, instr_t *i)
         ASSERT(instr_num_srcs(i) >= 1 && opnd_is_immed_int(instr_get_src(i, 0)));
         return opnd_get_immed_int(instr_get_src(i, 0));
     }
-    /* We were unable to encode this instruction. */
-    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
     return enc;
 }

--- a/core/arch/aarch64/codec.h
+++ b/core/arch/aarch64/codec.h
@@ -33,6 +33,8 @@
 #ifndef CODEC_H
 #define CODEC_H 1
 
+#define ENCFAIL (uint)0 /* a value that is not a valid instruction */
+
 byte *decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr);
 uint encode_common(byte *pc, instr_t *i);
 

--- a/core/arch/aarch64/encode.c
+++ b/core/arch/aarch64/encode.c
@@ -160,6 +160,11 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
     CLIENT_ASSERT(instr_operands_valid(instr), "instr_encode error: operands invalid");
 
     *(uint *)copy_pc = encode_common(final_pc, instr);
+    if (*(uint *)copy_pc == ENCFAIL) {
+        IF_DEBUG(instr_disassemble(dcontext, instr, STDERR));
+        /* We were unable to encode this instruction. */
+        ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
+    }
     return copy_pc + 4;
 }
 

--- a/core/arch/aarch64/encode.c
+++ b/core/arch/aarch64/encode.c
@@ -161,8 +161,14 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
 
     *(uint *)copy_pc = encode_common(final_pc, instr);
     if (*(uint *)copy_pc == ENCFAIL) {
-        IF_DEBUG(instr_disassemble(dcontext, instr, STDERR));
         /* We were unable to encode this instruction. */
+        IF_DEBUG({
+            char disas_instr[MAX_INSTR_DIS_SZ];
+            instr_disassemble_to_buffer(dcontext, instr, disas_instr,
+                                        MAX_INSTR_DIS_SZ);
+            SYSLOG_INTERNAL_ERROR("Internal Error: Failed to encode instruction:"
+                                  " '%s'\n", disas_instr);
+        });
         ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
     }
     return copy_pc + 4;


### PR DESCRIPTION
As the parser for AArch64 is not complete yet dumping instructions that could
not be encoded makes it easier to diagnose encoding problems.