### PR TITLE
i#3129 raw2trace perf: simplify module_mapper_t lifetime management

### DIFF
--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -188,9 +188,9 @@ post_process()
          * scope to delete the drmodtrack state afterward.
          */
         raw2trace_directory_t dir(output_path, output_trace);
-        module_mapper_t module_mapper(dir.modfile_bytes, parse_cb, process_cb,
-                                      MAGIC_VALUE, free_cb);
-        assert(module_mapper.get_last_error().empty());
+        std::unique_ptr<module_mapper_t> module_mapper = module_mapper_t::create(
+            dir.modfile_bytes, parse_cb, process_cb, MAGIC_VALUE, free_cb);
+        assert(module_mapper->get_last_error().empty());
         // Test back-compat of deprecated APIs.
         raw2trace_t raw2trace(dir.modfile_bytes, dir.thread_files, NULL, NULL);
         std::string error =

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -173,15 +173,16 @@ my_user_free(void *data)
 bool
 test_module_mapper(const raw2trace_directory_t *dir)
 {
-    module_mapper_t mapper(dir->modfile_bytes, nullptr, nullptr, nullptr, &my_user_free);
-    EXPECT(mapper.get_last_error().empty(), "Module mapper construction failed");
+    std::unique_ptr<module_mapper_t> mapper = module_mapper_t::create(
+        dir->modfile_bytes, nullptr, nullptr, nullptr, &my_user_free);
+    EXPECT(mapper->get_last_error().empty(), "Module mapper construction failed");
     REPORT("About to load modules");
-    const auto &loaded_modules = mapper.get_loaded_modules();
+    const auto &loaded_modules = mapper->get_loaded_modules();
     EXPECT(!loaded_modules.empty(), "Expected module entries");
-    EXPECT(mapper.get_last_error().empty(), "Module loading failed");
+    EXPECT(mapper->get_last_error().empty(), "Module loading failed");
     REPORT("Loaded modules successfully");
     bool found_simple_app = false;
-    for (const module_t &m : mapper.get_loaded_modules()) {
+    for (const module_t &m : mapper->get_loaded_modules()) {
         std::string path = m.path;
         if (path.rfind("simple_app") != std::string::npos) {
             found_simple_app = true;

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -64,8 +64,8 @@ opcode_mix_t::opcode_mix_t(const std::string &module_file_path, unsigned int ver
         return;
     }
     dcontext = dr_standalone_init();
-    module_mapper.reset(new module_mapper_t(directory.modfile_bytes, nullptr, nullptr,
-                                            nullptr, nullptr, verbose));
+    module_mapper = module_mapper_t::create(directory.modfile_bytes, nullptr, nullptr,
+                                            nullptr, nullptr, verbose);
     module_mapper->get_loaded_modules();
     std::string error = module_mapper->get_last_error();
     if (!error.empty()) {

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -68,8 +68,8 @@ view_t::view_t(const std::string &module_file_path, uint64_t skip_refs, uint64_t
         return;
     }
     dcontext = dr_standalone_init();
-    module_mapper.reset(new module_mapper_t(directory.modfile_bytes, nullptr, nullptr,
-                                            nullptr, nullptr, verbose));
+    module_mapper = module_mapper_t::create(directory.modfile_bytes, nullptr, nullptr,
+                                            nullptr, nullptr, verbose);
     module_mapper->get_loaded_modules();
     std::string error = module_mapper->get_last_error();
     if (!error.empty()) {

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -257,8 +257,8 @@ std::string
 raw2trace_t::do_module_parsing()
 {
     if (!module_mapper) {
-        module_mapper.reset(new module_mapper_t(modmap, user_parse, user_process,
-                                                user_process_data, user_free, verbosity));
+        module_mapper = module_mapper_t::create(modmap, user_parse, user_process,
+                                                user_process_data, user_free, verbosity);
     }
     return module_mapper->get_last_error();
 }

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -243,12 +243,18 @@ public:
      * On success, calls the \p process_cb function for every module in the list.
      * On failure, get_last_error() is non-empty, and indicates the cause.
      */
-    module_mapper_t(const char *module_map_in,
-                    const char *(*parse_cb)(const char *src, OUT void **data) = nullptr,
-                    std::string (*process_cb)(drmodtrack_info_t *info, void *data,
-                                              void *user_data) = nullptr,
-                    void *process_cb_user_data = nullptr,
-                    void (*free_cb)(void *data) = nullptr, uint verbosity_in = 0);
+    static std::unique_ptr<module_mapper_t>
+    create(const char *module_map_in,
+           const char *(*parse_cb)(const char *src, OUT void **data) = nullptr,
+           std::string (*process_cb)(drmodtrack_info_t *info, void *data,
+                                     void *user_data) = nullptr,
+           void *process_cb_user_data = nullptr, void (*free_cb)(void *data) = nullptr,
+           uint verbosity_in = 0)
+    {
+        return std::unique_ptr<module_mapper_t>(
+            new module_mapper_t(module_map_in, parse_cb, process_cb, process_cb_user_data,
+                                free_cb, verbosity_in));
+    }
 
     /**
      * All APIs on this type, including constructor, may fail. get_last_error() returns
@@ -292,17 +298,14 @@ public:
      */
     ~module_mapper_t();
 
-    // since the dtor frees resources, disable copy constructor but allow
-    // move semantics
-    module_mapper_t(const module_mapper_t &) = delete;
-    module_mapper_t &
-    operator=(const module_mapper_t &) = delete;
-    // VS2013 does not support defaulted move ctors/assign operators
-#ifndef WINDOWS
-    module_mapper_t(module_mapper_t &&) = default;
-#endif
-
 private:
+    module_mapper_t(const char *module_map_in,
+                    const char *(*parse_cb)(const char *src, OUT void **data) = nullptr,
+                    std::string (*process_cb)(drmodtrack_info_t *info, void *data,
+                                              void *user_data) = nullptr,
+                    void *process_cb_user_data = nullptr,
+                    void (*free_cb)(void *data) = nullptr, uint verbosity_in = 0);
+
     // We store this in drmodtrack_info_t.custom to combine our binary contents
     // data with any user-added module data from drmemtrace_custom_module_data.
     struct custom_module_data_t {

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -305,7 +305,14 @@ private:
                                               void *user_data) = nullptr,
                     void *process_cb_user_data = nullptr,
                     void (*free_cb)(void *data) = nullptr, uint verbosity_in = 0);
-
+    module_mapper_t(const module_mapper_t &) = delete;
+    module_mapper_t &
+    operator=(const module_mapper_t &) = delete;
+#ifndef WINDOWS
+    module_mapper_t(module_mapper_t &&) = delete;
+    module_mapper_t &
+    operator=(module_mapper_t &&) = delete;
+#endif
     // We store this in drmodtrack_info_t.custom to combine our binary contents
     // data with any user-added module data from drmemtrace_custom_module_data.
     struct custom_module_data_t {

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -82,7 +82,7 @@ if ($child) {
         $mydir = `/usr/bin/cygpath -wi \"$mydir\"`;
         chomp $mydir;
     }
-    system("ctest --output-on-failure -V -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
+    system("ctest --output-on-failure -VV -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
     exit 0;
 }
 

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -82,7 +82,7 @@ if ($child) {
         $mydir = `/usr/bin/cygpath -wi \"$mydir\"`;
         chomp $mydir;
     }
-    system("ctest --output-on-failure -VV -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
+    system("ctest --output-on-failure -V -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
     exit 0;
 }
 


### PR DESCRIPTION
module_mapper_t should have move semantics, but simply relying on
default ctors/assignment operands isn't enough: we also need to clear
the originating object, otherwise the destructor would free resources
twice; and the assignment operator would have to figure out what to
do with the original resources.

We don't need an overly-complicated design, and there's very little
value to be gained from module_mapper_t being stack-allocatable. This
CL hides constructors and instead offers a static API that returns a
unique pointer.

Issue: #3129