### PR TITLE
i#2694: add exiting threads record hash to avoid deadlock during late exit

### DIFF
--- a/core/arch/aarch64/aarch64.asm
+++ b/core/arch/aarch64/aarch64.asm
@@ -337,6 +337,9 @@ cat_have_lock:
         /* free dstack and call the EXIT_DR_HOOK */
         CALLC1(GLOBAL_REF(dynamo_thread_stack_free_and_exit), x24) /* pass dstack */
 
+        /* remove thead's exit record */
+        CALLC0(GLOBAL_REF(remove_thread_exiting))
+
         /* give up initstack mutex */
         adrp     x0, :got:initstack_mutex
         ldr      x0, [x0, #:got_lo12:initstack_mutex]

--- a/core/arch/arm/arm.asm
+++ b/core/arch/arm/arm.asm
@@ -305,6 +305,8 @@ cat_have_lock:
         ldr      sp, [REG_R3]
         /* free dstack and call the EXIT_DR_HOOK */
         CALLC1(GLOBAL_REF(dynamo_thread_stack_free_and_exit), REG_R4) /* pass dstack */
+        /* remove thead's exit record */
+        CALLC0(GLOBAL_REF(remove_thread_exiting))
         /* give up initstack mutex */
         ldr      REG_R2, .Lgot3
         add      REG_R2, REG_R2, pc

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -690,6 +690,8 @@ cat_no_thread2:
 #endif
         /* free dstack and call the EXIT_DR_HOOK */
         CALLC1(GLOBAL_REF(dynamo_thread_stack_free_and_exit), REG_XCX) /* pass dstack */
+        /* remove thead's exit record */
+        CALLC0(GLOBAL_REF(remove_thread_exiting))
 #if defined(MACOS) && !defined(X64)
         lea      REG_XSP, [2*ARG_SZ + REG_XSP] /* undo align to 16 */
 #endif

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -163,6 +163,7 @@ DECL_EXTERN(dynamo_process_exit)
 DECL_EXTERN(dynamo_thread_exit)
 DECL_EXTERN(dynamo_thread_stack_free_and_exit)
 DECL_EXTERN(dynamorio_app_take_over_helper)
+DECL_EXTERN(remove_thread_exiting)
 DECL_EXTERN(found_modified_code)
 DECL_EXTERN(get_cleanup_and_terminate_global_do_syscall_entry)
 #ifdef INTERNAL

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -2666,10 +2666,10 @@ dynamo_thread_exit_common(dcontext_t *dcontext, thread_id_t id,
 #endif
 
     /* If thread goes native, we don't need to keep track of it. A this
-    * point, we have already received the SUSPEND signal, and we don't
-    * expect or could handle other signals anymore, so a deadlock should
-    * not happen (i#2964).
-    */
+     * point, we have already received the SUSPEND signal, and we don't
+     * expect or could handle other signals anymore, so a deadlock should
+     * not happen (i#2964).
+     */
     if (!doing_detach)
         mark_thread_exiting(id, true);
 

--- a/core/globals.h
+++ b/core/globals.h
@@ -330,6 +330,12 @@ typedef struct _thread_record_t {
     struct _thread_record_t *next;
 } thread_record_t;
 
+typedef struct _thread_exit_t {
+    thread_id_t id; /* thread id */
+    bool exiting;   /* thread is on its way to exit (i#2694) */
+    struct _thread_exit_t *next;
+} thread_exit_t;
+
 /* we don't include dr_api.h, that's for external use, we only need _app
  * (everything in dr_defines.h is duplicated in our own header files)
  */
@@ -561,6 +567,8 @@ standalone_init(void);
 void
 standalone_exit(void);
 #endif
+bool
+is_thread_exiting(thread_id_t tid);
 thread_record_t *
 thread_lookup(thread_id_t tid);
 void
@@ -586,6 +594,8 @@ mark_thread_execve(thread_record_t *tr, bool execve);
 #endif
 bool
 is_thread_initialized(void);
+bool
+remove_thread_exiting(void);
 int
 dynamo_thread_init(byte *dstack_in, priv_mcontext_t *mc,
                    void *os_data _IF_CLIENT_INTERFACE(bool client_thread));

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -10223,6 +10223,16 @@ os_thread_take_over(priv_mcontext_t *mc, kernel_sigset_t *sigset)
      */
     os_thread_re_take_over();
     if (!is_thread_initialized()) {
+        /* If this is a thread on its way to exit, then we are here because its dc was
+         * already destroyed. Its thread record has potentially been destroyed and
+         * removed from the global thread record table as well. The thread exiting
+         * hash is used as a life line that preserves the knowledge about the thread
+         * on its way to the exit (i#2694).
+         */
+        if (is_thread_exiting(get_thread_id())) {
+            os_thread_signal_taken_over();
+            return false;
+        }
         /* If this is a thread on its way to init, don't self-interp (i#2688). */
         if (is_dynamo_address(mc->pc)) {
             os_thread_signal_taken_over();


### PR DESCRIPTION
Keep track of threads during late exit after dcontext and thread record have been destroyed. Use exit record to recognize a late takeover signal received when no dcontext is available anymore and avoid a deadlock that can happen if a thread is holding a vm_area lock while freeing its dstack and the signal arriving during write_lock or write_unlock, leaving the lock in an undefined state.

Fixes #2694