### PR TITLE
i#2645 delayed burst, part 2: add -exit_after_tracing

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -159,6 +159,12 @@ droption_t<bytesize_t> op_trace_after_instrs
  "executions are observed.  At that point, regular tracing is put into place.  Use "
  "-max_trace_size to set a limit on the subsequent trace length.");
 
+droption_t<bytesize_t> op_exit_after_tracing
+(DROPTION_SCOPE_CLIENT, "exit_after_tracing", 0,
+ "Exit the process after tracing N references",
+ "If non-zero, after tracing the specified number of references, the process is "
+ "exited with an exit code of 0.  The reference count is approximate.");
+
 droption_t<bool> op_online_instr_types
 (DROPTION_SCOPE_CLIENT, "online_instr_types", false,
  "Whether online traces should distinguish instr types",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -71,6 +71,7 @@ extern droption_t<bool> op_use_physical;
 extern droption_t<unsigned int> op_virt2phys_freq;
 extern droption_t<bytesize_t> op_max_trace_size;
 extern droption_t<bytesize_t> op_trace_after_instrs;
+extern droption_t<bytesize_t> op_exit_after_tracing;
 extern droption_t<bool> op_online_instr_types;
 extern droption_t<std::string> op_replace_policy;
 extern droption_t<std::string> op_data_prefetcher;

--- a/clients/drcachesim/tests/drcachesim-delay-simple.templatex
+++ b/clients/drcachesim/tests/drcachesim-delay-simple.templatex
@@ -1,5 +1,5 @@
 Hit delay threshold: enabling tracing.
-Hello, world!
+Exiting process after ~1.... references.
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2457,7 +2457,8 @@ if (CLIENT_INTERFACE)
 
       torunonly_ci(tool.drcachesim.delay ${ci_shared_app} drcachesim
         "drcachesim-delay-simple.c" # for templatex basename
-        "-ipc_name ${IPC_PREFIX}drtestdelay -trace_after_instrs 50000" "" "")
+        "-ipc_name ${IPC_PREFIX}drtestdelay -trace_after_instrs 50000 -exit_after_tracing 10000"
+        "" "")
         set(tool.drcachesim.delay_toolname "drcachesim")
         set(tool.drcachesim.delay_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")


### PR DESCRIPTION
Adds a new drmemtrace feature -exit_after_tracing N which exits the process
after tracing N memory references.  Extends the -trace_after_instr test to
include -exit_after_tracing.

We would prefer -detach_after_tracing but we need i#2644 for that and we
leave it for future work.

Fixes #2645