### PR TITLE
i#511 drreg: add drreg_is_instr_spill_or_restore()

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -226,7 +226,8 @@ Further non-compatibility-affecting changes include:
  - Added dr_where_am_i() to better support client self-profiling via sampling.
  - Added dr_get_stats() to retrieve runtime stats. Currently limited to number
    of built basic blocks.
- - Added drreg_reservation_info_ex() and drreg_statelessly_restore_app_value().
+ - Added drreg_reservation_info_ex(), drreg_statelessly_restore_app_value(),
+   and drreg_is_instr_spill_or_restore().
 
 **************************************************
 <hr>

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -5726,12 +5726,9 @@ dr_read_saved_reg(void *drcontext, dr_spill_slot_t slot)
                   "dr_read_saved_reg: drcontext is invalid");
     CLIENT_ASSERT(slot <= SPILL_SLOT_MAX,
                   "dr_read_saved_reg: invalid spill slot selection");
-
-    /* FIXME - should we allow clients to read other threads saved registers? It's not
-     * as dangerous as write, but I can't think of a usage scenario where you'd want to
-     * Seems more likely to be a bug.  */
-    CLIENT_ASSERT(dcontext == get_thread_private_dcontext(),
-                  "dr_read_saved_reg(): drcontext does not belong to current thread");
+    /* We do allow drcontext to not belong to the current thread, for state restoration
+     * during synchall and other scenarios.
+     */
 
     if (slot <= SPILL_SLOT_TLS_MAX) {
         ushort offs = SPILL_SLOT_TLS_OFFS[slot];
@@ -5754,12 +5751,9 @@ dr_write_saved_reg(void *drcontext, dr_spill_slot_t slot, reg_t value)
                   "dr_write_saved_reg: drcontext is invalid");
     CLIENT_ASSERT(slot <= SPILL_SLOT_MAX,
                   "dr_write_saved_reg: invalid spill slot selection");
