### PR TITLE
i#2062 trace non-mod: handle traced VDSO code

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -175,7 +175,11 @@ Further non-compatibility-affecting changes include:
  - Added drmodtrack customization via drmodtrack_add_custom_data() and
    post-processing support via drmodtrack_offline_write().
  - Added drcachesim customization via drmemtrace_replace_file_ops(),
-   drmemtrace_custom_module_data(), and drmemtrace_get_modlist_path().
+   drmemtrace_custom_module_data(), drmemtrace_get_output_path(),
+   drmemtrace_get_modlist_path(), and a separate rawtrace library for
+   post-processing customization with raw2trace_t::handle_custom_data(),
+   raw2trace_t::do_module_parsing(), raw2trace_t::do_conversion(), and
+   raw2trace_directory_t.
  - Added a set_value() function to the \ref page_droption.
  - Added instrlist_get_auto_predicate() and instrlist_set_auto_predicate().
  - Globally enabled auto predication in the drmgr instrumentation insertion event by

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(raw2trace STATIC
   tracer/raw2trace_directory.cpp
   )
 configure_DynamoRIO_standalone(raw2trace)
+target_link_libraries(raw2trace drfrontendlib)
 
 add_executable(drcachesim
   launcher.cpp
@@ -320,6 +321,11 @@ if (BUILD_TESTS)
     configure_DynamoRIO_static(tool.drcacheoff.burst_replace)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_replace drmemtrace_static)
     target_link_libraries(tool.drcacheoff.burst_replace raw2trace)
+    if (WIN32)
+      # burst_replace is unusual in cramming the tracer and post-processor into the
+      # same binary and we need some massaging to avoid duplicate symbol link errors.
+      target_link_libraries(tool.drcacheoff.burst_replace libcmtd)
+    endif ()
     add_win32_flags(tool.drcacheoff.burst_replace)
     # Not really using an extension, just for including drmemtrace.h.
     use_DynamoRIO_extension(tool.drcacheoff.burst_replace drmemtrace_static)

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -319,6 +319,7 @@ if (BUILD_TESTS)
     add_executable(tool.drcacheoff.burst_replace tests/burst_replace.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_replace)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_replace drmemtrace_static)
+    target_link_libraries(tool.drcacheoff.burst_replace raw2trace)
     add_win32_flags(tool.drcacheoff.burst_replace)
     # Not really using an extension, just for including drmemtrace.h.
     use_DynamoRIO_extension(tool.drcacheoff.burst_replace drmemtrace_static)

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -104,7 +104,7 @@ bool
 analyzer_t::start_reading()
 {
     if (!trace_iter->init()) {
-        ERRMSG("failed to read from trace\n");
+        ERRMSG("Failed to read from trace\n");
         return false;
     }
     return true;

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -70,7 +70,7 @@ analyzer_multi_t::analyzer_multi_t()
             raw2trace_t raw2trace(dir.modfile_bytes, dir.thread_files, &dir.out_file);
             std::string error = raw2trace.do_conversion();
             if (!error.empty())
-                ERRMSG("raw2trace failed: %s", error.c_str());
+                ERRMSG("raw2trace failed: %s\n", error.c_str());
             trace_iter = new file_reader_t(tracefile.c_str());
         }
         // We don't support a compressed file here (is_complete() is too hard

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -241,10 +241,16 @@ cache_simulator_t::process_memref(const memref_t &memref)
     }
 
     if (knob_verbose >= 3) {
-        std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
-            " @" << (void *)memref.data.pc <<
-            " " << trace_type_names[memref.data.type] << " " <<
-            (void *)memref.data.addr << " x" << memref.data.size << std::endl;
+        if (type_is_instr(memref.instr.type)) {
+            std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
+                " @" << (void *)memref.instr.addr << " instr x" <<
+                memref.instr.size << std::endl;
+        } else {
+            std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
+                " @" << (void *)memref.data.pc <<
+                " " << trace_type_names[memref.data.type] << " " <<
+                (void *)memref.data.addr << " x" << memref.data.size << std::endl;
+        }
     }
 
     // process counters for warmup and simulated references

