### PR TITLE
Makes instr_is_mov() return true for OP_movzx

### DIFF
--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -343,7 +343,8 @@ instr_is_mov(instr_t *instr)
             opc == OP_mov_ld ||
             opc == OP_mov_imm ||
             opc == OP_mov_seg ||
-            opc == OP_mov_priv);
+            opc == OP_mov_priv ||
+            opc == OP_movzx);
 }
 
 bool


### PR DESCRIPTION
From my understanding OP_movzx should be regarded as a mov instruction, so instr_is_mov() was modified accordingly.