### PR TITLE
i#3201: In non-static/Linux, read library name from maps instead of using hard-coded name.

### DIFF
--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1574,7 +1574,7 @@ dynamorio_lib_gap_empty(void)
         while (memquery_iterator_next(&iter) && iter.vm_start < dr_end) {
             if (iter.vm_start >= dr_start && iter.vm_end <= dr_end &&
                 iter.comment[0] != '\0' &&
-                strstr(iter.comment, DYNAMORIO_LIBRARY_NAME) == NULL) {
+                strstr(iter.comment, get_dynamorio_library_path()) == NULL) {
                 /* There's a non-anon mapping inside: probably vvar and/or vdso. */
                 res = false;
                 break;
@@ -1778,7 +1778,7 @@ privload_early_inject(void **sp, byte *old_libdr_base, size_t old_libdr_size)
                     (iter.comment[0] == '\0' /* .bss */ ||
                      /* The kernel sometimes mis-labels our .bss as "[heap]". */
                      strcmp(iter.comment, "[heap]") == 0 ||
-                     strstr(iter.comment, DYNAMORIO_LIBRARY_NAME) != NULL)) {
+                     strstr(iter.comment, get_dynamorio_library_path()) != NULL)) {
                     os_unmap_file(iter.vm_start, iter.vm_end - iter.vm_start);
                 }
                 if (iter.vm_start >= old_libdr_base + old_libdr_size)

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1772,8 +1772,8 @@ privload_early_inject(void **sp, byte *old_libdr_base, size_t old_libdr_size)
         /* i#2641: we can't blindly unload the whole region as vvar+vdso may be
          * in the text-data gap.
          */
