### PR TITLE
i2723 release asserts: remove unnecessary macro param in REPORT_FATAL_ERROR_AND_EXIT

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -2877,7 +2877,7 @@ dynamorio_take_over_threads(dcontext_t *dcontext)
     signal_event(dr_attach_finished);
 
     if (found_threads) {
-        REPORT_FATAL_ERROR_AND_EXIT(dcontext, FAILED_TO_TAKE_OVER_THREADS, 2,
+        REPORT_FATAL_ERROR_AND_EXIT(FAILED_TO_TAKE_OVER_THREADS, 2,
                                     get_application_name(), get_application_pid());
     }
     DO_ONCE({

--- a/core/synch.c
+++ b/core/synch.c
@@ -1877,7 +1877,7 @@ send_all_other_threads_native(void)
     if (!synch_with_all_threads(desired_state, &threads, &num_threads,
                                 THREAD_SYNCH_NO_LOCKS_NO_XFER,
                                 THREAD_SYNCH_SUSPEND_FAILURE_IGNORE)) {
-        REPORT_FATAL_ERROR_AND_EXIT(my_dcontext, FAILED_TO_SYNCHRONIZE_THREADS, 2,
+        REPORT_FATAL_ERROR_AND_EXIT(FAILED_TO_SYNCHRONIZE_THREADS, 2,
                                     get_application_name(), get_application_pid());
     }
 
@@ -2074,7 +2074,7 @@ detach_on_permanent_stack(bool internal, bool do_cleanup, dr_stats_t *drstats)
                                  * other threads.
                                  */
                                 THREAD_SYNCH_NO_LOCKS_NO_XFER, flags)) {
-        REPORT_FATAL_ERROR_AND_EXIT(my_dcontext, FAILED_TO_SYNCHRONIZE_THREADS, 2,
+        REPORT_FATAL_ERROR_AND_EXIT(FAILED_TO_SYNCHRONIZE_THREADS, 2,
                                     get_application_name(), get_application_pid());
     }
 

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -8961,12 +8961,7 @@ get_dynamo_library_bounds(void)
     NULL_TERMINATE_BUFFER(dynamorio_alt_arch_filepath);
 
     if (dynamo_dll_start == NULL || dynamo_dll_end == NULL) {
-        /* We do not have a dcontext and it may be unsafe to try to find one.
-         * Luckily, REPORT_FATAL_ERROR_AND_EXIT does not require one to be
-         * passed.
-         * TODO(i#2723): just delete the first parameter of the macro.
-         */
-        REPORT_FATAL_ERROR_AND_EXIT(NULL, FAILED_TO_FIND_DR_BOUNDS, 2,
+        REPORT_FATAL_ERROR_AND_EXIT(FAILED_TO_FIND_DR_BOUNDS, 2,
                                     get_application_name(), get_application_pid());
     }
 }

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4881,7 +4881,7 @@ master_signal_handler_C(byte *xsp)
         if (can_always_delay[sig])
             return;
 
-        REPORT_FATAL_ERROR_AND_EXIT(dcontext, FAILED_TO_HANDLE_SIGNAL, 2,
+        REPORT_FATAL_ERROR_AND_EXIT(FAILED_TO_HANDLE_SIGNAL, 2,
                                     get_application_name(), get_application_pid());
     }
 

--- a/core/utils.h
+++ b/core/utils.h
@@ -2021,12 +2021,14 @@ notify(syslog_event_type_t priority, bool internal, bool synch,
 
 #define FATAL_ERROR_EXIT_CODE 40
 
-#define REPORT_FATAL_ERROR_AND_EXIT(dcontext, msg_id, arg_count, ...)               \
+#define REPORT_FATAL_ERROR_AND_EXIT(msg_id, arg_count, ...)               \
     do {                                                                            \
         /* Right now we just print an error message. In the future */               \
         /* it may make sense to generate a core dump too. */                        \
         SYSLOG_COMMON(false, SYSLOG_CRITICAL, msg_id, arg_count, __VA_ARGS__);      \
-        os_terminate_with_code(dcontext, TERMINATE_PROCESS, FATAL_ERROR_EXIT_CODE); \
+        /* We hard-code NULL for the dcontext because we know it isn't used */      \
+        /* with TERMINATE_PROCESS or our specific error code */                     \
+        os_terminate_with_code(NULL, TERMINATE_PROCESS, FATAL_ERROR_EXIT_CODE); \
         ASSERT_NOT_REACHED();                                                       \
     } while (0)
 


### PR DESCRIPTION
As mentioned in a comment in the macro, the terminate function does not use the dcontext anyway, and it may even be hard to obtain. Instead, hard-code the NULL in the macro to make callers' lives easier.

Issue: #2723