### PR TITLE
i#1621 AArch64 cc opts: Implement out-of-line calls.

### DIFF
--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -288,7 +288,7 @@ insert_save_or_restore_registers(dcontext_t *dcontext, instrlist_t *ilist, instr
      */
     if (reg1 != UINT_MAX) {
         opnd_t mem = create_base_disp_for_save_restore(base_reg, first_reg, reg1,
-                                                       false /* is_single_reg */,
+                                                       true /* is_single_reg */,
                                                        is_gpr);
         if (save)
             new_instr = INSTR_CREATE_str(dcontext, mem, opnd_create_reg(first_reg + reg1));

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -945,11 +945,12 @@ insert_out_of_line_context_switch(dcontext_t *dcontext, instrlist_t *ilist,
                              opnd_create_reg(DR_REG_X30)));
     }
 
+    insert_mov_immed_ptrsz(dcontext,
+                           (long) (save ? get_clean_call_save(dcontext) :
+                                          get_clean_call_restore(dcontext)),
+                           opnd_create_reg(DR_REG_X30), ilist, instr, NULL, NULL);
     PRE(ilist, instr,
-        INSTR_CREATE_bl
-        (dcontext, save ?
-         opnd_create_pc(get_clean_call_save(dcontext)) :
-         opnd_create_pc(get_clean_call_restore(dcontext))));
+        INSTR_CREATE_blr(dcontext, opnd_create_reg(DR_REG_X30)));
 
    /* Restore original value of X30, which was changed by BL.
     *

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -329,8 +329,8 @@ insert_restore_registers(dcontext_t *dcontext, instrlist_t *ilist, instr_t *inst
 uint
 insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                           instrlist_t *ilist, instr_t *instr,
-                          uint alignment, opnd_t push_pc, reg_id_t scratch/*optional*/,
-                          bool out_of_line)
+                          uint alignment, opnd_t push_pc, reg_id_t scratch/*optional*/
+                          _IF_AARCH64(bool out_of_line))
 {
     uint dstack_offs = 0;
 #ifdef AARCH64
@@ -541,7 +541,7 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
 void
 insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                          instrlist_t *ilist, instr_t *instr,
-                         uint alignment, bool out_of_line)
+                         uint alignment _IF_AARCH64(bool out_of_line))
 {
     if (cci == NULL)
         cci = &default_clean_call_info;
@@ -616,7 +616,6 @@ insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
        PRE(ilist, instr,
             XINST_CREATE_add(dcontext, opnd_create_reg(DR_REG_SP),
                              OPND_CREATE_INT16(get_clean_call_switch_stack_size())));
-
     }
 
  #else

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -936,12 +936,11 @@ insert_out_of_line_context_switch(dcontext_t *dcontext, instrlist_t *ilist,
             XINST_CREATE_sub(dcontext, opnd_create_reg(DR_REG_SP),
                              OPND_CREATE_INT16(get_clean_call_switch_stack_size())));
 
-        /* stp x30, x30, [sp, #x30_offset] */
+        /* stp x30, [sp, #x30_offset] */
         PRE(ilist, instr,
-            INSTR_CREATE_stp(dcontext,
+            INSTR_CREATE_str(dcontext,
                              opnd_create_base_disp(DR_REG_SP, DR_REG_NULL, 0,
-                                                   REG_OFFSET(DR_REG_X30), OPSZ_16),
-                             opnd_create_reg(DR_REG_X30),
+                                                   REG_OFFSET(DR_REG_X30), OPSZ_8),
                              opnd_create_reg(DR_REG_X30)));
     }
 

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -936,7 +936,12 @@ insert_out_of_line_context_switch(dcontext_t *dcontext, instrlist_t *ilist,
             XINST_CREATE_sub(dcontext, opnd_create_reg(DR_REG_SP),
                              OPND_CREATE_INT16(get_clean_call_switch_stack_size())));
 
