### PR TITLE
i#2720 cpusim tests: add -ignore_all_libs option

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -207,6 +207,7 @@ Further non-compatibility-affecting changes include:
  - Added an event for kernel-mediated control flow via
    dr_register_kernel_xfer_event() with corresponding routines
    drmgr_register_kernel_xfer_event() and drmgr_register_kernel_xfer_event_ex().
+ - Added a new option -ignore_all_libs to drcpusim.
 
 **************************************************
 <hr>

--- a/clients/drcpusim/options.cpp
+++ b/clients/drcpusim/options.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,7 +43,7 @@
 #endif
 
 droption_t<std::string> op_cpu
-(DROPTION_SCOPE_CLIENT, "cpu", "Merom", "CPU model to simulate.  Typical values:\n"
+(DROPTION_SCOPE_CLIENT, "cpu", "Westmere", "CPU model to simulate.  Typical values:\n"
  "                                Pentium,PentiumMMX,PentiumPro,Klamath,Deschutes,\n"
  "                                Pentium3,Banias,Dothan,Prescott,Presler,Merom,\n"
  "                                Penryn,Westmere,Sandybridge,Ivybridge.",
@@ -131,6 +131,12 @@ droption_t<std::string> op_blacklist
  ":-separated list of libs to ignore.",
  "The blacklist is a :-separated list of library names for which violations "
  "should not be reported.");
+
+droption_t<bool> op_ignore_all_libs
+(DROPTION_SCOPE_CLIENT, "ignore_all_libs", false,
+ "Ignore all libraries: only check app itself.",
+ "Violations in libraries are ignored: only violations in the application executable "
+ "itself are reported.");
 
 droption_t<unsigned int> op_verbose
 (DROPTION_SCOPE_CLIENT, "verbose", 0, 0, 64, "Verbosity level",

--- a/clients/drcpusim/options.h
+++ b/clients/drcpusim/options.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,6 +43,7 @@ extern droption_t<bool> op_continue;
 extern droption_t<bool> op_fool_cpuid;
 extern droption_t<bool> op_allow_prefetchw;
 extern droption_t<std::string> op_blacklist;
+extern droption_t<bool> op_ignore_all_libs;
 extern droption_t<unsigned int> op_verbose;
 
 #endif /* _OPTIONS_H_ */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2755,7 +2755,8 @@ if (CLIENT_INTERFACE)
       macro (add_cpusim_cpuid_test model)
         torunonly_ci(tool.drcpusim.cpuid-${model} tool.cpuid drcpusim
           ${PROJECT_SOURCE_DIR}/clients/drcpusim/tests/cpuid-${model}.c
-          "-cpu ${model}" "" "")
+          # Ignore libs to reduce risk of violations (e.g., i#2720)
+          "-cpu ${model} -ignore_all_libs" "" "")
         set(tool.drcpusim.cpuid-${model}_toolname "drcpusim")
         set(tool.drcpusim.cpuid-${model}_basedir
           "${PROJECT_SOURCE_DIR}/clients/drcpusim/tests")


### PR DESCRIPTION
Adds a new drcpusim option -ignore_all_libs and uses it on cpuid tests to
avoid failures on Travis Mac where system libraries are using recent
instructions.  These cpuid tests are mainly testing cpuid fooling, not
instruction set violations.

Fixes #2720