### PR TITLE
i#3245: Fix the cache miss analyzer tests

### DIFF
--- a/clients/drcachesim/tests/stride_benchmark.cpp
+++ b/clients/drcachesim/tests/stride_benchmark.cpp
@@ -61,9 +61,9 @@ main(int argc, const char *argv[])
     const int kStride = 7;
     // Number of 1-byte elements in the array.
     // (200+ MiB to guarantee the array doesn't fit in Skylake caches)
-    const size_t kArraySize = 512 * 1024 * 1024;
+    const size_t kArraySize = 256 * 1024 * 1024;
     // Number of iterations in the main loop.
-    const int kIterations = 1000000;
+    const int kIterations = 500000;
     // The main vector/array used for emulating pointer chasing.
     unsigned char *buffer = new unsigned char[kArraySize];
     memset(buffer, kStride, kArraySize);


### PR DESCRIPTION
Fix the flaky benchmark test (tool.drcachesim.miss_analyzer) which is occasionally timing out. The number of iterations in the benchmark's main loop is halved. Also, fix the analyzer's unit test (tool.drcachesim.miss_analyzer_unit_test) which was not signaling a failure when it actually failed.

Fixes #3245