### PR TITLE
i#511 drreg: do not fail on xax-vs-aflags conflicts

### DIFF
--- a/suite/tests/client-interface/drreg-test.dll.c
+++ b/suite/tests/client-interface/drreg-test.dll.c
@@ -162,6 +162,26 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         CHECK(res == DRREG_SUCCESS, "restore of app aflags should work");
         res = drreg_unreserve_aflags(drcontext, bb, inst);
         CHECK(res == DRREG_SUCCESS, "unreserve of aflags");
+#ifdef X86
+        /* test aflags conflicts with xax: failing to reserve xax due to lazy
+         * aflags still in xax from above; failing to reserve aflags if xax is
+         * taken; failing to get app aflags if xax is taken.
+         */
+        drvector_t only_xax;
+        drreg_init_and_fill_vector(&only_xax, false);
+        drreg_set_vector_entry(&only_xax, DR_REG_XAX, true);
+        res = drreg_reserve_register(drcontext, bb, inst, &only_xax, &reg);
+        CHECK(res == DRREG_SUCCESS, "reserve of xax should work");
+        res = drreg_reserve_aflags(drcontext, bb, inst);
+        CHECK(res == DRREG_SUCCESS, "reserve of aflags w/ xax taken should work");
+        res = drreg_restore_app_aflags(drcontext, bb, inst);
+        CHECK(res == DRREG_SUCCESS, "restore of app aflags should work");
+        res = drreg_unreserve_aflags(drcontext, bb, inst);
+        CHECK(res == DRREG_SUCCESS, "unreserve of aflags");
+        res = drreg_unreserve_register(drcontext, bb, inst, reg);
+        CHECK(res == DRREG_SUCCESS, "unreserve of xax should work");
+        drvector_delete(&only_xax);
+#endif
     } else if (subtest == DRREG_TEST_1_C ||
                subtest == DRREG_TEST_2_C ||
                subtest == DRREG_TEST_3_C) {


### PR DESCRIPTION
Adds support for several conflicts between aflags and xax on x86: failing
to reserve xax due to lazy aflags still residing in xax; failing to reserve
aflags if xax is taken; and failing to get the app aflags value if xax is
taken.  For the first one, we throw away the lazy aflags.  For the other
two, we reserve a temporary scratch register, xchg it with xax, and restore
it afterward.  We place aflags in TLS and do not try to keep it in a
register.

Issue: #511