### PR TITLE
i#3098: fix shared ibt table races

### DIFF
--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -366,6 +366,7 @@ emit_detach_callback_final_jmp(dcontext_t *dcontext,
 #        define ATOMIC_ADD_PTR(type, var, val) ATOMIC_ADD_int(var, val)
 #        define ATOMIC_COMPARE_EXCHANGE_PTR ATOMIC_COMPARE_EXCHANGE_int
 #    endif
+#    define MEMORY_STORE_BARRIER()       /* not needed on x86 */
 #    define SPINLOCK_PAUSE() _mm_pause() /* PAUSE = 0xf3 0x90 = repz nop */
 #    define RDTSC_LL(var) (var = __rdtsc())
 #    define SERIALIZE_INSTRUCTIONS()     \

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -508,6 +508,7 @@ atomic_add_exchange_int64(volatile int64 *var, int64 value)
                              : "=r"(result), "=m"(var) \
                              : "0"(newval), "m"(var))
 
+#        define MEMORY_STORE_BARRIER() /* not needed on x86 */
 #        define SPINLOCK_PAUSE() __asm__ __volatile__("pause")
 #        ifdef X64
 #            define RDTSC_LL(llval)                                        \
@@ -657,6 +658,7 @@ DEF_ATOMIC_incdec(ATOMIC_INC_int, int, "w", "add") DEF_ATOMIC_incdec(ATOMIC_INC_
     return ret;
 }
 
+#        define MEMORY_STORE_BARRIER() __asm__ __volatile__("dmb st")
 #        define SPINLOCK_PAUSE()             \
             do {                             \
                 __asm__ __volatile__("wfi"); \
@@ -793,6 +795,7 @@ atomic_dec_becomes_zero(volatile int *var)
                                  : "r"(newval)                  \
                                  : "cc", "memory", "r2", "r3");
 
+#        define MEMORY_STORE_BARRIER() __asm__ __volatile__("dmb st")
 #        define SPINLOCK_PAUSE() __asm__ __volatile__("wfi") /* wait for interrupt */
 uint64
 proc_get_timestamp(void);

--- a/core/hashtablex.h
+++ b/core/hashtablex.h
@@ -68,6 +68,8 @@
  *     HASHTABLE_LOCKLESS_ACCESS tables
  *   bool ENTRIES_ARE_EQUAL(table, entry1, entry2)
  *     if using pointers, pointer equality is fine
+ *   void ENTRY_SET_TO_ENTRY(table_entry, new_entry)
+ *     This is optional; if omitted, "table_entry = new_entry" is used.
  *   ENTRY_TYPE ENTRY_EMPTY
  *   ENTRY_TYPE ENTRY_SENTINEL
  *     FIXME: to support structs we'll need lhs like AUX_ENTRY_SET_TO_SENTINEL
