### PR TITLE
i#2575 shrink thread mem: reduce private heap size

### DIFF
--- a/core/heap.c
+++ b/core/heap.c
@@ -272,7 +272,7 @@ typedef struct _thread_units_t {
  * of clean calls out of the cache that might allocate IR memory (which does not
  * use nonpersistent heap).  Any client actions that involve fragments or linking
  * should require couldbelinking status, which makes them safe wrt unlink flushing.
- * Xref i#1791.
+ * Xref DrMi#1791.
  */
 #define SEPARATE_NONPERSISTENT_HEAP() \
     (DYNAMO_OPTION(enable_reset) IF_CLIENT_INTERFACE(|| true))
@@ -3172,10 +3172,10 @@ threadunits_exit(thread_units_t *tu, dcontext_t *dcontext)
             LOG(THREAD,
                 LOG_HEAP|LOG_STATS, 1,
                 "Heap unit %d @"PFX"-"PFX" [-"PFX"] ("SZFMT" [/"SZFMT"] KB): used "
-                SZFMT" KB\n",
+                SZFMT" bytes\n",
                 u->id, u, UNIT_COMMIT_END(u),
                 UNIT_RESERVED_END(u), (UNIT_COMMIT_SIZE(u))/1024,
-                (UNIT_RESERVED_SIZE(u))/1024, num_used/1024);
+                (UNIT_RESERVED_SIZE(u))/1024, num_used);
         });
         next_u = u->next_local;
         heap_free_unit(u, dcontext);

--- a/core/heap.c
+++ b/core/heap.c
@@ -3233,7 +3233,8 @@ heap_thread_reset_init(dcontext_t *dcontext)
     thread_heap_t *th = (thread_heap_t *) dcontext->heap_field;
     if (SEPARATE_NONPERSISTENT_HEAP()) {
         ASSERT(th->nonpersistent_heap != NULL);
-        threadunits_init(dcontext, th->nonpersistent_heap, HEAP_UNIT_MIN_SIZE);
+        threadunits_init(dcontext, th->nonpersistent_heap,
+                         DYNAMO_OPTION(initial_heap_nonpers_size));
     }
 }
 

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -393,13 +393,8 @@ monitor_thread_exit(dcontext_t *dcontext)
         heap_free(dcontext, md->blk_info, md->blk_info_length*sizeof(trace_bb_build_t)
                   HEAPACCT(ACCT_TRACE));
     }
-
-    /* case 7966: don't initialize at all for hotp_only
-     * FIXME: could set initial sizes to 0 for all configurations, instead
-     */
-    if (!RUNNING_WITHOUT_CODE_CACHE() && !DYNAMO_OPTION(disable_traces)) {
+    if (md->thead_table != NULL)
         generic_hash_destroy(dcontext, md->thead_table);
-    }
     heap_free(dcontext, md, sizeof(monitor_data_t) HEAPACCT(ACCT_TRACE));
 #endif
 }
@@ -432,8 +427,10 @@ void
 thcounter_range_remove(dcontext_t *dcontext, app_pc start, app_pc end)
 {
     monitor_data_t *md = (monitor_data_t *) dcontext->monitor_field;
-    generic_hash_range_remove(dcontext, md->thead_table,
-                              (ptr_uint_t) start, (ptr_uint_t) end);
+    if (md->thead_table != NULL) {
+        generic_hash_range_remove(dcontext, md->thead_table,
+                                  (ptr_uint_t) start, (ptr_uint_t) end);
+    }
 }
 
 bool

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -360,7 +360,7 @@ monitor_thread_init(dcontext_t *dcontext)
      * FIXME: we can optimize even more to not allocate md at all, but would need
      * to have hotp_only checks in monitor_cache_exit(), etc.
      */
