### PR TITLE
i#2488: fix links for memtrace and drltrace in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Tools built on DynamoRIO include:
   [drcpusim](http://dynamorio.org/docs/page_drcpusim.html)
 - The "strace for Windows" tool [drstrace](http://drmemory.org/strace_for_windows.html)
 - The code coverage tool [drcov](http://dynamorio.org/docs/page_drcov.html)
-- The library tracing tool [drltrace](http://drmemory.org/docs/page_drltrace.html)
-- The memory tracing tool [memtrace](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/memtrace.c)
+- The library tracing tool [drltrace](http://dynamorio.org/docs/page_drltrace.html)
+- The memory tracing tool [memtrace](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/memtrace_simple.c)
 - The basic block tracing tool [bbbuf](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/bbbuf.c)
 - The instruction counting tool [inscount](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/inscount.cpp)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Tools built on DynamoRIO include:
   [drcpusim](http://dynamorio.org/docs/page_drcpusim.html)
 - The "strace for Windows" tool [drstrace](http://drmemory.org/strace_for_windows.html)
 - The code coverage tool [drcov](http://dynamorio.org/docs/page_drcov.html)
-- The library tracing tool [drltrace](http://dynamorio.org/docs/page_drltrace.html)
+- The library tracing tool [drltrace](https://github.com/DynamoRIO/drmemory/tree/master/drltrace)
 - The memory tracing tool [memtrace](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/memtrace_simple.c)
 - The basic block tracing tool [bbbuf](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/bbbuf.c)
 - The instruction counting tool [inscount](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/inscount.cpp)


### PR DESCRIPTION
Fixes #2488.