### PR TITLE
i#1820,i#2020: use c++11 and unordered_map in drcachesim

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -42,6 +42,8 @@ else ()
   add_definitions(-DUNIX)
 endif ()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
 # i#2277: we use zlib if available to read compressed trace files.
 # XXX: we could ship with a zlib for Windows: today we simply don't support
 # compressed traces on Windows.

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -42,7 +42,9 @@ else ()
   add_definitions(-DUNIX)
 endif ()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+if (UNIX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif ()
 
 # i#2277: we use zlib if available to read compressed trace files.
 # XXX: we could ship with a zlib for Windows: today we simply don't support

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -39,7 +39,7 @@
 
 #include <assert.h>
 #include <iterator>
-#include <map>
+#include <unordered_map>
 // For exporting we avoid "../common" and rely on -I.
 #include "memref.h"
 #include "utils.h"
@@ -88,7 +88,7 @@ class reader_t : public std::iterator<std::input_iterator_tag, memref_t>
     addr_t cur_pc;
     addr_t next_pc;
     int bundle_idx;
-    std::map<memref_tid_t, memref_pid_t> tid2pid;
+    std::unordered_map<memref_tid_t, memref_pid_t> tid2pid;
 };
 
 #endif /* _READER_H_ */

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -36,7 +36,7 @@
 #ifndef _CACHE_SIMULATOR_H_
 #define _CACHE_SIMULATOR_H_ 1
 
-#include <map>
+#include <unordered_map>
 #include "simulator.h"
 #include "cache_stats.h"
 #include "cache.h"

