### PR TITLE
i#3348 sym conflicts: Rename one-word global symbols, part 1

### DIFF
--- a/core/CMake_symbol_check.cmake
+++ b/core/CMake_symbol_check.cmake
@@ -61,13 +61,8 @@ string(REGEX MATCHALL "([^\n]+)\n" lines "${oneword}")
 foreach(line ${lines})
   set(is_ok OFF)
   # We have some legacy exceptions we allow until we've renamed them all.
-  if (line MATCHES "crc32\n" OR
-      line MATCHES "debugRegister\n" OR
-      line MATCHES "decode\n" OR
+  if (line MATCHES "decode\n" OR
       line MATCHES "disassemble\n" OR
-      line MATCHES "dispatch\n" OR
-      line MATCHES "emulate\n" OR
-      line MATCHES "extensions\n" OR
       line MATCHES "initstack\n" OR
       line MATCHES "loginst\n" OR
       line MATCHES "logopnd\n" OR

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -2852,7 +2852,7 @@ unhook_vsyscall(void)
  * rel8 jmp into the nop area and have a rel32 jmp there).  We
  * cleverly copy the 4 bytes of displaced code into the nop area, so
  * that 1) we don't have to allocate any memory and 2) we don't have
- * to do any extra work in dispatch, which will naturally go to the
+ * to do any extra work in d_r_dispatch, which will naturally go to the
  * post-system-call-instr pc.
  * Unfortunately the 4.4.8 kernel removed the nops (i#1939) so for
  * recent kernels we instead copy into the padding area:

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -236,7 +236,7 @@ typedef struct _local_state_extended_t {
 #    define DETACH_CALLBACK_CODE_SIZE 256
 #    define DETACH_CALLBACK_FINAL_JMP_SIZE 32
 
-/* For detach - stores callback continuation pcs and is used to dispatch to them after
+/* For detach - stores callback continuation pcs and is used to d_r_dispatch to them after
  * we detach. We have one per a thread (with stacked callbacks) stored in an array. */
 typedef struct _detach_callback_stack_t {
     thread_id_t tid;        /* thread tid */
@@ -2045,7 +2045,7 @@ void
 add_profile_call(dcontext_t *dcontext);
 #endif
 app_pc
-emulate(dcontext_t *dcontext, app_pc pc, priv_mcontext_t *mc);
+d_r_emulate(dcontext_t *dcontext, app_pc pc, priv_mcontext_t *mc);
 
 bool
 instr_is_trace_cmp(dcontext_t *dcontext, instr_t *inst);

--- a/core/arch/arm/decode.c
+++ b/core/arch/arm/decode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -170,7 +170,7 @@ is_isa_mode_legal(dr_isa_mode_t mode)
 
 /* We need to call canonicalize_pc_target() on all next_tag-writing
  * instances in initial takeover, signal handling, ibl, etc..
- * We can't put it in dispatch() b/c with our decision to store
+ * We can't put it in d_r_dispatch() b/c with our decision to store
  * tags and addresses as LSB=0, we can easily double-mode-switch.
  */
 app_pc

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -1826,7 +1826,7 @@ append_setup_fcache_target(dcontext_t *dcontext, instrlist_t *ilist, bool absolu
  *    far jmp to next instr, stored w/ 32-bit cs selector in fs:xbx_OFFSET
  *  endif
  *
- *  # jump indirect through dcontext->next_tag, set by dispatch()
+ *  # jump indirect through dcontext->next_tag, set by d_r_dispatch()
  *  if (absolute)
  *    JUMP_VIA_DCONTEXT next_tag_OFFSET
  *  else
@@ -1924,7 +1924,7 @@ append_jmp_to_fcache_target(dcontext_t *dcontext, instrlist_t *ilist,
  *
  * The code is split into several helper functions.
  *
- * # Used by dispatch to begin execution in fcache at dcontext->next_tag
+ * # Used by d_r_dispatch to begin execution in fcache at dcontext->next_tag
  * fcache_enter(dcontext_t *dcontext)
  *
  *  # append_fcache_enter_prologue
@@ -2034,7 +2034,7 @@ append_jmp_to_fcache_target(dcontext_t *dcontext, instrlist_t *ilist,
  *    far jmp to next instr, stored w/ 32-bit cs selector in fs:xbx_OFFSET
  *  endif
  *
- *  # jump indirect through dcontext->next_tag, set by dispatch()
+ *  # jump indirect through dcontext->next_tag, set by d_r_dispatch()
  *  if (absolute)
  *    JUMP_VIA_DCONTEXT next_tag_OFFSET
  *  else
@@ -2263,14 +2263,14 @@ append_prepare_fcache_return(dcontext_t *dcontext, generated_code_t *code,
 static void
 append_call_dispatch(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
 {
-    /* call central dispatch routine */
+    /* call central d_r_dispatch routine */
     /* for x64 linux we could optimize and avoid the "mov rdi, rdi" */
     /* for ARM we use _noreturn to avoid storing to %lr */
-    dr_insert_call_noreturn((void *)dcontext, ilist, NULL /*append*/, (void *)dispatch, 1,
-                            absolute ? OPND_CREATE_INTPTR((ptr_int_t)dcontext)
-                                     : opnd_create_reg(REG_DCTXT));
+    dr_insert_call_noreturn(
+        (void *)dcontext, ilist, NULL /*append*/, (void *)d_r_dispatch, 1,
+        absolute ? OPND_CREATE_INTPTR((ptr_int_t)dcontext) : opnd_create_reg(REG_DCTXT));
 
-    /* dispatch() shouldn't return! */
+    /* d_r_dispatch() shouldn't return! */
     insert_reachable_cti(dcontext, ilist, NULL, vmcode_get_start(),
                          (byte *)unexpected_return, true /*jmp*/, false /*!returns*/,
                          false /*!precise*/, DR_REG_R11 /*scratch*/, NULL);
@@ -2281,7 +2281,7 @@ append_call_dispatch(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
  * # Invoked via
  * #     a) from the fcache via a fragment exit stub,
  * #     b) from indirect_branch_lookup().
- * # Invokes dispatch() with a clean dstack.
+ * # Invokes d_r_dispatch() with a clean dstack.
  * # Assumptions:
  * #     1) app's value in xax/r0 already saved in dcontext.
  * #     2) xax/r0 holds the linkstub ptr
@@ -2407,14 +2407,14 @@ append_call_dispatch(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
  *    movl    $0, _sideline_trace
  *  .endif
  *
- *  # call central dispatch routine w/ dcontext as an argument
+ *  # call central d_r_dispatch routine w/ dcontext as an argument
  *  if (absolute)
  *    push    <dcontext>
  *  else
  *    push     %xdi  # for x64, mov %xdi, ARG1
  *  endif
- *  call    dispatch # for x64 windows, reserve 32 bytes stack space for call
- *  # dispatch() shouldn't return!
+ *  call    d_r_dispatch # for x64 windows, reserve 32 bytes stack space for call
+ *  # d_r_dispatch() shouldn't return!
  *  jmp     unexpected_return
  */
 
@@ -2426,7 +2426,7 @@ append_call_dispatch(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
  * If linkstub != NULL, used for coarse fragments, this routine assumes that:
  * - app xax is still in %xax
  * - next target pc is in DIRECT_STUB_SPILL_SLOT tls
- * - linkstub is the linkstub_t to pass back to dispatch
+ * - linkstub is the linkstub_t to pass back to d_r_dispatch
  * - if coarse_info:
  *   - app xcx is in MANGLE_XCX_SPILL_SLOT
  *   - source coarse info is in %xcx
@@ -2697,7 +2697,7 @@ emit_coarse_exit_prefix(dcontext_t *dcontext, byte *pc, coarse_info_t *info)
                      (ptr_uint_t *)&info->trace_head_return_prefix);
     if (DYNAMO_OPTION(disable_traces) ||
         /* i#670: the stub stored the abs addr at persist time.  we need
-         * to adjust to the use-time mod base which we do in dispatch
+         * to adjust to the use-time mod base which we do in d_r_dispatch
          * but we need to set the dcontext->coarse_exit so we go through
          * the fcache return
          */
@@ -3278,7 +3278,7 @@ emit_far_ibl(dcontext_t *dcontext, byte *pc, ibl_code_t *ibl_code,
         APP(&ilist, change_mode);
         APP(&ilist,
             instr_create_restore_from_tls(dcontext, SCRATCH_REG2, TLS_DCONTEXT_SLOT));
-        /* FIXME: for SELFPROT_DCONTEXT we'll need to exit to dispatch every time
+        /* FIXME: for SELFPROT_DCONTEXT we'll need to exit to d_r_dispatch every time
          * and add logic there to set x86_mode based on LINK_FAR.
          * We do not want x86_mode sitting in unprotected_context_t.
          */
@@ -3555,7 +3555,7 @@ skip_linked:
         .endif
 
         # even if !DYNAMO_OPTION(syscalls_synch_flush) must clear for cbret
-        movl 0, at_syscall_OFFSET # indicate to flusher/dispatch we're done w/ syscall
+        movl 0, at_syscall_OFFSET # indicate to flusher/d_r_dispatch we're done w/ syscall
 
         # assume interrupt could have changed register values
         .if !inline_ibl_head # else, saved inside inlined ibl
@@ -4081,7 +4081,7 @@ emit_shared_syscall(dcontext_t *dcontext, generated_code_t *code, byte *pc,
      * from a fragment exit stub through shared syscall, we could pass the
      * address of the IBL routine to jump to -- BB IBL for BBs and trace IBL
      * for traces. Shared syscall would do an indirect jump to reach the proper
-     * routine. On an IBL miss, the address is passed through to dispatch, which
+     * routine. On an IBL miss, the address is passed through to d_r_dispatch, which
      * can convert the address into the appropriate fake linkstub address (check
      * if the address is within emitted code and equals either BB or trace IBL.)
      * Since an address is being passed around and saved to the dcontext during
@@ -4107,7 +4107,7 @@ emit_shared_syscall(dcontext_t *dcontext, generated_code_t *code, byte *pc,
         insert_shared_restore_dcontext_reg(dcontext, &ilist, NULL);
     }
     /* When traversing the unlinked entry path, since IBL is bypassed
-     * control reaches dispatch, and the target is (usually) added to the IBT
+     * control reaches d_r_dispatch, and the target is (usually) added to the IBT
      * table. But since the unlinked path was used, the target may already be
      * present in the table so the add attempt is unnecessary and triggers an
      * ASSERT in fragment_add_ibl_target().
@@ -4266,7 +4266,7 @@ link_shared_syscall(dcontext_t *dcontext)
         link_shared_syscall_common(THREAD_GENCODE(dcontext));
 }
 
-/* Unlinks the shared_syscall routine so it goes back to dispatch after
+/* Unlinks the shared_syscall routine so it goes back to d_r_dispatch after
  * the system call itself.
  * If it is already unlinked, does nothing.
  * Assumes caller takes care of any synchronization if this is called
@@ -4642,7 +4642,7 @@ emit_do_syscall_common(dcontext_t *dcontext, generated_code_t *code, byte *pc,
 
 #if defined(ARM)
     /* We have to save r0 in case the syscall is interrupted.  We can't
-     * easily do this from dispatch b/c fcache_enter clobbers some TLS slots.
+     * easily do this from d_r_dispatch b/c fcache_enter clobbers some TLS slots.
      */
     APP(&ilist, instr_create_save_to_tls(dcontext, DR_REG_R0, TLS_REG0_SLOT));
     /* XXX: should have a proper patch list entry */

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1988,7 +1988,7 @@ bb_process_syscall(dcontext_t *dcontext, build_bb_t *bb)
 #ifdef X86
         /* PR 288101: On Linux we do not yet support inlined sysenter instrs as we
          * do not have in-cache support for the post-sysenter continuation: we rely
-         * for now on very simple sysenter handling where dispatch uses asynch_target
+         * for now on very simple sysenter handling where d_r_dispatch uses asynch_target
          * to know where to go next.
          */
         IF_LINUX(&&instr_get_opcode(bb->instr) != OP_sysenter)
@@ -2658,7 +2658,7 @@ static void
 bb_process_float_pc(dcontext_t *dcontext, build_bb_t *bb)
 {
     /* i#698: for instructions that save the floating-point state
-     * (e.g., fxsave), we go back to dispatch to translate the fp pc.
+     * (e.g., fxsave), we go back to d_r_dispatch to translate the fp pc.
      * We rule out being in a trace (and thus a potential alternative
      * would be to use a FRAG_ flag).  These are rare instructions so that
      * shouldn't have a significant perf impact: except we've been hitting
@@ -8041,7 +8041,7 @@ add_profile_call(dcontext_t *dcontext)
  * returns NULL if failed or not yet implemented, else returns the pc of the next instr.
  */
 app_pc
-emulate(dcontext_t *dcontext, app_pc pc, priv_mcontext_t *mc)
+d_r_emulate(dcontext_t *dcontext, app_pc pc, priv_mcontext_t *mc)
 {
     instr_t instr;
     app_pc next_pc = NULL;

--- a/core/arch/retcheck.c
+++ b/core/arch/retcheck.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1645,7 +1645,7 @@ at_licdll_rct_exception(dcontext_t *dcontext, app_pc target_pc, app_pc source_pc
 }
 
 /* return after call check
-   called by dispatch after inlined return lookup routine has failed */
+   called by d_r_dispatch after inlined return lookup routine has failed */
 /* FIXME: return value is ignored */
 int
 ret_after_call_check(dcontext_t *dcontext, app_pc target_addr, app_pc src_addr)

--- a/core/arch/sideline.c
+++ b/core/arch/sideline.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -91,7 +91,7 @@ volatile fragment_t *sideline_trace;
 /* number of processors we're running on */
 int num_processors;
 
-/* used to signal which thread we need to pause in dispatch */
+/* used to signal which thread we need to pause in d_r_dispatch */
 thread_id_t pause_for_sideline;
 event_t paused_for_sideline_event;
 event_t resume_from_sideline_event;
@@ -600,7 +600,7 @@ sideline_optimize(fragment_t *f,
     ASSERT(is_thread_known(pause_for_sideline));
 
     if (dcontext->whereami != DR_WHERE_FCACHE) {
-        /* wait for thread to reach waiting point in dispatch */
+        /* wait for thread to reach waiting point in d_r_dispatch */
         LOG(logfile, LOG_SIDELINE, VERB_3,
             "\nsideline_optimize: waiting for target thread " TIDFMT "\n",
             pause_for_sideline);
@@ -716,7 +716,7 @@ sideline_optimize(fragment_t *f,
 exit_sideline_optimize:
     pause_for_sideline = (thread_id_t)0;
     if (!mutex_trylock(&sideline_lock)) {
-        /* thread is waiting in dispatch */
+        /* thread is waiting in d_r_dispatch */
         signal_event(resume_from_sideline_event);
         mutex_lock(&sideline_lock);
         /* at this point we know thread has read our resume event

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -910,7 +910,7 @@ read_instruction(byte *pc, byte *orig_pc, const instr_info_t **ret_info,
         di->repne_prefix = false;
     } else if (info->type == EXTENSION) {
         /* discard old info, get new one */
-        info = &extensions[info->code][di->reg];
+        info = &base_extensions[info->code][di->reg];
         /* absurd cases of using prefix on top of reg opcode extension
          * (pslldq, psrldq) => PREFIX_EXT can happen after here,
          * and MOD_EXT after that

--- a/core/arch/x86/decode_private.h
+++ b/core/arch/x86/decode_private.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -452,7 +452,7 @@ opc_is_cbr_arch(int opc);
 /* exported tables */
 extern const instr_info_t first_byte[];
 extern const instr_info_t second_byte[];
-extern const instr_info_t extensions[][8];
+extern const instr_info_t base_extensions[][8];
 extern const instr_info_t prefix_extensions[][8];
 extern const instr_info_t mod_extensions[][2];
 extern const instr_info_t rm_extensions[][8];

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -100,7 +100,7 @@ const instr_info_t * const op_instr[] =
     /* OP_popa    */   &first_byte[0x61],
     /* OP_bound   */   &first_byte[0x62],
     /* OP_arpl    */   &x64_extensions[16][0],
-    /* OP_imul    */   &extensions[10][5],
+    /* OP_imul    */   &base_extensions[10][5],
 
     /* OP_jo_short    */   &first_byte[0x70],
     /* OP_jno_short   */   &first_byte[0x71],
@@ -120,14 +120,14 @@ const instr_info_t * const op_instr[] =
     /* OP_jnle_short  */   &first_byte[0x7f],
 
     /* OP_call          */   &first_byte[0xe8],
-    /* OP_call_ind      */   &extensions[12][2],
+    /* OP_call_ind      */   &base_extensions[12][2],
     /* OP_call_far      */   &first_byte[0x9a],
-    /* OP_call_far_ind  */   &extensions[12][3],
+    /* OP_call_far_ind  */   &base_extensions[12][3],
     /* OP_jmp           */   &first_byte[0xe9],
     /* OP_jmp_short     */   &first_byte[0xeb],
-    /* OP_jmp_ind       */   &extensions[12][4],
+    /* OP_jmp_ind       */   &base_extensions[12][4],
     /* OP_jmp_far       */   &first_byte[0xea],
-    /* OP_jmp_far_ind   */   &extensions[12][5],
+    /* OP_jmp_far_ind   */   &base_extensions[12][5],
 
     /* OP_loopne  */   &first_byte[0xe0],
     /* OP_loope   */   &first_byte[0xe1],
@@ -348,32 +348,32 @@ const instr_info_t * const op_instr[] =
     /* OP_pslldq      */   &prefix_extensions[102][2],
 
 
-    /* OP_rol          */   &extensions[ 4][0],
-    /* OP_ror          */   &extensions[ 4][1],
-    /* OP_rcl          */   &extensions[ 4][2],
-    /* OP_rcr          */   &extensions[ 4][3],
-    /* OP_shl          */   &extensions[ 4][4],
-    /* OP_shr          */   &extensions[ 4][5],
-    /* OP_sar          */   &extensions[ 4][7],
-    /* OP_not          */   &extensions[10][2],
-    /* OP_neg          */   &extensions[10][3],
-    /* OP_mul          */   &extensions[10][4],
-    /* OP_div          */   &extensions[10][6],
-    /* OP_idiv         */   &extensions[10][7],
-    /* OP_sldt         */   &extensions[13][0],
-    /* OP_str          */   &extensions[13][1],
-    /* OP_lldt         */   &extensions[13][2],
-    /* OP_ltr          */   &extensions[13][3],
-    /* OP_verr         */   &extensions[13][4],
-    /* OP_verw         */   &extensions[13][5],
+    /* OP_rol          */   &base_extensions[ 4][0],
+    /* OP_ror          */   &base_extensions[ 4][1],
+    /* OP_rcl          */   &base_extensions[ 4][2],
+    /* OP_rcr          */   &base_extensions[ 4][3],
+    /* OP_shl          */   &base_extensions[ 4][4],
+    /* OP_shr          */   &base_extensions[ 4][5],
+    /* OP_sar          */   &base_extensions[ 4][7],
+    /* OP_not          */   &base_extensions[10][2],
+    /* OP_neg          */   &base_extensions[10][3],
+    /* OP_mul          */   &base_extensions[10][4],
+    /* OP_div          */   &base_extensions[10][6],
+    /* OP_idiv         */   &base_extensions[10][7],
+    /* OP_sldt         */   &base_extensions[13][0],
+    /* OP_str          */   &base_extensions[13][1],
+    /* OP_lldt         */   &base_extensions[13][2],
+    /* OP_ltr          */   &base_extensions[13][3],
+    /* OP_verr         */   &base_extensions[13][4],
+    /* OP_verw         */   &base_extensions[13][5],
     /* OP_sgdt         */   &mod_extensions[0][0],
     /* OP_sidt         */   &mod_extensions[1][0],
     /* OP_lgdt         */   &mod_extensions[5][0],
     /* OP_lidt         */   &mod_extensions[4][0],
-    /* OP_smsw         */   &extensions[14][4],
-    /* OP_lmsw         */   &extensions[14][6],
+    /* OP_smsw         */   &base_extensions[14][4],
+    /* OP_lmsw         */   &base_extensions[14][6],
     /* OP_invlpg       */   &mod_extensions[2][0],
-    /* OP_cmpxchg8b    */   &extensions[16][1],
+    /* OP_cmpxchg8b    */   &base_extensions[16][1],
     /* OP_fxsave32     */   &rex_w_extensions[0][0],
     /* OP_fxrstor32    */   &rex_w_extensions[1][0],
     /* OP_ldmxcsr      */   &vex_extensions[61][0],
@@ -382,12 +382,12 @@ const instr_info_t * const op_instr[] =
     /* OP_mfence       */   &mod_extensions[7][1],
     /* OP_clflush      */   &mod_extensions[3][0],
     /* OP_sfence       */   &mod_extensions[3][1],
-    /* OP_prefetchnta  */   &extensions[23][0],
-    /* OP_prefetcht0   */   &extensions[23][1],
-    /* OP_prefetcht1   */   &extensions[23][2],
-    /* OP_prefetcht2   */   &extensions[23][3],
-    /* OP_prefetch     */   &extensions[24][0],
-    /* OP_prefetchw    */   &extensions[24][1],
+    /* OP_prefetchnta  */   &base_extensions[23][0],
+    /* OP_prefetcht0   */   &base_extensions[23][1],
+    /* OP_prefetcht1   */   &base_extensions[23][2],
+    /* OP_prefetcht2   */   &base_extensions[23][3],
+    /* OP_prefetch     */   &base_extensions[24][0],
+    /* OP_prefetchw    */   &base_extensions[24][1],
 
 
     /* OP_movups     */   &prefix_extensions[ 0][0],
@@ -1189,28 +1189,28 @@ const instr_info_t * const op_instr[] =
 
     /* AMD TBM */
     /* OP_bextr         */   &prefix_extensions[141][4],
-    /* OP_blcfill       */   &extensions[27][1],
-    /* OP_blci          */   &extensions[28][6],
-    /* OP_blcic         */   &extensions[27][5],
-    /* OP_blcmsk        */   &extensions[28][1],
-    /* OP_blcs          */   &extensions[27][3],
-    /* OP_blsfill       */   &extensions[27][2],
-    /* OP_blsic         */   &extensions[27][6],
-    /* OP_t1mskc        */   &extensions[27][7],
-    /* OP_tzmsk         */   &extensions[27][4],
+    /* OP_blcfill       */   &base_extensions[27][1],
+    /* OP_blci          */   &base_extensions[28][6],
+    /* OP_blcic         */   &base_extensions[27][5],
+    /* OP_blcmsk        */   &base_extensions[28][1],
+    /* OP_blcs          */   &base_extensions[27][3],
+    /* OP_blsfill       */   &base_extensions[27][2],
+    /* OP_blsic         */   &base_extensions[27][6],
+    /* OP_t1mskc        */   &base_extensions[27][7],
+    /* OP_tzmsk         */   &base_extensions[27][4],
 
     /* AMD LWP */
-    /* OP_llwpcb        */   &extensions[29][0],
-    /* OP_slwpcb        */   &extensions[29][1],
-    /* OP_lwpins        */   &extensions[30][0],
-    /* OP_lwpval        */   &extensions[30][1],
+    /* OP_llwpcb        */   &base_extensions[29][0],
+    /* OP_slwpcb        */   &base_extensions[29][1],
+    /* OP_lwpins        */   &base_extensions[30][0],
+    /* OP_lwpval        */   &base_extensions[30][1],
 
     /* Intel BMI1 */
     /* (includes non-immed form of OP_bextr) */
     /* OP_andn          */   &third_byte_38[100],
-    /* OP_blsr          */   &extensions[31][1],
-    /* OP_blsmsk        */   &extensions[31][2],
-    /* OP_blsi          */   &extensions[31][3],
+    /* OP_blsr          */   &base_extensions[31][1],
+    /* OP_blsmsk        */   &base_extensions[31][2],
+    /* OP_blsi          */   &base_extensions[31][3],
     /* OP_tzcnt         */   &prefix_extensions[140][1],
 
     /* Intel BMI2 */
@@ -1231,8 +1231,8 @@ const instr_info_t * const op_instr[] =
     /* OP_invpcid       */   &third_byte_38[103],
 
     /* Intel TSX */
-    /* OP_xabort        */   &extensions[17][7],
-    /* OP_xbegin        */   &extensions[18][7],
+    /* OP_xabort        */   &base_extensions[17][7],
+    /* OP_xbegin        */   &base_extensions[18][7],
     /* OP_xend          */   &rm_extensions[4][5],
     /* OP_xtest         */   &rm_extensions[4][6],
 
@@ -1276,7 +1276,7 @@ const instr_info_t * const op_instr[] =
 
     /* Keep these at the end so that ifdefs don't change internal enum values */
 #ifdef IA32_ON_IA64
-    /* OP_jmpe      */   &extensions[13][6],
+    /* OP_jmpe      */   &base_extensions[13][6],
     /* OP_jmpe_abs  */   &second_byte[0xb8],
 #endif
 };
@@ -1652,7 +1652,7 @@ const instr_info_t * const op_instr[] =
 #define END_LIST  0
 #define tfb (ptr_int_t)&first_byte
 #define tsb (ptr_int_t)&second_byte
-#define tex (ptr_int_t)&extensions
+#define tex (ptr_int_t)&base_extensions
 #define t38 (ptr_int_t)&third_byte_38
 #define t3a (ptr_int_t)&third_byte_3a
 #define tpe (ptr_int_t)&prefix_extensions
@@ -2295,7 +2295,7 @@ const instr_info_t second_byte[] = {
  * Opcode extensions
  * This is from Table A-6
  */
-const instr_info_t extensions[][8] = {
+const instr_info_t base_extensions[][8] = {
   /* group 1a -- first opcode byte 80: all assumed to have Ib */
   { /* extensions[0] */
     {OP_add, 0x800020, "add", Eb, xx, Ib, Eb, xx, mrm, fW6,  tex[25][0]},

--- a/core/arch/x86/emit_utils.c
+++ b/core/arch/x86/emit_utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2424,7 +2424,7 @@ emit_indirect_branch_lookup(dcontext_t *dcontext, generated_code_t *code, byte *
             OPND_CREATE_INT8((int)(ptr_int_t)HASHLOOKUP_SENTINEL_START_PC));
     } else {
         /* sentinel handled in C code
-         * just exit back to dispatch
+         * just exit back to d_r_dispatch
          */
         sentinel_check = fragment_not_found;
     }
@@ -2810,7 +2810,7 @@ emit_indirect_branch_lookup(dcontext_t *dcontext, generated_code_t *code, byte *
          */
         /* need to save xax (was never saved before) */
         /*>>>    SAVE_TO_UPCONTEXT %xax,xax_OFFSET                  */
-        /* put &linkstub where dispatch expects it */
+        /* put &linkstub where d_r_dispatch expects it */
         /*>>>    mov     %xbx,%xax                                       */
         if (linkstub == NULL) {
             APP(&ilist,

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -2532,7 +2532,7 @@ mangle_float_pc(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
                 instr_t *next_instr, uint *flags INOUT)
 {
     /* If there is a prior non-control float instr, we can inline the pc update.
-     * Otherwise, we go back to dispatch.  In the latter case we do not support
+     * Otherwise, we go back to d_r_dispatch.  In the latter case we do not support
      * building traces across the float pc save: we assume it's rare.
      */
     app_pc prior_float = NULL;

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1451,7 +1451,7 @@ enum { /* FIXME: vs RAW_OPCODE_* enum */
 #define DEBUG_REGISTERS_FLAG_ENABLE_DR1 0xc
 #define DEBUG_REGISTERS_FLAG_ENABLE_DR2 0x30
 #define DEBUG_REGISTERS_FLAG_ENABLE_DR3 0xc0
-extern app_pc debugRegister[DEBUG_REGISTERS_NB];
+extern app_pc d_r_debug_register[DEBUG_REGISTERS_NB];
 
 /* Tells if instruction will trigger an exception because of debug register. */
 static inline bool
@@ -1459,8 +1459,8 @@ debug_register_fire_on_addr(app_pc pc)
 {
     ASSERT(DEBUG_REGISTERS_NB == 4);
     return (pc != NULL &&
-            (pc == debugRegister[0] || pc == debugRegister[1] || pc == debugRegister[2] ||
-             pc == debugRegister[3]));
+            (pc == d_r_debug_register[0] || pc == d_r_debug_register[1] ||
+             pc == d_r_debug_register[2] || pc == d_r_debug_register[3]));
 }
 
 #endif /* _OPCODE_H_ */

--- a/core/arch/x86/proc.c
+++ b/core/arch/x86/proc.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -72,7 +72,7 @@ static bool avx_enabled;
 static int num_simd_saved;
 
 /* global writable variable for debug registers value */
-DECLARE_NEVERPROT_VAR(app_pc debugRegister[DEBUG_REGISTERS_NB], { 0 });
+DECLARE_NEVERPROT_VAR(app_pc d_r_debug_register[DEBUG_REGISTERS_NB], { 0 });
 
 static void
 get_cache_sizes_amd(uint max_ext_val)
@@ -377,7 +377,7 @@ proc_init_arch(void)
         }
     }
     for (i = 0; i < DEBUG_REGISTERS_NB; i++) {
-        debugRegister[i] = NULL;
+        d_r_debug_register[i] = NULL;
     }
 }
 

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * ********************************************************** */
 
@@ -155,7 +155,7 @@ DECL_EXTERN(get_xmm_vals)
 DECL_EXTERN(auto_setup)
 DECL_EXTERN(return_from_native)
 DECL_EXTERN(native_module_callout)
-DECL_EXTERN(dispatch)
+DECL_EXTERN(d_r_dispatch)
 #ifdef DR_APP_EXPORTS
 DECL_EXTERN(dr_app_start_helper)
 #endif

--- a/core/dispatch.h
+++ b/core/dispatch.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -46,7 +46,7 @@ is_stopping_point(dcontext_t *dcontext, app_pc pc);
 
 /* central hub of control flow in DynamoRIO */
 void
-dispatch(dcontext_t *dcontext);
+d_r_dispatch(dcontext_t *dcontext);
 
 void
 issue_last_system_call_from_app(dcontext_t *dcontext);

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -3178,7 +3178,7 @@ check_should_be_protected(uint sec)
      * unprot, but it's not easy.
      */
     if (/* case 8107: for INJECT_LOCATION_LdrpLoadImportModule we
-         * load a helper library and end up in dispatch() for
+         * load a helper library and end up in d_r_dispatch() for
          * syscall_while_native before DR is initialized.
          */
         !dynamo_initialized ||
@@ -3318,7 +3318,7 @@ data_section_exit(void)
     uint i;
     DOSTATS({
         /* There can't have been that many races.
-         * A failure to re-protect should result in a ton of dispatch
+         * A failure to re-protect should result in a ton of d_r_dispatch
          * entrances w/ .data unprot, so should show up here.
          * However, an app with threads that are initializing in DR and thus
          * unprotected .data while other threads are running new code (such as

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -605,7 +605,7 @@ DECLARE_FREQPROT_VAR(bool reset_in_progress, false);
  * reset_at_nth_thread is wholly inside dynamo.c, e.g.
  */
 DECLARE_CXTSWPROT_VAR(mutex_t reset_pending_lock, INIT_LOCK_FREE(reset_pending_lock));
-/* indicates a call to fcache_reset_all_caches_proactively() is pending in dispatch */
+/* indicates a call to fcache_reset_all_caches_proactively() is pending in d_r_dispatch */
 DECLARE_FREQPROT_VAR(uint reset_pending, 0);
 
 /* these cannot be per-cache since caches are reset so we have them act globally.
@@ -4251,7 +4251,7 @@ fcache_reset_all_caches_proactively(uint target)
             last_exit_deleted(dcontext);
             if (target == RESET_PENDING_DELETION) {
                 /* case 7394: need to abort other threads' trace building
-                 * since the reset xfer to dispatch will disrupt it
+                 * since the reset xfer to d_r_dispatch will disrupt it
                  */
                 if (is_building_trace(dcontext)) {
                     LOG(THREAD, LOG_FRAGMENT, 2,

--- a/core/fcache.h
+++ b/core/fcache.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -80,7 +80,8 @@ enum {
  * resets are not queued up -- one wins and the rest are canceled
  */
 extern mutex_t reset_pending_lock;
-/* indicates a call to fcache_reset_all_caches_proactively() is pending from dispatch */
+/* indicates a call to fcache_reset_all_caches_proactively() is pending from d_r_dispatch
+ */
 extern uint reset_pending;
 
 void

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -6034,7 +6034,7 @@ flush_fragments_synchall_start(dcontext_t *ignored, app_pc base, size_t size,
             if (dcontext == my_dcontext || thread_synch_successful(flush_threads[i])) {
                 last_exit_deleted(dcontext);
                 /* case 7394: need to abort other threads' trace building
-                 * since the reset xfer to dispatch will disrupt it.
+                 * since the reset xfer to d_r_dispatch will disrupt it.
                  * also, with PR 299808, we now have thread-shared
                  * "undeletable" trace-temp fragments, so we need to abort
                  * all traces.
@@ -6143,7 +6143,7 @@ flush_fragments_thread_unlink(dcontext_t *dcontext, int thread_index,
     per_thread_t *tgt_pt = (per_thread_t *)tgt_dcontext->fragment_field;
 
     /* if a trace-in-progress crosses this region, must squash the trace
-     * (all traces are essentially frozen now since threads stop in dispatch)
+     * (all traces are essentially frozen now since threads stop in d_r_dispatch)
      */
     if (flush_size > 0 /* else, no region to cross */ &&
         is_building_trace(tgt_dcontext)) {
@@ -6690,7 +6690,7 @@ flush_fragments_end_synch(dcontext_t *dcontext, bool keep_initexit_lock)
              * only wrt shared fragments (we don't free private fragments here,
              * though we could -- should we?  may make flush time while holding
              * lock take too long?  FIXME)
-             * Currently this works w/ syscalls from dispatch, and w/
+             * Currently this works w/ syscalls from d_r_dispatch, and w/
              * -shared_syscalls by using unprotected storage (thus a slight hole
              * but very hard to exploit for security purposes: can get stale code
              * executed, but we already have that window, or crash us).
@@ -7295,8 +7295,8 @@ profile_fragment_enter(fragment_t *f, uint64 end_time)
 
     /***********************************************************************/
 
-    /* we rely on dispatch being the only way to enter the fcache.
-     * dispatch sets prev_fragment to null prior to entry */
+    /* we rely on d_r_dispatch being the only way to enter the fcache.
+     * d_r_dispatch sets prev_fragment to null prior to entry */
     if (dcontext->prev_fragment != NULL) {
         trace_only_t *last_t = TRACE_FIELDS(dcontext->prev_fragment);
         ASSERT((dcontext->prev_fragment->flags & FRAG_IS_TRACE) != 0);
@@ -7314,7 +7314,7 @@ profile_fragment_enter(fragment_t *f, uint64 end_time)
 #    endif
 }
 
-/* this routine is called from dispatch after exiting the fcache
+/* this routine is called from d_r_dispatch after exiting the fcache
  * it finishes up the final fragment's time slot
  */
 void

--- a/core/globals.h
+++ b/core/globals.h
@@ -671,7 +671,7 @@ extern recursive_lock_t change_linking_lock;
 typedef enum {
     DR_WHERE_APP = 0,         /**< Control is in native application code. */
     DR_WHERE_INTERP,          /**< Control is in basic block building. */
-    DR_WHERE_DISPATCH,        /**< Control is in dispatch. */
+    DR_WHERE_DISPATCH,        /**< Control is in d_r_dispatch. */
     DR_WHERE_MONITOR,         /**< Control is in trace building. */
     DR_WHERE_SYSCALL_HANDLER, /**< Control is in system call handling. */
     DR_WHERE_SIGNAL_HANDLER,  /**< Control is in signal handling. */
@@ -756,7 +756,7 @@ typedef struct {
     int dr_errno; /* errno used for DR (no longer used for app) */
 #endif
     bool at_syscall;    /* for shared deletion syscalls_synch_flush,
-                         * as well as syscalls handled from dispatch,
+                         * as well as syscalls handled from d_r_dispatch,
                          * and for reset to identify when at syscalls
                          */
     ushort exit_reason; /* Allows multiplexing LINK_SPECIAL_EXIT */
@@ -954,7 +954,7 @@ struct _dcontext_t {
     app_pc asynch_target;
 
     /* must store post-intercepted-syscall target to allow using normal
-     * dispatch() for native_exec syscalls
+     * d_r_dispatch() for native_exec syscalls
      */
     app_pc native_exec_postsyscall;
 

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2010-2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -6729,7 +6729,7 @@ dr_delete_fragment(void *drcontext, void *tag)
         /* unlink fragment so will return to dynamo and delete.
          * Do not remove the fragment from the hashtable --
          * we need to be able to look up the fragment when
-         * inspecting the to_do list in dispatch.
+         * inspecting the to_do list in d_r_dispatch.
          */
         if ((f->flags & FRAG_LINKED_INCOMING) != 0)
             unlink_fragment_incoming(dcontext, f);

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -4028,15 +4028,16 @@ dr_log(void *drcontext, uint mask, uint level, const char *fmt, ...);
 #    define DR_LOG_CACHE                                           \
         0x00000100 /**< Log data related to code cache management. \
                     */
-#    define DR_LOG_FRAGMENT                                                         \
-        0x00000200                     /**< Log data related to app code fragments. \
-                                        */
-#    define DR_LOG_DISPATCH 0x00000400 /**< Log data on every context switch dispatch. \
-                                        */
-#    define DR_LOG_MONITOR 0x00000800  /**< Log data related to trace building. */
-#    define DR_LOG_HEAP 0x00001000     /**< Log data related to memory management. */
-#    define DR_LOG_VMAREAS 0x00002000  /**< Log data related to address space regions. */
-#    define DR_LOG_SYNCH 0x00004000    /**< Log data related to synchronization. */
+#    define DR_LOG_FRAGMENT                                     \
+        0x00000200 /**< Log data related to app code fragments. \
+                    */
+#    define DR_LOG_DISPATCH                                                           \
+        0x00000400                    /**< Log data on every context switch dispatch. \
+                                       */
+#    define DR_LOG_MONITOR 0x00000800 /**< Log data related to trace building. */
+#    define DR_LOG_HEAP 0x00001000    /**< Log data related to memory management. */
+#    define DR_LOG_VMAREAS 0x00002000 /**< Log data related to address space regions. */
+#    define DR_LOG_SYNCH 0x00004000   /**< Log data related to synchronization. */
 #    define DR_LOG_MEMSTATS                                                            \
         0x00008000                         /**< Log data related to memory statistics. \
                                             */
@@ -6240,7 +6241,7 @@ typedef enum {
 DR_API
 /**
  * Intended to augment dr_prepopulate_cache() by populating DR's indirect branch
- * tables, avoiding trips back to dispatch during initial execution.  This is only
+ * tables, avoiding trips back to the dispatcher during initial execution.  This is only
  * effective when one of the the runtime options -shared_trace_ibt_tables and
  * -shared_bb_ibt_tables (depending on whether traces are enabled) is turned on, as
  * this routine does not try to populate tables belonging to threads other than the

--- a/core/lib/kstatsx.h
+++ b/core/lib/kstatsx.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -752,7 +752,7 @@ STATS_DEF("Fcache exits, signal delivery", num_exits_dir_signal)
 STATS_DEF("Fcache exits needing cbr disambiguation", cbr_disambiguations)
 
 STATS_DEF("Float pc state updates intra-cache", float_pc_from_cache)
-STATS_DEF("Float pc state updates from dispatch", float_pc_from_dispatch)
+STATS_DEF("Float pc state updates from d_r_dispatch", float_pc_from_dispatch)
 
 STATS_DEF("Fragments with OF restore prefix", num_oflag_prefix_restore)
 STATS_DEF("Fcache free capacity (bytes)", fcache_free_capacity)

--- a/core/link.c
+++ b/core/link.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -163,7 +163,7 @@ static
 static const linkstub_t linkstub_ibl_deleted = { LINK_FAKE, 0 };
 static const linkstub_t linkstub_asynch = { LINK_FAKE, 0 };
 static const linkstub_t linkstub_native_exec = { LINK_FAKE, 0 };
-/* this one we give the flag LINK_NI_SYSCALL for executing a syscall in dispatch() */
+/* this one we give the flag LINK_NI_SYSCALL for executing a syscall in d_r_dispatch() */
 static const linkstub_t linkstub_native_exec_syscall = { LINK_FAKE | LINK_NI_SYSCALL, 0 };
 
 #ifdef WINDOWS
@@ -570,9 +570,9 @@ void
 set_last_exit(dcontext_t *dcontext, linkstub_t *l)
 {
     /* We try to set last_fragment every time we set last_exit, rather than
-     * leaving it as a dangling pointer until the next dispatch entrance,
+     * leaving it as a dangling pointer until the next d_r_dispatch entrance,
      * to avoid cases like bug 7534.  However, fcache_return only sets
-     * last_exit, though it hits the dispatch point that sets last_fragment
+     * last_exit, though it hits the d_r_dispatch point that sets last_fragment
      * soon after, and everyone who frees fragments that other threads can
      * see should call last_exit_deleted() on the other threads.
      */

--- a/core/link.h
+++ b/core/link.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -89,7 +89,7 @@ enum {
      */
     LINK_TRACE_CMP = 0x0080,
 #endif
-    /* Flags that tell DR to take some action upon returning to dispatch.
+    /* Flags that tell DR to take some action upon returning to d_r_dispatch.
      * This first one is multiplexed via dcontext->upcontext.upcontext.exit_reason.
      * All uses are assumed to be unlinkable.
      */

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -793,7 +793,7 @@ mark_trace_head(dcontext_t *dcontext_in, fragment_t *f, fragment_t *src_f,
     link_fragment_incoming(dcontext, f, false /*not new*/);
 #endif
     STATS_INC(num_trace_heads_marked);
-    /* caller is either dispatch or inside emit_fragment, they take care of
+    /* caller is either d_r_dispatch or inside emit_fragment, they take care of
      * re-protecting fcache
      */
     if (protected) {
@@ -2005,7 +2005,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
                     ASSERT((head->flags & FRAG_SHARED) == (f->flags & FRAG_SHARED));
                     if (TEST(FRAG_COARSE_GRAIN, head->flags)) {
                         /* we need a local copy before releasing the lock.
-                         * FIXME: share this code sequence w/ dispatch().
+                         * FIXME: share this code sequence w/ d_r_dispatch().
                          */
                         ASSERT(USE_BB_BUILDING_LOCK());
                         fragment_coarse_wrapper(&md->wrapper, f->tag,

--- a/core/native_exec.c
+++ b/core/native_exec.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -340,7 +340,7 @@ back_from_native_common(dcontext_t *dcontext, priv_mcontext_t *mc, app_pc target
     ASSERT(dcontext->last_exit == get_native_exec_linkstub());
     ASSERT(!is_native_pc(target));
     dcontext->next_tag = target;
-    /* tell dispatch() why we're coming there */
+    /* tell d_r_dispatch() why we're coming there */
     dcontext->whereami = DR_WHERE_FCACHE;
     /* FIXME i#2375: for -native_exec_opt on UNIX we need to update the gencode
      * to do what os_thread_{,not_}under_dynamo() and os_thread_re_take_over() do.
@@ -362,7 +362,7 @@ back_from_native_common(dcontext_t *dcontext, priv_mcontext_t *mc, app_pc target
             dcontext->next_tag, cur_esp, mc->xsp);
     });
 
-    call_switch_stack(dcontext, dcontext->dstack, (void (*)(void *))dispatch,
+    call_switch_stack(dcontext, dcontext->dstack, (void (*)(void *))d_r_dispatch,
                       NULL /*not on initstack*/, false /*shouldn't return*/);
     ASSERT_NOT_REACHED();
 }

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -2800,7 +2800,7 @@ OPTION_DEFAULT(bool, pad_jmps_mark_no_trace, false,
         "detach once a thread has 2 levels of nested callbacks (for internal testing)")
     OPTION_DEFAULT_INTERNAL(bool, detach_fix_sysenter_on_stack, true /* default true */,
         "if false then detach does not fix sysenter callbacks on the stack and instead "
-        "uses the emitted dispatch code used for other system calls (a fairly minor "
+        "uses the emitted d_r_dispatch code used for other system calls (a fairly minor "
         "transparency violation).  Used for internal testing.")
 
      /* for stress testing can use 1 */

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -725,7 +725,7 @@ enum {
                                 * no actual protection unless SELFPROT_GLOBAL */
     SELFPROT_LOCAL = 0x020,
     SELFPROT_CACHE = 0x040, /* FIXME: thread-safe NYI when doing all units */
-    SELFPROT_STACK = 0x080, /* essentially always on with clean-dstack dispatch()
+    SELFPROT_STACK = 0x080, /* essentially always on with clean-dstack d_r_dispatch()
                              * design, leaving as a bit in case we do more later */
     /* protect our generated thread-shared and thread-private code */
     SELFPROT_GENCODE = 0x100,
@@ -1158,7 +1158,7 @@ app_pc
 aslr_possible_preferred_address(app_pc target_addr);
 
 #ifdef WINDOWS
-/* dispatch places next pc in asynch_target and clears it after syscall handling
+/* d_r_dispatch places next pc in asynch_target and clears it after syscall handling
  * completes, so a zero value means shared syscall was used and the next pc
  * is in the esi slot. If asynch_target == BACK_TO_NATIVE_AFTER_SYSCALL then the
  * thread is native at an intercepted syscall and the real post syscall target is in

--- a/core/perscache.h
+++ b/core/perscache.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -62,7 +62,7 @@
  * and frozen.
  * Destruction is assumed to involve all-thread-synch and so reads of
  * fields do not require the struct lock.  Just like reset, we rely on
- * all-thread-synch plus redirection to dispatch (rather than resuming
+ * all-thread-synch plus redirection to d_r_dispatch (rather than resuming
  * at suspended location, which we only do for native threads) to
  * allow us to free these shared structures that are read w/o locks.
  * FIXME: what about where we lack setcontext permission

--- a/core/rct.c
+++ b/core/rct.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -252,7 +252,7 @@ is_address_after_call(dcontext_t *dcontext, app_pc target)
 }
 
 /* Restricted control transfer check on indirect branches called by
- * dispatch after inlined indirect branch lookup routine has failed
+ * d_r_dispatch after inlined indirect branch lookup routine has failed
  *
  * function does not return if a security violation is blocked
  * FIXME: return value is ignored

--- a/core/unix/module.c
+++ b/core/unix/module.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -192,7 +192,7 @@ os_module_area_init(module_area_t *ma, app_pc base, size_t view_size, bool at_ma
     if (ma->os_data.checksum == 0 &&
         (DYNAMO_OPTION(coarse_enable_freeze) || DYNAMO_OPTION(use_persisted))) {
         /* Use something so we have usable pcache names */
-        ma->os_data.checksum = crc32((const char *)ma->start, PAGE_SIZE);
+        ma->os_data.checksum = d_r_crc32((const char *)ma->start, PAGE_SIZE);
     }
     /* Timestamp we just leave as 0 */
 }

--- a/core/unix/native_elf.c
+++ b/core/unix/native_elf.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -277,7 +277,7 @@ create_opt_plt_stub(app_pc plt_tgt, app_pc stub_pc)
     instr_t *instr;
     byte *pc;
     /* XXX i#1238-c#4: because we may continue in the code cache if the target
-     * is found or back to dispatch otherwise, and we use the standard ibl
+     * is found or back to d_r_dispatch otherwise, and we use the standard ibl
      * routine, we may not be able to update kstats correctly.
      */
     ASSERT_BUG_NUM(1238,
@@ -816,7 +816,7 @@ is_special_ret_stub(app_pc pc)
 
 /* i#1276: dcontext->next_tag could be special stub pc from special_ret_stub
  * for DR maintaining the control in hybrid execution, this routine is called
- * in dispatch to adjust the target if necessary.
+ * in d_r_dispatch to adjust the target if necessary.
  */
 bool
 native_exec_replace_next_tag(dcontext_t *dcontext)

--- a/core/unix/pcprofile.c
+++ b/core/unix/pcprofile.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 

--- a/core/utils.c
+++ b/core/utils.c
@@ -1,6 +1,6 @@
 /* **********************************************************
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2017 ARM Limited. All rights reserved.
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -3643,7 +3643,7 @@ static const uint crctab[] = {
 
 /* This function implements the Ethernet AUTODIN II CRC32 algorithm.  */
 uint
-crc32(const char *buf, const uint len)
+d_r_crc32(const char *buf, const uint len)
 {
     uint i;
     uint crc = 0xFFFFFFFF;

--- a/core/utils.h
+++ b/core/utils.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2262,7 +2262,7 @@ void
 convert_date_to_millis(const dr_time_t *dr_time, uint64 *millis OUT);
 
 uint
-crc32(const char *buf, const uint len);
+d_r_crc32(const char *buf, const uint len);
 void
 utils_init(void);
 void

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -9035,7 +9035,7 @@ move_lazy_list_to_pending_delete(dcontext_t *dcontext)
      * never-occurring freeing), so we must grab thread_initexit_lock,
      * meaning we must be nolinking, meaning the caller must accept loss
      * of locals.
-     * FIXME: should switch to a flag-triggered addition in dispatch
+     * FIXME: should switch to a flag-triggered addition in d_r_dispatch
      * to avoid this nolinking trouble.
      */
     enter_nolinking(dcontext, NULL, false /*not a cache transition*/);
@@ -10375,7 +10375,7 @@ thread_vm_area_overlap(dcontext_t *dcontext, app_pc start, app_pc end)
 
 /* Returns NULL if should re-execute the faulting write
  * Else returns the target pc for a new basic block -- caller should
- * return to dispatch rather than the code cache
+ * return to d_r_dispatch rather than the code cache
  * If instr_cache_pc==NULL, assumes the cache is unavailable (due to reset).
  */
 app_pc
@@ -10801,9 +10801,9 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
      * region even if the src bb didn't and anyways flushing can end up
      * flushing outside the requested region (entire vm_area_t). If we could tell
      * we could return NULL instead (which is a special flag that says redo the
-     * write instead of going to dispatch) if f wasn't flushed.
+     * write instead of going to d_r_dispatch) if f wasn't flushed.
      * FIXME - Redoing the write would be more efficient then going back to
-     * dispatch and should be the common case. */
+     * d_r_dispatch and should be the common case. */
     flush_fragments_in_region_finish(dcontext, false /*don't keep initexit_lock*/);
     if (DYNAMO_OPTION(opt_jit) && !TEST(MEMPROT_WRITE, prot) &&
         is_jit_managed_area(flush_start))
@@ -11369,7 +11369,7 @@ apc_thread_policy_helper(app_pc *apc_target_location, /* IN/OUT */
              * of this because a main thread may get affected very early.
              *
              * It is also hard to reuse security_violation() call here
-             * (since we are not under dispatch()).  If we want to see a
+             * (since we are not under d_r_dispatch()).  If we want to see a
              * code origins failure, we can just disable this policy.
              */
             ASSERT(!TEST(OPTION_HANDLING, target_policy) &&

--- a/core/vmareas.h
+++ b/core/vmareas.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -745,7 +745,7 @@ thread_vm_area_overlap(dcontext_t *dcontext, app_pc start, app_pc end);
 
 /* Returns NULL if should re-execute the faulting write
  * Else returns the target pc for a new basic block -- caller should
- * return to dispatch rather than the code cache.
+ * return to d_r_dispatch rather than the code cache.
  * Pass in the fragment containing instr_cache_pc if known: else pass NULL.
  */
 app_pc

--- a/core/win32/aslr.c
+++ b/core/win32/aslr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1179,7 +1179,7 @@ aslr_get_module_mapping_size(HANDLE section_handle, size_t *module_size, uint pr
     return true;
 }
 
-/* since always coming from dispatch now, only need to set mcontext, but we
+/* since always coming from d_r_dispatch now, only need to set mcontext, but we
  * continue to set reg_eax in case it's read later in the routine
  * FIXME: assumes local variable reg_eax
  */
@@ -2813,9 +2813,9 @@ aslr_module_read_signature(HANDLE randomized_file, uint64 *randomized_file_point
      *  <metadata>  <!- not really going be in xml -->
      *    name=""
      *    <original>
-     *     <checksum md5|crc32|sha1= /> <-- staleness -->
+     *     <checksum md5|d_r_crc32|sha1= /> <-- staleness -->
      *    <rebased>
-     *     <checksum md5|crc32|sha1= /> <-- corruption -->
+     *     <checksum md5|d_r_crc32|sha1= /> <-- corruption -->
      *  </metadata>
      *  <hash>md5(metadata)</hash>
      *
@@ -2835,7 +2835,7 @@ aslr_module_read_signature(HANDLE randomized_file, uint64 *randomized_file_point
      */
 
     /* see reactos/0.2.9/lib/ntdll/ldr/utils.c for the original
-     * LdrpCheckImageChecksum, though we could produce our own crc32()
+     * LdrpCheckImageChecksum, though we could produce our own d_r_crc32()
      * checksum on original file as well and store it as checksum of
      * our generated file in some PE orifice.
      */
@@ -3869,7 +3869,7 @@ calculate_publish_name(wchar_t *generated_name /* OUT */,
     }
 
     /* name hash over the wide char as bytes (many will be 0's but OK) */
-    name_hash = crc32((char *)name_info.FileName, name_info.FileNameLength);
+    name_hash = d_r_crc32((char *)name_info.FileName, name_info.FileNameLength);
 
     /* xor over the file size as bytes */
     final_hash =

--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.   All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.   All rights reserved.
  * Copyright (c) 2009-2010 Derek Bruening   All rights reserved.
  * **********************************************************/
 
@@ -229,7 +229,7 @@ os_loader_init_prologue(void)
              * XXX: if we attach or something it seems possible that ntdll or user32
              * or some other shared resource might set these and we want to share
              * the value between app and priv.  In that case we should not clear here
-             * and should relax the asserts in dispatch and is_using_app_peb to
+             * and should relax the asserts in d_r_dispatch and is_using_app_peb to
              * allow app==priv if both ==pre.
              */
             set_tls(NLS_CACHE_TIB_OFFSET, NULL);

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -8764,12 +8764,12 @@ early_inject_init()
         dcontext->thread_record->under_dynamo_control = false;
         whereami_save = dcontext->whereami;
         /* FIXME - this is an ugly hack to get the kstack in a form compatible
-         * with dispatch for processing the native exec syscalls we'll hit
+         * with d_r_dispatch for processing the native exec syscalls we'll hit
          * while loading the helper dll (hotpatch has a similar issue but
          * lucks out with having a compatible stack).  Shouldn't mess things
          * up too much though.  We do have to use non-matching stops so not
          * sure how accurate these times will be (should be tiny anyways)
-         * should poke around dispatch sometime and figure out some way to
+         * should poke around d_r_dispatch sometime and figure out some way to
          * do this nicer. */
         KSTART(dispatch_num_exits);
         KSTART(dispatch_num_exits);

--- a/core/win32/syscall.c
+++ b/core/win32/syscall.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -766,7 +766,7 @@ syscall_while_native(app_state_at_intercept_t *state)
          * read-only until executed from, so in the common case we should not
          * incur any cost from cache consistency while native.
          */
-        /* Invoke normal DR syscall-handling by calling dispatch() with a
+        /* Invoke normal DR syscall-handling by calling d_r_dispatch() with a
          * linkstub_t marked just like those for fragments ending in syscalls.
          * (We cannot return to the trampoline tail for asynch_take_over() since
          * it will clobber out next_tag and last_exit and will execute the jmp
@@ -898,7 +898,7 @@ init_syscall_trampolines(void)
                     &syscall_trampoline_hook_pc[i], syscall_while_native,
                     (void *)(ptr_int_t)i /* callee arg */,
                     AFTER_INTERCEPT_DYNAMIC_DECISION,
-                    /* must store the skip_pc for the new dispatch()
+                    /* must store the skip_pc for the new d_r_dispatch()
                      * to know where to go after handling from DR --
                      * this is simpler than having trampoline
                      * pass it in as an arg to syscall_while_native
@@ -1125,7 +1125,7 @@ syscall_uses_edx_param_base()
                 ? (POST_SYSCALL_PC(dc) - CTI_FAR_ABS_LENGTH)                        \
                 : get_app_sysenter_addr()))
 
-/* since always coming from dispatch now, only need to set mcontext */
+/* since always coming from d_r_dispatch now, only need to set mcontext */
 #define SET_RETURN_VAL(dc, val) get_mcontext(dc)->xax = (reg_t)(val)
 
 /****************************************************************************

--- a/libutil/processes.c
+++ b/libutil/processes.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -102,12 +102,12 @@ read_hotp_status(const HANDLE hproc, const void *table_ptr,
     }
 
 #    if 0
-    /* FIXME: crc32 is not defined where share/ can get at it,
+    /* FIXME: d_r_crc32 is not defined where share/ can get at it,
      *  and we may be changing it anyway (case 5346) -- so just
      *  don't do a check for now. */
     /* verify crc: crc starts at size elt, see globals_shared.h */
     if ((*hotp_status)->crc !=
-        crc32((char *)*hotp_status + sizeof(UINT), size - sizeof(UINT))) {
+        d_r_crc32((char *)*hotp_status + sizeof(UINT), size - sizeof(UINT))) {
         free(*hotp_status);
         *hotp_status = NULL;
         return ERROR_DRMARKER_ERROR;

--- a/suite/tests/client-interface/timer.c
+++ b/suite/tests/client-interface/timer.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -70,7 +70,7 @@ main(int argc, char *argv[])
     sleeptime.tv_sec = 0;
     sleeptime.tv_nsec = 25 * 1000 * 1000; /* 25ms */
     /* Doing a few more syscalls makes the test more reliable than one long
-     * sleep, since we hit dispatch more often.
+     * sleep, since we hit d_r_dispatch more often.
      */
     nanosleep(&sleeptime, NULL);
     nanosleep(&sleeptime, NULL);


### PR DESCRIPTION
Renames several single-word global symbols to help reduce the chance
of name conflicts:

+ s/debugRegister/d_r_debug_register/
+ s/crc32/d_r_crc32/
+ s/dispatch/d_r_dispatch/
+ s/emulate/d_r_emulate/
+ s/extensions/base_extensions/

Issue: #3348