### PR TITLE
i#2144: better patch for single step with sandboxing

### DIFF
--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1020,7 +1020,7 @@ mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags INOUT,
                  dcontext->single_step_addr == instr->translation) {
             instr_t * last_addr = instr_get_next_app(instr);
             /* Checks if sandboxing added another app instruction. */
-            if (!last_addr || last_addr->translation != instr->translation) {
+            if (last_addr == NULL || last_addr->translation != instr->translation) {
                 mangle_single_step(dcontext, ilist, *flags, instr);
                 /* Resets to generate single step exception only once. */
                 dcontext->single_step_addr = NULL;

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1016,11 +1016,15 @@ mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags INOUT,
             mangle_possible_single_step(dcontext, ilist, instr);
             continue;
         }
-        else if (dcontext->single_step_addr != NULL &&
+        else if (dcontext->single_step_addr != NULL && instr_is_app(instr) &&
                  dcontext->single_step_addr == instr->translation) {
-            mangle_single_step(dcontext, ilist, *flags, instr);
-            /* Resets to generate single step exception only once. */
-            dcontext->single_step_addr = NULL;
+            instr_t * last_addr = instr_get_next_app(instr);
+            /* Checks if sandboxing added another app instruction. */
+            if (!last_addr || last_addr->translation != instr->translation) {
+                mangle_single_step(dcontext, ilist, *flags, instr);
+                /* Resets to generate single step exception only once. */
+                dcontext->single_step_addr = NULL;
+            }
         }
 #endif
 #ifdef FOOL_CPUID

--- a/suite/tests/security-win32/singlestep.c
+++ b/suite/tests/security-win32/singlestep.c
@@ -78,12 +78,18 @@ main(void)
 START_FILE
 
 /* int foo()
- *   Generates a single step execution on jump and should return 1.
+ *   Generates a single step execution on jump and should return 2.
  */
 #define FUNCNAME foo
 DECLARE_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
-        xor      eax, eax
+/* sets sandoxing mode in dynamorio by doing a self modification. */
+        mov      REG_XAX, HEX(1)
+        lea      REG_XDX, SYMREF(sandbox_immediate_addr_plus_four - 4)
+        mov      DWORD [REG_XDX], eax        /* selfmod write */
+        mov      REG_XDX, HEX(0)             /* mov_imm to modify */
+ADDRTAKEN_LABEL(sandbox_immediate_addr_plus_four:)
+        mov      REG_XAX, REG_XDX
 /* push flags on the stack */
         PUSHF
 /* setting the trap flag to 1 on top of the stack */

--- a/suite/tests/security-win32/singlestep.c
+++ b/suite/tests/security-win32/singlestep.c
@@ -67,6 +67,7 @@ main(void)
     SetUnhandledExceptionFilter((LPTOP_LEVEL_EXCEPTION_FILTER) our_top_handler);
 
     print("start of test, count = %d\n", count);
+    protect_mem(foo, 1024, ALLOW_READ|ALLOW_WRITE|ALLOW_EXEC);
     count+=foo();
     print("end of test, count = %d\n", count);
 

--- a/suite/tests/security-win32/singlestep.expect
+++ b/suite/tests/security-win32/singlestep.expect
@@ -1,3 +1,3 @@
 start of test, count = 0
 single step exception
-end of test, count = 2
+end of test, count = 3


### PR DESCRIPTION
Last patch worked fine for single step execution in normal mode.
But it does not work when dynamorio uses at the same time sandboxing.
Because sandboxing and single step both use special exit, there was a confusion.

When a basic block is built, sandboxing is inserted before mangling, which is used to modify special exit reason. 
But, sandboxing adds another cti (not a meta app) in case there was a self-modification in the basic block.

So, this patch checks that only the last app instruction at single step address will be mangled