### PR TITLE
i#2335 sig races: Init dr_app_started before clients

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -646,6 +646,11 @@ dynamorio_app_init(void)
         annotation_init();
 #endif
         jitopt_init();
+
+        /* New client threads rely on dr_app_started being initialized, so do
+         * that before initializing clients.
+         */
+        dr_app_started = create_broadcast_event();
 #ifdef CLIENT_INTERFACE
         /* client last, in case it depends on other inits: must be after
          * dynamo_thread_init so the client can use a dcontext (PR 216936).
@@ -703,8 +708,6 @@ dynamorio_app_init(void)
         }
 #endif
     }
-
-    dr_app_started = create_broadcast_event();
 
     dynamo_initialized = true;
 


### PR DESCRIPTION
instrument_init appears to call the dr_client_main of a client; since
clients might call dr_create_client_thread in their main func, it's
important to initialize the dr_app_started variable used via
dr_create_client_thread.

Fixes #2335