### PR TITLE
i#1967 cron builds: set up weekly travis builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -101,3 +101,22 @@ build_script:
   - echo %PATH%
   # The perl in c:\perl can't open a pipe so we use cygwin perl.
   - c:\cygwin\bin\perl ../suite/runsuite_wrapper.pl travis use_ninja %EXTRA_ARGS%
+
+# Automated deployment of builds to GitHub Releases.
+# We rely on a Travis cron job to push a tag to the repo which then
+# triggers this deployment.
+artifacts:
+  - path: build*/DynamoRIO*.zip
+    name: Release package
+    type: zip
+deploy:
+  description: 'Automated periodic Appveyor build'
+  provider: GitHub
+  auth_token:
+    secure: mfNFJ47dV/0CNpg156CiHuK3t6VUNCVhAIYNVkJfwjwY0dbhD1kIdMPfTMdarCnz
+  artifact: build*/DynamoRIO*.zip
+  draft: false
+  prerelease: false
+  on:
+    branch: master
+    appveyor_repo_tag: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -57,33 +57,33 @@ jobs:
     # 32-bit Linux build with gcc and run tests:
     - os: linux
       compiler: gcc
-      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no EXTRA_ARGS=32_only
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLAY=yes EXTRA_ARGS="32_only package"
     # 64-bit Linux build with gcc and run tests:
     - os: linux
       compiler: gcc
-      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no EXTRA_ARGS=64_only
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=yes EXTRA_ARGS="64_only package"
     # AArchXX cross-compile with gcc, no tests:
     - os: linux
       compiler: gcc
-      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=yes
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=yes DEPLOY=no
     # Android ARM cross-compile with gcc, no tests:
     - os: linux
       compiler: gcc
-      env: DYNAMORIO_CROSS_ANDROID_ONLY=yes DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e'
+      env: DYNAMORIO_CROSS_ANDROID_ONLY=yes DEPLOY=no DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e'
     # 32-bit Linux build with clang, no tests (runsuite.cmake disables the tests):
     - os: linux
       compiler: clang
-      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no EXTRA_ARGS=32_only
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=32_only
     # 64-bit Linux build with clang, no tests (runsuite.cmake disables the tests):
     - os: linux
       compiler: clang
-      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no EXTRA_ARGS=64_only
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=64_only
     # 32-bit OSX build with clang and run tests:
     - os: osx
       # gcc on Travis claims to not be CMAKE_COMPILER_IS_GNUCC so we only run clang.
       compiler: clang
       # We do not have 64-bit support on OSX yet (i#1979).
-      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no EXTRA_ARGS=32_only
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=32_only
       # XXX i#2764: Travis OSX resources are over-subscribed and it can take
       # hours to get an OSX machine, so we skip running PR's for now.
       if: type = push
@@ -122,6 +122,27 @@ install:
           cd -
       fi
 
-
 script:
   - suite/runsuite_wrapper.pl travis $EXTRA_ARGS
+
+# For now we create packages as part of each (enabled) job.
+# Longer-term we may want to use package.cmake instead and even make official
+# builds on Travis (i#2861).
+before_deploy:
+  - git config --local user.name "Travis Auto-Tag"
+  - git config --local user.email "dynamorio-devs@googlegroups.com"
+  # XXX: for now we duplicate this version number here with CMakeLists.txt.
+  # We should find a way to share (xref i#1565).
+  - export GIT_TAG="cronbuild-7.0.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+  - git tag $GIT_TAG -a -m "Travis auto-generated tag for build $TRAVIS_BUILD_NUMBER."
+deploy:
+  provider: releases
+  api_key:
+    secure: V3kgcRiwijjpmcSuVio1+/oZ8cqJGaVlL42hN0w/jjO6LoELy2kknT5h80H7wMVKpZnMg+2v/yWj5hawlrwh8nCS51lYllPHN7K+ivzkyJ3R4cp1WAzL56vnYFYz1/twYpeS10Zl6JL6wt788WcibpShMOIlAnXnm1kU9BBVtYE=
+  file_glob: true
+  file: "build*/DynamoRIO*.tar.gz"
+  skip_cleanup: true
+  on:
+    repo: DynamoRIO/dynamorio
+    branch: master
+    condition: $TRAVIS_EVENT_TYPE = cron && $DEPLOY = yes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2018 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -507,7 +507,9 @@ endif (EXISTS "${PROJECT_SOURCE_DIR}/.svn")
 # N.B.: if VERSION_NUMBER's major number is incremented without also
 # incrementing OLDEST_COMPATIBLE_VERSION we'll need to add another
 # symlink loop in core/CMakeLists.txt
