### PR TITLE
Replace incorrect usage of macro NULL with 0 or false

### DIFF
--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -1239,7 +1239,7 @@ privload_process_one_import(privmod_t *mod, privmod_t *impmod,
          */
         if (forwfunc == (char *)(ptr_int_t)1 || strchr(forwfunc+1, '.') != NULL) {
             CLIENT_ASSERT(false, "unexpected forwarder string");
-            return NULL;
+            return false;
         }
         if (forwfunc - forwarder + strlen("dll") >=
             BUFFER_SIZE_ELEMENTS(forwmodpath)) {

--- a/core/win32/module_shared.c
+++ b/core/win32/module_shared.c
@@ -845,7 +845,7 @@ get_own_x64_peb(void)
     uint peb64, peb64_hi;
     if (!is_wow64_process(NT_CURRENT_PROCESS)) {
         ASSERT_NOT_REACHED();
-        return NULL;
+        return 0;
     }
     __asm {
         mov eax, dword ptr gs:X64_PEB_TIB_OFFSET
@@ -980,8 +980,8 @@ get_module_handle_64(const wchar_t *name)
 {
     /* Be careful: we can't directly de-ref any ptrs b/c they can be >4GB */
     LDR_MODULE_64 mod;
-    if (!get_ldr_module_64(name, NULL, &mod))
-        return NULL;
+    if (!get_ldr_module_64(name, 0, &mod))
+        return 0;
     return mod.BaseAddress;
 }
 
@@ -1145,7 +1145,7 @@ load_library_64(const char *path)
                 get_ldr_module_64(NULL, (uint64)result, &mod);
             ASSERT(ok);
             entry = (dr_auxlib64_routine_ptr_t) mod.EntryPoint;
-            if (entry != NULL) {
+            if (entry != 0) {
                 if (dr_invoke_x64_routine(entry, 3, result, DLL_PROCESS_ATTACH, NULL))
                     return result;
                 else {

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -8235,7 +8235,7 @@ detach_internal()
     /* we go ahead and re-protect though detach thread will soon un-prot */
     SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
     LOG(GLOBAL, LOG_ALL, 1, "Starting detach\n");
-    nudge_internal(get_process_id(), NUDGE_GENERIC(detach), NULL, 0 /* ignored */, 0);
+    nudge_internal(get_process_id(), NUDGE_GENERIC(detach), 0, 0 /* ignored */, 0);
     LOG(GLOBAL, LOG_ALL, 1, "Created detach thread\n");
 }
 


### PR DESCRIPTION
The C NULL macro (defined as ((void *)0) should be used to initialize
pointer variables to 0. MSVC++ 14.12 will report compiler warnings
when the NULL macro is used to initialize variables or parameters that
are not pointers.