### PR TITLE
i#2566: handle anon mmaps in text segments

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -342,6 +342,12 @@ if (BUILD_TESTS)
       use_DynamoRIO_static_client(tool.drcacheoff.burst_noreach drmemtrace_static)
       add_win32_flags(tool.drcacheoff.burst_noreach)
     endif ()
+    if (LINUX) # Uses mremap.
+      add_executable(tool.drcacheoff.burst_maps tests/burst_maps.cpp)
+      configure_DynamoRIO_static(tool.drcacheoff.burst_maps)
+      use_DynamoRIO_static_client(tool.drcacheoff.burst_maps drmemtrace_static)
+      add_win32_flags(tool.drcacheoff.burst_maps)
+    endif ()
 
     if (UNIX)
       if (X86 AND NOT APPLE) # This test is x86-specific.

--- a/clients/drcachesim/tests/burst_maps.cpp
+++ b/clients/drcachesim/tests/burst_maps.cpp
@@ -1,0 +1,179 @@
+/* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* This application links in drmemtrace_static and acquires a trace during
+ * a "burst" of execution in the middle of the application.  Before attaching
+ * it allocates a lot of heap, preventing the statically linked client from
+ * being 32-bit reachable from any available space for the code cache.
+ */
+
+/* Like burst_static we deliberately do not include configure.h here. */
+#include "dr_api.h"
+#include "../../common/utils.h"
+#include <assert.h>
+#include <iostream>
+#include <math.h>
+#include <stdlib.h>
+#include <unistd.h>
+#define _GNU_SOURCE 1 /* for mremap */
+#include <sys/mman.h>
+#include <stdio.h>
+#include <string.h>
+
+/* XXX: share these with suite/tests/tools.c and the core? */
+#define MAPS_LINE_LENGTH      4096
+#define MAPS_LINE_FORMAT4     "%08lx-%08lx %s %*x %*s %*u %4096s"
+#define MAPS_LINE_MAX4        49 /* sum of 8  1  8  1 4 1 8 1 5 1 10 1 */
+#define MAPS_LINE_FORMAT8     "%016lx-%016lx %s %*x %*s %*u %4096s"
+#define MAPS_LINE_MAX8        73 /* sum of 16  1  16  1 4 1 16 1 5 1 10 1 */
+#define MAPS_LINE_MAX         MAPS_LINE_MAX8
+
+void *
+find_exe_base()
+{
+    pid_t pid = getpid();
+    char proc_pid_maps[64];        /* file name */
+    FILE *maps;
+    char line[MAPS_LINE_LENGTH];
+    int len = snprintf(proc_pid_maps, BUFFER_SIZE_ELEMENTS(proc_pid_maps),
+                       "/proc/%d/maps", pid);
+    if (len < 0 || len == sizeof(proc_pid_maps))
+        assert(0);
+    NULL_TERMINATE_BUFFER(proc_pid_maps);
+    maps = fopen(proc_pid_maps,"r");
+    while (!feof(maps)){
+        void *vm_start, *vm_end;
+        char perm[16];
+        char comment_buffer[MAPS_LINE_LENGTH];
+        if (fgets(line, sizeof(line), maps) == NULL)
+            break;
+        len = sscanf(line,
+                     sizeof(void*) == 4 ? MAPS_LINE_FORMAT4 : MAPS_LINE_FORMAT8,
+                     (unsigned long*)&vm_start, (unsigned long*)&vm_end, perm,
+                     comment_buffer);
+        if (len < 4)
+            comment_buffer[0] = '\0';
+        if (strstr(comment_buffer, "burst_maps") != 0) {
+            fclose(maps);
+            return vm_start;
+        }
+    }
+    fclose(maps);
+    return NULL;
+}
+
+bool
+my_setenv(const char *var, const char *value)
+{
+#ifdef UNIX
+    return setenv(var, value, 1/*override*/) == 0;
+#else
+    return SetEnvironmentVariable(var, value) == TRUE;
+#endif
+}
+
+static int
+do_some_work(int arg)
+{
+    static int iters = 512;
+    double val = (double)arg;
+    for (int i = 0; i < iters; ++i) {
+        val += sin(val);
+    }
+    return (val > 0);
+}
+
+static void
+copy_and_remap(void *base, size_t offs, size_t size)
+{
+    void *p = mmap(0, size, PROT_EXEC|PROT_READ|PROT_WRITE, MAP_ANON|MAP_PRIVATE, -1, 0);
+    assert(p != MAP_FAILED);
+    void *dst = (byte*)base + offs;
+    memcpy(p, dst, size);
+    int res = mprotect(p, size, PROT_EXEC|PROT_READ);
+    assert(res == 0);
+    void *loc = mremap(p, size, size, MREMAP_MAYMOVE|MREMAP_FIXED, dst);
+    assert(loc == dst);
+}
+
+static void
+clobber_mapping()
+{
+    /* Test placing anonymous regions in the exe mapping (i#2566) */
+    const size_t clobber_size = 4096;
+    void *exe = find_exe_base();
+    assert(exe != NULL);
+    copy_and_remap(exe, 0, clobber_size);
+    copy_and_remap(exe, 4*clobber_size, clobber_size);
+    copy_and_remap(exe, 8*clobber_size, clobber_size);
+}
+
+int
+main(int argc, const char *argv[])
+{
+    static int outer_iters = 2048;
+    /* We trace a 4-iter burst of execution. */
+    static int iter_start = outer_iters/3;
+    static int iter_stop = iter_start + 4;
+
+    clobber_mapping();
+
+    if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -vm_size 512M "
+                   "-client_lib ';;-offline'"))
+        std::cerr << "failed to set env var!\n";
+
+    /* We use an outer loop to test re-attaching (i#2157). */
+    for (int j = 0; j < 3; ++j) {
+        std::cerr << "pre-DR init\n";
+        dr_app_setup();
+        assert(!dr_app_running_under_dynamorio());
+
+        for (int i = 0; i < outer_iters; ++i) {
+            if (i == iter_start) {
+                std::cerr << "pre-DR start\n";
+                dr_app_start();
+            }
+            if (i >= iter_start && i <= iter_stop)
+                assert(dr_app_running_under_dynamorio());
+            else
+                assert(!dr_app_running_under_dynamorio());
+            if (do_some_work(i) < 0)
+                std::cerr << "error in computation\n";
+            if (i == iter_stop) {
+                std::cerr << "pre-DR detach\n";
+                dr_app_stop_and_cleanup();
+            }
+        }
+        std::cerr << "all done\n";
+    }
+    return 0;
+}

