### PR TITLE
i#2751: fix crash in private lib relocs accessing TLS

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -545,11 +545,13 @@ dynamorio_app_init(void)
         }
 #endif /* WINDOWS */
 
+#ifdef WINDOWS
         /* loader initialization, finalize the private lib load.
-         * FIXME i#338: this must be before arch_init() for Windows, but Linux
-         * wants it later.
+         * i#338: this must be before arch_init() for Windows, but Linux
+         * wants it later (i#2751).
          */
         loader_init();
+#endif
         arch_init();
         synch_init();
 
@@ -621,6 +623,10 @@ dynamorio_app_init(void)
 #ifdef UNIX
         /* i#27: we need to special-case the 1st thread */
         signal_thread_inherit(get_thread_private_dcontext(), NULL);
+#endif
+#ifndef WINDOWS
+        /* i#2751: we need TLS to be set up to relocate and call init funcs. */
+        loader_init();
 #endif
 
         /* We move vm_areas_init() below dynamo_thread_init() so we can have

--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2009 Derek Bruening   All rights reserved.
  * *******************************************************************************/
@@ -137,10 +137,6 @@ loader_init(void)
     }
     /* os specific loader initialization epilogue after finalize the load */
     os_loader_init_epilogue();
-    /* FIXME i#338: call loader_thread_init here once get
-     * loader_init called after dynamo_thread_init but in a way that
-     * works with Windows
-     */
     release_recursive_lock(&privload_lock);
 }
 

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1087,13 +1087,11 @@ privload_relocate_mod(privmod_t *mod)
 
     privload_relocate_os_privmod_data(opd, mod->base);
 
-#ifdef LINUX
     /* For the primary thread, we now perform TLS block copying, after relocating.
      * For subsequent threads this is done in privload_tls_init().
      */
     if (opd->tls_block_size != 0)
         privload_mod_tls_primary_thread_init(mod);
-#endif
 
     /* special handling on I/O file */
     if (strstr(mod->name, "libc.so") == mod->name) {

--- a/core/unix/loader_android.c
+++ b/core/unix/loader_android.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -117,6 +117,13 @@ size_of_pthread_internal(void)
 
 void
 privload_mod_tls_init(privmod_t *mod)
+{
+    /* Android does not yet support per-module TLS */
+}
+
+/* Called post-reloc. */
+void
+privload_mod_tls_primary_thread_init(privmod_t *mod)
 {
     /* Android does not yet support per-module TLS */
 }

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1781,6 +1781,7 @@ module_relocate_symbol(ELF_REL_TYPE *rel,
     case ELF_R_IRELATIVE:
         res = (byte *)pd->load_delta + (is_rela ? addend : *r_addr);
         *r_addr =  ((ELF_ADDR (*) (void)) res) ();
+        LOG(GLOBAL, LOG_LOADER, 4, "privmod ifunc reloc %s => "PFX"\n", name, *r_addr);
         break;
 #endif /* ANDROID */
     default:

--- a/core/unix/module_private.h
+++ b/core/unix/module_private.h
@@ -119,4 +119,7 @@ module_init_os_privmod_data_from_dyn(os_privmod_data_t *opd,
                                      ptr_int_t load_delta);
 #endif
 
+void
+privload_mod_thread_tls_init(void);
+
 #endif /* MODULE_PRIVATE_H */


### PR DESCRIPTION
Because relocating can invoke an ifunc which accesses TLS, for UNIX we move
loader_init() to after thread init.  The custom delayed init function
calling is moved back to privload finalization.  The ELF TLS block setup
for the primary thread is moved up to TLS block discovery time and is moved
to after relocation (but before init function calling).  Windows remains
unchanged as it has other ordering requirements (i#338).

Fixes #2751
Issue: #338