### PR TITLE
i#3129 raw2trace perf: summarize instr_t during raw2trace conversion

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -70,9 +70,9 @@
         }                                      \
     } while (0)
 
-#define DO_VERBOSE(level, x)              \
+#define DO_VERBOSE(level, x, verbosity)   \
     do {                                  \
-        if (verbosity >= (level)) {       \
+        if ((verbosity) >= (level)) {     \
             x; /* ; makes vera++ happy */ \
         }                                 \
     } while (0)
@@ -878,7 +878,8 @@ raw2trace_t::get_instr_summary(uint64 modidx, uint64 modoffs, INOUT app_pc *pc,
         hashtable_add(&decode_cache, decode_pc, desc);
         ret = desc;
     } else {
-        // Log some rendering of the instruction summary that will be returned. i#3129
+        /* XXX i#3129 Log some rendering of the instruction summary that will be returned.
+         */
         *pc = ret->next_pc();
     }
     return ret;
@@ -909,10 +910,12 @@ instr_summary_t::construct(void *dcontext, INOUT app_pc *pc, app_pc orig_pc,
     if (*pc == nullptr || !instr_valid(instr)) {
         return false;
     }
-    DO_VERBOSE(3, {
-        instr_set_translation(instr, orig_pc);
-        dr_print_instr(dcontext, STDOUT, instr, "");
-    });
+    DO_VERBOSE(3,
+               {
+                   instr_set_translation(instr, orig_pc);
+                   dr_print_instr(dcontext, STDOUT, instr, "");
+               },
+               verbosity);
     desc->next_pc_ = *pc;
     desc->packed_ = 0;
 

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -878,7 +878,8 @@ raw2trace_t::get_instr_summary(uint64 modidx, uint64 modoffs, INOUT app_pc *pc,
         hashtable_add(&decode_cache, decode_pc, desc);
         ret = desc;
     } else {
-        // TODO(mtrofin): log some rendering of the instruction summary that will be returned
+        // TODO(mtrofin): log some rendering of the instruction summary that will be
+        // returned
         *pc = ret->next_pc();
     }
     return ret;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -70,13 +70,6 @@
         }                                      \
     } while (0)
 
-#define DO_VERBOSE(level, x, verbosity)   \
-    do {                                  \
-        if ((verbosity) >= (level)) {     \
-            x; /* ; makes vera++ happy */ \
-        }                                 \
-    } while (0)
-
 /***************************************************************************
  * Module list
  */
@@ -878,7 +871,8 @@ raw2trace_t::get_instr_summary(uint64 modidx, uint64 modoffs, INOUT app_pc *pc,
         hashtable_add(&decode_cache, decode_pc, desc);
         ret = desc;
     } else {
-        /* XXX i#3129 Log some rendering of the instruction summary that will be returned.
+        /* XXX i#3129: Log some rendering of the instruction summary that will be
+         * returned.
          */
         *pc = ret->next_pc();
     }
