### PR TITLE
Extends hashtable_apply_to_all_payloads

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -259,6 +259,8 @@ Further non-compatibility-affecting changes include:
    and drmgr_get_emulated_instr_data().
  - Added drmgr_register_signal_event_user_data() and
    drmgr_unregister_signal_event_user_data() to enable passing of user data.
+ - Added hashtable_apply_to_all_payloads_user_data() to iterate over all payloads
+   in a hashtable with user data also available.
 
 **************************************************
 <hr>

--- a/ext/drcontainers/hashtable.c
+++ b/ext/drcontainers/hashtable.c
@@ -472,6 +472,24 @@ hashtable_apply_to_all_payloads(hashtable_t *table, void (*apply_func)(void *pay
     }
 }
 
+void
+hashtable_apply_to_all_payloads_ex(hashtable_t *table, void (*apply_func)(void *payload,
+		                                                                  void *user_data),
+				                   void *user_data)
+{
+    DR_ASSERT_MSG(apply_func != NULL, "The apply_func ptr cannot be NULL.");
+    uint i;
+    for (i = 0; i < HASHTABLE_SIZE(table->table_bits); i++) {
+        hash_entry_t *e = table->table[i];
+        while (e != NULL) {
+            hash_entry_t *nexte = e->next;
+            apply_func(e->payload, user_data);
+            e = nexte;
+        }
+    }
+}
+
+
 static void
 hashtable_clear_internal(hashtable_t *table)
 {

--- a/ext/drcontainers/hashtable.c
+++ b/ext/drcontainers/hashtable.c
@@ -476,7 +476,7 @@ void
 hashtable_apply_to_all_payloads_user_data(hashtable_t *table,
                                           void (*apply_func)(void *payload,
                                                              void *user_data),
-				          void *user_data)
+                                          void *user_data)
 {
     DR_ASSERT_MSG(apply_func != NULL, "The apply_func ptr cannot be NULL.");
     uint i;
@@ -489,7 +489,6 @@ hashtable_apply_to_all_payloads_user_data(hashtable_t *table,
         }
     }
 }
-
 
 static void
 hashtable_clear_internal(hashtable_t *table)

