### PR TITLE
Passing User Data to Generic Events.

### DIFF
--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -748,6 +748,14 @@ drmgr_register_thread_init_event(void (*func)(void *drcontext));
 
 DR_EXPORT
 /**
+ * TODO
+ */
+bool
+drmgr_register_thread_init_event_with_user_data(void (*func)(void *drcontext,
+		void *user_data), void *user_data);
+
+DR_EXPORT
+/**
  * Registers a callback function for the thread initialization event,
  * ordered by \p priority. drmgr calls \p func whenever the application
  * creates a new thread. \return whether successful.
@@ -758,12 +766,27 @@ drmgr_register_thread_init_event_ex(void (*func)(void *drcontext),
 
 DR_EXPORT
 /**
+ * TODO
+ */
+bool
+drmgr_register_thread_init_event_ex_with_user_data(void (*func)(void *drcontext, void *user_data),
+		                                           void *user_data, drmgr_priority_t *priority);
+
+DR_EXPORT
+/**
  * Unregister a callback function for the thread initialization event.
  * \return true if unregistration is successful and false if it is not
  * (e.g., \p func was not registered).
  */
 bool
 drmgr_unregister_thread_init_event(void (*func)(void *drcontext));
+
+DR_EXPORT
+/**
+ * TODO
+ */
+bool
+drmgr_unregister_thread_init_event_with_user(void (*func)(void *drcontext, void *user_data));
 
 DR_EXPORT
 /**


### PR DESCRIPTION
This PR is more to show the intended functionality rather than an official request to merge. Code needs to be refactored, but for now I am asking for feedback.

Essentially, the functionality proposed allows the user to register events, where user data is also supplied when the callback function is triggered. More specifically, the PR does this for the `drmgr_register_thread_init_event`  API function.

The proposed functionality would avoid the need to have, say a tls index stored globally, and therefore may allow instantiations of the same component to hook thread init events with different storage locations. 

Ideally, the ability to register user supplied data is available for all callbacks associated with generic events, but since this requires some code changes, I am asking for feedback, and whether this functionality is of any use?

Thanks!