### PR TITLE
i#1409 core libs: eliminate drdecode dependence from drfrontendlib

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -134,8 +134,8 @@ configure_DynamoRIO_standalone(drcachesim)
 target_link_libraries(drcachesim drmemtrace_simulator drmemtrace_reuse_distance
   drmemtrace_histogram drmemtrace_reuse_time drmemtrace_basic_counts
   drmemtrace_opcode_mix drmemtrace_view drmemtrace_raw2trace)
-# To avoid dup symbol errors between drinjectlib and the drdecode brought in
-# by drfrontendlib we have to explicitly list drdecode up front:
+# To avoid dup symbol errors between drinjectlib and drdecode on Windows we have
+# to explicitly list drdecode up front:
 target_link_libraries(drcachesim drdecode drinjectlib drconfiglib drfrontendlib)
 use_DynamoRIO_extension(drcachesim droption)
 # These are also for raw2trace:

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -852,8 +852,10 @@ endif ()
 target_link_libraries(${PRELOAD_NAME} drhelper)
 copy_target_to_device(${PRELOAD_NAME})
 
+# drpreinject.dll doesn't link in instr_shared.c so we can't include our inline
+# functions.
 set_target_properties(${PRELOAD_NAME} PROPERTIES
-  COMPILE_FLAGS "-DNOT_DYNAMORIO_CORE_PROPER -DRC_IS_PRELOAD")
+  COMPILE_FLAGS "-DNOT_DYNAMORIO_CORE_PROPER -DRC_IS_PRELOAD -DDR_NO_FAST_IR")
 
 if (UNIX)
   # FIXME case 69/1891: -z initfirst = initialize first at runtime (before libc)

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -47,15 +47,14 @@
 #include "opcode.h"
 #include "opnd.h"
 
-/* to avoid duplicating code we use our own exported macros */
-#define DR_FAST_IR 1
-
-/* drpreinject.dll doesn't link in instr_shared.c so we can't include our inline
- * functions.  We want to use our inline functions for the standalone decoder
- * and everything else, so we single out drpreinject.
+/* To avoid duplicating code we use our own exported macros, unless an includer
+ * needs to avoid it.
  */
-#ifdef RC_IS_PRELOAD
+#ifdef DR_NO_FAST_IR
 #    undef DR_FAST_IR
+#    undef INSTR_INLINE
+#else
+#    define DR_FAST_IR 1
 #endif
 
 /* can't include decode.h, it includes us, just declare struct */

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -51,8 +51,15 @@
 /* to avoid changing all our internal REG_ constants we define this for DR itself */
 #define DR_REG_ENUM_COMPATIBILITY 1
 
-/* to avoid duplicating code we use our own exported macros */
-#define DR_FAST_IR 1
+/* To avoid duplicating code we use our own exported macros, unless an includer
+ * needs to avoid it.
+ */
+#ifdef DR_NO_FAST_IR
+#    undef DR_FAST_IR
+#    undef INSTR_INLINE
+#else
+#    define DR_FAST_IR 1
+#endif
 
 /* drpreinject.dll doesn't link in instr_shared.c so we can't include our inline
  * functions.  We want to use our inline functions for the standalone decoder

--- a/core/lib/dr_helper.c
+++ b/core/lib/dr_helper.c
@@ -37,6 +37,9 @@
  * rather than putting this into say asm_shared.asm).
  */
 
+/* Avoid pulling in deps from instr_inline.h included from globals.h */
+#define DR_NO_FAST_IR
+
 #include "../globals.h" /* just to disable warning C4206 about an empty file */
 
 WEAK void

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1945,12 +1945,14 @@ elf_loader_map_phdrs(elf_loader_t *elf, bool fixed, map_fn_t map_func,
 
     /* reserve the memory from os for library */
     initial_map_size = elf->image_size;
+#ifndef NOT_DYNAMORIO_CORE_PROPER
     if (INTERNAL_OPTION(separate_private_bss) && !TEST(MODLOAD_NOT_PRIVLIB, flags)) {
         /* place an extra no-access page after .bss */
         /* XXX: update privload_early_inject call to init_emulated_brk if this changes */
         /* XXX: should we avoid this for -early_inject's map of the app and ld.so? */
         initial_map_size += PAGE_SIZE;
     }
+#endif
     lib_base = (*map_func)(-1, &initial_map_size, 0, map_base,
                            MEMPROT_NONE, /* so the separating page is no-access */
                            MAP_FILE_COPY_ON_WRITE | MAP_FILE_IMAGE |
@@ -1960,9 +1962,11 @@ elf_loader_map_phdrs(elf_loader_t *elf, bool fixed, map_fn_t map_func,
                                ((fixed && map_base != NULL) ? MAP_FILE_FIXED : 0) |
                                (TEST(MODLOAD_REACHABLE, flags) ? MAP_FILE_REACHABLE : 0));
     ASSERT(lib_base != NULL);
+#ifndef NOT_DYNAMORIO_CORE_PROPER
     if (INTERNAL_OPTION(separate_private_bss) && initial_map_size > elf->image_size)
         elf->image_size = initial_map_size - PAGE_SIZE;
     else
+#endif
         elf->image_size = initial_map_size;
     lib_end = lib_base + elf->image_size;
     elf->load_base = lib_base;

--- a/libutil/CMakeLists.txt
+++ b/libutil/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2016 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2018 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -204,12 +204,8 @@ add_library(drfrontendlib STATIC ${dr_frontend_srcs})
 if (AARCH64)
   add_dependencies(drfrontendlib gen_aarch64_codec)
 endif()
-# XXX i#1409: we need dynamo_options and dynamorio_syscall for core/unix/*.
-# We'd like a small lib for that, but for now our best option is to use
-# drdecode.  Update: drhelper gives us dynamorio_syscall, so it's just
-# dynamo_options, which probably should be refactored out when we
-# split module_*.c.
-target_link_libraries(drfrontendlib drdecode drhelper)
+# We need drhelper for dynamorio_syscall for core/unix/os.c.
+target_link_libraries(drfrontendlib drhelper)
 add_static_lib_debug_info(drfrontendlib "${INSTALL_BIN}")
 DR_export_target(drfrontendlib)
 install_exported_target(drfrontendlib ${INSTALL_BIN})


### PR DESCRIPTION
Adds "#ifndef NOT_DYNAMORIO_CORE_PROPER" around the two option
references in module_elf.c in order to remove the problematic drdecode
dependence from drfrontendlib.  (The drhelper library added in the
past already removed the dynamorio_syscall dependence for us.)

Adds disabling of inlining from instr.h and opnd.h for drhelper who
just wants to include globals.h, to avoid pulling in extra deps.

Issue: #1409