### PR TITLE
i#2001 trace perf: add drutil_insert_get_mem_addr_ex()

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -220,6 +220,7 @@ Further non-compatibility-affecting changes include:
    facilitate using drfrontendlib by itself.
  - Added instr_is_string_op() and instr_is_rep_string_op().
  - Added dr_app_recurlock_lock().
+ - Added drutil_insert_get_mem_addr_ex().
 
 **************************************************
 <hr>

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -110,13 +110,18 @@ instru_t::instr_is_flush(instr_t *instr)
 
 void
 instru_t::insert_obtain_addr(void *drcontext, instrlist_t *ilist, instr_t *where,
-                             reg_id_t reg_addr, reg_id_t reg_scratch, opnd_t ref)
+                             reg_id_t reg_addr, reg_id_t reg_scratch, opnd_t ref,
+                             OUT bool *scratch_used)
 {
     bool ok;
-    if (opnd_uses_reg(ref, reg_scratch))
+    if (opnd_uses_reg(ref, reg_scratch)) {
         drreg_get_app_value(drcontext, ilist, where, reg_scratch, reg_scratch);
+        if (scratch_used != NULL)
+            *scratch_used = true;
+    }
     if (opnd_uses_reg(ref, reg_addr))
         drreg_get_app_value(drcontext, ilist, where, reg_addr, reg_addr);
-    ok = drutil_insert_get_mem_addr(drcontext, ilist, where, ref, reg_addr, reg_scratch);
+    ok = drutil_insert_get_mem_addr_ex(drcontext, ilist, where, ref, reg_addr,
+                                       reg_scratch, scratch_used);
     DR_ASSERT(ok);
 }

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -97,7 +97,8 @@ public:
                                               bool repstr_expanded = false);
     static bool instr_is_flush(instr_t *instr);
     virtual void insert_obtain_addr(void *drcontext, instrlist_t *ilist, instr_t *where,
-                                    reg_id_t reg_addr, reg_id_t reg_scratch, opnd_t ref);
+                                    reg_id_t reg_addr, reg_id_t reg_scratch, opnd_t ref,
+                                    OUT bool *scratch_used = NULL);
 
 protected:
     void (*insert_load_buf_ptr)(void *, instrlist_t *, instr_t *, reg_id_t);

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -370,10 +370,12 @@ offline_instru_t::insert_save_addr(void *drcontext, instrlist_t *ilist, instr_t 
                                    opnd_t ref, bool write)
 {
     int disp = adjust;
-    insert_obtain_addr(drcontext, ilist, where, reg_addr, reg_ptr, ref);
-    // drutil_insert_get_mem_addr may clobber reg_ptr, so we need to re-load reg_ptr.
-    // XXX i#2001: determine whether we have to and avoid it when we don't.
-    insert_load_buf_ptr(drcontext, ilist, where, reg_ptr);
+    bool reg_ptr_used;
+    insert_obtain_addr(drcontext, ilist, where, reg_addr, reg_ptr, ref, &reg_ptr_used);
+    if (reg_ptr_used) {
+        // Re-load because reg_ptr was clobbered.
+        insert_load_buf_ptr(drcontext, ilist, where, reg_ptr);
+    }
     MINSERT(ilist, where,
             XINST_CREATE_store(drcontext,
                                OPND_CREATE_MEMPTR(reg_ptr, disp),

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -189,9 +189,12 @@ online_instru_t::insert_save_addr(void *drcontext, instrlist_t *ilist, instr_t *
                                   opnd_t ref)
 {
     int disp = adjust + offsetof(trace_entry_t, addr);
-    insert_obtain_addr(drcontext, ilist, where, reg_addr, reg_ptr, ref);
-    // drutil_insert_get_mem_addr may clobber reg_ptr, so we need to reload reg_ptr
-    insert_load_buf_ptr(drcontext, ilist, where, reg_ptr);
+    bool reg_ptr_used;
+    insert_obtain_addr(drcontext, ilist, where, reg_addr, reg_ptr, ref, &reg_ptr_used);
+    if (reg_ptr_used) {
+        // drutil_insert_get_mem_addr clobbered reg_ptr, so we need to reload reg_ptr.
+        insert_load_buf_ptr(drcontext, ilist, where, reg_ptr);
+    }
     MINSERT(ilist, where,
             XINST_CREATE_store(drcontext,
                                OPND_CREATE_MEMPTR(reg_ptr, disp),

--- a/ext/drutil/drutil.h
+++ b/ext/drutil/drutil.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /* drutil: DynamoRIO Instrumentation Utilities
@@ -93,6 +93,16 @@ DR_EXPORT
 bool
 drutil_insert_get_mem_addr(void *drcontext, instrlist_t *bb, instr_t *where,
                            opnd_t memref, reg_id_t dst, reg_id_t scratch);
+
+DR_EXPORT
+/**
+ * Identical to drutil_insert_get_mem_addr() except it returns in the optional
+ * OUT parameter \p scratch_used whether or not \p scratch was written to.
+ */
+bool
+drutil_insert_get_mem_addr_ex(void *drcontext, instrlist_t *bb, instr_t *where,
+                              opnd_t memref, reg_id_t dst, reg_id_t scratch,
+                              OUT bool *scratch_used);
 
 DR_EXPORT
 /**


### PR DESCRIPTION
Adds drutil_insert_get_mem_addr_ex() which returns whether the passed-in
extra scratch register was used.  Adds a test.

Leverages the new function to avoid redundant loads in drcachesim.

Issue: #2001