### PR TITLE
DrMi#2041: improve drutil_insert_get_mem_addr_x86

### DIFF
--- a/ext/drutil/drutil.c
+++ b/ext/drutil/drutil.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -137,26 +137,29 @@ drutil_insert_get_mem_addr_x86(void *drcontext, instrlist_t *bb, instr_t *where,
          * and inserts "mov 0 => reg" for %ds and %es instead.
          */
         opnd_get_segment(memref) != DR_SEG_ES &&
-        opnd_get_segment(memref) != DR_SEG_DS) {
-        /* get segment base into scratch, then add to memref base and lea */
-        instr_t *near_in_dst = NULL;
-        if (opnd_uses_reg(memref, scratch) ||
+        opnd_get_segment(memref) != DR_SEG_DS &&
+        /* cs: is sometimes seen, as here on win10:
+         *   RPCRT4!Invoke+0x28:
+         *   76d85ea0 2eff1548d5de76  call dword ptr cs:[RPCRT4!
+         *                              __guard_check_icall_fptr (76ded548)]
+         * We assume it's flat.
+         */
+        opnd_get_segment(memref) != DR_SEG_CS) {
+        /* get segment base into dst, then add to memref base and lea */
+        instr_t *near_in_scratch = NULL;
+        if (!dr_insert_get_seg_base(drcontext, bb, where, opnd_get_segment(memref), dst)) {
+            return false;
+        }
+        if (opnd_uses_reg(memref, dst) ||
             (opnd_get_base(memref) != DR_REG_NULL &&
              opnd_get_index(memref) != DR_REG_NULL)) {
             /* have to take two steps */
+            ASSERT(scratch != DR_REG_NULL, "missing scratch reg");
             opnd_set_size(&memref, OPSZ_lea);
-            near_in_dst = INSTR_CREATE_lea(drcontext, opnd_create_reg(dst), memref);
-            PRE(bb, where, near_in_dst);
+            near_in_scratch = INSTR_CREATE_lea(drcontext, opnd_create_reg(scratch), memref);
+            PRE(bb, where, near_in_scratch);
         }
-        if (!dr_insert_get_seg_base(drcontext, bb, where, opnd_get_segment(memref),
-                                    scratch)) {
-            if (near_in_dst != NULL) {
-                instrlist_remove(bb, near_in_dst);
-                instr_destroy(drcontext, near_in_dst);
-            }
-            return false;
-        }
-        if (near_in_dst != NULL) {
+        if (near_in_scratch != NULL) {
             PRE(bb, where,
                 INSTR_CREATE_lea(drcontext, opnd_create_reg(dst),
                                  opnd_create_base_disp(dst, scratch, 1, 0, OPSZ_lea)));
@@ -166,9 +169,9 @@ drutil_insert_get_mem_addr_x86(void *drcontext, instrlist_t *bb, instr_t *where,
             int scale = opnd_get_scale(memref);
             int disp = opnd_get_disp(memref);
             if (opnd_get_base(memref) == DR_REG_NULL) {
-                base = scratch;
+                base = dst;
             } else if (opnd_get_index(memref) == DR_REG_NULL) {
-                index = scratch;
+                index = dst;
                 scale = 1;
             } else {
                 ASSERT(false, "memaddr internal error");
@@ -188,6 +191,7 @@ drutil_insert_get_mem_addr_x86(void *drcontext, instrlist_t *bb, instr_t *where,
         bool is_xlat = false;
         if (opnd_get_index(memref) == DR_REG_AL) {
             is_xlat = true;
+            ASSERT(scratch != DR_REG_NULL, "missing scratch reg");
             if (scratch != DR_REG_XAX && dst != DR_REG_XAX) {
                 /* we do not have to save xax if it is saved by caller */
                 PRE(bb, where,

--- a/ext/drutil/drutil.h
+++ b/ext/drutil/drutil.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2014 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /* drutil: DynamoRIO Instrumentation Utilities
@@ -78,8 +78,11 @@ DR_EXPORT
  * All registers used in \p memref must hold their original
  * application values in order for the proper address to be computed
  * into \p dst.  The \p dst register may overlap with the registers
- * used in \p memref, but \p scratch must be different from those used
+ * used in \p memref.  On ARM, \p scratch must be different from those used
  * in \p memref (as well as from \p dst).
+ * On x86, \p scratch will not be used unless \p memref is a far reference
+ * that either uses \p dst or is a base-disp with both a base and an index,
+ * or \p memref is a reference in the #OP_xlat instruction.
  *
  * To obtain each memory address referenced in a single-instruction
  * string loop, use drutil_expand_rep_string() to transform such loops


### PR DESCRIPTION
Changes drutil_insert_get_mem_addr_x86() to avoid using the 2nd register
when we don't have to, and documents the cases where we have to, so clients
can use registers more efficiently.

Adds an explicit SEG_CS check and assumes it's flat (we were already doing
this in helper routines: we just make it explicit up front here).