### PR TITLE
i#3026: do not translate new signals while suspended

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4123,7 +4123,9 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
          * back to dispatch and don't need to receive it now (which complicates
          * post-syscall handling)
          */
-    } else if (thread_synch_check_state(dcontext, THREAD_SYNCH_NO_LOCKS)) {
+    } else if (thread_synch_check_state(dcontext, THREAD_SYNCH_NO_LOCKS) &&
+               /* Avoid grabbing locks for xl8 while in a suspended state (i#3026). */
+               ksynch_get_value(&ostd->suspended) == 0) {
         /* The signal interrupted DR or the client but it's at a safe spot so
          * deliver it now.
          */


### PR DESCRIPTION
Avoids translating a new signal while suspended, as the resulting lock
acquisitions can lead to deadlock.  An incoming signal there should
always be delayable in any case: the only reason we were trying to
deliver immediately was due to a too-broad check put in for #2659.

It is not easy to create a test that reliably exercises these races:
our existing detach_spawn and other tests are the closest and this
should reduce their flakiness.

Fixes #3026