### PR TITLE
Merge the sigreturn and asynch linkstubs

### DIFF
--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -1300,14 +1300,6 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
         KSWITCH_STOP_NOT_PROPAGATED(fcache_default);
         return;
     }
-# ifdef UNIX
-    else if (dcontext->last_exit == get_sigreturn_linkstub()) {
-        LOG(THREAD, LOG_DISPATCH, 2, "Exit from sigreturn, or os_forge_exception\n");
-        STATS_INC(num_exits_sigreturn);
-        KSTOP_NOT_MATCHING_NOT_PROPAGATED(syscall_fcache);
-        return;
-    }
-# else /* WINDOWS */
     else if (dcontext->last_exit == get_asynch_linkstub()) {
         LOG(THREAD, LOG_DISPATCH, 2, "Exit from asynch event\n");
         STATS_INC(num_exits_asynch);
@@ -1315,7 +1307,6 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
         KSTOP_NOT_MATCHING_NOT_PROPAGATED(syscall_fcache);
         return;
     }
-# endif
     else if (dcontext->last_exit == get_native_exec_linkstub()) {
         LOG(THREAD, LOG_DISPATCH, 2, "Exit from native_exec execution\n");
         STATS_INC(num_exits_native_exec);

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -695,11 +695,7 @@
     STATS_DEF("Fcache exits, system call executions", num_exits_syscalls)
     STATS_DEF("Fcache exits, flushed due to code mod", num_exits_code_mod_flush)
     STATS_DEF("Fcache exits, deleted but hit in ibl", num_exits_ibl_deleted)
-#ifdef UNIX
-    STATS_DEF("Fcache exits, sigreturn", num_exits_sigreturn)
-#else /* WINDOWS */
     STATS_DEF("Fcache exits, asynch", num_exits_asynch)
-#endif
     STATS_DEF("Fcache exits, native_exec executions", num_exits_native_exec)
     STATS_DEF("Fcache exits, native_exec syscalls", num_exits_native_exec_syscall)
     STATS_DEF("Fcache exits, proactive reset", num_exits_reset)

--- a/core/link.c
+++ b/core/link.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -157,11 +157,7 @@ static
 #endif
        const linkstub_t linkstub_selfmod     = { LINK_FAKE, 0 };
 static const linkstub_t linkstub_ibl_deleted = { LINK_FAKE, 0 };
-#ifdef UNIX
-static const linkstub_t linkstub_sigreturn   = { LINK_FAKE, 0 };
-#else /* WINDOWS */
 static const linkstub_t linkstub_asynch      = { LINK_FAKE, 0 };
-#endif
 static const linkstub_t linkstub_native_exec = { LINK_FAKE, 0 };
 /* this one we give the flag LINK_NI_SYSCALL for executing a syscall in dispatch() */
 static const linkstub_t linkstub_native_exec_syscall =
@@ -746,19 +742,11 @@ get_ibl_deleted_linkstub()
     return &linkstub_ibl_deleted;
 }
 
-#ifdef UNIX
-const linkstub_t *
-get_sigreturn_linkstub()
-{
-    return &linkstub_sigreturn;
-}
-#else /* WINDOWS */
 const linkstub_t *
 get_asynch_linkstub()
 {
     return &linkstub_asynch;
 }
-#endif
 
 const linkstub_t *
 get_native_exec_linkstub()

--- a/core/link.h
+++ b/core/link.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -482,11 +482,8 @@ const linkstub_t * get_selfmod_linkstub(void);
 extern const linkstub_t linkstub_selfmod;
 #endif
 const linkstub_t * get_ibl_deleted_linkstub(void);
-#ifdef UNIX
-const linkstub_t * get_sigreturn_linkstub(void);
-#else /* WINDOWS */
+/* This is used for Windows APC, callback, etc. and Linux sigreturn, forge fault, etc. */
 const linkstub_t * get_asynch_linkstub(void);
-#endif
 const linkstub_t * get_native_exec_linkstub(void);
 const linkstub_t * get_native_exec_syscall_linkstub(void);
 #ifdef HOT_PATCHING_INTERFACE


### PR DESCRIPTION
Currently Windows has the "asynch" special linkstub and UNIX has the
"sigreturn" special linkstub.  Both operate identically as far as dispatch
is concerned, and we've already overloaded the sigreturn linkstub for
forging exceptions.  We go ahead and merge the two into a single
cross-platform asynch linkstub.