### PR TITLE
 i#1569 AArch64: Add support for implicit X30 operands for BL and BLR. 

### DIFF
--- a/api/samples/CMakeLists.txt
+++ b/api/samples/CMakeLists.txt
@@ -31,12 +31,16 @@
 
 cmake_minimum_required(VERSION 2.6)
 
+if ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
+  set(DEBUG ON)
+endif ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
+
 # To match Makefiles and have just one build type per configured build
 # dir, we collapse VS generator configs to a single choice.
 # This must be done prior to the project() command and the var
 # must be set in the cache.
 if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
-  if (DEBUG OR "${CMAKE_BUILD_TYPE}" MATCHES "Debug")
+  if (DEBUG)
     set(CMAKE_CONFIGURATION_TYPES "Debug" CACHE STRING "" FORCE)
   else ()
     # Go w/ debug info (i#1392)
@@ -116,7 +120,7 @@ else (WIN32)
 endif (WIN32)
 
 if (DEBUG)
-  set(OPT_CFLAGS "-DDEBUG")
+  set(OPT_CFLAGS "${OPT_CFLAGS} -DDEBUG")
 endif (DEBUG)
 
 # For C clients that only rely on the DR API and not on any 3rd party

--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -1194,6 +1194,24 @@ encode_opnd_imms(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     return encode_opnd_imm_bf(10, enc, opnd, enc_out);
 }
 
+/* impx30: implicit X30 operand, used by BLR. */
+
+static inline bool
+decode_opnd_impx30(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_reg(DR_REG_X30);
+    return true;
+}
+
+static inline bool
+encode_opnd_impx30(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_reg(opnd) || opnd_get_reg(opnd) != DR_REG_X30)
+        return false;
+    *enc_out = 0;
+    return true;
+}
+
 /* index0: index of B subreg in Q register: 0-15 */
 
 static inline bool
@@ -2319,24 +2337,6 @@ static inline bool
 encode_opnd_x5sp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_wxn(true, true, 5, opnd, enc_out);
-}
-
-/* impx30: Implicit X30 operand, used by BLR. */
-
-static inline bool
-decode_opnd_impx30(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
-{
-    *opnd = opnd_create_reg(DR_REG_X30);
-    return true;
-}
-
-static inline bool
-encode_opnd_impx30(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
-{
-    if (!opnd_is_reg(opnd) || opnd_get_reg(opnd) != DR_REG_X30)
-        return false;
-    *enc_out = 0;
-    return true;
 }
 
 /*******************************************************************************

--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -2364,7 +2364,8 @@ encode_opnds_b(byte *pc, instr_t *instr, uint enc)
 {
     uint off;
     if (((instr_get_opcode(instr) == OP_bl && instr_num_dsts(instr) == 1) ||
-        instr_num_dsts(instr) == 0) && instr_num_srcs(instr) == 1 &&
+         instr_num_dsts(instr) == 0) &&
+        instr_num_srcs(instr) == 1 &&
         encode_pc_off(&off, 26, pc, instr, instr_get_src(instr, 0)))
         return (enc | off);
     return ENCFAIL;

--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -2321,6 +2321,24 @@ encode_opnd_x5sp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     return encode_opnd_wxn(true, true, 5, opnd, enc_out);
 }
 
+/* implX30: Implicit X30 operand, used by BLR. */
+
+static inline bool
+decode_opnd_impx30(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_reg(DR_REG_X30);
+    return true;
+}
+
+static inline bool
+encode_opnd_impx30(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_reg(opnd) || opnd_get_reg(opnd) != DR_REG_X30)
+        return false;
+    *enc_out = 0;
+    return true;
+}
+
 /*******************************************************************************
  * Pairs of functions for decoding and encoding opndsets, as listed in "codec.txt".
  * Currently all branch instructions are handled in this way.
@@ -2332,7 +2350,11 @@ static inline bool
 decode_opnds_b(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int opcode)
 {
     instr_set_opcode(instr, opcode);
-    instr_set_num_opnds(dcontext, instr, 0, 1);
+    if (opcode == OP_bl) {
+        instr_set_num_opnds(dcontext, instr, 1, 1);
+        instr_set_dst(instr, 0, opnd_create_reg(DR_REG_X30));
+    } else
+        instr_set_num_opnds(dcontext, instr, 0, 1);
     instr_set_src(instr, 0, opnd_create_pc(pc + extract_int(enc, 0, 26) * 4));
     return true;
 }
@@ -2341,7 +2363,8 @@ static inline uint
 encode_opnds_b(byte *pc, instr_t *instr, uint enc)
 {
     uint off;
-    if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 1 &&
+    if (((instr_get_opcode(instr) == OP_bl && instr_num_dsts(instr) == 1) ||
+        instr_num_dsts(instr) == 0) && instr_num_srcs(instr) == 1 &&
         encode_pc_off(&off, 26, pc, instr, instr_get_src(instr, 0)))
         return (enc | off);
     return ENCFAIL;

--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -2321,7 +2321,7 @@ encode_opnd_x5sp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     return encode_opnd_wxn(true, true, 5, opnd, enc_out);
 }
 
-/* implX30: Implicit X30 operand, used by BLR. */
+/* impx30: Implicit X30 operand, used by BLR. */
 
 static inline bool
 decode_opnd_impx30(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)

--- a/core/arch/aarch64/codec.txt
+++ b/core/arch/aarch64/codec.txt
@@ -47,6 +47,7 @@
 # In register operands (e.g. w10) the number refers to the position of the lowest bit.
 # In memory operands (e.g. mem7) the number refers to the number of offset bits.
 
+--------------------------------  impx30     # Implicit X30 operand
 --------------------------------  lsl        # LSL for ADD/MOV (immediate)
 ----------------------------xxxx  nzcv       # flag bit specifier for CCMN, CCMP
 ---------------------------xxxxx  b0         # B register
@@ -142,7 +143,6 @@ x---------------------xxxxx-----  wx5        # W/X register (or WZR/XZR)
 x---------------------xxxxx-----  wx5sp      # W/X register or WSP/XSP
 x----------------xxxxx----------  wx10       # W/X register (or WZR/XZR)
 x----------xxxxx----------------  wx16       # W/X register (or WZR/XZR)
---------------------------------  impx30     # Implicit X30 operand
 
 # Note: The encoders for adr and adrp take the current instruction as argument
 #       in order to support calculating offsets for instruction operands.

--- a/core/arch/aarch64/codec.txt
+++ b/core/arch/aarch64/codec.txt
@@ -142,6 +142,7 @@ x---------------------xxxxx-----  wx5        # W/X register (or WZR/XZR)
 x---------------------xxxxx-----  wx5sp      # W/X register or WSP/XSP
 x----------------xxxxx----------  wx10       # W/X register (or WZR/XZR)
 x----------xxxxx----------------  wx16       # W/X register (or WZR/XZR)
+--------------------------------  impx30     # Implicit X30 operand
 
 # Note: The encoders for adr and adrp take the current instruction as argument
 #       in order to support calculating offsets for instruction operands.
@@ -257,7 +258,7 @@ x0110111xxxxxxxxxxxxxxxxxxxxxxxx  tbnz   tbz
 ## Unconditional branch (register)
 
 1101011000011111000000xxxxx00000  br     : x5
-1101011000111111000000xxxxx00000  blr    : x5
+1101011000111111000000xxxxx00000  blr    impx30: x5
 1101011001011111000000xxxxx00000  ret    : x5
 
 # Loads and Stores

--- a/core/arch/aarch64/decode_gen.h
+++ b/core/arch/aarch64/decode_gen.h
@@ -4449,6 +4449,20 @@ decode_opndsgen_d61f0000(uint enc, dcontext_t *dcontext, byte *pc, instr_t *inst
 }
 
 static bool
+decode_opndsgen_d63f0000(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int opcode)
+{
+    opnd_t dst0, src0;
+    if (!decode_opnd_impx30(enc & 0xfffffc1f, opcode, pc, &dst0) ||
+        !decode_opnd_x5(enc & 0xffffffff, opcode, pc, &src0))
+        return false;
+    instr_set_opcode(instr, opcode);
+    instr_set_num_opnds(dcontext, instr, 1, 1);
+    instr_set_dst(instr, 0, dst0);
+    instr_set_src(instr, 0, src0);
+    return true;
+}
+
+static bool
 decode_opndsgen_d8000000(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int opcode)
 {
     opnd_t src0, src1;
@@ -5294,7 +5308,7 @@ decoder(uint enc, dcontext_t *dc, byte *pc, instr_t *instr)
                                             return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
                                     } else {
                                         if ((enc & 0xfffffc1f) == 0xd63f0000)
-                                            return decode_opndsgen_d61f0000(enc, dc, pc, instr, OP_blr);
+                                            return decode_opndsgen_d63f0000(enc, dc, pc, instr, OP_blr);
                                         if ((enc & 0xffe0001f) == 0xd4200000)
                                             return decode_opndsgen_d4000001(enc, dc, pc, instr, OP_brk);
                                     }

--- a/core/arch/aarch64/encode_gen.h
+++ b/core/arch/aarch64/encode_gen.h
@@ -5986,6 +5986,24 @@ encode_opndsgen_d61f0000(byte *pc, instr_t *instr, uint enc)
 }
 
 static uint
+encode_opndsgen_d63f0000(byte *pc, instr_t *instr, uint enc)
+{
+    int opcode = instr->opcode;
+    uint dst0, src0;
+    if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
+        encode_opnd_impx30(enc & 0xfffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
+        encode_opnd_x5(enc & 0xffffffff, opcode, pc, instr_get_src(instr, 0), &src0)) {
+        ASSERT((dst0 & 0xffffffff) == 0);
+        ASSERT((src0 & 0xfffffc1f) == 0);
+        enc |= dst0 | src0;
+        if (dst0 == (enc & 0x00000000) &&
+            src0 == (enc & 0x000003e0))
+            return enc;
+    }
+    return ENCFAIL;
+}
+
+static uint
 encode_opndsgen_d8000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
@@ -6526,7 +6544,7 @@ encoder(byte *pc, instr_t *instr)
     case OP_bl:
         return encode_opnds_b(pc, instr, 0x94000000);
     case OP_blr:
-        return encode_opndsgen_d61f0000(pc, instr, 0xd63f0000);
+        return encode_opndsgen_d63f0000(pc, instr, 0xd63f0000);
     case OP_br:
         return encode_opndsgen_d61f0000(pc, instr, 0xd61f0000);
     case OP_brk:

--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -280,7 +280,7 @@
 #define INSTR_CREATE_br(dc, xn) \
   instr_create_0dst_1src((dc), OP_br, (xn))
 #define INSTR_CREATE_blr(dc, xn) \
-  instr_create_0dst_1src((dc), OP_blr, (xn))
+  instr_create_1dst_1src((dc), OP_blr, opnd_create_reg(DR_REG_X30), (xn))
 #define INSTR_CREATE_brk(dc, imm) \
   instr_create_0dst_1src((dc), OP_brk, (imm))
 #define INSTR_CREATE_cbnz(dc, pc, reg) \

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -41,215 +41,76 @@
 081f7fff : stxrb  wzr, wzr, [sp]          : stxrb  %wzr $0x1f -> (%sp)[1byte] %wzr
 081fffff : stlxrb wzr, wzr, [sp]          : stlxrb %wzr $0x1f -> (%sp)[1byte] %wzr
 08287c40 : casp   w8, w9, w0, w1, [x2]    : casp   %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
-08287c41 : .inst  0x08287c41              : xx     $0x08287c41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 0828fc40 : caspl  w8, w9, w0, w1, [x2]    : caspl  %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
-0828fc41 : .inst  0x0828fc41              : xx     $0x0828fc41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 083e7ffe : casp   w30, wzr, w30, wzr, [sp]: casp   %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
 083efffe : caspl  w30, wzr, w30, wzr, [sp]: caspl  %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
-083f7fff : .inst  0x083f7fff              : xx     $0x083f7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
-083fffff : .inst  0x083fffff              : xx     $0x083fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 08481041 : ldxrb  w1, [x2]                : ldxrb  (%x2)[1byte] $0x04 $0x08 -> %w1
 08489041 : ldaxrb w1, [x2]                : ldaxrb (%x2)[1byte] $0x04 $0x08 -> %w1
 085f7fff : ldxrb  wzr, [sp]               : ldxrb  (%sp)[1byte] $0x1f $0x1f -> %wzr
 085fffff : ldaxrb wzr, [sp]               : ldaxrb (%sp)[1byte] $0x1f $0x1f -> %wzr
 08687c40 : caspa  w8, w9, w0, w1, [x2]    : caspa  %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
-08687c41 : .inst  0x08687c41              : xx     $0x08687c41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 0868fc40 : caspal w8, w9, w0, w1, [x2]    : caspal %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
-0868fc41 : .inst  0x0868fc41              : xx     $0x0868fc41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 087e7ffe : caspa  w30, wzr, w30, wzr, [sp]: caspa  %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
 087efffe : caspal w30, wzr, w30, wzr, [sp]: caspal %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
-087f7fff : .inst  0x087f7fff              : xx     $0x087f7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
-087fffff : .inst  0x087fffff              : xx     $0x087fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 08889041 : stlrb  w1, [x2]                : stlrb  %w1 $0x04 $0x08 -> (%x2)[1byte]
 089fffff : stlrb  wzr, [sp]               : stlrb  %wzr $0x1f $0x1f -> (%sp)[1byte]
 08a87c41 : casb   w8, w1, [x2]            : casb   %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
 08a8fc41 : caslb  w8, w1, [x2]            : caslb  %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
 08bf7fff : casb   wzr, wzr, [sp]          : casb   %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
 08bfffff : caslb  wzr, wzr, [sp]          : caslb  %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-08c89041 : .inst  0x08c89041              : ldarb  (%x2)[1byte] $0x04 $0x08 -> %w1
 08dfffff : ldarb  wzr, [sp]               : ldarb  (%sp)[1byte] $0x1f $0x1f -> %wzr
 08e87c41 : casab  w8, w1, [x2]            : casab  %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
 08e8fc41 : casalb w8, w1, [x2]            : casalb %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
 08ff7fff : casab  wzr, wzr, [sp]          : casab  %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
 08ffffff : casalb wzr, wzr, [sp]          : casalb %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
 0a031041 : and    w1, w2, w3, lsl #4      : and    %w2 %w3 lsl $0x04 -> %w1
-0a081041 : and    w1, w2, w8, lsl #4      : and    %w2 %w8 lsl $0x04 -> %w1
 0a231041 : bic    w1, w2, w3, lsl #4      : bic    %w2 %w3 lsl $0x04 -> %w1
-0a281041 : bic    w1, w2, w8, lsl #4      : bic    %w2 %w8 lsl $0x04 -> %w1
 0a7f7fff : bic    wzr, wzr, wzr, lsr #31  : bic    %wzr %wzr lsr $0x1f -> %wzr
 0a9f13ff : and    wzr, wzr, wzr, asr #4   : and    %wzr %wzr asr $0x04 -> %wzr
 0abf13ff : bic    wzr, wzr, wzr, asr #4   : bic    %wzr %wzr asr $0x04 -> %wzr
-0adf7fff : and    wzr, wzr, wzr, ror #31  : and    %wzr %wzr ror $0x1f -> %wzr
-0aff7fff : bic    wzr, wzr, wzr, ror #31  : bic    %wzr %wzr ror $0x1f -> %wzr
 0b031041 : add    w1, w2, w3, lsl #4      : add    %w2 %w3 lsl $0x04 -> %w1
-0b081041 : add    w1, w2, w8, lsl #4      : add    %w2 %w8 lsl $0x04 -> %w1
 0b1f7fff : add    wzr, wzr, wzr, lsl #31  : add    %wzr %wzr lsl $0x1f -> %wzr
-0b281041 : add    w1, w2, w8, uxtb #4     : add    %w2 %w8 uxtb $0x04 -> %w1
 0b3008a0 : add    w0, w5, w16, uxtb #2    : add    %w5 %w16 uxtb $0x02 -> %w0
 0b9f13ff : add    wzr, wzr, wzr, asr #4   : add    %wzr %wzr asr $0x04 -> %wzr
-0bdf7fff : .inst  0x0bdf7fff              : xx     $0x0bdf7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
-0c000041 : st4    {v1.8b-v4.8b}, [x2]     : st4    $0x00 %d1 %d2 %d3 %d4 -> (%x2)[32byte]
 0c0007ff : st4    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp]: st4    $0x01 %d31 %d0 %d1 %d2 -> (%sp)[32byte]
-0c002041 : st1    {v1.8b-v4.8b}, [x2]     : st1    $0x00 %d1 %d2 %d3 %d4 -> (%x2)[32byte]
-0c004041 : st3    {v1.8b-v3.8b}, [x2]     : st3    $0x00 %d1 %d2 %d3 -> (%x2)[24byte]
-0c006041 : st1    {v1.8b-v3.8b}, [x2]     : st1    $0x00 %d1 %d2 %d3 -> (%x2)[24byte]
 0c0067ff : st1    {v31.4h, v0.4h, v1.4h}, [sp]: st1    $0x01 %d31 %d0 %d1 -> (%sp)[24byte]
-0c007041 : st1    {v1.8b}, [x2]           : st1    $0x00 %d1 -> (%x2)[8byte]
 0c0077ff : st1    {v31.4h}, [sp]          : st1    $0x01 %d31 -> (%sp)[8byte]
-0c008041 : st2    {v1.8b, v2.8b}, [x2]    : st2    $0x00 %d1 %d2 -> (%x2)[16byte]
-0c00a041 : st1    {v1.8b, v2.8b}, [x2]    : st1    $0x00 %d1 %d2 -> (%x2)[16byte]
 0c00a7ff : st1    {v31.4h, v0.4h}, [sp]   : st1    $0x01 %d31 %d0 -> (%sp)[16byte]
-0c400041 : ld4    {v1.8b-v4.8b}, [x2]     : ld4    (%x2)[32byte] $0x00 -> %d1 %d2 %d3 %d4
-0c402041 : ld1    {v1.8b-v4.8b}, [x2]     : ld1    (%x2)[32byte] $0x00 -> %d1 %d2 %d3 %d4
 0c4027ff : ld1    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp]: ld1    (%sp)[32byte] $0x01 -> %d31 %d0 %d1 %d2
-0c404041 : ld3    {v1.8b-v3.8b}, [x2]     : ld3    (%x2)[24byte] $0x00 -> %d1 %d2 %d3
 0c4047ff : ld3    {v31.4h, v0.4h, v1.4h}, [sp]: ld3    (%sp)[24byte] $0x01 -> %d31 %d0 %d1
-0c406041 : ld1    {v1.8b-v3.8b}, [x2]     : ld1    (%x2)[24byte] $0x00 -> %d1 %d2 %d3
-0c407041 : ld1    {v1.8b}, [x2]           : ld1    (%x2)[8byte] $0x00 -> %d1
-0c408041 : ld2    {v1.8b, v2.8b}, [x2]    : ld2    (%x2)[16byte] $0x00 -> %d1 %d2
 0c4087ff : ld2    {v31.4h, v0.4h}, [sp]   : ld2    (%sp)[16byte] $0x01 -> %d31 %d0
-0c40a041 : ld1    {v1.8b, v2.8b}, [x2]    : ld1    (%x2)[16byte] $0x00 -> %d1 %d2
-0c880041 : st4    {v1.8b-v4.8b}, [x2], x8 : st4    $0x00 %d1 %d2 %d3 %d4 %x2 %x8 -> (%x2)[32byte] %x2
-0c882041 : st1    {v1.8b-v4.8b}, [x2], x8 : st1    $0x00 %d1 %d2 %d3 %d4 %x2 %x8 -> (%x2)[32byte] %x2
-0c884041 : st3    {v1.8b-v3.8b}, [x2], x8 : st3    $0x00 %d1 %d2 %d3 %x2 %x8 -> (%x2)[24byte] %x2
-0c886041 : st1    {v1.8b-v3.8b}, [x2], x8 : st1    $0x00 %d1 %d2 %d3 %x2 %x8 -> (%x2)[24byte] %x2
-0c887041 : st1    {v1.8b}, [x2], x8       : st1    $0x00 %d1 %x2 %x8 -> (%x2)[8byte] %x2
-0c888041 : st2    {v1.8b, v2.8b}, [x2], x8: st2    $0x00 %d1 %d2 %x2 %x8 -> (%x2)[16byte] %x2
-0c88a041 : st1    {v1.8b, v2.8b}, [x2], x8: st1    $0x00 %d1 %d2 %x2 %x8 -> (%x2)[16byte] %x2
 0c9f27ff : st1    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp], #32: st1    $0x01 %d31 %d0 %d1 %d2 %sp $0x20 -> (%sp)[32byte] %sp
 0c9f47ff : st3    {v31.4h, v0.4h, v1.4h}, [sp], #24: st3    $0x01 %d31 %d0 %d1 %sp $0x18 -> (%sp)[24byte] %sp
 0c9f87ff : st2    {v31.4h, v0.4h}, [sp], #16: st2    $0x01 %d31 %d0 %sp $0x10 -> (%sp)[16byte] %sp
-0cc80041 : ld4    {v1.8b-v4.8b}, [x2], x8 : ld4    (%x2)[32byte] $0x00 %x2 %x8 -> %d1 %d2 %d3 %d4 %x2
-0cc82041 : ld1    {v1.8b-v4.8b}, [x2], x8 : ld1    (%x2)[32byte] $0x00 %x2 %x8 -> %d1 %d2 %d3 %d4 %x2
-0cc84041 : ld3    {v1.8b-v3.8b}, [x2], x8 : ld3    (%x2)[24byte] $0x00 %x2 %x8 -> %d1 %d2 %d3 %x2
-0cc86041 : ld1    {v1.8b-v3.8b}, [x2], x8 : ld1    (%x2)[24byte] $0x00 %x2 %x8 -> %d1 %d2 %d3 %x2
-0cc87041 : ld1    {v1.8b}, [x2], x8       : ld1    (%x2)[8byte] $0x00 %x2 %x8 -> %d1 %x2
-0cc88041 : ld2    {v1.8b, v2.8b}, [x2], x8: ld2    (%x2)[16byte] $0x00 %x2 %x8 -> %d1 %d2 %x2
-0cc8a041 : ld1    {v1.8b, v2.8b}, [x2], x8: ld1    (%x2)[16byte] $0x00 %x2 %x8 -> %d1 %d2 %x2
 0cd5a7ff : ld1    {v31.4h, v0.4h}, [sp], x21: ld1    (%sp)[16byte] $0x01 %sp %x21 -> %d31 %d0 %sp
 0cdf07ff : ld4    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp], #32: ld4    (%sp)[32byte] $0x01 %sp $0x20 -> %d31 %d0 %d1 %d2 %sp
 0cdf67ff : ld1    {v31.4h, v0.4h, v1.4h}, [sp], #24: ld1    (%sp)[24byte] $0x01 %sp $0x18 -> %d31 %d0 %d1 %sp
 0cdf77ff : ld1    {v31.4h}, [sp], #8      : ld1    (%sp)[8byte] $0x01 %sp $0x08 -> %d31 %sp
 0cdfa7ff : ld1    {v31.4h, v0.4h}, [sp], #16: ld1    (%sp)[16byte] $0x01 %sp $0x10 -> %d31 %d0 %sp
-0d001041 : st1    {v1.b}[4], [x2]         : st1    %q1 $0x04 -> (%x2)[1byte]
-0d003041 : st3    {v1.b-v3.b}[4], [x2]    : st3    %q1 %q2 %q3 $0x04 -> (%x2)[3byte]
-0d005041 : st1    {v1.h}[2], [x2]         : st1    %q1 $0x02 -> (%x2)[2byte]
-0d007041 : st3    {v1.h-v3.h}[2], [x2]    : st3    %q1 %q2 %q3 $0x02 -> (%x2)[6byte]
-0d008441 : st1    {v1.d}[0], [x2]         : st1    %q1 $0x00 -> (%x2)[8byte]
-0d009041 : st1    {v1.s}[1], [x2]         : st1    %q1 $0x01 -> (%x2)[4byte]
-0d00a441 : st3    {v1.d-v3.d}[0], [x2]    : st3    %q1 %q2 %q3 $0x00 -> (%x2)[24byte]
-0d00b041 : st3    {v1.s-v3.s}[1], [x2]    : st3    %q1 %q2 %q3 $0x01 -> (%x2)[12byte]
-0d201041 : st2    {v1.b, v2.b}[4], [x2]   : st2    %q1 %q2 $0x04 -> (%x2)[2byte]
-0d203041 : st4    {v1.b-v4.b}[4], [x2]    : st4    %q1 %q2 %q3 %q4 $0x04 -> (%x2)[4byte]
-0d205041 : st2    {v1.h, v2.h}[2], [x2]   : st2    %q1 %q2 $0x02 -> (%x2)[4byte]
-0d207041 : st4    {v1.h-v4.h}[2], [x2]    : st4    %q1 %q2 %q3 %q4 $0x02 -> (%x2)[8byte]
-0d208441 : st2    {v1.d, v2.d}[0], [x2]   : st2    %q1 %q2 $0x00 -> (%x2)[16byte]
-0d209041 : st2    {v1.s, v2.s}[1], [x2]   : st2    %q1 %q2 $0x01 -> (%x2)[8byte]
-0d20a441 : st4    {v1.d-v4.d}[0], [x2]    : st4    %q1 %q2 %q3 %q4 $0x00 -> (%x2)[32byte]
-0d20b041 : st4    {v1.s-v4.s}[1], [x2]    : st4    %q1 %q2 %q3 %q4 $0x01 -> (%x2)[16byte]
-0d401041 : ld1    {v1.b}[4], [x2]         : ld1    (%x2)[1byte] $0x04 -> %q1
-0d403041 : ld3    {v1.b-v3.b}[4], [x2]    : ld3    (%x2)[3byte] $0x04 -> %q1 %q2 %q3
-0d405041 : ld1    {v1.h}[2], [x2]         : ld1    (%x2)[2byte] $0x02 -> %q1
-0d407041 : ld3    {v1.h-v3.h}[2], [x2]    : ld3    (%x2)[6byte] $0x02 -> %q1 %q2 %q3
-0d408441 : ld1    {v1.d}[0], [x2]         : ld1    (%x2)[8byte] $0x00 -> %q1
-0d409041 : ld1    {v1.s}[1], [x2]         : ld1    (%x2)[4byte] $0x01 -> %q1
-0d40a441 : ld3    {v1.d-v3.d}[0], [x2]    : ld3    (%x2)[24byte] $0x00 -> %q1 %q2 %q3
-0d40b041 : ld3    {v1.s-v3.s}[1], [x2]    : ld3    (%x2)[12byte] $0x01 -> %q1 %q2 %q3
-0d40c041 : ld1r   {v1.8b}, [x2]           : ld1r   (%x2)[1byte] -> %d1
-0d40e041 : ld3r   {v1.8b-v3.8b}, [x2]     : ld3r   (%x2)[3byte] -> %d1 %d2 %d3
 0d40e7ff : ld3r   {v31.4h, v0.4h, v1.4h}, [sp]: ld3r   (%sp)[6byte] -> %d31 %d0 %d1
-0d601041 : ld2    {v1.b, v2.b}[4], [x2]   : ld2    (%x2)[2byte] $0x04 -> %q1 %q2
-0d603041 : ld4    {v1.b-v4.b}[4], [x2]    : ld4    (%x2)[4byte] $0x04 -> %q1 %q2 %q3 %q4
-0d605041 : ld2    {v1.h, v2.h}[2], [x2]   : ld2    (%x2)[4byte] $0x02 -> %q1 %q2
-0d607041 : ld4    {v1.h-v4.h}[2], [x2]    : ld4    (%x2)[8byte] $0x02 -> %q1 %q2 %q3 %q4
-0d608441 : ld2    {v1.d, v2.d}[0], [x2]   : ld2    (%x2)[16byte] $0x00 -> %q1 %q2
-0d609041 : ld2    {v1.s, v2.s}[1], [x2]   : ld2    (%x2)[8byte] $0x01 -> %q1 %q2
-0d60a441 : ld4    {v1.d-v4.d}[0], [x2]    : ld4    (%x2)[32byte] $0x00 -> %q1 %q2 %q3 %q4
-0d60b041 : ld4    {v1.s-v4.s}[1], [x2]    : ld4    (%x2)[16byte] $0x01 -> %q1 %q2 %q3 %q4
-0d60c041 : ld2r   {v1.8b, v2.8b}, [x2]    : ld2r   (%x2)[2byte] -> %d1 %d2
 0d60cbff : ld2r   {v31.2s, v0.2s}, [sp]   : ld2r   (%sp)[8byte] -> %d31 %d0
-0d60e041 : ld4r   {v1.8b-v4.8b}, [x2]     : ld4r   (%x2)[4byte] -> %d1 %d2 %d3 %d4
-0d881041 : st1    {v1.b}[4], [x2], x8     : st1    %q1 $0x04 %x2 %x8 -> (%x2)[1byte] %x2
-0d883041 : st3    {v1.b-v3.b}[4], [x2], x8: st3    %q1 %q2 %q3 $0x04 %x2 %x8 -> (%x2)[3byte] %x2
-0d885041 : st1    {v1.h}[2], [x2], x8     : st1    %q1 $0x02 %x2 %x8 -> (%x2)[2byte] %x2
-0d887041 : st3    {v1.h-v3.h}[2], [x2], x8: st3    %q1 %q2 %q3 $0x02 %x2 %x8 -> (%x2)[6byte] %x2
-0d888441 : st1    {v1.d}[0], [x2], x8     : st1    %q1 $0x00 %x2 %x8 -> (%x2)[8byte] %x2
-0d889041 : st1    {v1.s}[1], [x2], x8     : st1    %q1 $0x01 %x2 %x8 -> (%x2)[4byte] %x2
-0d88a441 : st3    {v1.d-v3.d}[0], [x2], x8: st3    %q1 %q2 %q3 $0x00 %x2 %x8 -> (%x2)[24byte] %x2
-0d88b041 : st3    {v1.s-v3.s}[1], [x2], x8: st3    %q1 %q2 %q3 $0x01 %x2 %x8 -> (%x2)[12byte] %x2
-0da81041 : st2    {v1.b, v2.b}[4], [x2], x8: st2    %q1 %q2 $0x04 %x2 %x8 -> (%x2)[2byte] %x2
-0da83041 : st4    {v1.b-v4.b}[4], [x2], x8: st4    %q1 %q2 %q3 %q4 $0x04 %x2 %x8 -> (%x2)[4byte] %x2
-0da85041 : st2    {v1.h, v2.h}[2], [x2], x8: st2    %q1 %q2 $0x02 %x2 %x8 -> (%x2)[4byte] %x2
-0da87041 : st4    {v1.h-v4.h}[2], [x2], x8: st4    %q1 %q2 %q3 %q4 $0x02 %x2 %x8 -> (%x2)[8byte] %x2
-0da88441 : st2    {v1.d, v2.d}[0], [x2], x8: st2    %q1 %q2 $0x00 %x2 %x8 -> (%x2)[16byte] %x2
-0da89041 : st2    {v1.s, v2.s}[1], [x2], x8: st2    %q1 %q2 $0x01 %x2 %x8 -> (%x2)[8byte] %x2
-0da8a441 : st4    {v1.d-v4.d}[0], [x2], x8: st4    %q1 %q2 %q3 %q4 $0x00 %x2 %x8 -> (%x2)[32byte] %x2
-0da8b041 : st4    {v1.s-v4.s}[1], [x2], x8: st4    %q1 %q2 %q3 %q4 $0x01 %x2 %x8 -> (%x2)[16byte] %x2
 0dc1e7ff : ld3r   {v31.4h, v0.4h, v1.4h}, [sp], x1: ld3r   (%sp)[6byte] %sp %x1 -> %d31 %d0 %d1 %sp
-0dc81041 : ld1    {v1.b}[4], [x2], x8     : ld1    %q1 (%x2)[1byte] $0x04 %x2 %x8 -> %q1 %x2
-0dc83041 : ld3    {v1.b-v3.b}[4], [x2], x8: ld3    %q1 %q2 %q3 (%x2)[3byte] $0x04 %x2 %x8 -> %q1 %q2 %q3 %x2
-0dc85041 : ld1    {v1.h}[2], [x2], x8     : ld1    %q1 (%x2)[2byte] $0x02 %x2 %x8 -> %q1 %x2
-0dc87041 : ld3    {v1.h-v3.h}[2], [x2], x8: ld3    %q1 %q2 %q3 (%x2)[6byte] $0x02 %x2 %x8 -> %q1 %q2 %q3 %x2
-0dc88441 : ld1    {v1.d}[0], [x2], x8     : ld1    %q1 (%x2)[8byte] $0x00 %x2 %x8 -> %q1 %x2
-0dc89041 : ld1    {v1.s}[1], [x2], x8     : ld1    %q1 (%x2)[4byte] $0x01 %x2 %x8 -> %q1 %x2
-0dc8a441 : ld3    {v1.d-v3.d}[0], [x2], x8: ld3    %q1 %q2 %q3 (%x2)[24byte] $0x00 %x2 %x8 -> %q1 %q2 %q3 %x2
-0dc8b041 : ld3    {v1.s-v3.s}[1], [x2], x8: ld3    %q1 %q2 %q3 (%x2)[12byte] $0x01 %x2 %x8 -> %q1 %q2 %q3 %x2
-0dc8c041 : ld1r   {v1.8b}, [x2], x8       : ld1r   (%x2)[1byte] %x2 %x8 -> %d1 %x2
-0dc8c441 : ld1r   {v1.4h}, [x2], x8       : ld1r   (%x2)[2byte] %x2 %x8 -> %d1 %x2
-0dc8c841 : ld1r   {v1.2s}, [x2], x8       : ld1r   (%x2)[4byte] %x2 %x8 -> %d1 %x2
-0dc8cc41 : ld1r   {v1.1d}, [x2], x8       : ld1r   (%x2)[8byte] %x2 %x8 -> %d1 %x2
-0dc8e041 : ld3r   {v1.8b-v3.8b}, [x2], x8 : ld3r   (%x2)[3byte] %x2 %x8 -> %d1 %d2 %d3 %x2
-0dc8e441 : ld3r   {v1.4h-v3.4h}, [x2], x8 : ld3r   (%x2)[6byte] %x2 %x8 -> %d1 %d2 %d3 %x2
-0dc8e841 : ld3r   {v1.2s-v3.2s}, [x2], x8 : ld3r   (%x2)[12byte] %x2 %x8 -> %d1 %d2 %d3 %x2
-0dc8ec41 : ld3r   {v1.1d-v3.1d}, [x2], x8 : ld3r   (%x2)[24byte] %x2 %x8 -> %d1 %d2 %d3 %x2
 0ddfe7ff : ld3r   {v31.4h, v0.4h, v1.4h}, [sp], #6: ld3r   (%sp)[6byte] %sp $0x06 -> %d31 %d0 %d1 %sp
 0de2cbff : ld2r   {v31.2s, v0.2s}, [sp], x2: ld2r   (%sp)[8byte] %sp %x2 -> %d31 %d0 %sp
