### PR TITLE
i#2335: fix premature sigaction with dr_create_client_thread.

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -3683,10 +3683,11 @@ client_thread_run(void)
         get_thread_id());
     /* We stored the func and args in particular clone record fields */
     func = (void (*)(void *param)) signal_thread_inherit(dcontext, crec);
-    /* signal_thread_inherit() no longer sets up handlers or masks: we have to
-     * explicitly do that.
+
+    /* Client threads are sharing the same signal handler table as the app's
+     * thread group, so there's no reason to update signal handlers. But we
+     * still have to swap the signal mask to DR (see i#2339).
      */
-    signal_reinstate_handlers(dcontext, false/*alarm too*/);
     signal_swap_mask(dcontext, false/*to DR*/);
 
     void *arg = (void *) get_clone_record_app_xsp(crec);


### PR DESCRIPTION
As mentioned in the modified code comment, this call to
signal_reinstate_handlers was not good:

* It was not necessary: the newly cloned thread already is sharing the
signal handler table with the app's thread group
* Since DR only partially unregisters its signal handlers right before
dr_app_setup() returns, it causes an application signal handler to
receive signals (such as SIGSEGV) that DR expects to send to itself
(e.g. during TLS) when an application thread receives a signal between
dr_app_setup() and dr_app_start().

Issue: #2335