### PR TITLE
i#2453: support VS2013 CRT on XP

### DIFF
--- a/core/win32/drwinapi/kernel32_proc.c
+++ b/core/win32/drwinapi/kernel32_proc.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2014 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -73,6 +73,16 @@ kernel32_redir_onload_proc(privmod_t *mod, strhash_table_t *kernel32_table)
          */
         IF_DEBUG(bool found =)
             strhash_hash_remove(GLOBAL_DCONTEXT, kernel32_table, "FlsAlloc");
+        ASSERT(found);
+        /* i#2453: VS2013 checks other Fls routines as well so we clear them all. */
+        IF_DEBUG(found =)
+            strhash_hash_remove(GLOBAL_DCONTEXT, kernel32_table, "FlsFree");
+        ASSERT(found);
+        IF_DEBUG(found =)
+            strhash_hash_remove(GLOBAL_DCONTEXT, kernel32_table, "FlsGetValue");
+        ASSERT(found);
+        IF_DEBUG(found =)
+            strhash_hash_remove(GLOBAL_DCONTEXT, kernel32_table, "FlsSetValue");
         ASSERT(found);
     }
 }


### PR DESCRIPTION
Fixes a crash with VS2013 client library CRT code on XP where we need to
not redirect FlsGetValue as it doesn't exist natively.

Fixes #2453