### PR TITLE
i#1569 AArch64: Initialise variables in encoder functions.

### DIFF
--- a/core/arch/aarch64/codec.py
+++ b/core/arch/aarch64/codec.py
@@ -135,7 +135,8 @@ def generate_encoder(patterns, opndsgen, opndtypes):
             vars = (['dst%d' % i for i in range(len(dsts))] +
                     ['src%d' % i for i in range(len(srcs))])
             c += ['    int opcode = instr->opcode;']
-            c += ['    uint ' + ', '.join(vars) + ';']
+            # The initial values are only required to silence a bad compiler warning:
+            c += ['    uint ' + ' = 0, '.join(vars) + ' = 0;']
             tests = (['instr_num_dsts(instr) == %d && instr_num_srcs(instr) == %d' %
                       (len(dsts), len(srcs))] +
                      ['encode_opnd_%s(enc & 0x%08x, opcode, '

--- a/core/arch/aarch64/encode_gen.h
+++ b/core/arch/aarch64/encode_gen.h
@@ -4,7 +4,7 @@ static uint
 encode_opndsgen_08000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem0(enc & 0xffe083e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w16(enc & 0xffff8000, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -28,7 +28,7 @@ static uint
 encode_opndsgen_08207c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 5 &&
         encode_opnd_w16p0(enc & 0xfffffc00, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w16p1(enc & 0xfffffc00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -64,7 +64,7 @@ static uint
 encode_opndsgen_08400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem0(enc & 0xffe083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -88,7 +88,7 @@ static uint
 encode_opndsgen_08808000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem0(enc & 0xffe083e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xffe0801f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -112,7 +112,7 @@ static uint
 encode_opndsgen_08a07c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w16(enc & 0xfffffc00, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem0(enc & 0xffe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -139,7 +139,7 @@ static uint
 encode_opndsgen_0a000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0(enc & 0xff20801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xff2083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -166,7 +166,7 @@ static uint
 encode_opndsgen_0b000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0(enc & 0xff20801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xff2083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -193,7 +193,7 @@ static uint
 encode_opndsgen_0b200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0sp(enc & 0xffe0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5sp(enc & 0xffe003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -220,7 +220,7 @@ static uint
 encode_opndsgen_0c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3, src4;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvm(enc & 0xfffff3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vmsz(enc & 0xbffffc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -250,7 +250,7 @@ static uint
 encode_opndsgen_0c004000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvm(enc & 0xfffff3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vmsz(enc & 0xbffffc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -277,7 +277,7 @@ static uint
 encode_opndsgen_0c007000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_memvm(enc & 0xfffff3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vmsz(enc & 0xbffffc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -298,7 +298,7 @@ static uint
 encode_opndsgen_0c008000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_memvm(enc & 0xfffff3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vmsz(enc & 0xbffffc00, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -322,7 +322,7 @@ static uint
 encode_opndsgen_0c400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 2 &&
         encode_opnd_vt0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vt1(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -352,7 +352,7 @@ static uint
 encode_opndsgen_0c404000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 2 &&
         encode_opnd_vt0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vt1(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -379,7 +379,7 @@ static uint
 encode_opndsgen_0c407000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_vt0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memvm(enc & 0xfffff3e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -400,7 +400,7 @@ static uint
 encode_opndsgen_0c408000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_vt0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vt1(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -424,7 +424,7 @@ static uint
 encode_opndsgen_0c800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 7 &&
         encode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -463,7 +463,7 @@ static uint
 encode_opndsgen_0c804000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 6 &&
         encode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -499,7 +499,7 @@ static uint
 encode_opndsgen_0c807000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -529,7 +529,7 @@ static uint
 encode_opndsgen_0c808000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvm(enc & 0xffe0f3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -562,7 +562,7 @@ static uint
 encode_opndsgen_0cc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, dst4, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, dst4 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 5 && instr_num_srcs(instr) == 4 &&
         encode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -601,7 +601,7 @@ static uint
 encode_opndsgen_0cc04000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 4 &&
         encode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -637,7 +637,7 @@ static uint
 encode_opndsgen_0cc07000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0f3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -667,7 +667,7 @@ static uint
 encode_opndsgen_0cc08000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 4 &&
         encode_opnd_vt0(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_vt1(enc & 0xffe0f01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -700,7 +700,7 @@ static uint
 encode_opndsgen_0d000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_memvs(enc & 0xbfffe3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -721,7 +721,7 @@ static uint
 encode_opndsgen_0d002000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfffe3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -748,7 +748,7 @@ static uint
 encode_opndsgen_0d004000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_memvs(enc & 0xbfffe7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -769,7 +769,7 @@ static uint
 encode_opndsgen_0d006000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfffe7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -796,7 +796,7 @@ static uint
 encode_opndsgen_0d008000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_memvs(enc & 0xbfffefe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -817,7 +817,7 @@ static uint
 encode_opndsgen_0d008400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_memvs(enc & 0xbfffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -838,7 +838,7 @@ static uint
 encode_opndsgen_0d00a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfffefe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -865,7 +865,7 @@ static uint
 encode_opndsgen_0d00a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -892,7 +892,7 @@ static uint
 encode_opndsgen_0d200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_memvs(enc & 0xbfffe3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -916,7 +916,7 @@ static uint
 encode_opndsgen_0d202000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3, src4;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfffe3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -946,7 +946,7 @@ static uint
 encode_opndsgen_0d204000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_memvs(enc & 0xbfffe7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -970,7 +970,7 @@ static uint
 encode_opndsgen_0d206000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3, src4;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfffe7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1000,7 +1000,7 @@ static uint
 encode_opndsgen_0d208000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_memvs(enc & 0xbfffefe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1024,7 +1024,7 @@ static uint
 encode_opndsgen_0d208400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_memvs(enc & 0xbfffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1048,7 +1048,7 @@ static uint
 encode_opndsgen_0d20a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3, src4;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfffefe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1078,7 +1078,7 @@ static uint
 encode_opndsgen_0d20a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3, src4;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1108,7 +1108,7 @@ static uint
 encode_opndsgen_0d400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memvs(enc & 0xbfffe3e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1129,7 +1129,7 @@ static uint
 encode_opndsgen_0d402000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1156,7 +1156,7 @@ static uint
 encode_opndsgen_0d404000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memvs(enc & 0xbfffe7e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1177,7 +1177,7 @@ static uint
 encode_opndsgen_0d406000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1204,7 +1204,7 @@ static uint
 encode_opndsgen_0d408000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memvs(enc & 0xbfffefe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1225,7 +1225,7 @@ static uint
 encode_opndsgen_0d408400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memvs(enc & 0xbfffffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -1246,7 +1246,7 @@ static uint
 encode_opndsgen_0d40a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1273,7 +1273,7 @@ static uint
 encode_opndsgen_0d40a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1300,7 +1300,7 @@ static uint
 encode_opndsgen_0d40c000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_dq0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memvr(enc & 0xbfffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -1318,7 +1318,7 @@ static uint
 encode_opndsgen_0d40e000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 1 &&
         encode_opnd_dq0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_dq0p1(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1342,7 +1342,7 @@ static uint
 encode_opndsgen_0d600000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1366,7 +1366,7 @@ static uint
 encode_opndsgen_0d602000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffe01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1396,7 +1396,7 @@ static uint
 encode_opndsgen_0d604000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1420,7 +1420,7 @@ static uint
 encode_opndsgen_0d606000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffe41f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1450,7 +1450,7 @@ static uint
 encode_opndsgen_0d608000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1474,7 +1474,7 @@ static uint
 encode_opndsgen_0d608400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1498,7 +1498,7 @@ static uint
 encode_opndsgen_0d60a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfffec1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1528,7 +1528,7 @@ static uint
 encode_opndsgen_0d60a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 2 &&
         encode_opnd_q0(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbffffc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1558,7 +1558,7 @@ static uint
 encode_opndsgen_0d60c000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0;
+    uint dst0 = 0, dst1 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 1 &&
         encode_opnd_dq0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_dq0p1(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1579,7 +1579,7 @@ static uint
 encode_opndsgen_0d60e000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 1 &&
         encode_opnd_dq0(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_dq0p1(enc & 0xfffff01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1606,7 +1606,7 @@ static uint
 encode_opndsgen_0d800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1636,7 +1636,7 @@ static uint
 encode_opndsgen_0d802000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 6 &&
         encode_opnd_memvs(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1672,7 +1672,7 @@ static uint
 encode_opndsgen_0d804000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1702,7 +1702,7 @@ static uint
 encode_opndsgen_0d806000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 6 &&
         encode_opnd_memvs(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1738,7 +1738,7 @@ static uint
 encode_opndsgen_0d808000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1768,7 +1768,7 @@ static uint
 encode_opndsgen_0d808400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_memvs(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1798,7 +1798,7 @@ static uint
 encode_opndsgen_0d80a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 6 &&
         encode_opnd_memvs(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1834,7 +1834,7 @@ static uint
 encode_opndsgen_0d80a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 6 &&
         encode_opnd_memvs(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1870,7 +1870,7 @@ static uint
 encode_opndsgen_0da00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1903,7 +1903,7 @@ static uint
 encode_opndsgen_0da02000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 7 &&
         encode_opnd_memvs(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1942,7 +1942,7 @@ static uint
 encode_opndsgen_0da04000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -1975,7 +1975,7 @@ static uint
 encode_opndsgen_0da06000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 7 &&
         encode_opnd_memvs(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2014,7 +2014,7 @@ static uint
 encode_opndsgen_0da08000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2047,7 +2047,7 @@ static uint
 encode_opndsgen_0da08400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_memvs(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2080,7 +2080,7 @@ static uint
 encode_opndsgen_0da0a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 7 &&
         encode_opnd_memvs(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2119,7 +2119,7 @@ static uint
 encode_opndsgen_0da0a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 7 &&
         encode_opnd_memvs(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2158,7 +2158,7 @@ static uint
 encode_opndsgen_0dc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_q0(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e3e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2191,7 +2191,7 @@ static uint
 encode_opndsgen_0dc02000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 7 &&
         encode_opnd_q0(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2236,7 +2236,7 @@ static uint
 encode_opndsgen_0dc04000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_q0(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0e7e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2269,7 +2269,7 @@ static uint
 encode_opndsgen_0dc06000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 7 &&
         encode_opnd_q0(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2314,7 +2314,7 @@ static uint
 encode_opndsgen_0dc08000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_q0(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0efe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2347,7 +2347,7 @@ static uint
 encode_opndsgen_0dc08400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 5 &&
         encode_opnd_q0(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2380,7 +2380,7 @@ static uint
 encode_opndsgen_0dc0a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 7 &&
         encode_opnd_q0(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2425,7 +2425,7 @@ static uint
 encode_opndsgen_0dc0a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1, src2, src3, src4, src5, src6;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 7 &&
         encode_opnd_q0(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2470,7 +2470,7 @@ static uint
 encode_opndsgen_0dc0c000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_dq0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xbfe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2497,7 +2497,7 @@ static uint
 encode_opndsgen_0dc0e000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 4 && instr_num_srcs(instr) == 3 &&
         encode_opnd_dq0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_dq0p1(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2530,7 +2530,7 @@ static uint
 encode_opndsgen_0de00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 6 &&
         encode_opnd_q0(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2569,7 +2569,7 @@ static uint
 encode_opndsgen_0de02000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, dst4, src0, src1, src2, src3, src4, src5, src6, src7;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, dst4 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0, src7 = 0;
     if (instr_num_dsts(instr) == 5 && instr_num_srcs(instr) == 8 &&
         encode_opnd_q0(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0e01f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2620,7 +2620,7 @@ static uint
 encode_opndsgen_0de04000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 6 &&
         encode_opnd_q0(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2659,7 +2659,7 @@ static uint
 encode_opndsgen_0de06000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, dst4, src0, src1, src2, src3, src4, src5, src6, src7;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, dst4 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0, src7 = 0;
     if (instr_num_dsts(instr) == 5 && instr_num_srcs(instr) == 8 &&
         encode_opnd_q0(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0e41f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2710,7 +2710,7 @@ static uint
 encode_opndsgen_0de08000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 6 &&
         encode_opnd_q0(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2749,7 +2749,7 @@ static uint
 encode_opndsgen_0de08400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3, src4, src5;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 6 &&
         encode_opnd_q0(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2788,7 +2788,7 @@ static uint
 encode_opndsgen_0de0a000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, dst4, src0, src1, src2, src3, src4, src5, src6, src7;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, dst4 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0, src7 = 0;
     if (instr_num_dsts(instr) == 5 && instr_num_srcs(instr) == 8 &&
         encode_opnd_q0(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0ec1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2839,7 +2839,7 @@ static uint
 encode_opndsgen_0de0a400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, dst4, src0, src1, src2, src3, src4, src5, src6, src7;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, dst4 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0, src5 = 0, src6 = 0, src7 = 0;
     if (instr_num_dsts(instr) == 5 && instr_num_srcs(instr) == 8 &&
         encode_opnd_q0(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0p1(enc & 0xbfe0fc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2890,7 +2890,7 @@ static uint
 encode_opndsgen_0de0c000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_dq0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_dq0p1(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2920,7 +2920,7 @@ static uint
 encode_opndsgen_0de0e000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, dst3, dst4, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, dst3 = 0, dst4 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 5 && instr_num_srcs(instr) == 3 &&
         encode_opnd_dq0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_dq0p1(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -2956,7 +2956,7 @@ static uint
 encode_opndsgen_11000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0sp(enc & 0xff80001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5sp(enc & 0xff8003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -2983,7 +2983,7 @@ static uint
 encode_opndsgen_12800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xff80001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_imm16(enc & 0xff9fffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3007,7 +3007,7 @@ static uint
 encode_opndsgen_13000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w5(enc & 0xffc003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3031,7 +3031,7 @@ static uint
 encode_opndsgen_13800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffe0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w5(enc & 0xffe003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3055,7 +3055,7 @@ static uint
 encode_opndsgen_18000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_w0(enc & 0xff00001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memlit(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3073,7 +3073,7 @@ static uint
 encode_opndsgen_1a000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_wx0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xffe0ffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3094,7 +3094,7 @@ static uint
 encode_opndsgen_1a800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_wx0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xffe00fe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3118,7 +3118,7 @@ static uint
 encode_opndsgen_1ac04000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_w0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w5(enc & 0xffe0ffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3139,7 +3139,7 @@ static uint
 encode_opndsgen_1b000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_wx0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xffe083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3163,7 +3163,7 @@ static uint
 encode_opndsgen_1c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_s0(enc & 0xff00001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memlit(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3181,7 +3181,7 @@ static uint
 encode_opndsgen_28000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3202,7 +3202,7 @@ static uint
 encode_opndsgen_28400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0;
+    uint dst0 = 0, dst1 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 1 &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3223,7 +3223,7 @@ static uint
 encode_opndsgen_28800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7post(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3253,7 +3253,7 @@ static uint
 encode_opndsgen_28c00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3283,7 +3283,7 @@ static uint
 encode_opndsgen_29800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3313,7 +3313,7 @@ static uint
 encode_opndsgen_29c00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3343,7 +3343,7 @@ static uint
 encode_opndsgen_2b200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0(enc & 0xffe0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5sp(enc & 0xffe003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3370,7 +3370,7 @@ static uint
 encode_opndsgen_2c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3391,7 +3391,7 @@ static uint
 encode_opndsgen_2c400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0;
+    uint dst0 = 0, dst1 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 1 &&
         encode_opnd_s0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3412,7 +3412,7 @@ static uint
 encode_opndsgen_2c800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7post(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3442,7 +3442,7 @@ static uint
 encode_opndsgen_2cc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_s0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3472,7 +3472,7 @@ static uint
 encode_opndsgen_2d800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3502,7 +3502,7 @@ static uint
 encode_opndsgen_2dc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_s0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3532,7 +3532,7 @@ static uint
 encode_opndsgen_31000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0(enc & 0xff80001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5sp(enc & 0xff8003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3559,7 +3559,7 @@ static uint
 encode_opndsgen_33000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -3586,7 +3586,7 @@ static uint
 encode_opndsgen_38000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3604,7 +3604,7 @@ static uint
 encode_opndsgen_38000400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9post(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3631,7 +3631,7 @@ static uint
 encode_opndsgen_38000c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3658,7 +3658,7 @@ static uint
 encode_opndsgen_38200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_w0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem0(enc & 0xffe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3682,7 +3682,7 @@ static uint
 encode_opndsgen_38200800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3700,7 +3700,7 @@ static uint
 encode_opndsgen_38400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_w0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3718,7 +3718,7 @@ static uint
 encode_opndsgen_38400400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3745,7 +3745,7 @@ static uint
 encode_opndsgen_38400c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_w0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3772,7 +3772,7 @@ static uint
 encode_opndsgen_38600800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_w0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3790,7 +3790,7 @@ static uint
 encode_opndsgen_38800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3808,7 +3808,7 @@ static uint
 encode_opndsgen_38800400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3835,7 +3835,7 @@ static uint
 encode_opndsgen_38800c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -3862,7 +3862,7 @@ static uint
 encode_opndsgen_38a00800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3880,7 +3880,7 @@ static uint
 encode_opndsgen_39000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3898,7 +3898,7 @@ static uint
 encode_opndsgen_39400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_w0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3916,7 +3916,7 @@ static uint
 encode_opndsgen_39800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -3934,7 +3934,7 @@ static uint
 encode_opndsgen_3a400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1, src2, src3;
+    uint src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx5(enc & 0xffe00ff0, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_wx16(enc & 0xffff0c10, opcode, pc, instr_get_src(instr, 1), &src1) &&
@@ -3958,7 +3958,7 @@ static uint
 encode_opndsgen_3a400800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1, src2, src3;
+    uint src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx5(enc & 0xffe00ff0, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_imm5(enc & 0x7fff0c10, opcode, pc, instr_get_src(instr, 1), &src1) &&
@@ -3982,7 +3982,7 @@ static uint
 encode_opndsgen_3c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4000,7 +4000,7 @@ static uint
 encode_opndsgen_3c000400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9post(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4027,7 +4027,7 @@ static uint
 encode_opndsgen_3c000c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4054,7 +4054,7 @@ static uint
 encode_opndsgen_3c200800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4072,7 +4072,7 @@ static uint
 encode_opndsgen_3c400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4090,7 +4090,7 @@ static uint
 encode_opndsgen_3c400400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4117,7 +4117,7 @@ static uint
 encode_opndsgen_3c400c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4144,7 +4144,7 @@ static uint
 encode_opndsgen_3c600800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4162,7 +4162,7 @@ static uint
 encode_opndsgen_3c800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4180,7 +4180,7 @@ static uint
 encode_opndsgen_3c800400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9qpost(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4207,7 +4207,7 @@ static uint
 encode_opndsgen_3c800c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9q(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4234,7 +4234,7 @@ static uint
 encode_opndsgen_3ca00800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memregq(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_b0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4252,7 +4252,7 @@ static uint
 encode_opndsgen_3cc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_q0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4270,7 +4270,7 @@ static uint
 encode_opndsgen_3cc00400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_q0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4297,7 +4297,7 @@ static uint
 encode_opndsgen_3cc00c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_q0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4324,7 +4324,7 @@ static uint
 encode_opndsgen_3ce00800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_q0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memregq(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4342,7 +4342,7 @@ static uint
 encode_opndsgen_3d000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_b0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4360,7 +4360,7 @@ static uint
 encode_opndsgen_3d400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_b0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4378,7 +4378,7 @@ static uint
 encode_opndsgen_3d800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12q(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4396,7 +4396,7 @@ static uint
 encode_opndsgen_3dc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_q0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12q(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4414,7 +4414,7 @@ static uint
 encode_opndsgen_48207c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2, src3, src4;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0, src4 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 5 &&
         encode_opnd_x16p0(enc & 0xfffffc00, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x16p1(enc & 0xfffffc00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4450,7 +4450,7 @@ static uint
 encode_opndsgen_58000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xff00001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memlit(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4468,7 +4468,7 @@ static uint
 encode_opndsgen_5ac00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_wx0(enc & 0xfffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4486,7 +4486,7 @@ static uint
 encode_opndsgen_5ac00800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_w0(enc & 0xfffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w5(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4504,7 +4504,7 @@ static uint
 encode_opndsgen_5c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_d0(enc & 0xff00001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memlit(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4522,7 +4522,7 @@ static uint
 encode_opndsgen_68c00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4552,7 +4552,7 @@ static uint
 encode_opndsgen_69400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0;
+    uint dst0 = 0, dst1 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4573,7 +4573,7 @@ static uint
 encode_opndsgen_69c00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4603,7 +4603,7 @@ static uint
 encode_opndsgen_6c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -4624,7 +4624,7 @@ static uint
 encode_opndsgen_6c400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0;
+    uint dst0 = 0, dst1 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 1 &&
         encode_opnd_d0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4645,7 +4645,7 @@ static uint
 encode_opndsgen_6c800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7post(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4675,7 +4675,7 @@ static uint
 encode_opndsgen_6cc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_d0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4705,7 +4705,7 @@ static uint
 encode_opndsgen_6d800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4735,7 +4735,7 @@ static uint
 encode_opndsgen_6dc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_d0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4765,7 +4765,7 @@ static uint
 encode_opndsgen_72800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_w0(enc & 0xff80001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w0(enc & 0xff80001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -4792,7 +4792,7 @@ static uint
 encode_opndsgen_7c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_h0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4810,7 +4810,7 @@ static uint
 encode_opndsgen_7c000400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9post(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4837,7 +4837,7 @@ static uint
 encode_opndsgen_7c000c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4864,7 +4864,7 @@ static uint
 encode_opndsgen_7c200800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_h0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4882,7 +4882,7 @@ static uint
 encode_opndsgen_7c400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_h0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4900,7 +4900,7 @@ static uint
 encode_opndsgen_7c400400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_h0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4927,7 +4927,7 @@ static uint
 encode_opndsgen_7c400c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_h0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -4954,7 +4954,7 @@ static uint
 encode_opndsgen_7c600800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_h0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4972,7 +4972,7 @@ static uint
 encode_opndsgen_7d000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_h0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -4990,7 +4990,7 @@ static uint
 encode_opndsgen_7d400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_h0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5008,7 +5008,7 @@ static uint
 encode_opndsgen_88200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem0p(enc & 0xffe083e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w16(enc & 0xffff8000, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5032,7 +5032,7 @@ static uint
 encode_opndsgen_88600000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_w0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w10(enc & 0xffe0fc00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5056,7 +5056,7 @@ static uint
 encode_opndsgen_8a000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0(enc & 0xff20001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xff2003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5083,7 +5083,7 @@ static uint
 encode_opndsgen_8b000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_wx0(enc & 0xff20001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_wx5(enc & 0xff2003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5110,7 +5110,7 @@ static uint
 encode_opndsgen_92800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xff80001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_imm16(enc & 0xff9fffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5134,7 +5134,7 @@ static uint
 encode_opndsgen_93400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5(enc & 0xffc003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5158,7 +5158,7 @@ static uint
 encode_opndsgen_93c00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffe0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5(enc & 0xffe003e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5182,7 +5182,7 @@ static uint
 encode_opndsgen_9ac04c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_w0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w5(enc & 0xffe0ffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5203,7 +5203,7 @@ static uint
 encode_opndsgen_9b200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w5(enc & 0xffe083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5227,7 +5227,7 @@ static uint
 encode_opndsgen_9b400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5(enc & 0xffe083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5251,7 +5251,7 @@ static uint
 encode_opndsgen_9c000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_q0(enc & 0xff00001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memlit(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5269,7 +5269,7 @@ static uint
 encode_opndsgen_a8000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5290,7 +5290,7 @@ static uint
 encode_opndsgen_a8800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7post(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5320,7 +5320,7 @@ static uint
 encode_opndsgen_a9800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5350,7 +5350,7 @@ static uint
 encode_opndsgen_ac000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1;
+    uint dst0 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5371,7 +5371,7 @@ static uint
 encode_opndsgen_ac400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0;
+    uint dst0 = 0, dst1 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 1 &&
         encode_opnd_q0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5392,7 +5392,7 @@ static uint
 encode_opndsgen_ac800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7post(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5422,7 +5422,7 @@ static uint
 encode_opndsgen_acc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_q0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5452,7 +5452,7 @@ static uint
 encode_opndsgen_ad800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2, src3;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 4 &&
         encode_opnd_mem7(enc & 0xffff83e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffc003e0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5482,7 +5482,7 @@ static uint
 encode_opndsgen_adc00000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, dst2, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, dst2 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 3 && instr_num_srcs(instr) == 3 &&
         encode_opnd_q0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_q10(enc & 0xffc07c00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5512,7 +5512,7 @@ static uint
 encode_opndsgen_b3400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5539,7 +5539,7 @@ static uint
 encode_opndsgen_bc000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5557,7 +5557,7 @@ static uint
 encode_opndsgen_bc000400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9post(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5584,7 +5584,7 @@ static uint
 encode_opndsgen_bc000c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5611,7 +5611,7 @@ static uint
 encode_opndsgen_bc200800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5629,7 +5629,7 @@ static uint
 encode_opndsgen_bc400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_s0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5647,7 +5647,7 @@ static uint
 encode_opndsgen_bc400400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_s0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5674,7 +5674,7 @@ static uint
 encode_opndsgen_bc400c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_s0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5701,7 +5701,7 @@ static uint
 encode_opndsgen_bc600800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_s0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5719,7 +5719,7 @@ static uint
 encode_opndsgen_bd000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_s0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5737,7 +5737,7 @@ static uint
 encode_opndsgen_bd400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_s0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5755,7 +5755,7 @@ static uint
 encode_opndsgen_c8000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem0(enc & 0xffe083e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w16(enc & 0xffff8000, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5779,7 +5779,7 @@ static uint
 encode_opndsgen_c8200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_mem0p(enc & 0xffe083e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_w16(enc & 0xffff8000, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5803,7 +5803,7 @@ static uint
 encode_opndsgen_c8400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem0(enc & 0xffe083e0, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5827,7 +5827,7 @@ static uint
 encode_opndsgen_c8600000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_x0(enc & 0xffe0801f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x10(enc & 0xffe0fc00, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5851,7 +5851,7 @@ static uint
 encode_opndsgen_c8808000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem0(enc & 0xffe083e0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xffe0801f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -5875,7 +5875,7 @@ static uint
 encode_opndsgen_c8a07c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_x16(enc & 0xfffffc00, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem0(enc & 0xffe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -5902,7 +5902,7 @@ static uint
 encode_opndsgen_d4000001(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0;
+    uint src0 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 1 &&
         encode_opnd_imm16(enc & 0xffffffff, opcode, pc, instr_get_src(instr, 0), &src0)) {
         ASSERT((src0 & 0xffe0001f) == 0);
@@ -5923,7 +5923,7 @@ static uint
 encode_opndsgen_d503305f(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0;
+    uint src0 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 1 &&
         encode_opnd_imm4(enc & 0xffffffff, opcode, pc, instr_get_src(instr, 0), &src0)) {
         ASSERT((src0 & 0xfffff0ff) == 0);
@@ -5938,7 +5938,7 @@ static uint
 encode_opndsgen_d5080000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1;
+    uint src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 2 &&
         encode_opnd_sysops(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_x0(enc & 0xfff8001f, opcode, pc, instr_get_src(instr, 1), &src1)) {
@@ -5956,7 +5956,7 @@ static uint
 encode_opndsgen_d5280000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xfff8001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_sysops(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5974,7 +5974,7 @@ static uint
 encode_opndsgen_d5300000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xfff0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_sysreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -5992,7 +5992,7 @@ static uint
 encode_opndsgen_d61f0000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0;
+    uint src0 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x5(enc & 0xffffffff, opcode, pc, instr_get_src(instr, 0), &src0)) {
         ASSERT((src0 & 0xfffffc1f) == 0);
@@ -6007,7 +6007,7 @@ static uint
 encode_opndsgen_d63f0000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_impx30(enc & 0xfffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5(enc & 0xffffffff, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6025,7 +6025,7 @@ static uint
 encode_opndsgen_d8000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1;
+    uint src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 2 &&
         encode_opnd_prfop(enc & 0xff00001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_memlit(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 1), &src1)) {
@@ -6043,7 +6043,7 @@ static uint
 encode_opndsgen_dac00800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_x0(enc & 0xfffffc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6061,7 +6061,7 @@ static uint
 encode_opndsgen_f2800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0, src1, src2, src3;
+    uint dst0 = 0, src0 = 0, src1 = 0, src2 = 0, src3 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 4 &&
         encode_opnd_x0(enc & 0xff80001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xff80001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
@@ -6088,7 +6088,7 @@ static uint
 encode_opndsgen_f8000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6106,7 +6106,7 @@ static uint
 encode_opndsgen_f8000400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9post(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6133,7 +6133,7 @@ static uint
 encode_opndsgen_f8000c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6160,7 +6160,7 @@ static uint
 encode_opndsgen_f8200000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 2 &&
         encode_opnd_x0(enc & 0xffe0fc1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem0(enc & 0xffe0ffe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6184,7 +6184,7 @@ static uint
 encode_opndsgen_f8200800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6202,7 +6202,7 @@ static uint
 encode_opndsgen_f8800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1;
+    uint src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 2 &&
         encode_opnd_prfop(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_prf9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 1), &src1)) {
@@ -6220,7 +6220,7 @@ static uint
 encode_opndsgen_f8a00800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1;
+    uint src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 2 &&
         encode_opnd_prfop(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_prfreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 1), &src1)) {
@@ -6238,7 +6238,7 @@ static uint
 encode_opndsgen_f9000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6256,7 +6256,7 @@ static uint
 encode_opndsgen_f9800000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint src0, src1;
+    uint src0 = 0, src1 = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 2 &&
         encode_opnd_prfop(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0) &&
         encode_opnd_prf12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 1), &src1)) {
@@ -6274,7 +6274,7 @@ static uint
 encode_opndsgen_fc000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6292,7 +6292,7 @@ static uint
 encode_opndsgen_fc000400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9post(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6319,7 +6319,7 @@ static uint
 encode_opndsgen_fc000c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6346,7 +6346,7 @@ static uint
 encode_opndsgen_fc200800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d0(enc & 0xffe00c1f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6364,7 +6364,7 @@ static uint
 encode_opndsgen_fc400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_d0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem9(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6382,7 +6382,7 @@ static uint
 encode_opndsgen_fc400400(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_d0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6409,7 +6409,7 @@ static uint
 encode_opndsgen_fc400c00(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, dst1, src0, src1, src2;
+    uint dst0 = 0, dst1 = 0, src0 = 0, src1 = 0, src2 = 0;
     if (instr_num_dsts(instr) == 2 && instr_num_srcs(instr) == 3 &&
         encode_opnd_d0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_x5sp(enc & 0xffe00fe0, opcode, pc, instr_get_dst(instr, 1), &dst1) &&
@@ -6436,7 +6436,7 @@ static uint
 encode_opndsgen_fc600800(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_d0(enc & 0xffe00c1f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_memreg(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6454,7 +6454,7 @@ static uint
 encode_opndsgen_fd000000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_d0(enc & 0xffc0001f, opcode, pc, instr_get_src(instr, 0), &src0)) {
@@ -6472,7 +6472,7 @@ static uint
 encode_opndsgen_fd400000(byte *pc, instr_t *instr, uint enc)
 {
     int opcode = instr->opcode;
-    uint dst0, src0;
+    uint dst0 = 0, src0 = 0;
     if (instr_num_dsts(instr) == 1 && instr_num_srcs(instr) == 1 &&
         encode_opnd_d0(enc & 0xffc0001f, opcode, pc, instr_get_dst(instr, 0), &dst0) &&
         encode_opnd_mem12(enc & 0xffffffe0, opcode, pc, instr_get_src(instr, 0), &src0)) {


### PR DESCRIPTION
Add some unnecessary initialisers to prevent certain compiler versions
from breaking the build by incorrectly claiming that certain variables
"may be used uninitialized".

Change-Id: I8d9bf5497e64e464d3e7e49a3ba7db8daea3ac69