### PR TITLE
i#3407: Work around clang-format parsing errors

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2160,94 +2160,108 @@ get_ibl_branch_type(instr_t *instr)
 const char *
 get_ibl_routine_name(dcontext_t *dcontext, cache_pc target, const char **ibl_brtype_name)
 {
-    static const char *const
-        ibl_routine_names IF_X86_64([3]) [IBL_SOURCE_TYPE_END][IBL_LINK_STATE_END] = {
-        IF_X86_64({)
-        {"shared_unlinked_bb_ibl", "shared_delete_bb_ibl",
-         "shared_bb_far", "shared_bb_far_unlinked",
-         IF_X86_64_("shared_bb_cmp") IF_X86_64_("shared_bb_cmp_unlinked")
-         "shared_bb_ibl", "shared_bb_ibl_template"},
-        {"shared_unlinked_trace_ibl", "shared_delete_trace_ibl",
-         "shared_trace_far", "shared_trace_far_unlinked",
-         IF_X86_64_("shared_trace_cmp") IF_X86_64_("shared_trace_cmp_unlinked")
-         "shared_trace_ibl", "shared_trace_ibl_template"},
-        {"private_unlinked_bb_ibl", "private_delete_bb_ibl",
-         "private_bb_far", "private_bb_far_unlinked",
-         IF_X86_64_("private_bb_cmp") IF_X86_64_("private_bb_cmp_unlinked")
-         "private_bb_ibl", "private_bb_ibl_template"},
-        {"private_unlinked_trace_ibl", "private_delete_trace_ibl",
-         "private_trace_far", "private_trace_far_unlinked",
-         IF_X86_64_("private_trace_cmp") IF_X86_64_("private_trace_cmp_unlinked")
-         "private_trace_ibl", "private_trace_ibl_template"},
-        {"shared_unlinked_coarse_ibl", "shared_delete_coarse_ibl",
-         "shared_coarse_trace_far", "shared_coarse_trace_far_unlinked",
-         IF_X86_64_("shared_coarse_trace_cmp")
-         IF_X86_64_("shared_coarse_trace_cmp_unlinked")
-         "shared_coarse_ibl", "shared_coarse_ibl_template"},
 #if defined(X86) && defined(X64)
-        /* PR 282576: for WOW64 processes we have separate x86 routines */
-        }, {
-        {"x86_shared_unlinked_bb_ibl", "x86_shared_delete_bb_ibl",
-         "x86_shared_bb_far", "x86_shared_bb_far_unlinked",
-         IF_X64_("x86_shared_bb_cmp") IF_X64_("x86_shared_bb_cmp_unlinked")
-         "x86_shared_bb_ibl", "x86_shared_bb_ibl_template"},
-        {"x86_shared_unlinked_trace_ibl", "x86_shared_delete_trace_ibl",
-         "x86_shared_trace_far", "x86_shared_trace_far_unlinked",
-         IF_X64_("x86_shared_trace_cmp") IF_X64_("x86_shared_trace_cmp_unlinked")
-         "x86_shared_trace_ibl", "x86_shared_trace_ibl_template"},
-        {"x86_private_unlinked_bb_ibl", "x86_private_delete_bb_ibl",
-         "x86_private_bb_far", "x86_private_bb_far_unlinked",
-         IF_X64_("x86_private_bb_cmp") IF_X64_("x86_private_bb_cmp_unlinked")
-         "x86_private_bb_ibl", "x86_private_bb_ibl_template"},
-        {"x86_private_unlinked_trace_ibl", "x86_private_delete_trace_ibl",
-         "x86_private_trace_far", "x86_private_trace_far_unlinked",
-         IF_X64_("x86_private_trace_cmp") IF_X64_("x86_private_trace_cmp_unlinked")
-         "x86_private_trace_ibl", "x86_private_trace_ibl_template"},
-        {"x86_shared_unlinked_coarse_ibl", "x86_shared_delete_coarse_ibl",
-         "x86_shared_coarse_trace_far",
-         "x86_shared_coarse_trace_far_unlinked",
-         IF_X64_("x86_shared_coarse_trace_cmp")
-         IF_X64_("x86_shared_coarse_trace_cmp_unlinked")
-         "x86_shared_coarse_ibl", "x86_shared_coarse_ibl_template"},
-        }, {
-        { "x86_to_x64_shared_unlinked_bb_ibl", "x86_to_x64_shared_delete_bb_ibl",
-          "x86_to_x64_shared_bb_far",          "x86_to_x64_shared_bb_far_unlinked",
-          "x86_to_x64_shared_bb_cmp",          "x86_to_x64_shared_bb_cmp_unlinked",
-          "x86_to_x64_shared_bb_ibl",          "x86_to_x64_shared_bb_ibl_template" },
-            { "x86_to_x64_shared_unlinked_trace_ibl",
-              "x86_to_x64_shared_delete_trace_ibl",
-              "x86_to_x64_shared_trace_far",
-              "x86_to_x64_shared_trace_far_unlinked",
-              "x86_to_x64_shared_trace_cmp",
-              "x86_to_x64_shared_trace_cmp_unlinked",
-              "x86_to_x64_shared_trace_ibl",
-              "x86_to_x64_shared_trace_ibl_template" },
-            { "x86_to_x64_private_unlinked_bb_ibl", "x86_to_x64_private_delete_bb_ibl",
-              "x86_to_x64_private_bb_far", "x86_to_x64_private_bb_far_unlinked",
-              "x86_to_x64_private_bb_cmp", "x86_to_x64_private_bb_cmp_unlinked",
-              /* clang-format off */
+    static const char
+        *const ibl_routine_names[3][IBL_SOURCE_TYPE_END][IBL_LINK_STATE_END] = {
+            {
+                { "shared_unlinked_bb_ibl", "shared_delete_bb_ibl", "shared_bb_far",
+                  "shared_bb_far_unlinked", "shared_bb_cmp", "shared_bb_cmp_unlinked",
+                  "shared_bb_ibl", "shared_bb_ibl_template" },
+                { "shared_unlinked_trace_ibl", "shared_delete_trace_ibl",
+                  "shared_trace_far", "shared_trace_far_unlinked", "shared_trace_cmp",
+                  "shared_trace_cmp_unlinked", "shared_trace_ibl",
+                  "shared_trace_ibl_template" },
+                { "private_unlinked_bb_ibl", "private_delete_bb_ibl", "private_bb_far",
+                  "private_bb_far_unlinked", "private_bb_cmp", "private_bb_cmp_unlinked",
+                  "private_bb_ibl", "private_bb_ibl_template" },
+                { "private_unlinked_trace_ibl", "private_delete_trace_ibl",
+                  "private_trace_far", "private_trace_far_unlinked", "private_trace_cmp",
+                  "private_trace_cmp_unlinked", "private_trace_ibl",
+                  "private_trace_ibl_template" },
+                { "shared_unlinked_coarse_ibl", "shared_delete_coarse_ibl",
+                  "shared_coarse_trace_far", "shared_coarse_trace_far_unlinked",
+                  "shared_coarse_trace_cmp", "shared_coarse_trace_cmp_unlinked",
+                  "shared_coarse_ibl", "shared_coarse_ibl_template" },
+                /* PR 282576: for WOW64 processes we have separate x86 routines */
+            },
+            {
+                { "x86_shared_unlinked_bb_ibl", "x86_shared_delete_bb_ibl",
+                  "x86_shared_bb_far", "x86_shared_bb_far_unlinked",
+                  IF_X64_("x86_shared_bb_cmp")
+                      IF_X64_("x86_shared_bb_cmp_unlinked") "x86_shared_bb_ibl",
+                  "x86_shared_bb_ibl_template" },
+                { "x86_shared_unlinked_trace_ibl", "x86_shared_delete_trace_ibl",
+                  "x86_shared_trace_far", "x86_shared_trace_far_unlinked",
+                  IF_X64_("x86_shared_trace_cmp")
+                      IF_X64_("x86_shared_trace_cmp_unlinked") "x86_shared_trace_ibl",
+                  "x86_shared_trace_ibl_template" },
+                { "x86_private_unlinked_bb_ibl", "x86_private_delete_bb_ibl",
+                  "x86_private_bb_far", "x86_private_bb_far_unlinked",
+                  IF_X64_("x86_private_bb_cmp")
+                      IF_X64_("x86_private_bb_cmp_unlinked") "x86_private_bb_ibl",
+                  "x86_private_bb_ibl_template" },
+                { "x86_private_unlinked_trace_ibl", "x86_private_delete_trace_ibl",
+                  "x86_private_trace_far", "x86_private_trace_far_unlinked",
+                  IF_X64_("x86_private_trace_cmp")
+                      IF_X64_("x86_private_trace_cmp_unlinked") "x86_private_trace_ibl",
+                  "x86_private_trace_ibl_template" },
+                { "x86_shared_unlinked_coarse_ibl", "x86_shared_delete_coarse_ibl",
+                  "x86_shared_coarse_trace_far", "x86_shared_coarse_trace_far_unlinked",
+                  IF_X64_("x86_shared_coarse_trace_cmp") IF_X64_(
+                      "x86_shared_coarse_trace_cmp_unlinked") "x86_shared_coarse_ibl",
+                  "x86_shared_coarse_ibl_template" },
+            },
+            {
+                { "x86_to_x64_shared_unlinked_bb_ibl", "x86_to_x64_shared_delete_bb_ibl",
+                  "x86_to_x64_shared_bb_far", "x86_to_x64_shared_bb_far_unlinked",
+                  "x86_to_x64_shared_bb_cmp", "x86_to_x64_shared_bb_cmp_unlinked",
+                  "x86_to_x64_shared_bb_ibl", "x86_to_x64_shared_bb_ibl_template" },
+                { "x86_to_x64_shared_unlinked_trace_ibl",
+                  "x86_to_x64_shared_delete_trace_ibl", "x86_to_x64_shared_trace_far",
+                  "x86_to_x64_shared_trace_far_unlinked", "x86_to_x64_shared_trace_cmp",
+                  "x86_to_x64_shared_trace_cmp_unlinked", "x86_to_x64_shared_trace_ibl",
+                  "x86_to_x64_shared_trace_ibl_template" },
+                { "x86_to_x64_private_unlinked_bb_ibl",
+                  "x86_to_x64_private_delete_bb_ibl", "x86_to_x64_private_bb_far",
+                  "x86_to_x64_private_bb_far_unlinked", "x86_to_x64_private_bb_cmp",
+                  "x86_to_x64_private_bb_cmp_unlinked",
+                  /* clang-format off */
               "x86_to_x64_private_bb_ibl",
               "x86_to_x64_private_bb_ibl_template" },
-            /* clang-format on */
-            { "x86_to_x64_private_unlinked_trace_ibl",
-              "x86_to_x64_private_delete_trace_ibl",
-              "x86_to_x64_private_trace_far",
-              "x86_to_x64_private_trace_far_unlinked",
-              "x86_to_x64_private_trace_cmp",
-              "x86_to_x64_private_trace_cmp_unlinked",
-              "x86_to_x64_private_trace_ibl",
-              "x86_to_x64_private_trace_ibl_template" },
-            { "x86_to_x64_shared_unlinked_coarse_ibl",
-              "x86_to_x64_shared_delete_coarse_ibl",
-              "x86_to_x64_shared_coarse_trace_far",
-              "x86_to_x64_shared_coarse_trace_far_unlinked",
-              "x86_to_x64_shared_coarse_trace_cmp",
-              "x86_to_x64_shared_coarse_trace_cmp_unlinked",
-              "x86_to_x64_shared_coarse_ibl",
-              "x86_to_x64_shared_coarse_ibl_template" },
-        }
+                /* clang-format on */
+                { "x86_to_x64_private_unlinked_trace_ibl",
+                  "x86_to_x64_private_delete_trace_ibl", "x86_to_x64_private_trace_far",
+                  "x86_to_x64_private_trace_far_unlinked", "x86_to_x64_private_trace_cmp",
+                  "x86_to_x64_private_trace_cmp_unlinked", "x86_to_x64_private_trace_ibl",
+                  "x86_to_x64_private_trace_ibl_template" },
+                { "x86_to_x64_shared_unlinked_coarse_ibl",
+                  "x86_to_x64_shared_delete_coarse_ibl",
+                  "x86_to_x64_shared_coarse_trace_far",
+                  "x86_to_x64_shared_coarse_trace_far_unlinked",
+                  "x86_to_x64_shared_coarse_trace_cmp",
+                  "x86_to_x64_shared_coarse_trace_cmp_unlinked",
+                  "x86_to_x64_shared_coarse_ibl",
+                  "x86_to_x64_shared_coarse_ibl_template" },
+            }
+        };
+#else
+    static const char *const ibl_routine_names[IBL_SOURCE_TYPE_END][IBL_LINK_STATE_END] =
+        {
+            { "shared_unlinked_bb_ibl", "shared_delete_bb_ibl", "shared_bb_far",
+              "shared_bb_far_unlinked", "shared_bb_ibl", "shared_bb_ibl_template" },
+            { "shared_unlinked_trace_ibl", "shared_delete_trace_ibl", "shared_trace_far",
+              "shared_trace_far_unlinked", "shared_trace_ibl",
+              "shared_trace_ibl_template" },
+            { "private_unlinked_bb_ibl", "private_delete_bb_ibl", "private_bb_far",
+              "private_bb_far_unlinked", "private_bb_ibl", "private_bb_ibl_template" },
+            { "private_unlinked_trace_ibl", "private_delete_trace_ibl",
+              "private_trace_far", "private_trace_far_unlinked", "private_trace_ibl",
+              "private_trace_ibl_template" },
+            { "shared_unlinked_coarse_ibl", "shared_delete_coarse_ibl",
+              "shared_coarse_trace_far", "shared_coarse_trace_far_unlinked",
+              "shared_coarse_ibl", "shared_coarse_ibl_template" },
+        };
 #endif
-    };
     ibl_type_t ibl_type;
 #if defined(X86) && defined(X64)
     gencode_mode_t mode;
@@ -2528,48 +2542,51 @@ after_do_syscall_addr(dcontext_t *dcontext)
         return after_do_syscall_code(dcontext);
 }
 #else
-    cache_pc after_do_shared_syscall_addr(dcontext_t * dcontext)
-    {
-        /* PR 212570: return the thread-shared do_syscall used for vsyscall hook */
-        generated_code_t *code =
-            get_emitted_routines_code(GLOBAL_DCONTEXT _IF_X86_64(GENCODE_X64));
-        IF_X86_64(ASSERT_NOT_REACHED()); /* else have to worry about GENCODE_X86 */
-        ASSERT(code != NULL);
-        ASSERT(code->do_syscall != NULL);
-        return (cache_pc)(code->do_syscall + code->do_syscall_offs);
-    }
+cache_pc
+after_do_shared_syscall_addr(dcontext_t *dcontext)
+{
+    /* PR 212570: return the thread-shared do_syscall used for vsyscall hook */
+    generated_code_t *code =
+        get_emitted_routines_code(GLOBAL_DCONTEXT _IF_X86_64(GENCODE_X64));
+    IF_X86_64(ASSERT_NOT_REACHED()); /* else have to worry about GENCODE_X86 */
+    ASSERT(code != NULL);
+    ASSERT(code->do_syscall != NULL);
+    return (cache_pc)(code->do_syscall + code->do_syscall_offs);
+}
 
-    cache_pc after_do_syscall_addr(dcontext_t * dcontext)
-    {
-        /* PR 212570: return the thread-shared do_syscall used for vsyscall hook */
-        generated_code_t *code =
-            get_emitted_routines_code(dcontext _IF_X86_64(GENCODE_FROM_DCONTEXT));
-        ASSERT(code != NULL);
-        ASSERT(code->do_syscall != NULL);
-        return (cache_pc)(code->do_syscall + code->do_syscall_offs);
-    }
+cache_pc
+after_do_syscall_addr(dcontext_t *dcontext)
+{
+    /* PR 212570: return the thread-shared do_syscall used for vsyscall hook */
+    generated_code_t *code =
+        get_emitted_routines_code(dcontext _IF_X86_64(GENCODE_FROM_DCONTEXT));
+    ASSERT(code != NULL);
+    ASSERT(code->do_syscall != NULL);
+    return (cache_pc)(code->do_syscall + code->do_syscall_offs);
+}
 
-    bool is_after_main_do_syscall_addr(dcontext_t * dcontext, cache_pc pc)
-    {
-        generated_code_t *code =
-            get_emitted_routines_code(dcontext _IF_X86_64(GENCODE_FROM_DCONTEXT));
-        ASSERT(code != NULL);
-        return (pc == (cache_pc)(code->do_syscall + code->do_syscall_offs));
-    }
+bool
+is_after_main_do_syscall_addr(dcontext_t *dcontext, cache_pc pc)
+{
+    generated_code_t *code =
+        get_emitted_routines_code(dcontext _IF_X86_64(GENCODE_FROM_DCONTEXT));
+    ASSERT(code != NULL);
+    return (pc == (cache_pc)(code->do_syscall + code->do_syscall_offs));
+}
 
-    bool is_after_do_syscall_addr(dcontext_t * dcontext, cache_pc pc)
-    {
-        generated_code_t *code =
-            get_emitted_routines_code(dcontext _IF_X86_64(GENCODE_FROM_DCONTEXT));
-        ASSERT(code != NULL);
-        return (pc == (cache_pc)(code->do_syscall + code->do_syscall_offs) ||
-                pc ==
-                    (cache_pc)(code->do_int_syscall + code->do_int_syscall_offs)
-                        IF_VMX86(||
-                                 pc ==
-                                     (cache_pc)(code->do_vmkuw_syscall +
-                                                code->do_vmkuw_syscall_offs)));
-    }
+bool
+is_after_do_syscall_addr(dcontext_t *dcontext, cache_pc pc)
+{
+    generated_code_t *code =
+        get_emitted_routines_code(dcontext _IF_X86_64(GENCODE_FROM_DCONTEXT));
+    ASSERT(code != NULL);
+    return (
+        pc == (cache_pc)(code->do_syscall + code->do_syscall_offs) ||
+        pc ==
+            (cache_pc)(code->do_int_syscall + code->do_int_syscall_offs) IF_VMX86(
+                ||
+                pc == (cache_pc)(code->do_vmkuw_syscall + code->do_vmkuw_syscall_offs)));
+}
 #endif
 
 bool
@@ -2582,7 +2599,7 @@ is_after_syscall_address(dcontext_t *dcontext, cache_pc pc)
         return true;
     return false;
 #else
-        return is_after_do_syscall_addr(dcontext, pc);
+    return is_after_do_syscall_addr(dcontext, pc);
 #endif
     /* NOTE - we ignore global_do_syscall since that's only used in special
      * circumstances and is not something the callers (recreate_app_state)
@@ -2598,17 +2615,16 @@ is_after_syscall_that_rets(dcontext_t *dcontext, cache_pc pc)
 #ifdef WINDOWS
     return (is_after_syscall_address(dcontext, pc) && does_syscall_ret_to_callsite());
 #else
-        generated_code_t *code =
-            get_emitted_routines_code(dcontext _IF_X86_64(GENCODE_FROM_DCONTEXT));
-        ASSERT(code != NULL);
-        return ((pc == (cache_pc)(code->do_syscall + code->do_syscall_offs) &&
-                 does_syscall_ret_to_callsite()) ||
-                pc ==
-                    (cache_pc)(code->do_int_syscall + code->do_int_syscall_offs)
-                        IF_VMX86(||
-                                 pc ==
-                                     (cache_pc)(code->do_vmkuw_syscall +
-                                                code->do_vmkuw_syscall_offs)));
+    generated_code_t *code =
+        get_emitted_routines_code(dcontext _IF_X86_64(GENCODE_FROM_DCONTEXT));
+    ASSERT(code != NULL);
+    return (
+        (pc == (cache_pc)(code->do_syscall + code->do_syscall_offs) &&
+         does_syscall_ret_to_callsite()) ||
+        pc ==
+            (cache_pc)(code->do_int_syscall + code->do_int_syscall_offs) IF_VMX86(
+                ||
+                pc == (cache_pc)(code->do_vmkuw_syscall + code->do_vmkuw_syscall_offs)));
 #endif
 }
 
@@ -2735,7 +2751,7 @@ get_global_do_syscall_entry()
         else
             return (byte *)global_do_syscall_sysenter;
 #else
-            return (byte *)global_do_syscall_int;
+        return (byte *)global_do_syscall_int;
 #endif
     }
 #ifdef WINDOWS
@@ -2747,9 +2763,9 @@ get_global_do_syscall_entry()
         return (byte *)global_do_syscall_syscall;
 #else
 #    ifdef WINDOWS
-            ASSERT_NOT_IMPLEMENTED(false && "PR 205898: 32-bit syscall on Windows NYI");
+        ASSERT_NOT_IMPLEMENTED(false && "PR 205898: 32-bit syscall on Windows NYI");
 #    else
-            return (byte *)global_do_syscall_int;
+        return (byte *)global_do_syscall_int;
 #    endif
 #endif
     } else {
@@ -2759,7 +2775,7 @@ get_global_do_syscall_entry()
          */
         return (byte *)IF_X86_64_ELSE(global_do_syscall_syscall, global_do_syscall_int);
 #else
-            ASSERT_NOT_REACHED();
+        ASSERT_NOT_REACHED();
 #endif
     }
     return NULL;
