### PR TITLE
i#2626 AArch64 encoder: Add support for indexed vector instrs.

### DIFF
--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -941,8 +941,8 @@ encode_opnd_dq5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 }
 
 /*
- * dq16: D/Q register at bit position 16 with 4 bits only, for the FP16
- *       by-element encoding; bit 30 selects Q reg */
+ * dq16_fsz16: D/Q register at bit position 16 with 4 bits only, for the FP16
+ *             by-element encoding; bit 30 selects Q reg */
 
 static inline bool
 decode_opnd_dq16_fsz16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)

--- a/core/arch/aarch64/codec.c
+++ b/core/arch/aarch64/codec.c
@@ -940,9 +940,9 @@ encode_opnd_dq5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     return encode_opnd_dq_plus(0, 5, 30, opnd, enc_out);
 }
 
-/*
- * dq16_fsz16: D/Q register at bit position 16 with 4 bits only, for the FP16
- *             by-element encoding; bit 30 selects Q reg */
+/* dq16_fsz16: D/Q register at bit position 16 with 4 bits only, for the FP16
+ *             by-element encoding; bit 30 selects Q reg
+ */
 
 static inline bool
 decode_opnd_dq16_fsz16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)

--- a/core/arch/aarch64/codec.txt
+++ b/core/arch/aarch64/codec.txt
@@ -124,6 +124,11 @@
 ??--------xxxxxxxxxxxxxxxxx-----  mem12      # gets size from 31:30
 ----------xxxxxxxxxxxxxxxxx-----  mem12q     # size is 16 bytes
 ----------xxxxxxxxxxxxxxxxx-----  prf12      # size is 0 bytes (prefetch variant of mem12)
+----------xx--------x-----------  vindex_H   # Index for vector with half elements (0-7)
+---------xx---------x-----------  vindex_S   # Index for vector with single elements (0-3).
+                                             # Also sets bit 22 (sz) to 0, to indicate single width.
+---------xx---------x-----------  vindex_D   # Index for vector with double elements (0-1).
+                                             # Also sets bit 22 (sz) to 1, to indicate double width.
 ---------x----------------------  imm12sh    # shift for ADD/SUB (immediate); '0x'
 ---------x----------------------  fsz        # element width of FP vector reg for single
                                              # and double encoding
@@ -134,6 +139,7 @@
 -x------------------------------  index3     # index of D subreg in Q: 0-1
 -x-------------------------xxxxx  dq0        # Q register if bit 30 is set, else D
 -x--------------------xxxxx-----  dq5        # Q register if bit 30 is set, else D
+-x----------xxxx----------------  dq16_fsz16 # Q register (0-15) if bit 30 is set, else D
 -x---------xxxxx----------------  dq16       # Q register if bit 30 is set, else D
 -x-------------------------xxxxx  dq0p1      # ... add 1
 -x-------------------------xxxxx  dq0p2      # ... add 2
@@ -1068,6 +1074,11 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 # FMLA (vector)
 0x001110010xxxxx000011xxxxxxxxxx     fmla dq0 : dq0 dq5 dq16 fsz16 # Armv8.2
 0x0011100x1xxxxx110011xxxxxxxxxx     fmla dq0 : dq0 dq5 dq16 fsz
+
+# FMLA (vector by element)
+0x00111100xxxxxx0001x0xxxxxxxxxx     fmla dq0 : dq0 dq5 dq16_fsz16 vindex_H fsz16
+0x00111110xxxxxx0001x0xxxxxxxxxx     fmla dq0 : dq0 dq5 dq16 vindex_S fsz
+0x001111110xxxxx0001x0xxxxxxxxxx     fmla dq0 : dq0 dq5 dq16 vindex_D fsz
 
 # FMLS (vector)
 0x001110110xxxxx000011xxxxxxxxxx     fmls dq0 : dq0 dq5 dq16 fsz16 # Armv8.2

