### PR TITLE
i#2645 delayed burst, part 1: Add delayed-tracing to drmemtrace

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -188,6 +188,8 @@ Further non-compatibility-affecting changes include:
    default, so simulation results may not match those in prior releases.
    It can be disabled by running with "-data_prefetcher none" (see \ref
    sec_drcachesim_ops).
+ - Added a last-level cache miss recording feature to drcachesim.
+ - Added a delayed tracing feature to drcachesim.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -152,6 +152,13 @@ droption_t<bytesize_t> op_max_trace_size
  "of one internal buffer.  Once reached, instrumentation continues for that thread, "
  "but no further data is recorded.");
 
+droption_t<bytesize_t> op_trace_after_instrs
+(DROPTION_SCOPE_CLIENT, "trace_after_instrs", 0,
+ "Do not start tracing until N instructions",
+ "If non-zero, this causes tracing to be suppressed until this many dynamic instruction "
+ "executions are observed.  At that point, regular tracing is put into place.  Use "
+ "-max_trace_size to set a limit on the subsequent trace length.");
+
 droption_t<bool> op_online_instr_types
 (DROPTION_SCOPE_CLIENT, "online_instr_types", false,
  "Whether online traces should distinguish instr types",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -70,6 +70,7 @@ extern droption_t<bytesize_t> op_L0D_size;
 extern droption_t<bool> op_use_physical;
 extern droption_t<unsigned int> op_virt2phys_freq;
 extern droption_t<bytesize_t> op_max_trace_size;
+extern droption_t<bytesize_t> op_trace_after_instrs;
 extern droption_t<bool> op_online_instr_types;
 extern droption_t<std::string> op_replace_policy;
 extern droption_t<std::string> op_data_prefetcher;

--- a/clients/drcachesim/tests/drcachesim-delay-simple.templatex
+++ b/clients/drcachesim/tests/drcachesim-delay-simple.templatex
@@ -1,0 +1,22 @@
+Hit delay threshold: enabling tracing.
+Hello, world!
+---- <application exited with code 0> ----
+Cache simulation results:
+Core #0 \(1 thread\(s\)\)
+  L1I stats:
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*.
+.*   Miss rate:                   *[0-9,\.]*%
+  L1D stats:
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*.
+.*   Miss rate:                   *[0-9,\.]*%
+Core #1 \(0 thread\(s\)\)
+Core #2 \(0 thread\(s\)\)
+Core #3 \(0 thread\(s\)\)
+LL stats:
+    Hits:                         *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*..
+.*   Local miss rate:             *[0-9,\.]*%
+    Child hits:                   *[0-9,\.]*.
+    Total miss rate:              *[0-9,\.]*%

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -479,12 +479,12 @@ cblist_shift_and_resize(cb_list_t *l, uint insert_at)
     size_t orig_num = l->num;
     if (insert_at > l->num)
         return -1;
-    l->num++;
     /* check for invalid slots we can easily use */
     if (insert_at < l->num && !cblist_get_pri(l, insert_at)->valid)
         return insert_at;
     else if (insert_at > 0 && !cblist_get_pri(l, insert_at - 1)->valid)
         return insert_at - 1;
+    l->num++;
     if (l->num >= l->capacity) {
         /* do the shift implicitly while resizing */
         size_t new_cap = l->capacity * 2;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2455,6 +2455,14 @@ if (CLIENT_INTERFACE)
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.drcachesim.filter_rawtemp ON) # no preprocessor
 
+      torunonly_ci(tool.drcachesim.delay ${ci_shared_app} drcachesim
+        "drcachesim-delay-simple.c" # for templatex basename
+        "-ipc_name ${IPC_PREFIX}drtestdelay -trace_after_instrs 50000" "" "")
+        set(tool.drcachesim.delay_toolname "drcachesim")
+        set(tool.drcachesim.delay_basedir
+        "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+      set(tool.drcachesim.delay_rawtemp ON) # no preprocessor
+
       # FIXME i#1799: clang does not support "asm goto" used in annotation
       # FIXME i#1551, i#1569: get working on ARM/AArch64
       if (NOT ARM AND NOT AARCH64 AND NOT CMAKE_COMPILER_IS_CLANG)


### PR DESCRIPTION
Adds a new option -trace_after_instrs which counts instructions and once
the dynamic instruction count hits the specified threshold, tracing is only
then enabled.  This is more efficient than the -skip_refs simulation-side
option.

Fixes a drmgr bug hit by the dynamic event removal and adding exercised by
this feature.

Adds a test of the option.

Issue: #2645