### PR TITLE
i#2557: fix fencepost error in find_free_memory_in_region()

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -3209,7 +3209,7 @@ find_free_memory_in_region(byte *start, byte *end, size_t size,
             found = true;
             break;
         }
-        if (iter.vm_start >= end)
+        if (iter.vm_end >= end)
             break;
         last_end = iter.vm_end;
     }


### PR DESCRIPTION
Fixes an error where find_free_memory_in_region() thinks that an occupied
region that spans the requested endpoint is free, resulting in an infinite
loop in os_heap_reserve_in_region().

Manually tested on the app whose maps file hit this.  (Creating a suite
test is non-trivial without a mock for the maps iterator.)

Fixes #2557