### PR TITLE
Splits the changelist: 7.0.0-RC1 is the official 7.0.0

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -106,8 +106,8 @@ The following are part of the DynamoRIO release distribution:
    and a legacy CPU testing tool (see \ref page_drcpusim).
    If this is a DynamoRIO public release, it also includes the
    Dr. Memory memory debugging tool (see \ref page_drmemory), a system call
-   tracer for Windows (see \ref page_drstrace), and a symbol querying tool
-   (see \ref page_symquery).
+   tracer for Windows (see \ref page_drstrace), a library tracing tool (see
+   \ref page_drltrace), and a symbol querying tool (see \ref page_symquery).
 
 When unpacking the release package on Windows, be aware that the Cygwin
 unzip utility does not preserve executable permissions properly.  After
@@ -132,19 +132,10 @@ Dr. Memory Framework (DRMF) in the same package as DynamoRIO.  DRMF
 provides the umbra, drsyscall, and drsymcache Extensions for use by
 clients.
 
-The changes between version \DR_VERSION and 6.2.0 include the
-following minor compatibility changes:
+The changes between version \DR_VERSION and 6.2.0 include the following minor
+compatibility changes:
 
  - The drltrace tool has been moved to the Dr.Memory Framework.
- - Changed dr_app_stop() to send all threads native instead of only the
-   calling thread.
- - Replaced PAGE_SIZE with dr_page_size() and removed PAGE_START from the API.
-   However, clients may set(DynamoRIO_PAGE_SIZE_COMPATIBILITY ON), in which
-   case definitions of PAGE_SIZE and PAGE_START using dr_page_size() are
-   provided, though code that uses these macros in a constant expression,
-   such as a static initialiser, will still need to be rewritten.
-   DynamoRIO_PAGE_SIZE_COMPATIBILITY will be set automatically if the
-   client targets version 6.2 or earlier.
  - Removed DRMGR_PRIORITY_INSERT_CLS_ENTRY, DRMGR_PRIORITY_INSERT_CLS_EXIT,
    DRMGR_PRIORITY_NAME_CLS_ENTRY, and DRMGR_PRIORITY_NAME_CLS_EXIT, as
    the new kernel xfer event (drmgr_register_kernel_xfer_event()) removes the
@@ -152,28 +143,8 @@ following minor compatibility changes:
 
 Further non-compatibility-affecting changes include:
 
- - Added preliminary AArch64 ARMv8 support: see \ref sec_limits for a
-   description of what is not yet expected to work.
- - Added a static library form of DynamoRIO for use either with
-   auto-takeover or the start/stop API.  The configure_DynamoRIO_static()
-   and use_DynamoRIO_static_client() CMake utilities facilitate this.
- - Enabled \ref page_drcachesim for Windows for single-process applications.
- - Added a module tracking feature \p drmodtrack for quick identification of which
-   library a program counter belongs to and for persistent labeling of
-   modules for post-processing and across library reloads.  This is part of
-   the \p drcovlib Extension.  See #drmodtrack_init() and related functions.
- - Added drx_open_unique_appid_dir().
- - Added #DRX_FILE_SKIP_OPEN.
- - Added %[] support to dr_sscanf.
- - Added dr_map_executable_file() and dr_unmap_executable_file().
- - Added dr_get_microseconds().
- - Added #DR_CLEANCALL_ALWAYS_OUT_OF_LINE.
- - Added instr_create_4dst_2src().
- - Added drreg_restore_app_values() and drreg_restore_app_aflags().
- - Added drx_tail_pad_block().
- - Added XINST_CREATE_add_sll(), XINST_CREATE_load_1byte_zext4(),
-   XINST_CREATE_jump_cond(), and XINST_CREATE_slr_s().
  - Added drx_buf_insert_buf_memcpy().
+ - Added XINST_CREATE_add_sll(), XINST_CREATE_jump_cond(), and XINST_CREATE_slr_s().
  - Added thread synchronization events via dr_event_create(), dr_event_destroy(),
    dr_event_wait(), dr_event_signal(), and dr_event_reset().
  - Added drmodtrack customization via drmodtrack_add_custom_data() and
@@ -189,6 +160,7 @@ Further non-compatibility-affecting changes include:
    raw2trace_t::find_mapped_trace_address().
    A corresponding CMake function for finding the
    tracer customization header is use_DynamoRIO_drmemtrace_tracer().
