### PR TITLE
i#1621 AArch64 cc opts: Only use x1 and x2 to save flags.

### DIFF
--- a/core/arch/aarch64/clean_call_opt.c
+++ b/core/arch/aarch64/clean_call_opt.c
@@ -47,10 +47,6 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
 
     /* XXX implement bitset for optimisation */
     memset(ci->reg_used, 0, sizeof(bool) * NUM_GP_REGS);
-    /* Scratch registers used for setting up the jump to the clean callee. */
-    ci->reg_used[SCRATCH_REG0] = true;
-    ci->reg_used[SCRATCH_REG1] = true;
-    ci->reg_used[DR_REG_X11 - DR_REG_START_GPR] = true;
 
     for (instr  = instrlist_first(ilist);
          instr != NULL;


### PR DESCRIPTION
Only use x1 and x2 to save flags, which means x3 does not
have to be saved/restored. It also moves marking x1, x2 and x11 as used
to insert_push_all_registers, because they may not have to be
saved/restored for inlined clean calls.