### PR TITLE
i#140 pcprof: add client pc sampling support

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -132,7 +132,7 @@ Dr. Memory Framework (DRMF) in the same package as DynamoRIO.  DRMF
 provides the umbra, drsyscall, and drsymcache Extensions for use by
 clients.
 
-The changes between version \DR_VERSION and 6.2.0 include the following minor
+The changes between version \DR_VERSION and 7.0.0 include the following minor
 compatibility changes:
 
  - The drltrace tool has been moved to the Dr.Memory Framework.
@@ -223,6 +223,7 @@ Further non-compatibility-affecting changes include:
    drmgr_unregister_pre_syscall_event_user_data() to enable passing of user data.
  - Added drmgr_register_post_syscall_event_user_data() and
    drmgr_unregister_post_syscall_event_user_data() to enable passing of user data.
+ - Added dr_where_am_i() to better support client self-profiling via sampling.
 
 **************************************************
 <hr>

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -5638,11 +5638,11 @@ insert_entering_native(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
      */
 
     /* C equivalent:
-     *   whereami = WHERE_APP
+     *   whereami = DR_WHERE_APP
      */
     PRE(ilist, where,
         instr_create_save_immed_to_dc_via_reg(dcontext, reg_dc, WHEREAMI_OFFSET,
-                                              (ptr_int_t) WHERE_APP, OPSZ_4));
+                                              (ptr_int_t) DR_WHERE_APP, OPSZ_4));
 
     /* skip C equivalent:
      *   STATS_INC(num_native_module_enter)
@@ -5703,11 +5703,11 @@ insert_entering_non_native(dcontext_t *dcontext, instrlist_t *ilist, instr_t *wh
                          ilist, where, reg_dc);
 
     /* C equivalent:
-     *   whereami = WHERE_FCACHE
+     *   whereami = DR_WHERE_FCACHE
      */
     PRE(ilist, where,
         instr_create_save_immed_to_dc_via_reg(dcontext, reg_dc, WHEREAMI_OFFSET,
-                                              (ptr_int_t) WHERE_FCACHE, OPSZ_4));
+                                              (ptr_int_t) DR_WHERE_FCACHE, OPSZ_4));
 }
 
 /* Emit code to transfer execution from native module to code cache of non-native

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -5150,10 +5150,10 @@ build_basic_block_fragment(dcontext_t *dcontext, app_pc start, uint initial_flag
 {
     fragment_t *f;
     build_bb_t bb;
-    where_am_i_t wherewasi = dcontext->whereami;
+    dr_where_am_i_t wherewasi = dcontext->whereami;
     bool image_entry;
     KSTART(bb_building);
-    dcontext->whereami = WHERE_INTERP;
+    dcontext->whereami = DR_WHERE_INTERP;
 
     /* Neither thin_client nor hotp_only should be building any bbs. */
     ASSERT(!RUNNING_WITHOUT_CODE_CACHE());

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -437,7 +437,7 @@ insert_meta_call_vargs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
                 XINST_CREATE_store(dcontext,
                                    OPND_CREATE_MEMPTR(SCRATCH_REG0, 0),
                                    opnd_create_reg(SCRATCH_REG1)));
-            instrlist_insert_mov_immed_ptrsz(dcontext, (ptr_int_t)WHERE_CLEAN_CALLEE,
+            instrlist_insert_mov_immed_ptrsz(dcontext, (ptr_int_t)DR_WHERE_CLEAN_CALLEE,
                                              opnd_create_reg(SCRATCH_REG1),
                                              ilist, instr, NULL, NULL);
             PRE(ilist, instr,
@@ -449,14 +449,14 @@ insert_meta_call_vargs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
                                   OPND_CREATE_MEMPTR(SCRATCH_REG0, 0)));
 # else
             PRE(ilist, instr,
-                instr_create_save_immed_to_dc_via_reg(dcontext, SCRATCH_REG0,
-                                                      WHEREAMI_OFFSET,
-                                                      (uint) WHERE_CLEAN_CALLEE, OPSZ_4));
+                instr_create_save_immed_to_dc_via_reg
+                (dcontext, SCRATCH_REG0, WHEREAMI_OFFSET,
+                 (uint) DR_WHERE_CLEAN_CALLEE, OPSZ_4));
 # endif
         } else {
             PRE(ilist, instr, XINST_CREATE_store(dcontext,
                 opnd_create_dcontext_field(dcontext, WHEREAMI_OFFSET),
-                OPND_CREATE_INT32(WHERE_CLEAN_CALLEE)));
+                OPND_CREATE_INT32(DR_WHERE_CLEAN_CALLEE)));
         }
     }
 #endif
@@ -480,9 +480,9 @@ insert_meta_call_vargs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         uint whereami;
 
         if (TEST(META_CALL_RETURNS_TO_NATIVE, flags))
-            whereami = (uint) WHERE_APP;
+            whereami = (uint) DR_WHERE_APP;
         else
