### PR TITLE
i#1958 gcc 6: fix test build issues

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2018 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # Copyright (c) 2016      ARM Limited.    All rights reserved.
 # **********************************************************
@@ -3099,7 +3099,9 @@ if (UNIX)
       # The default value of CMAKE_SHARED_LIBRARY_LINK_C_FLAGS has -rdynamic,
       # which doesn't play well with clang and -static.  Adding
       # --no-export-dynamic avoids the problem.
-      "-static -Wl,--no-export-dynamic")
+      # We get two copies of memcpy (from drhelper and from libc) so we avoid
+      # linker warnings on gcc 6.x+ (i#1958).
+      "-static -Wl,--no-export-dynamic -Wl,--allow-multiple-definition")
   endif ()
   # Test position independent executables.
   # FIXME i#1001: fib-pie fails with -early_inject.

--- a/suite/tests/client-interface/drmgr-test.c
+++ b/suite/tests/client-interface/drmgr-test.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -32,7 +32,6 @@
 
 #include "tools.h"
 
-static char table[2] = {'A', 'B'};
 #ifdef WINDOWS
 /* based on suite/tests/win32/callback.c */
 
@@ -283,12 +282,13 @@ main(int argc, char **argv)
 {
     pthread_t thread0, thread1;
     void * retval;
+    char table[2] = {'A', 'B'};
 #ifdef X86
     char ch;
     /* test xlat for drutil_insert_get_mem_addr,
      * we do not bother to run this test on Windows side.
      */
-    __asm("mov %1, %%ebx\n\t"
+    __asm("mov %1, %%" IF_X64_ELSE("rbx","ebx") "\n\t"
           "mov $0x1, %%eax\n\t"
           "xlat\n\t"
           "movb %%al, %0\n\t"

--- a/suite/tests/client-interface/signal.c
+++ b/suite/tests/client-interface/signal.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -47,7 +47,6 @@
 #include <setjmp.h>
 
 static SIGJMP_BUF mark;
-static int bar;
 
 static void
 #ifdef UNIX
@@ -93,6 +92,7 @@ unintercept_signal(int sig)
 int
 main(int argc, char** argv)
 {
+    int bar;
     intercept_signal(SIGUSR1, signal_handler, false);
     intercept_signal(SIGUSR2, signal_handler, false);
     intercept_signal(SIGURG, signal_handler, false);

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -413,9 +413,15 @@ DECL_EXTERN(_setjmp3)
 # endif
 #else
 DECL_EXTERN(my_setjmp)
-# define CALL_SETJMP \
+# ifdef X64
+#  define CALL_SETJMP \
+        lea   REG_XAX, SYMREF(mark) @N@ \
+        CALLC1(my_setjmp, REG_XAX)
+# else
+#  define CALL_SETJMP \
         lea   REG_XAX, mark @N@\
         CALLC1(my_setjmp, REG_XAX)
+# endif
 #endif
 
 /* FIXME PR 271834: we need some far ctis that actually succeed, to fully test

--- a/suite/tests/security-common/selfmod-big.c
+++ b/suite/tests/security-common/selfmod-big.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -108,7 +108,11 @@ ADDRTAKEN_LABEL(foo_start:)
         /* now we have as many write instrs as necessary to cause a too-big
          * selfmod fragment.  xref case 7893.
          */
+#if defined(LINUX) && defined(X64)
+        lea      REG_XDX, SYMREF(big) /* rip-relative on x64 */
+#else
         mov      REG_XDX, offset GLOBAL_REF(big)
+#endif
         mov      DWORD [REG_XDX + 0], ecx
         mov      DWORD [REG_XDX + 1], ecx
         mov      DWORD [REG_XDX + 2], ecx


### PR DESCRIPTION
Fixes problems building several tests with gcc 6.x:
+ Avoids relocations for assembly code in client.drmgr-test,
  client.drutil-test, client.signal, common.decode, and
  security-common.selfmod-big
+ Suppresses memcpy warnings in linux.fib-static

Issue: #1958