### PR TITLE
i#2717 shrink static DR library: do not initialize dynamo_options sta…

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -853,10 +853,6 @@ standalone_init(void)
     standalone_library = true;
     /* We have release-build stats now so this is not just DEBUG */
     stats = &nonshared_stats;
-#if defined(INTERNAL) && defined(DEADLOCK_AVOIDANCE)
-    /* avoid issues w/ GLOBAL_DCONTEXT instead of thread dcontext */
-    dynamo_options.deadlock_avoidance = false;
-#endif
 #ifdef UNIX
     os_page_size_init((const char **)our_environ);
 #endif
@@ -867,6 +863,10 @@ standalone_init(void)
 #endif
     config_init();
     options_init();
+#if defined(INTERNAL) && defined(DEADLOCK_AVOIDANCE)
+    /* avoid issues w/ GLOBAL_DCONTEXT instead of thread dcontext */
+    dynamo_options.deadlock_avoidance = false;
+#endif
     vmm_heap_init();
     heap_init();
     dynamo_heap_initialized = true;
@@ -888,6 +888,7 @@ standalone_init(void)
 # ifdef DEBUG
     /* FIXME: share code w/ main init routine? */
     nonshared_stats.logmask = LOG_ALL;
+    /* Why do we need this to options_init()?  We did so above. */
     options_init();
     if (stats->loglevel > 0) {
         char initial_options[MAX_OPTIONS_STRING];

--- a/core/options.c
+++ b/core/options.c
@@ -209,9 +209,8 @@ char option_string[MAX_OPTIONS_STRING] = {0,};
 # define ASSERT_OWN_OPTIONS_LOCK(b, l) ASSERT_OWN_WRITE_LOCK(b, l)
 # define CORE_STATIC static
 /* official options */
-options_t dynamo_options = {
-# include "optionsx.h"
-};
+options_t dynamo_options;
+
 /* Temporary string, static to save stack space in synchronize_dynamic_options().
  * FIXME case 8074: should protect this better as w/o DR dll randomization attacker
  * can repeatedly try to clobber.  Move to heap?  Or shrink stack space elsewhere
@@ -2443,6 +2442,8 @@ options_init()
     /* .lspdata pages start out writable so no unprotect needed here */
     write_lock(&options_lock);
     ASSERT(sizeof(dynamo_options) == sizeof(options_t));
+    /* Set to default options. */
+    dynamo_options = default_options;
     /* get dynamo options */
     adjust_defaults_for_page_size(&dynamo_options);
     retval = get_parameter(PARAM_STR(DYNAMORIO_VAR_OPTIONS), option_string,


### PR DESCRIPTION
…tically.

We currently initialize dynamo_options at the time of declaration.  This
is not required since the initialization is same as default_options
variable.  Instead, we now copy the default_options to dynamo_options in
the function options_init().  This saves about 27,020 bytes of space.

Before:
-r-xr-xr-x 1 nilayvaish eng 2594134 Nov 24 23:37
blaze-bin/third_party/dynamorio/libdynamorio.a

After:
-r-xr-xr-x 1 nilayvaish eng 2567114 Nov 25 12:32
blaze-bin/third_party/dynamorio/libdynamorio.a

Issue: #2717