### PR TITLE
i#3296: Eliminate 32-bit-heap-reachability in standalone mode

### DIFF
--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -2048,6 +2048,9 @@ controlled via disassemble_set_syntax().  The processor to use will not be
 automatically set and will be assumed to be \p VENDOR_INTEL.  Use
 proc_set_vendor() to set to \p VENDOR_AMD instead.
 
+In standalone mode, there are no 32-bit-displacement reachability
+guarantees regarding DynamoRIO's heap.
+
 Some DynamoRIO API routines are not supported in standalone mode.  These
 include all event registration routines, module iteration,
 dr_memory_protect(), dr_messagebox(), dr_get_current_drcontext(),

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -153,6 +153,8 @@ compatibility changes:
    application thread, rather than a single interleaved file.  Reading and analyzing
    a legacy interleaved file is still supported, but all new generated traces are
    split.  Splitting enables parallelized post-processing and trace analysis.
+ - In standalone mode, there are no 32-bit-displacement reachability guarantees
+   regarding DynamoRIO's heap.
 
 Further non-compatibility-affecting changes include:
 

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -863,6 +863,9 @@ standalone_init(void)
     standalone_library = true;
     /* We have release-build stats now so this is not just DEBUG */
     stats = &nonshared_stats;
+    /* No reason to limit heap size when there's no code cache. */
+    dynamo_options.reachable_heap = false;
+    dynamo_options.vm_base_near_app = false;
 #    if defined(INTERNAL) && defined(DEADLOCK_AVOIDANCE)
     /* avoid issues w/ GLOBAL_DCONTEXT instead of thread dcontext */
     dynamo_options.deadlock_avoidance = false;

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -864,7 +864,7 @@ standalone_init(void)
     /* We have release-build stats now so this is not just DEBUG */
     stats = &nonshared_stats;
     /* No reason to limit heap size when there's no code cache. */
-    dynamo_options.reachable_heap = false;
+    IF_X64(dynamo_options.reachable_heap = false;)
     dynamo_options.vm_base_near_app = false;
 #    if defined(INTERNAL) && defined(DEADLOCK_AVOIDANCE)
     /* avoid issues w/ GLOBAL_DCONTEXT instead of thread dcontext */


### PR DESCRIPTION
Disables 32-bit-displacement reachability constraints for DR's heap
when operating in standalone mode.  There is no need for it, as
there's no code cache where generating absolute references is costly.
This removes the 2GB memory limit from tools using DR standalone mode.

Updates the docs to mention this change.

Fixes #3296