### PR TITLE
i#2756: proper handling of multi-memref instrs when filtering

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -257,6 +257,10 @@ typedef enum {
     OFFLINE_EXT_TYPE_FOOTER,
     // A marker type.  The valueB field holds the sub-type and valueA the value.
     OFFLINE_EXT_TYPE_MARKER,
+    // Stores the type of access in valueB and the size in valueA.
+    // Used for filters on multi-memref instrs where post-processing can't tell
+    // which memref passed the filter.
+    OFFLINE_EXT_TYPE_MEMINFO,
 } offline_ext_type_t;
 
 #define EXT_VALUE_A_BITS 48

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -213,12 +213,19 @@ private:
         void *user_data;
     };
 
+    bool instr_has_multiple_different_memrefs(instr_t *instr);
+    int insert_save_entry(void *drcontext, instrlist_t *ilist, instr_t *where,
+                          reg_id_t reg_ptr, reg_id_t scratch, int adjust,
+                          offline_entry_t *entry);
     int insert_save_pc(void *drcontext, instrlist_t *ilist, instr_t *where,
                         reg_id_t reg_ptr, reg_id_t scratch, int adjust, app_pc pc,
                         uint instr_count);
     int insert_save_addr(void *drcontext, instrlist_t *ilist, instr_t *where,
                          reg_id_t reg_ptr, reg_id_t reg_addr, int adjust, opnd_t ref,
                          bool write);