@@ -2803,96 +2819,97 @@ unhook_vsyscall(void)
     return false;
 }
 #elif defined(LINUX)
-    /* PR 212570: for sysenter support we need to regain control after the
-     * kernel sets eip to a hardcoded user-mode address on the vsyscall page.
-     * The vsyscall code layout is as follows:
-     *     0xffffe400 <__kernel_vsyscall+0>:       push   %ecx
-     *     0xffffe401 <__kernel_vsyscall+1>:       push   %edx
-     *     0xffffe402 <__kernel_vsyscall+2>:       push   %ebp
-     *     0xffffe403 <__kernel_vsyscall+3>:       mov    %esp,%ebp
-     *     0xffffe405 <__kernel_vsyscall+5>:       sysenter
-     *   nops for alignment of return point:
-     *     0xffffe407 <__kernel_vsyscall+7>:       nop
-     *     0xffffe408 <__kernel_vsyscall+8>:       nop
-     *     0xffffe409 <__kernel_vsyscall+9>:       nop
-     *     0xffffe40a <__kernel_vsyscall+10>:      nop
-     *     0xffffe40b <__kernel_vsyscall+11>:      nop
-     *     0xffffe40c <__kernel_vsyscall+12>:      nop
-     *     0xffffe40d <__kernel_vsyscall+13>:      nop
-     *   system call restart point:
-     *     0xffffe40e <__kernel_vsyscall+14>:      jmp    0xffffe403 <__kernel_vsyscall+3>
-     *   system call normal return point:
-     *     0xffffe410 <__kernel_vsyscall+16>:      pop    %ebp
-     *     0xffffe411 <__kernel_vsyscall+17>:      pop    %edx
-     *     0xffffe412 <__kernel_vsyscall+18>:      pop    %ecx
-     *     0xffffe413 <__kernel_vsyscall+19>:      ret
-     *
-     * For randomized vsyscall page locations we can mark the page +w and
-     * write to it.  For now, for simplicity, we focus only on that case;
-     * for vsyscall page at un-reachable 0xffffe000 we bail out and use
-     * ints for now (perf hit but works).  PR 288330 covers leaving
-     * as sysenters.
-     *
-     * There are either nops or garbage after the ret, so we clobber one
-     * byte past the ret to put in a rel32 jmp (an alternative is to do
-     * rel8 jmp into the nop area and have a rel32 jmp there).  We
-     * cleverly copy the 4 bytes of displaced code into the nop area, so
-     * that 1) we don't have to allocate any memory and 2) we don't have
-     * to do any extra work in dispatch, which will naturally go to the
-     * post-system-call-instr pc.
-     * Unfortunately the 4.4.8 kernel removed the nops (i#1939) so for
-     * recent kernels we instead copy into the padding area:
-     *     0xf77c6be0:  push   %ecx
-     *     0xf77c6be1:  push   %edx
-     *     0xf77c6be2:  push   %ebp
-     *     0xf77c6be3:  mov    %esp,%ebp
-     *     0xf77c6be5:  sysenter
-     *     0xf77c6be7:  int    $0x80
-     *   normal return point:
-     *     0xf77c6be9:  pop    %ebp
-     *     0xf77c6bea:  pop    %edx
-     *     0xf77c6beb:  pop    %ecx
-     *     0xf77c6bec:  ret
-     *     0xf77c6bed+:  <padding>
-     *
-     * Using a hook is much simpler than clobbering the retaddr, which is what
-     * Windows does and then has to spend a lot of effort juggling transparency
-     * and control on asynch in/out events.
-     */
+/* PR 212570: for sysenter support we need to regain control after the
+ * kernel sets eip to a hardcoded user-mode address on the vsyscall page.
+ * The vsyscall code layout is as follows:
+ *     0xffffe400 <__kernel_vsyscall+0>:       push   %ecx
+ *     0xffffe401 <__kernel_vsyscall+1>:       push   %edx
+ *     0xffffe402 <__kernel_vsyscall+2>:       push   %ebp
+ *     0xffffe403 <__kernel_vsyscall+3>:       mov    %esp,%ebp
+ *     0xffffe405 <__kernel_vsyscall+5>:       sysenter
+ *   nops for alignment of return point:
+ *     0xffffe407 <__kernel_vsyscall+7>:       nop
+ *     0xffffe408 <__kernel_vsyscall+8>:       nop
+ *     0xffffe409 <__kernel_vsyscall+9>:       nop
+ *     0xffffe40a <__kernel_vsyscall+10>:      nop
+ *     0xffffe40b <__kernel_vsyscall+11>:      nop
+ *     0xffffe40c <__kernel_vsyscall+12>:      nop
+ *     0xffffe40d <__kernel_vsyscall+13>:      nop
+ *   system call restart point:
+ *     0xffffe40e <__kernel_vsyscall+14>:      jmp    0xffffe403 <__kernel_vsyscall+3>
+ *   system call normal return point:
+ *     0xffffe410 <__kernel_vsyscall+16>:      pop    %ebp
+ *     0xffffe411 <__kernel_vsyscall+17>:      pop    %edx
+ *     0xffffe412 <__kernel_vsyscall+18>:      pop    %ecx
+ *     0xffffe413 <__kernel_vsyscall+19>:      ret
+ *
+ * For randomized vsyscall page locations we can mark the page +w and
+ * write to it.  For now, for simplicity, we focus only on that case;
+ * for vsyscall page at un-reachable 0xffffe000 we bail out and use
+ * ints for now (perf hit but works).  PR 288330 covers leaving
+ * as sysenters.
+ *
+ * There are either nops or garbage after the ret, so we clobber one
+ * byte past the ret to put in a rel32 jmp (an alternative is to do
+ * rel8 jmp into the nop area and have a rel32 jmp there).  We
+ * cleverly copy the 4 bytes of displaced code into the nop area, so
+ * that 1) we don't have to allocate any memory and 2) we don't have
+ * to do any extra work in dispatch, which will naturally go to the
+ * post-system-call-instr pc.
+ * Unfortunately the 4.4.8 kernel removed the nops (i#1939) so for
+ * recent kernels we instead copy into the padding area:
+ *     0xf77c6be0:  push   %ecx
+ *     0xf77c6be1:  push   %edx
+ *     0xf77c6be2:  push   %ebp
+ *     0xf77c6be3:  mov    %esp,%ebp
+ *     0xf77c6be5:  sysenter
+ *     0xf77c6be7:  int    $0x80
+ *   normal return point:
+ *     0xf77c6be9:  pop    %ebp
+ *     0xf77c6bea:  pop    %edx
+ *     0xf77c6beb:  pop    %ecx
+ *     0xf77c6bec:  ret
+ *     0xf77c6bed+:  <padding>
+ *
+ * Using a hook is much simpler than clobbering the retaddr, which is what
+ * Windows does and then has to spend a lot of effort juggling transparency
+ * and control on asynch in/out events.
+ */
 
 #    define VSYS_DISPLACED_LEN 4
 
