### PR TITLE
i#3315: avoid conflicts with memset and memcpy

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2018 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2019 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -79,6 +79,17 @@ if (NOT "${ARCH_NAME}" STREQUAL "${ARCH_NAME_SHARED}")
 endif ()
 add_asm_target(arch/pre_inject_asm.asm preinject_asm_src preinject_asm_tgt ""
   "-DNOT_DYNAMORIO_CORE_PROPER" "${asm_deps}")
+
+if (UNIX AND X86)
+  # i#3315: We want our own memcpy and memset for the shared-lib DR core and
+  # for drinjectlib + drfrontendlib to avoid glibc-versioned symbols in
+  # our auxiliary tools (i#1504), but we do *not* want our own memcpy and
+  # memset for static-lib DR core.  Thus we separate them out.  The i#1504
+  # glibc versioning is only an issue on x86.
+  add_asm_target(arch/x86/memfuncs.asm memfuncs_asm_src memfuncs_asm_tgt
+    "_memfuncs" "" "${asm_deps}")
+  add_library(drmemfuncs STATIC ${memfuncs_asm_src})
+endif ()
 
 # i#1409: to share core code with non-core, we use the "drhelper" library.
 # XXX: we're using _shared here, and for inject_shared, etc., to mean
@@ -559,6 +570,11 @@ add_library(dynamorio SHARED
   )
 
 configure_core_lib(dynamorio)
+if (UNIX AND X86)
+  # We need our own memcpy + memset for isolation.
+  # They're separated out for sharing for i#1504.
+  target_link_libraries(dynamorio drmemfuncs)
+endif ()
 
 if (UNIX)
   # i#47: set the ELF header entry point to _start for early injection.
@@ -843,6 +859,10 @@ if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
   add_dependencies(${PRELOAD_NAME} ${preinject_asm_tgt})
 endif ()
 target_link_libraries(${PRELOAD_NAME} drhelper)
+if (UNIX AND X86)
+  # We need our own memcpy + memset for isolation.
+  target_link_libraries(${PRELOAD_NAME} drmemfuncs)
+endif ()
 copy_target_to_device(${PRELOAD_NAME} "${location_suffix}")
 
 # drpreinject.dll doesn't link in instr_shared.c so we can't include our inline
@@ -930,6 +950,10 @@ endif ()
 add_library(drinjectlib ${inject_lib_type} ${INJECTOR_SRCS})
 add_gen_events_deps(drinjectlib)
 target_link_libraries(drinjectlib drdecode drhelper)
