### PR TITLE
i#3049 bug-drwrap-exit: drwrap not clean up when exit

### DIFF
--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -431,6 +431,11 @@ drmgr_exit(void)
 
     if (bb_event_count > 0)
         dr_unregister_bb_event(drmgr_bb_event);
+
+    bb_event_count = 0;
+    pair_count = 0;
+    quartet_count = 0;
+
     if (registered_fault) {
         dr_unregister_restore_state_ex_event(drmgr_restore_state_event);
         registered_fault = false;

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -974,12 +974,16 @@ drwrap_exit(void)
     if (count != 0)
         return;
 
-    drmgr_unregister_bb_app2app_event(drwrap_event_bb_app2app);
-    drmgr_unregister_bb_instrumentation_event(drwrap_event_bb_analysis);
-    drmgr_unregister_module_unload_event(drwrap_event_module_unload);
-    dr_unregister_delete_event(drwrap_fragment_delete);
-
-    drmgr_unregister_tls_field(tls_idx);
+    ASSERT(drmgr_unregister_bb_app2app_event(drwrap_event_bb_app2app),
+           "failed to unregister bb_app2app_event");
+    ASSERT(drmgr_unregister_bb_instrumentation_event(drwrap_event_bb_analysis),
+           "failed to unregister bb_instrumentation_event");
+    ASSERT(drmgr_unregister_module_unload_event(drwrap_event_module_unload),
+           "failed to unregister odule_unload_event");
+    ASSERT(dr_unregister_delete_event(drwrap_fragment_delete),
+           "failed to unregister delete_event");
+    ASSERT(drmgr_unregister_tls_field(tls_idx),
+           "failed to unregister tls_field");
 
     hashtable_delete(&replace_table);
     hashtable_delete(&replace_native_table);

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -974,6 +974,13 @@ drwrap_exit(void)
     if (count != 0)
         return;
 
+    drmgr_unregister_bb_app2app_event(drwrap_event_bb_app2app);
+    drmgr_unregister_bb_instrumentation_event(drwrap_event_bb_analysis);
+    drmgr_unregister_module_unload_event(drwrap_event_module_unload);
+    dr_unregister_delete_event(drwrap_fragment_delete);
+
+    drmgr_unregister_tls_field(tls_idx);
+
     hashtable_delete(&replace_table);
     hashtable_delete(&replace_native_table);
     hashtable_delete(&wrap_table);

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -974,16 +974,12 @@ drwrap_exit(void)
     if (count != 0)
         return;
 
-    ASSERT(drmgr_unregister_bb_app2app_event(drwrap_event_bb_app2app),
-           "failed to unregister bb_app2app_event");
-    ASSERT(drmgr_unregister_bb_instrumentation_event(drwrap_event_bb_analysis),
-           "failed to unregister bb_instrumentation_event");
-    ASSERT(drmgr_unregister_module_unload_event(drwrap_event_module_unload),
-           "failed to unregister odule_unload_event");
-    ASSERT(dr_unregister_delete_event(drwrap_fragment_delete),
-           "failed to unregister delete_event");
-    ASSERT(drmgr_unregister_tls_field(tls_idx),
-           "failed to unregister tls_field");
+    if (!drmgr_unregister_bb_app2app_event(drwrap_event_bb_app2app) ||
+        !drmgr_unregister_bb_instrumentation_event(drwrap_event_bb_analysis) ||
+        !drmgr_unregister_module_unload_event(drwrap_event_module_unload) ||
+        !drmgr_unregister_tls_field(tls_idx) ||
+        !dr_unregister_delete_event(drwrap_fragment_delete))
+        ASSERT(false, "failed to unregister in drwrap_exit");
 
     hashtable_delete(&replace_table);
     hashtable_delete(&replace_native_table);


### PR DESCRIPTION
1) Add code to clean all resources allocated on drwrap_init

Fixes [i3049](https://github.com/DynamoRIO/dynamorio/issues/3049)