### PR TITLE
i#2659 syscall restart: switch to using SA_RESTART

### DIFF
--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -1354,15 +1354,6 @@ mangle_syscall_arch(dcontext_t *dcontext, instrlist_t *ilist, uint flags,
      * mechanism) before the system call, and restore it afterwards.
      */
     ASSERT(DR_REG_STOLEN_MIN > DR_REG_SYSNUM);
-
-    /* We have to save r0 in case the syscall is interrupted.  To restart
-     * it, we need to replace the kernel's -EINTR in r0 with the original
-     * app arg.
-     * XXX optimization: we could try to get the syscall number and avoid
-     * this for non-auto-restart syscalls.
-     */
-    PRE(ilist, instr,
-        instr_create_save_to_tls(dcontext, DR_REG_R0, TLS_REG0_SLOT));
 }
 
 # ifdef UNIX

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -252,6 +252,14 @@ init_build_bb(build_bb_t *bb, app_pc start_pc, bool app_interp, bool for_cache,
               overlap_info_t *overlap_info)
 {
     memset(bb, 0, sizeof(*bb));
+#if defined(LINUX) && defined(X86_32)
+    /* With SA_RESTART (i#2659) we end up interpreting the int 0x80 in vsyscall,
+     * whose fall-through hits our hook.  We avoid interpreting our own hook
+     * by shifting it to the displaced pc.
+     */
+    if (start_pc == vsyscall_sysenter_return_pc)
+        start_pc = vsyscall_sysenter_displaced_pc;
+#endif
     bb->check_vm_area = true;
     bb->start_pc = start_pc;
     bb->app_interp = app_interp;

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -700,7 +700,6 @@ mangle_syscall(dcontext_t *dcontext, instrlist_t *ilist, uint flags,
         sysnum_is_not_restartable(ilist_find_sysnum(ilist, instr))) {
         /* i#1216: we insert a nop instr right after inlined non-auto-restart
          * syscall to make it a safe point for suspending.
-         * XXX-i#1216-c#2: we still need handle auto-restart syscall
          */
         instr_t *nop = XINST_CREATE_nop(dcontext);
         /* We make a fake app nop instr for easy handling in recreate_app_state.

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -6978,6 +6978,10 @@ dr_fragment_app_pc(void *tag)
             SYSLOG_INTERNAL_WARNING_ONCE("dr_fragment_app_pc is a DR/client pc");
         }
     });
+#elif defined(LINUX) && defined(X86_32)
+    /* Point back at our hook, undoing the bb shift for SA_RESTART (i#2659). */
+    if ((app_pc)tag == vsyscall_sysenter_displaced_pc)
+        tag = vsyscall_sysenter_return_pc;
 #endif
     return tag;
 }

--- a/core/synch.h
+++ b/core/synch.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -145,6 +145,9 @@ synch_thread_exit(dcontext_t *dcontext);
 
 bool
 thread_synch_state_no_xfer(dcontext_t *dcontext);
+
+bool
+thread_synch_check_state(dcontext_t *dcontext, thread_synch_permission_t desired_perm);
 
 /* Only valid while holding all_threads_synch_lock and thread_initexit_lock.  Set to
  * whether synch_with_thread was successful.

--- a/core/translate.c
+++ b/core/translate.c
@@ -936,7 +936,9 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
          is_after_main_do_syscall_addr(tdcontext, mcontext->pc) ||
          /* Check for pointing right at sysenter, for i#1145 */
          mcontext->pc + SYSENTER_LENGTH == vsyscall_syscall_end_pc ||
-         is_after_main_do_syscall_addr(tdcontext, mcontext->pc + SYSENTER_LENGTH))) {
+         is_after_main_do_syscall_addr(tdcontext, mcontext->pc + SYSENTER_LENGTH) ||
+         /* Check for pointing at the sysenter-restart int 0x80 for i#2659 */
+         mcontext->pc + SYSENTER_LENGTH == vsyscall_sysenter_return_pc)) {
         /* If at do_syscall yet not yet in the kernel (or the do_syscall still uses
          * int: i#2005), we need to translate to vsyscall, for detach (i#95).
          */

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -2580,6 +2580,15 @@ os_process_under_dynamorio_initiate(dcontext_t *dcontext)
     /* We only support regular process-wide signal handlers for delayed takeover. */
     /* i#2161: we ignore alarm signals during the attach process to avoid races. */
     signal_reinstate_handlers(dcontext, true/*ignore alarm*/);
+    /* XXX: there's a tradeoff here: we have a race when we remove the hook
+     * because dr_app_stop() has no barrier and a thread sent native might
+     * resume from vsyscall after we remove the hook.  However, if we leave the
+     * hook, then the next takeover signal might hit a native thread that's
+     * inside DR just to go back native after having hit the hook.  For now we
+     * remove the hook and rely on translate_from_synchall_to_dispatch() moving
+     * threads from vsyscall to our gencode and not relying on the hook being
+     * present to finish up their go-native code.
+     */
     hook_vsyscall(dcontext, false);
 }
 

