### PR TITLE
i#3315 memcpy conflict: fix Mac build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=32_only
       # XXX i#2764: Travis OSX resources are over-subscribed and it can take
       # hours to get an OSX machine, so we skip running PR's for now.
-#      if: type = push
+      if: type = push
 
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=32_only
       # XXX i#2764: Travis OSX resources are over-subscribed and it can take
       # hours to get an OSX machine, so we skip running PR's for now.
-      if: type = push
+#      if: type = push
 
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:

--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2009 VMware, Inc.  All rights reserved.
  * ********************************************************** */
 
@@ -212,7 +212,7 @@ ASSUME fs:_DATA @N@\
 # define GLOBAL_LABEL(label) _##label
 # define ADDRTAKEN_LABEL(label) _##label
 # define GLOBAL_REF(label) _##label
-# define WEAK(name) weak name
+# define WEAK(name) /* no support */
 # define BYTE byte
 # define WORD word
 # define DWORD dword

--- a/core/arch/x86/memfuncs.asm
+++ b/core/arch/x86/memfuncs.asm
@@ -70,6 +70,10 @@ START_FILE
 /* Private memcpy.
  */
         DECLARE_FUNC(memcpy)
+        /* i#3315: We mark as weak to avoid app conflicts in our static libs drinjectlib
+         * and drfrontendlib (we omit completely from static core DR).  There is no
+         * weak support in nasm on Mac so we live with potential conflicts there.
+         */
         WEAK(memcpy)
 GLOBAL_LABEL(memcpy:)
         ARGS_TO_XDI_XSI_XDX()           /* dst=xdi, src=xsi, n=xdx */
@@ -83,6 +87,7 @@ GLOBAL_LABEL(memcpy:)
 /* Private memset.
  */
         DECLARE_FUNC(memset)
+        /* See the discussion above on marking weak. */
         WEAK(memset)
 GLOBAL_LABEL(memset:)
         ARGS_TO_XDI_XSI_XDX()           /* dst=xdi, val=xsi, n=xdx */


### PR DESCRIPTION
Turns WEAK into a nop in asm files as the nasm assembler has no
support for weak symbols, so we live with potential conflicts on Mac.

Temporarily runs Mac on PR builds to ensure this fixes Mac on Travis
(tested locally and it does fix it there).

Issue: #3315