--- a/clients/drcachesim/tests/offline-burst_maps.templatex
+++ b/clients/drcachesim/tests/offline-burst_maps.templatex
@@ -1,0 +1,31 @@
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
+Cache simulation results:
+Core #0 \(1 thread\(s\)\)
+  L1I stats:
+    Hits:                         *[0-9,\.]*.....
+    Misses:                       *[0-9,\.]*...
+.*    Miss rate:                        0[,\.]..%
+  L1D stats:
+    Hits:                         *[0-9,\.]*.....
+    Misses:                       *[0-9,\.]*.
+.*   Miss rate:                        0[,\.]..%
+Core #1 \(0 thread\(s\)\)
+Core #2 \(0 thread\(s\)\)
+Core #3 \(0 thread\(s\)\)
+LL stats:
+    Hits:                         *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*..
+.*   Local miss rate:                *[0-9]*[,\.]..%
+    Child hits:                   *[0-9,\.]*...
+    Total miss rate:                  [0-1][,\.]..%

--- a/core/unix/memquery.c
+++ b/core/unix/memquery.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -47,6 +47,10 @@
 
 /* See memquery.h for full interface specs, which are identical to
  * memquery_library_bounds().
+ *
+ * XXX: I'd like to make unit tests for these maps file readers, but we
+ * can't just supply mock maps file enries: this code also walks ELF headers
+ * which complicates things.  For now we just go with live tests.
  */
 int
 memquery_library_bounds_by_iterator(const char *name, app_pc *start/*IN/OUT*/,
@@ -58,8 +62,12 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start/*IN/OUT*/,
     char libname[MAXIMUM_PATH];
     const char *name_cmp = name;
     memquery_iter_t iter;
-    app_pc last_base = NULL;
-    app_pc last_end = NULL;
+    app_pc target = *start;
+    app_pc last_lib_base = NULL;
+    app_pc last_lib_end = NULL;
+    app_pc prev_base = NULL;
+    app_pc prev_end = NULL;
+    uint prev_prot = 0;
     size_t image_size = 0;
     app_pc cur_end = NULL;
     app_pc mod_start = NULL;
@@ -84,13 +92,21 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start/*IN/OUT*/,
          * we find our target, when we'll clobber libpath
          */
         if (!found_library &&
-            strncmp(libname, iter.comment, BUFFER_SIZE_ELEMENTS(libname)) != 0) {
-            last_base = iter.vm_start;
-            /* last_end is used to know what's readable beyond last_base */
+            ((iter.comment[0] != '\0' &&
+              strncmp(libname, iter.comment, BUFFER_SIZE_ELEMENTS(libname)) != 0) ||
+             (iter.comment[0] == '\0' && prev_end != NULL && prev_end != iter.vm_start))) {
+            last_lib_base = iter.vm_start;
+            /* Include a prior anon mapping if contiguous and a header.  This happens
+             * for some page mapping schemes (i#2566).
+             */
+            if (prev_end == iter.vm_start && prev_prot == (MEMPROT_READ|MEMPROT_EXEC) &&
+                module_is_header(prev_base, prev_end - prev_base))
+                last_lib_base = prev_base;
+            /* last_lib_end is used to know what's readable beyond last_lib_base */
             if (TEST(MEMPROT_READ, iter.prot))
-                last_end = iter.vm_end;
+                last_lib_end = iter.vm_end;
             else
-                last_end = last_base;
+                last_lib_end = last_lib_base;
             /* remember name so we can find the base of a multiply-mapped so */
             strncpy(libname, iter.comment, BUFFER_SIZE_ELEMENTS(libname));
             NULL_TERMINATE_BUFFER(libname);
@@ -106,35 +122,45 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start/*IN/OUT*/,
                */
               (found_library && iter.comment[0] == '\0' && image_size != 0 &&
                iter.vm_end - mod_start < image_size))) ||
