### PR TITLE
i#3049: clean postcall_cache when drwrap_exit

### DIFF
--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -970,7 +970,7 @@ void
 drwrap_exit(void)
 {
     /* handle multiple sets of init/exit calls */
-    int count = dr_atomic_add32_return_sum(&drwrap_init_count, -1);
+    int i, count = dr_atomic_add32_return_sum(&drwrap_init_count, -1);
     if (count != 0)
         return;
 

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -970,7 +970,7 @@ void
 drwrap_exit(void)
 {
     /* handle multiple sets of init/exit calls */
-    int i, count = dr_atomic_add32_return_sum(&drwrap_init_count, -1);
+    int count = dr_atomic_add32_return_sum(&drwrap_init_count, -1);
     if (count != 0)
         return;
 
@@ -981,7 +981,7 @@ drwrap_exit(void)
         !dr_unregister_delete_event(drwrap_fragment_delete))
         ASSERT(false, "failed to unregister in drwrap_exit");
 
-    for (i = 0; i < POSTCALL_CACHE_SIZE; i++) {
+    for (int i = 0; i < POSTCALL_CACHE_SIZE; i++) {
         postcall_cache[i] = NULL;
     }
     postcall_cache_idx = 0;

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -981,6 +981,11 @@ drwrap_exit(void)
         !dr_unregister_delete_event(drwrap_fragment_delete))
         ASSERT(false, "failed to unregister in drwrap_exit");
 
+    for (i = 0; i < POSTCALL_CACHE_SIZE; i++) {
+        postcall_cache[i] = NULL;
+    }
+    postcall_cache_idx = 0;
+
     hashtable_delete(&replace_table);
     hashtable_delete(&replace_native_table);
     hashtable_delete(&wrap_table);


### PR DESCRIPTION
This commit is a supplement for PR #3050.
We need to clean `postcall_cache` on `drwrap_exit` as well, otherwise
post-callback (one of the arguments when calling `drwrap_wrap_ex`) will not be invoked at re-attach. This is because the registration of post-callback relies on pre-callback, and pre-callback checks postcall-cache before registering the post-callback. Stale data in `postcall_cache` prevents post-callback being registered to the hash table.

Fixes #3049