### PR TITLE
Adds __strncat_chk function to string.c

### DIFF
--- a/core/string.c
+++ b/core/string.c
@@ -182,6 +182,18 @@ __strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
 # else
     __attribute__((alias("strncpy")));
 # endif
+void *
+__strncat_chk(char *dst, const char *src, size_t n, size_t dst_len)
+# ifdef MACOS
+/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
+ * XXX: better to test for support at config time: for now assuming none on Mac.
+ */
+{
+  return strncat(dst, src, n);
+}
+# else
+    __attribute__((alias("strncat")));
+# endif
 #endif
 
 /* Private strncat. */

--- a/core/string.c
+++ b/core/string.c
@@ -165,7 +165,7 @@ __memmove_chk(void *dst, const void *src, size_t n, size_t dst_len)
  * XXX: better to test for support at config time: for now assuming none on Mac.
  */
 {
-  return memmove(dst, src, n);
+    return memmove(dst, src, n);
 }
 # else
     __attribute__((alias("memmove")));
@@ -177,7 +177,7 @@ __strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
  * XXX: better to test for support at config time: for now assuming none on Mac.
  */
 {
-  return strncpy(dst, src, n);
+    return strncpy(dst, src, n);
 }
 # else
     __attribute__((alias("strncpy")));
@@ -189,7 +189,7 @@ __strncat_chk(char *dst, const char *src, size_t n, size_t dst_len)
  * XXX: better to test for support at config time: for now assuming none on Mac.
  */
 {
-  return strncat(dst, src, n);
+    return strncat(dst, src, n);
 }
 # else
     __attribute__((alias("strncat")));


### PR DESCRIPTION
gcc emitted calls to this function when core/options.c was edited to
reduce the size of libdyanmorio.a.  On AArch64, the linker fails to
find this symbol elsewhere.  So we are adding it here like other
similar symbols.