### PR TITLE
Remove unused POST and PRE defines from clean_call_opt_shared.c

### DIFF
--- a/core/arch/clean_call_opt_shared.c
+++ b/core/arch/clean_call_opt_shared.c
@@ -46,13 +46,6 @@
 #include "instr_create.h"
 #include "clean_call_opt.h"
 
-/* make code more readable by shortening long lines
- * we mark everything we add as a meta-instr to avoid hitting
- * client asserts on setting translation fields
- */
-#define POST instrlist_meta_postinsert
-#define PRE  instrlist_meta_preinsert
-
 /****************************************************************************
  * clean call callee info table for i#42 and i#43
  */


### PR DESCRIPTION
Those macros are not used in the file and there is only one use of
instrlist_meta_preinsert.

Change-Id: I4c7390d6aa6fca9febd19d739f009a91e2f67c93