### PR TITLE
i#2558: relax client reachability and vmm base location

### DIFF
--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -1065,7 +1065,10 @@ DynamoRIO loads client libraries and Extensions (but not copies of system
 libraries) within 32-bit reachability of its code caches.  Typically, the
 code cache region is located in the low 4GB of the address space; thus, to
 avoid relocations at client library load time, it is recommended to set a
-preferred client library base in the low 4GB.
+preferred client library base in the low 4GB.  The \ref op_reachable_client
+"-reachable_client runtime option" can be used to remove this guarantee,
+though this would normally not be done unless the client is statically
+linked with the application.
 
 The net result is that any static data or code in a client library, or any
 data allocated using DynamoRIO's API routines (except dr_raw_mem_alloc() or
@@ -1075,7 +1078,7 @@ malloc, operator new, and HeapAlloc), as well as DynamoRIO's own
 internally-used heap memory, is *not* guaranteed to be reachable: only
 memory directly allocated via DynamoRIO's API.  The \ref op_reachable_heap
 "-reachable_heap runtime option" can be used to guarantee that all memory
-is reachable, at the risk of running out memory due to the smaller space
+is reachable, at the risk of running out of memory due to the smaller space
 of available memory.
 
 To make more space available for the code caches when running larger
@@ -1634,6 +1637,13 @@ Options available only in Code Manipulation mode and Memory Firewall mode
    the heap memory such that it is all guaranteed to be reachable from the
    code cache, at the risk of running out memory due to the smaller space
    of available memory.
+
+ - \b -reachable_client: \anchor op_reachable_client
+   By default, DynamoRIO guarantees that client libraries are reachable
+   from its code caches by a 32-bit displacement.  Disabling this option
+   removes that guarantee and allows a client to be located elsewhere.
+   This would typically be used with client that is statically-linked
+   into the application.
 
  - \b -max_bb_instrs:
    DynamoRIO stops building a basic block if it hits this application

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -336,6 +336,13 @@ if (BUILD_TESTS)
     add_win32_flags(tool.drcacheoff.burst_threads)
     target_link_libraries(tool.drcacheoff.burst_threads ${libpthread})
 
+    if (X64)
+      add_executable(tool.drcacheoff.burst_noreach tests/burst_noreach.cpp)
+      configure_DynamoRIO_static(tool.drcacheoff.burst_noreach)
+      use_DynamoRIO_static_client(tool.drcacheoff.burst_noreach drmemtrace_static)
+      add_win32_flags(tool.drcacheoff.burst_noreach)
+    endif ()
+
     if (UNIX)
       if (X86 AND NOT APPLE) # This test is x86-specific.
         # uses ptrace and looks for linux-specific syscalls
@@ -358,7 +365,7 @@ if (BUILD_TESTS)
         COMPILE_DEFINITIONS "TEST_APP_DR_CLIENT_MAIN")
       configure_DynamoRIO_static(tool.drcacheoff.burst_client)
       use_DynamoRIO_static_client(tool.drcacheoff.burst_client drmemtrace_static)
-      # A nop, keep it for the furture Windows support.
+      # A nop, keep it for the future Windows support.
       add_win32_flags(tool.drcacheoff.burst_client)
     endif ()
   endif ()

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -336,7 +336,7 @@ if (BUILD_TESTS)
     add_win32_flags(tool.drcacheoff.burst_threads)
     target_link_libraries(tool.drcacheoff.burst_threads ${libpthread})
 
-    if (X64)
+    if (X64 AND UNIX)
       add_executable(tool.drcacheoff.burst_noreach tests/burst_noreach.cpp)
       configure_DynamoRIO_static(tool.drcacheoff.burst_noreach)
       use_DynamoRIO_static_client(tool.drcacheoff.burst_noreach drmemtrace_static)

