### PR TITLE
i#1569 AArch64: Fix bug in encoding (SIMD structure load/store).

### DIFF
--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -2205,10 +2205,9 @@ encode_opnd_x16imm(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_ou
         return true;
     } else if (opnd_is_immed_int(opnd)) {
         ptr_int_t bytes = opnd_get_immed_int(opnd);
-        int regs = multistruct_regcount(enc);
-        if (bytes != regs * 8 && bytes != regs * 16)
+        if (bytes != (8 << extract_uint(enc, 30, 1)) * multistruct_regcount(enc))
             return false;
-        *enc_out = 31U << 16 | (uint)(bytes == regs * 16) << 30;
+        *enc_out = 31U << 16;
         return true;
     }
     return false;

--- a/core/arch/aarch64/codec.py
+++ b/core/arch/aarch64/codec.py
@@ -135,7 +135,8 @@ def generate_encoder(patterns, opndsgen, opndtypes):
             vars = (['dst%d' % i for i in range(len(dsts))] +
                     ['src%d' % i for i in range(len(srcs))])
             c += ['    int opcode = instr->opcode;']
-            c += ['    uint ' + ', '.join(vars) + ';']
+            # The initial values are only required to silence a bad compiler warning:
+            c += ['    uint ' + ' = 0, '.join(vars) + ' = 0;']
             tests = (['instr_num_dsts(instr) == %d && instr_num_srcs(instr) == %d' %
                       (len(dsts), len(srcs))] +
                      ['encode_opnd_%s(enc & 0x%08x, opcode, '

--- a/core/arch/aarch64/codec.txt
+++ b/core/arch/aarch64/codec.txt
@@ -100,7 +100,7 @@
 -----------xxxxx----------------  x16p0      # even-numbered X register (or XZR)
 -----------xxxxx----------------  x16p1      # ... add 1
 -----------xxxxx----------------  x16immvr   # computes immed from 21, 13 and 11:10
------------xxxxx----------------  x16immvs   # computes immed 21, 15:13 and 11:10
+-----------xxxxx----------------  x16immvs   # computes immed from 21, 15:13 and 11:10
 -----------xxxxxxxxx------------  mem9off    # immed offset for mem9/mem9post
 -----------xxxxxxxxx--xxxxx-----  mem9       # gets size from 31:30
 -----------xxxxxxxxx--xxxxx-----  mem9q      # size is 16 bytes
@@ -134,7 +134,7 @@
 -x-----------------x------------  index2     # index of S subreg in Q: 0-3
 -x-----------------xx-----------  index1     # index of H subreg in Q: 0-7
 -x-----------------xxx----------  index0     # index of B subreg in Q: 0-15
--x---------xxxxx----------------  x16imm     # computes immed from 30 and 15:12
+-----------xxxxx----------------  x16imm     # computes immed from 30 and 15:12
 x--------------------------xxxxx  wx0        # W/X register (or WZR/XZR)
 x--------------------------xxxxx  wx0sp      # W/X register or WSP/XSP
 x---------------------xxxxx-----  wx5        # W/X register (or WZR/XZR)
@@ -737,21 +737,37 @@ x0110111xxxxxxxxxxxxxxxxxxxxxxxx  tbnz   tbz
 
 ## Advanced SIMD load/store multiple structures (post-indexed)
 
-0x001100100xxxxx0000xxxxxxxxxxxx  st4    memvm x5sp : vmsz vt0 vt1 vt2 vt3 x5sp x16imm
-0x001100100xxxxx0010xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 vt1 vt2 vt3 x5sp x16imm
-0x001100100xxxxx0100xxxxxxxxxxxx  st3    memvm x5sp : vmsz vt0 vt1 vt2 x5sp x16imm
-0x001100100xxxxx0110xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 vt1 vt2 x5sp x16imm
-0x001100100xxxxx0111xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 x5sp x16imm
-0x001100100xxxxx1000xxxxxxxxxxxx  st2    memvm x5sp : vmsz vt0 vt1 x5sp x16imm
-0x001100100xxxxx1010xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 vt1 x5sp x16imm
+00001100100xxxxx0000xxxxxxxxxxxx  st4    memvm x5sp : vmsz vt0 vt1 vt2 vt3 x5sp x16imm
+00001100100xxxxx0010xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 vt1 vt2 vt3 x5sp x16imm
+00001100100xxxxx0100xxxxxxxxxxxx  st3    memvm x5sp : vmsz vt0 vt1 vt2 x5sp x16imm
+00001100100xxxxx0110xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 vt1 vt2 x5sp x16imm
+00001100100xxxxx0111xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 x5sp x16imm
+00001100100xxxxx1000xxxxxxxxxxxx  st2    memvm x5sp : vmsz vt0 vt1 x5sp x16imm
+00001100100xxxxx1010xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 vt1 x5sp x16imm
 
-0x001100110xxxxx0000xxxxxxxxxxxx  ld4    vt0 vt1 vt2 vt3 x5sp : memvm vmsz x5sp x16imm
-0x001100110xxxxx0010xxxxxxxxxxxx  ld1    vt0 vt1 vt2 vt3 x5sp : memvm vmsz x5sp x16imm
-0x001100110xxxxx0100xxxxxxxxxxxx  ld3    vt0 vt1 vt2 x5sp : memvm vmsz x5sp x16imm
-0x001100110xxxxx0110xxxxxxxxxxxx  ld1    vt0 vt1 vt2 x5sp : memvm vmsz x5sp x16imm
-0x001100110xxxxx0111xxxxxxxxxxxx  ld1    vt0 x5sp : memvm vmsz x5sp x16imm
-0x001100110xxxxx1000xxxxxxxxxxxx  ld2    vt0 vt1 x5sp : memvm vmsz x5sp x16imm
-0x001100110xxxxx1010xxxxxxxxxxxx  ld1    vt0 vt1 x5sp : memvm vmsz x5sp x16imm
+00001100110xxxxx0000xxxxxxxxxxxx  ld4    vt0 vt1 vt2 vt3 x5sp : memvm vmsz x5sp x16imm
+00001100110xxxxx0010xxxxxxxxxxxx  ld1    vt0 vt1 vt2 vt3 x5sp : memvm vmsz x5sp x16imm
+00001100110xxxxx0100xxxxxxxxxxxx  ld3    vt0 vt1 vt2 x5sp : memvm vmsz x5sp x16imm
+00001100110xxxxx0110xxxxxxxxxxxx  ld1    vt0 vt1 vt2 x5sp : memvm vmsz x5sp x16imm
+00001100110xxxxx0111xxxxxxxxxxxx  ld1    vt0 x5sp : memvm vmsz x5sp x16imm
+00001100110xxxxx1000xxxxxxxxxxxx  ld2    vt0 vt1 x5sp : memvm vmsz x5sp x16imm
+00001100110xxxxx1010xxxxxxxxxxxx  ld1    vt0 vt1 x5sp : memvm vmsz x5sp x16imm
+
+01001100100xxxxx0000xxxxxxxxxxxx  st4    memvm x5sp : vmsz vt0 vt1 vt2 vt3 x5sp x16imm
+01001100100xxxxx0010xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 vt1 vt2 vt3 x5sp x16imm
+01001100100xxxxx0100xxxxxxxxxxxx  st3    memvm x5sp : vmsz vt0 vt1 vt2 x5sp x16imm
+01001100100xxxxx0110xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 vt1 vt2 x5sp x16imm
+01001100100xxxxx0111xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 x5sp x16imm
+01001100100xxxxx1000xxxxxxxxxxxx  st2    memvm x5sp : vmsz vt0 vt1 x5sp x16imm
+01001100100xxxxx1010xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 vt1 x5sp x16imm
+
+01001100110xxxxx0000xxxxxxxxxxxx  ld4    vt0 vt1 vt2 vt3 x5sp : memvm vmsz x5sp x16imm
+01001100110xxxxx0010xxxxxxxxxxxx  ld1    vt0 vt1 vt2 vt3 x5sp : memvm vmsz x5sp x16imm
+01001100110xxxxx0100xxxxxxxxxxxx  ld3    vt0 vt1 vt2 x5sp : memvm vmsz x5sp x16imm
+01001100110xxxxx0110xxxxxxxxxxxx  ld1    vt0 vt1 vt2 x5sp : memvm vmsz x5sp x16imm
+01001100110xxxxx0111xxxxxxxxxxxx  ld1    vt0 x5sp : memvm vmsz x5sp x16imm
+01001100110xxxxx1000xxxxxxxxxxxx  ld2    vt0 vt1 x5sp : memvm vmsz x5sp x16imm
+01001100110xxxxx1010xxxxxxxxxxxx  ld1    vt0 vt1 x5sp : memvm vmsz x5sp x16imm
 
 ## Advanced SIMD load/store single structure
 

--- a/core/arch/aarch64/decode_gen.h
+++ b/core/arch/aarch64/decode_gen.h
@@ -317,13 +317,13 @@ decode_opndsgen_0c800000(uint enc, dcontext_t *dcontext, byte *pc, instr_t *inst
 {
     opnd_t dst0, dst1, src0, src1, src2, src3, src4, src5, src6;
     if (!decode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, &dst0) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &dst1) ||
-        !decode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, &src0) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &dst1) ||
+        !decode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, &src0) ||
         !decode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, &src1) ||
         !decode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, &src2) ||
         !decode_opnd_vt2(enc & 0xffe0f01f, opcode, pc, &src3) ||
         !decode_opnd_vt3(enc & 0xffe0f01f, opcode, pc, &src4) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &src5) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &src5) ||
         !decode_opnd_x16imm(enc & 0xfffff000, opcode, pc, &src6))
         return false;
     instr_set_opcode(instr, opcode);
@@ -345,12 +345,12 @@ decode_opndsgen_0c804000(uint enc, dcontext_t *dcontext, byte *pc, instr_t *inst
 {
     opnd_t dst0, dst1, src0, src1, src2, src3, src4, src5;
     if (!decode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, &dst0) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &dst1) ||
-        !decode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, &src0) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &dst1) ||
+        !decode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, &src0) ||
         !decode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, &src1) ||
         !decode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, &src2) ||
         !decode_opnd_vt2(enc & 0xffe0f01f, opcode, pc, &src3) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &src4) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &src4) ||
         !decode_opnd_x16imm(enc & 0xfffff000, opcode, pc, &src5))
         return false;
     instr_set_opcode(instr, opcode);
@@ -371,10 +371,10 @@ decode_opndsgen_0c807000(uint enc, dcontext_t *dcontext, byte *pc, instr_t *inst
 {
     opnd_t dst0, dst1, src0, src1, src2, src3;
     if (!decode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, &dst0) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &dst1) ||
-        !decode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, &src0) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &dst1) ||
+        !decode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, &src0) ||
         !decode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, &src1) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &src2) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &src2) ||
         !decode_opnd_x16imm(enc & 0xfffff000, opcode, pc, &src3))
         return false;
     instr_set_opcode(instr, opcode);
@@ -393,11 +393,11 @@ decode_opndsgen_0c808000(uint enc, dcontext_t *dcontext, byte *pc, instr_t *inst
 {
     opnd_t dst0, dst1, src0, src1, src2, src3, src4;
     if (!decode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, &dst0) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &dst1) ||
-        !decode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, &src0) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &dst1) ||
+        !decode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, &src0) ||
         !decode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, &src1) ||
         !decode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, &src2) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &src3) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &src3) ||
         !decode_opnd_x16imm(enc & 0xfffff000, opcode, pc, &src4))
         return false;
     instr_set_opcode(instr, opcode);
@@ -420,10 +420,10 @@ decode_opndsgen_0cc00000(uint enc, dcontext_t *dcontext, byte *pc, instr_t *inst
         !decode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, &dst1) ||
         !decode_opnd_vt2(enc & 0xffe0f01f, opcode, pc, &dst2) ||
         !decode_opnd_vt3(enc & 0xffe0f01f, opcode, pc, &dst3) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &dst4) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &dst4) ||
         !decode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, &src0) ||
-        !decode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, &src1) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &src2) ||
+        !decode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, &src1) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &src2) ||
         !decode_opnd_x16imm(enc & 0xfffff000, opcode, pc, &src3))
         return false;
     instr_set_opcode(instr, opcode);
@@ -447,10 +447,10 @@ decode_opndsgen_0cc04000(uint enc, dcontext_t *dcontext, byte *pc, instr_t *inst
     if (!decode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, &dst0) ||
         !decode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, &dst1) ||
         !decode_opnd_vt2(enc & 0xffe0f01f, opcode, pc, &dst2) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &dst3) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &dst3) ||
         !decode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, &src0) ||
-        !decode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, &src1) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &src2) ||
+        !decode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, &src1) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &src2) ||
         !decode_opnd_x16imm(enc & 0xfffff000, opcode, pc, &src3))
         return false;
     instr_set_opcode(instr, opcode);
@@ -471,10 +471,10 @@ decode_opndsgen_0cc07000(uint enc, dcontext_t *dcontext, byte *pc, instr_t *inst
 {
     opnd_t dst0, dst1, src0, src1, src2, src3;
     if (!decode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, &dst0) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &dst1) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &dst1) ||
         !decode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, &src0) ||
-        !decode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, &src1) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &src2) ||
+        !decode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, &src1) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &src2) ||
         !decode_opnd_x16imm(enc & 0xfffff000, opcode, pc, &src3))
         return false;
     instr_set_opcode(instr, opcode);
@@ -494,10 +494,10 @@ decode_opndsgen_0cc08000(uint enc, dcontext_t *dcontext, byte *pc, instr_t *inst
     opnd_t dst0, dst1, dst2, src0, src1, src2, src3;
     if (!decode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, &dst0) ||
         !decode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, &dst1) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &dst2) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &dst2) ||
         !decode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, &src0) ||
-        !decode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, &src1) ||
-        !decode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, &src2) ||
+        !decode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, &src1) ||
+        !decode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, &src2) ||
         !decode_opnd_x16imm(enc & 0xfffff000, opcode, pc, &src3))
         return false;
     instr_set_opcode(instr, opcode);
