### PR TITLE
i#3356: work around AMD gs base context switch bug

### DIFF
--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -5056,7 +5056,7 @@ emit_new_thread_dynamo_start(dcontext_t *dcontext, byte *pc)
         APP(&ilist,
             INSTR_CREATE_mov_seg(dcontext, opnd_create_reg(SEG_TLS),
                                  opnd_create_reg(REG_AX)));
-    }
+    } /* Else, os_clone_pre() inherits a valid-except-.magic segment (i#2089). */
 #        endif
 
     /* stack grew down, so priv_mcontext_t at tos */

--- a/core/unix/tls.h
+++ b/core/unix/tls.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -265,6 +265,10 @@ get_os_tls(void);
 
 void
 tls_thread_init(os_local_state_t *os_tls, byte *segment);
+
+/* Sets a non-zero value for unknown threads on attach (see i#3356). */
+bool
+tls_thread_preinit();
 
 void
 tls_thread_free(tls_type_t tls_type, int index);

--- a/core/unix/tls_linux_aarchxx.c
+++ b/core/unix/tls_linux_aarchxx.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -73,6 +73,12 @@ tls_thread_init(os_local_state_t *os_tls, byte *segment)
     ASSERT(*get_dr_tls_base_addr() == NULL);
     *get_dr_tls_base_addr() = segment;
     os_tls->tls_type = TLS_TYPE_SLOT;
+}
+
+bool
+tls_thread_preinit()
+{
+    return true;
 }
 
 void

--- a/core/unix/tls_linux_x86.c
+++ b/core/unix/tls_linux_x86.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -109,6 +109,10 @@ bool return_stolen_lib_tls_gdt;
 #ifdef DEBUG
 #    define GDT_32BIT 8  /*  6=NPTL, 7=wine */
 #    define GDT_64BIT 14 /* 12=NPTL, 13=wine */
+#endif
+
+#ifdef X64
+#    define NON_ZERO_UNINIT_GSBASE 0x1000UL
 #endif
 
 static int
@@ -438,7 +442,8 @@ tls_thread_init(os_local_state_t *os_tls, byte *segment)
     if (res >= 0) {
         LOG(GLOBAL, LOG_THREADS, 1, "os_tls_init: cur gs base is " PFX "\n", cur_gs);
         /* If we're a non-initial thread, gs will be set to the parent thread's value */
-        if (cur_gs == NULL || is_dynamo_address(cur_gs) ||
+        if (cur_gs == NULL || cur_gs == (byte *)NON_ZERO_UNINIT_GSBASE ||
+            is_dynamo_address(cur_gs) ||
             /* By resolving i#107, we can handle gs conflicts between app and dr. */
             INTERNAL_OPTION(mangle_app_seg)) {
             res = dynamorio_syscall(SYS_arch_prctl, 2, ARCH_SET_GS, segment);
@@ -580,10 +585,51 @@ tls_thread_init(os_local_state_t *os_tls, byte *segment)
     os_tls->ldt_index = index;
 }
 
+bool
+tls_thread_preinit()
+{
+#ifdef X64
+    /* i#3356: Write a non-zero value to the gs base to work around an AMD bug
+     * present on pre-4.7 Linux kernels.  See the call to this in our signal
+     * handler for more information.
+     */
+    if (proc_get_vendor() != VENDOR_AMD)
+        return true;
+    /* First identify a temp-native thread with a real segment in
+     * place but just an invalid .magic field.  We do not want to clobber the
+     * legitimate segment base in that case.
+     */
+    if (safe_read_tls_magic() == TLS_MAGIC_INVALID) {
+        os_local_state_t *tls = (os_local_state_t *)safe_read_tls_self();
+        if (tls != NULL &&
+            tls->state.spill_space.dcontext->owning_thread == get_sys_thread_id())
+            return true;
+    }
+    /* XXX: What about Mac on AMD?  Presumably by the time anyone wants to run
+     * that combination the Mac kernel will have fixed this if they haven't already.
+     */
+    /* We just don't have time to support non-arch_prctl and test it. */
+    if (tls_global_type != TLS_TYPE_ARCH_PRCTL) {
+        ASSERT_BUG_NUM(3356, tls_global_type == TLS_TYPE_ARCH_PRCTL);
+        return false;
+    }
+    int res = dynamorio_syscall(SYS_arch_prctl, 2, ARCH_SET_GS, NON_ZERO_UNINIT_GSBASE);
+    LOG(GLOBAL, LOG_THREADS, 1,
+        "%s: set non-zero pre-init gs base for thread " TIDFMT "\n", __FUNCTION__,
+        get_sys_thread_id());
+    return res == 0;
+#else
+    return true;
+#endif
+}
+
 /* i#2089: we skip this for non-detach */
 void
 tls_thread_free(tls_type_t tls_type, int index)
 {
+    /* XXX i#107 (and i#2088): We need to restore the segment base the
+     * app was using when we detach, instead of just clearing.
+     */
     if (tls_type == TLS_TYPE_LDT)
         clear_ldt_entry(index);
     else if (tls_type == TLS_TYPE_GDT) {
@@ -595,8 +641,11 @@ tls_thread_free(tls_type_t tls_type, int index)
     }
 #ifdef X64
     else if (tls_type == TLS_TYPE_ARCH_PRCTL) {
+        byte *restore_base =
+            /* i#3356: We need a non-zero value for AMD */
+            (proc_get_vendor() == VENDOR_AMD) ? (byte *)NON_ZERO_UNINIT_GSBASE : NULL;
         DEBUG_DECLARE(int res =)
-        dynamorio_syscall(SYS_arch_prctl, 2, ARCH_SET_GS, NULL);
+        dynamorio_syscall(SYS_arch_prctl, 2, ARCH_SET_GS, restore_base);
         ASSERT(res >= 0);
         /* syscall re-sets gs register so caller must re-clear it */
     }

--- a/core/unix/tls_macos.c
+++ b/core/unix/tls_macos.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2013-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -115,6 +115,12 @@ tls_thread_init(os_local_state_t *os_tls, byte *segment)
         WRITE_DR_SEG(selector); /* macro needs lvalue! */
     }
 #endif
+}
+
+bool
+tls_thread_preinit()
+{
+    return true;
 }
 
 #ifndef X64


### PR DESCRIPTION
Adds work-arounds for an AMD processor bug where the processor does
not clear the hidden gs base when the gs selector is written.  Pre-4.7
Linux kernels leave the prior thread's base in place on a switch due
to this.  When we attach and receive SIGUSR2 in a new thread, we can
thus get the wrong dcontext; worse, we can get NULL in the handler but
the wrong dcontext later during init.

To solve the problem on attach, we check the tid for threads receiving
a takeover signal.  For incorrect tid cases or unknown threads we set
a non-zero "pre-init" value (the kernel ignores zero) in the gs base.
We have to be careful to not clobber the valid gs base value of a
temporarily-native thread whose magic field was deliberately set to
invalid.

On detach, we now set a non-zero value rather than zero in the gs base.

When sending a thread native or cloning a child thread, we're already
leaving a copy of our base in place (with an invalid .magic field),
which eliminates any problems there.

Manually tested on an AMD machine with an older kernel: api.startstop
succeeded 1000 times in a row where before it failed every single run.

Fixes #3356