### PR TITLE
 i#2390 ind br: Emit NOPs instead of movk reg, #0. 

### DIFF
--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -125,7 +125,6 @@ insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f,
         *pc++ = (0xf9400000 | 1 | (dr_reg_stolen - DR_REG_X0) << 5 |
                  get_fcache_return_tls_offs(dcontext, f->flags) >>
                  3 << 10);
-
         /* br x1 */
         *pc++ = BR_X1_INST;
     } else {
@@ -141,7 +140,6 @@ insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f,
         /* ldr x1, [x(stolen), #(offs)] */
         *pc++ = (0xf9400000 | 1 | (dr_reg_stolen - DR_REG_X0) << 5 |
                  get_ibl_entry_tls_offs(dcontext, exit_target) >> 3 << 10);
-
         /* br x1 */
         *pc++ = BR_X1_INST;
     }

--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -288,8 +288,8 @@ link_indirect_exit_arch(dcontext_t *dcontext, fragment_t *f,
 
     pc = get_stub_branch(pc) - 1;
     /* ldr x1, [x(stolen), #(offs)] */
-    pc = (0xf9400000 | 1 | (dr_reg_stolen - DR_REG_X0) << 5 |
-          get_ibl_entry_tls_offs(dcontext, exit_target) >> 3 << 10);
+    *pc = (0xf9400000 | 1 | (dr_reg_stolen - DR_REG_X0) << 5 |
+           get_ibl_entry_tls_offs(dcontext, exit_target) >> 3 << 10);
 
     if (hot_patch)
         machine_cache_sync(pc, pc + 1, true);

--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -121,7 +121,6 @@ insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f,
         /* mov x0, ... */
         pc = insert_mov_imm(pc, DR_REG_X0, (ptr_int_t)l);
         num_nops_needed = 4 - (pc - (uint *) stub_pc - 1 );
-
         /* ldr x1, [x(stolen), #(offs)] */
         *pc++ = (0xf9400000 | 1 | (dr_reg_stolen - DR_REG_X0) << 5 |
                  get_fcache_return_tls_offs(dcontext, f->flags) >>

--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -254,7 +254,9 @@ exit_cti_disp_pc(cache_pc branch_pc)
 }
 
 /* Skips NOP instructions backwards until the first non-NOP instruction is found. */
-static uint *get_stub_branch(uint *pc) {
+static uint *
+get_stub_branch(uint *pc)
+{
     /* Skip NOP instructions backwards. */
     while (*pc == NOP_INST)
         pc--;

--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -327,8 +327,9 @@ unlink_indirect_exit(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
     exit_target = ibl_code->unlinked_ibl_entry;
 
     /* Set pc to the last instruction in the stub. */
-    pc = (uint *)(stub_pc +exit_stub_size(dcontext, ibl_code->indirect_branch_lookup_routine,
-                                          f->flags) - AARCH64_INSTR_SIZE);
+    pc = (uint *)(stub_pc +
+                  exit_stub_size(dcontext, ibl_code->indirect_branch_lookup_routine,
+                                 f->flags) - AARCH64_INSTR_SIZE);
     pc = get_stub_branch(pc) - 1;
 
     /* ldr x1, [x(stolen), #(offs)] */


### PR DESCRIPTION
Instead of creating unnecessary movk instructions when creating
exit stubs, we insert nops instead just before the branch. Ideally we
would just have a variable size for the exit stub fragments, but at
different places DynamoRIO expects them the be of a fixed size and the
last instruction to be a branch.

Issue #2390