### PR TITLE
i#2820 trace thread subset: fix release build test failure

### DIFF
--- a/clients/drcachesim/tests/burst_threadfilter.cpp
+++ b/clients/drcachesim/tests/burst_threadfilter.cpp
@@ -155,8 +155,7 @@ main(int argc, const char *argv[])
      * merged result several GB's: too much for a test.  We thus cap each thread.
      */
     std::string ops =
-        std::string("-loglevel 4 -logdir /tmp/ -stderr_mask 0xc -client_lib "
-                    "';;-offline -max_trace_size 256K ");
+        std::string("-stderr_mask 0xc -client_lib ';;-offline -max_trace_size 256K ");
     /* Support passing in extra tracer options. */
     for (int i = 1; i < argc; ++i)
         ops += std::string(argv[i]) + " ";


### PR DESCRIPTION
Removes logging parameters from the burst_thread*filter tests to fix
release build suite failures.

Issue: #2820