### PR TITLE
i#3203: Add a microbenchmark to test the cache miss analyzer

### DIFF
--- a/clients/drcachesim/tests/miss_analyzer.templatex
+++ b/clients/drcachesim/tests/miss_analyzer.templatex
@@ -1,2 +1,4 @@
+Value = [0-9]+
+---- <application exited with code 0> ----
 Cache miss analyzer results:
 pc=0x[0-9a-f]+, stride=448, locality=nta

--- a/clients/drcachesim/tests/miss_analyzer.templatex
+++ b/clients/drcachesim/tests/miss_analyzer.templatex
@@ -1,0 +1,2 @@
+Cache miss analyzer results:
+pc=0x[0-9a-f]+, stride=448, locality=nta

--- a/clients/drcachesim/tests/stride_benchmark.cpp
+++ b/clients/drcachesim/tests/stride_benchmark.cpp
@@ -34,6 +34,8 @@
  * (LLC) misses. SW prefetching can significantly improve its performance.
  */
 
+#include <string.h>
+#include <cstdint>
 #include <iostream>
 #include <vector>
 
@@ -43,16 +45,17 @@ int
 main(int argc, const char *argv[])
 {
     // Cache line size in bytes.
-    static constexpr int kLineSize = 64;
+    const int kLineSize = 64;
     // Number of cache lines skipped by the stream every iteration.
-    static constexpr int kStride = 7;
+    const int kStride = 7;
     // Number of 1-byte elements in the array.
     // (200+ MiB to guarantee the array doesn't fit in Skylake caches)
-    static constexpr size_t kArraySize = 512 * 1024 * 1024;
+    const size_t kArraySize = 512 * 1024 * 1024;
     // Number of iterations in the main loop.
-    static constexpr int kIterations = 5000000;
+    const int kIterations = 3000000;
     // The main vector/array used for emulating pointer chasing.
-    std::vector<uint8_t> buffer(kArraySize, kStride);
+    uint8_t *buffer = new uint8_t[kArraySize];
+    memset(buffer, kStride, kArraySize);
 
     // Add a memory barrier so the call doesn't get optimized away or
     // reordered with respect to callers.
@@ -66,7 +69,7 @@ main(int argc, const char *argv[])
     for (int loop = 0; loop < kIterations; ++loop) {
         // This prefetching instruction results in a speedup of ~3x
         // on a Skylake machine running Linux when compiled with g++ -O3.
-        // constexpr int prefetch_distance = 5 * kStride * kLineSize;
+        // const int prefetch_distance = 5 * kStride * kLineSize;
         // __builtin_prefetch(&buffer[position + prefetch_distance], 0, 0);
 
         position += (buffer[position] * kLineSize);

--- a/clients/drcachesim/tests/stride_benchmark.cpp
+++ b/clients/drcachesim/tests/stride_benchmark.cpp
@@ -37,7 +37,7 @@
 #include <iostream>
 #include <vector>
 
-#define MEM_BARRIER __asm__ __volatile__("" ::: "memory");
+#define MEM_BARRIER() __asm__ __volatile__("" ::: "memory")
 
 int
 main(int argc, const char *argv[])
@@ -56,9 +56,9 @@ main(int argc, const char *argv[])
 
     // Add a memory barrier so the call doesn't get optimized away or
     // reordered with respect to callers.
-    MEM_BARRIER
+    MEM_BARRIER();
 
-    int64_t position = 0;
+    int position = 0;
 
     // Here the code will pointer chase through the array skipping forward
     // kStride cache lines at a time. Since kStride is an odd number, the main
@@ -75,7 +75,7 @@ main(int argc, const char *argv[])
 
     // Add a memory barrier so the call doesn't get optimized away or
     // reordered with respect to callers.
-    MEM_BARRIER
+    MEM_BARRIER();
 
     std::cerr << "Value = " << position << std::endl;
 

--- a/clients/drcachesim/tests/stride_benchmark.cpp
+++ b/clients/drcachesim/tests/stride_benchmark.cpp
@@ -34,10 +34,9 @@
  * (LLC) misses. SW prefetching can significantly improve its performance.
  */
 
+#include <stdint.h>
 #include <string.h>
-#include <cstdint>
 #include <iostream>
-#include <vector>
 
 #define MEM_BARRIER() __asm__ __volatile__("" ::: "memory")
 
@@ -52,9 +51,9 @@ main(int argc, const char *argv[])
     // (200+ MiB to guarantee the array doesn't fit in Skylake caches)
     const size_t kArraySize = 512 * 1024 * 1024;
     // Number of iterations in the main loop.
-    const int kIterations = 3000000;
+    const int kIterations = 1000000;
     // The main vector/array used for emulating pointer chasing.
-    uint8_t *buffer = new uint8_t[kArraySize];
+    unsigned char *buffer = new unsigned char[kArraySize];
     memset(buffer, kStride, kArraySize);
 
     // Add a memory barrier so the call doesn't get optimized away or
@@ -67,7 +66,7 @@ main(int argc, const char *argv[])
     // kStride cache lines at a time. Since kStride is an odd number, the main
     // loop will touch different cache lines as it wraps around.
     for (int loop = 0; loop < kIterations; ++loop) {
-        // This prefetching instruction results in a speedup of ~3x
+        // This prefetching instruction results in a speedup of >2x
         // on a Skylake machine running Linux when compiled with g++ -O3.
         // const int prefetch_distance = 5 * kStride * kLineSize;
         // __builtin_prefetch(&buffer[position + prefetch_distance], 0, 0);

--- a/clients/drcachesim/tests/stride_benchmark.cpp
+++ b/clients/drcachesim/tests/stride_benchmark.cpp
@@ -1,0 +1,83 @@
+/* **********************************************************
+ * Copyright (c) 2018 Google LLC  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE LLC OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* This microbenchmark suffers from a significant number of last-level cache
+ * (LLC) misses. SW prefetching can significantly improve its performance.
+ */
+
+#include <iostream>
+#include <vector>
+
+#define MEM_BARRIER __asm__ __volatile__("" ::: "memory");
+
+int
+main(int argc, const char *argv[])
+{
+    // Cache line size in bytes.
+    static constexpr int kLineSize = 64;
+    // Number of cache lines skipped by the stream every iteration.
+    static constexpr int kStride = 7;
+    // Number of 1-byte elements in the array.
+    // (200+ MiB to guarantee the array doesn't fit in Skylake caches)
+    static constexpr size_t kArraySize = 512 * 1024 * 1024;
+    // Number of iterations in the main loop.
+    static constexpr int kIterations = 5000000;
+    // The main vector/array used for emulating pointer chasing.
+    std::vector<uint8_t> buffer(kArraySize, kStride);
+
+    // Add a memory barrier so the call doesn't get optimized away or
+    // reordered with respect to callers.
+    MEM_BARRIER
+
+    int64_t position = 0;
+
+    // Here the code will pointer chase through the array skipping forward
+    // kStride cache lines at a time. Since kStride is an odd number, the main
+    // loop will touch different cache lines as it wraps around.
+    for (int loop = 0; loop < kIterations; ++loop) {
+        // This prefetching instruction results in a speedup of ~3x
+        // on a Skylake machine running Linux when compiled with g++ -O3.
+        // constexpr int prefetch_distance = 5 * kStride * kLineSize;
+        // __builtin_prefetch(&buffer[position + prefetch_distance], 0, 0);
+
+        position += (buffer[position] * kLineSize);
+        position &= (kArraySize - 1);
+    }
+
+    // Add a memory barrier so the call doesn't get optimized away or
+    // reordered with respect to callers.
+    MEM_BARRIER
+
+    std::cerr << "Value = " << position << std::endl;
+
+    return 0;
+}

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2585,11 +2585,12 @@ endif ()
           ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/multiproc.c)
         get_target_path_for_execution(tool.multiproc_path tool.multiproc)
         torunonly_drcachesim(multiproc tool.multiproc "" "${tool.multiproc_path}")
+      endif ()
 
-        # Test the cache miss analyzer
+      # Test the cache miss analyzer.
+      if (UNIX)
         add_exe(stride_benchmark
           ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/stride_benchmark.cpp)
-        # get_target_path_for_execution(stride_benchmark_path stride_benchmark)
         torunonly_drcachesim(miss_analyzer stride_benchmark "-simulator_type miss_analyzer" "")
       endif ()
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2539,12 +2539,6 @@ endif ()
       # Test that warmup was enabled but not triggered.
       torunonly_drcachesim(warmup-zeros ${ci_shared_app} "-warmup_refs 1000000000" "")
 
-      # Test the cache miss analyzer
-      add_exe(stride_benchmark
-        ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/stride_benchmark.cpp)
-      # get_target_path_for_execution(tool.stride_benchmark_path tool.stride_benchmark)
-      torunonly_drcachesim(miss_analyzer stride_benchmark "-simulator_type miss_analyzer" "")
-
       # FIXME i#1799: clang does not support "asm goto" used in annotation
       # FIXME i#1551, i#1569: get working on ARM/AArch64
       if (NOT ARM AND NOT AARCH64 AND NOT CMAKE_COMPILER_IS_CLANG)
@@ -2591,6 +2585,12 @@ endif ()
           ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/multiproc.c)
         get_target_path_for_execution(tool.multiproc_path tool.multiproc)
         torunonly_drcachesim(multiproc tool.multiproc "" "${tool.multiproc_path}")
+
+        # Test the cache miss analyzer
+        add_exe(stride_benchmark
+          ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/stride_benchmark.cpp)
+        # get_target_path_for_execution(stride_benchmark_path stride_benchmark)
+        torunonly_drcachesim(miss_analyzer stride_benchmark "-simulator_type miss_analyzer" "")
       endif ()
 
       # Test other analysis tools

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2539,6 +2539,12 @@ endif ()
       # Test that warmup was enabled but not triggered.
       torunonly_drcachesim(warmup-zeros ${ci_shared_app} "-warmup_refs 1000000000" "")
 
+      # Test the cache miss analyzer
+      add_exe(stride_benchmark
+        ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/stride_benchmark.cpp)
+      # get_target_path_for_execution(tool.stride_benchmark_path tool.stride_benchmark)
+      torunonly_drcachesim(miss_analyzer stride_benchmark "-simulator_type miss_analyzer" "")
+
       # FIXME i#1799: clang does not support "asm goto" used in annotation
       # FIXME i#1551, i#1569: get working on ARM/AArch64
       if (NOT ARM AND NOT AARCH64 AND NOT CMAKE_COMPILER_IS_CLANG)


### PR DESCRIPTION
Adds a microbenchmark to test the newly added LLC miss analyzer.