### PR TITLE
Add cross-platform thread routines for tests

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -468,6 +468,12 @@ function (set_cflags source)
   get_filename_component(abs ${source} ABSOLUTE)
   file(READ ${abs} srccode)
   set(srccode "${srccode}" PARENT_SCOPE)
+  if (WIN32 AND "${srccode}" MATCHES "condvar\\.h")
+    # Ensure the ConditionVariable routines are pulled in when using >VS2010.
+    # Because dr_api.h includes windows.h and must be included before tools.h we do
+    # this via command line flags.
+    set(cflags "${cflags} -D_WIN32_WINNT=0x0600")
+  endif ()
   # We support a test either getting defines from configure.h or
   # needing them passed in on cmd line.
   if ("${srccode}" MATCHES "tools\\.h" OR

--- a/suite/tests/api/detach.c
+++ b/suite/tests/api/detach.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -36,16 +36,9 @@
 #include <math.h>
 #include <stdint.h>
 #include "configure.h"
-#ifdef WINDOWS
-/* Ensure the ConditionVariable routines are pulled in when using >VS2010 */
-# undef _WIN32_WINNT
-# define _WIN32_WINNT 0x0600
-# include <windows.h>
-#else
-# include <pthread.h>
-#endif
 #include "dr_api.h"
 #include "tools.h"
+#include "thread.h"
 #include "condvar.h"
 
 #define VERBOSE 0
@@ -97,11 +90,7 @@ static void *sideline_continue;
 static void *go_native;
 static void *sideline_ready[NUM_THREADS];
 
-#ifdef WINDOWS
-int __stdcall
-#else
-void *
-#endif
+THREAD_FUNC_RETURN_TYPE
 sideline_spinner(void *arg)
 {
     unsigned int idx = (unsigned int)(uintptr_t)arg;
@@ -132,11 +121,7 @@ sideline_spinner(void *arg)
     signal_cond_var(sideline_ready[idx]);
     VPRINT("%d exiting\n", idx);
 
-#ifdef WINDOWS
-    return 0;
-#else
-    return NULL;
-#endif
+    return THREAD_FUNC_RETURN_ZERO;
 }
 
 void foo(void)
@@ -148,12 +133,7 @@ int main(void)
     double res = 0.;
     int i;
     void *stack = NULL;
-#ifdef UNIX
-    pthread_t pt[NUM_THREADS];  /* On Linux, the tid. */
-#else
-    uintptr_t thread[NUM_THREADS];  /* _beginthreadex doesn't return HANDLE? */
-    uint tid[NUM_THREADS];
-#endif
+    thread_t thread[NUM_THREADS];  /* On Linux, the tid. */
 
     /* We could generate this via macros but that gets pretty obtuse */
     funcs[0] = &func_0;
@@ -172,12 +152,7 @@ int main(void)
 
     for (i = 0; i < NUM_THREADS; i++) {
         sideline_ready[i] = create_cond_var();
-#ifdef UNIX
-        pthread_create(&pt[i], NULL, sideline_spinner, (void*)(uintptr_t)i);
-#else
-        thread[i] = _beginthreadex(NULL, 0, sideline_spinner, (void*)(uintptr_t)i,
-                                   0, &tid[i]);
-#endif
+        thread[i] = create_thread(sideline_spinner, (void*)(uintptr_t)i);
     }
 
     /* Initialized DR */
@@ -226,14 +201,9 @@ int main(void)
     print("all done: %d iters\n", i);
 
     for (i = 0; i < NUM_THREADS; i++) {
-#ifdef UNIX
-        pthread_join(pt[i], NULL);
-#else
-        WaitForSingleObject((HANDLE)thread[i], INFINITE);
-#endif
+        join_thread(thread[i]);
         if (!took_over_thread[i]) {
-            print("failed to take over thread %d==%d!\n", i,
-                  IF_WINDOWS_ELSE(tid[i],pt[i]));
+            print("failed to take over thread %d!\n", i);
         }
     }
 

--- a/suite/tests/condvar.h
+++ b/suite/tests/condvar.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*

--- a/suite/tests/linux/vfork.c
+++ b/suite/tests/linux/vfork.c
@@ -37,7 +37,7 @@
 
 #include "tools.h"
 #ifdef LINUX
-# include "threads.h"
+# include "thread_clone.h"
 #endif
 
 #include <sys/types.h>

--- a/suite/tests/thread.h
+++ b/suite/tests/thread.h
@@ -71,7 +71,7 @@ join_thread(thread_t thread)
 void
 thread_sleep(int ms)
 {
-    usleep(ms);
+    usleep(1000*ms);
 }
 
 void

--- a/suite/tests/thread.h
+++ b/suite/tests/thread.h
@@ -1,0 +1,150 @@
+/* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2004-2007 VMware, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Separated out from tools.h because it requires linking with pthreads. */
+
+#ifndef THREADS_H
+#define THREADS_H
+
+/***************************************************************************/
+#ifdef UNIX
+
+#define WINAPI
+
+#include <pthread.h>
+#include <unistd.h>
+#include <sched.h>
+
+typedef pthread_t thread_t;
+
+# define THREAD_FUNC_RETURN_TYPE void *
+# define THREAD_FUNC_RETURN_ZERO NULL
+
+/* Create a new thread. It should be passed "run_func", a function which
+ * takes one argument ("arg"), for the thread to execute.
+ * Returns the handle to the new thread.
+ */
+static thread_t
+create_thread(THREAD_FUNC_RETURN_TYPE (*run_func)(void *), void *arg)
+{
+    thread_t thread;
+    pthread_create(&thread, NULL, run_func, arg);
+    return thread;
+}
+
+static void
+join_thread(thread_t thread)
+{
+    pthread_join(thread, NULL);
+}
+
+void
+thread_sleep(int ms)
+{
+    usleep(ms);
+}
+
+void
+thread_yield(void)
+{
+    sched_yield();
+}
+
+/***************************************************************************/
+#else /* WINDOWS */
+
+#include <windows.h>
+#include <process.h> /* for _beginthreadex */
+
+typedef HANDLE thread_t;
+
+# define THREAD_FUNC_RETURN_TYPE unsigned int __stdcall
+# define THREAD_FUNC_RETURN_ZERO 0
+
+/* Create a new thread. It should be passed "run_func", a function which
+ * takes one argument ("arg"), for the thread to execute.
+ * Returns a handle to the new thread.
+ */
+# ifndef STATIC_LIBRARY  /* FIXME i#975: conflicts with DR's symbols. */
+thread_t
+create_thread(unsigned int (__stdcall *run_func)(void *), void *arg)
+{
+    int tid;
+    return (thread_t) _beginthreadex(NULL, 0, run_func, arg, 0, &tid);
+}
+# endif
+
+void
+delete_thread(thread_t thread, void *stack)
+{
+    VERBOSE_PRINT("Waiting for child to exit\n");
+    WaitForSingleObject(thread, INFINITE);
+    VERBOSE_PRINT("Child has exited\n");
+}
+
+void
+join_thread(thread_t thread)
+{
+    WaitForSingleObject(thread, INFINITE);
+    CloseHandle(thread);
+}
+
+void
+thread_sleep(int ms)
+{
+    Sleep(ms);
+}
+
+void
+suspend_thread(thread_t thread)
+{
+    SuspendThread(thread);
+}
+
+void
+resume_thread(thread_t thread)
+{
+    ResumeThread(thread);
+}
+
+# ifndef STATIC_LIBRARY  /* FIXME i#975: conflicts with DR's symbols. */
+void
+thread_yield()
+{
+    Sleep(0); /* stay ready */
+}
+# endif
+
+#endif /* WINDOWS */
+
+#endif /* THREADS_H */

--- a/suite/tests/tools.c
+++ b/suite/tests/tools.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -122,50 +122,6 @@ is_wow64(HANDLE hProcess)
         return CAST_TO_bool(res);
     }
 }
