### PR TITLE
i#2845: fix racy nudge_test test output

### DIFF
--- a/suite/tests/client-interface/nudge_test.template
+++ b/suite/tests/client-interface/nudge_test.template
@@ -1,4 +1,7 @@
 thank you for testing the client interface
 nudge delivered 10
 nudge delivered 11
+#ifdef WINDOWS
+MessageBox closed
+#endif
 done

--- a/suite/tests/win32/infloop.c
+++ b/suite/tests/win32/infloop.c
@@ -54,6 +54,6 @@ main(int argc, const char *argv[])
                 "Infloop pid=%d", GetProcessId(GetCurrentProcess()));
     SetTimer(NULL, NULL, 180*1000/*3 mins*/, TimerProc);
     MessageBoxA(NULL, "DynamoRIO test: will be auto-closed", title, MB_OK);
-    print("done\n");
+    print("MessageBox closed\n");
     return 0;
 }


### PR DESCRIPTION
Fixes the nudge_test output to not have two "done" message that result in a
race in runall.cmake.

Issue: #1309
Fixes #2845