### PR TITLE
i#2082 : Sets translation when recreating app state from info

### DIFF
--- a/core/translate.c
+++ b/core/translate.c
@@ -531,6 +531,8 @@ recreate_app_state_from_info(dcontext_t *tdcontext, const translation_info_t *in
         prev_cpc = cpc;
         cpc = decode(tdcontext, cpc, &instr);
         instr_set_our_mangling(&instr, ours);
+        /* Sets the translation so that spilled registers can be restored. */
+        instr_set_translation(&instr, answer);
         translate_walk_track(tdcontext, &instr, &walk);
 
         /* advance translation by the stride: either instr length or 0 */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2277,6 +2277,9 @@ if (CLIENT_INTERFACE)
 
   if (X86) # FIXME i#1551, i#1569: port asm to ARM and AArch64
     tobuild_ci(client.retaddr client-interface/retaddr.c "" "" "")
+  endif (X86)
+
+  if (X86 AND WIN32) # FIXME port test application to other systems
     tobuild_ci(client.translate_sandbox client-interface/translate_sandbox.c "" "" "")
   endif (X86)
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2277,6 +2277,7 @@ if (CLIENT_INTERFACE)
 
   if (X86) # FIXME i#1551, i#1569: port asm to ARM and AArch64
     tobuild_ci(client.retaddr client-interface/retaddr.c "" "" "")
+    tobuild_ci(client.translate_sandbox client-interface/translate_sandbox.c "" "" "")
   endif (X86)
 
   if (NOT ANDROID) # XXX i#1874: get working on Android

--- a/suite/tests/client-interface/translate_sandbox.c
+++ b/suite/tests/client-interface/translate_sandbox.c
@@ -38,6 +38,16 @@
 int sandbox();
 int usebx();
 
+/* top-level exception handler */
+static LONG
+our_top_handler(struct _EXCEPTION_POINTERS * pExceptionInfo)
+{
+    if (pExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {
+        print("access violation exception\n");
+        return EXCEPTION_CONTINUE_EXECUTION;
+    }
+    return EXCEPTION_EXECUTE_HANDLER; /* => global unwind and silent death */
+}
 
 int main(int argc, char *argv[])
 {
@@ -46,7 +56,7 @@ int main(int argc, char *argv[])
     int count = 0;
     print("start of test, count = %d\n", count);
     protect_mem(sandbox, 1024, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
-    protect_mem(usebx, 1024, ALLOW_READ|ALLOW_WRITE);
+    protect_mem(usebx, 1024, ALLOW_READ);
     count = sandbox();
     protect_mem(usebx, 1024, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
     count += usebx();

--- a/suite/tests/client-interface/translate_sandbox.c
+++ b/suite/tests/client-interface/translate_sandbox.c
@@ -1,0 +1,132 @@
+/* **********************************************************
+ * Copyright (c) 2012-2015 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef ASM_CODE_ONLY /* C code */
+#include "tools.h" /* for print() */
+
+#include <assert.h>
+
+int sandbox();
+int usebx();
+
+
+int main(int argc, char *argv[])
+{
+    INIT();
+
+    int count = 0;
+    print("start of test, count = %d\n", count);
+    protect_mem(sandbox, 1024, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
+    protect_mem(usebx, 1024, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
+    count = sandbox();
+    count += usebx();
+    print("end of test, count = %d\n", count);
+    return 0;
+}
+
+
+#else /* asm code *************************************************************/
+#include "asm_defines.asm"
+START_FILE
+
+#if defined(ASSEMBLE_WITH_GAS)
+# define ALIGN_WITH_NOPS(bytes) .align (bytes)
+# define FILL_WITH_NOPS(bytes)  .fill  (bytes), 1, 0x90
+#elif defined(ASSEMBLE_WITH_MASM)
+/* Cannot align to a value greater than the section alignment.  See .mytext
+ * below.
+ */
+# define ALIGN_WITH_NOPS(bytes) ALIGN bytes
+# define FILL_WITH_NOPS(bytes) \
+    REPEAT (bytes) @N@\
+        nop @N@\
+        ENDM
+#else
+# define ALIGN_WITH_NOPS(bytes) ALIGN bytes
+# define FILL_WITH_NOPS(bytes) TIMES bytes nop
+#endif
+
+#if defined(ASSEMBLE_WITH_MASM)
+/* The .text section on Windows is only 16 byte aligned.  If we use plain
+ * ALIGN_WITH_NOPS(), we get error A2189.  We can't re-declare .text, but we can
+ * declare a new section with greater alignment.  The EXECUTE gets the right
+ * protections and makes ALIGN_WITH_NOPS() do nop fill.
+ */
+_MYTEXT SEGMENT ALIGN(4096) READ EXECUTE SHARED ALIAS(".mytext")
+#endif
+
+/* int sandbox()
+ *   Modifies self to enter sandbox.
+ *   Then does another self modification in another page.
+ *   Should return 2 (using ebx).
+ */
+
+#define FUNCNAME sandbox
+DECLARE_FUNC(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        mov      REG_XAX, HEX(1)
+        lea      REG_XDX, SYMREF(sandbox_immediate_addr_plus_four - 4)
+        mov      DWORD [REG_XDX], eax        /* selfmod write */
+        mov      REG_XDX, HEX(0)             /* mov_imm to modify */
+ADDRTAKEN_LABEL(sandbox_immediate_addr_plus_four:)
+        mov      REG_XAX, HEX(1)
+        mov      REG_XBX, HEX(2)
+        lea      REG_XDX, SYMREF(usebx_immediate_addr_plus_four - 4)
+        mov      DWORD [REG_XDX], eax        /* selfmod write in another page */
+        mov      REG_XAX, REG_XBX
+        ret
+END_FUNC(FUNCNAME)
+#undef FUNCNAME
+
+ALIGN_WITH_NOPS(4096)
+FILL_WITH_NOPS(4096)
+
+/* int usebx()
+ *   should return 1.
+ */
+
+#define FUNCNAME usebx
+DECLARE_FUNC(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        mov      REG_XDX, HEX(0)             /* mov_imm modified */
+ADDRTAKEN_LABEL(usebx_immediate_addr_plus_four:)
+        mov      REG_XAX, REG_XDX
+        ret
+END_FUNC(FUNCNAME)
+#undef FUNCNAME
+
+#ifdef ASSEMBLE_WITH_MASM
+_MYTEXT ENDS
+#endif
+
+END_FILE
+#endif

--- a/suite/tests/client-interface/translate_sandbox.c
+++ b/suite/tests/client-interface/translate_sandbox.c
@@ -44,6 +44,7 @@ our_top_handler(struct _EXCEPTION_POINTERS * pExceptionInfo)
 {
     if (pExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {
         print("access violation exception\n");
+        protect_mem(usebx, 1024, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
         return EXCEPTION_CONTINUE_EXECUTION;
     }
     return EXCEPTION_EXECUTE_HANDLER; /* => global unwind and silent death */
@@ -52,13 +53,14 @@ our_top_handler(struct _EXCEPTION_POINTERS * pExceptionInfo)
 int main(int argc, char *argv[])
 {
     INIT();
-
     int count = 0;
+
+    SetUnhandledExceptionFilter((LPTOP_LEVEL_EXCEPTION_FILTER) our_top_handler);
+
     print("start of test, count = %d\n", count);
     protect_mem(sandbox, 1024, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
     protect_mem(usebx, 1024, ALLOW_READ);
     count = sandbox();
-    protect_mem(usebx, 1024, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
     count += usebx();
     print("end of test, count = %d\n", count);
     return 0;

--- a/suite/tests/client-interface/translate_sandbox.c
+++ b/suite/tests/client-interface/translate_sandbox.c
@@ -46,8 +46,9 @@ int main(int argc, char *argv[])
     int count = 0;
     print("start of test, count = %d\n", count);
     protect_mem(sandbox, 1024, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
-    protect_mem(usebx, 1024, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
+    protect_mem(usebx, 1024, ALLOW_READ|ALLOW_WRITE);
     count = sandbox();
+    protect_mem(usebx, 1024, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
     count += usebx();
     print("end of test, count = %d\n", count);
     return 0;

--- a/suite/tests/client-interface/translate_sandbox.c
+++ b/suite/tests/client-interface/translate_sandbox.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2017 Simorfo, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -64,9 +65,9 @@ int main(int argc, char *argv[])
     print("start of test, count = %d\n", count);
     protect_mem(sandbox, MEMCHANGE_SIZE, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
     protect_mem(usebx, MEMCHANGE_SIZE, ALLOW_READ);
-    /* Sets dynamrio in sandboxing mode and generates an exception.
+    /* Sets DynamoRIO in sandboxing mode and generates an exception.
      * With a client storing translations, it is tested that
-     * dynamoRIO manages to restore spilled ebx register.
+     * DynamoRIO manages to restore spilled ebx register.
      */
     count = sandbox();
     count += usebx();

--- a/suite/tests/client-interface/translate_sandbox.c
+++ b/suite/tests/client-interface/translate_sandbox.c
@@ -100,8 +100,8 @@ GLOBAL_LABEL(FUNCNAME:)
 ADDRTAKEN_LABEL(sandbox_immediate_addr_plus_four:)
         mov      REG_XAX, HEX(1)
         mov      REG_XBX, HEX(2)
-        lea      REG_XDX, SYMREF(usebx_immediate_addr_plus_four - 4)
-        mov      DWORD [REG_XDX], eax        /* selfmod write in another page */
+        lea      REG_XDI, SYMREF(usebx_immediate_addr_plus_four - 4)
+        stosd    /* stos selfmod write in another page */
         mov      REG_XAX, REG_XBX
         ret
 END_FUNC(FUNCNAME)

--- a/suite/tests/client-interface/translate_sandbox.dll.c
+++ b/suite/tests/client-interface/translate_sandbox.dll.c
@@ -1,0 +1,51 @@
+/* **********************************************************
+ * Copyright (c) 2012 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "dr_api.h"
+
+static dr_emit_flags_t
+bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool translating)
+{
+    instr_t *instr;
+    for (instr = instrlist_first(bb); instr != NULL; instr = instr_get_next(instr)) {
+        if (instr_writes_memory(instr) && !instr_uses_reg(instr, DR_REG_XBX)) {
+            return DR_EMIT_STORE_TRANSLATIONS;
+        }
+    }
+    return DR_EMIT_DEFAULT;
+}
+
+DR_EXPORT
+void dr_init(client_id_t id)
+{
+    dr_register_bb_event(bb_event);
+}

--- a/suite/tests/client-interface/translate_sandbox.dll.c
+++ b/suite/tests/client-interface/translate_sandbox.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017 Simorfo, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,10 @@ bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool trans
     instr_t *instr;
     for (instr = instrlist_first(bb); instr != NULL; instr = instr_get_next(instr)) {
         if (instr_writes_memory(instr) && !instr_uses_reg(instr, DR_REG_XBX)) {
+            /* This non standard return value is being tested.
+             * DynamoRIO should manage to restore spilled register by sandboxing
+             * when an instruction generates an exception.
+             */
             return DR_EMIT_STORE_TRANSLATIONS;
         }
     }

--- a/suite/tests/client-interface/translate_sandbox.expect
+++ b/suite/tests/client-interface/translate_sandbox.expect
@@ -1,3 +1,3 @@
 start of test, count = 0
 access violation exception
-end of test, count = 2
+end of test, count = 3

--- a/suite/tests/client-interface/translate_sandbox.expect
+++ b/suite/tests/client-interface/translate_sandbox.expect
@@ -1,0 +1,3 @@
+start of test, count = 0
+end of test, count = 1
+

--- a/suite/tests/client-interface/translate_sandbox.expect
+++ b/suite/tests/client-interface/translate_sandbox.expect
@@ -1,2 +1,3 @@
 start of test, count = 0
-end of test, count = 3
+access violation exception
+end of test, count = 2

--- a/suite/tests/client-interface/translate_sandbox.expect
+++ b/suite/tests/client-interface/translate_sandbox.expect
@@ -1,3 +1,2 @@
 start of test, count = 0
-end of test, count = 1
-
+end of test, count = 3


### PR DESCRIPTION
Sets translation to instruction in recreate_app_state_from_info
so that translate_walk_track can restore spilled registers.