### PR TITLE
i#2820: trace a subset of threads

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -423,6 +423,12 @@ if (BUILD_TESTS)
     add_win32_flags(tool.drcacheoff.burst_threads)
     target_link_libraries(tool.drcacheoff.burst_threads ${libpthread})
 
+    add_executable(tool.drcacheoff.burst_threadfilter tests/burst_threadfilter.cpp)
+    configure_DynamoRIO_static(tool.drcacheoff.burst_threadfilter)
+    use_DynamoRIO_static_client(tool.drcacheoff.burst_threadfilter drmemtrace_static)
+    add_win32_flags(tool.drcacheoff.burst_threadfilter)
+    target_link_libraries(tool.drcacheoff.burst_threadfilter ${libpthread})
+
     if (X64 AND UNIX)
       add_executable(tool.drcacheoff.burst_noreach tests/burst_noreach.cpp)
       configure_DynamoRIO_static(tool.drcacheoff.burst_noreach)

--- a/clients/drcachesim/tests/burst_threadfilter.cpp
+++ b/clients/drcachesim/tests/burst_threadfilter.cpp
@@ -1,0 +1,191 @@
+/* **********************************************************
+ * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* This application links in drmemtrace_static and acquires a trace during
+ * a "burst" of execution in the middle of the application.  It then detaches.
+ * It tests the thread filtering feature.
+ */
+
+/* We deliberately do not include configure.h here to simulate what an
+ * actual app will look like.  configure_DynamoRIO_static sets DR_APP_EXPORTS
+ * for us.
+ */
+#include "dr_api.h"
+#include "drmemtrace/drmemtrace.h"
+#include <assert.h>
+#include <iostream>
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#ifndef UNIX
+# include <process.h>
+#endif
+
+static const int num_threads = 8;
+static const int burst_owner = 4;
+static bool finished[num_threads];
+static uint tid[num_threads];
+
+bool
+my_setenv(const char *var, const char *value)
+{
+#ifdef UNIX
+    return setenv(var, value, 1/*override*/) == 0;
+#else
+    return SetEnvironmentVariable(var, value) == TRUE;
+#endif
+}
+
+static int
+do_some_work(int i)
+{
+    static int iters = 512;
+    double val = (double)i;
+    for (int i = 0; i < iters; ++i) {
+        val += sin(val);
+    }
+    return (val > 0);
+}
+
+#ifdef WINDOWS
+unsigned int __stdcall
+#else
+void *
+#endif
+thread_func(void *arg)
+{
+    unsigned int idx = (unsigned int)(uintptr_t)arg;
+    static const int outer_iters = 2048;
+    /* We trace a 4-iter burst of execution. */
+    static const int iter_start = outer_iters/3;
+    static const int iter_stop = iter_start + 4;
+
+    /* We use an outer loop to test re-attaching (i#2157), except
+     * there is an unfixed bug i#2175.
+     * XXX i#2175: up the iter count once we fix the bug.
+     */
+    for (int j = 0; j < 1; ++j) {
+        if (j > 0 && idx == burst_owner)
+            dr_app_setup();
+        for (int i = 0; i < outer_iters; ++i) {
+            if (idx == burst_owner && i == iter_start) {
+                std::cerr << "pre-DR start\n";
+                dr_app_start();
+            }
+            if (idx == burst_owner) {
+                if (i >= iter_start && i <= iter_stop)
+                    assert(dr_app_running_under_dynamorio());
+                else
+                    assert(!dr_app_running_under_dynamorio());
+            }
+            if (do_some_work(i) < 0)
+                std::cerr << "error in computation\n";
+            if (idx == burst_owner && i == iter_stop) {
+                std::cerr << "pre-DR detach\n";
+                dr_app_stop_and_cleanup();
+            }
+        }
+    }
+    finished[idx] = true;
+    return 0;
+}
+
+static bool
+should_trace_thread_cb(thread_id_t thread_id, void *user_data)
+{
+#ifdef UNIX
+    /* We have no simple way to get the id (short of letting each thread get
+     * its own and using synch to wait for them all) so we just take the 1st N.
+     * We assume this is called exactly once per thread.  We are fine with races.
+     */
+    static int count;
+    return (count++ < num_threads/2);
+#else
+    for (uint i = 0; i < num_threads; i++) {
+        if (thread_id == tid[i])
+            return i % 2 == 0;
+    }
+    return true;
+#endif
+}
+
+int
+main(int argc, const char *argv[])
+{
+#ifdef UNIX
+    pthread_t thread[num_threads];
+#else
+    uintptr_t thread[num_threads];
+#endif
+
+    drmemtrace_status_t res = drmemtrace_filter_threads(should_trace_thread_cb, nullptr);
+    assert(res == DRMEMTRACE_SUCCESS);
+
+    /* While the start/stop thread only runs 4 iters, the other threads end up
+     * running more and their trace files get up to 65MB or more, with the
+     * merged result several GB's: too much for a test.  We thus cap each thread.
+     */
+    std::string ops =
+        std::string("-loglevel 4 -logdir /tmp/ -stderr_mask 0xc -client_lib "
+                    "';;-offline -max_trace_size 256K ");
+    /* Support passing in extra tracer options. */
+    for (int i = 1; i < argc; ++i)
+        ops += std::string(argv[i]) + " ";
+    ops += "'";
+    if (!my_setenv("DYNAMORIO_OPTIONS", ops.c_str()))
+        std::cerr << "failed to set env var!\n";
+
+    std::cerr << "pre-DR init\n";
+    dr_app_setup();
+    assert(!dr_app_running_under_dynamorio());
+
+    for (uint i = 0; i < num_threads; i++) {
+#ifdef UNIX
+        pthread_create(&thread[i], NULL, thread_func, (void*)(uintptr_t)i);
+#else
+        thread[i] = _beginthreadex(NULL, 0, thread_func, (void*)(uintptr_t)i, 0, &tid[i]);
+#endif
+    }
+    for (uint i = 0; i < num_threads; i++) {
+#ifdef UNIX
+        pthread_join(thread[i], NULL);
+#else
+        WaitForSingleObject((HANDLE)thread[i], INFINITE);
+#endif
+    }
+    for (int i = 0; i < num_threads; ++i) {
+        if (!finished[i])
+            std::cerr << "thread " << i << " failed to finish\n";
+    }
+    std::cerr << "all done\n";
+    return 0;
+}

