### PR TITLE
i#2708 trace discontinuity: allow single lookahead

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -300,7 +300,7 @@ raw2trace_t::read_from_thread_file(uint tidx, offline_entry_t *dest, size_t coun
     if (count > 0) {
         if (!thread_files[tidx]->read((char*)dest, count*sizeof(*dest))) {
             if (num_read != nullptr)
-                *num_read = from_buf + thread_files[tidx]->gcount();
+                *num_read = from_buf + (size_t)thread_files[tidx]->gcount();
             return false;
         }
     }

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -137,8 +137,10 @@ private:
 
     // We do some internal buffering to avoid istream::seekg whose performance is
     // detrimental for some filesystem types.
-    bool read_from_thread_file(uint tidx, offline_entry_t *dest, size_t count);
+    bool read_from_thread_file(uint tidx, offline_entry_t *dest, size_t count,
+                               OUT size_t *num_read = nullptr);
     void unread_from_thread_file(uint tidx, offline_entry_t *dest, size_t count);
+    bool thread_file_at_eof(uint tidx);
     std::vector<std::vector<offline_entry_t>> pre_read;
 
     static const uint MAX_COMBINED_ENTRIES = 64;


### PR DESCRIPTION
Commit 85ca26c added internal buffering for peeking and unpeeking in the
thread trace streams, but it failed to handle missing memrefs at the end of
a trace file.  We fix that here, as well as making eof checking more robust
in the presence of the buffering.

Issue: #2708