### PR TITLE
i#2051 rep ifetch: add no-fetch entries for rep strings

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -210,6 +210,7 @@ Further non-compatibility-affecting changes include:
  - Added a new option -ignore_all_libs to drcpusim.
  - Added a new tool basic_counts to drcachesim for counting up the
    different types of entries in a trace, broken down by thread.
+ - Added instr_is_string_op() and instr_is_rep_string_op().
 
 **************************************************
 <hr>

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -138,6 +138,14 @@ typedef enum {
     // A marker containing metadata about this point in the trace.
     // It includes a marker sub-type trace_marker_type_t and a value.
     TRACE_TYPE_MARKER,
+
+    // For core simulators, a trace includes instructions that do not incur
+    // instruction cache fetches, such as on each subsequent iteration of a
+    // rep string loop.
+    TRACE_TYPE_INSTR_NO_FETCH,
+    // An internal value used for online traces and turned by reader_t into
+    // either TRACE_TYPE_INSTR or TRACE_TYPE_INSTR_NO_FETCH.
+    TRACE_TYPE_INSTR_MAYBE_FETCH,
 } trace_type_t;
 
 // The sub-type for TRACE_TYPE_MARKER.
@@ -160,6 +168,8 @@ typedef enum {
 
 extern const char * const trace_type_names[];
 
+// Returns whether the type represents an instruction fetch.
+// Deliberately excludes TRACE_TYPE_INSTR_NO_FETCH.
 static inline bool
 type_is_instr(const trace_type_t type)
 {

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -45,6 +45,7 @@ simulator support multiple processes each with multiple threads.
  - \ref sec_drcachesim_run
  - \ref sec_drcachesim_sim
  - \ref sec_drcachesim_phys
+ - \ref sec_drcachesim_core
  - \ref sec_drcachesim_limit
  - \ref sec_drcachesim_extend
  - \ref sec_drcachesim_ops
@@ -91,7 +92,7 @@ bin64/drrun -t drcachesim -simulator_type reuse_distance -reuse_distance_histogr
 \endcode
 
 To simply see the counts of instructions and memory references broken down
-by thread use the basic count tool:
+by thread use the basic counts tool:
 
 \code
 bin64/drrun -t drcachesim -simulator_type basic_counts -- /path/to/target/app <args> <for> <app>
@@ -188,6 +189,16 @@ working from user mode on future kernels due to recent security changes
 (see
 http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=ab676b7d6fbf4b294bf198fb27ade5b0e865c7ce).
 
+\section sec_drcachesim_core Core Simulation Support
+
+The \p drcachesim trace format includes information intended for use by
+core simulators as well as pure cache simulators.  On x86, string loop
+instructions involve a single insruction fetch followed by a loop of loads
+and/or stores.  A \p drcachesim trace includes a special "no-fetch"
+instruction entry per iteration so that core simulators have the
+instruction information to go along with each load and store, while cache
+simulators can ignore these "no-fetch" entries and avoid incorrectly
+inflating instruction fetch statistics.
 
 \section sec_drcachesim_limit Current Limitations
 

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -43,7 +43,7 @@
 // Following typical stream iterator convention, the default constructor
 // produces an EOF object.
 reader_t::reader_t() : at_eof(true), input_entry(NULL), cur_tid(0), cur_pid(0),
-                       cur_pc(0), bundle_idx(0)
+                       cur_pc(0), prev_instr_addr(0), bundle_idx(0)
 {
     /* Empty. */
 }
@@ -101,6 +101,15 @@ reader_t::operator++()
             // use to obtain the PC for subsequent data references.
             cur_ref.data.pc = cur_pc;
             break;
+        case TRACE_TYPE_INSTR_MAYBE_FETCH:
+            // While offline traces can convert rep string per-iter instrs into
+            // no-fetch entries, online can't w/o extra work, so we do the work
+            // here:
+            if (prev_instr_addr == input_entry->addr)
+                input_entry->type = TRACE_TYPE_INSTR_NO_FETCH;
+            else
+                input_entry->type = TRACE_TYPE_INSTR;
+            /* fall through */
         case TRACE_TYPE_INSTR:
         case TRACE_TYPE_INSTR_DIRECT_JUMP:
         case TRACE_TYPE_INSTR_INDIRECT_JUMP:
@@ -108,6 +117,7 @@ reader_t::operator++()
         case TRACE_TYPE_INSTR_DIRECT_CALL:
         case TRACE_TYPE_INSTR_INDIRECT_CALL:
         case TRACE_TYPE_INSTR_RETURN:
+        case TRACE_TYPE_INSTR_NO_FETCH:
             have_memref = true;
             assert(cur_tid != 0 && cur_pid != 0);
             if (input_entry->size == 0) {
@@ -124,6 +134,7 @@ reader_t::operator++()
                 cur_pc = input_entry->addr;
                 cur_ref.instr.addr = cur_pc;
                 next_pc = cur_pc + cur_ref.instr.size;
+                prev_instr_addr = input_entry->addr;
             }
             break;
         case TRACE_TYPE_INSTR_BUNDLE:

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -87,6 +87,7 @@ class reader_t : public std::iterator<std::input_iterator_tag, memref_t>
     memref_pid_t cur_pid;
     addr_t cur_pc;
     addr_t next_pc;
+    addr_t prev_instr_addr;
     int bundle_idx;
     std::unordered_map<memref_tid_t, memref_pid_t> tid2pid;
 };

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -262,6 +262,13 @@ cache_simulator_t::process_memref(const memref_t &memref)
                 "marker type " << memref.marker.marker_type <<
                 " value " << memref.marker.marker_value << "\n";
         }