--- a/ext/drcontainers/hashtable.c
+++ b/ext/drcontainers/hashtable.c
@@ -473,9 +473,10 @@ hashtable_apply_to_all_payloads(hashtable_t *table, void (*apply_func)(void *pay
 }
 
 void
-hashtable_apply_to_all_payloads_ex(hashtable_t *table, void (*apply_func)(void *payload,
-		                                                                  void *user_data),
-				                   void *user_data)
+hashtable_apply_to_all_payloads_user_data(hashtable_t *table,
+                                          void (*apply_func)(void *payload,
+                                                             void *user_data),
+				          void *user_data)
 {
     DR_ASSERT_MSG(apply_func != NULL, "The apply_func ptr cannot be NULL.");
     uint i;

--- a/ext/drcontainers/hashtable.h
+++ b/ext/drcontainers/hashtable.h
@@ -203,12 +203,12 @@ void
 hashtable_apply_to_all_payloads(hashtable_t *table, void (*apply_func)(void *payload));
 
 /**
- * Calls the \p apply_func for each payload with user data. Similar to 
+ * Calls the \p apply_func for each payload with user data. Similar to
  * hashtable_apply_to_all_payloads().
  * @param table The hashtable to apply the function.
  * @param apply_func A pointer to a function that is called for all payloads
  * stored in the map. It also takes user data as a parameter.
- * @param user_data User data that is available when iterating through payloads. 
+ * @param user_data User data that is available when iterating through payloads.
  */
 void
 hashtable_apply_to_all_payloads_user_data(hashtable_t *table,

--- a/ext/drcontainers/hashtable.h
+++ b/ext/drcontainers/hashtable.h
@@ -203,6 +203,19 @@ void
 hashtable_apply_to_all_payloads(hashtable_t *table, void (*apply_func)(void *payload));
 
 /**
+ * Calls the \p apply_func for each payload with user data. Similar to 
+ * hashtable_apply_to_all_payloads().
+ * @param table The hashtable to apply the function.
+ * @param apply_func A pointer to a function that is called for all payloads
+ * stored in the map. It also takes user data as a parameter. 
+ */
+void
+hashtable_apply_to_all_payloads_user_data(hashtable_t *table,
+                                          void (*apply_func)(void *payload,
+                                                             void *user_data),
+                                          void *user_data);
+
+/**
  * Removes all entries from the table.  If free_payload_func was specified
  * calls it for each payload.
  */

--- a/ext/drcontainers/hashtable.h
+++ b/ext/drcontainers/hashtable.h
@@ -207,7 +207,8 @@ hashtable_apply_to_all_payloads(hashtable_t *table, void (*apply_func)(void *pay
  * hashtable_apply_to_all_payloads().
  * @param table The hashtable to apply the function.
  * @param apply_func A pointer to a function that is called for all payloads
- * stored in the map. It also takes user data as a parameter. 
+ * stored in the map. It also takes user data as a parameter.
+ * @param user_data User data that is available when iterating through payloads. 
  */
 void
 hashtable_apply_to_all_payloads_user_data(hashtable_t *table,

--- a/suite/tests/client-interface/drcontainers-test.dll.c
+++ b/suite/tests/client-interface/drcontainers-test.dll.c
@@ -162,20 +162,18 @@ test_hashtable_apply_all_user_data(void)
     hashtable_apply_to_all_payloads_user_data(&hash_table, sum_user_data, (void *)1);
     CHECK(c == hash_table.entries,
           "hashtable_apply_to_all_payloads_user_data (count test) failed");
-    CHECK(total == (6+hash_table.entries),
+    CHECK(total == (6 + hash_table.entries),
           "hashtable_apply_to_all_payloads_user_data (sum test) failed");
 
     /* Begin NULL Tests */
     c = 0;
     total = 0;
 
-    hashtable_apply_to_all_payloads_user_data(&hash_table, count_null_user_data,
-                                              NULL);
+    hashtable_apply_to_all_payloads_user_data(&hash_table, count_null_user_data, NULL);
     hashtable_apply_to_all_payloads_user_data(&hash_table, sum_user_data, NULL);
     CHECK(c == hash_table.entries,
           "hashtable_apply_to_all_payloads_user_data (count null test) failed");
-    CHECK(total == 6,
-          "hashtable_apply_to_all_payloads_user_data (sum null test) failed");
+    CHECK(total == 6, "hashtable_apply_to_all_payloads_user_data (sum null test) failed");
 
     hashtable_delete(&hash_table);
 }

--- a/suite/tests/client-interface/drcontainers-test.dll.c
+++ b/suite/tests/client-interface/drcontainers-test.dll.c
@@ -98,7 +98,7 @@ static void
 count_user_data(void *payload, void *user_data)
 {
     c++;
-    CHECK(user_data == apply_payload_user_data_test, "user data not correct");
+    CHECK(user_data == (void *)apply_payload_user_data_test, "user data not correct");
 }
 
 static void
@@ -158,7 +158,7 @@ test_hashtable_apply_all_user_data(void)
     hashtable_add_replace(&hash_table, (void *)3, (void *)3);
 
     hashtable_apply_to_all_payloads_user_data(&hash_table, count_user_data,
-                                              apply_payload_user_data_test);
+                                              (void *)apply_payload_user_data_test);
     hashtable_apply_to_all_payloads_user_data(&hash_table, sum_user_data, (void *)1);
     CHECK(c == hash_table.entries,
           "hashtable_apply_to_all_payloads_user_data (count test) failed");
@@ -171,7 +171,7 @@ test_hashtable_apply_all_user_data(void)
 
     hashtable_apply_to_all_payloads_user_data(&hash_table, count_null_user_data,
                                               NULL);
-    hashtable_apply_to_all_payloads_user_data(&hash_table, sum, NULL);
+    hashtable_apply_to_all_payloads_user_data(&hash_table, sum_user_data, NULL);
     CHECK(c == hash_table.entries,
           "hashtable_apply_to_all_payloads_user_data (count null test) failed");
     CHECK(total == 6,
@@ -185,6 +185,7 @@ dr_init(client_id_t id)
 {
     test_vector();
     test_hashtable_apply_all();
+    test_hashtable_apply_all_user_data();
 
-    /* XXX: test other data structures */`
+    /* XXX: test other data structures */
 }

--- a/suite/tests/client-interface/drcontainers-test.dll.c
+++ b/suite/tests/client-interface/drcontainers-test.dll.c
@@ -85,6 +85,8 @@ test_vector(void)
 }
 
 unsigned int c;
+static const uintptr_t apply_payload_user_data_test = 2323;
+uintptr_t total;
 
 static void
 count(void *payload)
@@ -92,12 +94,31 @@ count(void *payload)
     c++;
 }
 
-uintptr_t total;
+static void
+count_user_data(void *payload, void *user_data)
+{
+    c++;
+    CHECK(user_data == apply_payload_user_data_test, "user data not correct");
+}
+
+static void
+count_null_user_data(void *payload, void *user_data)
+{
+    c++;
+    CHECK(user_data == NULL, "user data not null");
+}
 
 static void
 sum(void *payload)
 {
     total += (uintptr_t)payload;
+}
+
+static void
+sum_user_data(void *payload, void *user_data)
+{
+    total += (uintptr_t)payload;
+    total += (uintptr_t)user_data;
 }
 
 static void
@@ -122,11 +143,48 @@ test_hashtable_apply_all(void)
     hashtable_delete(&hash_table);
 }
 
+static void
+test_hashtable_apply_all_user_data(void)
+{
+    hashtable_t hash_table;
+    hashtable_init(&hash_table, 8, HASH_INTPTR, false);
+
+    /* Begin Data Tests */
+    c = 0;
+    total = 0;
+
+    hashtable_add_replace(&hash_table, (void *)1, (void *)1);
+    hashtable_add_replace(&hash_table, (void *)2, (void *)2);
+    hashtable_add_replace(&hash_table, (void *)3, (void *)3);
+
+    hashtable_apply_to_all_payloads_user_data(&hash_table, count_user_data,
+                                              apply_payload_user_data_test);
+    hashtable_apply_to_all_payloads_user_data(&hash_table, sum_user_data, (void *)1);
+    CHECK(c == hash_table.entries,
+          "hashtable_apply_to_all_payloads_user_data (count test) failed");
+    CHECK(total == (6+hash_table.entries),
+          "hashtable_apply_to_all_payloads_user_data (sum test) failed");
+
+    /* Begin NULL Tests */
+    c = 0;
+    total = 0;
+
+    hashtable_apply_to_all_payloads_user_data(&hash_table, count_null_user_data,
+                                              NULL);
+    hashtable_apply_to_all_payloads_user_data(&hash_table, sum, NULL);
+    CHECK(c == hash_table.entries,
+          "hashtable_apply_to_all_payloads_user_data (count null test) failed");
+    CHECK(total == 6,
+          "hashtable_apply_to_all_payloads_user_data (sum null test) failed");
+
+    hashtable_delete(&hash_table);
+}
+
 DR_EXPORT void
 dr_init(client_id_t id)
 {
     test_vector();
     test_hashtable_apply_all();
 
-    /* XXX: test other data structures */
+    /* XXX: test other data structures */`
 }


### PR DESCRIPTION
Extends hashtable_apply_to_all_payloads() by proposing an additional function hashtable_apply_to_all_payloads_user_data(), which makes user data available when iterating over payloads.

This pull request also contains tests.