### PR TITLE
i#3177 sigstate: update altstack in app frame

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -5936,8 +5936,9 @@ handle_sigreturn(dcontext_t *dcontext, void *ucxt_param, int style)
         /* Re-set sigstack from the value stored in the frame. */
         /* FIXME i#3178: have a routine to set it that fails when the kernel fails */
         LOG(THREAD, LOG_ASYNCH, 3, "Restoring app signal stack to " PFX "-" PFX " %d\n",
-            frame->uc.uc_stack.ss_sp, frame->uc.uc_stack.ss_sp +
-            frame->uc.uc_stack.ss_size, frame->uc.uc_stack.ss_flags);
+            frame->uc.uc_stack.ss_sp,
+            frame->uc.uc_stack.ss_sp + frame->uc.uc_stack.ss_size,
+            frame->uc.uc_stack.ss_flags);
         info->app_sigstack = frame->uc.uc_stack;
         /* Restore DR's so sigreturn syscall won't change it. */
         frame->uc.uc_stack = info->sigstack;

--- a/suite/tests/linux/signal-base.h
+++ b/suite/tests/linux/signal-base.h
@@ -217,7 +217,7 @@ main(int argc, char *argv[])
 #if USE_SIGSTACK
     sigstack.ss_sp = (char *)malloc(ALT_STACK_SIZE);
     sigstack.ss_size = ALT_STACK_SIZE;
-    sigstack.ss_flags = SS_ONSTACK;
+    sigstack.ss_flags = 0;
     rc = sigaltstack(&sigstack, NULL);
     ASSERT_NOERR(rc);
 #    if VERBOSE
@@ -291,6 +291,12 @@ main(int argc, char *argv[])
 #endif
 
 #if USE_SIGSTACK
+    stack_t check_stack;
+    rc = sigaltstack(NULL, &check_stack);
+    ASSERT_NOERR(rc);
+    assert(check_stack.ss_sp == sigstack.ss_sp &&
+           check_stack.ss_size == sigstack.ss_size &&
+           check_stack.ss_flags == sigstack.ss_flags);
     free(sigstack.ss_sp);
 #endif
     return 0;

--- a/suite/tests/linux/sigplain-base.h
+++ b/suite/tests/linux/sigplain-base.h
@@ -148,7 +148,7 @@ main(int argc, char *argv[])
 #if USE_SIGSTACK
     sigstack.ss_sp = (char *)malloc(ALT_STACK_SIZE);
     sigstack.ss_size = ALT_STACK_SIZE;
-    sigstack.ss_flags = SS_ONSTACK;
+    sigstack.ss_flags = 0;
     rc = sigaltstack(&sigstack, NULL);
     ASSERT_NOERR(rc);
 #    if VERBOSE
@@ -199,6 +199,12 @@ main(int argc, char *argv[])
 #endif
 
 #if USE_SIGSTACK
+    stack_t check_stack;
+    rc = sigaltstack(NULL, &check_stack);
+    ASSERT_NOERR(rc);
+    assert(check_stack.ss_sp == sigstack.ss_sp &&
+           check_stack.ss_size == sigstack.ss_size &&
+           check_stack.ss_flags == sigstack.ss_flags);
     free(sigstack.ss_sp);
 #endif
     return 0;


### PR DESCRIPTION
Updates the alternate signal stack stored in each signal frame delivered to the
app to properly contain the app's alternate stack.

Restores DR's mask and altstack prior to executing SYS_sigreturn as
part of handling the app's sigreturn (that's the simplest way to
restore non-GPR state).

Adds tests that DR is doing the right thing with the stack across signal delivery.

Fixes #3177