### PR TITLE
i#2163 : better fix and test case

### DIFF
--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -3218,22 +3218,6 @@ bb_safe_to_stop(dcontext_t *dcontext, instrlist_t *ilist, instr_t *stop_after)
     return true;
 }
 
-#ifdef X86
-/* Tells if instruction will trigger an exception because of debug register. */
-static bool
-debug_register_fire_on_addr(app_pc pc) {
-    size_t i;
-
-    for (i=0; i<DEBUG_REGISTERS_NB; i++) {
-        if (pc == debugRegister[i]) {
-            return true;
-        }
-    }
-
-    return false;
-}
-#endif
-
 /* Interprets the application's instructions until the end of a basic
  * block is found, and prepares the resulting instrlist for creation of
  * a fragment, but does not create the fragment, just returns the instrlist.

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -3503,10 +3503,10 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
 
 #ifdef X86
             /* If the next instruction at bb->cur_pc fires a debug register,
-             * then we should generate a single step exception before getting to it.
+             * then we should stop this basic block before getting to it.
              */
-            if (my_dcontext != NULL && debug_register_fire_on_addr(bb->cur_pc)) {
-                my_dcontext->single_step_addr = bb->instr_start;
+            if (my_dcontext != NULL && debug_register_fire_on_addr(bb->instr_start)) {
+                stop_bb_on_fallthrough = true;
                 break;
             }
 #endif

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1016,11 +1016,15 @@ mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags INOUT,
             mangle_possible_single_step(dcontext, ilist, instr);
             continue;
         }
-        else if (dcontext->single_step_addr != NULL &&
+        else if (dcontext->single_step_addr != NULL && instr_is_app(instr) &&
                  dcontext->single_step_addr == instr->translation) {
-            mangle_single_step(dcontext, ilist, *flags, instr);
-            /* Resets to generate single step exception only once. */
-            dcontext->single_step_addr = NULL;
+            instr_t * last_addr = instr_get_next_app(instr);
+            /* Checks if sandboxing added another app instruction. */
+            if (!last_addr || last_addr->translation != instr->translation) {
+                mangle_single_step(dcontext, ilist, *flags, instr);
+                /* Resets to generate single step exception only once. */
+                dcontext->single_step_addr = NULL;
+            }
         }
 #endif
 #ifdef FOOL_CPUID

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1016,15 +1016,11 @@ mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags INOUT,
             mangle_possible_single_step(dcontext, ilist, instr);
             continue;
         }