-            whereami = (uint) WHERE_FCACHE;
+            whereami = (uint) DR_WHERE_FCACHE;
 
         if (SCRATCH_ALWAYS_TLS()) {
             /* SCRATCH_REG0 is dead here: restore of the app stack will clobber xax */

--- a/core/arch/sideline.c
+++ b/core/arch/sideline.c
@@ -591,7 +591,7 @@ sideline_optimize(fragment_t *f,
     pause_for_sideline = dcontext->owning_thread;
     ASSERT(is_thread_known(pause_for_sideline));
 
-    if (dcontext->whereami != WHERE_FCACHE) {
+    if (dcontext->whereami != DR_WHERE_FCACHE) {
         /* wait for thread to reach waiting point in dispatch */
         LOG(logfile, LOG_SIDELINE, VERB_3,
             "\nsideline_optimize: waiting for target thread "TIDFMT"\n",

--- a/core/arch/x86_code.c
+++ b/core/arch/x86_code.c
@@ -410,7 +410,7 @@ nt_continue_setup(priv_mcontext_t *mc)
     dcontext->next_tag = next_pc;
     ASSERT(dcontext->next_tag != NULL);
     set_last_exit(dcontext, (linkstub_t *) get_asynch_linkstub());
-    dcontext->whereami = WHERE_TRAMPOLINE;
+    dcontext->whereami = DR_WHERE_TRAMPOLINE;
 
     *get_mcontext(dcontext) = *mc;
     /* clear pc */

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -1704,7 +1704,7 @@ initialize_dynamo_context(dcontext_t *dcontext)
      */
     memset(dcontext->upcontext_ptr, 0, sizeof(unprotected_context_t));
     dcontext->initialized = true;
-    dcontext->whereami = WHERE_APP;
+    dcontext->whereami = DR_WHERE_APP;
     dcontext->next_tag = NULL;
     dcontext->native_exec_postsyscall = NULL;
     memset(dcontext->native_retstack, 0, sizeof(dcontext->native_retstack));

--- a/core/fcache.h
+++ b/core/fcache.h
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -140,6 +141,11 @@ bool fragment_lookup_deleted(dcontext_t *dcontext, app_pc tag);
 /* Returns the fragment_t whose body (not cache slot) contains lookup_pc */
 fragment_t *
 fcache_fragment_pclookup(dcontext_t *dcontext, cache_pc lookup_pc, fragment_t *wrapper);
+
+/* This is safe to call from a signal handler. */
+dr_where_am_i_t
+fcache_refine_whereami(dcontext_t *dcontext, dr_where_am_i_t whereami, app_pc pc,
+                       OUT fragment_t **containing_fragment);
 
 void
 fcache_coarse_cache_delete(dcontext_t *dcontext, coarse_info_t *info);

--- a/core/globals.h
+++ b/core/globals.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -598,25 +598,30 @@ extern mutex_t bb_building_lock;
 extern volatile bool bb_lock_start;
 extern recursive_lock_t change_linking_lock;
 
-/* where the current app thread's control is */
+/* DR_API EXPORT BEGIN */
+/**
+ * Identifies where a thread's control is at any one point.
+ * Used with client PC sampling using dr_set_itimer().
+ */
 typedef enum {
-    WHERE_APP=0,
-    WHERE_INTERP,
-    WHERE_DISPATCH,
-    WHERE_MONITOR,
-    WHERE_SYSCALL_HANDLER,
-    WHERE_SIGNAL_HANDLER,
-    WHERE_TRAMPOLINE,
-    WHERE_CONTEXT_SWITCH,
-    WHERE_IBL,
-    WHERE_FCACHE,
-    WHERE_CLEAN_CALLEE,
-    WHERE_UNKNOWN,
+    DR_WHERE_APP=0,            /**< Control is in native application code. */
+    DR_WHERE_INTERP,           /**< Control is in basic block building. */
+    DR_WHERE_DISPATCH,         /**< Control is in dispatch. */
+    DR_WHERE_MONITOR,          /**< Control is in trace building. */
+    DR_WHERE_SYSCALL_HANDLER,  /**< Control is in system call handling. */
+    DR_WHERE_SIGNAL_HANDLER,   /**< Control is in signal handling. */
+    DR_WHERE_TRAMPOLINE,       /**< Control is in trampoline hooks. */
+    DR_WHERE_CONTEXT_SWITCH,   /**< Control is in context switching. */
+    DR_WHERE_IBL,              /**< Control is in inlined indirect branch lookup. */
+    DR_WHERE_FCACHE,           /**< Control is in the code cache. */
+    DR_WHERE_CLEAN_CALLEE,     /**< Control is in a clean call. */
+    DR_WHERE_UNKNOWN,          /**< Control is in an unknown location. */
 #ifdef HOT_PATCHING_INTERFACE
-    WHERE_HOTPATCH,
+    DR_WHERE_HOTPATCH,         /**< Control is in hotpatching. */
 #endif
-    WHERE_LAST
-} where_am_i_t;
+    DR_WHERE_LAST              /**< Equals the count of DR_WHERE_xxx locations. */
+} dr_where_am_i_t;
+/* DR_API EXPORT END */
 
 /* make args easier to read for protection change calls
  * since only two possibilities not using new type
@@ -786,7 +791,7 @@ struct _dcontext_t {
         coarse_info_t *dir_exit;
     } coarse_exit;
 
-    where_am_i_t   whereami;        /* where control is at the moment */
+    dr_where_am_i_t   whereami;        /* where control is at the moment */
 #ifdef UNIX
     char           signals_pending; /* != 0: pending; < 0: currently handling one */
 #endif

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -4755,6 +4755,8 @@ DR_API
  * The itimer will operate successfully in the presence of an
  * application itimer of the same type.
  *
+ * Additional itimer signals are blocked while in our signal handler.
+ *
  * The return value indicates whether the timer was successfully
  * installed (or uninstalled if 0 was passed for \p millisec).
  *
@@ -4776,6 +4778,16 @@ DR_API
 uint
 dr_get_itimer(int which);
 #endif /* UNIX */
+
+DR_API
+/**
+ * Returns the #dr_where_am_i_t value indicating in which area of code \p pc
+ * resides.  This is meant for use with dr_set_itimer() for PC sampling for
+ * profiling purposes.  If the optional \p tag is non-NULL and \p pc is inside
+ * a fragment in the code cache, the fragment's tag is returned in \p tag.
+ */
+dr_where_am_i_t
+dr_where_am_i(void *drcontext, app_pc pc, OUT void**tag);
 
 /* DR_API EXPORT TOFILE dr_ir_utils.h */
 /* DR_API EXPORT BEGIN */

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -1829,8 +1829,8 @@ monitor_cache_exit(dcontext_t *dcontext)
 {
     monitor_data_t *md = (monitor_data_t *) dcontext->monitor_field;
     /* where processing */
-    ASSERT(dcontext->whereami == WHERE_DISPATCH);
-    dcontext->whereami = WHERE_MONITOR;
+    ASSERT(dcontext->whereami == DR_WHERE_DISPATCH);
+    dcontext->whereami = DR_WHERE_MONITOR;
     if (md->trace_tag != NULL && md->last_fragment != NULL) {
         /* unprotect local heap */
         SELF_PROTECT_LOCAL(dcontext, WRITABLE);
@@ -1862,7 +1862,7 @@ monitor_cache_exit(dcontext_t *dcontext)
             (TEST(FRAG_IS_TRACE, dcontext->last_fragment->flags) &&
              TEST(LINK_NI_SYSCALL, dcontext->last_exit->flags));
     }
-    dcontext->whereami = WHERE_DISPATCH;
+    dcontext->whereami = DR_WHERE_DISPATCH;
 }
 
 static void
@@ -1920,8 +1920,8 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
     }
 
     /* where processing */
-    ASSERT(dcontext->whereami == WHERE_DISPATCH);
-    dcontext->whereami = WHERE_MONITOR;
+    ASSERT(dcontext->whereami == DR_WHERE_DISPATCH);
+    dcontext->whereami = DR_WHERE_MONITOR;
 
     /* default internal routine */
 
@@ -2116,7 +2116,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
             /* add_size is set when !end_trace */
             f = internal_extend_trace(dcontext, f, dcontext->last_exit, add_size);
         }
-        dcontext->whereami = WHERE_DISPATCH;
+        dcontext->whereami = DR_WHERE_DISPATCH;
         /* re-protect local heap */
         SELF_PROTECT_LOCAL(dcontext, READONLY);
         KSTOP(trace_building);
@@ -2129,7 +2129,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
 
     if (TEST(FRAG_IS_TRACE, f->flags)) {
         /* nothing to do */
-        dcontext->whereami = WHERE_DISPATCH;
+        dcontext->whereami = DR_WHERE_DISPATCH;
         return f;
     }
 
@@ -2177,7 +2177,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
         }
 
         if (!trace_head) {
-            dcontext->whereami = WHERE_DISPATCH;
+            dcontext->whereami = DR_WHERE_DISPATCH;
             return f;
         }
     }
