### PR TITLE
i#2990, i#2950: fix Mac build errors

### DIFF
--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -1246,16 +1246,13 @@ dr_unregister_post_syscall_event(void (*func)(void *drcontext, int sysnum));
 #ifdef UNIX
 /* DR_API EXPORT END */
 
-/* FIXME: for PR 304708 I originally included siginfo_t in
+/* XXX: for PR 304708 I originally included siginfo_t in
  * dr_siginfo_t.  But can we really trust siginfo_t to be identical on
  * all supported platforms?  Esp. once we start supporting VMKUW,
  * MacOS, etc.  I'm removing it for now.  None of my samples need it,
  * and in my experience its fields are unreliable in any case.
  * PR 371370 covers re-adding it if users request it.
- * Xref PR 371339: we will need to not include it through signal.h but
- * instead something like this:
- *   #  define __need_siginfo_t
- *   #  include <bits/siginfo.h>
+ * If we re-add it, we should use our kernel_siginfo_t version.
  */
 /* DR_API EXPORT BEGIN */
 /**

--- a/core/unix/include/siginfo.h
+++ b/core/unix/include/siginfo.h
@@ -28,7 +28,12 @@ typedef siginfo_t kernel_siginfo_t;
  * all types here have kernel_ (or KERNEL_ for enums) prefixed, and all #defines are
  * first #undef-ed.
  */
