### PR TITLE
Increase -vm_size default and max for 64-bit

### DIFF
--- a/core/heap.c
+++ b/core/heap.c
@@ -577,8 +577,8 @@ static void report_low_on_memory(oom_source_t source,
                                  heap_error_code_t os_error_code);
 
 enum {
-    /* maximum 512MB virtual memory units */
-    MAX_VMM_HEAP_UNIT_SIZE = 512*1024*1024,
+    /* maximum 512MB for 32-bit, 1GB for 64-bit */
+    MAX_VMM_HEAP_UNIT_SIZE = IF_X64_ELSE(1024*1024*1024, 512*1024*1024),
     /* We should normally have only one large unit, so this is in fact
      * the maximum we should count on in one process
      */
@@ -601,7 +601,10 @@ typedef struct {
        static therefore we don't grab locks on read accesses.  Anyways,
        currently the bitmap_t is used with no write intent only for ASSERTs. */
     uint    num_free_blocks;    /* currently free blocks */
-    /* Bitmap uses 1KB static data for granularity 64KB and static maximum 512MB */
+    /* Bitmap uses 2KB static data for granularity 64KB and static maximum 1GB on Windows,
+     * and 32KB on Linux where granularity is 4KB.  These amounts are halved for
+     * 32-bit, so 1KB Windows and 16KB Linux.
+     */
     /* Since we expect only two of these, for now it is ok for users
        to have static max rather than dynamically allocating with
        exact size - however this field is left last in the structure

--- a/core/options.c
+++ b/core/options.c
@@ -388,6 +388,8 @@ parse_uint_size(uint *var, void *value)
         case 'k': factor = 1024; break;
         case 'M': // Mega (bytes)
         case 'm': factor = 1024*1024; break;
+        case 'G': // Giga (bytes)
+        case 'g': factor = 1024*1024*1024; break;
         default:
             /* var should be pre-initialized to default */
             OPTION_PARSE_ERROR(ERROR_OPTION_UNKNOWN_SIZE_SPECIFIER, 4,
@@ -597,11 +599,11 @@ check_param_bounds(uint *val, uint min, uint max, const char *name)
         (max > 0 && (*val < min || *val > max))) {
         if (max == 0) {
             new_val = min;
-            USAGE_ERROR("%s must be >= %d, resetting from %d to %d",
+            USAGE_ERROR("%s must be >= %u, resetting from %u to %u",
                         name, min, *val, new_val);
         } else {
-            new_val = min;
-            USAGE_ERROR("%s must be >= %d and <= %d, resetting from %d to %d",
+            new_val = max;
+            USAGE_ERROR("%s must be >= %u and <= %u, resetting from %u to %u",
                         name, min, max, *val, new_val);
         }
         *val = new_val;
@@ -611,7 +613,7 @@ check_param_bounds(uint *val, uint min, uint max, const char *name)
         if (*val == 0) {
             LOG(GLOBAL, LOG_CACHE, 1, "%s: <unlimited>\n", name);
         } else {
-            LOG(GLOBAL, LOG_CACHE, 1, "%s: %d KB\n", name, *val/1024);
+            LOG(GLOBAL, LOG_CACHE, 1, "%s: %u KB\n", name, *val/1024);
         }
     });
     return ret;
@@ -637,14 +639,14 @@ PRINT_STRING_uint(char *optionbuff, uint value, const char *option)
     /* FIXME: 0x100 hack to get logmask printed in hex,
      * loglevel etc in decimal */
     snprintf(optionbuff, MAX_OPTION_LENGTH,
-             (value > 0x100 ? "-%s 0x%x " : "-%s %d "), option, value);
+             (value > 0x100 ? "-%s 0x%x " : "-%s %u "), option, value);
 }
 #define PRINT_STRING_uint_size(optionbuff,value,option) \
-    snprintf(optionbuff, MAX_OPTION_LENGTH, "-%s %d%s ", option, \
+    snprintf(optionbuff, MAX_OPTION_LENGTH, "-%s %u%s ", option, \
              ((value) % 1024 == 0 ? (value)/1024 : (value)), \
              ((value) % 1024 == 0 ? "K" : "B"))
 #define PRINT_STRING_uint_time(optionbuff,value,option) \
-    snprintf(optionbuff, MAX_OPTION_LENGTH, "-%s %d ", option, (value))
+    snprintf(optionbuff, MAX_OPTION_LENGTH, "-%s %u ", option, (value))
 #define PRINT_STRING_uint_addr(optionbuff,value,option) \
     snprintf(optionbuff, MAX_OPTION_LENGTH, "-%s "PFX" ", option, (value));
 #define PRINT_STRING_pathstring_t(optionbuff,value,option) \

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1406,11 +1406,12 @@
     OPTION_DEFAULT_INTERNAL(bool, skip_out_of_vm_reserve_curiosity, false,
         "skip the assert curiosity on out of vm_reserve (for regression tests)")
     OPTION_DEFAULT(bool, vm_reserve, true, "reserve virtual memory")
-    /* FIXME - on 64bit probably will need more space */
-    OPTION_DEFAULT(uint_size, vm_size, 128*1024*1024,
-        "maximum virtual memory reserved, in KB or MB")
-        /* default size is in Kilobytes, Examples: 262144, 1024k, 256m, up to maximum of 512M */
-     /* FIXME: default value is currently not good enough for sqlserver, for which we need more than 256MB */
+    OPTION_DEFAULT(uint_size, vm_size, IF_X64_ELSE(256,128)*1024*1024,
+                   /* XXX: default value is currently not good enough for sqlserver,
+                    * for which we need more than 256MB.
+                    */
+                   "capacity of virtual memory region reserved (maximum supported is "
+                   "512MB for 32-bit and 1GB for 64-bit)")
 
     /* We hardcode an address in the mmap_text region here, but verify via
      * in vmk_init().


### PR DESCRIPTION
Increases the default -vm_size for 64-bit from 128M to 256M.
Increases the maximum supported -vm_size for 64-bit from 512M to 1G.
Adds support for a 'G' or 'g' suffix on size options.