### PR TITLE
Add an example in the documentation for the cache miss analyzer

### DIFF
--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -734,6 +734,13 @@ To invoke the miss analyzer, pass \p miss_analyzer to the \p -simulator_type
 parameter. To write the prefetching hints to a file use the \p -LL_miss_file
 parameter to specify the file's path and name.
 
+For example, to run the analyzer on a benchmark called "my_benchmark" and store
+the prefetching recommendations in a file called "rec.csv", run the following:
+
+\code
+$ bin64/drrun -t drcachesim -simulator_type miss_analyzer -LL_miss_file rec.csv -- my_benchmark
+\endcode
+
 
 ****************************************************************************
 \section sec_drcachesim_phys Physical Addresses


### PR DESCRIPTION
Adds an example in the documentation for the cache miss analyzer to show how to run the analyzer on a test program.