### PR TITLE
On ARM and AArch64, do not fail when no encoding is found.

### DIFF
--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -2648,15 +2648,6 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
 uint
 encode_common(byte *pc, instr_t *i)
 {
-    uint enc;
     ASSERT(((ptr_int_t)pc & 3) == 0);
-    enc = encoder(pc, i);
-    if (enc != ENCFAIL)
-        return enc;
-    /* We use OP_xx for instructions not yet handled by the decoder. */
-    if (instr_get_opcode(i) == OP_xx) {
-        ASSERT(instr_num_srcs(i) >= 1 && opnd_is_immed_int(instr_get_src(i, 0)));
-        return opnd_get_immed_int(instr_get_src(i, 0));
-    }
-    return enc;
+    return encoder(pc, i);
 }

--- a/core/arch/aarch64/encode.c
+++ b/core/arch/aarch64/encode.c
@@ -171,12 +171,12 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
         } else {
             /* We were unable to encode this instruction. */
             IF_DEBUG({
-                    char disas_instr[MAX_INSTR_DIS_SZ];
-                    instr_disassemble_to_buffer(dcontext, instr, disas_instr,
-                                                MAX_INSTR_DIS_SZ);
-                    SYSLOG_INTERNAL_ERROR("Internal Error: Failed to encode instruction:"
-                                          " '%s'\n", disas_instr);
-                });
+                char disas_instr[MAX_INSTR_DIS_SZ];
+                instr_disassemble_to_buffer(dcontext, instr, disas_instr,
+                                            MAX_INSTR_DIS_SZ);
+                SYSLOG_INTERNAL_ERROR("Internal Error: Failed to encode instruction:"
+                                      " '%s'\n", disas_instr);
+            });
             return NULL;
         }
     }

--- a/core/arch/aarch64/encode.c
+++ b/core/arch/aarch64/encode.c
@@ -144,6 +144,8 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
                   bool check_reachable, bool *has_instr_opnds/*OUT OPTIONAL*/
                   _IF_DEBUG(bool assert_reachable))
 {
+    uint enc;
+
     if (has_instr_opnds != NULL)
         *has_instr_opnds = false;
 
@@ -159,18 +161,26 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
     }
     CLIENT_ASSERT(instr_operands_valid(instr), "instr_encode error: operands invalid");
 
-    *(uint *)copy_pc = encode_common(final_pc, instr);
-    if (*(uint *)copy_pc == ENCFAIL) {
-        /* We were unable to encode this instruction. */
-        IF_DEBUG({
-            char disas_instr[MAX_INSTR_DIS_SZ];
-            instr_disassemble_to_buffer(dcontext, instr, disas_instr,
-                                        MAX_INSTR_DIS_SZ);
-            SYSLOG_INTERNAL_ERROR("Internal Error: Failed to encode instruction:"
-                                  " '%s'\n", disas_instr);
-        });
-        ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
+    enc = encode_common(final_pc, instr);
+    if (enc == ENCFAIL) {
+        /* This is to make decoding reversible. We would not normally encode an OP_xx. */
+        if (instr_get_opcode(instr) == OP_xx &&
+            instr_num_srcs(instr) > 0 &&
+            opnd_is_immed_int(instr_get_src(instr, 0))) {
+            enc = (uint)opnd_get_immed_int(instr_get_src(instr, 0));
+        } else {
+            /* We were unable to encode this instruction. */
+            IF_DEBUG({
+                    char disas_instr[MAX_INSTR_DIS_SZ];
+                    instr_disassemble_to_buffer(dcontext, instr, disas_instr,
+                                                MAX_INSTR_DIS_SZ);
+                    SYSLOG_INTERNAL_ERROR("Internal Error: Failed to encode instruction:"
+                                          " '%s'\n", disas_instr);
+                });
+            return NULL;
+        }
     }
+    *(uint *)copy_pc = enc;
     return copy_pc + 4;
 }
 

--- a/core/arch/arm/encode.c
+++ b/core/arch/arm/encode.c
@@ -2823,8 +2823,6 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
                 }
                 LOG(THREAD, LOG_EMIT, 1, "\n");
             });
-            CLIENT_ASSERT(!assert_reachable,
-                          "instr_encode error: no encoding found (see log)");
             return NULL;
         }
         /* We need to clear all the checking fields for each new template */


### PR DESCRIPTION
Make instr_encode_arch() return NULL, without an assertion failure,
if no encoding is found. The failure to encode might indicate an
internal error, but this function is also called from the API,
whose documented behaviour is to return NULL.

Also, on AArch64, move the code to handle OP_xx from codec.c to
encode.c because if encode_common() accepts OP_xx then we cannot
recognise a failure to encode from its uint return value.

Change-Id: I38f582c30481bb447c0a079ef12a5a80562f7176