### PR TITLE
i#2023 follow-up: apply to tool.drcachesim.filter

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2392,7 +2392,7 @@ if (CLIENT_INTERFACE)
 
       torunonly_ci(tool.drcachesim.filter ${ci_shared_app} drcachesim
         "drcachesim-filter-simple.c" # for templatex basename
-        "-ipc_name drtestfilter -L0_filter" "" "")
+        "-ipc_name ${IPC_PREFIX}drtestfilter -L0_filter" "" "")
         set(tool.drcachesim.filter_toolname "drcachesim")
         set(tool.drcachesim.filter_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")


### PR DESCRIPTION
Moves the tool.drcachesim.filter's test pipe file into the build dir from
/tmp to avoid stale files, to match all the other drcachesim tests.