-        /* stp x30, [sp, #x30_offset] */
+        /* str x30, [sp, #x30_offset]
+         *
+         * We have to save the original value of x30 before using BLR to jump
+         * to the save code, because BLR will modify x30. The original value of
+         * x30 is restored after the returning from the save/restore functions below.
+         */
         PRE(ilist, instr,
             INSTR_CREATE_str(dcontext,
                              opnd_create_base_disp(DR_REG_SP, DR_REG_NULL, 0,
@@ -951,7 +956,7 @@ insert_out_of_line_context_switch(dcontext_t *dcontext, instrlist_t *ilist,
     PRE(ilist, instr,
         INSTR_CREATE_blr(dcontext, opnd_create_reg(DR_REG_X30)));
 
-   /* Restore original value of X30, which was changed by BL.
+   /* Restore original value of X30, which was changed by BLR.
     *
     * ldr x30, [sp, #x30_offset]
     */

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -515,14 +515,29 @@ get_clean_call_temp_stack_size(void);
 void
 insert_clear_eflags(dcontext_t *dcontext, clean_call_info_t *cci,
                     instrlist_t *ilist, instr_t *instr);
+#ifdef AARCHXX
+uint
+insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
+                          instrlist_t *ilist, instr_t *instr,
+                          uint alignment, opnd_t push_pc, reg_id_t scratch/*optional*/,
+                          bool out_of_line);
+#else
 uint
 insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                           instrlist_t *ilist, instr_t *instr,
                           uint alignment, opnd_t push_pc, reg_id_t scratch/*optional*/);
+#endif
+#ifdef AARCHXX
+void
+insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
+                         instrlist_t *ilist, instr_t *instr,
+                         uint alignment, bool out_of_line);
+#else
 void
 insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                          instrlist_t *ilist, instr_t *instr,
                          uint alignment);
+#endif
 bool
 insert_reachable_cti(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
                      byte *encode_pc, byte *target, bool jmp, bool returns, bool precise,

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -515,29 +515,15 @@ get_clean_call_temp_stack_size(void);
 void
 insert_clear_eflags(dcontext_t *dcontext, clean_call_info_t *cci,
                     instrlist_t *ilist, instr_t *instr);
-#ifdef AARCHXX
 uint
 insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                           instrlist_t *ilist, instr_t *instr,
-                          uint alignment, opnd_t push_pc, reg_id_t scratch/*optional*/,
-                          bool out_of_line);
-#else
-uint
-insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
-                          instrlist_t *ilist, instr_t *instr,
-                          uint alignment, opnd_t push_pc, reg_id_t scratch/*optional*/);
-#endif
-#ifdef AARCHXX
+                          uint alignment, opnd_t push_pc, reg_id_t scratch/*optional*/
+                          _IF_AARCH64(bool out_of_line));
 void
 insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                          instrlist_t *ilist, instr_t *instr,
-                         uint alignment, bool out_of_line);
-#else
-void
-insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
-                         instrlist_t *ilist, instr_t *instr,
-                         uint alignment);
-#endif
+                         uint alignment _IF_AARCH64(bool out_of_line));
 bool
 insert_reachable_cti(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
                      byte *encode_pc, byte *target, bool jmp, bool returns, bool precise,

--- a/core/arch/clean_call_opt_shared.c
+++ b/core/arch/clean_call_opt_shared.c
@@ -743,9 +743,8 @@ analyze_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instr_t *where,
         always_out_of_line)
 #elif defined(AARCH64)
     /* Use out-of-line calls unless the majority of the registers are saved. */
-    if ((cci->num_simd_skip < 20 /* save majority of simd registers*/ &&
-         cci->num_regs_skip < 20 /* save majority of gprs */ &&
-         !cci->skip_save_flags) ||
+    if (cci->num_simd_skip < 20 /* save majority of simd registers*/ ||
+        cci->num_regs_skip < 20 /* save majority of gprs */ ||
         always_out_of_line)
 # endif
         cci->out_of_line_swap = true;

--- a/core/arch/clean_call_opt_shared.c
+++ b/core/arch/clean_call_opt_shared.c
@@ -741,10 +741,14 @@ analyze_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instr_t *where,
          cci->num_regs_skip == 0 /* save all regs */ &&
          !cci->skip_save_flags) ||
         always_out_of_line)
-        cci->out_of_line_swap = true;
 #elif defined(AARCH64)
