### PR TITLE
i#1312 fast X86 decoder: VEX/EVEX fix implied opcodes.

### DIFF
--- a/core/arch/x86/decode_fast.c
+++ b/core/arch/x86/decode_fast.c
@@ -1260,8 +1260,8 @@ intercept_fip_save(byte *pc, byte byte0, byte byte1)
 }
 
 static void
-get_implied_vex_opcode_bytes(byte *pc, int prefixes, byte vex_mm, byte *byte0,
-                             byte *byte1)
+get_implied_mm_vex_opcode_bytes(byte *pc, int prefixes, byte vex_mm, byte *byte0,
+                                byte *byte1)
 {
     switch (vex_mm) {
     case 1:
@@ -1337,14 +1337,18 @@ decode_cti(dcontext_t *dcontext, byte *pc, instr_t *instr)
      * fairly rare to begin with.
      */
 
-    if ((*pc == VEX_3BYTE_PREFIX_OPCODE) &&
+    if ((*pc == VEX_2BYTE_PREFIX_OPCODE) &&
         (X64_MODE_DC(dcontext) || TESTALL(MODRM_BYTE(3, 0, 0), *(pc + 1)))) {
+        byte0 = 0x0f;
+        byte1 = *(pc + prefixes);
+    } else if ((*pc == VEX_3BYTE_PREFIX_OPCODE) &&
+               (X64_MODE_DC(dcontext) || TESTALL(MODRM_BYTE(3, 0, 0), *(pc + 1)))) {
         byte vex_mm = *(pc + 1) & 0x1f;
-        get_implied_vex_opcode_bytes(pc, prefixes, vex_mm, &byte0, &byte1);
+        get_implied_mm_vex_opcode_bytes(pc, prefixes, vex_mm, &byte0, &byte1);
     } else if (*pc == EVEX_PREFIX_OPCODE &&
                (X64_MODE_DC(dcontext) || TEST(0x10, *(pc + 1)))) {
         byte vex_mm = *(pc + 1) & 0x3;
-        get_implied_vex_opcode_bytes(pc, prefixes, vex_mm, &byte0, &byte1);
+        get_implied_mm_vex_opcode_bytes(pc, prefixes, vex_mm, &byte0, &byte1);
     } else {
         if (prefixes > 0) {
             for (i = 0; i < prefixes; i++, pc++) {

--- a/core/arch/x86/decode_fast.c
+++ b/core/arch/x86/decode_fast.c
@@ -1293,7 +1293,7 @@ get_implied_vex_opcode_bytes(byte *pc, int prefixes, byte vex_mm, byte *byte0,
 byte *
 decode_cti(dcontext_t *dcontext, byte *pc, instr_t *instr)
 {
-    byte byte0, byte1;
+    byte byte0 = 0, byte1 = 0;
     byte *start_pc = pc;
 
     /* find and remember the instruction and its size */

--- a/core/arch/x86/decode_fast.c
+++ b/core/arch/x86/decode_fast.c
@@ -1264,9 +1264,18 @@ get_implied_vex_opcode_bytes(byte *pc, int prefixes, byte vex_mm, byte *byte0,
                              byte *byte1)
 {
     switch (vex_mm) {
-    case 1: *byte0 = 0x0f; *byte1 = *(pc + prefixes); break;
-    case 2: *byte0 = 0x0f; *byte1 = 0x38; break;
-    case 3: *byte0 = 0x0f; *byte1 = 0x3a; break;
+    case 1:
+        *byte0 = 0x0f;
+        *byte1 = *(pc + prefixes);
+        break;
+    case 2:
+        *byte0 = 0x0f;
+        *byte1 = 0x38;
+        break;
+    case 3:
+        *byte0 = 0x0f;
+        *byte1 = 0x3a;
+        break;
     default: CLIENT_ASSERT(false, "decode_cti: internal prefix error");
     }
 }

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1433,6 +1433,9 @@ enum { /* FIXME: vs RAW_OPCODE_* enum */
        RET_NOIMM_OPCODE = 0xc3,
        RET_IMM_OPCODE = 0xc2,
        MOV_IMM_EDX_OPCODE = 0xba,
+       VEX_2BYTE_PREFIX_OPCODE = 0xc5,
+       VEX_3BYTE_PREFIX_OPCODE = 0xc4,
+       EVEX_PREFIX_OPCOE = 0x62,
 };
 
 /* Debug registers are used for breakpoint with x86.

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1435,7 +1435,7 @@ enum { /* FIXME: vs RAW_OPCODE_* enum */
        MOV_IMM_EDX_OPCODE = 0xba,
        VEX_2BYTE_PREFIX_OPCODE = 0xc5,
        VEX_3BYTE_PREFIX_OPCODE = 0xc4,
-       EVEX_PREFIX_OPCOE = 0x62,
+       EVEX_PREFIX_OPCODE = 0x62,
 };
 
 /* Debug registers are used for breakpoint with x86.

--- a/suite/tests/api/dis-x64.expect
+++ b/suite/tests/api/dis-x64.expect
@@ -46,7 +46,8 @@
 +0x0056   8f 40 ff             pop    qword ptr [rax-0x01]
 +0x0059   72 e3                jb     0x000000001000003e
 +0x005b   d7                   xlatb
-+0x005c   62 83 84 d1 f7 99...??  <INVALID>
++0x005c   62 83 84 d1 f7 99 f4...??  <INVALID>
+ 6d 97 8e
 +0x005d   83 84 d1 f7 99 f4 6d add    dword ptr [rcx+rdx*8+0x6df499f7], 0x97
  97
 +0x0065   8e 2e                mov    gs, dword ptr [rsi]
@@ -70,7 +71,8 @@
 +0x0095   28 d9                sub    cl, bl
 +0x0097   dd 2e...??           <INVALID>
 +0x0098   2e f5                cmc
-+0x009a   62 00...??           <INVALID>
++0x009a   62 00 1f 59 88 2f 92...??  <INVALID>
+ d6 21
 +0x009b   00 1f                add    byte ptr [rdi], bl
 +0x009d   59                   pop    rcx
 +0x009e   88 2f                mov    byte ptr [rdi], ch
@@ -268,7 +270,7 @@
 +0x0263   fd                   std
 +0x0264   31 3e                xor    dword ptr [rsi], edi
 +0x0266   e6 9b                out    0x9b, al
-+0x0268   62 c0...??           <INVALID>
++0x0268   62 c0 44 35 33...??  <INVALID>
 +0x0269   c0 44 35 33 47       rol    byte ptr [rbp+rsi+0x33], 0x47
 +0x026e   0c 73                or     al, 0x73
 +0x0270   7e 87                jle    0x00000000100001f9
@@ -396,7 +398,7 @@
 +0x0396   15 c4 8b a8 8b       adc    eax, 0x8ba88bc4
 +0x039b   d3 e8                shr    eax, cl
 +0x039d   4b f6 31             div    ah, al, byte ptr [r9]
-+0x03a0   62 59 df...??        <INVALID>
++0x03a0   62 59 df d8 bd 13...??  <INVALID>
 +0x03a1   59                   pop    rcx
 +0x03a2   df d8                fstp   st0, st0
 +0x03a4   bd 13 1a 4b a4       mov    ebp, 0xa44b1a13
@@ -462,7 +464,7 @@
 +0x0448   c7 53 7f 45 62 14 11...??  <INVALID>
 +0x0449   53                   push   rbx
 +0x044a   7f 45                jnle   0x0000000010000491
-+0x044c   62 14 11...??        <INVALID>
++0x044c   62 14 11 de b5 c3...??  <INVALID>
 +0x044d   14 11                adc    al, 0x11
 +0x044f   de b5 c3 54 41 4b    fidiv  word ptr [rbp+0x4b4154c3]
 +0x0455   7e 84                jle    0x00000000100003db
@@ -584,12 +586,13 @@
 +0x059c   9c                   pushfq
 +0x059d   6d                   insd
 +0x059e   60...??              <INVALID>
-+0x059f   62 24 c7...??        <INVALID>
++0x059f   62 24 c7 2c 77...??  <INVALID>
 +0x05a0   24 c7                and    al, 0xc7
 +0x05a2   2c 77                sub    al, 0x77
 +0x05a4   0c ae                or     al, 0xae
 +0x05a6   94                   xchg   esp, eax
-+0x05a7   62 cb...??           <INVALID>
++0x05a7   62 cb f2 47 4d 3d d0...??  <INVALID>
+ bc 7c 78
 +0x05a8   cb                   retf
 +0x05a9   f2 47 4d 3d d0 bc 7c cmp    rax, 0x787cbcd0
  78
@@ -1092,8 +1095,9 @@
 +0x0a86   93                   xchg   ebx, eax
 +0x0a87   69 03 a2 9e d4 59    imul   eax, dword ptr [rbx], 0x59d49ea2
 +0x0a8d   91                   xchg   ecx, eax
-+0x0a8e   49 62 c7...??        <INVALID>
-+0x0a8f   62 c7...??           <INVALID>
++0x0a8e   49 62 c7 10 e0 ea 72...??  <INVALID>
+ 4f
++0x0a8f   62 c7 10 e0 ea 72 4f...??  <INVALID>
 +0x0a90   c7 10 e0 ea 72 4f...??  <INVALID>
 +0x0a91   10 e0                adc    al, ah
 +0x0a93   ea 72 4f 23 e4 e8 e3...??  <INVALID>
@@ -1562,7 +1566,7 @@
 +0x0f30   69 f7 5f 3f b5 a2    imul   esi, edi, 0xa2b53f5f
 +0x0f36   50                   push   rax
 +0x0f37   39 24 a9             cmp    dword ptr [rcx+rbp*4], esp
-+0x0f3a   62 1e...??           <INVALID>
++0x0f3a   62 1e 0b f7 64 e1...??  <INVALID>
 +0x0f3b   1e...??              <INVALID>
 +0x0f3c   0b f7                or     esi, edi
 +0x0f3e   64 e1 42             loope  0x0000000010000f83
@@ -2147,12 +2151,13 @@
 +0x151a   af                   scasd
 +0x151b   bd fa 74 29 e4       mov    ebp, 0xe42974fa
 +0x1520   2e c1 70 7d b5       shl    dword ptr [cs:rax+0x7d], 0xb5
-+0x1525   62 12...??           <INVALID>
++0x1525   62 12 6f d8 ed dc...??  <INVALID>
 +0x1526   12 6f d8             adc    ch, byte ptr [rdi-0x28]
 +0x1529   ed                   in     eax, dx
 +0x152a   dc 51 a9             fcom   qword ptr [rcx-0x57]
 +0x152d   3e 98                cwde
-+0x152f   62 52 7f...??        <INVALID>
++0x152f   62 52 7f 50 4f 99 36...??  <INVALID>
+ 07 fe 04
 +0x1530   52                   push   rdx
 +0x1531   7f 50                jnle   0x0000000010001583
 +0x1533   4f 99                cdq
@@ -2516,7 +2521,8 @@
 +0x18e1   92                   xchg   edx, eax
 +0x18e2   2f...??              <INVALID>
 +0x18e3   7a 0d                jp     0x00000000100018f2
-+0x18e5   62 75 28...??        <INVALID>
++0x18e5   62 75 28 c0 82 36 e5...??  <INVALID>
+ 53 94
 +0x18e6   75 28                jnz    0x0000000010001910
 +0x18e8   c0 82 36 e5 53 94 4f rol    byte ptr [rdx-0x6bac1aca], 0x4f
 +0x18ef   73 f2                jnb    0x00000000100018e3
@@ -2642,14 +2648,15 @@
 +0x1a2a   aa                   stosb
 +0x1a2b   7f 7d                jnle   0x0000000010001aaa
 +0x1a2d   9c                   pushfq
-+0x1a2e   62 84 4e 43 41 f7 5c...??  <INVALID>
++0x1a2e   62 84 4e 43 41 f7...??  <INVALID>
 +0x1a2f   84 4e 43             test   byte ptr [rsi+0x43], cl
 +0x1a32   41 f7 5c eb 04       neg    dword ptr [r11+rbp*8+0x04]
 +0x1a37   ab                   stosd
 +0x1a38   3e bc 82 5c 47 40    mov    esp, 0x40475c82
 +0x1a3e   6d                   insd
 +0x1a3f   08 84 d0 5c 26 9a d4 or     byte ptr [rax+rdx*8-0x2b65d9a4], al
-+0x1a46   62 07...??           <INVALID>
++0x1a46   62 07 91 5e 90 5c 38...??  <INVALID>
+ a6
 +0x1a47   07...??              <INVALID>
 +0x1a48   91                   xchg   ecx, eax
 +0x1a49   5e                   pop    rsi
@@ -2805,7 +2812,7 @@
 +0x1bd0   6e                   outsb
 +0x1bd1   f2 66 19 08          sbb    word ptr [rax], cx
 +0x1bd5   af                   scasd
-+0x1bd6   62 81 95 10 47 57...??  <INVALID>
++0x1bd6   62 81 95 10 47 57 84...??  <INVALID>
 +0x1bd7   81 95 10 47 57 84 c1 adc    dword ptr [rbp-0x7ba8b8f0], 0x48c539c1
  39 c5 48
 +0x1be1   f4                   hlt
@@ -2940,7 +2947,7 @@
 +0x1d13   cd 35                int    0x35
 +0x1d15   9e                   sahf
 +0x1d16   e7 81                out    0x81, eax
-+0x1d18   62 f0...??           <INVALID>
++0x1d18   62 f0 fb 91 cb...??  <INVALID>
 +0x1d19   f0 fb...??           <INVALID>
 +0x1d1a   fb                   sti
 +0x1d1b   91                   xchg   ecx, eax

--- a/suite/tests/api/dis-x86.expect
+++ b/suite/tests/api/dis-x86.expect
@@ -166,7 +166,7 @@
 +0x017d   da 11                ficom  dword ptr [ecx]
 +0x017f   a4                   movsb
 +0x0180   ea b0 78 35 32 68 52 jmp    0x5268:0x323578b0
-+0x0187   62 f1...??           <INVALID>
++0x0187   62 f1 08 88 ef d1...??  <INVALID>
 +0x0188   f1                   int1
 +0x0189   08 88 ef d1 8f e6    or     byte ptr [eax+0xe68fd1ef], cl
 +0x018f   91                   xchg   ecx, eax
@@ -266,7 +266,8 @@
 +0x0263   fd                   std
 +0x0264   31 3e                xor    dword ptr [esi], edi
 +0x0266   e6 9b                out    0x9b, al
-+0x0268   62 c0...??           <INVALID>
++0x0268   62 c0 44 35 33 47 0c...??  <INVALID>
+ 73
 +0x0269   c0 44 35 33 47       rol    byte ptr [ebp+esi+0x33], 0x47
 +0x026e   0c 73                or     al, 0x73
 +0x0270   7e 87                jle    0x100001f9
@@ -597,7 +598,7 @@
 +0x05a2   2c 77                sub    al, 0x77
 +0x05a4   0c ae                or     al, 0xae
 +0x05a6   94                   xchg   esp, eax
-+0x05a7   62 cb...??           <INVALID>
++0x05a7   62 cb f2 47 4d...??  <INVALID>
 +0x05a8   cb                   retf
 +0x05a9   f2 47                inc    edi
 +0x05ab   4d                   dec    ebp
@@ -1113,7 +1114,7 @@
 +0x0a87   69 03 a2 9e d4 59    imul   eax, dword ptr [ebx], 0x59d49ea2
 +0x0a8d   91                   xchg   ecx, eax
 +0x0a8e   49                   dec    ecx
-+0x0a8f   62 c7...??           <INVALID>
++0x0a8f   62 c7 10 e0...??     <INVALID>
 +0x0a90   c7 10 e0 ea 72 4f...??  <INVALID>
 +0x0a91   10 e0                adc    al, ah
 +0x0a93   ea 72 4f 23 e4 e8 e3 jmp    0xe3e8:0xe4234f72
@@ -3013,7 +3014,7 @@
 +0x1d13   cd 35                int    0x35
 +0x1d15   9e                   sahf
 +0x1d16   e7 81                out    0x81, eax
-+0x1d18   62 f0...??           <INVALID>
++0x1d18   62 f0 fb 91 cb...??  <INVALID>
 +0x1d19   f0 fb...??           <INVALID>
 +0x1d1a   fb                   sti
 +0x1d1b   91                   xchg   ecx, eax


### PR DESCRIPTION
VEX/EVEX instructions always imply at least one leading 0x0f opcode byte. Fix when looking up "interesting" flag.

Issue #1312