### PR TITLE
i#2042: signal interrupting ibl jump

### DIFF
--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -632,6 +632,13 @@ emit_inline_ibl_stub(dcontext_t *dcontext, byte *pc,
     return pc;
 }
 
+bool
+instr_is_ibl_hit_jump(instr_t *instr)
+{
+    return instr_get_opcode(instr) == OP_br &&
+        opnd_get_reg(instr_get_target(instr)) == DR_REG_X0;
+}
+
 byte *
 emit_indirect_branch_lookup(dcontext_t *dc, generated_code_t *code, byte *pc,
                             byte *fcache_return_pc,
@@ -739,7 +746,9 @@ emit_indirect_branch_lookup(dcontext_t *dc, generated_code_t *code, byte *pc,
                                   opnd_create_reg(DR_REG_X2)));
     /* Recover app's original x2. */
     APP(&ilist, instr_create_restore_from_tls(dc, DR_REG_R2, TLS_REG2_SLOT));
-    /* br x0 */
+    /* br x0
+     * (keep in sync with instr_is_ibl_hit_jump())
+     */
     APP(&ilist, INSTR_CREATE_br(dc, opnd_create_reg(DR_REG_X0)));
 
     APP(&ilist, try_next);

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -1078,6 +1078,7 @@ byte * emit_indirect_branch_lookup(dcontext_t *dcontext, generated_code_t *code,
                                    bool inline_ibl_head,
                                    ibl_code_t *ibl_code);
 void update_indirect_branch_lookup(dcontext_t *dcontext);
+bool instr_is_ibl_hit_jump(instr_t *instr);
 
 byte *emit_far_ibl(dcontext_t *dcontext, byte *pc, ibl_code_t *ibl_code, cache_pc ibl_tgt
                    _IF_X86_64(far_ref_t *far_jmp_opnd));

--- a/core/arch/arm/instr.c
+++ b/core/arch/arm/instr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -288,6 +288,13 @@ instr_is_mbr_arch(instr_t *instr)
      * OP_blx_ind when conditional is still an mbr) is an mbr.
      */
     return instr_writes_to_reg(instr, DR_REG_PC, DR_QUERY_INCLUDE_COND_DSTS);
+}
+
+bool
+instr_is_jump_mem(instr_t *instr)
+{
+    return instr_get_opcode(instr) == OP_ldr &&
+        opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_PC;
 }
 
 bool

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2911,6 +2911,15 @@ instrlist_convert_to_x86(instrlist_t *ilist)
         instr_set_x86_mode(in, true/*x86*/);
         instr_shrink_to_32_bits(in);
     }
+}
+#endif
+
+#ifndef AARCH64
+bool
+instr_is_ibl_hit_jump(instr_t *instr)
+{
+    /* ARM and x86 use XINST_CREATE_jump_mem() */
+    return instr_is_jump_mem(instr);
 }
 #endif
 

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2045,6 +2045,9 @@ DR_API
  */
 bool
 instr_is_mbr(instr_t *instr);
+
+bool
+instr_is_jump_mem(instr_t *instr);
 
 DR_API
 /**

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -412,6 +412,13 @@ instr_is_mbr_arch(instr_t *instr)      /* multi-way branch */
             opc == OP_call_far_ind ||
             opc == OP_ret_far ||
             opc == OP_iret);
