### PR TITLE
Add dr_abort_with_code()

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -250,6 +250,7 @@ Further non-compatibility-affecting changes include:
  - Added drmemtrace_get_timestamp_from_offline_trace(), an API for fetching the timestamp
    from the beginning of a raw trace bundle (regardless of whether it is a thread start
    or just a subsequent bundle).
+ - Added dr_abort_with_code().
 
 **************************************************
 <hr>

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -2451,6 +2451,15 @@ dr_abort(void)
 
 DR_API
 void
+dr_abort_with_code(int exit_code)
+{
+    if (TEST(DUMPCORE_DR_ABORT, dynamo_options.dumpcore_mask))
+        os_dump_core("dr_abort");
+    os_terminate_with_code(NULL, TERMINATE_PROCESS, exit_code);
+}
+
+DR_API
+void
 dr_exit_process(int exit_code)
 {
     dcontext_t *dcontext = get_thread_private_dcontext();

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -1951,6 +1951,19 @@ dr_abort(void);
 
 DR_API
 /**
+ * Aborts the process immediately without any cleanup (i.e., the exit event
+ * will not be called) with the exit code \p exit_code.
+ *
+ * On Linux, only the bottom 8 bits of \p exit_code will be honored
+ * for a normal exit.  If bits 9..16 are not all zero, DR will send an
+ * unhandled signal of that signal number instead of performing a normal
+ * exit.
+ */
+void
+dr_abort_with_code(int exit_code);
+
+DR_API
+/**
  * Exits the process, first performing a full cleanup that will
  * trigger the exit event (dr_register_exit_event()).  The process
  * exit code is set to \p exit_code.
@@ -1963,7 +1976,7 @@ DR_API
  * \note Calling this from \p dr_client_main or from the primary thread's
  * initialization event is not guaranteed to always work, as DR may
  * invoke a thread exit event where a thread init event was never
- * called.  We recommend using dr_abort() or waiting for full
+ * called.  We recommend using dr_abort_ex() or waiting for full
  * initialization prior to use of this routine.
  */
 void

--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -761,7 +761,7 @@ dr_inject_process_exit(void *data, bool terminate)
          * wait on it again or try to kill it, or we might target some new
          * process with the same pid.
          */
-        status = info->exitcode;
+        status = WEXITSTATUS(info->exitcode);
     } else if (info->exec_self) {
         status = -1; /* We never injected, must have been some other error. */
     } else if (terminate) {

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -1468,7 +1468,8 @@ os_terminate_common(dcontext_t *dcontext, terminate_flags_t terminate_type,
             terminate_type = TERMINATE_THREAD;
         } else {
             config_exit(); /* delete .1config file */
-            nt_terminate_process(currentThreadOrProcess, KILL_PROC_EXIT_STATUS);
+            nt_terminate_process(currentThreadOrProcess,
+                                 custom_code ? exit_code : KILL_PROC_EXIT_STATUS);
             ASSERT_NOT_REACHED();
         }
     }
@@ -1525,7 +1526,8 @@ os_terminate_common(dcontext_t *dcontext, terminate_flags_t terminate_type,
         /* may have decided to terminate process */
         if (exit_process) {
             config_exit(); /* delete .1config file */
-            nt_terminate_process(currentThreadOrProcess, KILL_PROC_EXIT_STATUS);
+            nt_terminate_process(currentThreadOrProcess,
+                                 custom_code ? exit_code : KILL_PROC_EXIT_STATUS);
             ASSERT_NOT_REACHED();
         } else {
             /* FIXME: this is now very dangerous - we even leave our own state */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1336,6 +1336,7 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out)
       -D postcmd2=${${key}_postcmd2}
       -D postcmd3=${${key}_postcmd3}
       -D cmp=${CMAKE_CURRENT_BINARY_DIR}/${expectbase}.expect
+      -D code=${${key}_code}
       -P ${runcmp_script})
     # No support for regex here (ctest can't handle large regex)
     set(ALREADY_REGEX ON)
@@ -1705,6 +1706,8 @@ if (CLIENT_INTERFACE)
 
   tobuild_ci(client.call-retarget client-interface/call-retarget.c "" "" "")
   if (X86) # FIXME i#1551, i#1569: port to ARM and AArch64
+    set(client.abort_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runcode.cmake")
+    set(client.abort_code "8")
     tobuild_ci(client.abort client-interface/abort.c "" "" "")
   endif (X86)
   tobuild_ci(client.crashmsg client-interface/crashmsg.c "" "" "")

--- a/suite/tests/client-interface/abort.dll.c
+++ b/suite/tests/client-interface/abort.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -53,7 +53,7 @@ my_abort(
     if (var0 != arg0 || var1 != arg1 || var2 != arg2)
         dr_fprintf(STDERR, "Error on mov_imm\n");
     dr_fprintf(STDERR, "aborting now\n");
-    dr_abort();
+    dr_abort_with_code(8);
 }
 
 #define MINSERT instrlist_meta_preinsert

--- a/suite/tests/runcode.cmake
+++ b/suite/tests/runcode.cmake
@@ -1,0 +1,52 @@
+# **********************************************************
+# Copyright (c) 2018 Google, Inc.    All rights reserved.
+# **********************************************************
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Google, Inc. nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+# Checks the exit code of a test.
+# * cmd = command to run
+#     should have intra-arg space=@@ and inter-arg space=@ and ;=!
+# * code = expected exit code
+# Does not check output content.
+
+# Intra-arg space=@@ and inter-arg space=@.
+# XXX i#1327: now that we have -c and other option passing improvements we
+# should be able to get rid of this @@ stuff.
+string(REGEX REPLACE "@-exit0@" "@" cmd "${cmd}")
+string(REGEX REPLACE "@@" " " cmd "${cmd}")
+string(REGEX REPLACE "@" ";" cmd "${cmd}")
+string(REGEX REPLACE "!" "\\\;" cmd "${cmd}")
+
+message("Running |${cmd}|")
+execute_process(COMMAND ${cmd}
+  RESULT_VARIABLE cmd_result
+  ERROR_VARIABLE cmd_err
+  OUTPUT_VARIABLE cmd_out)
+if (NOT "${cmd_result}" STREQUAL "${code}")
+  message(FATAL_ERROR "*** ${cmd} failed: ${cmd_result} != ${code} ***\n")
+endif ()


### PR DESCRIPTION
Adds a mechanism to exit immediately with no cleanup and also set an exit
code.  dr_exit_process() can set a code, but always cleans up and thus
cannot be called during process init.

Adds a test using a new script runcode.cmake to check the exit code.