### PR TITLE
Bump required cmake version to 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ branches:
   only:
   - master
 
-# We use Trusty to get cmake 2.8.12 instead of 2.8.7 from Precise:
+# We use Trusty to get cmake 3.5 via the cmake3 package.
 sudo: required
 dist: trusty
 
@@ -97,7 +97,10 @@ install:
   # ImageMagick is present but these are not:
   - >
       if [[ "`uname`" == "Linux" ]]; then
-      sudo apt-get -y install doxygen transfig vera++; fi
+        sudo apt-get -y install doxygen transfig vera++ cmake3
+        sudo update-alternatives --install /usr/bin/cmake cmake /usr/local/bin/cmake3
+        sudo update-alternatives --install /usr/bin/ctest3 ctest /usr/local/bin/ctest3
+      fi
   # Install multilib for non-cross-compiling Linux builds:
   - >
       if [[ "`uname`" == "Linux" && $DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY == no ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,12 +53,12 @@ endif ()
 
 if (${vsgen_ver} VERSION_GREATER 9)
   # for i#801 workaround
-  cmake_minimum_required(VERSION 2.8.8)
+  cmake_minimum_required(VERSION 3.2)
 elseif ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
   # for output dir name control
-  cmake_minimum_required(VERSION 2.8.2)
+  cmake_minimum_required(VERSION 3.2)
 else ()
-  cmake_minimum_required(VERSION 2.6.4) # VERSION_LESS
+  cmake_minimum_required(VERSION 3.2) # VERSION_LESS
 endif ()
 
 include(make/policies.cmake NO_POLICY_SCOPE)
@@ -83,19 +83,6 @@ if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
 else ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
   set(location_suffix "")
 endif ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
-
-set(cmake_ver_string
-  "${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_RELEASE_VERSION}")
-if ("${cmake_ver_string}" VERSION_LESS "2.6.4")
-  # Workaround for cmake bug #8639 where CMAKE_ASM_SOURCE_FILE_EXTENSIONS
-  # is not set and our asm files are not built (should be fixed in 2.6.4).
-  # We can simply set the var ahead of time, luckily, since noone clears it:
-  # Alternative workarounds:
-  # - Use ASM-ATT instead of ASM: should work
-  # - I tried puting a patched CMakeASMInformation.cmake ahead of share/Modules
-  #   but enable_language() seems to not use the CMAKE_MODULE_PATH
-  set(CMAKE_ASM_SOURCE_FILE_EXTENSIONS s;S;asm)
-endif ("${cmake_ver_string}" VERSION_LESS "2.6.4")
 
 # I want to override the default CMAKE_INSTALL_PREFIX, but allow it to
 # be set (as the same var name, so CPack and other standard tools

--- a/make/policies.cmake
+++ b/make/policies.cmake
@@ -34,35 +34,20 @@ if ("${CMAKE_VERSION}" VERSION_EQUAL "3.3" OR
   cmake_policy(SET CMP0058 OLD)
 endif ()
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "3.1" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "3.1")
-  # XXX i#1557: update our code to satisfy the changes in 3.x
-  cmake_policy(SET CMP0054 OLD)
-endif ()
+# XXX i#1557: update our code to satisfy the changes in 3.x
+cmake_policy(SET CMP0054 OLD)
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "3.0" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "3.0")
-  # XXX i#1557: update our code to satisfy the changes in 3.x
-  cmake_policy(SET CMP0026 OLD)
-  # XXX i#1375: if we make 2.8.12 the minimum we can remove the @rpath
-  # Mac stuff and this policy, right?
-  cmake_policy(SET CMP0042 OLD)
-endif ()
+# XXX i#1557: update our code to satisfy the changes in 3.x
+cmake_policy(SET CMP0026 OLD)
+# XXX i#1375: if we make 2.8.12 the minimum we can remove the @rpath
+# Mac stuff and this policy, right?
+cmake_policy(SET CMP0042 OLD)
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "2.8.12" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "2.8.12")
-  # XXX DrMem-i#1481: update to cmake 2.8.12's better handling of interface imports
-  cmake_policy(SET CMP0022 OLD)
-endif ()
+# XXX DrMem-i#1481: update to cmake 2.8.12's better handling of interface imports
+cmake_policy(SET CMP0022 OLD)
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "2.8.11" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "2.8.11")
-  # XXX i#1418: update to cmake 2.8.12's better handling of interface imports, for Qt
-  cmake_policy(SET CMP0020 OLD)
-endif ()
+# XXX i#1418: update to cmake 2.8.12's better handling of interface imports, for Qt
+cmake_policy(SET CMP0020 OLD)
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "2.6.4" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "2.6.4")
-  # Recognize literals in if statements
-  cmake_policy(SET CMP0012 NEW)
-endif ()
+# Recognize literals in if statements
+cmake_policy(SET CMP0012 NEW)

--- a/suite/runsuite_common_pre.cmake
+++ b/suite/runsuite_common_pre.cmake
@@ -638,21 +638,10 @@ function(testbuild_ex name is64 initial_cache test_only_in_long
       # to run a subset of tests add an INCLUDE regexp to ctest_test.  e.g.:
       #   INCLUDE broadfun
       if (NOT "${arg_exclude}" STREQUAL "")
-        if ("${cmake_ver_string}" VERSION_LESS "2.6.3")
-          # EXCLUDE arg to ctest_test() is not available so we edit the list of tests
-          file(READ "${CTEST_BINARY_DIRECTORY}/tests/CTestTestfile.cmake" testlist)
-          string(REGEX REPLACE "ADD_TEST\\((${arg_exclude}) [^\\)]*\\)\n" ""
-            testlist "${testlist}")
-          file(WRITE "${CTEST_BINARY_DIRECTORY}/tests/CTestTestfile.cmake" "${testlist}")
-        else ("${cmake_ver_string}" VERSION_LESS "2.6.3")
-          set(ctest_test_args ${ctest_test_args} EXCLUDE ${arg_exclude})
-        endif ("${cmake_ver_string}" VERSION_LESS "2.6.3")
+        set(ctest_test_args ${ctest_test_args} EXCLUDE ${arg_exclude})
       endif (NOT "${arg_exclude}" STREQUAL "")
       set(ctest_test_args ${ctest_test_args} ${extra_ctest_args})
-      if ("${cmake_ver_string}" VERSION_LESS "2.8.")
-        # Parallel tests not supported
-        set(RUN_PARALLEL OFF)
-      elseif (WIN32 AND TEST_LONG)
+      eif (WIN32 AND TEST_LONG)
         # FIXME i#265: on Windows we can't run multiple instances of
         # the same app b/c of global reg key conflicts: should support
         # env vars and not require registry


### PR DESCRIPTION
Bump cmake version to 3.2, which was released a few years ago and
should be shipped with most recent distributions. This allows us to
remove some code dealing with older cmake versions and fixes a bug
related to multiple values as OUTPUT for add_custom_command.

There probably more opportunities to for cleanups that I missed in
my initial scan.