### PR TITLE
i#2006 drcachesim: fix 32-bit gcc7.3 build

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -784,6 +784,7 @@ if (NOT APPLE)
         --globalize-symbol=__x86.get_pc_thunk.dx
         --globalize-symbol=__x86.get_pc_thunk.di
         --globalize-symbol=__x86.get_pc_thunk.si
+        --globalize-symbol=__x86.get_pc_thunk.bp
         "${dynamorio_dot_o}" &&
         )
     endif ()


### PR DESCRIPTION
Fixes 32-bit gcc7.3 build breakage from 4ac94411 by adding
__x86.get_pc_thunk.bp to the globalize_pc_thunks list.

Issue: #2006