### PR TITLE
i#1967 cron builds: Appveyor artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -115,7 +115,7 @@ deploy:
   provider: GitHub
   auth_token:
     secure: mfNFJ47dV/0CNpg156CiHuK3t6VUNCVhAIYNVkJfwjwY0dbhD1kIdMPfTMdarCnz
-  artifact: build*/DynamoRIO*.zip
+  artifact: 'build\build_*\DynamoRIO*.zip'
   draft: false
   prerelease: false
   force_update: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -107,7 +107,7 @@ build_script:
 # We rely on a Travis cron job to push a tag to the repo which then
 # triggers this deployment.
 artifacts:
-  - path: build*/DynamoRIO*.zip
+  - path: 'build\build_*\DynamoRIO*.zip'
     name: Release package
     type: zip
 deploy:


### PR DESCRIPTION
Adds the proper path for our package files to be "artifacts" that can then
be deployed to GitHub Releases.

Issue: #1967