### PR TITLE
i#2006 generalize drcachesim: declare drmemtrace_client_main

### DIFF
--- a/clients/drcachesim/tracer/drmemtrace.h
+++ b/clients/drcachesim/tracer/drmemtrace.h
@@ -55,6 +55,15 @@ typedef enum {
 } drmemtrace_status_t;
 
 /**
+ * To support statically linking multiple clients on UNIX, dr_client_main() inside
+ * drmemtrace is a weak symbol which just calls the real initializer
+ * drmemtrace_client_main().  An enclosing application can override dr_client_main()
+ * and invoke drmemtrace_client_main() explicitly at a time of its choosing.
+ */
+void
+drmemtrace_client_main(client_id_t id, int argc, const char *argv[]);
+
+/**
  * Function for file open.
  * The file access mode is set by the \p mode_flags argument which is drawn from
  * the DR_FILE_* defines ORed together.  Returns INVALID_FILE if unsuccessful.

--- a/clients/drcachesim/tracer/drmemtrace.h
+++ b/clients/drcachesim/tracer/drmemtrace.h
@@ -54,6 +54,7 @@ typedef enum {
     DRMEMTRACE_ERROR_INVALID_PARAMETER,  /**< Operation failed: invalid parameter */
 } drmemtrace_status_t;
 
+DR_EXPORT
 /**
  * To support statically linking multiple clients on UNIX, dr_client_main() inside
  * drmemtrace is a weak symbol which just calls the real initializer


### PR DESCRIPTION
Adds drmemtrace_client_main() to the drmemtrace.h header for use by
applications statically linking in the drmemtrace client.

The existing burst_static test for this linking feature did not need a
declaration as it tests a duplicate weak symbol, so there are no test
changes here.