### PR TITLE
i#3230 split traces: add parallel trace analysis support

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -277,9 +277,9 @@ Further non-compatibility-affecting changes include:
    initialization that could fail from tool construction.
  - Split raw2trace_directory_t initialization from its constructors
    into new initialize() and initialize_module_file() methods.
- - Added drcachesim/drmemtrace support for analyzing traces in parallel, concurrently
-   operating on each traced thread (or other sharding division).  This is made
-   possible by the new storage of traces in separate files.  Adds a new
+ - Added drcachesim/drmemtrace support for analyzing offline traces in parallel,
+   concurrently operating on each traced thread (or other sharding division).  This
+   is made possible by the new storage of traces in separate files.  Adds a new
    analysis_tool_t interface where if the tool's parallel_shard_supported() returns
    true, analyzer_t switches to a parallel operation mode.  Today, a simple static
    scheduling among worker threads is used.  Each worker completely owns one or more

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -277,6 +277,19 @@ Further non-compatibility-affecting changes include:
    initialization that could fail from tool construction.
  - Split raw2trace_directory_t initialization from its constructors
    into new initialize() and initialize_module_file() methods.
+ - Added drcachesim/drmemtrace support for analyzing traces in parallel, concurrently
+   operating on each traced thread (or other sharding division).  This is made
+   possible by the new storage of traces in separate files.  Adds a new
+   analysis_tool_t interface where if the tool's parallel_shard_supported() returns
+   true, analyzer_t switches to a parallel operation mode.  Today, a simple static
+   scheduling among worker threads is used.  Each worker completely owns one or more
+   shards, eliminating the need for synchronization when processing a thread's trace
+   entries.  The tools' parallel_shard_init() function is invoked to create
+   traced-thread-local data, which is passed to parallel_shard_memref().  A
+   parallel_shard_exit() is provided for cleanup, though most tools will sort,
+   aggregate, and clean up in print_results().
+ - Added module_mapper_t::find_mapped_trace_bounds() to allow callers to cache
+   results and avoid global locks during parallel operation.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -168,6 +168,7 @@ add_exported_library(drmemtrace_analyzer STATIC
   ${zlib_reader}
   )
 target_link_libraries(drmemtrace_analyzer directory_iterator)
+link_with_pthread(drmemtrace_analyzer)
 # We get away w/ exporting the generically-named "utils.h" by putting into a
 # drmemtrace/ subdir.
 install_client_nonDR_header(drmemtrace common/utils.h)

--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -54,10 +54,10 @@
  * "shards" which are each processed sequentially.  The default shard is a traced
  * application thread, but the tool interface can support other divisions.  For tools
  * that support concurrent processing of shards and do not need to see a single
- * time-sorted interleaved merged trace, the interface functions with the parallel_
+ * thread-interleaved merged trace, the interface functions with the parallel_
  * prefix should be implemented, and parallel_shard_supported() should return true.
  * parallel_shard_init() will be invoked for each shard prior to invoking
- * parallel_shard_memref() for each entry in that shard; the data structure returned
+ * parallel_shard_memref() for any entry in that shard; the data structure returned
  * from parallel_shard_init() will be passed to parallel_shard_memref() for each
  * trace entry for that shard.  The concurrency model used guarantees that all
  * entries from any one shard are processed by the same single worker thread, so no
@@ -131,7 +131,7 @@ public:
 
     /**
      * Returns whether this tool supports analyzing trace shards concurrently, or
-     * whether it needs to see a single time-sorted interleaved stream of traced
+     * whether it needs to see a single thread-interleaved stream of traced
      * events.
      */
     virtual bool
@@ -183,10 +183,13 @@ public:
      * results.  Most tools, however, prefer to aggregate data or at least sort data,
      * and perform nothing here, doing all cleanup in print_results() by storing the
      * thread data into a table.
+     * Return whether exiting was successful. On failure, parallel_shard_error()
+     * returns a descriptive message.
      */
-    virtual void
+    virtual bool
     parallel_shard_exit(void *shard_data)
     {
+        return true;
     }
     /**
      * The heart of an analysis tool, this routine operates on a single trace entry
@@ -194,7 +197,7 @@ public:
      * shard_data parameter is the value returned by parallel_shard_init() for this
      * shard.  Since each shard is operated upon in its entirety by the same worker
      * thread, no synchronization is needed.  The return value indicates whether this
-     * function was successful. On failure, parallel_shared_error() returns a
+     * function was successful. On failure, parallel_shard_error() returns a
      * descriptive message.
      */
     virtual bool

--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -48,13 +48,39 @@
 
 /**
  * The base class for a tool that analyzes a trace.  A new tool should subclass this
- * class.  Two key functions should be overridden: process_memref(), which operates
- * on a single trace entry, and print_results(), which is called just once after
- * processing the entire trace and should present the results of analysis.  In the
- * default mode of operation, the #analyzer_t class iterates over the trace and calls
- * the process_memref() function of each tool.  An alternative mode is supported
- * which exposes the iterator and allows a separate control infrastructure to be
- * built.
+ * class.
+ *
+ * Concurrent processing of traces is supported by logically splitting a trace into
+ * "shards" which are each processed sequentially.  The default shard is a traced
+ * application thread, but the tool interface can support other divisions.  For tools
+ * that support concurrent processing of shards and do not need to see a single
+ * time-sorted interleaved merged trace, the interface functions with the parallel_
+ * prefix should be implemented, and parallel_shard_supported() should return true.
+ * parallel_shard_init() will be invoked for each shard prior to invoking
+ * parallel_shard_memref() for each entry in that shard; the data structure returned
+ * from parallel_shard_init() will be passed to parallel_shard_memref() for each
+ * trace entry for that shard.  The concurrency model used guarantees that all
+ * entries from any one shard are processed by the same single worker thread, so no
+ * synchronization is needed inside the parallel_ functions.  A single worker thread
+ * invokes print_results() as well.
+ *
+ * For serial operation, process_memref(), operates on a trace entry in a single,
+ * sorted, interleaved stream of trace entries.  In the default mode of operation,
+ * the #analyzer_t class iterates over the trace and calls the process_memref()
+ * function of each tool.  An alternative mode is supported which exposes the
+ * iterator and allows a separate control infrastructure to be built.  This
+ * alternative mode does not support parallel operation at this time.
+ *
+ * Both parallel and serial operation can be supported by a tool, typically by having
+ * process_memref() create data on a newly seen traced thread and invoking
+ * parallel_shard_memref() to do its work.
+ *
+ * For both parallel and serial operation, the function print_results() should be
+ * overridden.  It is called just once after processing all trace data and it should
+ * present the results of the analysis.  For parallel operation, any desired
+ * aggregation across the whole trace should occur here as well, while shard-specific
+ * results can be presented in parallel_shard_exit().
+ *
  */
 class analysis_tool_t {
 public:
@@ -101,6 +127,86 @@ public:
      */
     virtual bool
     print_results() = 0;
+
+    /**
+     * Returns whether this tool supports analyzing trace shards concurrently, or
+     * whether it needs to see a single time-sorted interleaved stream of traced
+     * events.
+     */
+    virtual bool
+    parallel_shard_supported()
+    {
+        return false;
+    }
+    /**
+     * Invoked once for each worker thread prior to calling any shard routine from
+     * that thread.  This allows a tool to create data local to a worker, such as a
+     * cache of data global to the trace that crosses shards.  This data does not
+     * need any synchronization as it will only be accessed by this worker thread.
+     * The \p worker_index is a unique identifier for this worker.  The return value
+     * here will be passed to the invocation of parallel_shard_init() for each shard
+     * upon which this worker operates.
+     */
+    virtual void *
+    parallel_worker_init(int worker_index)
+    {
+        return nullptr;
+    }
+    /**
+     * Invoked once when a worker thread is finished processing all shard data.  The
+     * \p worker_data is the return value of parallel_worker_init().
+     */
+    virtual void
+    parallel_worker_exit(void *worker_data)
+    {
+    }
+    /**
+     * Invoked once for each trace shard prior to calling parallel_shard_memref() for
+     * that shard, this allows a tool to create data local to a shard.  The \p
+     * shard_index is a unique identifier allowing shard data to be stored into a
+     * global table if desired (typically for aggregation use in print_results()).
+     * The \p worker_data is the return value of parallel_worker_init() for the
+     * worker thread who will exclusively operate on this shard.  The return value
+     * here will be passed to each invocation of parallel_shard_memref() for that
+     * same shard.
+     */
+    virtual void *
+    parallel_shard_init(int shard_index, void *worker_data)
+    {
+        return nullptr;
+    }
+    /**
+     * Invoked once when all trace entries for a shard have been processed.  \p
+     * shard_data is the value returned by parallel_shard_init() for this shard.
+     * This allows a tool to clean up its thread data, or to report thread analysis
+     * results.  Most tools, however, prefer to aggregate data or at least sort data,
+     * and perform nothing here, doing all cleanup in print_results() by storing the
+     * thread data into a table.
+     */
+    virtual void
+    parallel_shard_exit(void *shard_data)
+    {
+    }
+    /**
+     * The heart of an analysis tool, this routine operates on a single trace entry
+     * and takes whatever actions the tool needs to perform its analysis. The \p
+     * shard_data parameter is the value returned by parallel_shard_init() for this
+     * shard.  Since each shard is operated upon in its entirety by the same worker
+     * thread, no synchronization is needed.  The return value indicates whether this
+     * function was successful. On failure, parallel_shared_error() returns a
+     * descriptive message.
+     */
+    virtual bool
+    parallel_shard_memref(void *shard_data, const memref_t &memref)
+    {
+        return false;
+    }
+    /** Returns a description of the last error for this shard. */
+    virtual std::string
+    parallel_shard_error(void *shard_data)
+    {
+        return "";
+    }
 
 protected:
     bool success;

--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -155,11 +155,13 @@ public:
     }
     /**
      * Invoked once when a worker thread is finished processing all shard data.  The
-     * \p worker_data is the return value of parallel_worker_init().
+     * \p worker_data is the return value of parallel_worker_init().  A non-empty
+     * string indicates an error while an empty string indicates success.
      */
