### PR TITLE
i#2157 reattach: Unregister TLS field in drcovlib

### DIFF
--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -377,7 +377,7 @@ drmodtrack_exit(void)
     if (count != 0)
         return DRCOVLIB_SUCCESS;
 
-    drmgr_register_tls_field(tls_idx);
+    drmgr_unregister_tls_field(tls_idx);
     drvector_delete(&module_table.vector);
     drmgr_exit();
     return DRCOVLIB_SUCCESS;

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -377,6 +377,7 @@ drmodtrack_exit(void)
     if (count != 0)
         return DRCOVLIB_SUCCESS;
 
+    drmgr_register_tls_field(tls_idx);
     drvector_delete(&module_table.vector);
     drmgr_exit();
     return DRCOVLIB_SUCCESS;


### PR DESCRIPTION
Fixes a reattach-based crash where this TLS leak caused drmgr to run out
of TLS slots.

Issue #2157