### PR TITLE
i#2615 Added support for Intel ADX instructions

### DIFF
--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1266,9 +1266,9 @@ const instr_info_t * const op_instr[] =
     /* OP_xsavec32      */   &rex_w_extensions[5][0],
     /* OP_xsavec64      */   &rex_w_extensions[5][1],
 
-	/* Intel ADX */
-	/* OP_adox          */   &prefix_extensions[143][1],
-	/* OP_adcx          */   &prefix_extensions[143][2],
+    /* Intel ADX */
+    /* OP_adox          */   &prefix_extensions[143][1],
+    /* OP_adcx          */   &prefix_extensions[143][2],
 
     /* Keep these at the end so that ifdefs don't change internal enum values */
 #ifdef IA32_ON_IA64
@@ -4287,8 +4287,8 @@ const instr_info_t prefix_extensions[][8] = {
   },
   { /* prefix extension 143 */
     {INVALID,        0x38f618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {OP_adox,      0xf338f618, "adox",    Gy, Ey, xx, xx, xx, mrm, fWO, END_LIST},
-    {OP_adcx,      0x6638f618, "adcx",    Gy, Ey, xx, xx, xx, mrm, fWC, END_LIST},
+    {OP_adox,      0xf338f618, "adox",    Gy, xx, Ey, xx, xx, mrm, (fWO|fRO), END_LIST},
+    {OP_adcx,      0x6638f618, "adcx",    Gy, xx, Ey, xx, xx, mrm, (fWC|fRC), END_LIST},
     {INVALID,      0xf238f618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,        0x38f618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,      0xf338f618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1266,6 +1266,10 @@ const instr_info_t * const op_instr[] =
     /* OP_xsavec32      */   &rex_w_extensions[5][0],
     /* OP_xsavec64      */   &rex_w_extensions[5][1],
 
+	/* Intel ADX */
+	/* OP_adox          */   &prefix_extensions[143][1],
+	/* OP_adcx          */   &prefix_extensions[143][2],
+
     /* Keep these at the end so that ifdefs don't change internal enum values */
 #ifdef IA32_ON_IA64
     /* OP_jmpe      */   &extensions[13][6],
@@ -4283,8 +4287,8 @@ const instr_info_t prefix_extensions[][8] = {
   },
   { /* prefix extension 143 */
     {INVALID,        0x38f618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338f618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638f618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {OP_adox,      0xf338f618, "adox",    Gy, Ey, xx, xx, xx, mrm, fWO, END_LIST},
+    {OP_adcx,      0x6638f618, "adcx",    Gy, Ey, xx, xx, xx, mrm, fWC, END_LIST},
     {INVALID,      0xf238f618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,        0x38f618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,      0xf338f618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -1565,6 +1565,11 @@
   instr_create_1dst_1src((dc), OP_vpbroadcastd, (d), (s))
 #define INSTR_CREATE_vpbroadcastq(dc, d, s) \
   instr_create_1dst_1src((dc), OP_vpbroadcastq, (d), (s))
+/* ADX */
+#define INSTR_CREATE_adox(dc, d, s) \
+  instr_create_1dst_1src((dc), OP_adox, (d), (s))
+#define INSTR_CREATE_adcx(dc, d, s) \
+  instr_create_1dst_1src((dc), OP_adcx, (d), (s))
 
 /* @} */ /* end doxygen group */
 

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1263,10 +1263,14 @@ enum {
 /* 1103 */     OP_xsavec32,       /**< IA-32/AMD64 xsavec opcode. */
 /* 1104 */     OP_xsavec64,       /**< IA-32/AMD64 xsavec64 opcode. */
 
+	/* Intel ADX */
+/* 1105 */     OP_adox,			  /**< IA-32/AMD64 adox opcode. */
+/* 1106 */     OP_adcx,			  /**< IA-32/AMD64 adox opcode. */
+
     /* Keep these at the end so that ifdefs don't change internal enum values */
 #ifdef IA32_ON_IA64
-/* 1105 */     OP_jmpe,       /**< IA-32/AMD64 jmpe opcode. */
-/* 1106 */     OP_jmpe_abs,   /**< IA-32/AMD64 jmpe_abs opcode. */
+/* 1107 */     OP_jmpe,       /**< IA-32/AMD64 jmpe opcode. */
+/* 1108 */     OP_jmpe_abs,   /**< IA-32/AMD64 jmpe_abs opcode. */
 #endif
 
     OP_AFTER_LAST,

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1263,9 +1263,9 @@ enum {
 /* 1103 */     OP_xsavec32,       /**< IA-32/AMD64 xsavec opcode. */
 /* 1104 */     OP_xsavec64,       /**< IA-32/AMD64 xsavec64 opcode. */
 
-	/* Intel ADX */
-/* 1105 */     OP_adox,			  /**< IA-32/AMD64 adox opcode. */
-/* 1106 */     OP_adcx,			  /**< IA-32/AMD64 adox opcode. */
+    /* Intel ADX */
+/* 1105 */     OP_adox,           /**< IA-32/AMD64 adox opcode. */
+/* 1106 */     OP_adcx,           /**< IA-32/AMD64 adox opcode. */
 
     /* Keep these at the end so that ifdefs don't change internal enum values */
 #ifdef IA32_ON_IA64

--- a/suite/tests/api/ir_x86_2args.h
+++ b/suite/tests/api/ir_x86_2args.h
@@ -439,3 +439,8 @@ OPCODE(blsr, blsr, blsr, 0, REGARG(EDX), MEMARG(OPSZ_4))
 OPCODE(blsmsk, blsmsk, blsmsk, 0, REGARG(EDX), MEMARG(OPSZ_4))
 OPCODE(blsi, blsi, blsi, 0, REGARG(EDX), MEMARG(OPSZ_4))
 OPCODE(tzcnt, tzcnt, tzcnt, 0, REGARG(EDX), MEMARG(OPSZ_4))
+
+/****************************************************************************/
+/* ADX */
+OPCODE(adox, adox, adox, 0, REGARG(EAX), MEMARG(OPSZ_4))
+OPCODE(adcx, adcx, adcx, 0, REGARG(EAX), MEMARG(OPSZ_4))

--- a/suite/tests/api/ir_x86_2args.h
+++ b/suite/tests/api/ir_x86_2args.h
@@ -442,5 +442,7 @@ OPCODE(tzcnt, tzcnt, tzcnt, 0, REGARG(EDX), MEMARG(OPSZ_4))
 
 /****************************************************************************/
 /* ADX */
+OPCODE(adox_x64, adox, adox, X64_ONLY, REGARG(RAX), MEMARG(OPSZ_8))
 OPCODE(adox, adox, adox, 0, REGARG(EAX), MEMARG(OPSZ_4))
+OPCODE(adcx_x64, adcx, adcx, X64_ONLY, REGARG(RAX), MEMARG(OPSZ_8))
 OPCODE(adcx, adcx, adcx, 0, REGARG(EAX), MEMARG(OPSZ_4))


### PR DESCRIPTION
Hi, I've fixed https://github.com/DynamoRIO/dynamorio/issues/2615 by adding support for the missing ADOX and ADCX instructions. I've verified that the application I was testing and was crashing under drrun due to the missing instructions i now working correctly.
It's the first time I submit a patch, so I hope my opcode declarations are correct. I was unable to find much information on how to add new opcodes, so I mostly reverse-engineered others and studied the Intel manual. Hopefully I got it right.