### PR TITLE
i#3059: add customized separator for droption_t

### DIFF
--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -34,8 +34,6 @@
  * @file droption.h
  * @brief Options parsing support
  */
-// We need to specify the @file command to make doxygen include global
-// functions, variables, typedefs, and enums in this file.
 
 #ifndef _DROPTION_H_
 #define _DROPTION_H_ 1

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -369,8 +369,8 @@ template <typename T> class droption_t : public droption_parser_t
     /** Returns the value of this option. */
     T get_value() const { return value; }
 
-    /** Returns the separator of the value of this option. */
-    std::string get_valsep() const { return valsep; }
+    /** Returns the separator of the option value (see #DROPTION_FLAG_ACCUMULATE). */
+    std::string get_value_separator() const { return valsep; }
 
     /** Sets the value of this option, overriding the command line. */
     void set_value(T new_value) { value = new_value; }

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -69,8 +69,9 @@ typedef enum {
      * By default, if an option is specified multiple times on the
      * command line, only the last value is honored.  If this flag is
      * set, repeated options accumulate, appending to the prior value
-     * (separating each appended value with a space).  This is
-     * supported for options of type std::string only.
+     * (separating each appended value with a space by default or with a user-specified
+     * accumulated value separator if it was supplied to the droption_t constructor).
+     * This is supported for options of type std::string only.
      */
     // XXX: to support other types of accumulation, we should add explicit
     // support for dr_option_t<std::vector<std::string> >.
@@ -345,8 +346,8 @@ template <typename T> class droption_t : public droption_parser_t
 
     /**
      * Declares a new option of type T with the given scope, behavior flags,
-     * accumulated value separator, default value, and description in short and long
-     * forms.
+     * accumulated value separator (see #DROPTION_FLAG_ACCUMULATE), default value,
+     * and description in short and long forms.
      */
     droption_t(unsigned int scope_, std::string name_, unsigned int flags_,
                std::string valsep_, T defval_, std::string desc_short_,

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -330,7 +330,8 @@ template <typename T> class droption_t : public droption_parser_t
     droption_t(unsigned int scope_, std::string name_, T defval_,
                std::string desc_short_, std::string desc_long_)
         : droption_parser_t(scope_, name_, desc_short_, desc_long_, 0),
-        value(defval_), defval(defval_), valsep(DROPTION_DEFAULT_VALUE_SEP), has_range(false) {}
+        value(defval_), defval(defval_), valsep(DROPTION_DEFAULT_VALUE_SEP),
+        has_range(false) {}
 
     /**
      * Declares a new option of type T with the given scope, behavior flags,
@@ -339,7 +340,8 @@ template <typename T> class droption_t : public droption_parser_t
     droption_t(unsigned int scope_, std::string name_, unsigned int flags_,
                T defval_, std::string desc_short_, std::string desc_long_)
         : droption_parser_t(scope_, name_, desc_short_, desc_long_, flags_),
-        value(defval_), defval(defval_), valsep(DROPTION_DEFAULT_VALUE_SEP), has_range(false) {}
+        value(defval_), defval(defval_), valsep(DROPTION_DEFAULT_VALUE_SEP),
+        has_range(false) {}
 
     /**
      * Declares a new option of type T with the given scope, behavior flags,
@@ -360,8 +362,8 @@ template <typename T> class droption_t : public droption_parser_t
                T minval_, T maxval_,
                std::string desc_short_, std::string desc_long_)
         : droption_parser_t(scope_, name_, desc_short_, desc_long_, 0),
-        value(defval_), defval(defval_), valsep(DROPTION_DEFAULT_VALUE_SEP), has_range(true),
-        minval(minval_), maxval(maxval_) {}
+        value(defval_), defval(defval_), valsep(DROPTION_DEFAULT_VALUE_SEP),
+        has_range(true), minval(minval_), maxval(maxval_) {}
 
     /** Returns the value of this option. */
     T get_value() const { return value; }

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -69,9 +69,10 @@ typedef enum {
      * By default, if an option is specified multiple times on the
      * command line, only the last value is honored.  If this flag is
      * set, repeated options accumulate, appending to the prior value
-     * (separating each appended value with a space by default or with a user-specified
-     * accumulated value separator if it was supplied to the droption_t constructor).
-     * This is supported for options of type std::string only.
+     * (separating each appended value with a space by default or with a
+     * user-specified accumulated value separator if it was supplied to the
+     * droption_t constructor). This is supported for options of type
+     * std::string only.
      */
     // XXX: to support other types of accumulation, we should add explicit
     // support for dr_option_t<std::vector<std::string> >.
@@ -346,8 +347,8 @@ template <typename T> class droption_t : public droption_parser_t
 
     /**
      * Declares a new option of type T with the given scope, behavior flags,
-     * accumulated value separator (see #DROPTION_FLAG_ACCUMULATE), default value,
-     * and description in short and long forms.
+     * accumulated value separator (see #DROPTION_FLAG_ACCUMULATE), default
+     * value, and description in short and long forms.
      */
     droption_t(unsigned int scope_, std::string name_, unsigned int flags_,
                std::string valsep_, T defval_, std::string desc_short_,
@@ -369,7 +370,9 @@ template <typename T> class droption_t : public droption_parser_t
     /** Returns the value of this option. */
     T get_value() const { return value; }
 
-    /** Returns the separator of the option value (see #DROPTION_FLAG_ACCUMULATE). */
+    /** Returns the separator of the option value
+     * (see #DROPTION_FLAG_ACCUMULATE).
+     */
     std::string get_value_separator() const { return valsep; }
 
     /** Sets the value of this option, overriding the command line. */

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -46,7 +46,7 @@
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 #define TESTANY(mask, var) (((mask) & (var)) != 0)
 
-#define DEFAULT_VALUE_SEP " "
+#define DROPTION_DEFAULT_VALUE_SEP " "
 
 // XXX: some clients want further distinctions, such as options passed to
 // post-processing components, internal (i.e., undocumented) options, etc.
@@ -330,7 +330,7 @@ template <typename T> class droption_t : public droption_parser_t
     droption_t(unsigned int scope_, std::string name_, T defval_,
                std::string desc_short_, std::string desc_long_)
         : droption_parser_t(scope_, name_, desc_short_, desc_long_, 0),
-        value(defval_), defval(defval_), valsep(DEFAULT_VALUE_SEP), has_range(false) {}
+        value(defval_), defval(defval_), valsep(DROPTION_DEFAULT_VALUE_SEP), has_range(false) {}
 
     /**
      * Declares a new option of type T with the given scope, behavior flags,
@@ -339,7 +339,7 @@ template <typename T> class droption_t : public droption_parser_t
     droption_t(unsigned int scope_, std::string name_, unsigned int flags_,
                T defval_, std::string desc_short_, std::string desc_long_)
         : droption_parser_t(scope_, name_, desc_short_, desc_long_, flags_),
-        value(defval_), defval(defval_), valsep(DEFAULT_VALUE_SEP), has_range(false) {}
+        value(defval_), defval(defval_), valsep(DROPTION_DEFAULT_VALUE_SEP), has_range(false) {}
 
     /**
      * Declares a new option of type T with the given scope, behavior flags,
@@ -360,7 +360,7 @@ template <typename T> class droption_t : public droption_parser_t
                T minval_, T maxval_,
                std::string desc_short_, std::string desc_long_)
         : droption_parser_t(scope_, name_, desc_short_, desc_long_, 0),
-        value(defval_), defval(defval_), valsep(DEFAULT_VALUE_SEP), has_range(true),
+        value(defval_), defval(defval_), valsep(DROPTION_DEFAULT_VALUE_SEP), has_range(true),
         minval(minval_), maxval(maxval_) {}
 
     /** Returns the value of this option. */

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -30,7 +30,12 @@
  * DAMAGE.
  */
 
-/* droption: option parsing support */
+/**
+ * @file droption.h
+ * @brief Options parsing support
+ */
+// We need to specify the @file command to make doxygen include global
+// functions, variables, typedefs, and enums in this file.
 
 #ifndef _DROPTION_H_
 #define _DROPTION_H_ 1

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -369,6 +369,9 @@ template <typename T> class droption_t : public droption_parser_t
     /** Returns the value of this option. */
     T get_value() const { return value; }
 
+    /** Returns the separator of the value of this option. */
+    std::string get_valsep() const { return valsep; }
+
     /** Sets the value of this option, overriding the command line. */
     void set_value(T new_value) { value = new_value; }
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2031,7 +2031,7 @@ if (CLIENT_INTERFACE)
   endif (NOT ARM)
 
   tobuild_ci(client.option_parse client-interface/option_parse.cpp
-    "-x;4;-y;quoted string;-z;first;-z;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-no_flag;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4"
+    "-x;4;-y;quoted string;-z;first;-z;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-no_flag;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4"
     "" "")
   use_DynamoRIO_extension(client.option_parse.dll droption)
   set(client.option_parse_client_ops_islist ON)

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -70,11 +70,19 @@ static droption_t<twostring_t> op_takes2
 (DROPTION_SCOPE_CLIENT, "takes2", DROPTION_FLAG_ACCUMULATE,
  twostring_t("",""), "Param that takes 2",
  "Longer desc of param that takes 2.");
+static droption_t<std::string> op_val_sep
+(DROPTION_SCOPE_CLIENT, "val_sep", DROPTION_FLAG_ACCUMULATE, "+",
+ std::string(""), "Param that uses cutomized seperator \";\"",
+ "Longer desc of that uses cutomized seperator \";\"");
+static droption_t<twostring_t> op_val_sep2
+(DROPTION_SCOPE_CLIENT, "val_sep2", DROPTION_FLAG_ACCUMULATE, "+",
+ twostring_t("",""), "Param that takes 2 and uses cutomized seperator \";\"",
+ "Longer desc of param that takes 2 and uses cutomized seperator \";\"");
 
 static void
 test_argv(int argc, const char *argv[])
 {
-    ASSERT(argc == 22);
+    ASSERT(argc == 32);
     ASSERT(strcmp(argv[1], "-x") == 0);
     ASSERT(strcmp(argv[2], "4") == 0);
     ASSERT(strcmp(argv[3], "-y") == 0);
@@ -96,6 +104,16 @@ test_argv(int argc, const char *argv[])
     ASSERT(strcmp(argv[19], "-takes2") == 0);
     ASSERT(strcmp(argv[20], "3_of_4") == 0);
     ASSERT(strcmp(argv[21], "4_of_4") == 0);
+    ASSERT(strcmp(argv[22], "-val_sep") == 0);
+    ASSERT(strcmp(argv[23], "v1.1 v1.2") == 0);
+    ASSERT(strcmp(argv[24], "-val_sep") == 0);
+    ASSERT(strcmp(argv[25], "v2.1 v2.2") == 0);
+    ASSERT(strcmp(argv[26], "-val_sep2") == 0);
+    ASSERT(strcmp(argv[27], "v1") == 0);
+    ASSERT(strcmp(argv[28], "v2") == 0);
+    ASSERT(strcmp(argv[29], "-val_sep2") == 0);
+    ASSERT(strcmp(argv[30], "v3") == 0);
+    ASSERT(strcmp(argv[31], "v4") == 0);
 }
 
 DR_EXPORT void
@@ -125,6 +143,9 @@ dr_client_main(client_id_t client_id, int argc, const char *argv[])
     dr_fprintf(STDERR, "param sweep = |%s|\n", op_sweep.get_value().c_str());
     dr_fprintf(STDERR, "param takes2 = |%s|,|%s|\n",
                op_takes2.get_value().first.c_str(), op_takes2.get_value().second.c_str());
+    dr_fprintf(STDERR, "param val_sep = |%s|\n", op_val_sep.get_value().c_str());
+    dr_fprintf(STDERR, "param val_sep2 = |%s|,|%s|\n",
+               op_val_sep2.get_value().first.c_str(), op_val_sep2.get_value().second.c_str());
     ASSERT(!op_foo.specified());
     ASSERT(!op_bar.specified());
 
@@ -137,4 +158,8 @@ dr_client_main(client_id_t client_id, int argc, const char *argv[])
     // not really supported by droption.
     ok = dr_parse_options(client_id, NULL, NULL);
     ASSERT(ok);
+
+    // Test get_valsep()
+    ASSERT(op_val_sep.get_valsep() == std::string("+"));
+    ASSERT(op_val_sep2.get_valsep() == std::string("+"));
 }

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -72,12 +72,12 @@ static droption_t<twostring_t> op_takes2
  "Longer desc of param that takes 2.");
 static droption_t<std::string> op_val_sep
 (DROPTION_SCOPE_CLIENT, "val_sep", DROPTION_FLAG_ACCUMULATE, "+",
- std::string(""), "Param that uses cutomized seperator \";\"",
- "Longer desc of that uses cutomized seperator \";\"");
+ std::string(""), "Param that uses customized separator \"+\"",
+ "Longer desc of that uses customized separator \"+\"");
 static droption_t<twostring_t> op_val_sep2
 (DROPTION_SCOPE_CLIENT, "val_sep2", DROPTION_FLAG_ACCUMULATE, "+",
- twostring_t("",""), "Param that takes 2 and uses cutomized seperator \";\"",
- "Longer desc of param that takes 2 and uses cutomized seperator \";\"");
+ twostring_t("",""), "Param that takes 2 and uses customized separator \"+\"",
+ "Longer desc of param that takes 2 and uses customize  d separator \"+\"");
 
 static void
 test_argv(int argc, const char *argv[])
