### PR TITLE
i#2328: improve repeated signal interruption

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -324,10 +324,12 @@ shared_gencode_emit(generated_code_t *gencode _IF_X86_64(bool x86_mode))
     pc = check_size_and_cache_line(isa_mode, gencode, pc);
     gencode->fcache_return = pc;
     pc = emit_fcache_return_shared(GLOBAL_DCONTEXT, gencode, pc);
+    gencode->fcache_return_end = pc;
     if (DYNAMO_OPTION(coarse_units)) {
         pc = check_size_and_cache_line(isa_mode, gencode, pc);
         gencode->fcache_return_coarse = pc;
         pc = emit_fcache_return_coarse(GLOBAL_DCONTEXT, gencode, pc);
+        gencode->fcache_return_coarse_end = pc;
         pc = check_size_and_cache_line(isa_mode, gencode, pc);
         gencode->trace_head_return_coarse = pc;
         pc = emit_trace_head_return_coarse(GLOBAL_DCONTEXT, gencode, pc);
@@ -1207,6 +1209,7 @@ arch_thread_init(dcontext_t *dcontext)
     pc = check_size_and_cache_line(isa_mode, code, pc);
     code->fcache_return = pc;
     pc = emit_fcache_return(dcontext, code, pc);;
+    code->fcache_return_end = pc;
 #ifdef WINDOWS_PC_SAMPLE
     code->fcache_enter_return_end = pc;
 #endif
@@ -1701,14 +1704,32 @@ in_generated_routine(dcontext_t *dcontext, cache_pc pc)
     /* FIXME: what about inlined IBL stubs */
 }
 
