### PR TITLE
i#1309 win8+ threads: use NtCreateThreadEx for client threads

### DIFF
--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -2086,7 +2086,7 @@ GLOBAL_LABEL(call_intr_excpt_alt_stack:)
         /* retaddr + this push => 16-byte alignment prior to call */
 # endif
         push     REG_XSI       /* save xsp */
-        CALLC4(GLOBAL_REF(internal_exception_info), \
+        CALLC5(GLOBAL_REF(internal_exception_info), \
                REG_XAX /* dcontext */,  \
                REG_XBX /* pExcptRec */, \
                REG_XDI /* cxt */,       \

--- a/core/win32/ntdll.h
+++ b/core/win32/ntdll.h
@@ -2121,6 +2121,9 @@ our_create_thread_have_stack(HANDLE hProcess, bool target_64bit, void *start_add
                              byte *stack_base, size_t stack_size,
                              bool suspended, thread_id_t *tid);
 
+void
+our_create_thread_wrapper(void *param);
+
 /* NOTE : this isn't equivalent to nt_get_context(NT_CURRENT_THREAD, cxt)
  * (where the returned context is undefined) so use this to get the context
  * of the current thread */

--- a/core/win32/os_private.h
+++ b/core/win32/os_private.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -131,6 +131,9 @@ check_for_ldrpLoadImportModule(byte *base, uint *ebp);
 #ifdef CLIENT_SIDELINE
 void
 client_thread_target(void *param);
+
+bool
+is_new_thread_client_thread(CONTEXT *cxt, OUT byte **dstack);
 #endif
 
 bool os_delete_file_w(const wchar_t *file_name,


### PR DESCRIPTION
For client threads where we want to use our dstack yet we're forced to use
NtCreateThreadEx and its kernel-provided stack, we target a wrapper that
switches stacks and calls the client thread function.  We pass data to the
wrapper on the dstack and pass the dstack as its parameter.

Issue: #1309, #1432, #2835