--- a/core/unix/signal_linux.c
+++ b/core/unix/signal_linux.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -215,11 +215,15 @@ bool
 sysnum_is_not_restartable(int sysnum)
 {
     /* Check the list of non-restartable syscalls.
+     * Since we only check the number, we're inaccurate!
+     * We err on the side of thinking more things are non-restartable
+     * than actually are, as this is only really used for inserting
+     * nops to ensure post-syscall points are safe spots, and too many
+     * nops is better than too few.
      * We're missing:
      * + SYS_read from an inotify file descriptor.
      * We're overly aggressive on:
-     * + Socket interfaces: supposed to restart if no timeout has been set
-     *   but we never restart for simplicity for now.
+     * + Socket interfaces: supposed to restart if no timeout has been set.
      */
     return (
 #ifdef SYS_pause

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1918,6 +1918,7 @@ if (CLIENT_INTERFACE)
     endif (X86 OR AARCH64)
     if (X86) # FIXME i#1551, i#1569: port asm to ARM and AArch64
       tobuild_ci(client.signal client-interface/signal.c "" "" "")
+      target_link_libraries(client.signal ${libpthread})
       tobuild_ci(client.cbr-retarget client-interface/cbr-retarget.c "" "" "")
     endif (X86)
   else (UNIX)

--- a/suite/tests/client-interface/signal.dll.c
+++ b/suite/tests/client-interface/signal.dll.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -37,8 +38,16 @@
 #include "dr_api.h"
 #include "client_tools.h"
 #include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/syscall.h>
 
 static app_pc redirect_tag;
+
+static void *child_alive;
+static void *child_dead;
+static void *sigchld_received;
+static pid_t child_pid, child_tid;
 
 static
 dr_signal_action_t signal_event(void *dcontext, dr_siginfo_t *info)
@@ -51,14 +60,14 @@ dr_signal_action_t signal_event(void *dcontext, dr_siginfo_t *info)
         static int count_urg = -1;
         count_urg++;
         switch (count_urg) {
-            /* test delayable signal with each return value */
-            case 0: return DR_SIGNAL_DELIVER;
-            case 1: return DR_SIGNAL_SUPPRESS;
-            case 2: return DR_SIGNAL_BYPASS;
-            case 3: return DR_SIGNAL_DELIVER;
-            case 4: return DR_SIGNAL_SUPPRESS;
-            case 5: return DR_SIGNAL_BYPASS;
-            default: dr_fprintf(STDERR, "too many SIGURG\n");
+        /* test delayable signal with each return value */
+        case 0: return DR_SIGNAL_DELIVER;
+        case 1: return DR_SIGNAL_SUPPRESS;
+        case 2: return DR_SIGNAL_BYPASS;
+        case 3: return DR_SIGNAL_DELIVER;
+        case 4: return DR_SIGNAL_SUPPRESS;
+        case 5: return DR_SIGNAL_BYPASS;
+        default: dr_fprintf(STDERR, "too many SIGURG\n");
         }
     } else if (info->sig == SIGTERM) {
         return DR_SIGNAL_SUPPRESS;
@@ -79,6 +88,8 @@ dr_signal_action_t signal_event(void *dcontext, dr_siginfo_t *info)
             info->mcontext->xax = info->mcontext->xcx;
             return DR_SIGNAL_DELIVER;
         }
+    } else if (info->sig == SIGCHLD) {
+        dr_event_signal(sigchld_received);
     }
 
     return DR_SIGNAL_DELIVER;
@@ -106,9 +117,59 @@ bb_event(void *drcontext, void* tag, instrlist_t *bb, bool for_trace, bool trans
     return DR_EMIT_DEFAULT;
 }
 
