### PR TITLE
Cleanup: VS2013 problematic variable declarations from recent changes

### DIFF
--- a/ext/drcontainers/hashtable.c
+++ b/ext/drcontainers/hashtable.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -270,8 +270,9 @@ hashtable_lookup(hashtable_t *table, void *key)
 {
     void *res = NULL;
     hash_entry_t *e;
-    if (table->synch)
+    if (table->synch) {
         dr_mutex_lock(table->lock);
+    }
     uint hindex = hash_key(table, key);
     for (e = table->table[hindex]; e != NULL; e = e->next) {
         if (keys_equal(table, e->key, key)) {
@@ -324,8 +325,9 @@ hashtable_add(hashtable_t *table, void *key, void *payload)
 {
     /* if payload is null can't tell from lookup miss */
     ASSERT(payload != NULL, "hashtable_add internal error");
-    if (table->synch)
+    if (table->synch) {
         dr_mutex_lock(table->lock);
+    }
     uint hindex = hash_key(table, key);
     hash_entry_t *e;
     for (e = table->table[hindex]; e != NULL; e = e->next) {
@@ -358,8 +360,9 @@ hashtable_add_replace(hashtable_t *table, void *key, void *payload)
 {
     /* if payload is null can't tell from lookup miss */
     ASSERT(payload != NULL, "hashtable_add_replace internal error");
-    if (table->synch)
+    if (table->synch) {
         dr_mutex_lock(table->lock);
+    }
     void *old_payload = NULL;
     uint hindex = hash_key(table, key);
     hash_entry_t *e, *new_e, *prev_e;
@@ -402,8 +405,9 @@ hashtable_remove(hashtable_t *table, void *key)
 {
     bool res = false;
     hash_entry_t *e, *prev_e;
-    if (table->synch)
+    if (table->synch) {
         dr_mutex_lock(table->lock);
+    }
     uint hindex = hash_key(table, key);
     for (e = table->table[hindex], prev_e = NULL; e != NULL; prev_e = e, e = e->next) {
         if (keys_equal(table, e->key, key)) {

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -2617,9 +2617,9 @@ bool
 drmgr_insert_emulation_start(void *drcontext, instrlist_t *ilist, instr_t *where,
                              emulated_instr_t *einstr)
 {
-    if (einstr->size < sizeof(emulated_instr_t))
+    if (einstr->size < sizeof(emulated_instr_t)) {
         return false;
-
+    }
     instr_t *start_emul_label = INSTR_CREATE_label(drcontext);
     instr_set_meta(start_emul_label);
     instr_set_note(start_emul_label, (void *)get_emul_note_val(DRMGR_NOTE_EMUL_START));


### PR DESCRIPTION
Works around a parsing problem in VS2013 where a variable cannot be
declared after an if() with no braces on its body by adding braces to
some recent code changes.