### PR TITLE
i#1569 AArch64: Fix macros to create AND,ANDs with imms.

### DIFF
--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -453,9 +453,9 @@
  * \param rm_or_imm   The second input register or immediate.
  */
 #define INSTR_CREATE_and(dc, rd, rn, rm_or_imm) \
-  opnd_is_immed(rm_or_imm) ? instr_create_1dst_2src((dc), OP_and, (rd), (rn), (rm_or_imm)) :  \
+  (opnd_is_immed(rm_or_imm) ? instr_create_1dst_2src((dc), OP_and, (rd), (rn), (rm_or_imm)) :  \
                              INSTR_CREATE_and_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(), \
-                                                    OPND_CREATE_INT(0))
+                                                    OPND_CREATE_INT(0)))
 #define INSTR_CREATE_and_shift(dc, rd, rn, rm, sht, sha) \
   instr_create_1dst_4src((dc), OP_and, (rd), (rn), \
     opnd_create_reg_ex(opnd_get_reg(rm), 0, DR_OPND_SHIFTED), \
@@ -469,9 +469,9 @@
  * \param rm_or_imm   The second input register or immediate.
  */
 #define INSTR_CREATE_ands(dc, rd, rn, rm_or_imm) \
-  opnd_is_immed(rm_or_imm) ? instr_create_1dst_2src((dc), OP_ands, (rd), (rn), (rm_or_imm)) :  \
+  (opnd_is_immed(rm_or_imm) ? instr_create_1dst_2src((dc), OP_ands, (rd), (rn), (rm_or_imm)) :  \
                              INSTR_CREATE_ands_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(), \
-                                                    OPND_CREATE_INT(0))
+                                                    OPND_CREATE_INT(0)))
 #define INSTR_CREATE_ands_shift(dc, rd, rn, rm, sht, sha) \
   instr_create_1dst_4src((dc), OP_ands, (rd), (rn), \
     opnd_create_reg_ex(opnd_get_reg(rm), 0, DR_OPND_SHIFTED), \

--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -444,14 +444,34 @@
   (opnd_is_reg(rm_or_imm) ? \
     INSTR_CREATE_adds_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(), OPND_CREATE_INT(0)) : \
     INSTR_CREATE_adds_imm(dc, rd, rn, rm_or_imm, OPND_CREATE_INT(0)))
-#define INSTR_CREATE_and(dc, rd, rn, rm_or_imm) \
-  INSTR_CREATE_and_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(), OPND_CREATE_INT(0))
+
+/**
+ * Creates an AND instruction with one output and two inputs.
+ * \param dc   The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd   The output register.
+ * \param Rn   The first input register.
+ * \param Rm_or_Imm   The second input register or immediate.
+ */
+#define INSTR_CREATE_and(dc, Rd, Rn, Rm_or_Imm) \
+  opnd_is_immed(rm_or_imm) ? instr_create_1dst_2src((dc), OP_and, (rd), (rn), (rm_or_imm)) :  \
+                             INSTR_CREATE_and_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(), \
+                                                    OPND_CREATE_INT(0))
 #define INSTR_CREATE_and_shift(dc, rd, rn, rm, sht, sha) \
   instr_create_1dst_4src((dc), OP_and, (rd), (rn), \
     opnd_create_reg_ex(opnd_get_reg(rm), 0, DR_OPND_SHIFTED), \
     opnd_add_flags((sht), DR_OPND_IS_SHIFT), (sha))
+
+/**
+ * Creates an ANDS instruction with one output and two inputs.
+ * \param dc   The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd   The output register.
+ * \param Rn   The first input register.
+ * \param Rm_or_Imm   The second input register or immediate.
+ */
 #define INSTR_CREATE_ands(dc, rd, rn, rm_or_imm) \
