### PR TITLE
Ensure correct variadic arguments are passed to (_snw)(f)printf

### DIFF
--- a/libutil/utils.c
+++ b/libutil/utils.c
@@ -378,7 +378,7 @@ reboot_system()
  *   and then checking error codes; but the problem there is that C:\\
  *   returns PATH_NOT_FOUND regardless. */
 bool
-file_exists(const TCHAR *fn)
+file_exists(const WCHAR *fn)
 {
 #ifdef WINDOWS
     WIN32_FIND_DATA fd;
@@ -393,7 +393,7 @@ file_exists(const TCHAR *fn)
         /* special handling for e.g. C:\\ */
         if (LAST_WCHAR(fn) == L'\\' || LAST_WCHAR(fn) == L':') {
             WCHAR buf[MAX_PATH];
-            _snwprintf(buf, MAX_PATH, L"%S%S*",
+            _snwprintf(buf, MAX_PATH, L"%s%s*",
                        fn, LAST_WCHAR(fn) == L'\\' ? L"" : L"\\");
             NULL_TERMINATE_BUFFER(buf);
             search = FindFirstFile(buf, &fd);

--- a/libutil/utils.h
+++ b/libutil/utils.h
@@ -62,7 +62,7 @@ const TCHAR *
 get_dynamorio_logdir(void);
 
 bool
-file_exists(const TCHAR *fn);
+file_exists(const WCHAR *fn);
 
 void
 set_dr_platform(dr_platform_t platform);


### PR DESCRIPTION
_snwprintf requires the use of %s when passing a wchar* type as variadic argument. %S should be used for for char* arguments. note: for method _snprintf it is the other way around.
Function file_exists can only handle a WCHAR * fn parameter (calls LAST_WCHAR at line 394)
file_exists(const TCHAR *fn) prototype changed to file_exists(const WCHAR *fn) as TCHAR gives the impression that it can be a char* or a wchar_t*.

Printf format specifier %08x expects an unsigned int and not a pointer.
Printf format specified %p expects a void pointer and not an unsigned int.

Note: alternative solution for %08x, would be to use %p as format specifier, which has the benefit of being more compatible with 64bit code.