-0de81041 : ld2    {v1.b, v2.b}[4], [x2], x8: ld2    %q1 %q2 (%x2)[2byte] $0x04 %x2 %x8 -> %q1 %q2 %x2
-0de83041 : ld4    {v1.b-v4.b}[4], [x2], x8: ld4    %q1 %q2 %q3 %q4 (%x2)[4byte] $0x04 %x2 %x8 -> %q1 %q2 %q3 %q4 %x2
-0de85041 : ld2    {v1.h, v2.h}[2], [x2], x8: ld2    %q1 %q2 (%x2)[4byte] $0x02 %x2 %x8 -> %q1 %q2 %x2
-0de87041 : ld4    {v1.h-v4.h}[2], [x2], x8: ld4    %q1 %q2 %q3 %q4 (%x2)[8byte] $0x02 %x2 %x8 -> %q1 %q2 %q3 %q4 %x2
-0de88441 : ld2    {v1.d, v2.d}[0], [x2], x8: ld2    %q1 %q2 (%x2)[16byte] $0x00 %x2 %x8 -> %q1 %q2 %x2
-0de89041 : ld2    {v1.s, v2.s}[1], [x2], x8: ld2    %q1 %q2 (%x2)[8byte] $0x01 %x2 %x8 -> %q1 %q2 %x2
-0de8a441 : ld4    {v1.d-v4.d}[0], [x2], x8: ld4    %q1 %q2 %q3 %q4 (%x2)[32byte] $0x00 %x2 %x8 -> %q1 %q2 %q3 %q4 %x2
-0de8b041 : ld4    {v1.s-v4.s}[1], [x2], x8: ld4    %q1 %q2 %q3 %q4 (%x2)[16byte] $0x01 %x2 %x8 -> %q1 %q2 %q3 %q4 %x2
-0de8c041 : ld2r   {v1.8b, v2.8b}, [x2], x8: ld2r   (%x2)[2byte] %x2 %x8 -> %d1 %d2 %x2
-0de8c441 : ld2r   {v1.4h, v2.4h}, [x2], x8: ld2r   (%x2)[4byte] %x2 %x8 -> %d1 %d2 %x2
-0de8c841 : ld2r   {v1.2s, v2.2s}, [x2], x8: ld2r   (%x2)[8byte] %x2 %x8 -> %d1 %d2 %x2
-0de8cc41 : ld2r   {v1.1d, v2.1d}, [x2], x8: ld2r   (%x2)[16byte] %x2 %x8 -> %d1 %d2 %x2
-0de8e041 : ld4r   {v1.8b-v4.8b}, [x2], x8 : ld4r   (%x2)[4byte] %x2 %x8 -> %d1 %d2 %d3 %d4 %x2
-0de8e441 : ld4r   {v1.4h-v4.4h}, [x2], x8 : ld4r   (%x2)[8byte] %x2 %x8 -> %d1 %d2 %d3 %d4 %x2
-0de8e841 : ld4r   {v1.2s-v4.2s}, [x2], x8 : ld4r   (%x2)[16byte] %x2 %x8 -> %d1 %d2 %d3 %d4 %x2
-0de8ec41 : ld4r   {v1.1d-v4.1d}, [x2], x8 : ld4r   (%x2)[32byte] %x2 %x8 -> %d1 %d2 %d3 %d4 %x2
 0dffcbff : ld2r   {v31.2s, v0.2s}, [sp], #8: ld2r   (%sp)[8byte] %sp $0x08 -> %d31 %d0 %sp
 10081041 : adr    x1, 10010208            : adr    <rel> 0x0000000010010208 -> %x1
 10800000 : adr    x0, ff00000             : adr    <rel> 0x000000000ff00000 -> %x0
 11000c41 : add    w1, w2, #0x3            : add    %w2 $0x0003 lsl $0x00 -> %w1
 11000fff : add    wsp, wsp, #0x3          : add    %wsp $0x0003 lsl $0x00 -> %wsp
-11081041 : add    w1, w2, #0x204          : add    %w2 $0x0204 lsl $0x00 -> %w1
 117fffff : add    wsp, wsp, #0xfff, lsl #12: add    %wsp $0x0fff lsl $0x10 -> %wsp
 12000441 : and    w1, w2, #0x3            : and    %w2 $0x00000003 -> %w1
-12081041 : and    w1, w2, #0x1f000000     : and    %w2 $0x1f000000 -> %w1
 12881041 : mov    w1, #0xffffbf7d         : movn   $0x4082 lsl $0x00 -> %w1
-12ffffff : .inst  0x12ffffff              : xx     $0x12ffffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 13031041 : sbfx   w1, w2, #3, #2          : sbfm   %w2 $0x03 $0x04 -> %w1
-13081041 : sbfiz  w1, w2, #24, #5         : sbfm   %w2 $0x08 $0x04 -> %w1
 131f7fff : asr    wzr, wzr, #31           : sbfm   %wzr $0x1f $0x1f -> %wzr
-133fffff : .inst  0x133fffff              : xx     $0x133fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 13831041 : extr   w1, w2, w3, #4          : extr   %w2 %w3 $0x04 -> %w1
-13881041 : extr   w1, w2, w8, #4          : extr   %w2 %w8 $0x04 -> %w1
 139f7fff : ror    wzr, wzr, #31           : extr   %wzr %wzr $0x1f -> %wzr
-139fffff : .inst  0x139fffff              : xx     $0x139fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 14081041 : b      10204104                : b      $0x0000000010204104
 15ffffff : b      17fffffc                : b      $0x0000000017fffffc
 17ffffff : b      ffffffc                 : b      $0x000000000ffffffc
 18081041 : ldr    w1, 10010208            : ldr    <rel> 0x0000000010010208[4byte] -> %w1
 187fffff : ldr    wzr, 100ffffc           : ldr    <rel> 0x00000000100ffffc[4byte] -> %wzr
 18800000 : ldr    w0, ff00000             : ldr    <rel> 0x000000000ff00000[4byte] -> %w0
-18ffffff : ldr    wzr, ffffffc            : ldr    <rel> 0x000000000ffffffc[4byte] -> %wzr
 1a030041 : adc    w1, w2, w3              : adc    %w2 %w3 -> %w1
-1a080041 : adc    w1, w2, w8              : adc    %w2 %w8 -> %w1
-1a881041 : csel   w1, w2, w8, ne          : csel   %w2 %w8 ne -> %w1
-1a881441 : csinc  w1, w2, w8, ne          : csinc  %w2 %w8 ne -> %w1
 1a9f7441 : csinc  w1, w2, wzr, vc         : csinc  %w2 %wzr vc -> %w1
 1ac30c5f : sdiv   wzr, w2, w3             : sdiv   %w2 %w3 -> %wzr
 1ac323e1 : lsl    w1, wzr, w3             : lslv   %wzr %w3 -> %w1
@@ -259,107 +120,59 @@
 1ac353e1 : crc32cb w1, wzr, w3            : crc32cb %wzr %w3 -> %w1
 1ac3545f : crc32ch wzr, w2, w3            : crc32ch %w2 %w3 -> %wzr
 1ac35841 : crc32cw w1, w2, w3             : crc32cw %w2 %w3 -> %w1
-1ac80841 : udiv   w1, w2, w8              : udiv   %w2 %w8 -> %w1
-1ac80c41 : sdiv   w1, w2, w8              : sdiv   %w2 %w8 -> %w1
-1ac82041 : lsl    w1, w2, w8              : lslv   %w2 %w8 -> %w1
-1ac82441 : lsr    w1, w2, w8              : lsrv   %w2 %w8 -> %w1
-1ac82841 : asr    w1, w2, w8              : asrv   %w2 %w8 -> %w1
-1ac82c41 : ror    w1, w2, w8              : rorv   %w2 %w8 -> %w1
-1ac84041 : crc32b w1, w2, w8              : crc32b %w2 %w8 -> %w1
-1ac84441 : crc32h w1, w2, w8              : crc32h %w2 %w8 -> %w1
-1ac84841 : crc32w w1, w2, w8              : crc32w %w2 %w8 -> %w1
-1ac85041 : crc32cb w1, w2, w8             : crc32cb %w2 %w8 -> %w1
-1ac85441 : crc32ch w1, w2, w8             : crc32ch %w2 %w8 -> %w1
-1ac85841 : crc32cw w1, w2, w8             : crc32cw %w2 %w8 -> %w1
-1adf43ff : crc32b wzr, wzr, wzr           : crc32b %wzr %wzr -> %wzr
-1adf47ff : crc32h wzr, wzr, wzr           : crc32h %wzr %wzr -> %wzr
 1adf4841 : crc32w w1, w2, wzr             : crc32w %w2 %wzr -> %w1
-1adf4bff : crc32w wzr, wzr, wzr           : crc32w %wzr %wzr -> %wzr
-1adf53ff : crc32cb wzr, wzr, wzr          : crc32cb %wzr %wzr -> %wzr
-1adf57ff : crc32ch wzr, wzr, wzr          : crc32ch %wzr %wzr -> %wzr
-1adf5bff : crc32cw wzr, wzr, wzr          : crc32cw %wzr %wzr -> %wzr
 1b03fc41 : mneg   w1, w2, w3              : msub   %w2 %w3 %wzr -> %w1
-1b081041 : madd   w1, w2, w8, w4          : madd   %w2 %w8 %w4 -> %w1
-1b089041 : msub   w1, w2, w8, w4          : msub   %w2 %w8 %w4 -> %w1
 1b1f1041 : madd   w1, w2, wzr, w4         : madd   %w2 %wzr %w4 -> %w1
 1c081041 : ldr    s1, 10010208            : ldr    <rel> 0x0000000010010208[4byte] -> %s1
 1c7fffff : ldr    s31, 100ffffc           : ldr    <rel> 0x00000000100ffffc[4byte] -> %s31
 1c800000 : ldr    s0, ff00000             : ldr    <rel> 0x000000000ff00000[4byte] -> %s0
-1cffffff : ldr    s31, ffffffc            : ldr    <rel> 0x000000000ffffffc[4byte] -> %s31
 28000000 : stnp   w0, w0, [x0]            : stnp   %w0 %w0 -> (%x0)[8byte]
