### PR TITLE
i#2995: do not blindly "restart" sigreturn

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -5504,8 +5504,8 @@ was_thread_create_syscall(dcontext_t *dcontext)
                                            dcontext->sys_param0);
 }
 
-static inline bool
-is_sigreturn_syscall_helper(int sysnum)
+bool
+is_sigreturn_syscall_number(int sysnum)
 {
 #ifdef MACOS
     return sysnum == SYS_sigreturn;
@@ -5518,13 +5518,13 @@ bool
 is_sigreturn_syscall(dcontext_t *dcontext)
 {
     priv_mcontext_t *mc = get_mcontext(dcontext);
-    return is_sigreturn_syscall_helper(MCXT_SYSNUM_REG(mc));
+    return is_sigreturn_syscall_number(MCXT_SYSNUM_REG(mc));
 }
 
 bool
 was_sigreturn_syscall(dcontext_t *dcontext)
 {
-    return is_sigreturn_syscall_helper(dcontext->sys_num);
+    return is_sigreturn_syscall_number(dcontext->sys_num);
 }
 
 /* process a signal this process/thread is sending to itself */

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -242,6 +242,9 @@ uint permstr_to_memprot(const char * const perm);
 int
 os_walk_address_space(memquery_iter_t *iter, bool add_modules);
 
+bool
+is_sigreturn_syscall_number(int sysnum);
+
 /* in signal.c */
 struct _kernel_sigaction_t;
 typedef struct _kernel_sigaction_t kernel_sigaction_t;

--- a/core/unix/os_public.h
+++ b/core/unix/os_public.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -124,6 +124,7 @@ typedef kernel_sigcontext_t sigcontext_t;
 # define SC_LR  SC_FIELD(regs[30])
 # define SC_XSP SC_FIELD(sp)
 # define SC_XFLAGS SC_FIELD(pstate)
+# define SC_SYSNUM_REG SC_FIELD(regs[8])
 #elif defined(ARM)
 # define SC_XIP SC_FIELD(arm_pc)
 # define SC_FP  SC_FIELD(arm_fp)


### PR DESCRIPTION
With SA_RESTART (#2659), we cannot distinguish
not-yet-executed-syscall from syscall-was-interrupted-in-the-kernel.
This doesn't matter for most syscalls, but it does matter for
sigreturn, whose asynch_target points somewhere other than right after
the syscall, so we exclude it (it can't be interrupted so we know we
haven't executed it yet).

Fixes #2995