### PR TITLE
i#1569 AArch64: Enable syscall-mod test.

### DIFF
--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -169,7 +169,10 @@
  * \param i   The source immediate integer opnd.
  */
 #define XINST_CREATE_load_int(dc, r, i) \
-    INSTR_CREATE_movz((dc), (r), (i), OPND_CREATE_INT(0))
+  (opnd_get_immed_int(i) < 0 ? \
+   INSTR_CREATE_movn((dc), (r), OPND_CREATE_INT32(~opnd_get_immed_int(i)), \
+                     OPND_CREATE_INT(0)) : \
+   INSTR_CREATE_movz((dc), (r), (i), OPND_CREATE_INT(0)))
 
 /**
  * This platform-independent macro creates an instr_t for a return instruction.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -627,13 +627,6 @@ function(tobuild_ci test source client_ops dr_ops exe_ops)
     # a single one, "simple_app".
     if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${source})
       add_exe(${test} ${source})
-      if (AARCH64)
-        set(arch_cflags "-DARM_64")
-      else (AARCH64)
-        set(arch_cflags "")
-      endif(AARCH64)
-      set_target_properties(${test} PROPERTIES COMPILE_FLAGS
-                            "${COMPILE_FLAGS} ${arch_cflags}")
       # Make sure to avoid using the modified flags which can break msbuild (i#1748).
       # On Linux this results in some build issues which I did not want to track
       # down, so we do this only on Windows.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -627,6 +627,13 @@ function(tobuild_ci test source client_ops dr_ops exe_ops)
     # a single one, "simple_app".
     if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${source})
       add_exe(${test} ${source})
+      if (AARCH64)
+        set(arch_cflags "-DARM_64")
+      else (AARCH64)
+        set(arch_cflags "")
+      endif(AARCH64)
+      set_target_properties(${test} PROPERTIES COMPILE_FLAGS
+                            "${COMPILE_FLAGS} ${arch_cflags}")
       # Make sure to avoid using the modified flags which can break msbuild (i#1748).
       # On Linux this results in some build issues which I did not want to track
       # down, so we do this only on Windows.
@@ -1898,8 +1905,10 @@ if (CLIENT_INTERFACE)
       tobuild_ci(client.nudge_test client-interface/nudge_test.runall "" "" "")
       tobuild_ci(client.timer client-interface/timer.c "" "" "")
     endif (NOT ARM)
-    if (X86) # FIXME i#1551, i#1569: port asm to ARM and AArch64
+    if (X86 OR AARCH64) # FIXME i#1551: port asm to AArch32
       tobuild_ci(client.syscall-mod client-interface/syscall-mod.c "" "" "")
+    endif (X86 OR AARCH64)
+    if (X86) # FIXME i#1551, i#1569: port asm to ARM and AArch64
       tobuild_ci(client.signal client-interface/signal.c "" "" "")
       tobuild_ci(client.cbr-retarget client-interface/cbr-retarget.c "" "" "")
     endif (X86)

--- a/suite/tests/client-interface/syscall-mod.c
+++ b/suite/tests/client-interface/syscall-mod.c
@@ -38,7 +38,7 @@
 # include <syscall.h>
 #endif
 
-#include "dr_defines.h"
+#include "configure.h"
 
 #define EXPANDSTR(x) #x
 #define STRINGIFY(x) EXPANDSTR(x)
@@ -55,11 +55,11 @@ int main()
     /* we don't want vsyscall since we rely on mov immed, eax being in same bb.
      * plus, libc getpid might cache the pid value.
      */
