### PR TITLE
i#3037: Add support for inclusive caches in DRCacheSim.

### DIFF
--- a/clients/drcachesim/simulator/cache.cpp
+++ b/clients/drcachesim/simulator/cache.cpp
@@ -37,13 +37,15 @@
 bool
 cache_t::init(int associativity_, int line_size_, int total_size,
               caching_device_t *parent_, caching_device_stats_t *stats_,
-              prefetcher_t *prefetcher_)
+              prefetcher_t *prefetcher_, bool inclusive_,
+              const std::vector<caching_device_t*>& children_)
 {
     // convert total_size to num_blocks to fit for caching_device_t::init
     int num_lines = total_size / line_size_;
 
     return caching_device_t::init(associativity_, line_size_, num_lines,
-                                  parent_, stats_, prefetcher_);
+                                  parent_, stats_, prefetcher_, inclusive_,
+                                  children_);
 }
 
 void

--- a/clients/drcachesim/simulator/cache.h
+++ b/clients/drcachesim/simulator/cache.h
@@ -47,7 +47,9 @@ class cache_t : public caching_device_t
     // to describe a CPU cache.
     virtual bool init(int associativity, int line_size, int total_size,
                       caching_device_t *parent, caching_device_stats_t *stats,
-                      prefetcher_t *prefetcher = nullptr);
+                      prefetcher_t *prefetcher = nullptr,
+                      bool inclusive = false,
+                      const std::vector<caching_device_t*>& children = {});
     virtual void request(const memref_t &memref);
     virtual void flush(const memref_t &memref);
  protected:

--- a/clients/drcachesim/simulator/cache_fifo.cpp
+++ b/clients/drcachesim/simulator/cache_fifo.cpp
@@ -41,13 +41,15 @@
 bool
 cache_fifo_t::init(int associativity_, int block_size_, int total_size,
                    caching_device_t *parent_, caching_device_stats_t *stats_,
-                   prefetcher_t *prefetcher_)
+                   prefetcher_t *prefetcher_, bool inclusive_,
+                   const std::vector<caching_device_t*>& children_)
 {
     // Works in the same way as the base class,
     // except that the counters are initialized in a different way.
 
     bool ret_val = cache_t::init(associativity_, block_size_, total_size,
-                                 parent_, stats_, prefetcher_);
+                                 parent_, stats_, prefetcher_, inclusive_,
+                                 children_);
     if (ret_val == false)
         return false;
 

