### PR TITLE
i#3129 raw2trace perf: raw trace header inspection APIs

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -245,6 +245,11 @@ Further non-compatibility-affecting changes include:
      and find_mapped_trace_address().
    - Added #trace_metadata_writer_t, a set of utility functions used by drcachesim's
      #raw2trace_t for writing trace metadata: process/thread ids, timestamps, etc.
+   - Added #trace_metadata_reader_t, a set of utilities for checking and validating
+     thread start successions of offline entries in a raw data file.
+ - Added drmemtrace_get_timestamp_from_offline_trace, an API for fetching the timestamp
+   from the beginning of a raw trace bundle (regardless of whether it is a thread start
+   or just a subsequent bundle)
 
 **************************************************
 <hr>

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -240,16 +240,16 @@ Further non-compatibility-affecting changes include:
    identifier #DR_WINDOWS_VERSION_10_1803 to distinguish this major update.
  - Generalization of the drcachesim #raw2trace_t API (Issue #3129):
    - Added #module_mapper_t, which factors out the module mapping functionality
-     out of raw2trace_t, replacing the following #raw2trace_t APIs:
-     handle_custom_data(), do_module_parsing(), do_module_parsing_and_mapping(),
-     and find_mapped_trace_address().
+     out of #raw2trace_t, replacing the following #raw2trace_t APIs:
+     #raw2trace_t::handle_custom_data(), #raw2trace_t::do_module_parsing(),
+     #raw2trace_t::do_module_parsing_and_mapping(), and #raw2trace_t::find_mapped_trace_address().
    - Added #trace_metadata_writer_t, a set of utility functions used by drcachesim's
      #raw2trace_t for writing trace metadata: process/thread ids, timestamps, etc.
    - Added #trace_metadata_reader_t, a set of utilities for checking and validating
      thread start successions of offline entries in a raw data file.
- - Added drmemtrace_get_timestamp_from_offline_trace, an API for fetching the timestamp
+ - Added drmemtrace_get_timestamp_from_offline_trace(), an API for fetching the timestamp
    from the beginning of a raw trace bundle (regardless of whether it is a thread start
-   or just a subsequent bundle)
+   or just a subsequent bundle).
 
 **************************************************
 <hr>

--- a/clients/drcachesim/tests/raw2trace-simple.templatex
+++ b/clients/drcachesim/tests/raw2trace-simple.templatex
@@ -9,3 +9,4 @@ Successfully found app entry
 Read timestamp from thread header
 Read timestamp without thread header
 Verified boundary conditions
+Verfied invalid buffer

--- a/clients/drcachesim/tests/raw2trace-simple.templatex
+++ b/clients/drcachesim/tests/raw2trace-simple.templatex
@@ -6,3 +6,6 @@ Processed
 About to load modules
 Loaded modules successfully
 Successfully found app entry
+Read timestamp from thread header
+Read timestamp without thread header
+Verified boundary conditions

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -194,13 +194,13 @@ test_trace_timestamp_reader(const raw2trace_directory_t *dir)
     // Seek back to the beginning to undo raw2trace_directory_t's validation
     file->seekg(0);
     offline_entry_t buffer[4];
-    file->read((char *)buffer, 4 * sizeof(offline_entry_t));
+    file->read((char *)buffer, BUFFER_SIZE_BYTES(buffer));
 
     std::string error;
     if (!trace_metadata_reader_t::is_thread_start(buffer, &error) && !error.empty())
         return false;
     uint64 timestamp = 0;
