### PR TITLE
Do not fail drfront_sym_init() on second call

### DIFF
--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -4395,20 +4395,21 @@ dr_write_forensics_report(void *dcontext, file_t file,
 DR_API void
 dr_messagebox(const char *fmt, ...)
 {
-    dcontext_t *dcontext = get_thread_private_dcontext();
+    dcontext_t *dcontext = NULL;
+    if (!standalone_library)
+        dcontext = get_thread_private_dcontext();
     char msg[MAX_LOG_LENGTH];
     wchar_t wmsg[MAX_LOG_LENGTH];
     va_list ap;
-    CLIENT_ASSERT(!standalone_library, "API not supported in standalone mode");
     va_start(ap, fmt);
     vsnprintf(msg, BUFFER_SIZE_ELEMENTS(msg), fmt, ap);
     NULL_TERMINATE_BUFFER(msg);
     snwprintf(wmsg, BUFFER_SIZE_ELEMENTS(wmsg), L"%S", msg);
     NULL_TERMINATE_BUFFER(wmsg);
-    if (IS_CLIENT_THREAD(dcontext))
+    if (!standalone_library && IS_CLIENT_THREAD(dcontext))
         dcontext->client_data->client_thread_safe_for_synch = true;
     nt_messagebox(wmsg, debugbox_get_title());
-    if (IS_CLIENT_THREAD(dcontext))
+    if (!standalone_library && IS_CLIENT_THREAD(dcontext))
         dcontext->client_data->client_thread_safe_for_synch = false;
     va_end(ap);
 }

--- a/libutil/dr_frontend_win.c
+++ b/libutil/dr_frontend_win.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -431,9 +431,9 @@ drfront_sym_init(const char *symsrv_path, const char *dbghelp_path)
     HANDLE proc_handle = GetCurrentProcess();
     TCHAR wdbghelp_path[MAX_PATH];
     TCHAR wsymsrv_path[MAX_SYMSRV_PATH];
-    /* check that it's first call */
+    /* Only initialize once. */
     if (hlib != NULL)
-        return DRFRONT_ERROR;
+        return DRFRONT_SUCCESS;
     if (dbghelp_path == NULL)
         return DRFRONT_ERROR_INVALID_PARAMETER;
     drfront_char_to_tchar(dbghelp_path, wdbghelp_path,


### PR DESCRIPTION
Fixes two issues hit when extending the Dr. Memory front-end:

+ Fixes drfront_sym_init() to not fail when called for a 2nd time: it can
  re-use the prior initialization.

+ Enables dr_messagebox() in standalone mode, which is useful for diagnostics
  in front-ends.