### PR TITLE
Add new option -log_to_stderr

### DIFF
--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -259,6 +259,7 @@
         if (stats != NULL && for_this_process)
             stats->loglevel = options->stats_loglevel;
     },"set level of detail for logging", DYNAMIC, OP_PCACHE_NOP)
+    OPTION_INTERNAL(bool, log_to_stderr, "log to stderr instead of files")
     OPTION_INTERNAL(uint, log_at_fragment_count,
         "start execution at loglevel 1 and raise to the specified -loglevel at this fragment count")
     /* For debugging purposes.  The bb count is distinct from the fragment count. */

--- a/core/utils.c
+++ b/core/utils.c
@@ -2909,8 +2909,10 @@ open_log_file(const char *basename, char *finalname_with_path, uint maxlen)
     uint flags = OS_OPEN_WRITE|OS_OPEN_ALLOW_LARGE|OS_OPEN_CLOSE_ON_FORK;
     name[0] = '\0';
 
-    if (INTERNAL_OPTION(log_to_stderr))
-        return STDERR;
+    DODEBUG({
+        if (INTERNAL_OPTION(log_to_stderr))
+            return STDERR;
+    });
 
     if (!get_log_dir(PROCESS_DIR, name, &name_size)) {
         create_log_dir(PROCESS_DIR);

--- a/core/utils.c
+++ b/core/utils.c
@@ -2909,6 +2909,9 @@ open_log_file(const char *basename, char *finalname_with_path, uint maxlen)
     uint flags = OS_OPEN_WRITE|OS_OPEN_ALLOW_LARGE|OS_OPEN_CLOSE_ON_FORK;
     name[0] = '\0';
 
+    if (INTERNAL_OPTION(log_to_stderr))
+        return STDERR;
+
     if (!get_log_dir(PROCESS_DIR, name, &name_size)) {
         create_log_dir(PROCESS_DIR);
         if (!get_log_dir(PROCESS_DIR, name, &name_size)) {

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1508,6 +1508,10 @@ endfunction(optimize)
 message(STATUS "Processing tests and generating expected output patterns")
 
 tobuild(common.broadfun common/broadfun.c)
+if (DEBUG)
+  torunonly(common.logstderr common.broadfun common/logstderr.c
+    "-log_to_stderr -loglevel 1" "")
+endif ()
 if (NOT ANDROID) # We do not support -no_early_inject on Android (i#1873).
   tobuild_ops(common.fib common/fib.c "-no_early_inject" "")
 endif ()

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1510,7 +1510,7 @@ message(STATUS "Processing tests and generating expected output patterns")
 tobuild(common.broadfun common/broadfun.c)
 if (DEBUG)
   torunonly(common.logstderr common.broadfun common/logstderr.c
-    "-log_to_stderr -loglevel 1" "")
+    "-log_to_stderr -loglevel 1 -logmask 2" "")
 endif ()
 if (NOT ANDROID) # We do not support -no_early_inject on Android (i#1873).
   tobuild_ops(common.fib common/fib.c "-no_early_inject" "")

--- a/suite/tests/common/logstderr.templatex
+++ b/suite/tests/common/logstderr.templatex
@@ -1,4 +1,4 @@
-global log file fd=2
+global log file.*
 DynamoRIO version .*
-Running:.*broadfun
+Running:.*broadfun.*
 DynamoRIO built with:.*

--- a/suite/tests/common/logstderr.templatex
+++ b/suite/tests/common/logstderr.templatex
@@ -1,0 +1,4 @@
+global log file fd=2
+DynamoRIO version .*
+Running:.*broadfun
+DynamoRIO built with:.*


### PR DESCRIPTION
Adds a feature to send all logging to stderr rather than files, under an
off-by-default option -log_to_stderr.  This is useful for some scenarios
where there is no readily accessible and writable local storage.

Adds a simple test.