### PR TITLE
Revert "i#1621 AArch64 cc opts: Implement out-of-line calls. (#2333)"

### DIFF
--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -329,8 +329,7 @@ insert_restore_registers(dcontext_t *dcontext, instrlist_t *ilist, instr_t *inst
 uint
 insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                           instrlist_t *ilist, instr_t *instr,
-                          uint alignment, opnd_t push_pc, reg_id_t scratch/*optional*/
-                          _IF_AARCH64(bool out_of_line))
+                          uint alignment, opnd_t push_pc, reg_id_t scratch/*optional*/)
 {
     uint dstack_offs = 0;
 #ifdef AARCH64
@@ -342,18 +341,14 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
         /* FIXME i#1551: once we add skipping of regs, need to keep shape here */
     }
     /* FIXME i#1551: once we have cci->num_simd_skip, skip this if possible */
+
 #ifdef AARCH64
 
-    max_offs = get_clean_call_switch_stack_size();
+    max_offs = ALIGN_FORWARD(sizeof(priv_mcontext_t), 16);
 
-    /* For out-of-line clean calls, the stack pointer is adjusted before jumping
-     * to this code.
-     */
-    if (!out_of_line) {
-        /* sub sp, sp, #clean_call_switch_stack_size */
-        PRE(ilist, instr, XINST_CREATE_sub(dcontext, opnd_create_reg(DR_REG_SP),
-                                           OPND_CREATE_INT16(max_offs)));
-    }
+    /* sub sp, sp, #sizeof(priv_mcontext_t) */
+    PRE(ilist, instr, XINST_CREATE_sub(dcontext, opnd_create_reg(DR_REG_SP),
+                                       OPND_CREATE_INT16(max_offs)));
 
     /* Push GPRs. */
     insert_save_registers(dcontext, ilist, instr, cci->reg_skip, DR_REG_SP, DR_REG_X0,
@@ -365,19 +360,11 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
     PRE(ilist, instr,
         XINST_CREATE_move(dcontext, opnd_create_reg(DR_REG_X0),
                           opnd_create_reg(DR_REG_SP)));
-
-    /* For out-of-line clean calls, X30 is saved before jumping to this code,
-     * because it is used for the return address.
-     */
-    if (!out_of_line) {
-        /* stp x30, x0, [sp, #x30_offset] */
-        PRE(ilist, instr,
-            INSTR_CREATE_stp(dcontext,
-                             opnd_create_base_disp(DR_REG_SP, DR_REG_NULL, 0,
-                                                   REG_OFFSET(DR_REG_X30), OPSZ_16),
-                             opnd_create_reg(DR_REG_X30),
-                             opnd_create_reg(DR_REG_X0)));
-    }
+    /* stp x30, x0, [sp, #x30_offset] */
+    PRE(ilist, instr,
+        INSTR_CREATE_stp(dcontext, opnd_create_base_disp(DR_REG_SP, DR_REG_NULL, 0,
+                                                         REG_OFFSET(DR_REG_X30), OPSZ_16),
+                         opnd_create_reg(DR_REG_X30), opnd_create_reg(DR_REG_X0)));
 
     /* add x0, x0, #dstack_offs */
     PRE(ilist, instr,
@@ -541,17 +528,15 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
 void
 insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                          instrlist_t *ilist, instr_t *instr,
-                         uint alignment _IF_AARCH64(bool out_of_line))
+                         uint alignment)
 {
-    if (cci == NULL)
-        cci = &default_clean_call_info;
 #ifdef AARCH64
     uint current_offs;
     /* mov x0, sp */
     PRE(ilist, instr, XINST_CREATE_move(dcontext, opnd_create_reg(DR_REG_X0),
                                         opnd_create_reg(DR_REG_SP)));
 
-    current_offs = get_clean_call_switch_stack_size() -
+    current_offs = sizeof(priv_mcontext_t) -
                    NUM_SIMD_SLOTS * sizeof(dr_simd_t);
 
     /* add x0, x0, current_offs */
@@ -604,21 +589,17 @@ insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
     insert_restore_registers(dcontext, ilist, instr, cci->reg_skip, DR_REG_SP, DR_REG_X0,
                              true /* is_gpr */);
 
-    /* For out-of-line clean calls, X30 is restored after jumping back from this
-     * code, because it is used for the return address.
-     */
-    if (!out_of_line) {
-        /* Recover x30 */
-        /* ldr w3, [x0, #16] */
-        PRE(ilist, instr,
-            INSTR_CREATE_ldr(dcontext, opnd_create_reg(DR_REG_X30),
-                             OPND_CREATE_MEM64(DR_REG_SP, REG_OFFSET(DR_REG_X30))));
-       PRE(ilist, instr,
-            XINST_CREATE_add(dcontext, opnd_create_reg(DR_REG_SP),
-                             OPND_CREATE_INT16(get_clean_call_switch_stack_size())));
-    }
-
- #else
+    /* Recover x30 */
+    /* ldr w3, [x0, #16] */
+    PRE(ilist, instr,
+        INSTR_CREATE_ldr(dcontext, opnd_create_reg(DR_REG_X30),
+                         OPND_CREATE_MEM64(DR_REG_SP, REG_OFFSET(DR_REG_X30))));
+    PRE(ilist, instr,
+        XINST_CREATE_add(dcontext, opnd_create_reg(DR_REG_SP),
+                         OPND_CREATE_INT32(sizeof(priv_mcontext_t))));
+#else
+    if (cci == NULL)
+        cci = &default_clean_call_info;
     /* We rely on dr_set_mcontext_priv() to set the app's stolen reg value,
      * and the stack swap to set the sp value: we assume the stolen reg on
      * the stack still has our TLS base in it.
@@ -923,59 +904,8 @@ int
 insert_out_of_line_context_switch(dcontext_t *dcontext, instrlist_t *ilist,
                                   instr_t *instr, bool save)
 {
-#ifdef AARCH64
-    if (save) {
-        /* Reserve stack space to push the context. We do it here instead of
-         * in insert_push_all_registers, so we can save the original value
-         * of X30 on the stack before it is changed by the BL (branch & link)
-         * to the clean call save routine in the code cache.
-         *
-         * sub sp, sp, #clean_call_switch_stack_size
-         */
-        PRE(ilist, instr,
-            XINST_CREATE_sub(dcontext, opnd_create_reg(DR_REG_SP),
-                             OPND_CREATE_INT16(get_clean_call_switch_stack_size())));
-
-        /* str x30, [sp, #x30_offset]
-         *
-         * We have to save the original value of x30 before using BLR to jump
-         * to the save code, because BLR will modify x30. The original value of
-         * x30 is restored after the returning from the save/restore functions below.
-         */
-        PRE(ilist, instr,
-            INSTR_CREATE_str(dcontext,
-                             opnd_create_base_disp(DR_REG_SP, DR_REG_NULL, 0,
-                                                   REG_OFFSET(DR_REG_X30), OPSZ_8),
-                             opnd_create_reg(DR_REG_X30)));
-    }
-
-    insert_mov_immed_ptrsz(dcontext,
-                           (long) (save ? get_clean_call_save(dcontext) :
-                                          get_clean_call_restore(dcontext)),
-                           opnd_create_reg(DR_REG_X30), ilist, instr, NULL, NULL);
-    PRE(ilist, instr,
-        INSTR_CREATE_blr(dcontext, opnd_create_reg(DR_REG_X30)));
-
-   /* Restore original value of X30, which was changed by BLR.
-    *
-    * ldr x30, [sp, #x30_offset]
-    */
-    PRE(ilist, instr,
-        INSTR_CREATE_ldr(dcontext, opnd_create_reg(DR_REG_X30),
-                         OPND_CREATE_MEM64(DR_REG_SP, REG_OFFSET(DR_REG_X30))));
-
-    if (!save) {
-        /* add sp, sp, #clean_call_switch_stack_size */
-        PRE(ilist, instr,
-            XINST_CREATE_add(dcontext, opnd_create_reg(DR_REG_SP),
-                             OPND_CREATE_INT16(get_clean_call_switch_stack_size())));
-    }
-
-    return get_clean_call_switch_stack_size();
-#else
-    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1621: NYI on AArch32. */
+    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1551, i#1569 */
     return 0;
