### PR TITLE
i#2694 vsyscall hook: Add XXX comment to describe bug.

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -2859,7 +2859,7 @@ unhook_vsyscall(void)
      * Windows does and then has to spend a lot of effort juggling transparency
      * and control on asynch in/out events.
      *
-     * XXX i#2694: We can't handle threads that have never been taken over. Such
+     * XXX i#2694: We can't handle threads that had never been taken over. Such
      * native threads w/o TLS will follow the hook and will crash when spilling
      * to TLS post-syscall before the jump to the linkstub. More synchronization
      * or no-TLS handling is needed.

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -2858,6 +2858,11 @@ unhook_vsyscall(void)
      * Using a hook is much simpler than clobbering the retaddr, which is what
      * Windows does and then has to spend a lot of effort juggling transparency
      * and control on asynch in/out events.
+     *
+     * XXX i#2694: We can't handle threads that have never been taken over. Such
+     * native threads w/o TLS will follow the hook and will crash when spilling
+     * to TLS post-syscall before the jump to the linkstub. More synchronization
+     * or no-TLS handling is needed.
      */
 
 #    define VSYS_DISPLACED_LEN 4


### PR DESCRIPTION
Test api.detach_spawn exposes a race during takeover, where a native thread that hadn't been taken over yet follows the vsyscall hook in the vdso page, and our post-syscall code assuming valid TLS causing a crash.

Issue: #2694