### PR TITLE
Cleanup: simplify libutil/ include dirs

### DIFF
--- a/libutil/CMakeLists.txt
+++ b/libutil/CMakeLists.txt
@@ -43,8 +43,9 @@ endfunction (add_gen_events_deps)
 # FIXME i#60: add rules from old Makefile for building unit tests
 # the tests had been broken for a while
 
+# We avoid core/ to avoid conflicts between core/hashtable.h and drcontainers
+# hashtable.h.  An alternative would be to rename core/hashtable.h.
 include_directories(BEFORE
-  ${PROJECT_SOURCE_DIR}/core
   ${PROJECT_SOURCE_DIR}/core/lib
   ${PROJECT_SOURCE_DIR}/core/win32
   ${PROJECT_SOURCE_DIR}/core/arch

--- a/libutil/config.h
+++ b/libutil/config.h
@@ -61,7 +61,7 @@
 #define _DETERMINA_CONFIG_H_
 
 #include <windows.h>
-#include "lib/globals_shared.h" /* for process_id_t */
+#include "globals_shared.h" /* for process_id_t */
 
 #ifdef __cplusplus
 extern "C" {

--- a/libutil/detach.c
+++ b/libutil/detach.c
@@ -34,9 +34,9 @@
 /* note - include order matters */
 #include <tchar.h>
 #include "share.h"
-#include "win32/ntdll.h" /* just for typedefs and defines */
+#include "ntdll.h" /* just for typedefs and defines */
 #include "processes.h"
-#include "win32/drmarker.h"
+#include "drmarker.h"
 #include <AccCtrl.h>
 #include <Aclapi.h>
 #include <stdio.h>

--- a/libutil/dr_config.c
+++ b/libutil/dr_config.c
@@ -37,7 +37,7 @@
 #include "utils.h"
 #include "share.h"
 #include "utils.h"
-#include "lib/dr_config.h"
+#include "dr_config.h"
 #include "our_tchar.h"
 #include "dr_frontend.h"
 

--- a/libutil/processes.c
+++ b/libutil/processes.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -33,9 +33,9 @@
 
 #include "share.h"
 
-#include "win32/drmarker.h"      // from src tree
-#include "win32/ntdll.h"         // from src tree
-#include "win32/inject_shared.h" // only for w_get_short_name
+#include "drmarker.h"      // from src tree
+#include "ntdll.h"         // from src tree
+#include "inject_shared.h" // only for w_get_short_name
 
 #include "processes.h"
 

--- a/libutil/processes.h
+++ b/libutil/processes.h
@@ -45,7 +45,7 @@
 extern "C" {
 #endif
 
-#include "lib/dr_stats.h" // from src tree
+#include "dr_stats.h" // from src tree
 
 /* dup KPRIORITY and VM_COUNTERS from src/win32/ntdll.h, in order
  *  to have process_info_s self-contained.

--- a/libutil/utils.c
+++ b/libutil/utils.c
@@ -42,7 +42,7 @@
 #    include "elm.h"
 #    include "events.h"      /* for canary */
 #    include "processes.h"   /* for canary */
-#    include "options.h"     /* for option checking */
+#    include "../options.h"  /* for option checking */
 #    include "ntdll_types.h" /* for NT_SUCCESS */
 
 #    include <io.h>    /* for canary */

--- a/libutil/utils.h
+++ b/libutil/utils.h
@@ -35,7 +35,7 @@
 #define _DETERMINA_SHAREUTILS_H_
 
 #include "share.h"
-#include "lib/dr_config.h"
+#include "dr_config.h"
 #include "our_tchar.h"
 
 #ifdef WINDOWS


### PR DESCRIPTION
Removes core/ from the include dirs for libutil, to simplify using
drfrontendlib with drcontainers at the same time without hitting a
conflict between drcontainers/hashtable.h and core/hashtable.h.