### PR TITLE
i#2805: use trylock to avoid hang

### DIFF
--- a/core/synch.h
+++ b/core/synch.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -146,6 +146,9 @@ synch_thread_exit(dcontext_t *dcontext);
 bool
 thread_synch_state_no_xfer(dcontext_t *dcontext);
 
+/* We support calling this from a signal handler that might have interrupted DR
+ * holding arbitrary locks.
+ */
 bool
 thread_synch_check_state(dcontext_t *dcontext, thread_synch_permission_t desired_perm);
 

--- a/core/utils.h
+++ b/core/utils.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -754,6 +754,11 @@ mutex_testlock(mutex_t *lock)
     return lock->lock_requests > LOCK_FREE_STATE;
 }
 
+static inline bool
+spinmutex_testlock(spin_mutex_t *spin_lock)
+{
+    return mutex_testlock(&spin_lock->lock);
+}
 
 /* A recursive lock can be taken more than once by the owning thread */
 void acquire_recursive_lock(recursive_lock_t *lock);


### PR DESCRIPTION
Adds missing synchronization on reads of tsd->synch_perm in
thread_synch_state_no_xfer() and thread_synch_check_state(), using a
trylock to avoid hanging on a suspended thread that holds tsd->synch_lock.
On trylock failure, both routines fail, which then prevents unsafe signal
delivery.

TODO: try to create a test that reproduces the hang: it will not be easy
and if it's not reliable it's not clear how much effort to put into it...

Fixes #2805