### PR TITLE
i#2921: support asynch signal in late exit and when interrupting a clone syscall

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1301,6 +1301,28 @@ os_slow_exit(void)
     IF_NO_MEMQUERY(memcache_exit());
 }
 
+/* Helper function that calls cleanup_and_terminate after blocking most signals
+ *(i#2921).
+ */
+void
+cleanup_and_terminate_helper(dcontext_t *dcontext, int sysnum, ptr_uint_t sys_arg1,
+                             ptr_uint_t sys_arg2, bool exitproc,
+                             /* these 2 args are only used for Mac thread exit */
+                             ptr_uint_t sys_arg3, ptr_uint_t sys_arg4)
+{
+    /* This thread is on its way to exit. We are blocking all signals since any
+     * signal that reaches us now can be delayed until after the exit is complete.
+     * We may still receive a suspend signal for synchronization that we may need
+     * to reply to (i#2921).
+     */
+    if (sysnum == SYS_kill)
+        block_all_signals_except(NULL, 2, dcontext->sys_param0, SUSPEND_SIGNAL);
+    else
+        block_all_signals_except(NULL, 1, SUSPEND_SIGNAL);
+    cleanup_and_terminate(dcontext, sysnum, sys_arg1, sys_arg2, exitproc, sys_arg3,
+                          sys_arg4);
+}
+
 /* os-specific atexit cleanup */
 void
 os_fast_exit(void)
@@ -1323,16 +1345,8 @@ os_terminate_with_code(dcontext_t *dcontext, terminate_flags_t flags, int exit_c
     if (TEST(TERMINATE_CLEANUP, flags)) {
         /* we enter from several different places, so rewind until top-level kstat */
         KSTOP_REWIND_UNTIL(thread_measured);
-
-        /* This thread is on its way to exit, we are blocking all signals since any
-         * signal that reaches us now can be delayed until after the exit is complete.
-         * We may still receive a suspend signal for synchronization that we may need
-         * to reply to (i#2921).
-         */
-        block_all_signals_except(NULL, 1, SUSPEND_SIGNAL);
-
-        cleanup_and_terminate(dcontext, SYSNUM_EXIT_PROCESS, exit_code, 0,
-                              true /*whole process*/, 0, 0);
+        cleanup_and_terminate_helper(dcontext, SYSNUM_EXIT_PROCESS, exit_code, 0,
+                                     true /*whole process*/, 0, 0);
     } else {
         /* clean up may be impossible - just terminate */
         config_exit(); /* delete .1config file */
@@ -3747,16 +3761,8 @@ client_thread_run(void)
 
     LOG(THREAD, LOG_ALL, 1, "\n***** CLIENT THREAD %d EXITING *****\n\n",
         get_thread_id());
-
-    /* This thread is on its way to exit, we are blocking all signals since any
-     * signal that reaches us now can be delayed until after the exit is complete.
-     * We may still receive a suspend signal for synchronization that we may need
-     * to reply to (i#2921).
-     */
-    block_all_signals_except(NULL, 1, SUSPEND_SIGNAL);
-
-    cleanup_and_terminate(dcontext, SYS_exit, 0, 0, false /*just thread*/,
-                          IF_MACOS_ELSE(dcontext->thread_port, 0), 0);
+    cleanup_and_terminate_helper(dcontext, SYS_exit, 0, 0, false /*just thread*/,
+                                 IF_MACOS_ELSE(dcontext->thread_port, 0), 0);
 }
 #        endif
 
@@ -5577,17 +5583,9 @@ handle_self_signal(dcontext_t *dcontext, uint sig)
          * Should do set_default_signal_action(SIGABRT) (and set a flag so
          * no races w/ another thread re-installing?) and then SYS_kill.
          */
-
-        /* This thread is on its way to exit, we are blocking all signals since any
-         * signal that reaches us now can be delayed until after the exit is complete.
-         * We may still receive a suspend signal for synchronization that we may need
-         * to reply to (i#2921).
-         */
-        block_all_signals_except(NULL, 1, SUSPEND_SIGNAL);
-
-        cleanup_and_terminate(dcontext, SYSNUM_EXIT_THREAD, -1, 0,
-                              (is_last_app_thread() && !dynamo_exited),
-                              IF_MACOS_ELSE(dcontext->thread_port, 0), 0);
+        cleanup_and_terminate_helper(dcontext, SYSNUM_EXIT_THREAD, -1, 0,
+                                     (is_last_app_thread() && !dynamo_exited),
+                                     IF_MACOS_ELSE(dcontext->thread_port, 0), 0);
         ASSERT_NOT_REACHED();
     }
 }