-    if (drmemtrace_get_timestamp_from_offline_trace(buffer, 4 * sizeof(offline_entry_t),
+    if (drmemtrace_get_timestamp_from_offline_trace(buffer, BUFFER_SIZE_BYTES(buffer),
                                                     &timestamp) != DRMEMTRACE_SUCCESS)
         return false;
     if (timestamp == 0)
@@ -224,7 +224,7 @@ test_trace_timestamp_reader(const raw2trace_directory_t *dir)
     if (drmemtrace_get_timestamp_from_offline_trace(buffer, sizeof(offline_entry_t),
                                                     &timestamp2) == DRMEMTRACE_SUCCESS)
         return false;
-    if (drmemtrace_get_timestamp_from_offline_trace(buffer, 4 * sizeof(offline_entry_t),
+    if (drmemtrace_get_timestamp_from_offline_trace(buffer, BUFFER_SIZE_BYTES(buffer),
                                                     nullptr) == DRMEMTRACE_SUCCESS)
         return false;
     if (timestamp != timestamp2)
@@ -232,9 +232,9 @@ test_trace_timestamp_reader(const raw2trace_directory_t *dir)
     REPORT("Verified boundary conditions");
 
     offline_entry_t invalid_buffer[4];
-    memset(invalid_buffer, 0, 4 * sizeof(offline_entry_t));
+    memset(invalid_buffer, 0, BUFFER_SIZE_BYTES(invalid_buffer));
     if (drmemtrace_get_timestamp_from_offline_trace(invalid_buffer,
-                                                    4 * sizeof(offline_entry_t),
+                                                    BUFFER_SIZE_BYTES(invalid_buffer),
                                                     &timestamp2) == DRMEMTRACE_SUCCESS)
         return false;
     if (timestamp != timestamp2)

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -230,6 +230,16 @@ test_trace_timestamp_reader(const raw2trace_directory_t *dir)
     if (timestamp != timestamp2)
         return false;
     REPORT("Verified boundary conditions");
+
+    offline_entry_t invalid_buffer[4];
+    memset(invalid_buffer, 0, 4 * sizeof(offline_entry_t));
+    if (drmemtrace_get_timestamp_from_offline_trace(invalid_buffer,
+                                                    4 * sizeof(offline_entry_t),
+                                                    &timestamp2) == DRMEMTRACE_SUCCESS)
+        return false;
+    if (timestamp != timestamp2)
+        return false;
+    REPORT("Verified invalid buffer");
     return true;
 }
 

--- a/clients/drcachesim/tracer/drmemtrace.h
+++ b/clients/drcachesim/tracer/drmemtrace.h
@@ -277,7 +277,7 @@ DR_EXPORT
  * null or if the trace is too short.
  */
 drmemtrace_status_t
-drmemtrace_get_timestamp_from_offline_trace(const void *trace, size_t size,
+drmemtrace_get_timestamp_from_offline_trace(const void *trace, size_t trace_size,
                                             OUT uint64 *timestamp);
 
 #ifdef __cplusplus

--- a/clients/drcachesim/tracer/drmemtrace.h
+++ b/clients/drcachesim/tracer/drmemtrace.h
@@ -268,6 +268,18 @@ drmemtrace_filter_threads(bool (*should_trace_thread_cb)(thread_id_t tid,
                                                          void *user_data),
                           void *user_value);
 
+DR_EXPORT
+/**
+ * Fetch the timestamp from a raw trace bundle. The API checks if the bundle
+ * is a thread start or not, and fetches the timestamp from the appropriate
+ * location.
+ * Returns DRMEMTRACE_ERROR_INVALID_PARAMETER if the pointer parameters are
+ * null or if the trace is too short.
+ */
+drmemtrace_status_t
+drmemtrace_get_timestamp_from_offline_trace(const void *trace, size_t size,
+                                            OUT uint64 *timestamp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -848,17 +848,7 @@ raw2trace_t::check_thread_file(std::istream *f)
     if (!f->read((char *)&ver_entry, sizeof(ver_entry))) {
         return "Unable to read thread log file";
     }
-    if (ver_entry.extended.type != OFFLINE_TYPE_EXTENDED ||
-        ver_entry.extended.ext != OFFLINE_EXT_TYPE_HEADER) {
-        return "Thread log file is corrupted: missing version entry";
-    }
-    if (ver_entry.extended.valueA != OFFLINE_FILE_VERSION) {
-        std::stringstream ss;
-        ss << "Version mismatch: expect " << OFFLINE_FILE_VERSION << " vs "
-           << (int)ver_entry.extended.valueA;
-        return ss.str();
-    }
-    return "";
+    return trace_metadata_reader_t::check_entry_thread_start(&ver_entry);
 }
 
 std::string
@@ -1025,4 +1015,66 @@ raw2trace_t::~raw2trace_t()
         }
     }
     hashtable_delete(&decode_cache);
+}
+
+bool
+trace_metadata_reader_t::is_thread_start(const offline_entry_t *entry, std::string *error)
+{
+    *error = "";
+    if (entry->extended.type != OFFLINE_TYPE_EXTENDED ||
+        entry->extended.ext != OFFLINE_EXT_TYPE_HEADER) {
+        return false;
+    }
+    if (entry->extended.valueA != OFFLINE_FILE_VERSION) {
+        std::stringstream ss;
+        ss << "Version mismatch: expect " << OFFLINE_FILE_VERSION << " vs "
+           << (int)entry->extended.valueA;
+        *error = ss.str();
+        return false;
+    }
+    return true;
+}
+
+std::string
+trace_metadata_reader_t::check_entry_thread_start(const offline_entry_t *entry)
+{
+    std::string error;
+    if (is_thread_start(entry, &error))
+        return "";
+    if (error.empty())
+        return "Thread log file is corrupted: missing version entry";
+    ;
+    return error;
+}
+
+drmemtrace_status_t
+drmemtrace_get_timestamp_from_offline_trace(const void *trace, size_t size,
+                                            OUT uint64 *timestamp)
+{
+    if (trace == nullptr || timestamp == nullptr)
+        return DRMEMTRACE_ERROR_INVALID_PARAMETER;
+
+    const offline_entry_t *offline_entries =
+        reinterpret_cast<const offline_entry_t *>(trace);
+    size = size / sizeof(offline_entry_t);
+    if (size < 1)
+        return DRMEMTRACE_ERROR_INVALID_PARAMETER;
+
+    size_t timestamp_pos = 0;
+    std::string error;
+    if (trace_metadata_reader_t::is_thread_start(offline_entries, &error) &&
+        error.empty()) {
+        if (size < 4)
+            return DRMEMTRACE_ERROR_INVALID_PARAMETER;
+        if (offline_entries[++timestamp_pos].tid.type != OFFLINE_TYPE_THREAD ||
+            offline_entries[++timestamp_pos].pid.type != OFFLINE_TYPE_PID)
+            return DRMEMTRACE_ERROR_INVALID_PARAMETER;
+        ++timestamp_pos;
+    }
+
+    if (offline_entries[timestamp_pos].timestamp.type != OFFLINE_TYPE_TIMESTAMP)
+        return DRMEMTRACE_ERROR_INVALID_PARAMETER;
+
+    *timestamp = offline_entries[timestamp_pos].timestamp.usec;
+    return DRMEMTRACE_SUCCESS;
 }

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1043,12 +1043,11 @@ trace_metadata_reader_t::check_entry_thread_start(const offline_entry_t *entry)
         return "";
     if (error.empty())
         return "Thread log file is corrupted: missing version entry";
-    ;
     return error;
 }
 
 drmemtrace_status_t
