### PR TITLE
i#2990: translate si_addr if a PC

### DIFF
--- a/suite/tests/common/decode-bad.c
+++ b/suite/tests/common/decode-bad.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -69,9 +69,13 @@ static bool invalid_lock;
 
 #ifdef UNIX
 static void
-signal_handler(int sig)
+signal_handler(int sig, siginfo_t *info, ucontext_t *ucxt)
 {
     if (sig == SIGILL) {
+        if ((greg_t)info->si_addr != ucxt->uc_mcontext.gregs[REG_RIP]) {
+            print("ERROR: si_addr=%p does not match rip=%p\n", info->si_addr,
+                  ucxt->uc_mcontext.gregs[REG_RIP]);
+        }
         count++;
         if (invalid_lock) {
             print("Invalid lock sequence, instance %d\n", count);

--- a/suite/tests/common/decode-bad.c
+++ b/suite/tests/common/decode-bad.c
@@ -68,13 +68,22 @@ static int count = 0;
 static bool invalid_lock;
 
 #ifdef UNIX
+# ifdef X86
+#  ifdef X64
+#   define REG_XIP REG_RIP
+#  else
+#   define REG_XIP REG_EIP
+#  endif
+# else
+#  error NYI /* FIXME i#1551, i#1569: port asm to ARM and AArch64 */
+# endif
 static void
 signal_handler(int sig, siginfo_t *info, ucontext_t *ucxt)
 {
     if (sig == SIGILL) {
-        if ((greg_t)info->si_addr != ucxt->uc_mcontext.gregs[REG_RIP]) {
+        if ((greg_t)info->si_addr != ucxt->uc_mcontext.gregs[REG_XIP]) {
             print("ERROR: si_addr=%p does not match rip=%p\n", info->si_addr,
-                  ucxt->uc_mcontext.gregs[REG_RIP]);
+                  ucxt->uc_mcontext.gregs[REG_XIP]);
         }
         count++;
         if (invalid_lock) {

--- a/suite/tests/tools.h
+++ b/suite/tests/tools.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -41,6 +41,7 @@
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x0600
 
+#define _GNU_SOURCE 1 /* for REG_RIP, etc. */
 #include "configure.h"
 #include "dr_helper.h"
 #include <stdarg.h>


### PR DESCRIPTION
Adds translation of siginfo_t.si_addr when it's a PC.
Adds a test.

Fixes #2990