@@ -159,7 +159,8 @@ dr_client_main(client_id_t client_id, int argc, const char *argv[])
     ok = dr_parse_options(client_id, NULL, NULL);
     ASSERT(ok);
 
-    // Test get_valsep()
-    ASSERT(op_val_sep.get_valsep() == std::string("+"));
-    ASSERT(op_val_sep2.get_valsep() == std::string("+"));
+    // Test get_value_separator()
+    ASSERT(op_y.get_value_separator() == std::string(" "));
+    ASSERT(op_val_sep.get_value_separator() == std::string("+"));
+    ASSERT(op_val_sep2.get_value_separator() == std::string("+"));
 }

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -77,7 +77,7 @@ static droption_t<std::string> op_val_sep
 static droption_t<twostring_t> op_val_sep2
 (DROPTION_SCOPE_CLIENT, "val_sep2", DROPTION_FLAG_ACCUMULATE, "+",
  twostring_t("",""), "Param that takes 2 and uses customized separator \"+\"",
- "Longer desc of param that takes 2 and uses customize  d separator \"+\"");
+ "Longer desc of param that takes 2 and uses customized separator \"+\"");
 
 static void
 test_argv(int argc, const char *argv[])
@@ -143,9 +143,11 @@ dr_client_main(client_id_t client_id, int argc, const char *argv[])
     dr_fprintf(STDERR, "param sweep = |%s|\n", op_sweep.get_value().c_str());
     dr_fprintf(STDERR, "param takes2 = |%s|,|%s|\n",
                op_takes2.get_value().first.c_str(), op_takes2.get_value().second.c_str());
-    dr_fprintf(STDERR, "param val_sep = |%s|\n", op_val_sep.get_value().c_str());
+    dr_fprintf(STDERR, "param val_sep = |%s|\n",
+               op_val_sep.get_value().c_str());
     dr_fprintf(STDERR, "param val_sep2 = |%s|,|%s|\n",
-               op_val_sep2.get_value().first.c_str(), op_val_sep2.get_value().second.c_str());
+               op_val_sep2.get_value().first.c_str(),
+               op_val_sep2.get_value().second.c_str());
     ASSERT(!op_foo.specified());
     ASSERT(!op_bar.specified());
 

--- a/suite/tests/client-interface/option_parse.expect
+++ b/suite/tests/client-interface/option_parse.expect
@@ -6,4 +6,6 @@ param bar = |some string with spaces|
 param flag = |0|
 param sweep = |-front value -front2 value2|
 param takes2 = |1_of_4 3_of_4|,|2_of_4 4_of_4|
+param val_sep = |v1.1 v1.2+v2.1 v2.2|
+param val_sep2 = |v1+v3|,|v2+v4|
 Hello, world!


### PR DESCRIPTION
Get rid of the hard-code space separator and add customized separator for
droption in droption_t constructor.

Fixes #3059