### PR TITLE
i#2638: avoid thread switch gaps after branches

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -128,10 +128,12 @@ set(file_analyzer_tool_srcs
 
 # We show one example of how to create a standalone analyzer of trace
 # files that does not need to link with DR.
+# We also use this to link in our trace_invariants sanity checker.
 # i#2006: the final method for supporting 3rd-party tools is not yet decided.
 add_executable(drmemtrace_histogram
   ${file_analyzer_tool_srcs}
   tools/histogram_launcher.cpp
+  tests/trace_invariants.cpp
   )
 target_link_libraries(drmemtrace_histogram histogram drfrontendlib)
 use_DynamoRIO_extension(drmemtrace_histogram droption)
@@ -225,6 +227,14 @@ macro(add_win32_flags target)
       append_property_string(TARGET ${target} LINK_FLAGS "/nodefaultlib:libcmt")
     else ()
       append_property_string(TARGET ${target} COMPILE_FLAGS "/EHsc /MT")
+    endif ()
+  else ()
+    # Work around configure_DynamoRIO_static() clobbering flags by re-adding
+    # the important ones for our tests, so they can include our headers
+    # with C++11-isms.
+    get_property(cur TARGET ${target} PROPERTY COMPILE_FLAGS)
+    if (NOT cur MATCHES "-std=")
+      append_property_string(TARGET ${target} COMPILE_FLAGS "-std=c++11")
     endif ()
   endif ()
 endmacro ()

--- a/clients/drcachesim/common/memref.h
+++ b/clients/drcachesim/common/memref.h
@@ -48,6 +48,11 @@ typedef int_least64_t memref_tid_t;
 // Although the pc of each data reference is provided, the trace also guarantees that
 // an instruction entry immediately precedes the data references that it is
 // responsible for, with no intervening trace entries.
+// Offline traces further guarantee that an instruction entry for a branch
+// instruction is always followed by an instruction entry for the branch's
+// target (with any memory references for the branch in between of course)
+// without a thread switch intervening, to make it simpler to identify branch
+// targets.  Online traces do not currently guarantee this.
 
 struct _memref_data_t {
     // TRACE_TYPE_READ, TRACE_TYPE_WRITE, and TRACE_TYPE_PREFETCH*:

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -177,6 +177,12 @@ type_is_instr(const trace_type_t type)
 }
 
 static inline bool
+type_is_instr_branch(const trace_type_t type)
+{
+    return (type >= TRACE_TYPE_INSTR_DIRECT_JUMP && type <= TRACE_TYPE_INSTR_RETURN);
+}
+
+static inline bool
 type_is_prefetch(const trace_type_t type)
 {
     return (type >= TRACE_TYPE_PREFETCH && type <= TRACE_TYPE_PREFETCH_INSTR) ||

--- a/clients/drcachesim/tests/trace_invariants.cpp
+++ b/clients/drcachesim/tests/trace_invariants.cpp
@@ -1,0 +1,68 @@
+/* **********************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "trace_invariants.h"
+#include <assert.h>
+#include <iostream>
+#include <string.h>
+
+trace_invariants_t::trace_invariants_t()
+{
+    memset(&prev_instr, 0, sizeof(prev_instr));
+}
+
+trace_invariants_t::~trace_invariants_t()
+{
+}
+
+bool
+trace_invariants_t::process_memref(const memref_t &memref)
+{
+    if (type_is_instr(memref.instr.type) ||
+        memref.instr.type == TRACE_TYPE_PREFETCH_INSTR ||
+        memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH) {
+        // Invariant: offline traces guarantee that a branch target must immediately
+        // follow the branch w/ no intervening trace switch.
+        if (type_is_instr_branch(prev_instr.instr.type)) {
+            assert(prev_instr.instr.tid == memref.instr.tid);
+        }
+        prev_instr = memref;
+    }
+    return true;
+}
+
+bool
+trace_invariants_t::print_results()
+{
+    std::cerr << "Trace invariant checks passed\n";
+    return true;
+}

--- a/clients/drcachesim/tests/trace_invariants.h
+++ b/clients/drcachesim/tests/trace_invariants.h
@@ -1,0 +1,54 @@
+/* **********************************************************
+ * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* trace_invariants: a memory trace invariants checker.
+ */
+
+#ifndef _TRACE_INVARIANTS_H_
+#define _TRACE_INVARIANTS_H_ 1
+
+#include "../analysis_tool.h"
+#include "../common/memref.h"
+
+class trace_invariants_t : public analysis_tool_t
+{
+ public:
+    trace_invariants_t();
+    virtual ~trace_invariants_t();
+    virtual bool process_memref(const memref_t &memref);
+    virtual bool print_results();
+
+ protected:
+    memref_t prev_instr;
+};
+
+#endif /* _TRACE_INVARIANTS_H_ */

--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -106,7 +106,7 @@ _tmain(int argc, const TCHAR *targv[])
         // We use this launcher to run tests as well:
         tools.push_back(&tool2);
     }
-    analyzer_t analyzer(op_trace.get_value(), &tools[0], tools.size());
+    analyzer_t analyzer(op_trace.get_value(), &tools[0], (int)tools.size());
     if (!analyzer)
         FATAL_ERROR("failed to initialize analyzer");
     if (!analyzer.run())

--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -43,6 +43,7 @@
 #include "dr_frontend.h"
 #include "../analyzer.h"
 #include "histogram_create.h"
+#include "../tests/trace_invariants.h"
 
 #define FATAL_ERROR(msg, ...) do { \
     fprintf(stderr, "ERROR: " msg "\n", ##__VA_ARGS__);    \
@@ -94,34 +95,40 @@ _tmain(int argc, const TCHAR *targv[])
                     droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
     }
 
-    analysis_tool_t *tool =
+    analysis_tool_t *tool1 =
         histogram_tool_create(op_line_size.get_value(),
                               op_report_top.get_value(),
                               op_verbose.get_value());
-
-    analyzer_t analyzer(op_trace.get_value(), &tool, 1);
+    std::vector<analysis_tool_t*> tools;
+    tools.push_back(tool1);
+    trace_invariants_t tool2;
+    if (op_test_mode.get_value()) {
+        // We use this launcher to run tests as well:
+        tools.push_back(&tool2);
+    }
+    analyzer_t analyzer(op_trace.get_value(), &tools[0], tools.size());
     if (!analyzer)
         FATAL_ERROR("failed to initialize analyzer");
     if (!analyzer.run())
         FATAL_ERROR("failed to run analyzer");
     analyzer.print_stats();
-    delete tool;
+    delete tool1;
 
     if (op_test_mode.get_value()) {
         // Test the external-iterator interface.
-        tool = histogram_tool_create(op_line_size.get_value(),
+        tool1 = histogram_tool_create(op_line_size.get_value(),
                                      op_report_top.get_value(),
                                      op_verbose.get_value());
         analyzer_t external(op_trace.get_value());
         if (!external)
             FATAL_ERROR("failed to initialize analyzer");
         for (reader_t &iter = external.begin(); iter != external.end(); ++iter) {
-            if (!tool->process_memref(*iter))
+            if (!tool1->process_memref(*iter))
                 FATAL_ERROR("tool failed to process entire trace");
         }
-        if (!tool->print_results())
+        if (!tool1->print_results())
             FATAL_ERROR("tool failed to print results");
-        delete tool;
+        delete tool1;
     }
 
     return 0;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -420,10 +420,37 @@ raw2trace_t::append_bb_entries(uint tidx, offline_entry_t *in_entry, OUT bool *h
             }
         }
         CHECK((size_t)(buf - buf_start) < MAX_COMBINED_ENTRIES, "Too many entries");
-        if (!out_file->write((char*)buf_start, (buf - buf_start)*sizeof(trace_entry_t)))
-            return "Failed to write to output file";
+        if (instr_is_cti(instr)) {
+            CHECK(delayed_branch[tidx].empty(), "Failed to flush delayed branch");
+            // In case this is the last branch prior to a thread switch, buffer it.  We
+            // avoid swapping threads immediately after a branch so that analyzers can
+            // more easily find the branch target.  Doing this in the tracer would incur
+            // extra overhead, and in the reader would be more complex and messy than
+            // here (and we are ok bailing on doing this for online traces), so we
+            // handle it in post-processing by delaying a thread-block-final branch (and
+            // its memrefs) to that thread's next block.  This changes the timestamp
+            // of the branch, which we live with.
+            delayed_branch[tidx].insert(delayed_branch[tidx].begin(),
+                                        (char *)buf_start, (char *)buf);
+        } else {
+            if (!out_file->write((char*)buf_start,
+                                 (buf - buf_start)*sizeof(trace_entry_t)))
+                return "Failed to write to output file";
+        }
     }
     *handled = true;
