### PR TITLE
i#2708 trace xfers: record kernel xfer boundaries in traces

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -208,6 +208,8 @@ Further non-compatibility-affecting changes include:
    dr_register_kernel_xfer_event() with corresponding routines
    drmgr_register_kernel_xfer_event() and drmgr_register_kernel_xfer_event_ex().
  - Added a new option -ignore_all_libs to drcpusim.
+ - Added a new tool basic_counts to drcachesim for counting up the
+   different types of entries in a trace, broken down by thread.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -63,6 +63,7 @@ set(client_and_sim_srcs
 add_library(reuse_distance STATIC tools/reuse_distance.cpp)
 add_library(histogram STATIC tools/histogram.cpp)
 add_library(reuse_time STATIC tools/reuse_time.cpp)
+add_library(basic_counts STATIC tools/basic_counts.cpp)
 # We combine the cache and TLB simulators as they share code already.
 add_library(simulator STATIC
   simulator/simulator.cpp
@@ -101,7 +102,8 @@ add_executable(drcachesim
 # In order to embed raw2trace we need to be standalone:
 configure_DynamoRIO_standalone(drcachesim)
 # Link in our tools:
-target_link_libraries(drcachesim simulator reuse_distance histogram reuse_time raw2trace)
+target_link_libraries(drcachesim simulator reuse_distance histogram reuse_time
+  basic_counts raw2trace)
 # To avoid dup symbol errors between drinjectlib and the drdecode brought in
 # by drfrontendlib we have to explicitly list drdecode up front:
 target_link_libraries(drcachesim drdecode drinjectlib drconfiglib drfrontendlib)
@@ -204,6 +206,7 @@ restore_nonclient_flags(simulator)
 restore_nonclient_flags(reuse_distance)
 restore_nonclient_flags(histogram)
 restore_nonclient_flags(reuse_time)
+restore_nonclient_flags(basic_counts)
 
 # We need to pass /EHsc and we pull in libcmtd into drcachesim from a dep lib.
 # Thus we need to override the /MT with /MTd.
@@ -227,6 +230,7 @@ add_win32_flags(simulator)
 add_win32_flags(reuse_distance)
 add_win32_flags(histogram)
 add_win32_flags(reuse_time)
+add_win32_flags(basic_counts)
 if (WIN32 AND DEBUG)
   get_target_property(sim_srcs drcachesim SOURCES)
   get_target_property(raw2trace_srcs drraw2trace SOURCES)

--- a/clients/drcachesim/common/memref.h
+++ b/clients/drcachesim/common/memref.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -86,6 +86,15 @@ struct _memref_thread_exit_t {
     memref_tid_t tid;
 };
 
+struct _memref_marker_t {
+    // TRACE_TYPE_MARKER.
+    trace_type_t type;
+    memref_pid_t pid;
+    memref_tid_t tid;
+    trace_marker_type_t marker_type;
+    uintptr_t marker_value;
+};
+
 typedef union _memref_t {
     // The C standard allows us to reference the type field of any of these, and the
     // addr and size fields of data, instr, or flush generically if known to be one
@@ -94,6 +103,7 @@ typedef union _memref_t {
     struct _memref_instr_t instr;
     struct _memref_flush_t flush;
     struct _memref_thread_exit_t exit;
+    struct _memref_marker_t marker;
 } memref_t;
 
 #endif /* _MEMREF_H_ */

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -220,9 +220,11 @@ droption_t<std::string> op_TLB_replace_policy
 
 droption_t<std::string> op_simulator_type
 (DROPTION_SCOPE_FRONTEND, "simulator_type", CPU_CACHE,
- "Simulator type (" CPU_CACHE", " TLB", " REUSE_DIST", " REUSE_TIME", or " HISTOGRAM").",
+ "Simulator type (" CPU_CACHE", " TLB", " REUSE_DIST", " REUSE_TIME", "
+ HISTOGRAM", or " BASIC_COUNTS").",
  "Specifies the type of the simulator. "
- "Supported types: " CPU_CACHE", " TLB", " REUSE_DIST", " REUSE_TIME", or " HISTOGRAM".");
+ "Supported types: " CPU_CACHE", " TLB", " REUSE_DIST", " REUSE_TIME", " HISTOGRAM
+ "or " BASIC_COUNTS".");
 
 droption_t<unsigned int> op_verbose
 (DROPTION_SCOPE_ALL, "verbose", 0, 0, 64, "Verbosity level",
@@ -265,8 +267,8 @@ droption_t<bytesize_t> op_warmup_refs
 
 droption_t<bytesize_t> op_sim_refs
 (DROPTION_SCOPE_FRONTEND, "sim_refs", bytesize_t(1ULL << 63),
- "Number of memory references simulated",
- "Specifies the number of memory references simulated. "
+ "Number of memory references to simulate",
+ "Specifies the number of memory references to simulate. "
  "The simulated references come after the skipped and warmup references, "
  "and the references following the simulated ones are dropped.");
 

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -46,6 +46,7 @@
 #define HISTOGRAM                               "histogram"
 #define REUSE_DIST                              "reuse_distance"
 #define REUSE_TIME                              "reuse_time"
+#define BASIC_COUNTS                            "basic_counts"
 
 #include <string>
 #include "droption.h"

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -134,7 +134,29 @@ typedef enum {
 
     // Hardware-issued prefetch.
     TRACE_TYPE_HARDWARE_PREFETCH,
+
+    // A marker containing metadata about this point in the trace.
+    // It includes a marker sub-type trace_marker_type_t and a value.
+    TRACE_TYPE_MARKER,
 } trace_type_t;
+
+// The sub-type for TRACE_TYPE_MARKER.
+typedef enum {
+    // The subsequent instruction is the start of a handler for a kernel-initiated
+    // event: a signal handler on UNIX, or an APC, exception, or callback dispatcher
+    // on Windows.
+    TRACE_MARKER_TYPE_KERNEL_EVENT,
+    // The subsequent instruction is the target of a system call that changes the
+    // context: a signal return on UNIX, or a callback return or NtContinue or
+    // NtSetContextThread on Windows.
+    TRACE_MARKER_TYPE_KERNEL_XFER,
+
+    // ...
+    // These values are reserved for future built-in marker types.
+    // ...
+    TRACE_MARKER_TYPE_RESERVED_END = 100,
+    // Values below here are available for users to use for custom markers.
+} trace_marker_type_t;
 
 extern const char * const trace_type_names[];
 
@@ -163,10 +185,11 @@ type_is_prefetch(const trace_type_t type)
 START_PACKED_STRUCTURE
 struct _trace_entry_t {
     unsigned short type; // 2 bytes: trace_type_t
-    // 2 bytes: mem ref size, instr length, or num of instrs for instr bundle
+    // 2 bytes: mem ref size, instr length, or num of instrs for instr bundle,
+    // or marker sub-type.
     unsigned short size;
     union {
-        addr_t addr;     // 4/8 bytes: mem ref addr, instr pc, tid, pid
+        addr_t addr;     // 4/8 bytes: mem ref addr, instr pc, tid, pid, marker val
         // The length of each instr in the instr bundle
         unsigned char length[sizeof(addr_t)];
     };
@@ -206,11 +229,16 @@ typedef enum {
 // Sub-type when the primary type is OFFLINE_TYPE_EXTENDED.
 // These differ in what they store in offline_entry_t.extended.value.
 typedef enum {
-    // The initial entry in the file.  The value field holds the version.
+    // The initial entry in the file.  The valueA field holds the version.
     OFFLINE_EXT_TYPE_HEADER,
-    // The final entry in the file.  The value field is 0.
+    // The final entry in the file.  The value fields are 0.
     OFFLINE_EXT_TYPE_FOOTER,
+    // A marker type.  The valueB field holds the sub-type and valueA the value.
+    OFFLINE_EXT_TYPE_MARKER,
 } offline_ext_type_t;
+
+#define EXT_VALUE_A_BITS 48
+#define EXT_VALUE_B_BITS 8
 
 #define OFFLINE_FILE_VERSION 1
 
@@ -243,8 +271,9 @@ struct _offline_entry_t {
             uint64_t type:3;
         } timestamp;
         struct {
-            uint64_t value:56; // Meaning is specific to ext type.
-            uint64_t ext:5;    // Holds an offline_ext_type_t value.
+            uint64_t valueA:EXT_VALUE_A_BITS; // Meaning is specific to ext type.
+            uint64_t valueB:EXT_VALUE_B_BITS; // Meaning is specific to ext type.
+            uint64_t ext:5;     // Holds an offline_ext_type_t value.
             uint64_t type:3;
         } extended;
         uint64_t combined_value;

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -84,7 +84,18 @@ parameter:
 bin64/drrun -t drcachesim -simulator_type TLB -- /path/to/target/app <args> <for> <app>
 \endcode
 
-Several other trace analysis tools are under development.
+Several other trace analysis tools are available, including reuse distance:
+
+\code
+bin64/drrun -t drcachesim -simulator_type reuse_distance -reuse_distance_histogram -- /path/to/target/app <args> <for> <app>
+\endcode
+
+To simply see the counts of instructions and memory references broken down
+by thread use the basic count tool:
+
+\code
+bin64/drrun -t drcachesim -simulator_type basic_counts -- /path/to/target/app <args> <for> <app>
+\endcode
 
 To dump the trace for future offline analysis:
 \code

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -177,6 +177,15 @@ reader_t::operator++()
             // We do want to replace, in case of tid reuse.
             tid2pid[cur_tid] = cur_pid;
             break;
+        case TRACE_TYPE_MARKER:
+            have_memref = true;
+            cur_ref.marker.type = (trace_type_t) input_entry->type;
+            assert(cur_tid != 0 && cur_pid != 0);
+            cur_ref.marker.pid = cur_pid;
+            cur_ref.marker.tid = cur_tid;
+            cur_ref.marker.marker_type = (trace_marker_type_t) input_entry->size;
+            cur_ref.marker.marker_value = input_entry->addr;
+            break;
         default:
             ERRMSG("Unknown trace entry type %d\n", input_entry->type);
             assert(false);

--- a/clients/drcachesim/simulator/analyzer_interface.cpp
+++ b/clients/drcachesim/simulator/analyzer_interface.cpp
@@ -43,6 +43,7 @@
 #include "../tools/histogram_create.h"
 #include "../tools/reuse_distance_create.h"
 #include "../tools/reuse_time_create.h"
+#include "../tools/basic_counts_create.h"
 
 analysis_tool_t *
 drmemtrace_analysis_tool_create()
@@ -92,10 +93,12 @@ drmemtrace_analysis_tool_create()
     } else if (op_simulator_type.get_value() == REUSE_TIME) {
         return reuse_time_tool_create(op_line_size.get_value(),
                                       op_verbose.get_value());
+    } else if (op_simulator_type.get_value() == BASIC_COUNTS) {
+        return basic_counts_tool_create(op_verbose.get_value());
     } else {
         ERRMSG("Usage error: unsupported analyzer type. "
                "Please choose " CPU_CACHE ", " TLB ", "
-               HISTOGRAM ", or " REUSE_DIST ".\n");
+               HISTOGRAM ", " REUSE_DIST ", or " BASIC_COUNTS ".\n");
         return NULL;
     }
 }

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -220,37 +220,51 @@ cache_simulator_t::process_memref(const memref_t &memref)
     }
 
     if (type_is_instr(memref.instr.type) ||
-        memref.instr.type == TRACE_TYPE_PREFETCH_INSTR)
-        icaches[core]->request(memref);
-    else if (memref.data.type == TRACE_TYPE_READ ||
-             memref.data.type == TRACE_TYPE_WRITE ||
-             // We may potentially handle prefetches differently.
-             // TRACE_TYPE_PREFETCH_INSTR is handled above.
-             type_is_prefetch(memref.data.type))
-        dcaches[core]->request(memref);
-    else if (memref.flush.type == TRACE_TYPE_INSTR_FLUSH)
-        icaches[core]->flush(memref);
-    else if (memref.flush.type == TRACE_TYPE_DATA_FLUSH)
-        dcaches[core]->flush(memref);
-    else if (memref.exit.type == TRACE_TYPE_THREAD_EXIT) {
-        handle_thread_exit(memref.exit.tid);
-        last_thread = 0;
-    } else {
-        ERRMSG("unhandled memref type");
-        return false;
-    }
-
-    if (knob_verbose >= 3) {
-        if (type_is_instr(memref.instr.type)) {
+        memref.instr.type == TRACE_TYPE_PREFETCH_INSTR) {
+        if (knob_verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
                 " @" << (void *)memref.instr.addr << " instr x" <<
-                memref.instr.size << std::endl;
-        } else {
+                memref.instr.size << "\n";
+        }
+        icaches[core]->request(memref);
+    } else if (memref.data.type == TRACE_TYPE_READ ||
+               memref.data.type == TRACE_TYPE_WRITE ||
+               // We may potentially handle prefetches differently.
+               // TRACE_TYPE_PREFETCH_INSTR is handled above.
+               type_is_prefetch(memref.data.type)) {
+        if (knob_verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
                 " @" << (void *)memref.data.pc <<
                 " " << trace_type_names[memref.data.type] << " " <<
-                (void *)memref.data.addr << " x" << memref.data.size << std::endl;
+                (void *)memref.data.addr << " x" << memref.data.size << "\n";
         }
+        dcaches[core]->request(memref);
+    } else if (memref.flush.type == TRACE_TYPE_INSTR_FLUSH) {
+        if (knob_verbose >= 3) {
+            std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
+                " @" << (void *)memref.data.pc << " iflush " <<
+                (void *)memref.data.addr << " x" << memref.data.size << "\n";
+        }
+        icaches[core]->flush(memref);
+    } else if (memref.flush.type == TRACE_TYPE_DATA_FLUSH) {
+        if (knob_verbose >= 3) {
+            std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
+                " @" << (void *)memref.data.pc << " dflush " <<
+                (void *)memref.data.addr << " x" << memref.data.size << "\n";
+        }
+        dcaches[core]->flush(memref);
+    } else if (memref.exit.type == TRACE_TYPE_THREAD_EXIT) {
+        handle_thread_exit(memref.exit.tid);
+        last_thread = 0;
+    } else if (memref.marker.type == TRACE_TYPE_MARKER) {
+        if (knob_verbose >= 3) {
+            std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
+                "marker type " << memref.marker.marker_type <<
+                " value " << memref.marker.marker_value << "\n";
+        }
+    } else {
+        ERRMSG("unhandled memref type");
+        return false;
     }
 
     // process counters for warmup and simulated references

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -188,8 +188,9 @@ tlb_simulator_t::process_memref(const memref_t &memref)
     }
     else if (type_is_prefetch(memref.data.type) ||
              memref.flush.type == TRACE_TYPE_INSTR_FLUSH ||
-             memref.flush.type == TRACE_TYPE_DATA_FLUSH) {
-      // TLB simulator ignores prefetching and cache flushing
+             memref.flush.type == TRACE_TYPE_DATA_FLUSH ||
+             memref.marker.type == TRACE_TYPE_MARKER) {
+        // TLB simulator ignores prefetching, cache flushing, and markers
     } else {
         ERRMSG("unhandled memref type");
         return false;

--- a/clients/drcachesim/tests/basic_counts.templatex
+++ b/clients/drcachesim/tests/basic_counts.templatex
@@ -1,0 +1,42 @@
+Privileged instructions about to happen
+Privileged instruction, instance 1
+Privileged instruction, instance 2
+Privileged instruction, instance 3
+Privileged instruction, instance 4
+OK instr about to happen
+Bad instr about to happen
+Invalid lock sequence, instance 1
+eax=1 ebx=2 ecx=3 edx=4 edi=5 esi=6 ebp=7
+Invalid instructions about to happen
+Bad instruction, instance 1
+Bad instruction, instance 2
+Bad instruction, instance 3
+Bad instruction, instance 4
+Bad instruction, instance 5
+Bad instruction, instance 6
+Bad instruction, instance 7
+Bad instruction, instance 8
+All done
+---- <application exited with code 0> ----
+Basic counts tool results:
+Total counts:
+     .* total instructions
+     .* total prefetches
+     .* total data loads
+     .* total data stores
+#if defined(WINDOWS) && !defined(X64)
+          26 total markers
+#else
+          13 total markers
+#endif
+           1 total threads
+Thread .* counts:
+     .* instructions
+     .* prefetches
+     .* data loads
+     .* data stores
+#if defined(WINDOWS) && !defined(X64)
+          26 markers
+#else
+          13 markers
+#endif

--- a/clients/drcachesim/tests/offline-basic_counts.templatex
+++ b/clients/drcachesim/tests/offline-basic_counts.templatex
@@ -1,0 +1,41 @@
+Privileged instructions about to happen
+Privileged instruction, instance 1
+Privileged instruction, instance 2
+Privileged instruction, instance 3
+Privileged instruction, instance 4
+OK instr about to happen
+Bad instr about to happen
+Invalid lock sequence, instance 1
+eax=1 ebx=2 ecx=3 edx=4 edi=5 esi=6 ebp=7
+Invalid instructions about to happen
+Bad instruction, instance 1
+Bad instruction, instance 2
+Bad instruction, instance 3
+Bad instruction, instance 4
+Bad instruction, instance 5
+Bad instruction, instance 6
+Bad instruction, instance 7
+Bad instruction, instance 8
+All done
+Basic counts tool results:
+Total counts:
+     .* total instructions
+     .* total prefetches
+     .* total data loads
+     .* total data stores
+#if defined(WINDOWS) && !defined(X64)
+          26 total markers
+#else
+          13 total markers
+#endif
+           1 total threads
+Thread .* counts:
+     .* instructions
+     .* prefetches
+     .* data loads
+     .* data stores
+#if defined(WINDOWS) && !defined(X64)
+          26 markers
+#else
+          13 markers
+#endif

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -1,0 +1,117 @@
+/* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+#include "basic_counts.h"
+#include "../common/utils.h"
+
+const std::string basic_counts_t::TOOL_NAME = "Basic counts tool";
+
+analysis_tool_t *
+basic_counts_tool_create(unsigned int verbose)
+{
+    return new basic_counts_t(verbose);
+}
+
+basic_counts_t::basic_counts_t(unsigned int verbose) :
+    total_threads(0), total_instrs(0), total_prefetches(0), total_loads(0),
+    total_stores(0), total_markers(0), knob_verbose(verbose)
+{
+    // Empty.
+}
+
+basic_counts_t::~basic_counts_t()
+{
+    // Empty.
+}
+
+bool
+basic_counts_t::process_memref(const memref_t &memref)
+{
+  if (type_is_instr(memref.instr.type)) {
+      ++thread_instrs[memref.instr.tid];
+      ++total_instrs;
+  } else if (type_is_prefetch(memref.data.type)) {
+      ++thread_prefetches[memref.data.tid];
+      ++total_prefetches;
+  } else if (memref.data.type == TRACE_TYPE_READ) {
+      ++thread_loads[memref.data.tid];
+      ++total_loads;
+  } else if (memref.data.type == TRACE_TYPE_WRITE) {
+      ++thread_stores[memref.data.tid];
+      ++total_stores;
+  } else if (memref.data.type == TRACE_TYPE_MARKER) {
+      ++thread_markers[memref.data.tid];
+      ++total_markers;
+  } else if (memref.data.type == TRACE_TYPE_THREAD_EXIT) {
+      ++total_threads;
+  }
+  return true;
+}
+
+static bool
+cmp_val(const std::pair<memref_tid_t, int_least64_t> &l,
+        const std::pair<memref_tid_t, int_least64_t> &r)
+{
+    return (l.second > r.second);
+}
+
+bool
+basic_counts_t::print_results() {
+    std::cerr << TOOL_NAME << " results:\n";
+    std::cerr << "Total counts:\n";
+    std::cerr << std::setw(12) << total_instrs << " total instructions\n";
+    std::cerr << std::setw(12) << total_prefetches << " total prefetches\n";
+    std::cerr << std::setw(12) << total_loads << " total data loads\n";
+    std::cerr << std::setw(12) << total_stores << " total data stores\n";
+    std::cerr << std::setw(12) << total_markers << " total markers\n";
+    std::cerr << std::setw(12) << total_threads << " total threads\n";
+
+    // Print the threads sorted by instrs.
+    std::vector<std::pair<memref_tid_t, int_least64_t>> sorted(thread_instrs.begin(),
+                                                               thread_instrs.end());
+    std::sort(sorted.begin(), sorted.end(), cmp_val);
+    for (const auto& keyvals : sorted) {
+        memref_tid_t tid = keyvals.first;
+        std::cerr << "Thread " << tid << " counts:\n";
+        std::cerr << std::setw(12) << thread_instrs[tid] << " instructions\n";
+        std::cerr << std::setw(12) << thread_prefetches[tid] << " prefetches\n";
+        std::cerr << std::setw(12) << thread_loads[tid] << " data loads\n";
+        std::cerr << std::setw(12) << thread_stores[tid] << " data stores\n";
+        std::cerr << std::setw(12) << thread_markers[tid] << " markers\n";
+    }
+    return true;
+}

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -30,33 +30,38 @@
  * DAMAGE.
  */
 
-#ifndef _REUSE_TIME_H_
-#define _REUSE_TIME_H_ 1
+#ifndef _BASIC_COUNTS_H_
+#define _BASIC_COUNTS_H_ 1
 
 #include <unordered_map>
 #include <string>
 
 #include "analysis_tool.h"
 
-class reuse_time_t : public analysis_tool_t
+class basic_counts_t : public analysis_tool_t
 {
  public:
-    reuse_time_t(unsigned int line_size, unsigned int verbose);
-    virtual ~reuse_time_t();
+    basic_counts_t(unsigned int verbose);
+    virtual ~basic_counts_t();
     virtual bool process_memref(const memref_t &memref);
     virtual bool print_results();
 
  protected:
-    std::unordered_map<addr_t, int_least64_t> time_map;
-    int_least64_t time_stamp;
-    int_least64_t total_instructions;
-    std::unordered_map<int_least64_t, int_least64_t> reuse_time_histogram;
+    int_least64_t total_threads;
+    int_least64_t total_instrs;
+    int_least64_t total_prefetches;
+    int_least64_t total_loads;
+    int_least64_t total_stores;
+    int_least64_t total_markers;
+    std::unordered_map<memref_tid_t, int_least64_t> thread_instrs;
+    std::unordered_map<memref_tid_t, int_least64_t> thread_prefetches;
+    std::unordered_map<memref_tid_t, int_least64_t> thread_loads;
+    std::unordered_map<memref_tid_t, int_least64_t> thread_stores;
+    std::unordered_map<memref_tid_t, int_least64_t> thread_markers;
 
     unsigned int knob_verbose;
-    unsigned int knob_line_size;
-    unsigned int line_size_bits;
 
     static const std::string TOOL_NAME;
 };
 
-#endif /* _REUSE_TIME_H_ */
+#endif /* _BASIC_COUNTS_H_ */

--- a/clients/drcachesim/tools/basic_counts_create.h
+++ b/clients/drcachesim/tools/basic_counts_create.h
@@ -30,33 +30,14 @@
  * DAMAGE.
  */
 
-#ifndef _REUSE_TIME_H_
-#define _REUSE_TIME_H_ 1
+/* basic-counts tool creation */
 
-#include <unordered_map>
-#include <string>
+#ifndef _BASIC_COUNTS_CREATE_H_
+#define _BASIC_COUNTS_CREATE_H_ 1
 
 #include "analysis_tool.h"
 
-class reuse_time_t : public analysis_tool_t
-{
- public:
-    reuse_time_t(unsigned int line_size, unsigned int verbose);
-    virtual ~reuse_time_t();
-    virtual bool process_memref(const memref_t &memref);
-    virtual bool print_results();
+analysis_tool_t *
+basic_counts_tool_create(unsigned int verbose = 0);
 
- protected:
-    std::unordered_map<addr_t, int_least64_t> time_map;
-    int_least64_t time_stamp;
-    int_least64_t total_instructions;
-    std::unordered_map<int_least64_t, int_least64_t> reuse_time_histogram;
-
-    unsigned int knob_verbose;
-    unsigned int knob_line_size;
-    unsigned int line_size_bits;
-
-    static const std::string TOOL_NAME;
-};
-
-#endif /* _REUSE_TIME_H_ */
+#endif /* _BASIC_COUNTS_CREATE_H_ */

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -69,6 +69,7 @@ public:
     virtual int append_pid(byte *buf_ptr, process_id_t pid) = 0;
     virtual int append_tid(byte *buf_ptr, thread_id_t tid) = 0;
     virtual int append_thread_exit(byte *buf_ptr, thread_id_t tid) = 0;
+    virtual int append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr_t val) = 0;
     virtual int append_iflush(byte *buf_ptr, addr_t start, size_t size) = 0;
     virtual int append_thread_header(byte *buf_ptr, thread_id_t tid) = 0;
     // This is a per-buffer-writeout header.
@@ -125,6 +126,7 @@ public:
     virtual int append_pid(byte *buf_ptr, process_id_t pid);
     virtual int append_tid(byte *buf_ptr, thread_id_t tid);
     virtual int append_thread_exit(byte *buf_ptr, thread_id_t tid);
+    virtual int append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr_t val);
     virtual int append_iflush(byte *buf_ptr, addr_t start, size_t size);
     virtual int append_thread_header(byte *buf_ptr, thread_id_t tid);
     virtual int append_unit_header(byte *buf_ptr, thread_id_t tid);
@@ -176,6 +178,7 @@ public:
     virtual int append_pid(byte *buf_ptr, process_id_t pid);
     virtual int append_tid(byte *buf_ptr, thread_id_t tid);
     virtual int append_thread_exit(byte *buf_ptr, thread_id_t tid);
+    virtual int append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr_t val);
     virtual int append_iflush(byte *buf_ptr, addr_t start, size_t size);
     virtual int append_thread_header(byte *buf_ptr, thread_id_t tid);
     virtual int append_unit_header(byte *buf_ptr, thread_id_t tid);

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -232,7 +232,21 @@ offline_instru_t::append_thread_exit(byte *buf_ptr, thread_id_t tid)
     offline_entry_t *entry = (offline_entry_t *) buf_ptr;
     entry->extended.type = OFFLINE_TYPE_EXTENDED;
     entry->extended.ext = OFFLINE_EXT_TYPE_FOOTER;
