### PR TITLE
#3159 ASSERT unix/signal.c pend_unit_size does not have AVX_ALIGNMENT on processor without AVX Bug-Assert

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -508,7 +508,7 @@ signal_thread_init(dcontext_t *dcontext, void *os_data)
         signal_frame_extra_size(true)
         /* sigpending_t has xstate inside it already */
         IF_LINUX(IF_X86(-sizeof(kernel_xstate_t)));
-    IF_LINUX(IF_X86(ASSERT(ALIGNED(pend_unit_size, AVX_ALIGNMENT))));
+    IF_LINUX(IF_X86(ASSERT(!YMM_ENABLED() || ALIGNED(pend_unit_size, AVX_ALIGNMENT))));
 
     /* all fields want to be initialized to 0 */
     memset(info, 0, sizeof(thread_sig_info_t));


### PR DESCRIPTION
Incorporated maintainer's suggestion of properly handling CPU hardware with no AVX support into the `core/unix/signal.c` during `signal_main_init()`, specifically Intel iCore2.

Fixes issue #3159.  