### PR TITLE
Revert "i#2717 Shorten enums if possible. (#2766)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -810,8 +810,6 @@ if (UNIX)
     set(DBG_OPT "${DBG_OPT} -fno-builtin-strcmp")
   endif ()
   set(LINK_EXTRA_FLAGS "")
-  # Use as small a type for enums as possible.
-  set(BASE_CFLAGS "${BASE_CFLAGS} -fshort-enums")
 else (UNIX)
   # FIXME: why isn't ${CMAKE_CL_NOLOGO} set?
   set(BASE_CFLAGS "${BASE_CFLAGS} /nologo")

--- a/core/link.h
+++ b/core/link.h
@@ -492,7 +492,7 @@ const linkstub_t * get_hot_patch_linkstub(void);
 #ifdef CLIENT_INTERFACE
 const linkstub_t * get_client_linkstub(void);
 #endif
-const linkstub_t *get_special_ibl_linkstub(ibl_branch_type_t index,  bool is_trace);
+const linkstub_t *get_special_ibl_linkstub(int index, bool is_trace);
 const linkstub_t * get_ibl_sourceless_linkstub(uint link_flags, uint frag_flags);
 bool is_ibl_sourceless_linkstub(const linkstub_t *l);
 const linkstub_t * get_coarse_exit_linkstub(void);

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -108,7 +108,7 @@
  * To support differing default actions, we have separate arrays, rather
  * than indirecting to a single all-signals array.
  */
-extern default_action_t default_action[];
+extern int default_action[];
 
 /* We know that many signals are always asynchronous.
  * Others, however, may be synchronous or may not -- e.g., another process

--- a/core/unix/signal_linux.c
+++ b/core/unix/signal_linux.c
@@ -71,7 +71,7 @@
  */
 
 
-default_action_t default_action[] = {
+int default_action[] = {
     /* nothing    0 */   DEFAULT_IGNORE,
     /* SIGHUP     1 */   DEFAULT_TERMINATE,
     /* SIGINT     2 */   DEFAULT_TERMINATE,

--- a/core/unix/signal_macos.c
+++ b/core/unix/signal_macos.c
@@ -46,7 +46,7 @@
 #endif
 
 /* based on xnu bsd/sys/signalvar.h */
-default_action_t default_action[] = {
+int default_action[] = {
     0,                      /*  0 unused */
     DEFAULT_TERMINATE,      /*  1 SIGHUP */
     DEFAULT_TERMINATE,      /*  2 SIGINT */

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -68,13 +68,13 @@ typedef void (*tramp_t)(handler_t, int, int, siginfo_t *, void *);
 #endif
 
 /* default actions */
-typedef enum default_action_t {
+enum {
     DEFAULT_TERMINATE,
     DEFAULT_TERMINATE_CORE,
     DEFAULT_IGNORE,
     DEFAULT_STOP,
     DEFAULT_CONTINUE,
-} default_action_t;
+};
 
 #ifdef X86
 /* Even though we don't always execute xsave ourselves, kernel will do


### PR DESCRIPTION
This reverts commit ffbc78e74526a7bc95b0e5109cea4569986ae082 as it causes
an assert for -loglevel 3 and -tracedump_text runs.