### PR TITLE
i#1715 Add DRCacheSim support for cache config files:

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -113,6 +113,7 @@ set(drcachesim_srcs
   analyzer_multi.cpp
   ${client_and_sim_srcs}
   reader/reader.cpp
+  reader/config_reader.cpp
   reader/file_reader.cpp
   ${zlib_reader}
   reader/ipc_reader.cpp

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -48,10 +48,10 @@
 #define REUSE_TIME                              "reuse_time"
 #define BASIC_COUNTS                            "basic_counts"
 #define OPCODE_MIX                              "opcode_mix"
-#define INSTRUCTION_CACHE                       "instruction"
-#define DATA_CACHE                              "data"
-#define UNIFIED_CACHE                           "unified"
-#define MEMORY                                  "memory"
+#define CACHE_TYPE_INSTRUCTION                  "instruction"
+#define CACHE_TYPE_DATA                         "data"
+#define CACHE_TYPE_UNIFIED                      "unified"
+#define CACHE_PARENT_MEMORY                     "memory"
 
 #include <string>
 #include "droption.h"

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -48,6 +48,10 @@
 #define REUSE_TIME                              "reuse_time"
 #define BASIC_COUNTS                            "basic_counts"
 #define OPCODE_MIX                              "opcode_mix"
+#define INSTRUCTION_CACHE                       "instruction"
+#define DATA_CACHE                              "data"
+#define UNIFIED_CACHE                           "unified"
+#define MEMORY                                  "memory"
 
 #include <string>
 #include "droption.h"

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -46,6 +46,7 @@ online and offline.
  - \ref sec_drcachesim
  - \ref sec_drcachesim_run
  - \ref sec_drcachesim_tools
+ - \ref sec_drcachesim_config_file
  - \ref sec_drcachesim_offline
  - \ref sec_drcachesim_partial
  - \ref sec_drcachesim_sim
@@ -420,6 +421,89 @@ dcache top 10
     0x7facdb6625c0: 2016
     0x7ffcc35e7e40: 1997
 \endcode
+
+****************************************************************************
+\section sec_drcachesim_config_file Configuration File
+
+\p drcachesim supports reconfigurable cache hierarchies defined in
+a configuration file. The configuration file is a text file with the following
+formatting rules.
+
+- A comment starts with two slashes followed by one or more spaces. Anything
+after the '// ' till the end of the line is considered a comment and ignored.
+- A parameter's name and its value are listed consecutively with white space
+(spaces, tabs, or a new line) between them.
+- Parameters must be separated by white space. Including one parameter per line
+helps keep the configuration file more human-readable.
+- A cache's parameters must be enclosed inside braces and preceded by the
+cache's unique name.
+- Parameters can be listed in any order.
+- Parameters not included in the configuration file take their default values.
+- String values must not be enclosed in quotations.
+
+Supported common parameters and their values types:
+- num_cores <unsigned int>
+- line_size <unsigned int>
+- skip_refs <unsigned int>
+- warmup_refs <unsigned int>
+- warmup_fraction <float in [0,1]>
+- sim_refs <unsigned int>
+- cpu_scheduling <bool>
+- verbose <unsigned int>
+
+Supported cache parameters and their values types:
+- type <string, one of instruction, data, or unified>
+- core <unsigned int in [0, num_cores)>
+- size <unsigned int, power of 2>
+- assoc <unsigned int, power of 2>
+- inclusive <bool>
+- parent <string>
+- replace_policy <string, one of >
+- prefetcher <string>
+- miss_file <string>
+
+Example:
+// Configuration for a single-core CPU.
+
+// Common params.
+num_cores       1
+line_size       64
+cpu_scheduling  true
+sim_refs        8888888
+warmup_fraction 0.8
+
+// Cache params.
+P0L1I {                        // P0 L1 I$
+  type          instruction
+  core          0
+  size          65536
+  assoc         8
+  parent        P0L2
+  rplc_policy   LRU
+}
+P0L1D {                        // P0 L1 D$
+  type          data
+  core          0
+  size          65536
+  assoc         8
+  parent        P0L2
+  rplc_policy   LRU
+}
+P0L2 {                         // P0 L2$
+  size          512K
+  assoc         16
+  inclusive     true
+  parent        LLC
+  rplc_policy   LRU
+}
+LLC {                          // LLC
+  size          1M
+  assoc         16
+  inclusive     true
+  parent        mem
+  rplc_policy   LRU
+  miss_file     misses.txt
+}
 
 ****************************************************************************
 \section sec_drcachesim_offline Offline Traces and Analysis

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -436,32 +436,32 @@ after the '// ' until the end of the line is considered a comment and ignored.
 - Parameters must be separated by white space. Including one parameter per line
 helps keep the configuration file more human-readable.
 - A cache's parameters must be enclosed inside braces and preceded by the
-cache's unique name.
+cache's user-chosen unique name.
 - Parameters can be listed in any order.
 - Parameters not included in the configuration file take their default values.
 - String values must not be enclosed in quotations.
 
 Supported common parameters and their value types (each of these parameters
 sets the corresponding option with the same name described in \ref sec_drcachesim_ops):
-- num_cores <unsigned int>
-- line_size <unsigned int>
-- skip_refs <unsigned int>
-- warmup_refs <unsigned int>
-- warmup_fraction <float in [0,1]>
-- sim_refs <unsigned int>
-- cpu_scheduling <bool>
-- verbose <unsigned int>
+- num_cores \<unsigned int\>
+- line_size \<unsigned int\>
+- skip_refs \<unsigned int\>
+- warmup_refs \<unsigned int\>
+- warmup_fraction \<float in [0,1]\>
+- sim_refs \<unsigned int\>
+- cpu_scheduling \<bool\>
+- verbose \<unsigned int\>
 
 Supported cache parameters and their value types:
-- type <string, one of "instruction", "data", or "unified">
-- core <unsigned int in [0, num_cores)>
-- size <unsigned int, power of 2>
-- assoc <unsigned int, power of 2>
-- inclusive <bool>
-- parent <string>
-- replace_policy <string, one of "LRU", "LFU", or "FIFO">
-- prefetcher <string, one of "nextline" or "none">
-- miss_file <string>
+- type \<string, one of "instruction", "data", or "unified"\>
+- core \<unsigned int in [0, num_cores)\>
+- size \<unsigned int, power of 2\>
+- assoc \<unsigned int, power of 2\>
+- inclusive \<bool\>
+- parent \<string\>
+- replace_policy \<string, one of "LRU", "LFU", or "FIFO"\>
+- prefetcher \<string, one of "nextline" or "none"\>
+- miss_file \<string\>
 
 Example:
 \code

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -430,7 +430,7 @@ a configuration file. The configuration file is a text file with the following
 formatting rules.
 
 - A comment starts with two slashes followed by one or more spaces. Anything
-after the '// ' till the end of the line is considered a comment and ignored.
+after the '// ' until the end of the line is considered a comment and ignored.
 - A parameter's name and its value are listed consecutively with white space
 (spaces, tabs, or a new line) between them.
 - Parameters must be separated by white space. Including one parameter per line
@@ -441,7 +441,8 @@ cache's unique name.
 - Parameters not included in the configuration file take their default values.
 - String values must not be enclosed in quotations.
 
-Supported common parameters and their values types:
+Supported common parameters and their value types (each of these parameters
+sets the corresponding option with the same name described in \ref sec_drcachesim_ops):
 - num_cores <unsigned int>
 - line_size <unsigned int>
 - skip_refs <unsigned int>
@@ -451,18 +452,19 @@ Supported common parameters and their values types:
 - cpu_scheduling <bool>
 - verbose <unsigned int>
 
-Supported cache parameters and their values types:
-- type <string, one of instruction, data, or unified>
+Supported cache parameters and their value types:
+- type <string, one of "instruction", "data", or "unified">
 - core <unsigned int in [0, num_cores)>
 - size <unsigned int, power of 2>
 - assoc <unsigned int, power of 2>
 - inclusive <bool>
 - parent <string>
-- replace_policy <string, one of >
-- prefetcher <string>
+- replace_policy <string, one of "LRU", "LFU", or "FIFO">
+- prefetcher <string, one of "nextline" or "none">
 - miss_file <string>
 
 Example:
+\code
 // Configuration for a single-core CPU.
 
 // Common params.
@@ -473,37 +475,38 @@ sim_refs        8888888
 warmup_fraction 0.8
 
 // Cache params.
-P0L1I {                        // P0 L1 I$
-  type          instruction
-  core          0
-  size          65536
-  assoc         8
-  parent        P0L2
-  rplc_policy   LRU
+P0L1I {                        // P0 L1 instruction cache
+  type            instruction
+  core            0
+  size            65536        // 64K
+  assoc           8
+  parent          P0L2
+  replace_policy  LRU
 }
-P0L1D {                        // P0 L1 D$
-  type          data
-  core          0
-  size          65536
-  assoc         8
-  parent        P0L2
-  rplc_policy   LRU
+P0L1D {                        // P0 L1 data cache
+  type            data
+  core            0
+  size            65536        // 64K
+  assoc           8
+  parent          P0L2
+  replace_policy  LRU
 }
-P0L2 {                         // P0 L2$
-  size          512K
-  assoc         16
-  inclusive     true
-  parent        LLC
-  rplc_policy   LRU
+P0L2 {                         // P0 L2 unified cache
+  size            512K
+  assoc           16
+  inclusive       true
+  parent          LLC
+  replace_policy  LRU
 }
 LLC {                          // LLC
-  size          1M
-  assoc         16
-  inclusive     true
-  parent        mem
-  rplc_policy   LRU
-  miss_file     misses.txt
+  size            1M
+  assoc           16
+  inclusive       true
+  parent          mem
+  replace_policy  LRU
+  miss_file       misses.txt
 }
+\endcode
 
 ****************************************************************************
 \section sec_drcachesim_offline Offline Traces and Analysis

--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -107,14 +107,16 @@ config_reader_t::configure(const string &config_file,
         else if (param == "warmup_refs") {
             // Number of references to use for caches warmup.
             if (!(fin >> knobs.warmup_refs)) {
-                ERRMSG("Error reading warmup_refs from the configuration file\n");
+                ERRMSG("Error reading warmup_refs from "
+                       "the configuration file\n");
                 return false;
             }
         }
         else if (param == "warmup_fraction") {
             // Fraction of cache lines that must be filled to end the warmup.
             if (!(fin >> knobs.warmup_fraction)) {
-                ERRMSG("Error reading warmup_fraction from the configuration file\n");
+                ERRMSG("Error reading warmup_fraction from "
+                       "the configuration file\n");
                 return false;
             }
             if (knobs.warmup_fraction < 0.0 || knobs.warmup_fraction > 1.0) {
@@ -133,7 +135,8 @@ config_reader_t::configure(const string &config_file,
             // Whether to simulate CPU scheduling or not.
             string bool_val;
             if (!(fin >> bool_val)) {
-                ERRMSG("Error reading cpu_scheduling from the configuration file\n");
+                ERRMSG("Error reading cpu_scheduling from "
+                       "the configuration file\n");
                 return false;
             }
             if (is_true(bool_val)) {
@@ -207,7 +210,8 @@ config_reader_t::configure_cache(cache_params_t &cache)
             // Cache type: CACHE_TYPE_INSTRUCTION, CACHE_TYPE_DATA,
             // or CACHE_TYPE_UNIFIED.
             if (!(fin >> cache.type)) {
-                ERRMSG("Error reading cache type from the configuration file\n");
+                ERRMSG("Error reading cache type from "
+                       "the configuration file\n");
                 return false;
             }
             if (cache.type != CACHE_TYPE_INSTRUCTION &&
@@ -220,7 +224,8 @@ config_reader_t::configure_cache(cache_params_t &cache)
         else if (param == "core") {
             // CPU core this cache is associated with.
             if (!(fin >> cache.core)) {
-                ERRMSG("Error reading cache core from the configuration file\n");
+                ERRMSG("Error reading cache core from "
+                       "the configuration file\n");
                 return false;
             }
         }
@@ -228,7 +233,8 @@ config_reader_t::configure_cache(cache_params_t &cache)
             // Cache size in bytes.
             string size_str;
             if (!(fin >> size_str)) {
-                ERRMSG("Error reading cache size from the configuration file\n");
+                ERRMSG("Error reading cache size from "
+                       "the configuration file\n");
                 return false;
             }
             if (!convert_string_to_size(size_str, cache.size)) {
@@ -244,7 +250,8 @@ config_reader_t::configure_cache(cache_params_t &cache)
         else if (param == "assoc") {
             // Cache associativity. Must be a power of 2.
             if (!(fin >> cache.assoc)) {
-                ERRMSG("Error reading cache assoc from the configuration file\n");
+                ERRMSG("Error reading cache assoc from "
+                       "the configuration file\n");
                 return false;
             }
             if (cache.assoc <= 0 || !IS_POWER_OF_2(cache.assoc)) {
@@ -257,7 +264,8 @@ config_reader_t::configure_cache(cache_params_t &cache)
             // Is the cache inclusive of its children.
             string bool_val;
             if (!(fin >> bool_val)) {
-                ERRMSG("Error reading cache inclusivity from the configuration file\n");
+                ERRMSG("Error reading cache inclusivity from "
+                       "the configuration file\n");
                 return false;
             }
             if (is_true(bool_val)) {
@@ -271,7 +279,8 @@ config_reader_t::configure_cache(cache_params_t &cache)
             // Name of the cache's parent. LLC's parent is main memory
             // (CACHE_PARENT_MEMORY).
             if (!(fin >> cache.parent)) {
-                ERRMSG("Error reading cache parent from the configuration file\n");
+                ERRMSG("Error reading cache parent from "
+                       "the configuration file\n");
                 return false;
             }
         }
@@ -279,7 +288,8 @@ config_reader_t::configure_cache(cache_params_t &cache)
             // Cache replacement policy: REPLACE_POLICY_LRU (default),
             // REPLACE_POLICY_LFU or REPLACE_POLICY_FIFO.
             if (!(fin >> cache.replace_policy)) {
-                ERRMSG("Error reading cache replace_policy from the configuration file\n");
+                ERRMSG("Error reading cache replace_policy from "
+                       "the configuration file\n");
                 return false;
             }
             if (cache.replace_policy != REPLACE_POLICY_NON_SPECIFIED &&
@@ -295,7 +305,8 @@ config_reader_t::configure_cache(cache_params_t &cache)
             // Type of prefetcher: PREFETCH_POLICY_NEXTLINE
             // or PREFETCH_POLICY_NONE.
             if (!(fin >> cache.prefetcher)) {
-                ERRMSG("Error reading cache prefetcher from the configuration file\n");
+                ERRMSG("Error reading cache prefetcher from "
+                       "the configuration file\n");
                 return false;
             }
             if (cache.prefetcher != PREFETCH_POLICY_NEXTLINE &&
@@ -308,7 +319,8 @@ config_reader_t::configure_cache(cache_params_t &cache)
         else if (param == "miss_file") {
             // Name of the file to use to dump cache misses info.
             if (!(fin >> cache.miss_file)) {
-                ERRMSG("Error reading cache miss_file from the configuration file\n");
+                ERRMSG("Error reading cache miss_file from "
+                       "the configuration file\n");
                 return false;
             }
         }
@@ -345,7 +357,7 @@ config_reader_t::check_cache_config(int num_cores,
         // Associate a cache to a core.
         if (cache.core >= 0) {
             if (cache.core >= num_cores) {
-                ERRMSG("Cache %s is associated with core %d which does not exist\n",
+                ERRMSG("Cache %s belongs to core %d which does not exist\n",
                        cache_name.c_str(), cache.core);
                 return false;
             }
@@ -385,7 +397,7 @@ config_reader_t::check_cache_config(int num_cores,
             string parent = cache.parent;
             while (parent != CACHE_PARENT_MEMORY) {
                 if (parent == cache_name) {
-                    ERRMSG("Cache %s and its parent %s have a cyclic reference\n",
+                    ERRMSG("Cache %s & its parent %s have a cyclic reference\n",
                            cache_name.c_str(), cache.parent.c_str());
                     return false;
                 }
@@ -412,8 +424,9 @@ config_reader_t::check_cache_config(int num_cores,
     return true;
 }
 
-// XXX: This function is a duplicate of droption_t<bytesize_t>::convert_from_string
-// Consider sharing the function using a single copy.
+// XXX: This function is a duplicate of
+//      droption_t<bytesize_t>::convert_from_string
+//      Consider sharing the function using a single copy.
 bool
 config_reader_t::convert_string_to_size(const string &s, uint64_t &size)
 {

--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -1,0 +1,342 @@
+/* **********************************************************
+ * Copyright (c) 2018 Google, LLC  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, LLC nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, LLC OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "config_reader.h"
+
+#include <iostream>
+using namespace std;
+
+config_reader_t::config_reader_t()
+{
+    /* Empty. */
+}
+
+config_reader_t::~config_reader_t()
+{
+    fin.close();
+}
+
+bool
+config_reader_t::configure(const string &config_file,
+                           cache_simulator_knobs_t &knobs,
+                           std::map<string, cache_params_t*> &caches)
+{
+    // String used to construct meaningful error messages.
+    string error_msg;
+
+    // Open the config file.
+    fin.open(config_file);
+    if (!fin.is_open()) {
+        error_msg = "Failed to open the config file '" + config_file + "'\n";
+        ERRMSG(error_msg.c_str());
+        return false;
+    }
+
+    // Walk through the configuration file.
+    while (!fin.eof()) {
+        string param;
+        fin >> ws >> param;
+
+        if (param == "//") {
+            // A comment.
+            getline(fin, param);
+        }
+        else if (param == "num_cores") {
+            // Number of cache cores.
+            fin >> knobs.num_cores;
+            if (knobs.num_cores == 0) {
+                ERRMSG("Number of cores must be >0\n");
+                return false;
+            }
+        }
+        else if (param == "line_size") {
+            // Cache line size in bytes.
+            fin >> knobs.line_size;
+            if (knobs.line_size == 0) {
+                ERRMSG("Line size must be >0\n");
+                return false;
+            }
+        }
+        else if (param == "skip_refs") {
+            // Number of references to skip.
+            fin >> knobs.skip_refs;
+        }
+        else if (param == "warmup_refs") {
+            // Number of references to use for caches warmup.
+            fin >> knobs.warmup_refs;
+        }
+        else if (param == "warmup_fraction") {
+            // Fraction of cache lines that must be filled to end the warmup.
+            fin >> knobs.warmup_fraction;
+            if (knobs.warmup_fraction < 0.0 || knobs.warmup_fraction > 1.0) {
+                ERRMSG("Warmup fraction should be in [0.0, 1.0]\n");
+                return false;
+            }
+        }
+        else if (param == "sim_refs") {
+            // Number of references to simulate.
+            fin >> knobs.sim_refs;
+        }
+        else if (param == "cpu_scheduling") {
+            // Whether to simulate CPU scheduling or not.
+            string bool_val;
+            fin >> bool_val;
+            if (bool_val == "true" || bool_val == "True" ||
+                bool_val == "TRUE") {
+                knobs.cpu_scheduling = true;
+            }
+            else {
+                knobs.cpu_scheduling = false;
+            }
+        }
+        else if (param == "verbose") {
+            // Verbose level.
+            fin >> knobs.verbose;
+        }
+        else {
+            // A cache unit.
+            cache_params_t *cache = new cache_params_t;
+            cache->name = param;
+            if (!configure_cache(cache)) {
+                return false;
+            }
+            caches[cache->name] = cache;
+        }
+
+        fin >> ws;
+    }
+
+    // Check cache configuration.
+    return check_cache_config(knobs.num_cores, caches);
+}
+
+bool
+config_reader_t::configure_cache(cache_params_t *cache)
+{
+    // String used to construct meaningful error messages.
+    string error_msg;
+
+    char c;
+    fin >> ws >> c;
+    if (c != '{') {
+        ERRMSG("Expected '{' before cache params\n");
+        return false;
+    }
+
+    while (!fin.eof()) {
+        string param;
+        fin >> ws >> param;
+
+        if (param == "}") {
+            return true;
+        }
+        else if (param == "//") {
+            // A comment.
+            getline(fin, param);
+        }
+        else if (param == "type") {
+            // Cache type: instruction, data, or unified (default).
+            fin >> cache->type;
+            if (cache->type != "instruction" && cache->type != "data" &&
+                cache->type != "unified") {
+                error_msg = "Unknown cache type: " + cache->type + "\n";
+                ERRMSG(error_msg.c_str());
+                return false;
+            }
+        }
+        else if (param == "core") {
+            // CPU core this cache is associated with.
+            fin >> cache->core;
+        }
+        else if (param == "size") {
+            // Cache size in bytes.
+            fin >> cache->size;
+            if (cache->size <= 0 || !IS_POWER_OF_2(cache->size)) {
+                error_msg = "Cache size (" + to_string(cache->size) +
+                            ") must be >0 and a power of 2\n";
+                ERRMSG(error_msg.c_str());
+                return false;
+            }
+        }
+        else if (param == "assoc") {
+            // Cache associativity. Must be a power of 2.
+            fin >> cache->assoc;
+            if (cache->assoc <= 0 || !IS_POWER_OF_2(cache->assoc)) {
+                error_msg = "Cache associativity (" + to_string(cache->assoc) +
+                            ") must be >0 and a power of 2\n";
+                ERRMSG(error_msg.c_str());
+                return false;
+            }
+        }
+        else if (param == "inclusive") {
+            // Is the cache inclusive of its children.
+            string bool_val;
+            fin >> bool_val;
+            if (bool_val == "true" || bool_val == "True" || bool_val == "TRUE") {
+                cache->inclusive = true;
+            }
+        }
+        else if (param == "parent") {
+            // Name of the cache's parent. LLC's parent is main memory (mem).
+            fin >> cache->parent;
+        }
+        else if (param == "rplc_policy") {
+            // Cache replacement policy: LRU (default), LFU or FIFO.
+            fin >> cache->rplc_policy;
+            if (cache->rplc_policy != "LRU" && cache->rplc_policy != "LFU" &&
+                cache->rplc_policy != "FIFO") {
+                error_msg = "Unknown replacement policy: "
+                            + cache->rplc_policy + "\n";
+                ERRMSG(error_msg.c_str());
+                return false;
+            }
+        }
+        else if (param == "prefetcher") {
+            // Type of prefetcher: nextline or none.
+            fin >> cache->prefetcher;
+            if (cache->prefetcher != "none" && cache->prefetcher != "nextline") {
+                error_msg = "Unknown prefetcher type: "
+                            + cache->prefetcher + "\n";
+                ERRMSG(error_msg.c_str());
+                return false;
+            }
+        }
+        else if (param == "miss_file") {
+            // Name of the file to use to dump cache misses info.
+            fin >> cache->miss_file;
+        }
+        else {
+            error_msg = "Unknown cache configuration setting '" + param + "'\n";
+            ERRMSG(error_msg.c_str());
+            return false;
+        }
+        fin >> ws;
+    }
+
+    ERRMSG("Expected '}' at the end of cache params\n");
+    return false;
+}
+
+bool
+config_reader_t::check_cache_config(unsigned int num_cores,
+                                    std::map<string, cache_params_t*> &caches_map)
+{
+    // String used to construct meaningful error messages.
+    string error_msg;
+
+    int *core_inst_caches = new int[num_cores];
+    int *core_data_caches = new int[num_cores];
+    for (int i = 0; i < num_cores; i++) {
+        core_inst_caches[i] = 0;
+        core_data_caches[i] = 0;
+    }
+
+    for (auto &cache_map : caches_map) {
+        string cache_name = cache_map.first;
+        auto &cache = cache_map.second;
+
+        // Associate a cache to a core.
+        if (cache->core >= 0) {
+            if (cache->core >= num_cores) {
+                error_msg = "Cache " + cache_name + " is associated with core "
+                            + to_string(cache->core) +
+                            " which does not exist\n";
+                ERRMSG(error_msg.c_str());
+                return false;
+            }
+            if (cache->type == "instruction" || cache->type == "unified") {
+               core_inst_caches[cache->core]++;
+            }
+            if (cache->type == "data" || cache->type == "unified") {
+               core_data_caches[cache->core]++;
+            }
+        }
+
+        // Associate a cache with its parent and children caches.
+        if (cache->parent != "mem") {
+            auto parent_it = caches_map.find(cache->parent);
+            if (parent_it != caches_map.end()) {
+                auto &parent = parent_it->second;
+                // Check that the cache types are compatible.
+                if (parent->type != "unified" &&
+                    cache->type != parent->type) {
+                    error_msg = "Cache " + cache_name +
+                                " and its parent have incompatible types\n";
+                    ERRMSG(error_msg.c_str());
+                    return false;
+                }
+
+                // Add the cache to its parents children.
+                parent->children.push_back(cache_name);
+            }
+            else {
+                error_msg = "Cache " + cache_name + " has a listed parent "
+                            + cache->parent + " that does not exist\n";
+                ERRMSG(error_msg.c_str());
+                return false;
+            }
+
+            // Check for cycles between the cache and its parent.
+            string parent = cache->parent;
+            while (parent != "mem") {
+                if (parent == cache_name) {
+                    error_msg = "Cache " + cache_name + " and its parent " +
+                                cache->parent + " have a cyclic reference\n";
+                    ERRMSG(error_msg.c_str());
+                    return false;
+                }
+                parent = caches_map.find(parent)->second->parent;
+            }
+        }
+    }
+
+    // Check that each core has exactly one instruction and one data caches or
+    // exactly one unified cache.
+    for (int i = 0; i < num_cores; i++) {
+        if (core_inst_caches[i] != 1) {
+            error_msg = "Core " + to_string(i) + " has " +
+                        to_string(core_inst_caches[i]) +
+                        " instruction caches. Must have exactly 1\n";
+            ERRMSG(error_msg.c_str());
+            return false;
+        }
+        if (core_data_caches[i] != 1) {
+            error_msg = "Core " + to_string(i) + " has " +
+                        to_string(core_data_caches[i]) +
+                        " data caches. Must have exactly 1\n";
+            ERRMSG(error_msg.c_str());
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -341,7 +341,8 @@ config_reader_t::configure_cache(cache_params_t &cache)
 
 bool
 config_reader_t::check_cache_config(int num_cores,
-                                    std::map<string, cache_params_t> &caches_map)
+                                    std::map<string, cache_params_t>
+                                        &caches_map)
 {
     int *core_inst_caches = new int[num_cores];
     int *core_data_caches = new int[num_cores];

--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -76,7 +76,7 @@ config_reader_t::configure(const string &config_file,
         else if (param == "num_cores") {
             // Number of cache cores.
             if (!(fin >> knobs.num_cores)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading num_cores from the configuration file\n");
                 return false;
             }
             if (knobs.num_cores == 0) {
@@ -89,7 +89,7 @@ config_reader_t::configure(const string &config_file,
         else if (param == "line_size") {
             // Cache line size in bytes.
             if (!(fin >> knobs.line_size)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading line_size from the configuration file\n");
                 return false;
             }
             if (knobs.line_size == 0) {
@@ -100,21 +100,21 @@ config_reader_t::configure(const string &config_file,
         else if (param == "skip_refs") {
             // Number of references to skip.
             if (!(fin >> knobs.skip_refs)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading skip_refs from the configuration file\n");
                 return false;
             }
         }
         else if (param == "warmup_refs") {
             // Number of references to use for caches warmup.
             if (!(fin >> knobs.warmup_refs)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading warmup_refs from the configuration file\n");
                 return false;
             }
         }
         else if (param == "warmup_fraction") {
             // Fraction of cache lines that must be filled to end the warmup.
             if (!(fin >> knobs.warmup_fraction)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading warmup_fraction from the configuration file\n");
                 return false;
             }
             if (knobs.warmup_fraction < 0.0 || knobs.warmup_fraction > 1.0) {
@@ -125,7 +125,7 @@ config_reader_t::configure(const string &config_file,
         else if (param == "sim_refs") {
             // Number of references to simulate.
             if (!(fin >> knobs.sim_refs)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading sim_refs from the configuration file\n");
                 return false;
             }
         }
@@ -133,7 +133,7 @@ config_reader_t::configure(const string &config_file,
             // Whether to simulate CPU scheduling or not.
             string bool_val;
             if (!(fin >> bool_val)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading cpu_scheduling from the configuration file\n");
                 return false;
             }
             if (is_true(bool_val)) {
@@ -146,7 +146,7 @@ config_reader_t::configure(const string &config_file,
         else if (param == "verbose") {
             // Verbose level.
             if (!(fin >> knobs.verbose)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading verbose from the configuration file\n");
                 return false;
             }
         }
@@ -207,7 +207,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
             // Cache type: CACHE_TYPE_INSTRUCTION, CACHE_TYPE_DATA,
             // or CACHE_TYPE_UNIFIED.
             if (!(fin >> cache.type)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading cache type from the configuration file\n");
                 return false;
             }
             if (cache.type != CACHE_TYPE_INSTRUCTION &&
@@ -220,7 +220,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
         else if (param == "core") {
             // CPU core this cache is associated with.
             if (!(fin >> cache.core)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading cache core from the configuration file\n");
                 return false;
             }
         }
@@ -228,7 +228,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
             // Cache size in bytes.
             string size_str;
             if (!(fin >> size_str)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading cache size from the configuration file\n");
                 return false;
             }
             if (!convert_string_to_size(size_str, cache.size)) {
@@ -244,7 +244,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
         else if (param == "assoc") {
             // Cache associativity. Must be a power of 2.
             if (!(fin >> cache.assoc)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading cache assoc from the configuration file\n");
                 return false;
             }
             if (cache.assoc <= 0 || !IS_POWER_OF_2(cache.assoc)) {
@@ -257,7 +257,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
             // Is the cache inclusive of its children.
             string bool_val;
             if (!(fin >> bool_val)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading cache inclusivity from the configuration file\n");
                 return false;
             }
             if (is_true(bool_val)) {
@@ -271,7 +271,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
             // Name of the cache's parent. LLC's parent is main memory
             // (CACHE_PARENT_MEMORY).
             if (!(fin >> cache.parent)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading cache parent from the configuration file\n");
                 return false;
             }
         }
@@ -279,7 +279,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
             // Cache replacement policy: REPLACE_POLICY_LRU (default),
             // REPLACE_POLICY_LFU or REPLACE_POLICY_FIFO.
             if (!(fin >> cache.replace_policy)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading cache replace_policy from the configuration file\n");
                 return false;
             }
             if (cache.replace_policy != REPLACE_POLICY_NON_SPECIFIED &&
@@ -295,7 +295,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
             // Type of prefetcher: PREFETCH_POLICY_NEXTLINE
             // or PREFETCH_POLICY_NONE.
             if (!(fin >> cache.prefetcher)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading cache prefetcher from the configuration file\n");
                 return false;
             }
             if (cache.prefetcher != PREFETCH_POLICY_NEXTLINE &&
@@ -308,7 +308,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
         else if (param == "miss_file") {
             // Name of the file to use to dump cache misses info.
             if (!(fin >> cache.miss_file)) {
-                ERRMSG("Unable to read from the configuration file\n");
+                ERRMSG("Error reading cache miss_file from the configuration file\n");
                 return false;
             }
         }
@@ -349,10 +349,12 @@ config_reader_t::check_cache_config(int num_cores,
                        cache_name.c_str(), cache.core);
                 return false;
             }
-            if (cache.type == "instruction" || cache.type == "unified") {
+            if (cache.type == CACHE_TYPE_INSTRUCTION ||
+                cache.type == CACHE_TYPE_UNIFIED) {
                core_inst_caches[cache.core]++;
             }
-            if (cache.type == "data" || cache.type == "unified") {
+            if (cache.type == CACHE_TYPE_DATA ||
+                cache.type == CACHE_TYPE_UNIFIED) {
                core_data_caches[cache.core]++;
             }
         }
@@ -363,7 +365,7 @@ config_reader_t::check_cache_config(int num_cores,
             if (parent_it != caches_map.end()) {
                 auto &parent = parent_it->second;
                 // Check that the cache types are compatible.
-                if (parent.type != "unified" &&
+                if (parent.type != CACHE_TYPE_UNIFIED &&
                     cache.type != parent.type) {
                     ERRMSG("Cache %s and its parent have incompatible types\n",
                            cache_name.c_str());

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -1,0 +1,103 @@
+/* **********************************************************
+ * Copyright (c) 2018 Google, LLC  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, LLC nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, LLC OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* config_reader: reads, parses, and configures a cache hierarchy from a config
+ * file.
+ */
+
+#ifndef _CONFIG_READER_H_
+#define _CONFIG_READER_H_ 1
+
+#include <fstream>
+#include <map>
+#include <string>
+
+#include "../simulator/cache.h"
+#include "../simulator/cache_simulator_create.h"
+
+using namespace std;
+
+// Cache configuration settings.
+struct cache_params_t {
+    cache_params_t() :
+        type("unified"),
+        core(-1),
+        size(0),
+        assoc(0),
+        inclusive(false),
+        parent("mem"),
+        rplc_policy("LRU"),
+        prefetcher("none"),
+        miss_file("") {}
+    // Cache's name. Each cache must have a unique name.
+    string name;
+    // Cache type: instruction, data, or unified (default).
+    string type;
+    // CPU core this cache is associated with.
+    // Must be specified for L1 caches only.
+    int core;
+    // Cache size in bytes.
+    int size;
+    // Cache associativity. Must be a power of 2.
+    int assoc;
+    // Is the cache inclusive of its children.
+    bool inclusive;
+    // Name of the cache's parent. LLC's parent is main memory (mem).
+    string parent;
+    // Names of the cache's children. L1 caches don't have children.
+    std::vector<string> children;
+    // Cache replacement policy: LRU (default), LFU or FIFO.
+    string rplc_policy;
+    // Type of prefetcher: nextline or none.
+    string prefetcher;
+    // Name of the file to use to dump cache misses info.
+    string miss_file;
+};
+
+class config_reader_t
+{
+ public:
+    config_reader_t();
+    ~config_reader_t();
+    bool configure(const string &config_file,
+                   cache_simulator_knobs_t &knobs,
+                   std::map<string, cache_params_t*> &caches);
+
+ private:
+    std::ifstream fin;
+
+    bool configure_cache(cache_params_t *cache);
+    bool check_cache_config(unsigned int num_cores,
+                            std::map<string, cache_params_t*> &caches_map);
+};
+
+#endif /* _CONFIG_READER_H_ */

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -61,7 +61,8 @@ struct cache_params_t {
         miss_file("") {}
     // Cache's name. Each cache must have a unique name.
     string name;
-    // Cache type: INSTRUCTION_CACHE, DATA_CACHE, or UNIFIED_CACHE (default).
+    // Cache type: CACHE_TYPE_INSTRUCTION, CACHE_TYPE_DATA,
+    // or CACHE_TYPE_UNIFIED (default).
     string type;
     // CPU core this cache is associated with.
     // Must be specified for L1 caches only.
@@ -72,7 +73,7 @@ struct cache_params_t {
     unsigned int assoc;
     // Is the cache inclusive of its children.
     bool inclusive;
-    // Name of the cache's parent. LLC's parent is main memory (MEMORY).
+    // Name of the cache's parent. LLC's parent is main memory (CACHE_PARENT_MEMORY).
     string parent;
     // Names of the cache's children. L1 caches don't have children.
     std::vector<string> children;

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -77,10 +77,11 @@ struct cache_params_t {
     string parent;
     // Names of the cache's children. L1 caches don't have children.
     std::vector<string> children;
-    // Cache replacement policy: REPLACE_POLICY_LRU (default),
-    // REPLACE_POLICY_LFU or REPLACE_POLICY_FIFO.
+    // Cache replacement policy as described by the runtime option
+    // op_replace_policy (see ../common/options.cpp).
     string replace_policy;
-    // Type of prefetcher: PREFETCH_POLICY_NEXTLINE or PREFETCH_POLICY_NONE.
+    // Type of prefetcher as described by the runtime option
+    // op_data_prefetcher (see ../common/options.cpp).
     string prefetcher;
     // Name of the file to use to dump cache misses info.
     string miss_file;
@@ -102,7 +103,8 @@ class config_reader_t
     bool check_cache_config(int num_cores,
                             std::map<string, cache_params_t> &caches_map);
     bool convert_string_to_size(const string &s, uint64_t &size);
-    bool is_true(string bool_val) {
+    bool is_true(string bool_val)
+    {
         if (bool_val == "true" || bool_val == "True" || bool_val == "TRUE") {
             return true;
         }

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -50,12 +50,12 @@ using namespace std;
 // Cache configuration settings.
 struct cache_params_t {
     cache_params_t() :
-        type(UNIFIED_CACHE),
+        type(CACHE_TYPE_UNIFIED),
         core(-1),
         size(0),
         assoc(0),
         inclusive(false),
-        parent(MEMORY),
+        parent(CACHE_PARENT_MEMORY),
         replace_policy(REPLACE_POLICY_LRU),
         prefetcher(PREFETCH_POLICY_NONE),
         miss_file("") {}

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -73,7 +73,8 @@ struct cache_params_t {
     unsigned int assoc;
     // Is the cache inclusive of its children.
     bool inclusive;
-    // Name of the cache's parent. LLC's parent is main memory (CACHE_PARENT_MEMORY).
+    // Name of the cache's parent. LLC's parent is main memory
+    // (CACHE_PARENT_MEMORY).
     string parent;
     // Names of the cache's children. L1 caches don't have children.
     std::vector<string> children;

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -41,6 +41,7 @@
 #include <map>
 #include <string>
 
+#include "../common/options.h"
 #include "../simulator/cache.h"
 #include "../simulator/cache_simulator_create.h"
 
@@ -49,35 +50,36 @@ using namespace std;
 // Cache configuration settings.
 struct cache_params_t {
     cache_params_t() :
-        type("unified"),
+        type(UNIFIED_CACHE),
         core(-1),
         size(0),
         assoc(0),
         inclusive(false),
-        parent("mem"),
-        rplc_policy("LRU"),
-        prefetcher("none"),
+        parent(MEMORY),
+        replace_policy(REPLACE_POLICY_LRU),
+        prefetcher(PREFETCH_POLICY_NONE),
         miss_file("") {}
     // Cache's name. Each cache must have a unique name.
     string name;
-    // Cache type: instruction, data, or unified (default).
+    // Cache type: INSTRUCTION_CACHE, DATA_CACHE, or UNIFIED_CACHE (default).
     string type;
     // CPU core this cache is associated with.
     // Must be specified for L1 caches only.
     int core;
     // Cache size in bytes.
-    int size;
+    uint64_t size;
     // Cache associativity. Must be a power of 2.
-    int assoc;
+    unsigned int assoc;
     // Is the cache inclusive of its children.
     bool inclusive;
-    // Name of the cache's parent. LLC's parent is main memory (mem).
+    // Name of the cache's parent. LLC's parent is main memory (MEMORY).
     string parent;
     // Names of the cache's children. L1 caches don't have children.
     std::vector<string> children;
-    // Cache replacement policy: LRU (default), LFU or FIFO.
-    string rplc_policy;
-    // Type of prefetcher: nextline or none.
+    // Cache replacement policy: REPLACE_POLICY_LRU (default),
+    // REPLACE_POLICY_LFU or REPLACE_POLICY_FIFO.
+    string replace_policy;
+    // Type of prefetcher: PREFETCH_POLICY_NEXTLINE or PREFETCH_POLICY_NONE.
     string prefetcher;
     // Name of the file to use to dump cache misses info.
     string miss_file;
@@ -98,6 +100,13 @@ class config_reader_t
     bool configure_cache(cache_params_t *cache);
     bool check_cache_config(int num_cores,
                             std::map<string, cache_params_t*> &caches_map);
+    bool convert_string_to_size(const string &s, uint64_t &size);
+    bool is_true(string bool_val) {
+        if (bool_val == "true" || bool_val == "True" || bool_val == "TRUE") {
+            return true;
+        }
+        return false;
+    }
 };
 
 #endif /* _CONFIG_READER_H_ */

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -92,14 +92,14 @@ class config_reader_t
     ~config_reader_t();
     bool configure(const string &config_file,
                    cache_simulator_knobs_t &knobs,
-                   std::map<string, cache_params_t*> &caches);
+                   std::map<string, cache_params_t> &caches);
 
  private:
     std::ifstream fin;
 
-    bool configure_cache(cache_params_t *cache);
+    bool configure_cache(cache_params_t &cache);
     bool check_cache_config(int num_cores,
-                            const std::map<string, cache_params_t*> &caches_map);
+                            std::map<string, cache_params_t> &caches_map);
     bool convert_string_to_size(const string &s, uint64_t &size);
     bool is_true(string bool_val) {
         if (bool_val == "true" || bool_val == "True" || bool_val == "TRUE") {

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -96,7 +96,7 @@ class config_reader_t
     std::ifstream fin;
 
     bool configure_cache(cache_params_t *cache);
-    bool check_cache_config(unsigned int num_cores,
+    bool check_cache_config(int num_cores,
                             std::map<string, cache_params_t*> &caches_map);
 };
 

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -99,7 +99,7 @@ class config_reader_t
 
     bool configure_cache(cache_params_t *cache);
     bool check_cache_config(int num_cores,
-                            std::map<string, cache_params_t*> &caches_map);
+                            const std::map<string, cache_params_t*> &caches_map);
     bool convert_string_to_size(const string &s, uint64_t &size);
     bool is_true(string bool_val) {
         if (bool_val == "true" || bool_val == "True" || bool_val == "TRUE") {

--- a/clients/drcachesim/tests/config_reader_test.cpp
+++ b/clients/drcachesim/tests/config_reader_test.cpp
@@ -36,11 +36,11 @@
 #include "../simulator/cache.h"
 #include "../simulator/cache_simulator_create.h"
 
-void
-check_cache(std::map<string, cache_params_t*> caches,
-                 string name, string type, int core, uint64_t size,
-                 unsigned int assoc, bool inclusive, string parent,
-                 string replace_policy, string prefetcher, string miss_file) {
+static void
+check_cache(const std::map<string, cache_params_t*> &caches, string name,
+            string type, int core, uint64_t size, unsigned int assoc,
+            bool inclusive, string parent, string replace_policy,
+            string prefetcher, string miss_file) {
     auto cache_it = caches.find(name);
     if (cache_it == caches.end()) {
         std::cerr << "drcachesim config_reader_test failed (cache: "

--- a/clients/drcachesim/tests/config_reader_test.cpp
+++ b/clients/drcachesim/tests/config_reader_test.cpp
@@ -38,9 +38,9 @@
 
 void
 check_cache(std::map<string, cache_params_t*> caches,
-                 string name, string type, int core, int size, int assoc,
-                 bool inclusive, string parent, string rplc_policy,
-                 string prefetcher, string miss_file) {
+                 string name, string type, int core, uint64_t size,
+                 unsigned int assoc, bool inclusive, string parent,
+                 string replace_policy, string prefetcher, string miss_file) {
     auto cache_it = caches.find(name);
     if (cache_it == caches.end()) {
         std::cerr << "drcachesim config_reader_test failed (cache: "
@@ -56,7 +56,7 @@ check_cache(std::map<string, cache_params_t*> caches,
         cache->assoc != assoc ||
         cache->inclusive != inclusive ||
         cache->parent != parent ||
-        cache->rplc_policy != rplc_policy ||
+        cache->replace_policy != replace_policy ||
         cache->prefetcher != prefetcher ||
         cache->miss_file != miss_file) {
         std::cerr << "drcachesim config_reader_test failed (cache: "
@@ -73,7 +73,10 @@ main(int argc, const char *argv[])
     string file_name = "single_core.conf";
 
     config_reader_t config;
-    config.configure(file_name, knobs, caches);
+    if (!config.configure(file_name, knobs, caches)) {
+       std::cerr << "drcachesim config_reader_test failed (config error)\n";
+       exit(1);
+    }
 
     if (knobs.num_cores != 1 ||
         knobs.line_size != 64 ||
@@ -102,7 +105,7 @@ main(int argc, const char *argv[])
         }
         else if (cache_map.first == "LLC") {
             check_cache(caches, "LLC", "unified", -1, 1048576, 16, true,
-                        "mem", "LRU", "none", "misses.txt");
+                        "memory", "LRU", "none", "misses.txt");
         }
         else {
             std::cerr << "drcachesim config_reader_test failed (unknown cache)\n";

--- a/clients/drcachesim/tests/config_reader_test.cpp
+++ b/clients/drcachesim/tests/config_reader_test.cpp
@@ -1,0 +1,114 @@
+/* **********************************************************
+ * Copyright (c) 2018 Google, LLC  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, LLC nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, LLC OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+
+#include <iostream>
+#include "../reader/config_reader.h"
+#include "../simulator/cache.h"
+#include "../simulator/cache_simulator_create.h"
+
+void
+check_cache(std::map<string, cache_params_t*> caches,
+                 string name, string type, int core, int size, int assoc,
+                 bool inclusive, string parent, string rplc_policy,
+                 string prefetcher, string miss_file) {
+    auto cache_it = caches.find(name);
+    if (cache_it == caches.end()) {
+        std::cerr << "drcachesim config_reader_test failed (cache: "
+                  << name << " unfound)\n";
+        exit(1);
+    }
+
+    auto &cache = cache_it->second;
+
+    if (cache->type != type ||
+        cache->core != core ||
+        cache->size != size ||
+        cache->assoc != assoc ||
+        cache->inclusive != inclusive ||
+        cache->parent != parent ||
+        cache->rplc_policy != rplc_policy ||
+        cache->prefetcher != prefetcher ||
+        cache->miss_file != miss_file) {
+        std::cerr << "drcachesim config_reader_test failed (cache: "
+                  << cache->name << ")\n";
+        exit(1);
+    }
+}
+
+int
+main(int argc, const char *argv[])
+{
+    cache_simulator_knobs_t knobs;
+    std::map<string, cache_params_t*> caches;
+    string file_name = "single_core.conf";
+
+    config_reader_t config;
+    config.configure(file_name, knobs, caches);
+
+    if (knobs.num_cores != 1 ||
+        knobs.line_size != 64 ||
+        knobs.skip_refs != 1000000 ||
+        knobs.warmup_refs != 0 ||
+        knobs.warmup_fraction != 0.8 ||
+        knobs.sim_refs != 8888888 ||
+        knobs.cpu_scheduling != true ||
+        knobs.verbose != 0) {
+        std::cerr << "drcachesim config_reader_test failed (common params)\n";
+        exit(1);
+    }
+
+    for (auto &cache_map : caches) {
+        if (cache_map.first == "P0L1I") {
+            check_cache(caches, "P0L1I", "instruction", 0, 65536, 8, false,
+                        "P0L2", "LRU", "none", "");
+        }
+        else if (cache_map.first == "P0L1D") {
+            check_cache(caches, "P0L1D", "data", 0, 65536, 8, false,
+                        "P0L2", "LRU", "none", "");
+        }
+        else if (cache_map.first == "P0L2") {
+            check_cache(caches, "P0L2", "unified", -1, 524288, 16, true,
+                        "LLC", "LRU", "none", "");
+        }
+        else if (cache_map.first == "LLC") {
+            check_cache(caches, "LLC", "unified", -1, 1048576, 16, true,
+                        "mem", "LRU", "none", "misses.txt");
+        }
+        else {
+            std::cerr << "drcachesim config_reader_test failed (unknown cache)\n";
+            exit(1);
+        }
+    }
+
+    return 0;
+}

--- a/clients/drcachesim/tests/config_reader_test.cpp
+++ b/clients/drcachesim/tests/config_reader_test.cpp
@@ -37,7 +37,7 @@
 #include "../simulator/cache_simulator_create.h"
 
 static void
-check_cache(const std::map<string, cache_params_t*> &caches, string name,
+check_cache(const std::map<string, cache_params_t> &caches, string name,
             string type, int core, uint64_t size, unsigned int assoc,
             bool inclusive, string parent, string replace_policy,
             string prefetcher, string miss_file) {
@@ -50,17 +50,17 @@ check_cache(const std::map<string, cache_params_t*> &caches, string name,
 
     auto &cache = cache_it->second;
 
-    if (cache->type != type ||
-        cache->core != core ||
-        cache->size != size ||
-        cache->assoc != assoc ||
-        cache->inclusive != inclusive ||
-        cache->parent != parent ||
-        cache->replace_policy != replace_policy ||
-        cache->prefetcher != prefetcher ||
-        cache->miss_file != miss_file) {
+    if (cache.type != type ||
+        cache.core != core ||
+        cache.size != size ||
+        cache.assoc != assoc ||
+        cache.inclusive != inclusive ||
+        cache.parent != parent ||
+        cache.replace_policy != replace_policy ||
+        cache.prefetcher != prefetcher ||
+        cache.miss_file != miss_file) {
         std::cerr << "drcachesim config_reader_test failed (cache: "
-                  << cache->name << ")\n";
+                  << cache.name << ")\n";
         exit(1);
     }
 }
@@ -69,7 +69,7 @@ int
 main(int argc, const char *argv[])
 {
     cache_simulator_knobs_t knobs;
-    std::map<string, cache_params_t*> caches;
+    std::map<string, cache_params_t> caches;
     string file_name = "single_core.conf";
 
     config_reader_t config;

--- a/clients/drcachesim/tests/single_core.conf
+++ b/clients/drcachesim/tests/single_core.conf
@@ -10,33 +10,33 @@ warmup_fraction 0.8
 
 // Cache params.
 P0L1I {                        // P0 L1 I$
-  type          instruction
-  core          0
-  size          65536
-  assoc         8
-  parent        P0L2
-  rplc_policy   LRU
+  type            instruction
+  core            0
+  size            65536
+  assoc           8
+  parent          P0L2
+  replace_policy  LRU
 }
 P0L1D {                        // P0 L1 D$
-  type          data
-  core          0
-  size          65536
-  assoc         8
-  parent        P0L2
-  rplc_policy   LRU
+  type            data
+  core            0
+  size            65536
+  assoc           8
+  parent          P0L2
+  replace_policy  LRU
 }
 P0L2 {                         // P0 L2$
-  size          524288
-  assoc         16
-  inclusive     true
-  parent        LLC
-  rplc_policy   LRU
+  size            512K
+  assoc           16
+  inclusive       true
+  parent          LLC
+  replace_policy  LRU
 }
 LLC {                          // LLC
-  size          1048576
-  assoc         16
-  inclusive     true
-  parent        mem
-  rplc_policy   LRU
-  miss_file     misses.txt
+  size            1M
+  assoc           16
+  inclusive       true
+  parent          memory
+  replace_policy  LRU
+  miss_file       misses.txt
 }

--- a/clients/drcachesim/tests/single_core.conf
+++ b/clients/drcachesim/tests/single_core.conf
@@ -1,0 +1,42 @@
+// Configuration for a single-core CPU.
+
+// Common params.
+num_cores       1
+line_size       64
+cpu_scheduling  true
+sim_refs        8888888
+skip_refs       1000000
+warmup_fraction 0.8
+
+// Cache params.
+P0L1I {                        // P0 L1 I$
+  type          instruction
+  core          0
+  size          65536
+  assoc         8
+  parent        P0L2
+  rplc_policy   LRU
+}
+P0L1D {                        // P0 L1 D$
+  type          data
+  core          0
+  size          65536
+  assoc         8
+  parent        P0L2
+  rplc_policy   LRU
+}
+P0L2 {                         // P0 L2$
+  size          524288
+  assoc         16
+  inclusive     true
+  parent        LLC
+  rplc_policy   LRU
+}
+LLC {                          // LLC
+  size          1048576
+  assoc         16
+  inclusive     true
+  parent        mem
+  rplc_policy   LRU
+  miss_file     misses.txt
+}


### PR DESCRIPTION
Currently, DRCacheSim only supports a 2-level non-inclusive cache hierarchy. For DRCacheSim to be more useful, it should be able to support a wide range of different cache hierarchy configurations. A cache hierarchy should be defined in a configuration file that is read by the analyzer. This change adds support for reading and parsing a configuration file. Support in the cache simulator will follow in the next change.