-set(VERSION_NUMBER_DEFAULT "6.2.${VERSION_NUMBER_PATCHLEVEL}")
+# N.B.: when updating this, update the git tag in .travis.yml.
+# We should find a way to share (xref i#1565).
+set(VERSION_NUMBER_DEFAULT "7.0.${VERSION_NUMBER_PATCHLEVEL}")
 # do not store the default VERSION_NUMBER in the cache to prevent a stale one
 # from preventing future version updates in a pre-existing build dir
 set(VERSION_NUMBER "" CACHE STRING "Version number: leave empty for default")
@@ -520,12 +522,14 @@ message(STATUS "Version number: ${VERSION_NUMBER}")
 set(BUILD_NUMBER "0" CACHE STRING "Build number (must be <64K)")
 set(UNIQUE_BUILD_NUMBER "0" CACHE STRING "Unique build number")
 set(CUSTOM_PRODUCT_NAME "" CACHE STRING "Custom product name")
+set(PACKAGE_PLATFORM "" CACHE STRING "Platform for package name (should have trailing -)")
 mark_as_advanced(
   VERSION_NUMBER
   VERSION_COMMA_DELIMITED
   BUILD_NUMBER
   UNIQUE_BUILD_NUMBER
   CUSTOM_PRODUCT_NAME
+  PACKAGE_PLATFORM
   )
 # This is hardcoded in globals_shared.h: going to leave it that way, but
 # adding indirection within cmake files
@@ -1922,7 +1926,7 @@ string(REGEX REPLACE
 # having the full version in the base dir is a good thing, though I'm not
 # sure about the caps.
 set(CPACK_PACKAGE_FILE_NAME
-  "DynamoRIO-${CPACK_SYSTEM_NAME}-${CPACK_PACKAGE_VERSION}-${BUILD_NUMBER}")
+  "DynamoRIO-${PACKAGE_PLATFORM}${CPACK_SYSTEM_NAME}-${CPACK_PACKAGE_VERSION}-${BUILD_NUMBER}")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "dynamorio")
 set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "DynamoRIO")
 set(CPACK_PACKAGE_RELOCATABLE "true")

--- a/suite/runsuite_common_pre.cmake
+++ b/suite/runsuite_common_pre.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2011-2018 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -160,6 +160,15 @@ if (arg_ssh)
     GENERATE_PDBS:BOOL=OFF")
 endif (arg_ssh)
 
