### PR TITLE
i#2573: print rstats at exit

### DIFF
--- a/clients/drcachesim/tests/burst_static.cpp
+++ b/clients/drcachesim/tests/burst_static.cpp
@@ -73,7 +73,9 @@ main(int argc, const char *argv[])
     static int iter_start = outer_iters/3;
     static int iter_stop = iter_start + 4;
 
-    if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -client_lib ';;-offline'"))
+    /* We also test -rstats_to_stderr */
+    if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -rstats_to_stderr "
+                   "-client_lib ';;-offline'"))
         std::cerr << "failed to set env var!\n";
 
     /* We use an outer loop to test re-attaching (i#2157). */

--- a/clients/drcachesim/tests/offline-burst_client.templatex
+++ b/clients/drcachesim/tests/offline-burst_client.templatex
@@ -2,6 +2,25 @@ pre-DR init
 app dr_client_main
 pre-DR start
 pre-DR detach
+DynamoRIO statistics:
+ *Peak threads under DynamoRIO control : *1
+.*
+all done
+pre-DR init
+app dr_client_main
+pre-DR start
+pre-DR detach
+DynamoRIO statistics:
+ *Peak threads under DynamoRIO control : *1
+.*
+all done
+pre-DR init
+app dr_client_main
+pre-DR start
+pre-DR detach
+DynamoRIO statistics:
+ *Peak threads under DynamoRIO control : *1
+.*
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)

--- a/clients/drcachesim/tests/offline-burst_static.templatex
+++ b/clients/drcachesim/tests/offline-burst_static.templatex
@@ -2,21 +2,21 @@ pre-DR init
 pre-DR start
 pre-DR detach
 DynamoRIO statistics:
-              Peak threads under DynamoRIO control :                 1
+ *Peak threads under DynamoRIO control : *1
 .*
 all done
 pre-DR init
 pre-DR start
 pre-DR detach
 DynamoRIO statistics:
-              Peak threads under DynamoRIO control :                 1
+ *Peak threads under DynamoRIO control : *1
 .*
 all done
 pre-DR init
 pre-DR start
 pre-DR detach
 DynamoRIO statistics:
-              Peak threads under DynamoRIO control :                 1
+ *Peak threads under DynamoRIO control : *1
 .*
 all done
 Cache simulation results:

--- a/clients/drcachesim/tests/offline-burst_static.templatex
+++ b/clients/drcachesim/tests/offline-burst_static.templatex
@@ -1,14 +1,23 @@
 pre-DR init
 pre-DR start
 pre-DR detach
+DynamoRIO statistics:
+              Peak threads under DynamoRIO control :                 1
+.*
 all done
 pre-DR init
 pre-DR start
 pre-DR detach
+DynamoRIO statistics:
+              Peak threads under DynamoRIO control :                 1
+.*
 all done
 pre-DR init
 pre-DR start
 pre-DR detach
+DynamoRIO statistics:
+              Peak threads under DynamoRIO control :                 1
+.*
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -1115,6 +1115,8 @@ dynamo_shared_exit(thread_record_t *toexit /* must ==cur thread for Linux */
          */
         dump_global_stats(false);
     });
+    if (INTERNAL_OPTION(rstats_to_stderr))
+        dump_global_rstats_to_stderr();
 
     statistics_exit();
 #ifdef DEBUG
@@ -1516,6 +1518,9 @@ dynamo_process_exit(void)
 # endif
     /* so make sure eventlog connection is terminated (if present)  */
     os_fast_exit();
+
+    if (INTERNAL_OPTION(rstats_to_stderr))
+        dump_global_rstats_to_stderr();
 
     return SUCCESS;
 #endif /* !DEBUG */

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -54,6 +54,9 @@
 #endif
 #undef STATS_DEF
 #undef RSTATS_DEF
+
+RSTATS_DEF should start the description with Current for stats to not print
+under -rstats_to_stderr.
 */
 
 /* Add new statistics at the end so that older GUIs can still show old statistics */
@@ -65,14 +68,14 @@
 /* use RSTATS_DEF for statistics that are available in release build as well
  * as debug (you must use RSTATS_INC, etc. as well with such stats)
  */
-#ifdef DEBUG
+#if defined(DEBUG) && !defined(RSTATS_ONLY)
 # define RSTATS_DEF STATS_DEF
 #else
 # define STATS_DEF(desc, name) /* nothing */
 #endif
 
     STATS_DEF("Application exited", exited)
-    RSTATS_DEF("Threads under DynamoRIO control", num_threads)
+    RSTATS_DEF("Current threads under DynamoRIO control", num_threads)
     RSTATS_DEF("Peak threads under DynamoRIO control", peak_num_threads)
     RSTATS_DEF("Threads ever created", num_threads_created)
     STATS_DEF("Threads killed", num_threads_killed)
