### PR TITLE
i#2375 update native_exec: properly swap signal and TLS state

### DIFF
--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -5564,6 +5564,9 @@ static void
 insert_entering_native(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
                        reg_id_t reg_dc, reg_id_t reg_scratch)
 {
+    /* FIXME i#2375: for UNIX we need to do what os_thread_not_under_dynamo() does:
+     * set the signal mask and clear the TLS.
+     */
 #ifdef WINDOWS
     /* FIXME i#1238-c#1: we did not turn off asynch interception in windows */
     /* skip C equivalent:
@@ -5642,6 +5645,10 @@ static void
 insert_entering_non_native(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
                            reg_id_t reg_dc, reg_id_t reg_scratch)
 {
+    /* FIXME i#2375: for UNIX we need to do what os_thread_re_take_over() and
+     * os_thread_under_dynamo() do: reinstate the TLS and restore the signal mask.
+     */
+
     /* C equivalent:
      *   dcontext->thread_record->under_dynamo_control = true
      */

--- a/core/native_exec.c
+++ b/core/native_exec.c
@@ -201,7 +201,8 @@ native_exec_module_unload(module_area_t *ma)
 static void
 entering_native(dcontext_t *dcontext)
 {
-#ifdef WINDOWS
+    /* we need to match dr_app_stop() so we pop the kstack */
+    KSTOP_NOT_MATCHING(dispatch_num_exits);
     /* turn off asynch interception for this thread while native
      * FIXME: what if callbacks and apcs are destined for other modules?
      * should instead run dispatcher under DR every time, if going to native dll
@@ -212,15 +213,16 @@ entering_native(dcontext_t *dcontext)
      * We can't revert memory prots, since other threads are under DR
      * control, but we do handle our-fault write faults in native threads.
      */
-    set_asynch_interception(dcontext->owning_thread, false);
-#endif
-    /* FIXME: setting same var that set_asynch_interception is! */
+    /* FIXME i#2375: for -native_exec_opt on UNIX we need to update the gencode
+     * to do what os_thread_{,not_}under_dynamo() and os_thread_re_take_over() do.
+     */
+    if (IF_WINDOWS_ELSE(true, !DYNAMO_OPTION(native_exec_opt)))
+        os_thread_not_under_dynamo(dcontext);
+    /* XXX: setting same var that set_asynch_interception is! */
     dcontext->thread_record->under_dynamo_control = false;
 
     ASSERT(!is_building_trace(dcontext));
     set_last_exit(dcontext, (linkstub_t *) get_native_exec_linkstub());
-    /* we need to match dr_app_stop() so we pop the kstack */
-    KSTOP_NOT_MATCHING(dispatch_num_exits);
     /* now we're in app! */
     dcontext->whereami = WHERE_APP;
     SYSLOG_INTERNAL_WARNING_ONCE("entered at least one module natively");
@@ -332,10 +334,11 @@ back_from_native_common(dcontext_t *dcontext, priv_mcontext_t *mc, app_pc target
     dcontext->next_tag = target;
     /* tell dispatch() why we're coming there */
     dcontext->whereami = WHERE_FCACHE;
-#ifdef WINDOWS
-    /* asynch back on */
-    set_asynch_interception(dcontext->owning_thread, true);
-#endif
+    /* FIXME i#2375: for -native_exec_opt on UNIX we need to update the gencode
+     * to do what os_thread_{,not_}under_dynamo() and os_thread_re_take_over() do.
+     */
+    if (IF_WINDOWS_ELSE(true, !DYNAMO_OPTION(native_exec_opt)))
+        os_thread_under_dynamo(dcontext);
     /* XXX: setting same var that set_asynch_interception is! */
     dcontext->thread_record->under_dynamo_control = true;
 
@@ -391,6 +394,10 @@ return_from_native(priv_mcontext_t *mc)
     int retidx;
     ENTERING_DR();
     dcontext = get_thread_private_dcontext();
+    if (dcontext == NULL) {
+        os_thread_re_take_over();
+        dcontext = get_thread_private_dcontext();
+    }
     ASSERT(dcontext != NULL);
     SYSLOG_INTERNAL_WARNING_ONCE("returned from at least one native module");
     retidx = native_get_retstack_idx(mc);
@@ -412,6 +419,10 @@ native_module_callout(priv_mcontext_t *mc, app_pc target)
     dcontext_t *dcontext;
     ENTERING_DR();
     dcontext = get_thread_private_dcontext();
+    if (dcontext == NULL) {
+        os_thread_re_take_over();
+        dcontext = get_thread_private_dcontext();
+    }
     ASSERT(dcontext != NULL);
     ASSERT(DYNAMO_OPTION(native_exec_retakeover));
     LOG(THREAD, LOG_ASYNCH, 4, "%s: cross-module call to %p\n",

--- a/core/native_exec.c
+++ b/core/native_exec.c
@@ -223,7 +223,7 @@ entering_native(dcontext_t *dcontext)
      * to do what os_thread_{,not_}under_dynamo() and os_thread_re_take_over() do.
      */
     if (IF_WINDOWS_ELSE(true, !DYNAMO_OPTION(native_exec_opt)))
-        os_thread_not_under_dynamo(dcontext);
+        dynamo_thread_not_under_dynamo(dcontext);
     /* XXX: setting same var that set_asynch_interception is! */
     dcontext->thread_record->under_dynamo_control = false;
 
@@ -344,7 +344,7 @@ back_from_native_common(dcontext_t *dcontext, priv_mcontext_t *mc, app_pc target
      * to do what os_thread_{,not_}under_dynamo() and os_thread_re_take_over() do.
      */
     if (IF_WINDOWS_ELSE(true, !DYNAMO_OPTION(native_exec_opt)))
-        os_thread_under_dynamo(dcontext);
+        dynamo_thread_under_dynamo(dcontext);
     /* XXX: setting same var that set_asynch_interception is! */
     dcontext->thread_record->under_dynamo_control = true;
 


### PR DESCRIPTION
Adds the use of os_thread_{,not_}under_dynamo() and
os_thread_re_take_over() for proper signal mask and TLS switching between
native and DR states for native_exec under default options.

Adds comments about doing this in gencode for -native_exec_opt.