### PR TITLE
i#2387 assert in drcov: fixed a bug in drcov for module reload

### DIFF
--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -141,7 +141,7 @@ event_module_load(void *drcontext, const module_data_t *data, bool loaded)
         entry = drvector_get_entry(&module_table.vector, i);
         mod   = entry->data;
         if (entry->unload &&
-            /* look for the first module entry instead of its sub-entries */
+            /* only check the main (containing) module */
             entry->id == entry->containing_id &&
             /* If the same module is re-loaded at the same address,
              * we will try to use the existing entry.
@@ -236,7 +236,7 @@ static inline void
 lookup_helper_set_fields(module_entry_t *entry, OUT uint *mod_index, OUT app_pc *mod_base)
 {
     if (mod_index != NULL)
-        *mod_index = entry->id;
+        *mod_index = entry->containing_id; /* Yes, the main (containing) module. */
     if (mod_base != NULL)
         *mod_base = entry->data->start; /* Yes, absolute base, not segment base. */
 }
@@ -299,7 +299,8 @@ event_module_unload(void *drcontext, const module_data_t *data)
     for (i = module_table.vector.entries - 1; i >= 0; i--) {
         entry = drvector_get_entry(&module_table.vector, i);
         ASSERT(entry != NULL, "fail to get module entry");
-        if (pc_is_in_module(entry, data->start))
+        /* only check the main (containing) module */
+        if (entry->id == entry->containing_id && pc_is_in_module(entry, data->start))
             break;
         entry = NULL;
     }

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -141,7 +141,9 @@ event_module_load(void *drcontext, const module_data_t *data, bool loaded)
         entry = drvector_get_entry(&module_table.vector, i);
         mod   = entry->data;
         if (entry->unload &&
-            /* only check the main (containing) module */
+            /* Only check the main (containing) module.
+             * This is necessary because the loop is backward.
+             */
             entry->id == entry->containing_id &&
             /* If the same module is re-loaded at the same address,
              * we will try to use the existing entry.
@@ -236,7 +238,7 @@ static inline void
 lookup_helper_set_fields(module_entry_t *entry, OUT uint *mod_index, OUT app_pc *mod_base)
 {
     if (mod_index != NULL)
-        *mod_index = entry->containing_id; /* Yes, the main (containing) module. */
+        *mod_index = entry->id; /* We expose the segment. */
     if (mod_base != NULL)
         *mod_base = entry->data->start; /* Yes, absolute base, not segment base. */
 }
@@ -299,7 +301,9 @@ event_module_unload(void *drcontext, const module_data_t *data)
     for (i = module_table.vector.entries - 1; i >= 0; i--) {
         entry = drvector_get_entry(&module_table.vector, i);
         ASSERT(entry != NULL, "fail to get module entry");
-        /* only check the main (containing) module */
+        /* Only check the main (containing) module.
+         * This is necessary because the loop is backward.
+         */
         if (entry->id == entry->containing_id && pc_is_in_module(entry, data->start))
             break;
         entry = NULL;

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -141,7 +141,7 @@ event_module_load(void *drcontext, const module_data_t *data, bool loaded)
         entry = drvector_get_entry(&module_table.vector, i);
         mod   = entry->data;
         if (entry->unload &&
-            /* looks for the first module entry instead of its sub-entries */
+            /* look for the first module entry instead of its sub-entries */
             entry->id == entry->containing_id &&
             /* If the same module is re-loaded at the same address,
              * we will try to use the existing entry.

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -129,6 +129,7 @@ event_module_load(void *drcontext, const module_data_t *data, bool loaded)
     module_entry_t *entry = NULL;
     module_data_t  *mod;
     int i;
+    bool found = false;
     /* Some apps repeatedly unload and reload the same module,
      * so we will try to re-use the old one.
      */
@@ -159,6 +160,7 @@ event_module_load(void *drcontext, const module_data_t *data, bool loaded)
             strcmp(dr_module_preferred_name(data),
                    dr_module_preferred_name(mod)) == 0) {
             entry->unload = false;
+            found = true;
 #ifndef WINDOWS
             if (!mod->contiguous) {
                 int j;
@@ -174,11 +176,12 @@ event_module_load(void *drcontext, const module_data_t *data, bool loaded)
                 }
             }
 #endif
-            break;
+            /* We may just see a sub module, so we cannot stop here. We need iterate
+             * all entries to update all sub modules of the reloaded module.
+             */
         }
-        entry = NULL;
     }
-    if (entry == NULL) {
+    if (!found) {
         entry = dr_global_alloc(sizeof(*entry));
         entry->id = module_table.vector.entries;
         entry->containing_id = entry->id;


### PR DESCRIPTION
This CL fixed a bug in drcov handling module reload.
Because there could be more than one submodules of a module, we should iterate
the whole module table to update all submodules when a module is reloaded.

Fixes #2387