### PR TITLE
Add configurable diagnostics to drfrontendlib

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -134,7 +134,8 @@ provides the umbra, drsyscall, and drsymcache Extensions for use by
 clients.
 
 The changes between version \DR_VERSION and 7.1.0 include:
- - Nothing yet.
+
+ - Added drfront_set_verbose() to obtain diagnostics from drfrontendlib.
 
 **************************************************
 <hr>

--- a/libutil/dr_frontend.h
+++ b/libutil/dr_frontend.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -497,6 +497,16 @@ drfront_dir_exists(const char *path, OUT bool *is_dir);
  */
 drfront_status_t
 drfront_dir_try_writable(const char *path, OUT bool *is_writable);
+
+/**
+ * Sets the verbosity level for additional diagnostics from the drfrontendlib
+ * library.  The default level is 0 which is quiet.  Diagnostics are printed
+ * to stderr.
+ *
+ * @param[in] verbosity  The new verbosity level.  Typical values are 0 through 3.
+ */
+drfront_status_t
+drfront_set_verbose(int verbosity);
 
 #ifdef __cplusplus
 }

--- a/libutil/dr_frontend_common.c
+++ b/libutil/dr_frontend_common.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -51,6 +51,8 @@
 #endif
 #include <sys/types.h>
 #include <sys/stat.h> /* for _stat */
+
+int drfrontend_verbosity = 0;
 
 drfront_status_t
 drfront_bufprint(char *buf, size_t bufsz, INOUT size_t *sofar, OUT ssize_t *len,
@@ -248,7 +250,7 @@ drfront_create_dir(const char *dir)
         } else if (errcode == ERROR_ACCESS_DENIED) {
             return DRFRONT_ERROR_ACCESS_DENIED;
         } else {
-            DO_DEBUG(DL_WARN, printf("CreateDirectoryW failed %d", errcode););
+            NOTIFY(1, "CreateDirectoryW failed %d\n", errcode);
             return DRFRONT_ERROR;
         }
     }
@@ -259,7 +261,7 @@ drfront_create_dir(const char *dir)
         } else if (errno == EACCES) {
             return DRFRONT_ERROR_ACCESS_DENIED;
         } else {
-            DO_DEBUG(DL_WARN, printf("mkdir failed %d", errno););
+            NOTIFY(1, "mkdir failed %d\n", errno);
             return DRFRONT_ERROR;
         }
     }
@@ -286,7 +288,7 @@ drfront_remove_dir(const char *dir)
         } else if (errcode == ERROR_ACCESS_DENIED) {
             return DRFRONT_ERROR_ACCESS_DENIED;
         } else {
-            DO_DEBUG(DL_WARN, printf("RemoveDirectoryW failed %d", errcode););
+            NOTIFY(1, "RemoveDirectoryW failed %d\n", errcode);
             return DRFRONT_ERROR;
         }
     }
@@ -297,10 +299,19 @@ drfront_remove_dir(const char *dir)
         } else if (errno == EACCES) {
             return DRFRONT_ERROR_ACCESS_DENIED;
         } else {
-            DO_DEBUG(DL_WARN, printf("rmdir failed %d", errno););
+            NOTIFY(1, "rmdir failed %d\n", errno);
             return DRFRONT_ERROR;
         }
     }
 #endif
+    return DRFRONT_SUCCESS;
+}
+
+drfront_status_t
+drfront_set_verbose(int verbosity)
+{
+    if (verbosity < 0)
+        return DRFRONT_ERROR_INVALID_PARAMETER;
+    drfrontend_verbosity = verbosity;
     return DRFRONT_SUCCESS;
 }

--- a/libutil/dr_frontend_private.h
+++ b/libutil/dr_frontend_private.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -32,11 +32,16 @@
 
 /* The header is used to add private internal defines for dr_frontend. */
 
-/* We copied these values from utils.* b/c we can't simply link utils.c with
- * the frontend (it also requires to include a number of additional *.c for
- * utils.c). The values are used in DO_DEBUG macros.
+/* We now make diagnostics available in release build as well, so we
+ * have our own defines separate from libutil/utils.h.
  */
-#ifdef DEBUG
-#    define debuglevel DL_FATAL
-#    define abortlevel DL_FATAL
-#endif
+extern int drfrontend_verbosity;
+
+#undef NOTIFY
+#define NOTIFY(level, ...)                     \
+    do {                                       \
+        if (drfrontend_verbosity >= (level)) { \
+            fprintf(stderr, __VA_ARGS__);      \
+            fflush(stderr);                    \
+        }                                      \
+    } while (0)

