### PR TITLE
i#140 client prof: eliminate unknown whereami instances

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -223,7 +223,8 @@ Further non-compatibility-affecting changes include:
    drmgr_unregister_pre_syscall_event_user_data() to enable passing of user data.
  - Added drmgr_register_post_syscall_event_user_data() and
    drmgr_unregister_post_syscall_event_user_data() to enable passing of user data.
- - Added dr_where_am_i() to better support client self-profiling via sampling.
+ - Added dr_where_am_i(), dr_track_where_am_i(), and dr_is_tracking_where_am_i()
+   better support client self-profiling via sampling.
  - Added dr_get_stats() to retrieve runtime stats. Currently limited to number
    of built basic blocks.
  - Added drreg_reservation_info_ex(), drreg_statelessly_restore_app_value(),

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -690,11 +690,9 @@ instrument_clean_call(void *drcontext, instrlist_t *ilist, instr_t *where,
      * proc to clean call gencode.
      */
     /* i#2147: -prof_pcs adds extra cleancall code that makes jecxz not reach.
-     * XXX: it would be nice to have a more robust solution than this explicit check
-     * for that DR option!
+     * XXX: it would be nice to have a more robust solution than this explicit check!
      */
-    uint64 prof_pcs;
-    if (dr_get_integer_option("profile_pcs", &prof_pcs) && prof_pcs)
+    if (dr_is_tracking_where_am_i())
         short_reaches = false;
 #elif defined(ARM)
     /* XXX: clean call is too long to use cbz to skip. */

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -424,7 +424,7 @@ insert_meta_call_vargs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     IF_X64(ASSERT(ALIGNED(stack_for_params, 16)));
 
 #ifdef CLIENT_INTERFACE
-    if (TEST(META_CALL_CLEAN, flags) && DYNAMO_OPTION(profile_pcs)) {
+    if (TEST(META_CALL_CLEAN, flags) && should_track_where_am_i()) {
         if (SCRATCH_ALWAYS_TLS()) {
 # ifdef AARCHXX
             /* DR_REG_LR is dead here */
@@ -479,7 +479,7 @@ insert_meta_call_vargs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     }
 
 #ifdef CLIENT_INTERFACE
-    if (TEST(META_CALL_CLEAN, flags) && DYNAMO_OPTION(profile_pcs)) {
+    if (TEST(META_CALL_CLEAN, flags) && should_track_where_am_i()) {
         uint whereami;
 
         if (TEST(META_CALL_RETURNS_TO_NATIVE, flags))

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -1200,11 +1200,14 @@ fcache_refine_whereami(dcontext_t *dcontext, dr_where_am_i_t whereami, app_pc pc
              * It's all generated and post-process can't identify.
              * Assume code order is as follows:
              */
-            if (in_context_switch_code(dcontext, (cache_pc)pc)) {
-                whereami = DR_WHERE_CONTEXT_SWITCH;
-            } else if (in_indirect_branch_lookup_code(dcontext,
-                                                      (cache_pc)pc)) {
+            if (in_indirect_branch_lookup_code(dcontext, (cache_pc)pc)) {
                 whereami = DR_WHERE_IBL;
+            } else if (in_generated_routine(dcontext, (cache_pc)pc)) {
+                /* We consider any non-ibl generated code as "context switch":
+                 * not just private or shared fcache_{enter,return} but also
+                 * do_syscall and other common transition code.
+                 */
+                whereami = DR_WHERE_CONTEXT_SWITCH;
             } else {
                 whereami = DR_WHERE_UNKNOWN;
             }

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -298,6 +298,8 @@ DECLARE_CXTSWPROT_VAR(static mutex_t client_thread_count_lock,
 
 static vm_area_vector_t *client_aux_libs;
 
+static bool track_where_am_i;
+
 #ifdef WINDOWS
 DECLARE_CXTSWPROT_VAR(static mutex_t client_aux_lib64_lock,
                       INIT_LOCK_FREE(client_aux_lib64_lock));
@@ -5062,6 +5064,26 @@ dr_get_itimer(int which)
     return get_itimer_frequency(dcontext, which);
 }
 # endif /* UNIX */
+
+DR_API
+void
+dr_track_where_am_i(void)
+{
+    track_where_am_i = true;
+}
+
+bool
+should_track_where_am_i(void)
+{
+    return track_where_am_i || DYNAMO_OPTION(profile_pcs);
+}
+
+DR_API
+bool
+dr_is_tracking_where_am_i(void)
+{
+    return should_track_where_am_i();
+}
 
 DR_API
 dr_where_am_i_t

--- a/core/lib/instrument.h
+++ b/core/lib/instrument.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -145,6 +145,7 @@ bool dr_thread_exit_hook_exists(void);
 bool dr_exit_hook_exists(void);
 bool dr_xl8_hook_exists(void);
 bool hide_tag_from_client(app_pc tag);
+bool should_track_where_am_i(void);
 
 uint instrument_persist_ro_size(dcontext_t *dcontext, void *perscxt, size_t file_offs);
 bool instrument_persist_ro(dcontext_t *dcontext, void *perscxt, file_t fd);

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -4781,10 +4781,30 @@ dr_get_itimer(int which);
 
 DR_API
 /**
+ * Should be called during process initialization.  Requests more accurate
+ * tracking of the #dr_where_am_i_t value for use with dr_where_am_i().  By
+ * default, if this routine is not called, DR avoids some updates to the value
+ * that incur extra overhead, such as identifying clean callees.
+ */
+void
+dr_track_where_am_i(void);
+
+DR_API
+/**
+ * Returns whether DR is using accurate tracking of the #dr_where_am_i value.
+ * Typically this is enabled by calling dr_track_where_am_i().
+ */
+bool
+dr_is_tracking_where_am_i(void);
+
+DR_API
+/**
  * Returns the #dr_where_am_i_t value indicating in which area of code \p pc
  * resides.  This is meant for use with dr_set_itimer() for PC sampling for
- * profiling purposes.  If the optional \p tag is non-NULL and \p pc is inside
- * a fragment in the code cache, the fragment's tag is returned in \p tag.
+ * profiling purposes.  If the optional \p tag is non-NULL and \p pc is inside a
+ * fragment in the code cache, the fragment's tag is returned in \p tag.  It is
+ * recommended that the user of this routine also call dr_track_where_am_i()
+ * during process initialization for more accurate results.
  */
 dr_where_am_i_t
 dr_where_am_i(void *drcontext, app_pc pc, OUT void**tag);

--- a/core/synch.c
+++ b/core/synch.c
@@ -623,6 +623,7 @@ at_safe_spot(thread_record_t *trec, priv_mcontext_t *mc,
     }
     if (safe) {
         ASSERT(trec->dcontext->whereami == DR_WHERE_FCACHE ||
+               trec->dcontext->whereami == DR_WHERE_SIGNAL_HANDLER ||
                is_thread_currently_native(trec));
         LOG(THREAD_GET, LOG_SYNCH, 2,
             "thread "TIDFMT" suspended at safe spot pc="PFX"\n", trec->id, mc->pc);

--- a/suite/tests/client-interface/timer.dll.c
+++ b/suite/tests/client-interface/timer.dll.c
@@ -120,6 +120,8 @@ void dr_init(client_id_t id)
     dr_register_exit_event(exit_event);
     dr_register_post_syscall_event(post_syscall_event);
     dr_register_filter_syscall_event(filter_syscall_event);
+    dr_track_where_am_i();
+    DR_ASSERT(dr_is_tracking_where_am_i());
     if (!dr_set_itimer(ITIMER_REAL, 25, event_timer))
         dr_fprintf(STDERR, "unable to set timer callback\n");
     /* Test pc sampling (i#140). */


### PR DESCRIPTION
Adds a new API routine dr_track_where_am_i() which enables tracking of
whereami for clean calls.  This is off by default for performance reasons,
which leads to clean calls being labeled initially DR_WHERE_FCACHE and then
refined into DR_WHERE_UNKNOWN.

Adds a query routine dr_is_tracking_where_am_i() for use in the tracer
where this tracking causes a short jump to not reach (#2147).

Cleans up a hole in whereami tracking to include shared context switch code
and do_syscall code along with other generated transition code as
DR_WHERE_CONTEXT_SWITCH.

Adds labeling of DR_WHERE_SIGNAL_HANDLER for at least the ksynch_wait on a
suspend signal; including other handler code is trickier and is left for
future work.

Issue: #140