### PR TITLE
i#2947: fix gcc 7.3.1 error missing __divdi3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -580,6 +580,18 @@ if (UNIX)
 
   check_if_linker_is_gnu_gold(LINKER_IS_GNU_GOLD)
 
+  # FIXME i#2949: static 32-bit release-build linking with gcc 7.3.1 fails when
+  # static C++ clients like drmemtrace or drmemtrace_raw2trace are linked in.
+  # For now we disable those builds.
+  if (UNIX AND NOT X64 AND NOT DEBUG AND NOT CLANG AND
+      "${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER "7.3")
+    message(STATUS "gcc 7.3+ non-debug 32-bit detected: disabling static C++ client "
+      "tests to work around i#2949")
+    set(DISABLE_FOR_BUG_2949 ON)
+  else ()
+    set(DISABLE_FOR_BUG_2949 OFF)
+  endif ()
+
 else (UNIX)
 
   if (NOT ${COMPILER_BASE_NAME} STREQUAL "cl")

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -373,7 +373,6 @@ endif ()
 # We build larger executables here.  All tests are added in suite/tests/ except unit tests.
 # Be sure to give the targets qualified test names ("tool.drcache*...").
 
-
 if (BUILD_TESTS)
   add_executable(tool.drcachesim.unit_tests tests/drcachesim_unit_tests.cpp)
   if (ZLIB_FOUND)
@@ -388,7 +387,8 @@ if (BUILD_TESTS)
            COMMAND tool.drcachesim.unit_tests)
   # FIXME i#2007: fails to link on A64
   # XXX i#1997: dynamorio_static is not supported on Mac yet
-  if (NOT AARCH64 AND NOT APPLE)
+  # FIXME i#2949: gcc 7.3 fails to link certain configs
+  if (NOT AARCH64 AND NOT APPLE AND NOT DISABLE_FOR_BUG_2949)
     add_executable(tool.drcacheoff.burst_static tests/burst_static.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_static)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_static drmemtrace_static)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2623,7 +2623,8 @@ if (CLIENT_INTERFACE)
       # FIXME i#2007: fails to link on A64
       # XXX i#1551: startstop API is NYI on ARM
       # XXX i#1997: dynamorio_static is not supported on Mac yet
-      if (NOT AARCH64 AND NOT ARM AND NOT APPLE)
+      # FIXME i#2949: gcc 7.3 fails to link certain configs
+      if (NOT AARCH64 AND NOT ARM AND NOT APPLE AND NOT DISABLE_FOR_BUG_2949)
         torunonly_drcacheoff(burst_static tool.drcacheoff.burst_static "" "" "")
         set(tool.drcacheoff.burst_static_nodr ON)
 


### PR DESCRIPTION
Adds signed 64-bit division helper routines to complement the unsigned we
already have for the core.  The signed is needed for gcc 7.3.1 32-bit
release builds.

Disables static drmemtrace tests as a workaround for gcc 7.3.+ link errors
for 32-bit non-debug builds.

Issue #2949
Fixes #2947