### PR TITLE
Avoid virtual call overhead of sizeof_entry

### DIFF
--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -62,7 +62,7 @@ public:
         instr_size(instruction_size) {}
     virtual ~instru_t() {}
 
-    size_t sizeof_entry() const { return instr_size; };
+    size_t sizeof_entry() const { return instr_size; }
 
     virtual trace_type_t get_entry_type(byte *buf_ptr) const = 0;
     virtual size_t get_entry_size(byte *buf_ptr) const = 0;

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -62,6 +62,8 @@ public:
         instr_size(instruction_size) {}
     virtual ~instru_t() {}
 
+    instru_t &operator=(instru_t&) = delete;
+
     size_t sizeof_entry() const { return instr_size; }
 
     virtual trace_type_t get_entry_type(byte *buf_ptr) const = 0;

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -54,13 +54,15 @@ public:
     instru_t(void (*insert_load_buf)(void *, instrlist_t *,
                                      instr_t *, reg_id_t),
              bool memref_needs_info,
-             drvector_t *reg_vector_in)
+             drvector_t *reg_vector_in,
+             size_t instruction_size)
         : insert_load_buf_ptr(insert_load_buf),
         memref_needs_full_info(memref_needs_info),
-        reg_vector(reg_vector_in) {}
+        reg_vector(reg_vector_in),
+        instr_size(instruction_size) {}
     virtual ~instru_t() {}
 
-    virtual size_t sizeof_entry() const = 0;
+    size_t sizeof_entry() const { return instr_size; };
 
     virtual trace_type_t get_entry_type(byte *buf_ptr) const = 0;
     virtual size_t get_entry_size(byte *buf_ptr) const = 0;
@@ -113,7 +115,9 @@ protected:
     drvector_t *reg_vector;
 
 private:
-    instru_t() {}
+    instru_t(): instr_size(0) {}
+
+    const size_t instr_size;
 };
 
 class online_instru_t : public instru_t
@@ -124,8 +128,6 @@ public:
                     bool memref_needs_info,
                     drvector_t *reg_vector);
     virtual ~online_instru_t();
-
-    virtual size_t sizeof_entry() const;
 
     virtual trace_type_t get_entry_type(byte *buf_ptr) const;
     virtual size_t get_entry_size(byte *buf_ptr) const;
@@ -177,8 +179,6 @@ public:
                                            size_t count),
                      file_t module_file);
     virtual ~offline_instru_t();
-
-    virtual size_t sizeof_entry() const;
 
     virtual trace_type_t get_entry_type(byte *buf_ptr) const;
     virtual size_t get_entry_size(byte *buf_ptr) const;

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -59,7 +59,7 @@ offline_instru_t::offline_instru_t(void (*insert_load_buf)(void *, instrlist_t *
                                                          size_t count),
                                    file_t module_file)
   : instru_t(insert_load_buf, memref_needs_info, reg_vector,
-             sizeof(trace_entry_t)),
+             sizeof(offline_entry_t)),
     write_file_func(write_file), modfile(module_file)
 {
     drcovlib_status_t res = drmodtrack_init();

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -58,7 +58,8 @@ offline_instru_t::offline_instru_t(void (*insert_load_buf)(void *, instrlist_t *
                                                          const void *data,
                                                          size_t count),
                                    file_t module_file)
-  : instru_t(insert_load_buf, memref_needs_info, reg_vector),
+  : instru_t(insert_load_buf, memref_needs_info, reg_vector,
+             sizeof(trace_entry_t)),
     write_file_func(write_file), modfile(module_file)
 {
     drcovlib_status_t res = drmodtrack_init();
@@ -168,12 +169,6 @@ offline_instru_t::custom_module_data
     user_print = print_cb;
     user_free = free_cb;
     return true;
-}
-
-size_t
-offline_instru_t::sizeof_entry() const
-{
-    return sizeof(offline_entry_t);
 }
 
 trace_type_t

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -45,18 +45,13 @@ online_instru_t::online_instru_t(void (*insert_load_buf)(void *, instrlist_t *,
                                                          instr_t *, reg_id_t),
                                  bool memref_needs_info,
                                  drvector_t *reg_vector)
-    : instru_t(insert_load_buf, memref_needs_info, reg_vector)
+    : instru_t(insert_load_buf, memref_needs_info, reg_vector,
+               sizeof(offline_entry_t))
 {
 }
 
 online_instru_t::~online_instru_t()
 {
-}
-
-size_t
-online_instru_t::sizeof_entry() const
-{
-    return sizeof(trace_entry_t);
 }
 
 trace_type_t

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -46,7 +46,7 @@ online_instru_t::online_instru_t(void (*insert_load_buf)(void *, instrlist_t *,
                                  bool memref_needs_info,
                                  drvector_t *reg_vector)
     : instru_t(insert_load_buf, memref_needs_info, reg_vector,
-               sizeof(offline_entry_t))
+               sizeof(trace_entry_t))
 {
 }
 

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -82,7 +82,7 @@ if ($child) {
         $mydir = `/usr/bin/cygpath -wi \"$mydir\"`;
         chomp $mydir;
     }
-    system("ctest --output-on-failure -V -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
+    system("ctest --output-on-failure -VV -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
     exit 0;
 }
 

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -82,7 +82,7 @@ if ($child) {
         $mydir = `/usr/bin/cygpath -wi \"$mydir\"`;
         chomp $mydir;
     }
-    system("ctest --output-on-failure -VV -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
+    system("ctest --output-on-failure -V -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
     exit 0;
 }
 


### PR DESCRIPTION
De-virtualized `sizeof_entry` by converting it to a field and
relying on derived classes to specify its value.

This was noticed while running an internal app under linux `perf` sampling, where `sizeof_entry` appeared as a very hot function.