### PR TITLE
i#3230 split traces: add lock for shard data map

### DIFF
--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -33,8 +33,9 @@
 #ifndef _BASIC_COUNTS_H_
 #define _BASIC_COUNTS_H_ 1
 
-#include <unordered_map>
+#include <mutex>
 #include <string>
+#include <unordered_map>
 
 #include "analysis_tool.h"
 
@@ -99,7 +100,10 @@ protected:
                  const std::pair<memref_tid_t, counters_t *> &r);
 
     // The keys here are int for parallel, tid for serial.
-    std::unordered_map<memref_tid_t, counters_t *> shard_counters;
+    std::unordered_map<memref_tid_t, counters_t *> shard_map;
+    // This mutex is only needed in parallel_shard_init.  In all other accesses to
+    // shard_map (process_memref, print_results) we are single-threaded.
+    std::mutex shard_map_mutex;
     unsigned int knob_verbose;
     static const std::string TOOL_NAME;
 };

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -33,6 +33,7 @@
 #ifndef _OPCODE_MIX_H_
 #define _OPCODE_MIX_H_ 1
 
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -114,7 +115,10 @@ protected:
     // We reference directory.modfile_bytes throughout operation, so its lifetime
     // must match ours.
     raw2trace_directory_t directory;
-    std::unordered_map<memref_tid_t, shard_data_t *> shard_data;
+    std::unordered_map<memref_tid_t, shard_data_t *> shard_map;
+    // This mutex is only needed in parallel_shard_init.  In all other accesses to
+    // shard_map (process_memref, print_results) we are single-threaded.
+    std::mutex shard_map_mutex;
     unsigned int knob_verbose;
     static const std::string TOOL_NAME;
     // For serial operation.


### PR DESCRIPTION
Adds missing synchronization for adding new per-shard data to the
global map of such data in the basic_counts and opcode_mix tools.

Issue: #3230