### PR TITLE
i#2207: enable Android cross build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ env:
   # With or without cross-compiling:
   - DYNAMORIO_CROSS_ONLY=yes
   # Cross-compile for Android only.
-  - DYNAMORIO_CROSS_ANDROID_ONLY=yes EXTRA_ARGS='-DANDROID_TOOLCHAIN=/tmp/android-gcc-arm-ndk-10e'
+  - DYNAMORIO_CROSS_ANDROID_ONLY=yes DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e'
   # We run 32-bit and 64-bit in parallel to speed things up.
   - DYNAMORIO_CROSS_ONLY=no EXTRA_ARGS=32_only
   - DYNAMORIO_CROSS_ONLY=no EXTRA_ARGS=64_only
@@ -83,7 +83,7 @@ matrix:
     - compiler: clang
       env: DYNAMORIO_CROSS_ONLY=yes
     - compiler: clang
-      env: DYNAMORIO_CROSS_ANDROID_ONLY=yes EXTRA_ARGS='-DANDROID_TOOLCHAIN=/tmp/android-gcc-arm-ndk-10e'
+      env: DYNAMORIO_CROSS_ANDROID_ONLY=yes DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e'
 
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,9 +112,8 @@ install:
               --platform=android-21 \
               --install-dir=/tmp/android-gcc-arm-ndk-10e
           # Manually force using ld.bfd, setting CMAKE_LINKER does not work.
-          rm /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
-          ln -s /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld.bfd \
-                /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
+          ln -sf ld.bfd /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
+          ln -sf arm-linux-androideabi-ld.bfd /tmp/android-gcc-arm-ndk-10e/bin/arm-linux-androideabi-ld
           cd -
       fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ matrix:
     - compiler: clang
       env: DYNAMORIO_CROSS_ONLY=yes
     - compiler: clang
-      env: DYNAMORIO_CROSS_ANDROID_ONLY=yes
+      env: DYNAMORIO_CROSS_ANDROID_ONLY=yes EXTRA_ARGS='-DANDROID_TOOLCHAIN=/tmp/android-gcc-arm-ndk-10e'
 
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:
@@ -105,7 +105,7 @@ install:
   - >
       if [[ "`uname`" == "Linux" && $DYNAMORIO_CROSS_ANDROID_ONLY == yes ]]; then
           wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
-          unzip android-ndk-r10e-linux-x86_64.zip
+          unzip -q android-ndk-r10e-linux-x86_64.zip
           android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
               --toolchain=arm-linux-androideabi-4.9 \
               --platform=android-21 \

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ install:
   # Fetch and install Android NDK for Andoid cross-compile build only.
   - >
       if [[ "`uname`" == "Linux" && $DYNAMORIO_CROSS_ANDROID_ONLY == yes ]]; then
+          cd /tmp
           wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
           unzip -q android-ndk-r10e-linux-x86_64.zip
           android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
@@ -114,6 +115,7 @@ install:
           rm /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
           ln -s /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld.bfd \
                 /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
+          cd -
       fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,12 +61,12 @@ compiler:
 
 env:
   # With or without cross-compiling:
-  - DYNAMORIO_CROSS_ONLY=yes
+  - DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=yes
   # Cross-compile for Android only.
   - DYNAMORIO_CROSS_ANDROID_ONLY=yes DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e'
   # We run 32-bit and 64-bit in parallel to speed things up.
-  - DYNAMORIO_CROSS_ONLY=no EXTRA_ARGS=32_only
-  - DYNAMORIO_CROSS_ONLY=no EXTRA_ARGS=64_only
+  - DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no EXTRA_ARGS=32_only
+  - DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no EXTRA_ARGS=64_only
 
 matrix:
   exclude:
@@ -75,13 +75,13 @@ matrix:
       compiler: gcc
     # We do not have 64-bit support on OSX yet (i#1979).
     - os: osx
-      env: DYNAMORIO_CROSS_ONLY=no EXTRA_ARGS=64_only
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no EXTRA_ARGS=64_only
     # Cross-compile only on Linux:
     - os: osx
-      env: DYNAMORIO_CROSS_ONLY=yes
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=yes
     # Cross-compile only with GCC:
     - compiler: clang
-      env: DYNAMORIO_CROSS_ONLY=yes
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=yes
     - compiler: clang
       env: DYNAMORIO_CROSS_ANDROID_ONLY=yes DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e'
 
