### PR TITLE
Fix most warnings generated by Clang 5.0 on AArch64.

### DIFF
--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -510,7 +510,7 @@ static inline int64 atomic_add_exchange_int64(volatile int64 *var, int64 value) 
      ASSERT_CURIOSITY(!hot_patch);                                    \
      /* Aligned load/store instructions are atomic on AArch64. */     \
      ASSERT(ALIGNED(target, 4));                                      \
-     __asm__ __volatile__("str %0, [%1]"                              \
+     __asm__ __volatile__("str %w0, [%1]"                             \
                           : : "r"  (value), "r" (target) : "memory"); \
    } while (0)
 #  define ATOMIC_8BYTE_WRITE(target, value, hot_patch) do {           \

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -921,6 +921,7 @@ bb_process_invalid_instr(dcontext_t *dcontext, build_bb_t *bb)
     }
 }
 
+/* FIXME i#1668, i#2974: NYI on ARM/AArch64 */
 #ifdef X86
 /* returns true to indicate "elide and continue" and false to indicate "end bb now"
  * should be used both for converted indirect jumps and
@@ -2326,6 +2327,7 @@ bb_process_convertible_indcall(dcontext_t *dcontext, build_bb_t *bb)
     return false; /* stop bb */
 }
 
+/* FIXME i#1668, i#2974: NYI on ARM/AArch64 */
 #ifdef X86
 /* if we make the IAT sections unreadable we will need to map to proper location */
 static inline app_pc
@@ -5713,6 +5715,7 @@ tracelist_add(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where, instr_t 
     return size;
 }
 
+/* FIXME i#1668, i#2974: NYI on ARM/AArch64 */
 #ifdef X86
 /* Combines instrlist_postinsert to ilist and the size calculation of the addition */
 static inline int
@@ -5829,7 +5832,7 @@ instr_is_trace_cmp(dcontext_t *dcontext, instr_t *inst)
 # endif
         ;
 #elif defined(AARCHXX)
-    /* FIXME i#1551, i#1569: NYI on ARM/AArch64 */
+    /* FIXME i#1668, i#2974: NYI on ARM/AArch64 */
     ASSERT_NOT_IMPLEMENTED(DYNAMO_OPTION(disable_traces));
     return false;
 #endif

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -921,6 +921,7 @@ bb_process_invalid_instr(dcontext_t *dcontext, build_bb_t *bb)
     }
 }
 
+#ifdef X86
 /* returns true to indicate "elide and continue" and false to indicate "end bb now"
  * should be used both for converted indirect jumps and
  * FIXME: for direct jumps by bb_process_ubr
@@ -952,6 +953,7 @@ follow_direct_jump(dcontext_t *dcontext, build_bb_t *bb,
     }
     return false;               /* stop bb */
 }
+#endif /* X86 */
 
 /* returns true to indicate "elide and continue" and false to indicate "end bb now" */
 static inline bool
@@ -2324,6 +2326,7 @@ bb_process_convertible_indcall(dcontext_t *dcontext, build_bb_t *bb)
     return false; /* stop bb */
 }
 
+#ifdef X86
 /* if we make the IAT sections unreadable we will need to map to proper location */
 static inline app_pc
 read_from_IAT(app_pc iat_reference)
@@ -2334,7 +2337,6 @@ read_from_IAT(app_pc iat_reference)
     return *(app_pc*) iat_reference;
 }
 
