### PR TITLE
i#2439 L0 filter: support i-only and d-only

### DIFF
--- a/clients/drcachesim/common/memref.h
+++ b/clients/drcachesim/common/memref.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -105,12 +105,14 @@ struct _memref_marker_t {
  * Each entry identifies the originating process and thread.
  * Although the pc of each data reference is provided, the trace also guarantees that
  * an instruction entry immediately precedes the data references that it is
- * responsible for, with no intervening trace entries.
+ * responsible for, with no intervening trace entries (unless it is a trace filtered
+ * with an online first-level cache).
  * Offline traces further guarantee that an instruction entry for a branch
  * instruction is always followed by an instruction entry for the branch's
  * target (with any memory references for the branch in between of course)
  * without a thread switch intervening, to make it simpler to identify branch
- * targets.  Online traces do not currently guarantee this.
+ * targets (again, unless the trace is filtered by an online first-level cache).
+ * Online traces do not currently guarantee this.
  */
 typedef union _memref_t {
     // The C standard allows us to reference the type field of any of these, and the

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -123,13 +123,15 @@ droption_t<bytesize_t> op_L0I_size
 (DROPTION_SCOPE_CLIENT, "L0I_size", 32*1024U,
  "If -L0_filter, filter out instruction hits during tracing",
  "Specifies the size of the 'zero-level' instruction cache for -L0_filter.  "
- "Must be a power of 2 and a multiple of -line_size.");
+ "Must be a power of 2 and a multiple of -line_size, unless it is set to 0, "
+ "which disables instruction fetch entries from appearing in the trace.");
 
 droption_t<bytesize_t> op_L0D_size
 (DROPTION_SCOPE_CLIENT, "L0D_size", 32*1024U,
  "If -L0_filter, filter out data hits during tracing",
  "Specifies the size of the 'zero-level' data cache for -L0_filter.  "
- "Must be a power of 2 and a multiple of -line_size.");
+ "Must be a power of 2 and a multiple of -line_size, unless it is set to 0, "
+ "which disables data entries from appearing in the trace.");
 
 droption_t<bool> op_use_physical
 (DROPTION_SCOPE_CLIENT, "use_physical", false, "Use physical addresses if possible",

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -494,7 +494,10 @@ http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=ab676b
 \section sec_drcachesim_core Core Simulation Support
 
 The \p drcachesim trace format includes information intended for use by
-core simulators as well as pure cache simulators.  On x86, string loop
+core simulators as well as pure cache simulators.  For traces that are not
+filtered by an online first-level cache, each data reference is preceded by
+the instruction fetch entry for the instruction that issued the data
+request.  Additionally, on x86, string loop
 instructions involve a single insruction fetch followed by a loop of loads
 and/or stores.  A \p drcachesim trace includes a special "no-fetch"
 instruction entry per iteration so that core simulators have the

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -118,7 +118,6 @@ reader_t::operator++()
         case TRACE_TYPE_INSTR_RETURN:
         case TRACE_TYPE_INSTR_SYSENTER:
         case TRACE_TYPE_INSTR_NO_FETCH:
-            have_memref = true;
             assert(cur_tid != 0 && cur_pid != 0);
             if (input_entry->size == 0) {
                 // Just an entry to tell us the PC of the subsequent memref,

--- a/clients/drcachesim/tests/filter-no-d.templatex
+++ b/clients/drcachesim/tests/filter-no-d.templatex
@@ -1,0 +1,20 @@
+Hello, world!
+---- <application exited with code 0> ----
+Cache simulation results:
+Core #0 \(1 thread\(s\)\)
+  L1I stats:
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*.
+.*   Miss rate:                   *[1-9][0-9][,\.]..%
+  L1D stats:
+    Hits:                                0
+    Misses:                              0
+Core #1 \(0 thread\(s\)\)
+Core #2 \(0 thread\(s\)\)
+Core #3 \(0 thread\(s\)\)
+LL stats:
+    Hits:                         *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*..
+.*   Local miss rate:             *[1-9][0-9][,\.]..%
+    Child hits:                   *[0-9,\.]*.
+    Total miss rate:              *[1-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/filter-no-i.templatex
+++ b/clients/drcachesim/tests/filter-no-i.templatex
@@ -1,0 +1,20 @@
+Hello, world!
+---- <application exited with code 0> ----
+Cache simulation results:
+Core #0 \(1 thread\(s\)\)
+  L1I stats:
+    Hits:                                0
+    Misses:                              0
+  L1D stats:
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*.
+.*   Miss rate:                   *[1-9][0-9][,\.]..%
+Core #1 \(0 thread\(s\)\)
+Core #2 \(0 thread\(s\)\)
+Core #3 \(0 thread\(s\)\)
+LL stats:
+    Hits:                         *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*..
+.*   Local miss rate:             *[1-9][0-9][,\.]..%
+    Child hits:                   *[0-9,\.]*.
+    Total miss rate:              *[1-9][0-9][,\.]..%

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -500,8 +500,8 @@ offline_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
     drreg_status_t res =
         drreg_reserve_register(drcontext, ilist, where, reg_vector, &reg_tmp);
     DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
-    adjust += insert_save_pc(drcontext, ilist, where, reg_ptr, reg_tmp, adjust,
-                           pc, memref_needs_full_info ? 1 : (uint)(ptr_uint_t)*bb_field);
+    adjust += insert_save_pc(drcontext, ilist, where, reg_ptr, reg_tmp, adjust, pc,
+                             memref_needs_full_info ? 1 : (uint)(ptr_uint_t)*bb_field);
     if (!memref_needs_full_info)
         *(ptr_uint_t*)bb_field = MAX_INSTR_COUNT + 1;
     res = drreg_unreserve_register(drcontext, ilist, where, reg_tmp);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2444,6 +2444,8 @@ if (CLIENT_INTERFACE)
       endif ()
 
       torunonly_drcachesim(filter-simple ${ci_shared_app} "-L0_filter" "")
+      torunonly_drcachesim(filter-no-i ${ci_shared_app} "-L0_filter -L0I_size 0" "")
+      torunonly_drcachesim(filter-no-d ${ci_shared_app} "-L0_filter -L0D_size 0" "")
 
       torunonly_drcachesim(delay-simple ${ci_shared_app}
         "-trace_after_instrs 50000 -exit_after_tracing 10000" "")


### PR DESCRIPTION
Adds support for instruction-only and data-only filtered traces when the
-L0I_size or L0D_size is set to 0.

Fixes a bug in the reader when reading filtered traces with no instructions.

Clarifies that the guarantee about always having a data trace entry
preceded by an insruction entry for the instruction that issued the data
request does not apply to filtered traces.

Adds tests for "-L0I_size 0" and "-L0D_size 0".

Issue: #2439