-    bool hook_vsyscall(dcontext_t * dcontext, bool method_changing)
-    {
+bool
+hook_vsyscall(dcontext_t *dcontext, bool method_changing)
+{
 #    ifdef X86
-        bool res = true;
-        instr_t instr;
-        byte *pc;
-        uint num_nops = 0;
-        uint prot;
+    bool res = true;
+    instr_t instr;
+    byte *pc;
+    uint num_nops = 0;
+    uint prot;
 
-        /* On a call on a method change the method is not yet finalized so we always try
-         */
-        if (get_syscall_method() != SYSCALL_METHOD_SYSENTER && !method_changing)
-            return false;
+    /* On a call on a method change the method is not yet finalized so we always try
+     */
+    if (get_syscall_method() != SYSCALL_METHOD_SYSENTER && !method_changing)
+        return false;
 
-        ASSERT(DATASEC_WRITABLE(DATASEC_RARELY_PROT));
-        ASSERT(vsyscall_page_start != NULL && vsyscall_syscall_end_pc != NULL &&
-               vsyscall_page_start == (app_pc)PAGE_START(vsyscall_syscall_end_pc));
+    ASSERT(DATASEC_WRITABLE(DATASEC_RARELY_PROT));
+    ASSERT(vsyscall_page_start != NULL && vsyscall_syscall_end_pc != NULL &&
+           vsyscall_page_start == (app_pc)PAGE_START(vsyscall_syscall_end_pc));
 
-        instr_init(dcontext, &instr);
-        pc = vsyscall_syscall_end_pc;
-        do {
-            instr_reset(dcontext, &instr);
-            pc = decode(dcontext, pc, &instr);
-            if (instr_is_nop(&instr))
-                num_nops++;
-        } while (instr_is_nop(&instr));
-        vsyscall_sysenter_return_pc = pc;
-        ASSERT(instr_get_opcode(&instr) == OP_jmp_short ||
-               instr_get_opcode(&instr) == OP_int /*ubuntu 11.10: i#647*/);
+    instr_init(dcontext, &instr);
+    pc = vsyscall_syscall_end_pc;
+    do {
+        instr_reset(dcontext, &instr);
+        pc = decode(dcontext, pc, &instr);
+        if (instr_is_nop(&instr))
+            num_nops++;
+    } while (instr_is_nop(&instr));
+    vsyscall_sysenter_return_pc = pc;
+    ASSERT(instr_get_opcode(&instr) == OP_jmp_short ||
+           instr_get_opcode(&instr) == OP_int /*ubuntu 11.10: i#647*/);
 
-        /* We fail if the pattern looks different */
+    /* We fail if the pattern looks different */
 #        define CHECK(x)                                          \
             do {                                                  \
                 if (!(x)) {                                       \
@@ -2902,124 +2919,125 @@ unhook_vsyscall(void)
                 }                                                 \
             } while (0);
 
-        /* Only now that we've set vsyscall_sysenter_return_pc do we check writability */
-        if (!DYNAMO_OPTION(hook_vsyscall)) {
-            res = false;
+    /* Only now that we've set vsyscall_sysenter_return_pc do we check writability */
+    if (!DYNAMO_OPTION(hook_vsyscall)) {
+        res = false;
+        goto hook_vsyscall_return;
+    }
+    get_memory_info(vsyscall_page_start, NULL, NULL, &prot);
+    if (!TEST(MEMPROT_WRITE, prot)) {
+        res = set_protection(vsyscall_page_start, PAGE_SIZE, prot | MEMPROT_WRITE);
+        if (!res)
             goto hook_vsyscall_return;
-        }
-        get_memory_info(vsyscall_page_start, NULL, NULL, &prot);
-        if (!TEST(MEMPROT_WRITE, prot)) {
-            res = set_protection(vsyscall_page_start, PAGE_SIZE, prot | MEMPROT_WRITE);
-            if (!res)
-                goto hook_vsyscall_return;
-        }
+    }
 
-        LOG(GLOBAL, LOG_SYSCALLS | LOG_VMAREAS, 1, "Hooking vsyscall page @ " PFX "\n",
-            vsyscall_sysenter_return_pc);
+    LOG(GLOBAL, LOG_SYSCALLS | LOG_VMAREAS, 1, "Hooking vsyscall page @ " PFX "\n",
+        vsyscall_sysenter_return_pc);
 
-        /* The 5 bytes we'll clobber: */
-        instr_reset(dcontext, &instr);
-        pc = decode(dcontext, pc, &instr);
-        CHECK(instr_get_opcode(&instr) == OP_pop);
-        instr_reset(dcontext, &instr);
-        pc = decode(dcontext, pc, &instr);
-        CHECK(instr_get_opcode(&instr) == OP_pop);
-        instr_reset(dcontext, &instr);
-        pc = decode(dcontext, pc, &instr);
-        CHECK(instr_get_opcode(&instr) == OP_pop);
-        instr_reset(dcontext, &instr);
-        pc = decode(dcontext, pc, &instr);
-        CHECK(instr_get_opcode(&instr) == OP_ret);
-        /* We don't know what the 5th byte is but we assume that it is junk */
+    /* The 5 bytes we'll clobber: */
+    instr_reset(dcontext, &instr);
+    pc = decode(dcontext, pc, &instr);
+    CHECK(instr_get_opcode(&instr) == OP_pop);
+    instr_reset(dcontext, &instr);
+    pc = decode(dcontext, pc, &instr);
+    CHECK(instr_get_opcode(&instr) == OP_pop);
+    instr_reset(dcontext, &instr);
+    pc = decode(dcontext, pc, &instr);
+    CHECK(instr_get_opcode(&instr) == OP_pop);
+    instr_reset(dcontext, &instr);
+    pc = decode(dcontext, pc, &instr);
+    CHECK(instr_get_opcode(&instr) == OP_ret);
+    /* We don't know what the 5th byte is but we assume that it is junk */
 
-        /* FIXME: at some point we should pull out all the hook code from
-         * callback.c into an os-neutral location.  For now, this hook
-         * is very special-case and simple.
+    /* FIXME: at some point we should pull out all the hook code from
+     * callback.c into an os-neutral location.  For now, this hook
+     * is very special-case and simple.
+     */
+
+    /* For thread synch, the datasec prot lock will serialize us (FIXME: do this at
+     * init time instead, when see [vdso] page in maps file?)
+     */
+
+    CHECK(pc - vsyscall_sysenter_return_pc == VSYS_DISPLACED_LEN);
+    ASSERT(pc + 1 /*nop*/ - vsyscall_sysenter_return_pc == JMP_LONG_LENGTH);
+    if (num_nops >= VSYS_DISPLACED_LEN) {
+        CHECK(num_nops >= pc - vsyscall_sysenter_return_pc);
+        memcpy(vsyscall_syscall_end_pc, vsyscall_sysenter_return_pc,
+               /* we don't copy the 5th byte to preserve nop for nice disassembly */
+               pc - vsyscall_sysenter_return_pc);
+        vsyscall_sysenter_displaced_pc = vsyscall_syscall_end_pc;
+    } else {
+        /* i#1939: the 4.4.8 kernel removed the nops.  It might be safer
+         * to place the bytes in our own memory somewhere but that requires
+         * extra logic to mark it as executable and to map the PC for
+         * dr_fragment_app_pc() and dr_app_pc_for_decoding(), so we go for the
+         * easier-to-implement route and clobber the padding garbage after the ret.
+         * We assume it is large enough for the 1 byte from the jmp32 and the
+         * 4 bytes of displacement.  Technically we should map the PC back
+         * here as well but it's close enough.
          */
+        pc += 1; /* skip 5th byte of to-be-inserted jmp */
+        CHECK(PAGE_START(pc) == PAGE_START(pc + VSYS_DISPLACED_LEN));
+        memcpy(pc, vsyscall_sysenter_return_pc, VSYS_DISPLACED_LEN);
+        vsyscall_sysenter_displaced_pc = pc;
+    }
+    insert_relative_jump(vsyscall_sysenter_return_pc,
+                         /* we require a thread-shared fcache_return */
+                         after_do_shared_syscall_addr(dcontext), NOT_HOT_PATCHABLE);
 
-        /* For thread synch, the datasec prot lock will serialize us (FIXME: do this at
-         * init time instead, when see [vdso] page in maps file?)
-         */
-
-        CHECK(pc - vsyscall_sysenter_return_pc == VSYS_DISPLACED_LEN);
-        ASSERT(pc + 1 /*nop*/ - vsyscall_sysenter_return_pc == JMP_LONG_LENGTH);
-        if (num_nops >= VSYS_DISPLACED_LEN) {
-            CHECK(num_nops >= pc - vsyscall_sysenter_return_pc);
-            memcpy(vsyscall_syscall_end_pc, vsyscall_sysenter_return_pc,
-                   /* we don't copy the 5th byte to preserve nop for nice disassembly */
-                   pc - vsyscall_sysenter_return_pc);
-            vsyscall_sysenter_displaced_pc = vsyscall_syscall_end_pc;
-        } else {
-            /* i#1939: the 4.4.8 kernel removed the nops.  It might be safer
-             * to place the bytes in our own memory somewhere but that requires
-             * extra logic to mark it as executable and to map the PC for
-             * dr_fragment_app_pc() and dr_app_pc_for_decoding(), so we go for the
-             * easier-to-implement route and clobber the padding garbage after the ret.
-             * We assume it is large enough for the 1 byte from the jmp32 and the
-             * 4 bytes of displacement.  Technically we should map the PC back
-             * here as well but it's close enough.
-             */
-            pc += 1; /* skip 5th byte of to-be-inserted jmp */
-            CHECK(PAGE_START(pc) == PAGE_START(pc + VSYS_DISPLACED_LEN));
-            memcpy(pc, vsyscall_sysenter_return_pc, VSYS_DISPLACED_LEN);
-            vsyscall_sysenter_displaced_pc = pc;
-        }
-        insert_relative_jump(vsyscall_sysenter_return_pc,
-                             /* we require a thread-shared fcache_return */
-                             after_do_shared_syscall_addr(dcontext), NOT_HOT_PATCHABLE);
-
-        if (!TEST(MEMPROT_WRITE, prot)) {
-            /* we don't override res here since not much point in not using the
-             * hook once its in if we failed to re-protect: we're going to have to
-             * trust the app code here anyway */
-            DEBUG_DECLARE(bool ok =)
-            set_protection(vsyscall_page_start, PAGE_SIZE, prot);
-            ASSERT(ok);
-        }
-    hook_vsyscall_return:
-        instr_free(dcontext, &instr);
-        return res;
+    if (!TEST(MEMPROT_WRITE, prot)) {
+        /* we don't override res here since not much point in not using the
+         * hook once its in if we failed to re-protect: we're going to have to
+         * trust the app code here anyway */
+        DEBUG_DECLARE(bool ok =)
+        set_protection(vsyscall_page_start, PAGE_SIZE, prot);
+        ASSERT(ok);
+    }
+hook_vsyscall_return:
+    instr_free(dcontext, &instr);
+    return res;
 #        undef CHECK
 #    elif defined(AARCHXX)
-        /* No vsyscall support needed for our ARM targets -- still called on
-         * os_process_under_dynamorio().
-         */
-        ASSERT(!method_changing);
-        return false;
+    /* No vsyscall support needed for our ARM targets -- still called on
+     * os_process_under_dynamorio().
+     */
+    ASSERT(!method_changing);
+    return false;
 #    endif /* X86/ARM */
-    }
+}
 
