### PR TITLE
i#3230 split traces: generate per-thread processed trace files

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -149,6 +149,10 @@ compatibility changes:
  - Added a parameter to cmake functions DynamoRIO_get_target_path_for_execution and
    DynamoRIO_copy_target_to_device. External projects outside of DynamoRIO need
    to pass _DR_location_suffix.
+ - The drcachesim tool's offline traces are now stored in separate files per traced
+   application thread, rather than a single interleaved file.  Reading and analyzing
+   a legacy interleaved file is still supported, but all new generated traces are
+   split.  Splitting enables parallelized post-processing and trace analysis.
 
 Further non-compatibility-affecting changes include:
 

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -115,7 +115,7 @@ add_exported_library(drmemtrace_raw2trace STATIC
   tracer/instru_offline.cpp
   )
 configure_DynamoRIO_standalone(drmemtrace_raw2trace)
-target_link_libraries(drmemtrace_raw2trace drfrontendlib)
+target_link_libraries(drmemtrace_raw2trace directory_iterator drfrontendlib)
 use_DynamoRIO_extension(drmemtrace_raw2trace drutil_static)
 
 set(drcachesim_srcs

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -58,14 +58,18 @@ droption_t<std::string> op_outdir(
     "to a directory where per-thread trace files will be written.");
 
 droption_t<std::string> op_indir(
-    DROPTION_SCOPE_ALL, "indir", "", "Offline directory of raw data for input",
+    DROPTION_SCOPE_ALL, "indir", "", "Input directory of offline trace files",
     "After a trace file is produced via -offline into -outdir, it can be passed to the "
-    "simulator via this flag pointing at the subdirectory created in -outdir.");
+    "simulator via this flag pointing at the subdirectory created in -outdir. "
+    "The -offline tracing produces raw data files which are converted into final "
+    "trace files on the first execution with -indir.  The raw files can also be manually "
+    "converted using the drraw2trace tool.  Legacy single trace files with all threads "
+    "interleaved into one are not supported with this option: use -infile instead.");
 
 droption_t<std::string> op_infile(
-    DROPTION_SCOPE_ALL, "infile", "", "Offline trace file for input to the simulator",
-    "Directs the simulator to use a trace file (not a raw data file from -offline: "
-    "such a file neeeds to be converted via drraw2trace or -indir first).");
+    DROPTION_SCOPE_ALL, "infile", "", "Offline legacy file for input to the simulator",
+    "Directs the simulator to use a single all-threads-interleaved-into-one trace file. "
+    "This is a legacy file format that is no longer produced.");
 
 droption_t<std::string> op_module_file(
     DROPTION_SCOPE_ALL, "module_file", "", "Path to modules.log for opcode_mix tool",

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -559,18 +559,24 @@ $ bin64/drrun -t drcachesim -indir drmemtrace.app.pid.xxxx.dir/
 \endcode
 
 The direct results of the \p -offline run are raw, compacted files, stored
-in a \p raw subdirectory of the \p drmemtrace.app.pid.xxxx.dir directory.
+in a \p raw/ subdirectory of the \p drmemtrace.app.pid.xxxx.dir directory.
 The \p -indir option both converts the data to a canonical trace form and
 passes the resulting data to the cache simulator.  The canonical trace data
-is stored by \p -indir in a file named \p drmemtrace.trace inside the \p
-drmemtrace.app.pid.xxxx.dir/ directory.  Future runs can point directly at
-this file using the \p -infile option:
+is stored by \p -indir in a \p trace/ subdirectory inside the \p
+drmemtrace.app.pid.xxxx.dir/ directory.  For both the raw and canonical
+data, a separate file per application thread is used.  If the canonical
+data already exists, future runs will use that data rather than
+re-converting it.  Either the top-level directory or the \p trace/
+subdirectory may be pointed at with \p -indir:
+
 \code
-$ bin64/drrun -t drcachesim -infile drmemtrace.app.pid.xxxx.dir/drmemtrace.trace
+$ bin64/drrun -t drcachesim -indir drmemtrace.app.pid.xxxx.dir/trace
 \endcode
 
-The \p -infile option supports reading a gzipped trace file, allowing
-compression of the \p drmemtrace.trace file to save space:
+The canonical trace files may be manually compressed with gzip, as the
+trace reader supports reading gzipped files.
+
+Older versions of the simulator produced a single trace file containing all threads interleaved.  The \p -infile option supports reading these legacy files:
 \code
 $ gzip drmemtrace.app.pid.xxxx.dir/drmemtrace.trace
 $ bin64/drrun -t drcachesim -infile drmemtrace.app.pid.xxxx.dir/drmemtrace.trace.gz

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -177,22 +177,20 @@ free_cb(void *data)
 static void
 post_process()
 {
-    const char *output_path;
-    drmemtrace_status_t mem_res = drmemtrace_get_output_path(&output_path);
+    const char *raw_dir;
+    drmemtrace_status_t mem_res = drmemtrace_get_output_path(&raw_dir);
     assert(mem_res == DRMEMTRACE_SUCCESS);
-    std::string output_trace(std::string(output_path) + std::string(DIRSEP) + ".." +
-                             std::string(DIRSEP) + TRACE_FILENAME);
     void *dr_context = dr_standalone_init();
     {
         /* First, test just the module parsing w/o writing a final trace, in a separate
          * scope to delete the drmodtrack state afterward.
          */
-        raw2trace_directory_t dir(output_path, output_trace);
+        raw2trace_directory_t dir(raw_dir, "");
         std::unique_ptr<module_mapper_t> module_mapper = module_mapper_t::create(
             dir.modfile_bytes, parse_cb, process_cb, MAGIC_VALUE, free_cb);
         assert(module_mapper->get_last_error().empty());
         // Test back-compat of deprecated APIs.
-        raw2trace_t raw2trace(dir.modfile_bytes, dir.thread_files, NULL, NULL);
+        raw2trace_t raw2trace(dir.modfile_bytes, dir.in_files, dir.out_files, NULL);
         std::string error =
             raw2trace.handle_custom_data(parse_cb, process_cb, MAGIC_VALUE, free_cb);
         assert(error.empty());
@@ -202,9 +200,8 @@ post_process()
     /* Now write a final trace to a location that the drcachesim -indir step
      * run by the outer test harness will find (TRACE_FILENAME).
      */
-    raw2trace_directory_t dir(output_path, output_trace);
-    raw2trace_t raw2trace(dir.modfile_bytes, dir.thread_files, &dir.out_file, dr_context,
-                          0);
+    raw2trace_directory_t dir(raw_dir, "");
+    raw2trace_t raw2trace(dir.modfile_bytes, dir.in_files, dir.out_files, dr_context, 0);
     std::string error =
         raw2trace.handle_custom_data(parse_cb, process_cb, MAGIC_VALUE, free_cb);
     assert(error.empty());

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -56,9 +56,6 @@ static droption_t<std::string> op_indir(DROPTION_SCOPE_FRONTEND, "indir", "",
                                         "[Required] Directory with trace input files",
                                         "Specifies a directory with raw files.");
 
-static droption_t<std::string> op_out(DROPTION_SCOPE_FRONTEND, "out", "",
-                                      "[Required] Path to output file",
-                                      "Specifies the path to the output file.");
 #if defined(X64)
 #    define SYS_NUM(r) (r).orig_rax
 #elif defined(X86)
@@ -150,7 +147,7 @@ test_raw2trace(raw2trace_directory_t *dir)
         /* Sycalls below will be ptraced. We don't expect any open/close calls outside of
          * raw2trace::read_and_map_modules().
          */
-        raw2trace_t raw2trace(dir->modfile_bytes, dir->thread_files, &dir->out_file,
+        raw2trace_t raw2trace(dir->modfile_bytes, dir->in_files, dir->out_files,
                               GLOBAL_DCONTEXT, 1);
         std::string error = raw2trace.do_conversion();
         if (!error.empty()) {
@@ -197,7 +194,7 @@ test_module_mapper(const raw2trace_directory_t *dir)
 bool
 test_trace_timestamp_reader(const raw2trace_directory_t *dir)
 {
-    std::istream *file = dir->thread_files[0];
+    std::istream *file = dir->in_files[0];
     // Seek back to the beginning to undo raw2trace_directory_t's validation
     file->seekg(0);
     offline_entry_t buffer[4];
@@ -256,7 +253,7 @@ main(int argc, const char *argv[])
     std::string parse_err;
     if (!droption_parser_t::parse_argv(DROPTION_SCOPE_FRONTEND, argc, (const char **)argv,
                                        &parse_err, NULL) ||
-        op_indir.get_value().empty() || op_out.get_value().empty()) {
+        op_indir.get_value().empty()) {
         std::cerr << "Usage error: " << parse_err << "\nUsage:\n"
                   << droption_parser_t::usage_short(DROPTION_SCOPE_ALL);
         return 1;
@@ -265,8 +262,7 @@ main(int argc, const char *argv[])
     /* Open input/output files outside of traced region. And explicitly don't destroy dir,
      * so they never get closed.
      */
-    raw2trace_directory_t *dir =
-        new raw2trace_directory_t(op_indir.get_value(), op_out.get_value());
+    raw2trace_directory_t *dir = new raw2trace_directory_t(op_indir.get_value(), "");
 
     bool test1_ret = test_raw2trace(dir);
     bool test2_ret = test_module_mapper(dir);

--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -53,8 +53,9 @@
     } while (0)
 
 static droption_t<std::string>
-    op_trace(DROPTION_SCOPE_FRONTEND, "trace", "", "[Required] Trace input file",
-             "Specifies the file containing the trace to be analyzed.");
+    op_trace_dir(DROPTION_SCOPE_FRONTEND, "trace_dir", "",
+                 "[Required] Trace input directory",
+                 "Specifies the directory containing the trace files to be analyzed.");
 
 // XXX i#2006: these are duplicated from drcachesim's options.
 // Once we decide on the final tool generalization approach we should
@@ -90,7 +91,7 @@ _tmain(int argc, const TCHAR *targv[])
     std::string parse_err;
     if (!droption_parser_t::parse_argv(DROPTION_SCOPE_FRONTEND, argc, (const char **)argv,
                                        &parse_err, NULL) ||
-        op_trace.get_value().empty()) {
+        op_trace_dir.get_value().empty()) {
         FATAL_ERROR("Usage error: %s\nUsage:\n%s", parse_err.c_str(),
                     droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
     }
@@ -104,7 +105,7 @@ _tmain(int argc, const TCHAR *targv[])
         // We use this launcher to run tests as well:
         tools.push_back(&tool2);
     }
-    analyzer_t analyzer(op_trace.get_value(), &tools[0], (int)tools.size());
+    analyzer_t analyzer(op_trace_dir.get_value(), &tools[0], (int)tools.size());
     if (!analyzer) {
         FATAL_ERROR("failed to initialize analyzer: %s",
                     analyzer.get_error_string().c_str());
@@ -119,7 +120,7 @@ _tmain(int argc, const TCHAR *targv[])
         // Test the external-iterator interface.
         tool1 = histogram_tool_create(op_line_size.get_value(), op_report_top.get_value(),
                                       op_verbose.get_value());
-        analyzer_t external(op_trace.get_value());
+        analyzer_t external(op_trace_dir.get_value());
         if (!external) {
             FATAL_ERROR("failed to initialize analyzer: %s",
                         external.get_error_string().c_str());

--- a/clients/drcachesim/tracer/raw2trace_directory.cpp
+++ b/clients/drcachesim/tracer/raw2trace_directory.cpp
@@ -34,26 +34,26 @@
  * Separate from raw2trace_t, so that raw2trace doesn't depend on dr_frontend.
  */
 
+#include <algorithm>
 #include <cstring>
 #include <iostream>
 #include <vector>
 
 #ifdef UNIX
-#    include <dirent.h> /* opendir, readdir */
-#    include <unistd.h> /* getcwd */
+#    include <sys/stat.h>
+#    include <sys/types.h>
 #else
 #    define UNICODE
 #    define _UNICODE
 #    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
-#    include <direct.h> /* _getcwd */
-#    pragma comment(lib, "User32.lib")
 #endif
 
 #include "dr_api.h"
 #include "dr_frontend.h"
 #include "raw2trace.h"
 #include "raw2trace_directory.h"
+#include "directory_iterator.h"
 #include "utils.h"
 
 #define FATAL_ERROR(msg, ...)                               \
@@ -77,48 +77,19 @@
         }                                      \
     } while (0)
 
-#ifdef UNIX
 void
 raw2trace_directory_t::open_thread_files()
 {
-    struct dirent *ent;
-    DIR *dir = opendir(indir.c_str());
     VPRINT(1, "Iterating dir %s\n", indir.c_str());
-    if (dir == NULL)
-        FATAL_ERROR("Failed to list directory %s", indir.c_str());
-    while ((ent = readdir(dir)) != NULL)
-        open_thread_log_file(ent->d_name);
-    closedir(dir);
+    directory_iterator_t end;
+    directory_iterator_t iter(indir);
+    if (!iter) {
+        FATAL_ERROR("Failed to list directory %s: %s", indir.c_str(),
+                    iter.error_string().c_str());
+    }
+    for (; iter != end; ++iter)
+        open_thread_log_file((*iter).c_str());
 }
-#else
-void
-raw2trace_directory_t::open_thread_files()
-{
-    HANDLE find = INVALID_HANDLE_VALUE;
-    WIN32_FIND_DATAW data;
-    char path[MAXIMUM_PATH];
-    TCHAR wpath[MAXIMUM_PATH];
-    VPRINT(1, "Iterating dir %s\n", indir.c_str());
-    // Append \*
-    dr_snprintf(path, BUFFER_SIZE_ELEMENTS(path), "%s\\*", indir.c_str());
-    NULL_TERMINATE_BUFFER(path);
-    if (drfront_char_to_tchar(path, wpath, BUFFER_SIZE_ELEMENTS(wpath)) !=
-        DRFRONT_SUCCESS)
-        FATAL_ERROR("Failed to convert from utf-8 to utf-16");
-    find = FindFirstFileW(wpath, &data);
-    if (find == INVALID_HANDLE_VALUE)
-        FATAL_ERROR("Failed to list directory %s\n", indir.c_str());
-    do {
-        if (!TESTANY(data.dwFileAttributes, FILE_ATTRIBUTE_DIRECTORY)) {
-            if (drfront_tchar_to_char(data.cFileName, path, BUFFER_SIZE_ELEMENTS(path)) !=
-                DRFRONT_SUCCESS)
-                FATAL_ERROR("Failed to convert from utf-16 to utf-8");
-            open_thread_log_file(path);
-        }
-    } while (FindNextFile(find, &data) != 0);
-    FindClose(find);
-}
-#endif
 
 void
 raw2trace_directory_t::open_thread_log_file(const char *basename)
@@ -130,22 +101,40 @@ raw2trace_directory_t::open_thread_log_file(const char *basename)
     if (strcmp(basename, DRMEMTRACE_MODULE_LIST_FILENAME) == 0)
         return;
     // Skip any non-.raw in case someone put some other file in there.
-    if (strstr(basename, OUTFILE_SUFFIX) == NULL)
+    const char *basename_pre_suffix = strrchr(basename, '.');
+    if (basename_pre_suffix != nullptr)
+        basename_pre_suffix = strstr(basename_pre_suffix, OUTFILE_SUFFIX);
+    if (basename_pre_suffix == nullptr)
         return;
     if (dr_snprintf(path, BUFFER_SIZE_ELEMENTS(path), "%s%s%s", indir.c_str(), DIRSEP,
                     basename) <= 0) {
         FATAL_ERROR("Failed to get full path of file %s", basename);
     }
     NULL_TERMINATE_BUFFER(path);
-    thread_files.push_back(new std::ifstream(path, std::ifstream::binary));
-    if (!(*thread_files.back()))
+    in_files.push_back(new std::ifstream(path, std::ifstream::binary));
+    if (!(*in_files.back()))
         FATAL_ERROR("Failed to open thread log file %s", path);
-    std::string error = raw2trace_t::check_thread_file(thread_files.back());
+    std::string error = raw2trace_t::check_thread_file(in_files.back());
     if (!error.empty()) {
         FATAL_ERROR("Failed sanity checks for thread log file %s: %s", path,
                     error.c_str());
     }
-    VPRINT(1, "Opened thread log file %s\n", path);
+    VPRINT(1, "Opened input file %s\n", path);
+
+    // Now open the corresponding output file.
+    char outname[MAXIMUM_PATH];
+    if (dr_snprintf(outname, BUFFER_SIZE_ELEMENTS(outname), "%.*s",
+                    basename_pre_suffix - 1 - basename, basename) <= 0) {
+        FATAL_ERROR("Failed to compute output name for file %s", basename);
+    }
+    if (dr_snprintf(path, BUFFER_SIZE_ELEMENTS(path), "%s%s%s.%s", outdir.c_str(), DIRSEP,
+                    outname, TRACE_SUFFIX) <= 0) {
+        FATAL_ERROR("Failed to compute full path of output file for %s", basename);
+    }
+    out_files.push_back(new std::ofstream(path, std::ofstream::binary));
+    if (!(*out_files.back()))
+        FATAL_ERROR("Failed to open output file %s", path);
+    VPRINT(1, "Opened output file %s\n", path);
 }
 
 void
@@ -163,25 +152,76 @@ raw2trace_directory_t::read_module_file(const std::string &modfilename)
         FATAL_ERROR("Didn't read whole module file %s", modfilename.c_str());
 }
 
+std::string
+raw2trace_directory_t::tracedir_from_rawdir(const std::string &rawdir_in)
+{
+    std::string rawdir = rawdir_in;
+#ifdef WINDOWS
+    std::replace(rawdir.begin(), rawdir.end(), ALT_DIRSEP[0], DIRSEP[0]);
+#endif
+    // First remove trailing slashes.
+    while (rawdir.back() == DIRSEP[0])
+        rawdir.pop_back();
+    std::string trace_sub(DIRSEP + std::string(TRACE_SUBDIR));
+    std::string raw_sub(DIRSEP + std::string(OUTFILE_SUBDIR));
+    // If it ends in "/trace", use it directly.
+    if (rawdir.size() > trace_sub.size() &&
+        rawdir.compare(rawdir.size() - trace_sub.size(), trace_sub.size(), trace_sub) ==
+            0)
+        return rawdir;
+    // If it ends in "/raw", replace with "/trace".
+    if (rawdir.size() > raw_sub.size() &&
+        rawdir.compare(rawdir.size() - raw_sub.size(), raw_sub.size(), raw_sub) == 0) {
+        std::string tracedir = rawdir;
+        size_t pos = rawdir.rfind(raw_sub);
+        if (pos == std::string::npos)
+            FATAL_ERROR("Internal error: should have returned already");
+        tracedir.erase(pos, raw_sub.size());
+        tracedir.insert(pos, trace_sub);
+        return tracedir;
+    }
+    // If it contains a "/raw" or "/trace" subdir, add "/trace" to it.
+    if (directory_iterator_t::is_directory(rawdir + raw_sub) ||
+        directory_iterator_t::is_directory(rawdir + trace_sub)) {
+        return rawdir + trace_sub;
+    }
+    // Use it directly.
+    return rawdir;
+}
+
 raw2trace_directory_t::raw2trace_directory_t(const std::string &indir_in,
-                                             const std::string &outname_in,
+                                             const std::string &outdir_in,
                                              unsigned int verbosity_in)
     : indir(indir_in)
-    , outname(outname_in)
+    , outdir(outdir_in)
     , verbosity(verbosity_in)
 {
+#ifdef WINDOWS
+    // Canonicalize.
+    std::replace(indir.begin(), indir.end(), ALT_DIRSEP[0], DIRSEP[0]);
+#endif
+    // Remove trailing slashes.
+    while (indir.back() == DIRSEP[0])
+        indir.pop_back();
+    if (!directory_iterator_t::is_directory(indir))
+        FATAL_ERROR("Directory does not exist: %s\n", indir.c_str());
     // Support passing both base dir and raw/ subdir.
     if (indir.find(OUTFILE_SUBDIR) == std::string::npos) {
         indir += std::string(DIRSEP) + OUTFILE_SUBDIR;
     }
+    // Support a default outdir.
+    if (outdir.empty()) {
+        outdir = tracedir_from_rawdir(indir);
+        if (!directory_iterator_t::is_directory(outdir)) {
+            if (!directory_iterator_t::create_directory(outdir)) {
+                FATAL_ERROR("Failed to create output dir %s: errno=%d\n", outdir.c_str(),
+                            errno);
+            }
+        }
+    }
     std::string modfilename =
         indir + std::string(DIRSEP) + DRMEMTRACE_MODULE_LIST_FILENAME;
     read_module_file(modfilename);
-
-    out_file.open(outname.c_str(), std::ofstream::binary);
-    if (!out_file)
-        FATAL_ERROR("Failed to open output file %s", outname.c_str());
-    VPRINT(1, "Writing to %s\n", outname.c_str());
 
     open_thread_files();
 }
@@ -189,7 +229,7 @@ raw2trace_directory_t::raw2trace_directory_t(const std::string &indir_in,
 raw2trace_directory_t::raw2trace_directory_t(const std::string &module_file_path,
                                              unsigned int verbosity_in)
     : indir("")
-    , outname("")
+    , outdir("")
     , verbosity(verbosity_in)
 {
     read_module_file(module_file_path);
@@ -199,8 +239,12 @@ raw2trace_directory_t::~raw2trace_directory_t()
 {
     delete[] modfile_bytes;
     dr_close_file(modfile);
-    for (std::vector<std::istream *>::iterator fi = thread_files.begin();
-         fi != thread_files.end(); ++fi) {
+    for (std::vector<std::istream *>::iterator fi = in_files.begin();
+         fi != in_files.end(); ++fi) {
         delete *fi;
+    }
+    for (std::vector<std::ostream *>::iterator fo = out_files.begin();
+         fo != out_files.end(); ++fo) {
+        delete *fo;
     }
 }

--- a/clients/drcachesim/tracer/raw2trace_directory.h
+++ b/clients/drcachesim/tracer/raw2trace_directory.h
@@ -41,16 +41,21 @@
 
 class raw2trace_directory_t {
 public:
-    raw2trace_directory_t(const std::string &indir, const std::string &outname,
+    // If outdir.empty() then a peer of indir's OUTFILE_SUBDIR named TRACE_SUBDIR
+    // is used by default.
+    raw2trace_directory_t(const std::string &indir, const std::string &outdir,
                           unsigned int verbosity = 0);
     // This version is for constructing module_mapper_t.
     raw2trace_directory_t(const std::string &module_file_path,
                           unsigned int verbosity = 0);
     ~raw2trace_directory_t();
 
+    static std::string
+    tracedir_from_rawdir(const std::string &rawdir);
+
     char *modfile_bytes;
-    std::vector<std::istream *> thread_files;
-    std::ofstream out_file;
+    std::vector<std::istream *> in_files;
+    std::vector<std::ostream *> out_files;
 
 private:
     void
@@ -61,7 +66,7 @@ private:
     open_thread_log_file(const char *basename);
     file_t modfile;
     std::string indir;
-    std::string outname;
+    std::string outdir;
     unsigned int verbosity;
 };
 

--- a/clients/drcachesim/tracer/raw2trace_launcher.cpp
+++ b/clients/drcachesim/tracer/raw2trace_launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -47,11 +47,12 @@
 static droption_t<std::string>
     op_indir(DROPTION_SCOPE_FRONTEND, "indir", "",
              "[Required] Directory with trace input files",
-             "Specifies a directory within which all *.log files will be processed.");
+             "Specifies a directory within which all *.raw files will be processed.");
 
-static droption_t<std::string> op_out(DROPTION_SCOPE_FRONTEND, "out", "",
-                                      "[Required] Path to output file",
-                                      "Specifies the path to the output file.");
+static droption_t<std::string>
+    op_outdir(DROPTION_SCOPE_FRONTEND, "out", "", "Path to output directory",
+              "Specifies the path to the output directory where per-thread output files "
+              "will be written.  If unspecified, -indir/trace/ is used.");
 
 static droption_t<unsigned int> op_verbose(DROPTION_SCOPE_FRONTEND, "verbose", 0,
                                            "Verbosity level for diagnostic output",
@@ -76,14 +77,14 @@ _tmain(int argc, const TCHAR *targv[])
     std::string parse_err;
     if (!droption_parser_t::parse_argv(DROPTION_SCOPE_FRONTEND, argc, (const char **)argv,
                                        &parse_err, NULL) ||
-        op_indir.get_value().empty() || op_out.get_value().empty()) {
+        op_indir.get_value().empty()) {
         FATAL_ERROR("Usage error: %s\nUsage:\n%s", parse_err.c_str(),
                     droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
     }
 
-    raw2trace_directory_t dir(op_indir.get_value(), op_out.get_value(),
+    raw2trace_directory_t dir(op_indir.get_value(), op_outdir.get_value(),
                               op_verbose.get_value());
-    raw2trace_t raw2trace(dir.modfile_bytes, dir.thread_files, &dir.out_file, NULL,
+    raw2trace_t raw2trace(dir.modfile_bytes, dir.in_files, dir.out_files, NULL,
                           op_verbose.get_value());
     std::string error = raw2trace.do_conversion();
     if (!error.empty())

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2769,7 +2769,7 @@ endif ()
               set(tool.raw2trace.${testname}_precmd
                 "foreach@${CMAKE_COMMAND}@-E@remove_directory@drmemtrace.${exetgt}.*.dir")
               set(tool.raw2trace.${testname}_postcmd
-              "${raw2trace_io_path}@-indir@drmemtrace.${exetgt}.*.dir@-out@drraw2trace.${exetgt}.out")
+                "${raw2trace_io_path}@-indir@drmemtrace.${exetgt}.*.dir")
             endmacro()
             # actual trace processing not important -- set a very small limit for speed
             torunonly_raw2trace(simple ${ci_shared_app} "-max_trace_size 8K" "")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2814,7 +2814,7 @@ endif ()
       set(tool.histogram.offline_postcmd
         "${drcachesim_path}@-indir@drmemtrace.${histo_app}.*.dir")
       set(tool.histogram.offline_postcmd2
-        "${histo_path}@-test_mode@-trace@drmemtrace.${histo_app}.*.dir/drmemtrace.trace")
+        "${histo_path}@-test_mode@-trace_dir@drmemtrace.${histo_app}.*.dir/trace")
 
       find_program(GZIP gzip "gzip compression utility")
       if (UNIX AND ZLIB_FOUND AND GZIP)
@@ -2836,9 +2836,9 @@ endif ()
         set(tool.histogram.gzip_postcmd
           "${drcachesim_path}@-indir@drmemtrace.${histo_app}.*.dir")
         set(tool.histogram.gzip_postcmd2
-          "${GZIP}@drmemtrace.${histo_app}.*.dir/drmemtrace.trace")
+          "${GZIP}@drmemtrace.${histo_app}.*.dir/trace/*")
         set(tool.histogram.gzip_postcmd3
-          "${histo_path}@-test_mode@-trace@drmemtrace.${histo_app}.*.dir/drmemtrace.trace.gz")
+          "${histo_path}@-test_mode@-trace_dir@drmemtrace.${histo_app}.*.dir/trace")
       elseif (UNIX)
         message(STATUS "gzip or zlib not found: disabling tool.histogram.gzip test")
       endif ()


### PR DESCRIPTION
Refactors raw2trace to produce a separate trace file per thread rather
than interleaving them into a single file.  The file_reader now does
the interleaving.  As part of the refactoring, per-traced-thread data
is isolated in a data structure which is passed to each processing
routine.  This will make it easier to parallelize in the future.

Changes raw2trace_directory_t to produce a vector of output files, one
per input file.  It puts them in a trace/ subdir that is a peer of the
input raw/ subdir by default.

Deprecates the drcachesim front-end -infile but still supports it for
legacy traces.  Updates analyzer_multi's input code to
auto-post-process the raw files if there no processed files in a
trace/ subdirectory.

Updates the changelog, documentation, and intra-repository uses of
raw2trace.

Issue: #3230