### PR TITLE
Follow-up to 0b75c63: Handle ARM Linux with CONFIG_IWMMXT.

### DIFF
--- a/core/unix/include/sigcontext.h
+++ b/core/unix/include/sigcontext.h
@@ -287,6 +287,9 @@ typedef struct _kernel_iwmmxt_sigframe_t {
     kernel_iwmmxt_struct_t storage;
 } __attribute__((__aligned__(8))) kernel_iwmmxt_sigframe_t;
 
+/* Dummy padding block: a block with this magic should be skipped. */
+# define DUMMY_MAGIC 0xb0d9ed01
+
 #endif /* __arm__ */
 
 #ifdef __aarch64__


### PR DESCRIPTION
Kernel 4.13 fixed the bug by inserting a dummy padding block,
and it expects the dummy block to be present if the VFP frame is
offset by the size of an IWMMXT frame. This requires an update to
our work-around.

Change-Id: Ie1fce56bbd89912cc8aa2e2a5360b6688d5f2be9