-28081041 : stnp   w1, w4, [x2,#64]        : stnp   %w1 %w4 -> +0x40(%x2)[8byte]
 283fffff : stnp   wzr, wzr, [sp,#-4]      : stnp   %wzr %wzr -> -0x04(%sp)[8byte]
 28400000 : ldnp   w0, w0, [x0]            : ldnp   (%x0)[8byte] -> %w0 %w0
-28481041 : ldnp   w1, w4, [x2,#64]        : ldnp   +0x40(%x2)[8byte] -> %w1 %w4
 287fffff : ldnp   wzr, wzr, [sp,#-4]      : ldnp   -0x04(%sp)[8byte] -> %wzr %wzr
 28800000 : stp    w0, w0, [x0],#0         : stp    %w0 %w0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
-28881041 : stp    w1, w4, [x2],#64        : stp    %w1 %w4 %x2 $0x0000000000000040 -> (%x2)[8byte] %x2
 28bfffff : stp    wzr, wzr, [sp],#-4      : stp    %wzr %wzr %sp $0xfffffffffffffffc -> (%sp)[8byte] %sp
 28c00000 : ldp    w0, w0, [x0],#0         : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %w0 %w0 %x0
-28c81041 : ldp    w1, w4, [x2],#64        : ldp    (%x2)[8byte] %x2 $0x0000000000000040 -> %w1 %w4 %x2
 28ffffff : ldp    wzr, wzr, [sp],#-4      : ldp    (%sp)[8byte] %sp $0xfffffffffffffffc -> %wzr %wzr %sp
 29000000 : stp    w0, w0, [x0]            : stp    %w0 %w0 -> (%x0)[8byte]
-29081041 : stp    w1, w4, [x2,#64]        : stp    %w1 %w4 -> +0x40(%x2)[8byte]
 293fffff : stp    wzr, wzr, [sp,#-4]      : stp    %wzr %wzr -> -0x04(%sp)[8byte]
 29400000 : ldp    w0, w0, [x0]            : ldp    (%x0)[8byte] -> %w0 %w0
-29481041 : ldp    w1, w4, [x2,#64]        : ldp    +0x40(%x2)[8byte] -> %w1 %w4
 297fffff : ldp    wzr, wzr, [sp,#-4]      : ldp    -0x04(%sp)[8byte] -> %wzr %wzr
 29800000 : stp    w0, w0, [x0,#0]!        : stp    %w0 %w0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
-29881041 : stp    w1, w4, [x2,#64]!       : stp    %w1 %w4 %x2 $0x0000000000000040 -> +0x40(%x2)[8byte] %x2
 29bfffff : stp    wzr, wzr, [sp,#-4]!     : stp    %wzr %wzr %sp $0xfffffffffffffffc -> -0x04(%sp)[8byte] %sp
 29c00000 : ldp    w0, w0, [x0,#0]!        : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %w0 %w0 %x0
-29c81041 : ldp    w1, w4, [x2,#64]!       : ldp    +0x40(%x2)[8byte] %x2 $0x0000000000000040 -> %w1 %w4 %x2
 29ffffff : ldp    wzr, wzr, [sp,#-4]!     : ldp    -0x04(%sp)[8byte] %sp $0xfffffffffffffffc -> %wzr %wzr %sp
 2a031041 : orr    w1, w2, w3, lsl #4      : orr    %w2 %w3 lsl $0x04 -> %w1
-2a081041 : orr    w1, w2, w8, lsl #4      : orr    %w2 %w8 lsl $0x04 -> %w1
 2a231041 : orn    w1, w2, w3, lsl #4      : orn    %w2 %w3 lsl $0x04 -> %w1
-2a281041 : orn    w1, w2, w8, lsl #4      : orn    %w2 %w8 lsl $0x04 -> %w1
 2a9f13ff : mov    wzr, wzr                : orr    %wzr %wzr asr $0x04 -> %wzr
 2a9f7fff : mov    wzr, wzr                : orr    %wzr %wzr asr $0x1f -> %wzr
 2abf13ff : mvn    wzr, wzr, asr #4        : orn    %wzr %wzr asr $0x04 -> %wzr
-2adf7fff : mov    wzr, wzr                : orr    %wzr %wzr ror $0x1f -> %wzr
-2aff7fff : mvn    wzr, wzr, ror #31       : orn    %wzr %wzr ror $0x1f -> %wzr
 2b031041 : adds   w1, w2, w3, lsl #4      : adds   %w2 %w3 lsl $0x04 -> %w1
-2b081041 : adds   w1, w2, w8, lsl #4      : adds   %w2 %w8 lsl $0x04 -> %w1
-2b281041 : adds   w1, w2, w8, uxtb #4     : adds   %w2 %w8 uxtb $0x04 -> %w1
 2b3f43ff : cmn    wsp, wzr                : adds   %wsp %wzr uxtw $0x00 -> %wzr
 2b5f7fff : cmn    wzr, wzr, lsr #31       : adds   %wzr %wzr lsr $0x1f -> %wzr
 2b9f13ff : cmn    wzr, wzr, asr #4        : adds   %wzr %wzr asr $0x04 -> %wzr
-2bdf7fff : .inst  0x2bdf7fff              : xx     $0x2bdf7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
 2c000000 : stnp   s0, s0, [x0]            : stnp   %s0 %s0 -> (%x0)[8byte]
-2c081041 : stnp   s1, s4, [x2,#64]        : stnp   %s1 %s4 -> +0x40(%x2)[8byte]
 2c3fffff : stnp   s31, s31, [sp,#-4]      : stnp   %s31 %s31 -> -0x04(%sp)[8byte]
 2c400000 : ldnp   s0, s0, [x0]            : ldnp   (%x0)[8byte] -> %s0 %s0
-2c481041 : ldnp   s1, s4, [x2,#64]        : ldnp   +0x40(%x2)[8byte] -> %s1 %s4
 2c7fffff : ldnp   s31, s31, [sp,#-4]      : ldnp   -0x04(%sp)[8byte] -> %s31 %s31
 2c800000 : stp    s0, s0, [x0],#0         : stp    %s0 %s0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
-2c881041 : stp    s1, s4, [x2],#64        : stp    %s1 %s4 %x2 $0x0000000000000040 -> (%x2)[8byte] %x2
 2cbfffff : stp    s31, s31, [sp],#-4      : stp    %s31 %s31 %sp $0xfffffffffffffffc -> (%sp)[8byte] %sp
 2cc00000 : ldp    s0, s0, [x0],#0         : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %s0 %s0 %x0
-2cc81041 : ldp    s1, s4, [x2],#64        : ldp    (%x2)[8byte] %x2 $0x0000000000000040 -> %s1 %s4 %x2
 2cffffff : ldp    s31, s31, [sp],#-4      : ldp    (%sp)[8byte] %sp $0xfffffffffffffffc -> %s31 %s31 %sp
 2d000000 : stp    s0, s0, [x0]            : stp    %s0 %s0 -> (%x0)[8byte]
-2d081041 : stp    s1, s4, [x2,#64]        : stp    %s1 %s4 -> +0x40(%x2)[8byte]
 2d3fffff : stp    s31, s31, [sp,#-4]      : stp    %s31 %s31 -> -0x04(%sp)[8byte]
 2d400000 : ldp    s0, s0, [x0]            : ldp    (%x0)[8byte] -> %s0 %s0
-2d481041 : ldp    s1, s4, [x2,#64]        : ldp    +0x40(%x2)[8byte] -> %s1 %s4
 2d7fffff : ldp    s31, s31, [sp,#-4]      : ldp    -0x04(%sp)[8byte] -> %s31 %s31
 2d800000 : stp    s0, s0, [x0,#0]!        : stp    %s0 %s0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
-2d881041 : stp    s1, s4, [x2,#64]!       : stp    %s1 %s4 %x2 $0x0000000000000040 -> +0x40(%x2)[8byte] %x2
 2dbfffff : stp    s31, s31, [sp,#-4]!     : stp    %s31 %s31 %sp $0xfffffffffffffffc -> -0x04(%sp)[8byte] %sp
 2dc00000 : ldp    s0, s0, [x0,#0]!        : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %s0 %s0 %x0
-2dc81041 : ldp    s1, s4, [x2,#64]!       : ldp    +0x40(%x2)[8byte] %x2 $0x0000000000000040 -> %s1 %s4 %x2
 2dffffff : ldp    s31, s31, [sp,#-4]!     : ldp    -0x04(%sp)[8byte] %sp $0xfffffffffffffffc -> %s31 %s31 %sp
 310003ff : cmn    wsp, #0x0               : adds   %wsp $0x0000 lsl $0x00 -> %wzr
 31000c41 : adds   w1, w2, #0x3            : adds   %w2 $0x0003 lsl $0x00 -> %w1
 31000fff : cmn    wsp, #0x3               : adds   %wsp $0x0003 lsl $0x00 -> %wzr
-31081041 : adds   w1, w2, #0x204          : adds   %w2 $0x0204 lsl $0x00 -> %w1
 32000441 : orr    w1, w2, #0x3            : orr    %w2 $0x00000003 -> %w1
-32081041 : orr    w1, w2, #0x1f000000     : orr    %w2 $0x1f000000 -> %w1
 33031041 : bfxil  w1, w2, #3, #2          : bfm    %w1 %w2 $0x03 $0x04 -> %w1
-33081041 : bfi    w1, w2, #24, #5         : bfm    %w1 %w2 $0x08 $0x04 -> %w1
 331f7fff : bfxil  wzr, wzr, #31, #1       : bfm    %wzr %wzr $0x1f $0x1f -> %wzr
-333fffff : .inst  0x333fffff              : xx     $0x333fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 34081041 : cbz    w1, 10010208            : cbz    $0x0000000010010208 %w1
 347fffff : cbz    wzr, 100ffffc           : cbz    $0x00000000100ffffc %wzr
 35081041 : cbnz   w1, 10010208            : cbnz   $0x0000000010010208 %w1
@@ -386,7 +199,6 @@
 3823f841 : strb   w1, [x2,x3,sxtx #0]     : strb   %w1 -> (%x2,%x3,sxtx #0)[1byte]
 38280041 : ldaddb w8, w1, [x2]            : ldaddb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38281041 : ldclrb w8, w1, [x2]            : ldclrb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38281841 : .inst  0x38281841              : xx     $0x38281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 38282041 : ldeorb w8, w1, [x2]            : ldeorb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38283041 : ldsetb w8, w1, [x2]            : ldsetb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38284041 : ldsmaxb w8, w1, [x2]           : ldsmaxb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
@@ -431,7 +243,6 @@
 3863f841 : ldrb   w1, [x2,x3,sxtx #0]     : ldrb   (%x2,%x3,sxtx #0)[1byte] -> %w1
 38680041 : ldaddlb w8, w1, [x2]           : ldaddlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38681041 : ldclrlb w8, w1, [x2]           : ldclrlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38681841 : .inst  0x38681841              : xx     $0x38681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 38682041 : ldeorlb w8, w1, [x2]           : ldeorlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38683041 : ldsetlb w8, w1, [x2]           : ldsetlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38684041 : ldsmaxlb w8, w1, [x2]          : ldsmaxlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
@@ -476,7 +287,6 @@
 38a3f841 : ldrsb  x1, [x2,x3,sxtx #0]     : ldrsb  (%x2,%x3,sxtx #0)[1byte] -> %x1
 38a80041 : ldaddab w8, w1, [x2]           : ldaddab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38a81041 : ldclrab w8, w1, [x2]           : ldclrab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38a81841 : .inst  0x38a81841              : xx     $0x38a81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 38a82041 : ldeorab w8, w1, [x2]           : ldeorab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38a83041 : ldsetab w8, w1, [x2]           : ldsetab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38a84041 : ldsmaxab w8, w1, [x2]          : ldsmaxab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
@@ -521,7 +331,6 @@
 38e3f841 : ldrsb  w1, [x2,x3,sxtx #0]     : ldrsb  (%x2,%x3,sxtx #0)[1byte] -> %w1
 38e80041 : ldaddalb w8, w1, [x2]          : ldaddalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38e81041 : ldclralb w8, w1, [x2]          : ldclralb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38e81841 : .inst  0x38e81841              : xx     $0x38e81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 38e82041 : ldeoralb w8, w1, [x2]          : ldeoralb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38e83041 : ldsetalb w8, w1, [x2]          : ldsetalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38e84041 : ldsmaxalb w8, w1, [x2]         : ldsmaxalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
@@ -554,12 +363,9 @@
 39bfffff : ldrsb  xzr, [sp,#4095]         : ldrsb  +0x0fff(%sp)[1byte] -> %xzr
 39c81041 : ldrsb  w1, [x2,#516]           : ldrsb  +0x0204(%x2)[1byte] -> %w1
 39ffffff : ldrsb  wzr, [sp,#4095]         : ldrsb  +0x0fff(%sp)[1byte] -> %wzr
-3a080041 : adcs   w1, w2, w8              : adcs   %w2 %w8 -> %w1
 3a1f03ff : adcs   wzr, wzr, wzr           : adcs   %wzr %wzr -> %wzr
 3a40f820 : ccmn   w1, #0x0, #0x0, nv      : ccmn   %w1 $0x00 $0x00 nv
 3a42f020 : ccmn   w1, w2, #0x0, nv        : ccmn   %w1 %w2 $0x00 nv
-3a481041 : ccmn   w2, w8, #0x1, ne        : ccmn   %w2 %w8 $0x01 ne
-3a481841 : ccmn   w2, #0x8, #0x1, ne      : ccmn   %w2 $0x08 $0x01 ne
 3c000400 : str    b0, [x0],#0             : str    %b0 %x0 $0x0000000000000000 -> (%x0)[1byte] %x0
 3c000c00 : str    b0, [x0,#0]!            : str    %b0 %x0 $0x0000000000000000 -> (%x0)[1byte] %x0
 3c081041 : stur   b1, [x2,#129]           : stur   %b1 -> +0x81(%x2)[1byte]
@@ -576,7 +382,6 @@
 3c23d841 : str    b1, [x2,w3,sxtw #0]     : str    %b1 -> (%x2,%x3,sxtw #0)[1byte]
 3c23e841 : str    b1, [x2,x3,sxtx]        : str    %b1 -> (%x2,%x3,sxtx)[1byte]
 3c23f841 : str    b1, [x2,x3,sxtx #0]     : str    %b1 -> (%x2,%x3,sxtx #0)[1byte]
-3c281841 : .inst  0x3c281841              : xx     $0x3c281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 3c3f4bff : str    b31, [sp,wzr,uxtw]      : str    %b31 -> (%sp,%xzr,uxtw)[1byte]
 3c3f5bff : str    b31, [sp,wzr,uxtw #0]   : str    %b31 -> (%sp,%xzr,uxtw #0)[1byte]
 3c3f6bff : str    b31, [sp,xzr]           : str    %b31 -> (%sp,%xzr)[1byte]
@@ -601,7 +406,6 @@
 3c63d841 : ldr    b1, [x2,w3,sxtw #0]     : ldr    (%x2,%x3,sxtw #0)[1byte] -> %b1
 3c63e841 : ldr    b1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[1byte] -> %b1
 3c63f841 : ldr    b1, [x2,x3,sxtx #0]     : ldr    (%x2,%x3,sxtx #0)[1byte] -> %b1
-3c681841 : .inst  0x3c681841              : xx     $0x3c681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 3c7f4bff : ldr    b31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[1byte] -> %b31
 3c7f5bff : ldr    b31, [sp,wzr,uxtw #0]   : ldr    (%sp,%xzr,uxtw #0)[1byte] -> %b31
 3c7f6bff : ldr    b31, [sp,xzr]           : ldr    (%sp,%xzr)[1byte] -> %b31
@@ -626,7 +430,6 @@
 3ca3d841 : str    q1, [x2,w3,sxtw #4]     : str    %b1 -> (%x2,%x3,sxtw #4)[16byte]
 3ca3e841 : str    q1, [x2,x3,sxtx]        : str    %b1 -> (%x2,%x3,sxtx)[16byte]
 3ca3f841 : str    q1, [x2,x3,sxtx #4]     : str    %b1 -> (%x2,%x3,sxtx #4)[16byte]
-3ca81841 : .inst  0x3ca81841              : xx     $0x3ca81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 3cbf4bff : str    q31, [sp,wzr,uxtw]      : str    %b31 -> (%sp,%xzr,uxtw)[16byte]
 3cbf5bff : str    q31, [sp,wzr,uxtw #4]   : str    %b31 -> (%sp,%xzr,uxtw #4)[16byte]
 3cbf6bff : str    q31, [sp,xzr]           : str    %b31 -> (%sp,%xzr)[16byte]
@@ -651,7 +454,6 @@
 3ce3d841 : ldr    q1, [x2,w3,sxtw #4]     : ldr    (%x2,%x3,sxtw #4)[16byte] -> %q1
 3ce3e841 : ldr    q1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[16byte] -> %q1
 3ce3f841 : ldr    q1, [x2,x3,sxtx #4]     : ldr    (%x2,%x3,sxtx #4)[16byte] -> %q1
-3ce81841 : .inst  0x3ce81841              : xx     $0x3ce81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 3cff4bff : ldr    q31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[16byte] -> %q31
 3cff5bff : ldr    q31, [sp,wzr,uxtw #4]   : ldr    (%sp,%xzr,uxtw #4)[16byte] -> %q31
 3cff6bff : ldr    q31, [sp,xzr]           : ldr    (%sp,%xzr)[16byte] -> %q31
@@ -673,93 +475,49 @@
 481f7fff : stxrh  wzr, wzr, [sp]          : stxrh  %wzr $0x1f -> (%sp)[2byte] %wzr
 481fffff : stlxrh wzr, wzr, [sp]          : stlxrh %wzr $0x1f -> (%sp)[2byte] %wzr
 48287c40 : casp   x8, x9, x0, x1, [x2]    : casp   %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
-48287c41 : .inst  0x48287c41              : xx     $0x48287c41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 4828fc40 : caspl  x8, x9, x0, x1, [x2]    : caspl  %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
-4828fc41 : .inst  0x4828fc41              : xx     $0x4828fc41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 483e7ffe : casp   x30, xzr, x30, xzr, [sp]: casp   %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
 483efffe : caspl  x30, xzr, x30, xzr, [sp]: caspl  %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
-483f7fff : .inst  0x483f7fff              : xx     $0x483f7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
-483fffff : .inst  0x483fffff              : xx     $0x483fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 48481041 : ldxrh  w1, [x2]                : ldxrh  (%x2)[2byte] $0x04 $0x08 -> %w1
 48489041 : ldaxrh w1, [x2]                : ldaxrh (%x2)[2byte] $0x04 $0x08 -> %w1
 485f7fff : ldxrh  wzr, [sp]               : ldxrh  (%sp)[2byte] $0x1f $0x1f -> %wzr
 485fffff : ldaxrh wzr, [sp]               : ldaxrh (%sp)[2byte] $0x1f $0x1f -> %wzr
 48687c40 : caspa  x8, x9, x0, x1, [x2]    : caspa  %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
-48687c41 : .inst  0x48687c41              : xx     $0x48687c41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 4868fc40 : caspal x8, x9, x0, x1, [x2]    : caspal %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
-4868fc41 : .inst  0x4868fc41              : xx     $0x4868fc41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 487e7ffe : caspa  x30, xzr, x30, xzr, [sp]: caspa  %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
 487efffe : caspal x30, xzr, x30, xzr, [sp]: caspal %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
-487f7fff : .inst  0x487f7fff              : xx     $0x487f7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
-487fffff : .inst  0x487fffff              : xx     $0x487fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 48889041 : stlrh  w1, [x2]                : stlrh  %w1 $0x04 $0x08 -> (%x2)[2byte]
 489fffff : stlrh  wzr, [sp]               : stlrh  %wzr $0x1f $0x1f -> (%sp)[2byte]
 48a87c41 : cash   w8, w1, [x2]            : cash   %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
 48a8fc41 : caslh  w8, w1, [x2]            : caslh  %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
 48bf7fff : cash   wzr, wzr, [sp]          : cash   %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
 48bfffff : caslh  wzr, wzr, [sp]          : caslh  %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-48c89041 : .inst  0x48c89041              : ldarh  (%x2)[2byte] $0x04 $0x08 -> %w1
 48dfffff : ldarh  wzr, [sp]               : ldarh  (%sp)[2byte] $0x1f $0x1f -> %wzr
 48e87c41 : casah  w8, w1, [x2]            : casah  %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
 48e8fc41 : casalh w8, w1, [x2]            : casalh %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
 48ff7fff : casah  wzr, wzr, [sp]          : casah  %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
 48ffffff : casalh wzr, wzr, [sp]          : casalh %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
 4a031041 : eor    w1, w2, w3, lsl #4      : eor    %w2 %w3 lsl $0x04 -> %w1
-4a081041 : eor    w1, w2, w8, lsl #4      : eor    %w2 %w8 lsl $0x04 -> %w1
 4a231041 : eon    w1, w2, w3, lsl #4      : eon    %w2 %w3 lsl $0x04 -> %w1
-4a281041 : eon    w1, w2, w8, lsl #4      : eon    %w2 %w8 lsl $0x04 -> %w1
 4a9f13ff : eor    wzr, wzr, wzr, asr #4   : eor    %wzr %wzr asr $0x04 -> %wzr
 4abf13ff : eon    wzr, wzr, wzr, asr #4   : eon    %wzr %wzr asr $0x04 -> %wzr
-4adf7fff : eor    wzr, wzr, wzr, ror #31  : eor    %wzr %wzr ror $0x1f -> %wzr
-4aff7fff : eon    wzr, wzr, wzr, ror #31  : eon    %wzr %wzr ror $0x1f -> %wzr
 4b031041 : sub    w1, w2, w3, lsl #4      : sub    %w2 %w3 lsl $0x04 -> %w1
-4b081041 : sub    w1, w2, w8, lsl #4      : sub    %w2 %w8 lsl $0x04 -> %w1
-4b281041 : sub    w1, w2, w8, uxtb #4     : sub    %w2 %w8 uxtb $0x04 -> %w1
 4b9f13ff : neg    wzr, wzr, asr #4        : sub    %wzr %wzr asr $0x04 -> %wzr
 4b9f7fff : neg    wzr, wzr, asr #31       : sub    %wzr %wzr asr $0x1f -> %wzr
-4bdf7fff : .inst  0x4bdf7fff              : xx     $0x4bdf7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
-4c000fff : st4    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp]: st4    $0x03 %q31 %q0 %q1 %q2 -> (%sp)[64byte]
 4c0027ff : st1    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp]: st1    $0x01 %q31 %q0 %q1 %q2 -> (%sp)[64byte]
-4c002fff : st1    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp]: st1    $0x03 %q31 %q0 %q1 %q2 -> (%sp)[64byte]
 4c0047ff : st3    {v31.8h, v0.8h, v1.8h}, [sp]: st3    $0x01 %q31 %q0 %q1 -> (%sp)[48byte]
-4c004fff : st3    {v31.2d, v0.2d, v1.2d}, [sp]: st3    $0x03 %q31 %q0 %q1 -> (%sp)[48byte]
-4c006fff : st1    {v31.2d, v0.2d, v1.2d}, [sp]: st1    $0x03 %q31 %q0 %q1 -> (%sp)[48byte]
-4c007fff : st1    {v31.2d}, [sp]          : st1    $0x03 %q31 -> (%sp)[16byte]
 4c0087ff : st2    {v31.8h, v0.8h}, [sp]   : st2    $0x01 %q31 %q0 -> (%sp)[32byte]
-4c008fff : st2    {v31.2d, v0.2d}, [sp]   : st2    $0x03 %q31 %q0 -> (%sp)[32byte]
-4c00afff : st1    {v31.2d, v0.2d}, [sp]   : st1    $0x03 %q31 %q0 -> (%sp)[32byte]
 4c4007ff : ld4    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp]: ld4    (%sp)[64byte] $0x01 -> %q31 %q0 %q1 %q2
-4c400fff : ld4    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp]: ld4    (%sp)[64byte] $0x03 -> %q31 %q0 %q1 %q2
-4c402fff : ld1    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp]: ld1    (%sp)[64byte] $0x03 -> %q31 %q0 %q1 %q2
-4c404fff : ld3    {v31.2d, v0.2d, v1.2d}, [sp]: ld3    (%sp)[48byte] $0x03 -> %q31 %q0 %q1
 4c4067ff : ld1    {v31.8h, v0.8h, v1.8h}, [sp]: ld1    (%sp)[48byte] $0x01 -> %q31 %q0 %q1
-4c406fff : ld1    {v31.2d, v0.2d, v1.2d}, [sp]: ld1    (%sp)[48byte] $0x03 -> %q31 %q0 %q1
 4c4077ff : ld1    {v31.8h}, [sp]          : ld1    (%sp)[16byte] $0x01 -> %q31
-4c407fff : ld1    {v31.2d}, [sp]          : ld1    (%sp)[16byte] $0x03 -> %q31
-4c408fff : ld2    {v31.2d, v0.2d}, [sp]   : ld2    (%sp)[32byte] $0x03 -> %q31 %q0
 4c40a7ff : ld1    {v31.8h, v0.8h}, [sp]   : ld1    (%sp)[32byte] $0x01 -> %q31 %q0
-4c40afff : ld1    {v31.2d, v0.2d}, [sp]   : ld1    (%sp)[32byte] $0x03 -> %q31 %q0
 4c9f07ff : st4    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp], #64: st4    $0x01 %q31 %q0 %q1 %q2 %sp $0x40 -> (%sp)[64byte] %sp
-4c9f0fff : st4    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], #64: st4    $0x03 %q31 %q0 %q1 %q2 %sp $0x40 -> (%sp)[64byte] %sp
-4c9f2fff : st1    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], #64: st1    $0x03 %q31 %q0 %q1 %q2 %sp $0x40 -> (%sp)[64byte] %sp
-4c9f4fff : st3    {v31.2d, v0.2d, v1.2d}, [sp], #48: st3    $0x03 %q31 %q0 %q1 %sp $0x30 -> (%sp)[48byte] %sp
 4c9f67ff : st1    {v31.8h, v0.8h, v1.8h}, [sp], #48: st1    $0x01 %q31 %q0 %q1 %sp $0x30 -> (%sp)[48byte] %sp
-4c9f6fff : st1    {v31.2d, v0.2d, v1.2d}, [sp], #48: st1    $0x03 %q31 %q0 %q1 %sp $0x30 -> (%sp)[48byte] %sp
 4c9f77ff : st1    {v31.8h}, [sp], #16     : st1    $0x01 %q31 %sp $0x10 -> (%sp)[16byte] %sp
-4c9f7fff : st1    {v31.2d}, [sp], #16     : st1    $0x03 %q31 %sp $0x10 -> (%sp)[16byte] %sp
-4c9f8fff : st2    {v31.2d, v0.2d}, [sp], #32: st2    $0x03 %q31 %q0 %sp $0x20 -> (%sp)[32byte] %sp
 4c9fa7ff : st1    {v31.8h, v0.8h}, [sp], #32: st1    $0x01 %q31 %q0 %sp $0x20 -> (%sp)[32byte] %sp
-4c9fafff : st1    {v31.2d, v0.2d}, [sp], #32: st1    $0x03 %q31 %q0 %sp $0x20 -> (%sp)[32byte] %sp
-4cdf0fff : ld4    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], #64: ld4    (%sp)[64byte] $0x03 %sp $0x40 -> %q31 %q0 %q1 %q2 %sp
 4cdf27ff : ld1    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp], #64: ld1    (%sp)[64byte] $0x01 %sp $0x40 -> %q31 %q0 %q1 %q2 %sp
-4cdf2fff : ld1    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], #64: ld1    (%sp)[64byte] $0x03 %sp $0x40 -> %q31 %q0 %q1 %q2 %sp
 4cdf47ff : ld3    {v31.8h, v0.8h, v1.8h}, [sp], #48: ld3    (%sp)[48byte] $0x01 %sp $0x30 -> %q31 %q0 %q1 %sp
-4cdf4fff : ld3    {v31.2d, v0.2d, v1.2d}, [sp], #48: ld3    (%sp)[48byte] $0x03 %sp $0x30 -> %q31 %q0 %q1 %sp
-4cdf6fff : ld1    {v31.2d, v0.2d, v1.2d}, [sp], #48: ld1    (%sp)[48byte] $0x03 %sp $0x30 -> %q31 %q0 %q1 %sp
-4cdf7fff : ld1    {v31.2d}, [sp], #16     : ld1    (%sp)[16byte] $0x03 %sp $0x10 -> %q31 %sp
 4cdf87ff : ld2    {v31.8h, v0.8h}, [sp], #32: ld2    (%sp)[32byte] $0x01 %sp $0x20 -> %q31 %q0 %sp
-4cdf8fff : ld2    {v31.2d, v0.2d}, [sp], #32: ld2    (%sp)[32byte] $0x03 %sp $0x20 -> %q31 %q0 %sp
-4cdfafff : ld1    {v31.2d, v0.2d}, [sp], #32: ld1    (%sp)[32byte] $0x03 %sp $0x20 -> %q31 %q0 %sp
 4d001fff : st1    {v31.b}[15], [sp]       : st1    %q31 $0x0f -> (%sp)[1byte]
 4d003fff : st3    {v31.b, v0.b, v1.b}[15], [sp]: st3    %q31 %q0 %q1 $0x0f -> (%sp)[3byte]
 4d005bff : st1    {v31.h}[7], [sp]        : st1    %q31 $0x07 -> (%sp)[2byte]
@@ -785,8 +543,6 @@
 4d40a7ff : ld3    {v31.d, v0.d, v1.d}[1], [sp]: ld3    (%sp)[24byte] $0x01 -> %q31 %q0 %q1
 4d40b3ff : ld3    {v31.s, v0.s, v1.s}[3], [sp]: ld3    (%sp)[12byte] $0x03 -> %q31 %q0 %q1
 4d40c3ff : ld1r   {v31.16b}, [sp]         : ld1r   (%sp)[1byte] -> %q31
-4d40cfff : ld1r   {v31.2d}, [sp]          : ld1r   (%sp)[8byte] -> %q31
-4d40efff : ld3r   {v31.2d, v0.2d, v1.2d}, [sp]: ld3r   (%sp)[24byte] -> %q31 %q0 %q1
 4d601fff : ld2    {v31.b, v0.b}[15], [sp] : ld2    (%sp)[2byte] $0x0f -> %q31 %q0
 4d603fff : ld4    {v31.b, v0.b, v1.b, v2.b}[15], [sp]: ld4    (%sp)[4byte] $0x0f -> %q31 %q0 %q1 %q2
 4d605bff : ld2    {v31.h, v0.h}[7], [sp]  : ld2    (%sp)[4byte] $0x07 -> %q31 %q0
@@ -795,7 +551,6 @@
 4d6093ff : ld2    {v31.s, v0.s}[3], [sp]  : ld2    (%sp)[8byte] $0x03 -> %q31 %q0
 4d60a7ff : ld4    {v31.d, v0.d, v1.d, v2.d}[1], [sp]: ld4    (%sp)[32byte] $0x01 -> %q31 %q0 %q1 %q2
 4d60b3ff : ld4    {v31.s, v0.s, v1.s, v2.s}[3], [sp]: ld4    (%sp)[16byte] $0x03 -> %q31 %q0 %q1 %q2
-4d60cfff : ld2r   {v31.2d, v0.2d}, [sp]   : ld2r   (%sp)[16byte] -> %q31 %q0
 4d60efff : ld4r   {v31.2d, v0.2d, v1.2d, v2.2d}, [sp]: ld4r   (%sp)[32byte] -> %q31 %q0 %q1 %q2
 4d9f1fff : st1    {v31.b}[15], [sp], #1   : st1    %q31 $0x0f %sp $0x01 -> (%sp)[1byte] %sp
 4d9f3fff : st3    {v31.b, v0.b, v1.b}[15], [sp], #3: st3    %q31 %q0 %q1 $0x0f %sp $0x03 -> (%sp)[3byte] %sp
@@ -823,13 +578,6 @@
 4ddfa7ff : ld3    {v31.d, v0.d, v1.d}[1], [sp], #24: ld3    %q31 %q0 %q1 (%sp)[24byte] $0x01 %sp $0x18 -> %q31 %q0 %q1 %sp
 4ddfb3ff : ld3    {v31.s, v0.s, v1.s}[3], [sp], #12: ld3    %q31 %q0 %q1 (%sp)[12byte] $0x03 %sp $0x0c -> %q31 %q0 %q1 %sp
 4ddfc3ff : ld1r   {v31.16b}, [sp], #1     : ld1r   (%sp)[1byte] %sp $0x01 -> %q31 %sp
-4ddfc7ff : ld1r   {v31.8h}, [sp], #2      : ld1r   (%sp)[2byte] %sp $0x02 -> %q31 %sp
-4ddfcbff : ld1r   {v31.4s}, [sp], #4      : ld1r   (%sp)[4byte] %sp $0x04 -> %q31 %sp
-4ddfcfff : ld1r   {v31.2d}, [sp], #8      : ld1r   (%sp)[8byte] %sp $0x08 -> %q31 %sp
-4ddfe3ff : ld3r   {v31.16b, v0.16b, v1.16b}, [sp], #3: ld3r   (%sp)[3byte] %sp $0x03 -> %q31 %q0 %q1 %sp
-4ddfe7ff : ld3r   {v31.8h, v0.8h, v1.8h}, [sp], #6: ld3r   (%sp)[6byte] %sp $0x06 -> %q31 %q0 %q1 %sp
-4ddfebff : ld3r   {v31.4s, v0.4s, v1.4s}, [sp], #12: ld3r   (%sp)[12byte] %sp $0x0c -> %q31 %q0 %q1 %sp
-4ddfefff : ld3r   {v31.2d, v0.2d, v1.2d}, [sp], #24: ld3r   (%sp)[24byte] %sp $0x18 -> %q31 %q0 %q1 %sp
 4df0efff : ld4r   {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], x16: ld4r   (%sp)[32byte] %sp %x16 -> %q31 %q0 %q1 %q2 %sp
 4dff1fff : ld2    {v31.b, v0.b}[15], [sp], #2: ld2    %q31 %q0 (%sp)[2byte] $0x0f %sp $0x02 -> %q31 %q0 %sp
 4dff3fff : ld4    {v31.b, v0.b, v1.b, v2.b}[15], [sp], #4: ld4    %q31 %q0 %q1 %q2 (%sp)[4byte] $0x0f %sp $0x04 -> %q31 %q0 %q1 %q2 %sp
@@ -839,25 +587,13 @@
 4dff93ff : ld2    {v31.s, v0.s}[3], [sp], #8: ld2    %q31 %q0 (%sp)[8byte] $0x03 %sp $0x08 -> %q31 %q0 %sp
 4dffa7ff : ld4    {v31.d, v0.d, v1.d, v2.d}[1], [sp], #32: ld4    %q31 %q0 %q1 %q2 (%sp)[32byte] $0x01 %sp $0x20 -> %q31 %q0 %q1 %q2 %sp
 4dffb3ff : ld4    {v31.s, v0.s, v1.s, v2.s}[3], [sp], #16: ld4    %q31 %q0 %q1 %q2 (%sp)[16byte] $0x03 %sp $0x10 -> %q31 %q0 %q1 %q2 %sp
-4dffc3ff : ld2r   {v31.16b, v0.16b}, [sp], #2: ld2r   (%sp)[2byte] %sp $0x02 -> %q31 %q0 %sp
-4dffc7ff : ld2r   {v31.8h, v0.8h}, [sp], #4: ld2r   (%sp)[4byte] %sp $0x04 -> %q31 %q0 %sp
-4dffcbff : ld2r   {v31.4s, v0.4s}, [sp], #8: ld2r   (%sp)[8byte] %sp $0x08 -> %q31 %q0 %sp
-4dffcfff : ld2r   {v31.2d, v0.2d}, [sp], #16: ld2r   (%sp)[16byte] %sp $0x10 -> %q31 %q0 %sp
-4dffe3ff : ld4r   {v31.16b, v0.16b, v1.16b, v2.16b}, [sp], #4: ld4r   (%sp)[4byte] %sp $0x04 -> %q31 %q0 %q1 %q2 %sp
-4dffe7ff : ld4r   {v31.8h, v0.8h, v1.8h, v2.8h}, [sp], #8: ld4r   (%sp)[8byte] %sp $0x08 -> %q31 %q0 %q1 %q2 %sp
-4dffebff : ld4r   {v31.4s, v0.4s, v1.4s, v2.4s}, [sp], #16: ld4r   (%sp)[16byte] %sp $0x10 -> %q31 %q0 %q1 %q2 %sp
 4dffefff : ld4r   {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], #32: ld4r   (%sp)[32byte] %sp $0x20 -> %q31 %q0 %q1 %q2 %sp
 51000c41 : sub    w1, w2, #0x3            : sub    %w2 $0x0003 lsl $0x00 -> %w1
 51000fff : sub    wsp, wsp, #0x3          : sub    %wsp $0x0003 lsl $0x00 -> %wsp
-51081041 : sub    w1, w2, #0x204          : sub    %w2 $0x0204 lsl $0x00 -> %w1
 52000441 : eor    w1, w2, #0x3            : eor    %w2 $0x00000003 -> %w1
-52081041 : eor    w1, w2, #0x1f000000     : eor    %w2 $0x1f000000 -> %w1
 52881041 : mov    w1, #0x4082             : movz   $0x4082 lsl $0x00 -> %w1
-52ffffff : .inst  0x52ffffff              : xx     $0x52ffffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 53031041 : ubfx   w1, w2, #3, #2          : ubfm   %w2 $0x03 $0x04 -> %w1
-53081041 : ubfiz  w1, w2, #24, #5         : ubfm   %w2 $0x08 $0x04 -> %w1
 531f7fff : lsr    wzr, wzr, #31           : ubfm   %wzr $0x1f $0x1f -> %wzr
-533fffff : .inst  0x533fffff              : xx     $0x533fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 54000000 : b.eq   10000000                : b.eq   $0x0000000010000000
 54000001 : b.ne   10000000                : b.ne   $0x0000000010000000
 54000002 : b.cs   10000000                : b.cs   $0x0000000010000000
@@ -871,88 +607,60 @@
 5400000a : b.ge   10000000                : b.ge   $0x0000000010000000
 5400000b : b.lt   10000000                : b.lt   $0x0000000010000000
 5400002c : b.gt   10000004                : b.gt   $0x0000000010000004
-54081041 : b.ne   10010208                : b.ne   $0x0000000010010208
 547fffed : b.le   100ffffc                : b.le   $0x00000000100ffffc
 547fffef : b.nv   100ffffc                : b.nv   $0x00000000100ffffc
 5480000e : b.al   ff00000                 : b.al   $0x000000000ff00000
 54ffffef : b.nv   ffffffc                 : b.nv   $0x000000000ffffffc
-58081041 : ldr    x1, 10010208            : ldr    <rel> 0x0000000010010208[8byte] -> %x1
 587fffff : ldr    xzr, 100ffffc           : ldr    <rel> 0x00000000100ffffc[8byte] -> %xzr
 58800000 : ldr    x0, ff00000             : ldr    <rel> 0x000000000ff00000[8byte] -> %x0
 58ffffff : ldr    xzr, ffffffc            : ldr    <rel> 0x000000000ffffffc[8byte] -> %xzr
-5a080041 : sbc    w1, w2, w8              : sbc    %w2 %w8 -> %w1
 5a1f03ff : ngc    wzr, wzr                : sbc    %wzr %wzr -> %wzr
 5a8383e1 : csinv  w1, wzr, w3, hi         : csinv  %wzr %w3 hi -> %w1
-5a881041 : csinv  w1, w2, w8, ne          : csinv  %w2 %w8 ne -> %w1
-5a881441 : csneg  w1, w2, w8, ne          : csneg  %w2 %w8 ne -> %w1
 5ac00041 : rbit   w1, w2                  : rbit   %w2 -> %w1
 5ac00441 : rev16  w1, w2                  : rev16  %w2 -> %w1
 5ac00841 : rev    w1, w2                  : rev    %w2 -> %w1
-5ac00bff : rev    wzr, wzr                : rev    %wzr -> %wzr
 5ac01041 : clz    w1, w2                  : clz    %w2 -> %w1
 5ac01441 : cls    w1, w2                  : cls    %w2 -> %w1
-5c081041 : ldr    d1, 10010208            : ldr    <rel> 0x0000000010010208[8byte] -> %d1
 5c7fffff : ldr    d31, 100ffffc           : ldr    <rel> 0x00000000100ffffc[8byte] -> %d31
 5c800000 : ldr    d0, ff00000             : ldr    <rel> 0x000000000ff00000[8byte] -> %d0
-5cffffff : ldr    d31, ffffffc            : ldr    <rel> 0x000000000ffffffc[8byte] -> %d31
 68c00000 : ldpsw  x0, x0, [x0],#0         : ldpsw  (%x0)[8byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
-68c81041 : ldpsw  x1, x4, [x2],#64        : ldpsw  (%x2)[8byte] %x2 $0x0000000000000040 -> %x1 %x4 %x2
 68ffffff : ldpsw  xzr, xzr, [sp],#-4      : ldpsw  (%sp)[8byte] %sp $0xfffffffffffffffc -> %xzr %xzr %sp
 69400000 : ldpsw  x0, x0, [x0]            : ldpsw  (%x0)[8byte] -> %x0 %x0
-69481041 : ldpsw  x1, x4, [x2,#64]        : ldpsw  +0x40(%x2)[8byte] -> %x1 %x4
 697fffff : ldpsw  xzr, xzr, [sp,#-4]      : ldpsw  -0x04(%sp)[8byte] -> %xzr %xzr
 69c00000 : ldpsw  x0, x0, [x0,#0]!        : ldpsw  (%x0)[8byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
-69c81041 : ldpsw  x1, x4, [x2,#64]!       : ldpsw  +0x40(%x2)[8byte] %x2 $0x0000000000000040 -> %x1 %x4 %x2
 69ffffff : ldpsw  xzr, xzr, [sp,#-4]!     : ldpsw  -0x04(%sp)[8byte] %sp $0xfffffffffffffffc -> %xzr %xzr %sp
 6a031041 : ands   w1, w2, w3, lsl #4      : ands   %w2 %w3 lsl $0x04 -> %w1
-6a081041 : ands   w1, w2, w8, lsl #4      : ands   %w2 %w8 lsl $0x04 -> %w1
 6a231041 : bics   w1, w2, w3, lsl #4      : bics   %w2 %w3 lsl $0x04 -> %w1
-6a281041 : bics   w1, w2, w8, lsl #4      : bics   %w2 %w8 lsl $0x04 -> %w1
 6a9f13ff : tst    wzr, wzr, asr #4        : ands   %wzr %wzr asr $0x04 -> %wzr
 6abf13ff : bics   wzr, wzr, wzr, asr #4   : bics   %wzr %wzr asr $0x04 -> %wzr
-6adf7fff : tst    wzr, wzr, ror #31       : ands   %wzr %wzr ror $0x1f -> %wzr
 6aff7fff : bics   wzr, wzr, wzr, ror #31  : bics   %wzr %wzr ror $0x1f -> %wzr
 6b031041 : subs   w1, w2, w3, lsl #4      : subs   %w2 %w3 lsl $0x04 -> %w1
-6b081041 : subs   w1, w2, w8, lsl #4      : subs   %w2 %w8 lsl $0x04 -> %w1
 6b1f7fff : negs   wzr, wzr, lsl #31       : subs   %wzr %wzr lsl $0x1f -> %wzr
-6b281041 : subs   w1, w2, w8, uxtb #4     : subs   %w2 %w8 uxtb $0x04 -> %w1
 6b3f8fff : cmp    wsp, wzr, sxtb #3       : subs   %wsp %wzr sxtb $0x03 -> %wzr
 6b3fc7ff : cmp    wsp, wzr, sxtw #1       : subs   %wsp %wzr sxtw $0x01 -> %wzr
 6b9f13ff : negs   wzr, wzr, asr #4        : subs   %wzr %wzr asr $0x04 -> %wzr
-6bdf7fff : .inst  0x6bdf7fff              : xx     $0x6bdf7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
 6c000000 : stnp   d0, d0, [x0]            : stnp   %d0 %d0 -> (%x0)[16byte]
-6c081041 : stnp   d1, d4, [x2,#128]       : stnp   %d1 %d4 -> +0x80(%x2)[16byte]
 6c3fffff : stnp   d31, d31, [sp,#-8]      : stnp   %d31 %d31 -> -0x08(%sp)[16byte]
 6c400000 : ldnp   d0, d0, [x0]            : ldnp   (%x0)[16byte] -> %d0 %d0
-6c481041 : ldnp   d1, d4, [x2,#128]       : ldnp   +0x80(%x2)[16byte] -> %d1 %d4
 6c7fffff : ldnp   d31, d31, [sp,#-8]      : ldnp   -0x08(%sp)[16byte] -> %d31 %d31
 6c800000 : stp    d0, d0, [x0],#0         : stp    %d0 %d0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
-6c881041 : stp    d1, d4, [x2],#128       : stp    %d1 %d4 %x2 $0x0000000000000080 -> (%x2)[16byte] %x2
 6cbfffff : stp    d31, d31, [sp],#-8      : stp    %d31 %d31 %sp $0xfffffffffffffff8 -> (%sp)[16byte] %sp
 6cc00000 : ldp    d0, d0, [x0],#0         : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %d0 %d0 %x0
-6cc81041 : ldp    d1, d4, [x2],#128       : ldp    (%x2)[16byte] %x2 $0x0000000000000080 -> %d1 %d4 %x2
 6cffffff : ldp    d31, d31, [sp],#-8      : ldp    (%sp)[16byte] %sp $0xfffffffffffffff8 -> %d31 %d31 %sp
 6d000000 : stp    d0, d0, [x0]            : stp    %d0 %d0 -> (%x0)[16byte]
-6d081041 : stp    d1, d4, [x2,#128]       : stp    %d1 %d4 -> +0x80(%x2)[16byte]
 6d3fffff : stp    d31, d31, [sp,#-8]      : stp    %d31 %d31 -> -0x08(%sp)[16byte]
 6d400000 : ldp    d0, d0, [x0]            : ldp    (%x0)[16byte] -> %d0 %d0
-6d481041 : ldp    d1, d4, [x2,#128]       : ldp    +0x80(%x2)[16byte] -> %d1 %d4
 6d7fffff : ldp    d31, d31, [sp,#-8]      : ldp    -0x08(%sp)[16byte] -> %d31 %d31
 6d800000 : stp    d0, d0, [x0,#0]!        : stp    %d0 %d0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
-6d881041 : stp    d1, d4, [x2,#128]!      : stp    %d1 %d4 %x2 $0x0000000000000080 -> +0x80(%x2)[16byte] %x2
 6dbfffff : stp    d31, d31, [sp,#-8]!     : stp    %d31 %d31 %sp $0xfffffffffffffff8 -> -0x08(%sp)[16byte] %sp
 6dc00000 : ldp    d0, d0, [x0,#0]!        : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %d0 %d0 %x0
-6dc81041 : ldp    d1, d4, [x2,#128]!      : ldp    +0x80(%x2)[16byte] %x2 $0x0000000000000080 -> %d1 %d4 %x2
 6dffffff : ldp    d31, d31, [sp,#-8]!     : ldp    -0x08(%sp)[16byte] %sp $0xfffffffffffffff8 -> %d31 %d31 %sp
 707fffff : adr    xzr, 100fffff           : adr    <rel> 0x00000000100fffff -> %xzr
 70ffffff : adr    xzr, fffffff            : adr    <rel> 0x000000000fffffff -> %xzr
 71000c41 : subs   w1, w2, #0x3            : subs   %w2 $0x0003 lsl $0x00 -> %w1
 71000fff : cmp    wsp, #0x3               : subs   %wsp $0x0003 lsl $0x00 -> %wzr
-71081041 : subs   w1, w2, #0x204          : subs   %w2 $0x0204 lsl $0x00 -> %w1
 72000441 : ands   w1, w2, #0x3            : ands   %w2 $0x00000003 -> %w1
-72081041 : ands   w1, w2, #0x1f000000     : ands   %w2 $0x1f000000 -> %w1
 72881041 : movk   w1, #0x4082             : movk   %w1 $0x4082 lsl $0x00 -> %w1
-72ffffff : .inst  0x72ffffff              : xx     $0x72ffffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 78000400 : strh   w0, [x0],#0             : strh   %w0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
 78000c00 : strh   w0, [x0,#0]!            : strh   %w0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
 78081041 : sturh  w1, [x2,#129]           : sturh  %w1 -> +0x81(%x2)[2byte]
@@ -973,7 +681,6 @@
 7823f841 : strh   w1, [x2,x3,sxtx #1]     : strh   %w1 -> (%x2,%x3,sxtx #1)[2byte]
 78280041 : ldaddh w8, w1, [x2]            : ldaddh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78281041 : ldclrh w8, w1, [x2]            : ldclrh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78281841 : .inst  0x78281841              : xx     $0x78281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 78282041 : ldeorh w8, w1, [x2]            : ldeorh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78283041 : ldseth w8, w1, [x2]            : ldseth %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78284041 : ldsmaxh w8, w1, [x2]           : ldsmaxh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
@@ -1018,7 +725,6 @@
 7863f841 : ldrh   w1, [x2,x3,sxtx #1]     : ldrh   (%x2,%x3,sxtx #1)[2byte] -> %w1
 78680041 : ldaddlh w8, w1, [x2]           : ldaddlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78681041 : ldclrlh w8, w1, [x2]           : ldclrlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78681841 : .inst  0x78681841              : xx     $0x78681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 78682041 : ldeorlh w8, w1, [x2]           : ldeorlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78683041 : ldsetlh w8, w1, [x2]           : ldsetlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78684041 : ldsmaxlh w8, w1, [x2]          : ldsmaxlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
@@ -1063,7 +769,6 @@
 78a3f841 : ldrsh  x1, [x2,x3,sxtx #1]     : ldrsh  (%x2,%x3,sxtx #1)[2byte] -> %x1
 78a80041 : ldaddah w8, w1, [x2]           : ldaddah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78a81041 : ldclrah w8, w1, [x2]           : ldclrah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78a81841 : .inst  0x78a81841              : xx     $0x78a81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 78a82041 : ldeorah w8, w1, [x2]           : ldeorah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78a83041 : ldsetah w8, w1, [x2]           : ldsetah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78a84041 : ldsmaxah w8, w1, [x2]          : ldsmaxah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
@@ -1108,7 +813,6 @@
 78e3f841 : ldrsh  w1, [x2,x3,sxtx #1]     : ldrsh  (%x2,%x3,sxtx #1)[2byte] -> %w1
 78e80041 : ldaddalh w8, w1, [x2]          : ldaddalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78e81041 : ldclralh w8, w1, [x2]          : ldclralh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78e81841 : .inst  0x78e81841              : xx     $0x78e81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 78e82041 : ldeoralh w8, w1, [x2]          : ldeoralh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78e83041 : ldsetalh w8, w1, [x2]          : ldsetalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78e84041 : ldsmaxalh w8, w1, [x2]         : ldsmaxalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
@@ -1142,10 +846,7 @@
 79c81041 : ldrsh  w1, [x2,#1032]          : ldrsh  +0x0408(%x2)[2byte] -> %w1
 79ffffff : ldrsh  wzr, [sp,#8190]         : ldrsh  +0x1ffe(%sp)[2byte] -> %wzr
 7a030041 : sbcs   w1, w2, w3              : sbcs   %w2 %w3 -> %w1
-7a080041 : sbcs   w1, w2, w8              : sbcs   %w2 %w8 -> %w1
 7a42e3e1 : ccmp   wzr, w2, #0x1, al       : ccmp   %wzr %w2 $0x01 al
-7a481041 : ccmp   w2, w8, #0x1, ne        : ccmp   %w2 %w8 $0x01 ne
-7a481841 : ccmp   w2, #0x8, #0x1, ne      : ccmp   %w2 $0x08 $0x01 ne
 7a4aebe1 : ccmp   wzr, #0xa, #0x1, al     : ccmp   %wzr $0x0a $0x01 al
 7c000400 : str    h0, [x0],#0             : str    %h0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
 7c000c00 : str    h0, [x0,#0]!            : str    %h0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
@@ -1163,7 +864,6 @@
 7c23d841 : str    h1, [x2,w3,sxtw #1]     : str    %h1 -> (%x2,%x3,sxtw #1)[2byte]
 7c23e841 : str    h1, [x2,x3,sxtx]        : str    %h1 -> (%x2,%x3,sxtx)[2byte]
 7c23f841 : str    h1, [x2,x3,sxtx #1]     : str    %h1 -> (%x2,%x3,sxtx #1)[2byte]
-7c281841 : .inst  0x7c281841              : xx     $0x7c281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 7c3f4bff : str    h31, [sp,wzr,uxtw]      : str    %h31 -> (%sp,%xzr,uxtw)[2byte]
 7c3f5bff : str    h31, [sp,wzr,uxtw #1]   : str    %h31 -> (%sp,%xzr,uxtw #1)[2byte]
 7c3f6bff : str    h31, [sp,xzr]           : str    %h31 -> (%sp,%xzr)[2byte]
@@ -1188,7 +888,6 @@
 7c63d841 : ldr    h1, [x2,w3,sxtw #1]     : ldr    (%x2,%x3,sxtw #1)[2byte] -> %h1
 7c63e841 : ldr    h1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[2byte] -> %h1
 7c63f841 : ldr    h1, [x2,x3,sxtx #1]     : ldr    (%x2,%x3,sxtx #1)[2byte] -> %h1
-7c681841 : .inst  0x7c681841              : xx     $0x7c681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 7c7f4bff : ldr    h31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[2byte] -> %h31
 7c7f5bff : ldr    h31, [sp,wzr,uxtw #1]   : ldr    (%sp,%xzr,uxtw #1)[2byte] -> %h31
 7c7f6bff : ldr    h31, [sp,xzr]           : ldr    (%sp,%xzr)[2byte] -> %h31
@@ -1223,44 +922,31 @@
 88a8fc41 : casl   w8, w1, [x2]            : casl   %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
 88bf7fff : cas    wzr, wzr, [sp]          : cas    %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
 88bfffff : casl   wzr, wzr, [sp]          : casl   %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-88c89041 : .inst  0x88c89041              : ldar   (%x2)[4byte] $0x04 $0x08 -> %w1
 88dfffff : ldar   wzr, [sp]               : ldar   (%sp)[4byte] $0x1f $0x1f -> %wzr
 88e87c41 : casa   w8, w1, [x2]            : casa   %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
 88e8fc41 : casal  w8, w1, [x2]            : casal  %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
 88ff7fff : casa   wzr, wzr, [sp]          : casa   %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
 88ffffff : casal  wzr, wzr, [sp]          : casal  %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-8a081041 : and    x1, x2, x8, lsl #4      : and    %x2 %x8 lsl $0x04 -> %x1
 8a1fffff : and    xzr, xzr, xzr, lsl #63  : and    %xzr %xzr lsl $0x3f -> %xzr
-8a281041 : bic    x1, x2, x8, lsl #4      : bic    %x2 %x8 lsl $0x04 -> %x1
 8a431041 : and    x1, x2, x3, lsr #4      : and    %x2 %x3 lsr $0x04 -> %x1
 8a631041 : bic    x1, x2, x3, lsr #4      : bic    %x2 %x3 lsr $0x04 -> %x1
 8adf13ff : and    xzr, xzr, xzr, ror #4   : and    %xzr %xzr ror $0x04 -> %xzr
-8adfffff : and    xzr, xzr, xzr, ror #63  : and    %xzr %xzr ror $0x3f -> %xzr
 8aff13ff : bic    xzr, xzr, xzr, ror #4   : bic    %xzr %xzr ror $0x04 -> %xzr
-8affffff : bic    xzr, xzr, xzr, ror #63  : bic    %xzr %xzr ror $0x3f -> %xzr
-8b081041 : add    x1, x2, x8, lsl #4      : add    %x2 %x8 lsl $0x04 -> %x1
 8b3f27ff : add    sp, sp, wzr, uxth #1    : add    %sp %xzr uxth $0x01 -> %sp
-8b3fffff : .inst  0x8b3fffff              : xx     $0x8b3fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 8b431041 : add    x1, x2, x3, lsr #4      : add    %x2 %x3 lsr $0x04 -> %x1
 8b5fffff : add    xzr, xzr, xzr, lsr #63  : add    %xzr %xzr lsr $0x3f -> %xzr
 8b9f13ff : add    xzr, xzr, xzr, asr #4   : add    %xzr %xzr asr $0x04 -> %xzr
-8bdfffff : .inst  0x8bdfffff              : xx     $0x8bdfffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 90081041 : adrp   x1, 20208000            : adrp   <rel> 0x0000000020208000 -> %x1
 90800000 : adrp   x0, ffffffff10000000    : adrp   <rel> 0xffffffff10000000 -> %x0
 91000c41 : add    x1, x2, #0x3            : add    %x2 $0x0003 lsl $0x00 -> %x1
 91000fff : add    sp, sp, #0x3            : add    %sp $0x0003 lsl $0x00 -> %sp
-917fffff : add    sp, sp, #0xfff, lsl #12 : add    %sp $0x0fff lsl $0x10 -> %sp
 9201f041 : and    x1, x2, #0xaaaaaaaaaaaaaaaa: and    %x2 $0xaaaaaaaaaaaaaaaa -> %x1
 923ff041 : and    x1, x2, #0xaaaaaaaaaaaaaaaa: and    %x2 $0xaaaaaaaaaaaaaaaa $0x0ffc -> %x1
 92400441 : and    x1, x2, #0x3            : and    %x2 $0x0000000000000003 -> %x1
-927fffff : .inst  0x927fffff              : xx     $0x927fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
-92881041 : mov    x1, #0xffffffffffffbf7d : movn   $0x4082 lsl $0x00 -> %x1
 92ffffff : mov    xzr, #0xffffffffffff    : movn   $0xffff lsl $0x30 -> %xzr
 93431041 : sbfx   x1, x2, #3, #2          : sbfm   %x2 $0x03 $0x04 -> %x1
-93481041 : sbfiz  x1, x2, #56, #5         : sbfm   %x2 $0x08 $0x04 -> %x1
 937fffff : asr    xzr, xzr, #63           : sbfm   %xzr $0x3f $0x3f -> %xzr
 93c31041 : extr   x1, x2, x3, #4          : extr   %x2 %x3 $0x04 -> %x1
-93c81041 : extr   x1, x2, x8, #4          : extr   %x2 %x8 $0x04 -> %x1
 93dfffff : ror    xzr, xzr, #63           : extr   %xzr %xzr $0x3f -> %xzr
 94081041 : bl     10204104                : bl     $0x0000000010204104 -> %x30
 96000000 : bl     8000000                 : bl     $0x0000000008000000 -> %x30
@@ -1271,118 +957,65 @@
 98ffffff : ldrsw  xzr, ffffffc            : ldrsw  <rel> 0x000000000ffffffc[4byte] -> %xzr
 9a1f03ff : adc    xzr, xzr, xzr           : adc    %xzr %xzr -> %xzr
 9a830041 : csel   x1, x2, x3, eq          : csel   %x2 %x3 eq -> %x1
-9a9ff3ff : csel   xzr, xzr, xzr, nv       : csel   %xzr %xzr nv -> %xzr
-9a9ff7ff : csinc  xzr, xzr, xzr, nv       : csinc  %xzr %xzr nv -> %xzr
 9ac30841 : udiv   x1, x2, x3              : udiv   %x2 %x3 -> %x1
 9ac32841 : asr    x1, x2, x3              : asrv   %x2 %x3 -> %x1
 9ac34c41 : crc32x w1, w2, x3              : crc32x %w2 %x3 -> %w1
 9ac35c41 : crc32cx w1, w2, x3             : crc32cx %w2 %x3 -> %w1
-9ac84c41 : crc32x w1, w2, x8              : crc32x %w2 %x8 -> %w1
-9ac85c41 : crc32cx w1, w2, x8             : crc32cx %w2 %x8 -> %w1
-9adf0bff : udiv   xzr, xzr, xzr           : udiv   %xzr %xzr -> %xzr
-9adf0fff : sdiv   xzr, xzr, xzr           : sdiv   %xzr %xzr -> %xzr
-9adf23ff : lsl    xzr, xzr, xzr           : lslv   %xzr %xzr -> %xzr
 9adf2441 : lsr    x1, x2, xzr             : lsrv   %x2 %xzr -> %x1
-9adf27ff : lsr    xzr, xzr, xzr           : lsrv   %xzr %xzr -> %xzr
-9adf2bff : asr    xzr, xzr, xzr           : asrv   %xzr %xzr -> %xzr
-9adf2fff : ror    xzr, xzr, xzr           : rorv   %xzr %xzr -> %xzr
-9adf4fff : crc32x wzr, wzr, xzr           : crc32x %wzr %xzr -> %wzr
-9adf5fff : crc32cx wzr, wzr, xzr          : crc32cx %wzr %xzr -> %wzr
 9b0313e1 : madd   x1, xzr, x3, x4         : madd   %xzr %x3 %x4 -> %x1
 9b03905f : msub   xzr, x2, x3, x4         : msub   %x2 %x3 %x4 -> %xzr
-9b1f7fff : mul    xzr, xzr, xzr           : madd   %xzr %xzr %xzr -> %xzr
-9b1fffff : mneg   xzr, xzr, xzr           : msub   %xzr %xzr %xzr -> %xzr
 9b23fc41 : smnegl x1, w2, w3              : smsubl %w2 %w3 %xzr -> %x1
-9b281041 : smaddl x1, w2, w8, x4          : smaddl %w2 %w8 %x4 -> %x1
-9b289041 : smsubl x1, w2, w8, x4          : smsubl %w2 %w8 %x4 -> %x1
 9b3f1041 : smaddl x1, w2, wzr, x4         : smaddl %w2 %wzr %x4 -> %x1
-9b3f7fff : smull  xzr, wzr, wzr           : smaddl %wzr %wzr %xzr -> %xzr
-9b3fffff : smnegl xzr, wzr, wzr           : smsubl %wzr %wzr %xzr -> %xzr
 9b4313e1 : smulh  x1, xzr, x3             : smulh  %xzr %x3 $0x04 -> %x1
-9b481041 : smulh  x1, x2, x8              : smulh  %x2 %x8 $0x04 -> %x1
-9b5f7fff : smulh  xzr, xzr, xzr           : smulh  %xzr %xzr $0x1f -> %xzr
 9ba3105f : umaddl xzr, w2, w3, x4         : umaddl %w2 %w3 %x4 -> %xzr
 9ba39041 : umsubl x1, w2, w3, x4          : umsubl %w2 %w3 %x4 -> %x1
-9ba81041 : umaddl x1, w2, w8, x4          : umaddl %w2 %w8 %x4 -> %x1
-9ba89041 : umsubl x1, w2, w8, x4          : umsubl %w2 %w8 %x4 -> %x1
-9bbf7fff : umull  xzr, wzr, wzr           : umaddl %wzr %wzr %xzr -> %xzr
-9bbfffff : umnegl xzr, wzr, wzr           : umsubl %wzr %wzr %xzr -> %xzr
 9bc31041 : umulh  x1, x2, x3              : umulh  %x2 %x3 $0x04 -> %x1
-9bc81041 : umulh  x1, x2, x8              : umulh  %x2 %x8 $0x04 -> %x1
-9bdf7fff : umulh  xzr, xzr, xzr           : umulh  %xzr %xzr $0x1f -> %xzr
-9c081041 : ldr    q1, 10010208            : ldr    <rel> 0x0000000010010208[16byte] -> %q1
 9c7fffff : ldr    q31, 100ffffc           : ldr    <rel> 0x00000000100ffffc[16byte] -> %q31
 9c800000 : ldr    q0, ff00000             : ldr    <rel> 0x000000000ff00000[16byte] -> %q0
-9cffffff : ldr    q31, ffffffc            : ldr    <rel> 0x000000000ffffffc[16byte] -> %q31
 a8000000 : stnp   x0, x0, [x0]            : stnp   %x0 %x0 -> (%x0)[16byte]
-a8081041 : stnp   x1, x4, [x2,#128]       : stnp   %x1 %x4 -> +0x80(%x2)[16byte]
 a83fffff : stnp   xzr, xzr, [sp,#-8]      : stnp   %xzr %xzr -> -0x08(%sp)[16byte]
 a8400000 : ldnp   x0, x0, [x0]            : ldnp   (%x0)[16byte] -> %x0 %x0
-a8481041 : ldnp   x1, x4, [x2,#128]       : ldnp   +0x80(%x2)[16byte] -> %x1 %x4
 a87fffff : ldnp   xzr, xzr, [sp,#-8]      : ldnp   -0x08(%sp)[16byte] -> %xzr %xzr
 a8800000 : stp    x0, x0, [x0],#0         : stp    %x0 %x0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
-a8881041 : stp    x1, x4, [x2],#128       : stp    %x1 %x4 %x2 $0x0000000000000080 -> (%x2)[16byte] %x2
 a8bfffff : stp    xzr, xzr, [sp],#-8      : stp    %xzr %xzr %sp $0xfffffffffffffff8 -> (%sp)[16byte] %sp
 a8c00000 : ldp    x0, x0, [x0],#0         : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
-a8c81041 : ldp    x1, x4, [x2],#128       : ldp    (%x2)[16byte] %x2 $0x0000000000000080 -> %x1 %x4 %x2
 a8ffffff : ldp    xzr, xzr, [sp],#-8      : ldp    (%sp)[16byte] %sp $0xfffffffffffffff8 -> %xzr %xzr %sp
 a9000000 : stp    x0, x0, [x0]            : stp    %x0 %x0 -> (%x0)[16byte]
-a9081041 : stp    x1, x4, [x2,#128]       : stp    %x1 %x4 -> +0x80(%x2)[16byte]
 a93fffff : stp    xzr, xzr, [sp,#-8]      : stp    %xzr %xzr -> -0x08(%sp)[16byte]
 a9400000 : ldp    x0, x0, [x0]            : ldp    (%x0)[16byte] -> %x0 %x0
-a9481041 : ldp    x1, x4, [x2,#128]       : ldp    +0x80(%x2)[16byte] -> %x1 %x4
 a97fffff : ldp    xzr, xzr, [sp,#-8]      : ldp    -0x08(%sp)[16byte] -> %xzr %xzr
 a9800000 : stp    x0, x0, [x0,#0]!        : stp    %x0 %x0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
-a9881041 : stp    x1, x4, [x2,#128]!      : stp    %x1 %x4 %x2 $0x0000000000000080 -> +0x80(%x2)[16byte] %x2
 a9bfffff : stp    xzr, xzr, [sp,#-8]!     : stp    %xzr %xzr %sp $0xfffffffffffffff8 -> -0x08(%sp)[16byte] %sp
 a9c00000 : ldp    x0, x0, [x0,#0]!        : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
-a9c81041 : ldp    x1, x4, [x2,#128]!      : ldp    +0x80(%x2)[16byte] %x2 $0x0000000000000080 -> %x1 %x4 %x2
 a9ffffff : ldp    xzr, xzr, [sp,#-8]!     : ldp    -0x08(%sp)[16byte] %sp $0xfffffffffffffff8 -> %xzr %xzr %sp
-aa081041 : orr    x1, x2, x8, lsl #4      : orr    %x2 %x8 lsl $0x04 -> %x1
-aa281041 : orn    x1, x2, x8, lsl #4      : orn    %x2 %x8 lsl $0x04 -> %x1
 aa431041 : orr    x1, x2, x3, lsr #4      : orr    %x2 %x3 lsr $0x04 -> %x1
 aa631041 : orn    x1, x2, x3, lsr #4      : orn    %x2 %x3 lsr $0x04 -> %x1
 aadf13ff : mov    xzr, xzr                : orr    %xzr %xzr ror $0x04 -> %xzr
-aadfffff : mov    xzr, xzr                : orr    %xzr %xzr ror $0x3f -> %xzr
 aaff13ff : mvn    xzr, xzr, ror #4        : orn    %xzr %xzr ror $0x04 -> %xzr
 aaffffff : mvn    xzr, xzr, ror #63       : orn    %xzr %xzr ror $0x3f -> %xzr
-ab081041 : adds   x1, x2, x8, lsl #4      : adds   %x2 %x8 lsl $0x04 -> %x1
-ab3fffff : .inst  0xab3fffff              : xx     $0xab3fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 ab431041 : adds   x1, x2, x3, lsr #4      : adds   %x2 %x3 lsr $0x04 -> %x1
 ab9f13ff : cmn    xzr, xzr, asr #4        : adds   %xzr %xzr asr $0x04 -> %xzr
 ab9fffff : cmn    xzr, xzr, asr #63       : adds   %xzr %xzr asr $0x3f -> %xzr
-abdfffff : .inst  0xabdfffff              : xx     $0xabdfffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 ac000000 : stnp   q0, q0, [x0]            : stnp   %q0 %q0 -> (%x0)[32byte]
-ac081041 : stnp   q1, q4, [x2,#256]       : stnp   %q1 %q4 -> +0x0100(%x2)[32byte]
 ac3fffff : stnp   q31, q31, [sp,#-16]     : stnp   %q31 %q31 -> -0x10(%sp)[32byte]
 ac400000 : ldnp   q0, q0, [x0]            : ldnp   (%x0)[32byte] -> %q0 %q0
-ac481041 : ldnp   q1, q4, [x2,#256]       : ldnp   +0x0100(%x2)[32byte] -> %q1 %q4
 ac7fffff : ldnp   q31, q31, [sp,#-16]     : ldnp   -0x10(%sp)[32byte] -> %q31 %q31
 ac800000 : stp    q0, q0, [x0],#0         : stp    %q0 %q0 %x0 $0x0000000000000000 -> (%x0)[32byte] %x0
-ac881041 : stp    q1, q4, [x2],#256       : stp    %q1 %q4 %x2 $0x0000000000000100 -> (%x2)[32byte] %x2
 acbfffff : stp    q31, q31, [sp],#-16     : stp    %q31 %q31 %sp $0xfffffffffffffff0 -> (%sp)[32byte] %sp
 acc00000 : ldp    q0, q0, [x0],#0         : ldp    (%x0)[32byte] %x0 $0x0000000000000000 -> %q0 %q0 %x0
-acc81041 : ldp    q1, q4, [x2],#256       : ldp    (%x2)[32byte] %x2 $0x0000000000000100 -> %q1 %q4 %x2
 acffffff : ldp    q31, q31, [sp],#-16     : ldp    (%sp)[32byte] %sp $0xfffffffffffffff0 -> %q31 %q31 %sp
 ad000000 : stp    q0, q0, [x0]            : stp    %q0 %q0 -> (%x0)[32byte]
-ad081041 : stp    q1, q4, [x2,#256]       : stp    %q1 %q4 -> +0x0100(%x2)[32byte]
 ad3fffff : stp    q31, q31, [sp,#-16]     : stp    %q31 %q31 -> -0x10(%sp)[32byte]
 ad400000 : ldp    q0, q0, [x0]            : ldp    (%x0)[32byte] -> %q0 %q0
-ad481041 : ldp    q1, q4, [x2,#256]       : ldp    +0x0100(%x2)[32byte] -> %q1 %q4
 ad7fffff : ldp    q31, q31, [sp,#-16]     : ldp    -0x10(%sp)[32byte] -> %q31 %q31
 ad800000 : stp    q0, q0, [x0,#0]!        : stp    %q0 %q0 %x0 $0x0000000000000000 -> (%x0)[32byte] %x0
-ad881041 : stp    q1, q4, [x2,#256]!      : stp    %q1 %q4 %x2 $0x0000000000000100 -> +0x0100(%x2)[32byte] %x2
 adbfffff : stp    q31, q31, [sp,#-16]!    : stp    %q31 %q31 %sp $0xfffffffffffffff0 -> -0x10(%sp)[32byte] %sp
 adc00000 : ldp    q0, q0, [x0,#0]!        : ldp    (%x0)[32byte] %x0 $0x0000000000000000 -> %q0 %q0 %x0
-adc81041 : ldp    q1, q4, [x2,#256]!      : ldp    +0x0100(%x2)[32byte] %x2 $0x0000000000000100 -> %q1 %q4 %x2
 adffffff : ldp    q31, q31, [sp,#-16]!    : ldp    -0x10(%sp)[32byte] %sp $0xfffffffffffffff0 -> %q31 %q31 %sp
 b1000c41 : adds   x1, x2, #0x3            : adds   %x2 $0x0003 lsl $0x00 -> %x1
 b1000fff : cmn    sp, #0x3                : adds   %sp $0x0003 lsl $0x00 -> %xzr
-b17fffff : cmn    sp, #0xfff, lsl #12     : adds   %sp $0x0fff lsl $0x10 -> %xzr
 b2400441 : orr    x1, x2, #0x3            : orr    %x2 $0x0000000000000003 -> %x1
-b27fffff : .inst  0xb27fffff              : xx     $0xb27fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 b3431041 : bfxil  x1, x2, #3, #2          : bfm    %x1 %x2 $0x03 $0x04 -> %x1
-b3481041 : bfi    x1, x2, #56, #5         : bfm    %x1 %x2 $0x08 $0x04 -> %x1
 b37fffff : bfxil  xzr, xzr, #63, #1       : bfm    %xzr %xzr $0x3f $0x3f -> %xzr
 b4ffffff : cbz    xzr, ffffffc            : cbz    $0x000000000ffffffc %xzr
 b5800000 : cbnz   x0, ff00000             : cbnz   $0x000000000ff00000 %x0
@@ -1410,7 +1043,6 @@ b823e841 : str    w1, [x2,x3,sxtx]        : str    %w1 -> (%x2,%x3,sxtx)[4byte]
 b823f841 : str    w1, [x2,x3,sxtx #2]     : str    %w1 -> (%x2,%x3,sxtx #2)[4byte]
 b8280041 : ldadd  w8, w1, [x2]            : ldadd  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8281041 : ldclr  w8, w1, [x2]            : ldclr  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8281841 : .inst  0xb8281841              : xx     $0xb8281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 b8282041 : ldeor  w8, w1, [x2]            : ldeor  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8283041 : ldset  w8, w1, [x2]            : ldset  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8284041 : ldsmax w8, w1, [x2]            : ldsmax %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
@@ -1455,7 +1087,6 @@ b863e841 : ldr    w1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[4byte] -> %w1
 b863f841 : ldr    w1, [x2,x3,sxtx #2]     : ldr    (%x2,%x3,sxtx #2)[4byte] -> %w1
 b8680041 : ldaddl w8, w1, [x2]            : ldaddl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8681041 : ldclrl w8, w1, [x2]            : ldclrl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8681841 : .inst  0xb8681841              : xx     $0xb8681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 b8682041 : ldeorl w8, w1, [x2]            : ldeorl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8683041 : ldsetl w8, w1, [x2]            : ldsetl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8684041 : ldsmaxl w8, w1, [x2]           : ldsmaxl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
@@ -1500,7 +1131,6 @@ b8a3e841 : ldrsw  x1, [x2,x3,sxtx]        : ldrsw  (%x2,%x3,sxtx)[4byte] -> %x1
 b8a3f841 : ldrsw  x1, [x2,x3,sxtx #2]     : ldrsw  (%x2,%x3,sxtx #2)[4byte] -> %x1
 b8a80041 : ldadda w8, w1, [x2]            : ldadda %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8a81041 : ldclra w8, w1, [x2]            : ldclra %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8a81841 : .inst  0xb8a81841              : xx     $0xb8a81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 b8a82041 : ldeora w8, w1, [x2]            : ldeora %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8a83041 : ldseta w8, w1, [x2]            : ldseta %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8a84041 : ldsmaxa w8, w1, [x2]           : ldsmaxa %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
@@ -1550,11 +1180,8 @@ b97fffff : ldr    wzr, [sp,#16380]        : ldr    +0x3ffc(%sp)[4byte] -> %wzr
 b9881041 : ldrsw  x1, [x2,#2064]          : ldrsw  +0x0810(%x2)[4byte] -> %x1
 b9bfffff : ldrsw  xzr, [sp,#16380]        : ldrsw  +0x3ffc(%sp)[4byte] -> %xzr
 ba030041 : adcs   x1, x2, x3              : adcs   %x2 %x3 -> %x1
-ba1f03ff : adcs   xzr, xzr, xzr           : adcs   %xzr %xzr -> %xzr
 ba55d822 : ccmn   x1, #0x15, #0x2, le     : ccmn   %x1 $0x15 $0x02 le
 ba5fd022 : ccmn   x1, xzr, #0x2, le       : ccmn   %x1 %xzr $0x02 le
-ba5ff3ef : ccmn   xzr, xzr, #0xf, nv      : ccmn   %xzr %xzr $0x0f nv
-ba5ffbef : ccmn   xzr, #0x1f, #0xf, nv    : ccmn   %xzr $0x1f $0x0f nv
 bc000400 : str    s0, [x0],#0             : str    %s0 %x0 $0x0000000000000000 -> (%x0)[4byte] %x0
 bc000c00 : str    s0, [x0,#0]!            : str    %s0 %x0 $0x0000000000000000 -> (%x0)[4byte] %x0
 bc081041 : stur   s1, [x2,#129]           : stur   %s1 -> +0x81(%x2)[4byte]
@@ -1571,7 +1198,6 @@ bc23c841 : str    s1, [x2,w3,sxtw]        : str    %s1 -> (%x2,%x3,sxtw)[4byte]
 bc23d841 : str    s1, [x2,w3,sxtw #2]     : str    %s1 -> (%x2,%x3,sxtw #2)[4byte]
 bc23e841 : str    s1, [x2,x3,sxtx]        : str    %s1 -> (%x2,%x3,sxtx)[4byte]
 bc23f841 : str    s1, [x2,x3,sxtx #2]     : str    %s1 -> (%x2,%x3,sxtx #2)[4byte]
-bc281841 : .inst  0xbc281841              : xx     $0xbc281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 bc3f4bff : str    s31, [sp,wzr,uxtw]      : str    %s31 -> (%sp,%xzr,uxtw)[4byte]
 bc3f5bff : str    s31, [sp,wzr,uxtw #2]   : str    %s31 -> (%sp,%xzr,uxtw #2)[4byte]
 bc3f6bff : str    s31, [sp,xzr]           : str    %s31 -> (%sp,%xzr)[4byte]
@@ -1596,7 +1222,6 @@ bc63c841 : ldr    s1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[4byte] -> %s1
 bc63d841 : ldr    s1, [x2,w3,sxtw #2]     : ldr    (%x2,%x3,sxtw #2)[4byte] -> %s1
 bc63e841 : ldr    s1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[4byte] -> %s1
 bc63f841 : ldr    s1, [x2,x3,sxtx #2]     : ldr    (%x2,%x3,sxtx #2)[4byte] -> %s1
-bc681841 : .inst  0xbc681841              : xx     $0xbc681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 bc7f4bff : ldr    s31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[4byte] -> %s31
 bc7f5bff : ldr    s31, [sp,wzr,uxtw #2]   : ldr    (%sp,%xzr,uxtw #2)[4byte] -> %s31
 bc7f6bff : ldr    s31, [sp,xzr]           : ldr    (%sp,%xzr)[4byte] -> %s31
@@ -1631,45 +1256,31 @@ c8a87c41 : cas    x8, x1, [x2]            : cas    %x8 %x1 (%x2)[8byte] -> %x8 (
 c8a8fc41 : casl   x8, x1, [x2]            : casl   %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
 c8bf7fff : cas    xzr, xzr, [sp]          : cas    %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
 c8bfffff : casl   xzr, xzr, [sp]          : casl   %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-c8c89041 : .inst  0xc8c89041              : ldar   (%x2)[8byte] $0x04 $0x08 -> %x1
 c8dfffff : ldar   xzr, [sp]               : ldar   (%sp)[8byte] $0x1f $0x1f -> %xzr
 c8e87c41 : casa   x8, x1, [x2]            : casa   %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
 c8e8fc41 : casal  x8, x1, [x2]            : casal  %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
 c8ff7fff : casa   xzr, xzr, [sp]          : casa   %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
 c8ffffff : casal  xzr, xzr, [sp]          : casal  %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-ca081041 : eor    x1, x2, x8, lsl #4      : eor    %x2 %x8 lsl $0x04 -> %x1
-ca281041 : eon    x1, x2, x8, lsl #4      : eon    %x2 %x8 lsl $0x04 -> %x1
 ca431041 : eor    x1, x2, x3, lsr #4      : eor    %x2 %x3 lsr $0x04 -> %x1
 ca631041 : eon    x1, x2, x3, lsr #4      : eon    %x2 %x3 lsr $0x04 -> %x1
 ca7f7fff : eon    xzr, xzr, xzr, lsr #31  : eon    %xzr %xzr lsr $0x1f -> %xzr
 cadf13ff : eor    xzr, xzr, xzr, ror #4   : eor    %xzr %xzr ror $0x04 -> %xzr
-cadfffff : eor    xzr, xzr, xzr, ror #63  : eor    %xzr %xzr ror $0x3f -> %xzr
 caff13ff : eon    xzr, xzr, xzr, ror #4   : eon    %xzr %xzr ror $0x04 -> %xzr
-caffffff : eon    xzr, xzr, xzr, ror #63  : eon    %xzr %xzr ror $0x3f -> %xzr
 cb031041 : sub    x1, x2, x3, lsl #4      : sub    %x2 %x3 lsl $0x04 -> %x1
-cb081041 : sub    x1, x2, x8, lsl #4      : sub    %x2 %x8 lsl $0x04 -> %x1
 cb3f73ff : sub    sp, sp, xzr, lsl #4     : sub    %sp %xzr uxtx $0x04 -> %sp
-cb3fffff : .inst  0xcb3fffff              : xx     $0xcb3fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 cb431041 : sub    x1, x2, x3, lsr #4      : sub    %x2 %x3 lsr $0x04 -> %x1
 cb9f13ff : neg    xzr, xzr, asr #4        : sub    %xzr %xzr asr $0x04 -> %xzr
-cbdfffff : .inst  0xcbdfffff              : xx     $0xcbdfffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 d1000c41 : sub    x1, x2, #0x3            : sub    %x2 $0x0003 lsl $0x00 -> %x1
 d1000fff : sub    sp, sp, #0x3            : sub    %sp $0x0003 lsl $0x00 -> %sp
 d13fffff : sub    sp, sp, #0xfff          : sub    %sp $0x0fff lsl $0x00 -> %sp
-d17fffff : sub    sp, sp, #0xfff, lsl #12 : sub    %sp $0x0fff lsl $0x10 -> %sp
 d2400441 : eor    x1, x2, #0x3            : eor    %x2 $0x0000000000000003 -> %x1
-d27fffff : .inst  0xd27fffff              : xx     $0xd27fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
-d2881041 : mov    x1, #0x4082             : movz   $0x4082 lsl $0x00 -> %x1
 d2ffffff : mov    xzr, #0xffff000000000000: movz   $0xffff lsl $0x30 -> %xzr
 d3431041 : ubfx   x1, x2, #3, #2          : ubfm   %x2 $0x03 $0x04 -> %x1
-d3481041 : ubfiz  x1, x2, #56, #5         : ubfm   %x2 $0x08 $0x04 -> %x1
 d37fffff : lsr    xzr, xzr, #63           : ubfm   %xzr $0x3f $0x3f -> %xzr
 d4000001 : svc    #0x0                    : svc    $0x0000
 d4000002 : hvc    #0x0                    : hvc    $0x0000
 d4000003 : smc    #0x0                    : smc    $0x0000
 d4081041 : svc    #0x4082                 : svc    $0x4082
-d4081042 : hvc    #0x4082                 : hvc    $0x4082
-d4081043 : smc    #0x4082                 : smc    $0x4082
 d41fffe1 : svc    #0xffff                 : svc    $0xffff
 d41fffe2 : hvc    #0xffff                 : hvc    $0xffff
 d41fffe3 : smc    #0xffff                 : smc    $0xffff
@@ -1677,7 +1288,6 @@ d4200000 : brk    #0x0                    : brk    $0x0000
 d4281040 : brk    #0x4082                 : brk    $0x4082
 d43fffe0 : brk    #0xffff                 : brk    $0xffff
 d4400000 : hlt    #0x0                    : hlt    $0x0000
-d4481040 : hlt    #0x4082                 : hlt    $0x4082
 d45fffe0 : hlt    #0xffff                 : hlt    $0xffff
 d503201f : nop                            : nop
 d503203f : yield                          : yield
@@ -1694,20 +1304,16 @@ d5033f9f : dsb    sy                      : dsb    $0x0f
 d5033fbf : dmb    sy                      : dmb    $0x0f
 d5033fdf : isb                            : isb    $0x0f
 d5080000 : sys    #0, C0, C0, #0, x0      : sys    $0x0000 %x0
-d5081041 : sys    #0, C1, C0, #2, x1      : sys    $0x0082 %x1
 d50fffff : sys    #7, C15, C15, #7        : sys    $0x3fff %xzr
 d5100000 : msr    s2_0_c0_c0_0, x0        : msr    %x0 $0x0000
-d5181041 : msr    cpacr_el1, x1           : msr    %x1 $0x4082
 d51b4201 : msr    nzcv, x1                : msr    %x1 -> %nzcv
 d51b4402 : msr    fpcr, x2                : msr    %x2 -> %fpcr
 d51b4423 : msr    fpsr, x3                : msr    %x3 -> %fpsr
 d51bd044 : msr    tpidr_el0, x4           : msr    %x4 -> %tpidr_el0
 d51fffff : msr    s3_7_c15_c15_7, xzr     : msr    %xzr $0x7fff
 d5280000 : sysl   x0, #0, C0, C0, #0      : sys    $0x0000 -> %x0
-d5281041 : sysl   x1, #0, C1, C0, #2      : sys    $0x0082 -> %x1
 d52fffff : sysl   xzr, #7, C15, C15, #7   : sys    $0x3fff -> %xzr
 d5300000 : mrs    x0, s2_0_c0_c0_0        : mrs    $0x0000 -> %x0
-d5381041 : mrs    x1, cpacr_el1           : mrs    $0x4082 -> %x1
 d53b4201 : mrs    x1, nzcv                : mrs    %nzcv -> %x1
 d53b4402 : mrs    x2, fpcr                : mrs    %fpcr -> %x2
 d53b4423 : mrs    x3, fpsr                : mrs    %fpsr -> %x3
@@ -1722,53 +1328,32 @@ d63f03e0 : blr    xzr                     : blr    %xzr -> %x30
 d65f0000 : ret    x0                      : ret    %x0
 d65f0040 : ret    x2                      : ret    %x2
 d65f03e0 : ret    xzr                     : ret    %xzr
-d8081041 : prfm   pldl1strm, 10010208     : prfm   $0x01 <rel> 0x0000000010010208
 d87fffff : prfm   #0x1f, 100ffffc         : prfm   $0x1f <rel> 0x00000000100ffffc
 d8800000 : prfm   pldl1keep, ff00000      : prfm   $0x00 <rel> 0x000000000ff00000
-d8ffffff : prfm   #0x1f, ffffffc          : prfm   $0x1f <rel> 0x000000000ffffffc
 da030041 : sbc    x1, x2, x3              : sbc    %x2 %x3 -> %x1
-da1f03ff : ngc    xzr, xzr                : sbc    %xzr %xzr -> %xzr
 da83f45f : csneg  xzr, x2, x3, nv         : csneg  %x2 %x3 nv -> %xzr
-da9ff3ff : csinv  xzr, xzr, xzr, nv       : csinv  %xzr %xzr nv -> %xzr
-da9ff7ff : csneg  xzr, xzr, xzr, nv       : csneg  %xzr %xzr nv -> %xzr
 dac00041 : rbit   x1, x2                  : rbit   %x2 -> %x1
-dac003ff : rbit   xzr, xzr                : rbit   %xzr -> %xzr
 dac00441 : rev16  x1, x2                  : rev16  %x2 -> %x1
-dac007ff : rev16  xzr, xzr                : rev16  %xzr -> %xzr
 dac00841 : rev32  x1, x2                  : rev32  %x2 -> %x1
-dac00bff : rev32  xzr, xzr                : rev32  %xzr -> %xzr
 dac00c41 : rev    x1, x2                  : rev    %x2 -> %x1
-dac00fff : rev    xzr, xzr                : rev    %xzr -> %xzr
 dac01041 : clz    x1, x2                  : clz    %x2 -> %x1
-dac013ff : clz    xzr, xzr                : clz    %xzr -> %xzr
 dac01441 : cls    x1, x2                  : cls    %x2 -> %x1
-dac017ff : cls    xzr, xzr                : cls    %xzr -> %xzr
-ea081041 : ands   x1, x2, x8, lsl #4      : ands   %x2 %x8 lsl $0x04 -> %x1
-ea281041 : bics   x1, x2, x8, lsl #4      : bics   %x2 %x8 lsl $0x04 -> %x1
 ea431041 : ands   x1, x2, x3, lsr #4      : ands   %x2 %x3 lsr $0x04 -> %x1
 ea631041 : bics   x1, x2, x3, lsr #4      : bics   %x2 %x3 lsr $0x04 -> %x1
 ea9fffff : tst    xzr, xzr, asr #63       : ands   %xzr %xzr asr $0x3f -> %xzr
 eadf13ff : tst    xzr, xzr, ror #4        : ands   %xzr %xzr ror $0x04 -> %xzr
-eadfffff : tst    xzr, xzr, ror #63       : ands   %xzr %xzr ror $0x3f -> %xzr
 eaff13ff : bics   xzr, xzr, xzr, ror #4   : bics   %xzr %xzr ror $0x04 -> %xzr
-eaffffff : bics   xzr, xzr, xzr, ror #63  : bics   %xzr %xzr ror $0x3f -> %xzr
-eb081041 : subs   x1, x2, x8, lsl #4      : subs   %x2 %x8 lsl $0x04 -> %x1
 eb3fabff : cmp    sp, wzr, sxth #2        : subs   %sp %xzr sxth $0x02 -> %xzr
 eb3fe3ff : cmp    sp, xzr, sxtx           : subs   %sp %xzr sxtx $0x00 -> %xzr
-eb3fffff : .inst  0xeb3fffff              : xx     $0xeb3fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 eb431041 : subs   x1, x2, x3, lsr #4      : subs   %x2 %x3 lsr $0x04 -> %x1
 eb5fffff : negs   xzr, xzr, lsr #63       : subs   %xzr %xzr lsr $0x3f -> %xzr
 eb9f13ff : negs   xzr, xzr, asr #4        : subs   %xzr %xzr asr $0x04 -> %xzr
-ebdfffff : .inst  0xebdfffff              : xx     $0xebdfffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 f07fffff : adrp   xzr, 10ffff000          : adrp   <rel> 0x000000010ffff000 -> %xzr
 f0ffffff : adrp   xzr, ffff000            : adrp   <rel> 0x000000000ffff000 -> %xzr
 f1000c41 : subs   x1, x2, #0x3            : subs   %x2 $0x0003 lsl $0x00 -> %x1
 f1000fff : cmp    sp, #0x3                : subs   %sp $0x0003 lsl $0x00 -> %xzr
 f16003ff : cmp    sp, #0x800, lsl #12     : subs   %sp $0x0800 lsl $0x10 -> %xzr
-f17fffff : cmp    sp, #0xfff, lsl #12     : subs   %sp $0x0fff lsl $0x10 -> %xzr
 f2400441 : ands   x1, x2, #0x3            : ands   %x2 $0x0000000000000003 -> %x1
-f27fffff : .inst  0xf27fffff              : xx     $0xf27fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
-f2881041 : movk   x1, #0x4082             : movk   %x1 $0x4082 lsl $0x00 -> %x1
 f2ffffff : movk   xzr, #0xffff, lsl #48   : movk   %xzr $0xffff lsl $0x30 -> %xzr
 f8000400 : str    x0, [x0],#0             : str    %x0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
 f8000c00 : str    x0, [x0,#0]!            : str    %x0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
@@ -1790,7 +1375,6 @@ f823e841 : str    x1, [x2,x3,sxtx]        : str    %x1 -> (%x2,%x3,sxtx)[8byte]
 f823f841 : str    x1, [x2,x3,sxtx #3]     : str    %x1 -> (%x2,%x3,sxtx #3)[8byte]
 f8280041 : ldadd  x8, x1, [x2]            : ldadd  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8281041 : ldclr  x8, x1, [x2]            : ldclr  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8281841 : .inst  0xf8281841              : xx     $0xf8281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 f8282041 : ldeor  x8, x1, [x2]            : ldeor  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8283041 : ldset  x8, x1, [x2]            : ldset  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8284041 : ldsmax x8, x1, [x2]            : ldsmax %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
@@ -1835,7 +1419,6 @@ f863e841 : ldr    x1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[8byte] -> %x1
 f863f841 : ldr    x1, [x2,x3,sxtx #3]     : ldr    (%x2,%x3,sxtx #3)[8byte] -> %x1
 f8680041 : ldaddl x8, x1, [x2]            : ldaddl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8681041 : ldclrl x8, x1, [x2]            : ldclrl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8681841 : .inst  0xf8681841              : xx     $0xf8681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 f8682041 : ldeorl x8, x1, [x2]            : ldeorl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8683041 : ldsetl x8, x1, [x2]            : ldsetl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8684041 : ldsmaxl x8, x1, [x2]           : ldsmaxl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
@@ -1873,7 +1456,6 @@ f8a3e841 : prfm   pldl1strm, [x2,x3,sxtx] : prfm   $0x01 (%x2,%x3,sxtx)
 f8a3f841 : prfm   pldl1strm, [x2,x3,sxtx #3]: prfm   $0x01 (%x2,%x3,sxtx #3)
 f8a80041 : ldadda x8, x1, [x2]            : ldadda %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8a81041 : ldclra x8, x1, [x2]            : ldclra %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8a81841 : .inst  0xf8a81841              : xx     $0xf8a81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 f8a82041 : ldeora x8, x1, [x2]            : ldeora %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8a83041 : ldseta x8, x1, [x2]            : ldseta %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8a84041 : ldsmaxa x8, x1, [x2]           : ldsmaxa %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
@@ -1925,8 +1507,6 @@ f9bfffff : prfm   #0x1f, [sp,#32760]      : prfm   $0x1f +0x7ff8(%sp)
 fa1f03ff : ngcs   xzr, xzr                : sbcs   %xzr %xzr -> %xzr
 fa42c023 : ccmp   x1, x2, #0x3, gt        : ccmp   %x1 %x2 $0x03 gt
 fa5fc823 : ccmp   x1, #0x1f, #0x3, gt     : ccmp   %x1 $0x1f $0x03 gt
-fa5ff3ef : ccmp   xzr, xzr, #0xf, nv      : ccmp   %xzr %xzr $0x0f nv
-fa5ffbef : ccmp   xzr, #0x1f, #0xf, nv    : ccmp   %xzr $0x1f $0x0f nv
 fc000400 : str    d0, [x0],#0             : str    %d0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
 fc000c00 : str    d0, [x0,#0]!            : str    %d0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
 fc081041 : stur   d1, [x2,#129]           : stur   %d1 -> +0x81(%x2)[8byte]
@@ -1943,7 +1523,6 @@ fc23c841 : str    d1, [x2,w3,sxtw]        : str    %d1 -> (%x2,%x3,sxtw)[8byte]
 fc23d841 : str    d1, [x2,w3,sxtw #3]     : str    %d1 -> (%x2,%x3,sxtw #3)[8byte]
 fc23e841 : str    d1, [x2,x3,sxtx]        : str    %d1 -> (%x2,%x3,sxtx)[8byte]
 fc23f841 : str    d1, [x2,x3,sxtx #3]     : str    %d1 -> (%x2,%x3,sxtx #3)[8byte]
-fc281841 : .inst  0xfc281841              : xx     $0xfc281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 fc3f4bff : str    d31, [sp,wzr,uxtw]      : str    %d31 -> (%sp,%xzr,uxtw)[8byte]
 fc3f5bff : str    d31, [sp,wzr,uxtw #3]   : str    %d31 -> (%sp,%xzr,uxtw #3)[8byte]
 fc3f6bff : str    d31, [sp,xzr]           : str    %d31 -> (%sp,%xzr)[8byte]
@@ -1968,7 +1547,6 @@ fc63c841 : ldr    d1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[8byte] -> %d1
 fc63d841 : ldr    d1, [x2,w3,sxtw #3]     : ldr    (%x2,%x3,sxtw #3)[8byte] -> %d1
 fc63e841 : ldr    d1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[8byte] -> %d1
 fc63f841 : ldr    d1, [x2,x3,sxtx #3]     : ldr    (%x2,%x3,sxtx #3)[8byte] -> %d1
-fc681841 : .inst  0xfc681841              : xx     $0xfc681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 fc7f4bff : ldr    d31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[8byte] -> %d31
 fc7f5bff : ldr    d31, [sp,wzr,uxtw #3]   : ldr    (%sp,%xzr,uxtw #3)[8byte] -> %d31
 fc7f6bff : ldr    d31, [sp,xzr]           : ldr    (%sp,%xzr)[8byte] -> %d31

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -41,76 +41,215 @@
 081f7fff : stxrb  wzr, wzr, [sp]          : stxrb  %wzr $0x1f -> (%sp)[1byte] %wzr
 081fffff : stlxrb wzr, wzr, [sp]          : stlxrb %wzr $0x1f -> (%sp)[1byte] %wzr
 08287c40 : casp   w8, w9, w0, w1, [x2]    : casp   %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
+08287c41 : .inst  0x08287c41              : xx     $0x08287c41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 0828fc40 : caspl  w8, w9, w0, w1, [x2]    : caspl  %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
+0828fc41 : .inst  0x0828fc41              : xx     $0x0828fc41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 083e7ffe : casp   w30, wzr, w30, wzr, [sp]: casp   %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
 083efffe : caspl  w30, wzr, w30, wzr, [sp]: caspl  %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
+083f7fff : .inst  0x083f7fff              : xx     $0x083f7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
+083fffff : .inst  0x083fffff              : xx     $0x083fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 08481041 : ldxrb  w1, [x2]                : ldxrb  (%x2)[1byte] $0x04 $0x08 -> %w1
 08489041 : ldaxrb w1, [x2]                : ldaxrb (%x2)[1byte] $0x04 $0x08 -> %w1
 085f7fff : ldxrb  wzr, [sp]               : ldxrb  (%sp)[1byte] $0x1f $0x1f -> %wzr
 085fffff : ldaxrb wzr, [sp]               : ldaxrb (%sp)[1byte] $0x1f $0x1f -> %wzr
 08687c40 : caspa  w8, w9, w0, w1, [x2]    : caspa  %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
+08687c41 : .inst  0x08687c41              : xx     $0x08687c41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 0868fc40 : caspal w8, w9, w0, w1, [x2]    : caspal %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
+0868fc41 : .inst  0x0868fc41              : xx     $0x0868fc41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 087e7ffe : caspa  w30, wzr, w30, wzr, [sp]: caspa  %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
 087efffe : caspal w30, wzr, w30, wzr, [sp]: caspal %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
+087f7fff : .inst  0x087f7fff              : xx     $0x087f7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
+087fffff : .inst  0x087fffff              : xx     $0x087fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 08889041 : stlrb  w1, [x2]                : stlrb  %w1 $0x04 $0x08 -> (%x2)[1byte]
 089fffff : stlrb  wzr, [sp]               : stlrb  %wzr $0x1f $0x1f -> (%sp)[1byte]
 08a87c41 : casb   w8, w1, [x2]            : casb   %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
 08a8fc41 : caslb  w8, w1, [x2]            : caslb  %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
 08bf7fff : casb   wzr, wzr, [sp]          : casb   %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
 08bfffff : caslb  wzr, wzr, [sp]          : caslb  %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+08c89041 : .inst  0x08c89041              : ldarb  (%x2)[1byte] $0x04 $0x08 -> %w1
 08dfffff : ldarb  wzr, [sp]               : ldarb  (%sp)[1byte] $0x1f $0x1f -> %wzr
 08e87c41 : casab  w8, w1, [x2]            : casab  %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
 08e8fc41 : casalb w8, w1, [x2]            : casalb %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
 08ff7fff : casab  wzr, wzr, [sp]          : casab  %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
 08ffffff : casalb wzr, wzr, [sp]          : casalb %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
 0a031041 : and    w1, w2, w3, lsl #4      : and    %w2 %w3 lsl $0x04 -> %w1
+0a081041 : and    w1, w2, w8, lsl #4      : and    %w2 %w8 lsl $0x04 -> %w1
 0a231041 : bic    w1, w2, w3, lsl #4      : bic    %w2 %w3 lsl $0x04 -> %w1
+0a281041 : bic    w1, w2, w8, lsl #4      : bic    %w2 %w8 lsl $0x04 -> %w1
 0a7f7fff : bic    wzr, wzr, wzr, lsr #31  : bic    %wzr %wzr lsr $0x1f -> %wzr
 0a9f13ff : and    wzr, wzr, wzr, asr #4   : and    %wzr %wzr asr $0x04 -> %wzr
 0abf13ff : bic    wzr, wzr, wzr, asr #4   : bic    %wzr %wzr asr $0x04 -> %wzr
+0adf7fff : and    wzr, wzr, wzr, ror #31  : and    %wzr %wzr ror $0x1f -> %wzr
+0aff7fff : bic    wzr, wzr, wzr, ror #31  : bic    %wzr %wzr ror $0x1f -> %wzr
 0b031041 : add    w1, w2, w3, lsl #4      : add    %w2 %w3 lsl $0x04 -> %w1
+0b081041 : add    w1, w2, w8, lsl #4      : add    %w2 %w8 lsl $0x04 -> %w1
 0b1f7fff : add    wzr, wzr, wzr, lsl #31  : add    %wzr %wzr lsl $0x1f -> %wzr
+0b281041 : add    w1, w2, w8, uxtb #4     : add    %w2 %w8 uxtb $0x04 -> %w1
 0b3008a0 : add    w0, w5, w16, uxtb #2    : add    %w5 %w16 uxtb $0x02 -> %w0
 0b9f13ff : add    wzr, wzr, wzr, asr #4   : add    %wzr %wzr asr $0x04 -> %wzr
+0bdf7fff : .inst  0x0bdf7fff              : xx     $0x0bdf7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
+0c000041 : st4    {v1.8b-v4.8b}, [x2]     : st4    $0x00 %d1 %d2 %d3 %d4 -> (%x2)[32byte]
 0c0007ff : st4    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp]: st4    $0x01 %d31 %d0 %d1 %d2 -> (%sp)[32byte]
+0c002041 : st1    {v1.8b-v4.8b}, [x2]     : st1    $0x00 %d1 %d2 %d3 %d4 -> (%x2)[32byte]
+0c004041 : st3    {v1.8b-v3.8b}, [x2]     : st3    $0x00 %d1 %d2 %d3 -> (%x2)[24byte]
+0c006041 : st1    {v1.8b-v3.8b}, [x2]     : st1    $0x00 %d1 %d2 %d3 -> (%x2)[24byte]
 0c0067ff : st1    {v31.4h, v0.4h, v1.4h}, [sp]: st1    $0x01 %d31 %d0 %d1 -> (%sp)[24byte]
+0c007041 : st1    {v1.8b}, [x2]           : st1    $0x00 %d1 -> (%x2)[8byte]
 0c0077ff : st1    {v31.4h}, [sp]          : st1    $0x01 %d31 -> (%sp)[8byte]
+0c008041 : st2    {v1.8b, v2.8b}, [x2]    : st2    $0x00 %d1 %d2 -> (%x2)[16byte]
+0c00a041 : st1    {v1.8b, v2.8b}, [x2]    : st1    $0x00 %d1 %d2 -> (%x2)[16byte]
 0c00a7ff : st1    {v31.4h, v0.4h}, [sp]   : st1    $0x01 %d31 %d0 -> (%sp)[16byte]
+0c400041 : ld4    {v1.8b-v4.8b}, [x2]     : ld4    (%x2)[32byte] $0x00 -> %d1 %d2 %d3 %d4
+0c402041 : ld1    {v1.8b-v4.8b}, [x2]     : ld1    (%x2)[32byte] $0x00 -> %d1 %d2 %d3 %d4
 0c4027ff : ld1    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp]: ld1    (%sp)[32byte] $0x01 -> %d31 %d0 %d1 %d2
+0c404041 : ld3    {v1.8b-v3.8b}, [x2]     : ld3    (%x2)[24byte] $0x00 -> %d1 %d2 %d3
 0c4047ff : ld3    {v31.4h, v0.4h, v1.4h}, [sp]: ld3    (%sp)[24byte] $0x01 -> %d31 %d0 %d1
+0c406041 : ld1    {v1.8b-v3.8b}, [x2]     : ld1    (%x2)[24byte] $0x00 -> %d1 %d2 %d3
+0c407041 : ld1    {v1.8b}, [x2]           : ld1    (%x2)[8byte] $0x00 -> %d1
+0c408041 : ld2    {v1.8b, v2.8b}, [x2]    : ld2    (%x2)[16byte] $0x00 -> %d1 %d2
 0c4087ff : ld2    {v31.4h, v0.4h}, [sp]   : ld2    (%sp)[16byte] $0x01 -> %d31 %d0
+0c40a041 : ld1    {v1.8b, v2.8b}, [x2]    : ld1    (%x2)[16byte] $0x00 -> %d1 %d2
+0c880041 : st4    {v1.8b-v4.8b}, [x2], x8 : st4    $0x00 %d1 %d2 %d3 %d4 %x2 %x8 -> (%x2)[32byte] %x2
+0c882041 : st1    {v1.8b-v4.8b}, [x2], x8 : st1    $0x00 %d1 %d2 %d3 %d4 %x2 %x8 -> (%x2)[32byte] %x2
+0c884041 : st3    {v1.8b-v3.8b}, [x2], x8 : st3    $0x00 %d1 %d2 %d3 %x2 %x8 -> (%x2)[24byte] %x2
+0c886041 : st1    {v1.8b-v3.8b}, [x2], x8 : st1    $0x00 %d1 %d2 %d3 %x2 %x8 -> (%x2)[24byte] %x2
+0c887041 : st1    {v1.8b}, [x2], x8       : st1    $0x00 %d1 %x2 %x8 -> (%x2)[8byte] %x2
+0c888041 : st2    {v1.8b, v2.8b}, [x2], x8: st2    $0x00 %d1 %d2 %x2 %x8 -> (%x2)[16byte] %x2
+0c88a041 : st1    {v1.8b, v2.8b}, [x2], x8: st1    $0x00 %d1 %d2 %x2 %x8 -> (%x2)[16byte] %x2
 0c9f27ff : st1    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp], #32: st1    $0x01 %d31 %d0 %d1 %d2 %sp $0x20 -> (%sp)[32byte] %sp
 0c9f47ff : st3    {v31.4h, v0.4h, v1.4h}, [sp], #24: st3    $0x01 %d31 %d0 %d1 %sp $0x18 -> (%sp)[24byte] %sp
 0c9f87ff : st2    {v31.4h, v0.4h}, [sp], #16: st2    $0x01 %d31 %d0 %sp $0x10 -> (%sp)[16byte] %sp
+0cc80041 : ld4    {v1.8b-v4.8b}, [x2], x8 : ld4    (%x2)[32byte] $0x00 %x2 %x8 -> %d1 %d2 %d3 %d4 %x2
+0cc82041 : ld1    {v1.8b-v4.8b}, [x2], x8 : ld1    (%x2)[32byte] $0x00 %x2 %x8 -> %d1 %d2 %d3 %d4 %x2
+0cc84041 : ld3    {v1.8b-v3.8b}, [x2], x8 : ld3    (%x2)[24byte] $0x00 %x2 %x8 -> %d1 %d2 %d3 %x2
+0cc86041 : ld1    {v1.8b-v3.8b}, [x2], x8 : ld1    (%x2)[24byte] $0x00 %x2 %x8 -> %d1 %d2 %d3 %x2
+0cc87041 : ld1    {v1.8b}, [x2], x8       : ld1    (%x2)[8byte] $0x00 %x2 %x8 -> %d1 %x2
+0cc88041 : ld2    {v1.8b, v2.8b}, [x2], x8: ld2    (%x2)[16byte] $0x00 %x2 %x8 -> %d1 %d2 %x2
+0cc8a041 : ld1    {v1.8b, v2.8b}, [x2], x8: ld1    (%x2)[16byte] $0x00 %x2 %x8 -> %d1 %d2 %x2
 0cd5a7ff : ld1    {v31.4h, v0.4h}, [sp], x21: ld1    (%sp)[16byte] $0x01 %sp %x21 -> %d31 %d0 %sp
 0cdf07ff : ld4    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp], #32: ld4    (%sp)[32byte] $0x01 %sp $0x20 -> %d31 %d0 %d1 %d2 %sp
 0cdf67ff : ld1    {v31.4h, v0.4h, v1.4h}, [sp], #24: ld1    (%sp)[24byte] $0x01 %sp $0x18 -> %d31 %d0 %d1 %sp
 0cdf77ff : ld1    {v31.4h}, [sp], #8      : ld1    (%sp)[8byte] $0x01 %sp $0x08 -> %d31 %sp
 0cdfa7ff : ld1    {v31.4h, v0.4h}, [sp], #16: ld1    (%sp)[16byte] $0x01 %sp $0x10 -> %d31 %d0 %sp
+0d001041 : st1    {v1.b}[4], [x2]         : st1    %q1 $0x04 -> (%x2)[1byte]
+0d003041 : st3    {v1.b-v3.b}[4], [x2]    : st3    %q1 %q2 %q3 $0x04 -> (%x2)[3byte]
+0d005041 : st1    {v1.h}[2], [x2]         : st1    %q1 $0x02 -> (%x2)[2byte]
+0d007041 : st3    {v1.h-v3.h}[2], [x2]    : st3    %q1 %q2 %q3 $0x02 -> (%x2)[6byte]
+0d008441 : st1    {v1.d}[0], [x2]         : st1    %q1 $0x00 -> (%x2)[8byte]
+0d009041 : st1    {v1.s}[1], [x2]         : st1    %q1 $0x01 -> (%x2)[4byte]
+0d00a441 : st3    {v1.d-v3.d}[0], [x2]    : st3    %q1 %q2 %q3 $0x00 -> (%x2)[24byte]
+0d00b041 : st3    {v1.s-v3.s}[1], [x2]    : st3    %q1 %q2 %q3 $0x01 -> (%x2)[12byte]
+0d201041 : st2    {v1.b, v2.b}[4], [x2]   : st2    %q1 %q2 $0x04 -> (%x2)[2byte]
+0d203041 : st4    {v1.b-v4.b}[4], [x2]    : st4    %q1 %q2 %q3 %q4 $0x04 -> (%x2)[4byte]
+0d205041 : st2    {v1.h, v2.h}[2], [x2]   : st2    %q1 %q2 $0x02 -> (%x2)[4byte]
+0d207041 : st4    {v1.h-v4.h}[2], [x2]    : st4    %q1 %q2 %q3 %q4 $0x02 -> (%x2)[8byte]
+0d208441 : st2    {v1.d, v2.d}[0], [x2]   : st2    %q1 %q2 $0x00 -> (%x2)[16byte]
+0d209041 : st2    {v1.s, v2.s}[1], [x2]   : st2    %q1 %q2 $0x01 -> (%x2)[8byte]
+0d20a441 : st4    {v1.d-v4.d}[0], [x2]    : st4    %q1 %q2 %q3 %q4 $0x00 -> (%x2)[32byte]
+0d20b041 : st4    {v1.s-v4.s}[1], [x2]    : st4    %q1 %q2 %q3 %q4 $0x01 -> (%x2)[16byte]
+0d401041 : ld1    {v1.b}[4], [x2]         : ld1    (%x2)[1byte] $0x04 -> %q1
+0d403041 : ld3    {v1.b-v3.b}[4], [x2]    : ld3    (%x2)[3byte] $0x04 -> %q1 %q2 %q3
+0d405041 : ld1    {v1.h}[2], [x2]         : ld1    (%x2)[2byte] $0x02 -> %q1
+0d407041 : ld3    {v1.h-v3.h}[2], [x2]    : ld3    (%x2)[6byte] $0x02 -> %q1 %q2 %q3
+0d408441 : ld1    {v1.d}[0], [x2]         : ld1    (%x2)[8byte] $0x00 -> %q1
+0d409041 : ld1    {v1.s}[1], [x2]         : ld1    (%x2)[4byte] $0x01 -> %q1
+0d40a441 : ld3    {v1.d-v3.d}[0], [x2]    : ld3    (%x2)[24byte] $0x00 -> %q1 %q2 %q3
+0d40b041 : ld3    {v1.s-v3.s}[1], [x2]    : ld3    (%x2)[12byte] $0x01 -> %q1 %q2 %q3
+0d40c041 : ld1r   {v1.8b}, [x2]           : ld1r   (%x2)[1byte] -> %d1
+0d40e041 : ld3r   {v1.8b-v3.8b}, [x2]     : ld3r   (%x2)[3byte] -> %d1 %d2 %d3
 0d40e7ff : ld3r   {v31.4h, v0.4h, v1.4h}, [sp]: ld3r   (%sp)[6byte] -> %d31 %d0 %d1
+0d601041 : ld2    {v1.b, v2.b}[4], [x2]   : ld2    (%x2)[2byte] $0x04 -> %q1 %q2
+0d603041 : ld4    {v1.b-v4.b}[4], [x2]    : ld4    (%x2)[4byte] $0x04 -> %q1 %q2 %q3 %q4
+0d605041 : ld2    {v1.h, v2.h}[2], [x2]   : ld2    (%x2)[4byte] $0x02 -> %q1 %q2
+0d607041 : ld4    {v1.h-v4.h}[2], [x2]    : ld4    (%x2)[8byte] $0x02 -> %q1 %q2 %q3 %q4
+0d608441 : ld2    {v1.d, v2.d}[0], [x2]   : ld2    (%x2)[16byte] $0x00 -> %q1 %q2
+0d609041 : ld2    {v1.s, v2.s}[1], [x2]   : ld2    (%x2)[8byte] $0x01 -> %q1 %q2
+0d60a441 : ld4    {v1.d-v4.d}[0], [x2]    : ld4    (%x2)[32byte] $0x00 -> %q1 %q2 %q3 %q4
+0d60b041 : ld4    {v1.s-v4.s}[1], [x2]    : ld4    (%x2)[16byte] $0x01 -> %q1 %q2 %q3 %q4
+0d60c041 : ld2r   {v1.8b, v2.8b}, [x2]    : ld2r   (%x2)[2byte] -> %d1 %d2
 0d60cbff : ld2r   {v31.2s, v0.2s}, [sp]   : ld2r   (%sp)[8byte] -> %d31 %d0
+0d60e041 : ld4r   {v1.8b-v4.8b}, [x2]     : ld4r   (%x2)[4byte] -> %d1 %d2 %d3 %d4
+0d881041 : st1    {v1.b}[4], [x2], x8     : st1    %q1 $0x04 %x2 %x8 -> (%x2)[1byte] %x2
+0d883041 : st3    {v1.b-v3.b}[4], [x2], x8: st3    %q1 %q2 %q3 $0x04 %x2 %x8 -> (%x2)[3byte] %x2
+0d885041 : st1    {v1.h}[2], [x2], x8     : st1    %q1 $0x02 %x2 %x8 -> (%x2)[2byte] %x2
+0d887041 : st3    {v1.h-v3.h}[2], [x2], x8: st3    %q1 %q2 %q3 $0x02 %x2 %x8 -> (%x2)[6byte] %x2
+0d888441 : st1    {v1.d}[0], [x2], x8     : st1    %q1 $0x00 %x2 %x8 -> (%x2)[8byte] %x2
+0d889041 : st1    {v1.s}[1], [x2], x8     : st1    %q1 $0x01 %x2 %x8 -> (%x2)[4byte] %x2
+0d88a441 : st3    {v1.d-v3.d}[0], [x2], x8: st3    %q1 %q2 %q3 $0x00 %x2 %x8 -> (%x2)[24byte] %x2
+0d88b041 : st3    {v1.s-v3.s}[1], [x2], x8: st3    %q1 %q2 %q3 $0x01 %x2 %x8 -> (%x2)[12byte] %x2
+0da81041 : st2    {v1.b, v2.b}[4], [x2], x8: st2    %q1 %q2 $0x04 %x2 %x8 -> (%x2)[2byte] %x2
+0da83041 : st4    {v1.b-v4.b}[4], [x2], x8: st4    %q1 %q2 %q3 %q4 $0x04 %x2 %x8 -> (%x2)[4byte] %x2
+0da85041 : st2    {v1.h, v2.h}[2], [x2], x8: st2    %q1 %q2 $0x02 %x2 %x8 -> (%x2)[4byte] %x2
+0da87041 : st4    {v1.h-v4.h}[2], [x2], x8: st4    %q1 %q2 %q3 %q4 $0x02 %x2 %x8 -> (%x2)[8byte] %x2
+0da88441 : st2    {v1.d, v2.d}[0], [x2], x8: st2    %q1 %q2 $0x00 %x2 %x8 -> (%x2)[16byte] %x2
+0da89041 : st2    {v1.s, v2.s}[1], [x2], x8: st2    %q1 %q2 $0x01 %x2 %x8 -> (%x2)[8byte] %x2
+0da8a441 : st4    {v1.d-v4.d}[0], [x2], x8: st4    %q1 %q2 %q3 %q4 $0x00 %x2 %x8 -> (%x2)[32byte] %x2
+0da8b041 : st4    {v1.s-v4.s}[1], [x2], x8: st4    %q1 %q2 %q3 %q4 $0x01 %x2 %x8 -> (%x2)[16byte] %x2
 0dc1e7ff : ld3r   {v31.4h, v0.4h, v1.4h}, [sp], x1: ld3r   (%sp)[6byte] %sp %x1 -> %d31 %d0 %d1 %sp
+0dc81041 : ld1    {v1.b}[4], [x2], x8     : ld1    %q1 (%x2)[1byte] $0x04 %x2 %x8 -> %q1 %x2
+0dc83041 : ld3    {v1.b-v3.b}[4], [x2], x8: ld3    %q1 %q2 %q3 (%x2)[3byte] $0x04 %x2 %x8 -> %q1 %q2 %q3 %x2
+0dc85041 : ld1    {v1.h}[2], [x2], x8     : ld1    %q1 (%x2)[2byte] $0x02 %x2 %x8 -> %q1 %x2
+0dc87041 : ld3    {v1.h-v3.h}[2], [x2], x8: ld3    %q1 %q2 %q3 (%x2)[6byte] $0x02 %x2 %x8 -> %q1 %q2 %q3 %x2
+0dc88441 : ld1    {v1.d}[0], [x2], x8     : ld1    %q1 (%x2)[8byte] $0x00 %x2 %x8 -> %q1 %x2
+0dc89041 : ld1    {v1.s}[1], [x2], x8     : ld1    %q1 (%x2)[4byte] $0x01 %x2 %x8 -> %q1 %x2
+0dc8a441 : ld3    {v1.d-v3.d}[0], [x2], x8: ld3    %q1 %q2 %q3 (%x2)[24byte] $0x00 %x2 %x8 -> %q1 %q2 %q3 %x2
+0dc8b041 : ld3    {v1.s-v3.s}[1], [x2], x8: ld3    %q1 %q2 %q3 (%x2)[12byte] $0x01 %x2 %x8 -> %q1 %q2 %q3 %x2
+0dc8c041 : ld1r   {v1.8b}, [x2], x8       : ld1r   (%x2)[1byte] %x2 %x8 -> %d1 %x2
+0dc8c441 : ld1r   {v1.4h}, [x2], x8       : ld1r   (%x2)[2byte] %x2 %x8 -> %d1 %x2
+0dc8c841 : ld1r   {v1.2s}, [x2], x8       : ld1r   (%x2)[4byte] %x2 %x8 -> %d1 %x2
+0dc8cc41 : ld1r   {v1.1d}, [x2], x8       : ld1r   (%x2)[8byte] %x2 %x8 -> %d1 %x2
+0dc8e041 : ld3r   {v1.8b-v3.8b}, [x2], x8 : ld3r   (%x2)[3byte] %x2 %x8 -> %d1 %d2 %d3 %x2
+0dc8e441 : ld3r   {v1.4h-v3.4h}, [x2], x8 : ld3r   (%x2)[6byte] %x2 %x8 -> %d1 %d2 %d3 %x2
+0dc8e841 : ld3r   {v1.2s-v3.2s}, [x2], x8 : ld3r   (%x2)[12byte] %x2 %x8 -> %d1 %d2 %d3 %x2
+0dc8ec41 : ld3r   {v1.1d-v3.1d}, [x2], x8 : ld3r   (%x2)[24byte] %x2 %x8 -> %d1 %d2 %d3 %x2
 0ddfe7ff : ld3r   {v31.4h, v0.4h, v1.4h}, [sp], #6: ld3r   (%sp)[6byte] %sp $0x06 -> %d31 %d0 %d1 %sp
 0de2cbff : ld2r   {v31.2s, v0.2s}, [sp], x2: ld2r   (%sp)[8byte] %sp %x2 -> %d31 %d0 %sp
+0de81041 : ld2    {v1.b, v2.b}[4], [x2], x8: ld2    %q1 %q2 (%x2)[2byte] $0x04 %x2 %x8 -> %q1 %q2 %x2
+0de83041 : ld4    {v1.b-v4.b}[4], [x2], x8: ld4    %q1 %q2 %q3 %q4 (%x2)[4byte] $0x04 %x2 %x8 -> %q1 %q2 %q3 %q4 %x2
+0de85041 : ld2    {v1.h, v2.h}[2], [x2], x8: ld2    %q1 %q2 (%x2)[4byte] $0x02 %x2 %x8 -> %q1 %q2 %x2
+0de87041 : ld4    {v1.h-v4.h}[2], [x2], x8: ld4    %q1 %q2 %q3 %q4 (%x2)[8byte] $0x02 %x2 %x8 -> %q1 %q2 %q3 %q4 %x2
+0de88441 : ld2    {v1.d, v2.d}[0], [x2], x8: ld2    %q1 %q2 (%x2)[16byte] $0x00 %x2 %x8 -> %q1 %q2 %x2
+0de89041 : ld2    {v1.s, v2.s}[1], [x2], x8: ld2    %q1 %q2 (%x2)[8byte] $0x01 %x2 %x8 -> %q1 %q2 %x2
+0de8a441 : ld4    {v1.d-v4.d}[0], [x2], x8: ld4    %q1 %q2 %q3 %q4 (%x2)[32byte] $0x00 %x2 %x8 -> %q1 %q2 %q3 %q4 %x2
+0de8b041 : ld4    {v1.s-v4.s}[1], [x2], x8: ld4    %q1 %q2 %q3 %q4 (%x2)[16byte] $0x01 %x2 %x8 -> %q1 %q2 %q3 %q4 %x2
+0de8c041 : ld2r   {v1.8b, v2.8b}, [x2], x8: ld2r   (%x2)[2byte] %x2 %x8 -> %d1 %d2 %x2
+0de8c441 : ld2r   {v1.4h, v2.4h}, [x2], x8: ld2r   (%x2)[4byte] %x2 %x8 -> %d1 %d2 %x2
+0de8c841 : ld2r   {v1.2s, v2.2s}, [x2], x8: ld2r   (%x2)[8byte] %x2 %x8 -> %d1 %d2 %x2
+0de8cc41 : ld2r   {v1.1d, v2.1d}, [x2], x8: ld2r   (%x2)[16byte] %x2 %x8 -> %d1 %d2 %x2
+0de8e041 : ld4r   {v1.8b-v4.8b}, [x2], x8 : ld4r   (%x2)[4byte] %x2 %x8 -> %d1 %d2 %d3 %d4 %x2
+0de8e441 : ld4r   {v1.4h-v4.4h}, [x2], x8 : ld4r   (%x2)[8byte] %x2 %x8 -> %d1 %d2 %d3 %d4 %x2
+0de8e841 : ld4r   {v1.2s-v4.2s}, [x2], x8 : ld4r   (%x2)[16byte] %x2 %x8 -> %d1 %d2 %d3 %d4 %x2
+0de8ec41 : ld4r   {v1.1d-v4.1d}, [x2], x8 : ld4r   (%x2)[32byte] %x2 %x8 -> %d1 %d2 %d3 %d4 %x2
 0dffcbff : ld2r   {v31.2s, v0.2s}, [sp], #8: ld2r   (%sp)[8byte] %sp $0x08 -> %d31 %d0 %sp
 10081041 : adr    x1, 10010208            : adr    <rel> 0x0000000010010208 -> %x1
 10800000 : adr    x0, ff00000             : adr    <rel> 0x000000000ff00000 -> %x0
 11000c41 : add    w1, w2, #0x3            : add    %w2 $0x0003 lsl $0x00 -> %w1
 11000fff : add    wsp, wsp, #0x3          : add    %wsp $0x0003 lsl $0x00 -> %wsp
+11081041 : add    w1, w2, #0x204          : add    %w2 $0x0204 lsl $0x00 -> %w1
 117fffff : add    wsp, wsp, #0xfff, lsl #12: add    %wsp $0x0fff lsl $0x10 -> %wsp
 12000441 : and    w1, w2, #0x3            : and    %w2 $0x00000003 -> %w1
+12081041 : and    w1, w2, #0x1f000000     : and    %w2 $0x1f000000 -> %w1
 12881041 : mov    w1, #0xffffbf7d         : movn   $0x4082 lsl $0x00 -> %w1
+12ffffff : .inst  0x12ffffff              : xx     $0x12ffffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 13031041 : sbfx   w1, w2, #3, #2          : sbfm   %w2 $0x03 $0x04 -> %w1
+13081041 : sbfiz  w1, w2, #24, #5         : sbfm   %w2 $0x08 $0x04 -> %w1
 131f7fff : asr    wzr, wzr, #31           : sbfm   %wzr $0x1f $0x1f -> %wzr
+133fffff : .inst  0x133fffff              : xx     $0x133fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 13831041 : extr   w1, w2, w3, #4          : extr   %w2 %w3 $0x04 -> %w1
+13881041 : extr   w1, w2, w8, #4          : extr   %w2 %w8 $0x04 -> %w1
 139f7fff : ror    wzr, wzr, #31           : extr   %wzr %wzr $0x1f -> %wzr
+139fffff : .inst  0x139fffff              : xx     $0x139fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 14081041 : b      10204104                : b      $0x0000000010204104
 15ffffff : b      17fffffc                : b      $0x0000000017fffffc
 17ffffff : b      ffffffc                 : b      $0x000000000ffffffc
 18081041 : ldr    w1, 10010208            : ldr    <rel> 0x0000000010010208[4byte] -> %w1
 187fffff : ldr    wzr, 100ffffc           : ldr    <rel> 0x00000000100ffffc[4byte] -> %wzr
 18800000 : ldr    w0, ff00000             : ldr    <rel> 0x000000000ff00000[4byte] -> %w0
+18ffffff : ldr    wzr, ffffffc            : ldr    <rel> 0x000000000ffffffc[4byte] -> %wzr
 1a030041 : adc    w1, w2, w3              : adc    %w2 %w3 -> %w1
+1a080041 : adc    w1, w2, w8              : adc    %w2 %w8 -> %w1
+1a881041 : csel   w1, w2, w8, ne          : csel   %w2 %w8 ne -> %w1
+1a881441 : csinc  w1, w2, w8, ne          : csinc  %w2 %w8 ne -> %w1
 1a9f7441 : csinc  w1, w2, wzr, vc         : csinc  %w2 %wzr vc -> %w1
 1ac30c5f : sdiv   wzr, w2, w3             : sdiv   %w2 %w3 -> %wzr
 1ac323e1 : lsl    w1, wzr, w3             : lslv   %wzr %w3 -> %w1
@@ -120,59 +259,107 @@
 1ac353e1 : crc32cb w1, wzr, w3            : crc32cb %wzr %w3 -> %w1
 1ac3545f : crc32ch wzr, w2, w3            : crc32ch %w2 %w3 -> %wzr
 1ac35841 : crc32cw w1, w2, w3             : crc32cw %w2 %w3 -> %w1
+1ac80841 : udiv   w1, w2, w8              : udiv   %w2 %w8 -> %w1
+1ac80c41 : sdiv   w1, w2, w8              : sdiv   %w2 %w8 -> %w1
+1ac82041 : lsl    w1, w2, w8              : lslv   %w2 %w8 -> %w1
+1ac82441 : lsr    w1, w2, w8              : lsrv   %w2 %w8 -> %w1
+1ac82841 : asr    w1, w2, w8              : asrv   %w2 %w8 -> %w1
+1ac82c41 : ror    w1, w2, w8              : rorv   %w2 %w8 -> %w1
+1ac84041 : crc32b w1, w2, w8              : crc32b %w2 %w8 -> %w1
+1ac84441 : crc32h w1, w2, w8              : crc32h %w2 %w8 -> %w1
+1ac84841 : crc32w w1, w2, w8              : crc32w %w2 %w8 -> %w1
+1ac85041 : crc32cb w1, w2, w8             : crc32cb %w2 %w8 -> %w1
+1ac85441 : crc32ch w1, w2, w8             : crc32ch %w2 %w8 -> %w1
+1ac85841 : crc32cw w1, w2, w8             : crc32cw %w2 %w8 -> %w1
+1adf43ff : crc32b wzr, wzr, wzr           : crc32b %wzr %wzr -> %wzr
+1adf47ff : crc32h wzr, wzr, wzr           : crc32h %wzr %wzr -> %wzr
 1adf4841 : crc32w w1, w2, wzr             : crc32w %w2 %wzr -> %w1
+1adf4bff : crc32w wzr, wzr, wzr           : crc32w %wzr %wzr -> %wzr
+1adf53ff : crc32cb wzr, wzr, wzr          : crc32cb %wzr %wzr -> %wzr
+1adf57ff : crc32ch wzr, wzr, wzr          : crc32ch %wzr %wzr -> %wzr
+1adf5bff : crc32cw wzr, wzr, wzr          : crc32cw %wzr %wzr -> %wzr
 1b03fc41 : mneg   w1, w2, w3              : msub   %w2 %w3 %wzr -> %w1
+1b081041 : madd   w1, w2, w8, w4          : madd   %w2 %w8 %w4 -> %w1
+1b089041 : msub   w1, w2, w8, w4          : msub   %w2 %w8 %w4 -> %w1
 1b1f1041 : madd   w1, w2, wzr, w4         : madd   %w2 %wzr %w4 -> %w1
 1c081041 : ldr    s1, 10010208            : ldr    <rel> 0x0000000010010208[4byte] -> %s1
 1c7fffff : ldr    s31, 100ffffc           : ldr    <rel> 0x00000000100ffffc[4byte] -> %s31
 1c800000 : ldr    s0, ff00000             : ldr    <rel> 0x000000000ff00000[4byte] -> %s0
+1cffffff : ldr    s31, ffffffc            : ldr    <rel> 0x000000000ffffffc[4byte] -> %s31
 28000000 : stnp   w0, w0, [x0]            : stnp   %w0 %w0 -> (%x0)[8byte]
+28081041 : stnp   w1, w4, [x2,#64]        : stnp   %w1 %w4 -> +0x40(%x2)[8byte]
 283fffff : stnp   wzr, wzr, [sp,#-4]      : stnp   %wzr %wzr -> -0x04(%sp)[8byte]
 28400000 : ldnp   w0, w0, [x0]            : ldnp   (%x0)[8byte] -> %w0 %w0
+28481041 : ldnp   w1, w4, [x2,#64]        : ldnp   +0x40(%x2)[8byte] -> %w1 %w4
 287fffff : ldnp   wzr, wzr, [sp,#-4]      : ldnp   -0x04(%sp)[8byte] -> %wzr %wzr
 28800000 : stp    w0, w0, [x0],#0         : stp    %w0 %w0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
+28881041 : stp    w1, w4, [x2],#64        : stp    %w1 %w4 %x2 $0x0000000000000040 -> (%x2)[8byte] %x2
 28bfffff : stp    wzr, wzr, [sp],#-4      : stp    %wzr %wzr %sp $0xfffffffffffffffc -> (%sp)[8byte] %sp
 28c00000 : ldp    w0, w0, [x0],#0         : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %w0 %w0 %x0
+28c81041 : ldp    w1, w4, [x2],#64        : ldp    (%x2)[8byte] %x2 $0x0000000000000040 -> %w1 %w4 %x2
 28ffffff : ldp    wzr, wzr, [sp],#-4      : ldp    (%sp)[8byte] %sp $0xfffffffffffffffc -> %wzr %wzr %sp
 29000000 : stp    w0, w0, [x0]            : stp    %w0 %w0 -> (%x0)[8byte]
+29081041 : stp    w1, w4, [x2,#64]        : stp    %w1 %w4 -> +0x40(%x2)[8byte]
 293fffff : stp    wzr, wzr, [sp,#-4]      : stp    %wzr %wzr -> -0x04(%sp)[8byte]
 29400000 : ldp    w0, w0, [x0]            : ldp    (%x0)[8byte] -> %w0 %w0
+29481041 : ldp    w1, w4, [x2,#64]        : ldp    +0x40(%x2)[8byte] -> %w1 %w4
 297fffff : ldp    wzr, wzr, [sp,#-4]      : ldp    -0x04(%sp)[8byte] -> %wzr %wzr
 29800000 : stp    w0, w0, [x0,#0]!        : stp    %w0 %w0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
+29881041 : stp    w1, w4, [x2,#64]!       : stp    %w1 %w4 %x2 $0x0000000000000040 -> +0x40(%x2)[8byte] %x2
 29bfffff : stp    wzr, wzr, [sp,#-4]!     : stp    %wzr %wzr %sp $0xfffffffffffffffc -> -0x04(%sp)[8byte] %sp
 29c00000 : ldp    w0, w0, [x0,#0]!        : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %w0 %w0 %x0
+29c81041 : ldp    w1, w4, [x2,#64]!       : ldp    +0x40(%x2)[8byte] %x2 $0x0000000000000040 -> %w1 %w4 %x2
 29ffffff : ldp    wzr, wzr, [sp,#-4]!     : ldp    -0x04(%sp)[8byte] %sp $0xfffffffffffffffc -> %wzr %wzr %sp
 2a031041 : orr    w1, w2, w3, lsl #4      : orr    %w2 %w3 lsl $0x04 -> %w1
+2a081041 : orr    w1, w2, w8, lsl #4      : orr    %w2 %w8 lsl $0x04 -> %w1
 2a231041 : orn    w1, w2, w3, lsl #4      : orn    %w2 %w3 lsl $0x04 -> %w1
+2a281041 : orn    w1, w2, w8, lsl #4      : orn    %w2 %w8 lsl $0x04 -> %w1
 2a9f13ff : mov    wzr, wzr                : orr    %wzr %wzr asr $0x04 -> %wzr
 2a9f7fff : mov    wzr, wzr                : orr    %wzr %wzr asr $0x1f -> %wzr
 2abf13ff : mvn    wzr, wzr, asr #4        : orn    %wzr %wzr asr $0x04 -> %wzr
+2adf7fff : mov    wzr, wzr                : orr    %wzr %wzr ror $0x1f -> %wzr
+2aff7fff : mvn    wzr, wzr, ror #31       : orn    %wzr %wzr ror $0x1f -> %wzr
 2b031041 : adds   w1, w2, w3, lsl #4      : adds   %w2 %w3 lsl $0x04 -> %w1
+2b081041 : adds   w1, w2, w8, lsl #4      : adds   %w2 %w8 lsl $0x04 -> %w1
+2b281041 : adds   w1, w2, w8, uxtb #4     : adds   %w2 %w8 uxtb $0x04 -> %w1
 2b3f43ff : cmn    wsp, wzr                : adds   %wsp %wzr uxtw $0x00 -> %wzr
 2b5f7fff : cmn    wzr, wzr, lsr #31       : adds   %wzr %wzr lsr $0x1f -> %wzr
 2b9f13ff : cmn    wzr, wzr, asr #4        : adds   %wzr %wzr asr $0x04 -> %wzr
+2bdf7fff : .inst  0x2bdf7fff              : xx     $0x2bdf7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
 2c000000 : stnp   s0, s0, [x0]            : stnp   %s0 %s0 -> (%x0)[8byte]
+2c081041 : stnp   s1, s4, [x2,#64]        : stnp   %s1 %s4 -> +0x40(%x2)[8byte]
 2c3fffff : stnp   s31, s31, [sp,#-4]      : stnp   %s31 %s31 -> -0x04(%sp)[8byte]
 2c400000 : ldnp   s0, s0, [x0]            : ldnp   (%x0)[8byte] -> %s0 %s0
+2c481041 : ldnp   s1, s4, [x2,#64]        : ldnp   +0x40(%x2)[8byte] -> %s1 %s4
 2c7fffff : ldnp   s31, s31, [sp,#-4]      : ldnp   -0x04(%sp)[8byte] -> %s31 %s31
 2c800000 : stp    s0, s0, [x0],#0         : stp    %s0 %s0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
+2c881041 : stp    s1, s4, [x2],#64        : stp    %s1 %s4 %x2 $0x0000000000000040 -> (%x2)[8byte] %x2
 2cbfffff : stp    s31, s31, [sp],#-4      : stp    %s31 %s31 %sp $0xfffffffffffffffc -> (%sp)[8byte] %sp
 2cc00000 : ldp    s0, s0, [x0],#0         : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %s0 %s0 %x0
+2cc81041 : ldp    s1, s4, [x2],#64        : ldp    (%x2)[8byte] %x2 $0x0000000000000040 -> %s1 %s4 %x2
 2cffffff : ldp    s31, s31, [sp],#-4      : ldp    (%sp)[8byte] %sp $0xfffffffffffffffc -> %s31 %s31 %sp
 2d000000 : stp    s0, s0, [x0]            : stp    %s0 %s0 -> (%x0)[8byte]
+2d081041 : stp    s1, s4, [x2,#64]        : stp    %s1 %s4 -> +0x40(%x2)[8byte]
 2d3fffff : stp    s31, s31, [sp,#-4]      : stp    %s31 %s31 -> -0x04(%sp)[8byte]
 2d400000 : ldp    s0, s0, [x0]            : ldp    (%x0)[8byte] -> %s0 %s0
+2d481041 : ldp    s1, s4, [x2,#64]        : ldp    +0x40(%x2)[8byte] -> %s1 %s4
 2d7fffff : ldp    s31, s31, [sp,#-4]      : ldp    -0x04(%sp)[8byte] -> %s31 %s31
 2d800000 : stp    s0, s0, [x0,#0]!        : stp    %s0 %s0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
+2d881041 : stp    s1, s4, [x2,#64]!       : stp    %s1 %s4 %x2 $0x0000000000000040 -> +0x40(%x2)[8byte] %x2
 2dbfffff : stp    s31, s31, [sp,#-4]!     : stp    %s31 %s31 %sp $0xfffffffffffffffc -> -0x04(%sp)[8byte] %sp
 2dc00000 : ldp    s0, s0, [x0,#0]!        : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %s0 %s0 %x0
+2dc81041 : ldp    s1, s4, [x2,#64]!       : ldp    +0x40(%x2)[8byte] %x2 $0x0000000000000040 -> %s1 %s4 %x2
 2dffffff : ldp    s31, s31, [sp,#-4]!     : ldp    -0x04(%sp)[8byte] %sp $0xfffffffffffffffc -> %s31 %s31 %sp
 310003ff : cmn    wsp, #0x0               : adds   %wsp $0x0000 lsl $0x00 -> %wzr
 31000c41 : adds   w1, w2, #0x3            : adds   %w2 $0x0003 lsl $0x00 -> %w1
 31000fff : cmn    wsp, #0x3               : adds   %wsp $0x0003 lsl $0x00 -> %wzr
+31081041 : adds   w1, w2, #0x204          : adds   %w2 $0x0204 lsl $0x00 -> %w1
 32000441 : orr    w1, w2, #0x3            : orr    %w2 $0x00000003 -> %w1
+32081041 : orr    w1, w2, #0x1f000000     : orr    %w2 $0x1f000000 -> %w1
 33031041 : bfxil  w1, w2, #3, #2          : bfm    %w1 %w2 $0x03 $0x04 -> %w1
+33081041 : bfi    w1, w2, #24, #5         : bfm    %w1 %w2 $0x08 $0x04 -> %w1
 331f7fff : bfxil  wzr, wzr, #31, #1       : bfm    %wzr %wzr $0x1f $0x1f -> %wzr
+333fffff : .inst  0x333fffff              : xx     $0x333fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 34081041 : cbz    w1, 10010208            : cbz    $0x0000000010010208 %w1
 347fffff : cbz    wzr, 100ffffc           : cbz    $0x00000000100ffffc %wzr
 35081041 : cbnz   w1, 10010208            : cbnz   $0x0000000010010208 %w1
@@ -199,6 +386,7 @@
 3823f841 : strb   w1, [x2,x3,sxtx #0]     : strb   %w1 -> (%x2,%x3,sxtx #0)[1byte]
 38280041 : ldaddb w8, w1, [x2]            : ldaddb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38281041 : ldclrb w8, w1, [x2]            : ldclrb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38281841 : .inst  0x38281841              : xx     $0x38281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 38282041 : ldeorb w8, w1, [x2]            : ldeorb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38283041 : ldsetb w8, w1, [x2]            : ldsetb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38284041 : ldsmaxb w8, w1, [x2]           : ldsmaxb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
@@ -243,6 +431,7 @@
 3863f841 : ldrb   w1, [x2,x3,sxtx #0]     : ldrb   (%x2,%x3,sxtx #0)[1byte] -> %w1
 38680041 : ldaddlb w8, w1, [x2]           : ldaddlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38681041 : ldclrlb w8, w1, [x2]           : ldclrlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38681841 : .inst  0x38681841              : xx     $0x38681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 38682041 : ldeorlb w8, w1, [x2]           : ldeorlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38683041 : ldsetlb w8, w1, [x2]           : ldsetlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38684041 : ldsmaxlb w8, w1, [x2]          : ldsmaxlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
@@ -287,6 +476,7 @@
 38a3f841 : ldrsb  x1, [x2,x3,sxtx #0]     : ldrsb  (%x2,%x3,sxtx #0)[1byte] -> %x1
 38a80041 : ldaddab w8, w1, [x2]           : ldaddab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38a81041 : ldclrab w8, w1, [x2]           : ldclrab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38a81841 : .inst  0x38a81841              : xx     $0x38a81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 38a82041 : ldeorab w8, w1, [x2]           : ldeorab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38a83041 : ldsetab w8, w1, [x2]           : ldsetab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38a84041 : ldsmaxab w8, w1, [x2]          : ldsmaxab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
@@ -331,6 +521,7 @@
 38e3f841 : ldrsb  w1, [x2,x3,sxtx #0]     : ldrsb  (%x2,%x3,sxtx #0)[1byte] -> %w1
 38e80041 : ldaddalb w8, w1, [x2]          : ldaddalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38e81041 : ldclralb w8, w1, [x2]          : ldclralb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38e81841 : .inst  0x38e81841              : xx     $0x38e81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 38e82041 : ldeoralb w8, w1, [x2]          : ldeoralb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38e83041 : ldsetalb w8, w1, [x2]          : ldsetalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
 38e84041 : ldsmaxalb w8, w1, [x2]         : ldsmaxalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
@@ -363,9 +554,12 @@
 39bfffff : ldrsb  xzr, [sp,#4095]         : ldrsb  +0x0fff(%sp)[1byte] -> %xzr
 39c81041 : ldrsb  w1, [x2,#516]           : ldrsb  +0x0204(%x2)[1byte] -> %w1
 39ffffff : ldrsb  wzr, [sp,#4095]         : ldrsb  +0x0fff(%sp)[1byte] -> %wzr
+3a080041 : adcs   w1, w2, w8              : adcs   %w2 %w8 -> %w1
 3a1f03ff : adcs   wzr, wzr, wzr           : adcs   %wzr %wzr -> %wzr
 3a40f820 : ccmn   w1, #0x0, #0x0, nv      : ccmn   %w1 $0x00 $0x00 nv
 3a42f020 : ccmn   w1, w2, #0x0, nv        : ccmn   %w1 %w2 $0x00 nv
+3a481041 : ccmn   w2, w8, #0x1, ne        : ccmn   %w2 %w8 $0x01 ne
+3a481841 : ccmn   w2, #0x8, #0x1, ne      : ccmn   %w2 $0x08 $0x01 ne
 3c000400 : str    b0, [x0],#0             : str    %b0 %x0 $0x0000000000000000 -> (%x0)[1byte] %x0
 3c000c00 : str    b0, [x0,#0]!            : str    %b0 %x0 $0x0000000000000000 -> (%x0)[1byte] %x0
 3c081041 : stur   b1, [x2,#129]           : stur   %b1 -> +0x81(%x2)[1byte]
@@ -382,6 +576,7 @@
 3c23d841 : str    b1, [x2,w3,sxtw #0]     : str    %b1 -> (%x2,%x3,sxtw #0)[1byte]
 3c23e841 : str    b1, [x2,x3,sxtx]        : str    %b1 -> (%x2,%x3,sxtx)[1byte]
 3c23f841 : str    b1, [x2,x3,sxtx #0]     : str    %b1 -> (%x2,%x3,sxtx #0)[1byte]
+3c281841 : .inst  0x3c281841              : xx     $0x3c281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 3c3f4bff : str    b31, [sp,wzr,uxtw]      : str    %b31 -> (%sp,%xzr,uxtw)[1byte]
 3c3f5bff : str    b31, [sp,wzr,uxtw #0]   : str    %b31 -> (%sp,%xzr,uxtw #0)[1byte]
 3c3f6bff : str    b31, [sp,xzr]           : str    %b31 -> (%sp,%xzr)[1byte]
@@ -406,6 +601,7 @@
 3c63d841 : ldr    b1, [x2,w3,sxtw #0]     : ldr    (%x2,%x3,sxtw #0)[1byte] -> %b1
 3c63e841 : ldr    b1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[1byte] -> %b1
 3c63f841 : ldr    b1, [x2,x3,sxtx #0]     : ldr    (%x2,%x3,sxtx #0)[1byte] -> %b1
+3c681841 : .inst  0x3c681841              : xx     $0x3c681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 3c7f4bff : ldr    b31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[1byte] -> %b31
 3c7f5bff : ldr    b31, [sp,wzr,uxtw #0]   : ldr    (%sp,%xzr,uxtw #0)[1byte] -> %b31
 3c7f6bff : ldr    b31, [sp,xzr]           : ldr    (%sp,%xzr)[1byte] -> %b31
@@ -430,6 +626,7 @@
 3ca3d841 : str    q1, [x2,w3,sxtw #4]     : str    %b1 -> (%x2,%x3,sxtw #4)[16byte]
 3ca3e841 : str    q1, [x2,x3,sxtx]        : str    %b1 -> (%x2,%x3,sxtx)[16byte]
 3ca3f841 : str    q1, [x2,x3,sxtx #4]     : str    %b1 -> (%x2,%x3,sxtx #4)[16byte]
+3ca81841 : .inst  0x3ca81841              : xx     $0x3ca81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 3cbf4bff : str    q31, [sp,wzr,uxtw]      : str    %b31 -> (%sp,%xzr,uxtw)[16byte]
 3cbf5bff : str    q31, [sp,wzr,uxtw #4]   : str    %b31 -> (%sp,%xzr,uxtw #4)[16byte]
 3cbf6bff : str    q31, [sp,xzr]           : str    %b31 -> (%sp,%xzr)[16byte]
@@ -454,6 +651,7 @@
 3ce3d841 : ldr    q1, [x2,w3,sxtw #4]     : ldr    (%x2,%x3,sxtw #4)[16byte] -> %q1
 3ce3e841 : ldr    q1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[16byte] -> %q1
 3ce3f841 : ldr    q1, [x2,x3,sxtx #4]     : ldr    (%x2,%x3,sxtx #4)[16byte] -> %q1
+3ce81841 : .inst  0x3ce81841              : xx     $0x3ce81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 3cff4bff : ldr    q31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[16byte] -> %q31
 3cff5bff : ldr    q31, [sp,wzr,uxtw #4]   : ldr    (%sp,%xzr,uxtw #4)[16byte] -> %q31
 3cff6bff : ldr    q31, [sp,xzr]           : ldr    (%sp,%xzr)[16byte] -> %q31
@@ -475,49 +673,93 @@
 481f7fff : stxrh  wzr, wzr, [sp]          : stxrh  %wzr $0x1f -> (%sp)[2byte] %wzr
 481fffff : stlxrh wzr, wzr, [sp]          : stlxrh %wzr $0x1f -> (%sp)[2byte] %wzr
 48287c40 : casp   x8, x9, x0, x1, [x2]    : casp   %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
+48287c41 : .inst  0x48287c41              : xx     $0x48287c41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 4828fc40 : caspl  x8, x9, x0, x1, [x2]    : caspl  %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
+4828fc41 : .inst  0x4828fc41              : xx     $0x4828fc41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 483e7ffe : casp   x30, xzr, x30, xzr, [sp]: casp   %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
 483efffe : caspl  x30, xzr, x30, xzr, [sp]: caspl  %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
+483f7fff : .inst  0x483f7fff              : xx     $0x483f7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
+483fffff : .inst  0x483fffff              : xx     $0x483fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 48481041 : ldxrh  w1, [x2]                : ldxrh  (%x2)[2byte] $0x04 $0x08 -> %w1
 48489041 : ldaxrh w1, [x2]                : ldaxrh (%x2)[2byte] $0x04 $0x08 -> %w1
 485f7fff : ldxrh  wzr, [sp]               : ldxrh  (%sp)[2byte] $0x1f $0x1f -> %wzr
 485fffff : ldaxrh wzr, [sp]               : ldaxrh (%sp)[2byte] $0x1f $0x1f -> %wzr
 48687c40 : caspa  x8, x9, x0, x1, [x2]    : caspa  %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
+48687c41 : .inst  0x48687c41              : xx     $0x48687c41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 4868fc40 : caspal x8, x9, x0, x1, [x2]    : caspal %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
+4868fc41 : .inst  0x4868fc41              : xx     $0x4868fc41 %x1 %x2 %sp %x8 -> %x1 %x2 %sp %x8
 487e7ffe : caspa  x30, xzr, x30, xzr, [sp]: caspa  %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
 487efffe : caspal x30, xzr, x30, xzr, [sp]: caspal %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
+487f7fff : .inst  0x487f7fff              : xx     $0x487f7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
+487fffff : .inst  0x487fffff              : xx     $0x487fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 48889041 : stlrh  w1, [x2]                : stlrh  %w1 $0x04 $0x08 -> (%x2)[2byte]
 489fffff : stlrh  wzr, [sp]               : stlrh  %wzr $0x1f $0x1f -> (%sp)[2byte]
 48a87c41 : cash   w8, w1, [x2]            : cash   %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
 48a8fc41 : caslh  w8, w1, [x2]            : caslh  %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
 48bf7fff : cash   wzr, wzr, [sp]          : cash   %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
 48bfffff : caslh  wzr, wzr, [sp]          : caslh  %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+48c89041 : .inst  0x48c89041              : ldarh  (%x2)[2byte] $0x04 $0x08 -> %w1
 48dfffff : ldarh  wzr, [sp]               : ldarh  (%sp)[2byte] $0x1f $0x1f -> %wzr
 48e87c41 : casah  w8, w1, [x2]            : casah  %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
 48e8fc41 : casalh w8, w1, [x2]            : casalh %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
 48ff7fff : casah  wzr, wzr, [sp]          : casah  %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
 48ffffff : casalh wzr, wzr, [sp]          : casalh %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
 4a031041 : eor    w1, w2, w3, lsl #4      : eor    %w2 %w3 lsl $0x04 -> %w1
+4a081041 : eor    w1, w2, w8, lsl #4      : eor    %w2 %w8 lsl $0x04 -> %w1
 4a231041 : eon    w1, w2, w3, lsl #4      : eon    %w2 %w3 lsl $0x04 -> %w1
+4a281041 : eon    w1, w2, w8, lsl #4      : eon    %w2 %w8 lsl $0x04 -> %w1
 4a9f13ff : eor    wzr, wzr, wzr, asr #4   : eor    %wzr %wzr asr $0x04 -> %wzr
 4abf13ff : eon    wzr, wzr, wzr, asr #4   : eon    %wzr %wzr asr $0x04 -> %wzr
+4adf7fff : eor    wzr, wzr, wzr, ror #31  : eor    %wzr %wzr ror $0x1f -> %wzr
+4aff7fff : eon    wzr, wzr, wzr, ror #31  : eon    %wzr %wzr ror $0x1f -> %wzr
 4b031041 : sub    w1, w2, w3, lsl #4      : sub    %w2 %w3 lsl $0x04 -> %w1
+4b081041 : sub    w1, w2, w8, lsl #4      : sub    %w2 %w8 lsl $0x04 -> %w1
+4b281041 : sub    w1, w2, w8, uxtb #4     : sub    %w2 %w8 uxtb $0x04 -> %w1
 4b9f13ff : neg    wzr, wzr, asr #4        : sub    %wzr %wzr asr $0x04 -> %wzr
 4b9f7fff : neg    wzr, wzr, asr #31       : sub    %wzr %wzr asr $0x1f -> %wzr
+4bdf7fff : .inst  0x4bdf7fff              : xx     $0x4bdf7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
+4c000fff : st4    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp]: st4    $0x03 %q31 %q0 %q1 %q2 -> (%sp)[64byte]
 4c0027ff : st1    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp]: st1    $0x01 %q31 %q0 %q1 %q2 -> (%sp)[64byte]
+4c002fff : st1    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp]: st1    $0x03 %q31 %q0 %q1 %q2 -> (%sp)[64byte]
 4c0047ff : st3    {v31.8h, v0.8h, v1.8h}, [sp]: st3    $0x01 %q31 %q0 %q1 -> (%sp)[48byte]
+4c004fff : st3    {v31.2d, v0.2d, v1.2d}, [sp]: st3    $0x03 %q31 %q0 %q1 -> (%sp)[48byte]
+4c006fff : st1    {v31.2d, v0.2d, v1.2d}, [sp]: st1    $0x03 %q31 %q0 %q1 -> (%sp)[48byte]
+4c007fff : st1    {v31.2d}, [sp]          : st1    $0x03 %q31 -> (%sp)[16byte]
 4c0087ff : st2    {v31.8h, v0.8h}, [sp]   : st2    $0x01 %q31 %q0 -> (%sp)[32byte]
+4c008fff : st2    {v31.2d, v0.2d}, [sp]   : st2    $0x03 %q31 %q0 -> (%sp)[32byte]
+4c00afff : st1    {v31.2d, v0.2d}, [sp]   : st1    $0x03 %q31 %q0 -> (%sp)[32byte]
 4c4007ff : ld4    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp]: ld4    (%sp)[64byte] $0x01 -> %q31 %q0 %q1 %q2
+4c400fff : ld4    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp]: ld4    (%sp)[64byte] $0x03 -> %q31 %q0 %q1 %q2
+4c402fff : ld1    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp]: ld1    (%sp)[64byte] $0x03 -> %q31 %q0 %q1 %q2
+4c404fff : ld3    {v31.2d, v0.2d, v1.2d}, [sp]: ld3    (%sp)[48byte] $0x03 -> %q31 %q0 %q1
 4c4067ff : ld1    {v31.8h, v0.8h, v1.8h}, [sp]: ld1    (%sp)[48byte] $0x01 -> %q31 %q0 %q1
+4c406fff : ld1    {v31.2d, v0.2d, v1.2d}, [sp]: ld1    (%sp)[48byte] $0x03 -> %q31 %q0 %q1
 4c4077ff : ld1    {v31.8h}, [sp]          : ld1    (%sp)[16byte] $0x01 -> %q31
+4c407fff : ld1    {v31.2d}, [sp]          : ld1    (%sp)[16byte] $0x03 -> %q31
+4c408fff : ld2    {v31.2d, v0.2d}, [sp]   : ld2    (%sp)[32byte] $0x03 -> %q31 %q0
 4c40a7ff : ld1    {v31.8h, v0.8h}, [sp]   : ld1    (%sp)[32byte] $0x01 -> %q31 %q0
+4c40afff : ld1    {v31.2d, v0.2d}, [sp]   : ld1    (%sp)[32byte] $0x03 -> %q31 %q0
 4c9f07ff : st4    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp], #64: st4    $0x01 %q31 %q0 %q1 %q2 %sp $0x40 -> (%sp)[64byte] %sp
+4c9f0fff : st4    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], #64: st4    $0x03 %q31 %q0 %q1 %q2 %sp $0x40 -> (%sp)[64byte] %sp
+4c9f2fff : st1    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], #64: st1    $0x03 %q31 %q0 %q1 %q2 %sp $0x40 -> (%sp)[64byte] %sp
+4c9f4fff : st3    {v31.2d, v0.2d, v1.2d}, [sp], #48: st3    $0x03 %q31 %q0 %q1 %sp $0x30 -> (%sp)[48byte] %sp
 4c9f67ff : st1    {v31.8h, v0.8h, v1.8h}, [sp], #48: st1    $0x01 %q31 %q0 %q1 %sp $0x30 -> (%sp)[48byte] %sp
+4c9f6fff : st1    {v31.2d, v0.2d, v1.2d}, [sp], #48: st1    $0x03 %q31 %q0 %q1 %sp $0x30 -> (%sp)[48byte] %sp
 4c9f77ff : st1    {v31.8h}, [sp], #16     : st1    $0x01 %q31 %sp $0x10 -> (%sp)[16byte] %sp
+4c9f7fff : st1    {v31.2d}, [sp], #16     : st1    $0x03 %q31 %sp $0x10 -> (%sp)[16byte] %sp
+4c9f8fff : st2    {v31.2d, v0.2d}, [sp], #32: st2    $0x03 %q31 %q0 %sp $0x20 -> (%sp)[32byte] %sp
 4c9fa7ff : st1    {v31.8h, v0.8h}, [sp], #32: st1    $0x01 %q31 %q0 %sp $0x20 -> (%sp)[32byte] %sp
+4c9fafff : st1    {v31.2d, v0.2d}, [sp], #32: st1    $0x03 %q31 %q0 %sp $0x20 -> (%sp)[32byte] %sp
+4cdf0fff : ld4    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], #64: ld4    (%sp)[64byte] $0x03 %sp $0x40 -> %q31 %q0 %q1 %q2 %sp
 4cdf27ff : ld1    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp], #64: ld1    (%sp)[64byte] $0x01 %sp $0x40 -> %q31 %q0 %q1 %q2 %sp
+4cdf2fff : ld1    {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], #64: ld1    (%sp)[64byte] $0x03 %sp $0x40 -> %q31 %q0 %q1 %q2 %sp
 4cdf47ff : ld3    {v31.8h, v0.8h, v1.8h}, [sp], #48: ld3    (%sp)[48byte] $0x01 %sp $0x30 -> %q31 %q0 %q1 %sp
+4cdf4fff : ld3    {v31.2d, v0.2d, v1.2d}, [sp], #48: ld3    (%sp)[48byte] $0x03 %sp $0x30 -> %q31 %q0 %q1 %sp
+4cdf6fff : ld1    {v31.2d, v0.2d, v1.2d}, [sp], #48: ld1    (%sp)[48byte] $0x03 %sp $0x30 -> %q31 %q0 %q1 %sp
+4cdf7fff : ld1    {v31.2d}, [sp], #16     : ld1    (%sp)[16byte] $0x03 %sp $0x10 -> %q31 %sp
 4cdf87ff : ld2    {v31.8h, v0.8h}, [sp], #32: ld2    (%sp)[32byte] $0x01 %sp $0x20 -> %q31 %q0 %sp
+4cdf8fff : ld2    {v31.2d, v0.2d}, [sp], #32: ld2    (%sp)[32byte] $0x03 %sp $0x20 -> %q31 %q0 %sp
+4cdfafff : ld1    {v31.2d, v0.2d}, [sp], #32: ld1    (%sp)[32byte] $0x03 %sp $0x20 -> %q31 %q0 %sp
 4d001fff : st1    {v31.b}[15], [sp]       : st1    %q31 $0x0f -> (%sp)[1byte]
 4d003fff : st3    {v31.b, v0.b, v1.b}[15], [sp]: st3    %q31 %q0 %q1 $0x0f -> (%sp)[3byte]
 4d005bff : st1    {v31.h}[7], [sp]        : st1    %q31 $0x07 -> (%sp)[2byte]
@@ -543,6 +785,8 @@
 4d40a7ff : ld3    {v31.d, v0.d, v1.d}[1], [sp]: ld3    (%sp)[24byte] $0x01 -> %q31 %q0 %q1
 4d40b3ff : ld3    {v31.s, v0.s, v1.s}[3], [sp]: ld3    (%sp)[12byte] $0x03 -> %q31 %q0 %q1
 4d40c3ff : ld1r   {v31.16b}, [sp]         : ld1r   (%sp)[1byte] -> %q31
+4d40cfff : ld1r   {v31.2d}, [sp]          : ld1r   (%sp)[8byte] -> %q31
+4d40efff : ld3r   {v31.2d, v0.2d, v1.2d}, [sp]: ld3r   (%sp)[24byte] -> %q31 %q0 %q1
 4d601fff : ld2    {v31.b, v0.b}[15], [sp] : ld2    (%sp)[2byte] $0x0f -> %q31 %q0
 4d603fff : ld4    {v31.b, v0.b, v1.b, v2.b}[15], [sp]: ld4    (%sp)[4byte] $0x0f -> %q31 %q0 %q1 %q2
 4d605bff : ld2    {v31.h, v0.h}[7], [sp]  : ld2    (%sp)[4byte] $0x07 -> %q31 %q0
@@ -551,6 +795,7 @@
 4d6093ff : ld2    {v31.s, v0.s}[3], [sp]  : ld2    (%sp)[8byte] $0x03 -> %q31 %q0
 4d60a7ff : ld4    {v31.d, v0.d, v1.d, v2.d}[1], [sp]: ld4    (%sp)[32byte] $0x01 -> %q31 %q0 %q1 %q2
 4d60b3ff : ld4    {v31.s, v0.s, v1.s, v2.s}[3], [sp]: ld4    (%sp)[16byte] $0x03 -> %q31 %q0 %q1 %q2
+4d60cfff : ld2r   {v31.2d, v0.2d}, [sp]   : ld2r   (%sp)[16byte] -> %q31 %q0
 4d60efff : ld4r   {v31.2d, v0.2d, v1.2d, v2.2d}, [sp]: ld4r   (%sp)[32byte] -> %q31 %q0 %q1 %q2
 4d9f1fff : st1    {v31.b}[15], [sp], #1   : st1    %q31 $0x0f %sp $0x01 -> (%sp)[1byte] %sp
 4d9f3fff : st3    {v31.b, v0.b, v1.b}[15], [sp], #3: st3    %q31 %q0 %q1 $0x0f %sp $0x03 -> (%sp)[3byte] %sp
@@ -578,6 +823,13 @@
 4ddfa7ff : ld3    {v31.d, v0.d, v1.d}[1], [sp], #24: ld3    %q31 %q0 %q1 (%sp)[24byte] $0x01 %sp $0x18 -> %q31 %q0 %q1 %sp
 4ddfb3ff : ld3    {v31.s, v0.s, v1.s}[3], [sp], #12: ld3    %q31 %q0 %q1 (%sp)[12byte] $0x03 %sp $0x0c -> %q31 %q0 %q1 %sp
 4ddfc3ff : ld1r   {v31.16b}, [sp], #1     : ld1r   (%sp)[1byte] %sp $0x01 -> %q31 %sp
+4ddfc7ff : ld1r   {v31.8h}, [sp], #2      : ld1r   (%sp)[2byte] %sp $0x02 -> %q31 %sp
+4ddfcbff : ld1r   {v31.4s}, [sp], #4      : ld1r   (%sp)[4byte] %sp $0x04 -> %q31 %sp
+4ddfcfff : ld1r   {v31.2d}, [sp], #8      : ld1r   (%sp)[8byte] %sp $0x08 -> %q31 %sp
+4ddfe3ff : ld3r   {v31.16b, v0.16b, v1.16b}, [sp], #3: ld3r   (%sp)[3byte] %sp $0x03 -> %q31 %q0 %q1 %sp
+4ddfe7ff : ld3r   {v31.8h, v0.8h, v1.8h}, [sp], #6: ld3r   (%sp)[6byte] %sp $0x06 -> %q31 %q0 %q1 %sp
+4ddfebff : ld3r   {v31.4s, v0.4s, v1.4s}, [sp], #12: ld3r   (%sp)[12byte] %sp $0x0c -> %q31 %q0 %q1 %sp
+4ddfefff : ld3r   {v31.2d, v0.2d, v1.2d}, [sp], #24: ld3r   (%sp)[24byte] %sp $0x18 -> %q31 %q0 %q1 %sp
 4df0efff : ld4r   {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], x16: ld4r   (%sp)[32byte] %sp %x16 -> %q31 %q0 %q1 %q2 %sp
 4dff1fff : ld2    {v31.b, v0.b}[15], [sp], #2: ld2    %q31 %q0 (%sp)[2byte] $0x0f %sp $0x02 -> %q31 %q0 %sp
 4dff3fff : ld4    {v31.b, v0.b, v1.b, v2.b}[15], [sp], #4: ld4    %q31 %q0 %q1 %q2 (%sp)[4byte] $0x0f %sp $0x04 -> %q31 %q0 %q1 %q2 %sp
@@ -587,13 +839,25 @@
 4dff93ff : ld2    {v31.s, v0.s}[3], [sp], #8: ld2    %q31 %q0 (%sp)[8byte] $0x03 %sp $0x08 -> %q31 %q0 %sp
 4dffa7ff : ld4    {v31.d, v0.d, v1.d, v2.d}[1], [sp], #32: ld4    %q31 %q0 %q1 %q2 (%sp)[32byte] $0x01 %sp $0x20 -> %q31 %q0 %q1 %q2 %sp
 4dffb3ff : ld4    {v31.s, v0.s, v1.s, v2.s}[3], [sp], #16: ld4    %q31 %q0 %q1 %q2 (%sp)[16byte] $0x03 %sp $0x10 -> %q31 %q0 %q1 %q2 %sp
+4dffc3ff : ld2r   {v31.16b, v0.16b}, [sp], #2: ld2r   (%sp)[2byte] %sp $0x02 -> %q31 %q0 %sp
+4dffc7ff : ld2r   {v31.8h, v0.8h}, [sp], #4: ld2r   (%sp)[4byte] %sp $0x04 -> %q31 %q0 %sp
+4dffcbff : ld2r   {v31.4s, v0.4s}, [sp], #8: ld2r   (%sp)[8byte] %sp $0x08 -> %q31 %q0 %sp
+4dffcfff : ld2r   {v31.2d, v0.2d}, [sp], #16: ld2r   (%sp)[16byte] %sp $0x10 -> %q31 %q0 %sp
+4dffe3ff : ld4r   {v31.16b, v0.16b, v1.16b, v2.16b}, [sp], #4: ld4r   (%sp)[4byte] %sp $0x04 -> %q31 %q0 %q1 %q2 %sp
+4dffe7ff : ld4r   {v31.8h, v0.8h, v1.8h, v2.8h}, [sp], #8: ld4r   (%sp)[8byte] %sp $0x08 -> %q31 %q0 %q1 %q2 %sp
+4dffebff : ld4r   {v31.4s, v0.4s, v1.4s, v2.4s}, [sp], #16: ld4r   (%sp)[16byte] %sp $0x10 -> %q31 %q0 %q1 %q2 %sp
 4dffefff : ld4r   {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], #32: ld4r   (%sp)[32byte] %sp $0x20 -> %q31 %q0 %q1 %q2 %sp
 51000c41 : sub    w1, w2, #0x3            : sub    %w2 $0x0003 lsl $0x00 -> %w1
 51000fff : sub    wsp, wsp, #0x3          : sub    %wsp $0x0003 lsl $0x00 -> %wsp
+51081041 : sub    w1, w2, #0x204          : sub    %w2 $0x0204 lsl $0x00 -> %w1
 52000441 : eor    w1, w2, #0x3            : eor    %w2 $0x00000003 -> %w1
+52081041 : eor    w1, w2, #0x1f000000     : eor    %w2 $0x1f000000 -> %w1
 52881041 : mov    w1, #0x4082             : movz   $0x4082 lsl $0x00 -> %w1
+52ffffff : .inst  0x52ffffff              : xx     $0x52ffffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 53031041 : ubfx   w1, w2, #3, #2          : ubfm   %w2 $0x03 $0x04 -> %w1
+53081041 : ubfiz  w1, w2, #24, #5         : ubfm   %w2 $0x08 $0x04 -> %w1
 531f7fff : lsr    wzr, wzr, #31           : ubfm   %wzr $0x1f $0x1f -> %wzr
+533fffff : .inst  0x533fffff              : xx     $0x533fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 54000000 : b.eq   10000000                : b.eq   $0x0000000010000000
 54000001 : b.ne   10000000                : b.ne   $0x0000000010000000
 54000002 : b.cs   10000000                : b.cs   $0x0000000010000000
@@ -607,60 +871,88 @@
 5400000a : b.ge   10000000                : b.ge   $0x0000000010000000
 5400000b : b.lt   10000000                : b.lt   $0x0000000010000000
 5400002c : b.gt   10000004                : b.gt   $0x0000000010000004
+54081041 : b.ne   10010208                : b.ne   $0x0000000010010208
 547fffed : b.le   100ffffc                : b.le   $0x00000000100ffffc
 547fffef : b.nv   100ffffc                : b.nv   $0x00000000100ffffc
 5480000e : b.al   ff00000                 : b.al   $0x000000000ff00000
 54ffffef : b.nv   ffffffc                 : b.nv   $0x000000000ffffffc
+58081041 : ldr    x1, 10010208            : ldr    <rel> 0x0000000010010208[8byte] -> %x1
 587fffff : ldr    xzr, 100ffffc           : ldr    <rel> 0x00000000100ffffc[8byte] -> %xzr
 58800000 : ldr    x0, ff00000             : ldr    <rel> 0x000000000ff00000[8byte] -> %x0
 58ffffff : ldr    xzr, ffffffc            : ldr    <rel> 0x000000000ffffffc[8byte] -> %xzr
+5a080041 : sbc    w1, w2, w8              : sbc    %w2 %w8 -> %w1
 5a1f03ff : ngc    wzr, wzr                : sbc    %wzr %wzr -> %wzr
 5a8383e1 : csinv  w1, wzr, w3, hi         : csinv  %wzr %w3 hi -> %w1
+5a881041 : csinv  w1, w2, w8, ne          : csinv  %w2 %w8 ne -> %w1
+5a881441 : csneg  w1, w2, w8, ne          : csneg  %w2 %w8 ne -> %w1
 5ac00041 : rbit   w1, w2                  : rbit   %w2 -> %w1
 5ac00441 : rev16  w1, w2                  : rev16  %w2 -> %w1
 5ac00841 : rev    w1, w2                  : rev    %w2 -> %w1
+5ac00bff : rev    wzr, wzr                : rev    %wzr -> %wzr
 5ac01041 : clz    w1, w2                  : clz    %w2 -> %w1
 5ac01441 : cls    w1, w2                  : cls    %w2 -> %w1
+5c081041 : ldr    d1, 10010208            : ldr    <rel> 0x0000000010010208[8byte] -> %d1
 5c7fffff : ldr    d31, 100ffffc           : ldr    <rel> 0x00000000100ffffc[8byte] -> %d31
 5c800000 : ldr    d0, ff00000             : ldr    <rel> 0x000000000ff00000[8byte] -> %d0
+5cffffff : ldr    d31, ffffffc            : ldr    <rel> 0x000000000ffffffc[8byte] -> %d31
 68c00000 : ldpsw  x0, x0, [x0],#0         : ldpsw  (%x0)[8byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
+68c81041 : ldpsw  x1, x4, [x2],#64        : ldpsw  (%x2)[8byte] %x2 $0x0000000000000040 -> %x1 %x4 %x2
 68ffffff : ldpsw  xzr, xzr, [sp],#-4      : ldpsw  (%sp)[8byte] %sp $0xfffffffffffffffc -> %xzr %xzr %sp
 69400000 : ldpsw  x0, x0, [x0]            : ldpsw  (%x0)[8byte] -> %x0 %x0
+69481041 : ldpsw  x1, x4, [x2,#64]        : ldpsw  +0x40(%x2)[8byte] -> %x1 %x4
 697fffff : ldpsw  xzr, xzr, [sp,#-4]      : ldpsw  -0x04(%sp)[8byte] -> %xzr %xzr
 69c00000 : ldpsw  x0, x0, [x0,#0]!        : ldpsw  (%x0)[8byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
+69c81041 : ldpsw  x1, x4, [x2,#64]!       : ldpsw  +0x40(%x2)[8byte] %x2 $0x0000000000000040 -> %x1 %x4 %x2
 69ffffff : ldpsw  xzr, xzr, [sp,#-4]!     : ldpsw  -0x04(%sp)[8byte] %sp $0xfffffffffffffffc -> %xzr %xzr %sp
 6a031041 : ands   w1, w2, w3, lsl #4      : ands   %w2 %w3 lsl $0x04 -> %w1
+6a081041 : ands   w1, w2, w8, lsl #4      : ands   %w2 %w8 lsl $0x04 -> %w1
 6a231041 : bics   w1, w2, w3, lsl #4      : bics   %w2 %w3 lsl $0x04 -> %w1
+6a281041 : bics   w1, w2, w8, lsl #4      : bics   %w2 %w8 lsl $0x04 -> %w1
 6a9f13ff : tst    wzr, wzr, asr #4        : ands   %wzr %wzr asr $0x04 -> %wzr
 6abf13ff : bics   wzr, wzr, wzr, asr #4   : bics   %wzr %wzr asr $0x04 -> %wzr
+6adf7fff : tst    wzr, wzr, ror #31       : ands   %wzr %wzr ror $0x1f -> %wzr
 6aff7fff : bics   wzr, wzr, wzr, ror #31  : bics   %wzr %wzr ror $0x1f -> %wzr
 6b031041 : subs   w1, w2, w3, lsl #4      : subs   %w2 %w3 lsl $0x04 -> %w1
+6b081041 : subs   w1, w2, w8, lsl #4      : subs   %w2 %w8 lsl $0x04 -> %w1
 6b1f7fff : negs   wzr, wzr, lsl #31       : subs   %wzr %wzr lsl $0x1f -> %wzr
+6b281041 : subs   w1, w2, w8, uxtb #4     : subs   %w2 %w8 uxtb $0x04 -> %w1
 6b3f8fff : cmp    wsp, wzr, sxtb #3       : subs   %wsp %wzr sxtb $0x03 -> %wzr
 6b3fc7ff : cmp    wsp, wzr, sxtw #1       : subs   %wsp %wzr sxtw $0x01 -> %wzr
 6b9f13ff : negs   wzr, wzr, asr #4        : subs   %wzr %wzr asr $0x04 -> %wzr
+6bdf7fff : .inst  0x6bdf7fff              : xx     $0x6bdf7fff %sp %sp %sp %sp -> %sp %sp %sp %sp
 6c000000 : stnp   d0, d0, [x0]            : stnp   %d0 %d0 -> (%x0)[16byte]
+6c081041 : stnp   d1, d4, [x2,#128]       : stnp   %d1 %d4 -> +0x80(%x2)[16byte]
 6c3fffff : stnp   d31, d31, [sp,#-8]      : stnp   %d31 %d31 -> -0x08(%sp)[16byte]
 6c400000 : ldnp   d0, d0, [x0]            : ldnp   (%x0)[16byte] -> %d0 %d0
+6c481041 : ldnp   d1, d4, [x2,#128]       : ldnp   +0x80(%x2)[16byte] -> %d1 %d4
 6c7fffff : ldnp   d31, d31, [sp,#-8]      : ldnp   -0x08(%sp)[16byte] -> %d31 %d31
 6c800000 : stp    d0, d0, [x0],#0         : stp    %d0 %d0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
+6c881041 : stp    d1, d4, [x2],#128       : stp    %d1 %d4 %x2 $0x0000000000000080 -> (%x2)[16byte] %x2
 6cbfffff : stp    d31, d31, [sp],#-8      : stp    %d31 %d31 %sp $0xfffffffffffffff8 -> (%sp)[16byte] %sp
 6cc00000 : ldp    d0, d0, [x0],#0         : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %d0 %d0 %x0
+6cc81041 : ldp    d1, d4, [x2],#128       : ldp    (%x2)[16byte] %x2 $0x0000000000000080 -> %d1 %d4 %x2
 6cffffff : ldp    d31, d31, [sp],#-8      : ldp    (%sp)[16byte] %sp $0xfffffffffffffff8 -> %d31 %d31 %sp
 6d000000 : stp    d0, d0, [x0]            : stp    %d0 %d0 -> (%x0)[16byte]
+6d081041 : stp    d1, d4, [x2,#128]       : stp    %d1 %d4 -> +0x80(%x2)[16byte]
 6d3fffff : stp    d31, d31, [sp,#-8]      : stp    %d31 %d31 -> -0x08(%sp)[16byte]
 6d400000 : ldp    d0, d0, [x0]            : ldp    (%x0)[16byte] -> %d0 %d0
+6d481041 : ldp    d1, d4, [x2,#128]       : ldp    +0x80(%x2)[16byte] -> %d1 %d4
 6d7fffff : ldp    d31, d31, [sp,#-8]      : ldp    -0x08(%sp)[16byte] -> %d31 %d31
 6d800000 : stp    d0, d0, [x0,#0]!        : stp    %d0 %d0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
+6d881041 : stp    d1, d4, [x2,#128]!      : stp    %d1 %d4 %x2 $0x0000000000000080 -> +0x80(%x2)[16byte] %x2
 6dbfffff : stp    d31, d31, [sp,#-8]!     : stp    %d31 %d31 %sp $0xfffffffffffffff8 -> -0x08(%sp)[16byte] %sp
 6dc00000 : ldp    d0, d0, [x0,#0]!        : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %d0 %d0 %x0
+6dc81041 : ldp    d1, d4, [x2,#128]!      : ldp    +0x80(%x2)[16byte] %x2 $0x0000000000000080 -> %d1 %d4 %x2
 6dffffff : ldp    d31, d31, [sp,#-8]!     : ldp    -0x08(%sp)[16byte] %sp $0xfffffffffffffff8 -> %d31 %d31 %sp
 707fffff : adr    xzr, 100fffff           : adr    <rel> 0x00000000100fffff -> %xzr
 70ffffff : adr    xzr, fffffff            : adr    <rel> 0x000000000fffffff -> %xzr
 71000c41 : subs   w1, w2, #0x3            : subs   %w2 $0x0003 lsl $0x00 -> %w1
 71000fff : cmp    wsp, #0x3               : subs   %wsp $0x0003 lsl $0x00 -> %wzr
+71081041 : subs   w1, w2, #0x204          : subs   %w2 $0x0204 lsl $0x00 -> %w1
 72000441 : ands   w1, w2, #0x3            : ands   %w2 $0x00000003 -> %w1
+72081041 : ands   w1, w2, #0x1f000000     : ands   %w2 $0x1f000000 -> %w1
 72881041 : movk   w1, #0x4082             : movk   %w1 $0x4082 lsl $0x00 -> %w1
+72ffffff : .inst  0x72ffffff              : xx     $0x72ffffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 78000400 : strh   w0, [x0],#0             : strh   %w0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
 78000c00 : strh   w0, [x0,#0]!            : strh   %w0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
 78081041 : sturh  w1, [x2,#129]           : sturh  %w1 -> +0x81(%x2)[2byte]
@@ -681,6 +973,7 @@
 7823f841 : strh   w1, [x2,x3,sxtx #1]     : strh   %w1 -> (%x2,%x3,sxtx #1)[2byte]
 78280041 : ldaddh w8, w1, [x2]            : ldaddh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78281041 : ldclrh w8, w1, [x2]            : ldclrh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78281841 : .inst  0x78281841              : xx     $0x78281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 78282041 : ldeorh w8, w1, [x2]            : ldeorh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78283041 : ldseth w8, w1, [x2]            : ldseth %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78284041 : ldsmaxh w8, w1, [x2]           : ldsmaxh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
@@ -725,6 +1018,7 @@
 7863f841 : ldrh   w1, [x2,x3,sxtx #1]     : ldrh   (%x2,%x3,sxtx #1)[2byte] -> %w1
 78680041 : ldaddlh w8, w1, [x2]           : ldaddlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78681041 : ldclrlh w8, w1, [x2]           : ldclrlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78681841 : .inst  0x78681841              : xx     $0x78681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 78682041 : ldeorlh w8, w1, [x2]           : ldeorlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78683041 : ldsetlh w8, w1, [x2]           : ldsetlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78684041 : ldsmaxlh w8, w1, [x2]          : ldsmaxlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
@@ -769,6 +1063,7 @@
 78a3f841 : ldrsh  x1, [x2,x3,sxtx #1]     : ldrsh  (%x2,%x3,sxtx #1)[2byte] -> %x1
 78a80041 : ldaddah w8, w1, [x2]           : ldaddah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78a81041 : ldclrah w8, w1, [x2]           : ldclrah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78a81841 : .inst  0x78a81841              : xx     $0x78a81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 78a82041 : ldeorah w8, w1, [x2]           : ldeorah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78a83041 : ldsetah w8, w1, [x2]           : ldsetah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78a84041 : ldsmaxah w8, w1, [x2]          : ldsmaxah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
@@ -813,6 +1108,7 @@
 78e3f841 : ldrsh  w1, [x2,x3,sxtx #1]     : ldrsh  (%x2,%x3,sxtx #1)[2byte] -> %w1
 78e80041 : ldaddalh w8, w1, [x2]          : ldaddalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78e81041 : ldclralh w8, w1, [x2]          : ldclralh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78e81841 : .inst  0x78e81841              : xx     $0x78e81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 78e82041 : ldeoralh w8, w1, [x2]          : ldeoralh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78e83041 : ldsetalh w8, w1, [x2]          : ldsetalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
 78e84041 : ldsmaxalh w8, w1, [x2]         : ldsmaxalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
@@ -846,7 +1142,10 @@
 79c81041 : ldrsh  w1, [x2,#1032]          : ldrsh  +0x0408(%x2)[2byte] -> %w1
 79ffffff : ldrsh  wzr, [sp,#8190]         : ldrsh  +0x1ffe(%sp)[2byte] -> %wzr
 7a030041 : sbcs   w1, w2, w3              : sbcs   %w2 %w3 -> %w1
+7a080041 : sbcs   w1, w2, w8              : sbcs   %w2 %w8 -> %w1
 7a42e3e1 : ccmp   wzr, w2, #0x1, al       : ccmp   %wzr %w2 $0x01 al
+7a481041 : ccmp   w2, w8, #0x1, ne        : ccmp   %w2 %w8 $0x01 ne
+7a481841 : ccmp   w2, #0x8, #0x1, ne      : ccmp   %w2 $0x08 $0x01 ne
 7a4aebe1 : ccmp   wzr, #0xa, #0x1, al     : ccmp   %wzr $0x0a $0x01 al
 7c000400 : str    h0, [x0],#0             : str    %h0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
 7c000c00 : str    h0, [x0,#0]!            : str    %h0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
@@ -864,6 +1163,7 @@
 7c23d841 : str    h1, [x2,w3,sxtw #1]     : str    %h1 -> (%x2,%x3,sxtw #1)[2byte]
 7c23e841 : str    h1, [x2,x3,sxtx]        : str    %h1 -> (%x2,%x3,sxtx)[2byte]
 7c23f841 : str    h1, [x2,x3,sxtx #1]     : str    %h1 -> (%x2,%x3,sxtx #1)[2byte]
+7c281841 : .inst  0x7c281841              : xx     $0x7c281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 7c3f4bff : str    h31, [sp,wzr,uxtw]      : str    %h31 -> (%sp,%xzr,uxtw)[2byte]
 7c3f5bff : str    h31, [sp,wzr,uxtw #1]   : str    %h31 -> (%sp,%xzr,uxtw #1)[2byte]
 7c3f6bff : str    h31, [sp,xzr]           : str    %h31 -> (%sp,%xzr)[2byte]
@@ -888,6 +1188,7 @@
 7c63d841 : ldr    h1, [x2,w3,sxtw #1]     : ldr    (%x2,%x3,sxtw #1)[2byte] -> %h1
 7c63e841 : ldr    h1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[2byte] -> %h1
 7c63f841 : ldr    h1, [x2,x3,sxtx #1]     : ldr    (%x2,%x3,sxtx #1)[2byte] -> %h1
+7c681841 : .inst  0x7c681841              : xx     $0x7c681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 7c7f4bff : ldr    h31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[2byte] -> %h31
 7c7f5bff : ldr    h31, [sp,wzr,uxtw #1]   : ldr    (%sp,%xzr,uxtw #1)[2byte] -> %h31
 7c7f6bff : ldr    h31, [sp,xzr]           : ldr    (%sp,%xzr)[2byte] -> %h31
@@ -922,100 +1223,166 @@
 88a8fc41 : casl   w8, w1, [x2]            : casl   %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
 88bf7fff : cas    wzr, wzr, [sp]          : cas    %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
 88bfffff : casl   wzr, wzr, [sp]          : casl   %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+88c89041 : .inst  0x88c89041              : ldar   (%x2)[4byte] $0x04 $0x08 -> %w1
 88dfffff : ldar   wzr, [sp]               : ldar   (%sp)[4byte] $0x1f $0x1f -> %wzr
 88e87c41 : casa   w8, w1, [x2]            : casa   %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
 88e8fc41 : casal  w8, w1, [x2]            : casal  %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
 88ff7fff : casa   wzr, wzr, [sp]          : casa   %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
 88ffffff : casal  wzr, wzr, [sp]          : casal  %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+8a081041 : and    x1, x2, x8, lsl #4      : and    %x2 %x8 lsl $0x04 -> %x1
 8a1fffff : and    xzr, xzr, xzr, lsl #63  : and    %xzr %xzr lsl $0x3f -> %xzr
+8a281041 : bic    x1, x2, x8, lsl #4      : bic    %x2 %x8 lsl $0x04 -> %x1
 8a431041 : and    x1, x2, x3, lsr #4      : and    %x2 %x3 lsr $0x04 -> %x1
 8a631041 : bic    x1, x2, x3, lsr #4      : bic    %x2 %x3 lsr $0x04 -> %x1
 8adf13ff : and    xzr, xzr, xzr, ror #4   : and    %xzr %xzr ror $0x04 -> %xzr
+8adfffff : and    xzr, xzr, xzr, ror #63  : and    %xzr %xzr ror $0x3f -> %xzr
 8aff13ff : bic    xzr, xzr, xzr, ror #4   : bic    %xzr %xzr ror $0x04 -> %xzr
+8affffff : bic    xzr, xzr, xzr, ror #63  : bic    %xzr %xzr ror $0x3f -> %xzr
+8b081041 : add    x1, x2, x8, lsl #4      : add    %x2 %x8 lsl $0x04 -> %x1
 8b3f27ff : add    sp, sp, wzr, uxth #1    : add    %sp %xzr uxth $0x01 -> %sp
+8b3fffff : .inst  0x8b3fffff              : xx     $0x8b3fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 8b431041 : add    x1, x2, x3, lsr #4      : add    %x2 %x3 lsr $0x04 -> %x1
 8b5fffff : add    xzr, xzr, xzr, lsr #63  : add    %xzr %xzr lsr $0x3f -> %xzr
 8b9f13ff : add    xzr, xzr, xzr, asr #4   : add    %xzr %xzr asr $0x04 -> %xzr
+8bdfffff : .inst  0x8bdfffff              : xx     $0x8bdfffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 90081041 : adrp   x1, 20208000            : adrp   <rel> 0x0000000020208000 -> %x1
 90800000 : adrp   x0, ffffffff10000000    : adrp   <rel> 0xffffffff10000000 -> %x0
 91000c41 : add    x1, x2, #0x3            : add    %x2 $0x0003 lsl $0x00 -> %x1
 91000fff : add    sp, sp, #0x3            : add    %sp $0x0003 lsl $0x00 -> %sp
+917fffff : add    sp, sp, #0xfff, lsl #12 : add    %sp $0x0fff lsl $0x10 -> %sp
 9201f041 : and    x1, x2, #0xaaaaaaaaaaaaaaaa: and    %x2 $0xaaaaaaaaaaaaaaaa -> %x1
 923ff041 : and    x1, x2, #0xaaaaaaaaaaaaaaaa: and    %x2 $0xaaaaaaaaaaaaaaaa $0x0ffc -> %x1
 92400441 : and    x1, x2, #0x3            : and    %x2 $0x0000000000000003 -> %x1
+927fffff : .inst  0x927fffff              : xx     $0x927fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
+92881041 : mov    x1, #0xffffffffffffbf7d : movn   $0x4082 lsl $0x00 -> %x1
 92ffffff : mov    xzr, #0xffffffffffff    : movn   $0xffff lsl $0x30 -> %xzr
 93431041 : sbfx   x1, x2, #3, #2          : sbfm   %x2 $0x03 $0x04 -> %x1
+93481041 : sbfiz  x1, x2, #56, #5         : sbfm   %x2 $0x08 $0x04 -> %x1
 937fffff : asr    xzr, xzr, #63           : sbfm   %xzr $0x3f $0x3f -> %xzr
 93c31041 : extr   x1, x2, x3, #4          : extr   %x2 %x3 $0x04 -> %x1
+93c81041 : extr   x1, x2, x8, #4          : extr   %x2 %x8 $0x04 -> %x1
 93dfffff : ror    xzr, xzr, #63           : extr   %xzr %xzr $0x3f -> %xzr
-94081041 : bl     10204104                : bl     $0x0000000010204104
-96000000 : bl     8000000                 : bl     $0x0000000008000000
-97ffffff : bl     ffffffc                 : bl     $0x000000000ffffffc
+94081041 : bl     10204104                : bl     $0x0000000010204104 -> %x30
+96000000 : bl     8000000                 : bl     $0x0000000008000000 -> %x30
+97ffffff : bl     ffffffc                 : bl     $0x000000000ffffffc -> %x30
 98081041 : ldrsw  x1, 10010208            : ldrsw  <rel> 0x0000000010010208[4byte] -> %x1
 987fffff : ldrsw  xzr, 100ffffc           : ldrsw  <rel> 0x00000000100ffffc[4byte] -> %xzr
 98800000 : ldrsw  x0, ff00000             : ldrsw  <rel> 0x000000000ff00000[4byte] -> %x0
 98ffffff : ldrsw  xzr, ffffffc            : ldrsw  <rel> 0x000000000ffffffc[4byte] -> %xzr
 9a1f03ff : adc    xzr, xzr, xzr           : adc    %xzr %xzr -> %xzr
 9a830041 : csel   x1, x2, x3, eq          : csel   %x2 %x3 eq -> %x1
+9a9ff3ff : csel   xzr, xzr, xzr, nv       : csel   %xzr %xzr nv -> %xzr
+9a9ff7ff : csinc  xzr, xzr, xzr, nv       : csinc  %xzr %xzr nv -> %xzr
 9ac30841 : udiv   x1, x2, x3              : udiv   %x2 %x3 -> %x1
 9ac32841 : asr    x1, x2, x3              : asrv   %x2 %x3 -> %x1
 9ac34c41 : crc32x w1, w2, x3              : crc32x %w2 %x3 -> %w1
 9ac35c41 : crc32cx w1, w2, x3             : crc32cx %w2 %x3 -> %w1
+9ac84c41 : crc32x w1, w2, x8              : crc32x %w2 %x8 -> %w1
+9ac85c41 : crc32cx w1, w2, x8             : crc32cx %w2 %x8 -> %w1
+9adf0bff : udiv   xzr, xzr, xzr           : udiv   %xzr %xzr -> %xzr
+9adf0fff : sdiv   xzr, xzr, xzr           : sdiv   %xzr %xzr -> %xzr
+9adf23ff : lsl    xzr, xzr, xzr           : lslv   %xzr %xzr -> %xzr
 9adf2441 : lsr    x1, x2, xzr             : lsrv   %x2 %xzr -> %x1
+9adf27ff : lsr    xzr, xzr, xzr           : lsrv   %xzr %xzr -> %xzr
+9adf2bff : asr    xzr, xzr, xzr           : asrv   %xzr %xzr -> %xzr
+9adf2fff : ror    xzr, xzr, xzr           : rorv   %xzr %xzr -> %xzr
+9adf4fff : crc32x wzr, wzr, xzr           : crc32x %wzr %xzr -> %wzr
+9adf5fff : crc32cx wzr, wzr, xzr          : crc32cx %wzr %xzr -> %wzr
 9b0313e1 : madd   x1, xzr, x3, x4         : madd   %xzr %x3 %x4 -> %x1
 9b03905f : msub   xzr, x2, x3, x4         : msub   %x2 %x3 %x4 -> %xzr
+9b1f7fff : mul    xzr, xzr, xzr           : madd   %xzr %xzr %xzr -> %xzr
+9b1fffff : mneg   xzr, xzr, xzr           : msub   %xzr %xzr %xzr -> %xzr
 9b23fc41 : smnegl x1, w2, w3              : smsubl %w2 %w3 %xzr -> %x1
+9b281041 : smaddl x1, w2, w8, x4          : smaddl %w2 %w8 %x4 -> %x1
+9b289041 : smsubl x1, w2, w8, x4          : smsubl %w2 %w8 %x4 -> %x1
 9b3f1041 : smaddl x1, w2, wzr, x4         : smaddl %w2 %wzr %x4 -> %x1
+9b3f7fff : smull  xzr, wzr, wzr           : smaddl %wzr %wzr %xzr -> %xzr
+9b3fffff : smnegl xzr, wzr, wzr           : smsubl %wzr %wzr %xzr -> %xzr
 9b4313e1 : smulh  x1, xzr, x3             : smulh  %xzr %x3 $0x04 -> %x1
+9b481041 : smulh  x1, x2, x8              : smulh  %x2 %x8 $0x04 -> %x1
+9b5f7fff : smulh  xzr, xzr, xzr           : smulh  %xzr %xzr $0x1f -> %xzr
 9ba3105f : umaddl xzr, w2, w3, x4         : umaddl %w2 %w3 %x4 -> %xzr
 9ba39041 : umsubl x1, w2, w3, x4          : umsubl %w2 %w3 %x4 -> %x1
+9ba81041 : umaddl x1, w2, w8, x4          : umaddl %w2 %w8 %x4 -> %x1
+9ba89041 : umsubl x1, w2, w8, x4          : umsubl %w2 %w8 %x4 -> %x1
+9bbf7fff : umull  xzr, wzr, wzr           : umaddl %wzr %wzr %xzr -> %xzr
+9bbfffff : umnegl xzr, wzr, wzr           : umsubl %wzr %wzr %xzr -> %xzr
 9bc31041 : umulh  x1, x2, x3              : umulh  %x2 %x3 $0x04 -> %x1
+9bc81041 : umulh  x1, x2, x8              : umulh  %x2 %x8 $0x04 -> %x1
+9bdf7fff : umulh  xzr, xzr, xzr           : umulh  %xzr %xzr $0x1f -> %xzr
+9c081041 : ldr    q1, 10010208            : ldr    <rel> 0x0000000010010208[16byte] -> %q1
 9c7fffff : ldr    q31, 100ffffc           : ldr    <rel> 0x00000000100ffffc[16byte] -> %q31
 9c800000 : ldr    q0, ff00000             : ldr    <rel> 0x000000000ff00000[16byte] -> %q0
+9cffffff : ldr    q31, ffffffc            : ldr    <rel> 0x000000000ffffffc[16byte] -> %q31
 a8000000 : stnp   x0, x0, [x0]            : stnp   %x0 %x0 -> (%x0)[16byte]
+a8081041 : stnp   x1, x4, [x2,#128]       : stnp   %x1 %x4 -> +0x80(%x2)[16byte]
 a83fffff : stnp   xzr, xzr, [sp,#-8]      : stnp   %xzr %xzr -> -0x08(%sp)[16byte]
 a8400000 : ldnp   x0, x0, [x0]            : ldnp   (%x0)[16byte] -> %x0 %x0
+a8481041 : ldnp   x1, x4, [x2,#128]       : ldnp   +0x80(%x2)[16byte] -> %x1 %x4
 a87fffff : ldnp   xzr, xzr, [sp,#-8]      : ldnp   -0x08(%sp)[16byte] -> %xzr %xzr
 a8800000 : stp    x0, x0, [x0],#0         : stp    %x0 %x0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
+a8881041 : stp    x1, x4, [x2],#128       : stp    %x1 %x4 %x2 $0x0000000000000080 -> (%x2)[16byte] %x2
 a8bfffff : stp    xzr, xzr, [sp],#-8      : stp    %xzr %xzr %sp $0xfffffffffffffff8 -> (%sp)[16byte] %sp
 a8c00000 : ldp    x0, x0, [x0],#0         : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
+a8c81041 : ldp    x1, x4, [x2],#128       : ldp    (%x2)[16byte] %x2 $0x0000000000000080 -> %x1 %x4 %x2
 a8ffffff : ldp    xzr, xzr, [sp],#-8      : ldp    (%sp)[16byte] %sp $0xfffffffffffffff8 -> %xzr %xzr %sp
 a9000000 : stp    x0, x0, [x0]            : stp    %x0 %x0 -> (%x0)[16byte]
+a9081041 : stp    x1, x4, [x2,#128]       : stp    %x1 %x4 -> +0x80(%x2)[16byte]
 a93fffff : stp    xzr, xzr, [sp,#-8]      : stp    %xzr %xzr -> -0x08(%sp)[16byte]
 a9400000 : ldp    x0, x0, [x0]            : ldp    (%x0)[16byte] -> %x0 %x0
+a9481041 : ldp    x1, x4, [x2,#128]       : ldp    +0x80(%x2)[16byte] -> %x1 %x4
 a97fffff : ldp    xzr, xzr, [sp,#-8]      : ldp    -0x08(%sp)[16byte] -> %xzr %xzr
 a9800000 : stp    x0, x0, [x0,#0]!        : stp    %x0 %x0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
+a9881041 : stp    x1, x4, [x2,#128]!      : stp    %x1 %x4 %x2 $0x0000000000000080 -> +0x80(%x2)[16byte] %x2
 a9bfffff : stp    xzr, xzr, [sp,#-8]!     : stp    %xzr %xzr %sp $0xfffffffffffffff8 -> -0x08(%sp)[16byte] %sp
 a9c00000 : ldp    x0, x0, [x0,#0]!        : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
+a9c81041 : ldp    x1, x4, [x2,#128]!      : ldp    +0x80(%x2)[16byte] %x2 $0x0000000000000080 -> %x1 %x4 %x2
 a9ffffff : ldp    xzr, xzr, [sp,#-8]!     : ldp    -0x08(%sp)[16byte] %sp $0xfffffffffffffff8 -> %xzr %xzr %sp
+aa081041 : orr    x1, x2, x8, lsl #4      : orr    %x2 %x8 lsl $0x04 -> %x1
+aa281041 : orn    x1, x2, x8, lsl #4      : orn    %x2 %x8 lsl $0x04 -> %x1
 aa431041 : orr    x1, x2, x3, lsr #4      : orr    %x2 %x3 lsr $0x04 -> %x1
 aa631041 : orn    x1, x2, x3, lsr #4      : orn    %x2 %x3 lsr $0x04 -> %x1
 aadf13ff : mov    xzr, xzr                : orr    %xzr %xzr ror $0x04 -> %xzr
+aadfffff : mov    xzr, xzr                : orr    %xzr %xzr ror $0x3f -> %xzr
 aaff13ff : mvn    xzr, xzr, ror #4        : orn    %xzr %xzr ror $0x04 -> %xzr
 aaffffff : mvn    xzr, xzr, ror #63       : orn    %xzr %xzr ror $0x3f -> %xzr
+ab081041 : adds   x1, x2, x8, lsl #4      : adds   %x2 %x8 lsl $0x04 -> %x1
+ab3fffff : .inst  0xab3fffff              : xx     $0xab3fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 ab431041 : adds   x1, x2, x3, lsr #4      : adds   %x2 %x3 lsr $0x04 -> %x1
 ab9f13ff : cmn    xzr, xzr, asr #4        : adds   %xzr %xzr asr $0x04 -> %xzr
 ab9fffff : cmn    xzr, xzr, asr #63       : adds   %xzr %xzr asr $0x3f -> %xzr
+abdfffff : .inst  0xabdfffff              : xx     $0xabdfffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 ac000000 : stnp   q0, q0, [x0]            : stnp   %q0 %q0 -> (%x0)[32byte]
+ac081041 : stnp   q1, q4, [x2,#256]       : stnp   %q1 %q4 -> +0x0100(%x2)[32byte]
 ac3fffff : stnp   q31, q31, [sp,#-16]     : stnp   %q31 %q31 -> -0x10(%sp)[32byte]
 ac400000 : ldnp   q0, q0, [x0]            : ldnp   (%x0)[32byte] -> %q0 %q0
+ac481041 : ldnp   q1, q4, [x2,#256]       : ldnp   +0x0100(%x2)[32byte] -> %q1 %q4
 ac7fffff : ldnp   q31, q31, [sp,#-16]     : ldnp   -0x10(%sp)[32byte] -> %q31 %q31
 ac800000 : stp    q0, q0, [x0],#0         : stp    %q0 %q0 %x0 $0x0000000000000000 -> (%x0)[32byte] %x0
+ac881041 : stp    q1, q4, [x2],#256       : stp    %q1 %q4 %x2 $0x0000000000000100 -> (%x2)[32byte] %x2
 acbfffff : stp    q31, q31, [sp],#-16     : stp    %q31 %q31 %sp $0xfffffffffffffff0 -> (%sp)[32byte] %sp
 acc00000 : ldp    q0, q0, [x0],#0         : ldp    (%x0)[32byte] %x0 $0x0000000000000000 -> %q0 %q0 %x0
+acc81041 : ldp    q1, q4, [x2],#256       : ldp    (%x2)[32byte] %x2 $0x0000000000000100 -> %q1 %q4 %x2
 acffffff : ldp    q31, q31, [sp],#-16     : ldp    (%sp)[32byte] %sp $0xfffffffffffffff0 -> %q31 %q31 %sp
 ad000000 : stp    q0, q0, [x0]            : stp    %q0 %q0 -> (%x0)[32byte]
+ad081041 : stp    q1, q4, [x2,#256]       : stp    %q1 %q4 -> +0x0100(%x2)[32byte]
 ad3fffff : stp    q31, q31, [sp,#-16]     : stp    %q31 %q31 -> -0x10(%sp)[32byte]
 ad400000 : ldp    q0, q0, [x0]            : ldp    (%x0)[32byte] -> %q0 %q0
+ad481041 : ldp    q1, q4, [x2,#256]       : ldp    +0x0100(%x2)[32byte] -> %q1 %q4
 ad7fffff : ldp    q31, q31, [sp,#-16]     : ldp    -0x10(%sp)[32byte] -> %q31 %q31
 ad800000 : stp    q0, q0, [x0,#0]!        : stp    %q0 %q0 %x0 $0x0000000000000000 -> (%x0)[32byte] %x0
+ad881041 : stp    q1, q4, [x2,#256]!      : stp    %q1 %q4 %x2 $0x0000000000000100 -> +0x0100(%x2)[32byte] %x2
 adbfffff : stp    q31, q31, [sp,#-16]!    : stp    %q31 %q31 %sp $0xfffffffffffffff0 -> -0x10(%sp)[32byte] %sp
 adc00000 : ldp    q0, q0, [x0,#0]!        : ldp    (%x0)[32byte] %x0 $0x0000000000000000 -> %q0 %q0 %x0
+adc81041 : ldp    q1, q4, [x2,#256]!      : ldp    +0x0100(%x2)[32byte] %x2 $0x0000000000000100 -> %q1 %q4 %x2
 adffffff : ldp    q31, q31, [sp,#-16]!    : ldp    -0x10(%sp)[32byte] %sp $0xfffffffffffffff0 -> %q31 %q31 %sp
 b1000c41 : adds   x1, x2, #0x3            : adds   %x2 $0x0003 lsl $0x00 -> %x1
 b1000fff : cmn    sp, #0x3                : adds   %sp $0x0003 lsl $0x00 -> %xzr
+b17fffff : cmn    sp, #0xfff, lsl #12     : adds   %sp $0x0fff lsl $0x10 -> %xzr
 b2400441 : orr    x1, x2, #0x3            : orr    %x2 $0x0000000000000003 -> %x1
+b27fffff : .inst  0xb27fffff              : xx     $0xb27fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 b3431041 : bfxil  x1, x2, #3, #2          : bfm    %x1 %x2 $0x03 $0x04 -> %x1
+b3481041 : bfi    x1, x2, #56, #5         : bfm    %x1 %x2 $0x08 $0x04 -> %x1
 b37fffff : bfxil  xzr, xzr, #63, #1       : bfm    %xzr %xzr $0x3f $0x3f -> %xzr
 b4ffffff : cbz    xzr, ffffffc            : cbz    $0x000000000ffffffc %xzr
 b5800000 : cbnz   x0, ff00000             : cbnz   $0x000000000ff00000 %x0
@@ -1043,6 +1410,7 @@ b823e841 : str    w1, [x2,x3,sxtx]        : str    %w1 -> (%x2,%x3,sxtx)[4byte]
 b823f841 : str    w1, [x2,x3,sxtx #2]     : str    %w1 -> (%x2,%x3,sxtx #2)[4byte]
 b8280041 : ldadd  w8, w1, [x2]            : ldadd  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8281041 : ldclr  w8, w1, [x2]            : ldclr  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8281841 : .inst  0xb8281841              : xx     $0xb8281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 b8282041 : ldeor  w8, w1, [x2]            : ldeor  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8283041 : ldset  w8, w1, [x2]            : ldset  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8284041 : ldsmax w8, w1, [x2]            : ldsmax %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
@@ -1087,6 +1455,7 @@ b863e841 : ldr    w1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[4byte] -> %w1
 b863f841 : ldr    w1, [x2,x3,sxtx #2]     : ldr    (%x2,%x3,sxtx #2)[4byte] -> %w1
 b8680041 : ldaddl w8, w1, [x2]            : ldaddl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8681041 : ldclrl w8, w1, [x2]            : ldclrl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8681841 : .inst  0xb8681841              : xx     $0xb8681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 b8682041 : ldeorl w8, w1, [x2]            : ldeorl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8683041 : ldsetl w8, w1, [x2]            : ldsetl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8684041 : ldsmaxl w8, w1, [x2]           : ldsmaxl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
@@ -1131,6 +1500,7 @@ b8a3e841 : ldrsw  x1, [x2,x3,sxtx]        : ldrsw  (%x2,%x3,sxtx)[4byte] -> %x1
 b8a3f841 : ldrsw  x1, [x2,x3,sxtx #2]     : ldrsw  (%x2,%x3,sxtx #2)[4byte] -> %x1
 b8a80041 : ldadda w8, w1, [x2]            : ldadda %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8a81041 : ldclra w8, w1, [x2]            : ldclra %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8a81841 : .inst  0xb8a81841              : xx     $0xb8a81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 b8a82041 : ldeora w8, w1, [x2]            : ldeora %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8a83041 : ldseta w8, w1, [x2]            : ldseta %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
 b8a84041 : ldsmaxa w8, w1, [x2]           : ldsmaxa %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
@@ -1180,8 +1550,11 @@ b97fffff : ldr    wzr, [sp,#16380]        : ldr    +0x3ffc(%sp)[4byte] -> %wzr
 b9881041 : ldrsw  x1, [x2,#2064]          : ldrsw  +0x0810(%x2)[4byte] -> %x1
 b9bfffff : ldrsw  xzr, [sp,#16380]        : ldrsw  +0x3ffc(%sp)[4byte] -> %xzr
 ba030041 : adcs   x1, x2, x3              : adcs   %x2 %x3 -> %x1
+ba1f03ff : adcs   xzr, xzr, xzr           : adcs   %xzr %xzr -> %xzr
 ba55d822 : ccmn   x1, #0x15, #0x2, le     : ccmn   %x1 $0x15 $0x02 le
 ba5fd022 : ccmn   x1, xzr, #0x2, le       : ccmn   %x1 %xzr $0x02 le
+ba5ff3ef : ccmn   xzr, xzr, #0xf, nv      : ccmn   %xzr %xzr $0x0f nv
+ba5ffbef : ccmn   xzr, #0x1f, #0xf, nv    : ccmn   %xzr $0x1f $0x0f nv
 bc000400 : str    s0, [x0],#0             : str    %s0 %x0 $0x0000000000000000 -> (%x0)[4byte] %x0
 bc000c00 : str    s0, [x0,#0]!            : str    %s0 %x0 $0x0000000000000000 -> (%x0)[4byte] %x0
 bc081041 : stur   s1, [x2,#129]           : stur   %s1 -> +0x81(%x2)[4byte]
@@ -1198,6 +1571,7 @@ bc23c841 : str    s1, [x2,w3,sxtw]        : str    %s1 -> (%x2,%x3,sxtw)[4byte]
 bc23d841 : str    s1, [x2,w3,sxtw #2]     : str    %s1 -> (%x2,%x3,sxtw #2)[4byte]
 bc23e841 : str    s1, [x2,x3,sxtx]        : str    %s1 -> (%x2,%x3,sxtx)[4byte]
 bc23f841 : str    s1, [x2,x3,sxtx #2]     : str    %s1 -> (%x2,%x3,sxtx #2)[4byte]
+bc281841 : .inst  0xbc281841              : xx     $0xbc281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 bc3f4bff : str    s31, [sp,wzr,uxtw]      : str    %s31 -> (%sp,%xzr,uxtw)[4byte]
 bc3f5bff : str    s31, [sp,wzr,uxtw #2]   : str    %s31 -> (%sp,%xzr,uxtw #2)[4byte]
 bc3f6bff : str    s31, [sp,xzr]           : str    %s31 -> (%sp,%xzr)[4byte]
@@ -1222,6 +1596,7 @@ bc63c841 : ldr    s1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[4byte] -> %s1
 bc63d841 : ldr    s1, [x2,w3,sxtw #2]     : ldr    (%x2,%x3,sxtw #2)[4byte] -> %s1
 bc63e841 : ldr    s1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[4byte] -> %s1
 bc63f841 : ldr    s1, [x2,x3,sxtx #2]     : ldr    (%x2,%x3,sxtx #2)[4byte] -> %s1
+bc681841 : .inst  0xbc681841              : xx     $0xbc681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 bc7f4bff : ldr    s31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[4byte] -> %s31
 bc7f5bff : ldr    s31, [sp,wzr,uxtw #2]   : ldr    (%sp,%xzr,uxtw #2)[4byte] -> %s31
 bc7f6bff : ldr    s31, [sp,xzr]           : ldr    (%sp,%xzr)[4byte] -> %s31
@@ -1256,31 +1631,45 @@ c8a87c41 : cas    x8, x1, [x2]            : cas    %x8 %x1 (%x2)[8byte] -> %x8 (
 c8a8fc41 : casl   x8, x1, [x2]            : casl   %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
 c8bf7fff : cas    xzr, xzr, [sp]          : cas    %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
 c8bfffff : casl   xzr, xzr, [sp]          : casl   %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+c8c89041 : .inst  0xc8c89041              : ldar   (%x2)[8byte] $0x04 $0x08 -> %x1
 c8dfffff : ldar   xzr, [sp]               : ldar   (%sp)[8byte] $0x1f $0x1f -> %xzr
 c8e87c41 : casa   x8, x1, [x2]            : casa   %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
 c8e8fc41 : casal  x8, x1, [x2]            : casal  %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
 c8ff7fff : casa   xzr, xzr, [sp]          : casa   %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
 c8ffffff : casal  xzr, xzr, [sp]          : casal  %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+ca081041 : eor    x1, x2, x8, lsl #4      : eor    %x2 %x8 lsl $0x04 -> %x1
+ca281041 : eon    x1, x2, x8, lsl #4      : eon    %x2 %x8 lsl $0x04 -> %x1
 ca431041 : eor    x1, x2, x3, lsr #4      : eor    %x2 %x3 lsr $0x04 -> %x1
 ca631041 : eon    x1, x2, x3, lsr #4      : eon    %x2 %x3 lsr $0x04 -> %x1
 ca7f7fff : eon    xzr, xzr, xzr, lsr #31  : eon    %xzr %xzr lsr $0x1f -> %xzr
 cadf13ff : eor    xzr, xzr, xzr, ror #4   : eor    %xzr %xzr ror $0x04 -> %xzr
+cadfffff : eor    xzr, xzr, xzr, ror #63  : eor    %xzr %xzr ror $0x3f -> %xzr
 caff13ff : eon    xzr, xzr, xzr, ror #4   : eon    %xzr %xzr ror $0x04 -> %xzr
+caffffff : eon    xzr, xzr, xzr, ror #63  : eon    %xzr %xzr ror $0x3f -> %xzr
 cb031041 : sub    x1, x2, x3, lsl #4      : sub    %x2 %x3 lsl $0x04 -> %x1
+cb081041 : sub    x1, x2, x8, lsl #4      : sub    %x2 %x8 lsl $0x04 -> %x1
 cb3f73ff : sub    sp, sp, xzr, lsl #4     : sub    %sp %xzr uxtx $0x04 -> %sp
+cb3fffff : .inst  0xcb3fffff              : xx     $0xcb3fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 cb431041 : sub    x1, x2, x3, lsr #4      : sub    %x2 %x3 lsr $0x04 -> %x1
 cb9f13ff : neg    xzr, xzr, asr #4        : sub    %xzr %xzr asr $0x04 -> %xzr
+cbdfffff : .inst  0xcbdfffff              : xx     $0xcbdfffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 d1000c41 : sub    x1, x2, #0x3            : sub    %x2 $0x0003 lsl $0x00 -> %x1
 d1000fff : sub    sp, sp, #0x3            : sub    %sp $0x0003 lsl $0x00 -> %sp
 d13fffff : sub    sp, sp, #0xfff          : sub    %sp $0x0fff lsl $0x00 -> %sp
+d17fffff : sub    sp, sp, #0xfff, lsl #12 : sub    %sp $0x0fff lsl $0x10 -> %sp
 d2400441 : eor    x1, x2, #0x3            : eor    %x2 $0x0000000000000003 -> %x1
+d27fffff : .inst  0xd27fffff              : xx     $0xd27fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
+d2881041 : mov    x1, #0x4082             : movz   $0x4082 lsl $0x00 -> %x1
 d2ffffff : mov    xzr, #0xffff000000000000: movz   $0xffff lsl $0x30 -> %xzr
 d3431041 : ubfx   x1, x2, #3, #2          : ubfm   %x2 $0x03 $0x04 -> %x1
+d3481041 : ubfiz  x1, x2, #56, #5         : ubfm   %x2 $0x08 $0x04 -> %x1
 d37fffff : lsr    xzr, xzr, #63           : ubfm   %xzr $0x3f $0x3f -> %xzr
 d4000001 : svc    #0x0                    : svc    $0x0000
 d4000002 : hvc    #0x0                    : hvc    $0x0000
 d4000003 : smc    #0x0                    : smc    $0x0000
 d4081041 : svc    #0x4082                 : svc    $0x4082
+d4081042 : hvc    #0x4082                 : hvc    $0x4082
+d4081043 : smc    #0x4082                 : smc    $0x4082
 d41fffe1 : svc    #0xffff                 : svc    $0xffff
 d41fffe2 : hvc    #0xffff                 : hvc    $0xffff
 d41fffe3 : smc    #0xffff                 : smc    $0xffff
@@ -1288,6 +1677,7 @@ d4200000 : brk    #0x0                    : brk    $0x0000
 d4281040 : brk    #0x4082                 : brk    $0x4082
 d43fffe0 : brk    #0xffff                 : brk    $0xffff
 d4400000 : hlt    #0x0                    : hlt    $0x0000
+d4481040 : hlt    #0x4082                 : hlt    $0x4082
 d45fffe0 : hlt    #0xffff                 : hlt    $0xffff
 d503201f : nop                            : nop
 d503203f : yield                          : yield
@@ -1304,16 +1694,20 @@ d5033f9f : dsb    sy                      : dsb    $0x0f
 d5033fbf : dmb    sy                      : dmb    $0x0f
 d5033fdf : isb                            : isb    $0x0f
 d5080000 : sys    #0, C0, C0, #0, x0      : sys    $0x0000 %x0
+d5081041 : sys    #0, C1, C0, #2, x1      : sys    $0x0082 %x1
 d50fffff : sys    #7, C15, C15, #7        : sys    $0x3fff %xzr
 d5100000 : msr    s2_0_c0_c0_0, x0        : msr    %x0 $0x0000
+d5181041 : msr    cpacr_el1, x1           : msr    %x1 $0x4082
 d51b4201 : msr    nzcv, x1                : msr    %x1 -> %nzcv
 d51b4402 : msr    fpcr, x2                : msr    %x2 -> %fpcr
 d51b4423 : msr    fpsr, x3                : msr    %x3 -> %fpsr
 d51bd044 : msr    tpidr_el0, x4           : msr    %x4 -> %tpidr_el0
 d51fffff : msr    s3_7_c15_c15_7, xzr     : msr    %xzr $0x7fff
 d5280000 : sysl   x0, #0, C0, C0, #0      : sys    $0x0000 -> %x0
+d5281041 : sysl   x1, #0, C1, C0, #2      : sys    $0x0082 -> %x1
 d52fffff : sysl   xzr, #7, C15, C15, #7   : sys    $0x3fff -> %xzr
 d5300000 : mrs    x0, s2_0_c0_c0_0        : mrs    $0x0000 -> %x0
+d5381041 : mrs    x1, cpacr_el1           : mrs    $0x4082 -> %x1
 d53b4201 : mrs    x1, nzcv                : mrs    %nzcv -> %x1
 d53b4402 : mrs    x2, fpcr                : mrs    %fpcr -> %x2
 d53b4423 : mrs    x3, fpsr                : mrs    %fpsr -> %x3
@@ -1322,38 +1716,59 @@ d53fffff : mrs    xzr, s3_7_c15_c15_7     : mrs    $0x7fff -> %xzr
 d61f0000 : br     x0                      : br     %x0
 d61f0040 : br     x2                      : br     %x2
 d61f03e0 : br     xzr                     : br     %xzr
-d63f0000 : blr    x0                      : blr    %x0
-d63f0040 : blr    x2                      : blr    %x2
-d63f03e0 : blr    xzr                     : blr    %xzr
+d63f0000 : blr    x0                      : blr    %x0 -> %x30
+d63f0040 : blr    x2                      : blr    %x2 -> %x30
+d63f03e0 : blr    xzr                     : blr    %xzr -> %x30
 d65f0000 : ret    x0                      : ret    %x0
 d65f0040 : ret    x2                      : ret    %x2
 d65f03e0 : ret    xzr                     : ret    %xzr
+d8081041 : prfm   pldl1strm, 10010208     : prfm   $0x01 <rel> 0x0000000010010208
 d87fffff : prfm   #0x1f, 100ffffc         : prfm   $0x1f <rel> 0x00000000100ffffc
 d8800000 : prfm   pldl1keep, ff00000      : prfm   $0x00 <rel> 0x000000000ff00000
+d8ffffff : prfm   #0x1f, ffffffc          : prfm   $0x1f <rel> 0x000000000ffffffc
 da030041 : sbc    x1, x2, x3              : sbc    %x2 %x3 -> %x1
+da1f03ff : ngc    xzr, xzr                : sbc    %xzr %xzr -> %xzr
 da83f45f : csneg  xzr, x2, x3, nv         : csneg  %x2 %x3 nv -> %xzr
+da9ff3ff : csinv  xzr, xzr, xzr, nv       : csinv  %xzr %xzr nv -> %xzr
+da9ff7ff : csneg  xzr, xzr, xzr, nv       : csneg  %xzr %xzr nv -> %xzr
 dac00041 : rbit   x1, x2                  : rbit   %x2 -> %x1
+dac003ff : rbit   xzr, xzr                : rbit   %xzr -> %xzr
 dac00441 : rev16  x1, x2                  : rev16  %x2 -> %x1
+dac007ff : rev16  xzr, xzr                : rev16  %xzr -> %xzr
 dac00841 : rev32  x1, x2                  : rev32  %x2 -> %x1
+dac00bff : rev32  xzr, xzr                : rev32  %xzr -> %xzr
 dac00c41 : rev    x1, x2                  : rev    %x2 -> %x1
+dac00fff : rev    xzr, xzr                : rev    %xzr -> %xzr
 dac01041 : clz    x1, x2                  : clz    %x2 -> %x1
+dac013ff : clz    xzr, xzr                : clz    %xzr -> %xzr
 dac01441 : cls    x1, x2                  : cls    %x2 -> %x1
+dac017ff : cls    xzr, xzr                : cls    %xzr -> %xzr
+ea081041 : ands   x1, x2, x8, lsl #4      : ands   %x2 %x8 lsl $0x04 -> %x1
+ea281041 : bics   x1, x2, x8, lsl #4      : bics   %x2 %x8 lsl $0x04 -> %x1
 ea431041 : ands   x1, x2, x3, lsr #4      : ands   %x2 %x3 lsr $0x04 -> %x1
 ea631041 : bics   x1, x2, x3, lsr #4      : bics   %x2 %x3 lsr $0x04 -> %x1
 ea9fffff : tst    xzr, xzr, asr #63       : ands   %xzr %xzr asr $0x3f -> %xzr
 eadf13ff : tst    xzr, xzr, ror #4        : ands   %xzr %xzr ror $0x04 -> %xzr
+eadfffff : tst    xzr, xzr, ror #63       : ands   %xzr %xzr ror $0x3f -> %xzr
 eaff13ff : bics   xzr, xzr, xzr, ror #4   : bics   %xzr %xzr ror $0x04 -> %xzr
+eaffffff : bics   xzr, xzr, xzr, ror #63  : bics   %xzr %xzr ror $0x3f -> %xzr
+eb081041 : subs   x1, x2, x8, lsl #4      : subs   %x2 %x8 lsl $0x04 -> %x1
 eb3fabff : cmp    sp, wzr, sxth #2        : subs   %sp %xzr sxth $0x02 -> %xzr
 eb3fe3ff : cmp    sp, xzr, sxtx           : subs   %sp %xzr sxtx $0x00 -> %xzr
+eb3fffff : .inst  0xeb3fffff              : xx     $0xeb3fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 eb431041 : subs   x1, x2, x3, lsr #4      : subs   %x2 %x3 lsr $0x04 -> %x1
 eb5fffff : negs   xzr, xzr, lsr #63       : subs   %xzr %xzr lsr $0x3f -> %xzr
 eb9f13ff : negs   xzr, xzr, asr #4        : subs   %xzr %xzr asr $0x04 -> %xzr
+ebdfffff : .inst  0xebdfffff              : xx     $0xebdfffff %sp %sp %sp %sp -> %sp %sp %sp %sp
 f07fffff : adrp   xzr, 10ffff000          : adrp   <rel> 0x000000010ffff000 -> %xzr
 f0ffffff : adrp   xzr, ffff000            : adrp   <rel> 0x000000000ffff000 -> %xzr
 f1000c41 : subs   x1, x2, #0x3            : subs   %x2 $0x0003 lsl $0x00 -> %x1
 f1000fff : cmp    sp, #0x3                : subs   %sp $0x0003 lsl $0x00 -> %xzr
 f16003ff : cmp    sp, #0x800, lsl #12     : subs   %sp $0x0800 lsl $0x10 -> %xzr
+f17fffff : cmp    sp, #0xfff, lsl #12     : subs   %sp $0x0fff lsl $0x10 -> %xzr
 f2400441 : ands   x1, x2, #0x3            : ands   %x2 $0x0000000000000003 -> %x1
+f27fffff : .inst  0xf27fffff              : xx     $0xf27fffff %sp %sp %sp %sp -> %sp %sp %sp %sp
+f2881041 : movk   x1, #0x4082             : movk   %x1 $0x4082 lsl $0x00 -> %x1
 f2ffffff : movk   xzr, #0xffff, lsl #48   : movk   %xzr $0xffff lsl $0x30 -> %xzr
 f8000400 : str    x0, [x0],#0             : str    %x0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
 f8000c00 : str    x0, [x0,#0]!            : str    %x0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
@@ -1375,6 +1790,7 @@ f823e841 : str    x1, [x2,x3,sxtx]        : str    %x1 -> (%x2,%x3,sxtx)[8byte]
 f823f841 : str    x1, [x2,x3,sxtx #3]     : str    %x1 -> (%x2,%x3,sxtx #3)[8byte]
 f8280041 : ldadd  x8, x1, [x2]            : ldadd  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8281041 : ldclr  x8, x1, [x2]            : ldclr  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8281841 : .inst  0xf8281841              : xx     $0xf8281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 f8282041 : ldeor  x8, x1, [x2]            : ldeor  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8283041 : ldset  x8, x1, [x2]            : ldset  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8284041 : ldsmax x8, x1, [x2]            : ldsmax %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
@@ -1419,6 +1835,7 @@ f863e841 : ldr    x1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[8byte] -> %x1
 f863f841 : ldr    x1, [x2,x3,sxtx #3]     : ldr    (%x2,%x3,sxtx #3)[8byte] -> %x1
 f8680041 : ldaddl x8, x1, [x2]            : ldaddl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8681041 : ldclrl x8, x1, [x2]            : ldclrl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8681841 : .inst  0xf8681841              : xx     $0xf8681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 f8682041 : ldeorl x8, x1, [x2]            : ldeorl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8683041 : ldsetl x8, x1, [x2]            : ldsetl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8684041 : ldsmaxl x8, x1, [x2]           : ldsmaxl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
@@ -1456,6 +1873,7 @@ f8a3e841 : prfm   pldl1strm, [x2,x3,sxtx] : prfm   $0x01 (%x2,%x3,sxtx)
 f8a3f841 : prfm   pldl1strm, [x2,x3,sxtx #3]: prfm   $0x01 (%x2,%x3,sxtx #3)
 f8a80041 : ldadda x8, x1, [x2]            : ldadda %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8a81041 : ldclra x8, x1, [x2]            : ldclra %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8a81841 : .inst  0xf8a81841              : xx     $0xf8a81841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 f8a82041 : ldeora x8, x1, [x2]            : ldeora %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8a83041 : ldseta x8, x1, [x2]            : ldseta %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
 f8a84041 : ldsmaxa x8, x1, [x2]           : ldsmaxa %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
@@ -1507,6 +1925,8 @@ f9bfffff : prfm   #0x1f, [sp,#32760]      : prfm   $0x1f +0x7ff8(%sp)
 fa1f03ff : ngcs   xzr, xzr                : sbcs   %xzr %xzr -> %xzr
 fa42c023 : ccmp   x1, x2, #0x3, gt        : ccmp   %x1 %x2 $0x03 gt
 fa5fc823 : ccmp   x1, #0x1f, #0x3, gt     : ccmp   %x1 $0x1f $0x03 gt
+fa5ff3ef : ccmp   xzr, xzr, #0xf, nv      : ccmp   %xzr %xzr $0x0f nv
+fa5ffbef : ccmp   xzr, #0x1f, #0xf, nv    : ccmp   %xzr $0x1f $0x0f nv
 fc000400 : str    d0, [x0],#0             : str    %d0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
 fc000c00 : str    d0, [x0,#0]!            : str    %d0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
 fc081041 : stur   d1, [x2,#129]           : stur   %d1 -> +0x81(%x2)[8byte]
@@ -1523,6 +1943,7 @@ fc23c841 : str    d1, [x2,w3,sxtw]        : str    %d1 -> (%x2,%x3,sxtw)[8byte]
 fc23d841 : str    d1, [x2,w3,sxtw #3]     : str    %d1 -> (%x2,%x3,sxtw #3)[8byte]
 fc23e841 : str    d1, [x2,x3,sxtx]        : str    %d1 -> (%x2,%x3,sxtx)[8byte]
 fc23f841 : str    d1, [x2,x3,sxtx #3]     : str    %d1 -> (%x2,%x3,sxtx #3)[8byte]
+fc281841 : .inst  0xfc281841              : xx     $0xfc281841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 fc3f4bff : str    d31, [sp,wzr,uxtw]      : str    %d31 -> (%sp,%xzr,uxtw)[8byte]
 fc3f5bff : str    d31, [sp,wzr,uxtw #3]   : str    %d31 -> (%sp,%xzr,uxtw #3)[8byte]
 fc3f6bff : str    d31, [sp,xzr]           : str    %d31 -> (%sp,%xzr)[8byte]
@@ -1547,6 +1968,7 @@ fc63c841 : ldr    d1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[8byte] -> %d1
 fc63d841 : ldr    d1, [x2,w3,sxtw #3]     : ldr    (%x2,%x3,sxtw #3)[8byte] -> %d1
 fc63e841 : ldr    d1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[8byte] -> %d1
 fc63f841 : ldr    d1, [x2,x3,sxtx #3]     : ldr    (%x2,%x3,sxtx #3)[8byte] -> %d1
+fc681841 : .inst  0xfc681841              : xx     $0xfc681841 %x1 %x2 %x6 %x8 -> %x1 %x2 %x6 %x8
 fc7f4bff : ldr    d31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[8byte] -> %d31
 fc7f5bff : ldr    d31, [sp,wzr,uxtw #3]   : ldr    (%sp,%xzr,uxtw #3)[8byte] -> %d31
 fc7f6bff : ldr    d31, [sp,xzr]           : ldr    (%sp,%xzr)[8byte] -> %d31


### PR DESCRIPTION
The BL and BLR instruction store the return address in X30, This patch
adds X30 as (implicit) destination register for BL and BLR.

Thanks @zhaoqin for spotting the problem in #2332 