### PR TITLE
Expose a dr_vfprintf

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -227,6 +227,7 @@ Further non-compatibility-affecting changes include:
  - Added hashtable_apply_to_all_payloads() to iterate over all payloads in a
    hashtable.
  - Added drutil_insert_get_mem_addr_ex().
+ - Added dr_vfprintf().
 
 **************************************************
 <hr>

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -4547,11 +4547,9 @@ dr_printf(const char *fmt, ...)
 }
 
 DR_API ssize_t
-dr_fprintf(file_t f, const char *fmt, ...)
+dr_vfprintf(file_t f, const char *fmt, va_list ap)
 {
     ssize_t written;
-    va_list ap;
-    va_start(ap, fmt);
 #ifdef WINDOWS
     if ((f == STDOUT || f == STDERR) && print_to_console) {
         written = dr_write_to_console(f == STDOUT, fmt, ap);
@@ -4560,8 +4558,18 @@ dr_fprintf(file_t f, const char *fmt, ...)
     } else
 #endif
         written = do_file_write(f, fmt, ap);
-    va_end(ap);
     return written;
+}
+
+DR_API ssize_t
+dr_fprintf(file_t f, const char *fmt, ...)
+{
+    va_list ap;
+    ssize_t res;
+    va_start(ap, fmt);
+    res = dr_vfprintf(f, fmt, ap);
+    va_end(ap);
+    return res;
 }
 
 DR_API int

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -4149,6 +4149,13 @@ DR_API
 ssize_t
 dr_fprintf(file_t f, const char *fmt, ...);
 
+DR_API
+/**
+ * Identical to dr_fprintf() but exposes va_list.
+ */
+ssize_t
+dr_vfprintf(file_t f, const char *fmt, va_list ap);
+
 #ifdef WINDOWS
 DR_API
 /**

--- a/suite/tests/client-interface/file_io.expect
+++ b/suite/tests/client-interface/file_io.expect
@@ -10,6 +10,7 @@ read_only_buf is r
 dr_safe_read() check
 DR_TRY_EXCEPT check
 dr_safe_write() check
+vfprintf check: 1234
 file separation check
 float i/o test: 3.1416
 done


### PR DESCRIPTION
Adds a dr_vfprintf function (a slight modification of the existing dr_fprintf). This is necessary for defining printf-like functions that wrap dr_fprintf.