### PR TITLE
i#2263 AArch64 flag usage: Set eflags in decode_common().

### DIFF
--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -2566,6 +2566,8 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
 {
     byte *next_pc = pc + 4;
     uint enc = *(uint *)pc;
+    uint eflags = 0;
+    int opc;
 
     CLIENT_ASSERT(instr->opcode == OP_INVALID || instr->opcode == OP_UNDECODED,
                   "decode: instr is already decoded, may need to call instr_reset()");
@@ -2591,6 +2593,36 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
         instr->srcs[3] = opnd_create_reg(DR_REG_X0 + (enc >> 16 & 31));
         instr->dsts[3] = opnd_create_reg(DR_REG_X0 + (enc >> 16 & 31));
     }
+
+    /* XXX: We should perhaps add flag information in codec.txt rather than list
+     * all the opcodes here, although the list is short and unlikely to change.
+     */
+    opc = instr_get_opcode(instr);
+    if ((opc == OP_mrs && instr_num_srcs(instr) == 1 &&
+         opnd_is_reg(instr_get_src(instr, 0)) &&
+         opnd_get_reg(instr_get_src(instr, 0)) == DR_REG_NZCV) ||
+        opc == OP_bcond ||
+        opc == OP_adc || opc == OP_adcs || opc == OP_sbc || opc == OP_sbcs ||
+        opc == OP_csel || opc == OP_csinc || opc == OP_csinv || opc == OP_csneg ||
+        opc == OP_ccmn || opc == OP_ccmp) {
+        /* FIXME i#1569: When handled by decoder, add:
+         * opc == OP_fcsel
+         */
+        eflags |= EFLAGS_READ_NZCV;
+    }
+    if ((opc == OP_msr && instr_num_dsts(instr) == 1 &&
+         opnd_is_reg(instr_get_dst(instr, 0)) &&
+         opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_NZCV) ||
+        opc == OP_adcs || opc == OP_adds || opc == OP_sbcs || opc == OP_subs ||
+        opc == OP_ands || opc == OP_bics ||
+        opc == OP_ccmn || opc == OP_ccmp) {
+        /* FIXME i#1569: When handled by decoder, add:
+         * opc == OP_fccmp || opc == OP_fccmpe || opc == OP_fcmp || opc == OP_fcmpe
+         */
+        eflags |= EFLAGS_WRITE_NZCV;
+    }
+    instr->eflags = eflags;
+    instr_set_eflags_valid(instr, true);
 
     instr_set_operands_valid(instr, true);
 

--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -2594,8 +2594,9 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
         instr->dsts[3] = opnd_create_reg(DR_REG_X0 + (enc >> 16 & 31));
     }
 
-    /* XXX: We should perhaps add flag information in codec.txt rather than list
-     * all the opcodes here, although the list is short and unlikely to change.
+    /* XXX i#2374: This determination of flag usage should be separate from the decoding
+     * of operands. Also, we should perhaps add flag information in codec.txt instead of
+     * listing all the opcodes, although the list is short and unlikely to change.
      */
     opc = instr_get_opcode(instr);
     if ((opc == OP_mrs && instr_num_srcs(instr) == 1 &&

--- a/core/arch/aarch64/decode.c
+++ b/core/arch/aarch64/decode.c
@@ -67,8 +67,13 @@ byte *
 decode_eflags_usage(dcontext_t *dcontext, byte *pc, uint *usage,
                     dr_opnd_query_flags_t flags)
 {
-    *usage = 0; /* FIXME i#1569 */
-    return pc + 4;
+    instr_t instr;
+    instr_init(dcontext, &instr);
+    pc = decode_common(dcontext, pc, pc, &instr);
+    ASSERT(instr_eflags_valid(&instr));
+    *usage = instr.eflags;
+    instr_free(dcontext, &instr);
+    return pc;
 }
 
 byte *

--- a/core/arch/aarch64/decode.c
+++ b/core/arch/aarch64/decode.c
@@ -67,6 +67,7 @@ byte *
 decode_eflags_usage(dcontext_t *dcontext, byte *pc, uint *usage,
                     dr_opnd_query_flags_t flags)
 {
+    /* XXX i#2374: Performing full decode here is inefficient. */
     instr_t instr;
     instr_init(dcontext, &instr);
     pc = decode_common(dcontext, pc, pc, &instr);

--- a/suite/tests/client-interface/drreg-test.dll.c
+++ b/suite/tests/client-interface/drreg-test.dll.c
@@ -156,17 +156,12 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         CHECK(res == DRREG_SUCCESS, "unreserve should work");
 
         /* test aflags */
-        /* FIXME i#2263: AArch64 fails to mark what flags are used in the IR, breaking
-         * use of aflags in instrumentation.
-         */
-#ifndef AARCH64
         res = drreg_reserve_aflags(drcontext, bb, inst);
         CHECK(res == DRREG_SUCCESS, "reserve of aflags should work");
         res = drreg_restore_app_aflags(drcontext, bb, inst);
         CHECK(res == DRREG_SUCCESS, "restore of app aflags should work");
         res = drreg_unreserve_aflags(drcontext, bb, inst);
         CHECK(res == DRREG_SUCCESS, "unreserve of aflags");
-#endif
     } else if (subtest == DRREG_TEST_1_C ||
                subtest == DRREG_TEST_2_C ||
                subtest == DRREG_TEST_3_C) {


### PR DESCRIPTION
Also implement decode_eflags_usage() and reenable client.drreg-test,
disabled by c839a54.

Fixes #2263