### PR TITLE
i#1723 predication: Globally enable auto predicate

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -178,8 +178,9 @@ Further non-compatibility-affecting changes include:
    drmemtrace_custom_module_data(), and drmemtrace_get_modlist_path().
  - Added a set_value() function to the \ref page_droption.
  - Added instrlist_get_auto_predicate() and instrlist_set_auto_predicate().
- - Globally enables auto predication to the drmgr instrumentation insertion event by
+ - Globally enabled auto predication in the drmgr instrumentation insertion event by
    default.
+ - Added drmgr_disable_auto_predication().
 
 **************************************************
 <hr>

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -178,6 +178,8 @@ Further non-compatibility-affecting changes include:
    drmemtrace_custom_module_data(), and drmemtrace_get_modlist_path().
  - Added a set_value() function to the \ref page_droption.
  - Added instrlist_get_auto_predicate() and instrlist_set_auto_predicate().
+ - Globally enables auto predication to the drmgr instrumentation insertion event by
+   default.
 
 **************************************************
 <hr>

--- a/api/samples/bbbuf.c
+++ b/api/samples/bbbuf.c
@@ -67,6 +67,11 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     /* We need a 2nd scratch reg for several operations on AArch32 and AArch64 only. */
     reg_id_t reg2 = DR_REG_NULL;
 
+    /* By default drmgr enables auto-predication, which predicates all instructions with
+     * the predicate of the current instruction on ARM.
+     * We disable it here because we want to unconditionally execute the following
+     * instrumentation.
+     */
     drmgr_disable_auto_predication(drcontext, bb);
 
     /* We do all our work at the start of the block prior to the first instr */
@@ -91,7 +96,6 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
 
     /* load buffer pointer from TLS field */
     drx_buf_insert_load_buf_ptr(drcontext, buf, bb, inst, reg);
