### PR TITLE
i#2350 rseq: fix syscall handling bug

### DIFF
--- a/core/native_exec.c
+++ b/core/native_exec.c
@@ -275,6 +275,8 @@ prepare_return_from_native_via_stack(dcontext_t *dcontext, app_pc *app_sp)
     dcontext->native_retstack[i].retaddr = *app_sp;
     dcontext->native_retstack[i].retloc = (app_pc) app_sp;
     dcontext->native_retstack_cur = i + 1;
+    LOG(THREAD, LOG_ASYNCH, 2,
+        "%s: app ra="PFX", sp="PFX", level=%d\n", *app_sp, app_sp, i);
     /* i#978: We use a different return stub for every nested call to native
      * code.  Each stub pushes a different index into the retstack.  We could
      * use the SP at return time to try to find the app's return address, but
@@ -466,7 +468,9 @@ put_back_native_retaddrs(dcontext_t *dcontext)
     for (i = 0; i < dcontext->native_retstack_cur; i++) {
         app_pc *retloc = (app_pc *) retstack[i].retloc;
         ASSERT(*retloc >= retstub_start && *retloc < retstub_end);
-        *retloc = retstack[i].retaddr;
+        LOG(THREAD, LOG_ASYNCH, 2, "%s: writing "PFX" over "PFX" @"PFX"\n",
+            __FUNCTION__, retstack[i].retaddr, *retloc, retloc);
+         *retloc = retstack[i].retaddr;
     }
     dcontext->native_retstack_cur = 0;
 #ifdef HOT_PATCHING_INTERFACE

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -10208,6 +10208,7 @@ handle_restartable_region_syscall_pre(dcontext_t *dcontext)
     /* We do the work in post */
     dcontext->sys_param0 = sys_param(dcontext, 0);
     dcontext->sys_param1 = sys_param(dcontext, 1);
+    dcontext->sys_param2 = sys_param(dcontext, 2);
     return true;
 }
 
@@ -10223,10 +10224,10 @@ handle_restartable_region_syscall_post(dcontext_t *dcontext, bool success)
         dcontext->sys_num != DYNAMO_OPTION(rseq_sysnum) ||
         !success)
         return;
-    op = (int) sys_param(dcontext, 0);
+    op = (int) dcontext->sys_param0;
     if (op == RSEQ_SET_CRITICAL) {
-        app_pc start = (app_pc) dcontext->sys_param0;
-        app_pc end = (app_pc) dcontext->sys_param1;
+        app_pc start = (app_pc) dcontext->sys_param1;
+        app_pc end = (app_pc) dcontext->sys_param2;
         LOG(THREAD, LOG_VMAREAS|LOG_SYSCALLS, 2,
             "syscall: set rseq region to " PFX"-" PFX"\n", start, end);
         /* An unlink flush should be good enough: we simply don't support


### PR DESCRIPTION
Fixes a bug in handling the rseq system call where the parameter numbers
were mismatched.  Includes additional native_exec logging that was useful
in diagnosing the bug.