### PR TITLE
Make the burst_threads test output matching less flaky

### DIFF
--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -25,8 +25,8 @@ Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
 Core #3 \([0-9] traced CPU\(s\).*
 LL stats:
-    Hits:                       *[0-9,\.]*.
-    Misses:                     *[0-9,\.]*..
+    Hits:                       *[0-9,\.]*
+    Misses:                     *[0-9,\.]*
 .*    Local miss rate:          *[0-9,\.]*%
-    Child hits:                 *[0-9,\.]*...
+    Child hits:                 *[0-9,\.]*
     Total miss rate:            *[0-9,\.]*%


### PR DESCRIPTION
Relaxes the burst_threads output further to handle non-determinism in the
test which had been causing sporadic failures.