--- a/clients/drcachesim/tests/burst_noreach.cpp
+++ b/clients/drcachesim/tests/burst_noreach.cpp
@@ -1,0 +1,114 @@
+/* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* This application links in drmemtrace_static and acquires a trace during
+ * a "burst" of execution in the middle of the application.  Before attaching
+ * it allocates a lot of heap, preventing the statically linked client from
+ * being 32-bit reachable from any available space for the code cache.
+ */
+
+/* Like burst_static we deliberately do not include configure.h here. */
+#include "dr_api.h"
+#include <assert.h>
+#include <iostream>
+#include <math.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+bool
+my_setenv(const char *var, const char *value)
+{
+#ifdef UNIX
+    return setenv(var, value, 1/*override*/) == 0;
+#else
+    return SetEnvironmentVariable(var, value) == TRUE;
+#endif
+}
+
+static int
+do_some_work(int arg)
+{
+    static int iters = 512;
+    double val = (double)arg;
+    for (int i = 0; i < iters; ++i) {
+        val += sin(val);
+    }
+    return (val > 0);
+}
+
+static void
+fill_up_heap()
+{
+    void *cur_brk = sbrk(0);
+    void *new_brk = (byte*)cur_brk + 2*1024*1024*1024ULL;
+    int res = brk(new_brk);
+}
+
+int
+main(int argc, const char *argv[])
+{
+    static int outer_iters = 2048;
+    /* We trace a 4-iter burst of execution. */
+    static int iter_start = outer_iters/3;
+    static int iter_stop = iter_start + 4;
+
+    fill_up_heap();
+
+    if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -vm_size 512M -no_reachable_client -client_lib ';;-offline'"))
+        std::cerr << "failed to set env var!\n";
+
+    /* We use an outer loop to test re-attaching (i#2157). */
+    for (int j = 0; j < 3; ++j) {
+        std::cerr << "pre-DR init\n";
+        dr_app_setup();
+        assert(!dr_app_running_under_dynamorio());
+
+        for (int i = 0; i < outer_iters; ++i) {
+            if (i == iter_start) {
+                std::cerr << "pre-DR start\n";
+                dr_app_start();
+            }
+            if (i >= iter_start && i <= iter_stop)
+                assert(dr_app_running_under_dynamorio());
+            else
+                assert(!dr_app_running_under_dynamorio());
+            if (do_some_work(i) < 0)
+                std::cerr << "error in computation\n";
+            if (i == iter_stop) {
+                std::cerr << "pre-DR detach\n";
+                dr_app_stop_and_cleanup();
+            }
+        }
+        std::cerr << "all done\n";
+    }
+    return 0;
+}

--- a/clients/drcachesim/tests/burst_noreach.cpp
+++ b/clients/drcachesim/tests/burst_noreach.cpp
@@ -83,7 +83,8 @@ main(int argc, const char *argv[])
 
     fill_up_heap();
 
-    if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -vm_size 512M -no_reachable_client -client_lib ';;-offline'"))
+    if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -vm_size 512M "
+                   "-no_reachable_client -client_lib ';;-offline'"))
         std::cerr << "failed to set env var!\n";
 
     /* We use an outer loop to test re-attaching (i#2157). */

--- a/clients/drcachesim/tests/offline-burst_noreach.templatex
+++ b/clients/drcachesim/tests/offline-burst_noreach.templatex
@@ -1,0 +1,31 @@
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
+Cache simulation results:
+Core #0 \(1 thread\(s\)\)
+  L1I stats:
+    Hits:                         *[0-9,\.]*.....
+    Misses:                       *[0-9,\.]*...
+.*    Miss rate:                        0[,\.]..%
+  L1D stats:
+    Hits:                         *[0-9,\.]*.....
+    Misses:                       *[0-9,\.]*.
+.*   Miss rate:                        0[,\.]..%
+Core #1 \(0 thread\(s\)\)
+Core #2 \(0 thread\(s\)\)
+Core #3 \(0 thread\(s\)\)
+LL stats:
+    Hits:                         *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*..
+.*   Local miss rate:                *[0-9]*[,\.]..%
+    Child hits:                   *[0-9,\.]*...
+    Total miss rate:                  [0-1][,\.]..%

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -472,18 +472,16 @@ dynamorio_app_init(void)
         /* Must be before {vmm_,}heap_init() */
         vmk_init_lib();
 #endif
