### PR TITLE
i#2626 AArch64 encoder: Add support for fmov from GPR to FPR.

### DIFF
--- a/core/arch/aarch64/codec.txt
+++ b/core/arch/aarch64/codec.txt
@@ -956,6 +956,7 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0001111000100111000000xxxxxxxxxx     fmov s0 : w5
 1001111011100111000000xxxxxxxxxx     fmov h0 : x5 # Armv8.2
 1001111001100111000000xxxxxxxxxx     fmov d0 : x5
+1001111010101111000000xxxxxxxxxx     fmov q0 : x5 # only sets the bit top half of q0
 
 # Generated patterns
 # FABD

--- a/core/arch/aarch64/codec.txt
+++ b/core/arch/aarch64/codec.txt
@@ -951,6 +951,13 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 1101101011000000000011xxxxxxxxxx  rev     x0 : x5
 
 # Data Processing - Scalar Floating-Point and Advanced SIMD
+# FMOV (general) GPR to FP reg
+0001111011100111000000xxxxxxxxxx     fmov h0 : w5 # Armv8.2
+0001111000100111000000xxxxxxxxxx     fmov s0 : w5
+1001111011100111000000xxxxxxxxxx     fmov h0 : x5 # Armv8.2
+1001111001100111000000xxxxxxxxxx     fmov d0 : x5
+
+# Generated patterns
 # FABD
 0x101110110xxxxx000101xxxxxxxxxx     fabd dq0 : dq5 dq16 fsz16 # Armv8.2
 0x1011101x1xxxxx110101xxxxxxxxxx     fabd dq0 : dq5 dq16 fsz