-    if (RUNNING_WITHOUT_CODE_CACHE())
+    if (RUNNING_WITHOUT_CODE_CACHE() || DYNAMO_OPTION(disable_traces))
         return;
 
     md->thead_table = generic_hash_create(dcontext, INIT_COUNTER_TABLE_SIZE,
@@ -397,10 +397,10 @@ monitor_thread_exit(dcontext_t *dcontext)
     /* case 7966: don't initialize at all for hotp_only
      * FIXME: could set initial sizes to 0 for all configurations, instead
      */
-    if (!RUNNING_WITHOUT_CODE_CACHE()) {
+    if (!RUNNING_WITHOUT_CODE_CACHE() && !DYNAMO_OPTION(disable_traces)) {
         generic_hash_destroy(dcontext, md->thead_table);
-        heap_free(dcontext, md, sizeof(monitor_data_t) HEAPACCT(ACCT_TRACE));
     }
+    heap_free(dcontext, md, sizeof(monitor_data_t) HEAPACCT(ACCT_TRACE));
 #endif
 }
 

--- a/core/options.c
+++ b/core/options.c
@@ -220,6 +220,9 @@ adjust_defaults_for_page_size(options_t *options)
     options->initial_heap_unit_size =
         MAX(ALIGN_FORWARD(options->initial_heap_unit_size, page_size),
             3 * page_size);
+    options->initial_heap_nonpers_size =
+        MAX(ALIGN_FORWARD(options->initial_heap_nonpers_size, page_size),
+            3 * page_size);
     options->initial_global_heap_unit_size =
         MAX(ALIGN_FORWARD(options->initial_global_heap_unit_size, page_size),
             3 * page_size);

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1145,11 +1145,14 @@
     OPTION_DEFAULT(uint_size, vmm_block_size, (IF_WINDOWS_ELSE(64,4)*1024),
                    "allocation unit for virtual memory manager")
     /* initial_heap_unit_size may be adjusted by adjust_defaults_for_page_size(). */
-    /* We avoid wasted space for every thread on UNIX for the
-     * non-persistent heap which often stays under 12K (i#2575).
-     */
-    OPTION_DEFAULT(uint_size, initial_heap_unit_size, IF_WINDOWS_ELSE(32,12)*1024,
+    OPTION_DEFAULT(uint_size, initial_heap_unit_size, 32*1024,
                    "initial private heap unit size")
+    /* We avoid wasted space for every thread on UNIX for the
+     * non-persistent heap which often stays under 12K (i#2575) (+8K for guards).
+     */
+    /* initial_heap_nonpers_size may be adjusted by adjust_defaults_for_page_size(). */
+    OPTION_DEFAULT(uint_size, initial_heap_nonpers_size, IF_WINDOWS_ELSE(32,20)*1024,
+                   "initial private non-persistent heap unit size")
     /* initial_global_heap_unit_size may be adjusted by adjust_defaults_for_page_size(). */
     OPTION_DEFAULT(uint_size, initial_global_heap_unit_size, 32*1024, "initial global heap unit size")
     /* if this is too small then once past the vm reservation we have too many

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1145,7 +1145,11 @@
     OPTION_DEFAULT(uint_size, vmm_block_size, (IF_WINDOWS_ELSE(64,4)*1024),
                    "allocation unit for virtual memory manager")
     /* initial_heap_unit_size may be adjusted by adjust_defaults_for_page_size(). */
-    OPTION_DEFAULT(uint_size, initial_heap_unit_size, 32*1024, "initial private heap unit size")
+    /* We avoid wasted space for every thread on UNIX for the
+     * non-persistent heap which often stays under 12K (i#2575).
+     */
+    OPTION_DEFAULT(uint_size, initial_heap_unit_size, IF_WINDOWS_ELSE(32,12)*1024,
+                   "initial private heap unit size")
     /* initial_global_heap_unit_size may be adjusted by adjust_defaults_for_page_size(). */
     OPTION_DEFAULT(uint_size, initial_global_heap_unit_size, 32*1024, "initial global heap unit size")
     /* if this is too small then once past the vm reservation we have too many


### PR DESCRIPTION
Eliminates the allocation of per-thread trace head hashtables when traces
are disabled.

Reduces -initial_heap_unit_size on UNIX to 12K, as the per-thread
non-persistent heap typically stays under 12K and there's no reason to
allocate 32K for every thread there.