-        vmm_heap_init_constraints(); /* before client libs are loaded! */
-#ifdef CLIENT_INTERFACE
-        /* PR 200207: load the client lib before callback_interception_init
-         * since the client library load would hit our own hooks (xref hotpatch
-         * cases about that) -- though -private_loader removes that issue. */
-        /* Must be before [vmm_]heap_init() so we can register the client lib as
-         * reachable from the dr heap. Xref PR 215395. */
-        instrument_load_client_libs();
-#endif
 
         /* initialize components (CAUTION: order is important here) */
         vmm_heap_init(); /* must be called even if not using vmm heap */
+#ifdef CLIENT_INTERFACE
+        /* PR 200207: load the client lib before callback_interception_init
+         * since the client library load would hit our own hooks (xref hotpatch
+         * cases about that) -- though -private_loader removes that issue.
+         */
+        instrument_load_client_libs();
+#endif
         heap_init();
         dynamo_heap_initialized = true;
 

--- a/core/heap.c
+++ b/core/heap.c
@@ -716,8 +716,7 @@ vmm_heap_initialize_unusable(vm_heap_t *vmh)
     vmh->num_free_blocks = vmh->num_blocks = 0;
 }
 
-static
-void
+static void
 vmm_heap_unit_init(vm_heap_t *vmh, size_t size)
 {
     ptr_uint_t preferred;
@@ -727,43 +726,73 @@ vmm_heap_unit_init(vm_heap_t *vmh, size_t size)
     size = ALIGN_FORWARD(size, DYNAMO_OPTION(vmm_block_size));
     ASSERT(size <= MAX_VMM_HEAP_UNIT_SIZE);
     vmh->alloc_size = size;
+    vmh->start_addr = NULL;
 
     if (size == 0) {
         vmm_heap_initialize_unusable(&heapmgt->vmheap);
         return;
     }
 
-    /* Out of 32 bits = 12 bits are page offset, windows wastes 4 more
-     * since its allocation base is 64KB, and if we want to stay
-     * safely in say 0x20000000-0x2fffffff we're left with only 12
-     * bits of randomness - which may be too little.  On the other
-     * hand changing any of the lower 16 bits will make our bugs
-     * non-deterministic. */
-    /* Make sure we don't waste the lower bits from our random number */
-    preferred = (DYNAMO_OPTION(vm_base)
-                 + get_random_offset(DYNAMO_OPTION(vm_max_offset) /
-                                     DYNAMO_OPTION(vmm_block_size)) *
-                 DYNAMO_OPTION(vmm_block_size));
-    preferred = ALIGN_FORWARD(preferred, DYNAMO_OPTION(vmm_block_size));
-    /* overflow check: w/ vm_base shouldn't happen so debug-only check */
-    ASSERT(!POINTER_OVERFLOW_ON_ADD(preferred, size));
-
-    /* let's assume a single chunk is sufficient to reserve */
-    vmh->start_addr = NULL;
 #ifdef X64
-    if ((byte *)preferred < heap_allowable_region_start ||
-        (byte *)preferred + size > heap_allowable_region_end) {
-        error_code = HEAP_ERROR_NOT_AT_PREFERRED;
-    } else {
-#endif
-        vmh->start_addr = os_heap_reserve((void*)preferred, size, &error_code,
-                                          true/*+x*/);
-        LOG(GLOBAL, LOG_HEAP, 1,
-            "vmm_heap_unit_init preferred="PFX" got start_addr="PFX"\n",
-            preferred, vmh->start_addr);
-#ifdef X64
+    /* -heap_in_lower_4GB takes top priority and has already set heap_allowable_region_*.
+     * Next comes -vm_base_near_app.
+     * XXX: we're ignoring -vm_base and -vm_max_offset here: it may be possible to
+     * honor them along with -vm_base_near_app, so should we take the effort to try?
+     */
+    if (DYNAMO_OPTION(vm_base_near_app)) {
+        /* Required for STATIC_LIBRARY: must be near app b/c clients are there.
+         * Non-static: still a good idea for fewer rip-rel manglings.
+         * Asking for app base means we'll prefer before the app, which
+         * has less of an impact on its heap.
+         */
+        app_pc app_base = get_application_base();
+        app_pc app_end = get_application_end();
+        app_pc reach_base = REACHABLE_32BIT_START(app_base, app_end);
+        app_pc reach_end = REACHABLE_32BIT_END(app_base, app_end);
+        vmh->alloc_start = os_heap_reserve_in_region
+            ((void *)ALIGN_FORWARD(reach_base, PAGE_SIZE),
+             (void *)ALIGN_FORWARD(reach_end, PAGE_SIZE),
+             size + DYNAMO_OPTION(vmm_block_size), &error_code, true/*+x*/);
+        if (vmh->alloc_start != NULL) {
+            vmh->start_addr = (heap_pc)
+                ALIGN_FORWARD(vmh->alloc_start, DYNAMO_OPTION(vmm_block_size));
+            request_region_be_heap_reachable(app_base, app_end - app_base);
+        }
     }
+#endif /* X64 */
+
+    /* Next we try the -vm_base value plus a random offset. */
+    if (vmh->start_addr == NULL) {
+        /* Out of 32 bits = 12 bits are page offset, windows wastes 4 more
+         * since its allocation base is 64KB, and if we want to stay
+         * safely in say 0x20000000-0x2fffffff we're left with only 12
+         * bits of randomness - which may be too little.  On the other
+         * hand changing any of the lower 16 bits will make our bugs
+         * non-deterministic. */
+        /* Make sure we don't waste the lower bits from our random number */
+        preferred = (DYNAMO_OPTION(vm_base)
+                     + get_random_offset(DYNAMO_OPTION(vm_max_offset) /
+                                         DYNAMO_OPTION(vmm_block_size)) *
+                     DYNAMO_OPTION(vmm_block_size));
+        preferred = ALIGN_FORWARD(preferred, DYNAMO_OPTION(vmm_block_size));
+        /* overflow check: w/ vm_base shouldn't happen so debug-only check */
+        ASSERT(!POINTER_OVERFLOW_ON_ADD(preferred, size));
+        /* let's assume a single chunk is sufficient to reserve */
+#ifdef X64
+        if ((byte *)preferred < heap_allowable_region_start ||
+            (byte *)preferred + size > heap_allowable_region_end) {
+            error_code = HEAP_ERROR_NOT_AT_PREFERRED;
+        } else {
 #endif
+            vmh->start_addr = os_heap_reserve((void*)preferred, size, &error_code,
+                                              true/*+x*/);
+            LOG(GLOBAL, LOG_HEAP, 1,
+                "vmm_heap_unit_init preferred="PFX" got start_addr="PFX"\n",
+                preferred, vmh->start_addr);
+#ifdef X64
+        }
+#endif
+    }
     while (vmh->start_addr == NULL && DYNAMO_OPTION(vm_allow_not_at_base)) {
         /* Since we prioritize low-4GB or near-app over -vm_base, we do not
          * syslog or assert here
@@ -953,7 +982,7 @@ rel32_reachable_from_vmcode(byte *tgt)
     ptr_int_t new_offs = (tgt > heap_allowable_region_start) ?
         (tgt - heap_allowable_region_start) : (heap_allowable_region_end - tgt);
     ASSERT(vmcode_get_start() >= heap_allowable_region_start);
-    ASSERT(vmcode_get_end() <= heap_allowable_region_end);
+    ASSERT(vmcode_get_end() <= heap_allowable_region_end+1/*closed*/);
     return REL32_REACHABLE_OFFS(new_offs);
 #else
     return true;
@@ -1333,47 +1362,21 @@ vmm_heap_alloc(size_t size, uint prot, heap_error_code_t *error_code)
     return p;
 }
 
-/* set reachability constraints before loading any client libs */
-void
-vmm_heap_init_constraints()
-{
-#ifdef X64
-    /* add reachable regions before we allocate the heap, xref PR 215395 */
-    /* i#774, i#901: we no longer need the DR library nor ntdll.dll to be
-     * reachable by the vmheap reservation.  But, for -heap_in_lower_4GB,
-     * we must call request_region_be_heap_reachable() up front.
-     */
-    if (DYNAMO_OPTION(heap_in_lower_4GB))
-        request_region_be_heap_reachable((byte *)(ptr_uint_t)0x80000000/*middle*/, 1);
-    else if (DYNAMO_OPTION(vm_base_near_app)) {
-        /* Required for STATIC_LIBRARY: must be near app b/c clients are there.
-         * Non-static: still a good idea for fewer rip-rel manglings.
-         * Asking for app base means we'll prefer before the app, which
-         * has less of an impact on its heap.
-         */
-        app_pc base = get_application_base();
-        request_region_be_heap_reachable(base, get_application_end() - base);
-    } else {
-        /* It seems silly to let the 1st client lib set the region, so we give
-         * -vm_base priority.
-         */
-        request_region_be_heap_reachable
-            ((byte *)DYNAMO_OPTION(vm_base), DYNAMO_OPTION(vm_size));
-    }
-    /* XXX: really we should iterate and try other options: right now we'll
-     * just fail if we run out of space.  E.g., if the app is quite large, we might
-     * fit the client near, and then our vm reservation could fail and at that
-     * point we'd just abort.  We need to restructure the code to allow
-     * iterating over the client lib loads and vm reservation at once.
-     */
-#endif /* X64 */
-}
-
 /* virtual memory manager initialization */
 void
 vmm_heap_init()
 {
     IF_WINDOWS(ASSERT(DYNAMO_OPTION(vmm_block_size) == OS_ALLOC_GRANULARITY));
+#ifdef X64
+    /* add reachable regions before we allocate the heap, xref PR 215395 */
+    /* i#774, i#901: we no longer need the DR library nor ntdll.dll to be
+     * reachable by the vmheap reservation.  But, for -heap_in_lower_4GB,
+     * we must call request_region_be_heap_reachable() up front.
+     * This is a hard requirement so we set it prior to locating the vmm region.
+     */
+    if (DYNAMO_OPTION(heap_in_lower_4GB))
+        request_region_be_heap_reachable((byte *)(ptr_uint_t)0x80000000/*middle*/, 1);
+#endif
     if (DYNAMO_OPTION(vm_reserve)) {
         vmm_heap_unit_init(&heapmgt->vmheap, DYNAMO_OPTION(vm_size));
     }

--- a/core/heap.h
+++ b/core/heap.h
@@ -109,7 +109,6 @@ vmcode_get_reachable_region(byte **region_start OUT, byte **region_end OUT);
 #endif
 
 /* virtual heap manager */
-void vmm_heap_init_constraints();
 void vmm_heap_init(void);
 void vmm_heap_exit(void);
 void print_vmm_heap_data(file_t outf);

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -482,7 +482,8 @@ add_client_lib(const char *path, const char *id_str, const char *options)
 
     LOG(GLOBAL, LOG_INTERP, 4, "about to load client library %s\n", path);
 
-    client_lib = load_shared_library(path, true/*reachable*/);
+    client_lib = load_shared_library(path, IF_X64_ELSE(DYNAMO_OPTION(reachable_client),
+                                                       true));
     if (client_lib == NULL) {
         char msg[MAXIMUM_PATH*4];
         char err[MAXIMUM_PATH*2];
@@ -536,9 +537,11 @@ add_client_lib(const char *path, const char *id_str, const char *options)
             /* Now that we map the client within the constraints, this request
              * should always succeed.
              */
-            request_region_be_heap_reachable(client_libs[idx].start,
-                                             client_libs[idx].end -
-                                             client_libs[idx].start);
+            if (DYNAMO_OPTION(reachable_client)) {
+                request_region_be_heap_reachable(client_libs[idx].start,
+                                                 client_libs[idx].end -
+                                                 client_libs[idx].start);
+            }
 #endif
             strncpy(client_libs[idx].path, path,
                     BUFFER_SIZE_ELEMENTS(client_libs[idx].path));

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1413,7 +1413,8 @@
     OPTION_DEFAULT(bool, vm_allow_smaller, true, "if we can't allocate vm heap of "
                    "requested size, try smaller sizes instead of dying")
     OPTION_DEFAULT(bool, vm_base_near_app, true,
-                   "allocate vm region near the app")
+                   "allocate vm region near the app if possible (if not, if "
+                   "-vm_allow_not_at_base, will try elsewhere)")
 #ifdef X64
     /* We prefer low addresses in general, and only need this option if it's
      * an absolute requirement (XXX i#829: it is required for mixed-mode).
@@ -1424,8 +1425,10 @@
                    "it can be accessed directly as a 32bit address. See PR 215395.")
     /* XXX i#774: this will become false by default once we split vmheap and vmcode */
     OPTION_DEFAULT(bool, reachable_heap, true,
-                   "guarantee that all heap memory 32-bit-displacement "
+                   "guarantee that all heap memory is 32-bit-displacement "
                    "reachable from the code cache.")
+    OPTION_DEFAULT(bool, reachable_client, true,
+                   "guarantee that clients are reachable from the code cache.")
 #endif
      /* FIXME: the lower 16 bits are ignored - so this here gives us
       * 12bits of randomness.  Could make it larger if we verify as

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -3222,7 +3222,7 @@ os_heap_reserve_in_region(void *start, void *end, size_t size,
                           heap_error_code_t *error_code, bool executable)
 {
     byte *p = NULL;
-    byte *try_start = NULL;
+    byte *try_start = NULL, *try_end = NULL;
 
     ASSERT(ALIGNED(start, PAGE_SIZE) && ALIGNED(end, PAGE_SIZE));
     ASSERT(ALIGNED(size, PAGE_SIZE));
@@ -3235,8 +3235,12 @@ os_heap_reserve_in_region(void *start, void *end, size_t size,
         return os_heap_reserve(NULL, size, error_code, executable);
 
     /* loop to handle races */
-    while (find_free_memory_in_region(start, end, size, &try_start, NULL)) {
-        p = os_heap_reserve(try_start, size, error_code, executable);
+    while (find_free_memory_in_region(start, end, size, &try_start, &try_end)) {
+        /* If there's space we'd prefer the end, to avoid the common case of
+         * a large binary + heap at attach where we're likely to reserve
+         * right at the start of the brk: we'd prefer to leave more brk space.
+         */
+        p = os_heap_reserve(try_end - size, size, error_code, executable);
         if (p != NULL) {
             ASSERT(*error_code == HEAP_ERROR_SUCCESS);
             ASSERT(p >= (byte *)start && p + size <= (byte *)end);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2559,7 +2559,7 @@ if (CLIENT_INTERFACE)
         torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall "" "")
         set(tool.drcacheoff.burst_replaceall_nodr ON)
 
-        if (X64)
+        if (X64 AND UNIX)
           torunonly_drcacheoff(burst_noreach tool.drcacheoff.burst_noreach "" "")
           set(tool.drcacheoff.burst_noreach_nodr ON)
         endif ()

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3301,7 +3301,8 @@ if (X64 AND NOT AARCH64) # FIXME i#1569: get working on AArch64
         "" "-native_exec_list foo.dll,bar.dll -opt_cleancall 3 -thread_private" "")
     endif (UNIX)
   endif (CLIENT_INTERFACE)
-
+  torunonly(low4GB security-common.selfmod security-common/selfmod.c
+    "-heap_in_lower_4GB" "")
 endif (X64 AND NOT AARCH64)
 
 tobuild("security-common.TestAllocWE" security-common/TestAllocWE.c)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2559,6 +2559,11 @@ if (CLIENT_INTERFACE)
         torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall "" "")
         set(tool.drcacheoff.burst_replaceall_nodr ON)
 
+        if (X64)
+          torunonly_drcacheoff(burst_noreach tool.drcacheoff.burst_noreach "" "")
+          set(tool.drcacheoff.burst_noreach_nodr ON)
+        endif ()
+
         if (UNIX)
           # FIXME i#2040: this hits static client issues on Windows
           torunonly_drcacheoff(burst_threads tool.drcacheoff.burst_threads "" "")


### PR DESCRIPTION
Adds a new option -reachable_client, on by default.  When turned off,
client libraries being within 32-bit-displacement reachability of the code
cache is relaxed, both the library load location and the fatal error on
violation.  This is particularly useful for statically-linked clients whose
location is difficult to change.

Includes changes to vmm allocation required to make this work for
statically-linked clients:
+ Eliminates the setting of heap reachability constraints prior to vmm
  allocation, except for -heap_in_lower_4GB which has no fallback.
+ Client libraries are now loaded *after* the vmm is allocated.
+ -vm_base_near_app tries to be near the app but on failure, if
  -vm_allow_not_at_base, it allows allocating away from the app.
+ When reserving any available memory, on UNIX, we take from the high end,
  for a lower chance of impacting the brk.

Adds a test of a static client with a large heap where the default -vm_base
or being near the app fail.

Fixes #2558