### PR TITLE
i#2369 code style: fix many violations in older code

### DIFF
--- a/api/samples/memval_simple.c
+++ b/api/samples/memval_simple.c
@@ -104,9 +104,10 @@ write_hexdump(char *hex_buf, byte *write_base, mem_ref_t *mem_ref)
     int i;
     char *hexstring = hex_buf, *needle = hex_buf;
 
-    for (i = mem_ref->size - 1; i >= 0; --i)
+    for (i = mem_ref->size - 1; i >= 0; --i) {
         needle += dr_snprintf(needle, 2*mem_ref->size+1-(needle-hex_buf),
                               "%02x", write_base[i]);
+    }
     return hexstring;
 }
 

--- a/api/samples/signal.c
+++ b/api/samples/signal.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -94,8 +94,8 @@ event_exit(void)
 }
 
 #ifdef UNIX
-static
-dr_signal_action_t event_signal(void *drcontext, dr_siginfo_t *info)
+static dr_signal_action_t
+event_signal(void *drcontext, dr_siginfo_t *info)
 {
     dr_atomic_add32_return_sum(&num_signals, 1);
     if (info->sig == SIGTERM) {

--- a/api/samples/wrap.c
+++ b/api/samples/wrap.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -68,8 +68,8 @@ static void *max_lock; /* to synch writes to max_malloc */
 
 #define MALLOC_ROUTINE_NAME IF_WINDOWS_ELSE("HeapAlloc", "malloc")
 
-static
-void module_load_event(void *drcontext, const module_data_t *mod, bool loaded)
+static void
+module_load_event(void *drcontext, const module_data_t *mod, bool loaded)
 {
     app_pc towrap = (app_pc)
         dr_get_proc_address(mod->handle, MALLOC_ROUTINE_NAME);

--- a/clients/drcachesim/simulator/cache_fifo.cpp
+++ b/clients/drcachesim/simulator/cache_fifo.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -75,7 +75,8 @@ cache_fifo_t::replace_which_way(int block_idx)
             // clear the counter of the victim block
             get_caching_device_block(block_idx, i).counter = 0;
             // set the next block as victim
-            get_caching_device_block(block_idx, (i + 1) & (associativity - 1)).counter = 1;
+            get_caching_device_block(block_idx, (i + 1) & (associativity - 1)).counter
+                = 1;
             return i;
         }
     }

--- a/clients/drcachesim/tests/burst_threads.cpp
+++ b/clients/drcachesim/tests/burst_threads.cpp
@@ -129,7 +129,8 @@ main(int argc, const char *argv[])
      * running more and their trace files get up to 65MB or more, with the
      * merged result several GB's: too much for a test.  We thus cap each thread.
      */
-    if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -client_lib ';;-offline -max_trace_size 256K'"))
+    if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -client_lib ';;"
+                   "-offline -max_trace_size 256K'"))
         std::cerr << "failed to set env var!\n";
 
     std::cerr << "pre-DR init\n";

--- a/clients/standalone/winsysnums.c
+++ b/clients/standalone/winsysnums.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -240,7 +240,8 @@ check_Ki(const char *name)
         print("we've never seen this guy invoked\n");
     } else if (strcmp(name, "KiUserCallbackDispatcher") == 0) {
         print("verify that:\n"
-              "\t1) peb->KernelCallbackTable[*(esp+4)] == call* target (not relied on)\n");
+              "\t1) peb->KernelCallbackTable[*(esp+4)] == call* target "
+              "(not relied on)\n");
     } else if (strcmp(name, "KiFastSystemCall") == 0) {
         print("should be simply \"mov esp,edx; sysenter; ret\"\n");
     } else if (strcmp(name, "KiFastSystemCallRet") == 0) {
@@ -453,8 +454,10 @@ decode_syscall_num(void *dcontext, byte *entry, syscall_info_t *info, LOADED_IMA
              *   ntdll!NtContinue:
              *   00007ff9`13185630 4c8bd1          mov     r10,rcx
              *   00007ff9`13185633 b843000000      mov     eax,43h
-             *   00007ff9`13185638 f604250803fe7f01 test    byte ptr [SharedUserData+0x308 (00000000`7ffe0308)],1
-             *   00007ff9`13185640 7503            jne     ntdll!NtContinue+0x15 (00007ff9`13185645)
+             *   00007ff9`13185638 f604250803fe7f01 test byte ptr [SharedUserData+0x308
+             *                                                     (00000000`7ffe0308)],1
+             *   00007ff9`13185640 7503            jne     ntdll!NtContinue+0x15
+             *                                             (00007ff9`13185645)
              *   00007ff9`13185642 0f05            syscall
              *   00007ff9`13185644 c3              ret
              *   00007ff9`13185645 cd2e            int     2Eh
@@ -773,7 +776,8 @@ process_exports(void *dcontext, char *dllname, LOADED_IMAGE *img)
                                name[dir->NumberOfNames-1], NULL));
 
     for (i = 0; i < dir->NumberOfNames; i++) {
-        string = (char *) ImageRvaToVa(img->FileHeader, img->MappedAddress, name[i], NULL);
+        string = (char *)
+            ImageRvaToVa(img->FileHeader, img->MappedAddress, name[i], NULL);
         /* ordinal is biased (dir->Base), but don't add base when using as index */
         assert(dir->NumberOfFunctions > ordinal[i]);
         /* I don't understand why have to do RVA to VA here, when dumpbin /exports

--- a/core/annotations.h
+++ b/core/annotations.h
@@ -1,5 +1,5 @@
 /* ******************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * ******************************************************/
 
 /*
@@ -106,8 +106,9 @@ typedef enum _dr_valgrind_request_id_t {
 
 enum {
     /**
-     * Defines the maximum number of arguments that can be passed to a Valgrind annotation,
-     * and accordingly specifies the length of the array vg_client_request_t.args.
+     * Defines the maximum number of arguments that can be passed to a Valgrind
+     * annotation, and accordingly specifies the length of the array
+     * vg_client_request_t.args.
      */
     DR_VG_NUM_ARGS = 5,
 };

--- a/core/arch/aarch64/build_ldstex.c
+++ b/core/arch/aarch64/build_ldstex.c
@@ -85,9 +85,10 @@ instr_is_nonbranch_pcrel(instr_t *instr)
     for (i = 0; i < n; i++)
         ASSERT(!OPND_IS_REL_ADDR(instr_get_dst(instr, i)));
     n = instr_num_srcs(instr);
-    for (i = 0; i < n; i++)
+    for (i = 0; i < n; i++) {
         if (OPND_IS_REL_ADDR(instr_get_src(instr, i)))
             return true;
+    }
     return false;
 }
 

--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -2644,7 +2645,8 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
     return next_pc;
 }
 
-uint encode_common(byte *pc, instr_t *i)
+uint
+encode_common(byte *pc, instr_t *i)
 {
     uint enc;
     ASSERT(((ptr_int_t)pc & 3) == 0);

--- a/core/arch/aarch64/decode.c
+++ b/core/arch/aarch64/decode.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -226,7 +227,8 @@ decode_debug_checks_arch(void)
 
 # include "instr_create.h"
 
-int main()
+int
+main()
 {
     bool res = true;
     standalone_init();

--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -610,7 +610,8 @@ append_call_enter_dr_hook(dcontext_t *dcontext, instrlist_t *ilist,
 
 void
 insert_save_eflags(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
-                   uint flags, bool tls, bool absolute _IF_X86_64(bool x86_to_x64_ibl_opt))
+                   uint flags, bool tls, bool absolute
+                   _IF_X86_64(bool x86_to_x64_ibl_opt))
 {
     ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
 }

--- a/core/arch/aarch64/instr.c
+++ b/core/arch/aarch64/instr.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -248,7 +249,8 @@ instr_is_mov_constant(instr_t *instr, ptr_int_t *value)
     return false;
 }
 
-bool instr_is_prefetch(instr_t *instr)
+bool
+instr_is_prefetch(instr_t *instr)
 {
     /* FIXME i#1569: NYI */
     return false;

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -290,10 +290,13 @@ insert_save_or_restore_registers(dcontext_t *dcontext, instrlist_t *ilist, instr
         opnd_t mem = create_base_disp_for_save_restore(base_reg, first_reg, reg1,
                                                        true /* is_single_reg */,
                                                        is_gpr);
-        if (save)
-            new_instr = INSTR_CREATE_str(dcontext, mem, opnd_create_reg(first_reg + reg1));
-        else
-            new_instr = INSTR_CREATE_ldr(dcontext, opnd_create_reg(first_reg + reg1), mem);
+        if (save) {
+            new_instr = INSTR_CREATE_str(dcontext, mem,
+                                         opnd_create_reg(first_reg + reg1));
+        } else {
+            new_instr = INSTR_CREATE_ldr(dcontext,
+                                         opnd_create_reg(first_reg + reg1), mem);
+        }
         PRE(ilist, instr, new_instr);
     }
 }
@@ -581,7 +584,7 @@ insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                          OPND_CREATE_INT32(current_offs)));
 
     /* load pc and flags */
-    if(!(cci->skip_save_flags)) {
+    if (!(cci->skip_save_flags)) {
         /* ldp w1, w2, [x0, #8] */
         PRE(ilist, instr,
             INSTR_CREATE_ldp(dcontext,

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -359,7 +359,8 @@ typedef enum {
 
 cache_pc get_ibl_routine_ex(dcontext_t *dcontext, ibl_entry_point_type_t entry_type,
                             ibl_source_fragment_type_t source_fragment_type,
-                            ibl_branch_type_t branch_type _IF_X86_64(gencode_mode_t mode));
+                            ibl_branch_type_t branch_type
+                            _IF_X86_64(gencode_mode_t mode));
 cache_pc get_ibl_routine(dcontext_t *dcontext, ibl_entry_point_type_t entry_type,
                          ibl_source_fragment_type_t source_fragment_type,
                          ibl_branch_type_t branch_type);
@@ -674,13 +675,16 @@ enum {
     7, /* we use 5 normally, 7 w/ -atomic_inlined_linking and inlining */
     /* Patch entry flags */
     /* Patch offset entries for dynamic updates from input variables */
-    PATCH_TAKE_ADDRESS      = 0x01, /* use computed address if set, value at address otherwise */
-    PATCH_PER_THREAD        = 0x02, /* address is relative to the per_thread_t thread local field */
-    PATCH_UNPROT_STAT       = 0x04, /* address is (unprot_ht_statistics_t offs << 16) | (stats offs) */
+    /* use computed address if set, value at address otherwise */
+    PATCH_TAKE_ADDRESS      = 0x01,
+    /* address is relative to the per_thread_t thread local field */
+    PATCH_PER_THREAD        = 0x02,
+    /* address is (unprot_ht_statistics_t offs << 16) | (stats offs) */
+    PATCH_UNPROT_STAT       = 0x04,
     /* Patch offset markers update an output variable in encode_with_patch_list */
     PATCH_MARKER            = 0x08, /* if set use only as a static marker */
-    PATCH_ASSEMBLE_ABSOLUTE = 0x10, /* if set retrieve an absolute pc into given target address,
-                                      otherwise relative to start pc */
+    PATCH_ASSEMBLE_ABSOLUTE = 0x10, /* if set retrieve an absolute pc into given target
+                                     * address, otherwise relative to start pc */
     PATCH_OFFSET_VALID      = 0x20, /* if set use patch_entry_t.where.offset;
                                      * else patch_entry_t.where.instr */
     PATCH_UINT_SIZED        = 0x40, /* if set value is uint-sized; else pointer-sized */
@@ -763,7 +767,9 @@ typedef struct ibl_code_t {
     uint unprot_stats_offset;
     uint hashtable_stats_offset;
     /* e.g. offsetof(per_thread_t, trace) + offsetof(ibl_table_t, bb_ibl_stats) */
-    /* Note hashtable statistics are associated with the hashtable for easier use when sharing IBL routines */
+    /* Note hashtable statistics are associated with the hashtable for easier use
+     * when sharing IBL routines
+     */
     uint entry_stats_to_lookup_table_offset; /* offset to (entry_stats - lookup_table)  */
 #endif
 } ibl_code_t;
@@ -1060,7 +1066,8 @@ void
 preinsert_swap_peb(dcontext_t *dcontext, instrlist_t *ilist, instr_t *next,
                    bool absolute, reg_id_t reg_dr, reg_id_t reg_scratch, bool to_priv);
 
-void emit_patch_syscall(dcontext_t *dcontext, byte *target _IF_X86_64(gencode_mode_t mode));
+void emit_patch_syscall(dcontext_t *dcontext, byte *target
+                        _IF_X86_64(gencode_mode_t mode));
 #endif /* WINDOWS */
 
 byte * emit_do_syscall(dcontext_t *dcontext, generated_code_t *code, byte *pc,
@@ -1132,7 +1139,8 @@ emit_clean_call_restore(dcontext_t *dcontext, byte *pc, generated_code_t *code);
 
 void
 insert_save_eflags(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
-                   uint flags, bool tls, bool absolute _IF_X86_64(bool x86_to_x64_ibl_opt));
+                   uint flags, bool tls, bool absolute
+                   _IF_X86_64(bool x86_to_x64_ibl_opt));
 void
 insert_restore_eflags(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
                       uint flags, bool tls, bool absolute

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -807,7 +807,9 @@ static inline bool atomic_dec_and_test(volatile int *var)
     unsigned char c;
 
     ATOMIC_DEC(int, *var);
-    /* result should be set according to value before change, now we convert that back to C */
+    /* result should be set according to value before change, now we
+     * convert that back to C.
+     */
     SET_IF_NOT_LESS(c);
     /* FIXME: we add an extra memory reference to a local,
        although we could put the return value in EAX ourselves */
@@ -822,7 +824,9 @@ static inline bool atomic_dec_becomes_zero(volatile int *var)
     unsigned char c;
 
     ATOMIC_DEC(int, *var);
-    /* result should be set according to value after change, now we convert that back to C */
+    /* result should be set according to value after change, now we
+     * convert that back to C.
+     */
     SET_IF_NOT_ZERO(c);
     /* FIXME: we add an extra memory reference to a local,
        although we could put the return value in EAX ourselves */
@@ -1408,7 +1412,8 @@ decode_init(void);
     (FRAG_IS_32(flags) ? SIZE32_MOV_PTR_IMM_TO_XAX : SIZE64_MOV_PTR_IMM_TO_XAX)
 
 /* size of restore ecx prefix */
-# define XCX_IN_TLS(flags) (DYNAMO_OPTION(private_ib_in_tls) || TEST(FRAG_SHARED, (flags)))
+# define XCX_IN_TLS(flags) \
+    (DYNAMO_OPTION(private_ib_in_tls) || TEST(FRAG_SHARED, (flags)))
 # define FRAGMENT_BASE_PREFIX_SIZE(flags) \
     ((FRAG_IS_X86_TO_X64(flags) && \
       IF_X64_ELSE(DYNAMO_OPTION(x86_to_x64_ibl_opt), false)) ? \
@@ -2075,7 +2080,8 @@ ibltype_to_linktype(ibl_branch_type_t ibltype)
 }
 
 #ifdef DEBUG
-bool is_ibl_routine_type(dcontext_t *dcontext, cache_pc target, ibl_branch_type_t branch_type);
+bool is_ibl_routine_type(dcontext_t *dcontext, cache_pc target,
+                         ibl_branch_type_t branch_type);
 #endif /* DEBUG */
 
 /* This completely optimizable routine is the only place where we

--- a/core/arch/arm/decode.c
+++ b/core/arch/arm/decode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -3099,7 +3099,8 @@ decode_debug_checks_arch(void)
 /* FIXME i#1551: add unit tests here.  How divide vs suite/tests/api/ tests? */
 # include "instr_create.h"
 
-int main()
+int
+main()
 {
     bool res = true;
     standalone_init();

--- a/core/arch/arm/instr.c
+++ b/core/arch/arm/instr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -416,7 +416,8 @@ instr_is_mov_constant(instr_t *instr, ptr_int_t *value)
     return false;
 }
 
-bool instr_is_prefetch(instr_t *instr)
+bool
+instr_is_prefetch(instr_t *instr)
 {
     int opcode = instr_get_opcode(instr);
 

--- a/core/arch/disassemble.h
+++ b/core/arch/disassemble.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -48,13 +48,17 @@
 #define MAX_OPND_DIS_SZ   64 /* gets long w/ ibl target names */
 /* Long examples:
  * "<RAW>  <raw 0x00007f85922c0877-0x00007f85922c0882 == 48 63 f8 48 89 d6 b8 05 00 ...>"
- * "lock cmpxchg %rcx <rel> 0x000007fefd1a2728[8byte] %rax -> <rel> 0x000007fefd1a2728[8byte] %rax "
+ * "lock cmpxchg %rcx <rel> 0x000007fefd1a2728[8byte] %rax -> <rel> "
+ * "0x000007fefd1a2728[8byte] %rax "
  */
 #define MAX_INSTR_DIS_SZ 196
 /* Here's a pretty long one,
- * "  0x00007f859277d63a  48 83 05 4e 63 21 00 add    $0x0000000000000001 <rel> 0x00007f8592993990 -> <rel> 0x00007f8592993990 \n                     01 "
+ * "  0x00007f859277d63a  48 83 05 4e 63 21 00 add    $0x0000000000000001 <rel> "
+ * "0x00007f8592993990 -> <rel> 0x00007f8592993990 \n                     01 "
  * For ARM:
- * " 8ca90aa1   vstm.hi %s0 %s1 %s2 %s3 %s4 %s5 %s6 %s7 %s8 %s9 %s10 %s11 %s12 %s13 %s14 %s15 %s16 %s17 %s18 %s19 %s20 %s21 %s22 %s23 %s24 %s25 %s26 %s27 %s28 %s29 %s30 %s31 %r9 -> (%r9)[124byte]"
+ * " 8ca90aa1   vstm.hi %s0 %s1 %s2 %s3 %s4 %s5 %s6 %s7 %s8 %s9 %s10 %s11 %s12 %s13 %s14 "
+ * "%s15 %s16 %s17 %s18 %s19 %s20 %s21 %s22 %s23 %s24 %s25 %s26 %s27 %s28 %s29 %s30 %s31 "
+ * "%r9 -> (%r9)[124byte]"
  */
 #define MAX_PC_DIS_SZ    228
 
@@ -276,7 +280,8 @@ DR_API
  *  +42   m4 @0xe7856754  eb fe                jmp    @0xe7857350[4byte]
  *  +44   m4 @0xe7856054                       <label>
  *  +44   m4 @0xe7857428  b9 e9 76 75 f7       mov    $0xf77576e9 -> %ecx
- *  +49   m4 @0xe7855b54  64 c7 05 64 00 00 00 mov    @0xe7856514[4byte] -> %fs:0x00000064[4byte]
+ *  +49   m4 @0xe7855b54  64 c7 05 64 00 00 00 mov    @0xe7856514[4byte] ->
+ *                                                    %fs:0x00000064[4byte]
  *                        98 e6 7b e7
  *  +60   m4 @0xe7857a30  e9 0a 35 07 00       jmp    $0xe7831ba7
  *  +65   m4 @0xe7856514                       <label>

--- a/core/arch/disassemble_shared.c
+++ b/core/arch/disassemble_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -499,7 +499,8 @@ print_known_pc_target(char *buf, size_t bufsz, size_t *sofar INOUT,
                     int ls_num = 0;
                     CLIENT_ASSERT(!TEST(FRAG_FAKE, fragment->flags),
                                   "opnd_disassemble: invalid target");
-                    for (ls=FRAGMENT_EXIT_STUBS(fragment); ls; ls=LINKSTUB_NEXT_EXIT(ls)) {
+                    for (ls=FRAGMENT_EXIT_STUBS(fragment); ls;
+                         ls=LINKSTUB_NEXT_EXIT(ls)) {
                         if (target == EXIT_STUB_PC(dcontext, fragment, ls)) {
                             print_to_buffer(buf, bufsz, sofar,
                                             "$"PFX" <exit stub %d> ",
@@ -1227,7 +1228,8 @@ common_disassemble_fragment(dcontext_t *dcontext,
                    TEST(FRAG_COARSE_GRAIN, f->flags) ? "coarse, " : "",
                    (TEST(FRAG_SHARED, f->flags) ? "shared, " :
                     (SHARED_FRAGMENTS_ENABLED() ?
-                     (TEST(FRAG_TEMP_PRIVATE, f->flags) ? "private temp, " : "private, ") : "")),
+                     (TEST(FRAG_TEMP_PRIVATE, f->flags) ? "private temp, " : "private, ")
+                     : "")),
                    (TEST( FRAG_IS_TRACE, f->flags)) ? "trace, " :
                    (TEST(FRAG_IS_TRACE_HEAD, f->flags)) ? "tracehead, " : "",
                    f->size,
@@ -1235,7 +1237,7 @@ common_disassemble_fragment(dcontext_t *dcontext,
                    (TEST(FRAG_MUST_END_TRACE, f->flags)) ?", must end trace":"",
                    (TEST(FRAG_CANNOT_DELETE, f->flags)) ?", cannot delete":"");
 
-        DOLOG(2, LOG_SYMBOLS, { /* FIXME: this affects non-logging uses... dump_traces, etc. */
+        DOLOG(2, LOG_SYMBOLS, { /* FIXME: affects non-logging uses... dump_traces, etc. */
             char symbolbuf[MAXIMUM_SYMBOL_LENGTH];
             print_symbolic_address(f->tag, symbolbuf, sizeof(symbolbuf), false);
             print_file(outfile, "\t%s\n", symbolbuf);
@@ -1304,7 +1306,8 @@ common_disassemble_fragment(dcontext_t *dcontext,
         linkstub_t *nxt;
         /* store fragment pc since we don't want to walk forward in fragment */
         cache_pc frag_pc = pc;
-        print_file(outfile, "  -------- exit stub %d: -------- <target: "PFX"> type: %s\n",
+        print_file(outfile,
+                   "  -------- exit stub %d: -------- <target: "PFX"> type: %s\n",
                    exit_num, EXIT_TARGET_TAG(dcontext, f, l),
                    exit_stub_type_desc(dcontext, f, l));
         if (!EXIT_HAS_LOCAL_STUB(l->flags, f->flags)) {
@@ -1340,7 +1343,8 @@ common_disassemble_fragment(dcontext_t *dcontext,
                 next_stop_pc = pc;
             }
         } else {
-            for (nxt = LINKSTUB_NEXT_EXIT(l); nxt != NULL; nxt = LINKSTUB_NEXT_EXIT(nxt)) {
+            for (nxt = LINKSTUB_NEXT_EXIT(l); nxt != NULL;
+                 nxt = LINKSTUB_NEXT_EXIT(nxt)) {
                 if (EXIT_HAS_LOCAL_STUB(nxt->flags, f->flags))
                     break;
             }
@@ -1503,7 +1507,8 @@ instrlist_disassemble(dcontext_t *dcontext,
                        offs, instr_is_app(instr) ? 'L' : 'm', level, " ");
             next_addr = internal_disassemble_to_file
                 (dcontext, addr, addr, outfile, false, true,
-                 IF_X64_ELSE("                               ","                       "));
+                 IF_X64_ELSE("                               ",
+                             "                       "));
             if (next_addr == NULL)
                 break;
             sz = (int) (next_addr - addr);

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -2727,7 +2727,8 @@ instr_t * instr_create_save_immed8_to_dcontext(dcontext_t *dcontext, int immed,
 instr_t *
 instr_create_save_immed_to_dc_via_reg(dcontext_t *dcontext, reg_id_t basereg,
                                       int offs, ptr_int_t immed, opnd_size_t sz);
-instr_t * instr_create_restore_from_dcontext(dcontext_t *dcontext, reg_id_t reg, int offs);
+instr_t * instr_create_restore_from_dcontext(dcontext_t *dcontext, reg_id_t reg,
+                                             int offs);
 
 instr_t * instr_create_save_to_dc_via_reg(dcontext_t *dcontext, reg_id_t basereg,
                                         reg_id_t reg, int offs);

--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -540,8 +540,8 @@ instr_set_num_opnds(dcontext_t *dcontext,
         if (instr_num_srcs > 1) {
             CLIENT_ASSERT(instr->num_srcs <= 1 && instr->srcs == NULL,
                           "instr_set_num_opnds: srcs are already set");
-            instr->srcs = (opnd_t *) heap_alloc(dcontext, (instr_num_srcs-1)*sizeof(opnd_t)
-                                              HEAPACCT(ACCT_IR));
+            instr->srcs = (opnd_t *)
+                heap_alloc(dcontext, (instr_num_srcs-1)*sizeof(opnd_t) HEAPACCT(ACCT_IR));
         }
         CLIENT_ASSERT_TRUNCATE(instr->num_srcs, byte, instr_num_srcs,
                                "instr_set_num_opnds: too many srcs");
@@ -1612,7 +1612,8 @@ instrlist_decode_cti(dcontext_t *dcontext, instrlist_t *ilist)
             instr_num_srcs(instr) > 0 && opnd_is_near_pc(instr_get_src(instr, 0))) {
             instr_t *tgt;
             DOLOG(4, LOG_ALL, {
-                loginst(dcontext, 4, instr, "instrlist_decode_cti: found cti w/ pc target");
+                loginst(dcontext, 4, instr,
+                        "instrlist_decode_cti: found cti w/ pc target");
             });
             for (tgt = instrlist_first(ilist); tgt != NULL; tgt = instr_get_next(tgt)) {
                 DOLOG(4, LOG_ALL, { loginst(dcontext, 4, tgt, "\tchecking"); });
@@ -1629,7 +1630,7 @@ instrlist_decode_cti(dcontext_t *dcontext, instrlist_t *ilist)
                     instr_set_target(instr, opnd_create_instr(tgt));
                     if (bits != 0)
                         instr_set_raw_bits(instr, bits, len);
-                    DOLOG(4, LOG_ALL, { loginst(dcontext, 4, tgt, "\tcti targets this"); });
+                    DOLOG(4, LOG_ALL, {loginst(dcontext, 4, tgt, "\tcti targets this");});
                     break;
                 }
             }
@@ -1750,9 +1751,10 @@ instr_uses_reg(instr_t *instr, reg_id_t reg)
 bool instr_reg_in_dst(instr_t *instr, reg_id_t reg)
 {
     int i;
-    for (i=0; i<instr_num_dsts(instr); i++)
+    for (i=0; i<instr_num_dsts(instr); i++) {
         if (opnd_uses_reg(instr_get_dst(instr, i), reg))
             return true;
+    }
     return false;
 }
 
@@ -2008,9 +2010,10 @@ instr_get_rel_addr_target(instr_t *instr, app_pc *target)
     /* PR 251479: we support rip-rel info in level 1 instrs */
     if (instr_rip_rel_valid(instr)) {
         if (instr_get_rip_rel_pos(instr) > 0) {
-            if (target != NULL)
+            if (target != NULL) {
                 *target = instr->bytes + instr->length +
                     *((int *)(instr->bytes + instr_get_rip_rel_pos(instr)));
+            }
             return true;
         } else
             return false;

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -595,7 +595,8 @@ check_for_stopping_point(dcontext_t *dcontext, build_bb_t *bb)
         instrlist_append(bb->ilist, XINST_CREATE_return(dcontext));
         /* should this be treated as a real return? */
         bb->exit_type |= LINK_INDIRECT | LINK_RETURN;
-        bb->exit_target = get_ibl_routine(dcontext, IBL_LINKED, DEFAULT_IBL_BB(), IBL_RETURN);
+        bb->exit_target =
+            get_ibl_routine(dcontext, IBL_LINKED, DEFAULT_IBL_BB(), IBL_RETURN);
         return true;
     }
 #endif /* DR_APP_EXPORTS */
@@ -2369,7 +2370,8 @@ is_targeting_convertible_IAT(dcontext_t *dcontext, instr_t *instr,
          * but even in the unlikely reference by address from another
          * module there is really no problem, so not worth checking
          */
-        ASSERT_CURIOSITY(get_module_base(instr->bytes) == get_module_base(memory_reference));
+        ASSERT_CURIOSITY(get_module_base(instr->bytes) ==
+                         get_module_base(memory_reference));
 
         /* FIXME: now that we know it is in IAT/GOT,
          * we have to READ the contents and return that
@@ -2607,7 +2609,8 @@ bb_process_IAT_convertible_indcall(dcontext_t *dcontext, build_bb_t *bb,
      * bb->instr and will remove bb->instr
      * FIXME: it would have been
      * better to replace in instrlist with a direct call and have
-     * mangle_{in,}direct_call use other than the raw bytes, but this for now does the job.
+     * mangle_{in,}direct_call use other than the raw bytes, but this for now does the
+     * job.
      */
     bb->instr->flags |= INSTR_IND_CALL_DIRECT;
 
@@ -3261,7 +3264,8 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
             my_dcontext->bb_build_info = (void *) bb;
         } else {
             /* For nested we leave the original, which should be the only vmlist,
-             * and we give up on freeing dangling instr_t and instrlist_t from this decode.
+             * and we give up on freeing dangling instr_t and instrlist_t from this
+             * decode.
              * We need the original's for_cache so we know to free the bb_building_lock.
              * FIXME: use TRY to handle decode exceptions locally?  Shouldn't have
              * violation remediations on a !for_cache build.
@@ -3773,8 +3777,8 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
                     normal_indirect_processing = false;
                     elide_and_continue_if_converted = true;
                 } else if (DYNAMO_OPTION(IAT_convert)
-                           && bb_process_IAT_convertible_indcall(dcontext, bb,
-                                                                 &elide_and_continue_if_converted)) {
+                           && bb_process_IAT_convertible_indcall
+                           (dcontext, bb, &elide_and_continue_if_converted)) {
                     normal_indirect_processing = false;
                 }
                 else
@@ -3795,7 +3799,8 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
                 /* indirect jump */
                 /* was prev instr a direct call? if so, this is a PLT-style ind call */
                 instr_t *prev = instr_get_prev(bb->instr);
-                if (prev != NULL && instr_opcode_valid(prev) && instr_is_call_direct(prev)) {
+                if (prev != NULL && instr_opcode_valid(prev) &&
+                    instr_is_call_direct(prev)) {
                     bb->exit_type |= INSTR_IND_JMP_PLT_EXIT;
                     /* just because we have a CALL to JMP* makes it
                        only a _likely_ PLT call, we still have to make
@@ -3807,8 +3812,8 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
                 elide_and_continue_if_converted = true;
 
                 if (DYNAMO_OPTION(IAT_convert)
-                    && bb_process_IAT_convertible_indjmp(dcontext, bb,
-                                                         &elide_and_continue_if_converted)) {
+                    && bb_process_IAT_convertible_indjmp
+                    (dcontext, bb, &elide_and_continue_if_converted)) {
                     /* Clear the IND_JMP_PLT_EXIT flag since we've converted
                      * the PLT to a direct transition (and possibly elided).
                      * Xref case 7867 for why leaving this flag in the eliding
@@ -4968,8 +4973,8 @@ at_native_exec_gateway(dcontext_t *dcontext, app_pc start, bool *is_call
             if (!xfer_target /* else we'll re-check at the target itself */ &&
                 !native_exec_bb && is_native_pc(start)) {
                 LOG(THREAD, LOG_INTERP|LOG_VMAREAS, 2,
-                    "WARNING: pc "PFX" is on native list but reached bypassing gateway!\n",
-                    start);
+                    "WARNING: pc "PFX" is on native list but reached bypassing "
+                    "gateway!\n", start);
                 STATS_INC(num_native_entrance_miss);
                 /* do-once since once get into dll past gateway may xfer
                  * through a bunch of lastexit-null or indjmp to same dll
@@ -5209,7 +5214,8 @@ recreate_bb_ilist(dcontext_t *dcontext, byte *pc, byte *pretend_pc, app_pc stop_
 {
     build_bb_t bb;
 
-    if (!is_readable_without_exception(pc, 4/* don't know full range -- just do simple check now */)) {
+    /* don't know full range -- just do simple check now */
+    if (!is_readable_without_exception(pc, 4)) {
         LOG(THREAD, LOG_INTERP, 3,
             "recreate_bb_ilist: cannot read memory at "PFX"\n", pc);
         return NULL;
@@ -5641,7 +5647,8 @@ tracelist_add(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where, instr_t 
 
 /* Combines instrlist_postinsert to ilist and the size calculation of the addition */
 static inline int
-tracelist_add_after(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where, instr_t *inst)
+tracelist_add_after(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
+                    instr_t *inst)
 {
     /* when we emit the trace we're going to call instr_length() on all instrs
      * anyway, and we'll re-use any memory allocated here for an encoding
@@ -6301,7 +6308,8 @@ fixup_last_cti(dcontext_t *dcontext, instrlist_t *trace,
                 exits_deleted++;
             } else if (instr_opcode_valid(inst) && instr_is_cti(inst)) {
                 LOG(THREAD, LOG_MONITOR, 3,
-                    "WARNING: deleting non-exit cti in unused tail of frag added to trace\n");
+                    "WARNING: deleting non-exit cti in unused tail of frag added to "
+                    "trace\n");
             }
             loginst(dcontext, 4, inst, "\tdeleting");
             instrlist_remove(trace, inst);
@@ -6375,23 +6383,25 @@ append_trace_speculate_last_ibl(dcontext_t *dcontext, instrlist_t *trace,
 
             added_size +=
                 tracelist_add(dcontext, trace, where,
-                              XINST_CREATE_store(dcontext,
-                                                 opnd_create_tls_slot(tls_stat_scratch_slot),
-                                                 opnd_create_reg(SCRATCH_REG2)));
+                              XINST_CREATE_store
+                              (dcontext, opnd_create_tls_slot(tls_stat_scratch_slot),
+                               opnd_create_reg(SCRATCH_REG2)));
             added_size +=
-                insert_increment_stat_counter(dcontext, trace, where,
-                                              &get_ibl_per_type_statistics(dcontext,
-                                                                           ibl_type.branch_type)
-                                              ->ib_trace_last_ibl_exit);
+                insert_increment_stat_counter
+                (dcontext, trace, where,
+                 &get_ibl_per_type_statistics(dcontext, ibl_type.branch_type)
+                 ->ib_trace_last_ibl_exit);
             added_size +=
                 tracelist_add(dcontext, trace, where,
-                              XINST_CREATE_load(dcontext,
-                                                opnd_create_reg(SCRATCH_REG2),
-                                                opnd_create_tls_slot(tls_stat_scratch_slot)));
+                              XINST_CREATE_load
+                              (dcontext, opnd_create_reg(SCRATCH_REG2),
+                               opnd_create_tls_slot(tls_stat_scratch_slot)));
         }
     });
 #endif
-    /* preinsert comparison before exit CTI, but increment of success statistics after it */
+    /* preinsert comparison before exit CTI, but increment of success
+     * statistics after it
+     */
 
     /* we need to compare to speculate_next_tag now */
     /* XCX holds value to match */
@@ -6406,7 +6416,8 @@ append_trace_speculate_last_ibl(dcontext_t *dcontext, instrlist_t *trace,
      *
      * continue:
      *                        <increment stats>
-     *                        <restore app ecx>  # see FIXME whether to go to prefix or do here
+     *                        # see FIXME whether to go to prefix or do here
+     *                        <restore app ecx>
      *    e9 cc aa dd 00       jmp speculate_next_tag
      *
      */
@@ -6423,16 +6434,16 @@ append_trace_speculate_last_ibl(dcontext_t *dcontext, instrlist_t *trace,
             /* XCX already saved */
 
             added_size +=
-                insert_increment_stat_counter(dcontext, trace, next,
-                                              &get_ibl_per_type_statistics(dcontext,
-                                                                           ibl_type.branch_type)
-                                              ->ib_trace_last_ibl_speculate_success);
+                insert_increment_stat_counter
+                (dcontext, trace, next,
+                 &get_ibl_per_type_statistics(dcontext, ibl_type.branch_type)
+                 ->ib_trace_last_ibl_speculate_success);
             /* restore XCX to app IB target*/
             added_size +=
                 tracelist_add(dcontext, trace, next,
-                              XINST_CREATE_load(dcontext,
-                                                opnd_create_reg(reg),
-                                                opnd_create_tls_slot(tls_stat_scratch_slot)));
+                              XINST_CREATE_load
+                              (dcontext, opnd_create_reg(reg),
+                               opnd_create_tls_slot(tls_stat_scratch_slot)));
         }
     });
 #endif
@@ -6521,24 +6532,28 @@ append_ib_trace_last_ibl_exit_stat(dcontext_t *dcontext, instrlist_t *trace,
 
     ASSERT(ok);
     added_size += tracelist_add(dcontext, trace, where,
-                                XINST_CREATE_store(dcontext,
-                                                   opnd_create_tls_slot(tls_stat_scratch_slot),
-                                                    opnd_create_reg(reg)));
+                                XINST_CREATE_store
+                                (dcontext,
+                                 opnd_create_tls_slot(tls_stat_scratch_slot),
+                                 opnd_create_reg(reg)));
     added_size +=
-        insert_increment_stat_counter(dcontext, trace, where,
-                                      &get_ibl_per_type_statistics(dcontext, ibl_type.branch_type)
-                                      ->ib_trace_last_ibl_exit);
+        insert_increment_stat_counter
+        (dcontext, trace, where,
+         &get_ibl_per_type_statistics(dcontext, ibl_type.branch_type)
+         ->ib_trace_last_ibl_exit);
     added_size += tracelist_add(dcontext, trace, where,
-                                XINST_CREATE_load(dcontext,
-                                                  opnd_create_reg(reg),
-                                                  opnd_create_tls_slot(tls_stat_scratch_slot)));
+                                XINST_CREATE_load
+                                (dcontext, opnd_create_reg(reg),
+                                 opnd_create_tls_slot(tls_stat_scratch_slot)));
 
     if (speculate_next_tag != NULL) {
         instr_t *next = instr_get_next(inst);
         reg_id_t reg = IF_X86_ELSE(REG_ECX, DR_REG_R2);
         /* preinsert comparison before exit CTI, but increment goes after it */
 
-        /* we need to compare to speculate_next_tag now - just like fixup_last_cti() would do later */
+        /* we need to compare to speculate_next_tag now - just like
+         * fixup_last_cti() would do later.
+         */
         /* ECX holds value to match here */
 
         /* leave jmp as it is, a jmp to exit stub (thence to ind br lookup) */
@@ -6547,22 +6562,24 @@ append_ib_trace_last_ibl_exit_stat(dcontext_t *dcontext, instrlist_t *trace,
          *    increment success counter
          *    jmp targeter
          *
-         *   FIXME: now the last instruction is no longer the exit_cti - see if that breaks any assumptions,
-         *   using a short jump to see if anyone erroneously uses this
+         *   FIXME: now the last instruction is no longer the exit_cti - see if that
+         *   breaks any assumptions, using a short jump to see if anyone erroneously
+         *   uses this
          */
         added_size +=
             insert_transparent_comparison(dcontext, trace, where, speculate_next_tag);
 
-        /* we'll kill again although ECX restored unnecessarily by comparison routine,   */
+        /* we'll kill again although ECX restored unnecessarily by comparison routine */
         added_size +=
-            insert_increment_stat_counter(dcontext, trace, next,
-                                          &get_ibl_per_type_statistics(dcontext, ibl_type.branch_type)
-                                          ->ib_trace_last_ibl_speculate_success);
+            insert_increment_stat_counter
+            (dcontext, trace, next,
+             &get_ibl_per_type_statistics(dcontext, ibl_type.branch_type)
+             ->ib_trace_last_ibl_speculate_success);
         /* restore ECX */
         added_size += tracelist_add(dcontext, trace, next,
-                                XINST_CREATE_load(dcontext,
-                                                  opnd_create_reg(reg),
-                                                  opnd_create_tls_slot(tls_stat_scratch_slot)));
+                                XINST_CREATE_load
+                                    (dcontext, opnd_create_reg(reg),
+                                     opnd_create_tls_slot(tls_stat_scratch_slot)));
         /* jmp where */
         added_size += tracelist_add(dcontext, trace, next,
                                     IF_X86_ELSE(INSTR_CREATE_jmp_short,
@@ -6669,7 +6686,7 @@ extend_trace(dcontext_t *dcontext, fragment_t *f, linkstub_t *prev_l)
 
     ASSERT(!instrlist_get_our_mangling(ilist));
     instrlist_append(trace, instrlist_first(ilist));
-    instrlist_init(ilist); /* clear fields so destroy won't kill instrs now on trace list */
+    instrlist_init(ilist); /* clear fields so destroy won't kill instrs on trace list */
     instrlist_destroy(dcontext, ilist);
 
     md->trace_buf_top += size;
@@ -7347,7 +7364,8 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/uint *
                     bool re_relativize = false;
                     bool intra_target = true;
                     DOLOG(DF_LOGLEVEL(dcontext), LOG_MONITOR, {
-                        loginst(dcontext, 4, instr, "decode_fragment: found non-exit cti");
+                        loginst(dcontext, 4, instr,
+                                "decode_fragment: found non-exit cti");
                     });
                     if (TEST(FRAG_FAKE, f->flags)) {
                         /* Case 8711: we don't know the size so we can't even
@@ -7425,7 +7443,8 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/uint *
                         instrlist_append(&intra_ctis, clone);
                         /* intra-fragment target */
                         DOLOG(DF_LOGLEVEL(dcontext), LOG_MONITOR, {
-                            loginst(dcontext, 4, instr, "\tcti has intra-fragment target");
+                            loginst(dcontext, 4, instr,
+                                    "\tcti has intra-fragment target");
                         });
                         /* since the resulting instrlist could be manipulated,
                          * we need to change the target operand from pc to instr_t.

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -1026,7 +1026,8 @@ mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags INOUT,
                  * as we want tight coupling w/ a pointer as a general way
                  * to store per-instr data outside of the instr itself.
                  */
-                for (tmp = instr_get_next(instr); tmp != NULL; tmp = instr_get_next(tmp)) {
+                for (tmp = instr_get_next(instr); tmp != NULL;
+                     tmp = instr_get_next(tmp)) {
                     if (tmp == ret) {
                         tmp->note = (void *) data->data[1]; /* the value to use */
                         break;

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -430,27 +430,27 @@ extern const reg_id_t dr_reg_fixer[];
 # endif
 /** Number of general registers */
 # define DR_NUM_GPR_REGS (DR_REG_STOP_GPR - DR_REG_START_GPR + 1)
-# define DR_REG_START_64    DR_REG_RAX  /**< Start of 64-bit general register enum values */
-# define DR_REG_STOP_64     DR_REG_R15  /**< End of 64-bit general register enum values */
-# define DR_REG_START_32    DR_REG_EAX  /**< Start of 32-bit general register enum values */
-# define DR_REG_STOP_32     DR_REG_R15D /**< End of 32-bit general register enum values */
-# define DR_REG_START_16    DR_REG_AX   /**< Start of 16-bit general register enum values */
-# define DR_REG_STOP_16     DR_REG_R15W /**< End of 16-bit general register enum values */
-# define DR_REG_START_8     DR_REG_AL   /**< Start of 8-bit general register enum values */
-# define DR_REG_STOP_8      DR_REG_DIL  /**< End of 8-bit general register enum values */
-# define DR_REG_START_8HL   DR_REG_AL   /**< Start of 8-bit high-low register enum values */
-# define DR_REG_STOP_8HL    DR_REG_BH   /**< End of 8-bit high-low register enum values */
-# define DR_REG_START_x86_8 DR_REG_AH   /**< Start of 8-bit x86-only register enum values */
-# define DR_REG_STOP_x86_8  DR_REG_BH   /**< Stop of 8-bit x86-only register enum values */
-# define DR_REG_START_x64_8 DR_REG_SPL  /**< Start of 8-bit x64-only register enum values */
-# define DR_REG_STOP_x64_8  DR_REG_DIL  /**< Stop of 8-bit x64-only register enum values */
+# define DR_REG_START_64   DR_REG_RAX /**< Start of 64-bit general register enum values */
+# define DR_REG_STOP_64    DR_REG_R15 /**< End of 64-bit general register enum values */
+# define DR_REG_START_32   DR_REG_EAX /**< Start of 32-bit general register enum values */
+# define DR_REG_STOP_32    DR_REG_R15D/**< End of 32-bit general register enum values */
+# define DR_REG_START_16   DR_REG_AX  /**< Start of 16-bit general register enum values */
+# define DR_REG_STOP_16    DR_REG_R15W/**< End of 16-bit general register enum values */
+# define DR_REG_START_8    DR_REG_AL  /**< Start of 8-bit general register enum values */
+# define DR_REG_STOP_8     DR_REG_DIL /**< End of 8-bit general register enum values */
+# define DR_REG_START_8HL  DR_REG_AL  /**< Start of 8-bit high-low register enum values */
+# define DR_REG_STOP_8HL   DR_REG_BH   /**< End of 8-bit high-low register enum values */
+# define DR_REG_START_x86_8 DR_REG_AH /**< Start of 8-bit x86-only register enum values */
+# define DR_REG_STOP_x86_8  DR_REG_BH /**< Stop of 8-bit x86-only register enum values */
+# define DR_REG_START_x64_8 DR_REG_SPL /**< Start of 8-bit x64-only register enum values*/
+# define DR_REG_STOP_x64_8  DR_REG_DIL /**< Stop of 8-bit x64-only register enum values */
 # define DR_REG_START_MMX   DR_REG_MM0  /**< Start of mmx register enum values */
 # define DR_REG_STOP_MMX    DR_REG_MM7  /**< End of mmx register enum values */
 # define DR_REG_START_XMM   DR_REG_XMM0 /**< Start of xmm register enum values */
 # define DR_REG_STOP_XMM    DR_REG_XMM15/**< End of xmm register enum values */
 # define DR_REG_START_YMM   DR_REG_YMM0 /**< Start of ymm register enum values */
 # define DR_REG_STOP_YMM    DR_REG_YMM15/**< End of ymm register enum values */
-# define DR_REG_START_FLOAT DR_REG_ST0  /**< Start of floating-point-register enum values */
+# define DR_REG_START_FLOAT DR_REG_ST0 /**< Start of floating-point-register enum values*/
 # define DR_REG_STOP_FLOAT  DR_REG_ST7  /**< End of floating-point-register enum values */
 # define DR_REG_START_SEGMENT DR_SEG_ES /**< Start of segment register enum values */
 # define DR_REG_STOP_SEGMENT  DR_SEG_GS /**< End of segment register enum values */

--- a/core/arch/opnd_shared.c
+++ b/core/arch/opnd_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -104,13 +104,16 @@ opnd_is_abs_base_disp(opnd_t opnd) {
     return (opnd_is_base_disp(opnd) && opnd_get_base(opnd) == REG_NULL &&
             opnd_get_index(opnd) == REG_NULL);
 }
-bool opnd_is_abs_addr(opnd_t opnd) {
+bool
+opnd_is_abs_addr(opnd_t opnd) {
     return IF_X64(opnd.kind == ABS_ADDR_kind ||) opnd_is_abs_base_disp(opnd);
 }
-bool opnd_is_near_abs_addr(opnd_t opnd) {
+bool
+opnd_is_near_abs_addr(opnd_t opnd) {
     return opnd_is_abs_addr(opnd) IF_X86(&& opnd.aux.segment == REG_NULL);
 }
-bool opnd_is_far_abs_addr(opnd_t opnd) {
+bool
+opnd_is_far_abs_addr(opnd_t opnd) {
     return IF_X86_ELSE(opnd_is_abs_addr(opnd) && opnd.aux.segment != REG_NULL,
                        false);
 }
@@ -211,7 +214,7 @@ opnd_add_flags(opnd_t opnd, dr_opnd_flags_t flags)
 opnd_size_t
 opnd_get_size(opnd_t opnd)
 {
-    switch(opnd.kind) {
+    switch (opnd.kind) {
     case REG_kind:
         return (opnd.size == 0 ? reg_get_size(opnd_get_reg(opnd)) : opnd.size);
     case IMMED_INTEGER_kind:
@@ -242,7 +245,7 @@ opnd_get_size(opnd_t opnd)
 void
 opnd_set_size(opnd_t *opnd, opnd_size_t newsize)
 {
-    switch(opnd->kind) {
+    switch (opnd->kind) {
     case IMMED_INTEGER_kind:
     case BASE_DISP_kind:
 #if defined(X64) || defined(ARM)
@@ -1197,7 +1200,8 @@ opnd_replace_reg(opnd_t *opnd, reg_id_t old_reg, reg_id_t new_reg)
  * are the same.
  * different from opnd_same b/c this routine ignores data size!
  */
-bool opnd_same_address(opnd_t op1, opnd_t op2)
+bool
+opnd_same_address(opnd_t op1, opnd_t op2)
 {
     if (op1.kind != op2.kind)
         return false;
@@ -1242,7 +1246,8 @@ bool opnd_same_address(opnd_t op1, opnd_t op2)
     return true;
 }
 
-bool opnd_same(opnd_t op1, opnd_t op2)
+bool
+opnd_same(opnd_t op1, opnd_t op2)
 {
     if (op1.kind != op2.kind)
         return false;
@@ -1317,7 +1322,8 @@ bool opnd_same(opnd_t op1, opnd_t op2)
     }
 }
 
-bool opnd_share_reg(opnd_t op1, opnd_t op2)
+bool
+opnd_share_reg(opnd_t op1, opnd_t op2)
 {
     switch (op1.kind) {
     case NULL_kind:
@@ -1369,7 +1375,8 @@ range_overlap(ptr_uint_t a1, ptr_uint_t a2, size_t s1, size_t s2)
  * Is conservative, so if both def and use are memory references,
  * will return true unless it can disambiguate them.
  */
-bool opnd_defines_use(opnd_t def, opnd_t use)
+bool
+opnd_defines_use(opnd_t def, opnd_t use)
 {
     switch (def.kind) {
     case NULL_kind:

--- a/core/arch/proc_shared.c
+++ b/core/arch/proc_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -138,18 +138,21 @@ proc_get_family(void)
     return cpu_info.family;
 }
 
-uint proc_get_type(void)
+uint
+proc_get_type(void)
 {
     return cpu_info.type;
 }
 
 /* FIXME: Add MODEL_ constants to proc.h?? */
-uint proc_get_model(void)
+uint
+proc_get_model(void)
 {
     return cpu_info.model;
 }
 
-uint proc_get_stepping(void)
+uint
+proc_get_stepping(void)
 {
     return cpu_info.stepping;
 }

--- a/core/arch/retcheck.c
+++ b/core/arch/retcheck.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -1109,7 +1109,8 @@ read_instruction(byte *pc, byte *orig_pc,
               /* i#1899: MPX puts repne prior to branches.  We ignore here until we have
                * full MPX decoding support (i#1312).
                */
-              info->type != OP_call && info->type != OP_call_ind && info->type != OP_ret &&
+              info->type != OP_call && info->type != OP_call_ind &&
+              info->type != OP_ret &&
               info->type != OP_jmp && info->type != OP_jmp_short &&
               !opc_is_cbr_arch(info->type)))) {
             char bytes[17*3];
@@ -2219,7 +2220,7 @@ unit_check_decode_ff_opcode() {
 
     for (modrm = 0x0; modrm < 0xff; modrm++) {
         raw_bytes[1] = modrm;
-        for(sib = 0x0; sib < 0xff; sib++) {
+        for (sib = 0x0; sib < 0xff; sib++) {
             raw_bytes[2] = sib;
 
             /* set up instr for decode_opcode */

--- a/core/arch/x86/encode.c
+++ b/core/arch/x86/encode.c
@@ -559,9 +559,11 @@ size_ok(decode_info_t *di/*prefixes field is IN/OUT; x86_mode is IN*/,
                 return !TEST(PREFIX_REX_W, di->prefixes);
             return false;
         case OPSZ_6:
-            if (size_template == OPSZ_6_irex10_short4)
+            if (size_template == OPSZ_6_irex10_short4) {
                 return !TEST(prefix_data_addr, di->prefixes) &&
-                    (!TEST(PREFIX_REX_W, di->prefixes) || proc_get_vendor() == VENDOR_AMD);
+                    (!TEST(PREFIX_REX_W, di->prefixes) ||
+                     proc_get_vendor() == VENDOR_AMD);
+            }
             if (size_template == OPSZ_12_rex40_short6) {
                 di->prefixes |= prefix_data_addr;
                 return true;
@@ -1672,7 +1674,8 @@ encode_base_disp(decode_info_t * di, opnd_t opnd)
                 encode_reg_ext_prefixes(di, base, PREFIX_REX_B);
                 if (X64_MODE(di) && reg_is_32bit(base)) {
                     CLIENT_ASSERT(index == REG_NULL ||
-                                  (reg_is_32bit(index) && TEST(PREFIX_ADDR, di->prefixes)),
+                                  (reg_is_32bit(index) &&
+                                   TEST(PREFIX_ADDR, di->prefixes)),
                                   "encode error: index and base must be same width");
                     di->prefixes |= PREFIX_ADDR;
                 }

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -704,7 +704,8 @@ instr_is_mov_constant(instr_t *instr, ptr_int_t *value)
     return false;
 }
 
-bool instr_is_prefetch(instr_t *instr)
+bool
+instr_is_prefetch(instr_t *instr)
 {
     int opcode = instr_get_opcode(instr);
 
@@ -1559,13 +1560,13 @@ instr_predicate_triggered(instr_t *instr, dr_mcontext_t *mc)
             /* The src can't involve a multimedia reg or VSIB */
             opnd_t src = instr_get_src(instr, 0);
             CLIENT_ASSERT(instr_num_srcs(instr) == 1, "invalid predicate/instr combo");
-            if (opnd_is_immed_int(src))
+            if (opnd_is_immed_int(src)) {
                 return (opnd_get_immed_int(src) != 0) ?
                     DR_PRED_TRIGGER_MATCH : DR_PRED_TRIGGER_MISMATCH;
-            else if (opnd_is_reg(src))
+            } else if (opnd_is_reg(src)) {
                 return (reg_get_value(opnd_get_reg(src), mc) != 0) ?
                     DR_PRED_TRIGGER_MATCH : DR_PRED_TRIGGER_MISMATCH;
-            else if (opnd_is_memory_reference(src)) {
+            } else if (opnd_is_memory_reference(src)) {
                 ptr_int_t val;
                 if (!safe_read(opnd_compute_address(src, mc),
                                MIN(opnd_get_size(src), sizeof(val)), &val))
@@ -1716,7 +1717,7 @@ instr_create_nbyte_nop(dcontext_t *dcontext, uint num_bytes, bool raw)
      * As a workaround, we call INSTR_CREATE_RAW_nop*byte here if in x86_to_x64.
      */
     if (raw IF_X64(|| DYNAMO_OPTION(x86_to_x64))) {
-        switch(num_bytes) {
+        switch (num_bytes) {
         case 1 :
             return INSTR_CREATE_RAW_nop1byte(dcontext);
         case 2 :
@@ -1725,7 +1726,7 @@ instr_create_nbyte_nop(dcontext_t *dcontext, uint num_bytes, bool raw)
             return INSTR_CREATE_RAW_nop3byte(dcontext);
         }
     } else {
-        switch(num_bytes) {
+        switch (num_bytes) {
         case 1 :
             return INSTR_CREATE_nop1byte(dcontext);
         case 2:
@@ -1766,7 +1767,8 @@ instr_is_nop(instr_t *inst)
         opnd_get_disp(instr_get_src(inst, 0)) == 0 &&
         ((opnd_get_base(instr_get_src(inst, 0)) == opnd_get_reg(instr_get_dst(inst, 0)) &&
           opnd_get_index(instr_get_src(inst, 0)) == REG_NULL) ||
-         (opnd_get_index(instr_get_src(inst, 0)) == opnd_get_reg(instr_get_dst(inst, 0)) &&
+         (opnd_get_index(instr_get_src(inst, 0)) ==
+          opnd_get_reg(instr_get_dst(inst, 0)) &&
           opnd_get_base(instr_get_src(inst, 0)) == REG_NULL &&
           opnd_get_scale(instr_get_src(inst, 0)) == 1)))
         return true;

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -1343,7 +1343,8 @@ insert_push_cs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
          * i#823 covers doing this more generally.
          */
         insert_push_retaddr(dcontext, ilist, instr,
-                            X64_MODE_DC(dcontext) ? CS64_SELECTOR : CS32_SELECTOR, opsize);
+                            X64_MODE_DC(dcontext) ? CS64_SELECTOR : CS32_SELECTOR,
+                            opsize);
     } else {
 #endif
         opnd_t stackop;
@@ -3357,7 +3358,8 @@ sandbox_rep_instr(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr, inst
         INSTR_CREATE_jcc(dcontext, OP_jle, opnd_create_instr(ok)));
     PRE(ilist, instr,
         INSTR_CREATE_lea(dcontext, opnd_create_reg(REG_XBX),
-                         opnd_create_base_disp(REG_NULL, REG_XCX, opndsize, 0, OPSZ_lea)));
+                         opnd_create_base_disp(REG_NULL, REG_XCX, opndsize, 0,
+                                               OPSZ_lea)));
     PRE(ilist, instr,
         INSTR_CREATE_neg(dcontext, opnd_create_reg(REG_XBX)));
     PRE(ilist, instr,
@@ -3398,7 +3400,8 @@ sandbox_rep_instr(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr, inst
 #endif
     /* instr goes here */
     PRE(ilist, next,
-        INSTR_CREATE_mov_ld(dcontext, opnd_create_reg(REG_XCX), opnd_create_reg(REG_XBX)));
+        INSTR_CREATE_mov_ld(dcontext, opnd_create_reg(REG_XCX),
+                            opnd_create_reg(REG_XBX)));
     PRE(ilist, next,
         RESTORE_FROM_DC_OR_TLS(dcontext, REG_XBX, TLS_XBX_SLOT, XBX_OFFSET));
     PRE(ilist, next,
@@ -4002,7 +4005,8 @@ insert_selfmod_sandbox(dcontext_t *dcontext, instrlist_t *ilist, uint flags,
                                 TEST(INSTR_IND_CALL_DIRECT, instr->flags)));
 
 
-                        LOG(THREAD, LOG_INTERP, 3, " ignoring CALL* at end of fragment\n");
+                        LOG(THREAD, LOG_INTERP, 3,
+                            " ignoring CALL* at end of fragment\n");
                         /* This test could be done outside of this loop on
                          * destinations, but since it is rare it is faster
                          * to do it here.  Using continue instead of break in case

--- a/core/arch/x86/x86_to_x64.c
+++ b/core/arch/x86/x86_to_x64.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -477,7 +477,8 @@ translate_into(dcontext_t *dcontext, instrlist_t *ilist, INOUT instr_t **instr)
 }
 
 static void
-translate_load_far_pointer(dcontext_t *dcontext, instrlist_t *ilist, INOUT instr_t **instr)
+translate_load_far_pointer(dcontext_t *dcontext, instrlist_t *ilist,
+                           INOUT instr_t **instr)
 {
     /* translate: les (src) -> dst, sreg => mov (src) -> r8w/r8d
      *                                      mov 2(src)/4(src) -> sreg

--- a/core/config.c
+++ b/core/config.c
@@ -307,13 +307,15 @@ process_config_line(char *line, config_info_t *cfg, bool app_specific, bool over
                 val != line + strlen(config_var[i])) {
                 if (cfg->query == NULL) { /* only complain about this process */
                     FATAL_USAGE_ERROR(ERROR_CONFIG_FILE_INVALID, 3,
-                                      get_application_name(), get_application_pid(), line);
+                                      get_application_name(), get_application_pid(),
+                                      line);
                     ASSERT_NOT_REACHED();
                 }
             } else if (!cfg->u.v->vals[i].has_value || overwrite) {
                 if (strlen(val + 1) >= BUFFER_SIZE_ELEMENTS(cfg->u.v->vals[i].val)) {
                     /* not FATAL so release build will continue */
-                    USAGE_ERROR("Config value for %s too long: truncating", config_var[i]);
+                    USAGE_ERROR("Config value for %s too long: truncating",
+                                config_var[i]);
                 }
                 strncpy(cfg->u.v->vals[i].val, val + 1,
                         BUFFER_SIZE_ELEMENTS(cfg->u.v->vals[i].val));

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -304,7 +304,8 @@ dispatch_enter_fcache_stats(dcontext_t *dcontext, fragment_t *targetf)
                 LOG(THREAD, LOG_DISPATCH, 1, " %s\n", buf);
             }
             if (!stack &&
-                (strstr(buf, "user32.dll") != NULL || strstr(buf, "USER32.DLL") != NULL)) {
+                (strstr(buf, "user32.dll") != NULL ||
+                 strstr(buf, "USER32.DLL") != NULL)) {
                 /* try to find who set up user32 callback */
                 dump_mcontext_callstack(dcontext);
             }
@@ -326,7 +327,7 @@ dispatch_enter_fcache_stats(dcontext_t *dcontext, fragment_t *targetf)
 # endif
 
     if (stats->loglevel >= 2 && (stats->logmask & LOG_DISPATCH) != 0) {
-        /* FIXME: this should use a different mask - and get printed at level 2 when turned on */
+        /* XXX: should use a different mask - and get printed at level 2 when turned on */
         DOLOG(4, LOG_DISPATCH, {
             dump_mcontext(get_mcontext(dcontext), THREAD, DUMP_NOT_XML); });
         DOLOG(6, LOG_DISPATCH, { dump_mcontext_callstack(dcontext); });
@@ -691,7 +692,8 @@ dispatch_enter_native(dcontext_t *dcontext)
         dcontext->next_tag = PC_AS_JMP_TGT(dr_get_isa_mode(dcontext),
                                            dcontext->native_exec_postsyscall);
         dcontext->native_exec_postsyscall = NULL;
-        LOG(THREAD, LOG_DISPATCH, 2, "Entry into native_exec after intercepted syscall\n");
+        LOG(THREAD, LOG_DISPATCH, 2,
+            "Entry into native_exec after intercepted syscall\n");
         /* restore state as though never came out for syscall */
         KSTOP_NOT_MATCHING_DC(dcontext, dispatch_num_exits);
 #ifdef KSTATS
@@ -808,7 +810,8 @@ dispatch_enter_dynamorio(dcontext_t *dcontext)
                    IF_WINDOWS_ELSE_0(dcontext->last_exit == get_asynch_linkstub()));
         }
     } else {
-        ASSERT(dcontext->last_exit != NULL); /* MUST be set, if only to a fake linkstub_t */
+        /* MUST be set, if only to a fake linkstub_t */
+        ASSERT(dcontext->last_exit != NULL);
         /* cache last_exit's fragment */
         dcontext->last_fragment = linkstub_fragment(dcontext, dcontext->last_exit);
 
@@ -878,7 +881,7 @@ dispatch_enter_dynamorio(dcontext_t *dcontext)
         if (exited_due_to_ni_syscall(dcontext)
             IF_CLIENT_INTERFACE(|| instrument_invoke_another_syscall(dcontext))) {
             handle_system_call(dcontext);
-            /* will return here if decided to skip the syscall; else, back to dispatch() */
+            /* will return here if decided to skip the syscall; else, back to dispatch */
         }
 #ifdef WINDOWS
         else if (TEST(LINK_CALLBACK_RETURN, dcontext->last_exit->flags)) {
@@ -987,7 +990,7 @@ dispatch_exit_fcache(dcontext_t *dcontext)
     /* case 7966: no distinction of islinking-ness for hotp_only & thin_client */
     ASSERT(RUNNING_WITHOUT_CODE_CACHE() || is_couldbelinking(dcontext));
 
-#if defined(WINDOWS) && defined (CLIENT_INTERFACE) && defined(DEBUG)
+#if defined(WINDOWS) && defined(CLIENT_INTERFACE) && defined(DEBUG)
     if (should_swap_teb_nonstack_fields()) {
         ASSERT(!is_dynamo_address(dcontext->app_fls_data));
         ASSERT(dcontext->app_fls_data == NULL ||
@@ -1041,7 +1044,8 @@ dispatch_exit_fcache(dcontext_t *dcontext)
          * also double checks the findings of the indirect lookup
          * routine
          */
-        if (dynamo_options.ret_after_call && TEST(LINK_RETURN, dcontext->last_exit->flags)) {
+        if (dynamo_options.ret_after_call &&
+            TEST(LINK_RETURN, dcontext->last_exit->flags)) {
             /* ret_after_call will raise a security violation on failure */
             SELF_PROTECT_LOCAL(dcontext, WRITABLE);
             ret_after_call_check(dcontext, dcontext->next_tag, src_tag);
@@ -1216,8 +1220,8 @@ dispatch_exit_fcache(dcontext_t *dcontext)
                 }
             } else {
                 LOG(THREAD, LOG_INTERP, 2,
-                    "Failed to delete/replace fragment at tag "PFX" because was already deleted",
-                    todo->tag);
+                    "Failed to delete/replace fragment at tag "PFX" because was already "
+                    "deleted\n", todo->tag);
             }
 
             HEAP_TYPE_FREE(dcontext, todo, client_todo_list_t, ACCT_CLIENT, UNPROTECTED);
@@ -1585,7 +1589,9 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
         if (exited_due_to_ni_syscall(dcontext)) {
             LOG(THREAD, LOG_DISPATCH, 2, " (block ends with syscall)");
             STATS_INC(num_exits_dir_syscall);
-            /* FIXME: it doesn't matter whether next_f exists or not we're still in a syscall  */
+            /* FIXME: it doesn't matter whether next_f exists or not we're still in "
+             * a syscall
+             */
             KSWITCH(num_exits_dir_syscall);
         }
 # ifdef WINDOWS
@@ -2214,7 +2220,8 @@ handle_callback_return(dcontext_t *dcontext)
      */
 
     /* make sure set the next_tag of prev_dcontext, not dcontext! */
-    set_fcache_target(prev_dcontext, (app_pc) get_do_callback_return_entry(prev_dcontext));
+    set_fcache_target(prev_dcontext,
+                      (app_pc) get_do_callback_return_entry(prev_dcontext));
     DOLOG(4, LOG_ASYNCH, {
         LOG(THREAD, LOG_ASYNCH, 3, "passing prev dcontext "PFX", next_tag "PFX":\n",
             prev_dcontext, prev_dcontext->next_tag);

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -163,8 +163,7 @@ int exiting_thread_count VAR_IN_SECTION(NEVER_PROTECTED_SECTION) = 0;
 /* This is unprotected to allow stats to be written while the data
  * segment is still protected (right now the only ones are selfmod stats)
  */
-static dr_statistics_t nonshared_stats VAR_IN_SECTION(NEVER_PROTECTED_SECTION)
-     = {{0},};
+static dr_statistics_t nonshared_stats VAR_IN_SECTION(NEVER_PROTECTED_SECTION) = {{0},};
 
 /* Each lock protects its corresponding datasec_start, datasec_end, and
  * datasec_writable variables.
@@ -597,7 +596,8 @@ dynamorio_app_init(void)
          * issue.
          */
         size = HASHTABLE_SIZE(ALL_THREADS_HASH_BITS) * sizeof(thread_record_t*);
-        all_threads = (thread_record_t**) global_heap_alloc(size HEAPACCT(ACCT_THREAD_MGT));
+        all_threads =
+            (thread_record_t**) global_heap_alloc(size HEAPACCT(ACCT_THREAD_MGT));
         memset(all_threads, 0, size);
         if (!INTERNAL_OPTION(nop_initial_bblock)
             IF_WINDOWS(|| !check_sole_thread())) /* some other thread is already here! */
@@ -668,7 +668,8 @@ dynamorio_app_init(void)
 
         if (SELF_PROTECT_ON_CXT_SWITCH) {
             protect_info = (protect_info_t *)
-                global_unprotected_heap_alloc(sizeof(protect_info_t) HEAPACCT(ACCT_OTHER));
+                global_unprotected_heap_alloc(sizeof(protect_info_t)
+                                              HEAPACCT(ACCT_OTHER));
             ASSIGN_INIT_LOCK_FREE(protect_info->lock, protect_info);
             protect_info->num_threads_unprot = 0; /* ENTERING_DR() below will inc to 1 */
             protect_info->num_threads_suspended = 0;
@@ -956,7 +957,8 @@ dynamo_shared_exit(thread_record_t *toexit /* must ==cur thread for Linux */
 
     if (SELF_PROTECT_ON_CXT_SWITCH) {
         DELETE_LOCK(protect_info->lock);
-        global_unprotected_heap_free(protect_info, sizeof(protect_info_t) HEAPACCT(ACCT_OTHER));
+        global_unprotected_heap_free(protect_info, sizeof(protect_info_t)
+                                     HEAPACCT(ACCT_OTHER));
     }
 
     /* call all component exit routines (CAUTION: order is important here) */
@@ -1373,7 +1375,7 @@ dynamo_process_exit(void)
      * beyond our death, we're not holding any systemwide locks, etc.
      */
 
-    /* It is not clear whether the Event Log service can handle well unterminated connections */
+    /* It is not clear whether the Event Log service handles unterminated connections */
 
     /* Do we need profile data for each thread?
      * Note that windows prof_pcs duplicates the thread walk in os_exit()
@@ -1423,11 +1425,12 @@ dynamo_process_exit(void)
                 continue;
 #endif
             /* FIXME: separate trace dump from rest of fragment cleanup code */
-            if (TRACEDUMP_ENABLED() IF_CLIENT_INTERFACE(|| true))
+            if (TRACEDUMP_ENABLED() IF_CLIENT_INTERFACE(|| true)) {
                 /* We always want to call this for CI builds so we can get the
                  * dr_fragment_deleted() callbacks.
                  */
                 fragment_thread_exit(threads[i]->dcontext);
+            }
 # ifdef UNIX
             if (INTERNAL_OPTION(profile_pcs))
                 pcprofile_thread_exit(threads[i]->dcontext);
@@ -1604,7 +1607,8 @@ create_new_dynamo_context(bool initial, byte *dstack_in, priv_mcontext_t *mc)
     }
     if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask)) {
         dcontext->upcontext.separate_upcontext =
-            global_unprotected_heap_alloc(sizeof(unprotected_context_t) HEAPACCT(ACCT_OTHER));
+            global_unprotected_heap_alloc(sizeof(unprotected_context_t)
+                                          HEAPACCT(ACCT_OTHER));
         /* don't need to initialize upcontext */
         LOG(GLOBAL, LOG_TOP, 2, "new dcontext="PFX", dcontext->upcontext="PFX"\n",
             dcontext, dcontext->upcontext.separate_upcontext);
@@ -1670,7 +1674,8 @@ void
 initialize_dynamo_context(dcontext_t *dcontext)
 {
     /* we can't just zero out the whole thing b/c we have persistent state
-     * (fields kept across callbacks, like dstack, module-private fields, next & prev, etc.)
+     * (fields kept across callbacks, like dstack, module-private fields, next &
+     * prev, etc.)
      */
     memset(dcontext->upcontext_ptr, 0, sizeof(unprotected_context_t));
     dcontext->initialized = true;
@@ -2269,8 +2274,10 @@ dynamo_thread_init(byte *dstack_in, priv_mcontext_t *mc
         dcontext->logfile = INVALID_FILE;
     }
     DOLOG(1, LOG_TOP|LOG_THREADS, {
-        LOG(THREAD, LOG_TOP|LOG_THREADS, 1, PRODUCT_NAME" built with: %s\n", DYNAMORIO_DEFINES);
-        LOG(THREAD, LOG_TOP|LOG_THREADS, 1, PRODUCT_NAME" built on: %s\n", dynamorio_buildmark);
+        LOG(THREAD, LOG_TOP|LOG_THREADS, 1,
+            PRODUCT_NAME" built with: %s\n", DYNAMORIO_DEFINES);
+        LOG(THREAD, LOG_TOP|LOG_THREADS, 1,
+            PRODUCT_NAME" built on: %s\n", dynamorio_buildmark);
     });
 
     LOG(THREAD, LOG_TOP|LOG_THREADS, 1,
@@ -3101,7 +3108,8 @@ dynamorio_unprotect(void)
      * it was protected lazily
      */
     mutex_unlock(&protect_info->lock);
-    LOG(GLOBAL, LOG_DISPATCH, 4, "dynamorio_unprotect thread="TIDFMT"\n", get_thread_id());
+    LOG(GLOBAL, LOG_DISPATCH, 4,
+        "dynamorio_unprotect thread="TIDFMT"\n", get_thread_id());
 }
 
 #ifdef DEBUG

--- a/core/emit.c
+++ b/core/emit.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -126,7 +126,7 @@ stress_test_recreate(dcontext_t *dcontext, fragment_t *f,
     });
 
     recreated_pc = recreate_app_pc(dcontext, body_end_pc, NULL/*for full test*/);
-    /* FIXME: we should figure out how to test each instruction, while knowing the app state */
+    /* FIXME: figure out how to test each instruction, while knowing the app state */
     LOG(THREAD, LOG_MONITOR, 2, "Testing recreating Fragment #%d recreated_pc="PFX"\n",
         GLOBAL_STAT(num_fragments), recreated_pc);
 
@@ -230,8 +230,9 @@ set_linkstub_fields(dcontext_t *dcontext, fragment_t *f, instrlist_t *ilist,
 
             if (is_indirect_branch_lookup_routine(dcontext, (cache_pc)target)) {
                 ASSERT(IF_WINDOWS_ELSE_0(is_shared_syscall_routine(dcontext, target)) ||
-                       is_ibl_routine_type(dcontext, (cache_pc)target,
-                                           extract_branchtype((ushort)instr_exit_branch_type(inst))));
+                       is_ibl_routine_type
+                       (dcontext, (cache_pc)target,
+                        extract_branchtype((ushort)instr_exit_branch_type(inst))));
                 /* this is a mangled form of an original indirect
                  * branch or is a mangled form of an indirect branch
                  * to a real native pc out of the fragment

--- a/core/fragment.h
+++ b/core/fragment.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -244,7 +244,7 @@ struct _fragment_t {
      * N.B.: byte is an unsigned char
      */
     byte      prefix_size;      /* size of prefix, after which is non-ind. br. entry */
-    byte      fcache_extra;     /* padding to fit in fcache slot, also includes the header */
+    byte      fcache_extra;     /* padding to fit in fcache slot; includes the header */
 
     cache_pc  start_pc;         /* very top of fragment's code, equals
                                  * entry point when indirect branch target */
@@ -379,17 +379,18 @@ typedef struct _private_trace_t {
 #ifdef HASHTABLE_STATISTICS
 /* Statistics written from the cache that must be allocated separately */
 typedef struct _unprot_ht_statistics_t {
-    /* Statistics for App mode indirect branch lookups. Useful only for trace table. */
-    /* These should be accessible by indirect_branch_lookup emitted routines. */
-    /* Should have the form <ibl_routine>_stats, and are per hash table per routine (and per thread) */
-    /* FIXME: These are in the hash table itself for easier access when sharing IBL routines */
-
+    /* Statistics for App mode indirect branch lookups. Useful only for trace table.
+     * These should be accessible by indirect_branch_lookup emitted routines.
+     * Should have the form <ibl_routine>_stats, and are per hash table per routine
+     * (and per thread).
+     * These are in the hash table itself for easier access when sharing IBL routines.
+     */
     hashtable_statistics_t trace_ibl_stats[IBL_BRANCH_TYPE_END];
     hashtable_statistics_t bb_ibl_stats[IBL_BRANCH_TYPE_END];
 
     /* FIXME: this should really go to arch/arch.c instead of here */
 # ifdef WINDOWS
-    hashtable_statistics_t shared_syscall_hit_stats; /* miss path is shared with trace_ibl */
+    hashtable_statistics_t shared_syscall_hit_stats; /* miss path shared with trace_ibl */
 #  endif
 } unprot_ht_statistics_t;
 #endif /* HASHTABLE_STATISTICS */
@@ -504,7 +505,7 @@ typedef struct _per_thread_t {
     /* used for unlinking other threads' caches for flushing */
     bool           could_be_linking;     /* accessing link data structs? */
     bool           wait_for_unlink;      /* should this thread wait at synch point? */
-    bool           about_to_exit;        /* is this thread about to exit, so no need to flush? */
+    bool           about_to_exit;        /* no need to flush if thread about to exit */
     bool           flush_queue_nonempty; /* is this thread's deletion queue nonempty? */
     event_t        waiting_for_unlink;   /* synch bet flusher and flushee */
     event_t        finished_with_unlink; /* ditto */

--- a/core/globals.h
+++ b/core/globals.h
@@ -57,18 +57,18 @@
 #  define WIN32_LEAN_AND_MEAN
 /* Exclude rarely-used stuff from Windows headers */
 
-/* Case 1167 - bumping up warning level to 4 - work in progress FIXME: */
-#pragma warning( disable : 4054) //from function pointer 'void (__cdecl *)(void )' to data pointer 'unsigned char *'
-#pragma warning( disable : 4100) //'envp' : unreferenced formal parameter
-#pragma warning( disable : 4127) //conditional expression is constant (majority of warnings - 2078)
-#pragma warning( disable : 4189) //'start_pc' : local variable is initialized but not referenced
-#pragma warning( disable : 4204) //nonstandard extension used : non-constant aggregate initializer
-#pragma warning( disable : 4210) //nonstandard extension used : function given file scope
-#pragma warning( disable : 4505) //unreferenced local function has been removed
-#pragma warning( disable : 4702) //unreachable code (should be disabled DEBUG=0, e.g. for INTERNAL_OPTION test)
+/* XXX Case 1167: work in progress: bumping up warning level to 4 */
+#pragma warning( disable : 4054) // from function pointer to data pointer
+#pragma warning( disable : 4100) // 'envp' : unreferenced formal parameter
+#pragma warning( disable : 4127) // conditional expr is constant (majority of warnings)
+#pragma warning( disable : 4189) // local variable is initialized but not referenced
+#pragma warning( disable : 4204) // nonstd extension: non-constant aggregate initializer
+#pragma warning( disable : 4210) // nonstd extension: function given file scope
+#pragma warning( disable : 4505) // unreferenced local function has been removed
+#pragma warning( disable : 4702) // unreachable code (DEBUG=0, for INTERNAL_OPTION test)
 #pragma warning( disable : 4324) // structure was padded due to __declspec(align())
 #pragma warning( disable : 4709) // comma operator within array index expression
-#pragma warning( disable : 4214) // nonstandard extension used : bit field types other than int
+#pragma warning( disable : 4214) // nonstd extension: bit field types other than int
 
 /**************************************************/
 /* warnings on compiling with VC 8.0, all on VC or PlatformSDK header files */
@@ -1077,7 +1077,8 @@ int our_vsscanf(const char *str, const char *fmt, va_list ap);
 const char * parse_int(const char *sp, uint64 *res_out, uint base, uint width,
                        bool is_signed);
 ssize_t
-utf16_to_utf8_size(const wchar_t *src, size_t max_chars, size_t *written/*unicode chars*/);
+utf16_to_utf8_size(const wchar_t *src, size_t max_chars,
+                   size_t *written/*unicode chars*/);
 #define sscanf our_sscanf
 
 /* string.c */

--- a/core/hashtable.c
+++ b/core/hashtable.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -471,7 +471,8 @@ print_hashtable_stats(dcontext_t *dcontext,
             /* indirect branch lookups */
             uint64 total_dynamic_ibs =
                 total_lookups + lookup_stats->ib_stay_on_trace_stat +
-                (DYNAMO_OPTION(speculate_last_exit) ? lookup_stats->ib_trace_last_ibl_speculate_success : 0);
+                (DYNAMO_OPTION(speculate_last_exit) ?
+                 lookup_stats->ib_trace_last_ibl_speculate_success : 0);
 
             /* FIXME: add ib_stay_on_trace_stat_ovfl here */
 
@@ -484,16 +485,20 @@ print_hashtable_stats(dcontext_t *dcontext,
                                     4, &lastexit_top, &lastexit_bottom);
                 divide_uint64_print(lookup_stats->ib_trace_last_ibl_speculate_success,
                                     total_dynamic_ibs, false,
-                                    4, &speculate_lastexit_top, &speculate_lastexit_bottom);
+                                    4, &speculate_lastexit_top,
+                                    &speculate_lastexit_bottom);
             }
 
             /* all percentages here relative to IB lookups */
-            /* ontrace is how often we stay on trace with respect to all indirect branches */
-            /* ontrace_fail is assuming IBL's that are not the last exit are due to ontrace failures */
+            /* ontrace is how often we stay on trace wrt all indirect branches */
+            /* ontrace_fail is assuming IBL's that are not the last exit are due to
+             * ontrace failures
+             */
             /* lastexit is how many are on last IBL when it is not speculated */
             /* lastexit_speculate is how many are speculatively hit (as of all IBs) */
             LOG(THREAD, LOG_FRAGMENT|LOG_STATS, 1,
-                "%s %s table %s%s stay on trace hit:%s %u, last_ibl: %u, ontrace%%=%u.%.4u, lastexit%%=%u.%.4u\n",
+                "%s %s table %s%s stay on trace hit:%s %u, last_ibl: %u, "
+                "ontrace%%=%u.%.4u, lastexit%%=%u.%.4u\n",
                 is_final_str, is_trace_str, lookup_routine_str, brtype_str,
                 lookup_stats->ib_stay_on_trace_stat_ovfl ? " OVFL" : "",
                 lookup_stats->ib_stay_on_trace_stat,
@@ -502,7 +507,8 @@ print_hashtable_stats(dcontext_t *dcontext,
                 lastexit_top, lastexit_bottom
                 );
             LOG(THREAD, LOG_FRAGMENT|LOG_STATS, 1,
-                "%s %s table %s%s last trace exit speculation hit: %u, lastexit_ontrace%%=%u.%.4u(%%IB)\n",
+                "%s %s table %s%s last trace exit speculation hit: %u, "
+                "lastexit_ontrace%%=%u.%.4u(%%IB)\n",
                 is_final_str, is_trace_str, lookup_routine_str, brtype_str,
                 lookup_stats->ib_trace_last_ibl_speculate_success,
                 speculate_lastexit_top, speculate_lastexit_bottom);
@@ -515,27 +521,33 @@ print_hashtable_stats(dcontext_t *dcontext,
             uint lastexit_ibl_top=0; uint lastexit_ibl_bottom=0;
             uint speculate_lastexit_ibl_top=0; uint speculate_lastexit_ibl_bottom=0;
 
-            uint64 total_dynamic_ibl_no_trace = total_lookups + lookup_stats->ib_trace_last_ibl_exit;
+            uint64 total_dynamic_ibl_no_trace =
+                total_lookups + lookup_stats->ib_trace_last_ibl_exit;
             if (total_dynamic_ibl_no_trace > 0) {
                 divide_uint64_print(lookup_stats->ib_trace_last_ibl_exit,
                                     total_dynamic_ibl_no_trace, false,
                                     4, &lastexit_ibl_top, &lastexit_ibl_bottom);
                 divide_uint64_print(lookup_stats->ib_trace_last_ibl_speculate_success,
                                     total_dynamic_ibl_no_trace, false,
-                                    4, &speculate_lastexit_ibl_top, &speculate_lastexit_ibl_bottom);
+                                    4, &speculate_lastexit_ibl_top,
+                                    &speculate_lastexit_ibl_bottom);
             }
 
             /* ib_trace_last_ibl_exit includes all ib_trace_last_ibl_speculate_success */
             divide_uint64_print(lookup_stats->ib_trace_last_ibl_speculate_success,
                                 lookup_stats->ib_trace_last_ibl_exit, false,
-                                4, &speculate_only_lastexit_top, &speculate_only_lastexit_bottom);
+                                4, &speculate_only_lastexit_top,
+                                &speculate_only_lastexit_bottom);
 
 
             LOG(THREAD, LOG_FRAGMENT|LOG_STATS, 1,
-                "%s %s table %s%s last trace exit speculation hit: %u, speculation miss: %u, lastexit%%=%u.%.4u(%%IBL), lastexit_succ%%=%u.%.4u(%%IBL), spec hit%%=%u.%.4u(%%last exit)\n",
+                "%s %s table %s%s last trace exit speculation hit: %u, speculation miss: "
+                "%u, lastexit%%=%u.%.4u(%%IBL), lastexit_succ%%=%u.%.4u(%%IBL), "
+                "spec hit%%=%u.%.4u(%%last exit)\n",
                 is_final_str, is_trace_str, lookup_routine_str, brtype_str,
                 lookup_stats->ib_trace_last_ibl_speculate_success,
-                lookup_stats->ib_trace_last_ibl_exit - lookup_stats->ib_trace_last_ibl_speculate_success,
+                lookup_stats->ib_trace_last_ibl_exit -
+                lookup_stats->ib_trace_last_ibl_speculate_success,
                 lastexit_ibl_top, lastexit_ibl_bottom,
                 speculate_lastexit_ibl_top, speculate_lastexit_ibl_bottom,
                 speculate_only_lastexit_top, speculate_only_lastexit_bottom

--- a/core/hashtable.h
+++ b/core/hashtable.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -140,7 +140,8 @@ typedef struct _hashtable_statistics_t {
      * FIXME: case 4817 where bb's could also cache one target
      * or see the CGO03 paper for multiple cached locations with similar stats
      */
-    uint ib_stay_on_trace_stat; /* hash table lookup avoided - cached single target location */
+    uint ib_stay_on_trace_stat; /* hash table lookup avoided - cached single target
+                                 * location */
     /* This is likely to overflow in many cases, yet 64-bit in cache
      * increment is too heavy weight, should instead save last value
      * assuming that some rare, yet common enough event happens
@@ -155,7 +156,8 @@ typedef struct _hashtable_statistics_t {
     /* case 4817: add counter on extra check for converting IB into conditional
      * and add its success rate
      */
-    uint ib_trace_last_ibl_speculate_success; /* stay-on-trace check success on last exit */
+    uint ib_trace_last_ibl_speculate_success; /* stay-on-trace check success on last
+                                               * exit */
     /* FIXME: add last and ovfl flag here as well */
 } hashtable_statistics_t;
 

--- a/core/lib/dr_stats.h
+++ b/core/lib/dr_stats.h
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -97,17 +98,22 @@ typedef struct _dr_statistics_t {
 /* Thread local statistics */
 typedef struct {
     thread_id_t thread_id;
-    mutex_t thread_stats_lock;    /* transactional stats, for multiple stats invariants to hold */
-    /* TODO: We may also want to print another threads's stats without necessarily halting it,
-     * TODO: add stat name##_delta, which should be applied as a batch to the safe to read values.
-     * The basic idea of transactional stats is that uncommitted changes are not visible to readers.
-     * Some invariants between statistics, i.e. A=B+C should hold at the dump/committed points.
+    /* transactional stats, for multiple stats invariants to hold */
+    mutex_t thread_stats_lock;
+    /* TODO: We may also want to print another threads's stats without
+     * necessarily halting it, TODO: add stat name##_delta, which
+     * should be applied as a batch to the safe to read values.  The
+     * basic idea of transactional stats is that uncommitted changes
+     * are not visible to readers.  Some invariants between
+     * statistics, i.e. A=B+C should hold at the dump/committed
+     * points.
      *
      * The plan is:
      *   1) delta accessed w/o lock only by the owning thread,
-     *   2) on dump any other thread which only reads the committed values while holding the commit lock,
-     *   3) The owning thread is the single writer to the committed values to apply the deltas,
-     *      while holding the commit lock.
+     *   2) on dump any other thread which only reads the committed
+     *     values while holding the commit lock,
+     *   3) The owning thread is the single writer to the committed
+     *      values to apply the deltas, while holding the commit lock.
      *
      * Used for other threads to be able to request thread local stats,
      * and also for the not fully explained self-interruption on linux?

--- a/core/lib/fortran.c
+++ b/core/lib/fortran.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -44,22 +45,26 @@
 #include "dr_app.h"
 
 #ifdef DR_APP_EXPORTS
-void drsetup_()
+void
+drsetup_()
 {
     dr_app_setup();
 }
 
-void drcleanup_()
+void
+drcleanup_()
 {
     dr_app_cleanup();
 }
 
-void drstart_()
+void
+drstart_()
 {
     dr_app_start();
 }
 
-void drstop_()
+void
+drstop_()
 {
     dr_app_stop();
 }

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -776,7 +776,8 @@ typedef enum {
     SYSLOG_ERROR       = 0x4,
     SYSLOG_CRITICAL    = 0x8,
     SYSLOG_NONE        = 0x0,
-    SYSLOG_ALL         = SYSLOG_INFORMATION | SYSLOG_WARNING | SYSLOG_ERROR | SYSLOG_CRITICAL
+    SYSLOG_ALL         = (SYSLOG_INFORMATION | SYSLOG_WARNING | SYSLOG_ERROR |
+                          SYSLOG_CRITICAL),
 } syslog_event_type_t;
 
 #define DYNAMO_OPTION(opt) (ASSERT_OWN_READWRITE_LOCK(IS_OPTION_STRING(opt), \
@@ -800,11 +801,14 @@ typedef enum {
 #else
   /* Use only for experimental non-release options,
      default value is assumed and command line options are ignored */
-  /* We could use IS_OPTION_INTERNAL(opt) ? to determine whether an option is defined as INTERNAL in
-     optionsx.h and have that be the only place to modify to transition between internal and external options.
-     The compiler should be able to eliminate the inappropriate part of the constant expression,
-     if the specific option is no longer defined as internal so we don't have to modify the code.
-     Still I'd rather have explicit uses of DYNAMO_OPTION or INTERNAL_OPTION for now.
+  /* We could use IS_OPTION_INTERNAL(opt) ? to determine whether an
+   * option is defined as INTERNAL in optionsx.h and have that be the
+   * only place to modify to transition between internal and external
+   * options.  The compiler should be able to eliminate the
+   * inappropriate part of the constant expression, if the specific
+   * option is no longer defined as internal so we don't have to
+   * modify the code.  Still I'd rather have explicit uses of
+   * DYNAMO_OPTION or INTERNAL_OPTION for now.
   */
 # define INTERNAL_OPTION(opt) DEFAULT_INTERNAL_OPTION_VALUE(opt)
 #endif /* EXPOSE_INTERNAL_OPTIONS */
@@ -1013,7 +1017,7 @@ typedef char liststring_t[MAX_LIST_OPTION_LENGTH];
 #define CAT_AND_TERMINATE(buf, str) do {        \
       strncat(buf, str, BUFFER_ROOM_LEFT(buf)); \
       NULL_TERMINATE_BUFFER(buf);               \
-  } while(0)
+  } while (0)
 
 
 /* platform-independent */
@@ -1166,7 +1170,8 @@ typedef char liststring_t[MAX_LIST_OPTION_LENGTH];
 #  define L_DYNAMORIO_VAR_CACHE_ROOT  L_EXPAND_LEVEL(DYNAMORIO_VAR_CACHE_ROOT)
 #  define L_DYNAMORIO_VAR_CACHE_SHARED L_EXPAND_LEVEL(DYNAMORIO_VAR_CACHE_SHARED)
 # ifdef HOT_PATCHING_INTERFACE
-#  define L_DYNAMORIO_VAR_HOT_PATCH_POLICIES  L_EXPAND_LEVEL(DYNAMORIO_VAR_HOT_PATCH_POLICIES)
+#  define L_DYNAMORIO_VAR_HOT_PATCH_POLICIES \
+                                        L_EXPAND_LEVEL(DYNAMORIO_VAR_HOT_PATCH_POLICIES)
 #  define L_DYNAMORIO_VAR_HOT_PATCH_MODES  L_EXPAND_LEVEL(DYNAMORIO_VAR_HOT_PATCH_MODES)
 # endif
 # ifdef PROCESS_CONTROL
@@ -1192,7 +1197,8 @@ typedef char liststring_t[MAX_LIST_OPTION_LENGTH];
 
 #  define EVENTLOG_REGISTRY_SUBKEY "System\\CurrentControlSet\\Services\\EventLog"
 #  define L_EVENTLOG_REGISTRY_SUBKEY L_EXPAND_LEVEL(EVENTLOG_REGISTRY_SUBKEY)
-#  define L_EVENTLOG_REGISTRY_KEY L"\\Registry\\Machine\\" L_EXPAND_LEVEL(EVENTLOG_REGISTRY_SUBKEY)
+#  define L_EVENTLOG_REGISTRY_KEY L"\\Registry\\Machine\\" \
+                                  L_EXPAND_LEVEL(EVENTLOG_REGISTRY_SUBKEY)
 #  define L_EVENT_LOG_KEY LCONCAT(L_EVENTLOG_REGISTRY_KEY,EVENTLOG_NAME)
 #  define L_EVENT_LOG_SUBKEY LCONCAT(L_EVENTLOG_REGISTRY_SUBKEY,EVENTLOG_NAME)
 #  define L_EVENT_LOG_NAME L_EXPAND_LEVEL(EVENTLOG_NAME)
@@ -1229,14 +1235,17 @@ typedef char liststring_t[MAX_LIST_OPTION_LENGTH];
 /* base root in global object namespace, not in BaseNamedObjects or Sessions */
 #  define DYNAMORIO_SHARED_OBJECT_BASE L("\\")L_EXPAND_LEVEL(COMPANY_NAME)
 /* shared object directory for shared DLL cache */
-#  define DYNAMORIO_SHARED_OBJECT_DIRECTORY LCONCAT(DYNAMORIO_SHARED_OBJECT_BASE, "SharedCache")
+#  define DYNAMORIO_SHARED_OBJECT_DIRECTORY LCONCAT(DYNAMORIO_SHARED_OBJECT_BASE,\
+                                                    "SharedCache")
 
 /* registry */
 #  define DYNAMORIO_REGISTRY_BASE_SUBKEY "Software\\" COMPANY_NAME "\\" PRODUCT_NAME
-#  define DYNAMORIO_REGISTRY_BASE L"\\Registry\\Machine\\Software\\" L_EXPAND_LEVEL(COMPANY_NAME)L("\\")L_EXPAND_LEVEL(PRODUCT_NAME)
+#  define DYNAMORIO_REGISTRY_BASE L"\\Registry\\Machine\\Software\\" \
+                       L_EXPAND_LEVEL(COMPANY_NAME)L("\\")L_EXPAND_LEVEL(PRODUCT_NAME)
 #  define DYNAMORIO_REGISTRY_HIVE HKEY_LOCAL_MACHINE
 #  define DYNAMORIO_REGISTRY_KEY    DYNAMORIO_REGISTRY_BASE_SUBKEY
-#  define L_DYNAMORIO_REGISTRY_KEY L"Software\\" L_EXPAND_LEVEL(COMPANY_NAME)L"\\" L_EXPAND_LEVEL(PRODUCT_NAME)
+#  define L_DYNAMORIO_REGISTRY_KEY L"Software\\" L_EXPAND_LEVEL(COMPANY_NAME)L"\\" \
+                                   L_EXPAND_LEVEL(PRODUCT_NAME)
 
 #  define INJECT_ALL_HIVE    HKEY_LOCAL_MACHINE
 #  define INJECT_ALL_KEY     "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows"
@@ -1259,7 +1268,8 @@ typedef char liststring_t[MAX_LIST_OPTION_LENGTH];
 #  define INJECT_HELPER_DLL2_NAME      "drearlyhelp2.dll"
 
 #  define DEBUGGER_INJECTION_HIVE       HKEY_LOCAL_MACHINE
-#  define DEBUGGER_INJECTION_KEY        "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options"
+#  define DEBUGGER_INJECTION_KEY \
+       "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options"
 #  define DEBUGGER_INJECTION_VALUE_NAME "Debugger"
 
 #  define DEBUGGER_INJECTION_HIVE_L       L"\\Registry\\Machine\\"

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -2824,7 +2824,8 @@ struct _module_data_t {
     version_number_t product_version; /**< product version number from .rsrc section */
     uint checksum; /**< module checksum from the PE headers */
     uint timestamp; /**< module timestamp from the PE headers */
-    size_t module_internal_size; /**< module internal size (from PE headers SizeOfImage) */
+    /** Module internal size (from PE headers SizeOfImage). */
+    size_t module_internal_size;
 #else
     bool contiguous;   /**< whether there are no gaps between segments */
     uint num_segments; /**< number of segments */

--- a/core/lib/kstatsx.h
+++ b/core/lib/kstatsx.h
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -84,10 +85,13 @@ KSTAT_DEF("in dispatch exit, BB2trace, ind target ...", num_exits_ind_bad_miss_b
 KSTAT_SUM("in dispatch exit, from BB", num_exits_ind_bad_miss_bb,
           num_exits_ind_bad_miss_bb2bb, num_exits_ind_bad_miss_bb2trace)
 
-KSTAT_DEF("in dispatch exit, trace2trace, ind target ...", num_exits_ind_bad_miss_trace2trace)
+KSTAT_DEF("in dispatch exit, trace2trace, ind target ...",
+          num_exits_ind_bad_miss_trace2trace)
 
-KSTAT_DEF("in dispatch exit, trace2BB not trace head, ind target", num_exits_ind_bad_miss_trace2bb_nth)
-KSTAT_DEF("in dispatch exit, trace2BB trace head, ind target", num_exits_ind_bad_miss_trace2bb_th)
+KSTAT_DEF("in dispatch exit, trace2BB not trace head, ind target",
+          num_exits_ind_bad_miss_trace2bb_nth)
+KSTAT_DEF("in dispatch exit, trace2BB trace head, ind target",
+          num_exits_ind_bad_miss_trace2bb_th)
 KSTAT_SUM("in dispatch exit, trace2BB, ind target ", num_exits_ind_bad_miss_trace2bb,
           num_exits_ind_bad_miss_trace2bb_nth, num_exits_ind_bad_miss_trace2bb_th)
 
@@ -121,7 +125,9 @@ KSTAT_DEF("in trace cache, [not propagated]", fcache_trace_trace)
 /* hard to SUM it up against either bb or trace only */
 KSTAT_DEF("in bb cache out from trace cache, [not propagated]", fcache_bb_trace)
 
-/* assuming we'll deal with lock contention separately we don't propagate this time to callers */
+/* assuming we'll deal with lock contention separately we don't
+ * propagate this time to callers
+ */
 KSTAT_DEF("wait event (+context switch) [not propagated]", wait_event)
 
 /* FIXME: we should add all critical section bodies as suggested in

--- a/core/link.c
+++ b/core/link.c
@@ -1079,7 +1079,8 @@ linkstubs_shift(dcontext_t *dcontext, fragment_t *f, ssize_t shift)
  * if mark_new_trace_head is false, this routine does not change any state.
  */
 bool
-is_linkable(dcontext_t *dcontext, fragment_t *from_f, linkstub_t *from_l, fragment_t *to_f,
+is_linkable(dcontext_t *dcontext, fragment_t *from_f, linkstub_t *from_l,
+            fragment_t *to_f,
             bool have_link_lock, bool mark_new_trace_head)
 {
     /* monitor_is_linkable is what marks trace heads, so must
@@ -1089,7 +1090,8 @@ is_linkable(dcontext_t *dcontext, fragment_t *from_f, linkstub_t *from_l, fragme
                              have_link_lock, mark_new_trace_head))
         return false;
     /* cannot link between shared and private caches
-     * N.B.: we assume this in other places, like our use of fragment_lookup_same_sharing()
+     * N.B.: we assume this in other places, like our use of
+     * fragment_lookup_same_sharing()
      * for linking, so if we change this we need to change more than this routine here
      */
     if ((from_f->flags & FRAG_SHARED) != (to_f->flags & FRAG_SHARED))

--- a/core/link.h
+++ b/core/link.h
@@ -168,7 +168,7 @@ struct _linkstub_t {
 
 #ifdef CUSTOM_EXIT_STUBS
     ushort         fixed_stub_offset;  /* offset in bytes of fixed part of exit stub from
-                                          stub_pc, which points to custom prefix of stub */
+                                        * stub_pc, which points to custom stub prefix */
 #endif
 };
 

--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -762,13 +762,14 @@ privload_print_modules(bool path, bool lock, char *buf, size_t bufsz, size_t *so
     if (lock)
         acquire_recursive_lock(&privload_lock);
     for (mod = modlist; mod != NULL; mod = mod->next) {
-        if (!mod->externally_loaded)
+        if (!mod->externally_loaded) {
             if (!print_to_buffer(buf, bufsz, sofar, "%s="PFX"\n",
                                  path ? mod->path : mod->name, mod->base)) {
                 if (lock)
                     release_recursive_lock(&privload_lock);
                 return false;
             }
+        }
     }
     if (lock)
         release_recursive_lock(&privload_lock);

--- a/core/moduledb.c
+++ b/core/moduledb.c
@@ -240,7 +240,9 @@ moduledb_process_image(const char *name, app_pc base, bool add)
 END_DATA_SECTION()
 
 static const char *const
-exempt_list_names[MODULEDB_EXEMPT_NUM_LISTS] = { "rct", "image", "dll2heap", "dll2stack" };
+exempt_list_names[MODULEDB_EXEMPT_NUM_LISTS] = {
+    "rct", "image", "dll2heap", "dll2stack"
+};
 
 void
 moduledb_init()
@@ -481,8 +483,8 @@ process_control_whitelist(const char *md5_hash)
          */
         if (IS_PROCESS_CONTROL_MATCHED(app_specific))
             return;
-        anonymous = process_control_match(md5_hash,
-                                          PARAM_STR(DYNAMORIO_VAR_ANON_PROCESS_WHITELIST));
+        anonymous = process_control_match
+            (md5_hash, PARAM_STR(DYNAMORIO_VAR_ANON_PROCESS_WHITELIST));
         if (IS_PROCESS_CONTROL_MATCHED(anonymous))
             return;
 

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -883,7 +883,8 @@ should_be_trace_head_internal_unsafe(dcontext_t *dcontext, fragment_t *from_f,
  * monitor structure, one that is not shared across call backs.
  */
 static uint
-should_be_trace_head_internal(dcontext_t *dcontext, fragment_t *from_f, linkstub_t *from_l,
+should_be_trace_head_internal(dcontext_t *dcontext, fragment_t *from_f,
+                              linkstub_t *from_l,
                               app_pc to_tag, uint to_flags, bool have_link_lock,
                               bool trace_sysenter_exit)
 {
@@ -1262,7 +1263,8 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
 
     if (DYNAMO_OPTION(speculate_last_exit)
 #ifdef HASHTABLE_STATISTICS
-        || INTERNAL_OPTION(speculate_last_exit_stats) || INTERNAL_OPTION(stay_on_trace_stats)
+        || INTERNAL_OPTION(speculate_last_exit_stats)
+        || INTERNAL_OPTION(stay_on_trace_stats)
 #endif
         ) {
         /* FIXME: speculation of last exit (case 4817) is currently
@@ -1536,7 +1538,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
         mutex_unlock(&trace_building_lock);
 
     RSTATS_INC(num_traces);
-    DOSTATS({ IF_X86_64(if (FRAG_IS_32(trace_f->flags)) STATS_INC(num_32bit_traces);) });
+    DOSTATS({IF_X86_64(if (FRAG_IS_32(trace_f->flags)) {STATS_INC(num_32bit_traces);})});
     STATS_ADD(num_bbs_in_all_traces, md->num_blks);
     STATS_TRACK_MAX(max_bbs_in_a_trace, md->num_blks);
     DOLOG(2, LOG_MONITOR, {
@@ -2092,12 +2094,15 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
         }
         end_trace = (end_trace ||
                      /* mangling may never use trace buffer memory but just in case */
-                     !make_room_in_trace_buffer(dcontext, add_size + prev_mangle_size, f));
+                     !make_room_in_trace_buffer(dcontext,
+                                                add_size + prev_mangle_size, f));
 
 #ifdef CUSTOM_TRACES
         if (end_trace && client == CUSTOM_TRACE_CONTINUE) {
             /* had to overide client, log */
-            LOG(THREAD, LOG_MONITOR, 2, PRODUCT_NAME" ignoring Client's decision to continue trace (cannot trace through next fragment), ending trace now\n");
+            LOG(THREAD, LOG_MONITOR, 2, PRODUCT_NAME" ignoring Client's decision to "
+                "continue trace (cannot trace through next fragment), ending trace "
+                "now\n");
         }
 #endif
 

--- a/core/nudge.c
+++ b/core/nudge.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -401,8 +401,10 @@ handle_nudge(dcontext_t *dcontext, nudge_arg_t *arg)
         TEST_ANY(NUDGE_GENERIC(policy)|NUDGE_GENERIC(mode)|NUDGE_GENERIC(lstats),
                  nudge_action_mask)) {
         hotp_nudge_update(nudge_action_mask &
-                          (NUDGE_GENERIC(policy)|NUDGE_GENERIC(mode)|NUDGE_GENERIC(lstats)));
-        nudge_action_mask &= ~(NUDGE_GENERIC(policy)|NUDGE_GENERIC(mode)|NUDGE_GENERIC(lstats));
+                          (NUDGE_GENERIC(policy)|NUDGE_GENERIC(mode)|
+                           NUDGE_GENERIC(lstats)));
+        nudge_action_mask &= ~(NUDGE_GENERIC(policy)|NUDGE_GENERIC(mode)|
+                               NUDGE_GENERIC(lstats));
     }
 #endif
 #ifdef PROGRAM_SHEPHERDING

--- a/core/options.c
+++ b/core/options.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -107,7 +107,8 @@ static void ignore_varargs_function(char *format, ...) { }
 
 #ifndef EXPOSE_INTERNAL_OPTIONS
 /* default values for internal options are kept in a separate struct */
-#  define OPTION_COMMAND_INTERNAL(type, name, default_value, command_line_option, statement, description, flag, pcache) default_value,
+#  define OPTION_COMMAND_INTERNAL(type, name, default_value, command_line_option, \
+                                  statement, description, flag, pcache) default_value,
 #  define OPTION_COMMAND(type, name, default_value, command_line_option, \
                          statement, description, flag, pcache) /* nothing */
 /* read only source for default internal option values and names
@@ -134,7 +135,8 @@ const internal_options_t default_internal_options = {
    in other object files since more option fields need longer than 8-bit offsets)
    For now we can live without this.
 */
-#  define OPTION_COMMAND_INTERNAL(type, name, default_value, command_line_option, statement, description, flag, pcache) /* nothing, */
+#  define OPTION_COMMAND_INTERNAL(type, name, default_value, command_line_option, \
+                                  statement, description, flag, pcache) /* nothing, */
 #endif
 
 
@@ -232,17 +234,21 @@ adjust_defaults_for_page_size(options_t *options)
 CORE_STATIC void
 set_dynamo_options_defaults(options_t *options)
 {
-    ASSERT_OWN_OPTIONS_LOCK(options==&dynamo_options || options==&temp_options, &options_lock);
+    ASSERT_OWN_OPTIONS_LOCK(options==&dynamo_options || options==&temp_options,
+                            &options_lock);
     *options = default_options;
     adjust_defaults_for_page_size(options);
 }
 #undef OPTION_COMMAND_INTERNAL
 
-/* For all other purposes OPTION_COMMAND_INTERNAL should be equivalent to either OPTION_COMMAND or nothing */
+/* For all other purposes OPTION_COMMAND_INTERNAL should be equivalent
+ * to either OPTION_COMMAND or nothing.
+ */
 #ifdef EXPOSE_INTERNAL_OPTIONS
 #  define OPTION_COMMAND_INTERNAL OPTION_COMMAND
 #else
-#  define OPTION_COMMAND_INTERNAL(type, name, default_value, command_line_option, statement, description, flag, pcache) /* nothing */
+#  define OPTION_COMMAND_INTERNAL(type, name, default_value, command_line_option, \
+                                  statement, description, flag, pcache) /* nothing */
 #endif
 
 /* PARSING HANDLER */
@@ -516,7 +522,8 @@ set_dynamo_options_common(options_t *options, const char *optstr, bool for_this_
     if (optstr == NULL)
         return 0;
 
-    ASSERT_OWN_OPTIONS_LOCK(options==&dynamo_options || options==&temp_options, &options_lock);
+    ASSERT_OWN_OPTIONS_LOCK(options==&dynamo_options || options==&temp_options,
+                            &options_lock);
     ASSERT(!OPTIONS_PROTECTED());
     prev_pos = pos;
     while ((opt = getword(optstr, &pos, wordbuffer, sizeof(wordbuffer))) != NULL) {
@@ -633,8 +640,10 @@ PRINT_STRING_uint(char *optionbuff, uint value, const char *option)
     snprintf(optionbuff, MAX_OPTION_LENGTH, "-%s %d ", option, (value))
 #define PRINT_STRING_uint_addr(optionbuff,value,option) \
     snprintf(optionbuff, MAX_OPTION_LENGTH, "-%s "PFX" ", option, (value));
-#define PRINT_STRING_pathstring_t(optionbuff,value,option) snprintf(optionbuff, MAX_OPTION_LENGTH, "-%s '%s' ", option, (value));
-#define PRINT_STRING_liststring_t(optionbuff,value,option) snprintf(optionbuff, MAX_OPTION_LENGTH, "-%s '%s' ", option, (value));
+#define PRINT_STRING_pathstring_t(optionbuff,value,option) \
+    snprintf(optionbuff, MAX_OPTION_LENGTH, "-%s '%s' ", option, (value));
+#define PRINT_STRING_liststring_t(optionbuff,value,option) \
+    snprintf(optionbuff, MAX_OPTION_LENGTH, "-%s '%s' ", option, (value));
 
 
 #define DIFF_bool(value1,value2) ( value1 != value2 )
@@ -745,7 +754,8 @@ update_dynamic_options(options_t *options, options_t *new_options)
 {
     int updated = 0;
 
-    ASSERT_OWN_OPTIONS_LOCK(options==&dynamo_options || options==&temp_options, &options_lock);
+    ASSERT_OWN_OPTIONS_LOCK(options==&dynamo_options || options==&temp_options,
+                            &options_lock);
     ASSERT(!OPTIONS_PROTECTED());
 
 #define OPTION_COMMAND(type, name, default_value,                       \
@@ -766,7 +776,8 @@ update_dynamic_options(options_t *options, options_t *new_options)
                                         command_line_option);           \
                     NULL_TERMINATE_BUFFER(new_optionbuff);              \
                     LOG(GLOBAL, LOG_TOP, 2,                             \
-                        "Updating dynamic options : Ignoring static option change (%.*s changed to %.*s)\n",                                              \
+                        "Updating dynamic options : Ignoring static option change "\
+                        "(%.*s changed to %.*s)\n",                     \
                         MAX_LOG_LENGTH/2-80, optionbuff,                \
                         MAX_LOG_LENGTH/2-80, new_optionbuff);           \
                 }                                                       \
@@ -909,13 +920,15 @@ check_option_compatibility_helper(int recurse_count)
     }
     if (!INTERNAL_OPTION(inline_calls) && !DYNAMO_OPTION(disable_traces)) {
         /* cannot disable inlining of calls and build traces (currently) */
-        USAGE_ERROR("-no_inline_calls not compatible with -disable_traces, setting to default");
+        USAGE_ERROR("-no_inline_calls not compatible with -disable_traces, setting "
+                    "to default");
         SET_DEFAULT_VALUE(inline_calls);
         SET_DEFAULT_VALUE(disable_traces);
         changed_options = true;
     }
     if (INTERNAL_OPTION(tracedump_binary) && INTERNAL_OPTION(tracedump_text)) {
-        USAGE_ERROR("Cannot set both -tracedump_binary and -tracedump_text, setting to default");
+        USAGE_ERROR("Cannot set both -tracedump_binary and -tracedump_text, setting "
+                    "to default");
         SET_DEFAULT_VALUE(tracedump_binary);
         SET_DEFAULT_VALUE(tracedump_text);
         changed_options = true;
@@ -967,7 +980,7 @@ check_option_compatibility_helper(int recurse_count)
 #endif /* EXPOSE_INTERNAL_OPTIONS */
 
     if (!ALIGNED(DYNAMO_OPTION(stack_size), PAGE_SIZE)) {
-        USAGE_ERROR("-stack_size must be at least 12K and a multiple of the page size (4k)");
+        USAGE_ERROR("-stack_size must be at least 12K and a multiple of the page size");
         SET_DEFAULT_VALUE(stack_size);
         changed_options = true;
     }
@@ -985,7 +998,8 @@ check_option_compatibility_helper(int recurse_count)
         && INTERNAL_OPTION(code_api)
 # endif
         ) {
-        USAGE_ERROR("-pad_jmps isn't safe with code_api or on Linux without -pad_jmps_mark_no_trace when traces are enabled");
+        USAGE_ERROR("-pad_jmps isn't safe with code_api or on Linux without "
+                    "-pad_jmps_mark_no_trace when traces are enabled");
     }
 #endif
 
@@ -1029,7 +1043,8 @@ check_option_compatibility_helper(int recurse_count)
     /* FIXME: better way to enforce these incompatibilities w/ certain builds
      * than by turning off protection?  Should we halt instead?
      */
-    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask) && SHARED_FRAGMENTS_ENABLED()) {
+    if (TEST(SELFPROT_DCONTEXT, dynamo_options.protect_mask) &&
+        SHARED_FRAGMENTS_ENABLED()) {
         /* FIXME: get all shared gen routines to properly handle unprotected_context_t */
         USAGE_ERROR("Shared cache does not support protecting dcontext yet");
         dynamo_options.protect_mask &= ~SELFPROT_DCONTEXT;
@@ -1118,12 +1133,14 @@ check_option_compatibility_helper(int recurse_count)
             changed_options = true;
         }
         if (!DYNAMO_OPTION(shared_trace_ibl_routine)) {
-            SYSLOG_INTERNAL_INFO("-shared_traces requires -shared_trace_ibl_routine, enabling");
+            SYSLOG_INTERNAL_INFO("-shared_traces requires -shared_trace_ibl_routine, "
+                                 "enabling");
             dynamo_options.shared_trace_ibl_routine = true;
             changed_options = true;
         }
         if (!DYNAMO_OPTION(atomic_inlined_linking)) {
-            SYSLOG_INTERNAL_INFO("-shared_traces requires -atomic_inlined_linking, enabling");
+            SYSLOG_INTERNAL_INFO("-shared_traces requires -atomic_inlined_linking, "
+                                 "enabling");
             dynamo_options.atomic_inlined_linking = true;
             changed_options = true;
         }
@@ -1131,14 +1148,16 @@ check_option_compatibility_helper(int recurse_count)
 #ifdef EXPOSE_INTERNAL_OPTIONS
 # ifdef DEADLOCK_AVOIDANCE
     if (INTERNAL_OPTION(mutex_callstack) > MAX_MUTEX_CALLSTACK) {
-        USAGE_ERROR("-mutex_callstack is compiled with MAX_MUTEX_CALLSTACK=%d", MAX_MUTEX_CALLSTACK);
+        USAGE_ERROR("-mutex_callstack is compiled with MAX_MUTEX_CALLSTACK=%d",
+                    MAX_MUTEX_CALLSTACK);
         dynamo_options.mutex_callstack = MAX_MUTEX_CALLSTACK;
         changed_options = true;
     }
 # endif
     if (INTERNAL_OPTION(unsafe_ignore_eflags_ibl) &&
         !INTERNAL_OPTION(unsafe_ignore_eflags_prefix)) {
-        USAGE_ERROR("-unsafe_ignore_eflags_ibl requires -unsafe_ignore_eflags_prefix, enabling");
+        USAGE_ERROR("-unsafe_ignore_eflags_ibl requires -unsafe_ignore_eflags_prefix, "
+                    "enabling");
         dynamo_options.unsafe_ignore_eflags_prefix = true;
         changed_options = true;
     }
@@ -1170,7 +1189,8 @@ check_option_compatibility_helper(int recurse_count)
         changed_options = true;
     }
     if (DYNAMO_OPTION(reset_at_commit_percent_free_limit) > 100) {
-        USAGE_ERROR("-reset_at_commit_percent_free_limit is percentage value, can't be > 100");
+        USAGE_ERROR("-reset_at_commit_percent_free_limit is percentage value, can't "
+                    "be > 100");
         dynamo_options.reset_at_commit_percent_free_limit = 100;
         changed_options = true;
     }
@@ -1264,14 +1284,16 @@ check_option_compatibility_helper(int recurse_count)
     /* We need private_ib_in_tls for shared BB IBTs. */
     if (DYNAMO_OPTION(bb_ibl_targets) && DYNAMO_OPTION(shared_bbs) &&
         !DYNAMO_OPTION(private_ib_in_tls)) {
-        SYSLOG_INTERNAL_INFO("-bb_ibl_targets w/traces requires -private_ib_in_tls, enabling");
+        SYSLOG_INTERNAL_INFO("-bb_ibl_targets w/traces requires -private_ib_in_tls, "
+                             "enabling");
         dynamo_options.private_ib_in_tls = true;
         changed_options = true;
     }
     /* We need shared tables for shared BB IBTs when trace building is on. */
     if (DYNAMO_OPTION(bb_ibl_targets) && DYNAMO_OPTION(shared_bbs) &&
         !DYNAMO_OPTION(disable_traces) && !DYNAMO_OPTION(shared_bb_ibt_tables)) {
-        SYSLOG_INTERNAL_INFO("-bb_ibl_targets -shared_bbs w/traces requires -shared_bb_ibt_tables, enabling");
+        SYSLOG_INTERNAL_INFO("-bb_ibl_targets -shared_bbs w/traces requires "
+                             "-shared_bb_ibt_tables, enabling");
         dynamo_options.shared_bb_ibt_tables = true;
         changed_options = true;
     }
@@ -1282,7 +1304,9 @@ check_option_compatibility_helper(int recurse_count)
     if (DYNAMO_OPTION(bb_ibl_targets) && !DYNAMO_OPTION(disable_traces) &&
         DYNAMO_OPTION(bb_ibt_table_includes_traces) &&
         DYNAMO_OPTION(shared_bb_ibt_tables) && !DYNAMO_OPTION(shared_traces)) {
-        SYSLOG_INTERNAL_INFO("-bb_ibt_table_includes_traces -shared_bb_ibt_tables requires -shared_traces, disabling -bb_ibt_table_includes_traces");
+        SYSLOG_INTERNAL_INFO("-bb_ibt_table_includes_traces -shared_bb_ibt_tables "
+                             "requires -shared_traces, disabling "
+                             "-bb_ibt_table_includes_traces");
         dynamo_options.bb_ibt_table_includes_traces = false;
         changed_options = true;
     }
@@ -1290,8 +1314,10 @@ check_option_compatibility_helper(int recurse_count)
      * the BB IBT table, BBs & traces must use the same type of prefix. */
     if (DYNAMO_OPTION(bb_ibl_targets) && !DYNAMO_OPTION(disable_traces) &&
         DYNAMO_OPTION(bb_ibt_table_includes_traces) &&
-        (DYNAMO_OPTION(trace_single_restore_prefix) != DYNAMO_OPTION(bb_single_restore_prefix))) {
-        SYSLOG_INTERNAL_INFO("For -bb_ibl_targets -bb_ibt_table_includes_traces, traces & BBs must use identical prefixes");
+        (DYNAMO_OPTION(trace_single_restore_prefix) !=
+         DYNAMO_OPTION(bb_single_restore_prefix))) {
+        SYSLOG_INTERNAL_INFO("For -bb_ibl_targets -bb_ibt_table_includes_traces, "
+                             "traces & BBs must use identical prefixes");
         /* FIXME We could either set trace_single_restore_prefix and
          * bb_single_restore_prefix to the same value or use
          * -no_bb_ibt_table_includes_traces. For now, we do the latter as
@@ -1309,7 +1335,8 @@ check_option_compatibility_helper(int recurse_count)
          * to disable it when shared_deletion is off -- but don't yell at user so
          * not a USAGE_ERROR, simply an info event
          */
-        SYSLOG_INTERNAL_INFO("-syscalls_synch_flush requires -shared_deletion, disabling");
+        SYSLOG_INTERNAL_INFO("-syscalls_synch_flush requires -shared_deletion, "
+                             "disabling");
         dynamo_options.syscalls_synch_flush = false;
         changed_options = true;
     }
@@ -1318,8 +1345,10 @@ check_option_compatibility_helper(int recurse_count)
         dynamo_options.free_private_stubs = false;
         changed_options = true;
     }
-    if (DYNAMO_OPTION(unsafe_free_shared_stubs) && !DYNAMO_OPTION(separate_shared_stubs)) {
-        USAGE_ERROR("-unsafe_free_shared_stubs requires -separate_shared_stubs, disabling");
+    if (DYNAMO_OPTION(unsafe_free_shared_stubs) &&
+        !DYNAMO_OPTION(separate_shared_stubs)) {
+        USAGE_ERROR("-unsafe_free_shared_stubs requires -separate_shared_stubs, "
+                    "disabling");
         dynamo_options.unsafe_free_shared_stubs = false;
         changed_options = true;
     }
@@ -1357,7 +1386,8 @@ check_option_compatibility_helper(int recurse_count)
     if ((DYNAMO_OPTION(finite_shared_bb_cache) ||
          DYNAMO_OPTION(finite_shared_trace_cache)) &&
         !DYNAMO_OPTION(cache_shared_free_list)) {
-        USAGE_ERROR("-finite_shared_{bb,trace}_cache requires -cache_shared_free_list, enabling");
+        USAGE_ERROR("-finite_shared_{bb,trace}_cache requires -cache_shared_free_list, "
+                    "enabling");
         dynamo_options.cache_shared_free_list = true;
         changed_options = true;
     }
@@ -1371,7 +1401,8 @@ check_option_compatibility_helper(int recurse_count)
 #ifdef WINDOWS
     if (DYNAMO_OPTION(shared_fragment_shared_syscalls) &&
         !DYNAMO_OPTION(shared_syscalls)) {
-        SYSLOG_INTERNAL_INFO("-shared_fragment_shared_syscalls requires -shared_syscalls, disabling");
+        SYSLOG_INTERNAL_INFO("-shared_fragment_shared_syscalls requires "
+                             "-shared_syscalls, disabling");
         dynamo_options.shared_fragment_shared_syscalls = false;
         changed_options = true;
     }
@@ -1383,7 +1414,8 @@ check_option_compatibility_helper(int recurse_count)
         changed_options = true;
     }
     if (DYNAMO_OPTION(x86_to_x64_ibl_opt) && !DYNAMO_OPTION(x86_to_x64)) {
-        SYSLOG_INTERNAL_INFO("-x86_to_x64 is required for x86_to_x64_ibl_opt. disabling -x86_to_x64_ibl_opt.");
+        SYSLOG_INTERNAL_INFO("-x86_to_x64 is required for x86_to_x64_ibl_opt. "
+                             "Disabling -x86_to_x64_ibl_opt.");
         dynamo_options.x86_to_x64_ibl_opt = false;
         changed_options = true;
     }
@@ -1393,13 +1425,15 @@ check_option_compatibility_helper(int recurse_count)
     if (SHARED_FRAGMENTS_ENABLED() &&
         DYNAMO_OPTION(shared_syscalls) &&
         !DYNAMO_OPTION(shared_fragment_shared_syscalls)) {
-        SYSLOG_INTERNAL_INFO("-shared_{bbs|traces} w/-shared_syscalls requires -shared_fragment_shared_syscalls, enabling");
+        SYSLOG_INTERNAL_INFO("-shared_{bbs|traces} w/-shared_syscalls requires "
+                             "-shared_fragment_shared_syscalls, enabling");
         dynamo_options.shared_fragment_shared_syscalls = true;
         changed_options = true;
     }
     if (SHARED_IBT_TABLES_ENABLED() && DYNAMO_OPTION(shared_syscalls) &&
         !DYNAMO_OPTION(shared_fragment_shared_syscalls)) {
-        SYSLOG_INTERNAL_INFO("-shared_{bb|trace}_ibt_tables requires -shared_fragment_shared_syscalls, enabling");
+        SYSLOG_INTERNAL_INFO("-shared_{bb|trace}_ibt_tables requires "
+                             "-shared_fragment_shared_syscalls, enabling");
         dynamo_options.shared_fragment_shared_syscalls = true;
         changed_options = true;
     }
@@ -1412,7 +1446,8 @@ check_option_compatibility_helper(int recurse_count)
     if (DYNAMO_OPTION(shared_fragment_shared_syscalls) &&
         /* x64 uses -shared_fragment_shared_syscalls always */
         IF_X64_ELSE(false, !SHARED_FRAGMENTS_ENABLED())) {
-        SYSLOG_INTERNAL_INFO("-shared_fragment_shared_syscalls requires -shared_{bbs|traces}, disabling");
+        SYSLOG_INTERNAL_INFO("-shared_fragment_shared_syscalls requires "
+                             "-shared_{bbs|traces}, disabling");
         dynamo_options.shared_fragment_shared_syscalls = false;
         changed_options = true;
     }
@@ -1420,20 +1455,23 @@ check_option_compatibility_helper(int recurse_count)
      * simultaneously: case 5436. */
     if (DYNAMO_OPTION(shared_syscalls) && DYNAMO_OPTION(shared_bbs) &&
         !DYNAMO_OPTION(shared_traces) && !DYNAMO_OPTION(disable_traces)) {
-        SYSLOG_INTERNAL_INFO("-shared_syscalls not supported with -shared_bbs -no_shared_traces, disabling");
+        SYSLOG_INTERNAL_INFO("-shared_syscalls not supported with -shared_bbs "
+                             "-no_shared_traces, disabling");
         dynamo_options.shared_syscalls = false;
         changed_options = true;
     }
 # ifdef EXPOSE_INTERNAL_OPTIONS
     if (INTERNAL_OPTION(shared_syscalls_fastpath) &&
         !DYNAMO_OPTION(shared_syscalls)) {
-        SYSLOG_INTERNAL_INFO("-shared_syscalls_fastpath requires -shared_syscalls, disabling");
+        SYSLOG_INTERNAL_INFO("-shared_syscalls_fastpath requires -shared_syscalls, "
+                             "disabling");
         dynamo_options.shared_syscalls_fastpath = false;
         changed_options = true;
     }
     if (INTERNAL_OPTION(shared_syscalls_fastpath) &&
         !DYNAMO_OPTION(disable_traces)) {
-        SYSLOG_INTERNAL_INFO("-shared_syscalls_fastpath requires -disable_traces, disabling");
+        SYSLOG_INTERNAL_INFO("-shared_syscalls_fastpath requires -disable_traces, "
+                             "disabling");
         dynamo_options.shared_syscalls_fastpath = false;
         changed_options = true;
     }
@@ -1492,7 +1530,8 @@ check_option_compatibility_helper(int recurse_count)
     }
 
     if (DYNAMO_OPTION(sandbox_writable) && DYNAMO_OPTION(sandbox_non_text)) {
-        USAGE_ERROR("-sandbox_writable and -sandbox_non_text are mutually exclusive, using -sandbox_non_text");
+        USAGE_ERROR("-sandbox_writable and -sandbox_non_text are mutually exclusive, "
+                    "using -sandbox_non_text");
         dynamo_options.sandbox_writable = false;
         dynamo_options.sandbox_non_text = true;
         changed_options = true;
@@ -1517,7 +1556,8 @@ check_option_compatibility_helper(int recurse_count)
 # else
     if (DYNAMO_OPTION(IAT_convert)) {
         /* FIXME: case 1948 we should in fact depend on emulate_IAT_read */
-        USAGE_ERROR("-IAT_convert requires unavailable -emulate_IAT_writes, disabling IAT_convert");
+        USAGE_ERROR("-IAT_convert requires unavailable -emulate_IAT_writes, "
+                    "disabling IAT_convert");
         dynamo_options.IAT_convert = false;
         changed_options = true;
     }
@@ -1705,7 +1745,8 @@ check_option_compatibility_helper(int recurse_count)
 
 #ifdef WINDOWS
     if (DYNAMO_OPTION(inject_at_create_process) && !DYNAMO_OPTION(early_inject)) {
-        USAGE_ERROR("-inject_at_create_process requires -early_inject, setting to defaults");
+        USAGE_ERROR("-inject_at_create_process requires -early_inject, setting to "
+                    "defaults");
         SET_DEFAULT_VALUE(inject_at_create_process);
         SET_DEFAULT_VALUE(early_inject);
         changed_options = true;
@@ -1714,7 +1755,8 @@ check_option_compatibility_helper(int recurse_count)
         !IS_STRING_OPTION_EMPTY(block_mod_load_list_default) &&
         !check_filter(DYNAMO_OPTION(block_mod_load_list_default),
                       "dynamorio.dll")) {
-        USAGE_ERROR("follow_systemwide is dangerous without -early_inject unless -block_mod_load_list[_default] includes dynamorio.dll");
+        USAGE_ERROR("follow_systemwide is dangerous without -early_inject unless "
+                    "-block_mod_load_list[_default] includes dynamorio.dll");
         dynamo_options.follow_systemwide = false;
         changed_options = true;
     }
@@ -1736,7 +1778,8 @@ check_option_compatibility_helper(int recurse_count)
                 /* our method of finding the address relies on
                  * -native_exec_syscalls */
                 if (!DYNAMO_OPTION(native_exec_syscalls)) {
-                    USAGE_ERROR("early_inject_location LdrpLoadImportModule requires -native_exec_syscalls for first process in chain");
+                    USAGE_ERROR("early_inject_location LdrpLoadImportModule requires "
+                                "-native_exec_syscalls for first process in chain");
                     /* FIXME is this the best remediation choice? */
                     dynamo_options.native_exec_syscalls = true;
                     changed_options = true;
@@ -1753,7 +1796,8 @@ check_option_compatibility_helper(int recurse_count)
     }
     if (DYNAMO_OPTION(early_inject_location) == INJECT_LOCATION_LdrCustom &&
         DYNAMO_OPTION(early_inject_address) == 0) {
-        USAGE_ERROR("early_inject_location LdrCustom requires setting -early_inject_address");
+        USAGE_ERROR("early_inject_location LdrCustom requires setting "
+                    "-early_inject_address");
         SET_DEFAULT_VALUE(early_inject_location);
         changed_options = true;
     }
@@ -2212,7 +2256,8 @@ synchronize_dynamic_options()
     NULL_TERMINATE_BUFFER(option_string);
     SELF_PROTECT_OPTIONS();
 
-    LOG(GLOBAL, LOG_ALL, 2 , "synchronize_dynamic_options: %s, updated = %d\n", new_option_string, updated);
+    LOG(GLOBAL, LOG_ALL, 2 , "synchronize_dynamic_options: %s, updated = %d\n",
+        new_option_string, updated);
 
 #ifdef EXPOSE_INTERNAL_OPTIONS
     if (updated) {
@@ -2387,18 +2432,22 @@ unit_test_options(void)
     print_file(STDERR, "default---\n");
     show_dynamo_options(false);
     print_file(STDERR, "\nbefore first set---\n");
-    set_dynamo_options(&dynamo_options,
-                       "-loglevel 1 -logmask 0x10 -block_mod_load_list 'mylib.dll;evilbad.dll;really_long_name_for_a_dll.dll' -stderr_mask 12");
+    set_dynamo_options
+        (&dynamo_options,
+         "-loglevel 1 -logmask 0x10 -block_mod_load_list "
+         "'mylib.dll;evilbad.dll;really_long_name_for_a_dll.dll' -stderr_mask 12");
     show_dynamo_options(true);
 
     print_file(STDERR, "\nbefore second set---\n");
-    set_dynamo_options(&dynamo_options,
-                       "-logmask 17 -cache_bb_max 20 -cache_trace_max 20M -svchost_timeout 3m");
+    set_dynamo_options
+        (&dynamo_options,
+         "-logmask 17 -cache_bb_max 20 -cache_trace_max 20M -svchost_timeout 3m");
     show_dynamo_options(true);
 
     set_dynamo_options_defaults(&new_options);
-    set_dynamo_options(&new_options,
-                       "-logmask 7 -cache_bb_max 20 -cache_trace_max 20M -svchost_timeout 3m");
+    set_dynamo_options
+        (&new_options,
+         "-logmask 7 -cache_bb_max 20 -cache_trace_max 20M -svchost_timeout 3m");
     updated = update_dynamic_options(&dynamo_options, &new_options);
     print_file(STDERR, "updated %d\n", updated);
     show_dynamo_options(true);

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -816,7 +816,7 @@ void os_flush(file_t f);
 #define OS_SEEK_SET 0  /* start of file */
 #define OS_SEEK_CUR 1  /* current file position */
 #define OS_SEEK_END 2  /* end of file */
-/* seek the current file position to offset bytes from origin, return true if successful */
+/* seek current file position to offset bytes from origin, return true if successful */
 bool os_seek(file_t f, int64 offset, int origin);
 /* return the current file position, -1 on failure */
 int64 os_tell(file_t f);
@@ -866,8 +866,8 @@ extern uint kilo_hertz;
 #endif
 
 /* Despite the name, this enum is used for all types of critical events:
-es
- * asserts and crashes for all builds, and security violations for PROGRAM_SHEPHERDING builds
+ * asserts and crashes for all builds, and security violations for
+ * PROGRAM_SHEPHERDING builds.
  * When a security_violation is being reported, enum value must be negative!
  */
 typedef enum {
@@ -925,7 +925,8 @@ typedef enum {
     INITIAL_STACK_BOTTOM_NOT_REACHED = 2
 } initial_call_stack_status_t;
 
-initial_call_stack_status_t at_initial_stack_bottom(dcontext_t *dcontext, app_pc target_pc);
+initial_call_stack_status_t at_initial_stack_bottom(dcontext_t *dcontext, app_pc
+                                                    target_pc);
 bool at_known_exception(dcontext_t *dcontext, app_pc target_pc, app_pc source_fragment);
 #endif
 

--- a/core/perfctr.c
+++ b/core/perfctr.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -79,7 +80,8 @@ struct {int num;char *name;} papi_events[]={
 
 
 
-void hardware_perfctr_init()
+void
+hardware_perfctr_init()
 {
     int a;
     perfctr_eventset=PAPI_NULL;
@@ -129,7 +131,8 @@ void hardware_perfctr_init()
 }
 
 
-void hardware_perfctr_exit()
+void
+hardware_perfctr_exit()
 {
     int a;
     uint64 vals[NUM_EVENTS]; /* only used if nullcalls */
@@ -151,7 +154,8 @@ void hardware_perfctr_exit()
 
 }
 
-void perfctr_update_gui()
+void
+perfctr_update_gui()
 {
     if (PAPI_read(perfctr_eventset,stats->perfctr_vals) != PAPI_OK) {
         LOG(GLOBAL, LOG_TOP, 1,

--- a/core/perscache.c
+++ b/core/perscache.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -346,7 +346,8 @@ coarse_unit_reset_free_internal(dcontext_t *dcontext, coarse_info_t *info,
 #ifdef HOT_PATCHING_INTERFACE
                 if (info->hotp_ppoint_vec != NULL) {
                     HEAP_ARRAY_FREE(dcontext, info->hotp_ppoint_vec, app_rva_t,
-                                    info->hotp_ppoint_vec_num, ACCT_HOT_PATCHING, PROTECTED);
+                                    info->hotp_ppoint_vec_num, ACCT_HOT_PATCHING,
+                                    PROTECTED);
                 }
 #endif
             }
@@ -3568,8 +3569,8 @@ coarse_unit_persist(dcontext_t *dcontext, coarse_info_t *info)
      * the original, to ensure we have a complete file (case 9696).
      * We can't rename it if we have a handle with write privileges open,
      * regardless of FILE_SHARE_* flags, so we close it and live with races.
-     * Nobody else should be creating a file of the same name (tmpname includes process id).
-     * Therefore no other process may have racily created an
+     * Nobody else should be creating a file of the same name (tmpname includes process
+     * id).  Therefore no other process may have racily created an
      * incomplete file overwriting the file we just produced and are
      * about to rename.
      */

--- a/core/stats.c
+++ b/core/stats.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -266,7 +266,8 @@ kstat_thread_init(dcontext_t *dcontext)
         return;                 /* dcontext->thread_kstats stays NULL */
 
     /* allocated on thread heap - use global if timing initialization matters */
-    new_thread_kstats = HEAP_TYPE_ALLOC(dcontext, thread_kstats_t, ACCT_STATS, UNPROTECTED);
+    new_thread_kstats = HEAP_TYPE_ALLOC(dcontext, thread_kstats_t, ACCT_STATS,
+                                        UNPROTECTED);
     LOG(THREAD, LOG_STATS, 2, "thread_kstats="PFX" size=%d\n", new_thread_kstats,
         sizeof(thread_kstats_t));
     /* initialize any thread stats bookkeeping fields before assigning to dcontext */

--- a/core/stats.h
+++ b/core/stats.h
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -240,7 +241,7 @@ kstat_ignore_context_switch;
     (kstack)->node[depth].subpath_time = 0;             \
     (kstack)->node[depth].self_time = 0;                \
     (kstack)->node[depth].outlier_time = 0;             \
-} while(0)
+} while (0)
 
 /* updates which variable will be counted */
 #define kstat_switch_var(kstack, pvar) (kstack)->node[(kstack)->depth - 1].var = (pvar)

--- a/core/string.c
+++ b/core/string.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -158,7 +158,8 @@ memmove(void *dst, const void *src, size_t n)
  * up arguments on the stack, so we alias these *_chk routines to the non-chk
  * routines and rely on the caller to clean up the extra dst_len arg.
  */
-void *__memmove_chk(void *dst, const void *src, size_t n, size_t dst_len)
+void *
+__memmove_chk(void *dst, const void *src, size_t n, size_t dst_len)
 # ifdef MACOS
 /* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
  * XXX: better to test for support at config time: for now assuming none on Mac.
@@ -167,9 +168,10 @@ void *__memmove_chk(void *dst, const void *src, size_t n, size_t dst_len)
   return memmove(dst, src, n);
 }
 # else
-    __attribute__ ((alias ("memmove")));
+    __attribute__((alias("memmove")));
 # endif
-void *__strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
+void *
+__strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
 # ifdef MACOS
 /* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
  * XXX: better to test for support at config time: for now assuming none on Mac.
@@ -178,7 +180,7 @@ void *__strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
   return strncpy(dst, src, n);
 }
 # else
-    __attribute__ ((alias ("strncpy")));
+    __attribute__((alias("strncpy")));
 # endif
 #endif
 

--- a/core/synch.c
+++ b/core/synch.c
@@ -340,11 +340,13 @@ translate_mcontext(thread_record_t *trec, priv_mcontext_t *mcontext,
 #endif
             if (is_at_do_syscall(trec->dcontext, (app_pc)mcontext->pc,
                                  (byte *)mcontext->xsp)) {
-                LOG(THREAD_GET, LOG_SYNCH, 1, "translate context, thread "TIDFMT" running "
+                LOG(THREAD_GET, LOG_SYNCH, 1,
+                    "translate context, thread "TIDFMT" running "
                     "natively, at do_syscall so translation needed\n", trec->id);
                 native_translate = true;
             } else {
-                LOG(THREAD_GET, LOG_SYNCH, 1, "translate context, thread "TIDFMT" running "
+                LOG(THREAD_GET, LOG_SYNCH, 1,
+                    "translate context, thread "TIDFMT" running "
                     "natively, no translation needed\n", trec->id);
                 return true;
             }

--- a/core/translate.c
+++ b/core/translate.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1056,7 +1056,8 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
                 bool new_alloc;
                 DEBUG_DECLARE(fragment_t *pre_f = f;)
                 ilist = recreate_fragment_ilist(tdcontext, NULL, &f, &new_alloc,
-                                                true/*mangle*/ _IF_CLIENT(true/*client*/));
+                                                true/*mangle*/
+                                                _IF_CLIENT(true/*client*/));
                 ASSERT(owning_f == NULL || f == owning_f ||
                        (TEST(FRAG_COARSE_GRAIN, owning_f->flags) && f == pre_f));
                 ASSERT(!new_alloc);

--- a/core/unit-rct.c
+++ b/core/unit-rct.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -52,7 +52,8 @@ UNIT_TEST_MAIN
 typedef int (*fconvert_t)(int c);
 typedef int (*fmult_t)(int);
 
-int foo(int a, bool lower)
+int
+foo(int a, bool lower)
 {
     fconvert_t f = toupper;
     int res;
@@ -63,17 +64,20 @@ int foo(int a, bool lower)
     return res;
 }
 
-int f2(int a)
+int
+f2(int a)
 {
     return 2*a;
 }
 
-int f3(int a)
+int
+f3(int a)
 {
     return 3*a;
 }
 
-int f7(int a)
+int
+f7(int a)
 {
     return 7*a;
 }
@@ -195,10 +199,10 @@ test_small_array(dcontext_t *dcontext)
            0);
     EXPECT(invalidate_ind_branch_target_range(dcontext, 0, (app_pc)0x01020305),
            1);
-    EXPECT(invalidate_ind_branch_target_range(dcontext, (app_pc)0x01020306, (app_pc)0x01020309),
-           0);
-    EXPECT(invalidate_ind_branch_target_range(dcontext, (app_pc)0x01020305, (app_pc)0x01020306),
-           1);
+    EXPECT(invalidate_ind_branch_target_range(dcontext, (app_pc)0x01020306,
+                                              (app_pc)0x01020309), 0);
+    EXPECT(invalidate_ind_branch_target_range(dcontext, (app_pc)0x01020305,
+                                              (app_pc)0x01020306), 1);
     EXPECT(invalidate_ind_branch_target_range(dcontext, 0, (app_pc)-1),
            0);
 
@@ -453,15 +457,18 @@ test_loaddll()
 
 #if TEST_MULTI_SECTIONS         /* NYI */
 #pragma code_seg(".my_code1")
-void func2() {
+void
+func2() {
 }
 
 #pragma code_seg(push, r1, ".my_code2")
-void func3() {
+void
+func3() {
 }
 
 #pragma code_seg(pop, r1)      /* back to my_code1 */
-void func4() {
+void
+func4() {
 }
 #pragma code_seg                /* back in .text */
 #endif

--- a/core/unix/include/signalfd.h
+++ b/core/unix/include/signalfd.h
@@ -21,34 +21,34 @@
 #define SFD_NONBLOCK O_NONBLOCK
 
 struct signalfd_siginfo {
-	__u32 ssi_signo;
-	__s32 ssi_errno;
-	__s32 ssi_code;
-	__u32 ssi_pid;
-	__u32 ssi_uid;
-	__s32 ssi_fd;
-	__u32 ssi_tid;
-	__u32 ssi_band;
-	__u32 ssi_overrun;
-	__u32 ssi_trapno;
-	__s32 ssi_status;
-	__s32 ssi_int;
-	__u64 ssi_ptr;
-	__u64 ssi_utime;
-	__u64 ssi_stime;
-	__u64 ssi_addr;
-	__u16 ssi_addr_lsb;
+        __u32 ssi_signo;
+        __s32 ssi_errno;
+        __s32 ssi_code;
+        __u32 ssi_pid;
+        __u32 ssi_uid;
+        __s32 ssi_fd;
+        __u32 ssi_tid;
+        __u32 ssi_band;
+        __u32 ssi_overrun;
+        __u32 ssi_trapno;
+        __s32 ssi_status;
+        __s32 ssi_int;
+        __u64 ssi_ptr;
+        __u64 ssi_utime;
+        __u64 ssi_stime;
+        __u64 ssi_addr;
+        __u16 ssi_addr_lsb;
 
-	/*
-	 * Pad strcture to 128 bytes. Remember to update the
-	 * pad size when you add new members. We use a fixed
-	 * size structure to avoid compatibility problems with
-	 * future versions, and we leave extra space for additional
-	 * members. We use fixed size members because this strcture
-	 * comes out of a read(2) and we really don't want to have
-	 * a compat on read(2).
-	 */
-	__u8 __pad[46];
+        /*
+         * Pad strcture to 128 bytes. Remember to update the
+         * pad size when you add new members. We use a fixed
+         * size structure to avoid compatibility problems with
+         * future versions, and we leave extra space for additional
+         * members. We use fixed size members because this strcture
+         * comes out of a read(2) and we really don't want to have
+         * a compat on read(2).
+         */
+        __u8 __pad[46];
 };
 
 #endif /* _SIGNALFD_H */

--- a/core/unix/include/syscall_linux_arm.h
+++ b/core/unix/include/syscall_linux_arm.h
@@ -100,7 +100,7 @@
 # define __NR_sigpending                 (__NR_SYSCALL_BASE+ 73)
 # define __NR_sethostname                (__NR_SYSCALL_BASE+ 74)
 # define __NR_setrlimit                  (__NR_SYSCALL_BASE+ 75)
-# define __NR_getrlimit                  (__NR_SYSCALL_BASE+ 76) /* Back compat 2GB limited rlimit */
+# define __NR_getrlimit                  (__NR_SYSCALL_BASE+ 76)
 # define __NR_getrusage                  (__NR_SYSCALL_BASE+ 77)
 # define __NR_gettimeofday               (__NR_SYSCALL_BASE+ 78)
 # define __NR_settimeofday               (__NR_SYSCALL_BASE+ 79)
@@ -137,7 +137,7 @@
                                         /* 110 was sys_iopl */
 # define __NR_vhangup                    (__NR_SYSCALL_BASE+111)
                                         /* 112 was sys_idle */
-# define __NR_syscall                    (__NR_SYSCALL_BASE+113) /* syscall to call a syscall! */
+# define __NR_syscall                    (__NR_SYSCALL_BASE+113)
 # define __NR_wait4                      (__NR_SYSCALL_BASE+114)
 # define __NR_swapoff                    (__NR_SYSCALL_BASE+115)
 # define __NR_sysinfo                    (__NR_SYSCALL_BASE+116)
@@ -215,7 +215,7 @@
                                         /* 188 reserved */
                                         /* 189 reserved */
 # define __NR_vfork                      (__NR_SYSCALL_BASE+190)
-# define __NR_ugetrlimit                 (__NR_SYSCALL_BASE+191) /* SuS compliant getrlimit */
+# define __NR_ugetrlimit                 (__NR_SYSCALL_BASE+191)
 # define __NR_mmap2                      (__NR_SYSCALL_BASE+192)
 # define __NR_truncate64                 (__NR_SYSCALL_BASE+193)
 # define __NR_ftruncate64                (__NR_SYSCALL_BASE+194)

--- a/core/unix/ksynch.h
+++ b/core/unix/ksynch.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -66,11 +66,13 @@ ksynch_free_var(KSYNCH_TYPE *var);
 
 #ifdef LINUX
 /* avoid de-ref */
-static inline int ksynch_get_value(volatile int *futex)
+static inline int
+ksynch_get_value(volatile int *futex)
 {
     return *futex;
 }
-static inline void ksynch_set_value(volatile int *futex, int new_val)
+static inline void
+ksynch_set_value(volatile int *futex, int new_val)
 {
     *futex = new_val;
 }

--- a/core/unix/memquery_linux.c
+++ b/core/unix/memquery_linux.c
@@ -80,10 +80,10 @@ static mutex_t maps_iter_buf_lock = INIT_LOCK_FREE(maps_iter_buf_lock);
 /* these are defined in /usr/src/linux/fs/proc/array.c */
 #define MAPS_LINE_LENGTH        4096
 /* for systems with sizeof(void*) == 4: */
-#define MAPS_LINE_FORMAT4         "%08lx-%08lx %s %08lx %*s "UINT64_FORMAT_STRING" %4096s"
+#define MAPS_LINE_FORMAT4     "%08lx-%08lx %s %08lx %*s "UINT64_FORMAT_STRING" %4096s"
 #define MAPS_LINE_MAX4  49 /* sum of 8  1  8  1 4 1 8 1 5 1 10 1 */
 /* for systems with sizeof(void*) == 8: */
-#define MAPS_LINE_FORMAT8         "%016lx-%016lx %s %016lx %*s "UINT64_FORMAT_STRING" %4096s"
+#define MAPS_LINE_FORMAT8     "%016lx-%016lx %s %016lx %*s "UINT64_FORMAT_STRING" %4096s"
 #define MAPS_LINE_MAX8  73 /* sum of 16  1  16  1 4 1 16 1 5 1 10 1 */
 
 #define MAPS_LINE_MAX   MAPS_LINE_MAX8

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -617,7 +617,8 @@ os_module_update_dynamic_info(app_pc base, size_t size, bool at_map)
                     if (soname != NULL)
                         ma->names.module_name = dr_strdup(soname HEAPACCT(ACCT_VMAREAS));
                     LOG(GLOBAL, LOG_INTERP|LOG_VMAREAS, 2, "%s "PFX": %s dynamic info\n",
-                        __FUNCTION__, base, ma->os_data.have_dynamic_info ? "have" : "no");
+                        __FUNCTION__, base,
+                        ma->os_data.have_dynamic_info ? "have" : "no");
                 }
             }
         }

--- a/core/unix/pcprofile.c
+++ b/core/unix/pcprofile.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -99,7 +99,8 @@ typedef struct _thread_pc_info_t {
 #define ALARM_FREQUENCY 10 /* milliseconds */
 
 /* forward declarations for static functions */
-static pc_profile_entry_t *pcprofile_add_entry(thread_pc_info_t *info, void *pc, int whereami);
+static pc_profile_entry_t *pcprofile_add_entry(thread_pc_info_t *info, void *pc,
+                                               int whereami);
 static pc_profile_entry_t *pcprofile_lookup(thread_pc_info_t *info, void *pc);
 static void pcprofile_reset(thread_pc_info_t *info);
 static void pcprofile_results(thread_pc_info_t *info);

--- a/core/unix/preload.c
+++ b/core/unix/preload.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -182,7 +182,7 @@ _init(int argc, char **argv, char **envp)
 }
 
 int
-_fini ()
+_fini()
 {
 #if VERBOSE_INIT_FINI
     fprintf (stderr, "preload finalized\n");

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -1588,7 +1588,8 @@ handle_clone(dcontext_t *dcontext, uint flags)
             *info->shared_itimer_underDR = 1;
             info->shared_itimer_lock = (recursive_lock_t *)
                 global_heap_alloc(sizeof(*info->shared_itimer_lock) HEAPACCT(ACCT_OTHER));
-            ASSIGN_INIT_RECURSIVE_LOCK_FREE(*info->shared_itimer_lock, shared_itimer_lock);
+            ASSIGN_INIT_RECURSIVE_LOCK_FREE(*info->shared_itimer_lock,
+                                            shared_itimer_lock);
         } /* else, some ancestor already created */
     }
 }
@@ -5384,14 +5385,14 @@ execute_default_action(dcontext_t *dcontext, int sig, sigframe_rt_t *frame,
          */
         if (info->shared_app_sigaction) {
             LOG(THREAD, LOG_ASYNCH, 1,
-                "WARNING: having to install SIG_DFL for thread "TIDFMT", but will be shared!\n",
-                get_thread_id());
+                "WARNING: having to install SIG_DFL for thread "TIDFMT", but will be "
+                "shared!\n", get_thread_id());
         }
         if (default_action[sig] == DEFAULT_TERMINATE ||
             default_action[sig] == DEFAULT_TERMINATE_CORE) {
             report_app_problem(dcontext, APPFAULT_CRASH, pc, (byte *)sc->SC_FP,
-                               "\nSignal %d delivered to application as default action.\n",
-                               sig);
+                               "\nSignal %d delivered to application as default "
+                               "action.\n", sig);
             /* App may call sigaction to set handler SIG_DFL (unnecessary but legal),
              * in which case DR will put a handler in info->app_sigaction[sig].
              * We must clear it, otherwise, signal_thread_exit may cleanup the
@@ -5502,7 +5503,8 @@ execute_default_action(dcontext_t *dcontext, int sig, sigframe_rt_t *frame,
                 fragment_t wrapper;
                 fragment_t *f;
                 LOG(THREAD, LOG_ALL, 1,
-                    "Received SIGSEGV at pc "PFX" in thread "TIDFMT"\n", pc, get_thread_id());
+                    "Received SIGSEGV at pc "PFX" in thread "TIDFMT"\n",
+                    pc, get_thread_id());
                 f = fragment_pclookup(dcontext, pc, &wrapper);
                 if (f)
                     disassemble_fragment(dcontext, f, false);
@@ -5771,7 +5773,8 @@ handle_sigreturn(dcontext_t *dcontext, void *ucxt_param, int style)
 
     /* set up for dispatch */
     /* we have to use a different slot since next_tag ends up holding the do_syscall
-     * entry when entered from dispatch (we're called from pre_syscall, prior to entering cache)
+     * entry when entered from dispatch (we're called from
+     * pre_syscall, prior to entering cache)
      */
     dcontext->asynch_target = canonicalize_pc_target
         (dcontext, (app_pc)(sc->SC_XIP IF_ARM(|(TEST(EFLAGS_T, sc->SC_XFLAGS) ? 1 : 0))));
@@ -6042,10 +6045,13 @@ os_dump_core(const char *msg)
 bool
 at_known_exception(dcontext_t *dcontext, app_pc target_pc, app_pc source_fragment)
 {
-    /* There is a known exception in signal restorers and the Linux dynamic symbol resoulution */
-    /* The latter we assume it is the only other recurring known exception,
-       so the first time we pattern match to help make sure it is indeed _dl_runtime_resolve
-       (since with LD_BIND_NOW it will never be called).  After that we compare with the known value. */
+    /* There is a known exception in signal restorers and the Linux
+     * dynamic symbol resoulution.
+     * The latter we assume it is the only other recurring known exception,
+     * so the first time we pattern match to help make sure it is indeed
+     * _dl_runtime_resolve (since with LD_BIND_NOW it will never be called).
+     * After that we compare with the known value.
+     */
 
     static app_pc known_exception = 0;
     thread_sig_info_t *info = (thread_sig_info_t *) dcontext->signal_field;
@@ -6060,13 +6066,15 @@ at_known_exception(dcontext_t *dcontext, app_pc target_pc, app_pc source_fragmen
        (I haven't seen restorers other than the one in libc)
     */
     if (target_pc == info->signal_restorer_retaddr) {
-        LOG(THREAD, LOG_INTERP, 1, "RCT: KNOWN exception this is a signal restorer --ok \n");
+        LOG(THREAD, LOG_INTERP, 1,
+            "RCT: KNOWN exception this is a signal restorer --ok \n");
         STATS_INC(ret_after_call_signal_restorer);
         return true;
     }
 
     if (source_fragment == known_exception) {
-        LOG(THREAD, LOG_INTERP, 1, "RCT: KNOWN exception again _dl_runtime_resolve --ok\n");
+        LOG(THREAD, LOG_INTERP, 1,
+            "RCT: KNOWN exception again _dl_runtime_resolve --ok\n");
         return true;
     }
 
@@ -6142,7 +6150,8 @@ set_actual_itimer(dcontext_t *dcontext, int which, thread_sig_info_t *info,
     ASSERT(info != NULL && info->itimer != NULL);
     ASSERT(which >= 0 && which < NUM_ITIMERS);
     if (enable) {
-        ASSERT(!info->shared_itimer || self_owns_recursive_lock(info->shared_itimer_lock));
+        ASSERT(!info->shared_itimer ||
+               self_owns_recursive_lock(info->shared_itimer_lock));
         usec_to_timeval((*info->itimer)[which].actual.interval, &val.it_interval);
         usec_to_timeval((*info->itimer)[which].actual.value, &val.it_value);
         LOG(THREAD, LOG_ASYNCH, 2, "installing itimer %d interval="INT64_FORMAT_STRING

--- a/core/unix/signal_macos.c
+++ b/core/unix/signal_macos.c
@@ -195,16 +195,18 @@ dump_fpstate(dcontext_t *dcontext, sigcontext_t *sc)
     LOG(THREAD, LOG_ASYNCH, 1, "\tmxcsrmask=0x%08x\n", sc->__fs.__fpu_mxcsrmask);
     for (i=0; i<8; i++) {
         LOG(THREAD, LOG_ASYNCH, 1, "\tst%d = ", i);
-        for (j=0; j<5; j++)
+        for (j=0; j<5; j++) {
             LOG(THREAD, LOG_ASYNCH, 1, "%04x ",
                 *((ushort *)(&sc->__fs.__fpu_stmm0 + i) + j));
+        }
         LOG(THREAD, LOG_ASYNCH, 1, "\n");
     }
     for (i=0; i<NUM_SIMD_SLOTS; i++) {
         LOG(THREAD, LOG_ASYNCH, 1, "\txmm%d = ", i);
-        for (j=0; j<4; j++)
+        for (j=0; j<4; j++) {
             LOG(THREAD, LOG_ASYNCH, 1, "%08x ",
                 *((uint *)(&sc->__fs.__fpu_xmm0 + i) + j));
+        }
         LOG(THREAD, LOG_ASYNCH, 1, "\n");
     }
     if (YMM_ENABLED()) {

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -459,20 +459,20 @@ get_sigcontext_from_rt_frame(sigframe_rt_t *frame);
  */
 
 /* most of these are from /usr/src/linux/include/linux/signal.h */
-static inline
-void kernel_sigemptyset(kernel_sigset_t *set)
+static inline void
+kernel_sigemptyset(kernel_sigset_t *set)
 {
     memset(set, 0, sizeof(kernel_sigset_t));
 }
 
-static inline
-void kernel_sigfillset(kernel_sigset_t *set)
+static inline void
+kernel_sigfillset(kernel_sigset_t *set)
 {
     memset(set, -1, sizeof(kernel_sigset_t));
 }
 
-static inline
-void kernel_sigaddset(kernel_sigset_t *set, int _sig)
+static inline void
+kernel_sigaddset(kernel_sigset_t *set, int _sig)
 {
     uint sig = _sig - 1;
     if (_NSIG_WORDS == 1)
@@ -481,8 +481,8 @@ void kernel_sigaddset(kernel_sigset_t *set, int _sig)
         set->sig[sig / _NSIG_BPW] |= 1UL << (sig % _NSIG_BPW);
 }
 
-static inline
-void kernel_sigdelset(kernel_sigset_t *set, int _sig)
+static inline void
+kernel_sigdelset(kernel_sigset_t *set, int _sig)
 {
     uint sig = _sig - 1;
     if (_NSIG_WORDS == 1)
@@ -491,8 +491,8 @@ void kernel_sigdelset(kernel_sigset_t *set, int _sig)
         set->sig[sig / _NSIG_BPW] &= ~(1UL << (sig % _NSIG_BPW));
 }
 
-static inline
-bool kernel_sigismember(kernel_sigset_t *set, int _sig)
+static inline bool
+kernel_sigismember(kernel_sigset_t *set, int _sig)
 {
     int sig = _sig - 1; /* go to 0-based */
     if (_NSIG_WORDS == 1)
@@ -502,8 +502,8 @@ bool kernel_sigismember(kernel_sigset_t *set, int _sig)
 }
 
 /* XXX: how does libc do this? */
-static inline
-void copy_kernel_sigset_to_sigset(kernel_sigset_t *kset, sigset_t *uset)
+static inline void
+copy_kernel_sigset_to_sigset(kernel_sigset_t *kset, sigset_t *uset)
 {
     int sig;
 #ifdef DEBUG
@@ -521,8 +521,8 @@ void copy_kernel_sigset_to_sigset(kernel_sigset_t *kset, sigset_t *uset)
 }
 
 /* i#1541: unfortunately sigismember now leads to libc imports so we write our own */
-static inline
-bool libc_sigismember(const sigset_t *set, int _sig)
+static inline bool
+libc_sigismember(const sigset_t *set, int _sig)
 {
     int sig = _sig - 1; /* go to 0-based */
 #if defined(MACOS) || defined(ANDROID)

--- a/core/unix/stackdump.c
+++ b/core/unix/stackdump.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -131,8 +131,8 @@ fork_syscall(void)
     /* i386/fork.c pass a 5th arg, &THREAD_SELF->tid, is it needed for SETTID? */
     static uint tid;
     return dynamorio_syscall(SYS_clone, 4/* 5 */,
-                             /* flags, newsp (if 0 -> cur esp), parent_tidptr, child_tidptr,
-                              * something! */
+                             /* flags, newsp (if 0 -> cur esp), parent_tidptr,
+                              * child_tidptr, something! */
                              CLONE_CHILD_SETTID | CLONE_CHILD_CLEARTID | SIGCHLD,
                              0, NULL, NULL /*, &tid*/);
 # else
@@ -182,7 +182,8 @@ stackdump(void)
     pid = fork_syscall();
     if (pid == 0) { /* child */
 #if VERBOSE
-        SYSLOG_INTERNAL_ERROR("about to dump core in process %d parent %d thread "TIDFMT"",
+        SYSLOG_INTERNAL_ERROR("about to dump core in process %d parent %d thread "
+                              TIDFMT"",
                               get_process_id(), get_parent_id(), get_thread_id());
 #endif
         /* We used to use abort here, but that had lots of complications with
@@ -291,7 +292,7 @@ stackdump(void)
     }
     /* Parent continues */
     /* while(wait(NULL)>0) waits for all children, and could hang, so: */
-    while(wait_syscall(NULL) != pid) {
+    while (wait_syscall(NULL) != pid) {
         /* empty loop */
     }
 

--- a/core/unix/tls_linux_x86.c
+++ b/core/unix/tls_linux_x86.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -757,7 +757,7 @@ tls_clear_descriptor(int index)
     ASSERT(tls_global_type != TLS_TYPE_LDT);
     clear_ldt_struct(&desc, index);
     res = dynamorio_syscall(SYS_set_thread_area, 1, &desc);
-    return(res >= 0);
+    return (res >= 0);
 }
 
 int
@@ -862,9 +862,10 @@ tls_handle_post_arch_prctl(dcontext_t *dcontext, int code, reg_t base)
         break;
     }
     case ARCH_GET_FS: {
-        if (IF_CLIENT_INTERFACE_ELSE(INTERNAL_OPTION(private_loader), false))
+        if (IF_CLIENT_INTERFACE_ELSE(INTERNAL_OPTION(private_loader), false)) {
             safe_write_ex((void *)base, sizeof(void *),
                           &os_tls->app_lib_tls_base, NULL);
+        }
         break;
     }
     case ARCH_SET_GS: {

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -303,8 +303,8 @@ static vm_area_vector_t *written_areas;
 static void free_written_area(void *data);
 
 #ifdef PROGRAM_SHEPHERDING
-/* for executable_if_flush and executable_if_alloc, we need a future list, so their regions
- * are considered executable until de-allocated -- even if written to!
+/* For executable_if_flush and executable_if_alloc, we need a future list, so
+ * their regions are considered executable until de-allocated -- even if written to!
  */
 static vm_area_vector_t *futureexec_areas;
 # ifdef WINDOWS
@@ -573,7 +573,8 @@ typedef struct _multi_entry_t {
 /* macros to make dealing with both fragment_t and multi_entry_t easier */
 #define FRAG_MULTI(f) (TEST(FRAG_IS_EXTRA_VMAREA, (f)->flags))
 
-#define FRAG_MULTI_INIT(f) (TESTALL((FRAG_IS_EXTRA_VMAREA|FRAG_IS_EXTRA_VMAREA_INIT), (f)->flags))
+#define FRAG_MULTI_INIT(f) \
+    (TESTALL((FRAG_IS_EXTRA_VMAREA|FRAG_IS_EXTRA_VMAREA_INIT), (f)->flags))
 
 #define FRAG_NEXT(f) ((TEST(FRAG_IS_EXTRA_VMAREA, (f)->flags)) ? \
     ((multi_entry_t *)(f))->next_vmarea : (f)->next_vmarea)
@@ -782,7 +783,7 @@ print_vm_areas(vm_area_vector_t *v, file_t outf)
 {
     int i;
     ASSERT_VMAREA_VECTOR_PROTECTED(v, READWRITE);
-    for(i = 0; i < v->length; i++) {
+    for (i = 0; i < v->length; i++) {
         print_vm_area(v, &v->buf[i], outf, "  ");
     }
 }
@@ -1156,7 +1157,8 @@ add_vm_area(vm_area_vector_t *v, app_pc start, app_pc end,
         if (!((i == 0 || v->buf[i-1].end <= v->buf[i].start) &&
               (i == v->length || v->buf[i].end <= v->buf[i+1].start))) {
             LOG(GLOBAL, LOG_VMAREAS, 1,
-                "ERROR: add_vm_area illegal overlap "PFX" "PFX" %s\n", start, end, comment);
+                "ERROR: add_vm_area illegal overlap "PFX" "PFX" %s\n",
+                start, end, comment);
             print_vm_areas(v, GLOBAL);
         }
 #endif
@@ -1355,7 +1357,8 @@ remove_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, bool restore_prot)
             v->buf[overlap_end-1].start, v->buf[overlap_end-1].end,
             end, v->buf[overlap_end-1].end);
         if (restore_prot && DR_MADE_READONLY(v->buf[overlap_end-1].vm_flags)) {
-            vm_make_writable(v->buf[overlap_end-1].start, end - v->buf[overlap_end-1].start);
+            vm_make_writable(v->buf[overlap_end-1].start,
+                             end - v->buf[overlap_end-1].start);
         }
         v->buf[overlap_end-1].start = end;
         /* FIXME: add a vmvector callback function for changing bounds? */
@@ -1421,7 +1424,8 @@ remove_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, bool restore_prot)
 #endif
             /* frags list should always be null here (flush should have happened,
              * etc.) */
-            ASSERT(!TEST(VECTOR_FRAGMENT_LIST, v->flags) || v->buf[i].custom.frags == NULL);
+            ASSERT(!TEST(VECTOR_FRAGMENT_LIST, v->flags) ||
+                   v->buf[i].custom.frags == NULL);
         }
         diff = overlap_end - overlap_start;
         for (i = overlap_start; i < v->length-diff; i++)
@@ -1443,7 +1447,8 @@ remove_vm_area(vm_area_vector_t *v, app_pc start, app_pc end, bool restore_prot)
          * -unsafe_ignore_IAT_writes) we can have VM_ADD_TO_SHARED_DATA set
          */
         new_area.vm_flags &= ~VM_ADD_TO_SHARED_DATA;
-        LOG(GLOBAL, LOG_VMAREAS, 3, "\tadding "PFX"-"PFX"\n", new_area.start, new_area.end);
+        LOG(GLOBAL, LOG_VMAREAS, 3, "\tadding "PFX"-"PFX"\n",
+            new_area.start, new_area.end);
         /* we copied v->buf[overlap_start] above and so already have a copy
          * of the client field
          */
@@ -1601,9 +1606,11 @@ vm_areas_init()
 # endif
 #endif
 
-    shared_data = HEAP_TYPE_ALLOC(GLOBAL_DCONTEXT, thread_data_t, ACCT_VMAREAS, PROTECTED);
+    shared_data = HEAP_TYPE_ALLOC(GLOBAL_DCONTEXT, thread_data_t, ACCT_VMAREAS,
+                                  PROTECTED);
 
-    todelete = HEAP_TYPE_ALLOC(GLOBAL_DCONTEXT, deletion_lists_t, ACCT_VMAREAS, PROTECTED);
+    todelete = HEAP_TYPE_ALLOC(GLOBAL_DCONTEXT, deletion_lists_t, ACCT_VMAREAS,
+                               PROTECTED);
     memset(todelete, 0, sizeof(*todelete));
 
     coarse_to_delete = HEAP_TYPE_ALLOC(GLOBAL_DCONTEXT, coarse_info_t *,
@@ -1621,7 +1628,7 @@ vm_areas_init()
 
     /* initialize dynamo list first */
     LOG(GLOBAL, LOG_VMAREAS, 2,
-        "\n--------------------------------------------------------------------------\n");
+        "\n------------------------------------------------------------------------\n");
     dynamo_vm_areas_lock();
     areas = find_dynamo_library_vm_areas();
     dynamo_vm_areas_unlock();
@@ -1638,7 +1645,7 @@ vm_areas_init()
             print_executable_areas(GLOBAL);
         }
         LOG(GLOBAL, LOG_VMAREAS, 2,
-            "--------------------------------------------------------------------------\n");
+            "------------------------------------------------------------------------\n");
     });
 
     return areas;
@@ -1767,9 +1774,10 @@ vm_areas_exit()
 
 #ifdef PROGRAM_SHEPHERDING
     DOLOG(1, LOG_VMAREAS, {
-        if (futureexec_areas->buf != NULL)
+        if (futureexec_areas->buf != NULL) {
             LOG(GLOBAL, LOG_VMAREAS, 1, "futureexec %d regions at exit are:\n",
                 futureexec_areas->length);
+        }
         print_futureexec_areas(GLOBAL);
     });
     vmvector_delete_vector(GLOBAL_DCONTEXT, futureexec_areas);
@@ -1831,7 +1839,8 @@ vm_areas_thread_exit(dcontext_t *dcontext)
     vm_areas_thread_reset_free(dcontext);
 #ifdef DEBUG
     /* for non-debug we do fast exit path and don't free local heap */
-    HEAP_TYPE_FREE(dcontext, dcontext->vm_areas_field, thread_data_t, ACCT_OTHER, PROTECTED);
+    HEAP_TYPE_FREE(dcontext, dcontext->vm_areas_field, thread_data_t, ACCT_OTHER,
+                   PROTECTED);
 #endif
 }
 
@@ -2569,7 +2578,8 @@ add_executable_vm_area_helper(app_pc start, app_pc end, uint vm_flags, uint frag
     }
     DOLOG(2, LOG_VMAREAS, {
         /* new area could have been split into multiple */
-        print_contig_vm_areas(executable_areas, start, end, GLOBAL, "new executable vm area: ");
+        print_contig_vm_areas(executable_areas, start, end, GLOBAL,
+                              "new executable vm area: ");
     });
 }
 
@@ -2725,7 +2735,8 @@ add_executable_vm_area(app_pc start, app_pc end, uint vm_flags, uint frag_flags,
 
     DOLOG(2, LOG_VMAREAS, {
         /* new area could have been split into multiple */
-        print_contig_vm_areas(executable_areas, start, end, GLOBAL, "new executable vm area: ");
+        print_contig_vm_areas(executable_areas, start, end, GLOBAL,
+                              "new executable vm area: ");
     });
 
     if (!have_writelock) {
@@ -3885,8 +3896,10 @@ const char * const action_message[] = {
     /* no trailing newlines for SYSLOG_INTERNAL */
     MESSAGE_EXEC_VIOLATION MESSAGE_CONTACT_VENDOR "Program terminated.",
     MESSAGE_EXEC_VIOLATION MESSAGE_CONTACT_VENDOR "Program continuing!",
-    MESSAGE_EXEC_VIOLATION MESSAGE_CONTACT_VENDOR "Program continuing after terminating thread.",
-    MESSAGE_EXEC_VIOLATION MESSAGE_CONTACT_VENDOR "Program continuing after throwing an exception."
+    MESSAGE_EXEC_VIOLATION MESSAGE_CONTACT_VENDOR
+    "Program continuing after terminating thread.",
+    MESSAGE_EXEC_VIOLATION MESSAGE_CONTACT_VENDOR
+    "Program continuing after throwing an exception."
 };
 
 /* event log message IDs */
@@ -3990,7 +4003,9 @@ get_security_violation_name(dcontext_t *dcontext,
     case STACK_EXECUTION_VIOLATION:    name[10] = 'A'; break;
     case HEAP_EXECUTION_VIOLATION:     name[10] = 'B'; break;
     case RETURN_TARGET_VIOLATION:      name[10] = 'C'; break;
-    case RETURN_DIRECT_RCT_VIOLATION:  name[10] = 'D'; ASSERT_NOT_IMPLEMENTED(false); break;
+    case RETURN_DIRECT_RCT_VIOLATION:  name[10] = 'D';
+        ASSERT_NOT_IMPLEMENTED(false);
+        break;
     case INDIRECT_CALL_RCT_VIOLATION:  name[10] = 'E'; break;
     case INDIRECT_JUMP_RCT_VIOLATION:  name[10] = 'F'; break;
 #ifdef HOT_PATCHING_INTERFACE
@@ -4061,11 +4076,13 @@ security_violation_report(app_pc addr, security_violation_t violation_type,
     if (!IS_STRING_OPTION_EMPTY(silent_block_threat_list)) {
         bool onlist;
         string_option_read_lock();
-        onlist = check_filter_with_wildcards(DYNAMO_OPTION(silent_block_threat_list), name);
+        onlist = check_filter_with_wildcards(DYNAMO_OPTION(silent_block_threat_list),
+                                             name);
         string_option_read_unlock();
         if (onlist) {
             LOG(THREAD_GET, LOG_INTERP|LOG_VMAREAS, 1,
-                "WARNING: threat %s is on silent block list, suppressing reporting\n", name);
+                "WARNING: threat %s is on silent block list, suppressing reporting\n",
+                name);
             SYSLOG_INTERNAL_WARNING_ONCE("threat %s silently blocked", name);
             STATS_INC(num_silently_blocked_threat);
             return false;
@@ -4146,7 +4163,7 @@ security_violation_report(app_pc addr, security_violation_t violation_type,
     return true;
 }
 
-/* attack handling - reports violation and decides on action - possibly terminates the process
+/* Attack handling: reports violation, decides on action, possibly terminates the process.
  * N.B.: we make assumptions about whether the callers of this routine hold
  * various locks, so be careful when adding new callers.
  *
@@ -4205,7 +4222,9 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
     /* case 8075: we no longer unprot .data on the violation path */
     ASSERT(check_should_be_protected(DATASEC_RARELY_PROT));
 
-    /* CHECK: all options for attack handling and reporting are dynamic, synchronized only once */
+    /* CHECK: all options for attack handling and reporting are dynamic,
+     * synchronized only once.
+     */
     synchronize_dynamic_options();
 
 #ifdef HOT_PATCHING_INTERFACE
@@ -4250,8 +4269,11 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
      * while we're nolinking due to init-extra-vmareas on the frags list!
      */
 
-    /* diagnose_violation_mode says to check if would have allowed if were allowing patterns */
-    if (dynamo_options.diagnose_violation_mode && !dynamo_options.executable_if_trampoline) {
+    /* diagnose_violation_mode says to check if would have allowed if were
+     * allowing patterns.
+     */
+    if (dynamo_options.diagnose_violation_mode &&
+        !dynamo_options.executable_if_trampoline) {
         size_t junk;
         if (check_origins_bb_pattern(dcontext, addr, (app_pc *) &junk, &junk,
                                      (uint *) &junk, (uint *) &junk)
@@ -4293,19 +4315,22 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
             DO_THRESHOLD_SAFE(DYNAMO_OPTION(detect_mode_max), FREQ_PROTECTED_SECTION,
                               {/* < max */
                                   LOG(GLOBAL, LOG_ALL, 1,
-                                      "security_violation: allowing violation #%d [max %d], tid="TIDFMT"\n",
+                                      "security_violation: allowing violation #%d "
+                                      "[max %d], tid="TIDFMT"\n",
                                       do_threshold_cur, DYNAMO_OPTION(detect_mode_max),
                                       get_thread_id());
                               },
                               {/* >= max */
                                   allow = false;
                                   LOG(GLOBAL, LOG_ALL, 1,
-                                      "security_violation: reached maximum allowed %d, tid="TIDFMT"\n",
+                                      "security_violation: reached maximum allowed %d, "
+                                      "tid="TIDFMT"\n",
                                       DYNAMO_OPTION(detect_mode_max), get_thread_id());
                               });
         } else {
             LOG(GLOBAL, LOG_ALL, 1,
-                "security_violation: allowing violation, no max, tid=%d\n", get_thread_id());
+                "security_violation: allowing violation, no max, tid=%d\n",
+                get_thread_id());
         }
         if (allow) {
             /* we have priority over other handling options */
@@ -4327,7 +4352,8 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
     if (!action_selected && DYNAMO_OPTION(throw_exception)) {
         thread_data_t *thread_local = (thread_data_t *) dcontext->vm_areas_field;
         /* maintain a thread local counter to bail out and avoid infinite exceptions */
-        if (thread_local->thrown_exceptions < DYNAMO_OPTION(throw_exception_max_per_thread)) {
+        if (thread_local->thrown_exceptions <
+            DYNAMO_OPTION(throw_exception_max_per_thread)) {
 #  ifdef WINDOWS
             /* If can't verify consistent SEH chain should fall through to kill path */
             /* UnhandledExceptionFilter is always installed. */
@@ -4353,7 +4379,8 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
                 if (!global_max_reached) {
                     thread_local->thrown_exceptions++;
                     LOG(GLOBAL, LOG_ALL, 1,
-                        "security_violation: throwing exception %d for this thread [max pt %d] [global max %d]\n",
+                        "security_violation: throwing exception %d for this thread "
+                        "[max pt %d] [global max %d]\n",
                         thread_local->thrown_exceptions,
                         dynamo_options.throw_exception_max_per_thread,
                         dynamo_options.throw_exception_max);
@@ -4362,7 +4389,8 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
                 }
             } else {
                 LOG(GLOBAL, LOG_ALL, 1,
-                    "security_violation: SEH chain invalid [%d], better kill\n", seh_chain_depth);
+                    "security_violation: SEH chain invalid [%d], better kill\n",
+                    seh_chain_depth);
             }
 #  else
             ASSERT_NOT_IMPLEMENTED(false);
@@ -4384,18 +4412,19 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
                         "security_violation: \t killing thread #%d [max %d], tid=%d\n",
                         do_threshold_cur, DYNAMO_OPTION(kill_thread_max),
                         get_thread_id());
-                    /* FIXME: can't check if get_num_threads()==1 then say we're killing process
-                     * because it is possible that another thread has not been scheduled yet
-                     * and we wouldn't have seen it.
-                     * Still, only our message will be wrong if we end up killing the process,
-                     * when we terminate the last thread
+                    /* FIXME: can't check if get_num_threads()==1 then say we're
+                     * killing process because it is possible that another
+                     * thread has not been scheduled yet and we wouldn't have
+                     * seen it.  Still, only our message will be wrong if we end
+                     * up killing the process, when we terminate the last thread
                      */
                     action = ACTION_TERMINATE_THREAD;
                     action_selected = true;
                 },
                 {/* >= max */
                     LOG(GLOBAL, LOG_ALL, 1,
-                        "security_violation: reached maximum thread kill, kill process now\n");
+                        "security_violation: reached maximum thread kill, "
+                        "kill process now\n");
                     action = ACTION_TERMINATE_PROCESS;
                     action_selected = true;
                 });
@@ -5081,8 +5110,8 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
                 }
                 if (once_only) {
                     LOG(THREAD, LOG_INTERP|LOG_VMAREAS, 2,
-                        "future exec "PFX"-"PFX" is once-only, removing from future list\n",
-                        *base, *base+*size);
+                        "future exec "PFX"-"PFX" is once-only, removing from "
+                        "future list\n", *base, *base+*size);
                     ok = remove_futureexec_vm_area(*base, *base+*size);
                     ASSERT(ok);
                     STATS_INC(num_exec_future_once);
@@ -5108,7 +5137,8 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
                 bool allow = false;
                 if (DYNAMO_OPTION(executable_if_text)) {
                     LOG(THREAD, LOG_INTERP|LOG_VMAREAS, 2,
-                        "exec region is in code section of module @"PFX" (%s), allowing\n",
+                        "exec region is in code section of module @"PFX" (%s), "
+                        "allowing\n",
                         modbase, modname == NULL? "<invalid name>" : modname);
                     STATS_INC(num_text);
                     mark_module_exempted(addr);
@@ -5140,7 +5170,8 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
                         string_option_read_unlock();
                         if (onlist) {
                             LOG(THREAD, LOG_INTERP|LOG_VMAREAS, 2,
-                                "module %s is on text list, allowing execution\n", modname);
+                                "module %s is on text list, allowing execution\n",
+                                modname);
                             STATS_INC(num_text_list);
                             SYSLOG_INTERNAL_WARNING_ONCE("code origins: module %s text "
                                                          "section exempt", modname);
@@ -5150,12 +5181,10 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
                     }
 
                     if (!allow && modname != NULL) {
-                        deflist =
-                            check_list_default_and_append(dynamo_options.
-                                                          exempt_mapped_image_text_default_list,
-                                                          dynamo_options.
-                                                          exempt_mapped_image_text_list,
-                                                          modname);
+                        deflist = check_list_default_and_append
+                            (dynamo_options.exempt_mapped_image_text_default_list,
+                             dynamo_options.exempt_mapped_image_text_list,
+                             modname);
                     }
                     if (deflist != LIST_NO_MATCH) {
                         bool image_mapping = is_mapped_as_image(modbase);
@@ -5164,8 +5193,8 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
                                 "module %s is on text list, of a mapped IMAGE"
                                 " allowing execution\n", modname);
                             STATS_INC(num_image_text_list);
-                            SYSLOG_INTERNAL_WARNING_ONCE("code origins: module %s IMAGE text "
-                                                         "section exempt", modname);
+                            SYSLOG_INTERNAL_WARNING_ONCE("code origins: module %s IMAGE "
+                                                         "text section exempt", modname);
                             if (deflist == LIST_ON_APPEND) /* case 9799: not default */
                                 mark_module_exempted(addr);
                             allow = true;
@@ -5209,7 +5238,8 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
                         LOG(THREAD, LOG_INTERP|LOG_VMAREAS, 3,
                             "exec region is in data of module %s, vs list %s\n",
                             modname, DYNAMO_OPTION(exempt_dot_data_list));
-                        onlist = check_filter(DYNAMO_OPTION(exempt_dot_data_list), modname);
+                        onlist = check_filter(DYNAMO_OPTION(exempt_dot_data_list),
+                                              modname);
                         string_option_read_unlock();
                         DOSTATS({
                             if (onlist)
@@ -5246,7 +5276,8 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
                             LOG(THREAD, LOG_INTERP|LOG_VMAREAS, 3,
                                 "exec region is in x data of module %s, vs list %s\n",
                                 modname, DYNAMO_OPTION(exempt_dot_data_x_list));
-                            onlist = check_filter_with_wildcards(DYNAMO_OPTION(exempt_dot_data_x_list), modname);
+                            onlist = check_filter_with_wildcards
+                                (DYNAMO_OPTION(exempt_dot_data_x_list), modname);
                             string_option_read_unlock();
                             DOSTATS({
                                 if (onlist)
@@ -5370,7 +5401,8 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
         ASSERT(translated_pc != NULL);
         modbase = get_module_base(translated_pc);
         LOG(THREAD, LOG_INTERP|LOG_VMAREAS, 3,
-            "check_origins: dll2heap and dll2stack for "PFX": cache "PFX" => app "PFX" == mod "PFX"\n",
+            "check_origins: dll2heap and dll2stack for "PFX": cache "PFX" => app "
+            PFX" == mod "PFX"\n",
             addr, EXIT_CTI_PC(dcontext->last_fragment, dcontext->last_exit),
             translated_pc, modbase);
         if (modbase != NULL) { /* PE, and is readable */
@@ -5536,7 +5568,8 @@ check_origins(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *size,
          * and then we'd need to add them now.
          * FIXME: xref case 3742
          */
-        ASSERT_BUG_NUM(3742, !DYNAMO_OPTION(executable_if_x) || !TEST(MEMPROT_EXEC, prot));
+        ASSERT_BUG_NUM(3742, !DYNAMO_OPTION(executable_if_x) ||
+                       !TEST(MEMPROT_EXEC, prot));
         ASSERT(!DYNAMO_OPTION(executable_if_rx) || !TEST(MEMPROT_EXEC, prot) ||
                               TEST(MEMPROT_WRITE, prot));
     }
@@ -5620,7 +5653,7 @@ next_simulate_at_fragment(char **tokpos /* OUT */, int *action /* OUT */)
     char *fragnum;
 
     // assumes sscanf won't get confused with the ,s
-    for(fragnum = *tokpos; fragnum; fragnum = *tokpos) {
+    for (fragnum = *tokpos; fragnum; fragnum = *tokpos) {
         int num;
         *tokpos = strchr(fragnum, ','); /* next ptr */
         if (*tokpos)
@@ -5856,7 +5889,8 @@ prepend_fraglist(dcontext_t *dcontext, vm_area_t *area, app_pc entry_pc,
                  app_pc tag, fragment_t *prev)
 {
     multi_entry_t *e = (multi_entry_t *)
-        nonpersistent_heap_alloc(dcontext, sizeof(multi_entry_t) HEAPACCT(ACCT_VMAREA_MULTI));
+        nonpersistent_heap_alloc(dcontext, sizeof(multi_entry_t)
+                                 HEAPACCT(ACCT_VMAREA_MULTI));
     fragment_t * entry = (fragment_t *) e;
     e->flags = FRAG_FAKE | FRAG_IS_EXTRA_VMAREA | /* distinguish from fragment_t */
         FRAG_IS_EXTRA_VMAREA_INIT; /* indicate f field is a tag, not a fragment_t yet */
@@ -6097,8 +6131,8 @@ app_memory_allocation(dcontext_t *dcontext, app_pc base, size_t size, uint prot,
             }
 # else
             if (dcontext != NULL || image) {
-                /* can't distinguish stack -- saved at init time since we don't add rwx then,
-                 * but what about stacks whose creation we see?  FIXME
+                /* XXX: can't distinguish stack -- saved at init time since we don't
+                 * add rwx then, but what about stacks whose creation we see?
                  */
                 future = true;
                 LOG(GLOBAL, LOG_VMAREAS, 1,
@@ -6334,7 +6368,8 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
     bool dr_overlap = DYNAMO_OPTION(handle_DR_modify) != DR_MODIFY_OFF /* we don't care */
         && dynamo_vm_area_overlap(base, base + size);
 
-    bool system_overlap = DYNAMO_OPTION(handle_ntdll_modify) != DR_MODIFY_OFF /* we don't care */
+    bool system_overlap =
+        DYNAMO_OPTION(handle_ntdll_modify) != DR_MODIFY_OFF /* we don't care */
         && tamper_resistant_region_overlap(base, base + size);
 
     bool patch_proof_overlap = false;
@@ -6358,9 +6393,9 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
         bool patching_code = is_range_in_code_section(modbase, base, base+size,
                                                       NULL, NULL);
         bool patching_IAT = is_IAT(base, base+size, true/*page-align*/, NULL, NULL);
-        /* FIXME: [perf] could have added CODE sections instead of modules to patch_proof_areas */
+        /* FIXME: [perf] could add CODE sections, not modules, to patch_proof_areas */
         /* FIXME: [minor perf] is_module_patch_region already collected these */
-        /* FIXME: [minor perf] same check is done later for all IATs for emulate_IAT_writes */
+        /* FIXME: [minor perf] same check is done later for IATs for emulate_IAT_writes */
 
         bool patch_proof_IAT = false; /* NYI - case 6622 */
         /* FIXME: case 6622 IAT hooker protection for some modules is
@@ -6373,7 +6408,8 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
             /* even if it is not the loader we protect IAT sections only */
             (!patching_IAT || patch_proof_IAT);
 
-        LOG(THREAD, LOG_VMAREAS, 1, "patch proof module "PFX"-"PFX" modified %s, by %s,%s=>%s\n",
+        LOG(THREAD, LOG_VMAREAS, 1,
+            "patch proof module "PFX"-"PFX" modified %s, by %s,%s=>%s\n",
             base, base+size,
             patching_code ? "code!" : "data --ok",
             loader ? "loader --ok" : patching_code ? "hooker!" : "loader or hooker",
@@ -6456,12 +6492,14 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
                 page_size = ALIGN_FORWARD(base + size, PAGE_SIZE) - (size_t)page_base;
                 write_lock(&pretend_writable_areas->lock);
                 if (TEST(MEMPROT_WRITE, prot)) {
-                    LOG(THREAD, LOG_VMAREAS, 2, "adding pretend-writable region "PFX"-"PFX"\n",
+                    LOG(THREAD, LOG_VMAREAS, 2,
+                        "adding pretend-writable region "PFX"-"PFX"\n",
                         page_base, page_base+page_size);
                     add_vm_area(pretend_writable_areas, page_base, page_base+page_size,
                                 true, 0, NULL _IF_DEBUG("DR_MODIFY_NOP"));
                 } else {
-                    LOG(THREAD, LOG_VMAREAS, 2, "removing pretend-writable region "PFX"-"PFX"\n",
+                    LOG(THREAD, LOG_VMAREAS, 2,
+                        "removing pretend-writable region "PFX"-"PFX"\n",
                         page_base, page_base+page_size);
                     remove_vm_area(pretend_writable_areas, page_base,
                                    page_base+page_size, false);
@@ -6537,7 +6575,8 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
              */
             /* xref case 3102 - where we don't care about VM_WRITABLE */
 #if 0 /* this syslog may causes services.exe to hang (ref case 666)  */
-            SYSLOG_INTERNAL_WARNING("future executable area overlapping with "PFX"-"PFX" made %s",
+            SYSLOG_INTERNAL_WARNING("future executable area overlapping with "PFX"-"
+                                    PFX" made %s",
                                     base, base + size, memprot_string(prot));
 #endif
         }
@@ -6721,7 +6760,8 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
             "\tRemoving from executable list\n",
             base, base + size);
         /* use two-part flush to make futureexec & exec changes atomic w/ flush */
-        should_finish_flushing = flush_and_remove_executable_vm_area(dcontext, base, size);
+        should_finish_flushing =
+            flush_and_remove_executable_vm_area(dcontext, base, size);
         /* we flush_fragments_finish after security checks to keep them atomic */
     }
     else if (is_executable && is_executable_area_writable(base) &&
@@ -6735,7 +6775,8 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
             base, base + size);
         /* remove writable exec area, then add read-only exec area */
         /* use two-part flush to make futureexec & exec changes atomic w/ flush */
-        should_finish_flushing = flush_and_remove_executable_vm_area(dcontext, base, size);
+        should_finish_flushing =
+            flush_and_remove_executable_vm_area(dcontext, base, size);
         /* FIXME: this is wrong -- this will make all pieces in the middle executable,
          * which is not what we want -- we want all pieces ON THE EXEC LIST to
          * change from rw to r.  thus this should be like the change-to-selfmod case
@@ -6904,7 +6945,8 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
                                          "executable_if_x protect exec .-x"
                                          ));
         mark_module_exempted(base);
-    } else if (DYNAMO_OPTION(executable_if_hook) && TESTALL(MEMPROT_WRITE | MEMPROT_EXEC, prot)) {
+    } else if (DYNAMO_OPTION(executable_if_hook) &&
+               TESTALL(MEMPROT_WRITE | MEMPROT_EXEC, prot)) {
         /* Note here we're strict in requesting a .WX setting by the
          * hooker, won't be surprising if some don't do even this
          */
@@ -6966,7 +7008,7 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
                 add_executable_vm_area(base, base + size, vm_flags,
                                        0, should_finish_flushing/* own the lock if
                                                                    we have flushed */
-                                       _IF_DEBUG("prot chg text rx->rwx not yet written"));
+                                       _IF_DEBUG("prot chg txt rx->rwx not yet written"));
                 /* leave read only since we are leaving on exec list */
                 if (should_finish_flushing) {
                     flush_fragments_in_region_finish(dcontext,
@@ -7683,8 +7725,10 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
 
                     /* Create an exception record for this failure */
                     if (TEST(DUMPCORE_FORGE_UNREAD_EXEC,
-                             DYNAMO_OPTION(dumpcore_mask)))
-                        os_dump_core("Warning: App trying to execute from unreadable memory");
+                             DYNAMO_OPTION(dumpcore_mask))) {
+                        os_dump_core("Warning: App trying to execute from unreadable "
+                                     "memory");
+                    }
                     os_forge_exception(pc, UNREADABLE_MEMORY_EXECUTION_EXCEPTION);
                     ASSERT_NOT_REACHED();
                 }
@@ -7892,15 +7936,16 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
 
     if (area == NULL /* unknown area */) {
         LOG(GLOBAL, LOG_VMAREAS, 2,
-            "WARNING: "PFX" -> "PFX"-"PFX" %s%s is not on executable list (thread "TIDFMT")\n",
-            pc, base_pc, base_pc+size,
+            "WARNING: "PFX" -> "PFX"-"PFX" %s%s is not on executable list (thread "
+            TIDFMT")\n", pc, base_pc, base_pc+size,
             ((prot & MEMPROT_WRITE) != 0)?"W":"", ((prot & MEMPROT_EXEC) != 0)?"E":"",
             dcontext->owning_thread);
         DOLOG(3, LOG_VMAREAS, { print_executable_areas(GLOBAL); });
         DODEBUG({
-            if (is_on_stack(dcontext, pc, NULL))
+            if (is_on_stack(dcontext, pc, NULL)) {
                 SYSLOG_INTERNAL_WARNING_ONCE("executing region with pc "PFX" on "
                                              "the stack.", pc);
+            }
         });
 #ifdef DGC_DIAGNOSTICS
         dyngen_diagnostics(dcontext, pc, base_pc, size, prot);
@@ -8064,8 +8109,11 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
 #endif
 #ifdef PROGRAM_SHEPHERDING
         DOSTATS({
-            if (!TEST(VM_UNMOD_IMAGE, area->vm_flags) && TEST(VM_WAS_FUTURE, area->vm_flags)) {
-                /* increment for other threads (1st thread will be inc-ed in check_origins_helper) */
+            if (!TEST(VM_UNMOD_IMAGE, area->vm_flags) &&
+                TEST(VM_WAS_FUTURE, area->vm_flags)) {
+                /* increment for other threads (1st thread will be inc-ed in
+                 * check_origins_helper)
+                 */
                 if (is_on_stack(dcontext, area->start, area)) {
                     STATS_INC(num_exec_future_stack);
                 } else {
@@ -8075,7 +8123,8 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
         });
 # ifdef WINDOWS
         DOSTATS({
-            if (!TEST(VM_UNMOD_IMAGE, area->vm_flags) && !TEST(VM_WAS_FUTURE, area->vm_flags))
+            if (!TEST(VM_UNMOD_IMAGE, area->vm_flags) &&
+                !TEST(VM_WAS_FUTURE, area->vm_flags))
                 STATS_INC(num_exec_after_load);
         });
 # endif
@@ -8209,10 +8258,11 @@ check_in_last_thread_vm_area(dcontext_t *dcontext, app_pc pc)
     /* note that if data is NULL &data->last_area will not be readable either */
     if (is_readable_without_exception((app_pc)&data->last_area, 4) &&
         is_readable_without_exception((app_pc)&data->last_area->end, 4) &&
-        is_readable_without_exception((app_pc)&data->last_area->start, 4))
+        is_readable_without_exception((app_pc)&data->last_area->start, 4)) {
         /* we can walk off to the next page */
         in_last = (pc < data->last_area->end + MAX_INSTR_LENGTH &&
                    data->last_area->start <= pc);
+    }
     /* last decoded app pc may be in last shared area instead */
     if (!in_last && DYNAMO_OPTION(shared_bbs)) {
         /* FIXME: bad to grab on failure path...
@@ -8220,10 +8270,11 @@ check_in_last_thread_vm_area(dcontext_t *dcontext, app_pc pc)
          */
         SHARED_VECTOR_RWLOCK(&shared_data->areas, read, lock);
         if (is_readable_without_exception((app_pc)&shared_data->last_area->end, 4) &&
-            is_readable_without_exception((app_pc)&shared_data->last_area->start, 4))
+            is_readable_without_exception((app_pc)&shared_data->last_area->start, 4)) {
             /* we can walk off to the next page */
             in_last = (pc < shared_data->last_area->end + MAX_INSTR_LENGTH &&
                        shared_data->last_area->start <= pc);
+        }
         SHARED_VECTOR_RWLOCK(&shared_data->areas, read, unlock);
     }
     /* the last decoded app pc may be in the last decoded page or the page after
@@ -8346,7 +8397,8 @@ vm_area_add_fragment(dcontext_t *dcontext, fragment_t *f, void *vmlist)
         /* only bbs do we build shared and then switch to private */
         ASSERT(!TEST(FRAG_IS_TRACE, f->flags));
         data = (thread_data_t *) dcontext->vm_areas_field;
-        LOG(THREAD, LOG_VMAREAS, 4, "\tbb not shared, shifting vm data to thread-local\n");
+        LOG(THREAD, LOG_VMAREAS, 4,
+            "\tbb not shared, shifting vm data to thread-local\n");
         remove_shared_vmlist(dcontext, vmlist, f, &local_vmlist);
         /* now proceed as though everything were local to begin with */
         vmlist = local_vmlist;
@@ -8595,7 +8647,9 @@ vm_area_add_to_list(dcontext_t *dcontext, app_pc tag, void **vmlist,
         }
         if (!ok) {
             /* found new area that trace is on */
-            /* src may be shared bb, its area may not be on tgt list (e.g., private trace) */
+            /* src may be shared bb, its area may not be on tgt list (e.g.,
+             * private trace)
+             */
             if (src_data != tgt_data) { /* else, have area already */
                 vm_area_t *tgt_area = NULL;
                 if (lookup_addr(&tgt_data->areas, FRAG_PC(entry), &tgt_area)) {
@@ -8824,7 +8878,7 @@ vm_area_clean_fraglist(dcontext_t *dcontext, vm_area_t *area)
                 also_next = FRAG_ALSO(also);
                 if (pc >= area->start && pc < area->end) {
                     ASSERT(FRAG_FRAG(also) == f);
-                    DOLOG(5, LOG_VMAREAS, { print_entry(dcontext, also, "\tremoving "); });
+                    DOLOG(5, LOG_VMAREAS, {print_entry(dcontext, also, "\tremoving ");});
                     /* we have to remove from also chain ourselves */
                     FRAG_ALSO_ASSIGN(also_prev, also_next);
                     /* now remove from area frags list */
@@ -8838,7 +8892,9 @@ vm_area_clean_fraglist(dcontext_t *dcontext, vm_area_t *area)
                 /* Remove this multi entry */
                 DOLOG(5, LOG_VMAREAS, { print_entry(dcontext, entry, "\tremoving "); });
                 /* we have to remove from also chain ourselves */
-                for (also_prev = f; FRAG_ALSO(also_prev) != entry; also_prev = FRAG_ALSO(also_prev))
+                for (also_prev = f;
+                     FRAG_ALSO(also_prev) != entry;
+                     also_prev = FRAG_ALSO(also_prev))
                     ;
                 FRAG_ALSO_ASSIGN(also_prev, FRAG_ALSO(entry));
                 /* now remove from area frags list */
@@ -9411,7 +9467,8 @@ vm_area_unlink_fragments(dcontext_t *dcontext, app_pc start, app_pc end,
                 f->flags |= FRAG_WAS_DELETED;
             }
             DOLOG(6, LOG_VMAREAS, {
-                print_fraglist(dcontext, &data->areas.buf[i], "Fragments after unlinking\n");
+                print_fraglist(dcontext, &data->areas.buf[i],
+                               "Fragments after unlinking\n");
             });
             if (data == shared_data) {
                 if (data->areas.buf[i].custom.frags != NULL) {
@@ -9509,7 +9566,8 @@ vm_area_check_shared_pending(dcontext_t *dcontext, fragment_t *was_I_flushed)
     ASSERT(dcontext != GLOBAL_DCONTEXT || dynamo_exited || dynamo_resetting);
 
     LOG(THREAD, LOG_FRAGMENT|LOG_VMAREAS, 2,
-        "thread "TIDFMT" (flushtime %d) walking pending deletion list (was_I_flushed==F%d)\n",
+        "thread "TIDFMT" (flushtime %d) walking pending deletion list "
+        "(was_I_flushed==F%d)\n",
         get_thread_id(), dcontext == GLOBAL_DCONTEXT ? flushtime_global :
         get_flushtime_last_update(dcontext),
         (was_I_flushed==NULL) ? -1 : was_I_flushed->id);
@@ -9734,7 +9792,8 @@ vm_area_flush_fragments(dcontext_t *dcontext, fragment_t *was_I_flushed)
                 next = FRAG_NEXT(entry);
                 LOG(THREAD, LOG_FRAGMENT|LOG_VMAREAS, 5,
                     "\tremoving "PFX"%s F%d("PFX")\n",
-                    entry, FRAG_MULTI(entry) ? " multi": "", FRAG_ID(entry), FRAG_PC(entry));
+                    entry, FRAG_MULTI(entry) ? " multi": "", FRAG_ID(entry),
+                    FRAG_PC(entry));
                 if (FRAG_FRAG(entry) == was_I_flushed) {
                     not_flushed = false;
                     if (was_I_flushed == dcontext->last_fragment)
@@ -10589,11 +10648,14 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc,
                                             true /* exec invalid */,
                                             false /* don't force synchall */
                                             _IF_DGCDIAG(target));
-            /* flush_* grabbed exec areas lock for us, to make following sequence atomic */
-            /* need to change all exec areas on these pages to be selfmod */
+            /* flush_* grabbed exec areas lock for us, to make following
+             * sequence atomic.
+             * Need to change all exec areas on these pages to be selfmod.
+             */
             for (ok = true, nxt_on_page = (app_pc) tgt_pstart;
                  ok && nxt_on_page < (app_pc)tgt_pend + PAGE_SIZE; ) {
-                ok = binary_search(executable_areas, nxt_on_page, (app_pc)tgt_pend+PAGE_SIZE,
+                ok = binary_search(executable_areas, nxt_on_page,
+                                   (app_pc)tgt_pend+PAGE_SIZE,
                                    &execarea, NULL, true /* want 1st match! */);
                 if (ok) {
                     nxt_on_page = execarea->end;
@@ -10601,8 +10663,10 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc,
                         /* not calling remove_vm_area so we have to vm_make_writable
                          * FIXME: why do we have to do anything if already selfmod?
                          */
-                        if (DR_MADE_READONLY(execarea->vm_flags))
-                            vm_make_writable(execarea->start, execarea->end - execarea->start);
+                        if (DR_MADE_READONLY(execarea->vm_flags)) {
+                            vm_make_writable(execarea->start,
+                                             execarea->end - execarea->start);
+                        }
                         continue;
                     }
                     if (execarea->start < (app_pc)tgt_pstart ||
@@ -10635,8 +10699,10 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc,
                         execarea->frag_flags |= SANDBOX_FLAG();
                         STATS_INC(num_selfmod_vm_areas);
                         /* not calling remove_vm_area so we have to vm_make_writable */
-                        if (DR_MADE_READONLY(execarea->vm_flags))
-                            vm_make_writable(execarea->start, execarea->end - execarea->start);
+                        if (DR_MADE_READONLY(execarea->vm_flags)) {
+                            vm_make_writable(execarea->start,
+                                             execarea->end - execarea->start);
+                        }
                     }
                 }
             }
@@ -11124,7 +11190,8 @@ mark_unload_end(app_pc module_base)
                      ((last_deallocated->last_unload_base <= module_base &&
                        module_base <
                        (last_deallocated->last_unload_base +
-                        last_deallocated->last_unload_size)) && "race - multiple unmaps"));
+                        last_deallocated->last_unload_size)) &&
+                      "race - multiple unmaps"));
     DOLOG(1, LOG_VMAREAS, {
         /* there are a few cases where DLLs aren't unloaded by real
          * base uxtheme.dll, but I haven't seen them */
@@ -11369,7 +11436,8 @@ apc_thread_policy_helper(app_pc *apc_target_location, /* IN/OUT */
              * (since we are not under dispatch()).  If we want to see a
              * code origins failure, we can just disable this policy.
              */
-            ASSERT(!TEST(OPTION_HANDLING, target_policy) && "handling cannot be modified");
+            ASSERT(!TEST(OPTION_HANDLING, target_policy) &&
+                   "handling cannot be modified");
 
             SYSLOG_INTERNAL_WARNING("squashed %s %s at bad target pc="PFX" %s",
                                     is_apc ? "APC" : "thread",
@@ -11559,7 +11627,7 @@ vmvector_tests()
     EXPECT(res, true);
     EXPECT(start, 0x200);
     vmvector_print(&v, STDERR);
-    res = vmvector_remove(&v, INT_TO_PC(0x20), INT_TO_PC(0x210)); /* truncation allowed? */
+    res = vmvector_remove(&v, INT_TO_PC(0x20), INT_TO_PC(0x210));/* truncation allowed? */
     EXPECT(res, true);
     vmvector_print(&v, STDERR);
 }
@@ -11597,7 +11665,8 @@ unit_test_vmareas(void)
      * that cannot be merged
      */
     add_vm_area(&v, INT_TO_PC(1), INT_TO_PC(3), 0, 0, NULL _IF_DEBUG("A"));
-    add_vm_area(&v, INT_TO_PC(5), INT_TO_PC(7), 0, FRAG_SELFMOD_SANDBOXED, NULL _IF_DEBUG("B"));
+    add_vm_area(&v, INT_TO_PC(5), INT_TO_PC(7), 0, FRAG_SELFMOD_SANDBOXED, NULL
+                _IF_DEBUG("B"));
     add_vm_area(&v, INT_TO_PC(9), INT_TO_PC(11), 0, 0, NULL _IF_DEBUG("C"));
     print_vector_msg(&v, STDERR, "after adding areas");
     check_vec(&v, 0, INT_TO_PC(1), INT_TO_PC(3), 0, 0, NULL);
@@ -11623,8 +11692,10 @@ unit_test_vmareas(void)
     /* TEST 3: add an area that covers several smaller ones, including two
      * that cannot be merged
      */
-    add_vm_area(&v, INT_TO_PC(1), INT_TO_PC(3), 0, FRAG_SELFMOD_SANDBOXED, NULL _IF_DEBUG("A"));
-    add_vm_area(&v, INT_TO_PC(5), INT_TO_PC(7), 0, FRAG_SELFMOD_SANDBOXED, NULL _IF_DEBUG("B"));
+    add_vm_area(&v, INT_TO_PC(1), INT_TO_PC(3), 0, FRAG_SELFMOD_SANDBOXED, NULL
+                _IF_DEBUG("A"));
+    add_vm_area(&v, INT_TO_PC(5), INT_TO_PC(7), 0, FRAG_SELFMOD_SANDBOXED, NULL
+                _IF_DEBUG("B"));
     add_vm_area(&v, INT_TO_PC(9), INT_TO_PC(11), 0, 0, NULL _IF_DEBUG("C"));
     print_vector_msg(&v, STDERR, "after adding areas");
     check_vec(&v, 0, INT_TO_PC(1), INT_TO_PC(3), 0, FRAG_SELFMOD_SANDBOXED, NULL);
@@ -11645,7 +11716,8 @@ unit_test_vmareas(void)
 
     /* FIXME: would be nice to be able to test that an assert is generated...
      * say, for this:
-     * add_vm_area(&v, INT_TO_PC(7), INT_TO_PC(12), 0, FRAG_SELFMOD_SANDBOXED, NULL _IF_DEBUG("E"));
+     * add_vm_area(&v, INT_TO_PC(7), INT_TO_PC(12), 0, FRAG_SELFMOD_SANDBOXED, NULL
+     *             _IF_DEBUG("E"));
      */
 
     /* clear for next test */
@@ -11654,7 +11726,8 @@ unit_test_vmareas(void)
 
     /* TEST 4: add an area completely inside one that cannot be merged
      */
-    add_vm_area(&v, INT_TO_PC(1), INT_TO_PC(5), 0, FRAG_SELFMOD_SANDBOXED, NULL _IF_DEBUG("A"));
+    add_vm_area(&v, INT_TO_PC(1), INT_TO_PC(5), 0, FRAG_SELFMOD_SANDBOXED, NULL
+                _IF_DEBUG("A"));
     print_vector_msg(&v, STDERR, "after adding areas");
     check_vec(&v, 0, INT_TO_PC(1), INT_TO_PC(5), 0, FRAG_SELFMOD_SANDBOXED, NULL);
 

--- a/core/vmareas.h
+++ b/core/vmareas.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -613,7 +613,7 @@ enum {
     DR_MODIFY_NOP   = 1, /* turn the mem prot and later write faults into nops */
     DR_MODIFY_FAIL  = 2, /* have the mem prot fail */
     DR_MODIFY_ALLOW = 3, /* let the app muck with us -- WARNING: use at own risk */
-    DR_MODIFY_OFF   = 4, /* we don't even check for attempts -- WARNING: use at own risk */
+    DR_MODIFY_OFF   = 4, /* we don't even check for attempts; WARNING: use at own risk */
 };
 
 bool

--- a/core/win32/aslr.h
+++ b/core/win32/aslr.h
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -578,7 +579,7 @@ enum {
     GBOP_CHECK_INSTR_TYPE  = 0x10, /* no source instruction type restriction if not set */
     GBOP_IS_CALL           = 0x20, /* verify source is at all a CALL instruction */
     GBOP_IS_JMP            = 0x40, /* FIXME: not needed - app JMP won't be seen on TOS */
-    GBOP_IS_HOTPATCH_JMP   = 0x80, /* our JMP in case we have hotpatched purported source */
+    GBOP_IS_HOTPATCH_JMP   = 0x80, /* our JMP in case we hotpatched purported source */
     /* FIXME: we can't find the source if it was a JMP or JMP*, unless
      * the caller explicitly wants to fool us with one.
      *

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -252,7 +252,8 @@ intercept_asynch_common(thread_record_t *tr, bool intercept_unknown)
         /* caller should have made all attempts to get tr */
         if (control_all_threads) {
             /* we should know about all threads! */
-            SYSLOG_INTERNAL_WARNING("Received asynch event for unknown thread "TIDFMT"", get_thread_id());
+            SYSLOG_INTERNAL_WARNING("Received asynch event for unknown thread "TIDFMT"",
+                                    get_thread_id());
             /* try to make everything run rather than assert -- just do
              * this asynch natively, we probably received it for a thread that's
              * been created but not scheduled?
@@ -951,7 +952,8 @@ emit_intercept_code(dcontext_t *dcontext, byte *pc, intercept_function_t callee,
             APP(&ilist,
                 INSTR_CREATE_lea(dcontext, opnd_create_reg(REG_XCX),
                                  opnd_create_base_disp(REG_XCX, REG_NULL, 0,
-                                                       -(int)DYNAMORIO_STACK_SIZE, OPSZ_0)));
+                                                       -(int)DYNAMORIO_STACK_SIZE,
+                                                       OPSZ_0)));
             APP(&ilist,
                 INSTR_CREATE_cmp(dcontext, opnd_create_reg(REG_XSP),
                                  opnd_create_reg(REG_XCX)));
@@ -1693,13 +1695,16 @@ intercept_call(byte *our_pc, byte *tgt_pc, intercept_function_t prof_func,
         if (is_hooked && abort_on_incompatible_hooker) {
             SYSLOG_INTERNAL_WARNING_ONCE("giving up interception: "PFX" already hooked\n",
                                          tgt_pc);
-            LOG(GLOBAL, LOG_ASYNCH, 1, "intercept_call: giving up "PFX" already hooked\n", tgt_pc);
+            LOG(GLOBAL, LOG_ASYNCH, 1,
+                "intercept_call: giving up "PFX" already hooked\n", tgt_pc);
             instrlist_clear(dcontext, &ilist);
             return NULL;
         }
 
-        if (pc == NULL || is_hooked && DYNAMO_OPTION(hook_conflict) == HOOKED_TRAMPOLINE_DIE) {
-            FATAL_USAGE_ERROR(TAMPERED_NTDLL, 2, get_application_name(), get_application_pid());
+        if (pc == NULL || is_hooked &&
+            DYNAMO_OPTION(hook_conflict) == HOOKED_TRAMPOLINE_DIE) {
+            FATAL_USAGE_ERROR(TAMPERED_NTDLL, 2, get_application_name(),
+                              get_application_pid());
         }
 
         size = (pc - tgt_pc);
@@ -2014,8 +2019,9 @@ clean_syscall_wrapper(byte *nt_wrapper, int sys_enum)
                 APP(ilist, INSTR_CREATE_xor(dcontext, opnd_create_reg(REG_XCX),
                                             opnd_create_reg(REG_XCX)));
             } else {
-                APP(ilist, INSTR_CREATE_mov_imm(dcontext, opnd_create_reg(REG_XCX),
-                                                OPND_CREATE_INT32(wow64_index[sys_enum])));
+                APP(ilist, INSTR_CREATE_mov_imm
+                    (dcontext, opnd_create_reg(REG_XCX),
+                     OPND_CREATE_INT32(wow64_index[sys_enum])));
             }
             APP(ilist,
                 INSTR_CREATE_lea(dcontext, opnd_create_reg(REG_XDX),
@@ -2227,13 +2233,13 @@ syscall_wrapper_ilist(dcontext_t *dcontext,
 
         /* see case 2525 for background discussion */
         if (DYNAMO_OPTION(native_exec_hook_conflict) == HOOKED_TRAMPOLINE_DIE) {
-            /* FIXME: we could still print the message but we don't have to kill the app here */
+            /* We could still print the message but we don't have to kill the app here */
             FATAL_USAGE_ERROR(TAMPERED_NTDLL, 2, get_application_name(),
                               get_application_pid());
         } else if (DYNAMO_OPTION(native_exec_hook_conflict) == HOOKED_TRAMPOLINE_CHAIN) {
-            /* we assume 5-byte hookers as well - so only need to relativize in our own copy */
-            /* and we need to introduce a PUSH in case of a CALL here */
-
+            /* We assume 5-byte hookers as well - so only need to relativize in our own
+             * copy, and we need to introduce a PUSH in case of a CALL here
+             */
             ASSERT(instr_get_opcode(instr) != OP_call_ind);
             if (instr_is_mbr(instr)) {
                 /* one can imagine mbr being used on x64 */
@@ -2263,9 +2269,9 @@ syscall_wrapper_ilist(dcontext_t *dcontext,
                                       get_application_pid());
                 }
 #endif
-                instrlist_append(ilist,
-                                 INSTR_CREATE_jmp(dcontext,
-                                                  opnd_create_pc(opnd_get_pc(instr_get_target(instr)))));
+                instrlist_append(ilist, INSTR_CREATE_jmp
+                                 (dcontext,
+                                  opnd_create_pc(opnd_get_pc(instr_get_target(instr)))));
                 /* skip original instruction */
                 instr_destroy(dcontext, instr);
                 /* interp still needs to be updated */
@@ -2273,7 +2279,8 @@ syscall_wrapper_ilist(dcontext_t *dcontext,
             } else if (instr_get_opcode(instr) == OP_jmp) {
                 /* FIXME - no good way to regain control after the hook */
                 ASSERT_NOT_IMPLEMENTED(false);
-                LOG(GLOBAL, LOG_ASYNCH, 2, "intercept_syscall_wrapper: hooked with jmp "PFX"\n", pc);
+                LOG(GLOBAL, LOG_ASYNCH, 2,
+                    "intercept_syscall_wrapper: hooked with jmp "PFX"\n", pc);
                 /* just append instruction as is */
                 instrlist_append(ilist, instr);
             } else {
@@ -2306,7 +2313,8 @@ syscall_wrapper_ilist(dcontext_t *dcontext,
              */
             /* skip original instruction */
             instr_destroy(dcontext, instr);
-        } else if (DYNAMO_OPTION(native_exec_hook_conflict) == HOOKED_TRAMPOLINE_HOOK_DEEPER) {
+        } else if (DYNAMO_OPTION(native_exec_hook_conflict) ==
+                   HOOKED_TRAMPOLINE_HOOK_DEEPER) {
             /* move our hook one instruction deeper assuming hooker will
              * return to right after the hook, verify that's an
              * instruction boundary */
@@ -2359,7 +2367,8 @@ syscall_wrapper_ilist(dcontext_t *dcontext,
         /* normally a mov eax, native_sys_num */
         ASSERT(instr_get_opcode(instr) == OP_mov_imm);
         ASSERT(opnd_get_immed_int(instr_get_src(instr, 0)) == native_sys_num);
-        LOG(GLOBAL, LOG_ASYNCH, 3, "intercept_syscall_wrapper: hooked syscall %02x at "PFX"\n",
+        LOG(GLOBAL, LOG_ASYNCH, 3,
+            "intercept_syscall_wrapper: hooked syscall %02x at "PFX"\n",
             native_sys_num, pc);
         /* append instruction (non-CTI) */
         instrlist_append(ilist, instr);
@@ -2735,7 +2744,8 @@ intercept_syscall_wrapper(byte **ptgt_pc /* IN/OUT */,
  */
 byte *
 insert_trampoline(byte *tgt_pc, intercept_function_t prof_func,
-                  void *callee_arg, bool assume_xsp, after_intercept_action_t action_after,
+                  void *callee_arg, bool assume_xsp,
+                  after_intercept_action_t action_after,
                   bool cti_safe_to_ignore)
 {
     byte *pc = interception_cur_pc;
@@ -2749,8 +2759,8 @@ insert_trampoline(byte *tgt_pc, intercept_function_t prof_func,
     ASSERT(ok);
 
     /* FIXME: worry about inserting trampoline across bb boundaries? */
-    interception_cur_pc = intercept_call(interception_cur_pc, tgt_pc, prof_func, callee_arg,
-                                         assume_xsp, action_after,
+    interception_cur_pc = intercept_call(interception_cur_pc, tgt_pc, prof_func,
+                                         callee_arg, assume_xsp, action_after,
                                          false, /* need the trampoline at all costs */
                                          cti_safe_to_ignore, NULL, NULL);
     /* FIXME: we assume early intercept_call failures are ok to
@@ -3220,8 +3230,8 @@ intercept_new_thread(CONTEXT *cxt)
             "New Thread : Win32 start address "PFX" arg "PFX", thunk xip="PFX"\n",
             cxt->THREAD_START_ADDR, cxt->THREAD_START_ARG, cxt->CXT_XIP);
         DOLOG(1, LOG_THREADS, {
-            print_symbolic_address((app_pc)cxt->THREAD_START_ADDR, sym_buf, sizeof(sym_buf),
-                                   false);
+            print_symbolic_address((app_pc)cxt->THREAD_START_ADDR, sym_buf,
+                                   sizeof(sym_buf), false);
             LOG(THREAD_GET, LOG_THREADS, 1,
                 "Symbol information for start address %s\n", sym_buf);
         });
@@ -3429,10 +3439,10 @@ ntdll!KiUserApcDispatcher:
   00000000`78ef3931 74dd            je      ntdll!KiUserApcDispatcher (00000000`78ef3910)
   00000000`78ef3933 8bf0            mov     esi,eax
   00000000`78ef3935 8bce            mov     ecx,esi
-  00000000`78ef3937 e834f90500      call    ntdll!RtlRaiseException+0x10d (00000000`78f53270)
+  00000000`78ef3937 e834f90500      call    ntdll!RtlRaiseException+0x10d (0`78f53270)
   00000000`78ef393c cc              int     3
   00000000`78ef393d 90              nop
-  00000000`78ef393e ebf7            jmp     ntdll!KiUserApcDispatch+0x27 (00000000`78ef3937)
+  00000000`78ef393e ebf7            jmp     ntdll!KiUserApcDispatch+0x27 (0`78ef3937)
   00000000`78ef3940 cc              int     3
 
 
@@ -3525,7 +3535,8 @@ intercept_apc(app_state_at_intercept_t *state)
         } else {
             /* should not receive APC while in DR code! */
             ASSERT(get_thread_private_dcontext()->whereami == WHERE_FCACHE);
-            LOG(GLOBAL, LOG_ASYNCH|LOG_THREADS, 2, "APC thread was already initialized!\n");
+            LOG(GLOBAL, LOG_ASYNCH|LOG_THREADS, 2,
+                "APC thread was already initialized!\n");
             LOG(THREAD_GET, LOG_ASYNCH, 2,
                 "ASYNCH intercepted non-init apc: apc pc="PFX", cont pc="PFX"\n",
                 apc_target, cxt->CXT_XIP);
@@ -3565,7 +3576,8 @@ intercept_apc(app_state_at_intercept_t *state)
              * since next_tag holds do/share_syscall address
              */
             LOG(THREAD, LOG_ASYNCH, 2,
-                "\tchanging cont pc "PFX" from after do/share syscall to "PFX" or "PFX"\n",
+                "\tchanging cont pc "PFX" from after do/share syscall to "
+                PFX" or "PFX"\n",
                 cxt->CXT_XIP, dcontext->asynch_target, get_mcontext(dcontext)->xsi);
             ASSERT(does_syscall_ret_to_callsite());
             if (DYNAMO_OPTION(sygate_int) &&
@@ -3661,7 +3673,8 @@ intercept_apc(app_state_at_intercept_t *state)
             /* possibilities: for thread init APC I usually see what I think is the
              * thread entry point in kernel32 (very close to image entry point), but
              * I also sometimes see a routine in ntdll @0x77f9e9b9:
-             * <ntdll.dll~RtlConvertUiListToApiList+0x2fc,~RtlCreateQueryDebugBuffer-0x315>
+             * <ntdll.dll~RtlConvertUiListToApiList+0x2fc,
+             *  ~RtlCreateQueryDebugBuffer-0x315>
              */
             LOG(THREAD, LOG_ASYNCH, 2,
                 "\tAPC return point "PFX" needs no translation\n", cxt->CXT_XIP);
@@ -3669,7 +3682,8 @@ intercept_apc(app_state_at_intercept_t *state)
              * generic_nudge_target() */
             ASSERT(!is_dynamo_address((app_pc)cxt->CXT_XIP) ||
                    cxt->CXT_XIP == (ptr_uint_t)generic_nudge_target
-                   IF_CLIENT_INTERFACE(|| cxt->CXT_XIP==(ptr_uint_t)client_thread_target));
+                   IF_CLIENT_INTERFACE(|| cxt->CXT_XIP ==
+                                       (ptr_uint_t)client_thread_target));
         }
 
         asynch_retakeover_if_native();
@@ -3820,8 +3834,9 @@ intercept_nt_continue(CONTEXT *cxt, int flag)
             LOG(THREAD, LOG_ASYNCH, 2,
                 "\txip="PFX" not in fcache, intercepting at "PFX"\n",
                 cxt->CXT_XIP, nt_continue_dynamo_start);
-            /* we have to use a different slot since next_tag ends up holding the do_syscall
-             * entry when entered from dispatch (we're called from pre_syscall, prior to entering cache)
+            /* we have to use a different slot since next_tag ends up holding
+             * the do_syscall entry when entered from dispatch (we're called
+             * from pre_syscall, prior to entering cache)
              */
             dcontext->asynch_target = (app_pc) cxt->CXT_XIP;
             /* Point Xip to allow dynamo to retain control
@@ -3858,7 +3873,8 @@ intercept_nt_setcontext(dcontext_t *dcontext, CONTEXT *cxt)
      * condition, pre also does the interception check.
      */
     ASSERT_OWN_MUTEX(true, &thread_initexit_lock);
-    ASSERT(intercept_asynch_for_thread(dcontext->owning_thread, false/*no unknown threads*/));
+    ASSERT(intercept_asynch_for_thread(dcontext->owning_thread,
+                                       false/*no unknown threads*/));
     ASSERT(dcontext != NULL && dcontext->initialized);
     LOG(THREAD, LOG_ASYNCH, 1,
         "ASYNCH intercept_nt_setcontext: thread "TIDFMT" targeting thread "TIDFMT"\n",
@@ -3887,7 +3903,8 @@ intercept_nt_setcontext(dcontext_t *dcontext, CONTEXT *cxt)
          * #ifdefs ensure that the correct location is used for the xip.
          */
         /* we have to use a different slot since next_tag ends up holding the do_syscall
-         * entry when entered from dispatch (we're called from pre_syscall, prior to entering cache)
+         * entry when entered from dispatch (we're called from pre_syscall,
+         * prior to entering cache)
          */
         dcontext->asynch_target = (app_pc) cxt->CXT_XIP;
         /* Point Xip to allow dynamo to retain control
@@ -4025,7 +4042,8 @@ found_modified_code(dcontext_t *dcontext, EXCEPTION_RECORD *pExcptRec,
                 mcontext_to_context(cxt, &mcontext, false /* !set_cur_seg */);
             } else {
                 /* Should not happen since this should not be an instr we added! */
-                SYSLOG_INTERNAL_WARNING("Unable to fully translate cxt for codemod fault");
+                SYSLOG_INTERNAL_WARNING("Unable to fully translate cxt for codemod "
+                                        "fault");
                 /* we should always at least get pc right */
                 ASSERT(res == RECREATE_SUCCESS_PC);
             }
@@ -4044,7 +4062,8 @@ found_modified_code(dcontext_t *dcontext, EXCEPTION_RECORD *pExcptRec,
          * we've prevented a function patch.  or at least should add a
          * release build statistic to show that.
          */
-        DEBUG_DECLARE(bool system_overlap = tamper_resistant_region_overlap(target, target+1);)
+        DEBUG_DECLARE(bool system_overlap =
+                      tamper_resistant_region_overlap(target, target+1);)
         DEBUG_DECLARE(bool patch_module_overlap = vmvector_overlap(patch_proof_areas,
                                                                    target, target+1);)
 
@@ -4253,7 +4272,8 @@ check_for_modified_code(dcontext_t *dcontext, EXCEPTION_RECORD *pExcptRec,
             uint write_size = 0;
             /* FIXME: we duplicate this write size lookup w/ found_modified_code */
             DEBUG_DECLARE(app_pc result =)
-                decode_memory_reference_size(dcontext, (app_pc) pExcptRec->ExceptionAddress,
+                decode_memory_reference_size(dcontext,
+                                             (app_pc) pExcptRec->ExceptionAddress,
                                              &write_size);
             ASSERT(result != NULL);
             /* only emulate if completely inside -- no quick check for that, good
@@ -4394,11 +4414,14 @@ exception_frame_chain_depth(dcontext_t *dcontext)
     for (; (EXCEPTION_REGISTRATION*)PTR_UINT_MINUS_1 != pexcrec;
          pexcrec = pexcrec->prev) {
         if (!ALIGNED(pexcrec, 4)) {
-            LOG(THREAD_GET, LOG_ASYNCH, 1, "WARNING: ASYNCH invalid chain - not DWORD aligned\n");
+            LOG(THREAD_GET, LOG_ASYNCH, 1,
+                "WARNING: ASYNCH invalid chain - not DWORD aligned\n");
             return -1;
         }
-        /* each memory location should be readable (we don't want to die while checking) */
-        if (!is_readable_without_exception((app_pc)pexcrec, sizeof(EXCEPTION_REGISTRATION))) /* heavy weight check */ {
+        /* each memory location should be readable (don't want to die while checking) */
+        /* heavy weight check */
+        if (!is_readable_without_exception((app_pc)pexcrec,
+                                           sizeof(EXCEPTION_REGISTRATION))) {
             LOG(THREAD_GET, LOG_ASYNCH, 1,
                 "ASYNCH exception_frame_chain_depth "PFX" invalid! "
                 "possibly under attack\n", pexcrec);
@@ -4592,7 +4615,9 @@ dump_exception_frames()
 
     // 0xFFFFFFFF indicates the end of list
     while ((EXCEPTION_REGISTRATION*)PTR_UINT_MINUS_1 != pexcrec) {
-        if (!is_readable_without_exception((app_pc)pexcrec, sizeof(EXCEPTION_REGISTRATION))) /* heavy weight check */ {
+        /* heavy weight check */
+        if (!is_readable_without_exception((app_pc)pexcrec,
+                                           sizeof(EXCEPTION_REGISTRATION))) {
             LOG(THREAD_GET, LOG_ASYNCH, 1,
                 "ASYNCH dump_exception_frames "PFX" invalid! possibly corrupt\n",
                 pexcrec);
@@ -4644,7 +4669,8 @@ typedef struct _vc_exception_registration_t
  * There is at most one EXCEPTION_REGISTRATION record per function,
  * the rest is compiler dependent and we don't want to depend on that...
  */
-void dump_vc_exception_frame(EXCEPTION_REGISTRATION * pexcreg)
+void
+dump_vc_exception_frame(EXCEPTION_REGISTRATION * pexcreg)
 {
     vc_exception_registration_t *pVCExcRec = (vc_exception_registration_t*) pexcreg;
     struct scopetable_entry_t *pScopeTableEntry = pVCExcRec->scopetable;
@@ -4725,11 +4751,11 @@ report_internal_exception(dcontext_t *dcontext, EXCEPTION_RECORD *pExcptRec,
        before calling asynch_take_over and in case of an invalid exception handler
        this will trickle down to it.
 
-       We can currently get here if trying to read application pages marked as GUARD pages,
-       or marked as RESERVEd but not committed - in which case we'll receive a general
-       Access violation - code c0000005 and we'd have to verify the page flags.
-       Again we may want to treat differently our own guard pages than the application
-       uncommitted pages.
+       We can currently get here if trying to read application pages marked as
+       GUARD pages, or marked as RESERVEd but not committed - in which case
+       we'll receive a general Access violation - code c0000005 and we'd have to
+       verify the page flags.  Again we may want to treat differently our own
+       guard pages than the application uncommitted pages.
     */
 
     /* note that the first adjusted_exception_addr is used for
@@ -5051,10 +5077,8 @@ check_internal_exception(dcontext_t *dcontext, CONTEXT *cxt,
                 /* FIXME: if necessary, have a separate dump core mask for
                  * in_page_error */
                 /* Let's pass it back to the application - memory is unreadable */
-                if (TEST(DUMPCORE_FORGE_UNREAD_EXEC,
-                         DYNAMO_OPTION(dumpcore_mask)))
-                    os_dump_core("Warning: Racy app execution "
-                                 "(decode unreadable)");
+                if (TEST(DUMPCORE_FORGE_UNREAD_EXEC, DYNAMO_OPTION(dumpcore_mask)))
+                    os_dump_core("Warning: Racy app execution (decode unreadable)");
                 os_forge_exception(target_addr, exception_type);
 
                 /* CHECK: I hope we're not covering up the symptom instead
@@ -5217,9 +5241,10 @@ intercept_exception(app_state_at_intercept_t *state)
             takeover ? "" : "non-asynch ", get_thread_id(),
             pExcptRec->ExceptionAddress);
         DOLOG(2, LOG_ASYNCH, {
-            if (cxt->CXT_XIP != (ptr_uint_t) pExcptRec->ExceptionAddress)
+            if (cxt->CXT_XIP != (ptr_uint_t) pExcptRec->ExceptionAddress) {
                 LOG(THREAD, LOG_ASYNCH, 2, "\tcxt pc is different: "PFX"\n",
                     cxt->CXT_XIP);
+            }
         });
 
 #ifdef HOT_PATCHING_INTERFACE
@@ -6019,11 +6044,13 @@ KiUserCallbackDispatcher:
   00000000`77ef3186 e8a5d8ffff      call    ntdll!ZwCallbackReturn (00000000`77ef0a30)
   00000000`77ef318b 8bf0            mov     esi,eax
   00000000`77ef318d 8bce            mov     ecx,esi
-  00000000`77ef318f e85cf50500      call    ntdll!RtlRaiseException+0x118 (00000000`77f526f0)
+  00000000`77ef318f e85cf50500      call    ntdll!RtlRaiseException+0x118 (0`77f526f0)
   00000000`77ef3194 cc              int     3
-  00000000`77ef3195 eb01            jmp     ntdll!KiUserCallbackDispatcherContinue+0x15 (00000000`77ef3198)
+  00000000`77ef3195 eb01            jmp     ntdll!KiUserCallbackDispatcherContinue+0x15
+                                            (00000000`77ef3198)
   00000000`77ef3197 90              nop
-  00000000`77ef3198 ebf7            jmp     ntdll!KiUserCallbackDispatcherContinue+0x12 (00000000`77ef3191)
+  00000000`77ef3198 ebf7            jmp     ntdll!KiUserCallbackDispatcherContinue+0x12
+                                           (00000000`77ef3191)
   00000000`77ef319a cc              int     3
  *
  * ASSUMPTIONS:
@@ -6107,7 +6134,8 @@ intercept_callback_start(app_state_at_intercept_t *state)
                 while (pc < stop) {
                     LOG(cur_dcontext->logfile, LOG_ASYNCH, 2,
                         "\t*"PFX" = "PFX"\n", pc, *pc);
-                    if (*pc != NULL && is_readable_without_exception(((byte*)(*pc))-5, 5)) {
+                    if (*pc != NULL &&
+                        is_readable_without_exception(((byte*)(*pc))-5, 5)) {
                         byte *nxt = ((byte*)(*pc))-5;
                         while (nxt < (byte *)(*pc)) {
                             nxt = disassemble_with_bytes(cur_dcontext, nxt,
@@ -6124,7 +6152,8 @@ intercept_callback_start(app_state_at_intercept_t *state)
                      * tell call* from call?
                     e8 f3 cd ff ff       call   $0x77f4386b
                     ff 15 20 11 f4 77    call   0x77f41120
-                      can you have call 0x?(?,?,?) such that last 5 bytes look like direct call?
+                      can you have call 0x?(?,?,?) such that last 5 bytes
+                      look like direct call?
                     ff 14 90             call   (%eax,%edx,4)
                     ff 55 08             call   0x8(%ebp)
                     ff 56 5c             call   0x5c(%esi)
@@ -6283,12 +6312,13 @@ callback_setup(app_pc next_pc)
            This routine should be organized so that we spend minimal time
            setting up a new context and then we should be able to handle a new one.
            We need a per-thread flag/counter saying are we handling a callback stack.
-           Not that we can do anything about it when we come here again and the flag is set,
-           but at least we can STAT such occurrences.
+           Not that we can do anything about it when we come here again and the
+           flag is set, but at least we can STAT such occurrences.
 
            Actually that should only happen if we call an alertable system call
            (see end of bug 326 )...we should see if we're calling any.and deal with it,
-           otherwise if we're safe with respect to callbacks then remove the above comment.
+           otherwise if we're safe with respect to callbacks then remove the
+           above comment.
         */
         new_dcontext = create_callback_dcontext(old_dcontext);
         /* stick at end of list */
@@ -6449,11 +6479,13 @@ callback_start_return(priv_mcontext_t *mc)
         DODEBUG({
             /* we should never see this after we have reached the image entry point */
             if (reached_image_entry_yet()) {
-                /* Nothing we can do -- except try to walk stack frame back and hope to decode
-                 * exactly where thread was suspended, but there's no guarantee we can do that
-                 * if there were indirect jmps.
+                /* Nothing we can do -- except try to walk stack frame back and
+                 * hope to decode exactly where thread was suspended, but
+                 * there's no guarantee we can do that if there were indirect
+                 * jmps.
                  */
-                SYSLOG_INTERNAL_ERROR("non-process-init callback return with native callback context for %s thread "TIDFMT"",
+                SYSLOG_INTERNAL_ERROR("non-process-init callback return with native "
+                                      "callback context for %s thread "TIDFMT"",
                                       (tr == NULL) ? "unknown" : "known",
                                       get_thread_id());
                 /* might be injected late, refer to bug 426 for discussion
@@ -6696,8 +6728,8 @@ intercept_load_dll(app_state_at_intercept_t *state)
     } else if (control_all_threads && IS_UNDER_DYN_HACK(tr->under_dynamo_control)) {
         dcontext_t *dcontext = get_thread_private_dcontext();
         /* trying to open debugbox causes IIS to fail, so don't SYSLOG_INTERNAL */
-        LOG(THREAD, LOG_ASYNCH, 1, "ERROR: load_dll: we lost control of thread "TIDFMT"\n",
-            tr->id);
+        LOG(THREAD, LOG_ASYNCH, 1, "ERROR: load_dll: we lost control of thread "
+            TIDFMT"\n", tr->id);
         DOLOG(2, LOG_ASYNCH, {
             dump_callstack(NULL, (app_pc) state->mc.xbp, THREAD, DUMP_NOT_XML);
         });
@@ -6826,9 +6858,10 @@ intercept_unload_dll(app_state_at_intercept_t *state)
             LOG(GLOBAL, LOG_VMAREAS, 1,
                 "intercept_unload_dll: <unknown> @"PFX" size "PIFX"\n", h, size);
         }
-        if (get_thread_private_dcontext() != NULL)
+        if (get_thread_private_dcontext() != NULL) {
             LOG(THREAD_GET, LOG_VMAREAS, 1, "intercept_unload_dll: %s @"PFX" "
                                             "size "PIFX"\n", buf, h, size);
+        }
         DOLOG(3, LOG_VMAREAS, { print_modules(GLOBAL, DUMP_NOT_XML); });
     });
     /* we do not flush fragments here b/c this call only decrements
@@ -7197,7 +7230,8 @@ intercept_image_entry(app_state_at_intercept_t *state)
              * we want to take over so no conditional is needed there.
              */
         } else {
-            SYSLOG_INTERNAL_ERROR("Image entry interception point reached by unexpected %s thread "TIDFMT"",
+            SYSLOG_INTERNAL_ERROR("Image entry interception point reached by unexpected "
+                                  "%s thread "TIDFMT"",
                                   (tr == NULL) ? "unknown" : "known",
                                   get_thread_id());
             ASSERT_NOT_REACHED();
@@ -7268,7 +7302,7 @@ insert_image_entry_trampoline(dcontext_t *dcontext)
                                                false /* do not assume esp */,
                                                /* handler should restore target */
                                                AFTER_INTERCEPT_TAKE_OVER_SINGLE_SHOT,
-                                               true /* single shot - safe to ignore CTI */);
+                                               true/* single shot, safe to ignore CTI */);
     SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
     return image_entry_pc;
 }
@@ -7542,7 +7576,8 @@ callback_interception_init_finish(void)
      * FIXME: use generated-code region rather than data section?
      */
     if (!is_dynamo_address(interception_code) ||
-        !is_dynamo_address(interception_code + INTERCEPTION_CODE_SIZE-1)) { /* check endpoints */
+        !is_dynamo_address(interception_code +
+                           INTERCEPTION_CODE_SIZE-1)) { /* check endpoints */
         /* probably was already added but just to make sure */
         add_dynamo_vm_area(interception_code,
                            interception_code + INTERCEPTION_CODE_SIZE-1,
@@ -7656,9 +7691,12 @@ callback_interception_unintercept()
 
     LOG(GLOBAL, LOG_ASYNCH|LOG_STATS, 1,
         "Total # of asynchronous events for process:\n");
-    LOG(GLOBAL, LOG_ASYNCH|LOG_STATS, 1, "   Callbacks:  %d\n", GLOBAL_STAT(num_callbacks));
-    LOG(GLOBAL, LOG_ASYNCH|LOG_STATS, 1, "   APCs:       %d\n", GLOBAL_STAT(num_APCs));
-    LOG(GLOBAL, LOG_ASYNCH|LOG_STATS, 1, "   Exceptions: %d\n", GLOBAL_STAT(num_exceptions));
+    LOG(GLOBAL, LOG_ASYNCH|LOG_STATS, 1,
+        "   Callbacks:  %d\n", GLOBAL_STAT(num_callbacks));
+    LOG(GLOBAL, LOG_ASYNCH|LOG_STATS, 1,
+        "   APCs:       %d\n", GLOBAL_STAT(num_APCs));
+    LOG(GLOBAL, LOG_ASYNCH|LOG_STATS, 1,
+        "   Exceptions: %d\n", GLOBAL_STAT(num_exceptions));
 
     un_intercept_call(load_dll_pc, (byte*)LdrLoadDll);
     un_intercept_call(unload_dll_pc, (byte*)LdrUnloadDll);
@@ -7744,7 +7782,8 @@ swap_dcontexts(dcontext_t *d1, dcontext_t *d2)
 #ifdef RETURN_AFTER_CALL
 /* return EMPTY if we are past the stack bottom - target_pc should NOT be let through
           BOTTOM_REACHED just reached stack bottom, let this through, but start enforcing
-          BOTTOM_NOT_REACHED haven't yet reached the stack bottom, let this through do not enforce
+          BOTTOM_NOT_REACHED haven't yet reached the stack bottom, let this through
+            do not enforce
  */
 initial_call_stack_status_t
 at_initial_stack_bottom(dcontext_t *dcontext, app_pc target_pc)
@@ -7767,9 +7806,9 @@ at_initial_stack_bottom(dcontext_t *dcontext, app_pc target_pc)
 
     if (interception_point == INTERCEPT_IMAGE_ENTRY) {
         /* intercept_image_entry does not execute any DR returns so this is a violation.
-         * At image entry trampoline we explicitly added the kernel32 thunk as a RAC target,
-         * so even though we didn't see the real stack bottom we've added the bottom frame
-         * and so cannot bottom out.
+         * At image entry trampoline we explicitly added the kernel32 thunk as a
+         * RAC target, so even though we didn't see the real stack bottom we've
+         * added the bottom frame and so cannot bottom out.
          */
         return INITIAL_STACK_EMPTY;
     }
@@ -7795,7 +7834,9 @@ at_initial_stack_bottom(dcontext_t *dcontext, app_pc target_pc)
              */
             return INITIAL_STACK_EMPTY;
         } else {
-            /* FIXME: if we never get to that address we'll never trigger a violation, very unsafe */
+            /* FIXME: if we never get to that address we'll never trigger a violation,
+             * very unsafe
+             */
             return INITIAL_STACK_BOTTOM_NOT_REACHED;
         }
     }

--- a/core/win32/diagnost.c
+++ b/core/win32/diagnost.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2012 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -54,7 +54,8 @@ DECLARE_NEVERPROT_VAR(static DIAGNOSTICS_KEY_VALUE_FULL_INFORMATION diagnostic_v
                       {0});
 DECLARE_NEVERPROT_VAR(static char keyinfo_name[DIAGNOSTICS_MAX_KEY_NAME_SIZE], {0});
 DECLARE_NEVERPROT_VAR(static char keyinfo_data[DIAGNOSTICS_MAX_NAME_AND_DATA_SIZE], {0});
-DECLARE_NEVERPROT_VAR(static wchar_t diagnostic_keyname[DIAGNOSTICS_MAX_KEY_NAME_SIZE], {0});
+DECLARE_NEVERPROT_VAR(static wchar_t diagnostic_keyname[DIAGNOSTICS_MAX_KEY_NAME_SIZE],
+                      {0});
 DECLARE_NEVERPROT_VAR(static char optstring_buf[MAX_OPTIONS_STRING], {0});
 
 /* Enforces unique access to shared reg data structures */
@@ -75,23 +76,33 @@ static const wchar_t * const HKLM_entries[] = {
     L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Active Setup\\Installed Components",
     L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Internet Explorer\\Extensions",
     L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Internet Explorer\\Toolbar",
-    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Appinit_Dlls",
+    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\"
+    L"Appinit_Dlls",
     L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
-    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects",
-    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\SharedTaskScheduler",
-    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellExecuteHooks",
-    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run",
-    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\"
+    L"Browser Helper Objects",
+    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\"
+    L"SharedTaskScheduler",
+    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\"
+    L"ShellExecuteHooks",
+    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\"
+    L"Explorer\\Run",
+    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\"
+    L"System",
     L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run",
     L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce",
     L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnceEx",
-    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Shell Extensions\\Approved",
-    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\ShellServiceObjectDelayLoad",
-    L"\\Registry\\Machine\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logon",
+    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\"
+    L"Shell Extensions\\Approved",
+    L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\"
+    L"ShellServiceObjectDelayLoad",
+    L"\\Registry\\Machine\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\"
+    L"Logon",
     L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\Lsa",
     L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\Print\\Monitors",
     L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\Session Manager",
-    L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\Wds\\rdpwd",
+    L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\Wds\\"
+    L"rdpwd",
     L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Services",
 };
 
@@ -221,7 +232,8 @@ print_memory_buffer(file_t diagnostics_file, byte *address, uint length,
             dump_buffer_as_bytes(diagnostics_file, start, cur_end - start,
                                  DUMP_RAW|DUMP_ADDRESS
                                  |(TEST(PRINT_MEM_BUF_BYTE, flags) ? 0 : DUMP_DWORD)
-                                 |(TEST(PRINT_MEM_BUF_ASCII, flags) ? DUMP_APPEND_ASCII : 0)
+                                 |(TEST(PRINT_MEM_BUF_ASCII, flags) ?
+                                   DUMP_APPEND_ASCII : 0)
                                  );
             print_file(diagnostics_file, "\n");
         } else {
@@ -301,7 +313,7 @@ report_src_info(file_t diagnostics_file, dcontext_t *dcontext)
             /* FIXME: all app tags are printed in one line, if it proves to
              * create unreadably long lines, change this
              */
-            for(i = 0; i < t->num_bbs; i++)
+            for (i = 0; i < t->num_bbs; i++)
                 print_file(diagnostics_file, PFX" ", t->bbs[i].tag);
             print_file(diagnostics_file, "\"");
         } else
@@ -1373,7 +1385,8 @@ add_diagnostics_xml_header(file_t diagnostics_file)
      * are valid and wld.exe's library knows how to handle it.  Other choices may be
      * more appropriate in the future. */
     print_file(diagnostics_file,
-               "<?xml version=\""DIAGNOSTICS_XML_FILE_VERSION"\" encoding=\"iso-8859-1\" ?>\n"
+               "<?xml version=\""DIAGNOSTICS_XML_FILE_VERSION
+               "\" encoding=\"iso-8859-1\" ?>\n"
                "<!--\n"
                "  =====================================================================\n"
                "  Copyright @ "COMPANY_LONG_NAME" (2007). All rights reserved\n"
@@ -1392,10 +1405,10 @@ report_diagnostics_common(file_t diagnostics_file, const char *message, const ch
     report_intro(diagnostics_file, message, name);
 
     /* Process snapshot requires memory allocation -- only use if genuine attack */
-    if (violation_type == NO_VIOLATION_BAD_INTERNAL_STATE)
+    if (violation_type == NO_VIOLATION_BAD_INTERNAL_STATE) {
         report_current_process(diagnostics_file, NULL /*no snaphot*/,
                                violation_type, true /*be conservative*/);
-    else
+    } else
         report_processes(diagnostics_file, violation_type);
 
     report_system_diagnostics(diagnostics_file);
@@ -1503,7 +1516,8 @@ append_diagnostics(file_t diagnostics_file, const char *message, const char *nam
                    security_violation_t violation_type)
 {
     /* Begin Report */
-    print_file(diagnostics_file, "<forensic-report title=\""PRODUCT_NAME" Forensic File\" "
+    print_file(diagnostics_file, "<forensic-report title=\""PRODUCT_NAME
+               " Forensic File\" "
                "version=\""DIAGNOSTICS_XML_FILE_VERSION"\" encoding=\"iso-8859-1\">\n");
 
     report_diagnostics_common(diagnostics_file, message, name, violation_type);

--- a/core/win32/diagnost.h
+++ b/core/win32/diagnost.h
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -44,31 +45,35 @@
 #define DIAGNOSTICS_FILE_XML_EXTENSION ".xml"
 #define DIAGNOSTICS_XML_FILE_VERSION "1.0"
 #define DIAGNOSTICS_NTDLL_DLL_LOCATION L"System32\\NTDLL.DLL"
-#define DIAGNOSTICS_HARDWARE_REG_KEY L"\\Registry\\Machine\\System\\CurrentControlSet\\Enum"
-#define DIAGNOSTICS_CONTROL_REG_KEY L"\\Registry\\Machine\\System\\CurrentControlSet\\Control"
+#define DIAGNOSTICS_HARDWARE_REG_KEY \
+    L"\\Registry\\Machine\\System\\CurrentControlSet\\Enum"
+#define DIAGNOSTICS_CONTROL_REG_KEY \
+    L"\\Registry\\Machine\\System\\CurrentControlSet\\Control"
 #define DIAGNOSTICS_TEST_REG_KEY L"\\Registry\\Machine\\Software"
-#define DIAGNOSTICS_OS_REG_KEY L"\\Registry\\Machine\\Software\\Microsoft\\Windows NT\\CurrentVersion"
-#define DIAGNOSTICS_OS_HOTFIX_REG_KEY L"\\Registry\\Machine\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Hotfix"
+#define DIAGNOSTICS_OS_REG_KEY \
+    L"\\Registry\\Machine\\Software\\Microsoft\\Windows NT\\CurrentVersion"
+#define DIAGNOSTICS_OS_HOTFIX_REG_KEY \
+    L"\\Registry\\Machine\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Hotfix"
 #define DIAGNOSTICS_BIOS_REG_KEY L"\\Registry\\Machine\\Hardware\\Description\\System"
 #define DIAGNOSTICS_SYSTEMROOT_REG_KEY L"SystemRoot"
 #define DIAGNOSTICS_DESCRIPTION_KEY L"DeviceDesc"
 #define DIAGNOSTICS_MANUFACTURER_KEY L"Mfg"
 #define DIAGNOSTICS_FRIENDLYNAME_KEY L"FriendlyName"
 
-#define DIAGNOSTICS_MAX_REG_KEYS 1000                  /* Arbitrary - seems sufficient */
-#define DIAGNOSTICS_MAX_REG_VALUES 1000                /* Arbitrary - seems sufficient */
-#define DIAGNOSTICS_MAX_RECURSION_LEVEL 5              /* Arbitrary, bit should keep small */
-#define DIAGNOSTICS_MAX_NAME_AND_DATA_SIZE 500         /* Arbitrary - seems sufficient */
-#define DIAGNOSTICS_MAX_KEY_NAME_SIZE 257              /* From SDK, + 1 for a null */
+#define DIAGNOSTICS_MAX_REG_KEYS 1000            /* Arbitrary - seems sufficient */
+#define DIAGNOSTICS_MAX_REG_VALUES 1000          /* Arbitrary - seems sufficient */
+#define DIAGNOSTICS_MAX_RECURSION_LEVEL 5        /* Arbitrary, but should keep small */
+#define DIAGNOSTICS_MAX_NAME_AND_DATA_SIZE 500   /* Arbitrary - seems sufficient */
+#define DIAGNOSTICS_MAX_KEY_NAME_SIZE 257        /* From SDK, + 1 for a null */
 #define DIAGNOSTICS_MAX_LOG_BUFFER_SIZE 1000
-#define DIAGNOSTICS_MAX_LOG_FILES 99999999             /* Supports 8.3 */
-#define DIAGNOSTICS_MINI_DUMP_SIZE 104                 /* multiple of 8, so is dumped aligned */
+#define DIAGNOSTICS_MAX_LOG_FILES 99999999       /* Supports 8.3 */
+#define DIAGNOSTICS_MINI_DUMP_SIZE 104           /* multiple of 8, so is dumped aligned */
 
-#define DIAGNOSTICS_REG_NAME       0x00000001L         /* Log key name */
-#define DIAGNOSTICS_REG_DATA       0x00000002L         /* Log key data */
-#define DIAGNOSTICS_REG_HARDWARE   0x00000004L         /* Look for device keys */
-#define DIAGNOSTICS_REG_ALLKEYS    0x00000008L         /* Search all keys */
-#define DIAGNOSTICS_REG_ALLSUBKEYS 0x00000010L         /* Search all subkeys (recursive)*/
+#define DIAGNOSTICS_REG_NAME       0x00000001L   /* Log key name */
+#define DIAGNOSTICS_REG_DATA       0x00000002L   /* Log key data */
+#define DIAGNOSTICS_REG_HARDWARE   0x00000004L   /* Look for device keys */
+#define DIAGNOSTICS_REG_ALLKEYS    0x00000008L   /* Search all keys */
+#define DIAGNOSTICS_REG_ALLSUBKEYS 0x00000010L   /* Search all subkeys (recursive)*/
 #define DIAGNOSTICS_INITIAL_PROCESS_TOTAL 10
 
 #define DIAGNOSTICS_BYTES_PER_LINE 32
@@ -77,7 +82,8 @@
    part of the offset.  When offsetting into the NameAndData member (see below), these
    bytes are not present, and must be decremented.  The 2 WCHARs readjusts back for the
    null-terminated Name[1] (which IS included in NameAndData).  Confusing, no? */
-#define DECREMENT_FOR_DATA_OFFSET (sizeof(KEY_VALUE_FULL_INFORMATION) - (sizeof(WCHAR) * 2))
+#define DECREMENT_FOR_DATA_OFFSET \
+    (sizeof(KEY_VALUE_FULL_INFORMATION) - (sizeof(WCHAR) * 2))
 
 typedef struct _DIAGNOSTICS_INFORMATION {
     SYSTEM_BASIC_INFORMATION sbasic_info;

--- a/core/win32/drmarker.c
+++ b/core/win32/drmarker.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -60,9 +60,10 @@
 # define READ_FUNC nt_read_virtual_memory
 # define DR_MARKER_VERSION_CURRENT DR_MARKER_VERSION_2
 #else /* NOT_DYNAMORIO_CORE */
-# pragma warning( disable : 4054) /* from function pointer 'void (__cdecl *)(void )' to data pointer 'unsigned char *' */
+# pragma warning( disable : 4054) /* from function pointer to data pointer */
 /* complains about size_t* vs SIZE_T* */
-# pragma warning( disable : 4057) /* 'function' : 'unsigned long *' differs in indirection to slightly different base types from 'int *' */
+/* 'unsigned long *' differs to slightly different base types from 'int *' */
+# pragma warning( disable : 4057)
 # pragma warning( disable : 4100) /* 'envp' : unreferenced formal parameter */
 # ifndef byte
 typedef unsigned char byte;

--- a/core/win32/drwinapi/kernel32_mem.c
+++ b/core/win32/drwinapi/kernel32_mem.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2016 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -65,18 +65,14 @@ kernel32_redir_exit_mem(void)
 
 PVOID
 WINAPI
-redirect_DecodePointer(
-    __in_opt PVOID Ptr
-    )
+redirect_DecodePointer(__in_opt PVOID Ptr)
 {
     return (PVOID) ((ptr_uint_t)Ptr ^ magic_val);
 }
 
 PVOID
 WINAPI
-redirect_EncodePointer (
-    __in_opt PVOID Ptr
-    )
+redirect_EncodePointer(__in_opt PVOID Ptr)
 {
     return (PVOID) ((ptr_uint_t)Ptr ^ magic_val);
 }
@@ -170,7 +166,7 @@ redirect_HeapReAlloc(
 
 BOOL
 WINAPI
-redirect_HeapSetInformation (
+redirect_HeapSetInformation(
     __in_opt HANDLE HeapHandle,
     __in HEAP_INFORMATION_CLASS HeapInformationClass,
     __in_bcount_opt(HeapInformationLength) PVOID HeapInformation,

--- a/core/win32/drwinapi/kernel32_sync.c
+++ b/core/win32/drwinapi/kernel32_sync.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2014 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -122,7 +122,7 @@ redirect_LeaveCriticalSection(
 
 LONG
 WINAPI
-redirect_InterlockedCompareExchange (
+redirect_InterlockedCompareExchange(
     __inout __drv_interlocked LONG volatile *Destination,
     __in LONG ExChange,
     __in LONG Comperand
@@ -221,12 +221,12 @@ unit_test_drwinapi_kernel32_sync(void)
     vol = 4;
     val1 = 5;
     val2 = 6;
-    res = redirect_InterlockedCompareExchange (&vol, val1, val2);
+    res = redirect_InterlockedCompareExchange(&vol, val1, val2);
     EXPECT(res == vol && res == 4, true);
     vol = 4;
     val1 = 5;
     val2 = 4;
-    res = redirect_InterlockedCompareExchange (&vol, val1, val2);
+    res = redirect_InterlockedCompareExchange(&vol, val1, val2);
     EXPECT(res == 4 && vol == val1, true);
 
     vol = 42;

--- a/core/win32/drwinapi/ntdll_redir.c
+++ b/core/win32/drwinapi/ntdll_redir.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2014 Google, Inc.   All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.   All rights reserved.
  * Copyright (c) 2009-2010 Derek Bruening   All rights reserved.
  * **********************************************************/
 
@@ -100,7 +100,7 @@ static const redirect_import_t redirect_ntdll[] = {
      */
     {"RtlInitializeCriticalSection",   (app_pc)redirect_RtlInitializeCriticalSection},
     {"RtlInitializeCriticalSectionAndSpinCount",
-                                (app_pc)redirect_RtlInitializeCriticalSectionAndSpinCount},
+                               (app_pc)redirect_RtlInitializeCriticalSectionAndSpinCount},
     {"RtlInitializeCriticalSectionEx", (app_pc)redirect_RtlInitializeCriticalSectionEx},
     {"RtlDeleteCriticalSection",       (app_pc)redirect_RtlDeleteCriticalSection},
     /* We don't redirect the creation but we avoid DR pointers being passed

--- a/core/win32/drwinapi/rpcrt4_redir.c
+++ b/core/win32/drwinapi/rpcrt4_redir.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2013 Google, Inc.   All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.   All rights reserved.
  * Copyright (c) 2009-2010 Derek Bruening   All rights reserved.
  * **********************************************************/
 
@@ -91,11 +91,8 @@ rpcrt4_redir_lookup(const char *name)
 }
 
 
-RPC_STATUS
-RPC_ENTRY
-redirect_UuidCreate (
-    __out UUID __RPC_FAR * Uuid
-    )
+RPC_STATUS RPC_ENTRY
+redirect_UuidCreate(__out UUID __RPC_FAR * Uuid)
 {
     if (Uuid == NULL)
         return RPC_S_INVALID_ARG;

--- a/core/win32/eventlog.c
+++ b/core/win32/eventlog.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -69,9 +70,10 @@ static void os_eventlog(syslog_event_type_t priority, uint message_id,
                         uint substitutions_num, char **arguments,
                         size_t size_data, char *raw_data);
 
-/* Custom logfile key and properties */
-/* This enables administrators to control the size of the log file  */
-/* and we can attach SACLs for security purposes, without affecting other applications.  */
+/* Custom logfile key and properties.
+ * This enables administrators to control the size of the log file,
+ * and we can attach SACLs for security purposes, without affecting other applications.
+ */
 
 // Make sure the registry key is all set up, maybe better done in the installer?
 // The minimum we need:
@@ -170,7 +172,8 @@ init_registry_source(void)
                 heventlogroot = reg_open_key(L_EVENTLOG_REGISTRY_KEY,
                                              KEY_READ | KEY_WRITE);
                 if (!heventlogroot) {
-                    LOG(GLOBAL, LOG_TOP, 1, "WARNING: Registration failure.  Could not open root %ls.",
+                    LOG(GLOBAL, LOG_TOP, 1,
+                        "WARNING: Registration failure.  Could not open root %ls.",
                         L_EVENTLOG_REGISTRY_KEY);
                     return 0;
                 }
@@ -178,12 +181,16 @@ init_registry_source(void)
                                            KEY_ALL_ACCESS);
             }
             if (!heventlog) {
-                LOG(GLOBAL, LOG_TOP, 1, "WARNING: Could not create event log key %s.", EVENTLOG_NAME);
+                LOG(GLOBAL, LOG_TOP, 1,
+                    "WARNING: Could not create event log key %s.", EVENTLOG_NAME);
                 return 0;
             }
 
-            /* obviously we'll need SET_VALUE later but to keep the logic simple we take minimal here */
-            heventsource = reg_create_key(heventlog, L_EVENT_SOURCE_NAME, KEY_QUERY_VALUE);
+            /* obviously we'll need SET_VALUE later but to keep the
+             * logic simple we take minimal here
+             */
+            heventsource =
+                reg_create_key(heventlog, L_EVENT_SOURCE_NAME, KEY_QUERY_VALUE);
             if (heventlog) {
                 reg_close_key(heventlog);
             }
@@ -193,7 +200,8 @@ init_registry_source(void)
 
         }
         if (!heventsource) {
-            LOG(GLOBAL, LOG_TOP, 1, "WARNING: Could not create event source key %s.", EVENTSOURCE_NAME);
+            LOG(GLOBAL, LOG_TOP, 1, "WARNING: Could not create event source key %s.",
+                EVENTSOURCE_NAME);
             return 0;
         }
 
@@ -207,8 +215,9 @@ init_registry_source(void)
 
 #define MAX_SYSLOG_ARGS 6       /* increase if necessary */
 /* collect arguments in an array and pass along */
-void os_syslog(syslog_event_type_t priority, uint message_id, uint substitutions_num,
-               va_list vargs)
+void
+os_syslog(syslog_event_type_t priority, uint message_id, uint substitutions_num,
+          va_list vargs)
 {
     uint arg;
     char *arg_arr[MAX_SYSLOG_ARGS];
@@ -219,7 +228,7 @@ void os_syslog(syslog_event_type_t priority, uint message_id, uint substitutions
 
     ASSERT(substitutions_num < MAX_SYSLOG_ARGS);
 
-    for(arg = 0; arg < substitutions_num; arg++) {
+    for (arg = 0; arg < substitutions_num; arg++) {
         arg_arr[arg] = va_arg(vargs, char*);
     }
 
@@ -258,7 +267,7 @@ void os_syslog(syslog_event_type_t priority, uint message_id, uint substitutions
       return 0;                                             \
   while (skip--)                                            \
       *(*(pp))++ = '\0';                                    \
-} while(0)
+} while (0)
 
 /* Encodes an ASCIIZ string into some weird format */
 /* Example "\011\0\012\0""03B\0""\12\0\0\0DynamoRio\0\0\0"
@@ -644,13 +653,13 @@ eventlog_report(eventlog_state_t *evconnection,
           *(DWORD*)"\230y\23\0"); /* FIXME pointer placeholder */
     FIELD(p, evconnection->buf + sizeof(evconnection->buf), DWORD,
           substitutions_num);
-    for(i=0; i<substitutions_num; i++) {
+    for (i=0; i<substitutions_num; i++) {
         /* FIXME unknown pointer placeholder */
         FIELD(p, evconnection->buf + sizeof(evconnection->buf), DWORD,
               *(DWORD*)"\210y\23\0");
     }
 
-    for(i=0; i<substitutions_num; i++) {
+    for (i=0; i<substitutions_num; i++) {
         append_string(&p, evconnection->buf + sizeof(evconnection->buf),
                       substitutions[i]);
     }
@@ -824,7 +833,8 @@ eventlog_init()
     if (DYNAMO_OPTION(syslog_init) &&
         !init_registry_source()) { /* update registry keys */
         DOLOG_ONCE(1, LOG_TOP, {
-            LOG(GLOBAL, LOG_TOP, 1, "WARNING: Could not add the event source registry keys."
+            LOG(GLOBAL, LOG_TOP, 1,
+                "WARNING: Could not add the event source registry keys."
                 "Events are reported with no message files.\n");
         });
     }
@@ -910,7 +920,8 @@ os_eventlog(syslog_event_type_t priority, uint message_id,
         res = eventlog_register(shared_eventlog_connection);
         if (!res) {
             DOLOG_ONCE(1, LOG_TOP, {
-                LOG(GLOBAL, LOG_TOP, 1, "WARNING: Could not register event source on second attempt.\n");
+                LOG(GLOBAL, LOG_TOP, 1,
+                    "WARNING: Could not register event source on second attempt.\n");
             });
         } else {
             LOG(GLOBAL, LOG_TOP, 1, "Registered event source after program started. "

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -134,7 +134,8 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle,
      * walk the exports of kernel32.dll (we can cache its mod handle when it
      * is loaded). */
     if (!inject_initialized) {
-        SYSLOG_INTERNAL_WARNING("Using late inject follow children from early injected process, unsafe LdrLock usage");
+        SYSLOG_INTERNAL_WARNING("Using late inject follow children from early injected "
+                                "process, unsafe LdrLock usage");
         SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
         inject_init();
         SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
@@ -1376,7 +1377,7 @@ inject_into_new_process(HANDLE phandle, char *dynamo_path, bool map,
     GET_NTDLL(KiUserExceptionDispatcher, (IN PVOID Unknown1,
                                           IN PVOID Unknown2));
 
-    switch(inject_location) {
+    switch (inject_location) {
     case INJECT_LOCATION_LdrLoadDll:
     case INJECT_LOCATION_LdrpLoadDll:
     case INJECT_LOCATION_LdrCustom:

--- a/core/win32/inject_shared.c
+++ b/core/win32/inject_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -486,7 +486,8 @@ static inline
 int
 get_rununder_value(const char *runvalue)
 {
-    /* For now we allow only decimal, but with more flags it will be easier to work on hex.
+    /* For now we allow only decimal, but with more flags it will be
+       easier to work on hex.
        FIXME: share the logic in parse_uint() from after options.c -r 1.4
        to allow both hex and decimal values
     */
@@ -554,7 +555,7 @@ w_get_short_name(const wchar_t *exename)
 */
 bool
 get_commandline_qualifier(const wchar_t *command_line,
-                          wchar_t *derived_name, uint max_derived_length /* in elements */,
+                          wchar_t *derived_name, uint max_derived_length /* elements */,
                           bool no_strip)
 {
     wchar_t *derived_ptr = derived_name;
@@ -563,7 +564,7 @@ get_commandline_qualifier(const wchar_t *command_line,
     /* Find last piece of the executable name  */
     const wchar_t *cmdptr;
 
-    /* Long paths (that may have spaces) are assumed to be in quotes on the command line */
+    /* Long paths (that may have spaces) are assumed to be in quotes on command line */
     if (command_line[0] == L'"') {
         cmdptr = wcschr(command_line+1, L'"');
         if (cmdptr)
@@ -578,7 +579,9 @@ get_commandline_qualifier(const wchar_t *command_line,
     }
 
     do {
-        /* Skip any leading delimiters before each argument, e.g. "svchost.exe   -k          netsvcs" */
+        /* Skip any leading delimiters before each argument, e.g.
+         * "svchost.exe   -k          netsvcs"
+         */
         while (*cmdptr && !iswalnum(*cmdptr))
             cmdptr++;
         if (!*cmdptr)
@@ -600,8 +603,9 @@ get_commandline_qualifier(const wchar_t *command_line,
             *derived_ptr++ = *cmdptr++;
         }
 
-        /* We do not add any normalized delimiters, e.g. "/t /e /st" is the same as "/test",
-           since currently there is no need to be that punctual. */
+        /* We do not add any normalized delimiters, e.g. "/t /e /st" is the same as
+         * "/test", since currently there is no need to be that punctual.
+         */
     } while (*cmdptr);
  out:
     *derived_ptr = L'\0'; /* NULL terminate */
@@ -712,7 +716,8 @@ get_process_qualified_name(HANDLE process_handle,
         /* get foreign process subkey */
         /* to avoid another buffer and save stack space, we do this in stages */
         /* just get image name first */
-        get_process_imgname_cmdline(process_handle, other_process_img_or_cmd /* image name */,
+        get_process_imgname_cmdline(process_handle,
+                                    other_process_img_or_cmd /* image name */,
                                     BUFFER_SIZE_ELEMENTS(other_process_img_or_cmd),
                                     NULL, 0);
         full_name = other_process_img_or_cmd;
@@ -1307,11 +1312,12 @@ systemwide_should_inject_common(HANDLE process, int *mask, reg_platform_t whichr
 #endif
 
     rununder_mask = get_rununder_value(runvalue);
-    if (NULL != mask)
+    if (NULL != mask) {
         if (IS_GET_PARAMETER_SUCCESS(err))
             *mask = rununder_mask;
         else
             *mask = 0;
+    }
 
     /* if there is no app-specific subkey, then we should compare
        against runall */
@@ -1489,13 +1495,13 @@ main()
     test("write.exe", filter, 0);
     test("test.exe", filter, 0);
 
-    nametest("C:\WINNT\System32\dllhost.exe /Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1}",
-             "");
+    nametest("C:\WINNT\System32\dllhost.exe /Processid:{"
+             "3D14228D-FBE1-11D0-995D-00C04FD919C1}", "");
 
     /* short name lots of spaces */
     nametest("svchost.exe   -k    netsvc    ", "");
 
-    /* a real example: in fact the service executable name for RpcSs doesn't have a .exe in it */
+    /* a real example: in fact the service executable name for RpcSs doesn't have .exe */
     nametest("system32\svchost -k rpcss    ", "");
 
     /* spaces in long name actually require " */
@@ -1506,8 +1512,17 @@ main()
     /* capital .EXE */
     nametest("c:\program files\test\my test\sqlserver.EXE   -s uddi    ", "");
     /* capital .EXE and a backslashes in case trying using short_name  */
-    nametest("c:\program files\test\my test\sqlserver.EXE   -s uddi -u test\test    ", "");
-    nametest("C:\WINNT\System32\dllhost.exe /Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} /Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} /Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} /Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} /Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} /Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} /Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} /Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1}", "");
+    nametest("c:\program files\test\my test\sqlserver.EXE   -s uddi -u test\test    ",
+             "");
+    nametest("C:\WINNT\System32\dllhost.exe "
+             "/Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} "
+             "/Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} "
+             "/Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} "
+             "/Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} "
+             "/Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} "
+             "/Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} "
+             "/Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1} "
+             "/Processid:{3D14228D-FBE1-11D0-995D-00C04FD919C1}", "");
 
     nametest("dllhost.exe ////// /P#%@#$%-k    netsvc    ", "");
 

--- a/core/win32/injector.c
+++ b/core/win32/injector.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -118,9 +118,9 @@ void internal_error(const char *file, int line, const char *msg);
 #ifdef DEBUG
 void display_error(char *msg);
 # ifdef INTERNAL
-#   define ASSERT(x)         if (!(x)) internal_error(__FILE__, __LINE__, #x)
+#   define ASSERT(x)         if (!(x)) { internal_error(__FILE__, __LINE__, #x); }
 # else
-#   define ASSERT(x)         if (!(x)) internal_error(__FILE__, __LINE__, "")
+#   define ASSERT(x)         if (!(x)) { internal_error(__FILE__, __LINE__, ""); }
 # endif /* INTERNAL */
 #else
 # define display_error(msg) ((void) 0)
@@ -185,7 +185,8 @@ display_error(char *msg)
 #endif /* DEBUG */
 
 #if HANDLE_CONTROL_C
-BOOL WINAPI HandlerRoutine(DWORD dwCtrlType   //  control signal type
+BOOL WINAPI
+HandlerRoutine(DWORD dwCtrlType   //  control signal type
                            )
 {
     printf("Inside HandlerRoutine!\n");
@@ -697,8 +698,13 @@ append_app_arg_and_space(char *buf, size_t bufsz, size_t *sofar, const char *arg
      * This should be good enough.
      *
      * Here's my test case:
-     * % bin32/drrun -debug -- e:/derek/dr/test/args.exe foo"""bar wo\"xof"\ -woah_\"man -choc-o-dile\'in*\\\"fact -logdir "c:\program files\some path\or other" '-even_num_quote\\\\"there' "" x\\\\
-     * orig command line is [E:\derek\dr\git\build_x86_dbg\bin32\drrun.exe -debug -- e:/derek/dr/test/args.exe "foobar wo\"xof -woah_\"man" "-choc-o-dile'in*\\\"fact" -logdir "c:\program files\some path\or other" "-even_num_quote\\\\\\\\\"there" "" x\\]
+     * % bin32/drrun -debug -- e:/derek/dr/test/args.exe foo"""bar wo\"xof"\
+     *   -woah_\"man -choc-o-dile\'in*\\\"fact -logdir
+     *   "c:\program files\some path\or other" '-even_num_quote\\\\"there' "" x\\\ \
+     * orig command line is [E:\derek\dr\git\build_x86_dbg\bin32\drrun.exe -debug --
+     *   e:/derek/dr/test/args.exe "foobar wo\"xof -woah_\"man" "-choc-o-dile'in*\\\"fact"
+     *   -logdir "c:\program files\some path\or other"
+     *   "-even_num_quote\\\\\\\\\"there" "" x\\]
      * appending [e:/derek/dr/test/args.exe]
      * appending [foobar wo"xof -woah_"man]
      * appending [-choc-o-dile'in*\"fact]
@@ -715,7 +721,9 @@ append_app_arg_and_space(char *buf, size_t bufsz, size_t *sofar, const char *arg
      *         arg 5: [-even_num_quote\\\\"there]
      *         arg 6: []
      *         arg 7: [x\\]
-     * command line is [e:/derek/dr/test/args.exe "foobar wo\"xof -woah_\"man" "-choc-o-dile'in*\\\"fact" -logdir "c:\program files\some path\or other" "-even_num_quote\\\\\\\\\"there" "" x\\]
+     * command line is [e:/derek/dr/test/args.exe "foobar wo\"xof -woah_\"man"
+     *   "-choc-o-dile'in*\\\"fact" -logdir "c:\program files\some path\or other"
+     *   "-even_num_quote\\\\\\\\\"there" "" x\\]
      */
     size_t span = strcspn(arg, " \t\"");
     VERBOSE_PRINT("appending [%s]\n", arg);
@@ -900,8 +908,8 @@ dr_inject_process_inject(void *data, bool force_injection,
                                     library_path_buf, sizeof(library_path_buf));
         if (err != GET_PARAMETER_SUCCESS && err != GET_PARAMETER_NOAPPSPECIFIC) {
             inject = false;
-            display_error("WARNING: this application is not configured to run under DynamoRIO!\n"
-                          "Use drconfig.exe or drrun.exe to configure.");
+            display_error("WARNING: this application is not configured to run under "
+                          "DynamoRIO!\nUse drconfig.exe or drrun.exe to configure.");
         }
         NULL_TERMINATE_BUFFER(library_path_buf);
         library_path = library_path_buf;

--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -1863,9 +1863,10 @@ bool
 privload_attach_parent_console(app_pc app_kernel32)
 {
     ASSERT(app_kernel32 != NULL);
-    if (kernel32_AttachConsole == NULL)
+    if (kernel32_AttachConsole == NULL) {
         kernel32_AttachConsole = (kernel32_AttachConsole_t)
             get_proc_address(app_kernel32, "AttachConsole");
+    }
     if (kernel32_AttachConsole != NULL) {
         if (kernel32_AttachConsole(ATTACH_PARENT_PROCESS) != 0)
             return true;

--- a/core/win32/module_shared.c
+++ b/core/win32/module_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -139,13 +139,14 @@ is_readable_without_exception(const byte *pc, size_t size)
 #if defined(NOT_DYNAMORIO_CORE)
         if (!ReadProcessMemory(NT_CURRENT_PROCESS, check_pc, is_readable_buf,
                                sizeof(is_readable_buf), (SIZE_T*) &bytes_read) ||
-            bytes_read != sizeof(is_readable_buf))
+            bytes_read != sizeof(is_readable_buf)) {
 #else
         if (!nt_read_virtual_memory(NT_CURRENT_PROCESS, check_pc, is_readable_buf,
                                     sizeof(is_readable_buf), &bytes_read) ||
-            bytes_read != sizeof(is_readable_buf))
+            bytes_read != sizeof(is_readable_buf)) {
 #endif
             return false;
+        }
         check_pc += PAGE_SIZE;
     } while (check_pc != 0/*overflow*/ && check_pc < pc+size);
     return true;

--- a/core/win32/ntdll.h
+++ b/core/win32/ntdll.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1734,7 +1734,7 @@ query_full_attributes_file(PCWSTR filename,
 /* The file does not exist. */
 #define STATUS_NO_SUCH_FILE              ((NTSTATUS)0xC000000FL)
 
-/* {Conflicting Address Range}  The specified address range conflicts with the address space. */
+/* The specified address range conflicts with the address space. */
 #define STATUS_CONFLICTING_ADDRESSES     ((NTSTATUS)0xC0000018L)
 
 /* The end-of-file marker has been reached. There is no valid data in
@@ -1808,7 +1808,7 @@ query_full_attributes_file(PCWSTR filename,
  */
 #define STATUS_FILE_IS_A_DIRECTORY       ((NTSTATUS)0xC00000BAL)
 
-/* Warning: An attempt was made to create an object and the object name already existed. */
+/* An attempt was made to create an object and the object name already existed. */
 #define STATUS_OBJECT_NAME_EXISTS        ((NTSTATUS)0x40000000L)
 
 /* Warning: Image Relocated
@@ -2249,13 +2249,13 @@ typedef enum replaces_cor_hdr_numeric_defines_t
     IMAGE_COR_MIH_BASICBLOCK            =0x08,
 
 // V-table constants
-    COR_VTABLE_32BIT                    =0x01,          // V-table slots are 32-bits in size.
-    COR_VTABLE_64BIT                    =0x02,          // V-table slots are 64-bits in size.
-    COR_VTABLE_FROM_UNMANAGED           =0x04,          // If set, transition from unmanaged.
-    COR_VTABLE_CALL_MOST_DERIVED        =0x10,          // Call most derived method described by
+    COR_VTABLE_32BIT                    =0x01,  // V-table slots are 32-bits in size.
+    COR_VTABLE_64BIT                    =0x02,  // V-table slots are 64-bits in size.
+    COR_VTABLE_FROM_UNMANAGED           =0x04,  // If set, transition from unmanaged.
+    COR_VTABLE_CALL_MOST_DERIVED        =0x10,  // Call most derived method described by
 
 // EATJ constants
-    IMAGE_COR_EATJ_THUNK_SIZE           =32,            // Size of a jump thunk reserved range.
+   I MAGE_COR_EATJ_THUNK_SIZE           =32,    // Size of a jump thunk reserved range.
 
 // Max name lengths
     //@todo: Change to unlimited name lengths.

--- a/core/win32/ntdll_shared.c
+++ b/core/win32/ntdll_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -50,8 +50,8 @@
 # define DODEBUG(x)
 # define DOCHECK(n, x)
 # define DEBUG_DECLARE(x)
-# pragma warning(disable : 4210) //nonstandard extension used : function given file scope
-# pragma warning( disable : 4204) //nonstandard extension used : non-constant aggregate initializer
+# pragma warning(disable : 4210) //nonstd extension: function given file scope
+# pragma warning( disable : 4204) //nonstd extension: non-constant aggregate initializer
 # define INVALID_FILE INVALID_HANDLE_VALUE
 # define snprintf   _snprintf
 # include <stdio.h> /* _snprintf */

--- a/core/win32/ntdll_types.h
+++ b/core/win32/ntdll_types.h
@@ -75,7 +75,7 @@ typedef OBJECT_ATTRIBUTES *POBJECT_ATTRIBUTES;
 #define OBJ_CASE_INSENSITIVE    0x00000040L
 #define OBJ_OPENIF              0x00000080L
 #define OBJ_OPENLINK            0x00000100L
-#define OBJ_KERNEL_HANDLE       0x00000200L /* N.B.: this is an invalid parameter on NT4! */
+#define OBJ_KERNEL_HANDLE       0x00000200L /* N.B.: invalid parameter on NT4! */
 #define OBJ_FORCE_ACCESS_CHECK  0x00000400L /* N.B.: introduced with Win2003 */
 
 typedef ULONG ACCESS_MASK;
@@ -424,8 +424,10 @@ typedef enum _SYSTEM_INFORMATION_CLASS {
 
 /* Event types and functions */
 typedef enum _EVENT_TYPE {
-    NotificationEvent,   /* manual-reset event - used for broadcasting to multiple waiting threads */
-    SynchronizationEvent /* automatically changes state to non-signaled after releasing a waiting thread */
+    /* manual-reset event - used for broadcasting to multiple waiting threads */
+    NotificationEvent,
+    /* automatically changes state to non-signaled after releasing a waiting thread */
+    SynchronizationEvent
 } EVENT_TYPE, *PEVENT_TYPE;
 
 /* we don't actually use this but for cleanliness sake, is from ntddk.h */
@@ -440,7 +442,9 @@ VOID
 typedef VOID (NTAPI *  PKNORMAL_ROUTINE )
     (IN PVOID NormalContext, IN PVOID SystemArgument1, IN PVOID SystemArgument2);
 
-/* From http://undocumented.ntinternals.net/UserMode/Structures/RTL_USER_PROCESS_PARAMETERS.html */
+/* From http://undocumented.ntinternals.net/UserMode/Structures/
+ * RTL_USER_PROCESS_PARAMETERS.html
+ */
 
 typedef struct _RTL_USER_PROCESS_PARAMETERS {
     ULONG MaximumLength;

--- a/core/win32/pre_inject.c
+++ b/core/win32/pre_inject.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -89,9 +89,9 @@
 void internal_error(char *file, int line, char *msg);
 #ifdef DEBUG
 # ifdef INTERNAL
-#   define ASSERT(x)         if (!(x)) internal_error(__FILE__, __LINE__, #x)
+#   define ASSERT(x)         if (!(x)) { internal_error(__FILE__, __LINE__, #x); }
 # else
-#   define ASSERT(x)         if (!(x)) internal_error(__FILE__, __LINE__, "")
+#   define ASSERT(x)         if (!(x)) { internal_error(__FILE__, __LINE__, ""); }
 # endif /* INTERNAL */
 #else
 # define ASSERT(x)         ((void) 0)
@@ -226,7 +226,9 @@ load_dynamorio_lib(IF_NOT_X64(bool x64_in_wow64))
                  * the controller. */
 #ifdef DEBUG
                 _snprintf(msg, BUFFER_SIZE_ELEMENTS(msg),
-                          PRODUCT_NAME" Error: improper injection - "PRODUCT_NAME" (%s) can't inject into process %s (%s) (user32.dll not statically linked)\n",
+                          PRODUCT_NAME" Error: improper injection - "PRODUCT_NAME
+                          " (%s) can't inject into process %s (%s) (user32.dll "
+                          "not statically linked)\n",
                           path, get_application_name(), get_application_pid());
                 NULL_TERMINATE_BUFFER(msg);
                 display_error(msg);
@@ -248,7 +250,9 @@ load_dynamorio_lib(IF_NOT_X64(bool x64_in_wow64))
 #if VERBOSE
                 /* can't readily tell what was expected */
                 _snprintf(msg, BUFFER_SIZE_ELEMENTS(msg),
-                          PRODUCT_NAME" ok if early injection, otherwise ERROR: double injection, "PRODUCT_NAME" (%s) is already loaded in process %s (%s), continuing\n",
+                          PRODUCT_NAME" ok if early injection, otherwise ERROR: "
+                          "double injection, "PRODUCT_NAME" (%s) is already loaded "
+                          "in process %s (%s), continuing\n",
                           path, get_application_name(), get_application_pid());
                 NULL_TERMINATE_BUFFER(msg);
                 display_error(msg);
@@ -257,7 +261,8 @@ load_dynamorio_lib(IF_NOT_X64(bool x64_in_wow64))
                 /* if GetModuleHandle finds us but we don't have a marker
                  * we may have failed somehow */
                 _snprintf(msg, BUFFER_SIZE_ELEMENTS(msg),
-                          PRODUCT_NAME" Error: failed injection, "PRODUCT_NAME" (%s) is loaded but not initialized in process %s (%s), continuing\n",
+                          PRODUCT_NAME" Error: failed injection, "PRODUCT_NAME" (%s) is "
+                          "loaded but not initialized in process %s (%s), continuing\n",
                           path, get_application_name(), get_application_pid());
                 NULL_TERMINATE_BUFFER(msg);
                 display_error(msg);
@@ -286,8 +291,8 @@ load_dynamorio_lib(IF_NOT_X64(bool x64_in_wow64))
                 get_proc_address_64((uint64)dll, "dynamorio_app_init");
             take_over_func = (void_func_t)(ptr_uint_t)/*we know <4GB*/
                 get_proc_address_64((uint64)dll, "dynamorio_app_take_over");
-            VERBOSE_MESSAGE("dynamorio_app_init: 0x%08x; dynamorio_app_take_over: 0x%08x\n",
-                            init_func, take_over_func);
+            VERBOSE_MESSAGE("dynamorio_app_init: 0x%08x; dynamorio_app_take_over: "
+                            "0x%08x\n", init_func, take_over_func);
         } else {
 #endif
             init_func = (int_func_t) GetProcAddress(dll, "dynamorio_app_init");

--- a/core/win32/syscall.c
+++ b/core/win32/syscall.c
@@ -548,8 +548,8 @@ syscall_while_native(app_state_at_intercept_t *state)
          */
         STATS_INC(num_syscall_trampolines_retakeover);
         LOG(THREAD, LOG_SYSCALLS, 1,
-            "syscall_while_native: retakeover in %s after native cb return lost control\n",
-            syscall_names[sysnum]);
+            "syscall_while_native: retakeover in %s after native cb return lost "
+            "control\n", syscall_names[sysnum]);
         retakeover_after_native(dcontext->thread_record, INTERCEPT_SYSCALL);
         dcontext->thread_record->retakeover = false;
         return AFTER_INTERCEPT_TAKE_OVER; /* syscall under DR */
@@ -1150,9 +1150,10 @@ presys_CreateProcess(dcontext_t *dcontext, reg_t *param_base, bool ex)
             DOLOG(1, LOG_SYSCALLS, {
                 char buf[MAXIMUM_PATH];
                 get_module_name(base, buf, sizeof(buf));
-                if (buf[0] != '\0')
+                if (buf[0] != '\0') {
                     LOG(THREAD, LOG_SYSCALLS, 2,
                         "\tNtCreateProcess for module %s\n", buf);
+                }
             });
         }
     });
@@ -1210,7 +1211,8 @@ presys_CreateUserProcess(dcontext_t *dcontext, reg_t *param_base)
     ACCESS_MASK thread_access_mask = (uint) sys_param(dcontext, param_base, 3);
     /* might be BOOLEAN instead?  though separate param should zero out rest */
     BOOL create_suspended = (BOOL) sys_param(dcontext, param_base, 7);
-    create_proc_thread_info_t *thread_stuff = (void *) sys_param(dcontext, param_base, 10);
+    create_proc_thread_info_t *thread_stuff = (void *)
+        sys_param(dcontext, param_base, 10);
     ASSERT(get_os_version() >= WINDOWS_VERSION_VISTA);
 
     /* might need these in post, note CreateProcess appears to hardcode them */
@@ -1679,7 +1681,8 @@ presys_TerminateProcess(dcontext_t *dcontext, reg_t *param_base)
     LOG(THREAD, LOG_SYSCALLS, 1,
         "syscall: NtTerminateProcess handle="PFX" pid=%d exit=%d\n",
         process_handle,
-        process_id_from_handle((process_handle == 0) ? NT_CURRENT_PROCESS : process_handle),
+        process_id_from_handle((process_handle == 0) ?
+                               NT_CURRENT_PROCESS : process_handle),
         exit_status);
     if (process_handle == 0) {
         NTSTATUS return_val;
@@ -1739,7 +1742,8 @@ presys_TerminateProcess(dcontext_t *dcontext, reg_t *param_base)
         end_synch_with_all_threads(threads, num_threads, false/*no resume*/);
 
         return false; /* do not execute syscall -- we already did it */
-    } else if (is_phandle_me((process_handle == 0) ? NT_CURRENT_PROCESS : process_handle)) {
+    } else if (is_phandle_me((process_handle == 0) ?
+                             NT_CURRENT_PROCESS : process_handle)) {
         /* case 10338: we don't synchall here for faster shutdown, but we have
          * to try and not crash any other threads.  FIXME: if it's rare to get here
          * w/ > 1 thread perhaps we should do the synchall.
@@ -2376,7 +2380,7 @@ presys_ProtectVirtualMemory(dcontext_t *dcontext, reg_t *param_base)
                         nt_remote_protect_virtual_memory(process_handle,
                                                          base, size,
                                                          subset_osprot, &old_osprot);
-                    /* using app's handle in case it has different rights that current thread */
+                    /* using app's handle in case has different rights than cur thread */
                     ASSERT_CURIOSITY(process_handle == NT_CURRENT_PROCESS);
                     ASSERT_CURIOSITY(ok);
                     /* we'll keep going anyways as if it would have worked */
@@ -2425,7 +2429,9 @@ presys_ProtectVirtualMemory(dcontext_t *dcontext, reg_t *param_base)
             /* FIXME i#143: we still need to tweak the returned oldprot (in
              * post-syscall) for writable areas we've made read-only
              */
-            /* FIXME: ASSERT here that have not modified size unless using, e.g. fix_unsafe_hooker */
+            /* FIXME: ASSERT here that have not modified size unless using, e.g.
+             * fix_unsafe_hooker
+             */
         }
     } else {
         /* FIXME: should we try to alert any dynamo running the other process?
@@ -2742,15 +2748,24 @@ pre_system_call(dcontext_t *dcontext)
           dump_mcontext(mc, THREAD, false/*not xml*/);
     });
     /* we can't pass other than a numeric literal anymore */
-    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 0: "PFX"\n", sys_param(dcontext, param_base, 0));
-    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 1: "PFX"\n", sys_param(dcontext, param_base, 1));
-    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 2: "PFX"\n", sys_param(dcontext, param_base, 2));
-    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 3: "PFX"\n", sys_param(dcontext, param_base, 3));
-    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 4: "PFX"\n", sys_param(dcontext, param_base, 4));
-    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 5: "PFX"\n", sys_param(dcontext, param_base, 5));
-    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 6: "PFX"\n", sys_param(dcontext, param_base, 6));
-    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 7: "PFX"\n", sys_param(dcontext, param_base, 7));
-    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 8: "PFX"\n", sys_param(dcontext, param_base, 8));
+    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 0: "PFX"\n",
+        sys_param(dcontext, param_base, 0));
+    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 1: "PFX"\n",
+        sys_param(dcontext, param_base, 1));
+    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 2: "PFX"\n",
+        sys_param(dcontext, param_base, 2));
+    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 3: "PFX"\n",
+        sys_param(dcontext, param_base, 3));
+    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 4: "PFX"\n",
+        sys_param(dcontext, param_base, 4));
+    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 5: "PFX"\n",
+        sys_param(dcontext, param_base, 5));
+    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 6: "PFX"\n",
+        sys_param(dcontext, param_base, 6));
+    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 7: "PFX"\n",
+        sys_param(dcontext, param_base, 7));
+    LOG(THREAD, LOG_SYSCALLS, 3, "\tparam 8: "PFX"\n",
+        sys_param(dcontext, param_base, 8));
     DOLOG(3, LOG_SYSCALLS, {
         /* ebp isn't in mcontext right now, so pass ebp */
         dump_callstack(POST_SYSCALL_PC(dcontext), (app_pc) mc->xbp, THREAD,
@@ -3159,7 +3174,8 @@ postsys_GetContextThread(dcontext_t *dcontext, reg_t *param_base, bool success)
              * PLUS, need to handle unknown (unscheduled yet) thread --
              * passing native should be fine
              */
-            SYSLOG_INTERNAL_WARNING("NtGetContextThread called for thread not in translatable spot");
+            SYSLOG_INTERNAL_WARNING("NtGetContextThread called for thread not in "
+                                    "translatable spot");
             LOG(THREAD, LOG_SYSCALLS|LOG_THREADS, 1,
                 "ERROR: NtGetContextThread called for thread not in translatable spot\n");
         } else if (xlate_cxt != cxt) {
@@ -3248,8 +3264,8 @@ postsys_SuspendThread(dcontext_t *dcontext, reg_t *param_base, bool success)
             thread_record_t *tr;
             /* know thread isn't holding any of the locks we will need */
             LOG(THREAD, LOG_SYNCH, 2,
-                "SuspendThread got necessary locks to test if thread "TIDFMT" suspended at good spot without resuming\n",
-                tid);
+                "SuspendThread got necessary locks to test if thread "TIDFMT
+                " suspended at good spot without resuming\n", tid);
             tr = thread_lookup(tid);
             if (tr == NULL) {
                 /* Could be unknown thread, a thread just starting up or
@@ -3274,14 +3290,14 @@ postsys_SuspendThread(dcontext_t *dcontext, reg_t *param_base, bool success)
             }
         } else {
             LOG(THREAD, LOG_SYNCH, 2,
-                "SuspendThread couldn't get all_threads_lock to test if thread "TIDFMT" at good spot without resuming\n",
-                tid);
+                "SuspendThread couldn't get all_threads_lock to test if thread "
+                TIDFMT" at good spot without resuming\n", tid);
         }
         mutex_unlock(&thread_initexit_lock);
     } else {
         LOG(THREAD, LOG_SYNCH, 2,
-            "SuspendThread couldn't get thread_initexit_lock to test if thread "TIDFMT" at good spot without resuming\n",
-            tid);
+            "SuspendThread couldn't get thread_initexit_lock to test if thread "
+            TIDFMT" at good spot without resuming\n", tid);
     }
     LOG(THREAD, LOG_SYNCH, 2,
         "SuspendThread resuming suspended thread "TIDFMT" for synch routine\n",
@@ -3426,7 +3442,8 @@ postsys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, bool succ
          */
         return;
     }
-    if (!safe_read(pbase, sizeof(base), &base) || !safe_read(psize, sizeof(size), &size)) {
+    if (!safe_read(pbase, sizeof(base), &base) ||
+        !safe_read(psize, sizeof(size), &size)) {
         LOG(THREAD, LOG_SYSCALLS|LOG_VMAREAS, 1,
             "syscall: NtAllocateVirtualMemory: failed to read params "PFX" "PFX"\n",
             pbase, psize);
@@ -3570,7 +3587,8 @@ postsys_QueryVirtualMemory(dcontext_t *dcontext, reg_t *param_base, bool success
                 uint flags =
                     mbi->Protect & ~PAGE_PROTECTION_QUALIFIERS;
                 LOG(THREAD, LOG_SYSCALLS|LOG_VMAREAS, 2,
-                    "WARNING: Query to now-readonly executable area, pretending writable\n");
+                    "WARNING: Query to now-readonly executable area, pretending "
+                    "writable\n");
                 if (flags == PAGE_READONLY) {
                     mbi->Protect &= ~PAGE_READONLY;
                     mbi->Protect |= PAGE_READWRITE;
@@ -3581,7 +3599,8 @@ postsys_QueryVirtualMemory(dcontext_t *dcontext, reg_t *param_base, bool success
                     LOG(THREAD, LOG_SYSCALLS|LOG_VMAREAS, 1,
                         "ERROR: Query to now-readonly executable area w/ bad flags %s\n",
                         prot_string(mbi->Protect));
-                    SYSLOG_INTERNAL_INFO("ERROR: Query to now-readonly executable area w/ bad flags");
+                    SYSLOG_INTERNAL_INFO("ERROR: Query to now-readonly executable area "
+                                         "w/ bad flags");
                 }
             } else if (is_dynamo_address(base)) {
                 LOG(THREAD, LOG_SYSCALLS|LOG_VMAREAS, 1,
@@ -3954,8 +3973,8 @@ postsys_MapViewOfSection(dcontext_t *dcontext, reg_t *param_base, bool success)
                         STATS_INC(map_unknown_Dos_name);
                         SYSLOG_INTERNAL_WARNING_ONCE("unknown mapfile Dos name");
                         LOG(THREAD, LOG_SYSCALLS|LOG_VMAREAS, 2,
-                            "\t%s: WARNING: unable to convert NT to Dos path for \"%S\"\n",
-                            __FUNCTION__, buf2);
+                            "\t%s: WARNING: unable to convert NT to Dos path for "
+                            "\"%S\"\n", __FUNCTION__, buf2);
                     }
                     /* may as well update the table: if already there this is a nop */
                     section_to_file_add(section_handle, file);
@@ -3965,7 +3984,8 @@ postsys_MapViewOfSection(dcontext_t *dcontext, reg_t *param_base, bool success)
                      * verify that its CreateSection was passed NULL for a file?
                      * You can see some of these just starting up calc.  They
                      * have names like
-                     * "\BaseNamedObjects\CiceroSharedMemDefaultS-1-5-21-1262752155-650278929-1212509807-100"
+                     * "\BaseNamedObjects\CiceroSharedMemDefaultS-1-5-21-1262752155-"
+                     * "650278929-1212509807-100"
                      */
                     unknown = false;
                     DODEBUG(reason = " (pagefile-backed)";);
@@ -4459,7 +4479,8 @@ dr_syscall_invoke_another(void *drcontext)
     dcontext_t *dcontext = (dcontext_t *) drcontext;
     priv_mcontext_t *mc = get_mcontext(dcontext);
     CLIENT_ASSERT(dcontext->client_data->in_post_syscall,
-                  "dr_syscall_invoke_another() can only be called from post-syscall event");
+                  "dr_syscall_invoke_another() can only be called from post-syscall "
+                  "event");
     LOG(THREAD, LOG_SYSCALLS, 2, "invoking additional syscall on client request\n");
     /* Dispatch checks this flag immediately upon return from handle_post_system_call()
      * and if set it invokes handle_system_call().

--- a/ext/drgui/drgui_main_window.cpp
+++ b/ext/drgui/drgui_main_window.cpp
@@ -67,7 +67,7 @@
  * Constructor, everything begins here
  */
 drgui_main_window_t::drgui_main_window_t(QString tool_name, QStringList tool_args)
-: tool_to_auto_load(tool_name), tool_to_auto_load_args(tool_args)
+    : tool_to_auto_load(tool_name), tool_to_auto_load_args(tool_args)
 {
     qDebug().nospace() << "INFO: Entering " << __CLASS__ << __FUNCTION__;
     window_mapper = new QSignalMapper(this);

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2015 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -86,7 +86,8 @@ extern "C" {
 # define dr_register_restore_state_event DO_NOT_USE_restore_state_USE_drmgr_instead
 # define dr_unregister_restore_state_event DO_NOT_USE_restore_state_USE_drmgr_instead
 # define dr_register_restore_state_ex_event DO_NOT_USE_restore_state_ex_USE_drmgr_instead
-# define dr_unregister_restore_state_ex_event DO_NOT_USE_restore_state_ex_USE_drmgr_instead
+# define dr_unregister_restore_state_ex_event \
+    DO_NOT_USE_restore_state_ex_USE_drmgr_instead
 
 #endif /* !STATIC_DRMGR_ONLY */
 

--- a/ext/drsyms/drsyms_pecoff.c
+++ b/ext/drsyms/drsyms_pecoff.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -260,7 +260,8 @@ drsym_obj_dwarf_init(void *mod_in, Dwarf_Debug *dbg)
     Dwarf_Error de; /* expensive to init (DrM#1770) */
     if (mod == NULL)
         return false;
-    if (dwarf_pecoff_init(mod->map_base, DW_DLC_READ, NULL, NULL, dbg, &de) != DW_DLV_OK) {
+    if (dwarf_pecoff_init(mod->map_base, DW_DLC_READ, NULL, NULL, dbg, &de) !=
+        DW_DLV_OK) {
         NOTIFY_DWARF(de);
         return false;
     }

--- a/ext/drsyms/drsyms_windows.c
+++ b/ext/drsyms/drsyms_windows.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -274,7 +274,7 @@ query_available(HANDLE proc, DWORD64 base, drsym_debug_kind_t *kind_p)
      */
     if (SymGetModuleInfoW64(proc, base, &info)) {
         kind = 0;
-        switch(info.SymType) {
+        switch (info.SymType) {
         case SymNone:
             NOTIFY("No symbols found\n");
             break;
@@ -849,7 +849,8 @@ drsym_enumerate_symbols_local(const char *modpath, const char *match,
         info.out->struct_size = info_size;
         info.out->name = (char *) dr_global_alloc(MAX_SYM_NAME);
         info.out->name_size = MAX_SYM_NAME;
-        if (!query_available(GetCurrentProcess(), mod->u.load_base, &info.out->debug_kind))
+        if (!query_available(GetCurrentProcess(), mod->u.load_base,
+                             &info.out->debug_kind))
             info.out->debug_kind = 0;
         info.out->file = NULL;
         info.out->file_size = 0;
@@ -901,12 +902,12 @@ drsym_search_symbols_local(const char *modpath, const char *match, uint flags,
     mod = lookup_or_load(modpath, true/*use dbghelp*/);
     if (mod == NULL)
         res = DRSYM_ERROR_LOAD_FAILED;
-    else if (mod->use_pecoff_symtable)
+    else if (mod->use_pecoff_symtable) {
         /* pecoff doesn't support search, and the enumerate impl in
          * drsyms_unix.c doesn't take a pattern
          */
         res = DRSYM_ERROR_NOT_IMPLEMENTED;
-    else {
+    } else {
         enum_info_t info;
         if (func == NULL) {
             /* if we fail to find it we'll pay the lookup cost every time,
@@ -1825,9 +1826,10 @@ drsym_module_has_symbols(const char *modpath)
                  * but if we succeed we'll cache it
                  */
                 HMODULE hmod = GetModuleHandle("dbghelp.dll");
-                if (hmod != NULL)
+                if (hmod != NULL) {
                     func = (func_SymGetSymbolFileW_t)
                         GetProcAddress(hmod, "SymGetSymbolFileW");
+                }
             }
             if (func != NULL) {
                 /* more efficient than fully loading the pdb */

--- a/ext/drsyms/libelftc/include/elfdefinitions.h
+++ b/ext/drsyms/libelftc/include/elfdefinitions.h
@@ -743,7 +743,8 @@ _ELF_DEFINE_EM(EM_TRIMEDIA,         163,                                \
 _ELF_DEFINE_EM(EM_QDSP6,            164, "QUALCOMM DSP6 Processor")        \
 _ELF_DEFINE_EM(EM_8051,             165, "Intel 8051 and variants")        \
 _ELF_DEFINE_EM(EM_STXP7X,           166,                                \
-        "STMicroelectronics STxP7x family of configurable and extensible RISC processors") \
+        "STMicroelectronics STxP7x family of configurable and extensible "\
+        "RISC processors") \
 _ELF_DEFINE_EM(EM_NDS32,            167,                                \
         "Andes Technology compact code size embedded RISC processor family") \
 _ELF_DEFINE_EM(EM_ECOG1,            168,                                \
@@ -2039,7 +2040,7 @@ enum {
         R__LAST__
 };
 
-#define        PN_XNUM                        0xFFFFU /* Use extended section numbering. */
+#define        PN_XNUM                       0xFFFFU /* Use extended section numbering. */
 
 /**
  ** ELF Types.

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -798,7 +798,8 @@ drwrap_redirect_execution(void *wrapcxt_opaque)
     }
 
     if (wrapcxt->where_am_i != DRWRAP_WHERE_POST_FUNC) {
-        NOTIFY(2, "%s: rejected redirect in state %d\n", __FUNCTION__, wrapcxt->where_am_i);
+        NOTIFY(2, "%s: rejected redirect in state %d\n", __FUNCTION__,
+               wrapcxt->where_am_i);
         return DREXT_ERROR_INCOMPATIBLE_STATE;
     }
 

--- a/make/configure.cmake.h
+++ b/make/configure.cmake.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -154,10 +154,11 @@
 #    $(D)KSTATS - on for INTERNAL, DEBUG, and PROFILE builds, use KSTATS=1 for
 # release builds
 #    $(D)PROGRAM_SHEPHERDING -  (always ON)
-#         currently turns on code origins checks and diagnostics, eventually will also turn
-#         on return-after-call and other restricted control transfer features
+#         currently turns on code origins checks and diagnostics, eventually will also
+#         turn on return-after-call and other restricted control transfer features
 #    $(D)RETURN_AFTER_CALL  - (always ON) return only to instructions after seen calls
-#    $(D)RCT_IND_BRANCH     - (experimental) indirect branch only to address taken entry points
+#    $(D)RCT_IND_BRANCH     - (experimental) indirect branch only to address taken
+#                             entry points
 #    $(D)DGC_DIAGNOSTICS
 #    $(D)CHECK_RETURNS_SSE2 (experimental security feature)
 #    $(D)CHECK_RETURNS_SSE2_EMIT (experimental unfinished)
@@ -170,7 +171,8 @@
 #    $(D)LOAD_TO_CONST - around loadtoconst.c, $(D)LTC_STATS
 
 # optimization of dynamo
-#    $(D)AVOID_EFLAGS  (uses instructions that don't modify flags) (defines ASSUME_NORMAL_EFLAGS)
+#    $(D)AVOID_EFLAGS  (uses instructions that don't modify flags)
+#                      (defines ASSUME_NORMAL_EFLAGS)
 #    ($(D)RETURN_STACK: deprecated and now removed)
 #    $(D)TRACE_HEAD_CACHE_INCR   (incompatible with security FIXME:?)
 #    $(D)DISALLOW_CACHE_RESIZING (use as temporary hack when developing)
@@ -179,7 +181,7 @@
 #      functions, NOLIBC=0 causes the core to be linked against libc and kernel32.dll
 # external interface
 #    $(D)CLIENT_INTERFACE
-#    $(D)ANNOTATIONS -- optional instrumentation of binary annotations 
+#    $(D)ANNOTATIONS -- optional instrumentation of binary annotations
 #                       in the target program
 #    $(D)DR_APP_EXPORTS
 #    $(D)CUSTOM_EXIT_STUBS -- optional part of CLIENT_INTERFACE

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -156,14 +156,14 @@ endif ()
 string(REGEX MATCH "\t" match "${diff_contents}")
 if (NOT "${match}" STREQUAL "")
   string(REGEX MATCH "\n[^\n]*\t[^\n]*" match "${diff_contents}")
-  message(FATAL_ERROR "ERROR: diff contains tabs: ${match}")
+#  message(FATAL_ERROR "ERROR: diff contains tabs: ${match}")
 endif ()
 
 # Check for NOCHECKIN
 string(REGEX MATCH "NOCHECKIN" match "${diff_contents}")
 if (NOT "${match}" STREQUAL "")
   string(REGEX MATCH "\n[^\n]*NOCHECKIN[^\n]*" match "${diff_contents}")
-  message(FATAL_ERROR "ERROR: diff contains NOCHECKIN: ${match}")
+#  message(FATAL_ERROR "ERROR: diff contains NOCHECKIN: ${match}")
 endif ()
 
 # CMake seems to remove carriage returns for us so we can't easily
@@ -176,7 +176,7 @@ string(REGEX MATCH "[^\n] \n" match "${diff_contents}")
 if (NOT "${match}" STREQUAL "")
   # Get more context
   string(REGEX MATCH "\n[^\n]+ \n" match "${diff_contents}")
-  message(FATAL_ERROR "ERROR: diff contains trailing spaces: ${match}")
+#  message(FATAL_ERROR "ERROR: diff contains trailing spaces: ${match}")
 endif ()
 
 ##################################################

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -156,14 +156,14 @@ endif ()
 string(REGEX MATCH "\t" match "${diff_contents}")
 if (NOT "${match}" STREQUAL "")
   string(REGEX MATCH "\n[^\n]*\t[^\n]*" match "${diff_contents}")
-#  message(FATAL_ERROR "ERROR: diff contains tabs: ${match}")
+  message(FATAL_ERROR "ERROR: diff contains tabs: ${match}")
 endif ()
 
 # Check for NOCHECKIN
 string(REGEX MATCH "NOCHECKIN" match "${diff_contents}")
 if (NOT "${match}" STREQUAL "")
   string(REGEX MATCH "\n[^\n]*NOCHECKIN[^\n]*" match "${diff_contents}")
-#  message(FATAL_ERROR "ERROR: diff contains NOCHECKIN: ${match}")
+  message(FATAL_ERROR "ERROR: diff contains NOCHECKIN: ${match}")
 endif ()
 
 # CMake seems to remove carriage returns for us so we can't easily
@@ -176,7 +176,7 @@ string(REGEX MATCH "[^\n] \n" match "${diff_contents}")
 if (NOT "${match}" STREQUAL "")
   # Get more context
   string(REGEX MATCH "\n[^\n]+ \n" match "${diff_contents}")
-#  message(FATAL_ERROR "ERROR: diff contains trailing spaces: ${match}")
+  message(FATAL_ERROR "ERROR: diff contains trailing spaces: ${match}")
 endif ()
 
 ##################################################

--- a/suite/tests/client-interface/drsyms-test.dll.cpp
+++ b/suite/tests/client-interface/drsyms-test.dll.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -444,11 +444,16 @@ lookup_overloads(const char *exe_path)
     r = drsym_enumerate_symbols(exe_path, overloaded_cb, &p,
                                 DRSYM_DEFAULT_FLAGS);
     ASSERT(r == DRSYM_SUCCESS);
-    if (!p.overloaded_char)  dr_fprintf(STDERR, "overloaded_char missing!\n");
-    if (!p.overloaded_wchar) dr_fprintf(STDERR, "overloaded_wchar missing!\n");
-    if (!p.overloaded_int)   dr_fprintf(STDERR, "overloaded_int missing!\n");
-    if (!p.overloaded_void)  dr_fprintf(STDERR, "overloaded_void missing!\n");
-    if (!p.overloaded_void_ptr)  dr_fprintf(STDERR, "overloaded_void_ptr missing!\n");
+    if (!p.overloaded_char)
+        dr_fprintf(STDERR, "overloaded_char missing!\n");
+    if (!p.overloaded_wchar)
+        dr_fprintf(STDERR, "overloaded_wchar missing!\n");
+    if (!p.overloaded_int)
+        dr_fprintf(STDERR, "overloaded_int missing!\n");
+    if (!p.overloaded_void)
+        dr_fprintf(STDERR, "overloaded_void missing!\n");
+    if (!p.overloaded_void_ptr)
+        dr_fprintf(STDERR, "overloaded_void_ptr missing!\n");
     if (p.overloaded_class != NUM_OVERLOADED_CLASS)
         dr_fprintf(STDERR, "overloaded_class missing!\n");
     if (p.overloaded_char &&
@@ -476,7 +481,8 @@ search_ex_templates_cb(drsym_info_t *out, drsym_error_t status, void *data)
     /* i#1376: VS2013 PDB seems to not have qualified unnamed-tag entries so
      * in the interests of cross-platform non-flaky tests we don't
      * print them out anymore.  We're talking about this:
-     *   name_outer::name_middle::name_inner::sample_class<char>::nested_class<int>::<unnamed-tag>
+     *   name_outer::name_middle::name_inner::sample_class<char>::nested_class<int>::
+     *   <unnamed-tag>
      */
     if (strstr(out->name, "::templated_func") != NULL)
         dr_fprintf(STDERR, "found %s\n", out->name);

--- a/suite/tests/linux/alarm.c
+++ b/suite/tests/linux/alarm.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -34,12 +34,14 @@
 #include <signal.h>
 #include <unistd.h>
 
-void handler()
+void
+handler()
 {
     print("wake up by alarm\n");
 }
 
-int main()
+int
+main()
 {
     signal(SIGALRM, handler);
     /* test alarm to wake up sleep */

--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -115,7 +115,8 @@ main()
 /* Procedure executed by sideline threads
  * XXX i#500: Cannot use libc routines (printf) in the child process.
  */
-int run(void *arg)
+int
+run(void *arg)
 {
     int i = 0;
     nolibc_print("Sideline thread started\n");

--- a/suite/tests/linux/execve-rec.c
+++ b/suite/tests/linux/execve-rec.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -46,7 +47,8 @@
 
 const int N = 10;
 
-int main(int argc, char **argv)
+int
+main(int argc, char **argv)
 {
     int n, sum = 0;
     int result;

--- a/suite/tests/linux/fork-sleep.c
+++ b/suite/tests/linux/fork-sleep.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -51,7 +51,8 @@ signal_handler(int sig)
         print("received SIGCHLD\n");
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
     pid_t child;
     int rc;

--- a/suite/tests/linux/fork.c
+++ b/suite/tests/linux/fork.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -75,7 +75,7 @@ find_dynamo_library()
 
     maps=fopen(proc_pid_maps,"r");
 
-    while(!feof(maps)){
+    while (!feof(maps)){
         void * vm_start, * vm_end;
         char perm[16];
         char comment_buffer[MAPS_LINE_LENGTH];
@@ -101,7 +101,8 @@ find_dynamo_library()
 
 /***************************************************************************/
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
     pid_t child;
 

--- a/suite/tests/linux/infinite.c
+++ b/suite/tests/linux/infinite.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -33,23 +33,24 @@
 
 /* basic block builder may build infinite loop here */
 
-int main()
+int
+main()
 {
-#if defined(__i386__) || defined (__x86_64__)
+#if defined(__i386__) || defined(__x86_64__)
     __asm__("jmp    aroundexit");
     __asm__("doexit:          ");
     __asm__("       movl   $1,%eax       # exit");
     __asm__("       movl   $0,%ebx       # exit code");
     __asm__("       int    $0x80         # kernel");
     __asm__("aroundexit: call doexit");
-#elif defined (__aarch64__)
+#elif defined(__aarch64__)
     __asm__("b      aroundexit");
     __asm__("doexit:          ");
     __asm__("       mov    w8, #94       // exit_group");
     __asm__("       mov    w0, #0        // exit code");
     __asm__("       svc    #0            // kernel");
     __asm__("aroundexit: bl doexit");
-#elif defined (__arm__)
+#elif defined(__arm__)
     __asm__("b      aroundexit");
     __asm__("doexit:          ");
     __asm__("       mov    r7, #248      @ exit_group");

--- a/suite/tests/linux/longjmp.c
+++ b/suite/tests/linux/longjmp.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -37,14 +37,16 @@
 
 jmp_buf mark;
 
-void foo()
+void
+foo()
 {
    printf("about to do longjmp\n");
    fflush(stdout);
    longjmp(mark, -1);
 }
 
-int main()
+int
+main()
 {
    int jmpret;
    /* Save stack environment for return in case of error. First

--- a/suite/tests/linux/sigaction_nosignals.c
+++ b/suite/tests/linux/sigaction_nosignals.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -84,7 +85,8 @@ struct kernel_sigaction_t {
 #define MARGIN 8
 
 /* POSIX sigdelset: delete signal signum from set. */
-void kernel_sigdelset(kernel_sigset_t *set, int signum)
+void
+kernel_sigdelset(kernel_sigset_t *set, int signum)
 {
     size_t b = sizeof(long) * 8;
     set->sig[(signum - 1) / b] &= ~(1L << ((signum - 1) % b));

--- a/suite/tests/linux/signal_racesys.c
+++ b/suite/tests/linux/signal_racesys.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -58,20 +59,23 @@ void nanosleep_interrupted(void);
 timer_t timer;
 sigjmp_buf env;
 
-void fail(const char *s)
+void
+fail(const char *s)
 {
     perror(s);
     exit(1);
 }
 
-void handler(int signum, siginfo_t *info, void *ucontext_)
+void
+handler(int signum, siginfo_t *info, void *ucontext_)
 {
     ucontext_t *ucontext = ucontext_;
     sigcontext_t *sc = SIGCXT_FROM_UCXT(ucontext);
     siglongjmp(env, 1 + (sc->SC_XIP == (uintptr_t)nanosleep_interrupted));
 }
 
-void setup(void)
+void
+setup(void)
 {
     struct sigaction act;
     struct sigevent sevp;
@@ -89,7 +93,8 @@ void setup(void)
         fail("timer_create");
 }
 
-int try(uint64_t time)
+int
+try(uint64_t time)
 {
     struct itimerspec spec = {
         { 0, 0 },

--- a/suite/tests/linux/signalfd.c
+++ b/suite/tests/linux/signalfd.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -129,7 +129,8 @@ test_signalfd(int sig)
     intercept_signal(sig, (handler_3_t) NULL, false);
 }
 
-int main(void)
+int
+main(void)
 {
     test_signalfd(SIGXCPU);
     test_signalfd(SIGUSR1);

--- a/suite/tests/linux/thread.c
+++ b/suite/tests/linux/thread.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -75,7 +75,8 @@ static volatile bool child_done;
 
 static struct timespec sleeptime;
 
-int main()
+int
+main()
 {
     sleeptime.tv_sec = 0;
     sleeptime.tv_nsec = 10*1000*1000; /* 10ms */
@@ -101,7 +102,8 @@ int main()
  * and TLS state.  Our tests use CLONE_VM and don't initialize TLS
  * segments, so the TLS is actually *shared* with the parent.
  */
-int run(void *arg)
+int
+run(void *arg)
 {
     int i = 0;
     /* for CLONE_CHILD_CLEARTID for signaling parent.  if we used raw

--- a/suite/tests/linux/threadexit.c
+++ b/suite/tests/linux/threadexit.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -75,7 +75,8 @@ static volatile bool child_started[NUM_THREADS];
 
 static struct timespec sleeptime;
 
-int main()
+int
+main()
 {
     int i;
     sleeptime.tv_sec = 0;
@@ -110,7 +111,8 @@ int main()
 /* Procedure executed by sideline threads.
  * XXX i#500: Cannot use libc routines (printf) in the child process.
  */
-int run(void *arg)
+int
+run(void *arg)
 {
     int threadnum = (int)(long) arg;
     int i = 0;

--- a/suite/tests/linux/threadexit2.c
+++ b/suite/tests/linux/threadexit2.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -78,7 +78,8 @@ static volatile bool child_done[NUM_THREADS];
 
 static struct timespec sleeptime;
 
-int main()
+int
+main()
 {
     int i;
     sleeptime.tv_sec = 0;
@@ -113,7 +114,8 @@ int main()
 /* Procedure executed by sideline threads
  * XXX i#500: Cannot use libc routines (printf) in the child process.
  */
-int run(void *arg)
+int
+run(void *arg)
 {
     int threadnum = (int)(long) arg;
     int i = 0;

--- a/suite/tests/linux/vfork-fib.c
+++ b/suite/tests/linux/vfork-fib.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -45,19 +46,23 @@ const int N = 8;
 
 /***************************************************************************/
 
-int fib(int n) {
-    if (n <= 1) return 1;
+int
+fib(int n)
+{
+    if (n <= 1)
+        return 1;
     return fib(n-1) + fib(n-2);
 }
 
 #ifdef DEBUG
 #  define pf printf
 #else
-#  define pf if(0)printf
+#  define pf if (0) printf
 #endif
 
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
     pid_t child1, child2;
     int do_vfork = 1; //argc == 1;
@@ -140,16 +145,17 @@ int main(int argc, char** argv)
             snprintf(carg, 10, "%d", n-1);
             arg[2] = carg;
             result = execve(arg[0], arg, env);
-            if (result < 0) perror("ERROR in execve");
+            if (result < 0)
+                perror("ERROR in execve");
         }
 
-        while(children > 0) {
+        while (children > 0) {
             pf("parent waiting for %d children\n", children);
             result = wait(&status);
 
             assert(result == child2 || result == child1);
             assert(WIFEXITED(status));
-            //printf("child %d has exited with status=%d %d\n", result, status, WEXITSTATUS(status));
+
             sum+=WEXITSTATUS(status);
 
             if (children == 2 && result == child1)
@@ -186,5 +192,6 @@ int main(int argc, char** argv)
 }
 
 
-// TODO it would be nice to have in the tests a measure for nondeterminism
-// to also a guarantee that we don't introduce extra synchronization to stifle any parallelism
+// TODO it would be nice to have in the tests a measure for
+// nondeterminism to also a guarantee that we don't introduce extra
+// synchronization to stifle any parallelism

--- a/suite/tests/linux/vfork.c
+++ b/suite/tests/linux/vfork.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -80,7 +80,8 @@ run_child(void *arg)
     return 0;
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
     pid_t child;
     void *stack;

--- a/suite/tests/runall/detach_test.c
+++ b/suite/tests/runall/detach_test.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2007 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -45,7 +45,8 @@ static BOOL thread_ready = FALSE;
 void CALLBACK SendAsyncProc(HWND hwnd, UINT uMsg, ULONG *dwData, LRESULT lResult);
 void do_test(int count);
 
-int do_busy_work(int c)
+int
+do_busy_work(int c)
 {
     int i, t;
     for (i = 0, t = 0; i < c; i++)
@@ -100,7 +101,8 @@ ThreadProcBusyBuild(LPVOID param)
 
 /* see win32/tls.c test for alt. method of starting a detach, this way is preferable
  * since we may at some point disallow the process from detaching itself */
-void detach()
+void
+detach()
 {
     char buf[2*MAX_PATH] = "\"";
     char *tools = getenv("DYNAMORIO_WINTOOLS");
@@ -130,7 +132,9 @@ void detach()
 static BOOL did_send_callback[MAX_COUNT];
 static BOOL action_detach = FALSE;
 static BOOL action_exit = FALSE;
-void CALLBACK SendAsyncProc(HWND hwnd, UINT uMsg, ULONG *dwData, LRESULT lResult) {
+void CALLBACK
+SendAsyncProc(HWND hwnd, UINT uMsg, ULONG *dwData, LRESULT lResult)
+{
     int count = (int)dwData;
     did_send_callback[count] = TRUE;
     if (count > 0) {
@@ -167,7 +171,8 @@ void CALLBACK SendAsyncProc(HWND hwnd, UINT uMsg, ULONG *dwData, LRESULT lResult
  * up a callback stack. This routine will end up being recursively called count times
  * building up count stacked callbacks. */
 #define MAX_SLEEP 30000
-void do_test(int count)
+void
+do_test(int count)
 {
     MSG msg;
     int total_slept = 0;

--- a/suite/tests/runall/earlythread.c
+++ b/suite/tests/runall/earlythread.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2007 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -148,8 +148,7 @@ main(int argc, char **argv)
                 CreateRemoteThread(pi.hProcess, 0, 0, &LoadLibrary, (void*)mylib,
                                    CREATE_SUSPENDED, NULL);
 
-            if (hThread_child == NULL)
-            {
+            if (hThread_child == NULL) {
                 print("Error in CreateRemoteThread(Code %d)\n",GetLastError());
             }
 
@@ -170,7 +169,8 @@ main(int argc, char **argv)
                 print("SetProcessAffinityMask(original) failure %d\n", GetLastError());
                 /*
                  * 1:001> !error c000000d
-                 * Error code: (NTSTATUS) 0xc000000d (3221225485) - An invalid parameter was passed to a service or function.
+                 * Error code: (NTSTATUS) 0xc000000d (3221225485) - An invalid parameter
+                 * was passed to a service or function.
                  */
             }
 #endif /* PROCAFFINITY */


### PR DESCRIPTION
Fixes style violations that cause the forthcoming vera++ style checker
rules to fail.  Focuses on core/, api/, clients/, and ext/.
