### PR TITLE
i#1432 win8+ tests: fix 8.3 name load failures

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3143,7 +3143,14 @@ else (UNIX)
   tobuild_dll(win32.dll win32/dll.c "")
   tobuild(win32.fiber-rac win32/fiber-rac.c)
   tobuild(win32.finally win32/finally.c)
+
   tobuild_dll(win32.multisec win32/multisec.c "")
+  # On Win8+ loading via 8.3 name doesn't fool the loader, so we make a copy.
+  get_target_property(multisec_path win32.multisec.dll LOCATION${location_suffix})
+  add_custom_command(TARGET win32.multisec.dll POST_BUILD
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy ${multisec_path}
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/win32.multisec2.dll.dll VERBATIM)
+
   tobuild_dll(win32.nativeterminate win32/nativeterminate.c
     "-native_exec_list nativeterminate.dll.dll")
   # FIXME i#192: oomtest ends up killing parent shell: investigate, fix, re-enable!
@@ -3154,7 +3161,13 @@ else (UNIX)
     torunonly(win32.partial_map_FLAKY win32.partial_map win32/partial_map.c "" "")
   endif (TEST_SUITE)
   tobuild(win32.protect-datasec win32/protect-datasec.c)
+
   tobuild_dll(win32.rebased win32/rebased.c "")
+  # On Win8+ loading via 8.3 name doesn't fool the loader, so we make a copy.
+  get_target_property(rebased_path win32.rebased.dll LOCATION${location_suffix})
+  add_custom_command(TARGET win32.rebased.dll POST_BUILD
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy ${rebased_path}
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/win32.rebased2.dll.dll VERBATIM)
 
   # Memory usage does go up a bit with reloading due to traces so we disable traces.
   tobuild_dll(win32.reload win32/reload.c "-disable_traces")

--- a/suite/tests/win32/multisec.c
+++ b/suite/tests/win32/multisec.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -86,7 +87,7 @@ int main()
 
     /* same as rebased test */
     lib1 = myload("win32.multisec.dll.dll");
-    lib2 = myload("win32m~1.dll");
+    lib2 = myload("win32.multisec2.dll.dll");
     if (lib1 == lib2) {
         print("there is a problem - should have collided, maybe missing\n");
     }

--- a/suite/tests/win32/multisec.template
+++ b/suite/tests/win32/multisec.template
@@ -23,7 +23,7 @@ calling f2
 func4
 func3
 func4
-loaded win32m~1.dll
+loaded win32.multisec2.dll.dll
 func2
 exe calling f2
 func2

--- a/suite/tests/win32/rebased.c
+++ b/suite/tests/win32/rebased.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -61,14 +61,10 @@ int main()
     HMODULE lib2;
 
     lib1 = myload("win32.rebased.dll.dll");
-    /* name conflicts w/ other r* tests so might be ~2 depending on build order */
-    lib2 = myload("win32r~1.dll");
-    if (lib2 == NULL)
-        lib2 = myload("win32r~2.dll");
-    if (lib2 == NULL)
-        lib2 = myload("win32r~3.dll");
-    if (lib2 == NULL)
-        lib2 = myload("win32r~4.dll");
+    /* We used to just load the 8.3 name, but the Win8+ loader no longer loads a
+     * separate copy that way.  Now we make an explicit separate copy.
+     */
+    lib2 = myload("win32.rebased2.dll.dll");
     if (lib1 == lib2) {
         print("there is a problem - should have collided, maybe missing\n");
     }

--- a/suite/tests/win32/rebased.templatex
+++ b/suite/tests/win32/rebased.templatex
@@ -13,5 +13,5 @@ foo
 foo
 bar
 foo
-loaded win32r~[1-4].dll
+loaded win32.rebased2.dll.dll
 #endif


### PR DESCRIPTION
Fixes the win32.rebased and win32.multisec tests on win8+.
These tests both try to load a separate copy of a dll by
using its 8.3 name which is mapped to the already-loaded full name in
win8+.  We add a post-build step to make a separate copy of the dll file
and load that to solve the problem.

Issue: #1432, #2835