-#endif
 }
 
 /*###########################################################################

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -518,12 +518,11 @@ insert_clear_eflags(dcontext_t *dcontext, clean_call_info_t *cci,
 uint
 insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                           instrlist_t *ilist, instr_t *instr,
-                          uint alignment, opnd_t push_pc, reg_id_t scratch/*optional*/
-                          _IF_AARCH64(bool out_of_line));
+                          uint alignment, opnd_t push_pc, reg_id_t scratch/*optional*/);
 void
 insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                          instrlist_t *ilist, instr_t *instr,
-                         uint alignment _IF_AARCH64(bool out_of_line));
+                         uint alignment);
 bool
 insert_reachable_cti(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
                      byte *encode_pc, byte *target, bool jmp, bool returns, bool precise,

--- a/core/arch/clean_call_opt_shared.c
+++ b/core/arch/clean_call_opt_shared.c
@@ -742,12 +742,6 @@ analyze_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instr_t *where,
          !cci->skip_save_flags) ||
         always_out_of_line)
         cci->out_of_line_swap = true;
-#elif defined(AARCH64)
-    /* Use out-of-line calls unless the majority of the registers are saved. */
-    if (cci->num_simd_skip < 20 /* save majority of simd registers*/ ||
-        cci->num_regs_skip < 20 /* save majority of gprs */ ||
-        always_out_of_line)
-        cci->out_of_line_swap = true;
 # endif
 
     return should_inline;

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -4985,7 +4985,7 @@ emit_new_thread_dynamo_start(dcontext_t *dcontext, byte *pc)
                                         * use of the stolen reg, which would be
                                         * a race w/ the parent's use of it!
                                         */