@@ -5132,193 +5132,33 @@ decoder(uint enc, dcontext_t *dc, byte *pc, instr_t *instr)
                     }
                 }
             } else {
-                if ((enc >> 28 & 1) == 0) {
+                if ((enc >> 24 & 1) == 0) {
                     if ((enc >> 23 & 1) == 0) {
-                        if ((enc >> 13 & 1) == 0) {
-                            if ((enc >> 15 & 1) == 0) {
-                                if ((enc >> 14 & 1) == 0) {
-                                    if ((enc & 0xbfffe000) == 0x0d000000)
-                                        return decode_opndsgen_0d000000(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbfffe000) == 0x0d200000)
-                                        return decode_opndsgen_0d200000(enc, dc, pc, instr, OP_st2);
-                                    if ((enc & 0xbffff000) == 0x0c000000)
-                                        return decode_opndsgen_0c000000(enc, dc, pc, instr, OP_st4);
-                                } else {
-                                    if ((enc & 0xbfffe400) == 0x0d004000)
-                                        return decode_opndsgen_0d004000(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbfffe400) == 0x0d204000)
-                                        return decode_opndsgen_0d204000(enc, dc, pc, instr, OP_st2);
-                                    if ((enc & 0xbffff000) == 0x0c004000)
-                                        return decode_opndsgen_0c004000(enc, dc, pc, instr, OP_st3);
-                                }
-                            } else {
-                                if ((enc >> 10 & 1) == 0) {
-                                    if ((enc & 0xbfffec00) == 0x0d008000)
-                                        return decode_opndsgen_0d008000(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbffff000) == 0x0c008000)
-                                        return decode_opndsgen_0c008000(enc, dc, pc, instr, OP_st2);
-                                    if ((enc & 0xbfffec00) == 0x0d208000)
-                                        return decode_opndsgen_0d208000(enc, dc, pc, instr, OP_st2);
-                                } else {
-                                    if ((enc & 0xbffffc00) == 0x0d008400)
-                                        return decode_opndsgen_0d008400(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbffff000) == 0x0c008000)
-                                        return decode_opndsgen_0c008000(enc, dc, pc, instr, OP_st2);
-                                    if ((enc & 0xbffffc00) == 0x0d208400)
-                                        return decode_opndsgen_0d208400(enc, dc, pc, instr, OP_st2);
-                                }
-                            }
-                        } else {
-                            if ((enc >> 15 & 1) == 0) {
-                                if ((enc >> 14 & 1) == 0) {
-                                    if ((enc & 0xbffff000) == 0x0c002000)
-                                        return decode_opndsgen_0c000000(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbfffe000) == 0x0d002000)
-                                        return decode_opndsgen_0d002000(enc, dc, pc, instr, OP_st3);
-                                    if ((enc & 0xbfffe000) == 0x0d202000)
-                                        return decode_opndsgen_0d202000(enc, dc, pc, instr, OP_st4);
-                                } else {
-                                    if ((enc >> 24 & 1) == 0) {
-                                        if ((enc & 0xbffff000) == 0x0c006000)
-                                            return decode_opndsgen_0c004000(enc, dc, pc, instr, OP_st1);
-                                        if ((enc & 0xbffff000) == 0x0c007000)
-                                            return decode_opndsgen_0c007000(enc, dc, pc, instr, OP_st1);
-                                    } else {
-                                        if ((enc & 0xbfffe400) == 0x0d006000)
-                                            return decode_opndsgen_0d006000(enc, dc, pc, instr, OP_st3);
-                                        if ((enc & 0xbfffe400) == 0x0d206000)
-                                            return decode_opndsgen_0d206000(enc, dc, pc, instr, OP_st4);
-                                    }
-                                }
-                            } else {
-                                if ((enc >> 10 & 1) == 0) {
-                                    if ((enc & 0xbffff000) == 0x0c00a000)
-                                        return decode_opndsgen_0c008000(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbfffec00) == 0x0d00a000)
-                                        return decode_opndsgen_0d00a000(enc, dc, pc, instr, OP_st3);
-                                    if ((enc & 0xbfffec00) == 0x0d20a000)
-                                        return decode_opndsgen_0d20a000(enc, dc, pc, instr, OP_st4);
-                                } else {
-                                    if ((enc & 0xbffff000) == 0x0c00a000)
-                                        return decode_opndsgen_0c008000(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbffffc00) == 0x0d00a400)
-                                        return decode_opndsgen_0d00a400(enc, dc, pc, instr, OP_st3);
-                                    if ((enc & 0xbffffc00) == 0x0d20a400)
-                                        return decode_opndsgen_0d20a400(enc, dc, pc, instr, OP_st4);
-                                }
-                            }
-                        }
-                    } else {
-                        if ((enc >> 13 & 1) == 0) {
-                            if ((enc >> 15 & 1) == 0) {
-                                if ((enc >> 14 & 1) == 0) {
-                                    if ((enc & 0xbfe0e000) == 0x0d800000)
-                                        return decode_opndsgen_0d800000(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbfe0e000) == 0x0da00000)
-                                        return decode_opndsgen_0da00000(enc, dc, pc, instr, OP_st2);
-                                    if ((enc & 0xbfe0f000) == 0x0c800000)
-                                        return decode_opndsgen_0c800000(enc, dc, pc, instr, OP_st4);
-                                } else {
-                                    if ((enc & 0xbfe0e400) == 0x0d804000)
-                                        return decode_opndsgen_0d804000(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbfe0e400) == 0x0da04000)
-                                        return decode_opndsgen_0da04000(enc, dc, pc, instr, OP_st2);
-                                    if ((enc & 0xbfe0f000) == 0x0c804000)
-                                        return decode_opndsgen_0c804000(enc, dc, pc, instr, OP_st3);
-                                }
-                            } else {
-                                if ((enc >> 10 & 1) == 0) {
-                                    if ((enc & 0xbfe0ec00) == 0x0d808000)
-                                        return decode_opndsgen_0d808000(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbfe0f000) == 0x0c808000)
-                                        return decode_opndsgen_0c808000(enc, dc, pc, instr, OP_st2);
-                                    if ((enc & 0xbfe0ec00) == 0x0da08000)
-                                        return decode_opndsgen_0da08000(enc, dc, pc, instr, OP_st2);
-                                } else {
-                                    if ((enc & 0xbfe0fc00) == 0x0d808400)
-                                        return decode_opndsgen_0d808400(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbfe0f000) == 0x0c808000)
-                                        return decode_opndsgen_0c808000(enc, dc, pc, instr, OP_st2);
-                                    if ((enc & 0xbfe0fc00) == 0x0da08400)
-                                        return decode_opndsgen_0da08400(enc, dc, pc, instr, OP_st2);
-                                }
-                            }
-                        } else {
-                            if ((enc >> 15 & 1) == 0) {
-                                if ((enc >> 14 & 1) == 0) {
-                                    if ((enc & 0xbfe0f000) == 0x0c802000)
-                                        return decode_opndsgen_0c800000(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbfe0e000) == 0x0d802000)
-                                        return decode_opndsgen_0d802000(enc, dc, pc, instr, OP_st3);
-                                    if ((enc & 0xbfe0e000) == 0x0da02000)
-                                        return decode_opndsgen_0da02000(enc, dc, pc, instr, OP_st4);
-                                } else {
-                                    if ((enc >> 24 & 1) == 0) {
-                                        if ((enc & 0xbfe0f000) == 0x0c806000)
-                                            return decode_opndsgen_0c804000(enc, dc, pc, instr, OP_st1);
-                                        if ((enc & 0xbfe0f000) == 0x0c807000)
-                                            return decode_opndsgen_0c807000(enc, dc, pc, instr, OP_st1);
-                                    } else {
-                                        if ((enc & 0xbfe0e400) == 0x0d806000)
-                                            return decode_opndsgen_0d806000(enc, dc, pc, instr, OP_st3);
-                                        if ((enc & 0xbfe0e400) == 0x0da06000)
-                                            return decode_opndsgen_0da06000(enc, dc, pc, instr, OP_st4);
-                                    }
-                                }
-                            } else {
-                                if ((enc >> 10 & 1) == 0) {
-                                    if ((enc & 0xbfe0f000) == 0x0c80a000)
-                                        return decode_opndsgen_0c808000(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbfe0ec00) == 0x0d80a000)
-                                        return decode_opndsgen_0d80a000(enc, dc, pc, instr, OP_st3);
-                                    if ((enc & 0xbfe0ec00) == 0x0da0a000)
-                                        return decode_opndsgen_0da0a000(enc, dc, pc, instr, OP_st4);
-                                } else {
-                                    if ((enc & 0xbfe0f000) == 0x0c80a000)
-                                        return decode_opndsgen_0c808000(enc, dc, pc, instr, OP_st1);
-                                    if ((enc & 0xbfe0fc00) == 0x0d80a400)
-                                        return decode_opndsgen_0d80a400(enc, dc, pc, instr, OP_st3);
-                                    if ((enc & 0xbfe0fc00) == 0x0da0a400)
-                                        return decode_opndsgen_0da0a400(enc, dc, pc, instr, OP_st4);
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    if ((enc >> 24 & 1) == 0) {
-                        if ((enc >> 30 & 1) == 0) {
-                            if ((enc >> 27 & 1) == 0) {
-                                if ((enc & 0xfc000000) == 0x14000000)
-                                    return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                if ((enc & 0xfc000000) == 0x94000000)
-                                    return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                            } else {
-                                if ((enc & 0xff000000) == 0x1c000000)
-                                    return decode_opndsgen_1c000000(enc, dc, pc, instr, OP_ldr);
-                                if ((enc & 0xff000000) == 0x9c000000)
-                                    return decode_opndsgen_9c000000(enc, dc, pc, instr, OP_ldr);
-                            }
-                        } else {
+                        if ((enc >> 27 & 1) == 0) {
                             if ((enc >> 0 & 1) == 0) {
                                 if ((enc >> 21 & 1) == 0) {
-                                    if ((enc >> 31 & 1) == 0) {
+                                    if ((enc >> 30 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                    } else {
                                         if ((enc & 0xff000010) == 0x54000000)
                                             return decode_opnds_bcond(enc, dc, pc, instr, OP_bcond);
-                                        if ((enc & 0xff000000) == 0x5c000000)
-                                            return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
-                                    } else {
                                         if ((enc & 0xfffffc1f) == 0xd61f0000)
                                             return decode_opndsgen_d61f0000(enc, dc, pc, instr, OP_br);
                                         if ((enc & 0xffe0001f) == 0xd4000002)
                                             return decode_opndsgen_d4000001(enc, dc, pc, instr, OP_hvc);
                                     }
                                 } else {
-                                    if ((enc >> 31 & 1) == 0) {
+                                    if ((enc >> 30 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                    } else {
                                         if ((enc & 0xff000010) == 0x54000000)
                                             return decode_opnds_bcond(enc, dc, pc, instr, OP_bcond);
-                                        if ((enc & 0xff000000) == 0x5c000000)
-                                            return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
-                                    } else {
                                         if ((enc & 0xfffffc1f) == 0xd63f0000)
                                             return decode_opndsgen_d63f0000(enc, dc, pc, instr, OP_blr);
                                         if ((enc & 0xffe0001f) == 0xd4200000)
@@ -5326,241 +5166,419 @@ decoder(uint enc, dcontext_t *dc, byte *pc, instr_t *instr)
                                     }
                                 }
                             } else {
-                                if ((enc >> 31 & 1) == 0) {
+                                if ((enc >> 30 & 1) == 0) {
+                                    if ((enc & 0xfc000000) == 0x14000000)
+                                        return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                    if ((enc & 0xfc000000) == 0x94000000)
+                                        return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                } else {
                                     if ((enc & 0xff000010) == 0x54000000)
                                         return decode_opnds_bcond(enc, dc, pc, instr, OP_bcond);
-                                    if ((enc & 0xff000000) == 0x5c000000)
-                                        return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
-                                } else {
                                     if ((enc & 0xffe0001f) == 0xd4000003)
                                         return decode_opndsgen_d4000001(enc, dc, pc, instr, OP_smc);
                                     if ((enc & 0xffe0001f) == 0xd4000001)
                                         return decode_opndsgen_d4000001(enc, dc, pc, instr, OP_svc);
                                 }
                             }
+                        } else {
+                            if ((enc >> 13 & 1) == 0) {
+                                if ((enc >> 28 & 1) == 0) {
+                                    if ((enc & 0xbffff000) == 0x0c008000)
+                                        return decode_opndsgen_0c008000(enc, dc, pc, instr, OP_st2);
+                                    if ((enc & 0xbffff000) == 0x0c004000)
+                                        return decode_opndsgen_0c004000(enc, dc, pc, instr, OP_st3);
+                                    if ((enc & 0xbffff000) == 0x0c000000)
+                                        return decode_opndsgen_0c000000(enc, dc, pc, instr, OP_st4);
+                                } else {
+                                    if ((enc & 0xff000000) == 0x1c000000)
+                                        return decode_opndsgen_1c000000(enc, dc, pc, instr, OP_ldr);
+                                    if ((enc & 0xff000000) == 0x5c000000)
+                                        return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
+                                    if ((enc & 0xff000000) == 0x9c000000)
+                                        return decode_opndsgen_9c000000(enc, dc, pc, instr, OP_ldr);
+                                }
+                            } else {
+                                if ((enc >> 28 & 1) == 0) {
+                                    if ((enc >> 14 & 1) == 0) {
+                                        if ((enc & 0xbffff000) == 0x0c002000)
+                                            return decode_opndsgen_0c000000(enc, dc, pc, instr, OP_st1);
+                                        if ((enc & 0xbffff000) == 0x0c00a000)
+                                            return decode_opndsgen_0c008000(enc, dc, pc, instr, OP_st1);
+                                    } else {
+                                        if ((enc & 0xbffff000) == 0x0c006000)
+                                            return decode_opndsgen_0c004000(enc, dc, pc, instr, OP_st1);
+                                        if ((enc & 0xbffff000) == 0x0c007000)
+                                            return decode_opndsgen_0c007000(enc, dc, pc, instr, OP_st1);
+                                    }
+                                } else {
+                                    if ((enc & 0xff000000) == 0x1c000000)
+                                        return decode_opndsgen_1c000000(enc, dc, pc, instr, OP_ldr);
+                                    if ((enc & 0xff000000) == 0x5c000000)
+                                        return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
+                                    if ((enc & 0xff000000) == 0x9c000000)
+                                        return decode_opndsgen_9c000000(enc, dc, pc, instr, OP_ldr);
+                                }
+                            }
                         }
                     } else {
-                        if ((enc >> 7 & 1) == 0) {
-                            if ((enc >> 5 & 1) == 0) {
-                                if ((enc >> 19 & 1) == 0) {
-                                    if ((enc >> 20 & 1) == 0) {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfffff0ff) == 0xd503305f)
-                                                return decode_opndsgen_d503305f(enc, dc, pc, instr, OP_clrex);
-                                            if ((enc & 0xffffffff) == 0xd503201f)
-                                                return decode_opndsgen_d503201f(enc, dc, pc, instr, OP_nop);
-                                            if ((enc & 0xffffffff) == 0xd503205f)
-                                                return decode_opndsgen_d503201f(enc, dc, pc, instr, OP_wfe);
-                                        }
+                        if ((enc >> 30 & 1) == 0) {
+                            if ((enc >> 28 & 1) == 0) {
+                                if ((enc >> 13 & 1) == 0) {
+                                    if ((enc & 0xffe0f000) == 0x0c808000)
+                                        return decode_opndsgen_0c808000(enc, dc, pc, instr, OP_st2);
+                                    if ((enc & 0xffe0f000) == 0x0c804000)
+                                        return decode_opndsgen_0c804000(enc, dc, pc, instr, OP_st3);
+                                    if ((enc & 0xffe0f000) == 0x0c800000)
+                                        return decode_opndsgen_0c800000(enc, dc, pc, instr, OP_st4);
+                                } else {
+                                    if ((enc >> 14 & 1) == 0) {
+                                        if ((enc & 0xffe0f000) == 0x0c802000)
+                                            return decode_opndsgen_0c800000(enc, dc, pc, instr, OP_st1);
+                                        if ((enc & 0xffe0f000) == 0x0c80a000)
+                                            return decode_opndsgen_0c808000(enc, dc, pc, instr, OP_st1);
                                     } else {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfff00000) == 0xd5300000)
-                                                return decode_opndsgen_d5300000(enc, dc, pc, instr, OP_mrs);
+                                        if ((enc & 0xffe0f000) == 0x0c806000)
+                                            return decode_opndsgen_0c804000(enc, dc, pc, instr, OP_st1);
+                                        if ((enc & 0xffe0f000) == 0x0c807000)
+                                            return decode_opndsgen_0c807000(enc, dc, pc, instr, OP_st1);
+                                    }
+                                }
+                            } else {
+                                if ((enc >> 27 & 1) == 0) {
+                                    if ((enc & 0xfc000000) == 0x14000000)
+                                        return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                    if ((enc & 0xfc000000) == 0x94000000)
+                                        return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                } else {
+                                    if ((enc & 0xff000000) == 0x1c000000)
+                                        return decode_opndsgen_1c000000(enc, dc, pc, instr, OP_ldr);
+                                    if ((enc & 0xff000000) == 0x9c000000)
+                                        return decode_opndsgen_9c000000(enc, dc, pc, instr, OP_ldr);
+                                }
+                            }
+                        } else {
+                            if ((enc >> 13 & 1) == 0) {
+                                if ((enc >> 28 & 1) == 0) {
+                                    if ((enc & 0xffe0f000) == 0x4c808000)
+                                        return decode_opndsgen_0c808000(enc, dc, pc, instr, OP_st2);
+                                    if ((enc & 0xffe0f000) == 0x4c804000)
+                                        return decode_opndsgen_0c804000(enc, dc, pc, instr, OP_st3);
+                                    if ((enc & 0xffe0f000) == 0x4c800000)
+                                        return decode_opndsgen_0c800000(enc, dc, pc, instr, OP_st4);
+                                } else {
+                                    if ((enc & 0xff000010) == 0x54000000)
+                                        return decode_opnds_bcond(enc, dc, pc, instr, OP_bcond);
+                                    if ((enc & 0xff000000) == 0x5c000000)
+                                        return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
+                                }
+                            } else {
+                                if ((enc >> 14 & 1) == 0) {
+                                    if ((enc >> 28 & 1) == 0) {
+                                        if ((enc & 0xffe0f000) == 0x4c802000)
+                                            return decode_opndsgen_0c800000(enc, dc, pc, instr, OP_st1);
+                                        if ((enc & 0xffe0f000) == 0x4c80a000)
+                                            return decode_opndsgen_0c808000(enc, dc, pc, instr, OP_st1);
+                                    } else {
+                                        if ((enc & 0xff000010) == 0x54000000)
+                                            return decode_opnds_bcond(enc, dc, pc, instr, OP_bcond);
+                                        if ((enc & 0xff000000) == 0x5c000000)
+                                            return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
+                                    }
+                                } else {
+                                    if ((enc >> 28 & 1) == 0) {
+                                        if ((enc & 0xffe0f000) == 0x4c806000)
+                                            return decode_opndsgen_0c804000(enc, dc, pc, instr, OP_st1);
+                                        if ((enc & 0xffe0f000) == 0x4c807000)
+                                            return decode_opndsgen_0c807000(enc, dc, pc, instr, OP_st1);
+                                    } else {
+                                        if ((enc & 0xff000010) == 0x54000000)
+                                            return decode_opnds_bcond(enc, dc, pc, instr, OP_bcond);
+                                        if ((enc & 0xff000000) == 0x5c000000)
+                                            return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    if ((enc >> 21 & 1) == 0) {
+                        if ((enc >> 27 & 1) == 0) {
+                            if ((enc >> 7 & 1) == 0) {
+                                if ((enc >> 5 & 1) == 0) {
+                                    if ((enc >> 30 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                    } else {
+                                        if ((enc >> 6 & 1) == 0) {
                                             if ((enc & 0xfff00000) == 0xd5100000)
                                                 return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
+                                            if ((enc & 0xffffffff) == 0xd503201f)
+                                                return decode_opndsgen_d503201f(enc, dc, pc, instr, OP_nop);
+                                            if ((enc & 0xfff80000) == 0xd5080000)
+                                                return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
+                                        } else {
+                                            if ((enc >> 12 & 1) == 0) {
+                                                if ((enc & 0xfff00000) == 0xd5100000)
+                                                    return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
+                                                if ((enc & 0xfff80000) == 0xd5080000)
+                                                    return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
+                                                if ((enc & 0xffffffff) == 0xd503205f)
+                                                    return decode_opndsgen_d503201f(enc, dc, pc, instr, OP_wfe);
+                                            } else {
+                                                if ((enc & 0xfffff0ff) == 0xd503305f)
+                                                    return decode_opndsgen_d503305f(enc, dc, pc, instr, OP_clrex);
+                                                if ((enc & 0xfff00000) == 0xd5100000)
+                                                    return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
+                                                if ((enc & 0xfff80000) == 0xd5080000)
+                                                    return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
+                                            }
                                         }
                                     }
                                 } else {
-                                    if ((enc >> 20 & 1) == 0) {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfff80000) == 0xd5080000)
-                                                return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
-                                            if ((enc & 0xfff80000) == 0xd5280000)
-                                                return decode_opndsgen_d5280000(enc, dc, pc, instr, OP_sys);
-                                        }
+                                    if ((enc >> 30 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
                                     } else {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfff00000) == 0xd5300000)
-                                                return decode_opndsgen_d5300000(enc, dc, pc, instr, OP_mrs);
+                                        if ((enc >> 6 & 1) == 0) {
                                             if ((enc & 0xfff00000) == 0xd5100000)
                                                 return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
+                                            if ((enc & 0xfff80000) == 0xd5080000)
+                                                return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
+                                            if ((enc & 0xffffffff) == 0xd503203f)
+                                                return decode_opndsgen_d503201f(enc, dc, pc, instr, OP_yield);
+                                        } else {
+                                            if ((enc & 0xfff00000) == 0xd5100000)
+                                                return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
+                                            if ((enc & 0xfff80000) == 0xd5080000)
+                                                return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
+                                            if ((enc & 0xffffffff) == 0xd503207f)
+                                                return decode_opndsgen_d503201f(enc, dc, pc, instr, OP_wfi);
                                         }
                                     }
                                 }
                             } else {
-                                if ((enc >> 19 & 1) == 0) {
-                                    if ((enc >> 20 & 1) == 0) {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xffffffff) == 0xd503207f)
-                                                return decode_opndsgen_d503201f(enc, dc, pc, instr, OP_wfi);
-                                            if ((enc & 0xffffffff) == 0xd503203f)
-                                                return decode_opndsgen_d503201f(enc, dc, pc, instr, OP_yield);
-                                        }
+                                if ((enc >> 5 & 1) == 0) {
+                                    if ((enc >> 30 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
                                     } else {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                        if ((enc >> 6 & 1) == 0) {
+                                            if ((enc >> 12 & 1) == 0) {
+                                                if ((enc & 0xfff00000) == 0xd5100000)
+                                                    return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
+                                                if ((enc & 0xffffffff) == 0xd503209f)
+                                                    return decode_opndsgen_d503201f(enc, dc, pc, instr, OP_sev);
+                                                if ((enc & 0xfff80000) == 0xd5080000)
+                                                    return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
+                                            } else {
+                                                if ((enc & 0xfffff0ff) == 0xd503309f)
+                                                    return decode_opndsgen_d503305f(enc, dc, pc, instr, OP_dsb);
+                                                if ((enc & 0xfff00000) == 0xd5100000)
+                                                    return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
+                                                if ((enc & 0xfff80000) == 0xd5080000)
+                                                    return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
+                                            }
                                         } else {
-                                            if ((enc & 0xfff00000) == 0xd5300000)
-                                                return decode_opndsgen_d5300000(enc, dc, pc, instr, OP_mrs);
+                                            if ((enc & 0xfffff0ff) == 0xd50330df)
+                                                return decode_opndsgen_d503305f(enc, dc, pc, instr, OP_isb);
                                             if ((enc & 0xfff00000) == 0xd5100000)
                                                 return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
+                                            if ((enc & 0xfff80000) == 0xd5080000)
+                                                return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
                                         }
                                     }
                                 } else {
-                                    if ((enc >> 20 & 1) == 0) {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfff80000) == 0xd5080000)
-                                                return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
-                                            if ((enc & 0xfff80000) == 0xd5280000)
-                                                return decode_opndsgen_d5280000(enc, dc, pc, instr, OP_sys);
-                                        }
+                                    if ((enc >> 30 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
                                     } else {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfff00000) == 0xd5300000)
-                                                return decode_opndsgen_d5300000(enc, dc, pc, instr, OP_mrs);
+                                        if ((enc >> 12 & 1) == 0) {
                                             if ((enc & 0xfff00000) == 0xd5100000)
                                                 return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
+                                            if ((enc & 0xffffffff) == 0xd50320bf)
+                                                return decode_opndsgen_d503201f(enc, dc, pc, instr, OP_sevl);
+                                            if ((enc & 0xfff80000) == 0xd5080000)
+                                                return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
+                                        } else {
+                                            if ((enc & 0xfffff0ff) == 0xd50330bf)
+                                                return decode_opndsgen_d503305f(enc, dc, pc, instr, OP_dmb);
+                                            if ((enc & 0xfff00000) == 0xd5100000)
+                                                return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
+                                            if ((enc & 0xfff80000) == 0xd5080000)
+                                                return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
                                         }
                                     }
                                 }
                             }
                         } else {
-                            if ((enc >> 5 & 1) == 0) {
-                                if ((enc >> 19 & 1) == 0) {
-                                    if ((enc >> 20 & 1) == 0) {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfffff0ff) == 0xd503309f)
-                                                return decode_opndsgen_d503305f(enc, dc, pc, instr, OP_dsb);
-                                            if ((enc & 0xfffff0ff) == 0xd50330df)
-                                                return decode_opndsgen_d503305f(enc, dc, pc, instr, OP_isb);
-                                            if ((enc & 0xffffffff) == 0xd503209f)
-                                                return decode_opndsgen_d503201f(enc, dc, pc, instr, OP_sev);
-                                        }
+                            if ((enc >> 13 & 1) == 0) {
+                                if ((enc >> 15 & 1) == 0) {
+                                    if ((enc >> 14 & 1) == 0) {
+                                        if ((enc & 0xbfffe000) == 0x0d000000)
+                                            return decode_opndsgen_0d000000(enc, dc, pc, instr, OP_st1);
+                                        if ((enc & 0xbfe0e000) == 0x0d800000)
+                                            return decode_opndsgen_0d800000(enc, dc, pc, instr, OP_st1);
                                     } else {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfff00000) == 0xd5300000)
-                                                return decode_opndsgen_d5300000(enc, dc, pc, instr, OP_mrs);
-                                            if ((enc & 0xfff00000) == 0xd5100000)
-                                                return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
-                                        }
+                                        if ((enc & 0xbfffe400) == 0x0d004000)
+                                            return decode_opndsgen_0d004000(enc, dc, pc, instr, OP_st1);
+                                        if ((enc & 0xbfe0e400) == 0x0d804000)
+                                            return decode_opndsgen_0d804000(enc, dc, pc, instr, OP_st1);
                                     }
                                 } else {
-                                    if ((enc >> 20 & 1) == 0) {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfff80000) == 0xd5080000)
-                                                return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
-                                            if ((enc & 0xfff80000) == 0xd5280000)
-                                                return decode_opndsgen_d5280000(enc, dc, pc, instr, OP_sys);
-                                        }
+                                    if ((enc >> 10 & 1) == 0) {
+                                        if ((enc & 0xbfffec00) == 0x0d008000)
+                                            return decode_opndsgen_0d008000(enc, dc, pc, instr, OP_st1);
+                                        if ((enc & 0xbfe0ec00) == 0x0d808000)
+                                            return decode_opndsgen_0d808000(enc, dc, pc, instr, OP_st1);
                                     } else {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfff00000) == 0xd5300000)
-                                                return decode_opndsgen_d5300000(enc, dc, pc, instr, OP_mrs);
-                                            if ((enc & 0xfff00000) == 0xd5100000)
-                                                return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
-                                        }
+                                        if ((enc & 0xbffffc00) == 0x0d008400)
+                                            return decode_opndsgen_0d008400(enc, dc, pc, instr, OP_st1);
+                                        if ((enc & 0xbfe0fc00) == 0x0d808400)
+                                            return decode_opndsgen_0d808400(enc, dc, pc, instr, OP_st1);
                                     }
                                 }
                             } else {
-                                if ((enc >> 19 & 1) == 0) {
-                                    if ((enc >> 20 & 1) == 0) {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfffff0ff) == 0xd50330bf)
-                                                return decode_opndsgen_d503305f(enc, dc, pc, instr, OP_dmb);
-                                            if ((enc & 0xffffffff) == 0xd50320bf)
-                                                return decode_opndsgen_d503201f(enc, dc, pc, instr, OP_sevl);
-                                        }
+                                if ((enc >> 15 & 1) == 0) {
+                                    if ((enc >> 14 & 1) == 0) {
+                                        if ((enc & 0xbfffe000) == 0x0d002000)
+                                            return decode_opndsgen_0d002000(enc, dc, pc, instr, OP_st3);
+                                        if ((enc & 0xbfe0e000) == 0x0d802000)
+                                            return decode_opndsgen_0d802000(enc, dc, pc, instr, OP_st3);
                                     } else {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfff00000) == 0xd5300000)