-    entry->extended.value = 0;
+    entry->extended.valueA = 0;
+    entry->extended.valueB = 0;
+    return sizeof(offline_entry_t);
+}
+
+int
+offline_instru_t::append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr_t val)
+{
+    offline_entry_t *entry = (offline_entry_t *) buf_ptr;
+    entry->extended.type = OFFLINE_TYPE_EXTENDED;
+    entry->extended.ext = OFFLINE_EXT_TYPE_MARKER;
+    DR_ASSERT(type < 1<<EXT_VALUE_B_BITS);
+    entry->extended.valueB = type;
+    DR_ASSERT(val < 1ULL<<EXT_VALUE_A_BITS);
+    entry->extended.valueA = val;
     return sizeof(offline_entry_t);
 }
 
@@ -254,7 +268,8 @@ offline_instru_t::append_thread_header(byte *buf_ptr, thread_id_t tid)
     offline_entry_t *entry = (offline_entry_t *) buf_ptr;
     entry->extended.type = OFFLINE_TYPE_EXTENDED;
     entry->extended.ext = OFFLINE_EXT_TYPE_HEADER;
-    entry->extended.value = OFFLINE_FILE_VERSION;
+    entry->extended.valueA = OFFLINE_FILE_VERSION;
+    entry->extended.valueB = 0;
     return sizeof(offline_entry_t) +
         append_unit_header(buf_ptr + sizeof(offline_entry_t), tid);
 }

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -243,9 +243,9 @@ offline_instru_t::append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr
     offline_entry_t *entry = (offline_entry_t *) buf_ptr;
     entry->extended.type = OFFLINE_TYPE_EXTENDED;
     entry->extended.ext = OFFLINE_EXT_TYPE_MARKER;
