### PR TITLE
i#2688: avoid self-interp of new child threads during attach

### DIFF
--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -192,7 +192,7 @@ typedef struct ptrace_stack_args_t {
 } ptrace_stack_args_t;
 
 /* in os.c */
-void os_thread_take_over(priv_mcontext_t *mc, kernel_sigset_t *sigset);
+bool os_thread_take_over(priv_mcontext_t *mc, kernel_sigset_t *sigset);
 
 void *os_get_priv_tls_base(dcontext_t *dcontext, reg_id_t seg);
 


### PR DESCRIPTION
Adds a check when taking over a new thread during attach to avoid
self-interp when the new thread is the child of a thread that's already
been taken over.

Tested with the api.detach_spawn test from #2601.

Fixes #2688