-    virtual void
+    virtual std::string
     parallel_worker_exit(void *worker_data)
     {
+        return "";
     }
     /**
      * Invoked once for each trace shard prior to calling parallel_shard_memref() for

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -220,10 +220,19 @@ analyzer_t::process_tasks(std::vector<analyzer_shard_data_t *> *tasks)
         for (int i = 0; i < num_tools; ++i) {
             if (!tools[i]->parallel_shard_exit(shard_data[i])) {
                 tdata->error = tools[i]->parallel_shard_error(shard_data[i]);
-                VPRINT(this, 1, "Worker %d hit shared exit error %s on trace shard %d\n",
+                VPRINT(this, 1, "Worker %d hit shard exit error %s on trace shard %d\n",
                        tdata->worker, tdata->error.c_str(), tdata->index);
                 return;
             }
+        }
+    }
+    for (int i = 0; i < num_tools; ++i) {
+        const std::string error = tools[i]->parallel_worker_exit(worker_data[i]);
+        if (!error.empty()) {
+            (*tasks)[0]->error = error;
+            VPRINT(this, 1, "Worker %d hit worker exit error %s\n", (*tasks)[0]->worker,
+                   error.c_str());
+            return;
         }
     }
 }

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -222,6 +222,10 @@ analyzer_t::run()
 {
     // XXX i#3286: Add a %-completed progress message by looking at the file sizes.
     if (parallel) {
+        if (worker_count <= 0) {
+            error_string = "Invalid worker count: must be > 0";
+            return false;
+        }
         std::vector<std::thread> threads;
         VPRINT(this, 1, "Creating %d worker threads\n", worker_count);
         threads.reserve(worker_count);

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -31,6 +31,7 @@
  */
 
 #include <iostream>
+#include <thread>
 #include "analysis_tool.h"
 #include "analyzer.h"
 #include "reader/file_reader.h"
@@ -39,43 +40,83 @@
 #endif
 #include "common/utils.h"
 
+#ifdef HAS_ZLIB
+// Even if the file is uncompressed, zlib's gzip interface is faster than
+// file_reader_t's fstream in our measurements, so we always use it when
+// available.
+typedef compressed_file_reader_t my_file_reader_t;
+#else
+typedef file_reader_t<std::ifstream *> my_file_reader_t;
+#endif
+
 analyzer_t::analyzer_t()
     : success(true)
-    , trace_iter(NULL)
-    , trace_end(NULL)
     , num_tools(0)
     , tools(NULL)
+    , parallel(true)
+    , worker_count(0)
 {
     /* Nothing else: child class needs to initialize. */
 }
 
 bool
-analyzer_t::init_file_reader(const std::string &trace_file)
+analyzer_t::init_file_reader(const std::string &trace_path, int verbosity_in)
 {
-    if (trace_file.empty()) {
+    verbosity = verbosity_in;
+    if (trace_path.empty()) {
         ERRMSG("Trace file name is empty\n");
         return false;
     }
-#ifdef HAS_ZLIB
-    // Even if the file is uncompressed, zlib's gzip interface is faster than
-    // file_reader_t's fstream in our measurements, so we always use it when
-    // available.
-    trace_iter = new compressed_file_reader_t(trace_file.c_str());
-    trace_end = new compressed_file_reader_t();
-#else
-    trace_iter = new file_reader_t<std::ifstream *>(trace_file.c_str());
-    trace_end = new file_reader_t<std::ifstream *>();
-#endif
+    for (int i = 0; i < num_tools; ++i) {
+        if (parallel && !tools[i]->parallel_shard_supported()) {
+            parallel = false;
+            break;
+        }
+    }
+    if (parallel && directory_iterator_t::is_directory(trace_path)) {
+        directory_iterator_t end;
+        directory_iterator_t iter(trace_path);
+        if (!iter) {
+            ERRMSG("Failed to list directory %s: %s", trace_path.c_str(),
+                   iter.error_string().c_str());
+            return false;
+        }
+        for (; iter != end; ++iter) {
+            std::string fname = *iter;
+            if (fname == "." || fname == "..")
+                continue;
+            std::string path = trace_path + DIRSEP + fname;
+            thread_data.push_back(analyzer_shard_data_t(
+                static_cast<int>(thread_data.size()),
+                std::unique_ptr<reader_t>(new my_file_reader_t(path, verbosity)), path));
+        }
+        // Like raw2trace, we use a simple round-robin static work assigment.  This
+        // could be improved later with dynamic work queue for better load balancing.
+        if (worker_count <= 0)
+            worker_count = std::thread::hardware_concurrency();
+        worker_tasks.resize(worker_count);
+        int worker = 0;
+        for (size_t i = 0; i < thread_data.size(); ++i) {
+            VPRINT(this, 2, "Worker %d assigned trace thread %zd\n", worker, i);
+            worker_tasks[worker].push_back(&thread_data[i]);
+            thread_data[i].worker = worker;
+            worker = (worker + 1) % worker_count;
+        }
+    } else {
+        serial_trace_iter = std::unique_ptr<reader_t>(
+            new my_file_reader_t(trace_path.c_str(), verbosity));
+    }
+    trace_end = std::unique_ptr<my_file_reader_t>(new my_file_reader_t());
     return true;
 }
 
-analyzer_t::analyzer_t(const std::string &trace_file, analysis_tool_t **tools_in,
-                       int num_tools_in)
+analyzer_t::analyzer_t(const std::string &trace_path, analysis_tool_t **tools_in,
+                       int num_tools_in, int worker_count_in)
     : success(true)
-    , trace_iter(NULL)
-    , trace_end(NULL)
     , num_tools(num_tools_in)
     , tools(tools_in)
+    , parallel(true)
+    , worker_count(worker_count_in)
 {
     for (int i = 0; i < num_tools; ++i) {
         if (tools[i] != NULL && !!*tools[i])
@@ -88,25 +129,25 @@ analyzer_t::analyzer_t(const std::string &trace_file, analysis_tool_t **tools_in
             return;
         }
     }
-    if (!init_file_reader(trace_file))
+    if (!init_file_reader(trace_path))
         success = false;
 }
 
-analyzer_t::analyzer_t(const std::string &trace_file)
+analyzer_t::analyzer_t(const std::string &trace_path)
     : success(true)
-    , trace_iter(NULL)
-    , trace_end(NULL)
     , num_tools(0)
     , tools(NULL)
+    // This external-iterator interface does not support parallel analysis.
+    , parallel(false)
+    , worker_count(0)
 {
-    if (!init_file_reader(trace_file))
+    if (!init_file_reader(trace_path))
         success = false;
 }
 
 analyzer_t::~analyzer_t()
 {
-    delete trace_iter;
-    delete trace_end;
+    // Empty.
 }
 
 // Work around clang-format bug: no newline after return type for single-char operator.
@@ -124,30 +165,90 @@ analyzer_t::get_error_string()
     return error_string;
 }
 
