### PR TITLE
i#2155: managing with direction flag set in sandboxing check

### DIFF
--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -3858,9 +3858,10 @@ sandbox_top_of_bb(dcontext_t *dcontext, instrlist_t *ilist,
                                  OPND_CREATE_INTPTR(end_pc - (start_pc + 1))));
         PRE(ilist, instr,
             INSTR_CREATE_jcc(dcontext, OP_jge, opnd_create_instr(forward)));
-        /*
-         * i#2155: We start at end_pc - 1 the comparison.
+        /* i#2155: We start at end_pc - 1 the comparison.
          * Current basic block is [start_pc:end_pc[ = [start_pc:end_pc-1].
+         * This means that end_pc is not included in the basic block.
+         * Hence it must not be compared here.
          */
         PRE(ilist, instr,
             INSTR_CREATE_mov_imm(dcontext, opnd_create_reg(REG_XDI),

--- a/suite/tests/security-common/selfmod.c
+++ b/suite/tests/security-common/selfmod.c
@@ -114,6 +114,9 @@ sandbox_illegal_instr(int i);
 void
 sandbox_cti_tgt(void);
 
+void
+sandbox_direction_flag(void);
+
 /* These *_no_ilt variants of the prototypes avoid indirection through the
  * Incremental Linking Table (ILT).  With inremental linking on Windows, all
  * functions are directed through a jump table at the beginning of .text.  Those
@@ -130,6 +133,7 @@ void sandbox_cross_page_no_ilt(void);
 void last_byte_jmp_no_ilt(void);
 void sandbox_fault_no_ilt(void);
 void sandbox_illegal_no_ilt(void);
+void sandbox_direction_flag_no_ilt(void);
 
 #ifdef X64
 /* Reduced from V8, which uses x64 absolute addresses in code which ends up
@@ -273,6 +277,15 @@ test_sandbox_cti_tgt(void)
     print("end selfmod loop test\n");
 }
 
+static void
+test_sandbox_direction_flag(void)
+{
+    /* i#2155: test sandboxing with direction flag set */
+    protect_mem(sandbox_cti_tgt, 1024, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
+    sandbox_direction_flag();
+    print("end selfmod direction flag test\n");
+}
+
 int
 main(void)
 {
@@ -298,6 +311,8 @@ main(void)
     test_sandbox_fault();
 
     test_sandbox_cti_tgt();
+
+    test_sandbox_direction_flag();
     return 0;
 }
 
@@ -543,6 +558,27 @@ loop_orig_target3:
         END_FUNC(FUNCNAME)
 #undef FUNCNAME
 
+
+#define FUNCNAME sandbox_direction_flag
+        DECLARE_FUNC(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+DECLARE_GLOBAL(sandbox_direction_flag_no_ilt)
+ADDRTAKEN_LABEL(sandbox_direction_flag_no_ilt:)
+        mov      REG_XAX, HEX(1)
+        lea      REG_XDX, SYMREF(direction_flag_immediate_addr_plus_four - 4)
+        mov      DWORD [REG_XDX], eax        /* selfmod write */
+        mov      REG_XDX, HEX(0)             /* mov_imm to modify */
+ADDRTAKEN_LABEL(direction_flag_immediate_addr_plus_four:)
+
+        std                                  /* set direction flag */
+        jmp      direction_flag_afterstd     /* jump begin a new basic block */
+
+direction_flag_afterstd:
+        nop                                  /* an unmodified basic block */
+        cld                                  /* clearing direction flag */
+        ret
+END_FUNC(FUNCNAME)
+#undef FUNCNAME
 
 END_FILE
 

--- a/suite/tests/security-common/selfmod.c
+++ b/suite/tests/security-common/selfmod.c
@@ -559,6 +559,11 @@ loop_orig_target3:
 #undef FUNCNAME
 
 
+/* First we do a self modification to have basic blocks in sandboxing mode.
+ * Then we set the direction flag.
+ * Then we enter a new basic block.
+ * Hence we test sandboxing code with direction flag set.
+ */
 #define FUNCNAME sandbox_direction_flag
         DECLARE_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)

--- a/suite/tests/security-common/selfmod.template
+++ b/suite/tests/security-common/selfmod.template
@@ -48,3 +48,4 @@ Illegal instruction
 fault bytes are 0f 0b preceded by c6 41 fb 05
 end fault test
 end selfmod loop test
+end selfmod direction flag test


### PR DESCRIPTION
Fixes an off by one in the comparison to check if a basic block was modified.

Fixes i#2155