### PR TITLE
i#2993: avoid itimer lock splitting by alarms

### DIFF
--- a/core/arch/disassemble_shared.c
+++ b/core/arch/disassemble_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1574,7 +1574,9 @@ internal_dump_callstack_to_buffer(char *buf, size_t bufsz, size_t *sofar,
     if (TEST(CALLSTACK_ADD_HEADER, flags)) {
         print_to_buffer(buf, bufsz, sofar,
                         TEST(CALLSTACK_USE_XML, flags) ?
-                        "\t<call-stack>\n" : "Call stack:\n");
+                        "\t<call-stack tid="TIDFMT">\n" : "Thread "TIDFMT" call stack:\n",
+                        /* We avoid TLS tid to work on crashes */
+                        IF_WINDOWS_ELSE(get_thread_id(),get_sys_thread_id()));
     }
 
     if (cur_pc != NULL) {


### PR DESCRIPTION
Addresses two problems with itimer lock acquisition being split by an
alarm signal:

First, rather than a single lock for all itimers, which is subject to
races due to alarms of different types arriving in different threads
simultaneously, we switch to using a separate lock per itimer signal
type.  (We also have to handle an alarm arriving while handling an app
itimer syscall, which is why we can't just blindly block and wait for
the lock.)

Second, rather than holding a mutex to increment a counter, we switch
two different itimer counters to use atomic increments instead.  These
counters are used for new threads, and an alarm can arrive in a new
thread while it's setting up.  This avoids having a frequent time
window where an alarm splits the lock routine.

Fixes #2993