### PR TITLE
i#2717 Mark some of the functions as static.

### DIFF
--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -2574,7 +2574,7 @@ bb_process_IAT_convertible_indjmp(dcontext_t *dcontext, build_bb_t *bb,
  * OUT elide_continue is set when bb building should continue in target,
  * and not set when bb building should be stopped.
  */
-bool
+static bool
 bb_process_IAT_convertible_indcall(dcontext_t *dcontext, build_bb_t *bb,
                                    bool *elide_continue)
 {

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -715,7 +715,7 @@ instrument_init(void)
     }
 }
 
-void
+static void
 free_callback_list(callback_list_t *vec)
 {
     if (vec->callbacks != NULL) {
@@ -727,7 +727,8 @@ free_callback_list(callback_list_t *vec)
     vec->num = 0;
 }
 
-void free_all_callback_lists()
+static void
+free_all_callback_lists()
 {
     free_callback_list(&exit_callbacks);
     free_callback_list(&thread_init_callbacks);

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -71,7 +71,7 @@ extern size_t wcslen(const wchar_t *str); /* in string.c */
  * so we just list possible common but in-complete paths for now.
  */
 #define SYSTEM_LIBRARY_PATH_VAR "LD_LIBRARY_PATH"
-char *ld_library_path = NULL;
+static char *ld_library_path = NULL;
 static const char *const system_lib_paths[] = {
 #ifdef X86
     "/lib/tls/i686/cmov",
@@ -1234,7 +1234,7 @@ redirect____tls_get_addr();
 #endif
 
 #ifdef LINUX
-int
+static int
 redirect_dl_iterate_phdr(int (*callback)(struct dl_phdr_info *info,
                                          size_t size, void *data),
                          void *data)

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -690,7 +690,7 @@ dynamorio_set_envp(char **envp)
 }
 
 /* shared library init */
-int
+static int
 our_init(int argc, char **argv, char **envp)
 {
     /* If we do not want to use drpreload.so, we can take over here: but when using

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -6295,7 +6295,7 @@ set_actual_itimer(dcontext_t *dcontext, int which, thread_sig_info_t *info,
 }
 
 /* Caller should hold lock */
-bool
+static bool
 itimer_new_settings(dcontext_t *dcontext, int which, bool app_changed)
 {
     struct itimerval val;

--- a/core/utils.c
+++ b/core/utils.c
@@ -3698,7 +3698,7 @@ convert_date_to_millis(const dr_time_t *dr_time, uint64 *millis OUT)
                 dr_time->second) * 1000 + dr_time->milliseconds);
 }
 
-const uint crctab[] = {
+static const uint crctab[] = {
     0x00000000, 0x77073096, 0xee0e612c, 0x990951ba,
     0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,
     0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -3383,7 +3383,7 @@ vm_area_coarse_iter_stop(vmvector_iterator_t *vmvi)
 /* returns true if addr is on a page that contains at least one selfmod
  * region and no non-selfmod regions.
  */
-bool
+static bool
 is_executable_area_on_all_selfmod_pages(app_pc start, app_pc end)
 {
     bool all_selfmod;


### PR DESCRIPTION
Reduces the size of the static library by 896 bytes.

Before:
-r-xr-xr-x 1 nilayvaish eng 2999798 Nov 23 14:03 libdynamorio.a

After:
-r-xr-xr-x 1 nilayvaish eng 2998902 Nov 23 14:33 libdynamorio.a

Issue #2717