### PR TITLE
i#3048 func-trace: update default -record_heap_value

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -396,8 +396,8 @@ droption_t<std::string> op_record_heap_value(
     "malloc|0|1" OP_RECORD_FUNC_ITEM_SEP "free|1|1" OP_RECORD_FUNC_ITEM_SEP
     "tc_malloc|2|1" OP_RECORD_FUNC_ITEM_SEP "tc_free|3|1" OP_RECORD_FUNC_ITEM_SEP
     "__libc_malloc|4|1" OP_RECORD_FUNC_ITEM_SEP "__libc_free|5|1" OP_RECORD_FUNC_ITEM_SEP
-    "operator new|10|1" OP_RECORD_FUNC_ITEM_SEP "operator delete|11|1"
-    OP_RECORD_FUNC_ITEM_SEP "calloc|6|2",
+    "operator new|10|1" OP_RECORD_FUNC_ITEM_SEP
+    "operator delete|11|1" OP_RECORD_FUNC_ITEM_SEP "calloc|6|2",
     "Functions recorded by -record_heap",
     "Functions recorded by -record_heap. The option value should fit the same"
     " format required by -record_function. These functions will not"

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -395,7 +395,9 @@ droption_t<std::string> op_record_heap_value(
     OP_RECORD_FUNC_ITEM_SEP,
     "malloc|0|1" OP_RECORD_FUNC_ITEM_SEP "free|1|1" OP_RECORD_FUNC_ITEM_SEP
     "tc_malloc|2|1" OP_RECORD_FUNC_ITEM_SEP "tc_free|3|1" OP_RECORD_FUNC_ITEM_SEP
-    "__libc_malloc|4|1" OP_RECORD_FUNC_ITEM_SEP "__libc_free|5|1",
+    "__libc_malloc|4|1" OP_RECORD_FUNC_ITEM_SEP "__libc_free|5|1" OP_RECORD_FUNC_ITEM_SEP
+    "operator new|10|1" OP_RECORD_FUNC_ITEM_SEP "operator delete|11|1"
+    OP_RECORD_FUNC_ITEM_SEP "calloc|6|2",
     "Functions recorded by -record_heap",
     "Functions recorded by -record_heap. The option value should fit the same"
     " format required by -record_function. These functions will not"

--- a/clients/drcachesim/tests/burst_malloc.cpp
+++ b/clients/drcachesim/tests/burst_malloc.cpp
@@ -58,21 +58,25 @@ static int
 do_some_work(int arg)
 {
     static const int iters = 1000;
-    static double *vals[iters];
+    double **vals = (double **)calloc(iters, sizeof(double *));
+    double *val = new double; // "malloc" is called inside "operator new"
+    *val = arg;
 
-    double val = (double)arg;
     for (int i = 0; i < iters; ++i) {
         vals[i] = (double *)malloc(sizeof(double));
-        *vals[i] = sin(val);
-        val += *vals[i];
+        *vals[i] = sin(*val);
+        *val += *vals[i];
     }
     for (int i = 0; i < iters; i++) {
-        val += *vals[i];
+        *val += *vals[i];
     }
     for (int i = 0; i < iters; i++) {
         free(vals[i]);
     }
-    return (val > 0);
+    free(vals);
+    double temp = *val;
+    delete val; // "free" is not called inside "operator delete"
+    return (temp > 0);
 }
 
 int

--- a/clients/drcachesim/tests/offline-burst_malloc.templatex
+++ b/clients/drcachesim/tests/offline-burst_malloc.templatex
@@ -8,7 +8,7 @@ DynamoRIO statistics:
 .*
 all done
 .*
-.* 4000 function id markers.*
-.* 2000 function return address markers.*
-.* 2000 function argument markers.*
-.* 2000 function return value markers.*
+.* 4010 function id markers.*
+.* 2005 function return address markers.*
+.* 2006 function argument markers.*
+.* 2005 function return value markers.*


### PR DESCRIPTION
Update the dafault value of -record_heap_value to include "calloc", "operator new", and "operator delete"

Fixes #3048