### PR TITLE
i#2820 trace thread subset: reset callbacks at exit

### DIFF
--- a/clients/drcachesim/tests/burst_threadfilter.cpp
+++ b/clients/drcachesim/tests/burst_threadfilter.cpp
@@ -71,7 +71,7 @@ my_setenv(const char *var, const char *value)
 static file_t
 open_nothing(const char *fname, uint mode_flags)
 {
-    return static_cast<file_t>(1UL);
+    return (file_t)(1UL);
 }
 
 static void
@@ -133,7 +133,7 @@ thread_func(void *arg)
 {
     unsigned int idx = (unsigned int)(uintptr_t)arg;
     static const int reattach_iters = 4;
-    static const int outer_iters = 2048;
+    static const int outer_iters = 4096;
     /* We trace a 4-iter burst of execution. */
     static const int iter_start = outer_iters/3;
     static const int iter_stop = iter_start + 4;
@@ -159,12 +159,11 @@ thread_func(void *arg)
                                                 close_nothing, create_no_dir);
                 assert(res == DRMEMTRACE_SUCCESS);
             } else {
-                drmemtrace_status_t res =
-                    drmemtrace_replace_file_ops(nullptr, nullptr, nullptr,
-                                                nullptr, nullptr);
-                assert(res == DRMEMTRACE_SUCCESS);
+#ifdef UNIX
                 filter_call_count = 0;
-                res = drmemtrace_filter_threads(should_trace_thread_cb, cb_arg[j]);
+#endif
+                drmemtrace_status_t res =
+                    drmemtrace_filter_threads(should_trace_thread_cb, cb_arg[j]);
                 assert(res == DRMEMTRACE_SUCCESS);
             }
             dr_app_setup();

--- a/clients/drcachesim/tests/burst_threadfilter.cpp
+++ b/clients/drcachesim/tests/burst_threadfilter.cpp
@@ -54,6 +54,9 @@ static const int num_threads = 8;
 static const int burst_owner = 4;
 static bool finished[num_threads];
 static uint tid[num_threads];
+#ifdef UNIX
+static int filter_call_count;
+#endif
 
 bool
 my_setenv(const char *var, const char *value)
@@ -63,6 +66,30 @@ my_setenv(const char *var, const char *value)
 #else
     return SetEnvironmentVariable(var, value) == TRUE;
 #endif
+}
+
+static file_t
+open_nothing(const char *fname, uint mode_flags)
+{
+    return static_cast<file_t>(1UL);
+}
+
+static void
+close_nothing(file_t file)
+{
+    /* nothing */
+}
+
+static bool
+create_no_dir(const char *dir)
+{
+    return true;
+}
+
+static ssize_t
+write_nothing(file_t file, const void *data, size_t size)
+{
+    return size;
 }
 
 static int
@@ -76,6 +103,27 @@ do_some_work(int i)
     return (val > 0);
 }
 
+static bool
+should_trace_thread_cb(thread_id_t thread_id, void *user_data)
+{
+    /* Test user_data across reattach (see setup below). */
+    if (*static_cast<int*>(user_data) == 0)
+        std::cerr << "invalid user_data (likely reattach error)\n";
+#ifdef UNIX
+    /* We have no simple way to get the id (short of letting each thread get
+     * its own and using synch to wait for them all) so we just take the 1st N.
+     * We assume this is called exactly once per thread.  We are fine with races.
+     */
+    return filter_call_count++ < num_threads/2;
+#else
+    for (uint i = 0; i < num_threads; i++) {
+        if (thread_id == tid[i])
+            return i % 2 == 0;
+    }
+    return true;
+#endif
+}
+
 #ifdef WINDOWS
 unsigned int __stdcall
 #else
