### PR TITLE
i#3315 memcpy conflict: mark _check aliases as weak

### DIFF
--- a/core/arch/x86/memfuncs.asm
+++ b/core/arch/x86/memfuncs.asm
@@ -134,10 +134,12 @@ make_val_word_size:
  */
 .global __memcpy_chk
 .hidden __memcpy_chk
+WEAK(__memcpy_chk)
 .set __memcpy_chk,memcpy
 
 .global __memset_chk
 .hidden __memset_chk
+WEAK(__memset_chk)
 .set __memset_chk,memset
 # endif
 


### PR DESCRIPTION
Marks the _-memcpy_check and __memset_chk aliases as weak to further
help avoid conflicts with static linking.

Issue: #3315