### PR TITLE
i#2006 generalize drcachesim: Add index field to drmodtrack_info_t

### DIFF
--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -244,6 +244,11 @@ typedef struct _drmodtrack_info_t {
 #endif
     /** The custom field set by the \p load_cb passed to drmodtrack_add_custom_data(). */
     void *custom;
+    /**
+     * The unique index of this module segment.  This equals the \p index parameter
+     * passed to drmodtrack_offline_lookup().
+     */
+    uint index;
 } drmodtrack_info_t;
 
 DR_EXPORT

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -36,6 +36,7 @@
 #include "drcovlib_private.h"
 #include <string.h>
 #include <stdio.h>
+#include <stddef.h>
 
 #define MODULE_FILE_VERSION 3
 
@@ -711,7 +712,7 @@ drmodtrack_offline_lookup(void *handle, uint index, OUT drmodtrack_info_t *out)
 {
     module_read_info_t *info = (module_read_info_t *)handle;
     if (info == NULL || index >= info->num_mods || out == NULL ||
-        out->struct_size != sizeof(*out))
+        out->struct_size < offsetof(drmodtrack_info_t, custom) + sizeof(out->custom))
         return DRCOVLIB_ERROR_INVALID_PARAMETER;
     out->containing_index = info->mod[index].containing_id;
     out->start = info->mod[index].base;
@@ -722,6 +723,8 @@ drmodtrack_offline_lookup(void *handle, uint index, OUT drmodtrack_info_t *out)
     out->timestamp = info->mod[index].timestamp;
 #endif
     out->custom = info->mod[index].custom;
+    if (out->struct_size > offsetof(drmodtrack_info_t, index))
+        out->index = index;
     return DRCOVLIB_SUCCESS;
 }
 

--- a/suite/tests/client-interface/drmodtrack-test.dll.cpp
+++ b/suite/tests/client-interface/drmodtrack-test.dll.cpp
@@ -131,6 +131,7 @@ event_exit(void)
         CHECK(res == DRCOVLIB_SUCCESS, "lookup failed");
         CHECK(((app_pc)info.custom) == info.start ||
               info.containing_index != i, "custom field doesn't match");
+        CHECK(info.index == i, "index field doesn't match");
     }
 
     char *buf_offline;


### PR DESCRIPTION
Adds an explicit index field to drmodtrack_info_t so that the data
structure can be passed around without an accompanying iterator index.

Issue: #2006