### PR TITLE
Add cbr, shift, and add-shift cross-platform instruction macros

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -167,7 +167,8 @@ Further non-compatibility-affecting changes include:
  - Added instr_create_4dst_2src().
  - Added drreg_restore_app_values() and drreg_restore_app_aflags().
  - Added drx_tail_pad_block().
- - Added XINST_CREATE_load_1byte_zext4().
+ - Added XINST_CREATE_add_sll(), XINST_CREATE_load_1byte_zext4(),
+   XINST_CREATE_jump_cond(), and XINST_CREATE_slr_s().
  - Added drx_buf_insert_buf_memcpy().
  - Added thread synchronization events via dr_event_create(), dr_event_destroy(),
    dr_event_wait(), dr_event_signal(), and dr_event_reset().

--- a/core/arch/arm/instr_create.h
+++ b/core/arch/arm/instr_create.h
@@ -93,7 +93,7 @@
  */
 
 /****************************************************************************
- * Platform-independent INSTR_CREATE_* macros
+ * Platform-independent XINST_CREATE_* macros
  */
 /** @name Platform-independent macros */
 /* @{ */ /* doxygen start group */
@@ -275,6 +275,21 @@
    INSTR_CREATE_b_short((dc), (t)) : INSTR_CREATE_b((dc), (t)))
 
 /**
+ * This platform-independent macro creates an instr_t for a conditional
+ * branch instruction that branches if the previously-set condition codes
+ * indicate the condition indicated by \p pred.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param pred  The #dr_pred_type_t condition to match.
+ * \param t   The opnd_t target operand for the instruction, which can be
+ * either a pc (opnd_create_pc)()) or an instr_t (opnd_create_instr()).
+ * Be sure to ensure that the limited reach of this short branch will reach
+ * the target (a pc operand is not suitable for most uses unless you know
+ * precisely where this instruction will be encoded).
+ */
+#define XINST_CREATE_jump_cond(dc, pred, t) \
+    (INSTR_PRED(INSTR_CREATE_b((dc), (t)), (pred)))
+
+/**
  * This platform-independent macro creates an instr_t for an addition
  * instruction that does not affect the status flags.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
@@ -295,6 +310,23 @@
  * can be either a register or a 32-bit immediate integer on x86.
  */
 #define XINST_CREATE_add_2src(dc, d, s1, s2) INSTR_CREATE_add((dc), (d), (s1), (s2))
+
+/**
+ * This platform-independent macro creates an instr_t for an addition
+ * instruction that does not affect the status flags and takes two register sources
+ * plus a destination, with one source being shifted logically left by
+ * an immediate scale that is limited to either 1, 2, 4, or 8.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param d  The opnd_t explicit destination operand for the instruction.
+ * \param s1  The opnd_t explicit first source operand for the instruction.  This
+ * must be a register.
+ * \param s2_toshift  The opnd_t explicit source operand for the instruction.  This
+ * must be a register.
+ * \param shift_amount  An integer value that must be either 1, 2, 4, or 8.
+ */
+#define XINST_CREATE_add_sll(dc, d, s1, s2_toshift, shift_amount) \
+  INSTR_CREATE_add_shimm((dc), (d), (s1), (s2_toshift), \
+    OPND_CREATE_INT8(DR_SHIFT_LSL), OPND_CREATE_INT8(shift_amount))
 
 /**
  * This platform-independent macro creates an instr_t for an addition
@@ -330,8 +362,16 @@
  * \param d  The opnd_t explicit destination operand for the instruction.
  * \param s  The opnd_t explicit source operand for the instruction.
  */
-#define XINST_CREATE_and_s(dc, d, s) \
-  instr_create_1dst_2src((dc), OP_ands, (d), (s), (d))
+#define XINST_CREATE_and_s(dc, d, s) INSTR_CREATE_ands((dc), (d), (d), (s))
+
+/**
+ * This platform-independent macro creates an instr_t for a logical right shift
+ * instruction that does affect the status flags.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param d  The opnd_t explicit destination operand for the instruction.
+ * \param s  The opnd_t explicit source operand for the instruction.
+ */
+#define XINST_CREATE_slr_s(dc, d, s) INSTR_CREATE_lsrs((dc), (d), (d), (s))
 
 /**
  * This platform-independent macro creates an instr_t for a comparison

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -257,6 +257,13 @@ typedef enum _dr_pred_type_t {
      * unconditionally written, unlike regular destination operands.
      */
     DR_PRED_COMPLEX,