-        cci->out_of_line_swap = true;
+    /* Use out-of-line calls unless the majority of the registers are saved. */
+    if ((cci->num_simd_skip < 20 /* save majority of simd registers*/ &&
+         cci->num_regs_skip < 20 /* save majority of gprs */ &&
+         !cci->skip_save_flags) ||
+        always_out_of_line)
 # endif
+        cci->out_of_line_swap = true;
 
     return should_inline;
 }

--- a/core/arch/clean_call_opt_shared.c
+++ b/core/arch/clean_call_opt_shared.c
@@ -741,13 +741,14 @@ analyze_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instr_t *where,
          cci->num_regs_skip == 0 /* save all regs */ &&
          !cci->skip_save_flags) ||
         always_out_of_line)
+        cci->out_of_line_swap = true;
 #elif defined(AARCH64)
     /* Use out-of-line calls unless the majority of the registers are saved. */
     if (cci->num_simd_skip < 20 /* save majority of simd registers*/ ||
         cci->num_regs_skip < 20 /* save majority of gprs */ ||
         always_out_of_line)
-# endif
         cci->out_of_line_swap = true;
+# endif
 
     return should_inline;
 }

--- a/core/arch/clean_call_opt_shared.c
+++ b/core/arch/clean_call_opt_shared.c
@@ -742,6 +742,8 @@ analyze_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instr_t *where,
          !cci->skip_save_flags) ||
         always_out_of_line)
         cci->out_of_line_swap = true;
+#elif defined(AARCH64)
+        cci->out_of_line_swap = true;
 # endif
 
     return should_inline;

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -4979,6 +4979,15 @@ emit_new_thread_dynamo_start(dcontext_t *dcontext, byte *pc)
      * new_thread_setup() will restore real app xsp.
      * We emulate x86.asm's PUSH_DR_MCONTEXT(SCRATCH_REG0) (for priv_mcontext_t.pc).
      */
+#ifdef AARCHXX
+    offset = insert_push_all_registers(dcontext, NULL, &ilist, NULL,
+                                       IF_X64_ELSE(16, 4), opnd_create_reg(SCRATCH_REG0),
+                                       /* we have to pass in scratch to prevent
+                                        * use of the stolen reg, which would be
+                                        * a race w/ the parent's use of it!
+                                        */
+                                       SCRATCH_REG0, false);
+#else
     offset = insert_push_all_registers(dcontext, NULL, &ilist, NULL,
                                        IF_X64_ELSE(16, 4), opnd_create_reg(SCRATCH_REG0),
                                        /* we have to pass in scratch to prevent
@@ -4986,6 +4995,7 @@ emit_new_thread_dynamo_start(dcontext_t *dcontext, byte *pc)
                                         * a race w/ the parent's use of it!
                                         */
                                        SCRATCH_REG0);
+#endif
 #ifndef AARCH64
     /* put pre-push xsp into priv_mcontext_t.xsp slot */
     ASSERT(offset == sizeof(priv_mcontext_t));
@@ -5392,13 +5402,6 @@ byte *
 emit_clean_call_save(dcontext_t *dcontext, byte *pc, generated_code_t *code)
 {
     instrlist_t ilist;
-#ifdef AARCHXX
-    /* FIXME i#1551, i#1569:
-     * NYI on ARM/AArch64 (no assert here, it's in get_clean_call_save())
-     */
-    return pc;
-#endif
-
     instrlist_init(&ilist);
     /* xref insert_out_of_line_context_switch @ x86/mangle.c,
      * stack was adjusted beyond what we place there to get retaddr
@@ -5420,8 +5423,12 @@ emit_clean_call_save(dcontext_t *dcontext, byte *pc, generated_code_t *code)
     /* save all registers */
     insert_push_all_registers(dcontext, NULL, &ilist, NULL, (uint)PAGE_SIZE,
                               OPND_CREATE_INT32(0), REG_NULL);
-#elif defined(ARM)
-    /* FIXME i#1551: NYI on ARM */
+#elif defined(AARCH64)
+    /* save all registers */
+    insert_push_all_registers(dcontext, NULL, &ilist, NULL, (uint)PAGE_SIZE,
+                              OPND_CREATE_INT32(0), REG_NULL, true);
+#else
+    /* FIXME i#1621: NYI on AArch32 */
     ASSERT_NOT_IMPLEMENTED(false);
 #endif
 
@@ -5458,8 +5465,10 @@ emit_clean_call_save(dcontext_t *dcontext, byte *pc, generated_code_t *code)
                                OPSZ_lea)));
     APP(&ilist, INSTR_CREATE_ret_imm
         (dcontext, OPND_CREATE_INT16(get_clean_call_temp_stack_size())));
