### PR TITLE
Fix Mac Travis breakage

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -5171,7 +5171,7 @@ master_signal_handler_C(byte *xsp)
      */
     IF_LINUX(ASSERT(dcontext == NULL || dcontext == GLOBAL_DCONTEXT ||
                     frame->uc.uc_stack.ss_sp ==
-                    ((thread_sig_info_t *)dcontext->signal_field)->sigstack.ss_sp));
+                        ((thread_sig_info_t *)dcontext->signal_field)->sigstack.ss_sp));
 
     /* restore protections */
     if (local)

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -159,6 +159,18 @@ for (my $i = 0; $i < $#lines; ++$i) {
             } else {
                 $issue_no = "#2417";
             }
+        } elsif ($^O eq 'darwin') {
+            %ignore_failures_32 = ('code_api|common.decode-bad' => 1, # i#3127
+                                   'code_api|linux.signal0000' => 1, # i#3127
+                                   'code_api|linux.signal0010' => 1, # i#3127
+                                   'code_api|linux.signal0100' => 1, # i#3127
+                                   'code_api|linux.signal0110' => 1, # i#3127
+                                   'code_api|linux.sigaction' => 1, # i#3127
+                                   'code_api|security-common.codemod' => 1, # i#3127
+                                   'code_api|client.crashmsg' => 1, # i#3127
+                                   'code_api|client.exception' => 1, # i#3127
+                                   'code_api|client.timer' => 1, # i#3127
+                                   'code_api|sample.signal' => 1); # i#3127
         } else {
             # FIXME i#2921: fix flaky ptsig test
             %ignore_failures_32 = ('code_api|pthreads.ptsig' => 1);


### PR DESCRIPTION
Fixes Mac build breakage from 49ee6922 #196.

Fixes Mac test failures from 036900c4 #3177: an assert was added that
should be disabled on Mac where the kernel does not restore the alt
stack from the frame.

Adds ignore rules for still-broken tests for #3127.

Issue: #3127, #196, #3177