+    return "";
+}
+
+std::string
+raw2trace_t::append_delayed_branch(uint tidx)
+{
+    if (delayed_branch[tidx].empty())
+        return "";
+    VPRINT(4, "Appending delayed branch for thread %d\n", tidx);
+    if (!out_file->write(&delayed_branch[tidx][0], delayed_branch[tidx].size()))
+        return "Failed to write to output file";
+    delayed_branch[tidx].clear();
     return "";
 }
 
@@ -506,6 +533,16 @@ raw2trace_t::merge_and_process_thread_files()
                 return ss.str();
             }
         }
+        if (in_entry.timestamp.type == OFFLINE_TYPE_TIMESTAMP) {
+            VPRINT(2, "Thread %u timestamp 0x" ZHEX64_FORMAT_STRING "\n",
+                   (uint)tids[tidx], in_entry.timestamp.usec);
+            times[tidx] = in_entry.timestamp.usec;
+            tidx = (uint)thread_files.size(); // Request thread scan.
+            continue;
+        }
+        std::string result = append_delayed_branch(tidx);
+        if (!result.empty())
+            return result;
         if (in_entry.extended.type == OFFLINE_TYPE_EXTENDED) {
             if (in_entry.extended.ext == OFFLINE_EXT_TYPE_FOOTER) {
                 // Push forward to EOF.
@@ -533,11 +570,6 @@ raw2trace_t::merge_and_process_thread_files()
                 ss << "Invalid extension type " << (int)in_entry.extended.ext;
                 return ss.str();
             }
-        } else if (in_entry.timestamp.type == OFFLINE_TYPE_TIMESTAMP) {
-            VPRINT(2, "Thread %u timestamp 0x" ZHEX64_FORMAT_STRING "\n",
-                   (uint)tids[tidx], in_entry.timestamp.usec);
-            times[tidx] = in_entry.timestamp.usec;
-            tidx = (uint)thread_files.size(); // Request thread scan.
         } else if (in_entry.addr.type == OFFLINE_TYPE_MEMREF ||
                    in_entry.addr.type == OFFLINE_TYPE_MEMREF_HIGH) {
             if (!last_bb_handled) {
@@ -556,9 +588,9 @@ raw2trace_t::merge_and_process_thread_files()
                 return "memref entry found outside of bb";
             }
         } else if (in_entry.pc.type == OFFLINE_TYPE_PC) {
-          std::string result = append_bb_entries(tidx, &in_entry, &last_bb_handled);
-          if (!result.empty())
-              return result;
+            result = append_bb_entries(tidx, &in_entry, &last_bb_handled);
+            if (!result.empty())
+                return result;
         } else if (in_entry.tid.type == OFFLINE_TYPE_THREAD) {
             VPRINT(2, "Thread %u entry\n", (uint)in_entry.tid.tid);
             if (tids[tidx] == INVALID_THREAD_ID)
@@ -663,6 +695,8 @@ raw2trace_t::raw2trace_t(const char *module_map_in,
     // We pay a little memory to get a lower load factor.
     hashtable_config_t config = {sizeof(config), true, 40};
     hashtable_configure(&decode_cache, &config);
+
+    delayed_branch.resize(thread_files.size());
 }
 
 raw2trace_t::~raw2trace_t()

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -133,6 +133,7 @@ private:
                                   OUT bool *handled);
     std::string append_memref(INOUT trace_entry_t **buf_in, uint tidx, instr_t *instr,
                               opnd_t ref, bool write);
