### PR TITLE
i#297 delay client-sideline-thread exit: fix several bugs

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -993,6 +993,7 @@ dynamo_shared_exit(thread_record_t *toexit /* must ==cur thread for Linux */
     /* Some lock can only be deleted if only one thread left. */
     instrument_exit_post_sideline();
 #endif /* CLIENT_INTERFACE */
+    fragment_exit_post_sideline();
 
     /* The dynamo_exited_and_cleaned should be set after the second synch-all.
      * If it is set earlier after the first synch-all, some client thread may
@@ -1501,6 +1502,7 @@ dynamo_process_exit(void)
 # endif
     }
 #endif /* CLIENT_INTERFACE */
+    fragment_exit_post_sideline();
 
 #ifdef CALL_PROFILE
     profile_callers_exit();
@@ -1533,6 +1535,7 @@ dynamo_exit_post_detach(void)
     dynamo_exiting = false;
 #endif
     dynamo_exited = false;
+    dynamo_exited_all_other_threads = false;
     dynamo_exited_and_cleaned = false;
 #ifdef DEBUG
     dynamo_exited_log_and_stats = false;

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -1711,6 +1711,11 @@ fragment_exit()
                                   false /* no flush */);
     DELETE_LOCK(client_flush_request_lock);
 #endif
+}
+
+void
+fragment_exit_post_sideline(void)
+{
     DELETE_LOCK(shared_cache_flush_lock);
 }
 

--- a/core/fragment.h
+++ b/core/fragment.h
@@ -596,6 +596,9 @@ void
 fragment_exit(void);
 
 void
+fragment_exit_post_sideline(void);
+
+void
 fragment_reset_init(void);
 
 void

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1252,6 +1252,7 @@ instrument_client_thread_init(dcontext_t *dcontext, bool client_thread)
         /* We don't call dynamo_thread_not_under_dynamo() b/c we want itimers. */
         dcontext->thread_record->under_dynamo_control = false;
         dcontext->client_data->is_client_thread = true;
+        dcontext->client_data->suspendable = true;
     }
 #endif /* CLIENT_SIDELINE */
 }

--- a/core/synch.c
+++ b/core/synch.c
@@ -1350,7 +1350,7 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
             }
         }
 
-        if (loop_count >= max_loops)
+        if (loop_count++ >= max_loops)
             break;
         /* We test the exiting thread count to avoid races between exit
          * process (current thread, though we could be here for detach or other

--- a/core/synch.c
+++ b/core/synch.c
@@ -1212,9 +1212,7 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
     /* FIXME: this should be a do/while loop - then we wouldn't have
      * to initialize all the variables above
      */
