### PR TITLE
i#3106 tool init: analysis_tool_t::initialize returns error

### DIFF
--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -68,12 +68,13 @@ public:
     virtual ~analysis_tool_t(){}; /**< Destructor. */
     /**
      * Tools are encouraged to perform any initialization that might fail here rather
-     * than in the constructor.  On an error, this will set the success flag, and
-     * get_error_string() provides a descriptive error message.
+     * than in the constructor.  On an error, this returns an error string.  On success,
+     * it returns "".
      */
-    virtual void
+    virtual std::string
     initialize()
     {
+        return "";
     }
     /** Returns whether the tool was created successfully. */
     virtual bool operator!()

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -78,13 +78,17 @@ analyzer_t::analyzer_t(const std::string &trace_file, analysis_tool_t **tools_in
     , tools(tools_in)
 {
     for (int i = 0; i < num_tools; ++i) {
-        if (tools[i] != NULL && !!*tools[i])
-            tools[i]->initialize();
         if (tools[i] == NULL || !*tools[i]) {
             success = false;
             error_string = "Tool is not successfully initialized";
             if (tools[i] != NULL)
                 error_string += ": " + tools[i]->get_error_string();
+            return;
+        }
+        std::string error = tools[i]->initialize();
+        if (!error.empty()) {
+            success = false;
+            error_string = "Tool failed to initialize: " + error;
             return;
         }
     }

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -156,10 +156,15 @@ analyzer_multi_t::create_analysis_tools()
     tools[0] = drmemtrace_analysis_tool_create();
     if (tools[0] == NULL)
         return false;
-    if (!!*tools[0])
-        tools[0]->initialize();
+    std::string tool_error;
     if (!*tools[0]) {
-        error_string = tools[0]->get_error_string();
+        tool_error = tools[0]->get_error_string();
+        if (tool_error.empty())
+            tool_error = "no error message provided.";
+    } else
+        tool_error = tools[0]->initialize();
+    if (!tool_error.empty()) {
+        error_string = "Tool failed to initialize: " + tool_error;
         delete tools[0];
         tools[0] = NULL;
         return false;

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -60,30 +60,22 @@ opcode_mix_t::opcode_mix_t(const std::string &module_file_path_in, unsigned int 
 {
 }
 
-void
+std::string
 opcode_mix_t::initialize()
 {
-    if (module_file_path.empty()) {
-        error_string = "Module file path is missing";
-        success = false;
-        return;
-    }
+    if (module_file_path.empty())
+        return "Module file path is missing";
     dcontext = dr_standalone_init();
     std::string error = directory.initialize_module_file(module_file_path);
-    if (!error.empty()) {
-        error_string = "Failed to initialize directory: " + error;
-        success = false;
-        return;
-    }
+    if (!error.empty())
+        return "Failed to initialize directory: " + error;
     module_mapper = module_mapper_t::create(directory.modfile_bytes, nullptr, nullptr,
                                             nullptr, nullptr, knob_verbose);
     module_mapper->get_loaded_modules();
     error = module_mapper->get_last_error();
-    if (!error.empty()) {
-        error_string = "Failed to load binaries: " + error;
-        success = false;
-        return;
-    }
+    if (!error.empty())
+        return "Failed to load binaries: " + error;
+    return "";
 }
 
 bool

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -46,7 +46,7 @@ public:
     virtual ~opcode_mix_t()
     {
     }
-    void
+    std::string
     initialize() override;
     bool
     process_memref(const memref_t &memref) override;

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -65,30 +65,21 @@ view_t::view_t(const std::string &module_file_path_in, uint64_t skip_refs,
 {
 }
 
-void
+std::string
 view_t::initialize()
 {
-    if (module_file_path.empty()) {
-        error_string = "Module file path is missing";
-        success = false;
-        return;
-    }
+    if (module_file_path.empty())
+        return "Module file path is missing";
     dcontext = dr_standalone_init();
     std::string error = directory.initialize_module_file(module_file_path);
-    if (!error.empty()) {
-        error_string = "Failed to initialize directory: " + error;
-        success = false;
-        return;
-    }
+    if (!error.empty())
+        return "Failed to initialize directory: " + error;
     module_mapper = module_mapper_t::create(directory.modfile_bytes, nullptr, nullptr,
                                             nullptr, nullptr, knob_verbose);
     module_mapper->get_loaded_modules();
     error = module_mapper->get_last_error();
-    if (!error.empty()) {
-        error_string = "Failed to load binaries: " + error;
-        success = false;
-        return;
-    }
+    if (!error.empty())
+        return "Failed to load binaries: " + error;
     dr_disasm_flags_t flags = DR_DISASM_ATT;
     if (knob_syntax == "intel") {
         flags = DR_DISASM_INTEL;
@@ -98,6 +89,7 @@ view_t::initialize()
         flags = DR_DISASM_ARM;
     }
     disassemble_set_syntax(flags);
+    return "";
 }
 
 bool

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -47,7 +47,7 @@ public:
     virtual ~view_t()
     {
     }
-    void
+    std::string
     initialize() override;
     bool
     process_memref(const memref_t &memref) override;


### PR DESCRIPTION
Changes analysis_tool_t::initialize() to directly return an error
string, to simplify the interface.

Issue: #3106