### PR TITLE
i#2901: Fix undefined L_aeabi_ldivmod

### DIFF
--- a/third_party/libgcc/README.dynamorio
+++ b/third_party/libgcc/README.dynamorio
@@ -25,8 +25,9 @@ Here are the changes to lib1funcs.S:
 > #define __prefer_thumb__
 > #define @TODEFINE@
 > #ifdef L_divsi3
-> # define L_dvmd_tls /* for __aeabi_idiv0 */
+> # define L_dvmd_tls       /* for __aeabi_idiv0    */
 > # define L_aeabi_uldivmod /* for __aeabi_uldivmod */
+> # define L_aeabi_ldivmod  /* for __aeabi_ldivmod  */
 > #endif
 > #ifndef __thumb__
 > # define __thumb__

--- a/third_party/libgcc/arm/lib1funcs.S
+++ b/third_party/libgcc/arm/lib1funcs.S
@@ -37,8 +37,9 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #define __prefer_thumb__
 #define @TODEFINE@
 #ifdef L_divsi3
-# define L_dvmd_tls /* for __aeabi_idiv0 */
+# define L_dvmd_tls       /* for __aeabi_idiv0    */
 # define L_aeabi_uldivmod /* for __aeabi_uldivmod */
+# define L_aeabi_ldivmod  /* for __aeabi_ldivmod  */
 #endif
 #ifndef __thumb__
 # define __thumb__


### PR DESCRIPTION
Build fails with error `undefined symbol: GLOBAL DEFAULT UND __aeabi_ldivmod` on ARM with GCC 7.

Issue: #3399 
Fixes #2901

---

I have successfully tested this fix on a PYNQ board and on a APM X-Gene 2 server (in arm32v7 and arm64v8 docker containers).

Note that the patch proposed by @TomSie in [#2901](https://github.com/DynamoRIO/dynamorio/issues/2901#issuecomment-429337486) is not included here. It seems to be specific to armv6, but I don't have any such device to test. Therefore I don't know whether it is ok to close #2901 with this PR.