-# include <bits/wordsize.h>
+# ifdef ANDROID
+#  define __WORDSIZE 32
+typedef clock_t __clock_t;
+# else
+#  include <bits/wordsize.h>
+# endif
 
 /* Type for data associated with a signal.  */
 typedef union kernel_sigval {
@@ -62,6 +67,7 @@ typedef __clock_t __kernel_sigchld_clock_t;
 
 # undef si_pid
 # undef si_uid
+# undef si_tid
 # undef si_timerid
 # undef si_overrun
 # undef si_status

--- a/core/unix/include/siginfo.h
+++ b/core/unix/include/siginfo.h
@@ -1,0 +1,216 @@
+/****************************************************************************
+ ****************************************************************************
+ ***
+ ***   This header was generated from glibc headers to make
+ ***   information necessary for userspace to call into the Linux
+ ***   kernel available to DynamoRIO.  It contains only constants,
+ ***   structures, and macros generated from the original header, and
+ ***   thus, contains no copyrightable information.
+ ***
+ ****************************************************************************
+ ****************************************************************************/
+
+#ifndef _SIGINFO_H_
+#define _SIGINFO_H_
+
+/* We make sure to pull in the system #defines first so we can
+ * undef them here.
+ */
+#include <signal.h>
+
+#ifdef MACOS
+/* For now we just use the system header. */
+typedef siginfo_t kernel_siginfo_t;
+
+#else
+
+/* To avoid conflicts with the system header, as we're still including <signal.h>,
+ * all types here have kernel_ (or KERNEL_ for enums) prefixed, and all #defines are
+ * first #undef-ed.
+ */
+# include <bits/wordsize.h>
+
+/* Type for data associated with a signal.  */
+typedef union kernel_sigval {
+    int sival_int;
+    void *sival_ptr;
+} kernel_sigval_t;
+
+# undef __SI_MAX_SIZE
+# undef __SI_PAD_SIZE
+
+# define __SI_MAX_SIZE     128
+# if __WORDSIZE == 64
+#  define __SI_PAD_SIZE     ((__SI_MAX_SIZE / sizeof (int)) - 4)
+# else
+#  define __SI_PAD_SIZE     ((__SI_MAX_SIZE / sizeof (int)) - 3)
+# endif
+
+# undef __SI_ALIGNMENT
+
+# if defined __x86_64__ && __WORDSIZE == 32
+/* si_utime and si_stime must be 4 byte aligned for x32 to match the
+   kernel.  We align siginfo_t to 8 bytes so that si_utime and si_stime
+   are actually aligned to 8 bytes since their offsets are multiple of
+   8 bytes.  */
+typedef __clock_t __attribute__ ((__aligned__ (4))) __kernel_sigchld_clock_t;
+#  define __SI_ALIGNMENT __attribute__ ((__aligned__ (8)))
+# else
+typedef __clock_t __kernel_sigchld_clock_t;
+#  define __SI_ALIGNMENT
+# endif
+
+# undef si_pid
+# undef si_uid
+# undef si_timerid
+# undef si_overrun
+# undef si_status
+# undef si_utime
+# undef si_stime
+# undef si_value
+# undef si_int
+# undef si_ptr
+# undef si_addr
+# undef si_addr_lsb
+# undef si_lower
+# undef si_upper
+# undef si_band
+# undef si_fd
+# undef si_call_addr
+# undef si_syscall
+# undef si_arch
+
+/* New fields are appended, and there's padding to cover them, so DR code can
+ * blindly write to the latest fields and still work on older kernels.
+ */
+typedef struct {
+    int si_signo;               /* Signal number.  */
+    int si_errno;               /* If non-zero, an errno value associated with
+                                   this signal, as defined in <errno.h>.  */
+    int si_code;                /* Signal code.  */
+
+    union {
+        int _pad[__SI_PAD_SIZE];
+
+        /* kill().  */
+        struct {
+            __pid_t si_pid;     /* Sending process ID.  */
+            __uid_t si_uid;     /* Real user ID of sending process.  */
+        } _kill;
+
+        /* POSIX.1b timers.  */
+        struct {
+            int si_tid;         /* Timer ID.  */
+            int si_overrun;     /* Overrun count.  */
+            kernel_sigval_t si_sigval;  /* Signal value.  */
+        } _timer;
+
+        /* POSIX.1b signals.  */
+        struct {
+            __pid_t si_pid;     /* Sending process ID.  */
+            __uid_t si_uid;     /* Real user ID of sending process.  */
+            kernel_sigval_t si_sigval;  /* Signal value.  */
+        } _rt;
+
+        /* SIGCHLD.  */
+        struct {
+            __pid_t si_pid;     /* Which child.  */
+            __uid_t si_uid;     /* Real user ID of sending process.  */
+            int si_status;      /* Exit value or signal.  */
+            __kernel_sigchld_clock_t si_utime;
+            __kernel_sigchld_clock_t si_stime;
+        } _sigchld;
+
+        /* SIGILL, SIGFPE, SIGSEGV, SIGBUS.  */
+        struct {
+            void *si_addr;      /* Faulting insn/memory ref.  */
+            short int si_addr_lsb;      /* Valid LSB of the reported address.  */
+            struct {
+                void *_lower;
+                void *_upper;
+            } si_addr_bnd;
+        } _sigfault;
+
+        /* SIGPOLL.  */
+        struct {
+            long int si_band;   /* Band event for SIGPOLL.  */
+            int si_fd;
+        } _sigpoll;
+
+        /* SIGSYS.  */
+        struct {
+            void *_call_addr;   /* Calling user insn.  */
+            int _syscall;       /* Triggering system call number.  */
+            unsigned int _arch; /* AUDIT_ARCH_* of syscall.  */
+        } _sigsys;
+    } _sifields;
+} kernel_siginfo_t __SI_ALIGNMENT;
+
+/* X/Open requires some more fields with fixed names.  */
+# define si_pid         _sifields._kill.si_pid
+# define si_uid         _sifields._kill.si_uid
+# define si_timerid     _sifields._timer.si_tid
+# define si_overrun     _sifields._timer.si_overrun
+# define si_status      _sifields._sigchld.si_status
+# define si_utime       _sifields._sigchld.si_utime
+# define si_stime       _sifields._sigchld.si_stime
+# define si_value       _sifields._rt.si_sigval
+# define si_int         _sifields._rt.si_sigval.sival_int
+# define si_ptr         _sifields._rt.si_sigval.sival_ptr
+# define si_addr        _sifields._sigfault.si_addr
+# define si_addr_lsb    _sifields._sigfault.si_addr_lsb
+# define si_lower       _sifields._sigfault.si_addr_bnd._lower
+# define si_upper       _sifields._sigfault.si_addr_bnd._upper
+# define si_band        _sifields._sigpoll.si_band
+# define si_fd          _sifields._sigpoll.si_fd
+# define si_call_addr   _sifields._sigsys._call_addr
+# define si_syscall     _sifields._sigsys._syscall
+# define si_arch        _sifields._sigsys._arch
+
+/* Values for `si_code'.  Positive values are reserved for kernel-generated
+   signals.  */
+enum
+{
+  KERNEL_SI_ASYNCNL = -60,             /* Sent by asynch name lookup completion.  */
+# undef SI_ASYNCNL
+# define SI_ASYNCNL     KERNEL_SI_ASYNCNL
+  KERNEL_SI_TKILL = -6,                /* Sent by tkill.  */
+# undef SI_TKILL
+# define SI_TKILL       KERNEL_SI_TKILL
+  KERNEL_SI_SIGIO,                     /* Sent by queued SIGIO. */
+# undef SI_SIGIO
+# define SI_SIGIO       KERNEL_SI_SIGIO
+  KERNEL_SI_ASYNCIO,                   /* Sent by AIO completion.  */
+# undef SI_ASYNCIO
+# define SI_ASYNCIO     KERNEL_SI_ASYNCIO
+  KERNEL_SI_MESGQ,                     /* Sent by real time mesq state change.  */
+# undef SI_MESGQ
+# define SI_MESGQ       KERNEL_SI_MESGQ
+  KERNEL_SI_TIMER,                     /* Sent by timer expiration.  */
+# undef SI_TIMER
+# define SI_TIMER       KERNEL_SI_TIMER
+  KERNEL_SI_QUEUE,                     /* Sent by sigqueue.  */
+# undef SI_QUEUE
+# define SI_QUEUE       KERNEL_SI_QUEUE
+  KERNEL_SI_USER,                      /* Sent by kill, sigsend.  */
+# undef SI_USER
+# define SI_USER        KERNEL_SI_USER
+  KERNEL_SI_KERNEL = 0x80              /* Send by kernel.  */
+# undef SI_KERNEL
+# define SI_KERNEL       KERNEL_SI_KERNEL
+};
+
+/* `si_code' values for SIGSEGV signal.  */
+enum
+{
+  KERNEL_SEGV_MAPERR = 1,              /* Address not mapped to object.  */
+# undef SEGV_MAPERR
+# define SEGV_MAPERR   KERNEL_SEGV_MAPERR
+  KERNEL_SEGV_ACCERR                   /* Invalid permissions for mapped object.  */
+# undef SEGV_ACCERR
+# define SEGV_ACCERR   KERNEL_SEGV_ACCERR
+};
+
+#endif /* !MACOS */
+
+#endif /* _SIGINFO_H_ */

--- a/core/unix/nudgesig.c
+++ b/core/unix/nudgesig.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,6 +40,7 @@
 #include <string.h>
 #include <unistd.h>
 #include "include/syscall.h"
+#include "include/siginfo.h"
 
 #include "globals_shared.h"
 #ifndef NOT_DYNAMORIO_CORE
@@ -48,7 +49,7 @@
 
 /* shared with tools/nudgeunix.c */
 bool
-create_nudge_signal_payload(siginfo_t *info OUT, uint action_mask,
+create_nudge_signal_payload(kernel_siginfo_t *info OUT, uint action_mask,
                             client_id_t client_id, uint64 client_arg)
 {
     nudge_arg_t *arg;
@@ -77,7 +78,7 @@ bool
 send_nudge_signal(process_id_t pid, uint action_mask,
                   client_id_t client_id, uint64 client_arg)
 {
-    siginfo_t info;
+    kernel_siginfo_t info;
     int res;
     if (!create_nudge_signal_payload(&info, action_mask, client_id, client_arg))
         return false;

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -40,6 +40,7 @@
 #define _OS_PRIVATE_H_ 1
 
 #include <signal.h> /* for stack_t */
+#include "include/siginfo.h"
 #include "module.h" /* for os_module_data_t */
 #include "ksynch.h" /* for KSYNCH_TYPE */
 #include "instr.h" /* for reg_id_t */

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -381,7 +381,7 @@ void init_android_version(void);
 
 /* in nudgesig.c */
 bool
-create_nudge_signal_payload(siginfo_t *info OUT, uint action_mask,
+create_nudge_signal_payload(kernel_siginfo_t *info OUT, uint action_mask,
                             client_id_t client_id, uint64 client_arg);
 
 #ifdef X86

--- a/core/unix/signal_linux.c
+++ b/core/unix/signal_linux.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -471,17 +471,12 @@ notify_signalfd(dcontext_t *dcontext, thread_sig_info_t *info, int sig,
         towrite.ssi_uid = frame->info.si_uid;
         towrite.ssi_fd = frame->info.si_fd;
         towrite.ssi_band = frame->info.si_band;
-        /* XXX: check older glibc headers */
-#ifdef ANDROID
-        towrite.ssi_tid = frame->info._sifields._timer._tid;
-#else
         towrite.ssi_tid = frame->info.si_timerid;
-#endif
         towrite.ssi_overrun = frame->info.si_overrun;
         towrite.ssi_status = frame->info.si_status;
         towrite.ssi_utime = frame->info.si_utime;
         towrite.ssi_stime = frame->info.si_stime;
-#ifdef __ARCH_SI_TRAPNO
+#ifdef __ARCH_SI_TRAPNO /* XXX: should update include/siginfo.h */
         towrite.ssi_trapno = frame->info.si_trapno;
 #endif
         towrite.ssi_addr = (ptr_int_t) frame->info.si_addr;

--- a/core/unix/signal_linux_arm.c
+++ b/core/unix/signal_linux_arm.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -140,7 +140,7 @@ signal_frame_extra_size(bool include_alignment)
 }
 
 static void
-vfp_query_signal_handler(int sig, siginfo_t *siginfo, kernel_ucontext_t *ucxt)
+vfp_query_signal_handler(int sig, kernel_siginfo_t *siginfo, kernel_ucontext_t *ucxt)
 {
     uint offset = sizeof(kernel_iwmmxt_sigframe_t);
     char *coproc = (char *)&ucxt->coproc;

--- a/core/unix/signal_linux_x86.c
+++ b/core/unix/signal_linux_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -521,7 +521,7 @@ signal_frame_extra_size(bool include_alignment)
  * state may not match later state.  Currently it seems to be all-or-nothing.
  */
 static void
-xstate_query_signal_handler(int sig, siginfo_t *siginfo, kernel_ucontext_t *ucxt)
+xstate_query_signal_handler(int sig, kernel_siginfo_t *siginfo, kernel_ucontext_t *ucxt)
 {
     ASSERT_CURIOSITY(sig == XSTATE_QUERY_SIG);
     if (sig == XSTATE_QUERY_SIG) {

--- a/suite/tests/common/decode-bad.c
+++ b/suite/tests/common/decode-bad.c
@@ -68,22 +68,17 @@ static int count = 0;
 static bool invalid_lock;
 
 #ifdef UNIX
-# ifdef X86
-#  ifdef X64
-#   define REG_XIP REG_RIP
-#  else
-#   define REG_XIP REG_EIP
-#  endif
-# else
+# ifndef X86
 #  error NYI /* FIXME i#1551, i#1569: port asm to ARM and AArch64 */
 # endif
 static void
 signal_handler(int sig, siginfo_t *info, ucontext_t *ucxt)
 {
     if (sig == SIGILL) {
-        if ((greg_t)info->si_addr != ucxt->uc_mcontext.gregs[REG_XIP]) {
+        sigcontext_t *sc = SIGCXT_FROM_UCXT(ucxt);
+        if (info->si_addr != (void*)sc->SC_XIP) {
             print("ERROR: si_addr=%p does not match rip=%p\n", info->si_addr,
-                  ucxt->uc_mcontext.gregs[REG_XIP]);
+                  sc->SC_XIP);
         }
         count++;
         if (invalid_lock) {


### PR DESCRIPTION
Fixes Mac build errors from 2 recent commits:

1) i#2990 7040ca7f added references to si_addr_lsb which are not on older
   Linux kernels or Mac.  I put in our own core/unix/include/siginfo.h so
   we can have the latest definition.  There is padding in the struct, so
   on Linux we can blindly write to new fields and not worry about the
   underlying kernel being old.

2) i#2950 e1b6a66a added struct rlimit64 references which we typedef here to
   struct rlimit on Mac.

Issue: #2990, #2950