--- a/clients/drcachesim/simulator/simulator.cpp
+++ b/clients/drcachesim/simulator/simulator.cpp
@@ -60,7 +60,7 @@ simulator_t::~simulator_t() {}
 int
 simulator_t::core_for_thread(memref_tid_t tid)
 {
-    std::map<memref_tid_t,int>::iterator exists = thread2core.find(tid);
+    std::unordered_map<memref_tid_t,int>::iterator exists = thread2core.find(tid);
     if (exists != thread2core.end())
         return exists->second;
     // A new thread: we want to assign it to the least-loaded core,
@@ -89,7 +89,7 @@ simulator_t::core_for_thread(memref_tid_t tid)
 void
 simulator_t::handle_thread_exit(memref_tid_t tid)
 {
-    std::map<memref_tid_t,int>::iterator exists = thread2core.find(tid);
+    std::unordered_map<memref_tid_t,int>::iterator exists = thread2core.find(tid);
     assert(exists != thread2core.end());
     assert(thread_counts[exists->second] > 0);
     --thread_counts[exists->second];

--- a/clients/drcachesim/simulator/simulator.h
+++ b/clients/drcachesim/simulator/simulator.h
@@ -36,7 +36,7 @@
 #ifndef _SIMULATOR_H_
 #define _SIMULATOR_H_ 1
 
-#include <map>
+#include <unordered_map>
 #include "caching_device_stats.h"
 #include "caching_device.h"
 #include "../analysis_tool.h"
@@ -59,7 +59,7 @@ class simulator_t : public analysis_tool_t
     int knob_num_cores;
 
     // For thread mapping to cores:
-    std::map<memref_tid_t, int> thread2core;
+    std::unordered_map<memref_tid_t, int> thread2core;
     unsigned int *thread_counts;
     unsigned int *thread_ever_counts;
 

--- a/clients/drcachesim/simulator/tlb_simulator.h
+++ b/clients/drcachesim/simulator/tlb_simulator.h
@@ -36,7 +36,7 @@
 #ifndef _TLB_SIMULATOR_H_
 #define _TLB_SIMULATOR_H_ 1
 
-#include <map>
+#include <unordered_map>
 #include "simulator.h"
 #include "tlb_stats.h"
 #include "tlb.h"

--- a/clients/drcachesim/tools/histogram.h
+++ b/clients/drcachesim/tools/histogram.h
@@ -36,7 +36,7 @@
 #ifndef _HISTOGRAM_H_
 #define _HISTOGRAM_H_ 1
 
-#include <map>
+#include <unordered_map>
 #include <string>
 #include "../analysis_tool.h"
 #include "../common/memref.h"
@@ -53,8 +53,8 @@ class histogram_t : public analysis_tool_t
 
  protected:
     /* FIXME i#2020: use unsorted_map (C++11) for faster lookup */
-    std::map<addr_t, uint64_t> icache_map;
-    std::map<addr_t, uint64_t> dcache_map;
+    std::unordered_map<addr_t, uint64_t> icache_map;
+    std::unordered_map<addr_t, uint64_t> dcache_map;
 
     unsigned int knob_line_size;
     unsigned int knob_report_top; /* most accessed lines */

--- a/clients/drcachesim/tools/reuse_distance.cpp
+++ b/clients/drcachesim/tools/reuse_distance.cpp
@@ -104,7 +104,7 @@ reuse_distance_t::process_memref(const memref_t &memref)
         type_is_prefetch(memref.data.type)) {
         ++total_refs;
         addr_t tag = memref.data.addr >> line_size_bits;
-        std::map<addr_t, line_ref_t*>::iterator it = cache_map.find(tag);
+        std::unordered_map<addr_t, line_ref_t*>::iterator it = cache_map.find(tag);
         if (it == cache_map.end()) {
             line_ref_t *ref = new line_ref_t(tag);
             // insert into the map
@@ -113,7 +113,7 @@ reuse_distance_t::process_memref(const memref_t &memref)
             ref_list->add_to_front(ref);
         } else {
             int_least64_t dist = ref_list->move_to_front(it->second);
-            std::map<int_least64_t, int_least64_t>::iterator dist_it =
+            std::unordered_map<int_least64_t, int_least64_t>::iterator dist_it =
                 dist_map.find(dist);
             if (dist_it == dist_map.end())
                 dist_map.insert(std::pair<int_least64_t, int_least64_t>(dist, 1));
@@ -127,7 +127,15 @@ reuse_distance_t::process_memref(const memref_t &memref)
     return true;
 }
 
-bool cmp_total_refs(const std::pair<addr_t, line_ref_t*> &l,
+static bool
+cmp_dist_key(const std::pair<int_least64_t, int_least64_t> &l,
+                  const std::pair<int_least64_t, int_least64_t> &r)
+{
+    return (l.first < r.first);
+}
+
+static bool
+cmp_total_refs(const std::pair<addr_t, line_ref_t*> &l,
                     const std::pair<addr_t, line_ref_t*> &r)
 {
     if (l.second->total_refs > r.second->total_refs)
@@ -139,7 +147,8 @@ bool cmp_total_refs(const std::pair<addr_t, line_ref_t*> &l,
     return false;
 }
 
-bool cmp_distant_refs(const std::pair<addr_t, line_ref_t*> &l,
+static bool
+cmp_distant_refs(const std::pair<addr_t, line_ref_t*> &l,
                       const std::pair<addr_t, line_ref_t*> &r)
 {
     if (l.second->distant_refs > r.second->distant_refs)
@@ -165,7 +174,7 @@ reuse_distance_t::print_results()
 
     double sum = 0.0;
     int_least64_t count = 0;
-    for (std::map<int_least64_t, int_least64_t>::iterator it = dist_map.begin();
+    for (std::unordered_map<int_least64_t, int_least64_t>::iterator it = dist_map.begin();
          it != dist_map.end(); ++it) {
         sum += it->first * it->second;
         count += it->second;
@@ -175,7 +184,7 @@ reuse_distance_t::print_results()
     double sum_of_squares = 0;
     int_least64_t recount = 0;
     bool have_median = false;
-    for (std::map<int_least64_t, int_least64_t>::iterator it = dist_map.begin();
+    for (std::unordered_map<int_least64_t, int_least64_t>::iterator it = dist_map.begin();
          it != dist_map.end(); ++it) {
         double diff = it->first - mean;
         sum_of_squares += (diff * diff) * it->second;
@@ -195,8 +204,10 @@ reuse_distance_t::print_results()
         std::cerr << "Distance" << std::setw(12) << "Count"
                   << "  Percent  Cumulative\n";
         double cum_percent = 0;
-        for (std::map<int_least64_t, int_least64_t>::iterator it = dist_map.begin();
-             it != dist_map.end(); ++it) {
+        std::vector<std::pair<int_least64_t, int_least64_t> > sorted(dist_map.size());
+        std::partial_sort_copy(dist_map.begin(), dist_map.end(),
+                               sorted.begin(), sorted.end(), cmp_dist_key);
+        for (auto it = sorted.begin(); it != sorted.end(); ++it) {
             double percent = it->second / static_cast<double>(count);
             cum_percent += percent;
             std::cerr << std::setw(8) << it->first

--- a/clients/drcachesim/tools/reuse_distance.cpp
+++ b/clients/drcachesim/tools/reuse_distance.cpp
@@ -136,7 +136,7 @@ cmp_dist_key(const std::pair<int_least64_t, int_least64_t> &l,
 
 static bool
 cmp_total_refs(const std::pair<addr_t, line_ref_t*> &l,
-                    const std::pair<addr_t, line_ref_t*> &r)
+               const std::pair<addr_t, line_ref_t*> &r)
 {
     if (l.second->total_refs > r.second->total_refs)
         return true;
@@ -144,12 +144,14 @@ cmp_total_refs(const std::pair<addr_t, line_ref_t*> &l,
         return false;
     if (l.second->distant_refs > r.second->distant_refs)
         return true;
+    if (l.second->distant_refs < r.second->distant_refs)
+        return false;
     return l.first < r.first;
 }
 
 static bool
 cmp_distant_refs(const std::pair<addr_t, line_ref_t*> &l,
-                      const std::pair<addr_t, line_ref_t*> &r)
+                 const std::pair<addr_t, line_ref_t*> &r)
 {
     if (l.second->distant_refs > r.second->distant_refs)
         return true;
@@ -157,6 +159,8 @@ cmp_distant_refs(const std::pair<addr_t, line_ref_t*> &l,
         return false;
     if (l.second->total_refs > r.second->total_refs)
         return true;
+    if (l.second->total_refs < r.second->total_refs)
+        return false;
     return l.first < r.first;
 }
 
@@ -184,8 +188,10 @@ reuse_distance_t::print_results()
     double sum_of_squares = 0;
     int_least64_t recount = 0;
     bool have_median = false;
-    for (std::unordered_map<int_least64_t, int_least64_t>::iterator it = dist_map.begin();
-         it != dist_map.end(); ++it) {
+    std::vector<std::pair<int_least64_t, int_least64_t> > sorted(dist_map.size());
+    std::partial_sort_copy(dist_map.begin(), dist_map.end(),
+                           sorted.begin(), sorted.end(), cmp_dist_key);
+    for (auto it = sorted.begin(); it != sorted.end(); ++it) {
         double diff = it->first - mean;
         sum_of_squares += (diff * diff) * it->second;
         if (!have_median) {
@@ -204,9 +210,6 @@ reuse_distance_t::print_results()
         std::cerr << "Distance" << std::setw(12) << "Count"
                   << "  Percent  Cumulative\n";
         double cum_percent = 0;
-        std::vector<std::pair<int_least64_t, int_least64_t> > sorted(dist_map.size());
-        std::partial_sort_copy(dist_map.begin(), dist_map.end(),
-                               sorted.begin(), sorted.end(), cmp_dist_key);
         for (auto it = sorted.begin(); it != sorted.end(); ++it) {
             double percent = it->second / static_cast<double>(count);
             cum_percent += percent;

--- a/clients/drcachesim/tools/reuse_distance.cpp
+++ b/clients/drcachesim/tools/reuse_distance.cpp
@@ -131,7 +131,7 @@ static bool
 cmp_dist_key(const std::pair<int_least64_t, int_least64_t> &l,
                   const std::pair<int_least64_t, int_least64_t> &r)
 {
-    return (l.first < r.first);
+    return l.first < r.first;
 }
 
 static bool
@@ -144,7 +144,7 @@ cmp_total_refs(const std::pair<addr_t, line_ref_t*> &l,
         return false;
     if (l.second->distant_refs > r.second->distant_refs)
         return true;
-    return false;
+    return l.first < r.first;
 }
 
 static bool
@@ -157,7 +157,7 @@ cmp_distant_refs(const std::pair<addr_t, line_ref_t*> &l,
         return false;
     if (l.second->total_refs > r.second->total_refs)
         return true;
-    return false;
+    return l.first < r.first;
 }
 
 bool

--- a/clients/drcachesim/tools/reuse_distance.h
+++ b/clients/drcachesim/tools/reuse_distance.h
@@ -36,7 +36,7 @@
 #ifndef _REUSE_DISTANCE_H_
 #define _REUSE_DISTANCE_H_ 1
 
-#include <map>
+#include <unordered_map>
 #include <string>
 #include <assert.h>
 #include <iostream>
@@ -75,9 +75,9 @@ class reuse_distance_t : public analysis_tool_t
 
  protected:
     /* XXX i#2020: use unsorted_map (C++11) for faster lookup */
-    std::map<addr_t, line_ref_t*> cache_map;
+    std::unordered_map<addr_t, line_ref_t*> cache_map;
     // This is our reuse distance histogram.
-    std::map<int_least64_t, int_least64_t> dist_map;
+    std::unordered_map<int_least64_t, int_least64_t> dist_map;
     line_ref_list_t *ref_list;
 
     unsigned int knob_line_size;

--- a/clients/drcachesim/tools/reuse_time.h
+++ b/clients/drcachesim/tools/reuse_time.h
@@ -30,7 +30,7 @@
  * DAMAGE.
  */
 
-#include <map>
+#include <unordered_map>
 #include <string>
 
 #include "analysis_tool.h"
@@ -44,9 +44,9 @@ class reuse_time_t : public analysis_tool_t
     virtual bool print_results();
 
  protected:
-    std::map<addr_t, int_least64_t> time_map;
+    std::unordered_map<addr_t, int_least64_t> time_map;
     int_least64_t time_stamp;
-    std::map<int_least64_t, int_least64_t> reuse_time_histogram;
+    std::unordered_map<int_least64_t, int_least64_t> reuse_time_histogram;
 
     unsigned int knob_verbose;
     unsigned int knob_line_size;

--- a/clients/drcachesim/tracer/physaddr.cpp
+++ b/clients/drcachesim/tracer/physaddr.cpp
@@ -111,7 +111,7 @@ physaddr_t::virtual2physical(addr_t virt)
             return last_ppage + PAGE_OFFS(virt);
         // XXX i#1703: add (debug-build-only) internal stats here and
         // on cache_t::request() fastpath.
-        std::map<addr_t,addr_t>::iterator exists = v2p.find(vpage);
+        std::unordered_map<addr_t,addr_t>::iterator exists = v2p.find(vpage);
         if (exists != v2p.end()) {
             last_vpage = vpage;
             last_ppage = exists->second;

--- a/clients/drcachesim/tracer/physaddr.h
+++ b/clients/drcachesim/tracer/physaddr.h
@@ -37,7 +37,7 @@
 #define _PHYSADDR_H_ 1
 
 #include <fstream>
-#include <map>
+#include <unordered_map>
 #include "../common/trace_entry.h"
 
 class physaddr_t
@@ -53,7 +53,7 @@ class physaddr_t
     addr_t last_vpage;
     addr_t last_ppage;
     int fd;
-    std::map<addr_t,addr_t> v2p;
+    std::unordered_map<addr_t,addr_t> v2p;
     unsigned int count;
 #endif
 };

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -529,14 +529,16 @@ droption_t<std::string>::default_as_string() const
 template<> inline std::string
 droption_t<int>::default_as_string() const
 {
-    return static_cast< std::ostringstream & >
-        ((std::ostringstream() << std::dec << defval)).str();
+    std::ostringstream stream;
+    stream << std::dec << defval;
+    return stream.str();
 }
 template<> inline std::string
 droption_t<unsigned int>::default_as_string() const
 {
-    return static_cast< std::ostringstream & >
-        ((std::ostringstream() << std::dec << defval)).str();
+    std::ostringstream stream;
+    stream << std::dec << defval;
+    return stream.str();
 }
 template<> inline std::string
 droption_t<bool>::default_as_string() const
@@ -558,8 +560,9 @@ droption_t<bytesize_t>::default_as_string() const
         suffix = "K";
         val /= 1024;
     }
-    return static_cast< std::ostringstream & >
-        ((std::ostringstream() << std::dec << val)).str() + suffix;
+    std::ostringstream stream;
+    stream << std::dec << val;
+    return stream.str() + suffix;
 }
 template<> inline std::string
 droption_t<twostring_t>::default_as_string() const

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -529,13 +529,13 @@ droption_t<std::string>::default_as_string() const
 template<> inline std::string
 droption_t<int>::default_as_string() const
 {
-    return dynamic_cast< std::ostringstream & >
+    return static_cast< std::ostringstream & >
         ((std::ostringstream() << std::dec << defval)).str();
 }
 template<> inline std::string
 droption_t<unsigned int>::default_as_string() const
 {
-    return dynamic_cast< std::ostringstream & >
+    return static_cast< std::ostringstream & >
         ((std::ostringstream() << std::dec << defval)).str();
 }
 template<> inline std::string
@@ -558,7 +558,7 @@ droption_t<bytesize_t>::default_as_string() const
         suffix = "K";
         val /= 1024;
     }
-    return dynamic_cast< std::ostringstream & >
+    return static_cast< std::ostringstream & >
         ((std::ostringstream() << std::dec << val)).str() + suffix;
 }
 template<> inline std::string

--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -380,8 +380,11 @@ function (_DR_set_compile_flags target tgt_cflags)
       # We can't do a test of the entire flag set at once b/c we add
       # "-fno-stack-protector" for the client and not for standalone.
       get_source_file_property(cur_flags ${src} COMPILE_FLAGS)
+      # Avoid -std=c++* from messing w/ our regex match.
+      string(REPLACE "++" "\\+\\+" cur_flags_esc ${cur_flags})
       foreach (flag ${tgt_flags})
-        if (NOT cur_flags MATCHES " ${flag}")
+        string(REPLACE "++" "\\+\\+" flag_esc ${flag})
+        if (NOT cur_flags_esc MATCHES " ${flag_esc}")
           _DR_append_property_string(SOURCE ${src} COMPILE_FLAGS "${flag}")
         endif ()
       endforeach ()


### PR DESCRIPTION
Adds -std=c++11 to the build flags for drcachesim.
Adds handling of -std=c++11 in the client flags processing code (i#1820).

Switches all instances of std::map to std::unordered_map in drcachesim.
Adds explicit sorting for printing histograms in the reuse_distance and
reuse_time tools (yes it's still faster to be unordered as the print time
is not on the critical path).

Issue: #2020
Fixes #1820