### PR TITLE
i#2157 re-attach: Add timeout to os_thread_suspend

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -3111,7 +3111,7 @@ dynamorio_unprotect(void)
                     for (tr = all_threads[i]; tr; tr = tr->next) {
                         if (tr->under_dynamo_control) {
                             DEBUG_DECLARE(bool ok =)
-                                os_thread_suspend(all_threads[i]);
+                                os_thread_suspend(all_threads[i], 0);
                             ASSERT(ok);
                             protect_info->num_threads_suspended++;
                         }

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -151,7 +151,11 @@ thread_id_t get_thread_id(void);
 process_id_t get_process_id(void);
 void os_thread_yield(void);
 void os_thread_sleep(uint64 milliseconds);
-bool os_thread_suspend(thread_record_t *tr);
+/* os_thread_suspend may return false in the case of a timeout. Note that the
+ * timeout field is best effort and may be ignored by implementations (i.e.
+ * Windows); setting timeout to 0 results in blocking forever.
+ */
+bool os_thread_suspend(thread_record_t *tr, int timeout_ms);
 bool os_thread_resume(thread_record_t *tr);
 bool os_thread_terminate(thread_record_t *tr);
 

--- a/core/synch.c
+++ b/core/synch.c
@@ -1922,10 +1922,10 @@ detach_on_permanent_stack(bool internal, bool do_cleanup)
     DEBUG_DECLARE(bool ok;)
     DEBUG_DECLARE(int exit_res;)
     /* synch-all flags: if we fail to suspend a thread (e.g., privilege
-     * problems) ignore it.  XXX Should we retry instead?
+     * problems) retry it.
      */
     /* i#297: we only synch client threads after process exit event. */
-    uint flags = THREAD_SYNCH_SUSPEND_FAILURE_IGNORE | THREAD_SYNCH_SKIP_CLIENT_THREAD;
+    uint flags = THREAD_SYNCH_SUSPEND_FAILURE_RETRY | THREAD_SYNCH_SKIP_CLIENT_THREAD;
 
     ENTERING_DR();
 

--- a/core/unix/ksynch.h
+++ b/core/unix/ksynch.h
@@ -88,7 +88,8 @@ KSYNCH_TYPE *
 mutex_get_contended_event(mutex_t *lock);
 
 /* These return 0 on success and a negative value on failure. ksynch_wait
- * returns -ETIMEDOUT if there was a timeout condition. */
+ * returns -ETIMEDOUT if there was a timeout condition.
+ */
 
 ptr_int_t
 ksynch_wait(KSYNCH_TYPE *var, int mustbe, int timeout_ms);

--- a/core/unix/ksynch.h
+++ b/core/unix/ksynch.h
@@ -87,7 +87,8 @@ ksynch_set_value(mac_synch_t *synch, int new_val);
 KSYNCH_TYPE *
 mutex_get_contended_event(mutex_t *lock);
 
-/* These return 0 on success: */
+/* These return 0 on success and a negative value on failure. ksynch_wait
+ * returns -ETIMEDOUT if there was a timeout condition. */
 
 ptr_int_t
 ksynch_wait(KSYNCH_TYPE *var, int mustbe, int timeout_ms);

--- a/core/unix/ksynch_macos.c
+++ b/core/unix/ksynch_macos.c
@@ -125,7 +125,16 @@ ksynch_wait(mac_synch_t *synch, int mustbe, int timeout_ms)
         res = semaphore_timedwait(synch->sem, timeout);
     } else
         res = semaphore_wait(synch->sem);
-    return (res == KERN_SUCCESS ? 0 : -1);
+
+    /* Conform to the API specified in ksynch.h */
+    switch (res) {
+    case KERN_SUCCESS:
+        return 0;
+    case KERN_OPERATION_TIMED_OUT:
+        return -ETIMEDOUT;
+    default:
+        return -1;
+    }
 }
 
 ptr_int_t

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -3440,7 +3440,7 @@ os_thread_sleep(uint64 milliseconds)
 }
 
 bool
-os_thread_suspend(thread_record_t *tr)
+os_thread_suspend(thread_record_t *tr, int timeout_ms)
 {
     os_thread_data_t *ostd = (os_thread_data_t *) tr->dcontext->os_field;
     ASSERT(ostd != NULL);
@@ -3478,7 +3478,7 @@ os_thread_suspend(thread_record_t *tr)
          * than a timeout value, the return value doesn't matter because the
          * flag will be re-checked.
          */
-        if (ksynch_wait(&ostd->suspended, 0, 5000) == -ETIMEDOUT) {
+        if (ksynch_wait(&ostd->suspended, 0, timeout_ms) == -ETIMEDOUT) {
             mutex_lock(&ostd->suspend_lock);
             ASSERT(ostd->suspend_count > 0);
             ostd->suspend_count--;

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -4905,7 +4905,7 @@ os_timeout(int time_in_milliseconds)
 }
 
 bool
-os_thread_suspend(thread_record_t *tr)
+os_thread_suspend(thread_record_t *tr, int timeout_ms)
 {
     return nt_thread_suspend(tr->handle, NULL);
 }

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -7679,7 +7679,7 @@ os_dump_core_live_dump(const char *msg, char *path OUT, size_t path_sz)
                         nt_get_handle_access_rights(tr->handle);
                     TEB *teb_addr = get_teb(tr->handle);
                     DEBUG_DECLARE(bool res = )
-                        os_thread_suspend(tr);
+                        os_thread_suspend(tr, 0);
                     /* we can't assert here (could infinite loop) */
                     DODEBUG({ suspend_failures = suspend_failures || !res; });
                     if (thread_get_context(tr, &cxt)) {


### PR DESCRIPTION
After 5 seconds of waiting for a thread to acknowledge a received
signal, os_thread_suspend now returns false so that the caller can
retry.

I have a unit test where there's a small chance that the thread doing detach will send the SUSPEND_SIGNAL to a newly created thread before its dcontext's `signal_field` is `fully_initialized`; the new thread discards the signal (`can_always_delay[SUSPEND_SIGNAL] == true`) and later initializes its `signal_field`, but the thread doing detach currently never retries to send the signal. So, this is kind of a workaround for a specific instance of i#26 that results in DR deadlocking on itself.

Issue: #2157