### PR TITLE
i#2494 ARM encoder: Fix bug in roll-back of reglists.

### DIFF
--- a/core/arch/arm/decode_private.h
+++ b/core/arch/arm/decode_private.h
@@ -239,6 +239,7 @@ struct _decode_info_t {
     uint reglist_stop;
     bool reglist_simd;
     opnd_size_t reglist_itemsz;
+    uint reglist_min_num;
     int memop_sz;
     /* For decoding and encoding shift types.  We need to coordinate across two
      * adjacent immediates.  This is set to point at the first one.

--- a/core/arch/arm/encode.c
+++ b/core/arch/arm/encode.c
@@ -1100,6 +1100,7 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
     /* Roll back greedy reglist if necessary */
     if (di->reglist_stop > 0 && optype_is_reg(optype) &&
         (!di->reglist_simd || !optype_is_gpr(optype)) &&
+        di->reglist_stop - 1 > di->reglist_start &&
         di->reglist_stop - di->reglist_start > di->reglist_min_num &&
         di->reglist_stop == opnum) {
         if ((is_dst &&

--- a/core/arch/arm/encode.c
+++ b/core/arch/arm/encode.c
@@ -639,6 +639,7 @@ encode_reglist_ok(decode_info_t *di, opnd_size_t size_temp, instr_t *in,
         opnd_size_in_bytes(size_temp);
     di->reglist_itemsz = size_temp; /* in case of rollback */
     di->reglist_simd = is_simd; /* in case of rollback */
+    di->reglist_min_num = min_num; /* in case of rollback */
     /* For T32.16, the base reg should appear either in the reglist or as
      * a writeback reg once and only once.
      */
@@ -665,6 +666,7 @@ encode_simd_reglist_single_entry(decode_info_t *di, byte optype, opnd_size_t siz
         /* There should be no rollback, but just to be complete: */
         di->reglist_itemsz = size_temp;
         di->reglist_simd = true;
+        di->reglist_min_num = 0;
         return true;
     }
     return false;
@@ -1098,7 +1100,8 @@ encode_opnd_ok(decode_info_t *di, byte optype, opnd_size_t size_temp, instr_t *i
     /* Roll back greedy reglist if necessary */
     if (di->reglist_stop > 0 && optype_is_reg(optype) &&
         (!di->reglist_simd || !optype_is_gpr(optype)) &&
-        di->reglist_stop - 1 > di->reglist_start && di->reglist_stop == opnum) {
+        di->reglist_stop - di->reglist_start > di->reglist_min_num &&
+        di->reglist_stop == opnum) {
         if ((is_dst &&
              (opnum >= instr_num_dsts(in) || !opnd_is_reg(instr_get_dst(in, opnum)))) ||
             (!is_dst &&


### PR DESCRIPTION
Roll-back of greedy reglists was permitted even when the reglist was
required to have min_num == max_num. This prevented the encoding of
an instruction such as "VTBL.8 d0, {d2-d3}, d4", because it was
tried with TYPE_L_VAx3 (list of length 3) before it was tried with
TYPE_L_VAx2 (list of length 2). The attempt to use TYPE_L_VAx3 would
incorrectly succeed because of the unrestricted roll-back.

The solution used here is to set a field reglist_min_num in the
decode_info_t and disallow roll-back beyond that minimum length.

Fixes #2494

Change-Id: Id1c22723f7862abc2cf24c0bbab4254b32232b33