--- a/core/arch/aarch64/codec.txt
+++ b/core/arch/aarch64/codec.txt
@@ -125,13 +125,11 @@
 ----------xxxxxxxxxxxxxxxxx-----  mem12q     # size is 16 bytes
 ----------xxxxxxxxxxxxxxxxx-----  prf12      # size is 0 bytes (prefetch variant of mem12)
 ----------xx--------x-----------  vindex_H   # Index for vector with half elements (0-7)
----------xx---------x-----------  vindex_S   # Index for vector with single elements (0-3).
-                                             # Also sets bit 22 (sz) to 0, to indicate single width.
----------xx---------x-----------  vindex_D   # Index for vector with double elements (0-1).
-                                             # Also sets bit 22 (sz) to 1, to indicate double width.
 ---------x----------------------  imm12sh    # shift for ADD/SUB (immediate); '0x'
 ---------x----------------------  fsz        # element width of FP vector reg for single
                                              # and double encoding
+---------?x---------x-----------  vindex_SD  # Index for vector with single or double
+                                             # elements, depending on bit 22 (sz)
 ?--------xx---------------------  imm16sh    # shift for MOVK/... (immediate); checks 31
 --------xx----------------------  shift3     # shift type for add/sub (shifted register)
 --------xx----------------------  shift4     # shift type for logical (shifted register)
@@ -1077,8 +1075,7 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 
 # FMLA (vector by element)
 0x00111100xxxxxx0001x0xxxxxxxxxx     fmla dq0 : dq0 dq5 dq16_fsz16 vindex_H fsz16
-0x00111110xxxxxx0001x0xxxxxxxxxx     fmla dq0 : dq0 dq5 dq16 vindex_S fsz
-0x001111110xxxxx0001x0xxxxxxxxxx     fmla dq0 : dq0 dq5 dq16 vindex_D fsz
+0x0011111xxxxxxx0001x0xxxxxxxxxx     fmla dq0 : dq0 dq5 dq16 vindex_SD fsz
 
 # FMLS (vector)
 0x001110110xxxxx000011xxxxxxxxxx     fmls dq0 : dq0 dq5 dq16 fsz16 # Armv8.2

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -1785,17 +1785,14 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 # FMLA (by element)
 4fcc116a : fmla  v10.2d, v11.2d, v12.d[0] : fmla   %q10 %q11 %q12 $0x00 $0x03 -> %q10
 4fcc196a : fmla  v10.2d, v11.2d, v12.d[1] : fmla   %q10 %q11 %q12 $0x01 $0x03 -> %q10
-
 4f8c116a : fmla  v10.4s, v11.4s, v12.s[0] : fmla   %q10 %q11 %q12 $0x00 $0x02 -> %q10
 4fac116a : fmla  v10.4s, v11.4s, v12.s[1] : fmla   %q10 %q11 %q12 $0x01 $0x02 -> %q10
 4f8c196a : fmla  v10.4s, v11.4s, v12.s[2] : fmla   %q10 %q11 %q12 $0x02 $0x02 -> %q10
 4fac196a : fmla  v10.4s, v11.4s, v12.s[3] : fmla   %q10 %q11 %q12 $0x03 $0x02 -> %q10
-
 0f0c116a : fmla  v10.4h, v11.4h, v12.h[0] : fmla   %d10 %d11 %d12 $0x00 $0x01 -> %d10
 0f1c116a : fmla  v10.4h, v11.4h, v12.h[1] : fmla   %d10 %d11 %d12 $0x01 $0x01 -> %d10
 0f2c116a : fmla  v10.4h, v11.4h, v12.h[2] : fmla   %d10 %d11 %d12 $0x02 $0x01 -> %d10
 0f3c116a : fmla  v10.4h, v11.4h, v12.h[3] : fmla   %d10 %d11 %d12 $0x03 $0x01 -> %d10
