### PR TITLE
i#2092 burst_threads test: reduce flakiness

### DIFF
--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -16,11 +16,11 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
   L1I stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
-.*    Miss rate:                *[0-9,\.]*%
+.*
   L1D stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
-.*    Miss rate:                *[0-9,\.]*%
+.*
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
 Core #3 \([0-9] traced CPU\(s\).*


### PR DESCRIPTION
Allows for zero data or instruction refs on a core and thus no printed miss
rate, to reduce flakiness in the burst_threads test.

Issue: #2092