### PR TITLE
i#3177 sigstate: update sigmask in app frame

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -3135,7 +3135,7 @@ copy_frame_to_stack(dcontext_t *dcontext, int sig, sigframe_rt_t *frame, byte *s
 #ifdef X64
         ASSERT_NOT_REACHED();
 #endif
-#ifdef LINUX
+#if defined(LINUX) && !defined(X64)
         sigframe_plain_t *f_new = (sigframe_plain_t *)sp;
 #    ifdef X86
 #        ifndef VMX86_SERVER
@@ -3173,7 +3173,7 @@ copy_frame_to_stack(dcontext_t *dcontext, int sig, sigframe_rt_t *frame, byte *s
 #    endif /* X86 */
         /* Store the prior mask, for restoring in sigreturn. */
         convert_rt_mask_to_nonrt(f_new, &info->app_sigblocked);
-#endif /* LINUX */
+#endif /* LINUX && !X64 */
     }
 
 #ifdef MACOS

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2868,14 +2868,14 @@ get_sigstack_frame_ptr(dcontext_t *dcontext, int sig, sigframe_rt_t *frame)
 
 #if defined(LINUX) && !defined(X64)
 static void
-convert_rt_mask_to_nonrt(sigframe_rt_t *f_plain, kernel_sigset_t *sigmask)
+convert_rt_mask_to_nonrt(sigframe_plain_t *f_plain, kernel_sigset_t *sigmask)
 {
 #    ifdef X86
-    f_plain->sc.oldmask = sigmask.sig[0];
-    memcpy(&f_plain->extramask, sigmask.sig[1], (_NSIG_WORDS - 1) * sizeof(uint));
+    f_plain->sc.oldmask = sigmask->sig[0];
+    memcpy(&f_plain->extramask, &sigmask->sig[1], (_NSIG_WORDS - 1) * sizeof(uint));
 #    elif defined(ARM)
-    f_plain->uc.uc_mcontet.oldmask = sigmask.sig[0];
-    memcpy(&f_plain->uc.sigset_ex, sigmask.sig[1], (_NSIG_WORDS - 1) * sizeof(uint));
+    f_plain->uc.uc_mcontext.oldmask = sigmask->sig[0];
+    memcpy(&f_plain->uc.sigset_ex, &sigmask->sig[1], (_NSIG_WORDS - 1) * sizeof(uint));
 #    else
 #        error NYI
 #    endif
@@ -3131,13 +3131,13 @@ copy_frame_to_stack(dcontext_t *dcontext, int sig, sigframe_rt_t *frame, byte *s
         /* Store the prior mask, for restoring in sigreturn. */
         memcpy(&f_new->uc.uc_sigmask, &info->app_sigblocked,
                sizeof(info->app_sigblocked));
-    }
-#if defined(X86) && defined(LINUX)
-    else {
-#    ifdef X64
+    } else {
+#ifdef X64
         ASSERT_NOT_REACHED();
-#    else
+#endif
+#ifdef LINUX
         sigframe_plain_t *f_new = (sigframe_plain_t *)sp;
+#    ifdef X86
 #        ifndef VMX86_SERVER
         sigframe_plain_t *f_old = (sigframe_plain_t *)frame;
 #        endif
@@ -3165,16 +3165,16 @@ copy_frame_to_stack(dcontext_t *dcontext, int sig, sigframe_rt_t *frame, byte *s
          * as well on older kernels.
          */
         ASSERT(f_new->sc.fpstate != &f_new->fpstate);
+        /* 32-bit kernel copies to aligned buf so no assert on fpstate alignment */
         LOG(THREAD, LOG_ASYNCH, 3, "\tretaddr = " PFX "\n", f_new->pretcode);
 #        ifdef RETURN_AFTER_CALL
         info->signal_restorer_retaddr = (app_pc)f_new->pretcode;
 #        endif
-        /* 32-bit kernel copies to aligned buf so no assert on fpstate alignment */
+#    endif /* X86 */
         /* Store the prior mask, for restoring in sigreturn. */
         convert_rt_mask_to_nonrt(f_new, &info->app_sigblocked);
-#    endif /* X64 */
+#endif /* LINUX */
     }
-#endif /* X86 && LINUX */
 
 #ifdef MACOS
     /* Update handler field, which is passed to the libc trampoline, to app */


### PR DESCRIPTION
Updates the signal mask stored in each signal frame delivered to the
app to properly contain the app's interrupted mask.

Adds tests that DR is doing the right thing with the mask across
signal delivery.

Issue: #3177