-drmemtrace_get_timestamp_from_offline_trace(const void *trace, size_t size,
+drmemtrace_get_timestamp_from_offline_trace(const void *trace, size_t trace_size,
                                             OUT uint64 *timestamp)
 {
     if (trace == nullptr || timestamp == nullptr)
@@ -1056,7 +1055,7 @@ drmemtrace_get_timestamp_from_offline_trace(const void *trace, size_t size,
 
     const offline_entry_t *offline_entries =
         reinterpret_cast<const offline_entry_t *>(trace);
-    size = size / sizeof(offline_entry_t);
+    size_t size = trace_size / sizeof(offline_entry_t);
     if (size < 1)
         return DRMEMTRACE_ERROR_INVALID_PARAMETER;
 

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -212,6 +212,16 @@ struct trace_metadata_writer_t {
 };
 
 /**
+ * Functions for decoding and verifying raw memtrace data headers.
+ */
+struct trace_metadata_reader_t {
+    static bool
+    is_thread_start(const offline_entry_t *entry, OUT std::string *error);
+    static std::string
+    check_entry_thread_start(const offline_entry_t *entry);
+};
+
+/**
  * module_mapper_t maps and unloads application modules.
  * Using it assumes a dr_context has already been setup.
  */


### PR DESCRIPTION
Added thread start checking/validation APIs, and a related, general-purpose API for fetching out the timestamp out of a raw trace.

Issue: #3129