### PR TITLE
i#3031 travis emails: re-instate devs list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+# Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -33,9 +33,9 @@
 notifications:
   email:
     # This overrides the default of sending to the committer and author.
-    # Temporarily sending to bruening too to help diagnose email problems.
     recipients:
-      - bruening@google.com
+      - dynamorio-devs@googlegroups.com
+    # This is temporarily "always" to test i#3031.
     on_success: always
     on_failure: always
 


### PR DESCRIPTION
Re-instates sending Travis failures to the dynamorio-devs list as a
test to see if migrating to travis-ci.com has fixed the email problem.
Temporarily asks for emails on success as well.

Issue: #3031, #3340