### PR TITLE
i#297 sideline thread exit: delay sideline threads synch and termination on Unix

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -121,6 +121,7 @@ bool    dr_preinjected = false;
 static bool dynamo_exiting = false;
 #endif
 bool    dynamo_exited = false;
+bool    dynamo_exited_all_other_threads = false;
 bool    dynamo_exited_and_cleaned = false;
 #ifdef DEBUG
 bool    dynamo_exited_log_and_stats = false;
@@ -262,6 +263,12 @@ DECLARE_CXTSWPROT_VAR(mutex_t thread_initexit_lock,
 /* recursive to handle signals/exceptions while in DR code */
 DECLARE_CXTSWPROT_VAR(static recursive_lock_t thread_in_DR_exclusion,
                       INIT_RECURSIVE_LOCK(thread_in_DR_exclusion));
+
+static thread_synch_state_t
+exit_synch_state(void);
+
+static void
+synch_with_threads_at_exit(thread_synch_state_t synch_res, bool pre_exit);
 
 /****************************************************************************/
 #ifdef DEBUG
@@ -952,8 +959,6 @@ dynamo_shared_exit(thread_record_t *toexit /* must ==cur thread for Linux */
         global_unprotected_heap_free(protect_info, sizeof(protect_info_t) HEAPACCT(ACCT_OTHER));
     }
 
-    dynamo_exited_and_cleaned = true;
-
     /* call all component exit routines (CAUTION: order is important here) */
 
     DELETE_RECURSIVE_LOCK(thread_in_DR_exclusion);
@@ -978,7 +983,23 @@ dynamo_shared_exit(thread_record_t *toexit /* must ==cur thread for Linux */
      * client trying to use api routines that depend on fragment state.
      */
     instrument_exit();
-#endif
+# ifdef CLIENT_SIDELINE
+    /* We only need do a second synch-all if there are sideline client threads. */
+    if (get_num_threads() > 1)
+        synch_with_threads_at_exit(exit_synch_state(), false/*post-exit*/);
+    /* only current thread is alive */
+    dynamo_exited_all_other_threads = true;
+# endif /* CLIENT_SIDELINE */
+    /* Some lock can only be deleted if only one thread left. */
+    instrument_exit_post_sideline();
+#endif /* CLIENT_INTERFACE */
+
+    /* The dynamo_exited_and_cleaned should be set after the second synch-all.
+     * If it is set earlier after the first synch-all, some client thread may
+     * have memory leak due to dynamo_thread_exit_pre_client being skipped in
+     * dynamo_thread_exit_common called from exiting client threads.
+     */
+    dynamo_exited_and_cleaned = true;
 
     /* we want dcontext around for loader_exit() */
     if (get_thread_private_dcontext() != NULL)
@@ -1126,11 +1147,19 @@ dynamorio_app_exit(void)
  * does not resume the threads but does release the thread_initexit_lock.
  */
 static void
-synch_with_threads_at_exit(thread_synch_state_t synch_res)
+synch_with_threads_at_exit(thread_synch_state_t synch_res, bool pre_exit)
 {
     int num_threads;
     thread_record_t **threads;
     DEBUG_DECLARE(bool ok;)
+    /* if we fail to suspend a thread (e.g., privilege
+     * problems) ignore it. FIXME: retry instead?
+     */
+    uint flags = THREAD_SYNCH_SUSPEND_FAILURE_IGNORE;
+    if (pre_exit) {
+        /* i#297: we only synch client thread after process exit event. */
+        flags |= THREAD_SYNCH_SKIP_CLIENT_THREAD;
+    }
     LOG(GLOBAL, LOG_TOP|LOG_THREADS, 1,
         "\nsynch_with_threads_at_exit: cleaning up %d un-terminated threads\n",
         get_num_threads());
@@ -1161,10 +1190,7 @@ synch_with_threads_at_exit(thread_synch_state_t synch_res)
                                 * only care about threads carrying fcache
                                 * state can ignore us
                                 */
-                               THREAD_SYNCH_NO_LOCKS_NO_XFER,
-                               /* if we fail to suspend a thread (e.g., privilege
-                                * problems) ignore it. FIXME: retry instead? */
-                               THREAD_SYNCH_SUSPEND_FAILURE_IGNORE);
+                               THREAD_SYNCH_NO_LOCKS_NO_XFER, flags);
     ASSERT(ok);
     ASSERT(threads == NULL && num_threads == 0); /* We asked for CLEANED */
     /* the synch_with_all_threads function grabbed the
@@ -1236,7 +1262,11 @@ dynamo_process_exit_cleanup(void)
          * we don't check control_all_threads b/c we're just killing
          * the threads we know about here
          */
-        synch_with_threads_at_exit(exit_synch_state());
+        synch_with_threads_at_exit(exit_synch_state(), true/*pre-exit*/);
+#ifndef CLIENT_SIDELINE
+        /* no sideline thread, synchall done */
+        dynamo_exited_all_other_threads = true;
+#endif
         /* now that APC interception point is unpatched and
          * dynamorio_exited is set and we've killed all the theads we know
          * about, assumption is that no other threads will be running in
@@ -1373,7 +1403,10 @@ dynamo_process_exit(void)
         /* needed primarily for CLIENT_INTERFACE but technically all configurations
          * can have racy crashes at exit time (xref PR 470957)
          */
-        synch_with_threads_at_exit(exit_synch_state());
+        synch_with_threads_at_exit(exit_synch_state(), true/*pre-exit*/);
+# ifndef CLIENT_SIDELINE
+        dynamo_exited_all_other_threads = true;
+# endif
     } else
         dynamo_exited = true;
 
