### PR TITLE
i#3106: add analysis_tool_t::initialize()

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -252,7 +252,8 @@ Further non-compatibility-affecting changes include:
    - Added #module_mapper_t, which factors out the module mapping functionality
      out of #raw2trace_t, replacing the following #raw2trace_t APIs:
      #raw2trace_t::handle_custom_data(), #raw2trace_t::do_module_parsing(),
-     #raw2trace_t::do_module_parsing_and_mapping(), and #raw2trace_t::find_mapped_trace_address().
+     #raw2trace_t::do_module_parsing_and_mapping(), and
+     #raw2trace_t::find_mapped_trace_address().
    - Added #trace_metadata_writer_t, a set of utility functions used by drcachesim's
      #raw2trace_t for writing trace metadata: process/thread ids, timestamps, etc.
    - Added #trace_metadata_reader_t, a set of utilities for checking and validating
@@ -272,6 +273,10 @@ Further non-compatibility-affecting changes include:
    in a hashtable with user data also available.
  - Added cmake function DynamoRIO_get_full_path that shall be used instead of reading
    the LOCATION target property.
+ - Added a drcachesim/drmemtrace analysis tool routine initialize() to help separate
+   initialization that could fail from tool construction.
+ - Split raw2trace_directory_t initialization from its constructors
+   into new initialize() and initialize_module_file() methods.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -66,6 +66,15 @@ public:
     analysis_tool_t()
         : success(true){};
     virtual ~analysis_tool_t(){}; /**< Destructor. */