+    } else if (memref.marker.type == TRACE_TYPE_INSTR_NO_FETCH) {
+        // Just ignore.
+        if (knob_verbose >= 3) {
+            std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
+                " @" << (void *)memref.instr.addr << " non-fetched instr x" <<
+                memref.instr.size << "\n";
+        }
     } else {
         ERRMSG("unhandled memref type");
         return false;

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -189,7 +189,8 @@ tlb_simulator_t::process_memref(const memref_t &memref)
     else if (type_is_prefetch(memref.data.type) ||
              memref.flush.type == TRACE_TYPE_INSTR_FLUSH ||
              memref.flush.type == TRACE_TYPE_DATA_FLUSH ||
-             memref.marker.type == TRACE_TYPE_MARKER) {
+             memref.marker.type == TRACE_TYPE_MARKER ||
+             memref.marker.type == TRACE_TYPE_INSTR_NO_FETCH) {
         // TLB simulator ignores prefetching, cache flushing, and markers
     } else {
         ERRMSG("unhandled memref type");

--- a/clients/drcachesim/tests/basic_counts.templatex
+++ b/clients/drcachesim/tests/basic_counts.templatex
@@ -20,7 +20,8 @@ All done
 ---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
-     .* total instructions
+     .* total \(fetched\) instructions
+     .* total non-fetched instructions
      .* total prefetches
      .* total data loads
      .* total data stores
@@ -31,7 +32,8 @@ Total counts:
 #endif
            1 total threads
 Thread .* counts:
-     .* instructions
+     .* \(fetched\) instructions
+     .* non-fetched instructions
      .* prefetches
      .* data loads
      .* data stores

--- a/clients/drcachesim/tests/offline-basic_counts.templatex
+++ b/clients/drcachesim/tests/offline-basic_counts.templatex
@@ -19,7 +19,8 @@ Bad instruction, instance 8
 All done
 Basic counts tool results:
 Total counts:
-     .* total instructions
+     .* total \(fetched\) instructions
+     .* total non-fetched instructions
      .* total prefetches
      .* total data loads
      .* total data stores
@@ -30,7 +31,8 @@ Total counts:
 #endif
            1 total threads
 Thread .* counts:
-     .* instructions
+     .* \(fetched\) instructions
+     .* non-fetched instructions
      .* prefetches
      .* data loads
      .* data stores

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -49,11 +49,13 @@ class basic_counts_t : public analysis_tool_t
  protected:
     int_least64_t total_threads;
     int_least64_t total_instrs;
+    int_least64_t total_instrs_nofetch;
     int_least64_t total_prefetches;
     int_least64_t total_loads;
     int_least64_t total_stores;
     int_least64_t total_markers;
     std::unordered_map<memref_tid_t, int_least64_t> thread_instrs;
+    std::unordered_map<memref_tid_t, int_least64_t> thread_instrs_nofetch;
     std::unordered_map<memref_tid_t, int_least64_t> thread_prefetches;
     std::unordered_map<memref_tid_t, int_least64_t> thread_loads;
     std::unordered_map<memref_tid_t, int_least64_t> thread_stores;

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -40,7 +40,7 @@
 #include "../common/trace_entry.h"
 
 unsigned short
-instru_t::instr_to_instr_type(instr_t *instr)
+instru_t::instr_to_instr_type(instr_t *instr, bool repstr_expanded)
 {
     if (instr_is_call_direct(instr))
         return TRACE_TYPE_INSTR_DIRECT_CALL;
@@ -54,6 +54,13 @@ instru_t::instr_to_instr_type(instr_t *instr)
         return TRACE_TYPE_INSTR_INDIRECT_JUMP;
     if (instr_is_cbr(instr))
         return TRACE_TYPE_INSTR_CONDITIONAL_JUMP;
+    // i#2051: to satisfy both cache and core simulators we mark subsequent iters
+    // of string loops as TRACE_TYPE_INSTR_NO_FETCH, converted from this
+    // TRACE_TYPE_INSTR_MAYBE_FETCH by reader_t (since online traces would need
+    // extra insru to distinguish the 1st and subsequent iters).
+    if (instr_is_rep_string_op(instr) ||
+        (repstr_expanded && instr_is_string_op(instr)))
+        return TRACE_TYPE_INSTR_MAYBE_FETCH;
     return TRACE_TYPE_INSTR;
 }
 

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -93,7 +93,8 @@ public:
 
     // Utilities.
     static unsigned short instr_to_prefetch_type(instr_t *instr);
-    static unsigned short instr_to_instr_type(instr_t *instr);
+    static unsigned short instr_to_instr_type(instr_t *instr,
+                                              bool repstr_expanded = false);
     static bool instr_is_flush(instr_t *instr);
     virtual void insert_obtain_addr(void *drcontext, instrlist_t *ilist, instr_t *where,
                                     reg_id_t reg_addr, reg_id_t reg_scratch, opnd_t ref);

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -309,8 +309,9 @@ online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
                                   reg_id_t reg_ptr, reg_id_t reg_tmp, int adjust,
                                   instr_t *app)
 {
+    bool repstr_expanded = (bool)bb_field;
     insert_save_type_and_size(drcontext, ilist, where, reg_ptr, reg_tmp,
-                              instr_to_instr_type(app),
+                              instr_to_instr_type(app, repstr_expanded),
                               (ushort)instr_length(drcontext, app), adjust);
     insert_save_pc(drcontext, ilist, where, reg_ptr, reg_tmp,
                    instr_get_app_pc(app), adjust);
@@ -347,5 +348,5 @@ void
 online_instru_t::bb_analysis(void *drcontext, void *tag, void **bb_field,
                              instrlist_t *ilist, bool repstr_expanded)
 {
-    // Nothing to do.
+    *bb_field = (void *)repstr_expanded;
 }

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -309,7 +309,7 @@ online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
                                   reg_id_t reg_ptr, reg_id_t reg_tmp, int adjust,
                                   instr_t *app)
 {
-    bool repstr_expanded = (bool)bb_field;
+    bool repstr_expanded = *bb_field != 0; // Avoid cl warning C4800.
     insert_save_type_and_size(drcontext, ilist, where, reg_ptr, reg_tmp,
                               instr_to_instr_type(app, repstr_expanded),
                               (ushort)instr_length(drcontext, app), adjust);

--- a/core/arch/aarch64/instr.c
+++ b/core/arch/aarch64/instr.c
@@ -257,6 +257,18 @@ instr_is_prefetch(instr_t *instr)
 }
 
 bool
+instr_is_string_op(instr_t *instr)
+{
+    return false;
+}
+
+bool
+instr_is_rep_string_op(instr_t *instr)
+{
+    return false;
+}
+
+bool
 instr_saves_float_pc(instr_t *instr)
 {
     return false;

--- a/core/arch/arm/instr.c
+++ b/core/arch/arm/instr.c
@@ -427,6 +427,18 @@ instr_is_prefetch(instr_t *instr)
 }
 
 bool
+instr_is_string_op(instr_t *instr)
+{
+    return false;
+}
+
+bool
+instr_is_rep_string_op(instr_t *instr)
+{
+    return false;
+}
+
+bool
 instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type OUT)
 {
     /* FIXME i#1551: NYI */

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -2135,6 +2135,16 @@ bool
 instr_is_icache_op(instr_t *instr);
 #endif
 
+DR_API
+/** Returns true iff \p instr is an Intel string operation instruction. */
+bool
+instr_is_string_op(instr_t *instr);
+
+DR_API
+/** Returns true iff \p instr is an Intel repeated-loop string operation instruction. */
+bool
+instr_is_rep_string_op(instr_t *instr);
+
 /* DR_API EXPORT BEGIN */
 /**
  * Indicates which type of floating-point operation and instruction performs.

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -721,6 +721,23 @@ instr_is_prefetch(instr_t *instr)
 }
 
 bool
+instr_is_string_op(instr_t *instr)
+{
+    uint opc = instr_get_opcode(instr);
+    return (opc == OP_ins || opc == OP_outs || opc == OP_movs ||
+            opc == OP_stos || opc == OP_lods || opc == OP_cmps || opc == OP_scas);
+}
+
+bool
+instr_is_rep_string_op(instr_t *instr)
+{
+    uint opc = instr_get_opcode(instr);
+    return (opc == OP_rep_ins || opc == OP_rep_outs || opc == OP_rep_movs ||
+            opc == OP_rep_stos || opc == OP_rep_lods || opc == OP_rep_cmps ||
+            opc == OP_repne_cmps || opc == OP_rep_scas || opc == OP_repne_scas);
+}
+
+bool
 instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type OUT)
 {
     int opc = instr_get_opcode(instr);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2560,11 +2560,13 @@ if (CLIENT_INTERFACE)
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
 
       # We run common.decode-bad to test markers for faults
-      torunonly_ci(tool.basic_counts common.decode-bad drcachesim
-        "basic_counts.c" # for templatex basename
-        "-ipc_name ${IPC_PREFIX}drtestpipe7 -simulator_type basic_counts" "" "")
-      set(tool.basic_counts_toolname "drcachesim")
-      set(tool.basic_counts_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+      if (X86) # decode-bad is x86-only
+        torunonly_ci(tool.basic_counts common.decode-bad drcachesim
+          "basic_counts.c" # for templatex basename
+          "-ipc_name ${IPC_PREFIX}drtestpipe7 -simulator_type basic_counts" "" "")
+        set(tool.basic_counts_toolname "drcachesim")
+        set(tool.basic_counts_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+      endif ()
 
       if (X86 AND X64) # We only bother with a sample trace for x86_64.
         # We test with a fixed trace file so we can test exact numeric results.
@@ -2623,9 +2625,11 @@ if (CLIENT_INTERFACE)
       set(tool.drcacheoff.filter_depends tool.drcacheoff.simple)
 
       # We run common.decode-bad to test markers for faults
-      torunonly_drcacheoff(basic_counts common.decode-bad ""
-        "@-simulator_type@basic_counts" "")
-      unset(tool.drcacheoff.basic_counts_rawtemp)
+      if (X86) # decode-bad is x86-only
+        torunonly_drcacheoff(basic_counts common.decode-bad ""
+          "@-simulator_type@basic_counts" "")
+        unset(tool.drcacheoff.basic_counts_rawtemp)
+      endif ()
 
       # FIXME i#2007: fails to link on A64
       # XXX i#1551: startstop API is NYI on ARM


### PR DESCRIPTION
To satisfy both cache and core simulators we mark subsequent iterations of
rep string loops with a new trace entry type TRACE_TYPE_INSTR_NO_FETCH,
which cache simulators can ignore.  For offline traces, raw2trace does this
for us.  Since online traces would need extra overhead to distinguish the
first from subsequent iters, they use a new internal type
TRACE_TYPE_INSTR_MAYBE_FETCH which is converted by reader_t.

Adds instr_is_string_op() and instr_is_rep_string_op() to DR's API to
facilitate this.

Adds no-fetch stats to the basic_counts tool and updates the basic_counts
tests.

Fixes #2051