### PR TITLE
i#2990 siginfo: update correct Mac siginfo

### DIFF
--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -324,7 +324,7 @@ bool
 set_default_signal_action(int sig);
 
 void
-signal_thread_inherit(dcontext_t *dcontext, void *os_data);
+signal_thread_inherit(dcontext_t *dcontext, void *clone_record);
 
 dcontext_t *
 init_thread_with_shared_siginfo(priv_mcontext_t *mc, dcontext_t *takeover_dc);

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2989,9 +2989,12 @@ fixup_siginfo(dcontext_t *dcontext, int sig, sigframe_rt_t *frame)
     if (sig != SIGILL && sig != SIGTRAP && sig != SIGFPE)
         return; /* nothing to do */
     sigcontext_t *sc = get_sigcontext_from_rt_frame(frame);
-    frame->info.si_addr = (void*) sc->SC_XIP;
+    kernel_siginfo_t *siginfo = SIGINFO_FROM_RT_FRAME(frame);
+    LOG(THREAD, LOG_ASYNCH, 3, "%s: updating si_addr from "PFX" to "PFX"\n",
+        __FUNCTION__, siginfo->si_addr, sc->SC_XIP);
+    siginfo->si_addr = (void*) sc->SC_XIP;
 #ifdef LINUX
-    frame->info.si_addr_lsb = sc->SC_XIP & 0x1;
+    siginfo->si_addr_lsb = sc->SC_XIP & 0x1;
 #endif
 }
 

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -188,6 +188,16 @@ typedef _STRUCT_UCONTEXT /* == __darwin_ucontext */ kernel_ucontext_t;
 #endif
 
 #ifdef LINUX
+# define SIGINFO_FROM_RT_FRAME(frame) (&(frame)->info)
+#elif defined(MACOS)
+/* Make sure to access through pinfo rather than info as on Mac the info
+ * location in our frame struct doesn't exactly match the kernel due to
+ * the mid padding.
+ */
+# define SIGINFO_FROM_RT_FRAME(frame) ((frame)->pinfo)
+#endif
+
+#ifdef LINUX
 /* we assume frames look like this, with rt_sigframe used if SA_SIGINFO is set
  * (these are from /usr/src/linux/arch/i386/kernel/signal.c for kernel 2.4.17)
  */


### PR DESCRIPTION
On Mac the kernel's mid-signal-frame padding means our fixed struct's
siginfo_t location is not reliable: we have to go through the pinfo
pointer instead.  This fixes a failure in the i#2990 test on Mac.

Issue: #2990