-    bool unhook_vsyscall(void)
-    {
+bool
+unhook_vsyscall(void)
+{
 #    ifdef X86
-        uint prot;
-        bool res;
-        uint len = VSYS_DISPLACED_LEN;
-        if (get_syscall_method() != SYSCALL_METHOD_SYSENTER)
-            return false;
-        ASSERT(!sysenter_hook_failed);
-        ASSERT(vsyscall_sysenter_return_pc != NULL);
-        ASSERT(vsyscall_syscall_end_pc != NULL);
-        get_memory_info(vsyscall_page_start, NULL, NULL, &prot);
-        if (!TEST(MEMPROT_WRITE, prot)) {
-            res = set_protection(vsyscall_page_start, PAGE_SIZE, prot | MEMPROT_WRITE);
-            if (!res)
-                return false;
-        }
-        memcpy(vsyscall_sysenter_return_pc, vsyscall_sysenter_displaced_pc, len);
-        /* we do not restore the 5th (junk/nop) byte (we never copied it) */
-        if (vsyscall_sysenter_displaced_pc == vsyscall_syscall_end_pc) /* <4.4.8 */
-            memset(vsyscall_syscall_end_pc, RAW_OPCODE_nop, len);
-        if (!TEST(MEMPROT_WRITE, prot)) {
-            res = set_protection(vsyscall_page_start, PAGE_SIZE, prot);
-            ASSERT(res);
-        }
-        return true;
-#    elif defined(AARCHXX)
-        ASSERT_NOT_IMPLEMENTED(get_syscall_method() != SYSCALL_METHOD_SYSENTER);
+    uint prot;
+    bool res;
+    uint len = VSYS_DISPLACED_LEN;
+    if (get_syscall_method() != SYSCALL_METHOD_SYSENTER)
         return false;
-#    endif /* X86/ARM */
+    ASSERT(!sysenter_hook_failed);
+    ASSERT(vsyscall_sysenter_return_pc != NULL);
+    ASSERT(vsyscall_syscall_end_pc != NULL);
+    get_memory_info(vsyscall_page_start, NULL, NULL, &prot);
+    if (!TEST(MEMPROT_WRITE, prot)) {
+        res = set_protection(vsyscall_page_start, PAGE_SIZE, prot | MEMPROT_WRITE);
+        if (!res)
+            return false;
     }
+    memcpy(vsyscall_sysenter_return_pc, vsyscall_sysenter_displaced_pc, len);
+    /* we do not restore the 5th (junk/nop) byte (we never copied it) */
+    if (vsyscall_sysenter_displaced_pc == vsyscall_syscall_end_pc) /* <4.4.8 */
+        memset(vsyscall_syscall_end_pc, RAW_OPCODE_nop, len);
+    if (!TEST(MEMPROT_WRITE, prot)) {
+        res = set_protection(vsyscall_page_start, PAGE_SIZE, prot);
+        ASSERT(res);
+    }
+    return true;
+#    elif defined(AARCHXX)
+    ASSERT_NOT_IMPLEMENTED(get_syscall_method() != SYSCALL_METHOD_SYSENTER);
+    return false;
+#    endif /* X86/ARM */
+}
 #endif     /* LINUX */
 
 void
@@ -3038,8 +3056,8 @@ check_syscall_method(dcontext_t *dcontext, instr_t *instr)
         new_method = SYSCALL_METHOD_WOW64;
 #    endif
 #elif defined(AARCHXX)
-        if (instr_get_opcode(instr) == OP_svc)
-            new_method = SYSCALL_METHOD_SVC;
+    if (instr_get_opcode(instr) == OP_svc)
+        new_method = SYSCALL_METHOD_SVC;
 #endif /* X86/ARM */
     else
         ASSERT_NOT_REACHED();
@@ -3136,9 +3154,9 @@ check_syscall_method(dcontext_t *dcontext, instr_t *instr)
             SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
         });
 #else
