### PR TITLE
i#2214 signal locks: verify app_sigaction is non-NULL in USE_APP_STACK.

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -151,8 +151,13 @@ sig_is_alarm_signal(int sig)
 #define APP_HAS_SIGSTACK(info) \
     ((info)->app_sigstack.ss_sp != NULL && (info)->app_sigstack.ss_flags != SS_DISABLE)
 
+// Under normal circumstances the app_sigaction is always fully initialized,
+// but during detach there are points where we are still sending/receiving
+// signals after app_sigaction has been set to zeros.
 #define USE_APP_SIGSTACK(info, sig) \
-    (APP_HAS_SIGSTACK(info) && TEST(SA_ONSTACK, (info)->app_sigaction[sig]->flags))
+    (APP_HAS_SIGSTACK(info) \
+     && (info)->app_sigaction[sig] != NULL \
+     && TEST(SA_ONSTACK, (info)->app_sigaction[sig]->flags))
 
 /* If we only intercept a few signals, we leave whether un-intercepted signals
  * are blocked unchanged and stored in the kernel.  If we intercept all (not

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -151,9 +151,11 @@ sig_is_alarm_signal(int sig)
 #define APP_HAS_SIGSTACK(info) \
     ((info)->app_sigstack.ss_sp != NULL && (info)->app_sigstack.ss_flags != SS_DISABLE)
 
-// Under normal circumstances the app_sigaction is always fully initialized,
-// but during detach there are points where we are still sending/receiving
-// signals after app_sigaction has been set to zeros.
+/* Under normal circumstances the app_sigaction is lazily initialized when the
+ * app registers a signal handler, but during detach there are points where we
+ * are still intercepting signals after app_sigaction has been set to
+ * zeros. To be extra defensive, we do a NULL check.
+ */
 #define USE_APP_SIGSTACK(info, sig) \
     (APP_HAS_SIGSTACK(info) \
      && (info)->app_sigaction[sig] != NULL \


### PR DESCRIPTION
As noted in the added code comment, there are points in time where it's
possible that the app_sigaction is NULL for a signal. This PR makes us
more defensive to avoid a crash on an internal unit test.

Issue #2214