@@ -95,11 +95,11 @@ install:
       sudo apt-get -y install doxygen transfig vera++; fi
   # Install multilib for non-cross-compiling Linux builds:
   - >
-      if [[ "`uname`" == "Linux" && $DYNAMORIO_CROSS_ONLY == no ]]; then
+      if [[ "`uname`" == "Linux" && $DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY == no ]]; then
       sudo apt-get -y install g++-multilib; fi
   # Install cross-compilers for cross-compiling Linux build:
   - >
-      if [[ "`uname`" == "Linux" && $DYNAMORIO_CROSS_ONLY == yes ]]; then
+      if [[ "`uname`" == "Linux" && $DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY == yes ]]; then
       sudo apt-get -y install g++-arm-linux-gnueabihf g++-aarch64-linux-gnu; fi
   # Fetch and install Android NDK for Andoid cross-compile build only.
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ compiler:
 env:
   # With or without cross-compiling:
   - DYNAMORIO_CROSS_ONLY=yes
+  # Cross-compile for Android only.
+  - DYNAMORIO_CROSS_ANDROID_ONLY=yes EXTRA_ARGS='-DANDROID_TOOLCHAIN=/tmp/android-gcc-arm-ndk-10e'
   # We run 32-bit and 64-bit in parallel to speed things up.
   - DYNAMORIO_CROSS_ONLY=no EXTRA_ARGS=32_only
   - DYNAMORIO_CROSS_ONLY=no EXTRA_ARGS=64_only
@@ -80,6 +82,8 @@ matrix:
     # Cross-compile only with GCC:
     - compiler: clang
       env: DYNAMORIO_CROSS_ONLY=yes
+    - compiler: clang
+      env: DYNAMORIO_CROSS_ANDROID_ONLY=yes
 
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:
@@ -97,6 +101,21 @@ install:
   - >
       if [[ "`uname`" == "Linux" && $DYNAMORIO_CROSS_ONLY == yes ]]; then
       sudo apt-get -y install g++-arm-linux-gnueabihf g++-aarch64-linux-gnu; fi
+  # Fetch and install Android NDK for Andoid cross-compile build only.
+  - >
+      if [[ "`uname`" == "Linux" && $DYNAMORIO_CROSS_ANDROID_ONLY == yes ]]; then
+          wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
+          unzip android-ndk-r10e-linux-x86_64.zip
+          android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
+              --toolchain=arm-linux-androideabi-4.9 \
+              --platform=android-21 \
+              --install-dir=/tmp/android-gcc-arm-ndk-10e
+          # Manually force using ld.bfd, setting CMAKE_LINKER does not work.
+          rm /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
+          ln -s /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld.bfd \
+                /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
+      fi
+
 
 script:
   - suite/runsuite_wrapper.pl travis $EXTRA_ARGS

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -45,13 +45,13 @@ include("${CTEST_SCRIPT_DIRECTORY}/runsuite_common_pre.cmake")
 # extra args (note that runsuite_common_pre.cmake has already walked
 # the list and did not remove its args so be sure to avoid conflicts).
 set(arg_travis OFF)
-set(cross_only OFF)
+set(cross_aarchxx_linux_only OFF)
 set(cross_android_only OFF)
 foreach (arg ${CTEST_SCRIPT_ARG})
   if (${arg} STREQUAL "travis")
     set(arg_travis ON)
-    if ($ENV{DYNAMORIO_CROSS_ONLY} MATCHES "yes")
-      set(cross_only ON)
+    if ($ENV{DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY} MATCHES "yes")
+      set(cross_aarchxx_linux_only ON)
     endif()
     if ($ENV{DYNAMORIO_CROSS_ANDROID_ONLY} MATCHES "yes")
       set(cross_android_only ON)
@@ -191,7 +191,7 @@ endif ()
 # (since building takes forever on windows): so we only turn
 # on BUILD_TESTS for TEST_LONG or debug-internal-{32,64}
 
