### PR TITLE
i#2723 audit debug-asserts: use fatal error macro in signal handler.

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4650,8 +4650,10 @@ master_signal_handler_C(byte *xsp)
          */
         if (can_always_delay[sig])
             return;
-        else
-            exit_process_syscall(1);
+
+        REPORT_FATAL_ERROR_AND_EXIT(dcontext, FAILED_TO_HANDLE_SIGNAL,
+                                    2, get_application_name(),
+                                    get_application_pid());
     }
 
     /* we may be entering dynamo from code cache! */

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -617,4 +617,15 @@ SymbolicName = MSG_FAILED_TO_SYNCHRONIZE_THREADS
 Language=English
 Application %1!s! (%2!s!). Failed to synchronize with all threads when detaching.
 .
+
+;#ifdef UNIX
+MessageId =
+Severity = Error
+Facility = DRCore
+SymbolicName = MSG_FAILED_TO_HANDLE_SIGNAL
+Language=English
+Application %1!s! (%2!s!). Cannot correctly handle a received signal.
+.
+;#endif
+
 ;// ADD NEW MESSAGES HERE


### PR DESCRIPTION
We see this error and it'd be nice to be able to more easily
differentiate when this is the failure case.

Issue #2723