### PR TITLE
i#2708 trace discontinuity: add test, fix bugs found by test

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -86,7 +86,7 @@ add_library(raw2trace STATIC
 configure_DynamoRIO_standalone(raw2trace)
 target_link_libraries(raw2trace drfrontendlib)
 
-add_executable(drcachesim
+set(drcachesim_srcs
   launcher.cpp
   analyzer.cpp
   analyzer_multi.cpp
@@ -99,6 +99,11 @@ add_executable(drcachesim
   tracer/instru.cpp
   tracer/instru_online.cpp
   )
+if (DEBUG)
+  # We include the invariants analyzer for testing.
+  set(drcachesim_srcs ${drcachesim_srcs} tests/trace_invariants.cpp)
+endif ()
+add_executable(drcachesim ${drcachesim_srcs})
 # In order to embed raw2trace we need to be standalone:
 configure_DynamoRIO_standalone(drcachesim)
 # Link in our tools:

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -42,6 +42,9 @@
 #include "reader/ipc_reader.h"
 #include "tracer/raw2trace_directory.h"
 #include "tracer/raw2trace.h"
+#ifdef DEBUG
+# include "tests/trace_invariants.h"
+#endif
 
 analyzer_multi_t::analyzer_multi_t()
 {
@@ -123,6 +126,18 @@ analyzer_multi_t::create_analysis_tools()
     if (tools[0] == NULL)
         return false;
     num_tools = 1;
+#ifdef DEBUG
+    if (op_test_mode.get_value()) {
+        tools[1] = new trace_invariants_t(op_offline.get_value(), op_verbose.get_value());
+        if (tools[1] != NULL && !*tools[1]) {
+            delete tools[1];
+            tools[1] = NULL;
+        }
+        if (tools[1] == NULL)
+            return false;
+        num_tools = 2;
+    }
+#endif
     return true;
 }
 

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -230,6 +230,12 @@ droption_t<unsigned int> op_verbose
 (DROPTION_SCOPE_ALL, "verbose", 0, 0, 64, "Verbosity level",
  "Verbosity level for notifications.");
 
+#ifdef DEBUG
+droption_t<bool> op_test_mode
+(DROPTION_SCOPE_ALL, "test_mode", false, "Run sanity tests",
+ "Run extra analyses for sanity checks on the trace.");
+#endif
+
 droption_t<std::string> op_dr_root
 (DROPTION_SCOPE_FRONTEND, "dr", "", "Path to DynamoRIO root directory",
  "Specifies the path of the DynamoRIO root directory.");

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -86,6 +86,9 @@ extern droption_t<unsigned int> op_TLB_L2_assoc;
 extern droption_t<std::string> op_TLB_replace_policy;
 extern droption_t<std::string> op_simulator_type;
 extern droption_t<unsigned int> op_verbose;
+#ifdef DEBUG
+extern droption_t<bool> op_test_mode;
+#endif
 extern droption_t<std::string> op_dr_root;
 extern droption_t<bool> op_dr_debug;
 extern droption_t<std::string> op_dr_ops;

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -146,6 +146,11 @@ typedef enum {
     // An internal value used for online traces and turned by reader_t into
     // either TRACE_TYPE_INSTR or TRACE_TYPE_INSTR_NO_FETCH.
     TRACE_TYPE_INSTR_MAYBE_FETCH,
+
+    // We separate out the x86 sysenter instruction as it has a hardcoded
+    // return point that shows up as a discontinuity in the user mode program
+    // counter execution sequence.
+    TRACE_TYPE_INSTR_SYSENTER,
 } trace_type_t;
 
 // The sub-type for TRACE_TYPE_MARKER.
@@ -169,11 +174,12 @@ typedef enum {
 extern const char * const trace_type_names[];
 
 // Returns whether the type represents an instruction fetch.
-// Deliberately excludes TRACE_TYPE_INSTR_NO_FETCH.
+// Deliberately excludes TRACE_TYPE_INSTR_NO_FETCH and TRACE_TYPE_INSTR_BUNDLE.
 static inline bool
 type_is_instr(const trace_type_t type)
 {
-    return (type >= TRACE_TYPE_INSTR && type <= TRACE_TYPE_INSTR_BUNDLE);
+    return (type >= TRACE_TYPE_INSTR && type <= TRACE_TYPE_INSTR_RETURN) ||
+        type == TRACE_TYPE_INSTR_SYSENTER;
 }
 
 static inline bool

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -31,7 +31,6 @@
  */
 
 #include <assert.h>
-#include <map>
 #include "reader.h"
 #include "../common/memref.h"
 #include "../common/utils.h"
@@ -117,6 +116,7 @@ reader_t::operator++()
         case TRACE_TYPE_INSTR_DIRECT_CALL:
         case TRACE_TYPE_INSTR_INDIRECT_CALL:
         case TRACE_TYPE_INSTR_RETURN:
+        case TRACE_TYPE_INSTR_SYSENTER:
         case TRACE_TYPE_INSTR_NO_FETCH:
             have_memref = true;
             assert(cur_tid != 0 && cur_pid != 0);
@@ -141,6 +141,7 @@ reader_t::operator++()
             have_memref = true;
             // The trace stream always has the instr fetch first, which we
             // use to compute the starting PC for the subsequent instructions.
+            assert(type_is_instr(cur_ref.instr.type));
             cur_ref.instr.size = input_entry->length[bundle_idx++];
             cur_pc = next_pc;
             cur_ref.instr.addr = cur_pc;

--- a/clients/drcachesim/tests/drcachesim-invariants.templatex
+++ b/clients/drcachesim/tests/drcachesim-invariants.templatex
@@ -1,0 +1,2 @@
+.*
+Trace invariant checks passed

--- a/clients/drcachesim/tests/trace_invariants.cpp
+++ b/clients/drcachesim/tests/trace_invariants.cpp
@@ -35,9 +35,11 @@
 #include <iostream>
 #include <string.h>
 
-trace_invariants_t::trace_invariants_t()
+trace_invariants_t::trace_invariants_t(bool offline, unsigned int verbose) :
+    knob_offline(offline), knob_verbose(verbose)
 {
     memset(&prev_instr, 0, sizeof(prev_instr));
+    memset(&prev_marker, 0, sizeof(prev_marker));
 }
 
 trace_invariants_t::~trace_invariants_t()
@@ -47,15 +49,52 @@ trace_invariants_t::~trace_invariants_t()
 bool
 trace_invariants_t::process_memref(const memref_t &memref)
 {
+    if (memref.exit.type == TRACE_TYPE_THREAD_EXIT)
+        thread_exited[memref.exit.tid] = true;
     if (type_is_instr(memref.instr.type) ||
         memref.instr.type == TRACE_TYPE_PREFETCH_INSTR ||
         memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH) {
+        if (knob_verbose >= 3) {
+            std::cerr << "::" << memref.data.pid << ":" << memref.data.tid << ":: " <<
+                " @" << (void *)memref.instr.addr <<
+                ((memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH) ? " non-fetched" : "")
+                << " instr x" << memref.instr.size << "\n";
+        }
         // Invariant: offline traces guarantee that a branch target must immediately
         // follow the branch w/ no intervening trace switch.
-        if (type_is_instr_branch(prev_instr.instr.type)) {
-            assert(prev_instr.instr.tid == memref.instr.tid);
+        if (knob_offline && type_is_instr_branch(prev_instr.instr.type)) {
+            assert(prev_instr.instr.tid == memref.instr.tid ||
+                   // For limited-window traces a thread might exit after a branch.
+                   thread_exited[prev_instr.instr.tid]);
+        }
+        // Invariant: non-explicit control flow (i.e., kernel-mediated) is indicated
+        // by markers.
+        if (prev_instr.instr.addr != 0/*first*/ &&
+            prev_instr.instr.tid == memref.instr.tid &&
+            !type_is_instr_branch(prev_instr.instr.type)) {
+            assert(// Regular fall-through.
+                   (prev_instr.instr.addr + prev_instr.instr.size == memref.instr.addr) ||
+                   // String loop.
+                   (prev_instr.instr.addr == memref.instr.addr &&
+                    memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH) ||
+                   // Kernel-mediated.
+                   (prev_marker.instr.tid == memref.instr.tid &&
+                    (prev_marker.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+                     prev_marker.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER)) ||
+                   prev_instr.instr.type == TRACE_TYPE_INSTR_SYSENTER);
         }
         prev_instr = memref;
+    }
+    if (memref.marker.type == TRACE_TYPE_MARKER) {
+        if (knob_verbose >= 3) {
+            std::cerr << "::" << memref.data.pid << ":" << memref.data.tid << ":: " <<
+                "marker type " << memref.marker.marker_type <<
+                " value " << memref.marker.marker_value << "\n";
+        }
+        prev_marker = memref;
+        // Clear prev_instr to avoid a branch-gap failure above for things like
+        // wow64 call* NtContinue syscall.
+        memset(&prev_instr, 0, sizeof(prev_instr));
     }
     return true;
 }

--- a/clients/drcachesim/tests/trace_invariants.h
+++ b/clients/drcachesim/tests/trace_invariants.h
@@ -38,17 +38,22 @@
 
 #include "../analysis_tool.h"
 #include "../common/memref.h"
+#include <unordered_map>
 
 class trace_invariants_t : public analysis_tool_t
 {
  public:
-    trace_invariants_t();
+    trace_invariants_t(bool offline = true, unsigned int verbose = 0);
     virtual ~trace_invariants_t();
     virtual bool process_memref(const memref_t &memref);
     virtual bool print_results();
 
  protected:
+    bool knob_offline;
+    unsigned int knob_verbose;
     memref_t prev_instr;
+    memref_t prev_marker;
+    std::unordered_map<memref_tid_t,bool> thread_exited;
 };
 
 #endif /* _TRACE_INVARIANTS_H_ */

--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -101,7 +101,7 @@ _tmain(int argc, const TCHAR *targv[])
                               op_verbose.get_value());
     std::vector<analysis_tool_t*> tools;
     tools.push_back(tool1);
-    trace_invariants_t tool2;
+    trace_invariants_t tool2(true/*offline*/, op_verbose.get_value());
     if (op_test_mode.get_value()) {
         // We use this launcher to run tests as well:
         tools.push_back(&tool2);

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -54,6 +54,10 @@ instru_t::instr_to_instr_type(instr_t *instr, bool repstr_expanded)
         return TRACE_TYPE_INSTR_INDIRECT_JUMP;
     if (instr_is_cbr(instr))
         return TRACE_TYPE_INSTR_CONDITIONAL_JUMP;
+#ifdef X86
+    if (instr_get_opcode(instr) == OP_sysenter)
+        return TRACE_TYPE_INSTR_SYSENTER;
+#endif
     // i#2051: to satisfy both cache and core simulators we mark subsequent iters
     // of string loops as TRACE_TYPE_INSTR_NO_FETCH, converted from this
     // TRACE_TYPE_INSTR_MAYBE_FETCH by reader_t (since online traces would need

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -387,8 +387,10 @@ offline_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
         if ((ptr_uint_t)*bb_field > MAX_INSTR_COUNT)
             return adjust;
         pc = dr_fragment_app_pc(tag);
-    } else
+    } else {
+        // XXX: For repstr do we want tag insted of skipping rep prefix?
         pc = instr_get_app_pc(app);
+    }
     adjust += insert_save_pc(drcontext, ilist, where, reg_ptr, reg_tmp, adjust,
                            pc, memref_needs_full_info ? 1 : (uint)(ptr_uint_t)*bb_field);
     if (!memref_needs_full_info)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2585,6 +2585,27 @@ if (CLIENT_INTERFACE)
         set(tool.reuse_time.offline_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       endif ()
 
+      # We run an app w/ kernel xfers to test trace_invariants online.
+      # Offline invariants are tested in the tool.histogram.offline test below.
+      if (UNIX)
+        set(kernel_xfer_app pthreads.ptsig)
+      else ()
+        if (CLIENT_INTERFACE)
+          set(kernel_xfer_app client.winxfer) # We want threads and xfers.
+        else ()
+          set(kernel_xfer_app win32.winapc)
+        endif ()
+      endif()
+      if (DEBUG) # for -test_mode
+        torunonly_ci(tool.drcachesim.invariants ${kernel_xfer_app} drcachesim
+          "drcachesim-invariants.c" # for templatex basename
+          "-test_mode -ipc_name ${IPC_PREFIX}drtestpipe8" "" "")
+        set(tool.drcachesim.invariants_toolname "drcachesim")
+        set(tool.drcachesim.invariants_basedir
+          "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+        set(tool.drcachesim.invariants_rawtemp ON) # no preprocessor
+      endif ()
+
       # Test offline traces.
       # XXX: we could exclude the pipe files and build the offline trace
       # support by itself for Android.
@@ -2690,13 +2711,20 @@ if (CLIENT_INTERFACE)
       # Test the standalone histogram tool.
       # ${ci_shared_app} is already used for an offline test, and we're deleting a
       # dir with that name, so we run other apps to avoid having to serialize.
-      if (UNIX)
-        set(histo_app pthreads.pthreads) # We want some threads for trace_invariants.
+      # We also want threads and signals for trace_invariants.
+      set(histo_app ${kernel_xfer_app})
+      if (WIN32)
+        # winxfer produces a 500M+ trace and test taking >3mins so we narrow
+        # the window.  2M makes a 50M trace and still hits 4 or 5 of the
+        # 13 markers on my machine but is still a little slow so we cut in half
+        # for 2+ markers.
+        set(histo_ops "-trace_after_instrs 5K -exit_after_tracing 1M")
+        set(tool.histogram.offline_timeout 180)
       else ()
-        set(histo_app common.${control_flags})
-      endif()
+        set(histo_ops "")
+      endif ()
       torunonly_ci(tool.histogram.offline ${histo_app} drcachesim
-        "histogram-offline.c" "-offline" "" "")
+        "histogram-offline.c" "-offline ${histo_ops}" "" "")
       set(tool.histogram.offline_toolname "drcachesim")
       set(tool.histogram.offline_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
@@ -3066,7 +3094,7 @@ if (UNIX)
     "-enable_reset -reset_at_fragment_count 100" "")
   tobuild(pthreads.pthreads pthreads/pthreads.c)
   tobuild(pthreads.pthreads_exit pthreads/pthreads_exit.c)
-  tobuild(pthreads.ptsig_FLAKY pthreads/ptsig.c)
+  tobuild(pthreads.ptsig pthreads/ptsig.c)
   if (NOT ANDROID) # FIXME i#1874: failing on Android
     # XXX i#951: pthreads_fork reports leaks on occasion so we mark it FLAKY
     tobuild(pthreads.pthreads_fork_FLAKY pthreads/pthreads_fork.c)


### PR DESCRIPTION
Extends the trace_invariants test from #2638 to ensure there's no
discontinuity in control flow not indicated by a branch or a kernel xfer
marker.

Adds an online trace_invariants test.

Switches the trace_invariants test to run pthreads.ptsig on UNIX, which is
marked un-FLAKY, to test both threads and signals, and on winxfer on
Windows.

Fixes several issues found by this new test:
+ Adds TRACE_TYPE_INSTR_SYSENTER to mark the PC discontinuity from
  OP_sysenter.
+ Adds proper handling of a mid-bb fault in offline trace conversion by
  looking ahead after each memref to see whether there's a marker.
+ #2011 follow-up: fixes the zero-iter code from 2772b0b which it turns out
  only worked for offline traces.  For online, the top-of-bb instr is
  jecxz, so the instr type and size were wrong.
+ Fixes pipe write splitting to avoid separating an instr from its bundle
  entries.
+ Avoids a marker for a thread init kernel xfer event on Windows.

Fixes #2708