### PR TITLE
i#2725 xfer under app locks: add dr_app_recurlock_lock

### DIFF
--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -3647,7 +3647,8 @@ DR_API
 void
 dr_app_recurlock_lock(void *reclock, dr_mcontext_t *mc)
 {
-    acquire_recursive_app_lock((recursive_lock_t *)reclock, dr_mcontext_as_priv_mcontext(mc));
+    acquire_recursive_app_lock((recursive_lock_t *)reclock,
+                               dr_mcontext_as_priv_mcontext(mc));
 }
 
 DR_API

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -3645,6 +3645,13 @@ dr_recurlock_lock(void *reclock)
 
 DR_API
 void
+dr_app_recurlock_lock(void *reclock, dr_mcontext_t *mc)
+{
+    acquire_recursive_app_lock((recursive_lock_t *)reclock, dr_mcontext_as_priv_mcontext(mc));
+}
+
+DR_API
+void
 dr_recurlock_unlock(void *reclock)
 {
     release_recursive_lock((recursive_lock_t *)reclock);

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -3647,6 +3647,9 @@ DR_API
 void
 dr_app_recurlock_lock(void *reclock, dr_mcontext_t *mc)
 {
+    CLIENT_ASSERT(mc->flags == DR_MC_ALL,
+                  "mcontext must be for DR_MC_ALL");
+
     acquire_recursive_app_lock((recursive_lock_t *)reclock,
                                dr_mcontext_as_priv_mcontext(mc));
 }

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -2781,6 +2781,20 @@ void
 dr_recurlock_lock(void *reclock);
 
 DR_API
+/**
+ * Acquires \p reclock, or increments the ownership count if already owned.
+ * Calls to this method which block (i.e. when the lock is already held) are
+ * marked safe to suspend AND transfer; in that case the provided mcontext will
+ * overwrite the current thread's mcontext. The provided mcontext must have a
+ * valid PC field.
+ *
+ * Callers of this function must resume application execution via
+ * dr_redirect_execution, lest they return into a flushed code page.
+ */
+void
+dr_app_recurlock_lock(void *reclock, dr_mcontext_t *mc);
+
+DR_API
 /** Decrements the ownership count of \p reclock and releases if zero. */
 void
 dr_recurlock_unlock(void *reclock);

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -936,10 +936,9 @@ bool at_known_exception(dcontext_t *dcontext, app_pc target_pc, app_pc source_fr
 /* contended path of mutex operations */
 bool ksynch_var_initialized(KSYNCH_TYPE *var);
 /* If mc != NULL we mark this thread safe to suspend and transfer with a valid
- * mcontext (THREAD_SYNCH_VALID_MCONTEXT). Note that passing a non-NULL mc is
- * only valid in the CLIENT_INTERFACE.
+ * mcontext (THREAD_SYNCH_VALID_MCONTEXT).
  */
-void mutex_wait_contended_lock(mutex_t *lock, priv_mcontext_t *mc);
+void mutex_wait_contended_lock(mutex_t *lock _IF_CLIENT_INTERFACE(priv_mcontext_t *mc));
 void mutex_notify_released_lock(mutex_t *lock);
 void mutex_free_contended_event(mutex_t *lock);
 /* contended path of rwlock operations */

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -936,7 +936,8 @@ bool at_known_exception(dcontext_t *dcontext, app_pc target_pc, app_pc source_fr
 /* contended path of mutex operations */
 bool ksynch_var_initialized(KSYNCH_TYPE *var);
 /* If mc != NULL we mark this thread safe to suspend and transfer with a valid
- * mcontext (THREAD_SYNCH_VALID_MCONTEXT).
+ * mcontext (THREAD_SYNCH_VALID_MCONTEXT). Note that means that all fields of
+ * \p mc must be valid (e.g. PC, control, integer, MMX fields).
  */
 void mutex_wait_contended_lock(mutex_t *lock _IF_CLIENT_INTERFACE(priv_mcontext_t *mc));
 void mutex_notify_released_lock(mutex_t *lock);

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -935,7 +935,11 @@ bool at_known_exception(dcontext_t *dcontext, app_pc target_pc, app_pc source_fr
 
 /* contended path of mutex operations */
 bool ksynch_var_initialized(KSYNCH_TYPE *var);
-void mutex_wait_contended_lock(mutex_t *lock);
+/* If mc != NULL we mark this thread safe to suspend and transfer with a valid
+ * mcontext (THREAD_SYNCH_VALID_MCONTEXT). Note that passing a non-NULL mc is
+ * only valid in the CLIENT_INTERFACE.
+ */
+void mutex_wait_contended_lock(mutex_t *lock, priv_mcontext_t *mc);
 void mutex_notify_released_lock(mutex_t *lock);
 void mutex_free_contended_event(mutex_t *lock);
 /* contended path of rwlock operations */

--- a/core/synch.c
+++ b/core/synch.c
@@ -609,6 +609,9 @@ should_wait_at_safe_spot(dcontext_t *dcontext)
 void
 set_synch_state(dcontext_t *dcontext, thread_synch_permission_t state)
 {
+    if (state >= THREAD_SYNCH_NO_LOCKS)
+        ASSERT_OWN_NO_LOCKS();
+
     thread_synch_data_t *tsd = (thread_synch_data_t *) dcontext->synch_field;
     spinmutex_lock(tsd->synch_lock);
     tsd->synch_perm = state;

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -9360,7 +9360,7 @@ get_memory_info_from_os(const byte *pc, byte **base_pc, size_t *size,
 extern void deadlock_avoidance_unlock(mutex_t *lock, bool ownable);
 
 void
-mutex_wait_contended_lock(mutex_t *lock, priv_mcontext_t *mc)
+mutex_wait_contended_lock(mutex_t *lock _IF_CLIENT_INTERFACE(priv_mcontext_t *mc))
 {
 #ifdef CLIENT_INTERFACE
     dcontext_t *dcontext = get_thread_private_dcontext();
@@ -9369,12 +9369,13 @@ mutex_wait_contended_lock(mutex_t *lock, priv_mcontext_t *mc)
                         ((mutex_t *)dcontext->client_data->client_grab_mutex == lock));
     if (mc != NULL) {
         ASSERT(dcontext != NULL);
+        /* set_safe_for_sync can't be true at the same time as passing
+         * an mcontext to return into: nothing would be able to reset the
+         * client_thread_safe_for_sync flag.
+         */
+        ASSERT(!set_client_safe_for_synch);
         *get_mcontext(dcontext) = *mc;
     }
-#else
-    DR_ASSERT_MSG(mc == NULL,
-               "passing a priv_mcontext_t to mutex_wait_contended_lock is not "
-               "supported on outside of the client interface.");
 #endif
 
     /* i#96/PR 295561: use futex(2) if available */

--- a/core/utils.c
+++ b/core/utils.c
@@ -841,12 +841,6 @@ mutex_ownable(mutex_t *lock)
 #endif
 
 void
-mutex_lock(mutex_t *lock)
-{
-    mutex_lock_app(lock _IF_CLIENT_INTERFACE(NULL));
-}
-
-void
 mutex_lock_app(mutex_t *lock _IF_CLIENT_INTERFACE(priv_mcontext_t *mc))
 {
     bool acquired;
@@ -902,6 +896,12 @@ mutex_lock_app(mutex_t *lock _IF_CLIENT_INTERFACE(priv_mcontext_t *mc))
             lock->max_contended_requests = (uint)lock->lock_requests;
 #       endif
     }
+}
+
+void
+mutex_lock(mutex_t *lock)
+{
+    mutex_lock_app(lock _IF_CLIENT_INTERFACE(NULL));
 }
 
 /* try once to grab the lock, return whether or not successful */

--- a/core/utils.c
+++ b/core/utils.c
@@ -843,6 +843,12 @@ mutex_ownable(mutex_t *lock)
 void
 mutex_lock(mutex_t *lock)
 {
+    mutex_lock_app(lock, NULL);
+}
+
+void
+mutex_lock_app(mutex_t *lock, priv_mcontext_t *mc)
+{
     bool acquired;
 #ifdef DEADLOCK_AVOIDANCE
     bool ownable = mutex_ownable(lock);
@@ -888,7 +894,7 @@ mutex_lock(mutex_t *lock)
     DEADLOCK_AVOIDANCE_LOCK(lock, acquired, ownable);
 
     if (!acquired) {
-        mutex_wait_contended_lock(lock);
+        mutex_wait_contended_lock(lock, mc);
 #       ifdef DEADLOCK_AVOIDANCE
         DEADLOCK_AVOIDANCE_LOCK(lock, true, ownable); /* now we got it  */
         /* this and previous owner are not included in lock_requests */
@@ -988,6 +994,12 @@ own_recursive_lock(recursive_lock_t *lock)
 void
 acquire_recursive_lock(recursive_lock_t *lock)
 {
+    acquire_recursive_app_lock(lock, NULL);
+}
+
+void
+acquire_recursive_app_lock(recursive_lock_t *lock, priv_mcontext_t *mc)
+{
     /* we no longer use the pattern of implementing acquire_lock as a
        busy try_lock
     */
@@ -996,7 +1008,7 @@ acquire_recursive_lock(recursive_lock_t *lock)
     if (lock->owner == get_thread_id()) {
         lock->count++;
     } else {
-        mutex_lock(&lock->lock);
+        mutex_lock_app(&lock->lock, mc);
         own_recursive_lock(lock);
     }
 }

--- a/core/utils.h
+++ b/core/utils.h
@@ -716,6 +716,12 @@ void mutex_delete(mutex_t *lock);
 
 /* basic synchronization functions */
 void mutex_lock(mutex_t *mutex);
+/* Use this version of 'lock' when obtaining a lock in an app context. In the
+ * case that there is contention on this lock, this thread will be marked safe
+ * to be relocated and even detached. The current thread's mcontext may be
+ * clobbered with the provided value even if the thread is not suspended.
+ */
+void mutex_lock_app(mutex_t *mutex, priv_mcontext_t *mc);
 bool mutex_trylock(mutex_t *mutex);
 void mutex_unlock(mutex_t *mutex);
 #ifdef UNIX
@@ -751,6 +757,12 @@ mutex_testlock(mutex_t *lock)
 
 /* A recursive lock can be taken more than once by the owning thread */
 void acquire_recursive_lock(recursive_lock_t *lock);
+/* Use this version of 'lock' when obtaining a lock in an app context. In the
+ * case that there is contention on this lock, this thread will be marked safe
+ * to be relocated and even detached. The current thread's mcontext may be
+ * clobbered with the provided value even if the thread is not suspended.
+ */
+void acquire_recursive_app_lock(recursive_lock_t *mutex, priv_mcontext_t *mc);
 bool try_recursive_lock(recursive_lock_t *lock);
 void release_recursive_lock(recursive_lock_t *lock);
 bool self_owns_recursive_lock(recursive_lock_t *lock);

--- a/core/utils.h
+++ b/core/utils.h
@@ -716,12 +716,6 @@ void mutex_delete(mutex_t *lock);
 
 /* basic synchronization functions */
 void mutex_lock(mutex_t *mutex);
-/* Use this version of 'lock' when obtaining a lock in an app context. In the
- * case that there is contention on this lock, this thread will be marked safe
- * to be relocated and even detached. The current thread's mcontext may be
- * clobbered with the provided value even if the thread is not suspended.
- */
-void mutex_lock_app(mutex_t *mutex, priv_mcontext_t *mc);
 bool mutex_trylock(mutex_t *mutex);
 void mutex_unlock(mutex_t *mutex);
 #ifdef UNIX
@@ -729,6 +723,12 @@ void mutex_fork_reset(mutex_t *mutex);
 #endif
 #ifdef CLIENT_INTERFACE
 void mutex_mark_as_app(mutex_t *lock);
+/* Use this version of 'lock' when obtaining a lock in an app context. In the
+ * case that there is contention on this lock, this thread will be marked safe
+ * to be relocated and even detached. The current thread's mcontext may be
+ * clobbered with the provided value even if the thread is not suspended.
+ */
+void mutex_lock_app(mutex_t *mutex, priv_mcontext_t *mc);
 #endif
 
 /* spinmutex synchronization */

--- a/core/utils.h
+++ b/core/utils.h
@@ -757,15 +757,17 @@ mutex_testlock(mutex_t *lock)
 
 /* A recursive lock can be taken more than once by the owning thread */
 void acquire_recursive_lock(recursive_lock_t *lock);
+bool try_recursive_lock(recursive_lock_t *lock);
+void release_recursive_lock(recursive_lock_t *lock);
+bool self_owns_recursive_lock(recursive_lock_t *lock);
+#ifdef CLIENT_INTERFACE
 /* Use this version of 'lock' when obtaining a lock in an app context. In the
  * case that there is contention on this lock, this thread will be marked safe
  * to be relocated and even detached. The current thread's mcontext may be
  * clobbered with the provided value even if the thread is not suspended.
  */
 void acquire_recursive_app_lock(recursive_lock_t *mutex, priv_mcontext_t *mc);
-bool try_recursive_lock(recursive_lock_t *lock);
-void release_recursive_lock(recursive_lock_t *lock);
-bool self_owns_recursive_lock(recursive_lock_t *lock);
+#endif
 
 /* A read write lock allows multiple readers or alternatively a single writer */
 void read_lock(read_write_lock_t *rw);

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -8299,15 +8299,29 @@ mutex_free_contended_event(mutex_t *lock)
     os_close(lock->contended_event);
 }
 
-/* common wrapper that also attempts to detect deadlocks */
-/* A 0 timeout_ms means to wait forever.  Returns false on timeout, true on signalled. */
+/* common wrapper that also attempts to detect deadlocks. Returns false on
+ * timeout, true on signalled.
+ *
+ * A 0 timeout_ms means to wait forever.
+ * A non-NULL mc will mark this thread save to suspend and transfer; setting mc
+ * requires a non-NULL dcontext to be passed.
+ */
 static bool
-os_wait_event(event_t e, int timeout_ms _IF_CLIENT_INTERFACE(bool set_safe_for_synch)
-              _IF_CLIENT_INTERFACE(dcontext_t *dcontext))
+os_wait_event(event_t e, int timeout_ms
+              _IF_CLIENT_INTERFACE(bool set_safe_for_synch)
+              _IF_CLIENT_INTERFACE(dcontext_t *dcontext)
+              _IF_CLIENT_INTERFACE(priv_mcontext_t *mc))
 {
     wait_status_t res;
     bool reported_timeout = false;
     LARGE_INTEGER timeout;
+
+#ifdef CLIENT_INTERFACE
+    if (mc != NULL) {
+        ASSERT(dcontext != NULL);
+        *get_mcontext(dcontext) = *mc;
+    }
+#endif
 
     KSTART(wait_event);
     /* we allow using this in release builds as well */
@@ -8319,11 +8333,15 @@ os_wait_event(event_t e, int timeout_ms _IF_CLIENT_INTERFACE(bool set_safe_for_s
         ASSERT(!set_safe_for_synch || dcontext != NULL);
         if (set_safe_for_synch)
             dcontext->client_data->client_thread_safe_for_synch = true;
+        if (mc != NULL)
+            set_synch_state(dcontext, THREAD_SYNCH_VALID_MCONTEXT);
 #endif
         res = nt_wait_event_with_timeout(e, &timeout /* debug timeout */);
 #ifdef CLIENT_INTERFACE
         if (set_safe_for_synch)
             dcontext->client_data->client_thread_safe_for_synch = false;
+        if (mc != NULL)
+            set_synch_state(dcontext, THREAD_SYNCH_NONE);
 #endif
         if (res == WAIT_SIGNALED) {
             KSTOP(wait_event);
@@ -8366,6 +8384,8 @@ os_wait_event(event_t e, int timeout_ms _IF_CLIENT_INTERFACE(bool set_safe_for_s
 #ifdef CLIENT_INTERFACE
     if (set_safe_for_synch)
         dcontext->client_data->client_thread_safe_for_synch = true;
+    if (mc != NULL)
+        set_synch_state(dcontext, THREAD_SYNCH_VALID_MCONTEXT);
 #endif
     if (timeout_ms > 0)
         timeout.QuadPart= -timeout_ms * TIMER_UNITS_PER_MILLISECOND;
@@ -8373,6 +8393,8 @@ os_wait_event(event_t e, int timeout_ms _IF_CLIENT_INTERFACE(bool set_safe_for_s
 #ifdef CLIENT_INTERFACE
     if (set_safe_for_synch)
         dcontext->client_data->client_thread_safe_for_synch = false;
+    if (mc != NULL)
+        set_synch_state(dcontext, THREAD_SYNCH_NONE);
 #endif
     if (reported_timeout) {
         /* Our wait eventually succeeded so not truly a deadlock.  Syslog a
@@ -8406,7 +8428,7 @@ os_wait_handle(HANDLE h, uint64 timeout_ms)
 #ifndef NOT_DYNAMORIO_CORE_PROPER
 
 void
-mutex_wait_contended_lock(mutex_t *lock)
+mutex_wait_contended_lock(mutex_t *lock, priv_mcontext_t *mc)
 {
     contention_event_t event =
         mutex_get_contended_event(&lock->contended_event, SynchronizationEvent);
@@ -8416,9 +8438,14 @@ mutex_wait_contended_lock(mutex_t *lock)
         (dcontext != NULL && IS_CLIENT_THREAD(dcontext) &&
          (mutex_t *)dcontext->client_data->client_grab_mutex == lock);
     ASSERT(!set_safe_for_sync || dcontext != NULL);
+#else
+    DR_ASSERT_MSG(mc == NULL,
+               "passing a priv_mcontext_t to mutex_wait_contended_lock is not "
+               "supported on outside of the client interface.");
 #endif
     os_wait_event(event, 0 _IF_CLIENT_INTERFACE(set_safe_for_sync)
-                  _IF_CLIENT_INTERFACE(dcontext));
+                  _IF_CLIENT_INTERFACE(dcontext)
+                  _IF_CLIENT_INTERFACE(mc));
     /* the event was signaled, and this thread was released,
        the auto-reset event is again nonsignaled for all other threads to wait on
     */
@@ -8437,7 +8464,8 @@ rwlock_wait_contended_writer(read_write_lock_t *rwlock)
 {
     contention_event_t event =
         mutex_get_contended_event(&rwlock->writer_waiting_readers, SynchronizationEvent);
-    os_wait_event(event, 0 _IF_CLIENT_INTERFACE(false) _IF_CLIENT_INTERFACE(NULL));
+    os_wait_event(event, 0 _IF_CLIENT_INTERFACE(false) _IF_CLIENT_INTERFACE(NULL)
+                  _IF_CLIENT_INTERFACE(NULL));
     /* the event was signaled, and this thread was released,
        the auto-reset event is again nonsignaled for all other threads to wait on
     */
@@ -8461,6 +8489,7 @@ rwlock_wait_contended_reader(read_write_lock_t *rwlock)
     contention_event_t notify_readers =
         mutex_get_contended_event(&rwlock->readers_waiting_writer, SynchronizationEvent);
     os_wait_event(notify_readers, 0 _IF_CLIENT_INTERFACE(false)
+                  _IF_CLIENT_INTERFACE(NULL)
                   _IF_CLIENT_INTERFACE(NULL));
     /* the event was signaled, and only a single threads waiting on
      * this event are released, if this was indeed the last reader
@@ -8507,6 +8536,7 @@ bool
 wait_for_event(event_t e, int timeout_ms)
 {
     return os_wait_event(e, timeout_ms _IF_CLIENT_INTERFACE(false)
+                         _IF_CLIENT_INTERFACE(NULL)
                          _IF_CLIENT_INTERFACE(NULL));
 }
 


### PR DESCRIPTION
This PR adds a new function to support transfer/relocation while waiting for a contended application mutex lock.

Fixes #2725