### PR TITLE
i#2337: swap signal mask on native-DR transitions

### DIFF
--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -253,6 +253,7 @@ void signal_exit(void);
 void signal_thread_init(dcontext_t *dcontext);
 void signal_thread_exit(dcontext_t *dcontext, bool other_thread);
 bool is_thread_signal_info_initialized(dcontext_t *dcontext);
+void signal_swap_mask(dcontext_t *dcontext, bool to_app);
 void signal_remove_handlers(dcontext_t *dcontext);
 void signal_reinstate_handlers(dcontext_t *dcontext, bool ignore_alarm);
 void signal_reinstate_alarm_handlers(dcontext_t *dcontext);


### PR DESCRIPTION
Adds swapping of each thread's signal mask on native<->DR transitions.

Shifts the initial setup of the mask to the same start execution point
where handler setup was moved by i#2335.

Changes the init-time crash handling to only change the mask for the crash
signals rather than everything.

Fixes #2337