+    /* Aliases for XINST_CREATE_jump_cond() and other cross-platform routines. */
+    DR_PRED_EQ = DR_PRED_Z,   /**< Condition code: equal. */
+    DR_PRED_NE = DR_PRED_NZ,  /**< Condition code: not equal. */
+    DR_PRED_LT = DR_PRED_L,   /**< Condition code: signed less than. */
+    /* DR_PRED_LE already matches aarchxx */
+    DR_PRED_GT = DR_PRED_NLE, /**< Condition code: signed greater than. */
+    DR_PRED_GE = DR_PRED_NL,  /**< Condition code: signed greater than or equal. */
 #elif defined(AARCHXX)
     DR_PRED_EQ, /**< ARM condition: 0000 Equal                   (Z == 1)           */
     DR_PRED_NE, /**< ARM condition: 0001 Not equal               (Z == 0)           */

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -304,6 +304,21 @@
 #define XINST_CREATE_jump_short(dc, t) INSTR_CREATE_jmp_short((dc), (t))
 
 /**
+ * This platform-independent macro creates an instr_t for a conditional
+ * branch instruction that branches if the previously-set condition codes
+ * indicate the condition indicated by \p pred.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param pred  The #dr_pred_type_t condition to match.
+ * \param t   The opnd_t target operand for the instruction, which can be
+ * either a pc (opnd_create_pc)()) or an instr_t (opnd_create_instr()).
+ * Be sure to ensure that the limited reach of this short branch will reach
+ * the target (a pc operand is not suitable for most uses unless you know
+ * precisely where this instruction will be encoded).
+ */
+#define XINST_CREATE_jump_cond(dc, pred, t) \
+    (INSTR_CREATE_jcc((dc), (pred) - DR_PRED_O + OP_jo, (t)))
+
+/**
  * This platform-independent macro creates an instr_t for an unconditional
  * branch instruction.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
@@ -346,6 +361,23 @@
 
 /**
  * This platform-independent macro creates an instr_t for an addition
+ * instruction that does not affect the status flags and takes two register sources
+ * plus a destination, with one source being shifted logically left by
+ * an immediate scale that is limited to either 1, 2, 4, or 8.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param d  The opnd_t explicit destination operand for the instruction.
+ * \param s1  The opnd_t explicit first source operand for the instruction.  This
+ * must be a register.
+ * \param s2_toshift  The opnd_t explicit source operand for the instruction.  This
+ * must be a register.
+ * \param shift_amount  An integer value that must be either 1, 2, 4, or 8.
+ */
+#define XINST_CREATE_add_sll(dc, d, s1, s2_toshift, shift_amount) \
+  INSTR_CREATE_lea((dc), (d), OPND_CREATE_MEM_lea(opnd_get_reg(s1), \
+    opnd_get_reg(s2_toshift), shift_amount, 0))
+
+/**
+ * This platform-independent macro creates an instr_t for an addition
  * instruction that does affect the status flags.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param d  The opnd_t explicit destination operand for the instruction.
@@ -382,6 +414,15 @@
  * \param s  The opnd_t explicit source operand for the instruction.
  */
 #define XINST_CREATE_and_s(dc, d, s) INSTR_CREATE_and((dc), (d), (s))
