### PR TITLE
i#3048 func-trace: Use dr_get_proc_address to find dynsym first

### DIFF
--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -126,9 +126,9 @@ func_post_hook(void *wrapcxt, void *user_data)
 }
 
 static app_pc
-get_pc_by_symbol(const module_data_t *mod, const char* symbol) {
-    app_pc pc = (app_pc)dr_get_proc_address(mod->handle, symbol);
+get_pc_by_symbol(const module_data_t *mod, const char *symbol) {
     // Try to find the symbol in the dynamic symbol table.
+    app_pc pc = (app_pc)dr_get_proc_address(mod->handle, symbol);
     if (pc != NULL) {
         dr_fprintf(STDERR, "dr_get_proc_address found symbol %s at pc=%p\n", symbol, pc);
         return pc;
@@ -144,12 +144,12 @@ get_pc_by_symbol(const module_data_t *mod, const char* symbol) {
             drsym_lookup_symbol(mod->full_path, symbol, &offset, DRSYM_DEMANGLE);
         if (err == DRSYM_SUCCESS) {
             pc = mod->start + offset;
-            dr_fprintf(STDERR, "drsym_lookup_symbol found symbol %s at pc=%p\n",
-                       symbol, pc);
+            dr_fprintf(STDERR, "drsym_lookup_symbol found symbol %s at pc=%p\n", symbol,
+                       pc);
             return pc;
         } else {
-            dr_fprintf(STDERR, "Failed to find symbol %s, drsym_error_t=%d\n",
-                       symbol, err);
+            dr_fprintf(STDERR, "Failed to find symbol %s, drsym_error_t=%d\n", symbol,
+                       err);
             return NULL;
         }
     }

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -49,6 +49,8 @@
 // where function_name can contain spaces (for instance, C++ namespace prefix)
 #define PATTERN_SEPARATOR "|"
 
+#define EMPTY_IF_NULL(str) ((str) == NULL ? "" : (str))
+
 #define NOTIFY(level, ...)                     \
     do {                                       \
         if (op_verbose.get_value() >= (level)) \
@@ -131,7 +133,8 @@ get_pc_by_symbol(const module_data_t *mod, const char *symbol)
     // Try to find the symbol in the dynamic symbol table.
     app_pc pc = (app_pc)dr_get_proc_address(mod->handle, symbol);
     if (pc != NULL) {
-        dr_fprintf(STDERR, "dr_get_proc_address found symbol %s at pc=%p\n", symbol, pc);
+        NOTIFY(1, "dr_get_proc_address found symbol %s at pc=%p\n", EMPTY_IF_NULL(symbol),
+               pc);
         return pc;
     } else {
         // If failed to find the symbol in the dynamic symbol table, then we try to find
@@ -145,12 +148,12 @@ get_pc_by_symbol(const module_data_t *mod, const char *symbol)
             drsym_lookup_symbol(mod->full_path, symbol, &offset, DRSYM_DEMANGLE);
         if (err == DRSYM_SUCCESS) {
             pc = mod->start + offset;
-            dr_fprintf(STDERR, "drsym_lookup_symbol found symbol %s at pc=%p\n", symbol,
-                       pc);
+            NOTIFY(1, "drsym_lookup_symbol found symbol %s at pc=%p\n",
+                   EMPTY_IF_NULL(symbol), pc);
             return pc;
         } else {
-            dr_fprintf(STDERR, "Failed to find symbol %s, drsym_error_t=%d\n", symbol,
-                       err);
+            NOTIFY(1, "Failed to find symbol %s, drsym_error_t=%d\n",
+                   EMPTY_IF_NULL(symbol), err);
             return NULL;
         }
     }
@@ -162,15 +165,17 @@ instru_funcs_module_load(void *drcontext, const module_data_t *mod, bool loaded)
     if (drcontext == NULL || mod == NULL)
         return;
 
-    dr_fprintf(STDERR, "instru_funcs_module_load, mod->full_path=%s\n", mod->full_path);
+    NOTIFY(1, "instru_funcs_module_load, mod->full_path=%s\n",
+           EMPTY_IF_NULL(mod->full_path));
     for (size_t i = 0; i < funcs.entries; i++) {
         func_metadata_t *f = (func_metadata_t *)drvector_get_entry(&funcs, (uint)i);
         app_pc f_pc = get_pc_by_symbol(mod, f->name);
         if (f_pc != NULL) {
             if (drwrap_wrap_ex(f_pc, func_pre_hook, func_post_hook, (void *)i, 0)) {
-                dr_fprintf(STDERR, "Inserted hooks for function %s\n", f->name);
+                NOTIFY(1, "Inserted hooks for function %s\n", EMPTY_IF_NULL(f->name));
             } else {
-                dr_fprintf(STDERR, "Failed to insert hooks for function %s\n", f->name);
+                NOTIFY(1, "Failed to insert hooks for function %s\n",
+                       EMPTY_IF_NULL(f->name));
             }
         }
     }

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -134,7 +134,7 @@ get_pc_by_symbol(const module_data_t *mod, const char *symbol)
     // Try to find the symbol in the dynamic symbol table.
     app_pc pc = (app_pc)dr_get_proc_address(mod->handle, symbol);
     if (pc != NULL) {
-        NOTIFY(1, "dr_get_proc_address found symbol %s at pc=%p\n", symbol, pc);
+        NOTIFY(1, "dr_get_proc_address found symbol %s at pc=" PFX "\n", symbol, pc);
         return pc;
     } else {
         // If failed to find the symbol in the dynamic symbol table, then we try to find
@@ -148,7 +148,7 @@ get_pc_by_symbol(const module_data_t *mod, const char *symbol)
             drsym_lookup_symbol(mod->full_path, symbol, &offset, DRSYM_DEMANGLE);
         if (err == DRSYM_SUCCESS) {
             pc = mod->start + offset;
-            NOTIFY(1, "drsym_lookup_symbol found symbol %s at pc=%p\n", symbol, pc);
+            NOTIFY(1, "drsym_lookup_symbol found symbol %s at pc=" PFX "\n", symbol, pc);
             return pc;
         } else {
             NOTIFY(1, "Failed to find symbol %s, drsym_error_t=%d\n", symbol, err);

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -125,24 +125,52 @@ func_post_hook(void *wrapcxt, void *user_data)
     append_entry(drcontext, TRACE_MARKER_TYPE_FUNC_RETVAL, retval);
 }
 
+static app_pc
+get_pc_by_symbol(const module_data_t *mod, const char* symbol) {
+    app_pc pc = (app_pc)dr_get_proc_address(mod->handle, symbol);
+    // Try to find the symbol in the dynamic symbol table.
+    if (pc != NULL) {
+        dr_fprintf(STDERR, "dr_get_proc_address found symbol %s at pc=%p\n", symbol, pc);
+        return pc;
+    } else {
+        // If failed to find the symbol in the dynamic symbol table, then we try to find
+        // it in the module loaded by reading the module file in mod->full_path.
+        // NOTE: mod->full_path could be invalid in the case where the original
+        // module file is remapped and deleted (e.g. hugepage_text).
+        // FIXME: find a way to find the PC of the symbol even if the original module file
+        // is deleted.
+        size_t offset;
+        drsym_error_t err =
+            drsym_lookup_symbol(mod->full_path, symbol, &offset, DRSYM_DEMANGLE);
+        if (err == DRSYM_SUCCESS) {
+            pc = mod->start + offset;
+            dr_fprintf(STDERR, "drsym_lookup_symbol found symbol %s at pc=%p\n",
+                       symbol, pc);
+            return pc;
+        } else {
+            dr_fprintf(STDERR, "Failed to find symbol %s, drsym_error_t=%d\n",
+                       symbol, err);
+            return NULL;
+        }
+    }
+}
+
 static void
 instru_funcs_module_load(void *drcontext, const module_data_t *mod, bool loaded)
 {
     if (drcontext == NULL || mod == NULL)
         return;
-    dr_log(NULL, DR_LOG_ALL, 1, "instru_funcs_module_load start=%p, mod->full_path=%s\n",
-           mod->start, mod->full_path);
 
+    dr_fprintf(STDERR, "instru_funcs_module_load, mod->full_path=%s\n", mod->full_path);
     for (size_t i = 0; i < funcs.entries; i++) {
         func_metadata_t *f = (func_metadata_t *)drvector_get_entry(&funcs, (uint)i);
-        size_t offset;
-        if (drsym_lookup_symbol(mod->full_path, f->name, &offset, DRSYM_DEMANGLE) ==
-            DRSYM_SUCCESS) {
-            dr_log(NULL, DR_LOG_ALL, 1,
-                   "Found and trace func name=%s, id=%d, arg_num=%d\n", f->name, f->id,
-                   f->arg_num);
-            app_pc f_pc = mod->start + offset;
-            drwrap_wrap_ex(f_pc, func_pre_hook, func_post_hook, (void *)i, 0);
+        app_pc f_pc = get_pc_by_symbol(mod, f->name);
+        if (f_pc != NULL) {
+            if (drwrap_wrap_ex(f_pc, func_pre_hook, func_post_hook, (void *)i, 0)) {
+                dr_fprintf(STDERR, "Inserted hooks for function %s\n", f->name);
+            } else {
+                dr_fprintf(STDERR, "Failed to insert hooks for function %s\n", f->name);
+            }
         }
     }
 }

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -126,7 +126,8 @@ func_post_hook(void *wrapcxt, void *user_data)
 }
 
 static app_pc
-get_pc_by_symbol(const module_data_t *mod, const char *symbol) {
+get_pc_by_symbol(const module_data_t *mod, const char *symbol)
+{
     // Try to find the symbol in the dynamic symbol table.
     app_pc pc = (app_pc)dr_get_proc_address(mod->handle, symbol);
     if (pc != NULL) {


### PR DESCRIPTION
If the kernel enables mechanisms like remapping sections in the module at runtime (i.e., hugepage_text, related issue #2566), the full_path of the module_data_t provided in drmgr_register_module_load_event callback could be invalid, since the original module file could already be deleted. This leads to the failure of finding PC for a particular function in memtrace func-tracing feature, given drsym_lookup_symbol depends on loading the original module file by path.
This PR is a partial fix to make function tracing feature works under scenarios like hugepage_text by using dr_get_proc_address before calling drsym_lookup_symbol. This way, we can still catch the target function if its name is in the dynamic symbol table. However, if a target function is not in the dynamic symbol table and the kernel is running with features like hugepage_text, then the function tracing feature would still fail to trace this target function.

Fixes #3048