### PR TITLE
i#1729 offline traces: fix initial tid entry errors

### DIFF
--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -56,6 +56,8 @@ analyzer_multi_t::analyzer_multi_t()
         success = false;
         return;
     }
+    //NOCHECKIN either accum indir (what about spaces in paths??), or
+    // have test merge the two dirs (and assume modules.logs are identical)
     if (!op_indir.get_value().empty()) {
         // XXX: better to put in app name + pid, or rely on staying inside subdir?
         std::string tracefile = op_indir.get_value() + std::string(DIRSEP) +

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -56,8 +56,6 @@ analyzer_multi_t::analyzer_multi_t()
         success = false;
         return;
     }
-    //NOCHECKIN either accum indir (what about spaces in paths??), or
-    // have test merge the two dirs (and assume modules.logs are identical)
     if (!op_indir.get_value().empty()) {
         // XXX: better to put in app name + pid, or rely on staying inside subdir?
         std::string tracefile = op_indir.get_value() + std::string(DIRSEP) +

--- a/clients/drcachesim/tests/offline-multiproc.templatex
+++ b/clients/drcachesim/tests/offline-multiproc.templatex
@@ -1,0 +1,20 @@
+all done
+Cache simulation results:
+Core #0 \(1 thread\(s\)\)
+  L1I stats:
+    Hits:                    *[0-9\.,]*
+    Misses:                  *[0-9,\.]*
+.*    Miss rate:             *[0-9]*[,\.]..%
+  L1D stats:
+    Hits:                    *[0-9\.,]*
+    Misses:                  *[0-9\.,]*
+.*   Miss rate:              *[0-9]*[,\.]..%
+Core #1 \(0 thread\(s\)\)
+Core #2 \(0 thread\(s\)\)
+Core #3 \(0 thread\(s\)\)
+LL stats:
+    Hits:                    *[0-9\.,]*
+    Misses:                  *[0-9\.,]*
+.*    Local miss rate:       *[0-9]*[,\.]..%
+    Child hits:              *[0-9\.,]*
+    Total miss rate:         *[0-9]*[,\.]..%

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -963,6 +963,7 @@ init_offline_dir(void)
     return (module_file != INVALID_FILE);
 }
 
+#ifdef UNIX
 static void
 fork_init(void *drcontext)
 {
@@ -983,6 +984,7 @@ fork_init(void *drcontext)
     }
     init_thread_in_process(drcontext);
 }
+#endif
 
 /* We export drmemtrace_client_main so that a global dr_client_main can initialize
  * drmemtrace client by calling drmemtrace_client_main in a statically linked
@@ -1057,7 +1059,9 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
 
     /* register events */
     dr_register_exit_event(event_exit);
+#ifdef UNIX
     dr_register_fork_init_event(fork_init);
+#endif
     if (!drmgr_register_thread_init_event(event_thread_init) ||
         !drmgr_register_thread_exit_event(event_thread_exit) ||
         !drmgr_register_pre_syscall_event(event_pre_syscall) ||

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -768,24 +768,15 @@ event_pre_syscall(void *drcontext, int sysnum)
     return true;
 }
 
+/* Initializes a thread either at process init or fork init, where we want
+ * a new offline file or a new thread,process registration pair for online.
+ */
 static void
-event_thread_init(void *drcontext)
+init_thread_in_process(void *drcontext)
 {
+    per_thread_t *data = (per_thread_t *) drmgr_get_tls_field(drcontext, tls_idx);
     char buf[MAXIMUM_PATH];
     byte *proc_info;
-    per_thread_t *data = (per_thread_t *)
-        dr_thread_alloc(drcontext, sizeof(per_thread_t));
-    DR_ASSERT(data != NULL);
-    memset(data, 0, sizeof(*data));
-    drmgr_set_tls_field(drcontext, tls_idx, data);
-
-    /* Keep seg_base in a per-thread data structure so we can get the TLS
-     * slot and find where the pointer points to in the buffer.
-     */
-    data->seg_base = (byte *) dr_get_dr_segment_base(tls_seg);
-    DR_ASSERT(data->seg_base != NULL);
-    create_buffer(data);
-
     if (op_offline.get_value()) {
         /* We do not need to call drx_init before using drx_open_unique_appid_file.
          * Since we're now in a subdir we could make the name simpler but this
@@ -835,6 +826,27 @@ event_thread_init(void *drcontext)
         /* put buf_base to TLS plus header slots as starting buf_ptr */
         BUF_PTR(data->seg_base) = data->buf_base + buf_hdr_slots_size;
     }
+
+    // XXX i#1729: gather and store an initial callstack for the thread.
+}
+
+static void
+event_thread_init(void *drcontext)
+{
+    per_thread_t *data = (per_thread_t *)
+        dr_thread_alloc(drcontext, sizeof(per_thread_t));
+    DR_ASSERT(data != NULL);
+    memset(data, 0, sizeof(*data));
+    drmgr_set_tls_field(drcontext, tls_idx, data);
+
+    /* Keep seg_base in a per-thread data structure so we can get the TLS
+     * slot and find where the pointer points to in the buffer.
+     */
+    data->seg_base = (byte *) dr_get_dr_segment_base(tls_seg);
+    DR_ASSERT(data->seg_base != NULL);
+    create_buffer(data);
+
+    init_thread_in_process(drcontext);
 
     // XXX i#1729: gather and store an initial callstack for the thread.
 }