@@ -888,7 +890,11 @@ static inline bool HTNAME(hashtable_, NAME_KEY,
 #    endif
     if (ENTRY_IS_INVALID(table->table[hindex]))
         table->unlinked_entries--;
+#    ifdef ENTRY_SET_TO_ENTRY
+    ENTRY_SET_TO_ENTRY(table->table[hindex], e);
+#    else
     table->table[hindex] = e;
+#    endif
     ASSERT(!ENTRY_IS_INVALID(table->table[hindex]));
     LOG(THREAD_GET, LOG_HTABLE, 4,
         "hashtable_" KEY_STRING "_add: added " PFX " to %s at table[%u]\n", ENTRY_TAG(e),
@@ -2208,6 +2214,7 @@ HTNAME(, NAME_KEY, _table_t) *
 #undef ENTRY_IS_SENTINEL
 #undef ENTRY_IS_INVALID
 #undef ENTRIES_ARE_EQUAL
+#undef ENTRY_SET_TO_ENTRY
 #undef ENTRY_EMPTY
 #undef ENTRY_SENTINEL
 #undef TAGS_ARE_EQUAL

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -7594,9 +7594,6 @@ dr_prepopulate_indirect_targets(dr_indirect_branch_type_t branch_type, app_pc *t
     uint i;
     if (dcontext == NULL)
         return false;
-#    ifdef UNIX
-    os_swap_context(dcontext, false /*to dr*/, DR_STATE_GO_NATIVE);
-#    endif
     /* Initially I took in an opcode and used extract_branchtype(instr_branch_type())
      * but every use case had to make a fake instr to get the opcode and had no
      * good cross-platform method so I switched to an enum.  We're unlikely to
@@ -7610,6 +7607,9 @@ dr_prepopulate_indirect_targets(dr_indirect_branch_type_t branch_type, app_pc *t
     }
     SYSLOG_INTERNAL_INFO("pre-populating ibt[%d] table for %d tags", ibl_type,
                          tags_count);
+#    ifdef UNIX
+    os_swap_context(dcontext, false /*to dr*/, DR_STATE_GO_NATIVE);
+#    endif
     for (i = 0; i < tags_count; i++) {
         fragment_add_ibl_target(dcontext, tags[i], ibl_type);
     }

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -9304,7 +9304,13 @@ get_stack_bounds(dcontext_t *dcontext, byte **base, byte **top)
             ok = get_memory_info_from_os((app_pc)get_mcontext(dcontext)->xsp,
                                          &ostd->stack_base, &size, NULL);
         }
-        ASSERT(ok);
+        if (!ok) {
+             /* This can happen with dr_prepopulate_cache() before we start running
+              * the app.
+              */
+             ASSERT(!dynamo_started);
+             return false;
+        }
         ostd->stack_top = ostd->stack_base + size;
         LOG(THREAD, LOG_THREADS, 1, "App stack is " PFX "-" PFX "\n", ostd->stack_base,
             ostd->stack_top);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -9305,11 +9305,11 @@ get_stack_bounds(dcontext_t *dcontext, byte **base, byte **top)
                                          &ostd->stack_base, &size, NULL);
         }
         if (!ok) {
-             /* This can happen with dr_prepopulate_cache() before we start running
-              * the app.
-              */
-             ASSERT(!dynamo_started);
-             return false;
+            /* This can happen with dr_prepopulate_cache() before we start running
+             * the app.
+             */
+            ASSERT(!dynamo_started);
+            return false;
         }
         ostd->stack_top = ostd->stack_base + size;
         LOG(THREAD, LOG_THREADS, 1, "App stack is " PFX "-" PFX "\n", ostd->stack_base,

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -3855,7 +3855,11 @@ is_on_stack(dcontext_t *dcontext, app_pc pc, vm_area_t *area)
     }
     if (query_esp) {
         ok = get_memory_info(esp, &esp_base, &size, NULL);
-        ASSERT(ok);
+        if (!ok) {
+          /* This can happen with dr_prepopulate_cache(). */
+          ASSERT(!dynamo_started);
+          return false;
+        }
         LOG(THREAD, LOG_VMAREAS, 3,
             "stack vs " PFX ": region " PFX ".." PFX ", esp " PFX "\n", pc, esp_base,
             esp_base + size, esp);

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -3856,9 +3856,9 @@ is_on_stack(dcontext_t *dcontext, app_pc pc, vm_area_t *area)
     if (query_esp) {
         ok = get_memory_info(esp, &esp_base, &size, NULL);
         if (!ok) {
-          /* This can happen with dr_prepopulate_cache(). */
-          ASSERT(!dynamo_started);
-          return false;
+            /* This can happen with dr_prepopulate_cache(). */
+            ASSERT(!dynamo_started);
+            return false;
         }
         LOG(THREAD, LOG_VMAREAS, 3,
             "stack vs " PFX ": region " PFX ".." PFX ", esp " PFX "\n", pc, esp_base,

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2295,11 +2295,21 @@ if (CLIENT_INTERFACE)
       # We use -checklevel 0 to disable the DOCHECK in check_thread_vm_area
       # which makes building 150K bbs very slow.
       "-disable_traces -shared_bb_ibt_tables -checklevel 0" "" OFF OFF)
+    use_DynamoRIO_extension(api.ibl-stress drcontainers)
     if (UNIX)
       target_link_libraries(api.ibl-stress ${libpthread})
+    else ()
+      # On Windows, somehow linking with drcontainers inserts it and drhelper
+      # in front of dynamorio.lib, despite being added to the link list later,
+      # which results in unresolved symbols.
+      # The only fix I could come up with is to force dynamorio.lib earlier
+      # using the link flags:
+      get_target_property(drpath dynamorio LOCATION${location_suffix})
+      get_filename_component(drdir ${drpath} DIRECTORY)
+      get_filename_component(drname ${drpath} NAME_WE)
+      append_link_flags(api.ibl-stress "${drdir}/${drname}.lib")
     endif ()
-    use_DynamoRIO_extension(api.ibl-stress drcontainers)
-  endif ()
+endif ()
 
   # XXX: we should expand this test of drsyms standalone to be cross-platform and
   # not just check libstdc++-6.dll.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2289,6 +2289,18 @@ if (CLIENT_INTERFACE)
     tobuild_api(api.drdecode api/drdecode_x86.c "" "" ON OFF)
   endif ()
 
+  if (X86) # Generated code is x86-specific.
+    tobuild_api(api.ibl-stress api/ibl-stress.c
+      # This tests indirect branches between blocks.
+      # We use -checklevel 0 to disable the DOCHECK in check_thread_vm_area
+      # which makes building 150K bbs very slow.
+      "-disable_traces -shared_bb_ibt_tables -checklevel 0" "" OFF OFF)
+    if (UNIX)
+      target_link_libraries(api.ibl-stress ${libpthread})
+    endif ()
+    use_DynamoRIO_extension(api.ibl-stress drcontainers)
+  endif ()
+
   # XXX: we should expand this test of drsyms standalone to be cross-platform and
   # not just check libstdc++-6.dll.
   if (WIN32)

--- a/suite/tests/api/ibl-stress.c
+++ b/suite/tests/api/ibl-stress.c
@@ -91,24 +91,24 @@ generate_stack_accesses(instrlist_t *ilist, drvector_t *tags, byte *encode_pc)
 {
     encode_pc =
         append_ilist(ilist, encode_pc,
-                     INSTR_CREATE_push(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RBP)));
+                     INSTR_CREATE_push(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_XBP)));
     encode_pc =
         append_ilist(ilist, encode_pc,
-                     INSTR_CREATE_push(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RBX)));
+                     INSTR_CREATE_push(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_XBX)));
     encode_pc =
         append_ilist(ilist, encode_pc,
-                     INSTR_CREATE_push(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RDI)));
+                     INSTR_CREATE_push(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_XDI)));
     encode_pc =
         append_ilist(ilist, encode_pc,
-                     INSTR_CREATE_push(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RSI)));
+                     INSTR_CREATE_push(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_XSI)));
     encode_pc = append_ilist(
-        ilist, encode_pc, INSTR_CREATE_pop(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RSI)));
+        ilist, encode_pc, INSTR_CREATE_pop(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_XSI)));
     encode_pc = append_ilist(
-        ilist, encode_pc, INSTR_CREATE_pop(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RDI)));
+        ilist, encode_pc, INSTR_CREATE_pop(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_XDI)));
     encode_pc = append_ilist(
-        ilist, encode_pc, INSTR_CREATE_pop(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RBX)));
+        ilist, encode_pc, INSTR_CREATE_pop(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_XBX)));
     encode_pc = append_ilist(
-        ilist, encode_pc, INSTR_CREATE_pop(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RBP)));
+        ilist, encode_pc, INSTR_CREATE_pop(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_XBP)));
     return encode_pc;
 }
 
