### PR TITLE
Fix Travis Mac setup failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,9 @@ matrix:
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:
   - uname -a
-  - if [[ "`uname`" == "Darwin" ]]; then brew install nasm; fi
+  # FIXME: remove the "brew update" step once Travis fixes their Mac VM's
+  # on 11/15/17.  Xref https://github.com/travis-ci/travis-ci/issues/8552.
+  - if [[ "`uname`" == "Darwin" ]]; then brew update; brew install nasm; fi
   # ImageMagick is present but these are not:
   - >
       if [[ "`uname`" == "Linux" ]]; then


### PR DESCRIPTION
Adds a "brew update" step to work around Travis Mac problems until they
upgrade their VM's.  Xref https://github.com/travis-ci/travis-ci/issues/8552.