### PR TITLE
Fix some GCC 8 warnings.

### DIFF
--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -282,7 +282,7 @@ under -rstats_to_stderr.
               num_flushq_relink_syscall)
     STATS_DEF("Flush queue nonempty: relink special ibl xfer",
               num_flushq_relink_special_ibl_xfer)
-    STATS_DEF("Flush queue nonempty, yet empty", num_flushq_actually_empty)
+    STATS_DEF("Flush queue marked nonempty, yet empty", num_flushq_actually_empty)
     STATS_DEF("Fragments added to lazy deletion list", num_lazy_deletion_appends)
     STATS_DEF("Fragments freed from lazy deletion list at exit",
               num_lazy_deletion_frees_atexit)

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -280,7 +280,7 @@ under -rstats_to_stderr.
               num_shared_ibt_entries_examined)
     STATS_DEF("Flush queue marked nonempty: relink shared_sys",
               num_flushq_relink_syscall)
-    STATS_DEF("Flush queue marked nonempty: relink special ibl xfer",
+    STATS_DEF("Flush queue marked nonempty: relink ibl xfer",
               num_flushq_relink_special_ibl_xfer)
     STATS_DEF("Flush queue marked nonempty, yet empty", num_flushq_actually_empty)
     STATS_DEF("Fragments added to lazy deletion list", num_lazy_deletion_appends)

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -278,11 +278,11 @@ under -rstats_to_stderr.
               num_shared_ibt_entries_skipped)
     STATS_DEF("Shared deletion: shared IBT entries examined",
               num_shared_ibt_entries_examined)
-    STATS_DEF("Flush queue marked nonempty: relink shared_sys",
+    STATS_DEF("Flush queue nonempty: relink shared_sys",
               num_flushq_relink_syscall)
-    STATS_DEF("Flush queue marked nonempty: relink ibl xfer",
+    STATS_DEF("Flush queue nonempty: relink special ibl xfer",
               num_flushq_relink_special_ibl_xfer)
-    STATS_DEF("Flush queue marked nonempty, yet empty", num_flushq_actually_empty)
+    STATS_DEF("Flush queue nonempty, yet empty", num_flushq_actually_empty)
     STATS_DEF("Fragments added to lazy deletion list", num_lazy_deletion_appends)
     STATS_DEF("Fragments freed from lazy deletion list at exit",
               num_lazy_deletion_frees_atexit)

--- a/core/string.c
+++ b/core/string.c
@@ -376,7 +376,7 @@ unit_test_string(void)
     /* memmove */
     strncpy(buf, test_path, sizeof(buf));
     memmove(buf + 4, buf, strlen(buf) + 1);
-    strncpy(buf, "/foo", 4);
+    memcpy(buf, "/foo", 4);
     EXPECT(strcmp(buf, "/foo/path/to/file"), 0);
 
     print_file(STDERR, "done testing string\n");

--- a/core/utils.c
+++ b/core/utils.c
@@ -2718,7 +2718,7 @@ create_log_dir(int dir_type)
         if (dir_type == BASE_DIR) {
             int retval;
             ASSERT(sizeof(basedir) == sizeof(old_basedir));
-            strncpy(old_basedir, basedir, sizeof(basedir));
+            strncpy(old_basedir, basedir, sizeof(old_basedir));
             /* option takes precedence over config var */
             if (IS_STRING_OPTION_EMPTY(logdir)) {
                 retval = get_parameter(PARAM_STR(DYNAMORIO_VAR_LOGDIR), basedir,

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -1676,9 +1676,10 @@ _tmain(int argc, TCHAR *targv[])
     }
 # ifdef UNIX
     /* i#1676: detect whether under gdb */
-    _snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "/proc/%d/exe", getppid());
-    NULL_TERMINATE_BUFFER(buf);
-    i = readlink(buf, buf, BUFFER_SIZE_ELEMENTS(buf));
+    char path_buf[MAXIMUM_PATH];
+    _snprintf(path_buf, BUFFER_SIZE_ELEMENTS(path_buf), "/proc/%d/exe", getppid());
+    NULL_TERMINATE_BUFFER(path_buf);
+    i = readlink(path_buf, buf, BUFFER_SIZE_ELEMENTS(buf));
     if (i > 0) {
         if (i < BUFFER_SIZE_ELEMENTS(buf))
             buf[i] = '\0';


### PR DESCRIPTION
statsx.h: String too long for buffer (50 chars)
string.c: strncmp cannot place terminating 0.
utils.c: sizeof(dst) instead of sizeof(src).
drdeploy.c: readlink is defined with restrict pointers in standard.