### PR TITLE
Rename exposed LOG_xxx macros to DR_LOG_xxx

### DIFF
--- a/api/docs/API.doxy
+++ b/api/docs/API.doxy
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
 # Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
 # **********************************************************/
 
@@ -210,7 +210,7 @@ EXPAND_ONLY_PREDEF     = YES
 SEARCH_INCLUDES        = YES
 INCLUDE_PATH           =
 INCLUDE_FILE_PATTERNS  =
-PREDEFINED             = WINDOWS UNIX LINUX X64 X86 ARM ANDROID DYNAMORIO_API DR_PAGE_SIZE_COMPATIBILITY AARCHXX AARCH64
+PREDEFINED             = WINDOWS UNIX LINUX X64 X86 ARM ANDROID DYNAMORIO_API DR_PAGE_SIZE_COMPATIBILITY DR_LOG_DEFINE_COMPATIBILITY AARCHXX AARCH64
 EXPAND_AS_DEFINED      = IF_X64_ELSE
 SKIP_FUNCTION_MACROS   = YES
 #---------------------------------------------------------------------------

--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -1858,8 +1858,8 @@ Options available only in the debug build of DynamoRIO:
 \anchor op_logmask
  - \b -logmask \e 0xN:
     Selects which DynamoRIO modules print out logging information, at the
