### PR TITLE
i#2157 re-attach: Always free the heap on unix

### DIFF
--- a/core/heap.c
+++ b/core/heap.c
@@ -906,7 +906,7 @@ vmm_heap_unit_exit(vm_heap_t *vmh)
             byte *sp;
             GET_STACK_PTR(sp);
             ASSERT(!(sp >= vmh->start_addr && sp < vmh->end_addr));
-        })
+        });
         free_heap = true;
     }
 #endif

--- a/core/heap.c
+++ b/core/heap.c
@@ -902,10 +902,12 @@ vmm_heap_unit_exit(vm_heap_t *vmh)
      * doing a detach we can be sure our stack is not actually in the heap.
      */
     if (doing_detach) {
-      byte *sp;
-      GET_STACK_PTR(sp);
-      ASSERT(!(sp >= vmh->start_addr && sp < vmh->end_addr));
-      free_heap = true;
+        DODEBUG({
+            byte *sp;
+            GET_STACK_PTR(sp);
+            ASSERT(!(sp >= vmh->start_addr && sp < vmh->end_addr));
+        })
+        free_heap = true;
     }
 #endif
     if (free_heap) {


### PR DESCRIPTION
On unix it should be safe to free the heap even if there blocks still
being used since we are clearing out all other memory references anyway.

I also included a fix to vmm_heap_unit_init which accidentally left
vmh->alloc_start uninitialized in the branch related to reserving OS
memory at a preferred location.

Issue: #2157