### PR TITLE
i#511 drreg: add drreg_restore_app_aflags()

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -165,7 +165,7 @@ Further non-compatibility-affecting changes include:
  - Added dr_get_microseconds().
  - Added #DR_CLEANCALL_ALWAYS_OUT_OF_LINE.
  - Added instr_create_4dst_2src().
- - Added drreg_restore_app_values().
+ - Added drreg_restore_app_values() and drreg_restore_app_aflags().
  - Added drx_tail_pad_block().
  - Added XINST_CREATE_load_1byte_zext4().
  - Added drx_buf_insert_buf_memcpy().

--- a/ext/drreg/drreg.h
+++ b/ext/drreg/drreg.h
@@ -263,6 +263,22 @@ DR_EXPORT
 drreg_status_t
 drreg_are_aflags_dead(void *drcontext, instr_t *inst, bool *dead);
 
+DR_EXPORT
+/**
+ * This routine ensures that the application's value for the arithmetic flags is
+ * in place prior to \p where.  This is automatically done when the flags are
+ * reserved prior to an application instruction, but sometimes instrumentation
+ * needs to read the value of the flags.  This is intended as a convenience
+ * barrier for lazy restores performed by drreg.
+ *
+ * If called during drmgr's insertion phase, \p where must be the
+ * current application instruction.
+ *
+ * @return whether successful or an error code on failure.
+ */
+drreg_status_t
+drreg_restore_app_aflags(void *drcontext, instrlist_t *ilist, instr_t *where);
+
 /***************************************************************************
  * SCRATCH REGISTERS
  */

--- a/suite/tests/client-interface/drreg-test.dll.c
+++ b/suite/tests/client-interface/drreg-test.dll.c
@@ -158,6 +158,8 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         /* test aflags */
         res = drreg_reserve_aflags(drcontext, bb, inst);
         CHECK(res == DRREG_SUCCESS, "reserve of aflags should work");
+        res = drreg_restore_app_aflags(drcontext, bb, inst);
+        CHECK(res == DRREG_SUCCESS, "restore of app aflags should work");
         res = drreg_unreserve_aflags(drcontext, bb, inst);
         CHECK(res == DRREG_SUCCESS, "unreserve of aflags");
     } else if (subtest == DRREG_TEST_1_C ||
@@ -235,8 +237,11 @@ event_instru2instru(void *drcontext, void *tag, instrlist_t *bb,
 
     res = drreg_reserve_aflags(drcontext, bb, inst);
     CHECK(res == DRREG_SUCCESS, "reserve of aflags should work");
+    res = drreg_restore_app_aflags(drcontext, bb, inst);
+    CHECK(res == DRREG_SUCCESS, "restore of app aflags should work");
     res = drreg_unreserve_aflags(drcontext, bb, inst);
     CHECK(res == DRREG_SUCCESS, "unreserve of aflags should work");
+
     res = drreg_aflags_liveness(drcontext, inst, &flags);
     CHECK(res == DRREG_SUCCESS, "query of aflags should work");
     res = drreg_are_aflags_dead(drcontext, inst, &dead);


### PR DESCRIPTION
Adds a new API routine for restoring the app's aflags value on demand.
This is required for instrumentation that needs to spill the aflags but
test the app's value in the middle of tool code.

Adds tests to drreg-test.