### PR TITLE
i#2001 trace perf: fix bug in drutil_insert_get_mem_addr_ex()

### DIFF
--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -114,14 +114,16 @@ instru_t::insert_obtain_addr(void *drcontext, instrlist_t *ilist, instr_t *where
                              OUT bool *scratch_used)
 {
     bool ok;
+    bool we_used_scratch = false;
     if (opnd_uses_reg(ref, reg_scratch)) {
         drreg_get_app_value(drcontext, ilist, where, reg_scratch, reg_scratch);
-        if (scratch_used != NULL)
-            *scratch_used = true;
+        we_used_scratch = true;
     }
     if (opnd_uses_reg(ref, reg_addr))
         drreg_get_app_value(drcontext, ilist, where, reg_addr, reg_addr);
     ok = drutil_insert_get_mem_addr_ex(drcontext, ilist, where, ref, reg_addr,
                                        reg_scratch, scratch_used);
     DR_ASSERT(ok);
+    if (scratch_used != NULL && we_used_scratch)
+        *scratch_used = true;
 }

--- a/ext/drutil/drutil.c
+++ b/ext/drutil/drutil.c
@@ -120,6 +120,8 @@ drutil_insert_get_mem_addr_ex(void *drcontext, instrlist_t *bb, instr_t *where,
                               opnd_t memref, reg_id_t dst, reg_id_t scratch,
                               OUT bool *scratch_used)
 {
+    if (scratch_used != NULL)
+        *scratch_used = false;
 #if defined(X86)
     return drutil_insert_get_mem_addr_x86(drcontext, bb, where, memref, dst, scratch,
                                           scratch_used);


### PR DESCRIPTION
Fixes a bug in the new drutil_insert_get_mem_addr_ex() feature: it wasn't
initializing the output prameter on all paths.

Issue: #2001