### PR TITLE
i#2626 AArch64 encode: Implement instr_is_encoding_possible.

### DIFF
--- a/core/arch/aarch64/encode.c
+++ b/core/arch/aarch64/encode.c
@@ -130,8 +130,11 @@ encode_debug_checks(void)
 bool
 encoding_possible(decode_info_t *di, instr_t *in, const instr_info_t * ii)
 {
-    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
-    return false;
+    uint enc;
+
+    byte tmp[4];
+    enc = encode_common(&tmp[0], in, di);
+    return enc != ENCFAIL;
 }
 
 void

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -1922,7 +1922,12 @@ set_reached_image_entry(void);
 /* in encode.c */
 /* DR_API EXPORT TOFILE dr_ir_instr.h */
 DR_API
-/** Returns true iff \p instr can be encoding as a valid IA-32 instruction. */
+/** Returns true iff \p instr can be encoded as
+ *    - a valid IA-32 instruction on X86
+ *    - a valid Armv8-a instruction on AArch64 (Note: The AArch64 encoder/decoder is
+ *      not complete yet, so DynamoRIO may fail to encode some valid Armv8-a
+ *      instructions. See i#2626)
+ */
 bool
 instr_is_encoding_possible(instr_t *instr);
 

--- a/core/arch/encode_shared.c
+++ b/core/arch/encode_shared.c
@@ -68,6 +68,17 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
                   bool check_reachable, bool *has_instr_opnds/*OUT OPTIONAL*/
                   _IF_DEBUG(bool assert_reachable));
 
+#ifdef AARCH64
+/* exported
+ */
+bool
+instr_is_encoding_possible(instr_t *instr)
+{
+    decode_info_t di;
+
+    return encoding_possible(&di, instr, NULL);
+}
+#else
 /* exported, looks at all possible instr_info_t templates
  */
 bool
@@ -76,6 +87,7 @@ instr_is_encoding_possible(instr_t *instr)
     const instr_info_t * info = get_encoding_info(instr);
     return (info != NULL);
 }
+#endif
 
 /* looks at all possible instr_info_t templates, returns first match
  * returns NULL if no encoding is possible

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2218,6 +2218,10 @@ if (CLIENT_INTERFACE)
         ${CMAKE_CURRENT_SOURCE_DIR}/api/ir_${sfx}_4args.h)
       append_property_string(SOURCE api/ir_${sfx}.c OBJECT_DEPENDS "${api_ir_headers}")
     endif ()
+
+    if (AARCH64)
+        tobuild_api(api.ir_negative api/ir_aarch64_negative.c "" "" OFF OFF)
+    endif (AARCH64)
   endif ()
 
   if (ARM)

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -107,6 +107,7 @@ test_instr_encoding(void *dc, uint opcode, instr_t *instr)
     ASSERT(instr_get_opcode(instr) == opcode);
     instr_disassemble(dc, instr, STDOUT); print("\n");
 
+    ASSERT(instr_is_encoding_possible(instr));
     pc = instr_encode(dc, instr, buf);
     decin = instr_create(dc);
     decode(dc, buf, decin);

--- a/suite/tests/api/ir_aarch64_negative.c
+++ b/suite/tests/api/ir_aarch64_negative.c
@@ -1,0 +1,97 @@
+/* **********************************************************
+ * Copyright (c) 2018 Arm Limited. All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of ARM Limited nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* This file contains tests to ensure we fail to encode invalid IR instructions. */
+
+/* Define DR_FAST_IR to verify that everything compiles when we call the inline
+ * versions of these routines.
+ */
+#ifndef STANDALONE_DECODER
+# define DR_FAST_IR 1
+#endif
+
+/* Uses the DR CLIENT_INTERFACE API, using DR as a standalone library, rather than
+ * being a client library working with DR on a target program.
+ */
+
+#include "configure.h"
+#include "dr_api.h"
+#include "tools.h"
+
+#ifdef STANDALONE_DECODER
+# define ASSERT(x) \
+    ((void)((!(x)) ? \
+        (fprintf(stderr, "ASSERT FAILURE (standalone): %s:%d: %s\n", __FILE__, \
+                          __LINE__, #x), \
+         abort(), 0) : 0))
+#else
+# define ASSERT(x) \
+    ((void)((!(x)) ? \
+        (dr_fprintf(STDERR, "ASSERT FAILURE (client): %s:%d: %s\n", __FILE__, \
+                             __LINE__, #x), \
+         dr_abort(), 0) : 0))
+#endif
+
+static void
+test_fmov_general(void *dc)
+{
+    byte *pc;
+    instr_t *instr;
+
+    instr = INSTR_CREATE_fmov_general(dc, opnd_create_reg(DR_REG_D10),
+                                      opnd_create_reg(DR_REG_W9));
+    ASSERT(!instr_is_encoding_possible(instr));
+
+    instr = INSTR_CREATE_fmov_general(dc, opnd_create_reg(DR_REG_S10),
+                                      opnd_create_reg(DR_REG_X9));
+    ASSERT(!instr_is_encoding_possible(instr));
+
+    instr = INSTR_CREATE_fmov_general(dc, opnd_create_reg(DR_REG_W10),
+                                      opnd_create_reg(DR_REG_X9));
+    ASSERT(!instr_is_encoding_possible(instr));
+}
+
+int
+main(int argc, char *argv[])
+{
+#ifdef STANDALONE_DECODER
+    void *dcontext = GLOBAL_DCONTEXT;
+#else
+    void *dcontext = dr_standalone_init();
+#endif
+
+    test_fmov_general(dcontext);
+    print("test_fmov_general complete\n");
+
+    print("All tests complete\n");
+    return 0;
+}

--- a/suite/tests/api/ir_aarch64_negative.expect
+++ b/suite/tests/api/ir_aarch64_negative.expect
@@ -1,0 +1,2 @@
+test_fmov_general complete
+All tests complete


### PR DESCRIPTION
This patch implements instr_is_encoding_possible and encoding_possible
using encode_common, which returns ENCFAIL in case of a failure. This
is not the most efficient implementation, but we do not have encoding
tables available in the AArch64 backend.

As a test case, it includes a check to make sure the encoder rejects
some invalid combinations of FMOV.

Issue #2626