### PR TITLE
i#2161 alarm races: relax flaky test

### DIFF
--- a/suite/tests/api/static_signal.c
+++ b/suite/tests/api/static_signal.c
@@ -107,7 +107,14 @@ static void
 event_exit(void)
 {
     dr_fprintf(STDERR, "Saw %s bb events\n", num_bbs > 0 ? "some" : "no");
-    dr_fprintf(STDERR, "Saw %s signals\n", num_signals > 2 ? ">2" : "<=2");
+    /* Unfortunately we have no synch to guarantee we see some alarm
+     * signals.
+     * FIXME: once we have i#2311 and can ensure alarms only arrive in
+     * the 2nd thread, we can use a cond var from the signal handler and
+     * ensure we see some.  For now we just hope to occasionally test some
+     * races with alarms.
+     */
+    dr_fprintf(STDERR, "Saw %s signals\n", num_signals >= 2 ? ">=2" : "<2");
 }
 
 DR_EXPORT void

--- a/suite/tests/api/static_signal.expect
+++ b/suite/tests/api/static_signal.expect
@@ -11,7 +11,7 @@ pre-raise SIGSEGV under DR
 Got SIGSEGV
 pre-DR stop
 Saw some bb events
-Saw >2 signals
+Saw >=2 signals
 Sending SIGUSR1 post-DR-stop
 Got SIGUSR1
 pre-raise SIGSEGV native


### PR DESCRIPTION
Relaxes the static_signal test to pass even if no alarms are seen, to avoid
flakiness.  To properly synch with an alarm I wanted to use a mask but the
i#2311 bug prevents that: once i#2311 is fixed we can improve the test and
ensure an alarm is seen.