### PR TITLE
i#3303: add and fix ARM/AArch64 support for drreg-test6

### DIFF
--- a/suite/tests/client-interface/drreg-test.c
+++ b/suite/tests/client-interface/drreg-test.c
@@ -397,11 +397,11 @@ GLOBAL_LABEL(FUNCNAME:)
         ret
 #elif defined(ARM)
         /* XXX i#3289: prologue missing */
-        /* Test 6: doesn't exit for ARM */
+        /* Test 6: doesn't exist for ARM */
         bx       lr
 #elif defined(AARCH64)
         /* XXX i#3289: prologue missing */
-        /* Test 6: doesn't exit for ARM */
+        /* Test 6: doesn't exist for AARCH64 */
         ret
 #endif
         END_FUNC(FUNCNAME)

--- a/suite/tests/client-interface/drreg-test.c
+++ b/suite/tests/client-interface/drreg-test.c
@@ -381,7 +381,7 @@ GLOBAL_LABEL(FUNCNAME:)
         END_PROLOG
 
         jmp      test6
-        /* Test 6: fault aflags restore */
+        /* Test 6: fault check ignore 3rd DR TLS slot */
      test6:
         mov      TEST_REG_ASM, DRREG_TEST_6_ASM
         mov      TEST_REG_ASM, DRREG_TEST_6_ASM
@@ -394,6 +394,36 @@ GLOBAL_LABEL(FUNCNAME:)
      epilog6:
         add      REG_XSP, FRAME_PADDING /* make a legal SEH64 epilog */
         POP_CALLEE_SAVED_REGS()
+        ret
+#elif defined(ARM)
+        /* XXX i#3289: prologue missing */
+        b        test6
+        /* Test 6: fault check ignore 3rd DR TLS slot */
+     test6:
+        movw     TEST_REG_ASM, DRREG_TEST_6_ASM
+        movw     TEST_REG_ASM, DRREG_TEST_6_ASM
+        nop
+        movw     TEST_REG_ASM, DRREG_TEST_7_ASM
+        nop
+        .word 0xe7f000f0 /* udf */
+
+        b        epilog6
+    epilog6:
+        bx       lr
+#elif defined(AARCH64)
+        /* XXX i#3289: prologue missing */
+        b        test6
+        /* Test 6: fault check ignore 3rd DR TLS slot */
+     test6:
+        movz     TEST_REG_ASM, DRREG_TEST_6_ASM
+        movz     TEST_REG_ASM, DRREG_TEST_6_ASM
+        nop
+        movz     TEST_REG_ASM, DRREG_TEST_7_ASM
+        nop
+        .inst 0xf36d19 /* udf */
+
+        b        epilog6
+    epilog6:
         ret
 #endif
         END_FUNC(FUNCNAME)

--- a/suite/tests/client-interface/drreg-test.c
+++ b/suite/tests/client-interface/drreg-test.c
@@ -397,33 +397,11 @@ GLOBAL_LABEL(FUNCNAME:)
         ret
 #elif defined(ARM)
         /* XXX i#3289: prologue missing */
-        b        test6
-        /* Test 6: fault check ignore 3rd DR TLS slot */
-     test6:
-        movw     TEST_REG_ASM, DRREG_TEST_6_ASM
-        movw     TEST_REG_ASM, DRREG_TEST_6_ASM
-        nop
-        movw     TEST_REG_ASM, DRREG_TEST_7_ASM
-        nop
-        .word 0xe7f000f0 /* udf */
-
-        b        epilog6
-    epilog6:
+        /* Test 6: doesn't exit for ARM */
         bx       lr
 #elif defined(AARCH64)
         /* XXX i#3289: prologue missing */
-        b        test6
-        /* Test 6: fault check ignore 3rd DR TLS slot */
-     test6:
-        movz     TEST_REG_ASM, DRREG_TEST_6_ASM
-        movz     TEST_REG_ASM, DRREG_TEST_6_ASM
-        nop
-        movz     TEST_REG_ASM, DRREG_TEST_7_ASM
-        nop
-        .inst 0xf36d19 /* udf */
-
-        b        epilog6
-    epilog6:
+        /* Test 6: doesn't exit for ARM */
         ret
 #endif
         END_FUNC(FUNCNAME)


### PR DESCRIPTION
Add ARM/AArch64 support for 3rd DR spill slot test6 in drreg-test.

Fixes #3303