@@ -1444,14 +1477,21 @@ dynamo_process_exit(void)
          */
         instrument_exit();
 
-# ifdef CLIENT_INTERFACE
+# ifdef CLIENT_SIDELINE
+        /* We only need do a second synch-all if there are sideline client threads. */
+        if (get_num_threads() > 1)
+            synch_with_threads_at_exit(exit_synch_state(), false/*post-exit*/);
+        dynamo_exited_all_other_threads = true;
+# endif
+        /* Some lock can only be deleted if one thread left. */
+        instrument_exit_post_sideline();
+
         /* i#1617: We need to call client library fini routines for global
          * destructors, etc.
          */
         if (!INTERNAL_OPTION(nullcalls) && !DYNAMO_OPTION(skip_thread_exit_at_exit))
             loader_thread_exit(get_thread_private_dcontext());
         loader_exit();
-# endif
 
         /* for -private_loader we do this here to catch more exit-time crashes */
 # ifdef WINDOWS

--- a/core/globals.h
+++ b/core/globals.h
@@ -446,6 +446,7 @@ extern bool control_all_threads; /* ok for "weird" things to happen -- not all
 extern bool dynamo_heap_initialized;  /* has dynamo_heap been initialized? */
 extern bool dynamo_initialized;  /* has dynamo been initialized? */
 extern bool dynamo_exited;       /* has dynamo exited? */
+extern bool dynamo_exited_all_other_threads;  /* has dynamo exited and synched? */
 extern bool dynamo_exited_and_cleaned; /* has dynamo component cleanup started? */
 #ifdef DEBUG
 extern bool dynamo_exited_log_and_stats; /* are stats and logfile shut down? */

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -767,6 +767,14 @@ void free_all_callback_lists()
 }
 
 void
+instrument_exit_post_sideline(void)
+{
+#if defined(WINDOWS) || defined(CLIENT_SIDELINE)
+    DELETE_LOCK(client_thread_count_lock);
+#endif
+}
+
+void
 instrument_exit(void)
 {
     /* Note - currently own initexit lock when this is called (see PR 227619). */
@@ -796,9 +804,6 @@ instrument_exit(void)
     num_client_libs = 0;
 #ifdef WINDOWS
     DELETE_LOCK(client_aux_lib64_lock);
-#endif
-#if defined(WINDOWS) || defined(CLIENT_SIDELINE)
-    DELETE_LOCK(client_thread_count_lock);
 #endif
     DELETE_READWRITE_LOCK(callback_registration_lock);
 }

--- a/core/lib/instrument.h
+++ b/core/lib/instrument.h
@@ -104,6 +104,8 @@ void instrument_post_syscall(dcontext_t *dcontext, int sysnum);
 bool instrument_invoke_another_syscall(dcontext_t *dcontext);
 
 void instrument_nudge(dcontext_t *dcontext, client_id_t id, uint64 arg);
+/* post instrument_event() cleanup */
+void instrument_exit_post_sideline(void);
 # ifdef WINDOWS
 bool instrument_exception(dcontext_t *dcontext, dr_exception_t *exception);
 void wait_for_outstanding_nudges(void);