-
-/* FIXME: Port these thread routines to Linux using the ones from linux/clone.c.
- * We'll have to change existing Windows tests to pass a stack out param or leak
- * the stack on Linux.
- */
-
-# ifndef STATIC_LIBRARY  /* FIXME i#975: conflicts with DR's symbols. */
-/* Thread related functions */
-thread_handle
-create_thread(fptr f)
-{
-    thread_handle th;
-
-    uint tid;
-    th = (thread_handle) _beginthreadex(NULL, 0, f, NULL, 0, &tid);
-    return th;
-}
-# endif
-
-void
-suspend_thread(thread_handle th)
-{
-    SuspendThread(th);
-}
-
-void
-resume_thread(thread_handle th)
-{
-    ResumeThread(th);
-}
-
-void
-join_thread(thread_handle th)
-{
-    WaitForSingleObject(th, INFINITE);
-}
-
-# ifndef STATIC_LIBRARY  /* FIXME i#975: conflicts with DR's symbols. */
-void
-thread_yield()
-{
-    Sleep(0); /* stay ready */
-}
-# endif
 #endif  /* WINDOWS */
 
 int

--- a/suite/tests/tools.h
+++ b/suite/tests/tools.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -35,11 +35,11 @@
 #define TOOLS_H
 
 /* i#1424: avoid pulling in features from recent versions to keep compatibility.
- * The core tries to stay at NT4 but some tests need 2K.
+ * The core may still support 2K but officially we only support XP+.
+ * Some tests need 0x0600, in particular condvar.h.
  */
-#ifndef _WIN32_WINNT
-# define _WIN32_WINNT _WIN32_WINNT_WIN2K
-#endif
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
 
 #include "configure.h"
 #include "dr_helper.h"
@@ -694,31 +694,6 @@ set_global_filter()
 }
 
 #endif /* UNIX */