--- a/clients/drcachesim/tests/offline-burst_threadL0filter.templatex
+++ b/clients/drcachesim/tests/offline-burst_threadL0filter.templatex
@@ -1,0 +1,13 @@
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
+Basic counts tool results:
+Total counts:
+           0 total \(fetched\) instructions
+           0 total non-fetched instructions
+    *[0-9]* total prefetches
+    *[0-9]* total data loads
+    *[0-9]* total data stores
+           0 total markers
+           4 total threads

--- a/clients/drcachesim/tests/offline-burst_threadfilter.templatex
+++ b/clients/drcachesim/tests/offline-burst_threadfilter.templatex
@@ -1,0 +1,14 @@
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
+Basic counts tool results:
+Total counts:
+    *[0-9]* total \(fetched\) instructions
+    *[0-9]* total non-fetched instructions
+    *[0-9]* total prefetches
+    *[0-9]* total data loads
+    *[0-9]* total data stores
+           0 total markers
+           4 total threads
+.*

--- a/clients/drcachesim/tracer/drmemtrace.h
+++ b/clients/drcachesim/tracer/drmemtrace.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -52,7 +52,8 @@ extern "C" {
 typedef enum {
     DRMEMTRACE_SUCCESS,                  /**< Operation succeeded. */
     DRMEMTRACE_ERROR,                    /**< Operation failed. */
-    DRMEMTRACE_ERROR_INVALID_PARAMETER,  /**< Operation failed: invalid parameter */
+    DRMEMTRACE_ERROR_INVALID_PARAMETER,  /**< Operation failed: invalid parameter. */
+    DRMEMTRACE_ERROR_NOT_IMPLEMENTED,    /**< Operation failed: not implemented. */
 } drmemtrace_status_t;
 
 DR_EXPORT
@@ -247,6 +248,24 @@ drmemtrace_status_t
 drmemtrace_custom_module_data(void * (*load_cb)(module_data_t *module),
                               int (*print_cb)(void *data, char *dst, size_t max_len),
                               void (*free_cb)(void *data));
+
+/**
+ * Activates thread filtering.  The \p should_trace_thread_cb will be
+ * called once for each new thread, with \p user_value passed in for \p
+ * user_data.  If it returns false, that thread will *not* be traced at
+ * all; if it returns true, that thread will be traced normally.  Returns
+ * whether the filter was successfully installed.  \note This feature is
+ * currently only supported for x86.
+ * This routine should be called during initialization, before any
+ * instrumentation is added.  To filter out the calling thread (the initial
+ * application thread) this should be called prior to DR initialization
+ * (via the start/stop API).  Only a single call to this routine is
+ * supported.
+ */
+drmemtrace_status_t
+drmemtrace_filter_threads(bool (*should_trace_thread_cb)(thread_id_t tid,
+                                                         void *user_data),
+                          void *user_value);
 
 #ifdef __cplusplus
 }

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -590,6 +590,8 @@ raw2trace_t::merge_and_process_thread_files()
 {
     // The current thread we're processing is tidx.  If it's set to thread_files.size()
     // that means we need to pick a new thread.
+    if (thread_files.empty())
+        return "No thread files found.";
     uint tidx = (uint)thread_files.size();
     uint thread_count = (uint)thread_files.size();
     offline_entry_t in_entry;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2629,6 +2629,9 @@ if (CLIENT_INTERFACE)
           torunonly_drcacheoff(burst_threadL0filter tool.drcacheoff.burst_threadfilter
             "" "@-simulator_type@basic_counts" "-L0_filter -L0I_size 0")
           set(tool.drcacheoff.burst_threadL0filter_nodr ON)
+          # We're using the same app so we serialize to avoid racing trace dirs:
+          set(tool.drcacheoff.burst_threadL0filter_depends
+            tool.drcacheoff.burst_threadfilter)
 
           if (X86 AND NOT APPPLE) # This test is x86-specific.
             # Test that raw2trace doesn't do more IO than it should.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2623,6 +2623,13 @@ if (CLIENT_INTERFACE)
           torunonly_drcacheoff(burst_threads tool.drcacheoff.burst_threads "" "" "")
           set(tool.drcacheoff.burst_threads_nodr ON)
 
+          torunonly_drcacheoff(burst_threadfilter tool.drcacheoff.burst_threadfilter
+            "" "@-simulator_type@basic_counts" "")
+          set(tool.drcacheoff.burst_threadfilter_nodr ON)
+          torunonly_drcacheoff(burst_threadL0filter tool.drcacheoff.burst_threadfilter
+            "" "@-simulator_type@basic_counts" "-L0_filter -L0I_size 0")
+          set(tool.drcacheoff.burst_threadL0filter_nodr ON)
+
           if (X86 AND NOT APPPLE) # This test is x86-specific.
             # Test that raw2trace doesn't do more IO than it should.
             get_target_path_for_execution(raw2trace_io_path tool.drcacheoff.raw2trace_io)


### PR DESCRIPTION
Adds a thread filtering feature to drcachesim, driven by a new API routine
drmemtrace_filter_threads() which decides for each thread whether to trace
it.  In the tracer, untraced threads have no trace buffer, which serves as
the flag indicating to skip instrumentation.  This flag is checked via
the same mechanism as skipping the clean call (the code is shared here as a
new utility insert_conditional_skip()), using jecxz on x86.

There are some complexities with the extra internal control for regular and
cache-filter modes where we need to insert barriers and sometimes wait for
spills we don't truly need.  The benefit is that in the end the
instrumentation is 3x faster than an approach of always filling the
per-thread buffers and filtering the threads only on i/o.

Adds two new bursty trace tests of the thread filter, one with and one
without the cache filter.

Fixes #2820