### PR TITLE
i#2626 AArch64 encoder: Add encoding group SIMD three same & fp16

### DIFF
--- a/core/arch/aarch64/codec.txt
+++ b/core/arch/aarch64/codec.txt
@@ -970,4 +970,110 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 1001111001100111000000xxxxxxxxxx     fmov d0 : x5
 1001111010101111000000xxxxxxxxxx     fmov q0 : x5 # only sets the bit top half of q0
 
+# Advanced SIMD three same (FP16)
+0x001110010xxxxx000001xxxxxxxxxx     fmaxnm    dq0 : dq5 dq16 h_sz
+0x001110010xxxxx000011xxxxxxxxxx     fmla      dq0 : dq0 dq5 dq16 h_sz
+0x001110010xxxxx000101xxxxxxxxxx     fadd      dq0 : dq5 dq16 h_sz
+0x001110010xxxxx000111xxxxxxxxxx     fmulx     dq0 : dq5 dq16 h_sz
+0x001110010xxxxx001001xxxxxxxxxx     fcmeq     dq0 : dq5 dq16 h_sz
+0x001110010xxxxx001101xxxxxxxxxx     fmax      dq0 : dq5 dq16 h_sz
+0x001110010xxxxx001111xxxxxxxxxx     frecps    dq0 : dq5 dq16 h_sz
+0x001110110xxxxx000001xxxxxxxxxx     fminnm    dq0 : dq5 dq16 h_sz
+0x001110110xxxxx000011xxxxxxxxxx     fmls      dq0 : dq0 dq5 dq16 h_sz
+0x001110110xxxxx000101xxxxxxxxxx     fsub      dq0 : dq5 dq16 h_sz
+0x001110110xxxxx001101xxxxxxxxxx     fmin      dq0 : dq5 dq16 h_sz
+0x001110110xxxxx001111xxxxxxxxxx     frsqrts   dq0 : dq5 dq16 h_sz
+0x101110010xxxxx000001xxxxxxxxxx     fmaxnmp   dq0 : dq5 dq16 h_sz
+0x101110010xxxxx000101xxxxxxxxxx     faddp     dq0 : dq5 dq16 h_sz
+0x101110010xxxxx000111xxxxxxxxxx     fmul      dq0 : dq5 dq16 h_sz
+0x101110010xxxxx001001xxxxxxxxxx     fcmge     dq0 : dq5 dq16 h_sz
+0x101110010xxxxx001011xxxxxxxxxx     facge     dq0 : dq5 dq16 h_sz
+0x101110010xxxxx001101xxxxxxxxxx     fmaxp     dq0 : dq5 dq16 h_sz
+0x101110010xxxxx001111xxxxxxxxxx     fdiv      dq0 : dq5 dq16 h_sz
+0x101110110xxxxx000001xxxxxxxxxx     fminnmp   dq0 : dq5 dq16 h_sz
+0x101110110xxxxx000101xxxxxxxxxx     fabd      dq0 : dq5 dq16 h_sz
+0x101110110xxxxx001001xxxxxxxxxx     fcmgt     dq0 : dq5 dq16 h_sz
+0x101110110xxxxx001011xxxxxxxxxx     facgt     dq0 : dq5 dq16 h_sz
+0x101110110xxxxx001101xxxxxxxxxx     fminp     dq0 : dq5 dq16 h_sz
 # Advanced SIMD three same
+0x001110xx1xxxxx000001xxxxxxxxxx     shadd     dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx000011xxxxxxxxxx     sqadd     dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx000101xxxxxxxxxx     srhadd    dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx001001xxxxxxxxxx     shsub     dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx001011xxxxxxxxxx     sqsub     dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx001101xxxxxxxxxx     cmgt      dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx001111xxxxxxxxxx     cmge      dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx010001xxxxxxxxxx     sshl      dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx010011xxxxxxxxxx     sqshl     dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx010101xxxxxxxxxx     srshl     dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx010111xxxxxxxxxx     sqrshl    dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx011001xxxxxxxxxx     smax      dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx011011xxxxxxxxxx     smin      dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx011101xxxxxxxxxx     sabd      dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx011111xxxxxxxxxx     saba      dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx100001xxxxxxxxxx     add       dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx100011xxxxxxxxxx     cmtst     dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx100101xxxxxxxxxx     mla       dq0 : dq0 dq5 dq16 bhs_sz
+0x001110xx1xxxxx100111xxxxxxxxxx     mul       dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx101001xxxxxxxxxx     smaxp     dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx101011xxxxxxxxxx     sminp     dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx101101xxxxxxxxxx     sqdmulh   dq0 : dq5 dq16 hs_sz
+0x001110xx1xxxxx101111xxxxxxxxxx     addp      dq0 : dq5 dq16 bhsd_sz
+0x0011100x1xxxxx110001xxxxxxxxxx     fmaxnm    dq0 : dq5 dq16 sd_sz
+0x0011100x1xxxxx110011xxxxxxxxxx     fmla      dq0 : dq0 dq5 dq16 sd_sz
+0x0011100x1xxxxx110101xxxxxxxxxx     fadd      dq0 : dq5 dq16 sd_sz
+0x0011100x1xxxxx110111xxxxxxxxxx     fmulx     dq0 : dq5 dq16 sd_sz
+0x0011100x1xxxxx111001xxxxxxxxxx     fcmeq     dq0 : dq5 dq16 sd_sz
+0x001110001xxxxx111011xxxxxxxxxx     fmlal     dq0 : dq0 dq5 dq16
+0x0011100x1xxxxx111101xxxxxxxxxx     fmax      dq0 : dq5 dq16 sd_sz
+0x0011100x1xxxxx111111xxxxxxxxxx     frecps    dq0 : dq5 dq16 sd_sz
+0x001110001xxxxx000111xxxxxxxxxx     and       dq0 : dq5 dq16
+0x001110011xxxxx000111xxxxxxxxxx     bic       dq0 : dq5 dq16
+0x0011101x1xxxxx110001xxxxxxxxxx     fminnm    dq0 : dq5 dq16 sd_sz
+0x0011101x1xxxxx110011xxxxxxxxxx     fmls      dq0 : dq0 dq5 dq16 sd_sz
+0x0011101x1xxxxx110101xxxxxxxxxx     fsub      dq0 : dq5 dq16 sd_sz
+0x001110101xxxxx111011xxxxxxxxxx     fmlsl     dq0 : dq0 dq5 dq16
+0x0011101x1xxxxx111101xxxxxxxxxx     fmin      dq0 : dq5 dq16 sd_sz
+0x0011101x1xxxxx111111xxxxxxxxxx     frsqrts   dq0 : dq5 dq16 sd_sz
+0x001110101xxxxx000111xxxxxxxxxx     orr       dq0 : dq5 dq16
+0x001110111xxxxx000111xxxxxxxxxx     orn       dq0 : dq5 dq16
+0x101110xx1xxxxx000001xxxxxxxxxx     uhadd     dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx000011xxxxxxxxxx     uqadd     dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx000101xxxxxxxxxx     urhadd    dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx001001xxxxxxxxxx     uhsub     dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx001011xxxxxxxxxx     uqsub     dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx001101xxxxxxxxxx     cmhi      dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx001111xxxxxxxxxx     cmhs      dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx010001xxxxxxxxxx     ushl      dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx010011xxxxxxxxxx     uqshl     dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx010101xxxxxxxxxx     urshl     dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx010111xxxxxxxxxx     uqrshl    dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx011001xxxxxxxxxx     umax      dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx011011xxxxxxxxxx     umin      dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx011101xxxxxxxxxx     uabd      dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx011111xxxxxxxxxx     uaba      dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx100001xxxxxxxxxx     sub       dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx100011xxxxxxxxxx     cmeq      dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx100101xxxxxxxxxx     mls       dq0 : dq0 dq5 dq16 bhs_sz
+0x101110xx1xxxxx100111xxxxxxxxxx     pmul      dq0 : dq5 dq16 b_sz
+0x101110xx1xxxxx101001xxxxxxxxxx     umaxp     dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx101011xxxxxxxxxx     uminp     dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx101101xxxxxxxxxx     sqrdmulh  dq0 : dq5 dq16 hs_sz
+0x1011100x1xxxxx110001xxxxxxxxxx     fmaxnmp   dq0 : dq5 dq16 sd_sz
+0x101110001xxxxx110011xxxxxxxxxx     fmlal2    dq0 : dq0 dq5 dq16
+0x1011100x1xxxxx110101xxxxxxxxxx     faddp     dq0 : dq5 dq16 sd_sz
+0x1011100x1xxxxx110111xxxxxxxxxx     fmul      dq0 : dq5 dq16 sd_sz
+0x1011100x1xxxxx111001xxxxxxxxxx     fcmge     dq0 : dq5 dq16 sd_sz
+0x1011100x1xxxxx111011xxxxxxxxxx     facge     dq0 : dq5 dq16 sd_sz
+0x1011100x1xxxxx111101xxxxxxxxxx     fmaxp     dq0 : dq5 dq16 sd_sz
+0x1011100x1xxxxx111111xxxxxxxxxx     fdiv      dq0 : dq5 dq16 sd_sz
+0x101110001xxxxx000111xxxxxxxxxx     eor       dq0 : dq5 dq16
+0x101110011xxxxx000111xxxxxxxxxx     bsl       dq0 : dq5 dq16
+0x1011101x1xxxxx110001xxxxxxxxxx     fminnmp   dq0 : dq5 dq16 sd_sz
+0x101110101xxxxx110011xxxxxxxxxx     fmlsl2    dq0 : dq0 dq5 dq16
+0x1011101x1xxxxx110101xxxxxxxxxx     fabd      dq0 : dq5 dq16 sd_sz
+0x1011101x1xxxxx111001xxxxxxxxxx     fcmgt     dq0 : dq5 dq16 sd_sz
+0x1011101x1xxxxx111011xxxxxxxxxx     facgt     dq0 : dq5 dq16 sd_sz
+0x1011101x1xxxxx111101xxxxxxxxxx     fminp     dq0 : dq5 dq16 sd_sz
+0x101110101xxxxx000111xxxxxxxxxx     bit       dq0 : dq5 dq16
+0x101110111xxxxx000111xxxxxxxxxx     bif       dq0 : dq5 dq16

--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -617,7 +617,7 @@
 #define INSTR_CREATE_fmov_general(dc, Rd, Rn) \
     instr_create_1dst_1src(dc, OP_fmov, Rd, Rn)
 
-/* -------- Advanced SIMD three same ----------------------------------- */
+/* -------- Advanced SIMD three same including fp16 versions ---------------- */
 
 /**
  * Creates a SHADD vector instruction.
@@ -625,8 +625,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_shadd_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_shadd, Rd, Rm, Rn, width)
@@ -637,8 +637,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_sqadd_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_sqadd, Rd, Rm, Rn, width)
@@ -649,8 +649,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_srhadd_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_srhadd, Rd, Rm, Rn, width)
@@ -661,8 +661,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_shsub_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_shsub, Rd, Rm, Rn, width)
@@ -673,8 +673,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_sqsub_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_sqsub, Rd, Rm, Rn, width)
@@ -685,8 +685,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_cmgt_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_cmgt, Rd, Rm, Rn, width)
@@ -697,8 +697,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_cmge_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_cmge, Rd, Rm, Rn, width)
@@ -709,8 +709,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_sshl_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_sshl, Rd, Rm, Rn, width)
@@ -721,8 +721,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_sqshl_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_sqshl, Rd, Rm, Rn, width)
@@ -733,8 +733,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_srshl_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_srshl, Rd, Rm, Rn, width)
@@ -745,8 +745,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_sqrshl_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_sqrshl, Rd, Rm, Rn, width)
@@ -757,8 +757,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_smax_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_smax, Rd, Rm, Rn, width)
@@ -769,8 +769,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_smin_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_smin, Rd, Rm, Rn, width)
@@ -781,8 +781,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_sabd_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_sabd, Rd, Rm, Rn, width)
@@ -793,8 +793,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_saba_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_saba, Rd, Rm, Rn, width)
@@ -805,8 +805,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_add_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_add, Rd, Rm, Rn, width)
@@ -817,8 +817,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_cmtst_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_cmtst, Rd, Rm, Rn, width)
@@ -829,8 +829,8 @@
  * \param Rd      The output register. The instruction also reads this register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_mla_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_4src(dc, OP_mla, Rd, Rd, Rm, Rn, width)
@@ -841,8 +841,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_mul_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_mul, Rd, Rm, Rn, width)
@@ -853,8 +853,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_smaxp_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_smaxp, Rd, Rm, Rn, width)
@@ -865,8 +865,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_sminp_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_sminp, Rd, Rm, Rn, width)
@@ -877,7 +877,7 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ * \param width   The vector element width. Use either OPND_CREATE_HALF() or
  *                OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_sqdmulh_vector(dc, Rd, Rm, Rn, width) \
@@ -889,8 +889,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_addp_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_addp, Rd, Rm, Rn, width)
@@ -1105,8 +1105,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_uhadd_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_uhadd, Rd, Rm, Rn, width)
@@ -1117,8 +1117,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_uqadd_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_uqadd, Rd, Rm, Rn, width)
@@ -1129,8 +1129,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_urhadd_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_urhadd, Rd, Rm, Rn, width)
@@ -1141,8 +1141,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_uhsub_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_uhsub, Rd, Rm, Rn, width)
@@ -1153,8 +1153,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_uqsub_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_uqsub, Rd, Rm, Rn, width)
@@ -1165,8 +1165,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_cmhi_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_cmhi, Rd, Rm, Rn, width)
@@ -1177,8 +1177,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_cmhs_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_cmhs, Rd, Rm, Rn, width)
@@ -1189,8 +1189,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_ushl_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_ushl, Rd, Rm, Rn, width)
@@ -1201,8 +1201,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_uqshl_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_uqshl, Rd, Rm, Rn, width)
@@ -1213,8 +1213,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_urshl_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_urshl, Rd, Rm, Rn, width)
@@ -1225,8 +1225,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_uqrshl_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_uqrshl, Rd, Rm, Rn, width)
@@ -1237,8 +1237,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_umax_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_umax, Rd, Rm, Rn, width)
@@ -1249,8 +1249,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_umin_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_umin, Rd, Rm, Rn, width)
@@ -1261,8 +1261,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_uabd_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_uabd, Rd, Rm, Rn, width)
@@ -1273,8 +1273,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_uaba_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_uaba, Rd, Rm, Rn, width)
@@ -1285,8 +1285,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_sub_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_sub, Rd, Rm, Rn, width)
@@ -1297,8 +1297,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_cmeq_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_cmeq, Rd, Rm, Rn, width)
@@ -1309,8 +1309,8 @@
  * \param Rd      The output register. The instruction also reads this register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_mls_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_4src(dc, OP_mls, Rd, Rd, Rm, Rn, width)
@@ -1321,7 +1321,7 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE().
+ * \param width   The vector element width. Use OPND_CREATE_BYTE().
  */
 #define INSTR_CREATE_pmul_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_pmul, Rd, Rm, Rn, width)
@@ -1332,8 +1332,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_umaxp_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_umaxp, Rd, Rm, Rn, width)
@@ -1344,8 +1344,8 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE().
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
+ *                OPND_CREATE_HALF() or OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_uminp_vector(dc, Rd, Rm, Rn, width) \
     instr_create_1dst_3src(dc, OP_uminp, Rd, Rm, Rn, width)
@@ -1356,7 +1356,7 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ * \param width   The vector element width. Use either OPND_CREATE_HALF() or
  *                OPND_CREATE_SINGLE().
  */
 #define INSTR_CREATE_sqrdmulh_vector(dc, Rd, Rm, Rn, width) \

--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -617,179 +617,287 @@
 #define INSTR_CREATE_fmov_general(dc, Rd, Rn) \
     instr_create_1dst_1src(dc, OP_fmov, Rd, Rn)
 
+/* -------- Advanced SIMD three same ----------------------------------- */
+
 /**
- * Creates a FABD vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * Creates a SHADD vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_shadd_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_shadd, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SQADD vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_sqadd_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_sqadd, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SRHADD vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_srhadd_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_srhadd, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SHSUB vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_shsub_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_shsub, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SQSUB vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_sqsub_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_sqsub, Rd, Rm, Rn, width)
+
+/**
+ * Creates a CMGT vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_cmgt_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_cmgt, Rd, Rm, Rn, width)
+
+/**
+ * Creates a CMGE vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_cmge_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_cmge, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SSHL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_sshl_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_sshl, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SQSHL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_sqshl_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_sqshl, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SRSHL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_srshl_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_srshl, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SQRSHL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_sqrshl_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_sqrshl, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SMAX vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_smax_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_smax, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SMIN vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_smin_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_smin, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SABD vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_sabd_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_sabd, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SABA vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_saba_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_saba, Rd, Rm, Rn, width)
+
+/**
+ * Creates a ADD vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_add_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_add, Rd, Rm, Rn, width)
+
+/**
+ * Creates a CMTST vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_cmtst_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_cmtst, Rd, Rm, Rn, width)
+
+/**
+ * Creates a MLA vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register. The instruction also reads this register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_mla_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_4src(dc, OP_mla, Rd, Rd, Rm, Rn, width)
+
+/**
+ * Creates a MUL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_mul_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_mul, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SMAXP vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_smaxp_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_smaxp, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SMINP vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_sminp_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_sminp, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SQDMULH vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_sqdmulh_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_sqdmulh, Rd, Rm, Rn, width)
+
+/**
+ * Creates a ADDP vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
  *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
-#define INSTR_CREATE_fabd_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fabd, Rd, Rm, Rn, width)
-
-/**
- * Creates a FABS floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- */
-#define INSTR_CREATE_fabs_scalar(dc, Rd, Rm) \
-    instr_create_1dst_1src(dc, OP_fabs, Rd, Rm)
-
-/**
- * Creates a FACGE vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_facge_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_facge, Rd, Rm, Rn, width)
-
-/**
- * Creates a FACGT vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_facgt_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_facgt, Rd, Rm, Rn, width)
-
-/**
- * Creates a FADD vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fadd_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fadd, Rd, Rm, Rn, width)
-
-/**
- * Creates a FADD floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- */
-#define INSTR_CREATE_fadd_scalar(dc, Rd, Rm, Rn) \
-    instr_create_1dst_2src(dc, OP_fadd, Rd, Rm, Rn)
-
-/**
- * Creates a FADDP vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_faddp_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_faddp, Rd, Rm, Rn, width)
-
-/**
- * Creates a FCMEQ vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fcmeq_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fcmeq, Rd, Rm, Rn, width)
-
-/**
- * Creates a FCMGE vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fcmge_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fcmge, Rd, Rm, Rn, width)
-
-/**
- * Creates a FCMGT vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fcmgt_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fcmgt, Rd, Rm, Rn, width)
-
-/**
- * Creates a FDIV vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fdiv_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fdiv, Rd, Rm, Rn, width)
-
-/**
- * Creates a FDIV floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- */
-#define INSTR_CREATE_fdiv_scalar(dc, Rd, Rm, Rn) \
-    instr_create_1dst_2src(dc, OP_fdiv, Rd, Rm, Rn)
-
-/**
- * Creates a FMADD floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param Ra      The third input register.
- */
-#define INSTR_CREATE_fmadd_scalar(dc, Rd, Rm, Rn, Ra) \
-    instr_create_1dst_3src(dc, OP_fmadd, Rd, Rm, Rn, Ra)
-
-/**
- * Creates a FMAX vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fmax_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fmax, Rd, Rm, Rn, width)
-
-/**
- * Creates a FMAX floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- */
-#define INSTR_CREATE_fmax_scalar(dc, Rd, Rm, Rn) \
-    instr_create_1dst_2src(dc, OP_fmax, Rd, Rm, Rn)
+#define INSTR_CREATE_addp_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_addp, Rd, Rm, Rn, width)
 
 /**
  * Creates a FMAXNM vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
@@ -800,110 +908,8 @@
     instr_create_1dst_3src(dc, OP_fmaxnm, Rd, Rm, Rn, width)
 
 /**
- * Creates a FMAXNM floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- */
-#define INSTR_CREATE_fmaxnm_scalar(dc, Rd, Rm, Rn) \
-    instr_create_1dst_2src(dc, OP_fmaxnm, Rd, Rm, Rn)
-
-/**
- * Creates a FMAXNMP vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fmaxnmp_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fmaxnmp, Rd, Rm, Rn, width)
-
-/**
- * Creates a FMAXP vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fmaxp_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fmaxp, Rd, Rm, Rn, width)
-
-/**
- * Creates a FMIN vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fmin_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fmin, Rd, Rm, Rn, width)
-
-/**
- * Creates a FMIN floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- */
-#define INSTR_CREATE_fmin_scalar(dc, Rd, Rm, Rn) \
-    instr_create_1dst_2src(dc, OP_fmin, Rd, Rm, Rn)
-
-/**
- * Creates a FMINNM vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fminnm_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fminnm, Rd, Rm, Rn, width)
-
-/**
- * Creates a FMINNM floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- */
-#define INSTR_CREATE_fminnm_scalar(dc, Rd, Rm, Rn) \
-    instr_create_1dst_2src(dc, OP_fminnm, Rd, Rm, Rn)
-
-/**
- * Creates a FMINNMP vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fminnmp_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fminnmp, Rd, Rm, Rn, width)
-
-/**
- * Creates a FMINP vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fminp_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fminp, Rd, Rm, Rn, width)
-
-/**
  * Creates a FMLA vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register. The instruction also reads this register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
@@ -914,62 +920,20 @@
     instr_create_1dst_4src(dc, OP_fmla, Rd, Rd, Rm, Rn, width)
 
 /**
- * Creates a FMLS vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register. The instruction also reads this register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
- */
-#define INSTR_CREATE_fmls_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_4src(dc, OP_fmls, Rd, Rd, Rm, Rn, width)
-
-/**
- * Creates a FMOV floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- */
-#define INSTR_CREATE_fmov_scalar(dc, Rd, Rm) \
-    instr_create_1dst_1src(dc, OP_fmov, Rd, Rm)
-
-/**
- * Creates a FMSUB floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param Ra      The third input register.
- */
-#define INSTR_CREATE_fmsub_scalar(dc, Rd, Rm, Rn, Ra) \
-    instr_create_1dst_3src(dc, OP_fmsub, Rd, Rm, Rn, Ra)
-
-/**
- * Creates a FMUL vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * Creates a FADD vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  * \param width   The vector element width. Use either OPND_CREATE_HALF(),
  *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
-#define INSTR_CREATE_fmul_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fmul, Rd, Rm, Rn, width)
-
-/**
- * Creates a FMUL floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- */
-#define INSTR_CREATE_fmul_scalar(dc, Rd, Rm, Rn) \
-    instr_create_1dst_2src(dc, OP_fmul, Rd, Rm, Rn)
+#define INSTR_CREATE_fadd_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fadd, Rd, Rm, Rn, width)
 
 /**
  * Creates a FMULX vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
@@ -980,49 +944,42 @@
     instr_create_1dst_3src(dc, OP_fmulx, Rd, Rm, Rn, width)
 
 /**
- * Creates a FNEG floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- */
-#define INSTR_CREATE_fneg_scalar(dc, Rd, Rm) \
-    instr_create_1dst_1src(dc, OP_fneg, Rd, Rm)
-
-/**
- * Creates a FNMADD floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * Creates a FCMEQ vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
- * \param Ra      The third input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
-#define INSTR_CREATE_fnmadd_scalar(dc, Rd, Rm, Rn, Ra) \
-    instr_create_1dst_3src(dc, OP_fnmadd, Rd, Rm, Rn, Ra)
+#define INSTR_CREATE_fcmeq_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fcmeq, Rd, Rm, Rn, width)
 
 /**
- * Creates a FNMSUB floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param Ra      The third input register.
- */
-#define INSTR_CREATE_fnmsub_scalar(dc, Rd, Rm, Rn, Ra) \
-    instr_create_1dst_3src(dc, OP_fnmsub, Rd, Rm, Rn, Ra)
-
-/**
- * Creates a FNMUL floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
+ * Creates a FMLAL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register. The instruction also reads this register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  */
-#define INSTR_CREATE_fnmul_scalar(dc, Rd, Rm, Rn) \
-    instr_create_1dst_2src(dc, OP_fnmul, Rd, Rm, Rn)
+#define INSTR_CREATE_fmlal_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_3src(dc, OP_fmlal, Rd, Rd, Rm, Rn)
+
+/**
+ * Creates a FMAX vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fmax_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fmax, Rd, Rm, Rn, width)
 
 /**
  * Creates a FRECPS vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
@@ -1033,92 +990,52 @@
     instr_create_1dst_3src(dc, OP_frecps, Rd, Rm, Rn, width)
 
 /**
- * Creates a FRINTA floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * Creates a AND vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
+ * \param Rn      The second input register.
  */
-#define INSTR_CREATE_frinta_scalar(dc, Rd, Rm) \
-    instr_create_1dst_1src(dc, OP_frinta, Rd, Rm)
+#define INSTR_CREATE_and_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_2src(dc, OP_and, Rd, Rm, Rn)
 
 /**
- * Creates a FRINTI floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * Creates a BIC vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
+ * \param Rn      The second input register.
  */
-#define INSTR_CREATE_frinti_scalar(dc, Rd, Rm) \
-    instr_create_1dst_1src(dc, OP_frinti, Rd, Rm)
+#define INSTR_CREATE_bic_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_2src(dc, OP_bic, Rd, Rm, Rn)
 
 /**
- * Creates a FRINTM floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- */
-#define INSTR_CREATE_frintm_scalar(dc, Rd, Rm) \
-    instr_create_1dst_1src(dc, OP_frintm, Rd, Rm)
-
-/**
- * Creates a FRINTN floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- */
-#define INSTR_CREATE_frintn_scalar(dc, Rd, Rm) \
-    instr_create_1dst_1src(dc, OP_frintn, Rd, Rm)
-
-/**
- * Creates a FRINTP floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- */
-#define INSTR_CREATE_frintp_scalar(dc, Rd, Rm) \
-    instr_create_1dst_1src(dc, OP_frintp, Rd, Rm)
-
-/**
- * Creates a FRINTX floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- */
-#define INSTR_CREATE_frintx_scalar(dc, Rd, Rm) \
-    instr_create_1dst_1src(dc, OP_frintx, Rd, Rm)
-
-/**
- * Creates a FRINTZ floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- */
-#define INSTR_CREATE_frintz_scalar(dc, Rd, Rm) \
-    instr_create_1dst_1src(dc, OP_frintz, Rd, Rm)
-
-/**
- * Creates a FRSQRTS vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * Creates a FMINNM vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  * \param width   The vector element width. Use either OPND_CREATE_HALF(),
  *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
-#define INSTR_CREATE_frsqrts_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_frsqrts, Rd, Rm, Rn, width)
+#define INSTR_CREATE_fminnm_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fminnm, Rd, Rm, Rn, width)
 
 /**
- * Creates a FSQRT floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
+ * Creates a FMLS vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register. The instruction also reads this register.
  * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
  */
