### PR TITLE
i#2006 generalize drcachesim: use structs of knobs

### DIFF
--- a/clients/drcachesim/simulator/analyzer_interface.cpp
+++ b/clients/drcachesim/simulator/analyzer_interface.cpp
@@ -52,49 +52,55 @@ analysis_tool_t *
 drmemtrace_analysis_tool_create()
 {
     if (op_simulator_type.get_value() == CPU_CACHE) {
-        return cache_simulator_create(op_num_cores.get_value(),
-                                      op_line_size.get_value(),
-                                      op_L1I_size.get_value(),
-                                      op_L1D_size.get_value(),
-                                      op_L1I_assoc.get_value(),
-                                      op_L1D_assoc.get_value(),
-                                      op_LL_size.get_value(),
-                                      op_LL_assoc.get_value(),
-                                      op_LL_miss_file.get_value(),
-                                      op_replace_policy.get_value(),
-                                      op_data_prefetcher.get_value(),
-                                      op_skip_refs.get_value(),
-                                      op_warmup_refs.get_value(),
-                                      op_warmup_fraction.get_value(),
-                                      op_sim_refs.get_value(),
-                                      op_verbose.get_value());
+        cache_simulator_knobs_t knobs;
+        knobs.num_cores = op_num_cores.get_value();
+        knobs.line_size = op_line_size.get_value();
+        knobs.L1I_size = op_L1I_size.get_value();
+        knobs.L1D_size = op_L1D_size.get_value();
+        knobs.L1I_assoc = op_L1I_assoc.get_value();
+        knobs.L1D_assoc = op_L1D_assoc.get_value();
+        knobs.LL_size = op_LL_size.get_value();
+        knobs.LL_assoc = op_LL_assoc.get_value();
+        knobs.LL_miss_file = op_LL_miss_file.get_value();
+        knobs.replace_policy = op_replace_policy.get_value();
+        knobs.data_prefetcher = op_data_prefetcher.get_value();
+        knobs.skip_refs = op_skip_refs.get_value();
+        knobs.warmup_refs = op_warmup_refs.get_value();
+        knobs.warmup_fraction = op_warmup_fraction.get_value();
+        knobs.sim_refs = op_sim_refs.get_value();
+        knobs.verbose = op_verbose.get_value();
+    return cache_simulator_create(knobs);
     } else if (op_simulator_type.get_value() == TLB) {
-        return tlb_simulator_create(op_num_cores.get_value(),
-                                    op_page_size.get_value(),
-                                    op_TLB_L1I_entries.get_value(),
-                                    op_TLB_L1D_entries.get_value(),
-                                    op_TLB_L1I_assoc.get_value(),
-                                    op_TLB_L1D_assoc.get_value(),
-                                    op_TLB_L2_entries.get_value(),
-                                    op_TLB_L2_assoc.get_value(),
-                                    op_TLB_replace_policy.get_value(),
-                                    op_skip_refs.get_value(),
-                                    op_warmup_refs.get_value(),
-                                    op_warmup_fraction.get_value(),
-                                    op_sim_refs.get_value(),
-                                    op_verbose.get_value());
+        tlb_simulator_knobs_t knobs;
+        knobs.num_cores = op_num_cores.get_value();
+        knobs.page_size = op_page_size.get_value();
+        knobs.TLB_L1I_entries = op_TLB_L1I_entries.get_value();
+        knobs.TLB_L1D_entries = op_TLB_L1D_entries.get_value();
+        knobs.TLB_L1I_assoc = op_TLB_L1I_assoc.get_value();
+        knobs.TLB_L1D_assoc = op_TLB_L1D_assoc.get_value();
+        knobs.TLB_L2_entries = op_TLB_L2_entries.get_value();
+        knobs.TLB_L2_assoc = op_TLB_L2_assoc.get_value();
+        knobs.TLB_replace_policy = op_TLB_replace_policy.get_value();
+        knobs.skip_refs = op_skip_refs.get_value();
+        knobs.warmup_refs = op_warmup_refs.get_value();
+        knobs.warmup_fraction = op_warmup_fraction.get_value();
+        knobs.sim_refs = op_sim_refs.get_value();
+        knobs.verbose = op_verbose.get_value();
+        return tlb_simulator_create(knobs);
     } else if (op_simulator_type.get_value() == HISTOGRAM) {
         return histogram_tool_create(op_line_size.get_value(),
                                      op_report_top.get_value(),
                                      op_verbose.get_value());
     } else if (op_simulator_type.get_value() == REUSE_DIST) {
-        return reuse_distance_tool_create(op_line_size.get_value(),
-                                          op_reuse_distance_histogram.get_value(),
-                                          op_reuse_distance_threshold.get_value(),
-                                          op_report_top.get_value(),
-                                          op_reuse_skip_dist.get_value(),
-                                          op_reuse_verify_skip.get_value(),
-                                          op_verbose.get_value());
+        reuse_distance_knobs_t knobs;
+        knobs.line_size = op_line_size.get_value();
+        knobs.report_histogram = op_reuse_distance_histogram.get_value();
+        knobs.distance_threshold = op_reuse_distance_threshold.get_value();
+        knobs.report_top = op_report_top.get_value();
+        knobs.skip_list_distance = op_reuse_skip_dist.get_value();
+        knobs.verify_skip = op_reuse_verify_skip.get_value();
+        knobs.verbose = op_verbose.get_value();
+        return reuse_distance_tool_create(knobs);
     } else if (op_simulator_type.get_value() == REUSE_TIME) {
         return reuse_time_tool_create(op_line_size.get_value(),
                                       op_verbose.get_value());

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -48,89 +48,40 @@
 #include "cache_simulator.h"
 #include "droption.h"
 
-// XXX i#2006: making this a library means that these options or knobs are
-// duplicated in multiple places as we pass them through the various layers.
-// We lose the convenience of adding a new option and its default value
-// in a single place.
-// It is also error-prone to pass in this long list if we want to set
-// just one option in the middle: should we switch to a struct of options
-// where we can set by field name?
 analysis_tool_t *
-cache_simulator_create(unsigned int num_cores,
-                       unsigned int line_size,
-                       uint64_t L1I_size,
-                       uint64_t L1D_size,
-                       unsigned int L1I_assoc,
-                       unsigned int L1D_assoc,
-                       uint64_t LL_size,
-                       unsigned int LL_assoc,
-                       const std::string &LL_miss_file,
-                       const std::string &replace_policy,
-                       const std::string &data_prefetcher,
-                       uint64_t skip_refs,
-                       uint64_t warmup_refs,
-                       double warmup_fraction,
-                       uint64_t sim_refs,
-                       unsigned int verbose)
+cache_simulator_create(const cache_simulator_knobs_t &knobs)
 {
-    return new cache_simulator_t(num_cores, line_size, L1I_size, L1D_size,
-                                 L1I_assoc, L1D_assoc, LL_size, LL_assoc,
-                                 LL_miss_file, replace_policy, data_prefetcher,
-                                 skip_refs, warmup_refs, warmup_fraction, sim_refs,
-                                 verbose);
+    return new cache_simulator_t(knobs);
 }
 
-cache_simulator_t::cache_simulator_t(unsigned int num_cores,
-                                     unsigned int line_size,
-                                     uint64_t L1I_size,
-                                     uint64_t L1D_size,
-                                     unsigned int L1I_assoc,
-                                     unsigned int L1D_assoc,
-                                     uint64_t LL_size,
-                                     unsigned int LL_assoc,
-                                     const std::string &LL_miss_file,
-                                     const std::string &replace_policy,
-                                     const std::string &data_prefetcher,
-                                     uint64_t skip_refs,
-                                     uint64_t warmup_refs,
-                                     double warmup_fraction,
-                                     uint64_t sim_refs,
-                                     unsigned int verbose) :
-    simulator_t(num_cores, skip_refs, warmup_refs, warmup_fraction, sim_refs, verbose),
-    knob_line_size(line_size),
-    knob_L1I_size(L1I_size),
-    knob_L1D_size(L1D_size),
-    knob_L1I_assoc(L1I_assoc),
-    knob_L1D_assoc(L1D_assoc),
-    knob_LL_size(LL_size),
-    knob_LL_assoc(LL_assoc),
-    knob_LL_miss_file(LL_miss_file),
-    knob_replace_policy(replace_policy),
-    knob_data_prefetcher(data_prefetcher),
+cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs_) :
+    simulator_t(knobs_.num_cores, knobs_.skip_refs, knobs_.warmup_refs,
+                knobs_.warmup_fraction, knobs_.sim_refs, knobs_.verbose),
+    knobs(knobs_),
     icaches(NULL),
     dcaches(NULL),
     is_warmed_up(false)
 {
     // XXX i#1703: get defaults from hardware being run on.
 
-    llcache = create_cache(knob_replace_policy);
+    llcache = create_cache(knobs.replace_policy);
     if (llcache == NULL) {
         success = false;
         return;
     }
 
-    if (data_prefetcher != PREFETCH_POLICY_NEXTLINE &&
-        data_prefetcher != PREFETCH_POLICY_NONE) {
+    if (knobs.data_prefetcher != PREFETCH_POLICY_NEXTLINE &&
+        knobs.data_prefetcher != PREFETCH_POLICY_NONE) {
         // Unknown value.
         success = false;
         return;
     }
 
-    bool warmup_enabled = ((warmup_refs > 0) || (warmup_fraction > 0.0));
+    bool warmup_enabled = ((knobs.warmup_refs > 0) || (knobs.warmup_fraction > 0.0));
 
-    if (!llcache->init(knob_LL_assoc, (int)knob_line_size,
-                       (int)knob_LL_size, NULL,
-                       new cache_stats_t(knob_LL_miss_file, warmup_enabled))) {
+    if (!llcache->init(knobs.LL_assoc, (int)knobs.line_size,
+                       (int)knobs.LL_size, NULL,
+                       new cache_stats_t(knobs.LL_miss_file, warmup_enabled))) {
         ERRMSG("Usage error: failed to initialize LL cache.  Ensure sizes and "
                "associativity are powers of 2, that the total size is a multiple "
                "of the line size, and that any miss file path is writable.\n");
@@ -138,28 +89,28 @@ cache_simulator_t::cache_simulator_t(unsigned int num_cores,
         return;
     }
 
-    icaches = new cache_t* [knob_num_cores];
-    dcaches = new cache_t* [knob_num_cores];
-    for (int i = 0; i < knob_num_cores; i++) {
-        icaches[i] = create_cache(knob_replace_policy);
+    icaches = new cache_t* [knobs.num_cores];
+    dcaches = new cache_t* [knobs.num_cores];
+    for (unsigned int i = 0; i < knobs.num_cores; i++) {
+        icaches[i] = create_cache(knobs.replace_policy);
         if (icaches[i] == NULL) {
             success = false;
             return;
         }
-        dcaches[i] = create_cache(knob_replace_policy);
+        dcaches[i] = create_cache(knobs.replace_policy);
         if (dcaches[i] == NULL) {
             success = false;
             return;
         }
 
-        if (!icaches[i]->init(knob_L1I_assoc, (int)knob_line_size,
-                              (int)knob_L1I_size, llcache,
+        if (!icaches[i]->init(knobs.L1I_assoc, (int)knobs.line_size,
+                              (int)knobs.L1I_size, llcache,
                               new cache_stats_t("", warmup_enabled)) ||
-            !dcaches[i]->init(knob_L1D_assoc, (int)knob_line_size,
-                              (int)knob_L1D_size, llcache,
+            !dcaches[i]->init(knobs.L1D_assoc, (int)knobs.line_size,
+                              (int)knobs.L1D_size, llcache,
                               new cache_stats_t("", warmup_enabled),
-                              data_prefetcher == PREFETCH_POLICY_NEXTLINE ?
-                              new prefetcher_t((int)knob_line_size) : nullptr)) {
+                              knobs.data_prefetcher == PREFETCH_POLICY_NEXTLINE ?
+                              new prefetcher_t((int)knobs.line_size) : nullptr)) {
             ERRMSG("Usage error: failed to initialize L1 caches.  Ensure sizes and "
                    "associativity are powers of 2 "
                    "and that the total sizes are multiples of the line size.\n");
@@ -183,7 +134,7 @@ cache_simulator_t::~cache_simulator_t()
     delete llcache;
     if (icaches == NULL)
         return;
-    for (int i = 0; i < knob_num_cores; i++) {
+    for (unsigned int i = 0; i < knobs.num_cores; i++) {
         // Try to handle failure during construction.
         if (icaches[i] == NULL)
             return;
@@ -205,13 +156,13 @@ cache_simulator_t::~cache_simulator_t()
 bool
 cache_simulator_t::process_memref(const memref_t &memref)
 {
-    if (knob_skip_refs > 0) {
-        knob_skip_refs--;
+    if (knobs.skip_refs > 0) {
+        knobs.skip_refs--;
         return true;
     }
 
     // The references after warmup and simulated ones are dropped.
-    if (check_warmed_up() && knob_sim_refs == 0)
+    if (check_warmed_up() && knobs.sim_refs == 0)
         return true;;
 
     // Both warmup and simulated references are simulated.
@@ -230,7 +181,7 @@ cache_simulator_t::process_memref(const memref_t &memref)
 
     if (type_is_instr(memref.instr.type) ||
         memref.instr.type == TRACE_TYPE_PREFETCH_INSTR) {
-        if (knob_verbose >= 3) {
+        if (knobs.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
                 " @" << (void *)memref.instr.addr << " instr x" <<
                 memref.instr.size << "\n";
@@ -241,7 +192,7 @@ cache_simulator_t::process_memref(const memref_t &memref)
                // We may potentially handle prefetches differently.
                // TRACE_TYPE_PREFETCH_INSTR is handled above.
                type_is_prefetch(memref.data.type)) {
-        if (knob_verbose >= 3) {
+        if (knobs.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
                 " @" << (void *)memref.data.pc <<
                 " " << trace_type_names[memref.data.type] << " " <<
@@ -249,14 +200,14 @@ cache_simulator_t::process_memref(const memref_t &memref)
         }
         dcaches[core]->request(memref);
     } else if (memref.flush.type == TRACE_TYPE_INSTR_FLUSH) {
-        if (knob_verbose >= 3) {
+        if (knobs.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
                 " @" << (void *)memref.data.pc << " iflush " <<
                 (void *)memref.data.addr << " x" << memref.data.size << "\n";
         }
         icaches[core]->flush(memref);
     } else if (memref.flush.type == TRACE_TYPE_DATA_FLUSH) {
-        if (knob_verbose >= 3) {
+        if (knobs.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
                 " @" << (void *)memref.data.pc << " dflush " <<
                 (void *)memref.data.addr << " x" << memref.data.size << "\n";
@@ -266,14 +217,14 @@ cache_simulator_t::process_memref(const memref_t &memref)
         handle_thread_exit(memref.exit.tid);
         last_thread = 0;
     } else if (memref.marker.type == TRACE_TYPE_MARKER) {
-        if (knob_verbose >= 3) {
+        if (knobs.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
                 "marker type " << memref.marker.marker_type <<
                 " value " << memref.marker.marker_value << "\n";
         }
     } else if (memref.marker.type == TRACE_TYPE_INSTR_NO_FETCH) {
         // Just ignore.
-        if (knob_verbose >= 3) {
+        if (knobs.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: " <<
                 " @" << (void *)memref.instr.addr << " non-fetched instr x" <<
                 memref.instr.size << "\n";
@@ -285,16 +236,16 @@ cache_simulator_t::process_memref(const memref_t &memref)
 
     // reset cache stats when warming up is completed
     if (!is_warmed_up && check_warmed_up()) {
-        for (int i = 0; i < knob_num_cores; i++) {
+        for (unsigned int i = 0; i < knobs.num_cores; i++) {
             icaches[i]->get_stats()->reset();
             dcaches[i]->get_stats()->reset();
         }
         llcache->get_stats()->reset();
-        if (knob_verbose >= 1) {
+        if (knobs.verbose >= 1) {
             std::cerr << "Cache simulation warmed up\n";
         }
     } else {
-        knob_sim_refs--;
+        knobs.sim_refs--;
     }
     return true;
 }
@@ -311,17 +262,17 @@ cache_simulator_t::check_warmed_up()
 
     // If the warmup_fraction option is set then check if the last level has
     // loaded enough data to be warmed up.
-    if (knob_warmup_fraction > 0.0 &&
-        llcache->get_loaded_fraction() > knob_warmup_fraction) {
+    if (knobs.warmup_fraction > 0.0 &&
+        llcache->get_loaded_fraction() > knobs.warmup_fraction) {
         is_warmed_up = true;
         return true;
     }
 
     // If warmup_refs is set then decrement and indicate warmup done when
     // counter hits zero.
-    if (knob_warmup_refs > 0) {
-        knob_warmup_refs--;
-        if (knob_warmup_refs == 0) {
+    if (knobs.warmup_refs > 0) {
+        knobs.warmup_refs--;
+        if (knobs.warmup_refs == 0) {
             is_warmed_up = true;
             return true;
         }
@@ -335,7 +286,7 @@ bool
 cache_simulator_t::print_results()
 {
     std::cerr << "Cache simulation results:\n";
-    for (int i = 0; i < knob_num_cores; i++) {
+    for (unsigned int i = 0; i < knobs.num_cores; i++) {
         unsigned int threads = thread_ever_counts[i];
         std::cerr << "Core #" << i << " (" << threads << " thread(s))" << std::endl;
         if (threads > 0) {

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,28 +38,14 @@
 
 #include <unordered_map>
 #include "simulator.h"
+#include "cache_simulator_create.h"
 #include "cache_stats.h"
 #include "cache.h"
 
 class cache_simulator_t : public simulator_t
 {
  public:
-    cache_simulator_t(unsigned int num_cores,
-                      unsigned int line_size,
-                      uint64_t L1I_size,
-                      uint64_t L1D_size,
-                      unsigned int L1I_assoc,
-                      unsigned int L1D_assoc,
-                      uint64_t LL_size,
-                      unsigned int LL_assoc,
-                      const std::string &LL_miss_file,
-                      const std::string &replace_policy,
-                      const std::string &data_prefetcher,
-                      uint64_t skip_refs,
-                      uint64_t warmup_refs,
-                      double warmup_fraction,
-                      uint64_t sim_refs,
-                      unsigned int verbose);
+    cache_simulator_t(const cache_simulator_knobs_t &knobs);
     virtual ~cache_simulator_t();
     virtual bool process_memref(const memref_t &memref);
     virtual bool print_results();
@@ -73,16 +59,7 @@ class cache_simulator_t : public simulator_t
     // Currently we only support a simple 2-level hierarchy.
     // XXX i#1715: add support for arbitrary cache layouts.
 
-    unsigned int knob_line_size;
-    uint64_t knob_L1I_size;
-    uint64_t knob_L1D_size;
-    unsigned int knob_L1I_assoc;
-    unsigned int knob_L1D_assoc;
-    uint64_t knob_LL_size;
-    unsigned int knob_LL_assoc;
-    std::string knob_LL_miss_file;
-    std::string knob_replace_policy;
-    std::string knob_data_prefetcher;
+    cache_simulator_knobs_t knobs;
 
     // Implement a set of ICaches and DCaches with pointer arrays.
     // This is useful for implementing polymorphism correctly.

--- a/clients/drcachesim/simulator/cache_simulator_create.h
+++ b/clients/drcachesim/simulator/cache_simulator_create.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -44,26 +44,48 @@
  */
 
 /**
- * Creates an instance of a cache simulator.
+ * The options for cache_simulator_create().
  * The options are currently documented in \ref sec_drcachesim_ops.
  */
 // The options are currently documented in ../common/options.cpp.
+struct cache_simulator_knobs_t {
+    cache_simulator_knobs_t() :
+        num_cores(4),
+        line_size(64),
+        L1I_size(32*1024U),
+        L1D_size(32*1024U),
+        L1I_assoc(8),
+        L1D_assoc(8),
+        LL_size(8*1024*1024),
+        LL_assoc(16),
+        LL_miss_file(""),
+        replace_policy("LRU"),
+        data_prefetcher("nextline"),
+        skip_refs(0),
+        warmup_refs(0),
+        warmup_fraction(0.0),
+        sim_refs(1ULL << 63),
+        verbose(0) {}
+    unsigned int num_cores;
+    unsigned int line_size;
+    uint64_t L1I_size;
+    uint64_t L1D_size;
+    unsigned int L1I_assoc;
+    unsigned int L1D_assoc;
+    uint64_t LL_size;
+    unsigned int LL_assoc;
+    std::string LL_miss_file;
+    std::string replace_policy;
+    std::string data_prefetcher;
+    uint64_t skip_refs;
+    uint64_t warmup_refs;
+    double warmup_fraction;
+    uint64_t sim_refs;
+    unsigned int verbose;
+};
+
+/** Creates an instance of a cache simulator. */
 analysis_tool_t *
-cache_simulator_create(unsigned int num_cores = 4,
-                       unsigned int line_size = 64,
-                       uint64_t L1I_size = 32*1024U,
-                       uint64_t L1D_size = 32*1024U,
-                       unsigned int L1I_assoc = 8,
-                       unsigned int L1D_assoc = 8,
-                       uint64_t LL_size = 8*1024*1024,
-                       unsigned int LL_assoc = 16,
-                       const std::string &LL_miss_file = "",
-                       const std::string &replace_policy = "LRU",
-                       const std::string &data_prefetcher = "nextline",
-                       uint64_t skip_refs = 0,
-                       uint64_t warmup_refs = 0,
-                       double warmup_fraction = 0.0,
-                       uint64_t sim_refs = 1ULL << 63,
-                       unsigned int verbose = 0);
+cache_simulator_create(const cache_simulator_knobs_t &knobs);
 
 #endif /* _CACHE_SIMULATOR_CREATE_H_ */

--- a/clients/drcachesim/simulator/simulator.cpp
+++ b/clients/drcachesim/simulator/simulator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -77,7 +77,7 @@ simulator_t::core_for_thread(memref_tid_t tid)
     // structure.
     unsigned int min_count = UINT_MAX;
     int min_core = 0;
-    for (int i = 0; i < knob_num_cores; i++) {
+    for (unsigned int i = 0; i < knob_num_cores; i++) {
         if (thread_counts[i] < min_count) {
             min_count = thread_counts[i];
             min_core = i;

--- a/clients/drcachesim/simulator/simulator.h
+++ b/clients/drcachesim/simulator/simulator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -57,7 +57,7 @@ class simulator_t : public analysis_tool_t
     virtual int core_for_thread(memref_tid_t tid);
     virtual void handle_thread_exit(memref_tid_t tid);
 
-    int knob_num_cores;
+    unsigned int knob_num_cores;
 
     // For thread mapping to cores:
     std::unordered_map<memref_tid_t, int> thread2core;

--- a/clients/drcachesim/simulator/tlb_simulator.h
+++ b/clients/drcachesim/simulator/tlb_simulator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,26 +38,14 @@
 
 #include <unordered_map>
 #include "simulator.h"
+#include "tlb_simulator_create.h"
 #include "tlb_stats.h"
 #include "tlb.h"
 
 class tlb_simulator_t : public simulator_t
 {
  public:
-    tlb_simulator_t(unsigned int num_cores,
-                    uint64_t page_size,
-                    unsigned int TLB_L1I_entries,
-                    unsigned int TLB_L1D_entries,
-                    unsigned int TLB_L1I_assoc,
-                    unsigned int TLB_L1D_assoc,
-                    unsigned int TLB_L2_entries,
-                    unsigned int TLB_L2_assoc,
-                    std::string replace_policy,
-                    uint64_t skip_refs,
-                    uint64_t warmup_refs,
-                    double warmup_fraction,
-                    uint64_t sim_refs,
-                    unsigned int verbose);
+    tlb_simulator_t(const tlb_simulator_knobs_t &knobs);
     virtual ~tlb_simulator_t();
     virtual bool process_memref(const memref_t &memref);
     virtual bool print_results();
@@ -66,14 +54,7 @@ class tlb_simulator_t : public simulator_t
     // Create a tlb_t object with a specific replacement policy.
     virtual tlb_t *create_tlb(std::string policy);
 
-    uint64_t knob_page_size;
-    unsigned int knob_TLB_L1I_entries;
-    unsigned int knob_TLB_L1D_entries;
-    unsigned int knob_TLB_L1I_assoc;
-    unsigned int knob_TLB_L1D_assoc;
-    unsigned int knob_TLB_L2_entries;
-    unsigned int knob_TLB_L2_assoc;
-    std::string knob_TLB_replace_policy;
+    tlb_simulator_knobs_t knobs;
 
     // Each CPU core contains a L1 ITLB, L1 DTLB and L2 TLB.
     // All of them are private to the core.

--- a/clients/drcachesim/simulator/tlb_simulator_create.h
+++ b/clients/drcachesim/simulator/tlb_simulator_create.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -44,24 +44,44 @@
  */
 
 /**
- * Creates an instance of a TLB simulator.
+ * The options for tlb_simulator_create().
  * The options are currently documented in \ref sec_drcachesim_ops.
  */
 // The options are currently documented in ../common/options.cpp.
+struct tlb_simulator_knobs_t {
+    tlb_simulator_knobs_t() :
+        num_cores(4),
+        page_size(4*1024),
+        TLB_L1I_entries(32),
+        TLB_L1D_entries(32),
+        TLB_L1I_assoc(32),
+        TLB_L1D_assoc(32),
+        TLB_L2_entries(1024),
+        TLB_L2_assoc(4),
+        TLB_replace_policy("LFU"),
+        skip_refs(0),
+        warmup_refs(0),
+        warmup_fraction(0.0),
+        sim_refs(1ULL << 63),
+        verbose(0) {}
+    unsigned int num_cores;
+    uint64_t page_size;
+    unsigned int TLB_L1I_entries;
+    unsigned int TLB_L1D_entries;
+    unsigned int TLB_L1I_assoc;
+    unsigned int TLB_L1D_assoc;
+    unsigned int TLB_L2_entries;
+    unsigned int TLB_L2_assoc;
+    std::string TLB_replace_policy;
+    uint64_t skip_refs;
+    uint64_t warmup_refs;
+    double warmup_fraction;
+    uint64_t sim_refs;
+    unsigned int verbose;
+};
+
+/** Creates an instance of a TLB simulator. */
 analysis_tool_t *
-tlb_simulator_create(unsigned int num_cores = 4,
-                     uint64_t page_size = 4*1024,
-                     unsigned int TLB_L1I_entries = 32,
-                     unsigned int TLB_L1D_entries = 32,
-                     unsigned int TLB_L1I_assoc = 32,
-                     unsigned int TLB_L1D_assoc = 32,
-                     unsigned int TLB_L2_entries = 1024,
-                     unsigned int TLB_L2_assoc = 4,
-                     std::string replace_policy = "LFU",
-                     uint64_t skip_refs = 0,
-                     uint64_t warmup_refs = 0,
-                     double warmup_fraction = 0.0,
-                     uint64_t sim_refs = 1ULL << 63,
-                     unsigned int verbose = 0);
+tlb_simulator_create(const tlb_simulator_knobs_t &knobs);
 
 #endif /* _TLB_SIMULATOR_CREATE_H_ */

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,10 +39,17 @@
 void
 unit_test_warmup_fraction()
 {
-    cache_simulator_t cache_sim(1, 64, 32*64, 32*64,
-                                32, 32, 32*64,
-                                32, "", "LRU", "none",
-                                0, 0, 0.5, 1ULL << 63, 0);
+    cache_simulator_knobs_t knobs;
+    knobs.num_cores = 1;
+    knobs.L1I_size = 32*64;
+    knobs.L1D_size = 32*64;
+    knobs.L1I_assoc = 32;
+    knobs.L1D_assoc = 32;
+    knobs.LL_size = 32*64;
+    knobs.LL_assoc = 32;
+    knobs.data_prefetcher = "none";
+    knobs.warmup_fraction = 0.5;
+    cache_simulator_t cache_sim(knobs);
 
     // Feed it some memrefs, warmup fraction is set to 0.5 where the capacity at
     // each level is 32 lines each. The first 16 memrefs warm up the cache and
@@ -64,10 +71,17 @@ unit_test_warmup_fraction()
 void
 unit_test_warmup_refs()
 {
-    cache_simulator_t cache_sim(1, 64, 32*64, 32*64,
-                                32, 32, 32*64,
-                                32, "", "LRU", "none",
-                                0, 16, 0.0, 1ULL << 63, 0);
+    cache_simulator_knobs_t knobs;
+    knobs.num_cores = 1;
+    knobs.L1I_size = 32*64;
+    knobs.L1D_size = 32*64;
+    knobs.L1I_assoc = 32;
+    knobs.L1D_assoc = 32;
+    knobs.LL_size = 32*64;
+    knobs.LL_assoc = 32;
+    knobs.data_prefetcher = "none";
+    knobs.warmup_refs = 16;
+    cache_simulator_t cache_sim(knobs);
 
     // Feed it some memrefs, warmup refs = 16 where the capacity at
     // each level is 32 lines each. The first 16 memrefs warm up the cache and

--- a/clients/drcachesim/tools/reuse_distance.h
+++ b/clients/drcachesim/tools/reuse_distance.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -41,6 +41,7 @@
 #include <assert.h>
 #include <iostream>
 #include "analysis_tool.h"
+#include "reuse_distance_create.h"
 #include "memref.h"
 
 // We see noticeable overhead in release build with an if() that directly
@@ -59,13 +60,7 @@ struct line_ref_list_t;
 class reuse_distance_t : public analysis_tool_t
 {
  public:
-    reuse_distance_t(unsigned int line_size,
-                     bool report_histogram,
-                     unsigned int distance_threshold,
-                     unsigned int report_top,
-                     unsigned int skip_list_distance,
-                     bool verify_skip,
-                     unsigned int verbose);
+    reuse_distance_t(const reuse_distance_knobs_t &knobs);
     virtual ~reuse_distance_t();
     virtual bool process_memref(const memref_t &memref);
     virtual bool print_results();
@@ -79,9 +74,7 @@ class reuse_distance_t : public analysis_tool_t
     std::unordered_map<int_least64_t, int_least64_t> dist_map;
     line_ref_list_t *ref_list;
 
-    unsigned int knob_line_size;
-    bool knob_report_histogram;
-    unsigned int knob_report_top; /* most accessed lines */
+    reuse_distance_knobs_t knobs;
 
     uint64_t time_stamp;
     size_t line_size_bits;

--- a/clients/drcachesim/tools/reuse_distance_create.h
+++ b/clients/drcachesim/tools/reuse_distance_create.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,17 +43,30 @@
  */
 
 /**
- * Creates an analysis tool which computes reuse distance.
+ * The options for reuse_distance_tool_create().
  * The options are currently documented in \ref sec_drcachesim_ops.
  */
 // These options are currently documented in ../common/options.cpp.
+struct reuse_distance_knobs_t {
+    reuse_distance_knobs_t() :
+        line_size(64),
+        report_histogram(false),
+        distance_threshold(100),
+        report_top(10),
+        skip_list_distance(500),
+        verify_skip(false),
+        verbose(0) {}
+     unsigned int line_size;
+     bool report_histogram;
+     unsigned int distance_threshold;
+     unsigned int report_top;
+     unsigned int skip_list_distance;
+     bool verify_skip;
+     unsigned int verbose;
+};
+
+/** Creates an analysis tool which computes reuse distance. */
 analysis_tool_t *
-reuse_distance_tool_create(unsigned int line_size = 64,
-                           bool report_histogram = false,
-                           unsigned int distance_threshold = 100,
-                           unsigned int report_top = 10,
-                           unsigned int skip_list_distance = 500,
-                           bool verify_skip = false,
-                           unsigned int verbose = 0);
+reuse_distance_tool_create(const reuse_distance_knobs_t &knobs);
 
 #endif /* _REUSE_DISTANCE_CREATE_H_ */


### PR DESCRIPTION
For tools that have many options, passing a long list of parameters is
cumbersome, error-prone, and difficult to extend with newly added options.
We change cache_simulator, tlb_simulator, and reuse_distance to use a
struct of knobs instead.  Tools with just a couple of options are left
using parameters.

Issue: #2006