-  INSTR_CREATE_ands_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(), OPND_CREATE_INT(0))
+  opnd_is_immed(rm_or_imm) ? instr_create_1dst_2src((dc), OP_ands, (rd), (rn), (rm_or_imm)) :  \
+                             INSTR_CREATE_ands_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(), \
+                                                    OPND_CREATE_INT(0))
 #define INSTR_CREATE_ands_shift(dc, rd, rn, rm, sht, sha) \
   instr_create_1dst_4src((dc), OP_ands, (rd), (rn), \
     opnd_create_reg_ex(opnd_get_reg(rm), 0, DR_OPND_SHIFTED), \

--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -448,11 +448,11 @@
 /**
  * Creates an AND instruction with one output and two inputs.
  * \param dc   The void * dcontext used to allocate memory for the instr_t.
- * \param Rd   The output register.
- * \param Rn   The first input register.
- * \param Rm_or_Imm   The second input register or immediate.
+ * \param rd   The output register.
+ * \param rn   The first input register.
+ * \param rm_or_imm   The second input register or immediate.
  */
-#define INSTR_CREATE_and(dc, Rd, Rn, Rm_or_Imm) \
+#define INSTR_CREATE_and(dc, rd, rn, rm_or_imm) \
   opnd_is_immed(rm_or_imm) ? instr_create_1dst_2src((dc), OP_and, (rd), (rn), (rm_or_imm)) :  \
                              INSTR_CREATE_and_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(), \
                                                     OPND_CREATE_INT(0))
@@ -464,9 +464,9 @@
 /**
  * Creates an ANDS instruction with one output and two inputs.
  * \param dc   The void * dcontext used to allocate memory for the instr_t.
- * \param Rd   The output register.
- * \param Rn   The first input register.
- * \param Rm_or_Imm   The second input register or immediate.
+ * \param rd   The output register.
+ * \param rn   The first input register.
+ * \param rm_or_imm   The second input register or immediate.
  */
 #define INSTR_CREATE_ands(dc, rd, rn, rm_or_imm) \
   opnd_is_immed(rm_or_imm) ? instr_create_1dst_2src((dc), OP_ands, (rd), (rn), (rm_or_imm)) :  \

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -282,6 +282,30 @@ test_ldar(void *dc)
 }
 
 static void
+test_instrs_with_logic_imm(void *dc)
+{
+    byte *pc;
+    instr_t *instr;
+
+    instr = INSTR_CREATE_and(dc, opnd_create_reg(DR_REG_X10),
+                             opnd_create_reg(DR_REG_X9), OPND_CREATE_INT(0xFFFF));
+    test_instr_encoding(dc, OP_and, instr);
+
+    instr = INSTR_CREATE_and(dc, opnd_create_reg(DR_REG_W5),
+                             opnd_create_reg(DR_REG_W5), OPND_CREATE_INT(0xFF));
+    test_instr_encoding(dc, OP_and, instr);
+
+    instr = INSTR_CREATE_ands(dc, opnd_create_reg(DR_REG_X23),
+                              opnd_create_reg(DR_REG_X19), OPND_CREATE_INT(0xFFFFFF));
+    test_instr_encoding(dc, OP_ands, instr);
+
+    instr = INSTR_CREATE_ands(dc, opnd_create_reg(DR_REG_W3),
+                              opnd_create_reg(DR_REG_W8), OPND_CREATE_INT(0xF));
+    test_instr_encoding(dc, OP_ands, instr);
+
+}
+
+static void
 test_neon_fp_arithmetic(void *dc)
 {
     byte *pc;
@@ -1557,6 +1581,9 @@ main(int argc, char *argv[])
 
     test_ldar(dcontext);
     print("test_ldar complete\n");
+
+    test_instrs_with_logic_imm(dcontext);
+    print("test_instrs_with_logic_imm complete\n");
 
     test_neon_fp_arithmetic(dcontext);
     print("test_neon_fp_arithmetic complete\n");

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -44,7 +44,7 @@ test_ldar complete
 and    %x9 $0x000000000000ffff -> %x10
 and    %w5 $0x00000000000000ff -> %w5
 ands   %x19 $0x0000000000ffffff -> %x23
-ands   %w8 $0x0000000000ffffff -> %w3
+ands   %w8 $0x000000000000000f -> %w3
 test_instrs_with_logic_imm complete
 fmov   %w9 -> %h10
 fmov   %w4 -> %s14

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -41,6 +41,11 @@ ldar   (%x1)[8byte] -> %x0
 ldarb  (%x1)[1byte] -> %w0
 ldarh  (%x1)[2byte] -> %w0
 test_ldar complete
+and    %x9 $0x000000000000ffff -> %x10
+and    %w5 $0x00000000000000ff -> %w5
+ands   %x19 $0x0000000000ffffff -> %x23
+ands   %w8 $0x0000000000ffffff -> %w3
+test_instrs_with_logic_imm complete
 fabd   %q27 %q30 $0x01 -> %q2
 fabd   %d27 %d30 $0x01 -> %d2
 fabd   %q13 %q29 $0x02 -> %q0


### PR DESCRIPTION
Instructions that take logical immediates are not encoded with shifts and the 
macros were broken for them.

Issue: #1569
