### PR TITLE
i#2511 raw2trace: fix bug from refactoring

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -495,7 +495,9 @@ raw2trace_t::do_conversion()
     if (!out_file->write((char*)&entry, sizeof(entry)))
         return "Failed to write header to output file";
 
-    merge_and_process_thread_files();
+    error = merge_and_process_thread_files();
+    if (!error.empty())
+        return error;
 
     entry.type = TRACE_TYPE_FOOTER;
     entry.size = 0;


### PR DESCRIPTION
Fixes a bug in 66fa2c7 where errors during raw trace file conversion are
silently ignored and success is misleadingly reported with a truncated output
file.