### PR TITLE
i#2800: fix drreg app vs tool ordering issue

### DIFF
--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -569,7 +569,12 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
                     spill_reg(drcontext, pt, reg, tmp_slot, bb, inst);
                 }
                 spill_reg(drcontext, pt, reg,
-                          pt->reg[GPR_IDX(reg)].slot, bb, next/*after*/);
+                          pt->reg[GPR_IDX(reg)].slot, bb,
+                          /* If reads and writes, make sure tool-restore and app-spill
+                           * are in the proper order.
+                           */
+                          restored_for_read[GPR_IDX(reg)] ? instr_get_prev(next) :
+                          next/*after*/);
                 pt->reg[GPR_IDX(reg)].ever_spilled = true;
                 if (!restored_for_read[GPR_IDX(reg)])
                     restore_reg(drcontext, pt, reg, tmp_slot, bb, next/*after*/, true);

--- a/suite/tests/client-interface/drreg-test.c
+++ b/suite/tests/client-interface/drreg-test.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -141,6 +141,11 @@ GLOBAL_LABEL(FUNCNAME:)
         mov      TEST_REG_ASM, DRREG_TEST_2_ASM
         mov      TEST_REG_ASM, DRREG_TEST_2_ASM
         mov      TEST_REG_ASM, REG_XSP
+        mov      PTRSZ [TEST_REG_ASM + 8], TEST_REG_ASM
+        mov      TEST_REG_ASM, PTRSZ [TEST_REG_ASM + 8]
+        /* Test accessing the reg again to ensure the app spill slot and tool value
+         * are handled in the proper order:
+         */
         mov      TEST_REG_ASM, PTRSZ [TEST_REG_ASM]
 
         jmp      test4

--- a/suite/tests/client-interface/drreg-test.c
+++ b/suite/tests/client-interface/drreg-test.c
@@ -141,8 +141,8 @@ GLOBAL_LABEL(FUNCNAME:)
         mov      TEST_REG_ASM, DRREG_TEST_2_ASM
         mov      TEST_REG_ASM, DRREG_TEST_2_ASM
         mov      TEST_REG_ASM, REG_XSP
-        mov      PTRSZ [TEST_REG_ASM + 8], TEST_REG_ASM
-        mov      TEST_REG_ASM, PTRSZ [TEST_REG_ASM + 8]
+        mov      PTRSZ [TEST_REG_ASM - 8], TEST_REG_ASM
+        mov      TEST_REG_ASM, PTRSZ [TEST_REG_ASM - 8]
         /* Test accessing the reg again to ensure the app spill slot and tool value
          * are handled in the proper order:
          */


### PR DESCRIPTION
Extends the drreg test's cross-app-instr case of the same instruction
writing and reading the reserved register to include the app accessing the
register afterward.

Fixes a drreg bug exposed by this test case where a tool has reserved a
register across an app instr that both reads and writes the register: drreg
was incorrectly restoring the tool value before writing out the new app
value.

Fixes #2800