@@ -139,7 +139,7 @@ generate_indirect_call(instrlist_t *ilist, drvector_t *tags, byte *encode_pc)
     instr_t *after_callee = INSTR_CREATE_label(GLOBAL_DCONTEXT);
     instr_t *first, *last;
     instrlist_insert_mov_instr_addr(GLOBAL_DCONTEXT, callee, generated_code,
-                                    opnd_create_reg(DR_REG_RAX), ilist, NULL, &first,
+                                    opnd_create_reg(DR_REG_XAX), ilist, NULL, &first,
                                     &last);
     while (first != NULL && first != last) {
         print_instr_pc(first, encode_pc);
@@ -148,7 +148,7 @@ generate_indirect_call(instrlist_t *ilist, drvector_t *tags, byte *encode_pc)
     }
     encode_pc =
         append_ilist(ilist, encode_pc,
-                     INSTR_CREATE_call_ind(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RAX)));
+                     INSTR_CREATE_call_ind(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_XAX)));
     drvector_append(tags, encode_pc);
     encode_pc =
         append_ilist(ilist, encode_pc,
@@ -168,7 +168,7 @@ generate_indirect_jump(instrlist_t *ilist, drvector_t *tags, byte *encode_pc)
     instr_t *target = INSTR_CREATE_label(GLOBAL_DCONTEXT);
     instr_t *first, *last;
     instrlist_insert_mov_instr_addr(GLOBAL_DCONTEXT, target, generated_code,
-                                    opnd_create_reg(DR_REG_RAX), ilist, NULL, &first,
+                                    opnd_create_reg(DR_REG_XAX), ilist, NULL, &first,
                                     &last);
     while (first != NULL && first != last) {
         print_instr_pc(first, encode_pc);
@@ -177,7 +177,7 @@ generate_indirect_jump(instrlist_t *ilist, drvector_t *tags, byte *encode_pc)
     }
     encode_pc =
         append_ilist(ilist, encode_pc,
-                     INSTR_CREATE_jmp_ind(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RAX)));
+                     INSTR_CREATE_jmp_ind(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_XAX)));
     drvector_append(tags, encode_pc);
     encode_pc = append_ilist(ilist, encode_pc, target);
     encode_pc = generate_stack_accesses(ilist, tags, encode_pc);
