### PR TITLE
i#2634: fix early crash on latest linux kernels

### DIFF
--- a/core/unix/memquery.c
+++ b/core/unix/memquery.c
@@ -97,11 +97,13 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start/*IN/OUT*/,
              (iter.comment[0] == '\0' && prev_end != NULL &&
               prev_end != iter.vm_start))) {
             last_lib_base = iter.vm_start;
-            /* Include a prior anon mapping if contiguous and a header.  This happens
-             * for some page mapping schemes (i#2566).
+            /* Include a prior anon mapping if contiguous and a header and this
+             * mapping is not a header.  This happens for some page mapping
+             * schemes (i#2566).
              */
             if (prev_end == iter.vm_start && prev_prot == (MEMPROT_READ|MEMPROT_EXEC) &&
-                module_is_header(prev_base, prev_end - prev_base))
+                module_is_header(prev_base, prev_end - prev_base) &&
+                !module_is_header(iter.vm_start, iter.vm_end - iter.vm_start))
                 last_lib_base = prev_base;
             /* last_lib_end is used to know what's readable beyond last_lib_base */
             if (TEST(MEMPROT_READ, iter.prot))


### PR DESCRIPTION
Fixes a crash on 4.4.0-93 kernels due to the vdso being placed right before
the exe.  The bug is in the hugepage text handling from i#2566 where it
merges with a prior mapping but fails to check whether the current mapping
is also an ELF header.

Issue: #2634, #2566
Fixes #2634