-                                       SCRATCH_REG0 _IF_AARCH64(false));
+                                       SCRATCH_REG0);
 #ifndef AARCH64
     /* put pre-push xsp into priv_mcontext_t.xsp slot */
     ASSERT(offset == sizeof(priv_mcontext_t));
@@ -5392,6 +5392,13 @@ byte *
 emit_clean_call_save(dcontext_t *dcontext, byte *pc, generated_code_t *code)
 {
     instrlist_t ilist;
+#ifdef AARCHXX
+    /* FIXME i#1551, i#1569:
+     * NYI on ARM/AArch64 (no assert here, it's in get_clean_call_save())
+     */
+    return pc;
+#endif
+
     instrlist_init(&ilist);
     /* xref insert_out_of_line_context_switch @ x86/mangle.c,
      * stack was adjusted beyond what we place there to get retaddr
@@ -5413,12 +5420,8 @@ emit_clean_call_save(dcontext_t *dcontext, byte *pc, generated_code_t *code)
     /* save all registers */
     insert_push_all_registers(dcontext, NULL, &ilist, NULL, (uint)PAGE_SIZE,
                               OPND_CREATE_INT32(0), REG_NULL);
-#elif defined(AARCH64)
-    /* save all registers */
-    insert_push_all_registers(dcontext, NULL, &ilist, NULL, (uint)PAGE_SIZE,
-                              OPND_CREATE_INT32(0), REG_NULL, true);
-#else
-    /* FIXME i#1621: NYI on AArch32 */
+#elif defined(ARM)
+    /* FIXME i#1551: NYI on ARM */
     ASSERT_NOT_IMPLEMENTED(false);
 #endif
 
@@ -5455,10 +5458,8 @@ emit_clean_call_save(dcontext_t *dcontext, byte *pc, generated_code_t *code)
                                OPSZ_lea)));
     APP(&ilist, INSTR_CREATE_ret_imm
         (dcontext, OPND_CREATE_INT16(get_clean_call_temp_stack_size())));
-#elif defined(AARCH64)
-    APP(&ilist, INSTR_CREATE_br(dcontext, opnd_create_reg(DR_REG_X30)));
-#else
-    /* FIXME i#1621: NYI on AArch32 */
+#elif defined(ARM)
+    /* FIXME i#1551: NYI on ARM */
     ASSERT_NOT_IMPLEMENTED(false);
 #endif
 