+    int insert_save_type_and_size(void *drcontext, instrlist_t *ilist, instr_t *where,
+                                  reg_id_t reg_ptr, reg_id_t scratch, int adjust,
+                                  instr_t *app, opnd_t ref, bool write);
     ssize_t (*write_file_func)(file_t file, const void *data, size_t count);
     file_t modfile;
 

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -274,7 +274,7 @@ online_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t 
                                    dr_pred_type_t pred)
 {
     ushort type = (ushort)(write ? TRACE_TYPE_WRITE : TRACE_TYPE_READ);
-    ushort size = (ushort)drutil_opnd_mem_size_in_bytes(ref, where);
+    ushort size = (ushort)drutil_opnd_mem_size_in_bytes(ref, app);
     if (!memref_needs_full_info) // For full info we skip this for !pred
         instrlist_set_auto_predicate(ilist, pred);
     if (memref_needs_full_info) {
@@ -289,11 +289,11 @@ online_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t 
     }
     insert_save_addr(drcontext, ilist, where, reg_ptr, reg_tmp, adjust, ref);
     // Special handling for prefetch instruction
-    if (instr_is_prefetch(where)) {
-        type = instru_t::instr_to_prefetch_type(where);
+    if (instr_is_prefetch(app)) {
+        type = instru_t::instr_to_prefetch_type(app);
         // Prefetch instruction may have zero sized mem reference.
         size = 1;
-    } else if (instru_t::instr_is_flush(where)) {
+    } else if (instru_t::instr_is_flush(app)) {
         // XXX: OP_clflush invalidates all levels of the processor cache
         // hierarchy (data and instruction)
         type = TRACE_TYPE_DATA_FLUSH;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -330,53 +330,64 @@ raw2trace_t::append_memref(INOUT trace_entry_t **buf_in, uint tidx, instr_t *ins
                            opnd_t ref, bool write)
 {
     trace_entry_t *buf = *buf_in;
-    // To avoid having to backtrack later, we read 2 ahead to see whether this memref
-    // faulted.  There's a footer so we should always get 1, but we might not get the
-    // 2nd for predication or zero-iter string loops (caught below).
-    offline_entry_t in_entry[2];
-    size_t num_read;
-    if (!read_from_thread_file(tidx, in_entry, 2, &num_read) && num_read == 0)
+    offline_entry_t in_entry;
+    bool have_type = false;
+    if (!read_from_thread_file(tidx, &in_entry, 1))
         return "Trace ends mid-block";
-    if (in_entry[0].addr.type != OFFLINE_TYPE_MEMREF &&
-        in_entry[0].addr.type != OFFLINE_TYPE_MEMREF_HIGH) {
+    if (in_entry.extended.type == OFFLINE_TYPE_EXTENDED &&
+        in_entry.extended.ext == OFFLINE_EXT_TYPE_MEMINFO) {
+        // For -L0_filter we have to store the type for multi-memref instrs where
+        // we can't tell which memref it is (we'll still come here for the subsequent
+        // memref operands but we'll exit early in the check below).
+        have_type = true;
+        buf->type = in_entry.extended.valueB;
+        buf->size = in_entry.extended.valueA;
+        VPRINT(4, "Found type entry type %d size %d\n", buf->type, buf->size);
+        if (!read_from_thread_file(tidx, &in_entry, 1))
+            return "Trace ends mid-block";
+    }
+    if (in_entry.addr.type != OFFLINE_TYPE_MEMREF &&
+        in_entry.addr.type != OFFLINE_TYPE_MEMREF_HIGH) {
         // This happens when there are predicated memrefs in the bb, or for a
-        // zero-iter rep string loop.  For predicated memrefs,
-        // they could be earlier, so "instr" may not itself be predicated.
+        // zero-iter rep string loop, or for a multi-memref instr with -L0_filter.
+        // For predicated memrefs, they could be earlier, so "instr"
+        // may not itself be predicated.
         // XXX i#2015: if there are multiple predicated memrefs, our instr vs
         // data stream may not be in the correct order here.
-        // FIXME i#2756: for -L0_filter we'll also come here b/c we don't know
-        // which memref it is.
-        VPRINT(4, "Missing memref from predication or 0-iter repstr (next type is 0x"
-               ZHEX64_FORMAT_STRING ")\n", in_entry[0].combined_value);
-        // Put back all entries read.
-        unread_from_thread_file(tidx, in_entry, num_read);
+        VPRINT(4, "Missing memref from predication, 0-iter repstr, or filter "
+               "(next type is 0x" ZHEX64_FORMAT_STRING ")\n", in_entry.combined_value);
+        unread_from_thread_file(tidx, &in_entry, 1);
         return "";
     }
-    if (num_read > 1) {
-        // Put back the 2nd entry.
-        unread_from_thread_file(tidx, &in_entry[1], 1);
-    }
-    if (instr_is_prefetch(instr)) {
-        buf->type = instru_t::instr_to_prefetch_type(instr);
-        buf->size = 1;
-    } else if (instru_t::instr_is_flush(instr)) {
-        buf->type = TRACE_TYPE_DATA_FLUSH;
-        buf->size = (ushort) opnd_size_in_bytes(opnd_get_size(ref));
-    } else {
-        if (write)
-            buf->type = TRACE_TYPE_WRITE;
-        else
-            buf->type = TRACE_TYPE_READ;
-        buf->size = (ushort) opnd_size_in_bytes(opnd_get_size(ref));
+    if (!have_type) {
+        if (instr_is_prefetch(instr)) {
+            buf->type = instru_t::instr_to_prefetch_type(instr);
+            buf->size = 1;
+        } else if (instru_t::instr_is_flush(instr)) {
+            buf->type = TRACE_TYPE_DATA_FLUSH;
+            buf->size = (ushort) opnd_size_in_bytes(opnd_get_size(ref));
+        } else {
+            if (write)
+                buf->type = TRACE_TYPE_WRITE;
+            else
+                buf->type = TRACE_TYPE_READ;
+            buf->size = (ushort) opnd_size_in_bytes(opnd_get_size(ref));
+        }
     }
     // We take the full value, to handle low or high.
-    buf->addr = (addr_t) in_entry[0].combined_value;
-    VPRINT(4, "Appended memref to " PFX "\n", (ptr_uint_t)buf->addr);
+    buf->addr = (addr_t) in_entry.combined_value;
+    VPRINT(4, "Appended memref type %d size %d to " PFX "\n", buf->type, buf->size,
+           (ptr_uint_t)buf->addr);
     *buf_in = ++buf;
-    if (num_read > 1 &&
-        in_entry[1].extended.type == OFFLINE_TYPE_EXTENDED &&
-        in_entry[1].extended.ext == OFFLINE_EXT_TYPE_MARKER &&
-        in_entry[1].extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT) {
+    // To avoid having to backtrack later, we read ahead to see whether this memref
+    // faulted.  There's a footer so this should always succeed.
+    if (!read_from_thread_file(tidx, &in_entry, 1))
+        return "Trace ends mid-block";
+    // Put it back.
+    unread_from_thread_file(tidx, &in_entry, 1);
+    if (in_entry.extended.type == OFFLINE_TYPE_EXTENDED &&
+        in_entry.extended.ext == OFFLINE_EXT_TYPE_MARKER &&
+        in_entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT) {
         // A signal/exception interrupted the bb after the memref.
         VPRINT(4, "Signal/exception interrupted the bb\n");
         return FAULT_INTERRUPTED_BB;


### PR DESCRIPTION
For -L0_filter on drcachesim, storing only the PC and data address is not
enough to figure out during post-processing which memref it was for a
multi-memref instruction.  Here we add a new offline entry type to store
the memref type and size and use it for multi-memref instructions where the
memrefs are different (when identical, such as for ALU operations, the
first will pass the filter and be picked in post-processing).

Fixes #2756