### PR TITLE
i#2876 clang-format: fix Mac build

### DIFF
--- a/make/configure.cmake.h
+++ b/make/configure.cmake.h
@@ -34,7 +34,7 @@
 /* configure.cmake.h
  * processed by cmake to contain all configuration defines
  */
-// We disable formatting as it messes up the ${var} references.
+/* We disable formatting as it messes up the ${var} references: */
 /* clang-format off */
 #ifndef _CONFIGURE_H_
 #define _CONFIGURE_H_ 1


### PR DESCRIPTION
Fixes the Mac build which was failing on a C++ comment inside configure.h.

Issue: #2876