@@ -5474,9 +5475,7 @@ emit_clean_call_restore(dcontext_t *dcontext, byte *pc, generated_code_t *code)
 {
     instrlist_t ilist;
 #ifdef ARM
-    /* FIXME i#1551: NYI on AArch32
-     * (no assert here, it's in get_clean_call_restore())
-    */
+    /* FIXME i#1551: NYI on ARM (no assert here, it's in get_clean_call_restore()) */
     return pc;
 #endif
 
@@ -5516,15 +5515,10 @@ emit_clean_call_restore(dcontext_t *dcontext, byte *pc, generated_code_t *code)
     APP(&ilist, INSTR_CREATE_ret_imm
         (dcontext,
          OPND_CREATE_INT16(get_clean_call_switch_stack_size())));
-#elif defined(AARCH64)
-    insert_pop_all_registers(dcontext, NULL, &ilist, NULL, (uint)PAGE_SIZE, true);
-
-    APP(&ilist, INSTR_CREATE_br(dcontext, opnd_create_reg(DR_REG_X30)));
-#else
-    /* FIXME i#1621: NYI on AArch32 */
+#elif defined(ARM)
+    /* FIXMED i#1551: NYI on ARM */
     ASSERT_NOT_IMPLEMENTED(false);
 #endif
-
     /* emit code */
     pc = instrlist_encode(dcontext, &ilist, pc, false);
     ASSERT(pc != NULL);

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -61,12 +61,7 @@ callee_info_t default_callee_info;
 int
 get_clean_call_switch_stack_size(void)
 {
-#ifdef AARCHXX
-    /* Stack size needs to be 16 byte aligned on ARM */
-    return ALIGN_FORWARD(sizeof(priv_mcontext_t), 16);
-#else
     return sizeof(priv_mcontext_t);
-#endif
 }
 
 /* extra temporarily-used stack usage beyond
@@ -263,9 +258,7 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci,
     } else {
         dstack_offs +=
             insert_push_all_registers(dcontext, cci, ilist, instr, (uint)PAGE_SIZE,
-                                      OPND_CREATE_INT32(0), REG_NULL
-                                      _IF_AARCH64(false));
-
+                                      OPND_CREATE_INT32(0), REG_NULL);
         insert_clear_eflags(dcontext, cci, ilist, instr);
         /* XXX: add a cci field for optimizing this away if callee makes no calls */
     }
@@ -334,7 +327,7 @@ cleanup_after_clean_call(dcontext_t *dcontext, clean_call_info_t *cci,
         /* XXX: add a cci field for optimizing this away if callee makes no calls */
         insert_pop_all_registers(dcontext, cci, ilist, instr,
                                  /* see notes in prepare_for_clean_call() */
-                                 (uint)PAGE_SIZE _IF_AARCH64(false));
+                                 (uint)PAGE_SIZE);
     }
 
     /* Swap stacks back.  For thread-shared, we need to get the dcontext

--- a/suite/tests/client-interface/cleancall-opt-1.dll.c
+++ b/suite/tests/client-interface/cleancall-opt-1.dll.c
@@ -85,7 +85,7 @@ event_basic_block(void *dc, void *tag, instrlist_t *bb,
     app_pc entry_pc = instr_get_app_pc(entry);
     int i;
     bool inline_expected = false;
-    bool out_of_line_expected = IF_AARCH64_ELSE(true, false);
+    bool out_of_line_expected = false;
     instr_t *before_label;
     instr_t *after_label;
 

--- a/suite/tests/client-interface/cleancall-opt-shared.h
+++ b/suite/tests/client-interface/cleancall-opt-shared.h
@@ -423,9 +423,11 @@ after_callee(app_pc start_inline, app_pc end_inline, bool inline_expected,
             instr_reset(dc, &instr);
         }
         if (blr_count != 3) {
-            dr_fprintf(STDERR, "Expected out-of-line call but did not find exactly 3 "
-                       IF_X86_ELSE("CALL", "BLR") " instructions.\n");
+            dr_fprintf(STDERR, "Expected out-of-line call but did not find exactly 3 %s instructions.\n"
+                       IF_X86_ELSE("CALL", "BLR"));
             dump_cc_code(dc, start_inline, end_inline, func_index);
+        } else {
+            dr_fprintf(STDERR, "Out-of-line call generated as expected.\n");
         }
     }
 


### PR DESCRIPTION
This reverts commit 4bbc682c5db6a3c0a8c7220edfcf31b11fc4613c which broke
every test on ARM.