-bool
-in_context_switch_code(dcontext_t *dcontext, cache_pc pc)
+static bool
+in_fcache_return_for_gencode(generated_code_t *code, cache_pc pc)
 {
-    return (pc >= (cache_pc)fcache_enter_routine(dcontext) &&
-            /* get last emitted routine */
-            pc <= get_ibl_routine(dcontext, IBL_LINKED, IBL_SOURCE_TYPE_END-1,
-                                  IBL_BRANCH_TYPE_START));
-    /* FIXME: too hacky, should have an extra field for PC profiling */
+    return pc != NULL &&
+        ((pc >= code->fcache_return && pc < code->fcache_return_end) ||
+         (pc >= code->fcache_return_coarse && pc < code->fcache_return_coarse_end));
+}
+
+bool
+in_fcache_return(dcontext_t *dcontext, cache_pc pc)
+{
+    generated_code_t *code = THREAD_GENCODE(dcontext);
+    if (in_fcache_return_for_gencode(code, pc))
+        return true;
+    if (USE_SHARED_GENCODE()) {
+        if (in_fcache_return_for_gencode(shared_code, pc))
+            return true;
+#if defined(X86) && defined(X64)
+        if (shared_code_x86 != NULL && in_fcache_return_for_gencode(shared_code_x86, pc))
+            return true;
+        if (shared_code_x86_to_x64 != NULL &&
+            in_fcache_return_for_gencode(shared_code_x86_to_x64, pc))
+            return true;
+#endif
+    }
+    return false;
 }
 
 bool

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -513,22 +513,24 @@ mangle_special_registers(dcontext_t *dcontext, instrlist_t *ilist, instr_t *inst
 void mangle_insert_clone_code(dcontext_t *dcontext, instrlist_t *ilist,
                               instr_t *instr _IF_X86_64(gencode_mode_t mode));
 
+#ifdef X86
+# if defined(X64) || defined(MACOS)
+#  define ABI_STACK_ALIGNMENT 16
+# else
+   /* See i#847 for discussing the stack alignment on X86. */
+#  define ABI_STACK_ALIGNMENT 4
+# endif
+#elif defined(AARCH64)
+# define ABI_STACK_ALIGNMENT 16
+#elif defined(ARM)
+# define ABI_STACK_ALIGNMENT 8
+#endif
+
 /* Returns the number of bytes the stack pointer has to be aligned to. */
 static inline uint
 get_ABI_stack_alignment()
 {
-#ifdef X86
-# if defined(X64) || defined(MACOS)
-    return 16;
-# else
-    /* See i#847 for discussing the stack alignment on X86. */
-    return 4;
-# endif
-#elif defined(AARCH64)
-    return 16;
-#elif defined(ARM)
-    return 8;
-#endif
+    return ABI_STACK_ALIGNMENT;
 }
 
 /* the stack size of a full context switch for clean call */

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -830,6 +830,7 @@ typedef struct ibl_code_t {
 typedef struct _generated_code_t {
     byte *fcache_enter;
     byte *fcache_return;
+    byte *fcache_return_end;
 #ifdef WINDOWS_PC_SAMPLE
     byte *fcache_enter_return_end;
 #endif
@@ -908,6 +909,7 @@ typedef struct _generated_code_t {
      */
     /* FIXME: these two return routines are only needed in the global struct */
     byte *fcache_return_coarse;
+    byte *fcache_return_coarse_end;
     byte *trace_head_return_coarse;
     /* special ibl xfer */
     byte *special_ibl_xfer[NUM_SPECIAL_IBL_XFERS];

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -983,7 +983,7 @@ void arch_mcontext_reset_stolen_reg(dcontext_t *dcontext, priv_mcontext_t *mc);
 
 bool is_indirect_branch_lookup_routine(dcontext_t *dcontext, cache_pc pc);
 bool in_generated_routine(dcontext_t *dcontext, cache_pc pc);
-bool in_context_switch_code(dcontext_t *dcontext, cache_pc pc);
+bool in_fcache_return(dcontext_t *dcontext, cache_pc pc);
 bool in_indirect_branch_lookup_code(dcontext_t *dcontext, cache_pc pc);
 cache_pc get_fcache_target(dcontext_t *dcontext);
 void set_fcache_target(dcontext_t *dcontext, cache_pc value);

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -3599,6 +3599,40 @@ unlink_fragment_for_signal(dcontext_t *dcontext, fragment_t *f,
     return changed;
 }
 
+static void
+relink_interrupted_fragment(dcontext_t *dcontext, thread_sig_info_t *info)
+{
+    if (info->interrupted == NULL)
+        return;
+    /* i#2066: if we were building a trace, it may already be re-linked */
+    if (!TEST(FRAG_LINKED_OUTGOING, info->interrupted->flags)) {
+        LOG(THREAD, LOG_ASYNCH, 3, "\tre-linking outgoing for interrupted F%d\n",
+            info->interrupted->id);
+        SHARED_FLAGS_RECURSIVE_LOCK(info->interrupted->flags, acquire,
+                                    change_linking_lock);
+        /* Double-check flags to ensure some other thread didn't link
+         * while we waited for the change_linking_lock.
+         */
+        if (!TEST(FRAG_LINKED_OUTGOING, info->interrupted->flags)) {
+            link_fragment_outgoing(dcontext, info->interrupted, false);
+        }
+        SHARED_FLAGS_RECURSIVE_LOCK(info->interrupted->flags, release,
+                                    change_linking_lock);
+    }
+    if (TEST(FRAG_HAS_SYSCALL, info->interrupted->flags)) {
+        /* restore syscall (they're a barrier to signals, so signal
+         * handler has cur frag exit before it does a syscall)
+         */
+        if (info->interrupted_pc != NULL) {
+            mangle_syscall_code(dcontext, info->interrupted,
+                                info->interrupted_pc, true/*skip exit cti*/);
+        }
+    }
+    info->interrupted = NULL;
+    info->interrupted_pc = NULL;
+    info->interrupted_gencode = false;
+}
+
 static bool
 interrupted_inlined_syscall(dcontext_t *dcontext, fragment_t *f,
                             byte *pc/*interruption pc*/)
@@ -3896,16 +3930,21 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
                      */
                 } else {
                     /* could get another signal but should be in same fragment */
-                    ASSERT(info->interrupted == NULL || info->interrupted == f);
-                    if (unlink_fragment_for_signal(dcontext, f, pc)) {
-                        info->interrupted = f;
-                        info->interrupted_pc = pc;
-                    } else {
-                        /* either was unlinked for trace creation, or we got another
-                         * signal before exiting cache to handle 1st
-                         */
-                        ASSERT(info->interrupted == NULL ||
-                               info->interrupted == f);
+                    ASSERT(info->interrupted == NULL || info->interrupted == f ||
+                           /* i#2328: if we interrupt gencode we have to guess */
+                           info->interrupted_gencode);
+                    if (info->interrupted != f) {
+                        /* Avoid leaving any prior unlinked */
+                        relink_interrupted_fragment(dcontext, info);
+                        if (unlink_fragment_for_signal(dcontext, f, pc)) {
+                            info->interrupted = f;
+                            info->interrupted_pc = pc;
+                        } else {
+                            /* either was unlinked for trace creation, or we got another
+                             * signal before exiting cache to handle 1st
+                             */
+                            ASSERT(info->interrupted == NULL || info->interrupted == f);
+                        }
                     }
                 }
             }
@@ -3977,6 +4016,7 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
              * XXX: better to get this code inside arch/ but we'd have to
              * convert to an mcontext which seems overkill.
              */
+            info->interrupted_gencode = true;
 #ifdef AARCHXX
             /* The target is in r2 the whole time, w/ or w/o Thumb LSB. */
             if (sc->SC_R2 != 0)
@@ -3990,8 +4030,14 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
 #else
 # error Unsupported arch.
 #endif
-            /* If in fcache_enter, we stored the next_tag in asynch_target in dispatch. */
-            if (f == NULL && dcontext->asynch_target != NULL)
+            /* If in fcache_enter, we stored the next_tag in asynch_target in dispatch.
+             * But, we need to avoid using the asynch_target for the fragment we just
+             * exited if we're in fcache_return.  We could also have exited if we're in
+             * certain ibl spots: we set interrupted_gencode to avoid asserts and we
+             * eventually relink.
+             */
+            if (f == NULL && dcontext->asynch_target != NULL &&
+                !in_fcache_return(dcontext, pc))
                 f = fragment_lookup(dcontext, dcontext->asynch_target);
             if (f != NULL && !TEST(FRAG_COARSE_GRAIN, f->flags)) {
                 if (unlink_fragment_for_signal(dcontext, f, FCACHE_ENTRY_PC(f))) {
@@ -5664,31 +5710,7 @@ receive_pending_signal(dcontext_t *dcontext)
     int sig;
     LOG(THREAD, LOG_ASYNCH, 3, "receive_pending_signal\n");
     if (info->interrupted != NULL) {
-        /* i#2066: if we were building a trace, it may already be re-linked */
-        if (!TEST(FRAG_LINKED_OUTGOING, info->interrupted->flags)) {
-            LOG(THREAD, LOG_ASYNCH, 3, "\tre-linking outgoing for interrupted F%d\n",
-                info->interrupted->id);
-            SHARED_FLAGS_RECURSIVE_LOCK(info->interrupted->flags, acquire,
-                                        change_linking_lock);
-            // Double-check flags to ensure some other thread didn't link
-            // while we waited for the change_linking_lock.
-            if (!TEST(FRAG_LINKED_OUTGOING, info->interrupted->flags)) {
-                link_fragment_outgoing(dcontext, info->interrupted, false);
-            }
-            SHARED_FLAGS_RECURSIVE_LOCK(info->interrupted->flags, release,
-                                        change_linking_lock);
-        }
-        if (TEST(FRAG_HAS_SYSCALL, info->interrupted->flags)) {
-            /* restore syscall (they're a barrier to signals, so signal
-             * handler has cur frag exit before it does a syscall)
-             */
-            if (info->interrupted_pc != NULL) {
-                mangle_syscall_code(dcontext, info->interrupted,
-                                    info->interrupted_pc, true/*skip exit cti*/);
-            }
-        }
-        info->interrupted = NULL;
-        info->interrupted_pc = NULL;
+        relink_interrupted_fragment(dcontext, info);
     }
     /* grab first pending signal
      * XXX: start with real-time ones?

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -433,6 +433,7 @@ typedef struct _thread_sig_info_t {
     void *sigheap; /* special heap */
     fragment_t *interrupted; /* frag we unlinked for delaying signal */
     cache_pc interrupted_pc; /* pc within frag we unlinked for delaying signal */
+    bool interrupted_gencode; /* are we guessing at .interrupted from gencode? */
 
 #if defined(X86) && defined(LINUX)
     /* As the xstate buffer varies dynamically and gets large (with avx512


### PR DESCRIPTION
Improves repeated signal interruption by relinking any prior interrupted
fragment before replacing it with a new one.  This happens when we've
guessed at what fragment to unlink when interruption is in generated code.
We add a field indicating the guess and use it to relax an assert.
We also add a new in_fcache_return() routine, used to rule out one case of
incorrect guessing.

Fixes #2328