### PR TITLE
i#2270 itimer detach: Remove alarm handlers before synching with threads.

### DIFF
--- a/core/synch.c
+++ b/core/synch.c
@@ -2060,6 +2060,11 @@ detach_on_permanent_stack(bool internal, bool do_cleanup, dr_stats_t *drstats)
 #    endif
 #endif
 
+#ifdef UNIX
+    /* i#2270: we ignore alarm signals during detach to reduce races. */
+    signal_remove_alarm_handlers(my_dcontext);
+#endif
+
     /* suspend all DR-controlled threads at safe locations */
     if (!synch_with_all_threads(THREAD_SYNCH_SUSPENDED_VALID_MCONTEXT, &threads,
                                 &num_threads,
@@ -2119,9 +2124,6 @@ detach_on_permanent_stack(bool internal, bool do_cleanup, dr_stats_t *drstats)
     /* Release the APC init lock and let any threads waiting there go native */
     LOG(GLOBAL, LOG_ALL, 1, "Detach : Releasing init_apc_go_native_pause\n");
     init_apc_go_native_pause = false;
-#else
-    /* i#2270: we ignore alarm signals during detach to reduce races. */
-    signal_remove_alarm_handlers(my_dcontext);
 #endif
 
     /* perform exit tasks that require full thread data structs */


### PR DESCRIPTION
If an alarm is received by a thread after it has blocked in
check_wait_at_safe_spot but before the detaching thread sends the
SUSPEND_SIGNAL, it is possible the fcache_unit_areas lock is being held in
record_pending_signal when the SUSPEND_SIGNAL is received. Since the
receiving thread was already marked as waiting at a safe spot, we
synchronize with the thread and detach it, and the fcache_unit_areas
lock is never unlocked.

Issue: #2270