### PR TITLE
i#2580 api.it: Fix it test failure on Android

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2141,9 +2141,11 @@ if (CLIENT_INTERFACE)
     set(client.pcache-use_depends client.pcache)
   endif (X86)
 
-  if (ARM)
+  if (ARM AND NOT ANDROID)
+    # i#2580: DT_RUNPATH is not yet supported on android so we disable this test on
+    # android
     tobuild_api(api.it api/it_arm.c "" "" OFF OFF)
-  endif(ARM)
+  endif(ARM AND NOT ANDROID)
 
   if (ARM)
     set(sfx "arm")


### PR DESCRIPTION
Currently the api.it test fails on Android, likely due to DT_RUNPATH not
being supported. The way these api.* tests operate should be changed to
support Android as well in the future.

Fixes #2580