### PR TITLE
i#1309 win8+ threads: use NtCreateThreadEx for external nudges

### DIFF
--- a/core/win32/ntdll.c
+++ b/core/win32/ntdll.c
@@ -4674,8 +4674,8 @@ our_create_thread_ex(HANDLE hProcess, bool target_64bit, void *start_addr,
     info.teb.buffer = &teb;
     res = NT_RAW_SYSCALL(CreateThreadEx, &hthread, THREAD_ALL_ACCESS, &oa, hProcess,
                          (LPTHREAD_START_ROUTINE)convert_data_to_function(start_addr),
-                         thread_arg, !!suspended, 0, stack_commit, stack_reserve,
-                         &info);
+                         thread_arg, suspended ? TRUE : FALSE, 0,
+                         stack_commit, stack_reserve, &info);
     if (!NT_SUCCESS(res)) {
         NTPRINT("create_thread_ex: failed to create thread: %x\n", res);
         return INVALID_HANDLE_VALUE;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1237,52 +1237,70 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out)
   endif ()
 
   if (is_runall)
-    # to run the test we use a series of commands in runall.cmake.
+    # To run the test we use a series of commands in runall.cmake.
     file(READ "${testpath}/${srcbase}.runall" runall)
     if (UNIX)
-      # swap from drrun to run_in_bg to run the test in the background
-      # XXX i#1874: add support for running on Android
-      set(tmpfile "${CMAKE_CURRENT_BINARY_DIR}/${test}-out")
-      string(REGEX REPLACE "^[^/]*(/.*)/drrun" "\\1/run_in_bg;-out;${tmpfile};\\1/drrun"
+      # We always run infloop.
+      get_target_path_for_execution(app_path linux.infloop)
+    else ()
+      # It's easier to run our own infloop, which prints so we know when it's up,
+      # than to run notepad or sthg.
+      get_target_path_for_execution(app_path win32.infloop)
+    endif ()
+    # Swap from drrun to run_in_bg to run the test in the background and print the pid.
+    # XXX i#1874: add support for running on Android
+    set(tmpfile "${CMAKE_CURRENT_BINARY_DIR}/${key}-out")
+    if (UNIX)
+      set(pidfile "")
+      string(REGEX REPLACE "^(.*)/drrun" "\\1/run_in_bg;-out;${tmpfile};\\1/drrun"
         rundr "${rundr}")
-      # Remove timeout args to drrun to ensure that it doesn't fork the app.
-      string(REGEX REPLACE ";-s;[0-9]+" "" rundr "${rundr}")
-      string(REGEX REPLACE ";-killpg" "" rundr "${rundr}")
-      set(clear_arg "")
-      if ("${runall}" MATCHES "<reset>")
-        set(nudge_arg "-type\;reset")
-      elseif ("${runall}" MATCHES "<freeze>")
-        set(nudge_arg "-type\;freeze")
-      elseif ("${runall}" MATCHES "<persist>")
-        set(nudge_arg "-type\;persist")
-        # clear out pcache dir prior to run
-        set(clear_arg "${PCACHE_SHARED_DIR}")
-      elseif ("${runall}" MATCHES "<use-persisted>")
-        set(nudge_arg "<use-persisted>")
-      elseif ("${runall}" MATCHES "<client")
-        string(REGEX MATCHALL "<client_nudge[^>]+" nudge_arg "${runall}")
-        string(REGEX REPLACE "<client_nudge" "-client" nudge_arg "${nudge_arg}")
-        string(REGEX REPLACE " " "\\\\;" nudge_arg "${nudge_arg}")
-      endif ()
-    endif (UNIX)
-    # FIXME i#120: for Windows, get app name to run from .runall file.
-    # For linux we always run linux.infloop.
-    get_target_path_for_execution(infloop_path linux.infloop)
-    set(cmd_with_at ${rundr} ${infloop_path} ${exe_ops})
+    else ()
+      set(pidfile "${CMAKE_CURRENT_BINARY_DIR}/${key}-pid")
+      # We want the pid not of drrun but its child so we pass -pidfile to drrun rather
+      # than -pid to run_in_bg.
+      # XXX i#120: add systemwide injection testing.  For now we only test drrun.
+      string(REGEX REPLACE "^(.*)/drrun.exe"
+        "\\1/run_in_bg;-out;${tmpfile};\\1/drrun.exe;-pidfile;${pidfile}"
+        rundr "${rundr}")
+    endif ()
+    # Remove timeout args to drrun to ensure that it doesn't fork the app.
+    string(REGEX REPLACE ";-s;[0-9]+" "" rundr "${rundr}")
+    string(REGEX REPLACE ";-killpg" "" rundr "${rundr}")
+    set(clear_arg "")
+    if ("${runall}" MATCHES "<reset>")
+      set(nudge_arg "-type\;reset")
+    elseif ("${runall}" MATCHES "<freeze>")
+      set(nudge_arg "-type\;freeze")
+    elseif ("${runall}" MATCHES "<persist>")
+      set(nudge_arg "-type\;persist")
+      # clear out pcache dir prior to run
+      set(clear_arg "${PCACHE_SHARED_DIR}")
+    elseif ("${runall}" MATCHES "<use-persisted>")
+      set(nudge_arg "<use-persisted>")
+    elseif ("${runall}" MATCHES "<client")
+      string(REGEX MATCHALL "<client_nudge[^>]+" nudge_arg "${runall}")
+      string(REGEX REPLACE "<client_nudge" "-client" nudge_arg "${nudge_arg}")
+      string(REGEX REPLACE " " "\\\\;" nudge_arg "${nudge_arg}")
+    endif ()
+    set(cmd_with_at ${rundr} ${app_path} ${exe_ops})
     # we pass intra-arg spaces via @@ and inter-arg via @ and ; via !
     # to get around the pain of trying to quote everything just right:
     # much simpler this way.
     string(REGEX REPLACE " " "@@" cmd_with_at "${cmd_with_at}")
     string(REGEX REPLACE ";" "@" cmd_with_at "${cmd_with_at}")
     if (NOT APPLE) # XXX i#1286: implement nudge for MacOS
-      get_target_path_for_execution(toolbindir nudgeunix)
+      if (UNIX)
+        get_target_path_for_execution(toolbindir nudgeunix)
+      else ()
+        get_target_path_for_execution(toolbindir drconfig)
+      endif ()
     else ()
       set(toolbindir "i#1286-not-implemented-for-Mac")
     endif ()
     get_filename_component(toolbindir ${toolbindir} DIRECTORY)
     add_test(${test} ${CMAKE_COMMAND} -D toolbindir=${toolbindir}
       -D cmd=${cmd_with_at} -D out=${tmpfile} -D nudge=${nudge_arg}
-      -D clear=${clear_arg}
+      -D clear=${clear_arg} -D pidfile=${pidfile}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/runall.cmake)
   elseif (is_runcmp)
     # Some apps have enough output that ctest runs out of memory when
@@ -1934,7 +1952,9 @@ if (CLIENT_INTERFACE)
     #tobuild_ci_runall(client.custom_traces client-interface/custom_traces.runall
     #  "" "" "")
     #tobuild_ci_runall(client.decode-bb client-interface/decode-bb.runall "" "" "")
-    #tobuild_ci_runall(client.nudge_test client-interface/nudge_test.runall "" "" "")
+    # I reworked Windows .runall support to run the new win32.infloop but have not yet
+    # looked at other tests:
+    tobuild_ci(client.nudge_test client-interface/nudge_test.runall "" "" "")
     #tobuild_ci_runall(client.pc-check client-interface/pc-check.runall "" "" "")
     if (NOT X64)
       # FIXME i#16, does not work in Win-X64 because of inline assembly code.
@@ -3121,6 +3141,7 @@ if (UNIX)
   # when running tests in parallel: have to generate pcaches first
   set(linux.persist-use_FLAKY_depends linux.persist_FLAKY)
 else (UNIX)
+  add_exe(win32.infloop win32/infloop.c)
   if (VPS)
     # too flaky across platforms so we limit to VPS only: not too useful
     # for other than testing our ASLR anyway

--- a/suite/tests/client-interface/nudge_test.template
+++ b/suite/tests/client-interface/nudge_test.template
@@ -1,7 +1,4 @@
 thank you for testing the client interface
 nudge delivered 10
 nudge delivered 11
-#ifdef WINDOWS
-starting
-#endif
 done

--- a/suite/tests/client-interface/nudge_test.template
+++ b/suite/tests/client-interface/nudge_test.template
@@ -1,38 +1,7 @@
 thank you for testing the client interface
-#if defined(RUNREGRESSION_XP) && defined(PROGRAM_SHEPHERDING) && defined(security) && defined(no_executable_if_rx_text) && !defined(executable_after_load)
-  SEC_VIO_STOP
-No such process found.
-# if defined(WINDOWS)
-Window not found: Untitled - Notepad
-# endif
-#else
-# if defined(WINDOWS)
-#  if defined(DEBUG)
-Process notepad.exe, running SC debug
-#  else
-#   if defined(PROFILE)
-Process notepad.exe, running SC profile
-#   else
-Process notepad.exe, running SC release
-#   endif
-#  endif
-# endif
 nudge delivered 10
 nudge delivered 11
-# if defined(WINDOWS)
-#  if defined(DEBUG)
-Process notepad.exe, running SC debug
-#  else
-#   if defined(PROFILE)
-Process notepad.exe, running SC profile
-#   else
-Process notepad.exe, running SC release
-#   endif
-#  endif
-Close message sent.
-# endif
+#ifdef WINDOWS
+starting
+#endif
 done
-#endif
-#if defined(WINDOWS)
-No such process found.
-#endif

--- a/suite/tests/runall.cmake
+++ b/suite/tests/runall.cmake
@@ -1,4 +1,5 @@
 # **********************************************************
+# Copyright (c) 2018 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -38,7 +39,8 @@
 #     should have intra-arg space=@@ and inter-arg space=@ and ;=!
 # * toolbindir
 # * out = file where output of background process will be sent
-# * nudge = arguments to nudgeunix
+# * pidfile = file where the pid of the background process will be written
+# * nudge = arguments to nudgeunix or drconfig
 # * clear = dir to clear ahead of time
 
 # intra-arg space=@@ and inter-arg space=@
@@ -57,7 +59,13 @@ if (NOT "${clear}" STREQUAL "")
   endif ()
 endif ()
 
-# run in the background
+# Remove any stale files.
+if (pidfile)
+  file(REMOVE ${pidfile})
+endif ()
+file(REMOVE ${out})
+
+# Run the target in the background.
 execute_process(COMMAND ${cmd}
   RESULT_VARIABLE cmd_result
   ERROR_VARIABLE cmd_err
@@ -70,23 +78,46 @@ if (UNIX)
   find_program(SLEEP "sleep")
   if (NOT SLEEP)
     message(FATAL_ERROR "cannot find 'sleep'")
-  endif (NOT SLEEP)
+  endif ()
+  set(nudge_cmd nudgeunix)
 else (UNIX)
-  message(FATAL_ERROR "need a sleep on Windows")
-  # FIXME i#120: add tools/sleep.exe?
-  # or use perl?  trying to get away from perl though
+  # We use "ping" on Windows to "sleep" :)
+  find_program(PING "ping")
+  if (NOT PING)
+    message(FATAL_ERROR "cannot find 'ping'")
+  endif ()
+  set(nudge_cmd drconfig)
 endif (UNIX)
 
+function (do_sleep ms)
+  if (UNIX)
+    execute_process(COMMAND "${SLEEP}" ${ms})
+  else ()
+    # XXX: ping's units are secs.  For now we always do 1 sec.
+    # We could try to use cygwin bash or perl.
+    execute_process(COMMAND ${PING} 127.0.0.1 -n 1 OUTPUT_QUIET)
+  endif ()
+endfunction (do_sleep)
+
+if (pidfile)
+  while (NOT EXISTS "${pidfile}")
+    do_sleep(0.1)
+  endwhile ()
+  file(READ "${pidfile}" pid)
+  string(REGEX REPLACE "\n" "" pid ${pid})
+endif ()
+
 while (NOT EXISTS "${out}")
-  execute_process(COMMAND "${SLEEP}" 0.1)
+  do_sleep(0.1)
 endwhile ()
 file(READ "${out}" output)
 # we require that all runall tests write at least one line up front
 while (NOT "${output}" MATCHES "\n")
-  execute_process(COMMAND "${SLEEP}" 0.1)
+  do_sleep(0.1)
   file(READ "${out}" output)
 endwhile()
 
+set(orig_nudge "${nudge}")
 if ("${nudge}" MATCHES "<use-persisted>")
   # ensure using pcaches, instead of nudging
   file(READ "/proc/${pid}/maps" maps)
@@ -94,7 +125,13 @@ if ("${nudge}" MATCHES "<use-persisted>")
     set(fail_msg "no .dpc files found in ${maps}: not using pcaches!")
   endif ()
 else ()
-  execute_process(COMMAND "${toolbindir}/nudgeunix" -pid ${pid} ${nudge}
+  # nudgeunix and drconfig have different syntax:
+  if (WIN32)
+    string(REGEX REPLACE "-client" "-nudge_pid;${pid}" nudge "${nudge}")
+  else ()
+    string(REGEX REPLACE "-client" "-pid;${pid};-client" nudge "${nudge}")
+  endif ()
+  execute_process(COMMAND "${toolbindir}/${nudge_cmd}" ${nudge}
     RESULT_VARIABLE nudge_result
     ERROR_VARIABLE nudge_err
     OUTPUT_VARIABLE nudge_out
@@ -102,17 +139,17 @@ else ()
   # combine out and err
   set(nudge_err "${nudge_out}${nudge_err}")
   if (nudge_result)
-    message(FATAL_ERROR "*** nudgeunix failed (${nudge_result}): ${nudge_err}***\n")
+    message(FATAL_ERROR "*** ${nudge_cmd} failed (${nudge_result}): ${nudge_err}***\n")
   endif (nudge_result)
 endif ()
 
-if ("${nudge}" MATCHES "-client")
+if ("${orig_nudge}" MATCHES "-client")
   # wait for more output to file
   string(LENGTH "${output}" prev_outlen)
   file(READ "${out}" output)
   string(LENGTH "${output}" new_outlen)
   while (NOT ${new_outlen} GREATER ${prev_outlen})
-    execute_process(COMMAND "${SLEEP}" 0.1)
+    do_sleep(0.1)
     file(READ "${out}" output)
     string(LENGTH "${output}" new_outlen)
   endwhile()
@@ -120,7 +157,7 @@ else ()
   # for reset or other DR tests there won't be further output
   # so we have to guess how long to wait.
   # FIXME: should we instead turn on stderr_mask?
-  execute_process(COMMAND "${SLEEP}" 0.5)
+  do_sleep(0.5)
 endif ()
 
 if (UNIX)
@@ -139,7 +176,16 @@ if (UNIX)
     message(FATAL_ERROR "*** kill failed (${kill_result}): ${kill_err}***\n")
   endif (kill_result)
 else (UNIX)
-  # FIXME i#120: for Windows, use ${toolbindir}/DRkill.exe
+  # win32.infloop has a title with the pid in it so we can uniquely target it
+  # for a cleaner exit than using drkill.
+  execute_process(COMMAND "${toolbindir}/closewnd.exe" "Infloop pid=${pid}" 10
+    RESULT_VARIABLE kill_result
+    ERROR_VARIABLE kill_err
+    OUTPUT_VARIABLE kill_out)
+  set(kill_err "${kill_out}${kill_err}")
+  if (kill_result)
+    message(FATAL_ERROR "*** kill failed (${kill_result}): ${kill_err}***\n")
+  endif (kill_result)
 endif (UNIX)
 
 if (NOT "${fail_msg}" STREQUAL "")
@@ -149,7 +195,7 @@ endif ()
 # we require that test print "done" as last line once done
 file(READ "${out}" output)
 while (NOT "${output}" MATCHES "\ndone\n")
-  execute_process(COMMAND "${SLEEP}" 0.1)
+  do_sleep(0.1)
   file(READ "${out}" output)
 endwhile()
 
@@ -160,6 +206,8 @@ message("${output}")
 if (UNIX)
   # sometimes infloop keeps running: FIXME: figure out why
   execute_process(COMMAND "${KILL}" -9 ${pid} ERROR_QUIET OUTPUT_QUIET)
-  find_program(PKILL "pkill")
   # we can't run pkill b/c there are other tests running infloop (i#1341)
-endif (UNIX)
+else ()
+  # We could run "${toolbindir}/DRkill.exe" -pid ${pid} but we shouldn't need to
+  # as the app itself has a timeout.
+endif ()

--- a/suite/tests/runall.cmake
+++ b/suite/tests/runall.cmake
@@ -127,9 +127,10 @@ if ("${nudge}" MATCHES "<use-persisted>")
 else ()
   # nudgeunix and drconfig have different syntax:
   if (WIN32)
+    # XXX i#120: expand beyond -client.
     string(REGEX REPLACE "-client" "-nudge_pid;${pid}" nudge "${nudge}")
   else ()
-    string(REGEX REPLACE "-client" "-pid;${pid};-client" nudge "${nudge}")
+    set(nudge "-pid;${pid};${nudge}")
   endif ()
   execute_process(COMMAND "${toolbindir}/${nudge_cmd}" ${nudge}
     RESULT_VARIABLE nudge_result

--- a/suite/tests/win32/infloop.c
+++ b/suite/tests/win32/infloop.c
@@ -52,7 +52,6 @@ main(int argc, const char *argv[])
     char title[64];
     _snprintf_s(title, BUFFER_SIZE_BYTES(title), BUFFER_SIZE_ELEMENTS(title),
                 "Infloop pid=%d", GetProcessId(GetCurrentProcess()));
-    print("starting\n");
     SetTimer(NULL, NULL, 180*1000/*3 mins*/, TimerProc);
     MessageBoxA(NULL, "DynamoRIO test: will be auto-closed", title, MB_OK);
     print("done\n");

--- a/suite/tests/win32/infloop.c
+++ b/suite/tests/win32/infloop.c
@@ -1,0 +1,60 @@
+/* **********************************************************
+ * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* An app that stays up long enough for testing nudges. */
+#include "tools.h"
+#include <windows.h>
+
+/* Timeout to avoid leaving stale processes in case something goes wrong. */
+static VOID CALLBACK
+TimerProc(HWND hwnd, UINT msg, UINT_PTR id, DWORD time)
+{
+    print("timed out\n");
+    ExitProcess(1);
+}
+
+int
+main(int argc, const char *argv[])
+{
+    /* We put the pid into the title so that tools/closewnd can target it
+     * uniquely when run in a parallel test suite.
+     * runall.cmake assumes this precise title.
+     */
+    char title[64];
+    _snprintf_s(title, BUFFER_SIZE_BYTES(title), BUFFER_SIZE_ELEMENTS(title),
+                "Infloop pid=%d", GetProcessId(GetCurrentProcess()));
+    print("starting\n");
+    SetTimer(NULL, NULL, 180*1000/*3 mins*/, TimerProc);
+    MessageBoxA(NULL, "DynamoRIO test: will be auto-closed", title, MB_OK);
+    print("done\n");
+    return 0;
+}

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1597,16 +1597,15 @@ _tmain(int argc, TCHAR *targv[])
                 printf("process %d is not running under DR\n", nudge_pid);
             if (res != DR_SUCCESS && res != DR_NUDGE_TIMEOUT) {
                 count = 0;
-                res = ERROR_SUCCESS;
             }
         } else
             res = dr_nudge_process(process, nudge_id, nudge_arg, nudge_timeout, &count);
 
         printf("%d processes nudged\n", count);
         if (res == DR_NUDGE_TIMEOUT)
-            printf("timed out waiting for nudge to complete");
+            printf("timed out waiting for nudge to complete\n");
         else if (res != DR_SUCCESS)
-            printf("nudge operation failed, verify adequate permissions for this operation.");
+            printf("nudge operation failed, verify permissions and parameters.\n");
     }
 #  ifdef WINDOWS
     /* FIXME i#840: Process iterator NYI for Linux. */


### PR DESCRIPTION
Changes the libutil nudge code to use NtCreateThreadEx on Win8+.

For a test, enables the client.nudge_test test, part of i#120: enable
.runall tests on Windows.  Here I added a new app win32.infloop to parallel
linux.infloop, rather than launching calc.exe or notepad.exe like we did in
the past (not yet tackling systemwide injection here).  It has a MessageBox
with a title containing the pid, allowing us to use tools/closewnd with a
unique target name for a clean and race-free exit.  win32.infloop also has
a 3-minute timeout to avoid leaving stale processes behind in case of
issues closing it externally.

Revamped runall.cmake to work on Windows, using "ping" to sleep,
updating nudge and close commands, removing stale pid files, etc.

Ported suite code to use run_in_bg on Windows as well as Linux,
but with the pidfile coming from drrun.

Fixes #1309
Fixes #1432
Issue: #120, #1835