--- a/clients/drcachesim/simulator/cache_fifo.h
+++ b/clients/drcachesim/simulator/cache_fifo.h
@@ -43,7 +43,8 @@ class cache_fifo_t : public cache_t
  public:
     virtual bool init(int associativity, int line_size, int total_size,
                       caching_device_t *parent, caching_device_stats_t *stats,
-                      prefetcher_t *prefetcher);
+                      prefetcher_t *prefetcher, bool inclusive = false,
+                      const std::vector<caching_device_t*>& children = {});
 
  protected:
     virtual void access_update(int line_idx, int way);

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -153,7 +153,7 @@ caching_device_t::request(const memref_t &memref_in)
             if (get_caching_device_block(block_idx, way).tag == TAG_INVALID) {
                 loaded_blocks++;
             } else if (inclusive && !children.empty()) {
-                for (auto& child : children) {
+                for (auto &child : children) {
                     child->invalidate(
                         get_caching_device_block(block_idx, way).tag);
                 }
@@ -217,13 +217,13 @@ caching_device_t::invalidate(const addr_t tag)
     int block_idx = compute_block_idx(tag);
 
     for (int way = 0; way < associativity; ++way) {
-        auto& cache_block = get_caching_device_block(block_idx, way);
+        auto &cache_block = get_caching_device_block(block_idx, way);
         if (cache_block.tag == tag) {
             cache_block.tag = TAG_INVALID;
             cache_block.counter = 0;
             stats->invalidate();
             if (inclusive && !children.empty()) {
-                for (auto& child : children) {
+                for (auto &child : children) {
                     child->invalidate(tag);
                 }
             }

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -222,7 +222,7 @@ caching_device_t::invalidate(const addr_t tag)
             cache_block.tag = TAG_INVALID;
             cache_block.counter = 0;
             stats->invalidate();
-            // Invalidate the block in the children's caches too.
+            // Invalidate the block in the children's caches.
             if (inclusive && !children.empty()) {
                 for (auto &child : children) {
                     child->invalidate(tag);

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -222,6 +222,7 @@ caching_device_t::invalidate(const addr_t tag)
             cache_block.tag = TAG_INVALID;
             cache_block.counter = 0;
             stats->invalidate();
+            // Invalidate the block in the children's caches too.
             if (inclusive && !children.empty()) {
                 for (auto &child : children) {
                     child->invalidate(tag);

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -92,7 +92,7 @@ class caching_device_t
     // Current valid blocks in the cache
     int loaded_blocks;
 
-    // Pointers to the caching devices parent and children devices.
+    // Pointers to the caching device's parent and children devices.
     caching_device_t *parent;
     std::vector<caching_device_t*> children;
 

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -36,6 +36,8 @@
 #ifndef _CACHING_DEVICE_H_
 #define _CACHING_DEVICE_H_ 1
 
+#include <vector>
+
 #include "caching_device_block.h"
 #include "caching_device_stats.h"
 #include "memref.h"
@@ -55,9 +57,12 @@ class caching_device_t
     caching_device_t();
     virtual bool init(int associativity, int block_size, int num_blocks,
                       caching_device_t *parent, caching_device_stats_t *stats,
-                      prefetcher_t *prefetcher = nullptr);
+                      prefetcher_t *prefetcher = nullptr,
+                      bool inclusive = false,
+                      const std::vector<caching_device_t*>& children = {});
     virtual ~caching_device_t();
     virtual void request(const memref_t &memref);
+    virtual void invalidate(const addr_t tag);
 
     caching_device_stats_t *get_stats() const { return stats; }
     void set_stats(caching_device_stats_t *stats_) { stats = stats_; }
@@ -86,7 +91,14 @@ class caching_device_t
     int num_blocks;
     // Current valid blocks in the cache
     int loaded_blocks;
+
+    // Pointers to the caching devices parent and children devices.
     caching_device_t *parent;
+    std::vector<caching_device_t*> children;
+
+    // If true, this device is inclusive of its children.
+    bool inclusive;
+
     // This should be an array of caching_device_block_t pointers, otherwise
     // an extended block class which has its own member variables cannot be indexed
     // correctly by base class pointers.

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -126,6 +126,8 @@ caching_device_stats_t::print_counts(std::string prefix)
         std::setw(20) << std::right << num_hits << std::endl;
     std::cerr << prefix << std::setw(18) << std::left << "Misses:" <<
         std::setw(20) << std::right << num_misses << std::endl;
+    std::cerr << prefix << std::setw(18) << std::left << "Invalidations:" <<
+        std::setw(20) << std::right << num_incl_invalidates << std::endl;
 }
 
 void
@@ -176,4 +178,9 @@ caching_device_stats_t::reset()
     num_hits = 0;
     num_misses = 0;
     num_child_hits = 0;
+    num_incl_invalidates = 0;
+}
+
+void caching_device_stats_t::invalidate() {
+    num_incl_invalidates++;
 }

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -38,8 +38,8 @@
 caching_device_stats_t::caching_device_stats_t(const std::string &miss_file,
                                                bool warmup_enabled) :
     success(true), num_hits(0), num_misses(0), num_child_hits(0),
-    num_hits_at_reset(0), num_misses_at_reset(0), num_child_hits_at_reset(0),
-    warmup_enabled(warmup_enabled), file(nullptr)
+    num_inclusive_invalidates(0), num_hits_at_reset(0), num_misses_at_reset(0),
+    num_child_hits_at_reset(0), warmup_enabled(warmup_enabled), file(nullptr)
 {
     if (miss_file.empty()) {
         dump_misses = false;
@@ -127,7 +127,7 @@ caching_device_stats_t::print_counts(std::string prefix)
     std::cerr << prefix << std::setw(18) << std::left << "Misses:" <<
         std::setw(20) << std::right << num_misses << std::endl;
     std::cerr << prefix << std::setw(18) << std::left << "Invalidations:" <<
-        std::setw(20) << std::right << num_incl_invalidates << std::endl;
+        std::setw(20) << std::right << num_inclusive_invalidates << std::endl;
 }
 
 void
@@ -178,9 +178,9 @@ caching_device_stats_t::reset()
     num_hits = 0;
     num_misses = 0;
     num_child_hits = 0;
-    num_incl_invalidates = 0;
+    num_inclusive_invalidates = 0;
 }
 
 void caching_device_stats_t::invalidate() {
-    num_incl_invalidates++;
+    num_inclusive_invalidates++;
 }

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -181,6 +181,8 @@ caching_device_stats_t::reset()
     num_inclusive_invalidates = 0;
 }
 
-void caching_device_stats_t::invalidate() {
+void
+caching_device_stats_t::invalidate()
+{
     num_inclusive_invalidates++;
 }

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -82,7 +82,7 @@ class caching_device_stats_t
     int_least64_t num_misses;
     int_least64_t num_child_hits;
 
-    int_least64_t num_incl_invalidates;
+    int_least64_t num_inclusive_invalidates;
 
     // Stats saved when the last reset was called. This helps us get insight
     // into what the stats were when the cache was warmed up.

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -64,6 +64,9 @@ class caching_device_stats_t
 
     virtual bool operator!() { return !success; }
 
+    // Process invalidations due to cache inclusions.
+    virtual void invalidate();
+
  protected:
     bool success;
 
@@ -78,6 +81,8 @@ class caching_device_stats_t
     int_least64_t num_hits;
     int_least64_t num_misses;
     int_least64_t num_child_hits;
+
+    int_least64_t num_incl_invalidates;
 
     // Stats saved when the last reset was called. This helps us get insight
     // into what the stats were when the cache was warmed up.

--- a/clients/drcachesim/tests/TLB-simple.templatex
+++ b/clients/drcachesim/tests/TLB-simple.templatex
@@ -5,14 +5,17 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                      *[0-9,\.]*
     Misses:                    *[0-9,\.]*
+    Invalidations:             0
     Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                      *[0-9,\.]*
     Misses:                    *[0-9,\.]*
+    Invalidations:             0
     Miss rate:                 *[0-9]*[,\.]..%
   LL stats:
     Hits:                      *[0-9,\.]*
     Misses:                           *[0-9]..?
+    Invalidations:             0
     Local miss rate:           *[0-9]*[,\.]..%
     Child hits:                *[0-9,\.]*
     Total miss rate:                  0[,\.]..%

--- a/clients/drcachesim/tests/TLB-simple.templatex
+++ b/clients/drcachesim/tests/TLB-simple.templatex
@@ -5,17 +5,17 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                      *[0-9,\.]*
     Misses:                    *[0-9,\.]*
-    Invalidations:             0
+    Invalidations:             *0
     Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                      *[0-9,\.]*
     Misses:                    *[0-9,\.]*
-    Invalidations:             0
+    Invalidations:             *0
     Miss rate:                 *[0-9]*[,\.]..%
   LL stats:
     Hits:                      *[0-9,\.]*
     Misses:                           *[0-9]..?
-    Invalidations:             0
+    Invalidations:             *0
     Local miss rate:           *[0-9]*[,\.]..%
     Child hits:                *[0-9,\.]*
     Total miss rate:                  0[,\.]..%

--- a/clients/drcachesim/tests/TLB-threads.templatex
+++ b/clients/drcachesim/tests/TLB-threads.templatex
@@ -69,14 +69,17 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
   L1I stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9,\.]*
+    Invalidations:           0
     Miss rate:                        [0-4][\.,]..%
   L1D stats:
     Hits:                      *[0-9,\.]*
     Misses:                    *[0-9,\.]*
+    Invalidations:             0
     Miss rate:                 *[0-9]*[\.,]..%
   LL stats:
     Hits:                      *[0-9,\.]*
     Misses:                    *[0-9,\.]*
+    Invalidations:             0
     Local miss rate:           *[0-9]*[\.,]..%
     Child hits:                *[0-9,\.]*
     Total miss rate:                  [0-4][\.,]..%

--- a/clients/drcachesim/tests/TLB-threads.templatex
+++ b/clients/drcachesim/tests/TLB-threads.templatex
@@ -69,17 +69,17 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
   L1I stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9,\.]*
-    Invalidations:           0
+    Invalidations:           *0
     Miss rate:                        [0-4][\.,]..%
   L1D stats:
     Hits:                      *[0-9,\.]*
     Misses:                    *[0-9,\.]*
-    Invalidations:             0
+    Invalidations:             *0
     Miss rate:                 *[0-9]*[\.,]..%
   LL stats:
     Hits:                      *[0-9,\.]*
     Misses:                    *[0-9,\.]*
-    Invalidations:             0
+    Invalidations:             *0
     Local miss rate:           *[0-9]*[\.,]..%
     Child hits:                *[0-9,\.]*
     Total miss rate:                  [0-4][\.,]..%

--- a/clients/drcachesim/tests/allasm-aarch64-cache.templatex
+++ b/clients/drcachesim/tests/allasm-aarch64-cache.templatex
@@ -5,12 +5,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                 *          8[,.]?246
     Misses:                              2
-    Invalidations:                       0
+    Invalidations:        *              0
     Miss rate:                        0[.,]02%
   L1D stats:
     Hits:                 *          2[,.]?030
     Misses:                             16
-    Invalidations:                       0
+    Invalidations:        *              0
     Miss rate:                        0[.,]78%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -18,7 +18,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                                0
     Misses:                             18
-    Invalidations:                       0
+    Invalidations:        *              0
     Local miss rate:                100[.,]00%
     Child hits:           *         10[,.]?276
     Total miss rate:                  0[.,]17%

--- a/clients/drcachesim/tests/allasm-aarch64-cache.templatex
+++ b/clients/drcachesim/tests/allasm-aarch64-cache.templatex
@@ -5,10 +5,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                 *          8[,.]?246
     Misses:                              2
+    Invalidations:                       0
     Miss rate:                        0[.,]02%
   L1D stats:
     Hits:                 *          2[,.]?030
     Misses:                             16
+    Invalidations:                       0
     Miss rate:                        0[.,]78%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -16,6 +18,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                                0
     Misses:                             18
+    Invalidations:                       0
     Local miss rate:                100[.,]00%
     Child hits:           *         10[,.]?276
     Total miss rate:                  0[.,]17%

--- a/clients/drcachesim/tests/allasm-arm.templatex
+++ b/clients/drcachesim/tests/allasm-arm.templatex
@@ -11,6 +11,7 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                              [45][90][0-9]
     Misses:                              [5-9]
+    Invalidations:                       0
     Flushes:                             1
     Prefetch hits:                       1
     Prefetch misses:                     1
@@ -18,6 +19,7 @@ Core #0 \(1 thread\(s\)\)
   L1D stats:
     Hits:                               1[0-9]
     Misses:                              [1-9]
+    Invalidations:                       0
     Prefetch hits:                       1
     Prefetch misses:                     3
     Miss rate:                       [ 1][0-3][,\.]..%
@@ -27,6 +29,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                                1
     Misses:                             [ 1][0-9]
+    Invalidations:                       0
     Flushes:                             1
     Prefetch hits:                       1
     Prefetch misses:                     3

--- a/clients/drcachesim/tests/allasm-thumb.templatex
+++ b/clients/drcachesim/tests/allasm-thumb.templatex
@@ -11,10 +11,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                              6[34].
     Misses:                             11
+    Invalidations:                       0
     Miss rate:                        1[,\.]69%
   L1D stats:
     Hits:                               3[0-9]
     Misses:                             *[0-9]*
+    Invalidations:                       0
     Prefetch hits:                       1
     Prefetch misses:                     6
     Miss rate:                       [ 1][0-5][,\.]..%
@@ -24,6 +26,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                                3
     Misses:                             1[0-9]
+    Invalidations:                       0
     Prefetch hits:                       1
     Prefetch misses:                     [56]
     Local miss rate:                 [89].[,\.]..%

--- a/clients/drcachesim/tests/delay-simple.templatex
+++ b/clients/drcachesim/tests/delay-simple.templatex
@@ -6,12 +6,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                   *[0-9,\.]*%
   L1D stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                   *[0-9,\.]*%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -19,7 +19,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:             *[0-9,\.]*%
     Child hits:                   *[0-9,\.]*.
     Total miss rate:              *[0-9,\.]*%

--- a/clients/drcachesim/tests/delay-simple.templatex
+++ b/clients/drcachesim/tests/delay-simple.templatex
@@ -6,10 +6,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                   *[0-9,\.]*%
   L1D stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                   *[0-9,\.]*%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -17,6 +19,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*   Local miss rate:             *[0-9,\.]*%
     Child hits:                   *[0-9,\.]*.
     Total miss rate:              *[0-9,\.]*%

--- a/clients/drcachesim/tests/filter-no-d.templatex
+++ b/clients/drcachesim/tests/filter-no-d.templatex
@@ -5,16 +5,19 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                   *[1-9][0-9][,\.]..%
   L1D stats:
     Hits:                                0
     Misses:                              0
+    Invalidations:                       0
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*   Local miss rate:             *[1-9][0-9][,\.]..%
     Child hits:                   *[0-9,\.]*.
     Total miss rate:              *[1-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/filter-no-d.templatex
+++ b/clients/drcachesim/tests/filter-no-d.templatex
@@ -5,7 +5,7 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                   *[1-9][0-9][,\.]..%
   L1D stats:
     Hits:                                0
@@ -17,7 +17,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:             *[1-9][0-9][,\.]..%
     Child hits:                   *[0-9,\.]*.
     Total miss rate:              *[1-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/filter-no-i.templatex
+++ b/clients/drcachesim/tests/filter-no-i.templatex
@@ -9,7 +9,7 @@ Core #0 \(1 thread\(s\)\)
   L1D stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                   *[1-9][0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -17,7 +17,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:             *[1-9][0-9][,\.]..%
     Child hits:                   *[0-9,\.]*.
     Total miss rate:              *[1-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/filter-no-i.templatex
+++ b/clients/drcachesim/tests/filter-no-i.templatex
@@ -5,9 +5,11 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                                0
     Misses:                              0
+    Invalidations:                       0
   L1D stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                   *[1-9][0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -15,6 +17,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*   Local miss rate:             *[1-9][0-9][,\.]..%
     Child hits:                   *[0-9,\.]*.
     Total miss rate:              *[1-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/filter-simple.templatex
+++ b/clients/drcachesim/tests/filter-simple.templatex
@@ -5,12 +5,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                   *[1-9][0-9][,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                   *[1-9][0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -18,7 +18,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:             *[1-9][0-9][,\.]..%
     Child hits:                   *[0-9,\.]*.
     Total miss rate:              *[1-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/filter-simple.templatex
+++ b/clients/drcachesim/tests/filter-simple.templatex
@@ -5,10 +5,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                   *[1-9][0-9][,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                   *[1-9][0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -16,6 +18,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*   Local miss rate:             *[1-9][0-9][,\.]..%
     Child hits:                   *[0-9,\.]*.
     Total miss rate:              *[1-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/multiproc.templatex
+++ b/clients/drcachesim/tests/multiproc.templatex
@@ -5,30 +5,30 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9,\.]*
-    Invalidations:           0
+    Invalidations:           *0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9\.,]*
-    Invalidations:           0
+    Invalidations:           *0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(1 thread\(s\)\)
   L1I stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9,\.]*
-    Invalidations:           0
+    Invalidations:           *0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9]*[,\.]?...
-    Invalidations:           0
+    Invalidations:           *0
 .*   Miss rate:              *[0-9]*[,\.]..%
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                    *[0-9]*
     Misses:                  *[0-9]*[,\.]?...
-    Invalidations:           0
+    Invalidations:           *0
 .*    Local miss rate:         *[1-9][0-9][,\.]..%
     Child hits:              *[0-9,\.]*[,\.]?...[,\.]?...
     Total miss rate:                  [0-9][,\.]..%

--- a/clients/drcachesim/tests/multiproc.templatex
+++ b/clients/drcachesim/tests/multiproc.templatex
@@ -5,25 +5,30 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9,\.]*
+    Invalidations:           0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9\.,]*
+    Invalidations:           0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(1 thread\(s\)\)
   L1I stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9,\.]*
+    Invalidations:           0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9]*[,\.]?...
+    Invalidations:           0
 .*   Miss rate:              *[0-9]*[,\.]..%
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                    *[0-9]*
     Misses:                  *[0-9]*[,\.]?...
+    Invalidations:           0
 .*    Local miss rate:         *[1-9][0-9][,\.]..%
     Child hits:              *[0-9,\.]*[,\.]?...[,\.]?...
     Total miss rate:                  [0-9][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_client.templatex
+++ b/clients/drcachesim/tests/offline-burst_client.templatex
@@ -27,12 +27,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*...
-    Invalidations:                0
+    Invalidations:                *0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -40,7 +40,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:                *[0-9]*[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_client.templatex
+++ b/clients/drcachesim/tests/offline-burst_client.templatex
@@ -27,10 +27,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*...
+    Invalidations:                0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -38,6 +40,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*   Local miss rate:                *[0-9]*[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_maps.templatex
+++ b/clients/drcachesim/tests/offline-burst_maps.templatex
@@ -15,12 +15,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*...
-    Invalidations:                0
+    Invalidations:                *0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -28,7 +28,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:                *[0-9]*[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_maps.templatex
+++ b/clients/drcachesim/tests/offline-burst_maps.templatex
@@ -15,10 +15,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*...
+    Invalidations:                0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -26,6 +28,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*   Local miss rate:                *[0-9]*[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_noreach.templatex
+++ b/clients/drcachesim/tests/offline-burst_noreach.templatex
@@ -15,12 +15,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*...
-    Invalidations:                0
+    Invalidations:                *0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -28,7 +28,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:                *[0-9]*[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_noreach.templatex
+++ b/clients/drcachesim/tests/offline-burst_noreach.templatex
@@ -15,10 +15,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*...
+    Invalidations:                0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -26,6 +28,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*   Local miss rate:                *[0-9]*[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_replace.templatex
+++ b/clients/drcachesim/tests/offline-burst_replace.templatex
@@ -19,10 +19,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*...
+    Invalidations:                0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -30,6 +32,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*   Local miss rate:                *[0-9]*[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_replace.templatex
+++ b/clients/drcachesim/tests/offline-burst_replace.templatex
@@ -19,12 +19,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*...
-    Invalidations:                0
+    Invalidations:                *0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -32,7 +32,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:                *[0-9]*[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_replaceall.templatex
+++ b/clients/drcachesim/tests/offline-burst_replaceall.templatex
@@ -10,12 +10,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*...
-    Invalidations:                0
+    Invalidations:                *0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -23,7 +23,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:                *[0-9]*[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_replaceall.templatex
+++ b/clients/drcachesim/tests/offline-burst_replaceall.templatex
@@ -10,10 +10,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*...
+    Invalidations:                0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -21,6 +23,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*   Local miss rate:                *[0-9]*[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_static.templatex
+++ b/clients/drcachesim/tests/offline-burst_static.templatex
@@ -24,10 +24,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*...
+    Invalidations:                0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -35,6 +37,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*   Local miss rate:                *[0-9]*[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_static.templatex
+++ b/clients/drcachesim/tests/offline-burst_static.templatex
@@ -24,12 +24,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*...
-    Invalidations:                0
+    Invalidations:                *0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*.....
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                        0[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -37,7 +37,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:                *[0-9]*[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -15,12 +15,12 @@ Cache simulation results:
 Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
   L1I stats:
     Hits:                       *[0-9,\.]*
-    Misses:                     *[0-9,\.]*.*
-    Invalidations:              *0
+    Misses:                     *[0-9,\.]*
+    Invalidations:              *0.*
   L1D stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*.*
-    Invalidations:              *0
+    Invalidations:              *0.*
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
 Core #3 \([0-9] traced CPU\(s\).*

--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -16,18 +16,18 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
   L1I stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*.*
-    Invalidations:              0
+    Invalidations:              *0
   L1D stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*.*
-    Invalidations:              0
+    Invalidations:              *0
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
 Core #3 \([0-9] traced CPU\(s\).*
 LL stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
-    Invalidations:              0
+    Invalidations:              *0
 .*    Local miss rate:          *[0-9,\.]*%
     Child hits:                 *[0-9,\.]*
     Total miss rate:            *[0-9,\.]*%

--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -16,15 +16,18 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
   L1I stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*.*
+    Invalidations:              0
   L1D stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*.*
+    Invalidations:              0
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
 Core #3 \([0-9] traced CPU\(s\).*
 LL stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
+    Invalidations:              0
 .*    Local miss rate:          *[0-9,\.]*%
     Child hits:                 *[0-9,\.]*
     Total miss rate:            *[0-9,\.]*%

--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -19,7 +19,7 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
     Invalidations:              *0.*
   L1D stats:
     Hits:                       *[0-9,\.]*
-    Misses:                     *[0-9,\.]*.*
+    Misses:                     *[0-9,\.]*
     Invalidations:              *0.*
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*

--- a/clients/drcachesim/tests/offline-filter.templatex
+++ b/clients/drcachesim/tests/offline-filter.templatex
@@ -4,10 +4,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                   *[0-9][0-9][,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
+    Invalidations:                0
 .*   Miss rate:                   *[0-9][0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -15,6 +17,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*   Local miss rate:             *[0-9][0-9][,\.]..%
     Child hits:                   *[0-9,\.]*.
     Total miss rate:              *[0-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/offline-filter.templatex
+++ b/clients/drcachesim/tests/offline-filter.templatex
@@ -4,12 +4,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                   *[0-9][0-9][,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*.
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                   *[0-9][0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -17,7 +17,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*.
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:             *[0-9][0-9][,\.]..%
     Child hits:                   *[0-9,\.]*.
     Total miss rate:              *[0-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/offline-multiproc.templatex
+++ b/clients/drcachesim/tests/offline-multiproc.templatex
@@ -4,12 +4,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9,\.]*
-    Invalidations:           0
+    Invalidations:           *0
 .*    Miss rate:             *[0-9]*[,\.]..%
   L1D stats:
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9\.,]*
-    Invalidations:           0
+    Invalidations:           *0
 .*   Miss rate:              *[0-9]*[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -17,7 +17,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9\.,]*
-    Invalidations:           0
+    Invalidations:           *0
 .*    Local miss rate:       *[0-9]*[,\.]..%
     Child hits:              *[0-9\.,]*
     Total miss rate:         *[0-9]*[,\.]..%

--- a/clients/drcachesim/tests/offline-multiproc.templatex
+++ b/clients/drcachesim/tests/offline-multiproc.templatex
@@ -4,10 +4,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9,\.]*
+    Invalidations:           0
 .*    Miss rate:             *[0-9]*[,\.]..%
   L1D stats:
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9\.,]*
+    Invalidations:           0
 .*   Miss rate:              *[0-9]*[,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -15,6 +17,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9\.,]*
+    Invalidations:           0
 .*    Local miss rate:       *[0-9]*[,\.]..%
     Child hits:              *[0-9\.,]*
     Total miss rate:         *[0-9]*[,\.]..%

--- a/clients/drcachesim/tests/offline-simple.templatex
+++ b/clients/drcachesim/tests/offline-simple.templatex
@@ -4,12 +4,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*...
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -17,7 +17,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*...
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:                 [0-9].[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-4][,\.]..%

--- a/clients/drcachesim/tests/offline-simple.templatex
+++ b/clients/drcachesim/tests/offline-simple.templatex
@@ -4,10 +4,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*...
+    Invalidations:                0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -15,6 +17,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*...
     Misses:                       *[0-9,\.]*...
+    Invalidations:                0
 .*   Local miss rate:                 [0-9].[,\.]..%
     Child hits:                   *[0-9,\.]*...
     Total miss rate:                  [0-4][,\.]..%

--- a/clients/drcachesim/tests/phys.templatex
+++ b/clients/drcachesim/tests/phys.templatex
@@ -5,12 +5,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9]*[,\.]?...
     Misses:                       *[0-9]..?
-    Invalidations:                0
+    Invalidations:                *0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9].[,\.]?...
     Misses:                       *[0-9]*[,\.]?..?.?
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -18,7 +18,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9]..?
     Misses:                       *[0-9]*[,\.]?..?.?
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:                 [0-9].[,\.]..%
     Child hits:                   *([3-9]|[1-9].).[,\.]?...
     Total miss rate:                  [0-2][,\.]..%

--- a/clients/drcachesim/tests/phys.templatex
+++ b/clients/drcachesim/tests/phys.templatex
@@ -5,10 +5,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9]*[,\.]?...
     Misses:                       *[0-9]..?
+    Invalidations:                0
 .*    Miss rate:                        0[,\.]..%
   L1D stats:
     Hits:                         *[0-9].[,\.]?...
     Misses:                       *[0-9]*[,\.]?..?.?
+    Invalidations:                0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -16,6 +18,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9]..?
     Misses:                       *[0-9]*[,\.]?..?.?
+    Invalidations:                0
 .*   Local miss rate:                 [0-9].[,\.]..%
     Child hits:                   *([3-9]|[1-9].).[,\.]?...
     Total miss rate:                  [0-2][,\.]..%

--- a/clients/drcachesim/tests/simple.templatex
+++ b/clients/drcachesim/tests/simple.templatex
@@ -5,10 +5,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*..
+    Invalidations:                       0
 .*    Miss rate:                        [0-1][,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*...
+    Invalidations:                       0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -16,6 +18,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*..
     Misses:                       *[0-9,\.]*...
+    Invalidations:                       0
 .*   Local miss rate:                 [0-9].[,\.]..%
     Child hits:                   *[0-9,\.]*.....
     Total miss rate:                  [0-3][,\.]..%

--- a/clients/drcachesim/tests/simple.templatex
+++ b/clients/drcachesim/tests/simple.templatex
@@ -5,12 +5,12 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*..
-    Invalidations:                       0
+    Invalidations:                *0
 .*    Miss rate:                        [0-1][,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*...
-    Invalidations:                       0
+    Invalidations:                *0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -18,7 +18,7 @@ Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                         *[0-9,\.]*..
     Misses:                       *[0-9,\.]*...
-    Invalidations:                       0
+    Invalidations:                *0
 .*   Local miss rate:                 [0-9].[,\.]..%
     Child hits:                   *[0-9,\.]*.....
     Total miss rate:                  [0-3][,\.]..%

--- a/clients/drcachesim/tests/threads.templatex
+++ b/clients/drcachesim/tests/threads.templatex
@@ -69,12 +69,12 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
   L1I stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
-    Invalidations:              0
+    Invalidations:              *0
 .*    Miss rate:                *[0-9,\.]*%
   L1D stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
-    Invalidations:              0
+    Invalidations:              *0
 .*    Miss rate:                *[0-9,\.]*%
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
@@ -82,7 +82,7 @@ Core #3 \([0-9] traced CPU\(s\).*
 LL stats:
     Hits:                    *[0-9,\.]*...
     Misses:                  *[0-9,\.]*...
-    Invalidations:           0
+    Invalidations:           *0
 .*    Local miss rate:         *[0-9]*[\.,]..%
     Child hits:              *[0-9,\.]*......
     Total miss rate:                  0[\.,]..%

--- a/clients/drcachesim/tests/threads.templatex
+++ b/clients/drcachesim/tests/threads.templatex
@@ -69,10 +69,12 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
   L1I stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
+    Invalidations:              0
 .*    Miss rate:                *[0-9,\.]*%
   L1D stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
+    Invalidations:              0
 .*    Miss rate:                *[0-9,\.]*%
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
@@ -80,6 +82,7 @@ Core #3 \([0-9] traced CPU\(s\).*
 LL stats:
     Hits:                    *[0-9,\.]*...
     Misses:                  *[0-9,\.]*...
+    Invalidations:           0
 .*    Local miss rate:         *[0-9]*[\.,]..%
     Child hits:              *[0-9,\.]*......
     Total miss rate:                  0[\.,]..%

--- a/clients/drcachesim/tests/warmup-valid.templatex
+++ b/clients/drcachesim/tests/warmup-valid.templatex
@@ -7,14 +7,14 @@ Core #0 \(1 thread\(s\)\)
     Warmup misses:                *[0-9,\.]*..
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*    Miss rate:                        [0-1][,\.]..%
   L1D stats:
     Warmup hits:                  *[0-9,\.]*..
     Warmup misses:                *[0-9,\.]*..
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*...
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -24,7 +24,7 @@ LL stats:
     Warmup misses:                *[0-9,\.]*..
     Hits:                         *[0-9,\.]*..
     Misses:                       *[0-9,\.]*...
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:                 [0-9].[,\.]..%
     Child hits:                   *[0-9,\.]*.....
     Total miss rate:                  [0-3][,\.]..%

--- a/clients/drcachesim/tests/warmup-valid.templatex
+++ b/clients/drcachesim/tests/warmup-valid.templatex
@@ -7,12 +7,14 @@ Core #0 \(1 thread\(s\)\)
     Warmup misses:                *[0-9,\.]*..
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*    Miss rate:                        [0-1][,\.]..%
   L1D stats:
     Warmup hits:                  *[0-9,\.]*..
     Warmup misses:                *[0-9,\.]*..
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*...
+    Invalidations:                0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -22,6 +24,7 @@ LL stats:
     Warmup misses:                *[0-9,\.]*..
     Hits:                         *[0-9,\.]*..
     Misses:                       *[0-9,\.]*...
+    Invalidations:                0
 .*   Local miss rate:                 [0-9].[,\.]..%
     Child hits:                   *[0-9,\.]*.....
     Total miss rate:                  [0-3][,\.]..%

--- a/clients/drcachesim/tests/warmup-zeros.templatex
+++ b/clients/drcachesim/tests/warmup-zeros.templatex
@@ -7,12 +7,14 @@ Core #0 \(1 thread\(s\)\)
     Warmup misses:                *[0]*..
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*..
+    Invalidations:                0
 .*    Miss rate:                        [0-1][,\.]..%
   L1D stats:
     Warmup hits:                  *[0]*..
     Warmup misses:                *[0]*..
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*...
+    Invalidations:                0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -22,6 +24,7 @@ LL stats:
     Warmup misses:                *[0]*..
     Hits:                         *[0-9,\.]*..
     Misses:                       *[0-9,\.]*...
+    Invalidations:                0
 .*   Local miss rate:                 [0-9].[,\.]..%
     Child hits:                   *[0-9,\.]*.....
     Total miss rate:                  [0-3][,\.]..%

--- a/clients/drcachesim/tests/warmup-zeros.templatex
+++ b/clients/drcachesim/tests/warmup-zeros.templatex
@@ -7,14 +7,14 @@ Core #0 \(1 thread\(s\)\)
     Warmup misses:                *[0]*..
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*..
-    Invalidations:                0
+    Invalidations:                *0
 .*    Miss rate:                        [0-1][,\.]..%
   L1D stats:
     Warmup hits:                  *[0]*..
     Warmup misses:                *[0]*..
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*...
-    Invalidations:                0
+    Invalidations:                *0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
@@ -24,7 +24,7 @@ LL stats:
     Warmup misses:                *[0]*..
     Hits:                         *[0-9,\.]*..
     Misses:                       *[0-9,\.]*...
-    Invalidations:                0
+    Invalidations:                *0
 .*   Local miss rate:                 [0-9].[,\.]..%
     Child hits:                   *[0-9,\.]*.....
     Total miss rate:                  [0-3][,\.]..%


### PR DESCRIPTION
Add support for inclusive caches and line invalidation in DRCacheSim.
No support for setting the "inclusive" field and the "children" vector are included in this CL because a new configuration file-based interface to the simulator is being added in a subsequent CL.