### PR TITLE
i#2868 test failures: partial fix mix-native

### DIFF
--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -989,7 +989,7 @@ instr_set_target(instr_t *cti_instr, opnd_t target);
 INSTR_INLINE /* hot internally */
 #endif
     DR_API
-    /** Returns true iff \p instr's operands are up to date. */
+    /** Returns true if \p instr's operands are up to date. */
     bool
     instr_operands_valid(instr_t *instr);
 

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -989,7 +989,7 @@ instr_set_target(instr_t *cti_instr, opnd_t target);
 INSTR_INLINE /* hot internally */
 #endif
     DR_API
-    /** Returns true if \p instr's operands are up to date. */
+    /** Returns true iff \p instr's operands are up to date. */
     bool
     instr_operands_valid(instr_t *instr);
 

--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -1299,7 +1299,11 @@ instr_expand(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
         !instr_valid(instr))
         return instr;
 
-    DOLOG(5, LOG_ALL, { loginst(dcontext, 4, instr, "instr_expand"); });
+    DOLOG(5, LOG_ALL, {
+        instr_t *log_instr = instr_clone(dcontext, instr);
+        loginst(dcontext, 4, log_instr, "instr_expand");
+        instr_free(dcontext, log_instr);
+    });
 
     /* decode routines use dcontext mode, but we want instr mode */
     dr_set_isa_mode(dcontext, instr_get_isa_mode(instr), &old_mode);

--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -1300,6 +1300,8 @@ instr_expand(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
         return instr;
 
     DOLOG(5, LOG_ALL, {
+        /* disassembling might change the instruction object, we're cloning it
+         * for the logger */
         instr_t *log_instr = instr_clone(dcontext, instr);
         loginst(dcontext, 4, log_instr, "instr_expand");
         instr_free(dcontext, log_instr);

--- a/core/unix/native_elf.c
+++ b/core/unix/native_elf.c
@@ -142,6 +142,8 @@ find_dl_fixup(dcontext_t *dcontext, app_pc resolver)
                 "%s: found _dl_fixup call at " PFX ", _dl_fixup is " PFX ":\n",
                 __FUNCTION__, pc, fixup);
             break;
+        } else if (instr_is_return(&instr)) {
+            break;
         }
         instr_reset(dcontext, &instr);
     }

--- a/core/unix/native_elf.c
+++ b/core/unix/native_elf.c
@@ -125,24 +125,22 @@ find_dl_fixup(dcontext_t *dcontext, app_pc resolver)
 {
 #ifdef X86
     instr_t instr;
-    int max_decodes = 30;
+    int max_decodes = 225;
     int i = 0;
     app_pc pc = resolver;
     app_pc fixup = NULL;
 
-    LOG(THREAD, 5, LOG_LOADER, "%s: scanning for _dl_fixup call:\n", __FUNCTION__);
+    LOG(THREAD, LOG_LOADER, 5, "%s: scanning for _dl_fixup call:\n", __FUNCTION__);
     instr_init(dcontext, &instr);
-    while (pc != NULL && i < max_decodes) {
+    while (pc != NULL && i++ < max_decodes) {
         DOLOG(5, LOG_LOADER, { disassemble(dcontext, pc, THREAD); });
         pc = decode(dcontext, pc, &instr);
         if (instr_get_opcode(&instr) == OP_call) {
             opnd_t tgt = instr_get_target(&instr);
             fixup = opnd_get_pc(tgt);
-            LOG(THREAD, 1, LOG_LOADER,
+            LOG(THREAD, LOG_LOADER, 1,
                 "%s: found _dl_fixup call at " PFX ", _dl_fixup is " PFX ":\n",
                 __FUNCTION__, pc, fixup);
-            break;
-        } else if (instr_is_cti(&instr)) {
             break;
         }
         instr_reset(dcontext, &instr);

--- a/core/unix/native_elf.c
+++ b/core/unix/native_elf.c
@@ -125,7 +125,7 @@ find_dl_fixup(dcontext_t *dcontext, app_pc resolver)
 {
 #ifdef X86
     instr_t instr;
-    int max_decodes = 225;
+    const int max_decodes = 225;
     int i = 0;
     app_pc pc = resolver;
     app_pc fixup = NULL;


### PR DESCRIPTION
Partial fix for native -> non-native re-takeover. Fix look-up for _dl_fixup by searching for first CALL instruction. IAT style dll call re-takeover is tested in common.nativeexec. Minor logging fixes.

Issue: #2868