### PR TITLE
fix: opnd_shared.c

### DIFF
--- a/core/arch/opnd_shared.c
+++ b/core/arch/opnd_shared.c
@@ -1885,7 +1885,7 @@ opnd_compute_address_priv(opnd_t opnd, priv_mcontext_t *mc)
                 (index_val >> amount) | (index_val << (sizeof(reg_t) * 8 - amount));
             break;
         case DR_SHIFT_RRX:
-            scaled_index = (index_val >> 1) ||
+            scaled_index = (index_val >> 1) |
                 (TEST(EFLAGS_C, mc->cpsr) ? (1 << (sizeof(reg_t) * 8 - 1)) : 0);
             break;
         default: scaled_index = index_val;


### PR DESCRIPTION
As commented by @egrimley in [#3381](https://github.com/DynamoRIO/dynamorio/issues/3381#issuecomment-467357845) and [#3382](https://github.com/DynamoRIO/dynamorio/pull/3382#issuecomment-467355775), this patch is required in order to build DynamoRIO with GCC7.

He commented that *"That bug should be fixed in any case. I thought it had been."*. So, I don't know if this patch is already present in some other branch that has not been merged yet.

Anyway, I know that the commit message is not correct, but I don't know the motivation for the change. Indeed, I neither know whether it should be specific to GCC 7. Therefore, I am opening this issue to let the CI tools check it agains other versions.