-        if (memquery_iterator_start(&iter, NULL, false /*no heap*/)) {
-            char *dynamorio_library_path = get_dynamorio_library_path();
+        char *dynamorio_library_path = get_dynamorio_library_path();
+        if (memquery_iterator_start(&iter, NULL, false /*no heap*/)) {\
             while (memquery_iterator_next(&iter)) {
                 if (iter.vm_start >= old_libdr_base &&
                     iter.vm_end <= old_libdr_base + old_libdr_size &&

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1773,7 +1773,7 @@ privload_early_inject(void **sp, byte *old_libdr_base, size_t old_libdr_size)
          * in the text-data gap.
          */
         char *dynamorio_library_path = get_dynamorio_library_path();
-        if (memquery_iterator_start(&iter, NULL, false /*no heap*/)) {\
+        if (memquery_iterator_start(&iter, NULL, false /*no heap*/)) {
             while (memquery_iterator_next(&iter)) {
                 if (iter.vm_start >= old_libdr_base &&
                     iter.vm_end <= old_libdr_base + old_libdr_size &&

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1571,7 +1571,7 @@ dynamorio_lib_gap_empty(void)
         byte *dr_start = get_dynamorio_dll_start();
         byte *dr_end = get_dynamorio_dll_end();
         byte *gap_start = dr_start;
-        char *dynamorio_library_path = get_dynamorio_library_path();
+        const char *dynamorio_library_path = get_dynamorio_library_path();
         while (memquery_iterator_next(&iter) && iter.vm_start < dr_end) {
             if (iter.vm_start >= dr_start && iter.vm_end <= dr_end &&
                 iter.comment[0] != '\0' &&
@@ -1772,7 +1772,7 @@ privload_early_inject(void **sp, byte *old_libdr_base, size_t old_libdr_size)
         /* i#2641: we can't blindly unload the whole region as vvar+vdso may be
          * in the text-data gap.
          */
-        char *dynamorio_library_path = get_dynamorio_library_path();
+        const char *dynamorio_library_path = get_dynamorio_library_path();
         if (memquery_iterator_start(&iter, NULL, false /*no heap*/)) {
             while (memquery_iterator_next(&iter)) {
                 if (iter.vm_start >= old_libdr_base &&

--- a/core/unix/memquery.c
+++ b/core/unix/memquery.c
@@ -54,7 +54,7 @@
  */
 int
 memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
-                                    app_pc *end /*OUT*/, char *fullpath /*OPTIONAL OUT*/,
+                                    app_pc *end /*OUT*/, char *fulldir /*OPTIONAL OUT*/,
                                     size_t path_size, char *filename /*OPTIONAL OUT*/,
                                     size_t filename_size)
 {
@@ -131,13 +131,13 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
                 /* Wait for the next entry which should have a file backing. */
                 target = iter.vm_end;
             } else if (!found_library) {
-                char *dst = (fullpath != NULL) ? fullpath : libname;
+                char *dst = (fulldir != NULL) ? fulldir : libname;
                 const char *src = (iter.comment[0] == '\0') ? libname : iter.comment;
                 size_t dstsz =
-                    (fullpath != NULL) ? path_size : BUFFER_SIZE_ELEMENTS(libname);
+                    (fulldir != NULL) ? path_size : BUFFER_SIZE_ELEMENTS(libname);
                 size_t mod_readable_sz;
                 if (src != dst) {
-                    if (dst == fullpath) {
+                    if (dst == fulldir) {
                         /* Just the path.  We use strstr for name_cmp. */
                         char *slash = strrchr(src, '/');
                         ASSERT_CURIOSITY(slash != NULL);
@@ -148,7 +148,7 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
                         if (filename != NULL && slash != NULL) {
                             /* slash is filename */
                             strncpy(filename, slash, MIN(strlen(slash), filename_size));
-                            filename[filename_size - 1] = '\0';
+                            filename[MIN(strlen(slash), filename_size - 1)] = '\0';
                         }
                     } else
                         strncpy(dst, src, dstsz);

--- a/core/unix/memquery.c
+++ b/core/unix/memquery.c
@@ -55,7 +55,7 @@
 int
 memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
                                     app_pc *end /*OUT*/, char *fullpath /*OPTIONAL OUT*/,
-                                    size_t path_size, char *filename,
+                                    size_t path_size, char *filename /*OPTIONAL OUT*/,
                                     size_t filename_size)
 {
     int count = 0;
@@ -145,9 +145,10 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
                         /* we keep the last '/' at end */
                         ++slash;
                         strncpy(dst, src, MIN(dstsz, (slash - src)));
-                        if (filename != NULL) {
+                        if (filename != NULL && slash != NULL) {
                             /* slash is filename */
                             strncpy(filename, slash, MIN(strlen(slash), filename_size));
+                            filename[filename_size - 1] = '\0';
                         }
                     } else
                         strncpy(dst, src, dstsz);

--- a/core/unix/memquery.c
+++ b/core/unix/memquery.c
@@ -145,9 +145,10 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
                         /* we keep the last '/' at end */
                         ++slash;
                         strncpy(dst, src, MIN(dstsz, (slash - src)));
-                        if (filename != NULL)
+                        if (filename != NULL) {
                             /* slash is filename */
                             strncpy(filename, slash, MIN(strlen(slash), filename_size));
+                        }
                     } else
                         strncpy(dst, src, dstsz);
                     /* if max no null */

--- a/core/unix/memquery.c
+++ b/core/unix/memquery.c
@@ -55,7 +55,8 @@
 int
 memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
                                     app_pc *end /*OUT*/, char *fullpath /*OPTIONAL OUT*/,
-                                    size_t path_size)
+                                    size_t path_size, char *filename,
+                                    size_t filename_size)
 {
     int count = 0;
     bool found_library = false;
@@ -144,6 +145,9 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
                         /* we keep the last '/' at end */
                         ++slash;
                         strncpy(dst, src, MIN(dstsz, (slash - src)));
+                        if (filename != NULL)
+                            /* slash is filename */
+                            strncpy(filename, slash, MIN(strlen(slash), filename_size));
                     } else
                         strncpy(dst, src, dstsz);
                     /* if max no null */

--- a/core/unix/memquery.c
+++ b/core/unix/memquery.c
@@ -55,7 +55,7 @@
 int
 memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
                                     app_pc *end /*OUT*/, char *fulldir /*OPTIONAL OUT*/,
-                                    size_t path_size, char *filename /*OPTIONAL OUT*/,
+                                    size_t fulldir_size, char *filename /*OPTIONAL OUT*/,
                                     size_t filename_size)
 {
     int count = 0;
@@ -134,7 +134,7 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
                 char *dst = (fulldir != NULL) ? fulldir : libname;
                 const char *src = (iter.comment[0] == '\0') ? libname : iter.comment;
                 size_t dstsz =
-                    (fulldir != NULL) ? path_size : BUFFER_SIZE_ELEMENTS(libname);
+                    (fulldir != NULL) ? fulldir_size : BUFFER_SIZE_ELEMENTS(libname);
                 size_t mod_readable_sz;
                 if (src != dst) {
                     if (dst == fulldir) {
@@ -149,7 +149,8 @@ memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
                             /* slash is filename */
                             strncpy(filename, slash, MIN(strlen(slash), filename_size));
                             filename[MIN(strlen(slash), filename_size - 1)] = '\0';
-                        }
+                        } else
+                            filename[0] = '\0';
                     } else
                         strncpy(dst, src, dstsz);
                     /* if max no null */

--- a/core/unix/memquery.h
+++ b/core/unix/memquery.h
@@ -104,7 +104,7 @@ memquery_iterator_next(memquery_iter_t *iter);
  */
 int
 memquery_library_bounds(const char *name, app_pc *start /*IN/OUT*/, app_pc *end /*OUT*/,
-                        char *fulldir /*OPTIONAL OUT*/, size_t path_size,
+                        char *fulldir /*OPTIONAL OUT*/, size_t fulldir_size,
                         char *filename /*OPTIONAL OUT*/, size_t filename_size);
 
 /* Interface is identical to memquery_library_bounds().  This is an iterator-based
@@ -112,8 +112,8 @@ memquery_library_bounds(const char *name, app_pc *start /*IN/OUT*/, app_pc *end 
  */
 int
 memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
-                                    app_pc *end /*OUT*/, char *fullpath /*OPTIONAL OUT*/,
-                                    size_t path_size, char *filename /*OPTIONAL OUT*/,
+                                    app_pc *end /*OUT*/, char *fulldir /*OPTIONAL OUT*/,
+                                    size_t fulldir_size, char *filename /*OPTIONAL OUT*/,
                                     size_t filename_size);
 
 /* XXX i#1270: ideally we could have os.c use generic memquery iterator code,

--- a/core/unix/memquery.h
+++ b/core/unix/memquery.h
@@ -104,7 +104,7 @@ memquery_iterator_next(memquery_iter_t *iter);
  */
 int
 memquery_library_bounds(const char *name, app_pc *start /*IN/OUT*/, app_pc *end /*OUT*/,
-                        char *fullpath /*OPTIONAL OUT*/, size_t path_size,
+                        char *fulldir /*OPTIONAL OUT*/, size_t path_size,
                         char *filename /*OPTIONAL OUT*/, size_t filename_size);
 
 /* Interface is identical to memquery_library_bounds().  This is an iterator-based

--- a/core/unix/memquery.h
+++ b/core/unix/memquery.h
@@ -104,7 +104,8 @@ memquery_iterator_next(memquery_iter_t *iter);
  */
 int
 memquery_library_bounds(const char *name, app_pc *start /*IN/OUT*/, app_pc *end /*OUT*/,
-                        char *fullpath /*OPTIONAL OUT*/, size_t path_size);
+                        char *fullpath /*OPTIONAL OUT*/, size_t path_size,
+                        char *filename /*OPTIONAL OUT*/, size_t filename_size);
 
 /* Interface is identical to memquery_library_bounds().  This is an iterator-based
  * impl shared among Linux and Mac.
@@ -112,7 +113,8 @@ memquery_library_bounds(const char *name, app_pc *start /*IN/OUT*/, app_pc *end 
 int
 memquery_library_bounds_by_iterator(const char *name, app_pc *start /*IN/OUT*/,
                                     app_pc *end /*OUT*/, char *fullpath /*OPTIONAL OUT*/,
-                                    size_t path_size);
+                                    size_t path_size, char *filename /*OPTIONAL OUT*/,
+                                    size_t filename_size);
 
 /* XXX i#1270: ideally we could have os.c use generic memquery iterator code,
  * but the probe + dl_iterate_phdr approach is difficult to fit into that mold

--- a/core/unix/memquery_linux.c
+++ b/core/unix/memquery_linux.c
@@ -323,10 +323,10 @@ memquery_iterator_next(memquery_iter_t *iter)
  */
 int
 memquery_library_bounds(const char *name, app_pc *start /*IN/OUT*/, app_pc *end /*OUT*/,
-                        char *fullpath /*OPTIONAL OUT*/, size_t path_size,
+                        char *fulldir /*OPTIONAL OUT*/, size_t path_size,
                         char *fullfilepath /*OPTIONAL OUT*/, size_t filepath_size)
 {
-    return memquery_library_bounds_by_iterator(name, start, end, fullpath, path_size,
+    return memquery_library_bounds_by_iterator(name, start, end, fulldir, path_size,
                                                fullfilepath, filepath_size);
 }
 

--- a/core/unix/memquery_linux.c
+++ b/core/unix/memquery_linux.c
@@ -323,9 +323,11 @@ memquery_iterator_next(memquery_iter_t *iter)
  */
 int
 memquery_library_bounds(const char *name, app_pc *start /*IN/OUT*/, app_pc *end /*OUT*/,
-                        char *fullpath /*OPTIONAL OUT*/, size_t path_size)
+                        char *fullpath /*OPTIONAL OUT*/, size_t path_size,
+                        char *fullfilepath /*OPTIONAL OUT*/, size_t filepath_size)
 {
-    return memquery_library_bounds_by_iterator(name, start, end, fullpath, path_size);
+    return memquery_library_bounds_by_iterator(name, start, end, fullpath, path_size,
+                                               fullfilepath, filepath_size);
 }
 
 /***************************************************************************

--- a/core/unix/memquery_linux.c
+++ b/core/unix/memquery_linux.c
@@ -323,8 +323,8 @@ memquery_iterator_next(memquery_iter_t *iter)
  */
 int
 memquery_library_bounds(const char *name, app_pc *start /*IN/OUT*/, app_pc *end /*OUT*/,
-                        char *fulldir /*OPTIONAL OUT*/, size_t path_size,
-                        char *fullfilepath /*OPTIONAL OUT*/, size_t filepath_size)
+                        char *fulldir /*OPTIONAL OUT*/, size_t fulldir_size,
+                        char *filename /*OPTIONAL OUT*/, size_t filename_size)
 {
     return memquery_library_bounds_by_iterator(name, start, end, fulldir, path_size,
                                                fullfilepath, filepath_size);

--- a/core/unix/memquery_linux.c
+++ b/core/unix/memquery_linux.c
@@ -326,8 +326,8 @@ memquery_library_bounds(const char *name, app_pc *start /*IN/OUT*/, app_pc *end 
                         char *fulldir /*OPTIONAL OUT*/, size_t fulldir_size,
                         char *filename /*OPTIONAL OUT*/, size_t filename_size)
 {
-    return memquery_library_bounds_by_iterator(name, start, end, fulldir, path_size,
-                                               fullfilepath, filepath_size);
+    return memquery_library_bounds_by_iterator(name, start, end, fulldir, fulldir_size,
+                                               filename, filename_size);
 }
 
 /***************************************************************************

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -8782,6 +8782,7 @@ get_dynamo_library_bounds(void)
         dynamorio_library_path);
     snprintf(dynamorio_library_filepath, BUFFER_SIZE_ELEMENTS(dynamorio_library_filepath),
              "%s%s", dynamorio_library_path, dynamorio_libname);
+    NULL_TERMINATE_BUFFER(dynamorio_library_filepath);
     LOG(GLOBAL, LOG_VMAREAS, 1, PRODUCT_NAME " library file path: %s\n",
         dynamorio_library_filepath);
     NULL_TERMINATE_BUFFER(dynamorio_library_filepath);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -3966,7 +3966,7 @@ shared_library_bounds(IN shlib_handle_t lib, IN byte *addr, IN const char *name,
         }
         release_recursive_lock(&privload_lock);
     }
-    return (memquery_library_bounds(name, start, end, NULL, 0) > 0);
+    return (memquery_library_bounds(name, start, end, NULL, 0, NULL, 0) > 0);
 }
 #    endif /* defined(CLIENT_INTERFACE) */
 
@@ -8765,11 +8765,24 @@ get_dynamo_library_bounds(void)
     check_start = dynamo_dll_start;
     dynamorio_libname = IF_UNIT_TEST_ELSE(UNIT_TEST_EXE_NAME, DYNAMORIO_LIBRARY_NAME);
 #    endif /* STATIC_LIBRARY */
+
+#    if !defined(STATIC_LIBRARY) && defined(LINUX)
+    static char dynamorio_libname_buf[MAXIMUM_PATH];
+    res = memquery_library_bounds(NULL, &check_start, &check_end, dynamorio_library_path,
+                                  BUFFER_SIZE_ELEMENTS(dynamorio_library_path),
+                                  dynamorio_libname_buf,
+                                  BUFFER_SIZE_ELEMENTS(dynamorio_libname_buf));
+    dynamorio_libname = IF_UNIT_TEST_ELSE(UNIT_TEST_EXE_NAME, dynamorio_libname_buf);
+#    else
     res = memquery_library_bounds(dynamorio_libname, &check_start, &check_end,
                                   dynamorio_library_path,
-                                  BUFFER_SIZE_ELEMENTS(dynamorio_library_path));
+                                  BUFFER_SIZE_ELEMENTS(dynamorio_library_path), NULL, 0);
+#    endif
+
     LOG(GLOBAL, LOG_VMAREAS, 1, PRODUCT_NAME " library path: %s\n",
         dynamorio_library_path);
+    LOG(GLOBAL, LOG_VMAREAS, 1, PRODUCT_NAME " library file path: %s\n",
+        dynamorio_library_filepath);
     snprintf(dynamorio_library_filepath, BUFFER_SIZE_ELEMENTS(dynamorio_library_filepath),
              "%s%s", dynamorio_library_path, dynamorio_libname);
     NULL_TERMINATE_BUFFER(dynamorio_library_filepath);
@@ -8869,7 +8882,8 @@ get_application_base(void)
         const char *name = get_application_name();
         if (name != NULL && name[0] != '\0') {
             DEBUG_DECLARE(int count =)
-            memquery_library_bounds(name, &executable_start, &executable_end, NULL, 0);
+            memquery_library_bounds(name, &executable_start, &executable_end, NULL, 0,
+                                    NULL, 0);
             ASSERT(count > 0 && executable_start != NULL);
         }
 #    else

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -5684,22 +5684,21 @@ add_dr_env_vars(dcontext_t *dcontext, char *inject_library_path, const char *app
             "WARNING: execve env does NOT preload DynamoRIO, forcing it!\n");
         if (preload >= 0) {
             /* replace the existing preload */
-            char *dynamorio_library_path = get_dynamorio_library_path();
+            const char *dr_lib_path = get_dynamorio_library_path();
             sz = strlen(envp[preload]) + strlen(DYNAMORIO_PRELOAD_NAME) +
-                strlen(dynamorio_library_path) + 3;
+                strlen(dr_lib_path) + 3;
             var = heap_alloc(dcontext, sizeof(char) * sz HEAPACCT(ACCT_OTHER));
             old = envp[preload] + strlen("LD_PRELOAD=");
-            snprintf(var, sz, "LD_PRELOAD=%s %s %s", DYNAMORIO_PRELOAD_NAME,
-                     dynamorio_library_path, old);
+            snprintf(var, sz, "LD_PRELOAD=%s %s %s", DYNAMORIO_PRELOAD_NAME, dr_lib_path,
+                     old);
             idx_preload = preload;
         } else {
             /* add new preload */
-            char *dynamorio_library_path = get_dynamorio_library_path();
+            const char *dr_lib_path = get_dynamorio_library_path();
             sz = strlen("LD_PRELOAD=") + strlen(DYNAMORIO_PRELOAD_NAME) +
-                strlen(dynamorio_library_path) + 2;
+                strlen(dr_lib_path) + 2;
             var = heap_alloc(dcontext, sizeof(char) * sz HEAPACCT(ACCT_OTHER));
-            snprintf(var, sz, "LD_PRELOAD=%s %s", DYNAMORIO_PRELOAD_NAME,
-                     dynamorio_library_path);
+            snprintf(var, sz, "LD_PRELOAD=%s %s", DYNAMORIO_PRELOAD_NAME, dr_lib_path);
             idx_preload = idx++;
         }
         *(var + sz - 1) = '\0'; /* null terminate */

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -8767,16 +8767,12 @@ get_dynamo_library_bounds(void)
     check_start = dynamo_dll_start;
 #    endif /* STATIC_LIBRARY */
 
-#    ifdef STATIC_LIBRARY
-    res = memquery_library_bounds(dynamorio_libname, &check_start, &check_end,
-                                  dynamorio_library_path,
-                                  BUFFER_SIZE_ELEMENTS(dynamorio_library_path), NULL, 0);
-#    else  /* !STATIC_LIBRARY */
     static char dynamorio_libname_buf[MAXIMUM_PATH];
     res = memquery_library_bounds(NULL, &check_start, &check_end, dynamorio_library_path,
                                   BUFFER_SIZE_ELEMENTS(dynamorio_library_path),
                                   dynamorio_libname_buf,
                                   BUFFER_SIZE_ELEMENTS(dynamorio_libname_buf));
+#    ifndef STATIC_LIBRARY
     dynamorio_libname = IF_UNIT_TEST_ELSE(UNIT_TEST_EXE_NAME, dynamorio_libname_buf);
 #    endif /* STATIC_LIBRARY */
 

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -5647,7 +5647,7 @@ add_dr_env_vars(dcontext_t *dcontext, char *inject_library_path, const char *app
                 strstr(envp[idx], "LD_PRELOAD=") == envp[idx]) {
                 preload = idx;
                 if (strstr(envp[idx], DYNAMORIO_PRELOAD_NAME) != NULL &&
-                    strstr(envp[idx], DYNAMORIO_LIBRARY_NAME) != NULL) {
+                    strstr(envp[idx], get_dynamorio_library_path()) != NULL) {
                     preload_us = true;
                 }
             }
@@ -5684,20 +5684,22 @@ add_dr_env_vars(dcontext_t *dcontext, char *inject_library_path, const char *app
             "WARNING: execve env does NOT preload DynamoRIO, forcing it!\n");
         if (preload >= 0) {
             /* replace the existing preload */
+            char *dynamorio_library_path = get_dynamorio_library_path();
             sz = strlen(envp[preload]) + strlen(DYNAMORIO_PRELOAD_NAME) +
-                strlen(DYNAMORIO_LIBRARY_NAME) + 3;
+                strlen(dynamorio_library_path) + 3;
             var = heap_alloc(dcontext, sizeof(char) * sz HEAPACCT(ACCT_OTHER));
             old = envp[preload] + strlen("LD_PRELOAD=");
             snprintf(var, sz, "LD_PRELOAD=%s %s %s", DYNAMORIO_PRELOAD_NAME,
-                     DYNAMORIO_LIBRARY_NAME, old);
+                     dynamorio_library_path, old);
             idx_preload = preload;
         } else {
             /* add new preload */
+            char *dynamorio_library_path = get_dynamorio_library_path();
             sz = strlen("LD_PRELOAD=") + strlen(DYNAMORIO_PRELOAD_NAME) +
-                strlen(DYNAMORIO_LIBRARY_NAME) + 2;
+                strlen(dynamorio_library_path) + 2;
             var = heap_alloc(dcontext, sizeof(char) * sz HEAPACCT(ACCT_OTHER));
             snprintf(var, sz, "LD_PRELOAD=%s %s", DYNAMORIO_PRELOAD_NAME,
-                     DYNAMORIO_LIBRARY_NAME);
+                     dynamorio_library_path);
             idx_preload = idx++;
         }
         *(var + sz - 1) = '\0'; /* null terminate */

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -8763,28 +8763,27 @@ get_dynamo_library_bounds(void)
     dynamo_dll_start = module_dynamorio_lib_base();
 #        endif
     check_start = dynamo_dll_start;
-    dynamorio_libname = IF_UNIT_TEST_ELSE(UNIT_TEST_EXE_NAME, DYNAMORIO_LIBRARY_NAME);
 #    endif /* STATIC_LIBRARY */
 
-#    if !defined(STATIC_LIBRARY) && defined(LINUX)
+#    ifdef STATIC_LIBRARY
+    res = memquery_library_bounds(dynamorio_libname, &check_start, &check_end,
+                                  dynamorio_library_path,
+                                  BUFFER_SIZE_ELEMENTS(dynamorio_library_path), NULL, 0);
+#    else  /* !STATIC_LIBRARY */
     static char dynamorio_libname_buf[MAXIMUM_PATH];
     res = memquery_library_bounds(NULL, &check_start, &check_end, dynamorio_library_path,
                                   BUFFER_SIZE_ELEMENTS(dynamorio_library_path),
                                   dynamorio_libname_buf,
                                   BUFFER_SIZE_ELEMENTS(dynamorio_libname_buf));
     dynamorio_libname = IF_UNIT_TEST_ELSE(UNIT_TEST_EXE_NAME, dynamorio_libname_buf);
-#    else
-    res = memquery_library_bounds(dynamorio_libname, &check_start, &check_end,
-                                  dynamorio_library_path,
-                                  BUFFER_SIZE_ELEMENTS(dynamorio_library_path), NULL, 0);
-#    endif
+#    endif /* STATIC_LIBRARY */
 
     LOG(GLOBAL, LOG_VMAREAS, 1, PRODUCT_NAME " library path: %s\n",
         dynamorio_library_path);
-    LOG(GLOBAL, LOG_VMAREAS, 1, PRODUCT_NAME " library file path: %s\n",
-        dynamorio_library_filepath);
     snprintf(dynamorio_library_filepath, BUFFER_SIZE_ELEMENTS(dynamorio_library_filepath),
              "%s%s", dynamorio_library_path, dynamorio_libname);
+    LOG(GLOBAL, LOG_VMAREAS, 1, PRODUCT_NAME " library file path: %s\n",
+        dynamorio_library_filepath);
     NULL_TERMINATE_BUFFER(dynamorio_library_filepath);
 #    if !defined(STATIC_LIBRARY) && defined(LINUX)
     ASSERT(check_start == dynamo_dll_start && check_end == dynamo_dll_end);

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -52,10 +52,8 @@
 
 #ifdef MACOS
 /* We end up de-referencing the symlink so we rely on a prefix match */
-#    define DYNAMORIO_LIBRARY_NAME "libdynamorio."
 #    define DYNAMORIO_PRELOAD_NAME "libdrpreload.dylib"
 #else
-#    define DYNAMORIO_LIBRARY_NAME "libdynamorio.so"
 #    define DYNAMORIO_PRELOAD_NAME "libdrpreload.so"
 #endif
 


### PR DESCRIPTION
Use get_dynamorio_library_path() instead of DYNAMORIO_LIBRARY_NAME in Linux memquery.

Fixes #3201