### PR TITLE
Fix get_remote_process_ldr_status() failure check

### DIFF
--- a/core/win32/syscall.c
+++ b/core/win32/syscall.c
@@ -897,7 +897,7 @@ align_page_boundary(dcontext_t *dcontext,
 bool
 is_newly_created_process(HANDLE process_handle)
 {
-    uint remote_ldr_data;
+    int remote_ldr_data;
     /* We check based on - trait 3) PEB.Ldr
      *    The Ldr entry is created by the running process itself later */
 


### PR DESCRIPTION
get_remote_process_ldr_status() returns 'int' but remote_ldr_data was 'uint'
and 'remote_ldr_data >= 0' was always true