### PR TITLE
i#3333: cut runtime of client.mangle_suspend.

### DIFF
--- a/suite/tests/client-interface/mangle_suspend-shared.h
+++ b/suite/tests/client-interface/mangle_suspend-shared.h
@@ -55,7 +55,7 @@
 #endif
 
 #define LOOP_COUNT_INNER 1000
-#define LOOP_COUNT_OUTER 10000000
+#define LOOP_COUNT_OUTER 100000
 
 #define MAKE_HEX_ASM(n) HEX(n)
 #define MAKE_HEX(n) 0x##n

--- a/suite/tests/client-interface/mangle_suspend.c
+++ b/suite/tests/client-interface/mangle_suspend.c
@@ -35,8 +35,8 @@
  */
 
 /* clang-format off */
-/* XXX: clang-format incorrectly detected a tab difference at "clang-format on"
- * below. This is why "clang-format off" has been moved outside the ifdef until
+/* XXX: clang-format incorrectly detects a white space difference at "clang-format on"
+ * below. This is why "clang-format off" has been moved outside the ifdef until the
  * bug is fixed.
  */
 #ifndef ASM_CODE_ONLY /* C code */

--- a/suite/tests/client-interface/mangle_suspend.c
+++ b/suite/tests/client-interface/mangle_suspend.c
@@ -34,6 +34,11 @@
  * by asynch interrupt.
  */
 
+/* clang-format off */
+/* XXX: clang-format incorrectly detected a tab difference at "clang-format on"
+ * below. This is why "clang-format off" has been moved outside the ifdef until
+ * bug is fixed.
+ */
 #ifndef ASM_CODE_ONLY /* C code */
 #    include "configure.h"
 #    ifndef UNIX
@@ -152,7 +157,6 @@ main(int argc, const char *argv[])
 #else /* asm code *************************************************************/
 #    include "asm_defines.asm"
 #    include "mangle_suspend-shared.h"
-/* clang-format off */
 START_FILE
 
 #ifdef X64
@@ -284,5 +288,5 @@ GLOBAL_LABEL(FUNCNAME:)
 
 END_FILE
 
-/* clang-format on */
 #endif
+/* clang-format on */

--- a/suite/tests/client-interface/mangle_suspend.c
+++ b/suite/tests/client-interface/mangle_suspend.c
@@ -64,7 +64,7 @@ suspend_thread_1_routine(void *arg)
      * does the suspend and subsequent check for correctness.
      */
     while (!test_ready) {
-        /* Empty. */
+        sched_yield();
     }
     while (!test_done) {
         asm volatile("mov %0, %%rdx\n\t"
@@ -73,7 +73,7 @@ suspend_thread_1_routine(void *arg)
                      : "i"(SUSPEND_VAL_TEST_1_C)
                      : "rdx");
         while (!test_suspend && !test_done) {
-            /* Empty. */
+            sched_yield();
         }
         test_suspend = false;
     }
@@ -89,7 +89,7 @@ suspend_thread_2_routine(void *arg)
      * does the suspend and subsequent check for correctness.
      */
     while (!test_ready) {
-        /* Empty. */
+        sched_yield();
     }
     while (!test_done) {
         asm volatile("mov %0, %%rdx\n\t"
@@ -98,7 +98,7 @@ suspend_thread_2_routine(void *arg)
                      : "i"(SUSPEND_VAL_TEST_2_C)
                      : "rdx");
         while (!test_suspend && !test_done) {
-            /* Empty. */
+            sched_yield();
         }
         test_suspend = false;
     }
@@ -184,9 +184,9 @@ GLOBAL_LABEL(FUNCNAME:)
         /* Code changes here must stay in synch with the loop bounds
          * check hardcoded in the dll.
          */
-      loop_a_outer:
+     loop_a_outer:
         mov      LOOP_TEST_REG_INNER_ASM, LOOP_COUNT_INNER
-      loop_a_inner:
+     loop_a_inner:
         mov      TEST_1_LOOP_COUNT_REG_ASM, 1
         add      TEST_1_LOOP_COUNT_REG_ASM, PTRSZ SYMREF(loop_inc)
         mov      TEST_1_LOOP_COUNT_REG_ASM, 2
@@ -245,9 +245,9 @@ GLOBAL_LABEL(FUNCNAME:)
         /* Code changes here must stay in synch with the loop bounds
          * check hardcoded in the dll.
          */
-  loop_b_outer:
+     loop_b_outer:
         mov      LOOP_TEST_REG_INNER_ASM, LOOP_COUNT_INNER
-  loop_b_inner:
+     loop_b_inner:
         mov      TEST_2_LOOP_COUNT_REG_ASM, 1
         add      TEST_2_LOOP_COUNT_REG_ASM, PTRSZ SYMREF(loop_inc)
         mov      TEST_2_LOOP_COUNT_REG_ASM, 2


### PR DESCRIPTION
Limits the runtime of client.mangle_suspend test and adds sched_yield to wait loops.

Fixes #3333