--- a/libutil/dr_frontend_private.h
+++ b/libutil/dr_frontend_private.h
@@ -37,6 +37,11 @@
  */
 extern int drfrontend_verbosity;
 
+#ifdef WINDOWS
+/* Disable warning about "while (0)" below. */
+#    pragma warning(disable : 4127)
+#endif
+
 #undef NOTIFY
 #define NOTIFY(level, ...)                     \
     do {                                       \

--- a/libutil/dr_frontend_win.c
+++ b/libutil/dr_frontend_win.c
@@ -39,12 +39,9 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <io.h>
-#include "config.h"
-#include "share.h"
-#include "dr_frontend_private.h" /* for debuglevel/abortlevel */
+#include "dr_frontend_private.h" /* for NOTIFY */
 #include <string.h>
 #include <errno.h>
-#include "utils.h"
 #include <assert.h>
 #include <stdio.h>
 #include <time.h>
@@ -325,8 +322,8 @@ drfront_set_client_symbol_search_path(const char *symdir, bool ignore_env,
         if ((sc != DRFRONT_SUCCESS && sc != DRFRONT_ERROR_FILE_EXISTS) ||
             drfront_access(pdb_dir, DRFRONT_READ, &dir_exists) != DRFRONT_SUCCESS ||
             !dir_exists) {
-            DO_DEBUG(DL_WARN,
-                     printf("Failed to create directory for symbols: %s\n", pdb_dir););
+            NOTIFY(1, "%s: Failed to create directory for symbols: %s\n", __FUNCTION__,
+                   pdb_dir);
             return DRFRONT_ERROR_INVALID_PATH;
         }
         strncpy(tmp_symsrv_path, pdb_dir, BUFFER_SIZE_ELEMENTS(tmp_symsrv_path));
@@ -368,27 +365,27 @@ drfront_set_client_symbol_search_path(const char *symdir, bool ignore_env,
     if (app_symsrv_path[0] == '\0') {
         if (!ignore_env) {
             /* Easiest to recurse.  Bool prevents 2nd recursion. */
-            DO_DEBUG(DL_WARN,
-                     printf("No _NT_SYMBOL_PATH dir exists. Trying to"
-                            "use user-provided path.\n"););
+            NOTIFY(1,
+                   "%s: No _NT_SYMBOL_PATH dir exists."
+                   "Trying to use user-provided path.\n",
+                   __FUNCTION__);
             return drfront_set_client_symbol_search_path(symdir, true, symsrv_path,
                                                          symsrv_path_sz);
         } else {
-            DO_DEBUG(DL_WARN,
-                     printf("Error parsing _NT_SYMBOL_PATH: may fail to fetch syms\n"););
+            NOTIFY(1, "%s: Error parsing _NT_SYMBOL_PATH: may fail to fetch syms\n",
+                   __FUNCTION__);
             return DRFRONT_ERROR;
         }
     }
-    DO_DEBUG(DL_INFO,
-             printf("Using symbol path %s as the local store\n", app_symsrv_path););
-    DO_DEBUG(DL_INFO,
-             printf("Using symbol path %s to fetch symbols\n", tmp_symsrv_path););
+    NOTIFY(2, "%s: setting %s as the local store\n", __FUNCTION__, app_symsrv_path);
+    NOTIFY(2, "%s: returning %s\n", __FUNCTION__, tmp_symsrv_path);
 
     /* Set _NT_SYMBOL_PATH for dbghelp in the app. */
     drfront_char_to_tchar(app_symsrv_path, wapp_symsrv_path,
                           BUFFER_SIZE_ELEMENTS(wapp_symsrv_path));
     if (!SetEnvironmentVariable(_T("_NT_SYMBOL_PATH"), wapp_symsrv_path)) {
-        DO_DEBUG(DL_INFO, printf("SetEnvironmentVariable failed: %d\n", GetLastError()););
+        NOTIFY(2, "%s: SetEnvironmentVariable failed: %d\n", __FUNCTION__,
+               GetLastError());
         return DRFRONT_ERROR;
     }
     /* Set it for our own use as well (dbghelp cached _NT_SYMBOL_PATH when it
@@ -399,7 +396,7 @@ drfront_set_client_symbol_search_path(const char *symdir, bool ignore_env,
      * cost of a network query.
      */
     if (!sym_set_path_func(GetCurrentProcess(), wapp_symsrv_path)) {
-        DO_DEBUG(DL_WARN, printf("SymSetSearchPathW failed %d\n", GetLastError()););
+        NOTIFY(1, "%s: SymSetSearchPathW failed %d\n", __FUNCTION__, GetLastError());
         return DRFRONT_ERROR;
     }
     if (symsrv_path != NULL) {
@@ -417,9 +414,10 @@ drfront_set_symbol_search_path(const char *symsrv_path)
         return DRFRONT_ERROR_LIB_UNSUPPORTED;
     drfront_char_to_tchar(symsrv_path, wsymsrv_path, BUFFER_SIZE_ELEMENTS(wsymsrv_path));
     if (!sym_set_path_func(GetCurrentProcess(), wsymsrv_path)) {
-        DO_DEBUG(DL_WARN, printf("SymSetSearchPathW failed %d\n", GetLastError()););
+        NOTIFY(1, "%s: SymSetSearchPathW failed %d\n", __FUNCTION__, GetLastError());
         return DRFRONT_ERROR;
     }
+    NOTIFY(2, "%s: set symbol search path to %s\n", __FUNCTION__, symsrv_path);
     return DRFRONT_SUCCESS;
 }
 
@@ -438,42 +436,42 @@ drfront_sym_init(const char *symsrv_path, const char *dbghelp_path)
                           BUFFER_SIZE_ELEMENTS(wdbghelp_path));
     hlib = LoadLibraryW(wdbghelp_path);
     if (hlib == NULL) {
-        DO_DEBUG(DL_WARN, printf("dbghelp.dll load failed %d\n", GetLastError()););
+        NOTIFY(1, "%s: dbghelp.dll load failed %d\n", __FUNCTION__, GetLastError());
         return DRFRONT_ERROR;
     }
     sym_init_func = (dbghelp_SymInitializeW_t)GetProcAddress(hlib, "SymInitializeW");
     if (sym_init_func == NULL) {
-        DO_DEBUG(DL_WARN, printf("SymInitializeW load failed %d\n", GetLastError()););
+        NOTIFY(1, "%s: SymInitializeW load failed %d\n", __FUNCTION__, GetLastError());
         return DRFRONT_ERROR_LIB_UNSUPPORTED;
     }
     sym_cleanup_func = (dbghelp_SymCleanupW_t)GetProcAddress(hlib, "SymCleanup");
     if (sym_cleanup_func == NULL) {
-        DO_DEBUG(DL_WARN, printf("SymCleanup load failed %d\n", GetLastError()););
+        NOTIFY(1, "%s: SymCleanup load failed %d\n", __FUNCTION__, GetLastError());
         return DRFRONT_ERROR_LIB_UNSUPPORTED;
     }
     sym_set_path_func =
         (dbghelp_SymSetSearchPathW_t)GetProcAddress(hlib, "SymSetSearchPathW");
     if (sym_set_path_func == NULL) {
-        DO_DEBUG(DL_WARN, printf("SymSetSearchPathW load failed %d\n", GetLastError()););
+        NOTIFY(1, "%s: SymSetSearchPathW load failed %d\n", __FUNCTION__, GetLastError());
         return DRFRONT_ERROR_LIB_UNSUPPORTED;
     }
     sym_load_module_func =
         (dbghelp_SymLoadModuleExW_t)GetProcAddress(hlib, "SymLoadModuleExW");
     if (sym_load_module_func == NULL) {
-        DO_DEBUG(DL_WARN, printf("SymLoadModuleExW load failed %d\n", GetLastError()););
+        NOTIFY(1, "%s: SymLoadModuleExW load failed %d\n", __FUNCTION__, GetLastError());
         return DRFRONT_ERROR_LIB_UNSUPPORTED;
     }
     sym_unload_module_func =
         (dbghelp_SymUnloadModule64_t)GetProcAddress(hlib, "SymUnloadModule64");
     if (sym_unload_module_func == NULL) {
-        DO_DEBUG(DL_WARN, printf("SymUnloadModule64 load failed %d\n", GetLastError()););
+        NOTIFY(1, "%s: SymUnloadModule64 load failed %d\n", __FUNCTION__, GetLastError());
         return DRFRONT_ERROR_LIB_UNSUPPORTED;
     }
     sym_get_module_info_func =
         (dbghelp_SymGetModuleInfoW64_t)GetProcAddress(hlib, "SymGetModuleInfoW64");
     if (sym_get_module_info_func == NULL) {
-        DO_DEBUG(DL_WARN,
-                 printf("SymGetModuleInfoW64 load failed %d\n", GetLastError()););
+        NOTIFY(1, "%s: SymGetModuleInfoW64 load failed %d\n", __FUNCTION__,
+               GetLastError());
         return DRFRONT_ERROR_LIB_UNSUPPORTED;
     }
     if (symsrv_path != NULL) {
@@ -482,10 +480,11 @@ drfront_sym_init(const char *symsrv_path, const char *dbghelp_path)
     } else
         wsymsrv_path[0] = '\0';
     if (!sym_init_func(proc_handle, symsrv_path == NULL ? NULL : wsymsrv_path, FALSE)) {
-        DO_DEBUG(DL_WARN, printf("SymInitializeW failed %d\n", GetLastError()););
+        NOTIFY(1, "%s: SymInitializeW failed %d\n", __FUNCTION__, GetLastError());
         return DRFRONT_ERROR;
     }
 
+    NOTIFY(1, "%s: success\n", __FUNCTION__);
     return DRFRONT_SUCCESS;
 }
 
@@ -524,10 +523,11 @@ drfront_fetch_module_symbols(const char *modpath, OUT char *symbol_path,
     /* We must use SymLoadModuleEx as there's no wide version of SymLoadModule64 */
     base = sym_load_module_func(proc, NULL, wmodpath, NULL, 0, 0, NULL, 0);
     if (base == 0) {
-        DO_DEBUG(DL_WARN,
-                 printf("SymLoadModuleEx %S error: %d\n", wmodpath, GetLastError()););
+        NOTIFY(1, "%s: SymLoadModuleEx %S error: %d\n", __FUNCTION__, wmodpath,
+               GetLastError());
         return DRFRONT_ERROR;
     }
+    NOTIFY(2, "%s: SymLoadModuleEx %S => 0x%I64x\n", __FUNCTION__, wmodpath, base);
 
     /* Check that we actually got pdbs. */
     memset(&mod_info, 0, sizeof(mod_info));
@@ -536,30 +536,26 @@ drfront_fetch_module_symbols(const char *modpath, OUT char *symbol_path,
         switch (mod_info.SymType) {
         case SymPdb:
         case SymDeferred:
-            DO_DEBUG(
-                DL_INFO,
-                printf("  pdb for %s stored at %S\n", modpath, mod_info.LoadedPdbName););
+            NOTIFY(2, "  pdb for %s stored at %S\n", modpath, mod_info.LoadedPdbName);
             got_pdbs = TRUE;
             break;
         case SymExport:
-            DO_DEBUG(DL_WARN,
-                     printf("  failed to fetch pdb for %s, exports only\n", modpath););
+            NOTIFY(1, "  failed to fetch pdb for %s, exports only\n", modpath);
             break;
         default:
-            DO_DEBUG(DL_WARN,
-                     printf("  failed to fetch pdb for %s, got SymType %d\n", modpath,
-                            mod_info.SymType););
+            NOTIFY(1, "  failed to fetch pdb for %s, got SymType %d\n", modpath,
+                   mod_info.SymType);
             break;
         }
     } else {
-        DO_DEBUG(DL_WARN, printf("SymGetModuleInfoEx failed: %d\n", GetLastError()););
+        NOTIFY(1, "%s: SymGetModuleInfoEx failed: %d\n", __FUNCTION__, GetLastError());
     }
     if (symbol_path_sz != 0)
         drfront_tchar_to_char(mod_info.LoadedPdbName, symbol_path, symbol_path_sz);
 
     /* Unload it. */
     if (!sym_unload_module_func(proc, base)) {
-        DO_DEBUG(DL_WARN, printf("SymUnloadModule64 error %d\n", GetLastError()););
+        NOTIFY(1, "%s: SymUnloadModule64 error %d\n", __FUNCTION__, GetLastError());
     }
     if (!got_pdbs)
         return DRFRONT_ERROR;

--- a/suite/tests/libutil/frontend_test.c
+++ b/suite/tests/libutil/frontend_test.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -59,6 +59,10 @@ main()
         return -1;
     }
 #ifdef WINDOWS
+    if (drfront_set_verbose(1) != DRFRONT_SUCCESS) {
+        printf("drfront_set_verbose failed\n");
+        return -1;
+    }
     if (drfront_sym_init(NULL, DBGHELP_LIB) != DRFRONT_SUCCESS) {
         printf("drfront_sym_init failed\n");
         return -1;

--- a/suite/tests/libutil/frontend_test.template
+++ b/suite/tests/libutil/frontend_test.template
@@ -1,1 +1,4 @@
+#ifdef WINDOWS
+drfront_sym_init: success
+#endif
 all done


### PR DESCRIPTION
For investigating symbol fetching errors, it is useful to be able to
obtain verbose diagnostics from the drfrontendlib routines.  Here we add
drfront_set_verbose() to programmatically enable them.