+// Used only for serial iteration.
 bool
 analyzer_t::start_reading()
 {
-    if (!trace_iter->init()) {
+    if (!serial_trace_iter->init()) {
         ERRMSG("Failed to read from trace\n");
         return false;
     }
     return true;
 }
 
+void
+analyzer_t::process_tasks(std::vector<analyzer_shard_data_t *> *tasks)
+{
+    if (tasks->empty()) {
+        VPRINT(this, 1, "Worker has no tasks\n");
+        return;
+    }
+    VPRINT(this, 1, "Worker %d assigned %zd task(s)\n", (*tasks)[0]->worker,
+           tasks->size());
+    std::vector<void *> worker_data(num_tools);
+    for (int i = 0; i < num_tools; ++i)
+        worker_data[i] = tools[i]->parallel_worker_init((*tasks)[0]->worker);
+    for (analyzer_shard_data_t *tdata : *tasks) {
+        VPRINT(this, 1, "Worker %d starting on trace thread %d\n", tdata->worker,
+               tdata->index);
+        if (!tdata->iter->init()) {
+            tdata->error = "Failed to read from trace" + tdata->trace_file;
+            return;
+        }
+        std::vector<void *> shard_data(num_tools);
+        for (int i = 0; i < num_tools; ++i)
+            shard_data[i] = tools[i]->parallel_shard_init(tdata->index, worker_data[i]);
+        VPRINT(this, 1, "shard_data[0] is %p\n", shard_data[0]);
+        for (; *tdata->iter != *trace_end; ++(*tdata->iter)) {
+            for (int i = 0; i < num_tools; ++i) {
+                memref_t memref = **tdata->iter;
+                if (!tools[i]->parallel_shard_memref(shard_data[i], memref)) {
+                    tdata->error = tools[i]->parallel_shard_error(shard_data[i]);
+                    VPRINT(this, 1, "Worker %d hit error %s on trace thread %d\n",
+                           tdata->worker, tdata->error.c_str(), tdata->index);
+                    return;
+                }
+            }
+        }
+        VPRINT(this, 1, "Worker %d finished trace thread %d\n", tdata->worker,
+               tdata->index);
+        for (int i = 0; i < num_tools; ++i)
+            tools[i]->parallel_shard_exit(shard_data[i]);
+    }
+}
+
 bool
 analyzer_t::run()
 {
-    if (!start_reading())
-        return false;
-
-    for (; *trace_iter != *trace_end; ++(*trace_iter)) {
-        for (int i = 0; i < num_tools; ++i) {
-            memref_t memref = **trace_iter;
-            // We short-circuit and exit on an error to avoid confusion over
-            // the results and avoid wasted continued work.
-            if (!tools[i]->process_memref(memref)) {
-                error_string = tools[i]->get_error_string();
+    // XXX i#3286: Add a %-completed progress message by looking at the file sizes.
+    if (parallel) {
+        std::vector<std::thread> threads;
+        VPRINT(this, 1, "Creating %d worker threads\n", worker_count);
+        threads.reserve(worker_count);
+        for (int i = 0; i < worker_count; ++i) {
+            threads.push_back(
+                std::thread(&analyzer_t::process_tasks, this, &worker_tasks[i]));
+        }
+        for (std::thread &thread : threads)
+            thread.join();
+        for (auto &tdata : thread_data) {
+            if (!tdata.error.empty()) {
+                error_string = tdata.error;
                 return false;
+            }
+        }
+    } else {
+        if (!start_reading())
+            return false;
+        for (; *serial_trace_iter != *trace_end; ++(*serial_trace_iter)) {
+            for (int i = 0; i < num_tools; ++i) {
+                memref_t memref = **serial_trace_iter;
+                // We short-circuit and exit on an error to avoid confusion over
+                // the results and avoid wasted continued work.
+                if (!tools[i]->process_memref(memref)) {
+                    error_string = tools[i]->get_error_string();
+                    return false;
+                }
             }
         }
     }
@@ -171,12 +272,14 @@ analyzer_t::print_stats()
     return true;
 }
 
+// XXX i#3287: Figure out how to support parallel operation with this external
+// iterator interface.
 reader_t &
 analyzer_t::begin()
 {
     if (!start_reading())
         return *trace_end;
-    return *trace_iter;
+    return *serial_trace_iter;
 }
 
 reader_t &

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -44,7 +44,9 @@
  */
 
 #include <iterator>
+#include <memory>
 #include <string>
+#include <vector>
 #include "analysis_tool.h"
 #include "reader.h"
 
@@ -71,8 +73,8 @@ public:
 
     /**
      * We have two usage models: one where there are multiple tools and the
-     * trace iteration is performed by analyzer_t, and another where a single
-     * tool controls the iteration.
+     * trace iteration is performed by analyzer_t and supports parallel trace
+     * analysis, and another where a single tool controls the iteration.
      *
      * The default, simpler, multiple-tool-supporting model uses this constructor.
      * The analyzer will reference the tools array passed in during its lifetime:
@@ -80,7 +82,8 @@ public:
      * The user must free them afterward.
      * The analyzer calls the initialize() function on each tool before use.
      */
-    analyzer_t(const std::string &trace_file, analysis_tool_t **tools, int num_tools);
+    analyzer_t(const std::string &trace_path, analysis_tool_t **tools, int num_tools,
+               int worker_count = 0);
     /** Launches the analysis process. */
     virtual bool
     run();
@@ -88,8 +91,11 @@ public:
     virtual bool
     print_stats();
 
-    /** The alternate usage model exposes the iterator to a single tool. */
-    analyzer_t(const std::string &trace_file);
+    /**
+     * The alternate usage model exposes the iterator to a single tool.
+     * This model does not currently support parallel shard analysis.
+     */
+    analyzer_t(const std::string &trace_path);
     /**
      * As the iterator is more heavyweight than regular container iterators
      * we hold it internally and return a reference.  Copying will fail to compile
@@ -103,20 +109,61 @@ public:
     end(); /** End iterator for the external-iterator usage model. */
 
 protected:
+    // Data for one trace shard.  Our concurrency model has each shard
+    // analyzed by a single worker thread, eliminating the need for locks.
+    struct analyzer_shard_data_t {
+        analyzer_shard_data_t(int index_in, std::unique_ptr<reader_t> iter_in,
+                              const std::string &trace_file_in)
+            : index(index_in)
+            , worker(0)
+            , iter(std::move(iter_in))
+            , trace_file(trace_file_in)
+        {
+        }
+        analyzer_shard_data_t(analyzer_shard_data_t &&src)
+        {
+            index = src.index;
+            worker = src.worker;
+            iter = std::move(src.iter);
+            trace_file = std::move(src.trace_file);
+            error = std::move(src.error);
+        }
+
+        int index;
+        int worker;
+        std::unique_ptr<reader_t> iter;
+        std::string trace_file;
+        std::string error;
+
+    private:
+        analyzer_shard_data_t(const analyzer_shard_data_t &) = delete;
+        analyzer_shard_data_t &
+        operator=(const analyzer_shard_data_t &) = delete;
+    };
+
     bool
-    init_file_reader(const std::string &trace_file);
+    init_file_reader(const std::string &trace_path, int verbosity = 0);
 
     // This finalizes the trace_iter setup.  It can block and is meant to be
     // called at the top of run() or begin().
     bool
     start_reading();
 
+    void
+    process_tasks(std::vector<analyzer_shard_data_t *> *tasks);
+
     bool success;
     std::string error_string;
-    reader_t *trace_iter;
-    reader_t *trace_end;
+    std::vector<analyzer_shard_data_t> thread_data;
+    std::unique_ptr<reader_t> serial_trace_iter;
+    std::unique_ptr<reader_t> trace_end;
     int num_tools;
     analysis_tool_t **tools;
+    bool parallel;
+    int worker_count;
+    std::vector<std::vector<analyzer_shard_data_t *>> worker_tasks;
+    int verbosity = 0;
+    const char *output_prefix = "[analyzer]";
 };
 
 #endif /* _ANALYZER_H_ */

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -47,15 +47,15 @@
 #    include "tests/trace_invariants.h"
 #endif
 
-#ifdef HAS_ZLIB
-// Even for uncompressed files, zlib's gzip interface is faster than fstream.
-typedef compressed_file_reader_t my_file_reader_t;
-#else
-typedef file_reader_t<std::ifstream *> my_file_reader_t;
-#endif
-
 analyzer_multi_t::analyzer_multi_t()
 {
+    worker_count = op_jobs.get_value();
+    // Initial measurements show it's sometimes faster to keep the parallel model
+    // of using single-file readers but use them sequentially, as opposed to
+    // the every-file interleaving reader, but the user can specify -jobs 1, so
+    // we still keep the serial vs parallel split for 0.
+    if (worker_count == 0)
+        parallel = false;
     if (!create_analysis_tools()) {
         success = false;
         error_string = "Failed to create analysis tool: " + error_string;
@@ -73,8 +73,6 @@ analyzer_multi_t::analyzer_multi_t()
     if (!op_indir.get_value().empty()) {
         std::string tracedir =
             raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
-        my_file_reader_t *existing =
-            new my_file_reader_t(tracedir.c_str(), op_verbose.get_value());
         // We support the trace dir being empty if we haven't post-processed
         // the raw files yet.
         bool needs_processing = false;
@@ -100,8 +98,6 @@ analyzer_multi_t::analyzer_multi_t()
             }
         }
         if (needs_processing) {
-            delete existing;
-            existing = nullptr;
             raw2trace_directory_t dir(op_verbose.get_value());
             std::string dir_err = dir.initialize(op_indir.get_value(), "");
             if (!dir_err.empty()) {
@@ -115,29 +111,29 @@ analyzer_multi_t::analyzer_multi_t()
                 success = false;
                 error_string = "raw2trace failed: " + error;
             }
-            trace_iter = new my_file_reader_t(tracedir.c_str(), op_verbose.get_value());
-        } else
-            trace_iter = existing;
-        trace_end = new my_file_reader_t();
+        }
+        if (!init_file_reader(tracedir, op_verbose.get_value()))
+            success = false;
     } else if (op_infile.get_value().empty()) {
-        trace_iter = new ipc_reader_t(op_ipc_name.get_value().c_str());
-        trace_end = new ipc_reader_t();
-        if (!*trace_iter) {
+        serial_trace_iter =
+            std::unique_ptr<reader_t>(new ipc_reader_t(op_ipc_name.get_value().c_str()));
+        trace_end = std::unique_ptr<reader_t>(new ipc_reader_t());
+        if (!*serial_trace_iter) {
             success = false;
 #ifdef UNIX
             // This is the most likely cause of the error.
             // XXX: Even better would be to propagate the mkfifo errno here.
             error_string = "try removing stale pipe file " +
-                reinterpret_cast<ipc_reader_t *>(trace_iter)->get_pipe_name();
+                reinterpret_cast<ipc_reader_t *>(serial_trace_iter.get())
+                    ->get_pipe_name();
 #endif
         }
     } else {
         // Legacy file.
-        trace_iter =
-            new my_file_reader_t(op_infile.get_value().c_str(), op_verbose.get_value());
-        trace_end = new my_file_reader_t();
+        if (!init_file_reader(op_infile.get_value(), op_verbose.get_value()))
+            success = false;
     }
-    // We can't call trace_iter->init() here as it blocks for ipc_reader_t.
+    // We can't call serial_trace_iter->init() here as it blocks for ipc_reader_t.
 }
 
 analyzer_multi_t::~analyzer_multi_t()

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -115,6 +115,8 @@ analyzer_multi_t::analyzer_multi_t()
         if (!init_file_reader(tracedir, op_verbose.get_value()))
             success = false;
     } else if (op_infile.get_value().empty()) {
+        // XXX i#3323: Add parallel analysis support for online tools.
+        parallel = false;
         serial_trace_iter =
             std::unique_ptr<reader_t>(new ipc_reader_t(op_ipc_name.get_value().c_str()));
         trace_end = std::unique_ptr<reader_t>(new ipc_reader_t());

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -873,6 +873,9 @@ present the results of the analysis.  For parallel operation, any desired
 aggregation across the whole trace should occur here as well, while shard-specific
 results can be presented in parallel_shard_exit().
 
+Today, parallel analysis is only supported for offline traces.
+Support for online traces may be added in the future.
+
 In the default mode of operation, the #analyzer_t class iterates over
 the trace and calls the appropriate #analysis_tool_t functions for
 each tool.  An alternative mode is supported which exposes the

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -576,7 +576,8 @@ $ bin64/drrun -t drcachesim -indir drmemtrace.app.pid.xxxx.dir/trace
 The canonical trace files may be manually compressed with gzip, as the
 trace reader supports reading gzipped files.
 
-Older versions of the simulator produced a single trace file containing all threads interleaved.  The \p -infile option supports reading these legacy files:
+Older versions of the simulator produced a single trace file containing all threads
+interleaved.  The \p -infile option supports reading these legacy files:
 \code
 $ gzip drmemtrace.app.pid.xxxx.dir/drmemtrace.trace
 $ bin64/drrun -t drcachesim -infile drmemtrace.app.pid.xxxx.dir/drmemtrace.trace.gz
@@ -839,14 +840,43 @@ class.
 
 \p drcachesim provides a \p drmemtrace analysis tool framework to make it
 easy to create new trace analysis tools.  A new tool should subclass
-#analysis_tool_t.  Two key functions should be overridden:
-analysis_tool_t::process_memref(), which operates on a single trace entry,
-and analysis_tool_t::print_results(), which is called just once after
-processing the entire trace and should present the results of analysis.  In
-the default mode of operation, the #analyzer_t class iterates over the
-trace and calls the analysis_tool_t::process_memref() function of each
-tool.  An alternative mode is supported which exposes the iterator and
-allows a separate control infrastructure to be built.
+#analysis_tool_t.
+
+Concurrent processing of traces is supported by logically splitting a trace into
+"shards" which are each processed sequentially.  The default shard is a traced
+application thread, but the tool interface can support other divisions.  For tools
+that support concurrent processing of shards and do not need to see a single
+time-sorted interleaved merged trace, the interface functions with the parallel_
+prefix should be overridden, and parallel_shard_supported() should return true.
+parallel_shard_init() will be invoked for each shard prior to invoking
+parallel_shard_memref() for each entry in that shard; the data structure returned
+from parallel_shard_init() will be passed to parallel_shard_memref() for each
+trace entry for that shard.  The concurrency model used guarantees that all
+entries from any one shard are processed by the same single worker thread, so no
+synchronization is needed inside the parallel_ functions.  A single worker thread
+invokes print_results() as well.
+
+For serial operation, process_memref(), operates on a trace entry in a single,
+sorted, interleaved stream of trace entries.  In the default mode of operation,
+the #analyzer_t class iterates over the trace and calls the process_memref()
+function of each tool.  An alternative mode is supported which exposes the
+iterator and allows a separate control infrastructure to be built.  This
+alternative mode does not support parallel operation at this time.
+
+Both parallel and serial operation can be supported by a tool, typically by having
+process_memref() create data on a newly seen traced thread and invoking
+parallel_shard_memref() to do its work.
+
+For both parallel and serial operation, the function print_results() should be
+overridden.  It is called just once after processing all trace data and it should
+present the results of the analysis.  For parallel operation, any desired
+aggregation across the whole trace should occur here as well, while shard-specific
+results can be presented in parallel_shard_exit().
+
+In the default mode of operation, the #analyzer_t class iterates over
+the trace and calls the appropriate #analysis_tool_t functions for
+each tool.  An alternative mode is supported which exposes the
+iterator and allows a separate control infrastructure to be built.
 
 Each trace entry is of type #memref_t and represents one instruction or
 data reference or a metadata operation such as a thread exit or marker.
@@ -897,7 +927,8 @@ The \p drcachesim tool is a work in progress.  We welcome contributions in
 these areas of missing functionality:
 
 - Cache coherence (https://github.com/DynamoRIO/dynamorio/issues/1726)
-- Multi-process online application simulation on Windows (https://github.com/DynamoRIO/dynamorio/issues/1727)
+- Multi-process online application simulation on Windows
+  (https://github.com/DynamoRIO/dynamorio/issues/1727)
 - Arbitrary cache hierarchy support via an input config file
   (https://github.com/DynamoRIO/dynamorio/issues/1715)
 - Offline traces do not currently accurately record instruction fetches in

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -47,141 +47,158 @@ basic_counts_tool_create(unsigned int verbose)
 }
 
 basic_counts_t::basic_counts_t(unsigned int verbose)
-    : total_threads(0)
-    , total_instrs(0)
-    , total_instrs_nofetch(0)
-    , total_prefetches(0)
-    , total_loads(0)
-    , total_stores(0)
-    , total_sched_markers(0)
-    , total_xfer_markers(0)
-    , total_func_id_markers(0)
-    , total_func_retaddr_markers(0)
-    , total_func_arg_markers(0)
-    , total_func_retval_markers(0)
-    , total_other_markers(0)
-    , knob_verbose(verbose)
+    : knob_verbose(verbose)
 {
     // Empty.
 }
 
 basic_counts_t::~basic_counts_t()
 {
-    // Empty.
+    for (auto &iter : shard_counters) {
+        delete iter.second;
+    }
+}
+
+bool
+basic_counts_t::parallel_shard_supported()
+{
+    return true;
+}
+
+void *
+basic_counts_t::parallel_shard_init(int shard_index, void *worker_data)
+{
+    auto counters = new counters_t;
+    shard_counters[shard_index] = counters;
+    return reinterpret_cast<void *>(counters);
+}
+
+void
+basic_counts_t::parallel_shard_exit(void *shard_data)
+{
+    // Nothing (we read the shard data in print_results).
+}
+
+std::string
+basic_counts_t::parallel_shard_error(void *shard_data)
+{
+    counters_t *counters = reinterpret_cast<counters_t *>(shard_data);
+    return counters->error;
+}
+
+bool
+basic_counts_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
+{
+    counters_t *counters = reinterpret_cast<counters_t *>(shard_data);
+    if (type_is_instr(memref.instr.type)) {
+        ++counters->instrs;
+    } else if (memref.data.type == TRACE_TYPE_INSTR_NO_FETCH) {
+        ++counters->instrs_nofetch;
+    } else if (type_is_prefetch(memref.data.type)) {
+        ++counters->prefetches;
+    } else if (memref.data.type == TRACE_TYPE_READ) {
+        ++counters->loads;
+    } else if (memref.data.type == TRACE_TYPE_WRITE) {
+        ++counters->stores;
+    } else if (memref.marker.type == TRACE_TYPE_MARKER) {
+        if (memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP ||
+            memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID) {
+            ++counters->sched_markers;
+        } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+                   memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER) {
+            ++counters->xfer_markers;
+        } else {
+            switch (memref.marker.marker_type) {
+            case TRACE_MARKER_TYPE_FUNC_ID: ++counters->func_id_markers; break;
+            case TRACE_MARKER_TYPE_FUNC_RETADDR: ++counters->func_retaddr_markers; break;
+            case TRACE_MARKER_TYPE_FUNC_ARG: ++counters->func_arg_markers; break;
+            case TRACE_MARKER_TYPE_FUNC_RETVAL: ++counters->func_retval_markers; break;
+            default: ++counters->other_markers; break;
+            }
+        }
+    } else if (memref.data.type == TRACE_TYPE_THREAD_EXIT) {
+        counters->tid = memref.exit.tid;
+    }
+    return true;
 }
 
 bool
 basic_counts_t::process_memref(const memref_t &memref)
 {
-    if (type_is_instr(memref.instr.type)) {
-        ++thread_instrs[memref.instr.tid];
-        ++total_instrs;
-    } else if (memref.data.type == TRACE_TYPE_INSTR_NO_FETCH) {
-        ++thread_instrs_nofetch[memref.instr.tid];
-        ++total_instrs_nofetch;
-    } else if (type_is_prefetch(memref.data.type)) {
-        ++thread_prefetches[memref.data.tid];
-        ++total_prefetches;
-    } else if (memref.data.type == TRACE_TYPE_READ) {
-        ++thread_loads[memref.data.tid];
-        ++total_loads;
-    } else if (memref.data.type == TRACE_TYPE_WRITE) {
-        ++thread_stores[memref.data.tid];
-        ++total_stores;
-    } else if (memref.marker.type == TRACE_TYPE_MARKER) {
-        if (memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP ||
-            memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID) {
-            ++thread_sched_markers[memref.data.tid];
-            ++total_sched_markers;
-        } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-                   memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER) {
-            ++thread_xfer_markers[memref.data.tid];
-            ++total_xfer_markers;
-        } else {
-            switch (memref.marker.marker_type) {
-            case TRACE_MARKER_TYPE_FUNC_ID:
-                ++total_func_id_markers;
-                ++thread_func_id_markers[memref.data.tid];
-                break;
-            case TRACE_MARKER_TYPE_FUNC_RETADDR:
-                ++total_func_retaddr_markers;
-                ++thread_func_retaddr_markers[memref.data.tid];
-                break;
-            case TRACE_MARKER_TYPE_FUNC_ARG:
-                ++total_func_arg_markers;
-                ++thread_func_arg_markers[memref.data.tid];
-                break;
-            case TRACE_MARKER_TYPE_FUNC_RETVAL:
-                ++total_func_retval_markers;
-                ++thread_func_retval_markers[memref.data.tid];
-                break;
-            default:
-                ++thread_other_markers[memref.data.tid];
-                ++total_other_markers;
-                break;
-            }
-        }
-    } else if (memref.exit.type == TRACE_TYPE_THREAD_EXIT) {
-        ++total_threads;
+    counters_t *counters;
+    const auto &lookup = shard_counters.find(memref.data.tid);
+    if (lookup == shard_counters.end()) {
+        counters = new counters_t;
+        shard_counters[memref.data.tid] = counters;
+    } else
+        counters = lookup->second;
+    if (!parallel_shard_memref(reinterpret_cast<void *>(counters), memref)) {
+        error_string = counters->error;
+        return false;
     }
     return true;
 }
 
-static bool
-cmp_val(const std::pair<memref_tid_t, int_least64_t> &l,
-        const std::pair<memref_tid_t, int_least64_t> &r)
+bool
+basic_counts_t::cmp_counters(const std::pair<memref_tid_t, counters_t *> &l,
+                             const std::pair<memref_tid_t, counters_t *> &r)
 {
-    return (l.second > r.second);
+    return (l.second->instrs > r.second->instrs);
 }
 
 bool
 basic_counts_t::print_results()
 {
+    counters_t total;
+    for (const auto &shard : shard_counters) {
+        total += *shard.second;
+    }
     std::cerr << TOOL_NAME << " results:\n";
     std::cerr << "Total counts:\n";
-    std::cerr << std::setw(12) << total_instrs << " total (fetched) instructions\n";
-    std::cerr << std::setw(12) << total_instrs_nofetch
+    std::cerr << std::setw(12) << total.instrs << " total (fetched) instructions\n";
+    std::cerr << std::setw(12) << total.instrs_nofetch
               << " total non-fetched instructions\n";
-    std::cerr << std::setw(12) << total_prefetches << " total prefetches\n";
-    std::cerr << std::setw(12) << total_loads << " total data loads\n";
-    std::cerr << std::setw(12) << total_stores << " total data stores\n";
-    std::cerr << std::setw(12) << total_threads << " total threads\n";
-    std::cerr << std::setw(12) << total_sched_markers << " total scheduling markers\n";
-    std::cerr << std::setw(12) << total_xfer_markers << " total transfer markers\n";
-    std::cerr << std::setw(12) << total_func_id_markers << " total function id markers\n";
-    std::cerr << std::setw(12) << total_func_retaddr_markers
+    std::cerr << std::setw(12) << total.prefetches << " total prefetches\n";
+    std::cerr << std::setw(12) << total.loads << " total data loads\n";
+    std::cerr << std::setw(12) << total.stores << " total data stores\n";
+    std::cerr << std::setw(12) << shard_counters.size() << " total threads\n";
+    std::cerr << std::setw(12) << total.sched_markers << " total scheduling markers\n";
+    std::cerr << std::setw(12) << total.xfer_markers << " total transfer markers\n";
+    std::cerr << std::setw(12) << total.func_id_markers << " total function id markers\n";
+    std::cerr << std::setw(12) << total.func_retaddr_markers
               << " total function return address markers\n";
-    std::cerr << std::setw(12) << total_func_arg_markers
+    std::cerr << std::setw(12) << total.func_arg_markers
               << " total function argument markers\n";
-    std::cerr << std::setw(12) << total_func_retval_markers
+    std::cerr << std::setw(12) << total.func_retval_markers
               << " total function return value markers\n";
-    std::cerr << std::setw(12) << total_other_markers << " total other markers\n";
+    std::cerr << std::setw(12) << total.other_markers << " total other markers\n";
 
     // Print the threads sorted by instrs.
-    std::vector<std::pair<memref_tid_t, int_least64_t>> sorted(thread_instrs.begin(),
-                                                               thread_instrs.end());
-    std::sort(sorted.begin(), sorted.end(), cmp_val);
+    std::vector<std::pair<memref_tid_t, counters_t *>> sorted(shard_counters.begin(),
+                                                              shard_counters.end());
+    std::sort(sorted.begin(), sorted.end(), cmp_counters);
     for (const auto &keyvals : sorted) {
-        memref_tid_t tid = keyvals.first;
-        std::cerr << "Thread " << tid << " counts:\n";
-        std::cerr << std::setw(12) << thread_instrs[tid] << " (fetched) instructions\n";
-        std::cerr << std::setw(12) << thread_instrs_nofetch[tid]
+        std::cerr << "Thread " << keyvals.second->tid << " counts:\n";
+        std::cerr << std::setw(12) << keyvals.second->instrs
+                  << " (fetched) instructions\n";
+        std::cerr << std::setw(12) << keyvals.second->instrs_nofetch
                   << " non-fetched instructions\n";
-        std::cerr << std::setw(12) << thread_prefetches[tid] << " prefetches\n";
-        std::cerr << std::setw(12) << thread_loads[tid] << " data loads\n";
-        std::cerr << std::setw(12) << thread_stores[tid] << " data stores\n";
-        std::cerr << std::setw(12) << thread_sched_markers[tid]
+        std::cerr << std::setw(12) << keyvals.second->prefetches << " prefetches\n";
+        std::cerr << std::setw(12) << keyvals.second->loads << " data loads\n";
+        std::cerr << std::setw(12) << keyvals.second->stores << " data stores\n";
+        std::cerr << std::setw(12) << keyvals.second->sched_markers
                   << " scheduling markers\n";
-        std::cerr << std::setw(12) << thread_xfer_markers[tid] << " transfer markers\n";
-        std::cerr << std::setw(12) << thread_func_id_markers[tid]
+        std::cerr << std::setw(12) << keyvals.second->xfer_markers
+                  << " transfer markers\n";
+        std::cerr << std::setw(12) << keyvals.second->func_id_markers
                   << " function id markers\n";
-        std::cerr << std::setw(12) << thread_func_retaddr_markers[tid]
+        std::cerr << std::setw(12) << keyvals.second->func_retaddr_markers
                   << " function return address markers\n";
-        std::cerr << std::setw(12) << thread_func_arg_markers[tid]
+        std::cerr << std::setw(12) << keyvals.second->func_arg_markers
                   << " function argument markers\n";
-        std::cerr << std::setw(12) << thread_func_retval_markers[tid]
+        std::cerr << std::setw(12) << keyvals.second->func_retval_markers
                   << " function return value markers\n";
-        std::cerr << std::setw(12) << thread_other_markers[tid] << " other markers\n";
+        std::cerr << std::setw(12) << keyvals.second->other_markers << " other markers\n";
     }
     return true;
 }

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -73,10 +73,11 @@ basic_counts_t::parallel_shard_init(int shard_index, void *worker_data)
     return reinterpret_cast<void *>(counters);
 }
 
-void
+bool
 basic_counts_t::parallel_shard_exit(void *shard_data)
 {
     // Nothing (we read the shard data in print_results).
+    return true;
 }
 
 std::string

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -50,7 +50,7 @@ public:
     parallel_shard_supported() override;
     void *
     parallel_shard_init(int shard_index, void *worker_data) override;
-    void
+    bool
     parallel_shard_exit(void *shard_data) override;
     bool
     parallel_shard_memref(void *shard_data, const memref_t &memref) override;
@@ -60,19 +60,6 @@ public:
 protected:
     struct counters_t {
         counters_t()
-            : tid(0)
-            , instrs(0)
-            , instrs_nofetch(0)
-            , prefetches(0)
-            , loads(0)
-            , stores(0)
-            , sched_markers(0)
-            , xfer_markers(0)
-            , func_id_markers(0)
-            , func_retaddr_markers(0)
-            , func_arg_markers(0)
-            , func_retval_markers(0)
-            , other_markers(0)
         {
         }
         counters_t &
@@ -92,19 +79,19 @@ protected:
             other_markers += rhs.other_markers;
             return *this;
         }
-        memref_tid_t tid;
-        int_least64_t instrs;
-        int_least64_t instrs_nofetch;
-        int_least64_t prefetches;
-        int_least64_t loads;
-        int_least64_t stores;
-        int_least64_t sched_markers;
-        int_least64_t xfer_markers;
-        int_least64_t func_id_markers;
-        int_least64_t func_retaddr_markers;
-        int_least64_t func_arg_markers;
-        int_least64_t func_retval_markers;
-        int_least64_t other_markers;
+        memref_tid_t tid = 0;
+        int_least64_t instrs = 0;
+        int_least64_t instrs_nofetch = 0;
+        int_least64_t prefetches = 0;
+        int_least64_t loads = 0;
+        int_least64_t stores = 0;
+        int_least64_t sched_markers = 0;
+        int_least64_t xfer_markers = 0;
+        int_least64_t func_id_markers = 0;
+        int_least64_t func_retaddr_markers = 0;
+        int_least64_t func_arg_markers = 0;
+        int_least64_t func_retval_markers = 0;
+        int_least64_t other_markers = 0;
         std::string error;
     };
     static bool

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -111,7 +111,8 @@ protected:
     cmp_counters(const std::pair<memref_tid_t, counters_t *> &l,
                  const std::pair<memref_tid_t, counters_t *> &r);
 
-    std::unordered_map<int, counters_t *> shard_counters;
+    // The keys here are int for parallel, tid for serial.
+    std::unordered_map<memref_tid_t, counters_t *> shard_counters;
     unsigned int knob_verbose;
     static const std::string TOOL_NAME;
 };

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -100,11 +100,12 @@ opcode_mix_t::parallel_worker_init(int worker_index)
     return reinterpret_cast<void *>(worker);
 }
 
