### PR TITLE
i#2511 isolate raw2trace: build tests on x86 only

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -337,7 +337,7 @@ if (BUILD_TESTS)
     target_link_libraries(tool.drcacheoff.burst_threads ${libpthread})
 
     if (UNIX)
-      if (NOT APPLE)
+      if (X86 AND NOT APPLE) # This test is x86-specific.
         # uses ptrace and looks for linux-specific syscalls
         add_executable(tool.drcacheoff.raw2trace_io tests/raw2trace_io.cpp
           tracer/instru.cpp

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -311,6 +311,7 @@ if (UNIX AND ARCH_IS_X86)
   testbuild_ex("arm-debug-internal-32" OFF "
     DEBUG:BOOL=ON
     INTERNAL:BOOL=ON
+    BUILD_TESTS:BOOL=ON
     CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
     " OFF OFF "")
   testbuild_ex("arm-release-external-32" OFF "
@@ -321,6 +322,7 @@ if (UNIX AND ARCH_IS_X86)
   testbuild_ex("arm-debug-internal-64" ON "
     DEBUG:BOOL=ON
     INTERNAL:BOOL=ON
+    BUILD_TESTS:BOOL=ON
     CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
     " OFF OFF "")
   testbuild_ex("arm-release-external-64" ON "

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -311,7 +311,6 @@ if (UNIX AND ARCH_IS_X86)
   testbuild_ex("arm-debug-internal-32" OFF "
     DEBUG:BOOL=ON
     INTERNAL:BOOL=ON
-    BUILD_TESTS:BOOL=ON
     CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
     " OFF OFF "")
   testbuild_ex("arm-release-external-32" OFF "
@@ -322,7 +321,6 @@ if (UNIX AND ARCH_IS_X86)
   testbuild_ex("arm-debug-internal-64" ON "
     DEBUG:BOOL=ON
     INTERNAL:BOOL=ON
-    BUILD_TESTS:BOOL=ON
     CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
     " OFF OFF "")
   testbuild_ex("arm-release-external-64" ON "

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2564,7 +2564,7 @@ if (CLIENT_INTERFACE)
           torunonly_drcacheoff(burst_threads tool.drcacheoff.burst_threads "" "")
           set(tool.drcacheoff.burst_threads_nodr ON)
 
-          if (NOT APPPLE)
+          if (X86 AND NOT APPPLE) # This test is x86-specific.
             # Test that raw2trace doesn't do more IO than it should.
             get_target_path_for_execution(raw2trace_io_path tool.drcacheoff.raw2trace_io)
             prefix_cmd_if_necessary(raw2trace_io_path ON ${raw2trace_io_path})


### PR DESCRIPTION
Fixes ARM build breakage from 66fa2c78 whose test is x86-specific.

Adds test building to the ARM and AArch64 cross-compile debug builds to
catch such errors in the future.