### PR TITLE
i#2399 add reuse time tool to drmemtrace.

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -62,6 +62,7 @@ set(client_and_sim_srcs
 # launchers.
 add_library(reuse_distance STATIC tools/reuse_distance.cpp)
 add_library(histogram STATIC tools/histogram.cpp)
+add_library(reuse_time STATIC tools/reuse_time.cpp)
 # We combine the cache and TLB simulators as they share code already.
 add_library(simulator STATIC
   simulator/simulator.cpp
@@ -94,7 +95,7 @@ add_executable(drcachesim
 # In order to embed raw2trace we need to be standalone:
 configure_DynamoRIO_standalone(drcachesim)
 # Link in our tools:
-target_link_libraries(drcachesim simulator reuse_distance histogram)
+target_link_libraries(drcachesim simulator reuse_distance histogram reuse_time)
 # To avoid dup symbol errors between drinjectlib and the drdecode brought in
 # by drfrontendlib we have to explicitly list drdecode up front:
 target_link_libraries(drcachesim drdecode drinjectlib drconfiglib drfrontendlib)
@@ -195,6 +196,7 @@ restore_nonclient_flags(drmemtrace_histogram)
 restore_nonclient_flags(simulator)
 restore_nonclient_flags(reuse_distance)
 restore_nonclient_flags(histogram)
+restore_nonclient_flags(reuse_time)
 
 # We need to pass /EHsc and we pull in libcmtd into drcachesim from a dep lib.
 # Thus we need to override the /MT with /MTd.
@@ -217,6 +219,7 @@ add_win32_flags(drmemtrace_histogram)
 add_win32_flags(simulator)
 add_win32_flags(reuse_distance)
 add_win32_flags(histogram)
+add_win32_flags(reuse_time)
 if (WIN32 AND DEBUG)
   get_target_property(sim_srcs drcachesim SOURCES)
   get_target_property(raw2trace_srcs drraw2trace SOURCES)

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -167,9 +167,9 @@ droption_t<std::string> op_TLB_replace_policy
 
 droption_t<std::string> op_simulator_type
 (DROPTION_SCOPE_FRONTEND, "simulator_type", CPU_CACHE,
- "Simulator type (" CPU_CACHE", " TLB", " REUSE_DIST", or " HISTOGRAM").",
+ "Simulator type (" CPU_CACHE", " TLB", " REUSE_DIST", " REUSE_TIME", or " HISTOGRAM").",
  "Specifies the type of the simulator. "
- "Supported types: " CPU_CACHE", " TLB", " REUSE_DIST", or " HISTOGRAM".");
+ "Supported types: " CPU_CACHE", " TLB", " REUSE_DIST", " REUSE_TIME", or " HISTOGRAM".");
 
 droption_t<unsigned int> op_verbose
 (DROPTION_SCOPE_ALL, "verbose", 0, 0, 64, "Verbosity level",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -43,6 +43,7 @@
 #define TLB                                     "TLB"
 #define HISTOGRAM                               "histogram"
 #define REUSE_DIST                              "reuse_distance"
+#define REUSE_TIME                              "reuse_time"
 
 #include <string>
 #include "droption.h"

--- a/clients/drcachesim/simulator/analyzer_interface.cpp
+++ b/clients/drcachesim/simulator/analyzer_interface.cpp
@@ -42,6 +42,7 @@
  */
 #include "../tools/histogram_create.h"
 #include "../tools/reuse_distance_create.h"
+#include "../tools/reuse_time_create.h"
 
 analysis_tool_t *
 drmemtrace_analysis_tool_create()
@@ -82,6 +83,9 @@ drmemtrace_analysis_tool_create()
                                           op_reuse_skip_dist.get_value(),
                                           op_reuse_verify_skip.get_value(),
                                           op_verbose.get_value());
+    } else if (op_simulator_type.get_value() == REUSE_TIME) {
+        return reuse_time_tool_create(op_line_size.get_value(),
+                                      op_verbose.get_value());
     } else {
         ERRMSG("Usage error: unsupported analyzer type. "
                "Please choose " CPU_CACHE ", " TLB ", "

--- a/clients/drcachesim/tests/reuse_time_offline.expect
+++ b/clients/drcachesim/tests/reuse_time_offline.expect
@@ -1,0 +1,8 @@
+Reuse time tool results:
+Total accesses: 57
+Mean reuse time: 3.00
+Reuse time histogram:
+Distance       Count  Percent  Cumulative
+       1          13   24.53%      24.53%
+       3          14   26.42%      50.94%
+       4          26   49.06%     100.00%

--- a/clients/drcachesim/tests/reuse_time_offline.expect
+++ b/clients/drcachesim/tests/reuse_time_offline.expect
@@ -1,5 +1,5 @@
 Reuse time tool results:
-Total accesses: 57
+Total accesses: 56
 Mean reuse time: 3.00
 Reuse time histogram:
 Distance       Count  Percent  Cumulative

--- a/clients/drcachesim/tools/reuse_time.cpp
+++ b/clients/drcachesim/tools/reuse_time.cpp
@@ -1,0 +1,135 @@
+/* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <iomanip>
+#include <iostream>
+
+#include "reuse_time.h"
+#include "../common/utils.h"
+
+#ifdef DEBUG
+# define DEBUG_VERBOSE(level) (knob_verbose >= (level))
+#else
+# define DEBUG_VERBOSE(level) (false)
+#endif
+
+const std::string reuse_time_t::TOOL_NAME = "Reuse time tool";
+
+analysis_tool_t *
+reuse_time_tool_create(unsigned int line_size,
+                       unsigned int verbose)
+{
+    return new reuse_time_t(line_size, verbose);
+}
+
+reuse_time_t::reuse_time_t(unsigned int line_size, unsigned int verbose) :
+    time_stamp(0), knob_verbose(verbose), knob_line_size(line_size)
+{
+    line_size_bits = compute_log2((int)knob_line_size);
+}
+
+reuse_time_t::~reuse_time_t() {}
+
+bool reuse_time_t::process_memref(const memref_t &memref)
+{
+    if (DEBUG_VERBOSE(3)) {
+        std::cerr << " ::" << memref.data.pid << "." << memref.data.tid
+                  << ":: " << trace_type_names[memref.data.type];
+        if (memref.data.type != TRACE_TYPE_THREAD_EXIT) {
+            std::cerr << " @ ";
+            if (!type_is_instr(memref.data.type))
+                std::cerr << (void *)memref.data.pc << " ";
+            std::cerr << (void *)memref.data.addr << " x" << memref.data.size;
+        }
+        std::cerr << std::endl;
+    }
+
+    // Only care about data for now.
+    if (type_is_instr(memref.instr.type)) {
+        return true;
+    }
+
+    // Ignore thread events and other tracing metadata.
+    if (memref.data.type != TRACE_TYPE_READ &&
+        memref.data.type != TRACE_TYPE_WRITE &&
+        type_is_prefetch(memref.data.type)) {
+        return true;
+    }
+
+    time_stamp++;
+    int_least64_t line = memref.data.addr >> line_size_bits;
+    if (time_map.count(line) > 0) {
+        int_least64_t reuse_time = time_stamp - time_map[line];
+        if (DEBUG_VERBOSE(3)) {
+            std::cerr << "Reuse " << reuse_time << std::endl;
+        }
+        reuse_time_histogram[reuse_time]++;
+    }
+    time_map[line] = time_stamp;
+    return true;
+}
+
+bool
+reuse_time_t::print_results() {
+    std::cerr << TOOL_NAME << " results:\n";
+    std::cerr << "Total accesses: " << time_stamp << "\n";
+    std::cerr.precision(2);
+    std::cerr.setf(std::ios::fixed);
+
+    int_least64_t count = 0;
+    int_least64_t sum = 0;
+    for (std::map<int_least64_t, int_least64_t>::iterator it =
+         reuse_time_histogram.begin(); it != reuse_time_histogram.end(); it++) {
+        count += it->second;
+        sum += it->first * it->second;
+    }
+    std::cerr << "Mean reuse time: " << sum / static_cast<double>(count) << "\n";
+
+    std::cerr << "Reuse time histogram:\n";
+    std::cerr << std::setw(8) << "Distance"
+              << std::setw(12) << "Count"
+              << std::setw(9) << "Percent"
+              << std::setw(12) << "Cumulative";
+    std::cerr << std::endl;
+    double cum_percent = 0.0;
+    for (std::map<int_least64_t, int_least64_t>::iterator it =
+         reuse_time_histogram.begin(); it != reuse_time_histogram.end(); it++) {
+        double percent = it->second / static_cast<double>(count);
+        cum_percent += percent;
+        std::cerr << std::setw(8) << it->first
+                  << std::setw(12) << it->second
+                  << std::setw(8) << percent * 100.0 << "%"
+                  << std::setw(11) << cum_percent * 100.0 << "%";
+        std::cerr << std::endl;
+    }
+    return true;
+}

--- a/clients/drcachesim/tools/reuse_time.cpp
+++ b/clients/drcachesim/tools/reuse_time.cpp
@@ -86,7 +86,7 @@ bool reuse_time_t::process_memref(const memref_t &memref)
     }
 
     time_stamp++;
-    int_least64_t line = memref.data.addr >> line_size_bits;
+    addr_t line = memref.data.addr >> line_size_bits;
     if (time_map.count(line) > 0) {
         int_least64_t reuse_time = time_stamp - time_map[line];
         if (DEBUG_VERBOSE(3)) {

--- a/clients/drcachesim/tools/reuse_time.cpp
+++ b/clients/drcachesim/tools/reuse_time.cpp
@@ -57,9 +57,13 @@ reuse_time_t::reuse_time_t(unsigned int line_size, unsigned int verbose) :
     line_size_bits = compute_log2((int)knob_line_size);
 }
 
-reuse_time_t::~reuse_time_t() {}
+reuse_time_t::~reuse_time_t()
+{
+    // Empty.
+}
 
-bool reuse_time_t::process_memref(const memref_t &memref)
+bool
+reuse_time_t::process_memref(const memref_t &memref)
 {
     if (DEBUG_VERBOSE(3)) {
         std::cerr << " ::" << memref.data.pid << "." << memref.data.tid
@@ -81,7 +85,7 @@ bool reuse_time_t::process_memref(const memref_t &memref)
     // Ignore thread events and other tracing metadata.
     if (memref.data.type != TRACE_TYPE_READ &&
         memref.data.type != TRACE_TYPE_WRITE &&
-        type_is_prefetch(memref.data.type)) {
+        !type_is_prefetch(memref.data.type)) {
         return true;
     }
 

--- a/clients/drcachesim/tools/reuse_time.h
+++ b/clients/drcachesim/tools/reuse_time.h
@@ -1,0 +1,56 @@
+/* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <map>
+#include <string>
+
+#include "analysis_tool.h"
+
+class reuse_time_t : public analysis_tool_t
+{
+ public:
+    reuse_time_t(unsigned int line_size, unsigned int verbose);
+    virtual ~reuse_time_t();
+    virtual bool process_memref(const memref_t &memref);
+    virtual bool print_results();
+
+ protected:
+    std::map<addr_t, int_least64_t> time_map;
+    int_least64_t time_stamp;
+    std::map<int_least64_t, int_least64_t> reuse_time_histogram;
+
+    unsigned int knob_verbose;
+    unsigned int knob_line_size;
+    unsigned int line_size_bits;
+
+    static const std::string TOOL_NAME;
+};

--- a/clients/drcachesim/tools/reuse_time_create.h
+++ b/clients/drcachesim/tools/reuse_time_create.h
@@ -1,0 +1,44 @@
+/* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* reuse-distance tool creation */
+
+#ifndef _REUSE_TIME_CREATE_H_
+#define _REUSE_TIME_CREATE_H_ 1
+
+#include "analysis_tool.h"
+
+// These options are currently documented in ../common/options.cpp.
+analysis_tool_t *
+reuse_time_tool_create(unsigned int line_size = 64, unsigned int verbose = 0);
+
+#endif /* _REUSE_TIME_CREATE_H_ */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2468,6 +2468,14 @@ if (CLIENT_INTERFACE)
           "-infile ${small_trace_file} -simulator_type reuse_distance -reuse_distance_histogram" "" "")
         set(tool.reuse.offline_toolname "drcachesim")
         set(tool.reuse.offline_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+
+        set(small_trace_file
+          "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.small.x64.trace")
+        torunonly_ci(tool.reuse_time.offline ${ci_shared_app} drcachesim
+          "reuse_time_offline.c" # for expect basename
+          "-infile ${small_trace_file} -simulator_type reuse_time" "" "")
+        set(tool.reuse_time.offline_toolname "drcachesim")
+        set(tool.reuse_time.offline_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       endif ()
 
       # Test offline traces.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2474,8 +2474,6 @@ if (CLIENT_INTERFACE)
         set(tool.reuse.offline_toolname "drcachesim")
         set(tool.reuse.offline_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
 
-        set(small_trace_file
-          "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.small.x64.trace")
         torunonly_ci(tool.reuse_time.offline ${ci_shared_app} drcachesim
           "reuse_time_offline.c" # for expect basename
           "-infile ${small_trace_file} -simulator_type reuse_time" "" "")


### PR DESCRIPTION
Adds a separate reuse time tool, which grabs a histogram of # memory
accesses between accesses to the same address. Space and time use is
linear with the size of the trace.

TESTED: ctest; code_api|sample.* were failing before.

Fixes #2399