### PR TITLE
i#1557 cmake LOCATION: eliminate remaining LOCATION property uses

### DIFF
--- a/api/samples/CMakeLists.txt
+++ b/api/samples/CMakeLists.txt
@@ -57,8 +57,6 @@ project(DynamoRIO_samples)
 
 if ("${CMAKE_VERSION}" VERSION_EQUAL "3.0" OR
     "${CMAKE_VERSION}" VERSION_GREATER "3.0")
-  # XXX i#1557: update our code to satisfy the changes in 3.x
-  cmake_policy(SET CMP0026 OLD)
   # XXX i#1375: if we make 2.8.12 the minimum we can remove the @rpath
   # Mac stuff and this policy, right?
   cmake_policy(SET CMP0042 OLD)
@@ -314,9 +312,7 @@ DR_install(FILES "${public_clist}"
   DESTINATION "${INSTALL_SAMPLES}" RENAME CMakeLists.txt)
 if (WIN32)                                                          # NON-PUBLIC
   # Have a copy of dynamorio library for tracedump.                 # NON-PUBLIC
-  # XXX i#1557: replace w/ generator expression to satisfy CMP0026. # NON-PUBLIC
-  get_target_property(DR_TARGET_LOCATION dynamorio                  # NON-PUBLIC
-    LOCATION${location_suffix})                                     # NON-PUBLIC
+  DynamoRIO_get_full_path(DR_TARGET_LOCATION dynamorio)             # NON-PUBLIC
   DR_install(FILES "${DR_TARGET_LOCATION}"                          # NON-PUBLIC
     DESTINATION "${INSTALL_SAMPLES_BIN}")                           # NON-PUBLIC
 endif (WIN32)                                                       # NON-PUBLIC

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -417,11 +417,9 @@ register_tool_file("drcachesim")
 
 if (WIN32)
   # drcachesim needs these dlls (i#1737 would eliminate this)
-  # XXX i#1557: replace w/ generator expression to satisfy CMP0026
-  get_target_property(injectlib_loc drinjectlib LOCATION${location_suffix})
+  DynamoRIO_get_full_path(injectlib_loc drinjectlib)
   DR_install(FILES "${injectlib_loc}"  DESTINATION "${INSTALL_CLIENTS_BIN}")
-  # XXX i#1557: replace w/ generator expression to satisfy CMP0026
-  get_target_property(configlib_loc drconfiglib LOCATION${location_suffix})
+  DynamoRIO_get_full_path(configlib_loc drconfiglib)
   DR_install(FILES "${configlib_loc}"  DESTINATION "${INSTALL_CLIENTS_BIN}")
   add_custom_command(TARGET drcachesim POST_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_BASE_DIRECTORY}/drinjectlib.dll

--- a/clients/drcov/CMakeLists.txt
+++ b/clients/drcov/CMakeLists.txt
@@ -99,8 +99,7 @@ install_target(drcov2lcov ${INSTALL_CLIENTS_BIN})
 
 # On Linux we rely on the rpath
 if (WIN32)
-  # XXX i#1557: replace w/ generator expression to satisfy CMP0026
-  get_target_property(DR_TARGET_LOCATION dynamorio LOCATION${location_suffix})
+  DynamoRIO_get_full_path(DR_TARGET_LOCATION dynamorio)
   DR_install(FILES "${DR_TARGET_LOCATION}"  DESTINATION "${INSTALL_CLIENTS_BIN}")
   # i#1344: Include a copy of a recent (> 6.0) redistributable version of dbghelp,
   # if we found one, so our drcov2lcov works pre-Vista.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -269,8 +269,7 @@ if (WIN32)
   add_library(ntdll_imports SHARED win32/ntdll_imports.c ${ntimp_def})
   # i#1137: ignore 'specified multiple times' linker warnings
   append_property_string(TARGET ntdll_imports LINK_FLAGS "/ignore:4197")
-  # XXX i#1557: replace w/ generator expression to satisfy CMP0026
-  get_target_property(ntimp_flags ntdll_imports LOCATION${location_suffix})
+  DynamoRIO_get_full_path(ntimp_flags ntdll_imports)
   string(REPLACE ".dll" ".lib" ntimp_flags ${ntimp_flags})
   DR_export_target(ntdll_imports)
   # We need separate 32-bit and 64-bit versions so we put into lib dir
@@ -690,8 +689,7 @@ else (UNIX)
   set(dynamorio_link_flags
     "${dynamorio_link_flags} ${NOLIBC_DLL_ENTRY} ${FORWARD_TO_NTDLL}")
   # cmake does /out, /implib, and /pdb for us, but we do want map file
-  # XXX i#1557: replace w/ $<TARGET_FILE:dynamorio> to satisfy CMP0026
-  get_target_property(drout dynamorio LOCATION${location_suffix})
+  DynamoRIO_get_full_path(drout dynamorio)
   get_filename_component(drpath ${drout} PATH)
   get_filename_component(drname ${drout} NAME_WE)
   set(dynamorio_link_flags

--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -245,13 +245,6 @@
 # should have a "_DR_" prefix.  Public functions and variables should have DynamoRIO
 # in the name.
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "3.0" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "3.0")
-  # XXX i#1557: update our code to satisfy the changes in 3.x
-  cmake_policy(PUSH)
-  cmake_policy(SET CMP0026 OLD)
-endif ()
-
 INCLUDEFILE make/utils_exposed.cmake
 
 if (UNIX)
@@ -1252,9 +1245,4 @@ endfunction ()
 if (NOT DrMemoryFramework_DIR AND EXISTS "${DynamoRIO_DIR}/../drmemory/drmf")
   set(DrMemoryFramework_DIR "${DynamoRIO_DIR}/../drmemory/drmf")
   find_package(DrMemoryFramework)
-endif ()
-
-if ("${CMAKE_VERSION}" VERSION_EQUAL "3.0" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "3.0")
-  cmake_policy(POP)
 endif ()

--- a/make/policies.cmake
+++ b/make/policies.cmake
@@ -37,9 +37,6 @@ endif ()
 # XXX i#1718: update our code to satisfy the changes in 3.x
 cmake_policy(SET CMP0054 OLD)
 
-# XXX i#1557: update our code to satisfy the changes in 3.x
-cmake_policy(SET CMP0026 OLD)
-
 # XXX i#1375: if we make 2.8.12 the minimum we can remove the @rpath
 # Mac stuff and this policy, right?
 cmake_policy(SET CMP0042 OLD)


### PR DESCRIPTION
Eliminate all remaining LOCATION target property uses.
Remove all CMP0026 policy changes.
CMake CMP0026 policy warnings are now gone starting with this CL.

Fixes #1557