### PR TITLE
i#3198 opcode_mix_t::proces_memref: return bool instead of string

### DIFF
--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -79,8 +79,10 @@ bool
 opcode_mix_t::process_memref(const memref_t &memref)
 {
     if (!type_is_instr(memref.instr.type) &&
-        memref.data.type != TRACE_TYPE_INSTR_NO_FETCH)
-        return "";
+        memref.data.type != TRACE_TYPE_INSTR_NO_FETCH) {
+        error_string = "";
+        return true;
+    }
     ++instr_count;
     app_pc mapped_pc;
     mapped_pc = module_mapper->find_mapped_trace_address((app_pc)memref.instr.addr);

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -80,7 +80,6 @@ opcode_mix_t::process_memref(const memref_t &memref)
 {
     if (!type_is_instr(memref.instr.type) &&
         memref.data.type != TRACE_TYPE_INSTR_NO_FETCH) {
-        error_string = "";
         return true;
     }
     ++instr_count;


### PR DESCRIPTION
The return type of process_memref is bool. One return statement was the empty string. Fixing this avoids special-case build flags.

Fixes #3198