### PR TITLE
i#3129 raw2trace perf: remove module_mapper_t move assignment operator

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -343,8 +343,6 @@ private:
     // VS2013 does not support defaulted move ctors/assign operators
 #ifndef WINDOWS
     module_mapper_t(module_mapper_t &&) = default;
-    module_mapper_t &
-    operator=(module_mapper_t &&) = default;
 #endif
 };
 


### PR DESCRIPTION
The operator is implicitly deleted because a member (cached_user_free) is a const pointer.

Issue: #3129