### PR TITLE
i#2805 synch lock hang: fix Mac test build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no EXTRA_ARGS=32_only
       # XXX i#2764: Travis OSX resources are over-subscribed and it can take
       # hours to get an OSX machine, so we skip running PR's for now.
-      if: type = push
+#TEMPORARY      if: type = push
 
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no EXTRA_ARGS=32_only
       # XXX i#2764: Travis OSX resources are over-subscribed and it can take
       # hours to get an OSX machine, so we skip running PR's for now.
-#TEMPORARY      if: type = push
+      if: type = push
 
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:

--- a/suite/tests/client-interface/timer.dll.c
+++ b/suite/tests/client-interface/timer.dll.c
@@ -34,7 +34,11 @@
 #include "dr_api.h"
 #ifdef UNIX
 # include <sys/time.h>
-# include <syscall.h>
+# ifdef MACOS
+#  include <sys/syscall.h>
+# else
+#  include <syscall.h>
+# endif
 #else
 # error NYI
 #endif


### PR DESCRIPTION
Fixes a Mac build issue in the new client.timer test code.

Issue: #2805