+static void
+thread_func(void *arg)
+{
+    int fd = (int)(long) arg;
+    char buf[16];
+    child_pid = getpid();
+    child_tid = syscall(SYS_gettid);
+    dr_event_signal(child_alive);
+    dr_mark_safe_to_suspend(dr_get_current_drcontext(), true);
+    int res = read(fd, buf, 2);
+    if (res < 0)
+        perror("error during read");
+    else
+        dr_fprintf(STDERR, "got %d bytes == %d %d\n", res, buf[0], buf[1]);
+    dr_mark_safe_to_suspend(dr_get_current_drcontext(), false);
+    close(fd);
+    dr_event_signal(child_dead);
+}
+
 DR_EXPORT
 void dr_init(client_id_t id)
 {
     dr_register_bb_event(bb_event);
     dr_register_signal_event(signal_event);
+
+    /* We test syscall auto-restart (i#2659) by having another thread
+     * sit at a blocking read while it receives signals.
+     * It's hard to arrange this w/ an app thread and app signals so we use a
+     * client thread and direct signals.
+     */
+    int pipefd[2];
+    int res = pipe(pipefd);
+    ASSERT(res != -1);
+    child_alive = dr_event_create();
+    child_dead = dr_event_create();
+    sigchld_received = dr_event_create();
+    bool success = dr_create_client_thread(thread_func, (void*)(long)pipefd[0]);
+    ASSERT(success);
+    dr_event_wait(child_alive);
+    /* XXX: there's no easy race-free solution here: we need the thread to
+     * be inside the read().
+     */
+    sleep(1);
+    /* Send a default-ignore signal */
+    res = syscall(SYS_tgkill, child_pid, child_tid, SIGCHLD);
+    ASSERT(res == 0);
+    dr_event_wait(sigchld_received);
+    /* Now finish up */
+    write(pipefd[1], "ab", 2);
+    close(pipefd[1]);
+    dr_event_wait(child_dead);
+
+    dr_event_destroy(child_alive);
+    dr_event_destroy(child_dead);
+    dr_event_destroy(sigchld_received);
 }

--- a/suite/tests/client-interface/signal.expect
+++ b/suite/tests/client-interface/signal.expect
@@ -1,8 +1,8 @@
-Sending SIGURG
-signal event 0 sig=23
-Got SIGURG
+signal event 0 sig=17
+got 2 bytes == 97 98
 Sending SIGURG
 signal event 1 sig=23
+Got SIGURG
 Sending SIGURG
 signal event 2 sig=23
 Sending SIGURG
@@ -11,16 +11,18 @@ Sending SIGURG
 signal event 4 sig=23
 Sending SIGURG
 signal event 5 sig=23
+Sending SIGURG
+signal event 6 sig=23
 Sending SIGTERM
-signal event 6 sig=15
+signal event 7 sig=15
 Redirected
 Sending SIGUSR2
-signal event 7 sig=12
+signal event 8 sig=12
 Redirected
-signal event 8 sig=11
 signal event 9 sig=11
+signal event 10 sig=11
 Got SIGSEGV
 Sending SIGUSR1
-signal event 10 sig=10
+signal event 11 sig=10
 Got SIGUSR1
 Done

--- a/suite/tests/linux/eintr.c
+++ b/suite/tests/linux/eintr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -136,6 +136,7 @@ main(int argc, char **argv)
     pthread_mutex_destroy(&lock);
 
     print("all done\n");
+    close(pipefd[1]);
 
     return 0;
 }


### PR DESCRIPTION
Changes the strategy for handling interrupted syscalls to use SA_RESTART,
which adds easy handling of interruptions of auto-restart syscalls in
native code, such as during attach or in client C code.

This also simplifies auto-restart of app syscalls, as we now have foolproof
identification of auto-restart situations (before our syscall-number-based
check was inaccurate) and the kernel has restored the clobbered register
value for us.  That eliminates the TLS store we were doing on ARM and the
decode on x86.

For fragment-inlined syscalls, we don't need to do anything anymore: we
deliver the signal immediately and the kernel has already set up the proper
resumption state.

For gencode syscalls, for sane post-syscall handling, we leverage i#1145's
auto-restart emulation and undo what the kernel did.  This lets us go back
to dispatch for a clean sequence of events.

Updates synch and translation checks for post-syscall to also account for
syscall-restart locations.

For sysenter, this change means we now see threads at the int 0x80 restart
point whose fall-through is our vsyscall hook.  To avoid interpreting our
own hook we map that PC to our displaced code, and mapping back in
dr_fragment_app_pc().

Fixes a race between going native and unhooking the vsyscall (to avoid
takeover problems) by redirecting threads at vsyscall or the int 0x80
restart to our own gencode.

Adds a test of a client making a blocking auto-restart syscall to ensure it
is not terminated with EINTR.  This was not simple to arrange in a non-racy
manner and required adding a new feature of immediately delivering a signal
that arrives in DR or client code where the receiving thread is at a safe
point (because if we delay, the test cannot ensure the signal was received).

Fixes #2659