### PR TITLE
DrMi#2132: add Mac High Sierra support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,8 @@ jobs:
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=32_only
       # XXX i#2764: Travis OSX resources are over-subscribed and it can take
       # hours to get an OSX machine, so we skip running PR's for now.
-      if: type = push
+# TEMPORARY to test Mac in this PR:
+#      if: type = push
 
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -687,7 +687,7 @@ DYNAMIC_OPTION(bool, pause_via_loop,
 
     /* For MacOS, set to 0 to disable the check */
     OPTION_DEFAULT(uint, max_supported_os_version,
-        IF_WINDOWS_ELSE(105, IF_MACOS_ELSE(15, 0)),
+        IF_WINDOWS_ELSE(105, IF_MACOS_ELSE(17, 0)),
         /* case 447, defaults to supporting NT, 2000, XP, 2003, and Vista.
          * Windows 7 added with i#218
          * Windows 8 added with i#565


### PR DESCRIPTION
Increases max_supported_os_version for Mac to 17.
Adds a MACOS_VERSION_HIGH_SIERRA define.

Removes an ASSERT_NOT_TESTED from LDT cleanup which is now exercised
on every app exit and works

Relaxes a curiosity on seeing an already-known module during the
address space walk on Mac, as we've already walked the dyld module
list beforehand

Issue: DynamoRIO/drmemory/issues/2132
