### PR TITLE
i#2540: use 128k for -stack_size in nightly tests.

### DIFF
--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -1576,14 +1576,15 @@ are specified via \c drconfig, \c drrun, or dr_register_process().  See
    is specified.
 
  - \b -stack_size \e \<number\>: \anchor op_stack_size
-   DynamoRIO's per-thread stack is limited to 56KB by default (this may
-   seem small, but this is much larger than its size when no client is
-   present).  This parameter can be used to increase the size; however,
-   larger stack sizes use significantly more memory when targeting
+   DynamoRIO's per-thread stack is limited to 56KB by default on systems
+   with a 4K page size (this may seem small, but this is much larger than its size
+   when no client is present). For systems with different page sizes, it defaults
+   to 2 * page size. This parameter can be used to increase the size;
+   however, larger stack sizes use significantly more memory when targeting
    applications with hundreds of threads.  The parameter can take a 'K'
-   suffix, and must be a multiple of the page size (4K).  This stack is
-   used \if vmsafe for probe callbacks and by the Code Manipulation
-   API \else by the \endif routines dr_insert_clean_call(),
+   suffix, and must be a multiple of the page size (4K, 16K or 64K depending on
+   the system).  This stack is used \if vmsafe for probe callbacks and by
+   the Code Manipulation API \else by the \endif routines dr_insert_clean_call(),
    dr_swap_to_clean_stack(), dr_prepare_for_call(),
    dr_insert_call_instrumentation(), dr_insert_mbr_instrumentation(),
    dr_insert_cbr_instrumentation(), and dr_insert_ubr_instrumentation().

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -117,10 +117,10 @@ set(vmap_run_list
   "X86::-prof_pcs -thread_private"                 # i#1884: ARM thread_private NYI
   "X86::LIN::ONLY::^common::-code_api -no_early_inject" # ARM only supports early
   "DEBUG::ONLY::^common::-code_api -loglevel 1"
-  "ONLY::^common::-code_api -stack_size 120k"
+  "ONLY::^common::-code_api -stack_size 128k"
   "WIN::ONLY::^(runall|client)::-enable_full_api"
-  "DEBUG::WIN::ONLY::^(common|client)::-code_api -stack_size 120K -loglevel 1 -no_hide"
-  "DEBUG::LIN::ONLY::^(common|client)::-code_api -stack_size 120K -loglevel 1"
+  "DEBUG::WIN::ONLY::^(common|client)::-code_api -stack_size 128K -loglevel 1 -no_hide"
+  "DEBUG::LIN::ONLY::^(common|client)::-code_api -stack_size 128K -loglevel 1"
   "ONLY::^common::"
   "X86::LIN::ONLY::^${osname}::-code_api -sysenter_is_int80"
 


### PR DESCRIPTION
By using 128k for -stack_size, we ensure that stack_size is a multiple
of all valid page sizes on AArch64 (4k, 16k and 64k).

Fixes #2540.