-            /* On Linux we can't clear vsyscall_page_start as the app will often use both
-             * inlined int and vsyscall sysenter system calls. We handle fixing up for
-             * that in the next ifdef. */
+        /* On Linux we can't clear vsyscall_page_start as the app will often use both
+         * inlined int and vsyscall sysenter system calls. We handle fixing up for
+         * that in the next ifdef. */
 #endif
     }
 
@@ -3185,8 +3203,8 @@ check_syscall_method(dcontext_t *dcontext, instr_t *instr)
         }
     }
 #else
-        /* we assume only single method; else need multiple do_syscalls */
-        ASSERT(new_method == get_syscall_method());
+    /* we assume only single method; else need multiple do_syscalls */
+    ASSERT(new_method == get_syscall_method());
 #endif
 }
 
@@ -3403,23 +3421,23 @@ dump_mcontext(priv_mcontext_t *context, file_t f, bool dump_xml)
                    "\n\t\tr14=\"" PFX "\"\n\t\tr15=\"" PFX "\""
 #    endif /* X64 */
 #elif defined(ARM)
-                       "\n\t\tr0=\"" PFX "\"\n\t\tr1=\"" PFX "\""
-                       "\n\t\tr2=\"" PFX "\"\n\t\tr3=\"" PFX "\""
-                       "\n\t\tr4=\"" PFX "\"\n\t\tr5=\"" PFX "\""
-                       "\n\t\tr6=\"" PFX "\"\n\t\tr7=\"" PFX "\""
-                       "\n\t\tr8=\"" PFX "\"\n\t\tr9=\"" PFX "\""
-                       "\n\t\tr10=\"" PFX "\"\n\t\tr11=\"" PFX "\""
-                       "\n\t\tr12=\"" PFX "\"\n\t\tr13=\"" PFX "\""
-                       "\n\t\tr14=\"" PFX "\"\n\t\tr15=\"" PFX "\""
+                   "\n\t\tr0=\"" PFX "\"\n\t\tr1=\"" PFX "\""
+                   "\n\t\tr2=\"" PFX "\"\n\t\tr3=\"" PFX "\""
+                   "\n\t\tr4=\"" PFX "\"\n\t\tr5=\"" PFX "\""
+                   "\n\t\tr6=\"" PFX "\"\n\t\tr7=\"" PFX "\""
+                   "\n\t\tr8=\"" PFX "\"\n\t\tr9=\"" PFX "\""
+                   "\n\t\tr10=\"" PFX "\"\n\t\tr11=\"" PFX "\""
+                   "\n\t\tr12=\"" PFX "\"\n\t\tr13=\"" PFX "\""
+                   "\n\t\tr14=\"" PFX "\"\n\t\tr15=\"" PFX "\""
 #    ifdef X64