@@ -910,12 +904,10 @@ instr_summary_t::construct(void *dcontext, INOUT app_pc *pc, app_pc orig_pc,
     if (*pc == nullptr || !instr_valid(instr)) {
         return false;
     }
-    DO_VERBOSE(3,
-               {
-                   instr_set_translation(instr, orig_pc);
-                   dr_print_instr(dcontext, STDOUT, instr, "");
-               },
-               verbosity);
+    if (verbosity > 3) {
+        instr_set_translation(instr, orig_pc);
+        dr_print_instr(dcontext, STDOUT, instr, "");
+    }
     desc->next_pc_ = *pc;
     desc->packed_ = 0;
 

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -72,8 +72,8 @@ struct module_t {
 };
 
 /**
- * instr_summary is a compact encapsulation of the information needed by trace conversion
- * from decoded instructions.
+ * instr_summary_t is a compact encapsulation of the information needed by trace
+ * conversion from decoded instructions.
  */
 struct instr_summary_t final {
     instr_summary_t()
@@ -81,9 +81,9 @@ struct instr_summary_t final {
     }
 
     /**
-     * Populates a pre-allocated instr_summary_t desc, from the instruction found at pc.
-     * Updates pc to the next instruction. Optionally logs translation details (using
-     * orig_pc and verbosity)
+     * Populates a pre-allocated instr_summary_t description, from the instruction found
+     * at pc. Updates pc to the next instruction. Optionally logs translation details
+     * (using orig_pc and verbosity)
      */
     static bool
     construct(void *dcontext, INOUT app_pc *pc, app_pc orig_pc, OUT instr_summary_t *desc,
@@ -144,36 +144,31 @@ private:
     }
 
     const opnd_t &
-    src_at(size_t pos) const
+    mem_src_at(size_t pos) const
     {
-        return srcs_and_dests_[pos];
+        return mem_srcs_and_dests_[pos];
     }
     const opnd_t &
-    dest_at(size_t pos) const
+    mem_dest_at(size_t pos) const
     {
-        return srcs_and_dests_[srcs_ + pos];
+        return mem_srcs_and_dests_[num_mem_srcs_ + pos];
     }
     size_t
-    srcs() const
+    num_mem_srcs() const
     {
-        return srcs_;
+        return num_mem_srcs_;
     }
     size_t
-    dests() const
+    num_mem_dests() const
     {
-        return dests_;
+        return mem_srcs_and_dests_.size() - num_mem_srcs_;
     }
 
-#define FIELD(NAME, POS)                 \
-    static const int k##NAME##Pos = POS; \
-    static const int k##NAME##Mask = 1 << POS;
-
-    FIELD(ReadsMem, 0)
-    FIELD(WritesMem, 1)
-    FIELD(IsPrefetch, 2)
-    FIELD(IsFlush, 3)
-    FIELD(IsCti, 4)
-#undef FIELD
+    static const int kReadsMemMask = 0x0001;
+    static const int kWritesMemMask = 0x0002;
+    static const int kIsPrefetchMask = 0x0004;
+    static const int kIsFlushMask = 0x0008;
+    static const int kIsCtiMask = 0x0010;
 
     instr_summary_t(const instr_summary_t &other) = delete;
     instr_summary_t &
@@ -187,9 +182,8 @@ private:
     byte length_ = 0;
     app_pc next_pc_ = 0;
 
-    std::vector<opnd_t> srcs_and_dests_;
-    uint8_t srcs_ = 0;
-    uint8_t dests_ = 0;
+    std::vector<opnd_t> mem_srcs_and_dests_;
+    uint8_t num_mem_srcs_ = 0;
     byte packed_ = 0;
 };
 

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -83,7 +83,7 @@ struct instr_summary_t final {
     /**
      * Populates a pre-allocated instr_summary_t description, from the instruction found
      * at pc. Updates pc to the next instruction. Optionally logs translation details
-     * (using orig_pc and verbosity)
+     * (using orig_pc and verbosity).
      */
     static bool
     construct(void *dcontext, INOUT app_pc *pc, app_pc orig_pc, OUT instr_summary_t *desc,
@@ -182,6 +182,10 @@ private:
     byte length_ = 0;
     app_pc next_pc_ = 0;
 
+    // Squash srcs and dests to save memory usage. We may want to
+    // bulk-allocate pages of instr_summary_t objects, instead
+    // of piece-meal allocating them on the heap one at a time.
+    // One vector and a byte is smaller than 2 vectors.
     std::vector<opnd_t> mem_srcs_and_dests_;
     uint8_t num_mem_srcs_ = 0;
     byte packed_ = 0;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -120,27 +120,27 @@ private:
     bool
     reads_memory() const
     {
-        return (1 << kReadsMemPos) & packed_;
+        return TESTANY(kReadsMemMask, packed_);
     }
     bool
     writes_memory() const
     {
-        return (1 << kWritesMemPos) & packed_;
+        return TESTANY(kWritesMemMask, packed_);
     }
     bool
     is_prefetch() const
     {
-        return (1 << kIsPrefetchPos) & packed_;
+        return TESTANY(kIsPrefetchMask, packed_);
     }
     bool
     is_flush() const
     {
-        return (1 << kIsFlushPos) & packed_;
+        return TESTANY(kIsFlushMask, packed_);
     }
     bool
     is_cti() const
     {
-        return (1 << kIsCtiPos) & packed_;
+        return TESTANY(kIsCtiMask, packed_);
     }
 
     const opnd_t &
@@ -164,11 +164,16 @@ private:
         return dests_;
     }
 
-    static const int kReadsMemPos = 0;
-    static const int kWritesMemPos = 1;
-    static const int kIsPrefetchPos = 2;
-    static const int kIsFlushPos = 3;
-    static const int kIsCtiPos = 4;
+#define FIELD(NAME, POS)                 \
+    static const int k##NAME##Pos = POS; \
+    static const int k##NAME##Mask = 1 << POS;
+
+    FIELD(ReadsMem, 0)
+    FIELD(WritesMem, 1)
+    FIELD(IsPrefetch, 2)
+    FIELD(IsFlush, 3)
+    FIELD(IsCti, 4)
+#undef FIELD
 
     instr_summary_t(const instr_summary_t &other) = delete;
     instr_summary_t &

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -82,7 +82,7 @@ if ($child) {
         $mydir = `/usr/bin/cygpath -wi \"$mydir\"`;
         chomp $mydir;
     }
-    system("ctest --output-on-failure -V -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
+    system("ctest --output-on-failure -VV -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
     exit 0;
 }
 

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -82,7 +82,7 @@ if ($child) {
         $mydir = `/usr/bin/cygpath -wi \"$mydir\"`;
         chomp $mydir;
     }
-    system("ctest --output-on-failure -VV -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
+    system("ctest --output-on-failure -V -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
     exit 0;
 }
 


### PR DESCRIPTION
Summarize instr_t to decouple trace conversion from DR internals (e.g. instru_t APIs)

As added benefit, the previous APIs were not inlined (at least by clang), being in a different module. That was resulting in noticeable (under perf profiling) function call overhead. This change alleviates that.

Issue: #3129