### PR TITLE
i#2214 signal locks: avoid memquery when copying signal frame

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -149,7 +149,10 @@ sig_is_alarm_signal(int sig)
  * as seen in kernel sources.
  */
 #define APP_HAS_SIGSTACK(info) \
-  ((info)->app_sigstack.ss_sp != NULL && (info)->app_sigstack.ss_flags != SS_DISABLE)
+    ((info)->app_sigstack.ss_sp != NULL && (info)->app_sigstack.ss_flags != SS_DISABLE)
+
+#define USE_APP_SIGSTACK(info, sig) \
+    (APP_HAS_SIGSTACK(info) && TEST(SA_ONSTACK, (info)->app_sigaction[sig]->flags))
 
 /* If we only intercept a few signals, we leave whether un-intercepted signals
  * are blocked unchanged and stored in the kernel.  If we intercept all (not
@@ -1057,6 +1060,15 @@ share_siginfo_after_take_over(dcontext_t *dcontext, dcontext_t *takeover_dc)
     signal_thread_inherit(dcontext, &crec);
 }
 
+static void
+free_pending_signal(thread_sig_info_t *info, int sig)
+{
+    sigpending_t *temp = info->sigpending[sig];
+    info->sigpending[sig] = temp->next;
+    special_heap_free(info->sigheap, temp);
+    info->num_pending--;
+}
+
 /* This is split from os_fork_init() so the new logfiles are available
  * (xref i#189/PR 452168).  It had to be after dynamo_other_thread_exit()
  * called in dynamorio_fork_init() after os_fork_init() else we clean
@@ -1107,9 +1119,7 @@ signal_fork_init(dcontext_t *dcontext)
         /* "A child created via fork(2) initially has an empty pending signal set" */
         dcontext->signals_pending = 0;
         while (info->sigpending[i] != NULL) {
-            sigpending_t *temp = info->sigpending[i];
-            info->sigpending[i] = temp->next;
-            special_heap_free(info->sigheap, temp);
+            free_pending_signal(info, i);
         }
         info->num_pending = 0;
     }
@@ -2764,8 +2774,8 @@ get_sigstack_frame_ptr(dcontext_t *dcontext, int sig, sigframe_rt_t *frame)
         LOG(THREAD, LOG_ASYNCH, 3, "get_sigstack_frame_ptr: using app xsp "PFX"\n", sp);
     }
 
