### PR TITLE
i#2964: reset statistics on detach to avoid accumulating

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -362,6 +362,8 @@ statistics_init(void)
 static void
 statistics_exit(void)
 {
+    if (doing_detach)
+        memset(stats, 0, sizeof(*stats)); /* for possible re-attach */
     stats = NULL;
 }
 


### PR DESCRIPTION
For re-attach, DR's statistics were accumulating each time.  We now
zero them out at exit time, but only when detaching to avoid an
unnecessary performance hit from zeroing out this large structure.

Fixes #2964