@@ -84,18 +132,43 @@ void *
 thread_func(void *arg)
 {
     unsigned int idx = (unsigned int)(uintptr_t)arg;
+    static const int reattach_iters = 4;
     static const int outer_iters = 2048;
     /* We trace a 4-iter burst of execution. */
     static const int iter_start = outer_iters/3;
     static const int iter_stop = iter_start + 4;
+    int *cb_arg[reattach_iters];
 
-    /* We use an outer loop to test re-attaching (i#2157), except
-     * there is an unfixed bug i#2175.
-     * XXX i#2175: up the iter count once we fix the bug.
-     */
-    for (int j = 0; j < 1; ++j) {
-        if (j > 0 && idx == burst_owner)
+    /* We use an outer loop to test re-attaching (i#2157). */
+    for (int j = 0; j < reattach_iters; ++j) {
+        if (idx == burst_owner) {
+            std::cerr << "pre-DR init\n";
+            assert(!dr_app_running_under_dynamorio());
+            /* We test reattach state clearing by passing a memory location as
+             * user data that we clear on reattach, and we do not filter on one
+             * of the runs.
+             */
+            cb_arg[j] = new int;
+            *cb_arg[j] = 1;
+            if (j == 1) {
+                /* Not filtering on this run, so we don't want output to avoid
+                 * messing up the template.
+                 */
+                drmemtrace_status_t res =
+                    drmemtrace_replace_file_ops(open_nothing, nullptr, write_nothing,
+                                                close_nothing, create_no_dir);
+                assert(res == DRMEMTRACE_SUCCESS);
+            } else {
+                drmemtrace_status_t res =
+                    drmemtrace_replace_file_ops(nullptr, nullptr, nullptr,
+                                                nullptr, nullptr);
+                assert(res == DRMEMTRACE_SUCCESS);
+                filter_call_count = 0;
+                res = drmemtrace_filter_threads(should_trace_thread_cb, cb_arg[j]);
+                assert(res == DRMEMTRACE_SUCCESS);
+            }
             dr_app_setup();
+        }
         for (int i = 0; i < outer_iters; ++i) {
             if (idx == burst_owner && i == iter_start) {
                 std::cerr << "pre-DR start\n";
@@ -112,30 +185,16 @@ thread_func(void *arg)
             if (idx == burst_owner && i == iter_stop) {
                 std::cerr << "pre-DR detach\n";
                 dr_app_stop_and_cleanup();
+                *cb_arg[j] = 0;
             }
         }
     }
+    if (idx == burst_owner) {
+        for (int j = 0; j < reattach_iters; ++j)
+            delete cb_arg[j];
+    }
     finished[idx] = true;
     return 0;
-}
-
-static bool
-should_trace_thread_cb(thread_id_t thread_id, void *user_data)
-{
-#ifdef UNIX
-    /* We have no simple way to get the id (short of letting each thread get
-     * its own and using synch to wait for them all) so we just take the 1st N.
-     * We assume this is called exactly once per thread.  We are fine with races.
-     */
-    static int count;
-    return (count++ < num_threads/2);
-#else
-    for (uint i = 0; i < num_threads; i++) {
-        if (thread_id == tid[i])
-            return i % 2 == 0;
-    }
-    return true;
-#endif
 }
 
 int
@@ -146,9 +205,6 @@ main(int argc, const char *argv[])
 #else
     uintptr_t thread[num_threads];
 #endif
-
-    drmemtrace_status_t res = drmemtrace_filter_threads(should_trace_thread_cb, nullptr);
-    assert(res == DRMEMTRACE_SUCCESS);
 
     /* While the start/stop thread only runs 4 iters, the other threads end up
      * running more and their trace files get up to 65MB or more, with the
@@ -162,10 +218,6 @@ main(int argc, const char *argv[])
     ops += "'";
     if (!my_setenv("DYNAMORIO_OPTIONS", ops.c_str()))
         std::cerr << "failed to set env var!\n";
-
-    std::cerr << "pre-DR init\n";
-    dr_app_setup();
-    assert(!dr_app_running_under_dynamorio());
 
     for (uint i = 0; i < num_threads; i++) {
 #ifdef UNIX

--- a/clients/drcachesim/tests/burst_threads.cpp
+++ b/clients/drcachesim/tests/burst_threads.cpp
@@ -81,16 +81,14 @@ void *
 thread_func(void *arg)
 {
     unsigned int idx = (unsigned int)(uintptr_t)arg;
+    static const int reattach_iters = 4;
     static const int outer_iters = 2048;
     /* We trace a 4-iter burst of execution. */
     static const int iter_start = outer_iters/3;
     static const int iter_stop = iter_start + 4;
 
-    /* We use an outer loop to test re-attaching (i#2157), except
-     * there is an unfixed bug i#2175.
-     * XXX i#2175: up the iter count once we fix the bug.
-     */
-    for (int j = 0; j < 1; ++j) {
+    /* We use an outer loop to test re-attaching (i#2157). */
+    for (int j = 0; j < reattach_iters; ++j) {
         if (j > 0 && idx == burst_owner)
             dr_app_setup();
         for (int i = 0; i < outer_iters; ++i) {

--- a/clients/drcachesim/tests/burst_threads.cpp
+++ b/clients/drcachesim/tests/burst_threads.cpp
@@ -89,8 +89,11 @@ thread_func(void *arg)
 
     /* We use an outer loop to test re-attaching (i#2157). */
     for (int j = 0; j < reattach_iters; ++j) {
-        if (j > 0 && idx == burst_owner)
+        if (idx == burst_owner) {
+            std::cerr << "pre-DR init\n";
             dr_app_setup();
+            assert(!dr_app_running_under_dynamorio());
+        }
         for (int i = 0; i < outer_iters; ++i) {
             if (idx == burst_owner && i == iter_start) {
                 std::cerr << "pre-DR start\n";
@@ -130,10 +133,6 @@ main(int argc, const char *argv[])
     if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -client_lib ';;"
                    "-offline -max_trace_size 256K'"))
         std::cerr << "failed to set env var!\n";
-
-    std::cerr << "pre-DR init\n";
-    dr_app_setup();
-    assert(!dr_app_running_under_dynamorio());
 
     for (uint i = 0; i < num_threads; i++) {
 #ifdef UNIX

--- a/clients/drcachesim/tests/offline-burst_threadL0filter.templatex
+++ b/clients/drcachesim/tests/offline-burst_threadL0filter.templatex
@@ -1,6 +1,15 @@
 pre-DR init
 pre-DR start
 pre-DR detach
+pre-DR init
+pre-DR start
+pre-DR detach
+pre-DR init
+pre-DR start
+pre-DR detach
+pre-DR init
+pre-DR start
+pre-DR detach
 all done
 Basic counts tool results:
 Total counts:

--- a/clients/drcachesim/tests/offline-burst_threadfilter.templatex
+++ b/clients/drcachesim/tests/offline-burst_threadfilter.templatex
@@ -1,6 +1,15 @@
 pre-DR init
 pre-DR start
 pre-DR detach
+pre-DR init
+pre-DR start
+pre-DR detach
+pre-DR init
+pre-DR start
+pre-DR detach
+pre-DR init
+pre-DR start
+pre-DR detach
 all done
 Basic counts tool results:
 Total counts:

--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -14,43 +14,43 @@ all done
 Cache simulation results:
 Core #0 \([0-4] thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*...
-    Misses:                       *[0-9,\.]*.
-.*    Miss rate:                  *[0-9,\.]*%
+    Hits:                       *[0-9,\.]*...
+    Misses:                     *[0-9,\.]*.
+.*    Miss rate:                *[0-9,\.]*%
   L1D stats:
-    Hits:                         *[0-9,\.]*...
-    Misses:                       *[0-9,\.]*.
-.*   Miss rate:                   *[0-9,\.]*%
+    Hits:                       *[0-9,\.]*...
+    Misses:                     *[0-9,\.]*.
+.*    Miss rate:                *[0-9,\.]*%
 Core #1 \([0-4] thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*...
-    Misses:                       *[0-9,\.]*.
-.*    Miss rate:                  *[0-9,\.]*%
+    Hits:                       *[0-9,\.]*...
+    Misses:                     *[0-9,\.]*.
+.*    Miss rate:                *[0-9,\.]*%
   L1D stats:
-    Hits:                         *[0-9,\.]*...
-    Misses:                       *[0-9,\.]*.
-.*   Miss rate:                   *[0-9,\.]*%
+    Hits:                       *[0-9,\.]*...
+    Misses:                     *[0-9,\.]*.
+.*    Miss rate:                *[0-9,\.]*%
 Core #2 \([0-4] thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*...
-    Misses:                       *[0-9,\.]*.
-.*    Miss rate:                  *[0-9,\.]*%
+    Hits:                       *[0-9,\.]*...
+    Misses:                     *[0-9,\.]*.
+.*    Miss rate:                *[0-9,\.]*%
   L1D stats:
-    Hits:                         *[0-9,\.]*...
-    Misses:                       *[0-9,\.]*.
-.*   Miss rate:                   *[0-9,\.]*%
+    Hits:                       *[0-9,\.]*...
+    Misses:                     *[0-9,\.]*.
+.*    Miss rate:                *[0-9,\.]*%
 Core #3 \([0-4] thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*...
-    Misses:                       *[0-9,\.]*.
-.*    Miss rate:                  *[0-9,\.]*%
+    Hits:                       *[0-9,\.]*...
+    Misses:                     *[0-9,\.]*.
+.*    Miss rate:                *[0-9,\.]*%
   L1D stats:
-    Hits:                         *[0-9,\.]*...
-    Misses:                       *[0-9,\.]*.
-.*   Miss rate:                   *[0-9,\.]*%
+    Hits:                       *[0-9,\.]*...
+    Misses:                     *[0-9,\.]*.
+.*    Miss rate:                *[0-9,\.]*%
 LL stats:
-    Hits:                         *[0-9,\.]*.
-    Misses:                       *[0-9,\.]*..
-.*   Local miss rate:             *[0-9,\.]*%
-    Child hits:                   *[0-9,\.]*...
-    Total miss rate:              *[0-9,\.]*%
+    Hits:                       *[0-9,\.]*.
+    Misses:                     *[0-9,\.]*..
+.*    Local miss rate:          *[0-9,\.]*%
+    Child hits:                 *[0-9,\.]*...
+    Total miss rate:            *[0-9,\.]*%

--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -1,6 +1,15 @@
 pre-DR init
 pre-DR start
 pre-DR detach
+pre-DR init
+pre-DR start
+pre-DR detach
+pre-DR init
+pre-DR start
+pre-DR detach
+pre-DR init
+pre-DR start
+pre-DR detach
 all done
 Cache simulation results:
 Core #0 \([0-4] thread\(s\)\)

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1559,6 +1559,12 @@ event_exit(void)
     if (file_ops_func.exit_cb != NULL)
         (*file_ops_func.exit_cb)(file_ops_func.exit_arg);
 
+    /* Clear callbacks to support reset. */
+    memset(&file_ops_func, 0, sizeof(file_ops_func));
+    if (!offline_instru_t::custom_module_data(nullptr, nullptr, nullptr))
+        DR_ASSERT(false && "failed to clear custom module callbacks");
+    should_trace_thread_cb = nullptr;
+
     if (!dr_raw_tls_cfree(tls_offs, MEMTRACE_TLS_COUNT))
         DR_ASSERT(false);
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2584,7 +2584,7 @@ if (CLIENT_INTERFACE)
         set(tool.drcacheoff.${testname}_precmd
           "foreach@${CMAKE_COMMAND}@-E@remove_directory@drmemtrace.${exetgt}.*.dir")
         set(tool.drcacheoff.${testname}_postcmd
-          "${drcachesim_path}@-indir@drmemtrace.${exetgt}.*.dir${sim_atops}")
+          "firstglob@${drcachesim_path}@-indir@drmemtrace.${exetgt}.*.dir${sim_atops}")
       endmacro()
 
       # We could share drcachesim-simple.templatex if we had the launcher fork

--- a/suite/tests/runmulti.cmake
+++ b/suite/tests/runmulti.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2015-2018 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,8 @@
 # If the command starts with "foreach@", instead of passing the glob-expansion
 # to the single command, the command will be repeated for each expansion entry,
 # and only one such expansion is supported (and it must be at the end).
+# If the command starts with "firstglob@", only the first item in the
+# glob-expansion is passed to the command.
 # If the expansion is empty for precmd, the precmd execution is skipped.
 
 # Intra-arg space=@@ and inter-arg space=@.
@@ -79,11 +81,16 @@ macro(process_cmdline line skip_empty err_and_out)
                 "*** ${${line}} failed (${cmd_result}): ${cmd_err}***\n")
             endif (cmd_result)
           endforeach ()
+        elseif (${line} MATCHES "^firstglob;")
+          list(GET expand 0 head)
+          set(newcmd ${newcmd} ${head})
         else ()
           set(newcmd ${newcmd} ${expand})
         endif ()
       else ()
-        set(newcmd ${newcmd} ${token})
+        if (NOT token STREQUAL "firstglob")
+          set(newcmd ${newcmd} ${token})
+        endif ()
       endif ()
     endforeach ()
     set(${line} ${newcmd})


### PR DESCRIPTION
Resets callback functions to empty at exit to better support re-attach.
Unfortunately i#2175 still prevents extending the thread filter test to
include re-attach.

Issue: #2820