### PR TITLE
i#2001 trace perf: do not store disp

### DIFF
--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -370,14 +370,17 @@ offline_instru_t::insert_save_addr(void *drcontext, instrlist_t *ilist, instr_t 
                                    reg_id_t reg_ptr, int adjust, opnd_t ref, bool write)
 {
     int disp = adjust;
-    reg_id_t reg_addr;
+    reg_id_t reg_addr = DR_REG_NULL;
     bool reserved = false;
     bool have_addr = false;
     drreg_status_t res;
+#ifdef X86
     if (opnd_is_near_base_disp(ref) && opnd_get_base(ref) != DR_REG_NULL &&
         opnd_get_index(ref) == DR_REG_NULL) {
         /* Optimization: to avoid needing a scratch reg to lea into, we simply
          * store the base reg directly and add the disp during post-processing.
+         * We only do this for x86 for now to avoid dealing with complexities of
+         * PC bases.
          */
         reg_addr = opnd_get_base(ref);
         if (opnd_get_base(ref) == reg_ptr) {
@@ -388,6 +391,7 @@ offline_instru_t::insert_save_addr(void *drcontext, instrlist_t *ilist, instr_t 
         } else
             have_addr = true;
     }
+#endif
     if (!have_addr) {
         res = drreg_reserve_register(drcontext, ilist, where, reg_vector, &reg_addr);
         DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -376,6 +376,10 @@ raw2trace_t::append_memref(INOUT trace_entry_t **buf_in, uint tidx, instr_t *ins
     }
     // We take the full value, to handle low or high.
     buf->addr = (addr_t) in_entry.combined_value;
+    if (opnd_is_near_base_disp(ref) && opnd_get_index(ref) == DR_REG_NULL) {
+        // We stored only the base reg, as an optimization.
+        buf->addr += opnd_get_disp(ref);
+    }
     VPRINT(4, "Appended memref type %d size %d to " PFX "\n", buf->type, buf->size,
            (ptr_uint_t)buf->addr);
     *buf_in = ++buf;
@@ -550,7 +554,7 @@ raw2trace_t::merge_and_process_thread_files()
     uint tidx = (uint)thread_files.size();
     uint thread_count = (uint)thread_files.size();
     offline_entry_t in_entry;
-    online_instru_t instru(NULL, false);
+    online_instru_t instru(NULL, false, NULL);
     bool last_bb_handled = true;
     std::vector<thread_id_t> tids(thread_files.size(), INVALID_THREAD_ID);
     std::vector<uint64> times(thread_files.size(), 0);

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -376,7 +376,8 @@ raw2trace_t::append_memref(INOUT trace_entry_t **buf_in, uint tidx, instr_t *ins
     }
     // We take the full value, to handle low or high.
     buf->addr = (addr_t) in_entry.combined_value;
-    if (opnd_is_near_base_disp(ref) && opnd_get_index(ref) == DR_REG_NULL) {
+    if (opnd_is_near_base_disp(ref) && opnd_get_base(ref) != DR_REG_NULL &&
+        opnd_get_index(ref) == DR_REG_NULL) {
         // We stored only the base reg, as an optimization.
         buf->addr += opnd_get_disp(ref);
     }

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -376,11 +376,13 @@ raw2trace_t::append_memref(INOUT trace_entry_t **buf_in, uint tidx, instr_t *ins
     }
     // We take the full value, to handle low or high.
     buf->addr = (addr_t) in_entry.combined_value;
+#ifdef X86
     if (opnd_is_near_base_disp(ref) && opnd_get_base(ref) != DR_REG_NULL &&
         opnd_get_index(ref) == DR_REG_NULL) {
         // We stored only the base reg, as an optimization.
         buf->addr += opnd_get_disp(ref);
     }
+#endif
     VPRINT(4, "Appended memref type %d size %d to " PFX "\n", buf->type, buf->size,
            (ptr_uint_t)buf->addr);
     *buf_in = ++buf;

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -594,8 +594,8 @@ instrument_clean_call(void *drcontext, instrlist_t *ilist, instr_t *where,
          * save aflags to a temp reg before check.
          * XXX optimization: use drreg to avoid aflags save/restore.
          */
-        if (drreg_reserve_register(drcontext, bb, where, reg_vector, &reg_tmp) !=
-            DRREG_SUCCESS)
+        if (drreg_reserve_register(drcontext, ilist, where, &scratch_reserve_vec,
+                                   &reg_tmp) != DRREG_SUCCESS)
             FATAL("Fatal error: failed to reserve reg.");
         dr_save_arith_flags_to_reg(drcontext, ilist, where, reg_tmp);
         MINSERT(ilist, where,
@@ -620,7 +620,7 @@ instrument_clean_call(void *drcontext, instrlist_t *ilist, instr_t *where,
     if (dr_get_isa_mode(drcontext) == DR_ISA_ARM_A32) {
         dr_restore_arith_flags_from_reg(drcontext, ilist, where, reg_tmp);
         DR_ASSERT(reg_tmp != DR_REG_NULL);
-        if (drreg_unreserve_register(drcontext, bb, where, reg_tmp) != DRREG_SUCCESS)
+        if (drreg_unreserve_register(drcontext, ilist, where, reg_tmp) != DRREG_SUCCESS)
             FATAL("Fatal error: failed to unreserve reg.\n");
     }
 #endif

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2017 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2018 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -210,7 +210,8 @@ restore_reg(void *drcontext, per_thread_t *pt, reg_id_t reg, uint slot,
 {
     LOG(drcontext, LOG_ALL, 3,
         "%s @%d."PFX" %s slot=%d release=%d\n", __FUNCTION__, pt->live_idx,
-        instr_get_app_pc(where), get_register_name(reg), slot, release);
+        where == NULL ? 0 : instr_get_app_pc(where),
+        get_register_name(reg), slot, release);
     ASSERT(pt->slot_use[slot] == reg ||
            /* aflags can be saved and restored using different regs */
            (slot == AFLAGS_SLOT && pt->slot_use[slot] != DR_REG_NULL),


### PR DESCRIPTION
For offline traces for a "disp(base)" memref, only stores the base and adds
the disp in raw2trace post-processing, as it's statically known.  The base
can be directly written as it's already in a register, reducing scratch
register pressure.

Moves the second scratch register reservation into the instru_t routines so
we can skip it for this optimization of just writing the base reg for
"disp(base)" memrefs.

Issue: #2001