### PR TITLE
i#2520: remove ifndef AARCH64 from drx_buf_insert_buf_memcpy

### DIFF
--- a/ext/drx/drx_buf.c
+++ b/ext/drx/drx_buf.c
@@ -650,8 +650,6 @@ drx_buf_insert_buf_store(void *drcontext, drx_buf_t *buf, instrlist_t *ilist,
     }
 }
 
-#ifndef AARCH64
-/* FIXME i#1569: NYI on AArch64 */
 static void
 insert_load(void *drcontext, instrlist_t *ilist, instr_t *where,
                     reg_id_t dst, reg_id_t src, opnd_size_t opsz)
@@ -670,9 +668,9 @@ insert_load(void *drcontext, instrlist_t *ilist, instr_t *where,
                  opnd_create_base_disp(src, DR_REG_NULL, 0, 0, opsz)));
         break;
     case OPSZ_4:
-# if defined(X86_64) || defined(AARCH64)
+#if defined(X86_64) || defined(AARCH64)
     case OPSZ_8:
-# endif
+#endif
         MINSERT(ilist, where, XINST_CREATE_load
                 (drcontext,
                  opnd_create_reg(reg_resize_to_opsz(dst, opsz)),
@@ -758,7 +756,6 @@ drx_buf_insert_buf_memcpy(void *drcontext, drx_buf_t *buf, instrlist_t *ilist,
         drx_buf_insert_update_buf_ptr(drcontext, buf, ilist, where, dst, src, len);
     }
 }
-#endif
 
 /* assumes that the instruction writes memory relative to some buffer pointer */
 static reg_id_t

--- a/suite/tests/client-interface/drx_buf-test.dll.c
+++ b/suite/tests/client-interface/drx_buf-test.dll.c
@@ -58,14 +58,12 @@ static char cmp[] = "ABCDEFGHABCDEFGH";
 static char cmp[] = "ABCDEFGH";
 #endif
 
-#ifndef AARCH64
 static const char test_copy[TRACE_SZ] =
     "12345678911234567892123456789312345678941234567895123456789612"
     "12345678911234567892123456789312345678941234567895123456789612"
     "12345678911234567892123456789312345678941234567895123456789612"
     "12345678911234567892123456789312345678941234567895123456789612";
 static const char test_null[TRACE_SZ];
-#endif
 
 static drx_buf_t *circular_fast;
 static drx_buf_t *circular_slow;
@@ -129,7 +127,6 @@ verify_store(drx_buf_t *client)
     memset(buf_base, 0, drx_buf_get_buffer_size(drcontext, client));
 }
 
-#ifndef AARCH64
 static void
 verify_memcpy(drx_buf_t *client)
 {
@@ -147,7 +144,6 @@ verify_buffers_nulled(drx_buf_t *client)
     byte *buf_base = drx_buf_get_buffer_base(drcontext, client);
     CHECK(memcmp(buf_base, test_null, sizeof(test_null)) == 0, "buffer not nulled");
 }
-#endif
 
 static dr_emit_flags_t
 event_app_analysis(void *drcontext, void *tag, instrlist_t *bb,
@@ -371,7 +367,6 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         dr_insert_clean_call(drcontext, bb, inst, verify_store, false, 1,
                              OPND_CREATE_INTPTR(circular_fast));
     } else if (subtest == DRX_BUF_TEST_6_C) {
-#ifndef AARCH64
         /* Currently, the fast circular buffer does not recommend variable-size
          * writes, for good reason. We don't test the memcpy operation on the
          * fast circular buffer.
@@ -421,9 +416,6 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         /* verify buffer was NULLed */
         dr_insert_clean_call(drcontext, bb, inst, (void *)verify_buffers_nulled, false, 1,
                              OPND_CREATE_INTPTR(trace));
-#else
-    /* FIXME i#1569: NYI on AArch64 */
-#endif
     }
 
     return DR_EMIT_DEFAULT;
@@ -436,7 +428,8 @@ event_exit(void)
      * because the callback is called on thread_exit(). Finally, two more for
      * drx_buf_insert_buf_memcpy().
      */
-    CHECK(num_faults == NUM_ITER * 2 + 2 + IF_AARCH64_ELSE(0, 2),
+
+    CHECK(num_faults == NUM_ITER * 2 + 2 + 2,
             "the number of faults don't match up");
     if (!drmgr_unregister_bb_insertion_event(event_app_instruction))
         CHECK(false, "exit failed");

--- a/suite/tests/client-interface/drx_buf-test.dll.c
+++ b/suite/tests/client-interface/drx_buf-test.dll.c
@@ -428,7 +428,6 @@ event_exit(void)
      * because the callback is called on thread_exit(). Finally, two more for
      * drx_buf_insert_buf_memcpy().
      */
-
     CHECK(num_faults == NUM_ITER * 2 + 2 + 2,
             "the number of faults don't match up");
     if (!drmgr_unregister_bb_insertion_event(event_app_instruction))


### PR DESCRIPTION
All required XINST_ macros required by drx_buf_insert_buf_memcpy have
been added for AArch64 and the ifndef AARCH64 guards can be removed
from drx_buf_insert_buf_memcpy and the accompanying test
drx_buf-test.dll.c

Thanks @toshipiazza for pointing that out!

Fixes #2520.