### PR TITLE
Add tool list to top-level docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ IA-32, AMD64, ARM, and AArch64 hardware.  Mac OSX support is in progress.
 
 ## Existing DynamoRIO-based tools
 
-Tools built on DynamoRIO include:
+Tools built on DynamoRIO and provided in our release package include:
 
 - The memory debugging tool [Dr. Memory](http://drmemory.org)
-- The multi-process online cache simulator
-  [drcachesim](http://dynamorio.org/docs/page_drcachesim.html)
+- The multi-process cache simulator and memory address trace collection and
+  analysis platform [drcachesim](http://dynamorio.org/docs/page_drcachesim.html)
 - The legacy processor emulator
   [drcpusim](http://dynamorio.org/docs/page_drcpusim.html)
 - The "strace for Windows" tool [drstrace](http://drmemory.org/strace_for_windows.html)

--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -114,6 +114,12 @@ sections:
 - \subpage API_samples
   <br>Shows some sample use cases and reference implementations.
 
+- \ref page_tool
+  <br>A collection of powerful DynamoRIO-based tools are provided for
+  direct use, including our \ref page_drcachesim and memory access trace
+  collection and analysis platform, the \ref page_drmemory, our \ref
+  page_drcov, and more.
+
 - \subpage overview
   <br>A description of the implementation of the DynamoRIO system.
 

--- a/api/docs/tool.gendox
+++ b/api/docs/tool.gendox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -35,7 +35,7 @@
 ***************************************************************************
 \page page_tool DynamoRIO-Based Tools
 
-DynamoRIO-based tools are provided for direct use.
+A collection of powerful DynamoRIO-based tools are provided for direct use.
 A tool can be invoked using the option \p -t with the tool name.
 For example:
 \code


### PR DESCRIPTION
Adds a link to the provided tool list on the front page of the docs.
Augments the description of drcachesim in README.md.