### PR TITLE
i#1621 AArch64 CC opt: Add get_ABI_stack_alignment function.

### DIFF
--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -512,6 +512,25 @@ mangle_special_registers(dcontext_t *dcontext, instrlist_t *ilist, instr_t *inst
 #endif
 void mangle_insert_clone_code(dcontext_t *dcontext, instrlist_t *ilist,
                               instr_t *instr _IF_X86_64(gencode_mode_t mode));
+
+/* Returns the number of bytes the stack pointer has to be aligned to. */
+static inline uint
+get_ABI_stack_alignment()
+{
+#ifdef X86
+# if defined(X64) || defined(MACOS)
+    return 16;
+# else
+    /* See i#847 for discussing the stack alignment on X86. */
+    return 4;
+# endif
+#elif defined(AARCH64)
+    return 16;
+#elif defined(ARM)
+    return 8;
+#endif
+}
+
 /* the stack size of a full context switch for clean call */
 int
 get_clean_call_switch_stack_size(void);


### PR DESCRIPTION
This patch adds a get_ABI_stack_alignment function as a
follow-up of a3ff20e. It also updates prepare_for_clean_call
to check if the stack pointer is aligned properly on all
platforms.


This is an  updated version of #2543, because I messed up the commit history in that branch.