-                       "\n\t\tr16=\"" PFX "\"\n\t\tr17=\"" PFX "\""
-                       "\n\t\tr18=\"" PFX "\"\n\t\tr19=\"" PFX "\""
-                       "\n\t\tr20=\"" PFX "\"\n\t\tr21=\"" PFX "\""
-                       "\n\t\tr22=\"" PFX "\"\n\t\tr23=\"" PFX "\""
-                       "\n\t\tr24=\"" PFX "\"\n\t\tr25=\"" PFX "\""
-                       "\n\t\tr26=\"" PFX "\"\n\t\tr27=\"" PFX "\""
-                       "\n\t\tr28=\"" PFX "\"\n\t\tr29=\"" PFX "\""
-                       "\n\t\tr30=\"" PFX "\"\n\t\tr31=\"" PFX "\""
+                   "\n\t\tr16=\"" PFX "\"\n\t\tr17=\"" PFX "\""
+                   "\n\t\tr18=\"" PFX "\"\n\t\tr19=\"" PFX "\""
+                   "\n\t\tr20=\"" PFX "\"\n\t\tr21=\"" PFX "\""
+                   "\n\t\tr22=\"" PFX "\"\n\t\tr23=\"" PFX "\""
+                   "\n\t\tr24=\"" PFX "\"\n\t\tr25=\"" PFX "\""
+                   "\n\t\tr26=\"" PFX "\"\n\t\tr27=\"" PFX "\""
+                   "\n\t\tr28=\"" PFX "\"\n\t\tr29=\"" PFX "\""
+                   "\n\t\tr30=\"" PFX "\"\n\t\tr31=\"" PFX "\""
 #    endif /* X64 */
 #endif     /* X86/ARM */
                  : "priv_mcontext_t @" PFX "\n"
