### PR TITLE
i#2006: Cleanup headers for drcachesim tools -- opcode mix and view 

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -146,6 +146,7 @@ use_DynamoRIO_extension(drcachesim drutil_static)
 # export in a single dir for 3rd-party tool integration.
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/common)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/reader)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/tracer)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 add_exported_library(drmemtrace_analyzer STATIC

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -38,9 +38,6 @@
 
 #include "dr_api.h"
 #include "opcode_mix.h"
-#include "common/utils.h"
-#include "tracer/raw2trace.h"
-#include "tracer/raw2trace_directory.h"
 #include <algorithm>
 #include <iomanip>
 #include <iostream>

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -37,8 +37,8 @@
 #include <unordered_map>
 
 #include "analysis_tool.h"
-#include "tracer/raw2trace.h"
-#include "tracer/raw2trace_directory.h"
+#include "raw2trace.h"
+#include "raw2trace_directory.h"
 
 class opcode_mix_t : public analysis_tool_t
 {

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -38,8 +38,6 @@
 
 #include "dr_api.h"
 #include "view.h"
-#include "common/utils.h"
-#include "tracer/raw2trace.h"
 #include <algorithm>
 #include <iomanip>
 #include <iostream>

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -37,8 +37,8 @@
 #include <unordered_map>
 
 #include "analysis_tool.h"
-#include "tracer/raw2trace.h"
-#include "tracer/raw2trace_directory.h"
+#include "raw2trace.h"
+#include "raw2trace_directory.h"
 
 class view_t : public analysis_tool_t
 {


### PR DESCRIPTION
The drcachesim tools opcode_mix and view depend on headers such as
raw2trace.h and raw2trace_directory.h. We update the CMakeLists.txt for
drcachesim so that they can be referenced directly instead of via
tracer/...

Issue: #2006 