-    DR_ASSERT(type < 1<<EXT_VALUE_B_BITS);
+    DR_ASSERT((int)type < 1<<EXT_VALUE_B_BITS);
     entry->extended.valueB = type;
-    DR_ASSERT(val < 1ULL<<EXT_VALUE_A_BITS);
+    DR_ASSERT((unsigned long long)val < 1ULL<<EXT_VALUE_A_BITS);
     entry->extended.valueA = val;
     return sizeof(offline_entry_t);
 }

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -117,6 +117,16 @@ online_instru_t::append_thread_exit(byte *buf_ptr, thread_id_t tid)
 }
 
 int
+online_instru_t::append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr_t val)
+{
+    trace_entry_t *entry = (trace_entry_t *) buf_ptr;
+    entry->type = TRACE_TYPE_MARKER;
+    entry->size = (ushort) type;
+    entry->addr = (addr_t) val;
+    return sizeof(trace_entry_t);
+}
+
+int
 online_instru_t::append_iflush(byte *buf_ptr, addr_t start, size_t size)
 {
     trace_entry_t *entry = (trace_entry_t *) buf_ptr;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -529,6 +529,15 @@ raw2trace_t::merge_and_process_thread_files()
                 buf += size;
                 --thread_count;
                 tidx = (uint)thread_files.size(); // Request thread scan.
+            } else if (in_entry.extended.ext == OFFLINE_EXT_TYPE_MARKER) {
+                trace_entry_t *entry = (trace_entry_t *) buf;
+                entry->type = TRACE_TYPE_MARKER;
+                entry->size = in_entry.extended.valueB;
+                entry->addr = (addr_t) in_entry.extended.valueA;
+                VPRINT(3, "Appended marker type %u value %zu\n", entry->size,
+                       entry->addr);
+                size += sizeof(*entry);
+                buf += size;
             } else {
                 std::stringstream ss;
                 ss << "Invalid extension type " << (int)in_entry.extended.ext;
@@ -606,10 +615,10 @@ raw2trace_t::check_thread_file(std::istream *f)
         ver_entry.extended.ext != OFFLINE_EXT_TYPE_HEADER) {
         return "Thread log file is corrupted: missing version entry";
     }