--- a/core/synch.c
+++ b/core/synch.c
@@ -1296,8 +1296,9 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
                     continue; /* skip this thread for now till non-client are finished */
                 }
                 if (IS_CLIENT_THREAD(threads[i]->dcontext) &&
-                    !should_suspend_client_thread(threads[i]->dcontext,
-                                                  desired_synch_state)) {
+                    (TEST(flags, THREAD_SYNCH_SKIP_CLIENT_THREAD) ||
+                     !should_suspend_client_thread(threads[i]->dcontext,
+                                                   desired_synch_state))) {
                     /* PR 609569: do not suspend this thread.
                      * Avoid races between resume_all_threads() and
                      * dr_client_thread_set_suspendable() by storing the fact.

--- a/core/synch.h
+++ b/core/synch.h
@@ -112,6 +112,9 @@ enum {
 
     /* specifies a much smaller loop max */
     THREAD_SYNCH_SMALL_LOOP_MAX         = 0x00000008,
+
+    /* specifies whether we should terminate client threads */
+    THREAD_SYNCH_SKIP_CLIENT_THREAD     = 0x00000010,
 };
 
 /* convenience macros */

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -2012,7 +2012,11 @@ os_tls_thread_exit(local_state_t *local_state)
 
     /* We already set TLS to &uninit_tls in os_thread_exit() */
 
-    if (dynamo_exited && !last_thread_tls_exited) {
+    /* Do not set last_thread_tls_exited if a client_thread is exiting.
+     * If set, get_thread_private_dcontext() returns NULL, which may cause
+     * other thread fault on using dcontext.
+     */
+    if (dynamo_exited_all_other_threads && !last_thread_tls_exited) {
         last_thread_tls_exited = true;
         first_thread_tls_initialized = false; /* for possible re-attach */
     }

--- a/core/win32/syscall.c
+++ b/core/win32/syscall.c
@@ -1710,6 +1710,9 @@ presys_TerminateProcess(dcontext_t *dcontext, reg_t *param_base)
                                    THREAD_SYNCH_VALID_MCONTEXT_NO_XFER,
                                    /* if we fail to suspend a thread (e.g., privilege
                                     * problems) ignore it. FIXME: retry instead? */
+                                   /* XXX i#2345: add THREAD_SYNCH_SKIP_CLIENT_THREAD
+                                    * to synch all application threads only.
+                                    */
                                    THREAD_SYNCH_SUSPEND_FAILURE_IGNORE);
         ASSERT(ok);
         ASSERT(threads == NULL && num_threads == 0); /* We asked for CLEANED */
@@ -1722,6 +1725,10 @@ presys_TerminateProcess(dcontext_t *dcontext, reg_t *param_base)
          * syscall comes in! (==case 4243) So, we hold the lock to issue
          * the syscall, safest to do syscall right here rather than going
          * back to handle_system_call()
+         */
+        /* XXX i#2346: instead of NtTerminateProcess syscall, which terminates all
+         * threads, we should use synch-all to terminate app threads only and
+         * delay client sideline threads termination.
          */
         return_val = nt_terminate_process_for_app(process_handle, exit_status);
         SET_RETURN_VAL(dcontext, return_val);

--- a/suite/tests/client-interface/thread.dll.c
+++ b/suite/tests/client-interface/thread.dll.c
@@ -179,6 +179,11 @@ void exit_event(void)
     bool success = dr_raw_tls_cfree(tls_offs, NUM_TLS_SLOTS);
     ASSERT(success);
     ASSERT(num_lea > 0);
+#ifdef UNIX /* XXX i#2346: we should delay client threads termination on Windows too. */
+    dr_fprintf(STDERR, "process is exiting\n");
+    dr_event_signal(child_continue);
+    dr_event_wait(child_dead);
+#endif
     /* DR should have terminated the client thread for us */
     dr_event_destroy(child_alive);
     dr_event_destroy(child_continue);

--- a/suite/tests/client-interface/thread.template
+++ b/suite/tests/client-interface/thread.template
@@ -32,3 +32,7 @@ TLS slot 1 is 0xbadcab43
 TLS slot 2 is 0xbadcab44
 TLS slot 3 is 0xbadcab45
 #endif
+#ifdef UNIX
+process is exiting
+client thread is dying
+#endif


### PR DESCRIPTION
We split the synch-all threads operation into two synch operations:
- pre-exit synch: synchronize all app threads and ignore client sideline threads
- post-exit synch: synchronize all threads.
The pre-exit synch is called before all app thread exit and process exit
events. The post-exit synch is called after all the app exit events.
By doing so, the sideline thread could be notified and have a chance to exit
gracefully before the app process exit event.

Fixes #297