### PR TITLE
i#2728 slow attach: Don't use make_unwritable in stack_alloc.

### DIFF
--- a/core/heap.c
+++ b/core/heap.c
@@ -2513,7 +2513,7 @@ stack_alloc(size_t size, byte *min_addr)
 #else
         /* For UNIX we just mark it as inaccessible. */
         if (!DYNAMO_OPTION(guard_pages))
-            make_unwritable(guard, PAGE_SIZE);
+            set_protection(guard, PAGE_SIZE, MEMPROT_READ);
 #endif
     }
 


### PR DESCRIPTION
A microbenchmark showed that make_unwritable was causing attach times to
take upwords of 56 seconds, whereas using set_protection (to avoid
excess querying of protections) reduces the time to around 1 second.

Issue #2728