### PR TITLE
i#3100: add ptrsz immed utilities to drdecode

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2018 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -231,6 +231,7 @@ set(ARCH_SRCS
   arch/proc_shared.c
   arch/${ARCH_NAME}/proc.c
   arch/mangle_shared.c
+  arch/mangle_utils.c
   arch/${ARCH_NAME_SHARED}/mangle.c
   arch/clean_call_opt_shared.c
   arch/${ARCH_NAME}/clean_call_opt.c
@@ -898,6 +899,7 @@ endif (UNIX)
 add_library(drdecode
   ${DECODER_SRCS}
   arch/${ARCH_NAME_SHARED}/mangle.c
+  arch/mangle_utils.c
   arch/decodelib.c
   )
 set_target_properties(drdecode PROPERTIES

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -1315,12 +1315,15 @@ mangle_reinstate_it_blocks(dcontext_t *dcontext, instrlist_t *ilist, instr_t *st
 
 #    endif /* !AARCH64 */
 
+#endif /* !STANDALONE_DECODER */
+/* We export these mov/push utilities to drdecode */
+
 void
 insert_mov_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
                       ptr_int_t val, opnd_t dst, instrlist_t *ilist, instr_t *instr,
                       OUT instr_t **first, OUT instr_t **last)
 {
-#    ifdef AARCH64
+#ifdef AARCH64
     instr_t *mov;
     int i;
 
@@ -1358,7 +1361,7 @@ insert_mov_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_esti
     }
     if (last != NULL)
         *last = mov;
-#    else
+#else
     instr_t *mov1, *mov2;
     if (src_inst != NULL)
         val = (ptr_int_t)encode_estimate;
@@ -1397,7 +1400,7 @@ insert_mov_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_esti
         *first = mov1;
     if (last != NULL)
         *last = mov2;
-#    endif
+#endif
 }
 
 void
@@ -1407,6 +1410,8 @@ insert_push_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_est
 {
     ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1551, i#1569 */
 }
+
+#ifndef STANDALONE_DECODER /* back for rest of file */
 
 /* Used for fault translation */
 bool

--- a/core/arch/decodelib.c
+++ b/core/arch/decodelib.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -135,15 +135,6 @@ priv_mcontext_t *
 dr_mcontext_as_priv_mcontext(dr_mcontext_t *mc)
 {
     return (priv_mcontext_t *)(&mc->IF_X86_ELSE(xdi, r0));
-}
-
-/* XXX: duplicated from instrument.c, for convert_to_near_rel_common() */
-/* Inserts inst as a non-application instruction into ilist after "where" */
-void
-instrlist_meta_postinsert(instrlist_t *ilist, instr_t *where, instr_t *inst)
-{
-    instr_set_meta(inst);
-    instrlist_postinsert(ilist, where, inst);
 }
 
 /* XXX: the code below is duplicated w/ only minor changes from utils.c.

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -533,39 +533,6 @@ insert_meta_call_vargs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
  *   M A N G L I N G   R O U T I N E S
  */
 
-void
-insert_mov_immed_ptrsz(dcontext_t *dcontext, ptr_int_t val, opnd_t dst,
-                       instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
-                       OUT instr_t **last)
-{
-    insert_mov_immed_arch(dcontext, NULL, NULL, val, dst, ilist, instr, first, last);
-}
-
-void
-insert_mov_instr_addr(dcontext_t *dcontext, instr_t *src, byte *encode_estimate,
-                      opnd_t dst, instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
-                      OUT instr_t **last)
-{
-    insert_mov_immed_arch(dcontext, src, encode_estimate, 0, dst, ilist, instr, first,
-                          last);
-}
-
-void
-insert_push_immed_ptrsz(dcontext_t *dcontext, ptr_int_t val, instrlist_t *ilist,
-                        instr_t *instr, OUT instr_t **first, OUT instr_t **last)
-{
-    insert_push_immed_arch(dcontext, NULL, NULL, val, ilist, instr, first, last);
-}
-
-void
-insert_push_instr_addr(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
-                       instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
-                       OUT instr_t **last)
-{
-    insert_push_immed_arch(dcontext, src_inst, encode_estimate, 0, ilist, instr, first,
-                           last);
-}
-
 app_pc
 get_app_instr_xl8(instr_t *instr)
 {

--- a/core/arch/mangle_utils.c
+++ b/core/arch/mangle_utils.c
@@ -1,0 +1,77 @@
+/* ******************************************************************************
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
+ * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
+ * ******************************************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Copyright (c) 2003-2007 Determina Corp. */
+/* Copyright (c) 2001-2003 Massachusetts Institute of Technology */
+/* Copyright (c) 2000-2001 Hewlett-Packard Company */
+
+/* file "mangle_utils.c": multi-instruction manipulation shared between the core
+ * and drdecode.
+ */
+
+#include "../globals.h"
+#include "arch.h"
+
+void
+insert_mov_immed_ptrsz(dcontext_t *dcontext, ptr_int_t val, opnd_t dst,
+                       instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
+                       OUT instr_t **last)
+{
+    insert_mov_immed_arch(dcontext, NULL, NULL, val, dst, ilist, instr, first, last);
+}
+
+void
+insert_mov_instr_addr(dcontext_t *dcontext, instr_t *src, byte *encode_estimate,
+                      opnd_t dst, instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
+                      OUT instr_t **last)
+{
+    insert_mov_immed_arch(dcontext, src, encode_estimate, 0, dst, ilist, instr, first,
+                          last);
+}
+
+void
+insert_push_immed_ptrsz(dcontext_t *dcontext, ptr_int_t val, instrlist_t *ilist,
+                        instr_t *instr, OUT instr_t **first, OUT instr_t **last)
+{
+    insert_push_immed_arch(dcontext, NULL, NULL, val, ilist, instr, first, last);
+}
+
+void
+insert_push_instr_addr(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
+                       instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
+                       OUT instr_t **last)
+{
+    insert_push_immed_arch(dcontext, src_inst, encode_estimate, 0, ilist, instr, first,
+                           last);
+}

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -5095,33 +5095,6 @@ dr_where_am_i(void *drcontext, app_pc pc, OUT void **tag_out)
 #endif /* CLIENT_INTERFACE */
 
 DR_API
-/* Inserts inst as a non-application instruction into ilist prior to "where" */
-void
-instrlist_meta_preinsert(instrlist_t *ilist, instr_t *where, instr_t *inst)
-{
-    instr_set_meta(inst);
-    instrlist_preinsert(ilist, where, inst);
-}
-
-DR_API
-/* Inserts inst as a non-application instruction into ilist after "where" */
-void
-instrlist_meta_postinsert(instrlist_t *ilist, instr_t *where, instr_t *inst)
-{
-    instr_set_meta(inst);
-    instrlist_postinsert(ilist, where, inst);
-}
-
-DR_API
-/* Inserts inst as a non-application instruction onto the end of ilist */
-void
-instrlist_meta_append(instrlist_t *ilist, instr_t *inst)
-{
-    instr_set_meta(inst);
-    instrlist_append(ilist, inst);
-}
-
-DR_API
 void
 instrlist_meta_fault_preinsert(instrlist_t *ilist, instr_t *where, instr_t *inst)
 {
@@ -7998,67 +7971,6 @@ dr_unregister_persist_patch(bool (*func_patch)(void *drcontext, void *perscxt,
                                                void *user_data))
 {
     return remove_callback(&persist_patch_callbacks, (void (*)(void))func_patch, true);
-}
-
-DR_API
-/* Create instructions for storing pointer-size integer val to dst,
- * and then insert them into ilist prior to where.
- * The "first" and "last" created instructions are returned.
- */
-void
-instrlist_insert_mov_immed_ptrsz(void *drcontext, ptr_int_t val, opnd_t dst,
-                                 instrlist_t *ilist, instr_t *where, OUT instr_t **first,
-                                 OUT instr_t **last)
-{
-    CLIENT_ASSERT(opnd_get_size(dst) == OPSZ_PTR, "wrong dst size");
-    insert_mov_immed_ptrsz((dcontext_t *)drcontext, val, dst, ilist, where, first, last);
-}
-
-DR_API
-/* Create instructions for pushing pointer-size integer val on the stack,
- * and then insert them into ilist prior to where.
- * The "first" and "last" created instructions are returned.
- */
-void
-instrlist_insert_push_immed_ptrsz(void *drcontext, ptr_int_t val, instrlist_t *ilist,
-                                  instr_t *where, OUT instr_t **first, OUT instr_t **last)
-{
-    insert_push_immed_ptrsz((dcontext_t *)drcontext, val, ilist, where, first, last);
-}
-
-DR_API
-void
-instrlist_insert_mov_instr_addr(void *drcontext, instr_t *src_inst, byte *encode_pc,
-                                opnd_t dst, instrlist_t *ilist, instr_t *where,
-                                OUT instr_t **first, OUT instr_t **last)
-{
-    CLIENT_ASSERT(opnd_get_size(dst) == OPSZ_PTR, "wrong dst size");
-    if (encode_pc == NULL) {
-        /* Pass highest code cache address.
-         * XXX: unless we're beyond the reservation!  Would still be reachable
-         * from rest of vmcode, but might be higher than vmcode_get_end()!
-         */
-        encode_pc = vmcode_get_end();
-    }
-    insert_mov_instr_addr((dcontext_t *)drcontext, src_inst, encode_pc, dst, ilist, where,
-                          first, last);
-}
-
-DR_API
-void
-instrlist_insert_push_instr_addr(void *drcontext, instr_t *src_inst, byte *encode_pc,
-                                 instrlist_t *ilist, instr_t *where, OUT instr_t **first,
-                                 OUT instr_t **last)
-{
-    if (encode_pc == NULL) {
-        /* Pass highest code cache address.
-         * XXX: unless we're beyond the reservation!  Would still be reachable
-         * from rest of vmcode, but might be higher than vmcode_get_end()!
-         */
-        encode_pc = vmcode_get_end();
-    }
-    insert_push_instr_addr((dcontext_t *)drcontext, src_inst, encode_pc, ilist, where,
-                           first, last);
 }
 
 #endif /* CLIENT_INTERFACE */

--- a/suite/tests/api/drdecode_x86.c
+++ b/suite/tests/api/drdecode_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -105,12 +105,33 @@ test_vendor(void)
 #endif
 }
 
+static void
+test_ptrsz_imm(void)
+{
+    /* We just ensure that these interfaces are available: we don't stress their
+     * corner cases here.
+     */
+    instrlist_t *ilist = instrlist_create(GD);
+    instr_t *callee = INSTR_CREATE_label(GD);
+    instrlist_insert_mov_instr_addr(GD, callee, (byte *)ilist,
+                                    opnd_create_reg(DR_REG_RAX), ilist, NULL, NULL, NULL);
+    instrlist_append(ilist, INSTR_CREATE_call_ind(GD, opnd_create_reg(DR_REG_RAX)));
+    instrlist_insert_push_instr_addr(GD, callee, (byte *)ilist, ilist, NULL, NULL, NULL);
+    instrlist_append(ilist, callee);
+    instrlist_insert_mov_immed_ptrsz(GD, (ptr_uint_t)ilist, opnd_create_reg(DR_REG_RAX),
+                                     ilist, NULL, NULL, NULL);
+    instrlist_insert_push_immed_ptrsz(GD, (ptr_uint_t)ilist, ilist, NULL, NULL, NULL);
+    instrlist_clear_and_destroy(GD, ilist);
+}
+
 int
 main()
 {
     test_disasm_style();
 
     test_vendor();
+
+    test_ptrsz_imm();
 
     printf("done\n");
 

--- a/suite/tests/api/drdecode_x86.c
+++ b/suite/tests/api/drdecode_x86.c
@@ -114,11 +114,11 @@ test_ptrsz_imm(void)
     instrlist_t *ilist = instrlist_create(GD);
     instr_t *callee = INSTR_CREATE_label(GD);
     instrlist_insert_mov_instr_addr(GD, callee, (byte *)ilist,
-                                    opnd_create_reg(DR_REG_RAX), ilist, NULL, NULL, NULL);
-    instrlist_append(ilist, INSTR_CREATE_call_ind(GD, opnd_create_reg(DR_REG_RAX)));
+                                    opnd_create_reg(DR_REG_XAX), ilist, NULL, NULL, NULL);
+    instrlist_append(ilist, INSTR_CREATE_call_ind(GD, opnd_create_reg(DR_REG_XAX)));
     instrlist_insert_push_instr_addr(GD, callee, (byte *)ilist, ilist, NULL, NULL, NULL);
     instrlist_append(ilist, callee);
-    instrlist_insert_mov_immed_ptrsz(GD, (ptr_uint_t)ilist, opnd_create_reg(DR_REG_RAX),
+    instrlist_insert_mov_immed_ptrsz(GD, (ptr_uint_t)ilist, opnd_create_reg(DR_REG_XAX),
                                      ilist, NULL, NULL, NULL);
     instrlist_insert_push_immed_ptrsz(GD, (ptr_uint_t)ilist, ilist, NULL, NULL, NULL);
     instrlist_clear_and_destroy(GD, ilist);


### PR DESCRIPTION
Moves the instrlist_insert_{mov,push}_{immed_ptrsz,instr_addr}() utility
routines from instrument.c to instrlist.c for inclusion in drdecode.
Moves their first-level helpers from mangle_shared.c to a new file
mangle_utils.c.  Makes their second-level helpers inside
arch/<arch>/mangle.c exposed to drdecode.

Adds minimal tests to api.drdecode.

Fixes #3100