+if (UNIX AND X86)
+  # We need our own memcpy + memset to avoid glibc versioning (i#1504).
+  target_link_libraries(drinjectlib drmemfuncs)
+endif ()
 set_target_properties(drinjectlib PROPERTIES
   # COMPILE_DEFINITONS isn't working for me: cmake bug?
   # Set define parameters for resources.rc
@@ -1066,3 +1090,7 @@ install_exported_target(drdecode ${INSTALL_LIB})
 # We have to export drhelper as static libs we're exporting depend on it.
 DR_export_target(drhelper)
 install_exported_target(drhelper ${INSTALL_LIB_BASE})
+if (UNIX AND X86)
+  DR_export_target(drmemfuncs)
+  install_exported_target(drmemfuncs ${INSTALL_LIB_BASE})
+endif ()

--- a/core/arch/x86/memfuncs.asm
+++ b/core/arch/x86/memfuncs.asm
@@ -1,0 +1,132 @@
+/* **********************************************************
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
+ * ********************************************************** */
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Copyright (c) 2003-2007 Determina Corp. */
+/* Copyright (c) 2001-2003 Massachusetts Institute of Technology */
+/* Copyright (c) 2001 Hewlett-Packard Company */
+
+/*
+ * memfuncs.asm: Contains our custom memcpy and memset routines.
+ *
+ * The core certainly needs its own memcpy and memset for libc isolation as
+ * described below, when a shared library and used for early injection.
+ * We also use these to avoid glibc-versioned imports in our auxiliary tools
+ * such as drrun (i#1504).  However, when DR is built as a static library, these
+ * functions can conflict with the application's own versions (even when
+ * marking as weak): i#3348.  Since a static-library DR will not be taking control
+ * early, and since these functions should always be re-entrant, we simply
+ * do not include them in libdynamorio_static and it imports from libc.
+ * We accomplish that by separating these into their own library.
+ */
+
+#include "../asm_defines.asm"
+#include "x86_asm_defines.asm" /* PUSHGPR, POPGPR, etc. */
+START_FILE
+
+/***************************************************************************/
+#ifdef UNIX
+
+/* i#46: Implement private memcpy and memset for libc isolation.  If we import
+ * memcpy and memset from libc in the normal way, the application can override
+ * those definitions and intercept them.  In particular, this occurs when
+ * running an app that links in the Address Sanitizer runtime.  Since we already
+ * need a reasonably efficient assembly memcpy implementation for safe_read, we
+ * go ahead and reuse the code for private memcpy and memset.
+ *
+ * XXX: See comment on REP_STRING_OP about maybe using SSE instrs.  It's more
+ * viable for memcpy and memset than for safe_read_asm.
+ */
+
+/* Private memcpy.
+ */
+        DECLARE_FUNC(memcpy)
+        WEAK(memcpy)
+GLOBAL_LABEL(memcpy:)
+        ARGS_TO_XDI_XSI_XDX()           /* dst=xdi, src=xsi, n=xdx */
+        mov    REG_XAX, REG_XDI         /* Save dst for return. */
+        /* Copy xdx bytes, align on src. */
+        REP_STRING_OP(memcpy, REG_XSI, movs)
+        RESTORE_XDI_XSI()
+        ret                             /* Return original dst. */
+        END_FUNC(memcpy)
+
+/* Private memset.
+ */
+        DECLARE_FUNC(memset)
+        WEAK(memset)
+GLOBAL_LABEL(memset:)
+        ARGS_TO_XDI_XSI_XDX()           /* dst=xdi, val=xsi, n=xdx */
+        push    REG_XDI                 /* Save dst for return. */
+        test    esi, esi                /* Usually val is zero. */
+        jnz     make_val_word_size
+        xor     eax, eax
+do_memset:
+        /* Set xdx bytes, align on dst. */
+        REP_STRING_OP(memset, REG_XDI, stos)
+        pop     REG_XAX                 /* Return original dst. */
+        RESTORE_XDI_XSI()
+        ret
+
+        /* Create pointer-sized value in XAX using multiply. */
+make_val_word_size:
+        and     esi, HEX(ff)
+# ifdef X64
+        mov     rax, HEX(0101010101010101)
+# else
+        mov     eax, HEX(01010101)
+# endif
+        /* Use two-operand imul to avoid clobbering XDX. */
+        imul    REG_XAX, REG_XSI
+        jmp     do_memset
+        END_FUNC(memset)
+
+
+# ifndef MACOS /* XXX: attribute alias issue, plus using nasm */
+/* gcc emits calls to these *_chk variants in release builds when the size of
+ * dst is known at compile time.  In C, the caller is responsible for cleaning
+ * up arguments on the stack, so we alias these *_chk routines to the non-chk
+ * routines and rely on the caller to clean up the extra dst_len arg.
+ */
+.global __memcpy_chk
+.hidden __memcpy_chk
+.set __memcpy_chk,memcpy
+
+.global __memset_chk
+.hidden __memset_chk
+.set __memset_chk,memset
+# endif
+
+#endif /* UNIX */
+
+
+END_FILE

--- a/core/arch/x86/x86_shared.asm
+++ b/core/arch/x86/x86_shared.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * ********************************************************** */
 
@@ -445,77 +445,6 @@ GLOBAL_LABEL(get_stack_ptr:)
         END_FUNC(get_stack_ptr)
 
 #endif /* WINDOWS */
-
-
-#ifdef UNIX
-/* i#46: Implement private memcpy and memset for libc isolation.  If we import
- * memcpy and memset from libc in the normal way, the application can override
- * those definitions and intercept them.  In particular, this occurs when
- * running an app that links in the Address Sanitizer runtime.  Since we already
- * need a reasonably efficient assembly memcpy implementation for safe_read, we
- * go ahead and reuse the code for private memcpy and memset.
- *
- * XXX: See comment on REP_STRING_OP about maybe using SSE instrs.  It's more
- * viable for memcpy and memset than for safe_read_asm.
- */
-
-/* Private memcpy.
- */
-        DECLARE_FUNC(memcpy)
-GLOBAL_LABEL(memcpy:)
-        ARGS_TO_XDI_XSI_XDX()           /* dst=xdi, src=xsi, n=xdx */
-        mov    REG_XAX, REG_XDI         /* Save dst for return. */
-        /* Copy xdx bytes, align on src. */
-        REP_STRING_OP(memcpy, REG_XSI, movs)
-        RESTORE_XDI_XSI()
-        ret                             /* Return original dst. */
-        END_FUNC(memcpy)
-
-/* Private memset.
- */
-        DECLARE_FUNC(memset)
-GLOBAL_LABEL(memset:)
-        ARGS_TO_XDI_XSI_XDX()           /* dst=xdi, val=xsi, n=xdx */
-        push    REG_XDI                 /* Save dst for return. */
-        test    esi, esi                /* Usually val is zero. */
-        jnz     make_val_word_size
-        xor     eax, eax
-do_memset:
-        /* Set xdx bytes, align on dst. */
-        REP_STRING_OP(memset, REG_XDI, stos)
-        pop     REG_XAX                 /* Return original dst. */
-        RESTORE_XDI_XSI()
-        ret
-
-        /* Create pointer-sized value in XAX using multiply. */
-make_val_word_size:
-        and     esi, HEX(ff)
-# ifdef X64
-        mov     rax, HEX(0101010101010101)
-# else
-        mov     eax, HEX(01010101)
-# endif
-        /* Use two-operand imul to avoid clobbering XDX. */
-        imul    REG_XAX, REG_XSI
-        jmp     do_memset
-        END_FUNC(memset)
-
-
-# ifndef MACOS /* XXX: attribute alias issue, plus using nasm */
-/* gcc emits calls to these *_chk variants in release builds when the size of
- * dst is known at compile time.  In C, the caller is responsible for cleaning
- * up arguments on the stack, so we alias these *_chk routines to the non-chk
- * routines and rely on the caller to clean up the extra dst_len arg.
- */
-.global __memcpy_chk
-.hidden __memcpy_chk
-.set __memcpy_chk,memcpy
-
-.global __memset_chk
-.hidden __memset_chk
-.set __memset_chk,memset
-# endif
-#endif /* UNIX */
 
 
 /***************************************************************************/

--- a/libutil/CMakeLists.txt
+++ b/libutil/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2018 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2019 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -207,6 +207,10 @@ if (AARCH64)
 endif()
 # We need drhelper for dynamorio_syscall for core/unix/os.c.
 target_link_libraries(drfrontendlib drhelper)
+if (UNIX AND X86)
+  # We need our own memcpy + memset to avoid glibc versioning (i#1504).
+  target_link_libraries(drfrontendlib drmemfuncs)
+endif ()
 add_static_lib_debug_info(drfrontendlib "${INSTALL_BIN}")
 DR_export_target(drfrontendlib)
 install_exported_target(drfrontendlib ${INSTALL_BIN})


### PR DESCRIPTION
Core DR's copies of memset and memcpy were placed into drhelper to
avoid glibc-versioned symbols in our shipped binaries (#1504).
They are linked into the static drfrontendlib and drinjectlib
libraries.  They are also in core DR when built as a static library.
In these static library cases they can conflict with symbols of the
same name elsewhere in the linking application.

To solve this, we first separate memset and memcpy from drhelper into
their own library, drmemfuncs.  We simply avoid linking it into static
core DR, and into drdecode.  For static core DR we assume that
whatever versions the application or glibc provides will be
re-entrant.

We can't avoid linking it into drfrontendlib and drinjectlib (we hit
the glibc versioning problem), but we reduce the chance of conflicts
with these libraries by marking memset and memcpy as weak.

Fixes #3315