### PR TITLE
Do not initialize temp_options variable.

### DIFF
--- a/core/options.c
+++ b/core/options.c
@@ -175,10 +175,9 @@ options_t dynamo_options = {
  * and put back as synchronize_dynamic_options() local var.
  */
 DECLARE_FREQPROT_VAR(char new_option_string[MAX_OPTIONS_STRING], {0,});
-/* temporary structure */
-options_t temp_options = {
-# include "optionsx.h"
-};
+
+/* Temporary structure.  Do not assume that it is initialized. */
+options_t temp_options;
 
 /* dynamo_options and temp_options, the two writable option structures,
  * are both protected by this lock, which is kept outside of the protected


### PR DESCRIPTION
This variable is not used anywhere else other than in the file
options.c.  Before it is used, it is always set.  So no need to provide
a default initialization.  This shaves 27,136 bytes from the size of the
statically compiled library.

Before:
-r-xr-xr-x 1 nilayvaish eng 3026934 Nov 23 14:08 libdynamorio.a
After:
-r-xr-xr-x 1 nilayvaish eng 2999798 Nov 23 14:03 libdynamorio.a