@@ -190,7 +190,8 @@ generate_code()
     const size_t sequence_size = 73; /* Measured manually. */
     /* The final return takes up 1 byte. */
     code_size = NUM_SEQUENCES * sequence_size + 1;
-    generated_code = allocate_mem(code_size, ALLOW_EXEC | ALLOW_READ | ALLOW_WRITE);
+    generated_code =
+        (byte *)allocate_mem(code_size, ALLOW_EXEC | ALLOW_READ | ALLOW_WRITE);
     assert(generated_code != NULL);
 
     /* Synthesize code which includes a lot of indirect branches to test i#3098.
@@ -235,7 +236,7 @@ generate_code()
 void
 cleanup_code(void)
 {
-    free_mem(generated_code, code_size);
+    free_mem((char *)generated_code, code_size);
 }
 
 /***************************************************************************

--- a/suite/tests/api/ibl-stress.c
+++ b/suite/tests/api/ibl-stress.c
@@ -1,0 +1,288 @@
+/* **********************************************************
+ * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "configure.h"
+#include "dr_api.h"
+#include "drvector.h"
+#include "tools.h"
+#include "thread.h"
+#include "condvar.h"
+
+#ifdef LARGER_TEST
+/* 20K sequences gives us ~150K bbs. */
+#    define NUM_SEQUENCES 20000
+#    define NUM_THREADS 16
+#else
+/* We scale down from the larger size which more readily exposes races
+ * to a size suitable for a regression test on a small-sized VM.
+ */
+#    define NUM_SEQUENCES 1000
+#    define NUM_THREADS 8
+#endif
+
+#define VERBOSE 0
+
+#if VERBOSE
+#    define VPRINT(...) print(__VA_ARGS__)
+#else
+#    define VPRINT(...) /* nothing */
+#endif
+
+/***************************************************************************
+ * Synthetic code generation
+ */
+
+#ifndef X86
+#    error Non-x86 is not supported.
+#endif
+
+static byte *generated_code;
+static size_t code_size;
+
+static void
+print_instr_pc(instr_t *instr, byte *encode_pc)
+{
+#if VERBOSE > 0
+    dr_fprintf(STDERR, "%p: ", encode_pc);
+    instr_disassemble(GLOBAL_DCONTEXT, instr, STDERR);
+    dr_fprintf(STDERR, "\n");
+#endif
+}
+
+static byte *
+append_ilist(instrlist_t *ilist, byte *encode_pc, instr_t *instr)
+{
+    instrlist_append(ilist, instr);
+    print_instr_pc(instr, encode_pc);
+    return encode_pc + instr_length(GLOBAL_DCONTEXT, instr);
+}
+
+static byte *
+generate_stack_accesses(instrlist_t *ilist, drvector_t *tags, byte *encode_pc)
+{
+    encode_pc =
+        append_ilist(ilist, encode_pc,
+                     INSTR_CREATE_push(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RBP)));
+    encode_pc =
+        append_ilist(ilist, encode_pc,
+                     INSTR_CREATE_push(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RBX)));
+    encode_pc =
+        append_ilist(ilist, encode_pc,
+                     INSTR_CREATE_push(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RDI)));
+    encode_pc =
+        append_ilist(ilist, encode_pc,
+                     INSTR_CREATE_push(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RSI)));
+    encode_pc = append_ilist(
+        ilist, encode_pc, INSTR_CREATE_pop(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RSI)));
+    encode_pc = append_ilist(
+        ilist, encode_pc, INSTR_CREATE_pop(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RDI)));
+    encode_pc = append_ilist(
+        ilist, encode_pc, INSTR_CREATE_pop(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RBX)));
+    encode_pc = append_ilist(
+        ilist, encode_pc, INSTR_CREATE_pop(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RBP)));
+    return encode_pc;
+}
+
+static byte *
+generate_direct_call(instrlist_t *ilist, drvector_t *tags, byte *encode_pc)
+{
+    instr_t *callee = INSTR_CREATE_label(GLOBAL_DCONTEXT);
+    instr_t *after_callee = INSTR_CREATE_label(GLOBAL_DCONTEXT);
+    encode_pc = append_ilist(
+        ilist, encode_pc, INSTR_CREATE_call(GLOBAL_DCONTEXT, opnd_create_instr(callee)));
+    drvector_append(tags, encode_pc);
+    encode_pc =
+        append_ilist(ilist, encode_pc,
+                     INSTR_CREATE_jmp(GLOBAL_DCONTEXT, opnd_create_instr(after_callee)));
+    drvector_append(tags, encode_pc);
+    encode_pc = append_ilist(ilist, encode_pc, callee);
+    encode_pc = generate_stack_accesses(ilist, tags, encode_pc);
+    encode_pc = append_ilist(ilist, encode_pc, INSTR_CREATE_ret(GLOBAL_DCONTEXT));
+    drvector_append(tags, encode_pc);
+    encode_pc = append_ilist(ilist, encode_pc, after_callee);
+    return encode_pc;
+}
+
+static byte *
+generate_indirect_call(instrlist_t *ilist, drvector_t *tags, byte *encode_pc)
+{
+    instr_t *callee = INSTR_CREATE_label(GLOBAL_DCONTEXT);
+    instr_t *after_callee = INSTR_CREATE_label(GLOBAL_DCONTEXT);
+    instr_t *first, *last;
+    instrlist_insert_mov_instr_addr(GLOBAL_DCONTEXT, callee, generated_code,
+                                    opnd_create_reg(DR_REG_RAX), ilist, NULL, &first,
+                                    &last);
+    while (first != NULL && first != last) {
+        print_instr_pc(first, encode_pc);
+        encode_pc += instr_length(GLOBAL_DCONTEXT, first);
+        first = instr_get_next(first);
+    }
+    encode_pc =
+        append_ilist(ilist, encode_pc,
+                     INSTR_CREATE_call_ind(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RAX)));
+    drvector_append(tags, encode_pc);
+    encode_pc =
+        append_ilist(ilist, encode_pc,
+                     INSTR_CREATE_jmp(GLOBAL_DCONTEXT, opnd_create_instr(after_callee)));
+    drvector_append(tags, encode_pc);
+    encode_pc = append_ilist(ilist, encode_pc, callee);
+    encode_pc = generate_stack_accesses(ilist, tags, encode_pc);
+    encode_pc = append_ilist(ilist, encode_pc, INSTR_CREATE_ret(GLOBAL_DCONTEXT));
+    drvector_append(tags, encode_pc);
+    encode_pc = append_ilist(ilist, encode_pc, after_callee);
+    return encode_pc;
+}
+
+static byte *
+generate_indirect_jump(instrlist_t *ilist, drvector_t *tags, byte *encode_pc)
+{
+    instr_t *target = INSTR_CREATE_label(GLOBAL_DCONTEXT);
+    instr_t *first, *last;
+    instrlist_insert_mov_instr_addr(GLOBAL_DCONTEXT, target, generated_code,
+                                    opnd_create_reg(DR_REG_RAX), ilist, NULL, &first,
+                                    &last);
+    while (first != NULL && first != last) {
+        print_instr_pc(first, encode_pc);
+        encode_pc += instr_length(GLOBAL_DCONTEXT, first);
+        first = instr_get_next(first);
+    }
+    encode_pc =
+        append_ilist(ilist, encode_pc,
+                     INSTR_CREATE_jmp_ind(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_RAX)));
+    drvector_append(tags, encode_pc);
+    encode_pc = append_ilist(ilist, encode_pc, target);
+    encode_pc = generate_stack_accesses(ilist, tags, encode_pc);
+    return encode_pc;
+}
+
+static void
+generate_code()
+{
+    const size_t sequence_size = 73; /* Measured manually. */
+    /* The final return takes up 1 byte. */
+    code_size = NUM_SEQUENCES * sequence_size + 1;
+    generated_code = allocate_mem(code_size, PROT_EXEC | PROT_READ | PROT_WRITE);
+    assert(generated_code != NULL);
+
+    /* Synthesize code which includes a lot of indirect branches to test i#3098.
+     * We pre-populate the cache to better stress the ibt tables.
+     * If we instead incrementally build blocks, the ibt table additions are
+     * mixed into the slow, serializing block building, and we don't see
+     * many races that way.
+     */
+    drvector_t tags;
+    /* Each sequence has 7 bb's.  We round up to 8 to cover the extra and have a
+     * rounder number.
+     */
+    drvector_init(&tags, 8 * NUM_SEQUENCES, false, NULL);
+    drvector_append(&tags, generated_code);
+    instrlist_t *ilist = instrlist_create(GLOBAL_DCONTEXT);
+    byte *encode_pc = generated_code;
+    for (int i = 0; i < NUM_SEQUENCES; ++i) {
+        encode_pc = generate_stack_accesses(ilist, &tags, encode_pc);
+        encode_pc = generate_direct_call(ilist, &tags, encode_pc);
+        encode_pc = generate_indirect_call(ilist, &tags, encode_pc);
+        encode_pc = generate_indirect_jump(ilist, &tags, encode_pc);
+    }
+    /* The outer level is a function. */
+    encode_pc = append_ilist(ilist, encode_pc, INSTR_CREATE_ret(GLOBAL_DCONTEXT));
+
+    byte *end_pc = instrlist_encode(GLOBAL_DCONTEXT, ilist, generated_code, true);
+    assert(end_pc <= generated_code + code_size);
+
+    protect_mem(generated_code, code_size, PROT_EXEC | PROT_READ);
+
+#if VERBOSE > 0
+    for (int i = 0; i < tags.entries; i++)
+        dr_fprintf(STDERR, "%d: %p\n", i, tags.array[i]);
+#endif
+    bool success = dr_prepopulate_cache((byte **)tags.array, tags.entries);
+    assert(success);
+
+    drvector_delete(&tags);
+    instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
+}
+
+void
+cleanup_code(void)
+{
+    int result = munmap(generated_code, code_size);
+    assert(result == 0);
+}
+
+/***************************************************************************
+ * Top-level
+ */
+
+static void *thread_continue;
+static void *thread_ready[NUM_THREADS];
+
+THREAD_FUNC_RETURN_TYPE
+thread_function(void *arg)
+{
+    const int ITERS = 5;
+    int i;
+    unsigned int idx = (unsigned int)(ptr_uint_t)arg;
+    signal_cond_var(thread_ready[idx]);
+    wait_cond_var(thread_continue);
+    for (i = 0; i < ITERS; ++i) {
+        ((void (*)(void))generated_code)();
+    }
+    return THREAD_FUNC_RETURN_ZERO;
+}
+
+int
+main(void)
+{
+    int i;
+    thread_t thread[NUM_THREADS];
+    thread_continue = create_cond_var();
+    dr_app_setup();
+    generate_code();
+    dr_app_start();
+    for (i = 0; i < NUM_THREADS; i++) {
+        thread_ready[i] = create_cond_var();
+        thread[i] = create_thread(thread_function, (void *)(ptr_uint_t)i);
+    }
+    signal_cond_var(thread_continue);
+    for (i = 0; i < NUM_THREADS; i++)
+        wait_cond_var(thread_ready[i]);
+    for (i = 0; i < NUM_THREADS; i++) {
+        join_thread(thread[i]);
+        destroy_cond_var(thread_ready[i]);
+    }
+    dr_app_stop_and_cleanup();
+    cleanup_code();
+    destroy_cond_var(thread_continue);
+    print("all done\n");
+    return 0;
+}