@@ -3431,23 +3449,15 @@ dump_mcontext(priv_mcontext_t *context, file_t f, bool dump_xml)
                    "\tr12 = " PFX "\n\tr13 = " PFX "\n\tr14 = " PFX "\n\tr15 = " PFX "\n"
 #    endif /* X64 */
 #elif defined(ARM)
-                       "\tr0  = " PFX "\n\tr1  = " PFX "\n\tr2  = " PFX "\n\tr3  = " PFX
-                       "\n"
-                       "\tr4  = " PFX "\n\tr5  = " PFX "\n\tr6  = " PFX "\n\tr7  = " PFX
-                       "\n"
-                       "\tr8  = " PFX "\n\tr9  = " PFX "\n\tr10 = " PFX "\n\tr11 = " PFX
-                       "\n"
-                       "\tr12 = " PFX "\n\tr13 = " PFX "\n\tr14 = " PFX "\n\tr15 = " PFX
-                       "\n"
+                   "\tr0  = " PFX "\n\tr1  = " PFX "\n\tr2  = " PFX "\n\tr3  = " PFX "\n"
+                   "\tr4  = " PFX "\n\tr5  = " PFX "\n\tr6  = " PFX "\n\tr7  = " PFX "\n"
+                   "\tr8  = " PFX "\n\tr9  = " PFX "\n\tr10 = " PFX "\n\tr11 = " PFX "\n"
+                   "\tr12 = " PFX "\n\tr13 = " PFX "\n\tr14 = " PFX "\n\tr15 = " PFX "\n"
 #    ifdef X64
