### PR TITLE
i#2779: fix thread creation signal race

### DIFF
--- a/core/globals.h
+++ b/core/globals.h
@@ -558,7 +558,7 @@ void get_list_of_threads_ex(thread_record_t ***list, int *num, bool include_exec
 void mark_thread_execve(thread_record_t *tr, bool execve);
 #endif
 bool is_thread_initialized(void);
-int dynamo_thread_init(byte *dstack_in, priv_mcontext_t *mc
+int dynamo_thread_init(byte *dstack_in, priv_mcontext_t *mc, void *os_data
                        _IF_CLIENT_INTERFACE(bool client_thread));
 int dynamo_thread_exit(void);
 void dynamo_thread_stack_free_and_exit(byte *stack);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -2186,8 +2186,9 @@ os_tls_cfree(uint offset, uint num_slots)
 }
 #endif
 
+/* os_data is a clone_record_t for signal_thread_inherit */
 void
-os_thread_init(dcontext_t *dcontext)
+os_thread_init(dcontext_t *dcontext, void *os_data)
 {
     os_local_state_t *os_tls = get_os_tls();
     os_thread_data_t *ostd = (os_thread_data_t *)
@@ -2213,7 +2214,7 @@ os_thread_init(dcontext_t *dcontext)
 
     ASSIGN_INIT_LOCK_FREE(ostd->suspend_lock, suspend_lock);
 
-    signal_thread_init(dcontext);
+    signal_thread_init(dcontext, os_data);
 
     /* i#107, initialize thread area information,
      * the value was first get in os_tls_init and stored in os_tls
@@ -2251,6 +2252,17 @@ os_thread_init(dcontext_t *dcontext)
     dcontext->thread_port = dynamorio_mach_syscall(MACH_thread_self_trap, 0);
     LOG(THREAD, LOG_ALL, 1, "Mach thread port: %d\n", dcontext->thread_port);
 #endif
+}
+
+/* os_data is a clone_record_t for signal_thread_inherit */
+void
+os_thread_init_finalize(dcontext_t *dcontext, void *os_data)
+{
+    /* We do not want to record pending signals until at least synch_thread_init()
+     * is finished so we delay until here: but we need this inside the
+     * thread_initexit_lock (i#2779).
+     */
+    signal_thread_inherit(dcontext, os_data);
 }
 
 void
@@ -3454,7 +3466,7 @@ os_thread_sleep(uint64 milliseconds)
 }
 
 bool
-os_thread_suspend(thread_record_t *tr, int timeout_ms)
+os_thread_suspend(thread_record_t *tr)
 {
     os_thread_data_t *ostd = (os_thread_data_t *) tr->dcontext->os_field;
     ASSERT(ostd != NULL);
@@ -3488,16 +3500,17 @@ os_thread_suspend(thread_record_t *tr, int timeout_ms)
      */
     mutex_unlock(&ostd->suspend_lock);
     while (ksynch_get_value(&ostd->suspended) == 0) {
-        /* For Linux, waits only if the suspended flag is not set as 1. Other
-         * than a timeout value, the return value doesn't matter because the
-         * flag will be re-checked.
+        /* For Linux, waits only if the suspended flag is not set as 1. Return value
+         * doesn't matter because the flag will be re-checked.
          */
-        if (ksynch_wait(&ostd->suspended, 0, timeout_ms) == -ETIMEDOUT) {
-            mutex_lock(&ostd->suspend_lock);
-            ASSERT(ostd->suspend_count > 0);
-            ostd->suspend_count--;
-            mutex_unlock(&ostd->suspend_lock);
-            return false;
+        /* We time out and assert in debug build to provide better diagnostics than a
+         * silent hang.  We can't safely return false b/c the synch model here
+         * assumes there will not be a retry until the target reaches the suspend
+         * point.  Xref i#2779.
+         */
+#define SUSPEND_DEBUG_TIMEOUT_MS 5000
+        if (ksynch_wait(&ostd->suspended, 0, SUSPEND_DEBUG_TIMEOUT_MS) == -ETIMEDOUT) {
+            ASSERT_CURIOSITY(false && "failed to suspend thread in 5s");
         }
         if (ksynch_get_value(&ostd->suspended) == 0) {
             /* If it still has to wait, give up the cpu. */
@@ -3689,14 +3702,14 @@ client_thread_run(void)
     GET_STACK_PTR(xsp);
     void *crec = get_clone_record((reg_t)xsp);
     IF_DEBUG(int rc = )
-        dynamo_thread_init(get_clone_record_dstack(crec), NULL, true);
+        dynamo_thread_init(get_clone_record_dstack(crec), NULL, crec, true);
     ASSERT(rc != -1); /* this better be a new thread */
     dcontext = get_thread_private_dcontext();
     ASSERT(dcontext != NULL);
     LOG(THREAD, LOG_ALL, 1, "\n***** CLIENT THREAD %d *****\n\n",
         get_thread_id());
     /* We stored the func and args in particular clone record fields */
-    func = (void (*)(void *param)) signal_thread_inherit(dcontext, crec);
+    func = (void (*)(void *param)) dcontext->next_tag;
     /* Reset any inherited mask (i#2337). */
     signal_swap_mask(dcontext, false/*to DR*/);
 
@@ -10097,12 +10110,8 @@ os_thread_take_over(priv_mcontext_t *mc, kernel_sigset_t *sigset)
             os_thread_signal_taken_over();
             return false;
         }
-        IF_DEBUG(int r =)
-            dynamo_thread_init(NULL, mc _IF_CLIENT_INTERFACE(false));
-        ASSERT(r == SUCCESS);
-        dcontext = get_thread_private_dcontext();
+        dcontext = init_thread_with_shared_siginfo(mc, takeover_dcontext);
         ASSERT(dcontext != NULL);
-        share_siginfo_after_take_over(dcontext, takeover_dcontext);
     } else {
         /* Re-takeover a thread that we let go native */
         dcontext = get_thread_private_dcontext();
@@ -10153,12 +10162,13 @@ os_thread_take_over_suspended_native(dcontext_t *dcontext)
 /* Called for os-specific takeover of a secondary thread from the one
  * that called dr_app_setup().
  */
-void
-os_thread_take_over_secondary(dcontext_t *dcontext)
+dcontext_t *
+os_thread_take_over_secondary(priv_mcontext_t *mc)
 {
     thread_record_t **list;
     int num_threads;
     int i;
+    dcontext_t *dcontext;
     /* We want to share with the thread that called dr_app_setup. */
     mutex_lock(&thread_initexit_lock);
     get_list_of_threads(&list, &num_threads);
@@ -10169,13 +10179,14 @@ os_thread_take_over_secondary(dcontext_t *dcontext)
             break;
     }
     ASSERT(i < num_threads);
-    ASSERT(list[i]->dcontext != dcontext);
+    ASSERT(list[i]->id != get_sys_thread_id());
     /* Assuming pthreads, prepare signal_field for sharing. */
     handle_clone(list[i]->dcontext, PTHREAD_CLONE_FLAGS);
-    share_siginfo_after_take_over(dcontext, list[i]->dcontext);
+    dcontext = init_thread_with_shared_siginfo(mc, list[i]->dcontext);
     mutex_unlock(&thread_initexit_lock);
     global_heap_free(list, num_threads*sizeof(thread_record_t*)
                      HEAPACCT(ACCT_THREAD_MGT));
+    return dcontext;
 }
 
 /***************************************************************************/

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -426,9 +426,6 @@ set_app_lib_tls_base_from_clone_record(dcontext_t *dcontext, void *record);
 void
 os_clone_post(dcontext_t *dcontext);
 
-app_pc
-signal_thread_inherit(dcontext_t *dcontext, void *clone_record);
-
 void
 signal_fork_init(dcontext_t *dcontext);
 

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -261,7 +261,7 @@ typedef kernel_sigaction_t prev_sigaction_t;
 
 void signal_init(void);
 void signal_exit(void);
-void signal_thread_init(dcontext_t *dcontext);
+void signal_thread_init(dcontext_t *dcontext, void *os_data);
 void signal_thread_exit(dcontext_t *dcontext, bool other_thread);
 bool is_thread_signal_info_initialized(dcontext_t *dcontext);
 void signal_swap_mask(dcontext_t *dcontext, bool to_app);
@@ -324,7 +324,10 @@ bool
 set_default_signal_action(int sig);
 
 void
-share_siginfo_after_take_over(dcontext_t *dcontext, dcontext_t *takeover_dc);
+signal_thread_inherit(dcontext_t *dcontext, void *os_data);
+
+dcontext_t *
+init_thread_with_shared_siginfo(priv_mcontext_t *mc, dcontext_t *takeover_dc);
 
 void
 signal_set_mask(dcontext_t *dcontext, kernel_sigset_t *sigset);

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -3138,7 +3138,7 @@ intercept_new_thread(CONTEXT *cxt)
      * the current (broken) context first.
      */
     context_to_mcontext_new_thread(&mc, cxt);
-    if (dynamo_thread_init(dstack, &mc _IF_CLIENT_INTERFACE(is_client)) != -1) {
+    if (dynamo_thread_init(dstack, &mc, NULL _IF_CLIENT_INTERFACE(is_client)) != -1) {
         app_pc thunk_xip = (app_pc)cxt->CXT_XIP;
         dcontext_t *dcontext = get_thread_private_dcontext();
         LOG_DECLARE(char sym_buf[MAXIMUM_SYMBOL_LENGTH];)
@@ -7364,7 +7364,7 @@ intercept_image_entry(app_state_at_intercept_t *state)
 
         /* we must create a new dcontext to be a 'known' thread */
         /* initialize thread now */
-        if (dynamo_thread_init(NULL, NULL _IF_CLIENT_INTERFACE(false)) != -1) {
+        if (dynamo_thread_init(NULL, NULL, NULL _IF_CLIENT_INTERFACE(false)) != -1) {
             LOG(THREAD_GET, LOG_ASYNCH, 1, "just initialized primary thread \n");
             /* keep in synch if we do anything else in intercept_new_thread() */
         } else {


### PR DESCRIPTION
Refactors signal_thread_inherit() to be called from a new routine
os_thread_init_finalize() which is invoked while holding
thread_initexit_lock yet after synch_thread_init().  This eliminates
races with suspend signals arriving in newly half-initialized threads,
which then drop the signals.  The refactoring rearranges several
thread initialization sequences to pass the clone record through
dynamo_thread_init().

This refactoring allows us to revert the os_thread_suspend timeout
from commit 972cddfa PR #2762 which added a timeout to
os_thread_suspend that turns out to not be safe on UNIX as the suspend
model assumes there is no retry.

Delays mask relaxing in handle_suspend_signal() to avoid timeout on
suspend due to an intervening signal.

Includes tweaks to an i#3020-related assert and i#2993-related alarm
lock retry which got in the way of testing the final solution here.

Tested by running thread creating apps that attach and detach many
times, similar to the static burst tests in our suite.

Issue: #3020, #2993
Fixes: #2779