### PR TITLE
Handle ARM Linux kernel with CONFIG_IWMMXT enabled.

### DIFF
--- a/core/unix/include/sigcontext.h
+++ b/core/unix/include/sigcontext.h
@@ -279,7 +279,7 @@ typedef struct _kernel_iwmmxt_struct_t {
     unsigned int save[38];
 } kernel_iwmmxt_struct_t;
 
-#define IWMMXT_MAGIC 0x12ef842a
+# define IWMMXT_MAGIC 0x12ef842a
 
 typedef struct _kernel_iwmmxt_sigframe_t {
     unsigned long magic;

--- a/core/unix/include/sigcontext.h
+++ b/core/unix/include/sigcontext.h
@@ -274,6 +274,19 @@ typedef struct _kernel_vfp_sigframe_t {
     kernel_sys_user_vfp_t ufp;
     kernel_sys_user_vfp_exc_t ufp_exc;
 } __attribute__((__aligned__(8))) kernel_vfp_sigframe_t;
+
+typedef struct _kernel_iwmmxt_struct_t {
+    unsigned int save[38];
+} kernel_iwmmxt_struct_t;
+
+#define IWMMXT_MAGIC 0x12ef842a
+
+typedef struct _kernel_iwmmxt_sigframe_t {
+    unsigned long magic;
+    unsigned long size;
+    kernel_iwmmxt_struct_t storage;
+} __attribute__((__aligned__(8))) kernel_iwmmxt_sigframe_t;
+
 #endif /* __arm__ */
 
 #ifdef __aarch64__

--- a/core/unix/signal_linux_arm.c
+++ b/core/unix/signal_linux_arm.c
@@ -46,6 +46,8 @@
 
 #include "arch.h"
 
+#define VFP_QUERY_SIG SIGILL
+
 /**** floating point support ********************************************/
 
 void
@@ -81,11 +83,28 @@ dump_sigcontext(dcontext_t *dcontext, sigcontext_t *sc)
 }
 #endif /* DEBUG */
 
+/* There is a bug in all released kernels up to 4.12 when CONFIG_IWMMXT is
+ * enabled but the hardware is not present or not used: the VFP frame in the
+ * ucontext is offset as if there were a preceding IWMMXT frame, though this
+ * memory is in fact not written to by the kernel. We work around this by
+ * sending ourselves a signal at init time and looking for the VFP frame in
+ * both places. We can then initialise vfp_offset and know where to look in
+ * future.
+ * XXX: Because of the IWMMXT space being unset by earlier kernels it is
+ * possible that we might find the VFP frame header in both places. We could
+ * guard against that by clearing some memory below the SP before sending the
+ * signal (assuming sigaltstack has not been used).
+ * XXX: When the kernel bug has been fixed we could implement a proper walk
+ * through the frames but we will need to work with old kernels in any case.
+ */
+
+static uint vfp_offset = 0;
+
 void
 sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
 {
     kernel_vfp_sigframe_t *vfp =
-        (kernel_vfp_sigframe_t *) sc_full->fp_simd_state;
+        (kernel_vfp_sigframe_t *)((char *)sc_full->fp_simd_state + vfp_offset);
     ASSERT(sizeof(mc->simd) == sizeof(vfp->ufp.fpregs));
     ASSERT(vfp->magic == VFP_MAGIC);
     ASSERT(vfp->size == sizeof(kernel_vfp_sigframe_t));
@@ -96,11 +115,13 @@ void
 mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
 {
     kernel_vfp_sigframe_t *vfp =
-        (kernel_vfp_sigframe_t *) sc_full->fp_simd_state;
+        (kernel_vfp_sigframe_t *)((char *)sc_full->fp_simd_state + vfp_offset);
     ASSERT(sizeof(mc->simd) == sizeof(vfp->ufp.fpregs));
     vfp->magic = VFP_MAGIC;
     vfp->size = sizeof(kernel_vfp_sigframe_t);
     memcpy(&vfp->ufp.fpregs[0], &mc->simd[0], sizeof(vfp->ufp.fpregs));
+    /* Terminate the frame list with zero magic. */
+    vfp[1].magic = 0;
 }
 
 size_t
@@ -109,8 +130,38 @@ signal_frame_extra_size(bool include_alignment)
     return 0;
 }
 
