### PR TITLE
i#2491 ARM unallocated encodings: Better handling of undecoded instrs.

### DIFF
--- a/core/arch/arm/decode.c
+++ b/core/arch/arm/decode.c
@@ -2893,8 +2893,12 @@ check_encode_decode_consistency(dcontext_t *dcontext, instrlist_t *ilist)
         byte buf[THUMB_LONG_INSTR_SIZE];
         instr_t tmp;
         byte *pc, *npc;
-        app_pc addr = instr_get_raw_bits(check);
-        int check_len = instr_length(dcontext, check);
+        app_pc addr;
+        int check_len;
+        if (check->opcode == OP_UNDECODED)
+            continue;
+        addr = instr_get_raw_bits(check);
+        check_len = instr_length(dcontext, check);
         instr_set_raw_bits_valid(check, false);
         pc = instr_encode_to_copy(dcontext, check, buf, addr);
         instr_init(dcontext, &tmp);

--- a/core/arch/arm/encode.c
+++ b/core/arch/arm/encode.c
@@ -2766,7 +2766,7 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
     }
 
     decode_info_init_for_instr(&di, instr);
-    di.opcode = instr_get_opcode(instr);
+    di.opcode = instr->opcode;
     di.check_reachable = check_reachable;
     di.start_pc = copy_pc;
     di.final_pc = final_pc;

--- a/suite/tests/client-interface/drreg-test.c
+++ b/suite/tests/client-interface/drreg-test.c
@@ -254,7 +254,8 @@ GLOBAL_LABEL(FUNCNAME:)
         movw     TEST_REG_ASM, DRREG_TEST_3_ASM
         movw     TEST_REG_ASM, DRREG_TEST_3_ASM
         nop
-        .word 0xe7f000f0 /* udf */
+        .inst    0xf2800f00 /* unallocated encoding */
+        mov      lr, #0 /* this should not be executed */
 
         b        epilog2
     epilog2:
@@ -266,7 +267,8 @@ GLOBAL_LABEL(FUNCNAME:)
         movz     TEST_REG_ASM, DRREG_TEST_3_ASM
         movz     TEST_REG_ASM, DRREG_TEST_3_ASM
         nop
-        .inst 0xf36d19 /* udf */
+        .inst    0x00f36d19 /* unallocated encoding */
+        mov      x30, #0 /* this should not be executed */
 
         b        epilog2
     epilog2:


### PR DESCRIPTION
In check_encode_decode_consistency(), do not try to reencode an
OP_UNDECODED instruction.

In instr_encode_arch(), use instr->opcode, not instr_get_opcode(instr),
as the latter can call the decoder, which is unhelpful when we are
trying to encode.

Fixes #2491

Change-Id: I66c42dc87268f1722eae4600b364026896796fc8