### PR TITLE
Improve documentation of which IR free routines to call

### DIFF
--- a/api/docs/bt.dox
+++ b/api/docs/bt.dox
@@ -114,8 +114,19 @@ that DynamoRIO performs on calls from the client, so it should typically be
 enabled only in a release build.  Furthermore, some of the macros evaluate their
 arguments twice, so clients should avoid passing arguments with side effects.
 
+When a new instruction is created using instr_create() or the
+INSTR_CREATE_* or XINST_CREATE_* macros, if the instruction is added to the
+\c instrlist_t that is passed to the basic block or trace events, the heap
+memory used by the instruction is automatically freed when that instruction
+list is freed by DynamoRIO.  If instead an instruction is created on the
+heap but used for other purposes and not added to a DynamoRIO-provided
+instruction list, it should be freed by calling instr_destroy() or by
+explicitly destroying a custom instruction list.
+
 See \ref sec_decode for further information on creating instructions from
-scratch, decoding, encoding, and disassembling instructions.
+scratch, decoding, encoding, and disassembling instructions.  Typically
+these instructions will be stored on the stack, using instr_init() and
+instr_free() or instr_reset(), as shown in that section.
 
 \if level_of_detail
 ********************

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -430,8 +430,8 @@ DR_API
  * Returns an initialized instr_t allocated on the thread-local heap.
  * Sets the x86/x64 mode of the returned instr_t to the mode of dcontext.
  * The instruction should be de-allocated with instr_destroy(), which
- * will be called automatically if this instruction is added to the #instrlist_t
- * passed to the basic block or trace events.
+ * will be called automatically if this instruction is added to the instruction
+ * list passed to the basic block or trace events.
  */
 /* For -x86_to_x64, sets the mode of the instr to the code cache mode instead of
 the app mode. */

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -429,6 +429,9 @@ DR_API
 /**
  * Returns an initialized instr_t allocated on the thread-local heap.
  * Sets the x86/x64 mode of the returned instr_t to the mode of dcontext.
+ * The instruction should be de-allocated with instr_destroy(), which
+ * will be called automatically if this instruction is added to the #instrlist_t
+ * passed to the basic block or trace events.
  */
 /* For -x86_to_x64, sets the mode of the instr to the code cache mode instead of
 the app mode. */
@@ -436,8 +439,11 @@ instr_t*
 instr_create(dcontext_t *dcontext);
 
 DR_API
-/** Initializes \p instr.
+/**
+ * Initializes \p instr.
  * Sets the x86/x64 mode of \p instr to the mode of dcontext.
+ * When finished with it, the instruction's internal memory should be freed
+ * with instr_free(), or instr_reset() for reuse.
  */
 void
 instr_init(dcontext_t *dcontext, instr_t *instr);
@@ -447,7 +453,8 @@ DR_API
  * Deallocates all memory that was allocated by \p instr.  This
  * includes raw bytes allocated by instr_allocate_raw_bits() and
  * operands allocated by instr_set_num_opnds().  Does not deallocate
- * the storage for \p instr itself.
+ * the storage for \p instr itself (use instr_destroy() instead if
+ * \p instr was created with instr_create()).
  */
 void
 instr_free(dcontext_t *dcontext, instr_t *instr);
@@ -474,7 +481,7 @@ instr_reuse(dcontext_t *dcontext, instr_t *instr);
 DR_API
 /**
  * Performs instr_free() and then deallocates the thread-local heap
- * storage for \p instr.
+ * storage for \p instr that was performed by instr_create().
  */
 void
 instr_destroy(dcontext_t *dcontext, instr_t *instr);


### PR DESCRIPTION
In the wake of recent user confusion, we improve the docs for when to call
instr_destroy() vs instr_free().