### PR TITLE
i#2603: fix hang on attach

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -158,9 +158,9 @@ mutex_t initstack_mutex VAR_IN_SECTION(NEVER_PROTECTED_SECTION)
      = INIT_SPINLOCK_FREE(initstack_mutex);
 byte * initstack_app_xsp VAR_IN_SECTION(NEVER_PROTECTED_SECTION) = 0;
 /* keeps track of how many threads are in cleanup_and_terminate */
-int exiting_thread_count VAR_IN_SECTION(NEVER_PROTECTED_SECTION) = 0;
+volatile int exiting_thread_count VAR_IN_SECTION(NEVER_PROTECTED_SECTION) = 0;
 /* Tracks newly created threads not yet on the all_threads list. */
-int uninit_thread_count VAR_IN_SECTION(NEVER_PROTECTED_SECTION) = 0;
+volatile int uninit_thread_count VAR_IN_SECTION(NEVER_PROTECTED_SECTION) = 0;
 
 /* This is unprotected to allow stats to be written while the data
  * segment is still protected (right now the only ones are selfmod stats)

--- a/core/globals.h
+++ b/core/globals.h
@@ -491,9 +491,9 @@ extern byte *  exception_stack;
 /* keeps track of how many threads are in cleanup_and_terminate so that we know
  * if any threads could still be using shared resources even if they aren't on
  * the all_threads list */
-extern int exiting_thread_count;
+extern volatile int exiting_thread_count;
 /* Tracks newly created threads not yet on the all_threads list. */
-extern int uninit_thread_count;
+extern volatile int uninit_thread_count;
 
 /* Called before a second thread is ever scheduled. */
 void pre_second_thread(void);


### PR DESCRIPTION
Fixes a hang on attach on UNIX by avoiding re-takeover of an in-transition
thread, by waiting for uninit_thread_count to reach 0 before initiating
takeover of "unknown" threads.

Tested on the api.detach_spawn test.

Fixes #2603