### PR TITLE
i#2868 pie/pic for native takeover: force plt stubs

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -549,7 +549,7 @@ function(add_exe test source)
   if (UNIX)
     # For common.nativeexec takeover tests, we do not support PIE. Newer (unix-) distri-
     # butions with toolchains may enable PIE by default. In order to be able take over the
-    # "PLT style" dll call (test with excutablee in native exec list), we expect the call
+    # "PLT style" dll call (test with executable in native exec list), we expect the call
     # to jump to a PLT stub first. However with PIe enabled, the compiler will generate a
     # rip-relative gotplt table call instead.
     CHECK_C_COMPILER_FLAG("-no-pie" no_pie_avail)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -553,10 +553,13 @@ function(add_exe test source)
     # native, exe in native list), we expect the call to jump to a PLT stub first. however with
     # pie/pic, the compiler will generate a rip-relative gotplt table call instead. we do not have
     # support to takeover such calls AFAIK
-    set_source_files_properties(common/nativeexec.c PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -fno-pie")
-    if ("${test}" MATCHES "common.nativeexec")
-      get_target_property(cur_ldflags ${test} LINK_FLAGS)
-      set_target_properties(common.nativeexec PROPERTIES LINK_FLAGS "-no-pie ${cur_ldflags}")
+    CHECK_C_COMPILER_FLAG("-no-pie" no_pie_avail)
+    if (no_pie_avail)
+      set_source_files_properties(common/nativeexec.c PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -fno-pie")
+      if ("${test}" MATCHES "common.nativeexec")
+        get_target_property(cur_ldflags ${test} LINK_FLAGS)
+        set_target_properties(common.nativeexec PROPERTIES LINK_FLAGS "-no-pie ${cur_ldflags}")
+      endif()
     endif()
     # This is kind of a hack: perhaps we should add a flag for whether to use libs.
     if (NOT ${source} MATCHES "\\.asm$" AND NOT ${test} MATCHES "static"

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -536,7 +536,6 @@ function(add_exe test source)
   endif ("${srccode}" MATCHES "include \"test.*annotation.*.h\"")
 
   add_executable(${test} ${test_srcs})
-
   if (DEFINED ${test}_outname)
     set_target_properties(${test} PROPERTIES OUTPUT_NAME "${${test}_outname}")
   endif ()
@@ -558,9 +557,7 @@ function(add_exe test source)
       set_source_files_properties(common/nativeexec.c PROPERTIES COMPILE_FLAGS
         "${CMAKE_C_FLAGS} -fno-pie")
       if ("${test}" MATCHES "common.nativeexec")
-        get_target_property(cur_ldflags ${test} LINK_FLAGS)
-        set_target_properties(common.nativeexec PROPERTIES LINK_FLAGS
-          "-no-pie ${cur_ldflags}")
+        append_link_flags(${test} "-no-pie")
       endif()
     endif()
     # This is kind of a hack: perhaps we should add a flag for whether to use libs.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -536,6 +536,7 @@ function(add_exe test source)
   endif ("${srccode}" MATCHES "include \"test.*annotation.*.h\"")
 
   add_executable(${test} ${test_srcs})
+
   if (DEFINED ${test}_outname)
     set_target_properties(${test} PROPERTIES OUTPUT_NAME "${${test}_outname}")
   endif ()
@@ -547,6 +548,16 @@ function(add_exe test source)
     # it hard to use other DR builds w/ these apps
     SKIP_BUILD_RPATH ON)
   if (UNIX)
+    # for common.nativeexec takeover tests, we do not support -pie/pic. newer (unix-) distributions
+    # with toolchains that enabled pie/pic by default. to takeover the "PLT style" dll call (dll not
+    # native, exe in native list), we expect the call to jump to a PLT stub first. however with
+    # pie/pic, the compiler will generate a rip-relative gotplt table call instead. we do not have
+    # support to takeover such calls AFAIK
+    set_source_files_properties(common/nativeexec.c PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -fno-pie")
+    if ("${test}" MATCHES "common.nativeexec")
+      get_target_property(cur_ldflags ${test} LINK_FLAGS)
+      set_target_properties(common.nativeexec PROPERTIES LINK_FLAGS "-no-pie ${cur_ldflags}")
+    endif()
     # This is kind of a hack: perhaps we should add a flag for whether to use libs.
     if (NOT ${source} MATCHES "\\.asm$" AND NOT ${test} MATCHES "static"
         AND NOT ${test} MATCHES "drdecode")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -548,17 +548,19 @@ function(add_exe test source)
     # it hard to use other DR builds w/ these apps
     SKIP_BUILD_RPATH ON)
   if (UNIX)
-    # for common.nativeexec takeover tests, we do not support -pie/pic. newer (unix-) distributions
-    # with toolchains that enabled pie/pic by default. to takeover the "PLT style" dll call (dll not
-    # native, exe in native list), we expect the call to jump to a PLT stub first. however with
-    # pie/pic, the compiler will generate a rip-relative gotplt table call instead. we do not have
-    # support to takeover such calls AFAIK
+    # For common.nativeexec takeover tests, we do not support -pie/pic. newer (unix-)
+    # distributions with toolchains that enabled pie/pic by default. To takeover the "PLT
+    # style" dll call (dll not native, exe in native list), we expect the call to jump to
+    # a PLT stub first. However with pie/pic, the compiler will generate a rip-relative
+    # gotplt table call instead. We do not have support to takeover such calls AFAIK.
     CHECK_C_COMPILER_FLAG("-no-pie" no_pie_avail)
     if (no_pie_avail)
-      set_source_files_properties(common/nativeexec.c PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -fno-pie")
+      set_source_files_properties(common/nativeexec.c PROPERTIES COMPILE_FLAGS
+        "${CMAKE_C_FLAGS} -fno-pie")
       if ("${test}" MATCHES "common.nativeexec")
         get_target_property(cur_ldflags ${test} LINK_FLAGS)
-        set_target_properties(common.nativeexec PROPERTIES LINK_FLAGS "-no-pie ${cur_ldflags}")
+        set_target_properties(common.nativeexec PROPERTIES LINK_FLAGS
+          "-no-pie ${cur_ldflags}")
       endif()
     endif()
     # This is kind of a hack: perhaps we should add a flag for whether to use libs.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -548,11 +548,11 @@ function(add_exe test source)
     # it hard to use other DR builds w/ these apps
     SKIP_BUILD_RPATH ON)
   if (UNIX)
-    # For common.nativeexec takeover tests, we do not support -pie/pic. newer (unix-)
-    # distributions with toolchains that enabled pie/pic by default. To takeover the "PLT
-    # style" dll call (dll not native, exe in native list), we expect the call to jump to
-    # a PLT stub first. However with pie/pic, the compiler will generate a rip-relative
-    # gotplt table call instead. We do not have support to takeover such calls AFAIK.
+    # For common.nativeexec takeover tests, we do not support PIE. Newer (unix-) distri-
+    # butions with toolchains may enable PIE by default. In order to be able take over the
+    # "PLT style" dll call (test with excutablee in native exec list), we expect the call
+    # to jump to a PLT stub first. However with PIe enabled, the compiler will generate a
+    # rip-relative gotplt table call instead.
     CHECK_C_COMPILER_FLAG("-no-pie" no_pie_avail)
     if (no_pie_avail)
       set_source_files_properties(common/nativeexec.c PROPERTIES COMPILE_FLAGS


### PR DESCRIPTION
In native executable to DR controlled dll takeover test, we need PLT stubs to work. This is adding no-pie option for these tests, as some newer unix distrubutions enable pie/pic by default.

Issue: #2868