-#elif defined(ARM)
-    /* FIXME i#1551: NYI on ARM */
+#elif defined(AARCH64)
+    APP(&ilist, INSTR_CREATE_br(dcontext, opnd_create_reg(DR_REG_X30)));
+#else
+    /* FIXME i#1621: NYI on AArch32 */
     ASSERT_NOT_IMPLEMENTED(false);
 #endif
 
@@ -5475,7 +5484,9 @@ emit_clean_call_restore(dcontext_t *dcontext, byte *pc, generated_code_t *code)
 {
     instrlist_t ilist;
 #ifdef ARM
-    /* FIXME i#1551: NYI on ARM (no assert here, it's in get_clean_call_restore()) */
+    /* FIXME i#1551: NYI on AArch32
+     * (no assert here, it's in get_clean_call_restore())
+    */
     return pc;
 #endif
 
@@ -5515,10 +5526,15 @@ emit_clean_call_restore(dcontext_t *dcontext, byte *pc, generated_code_t *code)
     APP(&ilist, INSTR_CREATE_ret_imm
         (dcontext,
          OPND_CREATE_INT16(get_clean_call_switch_stack_size())));
-#elif defined(ARM)
-    /* FIXMED i#1551: NYI on ARM */
+#elif defined(AARCH64)
+    insert_pop_all_registers(dcontext, NULL, &ilist, NULL, (uint)PAGE_SIZE, true);
+
+    APP(&ilist, INSTR_CREATE_br(dcontext, opnd_create_reg(DR_REG_X30)));
+#else
+    /* FIXME i#1621: NYI on AArch32 */
     ASSERT_NOT_IMPLEMENTED(false);
 #endif
+
     /* emit code */
     pc = instrlist_encode(dcontext, &ilist, pc, false);
     ASSERT(pc != NULL);

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -4979,23 +4979,13 @@ emit_new_thread_dynamo_start(dcontext_t *dcontext, byte *pc)
      * new_thread_setup() will restore real app xsp.
      * We emulate x86.asm's PUSH_DR_MCONTEXT(SCRATCH_REG0) (for priv_mcontext_t.pc).
      */
-#ifdef AARCHXX
     offset = insert_push_all_registers(dcontext, NULL, &ilist, NULL,
                                        IF_X64_ELSE(16, 4), opnd_create_reg(SCRATCH_REG0),
                                        /* we have to pass in scratch to prevent
                                         * use of the stolen reg, which would be
                                         * a race w/ the parent's use of it!
                                         */
-                                       SCRATCH_REG0, false);
-#else
-    offset = insert_push_all_registers(dcontext, NULL, &ilist, NULL,
-                                       IF_X64_ELSE(16, 4), opnd_create_reg(SCRATCH_REG0),
-                                       /* we have to pass in scratch to prevent
-                                        * use of the stolen reg, which would be
-                                        * a race w/ the parent's use of it!
-                                        */
-                                       SCRATCH_REG0);
-#endif
+                                       SCRATCH_REG0 _IF_AARCH64(false));
 #ifndef AARCH64
     /* put pre-push xsp into priv_mcontext_t.xsp slot */
     ASSERT(offset == sizeof(priv_mcontext_t));

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -261,15 +261,10 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci,
         dstack_offs +=
             insert_out_of_line_context_switch(dcontext, ilist, instr, true);
     } else {
-#ifdef AARCHXX
         dstack_offs +=
             insert_push_all_registers(dcontext, cci, ilist, instr, (uint)PAGE_SIZE,
-                                      OPND_CREATE_INT32(0), REG_NULL, false);
-#else
-        dstack_offs +=
-            insert_push_all_registers(dcontext, cci, ilist, instr, (uint)PAGE_SIZE,
-                                      OPND_CREATE_INT32(0), REG_NULL);
-#endif
+                                      OPND_CREATE_INT32(0), REG_NULL
+                                      _IF_AARCH64(false));
 
         insert_clear_eflags(dcontext, cci, ilist, instr);
         /* XXX: add a cci field for optimizing this away if callee makes no calls */