-                                                return decode_opndsgen_d5300000(enc, dc, pc, instr, OP_mrs);
-                                            if ((enc & 0xfff00000) == 0xd5100000)
-                                                return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
-                                        }
+                                        if ((enc & 0xbfffe400) == 0x0d006000)
+                                            return decode_opndsgen_0d006000(enc, dc, pc, instr, OP_st3);
+                                        if ((enc & 0xbfe0e400) == 0x0d806000)
+                                            return decode_opndsgen_0d806000(enc, dc, pc, instr, OP_st3);
                                     }
                                 } else {
-                                    if ((enc >> 20 & 1) == 0) {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfff80000) == 0xd5080000)
-                                                return decode_opndsgen_d5080000(enc, dc, pc, instr, OP_sys);
-                                            if ((enc & 0xfff80000) == 0xd5280000)
-                                                return decode_opndsgen_d5280000(enc, dc, pc, instr, OP_sys);
-                                        }
+                                    if ((enc >> 10 & 1) == 0) {
+                                        if ((enc & 0xbfffec00) == 0x0d00a000)
+                                            return decode_opndsgen_0d00a000(enc, dc, pc, instr, OP_st3);
+                                        if ((enc & 0xbfe0ec00) == 0x0d80a000)
+                                            return decode_opndsgen_0d80a000(enc, dc, pc, instr, OP_st3);
                                     } else {
-                                        if ((enc >> 30 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xfff00000) == 0xd5300000)
-                                                return decode_opndsgen_d5300000(enc, dc, pc, instr, OP_mrs);
-                                            if ((enc & 0xfff00000) == 0xd5100000)
-                                                return decode_opnds_msr(enc, dc, pc, instr, OP_msr);
-                                        }
+                                        if ((enc & 0xbffffc00) == 0x0d00a400)
+                                            return decode_opndsgen_0d00a400(enc, dc, pc, instr, OP_st3);
+                                        if ((enc & 0xbfe0fc00) == 0x0d80a400)
+                                            return decode_opndsgen_0d80a400(enc, dc, pc, instr, OP_st3);
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        if ((enc >> 13 & 1) == 0) {
+                            if ((enc >> 15 & 1) == 0) {
+                                if ((enc >> 27 & 1) == 0) {
+                                    if ((enc >> 30 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                    } else {
+                                        if ((enc & 0xfff00000) == 0xd5300000)
+                                            return decode_opndsgen_d5300000(enc, dc, pc, instr, OP_mrs);
+                                        if ((enc & 0xfff80000) == 0xd5280000)
+                                            return decode_opndsgen_d5280000(enc, dc, pc, instr, OP_sys);
+                                    }
+                                } else {
+                                    if ((enc >> 14 & 1) == 0) {
+                                        if ((enc & 0xbfffe000) == 0x0d200000)
+                                            return decode_opndsgen_0d200000(enc, dc, pc, instr, OP_st2);
+                                        if ((enc & 0xbfe0e000) == 0x0da00000)
+                                            return decode_opndsgen_0da00000(enc, dc, pc, instr, OP_st2);
+                                    } else {
+                                        if ((enc & 0xbfffe400) == 0x0d204000)
+                                            return decode_opndsgen_0d204000(enc, dc, pc, instr, OP_st2);
+                                        if ((enc & 0xbfe0e400) == 0x0da04000)
+                                            return decode_opndsgen_0da04000(enc, dc, pc, instr, OP_st2);
+                                    }
+                                }
+                            } else {
+                                if ((enc >> 27 & 1) == 0) {
+                                    if ((enc >> 30 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                    } else {
+                                        if ((enc & 0xfff00000) == 0xd5300000)
+                                            return decode_opndsgen_d5300000(enc, dc, pc, instr, OP_mrs);
+                                        if ((enc & 0xfff80000) == 0xd5280000)
+                                            return decode_opndsgen_d5280000(enc, dc, pc, instr, OP_sys);
+                                    }
+                                } else {
+                                    if ((enc >> 10 & 1) == 0) {
+                                        if ((enc & 0xbfffec00) == 0x0d208000)
+                                            return decode_opndsgen_0d208000(enc, dc, pc, instr, OP_st2);
+                                        if ((enc & 0xbfe0ec00) == 0x0da08000)
+                                            return decode_opndsgen_0da08000(enc, dc, pc, instr, OP_st2);
+                                    } else {
+                                        if ((enc & 0xbffffc00) == 0x0d208400)
+                                            return decode_opndsgen_0d208400(enc, dc, pc, instr, OP_st2);
+                                        if ((enc & 0xbfe0fc00) == 0x0da08400)
+                                            return decode_opndsgen_0da08400(enc, dc, pc, instr, OP_st2);
+                                    }
+                                }
+                            }
+                        } else {
+                            if ((enc >> 15 & 1) == 0) {
+                                if ((enc >> 27 & 1) == 0) {
+                                    if ((enc >> 30 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                    } else {
+                                        if ((enc & 0xfff00000) == 0xd5300000)
+                                            return decode_opndsgen_d5300000(enc, dc, pc, instr, OP_mrs);
+                                        if ((enc & 0xfff80000) == 0xd5280000)
+                                            return decode_opndsgen_d5280000(enc, dc, pc, instr, OP_sys);
+                                    }
+                                } else {
+                                    if ((enc >> 14 & 1) == 0) {
+                                        if ((enc & 0xbfffe000) == 0x0d202000)
+                                            return decode_opndsgen_0d202000(enc, dc, pc, instr, OP_st4);
+                                        if ((enc & 0xbfe0e000) == 0x0da02000)
+                                            return decode_opndsgen_0da02000(enc, dc, pc, instr, OP_st4);
+                                    } else {
+                                        if ((enc & 0xbfffe400) == 0x0d206000)
+                                            return decode_opndsgen_0d206000(enc, dc, pc, instr, OP_st4);
+                                        if ((enc & 0xbfe0e400) == 0x0da06000)
+                                            return decode_opndsgen_0da06000(enc, dc, pc, instr, OP_st4);
+                                    }
+                                }
+                            } else {
+                                if ((enc >> 27 & 1) == 0) {
+                                    if ((enc >> 30 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                    } else {
+                                        if ((enc & 0xfff00000) == 0xd5300000)
+                                            return decode_opndsgen_d5300000(enc, dc, pc, instr, OP_mrs);
+                                        if ((enc & 0xfff80000) == 0xd5280000)
+                                            return decode_opndsgen_d5280000(enc, dc, pc, instr, OP_sys);
+                                    }
+                                } else {
+                                    if ((enc >> 10 & 1) == 0) {
+                                        if ((enc & 0xbfffec00) == 0x0d20a000)
+                                            return decode_opndsgen_0d20a000(enc, dc, pc, instr, OP_st4);
+                                        if ((enc & 0xbfe0ec00) == 0x0da0a000)
+                                            return decode_opndsgen_0da0a000(enc, dc, pc, instr, OP_st4);
+                                    } else {
+                                        if ((enc & 0xbffffc00) == 0x0d20a400)
+                                            return decode_opndsgen_0d20a400(enc, dc, pc, instr, OP_st4);
+                                        if ((enc & 0xbfe0fc00) == 0x0da0a400)
+                                            return decode_opndsgen_0da0a400(enc, dc, pc, instr, OP_st4);
                                     }
                                 }
                             }
@@ -7704,43 +7722,50 @@ decoder(uint enc, dcontext_t *dc, byte *pc, instr_t *instr)
                     }
                 }
             } else {
-                if ((enc >> 13 & 1) == 0) {
-                    if ((enc >> 14 & 1) == 0) {
+                if ((enc >> 14 & 1) == 0) {
+                    if ((enc >> 13 & 1) == 0) {
                         if ((enc >> 24 & 1) == 0) {
-                            if ((enc >> 27 & 1) == 0) {
-                                if ((enc >> 30 & 1) == 0) {
-                                    if ((enc & 0xfc000000) == 0x14000000)
-                                        return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                    if ((enc & 0xfc000000) == 0x94000000)
-                                        return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                            if ((enc >> 28 & 1) == 0) {
+                                if ((enc >> 15 & 1) == 0) {
+                                    if ((enc & 0xbffff000) == 0x0c400000)
+                                        return decode_opndsgen_0c400000(enc, dc, pc, instr, OP_ld4);
+                                    if ((enc & 0xffe0f000) == 0x0cc00000)
+                                        return decode_opndsgen_0cc00000(enc, dc, pc, instr, OP_ld4);
+                                    if ((enc & 0xffe0f000) == 0x4cc00000)
+                                        return decode_opndsgen_0cc00000(enc, dc, pc, instr, OP_ld4);
                                 } else {
-                                    if ((enc & 0xff000010) == 0x54000000)
-                                        return decode_opnds_bcond(enc, dc, pc, instr, OP_bcond);
-                                    if ((enc & 0xffe0001f) == 0xd4400000)
-                                        return decode_opndsgen_d4000001(enc, dc, pc, instr, OP_hlt);
-                                    if ((enc & 0xfffffc1f) == 0xd65f0000)
-                                        return decode_opndsgen_d61f0000(enc, dc, pc, instr, OP_ret);
+                                    if ((enc & 0xbffff000) == 0x0c408000)
+                                        return decode_opndsgen_0c408000(enc, dc, pc, instr, OP_ld2);
+                                    if ((enc & 0xffe0f000) == 0x0cc08000)
+                                        return decode_opndsgen_0cc08000(enc, dc, pc, instr, OP_ld2);
+                                    if ((enc & 0xffe0f000) == 0x4cc08000)
+                                        return decode_opndsgen_0cc08000(enc, dc, pc, instr, OP_ld2);
                                 }
                             } else {
-                                if ((enc >> 28 & 1) == 0) {
-                                    if ((enc >> 15 & 1) == 0) {
-                                        if ((enc & 0xbffff000) == 0x0c400000)
-                                            return decode_opndsgen_0c400000(enc, dc, pc, instr, OP_ld4);
-                                        if ((enc & 0xbfe0f000) == 0x0cc00000)
-                                            return decode_opndsgen_0cc00000(enc, dc, pc, instr, OP_ld4);
+                                if ((enc >> 30 & 1) == 0) {
+                                    if ((enc >> 27 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
                                     } else {
-                                        if ((enc & 0xbffff000) == 0x0c408000)
-                                            return decode_opndsgen_0c408000(enc, dc, pc, instr, OP_ld2);
-                                        if ((enc & 0xbfe0f000) == 0x0cc08000)
-                                            return decode_opndsgen_0cc08000(enc, dc, pc, instr, OP_ld2);
+                                        if ((enc & 0xff000000) == 0x1c000000)
+                                            return decode_opndsgen_1c000000(enc, dc, pc, instr, OP_ldr);
+                                        if ((enc & 0xff000000) == 0x9c000000)
+                                            return decode_opndsgen_9c000000(enc, dc, pc, instr, OP_ldr);
                                     }
                                 } else {
-                                    if ((enc & 0xff000000) == 0x1c000000)
-                                        return decode_opndsgen_1c000000(enc, dc, pc, instr, OP_ldr);
-                                    if ((enc & 0xff000000) == 0x5c000000)
-                                        return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
-                                    if ((enc & 0xff000000) == 0x9c000000)
-                                        return decode_opndsgen_9c000000(enc, dc, pc, instr, OP_ldr);
+                                    if ((enc >> 31 & 1) == 0) {
+                                        if ((enc & 0xff000010) == 0x54000000)
+                                            return decode_opnds_bcond(enc, dc, pc, instr, OP_bcond);
+                                        if ((enc & 0xff000000) == 0x5c000000)
+                                            return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
+                                    } else {
+                                        if ((enc & 0xffe0001f) == 0xd4400000)
+                                            return decode_opndsgen_d4000001(enc, dc, pc, instr, OP_hlt);
+                                        if ((enc & 0xfffffc1f) == 0xd65f0000)
+                                            return decode_opndsgen_d61f0000(enc, dc, pc, instr, OP_ret);
+                                    }
                                 }
                             }
                         } else {
@@ -7807,8 +7832,24 @@ decoder(uint enc, dcontext_t *dc, byte *pc, instr_t *instr)
                             }
                         }
                     } else {
-                        if ((enc >> 21 & 1) == 0) {
-                            if ((enc >> 24 & 1) == 0) {
+                        if ((enc >> 24 & 1) == 0) {
+                            if ((enc >> 28 & 1) == 0) {
+                                if ((enc >> 15 & 1) == 0) {
+                                    if ((enc & 0xbffff000) == 0x0c402000)
+                                        return decode_opndsgen_0c400000(enc, dc, pc, instr, OP_ld1);
+                                    if ((enc & 0xffe0f000) == 0x0cc02000)
+                                        return decode_opndsgen_0cc00000(enc, dc, pc, instr, OP_ld1);
+                                    if ((enc & 0xffe0f000) == 0x4cc02000)
+                                        return decode_opndsgen_0cc00000(enc, dc, pc, instr, OP_ld1);
+                                } else {
+                                    if ((enc & 0xbffff000) == 0x0c40a000)
+                                        return decode_opndsgen_0c408000(enc, dc, pc, instr, OP_ld1);
+                                    if ((enc & 0xffe0f000) == 0x0cc0a000)
+                                        return decode_opndsgen_0cc08000(enc, dc, pc, instr, OP_ld1);
+                                    if ((enc & 0xffe0f000) == 0x4cc0a000)
+                                        return decode_opndsgen_0cc08000(enc, dc, pc, instr, OP_ld1);
+                                }
+                            } else {
                                 if ((enc >> 27 & 1) == 0) {
                                     if ((enc >> 30 & 1) == 0) {
                                         if ((enc & 0xfc000000) == 0x14000000)
@@ -7820,137 +7861,6 @@ decoder(uint enc, dcontext_t *dc, byte *pc, instr_t *instr)
                                             return decode_opnds_bcond(enc, dc, pc, instr, OP_bcond);
                                         if ((enc & 0xffe0001f) == 0xd4400000)
                                             return decode_opndsgen_d4000001(enc, dc, pc, instr, OP_hlt);
-                                    }
-                                } else {
-                                    if ((enc >> 28 & 1) == 0) {
-                                        if ((enc & 0xbffff000) == 0x0c404000)
-                                            return decode_opndsgen_0c404000(enc, dc, pc, instr, OP_ld3);
-                                        if ((enc & 0xbfe0f000) == 0x0cc04000)
-                                            return decode_opndsgen_0cc04000(enc, dc, pc, instr, OP_ld3);
-                                    } else {
-                                        if ((enc & 0xff000000) == 0x1c000000)
-                                            return decode_opndsgen_1c000000(enc, dc, pc, instr, OP_ldr);
-                                        if ((enc & 0xff000000) == 0x5c000000)
-                                            return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
-                                        if ((enc & 0xff000000) == 0x9c000000)
-                                            return decode_opndsgen_9c000000(enc, dc, pc, instr, OP_ldr);
-                                    }
-                                }
-                            } else {
-                                if ((enc >> 10 & 1) == 0) {
-                                    if ((enc >> 15 & 1) == 0) {
-                                        if ((enc >> 27 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xbfffe400) == 0x0d404000)
-                                                return decode_opndsgen_0d404000(enc, dc, pc, instr, OP_ld1);
-                                            if ((enc & 0xbfe0e400) == 0x0dc04000)
-                                                return decode_opndsgen_0dc04000(enc, dc, pc, instr, OP_ld1);
-                                        }
-                                    } else {
-                                        if ((enc >> 27 & 1) == 0) {
-                                            if ((enc & 0xfc000000) == 0x14000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                            if ((enc & 0xfc000000) == 0x94000000)
-                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                        } else {
-                                            if ((enc & 0xbffff000) == 0x0d40c000)
-                                                return decode_opndsgen_0d40c000(enc, dc, pc, instr, OP_ld1r);
-                                            if ((enc & 0xbfe0fc00) == 0x0dc0c000)
-                                                return decode_opndsgen_0dc0c000(enc, dc, pc, instr, OP_ld1r);
-                                            if ((enc & 0xbfe0fc00) == 0x0dc0c800)
-                                                return decode_opndsgen_0dc0c000(enc, dc, pc, instr, OP_ld1r);
-                                        }
-                                    }
-                                } else {
-                                    if ((enc >> 27 & 1) == 0) {
-                                        if ((enc & 0xfc000000) == 0x14000000)
-                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                        if ((enc & 0xfc000000) == 0x94000000)
-                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                    } else {
-                                        if ((enc & 0xbffff000) == 0x0d40c000)
-                                            return decode_opndsgen_0d40c000(enc, dc, pc, instr, OP_ld1r);
-                                        if ((enc & 0xbfe0fc00) == 0x0dc0c400)
-                                            return decode_opndsgen_0dc0c000(enc, dc, pc, instr, OP_ld1r);
-                                        if ((enc & 0xbfe0fc00) == 0x0dc0cc00)
-                                            return decode_opndsgen_0dc0c000(enc, dc, pc, instr, OP_ld1r);
-                                    }
-                                }
-                            }
-                        } else {
-                            if ((enc >> 28 & 1) == 0) {
-                                if ((enc >> 10 & 1) == 0) {
-                                    if ((enc >> 15 & 1) == 0) {
-                                        if ((enc & 0xbfffe400) == 0x0d604000)
-                                            return decode_opndsgen_0d604000(enc, dc, pc, instr, OP_ld2);
-                                        if ((enc & 0xbfe0e400) == 0x0de04000)
-                                            return decode_opndsgen_0de04000(enc, dc, pc, instr, OP_ld2);
-                                    } else {
-                                        if ((enc & 0xbffff000) == 0x0d60c000)
-                                            return decode_opndsgen_0d60c000(enc, dc, pc, instr, OP_ld2r);
-                                        if ((enc & 0xbfe0fc00) == 0x0de0c000)
-                                            return decode_opndsgen_0de0c000(enc, dc, pc, instr, OP_ld2r);
-                                        if ((enc & 0xbfe0fc00) == 0x0de0c800)
-                                            return decode_opndsgen_0de0c000(enc, dc, pc, instr, OP_ld2r);
-                                    }
-                                } else {
-                                    if ((enc & 0xbffff000) == 0x0d60c000)
-                                        return decode_opndsgen_0d60c000(enc, dc, pc, instr, OP_ld2r);
-                                    if ((enc & 0xbfe0fc00) == 0x0de0c400)
-                                        return decode_opndsgen_0de0c000(enc, dc, pc, instr, OP_ld2r);
-                                    if ((enc & 0xbfe0fc00) == 0x0de0cc00)
-                                        return decode_opndsgen_0de0c000(enc, dc, pc, instr, OP_ld2r);
-                                }
-                            } else {
-                                if ((enc >> 27 & 1) == 0) {
-                                    if ((enc & 0xfc000000) == 0x14000000)
-                                        return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                    if ((enc & 0xff000010) == 0x54000000)
-                                        return decode_opnds_bcond(enc, dc, pc, instr, OP_bcond);
-                                    if ((enc & 0xfc000000) == 0x94000000)
-                                        return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                } else {
-                                    if ((enc & 0xff000000) == 0x1c000000)
-                                        return decode_opndsgen_1c000000(enc, dc, pc, instr, OP_ldr);
-                                    if ((enc & 0xff000000) == 0x5c000000)
-                                        return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
-                                    if ((enc & 0xff000000) == 0x9c000000)
-                                        return decode_opndsgen_9c000000(enc, dc, pc, instr, OP_ldr);
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    if ((enc >> 14 & 1) == 0) {
-                        if ((enc >> 24 & 1) == 0) {
-                            if ((enc >> 27 & 1) == 0) {
-                                if ((enc >> 30 & 1) == 0) {
-                                    if ((enc & 0xfc000000) == 0x14000000)
-                                        return decode_opnds_b(enc, dc, pc, instr, OP_b);
-                                    if ((enc & 0xfc000000) == 0x94000000)
-                                        return decode_opnds_b(enc, dc, pc, instr, OP_bl);
-                                } else {
-                                    if ((enc & 0xff000010) == 0x54000000)
-                                        return decode_opnds_bcond(enc, dc, pc, instr, OP_bcond);
-                                    if ((enc & 0xffe0001f) == 0xd4400000)
-                                        return decode_opndsgen_d4000001(enc, dc, pc, instr, OP_hlt);
-                                }
-                            } else {
-                                if ((enc >> 28 & 1) == 0) {
-                                    if ((enc >> 15 & 1) == 0) {
-                                        if ((enc & 0xbffff000) == 0x0c402000)
-                                            return decode_opndsgen_0c400000(enc, dc, pc, instr, OP_ld1);
-                                        if ((enc & 0xbfe0f000) == 0x0cc02000)
-                                            return decode_opndsgen_0cc00000(enc, dc, pc, instr, OP_ld1);
-                                    } else {
-                                        if ((enc & 0xbffff000) == 0x0c40a000)
-                                            return decode_opndsgen_0c408000(enc, dc, pc, instr, OP_ld1);
-                                        if ((enc & 0xbfe0f000) == 0x0cc0a000)
-                                            return decode_opndsgen_0cc08000(enc, dc, pc, instr, OP_ld1);
                                     }
                                 } else {
                                     if ((enc & 0xff000000) == 0x1c000000)
@@ -8024,7 +7934,9 @@ decoder(uint enc, dcontext_t *dc, byte *pc, instr_t *instr)
                                 }
                             }
                         }
-                    } else {
+                    }
+                } else {
+                    if ((enc >> 13 & 1) == 0) {
                         if ((enc >> 24 & 1) == 0) {
                             if ((enc >> 27 & 1) == 0) {
                                 if ((enc >> 30 & 1) == 0) {
@@ -8040,16 +7952,142 @@ decoder(uint enc, dcontext_t *dc, byte *pc, instr_t *instr)
                                 }
                             } else {
                                 if ((enc >> 28 & 1) == 0) {
-                                    if ((enc >> 12 & 1) == 0) {
-                                        if ((enc & 0xbffff000) == 0x0c406000)
-                                            return decode_opndsgen_0c404000(enc, dc, pc, instr, OP_ld1);
-                                        if ((enc & 0xbfe0f000) == 0x0cc06000)
-                                            return decode_opndsgen_0cc04000(enc, dc, pc, instr, OP_ld1);
+                                    if ((enc & 0xbffff000) == 0x0c404000)
+                                        return decode_opndsgen_0c404000(enc, dc, pc, instr, OP_ld3);
+                                    if ((enc & 0xffe0f000) == 0x0cc04000)
+                                        return decode_opndsgen_0cc04000(enc, dc, pc, instr, OP_ld3);
+                                    if ((enc & 0xffe0f000) == 0x4cc04000)
+                                        return decode_opndsgen_0cc04000(enc, dc, pc, instr, OP_ld3);
+                                } else {
+                                    if ((enc & 0xff000000) == 0x1c000000)
+                                        return decode_opndsgen_1c000000(enc, dc, pc, instr, OP_ldr);
+                                    if ((enc & 0xff000000) == 0x5c000000)
+                                        return decode_opndsgen_5c000000(enc, dc, pc, instr, OP_ldr);
+                                    if ((enc & 0xff000000) == 0x9c000000)
+                                        return decode_opndsgen_9c000000(enc, dc, pc, instr, OP_ldr);
+                                }
+                            }
+                        } else {
+                            if ((enc >> 21 & 1) == 0) {
+                                if ((enc >> 10 & 1) == 0) {
+                                    if ((enc >> 15 & 1) == 0) {
+                                        if ((enc >> 27 & 1) == 0) {
+                                            if ((enc & 0xfc000000) == 0x14000000)
+                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                            if ((enc & 0xfc000000) == 0x94000000)
+                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                        } else {
+                                            if ((enc & 0xbfffe400) == 0x0d404000)
+                                                return decode_opndsgen_0d404000(enc, dc, pc, instr, OP_ld1);
+                                            if ((enc & 0xbfe0e400) == 0x0dc04000)
+                                                return decode_opndsgen_0dc04000(enc, dc, pc, instr, OP_ld1);
+                                        }
                                     } else {
-                                        if ((enc & 0xbffff000) == 0x0c407000)
-                                            return decode_opndsgen_0c407000(enc, dc, pc, instr, OP_ld1);
-                                        if ((enc & 0xbfe0f000) == 0x0cc07000)
-                                            return decode_opndsgen_0cc07000(enc, dc, pc, instr, OP_ld1);
+                                        if ((enc >> 27 & 1) == 0) {
+                                            if ((enc & 0xfc000000) == 0x14000000)
+                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                            if ((enc & 0xfc000000) == 0x94000000)
+                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                        } else {
+                                            if ((enc & 0xbffff000) == 0x0d40c000)
+                                                return decode_opndsgen_0d40c000(enc, dc, pc, instr, OP_ld1r);
+                                            if ((enc & 0xbfe0fc00) == 0x0dc0c000)
+                                                return decode_opndsgen_0dc0c000(enc, dc, pc, instr, OP_ld1r);
+                                            if ((enc & 0xbfe0fc00) == 0x0dc0c800)
+                                                return decode_opndsgen_0dc0c000(enc, dc, pc, instr, OP_ld1r);
+                                        }
+                                    }
+                                } else {
+                                    if ((enc >> 27 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                    } else {
+                                        if ((enc & 0xbffff000) == 0x0d40c000)
+                                            return decode_opndsgen_0d40c000(enc, dc, pc, instr, OP_ld1r);
+                                        if ((enc & 0xbfe0fc00) == 0x0dc0c400)
+                                            return decode_opndsgen_0dc0c000(enc, dc, pc, instr, OP_ld1r);
+                                        if ((enc & 0xbfe0fc00) == 0x0dc0cc00)
+                                            return decode_opndsgen_0dc0c000(enc, dc, pc, instr, OP_ld1r);
+                                    }
+                                }
+                            } else {
+                                if ((enc >> 10 & 1) == 0) {
+                                    if ((enc >> 15 & 1) == 0) {
+                                        if ((enc >> 27 & 1) == 0) {
+                                            if ((enc & 0xfc000000) == 0x14000000)
+                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                            if ((enc & 0xfc000000) == 0x94000000)
+                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                        } else {
+                                            if ((enc & 0xbfffe400) == 0x0d604000)
+                                                return decode_opndsgen_0d604000(enc, dc, pc, instr, OP_ld2);
+                                            if ((enc & 0xbfe0e400) == 0x0de04000)
+                                                return decode_opndsgen_0de04000(enc, dc, pc, instr, OP_ld2);
+                                        }
+                                    } else {
+                                        if ((enc >> 27 & 1) == 0) {
+                                            if ((enc & 0xfc000000) == 0x14000000)
+                                                return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                            if ((enc & 0xfc000000) == 0x94000000)
+                                                return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                        } else {
+                                            if ((enc & 0xbffff000) == 0x0d60c000)
+                                                return decode_opndsgen_0d60c000(enc, dc, pc, instr, OP_ld2r);
+                                            if ((enc & 0xbfe0fc00) == 0x0de0c000)
+                                                return decode_opndsgen_0de0c000(enc, dc, pc, instr, OP_ld2r);
+                                            if ((enc & 0xbfe0fc00) == 0x0de0c800)
+                                                return decode_opndsgen_0de0c000(enc, dc, pc, instr, OP_ld2r);
+                                        }
+                                    }
+                                } else {
+                                    if ((enc >> 27 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                    } else {
+                                        if ((enc & 0xbffff000) == 0x0d60c000)
+                                            return decode_opndsgen_0d60c000(enc, dc, pc, instr, OP_ld2r);
+                                        if ((enc & 0xbfe0fc00) == 0x0de0c400)
+                                            return decode_opndsgen_0de0c000(enc, dc, pc, instr, OP_ld2r);
+                                        if ((enc & 0xbfe0fc00) == 0x0de0cc00)
+                                            return decode_opndsgen_0de0c000(enc, dc, pc, instr, OP_ld2r);
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        if ((enc >> 24 & 1) == 0) {
+                            if ((enc >> 28 & 1) == 0) {
+                                if ((enc >> 12 & 1) == 0) {
+                                    if ((enc & 0xbffff000) == 0x0c406000)
+                                        return decode_opndsgen_0c404000(enc, dc, pc, instr, OP_ld1);
+                                    if ((enc & 0xffe0f000) == 0x0cc06000)
+                                        return decode_opndsgen_0cc04000(enc, dc, pc, instr, OP_ld1);
+                                    if ((enc & 0xffe0f000) == 0x4cc06000)
+                                        return decode_opndsgen_0cc04000(enc, dc, pc, instr, OP_ld1);
+                                } else {
+                                    if ((enc & 0xbffff000) == 0x0c407000)
+                                        return decode_opndsgen_0c407000(enc, dc, pc, instr, OP_ld1);
+                                    if ((enc & 0xffe0f000) == 0x0cc07000)
+                                        return decode_opndsgen_0cc07000(enc, dc, pc, instr, OP_ld1);
+                                    if ((enc & 0xffe0f000) == 0x4cc07000)
+                                        return decode_opndsgen_0cc07000(enc, dc, pc, instr, OP_ld1);
+                                }
+                            } else {
+                                if ((enc >> 27 & 1) == 0) {
+                                    if ((enc >> 30 & 1) == 0) {
+                                        if ((enc & 0xfc000000) == 0x14000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_b);
+                                        if ((enc & 0xfc000000) == 0x94000000)
+                                            return decode_opnds_b(enc, dc, pc, instr, OP_bl);
+                                    } else {
+                                        if ((enc & 0xff000010) == 0x54000000)
+                                            return decode_opnds_bcond(enc, dc, pc, instr, OP_bcond);
+                                        if ((enc & 0xffe0001f) == 0xd4400000)
+                                            return decode_opndsgen_d4000001(enc, dc, pc, instr, OP_hlt);
                                     }
                                 } else {
                                     if ((enc & 0xff000000) == 0x1c000000)

--- a/core/arch/aarch64/encode_gen.h
+++ b/core/arch/aarch64/encode_gen.h
@@ -4,7 +4,7 @@ static uint
 encode_opndsgen_08000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem0(enc & 0xffe083e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w16(enc & 0xffff8000, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -28,7 +28,7 @@ static uint
 encode_opndsgen_08207c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 5 &&
         encode_opnd_w16p0(enc & 0xfffffc00, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w16p1(enc & 0xfffffc00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -64,7 +64,7 @@ static uint
 encode_opndsgen_08400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem0(enc & 0xffe083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -88,7 +88,7 @@ static uint
 encode_opndsgen_08808000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem0(enc & 0xffe083e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xffe0801f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -112,7 +112,7 @@ static uint
 encode_opndsgen_08a07c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w16(enc & 0xfffffc00, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem0(enc & 0xffe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -139,7 +139,7 @@ static uint
 encode_opndsgen_0a000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0(enc & 0xff20801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xff2083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -166,7 +166,7 @@ static uint
 encode_opndsgen_0b000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0(enc & 0xff20801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xff2083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -193,7 +193,7 @@ static uint
 encode_opndsgen_0b200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0sp(enc & 0xffe0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5sp(enc & 0xffe003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -220,7 +220,7 @@ static uint
 encode_opndsgen_0c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3, src4;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvm(enc & 0xfffff3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vmsz(enc & 0xbffffc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -250,7 +250,7 @@ static uint
 encode_opndsgen_0c004000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvm(enc & 0xfffff3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vmsz(enc & 0xbffffc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -277,7 +277,7 @@ static uint
 encode_opndsgen_0c007000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_memvm(enc & 0xfffff3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vmsz(enc & 0xbffffc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -298,7 +298,7 @@ static uint
 encode_opndsgen_0c008000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_memvm(enc & 0xfffff3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vmsz(enc & 0xbffffc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -322,7 +322,7 @@ static uint
 encode_opndsgen_0c400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 2 &&
         encode_opnd_vt0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vt1(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -352,7 +352,7 @@ static uint
 encode_opndsgen_0c404000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 2 &&
         encode_opnd_vt0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vt1(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -379,7 +379,7 @@ static uint
 encode_opndsgen_0c407000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_vt0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memvm(enc & 0xfffff3e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -400,7 +400,7 @@ static uint
 encode_opndsgen_0c408000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_vt0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vt1(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -424,16 +424,16 @@ static uint
 encode_opndsgen_0c800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 7 &&
         encode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
-        encode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
+        encode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, instr_get_src(instr, 1), &src1) &&
         encode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, instr_get_src(instr, 2), &src2) &&
         encode_opnd_vt2(enc & 0xffe0f01f, opcode, pc, instr_get_src(instr, 3), &src3) &&
         encode_opnd_vt3(enc & 0xffe0f01f, opcode, pc, instr_get_src(instr, 4), &src4) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_src(instr, 5), &src5) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_src(instr, 5), &src5) &&
         encode_opnd_x16imm(enc & 0xfffff000, opcode, pc, instr_get_src(instr, 6), &src6)) {
         ASSERT((dst0 & 0xbffffc1f) == 0);
         ASSERT((dst1 & 0xfffffc1f) == 0);
@@ -443,7 +443,7 @@ encode_opndsgen_0c800000(byte *pc, instr_t *instr, uint enc)
         ASSERT((src3 & 0xbfffffe0) == 0);
         ASSERT((src4 & 0xbfffffe0) == 0);
         ASSERT((src5 & 0xfffffc1f) == 0);
-        ASSERT((src6 & 0xbfe0ffff) == 0);
+        ASSERT((src6 & 0xffe0ffff) == 0);
         enc |= dst0 | dst1 | src0 | src1 | src2 | src3 | src4 | src5 | src6;
         if (dst0 == (enc & 0x400003e0) &&
             dst1 == (enc & 0x000003e0) &&
@@ -453,7 +453,7 @@ encode_opndsgen_0c800000(byte *pc, instr_t *instr, uint enc)
             src3 == (enc & 0x4000001f) &&
             src4 == (enc & 0x4000001f) &&
             src5 == (enc & 0x000003e0) &&
-            src6 == (enc & 0x401f0000))
+            src6 == (enc & 0x001f0000))
             return enc;
     }
     return ENCFAIL;
@@ -463,15 +463,15 @@ static uint
 encode_opndsgen_0c804000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 6 &&
         encode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
-        encode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
+        encode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, instr_get_src(instr, 1), &src1) &&
         encode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, instr_get_src(instr, 2), &src2) &&
         encode_opnd_vt2(enc & 0xffe0f01f, opcode, pc, instr_get_src(instr, 3), &src3) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_src(instr, 4), &src4) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_src(instr, 4), &src4) &&
         encode_opnd_x16imm(enc & 0xfffff000, opcode, pc, instr_get_src(instr, 5), &src5)) {
         ASSERT((dst0 & 0xbffffc1f) == 0);
         ASSERT((dst1 & 0xfffffc1f) == 0);
@@ -480,7 +480,7 @@ encode_opndsgen_0c804000(byte *pc, instr_t *instr, uint enc)
         ASSERT((src2 & 0xbfffffe0) == 0);
         ASSERT((src3 & 0xbfffffe0) == 0);
         ASSERT((src4 & 0xfffffc1f) == 0);
-        ASSERT((src5 & 0xbfe0ffff) == 0);
+        ASSERT((src5 & 0xffe0ffff) == 0);
         enc |= dst0 | dst1 | src0 | src1 | src2 | src3 | src4 | src5;
         if (dst0 == (enc & 0x400003e0) &&
             dst1 == (enc & 0x000003e0) &&
@@ -489,7 +489,7 @@ encode_opndsgen_0c804000(byte *pc, instr_t *instr, uint enc)
             src2 == (enc & 0x4000001f) &&
             src3 == (enc & 0x4000001f) &&
             src4 == (enc & 0x000003e0) &&
-            src5 == (enc & 0x401f0000))
+            src5 == (enc & 0x001f0000))
             return enc;
     }
     return ENCFAIL;
@@ -499,27 +499,27 @@ static uint
 encode_opndsgen_0c807000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
-        encode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
+        encode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, instr_get_src(instr, 1), &src1) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_src(instr, 2), &src2) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_src(instr, 2), &src2) &&
         encode_opnd_x16imm(enc & 0xfffff000, opcode, pc, instr_get_src(instr, 3), &src3)) {
         ASSERT((dst0 & 0xbffffc1f) == 0);
         ASSERT((dst1 & 0xfffffc1f) == 0);
         ASSERT((src0 & 0xfffff3ff) == 0);
         ASSERT((src1 & 0xbfffffe0) == 0);
         ASSERT((src2 & 0xfffffc1f) == 0);
-        ASSERT((src3 & 0xbfe0ffff) == 0);
+        ASSERT((src3 & 0xffe0ffff) == 0);
         enc |= dst0 | dst1 | src0 | src1 | src2 | src3;
         if (dst0 == (enc & 0x400003e0) &&
             dst1 == (enc & 0x000003e0) &&
             src0 == (enc & 0x00000c00) &&
             src1 == (enc & 0x4000001f) &&
             src2 == (enc & 0x000003e0) &&
-            src3 == (enc & 0x401f0000))
+            src3 == (enc & 0x001f0000))
             return enc;
     }
     return ENCFAIL;
@@ -529,14 +529,14 @@ static uint
 encode_opndsgen_0c808000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
-        encode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
+        encode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, instr_get_src(instr, 1), &src1) &&
         encode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, instr_get_src(instr, 2), &src2) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_src(instr, 3), &src3) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_src(instr, 3), &src3) &&
         encode_opnd_x16imm(enc & 0xfffff000, opcode, pc, instr_get_src(instr, 4), &src4)) {
         ASSERT((dst0 & 0xbffffc1f) == 0);
         ASSERT((dst1 & 0xfffffc1f) == 0);
@@ -544,7 +544,7 @@ encode_opndsgen_0c808000(byte *pc, instr_t *instr, uint enc)
         ASSERT((src1 & 0xbfffffe0) == 0);
         ASSERT((src2 & 0xbfffffe0) == 0);
         ASSERT((src3 & 0xfffffc1f) == 0);
-        ASSERT((src4 & 0xbfe0ffff) == 0);
+        ASSERT((src4 & 0xffe0ffff) == 0);
         enc |= dst0 | dst1 | src0 | src1 | src2 | src3 | src4;
         if (dst0 == (enc & 0x400003e0) &&
             dst1 == (enc & 0x000003e0) &&
@@ -552,7 +552,7 @@ encode_opndsgen_0c808000(byte *pc, instr_t *instr, uint enc)
             src1 == (enc & 0x4000001f) &&
             src2 == (enc & 0x4000001f) &&
             src3 == (enc & 0x000003e0) &&
-            src4 == (enc & 0x401f0000))
+            src4 == (enc & 0x001f0000))
             return enc;
     }
     return ENCFAIL;
@@ -562,16 +562,16 @@ static uint
 encode_opndsgen_0cc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, dst4, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, dst4 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 5 && instr_num_srcs(instr) == 4 &&
         encode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
         encode_opnd_vt2(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 2), &dst2) &&
         encode_opnd_vt3(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 3), &dst3) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 4), &dst4) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 4), &dst4) &&
         encode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
-        encode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, instr_get_src(instr, 1), &src1) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_src(instr, 2), &src2) &&
+        encode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, instr_get_src(instr, 1), &src1) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_src(instr, 2), &src2) &&
         encode_opnd_x16imm(enc & 0xfffff000, opcode, pc, instr_get_src(instr, 3), &src3)) {
         ASSERT((dst0 & 0xbfffffe0) == 0);
         ASSERT((dst1 & 0xbfffffe0) == 0);
@@ -581,7 +581,7 @@ encode_opndsgen_0cc00000(byte *pc, instr_t *instr, uint enc)
         ASSERT((src0 & 0xbffffc1f) == 0);
         ASSERT((src1 & 0xfffff3ff) == 0);
         ASSERT((src2 & 0xfffffc1f) == 0);
-        ASSERT((src3 & 0xbfe0ffff) == 0);
+        ASSERT((src3 & 0xffe0ffff) == 0);
         enc |= dst0 | dst1 | dst2 | dst3 | dst4 | src0 | src1 | src2 | src3;
         if (dst0 == (enc & 0x4000001f) &&
             dst1 == (enc & 0x4000001f) &&
@@ -591,7 +591,7 @@ encode_opndsgen_0cc00000(byte *pc, instr_t *instr, uint enc)
             src0 == (enc & 0x400003e0) &&
             src1 == (enc & 0x00000c00) &&
             src2 == (enc & 0x000003e0) &&
-            src3 == (enc & 0x401f0000))
+            src3 == (enc & 0x001f0000))
             return enc;
     }
     return ENCFAIL;
@@ -601,15 +601,15 @@ static uint
 encode_opndsgen_0cc04000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 4 &&
         encode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
         encode_opnd_vt2(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 2), &dst2) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 3), &dst3) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 3), &dst3) &&
         encode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
-        encode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, instr_get_src(instr, 1), &src1) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_src(instr, 2), &src2) &&
+        encode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, instr_get_src(instr, 1), &src1) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_src(instr, 2), &src2) &&
         encode_opnd_x16imm(enc & 0xfffff000, opcode, pc, instr_get_src(instr, 3), &src3)) {
         ASSERT((dst0 & 0xbfffffe0) == 0);
         ASSERT((dst1 & 0xbfffffe0) == 0);
@@ -618,7 +618,7 @@ encode_opndsgen_0cc04000(byte *pc, instr_t *instr, uint enc)
         ASSERT((src0 & 0xbffffc1f) == 0);
         ASSERT((src1 & 0xfffff3ff) == 0);
         ASSERT((src2 & 0xfffffc1f) == 0);
-        ASSERT((src3 & 0xbfe0ffff) == 0);
+        ASSERT((src3 & 0xffe0ffff) == 0);
         enc |= dst0 | dst1 | dst2 | dst3 | src0 | src1 | src2 | src3;
         if (dst0 == (enc & 0x4000001f) &&
             dst1 == (enc & 0x4000001f) &&
@@ -627,7 +627,7 @@ encode_opndsgen_0cc04000(byte *pc, instr_t *instr, uint enc)
             src0 == (enc & 0x400003e0) &&
             src1 == (enc & 0x00000c00) &&
             src2 == (enc & 0x000003e0) &&
-            src3 == (enc & 0x401f0000))
+            src3 == (enc & 0x001f0000))
             return enc;
     }
     return ENCFAIL;
@@ -637,27 +637,27 @@ static uint
 encode_opndsgen_0cc07000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
         encode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
-        encode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, instr_get_src(instr, 1), &src1) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_src(instr, 2), &src2) &&
+        encode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, instr_get_src(instr, 1), &src1) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_src(instr, 2), &src2) &&
         encode_opnd_x16imm(enc & 0xfffff000, opcode, pc, instr_get_src(instr, 3), &src3)) {
         ASSERT((dst0 & 0xbfffffe0) == 0);
         ASSERT((dst1 & 0xfffffc1f) == 0);
         ASSERT((src0 & 0xbffffc1f) == 0);
         ASSERT((src1 & 0xfffff3ff) == 0);
         ASSERT((src2 & 0xfffffc1f) == 0);
-        ASSERT((src3 & 0xbfe0ffff) == 0);
+        ASSERT((src3 & 0xffe0ffff) == 0);
         enc |= dst0 | dst1 | src0 | src1 | src2 | src3;
         if (dst0 == (enc & 0x4000001f) &&
             dst1 == (enc & 0x000003e0) &&
             src0 == (enc & 0x400003e0) &&
             src1 == (enc & 0x00000c00) &&
             src2 == (enc & 0x000003e0) &&
-            src3 == (enc & 0x401f0000))
+            src3 == (enc & 0x001f0000))
             return enc;
     }
     return ENCFAIL;
