### PR TITLE
i#X: Fix flaky test

### DIFF
--- a/clients/drcachesim/tests/missfile-config-file.templatex
+++ b/clients/drcachesim/tests/missfile-config-file.templatex
@@ -8,14 +8,14 @@ Core #0 \([0-9] traced CPU\(s\): #.*\)
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*..
     Invalidations:                *[0-9,\.]*..
-.*    Miss rate:                        [0-9][,\.]..%
+.*    Miss rate:                        *[0-9][,\.]..%
   L1D stats:
     Warmup hits:                  *[0-9,\.]*....
     Warmup misses:                *[0-9,\.]*..
     Hits:                         *[0-9,\.]*....
     Misses:                       *[0-9,\.]*..
     Invalidations:                *[0-9,\.]*..
-.*    Miss rate:                        [0-9][,\.]..%
+.*    Miss rate:                        *[0-9,\.]*..%
 L2 stats:
     Warmup hits:                  *[0-9,\.]*....
     Warmup misses:                *[0-9,\.]*..
@@ -24,7 +24,7 @@ L2 stats:
     Invalidations:                *[0-9]
 .*   Local miss rate:                 [0-9].[,\.]..%
     Child hits:                   *[0-9,\.]*.....
-    Total miss rate:                  [0-3][,\.]..%
+    Total miss rate:                  [0-9][,\.]..%
 LLC stats:
     Warmup hits:                  *[0-9,\.]*....
     Warmup misses:                *[0-9,\.]*..


### PR DESCRIPTION
The test tool.drcachesim.missfile-config-file is flaky and this commit fixes it by relaxing the output template.