-
-#ifdef UNIX
-typedef int thread_handle;
-typedef unsigned int (*fptr)(void *);
-#else
-typedef HANDLE thread_handle;
-typedef unsigned int (__stdcall *fptr)(void *);
-#endif
-
-#ifdef WINDOWS
-/* Thread related functions */
-thread_handle
-create_thread(fptr f);
-void
-suspend_thread(thread_handle th);
-
-void
-resume_thread(thread_handle th);
-
-void
-join_thread(thread_handle th);
-
-void
-thread_yield();
-#endif
 
 #ifdef WINDOWS
 static byte *

--- a/suite/tests/win32/nativeterminate.c
+++ b/suite/tests/win32/nativeterminate.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2005 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -37,6 +37,7 @@
  */
 #include <windows.h>
 #include "tools.h"
+#include "thread.h"
 
 /* from nativeterminate.dll.dll */
 __declspec(dllimport) __stdcall import_me1(int x);
@@ -50,10 +51,10 @@ main()
     print("calling via IAT-style call\n");
     import_me1(57);
     print("calling in a thread\n");
-    join_thread(create_thread((fptr)import_me1));
+    join_thread(create_thread((unsigned int (__stdcall *)(void *))import_me1, NULL));
 
     print("calling in a thread that dies\n");
-    join_thread(create_thread((fptr)import_me_die));
+    join_thread(create_thread((unsigned int (__stdcall *)(void *))import_me_die, NULL));
     print("case 5455 regression passed\n");
 
     print("all done\n");

--- a/suite/tests/win32/threadchurn.c
+++ b/suite/tests/win32/threadchurn.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -39,13 +39,9 @@
 #endif
 
 #include "tools.h"
+#include "thread.h"
 
 typedef unsigned char* app_pc;
-
-#ifdef WINDOWS
-#  include <process.h> /* for _beginthreadex */
-#else
-#endif
 
 #define SILENT                  /* no writes at all */
 
@@ -79,7 +75,7 @@ enum {ROUNDS = 10};
 enum {LOOP_WORK = 100};
 
 /* --------- */
-thread_handle thread[TOTAL_THREADS];
+thread_t thread[TOTAL_THREADS];
 
 long global_started = 0;                   /* unsynchronized */
 long global_finished = 0;                   /* unsynchronized */
@@ -164,7 +160,7 @@ main()
         /* do in a batch */
         for (b = 0; b < TOTAL_THREADS / BATCH_SIZE; b++) {
             for (t = 0; t < BATCH_SIZE; t++) {
-                thread[t] = create_thread(executor);
+                thread[t] = create_thread(executor, NULL);
                 if (thread[t] == NULL)
                     print("GLE: %d\n", GetLastError());
                 assert(thread[t] != NULL);
@@ -181,7 +177,6 @@ main()
             for (t = 0; t < BATCH_SIZE; t++) {
                 assert(thread[t] != NULL);
                 join_thread(thread[t]);
-                CloseHandle((HANDLE)thread[t]);
                 thread[t] = NULL; /* in case want to synch with some in a batch, but with all at the end */
 
                 if (SWAP_OUT_AFTER_THREAD) {

--- a/suite/tests/win32/threadexit.c
+++ b/suite/tests/win32/threadexit.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -33,13 +33,9 @@
 
 /* case 3105 test cases for rapidly starting and terminating threads */
 #include "tools.h"
+#include "thread.h"
 
 typedef unsigned char* app_pc;
-
-#ifdef WINDOWS
-#  include <process.h> /* for _beginthreadex */
-#else
-#endif
 
 /* not including main thread */
 #ifndef NIGHTLY_REGRESSION

--- a/suite/tests/win32/threadexit.c
+++ b/suite/tests/win32/threadexit.c
@@ -164,7 +164,7 @@ main()
         global_finished = 0;
 
         for (t = 0; t < TOTAL_THREADS; t++) {
-            thread[t] = (HANDLE)create_thread(executor);
+            thread[t] = (HANDLE)create_thread(executor, NULL);
             if (thread[t] == NULL)
                 print("GLE: %d\n", GetLastError());
             assert(thread[t] != NULL);

--- a/suite/tests/win32/threadterm.c
+++ b/suite/tests/win32/threadterm.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -31,6 +31,7 @@
  */
 
 #include "tools.h"
+#include "thread.h"
 #include <windows.h>
 #include <process.h>
 #include <stdio.h>


### PR DESCRIPTION
Moves the current clone-based thread routines to thread_clone.h.

Moves the current Windows thread routines into thread.h and adds a
pthread-based UNIX parallel implementation.

Updates api/detach.c and api/startstop.c to use the new cross-platform
routines.

Moves the _WIN32_WINNT define for condvar.h from needing to be in each
test's code (due to header order limitations) to be auto-magically added
from cmake.

Updates other tests to include the right header files.