+    /**
+     * Tools are encouraged to perform any initialization that might fail here rather
+     * than in the constructor.  On an error, this will set the success flag, and
+     * get_error_string() provides a descriptive error message.
+     */
+    virtual void
+    initialize()
+    {
+    }
     /** Returns whether the tool was created successfully. */
     virtual bool operator!()
     {

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -78,6 +78,8 @@ analyzer_t::analyzer_t(const std::string &trace_file, analysis_tool_t **tools_in
     , tools(tools_in)
 {
     for (int i = 0; i < num_tools; ++i) {
+        if (tools[i] != NULL && !!*tools[i])
+            tools[i]->initialize();
         if (tools[i] == NULL || !*tools[i]) {
             success = false;
             error_string = "Tool is not successfully initialized";

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -78,6 +78,7 @@ public:
      * The analyzer will reference the tools array passed in during its lifetime:
      * it does not make a copy.
      * The user must free them afterward.
+     * The analyzer calls the initialize() function on each tool before use.
      */
     analyzer_t(const std::string &trace_file, analysis_tool_t **tools, int num_tools);
     /** Launches the analysis process. */

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -185,7 +185,9 @@ post_process()
         /* First, test just the module parsing w/o writing a final trace, in a separate
          * scope to delete the drmodtrack state afterward.
          */
-        raw2trace_directory_t dir(raw_dir, "");
+        raw2trace_directory_t dir;
+        std::string dir_err = dir.initialize(raw_dir, "");
+        assert(dir_err.empty());
         std::unique_ptr<module_mapper_t> module_mapper = module_mapper_t::create(
             dir.modfile_bytes, parse_cb, process_cb, MAGIC_VALUE, free_cb);
         assert(module_mapper->get_last_error().empty());
@@ -200,7 +202,9 @@ post_process()
     /* Now write a final trace to a location that the drcachesim -indir step
      * run by the outer test harness will find (TRACE_FILENAME).
      */
-    raw2trace_directory_t dir(raw_dir, "");
+    raw2trace_directory_t dir;
+    std::string dir_err = dir.initialize(raw_dir, "");
+    assert(dir_err.empty());
     raw2trace_t raw2trace(dir.modfile_bytes, dir.in_files, dir.out_files, dr_context, 0);
     std::string error =
         raw2trace.handle_custom_data(parse_cb, process_cb, MAGIC_VALUE, free_cb);

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -262,7 +262,10 @@ main(int argc, const char *argv[])
     /* Open input/output files outside of traced region. And explicitly don't destroy dir,
      * so they never get closed.
      */
-    raw2trace_directory_t *dir = new raw2trace_directory_t(op_indir.get_value(), "");
+    raw2trace_directory_t *dir = new raw2trace_directory_t;
+    std::string dir_err = dir->initialize(op_indir.get_value(), "");
+    if (!dir_err.empty())
+        std::cerr << "Directory setup failed: " << dir_err;
 
     bool test1_ret = test_raw2trace(dir);
     bool test2_ret = test_module_mapper(dir);

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -52,11 +52,16 @@ opcode_mix_tool_create(const std::string &module_file_path, unsigned int verbose
     return new opcode_mix_t(module_file_path, verbose);
 }
 
-opcode_mix_t::opcode_mix_t(const std::string &module_file_path, unsigned int verbose)
+opcode_mix_t::opcode_mix_t(const std::string &module_file_path_in, unsigned int verbose)
     : dcontext(nullptr)
-    , directory(module_file_path)
+    , module_file_path(module_file_path_in)
     , knob_verbose(verbose)
     , instr_count(0)
+{
+}
+
+void
+opcode_mix_t::initialize()
 {
     if (module_file_path.empty()) {
         error_string = "Module file path is missing";
@@ -64,10 +69,16 @@ opcode_mix_t::opcode_mix_t(const std::string &module_file_path, unsigned int ver
         return;
     }
     dcontext = dr_standalone_init();
+    std::string error = directory.initialize_module_file(module_file_path);
+    if (!error.empty()) {
+        error_string = "Failed to initialize directory: " + error;
+        success = false;
+        return;
+    }
     module_mapper = module_mapper_t::create(directory.modfile_bytes, nullptr, nullptr,
-                                            nullptr, nullptr, verbose);
+                                            nullptr, nullptr, knob_verbose);
     module_mapper->get_loaded_modules();
-    std::string error = module_mapper->get_last_error();
+    error = module_mapper->get_last_error();
     if (!error.empty()) {
         error_string = "Failed to load binaries: " + error;
         success = false;

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -46,13 +46,16 @@ public:
     virtual ~opcode_mix_t()
     {
     }
-    virtual bool
-    process_memref(const memref_t &memref);
-    virtual bool
-    print_results();
+    void
+    initialize() override;
+    bool
+    process_memref(const memref_t &memref) override;
+    bool
+    print_results() override;
 
 protected:
     void *dcontext;
+    std::string module_file_path;
     std::unique_ptr<module_mapper_t> module_mapper;
     // We reference directory.modfile_bytes throughout operation, so its lifetime
     // must match ours.

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -52,15 +52,21 @@ view_tool_create(const std::string &module_file_path, uint64_t skip_refs,
     return new view_t(module_file_path, skip_refs, sim_refs, syntax, verbose);
 }
 
-view_t::view_t(const std::string &module_file_path, uint64_t skip_refs, uint64_t sim_refs,
-               const std::string &syntax, unsigned int verbose)
+view_t::view_t(const std::string &module_file_path_in, uint64_t skip_refs,
+               uint64_t sim_refs, const std::string &syntax, unsigned int verbose)
     : dcontext(nullptr)
-    , directory(module_file_path)
+    , module_file_path(module_file_path_in)
     , knob_verbose(verbose)
     , instr_count(0)
     , knob_skip_refs(skip_refs)
     , knob_sim_refs(sim_refs)
+    , knob_syntax(syntax)
     , num_disasm_instrs(0)
+{
+}
+
+void
+view_t::initialize()
 {
     if (module_file_path.empty()) {
         error_string = "Module file path is missing";
@@ -68,22 +74,27 @@ view_t::view_t(const std::string &module_file_path, uint64_t skip_refs, uint64_t
         return;
     }
     dcontext = dr_standalone_init();
+    std::string error = directory.initialize_module_file(module_file_path);
+    if (!error.empty()) {
+        error_string = "Failed to initialize directory: " + error;
+        success = false;
+        return;
+    }
     module_mapper = module_mapper_t::create(directory.modfile_bytes, nullptr, nullptr,
-                                            nullptr, nullptr, verbose);
+                                            nullptr, nullptr, knob_verbose);
     module_mapper->get_loaded_modules();
-    std::string error = module_mapper->get_last_error();
+    error = module_mapper->get_last_error();
     if (!error.empty()) {
         error_string = "Failed to load binaries: " + error;
         success = false;
         return;
     }
-
     dr_disasm_flags_t flags = DR_DISASM_ATT;
-    if (syntax == "intel") {
+    if (knob_syntax == "intel") {
         flags = DR_DISASM_INTEL;
-    } else if (syntax == "dr") {
+    } else if (knob_syntax == "dr") {
         flags = DR_DISASM_DR;
-    } else if (syntax == "arm") {
+    } else if (knob_syntax == "arm") {
         flags = DR_DISASM_ARM;
     }
     disassemble_set_syntax(flags);

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -47,13 +47,16 @@ public:
     virtual ~view_t()
     {
     }
-    virtual bool
-    process_memref(const memref_t &memref);
-    virtual bool
-    print_results();
+    void
+    initialize() override;
+    bool
+    process_memref(const memref_t &memref) override;
+    bool
+    print_results() override;
 
 protected:
     void *dcontext;
+    std::string module_file_path;
     std::unique_ptr<module_mapper_t> module_mapper;
     raw2trace_directory_t directory;
     unsigned int knob_verbose;
@@ -61,6 +64,7 @@ protected:
     static const std::string TOOL_NAME;
     uint64_t knob_skip_refs;
     uint64_t knob_sim_refs;
+    std::string knob_syntax;
     uint64_t num_disasm_instrs;
     std::unordered_map<app_pc, std::string> disasm_cache;
 };

--- a/clients/drcachesim/tracer/raw2trace_directory.cpp
+++ b/clients/drcachesim/tracer/raw2trace_directory.cpp
@@ -244,8 +244,10 @@ raw2trace_directory_t::initialize_module_file(const std::string &module_file_pat
 
 raw2trace_directory_t::~raw2trace_directory_t()
 {
-    delete[] modfile_bytes;
-    dr_close_file(modfile);
+    if (modfile_bytes != nullptr)
+        delete[] modfile_bytes;
+    if (modfile != INVALID_FILE)
+        dr_close_file(modfile);
     for (std::vector<std::istream *>::iterator fi = in_files.begin();
          fi != in_files.end(); ++fi) {
         delete *fi;

--- a/clients/drcachesim/tracer/raw2trace_directory.cpp
+++ b/clients/drcachesim/tracer/raw2trace_directory.cpp
@@ -80,21 +80,21 @@
         }                                      \
     } while (0)
 
-void
+std::string
 raw2trace_directory_t::open_thread_files()
 {
     VPRINT(1, "Iterating dir %s\n", indir.c_str());
     directory_iterator_t end;
     directory_iterator_t iter(indir);
     if (!iter) {
-        FATAL_ERROR("Failed to list directory %s: %s", indir.c_str(),
-                    iter.error_string().c_str());
+        return "Failed to list directory " + indir + ": " + iter.error_string();
     }
     for (; iter != end; ++iter)
         open_thread_log_file((*iter).c_str());
+    return "";
 }
 
-void
+std::string
 raw2trace_directory_t::open_thread_log_file(const char *basename)
 {
     char path[MAXIMUM_PATH];
@@ -102,25 +102,25 @@ raw2trace_directory_t::open_thread_log_file(const char *basename)
           basename);
     // Skip the module list log.
     if (strcmp(basename, DRMEMTRACE_MODULE_LIST_FILENAME) == 0)
-        return;
+        return "";
     // Skip any non-.raw in case someone put some other file in there.
     const char *basename_pre_suffix = strrchr(basename, '.');
     if (basename_pre_suffix != nullptr)
         basename_pre_suffix = strstr(basename_pre_suffix, OUTFILE_SUFFIX);
     if (basename_pre_suffix == nullptr)
-        return;
+        return "";
     if (dr_snprintf(path, BUFFER_SIZE_ELEMENTS(path), "%s%s%s", indir.c_str(), DIRSEP,
                     basename) <= 0) {
-        FATAL_ERROR("Failed to get full path of file %s", basename);
+        return "Failed to get full path of file " + std::string(basename);
     }
     NULL_TERMINATE_BUFFER(path);
     in_files.push_back(new std::ifstream(path, std::ifstream::binary));
     if (!(*in_files.back()))
-        FATAL_ERROR("Failed to open thread log file %s", path);
+        return "Failed to open thread log file " + std::string(path);
     std::string error = raw2trace_t::check_thread_file(in_files.back());
     if (!error.empty()) {
-        FATAL_ERROR("Failed sanity checks for thread log file %s: %s", path,
-                    error.c_str());
+        return "Failed sanity checks for thread log file " + std::string(path) + ": " +
+            error;
     }
     VPRINT(1, "Opened input file %s\n", path);
 
@@ -128,11 +128,11 @@ raw2trace_directory_t::open_thread_log_file(const char *basename)
     char outname[MAXIMUM_PATH];
     if (dr_snprintf(outname, BUFFER_SIZE_ELEMENTS(outname), "%.*s",
                     basename_pre_suffix - 1 - basename, basename) <= 0) {
-        FATAL_ERROR("Failed to compute output name for file %s", basename);
+        return "Failed to compute output name for file " + std::string(basename);
     }
     if (dr_snprintf(path, BUFFER_SIZE_ELEMENTS(path), "%s%s%s.%s", outdir.c_str(), DIRSEP,
                     outname, TRACE_SUFFIX) <= 0) {
-        FATAL_ERROR("Failed to compute full path of output file for %s", basename);
+        return "Failed to compute full path of output file for " + std::string(basename);
     }
     std::ostream *ofile;
 #ifdef HAS_ZLIB
@@ -142,23 +142,25 @@ raw2trace_directory_t::open_thread_log_file(const char *basename)
 #endif
     out_files.push_back(ofile);
     if (!(*out_files.back()))
-        FATAL_ERROR("Failed to open output file %s", path);
+        return "Failed to open output file " + std::string(path);
     VPRINT(1, "Opened output file %s\n", path);
+    return "";
 }
 
-void
+std::string
 raw2trace_directory_t::read_module_file(const std::string &modfilename)
 {
     modfile = dr_open_file(modfilename.c_str(), DR_FILE_READ);
     if (modfile == INVALID_FILE)
-        FATAL_ERROR("Failed to open module file %s", modfilename.c_str());
+        return "Failed to open module file " + modfilename;
     uint64 modfile_size;
     if (!dr_file_size(modfile, &modfile_size))
-        FATAL_ERROR("Failed to get module file size: %s", modfilename.c_str());
+        return "Failed to get module file size: " + modfilename;
     size_t modfile_size_ = (size_t)modfile_size;
     modfile_bytes = new char[modfile_size_];
     if (dr_read_file(modfile, modfile_bytes, modfile_size_) < (ssize_t)modfile_size_)
-        FATAL_ERROR("Didn't read whole module file %s", modfilename.c_str());
+        return "Didn't read whole module file " + modfilename;
+    return "";
 }
 
 std::string
@@ -184,7 +186,7 @@ raw2trace_directory_t::tracedir_from_rawdir(const std::string &rawdir_in)
         std::string tracedir = rawdir;
         size_t pos = rawdir.rfind(raw_sub);
         if (pos == std::string::npos)
-            FATAL_ERROR("Internal error: should have returned already");
+            CHECK(false, "Internal error: should have returned already");
         tracedir.erase(pos, raw_sub.size());
         tracedir.insert(pos, trace_sub);
         return tracedir;
@@ -198,13 +200,12 @@ raw2trace_directory_t::tracedir_from_rawdir(const std::string &rawdir_in)
     return rawdir;
 }
 
-raw2trace_directory_t::raw2trace_directory_t(const std::string &indir_in,
-                                             const std::string &outdir_in,
-                                             unsigned int verbosity_in)
-    : indir(indir_in)
-    , outdir(outdir_in)
-    , verbosity(verbosity_in)
+std::string
+raw2trace_directory_t::initialize(const std::string &indir_in,
+                                  const std::string &outdir_in)
 {
+    indir = indir_in;
+    outdir = outdir_in;
 #ifdef WINDOWS
     // Canonicalize.
     std::replace(indir.begin(), indir.end(), ALT_DIRSEP[0], DIRSEP[0]);
@@ -213,7 +214,7 @@ raw2trace_directory_t::raw2trace_directory_t(const std::string &indir_in,
     while (indir.back() == DIRSEP[0])
         indir.pop_back();
     if (!directory_iterator_t::is_directory(indir))
-        FATAL_ERROR("Directory does not exist: %s\n", indir.c_str());
+        return "Directory does not exist: " + indir;
     // Support passing both base dir and raw/ subdir.
     if (indir.find(OUTFILE_SUBDIR) == std::string::npos) {
         indir += std::string(DIRSEP) + OUTFILE_SUBDIR;
@@ -223,8 +224,7 @@ raw2trace_directory_t::raw2trace_directory_t(const std::string &indir_in,
         outdir = tracedir_from_rawdir(indir);
         if (!directory_iterator_t::is_directory(outdir)) {
             if (!directory_iterator_t::create_directory(outdir)) {
-                FATAL_ERROR("Failed to create output dir %s: errno=%d\n", outdir.c_str(),
-                            errno);
+                return "Failed to create output dir " + outdir;
             }
         }
     }
@@ -233,15 +233,13 @@ raw2trace_directory_t::raw2trace_directory_t(const std::string &indir_in,
     read_module_file(modfilename);
 
     open_thread_files();
+    return "";
 }
 
-raw2trace_directory_t::raw2trace_directory_t(const std::string &module_file_path,
-                                             unsigned int verbosity_in)
-    : indir("")
-    , outdir("")
-    , verbosity(verbosity_in)
+std::string
+raw2trace_directory_t::initialize_module_file(const std::string &module_file_path)
 {
-    read_module_file(module_file_path);
+    return read_module_file(module_file_path);
 }
 
 raw2trace_directory_t::~raw2trace_directory_t()

--- a/clients/drcachesim/tracer/raw2trace_directory.h
+++ b/clients/drcachesim/tracer/raw2trace_directory.h
@@ -42,7 +42,9 @@
 class raw2trace_directory_t {
 public:
     raw2trace_directory_t(unsigned int verbosity_in = 0)
-        : indir("")
+        : modfile_bytes(nullptr)
+        , modfile(INVALID_FILE)
+        , indir("")
         , outdir("")
         , verbosity(verbosity_in)
     {

--- a/clients/drcachesim/tracer/raw2trace_directory.h
+++ b/clients/drcachesim/tracer/raw2trace_directory.h
@@ -41,14 +41,23 @@
 
 class raw2trace_directory_t {
 public:
-    // If outdir.empty() then a peer of indir's OUTFILE_SUBDIR named TRACE_SUBDIR
-    // is used by default.
-    raw2trace_directory_t(const std::string &indir, const std::string &outdir,
-                          unsigned int verbosity = 0);
-    // This version is for constructing module_mapper_t.
-    raw2trace_directory_t(const std::string &module_file_path,
-                          unsigned int verbosity = 0);
+    raw2trace_directory_t(unsigned int verbosity_in = 0)
+        : indir("")
+        , outdir("")
+        , verbosity(verbosity_in)
+    {
+    }
     ~raw2trace_directory_t();
+
+    // If outdir.empty() then a peer of indir's OUTFILE_SUBDIR named TRACE_SUBDIR
+    // is used by default.  Returns "" on success or an error message on failure.
+    std::string
+    initialize(const std::string &indir, const std::string &outdir);
+    // Use this instead of initialize() to only fill in modfile_bytes, for
+    // constructing a module_mapper_t.  Returns "" on success or an error message on
+    // failure.
+    std::string
+    initialize_module_file(const std::string &module_file_path);
 
     static std::string
     tracedir_from_rawdir(const std::string &rawdir);
@@ -58,11 +67,11 @@ public:
     std::vector<std::ostream *> out_files;
 
 private:
-    void
+    std::string
     read_module_file(const std::string &modfilename);
-    void
+    std::string
     open_thread_files();
-    void
+    std::string
     open_thread_log_file(const char *basename);
     file_t modfile;
     std::string indir;

--- a/clients/drcachesim/tracer/raw2trace_launcher.cpp
+++ b/clients/drcachesim/tracer/raw2trace_launcher.cpp
@@ -89,8 +89,10 @@ _tmain(int argc, const TCHAR *targv[])
                     droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
     }
 
-    raw2trace_directory_t dir(op_indir.get_value(), op_outdir.get_value(),
-                              op_verbose.get_value());
+    raw2trace_directory_t dir(op_verbose.get_value());
+    std::string dir_err = dir.initialize(op_indir.get_value(), op_outdir.get_value());
+    if (!dir_err.empty())
+        FATAL_ERROR("Directory parsing failed: %s", dir_err.c_str());
     raw2trace_t raw2trace(dir.modfile_bytes, dir.in_files, dir.out_files, NULL,
                           op_verbose.get_value(), op_jobs.get_value());
     std::string error = raw2trace.do_conversion();


### PR DESCRIPTION
Adds a separate analysis_tool_t::initialize() method to better handle
tool initialization that can fail, separating it out from the
constructor.  This simplifies subclassing as well.

Updates the view_t and opcode_mix_t tools to move their module mapping
and other code into initialize().  Leaves updating the simulator tools
for future work.

Changes raw2trace_directory_t to return error strings instead of
aborting the process, and splits its constructor from new initialize()
and initialize_module_file() methods.

Fixes #3106