### PR TITLE
iX: Save caching_device_stats counters on reset

### DIFF
--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -126,8 +126,11 @@ cache_simulator_t::cache_simulator_t(unsigned int num_cores,
         return;
     }
 
+    bool warmup_enabled = ((warmup_refs > 0) || (warmup_fraction > 0.0));
+
     if (!llcache->init(knob_LL_assoc, (int)knob_line_size,
-                       (int)knob_LL_size, NULL, new cache_stats_t(knob_LL_miss_file))) {
+                       (int)knob_LL_size, NULL,
+                       new cache_stats_t(knob_LL_miss_file, warmup_enabled))) {
         ERRMSG("Usage error: failed to initialize LL cache.  Ensure sizes and "
                "associativity are powers of 2, that the total size is a multiple "
                "of the line size, and that any miss file path is writable.\n");
@@ -150,9 +153,11 @@ cache_simulator_t::cache_simulator_t(unsigned int num_cores,
         }
 
         if (!icaches[i]->init(knob_L1I_assoc, (int)knob_line_size,
-                              (int)knob_L1I_size, llcache, new cache_stats_t) ||
+                              (int)knob_L1I_size, llcache,
+                              new cache_stats_t("", warmup_enabled)) ||
             !dcaches[i]->init(knob_L1D_assoc, (int)knob_line_size,
-                              (int)knob_L1D_size, llcache, new cache_stats_t,
+                              (int)knob_L1D_size, llcache,
+                              new cache_stats_t("", warmup_enabled),
                               data_prefetcher == PREFETCH_POLICY_NEXTLINE ?
                               new prefetcher_t((int)knob_line_size) : nullptr)) {
             ERRMSG("Usage error: failed to initialize L1 caches.  Ensure sizes and "

--- a/clients/drcachesim/simulator/cache_stats.cpp
+++ b/clients/drcachesim/simulator/cache_stats.cpp
@@ -34,8 +34,8 @@
 #include <iomanip>
 #include "cache_stats.h"
 
-cache_stats_t::cache_stats_t(const std::string &miss_file) :
-    caching_device_stats_t(miss_file),
+cache_stats_t::cache_stats_t(const std::string &miss_file, bool warmup_enabled) :
+    caching_device_stats_t(miss_file, warmup_enabled),
     num_flushes(0), num_prefetch_hits(0), num_prefetch_misses(0)
 {
 }

--- a/clients/drcachesim/simulator/cache_stats.h
+++ b/clients/drcachesim/simulator/cache_stats.h
@@ -42,7 +42,8 @@
 class cache_stats_t : public caching_device_stats_t
 {
  public:
-    explicit cache_stats_t(const std::string &miss_file = "");
+    explicit cache_stats_t(const std::string &miss_file = "",
+                           bool warmup_enabled = false);
 
     // In addition to caching_device_stats_t::access,
     // cache_stats_t::access processes prefetching requests.

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -35,7 +35,8 @@
 #include <iomanip>
 #include "caching_device_stats.h"
 
-caching_device_stats_t::caching_device_stats_t(const std::string &miss_file, bool warmup_enabled) :
+caching_device_stats_t::caching_device_stats_t(const std::string &miss_file,
+                                               bool warmup_enabled) :
     success(true), num_hits(0), num_misses(0), num_child_hits(0),
     num_hits_at_reset(0), num_misses_at_reset(0), num_child_hits_at_reset(0),
     warmup_enabled(warmup_enabled), file(nullptr)

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -36,7 +36,8 @@
 #include "caching_device_stats.h"
 
 caching_device_stats_t::caching_device_stats_t(const std::string &miss_file) :
-    success(true), num_hits(0), num_misses(0), num_child_hits(0), file(nullptr)
+    success(true), num_hits(0), num_misses(0), num_child_hits(0), file(nullptr),
+    num_hits_at_reset(0), num_misses_at_reset(0), num_child_hits_at_reset(0)
 {
     if (miss_file.empty()) {
         dump_misses = false;
@@ -155,6 +156,9 @@ caching_device_stats_t::print_stats(std::string prefix)
 void
 caching_device_stats_t::reset()
 {
+    num_hits_at_reset = num_hits;
+    num_misses_at_reset = num_misses;
+    num_child_hits_at_reset = num_child_hits;
     num_hits = 0;
     num_misses = 0;
     num_child_hits = 0;

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -36,8 +36,9 @@
 #include "caching_device_stats.h"
 
 caching_device_stats_t::caching_device_stats_t(const std::string &miss_file) :
-    success(true), num_hits(0), num_misses(0), num_child_hits(0), file(nullptr),
-    num_hits_at_reset(0), num_misses_at_reset(0), num_child_hits_at_reset(0)
+    success(true), num_hits(0), num_misses(0), num_child_hits(0),
+    num_hits_at_reset(0), num_misses_at_reset(0), num_child_hits_at_reset(0),
+    file(nullptr)
 {
     if (miss_file.empty()) {
         dump_misses = false;
@@ -109,6 +110,15 @@ caching_device_stats_t::dump_miss(const memref_t &memref)
 }
 
 void
+caching_device_stats_t::print_warmup(std::string prefix)
+{
+    std::cerr << prefix << std::setw(18) << std::left << "Warmup Hits:" <<
+        std::setw(20) << std::right << num_hits_at_reset << std::endl;
+    std::cerr << prefix << std::setw(18) << std::left << "Warmup Misses:" <<
+        std::setw(20) << std::right << num_misses_at_reset << std::endl;
+}
+
+void
 caching_device_stats_t::print_counts(std::string prefix)
 {
     std::cerr << prefix << std::setw(18) << std::left << "Hits:" <<
@@ -147,6 +157,7 @@ void
 caching_device_stats_t::print_stats(std::string prefix)
 {
     std::cerr.imbue(std::locale("")); // Add commas, at least for my locale
+    print_warmup(prefix);
     print_counts(prefix);
     print_rates(prefix);
     print_child_stats(prefix);

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -35,10 +35,10 @@
 #include <iomanip>
 #include "caching_device_stats.h"
 
-caching_device_stats_t::caching_device_stats_t(const std::string &miss_file) :
+caching_device_stats_t::caching_device_stats_t(const std::string &miss_file, bool warmup_enabled) :
     success(true), num_hits(0), num_misses(0), num_child_hits(0),
     num_hits_at_reset(0), num_misses_at_reset(0), num_child_hits_at_reset(0),
-    file(nullptr)
+    warmup_enabled(warmup_enabled), file(nullptr)
 {
     if (miss_file.empty()) {
         dump_misses = false;
@@ -112,9 +112,9 @@ caching_device_stats_t::dump_miss(const memref_t &memref)
 void
 caching_device_stats_t::print_warmup(std::string prefix)
 {
-    std::cerr << prefix << std::setw(18) << std::left << "Warmup Hits:" <<
+    std::cerr << prefix << std::setw(18) << std::left << "Warmup hits:" <<
         std::setw(20) << std::right << num_hits_at_reset << std::endl;
-    std::cerr << prefix << std::setw(18) << std::left << "Warmup Misses:" <<
+    std::cerr << prefix << std::setw(18) << std::left << "Warmup misses:" <<
         std::setw(20) << std::right << num_misses_at_reset << std::endl;
 }
 
@@ -157,7 +157,9 @@ void
 caching_device_stats_t::print_stats(std::string prefix)
 {
     std::cerr.imbue(std::locale("")); // Add commas, at least for my locale
-    print_warmup(prefix);
+    if (warmup_enabled) {
+        print_warmup(prefix);
+    }
     print_counts(prefix);
     print_rates(prefix);
     print_child_stats(prefix);

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -77,6 +77,12 @@ class caching_device_stats_t
     int_least64_t num_misses;
     int_least64_t num_child_hits;
 
+    // Stats saved when the last reset was called. This helps us get insight
+    // into what the stats were when the cache was warmed up.
+    int_least64_t num_misses_at_reset;
+    int_least64_t num_hits_at_reset;
+    int_least64_t num_child_hits_at_reset;
+
     // We provide a feature of dumping misses to a file.
     bool dump_misses;
 #ifdef HAS_ZLIB

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -67,6 +67,7 @@ class caching_device_stats_t
     bool success;
 
     // print different groups of information, beneficial for code reuse
+    virtual void print_warmup(std::string prefix);
     virtual void print_counts(std::string prefix); // hit/miss numbers
     virtual void print_rates(std::string prefix); // hit/miss rates
     virtual void print_child_stats(std::string prefix); // child/total info
@@ -79,8 +80,8 @@ class caching_device_stats_t
 
     // Stats saved when the last reset was called. This helps us get insight
     // into what the stats were when the cache was warmed up.
-    int_least64_t num_misses_at_reset;
     int_least64_t num_hits_at_reset;
+    int_least64_t num_misses_at_reset;
     int_least64_t num_child_hits_at_reset;
 
     // We provide a feature of dumping misses to a file.

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -46,7 +46,8 @@
 class caching_device_stats_t
 {
  public:
-    explicit caching_device_stats_t(const std::string &miss_file);
+    explicit caching_device_stats_t(const std::string &miss_file,
+                                    bool warmup_enabled = false);
     virtual ~caching_device_stats_t();
 
     // Called on each access.
@@ -83,6 +84,8 @@ class caching_device_stats_t
     int_least64_t num_hits_at_reset;
     int_least64_t num_misses_at_reset;
     int_least64_t num_child_hits_at_reset;
+    // Enabled if options warmup_refs > 0 || warmup_fraction > 0
+    bool warmup_enabled;
 
     // We provide a feature of dumping misses to a file.
     bool dump_misses;

--- a/clients/drcachesim/tests/warmup-valid.templatex
+++ b/clients/drcachesim/tests/warmup-valid.templatex
@@ -1,0 +1,27 @@
+Hello, world!
+---- <application exited with code 0> ----
+Cache simulation results:
+Core #0 \(1 thread\(s\)\)
+  L1I stats:
+    Warmup hits:                  *[0-9,\.]*..
+    Warmup misses:                *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*....
+    Misses:                       *[0-9,\.]*..
+.*    Miss rate:                        [0-1][,\.]..%
+  L1D stats:
+    Warmup hits:                  *[0-9,\.]*..
+    Warmup misses:                *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*....
+    Misses:                       *[0-9,\.]*...
+.*   Miss rate:                        [0-9][,\.]..%
+Core #1 \(0 thread\(s\)\)
+Core #2 \(0 thread\(s\)\)
+Core #3 \(0 thread\(s\)\)
+LL stats:
+    Warmup hits:                  *[0-9,\.]*..
+    Warmup misses:                *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*..
+    Misses:                       *[0-9,\.]*...
+.*   Local miss rate:                 [0-9].[,\.]..%
+    Child hits:                   *[0-9,\.]*.....
+    Total miss rate:                  [0-3][,\.]..%

--- a/clients/drcachesim/tests/warmup-zeros.templatex
+++ b/clients/drcachesim/tests/warmup-zeros.templatex
@@ -1,0 +1,27 @@
+Hello, world!
+---- <application exited with code 0> ----
+Cache simulation results:
+Core #0 \(1 thread\(s\)\)
+  L1I stats:
+    Warmup hits:                  *[0-9,\.]*..
+    Warmup misses:                *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*....
+    Misses:                       *[0-9,\.]*..
+.*    Miss rate:                        [0-1][,\.]..%
+  L1D stats:
+    Warmup hits:                  *[0-9,\.]*..
+    Warmup misses:                *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*....
+    Misses:                       *[0-9,\.]*...
+.*   Miss rate:                        [0-9][,\.]..%
+Core #1 \(0 thread\(s\)\)
+Core #2 \(0 thread\(s\)\)
+Core #3 \(0 thread\(s\)\)
+LL stats:
+    Warmup hits:                  *[0]*..
+    Warmup misses:                *[0]*..
+    Hits:                         *[0-9,\.]*..
+    Misses:                       *[0-9,\.]*...
+.*   Local miss rate:                 [0-9].[,\.]..%
+    Child hits:                   *[0-9,\.]*.....
+    Total miss rate:                  [0-3][,\.]..%

--- a/clients/drcachesim/tests/warmup-zeros.templatex
+++ b/clients/drcachesim/tests/warmup-zeros.templatex
@@ -3,14 +3,14 @@ Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Warmup hits:                  *[0-9,\.]*..
-    Warmup misses:                *[0-9,\.]*..
+    Warmup hits:                  *[0]*..
+    Warmup misses:                *[0]*..
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*..
 .*    Miss rate:                        [0-1][,\.]..%
   L1D stats:
-    Warmup hits:                  *[0-9,\.]*..
-    Warmup misses:                *[0-9,\.]*..
+    Warmup hits:                  *[0]*..
+    Warmup misses:                *[0]*..
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*...
 .*   Miss rate:                        [0-9][,\.]..%

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2450,6 +2450,12 @@ if (CLIENT_INTERFACE)
       torunonly_drcachesim(delay-simple ${ci_shared_app}
         "-trace_after_instrs 50000 -exit_after_tracing 10000" "")
 
+      # Test that "Warmup hits" and "Warmup misses" are printed out
+      torunonly_drcachesim(warmup-valid ${ci_shared_app} "-warmup_refs 1" "")
+
+      # Test that warmup was enabled but not triggered.
+      torunonly_drcachesim(warmup-zeros ${ci_shared_app} "-warmup_refs 1000000000" "")
+
       # FIXME i#1799: clang does not support "asm goto" used in annotation
       # FIXME i#1551, i#1569: get working on ARM/AArch64
       if (NOT ARM AND NOT AARCH64 AND NOT CMAKE_COMPILER_IS_CLANG)


### PR DESCRIPTION
When reset is called on caching_device_t, save the current values of num_hits, num_misses and num_child_hits before setting them to zero. Saving the last value on reset can help determine how long (number of misses) it took for the cache to be warm. This is particularly useful when determining cache warmup by fraction loaded rather than number of accesses.