### PR TITLE
Make the burst_threads template tighter

### DIFF
--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -15,12 +15,10 @@ Cache simulation results:
 Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
   L1I stats:
     Hits:                       *[0-9,\.]*
-    Misses:                     *[0-9,\.]*
-.*
+    Misses:                     *[0-9,\.]*.*
   L1D stats:
     Hits:                       *[0-9,\.]*
-    Misses:                     *[0-9,\.]*
-.*
+    Misses:                     *[0-9,\.]*.*
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
 Core #3 \([0-9] traced CPU\(s\).*


### PR DESCRIPTION
Tightens up the burst_threads test template to handle 0 hits and 0 misses,
in which case no miss rate line will be printed.