--- a/suite/tests/api/ibl-stress.c
+++ b/suite/tests/api/ibl-stress.c
@@ -190,7 +190,7 @@ generate_code()
     const size_t sequence_size = 73; /* Measured manually. */
     /* The final return takes up 1 byte. */
     code_size = NUM_SEQUENCES * sequence_size + 1;
-    generated_code = allocate_mem(code_size, PROT_EXEC | PROT_READ | PROT_WRITE);
+    generated_code = allocate_mem(code_size, ALLOW_EXEC | ALLOW_READ | ALLOW_WRITE);
     assert(generated_code != NULL);
 
     /* Synthesize code which includes a lot of indirect branches to test i#3098.
@@ -219,7 +219,7 @@ generate_code()
     byte *end_pc = instrlist_encode(GLOBAL_DCONTEXT, ilist, generated_code, true);
     assert(end_pc <= generated_code + code_size);
 
-    protect_mem(generated_code, code_size, PROT_EXEC | PROT_READ);
+    protect_mem(generated_code, code_size, ALLOW_EXEC | ALLOW_READ);
 
 #if VERBOSE > 0
     for (int i = 0; i < tags.entries; i++)
@@ -235,8 +235,7 @@ generate_code()
 void
 cleanup_code(void)
 {
-    int result = munmap(generated_code, code_size);
-    assert(result == 0);
+    free_mem(generated_code, code_size);
 }
 
 /***************************************************************************

--- a/suite/tests/api/ibl-stress.expect
+++ b/suite/tests/api/ibl-stress.expect
@@ -1,0 +1,1 @@
+all done

--- a/suite/tests/tools.c
+++ b/suite/tests/tools.c
@@ -167,20 +167,21 @@ get_os_prot_word(int prot)
 }
 
 char *
-allocate_mem(int size, int prot)
+allocate_mem(size_t size, int prot)
 {
 #    ifdef UNIX
     char *res = (char *)mmap((void *)0, size, get_os_prot_word(prot),
                              MAP_PRIVATE | MAP_ANON, -1, 0);
     if (res == MAP_FAILED)
         return NULL;
+    return res;
 #    else
     return (char *)VirtualAlloc(NULL, size, MEM_COMMIT, get_os_prot_word(prot));
 #    endif
 }
 
 void
-free_mem(char *addr, int size)
+free_mem(char *addr, size_t size)
 {
 #    ifdef UNIX
     int res = munmap(addr, size);

--- a/suite/tests/tools.h
+++ b/suite/tests/tools.h
@@ -619,6 +619,9 @@ char *
 allocate_mem(int size, int prot);
 
 void
+free_mem(char *addr, int size);
+
+void
 protect_mem(void *start, size_t len, int prot);
 
 void

--- a/suite/tests/tools.h
+++ b/suite/tests/tools.h
@@ -616,10 +616,10 @@ int
 get_os_prot_word(int prot);
 
 char *
-allocate_mem(int size, int prot);
+allocate_mem(size_t size, int prot);
 
 void
-free_mem(char *addr, int size);
+free_mem(char *addr, size_t size);
 
 void
 protect_mem(void *start, size_t len, int prot);


### PR DESCRIPTION
Fixes two races with shared ibt tables:

+ Adding a new table entry must write the start_pc before the tag.
  This is accomplished with a new ENTRY_SET_TO_ENTRY hashtablex.h
  optional specifier.  For ARM #2502 a new MEMORY_STORE_BARRIER macro
  is added.

+ Resizing a table must not clear the tags in the old table to avoid
  losing the tag on the target_delete ibl path.

Adds a test api.ibl-stress which uses the DR IR to synthetically
construct thousands of basic blocks with indirect branches betweent
them.

To make the test work, relaxes several is-on-stack checks to support
pre-building basic blocks (#2463) from generated code or other
locations not known prior to starting the application.

Issue: #3098, #2502, #2463

Fixes #3098