### PR TITLE
i#2145 appveyor: mark api.detach and api.startstop as flaky

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -120,12 +120,15 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                    'code_api|win32.reload-newaddr' => 1,
                                    'code_api|client.pcache-use' => 1,
                                    'code_api|api.detach' => 1, # i#2246
+                                   'code_api|api.startstop' => 1, # i#2093
                                    'code_api|client.nudge_ex' => 1);
             %ignore_failures_64 = ('code_api|common.floatpc_xl8all' => 1,
                                    'code_api|win32.reload-newaddr' => 1,
                                    'code_api|client.loader' => 1,
                                    'code_api|client.drmgr-test' => 1, # i#1369
                                    'code_api|client.nudge_ex' => 1,
+                                   'code_api|api.detach' => 1, # i#2246
+                                   'code_api|api.startstop' => 1, # i#2093
                                    'code_api|api.static_noclient' => 1,
                                    'code_api|api.static_noinit' => 1);
             $issue_no = "#2145";


### PR DESCRIPTION
Marks api.detach and api.startstop as flaky as they have been failing
occasionally on Appveyor.

Issue: #2093, #2246, #2145