### PR TITLE
Relax the assertion in recreate_app_state_from_ilist

### DIFF
--- a/core/translate.c
+++ b/core/translate.c
@@ -700,8 +700,10 @@ recreate_app_state_from_ilist(dcontext_t *tdcontext, instrlist_t *ilist, byte *s
                         "assuming a prefix instruction\n",
                         cpc, target_cache);
                     res = RECREATE_SUCCESS_PC; /* failed on full state, but pc good */
-                    /* should only happen for thread synch, not a fault */
-                    ASSERT(tdcontext != get_thread_private_dcontext() ||
+                    /* Should only happen for thread synch, not a fault. Checking whether
+                     * tdcontext is the same as this thread's private dcontext is a weak
+                     * indicator of xl8 due to a fault. */
+                    ASSERT_CURIOSITY(tdcontext != get_thread_private_dcontext() ||
                            INTERNAL_OPTION(stress_recreate_pc));
                 } else {
                     LOG(THREAD_GET, LOG_INTERP, 2,

--- a/core/translate.c
+++ b/core/translate.c
@@ -704,7 +704,7 @@ recreate_app_state_from_ilist(dcontext_t *tdcontext, instrlist_t *ilist, byte *s
                      * tdcontext is the same as this thread's private dcontext is a weak
                      * indicator of xl8 due to a fault. */
                     ASSERT_CURIOSITY(tdcontext != get_thread_private_dcontext() ||
-                           INTERNAL_OPTION(stress_recreate_pc));
+                                     INTERNAL_OPTION(stress_recreate_pc));
                 } else {
                     LOG(THREAD_GET, LOG_INTERP, 2,
                         "recreate_app -- WARNING: cache pc " PFX " != " PFX ", "


### PR DESCRIPTION
Downstream clients can asynchronously request translation of pc addresses in the fragment cache. A strict assertion of a different thread context causes tests to fail in debug mode. Here we relax the assertion to an ASSERT_CURIOSITY. 