### PR TITLE
i#3178: proper sigaltstack error checking

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7222,9 +7222,16 @@ pre_system_call(dcontext_t *dcontext)
         */
         const stack_t *uss = (const stack_t *)sys_param(dcontext, 0);
         stack_t *uoss = (stack_t *)sys_param(dcontext, 1);
-        execute_syscall = handle_sigaltstack(dcontext, uss, uoss);
+        uint res;
+        LOG(THREAD, LOG_SYSCALLS, 2, "syscall: sigaltstack " PFX " " PFX "\n", uss, uoss);
+        execute_syscall =
+            handle_sigaltstack(dcontext, uss, uoss, get_mcontext(dcontext)->xsp, &res);
         if (!execute_syscall) {
-            set_success_return_val(dcontext, 0);
+            LOG(THREAD, LOG_SYSCALLS, 2, "sigaltstack emulation => %d\n", -res);
+            if (res == 0)
+                set_success_return_val(dcontext, res);
+            else
+                set_failure_return_val(dcontext, res);
         }
         break;
     }

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -308,7 +308,8 @@ bool
 handle_sigreturn(dcontext_t *dcontext, void *ucxt, int style);
 #endif
 bool
-handle_sigaltstack(dcontext_t *dcontext, const stack_t *stack, stack_t *old_stack);
+handle_sigaltstack(dcontext_t *dcontext, const stack_t *stack, stack_t *old_stack,
+                   reg_t cur_xsp, OUT uint *result);
 bool
 handle_sigprocmask(dcontext_t *dcontext, int how, kernel_sigset_t *set,
                    kernel_sigset_t *oset, size_t sigsetsize);

--- a/suite/tests/linux/bad-signal-stack.c
+++ b/suite/tests/linux/bad-signal-stack.c
@@ -36,6 +36,7 @@
 #include <ucontext.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #define ALT_STACK_SIZE (SIGSTKSZ * 4)
 
@@ -48,13 +49,44 @@ signal_handler(int sig)
 int
 main(int argc, char *argv[])
 {
-    char *sp;
     int rc;
     INIT();
+    stack_t sigstack;
+    char *alloc = (char *)malloc(ALT_STACK_SIZE);
+
+    /* First, test various failures of sigaltstack */
+    rc = sigaltstack(NULL, (stack_t *)0x4);
+    assert(rc == -1 && errno == EFAULT);
+
+    rc = sigaltstack((stack_t *)0x4, NULL);
+    assert(rc == -1 && errno == EFAULT);
+
+    sigstack.ss_sp = alloc;
+    sigstack.ss_size = MINSIGSTKSZ - 1;
+    sigstack.ss_flags = 0;
+    rc = sigaltstack(&sigstack, NULL);
+    assert(rc == -1 && errno == ENOMEM);
+
+    sigstack.ss_sp = alloc;
+    sigstack.ss_size = MINSIGSTKSZ - 1;
+    /* SS_DISABLE causes the kernel to ignore sp and size: it zeroes them out. */
+    sigstack.ss_flags = SS_DISABLE;
+    rc = sigaltstack(&sigstack, NULL);
+    ASSERT_NOERR(rc);
+    stack_t mystack;
+    rc = sigaltstack(NULL, &mystack);
+    ASSERT_NOERR(rc);
+    assert(mystack.ss_sp == NULL && mystack.ss_size == 0 &&
+           mystack.ss_flags == SS_DISABLE);
+
+    sigstack.ss_sp = alloc;
+    sigstack.ss_size = ALT_STACK_SIZE;
+    sigstack.ss_flags = SS_DISABLE | SS_ONSTACK;
+    rc = sigaltstack(&sigstack, NULL);
+    assert(rc == -1 && errno == EINVAL);
 
     /* Make an alternate stack that's not writable. */
-    stack_t sigstack;
-    sigstack.ss_sp = (char *)malloc(ALT_STACK_SIZE);
+    sigstack.ss_sp = alloc;
     sigstack.ss_size = ALT_STACK_SIZE;
     sigstack.ss_flags = SS_ONSTACK;
     rc = sigaltstack(&sigstack, NULL);
@@ -77,6 +109,8 @@ main(int argc, char *argv[])
     print("Sending SIGUSR1\n");
     kill(getpid(), SIGUSR1);
 
+    protect_mem(alloc, ALT_STACK_SIZE, ALLOW_READ | ALLOW_WRITE);
+    free(alloc);
     print("All done\n");
     return 0;
 }