-if (NOT cross_only AND NOT cross_android_only)
+if (NOT cross_aarchxx_linux_only AND NOT cross_android_only)
   # For cross-arch execve test we need to "make install"
   testbuild_ex("debug-internal-32" OFF "
     DEBUG:BOOL=ON
@@ -303,14 +303,14 @@ if (NOT cross_only AND NOT cross_android_only)
         ")
     endif (DO_ALL_BUILDS)
   endif (ARCH_IS_X86 AND NOT APPLE)
-endif (NOT cross_only AND NOT cross_android_only)
+endif (NOT cross_aarchxx_linux_only AND NOT cross_android_only)
 
 if (UNIX AND ARCH_IS_X86)
   # Optional cross-compilation for ARM/Linux and ARM/Android if the cross
   # compilers are on the PATH.
   set(prev_optional_cross_compile ${optional_cross_compile})
-  if (NOT cross_only)
-    # For Travis cross_only builds, we want to fail on config failures.
+  if (NOT cross_aarchxx_linux_only)
+    # For Travis cross_aarchxx_linux_only builds, we want to fail on config failures.
     # For user suite runs, we want to just skip if there's no cross setup.
     set(optional_cross_compile ON)
   endif ()
@@ -319,30 +319,28 @@ if (UNIX AND ARCH_IS_X86)
   set(ENV{CXXFLAGS} "")
   set(prev_run_tests ${run_tests})
   set(run_tests OFF) # build tests but don't run them
-  if (NOT cross_android_only)
-      testbuild_ex("arm-debug-internal-32" OFF "
-        DEBUG:BOOL=ON
-        INTERNAL:BOOL=ON
-        BUILD_TESTS:BOOL=ON
-        CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
-        " OFF OFF "")
-      testbuild_ex("arm-release-external-32" OFF "
-        DEBUG:BOOL=OFF
-        INTERNAL:BOOL=OFF
-        CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
-        " OFF OFF "")
-      testbuild_ex("arm-debug-internal-64" ON "
-        DEBUG:BOOL=ON
-        INTERNAL:BOOL=ON
-        BUILD_TESTS:BOOL=ON
-        CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
-        " OFF OFF "")
-      testbuild_ex("arm-release-external-64" ON "
-        DEBUG:BOOL=OFF
-        INTERNAL:BOOL=OFF
-        CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
-        " OFF OFF "")
-  endif (NOT cross_android_only)
+  testbuild_ex("arm-debug-internal-32" OFF "
+    DEBUG:BOOL=ON
+    INTERNAL:BOOL=ON
+    BUILD_TESTS:BOOL=ON
+    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
+    " OFF OFF "")
+  testbuild_ex("arm-release-external-32" OFF "
+    DEBUG:BOOL=OFF
+    INTERNAL:BOOL=OFF
+    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
+    " OFF OFF "")
+  testbuild_ex("arm-debug-internal-64" ON "
+    DEBUG:BOOL=ON
+    INTERNAL:BOOL=ON
+    BUILD_TESTS:BOOL=ON
+    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
+    " OFF OFF "")
+  testbuild_ex("arm-release-external-64" ON "
+    DEBUG:BOOL=OFF
+    INTERNAL:BOOL=OFF
+    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
+    " OFF OFF "")
   set(run_tests ${prev_run_tests})
   set(optional_cross_compile ${prev_optional_cross_compile})
 

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -319,7 +319,7 @@ if (UNIX AND ARCH_IS_X86)
   set(ENV{CXXFLAGS} "")
   set(prev_run_tests ${run_tests})
   set(run_tests OFF) # build tests but don't run them
-  if (not cross_android_only)
+  if (NOT cross_android_only)
       testbuild_ex("arm-debug-internal-32" OFF "
         DEBUG:BOOL=ON
         INTERNAL:BOOL=ON

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -308,6 +308,7 @@ endif (NOT cross_only AND NOT cross_android_only)
 if (UNIX AND ARCH_IS_X86)
   # Optional cross-compilation for ARM/Linux and ARM/Android if the cross
   # compilers are on the PATH.
+  set(prev_optional_cross_compile ${optional_cross_compile})
   if (NOT cross_only)
     # For Travis cross_only builds, we want to fail on config failures.
     # For user suite runs, we want to just skip if there's no cross setup.
@@ -343,13 +344,9 @@ if (UNIX AND ARCH_IS_X86)
         " OFF OFF "")
   endif (NOT cross_android_only)
   set(run_tests ${prev_run_tests})
+  set(optional_cross_compile ${prev_optional_cross_compile})
 
   # Android cross-compilation and running of tests using "adb shell"
-  # For Travis cross_android_only builds, we want to fail on config failures.
-  # For user suite runs, we want to just skip if there's no cross setup.
-  if (NOT cross_android_only)
-      set(optional_cross_compile ON)
-  endif ()
   find_program(ADB adb DOC "adb Android utility")
   if (ADB)
     execute_process(COMMAND ${ADB} get-state
@@ -376,12 +373,18 @@ if (UNIX AND ARCH_IS_X86)
   endif ()
 
   # Pass through toolchain file.
-  if(DEFINED ENV{DYNAMORIO_ANDROID_TOOLCHAIN})
+  if (DEFINED ENV{DYNAMORIO_ANDROID_TOOLCHAIN})
     set(android_extra_dbg "${android_extra_dbg}
                            ANDROID_TOOLCHAIN:PATH=$ENV{DYNAMORIO_ANDROID_TOOLCHAIN}")
     set(android_extra_rel "${android_extra_dbg}
                            ANDROID_TOOLCHAIN:PATH=$ENV{DYNAMORIO_ANDROID_TOOLCHAIN}")
   endif()
+
+  # For Travis cross_android_only builds, we want to fail on config failures.
+  # For user suite runs, we want to just skip if there's no cross setup.
+  if (NOT cross_android_only)
+      set(optional_cross_compile ON)
+  endif ()
 
   testbuild_ex("android-debug-internal-32" OFF "
     DEBUG:BOOL=ON
@@ -398,7 +401,7 @@ if (UNIX AND ARCH_IS_X86)
     " OFF OFF "")
   set(run_tests ${prev_run_tests})
 
-  set(optional_cross_compile OFF)
+  set(optional_cross_compile ${prev_optional_cross_compile})
   set(ARCH_IS_X86 ON)
 endif (UNIX AND ARCH_IS_X86)
 

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -46,12 +46,17 @@ include("${CTEST_SCRIPT_DIRECTORY}/runsuite_common_pre.cmake")
 # the list and did not remove its args so be sure to avoid conflicts).
 set(arg_travis OFF)
 set(cross_only OFF)
+set(cross_android_only OFF)
 foreach (arg ${CTEST_SCRIPT_ARG})
   if (${arg} STREQUAL "travis")
     set(arg_travis ON)
     if ($ENV{DYNAMORIO_CROSS_ONLY} MATCHES "yes")
       set(cross_only ON)
     endif()
+    if ($ENV{DYNAMORIO_CROSS_ANDROID_ONLY} MATCHES "yes")
+      set(cross_android_only ON)
+    endif()
+
   endif ()
 endforeach (arg)
 
@@ -339,8 +344,11 @@ if (UNIX AND ARCH_IS_X86)
   set(run_tests ${prev_run_tests})
 
   # Android cross-compilation and running of tests using "adb shell"
-  # FIXME i#2207: once we have Android cross-compilation working on Travis, remove this:
-  set(optional_cross_compile ON)
+  # For Travis cross_android_only builds, we want to fail on config failures.
+  # For user suite runs, we want to just skip if there's no cross setup.
+  if (NOT cross_android_only)
+      set(optional_cross_compile ON)
+  endif ()
   find_program(ADB adb DOC "adb Android utility")
   if (ADB)
     execute_process(COMMAND ${ADB} get-state

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -192,7 +192,7 @@ endif ()
 # (since building takes forever on windows): so we only turn
 # on BUILD_TESTS for TEST_LONG or debug-internal-{32,64}
 
-if (NOT cross_only)
+if (NOT cross_only AND NOT cross_android_only)
   # For cross-arch execve test we need to "make install"
   testbuild_ex("debug-internal-32" OFF "
     DEBUG:BOOL=ON
@@ -304,7 +304,7 @@ if (NOT cross_only)
         ")
     endif (DO_ALL_BUILDS)
   endif (ARCH_IS_X86 AND NOT APPLE)
-endif (NOT cross_only)
+endif (NOT cross_only AND NOT cross_android_only)
 
 if (UNIX AND ARCH_IS_X86)
   # Optional cross-compilation for ARM/Linux and ARM/Android if the cross
@@ -319,28 +319,30 @@ if (UNIX AND ARCH_IS_X86)
   set(ENV{CXXFLAGS} "")
   set(prev_run_tests ${run_tests})
   set(run_tests OFF) # build tests but don't run them
-  testbuild_ex("arm-debug-internal-32" OFF "
-    DEBUG:BOOL=ON
-    INTERNAL:BOOL=ON
-    BUILD_TESTS:BOOL=ON
-    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
-    " OFF OFF "")
-  testbuild_ex("arm-release-external-32" OFF "
-    DEBUG:BOOL=OFF
-    INTERNAL:BOOL=OFF
-    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
-    " OFF OFF "")
-  testbuild_ex("arm-debug-internal-64" ON "
-    DEBUG:BOOL=ON
-    INTERNAL:BOOL=ON
-    BUILD_TESTS:BOOL=ON
-    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
-    " OFF OFF "")
-  testbuild_ex("arm-release-external-64" ON "
-    DEBUG:BOOL=OFF
-    INTERNAL:BOOL=OFF
-    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
-    " OFF OFF "")
+  if (not cross_android_only)
+      testbuild_ex("arm-debug-internal-32" OFF "
+        DEBUG:BOOL=ON
+        INTERNAL:BOOL=ON
+        BUILD_TESTS:BOOL=ON
+        CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
+        " OFF OFF "")
+      testbuild_ex("arm-release-external-32" OFF "
+        DEBUG:BOOL=OFF
+        INTERNAL:BOOL=OFF
+        CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
+        " OFF OFF "")
+      testbuild_ex("arm-debug-internal-64" ON "
+        DEBUG:BOOL=ON
+        INTERNAL:BOOL=ON
+        BUILD_TESTS:BOOL=ON
+        CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
+        " OFF OFF "")
+      testbuild_ex("arm-release-external-64" ON "
+        DEBUG:BOOL=OFF
+        INTERNAL:BOOL=OFF
+        CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
+        " OFF OFF "")
+   endif (NOT cross_android_only)
   set(run_tests ${prev_run_tests})
 
   # Android cross-compilation and running of tests using "adb shell"

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -56,7 +56,6 @@ foreach (arg ${CTEST_SCRIPT_ARG})
     if ($ENV{DYNAMORIO_CROSS_ANDROID_ONLY} MATCHES "yes")
       set(cross_android_only ON)
     endif()
-
   endif ()
 endforeach (arg)
 
@@ -342,7 +341,7 @@ if (UNIX AND ARCH_IS_X86)
         INTERNAL:BOOL=OFF
         CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
         " OFF OFF "")
-   endif (NOT cross_android_only)
+  endif (NOT cross_android_only)
   set(run_tests ${prev_run_tests})
 
   # Android cross-compilation and running of tests using "adb shell"
@@ -375,6 +374,15 @@ if (UNIX AND ARCH_IS_X86)
     set(android_extra_rel "")
     set(run_tests OFF) # build tests but don't run them
   endif ()
+
+  # Pass through toolchain file.
+  if(DEFINED ENV{DYNAMORIO_ANDROID_TOOLCHAIN})
+    set(android_extra_dbg "${android_extra_dbg}
+                           ANDROID_TOOLCHAIN:PATH=$ENV{DYNAMORIO_ANDROID_TOOLCHAIN}")
+    set(android_extra_rel "${android_extra_dbg}
+                           ANDROID_TOOLCHAIN:PATH=$ENV{DYNAMORIO_ANDROID_TOOLCHAIN}")
+  endif()
+
   testbuild_ex("android-debug-internal-32" OFF "
     DEBUG:BOOL=ON
     INTERNAL:BOOL=ON

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -82,7 +82,7 @@ if ($child) {
         $mydir = `/usr/bin/cygpath -wi \"$mydir\"`;
         chomp $mydir;
     }
-    system("ctest --output-on-failure -V -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
+    system("ctest --output-on-failure -VV -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
     exit 0;
 }
 

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -82,7 +82,7 @@ if ($child) {
         $mydir = `/usr/bin/cygpath -wi \"$mydir\"`;
         chomp $mydir;
     }
-    system("ctest --output-on-failure -VV -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
+    system("ctest --output-on-failure -V -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
     exit 0;
 }
 


### PR DESCRIPTION
For the Android cross build, we fetch Android NDK r10e and set it up to
use ld.bfd as ld for the build to work. Newer versions of the Android
NDK won't work until #1927 is fixed.

This commit introduces a new DYNAMORIO_CROSS_ANDROID_ONLY environment
variable, to allow building for Android on a separate instance, because
fetching the NDK might take a while.

Fixes #2207