+static void
+vfp_query_signal_handler(int sig, siginfo_t *siginfo, kernel_ucontext_t *ucxt)
+{
+    uint offset = 160; /* size of IWMMXT frame */
+    char *coproc = (char *)&ucxt->coproc;
+    kernel_vfp_sigframe_t *vfp0 = (kernel_vfp_sigframe_t *)coproc;
+    kernel_vfp_sigframe_t *vfp1 = (kernel_vfp_sigframe_t *)(coproc + offset);
+    bool vfp0_good = (vfp0->magic == VFP_MAGIC &&
+                      vfp0->size == sizeof(kernel_vfp_sigframe_t));
+    bool vfp1_good = (vfp1->magic == VFP_MAGIC &&
+                      vfp1->size == sizeof(kernel_vfp_sigframe_t));
+    if (vfp0_good == vfp1_good) {
+        ASSERT(false && "Cannot identify VFP frame offset");
+        /* It is safer not to continue. */
+        exit_process_syscall(1);
+    }
+    vfp_offset = vfp0_good ? 0 : offset;
+    /* Detect if we unexpectedly have a filled-in IWMMXT frame. */
+#define IWMMXT_MAGIC 0x12ef842a
+    ASSERT(!(vfp0->magic == IWMMXT_MAGIC && vfp0->size == offset));
+}
+
 void
 signal_arch_init(void)
 {
-    /* Nothing. */
+    kernel_sigaction_t act, oldact;
+    int rc;
+    memset(&act, 0, sizeof(act));
+    set_handler_sigact(&act, VFP_QUERY_SIG, (handler_t)vfp_query_signal_handler);
+    rc = sigaction_syscall(VFP_QUERY_SIG, &act, &oldact);
+    ASSERT(rc == 0);
+    thread_signal(get_process_id(), get_sys_thread_id(), VFP_QUERY_SIG);
+    rc = sigaction_syscall(VFP_QUERY_SIG, &oldact, NULL);
+    ASSERT(rc == 0);
 }

--- a/core/unix/signal_linux_arm.c
+++ b/core/unix/signal_linux_arm.c
@@ -146,9 +146,9 @@ vfp_query_signal_handler(int sig, siginfo_t *siginfo, kernel_ucontext_t *ucxt)
                       vfp1->size == sizeof(kernel_vfp_sigframe_t));
     ASSERT(offset == 160);
     if (vfp0_good == vfp1_good) {
-        ASSERT(false && "Cannot identify VFP frame offset");
-        /* It is safer not to continue. */
-        exit_process_syscall(1);
+        SYSLOG(SYSLOG_CRITICAL, CANNOT_FIND_VFP_FRAME, 2,
+               get_application_name(), get_application_pid());
+        os_terminate(NULL, TERMINATE_PROCESS);
     }
     vfp_offset = vfp0_good ? 0 : offset;
     /* Detect if we unexpectedly have a filled-in IWMMXT frame. */

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -600,4 +600,14 @@ Application %1!s! (%2!s!). A fixed memory map (%3!s!) overlaps with DynamoRIO li
 .
 ;#endif
 
+;#ifdef UNIX
+MessageId =
+Severity = Error
+Facility = DRCore
+SymbolicName = MSG_CANNOT_FIND_VFP_FRAME
+Language=English
+Application %1!s! (%2!s!). Cannot identify VFP frame offset.
+.
+;#endif
+
 ;// ADD NEW MESSAGES HERE


### PR DESCRIPTION
With kernels up to 4.12, when CONFIG_IWMMXT is enabled the VFP frame
in the ucontext is offset by the size of the IWMMXT frame even when
no IWMMXT frame is written. We work around this by sending ourselves
a signal at init time and looking for the VFP frame in both places.
