### PR TITLE
i#1937: dynamically size signal frame xstate area

### DIFF
--- a/core/heap.h
+++ b/core/heap.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -259,6 +259,8 @@ void global_unprotected_heap_free(void *p, size_t size HEAPACCT(which_heap_t whi
 /* special heap of same-sized blocks that avoids global locks */
 void *special_heap_init(uint block_size, bool use_lock, bool executable,
                         bool persistent);
+void *special_heap_init_aligned(uint block_size, uint alignment, bool use_lock,
+                                bool executable, bool persistent);
 void special_heap_exit(void *special);
 void *special_heap_alloc(void *special);
 void *special_heap_calloc(void *special, uint num);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -3298,7 +3298,7 @@ os_thread_yield()
 #endif
 }
 
-static bool
+bool
 thread_signal(process_id_t pid, thread_id_t tid, int signum)
 {
 #ifdef MACOS

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -318,6 +318,9 @@ signal_set_mask(dcontext_t *dcontext, kernel_sigset_t *sigset);
 void
 os_terminate_via_signal(dcontext_t *dcontext, terminate_flags_t flags, int sig);
 
+bool
+thread_signal(process_id_t pid, thread_id_t tid, int signum);
+
 void start_itimer(dcontext_t *dcontext);
 void stop_itimer(dcontext_t *dcontext);
 

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -462,7 +462,7 @@ signal_thread_init(dcontext_t *dcontext)
         signal_frame_extra_size(true)
         /* sigpending_t has xstate inside it already */
         IF_LINUX(IF_X86(- sizeof(struct _xstate)));
-    IF_X86(ASSERT(ALIGNED(pend_unit_size, AVX_ALIGNMENT)));
+    IF_LINUX(IF_X86(ASSERT(ALIGNED(pend_unit_size, AVX_ALIGNMENT))));
 
     /* all fields want to be initialized to 0 */
     memset(info, 0, sizeof(thread_sig_info_t));

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -152,34 +152,6 @@ sig_is_alarm_signal(int sig)
 #define APP_HAS_SIGSTACK(info) \
   ((info)->app_sigstack.ss_sp != NULL && (info)->app_sigstack.ss_flags != SS_DISABLE)
 
-/* Extra space needed to put the signal frame on the app stack.  We include the
- * size of the extra padding potentially needed to align these structs.  We
- * assume the stack pointer is 4-aligned already, so we over estimate padding
- * size by the alignment minus 4.
- */
-#ifdef LINUX
-/* An extra 4 for trailing FP_XSTATE_MAGIC2 */
-#  define AVX_FRAME_EXTRA (sizeof(struct _xstate) + AVX_ALIGNMENT - 4 + 4)
-#  define FPSTATE_FRAME_EXTRA (sizeof(struct _fpstate) + FPSTATE_ALIGNMENT - 4)
-#  define XSTATE_FRAME_EXTRA (YMM_ENABLED() ? AVX_FRAME_EXTRA : FPSTATE_FRAME_EXTRA)
-
-#  define AVX_DATA_SIZE (sizeof(struct _xstate) + 4)
-#  define FPSTATE_DATA_SIZE (sizeof(struct _fpstate))
-#  define XSTATE_DATA_SIZE (YMM_ENABLED() ? AVX_DATA_SIZE : FPSTATE_DATA_SIZE)
-
-#elif defined(MACOS)
-/* Currently assuming __darwin_mcontext_avx{32,64} is always used in the
- * frame.  If instead __darwin_mcontext{32,64} is used (w/ just float and no AVX)
- * on, say, older machines or OSX versions, we'll have to revisit this.
- */
-#  define AVX_FRAME_EXTRA 0
-#  define FPSTATE_FRAME_EXTRA 0
-#  define XSTATE_FRAME_EXTRA 0
-#  define AVX_DATA_SIZE 0
-#  define FPSTATE_DATA_SIZE 0
-#  define XSTATE_DATA_SIZE 0
-#endif
-
 /* If we only intercept a few signals, we leave whether un-intercepted signals
  * are blocked unchanged and stored in the kernel.  If we intercept all (not
  * quite yet: PR 297033, hence the need for this macro) we emulate the mask for
@@ -296,7 +268,7 @@ dump_sigset(dcontext_t *dcontext, kernel_sigset_t *set);
 static bool
 is_sys_kill(dcontext_t *dcontext, byte *pc, byte *xsp, siginfo_t *info);
 
-static inline int
+int
 sigaction_syscall(int sig, kernel_sigaction_t *act, kernel_sigaction_t *oact)
 {
 #if defined(X64) && !defined(VMX86_SERVER) && defined(LINUX)
@@ -432,7 +404,7 @@ os_itimers_thread_shared(void)
 }
 
 void
-signal_init()
+signal_init(void)
 {
     IF_LINUX(IF_X86_64(ASSERT(ALIGNED(offsetof(sigpending_t, xstate), AVX_ALIGNMENT))));
     IF_MACOS(ASSERT(sizeof(kernel_sigset_t) == sizeof(__darwin_sigset_t)));
@@ -453,6 +425,7 @@ signal_init()
     unblock_all_signals(&init_sigmask);
 
     IF_LINUX(signalfd_init());
+    signal_arch_init();
 }
 
 void
@@ -484,6 +457,12 @@ signal_thread_init(dcontext_t *dcontext)
 {
     thread_sig_info_t *info = HEAP_TYPE_ALLOC(dcontext, thread_sig_info_t,
                                               ACCT_OTHER, PROTECTED);
+    size_t pend_unit_size = sizeof(sigpending_t) +
+        /* include alignment for xsave on xstate */
+        signal_frame_extra_size(true)
+        /* sigpending_t has xstate inside it already */
+        IF_LINUX(IF_X86(- sizeof(struct _xstate)));
+    IF_X86(ASSERT(ALIGNED(pend_unit_size, AVX_ALIGNMENT)));
 
     /* all fields want to be initialized to 0 */
     memset(info, 0, sizeof(thread_sig_info_t));
@@ -496,10 +475,12 @@ signal_thread_init(dcontext_t *dcontext)
      * but if we need a new unit that will grab a lock: we try to
      * avoid that by limiting the # of pending alarm signals (PR 596768).
      */
-    info->sigheap = special_heap_init(sizeof(sigpending_t),
-                                      false /* cannot have any locking */,
-                                      false /* -x */,
-                                      true /* persistent */);
+    info->sigheap =
+        special_heap_init_aligned(pend_unit_size,
+                                  IF_X86_ELSE(AVX_ALIGNMENT, 0),
+                                  false /* cannot have any locking */,
+                                  false /* -x */,
+                                  true /* persistent */);
 
 #ifdef HAVE_SIGALTSTACK
     /* set up alternate stack
@@ -1154,6 +1135,23 @@ sigsegv_handler_is_ours(void)
 }
 #endif /* DEBUG */
 
+#if defined(X86) && defined(LINUX)
+static byte *
+get_xstate_buffer(dcontext_t *dcontext)
+{
+    /* See thread_sig_info_t.xstate_buf comments for why this is in TLS. */
+    thread_sig_info_t *info = (thread_sig_info_t *) dcontext->signal_field;
+    if (info->xstate_buf == NULL) {
+        info->xstate_alloc =
+            heap_alloc(dcontext, signal_frame_extra_size(true) HEAPACCT(ACCT_OTHER));
+        info->xstate_buf = (byte *) ALIGN_FORWARD(info->xstate_alloc, XSTATE_ALIGNMENT);
+        ASSERT(info->xstate_alloc + signal_frame_extra_size(true) >=
+               info->xstate_buf + signal_frame_extra_size(false));
+    }
+    return info->xstate_buf;
+}
+#endif
+
 void
 signal_thread_exit(dcontext_t *dcontext, bool other_thread)
 {
@@ -1176,6 +1174,13 @@ signal_thread_exit(dcontext_t *dcontext, bool other_thread)
         for (i = 0; i < NUM_ITIMERS; i++)
             set_actual_itimer(dcontext, i, info, false/*disable*/);
     }
+
+#if defined(X86) && defined(LINUX)
+    if (info->xstate_alloc != NULL) {
+        heap_free(dcontext, info->xstate_alloc, signal_frame_extra_size(true)
+                  HEAPACCT(ACCT_OTHER));
+    }
+#endif
 
     /* FIXME: w/ shared handlers, if parent (the owner here) dies,
      * can children keep living w/ a copy of the handlers?
@@ -1291,13 +1296,13 @@ signal_thread_exit(dcontext_t *dcontext, bool other_thread)
 #endif
 }
 
-static void
-set_our_handler_sigact(kernel_sigaction_t *act, int sig)
+void
+set_handler_sigact(kernel_sigaction_t *act, int sig, handler_t handler)
 {
-    act->handler = (handler_t) master_signal_handler;
+    act->handler = handler;
 #ifdef MACOS
     /* This is the real target */
-    act->tramp = (tramp_t) master_signal_handler;
+    act->tramp = (tramp_t) handler;
 #endif
 
     act->flags = SA_SIGINFO; /* send 3 args to handler */
@@ -1331,6 +1336,12 @@ set_our_handler_sigact(kernel_sigaction_t *act, int sig)
     IF_DEBUG(uint32 *mask_sig = (uint32*)&act->mask.sig[0]);
     LOG(THREAD_GET, LOG_ASYNCH, 3,
         "mask for our handler is "PFX" "PFX"\n", mask_sig[0], mask_sig[1]);
+}
+
+static void
+set_our_handler_sigact(kernel_sigaction_t *act, int sig)
+{
+    set_handler_sigact(act, sig, (handler_t) master_signal_handler);
 }
 
 static void
@@ -2433,13 +2444,8 @@ thread_set_self_context(void *cxt)
     memset(&frame, 0, sizeof(frame));
 #ifdef LINUX
 # ifdef X86
-    /* We need room for full xstate if nec (this is x86=944, x64=832 bytes).
-     * A real signal frame would be var-sized but we don't want to dynamically
-     * allocate, and only the kernel looks at this, so no risk of some
-     * app seeing a weird frame size.
-     */
-    struct _xstate __attribute__ ((aligned (AVX_ALIGNMENT))) xstate;
-    frame.uc.uc_mcontext.fpstate = &xstate.fpstate;
+    byte *xstate = get_xstate_buffer(dcontext);
+    frame.uc.uc_mcontext.fpstate = &((struct _xstate *)xstate)->fpstate;
 # endif /* X86 */
     frame.uc.uc_mcontext = *sc;
 #endif
@@ -2698,7 +2704,7 @@ get_sigstack_frame_ptr(dcontext_t *dcontext, int sig, sigframe_rt_t *frame)
          * kernel does, but we're not tracking app actions to know whether
          * we can skip lazy fpstate on the delay
          */
-        sp -= XSTATE_FRAME_EXTRA;
+        sp -= signal_frame_extra_size(true);
     } else {
         if (sc->fpstate != NULL) {
             /* The kernel doesn't seem to lazily include avx, so we don't either,
@@ -2706,11 +2712,12 @@ get_sigstack_frame_ptr(dcontext_t *dcontext, int sig, sigframe_rt_t *frame)
              * fpstate pointer is non-NULL, then we assume there's space for
              * full xstate
              */
-            sp -= XSTATE_FRAME_EXTRA;
+            sp -= signal_frame_extra_size(true);
             DOCHECK(1, {
                 if (YMM_ENABLED()) {
                     ASSERT_CURIOSITY(sc->fpstate->sw_reserved.magic1 == FP_XSTATE_MAGIC1);
-                    ASSERT(sc->fpstate->sw_reserved.extended_size <= XSTATE_FRAME_EXTRA);
+                    ASSERT(sc->fpstate->sw_reserved.extended_size <=
+                           signal_frame_extra_size(true));
                 }
             });
         }
@@ -2743,7 +2750,7 @@ convert_frame_to_nonrt(dcontext_t *dcontext, int sig, sigframe_rt_t *f_old,
         /* up to caller to include enough space for fpstate at end */
         byte *new_fpstate = (byte *)
             ALIGN_FORWARD(((byte *)f_new) + sizeof(*f_new), XSTATE_ALIGNMENT);
-        memcpy(new_fpstate, sc_old->fpstate, XSTATE_DATA_SIZE);
+        memcpy(new_fpstate, sc_old->fpstate, signal_frame_extra_size(false));
         f_new->sc.fpstate = (struct _fpstate *) new_fpstate;
     }
     f_new->sc.oldmask = f_old->uc.uc_sigmask.sig[0];
@@ -2768,10 +2775,16 @@ convert_frame_to_nonrt_partial(dcontext_t *dcontext, int sig, sigframe_rt_t *f_o
                                sigframe_plain_t *f_new, size_t size)
 {
 # ifdef X86
-    char frame_plus_xstate[sizeof(sigframe_plain_t) + AVX_FRAME_EXTRA];
-    sigframe_plain_t *f_plain = (sigframe_plain_t *) frame_plus_xstate;
+    /* We create a full-size buffer for conversion and then copy the partial amount. */
+    byte *frame_and_xstate =
+        heap_alloc(dcontext, sizeof(sigframe_plain_t) + signal_frame_extra_size(true)
+                   HEAPACCT(ACCT_OTHER));
+    sigframe_plain_t *f_plain = (sigframe_plain_t *) frame_and_xstate;
+    ASSERT_NOT_TESTED(); /* XXX: we have no test of this for change to heap_alloc */
     convert_frame_to_nonrt(dcontext, sig, f_old, f_plain);
     memcpy(f_new, f_plain, size);
+    heap_free(dcontext, frame_and_xstate, sizeof(sigframe_plain_t) +
+              signal_frame_extra_size(true) HEAPACCT(ACCT_OTHER));
 # elif defined(ARM)
     /* FIXME i#1551: NYI on ARM */
     ASSERT_NOT_IMPLEMENTED(false);
@@ -2836,7 +2849,7 @@ fixup_rtframe_pointers(dcontext_t *dcontext, int sig,
         uint frame_size = get_app_frame_size(info, sig);
         byte *frame_end = ((byte *)f_new) + frame_size;
         byte *tgt = (byte *) ALIGN_FORWARD(frame_end, XSTATE_ALIGNMENT);
-        ASSERT(tgt - frame_end <= XSTATE_FRAME_EXTRA);
+        ASSERT(tgt - frame_end <= signal_frame_extra_size(true));
         memcpy(tgt, f_old->uc.uc_mcontext.fpstate, sizeof(struct _fpstate));
         f_new->uc.uc_mcontext.fpstate = (struct _fpstate *) tgt;
         if (YMM_ENABLED()) {
@@ -2918,7 +2931,7 @@ copy_frame_to_stack(dcontext_t *dcontext, int sig, sigframe_rt_t *frame, byte *s
     uint size = frame_size;
 #if defined(LINUX) && defined(X86)
     sigcontext_t *sc = get_sigcontext_from_rt_frame(frame);
-    size += (sc->fpstate == NULL ? 0 : XSTATE_FRAME_EXTRA);
+    size += (sc->fpstate == NULL ? 0 : signal_frame_extra_size(true));
 #endif /* LINUX && X86 */
 
     LOG(THREAD, LOG_ASYNCH, 3, "copy_frame_to_stack: rt=%d, src="PFX", sp="PFX"\n",
@@ -3066,7 +3079,7 @@ copy_frame_to_pending(dcontext_t *dcontext, int sig, sigframe_rt_t *frame
     if (frame->uc.uc_mcontext.fpstate != NULL) {
         memcpy(&info->sigpending[sig]->xstate, frame->uc.uc_mcontext.fpstate,
                /* XXX: assuming full xstate if avx is enabled */
-               XSTATE_DATA_SIZE);
+               signal_frame_extra_size(false));
     }
     /* we must set the pointer now so that later save_fpstate, etc. work */
     dst->uc.uc_mcontext.fpstate = (struct _fpstate *) &info->sigpending[sig]->xstate;
@@ -4339,7 +4352,7 @@ sig_should_swap_stack(struct clone_and_swap_args *args, kernel_ucontext_t *ucxt)
          */
         args->stack = dcontext->dstack;
         /* leave room for fpstate */
-        args->stack -= XSTATE_FRAME_EXTRA;
+        args->stack -= signal_frame_extra_size(true);
         args->stack = (byte *) ALIGN_BACKWARD(args->stack, XSTATE_ALIGNMENT);
         args->tos = (byte *) sc->SC_XSP;
         return true;
@@ -5812,8 +5825,8 @@ os_forge_exception(app_pc target_pc, dr_exception_type_t type)
 #if defined(LINUX) && defined(X86)
     thread_sig_info_t *info = (thread_sig_info_t *) dcontext->signal_field;
 #endif
-    char frame_plus_xstate[sizeof(sigframe_rt_t)IF_X86( + AVX_FRAME_EXTRA)];
-    sigframe_rt_t *frame = (sigframe_rt_t *) frame_plus_xstate;
+    char frame_no_xstate[sizeof(sigframe_rt_t)];
+    sigframe_rt_t *frame = (sigframe_rt_t *) frame_no_xstate;
     int sig;
     where_am_i_t cur_whereami = dcontext->whereami;
     kernel_ucontext_t *uc = get_ucontext_from_rt_frame(frame);
@@ -5838,9 +5851,9 @@ os_forge_exception(app_pc target_pc, dr_exception_type_t type)
     frame->puc = (void *) &frame->uc;
 #endif
 #if defined(LINUX) && defined(X86)
-    sc->fpstate = (struct _fpstate *)
-        ALIGN_FORWARD(frame_plus_xstate + sizeof(*frame), XSTATE_ALIGNMENT);
-#endif /* LINUX && X86 */
+    /* We use a TLS buffer to avoid too much stack space here. */
+    sc->fpstate = (struct _fpstate *) get_xstate_buffer(dcontext);
+#endif
     mcontext_to_ucontext(uc, get_mcontext(dcontext));
     sc->SC_XIP = (reg_t) target_pc;
     /* We'll fill in fpstate at delivery time.

--- a/core/unix/signal_linux_aarch64.c
+++ b/core/unix/signal_linux_aarch64.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -90,4 +91,16 @@ mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
     memcpy(&fpc->vregs, &mc->simd, sizeof(fpc->vregs));
     next->magic = 0;
     next->size = 0;
+}
+
+size_t
+signal_frame_extra_size(bool include_alignment)
+{
+    return 0;
+}
+
+void
+signal_arch_init(void)
+{
+    /* Nothing. */
 }

--- a/core/unix/signal_linux_arm.c
+++ b/core/unix/signal_linux_arm.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -99,4 +99,16 @@ mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
     vfp->magic = VFP_MAGIC;
     vfp->size = sizeof(struct vfp_sigframe);
     memcpy(&vfp->ufp.fpregs[0], &mc->simd[0], sizeof(vfp->ufp.fpregs));
+}
+
+size_t
+signal_frame_extra_size(bool include_alignment)
+{
+    return 0;
+}
+
+void
+signal_arch_init(void)
+{
+    /* Nothing. */
 }

--- a/core/unix/signal_linux_x86.c
+++ b/core/unix/signal_linux_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -50,6 +50,12 @@
 #endif
 
 #include "arch.h"
+
+/* We have to dynamically size struct _xstate to account for kernel changes over time. */
+static size_t xstate_size;
+static bool xstate_has_extra_fields;
+
+#define XSTATE_QUERY_SIG SIGILL
 
 /**** floating point support ********************************************/
 
@@ -182,12 +188,28 @@ convert_fxsave_to_fpstate(struct _fpstate *fpstate,
 static void
 save_xmm(dcontext_t *dcontext, sigframe_rt_t *frame)
 {
-    /* see comments at call site: can't just do xsave */
+    /* The app's xmm registers may be saved away in priv_mcontext_t, in which
+     * case we need to copy those values instead of using what was in
+     * the physical xmm registers.
+     * Because of this, we can't just execute "xsave".  We still need to
+     * execute xgetbv though.  Xsave is very expensive so not worth doing
+     * when xgetbv is all we need, so we avoid it unless there are extra fields.
+     */
     int i;
     sigcontext_t *sc = get_sigcontext_from_rt_frame(frame);
     struct _xstate *xstate = (struct _xstate *) sc->fpstate;
     if (!preserve_xmm_caller_saved())
         return;
+    if (xstate_has_extra_fields) {
+        /* Fill in the extra fields first and then clobber xmm+ymm below.
+         * We assume that DR's code does not touch this extra state.
+         */
+        ASSERT(ALIGNED(xstate, AVX_ALIGNMENT));
+        /* A processor w/o xsave but w/ extra xstate fields should not exist. */
+        ASSERT(proc_has_feature(FEATURE_XSAVE));
+        /* XXX i#1312: use xsaveopt if available (need to add FEATURE_XSAVEOPT) */
+        asm volatile(IF_X64_ELSE("xsave64","xsave") " %0" : "=m" (*xstate));
+    }
     if (YMM_ENABLED()) {
         /* all ymm regs are in our mcontext.  the only other thing
          * in xstate is the xgetbv.
@@ -273,15 +295,6 @@ save_fpstate(dcontext_t *dcontext, sigframe_rt_t *frame)
         memcpy(sc->fpstate, &temp->fsave, sizeof(struct i387_fsave_struct));
     }
 
-    /* the app's xmm registers may be saved away in priv_mcontext_t, in which
-     * case we need to copy those values instead of using what was in
-     * the physical xmm registers.
-     * because of this, we can't just execute "xsave".  we still need to
-     * execute xgetbv though.  xsave is very expensive so not worth doing
-     * when xgetbv is all we need; if in the future they add status words,
-     * etc. we can't get any other way then we'll have to do it, but best
-     * to avoid for now.
-     */
     save_xmm(dcontext, frame);
 }
 
@@ -469,5 +482,65 @@ mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
                 }
             }
         }
+    }
+}
+
+size_t
+signal_frame_extra_size(bool include_alignment)
+{
+    /* Extra space needed to put the signal frame on the app stack.  We include the
+     * size of the extra padding potentially needed to align these structs.  We
+     * assume the stack pointer is 4-aligned already, so we over estimate padding
+     * size by the alignment minus 4.
+     */
+    size_t size = YMM_ENABLED() ? xstate_size : sizeof(struct _fpstate);
+    if (include_alignment)
+        size += (YMM_ENABLED() ? AVX_ALIGNMENT : FPSTATE_ALIGNMENT) - 4;
+    return size;
+}
+
+/* To handle varying xstate sizes as kernels add more state over time, we query
+ * the size by sending ourselves a signal at init time and reading what the
+ * kernel saved.  We assume that DR's own code does not touch this state, so
+ * that we can update it to the app's latest at delivery time by executing
+ * xsave in save_xmm().
+ *
+ * XXX: If the kernel ever does lazy state saving for any part of the new state
+ * and that affects the size, like it does with fpstate, this initial signal
+ * state may not match later state.
+ */
+static void
+xstate_query_signal_handler(int sig, siginfo_t *siginfo, kernel_ucontext_t *ucxt)
+{
+    ASSERT_CURIOSITY(sig == XSTATE_QUERY_SIG);
+    if (sig == XSTATE_QUERY_SIG) {
+        sigcontext_t *sc = SIGCXT_FROM_UCXT(ucxt);
+        if (YMM_ENABLED()) {
+            ASSERT_CURIOSITY(sc->fpstate->sw_reserved.magic1 == FP_XSTATE_MAGIC1);
+            LOG(GLOBAL, LOG_ASYNCH, 1, "orig xstate size = " SZFMT"\n", xstate_size);
+            if (sc->fpstate->sw_reserved.extended_size != xstate_size) {
+                xstate_size = sc->fpstate->sw_reserved.extended_size;
+                xstate_has_extra_fields = true;
+            }
+            LOG(GLOBAL, LOG_ASYNCH, 1, "new xstate size = " SZFMT"\n", xstate_size);
+        }
+    }
+}
+
+void
+signal_arch_init(void)
+{
+    xstate_size = sizeof(struct _xstate) + 4 /* trailing FP_XSTATE_MAGIC2 */;
+    if (YMM_ENABLED()) {
+        kernel_sigaction_t act, oldact;
+        int rc;
+        memset(&act, 0, sizeof(act));
+        set_handler_sigact(&act, XSTATE_QUERY_SIG,
+                           (handler_t) xstate_query_signal_handler);
+        rc = sigaction_syscall(XSTATE_QUERY_SIG, &act, &oldact);
+        ASSERT(rc == 0);
+        thread_signal(get_process_id(), get_sys_thread_id(), XSTATE_QUERY_SIG);
+        rc = sigaction_syscall(XSTATE_QUERY_SIG, &oldact, NULL);
+        ASSERT(rc == 0);
     }
 }

--- a/core/unix/signal_macos.c
+++ b/core/unix/signal_macos.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2013-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -267,4 +267,20 @@ send_nudge_signal(process_id_t pid, uint action_mask,
 {
     ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1286: MacOS nudges NYI */
     return false;
+}
+
+size_t
+signal_frame_extra_size(bool include_alignment)
+{
+    /* Currently assuming __darwin_mcontext_avx{32,64} is always used in the
+     * frame.  If instead __darwin_mcontext{32,64} is used (w/ just float and no AVX)
+     * on, say, older machines or OSX versions, we'll have to revisit this.
+     */
+    return 0;
+}
+
+void
+signal_arch_init(void)
+{
+    /* Nothing. */
 }


### PR DESCRIPTION
Adds dynamic sizing of the xstate area in Linux signal frames to handle
forward-going processor extensions.

Sends a signal at init time to obtain the size of the xstate area.  If it
is larger than the known size, adds an OP_xsave operation when updating the
state of a delivered signal.  This is expensive, which is why we avoided it
before.  Using OP_xsaveopt is future work once we have FEATURE_XSAVEOPT
(part of i#1312).

Adjusts the pending signal heap allocations to be aligned properly for an
in-place OP_xsave.

Several stack-allocated xstate structures no longer easily fit on the stack
and are changed to two different kinds of heap buffers: one in TLS for uses
that cannot easily free it locally (thread_set_self_context() and
os_forge_exception()), and one on the regular heap
(convert_frame_to_nonrt_partial()).  Unfortunately I was only able to
easily test os_forge_exception().  Our test suite is missing test paths for
the others.

Fixes #1937