### PR TITLE
i#2006 drcachesim: Fix use-after-free in opcode_mix tool

### DIFF
--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -45,6 +45,7 @@
 #include <iomanip>
 #include <iostream>
 #include <vector>
+#include <string.h>
 
 const std::string opcode_mix_t::TOOL_NAME = "Opcode mix tool";
 
@@ -55,15 +56,15 @@ opcode_mix_tool_create(const std::string& module_file_path, unsigned int verbose
 }
 
 opcode_mix_t::opcode_mix_t(const std::string& module_file_path, unsigned int verbose) :
-    dcontext(nullptr), raw2trace(nullptr), knob_verbose(verbose), instr_count(0)
+    dcontext(nullptr), raw2trace(nullptr), directory(module_file_path),
+    knob_verbose(verbose), instr_count(0)
 {
     if (module_file_path.empty()) {
         success = false;
         return;
     }
     dcontext = dr_standalone_init();
-    raw2trace_directory_t dir(module_file_path);
-    raw2trace = new raw2trace_t(dir.modfile_bytes, std::vector<std::istream*>(),
+    raw2trace = new raw2trace_t(directory.modfile_bytes, std::vector<std::istream*>(),
                                 nullptr, dcontext, verbose);
     std::string error = raw2trace->do_module_parsing_and_mapping();
     if (!error.empty()) {

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -38,6 +38,7 @@
 
 #include "analysis_tool.h"
 #include "tracer/raw2trace.h"
+#include "tracer/raw2trace_directory.h"
 
 class opcode_mix_t : public analysis_tool_t
 {
@@ -50,6 +51,9 @@ class opcode_mix_t : public analysis_tool_t
  protected:
     void *dcontext;
     raw2trace_t *raw2trace;
+    // We reference directory.modfile_bytes throughout operation, so its lifetime
+    // must match ours.
+    raw2trace_directory_t directory;
     unsigned int knob_verbose;
     int_least64_t instr_count;
     std::unordered_map<int, int_least64_t> opcode_counts;


### PR DESCRIPTION
Eliminates the too-early destruction of raw2trace_directory_t, as we
need to reference the vdso contents later on.

Issue: #2006