### PR TITLE
i#2575 shrink thread mem: shrink and parameterize pending signals

### DIFF
--- a/core/heap.h
+++ b/core/heap.h
@@ -271,7 +271,8 @@ void global_unprotected_heap_free(void *p, size_t size HEAPACCT(which_heap_t whi
 void *special_heap_init(uint block_size, bool use_lock, bool executable,
                         bool persistent);
 void *special_heap_init_aligned(uint block_size, uint alignment, bool use_lock,
-                                bool executable, bool persistent);
+                                bool executable, bool persistent,
+                                size_t initial_unit_size);
 void special_heap_exit(void *special);
 void *special_heap_alloc(void *special);
 void *special_heap_calloc(void *special, uint num);

--- a/core/options.c
+++ b/core/options.c
@@ -1716,6 +1716,13 @@ check_option_compatibility_helper(int recurse_count)
     }
 # endif
 #endif /* CLIENT_INTERFACE */
+#ifdef UNIX
+    if (DYNAMO_OPTION(max_pending_signals) < 1) {
+        USAGE_ERROR("-max_pending_signals must be at least 1");
+        dynamo_options.max_pending_signals = 1;
+        changed_options = true;
+    }
+#endif
 #ifdef CALL_PROFILE
     if (DYNAMO_OPTION(prof_caller) >  MAX_CALL_PROFILE_DEPTH) {
         USAGE_ERROR("-prof_caller must be <= %d",  MAX_CALL_PROFILE_DEPTH);

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -649,6 +649,8 @@
 
     /* PR 304708: we intercept all signals for a better client interface */
     OPTION_DEFAULT(bool, intercept_all_signals, true, "intercept all signals")
+    OPTION_DEFAULT(uint, max_pending_signals, 8,
+                   "maximum count of pending signals per thread")
 
     /* i#2080: we have had some problems using sigreturn to set a thread's
      * context to a given state.  Turning this off will instead use a direct

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -401,6 +401,10 @@ typedef struct _thread_sig_info_t {
     /* rest of app state */
     stack_t app_sigstack;
     sigpending_t *sigpending[SIGARRAY_SIZE];
+    /* count of pending signals */
+    int num_pending;
+    /* are the pending still on one special heap unit? */
+    bool multiple_pending_units;
     /* "lock" to prevent interrupting signal from messing up sigpending array */
     bool accessing_sigpending;
     kernel_sigset_t app_sigblocked;

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -1,5 +1,5 @@
 ;// **********************************************************
-;// Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+;// Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
 ;// Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
 ;// **********************************************************
 
@@ -249,6 +249,14 @@ Facility = DRCore
 SymbolicName = MSG_OUT_OF_MEMORY
 Language=English
 Application %1!s! (%2!s!).  Out of memory.  Program aborted. Status %3!s! 0x%4!s!
+.
+
+MessageId =
+Severity = Warning
+Facility = DRCore
+SymbolicName = MSG_MAX_PENDING_SIGNALS
+Language=English
+Application %1!s! (%2!s!).  Reached the soft maximum number (%3!s!) of pending signals: further accumulation prior to delivery may cause problems.  Consider raising -max_pending_signals.
 .
 
 MessageId =

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -123,6 +123,7 @@ set(vmap_run_list
   "DEBUG::LIN::ONLY::^(common|client)::-code_api -stack_size 128K -loglevel 1"
   "ONLY::^common::"
   "X86::LIN::ONLY::^${osname}::-code_api -sysenter_is_int80"
+  "X86::LIN::ONLY::^${osname}.sig::-max_pending_signals 1"
 
   # cover -tracedump_* options, just a couple combinations
   # XXX: how up time limit?  Used to have TEST_MINS=5 for tracedump runs.


### PR DESCRIPTION
Adds a new option -max_pending_signals.  Changes the special heap used for
pending signals to take in an initial unit size and not be dependent on the
regular heap's default unit sizes.  The pending signal heap size is sized
to fit -max_pending_signals entries.  The default is 8, which rounds up to
12K for x86_64, saving per-thread memory over the prior 32K size.

Adds a pending signal count and warns (in release build too) when the
maximum is reached.

Adds a check for getting close to the limit when delivering a pending
signal: if so, we proactively allocate a 2nd unit while we can safely
acquire locks.

Adds a test of "-max_pending_signals 1" for linux.sig* to the long suite.

Issue: #2575