--- a/clients/drcachesim/tests/offline-burst_replace.templatex
+++ b/clients/drcachesim/tests/offline-burst_replace.templatex
@@ -13,7 +13,6 @@ pre-DR detach
 close file .*
 2: writing [0-9]+ bytes .*
 close file .*
-processing .*
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)

--- a/clients/drcachesim/tracer/drmemtrace.h
+++ b/clients/drcachesim/tracer/drmemtrace.h
@@ -215,11 +215,17 @@ drmemtrace_buffer_handoff(drmemtrace_handoff_func_t handoff_func,
 
 DR_EXPORT
 /**
+ * Retrieves the full path to the output directory in -offline mode
+ * where data is being written.
+ */
+drmemtrace_status_t
+drmemtrace_get_output_path(OUT const char **path);
+
+DR_EXPORT
+/**
  * Retrieves the full path to the file in -offline mode where module data is written.
- * Its creation can be customized using drmemtrace_custom_module_data()
- * and then modified before passing to raw2trace via
- * drmodtrack_add_custom_data() with a parse and free callback
- * and drmodtrack_offline_write() to produce new file contents.
+ * Its creation can be customized using drmemtrace_custom_module_data() with
+ * corresponding post-processing with raw2trace_t::handle_custom_data().
  */
 drmemtrace_status_t
 drmemtrace_get_modlist_path(OUT const char **path);
@@ -232,13 +238,9 @@ DR_EXPORT
  * to a string with \p print_cb, which should return the number of characters
  * printed or -1 on error.  The data is freed with \p free_cb.
  *
- * The user can read and modify the resulting \p modules.log file, prior to
- * passing through the raw2trace post-processor.  Its path can be obtained from
- * drmemtrace_get_modlist_path() (unless drmemtrace_replace_file_ops() moved it:
- * then it's up to the caller to locate and process it), and the \p drmodtrack
- * API can be used to remove the custom field, update the path, and rewrite the
- * file: drmodtrack_add_custom_data(), drmodtrack_offline_read(),
- * drmodtrack_offline_lookup(), drmodtrack_offline_write().
+ * On the post-processing side, the user should create a custom post-processor
+ * by linking with raw2trace and calling raw2trace_t::handle_custom_data() to provide
+ * parsing and processing routines for the custom data.
  */
 drmemtrace_status_t
 drmemtrace_custom_module_data(void * (*load_cb)(module_data_t *module),

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -41,6 +41,9 @@
 
 #define MINSERT instrlist_meta_preinsert
 
+// Versioning for our drmodtrack custom module fields.
+#define CUSTOM_MODULE_VERSION 1
+
 class instru_t
 {
 public:
@@ -198,6 +201,14 @@ public:
                                    void (*free_cb)(void *data));
 
 private:
+    struct custom_module_data_t {
+        custom_module_data_t(const char *base_, size_t size_, void *user_) :
+            base(base_), size(size_), user_data(user_) {}
+        const char *base;
+        size_t size;
+        void *user_data;
+    };
+
     int insert_save_pc(void *drcontext, instrlist_t *ilist, instr_t *where,
                         reg_id_t reg_ptr, reg_id_t scratch, int adjust, app_pc pc,
                         uint instr_count);
@@ -206,6 +217,15 @@ private:
                          bool write);
     ssize_t (*write_file_func)(file_t file, const void *data, size_t count);
     file_t modfile;
+
+    // Custom module fields are global (since drmodtrack's support is global, we don't
+    // try to pass void* user data params through).
+    static void * (*user_load)(module_data_t *module);
+    static int (*user_print)(void *data, char *dst, size_t max_len);
+    static void (*user_free)(void *data);
+    static void *load_custom_module_data(module_data_t *module);
+    static int print_custom_module_data(void *data, char *dst, size_t max_len);
+    static void free_custom_module_data(void *data);
 };
 
 #endif /* _INSTRU_H_ */

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -38,6 +38,7 @@
 
 #include "dr_api.h"
 #include "drmemtrace.h"
+#include "drcovlib.h"
 #include "trace_entry.h"
 #include <fstream>
 #include "hashtable.h"
@@ -49,28 +50,83 @@
 #define TRACE_FILENAME "drmemtrace.trace"
 
 struct module_t {
-    module_t(const char *path, app_pc orig, byte *map, size_t size) :
-        path(path), orig_base(orig), map_base(map), map_size(size) {}
+    module_t(const char *path, app_pc orig, byte *map, size_t size,
+             bool external = false) :
+        path(path), orig_base(orig), map_base(map), map_size(size),
+        is_external(external) {}
     const char *path;
     app_pc orig_base;
     byte *map_base;
     size_t map_size;
+    bool is_external; // If true, the data is embedded in drmodtrack custom fields.
 };
 
 class raw2trace_t {
 public:
     // module_map, thread_files and out_file are all owned and opened/closed by the
-    // caller.
+    // caller.  module_map is not a string and can contain binary data.
     raw2trace_t(const char *module_map, const std::vector<std::istream*> &thread_files,
                 std::ostream *out_file, void *dcontext = NULL,
                 unsigned int verbosity = 0);
     ~raw2trace_t();
-    // Returns non-empty error message on failure.
+
+    /**
+     * Adds handling for custom data fields that were stored with each module via
+     * drmemtrace_custom_module_data() during trace generation.  When do_conversion()
+     * or do_module_parsing() is subsequently called, its parsing of the module data
+     * will invoke \p parse_cb, which should advance the module data pointer passed
+     * in \p src and return it as its return value (or nullptr on error), returning
+     * the resulting parsed data in \p data.  The \p data pointer will later be
+     * passed to both \p process_cb, which can update the module path inside \p info
+     * (and return a non-empty string on error), and \b free_cb, which can perform
+     * cleanup.
+     *
+     * A custom callback value \p process_cb_user_data can be passed to \p
+     * process_cb.  The same is not provided for the other callbacks as they end up
+     * using the drmodtrack_add_custom_data() framework where there is no support for
+     * custom callback parameters.
+     *
+     * Returns a non-empty error message on failure.
+     *
+     * Only one value for each callback is supported, globally.  Calling this routine
+     * again with a different value will replace the existing callbacks.
+     */
+    std::string handle_custom_data(const char * (*parse_cb)(const char *src,
+                                                            OUT void **data),
+                                   std::string (*process_cb)(drmodtrack_info_t *info,
+                                                             void *data, void *user_data),
+                                   void *process_cb_user_data,
+                                   void (*free_cb)(void *data));
+
+    /**
+     * Performs the first step of do_conversion() without further action: parses and
+     * iterates over the list of modules.  This is provided to give the user a method
+     * for iterating modules in the presence of the custom field used by drmemtrace
+     * that prevents direct use of drmodtrack_offline_read().
+     * On success, calls the \p process_cb function passed to handle_custom_data()
+     * for every module in the list, and returns an empty string at the end.
+     * Returns a non-empty error message on failure.
+     */
+    std::string do_module_parsing();
+
+    /**
+     * Performs the conversion from raw data to finished trace files.
+     * Returns a non-empty error message on failure.
+     */
     std::string do_conversion();
+
     static std::string check_thread_file(std::istream *f);
 
 private:
-    std::string read_and_map_modules(const char *module_map);
+    // We store this in drmodtrack_info_t.custom to combine our binary contents
+    // data with any user-added module data from drmemtrace_custom_module_data.
+    struct custom_module_data_t {
+        size_t contents_size;
+        const char *contents;
+        void *user_data;
+    };
+
+    std::string read_and_map_modules();
     std::string unmap_modules(void);
     std::string merge_and_process_thread_files();
     std::string append_bb_entries(uint tidx, offline_entry_t *in_entry,
@@ -95,6 +151,18 @@ private:
     // and c++11 std::unordered_map (including tuning its load factor, initial size,
     // and hash function), and hashtable_t outperformed the others (i#2056).
     hashtable_t decode_cache;
+
+    // We store module info for do_module_parsing.
+    std::vector<drmodtrack_info_t> modlist;
+    std::string (*user_process)(drmodtrack_info_t *info, void *data, void *user_data);
+    void *user_process_data;
+
+    // Custom module fields that use drmodtrack are global.
+    static const char * (*user_parse)(const char *src, OUT void **data);
+    static void (*user_free)(void *data);
+    static const char *parse_custom_module_data(const char *src, OUT void **data);
+    static void free_custom_module_data(void *data);
+    static bool has_custom_data;
 };
 
 #endif /* _RAW2TRACE_H_ */

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -211,6 +211,15 @@ drmemtrace_buffer_handoff(drmemtrace_handoff_func_t handoff_func,
 static char modlist_path[MAXIMUM_PATH];
 
 drmemtrace_status_t
+drmemtrace_get_output_path(OUT const char **path)
+{
+    if (path == NULL)
+        return DRMEMTRACE_ERROR_INVALID_PARAMETER;
+    *path = logsubdir;
+    return DRMEMTRACE_SUCCESS;
+}
+
+drmemtrace_status_t
 drmemtrace_get_modlist_path(OUT const char **path)
 {
     if (path == NULL)

--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -312,6 +312,8 @@ DR_EXPORT
  * are embedding a module list inside a file with further data following the
  * list in the file).  If \p next_line is NULL, this routine stops reading at
  * the final newline: thus, \p map need not be NULL-terminated.
+ * Although \p map uses a char type, it cannot be assumed to be a regular string:
+ * binary data containing zeroes may be embedded inside it.
  *
  * Returns an identifier in \p handle to use with other offline routines, along
  * with the number of modules read in \p num_mods.  Information on each module

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -550,11 +550,12 @@ drmodtrack_dump(file_t log)
     drcovlib_status_t res;
     size_t size = 200 + module_table.vector.entries * (MAXIMUM_PATH + 40);
     char *buf;
+    size_t wrote;
     do {
         buf = dr_global_alloc(size);
-        res = drmodtrack_dump_buf(buf, size, NULL);
+        res = drmodtrack_dump_buf(buf, size, &wrote);
         if (res == DRCOVLIB_SUCCESS)
-            dr_write_file(log, buf, strlen(buf));
+            dr_write_file(log, buf, wrote - 1/*no null*/);
         dr_global_free(buf, size);
         size *= 2;
     } while (res == DRCOVLIB_ERROR_BUF_TOO_SMALL);


### PR DESCRIPTION
Adds offline trace handling of VDSO code by dumping the actual contents of
the VDSO pages into drmodtrack custom data and using it to decode
instructions during post-processing.

Updates drmodtrack to handle binary data in custom fields.

Refactors how 3rd-party custom module fields are handled for drcachesim as
they now must be multiplexed with the new VDSO data.  The 3rd party must
now build a custom post-processor by linking with the raw2trace library.

Since the module list file is no longer completely human-readable and
contains hidden custom fields, a new interface
raw2trace_t::do_module_parsing() is added to support building 3rd-party
module file parsing code for use after a trace is gathered.

Adds drmemtrace_get_output_path() for dynamically locating offline trace
files.

Updates the burst_replace test to use the new methods.

Includes support for reading legacy trace module files that do not contain
VDSO data (in such a case we revert to the prior behavior of skipping the
ifetch entries).  This is accomplished by using a version field in the
module data.  If it's missing, and if either the user parser is happy or
the next field looks like a path, we assume everything's fine and we're
just missing the vdso data.  This legacy support was tested manually.