+    std::string append_delayed_branch(uint tidx);
 
     static const uint MAX_COMBINED_ENTRIES = 64;
     const char *modmap;
@@ -151,6 +152,9 @@ private:
     // and c++11 std::unordered_map (including tuning its load factor, initial size,
     // and hash function), and hashtable_t outperformed the others (i#2056).
     hashtable_t decode_cache;
+
+    // Used to delay thread-buffer-final branch to keep it next to its target.
+    std::vector<std::vector<char>> delayed_branch;
 
     // We store module info for do_module_parsing.
     std::vector<drmodtrack_info_t> modlist;

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -379,6 +379,9 @@ memtrace(void *drcontext, bool skip_size_cap)
                 // Split up the buffer into multiple writes to ensure atomic pipe writes.
                 // We can only split before TRACE_TYPE_INSTR, assuming only a few data
                 // entries in between instr entries.
+                // XXX i#2638: if we want to support branch target analysis in online
+                // traces we'll need to not split after a branch: either split before
+                // it or one instr after.
                 trace_type_t type = instru->get_entry_type(mem_ref);
                 if (type_is_instr(type) || type == TRACE_TYPE_INSTR_MAYBE_FETCH) {
                     if ((mem_ref - pipe_start) > ipc_pipe.get_atomic_write_size())
@@ -394,6 +397,9 @@ memtrace(void *drcontext, bool skip_size_cap)
             // Write the rest to pipe
             // The last few entries (e.g., instr + refs) may exceed the atomic write size,
             // so we may need two writes.
+            // XXX i#2638: if we want to support branch target analysis in online
+            // traces we'll need to not split after a branch by carrying a write-final
+            // branch forward to the next buffer.
             if ((buf_ptr - pipe_start) > ipc_pipe.get_atomic_write_size())
                 pipe_start = atomic_pipe_write(drcontext, pipe_start, pipe_end);
             if ((buf_ptr - pipe_start) > (ssize_t)buf_hdr_slots_size)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2689,8 +2689,12 @@ if (CLIENT_INTERFACE)
 
       # Test the standalone histogram tool.
       # ${ci_shared_app} is already used for an offline test, and we're deleting a
-      # dir with that name, so we run common.eflags to avoid having to serialize.
-      set(histo_app common.${control_flags})
+      # dir with that name, so we run other apps to avoid having to serialize.
+      if (UNIX)
+        set(histo_app pthreads.pthreads) # We want some threads for trace_invariants.
+      else ()
+        set(histo_app common.${control_flags})
+      endif()
       torunonly_ci(tool.histogram.offline ${histo_app} drcachesim
         "histogram-offline.c" "-offline" "" "")
       set(tool.histogram.offline_toolname "drcachesim")


### PR DESCRIPTION
Offline traces now guarantee that a branch target instruction entry in a
trace must immediately follow the branch instruction with no intervening
trace switch.  Because doing this during online tracing would cost extra
overhead due to the basic block-based instruction tracing, this is
implemented in raw2trace by delaying a buffer-final branch until the next
buffer for that thread.

Adds a trace_invariants tool linked into histogram_launcher where we can
add sanity checks for trace invariants like this one.

Fixes #2638