-#define INSTR_CREATE_fsqrt_scalar(dc, Rd, Rm) \
-    instr_create_1dst_1src(dc, OP_fsqrt, Rd, Rm)
+#define INSTR_CREATE_fmls_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_4src(dc, OP_fmls, Rd, Rd, Rm, Rn, width)
 
 /**
  * Creates a FSUB vector instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
@@ -1129,15 +1046,525 @@
     instr_create_1dst_3src(dc, OP_fsub, Rd, Rm, Rn, width)
 
 /**
- * Creates a FSUB floating point instruction.
- * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * Creates a FMLSL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register. The instruction also reads this register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ */
+#define INSTR_CREATE_fmlsl_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_3src(dc, OP_fmlsl, Rd, Rd, Rm, Rn)
+
+/**
+ * Creates a FMIN vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fmin_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fmin, Rd, Rm, Rn, width)
+
+/**
+ * Creates a FRSQRTS vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_frsqrts_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_frsqrts, Rd, Rm, Rn, width)
+
+/**
+ * Creates a ORR vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  */
-#define INSTR_CREATE_fsub_scalar(dc, Rd, Rm, Rn) \
-    instr_create_1dst_2src(dc, OP_fsub, Rd, Rm, Rn)
+#define INSTR_CREATE_orr_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_2src(dc, OP_orr, Rd, Rm, Rn)
+
+/**
+ * Creates a ORN vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ */
+#define INSTR_CREATE_orn_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_2src(dc, OP_orn, Rd, Rm, Rn)
+
+/**
+ * Creates a UHADD vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_uhadd_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_uhadd, Rd, Rm, Rn, width)
+
+/**
+ * Creates a UQADD vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_uqadd_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_uqadd, Rd, Rm, Rn, width)
+
+/**
+ * Creates a URHADD vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_urhadd_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_urhadd, Rd, Rm, Rn, width)
+
+/**
+ * Creates a UHSUB vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_uhsub_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_uhsub, Rd, Rm, Rn, width)
+
+/**
+ * Creates a UQSUB vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_uqsub_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_uqsub, Rd, Rm, Rn, width)
+
+/**
+ * Creates a CMHI vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_cmhi_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_cmhi, Rd, Rm, Rn, width)
+
+/**
+ * Creates a CMHS vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_cmhs_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_cmhs, Rd, Rm, Rn, width)
+
+/**
+ * Creates a USHL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_ushl_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_ushl, Rd, Rm, Rn, width)
+
+/**
+ * Creates a UQSHL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_uqshl_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_uqshl, Rd, Rm, Rn, width)
+
+/**
+ * Creates a URSHL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_urshl_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_urshl, Rd, Rm, Rn, width)
+
+/**
+ * Creates a UQRSHL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_uqrshl_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_uqrshl, Rd, Rm, Rn, width)
+
+/**
+ * Creates a UMAX vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_umax_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_umax, Rd, Rm, Rn, width)
+
+/**
+ * Creates a UMIN vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_umin_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_umin, Rd, Rm, Rn, width)
+
+/**
+ * Creates a UABD vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_uabd_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_uabd, Rd, Rm, Rn, width)
+
+/**
+ * Creates a UABA vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_uaba_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_uaba, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SUB vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_sub_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_sub, Rd, Rm, Rn, width)
+
+/**
+ * Creates a CMEQ vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_cmeq_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_cmeq, Rd, Rm, Rn, width)
+
+/**
+ * Creates a MLS vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register. The instruction also reads this register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_mls_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_4src(dc, OP_mls, Rd, Rd, Rm, Rn, width)
+
+/**
+ * Creates a PMUL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE().
+ */
+#define INSTR_CREATE_pmul_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_pmul, Rd, Rm, Rn, width)
+
+/**
+ * Creates a UMAXP vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_umaxp_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_umaxp, Rd, Rm, Rn, width)
+
+/**
+ * Creates a UMINP vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_BYTE(), OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_uminp_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_uminp, Rd, Rm, Rn, width)
+
+/**
+ * Creates a SQRDMULH vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE().
+ */
+#define INSTR_CREATE_sqrdmulh_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_sqrdmulh, Rd, Rm, Rn, width)
+
+/**
+ * Creates a FMAXNMP vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fmaxnmp_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fmaxnmp, Rd, Rm, Rn, width)
+
+/**
+ * Creates a FMLAL2 vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register. The instruction also reads this register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ */
+#define INSTR_CREATE_fmlal2_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_3src(dc, OP_fmlal2, Rd, Rd, Rm, Rn)
+
+/**
+ * Creates a FADDP vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_faddp_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_faddp, Rd, Rm, Rn, width)
+
+/**
+ * Creates a FMUL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fmul_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fmul, Rd, Rm, Rn, width)
+
+/**
+ * Creates a FCMGE vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fcmge_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fcmge, Rd, Rm, Rn, width)
+
+/**
+ * Creates a FACGE vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_facge_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_facge, Rd, Rm, Rn, width)
+
+/**
+ * Creates a FMAXP vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fmaxp_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fmaxp, Rd, Rm, Rn, width)
+
+/**
+ * Creates a FDIV vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fdiv_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fdiv, Rd, Rm, Rn, width)
+
+/**
+ * Creates a EOR vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ */
+#define INSTR_CREATE_eor_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_2src(dc, OP_eor, Rd, Rm, Rn)
+
+/**
+ * Creates a BSL vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ */
+#define INSTR_CREATE_bsl_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_2src(dc, OP_bsl, Rd, Rm, Rn)
+
+/**
+ * Creates a FMINNMP vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fminnmp_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fminnmp, Rd, Rm, Rn, width)
+
+/**
+ * Creates a FMLSL2 vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register. The instruction also reads this register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ */
+#define INSTR_CREATE_fmlsl2_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_3src(dc, OP_fmlsl2, Rd, Rd, Rm, Rn)
+
+/**
+ * Creates a FABD vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fabd_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fabd, Rd, Rm, Rn, width)
+
+/**
+ * Creates a FCMGT vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fcmgt_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fcmgt, Rd, Rm, Rn, width)
+
+/**
+ * Creates a FACGT vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_facgt_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_facgt, Rd, Rm, Rn, width)
+
+/**
+ * Creates a FMINP vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param width   The vector element width. Use either OPND_CREATE_HALF(),
+ *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fminp_vector(dc, Rd, Rm, Rn, width) \
+    instr_create_1dst_3src(dc, OP_fminp, Rd, Rm, Rn, width)
+
+/**
+ * Creates a BIT vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ */
+#define INSTR_CREATE_bit_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_2src(dc, OP_bit, Rd, Rm, Rn)
+
+/**
+ * Creates a BIF vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ */
+#define INSTR_CREATE_bif_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_2src(dc, OP_bif, Rd, Rm, Rn)
 
 /* DR_API EXPORT END */
