### PR TITLE
i#3129 raw2trace perf: ensure module_mapper_t calls custom data free callback

### DIFF
--- a/clients/drcachesim/tests/raw2trace-simple.templatex
+++ b/clients/drcachesim/tests/raw2trace-simple.templatex
@@ -6,6 +6,7 @@ Processed
 About to load modules
 Loaded modules successfully
 Successfully found app entry
+Custom user_free was called
 Read timestamp from thread header
 Read timestamp without thread header
 Verified boundary conditions

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -164,10 +164,16 @@ test_raw2trace(raw2trace_directory_t *dir)
     }
 }
 
+void
+my_user_free(void *data)
+{
+    REPORT("Custom user_free was called");
+}
+
 bool
 test_module_mapper(const raw2trace_directory_t *dir)
 {
-    module_mapper_t mapper(dir->modfile_bytes);
+    module_mapper_t mapper(dir->modfile_bytes, nullptr, nullptr, nullptr, &my_user_free);
     EXPECT(mapper.get_last_error().empty(), "Module mapper construction failed");
     REPORT("About to load modules");
     const auto &loaded_modules = mapper.get_loaded_modules();

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -412,8 +412,8 @@ struct trace_header_t {
  * Implementers are given the opportunity to implement their own logging. The level
  * parameter represents severity: the lower the level, the higher the severity.</LI>
  *
- * <LI>const instr_summary_t *get_instr_summary(uint64 modx, uint64 modoffs, INOUT app_pc
- * *pc, app_pc orig)
+ * <LI>const instr_summary_t *get_instr_summary(uint64 modidx, uint64 modoffs, INOUT
+ * app_pc *pc, app_pc orig)
  *
  * Return the #instr_summary_t representation of the instruction at *pc,
  * updating the value at pc to the PC of the next instruction. It is assumed the app
@@ -922,7 +922,7 @@ private:
     void
     log(uint level, const char *fmt, ...);
     const instr_summary_t *
-    get_instr_summary(uint64 modx, uint64 modoffs, INOUT app_pc *pc, app_pc orig);
+    get_instr_summary(uint64 modidx, uint64 modoffs, INOUT app_pc *pc, app_pc orig);
 
     std::string
     read_and_map_modules();

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -310,6 +310,7 @@ private:
     const char *modmap = nullptr;
     void *modhandle = nullptr;
     std::vector<module_t> modvec;
+    void (*const cached_user_free)(void *data) = nullptr;
 
     // Custom module fields that use drmodtrack are global.
     static const char *(*user_parse)(const char *src, OUT void **data);


### PR DESCRIPTION
We avoid holding on to global state past module_mapper_t construction. However, we need to remember the custom free_cb callback, if provided, as it will be needed when ~module_mapper_t is called.

Issue #3129