### PR TITLE
i#2538: fix regression on paths with spaces

### DIFF
--- a/core/unix/memquery_linux.c
+++ b/core/unix/memquery_linux.c
@@ -80,10 +80,10 @@ static mutex_t maps_iter_buf_lock = INIT_LOCK_FREE(maps_iter_buf_lock);
 /* these are defined in /usr/src/linux/fs/proc/array.c */
 #define MAPS_LINE_LENGTH        4096
 /* for systems with sizeof(void*) == 4: */
-#define MAPS_LINE_FORMAT4     "%08lx-%08lx %s %08lx %*s "UINT64_FORMAT_STRING" %4096s"
+#define MAPS_LINE_FORMAT4  "%08lx-%08lx %s %08lx %*s "UINT64_FORMAT_STRING" %4096[^\n]"
 #define MAPS_LINE_MAX4  49 /* sum of 8  1  8  1 4 1 8 1 5 1 10 1 */
 /* for systems with sizeof(void*) == 8: */
-#define MAPS_LINE_FORMAT8     "%016lx-%016lx %s %016lx %*s "UINT64_FORMAT_STRING" %4096s"
+#define MAPS_LINE_FORMAT8  "%016lx-%016lx %s %016lx %*s "UINT64_FORMAT_STRING" %4096[^\n]"
 #define MAPS_LINE_MAX8  73 /* sum of 16  1  16  1 4 1 16 1 5 1 10 1 */
 
 #define MAPS_LINE_MAX   MAPS_LINE_MAX8

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1522,6 +1522,8 @@ endfunction(optimize)
 message(STATUS "Processing tests and generating expected output patterns")
 
 tobuild(common.broadfun common/broadfun.c)
+# Make sure we test running a path with spaces (to avoid regressions like i#2538).
+set_target_properties(common.broadfun PROPERTIES OUTPUT_NAME "common.broadfun spaces")
 if (DEBUG)
   torunonly(common.logstderr common.broadfun common/logstderr.c
     "-log_to_stderr -loglevel 1 -logmask 2" "")


### PR DESCRIPTION
Fixes a regression on handling application paths with spaces by replacing
the %s in the maps file scanf format string.

Adds a test with a space in the name by renaming common.broadfun.

Fixes #2538