### PR TITLE
i#2910: support drreg use during process init

### DIFF
--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -1113,6 +1113,9 @@ drmgr_current_bb_phase(void *drcontext)
     if (drmgr_init_count == 0)
         return DRMGR_PHASE_NONE;
     pt = (per_thread_t *) drmgr_get_tls_field(drcontext, our_tls_idx);
+    /* Support being called during process init (i#2910). */
+    if (pt == NULL)
+        return DRMGR_PHASE_NONE;
     return pt->cur_phase;
 }
 

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -1694,6 +1694,8 @@ drreg_init(drreg_options_t *ops_in)
          */
         ops.num_spill_slots = 1;
 #endif
+        /* Support use during init when there is no TLS (i#2910). */
+        tls_data_init(&init_pt);
     }
 
     if (ops_in->struct_size < offsetof(drreg_options_t, error_callback))
@@ -1741,9 +1743,6 @@ drreg_init(drreg_options_t *ops_in)
     if (!dr_raw_tls_calloc(&tls_seg, &tls_slot_offs, ops.num_spill_slots, 0))
         return DRREG_ERROR_OUT_OF_SLOTS;
 
-    /* Support use during init when there is no TLS (i#2910). */
-    tls_data_init(&init_pt);
-
     return DRREG_SUCCESS;
 }
 
@@ -1778,4 +1777,3 @@ drreg_exit(void)
 
     return DRREG_SUCCESS;
 }
-

--- a/suite/tests/client-interface/drreg-test.dll.c
+++ b/suite/tests/client-interface/drreg-test.dll.c
@@ -283,4 +283,14 @@ dr_init(client_id_t id)
                                                  event_app_instruction, NULL) ||
         !drmgr_register_bb_instru2instru_event(event_instru2instru, NULL))
         CHECK(false, "init failed");
+
+    /* i#2910: test use during process init. */
+    void *drcontext = dr_get_current_drcontext();
+    instrlist_t *ilist = instrlist_create(drcontext);
+    drreg_status_t res = drreg_reserve_aflags(drcontext, ilist, NULL);
+    CHECK(res == DRREG_SUCCESS, "process init test failed");
+    reg_id_t reg;
+    res = drreg_reserve_register(drcontext, ilist, NULL, NULL, &reg);
+    CHECK(res == DRREG_SUCCESS, "process init test failed");
+    instrlist_clear_and_destroy(drcontext, ilist);
 }


### PR DESCRIPTION
Adds static TLS data to support drreg routines being called during process
init before thread init has happened.

Also adds support for drmgr_current_bb_phase(), which is called by drrreg,
being called during process init.

Adds a test case to drreg-test.

Fixes #2910