### PR TITLE
i#3031 travis emails: restore defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@
 
 notifications:
   email:
-    # This overrides the default of sending to the committer and author.
-    recipients:
-      - dynamorio-devs@googlegroups.com
-    # This is temporarily "always" to test i#3031.
-    on_success: always
+    # XXX i#3031: We'd like to send email to dynamorio-devs@googlegroups.com,
+    # but Travis stopped supporting that and will only send to registered
+    # Github account addresses, so we go with the default of just the
+    # committer and author and rely on PR testing to pre-detect failures.
+    on_success: change
     on_failure: always
 
 # Don't run Travis on pushes to feature branches: pull requests cover those.


### PR DESCRIPTION
We give up for now on sending email to dynamorio-devs and restore the
defaults of just the committer and author's github emails.

Issue: #3031, #3340