### PR TITLE
i#2626 AArch64 encoder: Add dst as src for instrs that read it.

### DIFF
--- a/core/arch/aarch64/codec.txt
+++ b/core/arch/aarch64/codec.txt
@@ -1064,12 +1064,12 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0x1011101x1xxxxx111101xxxxxxxxxx     fminp dq0 : dq5 dq16 fsz
 
 # FMLA (vector)
-0x001110010xxxxx000011xxxxxxxxxx     fmla dq0 : dq5 dq16 fsz16 # Armv8.2
-0x0011100x1xxxxx110011xxxxxxxxxx     fmla dq0 : dq5 dq16 fsz
+0x001110010xxxxx000011xxxxxxxxxx     fmla dq0 : dq0 dq5 dq16 fsz16 # Armv8.2
+0x0011100x1xxxxx110011xxxxxxxxxx     fmla dq0 : dq0 dq5 dq16 fsz
 
 # FMLS (vector)
-0x001110110xxxxx000011xxxxxxxxxx     fmls dq0 : dq5 dq16 fsz16 # Armv8.2
-0x0011101x1xxxxx110011xxxxxxxxxx     fmls dq0 : dq5 dq16 fsz
+0x001110110xxxxx000011xxxxxxxxxx     fmls dq0 : dq0 dq5 dq16 fsz16 # Armv8.2
+0x0011101x1xxxxx110011xxxxxxxxxx     fmls dq0 : dq0 dq5 dq16 fsz
 
 # FMOV (register)
 00011110xx100000010000xxxxxxxxxx     fmov float_reg0 : float_reg5

