### PR TITLE
Disable writing misses triggered by HW prefetches

### DIFF
--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -718,7 +718,7 @@ Software and hardware prefetches are combined in the prefetch hit and miss
 statistics, which are reported separately from regular loads and stores.
 To isolate software prefetch statistics, disable the hardware prefetcher by
 running with "-data_prefetcher none" (see \ref sec_drcachesim_ops).
-While misses from software prefetches are included in miss files,
+While misses from software prefetches are included in cache miss files,
 misses from hardware prefetches are not.
 
 ****************************************************************************

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -718,6 +718,8 @@ Software and hardware prefetches are combined in the prefetch hit and miss
 statistics, which are reported separately from regular loads and stores.
 To isolate software prefetch statistics, disable the hardware prefetcher by
 running with "-data_prefetcher none" (see \ref sec_drcachesim_ops).
+While misses from software prefetches are included in miss files,
+misses from hardware prefetches are not.
 
 ****************************************************************************
 \section sec_drcachesim_phys Physical Addresses

--- a/clients/drcachesim/simulator/cache_stats.cpp
+++ b/clients/drcachesim/simulator/cache_stats.cpp
@@ -51,7 +51,7 @@ cache_stats_t::access(const memref_t &memref, bool hit)
             num_prefetch_hits++;
         else {
             num_prefetch_misses++;
-            if (dump_misses)
+            if (dump_misses && memref.data.type != TRACE_TYPE_HARDWARE_PREFETCH)
                 dump_miss(memref);
         }
     } else { // handle regular memory accesses


### PR DESCRIPTION
Do not write misses triggered by HW prefetchers into miss files.