@@ -2336,7 +2336,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
              * export the size expansion factors considered?
              */
             /* now return */
-            dcontext->whereami = WHERE_DISPATCH;
+            dcontext->whereami = DR_WHERE_DISPATCH;
             /* link unprotects on demand, we then re-protect all */
             SELF_PROTECT_CACHE(dcontext, NULL, READONLY);
             /* re-protect local heap */
@@ -2355,7 +2355,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
     }
 
     /* release rest of state */
-    dcontext->whereami = WHERE_DISPATCH;
+    dcontext->whereami = DR_WHERE_DISPATCH;
     return f;
 }
 

--- a/core/native_exec.c
+++ b/core/native_exec.c
@@ -231,7 +231,7 @@ entering_native(dcontext_t *dcontext)
     ASSERT(!is_building_trace(dcontext));
     set_last_exit(dcontext, (linkstub_t *) get_native_exec_linkstub());
     /* now we're in app! */
-    dcontext->whereami = WHERE_APP;
+    dcontext->whereami = DR_WHERE_APP;
     SYSLOG_INTERNAL_WARNING_ONCE("entered at least one module natively");
     STATS_INC(num_native_module_enter);
 }
@@ -337,12 +337,12 @@ back_from_native_common(dcontext_t *dcontext, priv_mcontext_t *mc, app_pc target
     /* ASSUMPTION: was native entire time, don't need to initialize dcontext
      * or anything, and next_tag is still there!
      */
-    ASSERT(dcontext->whereami == WHERE_APP);
+    ASSERT(dcontext->whereami == DR_WHERE_APP);
     ASSERT(dcontext->last_exit == get_native_exec_linkstub());
     ASSERT(!is_native_pc(target));
     dcontext->next_tag = target;
     /* tell dispatch() why we're coming there */
-    dcontext->whereami = WHERE_FCACHE;
+    dcontext->whereami = DR_WHERE_FCACHE;
     /* FIXME i#2375: for -native_exec_opt on UNIX we need to update the gencode
      * to do what os_thread_{,not_}under_dynamo() and os_thread_re_take_over() do.
      */

--- a/core/synch.c
+++ b/core/synch.c
@@ -354,10 +354,10 @@ is_native_thread_state_valid(dcontext_t *dcontext, app_pc pc, byte *esp)
             IF_CLIENT_INTERFACE(!IS_CLIENT_THREAD(dcontext) &&)
 #ifdef HOT_PATCHING_INTERFACE
             /* Shouldn't be in the middle of executing a hotp_only patch.  The
-             * check for being in hotp_dll is WHERE_HOTPATCH because the patch can
+             * check for being in hotp_dll is DR_WHERE_HOTPATCH because the patch can
              * change esp.
              */
-            (dcontext->whereami != WHERE_HOTPATCH &&
+            (dcontext->whereami != DR_WHERE_HOTPATCH &&
              /* dynamo dll check has been done */
              !hotp_only_in_tramp(pc)) &&
 #endif
@@ -456,7 +456,7 @@ translate_mcontext(thread_record_t *trec, priv_mcontext_t *mcontext,
      * fine with us.  For other threads the app shouldn't be asking about them
      * unless they're suspended, and the same goes for us.
      */
-    ASSERT_CURIOSITY(trec->dcontext->whereami == WHERE_FCACHE ||
+    ASSERT_CURIOSITY(trec->dcontext->whereami == DR_WHERE_FCACHE ||
                      native_translate ||
                      trec->id == get_thread_id());
     LOG(THREAD_GET, LOG_SYNCH, 2,
@@ -596,7 +596,7 @@ at_safe_spot(thread_record_t *trec, priv_mcontext_t *mc,
         }
 #ifdef CLIENT_INTERFACE
     } else if (desired_state == THREAD_SYNCH_TERMINATED_AND_CLEANED &&
-               trec->dcontext->whereami == WHERE_FCACHE &&
+               trec->dcontext->whereami == DR_WHERE_FCACHE &&
                trec->dcontext->client_data->at_safe_to_terminate_syscall) {
         /* i#1420: At safe to terminate syscall like dr_sleep in a clean call.
          * XXX: A thread in dr_sleep might not be safe to terminate for some
@@ -622,7 +622,7 @@ at_safe_spot(thread_record_t *trec, priv_mcontext_t *mc,
         safe = true;
     }
     if (safe) {
-        ASSERT(trec->dcontext->whereami == WHERE_FCACHE ||
+        ASSERT(trec->dcontext->whereami == DR_WHERE_FCACHE ||
                is_thread_currently_native(trec));
         LOG(THREAD_GET, LOG_SYNCH, 2,
             "thread "TIDFMT" suspended at safe spot pc="PFX"\n", trec->id, mc->pc);
@@ -1809,7 +1809,7 @@ translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t sy
         LOG(GLOBAL, LOG_CACHE, 2,
             "\tsent to reset exit stub "PFX"\n", mc->pc);
         /* make dispatch happy */
-        dcontext->whereami = WHERE_FCACHE;
+        dcontext->whereami = DR_WHERE_FCACHE;
 #ifdef WINDOWS
         /* i#25: we could have interrupted thread in DR, where has priv fls data
          * in TEB, and fcache_return blindly copies into app fls: so swap to app

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -6661,8 +6661,8 @@ pre_system_call(dcontext_t *dcontext)
 {
     priv_mcontext_t *mc = get_mcontext(dcontext);
     bool execute_syscall = true;
-    where_am_i_t old_whereami = dcontext->whereami;
-    dcontext->whereami = WHERE_SYSCALL_HANDLER;
+    dr_where_am_i_t old_whereami = dcontext->whereami;
+    dcontext->whereami = DR_WHERE_SYSCALL_HANDLER;
     /* FIXME We haven't yet done the work to detect which syscalls we
      * can determine a priori will fail. Once we do, we will set the
      * expect_last_syscall_to_fail to true for those case, and can
@@ -8069,13 +8069,13 @@ post_system_call(dcontext_t *dcontext)
     app_pc base;
     size_t size;
     uint prot;
-    where_am_i_t old_whereami;
+    dr_where_am_i_t old_whereami;
     DEBUG_DECLARE(bool ok;)
 
     RSTATS_INC(post_syscall);
 
     old_whereami = dcontext->whereami;
-    dcontext->whereami = WHERE_SYSCALL_HANDLER;
+    dcontext->whereami = DR_WHERE_SYSCALL_HANDLER;
 
 #if defined(LINUX) && defined(X86)
     /* PR 313715: restore xbp since for some vsyscall sequences that use
@@ -10020,7 +10020,7 @@ os_thread_take_over(priv_mcontext_t *mc, kernel_sigset_t *sigset)
     dynamo_thread_under_dynamo(dcontext);
     dc_mc = get_mcontext(dcontext);
     *dc_mc = *mc;
-    dcontext->whereami = WHERE_APP;
+    dcontext->whereami = DR_WHERE_APP;
     dcontext->next_tag = mc->pc;
 
     os_thread_signal_taken_over();

--- a/core/unix/pcprofile.c
+++ b/core/unix/pcprofile.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -78,7 +78,7 @@ typedef struct _pc_profile_entry_t {
     int                     id;      /* if in fragment, id */
 #endif
     ushort              offset;      /* if in fragment, offset from start pc */
-    where_am_i_t    whereami:8;      /* location of pc */
+    dr_where_am_i_t    whereami:8;      /* location of pc */
     bool               trace:1;      /* if in fragment, is it a trace? */
     bool             retired:1;      /* owning fragment was deleted */
     int                counter;      /* execution counter */
@@ -93,7 +93,7 @@ typedef struct _thread_pc_info_t {
     pc_profile_entry_t **htable; /* HASH_BITS-bit addressed hash table, key is pc */
     void *special_heap;
     file_t file;
-    int where[WHERE_LAST];
+    int where[DR_WHERE_LAST];
 } thread_pc_info_t;
 
 #define ALARM_FREQUENCY 10 /* milliseconds */
@@ -139,7 +139,7 @@ pcprofile_thread_init(dcontext_t *dcontext, bool shared_itimer, void *parent_inf
 #if USE_SYMTAB
     valid_symtab = symtab_init();
 #endif
-    for (i = 0; i < WHERE_LAST; i++)
+    for (i = 0; i < DR_WHERE_LAST; i++)
         info->where[i] = 0;
     info->file = open_log_file("pcsamples", NULL, 0);
     /* FIXME PR 596808: we can easily fill up the initial special heap unit,
@@ -237,8 +237,6 @@ pcprofile_alarm(dcontext_t *dcontext, priv_mcontext_t *mcontext)
 {
     thread_pc_info_t *info = (thread_pc_info_t *) dcontext->pcprofile_field;
     pc_profile_entry_t *entry;
-    fragment_t *fragment;
-    fragment_t wrapper;
     void *pc = (void *) mcontext->pc;
 
     entry = pcprofile_lookup(info, pc);
@@ -259,30 +257,11 @@ pcprofile_alarm(dcontext_t *dcontext, priv_mcontext_t *mcontext)
          */
         entry = pcprofile_add_entry(info, pc, dcontext->whereami);
         /* if in a fragment, get fragment tag & offset now */
-        if (entry->whereami == WHERE_FCACHE) {
-            fragment = fragment_pclookup(dcontext, pc, &wrapper);
-            if (fragment == NULL) {
-                /* FIXME: should check fcache_unit_areas.lock before
-                 * calling (case 1317) and at least assert on it, if counting
-                 * on whereami to ensure no DR locks are held
-                 */
-                if (in_fcache(pc)) {
-                    entry->whereami = WHERE_UNKNOWN;
-                } else {
-                    /* identify parts of our assembly code now.
-                     * it's all generated and post-process can't identify.
-                     * assume code order is as follows:
-                     */
-                    if (in_context_switch_code(dcontext, (cache_pc)pc)) {
-                        entry->whereami = WHERE_CONTEXT_SWITCH;
-                    } else if (in_indirect_branch_lookup_code(dcontext,
-                                                              (cache_pc)pc)) {
-                        entry->whereami = WHERE_IBL;
-                    } else {
-                        entry->whereami = WHERE_UNKNOWN;
-                    }
-                }
-            } else {
+        if (entry->whereami == DR_WHERE_FCACHE) {
+            fragment_t *fragment;
+            entry->whereami = fcache_refine_whereami(dcontext, entry->whereami,
+                                                     pc, &fragment);
+            if (fragment != NULL) {
 #ifdef DEBUG
                 entry->id = fragment->id;
 #endif
@@ -410,7 +389,7 @@ pcprofile_reset(thread_pc_info_t *info)
         }
         info->htable[i] = NULL;
     }
-    for (i = 0; i < WHERE_LAST; i++)
+    for (i = 0; i < DR_WHERE_LAST; i++)
         info->where[i] = 0;
 }
 
@@ -428,7 +407,7 @@ pcprofile_results(thread_pc_info_t *info)
     int i, total = 0;
     pc_profile_entry_t *e;
 
-    for (i = 0; i < WHERE_LAST; i++)
+    for (i = 0; i < DR_WHERE_LAST; i++)
         total += info->where[i];
 
     print_file(info->file, "DynamoRIO library: "PFX"-"PFX"\n",
@@ -443,60 +422,60 @@ pcprofile_results(thread_pc_info_t *info)
     }
 #endif
     print_file(info->file, "ITIMER distribution (%d):\n", total);
-    if (info->where[WHERE_APP] > 0) {
+    if (info->where[DR_WHERE_APP] > 0) {
         print_file(info->file, "  %5.1f%% of time in APPLICATION (%d)\n",
-                   (float)info->where[WHERE_APP]/(float)total * 100.0,
-                   info->where[WHERE_APP]);
+                   (float)info->where[DR_WHERE_APP]/(float)total * 100.0,
+                   info->where[DR_WHERE_APP]);
     }
-    if (info->where[WHERE_INTERP] > 0) {
+    if (info->where[DR_WHERE_INTERP] > 0) {
         print_file(info->file, "  %5.1f%% of time in INTERPRETER (%d)\n",
-                   (float)info->where[WHERE_INTERP]/(float)total * 100.0,
-                   info->where[WHERE_INTERP]);
+                   (float)info->where[DR_WHERE_INTERP]/(float)total * 100.0,
+                   info->where[DR_WHERE_INTERP]);
     }
-    if (info->where[WHERE_DISPATCH] > 0) {
+    if (info->where[DR_WHERE_DISPATCH] > 0) {
         print_file(info->file, "  %5.1f%% of time in DISPATCH (%d)\n",
-                   (float)info->where[WHERE_DISPATCH]/(float)total * 100.0,
-                   info->where[WHERE_DISPATCH]);
+                   (float)info->where[DR_WHERE_DISPATCH]/(float)total * 100.0,
+                   info->where[DR_WHERE_DISPATCH]);
     }
-    if (info->where[WHERE_MONITOR] > 0) {
+    if (info->where[DR_WHERE_MONITOR] > 0) {
         print_file(info->file, "  %5.1f%% of time in MONITOR (%d)\n",
-                   (float)info->where[WHERE_MONITOR]/(float)total * 100.0,
-                   info->where[WHERE_MONITOR]);
+                   (float)info->where[DR_WHERE_MONITOR]/(float)total * 100.0,
+                   info->where[DR_WHERE_MONITOR]);
     }
-    if (info->where[WHERE_SYSCALL_HANDLER] > 0) {
+    if (info->where[DR_WHERE_SYSCALL_HANDLER] > 0) {
         print_file(info->file, "  %5.1f%% of time in SYSCALL HANDLER (%d)\n",
-                   (float)info->where[WHERE_SYSCALL_HANDLER]/(float)total * 100.0,
-                   info->where[WHERE_SYSCALL_HANDLER]);
+                   (float)info->where[DR_WHERE_SYSCALL_HANDLER]/(float)total * 100.0,
+                   info->where[DR_WHERE_SYSCALL_HANDLER]);
     }
-    if (info->where[WHERE_SIGNAL_HANDLER] > 0) {
+    if (info->where[DR_WHERE_SIGNAL_HANDLER] > 0) {
         print_file(info->file, "  %5.1f%% of time in SIGNAL HANDLER (%d)\n",
-                   (float)info->where[WHERE_SIGNAL_HANDLER]/(float)total * 100.0,
-                   info->where[WHERE_SIGNAL_HANDLER]);
+                   (float)info->where[DR_WHERE_SIGNAL_HANDLER]/(float)total * 100.0,
+                   info->where[DR_WHERE_SIGNAL_HANDLER]);
     }
-    if (info->where[WHERE_TRAMPOLINE] > 0) {
+    if (info->where[DR_WHERE_TRAMPOLINE] > 0) {
         print_file(info->file, "  %5.1f%% of time in TRAMPOLINES (%d)\n",
-                   (float)info->where[WHERE_TRAMPOLINE]/(float)total * 100.0,
-                   info->where[WHERE_TRAMPOLINE]);
+                   (float)info->where[DR_WHERE_TRAMPOLINE]/(float)total * 100.0,
+                   info->where[DR_WHERE_TRAMPOLINE]);
     }
-    if (info->where[WHERE_CONTEXT_SWITCH] > 0) {
+    if (info->where[DR_WHERE_CONTEXT_SWITCH] > 0) {
         print_file(info->file, "  %5.1f%% of time in CONTEXT SWITCH (%d)\n",
-                   (float)info->where[WHERE_CONTEXT_SWITCH]/(float)total * 100.0,
-                   info->where[WHERE_CONTEXT_SWITCH]);
+                   (float)info->where[DR_WHERE_CONTEXT_SWITCH]/(float)total * 100.0,
+                   info->where[DR_WHERE_CONTEXT_SWITCH]);
     }
-    if (info->where[WHERE_IBL] > 0) {
+    if (info->where[DR_WHERE_IBL] > 0) {
         print_file(info->file, "  %5.1f%% of time in INDIRECT BRANCH LOOKUP (%d)\n",
-                   (float)info->where[WHERE_IBL]/(float)total * 100.0,
-                   info->where[WHERE_IBL]);
+                   (float)info->where[DR_WHERE_IBL]/(float)total * 100.0,
+                   info->where[DR_WHERE_IBL]);
     }
-    if (info->where[WHERE_FCACHE] > 0) {
+    if (info->where[DR_WHERE_FCACHE] > 0) {
         print_file(info->file, "  %5.1f%% of time in FRAGMENT CACHE (%d)\n",
-                   (float)info->where[WHERE_FCACHE]/(float)total * 100.0,
-                   info->where[WHERE_FCACHE]);
+                   (float)info->where[DR_WHERE_FCACHE]/(float)total * 100.0,
+                   info->where[DR_WHERE_FCACHE]);
     }
-    if (info->where[WHERE_UNKNOWN] > 0) {
+    if (info->where[DR_WHERE_UNKNOWN] > 0) {
         print_file(info->file, "  %5.1f%% of time in UNKNOWN (%d)\n",
-                   (float)info->where[WHERE_UNKNOWN]/(float)total * 100.0,
-                   info->where[WHERE_UNKNOWN]);
+                   (float)info->where[DR_WHERE_UNKNOWN]/(float)total * 100.0,
+                   info->where[DR_WHERE_UNKNOWN]);
     }
 
     print_file(info->file, "\nPC PROFILING RESULTS\n");
@@ -504,7 +483,7 @@ pcprofile_results(thread_pc_info_t *info)
     for (i = 0; i < HASHTABLE_SIZE(HASH_BITS); i++) {
         e = info->htable[i];
         while (e) {
-            if (e->whereami == WHERE_FCACHE) {
+            if (e->whereami == DR_WHERE_FCACHE) {
                 const char *type;
                 if (e->trace)
                     type = "trace";
@@ -526,7 +505,7 @@ pcprofile_results(thread_pc_info_t *info)
                             symtab_lookup_pc((void *)(e->tag+e->offset)));
                 }
 #endif
-            } else if (e->whereami == WHERE_APP) {
+            } else if (e->whereami == DR_WHERE_APP) {
 #if USE_SYMTAB
                 if (valid_symtab) {
                     print_file(info->file, "pc="PFX"\t#=%d\tin the app = %s\n",
@@ -539,7 +518,7 @@ pcprofile_results(thread_pc_info_t *info)
 #if USE_SYMTAB
                 }
 #endif
-            } else if (e->whereami == WHERE_UNKNOWN) {
+            } else if (e->whereami == DR_WHERE_UNKNOWN) {
                 if (is_dynamo_address(e->pc)) {
                     print_file(info->file, "pc="PFX"\t#=%d\tin DynamoRIO <SOMEWHERE> | ",
                                e->pc, e->counter);
@@ -566,21 +545,21 @@ pcprofile_results(thread_pc_info_t *info)
 #else
                     print_file(info->file, "pc="PFX"\t#=%d\tin DynamoRIO",
                                e->pc, e->counter);
-                    if (e->whereami == WHERE_INTERP) {
+                    if (e->whereami == DR_WHERE_INTERP) {
                         print_file(info->file, " interpreter\n");
-                    } else if (e->whereami == WHERE_DISPATCH) {
+                    } else if (e->whereami == DR_WHERE_DISPATCH) {
                         print_file(info->file, " dispatch\n");
-                    } else if (e->whereami == WHERE_MONITOR) {
+                    } else if (e->whereami == DR_WHERE_MONITOR) {
                         print_file(info->file, " monitor\n");
-                    } else if (e->whereami == WHERE_SIGNAL_HANDLER) {
+                    } else if (e->whereami == DR_WHERE_SIGNAL_HANDLER) {
                         print_file(info->file, " signal handler\n");
-                    } else if (e->whereami == WHERE_SYSCALL_HANDLER) {
+                    } else if (e->whereami == DR_WHERE_SYSCALL_HANDLER) {
                         print_file(info->file, " syscall handler\n");
-                    } else if (e->whereami == WHERE_CONTEXT_SWITCH) {
+                    } else if (e->whereami == DR_WHERE_CONTEXT_SWITCH) {
                         print_file(info->file, " context switch\n");
-                    } else if (e->whereami == WHERE_IBL) {
+                    } else if (e->whereami == DR_WHERE_IBL) {
                         print_file(info->file, " indirect_branch_lookup\n");
-                    } else if (e->whereami == WHERE_CLEAN_CALLEE) {
+                    } else if (e->whereami == DR_WHERE_CLEAN_CALLEE) {
                         print_file(info->file, " clean call\n");
                     } else {
                         print_file(STDERR, "ERROR: unknown whereAmI %d\n",

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -7656,7 +7656,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
                                                  own_execareas_writelock,
                                                  caller_execareas_writelock);
                     /* avoid assert in dispatch_enter_dynamorio() */
-                    dcontext->whereami = WHERE_TRAMPOLINE;
+                    dcontext->whereami = DR_WHERE_TRAMPOLINE;
                     set_last_exit(dcontext, (linkstub_t *)
                                   get_ibl_sourceless_linkstub(LINK_RETURN, 0));
                     if (is_couldbelinking(dcontext))

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -8207,9 +8207,9 @@ detach_helper(int detach_type)
         return;
 
     ASSERT(detach_type < DETACH_NORMAL_TYPE ||
-           ((my_dcontext != NULL && my_dcontext->whereami == WHERE_FCACHE) ||
-            /* If detaching in thin_client/hotp_only mode, must only be WHERE_APP!  */
-            (RUNNING_WITHOUT_CODE_CACHE() && my_dcontext->whereami == WHERE_APP)));
+           ((my_dcontext != NULL && my_dcontext->whereami == DR_WHERE_FCACHE) ||
+            /* If detaching in thin_client/hotp_only mode, must only be DR_WHERE_APP!  */
+            (RUNNING_WITHOUT_CODE_CACHE() && my_dcontext->whereami == DR_WHERE_APP)));
 
     detach_on_permanent_stack(internal_detach,
                               detach_type != DETACH_BAD_STATE_NO_CLEANUP);
@@ -8629,7 +8629,7 @@ early_inject_init()
     dcontext_t *dcontext = get_thread_private_dcontext();
     module_handle_t mod;
     bool under_dr_save;
-    where_am_i_t whereami_save;
+    dr_where_am_i_t whereami_save;
     wchar_t buf[MAX_PATH];
     int os_version_number = get_os_version();
     GET_NTDLL(LdrLoadDll, (IN PCWSTR PathToFile OPTIONAL,

--- a/core/win32/os_private.h
+++ b/core/win32/os_private.h
@@ -285,7 +285,7 @@ static inline reg_t
 sys_param(dcontext_t *dcontext, reg_t *param_base, int num)
 {
     /* sys_param is also called from handle_system_call where dcontext->whereami
-     * is not set to WHERE_SYSCALL_HANDLER yet.
+     * is not set to DR_WHERE_SYSCALL_HANDLER yet.
      */
     ASSERT(!dcontext->post_syscall);
     return *sys_param_addr(dcontext, param_base, num);
@@ -294,7 +294,7 @@ sys_param(dcontext_t *dcontext, reg_t *param_base, int num)
 static inline reg_t
 postsys_param(dcontext_t *dcontext, reg_t *param_base, int num)
 {
-    ASSERT(dcontext->whereami == WHERE_SYSCALL_HANDLER &&
+    ASSERT(dcontext->whereami == DR_WHERE_SYSCALL_HANDLER &&
            dcontext->post_syscall);
 #ifdef X64
     switch (num) {

--- a/core/win32/syscall.c
+++ b/core/win32/syscall.c
@@ -663,7 +663,7 @@ syscall_while_native(app_state_at_intercept_t *state)
                 * redirect *everything*.  From privlib we need to keep
                 * the syscall native as DR locks may be held.
                 */
-               IF_CLIENT_INTERFACE(&& dcontext->whereami == WHERE_APP)) {
+               IF_CLIENT_INTERFACE(&& dcontext->whereami == DR_WHERE_APP)) {
         /* assumption is that any known native thread is one we control in general,
          * just not right now while in a native_exec_list dll */
         STATS_INC(num_syscall_trampolines_native);
@@ -756,8 +756,8 @@ syscall_while_native(app_state_at_intercept_t *state)
          */
         ASSERT(syscall_trampoline_skip_pc[sysnum] != NULL);
         dcontext->native_exec_postsyscall = syscall_trampoline_skip_pc[sysnum];
-        ASSERT(dcontext->whereami == WHERE_APP);
-        dcontext->whereami = WHERE_TRAMPOLINE;
+        ASSERT(dcontext->whereami == DR_WHERE_APP);
+        dcontext->whereami = DR_WHERE_TRAMPOLINE;
         set_last_exit(dcontext, (linkstub_t *) get_native_exec_syscall_linkstub());
         /* assumption: no special cleanup from tail of trampoline needed */
         transfer_to_dispatch(dcontext, &state->mc, false/*!full_DR_state*/);
@@ -2832,8 +2832,8 @@ pre_system_call(dcontext_t *dcontext)
     priv_mcontext_t *mc = get_mcontext(dcontext);
     int sysnum = (int) mc->xax;
     reg_t *param_base = pre_system_call_param_base(mc);
-    where_am_i_t old_whereami = dcontext->whereami;
-    dcontext->whereami = WHERE_SYSCALL_HANDLER;
+    dr_where_am_i_t old_whereami = dcontext->whereami;
+    dcontext->whereami = DR_WHERE_SYSCALL_HANDLER;
     IF_X64(ASSERT_TRUNCATE(sysnum, int, mc->xax));
     DODEBUG(dcontext->expect_last_syscall_to_fail = false;);
 
@@ -4225,9 +4225,9 @@ void post_system_call(dcontext_t *dcontext)
     reg_t *param_base = dcontext->sys_param_base;
     priv_mcontext_t *mc = get_mcontext(dcontext);
     bool success = NT_SUCCESS(mc->xax);
-    where_am_i_t old_whereami = dcontext->whereami;
+    dr_where_am_i_t old_whereami = dcontext->whereami;
     KSTART(post_syscall);
-    dcontext->whereami = WHERE_SYSCALL_HANDLER;
+    dcontext->whereami = DR_WHERE_SYSCALL_HANDLER;
     DODEBUG({ dcontext->post_syscall = true; });
 
     LOG(THREAD, LOG_SYSCALLS, 2,

--- a/suite/tests/client-interface/timer.dll.c
+++ b/suite/tests/client-interface/timer.dll.c
@@ -43,11 +43,32 @@
 # error NYI
 #endif
 
+/* We do not synchronize access because we assume the itimer is shared
+ * for the thread group, there's just one thread group, and the itimer
+ * signal is blocked while in the handler.
+ */
+static int buckets[DR_WHERE_LAST];
+
 /* test PR 368737: add client timer support */
 static void
 event_timer(void *drcontext, dr_mcontext_t *mcontext)
 {
     dr_fprintf(STDERR, "client event_timer fired\n");
+}
+
+/* Test i#140: add client pc sampling support */
+static void
+event_sample(void *drcontext, dr_mcontext_t *mcontext)
+{
+    void *tag;
+    dr_where_am_i_t whereami = dr_where_am_i(drcontext, mcontext->pc, &tag);
+    buckets[whereami]++;
+    DR_ASSERT(mcontext->pc != NULL &&
+              /* Ensure DR wrote the value and it's not the uninit 0xab pattern. */
+              mcontext->pc != (app_pc)IF_X64_ELSE(0xabababababababab,0xabababab));
+#if VERBOSE
+    dr_fprintf(STDERR, "sample: %p %d %p\n", mcontext->pc, whereami, tag);
+#endif
 }
 
 static void
@@ -79,11 +100,29 @@ filter_syscall_event(void *drcontext, int sysnum)
     return sysnum == SYS_setitimer;
 }
 
+static void
+exit_event(void)
+{
+    int i;
+    int total = 0;
+    for (i = 0; i < DR_WHERE_LAST; i++) {
+        total += buckets[i];
+#if VERBOSE
+        dr_fprintf(STDERR, "bucket %d: %d\n", i, buckets[i]);
+#endif
+    }
+    DR_ASSERT(total > 0);
+}
+
 DR_EXPORT
 void dr_init(client_id_t id)
 {
+    dr_register_exit_event(exit_event);
     dr_register_post_syscall_event(post_syscall_event);
     dr_register_filter_syscall_event(filter_syscall_event);
     if (!dr_set_itimer(ITIMER_REAL, 25, event_timer))
+        dr_fprintf(STDERR, "unable to set timer callback\n");
+    /* Test pc sampling (i#140). */
+    if (!dr_set_itimer(ITIMER_VIRTUAL, 10, event_sample))
         dr_fprintf(STDERR, "unable to set timer callback\n");
 }


### PR DESCRIPTION
Added dr_where_am_i() to better support client self-profiling via
sampling.  This also provides the fragment tag, by refactoring
the pcprofile code into a new helper fcache_refine_whereami().

Renamed the whereami types to better avoid name conflicts:
s/WHERE_xxx/DR_WHERE_xxx/ and s/where_am_i_t/dr_where_am_i_t/.
Exported the dr_where_am_i_t enum.

Fixed a bug where an uninitialized mcontext was passed to a
client timer callback: we only filled in the mcontext for a
DR-internal callback.

Added a test of client sampling to client.timer

Issue: #140