### PR TITLE
Update reg_get_size to handle AArch64's XZR/WZR.

### DIFF
--- a/core/arch/opnd_shared.c
+++ b/core/arch/opnd_shared.c
@@ -2162,6 +2162,10 @@ reg_get_size(reg_id_t reg)
     if (reg >= REG_START_FLOAT && reg <= REG_STOP_FLOAT)
         return OPSZ_10;
 #elif defined(AARCHXX)
+    if (reg == DR_REG_XZR)
+        return OPSZ_8;
+    if (reg == DR_REG_WZR)
+        return OPSZ_4;
     if (reg >= DR_REG_Q0 && reg <= DR_REG_Q31)
         return OPSZ_16;
     if (reg >= DR_REG_D0 && reg <= DR_REG_D31)
@@ -2180,9 +2184,6 @@ reg_get_size(reg_id_t reg)
 # endif
     if (reg == DR_REG_TPIDRURW || reg == DR_REG_TPIDRURO)
         return OPSZ_PTR;
-# ifdef AARCH64
-    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
-# endif
 #endif
     CLIENT_ASSERT(false, "reg_get_size: invalid register");
     return OPSZ_NA;

--- a/core/arch/opnd_shared.c
+++ b/core/arch/opnd_shared.c
@@ -2162,10 +2162,6 @@ reg_get_size(reg_id_t reg)
     if (reg >= REG_START_FLOAT && reg <= REG_STOP_FLOAT)
         return OPSZ_10;
 #elif defined(AARCHXX)
-    if (reg == DR_REG_XZR)
-        return OPSZ_8;
-    if (reg == DR_REG_WZR)
-        return OPSZ_4;
     if (reg >= DR_REG_Q0 && reg <= DR_REG_Q31)
         return OPSZ_16;
     if (reg >= DR_REG_D0 && reg <= DR_REG_D31)
@@ -2180,6 +2176,11 @@ reg_get_size(reg_id_t reg)
     if (reg >= DR_REG_CR0 && reg <= DR_REG_CR15)
         return OPSZ_PTR;
     if (reg >= DR_REG_CPSR && reg <= DR_REG_FPSCR)
+        return OPSZ_4;
+# elif defined(AARCH64)
+    if (reg == DR_REG_XZR)
+        return OPSZ_8;
+    if (reg == DR_REG_WZR)
         return OPSZ_4;
 # endif
     if (reg == DR_REG_TPIDRURW || reg == DR_REG_TPIDRURO)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2239,6 +2239,7 @@ if (CLIENT_INTERFACE)
     torunonly_api(api.dis-a64 api.dis-a64 api/dis-a64.c ""
       "-q;${CMAKE_CURRENT_SOURCE_DIR}/api/dis-a64.txt" OFF)
     add_api_exe(api.reenc-a64 api/reenc-a64.c OFF OFF)
+    tobuild_api(api.opnd api/opnd-a64.c "" "" OFF OFF)
   elseif (X86)
     tobuild_api(api.dis api/dis.c "-syntax_intel"
       "${CMAKE_CURRENT_SOURCE_DIR}/api/dis-udis86-randtest.raw" OFF OFF)

--- a/suite/tests/api/opnd-a64.c
+++ b/suite/tests/api/opnd-a64.c
@@ -1,0 +1,73 @@
+/* **********************************************************
+ * Copyright (c) 2018 Arm Limited.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* This file contains unit tests for the APIs exported from opnd.h. */
+
+#include "configure.h"
+#include "dr_api.h"
+#include <stdio.h>
+
+#define ASSERT(x) \
+   ((void)((!(x)) ? \
+       (fprintf(stderr, "ASSERT FAILURE: %s:%d: %s\n", __FILE__,  __LINE__, #x),\
+        abort(), 0) : 0))
+
+static void
+test_get_size() {
+    /* Check sizes of special registers. */
+    ASSERT(reg_get_size(DR_REG_WZR) == OPSZ_4);
+    ASSERT(reg_get_size(DR_REG_XZR) == OPSZ_8);
+    ASSERT(reg_get_size(DR_REG_SP) == OPSZ_8);
+    ASSERT(reg_get_size(DR_REG_XSP) == OPSZ_8);
+
+    // Check sizes of GPRs.
+    for (uint i = 0; i < DR_NUM_GPR_REGS; i++) {
+        ASSERT(reg_get_size((reg_id_t) DR_REG_W0 + i) == OPSZ_4);
+        ASSERT(reg_get_size((reg_id_t) DR_REG_X0 + i) == OPSZ_8);
+    }
+
+    // Check sizes of FP/SIMD regs.
+    for (uint i = 0; i < NUM_SIMD_SLOTS; i++) {
+        ASSERT(reg_get_size((reg_id_t) DR_REG_H0 + i) == OPSZ_2);
+        ASSERT(reg_get_size((reg_id_t) DR_REG_S0 + i) == OPSZ_4);
+        ASSERT(reg_get_size((reg_id_t) DR_REG_D0 + i) == OPSZ_8);
+        ASSERT(reg_get_size((reg_id_t) DR_REG_Q0 + i) == OPSZ_16);
+    }
+}
+
+int
+main(int argc, char *argv[]) {
+    test_get_size();
+
+    printf("all done\n");
+    return 0;
+}

--- a/suite/tests/api/opnd-a64.c
+++ b/suite/tests/api/opnd-a64.c
@@ -42,7 +42,8 @@
         abort(), 0) : 0))
 
 static void
-test_get_size() {
+test_get_size()
+{
     /* Check sizes of special registers. */
     ASSERT(reg_get_size(DR_REG_WZR) == OPSZ_4);
     ASSERT(reg_get_size(DR_REG_XZR) == OPSZ_8);
@@ -65,7 +66,8 @@ test_get_size() {
 }
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
     test_get_size();
 
     printf("all done\n");

--- a/suite/tests/api/opnd-a64.expect
+++ b/suite/tests/api/opnd-a64.expect
@@ -1,0 +1,1 @@
+all done


### PR DESCRIPTION
This patch also adds a file for unit tests for the APIs exported from
opnd.h: suite/tests/api/opnd-a64.c. For now it only contains tests for
reg_get_size.

It also removes a ASSERT_NOT_IMPLEMENTED from reg_get_size. All AArch64
registers should be supported, except some system registers.