### PR TITLE
i#2907 early itimer: delay itimer until handlers are in place

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -2853,7 +2853,7 @@ dynamo_thread_not_under_dynamo(dcontext_t *dcontext)
 
 #define MAX_TAKE_OVER_ATTEMPTS 4
 
-/* Take over other threads in the current process.
+/* Mark this thread as under DR, and take over other threads in the current process.
  */
 void
 dynamorio_take_over_threads(dcontext_t *dcontext)
@@ -2865,6 +2865,10 @@ dynamorio_take_over_threads(dcontext_t *dcontext)
     uint attempts = 0;
 
     os_process_under_dynamorio_initiate(dcontext);
+    /* We can start this thread now that we've set up process-wide actions such
+     * as handling signals.
+     */
+    dynamo_thread_under_dynamo(dcontext);
     signal_event(dr_app_started);
     /* XXX i#1305: we should suspend all the other threads for DR init to
      * satisfy the parts of the init process that assume there are no races.

--- a/core/globals.h
+++ b/core/globals.h
@@ -577,6 +577,7 @@ int dynamo_process_exit(void);
 #ifdef UNIX
 void dynamorio_fork_init(dcontext_t *dcontext);
 #endif
+/* This calls dynamo_thread_under_dynamo() for the current thread as well. */
 void dynamorio_take_over_threads(dcontext_t *dcontext);
 dr_statistics_t * get_dr_stats(void);
 


### PR DESCRIPTION
Addresses one init-time itimer race still in place: the initial thread's
itimer is set up prior to putting the signal handlers in place.  We delay
that here to eliminate the problematic time window.

Tested on a third-party app which crashed with SIGVTALRM 8x out of 3000
before this fix and 0x after.

Issue: #2907