### PR TITLE
i#975 static DR: support setup;detach

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -2855,7 +2855,9 @@ dynamorio_take_over_threads(dcontext_t *dcontext)
      */
     dynamo_thread_under_dynamo(dcontext);
     signal_event(dr_app_started);
+    SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
     dynamo_started = true;
+    SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
     /* XXX i#1305: we should suspend all the other threads for DR init to
      * satisfy the parts of the init process that assume there are no races.
      */

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -92,6 +92,7 @@
 /* global thread-shared variables */
 bool dynamo_initialized = false;
 bool dynamo_heap_initialized = false;
+bool dynamo_started = false;
 bool automatic_startup = false;
 bool control_all_threads = false;
 #ifdef WINDOWS
@@ -1154,6 +1155,7 @@ dynamo_shared_exit(thread_record_t *toexit /* must ==cur thread for Linux */
 #endif /* DEBUG */
 
     dynamo_initialized = false;
+    dynamo_started = false;
     return SUCCESS;
 }
 
@@ -2853,6 +2855,7 @@ dynamorio_take_over_threads(dcontext_t *dcontext)
      */
     dynamo_thread_under_dynamo(dcontext);
     signal_event(dr_app_started);
+    dynamo_started = true;
     /* XXX i#1305: we should suspend all the other threads for DR init to
      * satisfy the parts of the init process that assume there are no races.
      */

--- a/core/globals.h
+++ b/core/globals.h
@@ -462,6 +462,7 @@ extern bool control_all_threads;     /* ok for "weird" things to happen -- not a
                                         threads are under our control */
 extern bool dynamo_heap_initialized; /* has dynamo_heap been initialized? */
 extern bool dynamo_initialized;      /* has dynamo been initialized? */
+extern bool dynamo_started;          /* has DR initiated takeover of the app? */
 extern bool dynamo_exited;           /* has dynamo exited? */
 extern bool dynamo_exited_all_other_threads; /* has dynamo exited and synched? */
 extern bool dynamo_exited_and_cleaned;       /* has dynamo component cleanup started? */

--- a/core/synch.c
+++ b/core/synch.c
@@ -2021,6 +2021,17 @@ detach_on_permanent_stack(bool internal, bool do_cleanup, dr_stats_t *drstats)
 
     my_id = get_thread_id();
     my_dcontext = get_thread_private_dcontext();
+    if (my_dcontext == NULL) {
+        /* We support detach after just dr_app_setup() with no start. */
+        ASSERT(!dynamo_started);
+        my_tr = thread_lookup(my_id);
+        ASSERT(my_tr != NULL);
+        my_dcontext = my_tr->dcontext;
+        os_process_under_dynamorio_initiate(my_dcontext);
+        os_process_under_dynamorio_complete(my_dcontext);
+        dynamo_thread_under_dynamo(my_dcontext);
+        ASSERT(get_thread_private_dcontext() == my_dcontext);
+    }
     ASSERT(my_dcontext != NULL);
 
     LOG(GLOBAL, LOG_ALL, 1, "Detach: thread %d starting detach process\n", my_id);

--- a/suite/tests/api/static_noclient.c
+++ b/suite/tests/api/static_noclient.c
@@ -59,12 +59,15 @@ main(int argc, const char *argv[])
      * attach+detach testing.
      * XXX: When there's a client, this requires a flag to skip the client init
      * in this first dr_app_setup().
+     * FIXME i#2040: this hits the app_fls_data assert on Windows.
      */
+#ifdef UNIX
     dr_app_setup();
     instr_t *instr = XINST_CREATE_return(GLOBAL_DCONTEXT);
     assert(instr_is_return(instr));
     instr_destroy(GLOBAL_DCONTEXT, instr);
     dr_app_stop_and_cleanup();
+#endif
 
     print("pre-DR init\n");
     dr_app_setup();

--- a/suite/tests/api/static_noclient.c
+++ b/suite/tests/api/static_noclient.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -52,6 +52,20 @@ do_some_work(int seed)
 int
 main(int argc, const char *argv[])
 {
+    /* We test using DR IR routines when statically linked.  We can't use
+     * drdecode when statically linked with DR as drdecode relies on symbol
+     * replacement, so instead we initialize DR and then "detach" to do a full
+     * cleanup (even without an attach) before starting our regular
+     * attach+detach testing.
+     * XXX: When there's a client, this requires a flag to skip the client init
+     * in this first dr_app_setup().
+     */
+    dr_app_setup();
+    instr_t *instr = XINST_CREATE_return(GLOBAL_DCONTEXT);
+    assert(instr_is_return(instr));
+    instr_destroy(GLOBAL_DCONTEXT, instr);
+    dr_app_stop_and_cleanup();
+
     print("pre-DR init\n");
     dr_app_setup();
     assert(!dr_app_running_under_dynamorio());


### PR DESCRIPTION
Adds support for calling dr_app_setup();dr_app_stop_and_cleanup() with
no start in between.  This is useful to use DR as a decode/encode
library when it's statically linked and also used for instrumentation,
as that setup precludes using drdecodelib, which relies on redirecting
heap allocation via name redirection.

Add a test to api.static_noclient.

Issue: #975