### PR TITLE
i#2799: Make sure dstack_offs is 8-byte aligned on ARM.

### DIFF
--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -603,6 +603,9 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                                   DR_REG_LIST_LENGTH_ARM, DR_REG_LIST_ARM));
     }
     dstack_offs += 15 * XSP_SZ;
+
+    /* Make dstack_offs 8-byte algined, as we only accounted for 31 4-byte slots */
+    dstack_offs += XSP_SZ;
     ASSERT(cci->skip_save_flags    ||
            cci->num_simd_skip != 0 ||
            cci->num_regs_skip != 0 ||


### PR DESCRIPTION
2e9f20e made get_clean_call_switch_stack_size() 8-byte aligned for ARM,
which is required by the "Procedure Call Standard for the ARM Architecture
[AAPCS]" [1]. priv_mcontext_t on ARM only contains 31 8-byte slots,
which is why an extra adjustment is needed in insert_push_all_registers.

[1] http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka4127.html

Unfortunately I do not have access to AArch32 HW for a couple of days and cannot verify if that fixes the AArch32 problem for now.