### PR TITLE
i#774 x64 reachability: extend reachability to out-of-line helper calls

### DIFF
--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -935,7 +935,7 @@ insert_reachable_cti(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
 
 int
 insert_out_of_line_context_switch(dcontext_t *dcontext, instrlist_t *ilist,
-                                  instr_t *instr, bool save)
+                                  instr_t *instr, bool save, byte *encode_pc)
 {
 # ifdef AARCH64
     if (save) {

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -541,10 +541,10 @@ insert_get_mcontext_base(dcontext_t *dcontext, instrlist_t *ilist,
                          instr_t *where, reg_id_t reg);
 uint
 prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci,
-                       instrlist_t *ilist, instr_t *instr);
+                       instrlist_t *ilist, instr_t *instr, byte *encode_pc);
 void
 cleanup_after_clean_call(dcontext_t *dcontext, clean_call_info_t *cci,
-                         instrlist_t *ilist, instr_t *instr);
+                         instrlist_t *ilist, instr_t *instr, byte *encode_pc);
 void convert_to_near_rel(dcontext_t *dcontext, instr_t *instr);
 instr_t *convert_to_near_rel_meta(dcontext_t *dcontext, instrlist_t *ilist,
                                   instr_t *instr);
@@ -557,7 +557,7 @@ int find_syscall_num(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr);
 /* in mangle.c  but not exported to non-arch files */
 int
 insert_out_of_line_context_switch(dcontext_t *dcontext, instrlist_t *ilist,
-                                  instr_t *instr, bool save);
+                                  instr_t *instr, bool save, byte *encode_pc);
 #ifdef X86
 # ifdef UNIX
 /* Mangle reference of fs/gs semgents, reg must not be used in the oldop. */

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -156,7 +156,7 @@ insert_get_mcontext_base(dcontext_t *dcontext, instrlist_t *ilist,
 #define NUM_EXTRA_SLOTS 2 /* pc, aflags */
 uint
 prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci,
-                       instrlist_t *ilist, instr_t *instr)
+                       instrlist_t *ilist, instr_t *instr, byte *encode_pc)
 {
     uint dstack_offs = 0;
 
@@ -259,7 +259,7 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci,
      */
     if (cci->out_of_line_swap) {
         dstack_offs +=
-            insert_out_of_line_context_switch(dcontext, ilist, instr, true);
+            insert_out_of_line_context_switch(dcontext, ilist, instr, true, encode_pc);
     } else {
         dstack_offs +=
             insert_push_all_registers(dcontext, cci, ilist, instr, (uint)PAGE_SIZE,
@@ -311,7 +311,7 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci,
 
 void
 cleanup_after_clean_call(dcontext_t *dcontext, clean_call_info_t *cci,
-                         instrlist_t *ilist, instr_t *instr)
+                         instrlist_t *ilist, instr_t *instr, byte *encode_pc)
 {
     if (cci == NULL)
         cci = &default_clean_call_info;
@@ -337,7 +337,7 @@ cleanup_after_clean_call(dcontext_t *dcontext, clean_call_info_t *cci,
 
     /* now restore everything */
     if (cci->out_of_line_swap) {
-        insert_out_of_line_context_switch(dcontext, ilist, instr, false);
+        insert_out_of_line_context_switch(dcontext, ilist, instr, false, encode_pc);
     } else {
         /* XXX: add a cci field for optimizing this away if callee makes no calls */
         insert_pop_all_registers(dcontext, cci, ilist, instr,

--- a/core/heap.c
+++ b/core/heap.c
@@ -939,8 +939,10 @@ vmcode_unreachable_pc(void)
     get_vmm_heap_bounds((byte **)&start, (byte **)&end);
     if (start > INT_MAX)
         return NULL;
-    else
-        return (byte *) PTR_UINT_MINUS_1;
+    else {
+        /* We do not use -1 to avoid wraparound from thinking it's reachable. */
+        return (byte *)end + INT_MAX + PAGE_SIZE;
+    }
 }
 
 bool

--- a/core/heap.c
+++ b/core/heap.c
@@ -973,6 +973,15 @@ vmcode_get_end(void)
 byte *
 vmcode_unreachable_pc(void)
 {
+#ifdef X86_64
+    /* This is used to indicate something that is unreachable from *everything*
+     * for DR_CLEANCALL_INDIRECT, so ideally we want to not just provide an
+     * address that vmcode can't reach.
+     * We use a non-canonical address for x86_64.
+     */
+    return (byte *)0x8000000100000000ULL;
+#else
+    /* This is not really used for aarch* so we just go with vmcode reachability. */
     ptr_uint_t start, end;
     get_vmm_heap_bounds((byte **)&start, (byte **)&end);
     if (start > INT_MAX)
@@ -981,6 +990,7 @@ vmcode_unreachable_pc(void)
         /* We do not use -1 to avoid wraparound from thinking it's reachable. */
         return (byte *)end + INT_MAX + PAGE_SIZE;
     }
+#endif
 }
 
 bool

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -5281,10 +5281,6 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
      * flag will disappear and translation will fail.
      */
     instrlist_set_our_mangling(ilist, true);
-    if (TEST(DR_CLEANCALL_INDIRECT, save_flags))
-        encode_pc = vmcode_unreachable_pc();
-    else
-        encode_pc = vmcode_get_start();
     if (TEST(DR_CLEANCALL_RETURNS_TO_NATIVE, save_flags))
         call_flags |= META_CALL_RETURNS_TO_NATIVE;
     insert_meta_call_vargs(dcontext, ilist, where, call_flags,

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -5027,7 +5027,8 @@ typedef enum {
     /** Skip saving any XMM or YMM registers that are never used as return values. */
     DR_CLEANCALL_NOSAVE_XMM_NONRET      = 0x0010,
     /**
-     * Requests that an indirect call be used to ensure reachability.
+     * Requests that an indirect call be used to ensure reachability, both for
+     * reaching the callee and for any out-of-line helper routine calls.
      * Only honored for 64-bit mode, where r11 will be used for the indirection.
      */
     DR_CLEANCALL_INDIRECT               = 0x0020,

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2270,6 +2270,10 @@ if (CLIENT_INTERFACE)
       "" "-thread_private -cache_bb_unit_init 4K" "")
   endif ()
 
+  if (NOT ARM) # Tests x86 reachability.
+    tobuild_ci(client.reachability client-interface/reachability.c "" "" "")
+  endif ()
+
   if (X86) # FIXME i#1551, i#1569: fix bugs on ARM and AArch64
     tobuild_ci(client.nudge_ex client-interface/nudge_ex.c "" "" "")
     use_DynamoRIO_extension(client.nudge_ex.dll drmgr)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2270,7 +2270,7 @@ if (CLIENT_INTERFACE)
       "" "-thread_private -cache_bb_unit_init 4K" "")
   endif ()
 
-  if (NOT ARM) # Tests x86 reachability.
+  if (X86) # Tests x86 reachability.
     tobuild_ci(client.reachability client-interface/reachability.c "" "" "")
   endif ()
 

--- a/suite/tests/client-interface/reachability.dll.c
+++ b/suite/tests/client-interface/reachability.dll.c
@@ -1,0 +1,95 @@
+/* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "dr_api.h"
+
+#define PRE instrlist_meta_preinsert
+
+#define GENCODE_SIZE 4096
+
+static app_pc gencode;
+static bool used_gencode;
+
+static void
+clean_call(int arg)
+{
+    dr_fprintf(STDERR, "inside clean call arg=%d\n", arg);
+}
+
+static dr_emit_flags_t
+event_bb(void *dc, void *tag, instrlist_t *bb, bool for_trace, bool translating)
+{
+    if (!used_gencode) { /* We assume a single-threaded app. */
+        instr_t *where = instrlist_first(bb);
+        instr_t *ret_label = INSTR_CREATE_label(dc);
+        dr_save_reg(dc, bb, where, DR_REG_XAX, SPILL_SLOT_1);
+        dr_save_reg(dc, bb, where, DR_REG_XDX, SPILL_SLOT_2);
+        PRE(bb, where, INSTR_CREATE_mov_imm(dc, opnd_create_reg(DR_REG_XAX),
+                                            opnd_create_instr(ret_label)));
+        instrlist_insert_mov_immed_ptrsz(dc, (ptr_int_t)gencode,
+                                         opnd_create_reg(DR_REG_XDX), bb, where,
+                                         NULL, NULL);
+        PRE(bb, where, INSTR_CREATE_jmp_ind(dc, opnd_create_reg(DR_REG_XDX)));
+        PRE(bb, where, ret_label);
+        dr_restore_reg(dc, bb, where, DR_REG_XDX, SPILL_SLOT_2);
+        dr_restore_reg(dc, bb, where, DR_REG_XAX, SPILL_SLOT_1);
+        used_gencode = true;
+    }
+    return DR_EMIT_DEFAULT;
+}
+
+static void
+event_exit(void)
+{
+    dr_nonheap_free(gencode, GENCODE_SIZE);
+}
+
+DR_EXPORT void
+dr_init(client_id_t id)
+{
+    /* Use some API routines in non-code-cache code to test reachability. */
+    void *dc = dr_get_current_drcontext();
+    instrlist_t *ilist = instrlist_create(dc);
+    dr_insert_clean_call_ex(dc, ilist, NULL, (void *)clean_call,
+                            DR_CLEANCALL_ALWAYS_OUT_OF_LINE|DR_CLEANCALL_INDIRECT, 1,
+                            /* Pass a magic value we'll check in the template */
+                            OPND_CREATE_INT32(42));
+    /* Now return */
+    PRE(ilist, NULL, INSTR_CREATE_jmp_ind(dc, opnd_create_reg(DR_REG_XAX)));
+    gencode = dr_raw_mem_alloc(GENCODE_SIZE,
+                               DR_MEMPROT_READ|DR_MEMPROT_WRITE|DR_MEMPROT_EXEC, NULL);
+    instrlist_encode(dc, ilist, gencode, false /*no relative jumps*/);
+    instrlist_clear_and_destroy(dc, ilist);
+
+    dr_register_bb_event(event_bb);
+    dr_register_exit_event(event_exit);
+}

--- a/suite/tests/client-interface/reachability.expect
+++ b/suite/tests/client-interface/reachability.expect
@@ -1,0 +1,2 @@
+inside clean call arg=42
+Hello, world!


### PR DESCRIPTION
Applies DR_CLEANCALL_INDIRECT to out-of-line helper calls.  Removes the
hardcoded direct calls used for out-of-line clean call setup and cleanup
code and replaces with insert_reachable_cti().

Fixes vmcode_unreachable_pc() to avoid a wraparound issue.

Adds a test where a client generates a clean call into custom
non-code-cache memory.