+ - Added drreg_restore_app_aflags().
  - Added a set_value() function to the \ref page_droption.
  - Added instrlist_get_auto_predicate() and instrlist_set_auto_predicate().
  - Globally enabled auto predication in the drmgr instrumentation insertion event by
@@ -238,6 +210,49 @@ Further non-compatibility-affecting changes include:
    physical cpus.
  - Added #DR_DISALLOW_UNSAFE_STATIC and dr_disallow_unsafe_static_behavior()
    for sanity checks to help support statically-linked clients.
+
+**************************************************
+<hr>
+
+Version 7.0.0 includes Dr. Memory and the Dr. Memory Framework (DRMF) in
+the same package as DynamoRIO.  DRMF provides the umbra, drsyscall, and
+drsymcache Extensions for use by clients.
+
+The changes between version 7.0.0 and 6.2.0 include the following minor
+compatibility changes:
+
+ - Changed dr_app_stop() to send all threads native instead of only the
+   calling thread.
+ - Replaced PAGE_SIZE with dr_page_size() and removed PAGE_START from the API.
+   However, clients may set(DynamoRIO_PAGE_SIZE_COMPATIBILITY ON), in which
+   case definitions of PAGE_SIZE and PAGE_START using dr_page_size() are
+   provided, though code that uses these macros in a constant expression,
+   such as a static initialiser, will still need to be rewritten.
+   DynamoRIO_PAGE_SIZE_COMPATIBILITY will be set automatically if the
+   client targets version 6.2 or earlier.
+
+Further non-compatibility-affecting changes include:
+
+ - Added preliminary AArch64 ARMv8 support: see \ref sec_limits for a
+   description of what is not yet expected to work.
+ - Added a static library form of DynamoRIO for use either with
+   auto-takeover or the start/stop API.  The configure_DynamoRIO_static()
+   and use_DynamoRIO_static_client() CMake utilities facilitate this.
+ - Enabled \ref page_drcachesim for Windows for single-process applications.
+ - Added a module tracking feature \p drmodtrack for quick identification of which
+   library a program counter belongs to and for persistent labeling of
+   modules for post-processing and across library reloads.  This is part of
+   the \p drcovlib Extension.  See #drmodtrack_init() and related functions.
+ - Added drx_open_unique_appid_dir().
+ - Added #DRX_FILE_SKIP_OPEN.
+ - Added %[] support to dr_sscanf.
+ - Added dr_map_executable_file() and dr_unmap_executable_file().
+ - Added dr_get_microseconds().
+ - Added #DR_CLEANCALL_ALWAYS_OUT_OF_LINE.
+ - Added instr_create_4dst_2src().
+ - Added drreg_restore_app_values() and drreg_restore_app_aflags().
+ - Added drx_tail_pad_block().
+ - Added XINST_CREATE_load_1byte_zext4().
 
 **************************************************
 <hr>

--- a/api/docs/tool.gendox
+++ b/api/docs/tool.gendox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -48,6 +48,7 @@ the section \ref tool_frontend.
 REPLACE_WITH_GENDOX_SUBPAGES
 - \subpage page_drmemory
 - \subpage page_drstrace
+- \subpage page_drltrace
 - \subpage page_symquery
 */
 
@@ -76,6 +77,17 @@ should point at the local documentation provided with the release package.
 included with DynamoRIO versions 5.0.0 and higher.  If this documentation
 is part of a DynamoRIO public release, <a
 href="../../drmemory/drmemory/docs/html/page_drstrace.html">this link</a> should
+point at the local documentation provided with the release package.
+*/
+
+/**
+\page page_drltrace Library Call Tracer
+
+\p drltrace is a library call tracing tool for all platforms.  It is part of the
+<a href="http://drmemory.org">Dr. Memory tool suite</a>.  It is also
+included with DynamoRIO versions 5.0.0 and higher.  If this documentation
+is part of a DynamoRIO public release, <a
+href="../../drmemory/drmemory/docs/html/page_drltrace.html">this link</a> should
 point at the local documentation provided with the release package.
 */
 


### PR DESCRIPTION
Given the time since the RC1 we're retroactively considering it to be an
official release.  The base version was bumped to 7.0 already in ad850c4.
Here we split the changelist.  Additionally I added the missing
page_drltrace page to match page_drstrace.