### PR TITLE
Fix drvector_delete for zero capacity vectors.

### DIFF
--- a/suite/tests/client-interface/drcontainers-test.dll.c
+++ b/suite/tests/client-interface/drcontainers-test.dll.c
@@ -53,6 +53,12 @@ test_vector(void)
     CHECK(ok, "drvector_init failed");
     CHECK(vec.entries == 0, "should start empty");
 
+    ok = drvector_delete(&vec);
+    CHECK(ok, "drvector_delete failed for empty vec");
+
+    ok = drvector_init(&vec, 0, false/*!synch*/, NULL);
+    CHECK(ok, "drvector_init failed");
+
     drvector_append(&vec, (void *)&vec);
     CHECK(vec.entries == 1, "should add 1");
     CHECK(drvector_get_entry(&vec, 0) == (void *)&vec, "entries not equal");


### PR DESCRIPTION
If a drvector_t is initialized with zero capacity, it lazily allocates
memory on the first append invocation. If the vector is deleted before
append is called, then drvector_delete tries to free a nullptr which
shows up as an error in a DEBUG build.