--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -576,7 +576,7 @@
   INSTR_CREATE_sub_shift(dc, rd, rn, rm_or_imm, sht, sha)
 
 /**
- * Creates a FMOV instruction to move between GPRs and floating point registers.
+ * Creates an FMOV instruction to move between GPRs and floating point registers.
  * \param dc   The void * dcontext used to allocate memory for the instr_t.
  * \param Rd   The output register.
  * \param Rn   The first input register.

--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -576,6 +576,15 @@
   INSTR_CREATE_sub_shift(dc, rd, rn, rm_or_imm, sht, sha)
 
 /**
+ * Creates a FMOV instruction to move between GPRs and floating point registers.
+ * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ */
+#define INSTR_CREATE_fmov_general(dc, Rd, Rn) \
+    instr_create_1dst_1src(dc, OP_fmov, Rd, Rn)
+
+/**
  * Creates a FABD vector instruction.
  * \param dc The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.

--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -577,9 +577,9 @@
 
 /**
  * Creates a FMOV instruction to move between GPRs and floating point registers.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
+ * \param dc   The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd   The output register.
+ * \param Rn   The first input register.
  */
 #define INSTR_CREATE_fmov_general(dc, Rd, Rn) \
     instr_create_1dst_1src(dc, OP_fmov, Rd, Rn)

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -1561,6 +1561,12 @@ fd3fffff : str    d31, [sp,#32760]        : str    %d31 -> +0x7ff8(%sp)[8byte]
 fd481041 : ldr    d1, [x2,#4128]          : ldr    +0x1020(%x2)[8byte] -> %d1
 fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 
+# FMOV (general) GPR to FP reg
+1ee70220 : fmov  h0, w17 : fmov   %w17 -> %h0
+1e27012a : fmov  s10, w9 : fmov   %w9 -> %s10
+9ee701e5 : fmov  h5, x15 : fmov   %x15 -> %h5
+9e67004b : fmov  d11, x2 : fmov   %x2 -> %d11
+
 # FABD
 6ede1762 : fabd v2.8h, v27.8h, v30.8h : fabd   %q27 %q30 $0x01 -> %q2
 2ede1762 : fabd v2.4h, v27.4h, v30.4h : fabd   %d27 %d30 $0x01 -> %d2

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -1566,6 +1566,7 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 1e27012a : fmov  s10, w9 : fmov   %w9 -> %s10
 9ee701e5 : fmov  h5, x15 : fmov   %x15 -> %h5
 9e67004b : fmov  d11, x2 : fmov   %x2 -> %d11
+9eaf0149 : fmov  v9.d[1], x10 : fmov   %x10 -> %q9
 
 # FABD
 6ede1762 : fabd v2.8h, v27.8h, v30.8h : fabd   %q27 %q30 $0x01 -> %q2

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -282,6 +282,29 @@ test_ldar(void *dc)
 }
 
 static void
+test_fmov_general(void *dc)
+{
+    byte *pc;
+    instr_t *instr;
+
+    instr = INSTR_CREATE_fmov_general(dc, opnd_create_reg(DR_REG_H10),
+                                      opnd_create_reg(DR_REG_W9));
+    test_instr_encoding(dc, OP_fmov, instr);
+
+    instr = INSTR_CREATE_fmov_general(dc, opnd_create_reg(DR_REG_S14),
+                                      opnd_create_reg(DR_REG_W4));
+    test_instr_encoding(dc, OP_fmov, instr);
+
+    instr = INSTR_CREATE_fmov_general(dc, opnd_create_reg(DR_REG_H23),
+                                      opnd_create_reg(DR_REG_X8));
+    test_instr_encoding(dc, OP_fmov, instr);
+
+    instr = INSTR_CREATE_fmov_general(dc, opnd_create_reg(DR_REG_D6),
+                                      opnd_create_reg(DR_REG_X24));
+    test_instr_encoding(dc, OP_fmov, instr);
+}
+
+static void
 test_neon_fp_arithmetic(void *dc)
 {
     byte *pc;
@@ -1557,6 +1580,9 @@ main(int argc, char *argv[])
 
     test_ldar(dcontext);
     print("test_ldar complete\n");
+
+    test_fmov_general(dcontext);
+    print("test_fmov_general complete\n");
 
     test_neon_fp_arithmetic(dcontext);
     print("test_neon_fp_arithmetic complete\n");

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -302,6 +302,10 @@ test_fmov_general(void *dc)
     instr = INSTR_CREATE_fmov_general(dc, opnd_create_reg(DR_REG_D6),
                                       opnd_create_reg(DR_REG_X24));
     test_instr_encoding(dc, OP_fmov, instr);
+
+    instr = INSTR_CREATE_fmov_general(dc, opnd_create_reg(DR_REG_Q9),
+                                      opnd_create_reg(DR_REG_X10));
+    test_instr_encoding(dc, OP_fmov, instr);
 }
 
 static void

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -45,6 +45,7 @@ fmov   %w9 -> %h10
 fmov   %w4 -> %s14
 fmov   %x8 -> %h23
 fmov   %x24 -> %d6
+fmov   %x10 -> %q9
 test_fmov_general complete
 fabd   %q27 %q30 $0x01 -> %q2
 fabd   %d27 %d30 $0x01 -> %d2

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -41,6 +41,11 @@ ldar   (%x1)[8byte] -> %x0
 ldarb  (%x1)[1byte] -> %w0
 ldarh  (%x1)[2byte] -> %w0
 test_ldar complete
+fmov   %w9 -> %h10
+fmov   %w4 -> %s14
+fmov   %x8 -> %h23
+fmov   %x24 -> %d6
+test_fmov_general complete
 fabd   %q27 %q30 $0x01 -> %q2
 fabd   %d27 %d30 $0x01 -> %d2
 fabd   %q13 %q29 $0x02 -> %q0


### PR DESCRIPTION
This commit adds encoder/decoder support for fmov from GPRs to FPRs.

It does not add support for the variant to move a 64 bit GPR to the top
of a 128 bit register (`FMOV <Vd>.D[1], <Xn>`). I think for that variant,
we would need a way to express the top half of a 128 bit register.

Issue #2626