-void
+std::string
 opcode_mix_t::parallel_worker_exit(void *worker_data)
 {
     worker_data_t *worker = reinterpret_cast<worker_data_t *>(worker_data);
     delete worker;
+    return "";
 }
 
 void *

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -56,13 +56,13 @@ opcode_mix_t::opcode_mix_t(const std::string &module_file_path_in, unsigned int 
     : dcontext(nullptr)
     , module_file_path(module_file_path_in)
     , knob_verbose(verbose)
-    , instr_count(0)
 {
 }
 
 void
 opcode_mix_t::initialize()
 {
+    serial_shard.worker = &serial_worker;
     if (module_file_path.empty()) {
         error_string = "Module file path is missing";
         success = false;
@@ -75,6 +75,7 @@ opcode_mix_t::initialize()
         success = false;
         return;
     }
+    mapper_mutex = dr_mutex_create();
     module_mapper = module_mapper_t::create(directory.modfile_bytes, nullptr, nullptr,
                                             nullptr, nullptr, knob_verbose);
     module_mapper->get_loaded_modules();
@@ -86,24 +87,83 @@ opcode_mix_t::initialize()
     }
 }
 
+opcode_mix_t::~opcode_mix_t()
+{
+    for (auto &iter : shard_data) {
+        delete iter.second;
+    }
+    dr_mutex_destroy(mapper_mutex);
+}
+
 bool