-            (name == NULL && *start >= iter.vm_start && *start < iter.vm_end)) {
-            if (!found_library) {
-                size_t mod_readable_sz;
+            (name == NULL && target >= iter.vm_start && target < iter.vm_end)) {
+            if (!found_library && iter.comment[0] == '\0' && last_lib_base == NULL) {
+                /* Wait for the next entry which should have a file backing. */
+                target = iter.vm_end;
+            } else if (!found_library) {
                 char *dst = (fullpath != NULL) ? fullpath : libname;
+                const char *src = (iter.comment[0] == '\0') ? libname : iter.comment;
                 size_t dstsz = (fullpath != NULL) ? path_size :
                     BUFFER_SIZE_ELEMENTS(libname);
-                char *slash = strrchr(iter.comment, '/');
-                ASSERT_CURIOSITY(slash != NULL);
-                ASSERT_CURIOSITY((slash - iter.comment) < dstsz);
-                /* we keep the last '/' at end */
-                ++slash;
-                strncpy(dst, iter.comment, MIN(dstsz, (slash - iter.comment)));
-                /* if max no null */
-                dst[dstsz - 1] = '\0';
+                size_t mod_readable_sz;
+                if (src != dst) {
+                    if (dst == fullpath) {
+                        /* Just the path.  We use strstr for name_cmp so still ok there. */
+                        char *slash = strrchr(src, '/');
+                        ASSERT_CURIOSITY(slash != NULL);
+                        ASSERT_CURIOSITY((slash - src) < dstsz);
+                        /* we keep the last '/' at end */
+                        ++slash;
+                        strncpy(dst, src, MIN(dstsz, (slash - src)));
+                    } else
+                        strncpy(dst, src, dstsz);
+                    /* if max no null */
+                    dst[dstsz - 1] = '\0';
+                }
                 if (name == NULL)
                     name_cmp = dst;
                 found_library = true;
-                /* Most library have multiple segments, and some have the
+                /* Most libraries have multiple segments, and some have the
                  * ELF header repeated in a later mapping, so we can't rely
                  * on is_elf_so_header() and header walking.
                  * We use the name tracking to remember the first entry
                  * that had this name.
                  */
-                if (last_base == NULL) {
+                if (last_lib_base == NULL) {
                     mod_start = iter.vm_start;
                     mod_readable_sz = iter.vm_end - iter.vm_start;
                 } else {
-                    mod_start = last_base;
-                    mod_readable_sz = last_end - last_base;
+                    mod_start = last_lib_base;
+                    mod_readable_sz = last_lib_end - last_lib_base;
                 }
                 if (module_is_header(mod_start, mod_readable_sz)) {
                     app_pc mod_base, mod_end;
@@ -161,6 +187,9 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start/*IN/OUT*/,
             /* hit non-matching, we expect module segments to be adjacent */
             break;
         }
+        prev_base = iter.vm_start;
+        prev_end = iter.vm_end;
+        prev_prot = iter.prot;
     }
 
     /* Xref PR 208443: .bss sections are anonymous (no file name listed in
@@ -185,6 +214,8 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start/*IN/OUT*/,
     }
     memquery_iterator_stop(&iter);
 
+    if (name == NULL && *start < mod_start)
+        count = 0; /* Our target adjustment missed: we never found a file-backed entry */
     if (start != NULL)
         *start = mod_start;
     if (end != NULL)

--- a/core/unix/memquery.c
+++ b/core/unix/memquery.c
@@ -94,7 +94,8 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start/*IN/OUT*/,
         if (!found_library &&
             ((iter.comment[0] != '\0' &&
               strncmp(libname, iter.comment, BUFFER_SIZE_ELEMENTS(libname)) != 0) ||
-             (iter.comment[0] == '\0' && prev_end != NULL && prev_end != iter.vm_start))) {
+             (iter.comment[0] == '\0' && prev_end != NULL &&
+              prev_end != iter.vm_start))) {
             last_lib_base = iter.vm_start;
             /* Include a prior anon mapping if contiguous and a header.  This happens
              * for some page mapping schemes (i#2566).
@@ -134,7 +135,7 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start/*IN/OUT*/,
                 size_t mod_readable_sz;
                 if (src != dst) {
                     if (dst == fullpath) {
-                        /* Just the path.  We use strstr for name_cmp so still ok there. */
+                        /* Just the path.  We use strstr for name_cmp. */
                         char *slash = strrchr(src, '/');
                         ASSERT_CURIOSITY(slash != NULL);
                         ASSERT_CURIOSITY((slash - src) < dstsz);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -8771,8 +8771,9 @@ get_application_base(void)
         /* Haven't done find_executable_vm_areas() yet so walk maps ourselves */
         const char *name = get_application_name();
         if (name != NULL && name[0] != '\0') {
-            int count =
-                memquery_library_bounds(name, &executable_start, &executable_end, NULL, 0);
+            DEBUG_DECLARE(int count =)
+                memquery_library_bounds(name, &executable_start, &executable_end,
+                                        NULL, 0);
             ASSERT(count > 0 && executable_start != NULL);
         }
 #else

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7660,6 +7660,11 @@ mmap_check_for_module_overlap(app_pc base, size_t size, bool readable, uint64 in
             ASSERT_CURIOSITY(inode == 0 /*see above comment*/||
                              module_contains_addr(ma, base+size-1));
         }
+        /* Handle cases like transparent huge pages where there are anon regions on top
+         * of the file mapping (i#2566).
+         */
+        if (ma->names.inode == 0)
+            ma->names.inode = inode;
         ASSERT_CURIOSITY(ma->names.inode == inode || inode == 0 /* for .bss */);
         DOCHECK(1, {
             if (readable && module_is_header(base, size)) {
@@ -8766,16 +8771,9 @@ get_application_base(void)
         /* Haven't done find_executable_vm_areas() yet so walk maps ourselves */
         const char *name = get_application_name();
         if (name != NULL && name[0] != '\0') {
-            memquery_iter_t iter;
-            memquery_iterator_start(&iter, NULL, false/*won't alloc*/);
-            while (memquery_iterator_next(&iter)) {
-                if (strcmp(iter.comment, name) == 0) {
-                    executable_start = iter.vm_start;
-                    executable_end = iter.vm_end;
-                    break;
-                }
-            }
-            memquery_iterator_stop(&iter);
+            int count =
+                memquery_library_bounds(name, &executable_start, &executable_end, NULL, 0);
+            ASSERT(count > 0 && executable_start != NULL);
         }
 #else
         /* We have to fail.  Should we dl_iterate this early? */
@@ -9012,7 +9010,10 @@ find_executable_vm_areas(void)
                 iter.vm_start, iter.vm_end, TEST(MEMPROT_EXEC, iter.prot) ? " +x": "",
                 iter.inode, iter.comment);
 #ifdef LINUX
-            ASSERT_CURIOSITY(iter.inode != 0); /* mapped images should have inodes */
+            /* Mapped images should have inodes, except for cases where an anon
+             * map is placed on top (i#2566)
+             */
+            ASSERT_CURIOSITY(iter.inode != 0 || iter.comment[0] == '\0');
 #endif
             ASSERT_CURIOSITY(iter.offset == 0); /* first map shouldn't have offset */
             /* Get size by walking the program headers.  This includes .bss. */
@@ -9034,6 +9035,10 @@ find_executable_vm_areas(void)
             exec_match = get_application_name();
             if (exec_match != NULL && exec_match[0] != '\0')
                 found_exec = (strcmp(iter.comment, exec_match) == 0);
+            /* Handle an anon region for the header (i#2566) */
+            if (!found_exec && executable_start != NULL &&
+                executable_start == iter.vm_start)
+                found_exec = true;
 #else
             /* We don't have a nice normalized name: it can have ./ or ../ inside
              * it.  But, we can distinguish an exe from a lib here, even for PIE,

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2567,6 +2567,10 @@ if (CLIENT_INTERFACE)
           torunonly_drcacheoff(burst_noreach tool.drcacheoff.burst_noreach "" "")
           set(tool.drcacheoff.burst_noreach_nodr ON)
         endif ()
+        if (LINUX)
+          torunonly_drcacheoff(burst_maps tool.drcacheoff.burst_maps "" "")
+          set(tool.drcacheoff.burst_maps_nodr ON)
+        endif ()
 
         if (UNIX)
           # FIXME i#2040: this hits static client issues on Windows


### PR DESCRIPTION
Makes library identification when walking the /proc/self/maps file more
robust, in particular in the presence of anonymous mappings in the text
segment.  memquery_library_bounds_by_iterator() deduces the file backing
for sequences of contiguous entries even when some entries are anonymous.

Changes get_application_base() to use memquery_library_bounds_by_iterator()
to use this functionality as well.

Changes find_executable_vm_areas() to handle an anonymous region with an
ELF header.

Changes mmap_check_for_module_overlap() to use a later inode field if the
first is 0.

I wanted to have a unit test here but while mocking the maps iterator is
feasible, our code here also walks ELF headers, which is harder to
separate.  Instead I made a new application-based test where the app places
anonymous mremaps on top of its own text segment.

Fixes #2566