@@ -667,14 +667,14 @@ static uint
 encode_opndsgen_0cc08000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 4 &&
         encode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 2), &dst2) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 2), &dst2) &&
         encode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
-        encode_opnd_vmsz(enc & 0xbfe0fc00, opcode, pc, instr_get_src(instr, 1), &src1) &&
-        encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_src(instr, 2), &src2) &&
+        encode_opnd_vmsz(enc & 0xffe0fc00, opcode, pc, instr_get_src(instr, 1), &src1) &&
+        encode_opnd_x5sp(enc & 0xffe0f3e0, opcode, pc, instr_get_src(instr, 2), &src2) &&
         encode_opnd_x16imm(enc & 0xfffff000, opcode, pc, instr_get_src(instr, 3), &src3)) {
         ASSERT((dst0 & 0xbfffffe0) == 0);
         ASSERT((dst1 & 0xbfffffe0) == 0);
@@ -682,7 +682,7 @@ encode_opndsgen_0cc08000(byte *pc, instr_t *instr, uint enc)
         ASSERT((src0 & 0xbffffc1f) == 0);
         ASSERT((src1 & 0xfffff3ff) == 0);
         ASSERT((src2 & 0xfffffc1f) == 0);
-        ASSERT((src3 & 0xbfe0ffff) == 0);
+        ASSERT((src3 & 0xffe0ffff) == 0);
         enc |= dst0 | dst1 | dst2 | src0 | src1 | src2 | src3;
         if (dst0 == (enc & 0x4000001f) &&
             dst1 == (enc & 0x4000001f) &&
@@ -690,7 +690,7 @@ encode_opndsgen_0cc08000(byte *pc, instr_t *instr, uint enc)
             src0 == (enc & 0x400003e0) &&
             src1 == (enc & 0x00000c00) &&
             src2 == (enc & 0x000003e0) &&
-            src3 == (enc & 0x401f0000))
+            src3 == (enc & 0x001f0000))
             return enc;
     }
     return ENCFAIL;