@@ -6398,19 +6396,10 @@ handle_exit(dcontext_t *dcontext)
             exit_process ? "process" : "thread");
     }
     KSTOP(num_exits_dir_syscall);
-
-    /* This thread is on its way to exit, we are blocking all signals since any
-     * signal that reaches us now can be delayed until after the exit is complete.
-     * We may still receive a suspend signal for synchronization that we may need
-     * to reply to. If we are doing a detach, the thread's sigmask will be swapped
-     * back to the app's mask in signal_thread_exit (i#2921).
-     */
-    block_all_signals_except(NULL, 1, SUSPEND_SIGNAL);
-
-    cleanup_and_terminate(dcontext, MCXT_SYSNUM_REG(mc), sys_param(dcontext, 0),
-                          sys_param(dcontext, 1), exit_process,
-                          /* SYS_bsdthread_terminate has 2 more args */
-                          sys_param(dcontext, 2), sys_param(dcontext, 3));
+    cleanup_and_terminate_helper(dcontext, MCXT_SYSNUM_REG(mc), sys_param(dcontext, 0),
+                                 sys_param(dcontext, 1), exit_process,
+                                 /* SYS_bsdthread_terminate has 2 more args */
+                                 sys_param(dcontext, 2), sys_param(dcontext, 3));
 }
 
 #    if defined(LINUX) && defined(X86) /* XXX i#58: just until we have Mac support */

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -272,12 +272,12 @@ signal_thread_init(dcontext_t *dcontext, void *os_data);
 void
 signal_thread_exit(dcontext_t *dcontext, bool other_thread);
 void
-block_all_signals_except(kernel_sigset_t *oset, int num, ...);
+block_all_signals_except(kernel_sigset_t *oset, int num_signals, ...);
 void
-cleanup_and_terminate_helper(dcontext_t *dcontext, int sysnum, ptr_uint_t sys_arg1,
-                             ptr_uint_t sys_arg2, bool exitproc,
-                             /* these 2 args are only used for Mac thread exit */
-                             ptr_uint_t sys_arg3, ptr_uint_t sys_arg4);
+block_cleanup_and_terminate(dcontext_t *dcontext, int sysnum, ptr_uint_t sys_arg1,
+                            ptr_uint_t sys_arg2, bool exitproc,
+                            /* these 2 args are only used for Mac thread exit */
+                            ptr_uint_t sys_arg3, ptr_uint_t sys_arg4);
 bool
 is_thread_signal_info_initialized(dcontext_t *dcontext);
 void

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -271,6 +271,8 @@ void
 signal_thread_init(dcontext_t *dcontext, void *os_data);
 void
 signal_thread_exit(dcontext_t *dcontext, bool other_thread);
+void
+block_all_signals_except(kernel_sigset_t *oset, int num, ...);
 bool
 is_thread_signal_info_initialized(dcontext_t *dcontext);
 void

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -273,6 +273,11 @@ void
 signal_thread_exit(dcontext_t *dcontext, bool other_thread);
 void
 block_all_signals_except(kernel_sigset_t *oset, int num, ...);