-    while (threads_are_stale ||
-           ((!all_synched || exiting_thread_count > expect_exiting)
-            && loop_count++ < max_loops)) {
+    while (threads_are_stale || !all_synched || exiting_thread_count > expect_exiting) {
         if (threads != NULL){
             /* Case 8941: must free here rather than when yield (below) since
              * termination condition can change between there and here
@@ -1351,6 +1349,9 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
                     "Skipping synch with thread "TIDFMT"\n", thread_ids_temp[i]);
             }
         }
+
+        if (loop_count >= max_loops)
+            break;
         /* We test the exiting thread count to avoid races between exit
          * process (current thread, though we could be here for detach or other
          * reasons) and an exiting thread (who might no longer be on the all
@@ -1853,7 +1854,7 @@ detach_on_permanent_stack(bool internal, bool do_cleanup)
 #endif
     DEBUG_DECLARE(bool ok;)
     DEBUG_DECLARE(int exit_res;)
-    /* sycnh-all flags: if we fail to suspend a thread (e.g., privilege
+    /* synch-all flags: if we fail to suspend a thread (e.g., privilege
      * problems) ignore it.  XXX Should we retry instead?
      */
     /* i#297: we only synch client threads after process exit event. */

--- a/core/synch.c
+++ b/core/synch.c
@@ -1089,6 +1089,7 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
     /* Case 8815: we cannot use the OUT params themselves internally as they
      * may be volatile, so we need our own values until we're ready to return
      */
+    bool threads_are_stale = true;
     thread_record_t **threads = NULL;
     int num_threads = 0;
     /* we record ids from before we gave up thread_initexit_lock */
@@ -1211,8 +1212,9 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
     /* FIXME: this should be a do/while loop - then we wouldn't have
      * to initialize all the variables above
      */
-    while ((!all_synched || exiting_thread_count > expect_exiting)
-           && loop_count++ < max_loops) {
+    while (threads_are_stale ||
+           ((!all_synched || exiting_thread_count > expect_exiting)
+            && loop_count++ < max_loops)) {
         if (threads != NULL){
             /* Case 8941: must free here rather than when yield (below) since
              * termination condition can change between there and here
@@ -1225,6 +1227,7 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
             num_threads = 0;
         }
         get_list_of_threads(&threads, &num_threads);
+        threads_are_stale = false;
         synch_array = (uint *)global_heap_alloc(num_threads * sizeof(uint)
                                                 HEAPACCT(ACCT_THREAD_MGT));
         for (i = 0; i < num_threads; i++) {
@@ -1376,6 +1379,8 @@ synch_with_all_threads(thread_synch_state_t desired_synch_state,
             if (INTERNAL_OPTION(single_thread_in_DR))
                 ENTERING_DR(); /* re-gain DR exclusion lock */
             mutex_lock(&thread_initexit_lock);
+            /* We unlock and lock the thread_initexit_lock, so threads might be stale. */
+            threads_are_stale = true;
         }
     }
     /* case 9392: callers passing in ABORT expect a return value of failure
@@ -1848,6 +1853,11 @@ detach_on_permanent_stack(bool internal, bool do_cleanup)
 #endif
     DEBUG_DECLARE(bool ok;)
     DEBUG_DECLARE(int exit_res;)
+    /* sycnh-all flags: if we fail to suspend a thread (e.g., privilege
+     * problems) ignore it.  XXX Should we retry instead?
+     */
+    /* i#297: we only synch client threads after process exit event. */
+    uint flags = THREAD_SYNCH_SUSPEND_FAILURE_IGNORE | THREAD_SYNCH_SKIP_CLIENT_THREAD;
 
     ENTERING_DR();
 
@@ -1917,11 +1927,7 @@ detach_on_permanent_stack(bool internal, bool do_cleanup)
                                 * beat us to not wait on us.  We still have a problem
                                 * if we go first since we must xfer other threads.
                                 */
-                               &num_threads, THREAD_SYNCH_NO_LOCKS_NO_XFER,
-                               /* If we fail to suspend a thread (e.g., privilege
-                                * problems) ignore it.  Should we retry instead?
-                                */
-                               THREAD_SYNCH_SUSPEND_FAILURE_IGNORE);
+                               &num_threads, THREAD_SYNCH_NO_LOCKS_NO_XFER, flags);
     ASSERT(ok);
     /* Now we own the thread_initexit_lock.  We'll release the locks grabbed in
      * synch_with_all_threads below after cleaning up all the threads in case we
@@ -1993,16 +1999,9 @@ detach_on_permanent_stack(bool internal, bool do_cleanup)
             my_tr = threads[i];
             continue;
         } else if (IS_CLIENT_THREAD(threads[i]->dcontext)) {
-            /* If this is a client-owned thread then there is no app state to return
-             * it to so we kill it here.  Note - we won't kill threads that have
-             * returned from the client nudge routine, but the exit path there
-             * doesn't do anything that would interfere with rest of the detach
-             * cleanup.
+            /* i#297 we will kill client-owned threads later after app exit events
+             * in dynamo_shared_exit().
              */
-            /* FIXME i#95: should we raise the client exit event before this?! */
-            DEBUG_DECLARE(bool terminated =)
-                os_thread_terminate(threads[i]);
-            ASSERT(terminated); /* Should always be able to terminate. */
             continue;
         } else if (detach_do_not_translate(threads[i])) {
             LOG(GLOBAL, LOG_ALL, 2, "Detach: not translating "TIDFMT"\n", threads[i]->id);
@@ -2079,7 +2078,7 @@ detach_on_permanent_stack(bool internal, bool do_cleanup)
      * region.
      */
     for (i = 0; i < num_threads; i++) {
-        if (i != my_idx) {
+        if (i != my_idx && !IS_CLIENT_THREAD(threads[i]->dcontext)) {
             LOG(GLOBAL, LOG_ALL, 1,
                 "Detach: cleaning up thread "TIDFMT" %s\n", threads[i]->id,
                 IF_WINDOWS_ELSE(cleanup_tpc[i] ? "and its TPC" : "", ""));

--- a/core/unix/tls_linux_x86.c
+++ b/core/unix/tls_linux_x86.c
@@ -390,6 +390,11 @@ choose_gdt_slots(os_local_state_t *os_tls)
             }
         }
         lib_tls_gdt_index = index;
+    } else {
+        /* For no private loader, e.g., app statically linked with DR,
+         * we use app's lib tls gdt index.
+         */
+        lib_tls_gdt_index = SELECTOR_INDEX(os_tls->app_lib_tls_reg);
     }
 #endif
 }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2233,6 +2233,9 @@ if (CLIENT_INTERFACE)
       # i#2119: test invoking the app's handler on a DR fault.
       tobuild_api(api.static_crash api/static_crash.c "-unsafe_crash_process" "" OFF ON)
       target_link_libraries(api.static_crash ${libmath})
+      # i#2346: sideline therad on Windows
+      tobuild_api(api.static_sideline api/static_sideline.c "" "" OFF ON)
+      target_link_libraries(api.static_sideline ${libmath} ${libpthread})
     endif ()
   endif ()
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2233,7 +2233,7 @@ if (CLIENT_INTERFACE)
       # i#2119: test invoking the app's handler on a DR fault.
       tobuild_api(api.static_crash api/static_crash.c "-unsafe_crash_process" "" OFF ON)
       target_link_libraries(api.static_crash ${libmath})
-      # i#2346: sideline therad on Windows
+      # XXX i#2346: add delayed sideline thread exit on Windows
       tobuild_api(api.static_sideline api/static_sideline.c "" "" OFF ON)
       target_link_libraries(api.static_sideline ${libmath} ${libpthread})
     endif ()

--- a/suite/tests/api/static_sideline.c
+++ b/suite/tests/api/static_sideline.c
@@ -1,0 +1,167 @@
+/* **********************************************************
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "configure.h"
+#include "dr_api.h"
+#include "tools.h"
+#include <math.h>
+#include <pthread.h>
+#include <stdlib.h>
+
+/* XXX i#975: also add an api.static_takeover test that uses drrun
+ * -static instead of calling dr_app_*.
+ */
+
+
+#define NUM_SIDELINE_THREADS 4
+static void *child_events[NUM_SIDELINE_THREADS];
+static bool first_exit = true;
+
+static void
+sideline_run(void *arg)
+{
+    dr_fprintf(STDERR, "client thread is alive\n");
+    if (first_exit)
+        dr_event_wait(arg);
+}
+
+static int num_bbs;
+
+static dr_emit_flags_t
+event_bb(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
+         bool translating)
+{
+    num_bbs++;
+    return DR_EMIT_DEFAULT;
+}
+
+static void
+event_exit(void)
+{
+    int i;
+    for (i = 0; i < NUM_SIDELINE_THREADS; i++) {
+        if (first_exit)
+            dr_event_signal(child_events[i]);
+        dr_event_destroy(child_events[i]);
+    }
+    dr_fprintf(STDERR, "Saw %s bb events\n", num_bbs > 0 ? "some" : "no");
+    first_exit = false;
+}
+
+DR_EXPORT void
+dr_client_main(client_id_t id, int argc, const char *argv[])
+{
+    int i;
+    print("in dr_client_main\n");
+    dr_register_bb_event(event_bb);
+    dr_register_exit_event(event_exit);
+    for (i = 0; i < NUM_SIDELINE_THREADS; i++) {
+        child_events[i] = dr_event_create();
+        dr_create_client_thread(sideline_run, child_events[i]);
+    }
+    /* XXX i#975: add some more thorough tests of different events */
+}
+
+#define NUM_APP_THREADS 4
+static bool finished[NUM_APP_THREADS];
+
+static int
+do_some_work(void)
+{
+    static int iters = 8192;
+    int i;
+    double val = num_bbs;
+    for (i = 0; i < iters; ++i) {
+        val += sin(val);
+    }
+    return (val > 0);
+}
+
+void *
+thread_func(void *arg)
+{
+    int idx = (int)(ptr_int_t)arg;
+    if (do_some_work() < 0)
+        print("error in computation\n");
+    finished[idx] = true;
+}
+
+int
+main(int argc, const char *argv[])
+{
+    int i;
+    pthread_t thread[NUM_APP_THREADS];
+
+    /* test attaching to multi-threaded app */
+    for (i = 0; i < NUM_APP_THREADS; i++) {
+        pthread_create(&thread[i], NULL, thread_func, (void*)(ptr_int_t)i);
+    }
+    print("pre-DR init\n");
+    dr_app_setup();
+    assert(!dr_app_running_under_dynamorio());
+
+    print("pre-DR start\n");
+    dr_app_start();
+    assert(dr_app_running_under_dynamorio());
+
+    for (i = 0; i < NUM_APP_THREADS; i++) {
+        pthread_join(thread[i], NULL);
+        if (!finished[i])
+            print("ERROR: thread %d failed to finish\n", i);
+    }
+
+    dr_app_stop_and_cleanup();
+    print("post-DR detach\n");
+    assert(!dr_app_running_under_dynamorio());
+
+    /* i#2157: test re-attach */
+    print("re-attach attempt\n");
+    if (dr_app_running_under_dynamorio())
+        print("ERROR: should not be under DynamoRIO after dr_app_stop!\n");
+    dr_app_setup_and_start();
+    if (!dr_app_running_under_dynamorio())
+        print("ERROR: should be under DynamoRIO after dr_app_start!\n");
+    for (i = 0; i < NUM_APP_THREADS; i++) {
+        pthread_create(&thread[i], NULL, thread_func, (void*)(ptr_int_t)i);
+    }
+    /* test detaching from multi-threaded app */
+    dr_app_stop_and_cleanup();
+    if (dr_app_running_under_dynamorio())
+        print("ERROR: should not be under DynamoRIO after dr_app_stop!\n");
+    for (i = 0; i < NUM_APP_THREADS; i++) {
+        pthread_join(thread[i], NULL);
+        if (!finished[i])
+            print("ERROR: thread %d failed to finish\n", i);
+    }
+    print("all done\n");
+    return 0;
+}

--- a/suite/tests/api/static_sideline.expect
+++ b/suite/tests/api/static_sideline.expect
@@ -1,0 +1,17 @@
+pre-DR init
+in dr_client_main
+pre-DR start
+client thread is alive
+client thread is alive
+client thread is alive
+client thread is alive
+Saw some bb events
+post-DR detach
+re-attach attempt
+in dr_client_main
+client thread is alive
+client thread is alive
+client thread is alive
+client thread is alive
+Saw some bb events
+all done


### PR DESCRIPTION
Fixed several bugs in delayed client sideline threads exit.
- add fragment_exit_post_sideline to delete shared_cache_flush_lock
  after instrument_exit,
- add dynamo_exited_all_other_threads reset for reattchment,
- initialize dcontext->client_data->suspendable to be true,
- add flag threads_are_stale in synch_with_all_threads to enforce loop
  and avoid stale pointer in threads,
- skip synching client sideline threads in detach_on_permanent_stack
  during detachment,
- skip terminating client sideline threads in detach_on_permanent_stack,
- add test for static detach/attach with client sideline threads,
- use app tls gdb index for apps that are statically linked with DR.