+
+/**
+ * This platform-independent macro creates an instr_t for a logical right shift
+ * instruction that does affect the status flags.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param d  The opnd_t explicit destination operand for the instruction.
+ * \param s  The opnd_t explicit source operand for the instruction.
+ */
+#define XINST_CREATE_slr_s(dc, d, s) INSTR_CREATE_shr((dc), (d), (s))
 
 /**
  * This platform-independent macro creates an instr_t for a comparison

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -231,6 +231,11 @@ test_all_opcodes_4(void *dc)
         instrlist_append(ilist, INSTR_CREATE_##icnm(dc, arg1, arg2, arg3, arg4)); \
         len_##name = instr_length(dc, instrlist_last(ilist)); \
     } } while (0);
+#   define XOPCODE_FOR_CREATE(name, opc, icnm, flags, arg1, arg2, arg3, arg4) do { \
+    if ((flags & IF_X64_ELSE(X86_ONLY, X64_ONLY)) == 0) { \
+        instrlist_append(ilist, XINST_CREATE_##icnm(dc, arg1, arg2, arg3, arg4)); \
+        len_##name = instr_length(dc, instrlist_last(ilist)); \
+    } } while (0);
 #   include "ir_x86_all_opc.h"
 #   undef OPCODE_FOR_CREATE
 #   undef INCLUDE_NAME

--- a/suite/tests/api/ir_x86_2args.h
+++ b/suite/tests/api/ir_x86_2args.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -107,6 +107,7 @@ OPCODE(rcr, rcr, rcr, 0, MEMARG(OPSZ_4), IMMARG(OPSZ_1))
 OPCODE(shl, shl, shl, 0, MEMARG(OPSZ_4), IMMARG(OPSZ_1))
 OPCODE(shr, shr, shr, 0, MEMARG(OPSZ_4), IMMARG(OPSZ_1))
 OPCODE(sar, sar, sar, 0, MEMARG(OPSZ_4), IMMARG(OPSZ_1))
+XOPCODE(slr, shr, slr_s, 0, MEMARG(OPSZ_4), IMMARG(OPSZ_1))
 
 OPCODE(pmovmskb, pmovmskb, pmovmskb, 0, REGARG(EAX), REGARG(MM0))
 OPCODE(ptest, ptest, ptest, 0, REGARG(XMM0), MEMARG(OPSZ_16))
@@ -388,6 +389,12 @@ OPCODE(enter, enter, enter, 0, IMMARG(OPSZ_2), IMMARG(OPSZ_1))
 
 OPCODE(jnz, jnz, jcc, 0, OP_jnz, TGTARG)
 OPCODE(jno_short, jno_short, jcc_short, 0, OP_jno_short, TGTARG)
+XOPCODE(x_jz, jz, jump_cond, 0, DR_PRED_EQ, TGTARG)
+XOPCODE(x_jnz, jnz, jump_cond, 0, DR_PRED_NE, TGTARG)
+XOPCODE(x_jl, jl, jump_cond, 0, DR_PRED_LT, TGTARG)
+XOPCODE(x_jle, jle, jump_cond, 0, DR_PRED_LE, TGTARG)
+XOPCODE(x_jnle, jnle, jump_cond, 0, DR_PRED_GT, TGTARG)
+XOPCODE(x_jnl, jnl, jump_cond, 0, DR_PRED_GE, TGTARG)
 
 /****************************************************************************/
 /* XOP */

--- a/suite/tests/api/ir_x86_4args.h
+++ b/suite/tests/api/ir_x86_4args.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -33,6 +33,8 @@
 
 OPCODE(insertq_imm, insertq, insertq_imm, 0, REGARG(XMM0), REGARG(XMM1), IMMARG(OPSZ_1),
        IMMARG(OPSZ_1))
+
+XOPCODE(add_sll, lea, add_sll, 0, REGARG(XAX), REGARG(XCX), REGARG(XDX), 8)
 
 /****************************************************************************/
 /* AVX */


### PR DESCRIPTION
Adds three new cross-platform instruction creation macros,
XINST_CREATE_add_sll(), XINST_CREATE_jump_cond() and XINST_CREATE_slr_s(),
for use in drcachesim.

For XINST_CREATE_jump_cond(), we add aliases so that the same DR_PRED_*
constants can be used for x86 as are used on aarchxx.

Adds x86 tests.  The infrastructure for easily adding ARM (#1686) and
AArch64 (#2443) tests is still missing, unfortunately.