### PR TITLE
Clarify instr_is_cti() docs and make them cross-platform

### DIFF
--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -1950,8 +1950,8 @@ instr_is_return(instr_t *instr);
 
 DR_API
 /**
- * Returns true iff \p instr is a control transfer instruction of any kind
- * This includes OP_jcc, OP_jcc_short, OP_loop*, OP_jecxz, OP_call*, and OP_jmp*.
+ * Returns true iff \p instr is a control transfer instruction of any
+ * kind, whether direct, indirect, conditional, or unconditional.
  */
 bool
 instr_is_cti(instr_t *instr);
@@ -1972,7 +1972,7 @@ bool
 instr_is_cti_short(instr_t *instr);
 
 DR_API
-/** Returns true iff \p instr is one of OP_loop* or OP_jecxz. */
+/** Returns true iff \p instr is one of OP_loop* or OP_jecxz on x86. */
 bool
 instr_is_cti_loop(instr_t *instr);
 
@@ -2037,7 +2037,7 @@ instr_is_near_ubr(instr_t *instr);
 DR_API
 /**
  * Returns true iff \p instr is a far control transfer instruction: OP_jmp_far,
- * OP_call_far, OP_jmp_far_ind, OP_call_far_ind, OP_ret_far, or OP_iret.
+ * OP_call_far, OP_jmp_far_ind, OP_call_far_ind, OP_ret_far, or OP_iret, on x86.
  */
 bool
 instr_is_far_cti(instr_t *instr);


### PR DESCRIPTION
The instr_is_cti() docs listed some x86 opcodes, implying it was not
cross-platform.  It also failed to list OP_ret.  We change it here to
generalize and make it cross-platform.  We also update the docs for a few
other related routines that are x86-specific.