+}
+
+bool
+instr_is_jump_mem(instr_t *instr)
+{
+    return instr_get_opcode(instr) == OP_jmp_ind &&
+        opnd_is_memory_reference(instr_get_target(instr));
 }
 
 bool

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -284,8 +284,8 @@ insert_out_of_line_context_switch(dcontext_t *dcontext, instrlist_t *ilist,
          * so we can have call/return pair to take advantage of hardware
          * call return stack for better performance.
          * Xref emit_clean_call_save @ x86/emit_utils.c
-         * The precise adjustment amount is relied upon in record_pending_signal()'s
-         * handling of in_clean_call().
+         * The precise adjustment amount is relied upon in
+         * find_next_fragment_from_gencode()'s handling of in_clean_call_save().
          */
         PRE(ilist, instr,
             INSTR_CREATE_lea

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2697,9 +2697,6 @@ sig_has_restorer(thread_sig_info_t *info, int sig)
           {0x68, 0x11, 0x80, 0x52, 0x01, 0x00, 0x00, 0xd4};
 # endif
         byte buf[MAX(sizeof(SIGRET_NONRT), sizeof(SIGRET_RT))]= {0};
-# ifdef AARCH64
-        ASSERT_NOT_TESTED(); /* See SIGRET_RT, above. */
-# endif
         if (safe_read(info->app_sigaction[sig]->restorer, sizeof(buf), buf) &&
             ((IS_RT_FOR_APP(info, sig) &&
               memcmp(buf, SIGRET_RT, sizeof(SIGRET_RT)) == 0) ||
@@ -3785,6 +3782,105 @@ adjust_syscall_for_restart(dcontext_t *dcontext, thread_sig_info_t *info, int si
     return true;
 }
 
+/* XXX: Better to get this code inside arch/ but we'd have to convert to an mcontext
+ * which seems overkill.
+ */
+static fragment_t *
+find_next_fragment_from_gencode(dcontext_t *dcontext, sigcontext_t *sc)
+{
+    fragment_t *f = NULL;
+    fragment_t wrapper;
+    byte *pc = (byte *) sc->SC_XIP;
+    if (in_clean_call_save(dcontext, pc) || in_clean_call_restore(dcontext, pc)) {
+#ifdef AARCHXX
+        f = fragment_pclookup(dcontext, (cache_pc)sc->SC_LR, &wrapper);
+#elif defined(X86)
+        cache_pc retaddr = NULL;
+        /* Get the retaddr.  We assume this is the adjustment used by
+         * insert_out_of_line_context_switch().
+         */
+        byte *ra_slot = dcontext->dstack -
+            get_clean_call_switch_stack_size() - sizeof(retaddr);
+        /* The extra x86 slot is only there for save. */
+        if (in_clean_call_save(dcontext, pc))
+            ra_slot -= get_clean_call_temp_stack_size();
+        if (safe_read(ra_slot, sizeof(retaddr), &retaddr))
+            f = fragment_pclookup(dcontext, retaddr, &wrapper);
+#else
+# error Unsupported arch.
+#endif
+    } else if (in_indirect_branch_lookup_code(dcontext, pc)) {
+        /* Try to find the target if the signal arrived in the IBL.
+         * We could try to be a lot more precise by hardcoding the IBL
+         * sequence here but that would make the code less maintainable.
+         * Instead we try the registers that hold the target app address.
+         */
+        /* First check for the jmp* on the hit path: that is the only place
+         * in the ibl where the target tag is not sitting in a register.
+         */
+#if defined(X86) && defined(X64)
+        /* Optimization for the common case of targeting a prefix on x86_64:
+         *    ff 61 08             jmp    0x08(%rcx)[8byte]
+         * The tag is in 0x0(%rcx) so we avoid a decode and pclookup.
+         */
+        if (*pc == 0xff && *(pc+1) == 0x61 && *(pc+2) == 0x08) {
+            f = fragment_lookup(dcontext, *(app_pc*)sc->SC_XCX);
+        }
+#endif
+        if (f == NULL) {
+            instr_t instr;
+            instr_init(dcontext, &instr);
+            decode_cti(dcontext, pc, &instr);
+            if (instr_is_ibl_hit_jump(&instr)) {
+                priv_mcontext_t mc;
+                sig_full_cxt_t sc_full = { sc, NULL/*not provided*/ };
+                sigcontext_to_mcontext(&mc, &sc_full, DR_MC_INTEGER|DR_MC_CONTROL);
+                byte *target;
+                if (opnd_is_memory_reference(instr_get_target(&instr))) {
+                    target = instr_compute_address_priv(&instr, &mc);
+                    ASSERT(target != NULL);
+                    if (target != NULL)
+                        target = *(byte**)target;
+                } else {
+                    ASSERT(opnd_is_reg(instr_get_target(&instr)));
+                    target = (byte *) reg_get_value_priv
+                        (opnd_get_reg(instr_get_target(&instr)), &mc);
+                }
+                ASSERT(target != NULL);
+                if (target != NULL)
+                    f = fragment_pclookup(dcontext, target, &wrapper);
+                /* I tried to hit this case running client.cleancallsig in a loop
+                 * and while I could on x86 and x86_64 I never did on ARM or
+                 * AArch64.  We can remove this once someone hits it and it works.
+                 */
+                IF_AARCHXX(ASSERT_NOT_TESTED());
+            }
+            instr_free(dcontext, &instr);
+        }
+#ifdef AARCHXX
+        /* The target is in r2 the whole time, w/ or w/o Thumb LSB. */
+        if (f == NULL && sc->SC_R2 != 0)
+            f = fragment_lookup(dcontext, ENTRY_PC_TO_DECODE_PC(sc->SC_R2));
+#elif defined(X86)
+        /* The target is initially in xcx but is then copied to xbx. */
+        if (f == NULL && sc->SC_XBX != 0)
+            f = fragment_lookup(dcontext, (app_pc)sc->SC_XBX);
+        if (f == NULL && sc->SC_XCX != 0)
+            f = fragment_lookup(dcontext, (app_pc)sc->SC_XCX);
+#else
+# error Unsupported arch.
+#endif
+    } else {
+        /* If in fcache_enter or do_syscall*, we stored the next_tag in asynch_target
+         * in dispatch.  But, we need to avoid using the asynch_target for the
+         * fragment we just exited if we're in fcache_return.
+         */
+        if (dcontext->asynch_target != NULL && !in_fcache_return(dcontext, pc))
+            f = fragment_lookup(dcontext, dcontext->asynch_target);
+    }
+    return f;
+}
+
 static void
 record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
                       sigframe_rt_t *frame, bool forged
@@ -4002,54 +4098,7 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
          * only need a single info->interrupted.
          */
         if (info->interrupted == NULL && !get_at_syscall(dcontext)) {
-            /* Try to find the target if the signal arrived in the IBL.
-             * We could try to be a lot more precise by hardcoding the IBL
-             * sequence here but that would make the code less maintainable.
-             * Instead we try the registers that hold the target app address.
-             *
-             * FIXME i#2042: we'll still fail if the signal arrives at the
-             * actual jmp* in the hit path b/c the reg holding the target is
-             * restored on the prior instr.
-             *
-             * XXX: better to get this code inside arch/ but we'd have to
-             * convert to an mcontext which seems overkill.
-             */
-            if (in_clean_call_save(dcontext, pc) ||
-                in_clean_call_restore(dcontext, pc)) {
-                /* Get the retaddr.  We assume this is the adjustment used by
-                * insert_out_of_line_context_switch().
-                */
-                cache_pc retaddr = NULL;
-                byte *ra_slot = dcontext->dstack -
-                    get_clean_call_switch_stack_size() - sizeof(retaddr);
-                /* The extra x86 slot is only there for save. */
-                if (in_clean_call_save(dcontext, pc))
-                    ra_slot -= get_clean_call_temp_stack_size();
-                if (safe_read(ra_slot, sizeof(retaddr), &retaddr))
-                    f = fragment_pclookup(dcontext, retaddr, &wrapper);
-            }
-#ifdef AARCHXX
-            /* The target is in r2 the whole time, w/ or w/o Thumb LSB. */
-            if (sc->SC_R2 != 0)
-                f = fragment_lookup(dcontext, ENTRY_PC_TO_DECODE_PC(sc->SC_R2));
-#elif defined(X86)
-            /* The target is initially in xcx but is then copied to xbx. */
-            if (sc->SC_XBX != 0)
-                f = fragment_lookup(dcontext, (app_pc)sc->SC_XBX);
-            if (f == NULL && sc->SC_XCX != 0)
-                f = fragment_lookup(dcontext, (app_pc)sc->SC_XCX);
-#else
-# error Unsupported arch.
-#endif
-            /* If in fcache_enter, we stored the next_tag in asynch_target in dispatch.
-             * But, we need to avoid using the asynch_target for the fragment we just
-             * exited if we're in fcache_return.
-             */
-            if (f == NULL && dcontext->asynch_target != NULL &&
-                !in_fcache_return(dcontext, pc) &&
-                /* i#2042: we need to rule out the ibl until we handle it above */
-                !in_indirect_branch_lookup_code(dcontext, pc))
-                f = fragment_lookup(dcontext, dcontext->asynch_target);
+            f = find_next_fragment_from_gencode(dcontext, sc);
             if (f != NULL && !TEST(FRAG_COARSE_GRAIN, f->flags)) {
                 if (unlink_fragment_for_signal(dcontext, f, FCACHE_ENTRY_PC(f))) {
                     info->interrupted = f;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1942,6 +1942,7 @@ if (CLIENT_INTERFACE)
       target_link_libraries(client.signal ${libpthread})
       tobuild_ci(client.cbr-retarget client-interface/cbr-retarget.c "" "" "")
     endif (X86)
+    tobuild_ci(client.cleancallsig client-interface/cleancallsig.c "" "" "")
   else (UNIX)
     tobuild_ci(client.events client-interface/events.c
       "" "" "${events_appdll_path}")

--- a/suite/tests/client-interface/cleancallsig.c
+++ b/suite/tests/client-interface/cleancallsig.c
@@ -1,0 +1,91 @@
+/* **********************************************************
+ * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "tools.h"
+#include <assert.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <ucontext.h>
+#include <sys/time.h> /* itimer */
+#include <time.h>     /* for nanosleep */
+
+/* Test delivering async signals that interrupt clean call and IBL gencode.
+ * It is not easy to hit some of the corner cases reliably: changes to
+ * the signal code requires running this test in a loop to hit everything.
+ */
+
+static volatile int num_sigs;
+
+static void
+signal_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
+{
+    if (sig == SIGALRM) {
+        num_sigs++;
+    } else
+        assert(0);
+}
+
+static int
+foo(int x)
+{
+    if (x == 0)
+        return x;
+    return x + 1;
+}
+
+int
+main(int argc, char *argv[])
+{
+    int rc;
+    struct itimerval t;
+    intercept_signal(SIGALRM, signal_handler, false);
+    t.it_interval.tv_sec = 0;
+    t.it_interval.tv_usec = 5000;
+    t.it_value.tv_sec = 0;
+    t.it_value.tv_usec = 5000;
+    rc = setitimer(ITIMER_REAL, &t, NULL);
+    assert(rc == 0);
+
+    /* Now spend time doing indirect branches to try and stress signals interrupting
+     * the IBL.
+     */
+    int i;
+    int (*foo_ptr)(int) = foo;
+#define WAIT_FOR_NUM_SIGS 250
+    while (num_sigs < WAIT_FOR_NUM_SIGS) {
+        rc += (*foo_ptr)(i);
+    }
+
+    print("all done\n");
+    return rc > 0;
+}

--- a/suite/tests/client-interface/cleancallsig.dll.c
+++ b/suite/tests/client-interface/cleancallsig.dll.c
@@ -1,0 +1,65 @@
+/* **********************************************************
+ * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "dr_api.h"
+#include "client_tools.h"
+
+static void
+cleancallee(app_pc pc)
+{
+    /* Include enough complexity to avoid inlining. */
+    if (pc == NULL) {
+        dr_fprintf(STDERR, "pc is NULL\n");
+    }
+}
+
+static dr_emit_flags_t
+bb_event(void *drcontext, void* tag, instrlist_t *bb, bool for_trace, bool translating)
+{
+    static int64 bb_count;
+    if (++bb_count % 10 == 0) {
+        for (instr_t *inst = instrlist_first(bb); inst != NULL;
+             inst = instr_get_next(inst)) {
+            if (instr_is_exclusive_store(inst))
+                return DR_EMIT_DEFAULT;
+        }
+        dr_insert_clean_call(drcontext, bb, instrlist_first(bb),
+                             (void*) cleancallee, false, 1, OPND_CREATE_INTPTR(tag));
+    }
+    return DR_EMIT_DEFAULT;
+}
+
+DR_EXPORT void
+dr_init(client_id_t id)
+{
+    dr_register_bb_event(bb_event);
+}

--- a/suite/tests/client-interface/cleancallsig.expect
+++ b/suite/tests/client-interface/cleancallsig.expect
@@ -1,0 +1,1 @@
+all done


### PR DESCRIPTION
Adds handling of a signal interrupting the ibl hit path's jump, where the
target tag is not conveniently sitting in a register like it is in the rest
of the ibl.  We have to instead look at the jump's cache target and find
the fragment to unlink from there.

Also fixes up the i#2328 support for a signal interrupting
clean_call_{save,restore} to work for AArch64.

Adds a new test, client.cleancallsig, which tries to trigger both of these
cases: the client adds a lot of clean calls while the app runs a loop with
a lot of indirect branches along with an itimer.  I managed to hit each of
the new features at least once running this test in a loop on each platform
except the ibl jump on ARM and AArch64.  I left an ASSERT_NOT_TESTED for
those.

Issue: #2328
Fixes #2042