+# Make it clear that single-bitwidth packages only contain that bitwidth
+# (and provide unique names for Travis deployment).
+if (arg_64_only)
+  set(base_cache "${base_cache}
+      PACKAGE_PLATFORM:STRING=x86_64-")
+elseif (arg_32_only)
+  set(base_cache "${base_cache}
+      PACKAGE_PLATFORM:STRING=i386-")
+endif ()
 if (arg_use_make)
   find_program(MAKE_COMMAND make DOC "make command")
   if (NOT MAKE_COMMAND)
@@ -616,6 +625,7 @@ function(testbuild_ex name is64 initial_cache test_only_in_long
         set(DO_SUBMIT OFF)
         message("Warning: optional cross-compilation \"${name}\" is not available"
           "--skipping")
+        set(add_to_package OFF)
         file(WRITE ${CTEST_BINARY_DIRECTORY}/Testing/missing-cross-compile "${name}")
       endif (optional_cross_compile)
     endif (config_success EQUAL 0)

--- a/suite/runsuite_common_pre.cmake
+++ b/suite/runsuite_common_pre.cmake
@@ -409,7 +409,7 @@ endfunction(get_default_config)
 # + returns the build dir in "last_build_dir"
 # + for each build for which add_to_package is true:
 #   - returns the build dir in "last_package_build_dir"
-#   - prepends to "cpack_projects" for project "${cpack_project_name}"
+#   - adds to "cpack_projects" for project "${cpack_project_name}"
 #     (set by outer file)
 function(testbuild_ex name is64 initial_cache test_only_in_long
     add_to_package build_args)
@@ -687,11 +687,17 @@ function(testbuild_ex name is64 initial_cache test_only_in_long
     # w/ certain params, since they're pretty similar at this point?
     # communicate w/ caller
     set(last_package_build_dir "${CTEST_BINARY_DIRECTORY}" PARENT_SCOPE)
-    # prepend rather than append to get debug first, so we take release
-    # files preferentially in case of overlap
-    set(cpack_projects
-      "\"${CTEST_BINARY_DIRECTORY};${cpack_project_name};ALL;/\"\n  ${cpack_projects}"
-      PARENT_SCOPE)
+    if (CTEST_BINARY_DIRECTORY MATCHES "debug")
+      # prepend rather than append to get debug first, so we take release
+      # files preferentially in case of overlap
+      set(cpack_projects
+        "\"${CTEST_BINARY_DIRECTORY};${cpack_project_name};ALL;/\"\n  ${cpack_projects}"
+        PARENT_SCOPE)
+    else ()
+      set(cpack_projects
+        "${cpack_projects}\n  \"${CTEST_BINARY_DIRECTORY};${cpack_project_name};ALL;/\""
+        PARENT_SCOPE)
+    endif ()
 
     if ("${CTEST_CMAKE_GENERATOR}" MATCHES "Visual Studio")
       # i#390: workaround for cpack limitation where cpack is run w/

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -455,20 +455,26 @@ static bool check_dr_root(const char *dr_root, bool debug,
         "lib64\\release\\dynamorio.dll",
         "lib64\\debug\\dynamorio.dll"
 #elif defined(MACOS)
-        "lib32/debug/libdrpreload.dylib",
-        "lib32/debug/libdynamorio.dylib",
-        "lib32/release/libdrpreload.dylib",
-        "lib32/release/libdynamorio.dylib",
+# ifdef X64
         "lib64/debug/libdrpreload.dylib",
         "lib64/debug/libdynamorio.dylib",
         "lib64/release/libdrpreload.dylib",
         "lib64/release/libdynamorio.dylib"
+# else
+        "lib32/debug/libdrpreload.dylib",
+        "lib32/debug/libdynamorio.dylib",
+        "lib32/release/libdrpreload.dylib",
+        "lib32/release/libdynamorio.dylib",
+# endif
 #else /* LINUX */
         /* With early injection the default, we don't require preload to exist. */
-        "lib32/debug/libdynamorio.so",
-        "lib32/release/libdynamorio.so",
+# ifdef X64
         "lib64/debug/libdynamorio.so",
         "lib64/release/libdynamorio.so"
+# else
+        "lib32/debug/libdynamorio.so",
+        "lib32/release/libdynamorio.so",
+# endif
 #endif
     };
 

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -455,26 +455,20 @@ static bool check_dr_root(const char *dr_root, bool debug,
         "lib64\\release\\dynamorio.dll",
         "lib64\\debug\\dynamorio.dll"
 #elif defined(MACOS)
-# ifdef X64
-        "lib64/debug/libdrpreload.dylib",
-        "lib64/debug/libdynamorio.dylib",
-        "lib64/release/libdrpreload.dylib",
-        "lib64/release/libdynamorio.dylib"
-# else
         "lib32/debug/libdrpreload.dylib",
         "lib32/debug/libdynamorio.dylib",
         "lib32/release/libdrpreload.dylib",
         "lib32/release/libdynamorio.dylib",
-# endif
+        "lib64/debug/libdrpreload.dylib",
+        "lib64/debug/libdynamorio.dylib",
+        "lib64/release/libdrpreload.dylib",
+        "lib64/release/libdynamorio.dylib"
 #else /* LINUX */
         /* With early injection the default, we don't require preload to exist. */
-# ifdef X64
-        "lib64/debug/libdynamorio.so",
-        "lib64/release/libdynamorio.so"
-# else
         "lib32/debug/libdynamorio.so",
         "lib32/release/libdynamorio.so",
-# endif
+        "lib64/debug/libdynamorio.so",
+        "lib64/release/libdynamorio.so"
 #endif
     };
 
@@ -514,8 +508,12 @@ static bool check_dr_root(const char *dr_root, bool debug,
                           "Use -root to specify a proper DynamoRIO root directory.", buf);
                 }
                 return false;
-            } else if (!nowarn) {
-                warn("cannot find %s: is this an incomplete installation?", buf);
+            } else {
+                if (strstr(checked_files[i], arch) == NULL) {
+                    /* Support a single-bitwidth package. */
+                    ok = true;
+                } else if (!nowarn)
+                    warn("cannot find %s: is this an incomplete installation?", buf);
             }
         }
     }


### PR DESCRIPTION
Adds support for Travis builds to produce auto-published package files.
Each job can create its own package file, using existing support in
runsuite*.cmake and package.cmake with some additions here to enable and
tweak that code.  Longer-term we may want to use package.cmake instead and
even make official builds on Travis (i#2861).

Adds Travis deployment to Github Releases of produced packages files.  The
tag is "cronbuild-${VERSION_NUMBER}": e.g., "cronbuild-7.0.17592".

Adds better support for 32-bit-only or 64-bit-only x86 package files by
naming them differently and removing the drrun warnings on incomplete
packages when missing the opposite bitwidth.

Issue: #1967