+void
+cleanup_and_terminate_helper(dcontext_t *dcontext, int sysnum, ptr_uint_t sys_arg1,
+                             ptr_uint_t sys_arg2, bool exitproc,
+                             /* these 2 args are only used for Mac thread exit */
+                             ptr_uint_t sys_arg3, ptr_uint_t sys_arg4);
 bool
 is_thread_signal_info_initialized(dcontext_t *dcontext);
 void

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4865,9 +4865,9 @@ master_signal_handler_C(byte *xsp)
               * known, because the thread will be added to the all_threads list after its
               * tls has been initialized (i#2921).
               */
-             safe_read_tls_magic() == TLS_MAGIC_INVALID))
+             safe_read_tls_magic() == TLS_MAGIC_INVALID)
 #endif
-    ) {
+             )) {
         tr = thread_lookup(get_sys_thread_id());
         if (tr != NULL)
             dcontext = tr->dcontext;

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4869,11 +4869,10 @@ master_signal_handler_C(byte *xsp)
              /* Check for whether this is a thread with its invalid sentinel magic set.
               * In this case, we assume that it is either a thread that is currently
               * temporarily-native via API like DR_EMIT_GO_NATIVE, or a thread in the
-              * clone window. If the thread currently makes a clone, we will find it by
-              * looking it up. If the thread was just cloned, we will not find it yet.
-              * In both cases, we know by inspection of our own code, that it is safe to
-              * call thread_lookup. thread_lookup requires a lock that must not be held
-              * by the calling thread (i#2921).
+              * clone window. We know by inspection of our own code that it is safe to
+              * call thread_lookup for either case thread makes a clone or was just
+              * cloned. i.e. thread_lookup requires a lock that must not be held by the
+              * calling thread (i#2921).
               * XXX: what is ARM doing, any special case w/ dcontext == NULL?
               */
              safe_read_tls_magic() == TLS_MAGIC_INVALID)
@@ -5618,7 +5617,7 @@ terminate_via_kill(dcontext_t *dcontext)
     /* FIXME PR 541760: there can be multiple thread groups and thus
      * this may not exit all threads in the address space
      */
-    cleanup_and_terminate_helper(
+    block_cleanup_and_terminate(
         dcontext, SYS_kill,
         /* Pass -pid in case main thread has exited
          * in which case will get -ESRCH

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4857,13 +4857,17 @@ master_signal_handler_C(byte *xsp)
     if (dcontext == NULL &&
         /* Check for a temporarily-native thread we're synch-ing with. */
         (sig == SUSPEND_SIGNAL
-         /* Check for whether this is a thread that makes a clone, in which case its
-          * magic field is temporarily invalid. It is also possible that it is a new
-          * thread on its way to init, but in this case the thread will not yet be known,
-          * because the thread will be added to the all_threads list after its tls has
-          * been initialized (i#2921).
-          */
-         || safe_read_tls_magic() == TLS_MAGIC_INVALID)) {
+#ifdef X86
+         || (INTERNAL_OPTION(safe_read_tls_init) &&
+             /* Check for whether this is a thread that makes a clone, in which case its
+              * magic field is temporarily invalid. It is also possible that it is a new
+              * thread on its way to init, but in this case the thread will not yet be
+              * known, because the thread will be added to the all_threads list after its
+              * tls has been initialized (i#2921).
+              */
+             safe_read_tls_magic() == TLS_MAGIC_INVALID))
+#endif
+    ) {
         tr = thread_lookup(get_sys_thread_id());
         if (tr != NULL)
             dcontext = tr->dcontext;


### PR DESCRIPTION
Fixes an asynch signal arriving late when thread is on its way to exit by blocking all signals during exit. This is ok if because we're at the app's thread_exit system call. When doing a detach, the app's signal mask is restored before going native. For terminate events using kill, we are not blocking the kill signal. Suspend signal is also excluded because a detaching thread may try to synchronize with an exiting thread and as long as the signal is getting delivered to this thread, we need to reply to it from the signal handler.

Adds support to the signal handler for an asynch signal arriving in the middle of a clone system call or temporarily-native thread, while the spawning thread's tls magic sentinel is invalid. We're now detecting this condition in the signal handler by making assumptions as stated in this patch.

Fixes #2921