### PR TITLE
i#2575 shrink thread mem: separate signal stack size

### DIFF
--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -1585,7 +1585,7 @@ are specified via \c drconfig, \c drrun, or dr_register_process().  See
    to 2 * page size. This parameter can be used to increase the size;
    however, larger stack sizes use significantly more memory when targeting
    applications with hundreds of threads.  The parameter can take a 'K'
-   suffix, and must be a multiple of the page size (4K, 16K or 64K depending on
+   suffix, and must be a multiple of the page size (4K, 16K, or 64K depending on
    the system).  This stack is used \if vmsafe for probe callbacks and by
    the Code Manipulation API \else by the \endif routines dr_insert_clean_call(),
    dr_swap_to_clean_stack(), dr_prepare_for_call(),
@@ -1593,6 +1593,15 @@ are specified via \c drconfig, \c drrun, or dr_register_process().  See
    dr_insert_cbr_instrumentation(), and dr_insert_ubr_instrumentation().
    The stack is started fresh for each use, so <em>no persistent state may be
    stored on it</em>.
+ - \b -signal_stack_size \e \<number\>:
+   DynamoRIO uses an alternate signal handling stack which is smaller than
+   the regular stack by default, as signal handlers are called in
+   relatively fragile contexts and cannot safely use arbitrary library
+   routines: it is 32K for systems with a 4K page size. For systems with
+   different page sizes, it defaults to 2 * page size. This parameter can
+   be used to change the size.  The parameter can take a 'K' suffix, and
+   must be a multiple of the page size (4K, 16K, or 64K depending on the
+   system).
 \if vmsafe
 Options available only in Code Manipulation mode and Memory Firewall mode
 (see \ref dr_modes):

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -181,6 +181,8 @@ Further non-compatibility-affecting changes include:
  - Globally enabled auto predication in the drmgr instrumentation insertion event by
    default.
  - Added drmgr_disable_auto_predication().
+ - Added a new option -signal_stack_size with a smaller default value than
+   before, to save space on applications with many threads.
 
 **************************************************
 <hr>

--- a/core/options.c
+++ b/core/options.c
@@ -217,6 +217,10 @@ adjust_defaults_for_page_size(options_t *options)
         ALIGN_FORWARD(options->vmm_block_size, page_size);
     options->stack_size =
         MAX(ALIGN_FORWARD(options->stack_size, page_size), 2 * page_size);
+# ifdef UNIX
+    options->signal_stack_size =
+        MAX(ALIGN_FORWARD(options->signal_stack_size, page_size), 2 * page_size);
+# endif
     options->initial_heap_unit_size =
         MAX(ALIGN_FORWARD(options->initial_heap_unit_size, page_size),
             3 * page_size);
@@ -814,6 +818,13 @@ options_enable_code_api_dependences(options_t *options)
      * tail end of a multi-64K-region stack.
      */
     options->stack_size = MAX(options->stack_size, 56*1024);
+# ifdef UNIX
+    /* We assume that clients avoid private library code, within reason, and
+     * don't need as much space when handling signals.  We still raise the
+     * limit a little while saving some per-thread space.
+     */
+    options->signal_stack_size = MAX(options->signal_stack_size, 32*1024);
+# endif
 
     /* For CI builds we'll disable elision by default since we
      * expect most CI users will prefer a view of the

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -712,6 +712,12 @@
                     */
                    IF_CLIENT_INTERFACE_ELSE(24*1024,IF_X64_ELSE(20*1024,12*1024)),
                    "size of thread-private stacks, in KB")
+#ifdef UNIX
+    /* signal_stack_size may be adjusted by adjust_defaults_for_page_size(). */
+    OPTION_DEFAULT(uint_size, signal_stack_size,
+                   IF_CLIENT_INTERFACE_ELSE(24*1024,IF_X64_ELSE(20*1024,12*1024)),
+                   "size of signal handling stacks, in KB")
+#endif
     /* PR 415959: smaller vmm block size makes this both not work and not needed
      * on Linux.
      * FIXME PR 403008: stack_shares_gencode fails on vmkernel

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -128,8 +128,7 @@ sig_is_alarm_signal(int sig)
  * we end up calling many core routines and so want more space
  * (though currently non-debug stack size == SIGSTKSZ (8KB))
  */
-/* this size is assumed in heap.c's threadunits_exit leak relaxation */
-#define SIGSTACK_SIZE DYNAMORIO_STACK_SIZE
+#define SIGSTACK_SIZE (DYNAMO_OPTION(signal_stack_size))
 
 /* this flag not defined in our headers */
 #define SA_RESTORER 0x04000000


### PR DESCRIPTION
Adds a new option -signal_stack_size with a smaller default than
-stack_size (32K for -code_api instead of 56K).  Publicly documents this
option so that clients can control it and better tune their per-thread
memory usage for scaling to applications with many threads.

Issue: #2575