### PR TITLE
Include vdso in the module list

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -190,6 +190,8 @@ Further non-compatibility-affecting changes include:
    sec_drcachesim_ops).
  - Added a last-level cache miss recording feature to drcachesim.
  - Added a delayed tracing feature to drcachesim.
+ - On Linux, the VDSO (and vsyscall, if separate) modules are now included
+   in the module list at program startup.
 
 **************************************************
 <hr>

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -190,8 +190,8 @@ Further non-compatibility-affecting changes include:
    sec_drcachesim_ops).
  - Added a last-level cache miss recording feature to drcachesim.
  - Added a delayed tracing feature to drcachesim.
- - On Linux, the VDSO (and vsyscall, if separate) modules are now included
-   in the module list at program startup.
+ - On Linux, the VDSO module is now included in the module list at program
+   startup.
 
 **************************************************
 <hr>

--- a/clients/drcov/postprocess/drcov2lcov.cpp
+++ b/clients/drcov/postprocess/drcov2lcov.cpp
@@ -1160,6 +1160,7 @@ enumerate_line_info(void)
         hash_entry_t *e;
         drsym_error_t res;
         for (e = module_htable.table[i]; e != NULL; e = e->next) {
+            bool has_lines = true;
             num_entries++;
             PRINT(3, "Enumerate line info for %s\n", (char *)e->key);
             if (strcmp((char *)e->key, "<unknown>") == 0)
@@ -1167,10 +1168,13 @@ enumerate_line_info(void)
             if (e->payload == MODULE_TABLE_IGNORE)
                 continue;
             res = drsym_enumerate_lines((const char *)e->key, enum_line_cb, e->payload);
-            if (res != DRSYM_SUCCESS)
+            if (res != DRSYM_SUCCESS) {
                 WARN(1, "Failed to enumerate lines for %s\n", (char *)e->key);
+                has_lines = false;
+            }
             res = drsym_free_resources((char *)e->key);
-            if (res != DRSYM_SUCCESS)
+            /* I'm using has_lines to avoid warning on vdso. */
+            if (res != DRSYM_SUCCESS && has_lines)
                 WARN(1, "Failed to free resource for %s\n", (char *)e->key);
         }
     }

--- a/core/module_list.c
+++ b/core/module_list.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -261,9 +261,11 @@ module_list_add(app_pc base, size_t view_size, bool at_map, const char *filepath
             module_area_create(base, view_size, at_map, filepath _IF_UNIX(inode));
         ASSERT(ma != NULL);
 
-        LOG(GLOBAL, LOG_INTERP|LOG_VMAREAS, 1, "module %s ["PFX","PFX"] added\n",
+        LOG(GLOBAL, LOG_INTERP|LOG_VMAREAS, 1, "module %s |%s| ["PFX","PFX"] added\n",
             (GET_MODULE_NAME(&ma->names) == NULL) ? "<no name>" :
-            GET_MODULE_NAME(&ma->names), base, base+view_size);
+            GET_MODULE_NAME(&ma->names),
+            ma->names.file_name == NULL ? "<no file>" : ma->names.file_name,
+            base, base+view_size);
 
         /* note that while it would be natural to invoke the client module
          * load event since we have the data for it right here, the

--- a/suite/tests/client-interface/events.dll.c
+++ b/suite/tests/client-interface/events.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -41,6 +41,7 @@
 
 #ifdef UNIX
 # include <signal.h>
+# include <string.h>
 #endif
 
 #ifdef WINDOWS
@@ -322,7 +323,7 @@ void module_load_event_perm(void *drcontext, const module_data_t *info, bool loa
     else if (info->full_path[0] == '\\' || info->full_path[1] != ':')
         dr_fprintf(STDERR, "ERROR: full_path is not in DOS format: %s\n", info->full_path);
 #else
-    else if (info->full_path[0] != '/')
+    else if (info->full_path[0] != '/' && strcmp(info->full_path, "[vdso]") != 0)
         dr_fprintf(STDERR, "ERROR: full_path is not absolute: %s\n", info->full_path);
 #endif
 }


### PR DESCRIPTION
Adds vdso to the module list at init time.  Previously, it would be added
upon execution (via the module event trigger), but would otherwise be
absent.

I'd like to also add vsyscall, when it's separate, but it has no ELF header
and that complicates placing it on the module list, so for now we leave it
off.

Adds a release note as this could affect existing clients.

Tweaks drcovlib to handle displaced tags such as for the vsyscall hook.