-                       "\tr16 = " PFX "\n\tr17 = " PFX "\n\tr18 = " PFX "\n\tr19 = " PFX
-                       "\n"
-                       "\tr20 = " PFX "\n\tr21 = " PFX "\n\tr22 = " PFX "\n\tr23 = " PFX
-                       "\n"
-                       "\tr24 = " PFX "\n\tr25 = " PFX "\n\tr26 = " PFX "\n\tr27 = " PFX
-                       "\n"
-                       "\tr28 = " PFX "\n\tr29 = " PFX "\n\tr30 = " PFX "\n\tr31 = " PFX
-                       "\n"
+                   "\tr16 = " PFX "\n\tr17 = " PFX "\n\tr18 = " PFX "\n\tr19 = " PFX "\n"
+                   "\tr20 = " PFX "\n\tr21 = " PFX "\n\tr22 = " PFX "\n\tr23 = " PFX "\n"
+                   "\tr24 = " PFX "\n\tr25 = " PFX "\n\tr26 = " PFX "\n\tr27 = " PFX "\n"
+                   "\tr28 = " PFX "\n\tr29 = " PFX "\n\tr30 = " PFX "\n\tr31 = " PFX "\n"
 #    endif /* X64 */
 #endif     /* X86/ARM */
         ,
@@ -3461,15 +3471,14 @@ dump_mcontext(priv_mcontext_t *context, file_t f, bool dump_xml)
         context->r14, context->r15
 #    endif /* X64 */
 #elif defined(AARCHXX)
-            context->r0, context->r1, context->r2, context->r3, context->r4, context->r5,
-            context->r6, context->r7, context->r8, context->r9, context->r10,
-            context->r11, context->r12, context->r13, context->r14, context->r15
+        context->r0, context->r1, context->r2, context->r3, context->r4, context->r5,
+        context->r6, context->r7, context->r8, context->r9, context->r10, context->r11,
+        context->r12, context->r13, context->r14, context->r15
 #    ifdef X64
-            ,
-            context->r16, context->r17, context->r18, context->r19, context->r20,
-            context->r21, context->r22, context->r23, context->r24, context->r25,
-            context->r26, context->r27, context->r28, context->r29, context->r30,
-            context->r31
+        ,
+        context->r16, context->r17, context->r18, context->r19, context->r20,
+        context->r21, context->r22, context->r23, context->r24, context->r25,
+        context->r26, context->r27, context->r28, context->r29, context->r30, context->r31
 #    endif /* X64 */
 #endif     /* X86/ARM */
     );
@@ -3503,17 +3512,17 @@ dump_mcontext(priv_mcontext_t *context, file_t f, bool dump_xml)
         });
     }
 #elif defined(ARM)
-        {
-            int i, j;
-            /* XXX: should be proc_num_simd_saved(). */
-            for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
-                print_file(f, dump_xml ? "\t\tqd= \"0x" : "\tq%-3d= 0x", i);
-                for (j = 0; j < 4; j++) {
-                    print_file(f, "%08x ", context->simd[i].u32[j]);
-                }
-                print_file(f, dump_xml ? "\"\n" : "\n");
+    {
+        int i, j;
+        /* XXX: should be proc_num_simd_saved(). */
+        for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+            print_file(f, dump_xml ? "\t\tqd= \"0x" : "\tq%-3d= 0x", i);
+            for (j = 0; j < 4; j++) {
+                print_file(f, "%08x ", context->simd[i].u32[j]);
             }
+            print_file(f, dump_xml ? "\"\n" : "\n");
         }
+    }
 #endif
 
     print_file(f,

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -55,6 +55,15 @@
 #    undef INSTR_INLINE
 #else
 #    define DR_FAST_IR 1
+#endif
+
+/* Avoid clang-format bug in i#3158 where having ifdef AVOID_API_EXPORT before
+ * a declaration causes the declaration to be indented and skipped by genapi.pl.
+ */
+#ifdef AVOID_API_EXPORT
+#    define INSTR_INLINE_INTERNALLY INSTR_INLINE
+#else
+#    define INSTR_INLINE_INTERNALLY /* nothing */
 #endif
 
 /* can't include decode.h, it includes us, just declare struct */
@@ -994,13 +1003,11 @@ DR_API
 void
 instr_set_target(instr_t *cti_instr, opnd_t target);
 
-#ifdef AVOID_API_EXPORT
-INSTR_INLINE /* hot internally */
-#endif
-    DR_API
-    /** Returns true iff \p instr's operands are up to date. */
-    bool
-    instr_operands_valid(instr_t *instr);
+INSTR_INLINE_INTERNALLY
+DR_API
+/** Returns true iff \p instr's operands are up to date. */
+bool
+instr_operands_valid(instr_t *instr);
 
 DR_API
 /** Sets \p instr's operands to be valid if \p valid is true, invalid otherwise. */
@@ -1094,29 +1101,23 @@ DR_API
 void
 instr_set_raw_bits_valid(instr_t *instr, bool valid);
 
-#ifdef AVOID_API_EXPORT
-INSTR_INLINE /* internal inline */
-#endif
-    DR_API
-    /** Returns true iff \p instr's raw bits are a valid encoding of instr. */
-    bool
-    instr_raw_bits_valid(instr_t *instr);
+INSTR_INLINE_INTERNALLY
+DR_API
+/** Returns true iff \p instr's raw bits are a valid encoding of instr. */
+bool
+instr_raw_bits_valid(instr_t *instr);
 
-#ifdef AVOID_API_EXPORT
-INSTR_INLINE /* internal inline */
-#endif
-    DR_API
-    /** Returns true iff \p instr has its own allocated memory for raw bits. */
-    bool
-    instr_has_allocated_bits(instr_t *instr);
+INSTR_INLINE_INTERNALLY
+DR_API
+/** Returns true iff \p instr has its own allocated memory for raw bits. */
+bool
+instr_has_allocated_bits(instr_t *instr);
 
-#ifdef AVOID_API_EXPORT
-INSTR_INLINE /* internal inline */
-#endif
-    DR_API
-    /** Returns true iff \p instr's raw bits are not a valid encoding of \p instr. */
-    bool
-    instr_needs_encoding(instr_t *instr);
+INSTR_INLINE_INTERNALLY
+DR_API
+/** Returns true iff \p instr's raw bits are not a valid encoding of \p instr. */
+bool
+instr_needs_encoding(instr_t *instr);
 
 DR_API
 /**

--- a/core/nudge.c
+++ b/core/nudge.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -275,11 +275,9 @@ nudge_finished:
 #endif /* WINDOWS */
 
 /* This routine may not return */
-#ifdef WINDOWS
-static
-#endif
-    void
-    handle_nudge(dcontext_t *dcontext, nudge_arg_t *arg)
+IF_WINDOWS(static)
+void
+handle_nudge(dcontext_t *dcontext, nudge_arg_t *arg)
 {
     uint nudge_action_mask = arg->nudge_action_mask;
 


### PR DESCRIPTION
Changes get_ibl_routine_name() to avoid using IF_X86_64() for braces
and an extra dimension in a static array, which was causing
clang-format to fail to parse the file and incorrectly indent several
hundred subsequent lines.

Fixes indentation errors after #endif in instr.h and nudge.c.

Fixes #3407
Fixes #3158