-
 
     /* store bb's start pc into the buffer */
     drx_buf_insert_buf_store(drcontext, buf, bb, inst, reg, reg2,

--- a/api/samples/bbbuf.c
+++ b/api/samples/bbbuf.c
@@ -67,6 +67,8 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     /* We need a 2nd scratch reg for several operations on AArch32 and AArch64 only. */
     reg_id_t reg2 = DR_REG_NULL;
 
+    drmgr_disable_auto_predication(drcontext, bb);
+
     /* We do all our work at the start of the block prior to the first instr */
     if (!drmgr_is_first_instr(drcontext, inst))
         return DR_EMIT_DEFAULT;

--- a/api/samples/bbcount.c
+++ b/api/samples/bbcount.c
@@ -94,6 +94,11 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     bool aflags_dead;
 #endif
 
+    /* By default drmgr enables auto-predication, which predicates all instructions with
+     * the predicate of the current instruction on ARM.
+     * We disable it here because we want to unconditionally execute the following
+     * instrumentation.
+     */
     drmgr_disable_auto_predication(drcontext, bb);
     if (!drmgr_is_first_instr(drcontext, inst))
         return DR_EMIT_DEFAULT;

--- a/api/samples/bbcount.c
+++ b/api/samples/bbcount.c
@@ -94,6 +94,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     bool aflags_dead;
 #endif
 
+    drmgr_disable_auto_predication(drcontext, bb);
     if (!drmgr_is_first_instr(drcontext, inst))
         return DR_EMIT_DEFAULT;
 

--- a/api/samples/inscount.cpp
+++ b/api/samples/inscount.cpp
@@ -182,6 +182,11 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
                       bool for_trace, bool translating, void *user_data)
 {
     uint num_instrs;
+    /* By default drmgr enables auto-predication, which predicates all instructions with
+     * the predicate of the current instruction on ARM.
+     * We disable it here because we want to unconditionally execute the following
+     * instrumentation.
+     */
     drmgr_disable_auto_predication(drcontext, bb);
     if (!drmgr_is_first_instr(drcontext, instr))
         return DR_EMIT_DEFAULT;

--- a/api/samples/inscount.cpp
+++ b/api/samples/inscount.cpp
@@ -182,6 +182,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
                       bool for_trace, bool translating, void *user_data)
 {
     uint num_instrs;
+    drmgr_disable_auto_predication(drcontext, bb);
     if (!drmgr_is_first_instr(drcontext, instr))
         return DR_EMIT_DEFAULT;
     /* Only insert calls for in-app BBs */

--- a/api/samples/instrace_simple.c
+++ b/api/samples/instrace_simple.c
@@ -184,6 +184,8 @@ instrument_instr(void *drcontext, instrlist_t *ilist, instr_t *where)
 {
     /* We need two scratch registers */
     reg_id_t reg_ptr, reg_tmp;
+    /* we don't want to predicate this, because an instruction fetch always occurs */
+    instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
     if (drreg_reserve_register(drcontext, ilist, where, NULL, &reg_ptr) !=
         DRREG_SUCCESS ||
         drreg_reserve_register(drcontext, ilist, where, NULL, &reg_tmp) !=
@@ -203,6 +205,7 @@ instrument_instr(void *drcontext, instrlist_t *ilist, instr_t *where)
     if (drreg_unreserve_register(drcontext, ilist, where, reg_ptr) != DRREG_SUCCESS ||
         drreg_unreserve_register(drcontext, ilist, where, reg_tmp) != DRREG_SUCCESS)
         DR_ASSERT(false);
+    instrlist_set_auto_predicate(ilist, instr_get_predicate(where));
 }
 
 /* For each app instr, we insert inline code to fill the buffer. */

--- a/api/samples/instrace_simple.c
+++ b/api/samples/instrace_simple.c
@@ -184,8 +184,6 @@ instrument_instr(void *drcontext, instrlist_t *ilist, instr_t *where)
 {
     /* We need two scratch registers */
     reg_id_t reg_ptr, reg_tmp;
-    /* we don't want to predicate this, because an instruction fetch always occurs */
-    instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
     if (drreg_reserve_register(drcontext, ilist, where, NULL, &reg_ptr) !=
         DRREG_SUCCESS ||
         drreg_reserve_register(drcontext, ilist, where, NULL, &reg_tmp) !=
@@ -205,7 +203,6 @@ instrument_instr(void *drcontext, instrlist_t *ilist, instr_t *where)
     if (drreg_unreserve_register(drcontext, ilist, where, reg_ptr) != DRREG_SUCCESS ||
         drreg_unreserve_register(drcontext, ilist, where, reg_tmp) != DRREG_SUCCESS)
         DR_ASSERT(false);
-    instrlist_set_auto_predicate(ilist, instr_get_predicate(where));
 }
 
 /* For each app instr, we insert inline code to fill the buffer. */
@@ -214,6 +211,9 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb,
                       instr_t *instr, bool for_trace,
                       bool translating, void *user_data)
 {
+    /* we don't want to auto-predicate any instrumentation */
+    drmgr_disable_auto_predication(drcontext, bb);
+
     if (!instr_is_app(instr))
         return DR_EMIT_DEFAULT;
 

--- a/api/samples/memtrace_simple.c
+++ b/api/samples/memtrace_simple.c
@@ -235,6 +235,8 @@ instrument_instr(void *drcontext, instrlist_t *ilist, instr_t *where)
 {
     /* We need two scratch registers */
     reg_id_t reg_ptr, reg_tmp;
+    /* we don't want to predicate this, because an instruction fetch always occurs */
+    instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
     if (drreg_reserve_register(drcontext, ilist, where, NULL, &reg_ptr) !=
         DRREG_SUCCESS ||
         drreg_reserve_register(drcontext, ilist, where, NULL, &reg_tmp) !=
@@ -254,6 +256,7 @@ instrument_instr(void *drcontext, instrlist_t *ilist, instr_t *where)
     if (drreg_unreserve_register(drcontext, ilist, where, reg_ptr) != DRREG_SUCCESS ||
         drreg_unreserve_register(drcontext, ilist, where, reg_tmp) != DRREG_SUCCESS)
         DR_ASSERT(false);
+    instrlist_set_auto_predicate(ilist, instr_get_predicate(where));
 }
 
 /* insert inline code to add a memory reference info entry into the buffer */

--- a/api/samples/opcodes.c
+++ b/api/samples/opcodes.c
@@ -218,6 +218,7 @@ static dr_emit_flags_t
 event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
                       bool for_trace, bool translating, void *user_data)
 {
+    drmgr_disable_auto_predication(drcontext, bb);
     if (drmgr_is_first_instr(drcontext, instr)) {
         instr_t *ins;
         uint isa_idx = get_count_isa_idx(drcontext);

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -769,7 +769,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb,
 
     // XXX: Make use of auto predication feature instead of just disabling
     // globally.
-    instrlist_set_auto_predicate(bb, DR_PRED_NONE);
+    drmgr_disable_auto_predication(drcontext, bb);
 
     if (op_L0_filter.get_value() && ud->repstr &&
         drmgr_is_first_instr(drcontext, instr)) {

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -767,7 +767,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb,
     drvector_t rvec1, rvec2;
     bool is_memref;
 
-    // XXX: Make use of auto predication feature instead of just disabling
+    // XXX i#2584: Make use of auto predication feature instead of just disabling
     // globally.
     drmgr_disable_auto_predication(drcontext, bb);
 

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -767,6 +767,10 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb,
     drvector_t rvec1, rvec2;
     bool is_memref;
 
+    // XXX: Make use of auto predication feature instead of just disabling
+    // globally.
+    instrlist_set_auto_predicate(bb, DR_PRED_NONE);
+
     if (op_L0_filter.get_value() && ud->repstr &&
         drmgr_is_first_instr(drcontext, instr)) {
         // XXX: the control flow added for repstr ends up jumping over the

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -5053,8 +5053,22 @@ dr_insert_call(void *drcontext, instrlist_t *ilist, instr_t *where,
 {
     dcontext_t *dcontext = (dcontext_t *) drcontext;
     opnd_t *args = NULL;
+    instr_t *label = INSTR_CREATE_label(drcontext);
+    dr_pred_type_t auto_pred = instrlist_get_auto_predicate(ilist);
     va_list ap;
     CLIENT_ASSERT(drcontext != NULL, "dr_insert_call: drcontext cannot be NULL");
+    instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
+#ifdef ARM
+    if (auto_pred != DR_PRED_NONE && auto_pred != DR_PRED_AL) {
+        /* auto_predicate is set, though we handle the clean call with a cbr
+         * because we require inserting instrumentation which modifies cspr.
+         */
+        MINSERT(ilist, where, XINST_CREATE_jump_cond
+                (drcontext,
+                 instr_invert_predicate(auto_pred),
+                 opnd_create_instr(label)));
+    }
+#endif
     if (num_args != 0) {
         va_start(ap, num_args);
         convert_va_list_to_opnd(dcontext, &args, num_args, ap);
@@ -5064,6 +5078,8 @@ dr_insert_call(void *drcontext, instrlist_t *ilist, instr_t *where,
                            vmcode_get_start(), callee, num_args, args);
     if (num_args != 0)
         free_va_opnd_list(dcontext, num_args, args);
+    MINSERT(ilist, where, label);
+    instrlist_set_auto_predicate(ilist, auto_pred);
 }
 
 bool
@@ -5096,6 +5112,8 @@ dr_insert_call_noreturn(void *drcontext, instrlist_t *ilist, instr_t *where,
     opnd_t *args = NULL;
     va_list ap;
     CLIENT_ASSERT(drcontext != NULL, "dr_insert_call_noreturn: drcontext cannot be NULL");
+    CLIENT_ASSERT(instrlist_get_auto_predicate(ilist) == DR_PRED_NONE,
+                  "Does not support auto-predication");
     if (num_args != 0) {
         va_start(ap, num_args);
         convert_va_list_to_opnd(dcontext, &args, num_args, ap);

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -5061,7 +5061,7 @@ dr_insert_call(void *drcontext, instrlist_t *ilist, instr_t *where,
 #ifdef ARM
     if (auto_pred != DR_PRED_NONE && auto_pred != DR_PRED_AL) {
         /* auto_predicate is set, though we handle the clean call with a cbr
-         * because we require inserting instrumentation which modifies cspr.
+         * because we require inserting instrumentation which modifies cpsr.
          */
         MINSERT(ilist, where, XINST_CREATE_jump_cond
                 (drcontext,
@@ -5213,7 +5213,7 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
 #ifdef ARM
     if (auto_pred != DR_PRED_NONE && auto_pred != DR_PRED_AL) {
         /* auto_predicate is set, though we handle the clean call with a cbr
-         * because we require inserting instrumentation which modifies cspr.
+         * because we require inserting instrumentation which modifies cpsr.
          */
         MINSERT(ilist, where, XINST_CREATE_jump_cond
                 (drcontext,

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -654,7 +654,7 @@ drmgr_bb_event(void *drcontext, void *tag, instrlist_t *bb,
                 continue;
             /* Most client instrumentation wants to be predicated to match the app
              * instruction, so we do it by default (i#1723). Clients may opt-out
-             * by calling drmgr_disable_auto_predicate() at the start of the
+             * by calling drmgr_disable_auto_predication() at the start of the
              * insertion bb event.
              */
             instrlist_set_auto_predicate(bb, instr_get_predicate(inst));

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -652,6 +652,7 @@ drmgr_bb_event(void *drcontext, void *tag, instrlist_t *bb,
             e = &iter_insert.cbs.bb[i];
             if (!e->pri.valid)
                 continue;
+            instrlist_set_auto_predicate(bb, instr_get_predicate(inst));
             if (e->has_quartet) {
                 res |= (*e->cb.pair_ex.insertion_ex_cb)
                     (drcontext, tag, bb, inst, for_trace, translating,
@@ -665,13 +666,9 @@ drmgr_bb_event(void *drcontext, void *tag, instrlist_t *bb,
                 }
                 pair_idx++;
             }
+            instrlist_set_auto_predicate(bb, DR_PRED_NONE);
             /* XXX: add checks that cb followed the rules */
         }
-        /* XXX i#1723: in f28be26, we added auto-predication of instrumentation
-         * in Thumb IT blocks here, but it was asymmetric wrt ARM mode.
-         * instrlist_set_auto_predicate() has been written to address this, but
-         * has not been enabled yet by default.
-         */
     }
 
     /* Pass 4: final */

--- a/ext/drmgr/drmgr.dox
+++ b/ext/drmgr/drmgr.dox
@@ -136,6 +136,14 @@ added by callbacks during that stage.  Furthermore, \p drmgr automatically
 adds IT instructions after all stages are complete, to ensure that all
 condtional instructions are legal in Thumb mode.
 
+\subsection sec_drmgr_autopred Auto Predication
+
+Most client instrumentation wants to be predicated to match the app instruction,
+so we do it by default. Clients may opt-out by calling
+drmgr_disable_auto_predicate() at the start of the insertion bb event. Clients
+may also control auto predication with finer granularity by directly calling
+instrlist_set_auto_predicate() and instrlist_get_auto_predicate().
+
 \section sec_drmgr_tls Thread-Local and Callback-Local Storage
 
 \p drmgr also coordinates sharing of the thread-local-storage field among

--- a/ext/drmgr/drmgr.dox
+++ b/ext/drmgr/drmgr.dox
@@ -140,7 +140,7 @@ condtional instructions are legal in Thumb mode.
 
 Most client instrumentation wants to be predicated to match the app instruction,
 so we do it by default. Clients may opt-out by calling
-drmgr_disable_auto_predicate() at the start of the insertion bb event. Clients
+drmgr_disable_auto_predication() at the start of the insertion bb event. Clients
 may also control auto predication with finer granularity by directly calling
 instrlist_set_auto_predicate() and instrlist_get_auto_predicate().
 

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -1090,6 +1090,15 @@ bool
 drmgr_unregister_restore_state_ex_event(bool (*func)(void *drcontext, bool restore_memory,
                                                      dr_restore_state_info_t *info));
 
+DR_EXPORT
+/**
+ * Disables auto predication globally for this basic block.
+ * \return whether successful.
+ * \note Only to be used in the drmgr insertion event.
+ */
+bool
+drmgr_disable_auto_predication(void *drcontext, instrlist_t *ilist);
+
 /*@}*/ /* end doxygen group */
 
 #ifdef __cplusplus

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -395,7 +395,9 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
     instr_t *next = instr_get_next(inst);
     bool restored_for_read[DR_NUM_GPR_REGS];
     drreg_status_t res;
+    dr_pred_type_t pred = instrlist_get_auto_predicate(bb);
 
+    instrlist_set_auto_predicate(bb, DR_PRED_NONE);
     /* For unreserved regs still spilled, we lazily do the restore here.  We also
      * update reserved regs wrt app uses.
      */
@@ -601,7 +603,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
         }
     }
 #endif
-
+    instrlist_set_auto_predicate(bb, pred);
     return DR_EMIT_DEFAULT;
 }
 
@@ -823,26 +825,36 @@ drreg_status_t
 drreg_reserve_register(void *drcontext, instrlist_t *ilist, instr_t *where,
                        drvector_t *reg_allowed, OUT reg_id_t *reg_out)
 {
+    dr_pred_type_t pred = instrlist_get_auto_predicate(ilist);
+    drreg_status_t res;
     if (drmgr_current_bb_phase(drcontext) != DRMGR_PHASE_INSERTION) {
         drreg_status_t res = drreg_forward_analysis(drcontext, where);
         if (res != DRREG_SUCCESS)
             return res;
     }
-    return drreg_reserve_reg_internal(drcontext, ilist, where, reg_allowed,
-                                      false, reg_out);
+    instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
+    res = drreg_reserve_reg_internal(drcontext, ilist, where, reg_allowed,
+                                     false, reg_out);
+    instrlist_set_auto_predicate(ilist, pred);
+    return res;
 }
 
 drreg_status_t
 drreg_reserve_dead_register(void *drcontext, instrlist_t *ilist, instr_t *where,
                             drvector_t *reg_allowed, OUT reg_id_t *reg_out)
 {
+    dr_pred_type_t pred = instrlist_get_auto_predicate(ilist);
+    drreg_status_t res;
     if (drmgr_current_bb_phase(drcontext) != DRMGR_PHASE_INSERTION) {
         drreg_status_t res = drreg_forward_analysis(drcontext, where);
         if (res != DRREG_SUCCESS)
             return res;
     }
-    return drreg_reserve_reg_internal(drcontext, ilist, where, reg_allowed,
-                                      true, reg_out);
+    instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
+    res = drreg_reserve_reg_internal(drcontext, ilist, where, reg_allowed,
+                                     true, reg_out);
+    instrlist_set_auto_predicate(ilist, pred);
+    return res;
 }
 
 drreg_status_t
@@ -850,19 +862,28 @@ drreg_get_app_value(void *drcontext, instrlist_t *ilist, instr_t *where,
                     reg_id_t app_reg, reg_id_t dst_reg)
 {
     per_thread_t *pt = (per_thread_t *) drmgr_get_tls_field(drcontext, tls_idx);
+    dr_pred_type_t pred = instrlist_get_auto_predicate(ilist);
+
     if (!reg_is_pointer_sized(app_reg) || !reg_is_pointer_sized(dst_reg))
         return DRREG_ERROR_INVALID_PARAMETER;
+
+    instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
 
     /* check if app_reg is stolen reg */
     if (app_reg == dr_get_stolen_reg()) {
         /* DR will refuse to load into the same reg (the caller must use
          * opnd_replace_reg() with a scratch reg in that case).
          */
-        if (dst_reg == app_reg)
+        if (dst_reg == app_reg) {
+            instrlist_set_auto_predicate(ilist, pred);
             return DRREG_ERROR_INVALID_PARAMETER;
-        if (dr_insert_get_stolen_reg_value(drcontext, ilist, where, dst_reg))
+        }
+        if (dr_insert_get_stolen_reg_value(drcontext, ilist, where, dst_reg)) {
+            instrlist_set_auto_predicate(ilist, pred);
             return DRREG_SUCCESS;
+        }
         ASSERT(false, "internal error on getting stolen reg app value");
+        instrlist_set_auto_predicate(ilist, pred);
         return DRREG_ERROR;
     }
 
@@ -875,6 +896,7 @@ drreg_get_app_value(void *drcontext, instrlist_t *ilist, instr_t *where,
                                                 opnd_create_reg(dst_reg),
                                                 opnd_create_reg(app_reg)));
         }
+        instrlist_set_auto_predicate(ilist, pred);
         return DRREG_SUCCESS;
     }
 
@@ -882,11 +904,13 @@ drreg_get_app_value(void *drcontext, instrlist_t *ilist, instr_t *where,
     if (!pt->reg[GPR_IDX(app_reg)].ever_spilled) {
         LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": reg %s never spilled\n", __FUNCTION__,
             pt->live_idx, instr_get_app_pc(where), get_register_name(app_reg));
+        instrlist_set_auto_predicate(ilist, pred);
         return DRREG_ERROR_NO_APP_VALUE;
     }
     /* restore app value back to app_reg */
     if (pt->reg[GPR_IDX(app_reg)].xchg != DR_REG_NULL) {
         /* XXX i#511: NYI */
+        instrlist_set_auto_predicate(ilist, pred);
         return DRREG_ERROR_FEATURE_NOT_AVAILABLE;
     }
     LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": getting app value for %s\n",
@@ -898,6 +922,7 @@ drreg_get_app_value(void *drcontext, instrlist_t *ilist, instr_t *where,
         restore_reg(drcontext, pt, app_reg, pt->reg[GPR_IDX(app_reg)].slot,
                     ilist, where, false);
     }
+    instrlist_set_auto_predicate(ilist, pred);
     return DRREG_SUCCESS;
 }
 
@@ -908,7 +933,10 @@ drreg_restore_app_values(void *drcontext, instrlist_t *ilist, instr_t *where,
     drreg_status_t res;
     bool no_app_value = false;
     int num_op = opnd_num_regs_used(opnd);
+    dr_pred_type_t pred = instrlist_get_auto_predicate(ilist);
     int i;
+
+    instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
     for (i = 0; i < num_op; i++) {
         reg_id_t reg = opnd_get_reg_used(opnd, i);
         reg_id_t dst;
@@ -917,24 +945,33 @@ drreg_restore_app_values(void *drcontext, instrlist_t *ilist, instr_t *where,
         reg = reg_to_pointer_sized(reg);
         dst = reg;
         if (reg == dr_get_stolen_reg()) {
-            if (swap == NULL)
+            if (swap == NULL) {
+                instrlist_set_auto_predicate(ilist, pred);
                 return DRREG_ERROR_INVALID_PARAMETER;
+            }
             if (*swap == DR_REG_NULL) {
                 res = drreg_reserve_register(drcontext, ilist, where, NULL, &dst);
-                if (res != DRREG_SUCCESS)
+                if (res != DRREG_SUCCESS) {
+                    instrlist_set_auto_predicate(ilist, pred);
                     return res;
+                }
             } else
                 dst = *swap;
-            if (!opnd_replace_reg(&opnd, reg, dst))
+            if (!opnd_replace_reg(&opnd, reg, dst)) {
+                instrlist_set_auto_predicate(ilist, pred);
                 return DRREG_ERROR;
+            }
             *swap = dst;
         }
         res = drreg_get_app_value(drcontext, ilist, where, reg, dst);
         if (res == DRREG_ERROR_NO_APP_VALUE)
             no_app_value = true;
-        else if (res != DRREG_SUCCESS)
+        else if (res != DRREG_SUCCESS) {
+            instrlist_set_auto_predicate(ilist, pred);
             return res;
+        }
     }
+    instrlist_set_auto_predicate(ilist, pred);
     return (no_app_value ? DRREG_ERROR_NO_APP_VALUE : DRREG_SUCCESS);
 }
 
@@ -974,7 +1011,12 @@ drreg_unreserve_register(void *drcontext, instrlist_t *ilist, instr_t *where,
         /* We have no way to lazily restore.  We do not bother at this point
          * to try and eliminate back-to-back spill/restore pairs.
          */
-        drreg_status_t res = drreg_restore_reg_now(drcontext, ilist, where, pt, reg);
+        dr_pred_type_t pred = instrlist_get_auto_predicate(ilist);
+        drreg_status_t res;
+
+        instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
+        res = drreg_restore_reg_now(drcontext, ilist, where, pt, reg);
+        instrlist_set_auto_predicate(ilist, pred);
         if (res != DRREG_SUCCESS)
             return res;
     } else {
@@ -1237,6 +1279,7 @@ drreg_status_t
 drreg_reserve_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
 {
     per_thread_t *pt = (per_thread_t *) drmgr_get_tls_field(drcontext, tls_idx);
+    dr_pred_type_t pred = instrlist_get_auto_predicate(ilist);
     drreg_status_t res;
     uint aflags;
     if (drmgr_current_bb_phase(drcontext) != DRMGR_PHASE_INSERTION) {
@@ -1278,7 +1321,9 @@ drreg_reserve_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
      * xchg-null but xax-in-use won't happen b/c we'll use un-restored above.
      */
     pt->aflags.xchg = DR_REG_NULL;
+    instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
     res = drreg_spill_aflags(drcontext, ilist, where, pt);
+    instrlist_set_auto_predicate(ilist, pred);
     if (res != DRREG_SUCCESS)
         return res;
     pt->aflags.in_use = true;
@@ -1295,15 +1340,18 @@ drreg_unreserve_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
         return DRREG_ERROR_INVALID_PARAMETER;
     pt->aflags.in_use = false;
     if (drmgr_current_bb_phase(drcontext) != DRMGR_PHASE_INSERTION) {
+        dr_pred_type_t pred = instrlist_get_auto_predicate(ilist);
         /* We have no way to lazily restore.  We do not bother at this point
          * to try and eliminate back-to-back spill/restore pairs.
          */
+        instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
         if (pt->aflags.xchg != DR_REG_NULL)
             drreg_move_aflags_from_reg(drcontext, ilist, where, pt);
         else if (!pt->aflags.native) {
             drreg_restore_aflags(drcontext, ilist, where, pt, true/*release*/);
             pt->aflags.native = true;
         }
+        instrlist_set_auto_predicate(ilist, pred);
         pt->slot_use[AFLAGS_SLOT] = DR_REG_NULL;
     }
     LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX"\n", __FUNCTION__,
@@ -1349,9 +1397,12 @@ drreg_restore_app_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
     per_thread_t *pt = (per_thread_t *) drmgr_get_tls_field(drcontext, tls_idx);
     drreg_status_t res = DRREG_SUCCESS;
     if (!pt->aflags.native) {
+        dr_pred_type_t pred = instrlist_get_auto_predicate(ilist);
         LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": restoring app aflags as requested\n",
             __FUNCTION__, pt->live_idx, instr_get_app_pc(where));
+        instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
         res = drreg_restore_aflags(drcontext, ilist, where, pt, false/*keep slot*/);
+        instrlist_set_auto_predicate(ilist, pred);
     }
     return res;
 }

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -397,6 +397,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
     drreg_status_t res;
     dr_pred_type_t pred = instrlist_get_auto_predicate(bb);
 
+    /* XXX i#2585: drreg should predicate spills and restores as appropriate */
     instrlist_set_auto_predicate(bb, DR_PRED_NONE);
     /* For unreserved regs still spilled, we lazily do the restore here.  We also
      * update reserved regs wrt app uses.
@@ -832,6 +833,7 @@ drreg_reserve_register(void *drcontext, instrlist_t *ilist, instr_t *where,
         if (res != DRREG_SUCCESS)
             return res;
     }
+    /* XXX i#2585: drreg should predicate spills and restores as appropriate */
     instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
     res = drreg_reserve_reg_internal(drcontext, ilist, where, reg_allowed,
                                      false, reg_out);
@@ -850,6 +852,7 @@ drreg_reserve_dead_register(void *drcontext, instrlist_t *ilist, instr_t *where,
         if (res != DRREG_SUCCESS)
             return res;
     }
+    /* XXX i#2585: drreg should predicate spills and restores as appropriate */
     instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
     res = drreg_reserve_reg_internal(drcontext, ilist, where, reg_allowed,
                                      true, reg_out);
@@ -867,6 +870,7 @@ drreg_get_app_value(void *drcontext, instrlist_t *ilist, instr_t *where,
     if (!reg_is_pointer_sized(app_reg) || !reg_is_pointer_sized(dst_reg))
         return DRREG_ERROR_INVALID_PARAMETER;
 
+    /* XXX i#2585: drreg should predicate spills and restores as appropriate */
     instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
 
     /* check if app_reg is stolen reg */
@@ -936,6 +940,7 @@ drreg_restore_app_values(void *drcontext, instrlist_t *ilist, instr_t *where,
     dr_pred_type_t pred = instrlist_get_auto_predicate(ilist);
     int i;
 
+    /* XXX i#2585: drreg should predicate spills and restores as appropriate */
     instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
     for (i = 0; i < num_op; i++) {
         reg_id_t reg = opnd_get_reg_used(opnd, i);
@@ -1014,6 +1019,7 @@ drreg_unreserve_register(void *drcontext, instrlist_t *ilist, instr_t *where,
         dr_pred_type_t pred = instrlist_get_auto_predicate(ilist);
         drreg_status_t res;
 
+        /* XXX i#2585: drreg should predicate spills and restores as appropriate */
         instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
         res = drreg_restore_reg_now(drcontext, ilist, where, pt, reg);
         instrlist_set_auto_predicate(ilist, pred);
@@ -1321,6 +1327,7 @@ drreg_reserve_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
      * xchg-null but xax-in-use won't happen b/c we'll use un-restored above.
      */
     pt->aflags.xchg = DR_REG_NULL;
+    /* XXX i#2585: drreg should predicate spills and restores as appropriate */
     instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
     res = drreg_spill_aflags(drcontext, ilist, where, pt);
     instrlist_set_auto_predicate(ilist, pred);
@@ -1344,6 +1351,7 @@ drreg_unreserve_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
         /* We have no way to lazily restore.  We do not bother at this point
          * to try and eliminate back-to-back spill/restore pairs.
          */
+        /* XXX i#2585: drreg should predicate spills and restores as appropriate */
         instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
         if (pt->aflags.xchg != DR_REG_NULL)
             drreg_move_aflags_from_reg(drcontext, ilist, where, pt);
@@ -1400,6 +1408,7 @@ drreg_restore_app_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
         dr_pred_type_t pred = instrlist_get_auto_predicate(ilist);
         LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": restoring app aflags as requested\n",
             __FUNCTION__, pt->live_idx, instr_get_app_pc(where));
+        /* XXX i#2585: drreg should predicate spills and restores as appropriate */
         instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
         res = drreg_restore_aflags(drcontext, ilist, where, pt, false/*keep slot*/);
         instrlist_set_auto_predicate(ilist, pred);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2019,6 +2019,15 @@ if (CLIENT_INTERFACE)
   target_include_directories(client.drx_buf-test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/client-interface)
 
+  if (ARM)
+    tobuild_ci(client.predicate-test client-interface/predicate-test.c "" "" "")
+    use_DynamoRIO_extension(client.predicate-test.dll drmgr)
+    use_DynamoRIO_extension(client.predicate-test.dll drutil)
+    use_DynamoRIO_extension(client.predicate-test.dll drreg)
+    target_include_directories(client.predicate-test PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/client-interface)
+  endif (ARM)
+
   tobuild_ci(client.drreg-test client-interface/drreg-test.c "" "" "")
   use_DynamoRIO_extension(client.drreg-test.dll drmgr)
   use_DynamoRIO_extension(client.drreg-test.dll drreg)

--- a/suite/tests/client-interface/drx-test.dll.c
+++ b/suite/tests/client-interface/drx-test.dll.c
@@ -49,15 +49,19 @@ static client_id_t client_id;
 
 static uint counterA;
 static uint counterB;
+#if defined(ARM)
 static uint counterC;
 static uint counterD;
+#endif
 
 static void
 event_exit(void)
 {
     drx_exit();
     CHECK(counterB == 2*counterA, "counter inc messed up");
+#if defined(ARM)
     CHECK(counterD == 2*counterA, "counter inc messed up");
+#endif
     dr_fprintf(STDERR, "event_exit\n");
 }
 
@@ -99,6 +103,7 @@ event_basic_block(void *drcontext, void *tag, instrlist_t *bb,
                               SPILL_SLOT_1, IF_NOT_X86_(SPILL_SLOT_2)
                               &counterB, 2, IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
     instrlist_meta_preinsert(bb, first, INSTR_CREATE_label(drcontext));
+#if defined(ARM)
     /* Exercise drx's optimization bail-out in the presence of predication */
     /* XXX: For a more thorough test, we should save/restore aflags, and set
      * flags so that next counter update never occurs.
@@ -112,6 +117,7 @@ event_basic_block(void *drcontext, void *tag, instrlist_t *bb,
     drx_insert_counter_update(drcontext, bb, first,
                               SPILL_SLOT_1, IF_NOT_X86_(SPILL_SLOT_2)
                               &counterD, 2, IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
+#endif
     /* Exercise drx's basic block termination with a zero-cost label */
     drx_tail_pad_block(drcontext, bb);
     last = instrlist_last(bb);

--- a/suite/tests/client-interface/drx-test.dll.c
+++ b/suite/tests/client-interface/drx-test.dll.c
@@ -49,12 +49,15 @@ static client_id_t client_id;
 
 static uint counterA;
 static uint counterB;
+static uint counterC;
+static uint counterD;
 
 static void
 event_exit(void)
 {
     drx_exit();
     CHECK(counterB == 2*counterA, "counter inc messed up");
+    CHECK(counterD == 2*counterA, "counter inc messed up");
     dr_fprintf(STDERR, "event_exit\n");
 }
 
@@ -95,6 +98,20 @@ event_basic_block(void *drcontext, void *tag, instrlist_t *bb,
     drx_insert_counter_update(drcontext, bb, first,
                               SPILL_SLOT_1, IF_NOT_X86_(SPILL_SLOT_2)
                               &counterB, 2, IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
+    instrlist_meta_preinsert(bb, first, INSTR_CREATE_label(drcontext));
+    /* Exercise drx's optimization bail-out in the presence of predication */
+    /* XXX: For a more thorough test, we should save/restore aflags, and set
+     * flags so that next counter update never occurs.
+     */
+    instrlist_set_auto_predicate(bb, DR_PRED_LS);
+    drx_insert_counter_update(drcontext, bb, first,
+                              SPILL_SLOT_1, IF_NOT_X86_(SPILL_SLOT_2)
+                              &counterC, 1,
+                              IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
+    instrlist_set_auto_predicate(bb, DR_PRED_NONE);
+    drx_insert_counter_update(drcontext, bb, first,
+                              SPILL_SLOT_1, IF_NOT_X86_(SPILL_SLOT_2)
+                              &counterD, 2, IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
     /* Exercise drx's basic block termination with a zero-cost label */
     drx_tail_pad_block(drcontext, bb);
     last = instrlist_last(bb);

--- a/suite/tests/client-interface/predicate-test.c
+++ b/suite/tests/client-interface/predicate-test.c
@@ -1,0 +1,68 @@
+/* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef ASM_CODE_ONLY /* C code */
+#include "tools.h"
+
+/* asm routines */
+void test_asm();
+
+int
+main(int argc, const char *argv[])
+{
+    print("predicate-test running\n");
+    test_asm();
+    print("predicate-test finished\n");
+    return 0;
+}
+
+#else /* asm code *************************************************************/
+#include "asm_defines.asm"
+START_FILE
+
+#define FUNCNAME test_asm
+        DECLARE_FUNC_SEH(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        b        test1
+        /* Test 1: test predicate which does not occur at runtime */
+     test1:
+        movw     r4, #0
+        cmp      r4, #1
+        ldreq    r4, PTRSZ [r4] /* no crash */
+        b        epilog
+    epilog:
+        bx       lr
+        END_FUNC(FUNCNAME)
+#undef FUNCNAME
+
+END_FILE
+#endif

--- a/suite/tests/client-interface/predicate-test.dll.c
+++ b/suite/tests/client-interface/predicate-test.dll.c
@@ -1,0 +1,125 @@
+/* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Tests the auto-predicate functionality built into drmgr */
+
+#include "dr_api.h"
+#include "drmgr.h"
+#include "client_tools.h"
+#include "drutil.h"
+#include "drreg.h"
+#include <string.h> /* memset */
+
+#define CHECK(x, msg) do {               \
+    if (!(x)) {                          \
+        dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
+        dr_abort();                      \
+    }                                    \
+} while (0);
+
+static app_pc app;
+
+static void
+dereference_app(app_pc app_addr)
+{
+    /* store to a global so the load hopefully does not get optimized away */
+    app = *(app_pc *)app_addr;
+}
+
+static void
+instrument_mem(void *drcontext, instrlist_t *bb, instr_t *inst,
+               opnd_t ref)
+{
+    reg_id_t reg_ptr, reg_tmp;
+    bool ok;
+
+    if (drreg_reserve_register(drcontext, bb, inst, NULL, &reg_ptr) !=
+        DRREG_SUCCESS ||
+        drreg_reserve_register(drcontext, bb, inst, NULL, &reg_tmp) !=
+        DRREG_SUCCESS) {
+        CHECK(false, "drreg_reserve_register() failed");
+    }
+    ok = drutil_insert_get_mem_addr(drcontext, bb, inst, ref,
+                                    reg_ptr, reg_tmp);
+    CHECK(ok, "drutil_insert_get_mem_addr() failed");
+    dr_insert_clean_call(drcontext, bb, inst, (void *)dereference_app,
+                         false, 1, opnd_create_reg(reg_ptr));
+
+    if (drreg_unreserve_register(drcontext, bb, inst, reg_ptr) != DRREG_SUCCESS ||
+        drreg_unreserve_register(drcontext, bb, inst, reg_tmp) != DRREG_SUCCESS)
+        CHECK(false, "drreg_unreserve_register() failed");
+}
+
+static dr_emit_flags_t
+event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
+                      bool for_trace, bool translating, void *user_data)
+{
+    int i;
+
+    if (!instr_reads_memory(inst))
+        return DR_EMIT_DEFAULT;
+    /* Reading an app value should never crash if the underlying app doesn't
+     * crash; we can ensure this because even if the app instruction is
+     * predicated, if the load does not occur neither does the clean call
+     * due to drmgr's auto-predication guarantees.
+     */
+    for (i = 0; i < instr_num_srcs(inst); i++) {
+        if (opnd_is_memory_reference(instr_get_src(inst, i)))
+            instrument_mem(drcontext, bb, inst, instr_get_src(inst, i));
+    }
+    return DR_EMIT_DEFAULT;
+}
+
+static void
+event_exit(void)
+{
+    if (!drmgr_unregister_bb_insertion_event(event_app_instruction) ||
+        drreg_exit() != DRREG_SUCCESS)
+        CHECK(false, "exit failed");
+    drutil_exit();
+    drmgr_exit();
+}
+
+DR_EXPORT
+void
+dr_init(client_id_t id)
+{
+    drreg_options_t ops = {sizeof(ops), 2 /*max slots needed*/, false};
+    if (!drmgr_init() ||
+        drreg_init(&ops) != DRREG_SUCCESS ||
+        !drutil_init())
+        CHECK(false, "init failed");
+
+    dr_register_exit_event(event_exit);
+    if (!drmgr_register_bb_instrumentation_event(NULL, event_app_instruction, NULL))
+        CHECK(false, "init failed");
+}

--- a/suite/tests/client-interface/predicate-test.dll.c
+++ b/suite/tests/client-interface/predicate-test.dll.c
@@ -46,6 +46,8 @@
     }                                    \
 } while (0);
 
+#define MINSERT instrlist_meta_preinsert
+
 static app_pc app;
 
 static void
@@ -71,8 +73,14 @@ instrument_mem(void *drcontext, instrlist_t *bb, instr_t *inst,
     ok = drutil_insert_get_mem_addr(drcontext, bb, inst, ref,
                                     reg_ptr, reg_tmp);
     CHECK(ok, "drutil_insert_get_mem_addr() failed");
+    /* test that a clean call is predicated correctly */
     dr_insert_clean_call(drcontext, bb, inst, (void *)dereference_app,
                          false, 1, opnd_create_reg(reg_ptr));
+    /* test that regular meta-instrumentation is predicated correctly */
+    MINSERT(bb, inst, XINST_CREATE_load_1byte
+            (drcontext,
+             opnd_create_reg(reg_tmp),
+             OPND_CREATE_MEM8(reg_ptr, 0)));
 
     if (drreg_unreserve_register(drcontext, bb, inst, reg_ptr) != DRREG_SUCCESS ||
         drreg_unreserve_register(drcontext, bb, inst, reg_tmp) != DRREG_SUCCESS)

--- a/suite/tests/client-interface/predicate-test.dll.c
+++ b/suite/tests/client-interface/predicate-test.dll.c
@@ -73,10 +73,14 @@ instrument_mem(void *drcontext, instrlist_t *bb, instr_t *inst,
     ok = drutil_insert_get_mem_addr(drcontext, bb, inst, ref,
                                     reg_ptr, reg_tmp);
     CHECK(ok, "drutil_insert_get_mem_addr() failed");
-    /* test that a clean call is predicated correctly */
+    /* Test that a clean call is predicated correctly; if this clean call
+     * is not predicated correctly then DR will crash.
+     */
     dr_insert_clean_call(drcontext, bb, inst, (void *)dereference_app,
                          false, 1, opnd_create_reg(reg_ptr));
-    /* test that regular meta-instrumentation is predicated correctly */
+    /* Test that regular meta-instrumentation is predicated correctly; if
+     * this load is not predicated correctly then DR will crash.
+     */
     MINSERT(bb, inst, XINST_CREATE_load_1byte
             (drcontext,
              opnd_create_reg(reg_tmp),

--- a/suite/tests/client-interface/predicate-test.expect
+++ b/suite/tests/client-interface/predicate-test.expect
@@ -1,0 +1,2 @@
+predicate-test running
+predicate-test finished


### PR DESCRIPTION
Enables global auto-predication as part of drmgr's insertion event. Also
modifies instrace and memtrace samples to do the right thing with
respect to predication during memref tracing vs instruction tracing.

drreg does not interact well with other drmgr passes, as well as main
client passes when auto-predication is enabled. We disable
auto-predication for all drreg passes.

drmemtrace is non-trivial to add auto-predication to. We globally
disable auto-predication for drmemtrace.

Fixes #1723