-    asm("mov $" STRINGIFY(SYS_getpid) ", %eax;"
+    asm("mov $" STRINGIFY(SYS_getpid) ", %%eax;"
         "syscall;"
         "mov %%eax, %0" : "=m"(pid));
 #else
-    asm("mov $" STRINGIFY(SYS_getpid) ", %eax;"
+    asm("mov $" STRINGIFY(SYS_getpid) ", %%eax;"
         "int $0x80;"
         "mov %%eax, %0" : "=m"(pid));
 #endif

--- a/suite/tests/client-interface/syscall-mod.c
+++ b/suite/tests/client-interface/syscall-mod.c
@@ -38,6 +38,8 @@
 # include <syscall.h>
 #endif
 
+#include "dr_defines.h"
+
 #define EXPANDSTR(x) #x
 #define STRINGIFY(x) EXPANDSTR(x)
 
@@ -45,16 +47,22 @@ int main()
 {
     int pid;
     fprintf(stderr, "starting\n");
+#if defined(AARCH64)
+    asm("movz x8, " STRINGIFY(SYS_getpid) ";"
+        "svc 0;"
+        "mov %0, x0" : "=r"(pid));
+#elif defined(X64)
     /* we don't want vsyscall since we rely on mov immed, eax being in same bb.
      * plus, libc getpid might cache the pid value.
      */
-    asm("mov $" STRINGIFY(SYS_getpid) ", %eax");
-#ifdef X64
-    asm("syscall");
+    asm("mov $" STRINGIFY(SYS_getpid) ", %eax;"
+        "syscall;"
+        "mov %%eax, %0" : "=m"(pid));
 #else
-    asm("int $0x80");
+    asm("mov $" STRINGIFY(SYS_getpid) ", %eax;"
+        "int $0x80;"
+        "mov %%eax, %0" : "=m"(pid));
 #endif
-    asm("mov %%eax, %0" : "=m"(pid));
     fprintf(stderr, "pid = %d\n", pid);
 
     return 0;

--- a/suite/tests/client-interface/syscall-mod.c
+++ b/suite/tests/client-interface/syscall-mod.c
@@ -31,14 +31,14 @@
  * DAMAGE.
  */
 
+#include "configure.h"
+
 #include <stdio.h>
 #if defined(MACOS) || defined(ANDROID)
 # include <sys/syscall.h>
 #else
 # include <syscall.h>
 #endif
-
-#include "configure.h"
 
 #define EXPANDSTR(x) #x
 #define STRINGIFY(x) EXPANDSTR(x)

--- a/suite/tests/client-interface/syscall-mod.dll.c
+++ b/suite/tests/client-interface/syscall-mod.dll.c
@@ -42,33 +42,35 @@
 
 #define MINSERT instrlist_meta_preinsert
 
+#ifdef AARCH64
+# define SYSCALL_ARG_REG DR_REG_X8
+# define SYSCALL_RES_REG DR_REG_X0
+#else
+# define SYSCALL_ARG_REG REG_EAX
+# define SYSCALL_RES_REG REG_EAX
+#endif
+
 static
 dr_emit_flags_t bb_event(void* drcontext, void *tag, instrlist_t* bb,
                          bool for_trace, bool translating)
 {
     instr_t *instr;
     instr_t *next_instr;
+    ptr_int_t value;
     reg_t in_reg = -1;
 
     for (instr = instrlist_first(bb); instr != NULL; instr = next_instr) {
         next_instr = instr_get_next(instr);
-#ifdef AARCH64
-        if (instr_get_opcode(instr) == OP_movz &&
-            opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_X8)
+        if (instr_is_mov_constant(instr, &value) &&
+            opnd_is_reg(instr_get_dst(instr, 0)) &&
+            opnd_get_reg(instr_get_dst(instr, 0)) == SYSCALL_ARG_REG &&
+            opnd_is_immed_int(instr_get_src(instr, 0)))
             in_reg = opnd_get_immed_int(instr_get_src(instr, 0));
         if (instr_is_syscall(instr) &&
             in_reg == SYS_getpid) {
-            instr_t *myval = INSTR_CREATE_movn
-                (drcontext, opnd_create_reg(DR_REG_X0), OPND_CREATE_INT16(6), OPND_CREATE_INT(0));
-#else
-        if (instr_get_opcode(instr) == OP_mov_imm &&
-            opnd_get_reg(instr_get_dst(instr, 0)) == REG_EAX)
-            in_reg = opnd_get_immed_int(instr_get_src(instr, 0));
-        if (instr_is_syscall(instr) &&
-            in_reg == SYS_getpid) {
-            instr_t *myval = INSTR_CREATE_mov_imm
-                (drcontext, opnd_create_reg(REG_EAX), OPND_CREATE_INT32(-7));
-#endif
+            instr_t *myval = XINST_CREATE_load_int
+                (drcontext, opnd_create_reg(SYSCALL_RES_REG),
+                 OPND_CREATE_INT32(-7));
             instr_set_translation(myval, instr_get_app_pc(instr));
             instrlist_preinsert(bb, instr, myval);
             instrlist_remove(bb, instr);


### PR DESCRIPTION
Port assembly and enable syscall-mod test for AArch64.