-
 4f0c116a : fmla    v10.8h, v11.8h, v12.h[0] : fmla   %q10 %q11 %q12 $0x00 $0x01 -> %q10
 4f1c116a : fmla    v10.8h, v11.8h, v12.h[1] : fmla   %q10 %q11 %q12 $0x01 $0x01 -> %q10
 4f2c116a : fmla    v10.8h, v11.8h, v12.h[2] : fmla   %q10 %q11 %q12 $0x02 $0x01 -> %q10

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -1782,6 +1782,29 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 4e7bcc8c : fmla v12.2d, v4.2d, v27.2d : fmla   %q12 %q4 %q27 $0x03 -> %q12
 0e3bcc8c : fmla v12.2s, v4.2s, v27.2s : fmla   %d12 %d4 %d27 $0x02 -> %d12
 
+# FMLA (by element)
+4fcc116a : fmla  v10.2d, v11.2d, v12.d[0] : fmla   %q10 %q11 %q12 $0x00 $0x03 -> %q10
+4fcc196a : fmla  v10.2d, v11.2d, v12.d[1] : fmla   %q10 %q11 %q12 $0x01 $0x03 -> %q10
+
+4f8c116a : fmla  v10.4s, v11.4s, v12.s[0] : fmla   %q10 %q11 %q12 $0x00 $0x02 -> %q10
+4fac116a : fmla  v10.4s, v11.4s, v12.s[1] : fmla   %q10 %q11 %q12 $0x01 $0x02 -> %q10
+4f8c196a : fmla  v10.4s, v11.4s, v12.s[2] : fmla   %q10 %q11 %q12 $0x02 $0x02 -> %q10
+4fac196a : fmla  v10.4s, v11.4s, v12.s[3] : fmla   %q10 %q11 %q12 $0x03 $0x02 -> %q10
+
+0f0c116a : fmla  v10.4h, v11.4h, v12.h[0] : fmla   %d10 %d11 %d12 $0x00 $0x01 -> %d10
+0f1c116a : fmla  v10.4h, v11.4h, v12.h[1] : fmla   %d10 %d11 %d12 $0x01 $0x01 -> %d10
+0f2c116a : fmla  v10.4h, v11.4h, v12.h[2] : fmla   %d10 %d11 %d12 $0x02 $0x01 -> %d10
+0f3c116a : fmla  v10.4h, v11.4h, v12.h[3] : fmla   %d10 %d11 %d12 $0x03 $0x01 -> %d10
+
+4f0c116a : fmla    v10.8h, v11.8h, v12.h[0] : fmla   %q10 %q11 %q12 $0x00 $0x01 -> %q10
+4f1c116a : fmla    v10.8h, v11.8h, v12.h[1] : fmla   %q10 %q11 %q12 $0x01 $0x01 -> %q10
+4f2c116a : fmla    v10.8h, v11.8h, v12.h[2] : fmla   %q10 %q11 %q12 $0x02 $0x01 -> %q10
+4f3c116a : fmla    v10.8h, v11.8h, v12.h[3] : fmla   %q10 %q11 %q12 $0x03 $0x01 -> %q10
+4f0c196a : fmla    v10.8h, v11.8h, v12.h[4] : fmla   %q10 %q11 %q12 $0x04 $0x01 -> %q10
+4f1c196a : fmla    v10.8h, v11.8h, v12.h[5] : fmla   %q10 %q11 %q12 $0x05 $0x01 -> %q10
+4f2c196a : fmla    v10.8h, v11.8h, v12.h[6] : fmla   %q10 %q11 %q12 $0x06 $0x01 -> %q10
+4f3c196a : fmla    v10.8h, v11.8h, v12.h[7] : fmla   %q10 %q11 %q12 $0x07 $0x01 -> %q10
+
 # FMLS (vector)
 4ed60c65 : fmls v5.8h, v3.8h, v22.8h : fmls   %q5 %q3 %q22 $0x01 -> %q5
 0ed60c65 : fmls v5.4h, v3.4h, v22.4h : fmls   %d5 %d3 %d22 $0x01 -> %d5


### PR DESCRIPTION
This patch adds the operands required to add indexed vector
instructions to codec.txt and adds the vector-by-element encoding of
FMLA as an example. Additional tests and macros should be added once
the script in the project-aarch64-generate-patterns branch gets updated.

Issue #2626