@@ -700,7 +700,7 @@ static uint
 encode_opndsgen_0d000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_memvs(enc & 0xbfffe3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -721,7 +721,7 @@ static uint
 encode_opndsgen_0d002000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfffe3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -748,7 +748,7 @@ static uint
 encode_opndsgen_0d004000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_memvs(enc & 0xbfffe7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -769,7 +769,7 @@ static uint
 encode_opndsgen_0d006000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfffe7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -796,7 +796,7 @@ static uint
 encode_opndsgen_0d008000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_memvs(enc & 0xbfffefe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -817,7 +817,7 @@ static uint
 encode_opndsgen_0d008400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_memvs(enc & 0xbfffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -838,7 +838,7 @@ static uint
 encode_opndsgen_0d00a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfffefe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -865,7 +865,7 @@ static uint
 encode_opndsgen_0d00a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -892,7 +892,7 @@ static uint
 encode_opndsgen_0d200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_memvs(enc & 0xbfffe3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -916,7 +916,7 @@ static uint
 encode_opndsgen_0d202000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3, src4;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfffe3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -946,7 +946,7 @@ static uint
 encode_opndsgen_0d204000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_memvs(enc & 0xbfffe7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -970,7 +970,7 @@ static uint
 encode_opndsgen_0d206000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3, src4;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfffe7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1000,7 +1000,7 @@ static uint
 encode_opndsgen_0d208000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_memvs(enc & 0xbfffefe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1024,7 +1024,7 @@ static uint
 encode_opndsgen_0d208400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_memvs(enc & 0xbfffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1048,7 +1048,7 @@ static uint
 encode_opndsgen_0d20a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3, src4;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfffefe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1078,7 +1078,7 @@ static uint
 encode_opndsgen_0d20a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3, src4;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1108,7 +1108,7 @@ static uint
 encode_opndsgen_0d400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memvs(enc & 0xbfffe3e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1129,7 +1129,7 @@ static uint
 encode_opndsgen_0d402000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1156,7 +1156,7 @@ static uint
 encode_opndsgen_0d404000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memvs(enc & 0xbfffe7e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1177,7 +1177,7 @@ static uint
 encode_opndsgen_0d406000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1204,7 +1204,7 @@ static uint
 encode_opndsgen_0d408000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memvs(enc & 0xbfffefe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1225,7 +1225,7 @@ static uint
 encode_opndsgen_0d408400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memvs(enc & 0xbfffffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1246,7 +1246,7 @@ static uint
 encode_opndsgen_0d40a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1273,7 +1273,7 @@ static uint
 encode_opndsgen_0d40a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1300,7 +1300,7 @@ static uint
 encode_opndsgen_0d40c000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_dq0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memvr(enc & 0xbfffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -1318,7 +1318,7 @@ static uint
 encode_opndsgen_0d40e000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 1 &&
         encode_opnd_dq0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_dq0p1(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1342,7 +1342,7 @@ static uint
 encode_opndsgen_0d600000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1366,7 +1366,7 @@ static uint
 encode_opndsgen_0d602000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1396,7 +1396,7 @@ static uint
 encode_opndsgen_0d604000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1420,7 +1420,7 @@ static uint
 encode_opndsgen_0d606000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1450,7 +1450,7 @@ static uint
 encode_opndsgen_0d608000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1474,7 +1474,7 @@ static uint
 encode_opndsgen_0d608400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1498,7 +1498,7 @@ static uint
 encode_opndsgen_0d60a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1528,7 +1528,7 @@ static uint
 encode_opndsgen_0d60a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1558,7 +1558,7 @@ static uint
 encode_opndsgen_0d60c000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0;
+    uint dst0 = 0, dst1 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 1 &&
         encode_opnd_dq0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_dq0p1(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1579,7 +1579,7 @@ static uint
 encode_opndsgen_0d60e000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 1 &&
         encode_opnd_dq0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_dq0p1(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1606,7 +1606,7 @@ static uint
 encode_opndsgen_0d800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1636,7 +1636,7 @@ static uint
 encode_opndsgen_0d802000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 6 &&
         encode_opnd_memvs(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1672,7 +1672,7 @@ static uint
 encode_opndsgen_0d804000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1702,7 +1702,7 @@ static uint
 encode_opndsgen_0d806000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 6 &&
         encode_opnd_memvs(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1738,7 +1738,7 @@ static uint
 encode_opndsgen_0d808000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1768,7 +1768,7 @@ static uint
 encode_opndsgen_0d808400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1798,7 +1798,7 @@ static uint
 encode_opndsgen_0d80a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 6 &&
         encode_opnd_memvs(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1834,7 +1834,7 @@ static uint
 encode_opndsgen_0d80a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 6 &&
         encode_opnd_memvs(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1870,7 +1870,7 @@ static uint
 encode_opndsgen_0da00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1903,7 +1903,7 @@ static uint
 encode_opndsgen_0da02000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 7 &&
         encode_opnd_memvs(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1942,7 +1942,7 @@ static uint
 encode_opndsgen_0da04000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1975,7 +1975,7 @@ static uint
 encode_opndsgen_0da06000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 7 &&
         encode_opnd_memvs(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2014,7 +2014,7 @@ static uint
 encode_opndsgen_0da08000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2047,7 +2047,7 @@ static uint
 encode_opndsgen_0da08400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2080,7 +2080,7 @@ static uint
 encode_opndsgen_0da0a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 7 &&
         encode_opnd_memvs(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2119,7 +2119,7 @@ static uint
 encode_opndsgen_0da0a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 7 &&
         encode_opnd_memvs(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2158,7 +2158,7 @@ static uint
 encode_opndsgen_0dc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_q0(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2191,7 +2191,7 @@ static uint
 encode_opndsgen_0dc02000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 7 &&
         encode_opnd_q0(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2236,7 +2236,7 @@ static uint
 encode_opndsgen_0dc04000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_q0(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2269,7 +2269,7 @@ static uint
 encode_opndsgen_0dc06000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 7 &&
         encode_opnd_q0(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2314,7 +2314,7 @@ static uint
 encode_opndsgen_0dc08000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_q0(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2347,7 +2347,7 @@ static uint
 encode_opndsgen_0dc08400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_q0(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2380,7 +2380,7 @@ static uint
 encode_opndsgen_0dc0a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 7 &&
         encode_opnd_q0(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2425,7 +2425,7 @@ static uint
 encode_opndsgen_0dc0a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 7 &&
         encode_opnd_q0(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2470,7 +2470,7 @@ static uint
 encode_opndsgen_0dc0c000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_dq0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2497,7 +2497,7 @@ static uint
 encode_opndsgen_0dc0e000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 3 &&
         encode_opnd_dq0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_dq0p1(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2530,7 +2530,7 @@ static uint
 encode_opndsgen_0de00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 6 &&
         encode_opnd_q0(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2569,7 +2569,7 @@ static uint
 encode_opndsgen_0de02000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, dst4, src0, src1, src2, src3, src4, src5, src6, src7;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, dst4 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0, src7 = 0;
     if (instr_num_dsts(instr) == 5 && instr_num_srcs(instr) == 8 &&
         encode_opnd_q0(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2620,7 +2620,7 @@ static uint
 encode_opndsgen_0de04000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 6 &&
         encode_opnd_q0(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2659,7 +2659,7 @@ static uint
 encode_opndsgen_0de06000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, dst4, src0, src1, src2, src3, src4, src5, src6, src7;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, dst4 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0, src7 = 0;
     if (instr_num_dsts(instr) == 5 && instr_num_srcs(instr) == 8 &&
         encode_opnd_q0(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2710,7 +2710,7 @@ static uint
 encode_opndsgen_0de08000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 6 &&
         encode_opnd_q0(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2749,7 +2749,7 @@ static uint
 encode_opndsgen_0de08400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 6 &&
         encode_opnd_q0(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2788,7 +2788,7 @@ static uint
 encode_opndsgen_0de0a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, dst4, src0, src1, src2, src3, src4, src5, src6, src7;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, dst4 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0, src7 = 0;
     if (instr_num_dsts(instr) == 5 && instr_num_srcs(instr) == 8 &&
         encode_opnd_q0(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2839,7 +2839,7 @@ static uint
 encode_opndsgen_0de0a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, dst4, src0, src1, src2, src3, src4, src5, src6, src7;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, dst4 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0, src7 = 0;
     if (instr_num_dsts(instr) == 5 && instr_num_srcs(instr) == 8 &&
         encode_opnd_q0(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2890,7 +2890,7 @@ static uint
 encode_opndsgen_0de0c000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_dq0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_dq0p1(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2920,7 +2920,7 @@ static uint
 encode_opndsgen_0de0e000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, dst4, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, dst4 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 5 && instr_num_srcs(instr) == 3 &&
         encode_opnd_dq0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_dq0p1(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2956,7 +2956,7 @@ static uint
 encode_opndsgen_11000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0sp(enc & 0xff80001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5sp(enc & 0xff8003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -2983,7 +2983,7 @@ static uint
 encode_opndsgen_12800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xff80001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_imm16(enc & 0xff9fffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3007,7 +3007,7 @@ static uint
 encode_opndsgen_13000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w5(enc & 0xffc003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3031,7 +3031,7 @@ static uint
 encode_opndsgen_13800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffe0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w5(enc & 0xffe003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3055,7 +3055,7 @@ static uint
 encode_opndsgen_18000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_w0(enc & 0xff00001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memlit(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3073,7 +3073,7 @@ static uint
 encode_opndsgen_1a000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_wx0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xffe0ffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3094,7 +3094,7 @@ static uint
 encode_opndsgen_1a800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_wx0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xffe00fe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3118,7 +3118,7 @@ static uint
 encode_opndsgen_1ac04000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_w0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w5(enc & 0xffe0ffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3139,7 +3139,7 @@ static uint
 encode_opndsgen_1b000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_wx0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xffe083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3163,7 +3163,7 @@ static uint
 encode_opndsgen_1c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_s0(enc & 0xff00001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memlit(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3181,7 +3181,7 @@ static uint
 encode_opndsgen_28000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3202,7 +3202,7 @@ static uint
 encode_opndsgen_28400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0;
+    uint dst0 = 0, dst1 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 1 &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3223,7 +3223,7 @@ static uint
 encode_opndsgen_28800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7post(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3253,7 +3253,7 @@ static uint
 encode_opndsgen_28c00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3283,7 +3283,7 @@ static uint
 encode_opndsgen_29800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3313,7 +3313,7 @@ static uint
 encode_opndsgen_29c00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3343,7 +3343,7 @@ static uint
 encode_opndsgen_2b200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0(enc & 0xffe0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5sp(enc & 0xffe003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3370,7 +3370,7 @@ static uint
 encode_opndsgen_2c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3391,7 +3391,7 @@ static uint
 encode_opndsgen_2c400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0;
+    uint dst0 = 0, dst1 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 1 &&
         encode_opnd_s0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3412,7 +3412,7 @@ static uint
 encode_opndsgen_2c800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7post(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3442,7 +3442,7 @@ static uint
 encode_opndsgen_2cc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_s0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3472,7 +3472,7 @@ static uint
 encode_opndsgen_2d800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3502,7 +3502,7 @@ static uint
 encode_opndsgen_2dc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_s0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3532,7 +3532,7 @@ static uint
 encode_opndsgen_31000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0(enc & 0xff80001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5sp(enc & 0xff8003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3559,7 +3559,7 @@ static uint
 encode_opndsgen_33000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3586,7 +3586,7 @@ static uint
 encode_opndsgen_38000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3604,7 +3604,7 @@ static uint
 encode_opndsgen_38000400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9post(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3631,7 +3631,7 @@ static uint
 encode_opndsgen_38000c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3658,7 +3658,7 @@ static uint
 encode_opndsgen_38200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_w0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem0(enc & 0xffe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3682,7 +3682,7 @@ static uint
 encode_opndsgen_38200800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3700,7 +3700,7 @@ static uint
 encode_opndsgen_38400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_w0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3718,7 +3718,7 @@ static uint
 encode_opndsgen_38400400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3745,7 +3745,7 @@ static uint
 encode_opndsgen_38400c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3772,7 +3772,7 @@ static uint
 encode_opndsgen_38600800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_w0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3790,7 +3790,7 @@ static uint
 encode_opndsgen_38800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3808,7 +3808,7 @@ static uint
 encode_opndsgen_38800400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3835,7 +3835,7 @@ static uint
 encode_opndsgen_38800c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3862,7 +3862,7 @@ static uint
 encode_opndsgen_38a00800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3880,7 +3880,7 @@ static uint
 encode_opndsgen_39000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3898,7 +3898,7 @@ static uint
 encode_opndsgen_39400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3916,7 +3916,7 @@ static uint
 encode_opndsgen_39800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3934,7 +3934,7 @@ static uint
 encode_opndsgen_3a400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1, src2, src3;
+    uint src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx5(enc & 0xffe00ff0, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_wx16(enc & 0xffff0c10, opcode, pc, instr_get_src(instr, 1), &src1) &&
@@ -3958,7 +3958,7 @@ static uint
 encode_opndsgen_3a400800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1, src2, src3;
+    uint src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx5(enc & 0xffe00ff0, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_imm5(enc & 0x7fff0c10, opcode, pc, instr_get_src(instr, 1), &src1) &&
@@ -3982,7 +3982,7 @@ static uint
 encode_opndsgen_3c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4000,7 +4000,7 @@ static uint
 encode_opndsgen_3c000400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9post(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4027,7 +4027,7 @@ static uint
 encode_opndsgen_3c000c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4054,7 +4054,7 @@ static uint
 encode_opndsgen_3c200800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4072,7 +4072,7 @@ static uint
 encode_opndsgen_3c400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4090,7 +4090,7 @@ static uint
 encode_opndsgen_3c400400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4117,7 +4117,7 @@ static uint
 encode_opndsgen_3c400c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4144,7 +4144,7 @@ static uint
 encode_opndsgen_3c600800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4162,7 +4162,7 @@ static uint
 encode_opndsgen_3c800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4180,7 +4180,7 @@ static uint
 encode_opndsgen_3c800400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9qpost(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4207,7 +4207,7 @@ static uint
 encode_opndsgen_3c800c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9q(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4234,7 +4234,7 @@ static uint
 encode_opndsgen_3ca00800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memregq(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4252,7 +4252,7 @@ static uint
 encode_opndsgen_3cc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_q0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4270,7 +4270,7 @@ static uint
 encode_opndsgen_3cc00400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_q0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4297,7 +4297,7 @@ static uint
 encode_opndsgen_3cc00c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_q0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4324,7 +4324,7 @@ static uint
 encode_opndsgen_3ce00800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_q0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memregq(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4342,7 +4342,7 @@ static uint
 encode_opndsgen_3d000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_b0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4360,7 +4360,7 @@ static uint
 encode_opndsgen_3d400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_b0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4378,7 +4378,7 @@ static uint
 encode_opndsgen_3d800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12q(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4396,7 +4396,7 @@ static uint
 encode_opndsgen_3dc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_q0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12q(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4414,7 +4414,7 @@ static uint
 encode_opndsgen_48207c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 5 &&
         encode_opnd_x16p0(enc & 0xfffffc00, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x16p1(enc & 0xfffffc00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4450,7 +4450,7 @@ static uint
 encode_opndsgen_58000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xff00001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memlit(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4468,7 +4468,7 @@ static uint
 encode_opndsgen_5ac00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_wx0(enc & 0xfffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4486,7 +4486,7 @@ static uint
 encode_opndsgen_5ac00800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_w0(enc & 0xfffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w5(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4504,7 +4504,7 @@ static uint
 encode_opndsgen_5c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_d0(enc & 0xff00001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memlit(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4522,7 +4522,7 @@ static uint
 encode_opndsgen_68c00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4552,7 +4552,7 @@ static uint
 encode_opndsgen_69400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0;
+    uint dst0 = 0, dst1 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4573,7 +4573,7 @@ static uint
 encode_opndsgen_69c00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4603,7 +4603,7 @@ static uint
 encode_opndsgen_6c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -4624,7 +4624,7 @@ static uint
 encode_opndsgen_6c400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0;
+    uint dst0 = 0, dst1 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 1 &&
         encode_opnd_d0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4645,7 +4645,7 @@ static uint
 encode_opndsgen_6c800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7post(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4675,7 +4675,7 @@ static uint
 encode_opndsgen_6cc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_d0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4705,7 +4705,7 @@ static uint
 encode_opndsgen_6d800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4735,7 +4735,7 @@ static uint
 encode_opndsgen_6dc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_d0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4765,7 +4765,7 @@ static uint
 encode_opndsgen_72800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_w0(enc & 0xff80001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xff80001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -4792,7 +4792,7 @@ static uint
 encode_opndsgen_7c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_h0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4810,7 +4810,7 @@ static uint
 encode_opndsgen_7c000400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9post(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4837,7 +4837,7 @@ static uint
 encode_opndsgen_7c000c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4864,7 +4864,7 @@ static uint
 encode_opndsgen_7c200800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_h0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4882,7 +4882,7 @@ static uint
 encode_opndsgen_7c400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_h0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4900,7 +4900,7 @@ static uint
 encode_opndsgen_7c400400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_h0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4927,7 +4927,7 @@ static uint
 encode_opndsgen_7c400c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_h0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4954,7 +4954,7 @@ static uint
 encode_opndsgen_7c600800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_h0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4972,7 +4972,7 @@ static uint
 encode_opndsgen_7d000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_h0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4990,7 +4990,7 @@ static uint
 encode_opndsgen_7d400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_h0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5008,7 +5008,7 @@ static uint
 encode_opndsgen_88200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem0p(enc & 0xffe083e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w16(enc & 0xffff8000, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5032,7 +5032,7 @@ static uint
 encode_opndsgen_88600000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_w0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w10(enc & 0xffe0fc00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5056,7 +5056,7 @@ static uint
 encode_opndsgen_8a000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0(enc & 0xff20001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xff2003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5083,7 +5083,7 @@ static uint
 encode_opndsgen_8b000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0(enc & 0xff20001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xff2003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5110,7 +5110,7 @@ static uint
 encode_opndsgen_92800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xff80001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_imm16(enc & 0xff9fffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5134,7 +5134,7 @@ static uint
 encode_opndsgen_93400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5(enc & 0xffc003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5158,7 +5158,7 @@ static uint
 encode_opndsgen_93c00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffe0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5(enc & 0xffe003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5182,7 +5182,7 @@ static uint
 encode_opndsgen_9ac04c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_w0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w5(enc & 0xffe0ffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5203,7 +5203,7 @@ static uint
 encode_opndsgen_9b200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w5(enc & 0xffe083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5227,7 +5227,7 @@ static uint
 encode_opndsgen_9b400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5(enc & 0xffe083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5251,7 +5251,7 @@ static uint
 encode_opndsgen_9c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_q0(enc & 0xff00001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memlit(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5269,7 +5269,7 @@ static uint
 encode_opndsgen_a8000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5290,7 +5290,7 @@ static uint
 encode_opndsgen_a8800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7post(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5320,7 +5320,7 @@ static uint
 encode_opndsgen_a9800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5350,7 +5350,7 @@ static uint
 encode_opndsgen_ac000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5371,7 +5371,7 @@ static uint
 encode_opndsgen_ac400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0;
+    uint dst0 = 0, dst1 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 1 &&
         encode_opnd_q0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5392,7 +5392,7 @@ static uint
 encode_opndsgen_ac800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7post(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5422,7 +5422,7 @@ static uint
 encode_opndsgen_acc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_q0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5452,7 +5452,7 @@ static uint
 encode_opndsgen_ad800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5482,7 +5482,7 @@ static uint
 encode_opndsgen_adc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_q0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5512,7 +5512,7 @@ static uint
 encode_opndsgen_b3400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5539,7 +5539,7 @@ static uint
 encode_opndsgen_bc000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5557,7 +5557,7 @@ static uint
 encode_opndsgen_bc000400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9post(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5584,7 +5584,7 @@ static uint
 encode_opndsgen_bc000c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5611,7 +5611,7 @@ static uint
 encode_opndsgen_bc200800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5629,7 +5629,7 @@ static uint
 encode_opndsgen_bc400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_s0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5647,7 +5647,7 @@ static uint
 encode_opndsgen_bc400400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_s0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5674,7 +5674,7 @@ static uint
 encode_opndsgen_bc400c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_s0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5701,7 +5701,7 @@ static uint
 encode_opndsgen_bc600800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_s0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5719,7 +5719,7 @@ static uint
 encode_opndsgen_bd000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5737,7 +5737,7 @@ static uint
 encode_opndsgen_bd400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_s0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5755,7 +5755,7 @@ static uint
 encode_opndsgen_c8000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem0(enc & 0xffe083e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w16(enc & 0xffff8000, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5779,7 +5779,7 @@ static uint
 encode_opndsgen_c8200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem0p(enc & 0xffe083e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w16(enc & 0xffff8000, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5803,7 +5803,7 @@ static uint
 encode_opndsgen_c8400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem0(enc & 0xffe083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5827,7 +5827,7 @@ static uint
 encode_opndsgen_c8600000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_x0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x10(enc & 0xffe0fc00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5851,7 +5851,7 @@ static uint
 encode_opndsgen_c8808000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem0(enc & 0xffe083e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xffe0801f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5875,7 +5875,7 @@ static uint
 encode_opndsgen_c8a07c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x16(enc & 0xfffffc00, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem0(enc & 0xffe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5902,7 +5902,7 @@ static uint
 encode_opndsgen_d4000001(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0;
+    uint src0 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 1 &&
         encode_opnd_imm16(enc & 0xffffffff, opcode, pc, instr_get_src(instr, 0), &src0)) {
         ASSERT((src0 & 0xffe0001f) == 0);
@@ -5923,7 +5923,7 @@ static uint
 encode_opndsgen_d503305f(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0;
+    uint src0 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 1 &&
         encode_opnd_imm4(enc & 0xffffffff, opcode, pc, instr_get_src(instr, 0), &src0)) {
         ASSERT((src0 & 0xfffff0ff) == 0);
@@ -5938,7 +5938,7 @@ static uint
 encode_opndsgen_d5080000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1;
+    uint src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 2 &&
         encode_opnd_sysops(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_x0(enc & 0xfff8001f, opcode, pc, instr_get_src(instr, 1), &src1)) {
@@ -5956,7 +5956,7 @@ static uint
 encode_opndsgen_d5280000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xfff8001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_sysops(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5974,7 +5974,7 @@ static uint
 encode_opndsgen_d5300000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xfff0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_sysreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5992,7 +5992,7 @@ static uint
 encode_opndsgen_d61f0000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0;
+    uint src0 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x5(enc & 0xffffffff, opcode, pc, instr_get_src(instr, 0), &src0)) {
         ASSERT((src0 & 0xfffffc1f) == 0);
@@ -6007,7 +6007,7 @@ static uint
 encode_opndsgen_d63f0000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_impx30(enc & 0xfffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5(enc & 0xffffffff, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6025,7 +6025,7 @@ static uint
 encode_opndsgen_d8000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1;
+    uint src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 2 &&
         encode_opnd_prfop(enc & 0xff00001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_memlit(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 1), &src1)) {
@@ -6043,7 +6043,7 @@ static uint
 encode_opndsgen_dac00800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xfffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6061,7 +6061,7 @@ static uint
 encode_opndsgen_f2800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_x0(enc & 0xff80001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xff80001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -6088,7 +6088,7 @@ static uint
 encode_opndsgen_f8000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6106,7 +6106,7 @@ static uint
 encode_opndsgen_f8000400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9post(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6133,7 +6133,7 @@ static uint
 encode_opndsgen_f8000c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6160,7 +6160,7 @@ static uint
 encode_opndsgen_f8200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_x0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem0(enc & 0xffe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6184,7 +6184,7 @@ static uint
 encode_opndsgen_f8200800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6202,7 +6202,7 @@ static uint
 encode_opndsgen_f8800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1;
+    uint src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 2 &&
         encode_opnd_prfop(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_prf9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 1), &src1)) {
@@ -6220,7 +6220,7 @@ static uint
 encode_opndsgen_f8a00800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1;
+    uint src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 2 &&
         encode_opnd_prfop(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_prfreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 1), &src1)) {
@@ -6238,7 +6238,7 @@ static uint
 encode_opndsgen_f9000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6256,7 +6256,7 @@ static uint
 encode_opndsgen_f9800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1;
+    uint src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 2 &&
         encode_opnd_prfop(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_prf12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 1), &src1)) {
@@ -6274,7 +6274,7 @@ static uint
 encode_opndsgen_fc000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6292,7 +6292,7 @@ static uint
 encode_opndsgen_fc000400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9post(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6319,7 +6319,7 @@ static uint
 encode_opndsgen_fc000c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6346,7 +6346,7 @@ static uint
 encode_opndsgen_fc200800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6364,7 +6364,7 @@ static uint
 encode_opndsgen_fc400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_d0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6382,7 +6382,7 @@ static uint
 encode_opndsgen_fc400400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_d0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6409,7 +6409,7 @@ static uint
 encode_opndsgen_fc400c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_d0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6436,7 +6436,7 @@ static uint
 encode_opndsgen_fc600800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_d0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6454,7 +6454,7 @@ static uint
 encode_opndsgen_fd000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6472,7 +6472,7 @@ static uint
 encode_opndsgen_fd400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_d0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6711,13 +6711,25 @@ encoder(byte *pc, instr_t *instr)
         enc = encode_opndsgen_0cc00000(pc, instr, 0x0cc02000);
         if (enc != ENCFAIL)
             return enc;
+        enc = encode_opndsgen_0cc00000(pc, instr, 0x4cc02000);
+        if (enc != ENCFAIL)
+            return enc;
         enc = encode_opndsgen_0cc04000(pc, instr, 0x0cc06000);
+        if (enc != ENCFAIL)
+            return enc;
+        enc = encode_opndsgen_0cc04000(pc, instr, 0x4cc06000);
         if (enc != ENCFAIL)
             return enc;
         enc = encode_opndsgen_0cc07000(pc, instr, 0x0cc07000);
         if (enc != ENCFAIL)
             return enc;
+        enc = encode_opndsgen_0cc07000(pc, instr, 0x4cc07000);
+        if (enc != ENCFAIL)
+            return enc;
         enc = encode_opndsgen_0cc08000(pc, instr, 0x0cc0a000);
+        if (enc != ENCFAIL)
+            return enc;
+        enc = encode_opndsgen_0cc08000(pc, instr, 0x4cc0a000);
         if (enc != ENCFAIL)
             return enc;
         enc = encode_opndsgen_0d400000(pc, instr, 0x0d400000);
@@ -6763,6 +6775,9 @@ encoder(byte *pc, instr_t *instr)
         enc = encode_opndsgen_0cc08000(pc, instr, 0x0cc08000);
         if (enc != ENCFAIL)
             return enc;
+        enc = encode_opndsgen_0cc08000(pc, instr, 0x4cc08000);
+        if (enc != ENCFAIL)
+            return enc;
         enc = encode_opndsgen_0d600000(pc, instr, 0x0d600000);
         if (enc != ENCFAIL)
             return enc;
@@ -6806,6 +6821,9 @@ encoder(byte *pc, instr_t *instr)
         enc = encode_opndsgen_0cc04000(pc, instr, 0x0cc04000);
         if (enc != ENCFAIL)
             return enc;
+        enc = encode_opndsgen_0cc04000(pc, instr, 0x4cc04000);
+        if (enc != ENCFAIL)
+            return enc;
         enc = encode_opndsgen_0d402000(pc, instr, 0x0d402000);
         if (enc != ENCFAIL)
             return enc;
@@ -6847,6 +6865,9 @@ encoder(byte *pc, instr_t *instr)
         if (enc != ENCFAIL)
             return enc;
         enc = encode_opndsgen_0cc00000(pc, instr, 0x0cc00000);
+        if (enc != ENCFAIL)
+            return enc;
+        enc = encode_opndsgen_0cc00000(pc, instr, 0x4cc00000);
         if (enc != ENCFAIL)
             return enc;
         enc = encode_opndsgen_0d602000(pc, instr, 0x0d602000);
@@ -7619,13 +7640,25 @@ encoder(byte *pc, instr_t *instr)
         enc = encode_opndsgen_0c800000(pc, instr, 0x0c802000);
         if (enc != ENCFAIL)
             return enc;
+        enc = encode_opndsgen_0c800000(pc, instr, 0x4c802000);
+        if (enc != ENCFAIL)
+            return enc;
         enc = encode_opndsgen_0c804000(pc, instr, 0x0c806000);
+        if (enc != ENCFAIL)
+            return enc;
+        enc = encode_opndsgen_0c804000(pc, instr, 0x4c806000);
         if (enc != ENCFAIL)
             return enc;
         enc = encode_opndsgen_0c807000(pc, instr, 0x0c807000);
         if (enc != ENCFAIL)
             return enc;
+        enc = encode_opndsgen_0c807000(pc, instr, 0x4c807000);
+        if (enc != ENCFAIL)
+            return enc;
         enc = encode_opndsgen_0c808000(pc, instr, 0x0c80a000);
+        if (enc != ENCFAIL)
+            return enc;
+        enc = encode_opndsgen_0c808000(pc, instr, 0x4c80a000);
         if (enc != ENCFAIL)
             return enc;
         enc = encode_opndsgen_0d000000(pc, instr, 0x0d000000);
@@ -7657,6 +7690,9 @@ encoder(byte *pc, instr_t *instr)
         enc = encode_opndsgen_0c808000(pc, instr, 0x0c808000);
         if (enc != ENCFAIL)
             return enc;
+        enc = encode_opndsgen_0c808000(pc, instr, 0x4c808000);
+        if (enc != ENCFAIL)
+            return enc;
         enc = encode_opndsgen_0d200000(pc, instr, 0x0d200000);
         if (enc != ENCFAIL)
             return enc;
@@ -7686,6 +7722,9 @@ encoder(byte *pc, instr_t *instr)
         enc = encode_opndsgen_0c804000(pc, instr, 0x0c804000);
         if (enc != ENCFAIL)
             return enc;
+        enc = encode_opndsgen_0c804000(pc, instr, 0x4c804000);
+        if (enc != ENCFAIL)
+            return enc;
         enc = encode_opndsgen_0d002000(pc, instr, 0x0d002000);
         if (enc != ENCFAIL)
             return enc;
@@ -7713,6 +7752,9 @@ encoder(byte *pc, instr_t *instr)
         if (enc != ENCFAIL)
             return enc;
         enc = encode_opndsgen_0c800000(pc, instr, 0x0c800000);
+        if (enc != ENCFAIL)
+            return enc;
+        enc = encode_opndsgen_0c800000(pc, instr, 0x4c800000);
         if (enc != ENCFAIL)
             return enc;
         enc = encode_opndsgen_0d202000(pc, instr, 0x0d202000);

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -511,6 +511,7 @@
 4c4067ff : ld1    {v31.8h, v0.8h, v1.8h}, [sp]: ld1    (%sp)[48byte] $0x01 -> %q31 %q0 %q1
 4c4077ff : ld1    {v31.8h}, [sp]          : ld1    (%sp)[16byte] $0x01 -> %q31
 4c40a7ff : ld1    {v31.8h, v0.8h}, [sp]   : ld1    (%sp)[32byte] $0x01 -> %q31 %q0
+4c800000 : st4    {v0.16b-v3.16b}, [x0], x0: st4    $0x00 %q0 %q1 %q2 %q3 %x0 %x0 -> (%x0)[64byte] %x0
 4c9f07ff : st4    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp], #64: st4    $0x01 %q31 %q0 %q1 %q2 %sp $0x40 -> (%sp)[64byte] %sp
 4c9f67ff : st1    {v31.8h, v0.8h, v1.8h}, [sp], #48: st1    $0x01 %q31 %q0 %q1 %sp $0x30 -> (%sp)[48byte] %sp
 4c9f77ff : st1    {v31.8h}, [sp], #16     : st1    $0x01 %q31 %sp $0x10 -> (%sp)[16byte] %sp


### PR DESCRIPTION
The "x16imm" operand type can be a register, or a constant denoted
in the encoding by register number 31. The value of the constant can
be determined from various bits in the instruction, but those bits
can not be uniquely determined from the constant operand. In particular,
we can not generate bit 30 in this case. Within the constraints of the
current formalism the best solution seems to be to remove bit 30 from
the bits generated by x16imm and duplicate the 14 bit patterns that
use x16imm.

There are other instances of such duplication. The formalism should
perhaps be improved.

Change-Id: I319d8e4b9550d39b11f5dce80fe7801115445446