### PR TITLE
i#2976: avoid drcachesim vsyscall hook copying

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -491,12 +491,12 @@ raw2trace_t::append_bb_entries(uint tidx, offline_entry_t *in_entry, OUT bool *h
         } else {
             pc = instr_get_raw_bits(instr) + instr_length(dcontext, instr);
         }
-        CHECK(!instr_is_cti(instr) || i == instr_count - 1, "invalid cti");
-        // FIXME i#1729: make bundles via lazy accum until hit memref/end.
         DO_VERBOSE(3, {
             instr_set_translation(instr, orig_pc);
             dr_print_instr(dcontext, STDOUT, instr, "");
         });
+        CHECK(!instr_is_cti(instr) || i == instr_count - 1, "invalid cti");
+        // FIXME i#1729: make bundles via lazy accum until hit memref/end.
         buf->type = instru_t::instr_to_instr_type(instr);
         if (buf->type == TRACE_TYPE_INSTR_MAYBE_FETCH) {
             // We want it to look like the original rep string, with just one instr

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -1494,6 +1494,11 @@ dynamo_process_exit(void)
             callback_interception_unintercept();
         }
 # endif
+# ifdef UNIX
+        /* i#2976: unhook prior to client exit if modules are being watched */
+        if (dr_modload_hook_exists())
+            unhook_vsyscall();
+# endif
         /* Must be after fragment_exit() so that the client gets all the
          * fragment_deleted() callbacks (xref PR 228156).  FIXME - might be issues
          * with the client trying to use api routines that depend on fragment state.


### PR DESCRIPTION
Fixes drcachesim offline test failures for 32-bit release build where the
vsyscall hook is copied by unhooking in release build if a module load
event is present.

Fixes #2976