### PR TITLE
win32/loader: Add another pseudo-DLL

### DIFF
--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -1515,6 +1515,7 @@ map_api_set_dll(const char *name, privmod_t *dependent)
              str_case_prefix(name, "API-MS-Win-Core-Path-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-PerfCounters-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-ProcessSnapshot-L1-1") ||
+             str_case_prefix(name, "API-MS-Win-Core-Psm-Key-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-Quirks-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-RegistryUserSpecific-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-SHLWAPI-Legacy-L1-1") ||


### PR DESCRIPTION
Also observed experimentally on Windows 10, and correlated using [this list](https://redplait.blogspot.com/2017/02/apisetschemadll-from-windows-10-build.html).