### PR TITLE
i#2145 appveyor failures: add two tests to the ignore list

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -119,10 +119,12 @@ for (my $i = 0; $i < $#lines; ++$i) {
             %ignore_failures_32 = ('code_api|security-common.retnonexisting' => 1,
                                    'code_api|win32.reload-newaddr' => 1,
                                    'code_api|client.pcache-use' => 1,
+                                   'code_api|api.detach' => 1, # i#2246
                                    'code_api|client.nudge_ex' => 1);
             %ignore_failures_64 = ('code_api|common.floatpc_xl8all' => 1,
                                    'code_api|win32.reload-newaddr' => 1,
                                    'code_api|client.loader' => 1,
+                                   'code_api|client.drmgr-test' => 1, # i#1369
                                    'code_api|client.nudge_ex' => 1,
                                    'code_api|api.static_noclient' => 1,
                                    'code_api|api.static_noinit' => 1);


### PR DESCRIPTION
Unfortunately two failures are happening often enough that I'm adding them
to the #2145 list here: 32-bit api.detach #2246 and 64-bit drmgr-test #1369.