@@ -571,7 +574,7 @@
     STATS_DEF("Branches linked, indirect", num_indirect_links)
     STATS_DEF("Branches already linked, indirect", num_indirect_already_linked)
 
-    RSTATS_DEF("Coarse-grain units", num_coarse_units)
+    RSTATS_DEF("Current coarse-grain units", num_coarse_units)
     RSTATS_DEF("Peak coarse-grain units", peak_num_coarse_units)
     STATS_DEF("Coarse-grain fragments generated", num_coarse_fragments)
     STATS_DEF("Coarse-grain fragments in secondary units", num_coarse_secondary)
@@ -870,9 +873,9 @@
     STATS_DEF("Fcache combined claimed (bytes)", fcache_combined_claimed)
     STATS_DEF("Fcache combined capacity (bytes)", fcache_combined_capacity)
     STATS_DEF("Peak fcache combined capacity (bytes)", peak_fcache_combined_capacity)
-    RSTATS_DEF("Fcache units on live list", fcache_num_live)
+    RSTATS_DEF("Current fcache units on live list", fcache_num_live)
     RSTATS_DEF("Peak fcache units on live list", peak_fcache_num_live)
-    RSTATS_DEF("Fcache units on free list", fcache_num_free)
+    RSTATS_DEF("Current fcache units on free list", fcache_num_free)
     RSTATS_DEF("Peak fcache units on free list", peak_fcache_num_free)
     STATS_DEF("Fcache unit lookups", fcache_unit_lookups)
 
@@ -890,9 +893,9 @@
     STATS_DEF("Special heap capacity (bytes)", heap_special_capacity)
     STATS_DEF("Peak special heap capacity (bytes)", peak_heap_special_capacity)
 
-    RSTATS_DEF("Heap units on live list", heap_num_live)
+    RSTATS_DEF("Current heap units on live list", heap_num_live)
     RSTATS_DEF("Peak heap units on live list", peak_heap_num_live)
-    RSTATS_DEF("Heap units on free list", heap_num_free)
+    RSTATS_DEF("Current heap units on free list", heap_num_free)
     RSTATS_DEF("Peak heap units on free list", peak_heap_num_free)
     STATS_DEF("Heap headers (bytes)", heap_headers)
     STATS_DEF("Heap align space (bytes)", heap_align)

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -238,6 +238,8 @@
     OPTION_INTERNAL(bool, bbdump_tags, "dump tags, sizes, and sharedness of all bbs")
     OPTION_INTERNAL(bool, gendump, "dump generated code")
     OPTION_DEFAULT(bool, global_rstats, true, "enable global release-build statistics")
+    OPTION_DEFAULT_INTERNAL(bool, rstats_to_stderr, false,
+                            "print the final global rstats to stderr")
 
     /* this takes precedence over the DYNAMORIO_VAR_LOGDIR config var */
     OPTION_DEFAULT(pathstring_t, logdir, EMPTY_STRING,

--- a/core/utils.c
+++ b/core/utils.c
@@ -3281,8 +3281,28 @@ print_timestamp(file_t logfile)
         print_file(logfile, buffer);
     return len;
 }
-
 #endif /* DEBUG */
+
+void
+dump_global_rstats_to_stderr(void)
+{
+    if (GLOBAL_STATS_ON()) {
+        print_file(STDERR, "%s statistics:\n", PRODUCT_NAME);
+#undef RSTATS_DEF
+        /* It doesn't make sense to print Current stats.  We assume no rstat starts
+         * with "Cu".
+         */
+#define RSTATS_DEF(desc, stat) \
+        if (GLOBAL_STAT(stat) && (desc[0] != 'C' || desc[1] != 'u')) { \
+            print_file(STDERR, "%50s :"IF_X64_ELSE("%18","%9")SSZFC    \
+                       "\n", desc, GLOBAL_STAT(stat));                 \
+        }
+#define RSTATS_ONLY
+#include "statsx.h"
+#undef RSTATS_ONLY
+#undef RSTATS_DEF
+    }
+}
 
 static void
 dump_buffer_as_ascii(file_t logfile, char *buffer, size_t len)

--- a/core/utils.h
+++ b/core/utils.h
@@ -2030,6 +2030,8 @@ print_symbolic_address(app_pc tag, char *buf, int max_chars, bool exact_only);
 
 #endif /* DEBUG */
 
+void dump_global_rstats_to_stderr(void);
+
 bool
 under_internal_exception(void);
 


### PR DESCRIPTION
Adds a new option -rstats_to_stderr for obtaining some basic peak
statistics from release builds without resorting to concurrent shared
memory reading.

Tweaks the existing rstats to use a consistent name so we can skip the
non-peak stats for this option.

Adds a test case to the burst_static test.

Fixes #2573