### PR TITLE
i#3069 DRCachesim: Fix sim_refs regression

### DIFF
--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -287,7 +287,8 @@ cache_simulator_t::~cache_simulator_t()
 }
 
 uint64_t
-cache_simulator_t::knobs_sim_refs() const {
+cache_simulator_t::remaining_sim_refs() const
+{
   return knobs.sim_refs;
 }
 

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -286,6 +286,11 @@ cache_simulator_t::~cache_simulator_t()
     }
 }
 
+uint64_t
+cache_simulator_t::knobs_sim_refs() const {
+  return knobs.sim_refs;
+}
+
 bool
 cache_simulator_t::process_memref(const memref_t &memref)
 {
@@ -294,9 +299,15 @@ cache_simulator_t::process_memref(const memref_t &memref)
         return true;
     }
 
+    // If no warmup is specified and we have simulated sim_refs then
+    // we are done.
+    if ((knobs.warmup_refs == 0 && knobs.warmup_fraction == 0.0)
+        && knobs.sim_refs == 0)
+        return true;
+
     // The references after warmup and simulated ones are dropped.
     if (check_warmed_up() && knobs.sim_refs == 0)
-        return true;;
+        return true;
 
     // Both warmup and simulated references are simulated.
 
@@ -393,7 +404,8 @@ cache_simulator_t::process_memref(const memref_t &memref)
 
 // Return true if the number of warmup references have been executed or if
 // specified fraction of the llcaches has been loaded. Also return true if the
-// cache has already been warmed up.
+// cache has already been warmed up. When there are multiple last level caches
+// this function only returns true when all of them have been warmed up.
 bool
 cache_simulator_t::check_warmed_up()
 {
@@ -480,6 +492,6 @@ cache_simulator_t::create_cache(const std::string& policy)
 
     // undefined replacement policy
     ERRMSG("Usage error: undefined replacement policy. "
-           "Please choose " REPLACE_POLICY_LRU" or " REPLACE_POLICY_LFU".\n");
+           "Please choose " REPLACE_POLICY_LRU " or " REPLACE_POLICY_LFU ".\n");
     return NULL;
 }

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -61,6 +61,7 @@ class cache_simulator_t : public simulator_t
 
     // Exposed to make it easy to test
     bool check_warmed_up();
+    uint64_t knobs_sim_refs() const;
  protected:
     // Create a cache_t object with a specific replacement policy.
     virtual cache_t *create_cache(const std::string& policy);

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -60,7 +60,7 @@ class cache_simulator_t : public simulator_t
 
     // Exposed to make it easy to test
     bool check_warmed_up();
-    uint64_t knobs_sim_refs() const;
+    uint64_t remaining_sim_refs() const;
  protected:
     // Create a cache_t object with a specific replacement policy.
     virtual cache_t *create_cache(const std::string& policy);

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -129,7 +129,7 @@ unit_test_sim_refs()
         }
     }
 
-    if (cache_sim.knobs_sim_refs() != 0) {
+    if (cache_sim.remaining_sim_refs() != 0) {
         std::cerr << "drcachesim unit_test_sim_refs failed\n";
         exit(1);
     }

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -36,8 +36,8 @@
 #include "simulator/cache_simulator.h"
 #include "../common/memref.h"
 
-void
-unit_test_warmup_fraction()
+static cache_simulator_knobs_t
+make_test_knobs()
 {
     cache_simulator_knobs_t knobs;
     knobs.num_cores = 1;
@@ -48,6 +48,13 @@ unit_test_warmup_fraction()
     knobs.LL_size = 32*64;
     knobs.LL_assoc = 32;
     knobs.data_prefetcher = "none";
+    return knobs;
+}
+
+void
+unit_test_warmup_fraction()
+{
+    cache_simulator_knobs_t knobs = make_test_knobs();
     knobs.warmup_fraction = 0.5;
     cache_simulator_t cache_sim(knobs);
 
@@ -76,15 +83,7 @@ unit_test_warmup_fraction()
 void
 unit_test_warmup_refs()
 {
-    cache_simulator_knobs_t knobs;
-    knobs.num_cores = 1;
-    knobs.L1I_size = 32*64;
-    knobs.L1D_size = 32*64;
-    knobs.L1I_assoc = 32;
-    knobs.L1D_assoc = 32;
-    knobs.LL_size = 32*64;
-    knobs.LL_assoc = 32;
-    knobs.data_prefetcher = "none";
+    cache_simulator_knobs_t knobs = make_test_knobs();
     knobs.warmup_refs = 16;
     cache_simulator_t cache_sim(knobs);
 
@@ -110,11 +109,38 @@ unit_test_warmup_refs()
     }
 }
 
+void
+unit_test_sim_refs()
+{
+    cache_simulator_knobs_t knobs = make_test_knobs();
+    knobs.sim_refs = 8;
+    cache_simulator_t cache_sim(knobs);
+
+    std::string error;
+    for (int i = 0; i < 16; i++) {
+        memref_t ref;
+        ref.data.type = TRACE_TYPE_READ;
+        ref.data.size = 8;
+        ref.data.addr = i * 128;
+        if (!cache_sim.process_memref(ref)) {
+            std::cerr << "drcachesim unit_test_sim_refs failed: "
+                      << cache_sim.get_error_string() << "\n";
+            exit(1);
+        }
+    }
+
+    if (cache_sim.knobs_sim_refs() != 0) {
+        std::cerr << "drcachesim unit_test_sim_refs failed\n";
+        exit(1);
+    }
+}
+
 
 int
 main(int argc, const char *argv[])
 {
     unit_test_warmup_fraction();
     unit_test_warmup_refs();
+    unit_test_sim_refs();
     return 0;
 }


### PR DESCRIPTION
Make sure we respect the sim_refs knob when warmup_refs and
warmup_fraction are set to defaults. Add a unit test to check.

Fixes #3069