@@ -337,15 +332,9 @@ cleanup_after_clean_call(dcontext_t *dcontext, clean_call_info_t *cci,
         insert_out_of_line_context_switch(dcontext, ilist, instr, false);
     } else {
         /* XXX: add a cci field for optimizing this away if callee makes no calls */
-#ifdef AARCHXX
         insert_pop_all_registers(dcontext, cci, ilist, instr,
                                  /* see notes in prepare_for_clean_call() */
-                                 (uint)PAGE_SIZE, false);
-#else
-        insert_pop_all_registers(dcontext, cci, ilist, instr,
-                                 /* see notes in prepare_for_clean_call() */
-                                 (uint)PAGE_SIZE);
-#endif
+                                 (uint)PAGE_SIZE _IF_AARCH64(false));
     }
 
     /* Swap stacks back.  For thread-shared, we need to get the dcontext

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -337,7 +337,7 @@ cleanup_after_clean_call(dcontext_t *dcontext, clean_call_info_t *cci,
         insert_out_of_line_context_switch(dcontext, ilist, instr, false);
     } else {
         /* XXX: add a cci field for optimizing this away if callee makes no calls */
-#ifdef AARCH64
+#ifdef AARCHXX
         insert_pop_all_registers(dcontext, cci, ilist, instr,
                                  /* see notes in prepare_for_clean_call() */
                                  (uint)PAGE_SIZE, false);

--- a/suite/tests/client-interface/cleancall-opt-1.dll.c
+++ b/suite/tests/client-interface/cleancall-opt-1.dll.c
@@ -85,7 +85,7 @@ event_basic_block(void *dc, void *tag, instrlist_t *bb,
     app_pc entry_pc = instr_get_app_pc(entry);
     int i;
     bool inline_expected = false;
-    bool out_of_line_expected = false;
+    bool out_of_line_expected = IF_AARCH64_ELSE(true, false);
     instr_t *before_label;
     instr_t *after_label;
 

--- a/suite/tests/client-interface/cleancall-opt-shared.h
+++ b/suite/tests/client-interface/cleancall-opt-shared.h
@@ -423,8 +423,8 @@ after_callee(app_pc start_inline, app_pc end_inline, bool inline_expected,
             instr_reset(dc, &instr);
         }
         if (blr_count != 3) {
-            dr_fprintf(STDERR, "Expected out-of-line call but did not find exactly 3 %s instructions.\n"
-                       IF_X86_ELSE("CALL", "BLR"));
+            dr_fprintf(STDERR, "Expected out-of-line call but did not find exactly 3 "
+                       IF_X86_ELSE("CALL", "BLR") " instructions.\n");
             dump_cc_code(dc, start_inline, end_inline, func_index);
         }
     }

--- a/suite/tests/client-interface/cleancall-opt-shared.h
+++ b/suite/tests/client-interface/cleancall-opt-shared.h
@@ -426,8 +426,6 @@ after_callee(app_pc start_inline, app_pc end_inline, bool inline_expected,
             dr_fprintf(STDERR, "Expected out-of-line call but did not find exactly 3 %s instructions.\n"
                        IF_X86_ELSE("CALL", "BLR"));
             dump_cc_code(dc, start_inline, end_inline, func_index);
-        } else {
-            dr_fprintf(STDERR, "Out-of-line call generated as expected.\n");
         }
     }
 


### PR DESCRIPTION
Implement out-of-line calls on AArch64 using BL to jump to the code
cache. Before jumping to the save routine in the code cache, the
stack pointer is adjusted and the original value of X30 is stored
on the stack. The value from the stack is restored after jumping back
from the code cache, as BL puts the return address in X30.

This patch enables out-of-line calls for all clean calls for now, as no
other optimizations are implemented at the moment on AArch64.