### PR TITLE
i#1557 cmake LOCATION: use output dirs for Windows instances, CMP0026

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -417,11 +417,9 @@ register_tool_file("drcachesim")
 
 if (WIN32)
   # drcachesim needs these dlls (i#1737 would eliminate this)
-  # XXX i#1557: replace w/ generator expression to satisfy CMP0026
-  get_target_property(injectlib_loc drinjectlib LOCATION${location_suffix})
+  DynamoRIO_get_full_path(injectlib_loc drinjectlib )
   DR_install(FILES "${injectlib_loc}"  DESTINATION "${INSTALL_CLIENTS_BIN}")
-  # XXX i#1557: replace w/ generator expression to satisfy CMP0026
-  get_target_property(configlib_loc drconfiglib LOCATION${location_suffix})
+  DynamoRIO_get_full_path(configlib_loc drconfiglib )
   DR_install(FILES "${configlib_loc}"  DESTINATION "${INSTALL_CLIENTS_BIN}")
   add_custom_command(TARGET drcachesim POST_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_BASE_DIRECTORY}/drinjectlib.dll

--- a/clients/drcov/CMakeLists.txt
+++ b/clients/drcov/CMakeLists.txt
@@ -99,8 +99,7 @@ install_target(drcov2lcov ${INSTALL_CLIENTS_BIN})
 
 # On Linux we rely on the rpath
 if (WIN32)
-  # XXX i#1557: replace w/ generator expression to satisfy CMP0026
-  get_target_property(DR_TARGET_LOCATION dynamorio LOCATION${location_suffix})
+  DynamoRIO_get_full_path(DR_TARGET_LOCATION dynamorio)
   DR_install(FILES "${DR_TARGET_LOCATION}"  DESTINATION "${INSTALL_CLIENTS_BIN}")
   # i#1344: Include a copy of a recent (> 6.0) redistributable version of dbghelp,
   # if we found one, so our drcov2lcov works pre-Vista.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -269,8 +269,7 @@ if (WIN32)
   add_library(ntdll_imports SHARED win32/ntdll_imports.c ${ntimp_def})
   # i#1137: ignore 'specified multiple times' linker warnings
   append_property_string(TARGET ntdll_imports LINK_FLAGS "/ignore:4197")
-  # XXX i#1557: replace w/ generator expression to satisfy CMP0026
-  get_target_property(ntimp_flags ntdll_imports LOCATION${location_suffix})
+  DynamoRIO_get_full_path(ntimp_flags ntdll_imports)
   string(REPLACE ".dll" ".lib" ntimp_flags ${ntimp_flags})
   DR_export_target(ntdll_imports)
   # We need separate 32-bit and 64-bit versions so we put into lib dir
@@ -691,7 +690,7 @@ else (UNIX)
     "${dynamorio_link_flags} ${NOLIBC_DLL_ENTRY} ${FORWARD_TO_NTDLL}")
   # cmake does /out, /implib, and /pdb for us, but we do want map file
   # XXX i#1557: replace w/ $<TARGET_FILE:dynamorio> to satisfy CMP0026
-  get_target_property(drout dynamorio LOCATION${location_suffix})
+  DynamoRIO_get_full_path(drout dynamorio)
   get_filename_component(drpath ${drout} PATH)
   get_filename_component(drname ${drout} NAME_WE)
   set(dynamorio_link_flags

--- a/make/utils_exposed.cmake
+++ b/make/utils_exposed.cmake
@@ -205,7 +205,7 @@ function (DynamoRIO_prefix_cmd_if_necessary cmd_out use_ats cmd_in)
 endfunction (DynamoRIO_prefix_cmd_if_necessary)
 
 function (DynamoRIO_copy_target_to_device target device_base_dir)
-  get_target_property(abspath ${target} LOCATION${location_suffix})
+  DynamoRIO_get_full_path(abspath ${target})
   get_filename_component(builddir ${PROJECT_BINARY_DIR} NAME)
   file(RELATIVE_PATH relpath "${PROJECT_BINARY_DIR}" "${abspath}")
   add_custom_command(TARGET ${target} POST_BUILD


### PR DESCRIPTION
Incremental re-factoring towards eliminating reading LOCATION target property and resolving CMP0026 cmake policy warnings.

Issue: #1557