### PR TITLE
i#2066: add double-checked locking for fragment flags.

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -3560,7 +3560,14 @@ unlink_fragment_for_signal(dcontext_t *dcontext, fragment_t *f,
         LOG(THREAD, LOG_ASYNCH, 3,
             "\tunlinking outgoing for interrupted F%d\n", f->id);
         SHARED_FLAGS_RECURSIVE_LOCK(f->flags, acquire, change_linking_lock);
-        unlink_fragment_outgoing(dcontext, f);
+        // Double-check flags to ensure some other thread didn't unlink
+        // while we waited for the change_linking_lock.
+        if (TEST(FRAG_LINKED_OUTGOING, f->flags)) {
+            unlink_fragment_outgoing(dcontext, f);
+            // TODO(during review): should we set `changed`? the code below that
+            // says "already unlinked" is effectively equivalent to this case,
+            // and it doesn't set 'changed'.
+        }
         SHARED_FLAGS_RECURSIVE_LOCK(f->flags, release, change_linking_lock);
         changed = true;
     } else {
@@ -5654,7 +5661,11 @@ receive_pending_signal(dcontext_t *dcontext)
                 info->interrupted->id);
             SHARED_FLAGS_RECURSIVE_LOCK(info->interrupted->flags, acquire,
                                         change_linking_lock);
-            link_fragment_outgoing(dcontext, info->interrupted, false);
+            // Double-check flags to ensure some other thread didn't link
+            // while we waited for the change_linking_lock.
+            if (!TEST(FRAG_LINKED_OUTGOING, info->interrupted->flags)) {
+                link_fragment_outgoing(dcontext, info->interrupted, false);
+            }
             SHARED_FLAGS_RECURSIVE_LOCK(info->interrupted->flags, release,
                                         change_linking_lock);
         }

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -3534,12 +3534,9 @@ unlink_fragment_for_signal(dcontext_t *dcontext, fragment_t *f,
         // while we waited for the change_linking_lock.
         if (TEST(FRAG_LINKED_OUTGOING, f->flags)) {
             unlink_fragment_outgoing(dcontext, f);
-            // TODO(during review): should we set `changed`? the code below that
-            // says "already unlinked" is effectively equivalent to this case,
-            // and it doesn't set 'changed'.
+            changed = true;
         }
         SHARED_FLAGS_RECURSIVE_LOCK(f->flags, release, change_linking_lock);
-        changed = true;
     } else {
         LOG(THREAD, LOG_ASYNCH, 3,
             "\toutgoing already unlinked for interrupted F%d\n", f->id);


### PR DESCRIPTION
In environments where there are a lot of signals being delivered to
threads of a process, there is possibly a race where one thread
links/unlinks while another is waiting to do it themselves. With this
commit, we have threads skip linking/unlinking if they notice another
thread did this (after they have obtained the change_linking_lock).

This fixes an ASSERT I'm hitting with an app:
https://github.com/DynamoRIO/dynamorio/blob/9d9129a/core/link.c#L1896

Issue #2066