### PR TITLE
i#3348 sym conflicts: use "d_r_" prefix on core string routines

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -935,6 +935,8 @@ add_library(drdecode
   arch/${ARCH_NAME_SHARED}/mangle.c
   arch/mangle_utils.c
   arch/decodelib.c
+  string.c
+  io.c
   )
 set_target_properties(drdecode PROPERTIES
   COMPILE_FLAGS "-DNOT_DYNAMORIO_CORE_PROPER -DSTANDALONE_DECODER")

--- a/core/annotations.c
+++ b/core/annotations.c
@@ -1,5 +1,5 @@
 /* ******************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * ******************************************************/
 
 /*
@@ -43,10 +43,6 @@
 #    if !(defined(WINDOWS) && defined(X64))
 #        include "../third_party/valgrind/valgrind.h"
 #        include "../third_party/valgrind/memcheck.h"
-#    endif
-
-#    ifdef UNIX
-#        include <string.h>
 #    endif
 
 /* Macros for identifying an annotation head and extracting the pointer to its name.
@@ -1115,9 +1111,9 @@ annotation_printf(const char *format, ...)
                                                   ACCT_OTHER, UNPROTECTED);
 
             /* copy the original format string up to the timestamp token */
-            our_snprintf(timestamped_format, length_before_token, "%s", format);
+            d_r_snprintf(timestamped_format, length_before_token, "%s", format);
             /* copy the timestamp and the remainder of the original format string */
