### PR TITLE
i#3080 configure libelftc: Add DRSYM_HAVE_LIBELFTC.

### DIFF
--- a/ext/drsyms/CMakeLists.txt
+++ b/ext/drsyms/CMakeLists.txt
@@ -182,6 +182,10 @@ configure_extension(drsyms_static ON)
 configure_drsyms_target(drsyms_static)
 use_DynamoRIO_extension(drsyms_static drcontainers)
 
+# we always use the elftoolchain library when building with cmake
+append_property_string(TARGET drsyms COMPILE_FLAGS "-DDRSYM_HAVE_LIBELFTC")
+append_property_string(TARGET drsyms_static COMPILE_FLAGS "-DDRSYM_HAVE_LIBELFTC")
+
 target_link_libraries(drsyms "${dwarf_libpath}" "${elftc_libpath}")
 if (LINUX)
   target_link_libraries(drsyms "${elf_libpath}")


### PR DESCRIPTION
Add a drsyms configure flag, which allows non-cmake builds to build
without libelftc. Nothing changes for the cmake build, which always sets
it.

Fixes #3080