### PR TITLE
i#2006 drcachesim generalization: expose iterator from analyzer

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -111,6 +111,7 @@ use_DynamoRIO_extension(drcachesim drutil_static)
 # This is to avoid ../ and common/ in the #includes of headers that we
 # may want to install into a single dir for 3rd-party tool integration.
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/common)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/reader)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set(file_analyzer_tool_srcs

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -45,7 +45,8 @@ analyzer_t::analyzer_t() :
     /* Nothing else: child class needs to initialize. */
 }
 
-bool analyzer_t::init_file_reader(const std::string &trace_file)
+bool
+analyzer_t::init_file_reader(const std::string &trace_file)
 {
     if (trace_file.empty()) {
         ERRMSG("Trace file name is empty\n");

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -45,6 +45,25 @@ analyzer_t::analyzer_t() :
     /* Nothing else: child class needs to initialize. */
 }
 
+bool analyzer_t::init_file_reader(const std::string &trace_file)
+{
+    if (trace_file.empty()) {
+        ERRMSG("Trace file name is empty\n");
+        return false;
+    }
+#ifdef HAS_ZLIB
+    // Even if the file is uncompressed, zlib's gzip interface is faster than
+    // file_reader_t's fstream in our measurements, so we always use it when
+    // available.
+    trace_iter = new compressed_file_reader_t(trace_file.c_str());
+    trace_end = new compressed_file_reader_t();
+#else
+    trace_iter = new file_reader_t(trace_file.c_str());
+    trace_end = new file_reader_t();
+#endif
+    return true;
+}
+
 analyzer_t::analyzer_t(const std::string &trace_file, analysis_tool_t **tools_in,
                        int num_tools_in) :
     success(true), trace_iter(NULL), trace_end(NULL), num_tools(num_tools_in),
@@ -57,21 +76,15 @@ analyzer_t::analyzer_t(const std::string &trace_file, analysis_tool_t **tools_in
             return;
         }
     }
-    if (trace_file.empty()) {
+    if (!init_file_reader(trace_file))
         success = false;
-        ERRMSG("Trace file name is empty\n");
-        return;
-    }
-#ifdef HAS_ZLIB
-    // Even if the file is uncompressed, zlib's gzip interface is faster than
-    // file_reader_t's fstream in our measurements, so we always use it when
-    // available.
-    trace_iter = new compressed_file_reader_t(trace_file.c_str());
-    trace_end = new compressed_file_reader_t();
-#else
-    trace_iter = new file_reader_t(trace_file.c_str());
-    trace_end = new file_reader_t();
-#endif
+}
+
+analyzer_t::analyzer_t(const std::string &trace_file) :
+    success(true), trace_iter(NULL), trace_end(NULL), num_tools(0), tools(NULL)
+{
+    if (!init_file_reader(trace_file))
+        success = false;
 }
 
 analyzer_t::~analyzer_t()
@@ -125,4 +138,18 @@ analyzer_t::print_stats()
         }
     }
     return res;
+}
+
+reader_t &
+analyzer_t::begin()
+{
+    if (!start_reading())
+        return *trace_end;
+    return *trace_iter;
+}
+
+reader_t &
+analyzer_t::end()
+{
+    return *trace_end;
 }

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,8 +40,9 @@
 #include <assert.h>
 #include <iterator>
 #include <map>
-#include "../common/memref.h"
-#include "../common/utils.h"
+// For exporting we avoid "../common" and rely on -I.
+#include "memref.h"
+#include "utils.h"
 
 class reader_t : public std::iterator<std::input_iterator_tag, memref_t>
 {

--- a/clients/drcachesim/tests/histogram-offline.templatex
+++ b/clients/drcachesim/tests/histogram-offline.templatex
@@ -6,3 +6,10 @@ icache top 10
 .*
 dcache top 10
 .*
+Cache line histogram tool results:
+icache: [0-9]+ unique cache lines
+dcache: [0-9]+ unique cache lines
+icache top 10
+.*
+dcache top 10
+.*

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2660,7 +2660,7 @@ if (CLIENT_INTERFACE)
       set(tool.histogram.offline_postcmd
         "${drcachesim_path}@-indir@drmemtrace.${histo_app}.*.dir")
       set(tool.histogram.offline_postcmd2
-        "${histo_path}@-trace@drmemtrace.${histo_app}.*.dir/drmemtrace.trace")
+        "${histo_path}@-test_mode@-trace@drmemtrace.${histo_app}.*.dir/drmemtrace.trace")
 
       find_program(GZIP gzip "gzip compression utility")
       if (UNIX AND ZLIB_FOUND AND GZIP)
@@ -2684,7 +2684,7 @@ if (CLIENT_INTERFACE)
         set(tool.histogram.gzip_postcmd2
           "${GZIP}@drmemtrace.${histo_app}.*.dir/drmemtrace.trace")
         set(tool.histogram.gzip_postcmd3
-          "${histo_path}@-trace@drmemtrace.${histo_app}.*.dir/drmemtrace.trace.gz")
+          "${histo_path}@-test_mode@-trace@drmemtrace.${histo_app}.*.dir/drmemtrace.trace.gz")
       elseif (UNIX)
         message(STATUS "gzip or zlib not found: disabling tool.histogram.gzip test")
       endif ()


### PR DESCRIPTION
Adds an alternate analyzer_t mode where a single tool controls iteration,
by exposing the iterator and making reader.h public.

Adds a test case of the external iterator to the histogram_launcher-based
tests.