-#ifdef X86
 /* returns whether target is an IAT of a module that we convert.  Note
  * users still have to check the referred to value to verify targeting
  * a native module.
@@ -5711,6 +5713,7 @@ tracelist_add(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where, instr_t 
     return size;
 }
 
+#ifdef X86
 /* Combines instrlist_postinsert to ilist and the size calculation of the addition */
 static inline int
 tracelist_add_after(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
@@ -5720,16 +5723,17 @@ tracelist_add_after(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
      * anyway, and we'll re-use any memory allocated here for an encoding
      */
     int size;
-#if defined(X86) && defined(X64)
+# ifdef X64
     if (!X64_CACHE_MODE_DC(dcontext)) {
         instr_set_x86_mode(inst, true/*x86*/);
         instr_shrink_to_32_bits(inst);
     }
-#endif
+# endif
     size = instr_length(dcontext, inst);
     instrlist_postinsert(ilist, where, inst);
     return size;
 }
+#endif /* X86 */
 
 #ifdef HASHTABLE_STATISTICS
 /* increments a given counter - assuming XCX/R2 is dead */

--- a/core/arch/opnd_shared.c
+++ b/core/arch/opnd_shared.c
@@ -781,7 +781,7 @@ opnd_set_index_extend(opnd_t *opnd, dr_extend_type_t extend, bool scaled)
         CLIENT_ASSERT(false, "opnd_set_index_shift called on invalid opnd type");
         return false;
     }
-    if (extend < 0 || extend > 7) {
+    if (extend > 7) {
         CLIENT_ASSERT(false, "opnd index extend: invalid extend type");
         return false;
     }

--- a/core/lib/dr_helper.c
+++ b/core/lib/dr_helper.c
@@ -49,7 +49,7 @@ internal_error(const char *file, int line, const char *expr)
 void
 clear_icache(void *beg, void *end)
 {
-    static uint cache_info = 0;
+    static size_t cache_info = 0;
     size_t dcache_line_size;
     size_t icache_line_size;
     ptr_uint_t beg_uint = (ptr_uint_t)beg;

--- a/suite/tests/api/dis-a64.c
+++ b/suite/tests/api/dis-a64.c
@@ -174,7 +174,7 @@ run_test(void *dc, const char *file, bool verbose)
     end = map_base + map_size;
     while (s < end) {
         byte *t = memchr(s, '\n', end - s);
-        do_line(dc, s, (t == NULL ? end : t) - s, verbose, &failed);
+        do_line(dc, (const char *) s, (t == NULL ? end : t) - s, verbose, &failed);
         s = (t == NULL ? end : t + 1);
     }
 

--- a/suite/tests/client-interface/syscall-mod.c
+++ b/suite/tests/client-interface/syscall-mod.c
@@ -45,12 +45,12 @@
 
 int main()
 {
-    int64_t pid;
+    int pid;
     fprintf(stderr, "starting\n");
 #if defined(AARCH64)
     asm("movz x8, " STRINGIFY(SYS_getpid) ";"
         "svc 0;"
-        "mov %0, x0" : "=r"(pid));
+        "mov %w0, w0" : "=r"(pid));
 #elif defined(X64)
     /* we don't want vsyscall since we rely on mov immed, eax being in same bb.
      * plus, libc getpid might cache the pid value.
@@ -63,7 +63,7 @@ int main()
         "int $0x80;"
         "mov %%eax, %0" : "=m"(pid));
 #endif
-    fprintf(stderr, "pid = %lld\n", (long long)pid);
+    fprintf(stderr, "pid = %d\n", pid);
 
     return 0;
 }

--- a/suite/tests/client-interface/syscall-mod.c
+++ b/suite/tests/client-interface/syscall-mod.c
@@ -45,7 +45,7 @@
 
 int main()
 {
-    int pid;
+    int64_t pid;
     fprintf(stderr, "starting\n");
 #if defined(AARCH64)
     asm("movz x8, " STRINGIFY(SYS_getpid) ";"
@@ -63,7 +63,7 @@ int main()
         "int $0x80;"
         "mov %%eax, %0" : "=m"(pid));
 #endif
-    fprintf(stderr, "pid = %d\n", pid);
+    fprintf(stderr, "pid = %lld\n", (long long)pid);
 
     return 0;
 }


### PR DESCRIPTION
For the dr_extend_type_t enum type, Clang decided that it is unsigned.
I am not sure if we can rely on Gcc to agree or how to ensure that.