### PR TITLE
i#2299: shrink drmemtrace buffer redzone

### DIFF
--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,6 +49,9 @@
 #define BUFFER_LAST_ELEMENT(buf)    buf[BUFFER_SIZE_ELEMENTS(buf) - 1]
 #define NULL_TERMINATE_BUFFER(buf)  BUFFER_LAST_ELEMENT(buf) = 0
 #define TESTANY(mask, var) (((mask) & (var)) != 0)
+
+#define ALIGN_FORWARD(x, alignment) \
+    ((((ptr_uint_t)x) + ((alignment)-1)) & (~((ptr_uint_t)(alignment)-1)))
 
 #define BOOLS_MATCH(b1, b2) (!!(b1) == !!(b2))
 

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1345,7 +1345,7 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
     uint64 max_bb_instrs;
     if (!dr_get_integer_option("max_bb_instrs", &max_bb_instrs))
         max_bb_instrs = 256; /* current default */
-    redzone_size = instru->sizeof_entry() * max_bb_instrs * 2;
+    redzone_size = instru->sizeof_entry() * (size_t)max_bb_instrs * 2;
 
     max_buf_size = ALIGN_FORWARD(trace_buf_size + redzone_size, dr_page_size());
     /* Mark any padding as redzone as well */

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1334,8 +1334,22 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
         DR_ASSERT(false);
 
     trace_buf_size = instru->sizeof_entry() * MAX_NUM_ENTRIES;
-    redzone_size = instru->sizeof_entry() * MAX_NUM_ENTRIES;
-    max_buf_size = trace_buf_size + redzone_size;
+
+    /* The redzone needs to hold one bb's worth of data, until we
+     * reach the clean call at the bottom of the bb that dumps the
+     * buffer if full.  We leave room for each of the maximum count of
+     * instructions accessing memory once, which is fairly
+     * pathological as by default that's 256 memrefs for one bb.  We double
+     * it to ensure we cover skipping clean calls for sthg like strex.
+     */
+    uint64 max_bb_instrs;
+    if (!dr_get_integer_option("max_bb_instrs", &max_bb_instrs))
+        max_bb_instrs = 256; /* current default */
+    redzone_size = instru->sizeof_entry() * max_bb_instrs * 2;
+
+    max_buf_size = ALIGN_FORWARD(trace_buf_size + redzone_size, dr_page_size());
+    /* Mark any padding as redzone as well */
+    redzone_size = max_buf_size - trace_buf_size;
     buf_hdr_slots_size = instru->sizeof_entry() * BUF_HDR_SLOTS;
 
     client_id = id;


### PR DESCRIPTION
The drmemtrace buffer's redzone was much larger than necessary, as it only
needs to hold about one basic block's worth of memory references.  We
shrink it substantially here based on -max_bb_instrs: now it's 4K by
default (for -offline) as opposed to the 32K it took before, which makes a
significant difference on apps with many threads.

Fixes #2299