### PR TITLE
i#1896 WSL: relax fpstate assert and unsupported syslog

### DIFF
--- a/core/unix/tls_linux_x86.c
+++ b/core/unix/tls_linux_x86.c
@@ -460,8 +460,10 @@ tls_thread_init(os_local_state_t *os_tls, byte *segment)
                     on_WSL = true;
                     LOG(GLOBAL, LOG_THREADS, 1, "os_tls_init: running on WSL\n");
                     if (INTERNAL_OPTION(safe_read_tls_init)) {
-                        SYSLOG(SYSLOG_WARNING, WSL_UNSUPPORTED, 2,
-                               get_application_name(), get_application_pid());
+                        SYSLOG_INTERNAL_WARNING
+                            ("Support for the Windows Subsystem for Linux is still "
+                             "preliminary, due to missing kernel features.  "
+                             "Continuing, but please report any problems encountered.");
                     } else {
                         SYSLOG(SYSLOG_ERROR, WSL_UNSUPPORTED_FATAL, 2,
                                get_application_name(), get_application_pid());

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -268,14 +268,6 @@ Application %1!s! (%2!s!) is not supported due to dll %3!s!.  Program aborted.
 .
 
 MessageId =
-Severity = Warning
-Facility = DRCore
-SymbolicName = MSG_WSL_UNSUPPORTED
-Language=English
-Application %1!s! (%2!s!).  The Windows Subsystem for Linux is not yet fully supported due to missing kernel features.   Continuing, but may encounter problems.
-.
-
-MessageId =
 Severity = Error
 Facility = DRCore
 SymbolicName = MSG_WSL_UNSUPPORTED_FATAL


### PR DESCRIPTION
Relaxes the signal query assert that fpstate is set up, as it's NULL for
WSL (needs further investigation for proper signal support).

Downgrades the general syslog warning for WSL to an internal warning as
simple applications are working.

Issue: #1896