### PR TITLE
i#2812 sigaction: support disabled vsyscall32

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -278,9 +278,7 @@ sigaction_syscall(int sig, kernel_sigaction_t *act, kernel_sigaction_t *oact)
 {
 #if !defined(VMX86_SERVER) && defined(LINUX)
     /* PR 305020: must have SA_RESTORER for x64 */
-    /* Must have SA_RESTORER to handle vsyscall32 being disabled
-       (see https://github.com/DynamoRIO/dynamorio/issues/2812)
-    */
+    /* i#2812: must have SA_RESTORER to handle vsyscall32 being disabled */
     if (act != NULL && !TEST(SA_RESTORER, act->flags)) {
         act->flags |= SA_RESTORER;
         act->restorer = (void (*)(void)) dynamorio_sigreturn;
@@ -1317,9 +1315,7 @@ set_handler_sigact(kernel_sigaction_t *act, int sig, handler_t handler)
 
 #if !defined(VMX86_SERVER) && defined(LINUX)
     /* PR 305020: must have SA_RESTORER for x64 */
-    /* Must have SA_RESTORER to handle vsyscall32 being disabled
-       (see https://github.com/DynamoRIO/dynamorio/issues/2812)
-    */
+    /* i#2812: must have SA_RESTORER to handle vsyscall32 being disabled */
     act->flags |= SA_RESTORER;
     act->restorer = (void (*)(void)) dynamorio_sigreturn;
 #endif

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -276,8 +276,11 @@ is_sys_kill(dcontext_t *dcontext, byte *pc, byte *xsp, siginfo_t *info);
 int
 sigaction_syscall(int sig, kernel_sigaction_t *act, kernel_sigaction_t *oact)
 {
-#if defined(X64) && !defined(VMX86_SERVER) && defined(LINUX)
+#if !defined(VMX86_SERVER) && defined(LINUX)
     /* PR 305020: must have SA_RESTORER for x64 */
+    /* Must have SA_RESTORER to handle vsyscall32 being disabled
+       (see https://github.com/DynamoRIO/dynamorio/issues/2812)
+    */
     if (act != NULL && !TEST(SA_RESTORER, act->flags)) {
         act->flags |= SA_RESTORER;
         act->restorer = (void (*)(void)) dynamorio_sigreturn;
@@ -1312,8 +1315,11 @@ set_handler_sigact(kernel_sigaction_t *act, int sig, handler_t handler)
      */
     act->flags |= SA_RESTART;
 
-#if defined(X64) && !defined(VMX86_SERVER) && defined(LINUX)
+#if !defined(VMX86_SERVER) && defined(LINUX)
     /* PR 305020: must have SA_RESTORER for x64 */
+    /* Must have SA_RESTORER to handle vsyscall32 being disabled
+       (see https://github.com/DynamoRIO/dynamorio/issues/2812)
+    */
     act->flags |= SA_RESTORER;
     act->restorer = (void (*)(void)) dynamorio_sigreturn;
 #endif


### PR DESCRIPTION
This ensures that SA_RESTORER is passed to sigaction on 32-bit builds. A signal
restorer is required when vsyscall32 is disabled, which removes the default
signal restorer stub included in the vdso. Therefore, the application cannot
rely on the existence of a default signal handler, and provides one by setting
the SA_RESTORER flag.

Issue: #2812