### PR TITLE
i#2632 clang: fix Travis clang build

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -590,11 +590,19 @@ if (UNIX)
           set(check_deps ON)
         endif ()
       endif ()
+      # i#2632: 32-bit recent clang release builds are inserting text relocs.
+      # XXX: We don't support clang for official package builds until this is fixed.
+      if (X64 OR DEBUG OR NOT CLANG)
+        set(check_textrel ON)
+      else ()
+        set(check_textrel OFF)
+      endif ()
       add_custom_command(TARGET dynamorio
         POST_BUILD
         COMMAND ${CMAKE_COMMAND}
         # to work around i#84 be sure to put a space after -D for 1st arg at least
         ARGS -D lib=${lib_to_check}
+             -D check_textrel=${check_textrel}
              -D check_deps=${check_deps}
              -D check_libc=OFF
              -D check_interp=ON
@@ -838,6 +846,7 @@ if (UNIX)
       COMMAND ${CMAKE_COMMAND}
       # to work around i#84 be sure to put a space after -D for 1st arg at least
       ARGS -D lib=${lib_to_check}
+           -D check_textrel=ON
            -D check_deps=OFF
            -D check_libc=ON
            -D check_interp=ON

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2511,7 +2511,12 @@ thread_set_self_context(void *cxt)
     ASSERT_NOT_IMPLEMENTED(false && "need to pass 2 params to SYS_sigreturn");
     asm("jmp _dynamorio_sigreturn");
 # else
-    asm("jmp dynamorio_sigreturn");
+    /* i#2632: recent clang for 32-bit annoyingly won't do the right thing for
+     * "jmp dynamorio_sigreturn" and leaves relocs so we ensure it's PIC:
+     */
+    void (*asm_jmp_tgt)() = dynamorio_sigreturn;
+    asm("mov  %0, %%"ASM_XCX : : "m"(asm_jmp_tgt));
+    asm("jmp  *%"ASM_XCX);
 # endif /* MACOS/LINUX */
 #elif defined(AARCH64)
     ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
@@ -6633,7 +6638,12 @@ notify_and_jmp_without_stack(KSYNCH_TYPE *notify_var, byte *continuation, byte *
         asm("jmp _dynamorio_condvar_wake_and_jmp");
 # else
         asm("movl $1,(%"ASM_XAX")");
-        asm("jmp dynamorio_condvar_wake_and_jmp");
+        /* i#2632: recent clang for 32-bit annoyingly won't do the right thing for
+         * "jmp dynamorio_condvar_wake_and_jmp" and leaves relocs so we ensure it's PIC:
+         */
+        void (*asm_jmp_tgt)() = dynamorio_condvar_wake_and_jmp;
+        asm("mov  %0, %%"ASM_XDX : : "m"(asm_jmp_tgt));
+        asm("jmp  *%"ASM_XDX);
 # endif
 #elif defined(AARCHXX)
         asm("ldr "ASM_R0", %0" : : "m"(notify_var));

--- a/make/package.cmake
+++ b/make/package.cmake
@@ -109,6 +109,14 @@ if (APPLE)
   set(arg_32_only ON)
 endif ()
 
+if (NOT APPLE AND NOT arg_no32)
+  identify_clang(CMAKE_COMPILER_IS_CLANG)
+  if (CMAKE_COMPILER_IS_CLANG)
+    # i#2632: 32-bit recent clang release builds are inserting text relocs.
+    message(FATAL_ERROR "clang is not supported for package builds until i#2632 is fixed")
+  endif ()
+endif ()
+
 set(base_cache "
   BUILD_NUMBER:STRING=${arg_build}
   UNIQUE_BUILD_NUMBER:STRING=${arg_ubuild}

--- a/suite/tests/linux/signal_racesys.c
+++ b/suite/tests/linux/signal_racesys.c
@@ -101,7 +101,7 @@ try(uint64_t time)
         /* overflows for 32-bit so cast to pointer-sized */
         { (size_t)time / 1000000000, time % 1000000000 }
     };
-    struct timespec ts = { 3155760000, 0 };
+    struct timespec ts = { 3155760000U, 0 };
     int result;
 
     result = sigsetjmp(env, 1);

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -187,6 +187,7 @@ foreach (deploytgt drconfig drrun drinject)
       POST_BUILD
       COMMAND ${CMAKE_COMMAND}
       ARGS -D lib=${check_path}
+           -D check_textrel=ON
            -D check_deps=OFF
            -D check_libc=ON
            -D READELF_EXECUTABLE=${READELF_EXECUTABLE}


### PR DESCRIPTION
Fixes a clang warning in suite/tests/linux/signal_racesys.c.

Changes two inline asm direct jumps to indirect in core/unix/signal.c to
work around clang text relocations that have suddently appeared in recent
clang versions.

However, clang is still marking libdynamorio.so as TEXTREL, so I'm
disabling the TEXTREL check on libdynamorio.so for 32-bit release clang.  I
also add a check refusing to build an official package with clang until
this is fixed.

Issue: #2632