--- a/suite/tests/linux/signal-base.h
+++ b/suite/tests/linux/signal-base.h
@@ -102,6 +102,16 @@ signal_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
         print("in signal handler\n");
 #endif
 
+#if USE_SIGSTACK
+    /* Ensure setting a new stack while on the current one fails with EPERM. */
+    stack_t sigstack;
+    sigstack.ss_sp = siginfo; /* will fail: just need sthg */
+    sigstack.ss_size = ALT_STACK_SIZE;
+    sigstack.ss_flags = SS_ONSTACK;
+    int rc = sigaltstack(&sigstack, NULL);
+    assert(rc == -1 && errno == EPERM);
+#endif
+
     switch (sig) {
 
     case SIGSEGV: {
@@ -204,16 +214,6 @@ main(int argc, char *argv[])
     rc = sigprocmask(SIG_SETMASK, &mask, NULL);
     ASSERT_NOERR(rc);
 
-#if USE_TIMER
-    custom_intercept_signal(SIGVTALRM, (handler_t)signal_handler);
-    t.it_interval.tv_sec = 0;
-    t.it_interval.tv_usec = 10000;
-    t.it_value.tv_sec = 0;
-    t.it_value.tv_usec = 10000;
-    rc = setitimer(ITIMER_VIRTUAL, &t, NULL);
-    ASSERT_NOERR(rc);
-#endif
-
 #if USE_SIGSTACK
     sigstack.ss_sp = (char *)malloc(ALT_STACK_SIZE);
     sigstack.ss_size = ALT_STACK_SIZE;
@@ -224,6 +224,16 @@ main(int argc, char *argv[])
     print("Set up sigstack: 0x%08x - 0x%08x\n", sigstack.ss_sp,
           sigstack.ss_sp + sigstack.ss_size);
 #    endif
+#endif
+
+#if USE_TIMER
+    custom_intercept_signal(SIGVTALRM, (handler_t)signal_handler);
+    t.it_interval.tv_sec = 0;
+    t.it_interval.tv_usec = 10000;
+    t.it_value.tv_sec = 0;
+    t.it_value.tv_usec = 10000;
+    rc = setitimer(ITIMER_VIRTUAL, &t, NULL);
+    ASSERT_NOERR(rc);
 #endif
 
     custom_intercept_signal(SIGSEGV, (handler_t)signal_handler);
@@ -290,7 +300,10 @@ main(int argc, char *argv[])
         print("Got some timer hits!\n");
 #endif
 
-#if USE_SIGSTACK
+    /* We leave the sigstack in place for the timer so any racy alarm arriving
+     * after we disabled the itimer will be on the alt stack.
+     */
+#if USE_SIGSTACK && !USE_TIMER
     stack_t check_stack;
     rc = sigaltstack(NULL, &check_stack);
     ASSERT_NOERR(rc);

--- a/suite/tests/linux/signal-base.h
+++ b/suite/tests/linux/signal-base.h
@@ -300,9 +300,9 @@ main(int argc, char *argv[])
         print("Got some timer hits!\n");
 #endif
 
-    /* We leave the sigstack in place for the timer so any racy alarm arriving
-     * after we disabled the itimer will be on the alt stack.
-     */
+        /* We leave the sigstack in place for the timer so any racy alarm arriving
+         * after we disabled the itimer will be on the alt stack.
+         */
 #if USE_SIGSTACK && !USE_TIMER
     stack_t check_stack;
     rc = sigaltstack(NULL, &check_stack);

--- a/suite/tests/linux/sigplain-base.h
+++ b/suite/tests/linux/sigplain-base.h
@@ -208,9 +208,9 @@ main(int argc, char *argv[])
         print("Got some timer hits!\n");
 #endif
 
-    /* We leave the sigstack in place for the timer so any racy alarm arriving
-     * after we disabled the itimer will be on the alt stack.
-     */
+        /* We leave the sigstack in place for the timer so any racy alarm arriving
+         * after we disabled the itimer will be on the alt stack.
+         */
 #if USE_SIGSTACK && !USE_TIMER
     stack_t check_stack;
     rc = sigaltstack(NULL, &check_stack);


### PR DESCRIPTION
Adds proper error checking for the various ways that the kernel fails
the SYS_sigaltstack system call.  Adds tests of each error case.

Fixes #3178