### PR TITLE
i#3369: relax sigstack assertion in signal handler if thread is at late-exit

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4879,17 +4879,8 @@ master_signal_handler_C(byte *xsp)
 #endif
              )) {
         tr = thread_lookup(get_sys_thread_id());
-        if (tr != NULL) {
+        if (tr != NULL)
             dcontext = tr->dcontext;
-            ASSERT(dcontext != NULL);
-            /* If the thread's thread private dcontext pointer was NULL because it is
-             * currently on its way to exit, we are re-setting it to NULL. We don't
-             * have to, but not doing it can trigger an assertion further below. It is
-             * more safe to treat the thread like its dcontext is gone (i#3369).
-             */
-            if (dcontext->is_exiting)
-                dcontext = NULL;
-        }
     }
     if (dcontext == NULL ||
         (dcontext != GLOBAL_DCONTEXT &&
@@ -5251,8 +5242,11 @@ master_signal_handler_C(byte *xsp)
 
     /* Ensure we didn't get the app's sigstack into our frame.  On Mac, the kernel
      * doesn't use the frame's uc_stack, so we limit this to Linux.
+     * The pointers may be different if a thread is on its way to exit, and the app's
+     * sigstack was already restored (i#3369).
      */
-    IF_LINUX(ASSERT(dcontext == NULL || dcontext == GLOBAL_DCONTEXT ||
+    IF_LINUX(ASSERT(dcontext == NULL || dcontext->is_exiting ||
+                    dcontext == GLOBAL_DCONTEXT ||
                     frame->uc.uc_stack.ss_sp ==
                         ((thread_sig_info_t *)dcontext->signal_field)->sigstack.ss_sp));
 

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4879,8 +4879,17 @@ master_signal_handler_C(byte *xsp)
 #endif
              )) {
         tr = thread_lookup(get_sys_thread_id());
-        if (tr != NULL)
+        if (tr != NULL) {
             dcontext = tr->dcontext;
+            ASSERT(dcontext != NULL);
+            /* If the thread's thread private dcontext pointer was NULL because it is
+             * currently on its way to exit, we are re-setting it to NULL. We don't
+             * have to, but not doing it can trigger an assertion further below. It is
+             * more safe to treat the thread like its dcontext is gone (i#3369).
+             */
+            if (dcontext->is_exiting)
+                dcontext = NULL;
+        }
     }
     if (dcontext == NULL ||
         (dcontext != GLOBAL_DCONTEXT &&

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -5245,8 +5245,8 @@ master_signal_handler_C(byte *xsp)
      * The pointers may be different if a thread is on its way to exit, and the app's
      * sigstack was already restored (i#3369).
      */
-    IF_LINUX(ASSERT(dcontext == NULL || dcontext->is_exiting ||
-                    dcontext == GLOBAL_DCONTEXT ||
+    IF_LINUX(ASSERT(dcontext == NULL || dcontext == GLOBAL_DCONTEXT ||
+                    dcontext->is_exiting ||
                     frame->uc.uc_stack.ss_sp ==
                         ((thread_sig_info_t *)dcontext->signal_field)->sigstack.ss_sp));
 


### PR DESCRIPTION
Fix a regression introduced in edb2eed6b74646dcf92718675ad2ec9a3fe2b674. If a thread is on its way to exit, the app's sigstack may be restored already. Relax the master_signal_handler assertion accordingly.

Fixes #3369