### PR TITLE
i#2499: auto-standalone-init from global heap alloc

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -841,6 +841,8 @@ dcontext_t *
 standalone_init(void)
 {
     dcontext_t *dcontext;
+    if (dynamo_initialized)
+        return GLOBAL_DCONTEXT;
     standalone_library = true;
     /* We have release-build stats now so this is not just DEBUG */
     stats = &nonshared_stats;

--- a/core/heap.c
+++ b/core/heap.c
@@ -1532,7 +1532,7 @@ heap_init()
      * our post-init heapmgt struct
      */
     ASSERT(heapmgt == &temp_heapmgt);
-    heapmgt->global_heap_writable = true;
+    heapmgt->global_heap_writable = true; /* this is relied on in global_heap_alloc */
     threadunits_init(GLOBAL_DCONTEXT, &heapmgt->global_units, GLOBAL_UNIT_MIN_SIZE);
 
     heapmgt = HEAP_TYPE_ALLOC(GLOBAL_DCONTEXT, heap_management_t, ACCT_MEM_MGT,
@@ -2702,7 +2702,17 @@ common_global_heap_free(thread_units_t *tu, void *p, size_t size
 void *
 global_heap_alloc(size_t size HEAPACCT(which_heap_t which))
 {
-    void *p = common_global_heap_alloc(&heapmgt->global_units, size HEAPACCT(which));
+    void *p;
+    /* We pay the cost of this branch to support using DR's decode routines from the
+     * regular DR library and not just drdecode, to support libraries that would use
+     * drdecode but that also have to work with full DR (i#2499).
+     */
+    if (heapmgt == &temp_heapmgt &&
+        /* We prevent recrusion by checking for a field that heap_init writes. */
+        !heapmgt->global_heap_writable) {
+        standalone_init();
+    }
+    p = common_global_heap_alloc(&heapmgt->global_units, size HEAPACCT(which));
     ASSERT(p != NULL);
     LOG(GLOBAL, LOG_HEAP, 6, "\nglobal alloc: "PFX" (%d bytes)\n", p, size);
     return p;

--- a/core/heap.c
+++ b/core/heap.c
@@ -2703,6 +2703,7 @@ void *
 global_heap_alloc(size_t size HEAPACCT(which_heap_t which))
 {
     void *p;
+#ifdef CLIENT_INTERFACE
     /* We pay the cost of this branch to support using DR's decode routines from the
      * regular DR library and not just drdecode, to support libraries that would use
      * drdecode but that also have to work with full DR (i#2499).
@@ -2712,6 +2713,7 @@ global_heap_alloc(size_t size HEAPACCT(which_heap_t which))
         !heapmgt->global_heap_writable) {
         standalone_init();
     }
+#endif
     p = common_global_heap_alloc(&heapmgt->global_units, size HEAPACCT(which));
     ASSERT(p != NULL);
     LOG(GLOBAL, LOG_HEAP, 6, "\nglobal alloc: "PFX" (%d bytes)\n", p, size);

--- a/suite/tests/api/dis.c
+++ b/suite/tests/api/dis.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -93,6 +93,11 @@ main(int argc, char *argv[])
     uint64 file_size;
     size_t map_size;
     byte *map_base;
+
+    /* Test i#2499: heap alloc prior to standalone init. */
+    void *temp = dr_global_alloc(sizeof(void*));
+    dr_global_free(temp, sizeof(void*));
+
     void *drcontext = dr_standalone_init();
 
 #ifdef ARM


### PR DESCRIPTION
We call standalone_init() if global_heap_alloc() is invoked in full DR that
is not yet initialized, to support use as a decoding library without
requiring explicit initialization.

Adds a test to api.dis.

Fixes #2499