### PR TITLE
i#2761: fix drcachesim crash from drreg overreach

### DIFF
--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1518,9 +1518,6 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
 {
     /* We need 2 reg slots beyond drreg's eflags slots => 3 slots */
     drreg_options_t ops = {sizeof(ops), 3, false};
-    /* We need an extra for -L0_filter. */
-    if (op_L0_filter.get_value())
-        ++ops.num_spill_slots;
 
     dr_set_client_name("DynamoRIO Cache Simulator Tracer",
                        "http://dynamorio.org/issues");
@@ -1586,6 +1583,10 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
         if (!ipc_pipe.maximize_buffer())
             NOTIFY(1, "Failed to maximize pipe buffer: performance may suffer.\n");
     }
+
+    /* We need an extra for -L0_filter. */
+    if (op_L0_filter.get_value())
+        ++ops.num_spill_slots;
 
     if (!drmgr_init() || !drutil_init() || drreg_init(&ops) != DRREG_SUCCESS)
         DR_ASSERT(false);

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -412,7 +412,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
          (TESTANY(EFLAGS_WRITE_ARITH, instr_get_eflags(inst, DR_QUERY_INCLUDE_ALL)) &&
           aflags != 0 /*0 means everything is dead*/) ||
          /* DR slots are not guaranteed across app instrs */
-         pt->aflags.slot >= ops.num_spill_slots)) {
+         pt->aflags.slot >= (int)ops.num_spill_slots)) {
         /* Restore aflags to app value */
         LOG(drcontext, LOG_ALL, 3,
             "%s @%d."PFX" aflags=0x%x use=%d: lazily restoring aflags\n",
@@ -449,7 +449,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
                 /* If we're out of our own slots and are using a DR slot, we have to
                  * restore now b/c DR slots are not guaranteed across app instrs.
                  */
-                pt->reg[GPR_IDX(reg)].slot >= ops.num_spill_slots) {
+                pt->reg[GPR_IDX(reg)].slot >= (int)ops.num_spill_slots) {
                 if (!pt->reg[GPR_IDX(reg)].in_use) {
                     LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": lazily restoring %s\n",
                         __FUNCTION__, pt->live_idx, instr_get_app_pc(inst),
@@ -1638,6 +1638,12 @@ drreg_init(drreg_options_t *ops_in)
             !drmgr_register_restore_state_ex_event_ex
             (drreg_event_restore_state, &fault_priority))
             return DRREG_ERROR;
+#ifdef X86
+        /* We get an extra slot for aflags xax, rather than just documenting that
+         * clients should add 2 instead of just 1, as there are many existing clients.
+         */
+        ops.num_spill_slots = 1;
+#endif
     }
 
     if (ops_in->struct_size < offsetof(drreg_options_t, error_callback))

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -410,7 +410,9 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
          TESTANY(EFLAGS_READ_ARITH, instr_get_eflags(inst, DR_QUERY_DEFAULT)) ||
          /* Writing just a subset needs to combine with the original unwritten */
          (TESTANY(EFLAGS_WRITE_ARITH, instr_get_eflags(inst, DR_QUERY_INCLUDE_ALL)) &&
-          aflags != 0 /*0 means everything is dead*/))) {
+          aflags != 0 /*0 means everything is dead*/) ||
+         /* DR slots are not guaranteed across app instrs */
+         pt->aflags.slot >= ops.num_spill_slots)) {
         /* Restore aflags to app value */
         LOG(drcontext, LOG_ALL, 3,
             "%s @%d."PFX" aflags=0x%x use=%d: lazily restoring aflags\n",
@@ -443,7 +445,11 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
                 (!pt->reg[GPR_IDX(reg)].in_use &&
                  ((pt->bb_has_internal_flow &&
                    !TEST(DRREG_IGNORE_CONTROL_FLOW, pt->bb_props)) ||
-                  TEST(DRREG_CONTAINS_SPANNING_CONTROL_FLOW, pt->bb_props)))) {
+                  TEST(DRREG_CONTAINS_SPANNING_CONTROL_FLOW, pt->bb_props))) ||
+                /* If we're out of our own slots and are using a DR slot, we have to
+                 * restore now b/c DR slots are not guaranteed across app instrs.
+                 */
+                pt->reg[GPR_IDX(reg)].slot >= ops.num_spill_slots) {
                 if (!pt->reg[GPR_IDX(reg)].in_use) {
                     LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": lazily restoring %s\n",
                         __FUNCTION__, pt->live_idx, instr_get_app_pc(inst),

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -82,7 +82,7 @@ if ($child) {
         $mydir = `/usr/bin/cygpath -wi \"$mydir\"`;
         chomp $mydir;
     }
-    system("ctest --output-on-failure -V -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
+    system("ctest --output-on-failure -VV -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
     exit 0;
 }
 

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -82,7 +82,7 @@ if ($child) {
         $mydir = `/usr/bin/cygpath -wi \"$mydir\"`;
         chomp $mydir;
     }
-    system("ctest --output-on-failure -VV -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
+    system("ctest --output-on-failure -V -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
     exit 0;
 }
 


### PR DESCRIPTION
Fixes a drcachesim -L0_filter crash from requesting too few slots from
drreg.

Fixes drreg to abort lazy restoring at app instr boundaries for registers
in DR slots, which are not guaranteed across app instrs.

Fixes #2761