### PR TITLE
i#2871: keep app itimers on detach

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -1183,11 +1183,10 @@ signal_thread_exit(dcontext_t *dcontext, bool other_thread)
         os_thread_yield();
     }
 
-    if (dynamo_exited) {
-        /* stop itimers before removing signal handlers */
-        for (i = 0; i < NUM_ITIMERS; i++)
-            set_actual_itimer(dcontext, i, info, false/*disable*/);
-    }
+    /* stop_itimer() was already called by os_thread_not_under_dynamo() called
+     * from dynamo_thread_exit_common().  We need to leave the app itimers in place
+     * in case we're detaching.
+     */
 
 #if defined(X86) && defined(LINUX)
     if (info->xstate_alloc != NULL) {

--- a/suite/tests/api/static_signal.c
+++ b/suite/tests/api/static_signal.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -217,6 +217,12 @@ main(int argc, const char *argv[])
 
     signal_cond_var(thread_exit);
     pthread_join(thread, NULL);
+
+    // i#2871: ensure our itimer is still there.
+    rc = getitimer(ITIMER_PROF, &timer);
+    assert(rc == 0);
+    // We don't compare to 1000 b/c the min may be larger.
+    assert(timer.it_interval.tv_usec > 0);
 
     print("all done\n");
     return 0;


### PR DESCRIPTION
Removes the incorrect removal of all itimers in signal_thread_exit(), which
was disabling app itimers on detach.

Adds a test to api.static_signal.

Fixes #2871