-
-    /* FIXME - should we allow clients to write to other threads saved registers?
-     * I can't think of a usage scenario where that would be correct, seems much more
-     * likely to be a difficult to diagnose bug that crashes the app or dr.  */
-    CLIENT_ASSERT(dcontext == get_thread_private_dcontext(),
-                  "dr_write_saved_reg(): drcontext does not belong to current thread");
+    /* We do allow drcontext to not belong to the current thread, for state restoration
+     * during synchall and other scenarios.
+     */
 
     if (slot <= SPILL_SLOT_TLS_MAX) {
         ushort offs = SPILL_SLOT_TLS_OFFS[slot];

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -1591,6 +1591,72 @@ drreg_restore_app_aflags(void *drcontext, instrlist_t *ilist, instr_t *where)
  */
 
 static bool
+is_our_spill_or_restore(void *drcontext, instr_t *instr, bool *spill OUT,
+                        reg_id_t *reg_spilled OUT, uint *slot_out OUT,
+                        uint *offs_out OUT)
+{
+    bool tls;
+    uint slot, offs;
+    reg_id_t reg;
+    if (!instr_is_reg_spill_or_restore(drcontext, instr, &tls, spill, &reg, &offs))
+        return false;
+    /* Is this from our raw TLS? */
+    if (tls && offs >= tls_slot_offs &&
+        offs < (tls_slot_offs + ops.num_spill_slots*sizeof(reg_t))) {
+        slot = (offs - tls_slot_offs) / sizeof(reg_t);
+    } else {
+        /* We assume a DR spill slot, in TLS or thread-private mcontext */
+        if (tls) {
+            /* We assume the DR slots are either low-to-high or high-to-low. */
+            uint DR_min_offs =
+                opnd_get_disp(dr_reg_spill_slot_opnd(drcontext, SPILL_SLOT_1));
+            uint DR_max_offs =
+                opnd_get_disp(dr_reg_spill_slot_opnd
+                              (drcontext, dr_max_opnd_accessible_spill_slot()));
+            if (DR_min_offs > DR_max_offs)
+                DR_min_offs = DR_max_offs;
+            slot = (offs - DR_min_offs) / sizeof(reg_t);
+            if (slot > dr_max_opnd_accessible_spill_slot()) {
+                /* This is not a drreg spill, but some TLS access by
+                 * tool instrumentation (i#2035).
+                 */
+                return false;
+            }
+        } else {
+            /* We assume mcontext spill offs is 0 */
+            slot = offs / sizeof(reg_t);
+        }
+        slot += ops.num_spill_slots;
+    }
+    if (reg_spilled != NULL)
+        *reg_spilled = reg;
+    if (slot_out != NULL)
+        *slot_out = slot;
+    if (offs_out != NULL)
+        *offs_out = offs;
+    return true;
+}
+
+drreg_status_t
+drreg_is_instr_spill_or_restore(void *drcontext, instr_t *instr, bool *spill OUT,
+                                bool *restore OUT, reg_id_t *reg_spilled OUT)
+{
+    bool is_spill;
+    if (!is_our_spill_or_restore(drcontext, instr, &is_spill, reg_spilled, NULL, NULL)) {
+        if (spill != NULL)
+            *spill = false;
+        if (restore != NULL)
+            *restore = false;
+        return DRREG_SUCCESS;
+    }
+    if (spill != NULL)
+        *spill = is_spill;
+    if (restore != NULL)
+        *restore = !is_spill;
+    return DRREG_SUCCESS;
+}
+
+static bool
 drreg_event_restore_state(void *drcontext, bool restore_memory,
                           dr_restore_state_info_t *info)
 {
@@ -1608,11 +1674,12 @@ drreg_event_restore_state(void *drcontext, bool restore_memory,
     instr_t inst;
     byte *prev_pc, *pc = info->fragment_info.cache_start_pc;
     uint offs;
-    bool spill, tls;
+    bool spill;
 #ifdef X86
     bool prev_xax_spill = false;
     bool aflags_in_xax = false;
 #endif
+    uint slot;
     if (pc == NULL)
         return true; /* fault not in cache */
     for (reg = DR_REG_START_GPR; reg <= DR_REG_STOP_GPR; reg++)
@@ -1625,31 +1692,7 @@ drreg_event_restore_state(void *drcontext, bool restore_memory,
         prev_pc = pc;
         pc = decode(drcontext, pc, &inst);
 
-        /* XXX i#511: if we add xchg to our arsenal we'll have to detect it here */
-        if (instr_is_reg_spill_or_restore(drcontext, &inst, &tls, &spill, &reg, &offs)) {
-            uint slot;
-            /* Is this from our raw TLS? */
-            if (tls && offs >= tls_slot_offs &&
-                offs < (tls_slot_offs + ops.num_spill_slots*sizeof(reg_t))) {
-                slot = (offs - tls_slot_offs) / sizeof(reg_t);
-            } else {
-                /* We assume a DR spill slot, in TLS or thread-private mcontext */
-                if (tls) {
-                    uint DR_min_offs =
-                        opnd_get_disp(dr_reg_spill_slot_opnd(drcontext, SPILL_SLOT_1));
-                    slot = (offs - DR_min_offs) / sizeof(reg_t);
-                    if (slot > SPILL_SLOT_MAX) {
-                        /* This is not a drreg spill, but some TLS access by
-                         * tool instrumentation (i#2035).
-                         */
-                        continue;
-                    }
-                } else {
-                    /* We assume mcontext spill offs is 0 */
-                    slot = offs / sizeof(reg_t);
-                }
-                slot += ops.num_spill_slots;
-            }
+        if (is_our_spill_or_restore(drcontext, &inst, &spill, &reg, &slot, &offs)) {
             LOG(drcontext, DR_LOG_ALL, 3,
                 "%s @"PFX" found %s to %s offs=0x%x => slot %d\n",
                 __FUNCTION__, prev_pc, spill ? "spill" : "restore",

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -1622,8 +1622,18 @@ is_our_spill_or_restore(void *drcontext, instr_t *instr, bool *spill OUT,
                  */
                 return false;
             }
+            if (slot > 1) {
+                /* FIXME i#2933: We rule out the 3rd DR TLS slot b/c it's used by
+                 * DR for purposes where there's no restore paired with a spill.
+                 * Another tool component could also use the other slots that way,
+                 * though: we need a more foolproof solution.  For now we have a hole
+                 * and tools should allocate enough dedicated drreg TLS slots to
+                 * ensure robustness.
+                 */
+                return false;
+            }
         } else {
-            /* We assume mcontext spill offs is 0 */
+            /* We assume mcontext spill offs is 0-based. */
             slot = offs / sizeof(reg_t);
         }
         slot += ops.num_spill_slots;

--- a/ext/drreg/drreg.h
+++ b/ext/drreg/drreg.h
@@ -580,6 +580,22 @@ DR_EXPORT
 drreg_status_t
 drreg_set_bb_properties(void *drcontext, drreg_bb_properties_t flags);
 
+DR_EXPORT
+/**
+ * Analyzes \p instr and returns whether it is a drreg register spill
+ * in \p spill, a drreg register restore in \p restore, and which
+ * register is being spilled or restored in \p reg_spilled.  Each
+ * output parameter is optional and may be NULL.  If DR's spill slots
+ * are being used (see drreg_options_t.num_spill_slots), this routine
+ * may not be able to distinguish a drreg spill or restore from some
+ * other spill or restore.
+ *
+ * @return whether successful or an error code on failure.
+ */
+drreg_status_t
+drreg_is_instr_spill_or_restore(void *drcontext, instr_t *instr, bool *spill OUT,
+                                bool *restore OUT, reg_id_t *reg_spilled OUT);
+
 
 /*@}*/ /* end doxygen group */
 

--- a/suite/tests/client-interface/drreg-test.dll.c
+++ b/suite/tests/client-interface/drreg-test.dll.c
@@ -163,6 +163,27 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         /* test stateless restore when lazily unrestored */
         drreg_statelessly_restore_app_value(drcontext, bb, reg, inst, inst, NULL, NULL);
 
+        /* test spill-restore query */
+        bool is_dead;
+        res = drreg_is_register_dead(drcontext, reg, inst, &is_dead);
+        CHECK(res == DRREG_SUCCESS, "query should work");
+        instr_t *prev;
+        bool found_restore = false;
+        for (prev = instr_get_prev(inst); prev != NULL; prev = instr_get_prev(prev)) {
+            bool spill, restore;
+            reg_id_t which_reg;
+            res = drreg_is_instr_spill_or_restore(drcontext, prev, &spill, &restore,
+                                                  &which_reg);
+            CHECK(res == DRREG_SUCCESS, "spill query should work");
+            CHECK(!(spill && restore), "can't be both a spill and a restore");
+            if (restore) {
+                found_restore = true;
+                CHECK(which_reg == reg || is_dead, "expected restore of given reg");
+                break;
+            }
+        }
+        CHECK(found_restore || is_dead, "failed to find restore");
+
         /* test aflags */
         res = drreg_reservation_info_ex(drcontext, DR_REG_NULL, &info);
         CHECK(res == DRREG_SUCCESS && !info.reserved &&


### PR DESCRIPTION
Adds a query routine to identify whether an instruction is a spill or
restore generated by drreg.

Adds a sanity check test.

Issue: #511