### PR TITLE
Fix XINST_CREATE_add_sll shift amount on x86

### DIFF
--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -291,14 +291,14 @@
  * This platform-independent macro creates an instr_t for an addition
  * instruction that does not affect the status flags and takes two register sources
  * plus a destination, with one source being shifted logically left by
- * an immediate scale that is limited to either 1, 2, 4, or 8.
+ * an immediate amount that is limited to either 0, 1, 2, or 3.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param d  The opnd_t explicit destination operand for the instruction.
  * \param s1  The opnd_t explicit first source operand for the instruction.  This
  * must be a register.
  * \param s2_toshift  The opnd_t explicit source operand for the instruction.  This
  * must be a register.
- * \param shift_amount  An integer value that must be either 1, 2, 4, or 8.
+ * \param shift_amount  An integer value that must be either 0, 1, 2, or 3.
  */
 #define XINST_CREATE_add_sll(dc, d, s1, s2_toshift, shift_amount) \
   INSTR_CREATE_add_shift((dc), (d), (s1), (s2_toshift), \

--- a/core/arch/arm/instr_create.h
+++ b/core/arch/arm/instr_create.h
@@ -315,14 +315,14 @@
  * This platform-independent macro creates an instr_t for an addition
  * instruction that does not affect the status flags and takes two register sources
  * plus a destination, with one source being shifted logically left by
- * an immediate scale that is limited to either 1, 2, 4, or 8.
+ * an immediate amount that is limited to either 0, 1, 2, or 3.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param d  The opnd_t explicit destination operand for the instruction.
  * \param s1  The opnd_t explicit first source operand for the instruction.  This
  * must be a register.
  * \param s2_toshift  The opnd_t explicit source operand for the instruction.  This
  * must be a register.
- * \param shift_amount  An integer value that must be either 1, 2, 4, or 8.
+ * \param shift_amount  An integer value that must be either 0, 1, 2, or 3.
  */
 #define XINST_CREATE_add_sll(dc, d, s1, s2_toshift, shift_amount) \
   INSTR_CREATE_add_shimm((dc), (d), (s1), (s2_toshift), \

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -363,18 +363,20 @@
  * This platform-independent macro creates an instr_t for an addition
  * instruction that does not affect the status flags and takes two register sources
  * plus a destination, with one source being shifted logically left by
- * an immediate scale that is limited to either 1, 2, 4, or 8.
+ * an immediate amount that is limited to either 0, 1, 2, or 3.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param d  The opnd_t explicit destination operand for the instruction.
  * \param s1  The opnd_t explicit first source operand for the instruction.  This
  * must be a register.
  * \param s2_toshift  The opnd_t explicit source operand for the instruction.  This
  * must be a register.
- * \param shift_amount  An integer value that must be either 1, 2, 4, or 8.
+ * \param shift_amount  An integer value that must be either 0, 1, 2, or 3.
  */
 #define XINST_CREATE_add_sll(dc, d, s1, s2_toshift, shift_amount) \
   INSTR_CREATE_lea((dc), (d), OPND_CREATE_MEM_lea(opnd_get_reg(s1), \
-    opnd_get_reg(s2_toshift), shift_amount, 0))
+    opnd_get_reg(s2_toshift), ((shift_amount) == 0 ? 1 : ((shift_amount) == 1 ? 2 : \
+      ((shift_amount) == 2 ? 4 : ((shift_amount) == 3 ? 8 : \
+        (DR_ASSERT_MSG(false, "invalid shift amount"), 0))))), 0))
 
 /**
  * This platform-independent macro creates an instr_t for an addition

--- a/suite/tests/api/ir_x86_4args.h
+++ b/suite/tests/api/ir_x86_4args.h
@@ -34,7 +34,7 @@
 OPCODE(insertq_imm, insertq, insertq_imm, 0, REGARG(XMM0), REGARG(XMM1), IMMARG(OPSZ_1),
        IMMARG(OPSZ_1))
 
-XOPCODE(add_sll, lea, add_sll, 0, REGARG(XAX), REGARG(XCX), REGARG(XDX), 8)
+XOPCODE(add_sll, lea, add_sll, 0, REGARG(XAX), REGARG(XCX), REGARG(XDX), 3)
 
 /****************************************************************************/
 /* AVX */


### PR DESCRIPTION
Fixes an error with XINST_CREATE_add_sll where on x86 it does not convert
from a shift to the multiply that OP_lea wants.