-
 #endif /* INSTR_CREATE_H */

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -1560,3 +1560,434 @@ fd081041 : str    d1, [x2,#4128]          : str    %d1 -> +0x1020(%x2)[8byte]
 fd3fffff : str    d31, [sp,#32760]        : str    %d31 -> +0x7ff8(%sp)[8byte]
 fd481041 : ldr    d1, [x2,#4128]          : ldr    +0x1020(%x2)[8byte] -> %d1
 fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
+
+# Advanced SIMD three same (FP16)
+0e5e0762 : fmaxnm v2.4h, v27.4h, v30.4h             : fmaxnm %d27 %d30 $0x01 -> %d2
+4e5e0762 : fmaxnm v2.8h, v27.8h, v30.8h             : fmaxnm %q27 %q30 $0x01 -> %q2
+0e5f0fa0 : fmla v0.4h, v29.4h, v31.4h               : fmla   %d0 %d29 %d31 $0x01 -> %d0
+4e5f0fa0 : fmla v0.8h, v29.8h, v31.8h               : fmla   %q0 %q29 %q31 $0x01 -> %q0
+0e421551 : fadd v17.4h, v10.4h, v2.4h               : fadd   %d10 %d2 $0x01 -> %d17
+4e421551 : fadd v17.8h, v10.8h, v2.8h               : fadd   %q10 %q2 $0x01 -> %q17
+0e441e9f : fmulx v31.4h, v20.4h, v4.4h              : fmulx  %d20 %d4 $0x01 -> %d31
+4e441e9f : fmulx v31.8h, v20.8h, v4.8h              : fmulx  %q20 %q4 $0x01 -> %q31
+0e4226ef : fcmeq v15.4h, v23.4h, v2.4h              : fcmeq  %d23 %d2 $0x01 -> %d15
+4e4226ef : fcmeq v15.8h, v23.8h, v2.8h              : fcmeq  %q23 %q2 $0x01 -> %q15
+0e56351a : fmax v26.4h, v8.4h, v22.4h               : fmax   %d8 %d22 $0x01 -> %d26
+4e56351a : fmax v26.8h, v8.8h, v22.8h               : fmax   %q8 %q22 $0x01 -> %q26
+0e523f58 : frecps v24.4h, v26.4h, v18.4h            : frecps %d26 %d18 $0x01 -> %d24
+4e523f58 : frecps v24.8h, v26.8h, v18.8h            : frecps %q26 %q18 $0x01 -> %q24
+0ecb07b0 : fminnm v16.4h, v29.4h, v11.4h            : fminnm %d29 %d11 $0x01 -> %d16
+4ecb07b0 : fminnm v16.8h, v29.8h, v11.8h            : fminnm %q29 %q11 $0x01 -> %q16
+0edd0d13 : fmls v19.4h, v8.4h, v29.4h               : fmls   %d19 %d8 %d29 $0x01 -> %d19
+4edd0d13 : fmls v19.8h, v8.8h, v29.8h               : fmls   %q19 %q8 %q29 $0x01 -> %q19
+0ed8178f : fsub v15.4h, v28.4h, v24.4h              : fsub   %d28 %d24 $0x01 -> %d15
+4ed8178f : fsub v15.8h, v28.8h, v24.8h              : fsub   %q28 %q24 $0x01 -> %q15
+0ecf3402 : fmin v2.4h, v0.4h, v15.4h                : fmin   %d0 %d15 $0x01 -> %d2
+4ecf3402 : fmin v2.8h, v0.8h, v15.8h                : fmin   %q0 %q15 $0x01 -> %q2
+0ed33d88 : frsqrts v8.4h, v12.4h, v19.4h            : frsqrts %d12 %d19 $0x01 -> %d8
+4ed33d88 : frsqrts v8.8h, v12.8h, v19.8h            : frsqrts %q12 %q19 $0x01 -> %q8
+2e5405f7 : fmaxnmp v23.4h, v15.4h, v20.4h           : fmaxnmp %d15 %d20 $0x01 -> %d23
+6e5405f7 : fmaxnmp v23.8h, v15.8h, v20.8h           : fmaxnmp %q15 %q20 $0x01 -> %q23
+2e5e177c : faddp v28.4h, v27.4h, v30.4h             : faddp  %d27 %d30 $0x01 -> %d28
+6e5e177c : faddp v28.8h, v27.8h, v30.8h             : faddp  %q27 %q30 $0x01 -> %q28
+2e4a1e84 : fmul v4.4h, v20.4h, v10.4h               : fmul   %d20 %d10 $0x01 -> %d4
+6e4a1e84 : fmul v4.8h, v20.8h, v10.8h               : fmul   %q20 %q10 $0x01 -> %q4
+2e4f274e : fcmge v14.4h, v26.4h, v15.4h             : fcmge  %d26 %d15 $0x01 -> %d14
+6e4f274e : fcmge v14.8h, v26.8h, v15.8h             : fcmge  %q26 %q15 $0x01 -> %q14
+2e5f2c42 : facge v2.4h, v2.4h, v31.4h               : facge  %d2 %d31 $0x01 -> %d2
+6e5f2c42 : facge v2.8h, v2.8h, v31.8h               : facge  %q2 %q31 $0x01 -> %q2
+2e453493 : fmaxp v19.4h, v4.4h, v5.4h               : fmaxp  %d4 %d5 $0x01 -> %d19
+6e453493 : fmaxp v19.8h, v4.8h, v5.8h               : fmaxp  %q4 %q5 $0x01 -> %q19
+2e573f09 : fdiv v9.4h, v24.4h, v23.4h               : fdiv   %d24 %d23 $0x01 -> %d9
+6e573f09 : fdiv v9.8h, v24.8h, v23.8h               : fdiv   %q24 %q23 $0x01 -> %q9
+2ec604e9 : fminnmp v9.4h, v7.4h, v6.4h              : fminnmp %d7 %d6 $0x01 -> %d9
+6ec604e9 : fminnmp v9.8h, v7.8h, v6.8h              : fminnmp %q7 %q6 $0x01 -> %q9
+2ecc155c : fabd v28.4h, v10.4h, v12.4h              : fabd   %d10 %d12 $0x01 -> %d28
+6ecc155c : fabd v28.8h, v10.8h, v12.8h              : fabd   %q10 %q12 $0x01 -> %q28
+2eda2776 : fcmgt v22.4h, v27.4h, v26.4h             : fcmgt  %d27 %d26 $0x01 -> %d22
+6eda2776 : fcmgt v22.8h, v27.8h, v26.8h             : fcmgt  %q27 %q26 $0x01 -> %q22
+2ed12dfc : facgt v28.4h, v15.4h, v17.4h             : facgt  %d15 %d17 $0x01 -> %d28
+6ed12dfc : facgt v28.8h, v15.8h, v17.8h             : facgt  %q15 %q17 $0x01 -> %q28
+2ec73569 : fminp v9.4h, v11.4h, v7.4h               : fminp  %d11 %d7 $0x01 -> %d9
+6ec73569 : fminp v9.8h, v11.8h, v7.8h               : fminp  %q11 %q7 $0x01 -> %q9
+
+# Advanced SIMD three same
+0e3e0762 : shadd v2.8b, v27.8b, v30.8b              : shadd  %d27 %d30 $0x00 -> %d2
+4e3e0762 : shadd v2.16b, v27.16b, v30.16b           : shadd  %q27 %q30 $0x00 -> %q2
+0e7e0762 : shadd v2.4h, v27.4h, v30.4h              : shadd  %d27 %d30 $0x01 -> %d2
+4e7e0762 : shadd v2.8h, v27.8h, v30.8h              : shadd  %q27 %q30 $0x01 -> %q2
+0ebe0762 : shadd v2.2s, v27.2s, v30.2s              : shadd  %d27 %d30 $0x02 -> %d2
+4ebe0762 : shadd v2.4s, v27.4s, v30.4s              : shadd  %q27 %q30 $0x02 -> %q2
+0e3d0da0 : sqadd v0.8b, v13.8b, v29.8b              : sqadd  %d13 %d29 $0x00 -> %d0
+4e3d0da0 : sqadd v0.16b, v13.16b, v29.16b           : sqadd  %q13 %q29 $0x00 -> %q0
+0e7d0da0 : sqadd v0.4h, v13.4h, v29.4h              : sqadd  %d13 %d29 $0x01 -> %d0
+4e7d0da0 : sqadd v0.8h, v13.8h, v29.8h              : sqadd  %q13 %q29 $0x01 -> %q0
+0ebd0da0 : sqadd v0.2s, v13.2s, v29.2s              : sqadd  %d13 %d29 $0x02 -> %d0
+4ebd0da0 : sqadd v0.4s, v13.4s, v29.4s              : sqadd  %q13 %q29 $0x02 -> %q0
+4efd0da0 : sqadd v0.2d, v13.2d, v29.2d              : sqadd  %q13 %q29 $0x03 -> %q0
+0e2a163f : srhadd v31.8b, v17.8b, v10.8b            : srhadd %d17 %d10 $0x00 -> %d31
+4e2a163f : srhadd v31.16b, v17.16b, v10.16b         : srhadd %q17 %q10 $0x00 -> %q31
+0e6a163f : srhadd v31.4h, v17.4h, v10.4h            : srhadd %d17 %d10 $0x01 -> %d31
+4e6a163f : srhadd v31.8h, v17.8h, v10.8h            : srhadd %q17 %q10 $0x01 -> %q31
+0eaa163f : srhadd v31.2s, v17.2s, v10.2s            : srhadd %d17 %d10 $0x02 -> %d31
+4eaa163f : srhadd v31.4s, v17.4s, v10.4s            : srhadd %q17 %q10 $0x02 -> %q31
+0e3427e2 : shsub v2.8b, v31.8b, v20.8b              : shsub  %d31 %d20 $0x00 -> %d2
+4e3427e2 : shsub v2.16b, v31.16b, v20.16b           : shsub  %q31 %q20 $0x00 -> %q2
+0e7427e2 : shsub v2.4h, v31.4h, v20.4h              : shsub  %d31 %d20 $0x01 -> %d2
+4e7427e2 : shsub v2.8h, v31.8h, v20.8h              : shsub  %q31 %q20 $0x01 -> %q2
+0eb427e2 : shsub v2.2s, v31.2s, v20.2s              : shsub  %d31 %d20 $0x02 -> %d2
+4eb427e2 : shsub v2.4s, v31.4s, v20.4s              : shsub  %q31 %q20 $0x02 -> %q2
+0e372de4 : sqsub v4.8b, v15.8b, v23.8b              : sqsub  %d15 %d23 $0x00 -> %d4
+4e372de4 : sqsub v4.16b, v15.16b, v23.16b           : sqsub  %q15 %q23 $0x00 -> %q4
+0e772de4 : sqsub v4.4h, v15.4h, v23.4h              : sqsub  %d15 %d23 $0x01 -> %d4
+4e772de4 : sqsub v4.8h, v15.8h, v23.8h              : sqsub  %q15 %q23 $0x01 -> %q4
+0eb72de4 : sqsub v4.2s, v15.2s, v23.2s              : sqsub  %d15 %d23 $0x02 -> %d4
+4eb72de4 : sqsub v4.4s, v15.4s, v23.4s              : sqsub  %q15 %q23 $0x02 -> %q4
+4ef72de4 : sqsub v4.2d, v15.2d, v23.2d              : sqsub  %q15 %q23 $0x03 -> %q4
+0e283742 : cmgt v2.8b, v26.8b, v8.8b                : cmgt   %d26 %d8 $0x00 -> %d2
+4e283742 : cmgt v2.16b, v26.16b, v8.16b             : cmgt   %q26 %q8 $0x00 -> %q2
+0e683742 : cmgt v2.4h, v26.4h, v8.4h                : cmgt   %d26 %d8 $0x01 -> %d2
+4e683742 : cmgt v2.8h, v26.8h, v8.8h                : cmgt   %q26 %q8 $0x01 -> %q2
+0ea83742 : cmgt v2.2s, v26.2s, v8.2s                : cmgt   %d26 %d8 $0x02 -> %d2
+4ea83742 : cmgt v2.4s, v26.4s, v8.4s                : cmgt   %q26 %q8 $0x02 -> %q2
+4ee83742 : cmgt v2.2d, v26.2d, v8.2d                : cmgt   %q26 %q8 $0x03 -> %q2
+0e3a3f16 : cmge v22.8b, v24.8b, v26.8b              : cmge   %d24 %d26 $0x00 -> %d22
+4e3a3f16 : cmge v22.16b, v24.16b, v26.16b           : cmge   %q24 %q26 $0x00 -> %q22
+0e7a3f16 : cmge v22.4h, v24.4h, v26.4h              : cmge   %d24 %d26 $0x01 -> %d22
+4e7a3f16 : cmge v22.8h, v24.8h, v26.8h              : cmge   %q24 %q26 $0x01 -> %q22
+0eba3f16 : cmge v22.2s, v24.2s, v26.2s              : cmge   %d24 %d26 $0x02 -> %d22
+4eba3f16 : cmge v22.4s, v24.4s, v26.4s              : cmge   %q24 %q26 $0x02 -> %q22
+4efa3f16 : cmge v22.2d, v24.2d, v26.2d              : cmge   %q24 %q26 $0x03 -> %q22
+0e3d4612 : sshl v18.8b, v16.8b, v29.8b              : sshl   %d16 %d29 $0x00 -> %d18
+4e3d4612 : sshl v18.16b, v16.16b, v29.16b           : sshl   %q16 %q29 $0x00 -> %q18
+0e7d4612 : sshl v18.4h, v16.4h, v29.4h              : sshl   %d16 %d29 $0x01 -> %d18
+4e7d4612 : sshl v18.8h, v16.8h, v29.8h              : sshl   %q16 %q29 $0x01 -> %q18
+0ebd4612 : sshl v18.2s, v16.2s, v29.2s              : sshl   %d16 %d29 $0x02 -> %d18
+4ebd4612 : sshl v18.4s, v16.4s, v29.4s              : sshl   %q16 %q29 $0x02 -> %q18
+4efd4612 : sshl v18.2d, v16.2d, v29.2d              : sshl   %q16 %q29 $0x03 -> %q18
+0e374e6b : sqshl v11.8b, v19.8b, v23.8b             : sqshl  %d19 %d23 $0x00 -> %d11
+4e374e6b : sqshl v11.16b, v19.16b, v23.16b          : sqshl  %q19 %q23 $0x00 -> %q11
+0e774e6b : sqshl v11.4h, v19.4h, v23.4h             : sqshl  %d19 %d23 $0x01 -> %d11
+4e774e6b : sqshl v11.8h, v19.8h, v23.8h             : sqshl  %q19 %q23 $0x01 -> %q11
+0eb74e6b : sqshl v11.2s, v19.2s, v23.2s             : sqshl  %d19 %d23 $0x02 -> %d11
+4eb74e6b : sqshl v11.4s, v19.4s, v23.4s             : sqshl  %q19 %q23 $0x02 -> %q11
+4ef74e6b : sqshl v11.2d, v19.2d, v23.2d             : sqshl  %q19 %q23 $0x03 -> %q11
+0e2f57a8 : srshl v8.8b, v29.8b, v15.8b              : srshl  %d29 %d15 $0x00 -> %d8
+4e2f57a8 : srshl v8.16b, v29.16b, v15.16b           : srshl  %q29 %q15 $0x00 -> %q8
+0e6f57a8 : srshl v8.4h, v29.4h, v15.4h              : srshl  %d29 %d15 $0x01 -> %d8
+4e6f57a8 : srshl v8.8h, v29.8h, v15.8h              : srshl  %q29 %q15 $0x01 -> %q8
+0eaf57a8 : srshl v8.2s, v29.2s, v15.2s              : srshl  %d29 %d15 $0x02 -> %d8
+4eaf57a8 : srshl v8.4s, v29.4s, v15.4s              : srshl  %q29 %q15 $0x02 -> %q8
+4eef57a8 : srshl v8.2d, v29.2d, v15.2d              : srshl  %q29 %q15 $0x03 -> %q8
+0e225f1c : sqrshl v28.8b, v24.8b, v2.8b             : sqrshl %d24 %d2 $0x00 -> %d28
+4e225f1c : sqrshl v28.16b, v24.16b, v2.16b          : sqrshl %q24 %q2 $0x00 -> %q28
+0e625f1c : sqrshl v28.4h, v24.4h, v2.4h             : sqrshl %d24 %d2 $0x01 -> %d28
+4e625f1c : sqrshl v28.8h, v24.8h, v2.8h             : sqrshl %q24 %q2 $0x01 -> %q28
+0ea25f1c : sqrshl v28.2s, v24.2s, v2.2s             : sqrshl %d24 %d2 $0x02 -> %d28
+4ea25f1c : sqrshl v28.4s, v24.4s, v2.4s             : sqrshl %q24 %q2 $0x02 -> %q28
+4ee25f1c : sqrshl v28.2d, v24.2d, v2.2d             : sqrshl %q24 %q2 $0x03 -> %q28
+0e2865e0 : smax v0.8b, v15.8b, v8.8b                : smax   %d15 %d8 $0x00 -> %d0
+4e2865e0 : smax v0.16b, v15.16b, v8.16b             : smax   %q15 %q8 $0x00 -> %q0
+0e6865e0 : smax v0.4h, v15.4h, v8.4h                : smax   %d15 %d8 $0x01 -> %d0
+4e6865e0 : smax v0.8h, v15.8h, v8.8h                : smax   %q15 %q8 $0x01 -> %q0
+0ea865e0 : smax v0.2s, v15.2s, v8.2s                : smax   %d15 %d8 $0x02 -> %d0
+4ea865e0 : smax v0.4s, v15.4s, v8.4s                : smax   %q15 %q8 $0x02 -> %q0
+0e376e6c : smin v12.8b, v19.8b, v23.8b              : smin   %d19 %d23 $0x00 -> %d12
+4e376e6c : smin v12.16b, v19.16b, v23.16b           : smin   %q19 %q23 $0x00 -> %q12
+0e776e6c : smin v12.4h, v19.4h, v23.4h              : smin   %d19 %d23 $0x01 -> %d12
+4e776e6c : smin v12.8h, v19.8h, v23.8h              : smin   %q19 %q23 $0x01 -> %q12
+0eb76e6c : smin v12.2s, v19.2s, v23.2s              : smin   %d19 %d23 $0x02 -> %d12
+4eb76e6c : smin v12.4s, v19.4s, v23.4s              : smin   %q19 %q23 $0x02 -> %q12
+0e3c768f : sabd v15.8b, v20.8b, v28.8b              : sabd   %d20 %d28 $0x00 -> %d15
+4e3c768f : sabd v15.16b, v20.16b, v28.16b           : sabd   %q20 %q28 $0x00 -> %q15
+0e7c768f : sabd v15.4h, v20.4h, v28.4h              : sabd   %d20 %d28 $0x01 -> %d15
+4e7c768f : sabd v15.8h, v20.8h, v28.8h              : sabd   %q20 %q28 $0x01 -> %q15
+0ebc768f : sabd v15.2s, v20.2s, v28.2s              : sabd   %d20 %d28 $0x02 -> %d15
+4ebc768f : sabd v15.4s, v20.4s, v28.4s              : sabd   %q20 %q28 $0x02 -> %q15
+0e247fdb : saba v27.8b, v30.8b, v4.8b               : saba   %d30 %d4 $0x00 -> %d27
+4e247fdb : saba v27.16b, v30.16b, v4.16b            : saba   %q30 %q4 $0x00 -> %q27
+0e647fdb : saba v27.4h, v30.4h, v4.4h               : saba   %d30 %d4 $0x01 -> %d27
+4e647fdb : saba v27.8h, v30.8h, v4.8h               : saba   %q30 %q4 $0x01 -> %q27
+0ea47fdb : saba v27.2s, v30.2s, v4.2s               : saba   %d30 %d4 $0x02 -> %d27
+4ea47fdb : saba v27.4s, v30.4s, v4.4s               : saba   %q30 %q4 $0x02 -> %q27
+0e2e8554 : add v20.8b, v10.8b, v14.8b               : add    %d10 %d14 $0x00 -> %d20
+4e2e8554 : add v20.16b, v10.16b, v14.16b            : add    %q10 %q14 $0x00 -> %q20
+0e6e8554 : add v20.4h, v10.4h, v14.4h               : add    %d10 %d14 $0x01 -> %d20
+4e6e8554 : add v20.8h, v10.8h, v14.8h               : add    %q10 %q14 $0x01 -> %q20
+0eae8554 : add v20.2s, v10.2s, v14.2s               : add    %d10 %d14 $0x02 -> %d20
+4eae8554 : add v20.4s, v10.4s, v14.4s               : add    %q10 %q14 $0x02 -> %q20
+4eee8554 : add v20.2d, v10.2d, v14.2d               : add    %q10 %q14 $0x03 -> %q20
+0e228dfa : cmtst v26.8b, v15.8b, v2.8b              : cmtst  %d15 %d2 $0x00 -> %d26
+4e228dfa : cmtst v26.16b, v15.16b, v2.16b           : cmtst  %q15 %q2 $0x00 -> %q26
+0e628dfa : cmtst v26.4h, v15.4h, v2.4h              : cmtst  %d15 %d2 $0x01 -> %d26
+4e628dfa : cmtst v26.8h, v15.8h, v2.8h              : cmtst  %q15 %q2 $0x01 -> %q26
+0ea28dfa : cmtst v26.2s, v15.2s, v2.2s              : cmtst  %d15 %d2 $0x02 -> %d26
+4ea28dfa : cmtst v26.4s, v15.4s, v2.4s              : cmtst  %q15 %q2 $0x02 -> %q26
+4ee28dfa : cmtst v26.2d, v15.2d, v2.2d              : cmtst  %q15 %q2 $0x03 -> %q26
+0e249662 : mla v2.8b, v19.8b, v4.8b                 : mla    %d2 %d19 %d4 $0x00 -> %d2
+4e249662 : mla v2.16b, v19.16b, v4.16b              : mla    %q2 %q19 %q4 $0x00 -> %q2
+0e649662 : mla v2.4h, v19.4h, v4.4h                 : mla    %d2 %d19 %d4 $0x01 -> %d2
+4e649662 : mla v2.8h, v19.8h, v4.8h                 : mla    %q2 %q19 %q4 $0x01 -> %q2
+0ea49662 : mla v2.2s, v19.2s, v4.2s                 : mla    %d2 %d19 %d4 $0x02 -> %d2
+4ea49662 : mla v2.4s, v19.4s, v4.4s                 : mla    %q2 %q19 %q4 $0x02 -> %q2
+0e389d25 : mul v5.8b, v9.8b, v24.8b                 : mul    %d9 %d24 $0x00 -> %d5
+4e389d25 : mul v5.16b, v9.16b, v24.16b              : mul    %q9 %q24 $0x00 -> %q5
+0e789d25 : mul v5.4h, v9.4h, v24.4h                 : mul    %d9 %d24 $0x01 -> %d5
+4e789d25 : mul v5.8h, v9.8h, v24.8h                 : mul    %q9 %q24 $0x01 -> %q5
+0eb89d25 : mul v5.2s, v9.2s, v24.2s                 : mul    %d9 %d24 $0x02 -> %d5
+4eb89d25 : mul v5.4s, v9.4s, v24.4s                 : mul    %q9 %q24 $0x02 -> %q5
+0e27a537 : smaxp v23.8b, v9.8b, v7.8b               : smaxp  %d9 %d7 $0x00 -> %d23
+4e27a537 : smaxp v23.16b, v9.16b, v7.16b            : smaxp  %q9 %q7 $0x00 -> %q23
+0e67a537 : smaxp v23.4h, v9.4h, v7.4h               : smaxp  %d9 %d7 $0x01 -> %d23
+4e67a537 : smaxp v23.8h, v9.8h, v7.8h               : smaxp  %q9 %q7 $0x01 -> %q23
+0ea7a537 : smaxp v23.2s, v9.2s, v7.2s               : smaxp  %d9 %d7 $0x02 -> %d23
+4ea7a537 : smaxp v23.4s, v9.4s, v7.4s               : smaxp  %q9 %q7 $0x02 -> %q23
+0e2aaf86 : sminp v6.8b, v28.8b, v10.8b              : sminp  %d28 %d10 $0x00 -> %d6
+4e2aaf86 : sminp v6.16b, v28.16b, v10.16b           : sminp  %q28 %q10 $0x00 -> %q6
+0e6aaf86 : sminp v6.4h, v28.4h, v10.4h              : sminp  %d28 %d10 $0x01 -> %d6
+4e6aaf86 : sminp v6.8h, v28.8h, v10.8h              : sminp  %q28 %q10 $0x01 -> %q6
+0eaaaf86 : sminp v6.2s, v28.2s, v10.2s              : sminp  %d28 %d10 $0x02 -> %d6
+4eaaaf86 : sminp v6.4s, v28.4s, v10.4s              : sminp  %q28 %q10 $0x02 -> %q6
+0e7bb6cc : sqdmulh v12.4h, v22.4h, v27.4h           : sqdmulh %d22 %d27 $0x01 -> %d12
+4e7bb6cc : sqdmulh v12.8h, v22.8h, v27.8h           : sqdmulh %q22 %q27 $0x01 -> %q12
+0ebbb6cc : sqdmulh v12.2s, v22.2s, v27.2s           : sqdmulh %d22 %d27 $0x02 -> %d12
+4ebbb6cc : sqdmulh v12.4s, v22.4s, v27.4s           : sqdmulh %q22 %q27 $0x02 -> %q12
+0e2fbf9a : addp v26.8b, v28.8b, v15.8b              : addp   %d28 %d15 $0x00 -> %d26
+4e2fbf9a : addp v26.16b, v28.16b, v15.16b           : addp   %q28 %q15 $0x00 -> %q26
+0e6fbf9a : addp v26.4h, v28.4h, v15.4h              : addp   %d28 %d15 $0x01 -> %d26
+4e6fbf9a : addp v26.8h, v28.8h, v15.8h              : addp   %q28 %q15 $0x01 -> %q26
+0eafbf9a : addp v26.2s, v28.2s, v15.2s              : addp   %d28 %d15 $0x02 -> %d26
+4eafbf9a : addp v26.4s, v28.4s, v15.4s              : addp   %q28 %q15 $0x02 -> %q26
+4eefbf9a : addp v26.2d, v28.2d, v15.2d              : addp   %q28 %q15 $0x03 -> %q26
+0e2bc531 : fmaxnm v17.2s, v9.2s, v11.2s             : fmaxnm %d9 %d11 $0x02 -> %d17
+4e2bc531 : fmaxnm v17.4s, v9.4s, v11.4s             : fmaxnm %q9 %q11 $0x02 -> %q17
+4e6bc531 : fmaxnm v17.2d, v9.2d, v11.2d             : fmaxnm %q9 %q11 $0x03 -> %q17
+0e33cfa7 : fmla v7.2s, v29.2s, v19.2s               : fmla   %d7 %d29 %d19 $0x02 -> %d7
+4e33cfa7 : fmla v7.4s, v29.4s, v19.4s               : fmla   %q7 %q29 %q19 $0x02 -> %q7
+4e73cfa7 : fmla v7.2d, v29.2d, v19.2d               : fmla   %q7 %q29 %q19 $0x03 -> %q7
+0e2bd56a : fadd v10.2s, v11.2s, v11.2s              : fadd   %d11 %d11 $0x02 -> %d10
+4e2bd56a : fadd v10.4s, v11.4s, v11.4s              : fadd   %q11 %q11 $0x02 -> %q10
+4e6bd56a : fadd v10.2d, v11.2d, v11.2d              : fadd   %q11 %q11 $0x03 -> %q10
+0e34dede : fmulx v30.2s, v22.2s, v20.2s             : fmulx  %d22 %d20 $0x02 -> %d30
+4e34dede : fmulx v30.4s, v22.4s, v20.4s             : fmulx  %q22 %q20 $0x02 -> %q30
+4e74dede : fmulx v30.2d, v22.2d, v20.2d             : fmulx  %q22 %q20 $0x03 -> %q30
+0e20e5db : fcmeq v27.2s, v14.2s, v0.2s              : fcmeq  %d14 %d0 $0x02 -> %d27
+4e20e5db : fcmeq v27.4s, v14.4s, v0.4s              : fcmeq  %q14 %q0 $0x02 -> %q27
+4e60e5db : fcmeq v27.2d, v14.2d, v0.2d              : fcmeq  %q14 %q0 $0x03 -> %q27
+0e20ed42 : fmlal v2.2s, v10.2h, v0.2h               : fmlal  %d2 %d10 %d0 -> %d2
+4e20ed42 : fmlal v2.4s, v10.4h, v0.4h               : fmlal  %q2 %q10 %q0 -> %q2
+0e34f6a2 : fmax v2.2s, v21.2s, v20.2s               : fmax   %d21 %d20 $0x02 -> %d2
+4e34f6a2 : fmax v2.4s, v21.4s, v20.4s               : fmax   %q21 %q20 $0x02 -> %q2
+4e74f6a2 : fmax v2.2d, v21.2d, v20.2d               : fmax   %q21 %q20 $0x03 -> %q2
+0e30fcaf : frecps v15.2s, v5.2s, v16.2s             : frecps %d5 %d16 $0x02 -> %d15
+4e30fcaf : frecps v15.4s, v5.4s, v16.4s             : frecps %q5 %q16 $0x02 -> %q15
+4e70fcaf : frecps v15.2d, v5.2d, v16.2d             : frecps %q5 %q16 $0x03 -> %q15
+0e2a1f3c : and v28.8b, v25.8b, v10.8b               : and    %d25 %d10 -> %d28
+4e2a1f3c : and v28.16b, v25.16b, v10.16b            : and    %q25 %q10 -> %q28
+0e6f1ff8 : bic v24.8b, v31.8b, v15.8b               : bic    %d31 %d15 -> %d24
+4e6f1ff8 : bic v24.16b, v31.16b, v15.16b            : bic    %q31 %q15 -> %q24
+0ebfc7d1 : fminnm v17.2s, v30.2s, v31.2s            : fminnm %d30 %d31 $0x02 -> %d17
+4ebfc7d1 : fminnm v17.4s, v30.4s, v31.4s            : fminnm %q30 %q31 $0x02 -> %q17
+4effc7d1 : fminnm v17.2d, v30.2d, v31.2d            : fminnm %q30 %q31 $0x03 -> %q17
+0ebdcfe4 : fmls v4.2s, v31.2s, v29.2s               : fmls   %d4 %d31 %d29 $0x02 -> %d4
+4ebdcfe4 : fmls v4.4s, v31.4s, v29.4s               : fmls   %q4 %q31 %q29 $0x02 -> %q4
+4efdcfe4 : fmls v4.2d, v31.2d, v29.2d               : fmls   %q4 %q31 %q29 $0x03 -> %q4
+0ebad519 : fsub v25.2s, v8.2s, v26.2s               : fsub   %d8 %d26 $0x02 -> %d25
+4ebad519 : fsub v25.4s, v8.4s, v26.4s               : fsub   %q8 %q26 $0x02 -> %q25
+4efad519 : fsub v25.2d, v8.2d, v26.2d               : fsub   %q8 %q26 $0x03 -> %q25
+0ea0ed42 : fmlsl v2.2s, v10.2h, v0.2h               : fmlsl  %d2 %d10 %d0 -> %d2
+4ea0ed42 : fmlsl v2.4s, v10.4h, v0.4h               : fmlsl  %q2 %q10 %q0 -> %q2
+0ebff716 : fmin v22.2s, v24.2s, v31.2s              : fmin   %d24 %d31 $0x02 -> %d22
+4ebff716 : fmin v22.4s, v24.4s, v31.4s              : fmin   %q24 %q31 $0x02 -> %q22
+4efff716 : fmin v22.2d, v24.2d, v31.2d              : fmin   %q24 %q31 $0x03 -> %q22
+0ea6ff8a : frsqrts v10.2s, v28.2s, v6.2s            : frsqrts %d28 %d6 $0x02 -> %d10
+4ea6ff8a : frsqrts v10.4s, v28.4s, v6.4s            : frsqrts %q28 %q6 $0x02 -> %q10
+4ee6ff8a : frsqrts v10.2d, v28.2d, v6.2d            : frsqrts %q28 %q6 $0x03 -> %q10
+0ea01c5a : orr v26.8b, v2.8b, v0.8b                 : orr    %d2 %d0 -> %d26
+4ea01c5a : orr v26.16b, v2.16b, v0.16b              : orr    %q2 %q0 -> %q26
+0ee31c9c : orn v28.8b, v4.8b, v3.8b                 : orn    %d4 %d3 -> %d28
+4ee31c9c : orn v28.16b, v4.16b, v3.16b              : orn    %q4 %q3 -> %q28
+2e2904b6 : uhadd v22.8b, v5.8b, v9.8b               : uhadd  %d5 %d9 $0x00 -> %d22
+6e2904b6 : uhadd v22.16b, v5.16b, v9.16b            : uhadd  %q5 %q9 $0x00 -> %q22
+2e6904b6 : uhadd v22.4h, v5.4h, v9.4h               : uhadd  %d5 %d9 $0x01 -> %d22
+6e6904b6 : uhadd v22.8h, v5.8h, v9.8h               : uhadd  %q5 %q9 $0x01 -> %q22
+2ea904b6 : uhadd v22.2s, v5.2s, v9.2s               : uhadd  %d5 %d9 $0x02 -> %d22
+6ea904b6 : uhadd v22.4s, v5.4s, v9.4s               : uhadd  %q5 %q9 $0x02 -> %q22
+2e3f0fa6 : uqadd v6.8b, v29.8b, v31.8b              : uqadd  %d29 %d31 $0x00 -> %d6
+6e3f0fa6 : uqadd v6.16b, v29.16b, v31.16b           : uqadd  %q29 %q31 $0x00 -> %q6
+2e7f0fa6 : uqadd v6.4h, v29.4h, v31.4h              : uqadd  %d29 %d31 $0x01 -> %d6
+6e7f0fa6 : uqadd v6.8h, v29.8h, v31.8h              : uqadd  %q29 %q31 $0x01 -> %q6
+2ebf0fa6 : uqadd v6.2s, v29.2s, v31.2s              : uqadd  %d29 %d31 $0x02 -> %d6
+6ebf0fa6 : uqadd v6.4s, v29.4s, v31.4s              : uqadd  %q29 %q31 $0x02 -> %q6
+6eff0fa6 : uqadd v6.2d, v29.2d, v31.2d              : uqadd  %q29 %q31 $0x03 -> %q6
+2e3b17a8 : urhadd v8.8b, v29.8b, v27.8b             : urhadd %d29 %d27 $0x00 -> %d8
+6e3b17a8 : urhadd v8.16b, v29.16b, v27.16b          : urhadd %q29 %q27 $0x00 -> %q8
+2e7b17a8 : urhadd v8.4h, v29.4h, v27.4h             : urhadd %d29 %d27 $0x01 -> %d8
+6e7b17a8 : urhadd v8.8h, v29.8h, v27.8h             : urhadd %q29 %q27 $0x01 -> %q8
+2ebb17a8 : urhadd v8.2s, v29.2s, v27.2s             : urhadd %d29 %d27 $0x02 -> %d8
+6ebb17a8 : urhadd v8.4s, v29.4s, v27.4s             : urhadd %q29 %q27 $0x02 -> %q8
+2e3026bc : uhsub v28.8b, v21.8b, v16.8b             : uhsub  %d21 %d16 $0x00 -> %d28
+6e3026bc : uhsub v28.16b, v21.16b, v16.16b          : uhsub  %q21 %q16 $0x00 -> %q28
+2e7026bc : uhsub v28.4h, v21.4h, v16.4h             : uhsub  %d21 %d16 $0x01 -> %d28
+6e7026bc : uhsub v28.8h, v21.8h, v16.8h             : uhsub  %q21 %q16 $0x01 -> %q28
+2eb026bc : uhsub v28.2s, v21.2s, v16.2s             : uhsub  %d21 %d16 $0x02 -> %d28
+6eb026bc : uhsub v28.4s, v21.4s, v16.4s             : uhsub  %q21 %q16 $0x02 -> %q28
+2e352f7d : uqsub v29.8b, v27.8b, v21.8b             : uqsub  %d27 %d21 $0x00 -> %d29
+6e352f7d : uqsub v29.16b, v27.16b, v21.16b          : uqsub  %q27 %q21 $0x00 -> %q29
+2e752f7d : uqsub v29.4h, v27.4h, v21.4h             : uqsub  %d27 %d21 $0x01 -> %d29
+6e752f7d : uqsub v29.8h, v27.8h, v21.8h             : uqsub  %q27 %q21 $0x01 -> %q29
+2eb52f7d : uqsub v29.2s, v27.2s, v21.2s             : uqsub  %d27 %d21 $0x02 -> %d29
+6eb52f7d : uqsub v29.4s, v27.4s, v21.4s             : uqsub  %q27 %q21 $0x02 -> %q29
+6ef52f7d : uqsub v29.2d, v27.2d, v21.2d             : uqsub  %q27 %q21 $0x03 -> %q29
+2e3435e9 : cmhi v9.8b, v15.8b, v20.8b               : cmhi   %d15 %d20 $0x00 -> %d9
+6e3435e9 : cmhi v9.16b, v15.16b, v20.16b            : cmhi   %q15 %q20 $0x00 -> %q9
+2e7435e9 : cmhi v9.4h, v15.4h, v20.4h               : cmhi   %d15 %d20 $0x01 -> %d9
+6e7435e9 : cmhi v9.8h, v15.8h, v20.8h               : cmhi   %q15 %q20 $0x01 -> %q9
+2eb435e9 : cmhi v9.2s, v15.2s, v20.2s               : cmhi   %d15 %d20 $0x02 -> %d9
+6eb435e9 : cmhi v9.4s, v15.4s, v20.4s               : cmhi   %q15 %q20 $0x02 -> %q9
+6ef435e9 : cmhi v9.2d, v15.2d, v20.2d               : cmhi   %q15 %q20 $0x03 -> %q9
+2e3e3d82 : cmhs v2.8b, v12.8b, v30.8b               : cmhs   %d12 %d30 $0x00 -> %d2
+6e3e3d82 : cmhs v2.16b, v12.16b, v30.16b            : cmhs   %q12 %q30 $0x00 -> %q2
+2e7e3d82 : cmhs v2.4h, v12.4h, v30.4h               : cmhs   %d12 %d30 $0x01 -> %d2
+6e7e3d82 : cmhs v2.8h, v12.8h, v30.8h               : cmhs   %q12 %q30 $0x01 -> %q2
+2ebe3d82 : cmhs v2.2s, v12.2s, v30.2s               : cmhs   %d12 %d30 $0x02 -> %d2
+6ebe3d82 : cmhs v2.4s, v12.4s, v30.4s               : cmhs   %q12 %q30 $0x02 -> %q2
+6efe3d82 : cmhs v2.2d, v12.2d, v30.2d               : cmhs   %q12 %q30 $0x03 -> %q2
+2e3244e1 : ushl v1.8b, v7.8b, v18.8b                : ushl   %d7 %d18 $0x00 -> %d1
+6e3244e1 : ushl v1.16b, v7.16b, v18.16b             : ushl   %q7 %q18 $0x00 -> %q1
+2e7244e1 : ushl v1.4h, v7.4h, v18.4h                : ushl   %d7 %d18 $0x01 -> %d1
+6e7244e1 : ushl v1.8h, v7.8h, v18.8h                : ushl   %q7 %q18 $0x01 -> %q1
+2eb244e1 : ushl v1.2s, v7.2s, v18.2s                : ushl   %d7 %d18 $0x02 -> %d1
+6eb244e1 : ushl v1.4s, v7.4s, v18.4s                : ushl   %q7 %q18 $0x02 -> %q1
+6ef244e1 : ushl v1.2d, v7.2d, v18.2d                : ushl   %q7 %q18 $0x03 -> %q1
+2e324dfb : uqshl v27.8b, v15.8b, v18.8b             : uqshl  %d15 %d18 $0x00 -> %d27
+6e324dfb : uqshl v27.16b, v15.16b, v18.16b          : uqshl  %q15 %q18 $0x00 -> %q27
+2e724dfb : uqshl v27.4h, v15.4h, v18.4h             : uqshl  %d15 %d18 $0x01 -> %d27
+6e724dfb : uqshl v27.8h, v15.8h, v18.8h             : uqshl  %q15 %q18 $0x01 -> %q27
+2eb24dfb : uqshl v27.2s, v15.2s, v18.2s             : uqshl  %d15 %d18 $0x02 -> %d27
+6eb24dfb : uqshl v27.4s, v15.4s, v18.4s             : uqshl  %q15 %q18 $0x02 -> %q27
+6ef24dfb : uqshl v27.2d, v15.2d, v18.2d             : uqshl  %q15 %q18 $0x03 -> %q27
+2e265445 : urshl v5.8b, v2.8b, v6.8b                : urshl  %d2 %d6 $0x00 -> %d5
+6e265445 : urshl v5.16b, v2.16b, v6.16b             : urshl  %q2 %q6 $0x00 -> %q5
+2e665445 : urshl v5.4h, v2.4h, v6.4h                : urshl  %d2 %d6 $0x01 -> %d5
+6e665445 : urshl v5.8h, v2.8h, v6.8h                : urshl  %q2 %q6 $0x01 -> %q5
+2ea65445 : urshl v5.2s, v2.2s, v6.2s                : urshl  %d2 %d6 $0x02 -> %d5
+6ea65445 : urshl v5.4s, v2.4s, v6.4s                : urshl  %q2 %q6 $0x02 -> %q5
+6ee65445 : urshl v5.2d, v2.2d, v6.2d                : urshl  %q2 %q6 $0x03 -> %q5
+2e3e5d52 : uqrshl v18.8b, v10.8b, v30.8b            : uqrshl %d10 %d30 $0x00 -> %d18
+6e3e5d52 : uqrshl v18.16b, v10.16b, v30.16b         : uqrshl %q10 %q30 $0x00 -> %q18
+2e7e5d52 : uqrshl v18.4h, v10.4h, v30.4h            : uqrshl %d10 %d30 $0x01 -> %d18
+6e7e5d52 : uqrshl v18.8h, v10.8h, v30.8h            : uqrshl %q10 %q30 $0x01 -> %q18
+2ebe5d52 : uqrshl v18.2s, v10.2s, v30.2s            : uqrshl %d10 %d30 $0x02 -> %d18
+6ebe5d52 : uqrshl v18.4s, v10.4s, v30.4s            : uqrshl %q10 %q30 $0x02 -> %q18
+6efe5d52 : uqrshl v18.2d, v10.2d, v30.2d            : uqrshl %q10 %q30 $0x03 -> %q18
+2e3966e9 : umax v9.8b, v23.8b, v25.8b               : umax   %d23 %d25 $0x00 -> %d9
+6e3966e9 : umax v9.16b, v23.16b, v25.16b            : umax   %q23 %q25 $0x00 -> %q9
+2e7966e9 : umax v9.4h, v23.4h, v25.4h               : umax   %d23 %d25 $0x01 -> %d9
+6e7966e9 : umax v9.8h, v23.8h, v25.8h               : umax   %q23 %q25 $0x01 -> %q9
+2eb966e9 : umax v9.2s, v23.2s, v25.2s               : umax   %d23 %d25 $0x02 -> %d9
+6eb966e9 : umax v9.4s, v23.4s, v25.4s               : umax   %q23 %q25 $0x02 -> %q9
+2e2b6ecc : umin v12.8b, v22.8b, v11.8b              : umin   %d22 %d11 $0x00 -> %d12
+6e2b6ecc : umin v12.16b, v22.16b, v11.16b           : umin   %q22 %q11 $0x00 -> %q12
+2e6b6ecc : umin v12.4h, v22.4h, v11.4h              : umin   %d22 %d11 $0x01 -> %d12
+6e6b6ecc : umin v12.8h, v22.8h, v11.8h              : umin   %q22 %q11 $0x01 -> %q12
+2eab6ecc : umin v12.2s, v22.2s, v11.2s              : umin   %d22 %d11 $0x02 -> %d12
+6eab6ecc : umin v12.4s, v22.4s, v11.4s              : umin   %q22 %q11 $0x02 -> %q12
+2e3b7585 : uabd v5.8b, v12.8b, v27.8b               : uabd   %d12 %d27 $0x00 -> %d5
+6e3b7585 : uabd v5.16b, v12.16b, v27.16b            : uabd   %q12 %q27 $0x00 -> %q5
+2e7b7585 : uabd v5.4h, v12.4h, v27.4h               : uabd   %d12 %d27 $0x01 -> %d5
+6e7b7585 : uabd v5.8h, v12.8h, v27.8h               : uabd   %q12 %q27 $0x01 -> %q5
+2ebb7585 : uabd v5.2s, v12.2s, v27.2s               : uabd   %d12 %d27 $0x02 -> %d5
+6ebb7585 : uabd v5.4s, v12.4s, v27.4s               : uabd   %q12 %q27 $0x02 -> %q5
+2e337ccd : uaba v13.8b, v6.8b, v19.8b               : uaba   %d6 %d19 $0x00 -> %d13
+6e337ccd : uaba v13.16b, v6.16b, v19.16b            : uaba   %q6 %q19 $0x00 -> %q13
+2e737ccd : uaba v13.4h, v6.4h, v19.4h               : uaba   %d6 %d19 $0x01 -> %d13
+6e737ccd : uaba v13.8h, v6.8h, v19.8h               : uaba   %q6 %q19 $0x01 -> %q13
+2eb37ccd : uaba v13.2s, v6.2s, v19.2s               : uaba   %d6 %d19 $0x02 -> %d13
+6eb37ccd : uaba v13.4s, v6.4s, v19.4s               : uaba   %q6 %q19 $0x02 -> %q13
+2e3c877d : sub v29.8b, v27.8b, v28.8b               : sub    %d27 %d28 $0x00 -> %d29
+6e3c877d : sub v29.16b, v27.16b, v28.16b            : sub    %q27 %q28 $0x00 -> %q29
+2e7c877d : sub v29.4h, v27.4h, v28.4h               : sub    %d27 %d28 $0x01 -> %d29
+6e7c877d : sub v29.8h, v27.8h, v28.8h               : sub    %q27 %q28 $0x01 -> %q29
+2ebc877d : sub v29.2s, v27.2s, v28.2s               : sub    %d27 %d28 $0x02 -> %d29
+6ebc877d : sub v29.4s, v27.4s, v28.4s               : sub    %q27 %q28 $0x02 -> %q29
+6efc877d : sub v29.2d, v27.2d, v28.2d               : sub    %q27 %q28 $0x03 -> %q29
+2e378e2d : cmeq v13.8b, v17.8b, v23.8b              : cmeq   %d17 %d23 $0x00 -> %d13
+6e378e2d : cmeq v13.16b, v17.16b, v23.16b           : cmeq   %q17 %q23 $0x00 -> %q13
+2e778e2d : cmeq v13.4h, v17.4h, v23.4h              : cmeq   %d17 %d23 $0x01 -> %d13
+6e778e2d : cmeq v13.8h, v17.8h, v23.8h              : cmeq   %q17 %q23 $0x01 -> %q13
+2eb78e2d : cmeq v13.2s, v17.2s, v23.2s              : cmeq   %d17 %d23 $0x02 -> %d13
+6eb78e2d : cmeq v13.4s, v17.4s, v23.4s              : cmeq   %q17 %q23 $0x02 -> %q13
+6ef78e2d : cmeq v13.2d, v17.2d, v23.2d              : cmeq   %q17 %q23 $0x03 -> %q13
+2e3b95a7 : mls v7.8b, v13.8b, v27.8b                : mls    %d7 %d13 %d27 $0x00 -> %d7
+6e3b95a7 : mls v7.16b, v13.16b, v27.16b             : mls    %q7 %q13 %q27 $0x00 -> %q7
+2e7b95a7 : mls v7.4h, v13.4h, v27.4h                : mls    %d7 %d13 %d27 $0x01 -> %d7
+6e7b95a7 : mls v7.8h, v13.8h, v27.8h                : mls    %q7 %q13 %q27 $0x01 -> %q7
+2ebb95a7 : mls v7.2s, v13.2s, v27.2s                : mls    %d7 %d13 %d27 $0x02 -> %d7
+6ebb95a7 : mls v7.4s, v13.4s, v27.4s                : mls    %q7 %q13 %q27 $0x02 -> %q7
+2e2c9f1a : pmul v26.8b, v24.8b, v12.8b              : pmul   %d24 %d12 $0x00 -> %d26
+6e2c9f1a : pmul v26.16b, v24.16b, v12.16b           : pmul   %q24 %q12 $0x00 -> %q26
+2e25a764 : umaxp v4.8b, v27.8b, v5.8b               : umaxp  %d27 %d5 $0x00 -> %d4
+6e25a764 : umaxp v4.16b, v27.16b, v5.16b            : umaxp  %q27 %q5 $0x00 -> %q4
+2e65a764 : umaxp v4.4h, v27.4h, v5.4h               : umaxp  %d27 %d5 $0x01 -> %d4
+6e65a764 : umaxp v4.8h, v27.8h, v5.8h               : umaxp  %q27 %q5 $0x01 -> %q4
+2ea5a764 : umaxp v4.2s, v27.2s, v5.2s               : umaxp  %d27 %d5 $0x02 -> %d4
+6ea5a764 : umaxp v4.4s, v27.4s, v5.4s               : umaxp  %q27 %q5 $0x02 -> %q4
+2e30aec3 : uminp v3.8b, v22.8b, v16.8b              : uminp  %d22 %d16 $0x00 -> %d3
+6e30aec3 : uminp v3.16b, v22.16b, v16.16b           : uminp  %q22 %q16 $0x00 -> %q3
+2e70aec3 : uminp v3.4h, v22.4h, v16.4h              : uminp  %d22 %d16 $0x01 -> %d3
+6e70aec3 : uminp v3.8h, v22.8h, v16.8h              : uminp  %q22 %q16 $0x01 -> %q3
+2eb0aec3 : uminp v3.2s, v22.2s, v16.2s              : uminp  %d22 %d16 $0x02 -> %d3
+6eb0aec3 : uminp v3.4s, v22.4s, v16.4s              : uminp  %q22 %q16 $0x02 -> %q3
+2e7bb7b7 : sqrdmulh v23.4h, v29.4h, v27.4h          : sqrdmulh %d29 %d27 $0x01 -> %d23
+6e7bb7b7 : sqrdmulh v23.8h, v29.8h, v27.8h          : sqrdmulh %q29 %q27 $0x01 -> %q23
+2ebbb7b7 : sqrdmulh v23.2s, v29.2s, v27.2s          : sqrdmulh %d29 %d27 $0x02 -> %d23
+6ebbb7b7 : sqrdmulh v23.4s, v29.4s, v27.4s          : sqrdmulh %q29 %q27 $0x02 -> %q23
+2e3dc64c : fmaxnmp v12.2s, v18.2s, v29.2s           : fmaxnmp %d18 %d29 $0x02 -> %d12
+6e3dc64c : fmaxnmp v12.4s, v18.4s, v29.4s           : fmaxnmp %q18 %q29 $0x02 -> %q12
+6e7dc64c : fmaxnmp v12.2d, v18.2d, v29.2d           : fmaxnmp %q18 %q29 $0x03 -> %q12
+2e20cd42 : fmlal2 v2.2s, v10.2h, v0.2h              : fmlal2 %d2 %d10 %d0 -> %d2
+6e20cd42 : fmlal2 v2.4s, v10.4h, v0.4h              : fmlal2 %q2 %q10 %q0 -> %q2
+2e30d7f2 : faddp v18.2s, v31.2s, v16.2s             : faddp  %d31 %d16 $0x02 -> %d18
+6e30d7f2 : faddp v18.4s, v31.4s, v16.4s             : faddp  %q31 %q16 $0x02 -> %q18
+6e70d7f2 : faddp v18.2d, v31.2d, v16.2d             : faddp  %q31 %q16 $0x03 -> %q18
+2e35df99 : fmul v25.2s, v28.2s, v21.2s              : fmul   %d28 %d21 $0x02 -> %d25
+6e35df99 : fmul v25.4s, v28.4s, v21.4s              : fmul   %q28 %q21 $0x02 -> %q25
+6e75df99 : fmul v25.2d, v28.2d, v21.2d              : fmul   %q28 %q21 $0x03 -> %q25
+2e3ee636 : fcmge v22.2s, v17.2s, v30.2s             : fcmge  %d17 %d30 $0x02 -> %d22
+6e3ee636 : fcmge v22.4s, v17.4s, v30.4s             : fcmge  %q17 %q30 $0x02 -> %q22
+6e7ee636 : fcmge v22.2d, v17.2d, v30.2d             : fcmge  %q17 %q30 $0x03 -> %q22
+2e3eefdc : facge v28.2s, v30.2s, v30.2s             : facge  %d30 %d30 $0x02 -> %d28
+6e3eefdc : facge v28.4s, v30.4s, v30.4s             : facge  %q30 %q30 $0x02 -> %q28
+6e7eefdc : facge v28.2d, v30.2d, v30.2d             : facge  %q30 %q30 $0x03 -> %q28
+2e39f6e5 : fmaxp v5.2s, v23.2s, v25.2s              : fmaxp  %d23 %d25 $0x02 -> %d5
+6e39f6e5 : fmaxp v5.4s, v23.4s, v25.4s              : fmaxp  %q23 %q25 $0x02 -> %q5
+6e79f6e5 : fmaxp v5.2d, v23.2d, v25.2d              : fmaxp  %q23 %q25 $0x03 -> %q5
+2e24ff4a : fdiv v10.2s, v26.2s, v4.2s               : fdiv   %d26 %d4 $0x02 -> %d10
+6e24ff4a : fdiv v10.4s, v26.4s, v4.4s               : fdiv   %q26 %q4 $0x02 -> %q10
+6e64ff4a : fdiv v10.2d, v26.2d, v4.2d               : fdiv   %q26 %q4 $0x03 -> %q10
+2e341c33 : eor v19.8b, v1.8b, v20.8b                : eor    %d1 %d20 -> %d19
+6e341c33 : eor v19.16b, v1.16b, v20.16b             : eor    %q1 %q20 -> %q19
+2e791c94 : bsl v20.8b, v4.8b, v25.8b                : bsl    %d4 %d25 -> %d20
+6e791c94 : bsl v20.16b, v4.16b, v25.16b             : bsl    %q4 %q25 -> %q20
+2eabc657 : fminnmp v23.2s, v18.2s, v11.2s           : fminnmp %d18 %d11 $0x02 -> %d23
+6eabc657 : fminnmp v23.4s, v18.4s, v11.4s           : fminnmp %q18 %q11 $0x02 -> %q23
+6eebc657 : fminnmp v23.2d, v18.2d, v11.2d           : fminnmp %q18 %q11 $0x03 -> %q23
+2ea0cd42 : fmlsl2 v2.2s, v10.2h, v0.2h              : fmlsl2 %d2 %d10 %d0 -> %d2
+6ea0cd42 : fmlsl2 v2.4s, v10.4h, v0.4h              : fmlsl2 %q2 %q10 %q0 -> %q2
+2eb3d54f : fabd v15.2s, v10.2s, v19.2s              : fabd   %d10 %d19 $0x02 -> %d15
+6eb3d54f : fabd v15.4s, v10.4s, v19.4s              : fabd   %q10 %q19 $0x02 -> %q15
+6ef3d54f : fabd v15.2d, v10.2d, v19.2d              : fabd   %q10 %q19 $0x03 -> %q15
+2eaee466 : fcmgt v6.2s, v3.2s, v14.2s               : fcmgt  %d3 %d14 $0x02 -> %d6
+6eaee466 : fcmgt v6.4s, v3.4s, v14.4s               : fcmgt  %q3 %q14 $0x02 -> %q6
+6eeee466 : fcmgt v6.2d, v3.2d, v14.2d               : fcmgt  %q3 %q14 $0x03 -> %q6
+2eacef44 : facgt v4.2s, v26.2s, v12.2s              : facgt  %d26 %d12 $0x02 -> %d4
+6eacef44 : facgt v4.4s, v26.4s, v12.4s              : facgt  %q26 %q12 $0x02 -> %q4
+6eecef44 : facgt v4.2d, v26.2d, v12.2d              : facgt  %q26 %q12 $0x03 -> %q4
+2eb9f43c : fminp v28.2s, v1.2s, v25.2s              : fminp  %d1 %d25 $0x02 -> %d28
+6eb9f43c : fminp v28.4s, v1.4s, v25.4s              : fminp  %q1 %q25 $0x02 -> %q28
+6ef9f43c : fminp v28.2d, v1.2d, v25.2d              : fminp  %q1 %q25 $0x03 -> %q28
+2eac1eac : bit v12.8b, v21.8b, v12.8b               : bit    %d21 %d12 -> %d12
+6eac1eac : bit v12.16b, v21.16b, v12.16b            : bit    %q21 %q12 -> %q12
+2ee31c74 : bif v20.8b, v3.8b, v3.8b                 : bif    %d3 %d3 -> %d20
+6ee31c74 : bif v20.16b, v3.16b, v3.16b              : bif    %q3 %q3 -> %q20

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -331,6 +331,2991 @@ test_fmov_general(void *dc)
     test_instr_encoding(dc, OP_fmov, instr);
 }
 
+static void
+test_asimdsamefp16(void *dc)
+{
+    byte *pc;
+    instr_t *instr;
+
+    /* Advanced SIMD three same (FP16) */
+
+    instr = INSTR_CREATE_fmaxnm_vector(dc,
+                                       opnd_create_reg(DR_REG_D2),
+                                       opnd_create_reg(DR_REG_D27),
+                                       opnd_create_reg(DR_REG_D30),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmaxnm, instr);
+
+    instr = INSTR_CREATE_fmaxnm_vector(dc,
+                                       opnd_create_reg(DR_REG_Q2),
+                                       opnd_create_reg(DR_REG_Q27),
+                                       opnd_create_reg(DR_REG_Q30),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmaxnm, instr);
+
+    instr = INSTR_CREATE_fmla_vector(dc,
+                                     opnd_create_reg(DR_REG_D0),
+                                     opnd_create_reg(DR_REG_D29),
+                                     opnd_create_reg(DR_REG_D31),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmla, instr);
+
+    instr = INSTR_CREATE_fmla_vector(dc,
+                                     opnd_create_reg(DR_REG_Q0),
+                                     opnd_create_reg(DR_REG_Q29),
+                                     opnd_create_reg(DR_REG_Q31),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmla, instr);
+
+    instr = INSTR_CREATE_fadd_vector(dc,
+                                     opnd_create_reg(DR_REG_D17),
+                                     opnd_create_reg(DR_REG_D10),
+                                     opnd_create_reg(DR_REG_D2),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fadd, instr);
+
+    instr = INSTR_CREATE_fadd_vector(dc,
+                                     opnd_create_reg(DR_REG_Q17),
+                                     opnd_create_reg(DR_REG_Q10),
+                                     opnd_create_reg(DR_REG_Q2),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fadd, instr);
+
+    instr = INSTR_CREATE_fmulx_vector(dc,
+                                      opnd_create_reg(DR_REG_D31),
+                                      opnd_create_reg(DR_REG_D20),
+                                      opnd_create_reg(DR_REG_D4),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmulx, instr);
+
+    instr = INSTR_CREATE_fmulx_vector(dc,
+                                      opnd_create_reg(DR_REG_Q31),
+                                      opnd_create_reg(DR_REG_Q20),
+                                      opnd_create_reg(DR_REG_Q4),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmulx, instr);
+
+    instr = INSTR_CREATE_fcmeq_vector(dc,
+                                      opnd_create_reg(DR_REG_D15),
+                                      opnd_create_reg(DR_REG_D23),
+                                      opnd_create_reg(DR_REG_D2),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fcmeq, instr);
+
+    instr = INSTR_CREATE_fcmeq_vector(dc,
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q23),
+                                      opnd_create_reg(DR_REG_Q2),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fcmeq, instr);
+
+    instr = INSTR_CREATE_fmax_vector(dc,
+                                     opnd_create_reg(DR_REG_D26),
+                                     opnd_create_reg(DR_REG_D8),
+                                     opnd_create_reg(DR_REG_D22),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmax, instr);
+
+    instr = INSTR_CREATE_fmax_vector(dc,
+                                     opnd_create_reg(DR_REG_Q26),
+                                     opnd_create_reg(DR_REG_Q8),
+                                     opnd_create_reg(DR_REG_Q22),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmax, instr);
+
+    instr = INSTR_CREATE_frecps_vector(dc,
+                                       opnd_create_reg(DR_REG_D24),
+                                       opnd_create_reg(DR_REG_D26),
+                                       opnd_create_reg(DR_REG_D18),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_frecps, instr);
+
+    instr = INSTR_CREATE_frecps_vector(dc,
+                                       opnd_create_reg(DR_REG_Q24),
+                                       opnd_create_reg(DR_REG_Q26),
+                                       opnd_create_reg(DR_REG_Q18),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_frecps, instr);
+
+    instr = INSTR_CREATE_fminnm_vector(dc,
+                                       opnd_create_reg(DR_REG_D16),
+                                       opnd_create_reg(DR_REG_D29),
+                                       opnd_create_reg(DR_REG_D11),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fminnm, instr);
+
+    instr = INSTR_CREATE_fminnm_vector(dc,
+                                       opnd_create_reg(DR_REG_Q16),
+                                       opnd_create_reg(DR_REG_Q29),
+                                       opnd_create_reg(DR_REG_Q11),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fminnm, instr);
+
+    instr = INSTR_CREATE_fmls_vector(dc,
+                                     opnd_create_reg(DR_REG_D19),
+                                     opnd_create_reg(DR_REG_D8),
+                                     opnd_create_reg(DR_REG_D29),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmls, instr);
+
+    instr = INSTR_CREATE_fmls_vector(dc,
+                                     opnd_create_reg(DR_REG_Q19),
+                                     opnd_create_reg(DR_REG_Q8),
+                                     opnd_create_reg(DR_REG_Q29),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmls, instr);
+
+    instr = INSTR_CREATE_fsub_vector(dc,
+                                     opnd_create_reg(DR_REG_D15),
+                                     opnd_create_reg(DR_REG_D28),
+                                     opnd_create_reg(DR_REG_D24),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fsub, instr);
+
+    instr = INSTR_CREATE_fsub_vector(dc,
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q28),
+                                     opnd_create_reg(DR_REG_Q24),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fsub, instr);
+
+    instr = INSTR_CREATE_fmin_vector(dc,
+                                     opnd_create_reg(DR_REG_D2),
+                                     opnd_create_reg(DR_REG_D0),
+                                     opnd_create_reg(DR_REG_D15),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmin, instr);
+
+    instr = INSTR_CREATE_fmin_vector(dc,
+                                     opnd_create_reg(DR_REG_Q2),
+                                     opnd_create_reg(DR_REG_Q0),
+                                     opnd_create_reg(DR_REG_Q15),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmin, instr);
+
+    instr = INSTR_CREATE_frsqrts_vector(dc,
+                                        opnd_create_reg(DR_REG_D8),
+                                        opnd_create_reg(DR_REG_D12),
+                                        opnd_create_reg(DR_REG_D19),
+                                        OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_frsqrts, instr);
+
+    instr = INSTR_CREATE_frsqrts_vector(dc,
+                                        opnd_create_reg(DR_REG_Q8),
+                                        opnd_create_reg(DR_REG_Q12),
+                                        opnd_create_reg(DR_REG_Q19),
+                                        OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_frsqrts, instr);
+
+    instr = INSTR_CREATE_fmaxnmp_vector(dc,
+                                        opnd_create_reg(DR_REG_D23),
+                                        opnd_create_reg(DR_REG_D15),
+                                        opnd_create_reg(DR_REG_D20),
+                                        OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmaxnmp, instr);
+
+    instr = INSTR_CREATE_fmaxnmp_vector(dc,
+                                        opnd_create_reg(DR_REG_Q23),
+                                        opnd_create_reg(DR_REG_Q15),
+                                        opnd_create_reg(DR_REG_Q20),
+                                        OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmaxnmp, instr);
+
+    instr = INSTR_CREATE_faddp_vector(dc,
+                                      opnd_create_reg(DR_REG_D28),
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D30),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_faddp, instr);
+
+    instr = INSTR_CREATE_faddp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q28),
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q30),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_faddp, instr);
+
+    instr = INSTR_CREATE_fmul_vector(dc,
+                                     opnd_create_reg(DR_REG_D4),
+                                     opnd_create_reg(DR_REG_D20),
+                                     opnd_create_reg(DR_REG_D10),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmul, instr);
+
+    instr = INSTR_CREATE_fmul_vector(dc,
+                                     opnd_create_reg(DR_REG_Q4),
+                                     opnd_create_reg(DR_REG_Q20),
+                                     opnd_create_reg(DR_REG_Q10),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmul, instr);
+
+    instr = INSTR_CREATE_fcmge_vector(dc,
+                                      opnd_create_reg(DR_REG_D14),
+                                      opnd_create_reg(DR_REG_D26),
+                                      opnd_create_reg(DR_REG_D15),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fcmge, instr);
+
+    instr = INSTR_CREATE_fcmge_vector(dc,
+                                      opnd_create_reg(DR_REG_Q14),
+                                      opnd_create_reg(DR_REG_Q26),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fcmge, instr);
+
+    instr = INSTR_CREATE_facge_vector(dc,
+                                      opnd_create_reg(DR_REG_D2),
+                                      opnd_create_reg(DR_REG_D2),
+                                      opnd_create_reg(DR_REG_D31),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_facge, instr);
+
+    instr = INSTR_CREATE_facge_vector(dc,
+                                      opnd_create_reg(DR_REG_Q2),
+                                      opnd_create_reg(DR_REG_Q2),
+                                      opnd_create_reg(DR_REG_Q31),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_facge, instr);
+
+    instr = INSTR_CREATE_fmaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_D19),
+                                      opnd_create_reg(DR_REG_D4),
+                                      opnd_create_reg(DR_REG_D5),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmaxp, instr);
+
+    instr = INSTR_CREATE_fmaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q19),
+                                      opnd_create_reg(DR_REG_Q4),
+                                      opnd_create_reg(DR_REG_Q5),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fmaxp, instr);
+
+    instr = INSTR_CREATE_fdiv_vector(dc,
+                                     opnd_create_reg(DR_REG_D9),
+                                     opnd_create_reg(DR_REG_D24),
+                                     opnd_create_reg(DR_REG_D23),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fdiv, instr);
+
+    instr = INSTR_CREATE_fdiv_vector(dc,
+                                     opnd_create_reg(DR_REG_Q9),
+                                     opnd_create_reg(DR_REG_Q24),
+                                     opnd_create_reg(DR_REG_Q23),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fdiv, instr);
+
+    instr = INSTR_CREATE_fminnmp_vector(dc,
+                                        opnd_create_reg(DR_REG_D9),
+                                        opnd_create_reg(DR_REG_D7),
+                                        opnd_create_reg(DR_REG_D6),
+                                        OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fminnmp, instr);
+
+    instr = INSTR_CREATE_fminnmp_vector(dc,
+                                        opnd_create_reg(DR_REG_Q9),
+                                        opnd_create_reg(DR_REG_Q7),
+                                        opnd_create_reg(DR_REG_Q6),
+                                        OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fminnmp, instr);
+
+    instr = INSTR_CREATE_fabd_vector(dc,
+                                     opnd_create_reg(DR_REG_D28),
+                                     opnd_create_reg(DR_REG_D10),
+                                     opnd_create_reg(DR_REG_D12),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fabd, instr);
+
+    instr = INSTR_CREATE_fabd_vector(dc,
+                                     opnd_create_reg(DR_REG_Q28),
+                                     opnd_create_reg(DR_REG_Q10),
+                                     opnd_create_reg(DR_REG_Q12),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fabd, instr);
+
+    instr = INSTR_CREATE_fcmgt_vector(dc,
+                                      opnd_create_reg(DR_REG_D22),
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D26),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fcmgt, instr);
+
+    instr = INSTR_CREATE_fcmgt_vector(dc,
+                                      opnd_create_reg(DR_REG_Q22),
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q26),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fcmgt, instr);
+
+    instr = INSTR_CREATE_facgt_vector(dc,
+                                      opnd_create_reg(DR_REG_D28),
+                                      opnd_create_reg(DR_REG_D15),
+                                      opnd_create_reg(DR_REG_D17),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_facgt, instr);
+
+    instr = INSTR_CREATE_facgt_vector(dc,
+                                      opnd_create_reg(DR_REG_Q28),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q17),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_facgt, instr);
+
+    instr = INSTR_CREATE_fminp_vector(dc,
+                                      opnd_create_reg(DR_REG_D9),
+                                      opnd_create_reg(DR_REG_D11),
+                                      opnd_create_reg(DR_REG_D7),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fminp, instr);
+
+    instr = INSTR_CREATE_fminp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q9),
+                                      opnd_create_reg(DR_REG_Q11),
+                                      opnd_create_reg(DR_REG_Q7),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_fminp, instr);
+}
+
+static void
+test_asimdsame(void *dc)
+{
+    byte *pc;
+    instr_t *instr;
+
+    /* Advanced SIMD three same */
+
+    instr = INSTR_CREATE_shadd_vector(dc,
+                                      opnd_create_reg(DR_REG_D2),
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D30),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_shadd, instr);
+
+    instr = INSTR_CREATE_shadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q2),
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q30),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_shadd, instr);
+
+    instr = INSTR_CREATE_shadd_vector(dc,
+                                      opnd_create_reg(DR_REG_D2),
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D30),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_shadd, instr);
+
+    instr = INSTR_CREATE_shadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q2),
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q30),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_shadd, instr);
+
+    instr = INSTR_CREATE_shadd_vector(dc,
+                                      opnd_create_reg(DR_REG_D2),
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D30),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_shadd, instr);
+
+    instr = INSTR_CREATE_shadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q2),
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q30),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_shadd, instr);
+
+    instr = INSTR_CREATE_sqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_D0),
+                                      opnd_create_reg(DR_REG_D13),
+                                      opnd_create_reg(DR_REG_D29),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sqadd, instr);
+
+    instr = INSTR_CREATE_sqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q0),
+                                      opnd_create_reg(DR_REG_Q13),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sqadd, instr);
+
+    instr = INSTR_CREATE_sqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_D0),
+                                      opnd_create_reg(DR_REG_D13),
+                                      opnd_create_reg(DR_REG_D29),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sqadd, instr);
+
+    instr = INSTR_CREATE_sqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q0),
+                                      opnd_create_reg(DR_REG_Q13),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sqadd, instr);
+
+    instr = INSTR_CREATE_sqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_D0),
+                                      opnd_create_reg(DR_REG_D13),
+                                      opnd_create_reg(DR_REG_D29),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sqadd, instr);
+
+    instr = INSTR_CREATE_sqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q0),
+                                      opnd_create_reg(DR_REG_Q13),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sqadd, instr);
+
+    instr = INSTR_CREATE_sqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q0),
+                                      opnd_create_reg(DR_REG_Q13),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_sqadd, instr);
+
+    instr = INSTR_CREATE_srhadd_vector(dc,
+                                       opnd_create_reg(DR_REG_D31),
+                                       opnd_create_reg(DR_REG_D17),
+                                       opnd_create_reg(DR_REG_D10),
+                                       OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_srhadd, instr);
+
+    instr = INSTR_CREATE_srhadd_vector(dc,
+                                       opnd_create_reg(DR_REG_Q31),
+                                       opnd_create_reg(DR_REG_Q17),
+                                       opnd_create_reg(DR_REG_Q10),
+                                       OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_srhadd, instr);
+
+    instr = INSTR_CREATE_srhadd_vector(dc,
+                                       opnd_create_reg(DR_REG_D31),
+                                       opnd_create_reg(DR_REG_D17),
+                                       opnd_create_reg(DR_REG_D10),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_srhadd, instr);
+
+    instr = INSTR_CREATE_srhadd_vector(dc,
+                                       opnd_create_reg(DR_REG_Q31),
+                                       opnd_create_reg(DR_REG_Q17),
+                                       opnd_create_reg(DR_REG_Q10),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_srhadd, instr);
+
+    instr = INSTR_CREATE_srhadd_vector(dc,
+                                       opnd_create_reg(DR_REG_D31),
+                                       opnd_create_reg(DR_REG_D17),
+                                       opnd_create_reg(DR_REG_D10),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_srhadd, instr);
+
+    instr = INSTR_CREATE_srhadd_vector(dc,
+                                       opnd_create_reg(DR_REG_Q31),
+                                       opnd_create_reg(DR_REG_Q17),
+                                       opnd_create_reg(DR_REG_Q10),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_srhadd, instr);
+
+    instr = INSTR_CREATE_shsub_vector(dc,
+                                      opnd_create_reg(DR_REG_D2),
+                                      opnd_create_reg(DR_REG_D31),
+                                      opnd_create_reg(DR_REG_D20),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_shsub, instr);
+
+    instr = INSTR_CREATE_shsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q2),
+                                      opnd_create_reg(DR_REG_Q31),
+                                      opnd_create_reg(DR_REG_Q20),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_shsub, instr);
+
+    instr = INSTR_CREATE_shsub_vector(dc,
+                                      opnd_create_reg(DR_REG_D2),
+                                      opnd_create_reg(DR_REG_D31),
+                                      opnd_create_reg(DR_REG_D20),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_shsub, instr);
+
+    instr = INSTR_CREATE_shsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q2),
+                                      opnd_create_reg(DR_REG_Q31),
+                                      opnd_create_reg(DR_REG_Q20),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_shsub, instr);
+
+    instr = INSTR_CREATE_shsub_vector(dc,
+                                      opnd_create_reg(DR_REG_D2),
+                                      opnd_create_reg(DR_REG_D31),
+                                      opnd_create_reg(DR_REG_D20),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_shsub, instr);
+
+    instr = INSTR_CREATE_shsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q2),
+                                      opnd_create_reg(DR_REG_Q31),
+                                      opnd_create_reg(DR_REG_Q20),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_shsub, instr);
+
+    instr = INSTR_CREATE_sqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_D4),
+                                      opnd_create_reg(DR_REG_D15),
+                                      opnd_create_reg(DR_REG_D23),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sqsub, instr);
+
+    instr = INSTR_CREATE_sqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q4),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q23),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sqsub, instr);
+
+    instr = INSTR_CREATE_sqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_D4),
+                                      opnd_create_reg(DR_REG_D15),
+                                      opnd_create_reg(DR_REG_D23),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sqsub, instr);
+
+    instr = INSTR_CREATE_sqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q4),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q23),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sqsub, instr);
+
+    instr = INSTR_CREATE_sqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_D4),
+                                      opnd_create_reg(DR_REG_D15),
+                                      opnd_create_reg(DR_REG_D23),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sqsub, instr);
+
+    instr = INSTR_CREATE_sqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q4),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q23),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sqsub, instr);
+
+    instr = INSTR_CREATE_sqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q4),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q23),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_sqsub, instr);
+
+    instr = INSTR_CREATE_cmgt_vector(dc,
+                                     opnd_create_reg(DR_REG_D2),
+                                     opnd_create_reg(DR_REG_D26),
+                                     opnd_create_reg(DR_REG_D8),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_cmgt, instr);
+
+    instr = INSTR_CREATE_cmgt_vector(dc,
+                                     opnd_create_reg(DR_REG_Q2),
+                                     opnd_create_reg(DR_REG_Q26),
+                                     opnd_create_reg(DR_REG_Q8),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_cmgt, instr);
+
+    instr = INSTR_CREATE_cmgt_vector(dc,
+                                     opnd_create_reg(DR_REG_D2),
+                                     opnd_create_reg(DR_REG_D26),
+                                     opnd_create_reg(DR_REG_D8),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_cmgt, instr);
+
+    instr = INSTR_CREATE_cmgt_vector(dc,
+                                     opnd_create_reg(DR_REG_Q2),
+                                     opnd_create_reg(DR_REG_Q26),
+                                     opnd_create_reg(DR_REG_Q8),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_cmgt, instr);
+
+    instr = INSTR_CREATE_cmgt_vector(dc,
+                                     opnd_create_reg(DR_REG_D2),
+                                     opnd_create_reg(DR_REG_D26),
+                                     opnd_create_reg(DR_REG_D8),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_cmgt, instr);
+
+    instr = INSTR_CREATE_cmgt_vector(dc,
+                                     opnd_create_reg(DR_REG_Q2),
+                                     opnd_create_reg(DR_REG_Q26),
+                                     opnd_create_reg(DR_REG_Q8),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_cmgt, instr);
+
+    instr = INSTR_CREATE_cmgt_vector(dc,
+                                     opnd_create_reg(DR_REG_Q2),
+                                     opnd_create_reg(DR_REG_Q26),
+                                     opnd_create_reg(DR_REG_Q8),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_cmgt, instr);
+
+    instr = INSTR_CREATE_cmge_vector(dc,
+                                     opnd_create_reg(DR_REG_D22),
+                                     opnd_create_reg(DR_REG_D24),
+                                     opnd_create_reg(DR_REG_D26),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_cmge, instr);
+
+    instr = INSTR_CREATE_cmge_vector(dc,
+                                     opnd_create_reg(DR_REG_Q22),
+                                     opnd_create_reg(DR_REG_Q24),
+                                     opnd_create_reg(DR_REG_Q26),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_cmge, instr);
+
+    instr = INSTR_CREATE_cmge_vector(dc,
+                                     opnd_create_reg(DR_REG_D22),
+                                     opnd_create_reg(DR_REG_D24),
+                                     opnd_create_reg(DR_REG_D26),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_cmge, instr);
+
+    instr = INSTR_CREATE_cmge_vector(dc,
+                                     opnd_create_reg(DR_REG_Q22),
+                                     opnd_create_reg(DR_REG_Q24),
+                                     opnd_create_reg(DR_REG_Q26),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_cmge, instr);
+
+    instr = INSTR_CREATE_cmge_vector(dc,
+                                     opnd_create_reg(DR_REG_D22),
+                                     opnd_create_reg(DR_REG_D24),
+                                     opnd_create_reg(DR_REG_D26),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_cmge, instr);
+
+    instr = INSTR_CREATE_cmge_vector(dc,
+                                     opnd_create_reg(DR_REG_Q22),
+                                     opnd_create_reg(DR_REG_Q24),
+                                     opnd_create_reg(DR_REG_Q26),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_cmge, instr);
+
+    instr = INSTR_CREATE_cmge_vector(dc,
+                                     opnd_create_reg(DR_REG_Q22),
+                                     opnd_create_reg(DR_REG_Q24),
+                                     opnd_create_reg(DR_REG_Q26),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_cmge, instr);
+
+    instr = INSTR_CREATE_sshl_vector(dc,
+                                     opnd_create_reg(DR_REG_D18),
+                                     opnd_create_reg(DR_REG_D16),
+                                     opnd_create_reg(DR_REG_D29),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sshl, instr);
+
+    instr = INSTR_CREATE_sshl_vector(dc,
+                                     opnd_create_reg(DR_REG_Q18),
+                                     opnd_create_reg(DR_REG_Q16),
+                                     opnd_create_reg(DR_REG_Q29),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sshl, instr);
+
+    instr = INSTR_CREATE_sshl_vector(dc,
+                                     opnd_create_reg(DR_REG_D18),
+                                     opnd_create_reg(DR_REG_D16),
+                                     opnd_create_reg(DR_REG_D29),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sshl, instr);
+
+    instr = INSTR_CREATE_sshl_vector(dc,
+                                     opnd_create_reg(DR_REG_Q18),
+                                     opnd_create_reg(DR_REG_Q16),
+                                     opnd_create_reg(DR_REG_Q29),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sshl, instr);
+
+    instr = INSTR_CREATE_sshl_vector(dc,
+                                     opnd_create_reg(DR_REG_D18),
+                                     opnd_create_reg(DR_REG_D16),
+                                     opnd_create_reg(DR_REG_D29),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sshl, instr);
+
+    instr = INSTR_CREATE_sshl_vector(dc,
+                                     opnd_create_reg(DR_REG_Q18),
+                                     opnd_create_reg(DR_REG_Q16),
+                                     opnd_create_reg(DR_REG_Q29),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sshl, instr);
+
+    instr = INSTR_CREATE_sshl_vector(dc,
+                                     opnd_create_reg(DR_REG_Q18),
+                                     opnd_create_reg(DR_REG_Q16),
+                                     opnd_create_reg(DR_REG_Q29),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_sshl, instr);
+
+    instr = INSTR_CREATE_sqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_D11),
+                                      opnd_create_reg(DR_REG_D19),
+                                      opnd_create_reg(DR_REG_D23),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sqshl, instr);
+
+    instr = INSTR_CREATE_sqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q11),
+                                      opnd_create_reg(DR_REG_Q19),
+                                      opnd_create_reg(DR_REG_Q23),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sqshl, instr);
+
+    instr = INSTR_CREATE_sqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_D11),
+                                      opnd_create_reg(DR_REG_D19),
+                                      opnd_create_reg(DR_REG_D23),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sqshl, instr);
+
+    instr = INSTR_CREATE_sqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q11),
+                                      opnd_create_reg(DR_REG_Q19),
+                                      opnd_create_reg(DR_REG_Q23),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sqshl, instr);
+
+    instr = INSTR_CREATE_sqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_D11),
+                                      opnd_create_reg(DR_REG_D19),
+                                      opnd_create_reg(DR_REG_D23),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sqshl, instr);
+
+    instr = INSTR_CREATE_sqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q11),
+                                      opnd_create_reg(DR_REG_Q19),
+                                      opnd_create_reg(DR_REG_Q23),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sqshl, instr);
+
+    instr = INSTR_CREATE_sqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q11),
+                                      opnd_create_reg(DR_REG_Q19),
+                                      opnd_create_reg(DR_REG_Q23),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_sqshl, instr);
+
+    instr = INSTR_CREATE_srshl_vector(dc,
+                                      opnd_create_reg(DR_REG_D8),
+                                      opnd_create_reg(DR_REG_D29),
+                                      opnd_create_reg(DR_REG_D15),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_srshl, instr);
+
+    instr = INSTR_CREATE_srshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q8),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_srshl, instr);
+
+    instr = INSTR_CREATE_srshl_vector(dc,
+                                      opnd_create_reg(DR_REG_D8),
+                                      opnd_create_reg(DR_REG_D29),
+                                      opnd_create_reg(DR_REG_D15),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_srshl, instr);
+
+    instr = INSTR_CREATE_srshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q8),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_srshl, instr);
+
+    instr = INSTR_CREATE_srshl_vector(dc,
+                                      opnd_create_reg(DR_REG_D8),
+                                      opnd_create_reg(DR_REG_D29),
+                                      opnd_create_reg(DR_REG_D15),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_srshl, instr);
+
+    instr = INSTR_CREATE_srshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q8),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_srshl, instr);
+
+    instr = INSTR_CREATE_srshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q8),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_srshl, instr);
+
+    instr = INSTR_CREATE_sqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_D28),
+                                       opnd_create_reg(DR_REG_D24),
+                                       opnd_create_reg(DR_REG_D2),
+                                       OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sqrshl, instr);
+
+    instr = INSTR_CREATE_sqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_Q28),
+                                       opnd_create_reg(DR_REG_Q24),
+                                       opnd_create_reg(DR_REG_Q2),
+                                       OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sqrshl, instr);
+
+    instr = INSTR_CREATE_sqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_D28),
+                                       opnd_create_reg(DR_REG_D24),
+                                       opnd_create_reg(DR_REG_D2),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sqrshl, instr);
+
+    instr = INSTR_CREATE_sqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_Q28),
+                                       opnd_create_reg(DR_REG_Q24),
+                                       opnd_create_reg(DR_REG_Q2),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sqrshl, instr);
+
+    instr = INSTR_CREATE_sqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_D28),
+                                       opnd_create_reg(DR_REG_D24),
+                                       opnd_create_reg(DR_REG_D2),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sqrshl, instr);
+
+    instr = INSTR_CREATE_sqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_Q28),
+                                       opnd_create_reg(DR_REG_Q24),
+                                       opnd_create_reg(DR_REG_Q2),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sqrshl, instr);
+
+    instr = INSTR_CREATE_sqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_Q28),
+                                       opnd_create_reg(DR_REG_Q24),
+                                       opnd_create_reg(DR_REG_Q2),
+                                       OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_sqrshl, instr);
+
+    instr = INSTR_CREATE_smax_vector(dc,
+                                     opnd_create_reg(DR_REG_D0),
+                                     opnd_create_reg(DR_REG_D15),
+                                     opnd_create_reg(DR_REG_D8),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_smax, instr);
+
+    instr = INSTR_CREATE_smax_vector(dc,
+                                     opnd_create_reg(DR_REG_Q0),
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q8),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_smax, instr);
+
+    instr = INSTR_CREATE_smax_vector(dc,
+                                     opnd_create_reg(DR_REG_D0),
+                                     opnd_create_reg(DR_REG_D15),
+                                     opnd_create_reg(DR_REG_D8),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_smax, instr);
+
+    instr = INSTR_CREATE_smax_vector(dc,
+                                     opnd_create_reg(DR_REG_Q0),
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q8),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_smax, instr);
+
+    instr = INSTR_CREATE_smax_vector(dc,
+                                     opnd_create_reg(DR_REG_D0),
+                                     opnd_create_reg(DR_REG_D15),
+                                     opnd_create_reg(DR_REG_D8),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_smax, instr);
+
+    instr = INSTR_CREATE_smax_vector(dc,
+                                     opnd_create_reg(DR_REG_Q0),
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q8),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_smax, instr);
+
+    instr = INSTR_CREATE_smin_vector(dc,
+                                     opnd_create_reg(DR_REG_D12),
+                                     opnd_create_reg(DR_REG_D19),
+                                     opnd_create_reg(DR_REG_D23),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_smin, instr);
+
+    instr = INSTR_CREATE_smin_vector(dc,
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q19),
+                                     opnd_create_reg(DR_REG_Q23),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_smin, instr);
+
+    instr = INSTR_CREATE_smin_vector(dc,
+                                     opnd_create_reg(DR_REG_D12),
+                                     opnd_create_reg(DR_REG_D19),
+                                     opnd_create_reg(DR_REG_D23),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_smin, instr);
+
+    instr = INSTR_CREATE_smin_vector(dc,
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q19),
+                                     opnd_create_reg(DR_REG_Q23),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_smin, instr);
+
+    instr = INSTR_CREATE_smin_vector(dc,
+                                     opnd_create_reg(DR_REG_D12),
+                                     opnd_create_reg(DR_REG_D19),
+                                     opnd_create_reg(DR_REG_D23),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_smin, instr);
+
+    instr = INSTR_CREATE_smin_vector(dc,
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q19),
+                                     opnd_create_reg(DR_REG_Q23),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_smin, instr);
+
+    instr = INSTR_CREATE_sabd_vector(dc,
+                                     opnd_create_reg(DR_REG_D15),
+                                     opnd_create_reg(DR_REG_D20),
+                                     opnd_create_reg(DR_REG_D28),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sabd, instr);
+
+    instr = INSTR_CREATE_sabd_vector(dc,
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q20),
+                                     opnd_create_reg(DR_REG_Q28),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sabd, instr);
+
+    instr = INSTR_CREATE_sabd_vector(dc,
+                                     opnd_create_reg(DR_REG_D15),
+                                     opnd_create_reg(DR_REG_D20),
+                                     opnd_create_reg(DR_REG_D28),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sabd, instr);
+
+    instr = INSTR_CREATE_sabd_vector(dc,
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q20),
+                                     opnd_create_reg(DR_REG_Q28),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sabd, instr);
+
+    instr = INSTR_CREATE_sabd_vector(dc,
+                                     opnd_create_reg(DR_REG_D15),
+                                     opnd_create_reg(DR_REG_D20),
+                                     opnd_create_reg(DR_REG_D28),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sabd, instr);
+
+    instr = INSTR_CREATE_sabd_vector(dc,
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q20),
+                                     opnd_create_reg(DR_REG_Q28),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sabd, instr);
+
+    instr = INSTR_CREATE_saba_vector(dc,
+                                     opnd_create_reg(DR_REG_D27),
+                                     opnd_create_reg(DR_REG_D30),
+                                     opnd_create_reg(DR_REG_D4),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_saba, instr);
+
+    instr = INSTR_CREATE_saba_vector(dc,
+                                     opnd_create_reg(DR_REG_Q27),
+                                     opnd_create_reg(DR_REG_Q30),
+                                     opnd_create_reg(DR_REG_Q4),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_saba, instr);
+
+    instr = INSTR_CREATE_saba_vector(dc,
+                                     opnd_create_reg(DR_REG_D27),
+                                     opnd_create_reg(DR_REG_D30),
+                                     opnd_create_reg(DR_REG_D4),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_saba, instr);
+
+    instr = INSTR_CREATE_saba_vector(dc,
+                                     opnd_create_reg(DR_REG_Q27),
+                                     opnd_create_reg(DR_REG_Q30),
+                                     opnd_create_reg(DR_REG_Q4),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_saba, instr);
+
+    instr = INSTR_CREATE_saba_vector(dc,
+                                     opnd_create_reg(DR_REG_D27),
+                                     opnd_create_reg(DR_REG_D30),
+                                     opnd_create_reg(DR_REG_D4),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_saba, instr);
+
+    instr = INSTR_CREATE_saba_vector(dc,
+                                     opnd_create_reg(DR_REG_Q27),
+                                     opnd_create_reg(DR_REG_Q30),
+                                     opnd_create_reg(DR_REG_Q4),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_saba, instr);
+
+    instr = INSTR_CREATE_add_vector(dc,
+                                    opnd_create_reg(DR_REG_D20),
+                                    opnd_create_reg(DR_REG_D10),
+                                    opnd_create_reg(DR_REG_D14),
+                                    OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_add, instr);
+
+    instr = INSTR_CREATE_add_vector(dc,
+                                    opnd_create_reg(DR_REG_Q20),
+                                    opnd_create_reg(DR_REG_Q10),
+                                    opnd_create_reg(DR_REG_Q14),
+                                    OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_add, instr);
+
+    instr = INSTR_CREATE_add_vector(dc,
+                                    opnd_create_reg(DR_REG_D20),
+                                    opnd_create_reg(DR_REG_D10),
+                                    opnd_create_reg(DR_REG_D14),
+                                    OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_add, instr);
+
+    instr = INSTR_CREATE_add_vector(dc,
+                                    opnd_create_reg(DR_REG_Q20),
+                                    opnd_create_reg(DR_REG_Q10),
+                                    opnd_create_reg(DR_REG_Q14),
+                                    OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_add, instr);
+
+    instr = INSTR_CREATE_add_vector(dc,
+                                    opnd_create_reg(DR_REG_D20),
+                                    opnd_create_reg(DR_REG_D10),
+                                    opnd_create_reg(DR_REG_D14),
+                                    OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_add, instr);
+
+    instr = INSTR_CREATE_add_vector(dc,
+                                    opnd_create_reg(DR_REG_Q20),
+                                    opnd_create_reg(DR_REG_Q10),
+                                    opnd_create_reg(DR_REG_Q14),
+                                    OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_add, instr);
+
+    instr = INSTR_CREATE_add_vector(dc,
+                                    opnd_create_reg(DR_REG_Q20),
+                                    opnd_create_reg(DR_REG_Q10),
+                                    opnd_create_reg(DR_REG_Q14),
+                                    OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_add, instr);
+
+    instr = INSTR_CREATE_cmtst_vector(dc,
+                                      opnd_create_reg(DR_REG_D26),
+                                      opnd_create_reg(DR_REG_D15),
+                                      opnd_create_reg(DR_REG_D2),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_cmtst, instr);
+
+    instr = INSTR_CREATE_cmtst_vector(dc,
+                                      opnd_create_reg(DR_REG_Q26),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q2),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_cmtst, instr);
+
+    instr = INSTR_CREATE_cmtst_vector(dc,
+                                      opnd_create_reg(DR_REG_D26),
+                                      opnd_create_reg(DR_REG_D15),
+                                      opnd_create_reg(DR_REG_D2),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_cmtst, instr);
+
+    instr = INSTR_CREATE_cmtst_vector(dc,
+                                      opnd_create_reg(DR_REG_Q26),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q2),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_cmtst, instr);
+
+    instr = INSTR_CREATE_cmtst_vector(dc,
+                                      opnd_create_reg(DR_REG_D26),
+                                      opnd_create_reg(DR_REG_D15),
+                                      opnd_create_reg(DR_REG_D2),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_cmtst, instr);
+
+    instr = INSTR_CREATE_cmtst_vector(dc,
+                                      opnd_create_reg(DR_REG_Q26),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q2),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_cmtst, instr);
+
+    instr = INSTR_CREATE_cmtst_vector(dc,
+                                      opnd_create_reg(DR_REG_Q26),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q2),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_cmtst, instr);
+
+    instr = INSTR_CREATE_mla_vector(dc,
+                                    opnd_create_reg(DR_REG_D2),
+                                    opnd_create_reg(DR_REG_D19),
+                                    opnd_create_reg(DR_REG_D4),
+                                    OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_mla, instr);
+
+    instr = INSTR_CREATE_mla_vector(dc,
+                                    opnd_create_reg(DR_REG_Q2),
+                                    opnd_create_reg(DR_REG_Q19),
+                                    opnd_create_reg(DR_REG_Q4),
+                                    OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_mla, instr);
+
+    instr = INSTR_CREATE_mla_vector(dc,
+                                    opnd_create_reg(DR_REG_D2),
+                                    opnd_create_reg(DR_REG_D19),
+                                    opnd_create_reg(DR_REG_D4),
+                                    OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_mla, instr);
+
+    instr = INSTR_CREATE_mla_vector(dc,
+                                    opnd_create_reg(DR_REG_Q2),
+                                    opnd_create_reg(DR_REG_Q19),
+                                    opnd_create_reg(DR_REG_Q4),
+                                    OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_mla, instr);
+
+    instr = INSTR_CREATE_mla_vector(dc,
+                                    opnd_create_reg(DR_REG_D2),
+                                    opnd_create_reg(DR_REG_D19),
+                                    opnd_create_reg(DR_REG_D4),
+                                    OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_mla, instr);
+
+    instr = INSTR_CREATE_mla_vector(dc,
+                                    opnd_create_reg(DR_REG_Q2),
+                                    opnd_create_reg(DR_REG_Q19),
+                                    opnd_create_reg(DR_REG_Q4),
+                                    OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_mla, instr);
+
+    instr = INSTR_CREATE_mul_vector(dc,
+                                    opnd_create_reg(DR_REG_D5),
+                                    opnd_create_reg(DR_REG_D9),
+                                    opnd_create_reg(DR_REG_D24),
+                                    OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_mul, instr);
+
+    instr = INSTR_CREATE_mul_vector(dc,
+                                    opnd_create_reg(DR_REG_Q5),
+                                    opnd_create_reg(DR_REG_Q9),
+                                    opnd_create_reg(DR_REG_Q24),
+                                    OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_mul, instr);
+
+    instr = INSTR_CREATE_mul_vector(dc,
+                                    opnd_create_reg(DR_REG_D5),
+                                    opnd_create_reg(DR_REG_D9),
+                                    opnd_create_reg(DR_REG_D24),
+                                    OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_mul, instr);
+
+    instr = INSTR_CREATE_mul_vector(dc,
+                                    opnd_create_reg(DR_REG_Q5),
+                                    opnd_create_reg(DR_REG_Q9),
+                                    opnd_create_reg(DR_REG_Q24),
+                                    OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_mul, instr);
+
+    instr = INSTR_CREATE_mul_vector(dc,
+                                    opnd_create_reg(DR_REG_D5),
+                                    opnd_create_reg(DR_REG_D9),
+                                    opnd_create_reg(DR_REG_D24),
+                                    OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_mul, instr);
+
+    instr = INSTR_CREATE_mul_vector(dc,
+                                    opnd_create_reg(DR_REG_Q5),
+                                    opnd_create_reg(DR_REG_Q9),
+                                    opnd_create_reg(DR_REG_Q24),
+                                    OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_mul, instr);
+
+    instr = INSTR_CREATE_smaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_D23),
+                                      opnd_create_reg(DR_REG_D9),
+                                      opnd_create_reg(DR_REG_D7),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_smaxp, instr);
+
+    instr = INSTR_CREATE_smaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q23),
+                                      opnd_create_reg(DR_REG_Q9),
+                                      opnd_create_reg(DR_REG_Q7),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_smaxp, instr);
+
+    instr = INSTR_CREATE_smaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_D23),
+                                      opnd_create_reg(DR_REG_D9),
+                                      opnd_create_reg(DR_REG_D7),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_smaxp, instr);
+
+    instr = INSTR_CREATE_smaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q23),
+                                      opnd_create_reg(DR_REG_Q9),
+                                      opnd_create_reg(DR_REG_Q7),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_smaxp, instr);
+
+    instr = INSTR_CREATE_smaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_D23),
+                                      opnd_create_reg(DR_REG_D9),
+                                      opnd_create_reg(DR_REG_D7),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_smaxp, instr);
+
+    instr = INSTR_CREATE_smaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q23),
+                                      opnd_create_reg(DR_REG_Q9),
+                                      opnd_create_reg(DR_REG_Q7),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_smaxp, instr);
+
+    instr = INSTR_CREATE_sminp_vector(dc,
+                                      opnd_create_reg(DR_REG_D6),
+                                      opnd_create_reg(DR_REG_D28),
+                                      opnd_create_reg(DR_REG_D10),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sminp, instr);
+
+    instr = INSTR_CREATE_sminp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q6),
+                                      opnd_create_reg(DR_REG_Q28),
+                                      opnd_create_reg(DR_REG_Q10),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sminp, instr);
+
+    instr = INSTR_CREATE_sminp_vector(dc,
+                                      opnd_create_reg(DR_REG_D6),
+                                      opnd_create_reg(DR_REG_D28),
+                                      opnd_create_reg(DR_REG_D10),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sminp, instr);
+
+    instr = INSTR_CREATE_sminp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q6),
+                                      opnd_create_reg(DR_REG_Q28),
+                                      opnd_create_reg(DR_REG_Q10),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sminp, instr);
+
+    instr = INSTR_CREATE_sminp_vector(dc,
+                                      opnd_create_reg(DR_REG_D6),
+                                      opnd_create_reg(DR_REG_D28),
+                                      opnd_create_reg(DR_REG_D10),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sminp, instr);
+
+    instr = INSTR_CREATE_sminp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q6),
+                                      opnd_create_reg(DR_REG_Q28),
+                                      opnd_create_reg(DR_REG_Q10),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sminp, instr);
+
+    instr = INSTR_CREATE_sqdmulh_vector(dc,
+                                        opnd_create_reg(DR_REG_D12),
+                                        opnd_create_reg(DR_REG_D22),
+                                        opnd_create_reg(DR_REG_D27),
+                                        OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sqdmulh, instr);
+
+    instr = INSTR_CREATE_sqdmulh_vector(dc,
+                                        opnd_create_reg(DR_REG_Q12),
+                                        opnd_create_reg(DR_REG_Q22),
+                                        opnd_create_reg(DR_REG_Q27),
+                                        OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sqdmulh, instr);
+
+    instr = INSTR_CREATE_sqdmulh_vector(dc,
+                                        opnd_create_reg(DR_REG_D12),
+                                        opnd_create_reg(DR_REG_D22),
+                                        opnd_create_reg(DR_REG_D27),
+                                        OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sqdmulh, instr);
+
+    instr = INSTR_CREATE_sqdmulh_vector(dc,
+                                        opnd_create_reg(DR_REG_Q12),
+                                        opnd_create_reg(DR_REG_Q22),
+                                        opnd_create_reg(DR_REG_Q27),
+                                        OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sqdmulh, instr);
+
+    instr = INSTR_CREATE_addp_vector(dc,
+                                     opnd_create_reg(DR_REG_D26),
+                                     opnd_create_reg(DR_REG_D28),
+                                     opnd_create_reg(DR_REG_D15),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_addp, instr);
+
+    instr = INSTR_CREATE_addp_vector(dc,
+                                     opnd_create_reg(DR_REG_Q26),
+                                     opnd_create_reg(DR_REG_Q28),
+                                     opnd_create_reg(DR_REG_Q15),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_addp, instr);
+
+    instr = INSTR_CREATE_addp_vector(dc,
+                                     opnd_create_reg(DR_REG_D26),
+                                     opnd_create_reg(DR_REG_D28),
+                                     opnd_create_reg(DR_REG_D15),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_addp, instr);
+
+    instr = INSTR_CREATE_addp_vector(dc,
+                                     opnd_create_reg(DR_REG_Q26),
+                                     opnd_create_reg(DR_REG_Q28),
+                                     opnd_create_reg(DR_REG_Q15),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_addp, instr);
+
+    instr = INSTR_CREATE_addp_vector(dc,
+                                     opnd_create_reg(DR_REG_D26),
+                                     opnd_create_reg(DR_REG_D28),
+                                     opnd_create_reg(DR_REG_D15),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_addp, instr);
+
+    instr = INSTR_CREATE_addp_vector(dc,
+                                     opnd_create_reg(DR_REG_Q26),
+                                     opnd_create_reg(DR_REG_Q28),
+                                     opnd_create_reg(DR_REG_Q15),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_addp, instr);
+
+    instr = INSTR_CREATE_addp_vector(dc,
+                                     opnd_create_reg(DR_REG_Q26),
+                                     opnd_create_reg(DR_REG_Q28),
+                                     opnd_create_reg(DR_REG_Q15),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_addp, instr);
+
+    instr = INSTR_CREATE_fmaxnm_vector(dc,
+                                       opnd_create_reg(DR_REG_D17),
+                                       opnd_create_reg(DR_REG_D9),
+                                       opnd_create_reg(DR_REG_D11),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmaxnm, instr);
+
+    instr = INSTR_CREATE_fmaxnm_vector(dc,
+                                       opnd_create_reg(DR_REG_Q17),
+                                       opnd_create_reg(DR_REG_Q9),
+                                       opnd_create_reg(DR_REG_Q11),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmaxnm, instr);
+
+    instr = INSTR_CREATE_fmaxnm_vector(dc,
+                                       opnd_create_reg(DR_REG_Q17),
+                                       opnd_create_reg(DR_REG_Q9),
+                                       opnd_create_reg(DR_REG_Q11),
+                                       OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fmaxnm, instr);
+
+    instr = INSTR_CREATE_fmla_vector(dc,
+                                     opnd_create_reg(DR_REG_D7),
+                                     opnd_create_reg(DR_REG_D29),
+                                     opnd_create_reg(DR_REG_D19),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmla, instr);
+
+    instr = INSTR_CREATE_fmla_vector(dc,
+                                     opnd_create_reg(DR_REG_Q7),
+                                     opnd_create_reg(DR_REG_Q29),
+                                     opnd_create_reg(DR_REG_Q19),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmla, instr);
+
+    instr = INSTR_CREATE_fmla_vector(dc,
+                                     opnd_create_reg(DR_REG_Q7),
+                                     opnd_create_reg(DR_REG_Q29),
+                                     opnd_create_reg(DR_REG_Q19),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fmla, instr);
+
+    instr = INSTR_CREATE_fadd_vector(dc,
+                                     opnd_create_reg(DR_REG_D10),
+                                     opnd_create_reg(DR_REG_D11),
+                                     opnd_create_reg(DR_REG_D11),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fadd, instr);
+
+    instr = INSTR_CREATE_fadd_vector(dc,
+                                     opnd_create_reg(DR_REG_Q10),
+                                     opnd_create_reg(DR_REG_Q11),
+                                     opnd_create_reg(DR_REG_Q11),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fadd, instr);
+
+    instr = INSTR_CREATE_fadd_vector(dc,
+                                     opnd_create_reg(DR_REG_Q10),
+                                     opnd_create_reg(DR_REG_Q11),
+                                     opnd_create_reg(DR_REG_Q11),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fadd, instr);
+
+    instr = INSTR_CREATE_fmulx_vector(dc,
+                                      opnd_create_reg(DR_REG_D30),
+                                      opnd_create_reg(DR_REG_D22),
+                                      opnd_create_reg(DR_REG_D20),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmulx, instr);
+
+    instr = INSTR_CREATE_fmulx_vector(dc,
+                                      opnd_create_reg(DR_REG_Q30),
+                                      opnd_create_reg(DR_REG_Q22),
+                                      opnd_create_reg(DR_REG_Q20),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmulx, instr);
+
+    instr = INSTR_CREATE_fmulx_vector(dc,
+                                      opnd_create_reg(DR_REG_Q30),
+                                      opnd_create_reg(DR_REG_Q22),
+                                      opnd_create_reg(DR_REG_Q20),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fmulx, instr);
+
+    instr = INSTR_CREATE_fcmeq_vector(dc,
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D14),
+                                      opnd_create_reg(DR_REG_D0),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcmeq, instr);
+
+    instr = INSTR_CREATE_fcmeq_vector(dc,
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q14),
+                                      opnd_create_reg(DR_REG_Q0),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcmeq, instr);
+
+    instr = INSTR_CREATE_fcmeq_vector(dc,
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q14),
+                                      opnd_create_reg(DR_REG_Q0),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fcmeq, instr);
+
+    instr = INSTR_CREATE_fmlal_vector(dc,
+                                      opnd_create_reg(DR_REG_D0),
+                                      opnd_create_reg(DR_REG_D29),
+                                      opnd_create_reg(DR_REG_D31));
+    test_instr_encoding(dc, OP_fmlal, instr);
+
+    instr = INSTR_CREATE_fmlal_vector(dc,
+                                      opnd_create_reg(DR_REG_Q0),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q31));
+    test_instr_encoding(dc, OP_fmlal, instr);
+
+    instr = INSTR_CREATE_fmax_vector(dc,
+                                     opnd_create_reg(DR_REG_D2),
+                                     opnd_create_reg(DR_REG_D21),
+                                     opnd_create_reg(DR_REG_D20),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmax, instr);
+
+    instr = INSTR_CREATE_fmax_vector(dc,
+                                     opnd_create_reg(DR_REG_Q2),
+                                     opnd_create_reg(DR_REG_Q21),
+                                     opnd_create_reg(DR_REG_Q20),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmax, instr);
+
+    instr = INSTR_CREATE_fmax_vector(dc,
+                                     opnd_create_reg(DR_REG_Q2),
+                                     opnd_create_reg(DR_REG_Q21),
+                                     opnd_create_reg(DR_REG_Q20),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fmax, instr);
+
+    instr = INSTR_CREATE_frecps_vector(dc,
+                                       opnd_create_reg(DR_REG_D15),
+                                       opnd_create_reg(DR_REG_D5),
+                                       opnd_create_reg(DR_REG_D16),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_frecps, instr);
+
+    instr = INSTR_CREATE_frecps_vector(dc,
+                                       opnd_create_reg(DR_REG_Q15),
+                                       opnd_create_reg(DR_REG_Q5),
+                                       opnd_create_reg(DR_REG_Q16),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_frecps, instr);
+
+    instr = INSTR_CREATE_frecps_vector(dc,
+                                       opnd_create_reg(DR_REG_Q15),
+                                       opnd_create_reg(DR_REG_Q5),
+                                       opnd_create_reg(DR_REG_Q16),
+                                       OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_frecps, instr);
+
+    instr = INSTR_CREATE_and_vector(dc,
+                                    opnd_create_reg(DR_REG_D28),
+                                    opnd_create_reg(DR_REG_D25),
+                                    opnd_create_reg(DR_REG_D10));
+    test_instr_encoding(dc, OP_and, instr);
+
+    instr = INSTR_CREATE_and_vector(dc,
+                                    opnd_create_reg(DR_REG_Q28),
+                                    opnd_create_reg(DR_REG_Q25),
+                                    opnd_create_reg(DR_REG_Q10));
+    test_instr_encoding(dc, OP_and, instr);
+
+    instr = INSTR_CREATE_bic_vector(dc,
+                                    opnd_create_reg(DR_REG_D24),
+                                    opnd_create_reg(DR_REG_D31),
+                                    opnd_create_reg(DR_REG_D15));
+    test_instr_encoding(dc, OP_bic, instr);
+
+    instr = INSTR_CREATE_bic_vector(dc,
+                                    opnd_create_reg(DR_REG_Q24),
+                                    opnd_create_reg(DR_REG_Q31),
+                                    opnd_create_reg(DR_REG_Q15));
+    test_instr_encoding(dc, OP_bic, instr);
+
+    instr = INSTR_CREATE_fminnm_vector(dc,
+                                       opnd_create_reg(DR_REG_D17),
+                                       opnd_create_reg(DR_REG_D30),
+                                       opnd_create_reg(DR_REG_D31),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fminnm, instr);
+
+    instr = INSTR_CREATE_fminnm_vector(dc,
+                                       opnd_create_reg(DR_REG_Q17),
+                                       opnd_create_reg(DR_REG_Q30),
+                                       opnd_create_reg(DR_REG_Q31),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fminnm, instr);
+
+    instr = INSTR_CREATE_fminnm_vector(dc,
+                                       opnd_create_reg(DR_REG_Q17),
+                                       opnd_create_reg(DR_REG_Q30),
+                                       opnd_create_reg(DR_REG_Q31),
+                                       OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fminnm, instr);
+
+    instr = INSTR_CREATE_fmls_vector(dc,
+                                     opnd_create_reg(DR_REG_D4),
+                                     opnd_create_reg(DR_REG_D31),
+                                     opnd_create_reg(DR_REG_D29),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmls, instr);
+
+    instr = INSTR_CREATE_fmls_vector(dc,
+                                     opnd_create_reg(DR_REG_Q4),
+                                     opnd_create_reg(DR_REG_Q31),
+                                     opnd_create_reg(DR_REG_Q29),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmls, instr);
+
+    instr = INSTR_CREATE_fmls_vector(dc,
+                                     opnd_create_reg(DR_REG_Q4),
+                                     opnd_create_reg(DR_REG_Q31),
+                                     opnd_create_reg(DR_REG_Q29),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fmls, instr);
+
+    instr = INSTR_CREATE_fsub_vector(dc,
+                                     opnd_create_reg(DR_REG_D25),
+                                     opnd_create_reg(DR_REG_D8),
+                                     opnd_create_reg(DR_REG_D26),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fsub, instr);
+
+    instr = INSTR_CREATE_fsub_vector(dc,
+                                     opnd_create_reg(DR_REG_Q25),
+                                     opnd_create_reg(DR_REG_Q8),
+                                     opnd_create_reg(DR_REG_Q26),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fsub, instr);
+
+    instr = INSTR_CREATE_fsub_vector(dc,
+                                     opnd_create_reg(DR_REG_Q25),
+                                     opnd_create_reg(DR_REG_Q8),
+                                     opnd_create_reg(DR_REG_Q26),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fsub, instr);
+
+    instr = INSTR_CREATE_fmlsl_vector(dc,
+                                      opnd_create_reg(DR_REG_D0),
+                                      opnd_create_reg(DR_REG_D29),
+                                      opnd_create_reg(DR_REG_D31));
+    test_instr_encoding(dc, OP_fmlsl, instr);
+
+    instr = INSTR_CREATE_fmlsl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q0),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q31));
+    test_instr_encoding(dc, OP_fmlsl, instr);
+
+    instr = INSTR_CREATE_fmin_vector(dc,
+                                     opnd_create_reg(DR_REG_D22),
+                                     opnd_create_reg(DR_REG_D24),
+                                     opnd_create_reg(DR_REG_D31),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmin, instr);
+
+    instr = INSTR_CREATE_fmin_vector(dc,
+                                     opnd_create_reg(DR_REG_Q22),
+                                     opnd_create_reg(DR_REG_Q24),
+                                     opnd_create_reg(DR_REG_Q31),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmin, instr);
+
+    instr = INSTR_CREATE_fmin_vector(dc,
+                                     opnd_create_reg(DR_REG_Q22),
+                                     opnd_create_reg(DR_REG_Q24),
+                                     opnd_create_reg(DR_REG_Q31),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fmin, instr);
+
+    instr = INSTR_CREATE_frsqrts_vector(dc,
+                                        opnd_create_reg(DR_REG_D10),
+                                        opnd_create_reg(DR_REG_D28),
+                                        opnd_create_reg(DR_REG_D6),
+                                        OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_frsqrts, instr);
+
+    instr = INSTR_CREATE_frsqrts_vector(dc,
+                                        opnd_create_reg(DR_REG_Q10),
+                                        opnd_create_reg(DR_REG_Q28),
+                                        opnd_create_reg(DR_REG_Q6),
+                                        OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_frsqrts, instr);
+
+    instr = INSTR_CREATE_frsqrts_vector(dc,
+                                        opnd_create_reg(DR_REG_Q10),
+                                        opnd_create_reg(DR_REG_Q28),
+                                        opnd_create_reg(DR_REG_Q6),
+                                        OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_frsqrts, instr);
+
+    instr = INSTR_CREATE_orr_vector(dc,
+                                    opnd_create_reg(DR_REG_D26),
+                                    opnd_create_reg(DR_REG_D2),
+                                    opnd_create_reg(DR_REG_D0));
+    test_instr_encoding(dc, OP_orr, instr);
+
+    instr = INSTR_CREATE_orr_vector(dc,
+                                    opnd_create_reg(DR_REG_Q26),
+                                    opnd_create_reg(DR_REG_Q2),
+                                    opnd_create_reg(DR_REG_Q0));
+    test_instr_encoding(dc, OP_orr, instr);
+
+    instr = INSTR_CREATE_orn_vector(dc,
+                                    opnd_create_reg(DR_REG_D28),
+                                    opnd_create_reg(DR_REG_D4),
+                                    opnd_create_reg(DR_REG_D3));
+    test_instr_encoding(dc, OP_orn, instr);
+
+    instr = INSTR_CREATE_orn_vector(dc,
+                                    opnd_create_reg(DR_REG_Q28),
+                                    opnd_create_reg(DR_REG_Q4),
+                                    opnd_create_reg(DR_REG_Q3));
+    test_instr_encoding(dc, OP_orn, instr);
+
+    instr = INSTR_CREATE_uhadd_vector(dc,
+                                      opnd_create_reg(DR_REG_D22),
+                                      opnd_create_reg(DR_REG_D5),
+                                      opnd_create_reg(DR_REG_D9),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uhadd, instr);
+
+    instr = INSTR_CREATE_uhadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q22),
+                                      opnd_create_reg(DR_REG_Q5),
+                                      opnd_create_reg(DR_REG_Q9),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uhadd, instr);
+
+    instr = INSTR_CREATE_uhadd_vector(dc,
+                                      opnd_create_reg(DR_REG_D22),
+                                      opnd_create_reg(DR_REG_D5),
+                                      opnd_create_reg(DR_REG_D9),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uhadd, instr);
+
+    instr = INSTR_CREATE_uhadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q22),
+                                      opnd_create_reg(DR_REG_Q5),
+                                      opnd_create_reg(DR_REG_Q9),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uhadd, instr);
+
+    instr = INSTR_CREATE_uhadd_vector(dc,
+                                      opnd_create_reg(DR_REG_D22),
+                                      opnd_create_reg(DR_REG_D5),
+                                      opnd_create_reg(DR_REG_D9),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uhadd, instr);
+
+    instr = INSTR_CREATE_uhadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q22),
+                                      opnd_create_reg(DR_REG_Q5),
+                                      opnd_create_reg(DR_REG_Q9),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uhadd, instr);
+
+    instr = INSTR_CREATE_uqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_D6),
+                                      opnd_create_reg(DR_REG_D29),
+                                      opnd_create_reg(DR_REG_D31),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uqadd, instr);
+
+    instr = INSTR_CREATE_uqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q6),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q31),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uqadd, instr);
+
+    instr = INSTR_CREATE_uqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_D6),
+                                      opnd_create_reg(DR_REG_D29),
+                                      opnd_create_reg(DR_REG_D31),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uqadd, instr);
+
+    instr = INSTR_CREATE_uqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q6),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q31),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uqadd, instr);
+
+    instr = INSTR_CREATE_uqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_D6),
+                                      opnd_create_reg(DR_REG_D29),
+                                      opnd_create_reg(DR_REG_D31),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uqadd, instr);
+
+    instr = INSTR_CREATE_uqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q6),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q31),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uqadd, instr);
+
+    instr = INSTR_CREATE_uqadd_vector(dc,
+                                      opnd_create_reg(DR_REG_Q6),
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q31),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_uqadd, instr);
+
+    instr = INSTR_CREATE_urhadd_vector(dc,
+                                       opnd_create_reg(DR_REG_D8),
+                                       opnd_create_reg(DR_REG_D29),
+                                       opnd_create_reg(DR_REG_D27),
+                                       OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_urhadd, instr);
+
+    instr = INSTR_CREATE_urhadd_vector(dc,
+                                       opnd_create_reg(DR_REG_Q8),
+                                       opnd_create_reg(DR_REG_Q29),
+                                       opnd_create_reg(DR_REG_Q27),
+                                       OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_urhadd, instr);
+
+    instr = INSTR_CREATE_urhadd_vector(dc,
+                                       opnd_create_reg(DR_REG_D8),
+                                       opnd_create_reg(DR_REG_D29),
+                                       opnd_create_reg(DR_REG_D27),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_urhadd, instr);
+
+    instr = INSTR_CREATE_urhadd_vector(dc,
+                                       opnd_create_reg(DR_REG_Q8),
+                                       opnd_create_reg(DR_REG_Q29),
+                                       opnd_create_reg(DR_REG_Q27),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_urhadd, instr);
+
+    instr = INSTR_CREATE_urhadd_vector(dc,
+                                       opnd_create_reg(DR_REG_D8),
+                                       opnd_create_reg(DR_REG_D29),
+                                       opnd_create_reg(DR_REG_D27),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_urhadd, instr);
+
+    instr = INSTR_CREATE_urhadd_vector(dc,
+                                       opnd_create_reg(DR_REG_Q8),
+                                       opnd_create_reg(DR_REG_Q29),
+                                       opnd_create_reg(DR_REG_Q27),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_urhadd, instr);
+
+    instr = INSTR_CREATE_uhsub_vector(dc,
+                                      opnd_create_reg(DR_REG_D28),
+                                      opnd_create_reg(DR_REG_D21),
+                                      opnd_create_reg(DR_REG_D16),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uhsub, instr);
+
+    instr = INSTR_CREATE_uhsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q28),
+                                      opnd_create_reg(DR_REG_Q21),
+                                      opnd_create_reg(DR_REG_Q16),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uhsub, instr);
+
+    instr = INSTR_CREATE_uhsub_vector(dc,
+                                      opnd_create_reg(DR_REG_D28),
+                                      opnd_create_reg(DR_REG_D21),
+                                      opnd_create_reg(DR_REG_D16),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uhsub, instr);
+
+    instr = INSTR_CREATE_uhsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q28),
+                                      opnd_create_reg(DR_REG_Q21),
+                                      opnd_create_reg(DR_REG_Q16),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uhsub, instr);
+
+    instr = INSTR_CREATE_uhsub_vector(dc,
+                                      opnd_create_reg(DR_REG_D28),
+                                      opnd_create_reg(DR_REG_D21),
+                                      opnd_create_reg(DR_REG_D16),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uhsub, instr);
+
+    instr = INSTR_CREATE_uhsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q28),
+                                      opnd_create_reg(DR_REG_Q21),
+                                      opnd_create_reg(DR_REG_Q16),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uhsub, instr);
+
+    instr = INSTR_CREATE_uqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_D29),
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D21),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uqsub, instr);
+
+    instr = INSTR_CREATE_uqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q21),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uqsub, instr);
+
+    instr = INSTR_CREATE_uqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_D29),
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D21),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uqsub, instr);
+
+    instr = INSTR_CREATE_uqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q21),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uqsub, instr);
+
+    instr = INSTR_CREATE_uqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_D29),
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D21),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uqsub, instr);
+
+    instr = INSTR_CREATE_uqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q21),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uqsub, instr);
+
+    instr = INSTR_CREATE_uqsub_vector(dc,
+                                      opnd_create_reg(DR_REG_Q29),
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q21),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_uqsub, instr);
+
+    instr = INSTR_CREATE_cmhi_vector(dc,
+                                     opnd_create_reg(DR_REG_D9),
+                                     opnd_create_reg(DR_REG_D15),
+                                     opnd_create_reg(DR_REG_D20),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_cmhi, instr);
+
+    instr = INSTR_CREATE_cmhi_vector(dc,
+                                     opnd_create_reg(DR_REG_Q9),
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q20),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_cmhi, instr);
+
+    instr = INSTR_CREATE_cmhi_vector(dc,
+                                     opnd_create_reg(DR_REG_D9),
+                                     opnd_create_reg(DR_REG_D15),
+                                     opnd_create_reg(DR_REG_D20),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_cmhi, instr);
+
+    instr = INSTR_CREATE_cmhi_vector(dc,
+                                     opnd_create_reg(DR_REG_Q9),
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q20),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_cmhi, instr);
+
+    instr = INSTR_CREATE_cmhi_vector(dc,
+                                     opnd_create_reg(DR_REG_D9),
+                                     opnd_create_reg(DR_REG_D15),
+                                     opnd_create_reg(DR_REG_D20),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_cmhi, instr);
+
+    instr = INSTR_CREATE_cmhi_vector(dc,
+                                     opnd_create_reg(DR_REG_Q9),
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q20),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_cmhi, instr);
+
+    instr = INSTR_CREATE_cmhi_vector(dc,
+                                     opnd_create_reg(DR_REG_Q9),
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q20),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_cmhi, instr);
+
+    instr = INSTR_CREATE_cmhs_vector(dc,
+                                     opnd_create_reg(DR_REG_D2),
+                                     opnd_create_reg(DR_REG_D12),
+                                     opnd_create_reg(DR_REG_D30),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_cmhs, instr);
+
+    instr = INSTR_CREATE_cmhs_vector(dc,
+                                     opnd_create_reg(DR_REG_Q2),
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q30),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_cmhs, instr);
+
+    instr = INSTR_CREATE_cmhs_vector(dc,
+                                     opnd_create_reg(DR_REG_D2),
+                                     opnd_create_reg(DR_REG_D12),
+                                     opnd_create_reg(DR_REG_D30),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_cmhs, instr);
+
+    instr = INSTR_CREATE_cmhs_vector(dc,
+                                     opnd_create_reg(DR_REG_Q2),
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q30),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_cmhs, instr);
+
+    instr = INSTR_CREATE_cmhs_vector(dc,
+                                     opnd_create_reg(DR_REG_D2),
+                                     opnd_create_reg(DR_REG_D12),
+                                     opnd_create_reg(DR_REG_D30),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_cmhs, instr);
+
+    instr = INSTR_CREATE_cmhs_vector(dc,
+                                     opnd_create_reg(DR_REG_Q2),
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q30),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_cmhs, instr);
+
+    instr = INSTR_CREATE_cmhs_vector(dc,
+                                     opnd_create_reg(DR_REG_Q2),
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q30),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_cmhs, instr);
+
+    instr = INSTR_CREATE_ushl_vector(dc,
+                                     opnd_create_reg(DR_REG_D1),
+                                     opnd_create_reg(DR_REG_D7),
+                                     opnd_create_reg(DR_REG_D18),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_ushl, instr);
+
+    instr = INSTR_CREATE_ushl_vector(dc,
+                                     opnd_create_reg(DR_REG_Q1),
+                                     opnd_create_reg(DR_REG_Q7),
+                                     opnd_create_reg(DR_REG_Q18),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_ushl, instr);
+
+    instr = INSTR_CREATE_ushl_vector(dc,
+                                     opnd_create_reg(DR_REG_D1),
+                                     opnd_create_reg(DR_REG_D7),
+                                     opnd_create_reg(DR_REG_D18),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_ushl, instr);
+
+    instr = INSTR_CREATE_ushl_vector(dc,
+                                     opnd_create_reg(DR_REG_Q1),
+                                     opnd_create_reg(DR_REG_Q7),
+                                     opnd_create_reg(DR_REG_Q18),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_ushl, instr);
+
+    instr = INSTR_CREATE_ushl_vector(dc,
+                                     opnd_create_reg(DR_REG_D1),
+                                     opnd_create_reg(DR_REG_D7),
+                                     opnd_create_reg(DR_REG_D18),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_ushl, instr);
+
+    instr = INSTR_CREATE_ushl_vector(dc,
+                                     opnd_create_reg(DR_REG_Q1),
+                                     opnd_create_reg(DR_REG_Q7),
+                                     opnd_create_reg(DR_REG_Q18),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_ushl, instr);
+
+    instr = INSTR_CREATE_ushl_vector(dc,
+                                     opnd_create_reg(DR_REG_Q1),
+                                     opnd_create_reg(DR_REG_Q7),
+                                     opnd_create_reg(DR_REG_Q18),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_ushl, instr);
+
+    instr = INSTR_CREATE_uqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D15),
+                                      opnd_create_reg(DR_REG_D18),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uqshl, instr);
+
+    instr = INSTR_CREATE_uqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q18),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uqshl, instr);
+
+    instr = INSTR_CREATE_uqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D15),
+                                      opnd_create_reg(DR_REG_D18),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uqshl, instr);
+
+    instr = INSTR_CREATE_uqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q18),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uqshl, instr);
+
+    instr = INSTR_CREATE_uqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D15),
+                                      opnd_create_reg(DR_REG_D18),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uqshl, instr);
+
+    instr = INSTR_CREATE_uqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q18),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uqshl, instr);
+
+    instr = INSTR_CREATE_uqshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q15),
+                                      opnd_create_reg(DR_REG_Q18),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_uqshl, instr);
+
+    instr = INSTR_CREATE_urshl_vector(dc,
+                                      opnd_create_reg(DR_REG_D5),
+                                      opnd_create_reg(DR_REG_D2),
+                                      opnd_create_reg(DR_REG_D6),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_urshl, instr);
+
+    instr = INSTR_CREATE_urshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q5),
+                                      opnd_create_reg(DR_REG_Q2),
+                                      opnd_create_reg(DR_REG_Q6),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_urshl, instr);
+
+    instr = INSTR_CREATE_urshl_vector(dc,
+                                      opnd_create_reg(DR_REG_D5),
+                                      opnd_create_reg(DR_REG_D2),
+                                      opnd_create_reg(DR_REG_D6),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_urshl, instr);
+
+    instr = INSTR_CREATE_urshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q5),
+                                      opnd_create_reg(DR_REG_Q2),
+                                      opnd_create_reg(DR_REG_Q6),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_urshl, instr);
+
+    instr = INSTR_CREATE_urshl_vector(dc,
+                                      opnd_create_reg(DR_REG_D5),
+                                      opnd_create_reg(DR_REG_D2),
+                                      opnd_create_reg(DR_REG_D6),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_urshl, instr);
+
+    instr = INSTR_CREATE_urshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q5),
+                                      opnd_create_reg(DR_REG_Q2),
+                                      opnd_create_reg(DR_REG_Q6),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_urshl, instr);
+
+    instr = INSTR_CREATE_urshl_vector(dc,
+                                      opnd_create_reg(DR_REG_Q5),
+                                      opnd_create_reg(DR_REG_Q2),
+                                      opnd_create_reg(DR_REG_Q6),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_urshl, instr);
+
+    instr = INSTR_CREATE_uqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_D18),
+                                       opnd_create_reg(DR_REG_D10),
+                                       opnd_create_reg(DR_REG_D30),
+                                       OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uqrshl, instr);
+
+    instr = INSTR_CREATE_uqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_Q18),
+                                       opnd_create_reg(DR_REG_Q10),
+                                       opnd_create_reg(DR_REG_Q30),
+                                       OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uqrshl, instr);
+
+    instr = INSTR_CREATE_uqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_D18),
+                                       opnd_create_reg(DR_REG_D10),
+                                       opnd_create_reg(DR_REG_D30),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uqrshl, instr);
+
+    instr = INSTR_CREATE_uqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_Q18),
+                                       opnd_create_reg(DR_REG_Q10),
+                                       opnd_create_reg(DR_REG_Q30),
+                                       OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uqrshl, instr);
+
+    instr = INSTR_CREATE_uqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_D18),
+                                       opnd_create_reg(DR_REG_D10),
+                                       opnd_create_reg(DR_REG_D30),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uqrshl, instr);
+
+    instr = INSTR_CREATE_uqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_Q18),
+                                       opnd_create_reg(DR_REG_Q10),
+                                       opnd_create_reg(DR_REG_Q30),
+                                       OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uqrshl, instr);
+
+    instr = INSTR_CREATE_uqrshl_vector(dc,
+                                       opnd_create_reg(DR_REG_Q18),
+                                       opnd_create_reg(DR_REG_Q10),
+                                       opnd_create_reg(DR_REG_Q30),
+                                       OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_uqrshl, instr);
+
+    instr = INSTR_CREATE_umax_vector(dc,
+                                     opnd_create_reg(DR_REG_D9),
+                                     opnd_create_reg(DR_REG_D23),
+                                     opnd_create_reg(DR_REG_D25),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_umax, instr);
+
+    instr = INSTR_CREATE_umax_vector(dc,
+                                     opnd_create_reg(DR_REG_Q9),
+                                     opnd_create_reg(DR_REG_Q23),
+                                     opnd_create_reg(DR_REG_Q25),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_umax, instr);
+
+    instr = INSTR_CREATE_umax_vector(dc,
+                                     opnd_create_reg(DR_REG_D9),
+                                     opnd_create_reg(DR_REG_D23),
+                                     opnd_create_reg(DR_REG_D25),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_umax, instr);
+
+    instr = INSTR_CREATE_umax_vector(dc,
+                                     opnd_create_reg(DR_REG_Q9),
+                                     opnd_create_reg(DR_REG_Q23),
+                                     opnd_create_reg(DR_REG_Q25),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_umax, instr);
+
+    instr = INSTR_CREATE_umax_vector(dc,
+                                     opnd_create_reg(DR_REG_D9),
+                                     opnd_create_reg(DR_REG_D23),
+                                     opnd_create_reg(DR_REG_D25),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_umax, instr);
+
+    instr = INSTR_CREATE_umax_vector(dc,
+                                     opnd_create_reg(DR_REG_Q9),
+                                     opnd_create_reg(DR_REG_Q23),
+                                     opnd_create_reg(DR_REG_Q25),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_umax, instr);
+
+    instr = INSTR_CREATE_umin_vector(dc,
+                                     opnd_create_reg(DR_REG_D12),
+                                     opnd_create_reg(DR_REG_D22),
+                                     opnd_create_reg(DR_REG_D11),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_umin, instr);
+
+    instr = INSTR_CREATE_umin_vector(dc,
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q22),
+                                     opnd_create_reg(DR_REG_Q11),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_umin, instr);
+
+    instr = INSTR_CREATE_umin_vector(dc,
+                                     opnd_create_reg(DR_REG_D12),
+                                     opnd_create_reg(DR_REG_D22),
+                                     opnd_create_reg(DR_REG_D11),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_umin, instr);
+
+    instr = INSTR_CREATE_umin_vector(dc,
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q22),
+                                     opnd_create_reg(DR_REG_Q11),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_umin, instr);
+
+    instr = INSTR_CREATE_umin_vector(dc,
+                                     opnd_create_reg(DR_REG_D12),
+                                     opnd_create_reg(DR_REG_D22),
+                                     opnd_create_reg(DR_REG_D11),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_umin, instr);
+
+    instr = INSTR_CREATE_umin_vector(dc,
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q22),
+                                     opnd_create_reg(DR_REG_Q11),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_umin, instr);
+
+    instr = INSTR_CREATE_uabd_vector(dc,
+                                     opnd_create_reg(DR_REG_D5),
+                                     opnd_create_reg(DR_REG_D12),
+                                     opnd_create_reg(DR_REG_D27),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uabd, instr);
+
+    instr = INSTR_CREATE_uabd_vector(dc,
+                                     opnd_create_reg(DR_REG_Q5),
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q27),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uabd, instr);
+
+    instr = INSTR_CREATE_uabd_vector(dc,
+                                     opnd_create_reg(DR_REG_D5),
+                                     opnd_create_reg(DR_REG_D12),
+                                     opnd_create_reg(DR_REG_D27),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uabd, instr);
+
+    instr = INSTR_CREATE_uabd_vector(dc,
+                                     opnd_create_reg(DR_REG_Q5),
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q27),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uabd, instr);
+
+    instr = INSTR_CREATE_uabd_vector(dc,
+                                     opnd_create_reg(DR_REG_D5),
+                                     opnd_create_reg(DR_REG_D12),
+                                     opnd_create_reg(DR_REG_D27),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uabd, instr);
+
+    instr = INSTR_CREATE_uabd_vector(dc,
+                                     opnd_create_reg(DR_REG_Q5),
+                                     opnd_create_reg(DR_REG_Q12),
+                                     opnd_create_reg(DR_REG_Q27),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uabd, instr);
+
+    instr = INSTR_CREATE_uaba_vector(dc,
+                                     opnd_create_reg(DR_REG_D13),
+                                     opnd_create_reg(DR_REG_D6),
+                                     opnd_create_reg(DR_REG_D19),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uaba, instr);
+
+    instr = INSTR_CREATE_uaba_vector(dc,
+                                     opnd_create_reg(DR_REG_Q13),
+                                     opnd_create_reg(DR_REG_Q6),
+                                     opnd_create_reg(DR_REG_Q19),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uaba, instr);
+
+    instr = INSTR_CREATE_uaba_vector(dc,
+                                     opnd_create_reg(DR_REG_D13),
+                                     opnd_create_reg(DR_REG_D6),
+                                     opnd_create_reg(DR_REG_D19),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uaba, instr);
+
+    instr = INSTR_CREATE_uaba_vector(dc,
+                                     opnd_create_reg(DR_REG_Q13),
+                                     opnd_create_reg(DR_REG_Q6),
+                                     opnd_create_reg(DR_REG_Q19),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uaba, instr);
+
+    instr = INSTR_CREATE_uaba_vector(dc,
+                                     opnd_create_reg(DR_REG_D13),
+                                     opnd_create_reg(DR_REG_D6),
+                                     opnd_create_reg(DR_REG_D19),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uaba, instr);
+
+    instr = INSTR_CREATE_uaba_vector(dc,
+                                     opnd_create_reg(DR_REG_Q13),
+                                     opnd_create_reg(DR_REG_Q6),
+                                     opnd_create_reg(DR_REG_Q19),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uaba, instr);
+
+    instr = INSTR_CREATE_sub_vector(dc,
+                                    opnd_create_reg(DR_REG_D29),
+                                    opnd_create_reg(DR_REG_D27),
+                                    opnd_create_reg(DR_REG_D28),
+                                    OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sub, instr);
+
+    instr = INSTR_CREATE_sub_vector(dc,
+                                    opnd_create_reg(DR_REG_Q29),
+                                    opnd_create_reg(DR_REG_Q27),
+                                    opnd_create_reg(DR_REG_Q28),
+                                    OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_sub, instr);
+
+    instr = INSTR_CREATE_sub_vector(dc,
+                                    opnd_create_reg(DR_REG_D29),
+                                    opnd_create_reg(DR_REG_D27),
+                                    opnd_create_reg(DR_REG_D28),
+                                    OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sub, instr);
+
+    instr = INSTR_CREATE_sub_vector(dc,
+                                    opnd_create_reg(DR_REG_Q29),
+                                    opnd_create_reg(DR_REG_Q27),
+                                    opnd_create_reg(DR_REG_Q28),
+                                    OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sub, instr);
+
+    instr = INSTR_CREATE_sub_vector(dc,
+                                    opnd_create_reg(DR_REG_D29),
+                                    opnd_create_reg(DR_REG_D27),
+                                    opnd_create_reg(DR_REG_D28),
+                                    OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sub, instr);
+
+    instr = INSTR_CREATE_sub_vector(dc,
+                                    opnd_create_reg(DR_REG_Q29),
+                                    opnd_create_reg(DR_REG_Q27),
+                                    opnd_create_reg(DR_REG_Q28),
+                                    OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sub, instr);
+
+    instr = INSTR_CREATE_sub_vector(dc,
+                                    opnd_create_reg(DR_REG_Q29),
+                                    opnd_create_reg(DR_REG_Q27),
+                                    opnd_create_reg(DR_REG_Q28),
+                                    OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_sub, instr);
+
+    instr = INSTR_CREATE_cmeq_vector(dc,
+                                     opnd_create_reg(DR_REG_D13),
+                                     opnd_create_reg(DR_REG_D17),
+                                     opnd_create_reg(DR_REG_D23),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_cmeq, instr);
+
+    instr = INSTR_CREATE_cmeq_vector(dc,
+                                     opnd_create_reg(DR_REG_Q13),
+                                     opnd_create_reg(DR_REG_Q17),
+                                     opnd_create_reg(DR_REG_Q23),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_cmeq, instr);
+
+    instr = INSTR_CREATE_cmeq_vector(dc,
+                                     opnd_create_reg(DR_REG_D13),
+                                     opnd_create_reg(DR_REG_D17),
+                                     opnd_create_reg(DR_REG_D23),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_cmeq, instr);
+
+    instr = INSTR_CREATE_cmeq_vector(dc,
+                                     opnd_create_reg(DR_REG_Q13),
+                                     opnd_create_reg(DR_REG_Q17),
+                                     opnd_create_reg(DR_REG_Q23),
+                                     OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_cmeq, instr);
+
+    instr = INSTR_CREATE_cmeq_vector(dc,
+                                     opnd_create_reg(DR_REG_D13),
+                                     opnd_create_reg(DR_REG_D17),
+                                     opnd_create_reg(DR_REG_D23),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_cmeq, instr);
+
+    instr = INSTR_CREATE_cmeq_vector(dc,
+                                     opnd_create_reg(DR_REG_Q13),
+                                     opnd_create_reg(DR_REG_Q17),
+                                     opnd_create_reg(DR_REG_Q23),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_cmeq, instr);
+
+    instr = INSTR_CREATE_cmeq_vector(dc,
+                                     opnd_create_reg(DR_REG_Q13),
+                                     opnd_create_reg(DR_REG_Q17),
+                                     opnd_create_reg(DR_REG_Q23),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_cmeq, instr);
+
+    instr = INSTR_CREATE_mls_vector(dc,
+                                    opnd_create_reg(DR_REG_D7),
+                                    opnd_create_reg(DR_REG_D13),
+                                    opnd_create_reg(DR_REG_D27),
+                                    OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_mls, instr);
+
+    instr = INSTR_CREATE_mls_vector(dc,
+                                    opnd_create_reg(DR_REG_Q7),
+                                    opnd_create_reg(DR_REG_Q13),
+                                    opnd_create_reg(DR_REG_Q27),
+                                    OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_mls, instr);
+
+    instr = INSTR_CREATE_mls_vector(dc,
+                                    opnd_create_reg(DR_REG_D7),
+                                    opnd_create_reg(DR_REG_D13),
+                                    opnd_create_reg(DR_REG_D27),
+                                    OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_mls, instr);
+
+    instr = INSTR_CREATE_mls_vector(dc,
+                                    opnd_create_reg(DR_REG_Q7),
+                                    opnd_create_reg(DR_REG_Q13),
+                                    opnd_create_reg(DR_REG_Q27),
+                                    OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_mls, instr);
+
+    instr = INSTR_CREATE_mls_vector(dc,
+                                    opnd_create_reg(DR_REG_D7),
+                                    opnd_create_reg(DR_REG_D13),
+                                    opnd_create_reg(DR_REG_D27),
+                                    OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_mls, instr);
+
+    instr = INSTR_CREATE_mls_vector(dc,
+                                    opnd_create_reg(DR_REG_Q7),
+                                    opnd_create_reg(DR_REG_Q13),
+                                    opnd_create_reg(DR_REG_Q27),
+                                    OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_mls, instr);
+
+    instr = INSTR_CREATE_pmul_vector(dc,
+                                     opnd_create_reg(DR_REG_D26),
+                                     opnd_create_reg(DR_REG_D24),
+                                     opnd_create_reg(DR_REG_D12),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_pmul, instr);
+
+    instr = INSTR_CREATE_pmul_vector(dc,
+                                     opnd_create_reg(DR_REG_Q26),
+                                     opnd_create_reg(DR_REG_Q24),
+                                     opnd_create_reg(DR_REG_Q12),
+                                     OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_pmul, instr);
+
+    instr = INSTR_CREATE_umaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_D4),
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D5),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_umaxp, instr);
+
+    instr = INSTR_CREATE_umaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q4),
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q5),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_umaxp, instr);
+
+    instr = INSTR_CREATE_umaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_D4),
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D5),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_umaxp, instr);
+
+    instr = INSTR_CREATE_umaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q4),
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q5),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_umaxp, instr);
+
+    instr = INSTR_CREATE_umaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_D4),
+                                      opnd_create_reg(DR_REG_D27),
+                                      opnd_create_reg(DR_REG_D5),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_umaxp, instr);
+
+    instr = INSTR_CREATE_umaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q4),
+                                      opnd_create_reg(DR_REG_Q27),
+                                      opnd_create_reg(DR_REG_Q5),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_umaxp, instr);
+
+    instr = INSTR_CREATE_uminp_vector(dc,
+                                      opnd_create_reg(DR_REG_D3),
+                                      opnd_create_reg(DR_REG_D22),
+                                      opnd_create_reg(DR_REG_D16),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uminp, instr);
+
+    instr = INSTR_CREATE_uminp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q3),
+                                      opnd_create_reg(DR_REG_Q22),
+                                      opnd_create_reg(DR_REG_Q16),
+                                      OPND_CREATE_BYTE());
+    test_instr_encoding(dc, OP_uminp, instr);
+
+    instr = INSTR_CREATE_uminp_vector(dc,
+                                      opnd_create_reg(DR_REG_D3),
+                                      opnd_create_reg(DR_REG_D22),
+                                      opnd_create_reg(DR_REG_D16),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uminp, instr);
+
+    instr = INSTR_CREATE_uminp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q3),
+                                      opnd_create_reg(DR_REG_Q22),
+                                      opnd_create_reg(DR_REG_Q16),
+                                      OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_uminp, instr);
+
+    instr = INSTR_CREATE_uminp_vector(dc,
+                                      opnd_create_reg(DR_REG_D3),
+                                      opnd_create_reg(DR_REG_D22),
+                                      opnd_create_reg(DR_REG_D16),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uminp, instr);
+
+    instr = INSTR_CREATE_uminp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q3),
+                                      opnd_create_reg(DR_REG_Q22),
+                                      opnd_create_reg(DR_REG_Q16),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_uminp, instr);
+
+    instr = INSTR_CREATE_sqrdmulh_vector(dc,
+                                         opnd_create_reg(DR_REG_D23),
+                                         opnd_create_reg(DR_REG_D29),
+                                         opnd_create_reg(DR_REG_D27),
+                                         OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sqrdmulh, instr);
+
+    instr = INSTR_CREATE_sqrdmulh_vector(dc,
+                                         opnd_create_reg(DR_REG_Q23),
+                                         opnd_create_reg(DR_REG_Q29),
+                                         opnd_create_reg(DR_REG_Q27),
+                                         OPND_CREATE_HALF());
+    test_instr_encoding(dc, OP_sqrdmulh, instr);
+
+    instr = INSTR_CREATE_sqrdmulh_vector(dc,
+                                         opnd_create_reg(DR_REG_D23),
+                                         opnd_create_reg(DR_REG_D29),
+                                         opnd_create_reg(DR_REG_D27),
+                                         OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sqrdmulh, instr);
+
+    instr = INSTR_CREATE_sqrdmulh_vector(dc,
+                                         opnd_create_reg(DR_REG_Q23),
+                                         opnd_create_reg(DR_REG_Q29),
+                                         opnd_create_reg(DR_REG_Q27),
+                                         OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_sqrdmulh, instr);
+
+    instr = INSTR_CREATE_fmaxnmp_vector(dc,
+                                        opnd_create_reg(DR_REG_D12),
+                                        opnd_create_reg(DR_REG_D18),
+                                        opnd_create_reg(DR_REG_D29),
+                                        OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmaxnmp, instr);
+
+    instr = INSTR_CREATE_fmaxnmp_vector(dc,
+                                        opnd_create_reg(DR_REG_Q12),
+                                        opnd_create_reg(DR_REG_Q18),
+                                        opnd_create_reg(DR_REG_Q29),
+                                        OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmaxnmp, instr);
+
+    instr = INSTR_CREATE_fmaxnmp_vector(dc,
+                                        opnd_create_reg(DR_REG_Q12),
+                                        opnd_create_reg(DR_REG_Q18),
+                                        opnd_create_reg(DR_REG_Q29),
+                                        OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fmaxnmp, instr);
+
+    instr = INSTR_CREATE_fmlal2_vector(dc,
+                                       opnd_create_reg(DR_REG_D0),
+                                       opnd_create_reg(DR_REG_D29),
+                                       opnd_create_reg(DR_REG_D31));
+    test_instr_encoding(dc, OP_fmlal2, instr);
+
+    instr = INSTR_CREATE_fmlal2_vector(dc,
+                                       opnd_create_reg(DR_REG_Q0),
+                                       opnd_create_reg(DR_REG_Q29),
+                                       opnd_create_reg(DR_REG_Q31));
+    test_instr_encoding(dc, OP_fmlal2, instr);
+
+    instr = INSTR_CREATE_faddp_vector(dc,
+                                      opnd_create_reg(DR_REG_D18),
+                                      opnd_create_reg(DR_REG_D31),
+                                      opnd_create_reg(DR_REG_D16),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_faddp, instr);
+
+    instr = INSTR_CREATE_faddp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q18),
+                                      opnd_create_reg(DR_REG_Q31),
+                                      opnd_create_reg(DR_REG_Q16),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_faddp, instr);
+
+    instr = INSTR_CREATE_faddp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q18),
+                                      opnd_create_reg(DR_REG_Q31),
+                                      opnd_create_reg(DR_REG_Q16),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_faddp, instr);
+
+    instr = INSTR_CREATE_fmul_vector(dc,
+                                     opnd_create_reg(DR_REG_D25),
+                                     opnd_create_reg(DR_REG_D28),
+                                     opnd_create_reg(DR_REG_D21),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmul, instr);
+
+    instr = INSTR_CREATE_fmul_vector(dc,
+                                     opnd_create_reg(DR_REG_Q25),
+                                     opnd_create_reg(DR_REG_Q28),
+                                     opnd_create_reg(DR_REG_Q21),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmul, instr);
+
+    instr = INSTR_CREATE_fmul_vector(dc,
+                                     opnd_create_reg(DR_REG_Q25),
+                                     opnd_create_reg(DR_REG_Q28),
+                                     opnd_create_reg(DR_REG_Q21),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fmul, instr);
+
+    instr = INSTR_CREATE_fcmge_vector(dc,
+                                      opnd_create_reg(DR_REG_D22),
+                                      opnd_create_reg(DR_REG_D17),
+                                      opnd_create_reg(DR_REG_D30),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcmge, instr);
+
+    instr = INSTR_CREATE_fcmge_vector(dc,
+                                      opnd_create_reg(DR_REG_Q22),
+                                      opnd_create_reg(DR_REG_Q17),
+                                      opnd_create_reg(DR_REG_Q30),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcmge, instr);
+
+    instr = INSTR_CREATE_fcmge_vector(dc,
+                                      opnd_create_reg(DR_REG_Q22),
+                                      opnd_create_reg(DR_REG_Q17),
+                                      opnd_create_reg(DR_REG_Q30),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fcmge, instr);
+
+    instr = INSTR_CREATE_facge_vector(dc,
+                                      opnd_create_reg(DR_REG_D28),
+                                      opnd_create_reg(DR_REG_D30),
+                                      opnd_create_reg(DR_REG_D30),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_facge, instr);
+
+    instr = INSTR_CREATE_facge_vector(dc,
+                                      opnd_create_reg(DR_REG_Q28),
+                                      opnd_create_reg(DR_REG_Q30),
+                                      opnd_create_reg(DR_REG_Q30),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_facge, instr);
+
+    instr = INSTR_CREATE_facge_vector(dc,
+                                      opnd_create_reg(DR_REG_Q28),
+                                      opnd_create_reg(DR_REG_Q30),
+                                      opnd_create_reg(DR_REG_Q30),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_facge, instr);
+
+    instr = INSTR_CREATE_fmaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_D5),
+                                      opnd_create_reg(DR_REG_D23),
+                                      opnd_create_reg(DR_REG_D25),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmaxp, instr);
+
+    instr = INSTR_CREATE_fmaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q5),
+                                      opnd_create_reg(DR_REG_Q23),
+                                      opnd_create_reg(DR_REG_Q25),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fmaxp, instr);
+
+    instr = INSTR_CREATE_fmaxp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q5),
+                                      opnd_create_reg(DR_REG_Q23),
+                                      opnd_create_reg(DR_REG_Q25),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fmaxp, instr);
+
+    instr = INSTR_CREATE_fdiv_vector(dc,
+                                     opnd_create_reg(DR_REG_D10),
+                                     opnd_create_reg(DR_REG_D26),
+                                     opnd_create_reg(DR_REG_D4),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fdiv, instr);
+
+    instr = INSTR_CREATE_fdiv_vector(dc,
+                                     opnd_create_reg(DR_REG_Q10),
+                                     opnd_create_reg(DR_REG_Q26),
+                                     opnd_create_reg(DR_REG_Q4),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fdiv, instr);
+
+    instr = INSTR_CREATE_fdiv_vector(dc,
+                                     opnd_create_reg(DR_REG_Q10),
+                                     opnd_create_reg(DR_REG_Q26),
+                                     opnd_create_reg(DR_REG_Q4),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fdiv, instr);
+
+    instr = INSTR_CREATE_eor_vector(dc,
+                                    opnd_create_reg(DR_REG_D19),
+                                    opnd_create_reg(DR_REG_D1),
+                                    opnd_create_reg(DR_REG_D20));
+    test_instr_encoding(dc, OP_eor, instr);
+
+    instr = INSTR_CREATE_eor_vector(dc,
+                                    opnd_create_reg(DR_REG_Q19),
+                                    opnd_create_reg(DR_REG_Q1),
+                                    opnd_create_reg(DR_REG_Q20));
+    test_instr_encoding(dc, OP_eor, instr);
+
+    instr = INSTR_CREATE_bsl_vector(dc,
+                                    opnd_create_reg(DR_REG_D20),
+                                    opnd_create_reg(DR_REG_D4),
+                                    opnd_create_reg(DR_REG_D25));
+    test_instr_encoding(dc, OP_bsl, instr);
+
+    instr = INSTR_CREATE_bsl_vector(dc,
+                                    opnd_create_reg(DR_REG_Q20),
+                                    opnd_create_reg(DR_REG_Q4),
+                                    opnd_create_reg(DR_REG_Q25));
+    test_instr_encoding(dc, OP_bsl, instr);
+
+    instr = INSTR_CREATE_fminnmp_vector(dc,
+                                        opnd_create_reg(DR_REG_D23),
+                                        opnd_create_reg(DR_REG_D18),
+                                        opnd_create_reg(DR_REG_D11),
+                                        OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fminnmp, instr);
+
+    instr = INSTR_CREATE_fminnmp_vector(dc,
+                                        opnd_create_reg(DR_REG_Q23),
+                                        opnd_create_reg(DR_REG_Q18),
+                                        opnd_create_reg(DR_REG_Q11),
+                                        OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fminnmp, instr);
+
+    instr = INSTR_CREATE_fminnmp_vector(dc,
+                                        opnd_create_reg(DR_REG_Q23),
+                                        opnd_create_reg(DR_REG_Q18),
+                                        opnd_create_reg(DR_REG_Q11),
+                                        OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fminnmp, instr);
+
+    instr = INSTR_CREATE_fmlsl2_vector(dc,
+                                       opnd_create_reg(DR_REG_D0),
+                                       opnd_create_reg(DR_REG_D29),
+                                       opnd_create_reg(DR_REG_D31));
+    test_instr_encoding(dc, OP_fmlsl2, instr);
+
+    instr = INSTR_CREATE_fmlsl2_vector(dc,
+                                       opnd_create_reg(DR_REG_Q0),
+                                       opnd_create_reg(DR_REG_Q29),
+                                       opnd_create_reg(DR_REG_Q31));
+    test_instr_encoding(dc, OP_fmlsl2, instr);
+
+    instr = INSTR_CREATE_fabd_vector(dc,
+                                     opnd_create_reg(DR_REG_D15),
+                                     opnd_create_reg(DR_REG_D10),
+                                     opnd_create_reg(DR_REG_D19),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fabd, instr);
+
+    instr = INSTR_CREATE_fabd_vector(dc,
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q10),
+                                     opnd_create_reg(DR_REG_Q19),
+                                     OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fabd, instr);
+
+    instr = INSTR_CREATE_fabd_vector(dc,
+                                     opnd_create_reg(DR_REG_Q15),
+                                     opnd_create_reg(DR_REG_Q10),
+                                     opnd_create_reg(DR_REG_Q19),
+                                     OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fabd, instr);
+
+    instr = INSTR_CREATE_fcmgt_vector(dc,
+                                      opnd_create_reg(DR_REG_D6),
+                                      opnd_create_reg(DR_REG_D3),
+                                      opnd_create_reg(DR_REG_D14),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcmgt, instr);
+
+    instr = INSTR_CREATE_fcmgt_vector(dc,
+                                      opnd_create_reg(DR_REG_Q6),
+                                      opnd_create_reg(DR_REG_Q3),
+                                      opnd_create_reg(DR_REG_Q14),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcmgt, instr);
+
+    instr = INSTR_CREATE_fcmgt_vector(dc,
+                                      opnd_create_reg(DR_REG_Q6),
+                                      opnd_create_reg(DR_REG_Q3),
+                                      opnd_create_reg(DR_REG_Q14),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fcmgt, instr);
+
+    instr = INSTR_CREATE_facgt_vector(dc,
+                                      opnd_create_reg(DR_REG_D4),
+                                      opnd_create_reg(DR_REG_D26),
+                                      opnd_create_reg(DR_REG_D12),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_facgt, instr);
+
+    instr = INSTR_CREATE_facgt_vector(dc,
+                                      opnd_create_reg(DR_REG_Q4),
+                                      opnd_create_reg(DR_REG_Q26),
+                                      opnd_create_reg(DR_REG_Q12),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_facgt, instr);
+
+    instr = INSTR_CREATE_facgt_vector(dc,
+                                      opnd_create_reg(DR_REG_Q4),
+                                      opnd_create_reg(DR_REG_Q26),
+                                      opnd_create_reg(DR_REG_Q12),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_facgt, instr);
+
+    instr = INSTR_CREATE_fminp_vector(dc,
+                                      opnd_create_reg(DR_REG_D28),
+                                      opnd_create_reg(DR_REG_D1),
+                                      opnd_create_reg(DR_REG_D25),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fminp, instr);
+
+    instr = INSTR_CREATE_fminp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q28),
+                                      opnd_create_reg(DR_REG_Q1),
+                                      opnd_create_reg(DR_REG_Q25),
+                                      OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fminp, instr);
+
+    instr = INSTR_CREATE_fminp_vector(dc,
+                                      opnd_create_reg(DR_REG_Q28),
+                                      opnd_create_reg(DR_REG_Q1),
+                                      opnd_create_reg(DR_REG_Q25),
+                                      OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fminp, instr);
+
+    instr = INSTR_CREATE_bit_vector(dc,
+                                    opnd_create_reg(DR_REG_D12),
+                                    opnd_create_reg(DR_REG_D21),
+                                    opnd_create_reg(DR_REG_D12));
+    test_instr_encoding(dc, OP_bit, instr);
+
+    instr = INSTR_CREATE_bit_vector(dc,
+                                    opnd_create_reg(DR_REG_Q12),
+                                    opnd_create_reg(DR_REG_Q21),
+                                    opnd_create_reg(DR_REG_Q12));
+    test_instr_encoding(dc, OP_bit, instr);
+
+    instr = INSTR_CREATE_bif_vector(dc,
+                                    opnd_create_reg(DR_REG_D20),
+                                    opnd_create_reg(DR_REG_D3),
+                                    opnd_create_reg(DR_REG_D3));
+    test_instr_encoding(dc, OP_bif, instr);
+
+    instr = INSTR_CREATE_bif_vector(dc,
+                                    opnd_create_reg(DR_REG_Q20),
+                                    opnd_create_reg(DR_REG_Q3),
+                                    opnd_create_reg(DR_REG_Q3));
+    test_instr_encoding(dc, OP_bif, instr);
+}
+
+
+
 int
 main(int argc, char *argv[])
 {
@@ -354,6 +3339,12 @@ main(int argc, char *argv[])
 
     test_fmov_general(dcontext);
     print("test_fmov_general complete\n");
+
+    test_asimdsamefp16(dcontext);
+    print("test_asimdsamefp16 complete\n");
+
+    test_asimdsame(dcontext);
+    print("test_asimdsame complete\n");
 
     print("All tests complete\n");
     return 0;

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -52,4 +52,433 @@ fmov   %x8 -> %h23
 fmov   %x24 -> %d6
 fmov   %x10 -> %q9
 test_fmov_general complete
+fmaxnm %d27 %d30 $0x01 -> %d2
+fmaxnm %q27 %q30 $0x01 -> %q2
+fmla   %d0 %d29 %d31 $0x01 -> %d0
+fmla   %q0 %q29 %q31 $0x01 -> %q0
+fadd   %d10 %d2 $0x01 -> %d17
+fadd   %q10 %q2 $0x01 -> %q17
+fmulx  %d20 %d4 $0x01 -> %d31
+fmulx  %q20 %q4 $0x01 -> %q31
+fcmeq  %d23 %d2 $0x01 -> %d15
+fcmeq  %q23 %q2 $0x01 -> %q15
+fmax   %d8 %d22 $0x01 -> %d26
+fmax   %q8 %q22 $0x01 -> %q26
+frecps %d26 %d18 $0x01 -> %d24
+frecps %q26 %q18 $0x01 -> %q24
+fminnm %d29 %d11 $0x01 -> %d16
+fminnm %q29 %q11 $0x01 -> %q16
+fmls   %d19 %d8 %d29 $0x01 -> %d19
+fmls   %q19 %q8 %q29 $0x01 -> %q19
+fsub   %d28 %d24 $0x01 -> %d15
+fsub   %q28 %q24 $0x01 -> %q15
+fmin   %d0 %d15 $0x01 -> %d2
+fmin   %q0 %q15 $0x01 -> %q2
+frsqrts %d12 %d19 $0x01 -> %d8
+frsqrts %q12 %q19 $0x01 -> %q8
+fmaxnmp %d15 %d20 $0x01 -> %d23
+fmaxnmp %q15 %q20 $0x01 -> %q23
+faddp  %d27 %d30 $0x01 -> %d28
+faddp  %q27 %q30 $0x01 -> %q28
+fmul   %d20 %d10 $0x01 -> %d4
+fmul   %q20 %q10 $0x01 -> %q4
+fcmge  %d26 %d15 $0x01 -> %d14
+fcmge  %q26 %q15 $0x01 -> %q14
+facge  %d2 %d31 $0x01 -> %d2
+facge  %q2 %q31 $0x01 -> %q2
+fmaxp  %d4 %d5 $0x01 -> %d19
+fmaxp  %q4 %q5 $0x01 -> %q19
+fdiv   %d24 %d23 $0x01 -> %d9
+fdiv   %q24 %q23 $0x01 -> %q9
+fminnmp %d7 %d6 $0x01 -> %d9
+fminnmp %q7 %q6 $0x01 -> %q9
+fabd   %d10 %d12 $0x01 -> %d28
+fabd   %q10 %q12 $0x01 -> %q28
+fcmgt  %d27 %d26 $0x01 -> %d22
+fcmgt  %q27 %q26 $0x01 -> %q22
+facgt  %d15 %d17 $0x01 -> %d28
+facgt  %q15 %q17 $0x01 -> %q28
+fminp  %d11 %d7 $0x01 -> %d9
+fminp  %q11 %q7 $0x01 -> %q9
+test_asimdsamefp16 complete
+shadd  %d27 %d30 $0x00 -> %d2
+shadd  %q27 %q30 $0x00 -> %q2
+shadd  %d27 %d30 $0x01 -> %d2
+shadd  %q27 %q30 $0x01 -> %q2
+shadd  %d27 %d30 $0x02 -> %d2
+shadd  %q27 %q30 $0x02 -> %q2
+sqadd  %d13 %d29 $0x00 -> %d0
+sqadd  %q13 %q29 $0x00 -> %q0
+sqadd  %d13 %d29 $0x01 -> %d0
+sqadd  %q13 %q29 $0x01 -> %q0
+sqadd  %d13 %d29 $0x02 -> %d0
+sqadd  %q13 %q29 $0x02 -> %q0
+sqadd  %q13 %q29 $0x03 -> %q0
+srhadd %d17 %d10 $0x00 -> %d31
+srhadd %q17 %q10 $0x00 -> %q31
+srhadd %d17 %d10 $0x01 -> %d31
+srhadd %q17 %q10 $0x01 -> %q31
+srhadd %d17 %d10 $0x02 -> %d31
+srhadd %q17 %q10 $0x02 -> %q31
+shsub  %d31 %d20 $0x00 -> %d2
+shsub  %q31 %q20 $0x00 -> %q2
+shsub  %d31 %d20 $0x01 -> %d2
+shsub  %q31 %q20 $0x01 -> %q2
+shsub  %d31 %d20 $0x02 -> %d2
+shsub  %q31 %q20 $0x02 -> %q2
+sqsub  %d15 %d23 $0x00 -> %d4
+sqsub  %q15 %q23 $0x00 -> %q4
+sqsub  %d15 %d23 $0x01 -> %d4
+sqsub  %q15 %q23 $0x01 -> %q4
+sqsub  %d15 %d23 $0x02 -> %d4
+sqsub  %q15 %q23 $0x02 -> %q4
+sqsub  %q15 %q23 $0x03 -> %q4
+cmgt   %d26 %d8 $0x00 -> %d2
+cmgt   %q26 %q8 $0x00 -> %q2
+cmgt   %d26 %d8 $0x01 -> %d2
+cmgt   %q26 %q8 $0x01 -> %q2
+cmgt   %d26 %d8 $0x02 -> %d2
+cmgt   %q26 %q8 $0x02 -> %q2
+cmgt   %q26 %q8 $0x03 -> %q2
+cmge   %d24 %d26 $0x00 -> %d22
+cmge   %q24 %q26 $0x00 -> %q22
+cmge   %d24 %d26 $0x01 -> %d22
+cmge   %q24 %q26 $0x01 -> %q22
+cmge   %d24 %d26 $0x02 -> %d22
+cmge   %q24 %q26 $0x02 -> %q22
+cmge   %q24 %q26 $0x03 -> %q22
+sshl   %d16 %d29 $0x00 -> %d18
+sshl   %q16 %q29 $0x00 -> %q18
+sshl   %d16 %d29 $0x01 -> %d18
+sshl   %q16 %q29 $0x01 -> %q18
+sshl   %d16 %d29 $0x02 -> %d18
+sshl   %q16 %q29 $0x02 -> %q18
+sshl   %q16 %q29 $0x03 -> %q18
+sqshl  %d19 %d23 $0x00 -> %d11
+sqshl  %q19 %q23 $0x00 -> %q11
+sqshl  %d19 %d23 $0x01 -> %d11
+sqshl  %q19 %q23 $0x01 -> %q11
+sqshl  %d19 %d23 $0x02 -> %d11
+sqshl  %q19 %q23 $0x02 -> %q11
+sqshl  %q19 %q23 $0x03 -> %q11
+srshl  %d29 %d15 $0x00 -> %d8
+srshl  %q29 %q15 $0x00 -> %q8
+srshl  %d29 %d15 $0x01 -> %d8
+srshl  %q29 %q15 $0x01 -> %q8
+srshl  %d29 %d15 $0x02 -> %d8
+srshl  %q29 %q15 $0x02 -> %q8
+srshl  %q29 %q15 $0x03 -> %q8
+sqrshl %d24 %d2 $0x00 -> %d28
+sqrshl %q24 %q2 $0x00 -> %q28
+sqrshl %d24 %d2 $0x01 -> %d28
+sqrshl %q24 %q2 $0x01 -> %q28
+sqrshl %d24 %d2 $0x02 -> %d28
+sqrshl %q24 %q2 $0x02 -> %q28
+sqrshl %q24 %q2 $0x03 -> %q28
+smax   %d15 %d8 $0x00 -> %d0
+smax   %q15 %q8 $0x00 -> %q0
+smax   %d15 %d8 $0x01 -> %d0
+smax   %q15 %q8 $0x01 -> %q0
+smax   %d15 %d8 $0x02 -> %d0
+smax   %q15 %q8 $0x02 -> %q0
+smin   %d19 %d23 $0x00 -> %d12
+smin   %q19 %q23 $0x00 -> %q12
+smin   %d19 %d23 $0x01 -> %d12
+smin   %q19 %q23 $0x01 -> %q12
+smin   %d19 %d23 $0x02 -> %d12
+smin   %q19 %q23 $0x02 -> %q12
+sabd   %d20 %d28 $0x00 -> %d15
+sabd   %q20 %q28 $0x00 -> %q15
+sabd   %d20 %d28 $0x01 -> %d15
+sabd   %q20 %q28 $0x01 -> %q15
+sabd   %d20 %d28 $0x02 -> %d15
+sabd   %q20 %q28 $0x02 -> %q15
+saba   %d30 %d4 $0x00 -> %d27
+saba   %q30 %q4 $0x00 -> %q27
+saba   %d30 %d4 $0x01 -> %d27
+saba   %q30 %q4 $0x01 -> %q27
+saba   %d30 %d4 $0x02 -> %d27
+saba   %q30 %q4 $0x02 -> %q27
+add    %d10 %d14 $0x00 -> %d20
+add    %q10 %q14 $0x00 -> %q20
+add    %d10 %d14 $0x01 -> %d20
+add    %q10 %q14 $0x01 -> %q20
+add    %d10 %d14 $0x02 -> %d20
+add    %q10 %q14 $0x02 -> %q20
+add    %q10 %q14 $0x03 -> %q20
+cmtst  %d15 %d2 $0x00 -> %d26
+cmtst  %q15 %q2 $0x00 -> %q26
+cmtst  %d15 %d2 $0x01 -> %d26
+cmtst  %q15 %q2 $0x01 -> %q26
+cmtst  %d15 %d2 $0x02 -> %d26
+cmtst  %q15 %q2 $0x02 -> %q26
+cmtst  %q15 %q2 $0x03 -> %q26
+mla    %d2 %d19 %d4 $0x00 -> %d2
+mla    %q2 %q19 %q4 $0x00 -> %q2
+mla    %d2 %d19 %d4 $0x01 -> %d2
+mla    %q2 %q19 %q4 $0x01 -> %q2
+mla    %d2 %d19 %d4 $0x02 -> %d2
+mla    %q2 %q19 %q4 $0x02 -> %q2
+mul    %d9 %d24 $0x00 -> %d5
+mul    %q9 %q24 $0x00 -> %q5
+mul    %d9 %d24 $0x01 -> %d5
+mul    %q9 %q24 $0x01 -> %q5
+mul    %d9 %d24 $0x02 -> %d5
+mul    %q9 %q24 $0x02 -> %q5
+smaxp  %d9 %d7 $0x00 -> %d23
+smaxp  %q9 %q7 $0x00 -> %q23
+smaxp  %d9 %d7 $0x01 -> %d23
+smaxp  %q9 %q7 $0x01 -> %q23
+smaxp  %d9 %d7 $0x02 -> %d23
+smaxp  %q9 %q7 $0x02 -> %q23
+sminp  %d28 %d10 $0x00 -> %d6
+sminp  %q28 %q10 $0x00 -> %q6
+sminp  %d28 %d10 $0x01 -> %d6
+sminp  %q28 %q10 $0x01 -> %q6
+sminp  %d28 %d10 $0x02 -> %d6
+sminp  %q28 %q10 $0x02 -> %q6
+sqdmulh %d22 %d27 $0x01 -> %d12
+sqdmulh %q22 %q27 $0x01 -> %q12
+sqdmulh %d22 %d27 $0x02 -> %d12
+sqdmulh %q22 %q27 $0x02 -> %q12
+addp   %d28 %d15 $0x00 -> %d26
+addp   %q28 %q15 $0x00 -> %q26
+addp   %d28 %d15 $0x01 -> %d26
+addp   %q28 %q15 $0x01 -> %q26
+addp   %d28 %d15 $0x02 -> %d26
+addp   %q28 %q15 $0x02 -> %q26
+addp   %q28 %q15 $0x03 -> %q26
+fmaxnm %d9 %d11 $0x02 -> %d17
+fmaxnm %q9 %q11 $0x02 -> %q17
+fmaxnm %q9 %q11 $0x03 -> %q17
+fmla   %d7 %d29 %d19 $0x02 -> %d7
+fmla   %q7 %q29 %q19 $0x02 -> %q7
+fmla   %q7 %q29 %q19 $0x03 -> %q7
+fadd   %d11 %d11 $0x02 -> %d10
+fadd   %q11 %q11 $0x02 -> %q10
+fadd   %q11 %q11 $0x03 -> %q10
+fmulx  %d22 %d20 $0x02 -> %d30
+fmulx  %q22 %q20 $0x02 -> %q30
+fmulx  %q22 %q20 $0x03 -> %q30
+fcmeq  %d14 %d0 $0x02 -> %d27
+fcmeq  %q14 %q0 $0x02 -> %q27
+fcmeq  %q14 %q0 $0x03 -> %q27
+fmlal  %d0 %d29 %d31 -> %d0
+fmlal  %q0 %q29 %q31 -> %q0
+fmax   %d21 %d20 $0x02 -> %d2
+fmax   %q21 %q20 $0x02 -> %q2
+fmax   %q21 %q20 $0x03 -> %q2
+frecps %d5 %d16 $0x02 -> %d15
+frecps %q5 %q16 $0x02 -> %q15
+frecps %q5 %q16 $0x03 -> %q15
+and    %d25 %d10 -> %d28
+and    %q25 %q10 -> %q28
+bic    %d31 %d15 -> %d24
+bic    %q31 %q15 -> %q24
+fminnm %d30 %d31 $0x02 -> %d17
+fminnm %q30 %q31 $0x02 -> %q17
+fminnm %q30 %q31 $0x03 -> %q17
+fmls   %d4 %d31 %d29 $0x02 -> %d4
+fmls   %q4 %q31 %q29 $0x02 -> %q4
+fmls   %q4 %q31 %q29 $0x03 -> %q4
+fsub   %d8 %d26 $0x02 -> %d25
+fsub   %q8 %q26 $0x02 -> %q25
+fsub   %q8 %q26 $0x03 -> %q25
+fmlsl  %d0 %d29 %d31 -> %d0
+fmlsl  %q0 %q29 %q31 -> %q0
+fmin   %d24 %d31 $0x02 -> %d22
+fmin   %q24 %q31 $0x02 -> %q22
+fmin   %q24 %q31 $0x03 -> %q22
+frsqrts %d28 %d6 $0x02 -> %d10
+frsqrts %q28 %q6 $0x02 -> %q10
+frsqrts %q28 %q6 $0x03 -> %q10
+orr    %d2 %d0 -> %d26
+orr    %q2 %q0 -> %q26
+orn    %d4 %d3 -> %d28
+orn    %q4 %q3 -> %q28
+uhadd  %d5 %d9 $0x00 -> %d22
+uhadd  %q5 %q9 $0x00 -> %q22
+uhadd  %d5 %d9 $0x01 -> %d22
+uhadd  %q5 %q9 $0x01 -> %q22
+uhadd  %d5 %d9 $0x02 -> %d22
+uhadd  %q5 %q9 $0x02 -> %q22
+uqadd  %d29 %d31 $0x00 -> %d6
+uqadd  %q29 %q31 $0x00 -> %q6
+uqadd  %d29 %d31 $0x01 -> %d6
+uqadd  %q29 %q31 $0x01 -> %q6
+uqadd  %d29 %d31 $0x02 -> %d6
+uqadd  %q29 %q31 $0x02 -> %q6
+uqadd  %q29 %q31 $0x03 -> %q6
+urhadd %d29 %d27 $0x00 -> %d8
+urhadd %q29 %q27 $0x00 -> %q8
+urhadd %d29 %d27 $0x01 -> %d8
+urhadd %q29 %q27 $0x01 -> %q8
+urhadd %d29 %d27 $0x02 -> %d8
+urhadd %q29 %q27 $0x02 -> %q8
+uhsub  %d21 %d16 $0x00 -> %d28
+uhsub  %q21 %q16 $0x00 -> %q28
+uhsub  %d21 %d16 $0x01 -> %d28
+uhsub  %q21 %q16 $0x01 -> %q28
+uhsub  %d21 %d16 $0x02 -> %d28
+uhsub  %q21 %q16 $0x02 -> %q28
+uqsub  %d27 %d21 $0x00 -> %d29
+uqsub  %q27 %q21 $0x00 -> %q29
+uqsub  %d27 %d21 $0x01 -> %d29
+uqsub  %q27 %q21 $0x01 -> %q29
+uqsub  %d27 %d21 $0x02 -> %d29
+uqsub  %q27 %q21 $0x02 -> %q29
+uqsub  %q27 %q21 $0x03 -> %q29
+cmhi   %d15 %d20 $0x00 -> %d9
+cmhi   %q15 %q20 $0x00 -> %q9
+cmhi   %d15 %d20 $0x01 -> %d9
+cmhi   %q15 %q20 $0x01 -> %q9
+cmhi   %d15 %d20 $0x02 -> %d9
+cmhi   %q15 %q20 $0x02 -> %q9
+cmhi   %q15 %q20 $0x03 -> %q9
+cmhs   %d12 %d30 $0x00 -> %d2
+cmhs   %q12 %q30 $0x00 -> %q2
+cmhs   %d12 %d30 $0x01 -> %d2
+cmhs   %q12 %q30 $0x01 -> %q2
+cmhs   %d12 %d30 $0x02 -> %d2
+cmhs   %q12 %q30 $0x02 -> %q2
+cmhs   %q12 %q30 $0x03 -> %q2
+ushl   %d7 %d18 $0x00 -> %d1
+ushl   %q7 %q18 $0x00 -> %q1
+ushl   %d7 %d18 $0x01 -> %d1
+ushl   %q7 %q18 $0x01 -> %q1
+ushl   %d7 %d18 $0x02 -> %d1
+ushl   %q7 %q18 $0x02 -> %q1
+ushl   %q7 %q18 $0x03 -> %q1
+uqshl  %d15 %d18 $0x00 -> %d27
+uqshl  %q15 %q18 $0x00 -> %q27
+uqshl  %d15 %d18 $0x01 -> %d27
+uqshl  %q15 %q18 $0x01 -> %q27
+uqshl  %d15 %d18 $0x02 -> %d27
+uqshl  %q15 %q18 $0x02 -> %q27
+uqshl  %q15 %q18 $0x03 -> %q27
+urshl  %d2 %d6 $0x00 -> %d5
+urshl  %q2 %q6 $0x00 -> %q5
+urshl  %d2 %d6 $0x01 -> %d5
+urshl  %q2 %q6 $0x01 -> %q5
+urshl  %d2 %d6 $0x02 -> %d5
+urshl  %q2 %q6 $0x02 -> %q5
+urshl  %q2 %q6 $0x03 -> %q5
+uqrshl %d10 %d30 $0x00 -> %d18
+uqrshl %q10 %q30 $0x00 -> %q18
+uqrshl %d10 %d30 $0x01 -> %d18
+uqrshl %q10 %q30 $0x01 -> %q18
+uqrshl %d10 %d30 $0x02 -> %d18
+uqrshl %q10 %q30 $0x02 -> %q18
+uqrshl %q10 %q30 $0x03 -> %q18
+umax   %d23 %d25 $0x00 -> %d9
+umax   %q23 %q25 $0x00 -> %q9
+umax   %d23 %d25 $0x01 -> %d9
+umax   %q23 %q25 $0x01 -> %q9
+umax   %d23 %d25 $0x02 -> %d9
+umax   %q23 %q25 $0x02 -> %q9
+umin   %d22 %d11 $0x00 -> %d12
+umin   %q22 %q11 $0x00 -> %q12
+umin   %d22 %d11 $0x01 -> %d12
+umin   %q22 %q11 $0x01 -> %q12
+umin   %d22 %d11 $0x02 -> %d12
+umin   %q22 %q11 $0x02 -> %q12
+uabd   %d12 %d27 $0x00 -> %d5
+uabd   %q12 %q27 $0x00 -> %q5
+uabd   %d12 %d27 $0x01 -> %d5
+uabd   %q12 %q27 $0x01 -> %q5
+uabd   %d12 %d27 $0x02 -> %d5
+uabd   %q12 %q27 $0x02 -> %q5
+uaba   %d6 %d19 $0x00 -> %d13
+uaba   %q6 %q19 $0x00 -> %q13
+uaba   %d6 %d19 $0x01 -> %d13
+uaba   %q6 %q19 $0x01 -> %q13
+uaba   %d6 %d19 $0x02 -> %d13
+uaba   %q6 %q19 $0x02 -> %q13
+sub    %d27 %d28 $0x00 -> %d29
+sub    %q27 %q28 $0x00 -> %q29
+sub    %d27 %d28 $0x01 -> %d29
+sub    %q27 %q28 $0x01 -> %q29
+sub    %d27 %d28 $0x02 -> %d29
+sub    %q27 %q28 $0x02 -> %q29
+sub    %q27 %q28 $0x03 -> %q29
+cmeq   %d17 %d23 $0x00 -> %d13
+cmeq   %q17 %q23 $0x00 -> %q13
+cmeq   %d17 %d23 $0x01 -> %d13
+cmeq   %q17 %q23 $0x01 -> %q13
+cmeq   %d17 %d23 $0x02 -> %d13
+cmeq   %q17 %q23 $0x02 -> %q13
+cmeq   %q17 %q23 $0x03 -> %q13
+mls    %d7 %d13 %d27 $0x00 -> %d7
+mls    %q7 %q13 %q27 $0x00 -> %q7
+mls    %d7 %d13 %d27 $0x01 -> %d7
+mls    %q7 %q13 %q27 $0x01 -> %q7
+mls    %d7 %d13 %d27 $0x02 -> %d7
+mls    %q7 %q13 %q27 $0x02 -> %q7
+pmul   %d24 %d12 $0x00 -> %d26
+pmul   %q24 %q12 $0x00 -> %q26
+umaxp  %d27 %d5 $0x00 -> %d4
+umaxp  %q27 %q5 $0x00 -> %q4
+umaxp  %d27 %d5 $0x01 -> %d4
+umaxp  %q27 %q5 $0x01 -> %q4
+umaxp  %d27 %d5 $0x02 -> %d4
+umaxp  %q27 %q5 $0x02 -> %q4
+uminp  %d22 %d16 $0x00 -> %d3
+uminp  %q22 %q16 $0x00 -> %q3
+uminp  %d22 %d16 $0x01 -> %d3
+uminp  %q22 %q16 $0x01 -> %q3
+uminp  %d22 %d16 $0x02 -> %d3
+uminp  %q22 %q16 $0x02 -> %q3
+sqrdmulh %d29 %d27 $0x01 -> %d23
+sqrdmulh %q29 %q27 $0x01 -> %q23
+sqrdmulh %d29 %d27 $0x02 -> %d23
+sqrdmulh %q29 %q27 $0x02 -> %q23
+fmaxnmp %d18 %d29 $0x02 -> %d12
+fmaxnmp %q18 %q29 $0x02 -> %q12
+fmaxnmp %q18 %q29 $0x03 -> %q12
+fmlal2 %d0 %d29 %d31 -> %d0
+fmlal2 %q0 %q29 %q31 -> %q0
+faddp  %d31 %d16 $0x02 -> %d18
+faddp  %q31 %q16 $0x02 -> %q18
+faddp  %q31 %q16 $0x03 -> %q18
+fmul   %d28 %d21 $0x02 -> %d25
+fmul   %q28 %q21 $0x02 -> %q25
+fmul   %q28 %q21 $0x03 -> %q25
+fcmge  %d17 %d30 $0x02 -> %d22
+fcmge  %q17 %q30 $0x02 -> %q22
+fcmge  %q17 %q30 $0x03 -> %q22
+facge  %d30 %d30 $0x02 -> %d28
+facge  %q30 %q30 $0x02 -> %q28
+facge  %q30 %q30 $0x03 -> %q28
+fmaxp  %d23 %d25 $0x02 -> %d5
+fmaxp  %q23 %q25 $0x02 -> %q5
+fmaxp  %q23 %q25 $0x03 -> %q5
+fdiv   %d26 %d4 $0x02 -> %d10
+fdiv   %q26 %q4 $0x02 -> %q10
+fdiv   %q26 %q4 $0x03 -> %q10
+eor    %d1 %d20 -> %d19
+eor    %q1 %q20 -> %q19
+bsl    %d4 %d25 -> %d20
+bsl    %q4 %q25 -> %q20
+fminnmp %d18 %d11 $0x02 -> %d23
+fminnmp %q18 %q11 $0x02 -> %q23
+fminnmp %q18 %q11 $0x03 -> %q23
+fmlsl2 %d0 %d29 %d31 -> %d0
+fmlsl2 %q0 %q29 %q31 -> %q0
+fabd   %d10 %d19 $0x02 -> %d15
+fabd   %q10 %q19 $0x02 -> %q15
+fabd   %q10 %q19 $0x03 -> %q15
+fcmgt  %d3 %d14 $0x02 -> %d6
+fcmgt  %q3 %q14 $0x02 -> %q6
+fcmgt  %q3 %q14 $0x03 -> %q6
+facgt  %d26 %d12 $0x02 -> %d4
+facgt  %q26 %q12 $0x02 -> %q4
+facgt  %q26 %q12 $0x03 -> %q4
+fminp  %d1 %d25 $0x02 -> %d28
+fminp  %q1 %q25 $0x02 -> %q28
+fminp  %q1 %q25 $0x03 -> %q28
+bit    %d21 %d12 -> %d12
+bit    %q21 %q12 -> %q12
+bif    %d3 %d3 -> %d20
+bif    %q3 %q3 -> %q20
+test_asimdsame complete
 All tests complete


### PR DESCRIPTION
This commits adds the instructions from the Armv8-a
'Advanced SIMD three same' and 'Advanced SIMD three same (FP16)'
encoding groups. For the macros, all FP16 version are handled by
the macros for 'Advanced SIMD three same'

Issue #2626