### PR TITLE
i#2371: fix native exec regression on gateway vs entry checks

### DIFF
--- a/core/native_exec.c
+++ b/core/native_exec.c
@@ -100,9 +100,15 @@ is_dr_native_pc(app_pc pc)
 bool
 is_native_pc(app_pc pc)
 {
+    return vmvector_overlap(native_exec_areas, pc, pc+1);
+}
+
+bool
+is_stay_native_pc(app_pc pc)
+{
     /* only used for native exec */
     ASSERT(DYNAMO_OPTION(native_exec) && !vmvector_empty(native_exec_areas));
-    return (is_dr_native_pc(pc) || vmvector_overlap(native_exec_areas, pc, pc+1));
+    return (is_dr_native_pc(pc) || is_native_pc(pc));
 }
 
 static bool
@@ -336,6 +342,7 @@ back_from_native_common(dcontext_t *dcontext, priv_mcontext_t *mc, app_pc target
     /* asynch back on */
     set_asynch_interception(dcontext->owning_thread, true);
 #endif
+    os_thread_under_dynamo(dcontext);
     /* XXX: setting same var that set_asynch_interception is! */
     dcontext->thread_record->under_dynamo_control = true;
 

--- a/core/native_exec.c
+++ b/core/native_exec.c
@@ -342,7 +342,6 @@ back_from_native_common(dcontext_t *dcontext, priv_mcontext_t *mc, app_pc target
     /* asynch back on */
     set_asynch_interception(dcontext->owning_thread, true);
 #endif
-    os_thread_under_dynamo(dcontext);
     /* XXX: setting same var that set_asynch_interception is! */
     dcontext->thread_record->under_dynamo_control = true;
 

--- a/core/native_exec.h
+++ b/core/native_exec.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -52,6 +52,12 @@ native_exec_exit(void);
 
 bool
 is_native_pc(app_pc pc);
+
+/* Includes regions where we execute natively as well as DR entry points where
+ * we should not re-takeover if we're already native.
+ */
+bool
+is_stay_native_pc(app_pc pc);
 
 /* Gets called on every call into a native module. */
 void


### PR DESCRIPTION
Split off the uses of is_native_pc() as a test for targets that should
not re-takeover as a new routine is_stay_native_pc().  Use of
dr_app_running_under_dynamorio() was broken in the presence of non-empty
native_exec_areas by 6a8d7d2, causing its execution to go native.

Fixes #2371