### PR TITLE
i#1309 win8+ threads: use NtCreateThreadEx for internal nudges

### DIFF
--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * ********************************************************** */
 
@@ -594,7 +594,7 @@ GLOBAL_LABEL(cleanup_and_terminate:)
         mov      REG_XBX, PTRSZ [1*ARG_SZ + REG_XBP] /* dcontext */
         SAVE_TO_DCONTEXT_VIA_REG(REG_XBX,is_exiting_OFFSET,1)
         CALLC1(GLOBAL_REF(is_currently_on_dstack), REG_XBX) /* xbx is callee-saved */
-        cmp      REG_XAX, 0
+        cmp      al, 0
         jnz      cat_save_dstack
         mov      REG_XBX, 0 /* save 0 for dstack to avoid double-free */
         jmp      cat_done_saving_dstack
@@ -1486,7 +1486,7 @@ GLOBAL_LABEL(master_signal_handler:)
         mov      REG_XAX, REG_XSP
         /* call a C routine rather than writing everything in asm */
         CALLC2(GLOBAL_REF(sig_should_swap_stack), REG_XAX, REG_XDX)
-        cmp      REG_XAX, 0
+        cmp      al, 0
         pop      REG_XAX /* clone_and_swap_args.stack */
         pop      REG_XCX /* clone_and_swap_args.tos */
         je       no_swap

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1662,6 +1662,7 @@ delete_dynamo_context(dcontext_t *dcontext, bool free_stack)
     if (free_stack) {
         ASSERT(dcontext->dstack != NULL);
         ASSERT(!is_currently_on_dstack(dcontext));
+        LOG(GLOBAL, LOG_THREADS, 1, "Freeing DR stack "PFX"\n", dcontext->dstack);
         stack_free(dcontext->dstack, DYNAMORIO_STACK_SIZE);
     } /* else will be cleaned up by caller */
 
@@ -2313,8 +2314,8 @@ dynamo_thread_init(byte *dstack_in, priv_mcontext_t *mc
         IF_CLIENT_INTERFACE_ELSE(client_thread ? "CLIENT " : "", ""),
         get_thread_id(), dcontext);
     LOG(THREAD, LOG_TOP|LOG_THREADS, 1,
-        "DR stack is "PFX"-"PFX"\n", dcontext->dstack - DYNAMORIO_STACK_SIZE,
-        dcontext->dstack);
+        "DR stack is "PFX"-"PFX" (passed in "PFX")\n",
+        dcontext->dstack - DYNAMORIO_STACK_SIZE, dcontext->dstack, dstack_in);
 #endif
 
 #ifdef DEADLOCK_AVOIDANCE

--- a/core/nudge.c
+++ b/core/nudge.c
@@ -492,12 +492,14 @@ nudge_internal(process_id_t pid, uint nudge_action_mask,
      * in the target process, for <=win7.
      */
     nudge_arg.flags = (internal ? NUDGE_IS_INTERNAL : 0);
+#ifdef WINDOWS
     if (get_os_version() >= WINDOWS_VERSION_8) {
         /* The kernel owns and frees the stack. */
         nudge_arg.flags |= NUDGE_NUDGER_FREE_STACK;
         /* The arg was placed in a new kernel alloc. */
         nudge_arg.flags |= NUDGE_FREE_ARG;
     }
+#endif
     nudge_arg.client_arg = client_arg;
     nudge_arg.client_id = client_id;
 

--- a/core/win32/ntdll.h
+++ b/core/win32/ntdll.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -939,6 +939,7 @@ typedef enum { /* NOTE - these are speculative */
                                                 * - INOUT */
     THREAD_INFO_ELEMENT_UNKNOWN_1       = 0x9, /* Unknown - ptr_uint_t sized
                                                 * [ observed 1 ] - IN */
+    THREAD_INFO_ELEMENT_UNKNOWN_2       = 0x10000,
 } thread_info_elm_buf_type_t;
 
 typedef struct _thread_info_element_t { /* NOTE - this is speculative */
@@ -2102,13 +2103,18 @@ nt_stop_profile(HANDLE profile_handle);
 HANDLE
 create_process(wchar_t *exe, wchar_t *cmdline);
 
-/* NOTE see important usage information in ntdll.c, threads created with this
- * function can NOT return from their start routine */
+/* See important usage information in ntdll.c: threads created with this
+ * function can NOT return from their start routine.
+ * On Win8+, the kernel owns the created stack; o/w, we own it.
+ * On Win8+, if arg_buf != NULL, it's placed in a new virtual alloc and it's
+ * up to the caller to free it.
+ */
 HANDLE
 our_create_thread(HANDLE hProcess, bool target_64bit, void *start_addr,
                   void *arg, const void *arg_buf, size_t arg_buf_size,
                   uint stack_reserve, uint stack_commit, bool suspended,
                   thread_id_t *tid);
+/* Uses caller-allocated stack.  hProcess must be NT_CURRENT_PROCESS for win8+. */
 HANDLE
 our_create_thread_have_stack(HANDLE hProcess, bool target_64bit, void *start_addr,
                              void *arg, const void *arg_buf, size_t arg_buf_size,


### PR DESCRIPTION
Since NtCreateThread returns STATUS_ACCESS_DENIED on win8+, we implement a
solution for internal nudges using NtCreateThreadEx.  We already have
support for varying who frees the stack in NUDGE_NUDGER_FREE_STACK, which
we leverage here.  The other complication is who frees the arg_buf for a
remote process (since we can't easily put it on the stack): again, we
already have NUDGE_FREE_ARG which we use here.

We also fix a bug in cleanup_and_terminate that results in a double-free of
a nudge dstack: a simple 1-byte-bool error where our asm checks all 4
bytes.  A similar asm bug found by inspection with sig_should_swap_stack()
is also fixed.

This fixes internal nudges.  Client threads and external nudges will be
fixed separately.

Issue: #1309, #1432, #2835