### PR TITLE
i#3023: add new-thread barrier during attach

### DIFF
--- a/core/globals.h
+++ b/core/globals.h
@@ -469,6 +469,7 @@ extern bool dynamo_all_threads_synched; /* are all other threads suspended safel
 extern bool doing_detach;
 
 extern event_t dr_app_started;
+extern event_t dr_attach_finished;
 
 #if defined(CLIENT_INTERFACE) || defined(STANDALONE_UNIT_TEST)
 extern bool standalone_library;  /* used as standalone library */


### PR DESCRIPTION
Adds a barrier to taken-over threads creating new threads until attach
is fully finished.  This avoids problems keeping up with an app that
is creating threads while we try to attach.

Fixes #3023