--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -891,26 +891,26 @@
 /**
  * Creates a FMLA vector instruction.
  * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
+ * \param Rd      The output register. The instruction also reads this register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  * \param width   The vector element width. Use either OPND_CREATE_HALF(),
  *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fmla_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fmla, Rd, Rm, Rn, width)
+    instr_create_1dst_4src(dc, OP_fmla, Rd, Rd, Rm, Rn, width)
 
 /**
  * Creates a FMLS vector instruction.
  * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
+ * \param Rd      The output register. The instruction also reads this register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  * \param width   The vector element width. Use either OPND_CREATE_HALF(),
  *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fmls_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fmls, Rd, Rm, Rn, width)
+    instr_create_1dst_4src(dc, OP_fmls, Rd, Rd, Rm, Rn, width)
 
 /**
  * Creates a FMOV floating point instruction.

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -1776,18 +1776,18 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 2eadf407 : fminp v7.2s, v0.2s, v13.2s : fminp  %d0 %d13 $0x02 -> %d7
 
 # FMLA (vector)
-4e4c0f1b : fmla v27.8h, v24.8h, v12.8h : fmla   %q27 %q24 %q12 $0x01 -> %q27
-0e4c0f1b : fmla v27.4h, v24.4h, v12.4h : fmla   %d27 %d24 %d12 $0x01 -> %d27
-4e23cca4 : fmla v4.4s, v5.4s, v3.4s : fmla   %q4 %q5 %q3 $0x02 -> %q4
-4e63cca4 : fmla v4.2d, v5.2d, v3.2d : fmla   %q4 %q5 %q3 $0x03 -> %q4
-0e23cca4 : fmla v4.2s, v5.2s, v3.2s : fmla   %d4 %d5 %d3 $0x02 -> %d4
+4e580f5b : fmla v27.8h, v26.8h, v24.8h : fmla   %q27 %q26 %q24 $0x01 -> %q27
+0e580f5b : fmla v27.4h, v26.4h, v24.4h : fmla   %d27 %d26 %d24 $0x01 -> %d27
+4e3bcc8c : fmla v12.4s, v4.4s, v27.4s : fmla   %q12 %q4 %q27 $0x02 -> %q12
+4e7bcc8c : fmla v12.2d, v4.2d, v27.2d : fmla   %q12 %q4 %q27 $0x03 -> %q12
+0e3bcc8c : fmla v12.2s, v4.2s, v27.2s : fmla   %d12 %d4 %d27 $0x02 -> %d12
 
 # FMLS (vector)
-4edd0ef6 : fmls v22.8h, v23.8h, v29.8h : fmls   %q22 %q23 %q29 $0x01 -> %q22
-0edd0ef6 : fmls v22.4h, v23.4h, v29.4h : fmls   %d22 %d23 %d29 $0x01 -> %d22
-4ebdce5b : fmls v27.4s, v18.4s, v29.4s : fmls   %q27 %q18 %q29 $0x02 -> %q27
-4efdce5b : fmls v27.2d, v18.2d, v29.2d : fmls   %q27 %q18 %q29 $0x03 -> %q27
-0ebdce5b : fmls v27.2s, v18.2s, v29.2s : fmls   %d27 %d18 %d29 $0x02 -> %d27
+4ed60c65 : fmls v5.8h, v3.8h, v22.8h : fmls   %q5 %q3 %q22 $0x01 -> %q5
+0ed60c65 : fmls v5.4h, v3.4h, v22.4h : fmls   %d5 %d3 %d22 $0x01 -> %d5
+4ebdcef0 : fmls v16.4s, v23.4s, v29.4s : fmls   %q16 %q23 %q29 $0x02 -> %q16
+4efdcef0 : fmls v16.2d, v23.2d, v29.2d : fmls   %q16 %q23 %q29 $0x03 -> %q16
+0ebdcef0 : fmls v16.2s, v23.2s, v29.2s : fmls   %d16 %d23 %d29 $0x02 -> %d16
 
 # FMOV (register)
 1e60419b : fmov d27, d12 : fmov   %d12 -> %d27

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -1776,18 +1776,18 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 2eadf407 : fminp v7.2s, v0.2s, v13.2s : fminp  %d0 %d13 $0x02 -> %d7
 
 # FMLA (vector)
-4e580f5b : fmla v27.8h, v26.8h, v24.8h : fmla   %q26 %q24 $0x01 -> %q27
-0e580f5b : fmla v27.4h, v26.4h, v24.4h : fmla   %d26 %d24 $0x01 -> %d27
-4e3bcc8c : fmla v12.4s, v4.4s, v27.4s : fmla   %q4 %q27 $0x02 -> %q12
-4e7bcc8c : fmla v12.2d, v4.2d, v27.2d : fmla   %q4 %q27 $0x03 -> %q12
-0e3bcc8c : fmla v12.2s, v4.2s, v27.2s : fmla   %d4 %d27 $0x02 -> %d12
+4e4c0f1b : fmla v27.8h, v24.8h, v12.8h : fmla   %q27 %q24 %q12 $0x01 -> %q27
+0e4c0f1b : fmla v27.4h, v24.4h, v12.4h : fmla   %d27 %d24 %d12 $0x01 -> %d27
+4e23cca4 : fmla v4.4s, v5.4s, v3.4s : fmla   %q4 %q5 %q3 $0x02 -> %q4
+4e63cca4 : fmla v4.2d, v5.2d, v3.2d : fmla   %q4 %q5 %q3 $0x03 -> %q4
+0e23cca4 : fmla v4.2s, v5.2s, v3.2s : fmla   %d4 %d5 %d3 $0x02 -> %d4
 
 # FMLS (vector)
-4ed60c65 : fmls v5.8h, v3.8h, v22.8h : fmls   %q3 %q22 $0x01 -> %q5
-0ed60c65 : fmls v5.4h, v3.4h, v22.4h : fmls   %d3 %d22 $0x01 -> %d5
-4ebdcef0 : fmls v16.4s, v23.4s, v29.4s : fmls   %q23 %q29 $0x02 -> %q16
-4efdcef0 : fmls v16.2d, v23.2d, v29.2d : fmls   %q23 %q29 $0x03 -> %q16
-0ebdcef0 : fmls v16.2s, v23.2s, v29.2s : fmls   %d23 %d29 $0x02 -> %d16
+4edd0ef6 : fmls v22.8h, v23.8h, v29.8h : fmls   %q22 %q23 %q29 $0x01 -> %q22
+0edd0ef6 : fmls v22.4h, v23.4h, v29.4h : fmls   %d22 %d23 %d29 $0x01 -> %d22
+4ebdce5b : fmls v27.4s, v18.4s, v29.4s : fmls   %q27 %q18 %q29 $0x02 -> %q27
+4efdce5b : fmls v27.2d, v18.2d, v29.2d : fmls   %q27 %q18 %q29 $0x03 -> %q27
+0ebdce5b : fmls v27.2s, v18.2s, v29.2s : fmls   %d27 %d18 %d29 $0x02 -> %d27
 
 # FMOV (register)
 1e60419b : fmov d27, d12 : fmov   %d12 -> %d27

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -1077,70 +1077,70 @@ test_neon_fp_arithmetic(void *dc)
 
     instr = INSTR_CREATE_fmla_vector(dc,
                                      opnd_create_reg(DR_REG_Q27),
+                                     opnd_create_reg(DR_REG_Q26),
                                      opnd_create_reg(DR_REG_Q24),
-                                     opnd_create_reg(DR_REG_Q12),
                                      OPND_CREATE_HALF());
     test_instr_encoding(dc, OP_fmla, instr);
 
     instr = INSTR_CREATE_fmla_vector(dc,
                                      opnd_create_reg(DR_REG_D27),
+                                     opnd_create_reg(DR_REG_D26),
                                      opnd_create_reg(DR_REG_D24),
-                                     opnd_create_reg(DR_REG_D12),
                                      OPND_CREATE_HALF());
     test_instr_encoding(dc, OP_fmla, instr);
 
     instr = INSTR_CREATE_fmla_vector(dc,
+                                     opnd_create_reg(DR_REG_Q12),
                                      opnd_create_reg(DR_REG_Q4),
-                                     opnd_create_reg(DR_REG_Q5),
-                                     opnd_create_reg(DR_REG_Q3),
+                                     opnd_create_reg(DR_REG_Q27),
                                      OPND_CREATE_SINGLE());
     test_instr_encoding(dc, OP_fmla, instr);
 
     instr = INSTR_CREATE_fmla_vector(dc,
+                                     opnd_create_reg(DR_REG_Q12),
                                      opnd_create_reg(DR_REG_Q4),
-                                     opnd_create_reg(DR_REG_Q5),
-                                     opnd_create_reg(DR_REG_Q3),
+                                     opnd_create_reg(DR_REG_Q27),
                                      OPND_CREATE_DOUBLE());
     test_instr_encoding(dc, OP_fmla, instr);
 
     instr = INSTR_CREATE_fmla_vector(dc,
+                                     opnd_create_reg(DR_REG_D12),
                                      opnd_create_reg(DR_REG_D4),
+                                     opnd_create_reg(DR_REG_D27),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmla, instr);
+
+    instr = INSTR_CREATE_fmls_vector(dc,
+                                     opnd_create_reg(DR_REG_Q5),
+                                     opnd_create_reg(DR_REG_Q3),
+                                     opnd_create_reg(DR_REG_Q22),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmls, instr);
+
+    instr = INSTR_CREATE_fmls_vector(dc,
                                      opnd_create_reg(DR_REG_D5),
                                      opnd_create_reg(DR_REG_D3),
-                                     OPND_CREATE_SINGLE());
-    test_instr_encoding(dc, OP_fmla, instr);
+                                     opnd_create_reg(DR_REG_D22),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmls, instr);
 
     instr = INSTR_CREATE_fmls_vector(dc,
-                                     opnd_create_reg(DR_REG_Q22),
+                                     opnd_create_reg(DR_REG_Q16),
                                      opnd_create_reg(DR_REG_Q23),
                                      opnd_create_reg(DR_REG_Q29),
-                                     OPND_CREATE_HALF());
-    test_instr_encoding(dc, OP_fmls, instr);
-
-    instr = INSTR_CREATE_fmls_vector(dc,
-                                     opnd_create_reg(DR_REG_D22),
-                                     opnd_create_reg(DR_REG_D23),
-                                     opnd_create_reg(DR_REG_D29),
-                                     OPND_CREATE_HALF());
-    test_instr_encoding(dc, OP_fmls, instr);
-
-    instr = INSTR_CREATE_fmls_vector(dc,
-                                     opnd_create_reg(DR_REG_Q27),
-                                     opnd_create_reg(DR_REG_Q18),
-                                     opnd_create_reg(DR_REG_Q29),
                                      OPND_CREATE_SINGLE());
     test_instr_encoding(dc, OP_fmls, instr);
 
     instr = INSTR_CREATE_fmls_vector(dc,
-                                     opnd_create_reg(DR_REG_Q27),
-                                     opnd_create_reg(DR_REG_Q18),
+                                     opnd_create_reg(DR_REG_Q16),
+                                     opnd_create_reg(DR_REG_Q23),
                                      opnd_create_reg(DR_REG_Q29),
                                      OPND_CREATE_DOUBLE());
     test_instr_encoding(dc, OP_fmls, instr);
 
     instr = INSTR_CREATE_fmls_vector(dc,
-                                     opnd_create_reg(DR_REG_D27),
-                                     opnd_create_reg(DR_REG_D18),
+                                     opnd_create_reg(DR_REG_D16),
+                                     opnd_create_reg(DR_REG_D23),
                                      opnd_create_reg(DR_REG_D29),
                                      OPND_CREATE_SINGLE());
     test_instr_encoding(dc, OP_fmls, instr);

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -1077,70 +1077,70 @@ test_neon_fp_arithmetic(void *dc)
 
     instr = INSTR_CREATE_fmla_vector(dc,
                                      opnd_create_reg(DR_REG_Q27),
-                                     opnd_create_reg(DR_REG_Q26),
                                      opnd_create_reg(DR_REG_Q24),
+                                     opnd_create_reg(DR_REG_Q12),
                                      OPND_CREATE_HALF());
     test_instr_encoding(dc, OP_fmla, instr);
 
     instr = INSTR_CREATE_fmla_vector(dc,
                                      opnd_create_reg(DR_REG_D27),
-                                     opnd_create_reg(DR_REG_D26),
                                      opnd_create_reg(DR_REG_D24),
+                                     opnd_create_reg(DR_REG_D12),
                                      OPND_CREATE_HALF());
     test_instr_encoding(dc, OP_fmla, instr);
 
     instr = INSTR_CREATE_fmla_vector(dc,
-                                     opnd_create_reg(DR_REG_Q12),
                                      opnd_create_reg(DR_REG_Q4),
-                                     opnd_create_reg(DR_REG_Q27),
-                                     OPND_CREATE_SINGLE());
-    test_instr_encoding(dc, OP_fmla, instr);
-
-    instr = INSTR_CREATE_fmla_vector(dc,
-                                     opnd_create_reg(DR_REG_Q12),
-                                     opnd_create_reg(DR_REG_Q4),
-                                     opnd_create_reg(DR_REG_Q27),
-                                     OPND_CREATE_DOUBLE());
-    test_instr_encoding(dc, OP_fmla, instr);
-
-    instr = INSTR_CREATE_fmla_vector(dc,
-                                     opnd_create_reg(DR_REG_D12),
-                                     opnd_create_reg(DR_REG_D4),
-                                     opnd_create_reg(DR_REG_D27),
-                                     OPND_CREATE_SINGLE());
-    test_instr_encoding(dc, OP_fmla, instr);
-
-    instr = INSTR_CREATE_fmls_vector(dc,
                                      opnd_create_reg(DR_REG_Q5),
                                      opnd_create_reg(DR_REG_Q3),
-                                     opnd_create_reg(DR_REG_Q22),
-                                     OPND_CREATE_HALF());
-    test_instr_encoding(dc, OP_fmls, instr);
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmla, instr);
 
-    instr = INSTR_CREATE_fmls_vector(dc,
+    instr = INSTR_CREATE_fmla_vector(dc,
+                                     opnd_create_reg(DR_REG_Q4),
+                                     opnd_create_reg(DR_REG_Q5),
+                                     opnd_create_reg(DR_REG_Q3),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fmla, instr);
+
+    instr = INSTR_CREATE_fmla_vector(dc,
+                                     opnd_create_reg(DR_REG_D4),
                                      opnd_create_reg(DR_REG_D5),
                                      opnd_create_reg(DR_REG_D3),
-                                     opnd_create_reg(DR_REG_D22),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmla, instr);
+
+    instr = INSTR_CREATE_fmls_vector(dc,
+                                     opnd_create_reg(DR_REG_Q22),
+                                     opnd_create_reg(DR_REG_Q23),
+                                     opnd_create_reg(DR_REG_Q29),
                                      OPND_CREATE_HALF());
     test_instr_encoding(dc, OP_fmls, instr);
 
     instr = INSTR_CREATE_fmls_vector(dc,
-                                     opnd_create_reg(DR_REG_Q16),
-                                     opnd_create_reg(DR_REG_Q23),
+                                     opnd_create_reg(DR_REG_D22),
+                                     opnd_create_reg(DR_REG_D23),
+                                     opnd_create_reg(DR_REG_D29),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmls, instr);
+
+    instr = INSTR_CREATE_fmls_vector(dc,
+                                     opnd_create_reg(DR_REG_Q27),
+                                     opnd_create_reg(DR_REG_Q18),
                                      opnd_create_reg(DR_REG_Q29),
                                      OPND_CREATE_SINGLE());
     test_instr_encoding(dc, OP_fmls, instr);
 
     instr = INSTR_CREATE_fmls_vector(dc,
-                                     opnd_create_reg(DR_REG_Q16),
-                                     opnd_create_reg(DR_REG_Q23),
+                                     opnd_create_reg(DR_REG_Q27),
+                                     opnd_create_reg(DR_REG_Q18),
                                      opnd_create_reg(DR_REG_Q29),
                                      OPND_CREATE_DOUBLE());
     test_instr_encoding(dc, OP_fmls, instr);
 
     instr = INSTR_CREATE_fmls_vector(dc,
-                                     opnd_create_reg(DR_REG_D16),
-                                     opnd_create_reg(DR_REG_D23),
+                                     opnd_create_reg(DR_REG_D27),
+                                     opnd_create_reg(DR_REG_D18),
                                      opnd_create_reg(DR_REG_D29),
                                      OPND_CREATE_SINGLE());
     test_instr_encoding(dc, OP_fmls, instr);

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -161,16 +161,16 @@ fminp  %d17 %d23 $0x01 -> %d13
 fminp  %q0 %q13 $0x02 -> %q7
 fminp  %q0 %q13 $0x03 -> %q7
 fminp  %d0 %d13 $0x02 -> %d7
-fmla   %q26 %q24 $0x01 -> %q27
-fmla   %d26 %d24 $0x01 -> %d27
-fmla   %q4 %q27 $0x02 -> %q12
-fmla   %q4 %q27 $0x03 -> %q12
-fmla   %d4 %d27 $0x02 -> %d12
-fmls   %q3 %q22 $0x01 -> %q5
-fmls   %d3 %d22 $0x01 -> %d5
-fmls   %q23 %q29 $0x02 -> %q16
-fmls   %q23 %q29 $0x03 -> %q16
-fmls   %d23 %d29 $0x02 -> %d16
+fmla   %q27 %q24 %q12 $0x01 -> %q27
+fmla   %d27 %d24 %d12 $0x01 -> %d27
+fmla   %q4 %q5 %q3 $0x02 -> %q4
+fmla   %q4 %q5 %q3 $0x03 -> %q4
+fmla   %d4 %d5 %d3 $0x02 -> %d4
+fmls   %q22 %q23 %q29 $0x01 -> %q22
+fmls   %d22 %d23 %d29 $0x01 -> %d22
+fmls   %q27 %q18 %q29 $0x02 -> %q27
+fmls   %q27 %q18 %q29 $0x03 -> %q27
+fmls   %d27 %d18 %d29 $0x02 -> %d27
 fmov   %d31 -> %d18
 fmov   %s31 -> %s18
 fmov   %h31 -> %h18

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -161,16 +161,16 @@ fminp  %d17 %d23 $0x01 -> %d13
 fminp  %q0 %q13 $0x02 -> %q7
 fminp  %q0 %q13 $0x03 -> %q7
 fminp  %d0 %d13 $0x02 -> %d7
-fmla   %q27 %q24 %q12 $0x01 -> %q27
-fmla   %d27 %d24 %d12 $0x01 -> %d27
-fmla   %q4 %q5 %q3 $0x02 -> %q4
-fmla   %q4 %q5 %q3 $0x03 -> %q4
-fmla   %d4 %d5 %d3 $0x02 -> %d4
-fmls   %q22 %q23 %q29 $0x01 -> %q22
-fmls   %d22 %d23 %d29 $0x01 -> %d22
-fmls   %q27 %q18 %q29 $0x02 -> %q27
-fmls   %q27 %q18 %q29 $0x03 -> %q27
-fmls   %d27 %d18 %d29 $0x02 -> %d27
+fmla   %q27 %q26 %q24 $0x01 -> %q27
+fmla   %d27 %d26 %d24 $0x01 -> %d27
+fmla   %q12 %q4 %q27 $0x02 -> %q12
+fmla   %q12 %q4 %q27 $0x03 -> %q12
+fmla   %d12 %d4 %d27 $0x02 -> %d12
+fmls   %q5 %q3 %q22 $0x01 -> %q5
+fmls   %d5 %d3 %d22 $0x01 -> %d5
+fmls   %q16 %q23 %q29 $0x02 -> %q16
+fmls   %q16 %q23 %q29 $0x03 -> %q16
+fmls   %d16 %d23 %d29 $0x02 -> %d16
 fmov   %d31 -> %d18
 fmov   %s31 -> %s18
 fmov   %h31 -> %h18


### PR DESCRIPTION
Some instructions, like FMLA/FMLS also read the destination register.
I think in the IR, we should have them as source registers too.

I kept the INSTR_CREATE_ macros to not have a extra source operand, as
this is closer to the AArch64 assembly syntax.

Issue: #2626