### PR TITLE
Remove unnecessary include.

### DIFF
--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -41,7 +41,6 @@
 #include "cache_simulator_create.h"
 #include "cache_stats.h"
 #include "cache.h"
-#include "../reader/config_reader.h"
 
 class cache_simulator_t : public simulator_t
 {


### PR DESCRIPTION
Not necessary, plus causes header checking failures with bazel.