### PR TITLE
i#2921: fix rare race in test of signal arriving at late exit stage

### DIFF
--- a/suite/tests/pthreads/ptsig.c
+++ b/suite/tests/pthreads/ptsig.c
@@ -124,6 +124,11 @@ process(void *arg)
     pi += localsum;
     pthread_mutex_unlock(&pi_lock);
 
+    struct timespec sleeptime;
+    sleeptime.tv_sec = 0;
+    sleeptime.tv_nsec = 100 * 1000 * 1000; /* 100ms */
+    nanosleep(&sleeptime, NULL);
+
 #if VERBOSE
     print("thread %s exiting\n", id);
 #endif
@@ -196,4 +201,9 @@ main(int argc, char **argv)
 
     /* Print the result */
     print("Estimation of pi is %16.15f\n", pi);
+
+    struct timespec sleeptime;
+    sleeptime.tv_sec = 0;
+    sleeptime.tv_nsec = 100 * 1000 * 1000; /* 100ms */
+    nanosleep(&sleeptime, NULL);
 }

--- a/suite/tests/pthreads/ptsig.c
+++ b/suite/tests/pthreads/ptsig.c
@@ -73,6 +73,12 @@ signal_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
 #endif
         break;
     }
+    case SIGUSR2: {
+#if VERBOSE
+        print("thread %d got SIGUSR2 @ " PFX "\n", getpid(), pc);
+#endif
+        break;
+    }
     case SIGSEGV: {
 #if VERBOSE
         print("thread %d got SIGSEGV @ " PFX "\n", getpid(), pc);
@@ -145,6 +151,7 @@ main(int argc, char **argv)
     pthread_mutex_init(&pi_lock, NULL);
 
     intercept_signal(SIGUSR1, signal_handler, false);
+    intercept_signal(SIGUSR2, signal_handler, false);
     intercept_signal(SIGSEGV, signal_handler, false);
 
     /* Make the two threads */
@@ -165,9 +172,9 @@ main(int argc, char **argv)
     }
 
 #if VERBOSE
-    print("thread %d sending SIGUSR1\n", getpid());
+    print("thread %d sending SIGUSR2\n", getpid());
 #endif
-    kill(getpid(), SIGUSR1);
+    kill(getpid(), SIGUSR2);
 
     wait_cond_var(signal_received);
     reset_cond_var(signal_received);


### PR DESCRIPTION
The test occasionally hit the case where a async signal was received while the main thread is exiting. The patch adds a global var that waits for until the signal has been received.

Fixes #2921