### PR TITLE
i#2737 gcc 7: Add gnu::fallthrough

### DIFF
--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -78,6 +78,8 @@
 // We annotate to support building with -Wimplicit-fallthrough.
 #if __has_cpp_attribute(clang::fallthrough)
 # define ANNOTATE_FALLTHROUGH [[clang::fallthrough]]
+#elif __has_cpp_attribute(gnu::fallthrough)
+# define ANNOTATE_FALLTHROUGH [[gnu::fallthrough]]
 #else
 # define ANNOTATE_FALLTHROUGH
 #endif


### PR DESCRIPTION
GCC 7 enabled -Wimplicit-fallthough and intended fall-throughs can be
annotated by gnu::fallthrough.

See
https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/