### PR TITLE
i#2463 prepop: add indirect branch table pre-population

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -234,6 +234,8 @@ Further non-compatibility-affecting changes include:
  - drmodtrack now allocates an entry per segment for each loaded module.
    Added a file offset field to module_segment_data_t for UNIX platforms.
    drcachesim saves file offset information in modules.log on UNIX platforms.
+ - Added dr_prepopulate_cache() and dr_prepopulate_indirect_targets() for
+   setting up the code cache prior to execution.
 
 **************************************************
 <hr>

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -6225,6 +6225,36 @@ DR_API
 bool
 dr_prepopulate_cache(app_pc *tags, size_t tags_count);
 
+/* DR_API EXPORT BEGIN */
+/**
+ * Specifies the type of indirect branch for use with dr_prepopulate_indirect_targets().
+ */
+typedef enum {
+    DR_INDIRECT_RETURN, /**< Return instruction type. */
+    DR_INDIRECT_CALL,   /**< Indirect call instruction type. */
+    DR_INDIRECT_JUMP,   /**< Indirect jump instruction type. */
+} dr_indirect_branch_type_t;
+/* DR_API EXPORT END */
+
+DR_API
+/**
+ * Intended to augment dr_prepopulate_cache() by populating DR's indirect branch
+ * tables, avoiding trips back to dispatch during initial execution.  This is only
+ * effective when one of the the runtime options -shared_trace_ibt_tables and
+ * -shared_bb_ibt_tables (depending on whether traces are enabled) is turned on, as
+ * this routine does not try to populate tables belonging to threads other than the
+ * calling thread.
+ *
+ * This is meant to be called between dr_app_setup() and dr_app_start(), immediately
+ * after calling dr_prepopulate_cache().  It adds entries for each target address in
+ * the \p tags array to the indirect branch table for the branch type \p branch_type.
+ *
+ * Returns whether successful.
+ */
+bool
+dr_prepopulate_indirect_targets(dr_indirect_branch_type_t branch_type,
+                                app_pc *tags, size_t tags_count);
+
 DR_API
 /**
  * Get the number of blocks built so far, globally. The API is not thread-safe.

--- a/suite/tests/api/static_prepop.expect
+++ b/suite/tests/api/static_prepop.expect
@@ -4,6 +4,7 @@ bb asm_func
 bb asm_label1
 bb asm_label2
 bb asm_label3
+bb asm_return
 pre-DR start
 pre-DR detach
 Exit event
@@ -13,6 +14,7 @@ bb asm_func
 bb asm_label1
 bb asm_label2
 bb asm_label3
+bb asm_return
 pre-DR start
 pre-DR detach with stats
 Exit event

--- a/suite/tests/api/static_signal.c
+++ b/suite/tests/api/static_signal.c
@@ -175,16 +175,6 @@ do_some_work(void)
     return (val > 0);
 }
 
-bool
-my_setenv(const char *var, const char *value)
-{
-#ifdef UNIX
-    return setenv(var, value, 1/*override*/) == 0;
-#else
-    return SetEnvironmentVariable(var, value) == TRUE;
-#endif
-}
-
 int
 main(int argc, const char *argv[])
 {

--- a/suite/tests/tools.h
+++ b/suite/tests/tools.h
@@ -753,4 +753,14 @@ __asm {             \
 }
 #endif
 
+static inline bool
+my_setenv(const char *var, const char *value)
+{
+#ifdef UNIX
+    return setenv(var, value, 1/*override*/) == 0;
+#else
+    return SetEnvironmentVariable(var, value) == TRUE;
+#endif
+}
+
 #endif /* TOOLS_H */


### PR DESCRIPTION
Adds dr_prepopulate_indirect_targets() for filling in indirect branch
target tables to avoid trips to dispatch when attaching.

Adds a test to api.static_prepop.

Issue: #2463