### PR TITLE
Add a function to expose the cache configs to clients of DRCacheSim

### DIFF
--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -144,7 +144,6 @@ cache_simulator_t::cache_simulator_t(const std::string &config_file)
     , l1_dcaches(NULL)
     , is_warmed_up(false)
 {
-    std::map<std::string, cache_params_t> cache_params;
     config_reader_t config_reader;
     if (!config_reader.configure(config_file, knobs, cache_params)) {
         error_string =
@@ -490,4 +489,14 @@ cache_simulator_t::create_cache(const std::string &policy)
     ERRMSG("Usage error: undefined replacement policy. "
            "Please choose " REPLACE_POLICY_LRU " or " REPLACE_POLICY_LFU ".\n");
     return NULL;
+}
+
+cache_params_t *
+cache_simulator_t::get_cache_params(const std::string &cache_name) {
+    const auto &cache_config_it = cache_params.find(cache_name);
+    if (cache_config_it != cache_params.end()) {
+        return &cache_config_it->second;
+    } else {
+        return NULL;
+    }
 }

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -36,11 +36,13 @@
 #ifndef _CACHE_SIMULATOR_H_
 #define _CACHE_SIMULATOR_H_ 1
 
+#include <map>
 #include <unordered_map>
-#include "simulator.h"
+#include "../reader/config_reader.h"
 #include "cache_simulator_create.h"
 #include "cache_stats.h"
 #include "cache.h"
+#include "simulator.h"
 
 class cache_simulator_t : public simulator_t {
 public:
@@ -65,6 +67,10 @@ public:
     uint64_t
     remaining_sim_refs() const;
 
+    // Expose to allow clients to use cache configuration.
+    cache_params_t *
+    get_cache_params(const std::string &cache_name);
+
 protected:
     // Create a cache_t object with a specific replacement policy.
     virtual cache_t *
@@ -81,6 +87,9 @@ protected:
     std::unordered_map<std::string, cache_t *> llcaches;     // LLC(s)
     std::unordered_map<std::string, cache_t *> other_caches; // Non-L1, non-LLC caches
     std::unordered_map<std::string, cache_t *> all_caches;   // All caches.
+
+    // The following map maps a cache's name to its configuration.
+    std::map<std::string, cache_params_t> cache_params;
 
 private:
     bool is_warmed_up;


### PR DESCRIPTION
Add a function that would allow clients of DRCacheSim to lookup cache configurations read from the cache hierarchy config file.