-    if (APP_HAS_SIGSTACK(info)) {
-        /* app has own signal stack */
+    if (USE_APP_SIGSTACK(info, sig)) {
+        /* app has own signal stack which is enabled for this handler */
         LOG(THREAD, LOG_ASYNCH, 3,
             "get_sigstack_frame_ptr: app has own stack "PFX"\n",
             info->app_sigstack.ss_sp);
@@ -2857,28 +2867,6 @@ convert_frame_to_nonrt(dcontext_t *dcontext, int sig, sigframe_rt_t *f_old,
 # endif /* X86 */
     LOG(THREAD, LOG_ASYNCH, 3, "\tconverted sig=%d rt frame to non-rt frame\n",
         f_new->sig_noclobber);
-}
-
-/* separated out to avoid the stack size cost on the common path */
-static void
-convert_frame_to_nonrt_partial(dcontext_t *dcontext, int sig, sigframe_rt_t *f_old,
-                               sigframe_plain_t *f_new, size_t size)
-{
-# ifdef X86
-    /* We create a full-size buffer for conversion and then copy the partial amount. */
-    byte *frame_and_xstate =
-        heap_alloc(dcontext, sizeof(sigframe_plain_t) + signal_frame_extra_size(true)
-                   HEAPACCT(ACCT_OTHER));
-    sigframe_plain_t *f_plain = (sigframe_plain_t *) frame_and_xstate;
-    ASSERT_NOT_TESTED(); /* XXX: we have no test of this for change to heap_alloc */
-    convert_frame_to_nonrt(dcontext, sig, f_old, f_plain);
-    memcpy(f_new, f_plain, size);
-    heap_free(dcontext, frame_and_xstate, sizeof(sigframe_plain_t) +
-              signal_frame_extra_size(true) HEAPACCT(ACCT_OTHER));
-# elif defined(ARM)
-    /* FIXME i#1551: NYI on ARM */
-    ASSERT_NOT_IMPLEMENTED(false);
-# endif /* X86/ARM */
 }
 #endif
 
@@ -3018,7 +3006,8 @@ copy_frame_to_stack(dcontext_t *dcontext, int sig, sigframe_rt_t *frame, byte *s
 #if defined(LINUX) && defined(X86_32)
     bool has_restorer = sig_has_restorer(info, sig);
 #endif
-    byte *check_pc;
+    byte *flush_pc;
+    bool stack_unwritable = false;
     uint size = frame_size;
 #if defined(LINUX) && defined(X86)
     sigcontext_t *sc = get_sigcontext_from_rt_frame(frame);
@@ -3028,58 +3017,39 @@ copy_frame_to_stack(dcontext_t *dcontext, int sig, sigframe_rt_t *frame, byte *s
     LOG(THREAD, LOG_ASYNCH, 3, "copy_frame_to_stack: rt=%d, src="PFX", sp="PFX"\n",
         rtframe, frame, sp);
 
-    /* before we write to the app's stack we need to see if it's writable */
-    check_pc = (byte *) ALIGN_BACKWARD(sp, PAGE_SIZE);
-    while (check_pc < (byte *)sp + size) {
-        uint prot;
-        DEBUG_DECLARE(bool ok = )
-            get_memory_info(check_pc, NULL, NULL, &prot);
-        ASSERT(ok);
-        if (!TEST(MEMPROT_WRITE, prot)) {
-            size_t rest = (byte *)sp + size - check_pc;
-            if (is_executable_area_writable(check_pc)) {
-                LOG(THREAD, LOG_ASYNCH, 2,
-                    "\tcopy_frame_to_stack: part of stack is unwritable-by-us @"PFX"\n",
-                    check_pc);
-                flush_fragments_and_remove_region(dcontext, check_pc, rest,
-                                                  false /* don't own initexit_lock */,
-                                                  false /* keep futures */);
-            } else {
-                LOG(THREAD, LOG_ASYNCH, 2,
-                    "\tcopy_frame_to_stack: part of stack is unwritable @"PFX"\n",
-                    check_pc);
-                /* copy what we can */
-                if (rtframe)
-                    memcpy(sp, frame, rest);
-#if defined(LINUX) && !defined(X64)
-                else {
-                    convert_frame_to_nonrt_partial(dcontext, sig, frame,
-                                                   (sigframe_plain_t *) sp, rest);
-                }
-#endif
-                /* now throw exception
-                 * FIXME: what give as address?  what does kernel use?
-                 * If the app intercepts SIGSEGV then we'll come right back
-                 * here, so we terminate explicitly instead.  FIXME: set exit
-                 * code properly: xref PR 205310.
-                 */
-                if (info->app_sigaction[SIGSEGV] == NULL)
-                    os_forge_exception(0, UNREADABLE_MEMORY_EXECUTION_EXCEPTION);
-                else
-                    os_terminate(dcontext, TERMINATE_PROCESS);
-                ASSERT_NOT_REACHED();
-            }
+    /* We avoid querying memory as it incurs global contended locks. */
+    flush_pc = is_executable_area_writable_overlap(sp, sp + size);
+    if (flush_pc != NULL) {
+        LOG(THREAD, LOG_ASYNCH, 2,
+            "\tcopy_frame_to_stack: part of stack is unwritable-by-us @"PFX"\n",
+            flush_pc);
+        flush_fragments_and_remove_region(dcontext, flush_pc, sp + size - flush_pc,
+                                          false /* don't own initexit_lock */,
+                                          false /* keep futures */);
+    }
+    TRY_EXCEPT(dcontext, /* try */ {
+        if (rtframe) {
+            ASSERT(frame_size == sizeof(*frame));
+            memcpy_rt_frame(frame, sp, from_pending);
         }
-        check_pc += PAGE_SIZE;
+        IF_NOT_X64(IF_LINUX(
+        else convert_frame_to_nonrt(dcontext, sig, frame, (sigframe_plain_t *) sp);));
+    }, /* except */ {
+        stack_unwritable = true;
+    });
+    if (stack_unwritable) {
+        /* Override the no-nested check in record_pending_signal(): it's ok b/c
+         * receive_pending_signal() calls to here at a consistent point,
+         * and we won't return there.
+         */
+        info->nested_pending_ok = true;
+        /* Just throw away this signal and deliver SIGSEGV instead with the
+         * same sigcontext, like the kernel does.
+         */
+        free_pending_signal(info, sig);
+        os_forge_exception(0, UNREADABLE_MEMORY_EXECUTION_EXCEPTION);
+        ASSERT_NOT_REACHED();
     }
-    if (rtframe) {
-        ASSERT(frame_size == sizeof(*frame));
-        memcpy_rt_frame(frame, sp, from_pending);
-    }
-#if defined(LINUX) && !defined(X64)
-    else
-        convert_frame_to_nonrt(dcontext, sig, frame, (sigframe_plain_t *) sp);
-#endif
 
     /* if !has_restorer we do NOT add the restorer code to the exec list here,
      * to avoid removal problems (if handler never returns) and consistency problems
@@ -3769,6 +3739,7 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
          * just drop this one: should only happen for alarm signal
          */
         (info->accessing_sigpending &&
+         !info->nested_pending_ok &&
          /* we do want to report a crash in receive_pending_signal() */
          (can_always_delay[sig] ||
           is_sys_kill(dcontext, pc, (byte*)sc->SC_XSP, &frame->info)))) {
@@ -5706,6 +5677,10 @@ receive_pending_signal(dcontext_t *dcontext)
                 continue;
             }
             LOG(THREAD, LOG_ASYNCH, 3, "\treceiving signal %d\n", sig);
+            /* execute_handler_from_dispatch()'s call to copy_frame_to_stack() is
+             * allowed to remove the front entry from info->sigpending[sig] and
+             * jump to dispatch.
+             */
             executing = execute_handler_from_dispatch(dcontext, sig);
             temp = info->sigpending[sig];
             info->sigpending[sig] = temp->next;

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -407,6 +407,7 @@ typedef struct _thread_sig_info_t {
     bool multiple_pending_units;
     /* "lock" to prevent interrupting signal from messing up sigpending array */
     bool accessing_sigpending;
+    bool nested_pending_ok;
     kernel_sigset_t app_sigblocked;
     /* for returning the old mask (xref PR 523394) */
     kernel_sigset_t pre_syscall_app_sigblocked;

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -3129,6 +3129,8 @@ mark_executable_area_coarse_frozen(coarse_info_t *frozen)
  */
 static bool
 executable_areas_match_flags(app_pc addr_start, app_pc addr_end, bool *found_area,
+                             /* first_match_start is only set for !are_all_matching */
+                             app_pc *first_match_start,
                              bool are_all_matching /* ALL when true,
                                                       EXISTS when false */,
                              uint match_vm_flags, uint match_frag_flags)
@@ -3154,8 +3156,11 @@ executable_areas_match_flags(app_pc addr_start, app_pc addr_end, bool *found_are
                 return false;
         } else {
             if (TESTALL(match_vm_flags, area->vm_flags) &&
-                TESTALL(match_frag_flags, area->frag_flags))
+                TESTALL(match_frag_flags, area->frag_flags)) {
+                if (first_match_start != NULL)
+                    *first_match_start = area->start;
                 return true;
+            }
         }
         if (area->end < page_end || page_end == NULL)
             page_start = area->end;
@@ -3175,10 +3180,22 @@ is_executable_area_writable(app_pc addr)
     bool writable;
     read_lock(&executable_areas->lock);
     writable = executable_areas_match_flags(addr, addr+1 /* open ended */,
-                                            NULL, false /* EXISTS */,
+                                            NULL, NULL, false /* EXISTS */,
                                             VM_MADE_READONLY, 0);
     read_unlock(&executable_areas->lock);
     return writable;
+}
+
+app_pc
+is_executable_area_writable_overlap(app_pc start, app_pc end)
+{
+    app_pc match_start = NULL;
+    bool writable;
+    read_lock(&executable_areas->lock);
+    writable = executable_areas_match_flags(start, end, NULL, &match_start,
+                                            false /* EXISTS */, VM_MADE_READONLY, 0);
+    read_unlock(&executable_areas->lock);
+    return match_start;
 }
 
 #if defined(DEBUG) /* since only used for a stat right now */
@@ -3191,13 +3208,13 @@ is_executable_area_writable(app_pc addr)
  * whether all regions need to match flags, or whether a matching
  * region exists.
  */
-static bool
-is_executable_area_writable_overlap(app_pc start, app_pc end,
-                                    bool are_all_matching, uint match_vm_flags)
+bool
+is_executable_area_overlap(app_pc start, app_pc end,
+                           bool are_all_matching, uint match_vm_flags)
 {
     bool writable;
     read_lock(&executable_areas->lock);
-    writable = executable_areas_match_flags(start, end, NULL,
+    writable = executable_areas_match_flags(start, end, NULL, NULL,
                                             are_all_matching, match_vm_flags, 0);
     read_unlock(&executable_areas->lock);
     return writable;
@@ -3222,7 +3239,7 @@ executable_vm_area_coarse_overlap(app_pc start, app_pc end)
 {
     bool match;
     read_lock(&executable_areas->lock);
-    match = executable_areas_match_flags(start, end, NULL, false/*exists, not all*/,
+    match = executable_areas_match_flags(start, end, NULL, NULL, false/*exists, not all*/,
                                          0, FRAG_COARSE_GRAIN);
     read_unlock(&executable_areas->lock);
     return match;
@@ -3236,7 +3253,7 @@ executable_vm_area_persisted_overlap(app_pc start, app_pc end)
 {
     bool match;
     read_lock(&executable_areas->lock);
-    match = executable_areas_match_flags(start, end, NULL, false/*exists, not all*/,
+    match = executable_areas_match_flags(start, end, NULL, NULL, false/*exists, not all*/,
                                          VM_PERSISTED_CACHE, 0);
     read_unlock(&executable_areas->lock);
     return match;
@@ -3248,7 +3265,7 @@ executable_vm_area_executed_from(app_pc start, app_pc end)
 {
     bool match;
     read_lock(&executable_areas->lock);
-    match = executable_areas_match_flags(start, end, NULL, false/*exists, not all*/,
+    match = executable_areas_match_flags(start, end, NULL, NULL, false/*exists, not all*/,
                                          VM_EXECUTED_FROM, 0);
     read_unlock(&executable_areas->lock);
     return match;
@@ -3390,7 +3407,7 @@ is_executable_area_on_all_selfmod_pages(app_pc start, app_pc end)
     bool found;
     read_lock(&executable_areas->lock);
     all_selfmod = executable_areas_match_flags(start, end,
-                                               &found, true /* ALL */,
+                                               &found, NULL, true /* ALL */,
                                                0, FRAG_SELFMOD_SANDBOXED);
     read_unlock(&executable_areas->lock);
     /* we require at least one area to be present */
@@ -3409,7 +3426,7 @@ was_executable_area_writable(app_pc addr)
 {
     bool found_area = false, was_writable = false;
     read_lock(&executable_areas->lock);
-    was_writable = executable_areas_match_flags(addr, addr+1, &found_area,
+    was_writable = executable_areas_match_flags(addr, addr+1, &found_area, NULL,
                                                 false /* EXISTS */,
                                                 VM_MADE_READONLY, 0);
     /* seg fault could have happened, then area was made writable before
@@ -6752,9 +6769,9 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
              * consistency purposes.  We haven't implemented this optimization
              * as it's quite rare (though does happen xref case 8104) and
              * previous implementations of this optimization proved buggy. */
-            if (is_executable_area_writable_overlap(base, base + size,
-                                                     true /* ALL regions are: */,
-                                                     VM_WRITABLE|VM_DELAY_READONLY)) {
+            if (is_executable_area_overlap(base, base + size,
+                                           true /* ALL regions are: */,
+                                           VM_WRITABLE|VM_DELAY_READONLY)) {
                 STATS_INC(num_possible_app_to_rwx_skip_flush);
             }
         });

--- a/core/vmareas.h
+++ b/core/vmareas.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -330,6 +330,9 @@ mark_executable_area_coarse_frozen(coarse_info_t *info);
  */
 bool
 is_executable_area_writable(app_pc addr);
+
+app_pc
+is_executable_area_writable_overlap(app_pc start, app_pc end);
 
 /* combines is_executable_area_writable and is_pretend_writable_address */
 bool

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3033,6 +3033,7 @@ if (UNIX)
     tobuild(linux.signal_racesys linux/signal_racesys.c)
     target_link_libraries(linux.signal_racesys rt)
   endif ()
+  tobuild(linux.bad-signal-stack linux/bad-signal-stack.c)
 
   # i#1145: test re-starting syscalls, both inlined and from dispatch
   tobuild(linux.eintr linux/eintr.c)

--- a/suite/tests/linux/bad-signal-stack.c
+++ b/suite/tests/linux/bad-signal-stack.c
@@ -1,0 +1,82 @@
+/* **********************************************************
+ * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "tools.h"
+#include <unistd.h>
+#include <signal.h>
+#include <ucontext.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#define ALT_STACK_SIZE  (SIGSTKSZ*4)
+
+static void
+signal_handler(int sig)
+{
+    print("Got signal %d\n", sig);
+}
+
+int
+main(int argc, char *argv[])
+{
+    char *sp;
+    int rc;
+    INIT();
+
+    /* Make an alternate stack that's not writable. */
+    stack_t sigstack;
+    sigstack.ss_sp = (char *) malloc(ALT_STACK_SIZE);
+    sigstack.ss_size = ALT_STACK_SIZE;
+    sigstack.ss_flags = SS_ONSTACK;
+    rc = sigaltstack(&sigstack, NULL);
+    ASSERT_NOERR(rc);
+    protect_mem((void *)sigstack.ss_sp, ALT_STACK_SIZE, ALLOW_READ);
+
+    /* Test checking for SA_ONSTACK: this one should be delivered to the main
+     * stack and should work.
+     */
+    intercept_signal(SIGUSR1, (handler_3_t) signal_handler, false);
+    print("Sending SIGUSR1\n");
+    kill(getpid(), SIGUSR1);
+
+    /* Now route to the alt stack, which is unwritable and thus should
+     * crash with SIGSEGV, which we handle on the main stack and whose
+     * resumption is the same post-kill point, letting us continue.
+     */
+    intercept_signal(SIGSEGV, (handler_3_t) signal_handler, false);
+    intercept_signal(SIGUSR1, (handler_3_t) signal_handler, true);
+    print("Sending SIGUSR1\n");
+    kill(getpid(), SIGUSR1);
+
+    print("All done\n");
+    return 0;
+}

--- a/suite/tests/linux/bad-signal-stack.expect
+++ b/suite/tests/linux/bad-signal-stack.expect
@@ -1,0 +1,5 @@
+Sending SIGUSR1
+Got signal 10
+Sending SIGUSR1
+Got signal 11
+All done


### PR DESCRIPTION
Eliminates the memory query loop in copy_frame_to_stack() which checks
whether each part of the app stack is writable before copying over the
signal frame.  This loop grabs the global all_memory_areas lock and if that
lookup misses it goes to a maps lookup.  This has shown to cause
noticeable contention.  Instead we perform an overlap check for
is_executable_area_writable followed by a TRY_EXCEPT safe write.

Adds a new test linux.bad-signal-stack which tests this by setting up an
unwritable alternate stack.  It also tests checking for SA_ONSTACK, and we
fix #2017 here to make that work, which is needed for a good test.  The
existing security-common.decode-bad-stack hits the
is_executable_area_writable() case.

Issue: #2214
Fixes #2017