### PR TITLE
Do not reference PTRACE_{G,S}ETFPXREGS when undefined

### DIFF
--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -862,7 +862,7 @@ static const enum_name_pair_t pt_req_map[] = { { PTRACE_TRACEME, "PTRACE_TRACEME
 #    endif
                                                { PTRACE_ATTACH, "PTRACE_ATTACH" },
                                                { PTRACE_DETACH, "PTRACE_DETACH" },
-#    ifndef AARCH64
+#    if defined(PTRACE_GETFPXREGS) && defined(PTRACE_SETFPXREGS)
                                                { PTRACE_GETFPXREGS, "PTRACE_GETFPXREGS" },
                                                { PTRACE_SETFPXREGS, "PTRACE_SETFPXREGS" },
 #    endif


### PR DESCRIPTION
Issue: #3381
Issue: #3399

Signed-off-by: Unai Martinez-Corral <unai.martinezcorral@ehu.eus>

---

Building on `armv7l` or `armv8l` fails with:

``` bash
[ 64%] Building C object core/CMakeFiles/drinjectlib.dir/config.c.o
/dynamorio/core/unix/injector.c:866:50: error: 'PTRACE_GETFPXREGS' undeclared here (not in a function)
                                                { PTRACE_GETFPXREGS, "PTRACE_GETFPXREGS" },
                                                  ^~~~~~~~~~~~~~~~~
/dynamorio/core/unix/injector.c:867:50: error: 'PTRACE_SETFPXREGS' undeclared here (not in a function)
                                                { PTRACE_SETFPXREGS, "PTRACE_SETFPXREGS" },
                                                  ^~~~~~~~~~~~~~~~~
make[2]: *** [core/CMakeFiles/drinjectlib.dir/unix/injector.c.o] Error 1
```

This PR avoids using `PTRACE_GETFPXREGS` and `PTRACE_SETFPXREGS` on `ARM`, as it is currently done on `AARCH64`.