### PR TITLE
Use std namespace qualifier for strings.

### DIFF
--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -46,9 +46,9 @@ config_reader_t::~config_reader_t()
 }
 
 bool
-config_reader_t::configure(const string &config_file,
+config_reader_t::configure(const std::string &config_file,
                            cache_simulator_knobs_t &knobs,
-                           std::map<string, cache_params_t> &caches)
+                           std::map<std::string, cache_params_t> &caches)
 {
     // Open the config file.
     fin.open(config_file);
@@ -59,7 +59,7 @@ config_reader_t::configure(const string &config_file,
 
     // Walk through the configuration file.
     while (!fin.eof()) {
-        string param;
+        std::string param;
 
         if (!(fin >> ws >> param)) {
             ERRMSG("Unable to read from the configuration file\n");
@@ -133,7 +133,7 @@ config_reader_t::configure(const string &config_file,
         }
         else if (param == "cpu_scheduling") {
             // Whether to simulate CPU scheduling or not.
-            string bool_val;
+            std::string bool_val;
             if (!(fin >> bool_val)) {
                 ERRMSG("Error reading cpu_scheduling from "
                        "the configuration file\n");
@@ -177,7 +177,7 @@ bool
 config_reader_t::configure_cache(cache_params_t &cache)
 {
     // String used to construct meaningful error messages.
-    string error_msg;
+    std::string error_msg;
 
     char c;
     if (!(fin >> ws >> c)) {
@@ -190,7 +190,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
     }
 
     while (!fin.eof()) {
-        string param;
+        std::string param;
         if (!(fin >> ws >> param)) {
             ERRMSG("Unable to read from the configuration file\n");
             return false;
@@ -231,7 +231,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
         }
         else if (param == "size") {
             // Cache size in bytes.
-            string size_str;
+            std::string size_str;
             if (!(fin >> size_str)) {
                 ERRMSG("Error reading cache size from "
                        "the configuration file\n");
@@ -262,7 +262,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
         }
         else if (param == "inclusive") {
             // Is the cache inclusive of its children.
-            string bool_val;
+            std::string bool_val;
             if (!(fin >> bool_val)) {
                 ERRMSG("Error reading cache inclusivity from "
                        "the configuration file\n");
@@ -341,7 +341,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
 
 bool
 config_reader_t::check_cache_config(int num_cores,
-                                    std::map<string, cache_params_t>
+                                    std::map<std::string, cache_params_t>
                                         &caches_map)
 {
     int *core_inst_caches = new int[num_cores];
@@ -352,7 +352,7 @@ config_reader_t::check_cache_config(int num_cores,
     }
 
     for (auto &cache_map : caches_map) {
-        string cache_name = cache_map.first;
+        std::string cache_name = cache_map.first;
         auto &cache = cache_map.second;
 
         // Associate a cache to a core.
@@ -395,7 +395,7 @@ config_reader_t::check_cache_config(int num_cores,
             }
 
             // Check for cycles between the cache and its parent.
-            string parent = cache.parent;
+            std::string parent = cache.parent;
             while (parent != CACHE_PARENT_MEMORY) {
                 if (parent == cache_name) {
                     ERRMSG("Cache %s & its parent %s have a cyclic reference\n",
@@ -429,7 +429,7 @@ config_reader_t::check_cache_config(int num_cores,
 //      droption_t<bytesize_t>::convert_from_string
 //      Consider sharing the function using a single copy.
 bool
-config_reader_t::convert_string_to_size(const string &s, uint64_t &size)
+config_reader_t::convert_string_to_size(const std::string &s, uint64_t &size)
 {
     char suffix = *s.rbegin();  // s.back() only in C++11
     int scale;

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -60,10 +60,10 @@ struct cache_params_t {
         prefetcher(PREFETCH_POLICY_NONE),
         miss_file("") {}
     // Cache's name. Each cache must have a unique name.
-    string name;
+    std::string name;
     // Cache type: CACHE_TYPE_INSTRUCTION, CACHE_TYPE_DATA,
     // or CACHE_TYPE_UNIFIED (default).
-    string type;
+    std::string type;
     // CPU core this cache is associated with.
     // Must be specified for L1 caches only.
     int core;
@@ -75,17 +75,17 @@ struct cache_params_t {
     bool inclusive;
     // Name of the cache's parent. LLC's parent is main memory
     // (CACHE_PARENT_MEMORY).
-    string parent;
+    std::string parent;
     // Names of the cache's children. L1 caches don't have children.
-    std::vector<string> children;
+    std::vector<std::string> children;
     // Cache replacement policy as described by the runtime option
     // op_replace_policy (see ../common/options.cpp).
-    string replace_policy;
+    std::string replace_policy;
     // Type of prefetcher as described by the runtime option
     // op_data_prefetcher (see ../common/options.cpp).
-    string prefetcher;
+    std::string prefetcher;
     // Name of the file to use to dump cache misses info.
-    string miss_file;
+    std::string miss_file;
 };
 
 class config_reader_t
@@ -93,18 +93,18 @@ class config_reader_t
  public:
     config_reader_t();
     ~config_reader_t();
-    bool configure(const string &config_file,
+    bool configure(const std::string &config_file,
                    cache_simulator_knobs_t &knobs,
-                   std::map<string, cache_params_t> &caches);
+                   std::map<std::string, cache_params_t> &caches);
 
  private:
     std::ifstream fin;
 
     bool configure_cache(cache_params_t &cache);
     bool check_cache_config(int num_cores,
-                            std::map<string, cache_params_t> &caches_map);
-    bool convert_string_to_size(const string &s, uint64_t &size);
-    bool is_true(string bool_val)
+                            std::map<std::string, cache_params_t> &caches_map);
+    bool convert_string_to_size(const std::string &s, uint64_t &size);
+    bool is_true(std::string bool_val)
     {
         if (bool_val == "true" || bool_val == "True" || bool_val == "TRUE") {
             return true;

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -56,7 +56,7 @@ cache_simulator_create(const cache_simulator_knobs_t &knobs)
 }
 
 analysis_tool_t *
-cache_simulator_create(const string &config_file)
+cache_simulator_create(const std::string &config_file)
 {
     return new cache_simulator_t(config_file);
 }
@@ -98,7 +98,7 @@ cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs_) :
         return;
     }
 
-    string cache_name = "LL";
+    std::string cache_name = "LL";
     all_caches[cache_name] = llc;
     llcaches[cache_name] = llc;
 
@@ -173,7 +173,7 @@ cache_simulator_t::cache_simulator_t(const string &config_file) :
 
     // Create all the caches in the hierarchy.
     for (auto &cache_params_it : cache_params) {
-        string cache_name = cache_params_it.first;
+        std::string cache_name = cache_params_it.first;
         auto &cache_config = cache_params_it.second;
 
         cache_t *cache = create_cache(cache_config.replace_policy);
@@ -188,7 +188,7 @@ cache_simulator_t::cache_simulator_t(const string &config_file) :
     // Initialize all the caches in the hierarchy and identify both
     // the L1 caches and LLC(s).
     for (auto &cache_it : all_caches) {
-        string cache_name = cache_it.first;
+        std::string cache_name = cache_it.first;
         cache_t *cache = cache_it.second;
 
         // Locate the cache's configuration.
@@ -217,7 +217,7 @@ cache_simulator_t::cache_simulator_t(const string &config_file) :
         std::vector<caching_device_t*> children;
         children.clear();
         if (cache_config.inclusive) {
-            for (string &child_name : cache_config.children) {
+            for (std::string &child_name : cache_config.children) {
                 const auto &child_it = all_caches.find(child_name);
                 if (child_it == all_caches.end()) {
                     error_string = "Error locating the configuration of the cache: " +
@@ -468,7 +468,7 @@ cache_simulator_t::print_results()
 }
 
 cache_t*
-cache_simulator_t::create_cache(std::string policy)
+cache_simulator_t::create_cache(const std::string& policy)
 {
     if (policy == REPLACE_POLICY_NON_SPECIFIED || // default LRU
         policy == REPLACE_POLICY_LRU) // set to LRU

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -63,7 +63,7 @@ class cache_simulator_t : public simulator_t
     bool check_warmed_up();
  protected:
     // Create a cache_t object with a specific replacement policy.
-    virtual cache_t *create_cache(std::string policy);
+    virtual cache_t *create_cache(const std::string& policy);
 
     cache_simulator_knobs_t knobs;
 

--- a/clients/drcachesim/tests/config_reader_test.cpp
+++ b/clients/drcachesim/tests/config_reader_test.cpp
@@ -37,10 +37,10 @@
 #include "../simulator/cache_simulator_create.h"
 
 static void
-check_cache(const std::map<string, cache_params_t> &caches, string name,
-            string type, int core, uint64_t size, unsigned int assoc,
-            bool inclusive, string parent, string replace_policy,
-            string prefetcher, string miss_file) {
+check_cache(const std::map<std::string, cache_params_t> &caches, std::string name,
+            std::string type, int core, uint64_t size, unsigned int assoc,
+            bool inclusive, std::string parent, std::string replace_policy,
+            std::string prefetcher, std::string miss_file) {
     auto cache_it = caches.find(name);
     if (cache_it == caches.end()) {
         std::cerr << "drcachesim config_reader_test failed (cache: "
@@ -69,8 +69,8 @@ int
 main(int argc, const char *argv[])
 {
     cache_simulator_knobs_t knobs;
-    std::map<string, cache_params_t> caches;
-    string file_name = "single_core.conf";
+    std::map<std::string, cache_params_t> caches;
+    std::string file_name = "single_core.conf";
 
     config_reader_t config;
     if (!config.configure(file_name, knobs, caches)) {


### PR DESCRIPTION
Use std namespace qualifier for strings so that they don't cause conflicts with google internal libraries. 