### PR TITLE
Revert "i#2006 Split segments and record segment offsets (#2940)"

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -229,9 +229,6 @@ Further non-compatibility-affecting changes include:
    of built basic blocks.
  - Added drreg_reservation_info_ex(), drreg_statelessly_restore_app_value(),
    and drreg_is_instr_spill_or_restore().
- - drmodtrack now allocates an entry per segment for each loaded module.
-   Added a file offset field to module_segment_data_t for UNIX platforms.
-   drcachesim saves file offset information in modules.log on UNIX platforms.
 
 **************************************************
 <hr>

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1813,7 +1813,6 @@ create_and_initialize_module_data(app_pc start, app_pc end, app_pc entry_point,
             copy->segments[i].start = os_segments[i].start;
             copy->segments[i].end = os_segments[i].end;
             copy->segments[i].prot = os_segments[i].prot;
-            copy->segments[i].offset = os_segments[i].offset;
         }
     } else {
         ASSERT(segments != NULL);

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -2918,7 +2918,6 @@ typedef struct _module_segment_data_t {
     app_pc start; /**< Start address of the segment, page-aligned backward. */
     app_pc end;   /**< End address of the segment, page-aligned forward. */
     uint prot;    /**< Protection attributes of the segment */
-    uint64 offset; /**< Offset of the segment from the beginning of the backing file */
 } module_segment_data_t;
 #endif
 

--- a/core/unix/module.c
+++ b/core/unix/module.c
@@ -470,8 +470,7 @@ module_add_segment_data(OUT os_module_data_t *out_data,
                         size_t segment_size,
                         uint segment_prot, /* MEMPROT_ */
                         size_t alignment,
-                        bool shared,
-                        uint64 offset)
+                        bool shared)
 {
     uint seg, i;
     if (out_data->alignment == 0) {
@@ -523,7 +522,6 @@ module_add_segment_data(OUT os_module_data_t *out_data,
         ALIGN_FORWARD(segment_start + segment_size, PAGE_SIZE);
     out_data->segments[seg].prot = segment_prot;
     out_data->segments[seg].shared = shared;
-    out_data->segments[seg].offset = offset;
     if (seg > 0) {
         ASSERT(out_data->segments[seg].start >= out_data->segments[seg - 1].end);
         if (out_data->segments[seg].start > out_data->segments[seg - 1].end)

--- a/core/unix/module.h
+++ b/core/unix/module.h
@@ -48,7 +48,6 @@ typedef struct _module_segment_t {
     app_pc end;
     uint prot;
     bool shared; /* not unique to this module */
-    uint64 offset;
 } module_segment_t;
 
 typedef struct _os_module_data_t {
@@ -152,8 +151,7 @@ module_add_segment_data(OUT os_module_data_t *out_data,
                         size_t segment_size,
                         uint segment_prot,
                         size_t alignment,
-                        bool shared,
-                        uint64 offset);
+                        bool shared);
 
 /* Redirected functions for loaded module,
  * they are also used by __wrap_* functions in instrument.c

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -539,8 +539,7 @@ module_walk_program_headers(app_pc base, size_t view_size, bool at_map, bool dyn
                                             (app_pc) prog_hdr->p_vaddr + load_delta,
                                             prog_hdr->p_memsz,
                                             module_segment_prot_to_osprot(prog_hdr),
-                                            prog_hdr->p_align, false/*!shared*/,
-                                            prog_hdr->p_offset);
+                                            prog_hdr->p_align, false/*!shared*/);
                 }
                 found_load = true;
             }

--- a/core/unix/module_macho.c
+++ b/core/unix/module_macho.c
@@ -288,8 +288,7 @@ module_walk_program_headers(app_pc base, size_t view_size, bool at_map, bool dyn
                               * ignoring for now
                               */
                              PAGE_SIZE,
-                             shared,
-                             seg->fileoff);
+                             shared);
                     }
                 } else if (cmd->cmd == LC_SYMTAB) {
                     /* even if stripped, dynamic symbols are in this table */

--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -249,10 +249,6 @@ typedef struct _drmodtrack_info_t {
      * passed to drmodtrack_offline_lookup().
      */
     uint index;
-    /**
-     * The offset of this segment from the beginning of this backing file.
-     */
-    uint64 offset;
 } drmodtrack_info_t;
 
 DR_EXPORT

--- a/suite/tests/client-interface/drmodtrack-test.dll.cpp
+++ b/suite/tests/client-interface/drmodtrack-test.dll.cpp
@@ -38,7 +38,6 @@
 #include "drx.h"
 #include "client_tools.h"
 #include "string.h"
-#include "stddef.h"
 
 #ifdef WINDOWS
 # pragma warning( disable : 4100) /* unreferenced formal parameter */
@@ -133,19 +132,6 @@ event_exit(void)
         CHECK(((app_pc)info.custom) == info.start ||
               info.containing_index != i, "custom field doesn't match");
         CHECK(info.index == i, "index field doesn't match");
-#ifndef WINDOWS
-        if (info.struct_size > offsetof(drmodtrack_info_t, offset)) {
-            module_data_t * data = dr_lookup_module(info.start);
-            for (uint j = 0; j < data->num_segments; j++) {
-                module_segment_data_t *seg = data->segments + j;
-                if (seg->start == info.start) {
-                    CHECK(seg->offset == info.offset,
-                        "Module data offset and drmodtrack offset don't match");
-                }
-            }
-            dr_free_module_data(data);
-        }
-#endif
     }
 
     char *buf_offline;


### PR DESCRIPTION
This reverts commit 8c90e2dc81eb9b9dfdcf2313bdf91b02f12c4de4 as it pushes
the module count for drcachesim offline traces beyond the limit in the
module index bitfield (#2956).

Issue: #2006, #2939, #2956.