### PR TITLE
Fix raw2trace ignoring of error

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -200,7 +200,7 @@ raw2trace_t::read_and_map_modules()
 {
     std::string err;
     if (modlist.empty())
-        do_module_parsing(); // May have already been called, since public.
+        err = do_module_parsing(); // May have already been called, since public.
     if (!err.empty())
         return err;
     for (auto it = modlist.begin(); it != modlist.end(); ++it) {


### PR DESCRIPTION
Adds a missing error capture in raw2trace_t::read_and_map_modules() where
an error in module parsing was accidentally ignored.