### PR TITLE
Fix includes for histogram.h and reuse_distance.h

### DIFF
--- a/clients/drcachesim/tools/histogram.h
+++ b/clients/drcachesim/tools/histogram.h
@@ -38,8 +38,8 @@
 
 #include <unordered_map>
 #include <string>
-#include "../analysis_tool.h"
-#include "../common/memref.h"
+#include "analysis_tool.h"
+#include "memref.h"
 
 class histogram_t : public analysis_tool_t
 {

--- a/clients/drcachesim/tools/reuse_distance.h
+++ b/clients/drcachesim/tools/reuse_distance.h
@@ -40,8 +40,8 @@
 #include <string>
 #include <assert.h>
 #include <iostream>
-#include "../analysis_tool.h"
-#include "../common/memref.h"
+#include "analysis_tool.h"
+#include "memref.h"
 
 // We see noticeable overhead in release build with an if() that directly
 // checks knob_verbose, so for debug-only uses we turn it into something the


### PR DESCRIPTION
Remove relative paths for includes in histogram.h and reuse_distance.h. 