### PR TITLE
i#2796: Add missing break in find_nzcv_spill_reg

### DIFF
--- a/core/arch/aarch64/clean_call_opt.c
+++ b/core/arch/aarch64/clean_call_opt.c
@@ -167,6 +167,7 @@ find_nzcv_spill_reg(callee_info_t *ci)
         if (reg == ci->spill_reg || ci->reg_used[i])
             continue;
         spill_reg = reg;
+        break;
     }
     ASSERT(spill_reg != DR_REG_INVALID);
     return spill_reg;


### PR DESCRIPTION
Break from loop in find_nzcv_spill_reg when spill register found.

Issue: #2796