### PR TITLE
i#2006 generalize drcachesime: add two options for asynchronous trace…

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -42,6 +42,17 @@ droption_t<bool> op_offline
  "If this option is enabled, trace data is instead written to files in -outdir "
  "for later offline analysis.  No simulator is executed.");
 
+droption_t<bytesize_t> op_num_threads
+(DROPTION_SCOPE_ALL, "num_threads", 0, "Number of threads for writing traces",
+ "For the offline analysis mode (when -offline is requested), specifies the number "
+ "of sideline threads are used to write traces file out.  "
+ "0 means synchronized write without any sideline threads.");
+
+droption_t<unsigned int> op_queue_size
+(DROPTION_SCOPE_ALL, "queue_size", 4000, "The queue size for ",
+ "For the offline analysis mode (when -offline is requested), specifies the size "
+ "of the queue for batching trace data to be written out by sideline threads.");
+
 droption_t<std::string> op_ipc_name
 (DROPTION_SCOPE_ALL, "ipc_name", "drcachesimpipe", "Base name of named pipe",
  "For online tracing and simulation (the default, unless -offline is requested), "

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -48,6 +48,8 @@
 #include "droption.h"
 
 extern droption_t<bool> op_offline;
+extern droption_t<bytesize_t> op_num_threads;
+extern droption_t<unsigned int> op_queue_size;
 extern droption_t<std::string> op_ipc_name;
 extern droption_t<std::string> op_outdir;
 extern droption_t<std::string> op_infile;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2462,7 +2462,7 @@ if (CLIENT_INTERFACE)
       macro (torunonly_drcacheoff testname exetgt)
         torunonly_ci(tool.drcacheoff.${testname} ${exetgt} drcachesim
           "offline-${testname}.c" # for templatex basename
-          "-offline" "" "")
+          "-offline -num_threads 0" "" "")
         set(tool.drcacheoff.${testname}_toolname "drcachesim")
         set(tool.drcacheoff.${testname}_basedir
           "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")


### PR DESCRIPTION
Adds two options -num_threads and -queue_size to the tracer for asynchronous
trace write by the sideline threads.
This CL only adds the two options, and the real implementation is to be added.