### PR TITLE
i#2575 shrink thread mem: reduce vmm block size to 4KB on UNIX

### DIFF
--- a/core/heap.c
+++ b/core/heap.c
@@ -673,7 +673,7 @@ vmm_dump_map(vm_heap_t *vmh)
 
     LOG(GLOBAL, LOG_HEAP, 3, "vmm_dump_map("PFX")\n", vmh);
     /* raw dump first - if you really want binary dump use windbg's dyd */
-    DOLOG(3, LOG_HEAP, {
+    DOLOG(4, LOG_HEAP, {
         dump_buffer_as_bytes(GLOBAL, b,
                              BITMAP_INDEX(bitmap_size)*sizeof(bitmap_element_t),
                              DUMP_RAW|DUMP_ADDRESS);

--- a/core/heap.h
+++ b/core/heap.h
@@ -265,7 +265,7 @@ void global_unprotected_heap_free(void *p, size_t size HEAPACCT(which_heap_t whi
 #define NONPERSISTENT_HEAP_TYPE_FREE(dc, p, type, which) \
     NONPERSISTENT_HEAP_ARRAY_FREE(dc, p, type, 1, which)
 
-#define MIN_VMM_BLOCK_SIZE (16 * 1024)
+#define MIN_VMM_BLOCK_SIZE IF_WINDOWS_ELSE(16*1024, 4*1024)
 
 /* special heap of same-sized blocks that avoids global locks */
 void *special_heap_init(uint block_size, bool use_lock, bool executable,

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1129,20 +1129,20 @@
 
     /* Virtual memory manager.
      * Our current default allocation unit matches the allocation granularity on
-     * windows, to avoid worrying about external fragmentation
+     * Windows, to avoid worrying about external fragmentation.
      * Since most of our allocations fall within this range this makes the
      * common operation be finding a single empty block.
      *
      * On Linux we save a lot of wasted alignment space by using a smaller
-     * granularity (PR 415959).
+     * granularity (PR 415959, i#2575).
      *
-     * FIXME: for Windows, if we reserve the whole region up front and
+     * XXX: for Windows, if we reserve the whole region up front and
      * just commit pieces, why do we need to match the Windows kernel
-     * alloc granularity?
+     * alloc granularity while within the region?
      *
      * vmm_block_size may be adjusted by adjust_defaults_for_page_size().
      */
-    OPTION_DEFAULT(uint_size, vmm_block_size, (IF_WINDOWS_ELSE(64,16)*1024),
+    OPTION_DEFAULT(uint_size, vmm_block_size, (IF_WINDOWS_ELSE(64,4)*1024),
                    "allocation unit for virtual memory manager")
     /* initial_heap_unit_size may be adjusted by adjust_defaults_for_page_size(). */
     OPTION_DEFAULT(uint_size, initial_heap_unit_size, 32*1024, "initial private heap unit size")


### PR DESCRIPTION
Reduces the compile-time minimum VMM block size as well as the default
-vmm_block_size from 16KB to 4KB on UNIX to avoid wasted space from
non-16KB-aligned allocation sizes.  The savings are non-trivial for
applications with many threads where we have multiple per-thread small
allocations (such as the TLS mmaps) and will make further memory reductions
via changing unit size parameters more fruitful by allowing a wider range
of sizes without overhead.  The downside is more memory and overhead on
memory management but the tradeoff is worthwhile.  This is much simpler
than trying to share VMM block allocations among separate uses like we do
on Windows for the stack and gencode.