-    -loglevel level.  The mask is a combination of the LOG_ bitfields
-    listed in dr_tools.h (#LOG_ALL selects all modules).
+    -loglevel level.  The mask is a combination of the DR_LOG_ bitfields
+    listed in dr_tools.h (#DR_LOG_ALL selects all modules).
 
 \anchor op_logdir
  - \b -logdir \e \<path\>:

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -140,6 +140,11 @@ compatibility changes:
    DRMGR_PRIORITY_NAME_CLS_ENTRY, and DRMGR_PRIORITY_NAME_CLS_EXIT, as
    the new kernel xfer event (drmgr_register_kernel_xfer_event()) removes the
    need for them.
+ - Renamed the LOG_ macros (#LOG_NONE, #LOG_ALL, etc.) to have a DR_ prefix
+   to avoid name conflicts.  Clients should set(DynamoRIO_LOG_COMPATIBILITY ON)
+   prior to configure_DynamoRIO_client() to use the old constants and avoid
+   any source changes; this will happen automatically if the client
+   targets version 7.0.0 or earlier.  Binary compatibility is unaffected.
 
 Further non-compatibility-affecting changes include:
 

--- a/api/docs/samples.dox
+++ b/api/docs/samples.dox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -217,7 +217,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
   dr_register_bb_event(event_basic_block);
 
   /* make it easy to tell, by looking at log file, which client executed */
-  dr_log(NULL, LOG_ALL, 1, "Client 'countcalls' initializing\n");
+  dr_log(NULL, DR_LOG_ALL, 1, "Client 'countcalls' initializing\n");
 }
 \endcode
 
@@ -251,7 +251,7 @@ static void event_thread_init(void *drcontext)
   data->num_direct_calls = 0;
   data->num_indirect_calls = 0;
   data->num_returns = 0;
-  dr_log(drcontext, LOG_ALL, 1, "countcalls: set up for thread "TIDFMT"\n",
+  dr_log(drcontext, DR_LOG_ALL, 1, "countcalls: set up for thread "TIDFMT"\n",
          dr_get_thread_id(drcontext));
 }
 

--- a/api/samples/bbcount.c
+++ b/api/samples/bbcount.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -148,7 +148,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         DR_ASSERT(false);
 
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client 'bbcount' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'bbcount' initializing\n");
 #ifdef SHOW_RESULTS
     /* also give notification to stderr */
     if (dr_is_notify_on()) {

--- a/api/samples/cbrtrace.c
+++ b/api/samples/cbrtrace.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -95,7 +95,7 @@ event_thread_exit(void *drcontext)
 static void
 event_exit(void)
 {
-    dr_log(NULL, LOG_ALL, 1, "Client 'cbrtrace' exiting");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'cbrtrace' exiting");
 #ifdef SHOW_RESULTS
     if (dr_is_notify_on())
         dr_fprintf(STDERR, "Client 'cbrtrace' exiting\n");
@@ -111,7 +111,7 @@ void dr_client_main(client_id_t id, int argc, const char *argv[])
 {
     dr_set_client_name("DynamoRIO Sample Client 'cbrtrace'",
                        "http://dynamorio.org/issues");
-    dr_log(NULL, LOG_ALL, 1, "Client 'cbrtrace' initializing");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'cbrtrace' initializing");
 
     drmgr_init();
 

--- a/api/samples/countcalls.c
+++ b/api/samples/countcalls.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -90,7 +90,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     tls_idx = drmgr_register_tls_field();
 
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client 'countcalls' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'countcalls' initializing\n");
 #ifdef SHOW_RESULTS
     /* also give notification to stderr */
     if (dr_is_notify_on()) {
@@ -145,7 +145,7 @@ event_thread_init(void *drcontext)
     data->num_direct_calls = 0;
     data->num_indirect_calls = 0;
     data->num_returns = 0;
-    dr_log(drcontext, LOG_ALL, 1, "countcalls: set up for thread "TIDFMT"\n",
+    dr_log(drcontext, DR_LOG_ALL, 1, "countcalls: set up for thread "TIDFMT"\n",
            dr_get_thread_id(drcontext));
 }
 

--- a/api/samples/inc2add.c
+++ b/api/samples/inc2add.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -98,7 +98,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     enable = true;
 
     /* Make it easy to tell by looking at the log file which client executed. */
-    dr_log(NULL, LOG_ALL, 1, "Client 'inc2add' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'inc2add' initializing\n");
 #ifdef SHOW_RESULTS
     /* Also give notification to stderr */
     if (dr_is_notify_on()) {

--- a/api/samples/inline.c
+++ b/api/samples/inline.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -134,7 +134,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     dr_register_end_trace_event(query_end_trace);
 
     /* Make it easy to tell from the log file which client executed. */
-    dr_log(NULL, LOG_ALL, 1, "Client 'inline' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'inline' initializing\n");
 #ifdef SHOW_RESULTS
     /* also give notification to stderr */
     if (dr_is_notify_on()) {
@@ -196,7 +196,7 @@ event_analyze_bb(void *drcontext, void *tag, instrlist_t *bb,
             e->is_trace_head = true;
             hashtable_unlock(&head_table);
 #ifdef VERBOSE
-            dr_log(drcontext, LOG_ALL, 3,
+            dr_log(drcontext, DR_LOG_ALL, 3,
                    "inline: marking bb "PFX" as call trace head\n", tag);
 #endif
             /* Doesn't matter what's in rest of the bb. */
@@ -213,7 +213,7 @@ event_analyze_bb(void *drcontext, void *tag, instrlist_t *bb,
             e->has_ret = true;
             hashtable_unlock(&head_table);
 #ifdef VERBOSE
-            dr_log(drcontext, LOG_ALL, 3,
+            dr_log(drcontext, DR_LOG_ALL, 3,
                    "inline: marking bb "PFX" as return trace head\n", tag);
 #endif
         }
@@ -265,7 +265,7 @@ query_end_trace(void *drcontext, void *trace_tag, void *next_tag)
              * end up never entering the call trace.
              */
 #ifdef VERBOSE
-            dr_log(drcontext, LOG_ALL, 3,
+            dr_log(drcontext, DR_LOG_ALL, 3,
                    "inline: ending trace "PFX" before block "PFX" containing call\n",
                    trace_tag, next_tag);
 #endif
@@ -279,7 +279,7 @@ query_end_trace(void *drcontext, void *trace_tag, void *next_tag)
         e->end_next--;
         if (e->end_next == 0) {
 #ifdef VERBOSE
-            dr_log(drcontext, LOG_ALL, 3,
+            dr_log(drcontext, DR_LOG_ALL, 3,
                    "inline: ending trace "PFX" before "PFX"\n",
                    trace_tag, next_tag);
 #endif
@@ -296,7 +296,7 @@ query_end_trace(void *drcontext, void *trace_tag, void *next_tag)
         e->size += size;
         if (e->size > INLINE_SIZE_LIMIT) {
 #ifdef VERBOSE
-            dr_log(drcontext, LOG_ALL, 3,
+            dr_log(drcontext, DR_LOG_ALL, 3,
                    "inline: ending trace "PFX" before "PFX" because reached size limit\n",
                    trace_tag, next_tag);
 #endif
@@ -310,7 +310,7 @@ query_end_trace(void *drcontext, void *trace_tag, void *next_tag)
             /* End trace after NEXT block */
             e->end_next = 2;
 #ifdef VERBOSE
-            dr_log(drcontext, LOG_ALL, 3,
+            dr_log(drcontext, DR_LOG_ALL, 3,
                    "inline: going to be ending trace "PFX" after "PFX"\n",
                    trace_tag, next_tag);
 #endif
@@ -320,7 +320,7 @@ query_end_trace(void *drcontext, void *trace_tag, void *next_tag)
     }
     /* Do not end trace */
 #ifdef VERBOSE
-    dr_log(drcontext, LOG_ALL, 3,
+    dr_log(drcontext, DR_LOG_ALL, 3,
            "inline: NOT ending trace "PFX" after "PFX"\n", trace_tag, next_tag);
 #endif
     hashtable_unlock(&head_table);

--- a/api/samples/inscount.cpp
+++ b/api/samples/inscount.cpp
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -108,7 +108,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
                                             NULL);
 
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client 'inscount' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'inscount' initializing\n");
 #ifdef SHOW_RESULTS
     /* also give notification to stderr */
     if (dr_is_notify_on()) {

--- a/api/samples/instrace_simple.c
+++ b/api/samples/instrace_simple.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * ******************************************************************************/
 
@@ -290,7 +290,7 @@ event_thread_exit(void *drcontext)
 static void
 event_exit(void)
 {
-    dr_log(NULL, LOG_ALL, 1, "Client 'instrace' num refs seen: "SZFMT"\n", num_refs);
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'instrace' num refs seen: "SZFMT"\n", num_refs);
     if (!dr_raw_tls_cfree(tls_offs, INSTRACE_TLS_COUNT))
         DR_ASSERT(false);
 
@@ -336,5 +336,5 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     if (!dr_raw_tls_calloc(&tls_seg, &tls_offs, INSTRACE_TLS_COUNT, 0))
         DR_ASSERT(false);
 
-    dr_log(NULL, LOG_ALL, 1, "Client 'instrace' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'instrace' initializing\n");
 }

--- a/api/samples/instrace_x86.c
+++ b/api/samples/instrace_x86.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * ******************************************************************************/
 
@@ -139,7 +139,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     DR_ASSERT(tls_index != -1);
 
     code_cache_init();
-    dr_log(NULL, LOG_ALL, 1, "Client 'instrace' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'instrace' initializing\n");
 #ifdef SHOW_RESULTS
     if (dr_is_notify_on()) {
 # ifdef WINDOWS

--- a/api/samples/instrcalls.c
+++ b/api/samples/instrcalls.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -77,7 +77,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     drmgr_init();
     my_id = id;
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client 'instrcalls' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'instrcalls' initializing\n");
     /* also give notification to stderr */
 #ifdef SHOW_RESULTS
     if (dr_is_notify_on()) {
@@ -94,7 +94,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     drmgr_register_thread_exit_event(event_thread_exit);
 #ifdef SHOW_SYMBOLS
     if (drsym_init(0) != DRSYM_SUCCESS) {
-        dr_log(NULL, LOG_ALL, 1, "WARNING: unable to initialize symbol translation\n");
+        dr_log(NULL, DR_LOG_ALL, 1, "WARNING: unable to initialize symbol translation\n");
     }
 #endif
     tls_idx = drmgr_register_tls_field();
@@ -106,7 +106,7 @@ event_exit(void)
 {
 #ifdef SHOW_SYMBOLS
     if (drsym_exit() != DRSYM_SUCCESS) {
-        dr_log(NULL, LOG_ALL, 1, "WARNING: error cleaning up symbol library\n");
+        dr_log(NULL, DR_LOG_ALL, 1, "WARNING: error cleaning up symbol library\n");
     }
 #endif
     drmgr_unregister_tls_field(tls_idx);

--- a/api/samples/memtrace_simple.c
+++ b/api/samples/memtrace_simple.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * ******************************************************************************/
 
@@ -399,7 +399,7 @@ event_thread_exit(void *drcontext)
 static void
 event_exit(void)
 {
-    dr_log(NULL, LOG_ALL, 1, "Client 'memtrace' num refs seen: "SZFMT"\n", num_refs);
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'memtrace' num refs seen: "SZFMT"\n", num_refs);
     if (!dr_raw_tls_cfree(tls_offs, MEMTRACE_TLS_COUNT))
         DR_ASSERT(false);
 
@@ -449,5 +449,5 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         DR_ASSERT(false);
 
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client 'memtrace' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'memtrace' initializing\n");
 }

--- a/api/samples/memtrace_x86.c
+++ b/api/samples/memtrace_x86.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * ******************************************************************************/
 
@@ -157,7 +157,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 
     code_cache_init();
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client 'memtrace' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'memtrace' initializing\n");
 #ifdef SHOW_RESULTS
     if (dr_is_notify_on()) {
 # ifdef WINDOWS

--- a/api/samples/memval_simple.c
+++ b/api/samples/memval_simple.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -464,5 +464,5 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     DR_ASSERT(tls_idx != -1 && trace_buffer != NULL && write_buffer != NULL);
 
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client 'memval' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'memval' initializing\n");
 }

--- a/api/samples/modxfer.c
+++ b/api/samples/modxfer.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -184,7 +184,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 
     DR_ASSERT(logfile != INVALID_FILE);
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client 'modxfer' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'modxfer' initializing\n");
 #ifdef SHOW_RESULTS
     /* also give notification to stderr */
     if (dr_is_notify_on()) {

--- a/api/samples/modxfer_app2lib.c
+++ b/api/samples/modxfer_app2lib.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -122,7 +122,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         DR_ASSERT(false);
 
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client 'modxfer_app2lib' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'modxfer_app2lib' initializing\n");
 #ifdef SHOW_RESULTS
     /* also give notification to stderr */
     if (dr_is_notify_on()) {

--- a/api/samples/opcodes.c
+++ b/api/samples/opcodes.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -102,7 +102,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         DR_ASSERT(false);
 
     /* Make it easy to tell from the log file which client executed. */
-    dr_log(NULL, LOG_ALL, 1, "Client 'opcodes' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'opcodes' initializing\n");
 #ifdef SHOW_RESULTS
     /* Also give notification to stderr. */
     if (dr_is_notify_on()) {

--- a/api/samples/prefetch.c
+++ b/api/samples/prefetch.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -70,7 +70,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     }
 
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client 'prefetch' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'prefetch' initializing\n");
 
     /* must create the counting mutex */
     count_mutex = dr_mutex_create();
@@ -79,7 +79,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 static void
 event_exit(void)
 {
-    dr_log(NULL, LOG_ALL, 1, "Removed %d prefetches and %d prefetchws.\n",
+    dr_log(NULL, DR_LOG_ALL, 1, "Removed %d prefetches and %d prefetchws.\n",
            prefetches_removed, prefetchws_removed);
     dr_mutex_destroy(count_mutex);
     drmgr_exit();

--- a/api/samples/ssljack.c
+++ b/api/samples/ssljack.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -111,7 +111,7 @@ dr_init(client_id_t id)
 {
     dr_set_client_name("DynamoRIO client 'ssljack'", "http://dynamorio.org/issues");
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client ssljack initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client ssljack initializing\n");
 #ifdef SHOW_RESULTS
     if (dr_is_notify_on()) {
         dr_fprintf(STDERR, "Client ssljack running! See trace-* files for SSL logs!\n");

--- a/api/samples/stats.c
+++ b/api/samples/stats.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -189,7 +189,7 @@ shared_memory_init(void)
             break;
         num++;
     }
-    dr_log(NULL, LOG_ALL, 1, "Shared memory key is: \"%S\"\n", shared_keyname);
+    dr_log(NULL, DR_LOG_ALL, 1, "Shared memory key is: \"%S\"\n", shared_keyname);
 #ifdef SHOW_RESULTS
     dr_fprintf(STDERR, "Shared memory key is: \"%S\"\n", shared_keyname);
 #endif
@@ -241,7 +241,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     dr_set_client_name("DynamoRIO Sample Client 'stats'", "http://dynamorio.org/issues");
     my_id = id;
     /* Make it easy to tell by looking at the log which client executed. */
-    dr_log(NULL, LOG_ALL, 1, "Client 'stats' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'stats' initializing\n");
 
     if (!drmgr_init())
         DR_ASSERT(false);

--- a/api/samples/utils.c
+++ b/api/samples/utils.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2013-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -79,7 +79,7 @@ log_file_open(client_id_t id, void *drcontext,
         len = dr_snprintf(msg, BUFFER_SIZE_ELEMENTS(msg), "Data file %s created", buf);
         DR_ASSERT(len > 0);
         NULL_TERMINATE_BUFFER(msg);
-        dr_log(drcontext, LOG_ALL, 1, "%s", msg);
+        dr_log(drcontext, DR_LOG_ALL, 1, "%s", msg);
 #ifdef SHOW_RESULTS
         DISPLAY_STRING(msg);
 # ifdef WINDOWS

--- a/api/samples/wrap.c
+++ b/api/samples/wrap.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -99,7 +99,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 {
     dr_set_client_name("DynamoRIO Sample Client 'wrap'", "http://dynamorio.org/issues");
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client 'wrap' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'wrap' initializing\n");
     /* also give notification to stderr */
 #ifdef SHOW_RESULTS
     if (dr_is_notify_on()) {

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1543,7 +1543,7 @@ event_thread_exit(void *drcontext)
 static void
 event_exit(void)
 {
-    dr_log(NULL, LOG_ALL, 1, "drcachesim num refs seen: " UINT64_FORMAT_STRING"\n",
+    dr_log(NULL, DR_LOG_ALL, 1, "drcachesim num refs seen: " UINT64_FORMAT_STRING"\n",
            num_refs);
     NOTIFY(1, "drmemtrace exiting process " PIDFMT"; traced " UINT64_FORMAT_STRING
            " references.\n", dr_get_process_id(), num_refs);
@@ -1810,7 +1810,7 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
         DR_ASSERT(false);
 
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "drcachesim client initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "drcachesim client initializing\n");
 
     if (op_use_physical.get_value()) {
         have_phys = physaddr.init();

--- a/core/lib/genapi.pl
+++ b/core/lib/genapi.pl
@@ -1,7 +1,7 @@
 #!/usr/local/bin/perl
 
 # **********************************************************
-# Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+# Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
 # Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -268,7 +268,8 @@ sub keep_define($)
             $def eq "X86_32" || $def eq "X86_64" ||
             $def eq "ANDROID" || $def eq "USE_VISIBILITY_ATTRIBUTES" ||
             $def eq "DR_FAST_IR" || $def eq "__cplusplus" || $def eq "PAGE_SIZE" ||
-            $def eq "DR_PAGE_SIZE_COMPATIBILITY");
+            $def eq "DR_PAGE_SIZE_COMPATIBILITY" ||
+            $def eq "DR_LOG_DEFINE_COMPATIBILITY");
 }
 
 foreach $file (@headers) {

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -3996,7 +3996,7 @@ DR_API
 /**
  * Writes to DR's log file for the thread with drcontext \p drcontext if the current
  * loglevel is >= \p level and the current \p logmask & \p mask != 0.
- * The mask constants are below.
+ * The mask constants are the DR_LOG_* defines below.
  * Logging is disabled for the release build.
  * If \p drcontext is NULL, writes to the main log file.
  */
@@ -4009,35 +4009,63 @@ dr_log(void *drcontext, uint mask, uint level, const char *fmt, ...);
 /* DR_API EXPORT BEGIN */
 
 /* The log mask constants */
-#define LOG_NONE           0x00000000  /**< Log no data. */
-#define LOG_STATS          0x00000001  /**< Log per-thread and global statistics. */
-#define LOG_TOP            0x00000002  /**< Log top-level information. */
-#define LOG_THREADS        0x00000004  /**< Log data related to threads. */
-#define LOG_SYSCALLS       0x00000008  /**< Log data related to system calls. */
-#define LOG_ASYNCH         0x00000010  /**< Log data related to signals/callbacks/etc. */
-#define LOG_INTERP         0x00000020  /**< Log data related to app interpretation. */
-#define LOG_EMIT           0x00000040  /**< Log data related to emitting code. */
-#define LOG_LINKS          0x00000080  /**< Log data related to linking code. */
-#define LOG_CACHE          0x00000100  /**< Log data related to code cache management. */
-#define LOG_FRAGMENT       0x00000200  /**< Log data related to app code fragments. */
-#define LOG_DISPATCH       0x00000400  /**< Log data on every context switch dispatch. */
-#define LOG_MONITOR        0x00000800  /**< Log data related to trace building. */
-#define LOG_HEAP           0x00001000  /**< Log data related to memory management. */
-#define LOG_VMAREAS        0x00002000  /**< Log data related to address space regions. */
-#define LOG_SYNCH          0x00004000  /**< Log data related to synchronization. */
-#define LOG_MEMSTATS       0x00008000  /**< Log data related to memory statistics. */
-#define LOG_OPTS           0x00010000  /**< Log data related to optimizations. */
-#define LOG_SIDELINE       0x00020000  /**< Log data related to sideline threads. */
-#define LOG_SYMBOLS        0x00040000  /**< Log data related to app symbols. */
-#define LOG_RCT            0x00080000  /**< Log data related to indirect transfers. */
-#define LOG_NT             0x00100000  /**< Log data related to Windows Native API. */
-#define LOG_HOT_PATCHING   0x00200000  /**< Log data related to hot patching. */
-#define LOG_HTABLE         0x00400000  /**< Log data related to hash tables. */
-#define LOG_MODULEDB       0x00800000  /**< Log data related to the module database. */
-#define LOG_ALL            0x00ffffff  /**< Log all data. */
-/* DR_API EXPORT END */
+#define DR_LOG_NONE         0x00000000  /**< Log no data. */
+#define DR_LOG_STATS        0x00000001  /**< Log per-thread and global statistics. */
+#define DR_LOG_TOP          0x00000002  /**< Log top-level information. */
+#define DR_LOG_THREADS      0x00000004  /**< Log data related to threads. */
+#define DR_LOG_SYSCALLS     0x00000008  /**< Log data related to system calls. */
+#define DR_LOG_ASYNCH       0x00000010  /**< Log data related to signals/callbacks/etc. */
+#define DR_LOG_INTERP       0x00000020  /**< Log data related to app interpretation. */
+#define DR_LOG_EMIT         0x00000040  /**< Log data related to emitting code. */
+#define DR_LOG_LINKS        0x00000080  /**< Log data related to linking code. */
+#define DR_LOG_CACHE        0x00000100  /**< Log data related to code cache management. */
+#define DR_LOG_FRAGMENT     0x00000200  /**< Log data related to app code fragments. */
+#define DR_LOG_DISPATCH     0x00000400  /**< Log data on every context switch dispatch. */
+#define DR_LOG_MONITOR      0x00000800  /**< Log data related to trace building. */
+#define DR_LOG_HEAP         0x00001000  /**< Log data related to memory management. */
+#define DR_LOG_VMAREAS      0x00002000  /**< Log data related to address space regions. */
+#define DR_LOG_SYNCH        0x00004000  /**< Log data related to synchronization. */
+#define DR_LOG_MEMSTATS     0x00008000  /**< Log data related to memory statistics. */
+#define DR_LOG_OPTS         0x00010000  /**< Log data related to optimizations. */
+#define DR_LOG_SIDELINE     0x00020000  /**< Log data related to sideline threads. */
+#define DR_LOG_SYMBOLS      0x00040000  /**< Log data related to app symbols. */
+#define DR_LOG_RCT          0x00080000  /**< Log data related to indirect transfers. */
+#define DR_LOG_NT           0x00100000  /**< Log data related to Windows Native API. */
+#define DR_LOG_HOT_PATCHING 0x00200000  /**< Log data related to hot patching. */
+#define DR_LOG_HTABLE       0x00400000  /**< Log data related to hash tables. */
+#define DR_LOG_MODULEDB     0x00800000  /**< Log data related to the module database. */
+#define DR_LOG_ALL          0x00ffffff  /**< Log all data. */
+#ifdef DR_LOG_DEFINE_COMPATIBILITY
+# define LOG_NONE           DR_LOG_NONE         /**< Identical to #DR_LOG_NONE. */
+# define LOG_STATS          DR_LOG_STATS        /**< Identical to #DR_LOG_STATS. */
+# define LOG_TOP            DR_LOG_TOP          /**< Identical to #DR_LOG_TOP. */
+# define LOG_THREADS        DR_LOG_THREADS      /**< Identical to #DR_LOG_THREADS. */
+# define LOG_SYSCALLS       DR_LOG_SYSCALLS     /**< Identical to #DR_LOG_SYSCALLS. */
+# define LOG_ASYNCH         DR_LOG_ASYNCH       /**< Identical to #DR_LOG_ASYNCH. */
+# define LOG_INTERP         DR_LOG_INTERP       /**< Identical to #DR_LOG_INTERP. */
+# define LOG_EMIT           DR_LOG_EMIT         /**< Identical to #DR_LOG_EMIT. */
+# define LOG_LINKS          DR_LOG_LINKS        /**< Identical to #DR_LOG_LINKS. */
+# define LOG_CACHE          DR_LOG_CACHE        /**< Identical to #DR_LOG_CACHE. */
+# define LOG_FRAGMENT       DR_LOG_FRAGMENT     /**< Identical to #DR_LOG_FRAGMENT. */
+# define LOG_DISPATCH       DR_LOG_DISPATCH     /**< Identical to #DR_LOG_DISPATCH. */
+# define LOG_MONITOR        DR_LOG_MONITOR      /**< Identical to #DR_LOG_MONITOR. */
+# define LOG_HEAP           DR_LOG_HEAP         /**< Identical to #DR_LOG_HEAP. */
+# define LOG_VMAREAS        DR_LOG_VMAREAS      /**< Identical to #DR_LOG_VMAREAS. */
+# define LOG_SYNCH          DR_LOG_SYNCH        /**< Identical to #DR_LOG_SYNCH. */
+# define LOG_MEMSTATS       DR_LOG_MEMSTATS     /**< Identical to #DR_LOG_MEMSTATS. */
+# define LOG_OPTS           DR_LOG_OPTS         /**< Identical to #DR_LOG_OPTS. */
+# define LOG_SIDELINE       DR_LOG_SIDELINE     /**< Identical to #DR_LOG_SIDELINE. */
+# define LOG_SYMBOLS        DR_LOG_SYMBOLS      /**< Identical to #DR_LOG_SYMBOLS. */
+# define LOG_RCT            DR_LOG_RCT          /**< Identical to #DR_LOG_RCT. */
+# define LOG_NT             DR_LOG_NT           /**< Identical to #DR_LOG_NT. */
+# define LOG_HOT_PATCHING   DR_LOG_HOT_PATCHING /**< Identical to #DR_LOG_HOT_PATCHING. */
+# define LOG_HTABLE         DR_LOG_HTABLE       /**< Identical to #DR_LOG_HTABLE. */
+# define LOG_MODULEDB       DR_LOG_MODULEDB     /**< Identical to #DR_LOG_MODULEDB. */
+# define LOG_ALL            DR_LOG_ALL          /**< Identical to #DR_LOG_ALL. */
 #endif
 
+/* DR_API EXPORT END */
+#endif
 
 DR_API
 /**

--- a/ext/drcovlib/drcovlib.c
+++ b/ext/drcovlib/drcovlib.c
@@ -1,5 +1,5 @@
 /* ***************************************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
  * ***************************************************************************/
 
 /*
@@ -102,7 +102,7 @@ log_file_create_helper(void *drcontext, const char *suffix, char *buf, size_t bu
                                    DR_FILE_ALLOW_LARGE,
                                    buf, buf_els);
     if (log != INVALID_FILE) {
-        dr_log(drcontext, LOG_ALL, 1, "drcov: log file is %s\n", buf);
+        dr_log(drcontext, DR_LOG_ALL, 1, "drcov: log file is %s\n", buf);
         NOTIFY(1, "<created log file %s>\n", buf);
     }
     return log;

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -181,7 +181,7 @@ static void
 spill_reg(void *drcontext, per_thread_t *pt, reg_id_t reg, uint slot,
           instrlist_t *ilist, instr_t *where)
 {
-    LOG(drcontext, LOG_ALL, 3,
+    LOG(drcontext, DR_LOG_ALL, 3,
         "%s @%d."PFX" %s %d\n", __FUNCTION__, pt->live_idx, instr_get_app_pc(where),
         get_register_name(reg), slot);
     ASSERT(pt->slot_use[slot] == DR_REG_NULL ||
@@ -208,7 +208,7 @@ static void
 restore_reg(void *drcontext, per_thread_t *pt, reg_id_t reg, uint slot,
             instrlist_t *ilist, instr_t *where, bool release)
 {
-    LOG(drcontext, LOG_ALL, 3,
+    LOG(drcontext, DR_LOG_ALL, 3,
         "%s @%d."PFX" %s slot=%d release=%d\n", __FUNCTION__, pt->live_idx,
         where == NULL ? 0 : instr_get_app_pc(where),
         get_register_name(reg), slot, release);
@@ -311,13 +311,13 @@ drreg_event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb,
             opnd_is_instr(instr_get_target(inst))) {
             /* i#1954: we disable some opts in the presence of control flow. */
             pt->bb_has_internal_flow = true;
-            LOG(drcontext, LOG_ALL, 2,
+            LOG(drcontext, DR_LOG_ALL, 2,
                 "%s @%d."PFX": disabling lazy restores due to intra-bb control flow\n",
                 __FUNCTION__, index, instr_get_app_pc(inst));
         }
 
         /* GPR liveness */
-        LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX":", __FUNCTION__,
+        LOG(drcontext, DR_LOG_ALL, 3, "%s @%d."PFX":", __FUNCTION__,
             index, instr_get_app_pc(inst));
         for (reg = DR_REG_START_GPR; reg <= DR_REG_STOP_GPR; reg++) {
             void *value = REG_LIVE;
@@ -334,7 +334,7 @@ drreg_event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb,
                 value = REG_LIVE;
             else if (index > 0)
                 value = drvector_get_entry(&pt->reg[GPR_IDX(reg)].live, index-1);
-            LOG(drcontext, LOG_ALL, 3, " %s=%d", get_register_name(reg),
+            LOG(drcontext, DR_LOG_ALL, 3, " %s=%d", get_register_name(reg),
                 (int)(ptr_uint_t)value);
             drvector_set_entry(&pt->reg[GPR_IDX(reg)].live, index, value);
         }
@@ -358,7 +358,7 @@ drreg_event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb,
             aflags_w2r = EFLAGS_WRITE_TO_READ(aflags_new & EFLAGS_WRITE_ARITH);
             aflags_cur &= ~(aflags_w2r & ~aflags_read);
         }
-        LOG(drcontext, LOG_ALL, 3, " flags=%d\n", aflags_cur);
+        LOG(drcontext, DR_LOG_ALL, 3, " flags=%d\n", aflags_cur);
         drvector_set_entry(&pt->aflags.live, index, (void *)(ptr_uint_t)aflags_cur);
 
         if (instr_is_app(inst)) {
@@ -415,7 +415,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
          /* DR slots are not guaranteed across app instrs */
          pt->aflags.slot >= (int)ops.num_spill_slots)) {
         /* Restore aflags to app value */
-        LOG(drcontext, LOG_ALL, 3,
+        LOG(drcontext, DR_LOG_ALL, 3,
             "%s @%d."PFX" aflags=0x%x use=%d: lazily restoring aflags\n",
             __FUNCTION__, pt->live_idx, instr_get_app_pc(inst), aflags,
             pt->aflags.in_use);
@@ -452,7 +452,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
                  */
                 pt->reg[GPR_IDX(reg)].slot >= (int)ops.num_spill_slots) {
                 if (!pt->reg[GPR_IDX(reg)].in_use) {
-                    LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": lazily restoring %s\n",
+                    LOG(drcontext, DR_LOG_ALL, 3, "%s @%d."PFX": lazily restoring %s\n",
                         __FUNCTION__, pt->live_idx, instr_get_app_pc(inst),
                         get_register_name(reg));
                     res = drreg_restore_reg_now(drcontext, bb, inst, pt, reg);
@@ -483,7 +483,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
                      * XXX: if we change this, we need to update
                      * drreg_event_restore_state().
                      */
-                    LOG(drcontext, LOG_ALL, 3,
+                    LOG(drcontext, DR_LOG_ALL, 3,
                         "%s @%d."PFX": restoring %s for app read\n", __FUNCTION__,
                         pt->live_idx, instr_get_app_pc(inst), get_register_name(reg));
                     spill_reg(drcontext, pt, reg, tmp_slot, bb, inst);
@@ -505,7 +505,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
         (pt->live_idx == 0 ||
          (ptr_uint_t)drvector_get_entry(&pt->aflags.live, pt->live_idx-1) != 0)) {
         if (pt->aflags.in_use) {
-            LOG(drcontext, LOG_ALL, 3,
+            LOG(drcontext, DR_LOG_ALL, 3,
                 "%s @%d."PFX": re-spilling aflags after app write\n",
                 __FUNCTION__, pt->live_idx, instr_get_app_pc(inst));
             res = drreg_spill_aflags(drcontext, bb, next/*after*/, pt);
@@ -517,7 +517,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
                    IF_X86(|| (pt->reg[DR_REG_XAX-DR_REG_START_GPR].in_use &&
                               pt->aflags.xchg == DR_REG_XAX))) {
             /* give up slot */
-            LOG(drcontext, LOG_ALL, 3,
+            LOG(drcontext, DR_LOG_ALL, 3,
                 "%s @%d."PFX": giving up aflags slot after app write\n",
                 __FUNCTION__, pt->live_idx, instr_get_app_pc(inst));
 #ifdef X86
@@ -557,7 +557,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
                  * XXX: if we change this, we need to update
                  * drreg_event_restore_state().
                  */
-                LOG(drcontext, LOG_ALL, 3,
+                LOG(drcontext, DR_LOG_ALL, 3,
                     "%s @%d."PFX": re-spilling %s after app write\n", __FUNCTION__,
                     pt->live_idx, instr_get_app_pc(inst), get_register_name(reg));
                 if (!restored_for_read[GPR_IDX(reg)]) {
@@ -584,7 +584,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
             /* For an unreserved reg that's written, just drop the slot, even
              * if it was spilled at an earlier reservation point.
              */
-            LOG(drcontext, LOG_ALL, 3,
+            LOG(drcontext, DR_LOG_ALL, 3,
                 "%s @%d."PFX": dropping slot for unreserved reg %s after app write\n",
                 __FUNCTION__, pt->live_idx, instr_get_app_pc(inst),
                 get_register_name(reg));
@@ -755,7 +755,8 @@ drreg_reserve_reg_internal(void *drcontext, instrlist_t *ilist, instr_t *where,
                 slot = pt->reg[idx].slot;
                 pt->pending_unreserved--;
                 already_spilled = pt->reg[idx].ever_spilled;
-                LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": using un-restored %s slot %d\n",
+                LOG(drcontext, DR_LOG_ALL, 3,
+                    "%s @%d."PFX": using un-restored %s slot %d\n",
                     __FUNCTION__, pt->live_idx, instr_get_app_pc(where),
                     get_register_name(reg), slot);
                 break;
@@ -810,20 +811,21 @@ drreg_reserve_reg_internal(void *drcontext, instrlist_t *ilist, instr_t *where,
         if (ops.conservative ||
             drvector_get_entry(&pt->reg[GPR_IDX(reg)].live, pt->live_idx) ==
             REG_LIVE) {
-            LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": spilling %s to slot %d\n",
+            LOG(drcontext, DR_LOG_ALL, 3, "%s @%d."PFX": spilling %s to slot %d\n",
                 __FUNCTION__, pt->live_idx, instr_get_app_pc(where),
                 get_register_name(reg), slot);
             spill_reg(drcontext, pt, reg, slot, ilist, where);
             pt->reg[GPR_IDX(reg)].ever_spilled = true;
         } else {
-            LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": no need to spill %s to slot %d\n",
+            LOG(drcontext, DR_LOG_ALL, 3,
+                "%s @%d."PFX": no need to spill %s to slot %d\n",
                 __FUNCTION__, pt->live_idx, instr_get_app_pc(where),
                 get_register_name(reg), slot);
             pt->slot_use[slot] = reg;
             pt->reg[GPR_IDX(reg)].ever_spilled = false;
         }
     } else {
-        LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": %s already spilled to slot %d\n",
+        LOG(drcontext, DR_LOG_ALL, 3, "%s @%d."PFX": %s already spilled to slot %d\n",
             __FUNCTION__, pt->live_idx, instr_get_app_pc(where), get_register_name(reg),
             slot);
     }
@@ -905,7 +907,8 @@ drreg_get_app_value(void *drcontext, instrlist_t *ilist, instr_t *where,
 
     /* check if app_reg is an unspilled reg */
     if (pt->reg[GPR_IDX(app_reg)].native) {
-        LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": reg %s already native\n", __FUNCTION__,
+        LOG(drcontext, DR_LOG_ALL, 3,
+            "%s @%d."PFX": reg %s already native\n", __FUNCTION__,
             pt->live_idx, instr_get_app_pc(where), get_register_name(app_reg));
         if (dst_reg != app_reg) {
             PRE(ilist, where, XINST_CREATE_move(drcontext,
@@ -918,7 +921,8 @@ drreg_get_app_value(void *drcontext, instrlist_t *ilist, instr_t *where,
 
     /* we may have lost the app value for a dead reg */
     if (!pt->reg[GPR_IDX(app_reg)].ever_spilled) {
-        LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": reg %s never spilled\n", __FUNCTION__,
+        LOG(drcontext, DR_LOG_ALL, 3,
+            "%s @%d."PFX": reg %s never spilled\n", __FUNCTION__,
             pt->live_idx, instr_get_app_pc(where), get_register_name(app_reg));
         instrlist_set_auto_predicate(ilist, pred);
         return DRREG_ERROR_NO_APP_VALUE;
@@ -929,7 +933,7 @@ drreg_get_app_value(void *drcontext, instrlist_t *ilist, instr_t *where,
         instrlist_set_auto_predicate(ilist, pred);
         return DRREG_ERROR_FEATURE_NOT_AVAILABLE;
     }
-    LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": getting app value for %s\n",
+    LOG(drcontext, DR_LOG_ALL, 3, "%s @%d."PFX": getting app value for %s\n",
         __FUNCTION__, pt->live_idx, instr_get_app_pc(where), get_register_name(app_reg));
     if (pt->aflags.xchg == app_reg) {
         /* Bail on keeping the flags in the reg. */
@@ -1003,13 +1007,13 @@ drreg_restore_reg_now(void *drcontext, instrlist_t *ilist, instr_t *inst,
             /* XXX i#511: NYI */
             return DRREG_ERROR_FEATURE_NOT_AVAILABLE;
         }
-        LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": restoring %s\n",
+        LOG(drcontext, DR_LOG_ALL, 3, "%s @%d."PFX": restoring %s\n",
             __FUNCTION__, pt->live_idx, instr_get_app_pc(inst), get_register_name(reg));
         restore_reg(drcontext, pt, reg,
                     pt->reg[GPR_IDX(reg)].slot, ilist, inst, true);
     } else {
         /* still need to release slot */
-        LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": %s never spilled\n",
+        LOG(drcontext, DR_LOG_ALL, 3, "%s @%d."PFX": %s never spilled\n",
             __FUNCTION__, pt->live_idx, instr_get_app_pc(inst), get_register_name(reg));
         pt->slot_use[pt->reg[GPR_IDX(reg)].slot] = DR_REG_NULL;
     }
@@ -1024,7 +1028,7 @@ drreg_unreserve_register(void *drcontext, instrlist_t *ilist, instr_t *where,
     per_thread_t *pt = (per_thread_t *) drmgr_get_tls_field(drcontext, tls_idx);
     if (!pt->reg[GPR_IDX(reg)].in_use)
         return DRREG_ERROR_INVALID_PARAMETER;
-    LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX" %s\n", __FUNCTION__,
+    LOG(drcontext, DR_LOG_ALL, 3, "%s @%d."PFX" %s\n", __FUNCTION__,
         pt->live_idx, instr_get_app_pc(where), get_register_name(reg));
     if (drmgr_current_bb_phase(drcontext) != DRMGR_PHASE_INSERTION) {
         /* We have no way to lazily restore.  We do not bother at this point
@@ -1111,7 +1115,7 @@ drreg_set_bb_properties(void *drcontext, drreg_bb_properties_t flags)
         return DRREG_ERROR_FEATURE_NOT_AVAILABLE;
     /* XXX: interactions with multiple callers gets messy...for now we just or-in */
     pt->bb_props |= flags;
-    LOG(drcontext, LOG_ALL, 2,
+    LOG(drcontext, DR_LOG_ALL, 2,
         "%s: bb flags are now 0x%x\n", __FUNCTION__, pt->bb_props);
     return DRREG_SUCCESS;
 }
@@ -1130,13 +1134,14 @@ drreg_move_aflags_from_reg(void *drcontext, instrlist_t *ilist,
 {
 #ifdef X86
     if (pt->aflags.in_use) {
-        LOG(drcontext, LOG_ALL, 3,
+        LOG(drcontext, DR_LOG_ALL, 3,
             "%s @%d."PFX": moving aflags from xax to slot\n", __FUNCTION__,
             pt->live_idx, instr_get_app_pc(where));
         spill_reg(drcontext, pt, DR_REG_XAX, AFLAGS_SLOT, ilist, where);
     } else if (!pt->aflags.native) {
         drreg_status_t res;
-        LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": lazily restoring aflags for app xax\n",
+        LOG(drcontext, DR_LOG_ALL, 3,
+            "%s @%d."PFX": lazily restoring aflags for app xax\n",
             __FUNCTION__, pt->live_idx, instr_get_app_pc(where));
         res = drreg_restore_aflags(drcontext, ilist, where, pt, true/*release*/);
         if (res != DRREG_SUCCESS)
@@ -1144,7 +1149,7 @@ drreg_move_aflags_from_reg(void *drcontext, instrlist_t *ilist,
         pt->aflags.native = true;
         pt->slot_use[AFLAGS_SLOT] = DR_REG_NULL;
     }
-    LOG(drcontext, LOG_ALL, 3,
+    LOG(drcontext, DR_LOG_ALL, 3,
         "%s @%d."PFX": restoring xax spilled for aflags in slot %d\n", __FUNCTION__,
         pt->live_idx, instr_get_app_pc(where), pt->reg[DR_REG_XAX-DR_REG_START_GPR].slot);
     if (ops.conservative ||
@@ -1167,7 +1172,7 @@ drreg_spill_aflags(void *drcontext, instrlist_t *ilist, instr_t *where, per_thre
 {
 #ifdef X86
     uint aflags = (uint)(ptr_uint_t) drvector_get_entry(&pt->aflags.live, pt->live_idx);
-    LOG(drcontext, LOG_ALL, 3,
+    LOG(drcontext, DR_LOG_ALL, 3,
         "%s @%d."PFX"\n", __FUNCTION__, pt->live_idx, instr_get_app_pc(where));
     /* It may be in-use for ourselves, storing the flags in xax. */
     if (pt->reg[DR_REG_XAX-DR_REG_START_GPR].in_use && pt->aflags.xchg != DR_REG_XAX) {
@@ -1175,14 +1180,14 @@ drreg_spill_aflags(void *drcontext, instrlist_t *ilist, instr_t *where, per_thre
         /* XXX i#511: pick an unreserved reg, spill it, and put xax there
          * temporarily.  Store aflags in our dedicated aflags tls slot.
          */
-        LOG(drcontext, LOG_ALL, 3, "  xax is in use!\n");
+        LOG(drcontext, DR_LOG_ALL, 3, "  xax is in use!\n");
         return DRREG_ERROR_REG_CONFLICT;
     }
     if (!pt->reg[DR_REG_XAX-DR_REG_START_GPR].native) {
         /* xax is unreserved but not restored */
         ASSERT(pt->slot_use[pt->reg[DR_REG_XAX-DR_REG_START_GPR].slot] == DR_REG_XAX,
                "xax tracking error");
-        LOG(drcontext, LOG_ALL, 3, "  using un-restored xax in slot %d\n",
+        LOG(drcontext, DR_LOG_ALL, 3, "  using un-restored xax in slot %d\n",
             pt->reg[DR_REG_XAX-DR_REG_START_GPR].slot);
     } else {
         uint xax_slot = find_free_slot(pt);
@@ -1236,7 +1241,7 @@ drreg_restore_aflags(void *drcontext, instrlist_t *ilist, instr_t *where,
 #ifdef X86
     uint aflags = (uint)(ptr_uint_t) drvector_get_entry(&pt->aflags.live, pt->live_idx);
     uint temp_slot = 0;
-    LOG(drcontext, LOG_ALL, 3,
+    LOG(drcontext, DR_LOG_ALL, 3,
         "%s @%d."PFX": release=%d xax-in-use=%d,slot=%d xchg=%s\n", __FUNCTION__,
         pt->live_idx, instr_get_app_pc(where), release,
         pt->reg[DR_REG_XAX-DR_REG_START_GPR].in_use,
@@ -1318,7 +1323,7 @@ drreg_reserve_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
             pt->slot_use[AFLAGS_SLOT] = DR_REG_NULL;
         pt->aflags.in_use = true;
         pt->aflags.native = true;
-        LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": aflags are dead\n",
+        LOG(drcontext, DR_LOG_ALL, 3, "%s @%d."PFX": aflags are dead\n",
             __FUNCTION__, pt->live_idx, instr_get_app_pc(where));
         return DRREG_SUCCESS;
     }
@@ -1326,7 +1331,7 @@ drreg_reserve_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
     if (!pt->aflags.native
         IF_X86(|| (pt->reg[DR_REG_XAX-DR_REG_START_GPR].in_use &&
                    pt->aflags.xchg == DR_REG_XAX))) {
-        LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": using un-restored aflags\n",
+        LOG(drcontext, DR_LOG_ALL, 3, "%s @%d."PFX": using un-restored aflags\n",
             __FUNCTION__, pt->live_idx, instr_get_app_pc(where));
         ASSERT(pt->aflags.xchg != DR_REG_NULL ||
                pt->slot_use[AFLAGS_SLOT] != DR_REG_NULL, "lost slot reservation");
@@ -1335,7 +1340,7 @@ drreg_reserve_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
         return DRREG_SUCCESS;
     }
 
-    LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": spilling aflags\n",
+    LOG(drcontext, DR_LOG_ALL, 3, "%s @%d."PFX": spilling aflags\n",
         __FUNCTION__, pt->live_idx, instr_get_app_pc(where));
     /* drreg_spill_aflags writes to this, so clear first.  The inconsistent combo
      * xchg-null but xax-in-use won't happen b/c we'll use un-restored above.
@@ -1376,7 +1381,7 @@ drreg_unreserve_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
         instrlist_set_auto_predicate(ilist, pred);
         pt->slot_use[AFLAGS_SLOT] = DR_REG_NULL;
     }
-    LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX"\n", __FUNCTION__,
+    LOG(drcontext, DR_LOG_ALL, 3, "%s @%d."PFX"\n", __FUNCTION__,
         pt->live_idx, instr_get_app_pc(where));
     /* We lazily restore in drreg_event_bb_insert_late(), in case
      * someone else wants the aflags locally.
@@ -1420,7 +1425,8 @@ drreg_restore_app_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
     drreg_status_t res = DRREG_SUCCESS;
     if (!pt->aflags.native) {
         dr_pred_type_t pred = instrlist_get_auto_predicate(ilist);
-        LOG(drcontext, LOG_ALL, 3, "%s @%d."PFX": restoring app aflags as requested\n",
+        LOG(drcontext, DR_LOG_ALL, 3,
+            "%s @%d."PFX": restoring app aflags as requested\n",
             __FUNCTION__, pt->live_idx, instr_get_app_pc(where));
         /* XXX i#2585: drreg should predicate spills and restores as appropriate */
         instrlist_set_auto_predicate(ilist, DR_PRED_NONE);
@@ -1463,7 +1469,7 @@ drreg_event_restore_state(void *drcontext, bool restore_memory,
         return true; /* fault not in cache */
     for (reg = DR_REG_START_GPR; reg <= DR_REG_STOP_GPR; reg++)
         spilled_to[GPR_IDX(reg)] = MAX_SPILLS;
-    LOG(drcontext, LOG_ALL, 3, "%s: processing fault @"PFX": decoding from "PFX"\n",
+    LOG(drcontext, DR_LOG_ALL, 3, "%s: processing fault @"PFX": decoding from "PFX"\n",
         __FUNCTION__, info->raw_mcontext->pc, pc);
     instr_init(drcontext, &inst);
     while (pc < info->raw_mcontext->pc) {
@@ -1496,7 +1502,8 @@ drreg_event_restore_state(void *drcontext, bool restore_memory,
                 }
                 slot += ops.num_spill_slots;
             }
-            LOG(drcontext, LOG_ALL, 3, "%s @"PFX" found %s to %s offs=0x%x => slot %d\n",
+            LOG(drcontext, DR_LOG_ALL, 3,
+                "%s @"PFX" found %s to %s offs=0x%x => slot %d\n",
                 __FUNCTION__, prev_pc, spill ? "spill" : "restore",
                 get_register_name(reg), offs, slot);
             if (spill) {
@@ -1508,7 +1515,7 @@ drreg_event_restore_state(void *drcontext, bool restore_memory,
                     /* This reg is already spilled: we assume that this new spill
                      * is to a tmp slot for preserving the tool's value.
                      */
-                    LOG(drcontext, LOG_ALL, 3, "%s @"PFX": ignoring tool spill\n",
+                    LOG(drcontext, DR_LOG_ALL, 3, "%s @"PFX": ignoring tool spill\n",
                         __FUNCTION__, pc);
                 } else {
                     spilled_to[GPR_IDX(reg)] = slot;
@@ -1519,7 +1526,7 @@ drreg_event_restore_state(void *drcontext, bool restore_memory,
                 else if (spilled_to[GPR_IDX(reg)] == slot)
                     spilled_to[GPR_IDX(reg)] = MAX_SPILLS;
                 else {
-                    LOG(drcontext, LOG_ALL, 3, "%s @"PFX": ignoring restore\n",
+                    LOG(drcontext, DR_LOG_ALL, 3, "%s @"PFX": ignoring restore\n",
                         __FUNCTION__, pc);
                 }
             }
@@ -1560,14 +1567,14 @@ drreg_event_restore_state(void *drcontext, bool restore_memory,
         if (TEST(1, val)) /* seto */
             newval |= EFLAGS_OF;
 #endif
-        LOG(drcontext, LOG_ALL, 3, "%s: restoring aflags from "PFX" to "PFX"\n",
+        LOG(drcontext, DR_LOG_ALL, 3, "%s: restoring aflags from "PFX" to "PFX"\n",
             __FUNCTION__, info->mcontext->xflags, newval);
         info->mcontext->xflags = newval;
     }
     for (reg = DR_REG_START_GPR; reg <= DR_REG_STOP_GPR; reg++) {
         if (spilled_to[GPR_IDX(reg)] < MAX_SPILLS) {
             reg_t val = get_spilled_value(drcontext, spilled_to[GPR_IDX(reg)]);
-            LOG(drcontext, LOG_ALL, 3, "%s: restoring %s from "PFX" to "PFX"\n",
+            LOG(drcontext, DR_LOG_ALL, 3, "%s: restoring %s from "PFX" to "PFX"\n",
                 __FUNCTION__, get_register_name(reg), reg_get_value(reg, info->mcontext),
                 val);
             reg_set_value(reg, info->mcontext, val);

--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2018 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -580,6 +580,10 @@ function (DynamoRIO_extra_cflags flags_out extra_cflags tgt_cxx)
   if (DynamoRIO_PAGE_SIZE_COMPATIBILITY)
     set(extra_cflags "${extra_cflags} -DDR_PAGE_SIZE_COMPATIBILITY")
   endif (DynamoRIO_PAGE_SIZE_COMPATIBILITY)
+
+  if (DynamoRIO_LOG_COMPATIBILITY)
+    set(extra_cflags "${extra_cflags} -DDR_LOG_DEFINE_COMPATIBILITY")
+  endif ()
 
   if (DynamoRIO_FAST_IR)
     set(extra_cflags "${extra_cflags} -DDR_FAST_IR")

--- a/make/DynamoRIOConfigVersion.cmake.in
+++ b/make/DynamoRIOConfigVersion.cmake.in
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2013 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2018 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -88,5 +88,12 @@ if (NOT "${PACKAGE_FIND_VERSION_MAJOR}" EQUAL 0)
   # Automatically define PAGE_SIZE and PAGE_START if client targets older version
   if ("${PACKAGE_FIND_VERSION}" VERSION_LESS "6.3")
     set(DynamoRIO_PAGE_SIZE_COMPATIBILITY ON PARENT_SCOPE)
+  endif ()
+  # Ditto with the LOG_ defines.
+  if ("${PACKAGE_FIND_VERSION_COUNT}" GREATER 2 AND
+      "${PACKAGE_FIND_VERSION}" STREQUAL "7.0.0")
+    set(DynamoRIO_LOG_COMPATIBILITY ON PARENT_SCOPE)
+  elseif ("${PACKAGE_FIND_VERSION}" VERSION_LESS "7.0")
+    set(DynamoRIO_LOG_COMPATIBILITY ON PARENT_SCOPE)
   endif ()
 endif ()

--- a/suite/tests/client-interface/cleancall-opt-shared.h
+++ b/suite/tests/client-interface/cleancall-opt-shared.h
@@ -129,7 +129,7 @@ codegen_instrumentation_funcs(void)
     for (i = 0; i < N_FUNCS; i++) {
         pc = (byte*)ALIGN_FORWARD(pc, CALLEE_ALIGNMENT);
         func_ptrs[i] = pc;
-        dr_log(dc, LOG_EMIT, 3, "Generated instrumentation function %s at "PFX
+        dr_log(dc, DR_LOG_EMIT, 3, "Generated instrumentation function %s at "PFX
                ":", func_names[i], pc);
         instrlist_disassemble(dc, pc, ilists[i], dr_get_logfile(dc));
         pc = instrlist_encode(dc, ilists[i], pc, true);
@@ -587,7 +587,7 @@ before_callee(app_pc func, const char *func_name)
 # endif /* X86 */
     end_pc = instrlist_encode(dc, ilist, func, false /* no jump targets */);
     instrlist_clear_and_destroy(dc, ilist);
-    dr_log(dc, LOG_EMIT, 3, "Patched instrumentation function %s at "PFX":\n",
+    dr_log(dc, DR_LOG_EMIT, 3, "Patched instrumentation function %s at "PFX":\n",
            (func_name ? func_name : "(null)"), func);
 
     /* Check there was enough room in the function.  We align every callee

--- a/suite/tests/client-interface/custom_traces.dll.c
+++ b/suite/tests/client-interface/custom_traces.dll.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -190,7 +191,7 @@ dr_init(client_id_t id)
     dr_register_end_trace_event(query_end_trace);
 
     /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, LOG_ALL, 1, "Client 'inline' initializing\n");
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'inline' initializing\n");
     num_complete_inlines = 0;
 }
 
@@ -225,7 +226,7 @@ event_basic_block(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, b
             e->is_trace_head = true;
             dr_mutex_unlock(htable_mutex);
 #ifdef VERBOSE
-            dr_log(drcontext, LOG_ALL, 3,
+            dr_log(drcontext, DR_LOG_ALL, 3,
                    "inline: marking bb "PFX" as trace head\n", tag);
 #endif
             /* doesn't matter what's in rest of bb */
@@ -278,7 +279,7 @@ query_end_trace(void *drcontext, void *trace_tag, void *next_tag)
              * end up never entering the call trace
              */
 #ifdef VERBOSE
-            dr_log(drcontext, LOG_ALL, 3,
+            dr_log(drcontext, DR_LOG_ALL, 3,
                    "inline: ending trace "PFX" before block "PFX" containing call\n",
                    trace_tag, next_tag);
 #endif
@@ -289,7 +290,7 @@ query_end_trace(void *drcontext, void *trace_tag, void *next_tag)
         e->end_next--;
         if (e->end_next == 0) {
 #ifdef VERBOSE
-            dr_log(drcontext, LOG_ALL, 3,
+            dr_log(drcontext, DR_LOG_ALL, 3,
                    "inline: ending trace "PFX" before "PFX"\n",
                    trace_tag, next_tag);
 #endif
@@ -303,7 +304,7 @@ query_end_trace(void *drcontext, void *trace_tag, void *next_tag)
         e->size += size;
         if (e->size > INLINE_SIZE_LIMIT) {
 #ifdef VERBOSE
-            dr_log(drcontext, LOG_ALL, 3,
+            dr_log(drcontext, DR_LOG_ALL, 3,
                    "inline: ending trace "PFX" before "PFX" because reached size limit\n",
                    trace_tag, next_tag);
 #endif
@@ -314,7 +315,7 @@ query_end_trace(void *drcontext, void *trace_tag, void *next_tag)
             /* end trace after NEXT block */
             e->end_next = 2;
 #ifdef VERBOSE
-            dr_log(drcontext, LOG_ALL, 3,
+            dr_log(drcontext, DR_LOG_ALL, 3,
                    "inline: going to be ending trace "PFX" after "PFX"\n",
                    trace_tag, next_tag);
 #endif
@@ -324,7 +325,7 @@ query_end_trace(void *drcontext, void *trace_tag, void *next_tag)
     }
     /* do not end trace */
 #ifdef VERBOSE
-    dr_log(drcontext, LOG_ALL, 3,
+    dr_log(drcontext, DR_LOG_ALL, 3,
            "inline: NOT ending trace "PFX" after "PFX"\n", trace_tag, next_tag);
 #endif
     dr_mutex_unlock(htable_mutex);

--- a/suite/tests/client-interface/drreg-test.dll.c
+++ b/suite/tests/client-interface/drreg-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -97,7 +97,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         /* Local tests */
         res = drreg_reserve_register(drcontext, bb, inst, NULL, &reg);
         CHECK(res == DRREG_SUCCESS, "default reserve should always work");
-        dr_log(drcontext, LOG_ALL, 3, "drreg at "PFX" scratch=%s\n",
+        dr_log(drcontext, DR_LOG_ALL, 3, "drreg at "PFX" scratch=%s\n",
                instr_get_app_pc(inst), get_register_name(reg));
         /* test restore app value back to reg */
         res = drreg_get_app_value(drcontext, bb, inst, reg, reg);
@@ -166,7 +166,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
                subtest == DRREG_TEST_2_C ||
                subtest == DRREG_TEST_3_C) {
         /* Cross-app-instr tests */
-        dr_log(drcontext, LOG_ALL, 1, "drreg test #1/2/3\n");
+        dr_log(drcontext, DR_LOG_ALL, 1, "drreg test #1/2/3\n");
         if (instr_is_label(inst)) {
             res = drreg_reserve_register(drcontext, bb, inst, &allowed, &reg);
             CHECK(res == DRREG_SUCCESS, "reserve of test reg should work");
@@ -183,7 +183,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     } else if (subtest == DRREG_TEST_4_C ||
                subtest == DRREG_TEST_5_C) {
         /* Cross-app-instr aflags test */
-        dr_log(drcontext, LOG_ALL, 1, "drreg test #4\n");
+        dr_log(drcontext, DR_LOG_ALL, 1, "drreg test #4\n");
         if (instr_is_label(inst)) {
             res = drreg_reserve_aflags(drcontext, bb, inst);
             CHECK(res == DRREG_SUCCESS, "reserve of aflags should work");

--- a/suite/tests/client-interface/events.dll.c
+++ b/suite/tests/client-interface/events.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -431,7 +431,7 @@ static void
 kernel_xfer_event2(void *drcontext, const dr_kernel_xfer_info_t *info)
 {
     inc_count_second(EVENT_KERNEL_XFER_2);
-    dr_log(drcontext, LOG_ALL, 2, "%s: %d %p to %p sp=%zx\n", __FUNCTION__, info->type,
+    dr_log(drcontext, DR_LOG_ALL, 2, "%s: %d %p to %p sp=%zx\n", __FUNCTION__, info->type,
            info->source_mcontext == NULL ? 0 : info->source_mcontext->pc,
            info->target_pc, info->target_xsp);
     if (info->type == DR_XFER_CLIENT_REDIRECT) {

--- a/suite/tests/client-interface/signal.dll.c
+++ b/suite/tests/client-interface/signal.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -62,7 +62,7 @@ static void
 kernel_xfer_event(void *drcontext, const dr_kernel_xfer_info_t *info)
 {
     dr_fprintf(STDERR, "%s: type %d, sig %d\n", __FUNCTION__, info->type, info->sig);
-    dr_log(drcontext, LOG_ALL, 2, "%s: %d %d %p to %p sp=%zx\n", __FUNCTION__, info->type,
+    dr_log(drcontext, DR_LOG_ALL, 2, "%s: %d %d %p to %p sp=%zx\n", __FUNCTION__, info->type,
            info->sig, info->source_mcontext->pc, info->target_pc, info->target_xsp);
     dr_mcontext_t mc = {sizeof(mc)};
     mc.flags = DR_MC_CONTROL;

--- a/suite/tests/client-interface/winxfer.dll.c
+++ b/suite/tests/client-interface/winxfer.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,7 +49,7 @@ static void
 kernel_xfer_event(void *drcontext, const dr_kernel_xfer_info_t *info)
 {
     dr_fprintf(STDERR, "%s: type %d\n", __FUNCTION__, info->type);
-    dr_log(drcontext, LOG_ALL, 2, "%s: %d %p to %p sp=%zx\n", __FUNCTION__, info->type,
+    dr_log(drcontext, DR_LOG_ALL, 2, "%s: %d %p to %p sp=%zx\n", __FUNCTION__, info->type,
            info->source_mcontext == NULL ? 0 : info->source_mcontext->pc,
            info->target_pc, info->target_xsp);
     dr_mcontext_t mc = {sizeof(mc)};


### PR DESCRIPTION
Avoids name conflicts by renaming the LOG_xxx macros to have a DR_ prefix,
so DR_LOG_xxx.  Puts in place a compatibility CMake option
DynamoRIO_LOG_COMPATIBILITY that requests the old LOG_xxx macros and
automatically sets it if the client targets DR version 7.0.0 or older.

Updates all non-core uses of LOG_xxx.