-opcode_mix_t::process_memref(const memref_t &memref)
+opcode_mix_t::parallel_shard_supported()
+{
+    return true;
+}
+
+void *
+opcode_mix_t::parallel_worker_init(int worker_index)
+{
+    auto worker = new worker_data_t;
+    return reinterpret_cast<void *>(worker);
+}
+
+void
+opcode_mix_t::parallel_worker_exit(void *worker_data)
+{
+    worker_data_t *worker = reinterpret_cast<worker_data_t *>(worker_data);
+    delete worker;
+}
+
+void *
+opcode_mix_t::parallel_shard_init(int shard_index, void *worker_data)
+{
+    worker_data_t *worker = reinterpret_cast<worker_data_t *>(worker_data);
+    auto shard = new shard_data_t(worker);
+    shard_data[shard_index] = shard;
+    return reinterpret_cast<void *>(shard);
+}
+
+void
+opcode_mix_t::parallel_shard_exit(void *shard_data)
+{
+    // Nothing (we read the shard data in print_results).
+}
+
+bool
+opcode_mix_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
 {
     if (!type_is_instr(memref.instr.type) &&
         memref.data.type != TRACE_TYPE_INSTR_NO_FETCH) {
         return true;
     }
-    ++instr_count;
+    shard_data_t *shard = reinterpret_cast<shard_data_t *>(shard_data);
+    ++shard->instr_count;
+
     app_pc mapped_pc;
-    mapped_pc = module_mapper->find_mapped_trace_address((app_pc)memref.instr.addr);
-    if (!module_mapper->get_last_error().empty()) {
-        error_string = "Failed to find mapped address for " +
-            to_hex_string(memref.instr.addr) + ": " + module_mapper->get_last_error();
-        return false;
+    app_pc trace_pc = reinterpret_cast<app_pc>(memref.instr.addr);
+    if (trace_pc >= shard->last_trace_module_start &&
+        static_cast<size_t>(trace_pc - shard->last_trace_module_start) <
+            shard->last_trace_module_size) {
+        mapped_pc =
+            shard->last_mapped_module_start + (trace_pc - shard->last_trace_module_start);
+    } else {
+        scoped_mutex_t scoped_mutex(mapper_mutex);
+        mapped_pc = module_mapper->find_mapped_trace_bounds(
+            trace_pc, &shard->last_mapped_module_start, &shard->last_trace_module_size);
+        if (!module_mapper->get_last_error().empty()) {
+            shard->last_trace_module_start = nullptr;
+            shard->last_trace_module_size = 0;
+            shard->error = "Failed to find mapped address for " +
+                to_hex_string(memref.instr.addr) + ": " + module_mapper->get_last_error();
+            return false;
+        }
+        shard->last_trace_module_start =
+            trace_pc - (mapped_pc - shard->last_mapped_module_start);
     }
     int opcode;
-    auto cached_opcode = opcode_cache.find(mapped_pc);
-    if (cached_opcode != opcode_cache.end()) {
+    auto cached_opcode = shard->worker->opcode_cache.find(mapped_pc);
+    if (cached_opcode != shard->worker->opcode_cache.end()) {
         opcode = cached_opcode->second;
     } else {
         instr_t instr;
@@ -115,10 +175,27 @@ opcode_mix_t::process_memref(const memref_t &memref)
             return false;
         }
         opcode = instr_get_opcode(&instr);
-        opcode_cache[mapped_pc] = opcode;
+        shard->worker->opcode_cache[mapped_pc] = opcode;
         instr_free(dcontext, &instr);
     }
-    ++opcode_counts[opcode];
+    ++shard->opcode_counts[opcode];
+    return true;
+}
+
+std::string
+opcode_mix_t::parallel_shard_error(void *shard_data)
+{
+    shard_data_t *shard = reinterpret_cast<shard_data_t *>(shard_data);
+    return shard->error;
+}
+
+bool
+opcode_mix_t::process_memref(const memref_t &memref)
+{
+    if (!parallel_shard_memref(reinterpret_cast<void *>(&serial_shard), memref)) {
+        error_string = serial_shard.error;
+        return false;
+    }
     return true;
 }
 
@@ -131,10 +208,21 @@ cmp_val(const std::pair<int, int_least64_t> &l, const std::pair<int, int_least64
 bool
 opcode_mix_t::print_results()
 {
+    shard_data_t total(0);
+    if (shard_data.empty()) {
+        total = serial_shard;
+    } else {
+        for (const auto &shard : shard_data) {
+            total.instr_count += shard.second->instr_count;
+            for (const auto &keyvals : shard.second->opcode_counts) {
+                total.opcode_counts[keyvals.first] += keyvals.second;
+            }
+        }
+    }
     std::cerr << TOOL_NAME << " results:\n";
-    std::cerr << std::setw(15) << instr_count << " : total executed instructions\n";
-    std::vector<std::pair<int, int_least64_t>> sorted(opcode_counts.begin(),
-                                                      opcode_counts.end());
+    std::cerr << std::setw(15) << total.instr_count << " : total executed instructions\n";
+    std::vector<std::pair<int, int_least64_t>> sorted(total.opcode_counts.begin(),
+                                                      total.opcode_counts.end());
     std::sort(sorted.begin(), sorted.end(), cmp_val);
     for (const auto &keyvals : sorted) {
         std::cerr << std::setw(15) << keyvals.second << " : " << std::setw(9)

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -116,10 +116,11 @@ opcode_mix_t::parallel_shard_init(int shard_index, void *worker_data)
     return reinterpret_cast<void *>(shard);
 }
 
-void
+bool
 opcode_mix_t::parallel_shard_exit(void *shard_data)
 {
     // Nothing (we read the shard data in print_results).
+    return true;
 }
 
 bool
@@ -133,7 +134,7 @@ opcode_mix_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
     ++shard->instr_count;
 
     app_pc mapped_pc;
-    app_pc trace_pc = reinterpret_cast<app_pc>(memref.instr.addr);
+    const app_pc trace_pc = reinterpret_cast<app_pc>(memref.instr.addr);
     if (trace_pc >= shard->last_trace_module_start &&
         static_cast<size_t>(trace_pc - shard->last_trace_module_start) <
             shard->last_trace_module_size) {

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -58,7 +58,7 @@ public:
     parallel_worker_exit(void *worker_data) override;
     void *
     parallel_shard_init(int shard_index, void *worker_data) override;
-    void
+    bool
     parallel_shard_exit(void *shard_data) override;
     bool
     parallel_shard_memref(void *shard_data, const memref_t &memref) override;
@@ -93,6 +93,7 @@ protected:
         app_pc last_mapped_module_start;
     };
 
+    // XXX: Share this for use in other C++ code.
     struct scoped_mutex_t {
         scoped_mutex_t(void *mutex_in)
             : mutex(mutex_in)

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -54,7 +54,7 @@ public:
     parallel_shard_supported() override;
     void *
     parallel_worker_init(int worker_index) override;
-    void
+    std::string
     parallel_worker_exit(void *worker_data) override;
     void *
     parallel_shard_init(int shard_index, void *worker_data) override;

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -43,28 +43,82 @@
 class opcode_mix_t : public analysis_tool_t {
 public:
     opcode_mix_t(const std::string &module_file_path, unsigned int verbose);
-    virtual ~opcode_mix_t()
-    {
-    }
+    virtual ~opcode_mix_t();
     void
     initialize() override;
     bool
     process_memref(const memref_t &memref) override;
     bool
     print_results() override;
+    bool
+    parallel_shard_supported() override;
+    void *
+    parallel_worker_init(int worker_index) override;
+    void
+    parallel_worker_exit(void *worker_data) override;
+    void *
+    parallel_shard_init(int shard_index, void *worker_data) override;
+    void
+    parallel_shard_exit(void *shard_data) override;
+    bool
+    parallel_shard_memref(void *shard_data, const memref_t &memref) override;
+    std::string
+    parallel_shard_error(void *shard_data) override;
 
 protected:
+    struct worker_data_t {
+        std::unordered_map<app_pc, int> opcode_cache;
+    };
+
+    struct shard_data_t {
+        shard_data_t()
+            : worker(nullptr)
+            , instr_count(0)
+        {
+        }
+        shard_data_t(worker_data_t *worker_in)
+            : worker(worker_in)
+            , instr_count(0)
+            , last_trace_module_start(nullptr)
+            , last_trace_module_size(0)
+            , last_mapped_module_start(nullptr)
+        {
+        }
+        worker_data_t *worker;
+        int_least64_t instr_count;
+        std::unordered_map<int, int_least64_t> opcode_counts;
+        std::string error;
+        app_pc last_trace_module_start;
+        size_t last_trace_module_size;
+        app_pc last_mapped_module_start;
+    };
+
+    struct scoped_mutex_t {
+        scoped_mutex_t(void *mutex_in)
+            : mutex(mutex_in)
+        {
+            dr_mutex_lock(mutex);
+        }
+        ~scoped_mutex_t()
+        {
+            dr_mutex_unlock(mutex);
+        }
+        void *mutex;
+    };
+
     void *dcontext;
     std::string module_file_path;
     std::unique_ptr<module_mapper_t> module_mapper;
+    void *mapper_mutex;
     // We reference directory.modfile_bytes throughout operation, so its lifetime
     // must match ours.
     raw2trace_directory_t directory;
+    std::unordered_map<memref_tid_t, shard_data_t *> shard_data;
     unsigned int knob_verbose;
-    int_least64_t instr_count;
-    std::unordered_map<int, int_least64_t> opcode_counts;
-    std::unordered_map<app_pc, int> opcode_cache;
     static const std::string TOOL_NAME;
+    // For serial operation.
+    worker_data_t serial_worker;
+    shard_data_t serial_shard;
 };
 
 #endif /* _OPCODE_MIX_H_ */

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -231,6 +231,7 @@ struct trace_metadata_reader_t {
 /**
  * module_mapper_t maps and unloads application modules.
  * Using it assumes a dr_context has already been setup.
+ * This class is not thread-safe.
  */
 class module_mapper_t final {
 public:
@@ -299,6 +300,15 @@ public:
      */
     app_pc
     find_mapped_trace_address(app_pc trace_address);
+
+    /**
+     * This is identical to find_mapped_trace_address() but it also returns the
+     * bounds of the containing region, allowing the caller to perform its own
+     * mapping for any address that is also within those bounds.
+     */
+    app_pc
+    find_mapped_trace_bounds(app_pc trace_address, OUT app_pc *module_start,
+                             OUT size_t *module_size);
 
     /**
      * Unload modules loaded with read_and_map_modules(), freeing associated resources.


### PR DESCRIPTION
Adds support for analyzing traces in parallel, concurrently operating on each
traced thread.  This is made possible by the new storage of traces in separate
per-thread files.

Adds a new analysis_tool_t interface where if the tool's
parallel_shard_supported() returns true, analyzer_t switches to a parallel
operation mode.  Today, a simple static scheduling among worker threads is used.
Each worker completely owns one or more shards, eliminating the need for
synchronization when processing a shard's trace entries.  The default shard is
today's trace file split, a traced thread.

A tool's parallel_shard_init() function is invoked to create shard-thread-local
data, which is passed to parallel_shard_memref().  Errors are also shard-local
with parallel_shard_error().  A parallel_shard_exit() is provided for cleanup,
though most tools will sort, aggregate, and clean up in print_results().

Implements the new interface in the basic_counts and opcode_mix tools.  More
tools will be converted in the future.

Adds a new routine module_mapper_t::find_mapped_trace_bounds() so opcode_mix can
perform local caching of mappings, to avoid a global lock bottleneck for
module_mapper_t usage.

Issue: #3230