### PR TITLE
i#2037: update memcache on re-takeover and query miss

### DIFF
--- a/core/unix/memcache.c
+++ b/core/unix/memcache.c
@@ -446,7 +446,7 @@ memcache_query_memory(const byte *pc, OUT dr_mem_info_t *out_info)
              * are holes in all_memory_areas
              */
             from_os_prot != MEMPROT_NONE) {
-            SYSLOG_INTERNAL_ERROR_ONCE
+            SYSLOG_INTERNAL_WARNING_ONCE
                 ("all_memory_areas is missing regions including " PFX"-"PFX,
                  from_os_base_pc, from_os_base_pc + from_os_size);
             DOLOG(4, LOG_VMAREAS, memcache_print(THREAD_GET, ""););

--- a/core/unix/memcache.h
+++ b/core/unix/memcache.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -77,5 +77,8 @@ memcache_handle_mremap(dcontext_t *dcontext, byte *base, size_t size,
 
 void
 memcache_handle_app_brk(byte *lowest_brk/*if known*/, byte *old_brk, byte *new_brk);
+
+void
+memcache_update_all_from_os(void);
 
 #endif /* _MEMCACHE_H_ */

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -2597,6 +2597,13 @@ os_process_under_dynamorio_complete(dcontext_t *dcontext)
 {
     /* i#2161: only now do we un-ignore alarm signals. */
     signal_reinstate_alarm_handlers(dcontext);
+    IF_NO_MEMQUERY({
+        /* Update the memory cache (i#2037) now that we've taken over all the
+         * threads, if there may have been a gap between setup and start.
+         */
+        if (dr_api_entry)
+            memcache_update_all_from_os();
+    });
 }
 
 void

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -2116,6 +2116,12 @@ vmvector_reset_vector(dcontext_t *dcontext, vm_area_vector_t *v)
     });
     /* with thread shared cache it is in fact possible to have no thread local vmareas */
     if (v->buf != NULL) {
+        if (v->free_payload_func != NULL) {
+            int i;
+            for (i = 0; i < v->length; i++) {
+                v->free_payload_func(v->buf[i].custom.client);
+            }
+        }
         /* FIXME: walk through and make sure frags lists are all freed */
         global_heap_free(v->buf, v->size*sizeof(struct vm_area_t) HEAPACCT(ACCT_VMAREAS));
         v->size = 0;
@@ -2136,12 +2142,6 @@ vmvector_free_vector(dcontext_t *dcontext, vm_area_vector_t *v)
 void
 vmvector_delete_vector(dcontext_t *dcontext, vm_area_vector_t *v)
 {
-    if (v->free_payload_func != NULL) {
-        int i;
-        for (i = 0; i < v->length; i++) {
-            v->free_payload_func(v->buf[i].custom.client);
-        }
-    }
     vmvector_free_vector(dcontext, v);
     HEAP_TYPE_FREE(dcontext, v, vm_area_vector_t, ACCT_VMAREAS, PROTECTED);
 }


### PR DESCRIPTION
Adds a complete maps file walk to update the memcache on re-taking-over the
process for dr_api_start.  The memcache is cleared beforehand to avoid both
false positives and negatives in later queries.  This helps to solve issues
with a gap between dr_app_setup() and dr_app_start().

Does not update the executable areas or module list: they are more
difficult to re-walk, and existing lazy updates to those will suffice for
now, with a low risk of false positives.

Adds updating of the memcache on a query miss.  Previously we would just
continue to miss and walk the maps file every time.

Tested manually by disabling the i#2114 change so that a signal does a
query, adding signals to the burst_threads test, and calling dr_app_setup()
before creating the test's threads, causing queries to miss when delivering
signals.  It is difficult to create a regression test for this as the
consequences are performance degradations rather than correctness, and
these degradations only really show up at scale with hundreds of threads
whose missing stacks are queried at once with no caching.

Fixes #2037