### PR TITLE
i#2617: do not send query signal for standalone

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1466,6 +1466,8 @@ is_thread_tls_initialized(void)
     if (INTERNAL_OPTION(safe_read_tls_init)) {
         /* Avoid faults during early init or during exit when we have no handler.
          * It's not worth extending the handler as the faults are a perf hit anyway.
+         * For standalone_library, first_thread_tls_initialized will always be false,
+         * so we'll return false here and use our check in get_thread_private_dcontext().
          */
         if (!first_thread_tls_initialized || last_thread_tls_exited)
             return false;

--- a/core/unix/signal_linux_x86.c
+++ b/core/unix/signal_linux_x86.c
@@ -543,7 +543,7 @@ void
 signal_arch_init(void)
 {
     xstate_size = sizeof(kernel_xstate_t) + 4 /* trailing FP_XSTATE_MAGIC2 */;
-    if (YMM_ENABLED()) {
+    if (YMM_ENABLED() && !standalone_library/* avoid SIGILL for standalone */) {
         kernel_sigaction_t act, oldact;
         int rc;
         /* i#2438: it's possible that our init code to this point has not yet executed


### PR DESCRIPTION
In standalone mode we avoid sending the xstate query signal to avoid a
spurious SIGILL in "regular" applications.

Fixes #2617