### PR TITLE
iX: Export GLOBAL_STAT(peak_num_threads) as in dr_stats_t

### DIFF
--- a/core/globals.h
+++ b/core/globals.h
@@ -293,6 +293,8 @@ typedef struct _dr_stats_t {
      *  or capacity reasons or thread-private caches.
      */
     uint64 basic_block_count;
+    /** Total number of threads ever under DR control. */
+    uint64 peak_num_threads;
 } dr_stats_t;
 
 /* DR_API EXPORT END */

--- a/core/globals.h
+++ b/core/globals.h
@@ -293,8 +293,10 @@ typedef struct _dr_stats_t {
      *  or capacity reasons or thread-private caches.
      */
     uint64 basic_block_count;
-    /** Total number of threads ever under DR control. */
+    /** Peak number of simultaneous threads under DR control. */
     uint64 peak_num_threads;
+    /** Accumulated total number of threads encountered by DR. */
+    uint64 num_threads_created;
 } dr_stats_t;
 
 /* DR_API EXPORT END */

--- a/core/utils.c
+++ b/core/utils.c
@@ -4651,9 +4651,10 @@ stats_get_snapshot(dr_stats_t *drstats)
         return false;
     CLIENT_ASSERT(drstats != NULL, "Expected non-null value for parameter drstats.");
     drstats->basic_block_count = GLOBAL_STAT(num_bbs);
-    if (drstats->size > offsetof(dr_stats_t, peak_num_threads)) {
-        drstats->peak_num_threads = GLOBAL_STAT(peak_num_threads);
-        drstats->num_threads_created = GLOBAL_STAT(num_threads_created);
+    if (drstats->size <= offsetof(dr_stats_t, peak_num_threads)) {
+        return true;
     }
+    drstats->peak_num_threads = GLOBAL_STAT(peak_num_threads);
+    drstats->num_threads_created = GLOBAL_STAT(num_threads_created);
     return true;
 }

--- a/core/utils.c
+++ b/core/utils.c
@@ -74,6 +74,7 @@
 #endif
 
 #include <stdarg.h> /* for varargs */
+#include <stddef.h> /* for offsetof */
 
 try_except_t global_try_except;
 
@@ -4650,6 +4651,9 @@ stats_get_snapshot(dr_stats_t *drstats)
         return false;
     CLIENT_ASSERT(drstats != NULL, "Expected non-null value for parameter drstats.");
     drstats->basic_block_count = GLOBAL_STAT(num_bbs);
-    drstats->peak_num_threads = GLOBAL_STAT(peak_num_threads);
+    if (drstats->size > offsetof(dr_stats_t, peak_num_threads)) {
+        drstats->peak_num_threads = GLOBAL_STAT(peak_num_threads);
+        drstats->num_threads_created = GLOBAL_STAT(num_threads_created);
+    }
     return true;
 }

--- a/core/utils.c
+++ b/core/utils.c
@@ -4649,10 +4649,7 @@ stats_get_snapshot(dr_stats_t *drstats)
     if (!GLOBAL_STATS_ON())
         return false;
     CLIENT_ASSERT(drstats != NULL, "Expected non-null value for parameter drstats.");
-    /* We are at V1 of the structure, and we can't return less than the one
-     * field. We need to remove this assert when we add more fields.
-     */
-    CLIENT_ASSERT(drstats->size >= sizeof(dr_stats_t), "Invalid drstats->size value.");
     drstats->basic_block_count = GLOBAL_STAT(num_bbs);
+    drstats->peak_num_threads = GLOBAL_STAT(peak_num_threads);
     return true;
 }

--- a/suite/tests/api/static_prepop.c
+++ b/suite/tests/api/static_prepop.c
@@ -127,6 +127,8 @@ main(int argc, const char *argv[])
         got_stats = dr_get_stats(&stats);
         assert(got_stats);
         assert(stats.basic_block_count > 0);
+        assert(stats.peak_num_threads > 0);
+        assert(stats.num_threads_created > 0);
 
         print("pre-DR start\n");
         dr_app_start();


### PR DESCRIPTION
This change exports the peak_num_threads stat as part of dr_stats_t so that it can be used internally as part of unit tests.