### PR TITLE
Changes handling of looping on enum ibl_entry_point_type_t.

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -1963,9 +1963,8 @@ get_ibl_routine_type_ex(dcontext_t *dcontext, cache_pc target, ibl_type_t *type
 
     /* a decent compiler should inline these nested loops */
     /* iterate in order <linked, unlinked> */
-    for (link_state = IBL_LINKED;
-         /* keep in mind we need a signed comparison when going downwards */
-         (int)link_state >= (int)IBL_UNLINKED; link_state-- ) {
+    link_state = IBL_LINKED;
+    while (true) {
         /* it is OK to compare to IBL_BB_PRIVATE even when !SHARED_FRAGMENTS_ENABLED() */
         for (source_fragment_type = IBL_SOURCE_TYPE_START;
              source_fragment_type < IBL_SOURCE_TYPE_END;
@@ -1995,6 +1994,9 @@ get_ibl_routine_type_ex(dcontext_t *dcontext, cache_pc target, ibl_type_t *type
 #endif
             }
         }
+        if (link_state == IBL_UNLINKED)
+          break;
+        link_state--;
     }
 #ifdef WINDOWS
     if (is_shared_syscall_routine(dcontext, target)) {

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -1933,6 +1933,11 @@ bool
 get_ibl_routine_type_ex(dcontext_t *dcontext, cache_pc target, ibl_type_t *type
                         _IF_X86_64(gencode_mode_t *mode_out))
 {
+    /* This variable is int instead of ibl_entry_point_type_t.  This is because
+     * below we use it as loop index variable which can take negative values.
+     * It is possible that ibl_entry_point_type_t, which is an enum, has an
+     * underlying unsigned type which can cause problems due to wrap around.
+     */
     int link_state;
     ibl_source_fragment_type_t source_fragment_type;
     ibl_branch_type_t branch_type;

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -1933,7 +1933,7 @@ bool
 get_ibl_routine_type_ex(dcontext_t *dcontext, cache_pc target, ibl_type_t *type
                         _IF_X86_64(gencode_mode_t *mode_out))
 {
-    ibl_entry_point_type_t link_state;
+    int link_state;
     ibl_source_fragment_type_t source_fragment_type;
     ibl_branch_type_t branch_type;
 #if defined(X86) && defined(X64)
@@ -1963,8 +1963,9 @@ get_ibl_routine_type_ex(dcontext_t *dcontext, cache_pc target, ibl_type_t *type
 
     /* a decent compiler should inline these nested loops */
     /* iterate in order <linked, unlinked> */
-    link_state = IBL_LINKED;
-    while (true) {
+    for (link_state = IBL_LINKED;
+         /* keep in mind we need a signed comparison when going downwards */
+         link_state >= (int)IBL_UNLINKED; link_state--) {
         /* it is OK to compare to IBL_BB_PRIVATE even when !SHARED_FRAGMENTS_ENABLED() */
         for (source_fragment_type = IBL_SOURCE_TYPE_START;
              source_fragment_type < IBL_SOURCE_TYPE_END;
@@ -1994,9 +1995,6 @@ get_ibl_routine_type_ex(dcontext_t *dcontext, cache_pc target, ibl_type_t *type
 #endif
             }
         }
-        if (link_state == IBL_UNLINKED)
-          break;
-        link_state--;
     }
 #ifdef WINDOWS
     if (is_shared_syscall_routine(dcontext, target)) {


### PR DESCRIPTION
The looping code assumes that enums are signed.  As per the C standard,
this is implementation defined.  Therefore the code is being changed so
that it does not depend on the type used for the enum.