-    if (ver_entry.extended.value != OFFLINE_FILE_VERSION) {
+    if (ver_entry.extended.valueA != OFFLINE_FILE_VERSION) {
         std::stringstream ss;
         ss << "Version mismatch: expect " << OFFLINE_FILE_VERSION << " vs "
-           << (int)ver_entry.extended.value;
+           << (int)ver_entry.extended.valueA;
         return ss.str();
     }
     return "";

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2593,7 +2593,7 @@ if (CLIENT_INTERFACE)
       macro (torunonly_drcacheoff testname exetgt tracer_ops sim_atops app_args)
         torunonly_ci(tool.drcacheoff.${testname} ${exetgt} drcachesim
           "offline-${testname}.c" # for templatex basename
-          "-offline ${extra_ops}" "" "${app_args}")
+          "-offline ${tracer_ops}" "" "${app_args}")
         set(tool.drcacheoff.${testname}_toolname "drcachesim")
         set(tool.drcacheoff.${testname}_basedir
           "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2559,6 +2559,13 @@ if (CLIENT_INTERFACE)
       set(tool.reuse_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
 
+      # We run common.decode-bad to test markers for faults
+      torunonly_ci(tool.basic_counts common.decode-bad drcachesim
+        "basic_counts.c" # for templatex basename
+        "-ipc_name ${IPC_PREFIX}drtestpipe7 -simulator_type basic_counts" "" "")
+      set(tool.basic_counts_toolname "drcachesim")
+      set(tool.basic_counts_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+
       if (X86 AND X64) # We only bother with a sample trace for x86_64.
         # We test with a fixed trace file so we can test exact numeric results.
         set(small_trace_file
@@ -2582,7 +2589,8 @@ if (CLIENT_INTERFACE)
       get_target_path_for_execution(drcachesim_path drcachesim)
       prefix_cmd_if_necessary(drcachesim_path ON ${drcachesim_path})
 
-      macro (torunonly_drcacheoff testname exetgt extra_ops app_args)
+      # The sim_atops should start with @ and be in @-as-space format (hence "atops")
+      macro (torunonly_drcacheoff testname exetgt tracer_ops sim_atops app_args)
         torunonly_ci(tool.drcacheoff.${testname} ${exetgt} drcachesim
           "offline-${testname}.c" # for templatex basename
           "-offline ${extra_ops}" "" "${app_args}")
@@ -2595,50 +2603,55 @@ if (CLIENT_INTERFACE)
         set(tool.drcacheoff.${testname}_precmd
           "foreach@${CMAKE_COMMAND}@-E@remove_directory@drmemtrace.${exetgt}.*.dir")
         set(tool.drcacheoff.${testname}_postcmd
-          "${drcachesim_path}@-indir@drmemtrace.${exetgt}.*.dir")
+          "${drcachesim_path}@-indir@drmemtrace.${exetgt}.*.dir${sim_atops}")
       endmacro()
 
       # We could share drcachesim-simple.templatex if we had the launcher fork
       # and print out the "---- <application exited with code 0> ----".
-      torunonly_drcacheoff(simple ${ci_shared_app} "" "")
+      torunonly_drcacheoff(simple ${ci_shared_app} "" "" "")
 
       if (UNIX) # Enable on Windows once i#1727 is fixed.
         # FIXME i#2384: we need to combine the subdir from the child with the
         # parent in some way and update the templatex file to include both.
         # Right now we're only ensuring this doesn't crash and that one of
         # the processes produced traces.
-        torunonly_drcacheoff(multiproc tool.multiproc "" "${tool.multiproc_path}")
+        torunonly_drcacheoff(multiproc tool.multiproc "" "" "${tool.multiproc_path}")
       endif ()
 
-      torunonly_drcacheoff(filter ${ci_shared_app} "-L0_filter" "")
+      torunonly_drcacheoff(filter ${ci_shared_app} "-L0_filter" "" "")
       # We're using the same app so we serialize to avoid racing trace dirs:
       set(tool.drcacheoff.filter_depends tool.drcacheoff.simple)
+
+      # We run common.decode-bad to test markers for faults
+      torunonly_drcacheoff(basic_counts common.decode-bad ""
+        "@-simulator_type@basic_counts" "")
+      unset(tool.drcacheoff.basic_counts_rawtemp)
 
       # FIXME i#2007: fails to link on A64
       # XXX i#1551: startstop API is NYI on ARM
       # XXX i#1997: dynamorio_static is not supported on Mac yet
       if (NOT AARCH64 AND NOT ARM AND NOT APPLE)
-        torunonly_drcacheoff(burst_static tool.drcacheoff.burst_static "" "")
+        torunonly_drcacheoff(burst_static tool.drcacheoff.burst_static "" "" "")
         set(tool.drcacheoff.burst_static_nodr ON)
 
-        torunonly_drcacheoff(burst_replace tool.drcacheoff.burst_replace "" "")
+        torunonly_drcacheoff(burst_replace tool.drcacheoff.burst_replace "" "" "")
         set(tool.drcacheoff.burst_replace_nodr ON)
 
-        torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall "" "")
+        torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall "" "" "")
         set(tool.drcacheoff.burst_replaceall_nodr ON)
 
         if (X64 AND UNIX)
-          torunonly_drcacheoff(burst_noreach tool.drcacheoff.burst_noreach "" "")
+          torunonly_drcacheoff(burst_noreach tool.drcacheoff.burst_noreach "" "" "")
           set(tool.drcacheoff.burst_noreach_nodr ON)
         endif ()
         if (LINUX)
-          torunonly_drcacheoff(burst_maps tool.drcacheoff.burst_maps "" "")
+          torunonly_drcacheoff(burst_maps tool.drcacheoff.burst_maps "" "" "")
           set(tool.drcacheoff.burst_maps_nodr ON)
         endif ()
 
         if (UNIX)
           # FIXME i#2040: this hits static client issues on Windows
-          torunonly_drcacheoff(burst_threads tool.drcacheoff.burst_threads "" "")
+          torunonly_drcacheoff(burst_threads tool.drcacheoff.burst_threads "" "" "")
           set(tool.drcacheoff.burst_threads_nodr ON)
 
           if (X86 AND NOT APPPLE) # This test is x86-specific.
@@ -2665,7 +2678,7 @@ if (CLIENT_INTERFACE)
           endif()
 
           # FIXME i#2099: the weak symbol is not supported not work on Windows
-          torunonly_drcacheoff(burst_client tool.drcacheoff.burst_client "" "")
+          torunonly_drcacheoff(burst_client tool.drcacheoff.burst_client "" "" "")
           set(tool.drcacheoff.burst_client_nodr ON)
         endif ()
       endif ()


### PR DESCRIPTION
Adds the concept of "marker entries" to drcachesim's traces, which can be
used to store metadata about a location in a trace.

Uses DR's new kernel xfer event to insert trace marker entries on
kernel-mediated control transfers: signal handlers, signal returns, Windows
APCs, exceptions, callbacks, etc.

To help with testing, adds a new tool basic_counts which counts the number
of each trace entry type per thread in the trace.

Adds new online and offline tests that run the basic_counts tool it on the
common.decode-bad test binary.

Fixes #2708