-        else if (dcontext->single_step_addr != NULL && instr_is_app(instr) &&
+        else if (dcontext->single_step_addr != NULL &&
                  dcontext->single_step_addr == instr->translation) {
-            instr_t * last_addr = instr_get_next_app(instr);
-            /* Checks if sandboxing added another app instruction. */
-            if (!last_addr || last_addr->translation != instr->translation) {
-                mangle_single_step(dcontext, ilist, *flags, instr);
-                /* Resets to generate single step exception only once. */
-                dcontext->single_step_addr = NULL;
-            }
+            mangle_single_step(dcontext, ilist, *flags, instr);
+            /* Resets to generate single step exception only once. */
+            dcontext->single_step_addr = NULL;
         }
 #endif
 #ifdef FOOL_CPUID

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1441,8 +1441,8 @@ extern app_pc debugRegister[DEBUG_REGISTERS_NB];
 /* Tells if instruction will trigger an exception because of debug register. */
 static inline bool
 debug_register_fire_on_addr(app_pc pc) {
-    return (pc == debugRegister[0] || pc == debugRegister[1] ||
-            pc == debugRegister[2] || pc == debugRegister[3]);
+    return (pc != NULL && (pc == debugRegister[0] || pc == debugRegister[1] ||
+                           pc == debugRegister[2] || pc == debugRegister[3]));
 }
 
 #endif /* _OPCODE_H_ */

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1438,4 +1438,11 @@ enum { /* FIXME: vs RAW_OPCODE_* enum */
 #define DEBUG_REGISTERS_FLAG_ENABLE_DR3 0xc0
 extern app_pc debugRegister[DEBUG_REGISTERS_NB];
 
+/* Tells if instruction will trigger an exception because of debug register. */
+static inline bool
+debug_register_fire_on_addr(app_pc pc) {
+    return (pc == debugRegister[0] || pc == debugRegister[1] ||
+            pc == debugRegister[2] || pc == debugRegister[3]);
+}
+
 #endif /* _OPCODE_H_ */

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1440,7 +1440,9 @@ extern app_pc debugRegister[DEBUG_REGISTERS_NB];
 
 /* Tells if instruction will trigger an exception because of debug register. */
 static inline bool
-debug_register_fire_on_addr(app_pc pc) {
+debug_register_fire_on_addr(app_pc pc)
+{
+    ASSERT(DEBUG_REGISTERS_NB == 4);
     return (pc != NULL && (pc == debugRegister[0] || pc == debugRegister[1] ||
                            pc == debugRegister[2] || pc == debugRegister[3]));
 }

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -874,6 +874,17 @@ dispatch_enter_dynamorio(dcontext_t *dcontext)
         if (get_at_syscall(dcontext))
             handle_post_system_call(dcontext);
 
+#ifdef X86
+        /* If the next basic block starts at a debug register value,
+         * we fire a single step exception before getting to the basic block. */
+        if (debug_register_fire_on_addr(dcontext->next_tag)) {
+            LOG(THREAD, LOG_DISPATCH, 2, "Generates single step before "PFX"\n",
+                dcontext->next_tag);
+            os_forge_exception(dcontext->next_tag, SINGLE_STEP_EXCEPTION);
+            ASSERT_NOT_REACHED();
+        }
+#endif
+
         /* A non-ignorable syscall or cb return ending a bb must be acted on
          * We do it here to avoid becoming couldbelinking twice.
          *

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -3790,7 +3790,12 @@ intercept_nt_continue(CONTEXT *cxt, int flag)
             }
             else {
                 /* Disable debug register. */
-                debugRegister[0] = NULL;
+                if (debugRegister[0] != NULL) {
+                    flush_fragments_from_region(dcontext, debugRegister[0],
+                                                1 /* size */,
+                                                false/*don't force synchall*/);
+                    debugRegister[0] = NULL;
+                }
             }
             if (TESTANY(cxt->Dr7, DEBUG_REGISTERS_FLAG_ENABLE_DR1) ) {
                 if (debugRegister[1] != (app_pc) cxt->Dr1) {
@@ -3801,7 +3806,13 @@ intercept_nt_continue(CONTEXT *cxt, int flag)
                 }
             }
             else {
-                debugRegister[1] = NULL;
+                /* Disable debug register. */
+                if (debugRegister[1] != NULL) {
+                    flush_fragments_from_region(dcontext, debugRegister[1],
+                                                1 /* size */,
+                                                false/*don't force synchall*/);
+                    debugRegister[1] = NULL;
+                }
             }
             if (TESTANY(cxt->Dr7, DEBUG_REGISTERS_FLAG_ENABLE_DR2) ) {
                 if (debugRegister[2] != (app_pc) cxt->Dr2) {
@@ -3812,7 +3823,13 @@ intercept_nt_continue(CONTEXT *cxt, int flag)
                 }
             }
             else {
-                debugRegister[2] = NULL;
+                /* Disable debug register. */
+                if (debugRegister[2] != NULL) {
+                    flush_fragments_from_region(dcontext, debugRegister[2],
+                                                1 /* size */,
+                                                false/*don't force synchall*/);
+                    debugRegister[2] = NULL;
+                }
             }
             if (TESTANY(cxt->Dr7, DEBUG_REGISTERS_FLAG_ENABLE_DR3) ) {
                 if (debugRegister[3] != (app_pc) cxt->Dr3) {
@@ -3823,7 +3840,13 @@ intercept_nt_continue(CONTEXT *cxt, int flag)
                 }
             }
             else {
-                debugRegister[3] = NULL;
+                /* Disable debug register. */
+                if (debugRegister[3] != NULL) {
+                    flush_fragments_from_region(dcontext, debugRegister[3],
+                                                1 /* size */,
+                                                false/*don't force synchall*/);
+                    debugRegister[3] = NULL;
+                }
             }
         }
 
@@ -5737,9 +5760,6 @@ intercept_exception(app_state_at_intercept_t *state)
                     /* Checks that exception address translate on a popf. */
                     if (instr_get_opcode(&instr) == OP_popf ||
                         instr_get_opcode(&instr) == OP_iret) {
-                        LOG(THREAD, LOG_ASYNCH, 2,
-                            "Caught generated single step exception at "PFX"\n",
-                            pExcptRec->ExceptionAddress);
                         /* Will continue after one byte popf or iret. */
                         if (instr_get_opcode(&instr) == OP_popf) {
                             dcontext->next_tag = mcontext.pc + POPF_LENGTH;
@@ -5756,6 +5776,9 @@ intercept_exception(app_state_at_intercept_t *state)
                                                     false/*don't force synchall*/);
                         /* Sets a field so that build_bb_ilist knows when to stop. */
                         dcontext->single_step_addr = dcontext->next_tag;
+                        LOG(THREAD, LOG_ASYNCH, 2,
+                            "Caught generated single step exception at "PFX" to "PFX"\n",
+                            pExcptRec->ExceptionAddress, dcontext->next_tag);
                         /* Will return to execute instruction
                          * where single step exception will be forged.
                          */

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -3764,8 +3764,6 @@ NtContinue:
 void
 intercept_nt_continue(CONTEXT *cxt, int flag)
 {
-    size_t i;
-
     if (intercept_asynch_for_self(false/*no unknown threads*/)) {
         dcontext_t *dcontext = get_thread_private_dcontext();
 
@@ -3782,23 +3780,50 @@ intercept_nt_continue(CONTEXT *cxt, int flag)
          */
         if (TESTALL(CONTEXT_DEBUG_REGISTERS, cxt->ContextFlags)) {
             if (TESTANY(cxt->Dr7, DEBUG_REGISTERS_FLAG_ENABLE_DR0) ) {
-                debugRegister[0] = (app_pc) cxt->Dr0;
-            }
-            if (TESTANY(cxt->Dr7, DEBUG_REGISTERS_FLAG_ENABLE_DR1) ) {
-                debugRegister[1] = (app_pc) cxt->Dr1;
-            }
-            if (TESTANY(cxt->Dr7, DEBUG_REGISTERS_FLAG_ENABLE_DR2) ) {
-                debugRegister[2] = (app_pc) cxt->Dr2;
-            }
-            if (TESTANY(cxt->Dr7, DEBUG_REGISTERS_FLAG_ENABLE_DR3) ) {
-                debugRegister[3] = (app_pc) cxt->Dr3;
-            }
-            for (i=0; i<DEBUG_REGISTERS_NB; i++) {
-                if (debugRegister[i] != NULL) {
-                    flush_fragments_from_region(dcontext, debugRegister[i],
+                /* Flush only when debug register value changes. */
+                if (debugRegister[0] != (app_pc) cxt->Dr0) {
+                    debugRegister[0] = (app_pc) cxt->Dr0;
+                    flush_fragments_from_region(dcontext, debugRegister[0],
                                                 1 /* size */,
                                                 false/*don't force synchall*/);
                 }
+            }
+            else {
+                /* Disable debug register. */
+                debugRegister[0] = NULL;
+            }
+            if (TESTANY(cxt->Dr7, DEBUG_REGISTERS_FLAG_ENABLE_DR1) ) {
+                if (debugRegister[1] != (app_pc) cxt->Dr1) {
+                    debugRegister[1] = (app_pc) cxt->Dr1;
+                    flush_fragments_from_region(dcontext, debugRegister[1],
+                                                1 /* size */,
+                                                false/*don't force synchall*/);
+                }
+            }
+            else {
+                debugRegister[1] = NULL;
+            }
+            if (TESTANY(cxt->Dr7, DEBUG_REGISTERS_FLAG_ENABLE_DR2) ) {
+                if (debugRegister[2] != (app_pc) cxt->Dr2) {
+                    debugRegister[2] = (app_pc) cxt->Dr2;
+                    flush_fragments_from_region(dcontext, debugRegister[2],
+                                                1 /* size */,
+                                                false/*don't force synchall*/);
+                }
+            }
+            else {
+                debugRegister[2] = NULL;
+            }
+            if (TESTANY(cxt->Dr7, DEBUG_REGISTERS_FLAG_ENABLE_DR3) ) {
+                if (debugRegister[3] != (app_pc) cxt->Dr3) {
+                    debugRegister[3] = (app_pc) cxt->Dr3;
+                    flush_fragments_from_region(dcontext, debugRegister[3],
+                                                1 /* size */,
+                                                false/*don't force synchall*/);
+                }
+            }
+            else {
+                debugRegister[3] = NULL;
             }
         }
 

--- a/suite/tests/security-win32/except-debugreg.c
+++ b/suite/tests/security-win32/except-debugreg.c
@@ -38,7 +38,8 @@
 static int count = 0;
 void set_debug_register();
 void test_debug_register();
-void single_step_addr(void);
+void single_step_addr0(void);
+void single_step_addr1(void);
 
 
 /* top-level exception handler */
@@ -50,11 +51,12 @@ our_top_handler(struct _EXCEPTION_POINTERS * pExceptionInfo)
         // We should find another way compatible with 64-bit to be able to test it
 
         // Should get here thanks to the int 3 instruction in set_debug_register
-        // Set Dr0 to the address where to add a breakpoint
-        pExceptionInfo->ContextRecord->Dr0 = (unsigned int) single_step_addr;
+        // Set Dr0 and Dr1 to the address where to add a breakpoint
+        pExceptionInfo->ContextRecord->Dr0 = (unsigned int) single_step_addr0;
+        pExceptionInfo->ContextRecord->Dr1 = (unsigned int) single_step_addr1;
         pExceptionInfo->ContextRecord->Dr6 = 0xfffe0ff0;
-        // Set Dr7 to enable Dr0 breakpoint
-        pExceptionInfo->ContextRecord->Dr7 = 0x00000101;
+        // Set Dr7 to enable Dr0 and Dr1 breakpoint
+        pExceptionInfo->ContextRecord->Dr7 = 0x00000505;
         print("set debug register\n");
         // Increment pc pointer to go to next instruction and avoid infinite loop
 #ifndef X64
@@ -64,19 +66,29 @@ our_top_handler(struct _EXCEPTION_POINTERS * pExceptionInfo)
 #endif
         return EXCEPTION_CONTINUE_EXECUTION;
     } else if (pExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_SINGLE_STEP) {
-        print("single step seen\n");
-        if (pExceptionInfo->ExceptionRecord->ExceptionAddress == single_step_addr) {
+        // Prints eax to check if "inc eax" instruction was executed
+        print("single step seen eax = %x\n", pExceptionInfo->ContextRecord->Eax);
+        if (pExceptionInfo->ExceptionRecord->ExceptionAddress == single_step_addr0 ||
+            pExceptionInfo->ExceptionRecord->ExceptionAddress == single_step_addr1) {
             count++;
+            // Increment pc pointer to go to next instruction and avoid infinite loop
+#ifndef X64
+            pExceptionInfo->ContextRecord->Eip++;
+#else
+            pExceptionInfo->ContextRecord->Rip++;
+#endif
         }
         else {
-            print("got address "PFX", expected "PFX"\n",
+            print("got address "PFX", expected "PFX" or "PFX"\n",
                   pExceptionInfo->ExceptionRecord->ExceptionAddress,
-                  single_step_addr);
+                  single_step_addr0, single_step_addr1);
         }
-        //deactivate breakpoint
-        pExceptionInfo->ContextRecord->Dr0 = 0;
-        pExceptionInfo->ContextRecord->Dr6 = 0;
-        pExceptionInfo->ContextRecord->Dr7 = 0;
+        if (count == 2) {
+            //deactivate breakpoints
+            pExceptionInfo->ContextRecord->Dr0 = 0;
+            pExceptionInfo->ContextRecord->Dr6 = 0;
+            pExceptionInfo->ContextRecord->Dr7 = 0;
+        }
         return EXCEPTION_CONTINUE_EXECUTION;
     }
     return EXCEPTION_EXECUTE_HANDLER; /* => global unwind and silent death */
@@ -121,14 +133,22 @@ END_FUNC(FUNCNAME)
 #define FUNCNAME test_debug_register
 DECLARE_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
-        nop
-        nop
-DECLARE_GLOBAL(single_step_addr)
-ADDRTAKEN_LABEL(single_step_addr:)
-        nop
         xor      eax, eax
-        test     eax, eax
+        // Sets eax to some value
+        mov      eax, 1
+        // Modifies eax with a one byte instruction at a single step
+DECLARE_GLOBAL(single_step_addr0)
+ADDRTAKEN_LABEL(single_step_addr0:)
+        inc      eax
         nop
+        inc      eax
+        jmp      eaxEquals2
+        ret
+        // Check debug register at the start of a new basic block
+    eaxEquals2:
+DECLARE_GLOBAL(single_step_addr1)
+ADDRTAKEN_LABEL(single_step_addr1:)
+        inc      eax
         nop
         ret
 END_FUNC(FUNCNAME)

--- a/suite/tests/security-win32/except-debugreg.c
+++ b/suite/tests/security-win32/except-debugreg.c
@@ -59,11 +59,7 @@ our_top_handler(struct _EXCEPTION_POINTERS * pExceptionInfo)
         pExceptionInfo->ContextRecord->Dr7 = 0x00000505;
         print("set debug register\n");
         // Increment pc pointer to go to next instruction and avoid infinite loop
-#ifndef X64
-        pExceptionInfo->ContextRecord->Eip++;
-#else
-        pExceptionInfo->ContextRecord->Rip++;
-#endif
+        pExceptionInfo->ContextRecord->CXT_XIP++;
         return EXCEPTION_CONTINUE_EXECUTION;
     } else if (pExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_SINGLE_STEP) {
         // Prints eax to check if "inc eax" instruction was executed
@@ -72,11 +68,7 @@ our_top_handler(struct _EXCEPTION_POINTERS * pExceptionInfo)
             pExceptionInfo->ExceptionRecord->ExceptionAddress == single_step_addr1) {
             count++;
             // Increment pc pointer to go to next instruction and avoid infinite loop
-#ifndef X64
-            pExceptionInfo->ContextRecord->Eip++;
-#else
-            pExceptionInfo->ContextRecord->Rip++;
-#endif
+            pExceptionInfo->ContextRecord->CXT_XIP++;
         }
         else {
             print("got address "PFX", expected "PFX" or "PFX"\n",

--- a/suite/tests/security-win32/except-debugreg.expect
+++ b/suite/tests/security-win32/except-debugreg.expect
@@ -1,4 +1,5 @@
 start of test, count = 0
 set debug register
-single step seen
-end of test, count = 1
+single step seen eax = 1
+single step seen eax = 2
+end of test, count = 2


### PR DESCRIPTION
The previous patch was not complete : it did not work when debug register was set to an address starting a basic block.
The test case checks now both situations : debug register at a start or in the middle of a basic block.
+ there were useless flushes