### PR TITLE
i#2723 audit debug asserts: use fatal error macro in dynamorio_take_over_threads

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -2861,10 +2861,9 @@ dynamorio_take_over_threads(dcontext_t *dcontext)
     os_process_under_dynamorio_complete(dcontext);
 
     if (found_threads) {
-        SYSLOG(SYSLOG_WARNING, INTERNAL_SYSLOG_WARNING,
-               3, get_application_name(), get_application_pid(),
-               "Failed to take over all threads after multiple attempts");
-        ASSERT_NOT_REACHED();
+        REPORT_FATAL_ERROR_AND_EXIT(dcontext, FAILED_TO_TAKE_OVER_THREADS,
+                                    2, get_application_name(),
+                                    get_application_pid());
     }
     DO_ONCE({
         char buf[16];

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -628,4 +628,12 @@ Application %1!s! (%2!s!). Cannot correctly handle a received signal.
 .
 ;#endif
 
+MessageId =
+Severity = Error
+Facility = DRCore
+SymbolicName = MSG_FAILED_TO_TAKE_OVER_THREADS
+Language=English
+Application %1!s! (%2!s!). Failed to take over all threads after multiple attempts
+.
+
 ;// ADD NEW MESSAGES HERE


### PR DESCRIPTION
Previously, if we weren't able to take over all threads after a few
retries we would have a debug-level assert but otherwise continue on
with running the application. This can cause lots of correctness
problems in the application, and it would be better to cleanly crash
ahead of time rather than wait for an application crash to happen.

Issue #2723