### PR TITLE
i#1621 AArch64 cc opt: Use analyze_callee_regs_usage for GPRs.

### DIFF
--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -288,7 +288,7 @@ insert_save_or_restore_registers(dcontext_t *dcontext, instrlist_t *ilist, instr
      */
     if (reg1 != UINT_MAX) {
         opnd_t mem = create_base_disp_for_save_restore(base_reg, first_reg, reg1,
-                                                       false /* is_single_reg */,
+                                                       true /* is_single_reg */,
                                                        is_gpr);
         if (save)
             new_instr = INSTR_CREATE_str(dcontext, mem, opnd_create_reg(first_reg + reg1));

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -474,8 +474,8 @@
      * All the optimizations assume that clean callee will not be changed
      * later.
      */
-    /* FIXME i#1551, i#1569: NYI on ARM/AArch64 */
-    OPTION_DEFAULT_INTERNAL(uint, opt_cleancall, IF_X86_ELSE(2, 0),
+    /* FIXME i#1621: NYI on ARM, partly implemented on AArch64 */
+    OPTION_DEFAULT_INTERNAL(uint, opt_cleancall, IF_X86_ELSE(2, IF_AARCH64_ELSE(1, 0)),
                             "optimization level on optimizing clean call sequences")
     /* Assuming the client's clean call does not rely on the cleared eflags,
      * i.e., initialize the eflags before using it, we can skip the eflags


### PR DESCRIPTION
This patch implements analyze_callee_regs_usage to analyze the usage of
GPRs in the callee. insert_push_all_registers and
insert_pop_all_registers do not save and restore unused registers.

cleanall_opt=1 has limited support now and is the default level for
AArch64.

Based on work by Kevin Zhou and Edmund Grimley-Evans.