### PR TITLE
i#1967 cron builds: do not run tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -106,20 +106,24 @@ build_script:
 # Automated deployment of builds to GitHub Releases.
 # We rely on a Travis cron job to push a tag to the repo which then
 # triggers this deployment.
+# We disable test running for these package builds in runsuite.cmake by
+# looking for $APPVEYOR_REPO_TAG=="true".
 artifacts:
   - path: 'build\build_*\DynamoRIO*.zip'
     name: DR.zip
     type: zip
 deploy:
-  # Using the default "release:" name (the tag) to match Travis.
-  description: 'Auto-generated periodic build (Appveyor build $(appveyor_build_version)).  Unlike official release builds, Dr. Memory is not included in this build, and for Linux, i686 is separated from x86_64 rather than being combined in one package.'
   provider: GitHub
   auth_token:
     secure: mfNFJ47dV/0CNpg156CiHuK3t6VUNCVhAIYNVkJfwjwY0dbhD1kIdMPfTMdarCnz
   artifact: DR.zip
   draft: false
   prerelease: false
+  # We want to use the same release as Travis.
   force_update: true
+  # Using the default "release:" name (the tag) to match Travis.
+  # This description replaces the one provided by Travis.
+  description: 'Auto-generated periodic build (Appveyor build $(appveyor_build_version)).  Unlike official release builds, Dr. Memory is not included in this build, and for Linux, i686 is separated from x86_64 rather than being combined in one package.'
   on:
     branch: master
     appveyor_repo_tag: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,8 @@ script:
   - suite/runsuite_wrapper.pl travis $EXTRA_ARGS
 
 # For now we create packages as part of each (enabled) job.
+# We disable test running for these package builds in runsuite.cmake by
+# looking for $TRAVIS_EVENT_TYPE=="cron".
 # Longer-term we may want to use package.cmake instead and even make official
 # builds on Travis (i#2861).
 before_deploy:
@@ -144,7 +146,9 @@ deploy:
   file_glob: true
   file: "build*/DynamoRIO*.tar.gz"
   skip_cleanup: true
+  # The name must just be the tag in order to match Appveyor.
   name: $GIT_TAG
+  # This body is clobbered by Appveyor.
   body: "Auto-generated periodic build (Travis build $TRAVIS_BUILD_NUMBER).  Unlike official release builds, Dr. Memory is not included in this build, and i686 is separated from x86_64 rather than combined in one package."
   on:
     repo: DynamoRIO/dynamorio

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -51,10 +51,10 @@ set(cross_android_only OFF)
 foreach (arg ${CTEST_SCRIPT_ARG})
   if (${arg} STREQUAL "travis")
     set(arg_travis ON)
-    if ($ENV{DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY} STREQUAL "yes")
+    if ($ENV{DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY} MATCHES "yes")
       set(cross_aarchxx_linux_only ON)
     endif()
-    if ($ENV{DYNAMORIO_CROSS_ANDROID_ONLY} STREQUAL "yes")
+    if ($ENV{DYNAMORIO_CROSS_ANDROID_ONLY} MATCHES "yes")
       set(cross_android_only ON)
     endif()
   elseif (${arg} STREQUAL "package")
@@ -72,8 +72,8 @@ if (arg_travis)
     set(run_tests OFF)
     message("Detected a Travis clang suite: disabling running of tests")
   endif ()
-  if ($ENV{TRAVIS_EVENT_TYPE} STREQUAL "cron" OR
-      $ENV{APPVEYOR_REPO_TAG} STREQUAL "true")
+  if ($ENV{TRAVIS_EVENT_TYPE} MATCHES "cron" OR
+      $ENV{APPVEYOR_REPO_TAG} MATCHES "true")
     # We don't want flaky tests to derail package deployment.  We've already run
     # the tests for this same commit via regular master-push triggers: these
     # package builds are coming from a cron trigger (Travis) or a tag addition

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -72,8 +72,8 @@ if (arg_travis)
     set(run_tests OFF)
     message("Detected a Travis clang suite: disabling running of tests")
   endif ()
-  if ($ENV{TRAVIS_EVENT_TYPE} MATCHES "cron" OR
-      $ENV{APPVEYOR_REPO_TAG} MATCHES "true")
+  if ("$ENV{TRAVIS_EVENT_TYPE}" STREQUAL "cron" OR
+      "$ENV{APPVEYOR_REPO_TAG}" STREQUAL "true")
     # We don't want flaky tests to derail package deployment.  We've already run
     # the tests for this same commit via regular master-push triggers: these
     # package builds are coming from a cron trigger (Travis) or a tag addition

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -51,10 +51,10 @@ set(cross_android_only OFF)
 foreach (arg ${CTEST_SCRIPT_ARG})
   if (${arg} STREQUAL "travis")
     set(arg_travis ON)
-    if ($ENV{DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY} MATCHES "yes")
+    if ($ENV{DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY} STREQUAL "yes")
       set(cross_aarchxx_linux_only ON)
     endif()
-    if ($ENV{DYNAMORIO_CROSS_ANDROID_ONLY} MATCHES "yes")
+    if ($ENV{DYNAMORIO_CROSS_ANDROID_ONLY} STREQUAL "yes")
       set(cross_android_only ON)
     endif()
   elseif (${arg} STREQUAL "package")
@@ -72,6 +72,17 @@ if (arg_travis)
     set(run_tests OFF)
     message("Detected a Travis clang suite: disabling running of tests")
   endif ()
+  if ($ENV{TRAVIS_EVENT_TYPE} STREQUAL "cron" OR
+      $ENV{APPVEYOR_REPO_TAG} STREQUAL "true")
+    # We don't want flaky tests to derail package deployment.  We've already run
+    # the tests for this same commit via regular master-push triggers: these
+    # package builds are coming from a cron trigger (Travis) or a tag addition
+    # (Appveyor), not a code change.
+    # XXX: I'd rather set this in the .yml files but I don't see a way to set
+    # one env var based on another's value there.
+    set(run_tests OFF)
+    message("Detected a cron package build: disabling running of tests")
+  endif()
 endif()
 
 if (TEST_LONG)


### PR DESCRIPTION
We don't want flaky tests to derail package deployment, so we disable test
running for such builds.  We've already run the tests for the same commit
via regular master-push triggers: these package builds are coming from a
cron trigger (Travis) or a tag addition (Appveyor), not a code change.

Issue: #1967