### PR TITLE
i#2006 drcachesim generalization: make subclassing easier

### DIFF
--- a/clients/drcachesim/reader/compressed_file_reader.h
+++ b/clients/drcachesim/reader/compressed_file_reader.h
@@ -47,7 +47,7 @@ class compressed_file_reader_t : public reader_t
     explicit compressed_file_reader_t(const char *file_name);
     virtual ~compressed_file_reader_t();
     virtual bool init();
-    bool is_complete();
+    virtual bool is_complete();
 
  protected:
     virtual trace_entry_t * read_next_entry();

--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -50,7 +50,7 @@ class file_reader_t : public reader_t
     explicit file_reader_t(const char *file_name);
     virtual ~file_reader_t();
     virtual bool init();
-    bool is_complete();
+    virtual bool is_complete();
 
  protected:
     virtual trace_entry_t * read_next_entry();

--- a/clients/drcachesim/tools/histogram.h
+++ b/clients/drcachesim/tools/histogram.h
@@ -52,7 +52,6 @@ class histogram_t : public analysis_tool_t
     virtual bool print_results();
 
  protected:
-    /* FIXME i#2020: use unsorted_map (C++11) for faster lookup */
     std::unordered_map<addr_t, uint64_t> icache_map;
     std::unordered_map<addr_t, uint64_t> dcache_map;
 

--- a/clients/drcachesim/tools/reuse_distance.h
+++ b/clients/drcachesim/tools/reuse_distance.h
@@ -74,7 +74,6 @@ class reuse_distance_t : public analysis_tool_t
     static unsigned int knob_verbose;
 
  protected:
-    /* XXX i#2020: use unsorted_map (C++11) for faster lookup */
     std::unordered_map<addr_t, line_ref_t*> cache_map;
     // This is our reuse distance histogram.
     std::unordered_map<int_least64_t, int_least64_t> dist_map;


### PR DESCRIPTION
Marks the file_reader_t::is_complete() and analyzer_t::init_file_reader()
methods as virtual to provide more flexibility in subclassing.

Cleans up some now-stale comments about drcachesim optimizations.

Issue: #2006