-            our_snprintf(timestamped_format + length_before_token,
+            d_r_snprintf(timestamped_format + length_before_token,
                          (buffer_length - length_before_token), "%s%s", timestamp_buffer,
                          timestamp_token_start + LOG_ANNOTATION_TIMESTAMP_TOKEN_LENGTH);
             /* use the timestamped format string */

--- a/core/arch/aarch64/disassemble.c
+++ b/core/arch/aarch64/disassemble.c
@@ -35,7 +35,6 @@
 #include "instr.h"
 #include "decode.h"
 #include "disassemble.h"
-#include <string.h>
 
 #if defined(INTERNAL) || defined(DEBUG) || defined(CLIENT_INTERFACE)
 

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -51,8 +51,6 @@
 #include "../fcache.h"
 #include "proc.h"
 #include "instrument.h"
-
-#include <string.h> /* for memcpy */
 
 #if defined(DEBUG) || defined(INTERNAL)
 #    include "disassemble.h"

--- a/core/arch/arm/decode.c
+++ b/core/arch/arm/decode.c
@@ -36,7 +36,6 @@
 #include "decode_private.h"
 #include "decode_fast.h" /* ensure we export decode_next_pc, decode_sizeof */
 #include "instr_create.h"
-#include <string.h> /* for memcpy */
 #include "disassemble.h"
 
 /* ARM decoder.

--- a/core/arch/arm/disassemble.c
+++ b/core/arch/arm/disassemble.c
@@ -38,7 +38,6 @@
 #include "decode.h"
 #include "decode_private.h"
 #include "disassemble.h"
-#include <string.h>
 
 #if defined(INTERNAL) || defined(DEBUG) || defined(CLIENT_INTERFACE)
 

--- a/core/arch/decodelib.c
+++ b/core/arch/decodelib.c
@@ -178,7 +178,7 @@ print_to_buffer(char *buf, size_t bufsz, size_t *sofar INOUT, const char *fmt, .
     ok = (len > 0 && len < (ssize_t)(bufsz - *sofar));
 #    ifdef UNIX
     /* Linux vsnprintf returns what would have been written, unlike Windows
-     * or our_vsnprintf
+     * or d_r_vsnprintf
      */
     if (len >= (ssize_t)(bufsz - *sofar))
         len = -1;
@@ -207,7 +207,7 @@ print_file(file_t f, const char *fmt, ...)
 
 #    ifdef UNIX
     /* Linux vsnprintf returns what would have been written, unlike Windows
-     * or our_vsnprintf
+     * or d_r_vsnprintf
      */
     if (len >= BUFFER_SIZE_ELEMENTS(buf))
         len = BUFFER_SIZE_ELEMENTS(buf); /* don't need NULL term */

--- a/core/arch/disassemble_shared.c
+++ b/core/arch/disassemble_shared.c
@@ -59,7 +59,6 @@
 #include "decode_fast.h"
 #include "disassemble.h"
 #include "../module_shared.h"
-#include <string.h>
 
 /* these are only needed for symbolic address lookup: */
 #include "../fragment.h" /* for fragment_pclookup */

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -55,7 +55,6 @@
 #include "instrlist.h"
 #include "instrument.h" /* for dr_insert_call() */
 #include "proc.h"
-#include <string.h> /* for memcpy */
 #include "decode.h"
 #include "decode_fast.h"
 #include "x86/decode_private.h"

--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -61,8 +61,6 @@
 /* FIXME i#1551: refactor this file and avoid this x86-specific include in base arch/ */
 #include "x86/decode_private.h"
 
-#include <string.h> /* for memcpy */
-
 #ifdef DEBUG
 #    include "disassemble.h"
 #endif

--- a/core/arch/instrlist.c
+++ b/core/arch/instrlist.c
@@ -42,7 +42,6 @@
 #include "instr.h"
 #include "decode.h"
 #include "arch.h"
-#include <string.h>
 
 #if defined(DEBUG) && defined(CLIENT_INTERFACE)
 /* case 10450: give messages to clients */

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -53,7 +53,6 @@
 #include "decode.h"
 #include "decode_fast.h"
 #include "disassemble.h"
-#include <string.h> /* for memcpy */
 #include "instrument.h"
 #include "../hotpatch.h"
 #ifdef RETURN_AFTER_CALL

--- a/core/arch/loadtoconst.c
+++ b/core/arch/loadtoconst.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -50,8 +50,6 @@
 #    include "instrument.h"
 #    include "../emit.h"
 #    include "../link.h"
-
-#    include <string.h> /* for memset */
 
 #    include "loadtoconst.h"
 

--- a/core/arch/opnd_shared.c
+++ b/core/arch/opnd_shared.c
@@ -45,8 +45,6 @@
 #    include "x86/decode_private.h"
 #endif
 
-#include <string.h> /* for memcpy */
-
 #if defined(DEBUG) && !defined(STANDALONE_DECODER)
 /* case 10450: give messages to clients */
 /* we can't undef ASSERT b/c of DYNAMO_OPTION */

--- a/core/arch/retcheck.c
+++ b/core/arch/retcheck.c
@@ -71,8 +71,6 @@
  * Need to provide asm code for win32 (currently #error)
  */
 
-#    include <string.h> /* for memcpy */
-
 /* we have two ways of keeping our stack in the xmm registers:
  * use one of them as a stack pointer, or have a constant top of
  * stack and always shift the registers.

--- a/core/arch/sideline.c
+++ b/core/arch/sideline.c
@@ -55,7 +55,6 @@
 #        include <sys/wait.h>    /* for wait */
 #        include <linux/sched.h> /* for clone */
 #        include <signal.h>      /* for SIGCHLD */
-#        include <string.h>      /* for memset */
 #        include <unistd.h>      /* for nice */
 #        define RUN_SIG
 typedef pid_t thread_t;

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -43,7 +43,6 @@
 #include "decode.h"
 #include "decode_fast.h"
 #include "decode_private.h"
-#include <string.h> /* for memcpy */
 
 /*
  * XXX i#431: consider cpuid features when deciding invalid instrs:

--- a/core/arch/x86/disassemble.c
+++ b/core/arch/x86/disassemble.c
@@ -43,7 +43,6 @@
 #include "decode.h"
 #include "decode_private.h"
 #include "disassemble.h"
-#include <string.h>
 
 #if defined(INTERNAL) || defined(DEBUG) || defined(CLIENT_INTERFACE)
 

--- a/core/arch/x86/encode.c
+++ b/core/arch/x86/encode.c
@@ -45,8 +45,6 @@
 #include "decode_fast.h"
 #include "decode_private.h"
 
-#include <string.h> /* memcpy, memset */
-
 #ifdef DEBUG
 /* case 10450: give messages to clients */
 /* we can't undef ASSERT b/c of DYNAMO_OPTION */

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -64,8 +64,6 @@
 #    include <sys/syscall.h>
 #endif
 
-#include <string.h> /* for memset */
-
 #ifdef ANNOTATIONS
 #    include "../annotations.h"
 #endif

--- a/core/arch/x86/optimize.c
+++ b/core/arch/x86/optimize.c
@@ -56,7 +56,6 @@
 #    include "../fragment.h"
 #    include "disassemble.h"
 #    include "proc.h"
-#    include <string.h> /* for memset */
 
 /* IMPORTANT INSTRUCTIONS FOR WRITING OPTIMIZATIONS:
  *

--- a/core/arch/x86_code.c
+++ b/core/arch/x86_code.c
@@ -43,7 +43,6 @@
 #include "../dispatch.h"
 #include "../monitor.h"
 #include "arch.h"
-#include <string.h> /* for memcpy */
 
 /* Helper routine for the x86.asm PUSH_DR_MCONTEXT, to fill in the xmm0-5 values
  * (or all for linux) (or ymm) only if necessary.

--- a/core/config.c
+++ b/core/config.c
@@ -45,8 +45,6 @@
 #        include "ntdll.h"
 #    endif
 
-#    include <string.h>
-
 /* DYNAMORIO_VAR_CONFIGDIR is searched first, and then these: */
 #    ifdef UNIX
 #        define GLOBAL_CONFIG_DIR "/etc/dynamorio"
@@ -104,11 +102,11 @@ display_verbose_message(char *format, ...);
 #        endif
 #        undef STDERR
 #        define STDERR stderr
-#        undef our_snprintf
+#        undef d_r_snprintf
 #        ifdef WINDOWS
-#            define our_snprintf _snprintf
+#            define d_r_snprintf _snprintf
 #        else
-#            define our_snprintf snprintf
+#            define d_r_snprintf snprintf
 #        endif
 #        undef DECLARE_NEVERPROT_VAR
 #        define DECLARE_NEVERPROT_VAR(var, val) var = (val)

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -48,7 +48,6 @@
 #include "perscache.h"
 #include "native_exec.h"
 #include "translate.h"
-#include <string.h> /* for strstr */
 
 #ifdef CLIENT_INTERFACE
 #    include "emit.h"

--- a/core/drlibc/drlibc.c
+++ b/core/drlibc/drlibc.c
@@ -44,7 +44,6 @@
 
 #ifdef MACOS
 #    include <sys/utsname.h> /* for struct utsname */
-#    include <string.h>
 #endif
 
 /***************************************************************************
@@ -70,6 +69,19 @@ WEAK bool
 ignore_assert(const char *assert_file_line, const char *expr)
 {
     return true;
+}
+
+WEAK int
+d_r_strcmp(const char *left, const char *right)
+{
+    size_t i;
+    for (i = 0; left[i] != '\0' || right[i] != '\0'; i++) {
+        if (left[i] < right[i])
+            return -1;
+        if (left[i] > right[i])
+            return 1;
+    }
+    return 0;
 }
 
 WEAK file_t main_logfile;

--- a/core/drlibc/drlibc_module_elf.c
+++ b/core/drlibc/drlibc_module_elf.c
@@ -40,7 +40,6 @@
 #include "module_private.h"
 #include "../utils.h"
 #include "instrument.h"
-#include <string.h>
 #include <stddef.h> /* offsetof */
 #include <link.h>   /* Elf_Symndx */
 

--- a/core/drlibc/drlibc_module_macho.c
+++ b/core/drlibc/drlibc_module_macho.c
@@ -46,7 +46,6 @@
 #include <mach-o/fat.h>
 #include <sys/syscall.h>
 #include <stddef.h> /* offsetof */
-#include <string.h> /* strcmp */
 #include <dlfcn.h>
 
 /* Like is_elf_so_header(), if size == 0 then safe-reads the header; else

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -69,8 +69,6 @@
 #    include "annotations.h"
 #endif
 
-#include <string.h>
-
 #ifdef WINDOWS
 /* for close handle, duplicate handle, free memory and constants associated with them
  */

--- a/core/emit.c
+++ b/core/emit.c
@@ -51,7 +51,6 @@
 #include "instr_create.h"
 #include "monitor.h"
 #include "translate.h"
-#include <string.h> /* memcpy */
 
 #ifdef DEBUG
 #    include "decode_fast.h" /* for decode_next_pc for stress_recreate_pc */

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -47,7 +47,6 @@
 #ifdef HOT_PATCHING_INTERFACE
 #    include "hotpatch.h"
 #endif
-#include <string.h> /* for memcpy */
 #include <stddef.h> /* for offsetof */
 #include <limits.h> /* for UCHAR_MAX */
 #include "perscache.h"

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -45,7 +45,6 @@
 #include "fcache.h"
 #include "emit.h"
 #include "monitor.h"
-#include <string.h> /* for memset */
 #include "instrument.h"
 #include <stddef.h> /* for offsetof */
 #include <limits.h> /* UINT_MAX */

--- a/core/globals.h
+++ b/core/globals.h
@@ -1129,35 +1129,97 @@ enum { DUMP_XML = true, DUMP_NOT_XML = false };
 /* to avoid transparency problems we must have our own vnsprintf and sscanf */
 #include <stdarg.h> /* for va_list */
 int
-our_snprintf(char *s, size_t max, const char *fmt, ...);
+d_r_snprintf(char *s, size_t max, const char *fmt, ...);
 int
-our_vsnprintf(char *s, size_t max, const char *fmt, va_list ap);
+d_r_vsnprintf(char *s, size_t max, const char *fmt, va_list ap);
 int
-our_snprintf_wide(wchar_t *s, size_t max, const wchar_t *fmt, ...);
+d_r_snprintf_wide(wchar_t *s, size_t max, const wchar_t *fmt, ...);
 int
-our_vsnprintf_wide(wchar_t *s, size_t max, const wchar_t *fmt, va_list ap);
+d_r_vsnprintf_wide(wchar_t *s, size_t max, const wchar_t *fmt, va_list ap);
 #undef snprintf /* defined on macos */
-#define snprintf our_snprintf
+#define snprintf d_r_snprintf
 #undef _snprintf
-#define _snprintf our_snprintf
+#define _snprintf d_r_snprintf
 #undef vsnprintf
-#define vsnprintf our_vsnprintf
-#define snwprintf our_snprintf_wide
-#define _snwprintf our_snprintf_wide
+#define vsnprintf d_r_vsnprintf
+#define snwprintf d_r_snprintf_wide
+#define _snwprintf d_r_snprintf_wide
 int
-our_sscanf(const char *str, const char *format, ...);
+d_r_sscanf(const char *str, const char *format, ...);
 int
-our_vsscanf(const char *str, const char *fmt, va_list ap);
+d_r_vsscanf(const char *str, const char *fmt, va_list ap);
 const char *
 parse_int(const char *sp, uint64 *res_out, uint base, uint width, bool is_signed);
 ssize_t
 utf16_to_utf8_size(const wchar_t *src, size_t max_chars,
                    size_t *written /*unicode chars*/);
-#define sscanf our_sscanf
+#define sscanf d_r_sscanf
 
 /* string.c */
+#ifdef UNIX
+/* i#3348: Use unique names to avoid conflicts during static linking.  We'd
+ * prefer to just invoke the d_r_ version explicitly, but on Windows we need the
+ * regular name to use the ntdll versions.  Thus we use macro indirection.
+ */
+#    undef strlen
+#    define strlen d_r_strlen
+#    undef strlen
+#    define strlen d_r_strlen
+#    undef wcslen
+#    define wcslen d_r_wcslen
+#    undef strchr
+#    define strchr d_r_strchr
+#    undef strrchr
+#    define strrchr d_r_strrchr
+#    undef strncpy
+#    define strncpy d_r_strncpy
+#    undef strncat
+#    define strncat d_r_strncat
+#    undef memmove
+#    define memmove d_r_memmove
+#    undef strcmp
+#    define strcmp d_r_strcmp
+#    undef strncmp
+#    define strncmp d_r_strncmp
+#    undef memcmp
+#    define memcmp d_r_memcmp
+#    undef strstr
+#    define strstr d_r_strstr
+#    undef tolower
+#    define tolower d_r_tolower
+#    undef strcasecmp
+#    define strcasecmp d_r_strcasecmp
+#    undef strtoul
+#    define strtoul d_r_strtoul
+#endif
+size_t
+strlen(const char *str);
+size_t
+wcslen(const wchar_t *str);
+char *
+strchr(const char *str, int c);
+char *
+strrchr(const char *str, int c);
+char *
+strncpy(char *dst, const char *src, size_t n);
+char *
+strncat(char *dest, const char *src, size_t n);
+void *
+memmove(void *dst, const void *src, size_t n);
+int
+strcmp(const char *left, const char *right);
+int
+strncmp(const char *left, const char *right, size_t n);
+int
+memcmp(const void *left_v, const void *right_v, size_t n);
+char *
+strstr(const char *haystack, const char *needle);
 int
 tolower(int c);
+int
+strcasecmp(const char *left, const char *right);
+unsigned long
+strtoul(const char *str, char **end, int base);
 
 /* Code cleanliness rules */
 #ifdef WINDOWS

--- a/core/hashtable.c
+++ b/core/hashtable.c
@@ -35,7 +35,6 @@
 
 #include "globals.h"
 #include "hashtable.h"
-#include <string.h> /* memset */
 
 /* Returns the proper number of hash bits to have a capacity with the
  * given load for the given number of entries

--- a/core/heap.c
+++ b/core/heap.c
@@ -40,7 +40,6 @@
  */
 
 #include "globals.h"
-#include <string.h> /* for memcpy */
 #include <limits.h>
 
 #include "fragment.h" /* for struct sizes */

--- a/core/hotpatch.c
+++ b/core/hotpatch.c
@@ -49,7 +49,6 @@
 #include "moduledb.h" /* macros for nudge; can be moved with nudge to os.c */
 
 #ifndef WINDOWS
-#    include <string.h>
 #endif
 
 #include <limits.h> /* for ULLONG_MAX */

--- a/core/io.c
+++ b/core/io.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -45,11 +45,11 @@
 #else
 #    include "configure.h"
 #    include "globals_shared.h"
+#    include <string.h>
 typedef unsigned long ulong;
 void
 dr_fpu_exception_init(void);
 #endif
-#include <string.h>
 #include <stdarg.h> /* for varargs */
 
 #ifdef UNIX
@@ -360,8 +360,8 @@ typedef enum _int_sz_t {
  */
 /* clang-format off */ /* (work around clang-format newline-after-type bug) */
 static bool inline
-/* clang-format on */
 our_isspace(int c)
+/* clang-format on */
 {
     return (c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v');
 }
@@ -478,7 +478,7 @@ parse_int(const char *sp, uint64 *res_out, uint base, uint width, bool is_signed
  * Therefore, we roll our own.
  */
 int
-our_vsscanf(const char *str, const char *fmt, va_list ap)
+d_r_vsscanf(const char *str, const char *fmt, va_list ap)
 {
     int num_parsed = 0;
     const char *fp = fmt;
@@ -719,13 +719,13 @@ our_vsscanf(const char *str, const char *fmt, va_list ap)
 }
 
 int
-our_sscanf(const char *str, const char *fmt, ...)
+d_r_sscanf(const char *str, const char *fmt, ...)
 {
     /* No need to save errno, we don't call libc anymore. */
     int res;
     va_list ap;
     va_start(ap, fmt);
-    res = our_vsscanf(str, fmt, ap);
+    res = d_r_vsscanf(str, fmt, ap);
     va_end(ap);
     return res;
 }
@@ -755,8 +755,8 @@ test_sscanf_maps_x86(void)
     const char *maps_line = "f75c3000-f75c4000 rw-p 00155000 fc:00 1840387"
                             "                            /lib32/libc-2.11.1.so";
 
-    strcpy(line_copy, maps_line);
-    len = our_sscanf(line_copy, MAPS_LINE_FORMAT4, &start, &end, perm, &offset, &inode,
+    strncpy(line_copy, maps_line, BUFFER_SIZE_ELEMENTS(line_copy));
+    len = d_r_sscanf(line_copy, MAPS_LINE_FORMAT4, &start, &end, perm, &offset, &inode,
                      comment);
     EXPECT(len, 6);
     /* Do int64 comparisons directly.  EXPECT casts to ptr_uint_t. */
@@ -783,8 +783,8 @@ test_sscanf_maps_x64(void)
     const char *maps_line = "7f94a6757000-7f94a6758000 rw-p 0017d000 fc:00 "
                             "1839331                     /lib/libc-2.11.1.so";
 
-    strcpy(line_copy, maps_line);
-    len = our_sscanf(line_copy, MAPS_LINE_FORMAT8, &start, &end, perm, &offset, &inode,
+    strncpy(line_copy, maps_line, BUFFER_SIZE_ELEMENTS(line_copy));
+    len = d_r_sscanf(line_copy, MAPS_LINE_FORMAT8, &start, &end, perm, &offset, &inode,
                      comment);
     EXPECT(len, 6);
     /* Do int64 comparisons directly.  EXPECT casts to ptr_uint_t. */
@@ -818,7 +818,7 @@ test_sscanf_all_specs(void)
 #    endif
 
     /* ULLONG_MAX is a corner case. */
-    res = our_sscanf("c str -123 +456 0x789 0xffffffffffffffff", "%c %s %d %u %x %llx",
+    res = d_r_sscanf("c str -123 +456 0x789 0xffffffffffffffff", "%c %s %d %u %x %llx",
                      &ch, str, &signed_int, &unsigned_int, &hex_num, &ull_num);
     EXPECT(res, 6);
     EXPECT(ch, 'c');
@@ -829,28 +829,28 @@ test_sscanf_all_specs(void)
     EXPECT((ull_num == ULLONG_MAX), true);
 
     /* A variety of ways to say negative one. */
-    res = our_sscanf("-1-1", "%d%d", &signed_int, &signed_int_2);
+    res = d_r_sscanf("-1-1", "%d%d", &signed_int, &signed_int_2);
     EXPECT(res, 2);
     EXPECT(signed_int, -1);
     EXPECT(signed_int_2, -1);
 
     /* Test ignores. */
-    res = our_sscanf("c str -123 +456 0x789 0xffffffffffffffff 1",
+    res = d_r_sscanf("c str -123 +456 0x789 0xffffffffffffffff 1",
                      "%*c %*s %*d %*u %*x %*llx %d", &signed_int);
     EXPECT(res, 1);
     EXPECT(signed_int, 1);
 
     /* Test width specifications on strings. */
     memset(str, '*', sizeof(str)); /* Fill string with garbage. */
-    res = our_sscanf("abcdefghijklmnopqrstuvwxyz", "%13s", str);
+    res = d_r_sscanf("abcdefghijklmnopqrstuvwxyz", "%13s", str);
     EXPECT(res, 1);
-    /* our_sscanf should read 13 chars and add null termination. */
+    /* d_r_sscanf should read 13 chars and add null termination. */
     EXPECT(memcmp(str, "abcdefghijklm", 13), 0);
     EXPECT(str[13], '\0');
     EXPECT(str[14], '*'); /* Asterisk should still be there. */
 
     /* Test width specifications for integers. */
-    res = our_sscanf("123456 0x9abc", "%03d%03d %03xc", &signed_int, &signed_int_2,
+    res = d_r_sscanf("123456 0x9abc", "%03d%03d %03xc", &signed_int, &signed_int_2,
                      &unsigned_int);
     EXPECT(res, 3);
     EXPECT(signed_int, 123);
@@ -858,7 +858,7 @@ test_sscanf_all_specs(void)
     EXPECT(unsigned_int, 0x9ab);
 
     /* Test modifiers for integers. */
-    res = our_sscanf("123456 789012345 678901234", "%hd %ld %zd", &signed_short,
+    res = d_r_sscanf("123456 789012345 678901234", "%hd %ld %zd", &signed_short,
                      &signed_long, &z_num);
     EXPECT(res, 3);
     EXPECT(signed_short, -7616);
@@ -866,37 +866,37 @@ test_sscanf_all_specs(void)
     EXPECT(z_num, 678901234);
 
     /* Test skipping leading whitespace for integer conversions. */
-    res = our_sscanf(" \t123456\t\n 0x9abc", "%d%x", &signed_int, &unsigned_int);
+    res = d_r_sscanf(" \t123456\t\n 0x9abc", "%d%x", &signed_int, &unsigned_int);
     EXPECT(res, 2);
     EXPECT(signed_int, 123456);
     EXPECT(unsigned_int, 0x9abc);
 
     /* Test Windows-style integer width specifiers using decimal ULLONG_MAX. */
-    res = our_sscanf("1234 18446744073709551615", "%I32d %I64d", &signed_int, &ull_num);
+    res = d_r_sscanf("1234 18446744073709551615", "%I32d %I64d", &signed_int, &ull_num);
     EXPECT(res, 2);
     EXPECT(signed_int, 1234);
     EXPECT((ull_num == ULLONG_MAX), true);
 
     /* Test [] charsets. */
-    res = our_sscanf("aacaadaac", "%[abc]", str);
+    res = d_r_sscanf("aacaadaac", "%[abc]", str);
     EXPECT(res, 1);
     EXPECT(strcmp(str, "aacaa"), 0);
-    res = our_sscanf("abcd.%[]/\\^4xyz", "%[^0-9]", str);
+    res = d_r_sscanf("abcd.%[]/\\^4xyz", "%[^0-9]", str);
     EXPECT(res, 1);
     EXPECT(strcmp(str, "abcd.%[]/\\^"), 0);
-    res = our_sscanf("abcd.%[]/\\^4xyz", "%8[^0-9]", str);
+    res = d_r_sscanf("abcd.%[]/\\^4xyz", "%8[^0-9]", str);
     EXPECT(res, 1);
     EXPECT(strcmp(str, "abcd.%[]"), 0);
-    res = our_sscanf("32495873-23489---34---00a0", "%[0-9-]", str);
+    res = d_r_sscanf("32495873-23489---34---00a0", "%[0-9-]", str);
     EXPECT(res, 1);
     EXPECT(strcmp(str, "32495873-23489---34---00"), 0);
-    res = our_sscanf("]3249587]3-23489---34---00a0", "%[]0-9-]", str);
+    res = d_r_sscanf("]3249587]3-23489---34---00a0", "%[]0-9-]", str);
     EXPECT(res, 1);
     EXPECT(strcmp(str, "]3249587]3-23489---34---00"), 0);
-    res = our_sscanf("abcd.%[]/\\^4xyz", "%[^]]", str);
+    res = d_r_sscanf("abcd.%[]/\\^4xyz", "%[^]]", str);
     EXPECT(res, 1);
     EXPECT(strcmp(str, "abcd.%["), 0);
-    res = our_sscanf("line\v\r\nline\r\n", "%[^\r\n]", str);
+    res = d_r_sscanf("line\v\r\nline\r\n", "%[^\r\n]", str);
     EXPECT(res, 1);
     EXPECT(strcmp(str, "line\v"), 0);
 
@@ -1049,25 +1049,25 @@ test_integer(void)
     ssize_t res;
 
     /* test integer codes */
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%lld", 0x12345678abcdef01LL);
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%lld", 0x12345678abcdef01LL);
     EXPECT(res == (ssize_t)strlen("1311768467750121217"), true);
     EXPECT(strcmp(buf, "1311768467750121217"), 0);
 
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%lld", 0x82345678abcdef01LL);
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%lld", 0x82345678abcdef01LL);
     EXPECT(res == (ssize_t)strlen("-9064525073711501567"), true);
     EXPECT(strcmp(buf, "-9064525073711501567"), 0);
 
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%llu", 0x82345678abcdef01LL);
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%llu", 0x82345678abcdef01LL);
     EXPECT(res == (ssize_t)strlen("9382218999998050049"), true);
     EXPECT(strcmp(buf, "9382218999998050049"), 0);
 
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%zu",
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%zu",
                        (size_t)IF_X64_ELSE(0x82345678abcdef01LL, 0x82345678));
     EXPECT(res == (ssize_t)strlen(IF_X64_ELSE("9382218999998050049", "2184468088")),
            true);
     EXPECT(strcmp(buf, IF_X64_ELSE("9382218999998050049", "2184468088")), 0);
 
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%zd",
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%zd",
                        (size_t)IF_X64_ELSE(0x82345678abcdef01LL, 0x82345678));
     EXPECT(res == (ssize_t)strlen(IF_X64_ELSE("-9064525073711501567", "-2110499208")),
            true);
@@ -1084,44 +1084,44 @@ unit_test_io(void)
     ssize_t res;
 
     /* test wide char conversion */
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%S", L"wide string");
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%S", L"wide string");
     EXPECT(res == (ssize_t)strlen("wide string"), true);
     EXPECT(strcmp(buf, "wide string"), 0);
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%ls", L"wide string");
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%ls", L"wide string");
     EXPECT(res == (ssize_t)strlen("wide string"), true);
     EXPECT(strcmp(buf, "wide string"), 0);
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%.3S", L"wide string");
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%.3S", L"wide string");
     EXPECT(res == (ssize_t)strlen("wid"), true);
     EXPECT(strcmp(buf, "wid"), 0);
-    res = our_snprintf(buf, 4, "%S", L"wide string");
+    res = d_r_snprintf(buf, 4, "%S", L"wide string");
     EXPECT(res == -1, true);
     EXPECT(buf[4], ' '); /* ' ' from prior calls: no NULL written since hit max */
     buf[4] = '\0';
     EXPECT(strcmp(buf, "wide"), 0);
 
     /* test float */
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%3.1f", 42.9f);
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%3.1f", 42.9f);
     EXPECT(res == (ssize_t)strlen("42.9"), true);
     EXPECT(strcmp(buf, "42.9"), 0);
     /* XXX: add more */
 
     /* test all-wide */
-    res = our_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%d%s%3.1f", -42,
+    res = d_r_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%d%s%3.1f", -42,
                             L"wide string", 42.9f);
     EXPECT(res == (ssize_t)wcslen(L"-42wide string42.9"), true);
     EXPECT(wcscmp(wbuf, L"-42wide string42.9"), 0);
 
     /* test all-wide conversion */
-    res = our_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%S", "narrow string");
+    res = d_r_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%S", "narrow string");
     EXPECT(res == (ssize_t)wcslen(L"narrow string"), true);
     EXPECT(wcscmp(wbuf, L"narrow string"), 0);
-    res = our_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%hs", "narrow string");
+    res = d_r_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%hs", "narrow string");
     EXPECT(res == (ssize_t)wcslen(L"narrow string"), true);
     EXPECT(wcscmp(wbuf, L"narrow string"), 0);
-    res = our_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%.3S", "narrow string");
+    res = d_r_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%.3S", "narrow string");
     EXPECT(res == (ssize_t)wcslen(L"nar"), true);
     EXPECT(wcscmp(wbuf, L"nar"), 0);
-    res = our_snprintf_wide(wbuf, 6, L"%S", "narrow string");
+    res = d_r_snprintf_wide(wbuf, 6, L"%S", "narrow string");
     EXPECT(res == -1, true);
     EXPECT(wbuf[6], L' '); /* ' ' from prior calls: no NULL written since hit max */
     wbuf[6] = L'\0';
@@ -1129,7 +1129,7 @@ unit_test_io(void)
 
 #    ifdef WINDOWS
     /* test UTF-16 to UTF-8 */
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%S",
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%S",
                        L"\x0391\x03A9\x20Ac"); /* alpha, omega, euro sign */
     EXPECT(res == 7, true);                    /* 2x 2-char + 1 3-char encodings */
     EXPECT((byte)buf[0] == 0xce && (byte)buf[1] == 0x91, true); /* UTF-8 U-0391 */
@@ -1137,17 +1137,17 @@ unit_test_io(void)
     EXPECT((byte)buf[4] == 0xe2 && (byte)buf[5] == 0x82 && (byte)buf[6] == 0xac,
            true); /* UTF-8 U-20Ac */
     EXPECT((byte)buf[7] == '\0', true);
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%S",
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%S",
                        L"\xd800"); /* no low surrogate */
     EXPECT(res == -1, true);
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%S",
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%S",
                        L"\xd800\xdc00"); /* surrogate pair */
     EXPECT(res == 4, true);              /* 4-char encoding */
     EXPECT((byte)buf[0] == 0xf0 && (byte)buf[1] == 0x90 && (byte)buf[2] == 0x80 &&
                (byte)buf[3] == 0x80,
            true); /* UTF-8 U-10000 */
     EXPECT((byte)buf[4] == '\0', true);
-    res = our_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%.6S",
+    res = d_r_snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%.6S",
                        L"\x0391\x03A9\x20Ac"); /* alpha, omega, euro sign */
     EXPECT(res == 4, true); /* 2x 2-char + aborted the 3-char encoding */
     EXPECT((byte)buf[0] == 0xce && (byte)buf[1] == 0x91, true); /* UTF-8 U-0391 */
@@ -1155,19 +1155,19 @@ unit_test_io(void)
     EXPECT((byte)buf[4] == '\0', true);
 
     /* test UTF-8 to UTF-16 */
-    res = our_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%S",
+    res = d_r_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%S",
                             "\xce\x91\xce\xa9\xe2\x82\xac"); /* alpha, omega, euro sign */
     EXPECT(res == 3, true);
     EXPECT(wbuf[0] == 0x0391 && wbuf[1] == 0x03a9 && wbuf[2] == 0x20ac, true);
     EXPECT(wbuf[3] == L'\0', true);
-    res = our_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%S",
+    res = d_r_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%S",
                             "\xff\x91\xce\xa9\xe2\x82");
     EXPECT(res == -1, true); /* not encodable in UTF-16 */
-    res = our_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%S",
+    res = d_r_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%S",
                             "\xf0\x90\x80\x80"); /* U-1000 */
     EXPECT(res == 2, true);
     EXPECT(wbuf[0] == 0xd800 && wbuf[1] == 0xdc00 && wbuf[2] == L'\0', true);
-    res = our_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%.2S",
+    res = d_r_snprintf_wide(wbuf, BUFFER_SIZE_ELEMENTS(wbuf), L"%.2S",
                             "\xce\x91\xce\xa9\xe2\x82\xac"); /* alpha, omega, euro sign */
     EXPECT(res == 2, true);
     EXPECT(wbuf[0] == 0x0391 && wbuf[1] == 0x03a9 && wbuf[2] == L'\0', true);

--- a/core/iox.h
+++ b/core/iox.h
@@ -201,10 +201,10 @@ TNAME(double_to_exp_str)(double d, int exp, int decimal, TCHAR *buf,
     return buf;
 }
 
-/* i#386: separated out to avoid floating-point instrs in our_vsnprintf */
+/* i#386: separated out to avoid floating-point instrs in d_r_vsnprintf */
 /* clang-format off */ /* (work around clang-format newline-after-type bug) */
 static const TCHAR *
-TNAME(our_vsnprintf_float)(double val, const TCHAR *c,
+TNAME(d_r_vsnprintf_float)(double val, const TCHAR *c,
                            TCHAR prefixbuf[3], TCHAR buf[BUF_SIZE],
                            int decimal, bool space_flag,
                            bool plus_flag, bool pound_flag)
@@ -282,7 +282,7 @@ TNAME(our_vsnprintf_float)(double val, const TCHAR *c,
  */
 /* clang-format off */ /* (work around clang-format newline-after-type bug) */
 int
-TNAME(our_vsnprintf)(TCHAR *s, size_t max, const TCHAR *fmt, va_list ap)
+TNAME(d_r_vsnprintf)(TCHAR *s, size_t max, const TCHAR *fmt, va_list ap)
 /* clang-format on */
 {
     const TCHAR *c;
@@ -563,7 +563,7 @@ TNAME(our_vsnprintf)(TCHAR *s, size_t max, const TCHAR *fmt, va_list ap)
             case _T('f'): {
                 /* pretty sure will always be promoted to a double in arg list */
                 double val = va_arg(ap, double);
-                str = TNAME(our_vsnprintf_float)(val, c, prefixbuf, buf, decimal,
+                str = TNAME(d_r_vsnprintf_float)(val, c, prefixbuf, buf, decimal,
                                                  space_flag, plus_flag, pound_flag);
                 break;
             }
@@ -738,14 +738,14 @@ max_reached:
  */
 /* clang-format off */ /* (work around clang-format newline-after-type bug) */
 int
-TNAME(our_snprintf)(TCHAR *s, size_t max, const TCHAR *fmt, ...)
+TNAME(d_r_snprintf)(TCHAR *s, size_t max, const TCHAR *fmt, ...)
 /* clang-format on */
 {
     int res;
     va_list ap;
     ASSERT(s);
     va_start(ap, fmt);
-    res = TNAME(our_vsnprintf)(s, max, fmt, ap);
+    res = TNAME(d_r_vsnprintf)(s, max, fmt, ap);
     va_end(ap);
     return res;
 }

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -54,7 +54,6 @@
 #include "../emit.h"
 #include "../link.h"
 #include "../monitor.h" /* for mark_trace_head */
-#include <string.h>     /* for strstr */
 #include <stdarg.h>     /* for varargs */
 #include "../nudge.h"   /* for nudge_internal() */
 #include "../synch.h"
@@ -4596,12 +4595,12 @@ dr_snprintf(char *buf, size_t max, const char *fmt, ...)
     int res;
     va_list ap;
     va_start(ap, fmt);
-    /* PR 219380: we use our_vsnprintf instead of ntdll._vsnprintf b/c the
+    /* PR 219380: we use d_r_vsnprintf instead of ntdll._vsnprintf b/c the
      * latter does not support floating point.
-     * Plus, our_vsnprintf returns -1 for > max chars (matching Windows
+     * Plus, d_r_vsnprintf returns -1 for > max chars (matching Windows
      * behavior, but which Linux libc version does not do).
      */
-    res = our_vsnprintf(buf, max, fmt, ap);
+    res = d_r_vsnprintf(buf, max, fmt, ap);
     va_end(ap);
     return res;
 }
@@ -4609,7 +4608,7 @@ dr_snprintf(char *buf, size_t max, const char *fmt, ...)
 DR_API int
 dr_vsnprintf(char *buf, size_t max, const char *fmt, va_list ap)
 {
-    return our_vsnprintf(buf, max, fmt, ap);
+    return d_r_vsnprintf(buf, max, fmt, ap);
 }
 
 DR_API int
@@ -4618,7 +4617,7 @@ dr_snwprintf(wchar_t *buf, size_t max, const wchar_t *fmt, ...)
     int res;
     va_list ap;
     va_start(ap, fmt);
-    res = our_vsnprintf_wide(buf, max, fmt, ap);
+    res = d_r_vsnprintf_wide(buf, max, fmt, ap);
     va_end(ap);
     return res;
 }
@@ -4626,7 +4625,7 @@ dr_snwprintf(wchar_t *buf, size_t max, const wchar_t *fmt, ...)
 DR_API int
 dr_vsnwprintf(wchar_t *buf, size_t max, const wchar_t *fmt, va_list ap)
 {
-    return our_vsnprintf_wide(buf, max, fmt, ap);
+    return d_r_vsnprintf_wide(buf, max, fmt, ap);
 }
 
 DR_API int
@@ -4635,7 +4634,7 @@ dr_sscanf(const char *str, const char *fmt, ...)
     int res;
     va_list ap;
     va_start(ap, fmt);
-    res = our_vsscanf(str, fmt, ap);
+    res = d_r_vsscanf(str, fmt, ap);
     va_end(ap);
     return res;
 }

--- a/core/link.c
+++ b/core/link.c
@@ -45,7 +45,6 @@
 #include "fcache.h"
 #include "emit.h"
 #include "monitor.h"
-#include <string.h> /* for memset */
 #include "perscache.h"
 #include "instr.h" /* PC_RELATIVE_TARGET */
 

--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -43,8 +43,6 @@
 #    include "instrument.h" /* for instrument_client_lib_unloaded */
 #endif
 
-#include <string.h>
-
 /* ok to be in .data w/ no sentinel head node b/c never empties out
  * .ntdll always there for Windows, so no need to unprot.
  * XXX: Does it hold for Linux?

--- a/core/module_list.c
+++ b/core/module_list.c
@@ -34,7 +34,6 @@
 #include "globals.h"
 #include "instrument.h"
 #include "native_exec.h"
-#include <string.h> /* for memset */
 #ifdef WINDOWS
 #    include "ntdll.h" /* for protect_virtual_memory */
 #endif

--- a/core/moduledb.c
+++ b/core/moduledb.c
@@ -37,7 +37,6 @@
 #include "utils.h"
 #include "moduledb.h"
 #include "module_shared.h"
-#include <string.h> /* for memset, strlen */
 
 /* An array of pointers to the various exempt lists indexed by the
  * moduledb_exempt_list_t enum.  We have the ugliness of an extra indirection

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -48,7 +48,6 @@
 #ifdef CUSTOM_TRACES
 #    include "instrument.h"
 #endif
-#include <string.h> /* for memset */
 #include "instr.h"
 #include "perscache.h"
 #include "disassemble.h"

--- a/core/nudge.c
+++ b/core/nudge.c
@@ -40,7 +40,6 @@
 #    include "os_exports.h" /* for detach_helper(), get_stack_bounds() */
 #    include "drmarker.h"
 #else
-#    include <string.h>
 #endif /* WINDOWS */
 
 #ifdef HOT_PATCHING_INTERFACE

--- a/core/options.c
+++ b/core/options.c
@@ -48,12 +48,10 @@
 #    include "monitor.h"
 #    include "moduledb.h" /* for the process control defines */
 #    include "disassemble.h"
-#    include <string.h>
 
 #else /* NOT_DYNAMORIO_CORE */
 #    include "configure.h"
 #    include <stdio.h> /* snprintf, sscanf */
-#    include <string.h>
 
 #    ifdef WINDOWS
 #        define inline __inline

--- a/core/perscache.c
+++ b/core/perscache.c
@@ -48,7 +48,6 @@
 #include "hotpatch.h"
 #include "synch.h"
 #include "module_shared.h"
-#include <string.h> /* for memset */
 #include <stddef.h> /* for offsetof */
 #ifdef CLIENT_INTERFACE
 #    include "instrument.h"

--- a/core/stats.c
+++ b/core/stats.c
@@ -60,8 +60,6 @@
 #include "dr_stats.h"
 #include "stats.h"
 
-#include <string.h> /* for memset */
-
 #ifdef KSTATS
 
 #    ifdef KSTAT_UNIT_TEST

--- a/core/string.c
+++ b/core/string.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,17 +49,17 @@
  * define or declare these routines.  We simplify our lives by avoiding
  * string.h.
  *
- * Other files are free to include string.h.  If the compiler decides not to
- * inline, it will emit a call to the routine with the standard name, and the
- * linker will resolve it to our implementations.
+ * Other files should not include string.h either.  On UNIX, we no longer use
+ * the standard string function names, so the linker will not resolve a
+ * compiler-inlined symbol to ours.
  */
 #ifdef _STRING_H
-#    error "Don't include <string.h> in string.c"
+#    error "Don't include <string.h>"
 #endif
 
 /* Private strlen. */
 size_t
-strlen(const char *str)
+d_r_strlen(const char *str)
 {
     const char *cur = str;
     while (*cur != '\0') {
@@ -70,7 +70,7 @@ strlen(const char *str)
 
 /* Private wcslen. */
 size_t
-wcslen(const wchar_t *str)
+d_r_wcslen(const wchar_t *str)
 {
     const wchar_t *cur = str;
     while (*cur != L'\0') {
@@ -84,7 +84,7 @@ wcslen(const wchar_t *str)
  * returning NULL.
  */
 char *
-strchr(const char *str, int c)
+d_r_strchr(const char *str, int c)
 {
     while (true) {
         if (*str == c)
@@ -101,7 +101,7 @@ strchr(const char *str, int c)
  * returning NULL.
  */
 char *
-strrchr(const char *str, int c)
+d_r_strrchr(const char *str, int c)
 {
     const char *ret = NULL;
     while (true) {
@@ -118,7 +118,7 @@ strrchr(const char *str, int c)
  * truncation applies.
  */
 char *
-strncpy(char *dst, const char *src, size_t n)
+d_r_strncpy(char *dst, const char *src, size_t n)
 {
     size_t i;
     for (i = 0; i < n && src[i] != '\0'; i++)
@@ -131,7 +131,7 @@ strncpy(char *dst, const char *src, size_t n)
 
 /* Private strncat. */
 char *
-strncat(char *dest, const char *src, size_t n)
+d_r_strncat(char *dest, const char *src, size_t n)
 {
     size_t dest_len = strlen(dest);
     size_t i;
@@ -150,7 +150,7 @@ strncat(char *dest, const char *src, size_t n)
  * you want.
  */
 void *
-memmove(void *dst, const void *src, size_t n)
+d_r_memmove(void *dst, const void *src, size_t n)
 {
     ssize_t i;
     byte *dst_b = (byte *)dst;
@@ -180,7 +180,7 @@ __memmove_chk(void *dst, const void *src, size_t n, size_t dst_len)
     return memmove(dst, src, n);
 }
 #    else
-    __attribute__((alias("memmove")));
+    __attribute__((alias("d_r_memmove")));
 #    endif
 void *
 __strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
@@ -192,7 +192,7 @@ __strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
     return strncpy(dst, src, n);
 }
 #    else
-    __attribute__((alias("strncpy")));
+    __attribute__((alias("d_r_strncpy")));
 #    endif
 void *
 __strncat_chk(char *dst, const char *src, size_t n, size_t dst_len)
@@ -204,13 +204,13 @@ __strncat_chk(char *dst, const char *src, size_t n, size_t dst_len)
     return strncat(dst, src, n);
 }
 #    else
-    __attribute__((alias("strncat")));
+    __attribute__((alias("d_r_strncat")));
 #    endif
 #endif
 
 /* Private strcmp. */
 int
-strcmp(const char *left, const char *right)
+d_r_strcmp(const char *left, const char *right)
 {
     size_t i;
     for (i = 0; left[i] != '\0' || right[i] != '\0'; i++) {
@@ -224,7 +224,7 @@ strcmp(const char *left, const char *right)
 
 /* Private strncmp. */
 int
-strncmp(const char *left, const char *right, size_t n)
+d_r_strncmp(const char *left, const char *right, size_t n)
 {
     size_t i;
     for (i = 0; i < n && (left[i] != '\0' || right[i] != '\0'); i++) {
@@ -238,7 +238,7 @@ strncmp(const char *left, const char *right, size_t n)
 
 /* Private memcmp. */
 int
-memcmp(const void *left_v, const void *right_v, size_t n)
+d_r_memcmp(const void *left_v, const void *right_v, size_t n)
 {
     /* Use unsigned comparisons. */
     const byte *left = left_v;
@@ -255,7 +255,7 @@ memcmp(const void *left_v, const void *right_v, size_t n)
 
 /* Private strstr. */
 char *
-strstr(const char *haystack, const char *needle)
+d_r_strstr(const char *haystack, const char *needle)
 {
     const char *cur = haystack;
     size_t needle_len = strlen(needle);
@@ -270,7 +270,7 @@ strstr(const char *haystack, const char *needle)
 
 /* Private tolower. */
 int
-tolower(int c)
+d_r_tolower(int c)
 {
     if (c >= 'A' && c <= 'Z')
         return (c - ('A' - 'a'));
@@ -279,7 +279,7 @@ tolower(int c)
 
 /* Private strcasecmp. */
 int
-strcasecmp(const char *left, const char *right)
+d_r_strcasecmp(const char *left, const char *right)
 {
     size_t i;
     for (i = 0; left[i] != '\0' || right[i] != '\0'; i++) {
@@ -301,7 +301,7 @@ strcasecmp(const char *left, const char *right)
  * can call parse_int directly.
  */
 unsigned long
-strtoul(const char *str, char **end, int base)
+d_r_strtoul(const char *str, char **end, int base)
 {
     uint64 num;
     const char *parse_end = parse_int(str, &num, base, 0 /*width*/, true /*signed*/);

--- a/core/synch.c
+++ b/core/synch.c
@@ -43,7 +43,6 @@
 #include "fcache.h"     /* in_fcache() */
 #include "translate.h"
 #include "native_exec.h"
-#include <string.h> /* for memcpy */
 
 extern vm_area_vector_t *fcache_unit_areas; /* from fcache.c */
 

--- a/core/translate.c
+++ b/core/translate.c
@@ -52,8 +52,6 @@
 #include "proc.h"
 #include "instrument.h"
 
-#include <string.h> /* for memcpy */
-
 #if defined(DEBUG) || defined(INTERNAL)
 #    include "disassemble.h"
 #endif

--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -68,7 +68,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
+#include <string.h> /* for strerror */
 #include <sys/mman.h>
 #include <sys/ptrace.h>
 #if defined(LINUX) && defined(AARCH64)

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -58,7 +58,6 @@
 #ifdef LINUX
 #    include <sys/prctl.h> /* PR_SET_NAME */
 #endif
-#include <string.h> /* strcmp */
 #include <stdlib.h> /* getenv */
 #include <dlfcn.h>  /* dlopen/dlsym */
 #include <unistd.h> /* __environ */

--- a/core/unix/memcache.c
+++ b/core/unix/memcache.c
@@ -44,7 +44,6 @@
 #include "memcache.h"
 #include "memquery.h"
 #include "os_private.h"
-#include <string.h>
 #include <sys/mman.h>
 #ifdef CLIENT_INTERFACE
 #    include "instrument.h"

--- a/core/unix/memquery.c
+++ b/core/unix/memquery.c
@@ -39,7 +39,6 @@
 #include "../globals.h"
 #include "memquery.h"
 #include "module.h"
-#include <string.h>
 
 /***************************************************************************
  * LIBRARY BOUNDS

--- a/core/unix/memquery_emulate.c
+++ b/core/unix/memquery_emulate.c
@@ -43,7 +43,6 @@
 #include "../globals.h"
 #include "memquery.h"
 #include "os_private.h"
-#include <string.h>
 
 #ifdef HAVE_MEMINFO
 #    error Use kernel queries instead of emulation

--- a/core/unix/memquery_linux.c
+++ b/core/unix/memquery_linux.c
@@ -44,7 +44,6 @@
 #include "memquery.h"
 #include "os_private.h"
 #include "module_private.h"
-#include <string.h>
 #include <sys/mman.h>
 
 #ifndef LINUX

--- a/core/unix/module.c
+++ b/core/unix/module.c
@@ -38,7 +38,6 @@
 #include "os_private.h"
 #include "../utils.h"
 #include "instrument.h"
-#include <string.h>
 #include <stddef.h> /* offsetof */
 
 #ifdef NOT_DYNAMORIO_CORE_PROPER

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -38,7 +38,6 @@
 #include "module_private.h"
 #include "../utils.h"
 #include "instrument.h"
-#include <string.h>
 #include <stddef.h> /* offsetof */
 #include <link.h>   /* Elf_Symndx */
 

--- a/core/unix/module_macho.c
+++ b/core/unix/module_macho.c
@@ -58,7 +58,6 @@
 #include <mach-o/fat.h>
 #include <sys/syscall.h>
 #include <stddef.h> /* offsetof */
-#include <string.h> /* strcmp */
 #include <dlfcn.h>
 
 bool

--- a/core/unix/nudgesig.c
+++ b/core/unix/nudgesig.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,7 +37,6 @@
  */
 
 #include "configure.h"
-#include <string.h>
 #include <unistd.h>
 #include "include/syscall.h"
 #include "include/siginfo.h"
@@ -45,6 +44,8 @@
 #include "globals_shared.h"
 #ifndef NOT_DYNAMORIO_CORE
 #    include "../globals.h" /* for arch_exports.h for dynamorio_syscall */
+#else
+#    include <string.h> /* for memset */
 #endif
 
 /* shared with tools/nudgeunix.c */

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -64,7 +64,6 @@
 #include "../globals.h"
 #include "../hashtable.h"
 #include "../native_exec.h"
-#include <string.h>
 #include <unistd.h> /* for write and usleep and _exit */
 #include <limits.h>
 

--- a/core/unix/pcprofile.c
+++ b/core/unix/pcprofile.c
@@ -43,7 +43,6 @@
 #include "../utils.h"
 #include "../fragment.h"
 #include "../fcache.h"
-#include <string.h> /* for memset */
 #ifdef CLIENT_INTERFACE
 #    include "instrument.h"
 #endif

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -65,7 +65,6 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <ucontext.h>
-#include <string.h> /* for memcpy and memset */
 #include "os_private.h"
 #include "../fragment.h"
 #include "../fcache.h"

--- a/core/unix/stackdump.c
+++ b/core/unix/stackdump.c
@@ -48,7 +48,6 @@
 #include <fcntl.h>
 #include <sys/file.h>
 #include <sys/wait.h>
-#include <string.h>
 
 #include "../globals.h"
 #include "os_private.h"

--- a/core/unix/symtab.c
+++ b/core/unix/symtab.c
@@ -42,7 +42,6 @@
  * FIXME: assumes ELF executable compiled w/ -static
  */
 
-#include <string.h>
 #include <errno.h>
 #include <bfd.h>
 /* globals.h gives us stdio, stdlib, and assert */

--- a/core/utils.c
+++ b/core/utils.c
@@ -44,7 +44,6 @@
 #include "configure_defines.h"
 #include "utils.h"
 #include "module_shared.h"
-#include <string.h> /* for memset */
 #include <math.h>
 
 #ifdef PROCESS_CONTROL
@@ -1790,11 +1789,11 @@ vprint_to_buffer(char *buf, size_t bufsz, size_t *sofar INOUT, const char *fmt,
                  va_list ap)
 {
     /* in io.c */
-    extern int our_vsnprintf(char *s, size_t max, const char *fmt, va_list ap);
+    extern int d_r_vsnprintf(char *s, size_t max, const char *fmt, va_list ap);
     ssize_t len;
     bool ok;
-    /* we use our_vsnprintf for consistent return value and to handle floats */
-    len = our_vsnprintf(buf + *sofar, bufsz - *sofar, fmt, ap);
+    /* we use d_r_vsnprintf for consistent return value and to handle floats */
+    len = d_r_vsnprintf(buf + *sofar, bufsz - *sofar, fmt, ap);
     /* we support appending an empty string (len==0) */
     ok = (len >= 0 && len < (ssize_t)(bufsz - *sofar));
     *sofar += (len == -1 ? (bufsz - *sofar - 1) : (len < 0 ? 0 : len));
@@ -3188,7 +3187,7 @@ print_timestamp_to_buffer(char *buffer, size_t len)
     msec = (uint)(current_time % 1000);
     min = sec / 60;
     sec = sec % 60;
-    return our_snprintf(buffer, print_len, "(%ld:%02ld.%03ld)", min, sec, msec);
+    return d_r_snprintf(buffer, print_len, "(%ld:%02ld.%03ld)", min, sec, msec);
 }
 
 /* prints elapsed time since program startup to the given logfile

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -68,8 +68,6 @@
 #    include "synch.h" /* all_threads_synch_lock */
 #endif
 
-#include <string.h>
-
 enum {
     /* VM_ flags to distinguish region types
      * We also use some FRAG_ flags (but in a separate field so no value space overlap)

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -68,7 +68,6 @@
 #include "../perscache.h"
 #include "../translate.h"
 
-#include <string.h> /* for memcpy */
 #include <windows.h>
 
 /* forward declarations */

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -46,9 +46,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <stdio.h>
-#include <string.h>
 
-#include "ntdll.h"      /* for get/set context etc. */
+#include "ntdll.h" /* for get/set context etc. */
 
 #include "instr.h"
 #include "instr_create.h"

--- a/core/win32/injector.c
+++ b/core/win32/injector.c
@@ -63,7 +63,6 @@
 #include <imagehlp.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h> /* memset */
 #include <time.h>
 #include <tchar.h>
 

--- a/libutil/dr_config.c
+++ b/libutil/dr_config.c
@@ -55,13 +55,13 @@
 #    define LIB32_SUBDIR _TEXT("\\lib32")
 #    define PREINJECT32_DLL _TEXT("\\lib32\\drpreinject.dll")
 #    define PREINJECT64_DLL _TEXT("\\lib64\\drpreinject.dll")
-#    define _snprintf our_snprintf
+#    define _snprintf d_r_snprintf
 #    undef _sntprintf
-#    define _sntprintf our_snprintf_wide
+#    define _sntprintf d_r_snprintf_wide
 int
-our_snprintf(char *s, size_t max, const char *fmt, ...);
+d_r_snprintf(char *s, size_t max, const char *fmt, ...);
 int
-our_snprintf_wide(wchar_t *s, size_t max, const wchar_t *fmt, ...);
+d_r_snprintf_wide(wchar_t *s, size_t max, const wchar_t *fmt, ...);
 #else
 #    include <sys/stat.h>
 #    include <sys/types.h>

--- a/libutil/dr_frontend_common.c
+++ b/libutil/dr_frontend_common.c
@@ -60,7 +60,7 @@ drfront_bufprint(char *buf, size_t bufsz, INOUT size_t *sofar, OUT ssize_t *len,
 {
     va_list ap;
     va_start(ap, fmt);
-    /* XXX i#1397: We would like to use our_vsnprintf() instead of depending
+    /* XXX i#1397: We would like to use d_r_vsnprintf() instead of depending
      * on libc/winapi.
      */
     *len = vsnprintf(buf + *sofar, bufsz - *sofar, fmt, ap);

--- a/suite/tests/client-interface/file_io.c
+++ b/suite/tests/client-interface/file_io.c
@@ -197,9 +197,9 @@ main()
 
 #endif
     /* Now test any floating-point printing at exit time in DR or a
-     * client by unmasking div-by-zero, which our_vsnprintf_float()
+     * client by unmasking div-by-zero, which d_r_vsnprintf_float()
      * relies on being masked (i#1213).
-     * On Linux the our_vsnprintf_float() code currently doesn't do a
+     * On Linux the d_r_vsnprintf_float() code currently doesn't do a
      * divide but we check there nonetheless.
      */
 #ifdef WINDOWS


### PR DESCRIPTION
Rename our_*snprintf* to d_r_*snprintf* per the new global variable naming policy.
Rename our_*sscanf to d_r_*sscanf.

Rename DR's internal string routines to use a d_r_ prefix to reduce
name conflicts with static linking.  Because on Windows we still want
to use the standard names (because we import from ntdll), we resort to
macro renames within core/ just like we're doing with snprintf.

Remove includes of string.h in core/ to avoid macros and inlined
functions pulling in libc functions, now that our versions use
different names.

Issue: #3348