@@ -951,6 +963,27 @@ init_offline_dir(void)
     return (module_file != INVALID_FILE);
 }
 
+static void
+fork_init(void *drcontext)
+{
+    /* We use DR_FILE_CLOSE_ON_FORK, and we dumped outstanding data prior to the
+     * fork syscall, so we just need to create a new subdir, new module log, and
+     * a new initial thread file for offline, or register the new process for
+     * online.
+     */
+    per_thread_t *data = (per_thread_t *) drmgr_get_tls_field(drcontext, tls_idx);
+    /* Only count refs in the new process (plus, we use this to set up the
+     * initial header in memtrace() for offline).
+     */
+    data->num_refs = 0;
+    if (op_offline.get_value()) {
+        if (!init_offline_dir()) {
+            FATAL("Failed to create a subdir in %s\n", op_outdir.get_value().c_str());
+        }
+    }
+    init_thread_in_process(drcontext);
+}
+
 /* We export drmemtrace_client_main so that a global dr_client_main can initialize
  * drmemtrace client by calling drmemtrace_client_main in a statically linked
  * multi-client executable.
@@ -1024,6 +1057,7 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
 
     /* register events */
     dr_register_exit_event(event_exit);
+    dr_register_fork_init_event(fork_init);
     if (!drmgr_register_thread_init_event(event_thread_init) ||
         !drmgr_register_thread_exit_event(event_thread_exit) ||
         !drmgr_register_pre_syscall_event(event_pre_syscall) ||

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2495,10 +2495,10 @@ if (CLIENT_INTERFACE)
       get_target_path_for_execution(drcachesim_path drcachesim)
       prefix_cmd_if_necessary(drcachesim_path ON ${drcachesim_path})
 
-      macro (torunonly_drcacheoff testname exetgt)
+      macro (torunonly_drcacheoff testname exetgt app_args)
         torunonly_ci(tool.drcacheoff.${testname} ${exetgt} drcachesim
           "offline-${testname}.c" # for templatex basename
-          "-offline" "" "")
+          "-offline" "" "${app_args}")
         set(tool.drcacheoff.${testname}_toolname "drcachesim")
         set(tool.drcacheoff.${testname}_basedir
           "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
@@ -2513,28 +2513,36 @@ if (CLIENT_INTERFACE)
 
       # We could share drcachesim-simple.templatex if we had the launcher fork
       # and print out the "---- <application exited with code 0> ----".
-      torunonly_drcacheoff(simple ${ci_shared_app})
+      torunonly_drcacheoff(simple ${ci_shared_app} "")
+
+      if (UNIX) # Enable on Windows once i#1727 is fixed.
+        # FIXME i#2384: we need to combine the subdir from the child with the
+        # parent in some way and update the templatex file to include both.
+        # Right now we're only ensuring this doesn't crash and that one of
+        # the processes produced traces.
+        torunonly_drcacheoff(multiproc tool.multiproc "${tool.multiproc_path}")
+      endif ()
 
       # FIXME i#2007: fails to link on A64
       # XXX i#1551: startstop API is NYI on ARM
       # XXX i#1997: dynamorio_static is not supported on Mac yet
       if (NOT AARCH64 AND NOT ARM AND NOT APPLE)
-        torunonly_drcacheoff(burst_static tool.drcacheoff.burst_static)
+        torunonly_drcacheoff(burst_static tool.drcacheoff.burst_static "")
         set(tool.drcacheoff.burst_static_nodr ON)
 
-        torunonly_drcacheoff(burst_replace tool.drcacheoff.burst_replace)
+        torunonly_drcacheoff(burst_replace tool.drcacheoff.burst_replace "")
         set(tool.drcacheoff.burst_replace_nodr ON)
 
-        torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall)
+        torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall "")
         set(tool.drcacheoff.burst_replaceall_nodr ON)
 
         if (UNIX)
           # FIXME i#2040: this hits static client issues on Windows
-          torunonly_drcacheoff(burst_threads tool.drcacheoff.burst_threads)
+          torunonly_drcacheoff(burst_threads tool.drcacheoff.burst_threads "")
           set(tool.drcacheoff.burst_threads_nodr ON)
 
           # FIXME i#2099: the weak symbol is not supported not work on Windows
-          torunonly_drcacheoff(burst_client tool.drcacheoff.burst_client)
+          torunonly_drcacheoff(burst_client tool.drcacheoff.burst_client "")
           set(tool.drcacheoff.burst_client_nodr ON)
         endif ()
       endif ()


### PR DESCRIPTION
Fixes two issues with offline traces (#1729): first, changes the reader to
not assume a separate tid header right after the initial tid,pid header, as
offline traces (as opposed to online) do not contain it.  Second, changes
raw2trace to not emit a superfluous tid entry of 0 just prior to the real
initial tid entry for each thread.

Adds asserts to catch related errors in the future in the test suite.