### PR TITLE
i#2606: stack size with 64K pages

### DIFF
--- a/core/heap.c
+++ b/core/heap.c
@@ -1445,8 +1445,9 @@ vmm_heap_exit()
          */
         DOCHECK(1, {
             uint perstack =
-                ALIGN_FORWARD_UINT(dynamo_options.stack_size +
-                                   (dynamo_options.guard_pages ? (2*PAGE_SIZE) : 0),
+                ALIGN_FORWARD_UINT(DYNAMO_OPTION(stack_size) +
+                                   (DYNAMO_OPTION(guard_pages) ? (2*PAGE_SIZE) :
+                                    (DYNAMO_OPTION(stack_guard_pages) ? PAGE_SIZE : 0)),
                                    DYNAMO_OPTION(vmm_block_size)) /
                 DYNAMO_OPTION(vmm_block_size);
             uint unfreed_blocks = perstack * 1 /* initstack */ +
@@ -2536,7 +2537,7 @@ is_stack_overflow(dcontext_t *dcontext, byte *sp)
      * -signal_stack_size, but all dstacks and initstack should be this size.
      */
     byte *bottom = dcontext->dstack - DYNAMORIO_STACK_SIZE;
-    if (!DYNAMO_OPTION(stack_guard_pages))
+    if (!DYNAMO_OPTION(stack_guard_pages) && !DYNAMO_OPTION(guard_pages))
         return false;
     /* see if in bottom guard page of dstack */
     if (sp >= bottom - PAGE_SIZE && sp < bottom)

--- a/core/options.c
+++ b/core/options.c
@@ -216,10 +216,10 @@ adjust_defaults_for_page_size(options_t *options)
     options->vmm_block_size =
         ALIGN_FORWARD(options->vmm_block_size, page_size);
     options->stack_size =
-        MAX(ALIGN_FORWARD(options->stack_size, page_size), 2 * page_size);
+        MAX(ALIGN_FORWARD(options->stack_size, page_size), page_size);
 # ifdef UNIX
     options->signal_stack_size =
-        MAX(ALIGN_FORWARD(options->signal_stack_size, page_size), 2 * page_size);
+        MAX(ALIGN_FORWARD(options->signal_stack_size, page_size), page_size);
 # endif
     options->initial_heap_unit_size =
         MAX(ALIGN_FORWARD(options->initial_heap_unit_size, page_size),

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1686,7 +1686,9 @@ if (CLIENT_INTERFACE)
   endif (X86)
   tobuild_ci(client.crashmsg client-interface/crashmsg.c "" "" "")
   if (UNIX) # XXX i#2595: NYI on Windows
-    tobuild_ci(client.stack-overflow client-interface/stack-overflow.c "" "" "")
+    tobuild_ci(client.stack-overflow client-interface/stack-overflow.c ""
+      # To avoid flakiness on different systems we nail down the stack size:
+      "-stack_size 64K" "")
   endif ()
   # FIXME i#1360: implement Mach-O export iterator
   # FIXME i#2008: fix bugs on Android

--- a/suite/tests/client-interface/stack-overflow.dll.c
+++ b/suite/tests/client-interface/stack-overflow.dll.c
@@ -35,10 +35,16 @@
 static dr_emit_flags_t
 bb_event(void* drcontext, void *tag, instrlist_t* bb, bool for_trace, bool translating)
 {
-    /* Deliberate stack overflow crash */
+    /* Deliberate stack overflow crash.  Unfortunately the compiler puts some locals
+     * *beyond* the array so we cannot always incrementally touch pages and handle
+     * any stack size, so we have this test run with -stack_size 64K (which is the min
+     * for systems with 64K pages).
+     */
     char too_big[65*1024];
     int i;
-    /* Overflow detection is limited to a single page so make sure we touch it: */
+    /* Overflow detection is limited to a single page so make sure we touch it if
+     * the compiler didn't touch a local beyond the array already:
+     */
     for (i = 1; i < sizeof(too_big); i+=1024)
         too_big[sizeof(too_big) - i] = '\0';
     /* Avoid optimizing away the array. */


### PR DESCRIPTION
Fixes issues from 240b75d6 #2592 which added UNIX stack overflow
reporting:
+ Fixes -stack_size and -signal_stack_size to have a minimum of just the
  page size, not double it, as the guards are added on top.
+ Fixes leak reporting to consider -stack_guard_pages and not just
  -guard_pages.
+ Makes the client.stack-overflow test less flaky by setting a specific
  stack size to avoid variations in compilers and platforms.

Fixes #2606