### PR TITLE
i#1569 AArch64: Implement move (immediate) to zero register.

### DIFF
--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -5546,6 +5546,8 @@ DR_API
  * Pointers to the first and last created meta instructions are returned
  * in \p first and \p last, unless only one meta instruction is created,
  * in which case NULL is returned in last.
+ * If the instruction is a no-op (when dst is the zero register on AArch64)
+ * then no instructions are created and NULL is returned in first and last.
  */
 void
 instrlist_insert_mov_immed_ptrsz(void *drcontext, ptr_int_t val, opnd_t dst,
@@ -5578,6 +5580,8 @@ DR_API
  * Pointers to the first and last created meta instructions are returned
  * in \p first and \p last, unless only one meta instruction is created,
  * in which case NULL is returned in last.
+ * If the instruction is a no-op (when dst is the zero register on AArch64)
+ * then no instructions are created and NULL is returned in first and last.
  */
 void
 instrlist_insert_mov_instr_addr(void *drcontext, instr_t *src_inst,


### PR DESCRIPTION
Moving a value to the zero register is a no-op but we have seen
ADR XZR,... used by Node.js (libv8). Having these API functions,
instrlist_insert_mov_{immed_ptrsz,instr_addr}, create no instructions
potentially adds a case for the caller to handle but most uses of
those functions set the last two arguments to NULL in any case. If it
were a problem we could create a NOP instruction instead. Creating
actual moves to XZR seems less good and would be awkward if in
generating a constant value we ever used instructions that cannot
target XZR.
