### PR TITLE
i#1569 AArch64: Follow-up to 3275b81: check X30 opnd in encoder.

### DIFF
--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -1195,7 +1195,7 @@ encode_opnd_imms(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     return encode_opnd_imm_bf(10, enc, opnd, enc_out);
 }
 
-/* impx30: implicit X30 operand, used by BLR. */
+/* impx30: implicit X30 operand, used by BLR */
 
 static inline bool
 decode_opnd_impx30(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
@@ -2363,10 +2363,12 @@ decode_opnds_b(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int opc
 static inline uint
 encode_opnds_b(byte *pc, instr_t *instr, uint enc)
 {
-    uint off;
-    if (((instr_get_opcode(instr) == OP_bl && instr_num_dsts(instr) == 1) ||
-         instr_num_dsts(instr) == 0) &&
+    int opcode = instr_get_opcode(instr);
+    bool is_bl = (opcode == OP_bl);
+    uint off, x30;
+    if (instr_num_dsts(instr) == (is_bl ? 1 : 0) &&
         instr_num_srcs(instr) == 1 &&
+        (!is_bl || encode_opnd_impx30(enc, opcode, pc, instr_get_dst(instr, 0), &x30)) &&
         encode_pc_off(&off, 26, pc, instr, instr_get_src(instr, 0)))
         return (enc | off);
     return ENCFAIL;

--- a/core/arch/aarch64/codec.txt
+++ b/core/arch/aarch64/codec.txt
@@ -258,7 +258,7 @@ x0110111xxxxxxxxxxxxxxxxxxxxxxxx  tbnz   tbz
 ## Unconditional branch (register)
 
 1101011000011111000000xxxxx00000  br     : x5
-1101011000111111000000xxxxx00000  blr    impx30: x5
+1101011000111111000000xxxxx00000  blr    impx30 : x5
 1101011001011111000000xxxxx00000  ret    : x5
 
 # Loads and Stores


### PR DESCRIPTION
When encoding BL, require X30 as the destination opnd, for
consistency with BLR.

Change-Id: I448ad6e057c2d8bea047854aa3f031c2bcade89d