### PR TITLE
i#3348 sym conflicts: Rename one-word global symbols, part 2

### DIFF
--- a/core/CMake_symbol_check.cmake
+++ b/core/CMake_symbol_check.cmake
@@ -62,19 +62,7 @@ foreach(line ${lines})
   set(is_ok OFF)
   # We have some legacy exceptions we allow until we've renamed them all.
   if (line MATCHES "decode\n" OR
-      line MATCHES "disassemble\n" OR
-      line MATCHES "initstack\n" OR
-      line MATCHES "loginst\n" OR
-      line MATCHES "logopnd\n" OR
-      line MATCHES "logtrace\n" OR
-      line MATCHES "mangle\n" OR
-      line MATCHES "MD5Final\n" OR
-      line MATCHES "MD5Init\n" OR
-      line MATCHES "MD5Update\n" OR
-      line MATCHES "notify\n" OR
-      line MATCHES "regparms\n" OR
-      line MATCHES "stackdump\n" OR
-      line MATCHES "stats\n")
+      line MATCHES "disassemble\n")
     # OK: an exception we allow for now.
     set(is_ok ON)
   endif ()

--- a/core/annotations.c
+++ b/core/annotations.c
@@ -1091,9 +1091,9 @@ annotation_printf(const char *format, ...)
     char *timestamped_format = NULL;
     uint buffer_length = 0;
 
-    if (stats == NULL || stats->loglevel == 0)
+    if (d_r_stats == NULL || d_r_stats->loglevel == 0)
         return 0; /* No log is available for writing. */
-    if ((stats->logmask & LOG_VIA_ANNOTATIONS) == 0)
+    if ((d_r_stats->logmask & LOG_VIA_ANNOTATIONS) == 0)
         return 0; /* Filtered out by the user. */
 
     /* Substitute the first instance of the timestamp token with a timestamp string.

--- a/core/arch/aarch64/aarch64.asm
+++ b/core/arch/aarch64/aarch64.asm
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2019 Google, Inc. All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -318,7 +319,7 @@ cat_done_saving_dstack:
 cat_thread_only:
         CALLC0(GLOBAL_REF(dynamo_thread_exit))
 cat_no_thread:
-        /* switch to initstack for cleanup of dstack */
+        /* switch to d_r_initstack for cleanup of dstack */
         adrp     x26, :got:initstack_mutex
         ldr      x26, [x26, #:got_lo12:initstack_mutex]
 cat_spin:
@@ -329,15 +330,15 @@ cat_spin:
 
 cat_have_lock:
         /* switch stack */
-        adrp     x0, :got:initstack
-        ldr      x0, [x0, #:got_lo12:initstack]
+        adrp     x0, :got:d_r_initstack
+        ldr      x0, [x0, #:got_lo12:d_r_initstack]
         ldr      x0, [x0]
         mov      sp, x0
 
         /* free dstack and call the EXIT_DR_HOOK */
         CALLC1(GLOBAL_REF(dynamo_thread_stack_free_and_exit), x24) /* pass dstack */
 
-        /* give up initstack mutex */
+        /* give up initstack_mutex */
         adrp     x0, :got:initstack_mutex
         ldr      x0, [x0, #:got_lo12:initstack_mutex]
         mov      x1, #0

--- a/core/arch/aarch64/clean_call_opt.c
+++ b/core/arch/aarch64/clean_call_opt.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2019 Google, Inc. All rights reserved.
  * Copyright (c) 2016-2018 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -188,7 +189,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
 
     num_regparm = MIN(ci->num_args, NUM_REGPARM);
     for (i = 0; i < num_regparm; i++) {
-        reg_id_t reg = regparms[i];
+        reg_id_t reg = d_r_regparms[i];
         if (!ci->reg_used[reg - DR_REG_START_GPR]) {
             LOG(THREAD, LOG_CLEANCALL, 2,
                 "CLEANCALL: callee " PFX " uses REG %s for arg passing\n", ci->start,
@@ -523,7 +524,7 @@ insert_inline_arg_setup(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_
                         instr_t *where, opnd_t *args)
 {
     callee_info_t *ci = cci->callee_info;
-    reg_id_t regparm = regparms[0];
+    reg_id_t regparm = d_r_regparms[0];
     opnd_t arg;
 
     if (cci->num_args == 0)
@@ -532,7 +533,7 @@ insert_inline_arg_setup(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_
     /* If the arg is un-referenced, don't set it up.  This is actually necessary
      * for correctness because we will not have spilled regparm[0].
      */
-    if (!ci->reg_used[regparms[0] - DR_REG_START_GPR]) {
+    if (!ci->reg_used[d_r_regparms[0] - DR_REG_START_GPR]) {
         LOG(THREAD, LOG_CLEANCALL, 2,
             "CLEANCALL: callee " PFX " doesn't read arg, skipping arg setup.\n",
             ci->start);

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -425,8 +425,8 @@ void
 clean_call_info_init(clean_call_info_t *cci, void *callee, bool save_fpstate,
                      uint num_args);
 void
-mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags INOUT, bool mangle_calls,
-       bool record_translation);
+d_r_mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags INOUT, bool mangle_calls,
+           bool record_translation);
 bool
 parameters_stack_padded(void);
 /* Inserts a complete call to callee with the passed-in arguments */

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -1225,8 +1225,8 @@ get_app_sysenter_addr(void);
 
 /* in [x86/arm].asm */
 /* Calls the specified function 'func' after switching to the stack 'stack'.  If we're
- * currently on the initstack 'mutex_to_free' should be passed so we release the
- * initstack lock.  The supplied 'func_arg' will be passed as an argument to 'func'.
+ * currently on the d_r_initstack, 'mutex_to_free' should be passed so we release the
+ * initstack_mutex.  The supplied 'func_arg' will be passed as an argument to 'func'.
  * If 'func' returns then 'return_on_return' is checked. If set we swap back stacks and
  * return to the caller.  If not set then it's assumed that func wasn't supposed to
  * return and we go to an error routine unexpected_return() below.
@@ -1247,8 +1247,8 @@ go_native(dcontext_t *dcontext);
 
 /* Calls dynamo_exit_process if exitproc is true, else calls dynamo_exit_thread.
  * Uses the current dstack, but instructs the cleanup routines not to
- * de-allocate it, does a custom de-allocate after swapping to initstack (don't
- * want to use initstack the whole time, that's too long to hold the mutex).
+ * de-allocate it, does a custom de-allocate after swapping to d_r_initstack (don't
+ * want to use d_r_initstack the whole time, that's too long to hold the mutex).
  * Then calls system call sysnum with parameter base param_base, which is presumed
  * to be either NtTerminateThread or NtTerminateProcess or exit.
  *

--- a/core/arch/arm/arm.asm
+++ b/core/arch/arm/arm.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * ********************************************************** */
 
 /*
@@ -47,7 +47,7 @@ DECL_EXTERN(relocate_dynamorio)
 DECL_EXTERN(privload_early_inject)
 
 DECL_EXTERN(exiting_thread_count)
-DECL_EXTERN(initstack)
+DECL_EXTERN(d_r_initstack)
 DECL_EXTERN(initstack_mutex)
 
 #define RESTORE_FROM_DCONTEXT_VIA_REG(reg,offs,dest) ldr dest, PTRSZ [reg, POUND (offs)]
@@ -279,7 +279,7 @@ cat_done_saving_dstack:
 cat_thread_only:
         CALLC0(GLOBAL_REF(dynamo_thread_exit))
 cat_no_thread:
-        /* switch to initstack for cleanup of dstack */
+        /* switch to d_r_initstack for cleanup of dstack */
         /* we use r6, r7, and r8 here so that atomic_swap doesn't clobber them */
         mov      REG_R6, #1
         ldr      REG_R8, .Lgot1
@@ -300,12 +300,12 @@ cat_have_lock:
         /* swap stacks */
         ldr      REG_R2, .Lgot2
         add      REG_R2, REG_R2, pc
-        ldr      REG_R3, .Linitstack
+        ldr      REG_R3, .Ld_r_initstack
 .LPIC2: ldr      REG_R3, [REG_R3, REG_R2]
         ldr      sp, [REG_R3]
         /* free dstack and call the EXIT_DR_HOOK */
         CALLC1(GLOBAL_REF(dynamo_thread_stack_free_and_exit), REG_R4) /* pass dstack */
-        /* give up initstack mutex */
+        /* give up initstack_mutex */
         ldr      REG_R2, .Lgot3
         add      REG_R2, REG_R2, pc
         ldr      REG_R3, .Linitstack_mutex
@@ -338,8 +338,8 @@ cat_have_lock:
         .long   _GLOBAL_OFFSET_TABLE_-.LPIC4
 .Lexiting_thread_count:
         .word   exiting_thread_count(GOT)
-.Linitstack:
-        .word   initstack(GOT)
+.Ld_r_initstack:
+        .word   d_r_initstack(GOT)
 .Linitstack_mutex:
         .word   initstack_mutex(GOT)
 #endif /* NOT_DYNAMORIO_CORE_PROPER */

--- a/core/arch/clean_call_opt_shared.c
+++ b/core/arch/clean_call_opt_shared.c
@@ -1,6 +1,6 @@
 /* **********************************************************
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
- * Copyright (c) 2010-2014 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * Copyright (c) 2003-2007 Determina Corp.
@@ -541,12 +541,12 @@ analyze_clean_call_regs(dcontext_t *dcontext, clean_call_info_t *cci)
      */
     num_regparm = cci->num_args < NUM_REGPARM ? cci->num_args : NUM_REGPARM;
     for (i = 0; i < num_regparm; i++) {
-        if (cci->reg_skip[regparms[i] - DR_REG_START_GPR]) {
+        if (cci->reg_skip[d_r_regparms[i] - DR_REG_START_GPR]) {
             LOG(THREAD, LOG_CLEANCALL, 3,
                 "CLEANCALL: if inserting clean call " PFX
                 ", cannot skip saving reg %s due to param passing.\n",
-                info->start, reg_names[regparms[i]]);
-            cci->reg_skip[regparms[i] - DR_REG_START_GPR] = false;
+                info->start, reg_names[d_r_regparms[i]]);
+            cci->reg_skip[d_r_regparms[i] - DR_REG_START_GPR] = false;
             cci->num_regs_skip--;
             /* We cannot call callee_info_reserve_slot for reserving slot
              * on inlining the callee here, because we are in clean call
@@ -576,7 +576,7 @@ analyze_clean_call_args(dcontext_t *dcontext, clean_call_info_t *cci, opnd_t *ar
         if (opnd_is_reg(args[i]))
             cci->save_all_regs = true;
         for (j = 0; j < num_regparm; j++) {
-            if (opnd_uses_reg(args[i], regparms[j]))
+            if (opnd_uses_reg(args[i], d_r_regparms[j]))
                 cci->save_all_regs = true;
         }
     }

--- a/core/arch/disassemble_shared.c
+++ b/core/arch/disassemble_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1253,7 +1253,7 @@ common_disassemble_fragment(dcontext_t *dcontext, fragment_t *f_in, file_t outfi
     if (dynamo_options.profile_times && (f->flags & FRAG_IS_TRACE) != 0) {
         int sz = profile_call_size();
         profile_end = pc + sz;
-        if (stats->loglevel < 3) {
+        if (d_r_stats->loglevel < 3) {
             /* don't print profile stuff to save space */
             print_file(outfile, "  " PFX "..." PFX " = profile code\n", pc,
                        (pc + sz - 1));
@@ -1364,7 +1364,7 @@ common_disassemble_fragment(dcontext_t *dcontext, fragment_t *f_in, file_t outfi
 void
 disassemble_fragment(dcontext_t *dcontext, fragment_t *f, bool just_header)
 {
-    if ((stats->logmask & LOG_EMIT) != 0) {
+    if ((d_r_stats->logmask & LOG_EMIT) != 0) {
         common_disassemble_fragment(dcontext, f, THREAD, true, !just_header);
         if (!just_header)
             LOG(THREAD, LOG_EMIT, 1, "\n");

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -2387,10 +2387,10 @@ opnd_t
 instr_get_src_mem_access(instr_t *instr);
 
 void
-loginst(dcontext_t *dcontext, uint level, instr_t *instr, const char *string);
+d_r_loginst(dcontext_t *dcontext, uint level, instr_t *instr, const char *string);
 
 void
-logopnd(dcontext_t *dcontext, uint level, opnd_t opnd, const char *string);
+d_r_logopnd(dcontext_t *dcontext, uint level, opnd_t opnd, const char *string);
 
 DR_API
 /**

--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1301,7 +1301,7 @@ instr_expand(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
         /* disassembling might change the instruction object, we're cloning it
          * for the logger */
         instr_t *log_instr = instr_clone(dcontext, instr);
-        loginst(dcontext, 4, log_instr, "instr_expand");
+        d_r_loginst(dcontext, 4, log_instr, "instr_expand");
         instr_free(dcontext, log_instr);
     });
 
@@ -1336,7 +1336,8 @@ instr_expand(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
             dr_set_isa_mode(dcontext, old_mode, NULL);
             return firstinstr;
         }
-        DOLOG(5, LOG_ALL, { loginst(dcontext, 4, newinstr, "\tjust expanded into"); });
+        DOLOG(5, LOG_ALL,
+              { d_r_loginst(dcontext, 4, newinstr, "\tjust expanded into"); });
 
         /* CAREFUL of what you call here -- don't call anything that
          * auto-upgrades instr to Level 2, it will fail on Level 0 bundles!
@@ -1607,10 +1608,10 @@ instrlist_decode_cti(dcontext_t *dcontext, instrlist_t *ilist)
         if (!instr_opcode_valid(instr) ||
             (instr_is_cti(instr) && !instr_operands_valid(instr))) {
             DOLOG(4, LOG_ALL, {
-                loginst(dcontext, 4, instr, "instrlist_decode_cti: about to decode");
+                d_r_loginst(dcontext, 4, instr, "instrlist_decode_cti: about to decode");
             });
             instr_decode_cti(dcontext, instr);
-            DOLOG(4, LOG_ALL, { loginst(dcontext, 4, instr, "\tjust decoded"); });
+            DOLOG(4, LOG_ALL, { d_r_loginst(dcontext, 4, instr, "\tjust decoded"); });
         }
     }
 
@@ -1629,11 +1630,11 @@ instrlist_decode_cti(dcontext_t *dcontext, instrlist_t *ilist)
             opnd_is_near_pc(instr_get_src(instr, 0))) {
             instr_t *tgt;
             DOLOG(4, LOG_ALL, {
-                loginst(dcontext, 4, instr,
-                        "instrlist_decode_cti: found cti w/ pc target");
+                d_r_loginst(dcontext, 4, instr,
+                            "instrlist_decode_cti: found cti w/ pc target");
             });
             for (tgt = instrlist_first(ilist); tgt != NULL; tgt = instr_get_next(tgt)) {
-                DOLOG(4, LOG_ALL, { loginst(dcontext, 4, tgt, "\tchecking"); });
+                DOLOG(4, LOG_ALL, { d_r_loginst(dcontext, 4, tgt, "\tchecking"); });
                 LOG(THREAD, LOG_INTERP | LOG_OPTS, 4, "\t\taddress is " PFX "\n",
                     instr_get_raw_bits(tgt));
                 if (opnd_get_pc(instr_get_target(instr)) == instr_get_raw_bits(tgt)) {
@@ -1648,7 +1649,7 @@ instrlist_decode_cti(dcontext_t *dcontext, instrlist_t *ilist)
                     if (bits != 0)
                         instr_set_raw_bits(instr, bits, len);
                     DOLOG(4, LOG_ALL,
-                          { loginst(dcontext, 4, tgt, "\tcti targets this"); });
+                          { d_r_loginst(dcontext, 4, tgt, "\tcti targets this"); });
                     break;
                 }
             }
@@ -1666,7 +1667,7 @@ instrlist_decode_cti(dcontext_t *dcontext, instrlist_t *ilist)
 /* utility routines */
 
 void
-loginst(dcontext_t *dcontext, uint level, instr_t *instr, const char *string)
+d_r_loginst(dcontext_t *dcontext, uint level, instr_t *instr, const char *string)
 {
     DOLOG(level, LOG_ALL, {
         LOG(THREAD, LOG_ALL, level, "%s: ", string);
@@ -1676,7 +1677,7 @@ loginst(dcontext_t *dcontext, uint level, instr_t *instr, const char *string)
 }
 
 void
-logopnd(dcontext_t *dcontext, uint level, opnd_t opnd, const char *string)
+d_r_logopnd(dcontext_t *dcontext, uint level, opnd_t opnd, const char *string)
 {
     DOLOG(level, LOG_ALL, {
         LOG(THREAD, LOG_ALL, level, "%s: ", string);
@@ -1686,7 +1687,7 @@ logopnd(dcontext_t *dcontext, uint level, opnd_t opnd, const char *string)
 }
 
 void
-logtrace(dcontext_t *dcontext, uint level, instrlist_t *trace, const char *string)
+d_r_logtrace(dcontext_t *dcontext, uint level, instrlist_t *trace, const char *string)
 {
     DOLOG(level, LOG_ALL, {
         instr_t *inst;

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -528,7 +528,7 @@ bb_add_native_direct_xfer(dcontext_t *dcontext, build_bb_t *bb, bool appended)
      * reachability from the likely code cache slot, but these should be
      * rare enough that making them indirect won't matter and then we have
      * fewer reachability dependences.
-     * We do this here rather than in mangle() b/c we'd have a hard time
+     * We do this here rather than in d_r_mangle() b/c we'd have a hard time
      * distinguishing native jmp/call due to DR's own operations from a
      * client's inserted meta jmp/call.
      */
@@ -573,7 +573,7 @@ bb_add_native_direct_xfer(dcontext_t *dcontext, build_bb_t *bb, bool appended)
     /* Indicate that relative target must be
      * re-encoded, and that it is not an exit cti.
      * However, we must mangle this to ensure it reaches (i#992)
-     * which we special-case in mangle().
+     * which we special-case in d_r_mangle().
      */
     instr_set_meta(bb->instr);
     instr_set_raw_bits_valid(bb->instr, false);
@@ -1601,7 +1601,7 @@ bb_process_fs_ref(dcontext_t *dcontext, build_bb_t *bb)
                     /* an unexpected SEH frame push */
                     LOG(THREAD, LOG_INTERP, 1,
                         "found unexpected write to fs:[0] @" PFX "\n", bb->instr_start);
-                    DOLOG(1, LOG_INTERP, { loginst(dcontext, 1, bb->instr, ""); });
+                    DOLOG(1, LOG_INTERP, { d_r_loginst(dcontext, 1, bb->instr, ""); });
                     ASSERT_CURIOSITY(!is_to_fs0);
                 }
             }
@@ -4516,7 +4516,7 @@ mangle_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
         LOG(THREAD, LOG_INTERP, 4, "bb ilist before mangling:\n");
         instrlist_disassemble(dcontext, bb->start_pc, bb->ilist, THREAD);
     });
-    mangle(dcontext, bb->ilist, &bb->flags, true, bb->record_translation);
+    d_r_mangle(dcontext, bb->ilist, &bb->flags, true, bb->record_translation);
     DOLOG(4, LOG_INTERP, {
         LOG(THREAD, LOG_INTERP, 4, "bb ilist after mangling:\n");
         instrlist_disassemble(dcontext, bb->start_pc, bb->ilist, THREAD);
@@ -5186,7 +5186,8 @@ build_basic_block_fragment(dcontext_t *dcontext, app_pc start, uint initial_flag
         DOLOG(3, LOG_INTERP, { disassemble_fragment(dcontext, f, false); });
     }
 #endif
-    DOLOG(2, LOG_INTERP, { disassemble_fragment(dcontext, f, stats->loglevel <= 3); });
+    DOLOG(2, LOG_INTERP,
+          { disassemble_fragment(dcontext, f, d_r_stats->loglevel <= 3); });
     DOLOG(4, LOG_INTERP, {
         if (TEST(FRAG_SELFMOD_SANDBOXED, f->flags)) {
             LOG(THREAD, LOG_INTERP, 4, "\nXXXX sandboxed fragment!  original code:\n");
@@ -5597,7 +5598,7 @@ regenerate_custom_exit_stub(dcontext_t *dcontext, instr_t *exit_cti, linkstub_t 
             if (!instr_is_return(in) && opnd_is_near_pc(instr_get_target(in)) &&
                 (opnd_get_pc(instr_get_target(in)) < start_pc ||
                  opnd_get_pc(instr_get_target(in)) > start_pc + f->size)) {
-                loginst(dcontext, 3, in, "\tcti has off-fragment target");
+                d_r_loginst(dcontext, 3, in, "\tcti has off-fragment target");
                 /* indicate that relative target must be
                  * re-encoded, and that it is not an exit cti
                  */
@@ -5629,8 +5630,8 @@ regenerate_custom_exit_stub(dcontext_t *dcontext, instr_t *exit_cti, linkstub_t 
                  * and the instr target moves (xref PR 333691)
                  */
                 instr_set_target(real_cti, opnd_create_instr(in));
-                loginst(dcontext, 3, real_cti, "\tthis cti: ");
-                loginst(dcontext, 3, in, "\t  targets intra-stub instr");
+                d_r_loginst(dcontext, 3, real_cti, "\tthis cti: ");
+                d_r_loginst(dcontext, 3, in, "\t  targets intra-stub instr");
                 break;
             }
         }
@@ -6227,7 +6228,7 @@ fixup_last_cti(dcontext_t *dcontext, instrlist_t *trace, app_pc next_tag, uint n
                     } else {
                         /* need to search for targeting jmp */
                         DOLOG(4, LOG_MONITOR,
-                              { loginst(dcontext, 4, inst, "exit==targeter?"); });
+                              { d_r_loginst(dcontext, 4, inst, "exit==targeter?"); });
                         LOG(THREAD, LOG_MONITOR, 4,
                             "target_tag = " PFX ", next_tag = " PFX "\n", target_tag,
                             next_tag);
@@ -6250,7 +6251,7 @@ fixup_last_cti(dcontext_t *dcontext, instrlist_t *trace, app_pc next_tag, uint n
     if (record_translation)
         instrlist_set_translation_target(trace, instr_get_translation(targeter));
     instrlist_set_our_mangling(trace, true); /* PR 267260 */
-    DOLOG(4, LOG_MONITOR, { loginst(dcontext, 4, targeter, "\ttargeter"); });
+    DOLOG(4, LOG_MONITOR, { d_r_loginst(dcontext, 4, targeter, "\ttargeter"); });
     if (is_indirect) {
         added_size += mangle_indirect_branch_in_trace(
             dcontext, trace, targeter, next_tag, next_flags, &delete_after, end_instr);
@@ -6317,7 +6318,7 @@ fixup_last_cti(dcontext_t *dcontext, instrlist_t *trace, app_pc next_tag, uint n
                     "WARNING: deleting non-exit cti in unused tail of frag added to "
                     "trace\n");
             }
-            loginst(dcontext, 4, inst, "\tdeleting");
+            d_r_loginst(dcontext, 4, inst, "\tdeleting");
             instrlist_remove(trace, inst);
             added_size -= instr_length(dcontext, inst);
             instr_destroy(dcontext, inst);
@@ -6764,7 +6765,7 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
 
         DOLOG(5, LOG_INTERP, {
             LOG(THREAD, LOG_MONITOR, 4, "transl " PFX " ", xl8);
-            loginst(dcontext, 4, inst, "considering non-meta");
+            d_r_loginst(dcontext, 4, inst, "considering non-meta");
         });
 
         /* Skip blocks that don't end in ctis (except final) */
@@ -6832,7 +6833,7 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
                 */
                opnd_get_pc(instr_get_target(inst)) == md->blk_info[blk + 1].info.tag)))) {
 
-            DOLOG(4, LOG_INTERP, { loginst(dcontext, 4, inst, "end of bb"); });
+            DOLOG(4, LOG_INTERP, { d_r_loginst(dcontext, 4, inst, "end of bb"); });
 
             /* Add jump that fixup_last_cti expects */
             if (!instr_is_ubr(inst) IF_X86(|| instr_get_opcode(inst) == OP_jmp_far)) {
@@ -6853,7 +6854,7 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
                 jmp = create_exit_jmp(dcontext, target, xl8, instr_branch_type(inst));
                 instrlist_postinsert(ilist, inst, jmp);
                 /* we're now done w/ vmlist: switch to end instr.
-                 * mangle() shouldn't remove the exit cti.
+                 * d_r_mangle() shouldn't remove the exit cti.
                  */
                 vm_area_destroy_list(dcontext, md->blk_info[blk].vmlist);
                 md->blk_info[blk].vmlist = NULL;
@@ -6937,9 +6938,9 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
         instrlist_disassemble(dcontext, md->trace_tag, ilist, THREAD);
     });
     /* We do not need to remove nops since we never emitted */
-    mangle(dcontext, ilist, &md->trace_flags, true /*mangle calls*/,
-           /* we're post-client so we don't need translations unless storing */
-           TEST(FRAG_HAS_TRANSLATION_INFO, md->trace_flags));
+    d_r_mangle(dcontext, ilist, &md->trace_flags, true /*mangle calls*/,
+               /* we're post-client so we don't need translations unless storing */
+               TEST(FRAG_HAS_TRANSLATION_INFO, md->trace_flags));
     DOLOG(4, LOG_INTERP, {
         LOG(THREAD, LOG_INTERP, 4, "trace ilist after mangling:\n");
         instrlist_disassemble(dcontext, md->trace_tag, ilist, THREAD);
@@ -7043,7 +7044,7 @@ forward_eflags_analysis(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr
         if (eflags_result != EFLAGS_WRITE_ARITH IF_X86(&&eflags_result != EFLAGS_READ_OF))
             eflags_result = eflags_analysis(in, eflags_result, &eflags_6);
         DOLOG(4, LOG_INTERP, {
-            loginst(dcontext, 4, in, "forward_eflags_analysis");
+            d_r_loginst(dcontext, 4, in, "forward_eflags_analysis");
             LOG(THREAD, LOG_INTERP, 4, "\tinstr %x => %x\n",
                 instr_get_eflags(in, DR_QUERY_DEFAULT), eflags_result);
         });
@@ -7347,8 +7348,8 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
                     bool re_relativize = false;
                     bool intra_target = true;
                     DOLOG(DF_LOGLEVEL(dcontext), LOG_MONITOR, {
-                        loginst(dcontext, 4, instr,
-                                "decode_fragment: found non-exit cti");
+                        d_r_loginst(dcontext, 4, instr,
+                                    "decode_fragment: found non-exit cti");
                     });
                     if (TEST(FRAG_FAKE, f->flags)) {
                         /* Case 8711: we don't know the size so we can't even
@@ -7377,8 +7378,8 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
                              * or none for others, so not worth doing anything about.
                              */
                             DOLOG(DF_LOGLEVEL(dcontext), LOG_MONITOR, {
-                                loginst(dcontext, DF_LOGLEVEL(dcontext), instr,
-                                        "\tcoarse exit cti");
+                                d_r_loginst(dcontext, DF_LOGLEVEL(dcontext), instr,
+                                            "\tcoarse exit cti");
                             });
                             intra_target = false;
                             stop_pc = prev_pc;
@@ -7387,8 +7388,8 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
                         } else {
                             /* we'll make it to intra_target if() below */
                             DOLOG(DF_LOGLEVEL(dcontext), LOG_MONITOR, {
-                                loginst(dcontext, DF_LOGLEVEL(dcontext), instr,
-                                        "\tcoarse intra-fragment cti");
+                                d_r_loginst(dcontext, DF_LOGLEVEL(dcontext), instr,
+                                            "\tcoarse intra-fragment cti");
                             });
                         }
                     } else if (instr_is_return(instr) ||
@@ -7413,7 +7414,8 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
                         re_relativize = true;
                         intra_target = false;
                         DOLOG(DF_LOGLEVEL(dcontext), LOG_MONITOR, {
-                            loginst(dcontext, 4, instr, "\tcti has off-fragment target");
+                            d_r_loginst(dcontext, 4, instr,
+                                        "\tcti has off-fragment target");
                         });
                     }
                     if (intra_target) {
@@ -7427,8 +7429,8 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
                         instrlist_append(&intra_ctis, clone);
                         /* intra-fragment target */
                         DOLOG(DF_LOGLEVEL(dcontext), LOG_MONITOR, {
-                            loginst(dcontext, 4, instr,
-                                    "\tcti has intra-fragment target");
+                            d_r_loginst(dcontext, 4, instr,
+                                        "\tcti has intra-fragment target");
                         });
                         /* since the resulting instrlist could be manipulated,
                          * we need to change the target operand from pc to instr_t.
@@ -7735,7 +7737,8 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
                      */
                     instr_set_target(real_cti, opnd_create_instr(instr));
                     DOLOG(DF_LOGLEVEL(dcontext), LOG_MONITOR, {
-                        loginst(dcontext, 4, real_cti, "\tre-set intra-fragment target");
+                        d_r_loginst(dcontext, 4, real_cti,
+                                    "\tre-set intra-fragment target");
                     });
                     break;
                 }
@@ -7873,10 +7876,10 @@ copy_fragment(dcontext_t *dcontext, fragment_t *f, bool replace)
     fragment_copy_data_fields(dcontext, f, new_f);
 
 #ifdef DEBUG
-    if (stats->loglevel > 1) {
+    if (d_r_stats->loglevel > 1) {
         LOG(THREAD, LOG_ALL, 2, "Copying F%d to F%d\n", f->id, new_f->id);
-        disassemble_fragment(dcontext, f, stats->loglevel < 3);
-        disassemble_fragment(dcontext, new_f, stats->loglevel < 3);
+        disassemble_fragment(dcontext, f, d_r_stats->loglevel < 3);
+        disassemble_fragment(dcontext, new_f, d_r_stats->loglevel < 3);
     }
 #endif /* DEBUG */
 
@@ -7996,9 +7999,10 @@ shift_ctis_in_fragment(dcontext_t *dcontext, fragment_t *f, ssize_t shift,
                 /* must not change size! */
                 ASSERT(nxt_pc != NULL && nxt_pc == pc);
 #ifdef DEBUG
-                if ((stats->logmask & LOG_CACHE) != 0) {
-                    loginst(dcontext, 5, &instr,
-                            "shift_ctis_in_fragment: found cti w/ out-of-cache target");
+                if ((d_r_stats->logmask & LOG_CACHE) != 0) {
+                    d_r_loginst(
+                        dcontext, 5, &instr,
+                        "shift_ctis_in_fragment: found cti w/ out-of-cache target");
                 }
 #endif
             }
@@ -8052,7 +8056,7 @@ d_r_emulate(dcontext_t *dcontext, app_pc pc, priv_mcontext_t *mc)
         next_pc = NULL;
         goto emulate_failure;
     }
-    DOLOG(2, LOG_INTERP, { loginst(dcontext, 2, &instr, "emulating"); });
+    DOLOG(2, LOG_INTERP, { d_r_loginst(dcontext, 2, &instr, "emulating"); });
     opc = instr_get_opcode(&instr);
     if (opc == OP_store) {
         opnd_t src = instr_get_src(&instr, 0);

--- a/core/arch/loadtoconst.c
+++ b/core/arch/loadtoconst.c
@@ -78,7 +78,7 @@ analyze_memrefs(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
     LOG(THREAD, LOG_OPTS, 3, "in analyze_memrefs\n");
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 3, "before analyze_memrefs optimization:\n");
-    if (stats->loglevel >= 3)
+    if (d_r_stats->loglevel >= 3)
         instrlist_disassemble(dcontext, 0, trace, THREAD);
 #    endif
 #    ifdef LTC_STATS
@@ -118,8 +118,8 @@ analyze_memrefs(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
             basereg = opnd_get_base(mem_access);
             indexreg = opnd_get_index(mem_access);
 
-            logopnd(dcontext, 3, mem_access, "checking this operand in");
-            loginst(dcontext, 3, instr, "\tthis instruction");
+            d_r_logopnd(dcontext, 3, mem_access, "checking this operand in");
+            d_r_loginst(dcontext, 3, instr, "\tthis instruction");
 
             if (mem_access.size == OPSZ_4_short2 &&
                 !instr_get_prefix_flag(instr, PREFIX_DATA)) {
@@ -128,14 +128,14 @@ analyze_memrefs(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                 LOG(THREAD, LOG_OPTS, 3,
                     "\tthis operand is not size_v or size_d.  its %s: ",
                     size_names[mem_access.size]);
-                loginst(dcontext, 3, instr, "");
+                d_r_loginst(dcontext, 3, instr, "");
                 continue;
             }
 
             if ((basereg != REG_NULL && basereg != REG_EBP) ||
                 (indexreg != REG_NULL && indexreg != REG_EBP)) {
-                logopnd(dcontext, 3, mem_access,
-                        "\tthis mem access reads a sketch register, so forget it");
+                d_r_logopnd(dcontext, 3, mem_access,
+                            "\tthis mem access reads a sketch register, so forget it");
                 continue;
             }
 
@@ -202,7 +202,7 @@ analyze_memrefs(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                 LOG(THREAD, LOG_OPTS, 3,
                     "%d instances of addresses which could be constants",
                     instances_of_address);
-                logopnd(dcontext, 3, mem_access, "");
+                d_r_logopnd(dcontext, 3, mem_access, "");
 
                 if (has_back_arc) {
                     LOG(THREAD, LOG_OPTS, 3, "this trace loops!\n");
@@ -332,10 +332,10 @@ check_mem_refs(app_pc tag, int errno, reg_t eflags, reg_t reg_edi, reg_t reg_esi
 
 #    ifdef DEBUG
         // this block can be removed, its just printing...
-        if (stats->loglevel >= 4) {
+        if (d_r_stats->loglevel >= 4) {
             for (address = 0; address < t_curfrag->ltc.num_mem_addresses; address++) {
-                logopnd(dcontext, 3, t_curfrag->ltc.mem_refs[address].opnd,
-                        "\tgot enough values for");
+                d_r_logopnd(dcontext, 3, t_curfrag->ltc.mem_refs[address].opnd,
+                            "\tgot enough values for");
 
                 for (a = 0; a < NUM_VALUES_FOR_SPECULATION; a++)
 
@@ -372,7 +372,7 @@ check_mem_refs(app_pc tag, int errno, reg_t eflags, reg_t reg_edi, reg_t reg_esi
 #    endif
         {
 #    ifdef DEBUG
-            if (stats->loglevel >= 3) {
+            if (d_r_stats->loglevel >= 3) {
                 LOG(THREAD, LOG_OPTS, 3,
                     "check mem refs returning true for tag " PFX "\n", tag);
                 disassemble_fragment(dcontext, curfrag, 0);
@@ -431,7 +431,7 @@ LTC_online_optimize_and_replace(dcontext_t *dcontext, app_pc tag, fragment_t *cu
     // returning true means that it should jump back to the top of trace
     // need to make sure that the exit is not linked so that
 #    ifdef DEBUG
-    if (stats->loglevel >= 3) {
+    if (d_r_stats->loglevel >= 3) {
         LOG(THREAD, LOG_OPTS, 3, "new fragment after doing ltc\n");
         disassemble_fragment(dcontext, new_f, 0);
     }
@@ -445,7 +445,7 @@ get_mem_address(dcontext_t *dcontext, opnd_t mem_access, int regs[8])
 
     int indexreg, basereg, index, base, scale, disp;
     int *address;
-    logopnd(dcontext, 3, mem_access, "getting this val");
+    d_r_logopnd(dcontext, 3, mem_access, "getting this val");
     ASSERT(opnd_is_near_base_disp(mem_access));
 
     indexreg = opnd_get_index(mem_access);
@@ -488,10 +488,10 @@ get_mem_val(dcontext_t *dcontext, opnd_t mem_access, int address)
         break;
     case OPSZ_1: val = (int)(*(char *)addrp); break;
     case OPSZ_2: val = (int)(*(short *)addrp); break;
-    default: logopnd(dcontext, 3, mem_access, "funky operand"); ASSERT_NOT_REACHED();
+    default: d_r_logopnd(dcontext, 3, mem_access, "funky operand"); ASSERT_NOT_REACHED();
     }
     LOG(THREAD, LOG_OPTS, 3, "in get_mem_val addr= %d ", address);
-    logopnd(dcontext, 3, mem_access, "");
+    d_r_logopnd(dcontext, 3, mem_access, "");
     LOG(THREAD, LOG_OPTS, 3, "value =  " PFX "\n", val);
     return val;
 }
@@ -645,7 +645,7 @@ ltc_trace(dcontext_t *dcontext, fragment_t *frag, instrlist_t *trace)
 
     LOG(THREAD, LOG_OPTS, 3, "trace before ltc_trace\n");
 #    ifdef DEBUG
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, 0, trace, THREAD);
 #    endif
 
@@ -697,8 +697,8 @@ ltc_trace(dcontext_t *dcontext, fragment_t *frag, instrlist_t *trace)
             mem_ref = t_frag->ltc.mem_refs[a].opnd;
             valop = value_to_replace(t_frag->ltc.mem_refs[a]);
 
-            logopnd(dcontext, 3, mem_ref, "\tthis memory ref");
-            logopnd(dcontext, 3, valop, "\tgets this value");
+            d_r_logopnd(dcontext, 3, mem_ref, "\tthis memory ref");
+            d_r_logopnd(dcontext, 3, valop, "\tgets this value");
 
             do_single_LTC(dcontext, opt_trace, mem_ref, valop);
 #    ifdef LTC_STATS
@@ -728,14 +728,14 @@ ltc_trace(dcontext_t *dcontext, fragment_t *frag, instrlist_t *trace)
                 INSTR_CREATE_jcc(dcontext, OP_jne, opnd_create_instr(top_safe)));
 
         } else {
-            logopnd(dcontext, 3, t_frag->ltc.mem_refs[a].opnd,
-                    "not replacing me because of bad sampled vals");
+            d_r_logopnd(dcontext, 3, t_frag->ltc.mem_refs[a].opnd,
+                        "not replacing me because of bad sampled vals");
         }
     }
 
     LOG(THREAD, LOG_OPTS, 3, "after ltc");
 #    ifdef DEBUG
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, 0, trace, THREAD);
 #    endif
 
@@ -774,7 +774,7 @@ ltc_trace(dcontext_t *dcontext, fragment_t *frag, instrlist_t *trace)
 
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 3, "after LTC optimization:\n");
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, 0, trace, THREAD);
 #    endif
 }
@@ -792,37 +792,37 @@ do_single_LTC(dcontext_t *dcontext, instrlist_t *trace, opnd_t mem_access,
 
     while (in) {
         next = instr_get_next(in);
-        loginst(dcontext, 3, in, "in_single_LTC, examining");
+        d_r_loginst(dcontext, 3, in, "in_single_LTC, examining");
         ASSERT(instr_is_encoding_possible(in));
         if (instr_reads_memory(in)) { // could this be if (!op_lea)
             instr_mem_access = instr_get_src_mem_access(in);
             if (opnd_same_address(instr_mem_access, mem_access)) {
                 if (instr_get_opcode(in) == OP_mov_ld) {
-                    loginst(dcontext, 3, in, "\tdoing LTC on mov");
-                    logopnd(dcontext, 3, mem_access, "replacing this operand");
-                    logopnd(dcontext, 3, const_value, "with this");
+                    d_r_loginst(dcontext, 3, in, "\tdoing LTC on mov");
+                    d_r_logopnd(dcontext, 3, mem_access, "replacing this operand");
+                    d_r_logopnd(dcontext, 3, const_value, "with this");
                     instr_set_opcode(in, OP_mov_imm);
                     instr_replace_src_opnd(in, mem_access, const_value);
                 } else if (instr_get_opcode(in) == OP_cmp) {
                     opnd_t orig_op1, orig_op2;
                     orig_op1 = instr_get_src(in, 0);
                     orig_op2 = instr_get_src(in, 1);
-                    loginst(dcontext, 3, in, "\tdoing LTC on cmp");
-                    logopnd(dcontext, 3, const_value, "\tnewvalue");
+                    d_r_loginst(dcontext, 3, in, "\tdoing LTC on cmp");
+                    d_r_logopnd(dcontext, 3, const_value, "\tnewvalue");
                     instr_replace_src_opnd(in, mem_access, const_value);
-                    loginst(dcontext, 3, in, "\tafter replacing mem access");
+                    d_r_loginst(dcontext, 3, in, "\tafter replacing mem access");
 
                     next = fix_cmp_containing_constant(dcontext, trace, in, orig_op1,
                                                        orig_op2);
                 } else {
                     // try to replace and see if its encodable
-                    loginst(dcontext, 3, in, "\tdoing LTC on a non mov, cmp");
+                    d_r_loginst(dcontext, 3, in, "\tdoing LTC on a non mov, cmp");
                     instr_replace_src_opnd(in, instr_mem_access, const_value);
                     if (!instr_is_encoding_possible(in)) {
                         instr_replace_src_opnd(in, const_value, instr_mem_access);
                         ASSERT(instr_is_encoding_possible(in));
                     }
-                    loginst(dcontext, 3, in, "\tafter replacing mem access");
+                    d_r_loginst(dcontext, 3, in, "\tafter replacing mem access");
                     instr_arithmatic_simplify(dcontext, in);
                 }
             }
@@ -862,7 +862,8 @@ fix_cmp_containing_constant(dcontext_t *dcontext, instrlist_t *trace, instr_t *i
                  ((instr_get_arith_flags(jcc, DR_QUERY_DEFAULT) & EFLAGS_WRITE_6) == 0);
                  jcc = instr_get_next(jcc)) {
                 if (instr_is_cbr(jcc)) {
-                    loginst(dcontext, 3, jcc, "change_cbr_due_to_reversed_cmp called on");
+                    d_r_loginst(dcontext, 3, jcc,
+                                "change_cbr_due_to_reversed_cmp called on");
                     change_cbr_due_to_reversed_cmp(jcc);
                 }
             }
@@ -870,7 +871,7 @@ fix_cmp_containing_constant(dcontext_t *dcontext, instrlist_t *trace, instr_t *i
                  // stuff
             instr_set_src(in, 0, orig_op1);
             instr_set_src(in, 1, orig_op2);
-            loginst(
+            d_r_loginst(
                 dcontext, 3, in,
                 "wasn't swappable, even though one opnd was a reg. whats up with that?");
             ASSERT_CURIOSITY(false);
@@ -882,12 +883,12 @@ fix_cmp_containing_constant(dcontext_t *dcontext, instrlist_t *trace, instr_t *i
              safe_to_delete_cmp(dcontext, in)) { // cmp gets two constants
         int op1, op2;
         instr_t *nextjcc;
-        loginst(dcontext, 3, in, "swapping order didn't help, must be 2 constants");
+        d_r_loginst(dcontext, 3, in, "swapping order didn't help, must be 2 constants");
 
         op1 = (int)opnd_get_immed_int(instr_get_src(in, 0));
         op2 = (int)opnd_get_immed_int(instr_get_src(in, 1));
 
-        loginst(dcontext, 3, in, "got the two constants");
+        d_r_loginst(dcontext, 3, in, "got the two constants");
 
         ASSERT(instr_get_opcode(in) == OP_cmp);
 
@@ -895,26 +896,26 @@ fix_cmp_containing_constant(dcontext_t *dcontext, instrlist_t *trace, instr_t *i
              ((instr_get_arith_flags(jcc, DR_QUERY_DEFAULT) & EFLAGS_WRITE_6) == 0);
              jcc = nextjcc) {
             nextjcc = instr_get_next(jcc);
-            loginst(dcontext, 3, jcc, "walking to try to remove cmp");
+            d_r_loginst(dcontext, 3, jcc, "walking to try to remove cmp");
             if (instr_is_cbr(jcc)) {
                 if (becomes_ubr_from_cmp(jcc, op1, op2)) {
                     // the cbr becomes an unconditional jmp
-                    loginst(dcontext, 3, jcc, "becomes an unconditional jmp");
+                    d_r_loginst(dcontext, 3, jcc, "becomes an unconditional jmp");
                     instr_set_opcode(jcc, OP_jmp);
                     ASSERT(instr_is_encoding_possible(jcc));
 
                     jcc = instr_get_next(jcc);
                     while (jcc) { // removing instrs after jmp
                         nextjcc = instr_get_next(jcc);
-                        loginst(dcontext, 3, jcc,
-                                "removed because it follows an unconditional jmp");
+                        d_r_loginst(dcontext, 3, jcc,
+                                    "removed because it follows an unconditional jmp");
                         instrlist_remove(trace, jcc);
                         instr_destroy(dcontext, jcc);
                         jcc = nextjcc;
                     }
                     nextjcc = NULL;
                 } else { // otherwise never jumps, so remove
-                    loginst(dcontext, 3, jcc, "will never jmp, so removed");
+                    d_r_loginst(dcontext, 3, jcc, "will never jmp, so removed");
                     instrlist_remove(trace, jcc);
                     instr_destroy(dcontext, jcc);
                 }
@@ -923,8 +924,8 @@ fix_cmp_containing_constant(dcontext_t *dcontext, instrlist_t *trace, instr_t *i
 
         // remove the cmp instruction
         next = instr_get_next(in);
-        loginst(dcontext, 3, in, "this cmp isn't needed, so remove");
-        loginst(dcontext, 3, next, "setting next to");
+        d_r_loginst(dcontext, 3, in, "this cmp isn't needed, so remove");
+        d_r_loginst(dcontext, 3, next, "setting next to");
         instrlist_remove(trace, in);
         instr_destroy(dcontext, in);
         in = NULL;
@@ -932,14 +933,15 @@ fix_cmp_containing_constant(dcontext_t *dcontext, instrlist_t *trace, instr_t *i
     } else { // if none of that shit helped the situation, put back original cmp operands
         instr_set_src(in, 0, orig_op1);
         instr_set_src(in, 1, orig_op2);
-        loginst(dcontext, 3, in,
-                "wasn't able to fix this instr by either removing or transposing cmp, "
-                "original opnds back");
+        d_r_loginst(
+            dcontext, 3, in,
+            "wasn't able to fix this instr by either removing or transposing cmp, "
+            "original opnds back");
         ASSERT(instr_is_encoding_possible(in));
     }
 
     if (in && !instr_is_encoding_possible(in)) {
-        loginst(dcontext, 0, in, "error encoding me");
+        d_r_loginst(dcontext, 0, in, "error encoding me");
         ASSERT_NOT_REACHED();
     }
     return next;
@@ -1021,11 +1023,11 @@ safe_to_modify_cmp(dcontext_t *dcontext, instr_t *testinstr, bool transpose)
     for (in = instr_get_next(testinstr); in != NULL; in = instr_get_next(in)) {
         eflags = instr_get_arith_flags(in, DR_QUERY_DEFAULT);
 
-        loginst(dcontext, 3, in, "\texamining");
+        d_r_loginst(dcontext, 3, in, "\texamining");
 
         // if the jump is always taken
         if (instr_is_exit_cti(in)) {
-            loginst(dcontext, 3, in, "\texit cti");
+            d_r_loginst(dcontext, 3, in, "\texit cti");
             if (cmp_both_ops_immed && instr_is_cbr(in)) {
                 ASSERT(instr_get_opcode(testinstr) == OP_cmp);
 
@@ -1036,12 +1038,12 @@ safe_to_modify_cmp(dcontext_t *dcontext, instr_t *testinstr, bool transpose)
                         // if the jump is always taken
                         if (pc_reads_flags_before_writes(
                                 dcontext, opnd_get_pc(instr_get_target(in)))) {
-                            loginst(
+                            d_r_loginst(
                                 dcontext, 3, in,
                                 "jcc always taken, but dest pc depends on flags, true");
                             return false; // if dest pc depends on the flags
                         } else {
-                            loginst(
+                            d_r_loginst(
                                 dcontext, 3, in,
                                 "jcc always taken,  dest pc overwrites flag, ret false");
                             return true; // if dest pc doesn't depend on flags, then safe
@@ -1055,12 +1057,12 @@ safe_to_modify_cmp(dcontext_t *dcontext, instr_t *testinstr, bool transpose)
                         // if the jump is always taken
                         if (pc_reads_flags_before_writes(
                                 dcontext, opnd_get_pc(instr_get_target(in)))) {
-                            loginst(
+                            d_r_loginst(
                                 dcontext, 3, in,
                                 "jcc always taken, but dest pc depends on flags, true");
                             return false; // if dest pc depends on the flags
                         } else {
-                            loginst(
+                            d_r_loginst(
                                 dcontext, 3, in,
                                 "jcc always taken,  dest pc overwrites flag, ret false");
                             return true; // if dest pc doesn't depend on flags, then safe
@@ -1072,23 +1074,26 @@ safe_to_modify_cmp(dcontext_t *dcontext, instr_t *testinstr, bool transpose)
             // if not a cbr, then you have to assume the branch is taken
             else if (pc_reads_flags_before_writes(dcontext,
                                                   opnd_get_pc(instr_get_target(in)))) {
-                loginst(dcontext, 3, in,
-                        "\tin safe_to_modify_cmp, this CBR may be taken and reads flags "
-                        "before writing");
+                d_r_loginst(
+                    dcontext, 3, in,
+                    "\tin safe_to_modify_cmp, this CBR may be taken and reads flags "
+                    "before writing");
                 return false;
             } else {
-                loginst(dcontext, 3, in,
-                        "\tin safe_to_modify_cmp, this CBR may be taken but it writes "
-                        "before reads, so the cmp can be changed");
+                d_r_loginst(
+                    dcontext, 3, in,
+                    "\tin safe_to_modify_cmp, this CBR may be taken but it writes "
+                    "before reads, so the cmp can be changed");
             }
         } else {
             if ((eflags & EFLAGS_READ_6) != 0) {
-                loginst(dcontext, 3, in,
-                        "\treads the flags. cmp needed treturning false: ");
+                d_r_loginst(dcontext, 3, in,
+                            "\treads the flags. cmp needed treturning false: ");
                 return false;
             }
             if ((eflags & EFLAGS_WRITE_6) != 0) {
-                loginst(dcontext, 3, in, "\twritesthe flags. cmp not needed, ret true:");
+                d_r_loginst(dcontext, 3, in,
+                            "\twritesthe flags. cmp not needed, ret true:");
                 return true;
             }
         }
@@ -1107,7 +1112,7 @@ pc_reads_flags_before_writes(dcontext_t *dcontext, app_pc target)
     do {
         target = decode_eflags_usage(dcontext, target, &eflags, DR_QUERY_DEFAULT);
         if ((eflags & EFLAGS_READ_6) != 0) {
-            loginst(dcontext, 3, &tinst, "reads cmpflags before writing");
+            d_r_loginst(dcontext, 3, &tinst, "reads cmpflags before writing");
             return true;
         }
         /* if writes but doesn't read, ok */
@@ -1210,7 +1215,7 @@ should_replace_load(dcontext_t *dcontext, struct ltc_mem_ref_data data)
     int freq[NUM_VALUES_FOR_SPECULATION];
     int a, b, curval;
 
-    logopnd(dcontext, 3, data.opnd, "in should_replace_load on this operand");
+    d_r_logopnd(dcontext, 3, data.opnd, "in should_replace_load on this operand");
 
     for (a = 0; a < NUM_VALUES_FOR_SPECULATION; a++) {
         curval = data.vals[a];
@@ -1240,7 +1245,7 @@ should_replace_load(dcontext_t *dcontext, struct ltc_mem_ref_data data)
 
     // if it got this far, then there are no values that happen more than half the time
     // so we shouldn't replace
-    logopnd(dcontext, 3, data.opnd, "should_replace_load returning false on");
+    d_r_logopnd(dcontext, 3, data.opnd, "should_replace_load returning false on");
     return false;
 }
 
@@ -1348,7 +1353,7 @@ constant_propagate(dcontext_t *dcontext, instrlist_t *trace, app_pc tag)
     opnd_t regop, orig1, orig2;
     LOG(THREAD, LOG_OPTS, 3, "before constant_propagate\n");
 #    ifdef DEBUG
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, 0, trace, THREAD);
 #    endif
 
@@ -1360,7 +1365,7 @@ constant_propagate(dcontext_t *dcontext, instrlist_t *trace, app_pc tag)
             reg = opnd_get_reg(regop);
 
             LOG(THREAD, LOG_OPTS, 3, "reg=%s, val=" PFX " ", reg_names[reg], cons);
-            loginst(dcontext, 3, instr, "trying to remove me via constant prop");
+            d_r_loginst(dcontext, 3, instr, "trying to remove me via constant prop");
 
             conwalker = instr_get_next(instr);
             mov_immed_needed = false;
@@ -1372,7 +1377,7 @@ constant_propagate(dcontext_t *dcontext, instrlist_t *trace, app_pc tag)
                     opnd_t target = instr_get_target(conwalker);
                     if (opnd_is_near_pc(target) && (opnd_get_pc(target) == tag)) {
 
-                        loginst(dcontext, 3, conwalker, "this CTI is a self-loop");
+                        d_r_loginst(dcontext, 3, conwalker, "this CTI is a self-loop");
                         if (instrlist_depends_on_reg(dcontext, trace, reg)) {
                             LOG(THREAD, LOG_OPTS, 3,
                                 "\tsubsequent loop iteration needs the val, so keep "
@@ -1386,24 +1391,25 @@ constant_propagate(dcontext_t *dcontext, instrlist_t *trace, app_pc tag)
 
                     else {
                         instr_t *foo;
-                        loginst(dcontext, 3, conwalker,
-                                "reached cti without overwriting reg, trying to add "
-                                "instr to the pseudo exitstub");
-                        loginst(dcontext, 3, conwalker, "this CTI is NOT a self-loop");
+                        d_r_loginst(dcontext, 3, conwalker,
+                                    "reached cti without overwriting reg, trying to add "
+                                    "instr to the pseudo exitstub");
+                        d_r_loginst(dcontext, 3, conwalker,
+                                    "this CTI is NOT a self-loop");
                         instr_add_to_exitexec_list(dcontext, conwalker,
                                                    instr_clone(dcontext, instr));
 
 #    ifdef DEBUG
-                        if (stats->loglevel >= 3)
+                        if (d_r_stats->loglevel >= 3)
                             for (foo = instr; foo != conwalker->next;
                                  foo = instr_get_next(foo))
-                                loginst(dcontext, 3, foo, "\twalking\t");
+                                d_r_loginst(dcontext, 3, foo, "\twalking\t");
 #    endif
                     }
                 } else if (instr_get_opcode(conwalker) ==
                            OP_lahf /*to catch ind branch*/) {
-                    loginst(dcontext, 3, conwalker,
-                            "reached cti without overwriting reg, mov_imm needed");
+                    d_r_loginst(dcontext, 3, conwalker,
+                                "reached cti without overwriting reg, mov_imm needed");
                     mov_immed_needed = true;
                 }
 
@@ -1411,14 +1417,16 @@ constant_propagate(dcontext_t *dcontext, instrlist_t *trace, app_pc tag)
                                                          cons)) {
                     if (instr_get_opcode(conwalker) == OP_cmp) {
                         instr_t *oldnext;
-                        loginst(dcontext, 3, conwalker, "trying to optimize this cmp");
+                        d_r_loginst(dcontext, 3, conwalker,
+                                    "trying to optimize this cmp");
                         orig1 = instr_get_src(conwalker, 0);
                         orig2 = instr_get_src(conwalker, 1);
 
                         // replace the register with the constant
-                        logopnd(dcontext, 3, regop, "trying to replace this operand");
+                        d_r_logopnd(dcontext, 3, regop, "trying to replace this operand");
                         instr_replace_src_opnd(conwalker, regop, OPND_CREATE_INT32(cons));
-                        loginst(dcontext, 3, conwalker, "replaced reg with const int");
+                        d_r_loginst(dcontext, 3, conwalker,
+                                    "replaced reg with const int");
                         // if they're both immeds
                         oldnext = conwalker_next;
                         conwalker_next = fix_cmp_containing_constant(
@@ -1426,28 +1434,29 @@ constant_propagate(dcontext_t *dcontext, instrlist_t *trace, app_pc tag)
                         if (oldnext == conwalker_next)
                             mov_immed_needed = true;
                     } else { // if its not a compare
-                        loginst(dcontext, 3, conwalker,
-                                "couldn't replace reg in src, mov_immed needed");
+                        d_r_loginst(dcontext, 3, conwalker,
+                                    "couldn't replace reg in src, mov_immed needed");
                         mov_immed_needed = true;
                     }
                 }
 
                 if (!instr_replace_reg_with_const_in_dst(dcontext, conwalker, reg,
                                                          cons)) {
-                    loginst(dcontext, 3, conwalker,
-                            "couldn't replace reg in dst, mov_immed needed");
+                    d_r_loginst(dcontext, 3, conwalker,
+                                "couldn't replace reg in dst, mov_immed needed");
                     mov_immed_needed = true;
                 }
 
                 if (instr_writes_to_reg(conwalker, reg)) {
-                    loginst(dcontext, 3, conwalker, "writes to the reg, so move on");
+                    d_r_loginst(dcontext, 3, conwalker, "writes to the reg, so move on");
                     reg_overwritten = true;
                     // if it doesn't overwrite the entire register
                     // then there is still a dependancy on the full 32 bit previous value
                     // so keep the immediate... man, x86 sucks
                     if (!instr_writes_to_exact_reg(conwalker, reg)) {
                         mov_immed_needed = true;
-                        loginst(dcontext, 3, conwalker, "\tmov_imm needed because of me");
+                        d_r_loginst(dcontext, 3, conwalker,
+                                    "\tmov_imm needed because of me");
                     }
                     break;
                 }
@@ -1471,12 +1480,12 @@ constant_propagate(dcontext_t *dcontext, instrlist_t *trace, app_pc tag)
                  */
 
                 if (instr == instrlist_first(trace)) {
-                    loginst(dcontext, 3, instr,
-                            "trying to remove the first item in the trace");
+                    d_r_loginst(dcontext, 3, instr,
+                                "trying to remove the first item in the trace");
                     replace_self_loop_with_opnd(dcontext, (size_t)0, trace,
                                                 opnd_create_instr(next));
                 }
-                loginst(dcontext, 3, instr, "this mov imm isn't needed, remove");
+                d_r_loginst(dcontext, 3, instr, "this mov imm isn't needed, remove");
                 instrlist_remove(trace, instr);
                 instr_destroy(dcontext, instr);
                 instr = next;
@@ -1489,7 +1498,7 @@ constant_propagate(dcontext_t *dcontext, instrlist_t *trace, app_pc tag)
 
     LOG(THREAD, LOG_OPTS, 3, "after constant_propagate\n");
 #    ifdef DEBUG
-    if (stats->loglevel >= 3)
+    if (d_r_stats->loglevel >= 3)
         instrlist_disassemble(dcontext, 0, trace, THREAD);
 #    endif
 }
@@ -1514,7 +1523,7 @@ instr_replace_reg_with_const_in_src(dcontext_t *dcontext, instr_t *in, int reg, 
 
         if (opnd_replace_reg_with_val(&op, reg, val)) {
             instr_set_src(in, a, op);
-            loginst(dcontext, 3, in, "replaced by this in src");
+            d_r_loginst(dcontext, 3, in, "replaced by this in src");
             // THIS SHOULD BE FIXED BY FIXING is_encoding_possible so it doesn't
             // give true when there is a constant in a rep* instruction
             // when thats fixed, then the next if statement can be
@@ -1523,7 +1532,7 @@ instr_replace_reg_with_const_in_src(dcontext_t *dcontext, instr_t *in, int reg, 
             if ((instr_get_opcode(in) == OP_rep_cmps ||
                  instr_get_opcode(in) == OP_rep_movs) &&
                 (reg == REG_ECX)) {
-                loginst(dcontext, 3, in, "quirk involving rep* instructions and ECX");
+                d_r_loginst(dcontext, 3, in, "quirk involving rep* instructions and ECX");
                 instr_set_src(in, a, oldop);
                 return false;
             }
@@ -1533,7 +1542,7 @@ instr_replace_reg_with_const_in_src(dcontext_t *dcontext, instr_t *in, int reg, 
                able to do some arithmetic simplification with this case).
             */
             if (instr_reg_in_src(in, reg)) {
-                loginst(
+                d_r_loginst(
                     dcontext, 3, in,
                     "FIXME: doesn't yet handle two src instances of the same register");
                 instr_set_src(in, a, oldop);
@@ -1544,11 +1553,11 @@ instr_replace_reg_with_const_in_src(dcontext_t *dcontext, instr_t *in, int reg, 
         }
 
         if (!instr_is_encoding_possible(in)) {
-            loginst(dcontext, 3, in,
-                    "replace_reg_with_const: encoding not possible, so putting back "
-                    "original");
+            d_r_loginst(dcontext, 3, in,
+                        "replace_reg_with_const: encoding not possible, so putting back "
+                        "original");
             instr_set_src(in, a, oldop);
-            loginst(dcontext, 3, in, "original instr");
+            d_r_loginst(dcontext, 3, in, "original instr");
             ASSERT(instr_is_encoding_possible(in));
             return false;
         }
@@ -1569,13 +1578,13 @@ instr_replace_reg_with_const_in_dst(dcontext_t *dcontext, instr_t *in, int reg, 
 
             if (opnd_replace_reg_with_val(&op, reg, val)) {
                 instr_set_dst(in, a, op);
-                loginst(dcontext, 3, in, "replaced by this in dst");
+                d_r_loginst(dcontext, 3, in, "replaced by this in dst");
             }
             if (!instr_is_encoding_possible(in)) {
-                loginst(dcontext, 3, in,
-                        "encoding not possible, so putting back original");
+                d_r_loginst(dcontext, 3, in,
+                            "encoding not possible, so putting back original");
                 instr_set_dst(in, a, oldop);
-                loginst(dcontext, 3, in, "original instr");
+                d_r_loginst(dcontext, 3, in, "original instr");
                 ASSERT(instr_is_encoding_possible(in));
                 return false;
             }
@@ -1670,17 +1679,17 @@ replace_self_loop_with_opnd(dcontext_t *dcontext, app_pc tag, instrlist_t *trace
 
     while (in != NULL) {
 #    ifdef DEBUG
-        loginst(dcontext, 3, in, "examining me in replace self loop");
+        d_r_loginst(dcontext, 3, in, "examining me in replace self loop");
         LOG(THREAD, LOG_OPTS, 3, "my bytes are: " PFX "\n", in->bytes);
 #    endif
         if (instr_is_cbr(in) || instr_is_ubr(in)) {
             targetop = instr_get_target(in);
             if (opnd_is_near_pc(targetop) && opnd_get_pc(targetop) == tag) {
-                loginst(dcontext, 3, in, "self_loop (pc target==tag) fixing in");
+                d_r_loginst(dcontext, 3, in, "self_loop (pc target==tag) fixing in");
                 instr_set_target(in, desiredtarget);
             } else if (opnd_is_near_instr(targetop) && opnd_get_instr(targetop) == top) {
-                loginst(dcontext, 3, in, "self_loop (inter traget==top)fixing in");
-                logopnd(dcontext, 3, desiredtarget, "self_loop in now points to");
+                d_r_loginst(dcontext, 3, in, "self_loop (inter traget==top)fixing in");
+                d_r_logopnd(dcontext, 3, desiredtarget, "self_loop in now points to");
                 instr_set_target(in, desiredtarget);
             }
         }
@@ -1700,7 +1709,7 @@ instr_arithmatic_simplify(dcontext_t *dcontext, instr_t *in)
     instr_t *newinstr = NULL;
     int opcode;
     int newvalue;
-    loginst(dcontext, 3, in, "arithmatic simplify called on");
+    d_r_loginst(dcontext, 3, in, "arithmatic simplify called on");
 
     opcode = instr_get_opcode(in);
     if (instr_flag_write_necessary(dcontext, in))
@@ -1726,18 +1735,18 @@ instr_arithmatic_simplify(dcontext_t *dcontext, instr_t *in)
         case OP_fild:
         case OP_fld:
             if (val==0 && opnd_is_reg(dst)&& (opnd_get_reg(dst)==REG_ST0)) {
-                loginst(dcontext,3,in,"arithmatic simplify: making fload of 0 to store!");
-                newinstr=INSTR_CREATE_fldz(dcontext);
-                break;
+                d_r_loginst(dcontext,3,in,
+                            "arithmatic simplify: making fload of 0 to store!");
+                newinstr=INSTR_CREATE_fldz(dcontext); break;
             }
             */
         case OP_inc:
-            loginst(dcontext, 3, in, "arithmatic simplify: making inc to store!");
+            d_r_loginst(dcontext, 3, in, "arithmatic simplify: making inc to store!");
             newinstr = INSTR_CREATE_mov_imm(dcontext, instr_get_dst(in, 0),
                                             OPND_CREATE_INT32(val + 1));
             break;
         case OP_dec:
-            loginst(dcontext, 3, in, "arithmatic simplify: making dec to store!");
+            d_r_loginst(dcontext, 3, in, "arithmatic simplify: making dec to store!");
             newinstr = INSTR_CREATE_mov_imm(dcontext, instr_get_dst(in, 0),
                                             OPND_CREATE_INT32(val - 1));
             break;
@@ -1766,43 +1775,43 @@ instr_arithmatic_simplify(dcontext_t *dcontext, instr_t *in)
                 newvalue = val2 + val1;
                 newinstr =
                     INSTR_CREATE_mov_imm(dcontext, dst, OPND_CREATE_INT32(newvalue));
-                loginst(dcontext, 3, in, "arithmatic simplify: OP_ADD!");
+                d_r_loginst(dcontext, 3, in, "arithmatic simplify: OP_ADD!");
                 break;
             case OP_imul:
                 newvalue = val2 * val1;
                 newinstr =
                     INSTR_CREATE_mov_imm(dcontext, dst, OPND_CREATE_INT32(newvalue));
-                loginst(dcontext, 3, in, "arithmatic simplify: OP_imul!");
+                d_r_loginst(dcontext, 3, in, "arithmatic simplify: OP_imul!");
                 break;
             case OP_mul:
                 newvalue = (unsigned)val2 * (unsigned)val1;
                 newinstr =
                     INSTR_CREATE_mov_imm(dcontext, dst, OPND_CREATE_INT32(newvalue));
-                loginst(dcontext, 3, in, "arithmatic simplify: OP_mul!");
+                d_r_loginst(dcontext, 3, in, "arithmatic simplify: OP_mul!");
                 break;
             case OP_and:
                 newvalue = val2 & val1;
                 newinstr =
                     INSTR_CREATE_mov_imm(dcontext, dst, OPND_CREATE_INT32(newvalue));
-                loginst(dcontext, 3, in, "arithmatic simplify: OP_and!");
+                d_r_loginst(dcontext, 3, in, "arithmatic simplify: OP_and!");
                 break;
             case OP_or:
                 newvalue = val2 | val1;
                 newinstr =
                     INSTR_CREATE_mov_imm(dcontext, dst, OPND_CREATE_INT32(newvalue));
-                loginst(dcontext, 3, in, "arithmatic simplify: OP_or!");
+                d_r_loginst(dcontext, 3, in, "arithmatic simplify: OP_or!");
                 break;
             case OP_xor:
                 newvalue = val2 ^ val1;
                 newinstr =
                     INSTR_CREATE_mov_imm(dcontext, dst, OPND_CREATE_INT32(newvalue));
-                loginst(dcontext, 3, in, "arithmatic simplify: OP_xor!");
+                d_r_loginst(dcontext, 3, in, "arithmatic simplify: OP_xor!");
                 break;
             case OP_sub:
                 newvalue = val2 - val1;
                 newinstr =
                     INSTR_CREATE_mov_imm(dcontext, dst, OPND_CREATE_INT32(newvalue));
-                loginst(dcontext, 3, in, "arithmatic simplify: OP_sub!");
+                d_r_loginst(dcontext, 3, in, "arithmatic simplify: OP_sub!");
                 break;
             }
         } else if (opnd_is_immed_int(op1) || opnd_is_immed_int(op2)) {
@@ -1821,20 +1830,21 @@ instr_arithmatic_simplify(dcontext_t *dcontext, instr_t *in)
             case OP_and:
                 if (cons == 0xffffffff) {
                     newinstr = INSTR_CREATE_nop(dcontext);
-                    loginst(dcontext, 3, in,
-                            "arithmatic simplify: turned OP_and to OP_nop");
+                    d_r_loginst(dcontext, 3, in,
+                                "arithmatic simplify: turned OP_and to OP_nop");
                 } else if (cons == 0) {
 
                     if (opnd_is_reg(dst)) {
                         newinstr = INSTR_CREATE_xor(dcontext, dst, dst);
-                        loginst(dcontext, 3, in,
-                                "arithmatic simplify: turned OP_and to zeroing xor");
+                        d_r_loginst(dcontext, 3, in,
+                                    "arithmatic simplify: turned OP_and to zeroing xor");
                     } else {
                         ASSERT(opnd_is_memory_reference(dst));
                         newinstr =
                             INSTR_CREATE_mov_imm(dcontext, dst, OPND_CREATE_INT32(0));
-                        loginst(dcontext, 3, in,
-                                "arithmatic simplify: turned OP_and to zeroing mov_imm");
+                        d_r_loginst(
+                            dcontext, 3, in,
+                            "arithmatic simplify: turned OP_and to zeroing mov_imm");
                     }
                 }
                 break;
@@ -1843,26 +1853,27 @@ instr_arithmatic_simplify(dcontext_t *dcontext, instr_t *in)
                 if (cons == 0xffffffff) {
                     newinstr = INSTR_CREATE_mov_imm(dcontext, dst,
                                                     OPND_CREATE_INT32(0xffffffff));
-                    loginst(dcontext, 3, in,
-                            "arithmatic simplify: turned OP_or into mov 0xffffffff");
+                    d_r_loginst(dcontext, 3, in,
+                                "arithmatic simplify: turned OP_or into mov 0xffffffff");
                 } else if (cons == 0) {
                     newinstr = INSTR_CREATE_nop(dcontext);
-                    loginst(dcontext, 3, in,
-                            "arithmatic simplify: turned OP_or into nop");
+                    d_r_loginst(dcontext, 3, in,
+                                "arithmatic simplify: turned OP_or into nop");
                 }
                 break;
             case OP_add:
                 if (cons == 0) {
                     newinstr = INSTR_CREATE_nop(dcontext);
-                    loginst(dcontext, 3, in,
-                            "arithmatic simplify: turned OP_add into nop");
+                    d_r_loginst(dcontext, 3, in,
+                                "arithmatic simplify: turned OP_add into nop");
                 }
                 break;
             case OP_sub:
                 /* fixme
                 if (cons==0) {
                     newinstr=INSTR_CREATE_nop(dcontext);
-                    loginst(dcontext,3,in,"arithmatic simplify: turned OP_sub into nop");
+                    d_r_loginst(dcontext,3,in,"arithmatic simplify: turned OP_sub into
+                nop");
                 }
                 */
                 break;
@@ -1870,12 +1881,12 @@ instr_arithmatic_simplify(dcontext_t *dcontext, instr_t *in)
             case OP_imul:
                 if (cons == 1) {
                     newinstr = INSTR_CREATE_nop(dcontext);
-                    loginst(dcontext, 3, in,
-                            "arithmatic simplify: turned OP_add into nop");
+                    d_r_loginst(dcontext, 3, in,
+                                "arithmatic simplify: turned OP_add into nop");
                 } else if (cons == 0) {
                     newinstr = INSTR_CREATE_mov_imm(dcontext, dst, OPND_CREATE_INT32(0));
-                    loginst(dcontext, 3, in,
-                            "arithmatic simplify: turned OP_mul with 0 to mov_immed");
+                    d_r_loginst(dcontext, 3, in,
+                                "arithmatic simplify: turned OP_mul with 0 to mov_immed");
                 }
                 break;
             }
@@ -1883,7 +1894,7 @@ instr_arithmatic_simplify(dcontext_t *dcontext, instr_t *in)
     }
 
     if (newinstr) {
-        loginst(dcontext, 3, newinstr, "with me");
+        d_r_loginst(dcontext, 3, newinstr, "with me");
 
         ASSERT(instr_is_encoding_possible(newinstr));
 
@@ -1967,7 +1978,7 @@ instr_add_to_exitexec_list(dcontext_t *dcontext, instr_t *in, instr_t *exitinstr
         in->exitlist = instrlist_create(dcontext);
 
     instrlist_append(in->exitlist, exitinstr);
-    loginst(dcontext, 3, exitinstr, "adding this to exit list");
+    d_r_loginst(dcontext, 3, exitinstr, "adding this to exit list");
     LOG(THREAD, LOG_OPTS, 3, "exitinstr=" PFX "\n", exitinstr);
 }
 void
@@ -1983,7 +1994,7 @@ instrlist_setup_pseudo_exitstubs(dcontext_t *dcontext, instrlist_t *trace)
             ASSERT(instr_is_cti(instr));
             instrlist_append(instr->exitlist,
                              INSTR_CREATE_jmp(dcontext, instr_get_target(instr)));
-            loginst(dcontext, 3, instr, "setting up pseudo exit stub for me");
+            d_r_loginst(dcontext, 3, instr, "setting up pseudo exit stub for me");
 
             newtarget = instrlist_first(instr->exitlist);
             instrlist_append_instrlist(dcontext, exitlist, instr->exitlist);
@@ -1994,8 +2005,8 @@ instrlist_setup_pseudo_exitstubs(dcontext_t *dcontext, instrlist_t *trace)
 
             instr->exitlist = NULL;
 #    ifdef DEBUG
-            if (stats->loglevel >= 3) {
-                loginst(dcontext, 3, instr, "after setting");
+            if (d_r_stats->loglevel >= 3) {
+                d_r_loginst(dcontext, 3, instr, "after setting");
                 instrlist_disassemble(dcontext, 0, trace, THREAD);
                 instrlist_disassemble(dcontext, 0, exitlist, THREAD);
             }

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -776,8 +776,8 @@ mangle_syscall_code(dcontext_t *dcontext, fragment_t *f, byte *pc, bool skip)
  * inserted instr -- but this slows down encoding in current implementation
  */
 void
-mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags INOUT, bool mangle_calls,
-       bool record_translation)
+d_r_mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags INOUT, bool mangle_calls,
+           bool record_translation)
 {
     instr_t *instr, *next_instr;
 #ifdef WINDOWS

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2776,7 +2776,7 @@ enum {
     REGPARM_END_ALIGN = 8,
 #endif
 };
-extern const reg_id_t regparms[];
+extern const reg_id_t d_r_regparms[];
 
 /* arch-specific */
 uint

--- a/core/arch/opnd_shared.c
+++ b/core/arch/opnd_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1106,7 +1106,7 @@ opnd_get_reg_used(opnd_t opnd, int index)
 /***************************************************************************/
 /* utility routines */
 
-const reg_id_t regparms[] = {
+const reg_id_t d_r_regparms[] = {
 #ifdef X86
 #    ifdef X64
     REGPARM_0,  REGPARM_1, REGPARM_2, REGPARM_3,
@@ -1838,7 +1838,7 @@ opnd_compute_address_helper(opnd_t opnd, priv_mcontext_t *mc, ptr_int_t scaled_i
     addr = seg_base;
     base = opnd_get_base(opnd);
     disp = opnd_get_disp(opnd);
-    logopnd(get_thread_private_dcontext(), 4, opnd, "opnd_compute_address for");
+    d_r_logopnd(get_thread_private_dcontext(), 4, opnd, "opnd_compute_address for");
     addr += reg_get_value_priv(base, mc);
     LOG(THREAD_GET, LOG_ALL, 4, "\tbase => " PFX "\n", addr);
     addr += scaled_index;
@@ -2021,7 +2021,7 @@ reg_parameter_num(reg_id_t reg)
 {
     int r;
     for (r = 0; r < NUM_REGPARM; r++) {
-        if (reg == regparms[r])
+        if (reg == d_r_regparms[r])
             return r;
     }
     return -1;

--- a/core/arch/retcheck.c
+++ b/core/arch/retcheck.c
@@ -325,7 +325,7 @@ finalize_return_check(dcontext_t *dcontext, fragment_t *f)
         pc = decode(dcontext, pc, &instr);
         ASSERT(instr_valid(&instr)); /* our own code! */
         if (leas_next == 2) {
-            loginst(dcontext, 3, &instr, "\tlea 2");
+            d_r_loginst(dcontext, 3, &instr, "\tlea 2");
             if (instr_get_opcode(&instr) == OP_lea) {
                 opnd_t op = instr_get_src(&instr, 0);
                 int scale = opnd_get_scale(op);
@@ -340,7 +340,7 @@ finalize_return_check(dcontext_t *dcontext, fragment_t *f)
             leas_next = 0;
         }
         if (leas_next == 1) {
-            loginst(dcontext, 3, &instr, "\tlea 1");
+            d_r_loginst(dcontext, 3, &instr, "\tlea 1");
             if (instr_get_opcode(&instr) == OP_lea)
                 leas_next = 2;
             else
@@ -352,14 +352,14 @@ finalize_return_check(dcontext_t *dcontext, fragment_t *f)
             opnd_get_reg(instr_get_src(&instr, 0)) == REG_XMM7 &&
             opnd_is_immed_int(instr_get_src(&instr, 1)) &&
             opnd_get_immed_int(instr_get_src(&instr, 1)) == 7) {
-            loginst(dcontext, 3, &instr, "\tfound pextrw");
+            d_r_loginst(dcontext, 3, &instr, "\tfound pextrw");
             leas_next = 1;
         } else if (leas_next == 0 && instr_get_opcode(&instr) == OP_pinsrw &&
                    opnd_is_reg(instr_get_dst(&instr, 0)) &&
                    opnd_get_reg(instr_get_dst(&instr, 0)) == REG_XMM7 &&
                    opnd_is_immed_int(instr_get_src(&instr, 1)) &&
                    opnd_get_immed_int(instr_get_src(&instr, 1)) == 7) {
-            loginst(dcontext, 3, &instr, "\tfound pinsrw");
+            d_r_loginst(dcontext, 3, &instr, "\tfound pinsrw");
             leas_next = 1;
         }
     } while (pc < end_pc);
@@ -423,7 +423,7 @@ check_return_too_deep(dcontext_t *dcontext, volatile int errno, volatile reg_t e
     memcpy(stack->retaddr, xmm[0], 64);
 
 #        ifdef DEBUG
-    if (stats->loglevel >= 3) {
+    if (d_r_stats->loglevel >= 3) {
         int i, j;
         LOG(THREAD, LOG_ALL, 3, "Copied into stored stack:\n");
         for (i = 0; i < 4; i++) {
@@ -513,7 +513,7 @@ check_return_too_shallow(dcontext_t *dcontext, volatile int errno, volatile reg_
 #            error NYI
 #        endif
 #        ifdef DEBUG
-        if (stats->loglevel >= 3) {
+        if (d_r_stats->loglevel >= 3) {
             int i, j;
             LOG(THREAD, LOG_ALL, 3, "Restored:\n");
             for (i = 0; i < 4; i++) {
@@ -558,7 +558,7 @@ check_return_ra_mangled(dcontext_t *dcontext, volatile int errno, volatile reg_t
     SELF_PROTECT_LOCAL(dcontext, WRITABLE);
 
 #        ifdef DEBUG
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_ALL) != 0) {
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_ALL) != 0) {
         int idx;
 #            ifdef UNIX
         asm("pextrw $7,%xmm7,%eax");
@@ -692,7 +692,7 @@ check_debug(dcontext_t *dcontext, volatile int errno, volatile reg_t eflags,
 {
     ENTERING_DR();
     SELF_PROTECT_LOCAL(dcontext, WRITABLE);
-    if (stats->loglevel >= 3) {
+    if (d_r_stats->loglevel >= 3) {
         int i, j;
         byte xmm[8][16]; /* each sse2 is 128 bits = 16 bytes */
         /* move from registers into memory where we can work with it */
@@ -797,7 +797,7 @@ check_return_handle_return(dcontext_t *dcontext, instrlist_t *ilist, instr_t *in
     PRE(ilist, instr, instr_create_save_to_dcontext(dcontext, REG_EBX, XBX_OFFSET));
 
 #        ifdef DEBUG
-    if (stats->loglevel >= 4) {
+    if (d_r_stats->loglevel >= 4) {
         dr_insert_clean_call(dcontext, ilist, instr, (app_pc)check_debug, false /*!fp*/,
                              1, OPND_CREATE_INTPTR(dcontext));
     }
@@ -919,7 +919,7 @@ check_return_too_deep(dcontext_t *dcontext, volatile int errno, volatile reg_t e
     memcpy(stack->retaddr, &xmm[3][14], 64);
 
 #        ifdef DEBUG
-    if (stats->loglevel >= 3) {
+    if (d_r_stats->loglevel >= 3) {
         int i, j;
         LOG(THREAD, LOG_ALL, 3, "Copied into stored stack:\n");
         for (i = 0; i < 4; i++) {
@@ -1016,7 +1016,7 @@ check_return_too_shallow(dcontext_t *dcontext, volatile int errno, volatile reg_
 #            error NYI
 #        endif
 #        ifdef DEBUG
-        if (stats->loglevel >= 3) {
+        if (d_r_stats->loglevel >= 3) {
             int i, j;
             LOG(THREAD, LOG_ALL, 3, "Restored:\n");
             for (i = 0; i < 4; i++) {
@@ -1061,7 +1061,7 @@ check_return_ra_mangled(dcontext_t *dcontext, volatile int errno, volatile reg_t
     SELF_PROTECT_LOCAL(dcontext, WRITABLE);
 
 #        ifdef DEBUG
-    if (stats->loglevel >= 3) {
+    if (d_r_stats->loglevel >= 3) {
         int idx, i, j;
         byte xmm[8][16]; /* each sse2 is 128 bits = 16 bytes */
         /* move from registers into memory where we can work with it */

--- a/core/arch/sideline.c
+++ b/core/arch/sideline.c
@@ -634,14 +634,14 @@ sideline_optimize(fragment_t *f,
 #    ifdef DEBUG
     ASSERT(instr_get_opcode(instrlist_last(ilist)) == OP_jmp);
     LOG(logfile, LOG_SIDELINE, VERB_3, "\nbefore removing profiling:\n");
-    if (stats->loglevel >= VERB_3 && (stats->logmask & LOG_SIDELINE) != 0)
+    if (d_r_stats->loglevel >= VERB_3 && (d_r_stats->logmask & LOG_SIDELINE) != 0)
         instrlist_disassemble(dcontext, f->tag, ilist, THREAD);
 #    endif
     remove_profiling_func(dcontext, ilist);
 
 #    ifdef DEBUG
     LOG(logfile, LOG_SIDELINE, VERB_3, "\nafter removing profiling:\n");
-    if (stats->loglevel >= VERB_3 && (stats->logmask & LOG_SIDELINE) != 0)
+    if (d_r_stats->loglevel >= VERB_3 && (d_r_stats->logmask & LOG_SIDELINE) != 0)
         instrlist_disassemble(dcontext, f->tag, ilist, THREAD);
 #    endif
 
@@ -653,13 +653,13 @@ sideline_optimize(fragment_t *f,
          */
 #    ifdef DEBUG
     LOG(logfile, LOG_SIDELINE, OPTVERB_3, "\nbefore optimization:\n");
-    if (stats->loglevel >= OPTVERB_3 && (stats->logmask & LOG_SIDELINE) != 0)
+    if (d_r_stats->loglevel >= OPTVERB_3 && (d_r_stats->logmask & LOG_SIDELINE) != 0)
         instrlist_disassemble(dcontext, f->tag, ilist, THREAD);
 #    endif
     optimize_function(dcontext, f, ilist);
 #    ifdef DEBUG
     LOG(logfile, LOG_SIDELINE, OPTVERB_3, "\nafter optimization:\n");
-    if (stats->loglevel >= OPTVERB_3 && (stats->logmask & LOG_SIDELINE) != 0)
+    if (d_r_stats->loglevel >= OPTVERB_3 && (d_r_stats->logmask & LOG_SIDELINE) != 0)
         instrlist_disassemble(dcontext, f->tag, ilist, THREAD);
 #    endif
     /* Note that the offline optimization interface cannot be used
@@ -706,8 +706,8 @@ sideline_optimize(fragment_t *f,
 
 #    ifdef DEBUG
     num_optimized++;
-    if (stats->loglevel >= 2 && (stats->logmask & LOG_SIDELINE) != 0) {
-        disassemble_fragment(dcontext, new_f, stats->loglevel < 3);
+    if (d_r_stats->loglevel >= 2 && (d_r_stats->logmask & LOG_SIDELINE) != 0) {
+        disassemble_fragment(dcontext, new_f, d_r_stats->loglevel < 3);
         LOG(logfile, LOG_SIDELINE, 2,
             "\tSIDELINE: emitted optimized F%d to replace F%d\n", new_f->id, f->id);
     }

--- a/core/arch/x86/clean_call_opt.c
+++ b/core/arch/x86/clean_call_opt.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -151,7 +151,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
     /* i#987, i#988: reg might be used for arg passing but not used in callee */
     num_regparm = MIN(ci->num_args, NUM_REGPARM);
     for (i = 0; i < num_regparm; i++) {
-        reg_id_t reg = regparms[i];
+        reg_id_t reg = d_r_regparms[i];
         if (!ci->reg_used[reg - DR_REG_XAX]) {
             LOG(THREAD, LOG_CLEANCALL, 2,
                 "CLEANCALL: callee " PFX " uses REG %s for arg passing\n", ci->start,
@@ -688,7 +688,7 @@ insert_inline_arg_setup(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_
      * for correctness because we will not have spilled regparm[0] on x64 or
      * reserved SLOT_LOCAL for x86_32.
      */
-    if (IF_X64_ELSE(!ci->reg_used[regparms[0] - DR_REG_XAX], !ci->has_locals)) {
+    if (IF_X64_ELSE(!ci->reg_used[d_r_regparms[0] - DR_REG_XAX], !ci->has_locals)) {
         LOG(THREAD, LOG_CLEANCALL, 2,
             "CLEANCALL: callee " PFX " doesn't read arg, skipping arg setup.\n",
             ci->start);
@@ -697,7 +697,7 @@ insert_inline_arg_setup(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_
 
     ASSERT(cci->num_args == 1);
     arg = args[0];
-    regparm = shrink_reg_for_param(IF_X64_ELSE(regparms[0], DR_REG_XAX), arg);
+    regparm = shrink_reg_for_param(IF_X64_ELSE(d_r_regparms[0], DR_REG_XAX), arg);
 
     if (opnd_uses_reg(arg, ci->spill_reg)) {
         if (opnd_is_reg(arg)) {

--- a/core/arch/x86/encode.c
+++ b/core/arch/x86/encode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2339,7 +2339,7 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
     /* first, walk through instr list to find format that matches
      * this instr's operands
      */
-    DOLOG(ENC_LEVEL, LOG_EMIT, { loginst(dcontext, 1, instr, "\n--- encoding"); });
+    DOLOG(ENC_LEVEL, LOG_EMIT, { d_r_loginst(dcontext, 1, instr, "\n--- encoding"); });
 
     memset(&di, 0, sizeof(decode_info_t));
     di.opcode = opc;
@@ -2630,7 +2630,7 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
     }
 
 #if DEBUG_DISABLE /* turn back on if want to debug */
-    if (stats->loglevel >= 3) {
+    if (d_r_stats->loglevel >= 3) {
         byte *pc = cache_pc;
         LOG(THREAD, LOG_EMIT, 3, "instr_encode on: ");
         instr_disassemble(dcontext, instr, THREAD);

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -594,9 +594,9 @@ insert_parameter_preparation(dcontext_t *dcontext, instrlist_t *ilist, instr_t *
 
     /* For a clean call, xax is dead (clobbered by prepare_for_clean_call()).
      * Rather than use as scratch and restore prior to each param that uses it,
-     * we restore once up front if any use it, and use regparms[0] as scratch,
-     * which is symmetric with non-clean-calls: regparms[0] is dead since we're
-     * doing args in reverse order.  However, we then can't use regparms[0]
+     * we restore once up front if any use it, and use d_r_regparms[0] as scratch,
+     * which is symmetric with non-clean-calls: d_r_regparms[0] is dead since we're
+     * doing args in reverse order.  However, we then can't use d_r_regparms[0]
      * directly if referenced in earlier params, but similarly for xax, so
      * there's no clear better way. (prepare_for_clean_call also clobbers xsp,
      * but we just disallow args that use it).
@@ -719,12 +719,12 @@ insert_parameter_preparation(dcontext_t *dcontext, instrlist_t *ilist, instr_t *
                              INSTR_CREATE_mov_st(dcontext,
                                                  OPND_CREATE_MEMPTR(REG_XSP, disp), arg));
                     } else {
-                        reg_id_t xsp_scratch = regparms[0];
+                        reg_id_t xsp_scratch = d_r_regparms[0];
                         /* don't want to just change size since will read extra bytes.
                          * can't do mem-to-mem so go through scratch reg */
                         if (reg_overlap(used, REG_XSP)) {
                             /* Get original xsp into scratch[0] and replace in arg */
-                            if (opnd_uses_reg(arg, regparms[0])) {
+                            if (opnd_uses_reg(arg, d_r_regparms[0])) {
                                 xsp_scratch = REG_XAX;
                                 ASSERT(!opnd_uses_reg(arg, REG_XAX)); /* can't use 3 */
                                 /* FIXME: rather than putting xsp into mcontext
@@ -739,13 +739,13 @@ insert_parameter_preparation(dcontext_t *dcontext, instrlist_t *ilist, instr_t *
                         POST(ilist, prev,
                              INSTR_CREATE_mov_st(dcontext,
                                                  OPND_CREATE_MEMPTR(REG_XSP, disp),
-                                                 opnd_create_reg(regparms[0])));
+                                                 opnd_create_reg(d_r_regparms[0])));
                         /* If sub-ptr-size, zero-extend is what we want so no movsxd */
                         POST(ilist, prev,
-                             INSTR_CREATE_mov_ld(
-                                 dcontext,
-                                 opnd_create_reg(shrink_reg_for_param(regparms[0], arg)),
-                                 arg));
+                             INSTR_CREATE_mov_ld(dcontext,
+                                                 opnd_create_reg(shrink_reg_for_param(
+                                                     d_r_regparms[0], arg)),
+                                                 arg));
                         if (reg_overlap(used, REG_XSP)) {
                             int xsp_disp = opnd_get_reg_dcontext_offs(REG_XSP) +
                                 clean_call_beyond_mcontext() + total_stack;
@@ -759,13 +759,13 @@ insert_parameter_preparation(dcontext_t *dcontext, instrlist_t *ilist, instr_t *
                                                               TLS_XAX_SLOT));
                             }
                         }
-                        if (opnd_uses_reg(arg, regparms[0])) {
+                        if (opnd_uses_reg(arg, d_r_regparms[0])) {
                             /* must restore since earlier arg might have clobbered */
-                            int mc_disp = opnd_get_reg_dcontext_offs(regparms[0]) +
+                            int mc_disp = opnd_get_reg_dcontext_offs(d_r_regparms[0]) +
                                 clean_call_beyond_mcontext() + total_stack;
                             POST(ilist, prev,
                                  INSTR_CREATE_mov_ld(
-                                     dcontext, opnd_create_reg(regparms[0]),
+                                     dcontext, opnd_create_reg(d_r_regparms[0]),
                                      OPND_CREATE_MEMPTR(REG_XSP, mc_disp)));
                         }
                     }
@@ -779,7 +779,7 @@ insert_parameter_preparation(dcontext_t *dcontext, instrlist_t *ilist, instr_t *
 #    endif
 
         if (i < NUM_REGPARM) {
-            reg_id_t regparm = shrink_reg_for_param(regparms[i], arg);
+            reg_id_t regparm = shrink_reg_for_param(d_r_regparms[i], arg);
             if (opnd_is_immed_int(arg) || opnd_is_instr(arg)) {
                 POST(ilist, mark,
                      INSTR_CREATE_mov_imm(dcontext, opnd_create_reg(regparm), arg));
@@ -827,9 +827,9 @@ insert_parameter_preparation(dcontext_t *dcontext, instrlist_t *ilist, instr_t *
                     ASSERT(NUM_REGPARM > 0);
                     POST(ilist, mark,
                          INSTR_CREATE_mov_st(dcontext, OPND_CREATE_MEMPTR(REG_XSP, offs),
-                                             opnd_create_reg(regparms[0])));
+                                             opnd_create_reg(d_r_regparms[0])));
                     POST(ilist, mark,
-                         INSTR_CREATE_mov_imm(dcontext, opnd_create_reg(regparms[0]),
+                         INSTR_CREATE_mov_imm(dcontext, opnd_create_reg(d_r_regparms[0]),
                                               arg));
                 } else {
 #    endif
@@ -837,11 +837,11 @@ insert_parameter_preparation(dcontext_t *dcontext, instrlist_t *ilist, instr_t *
                         /* can't do mem-to-mem so go through scratch */
                         reg_id_t scratch;
                         if (NUM_REGPARM > 0)
-                            scratch = regparms[0];
+                            scratch = d_r_regparms[0];
                         else {
                             /* This happens on Mac.
                              * FIXME i#1370: not safe if later arg uses xax:
-                             * local spill?  Review how regparms[0] is preserved.
+                             * local spill?  Review how d_r_regparms[0] is preserved.
                              */
                             scratch = REG_XAX;
                         }
@@ -2720,7 +2720,7 @@ mangle_cpuid(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     instr_decode(dcontext, instr);
     if (!instr_valid(instr))
         goto cpuid_give_up;
-    loginst(dcontext, 2, prev, "prior to cpuid");
+    d_r_loginst(dcontext, 2, prev, "prior to cpuid");
 
     /* FIXME: maybe should insert code to dispatch on eax, rather than
      * this hack, which is based on photoshop, which either does
@@ -3173,7 +3173,7 @@ mangle_seg_ref(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     STATS_INC(app_seg_refs_mangled);
 
     DOLOG(3, LOG_INTERP,
-          { loginst(dcontext, 3, instr, "reference with fs/gs segment"); });
+          { d_r_loginst(dcontext, 3, instr, "reference with fs/gs segment"); });
     /* 2. decide the scratch reg */
     /* Opt: if it's a load (OP_mov_ld, or OP_movzx, etc.), use dead reg */
     if (si >= 0 && instr_num_srcs(instr) == 1 && /* src is the seg ref opnd */
@@ -3218,7 +3218,8 @@ mangle_seg_ref(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     /* we need the whole spill...restore region to all be marked mangle */
     instr_set_our_mangling(instr, true);
     /* FIXME: i#107 we should check the bound and raise signal if out of bound. */
-    DOLOG(3, LOG_INTERP, { loginst(dcontext, 3, instr, "re-wrote app tls reference"); });
+    DOLOG(3, LOG_INTERP,
+          { d_r_loginst(dcontext, 3, instr, "re-wrote app tls reference"); });
 
     if (spill) {
         PRE(ilist, next_instr,
@@ -3354,7 +3355,7 @@ sandbox_rep_instr(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr, inst
     bool use_tls = IF_X64_ELSE(true, false);
     IF_X64(bool x86_to_x64_ibl_opt = DYNAMO_OPTION(x86_to_x64_ibl_opt);)
     instr_t *next_app = next;
-    DOLOG(3, LOG_INTERP, { loginst(dcontext, 3, instr, "writes memory"); });
+    DOLOG(3, LOG_INTERP, { d_r_loginst(dcontext, 3, instr, "writes memory"); });
 
     ASSERT(!instr_is_call_indirect(instr)); /* FIXME: can you have REP on on CALL's */
 
@@ -3498,7 +3499,7 @@ sandbox_write(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr, instr_t 
     instr_t *next_app = next;
     instr_t *get_addr_at = next;
     int opcode = instr_get_opcode(instr);
-    DOLOG(3, LOG_INTERP, { loginst(dcontext, 3, instr, "writes memory"); });
+    DOLOG(3, LOG_INTERP, { d_r_loginst(dcontext, 3, instr, "writes memory"); });
 
     /* skip meta instrs to find next app instr (xref PR 472190) */
     while (next_app != NULL && instr_is_meta(next_app))
@@ -3521,7 +3522,8 @@ sandbox_write(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr, instr_t 
              * CALL* already means that we're leaving the block and it cannot be a selfmod
              * instruction even though it writes to memory
              */
-            DOLOG(4, LOG_INTERP, { loginst(dcontext, 4, next_app, "next app instr"); });
+            DOLOG(4, LOG_INTERP,
+                  { d_r_loginst(dcontext, 4, next_app, "next app instr"); });
             after_write = opnd_get_pc(instr_get_target(next_app));
             LOG(THREAD, LOG_INTERP, 4, "after_write = " PFX " next should be final jmp\n",
                 after_write);

--- a/core/arch/x86/optimize.c
+++ b/core/arch/x86/optimize.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -140,11 +140,11 @@ get_decision_instr(instr_t *jmp);
 
 /* exported utility routines */
 void
-loginst(dcontext_t *dcontext, uint level, instr_t *instr, const char *string);
+d_r_loginst(dcontext_t *dcontext, uint level, instr_t *instr, const char *string);
 void
-logopnd(dcontext_t *dcontext, uint level, opnd_t opnd, const char *string);
+d_r_logopnd(dcontext_t *dcontext, uint level, opnd_t opnd, const char *string);
 void
-logtrace(dcontext_t *dcontext, uint level, instrlist_t *trace, const char *string);
+d_r_logtrace(dcontext_t *dcontext, uint level, instrlist_t *trace, const char *string);
 
 /****************************************************************************/
 /* master routine */
@@ -169,7 +169,7 @@ optimize_trace(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
     LOG(THREAD, LOG_OPTS, 3, "\noptimize_trace ******************\n");
     LOG(THREAD, LOG_OPTS, 3, "\nbefore optimization:\n");
 
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 
 #    endif
@@ -230,7 +230,7 @@ optimize_trace(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
 
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 3, "\nafter optimization:\n");
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
 }
@@ -466,7 +466,7 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 1,
         "\nidentify_for_loop: found whole-trace self-loop: tag " PFX "\n", tag);
-    if ((stats->logmask & LOG_OPTS) != 0)
+    if ((d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
 
@@ -491,7 +491,7 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
          * FIXME: better to store dependence info somehow, or to make passes
          * through instrlist whenever need info?
          */
-        loginst(dcontext, 1, inst, "considering");
+        d_r_loginst(dcontext, 1, inst, "considering");
         for (i = 0; i < instr_num_srcs(inst); i++) {
             opnd = instr_get_src(inst, i);
             /* ignore immeds and memory references */
@@ -502,7 +502,8 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                 for (j = 0; j < instr_num_dsts(check); j++) {
                     if (opnd_defines_use(instr_get_dst(check, j), opnd)) {
                         /* write prior to read: no lcd */
-                        loginst(dcontext, 1, check, "\twrite prior to read -> no lcd");
+                        d_r_loginst(dcontext, 1, check,
+                                    "\twrite prior to read -> no lcd");
                         goto no_lcd;
                     }
                 }
@@ -516,7 +517,7 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                 }
             }
             /* no writes: loop invariant! */
-            logopnd(dcontext, 1, opnd, "\tloop invariant");
+            d_r_logopnd(dcontext, 1, opnd, "\tloop invariant");
             invariant[num_invariants] = opnd;
             num_invariants++;
             if (num_invariants >= MAX_INVARIANTS) {
@@ -524,11 +525,11 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                 return;
             }
         }
-        loginst(dcontext, 1, inst, "\tfell off end -> no lcd");
+        d_r_loginst(dcontext, 1, inst, "\tfell off end -> no lcd");
     no_lcd:
         continue;
     has_lcd:
-        loginst(dcontext, 1, inst, "\tfound a loop-carried dependence");
+        d_r_loginst(dcontext, 1, inst, "\tfound a loop-carried dependence");
         /* find basic induction variables: i = i + constant
          * FIXME: consider loop invariants as well as immeds as constants
          * FIXME: only consider inc,dec,add,sub?
@@ -539,7 +540,7 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
             (instr_num_srcs(inst) == 2 && instr_num_dsts(inst) == 1 &&
              opnd_is_immed_int(instr_get_src(inst, 0)) &&
              opnd_same(instr_get_src(inst, 1), instr_get_dst(inst, 0)))) {
-            loginst(dcontext, 1, inst, "\t\tfound induction variable");
+            d_r_loginst(dcontext, 1, inst, "\t\tfound induction variable");
             induction_var[num_induction_vars] = inst;
             num_induction_vars++;
             if (num_induction_vars >= MAX_INDUCTION_VARS) {
@@ -592,16 +593,17 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
         } else
             ASSERT_NOT_REACHED();
     next_lcd:
-        logopnd(dcontext, 1, lcd[i], "\tlcd read is induction var value, so it's ok");
+        d_r_logopnd(dcontext, 1, lcd[i], "\tlcd read is induction var value, so it's ok");
         continue;
     lcd_bad:
-        logopnd(dcontext, 1, lcd[i], "\tlcd read is not induction var value, giving up");
+        d_r_logopnd(dcontext, 1, lcd[i],
+                    "\tlcd read is not induction var value, giving up");
         return;
     }
 
     /* now look at loop termination test */
     inst = get_decision_instr(branch);
-    loginst(dcontext, 1, inst, "looking at decision instr");
+    d_r_loginst(dcontext, 1, inst, "looking at decision instr");
     /* test must involve only induction vars and constants */
     for (i = 0; i < instr_num_srcs(inst); i++) {
         opnd = instr_get_src(inst, i);
@@ -611,8 +613,8 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                     break;
             }
             if (j == num_induction_vars) {
-                loginst(dcontext, 1, inst,
-                        "\tloop termination test not just consts & inductions!");
+                d_r_loginst(dcontext, 1, inst,
+                            "\tloop termination test not just consts & inductions!");
                 return;
             }
         }
@@ -623,7 +625,7 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
         /* for each store, generate pre-loop checks to ensure no overlap with
          * any other store or read
          */
-        loginst(dcontext, 1, inst, "considering");
+        d_r_loginst(dcontext, 1, inst, "considering");
         for (i = 0; i < instr_num_dsts(inst); i++) {
             opnd = instr_get_dst(inst, i);
             if (!opnd_is_memory_reference(opnd))
@@ -635,11 +637,12 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                         continue;
                     if (opnd_is_memory_reference(instr_get_dst(check, j))) {
                         /* disambiguate these writes */
-                        logopnd(dcontext, 1, instr_get_dst(check, j),
-                                "\tgenerating checks");
+                        d_r_logopnd(dcontext, 1, instr_get_dst(check, j),
+                                    "\tgenerating checks");
                         if (!generate_antialias_check(dcontext, &pre_loop, opnd,
                                                       instr_get_dst(check, j))) {
-                            loginst(dcontext, 1, inst, "unavoidable alias, giving up");
+                            d_r_loginst(dcontext, 1, inst,
+                                        "unavoidable alias, giving up");
                             return;
                         }
                     }
@@ -665,7 +668,7 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
     LOG(THREAD, LOG_OPTS, 1, "loop has passed all tests so far!\n");
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 1, "pre-loop checks are:\n");
-    if (stats->loglevel >= 1 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 1 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, &pre_loop, THREAD);
 #    endif
 
@@ -694,7 +697,7 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                 break;
         }
         if (j == num_induction_vars) {
-            loginst(dcontext, 1, check, "non-induction var is present");
+            d_r_loginst(dcontext, 1, check, "non-induction var is present");
             return;
         }
     }
@@ -712,8 +715,8 @@ identify_for_loop(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                 else
                     induction_var[i] = instr_get_next(inst);
             } else {
-                loginst(dcontext, 1, induction_var[i],
-                        "couldn't replace inc w/ add b/c of eflags\n");
+                d_r_loginst(dcontext, 1, induction_var[i],
+                            "couldn't replace inc w/ add b/c of eflags\n");
                 /* FIXME: undo earlier inc->adds */
                 return;
             }
@@ -804,8 +807,8 @@ now do not have a pre-loop and do unaligned simd
     ASSERT(opnd_is_memory_reference(opnd));
     opnd_set_size(&opnd, OPSZ_8);
     check = INSTR_CREATE_movq(dcontext, opnd_create_reg(REG_MM0), opnd);
-    loginst(dcontext, 1, inst, "replacing this");
-    loginst(dcontext, 1, check, "\twith this");
+    d_r_loginst(dcontext, 1, inst, "replacing this");
+    d_r_loginst(dcontext, 1, check, "\twith this");
     replace_inst(dcontext, trace, inst, check);
 
     inst = instr_get_next(check);
@@ -813,8 +816,8 @@ now do not have a pre-loop and do unaligned simd
     ASSERT(opnd_is_memory_reference(opnd));
     opnd_set_size(&opnd, OPSZ_8);
     check = INSTR_CREATE_paddd(dcontext, opnd_create_reg(REG_MM0), opnd);
-    loginst(dcontext, 1, inst, "replacing this");
-    loginst(dcontext, 1, check, "\twith this");
+    d_r_loginst(dcontext, 1, inst, "replacing this");
+    d_r_loginst(dcontext, 1, check, "\twith this");
     replace_inst(dcontext, trace, inst, check);
 
     inst = instr_get_next(check);
@@ -822,8 +825,8 @@ now do not have a pre-loop and do unaligned simd
     ASSERT(opnd_is_memory_reference(opnd));
     opnd_set_size(&opnd, OPSZ_8);
     check = INSTR_CREATE_movq(dcontext, opnd, opnd_create_reg(REG_MM0));
-    loginst(dcontext, 1, inst, "replacing this");
-    loginst(dcontext, 1, check, "\twith this");
+    d_r_loginst(dcontext, 1, inst, "replacing this");
+    d_r_loginst(dcontext, 1, check, "\twith this");
     replace_inst(dcontext, trace, inst, check);
 
     /* now make induction vars do X unroll duty */
@@ -844,7 +847,7 @@ now do not have a pre-loop and do unaligned simd
 
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 1, "\nfinal version of trace:\n");
-    if ((stats->logmask & LOG_OPTS) != 0)
+    if ((d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
 }
@@ -888,7 +891,7 @@ unroll_loops(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
          */
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 3, "\nunroll loop -- checking eflags on:\n");
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
     for (inst = instrlist_first(trace); inst != branch; inst = instr_get_next(inst)) {
@@ -897,7 +900,8 @@ unroll_loops(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
             if ((eflags & EFLAGS_READ_6) != 0) {
                 if ((eflags_6 | (eflags & EFLAGS_READ_6)) != eflags_6) {
                     /* we're reading a flag that has not been written yet */
-                    loginst(dcontext, 3, inst, "reads flag before writing it, giving up");
+                    d_r_loginst(dcontext, 3, inst,
+                                "reads flag before writing it, giving up");
                     return;
                 }
             } else if ((eflags & EFLAGS_WRITE_6) != 0) {
@@ -919,7 +923,7 @@ unroll_loops(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 3, "\nunroll loop: found whole-trace self-loop: tag " PFX "\n",
         tag);
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
 
@@ -957,7 +961,7 @@ unroll_loops(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
         LOG(THREAD, LOG_OPTS, 3, "can't find decision instr\n");
         return;
     }
-    loginst(dcontext, 3, decision, "decision instr");
+    d_r_loginst(dcontext, 3, decision, "decision instr");
 
     if (instr_get_opcode(decision) == OP_cmp) {
         int opcode = instr_get_opcode(branch);
@@ -972,7 +976,9 @@ unroll_loops(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
         case OP_jnle: counting_up = false; break;
         case OP_js: counting_up = true; break;
         case OP_jns: counting_up = false; break;
-        default: loginst(dcontext, 3, branch, "cannot handle decision branch"); return;
+        default:
+            d_r_loginst(dcontext, 3, branch, "cannot handle decision branch");
+            return;
         }
     } else if (instr_get_opcode(decision) == OP_inc ||
                instr_get_opcode(decision) == OP_add ||
@@ -1004,7 +1010,7 @@ unroll_loops(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                 cmp_const = OPND_CREATE_INT8(0);
                 opcode = OP_jl;
             } else {
-                loginst(dcontext, 3, branch, "can't handle loop branch");
+                d_r_loginst(dcontext, 3, branch, "can't handle loop branch");
                 return;
             }
             cmp = INSTR_CREATE_cmp(dcontext, cmp_var, cmp_const);
@@ -1018,12 +1024,12 @@ unroll_loops(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
              * because of eflags concerns
              */
             if (!replace_inc_with_add(dcontext, decision, trace)) {
-                loginst(dcontext, 3, decision, "couldn't replace with add/sub");
+                d_r_loginst(dcontext, 3, decision, "couldn't replace with add/sub");
                 return;
             }
         } else {
             /* give up -- if add cases in future, remember to deal w/ eflags */
-            loginst(dcontext, 3, decision, "can't handle loop branch decision");
+            d_r_loginst(dcontext, 3, decision, "can't handle loop branch decision");
             return;
         }
     }
@@ -1031,7 +1037,7 @@ unroll_loops(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
      * requires adding extra instructions to compute bounds
      */
     if (!opnd_is_immed_int(instr_get_src(cmp, 1))) {
-        loginst(dcontext, 3, cmp, "cmp is not vs. constant");
+        d_r_loginst(dcontext, 3, cmp, "cmp is not vs. constant");
         return;
     }
 
@@ -1096,7 +1102,7 @@ unroll_loops(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
 #    ifdef DEBUG
     opt_stats_t.loops_unrolled++;
     LOG(THREAD, LOG_OPTS, 3, "\nfinal version of unrolled trace:\n");
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
 }
@@ -1122,7 +1128,7 @@ test_i64(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
 #        ifdef DEBUG
         opt_stats_t.i64_test = false;
         LOG(THREAD, LOG_OPTS, 1, "\nadding ia64 test\n");
-        if (stats->loglevel >= 1 && (stats->logmask & LOG_OPTS) != 0)
+        if (d_r_stats->loglevel >= 1 && (d_r_stats->logmask & LOG_OPTS) != 0)
             instrlist_disassemble(dcontext, tag, trace, THREAD);
 #        endif
         have_done = true;
@@ -1244,7 +1250,7 @@ test_i64(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
             instr_create_restore_from_dcontext(dcontext, REG_EBX, XBX_OFFSET));
 #        ifdef DEBUG
         LOG(THREAD, LOG_OPTS, 1, "\ndone adding ia64 test\n");
-        if (stats->loglevel >= 1 && (stats->logmask & LOG_OPTS) != 0)
+        if (d_r_stats->loglevel >= 1 && (d_r_stats->logmask & LOG_OPTS) != 0)
             instrlist_disassemble(dcontext, tag, trace, THREAD);
 #        endif
         LOG(THREAD, LOG_OPTS, 1,
@@ -1544,8 +1550,8 @@ get_immutable_value(opnd_t address, prop_state_t *state, int size)
         /* can't handle size, log is usually quadwords for floats */
 #    ifdef DEBUG
         dcontext_t *dcontext = state->dcontext;
-        logopnd(state->dcontext, 3, address,
-                "Couldn't handle size in get_immutable_value");
+        d_r_logopnd(state->dcontext, 3, address,
+                    "Couldn't handle size in get_immutable_value");
         LOG(THREAD, LOG_OPTS, 3, "Address size was %d\n", size);
 #    endif
         /* should never get here, since const_address_const_mem should fail */
@@ -1573,7 +1579,7 @@ const_address_const_mem(opnd_t address, prop_state_t *state, bool prefix_data)
 {
     bool success = false;
     int size = opnd_get_size(address);
-    logopnd(state->dcontext, 3, address, " checking const address const mem\n");
+    d_r_logopnd(state->dcontext, 3, address, " checking const address const mem\n");
     if (size == OPSZ_4_short2) {
         if (prefix_data)
             size = OPSZ_2;
@@ -1584,8 +1590,8 @@ const_address_const_mem(opnd_t address, prop_state_t *state, bool prefix_data)
         /* can't handle size, is usually quadwords for floats */
 #    ifdef DEBUG
         dcontext_t *dcontext = state->dcontext;
-        logopnd(state->dcontext, 3, address,
-                "Couldn't handle size in const_address_const_mem");
+        d_r_logopnd(state->dcontext, 3, address,
+                    "Couldn't handle size in const_address_const_mem");
         LOG(THREAD, LOG_OPTS, 3, "Address size was %d\n", size);
 #    endif
         return false;
@@ -1753,7 +1759,7 @@ propagate_opnd(opnd_t old, prop_state_t *state, bool prefix_data)
                 state->cur_scope == state->stack_scope[i] &&
                 (state->stack_address_state[i] & PS_VALID_VAL) != 0) {
                 LOG(THREAD, LOG_OPTS, 3, "  at stack depth %d ", state->cur_scope);
-                logopnd(state->dcontext, 3, old, " found cached stack address");
+                d_r_logopnd(state->dcontext, 3, old, " found cached stack address");
                 immed = state->stack_vals[i];
                 return opnd_create_immed_int(immed, size);
             }
@@ -1763,7 +1769,7 @@ propagate_opnd(opnd_t old, prop_state_t *state, bool prefix_data)
     if (opnd_is_constant_address(old) && cp_global_aggr > 0) {
         if (const_address_const_mem(old, state, prefix_data)) {
 #    ifdef DEBUG
-            logopnd(state->dcontext, 2, old, " found const address const mem\n");
+            d_r_logopnd(state->dcontext, 2, old, " found const address const mem\n");
             opt_stats_t.num_const_add_const_mem++;
 #    endif
             immed = get_immutable_value(old, state, size);
@@ -1774,7 +1780,8 @@ propagate_opnd(opnd_t old, prop_state_t *state, bool prefix_data)
             for (i = 0; i < NUM_CONSTANT_ADDRESS; i++) {
                 if (state->addresses[i] == disp &&
                     (state->address_state[i] & PS_VALID_VAL) != 0) {
-                    logopnd(state->dcontext, 3, old, " found cached constant address\n");
+                    d_r_logopnd(state->dcontext, 3, old,
+                                " found cached constant address\n");
                     immed = state->address_vals[i];
                     return opnd_create_immed_int(immed, size);
                 }
@@ -1917,7 +1924,7 @@ do_forward_check_eflags(instr_t *inst, uint eflags, uint eflags_valid,
         return true;
     for (inst = instr_get_next(inst); inst != NULL; inst = next_inst) {
         next_inst = instr_get_next(inst);
-        loginst(state->dcontext, 3, inst, " flag checking ");
+        d_r_loginst(state->dcontext, 3, inst, " flag checking ");
         while ((inst != NULL) && instr_is_cti(inst)) {
             LOG(THREAD, LOG_OPTS, 3,
                 "attempting to remove, eflags = " PFX " eflags valid = " PFX "\n", eflags,
@@ -1925,7 +1932,7 @@ do_forward_check_eflags(instr_t *inst, uint eflags, uint eflags_valid,
             if (removable_jmp(inst, eflags, eflags_valid)) {
 #    ifdef DEBUG
                 opt_stats_t.num_jmps_simplified++;
-                loginst(state->dcontext, 3, inst, " removing this jmp ");
+                d_r_loginst(state->dcontext, 3, inst, " removing this jmp ");
 #    endif
                 remove_inst(state->dcontext, state->trace, inst);
                 inst = next_inst;
@@ -2023,8 +2030,8 @@ do_forward_check_eflags(instr_t *inst, uint eflags, uint eflags_valid,
         if (replace) {
 #    ifdef DEBUG
             opt_stats_t.num_instrs_simplified++;
-            loginst(state->dcontext, 3, inst, " old instruction");
-            loginst(state->dcontext, 3, temp, " simplified to  ");
+            d_r_loginst(state->dcontext, 3, inst, " old instruction");
+            d_r_loginst(state->dcontext, 3, temp, " simplified to  ");
 #    endif
             replace_inst(state->dcontext, state->trace, inst, temp);
             inst = temp;
@@ -2034,7 +2041,7 @@ do_forward_check_eflags(instr_t *inst, uint eflags, uint eflags_valid,
         eflags_check = instr_get_eflags(inst, DR_QUERY_DEFAULT);
         if (((eflags_invalid & eflags_check) != 0) ||
             ((eflags_valid & eflags_check) != 0)) {
-            loginst(state->dcontext, 3, inst, " uses eflags!");
+            d_r_loginst(state->dcontext, 3, inst, " uses eflags!");
             LOG(THREAD, LOG_OPTS, 3,
                 "forward eflags check failed(3)  " PFX "   " PFX "  " PFX "\n",
                 eflags_valid, eflags_invalid, eflags_check);
@@ -2094,8 +2101,8 @@ make_to_imm_store(instr_t *inst, int value, prop_state_t *state)
             replace_inst(dcontext, state->trace, inst, replacement);
             return replacement;
         } else {
-            loginst(dcontext, 3, inst,
-                    " unable to simplify move zero to xor, e-flags check failed ");
+            d_r_loginst(dcontext, 3, inst,
+                        " unable to simplify move zero to xor, e-flags check failed ");
             instr_destroy(dcontext, replacement);
         }
     }
@@ -2124,13 +2131,13 @@ make_to_nop(prop_state_t *state, instr_t *inst, const char *pre, const char *pos
 {
     instr_t *backup;
     if (forward_check_eflags(inst, state)) {
-        loginst(state->dcontext, 3, inst, pre);
+        d_r_loginst(state->dcontext, 3, inst, pre);
         backup = INSTR_CREATE_nop(state->dcontext);
         replace_inst(state->dcontext, state->trace, inst, backup);
-        loginst(state->dcontext, 3, backup, post);
+        d_r_loginst(state->dcontext, 3, backup, post);
         return backup;
     } else {
-        loginst(state->dcontext, 3, inst, fail);
+        d_r_loginst(state->dcontext, 3, inst, fail);
         return inst;
     }
 }
@@ -2278,12 +2285,12 @@ prop_simplify(instr_t *inst, prop_state_t *state)
 
                 /* remove control flow after jecxz */
                 inst2 = instr_get_next(inst);
-                loginst(dcontext, 3, inst2, "removing ");
+                d_r_loginst(dcontext, 3, inst2, "removing ");
                 ASSERT(instr_get_opcode(inst2) == OP_lea &&
                        opnd_get_reg(instr_get_dst(inst2, 0)) == REG_ECX);
                 instrlist_remove(state->trace, inst2);
                 inst2 = instr_get_next(inst);
-                loginst(dcontext, 3, inst2, "removing ");
+                d_r_loginst(dcontext, 3, inst2, "removing ");
                 ASSERT(instr_get_opcode(inst2) == OP_jmp);
                 instrlist_remove(state->trace, inst2);
 
@@ -2294,12 +2301,13 @@ prop_simplify(instr_t *inst, prop_state_t *state)
                     ((instr_get_opcode(inst2) == OP_mov_imm ||
                       instr_get_opcode(inst2) == OP_mov_st || is_zeroing_instr(inst2)) &&
                      opnd_get_reg(instr_get_dst(inst2, 0)) == REG_ECX)) {
-                    loginst(dcontext, 3, inst2, "removing ");
+                    d_r_loginst(dcontext, 3, inst2, "removing ");
                     instrlist_remove(state->trace, inst2);
                 } else {
-                    loginst(dcontext, 1, inst2,
-                            "ERROR : unexpected instruction in constant prop indirect "
-                            "branch removal (1) aborting");
+                    d_r_loginst(
+                        dcontext, 1, inst2,
+                        "ERROR : unexpected instruction in constant prop indirect "
+                        "branch removal (1) aborting");
                     return inst;
                 }
                 inst2 = inst3;
@@ -2313,13 +2321,13 @@ prop_simplify(instr_t *inst, prop_state_t *state)
                 /* prev. by constant prop, asserts are fragile, remove them? */
                 if (instr_get_opcode(inst2) == OP_pop ||
                     instr_get_opcode(inst2) == OP_lea) {
-                    loginst(dcontext, 3, inst2,
-                            "ERROR : found what looks like a call return in jecxz "
-                            "removal, but we can't find those yet!! aborting");
+                    d_r_loginst(dcontext, 3, inst2,
+                                "ERROR : found what looks like a call return in jecxz "
+                                "removal, but we can't find those yet!! aborting");
                     return inst;
                 }
                 if (instr_get_opcode(inst2) == OP_push_imm) {
-                    loginst(dcontext, 3, inst2, "skipping ");
+                    d_r_loginst(dcontext, 3, inst2, "skipping ");
                     inst2 = instr_get_prev(inst2);
                 }
                 inst3 = instr_get_prev(inst2);
@@ -2327,23 +2335,25 @@ prop_simplify(instr_t *inst, prop_state_t *state)
                     ((instr_get_opcode(inst2) == OP_mov_imm ||
                       instr_get_opcode(inst2) == OP_mov_st || is_zeroing_instr(inst2)) &&
                      opnd_get_reg(instr_get_dst(inst2, 0)) == REG_ECX)) {
-                    loginst(dcontext, 3, inst2, "removing ");
+                    d_r_loginst(dcontext, 3, inst2, "removing ");
                     instrlist_remove(state->trace, inst2);
                 } else {
-                    loginst(dcontext, 1, inst2,
-                            "ERROR : unexpected instruction in constant prop indirect "
-                            "branch removal (2) aborting");
+                    d_r_loginst(
+                        dcontext, 1, inst2,
+                        "ERROR : unexpected instruction in constant prop indirect "
+                        "branch removal (2) aborting");
                     return inst;
                 }
                 inst2 = inst3;
                 if (instr_get_opcode(inst2) == OP_nop ||
                     is_store_to_ecxoff(dcontext, inst2)) {
-                    loginst(dcontext, 3, inst2, "removing ");
+                    d_r_loginst(dcontext, 3, inst2, "removing ");
                     instrlist_remove(state->trace, inst2);
                 } else {
-                    loginst(dcontext, 1, inst2,
-                            "ERROR : unexpected instruction in constant prop indirect "
-                            "branch removal (3) aborting");
+                    d_r_loginst(
+                        dcontext, 1, inst2,
+                        "ERROR : unexpected instruction in constant prop indirect "
+                        "branch removal (3) aborting");
                     return inst;
                 }
 
@@ -2351,12 +2361,13 @@ prop_simplify(instr_t *inst, prop_state_t *state)
                 /* some op may have removed this already so check to be sure */
                 inst2 = instr_get_next(inst);
                 if (is_load_from_ecxoff(dcontext, inst2)) {
-                    loginst(dcontext, 3, inst2, "removing ");
+                    d_r_loginst(dcontext, 3, inst2, "removing ");
                     instrlist_remove(state->trace, inst2);
                 } else {
-                    loginst(dcontext, 1, inst2,
-                            "ERROR : unexpected instruction in constant prop indirect "
-                            "branch removal (a), This could be very bad");
+                    d_r_loginst(
+                        dcontext, 1, inst2,
+                        "ERROR : unexpected instruction in constant prop indirect "
+                        "branch removal (a), This could be very bad");
                 }
 
 #    ifdef DEBUG
@@ -2365,11 +2376,12 @@ prop_simplify(instr_t *inst, prop_state_t *state)
                 opt_stats_t.num_jecxz_instrs_removed += 6;
 #    endif
             } else {
-                loginst(dcontext, 1, inst,
-                        "ERROR : Constant prop predicts indirect branch exit from trace "
-                        "always taken! If this is part of a reconstruct for exception "
-                        "state then the pc calculated is going to be wrong, if it isn't "
-                        "then something is broken regarding constant prop");
+                d_r_loginst(
+                    dcontext, 1, inst,
+                    "ERROR : Constant prop predicts indirect branch exit from trace "
+                    "always taken! If this is part of a reconstruct for exception "
+                    "state then the pc calculated is going to be wrong, if it isn't "
+                    "then something is broken regarding constant prop");
             }
         }
         return inst;
@@ -2687,11 +2699,11 @@ update_prop_state(prop_state_t *state, instr_t *inst, bool intrace)
                 for (i = 0; i < NUM_CONSTANT_ADDRESS; i++) {
                     if (state->addresses[i] == disp && state->address_vals[i] == val &&
                         (state->address_state[i] & PS_VALID_VAL) != 0) {
-                        loginst(dcontext, 3, inst,
-                                " mem location already set to val, simplify ");
+                        d_r_loginst(dcontext, 3, inst,
+                                    " mem location already set to val, simplify ");
                         backup = INSTR_CREATE_nop(dcontext);
                         replace_inst(dcontext, state->trace, inst, backup);
-                        loginst(dcontext, 3, backup, " to ");
+                        d_r_loginst(dcontext, 3, backup, " to ");
                         inst = backup;
                     }
                 }
@@ -2707,11 +2719,11 @@ update_prop_state(prop_state_t *state, instr_t *inst, bool intrace)
                         state->stack_vals[i] == val &&
                         (state->stack_address_state[i] & PS_VALID_VAL) != 0 &&
                         state->stack_scope[i] == state->cur_scope) {
-                        loginst(dcontext, 3, inst,
-                                " mem location already set to val, simplify ");
+                        d_r_loginst(dcontext, 3, inst,
+                                    " mem location already set to val, simplify ");
                         backup = INSTR_CREATE_nop(dcontext);
                         replace_inst(dcontext, state->trace, inst, backup);
-                        loginst(dcontext, 3, backup, " to ");
+                        d_r_loginst(dcontext, 3, backup, " to ");
                         inst = backup;
                     }
                 }
@@ -2798,7 +2810,7 @@ handle_stack(prop_state_t *state, instr_t *inst)
         return inst;
     }
     if (instr_writes_to_reg(inst, REG_EBP, DR_QUERY_DEFAULT)) {
-        loginst(dcontext, 2, inst, "Lost stack scope count");
+        d_r_loginst(dcontext, 2, inst, "Lost stack scope count");
         state->lost_scope_count = true;
         for (i = 0; i < NUM_STACK_SLOTS; i++) {
             state->stack_address_state[i] = 0;
@@ -2883,7 +2895,7 @@ constant_propagation(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
         /* propagate to sources */
         num_src = instr_num_srcs(inst);
 
-        loginst(dcontext, 3, inst, " checking");
+        d_r_loginst(dcontext, 3, inst, " checking");
 
         for (i = 0; i < num_src; i++) {
             opnd = instr_get_src(inst, i);
@@ -2897,8 +2909,8 @@ constant_propagation(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
             if (!opnd_same(opnd, prop_opnd)) {
 #    ifdef DEBUG
                 opt_stats_t.num_opnds_simplified++;
-                logopnd(dcontext, 3, opnd, " old operand");
-                logopnd(dcontext, 3, prop_opnd, " simplified to  ");
+                d_r_logopnd(dcontext, 3, opnd, " old operand");
+                d_r_logopnd(dcontext, 3, prop_opnd, " simplified to  ");
 #    endif
                 if (backup == NULL)
                     backup = instr_clone(dcontext, inst);
@@ -2913,8 +2925,8 @@ constant_propagation(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
             if (!opnd_same(opnd, prop_opnd)) {
 #    ifdef DEBUG
                 opt_stats_t.num_opnds_simplified++;
-                logopnd(dcontext, 3, opnd, " old operand");
-                logopnd(dcontext, 3, prop_opnd, " simplified to  ");
+                d_r_logopnd(dcontext, 3, opnd, " old operand");
+                d_r_logopnd(dcontext, 3, prop_opnd, " simplified to  ");
 #    endif
                 if (backup == NULL)
                     backup = instr_clone(dcontext, inst);
@@ -2928,16 +2940,16 @@ constant_propagation(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
             if (instr_is_encoding_possible(inst)) {
 #    ifdef DEBUG
                 opt_stats_t.num_instrs_simplified++;
-                loginst(dcontext, 3, backup, " old instruction");
-                loginst(dcontext, 3, inst, " simplified to  ");
+                d_r_loginst(dcontext, 3, backup, " old instruction");
+                d_r_loginst(dcontext, 3, inst, " simplified to  ");
 #    endif
                 instr_destroy(dcontext, backup);
                 backup = NULL;
             } else {
 #    ifdef DEBUG
                 opt_stats_t.num_fail_simplified++;
-                loginst(dcontext, 3, backup, " was unable to simplify ");
-                loginst(dcontext, 3, inst, " to this ");
+                d_r_loginst(dcontext, 3, backup, " was unable to simplify ");
+                d_r_loginst(dcontext, 3, inst, " to this ");
 #    endif
                 replace_inst(dcontext, trace, inst, backup);
                 inst = backup;
@@ -2949,8 +2961,9 @@ constant_propagation(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
         if (state.hint == NULL)
             inst = update_prop_state(&state, inst, true);
         else {
-            loginst(dcontext, 3, state.hint,
-                    " using hint instruction instead of actual to update prop state ");
+            d_r_loginst(
+                dcontext, 3, state.hint,
+                " using hint instruction instead of actual to update prop state ");
             update_prop_state(&state, state.hint, false);
             instr_destroy(dcontext, state.hint);
             state.hint = NULL;
@@ -2959,7 +2972,7 @@ constant_propagation(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
 
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 3, "done constant prop\n");
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
 }
@@ -3003,7 +3016,7 @@ remove_unnecessary_zeroing(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
             if (check_down(zeroed, cur_reg)) {
                 /* is ok to remove instruction reg and subregs already zero */
 #    ifdef DEBUG
-                loginst(dcontext, 3, inst, "unnecsary xor removed ");
+                d_r_loginst(dcontext, 3, inst, "unnecsary xor removed ");
                 opt_stats_t.xors_removed++;
 #    endif
                 remove_inst(dcontext, trace, inst);
@@ -3189,7 +3202,7 @@ remove_dead_code(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
     LOG(THREAD, LOG_OPTS, 3,
         "removing dead loads, global aggressiveness %d local aggressiveness %d\n",
         dc_global_aggr, dc_local_aggr);
-    if (stats->loglevel >= 4 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 4 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
     /* initialize */
@@ -3212,7 +3225,7 @@ remove_dead_code(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
     /* main loop runs from bottom of trace to top */
     for (inst = instrlist_last(trace); inst != NULL; inst = prev_inst) {
         prev_inst = instr_get_prev(inst);
-        loginst(dcontext, 3, inst, "remove_dead_code working on:");
+        d_r_loginst(dcontext, 3, inst, "remove_dead_code working on:");
         if (instr_is_cti(inst) || instr_is_interrupt(inst)) {
             /* perhaps to a bit of multi-trace search here to see if really
              * necessary to mark all flags and regs as live when hit cti? */
@@ -3304,7 +3317,7 @@ remove_dead_code(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                             if (kill_ecx_load) {
 #    ifdef DEBUG
                                 opt_stats_t.dead_loads_removed++;
-                                loginst(dcontext, 3, ecx_load, "removed dead code ");
+                                d_r_loginst(dcontext, 3, ecx_load, "removed dead code ");
 #    endif
                                 remove_inst(dcontext, trace, ecx_load);
                             }
@@ -3341,7 +3354,7 @@ remove_dead_code(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                 /* delete the instruction */
 #    ifdef DEBUG
                 opt_stats_t.dead_loads_removed++;
-                loginst(dcontext, 3, inst, "removed dead code ");
+                d_r_loginst(dcontext, 3, inst, "removed dead code ");
 #    endif
                 remove_inst(dcontext, trace, inst);
             } else {
@@ -3402,7 +3415,7 @@ remove_dead_code(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
     }
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 3, "done removing dead code\n");
-    if (stats->loglevel >= 4 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 4 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
 }
@@ -3476,7 +3489,7 @@ stack_adjust_combiner(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
     int opcode, adj, max_off = 0, cur_off = 0, first_off = 0;
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 3, "combining stack adjustments\n");
-    if (stats->loglevel >= 4 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 4 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
     last_adjust = NULL;
@@ -3485,7 +3498,7 @@ stack_adjust_combiner(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
         next = instr_get_next(inst); /* in case we destroy inst */
 #    ifdef DEBUG
         instr_decode(dcontext, inst);
-        loginst(dcontext, 3, inst, "stack adjust considering");
+        d_r_loginst(dcontext, 3, inst, "stack adjust considering");
 #    endif
         if (first_adjust == NULL) {
             if (is_stack_adjustment(inst)) {
@@ -3506,7 +3519,8 @@ stack_adjust_combiner(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                     cur_off);
                 if (last_adjust != NULL) {
 #    ifdef DEBUG
-                    loginst(dcontext, 3, last_adjust, "  removing old last adjustment");
+                    d_r_loginst(dcontext, 3, last_adjust,
+                                "  removing old last adjustment");
                     opt_stats_t.num_stack_adjust_removed++;
 #    endif
                     ASSERT(cur_off % 4 == 0);
@@ -3558,26 +3572,26 @@ stack_adjust_combiner(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                 LOG(THREAD, LOG_OPTS, 3,
                     "  max offset is less than current off set, set and fix\n");
                 /* need to be sure to allocate enough space on stack at beginning */
-                loginst(dcontext, 3, first_adjust, "  replacing initial adjustment");
+                d_r_loginst(dcontext, 3, first_adjust, "  replacing initial adjustment");
                 set_stack_adjustment(first_adjust, max_off);
-                loginst(dcontext, 3, first_adjust, "  with");
+                d_r_loginst(dcontext, 3, first_adjust, "  with");
                 ASSERT(max_off % 4 == 0);
                 /* protect eflags use lea */
-                loginst(dcontext, 3, last_adjust, "  replacing last adjustment");
+                d_r_loginst(dcontext, 3, last_adjust, "  replacing last adjustment");
                 set_stack_adjustment(last_adjust, cur_off - max_off);
-                loginst(dcontext, 3, last_adjust, "  with");
+                d_r_loginst(dcontext, 3, last_adjust, "  with");
                 ASSERT((cur_off - max_off) % 4 == 0);
             } else {
                 if (cur_off == 0) {
                     /* remove initial and last adjustment */
 #    ifdef DEBUG
                     opt_stats_t.num_stack_adjust_removed++;
-                    loginst(dcontext, 3, first_adjust,
-                            "  curent offset = 0 removing initial adjustment");
+                    d_r_loginst(dcontext, 3, first_adjust,
+                                "  curent offset = 0 removing initial adjustment");
                     if (last_adjust != NULL) {
                         opt_stats_t.num_stack_adjust_removed++;
-                        loginst(dcontext, 3, last_adjust,
-                                "  curent offset = 0 removing last adjustment");
+                        d_r_loginst(dcontext, 3, last_adjust,
+                                    "  curent offset = 0 removing last adjustment");
                     }
 #    endif
                     remove_inst(dcontext, trace, first_adjust);
@@ -3589,10 +3603,10 @@ stack_adjust_combiner(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                         LOG(THREAD, LOG_OPTS, 3,
                             "  current offset %d, initial offset %d\n", cur_off,
                             first_off);
-                        loginst(dcontext, 3, first_adjust,
-                                "  replacing initial adjustment");
+                        d_r_loginst(dcontext, 3, first_adjust,
+                                    "  replacing initial adjustment");
                         set_stack_adjustment(first_adjust, cur_off);
-                        loginst(dcontext, 3, first_adjust, "  with");
+                        d_r_loginst(dcontext, 3, first_adjust, "  with");
                         ASSERT(cur_off % 4 == 0);
                     } else {
                         LOG(THREAD, LOG_OPTS, 3,
@@ -3603,7 +3617,8 @@ stack_adjust_combiner(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                     if (last_adjust != NULL) {
 #    ifdef DEBUG
                         opt_stats_t.num_stack_adjust_removed++;
-                        loginst(dcontext, 3, last_adjust, "  removing last adjustment");
+                        d_r_loginst(dcontext, 3, last_adjust,
+                                    "  removing last adjustment");
 #    endif
                         remove_inst(dcontext, trace, last_adjust);
                     }
@@ -3615,7 +3630,7 @@ stack_adjust_combiner(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
     }
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 3, "done combining stack adjustments\n");
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
 }
@@ -3658,13 +3673,13 @@ remove_return_no_save_eflags(dcontext_t *dcontext, instrlist_t *trace, instr_t *
 
     inst2 = instr_get_next(inst);
     ASSERT(instr_get_opcode(inst) == OP_mov_st);
-    loginst(dcontext, 3, inst, "removing");
+    d_r_loginst(dcontext, 3, inst, "removing");
     remove_inst(dcontext, trace, inst);
     inst = inst2;
 
     inst2 = instr_get_next(inst);
     ASSERT(instr_get_opcode(inst) == OP_pop);
-    loginst(dcontext, 3, inst, "removing");
+    d_r_loginst(dcontext, 3, inst, "removing");
     remove_inst(dcontext, trace, inst);
     inst = inst2;
 
@@ -3672,7 +3687,7 @@ remove_return_no_save_eflags(dcontext_t *dcontext, instrlist_t *trace, instr_t *
     if (instr_get_opcode(inst) == OP_lea) {
         /* this popping of the stack, lea */
         to_pop += opnd_get_disp(instr_get_src(inst, 0));
-        loginst(dcontext, 3, inst, "removing");
+        d_r_loginst(dcontext, 3, inst, "removing");
         remove_inst(dcontext, trace, inst);
         inst = inst2;
 #    ifdef DEBUG
@@ -3682,19 +3697,19 @@ remove_return_no_save_eflags(dcontext_t *dcontext, instrlist_t *trace, instr_t *
 
     inst2 = instr_get_next(inst);
     ASSERT(instr_get_opcode(inst) == OP_cmp);
-    loginst(dcontext, 3, inst, "removing");
+    d_r_loginst(dcontext, 3, inst, "removing");
     remove_inst(dcontext, trace, inst);
     inst = inst2;
 
     inst2 = instr_get_next(inst);
     ASSERT(instr_get_opcode(inst) == OP_jne);
-    loginst(dcontext, 3, inst, "removing");
+    d_r_loginst(dcontext, 3, inst, "removing");
     remove_inst(dcontext, trace, inst);
     inst = inst2;
 
     inst2 = instr_get_next(inst);
     ASSERT(instr_get_opcode(inst) == OP_mov_ld);
-    loginst(dcontext, 3, inst, "removing");
+    d_r_loginst(dcontext, 3, inst, "removing");
     remove_inst(dcontext, trace, inst);
     inst = inst2;
 
@@ -3718,9 +3733,9 @@ remove_return_no_save_eflags(dcontext_t *dcontext, instrlist_t *trace, instr_t *
         } else {
             replacement = OPND_CREATE_INT32(to_pop);
         }
-        loginst(dcontext, 3, inst, " updating stack adjustment :");
+        d_r_loginst(dcontext, 3, inst, " updating stack adjustment :");
         instr_set_src(inst, 0, replacement);
-        loginst(dcontext, 3, inst, " to :");
+        d_r_loginst(dcontext, 3, inst, " to :");
         return inst;
     }
     if ((to_pop <= 127) && (to_pop >= -128)) {
@@ -3729,7 +3744,7 @@ remove_return_no_save_eflags(dcontext_t *dcontext, instrlist_t *trace, instr_t *
         replacement = OPND_CREATE_INT32(to_pop);
     }
     inst2 = INSTR_CREATE_add(dcontext, opnd_create_reg(REG_ESP), replacement);
-    loginst(dcontext, 3, inst2, "adjusting stack");
+    d_r_loginst(dcontext, 3, inst2, "adjusting stack");
     instrlist_preinsert(trace, inst, inst2);
     return inst2;
 }
@@ -3749,13 +3764,13 @@ remove_return(dcontext_t *dcontext, instrlist_t *trace, instr_t *inst)
 
         inst2 = instr_get_next(inst);
         ASSERT(instr_get_opcode(inst) == OP_mov_st);
-        loginst(dcontext, 3, inst, "removing");
+        d_r_loginst(dcontext, 3, inst, "removing");
         remove_inst(dcontext, trace, inst);
         inst = inst2;
 
         inst2 = instr_get_next(inst);
         ASSERT(instr_get_opcode(inst) == OP_pop);
-        loginst(dcontext, 3, inst, "removing");
+        d_r_loginst(dcontext, 3, inst, "removing");
         remove_inst(dcontext, trace, inst);
         inst = inst2;
 
@@ -3763,7 +3778,7 @@ remove_return(dcontext_t *dcontext, instrlist_t *trace, instr_t *inst)
         if (instr_get_opcode(inst2) == OP_lea) {
             /* this popping of the stack, lea */
             to_pop += opnd_get_disp(instr_get_src(inst, 0));
-            loginst(dcontext, 3, inst, "removing");
+            d_r_loginst(dcontext, 3, inst, "removing");
             remove_inst(dcontext, trace, inst);
             inst = inst2;
 #    ifdef DEBUG
@@ -3773,31 +3788,31 @@ remove_return(dcontext_t *dcontext, instrlist_t *trace, instr_t *inst)
 
         inst2 = instr_get_next(inst);
         ASSERT(instr_get_opcode(inst) == OP_lea);
-        loginst(dcontext, 3, inst, "removing");
+        d_r_loginst(dcontext, 3, inst, "removing");
         remove_inst(dcontext, trace, inst);
         inst = inst2;
 
         inst2 = instr_get_next(inst);
         ASSERT(instr_get_opcode(inst) == OP_jecxz);
-        loginst(dcontext, 3, inst, "removing");
+        d_r_loginst(dcontext, 3, inst, "removing");
         remove_inst(dcontext, trace, inst);
         inst = inst2;
 
         inst2 = instr_get_next(inst);
         ASSERT(instr_get_opcode(inst) == OP_lea);
-        loginst(dcontext, 3, inst, "removing");
+        d_r_loginst(dcontext, 3, inst, "removing");
         remove_inst(dcontext, trace, inst);
         inst = inst2;
 
         inst2 = instr_get_next(inst);
         ASSERT(instr_get_opcode(inst) == OP_jmp);
-        loginst(dcontext, 3, inst, "removing");
+        d_r_loginst(dcontext, 3, inst, "removing");
         remove_inst(dcontext, trace, inst);
         inst = inst2;
 
         inst2 = instr_get_next(inst);
         ASSERT(instr_get_opcode(inst) == OP_mov_ld);
-        loginst(dcontext, 3, inst, "removing");
+        d_r_loginst(dcontext, 3, inst, "removing");
         remove_inst(dcontext, trace, inst);
         inst = inst2;
 
@@ -3821,9 +3836,9 @@ remove_return(dcontext_t *dcontext, instrlist_t *trace, instr_t *inst)
             } else {
                 replacement = OPND_CREATE_INT32(to_pop);
             }
-            loginst(dcontext, 3, inst, " updating stack adjustment :");
+            d_r_loginst(dcontext, 3, inst, " updating stack adjustment :");
             instr_set_src(inst, 0, replacement);
-            loginst(dcontext, 3, inst, " to :");
+            d_r_loginst(dcontext, 3, inst, " to :");
             return inst;
         }
         if (check_eflags_cr(inst)) {
@@ -3840,7 +3855,7 @@ remove_return(dcontext_t *dcontext, instrlist_t *trace, instr_t *inst)
                 dcontext, opnd_create_reg(REG_ESP),
                 opnd_create_base_disp(REG_ESP, REG_NULL, 0, to_pop, OPSZ_lea));
         }
-        loginst(dcontext, 3, inst2, "adjusting stack");
+        d_r_loginst(dcontext, 3, inst2, "adjusting stack");
         instrlist_preinsert(trace, inst, inst2);
         return inst2;
     } else
@@ -3902,7 +3917,7 @@ check_return(dcontext_t *dcontext, instr_t *inst, instr_t *push)
         if (instr_get_opcode(lea) != OP_lea)
             lea = inst;
         check = instr_get_src(lea, 0);
-        logopnd(dcontext, 3, check, "check opnd");
+        d_r_logopnd(dcontext, 3, check, "check opnd");
         return (
             opnd_is_near_base_disp(check) &&
             (opnd_get_disp(check) == -(int)opnd_get_immed_int(instr_get_src(push, 0))));
@@ -3912,7 +3927,7 @@ check_return(dcontext_t *dcontext, instr_t *inst, instr_t *push)
         if (instr_get_opcode(cmp) != OP_cmp)
             cmp = inst;
         check = instr_get_src(cmp, 1);
-        logopnd(dcontext, 3, check, "check opnd");
+        d_r_logopnd(dcontext, 3, check, "check opnd");
         return (opnd_is_immed_int(check) &&
                 opnd_get_immed_int(check) == opnd_get_immed_int(instr_get_src(push, 0)));
     }
@@ -3931,19 +3946,19 @@ call_return_matching(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
     top = 0;
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 3, "starting call return matching\n");
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
     for (inst = instrlist_first(trace); inst != NULL; inst = next_inst) {
         next_inst = instr_get_next(inst);
-        loginst(dcontext, 3, inst, "checking");
+        d_r_loginst(dcontext, 3, inst, "checking");
         // look for push_imm from call and add to state
         if (next_inst != NULL) {
             opcode = instr_get_opcode(next_inst);
             if ((opcode == OP_push_imm) &&
                 (opnd_get_size(instr_get_src(next_inst, 0)) == OPSZ_4)) {
                 inst = next_inst;
-                loginst(dcontext, 3, inst, "found call push");
+                d_r_loginst(dcontext, 3, inst, "found call push");
                 if (top < CALL_RETURN_STACK_SIZE) {
                     a[top] = inst;
                     top++;
@@ -3958,16 +3973,16 @@ call_return_matching(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
         }
         // look for pop from return and remove instruction is possible
         if (is_return(dcontext, inst)) {
-            loginst(dcontext, 3, inst, "found start of return");
+            d_r_loginst(dcontext, 3, inst, "found start of return");
             while ((top > 0) &&
                    (!check_return(dcontext, instr_get_next(instr_get_next(inst)),
                                   a[top - 1]))) {
                 top--;
-                loginst(dcontext, 3, a[top],
-                        "ignoring probable non call push immed on call return stack");
+                d_r_loginst(dcontext, 3, a[top],
+                            "ignoring probable non call push immed on call return stack");
             }
             if (top > 0) {
-                loginst(dcontext, 3, a[top - 1], "corresponding push was");
+                d_r_loginst(dcontext, 3, a[top - 1], "corresponding push was");
                 LOG(THREAD, LOG_OPTS, 3, "attempting to remove return code\n");
                 next_inst = remove_return(dcontext, trace, inst);
                 top--;
@@ -3978,7 +3993,7 @@ call_return_matching(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
     }
 #    ifdef DEBUG
     LOG(THREAD, LOG_OPTS, 3, "done call return matching\n");
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_OPTS) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_OPTS) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
 }
@@ -4050,7 +4065,7 @@ replace_inc_with_add(dcontext_t *dcontext, instr_t *inst, instrlist_t *trace)
     for (in = inst; in != NULL; in = instr_get_next(in)) {
         eflags = instr_get_eflags(in, DR_QUERY_DEFAULT);
         if ((eflags & EFLAGS_READ_CF) != 0) {
-            loginst(dcontext, 3, in, "reads CF => cannot replace inc with add");
+            d_r_loginst(dcontext, 3, in, "reads CF => cannot replace inc with add");
             return false;
         }
         /* if writes but doesn't read, ok */
@@ -4075,7 +4090,7 @@ replace_inc_with_add(dcontext_t *dcontext, instr_t *inst, instrlist_t *trace)
             if (!opnd_is_near_pc(instr_get_target(in)))
                 break;
             target = (byte *)opnd_get_pc(instr_get_target(in));
-            loginst(dcontext, 3, in, "looking at target");
+            d_r_loginst(dcontext, 3, in, "looking at target");
             instr_init(dcontext, &tinst);
             do {
                 instr_reset(dcontext, &tinst);
@@ -4083,7 +4098,8 @@ replace_inc_with_add(dcontext_t *dcontext, instr_t *inst, instrlist_t *trace)
                 ASSERT(instr_valid(&tinst));
                 eflags = instr_get_eflags(&tinst, DR_QUERY_DEFAULT);
                 if ((eflags & EFLAGS_READ_CF) != 0) {
-                    loginst(dcontext, 3, in, "reads CF => cannot replace inc with add");
+                    d_r_loginst(dcontext, 3, in,
+                                "reads CF => cannot replace inc with add");
                     return false;
                 }
                 /* if writes but doesn't read, ok */
@@ -4161,19 +4177,19 @@ remove_redundant_loads(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
         if (opnd_get_base(mem_read) != REG_EBP || opnd_get_index(mem_read) != REG_NULL)
             continue;
         LOG(THREAD, LOG_OPTS, 3, "\n");
-        loginst(dcontext, 3, instr, " reads memory, try to eliminate. ");
+        d_r_loginst(dcontext, 3, instr, " reads memory, try to eliminate. ");
 
         // walk backwards to try to find where the memory was written
         for (dist = 0, first_mem_access = instr_get_prev(instr);
              ((dist < MAX_DIST) && (first_mem_access != NULL));
              first_mem_access = instr_get_prev(first_mem_access), dist++) {
 
-            loginst(dcontext, 3, first_mem_access, "mem_writer walking backwards");
+            d_r_loginst(dcontext, 3, first_mem_access, "mem_writer walking backwards");
 
             // if the instr writes to ebp (eventually, any register)
             if (instruction_affects_mem_access(first_mem_access, mem_read)) {
-                loginst(dcontext, 3, first_mem_access,
-                        "this instr. probably writes to ebp");
+                d_r_loginst(dcontext, 3, first_mem_access,
+                            "this instr. probably writes to ebp");
                 first_mem_access = NULL;
                 break;
             }
@@ -4183,26 +4199,28 @@ remove_redundant_loads(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
 
                 // takes care of push/pop. should i make this if (!pushorpop?)
                 if (opnd_is_memory_reference(writeopnd)) {
-                    loginst(dcontext, 3, first_mem_access, "this instr writes to memory");
+                    d_r_loginst(dcontext, 3, first_mem_access,
+                                "this instr writes to memory");
                     if (opnd_same_address(writeopnd, mem_read)) {
 
                         // if the writing instruction was a store, then its OK
 
                         if (instr_get_opcode(first_mem_access) == OP_mov_st) {
-                            loginst(dcontext, 3, first_mem_access,
-                                    "this instr writes to same location");
+                            d_r_loginst(dcontext, 3, first_mem_access,
+                                        "this instr writes to same location");
                             orig_reg_opnd = instr_get_src(first_mem_access, 0);
                             removed_from_store = true;
                             if (!opnd_is_reg(orig_reg_opnd)) {
-                                loginst(
+                                d_r_loginst(
                                     dcontext, 3, first_mem_access,
                                     "source isn't a register. can't optimize for now");
                                 first_mem_access = NULL;
                             }
                             break;
                         } else { // an add or something else wrote to memory
-                            loginst(dcontext, 3, first_mem_access,
-                                    "this non-store accesses memory, stop optimization");
+                            d_r_loginst(
+                                dcontext, 3, first_mem_access,
+                                "this non-store accesses memory, stop optimization");
                             first_mem_access = NULL;
 
                             break;
@@ -4225,8 +4243,8 @@ remove_redundant_loads(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                     } // end quick fix
 
                     if (!safe_write(first_mem_access)) {
-                        loginst(dcontext, 3, first_mem_access,
-                                "unsafe write, killing optmization");
+                        d_r_loginst(dcontext, 3, first_mem_access,
+                                    "unsafe write, killing optmization");
                         first_mem_access = NULL;
 
                         break;
@@ -4240,18 +4258,19 @@ remove_redundant_loads(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
 
                 // takes care of push/pop. should i make this if (!pushorpop?)
                 if (opnd_is_memory_reference(readopnd)) {
-                    loginst(dcontext, 3, first_mem_access,
-                            "this instr reads from memory");
+                    d_r_loginst(dcontext, 3, first_mem_access,
+                                "this instr reads from memory");
                     if (opnd_same_address(readopnd, mem_read)) {
                         // if the writing instruction was a store, then its OK
                         if (instr_get_opcode(first_mem_access) == OP_mov_ld) {
-                            loginst(dcontext, 3, first_mem_access,
-                                    "this instr reads from the same location");
+                            d_r_loginst(dcontext, 3, first_mem_access,
+                                        "this instr reads from the same location");
                             orig_reg_opnd = instr_get_dst(first_mem_access, 0);
                             removed_from_store = false;
                             if (!opnd_is_reg(orig_reg_opnd)) {
-                                loginst(dcontext, 3, first_mem_access,
-                                        "dest. isn't a register. can't optimize for now");
+                                d_r_loginst(
+                                    dcontext, 3, first_mem_access,
+                                    "dest. isn't a register. can't optimize for now");
                                 ASSERT(0);
                                 first_mem_access = NULL;
                             }
@@ -4285,10 +4304,10 @@ remove_redundant_loads(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
              reg_write_checker != instr;
              reg_write_checker = instr_get_next(reg_write_checker)) {
 
-            loginst(dcontext, 3, reg_write_checker, "walking forward");
+            d_r_loginst(dcontext, 3, reg_write_checker, "walking forward");
             if (instr_is_cti(reg_write_checker)) {
-                loginst(dcontext, 3, reg_write_checker,
-                        "holy shit, load-removal across basic blocks!");
+                d_r_loginst(dcontext, 3, reg_write_checker,
+                            "holy shit, load-removal across basic blocks!");
                 ctis++;
             }
 
@@ -4298,8 +4317,8 @@ remove_redundant_loads(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
 #    ifdef DEBUG
                 opt_stats_t.reg_overwritten++;
 #    endif
-                loginst(dcontext, 3, reg_write_checker,
-                        "original register was overwritten");
+                d_r_loginst(dcontext, 3, reg_write_checker,
+                            "original register was overwritten");
                 break;
             }
         }
@@ -4326,8 +4345,8 @@ remove_redundant_loads(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                 instrlist_remove(trace, instr);
                 instr_destroy(dcontext, instr);
             } else if (!instr_is_encoding_possible(instr)) {
-                loginst(dcontext, 3, instr,
-                        "encoding not possible ;( reverting to orig. instr\n");
+                d_r_loginst(dcontext, 3, instr,
+                            "encoding not possible ;( reverting to orig. instr\n");
                 ok = instr_replace_src_opnd(instr, opnd_create_reg(orig_reg), mem_read);
                 ASSERT(ok);
             } else {
@@ -4339,14 +4358,14 @@ remove_redundant_loads(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
 #    ifdef DEBUG
                     opt_stats_t.loads_removed_from_stores++;
 #    endif
-                    loginst(dcontext, 3, instr,
-                            "replaced original instr with val from store");
+                    d_r_loginst(dcontext, 3, instr,
+                                "replaced original instr with val from store");
                 } else {
 #    ifdef DEBUG
                     opt_stats_t.loads_removed_from_loads++;
 #    endif
-                    loginst(dcontext, 3, instr,
-                            "replaced original instr with val from load");
+                    d_r_loginst(dcontext, 3, instr,
+                                "replaced original instr with val from load");
                 }
             }
         } else {
@@ -4365,12 +4384,12 @@ remove_redundant_loads(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
                 copy_to_dead_instr =
                     INSTR_CREATE_mov_ld(dcontext, dead_reg_opnd, orig_reg_opnd);
                 instrlist_postinsert(trace, first_mem_access, copy_to_dead_instr);
-                loginst(dcontext, 3, copy_to_dead_instr,
-                        "inserted this to save val. in dead register");
+                d_r_loginst(dcontext, 3, copy_to_dead_instr,
+                            "inserted this to save val. in dead register");
 
                 instr_replace_src_opnd(instr, mem_read, dead_reg_opnd);
-                loginst(dcontext, 3, instr,
-                        "modified this instr to use the new dead register");
+                d_r_loginst(dcontext, 3, instr,
+                            "modified this instr to use the new dead register");
 #    ifdef DEBUG
                 opt_stats_t.val_saved_in_dead_reg++;
                 opt_stats_t.ctis_in_load_removal += ctis;
@@ -4521,10 +4540,10 @@ prefetch_optimize_trace(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
             if (insertprefetch) {
 #    ifdef DEBUG
                 LOG(THREAD, LOG_OPTS, 3, "in trace " PFX " inserting prefetch for:", tag);
-                if (stats->loglevel >= 3)
+                if (d_r_stats->loglevel >= 3)
                     instr_disassemble(dcontext, instr, THREAD);
                 LOG(THREAD, LOG_OPTS, 3, " after instruction: ");
-                if (stats->loglevel >= 3)
+                if (d_r_stats->loglevel >= 3)
                     instr_disassemble(dcontext, tracewalker, THREAD);
                 LOG(THREAD, LOG_OPTS, 3, "\n");
 #    endif
@@ -4748,12 +4767,12 @@ replace_self_loop_with_instr(dcontext_t *dcontext, app_pc tag, instrlist_t *trac
         if (instr_is_cbr(in) || instr_is_ubr(in)) {
             targetop = instr_get_target(in);
             if (opnd_is_near_pc(targetop) && opnd_get_pc(targetop) == tag) {
-                loginst(dcontext, 3, in, "self_loop (pc target==tag) fixing in");
+                d_r_loginst(dcontext, 3, in, "self_loop (pc target==tag) fixing in");
                 instr_set_target(in, opnd_create_instr(desiredtargetinstr));
             } else if (opnd_is_near_instr(targetop) && opnd_get_instr(targetop) == top) {
-                loginst(dcontext, 3, in, "self_loop (inter traget==top)fixing in");
-                logopnd(dcontext, 3, opnd_create_instr(desiredtargetinstr),
-                        "self_loop in now points to");
+                d_r_loginst(dcontext, 3, in, "self_loop (inter traget==top)fixing in");
+                d_r_logopnd(dcontext, 3, opnd_create_instr(desiredtargetinstr),
+                            "self_loop in now points to");
                 instr_set_target(in, opnd_create_instr(desiredtargetinstr));
             }
         }

--- a/core/arch/x86/proc.c
+++ b/core/arch/x86/proc.c
@@ -326,7 +326,7 @@ proc_init_arch(void)
      * care enough to add more, it would probably be best to loop
      * through a const array of feature names.
      */
-    if (stats->loglevel > 0 && (stats->logmask & LOG_TOP) != 0) {
+    if (d_r_stats->loglevel > 0 && (d_r_stats->logmask & LOG_TOP) != 0) {
         LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n\tedx = 0x%08x\n\tecx = 0x%08x\n",
             cpu_info.features.flags_edx, cpu_info.features.flags_ecx);
         LOG(GLOBAL, LOG_TOP, 1, "\text_edx = 0x%08x\n\text_ecx = 0x%08x\n",

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -196,7 +196,7 @@ DECL_EXTERN(os_terminate_wow64_stack)
 
 /* non-functions: these make us non-PIC! (PR 212290) */
 DECL_EXTERN(exiting_thread_count)
-DECL_EXTERN(initstack)
+DECL_EXTERN(d_r_initstack)
 DECL_EXTERN(initstack_mutex)
 DECL_EXTERN(int_syscall_address)
 DECL_EXTERN(syscalls)
@@ -621,8 +621,8 @@ cat_done_saving_dstack:
 cat_thread_only:
         CALLC0(GLOBAL_REF(dynamo_thread_exit))
 cat_no_thread:
-        /* now switch to initstack for cleanup of dstack
-         * could use initstack for whole thing but that's too long
+        /* now switch to d_r_initstack for cleanup of dstack
+         * could use d_r_initstack for whole thing but that's too long
          * of a time to hold global initstack_mutex */
         mov      ecx, 1
 #if !defined(X64) && defined(LINUX)
@@ -661,10 +661,10 @@ cat_have_lock:
         /* swap stacks */
 #if !defined(X64) && defined(LINUX)
         /* PIC base is still in xdi */
-        lea      REG_XBP, VAR_VIA_GOT(REG_XDI, GLOBAL_REF(initstack))
+        lea      REG_XBP, VAR_VIA_GOT(REG_XDI, GLOBAL_REF(d_r_initstack))
         mov      REG_XSP, PTRSZ [REG_XBP]
 #else
-        mov      REG_XSP, PTRSZ SYMREF(initstack) /* rip-relative on x64 */
+        mov      REG_XSP, PTRSZ SYMREF(d_r_initstack) /* rip-relative on x64 */
 #endif
         /* now save registers */
 #if defined(MACOS) && !defined(X64)
@@ -724,9 +724,9 @@ cat_no_thread2:
 #ifdef WINDOWS
         pop      REG_XSP    /* get the stack pointer we pushed earlier */
 #endif
-        /* give up initstack mutex -- potential problem here with a thread getting
-         *   an asynch event that then uses initstack, but syscall should only care
-         *   about ebx and edx */
+        /* Give up initstack_mutex -- potential problem here with a thread getting
+         * an asynch event that then uses d_r_initstack, but syscall should only care
+         * about ebx and edx. */
 #if !defined(X64) && defined(LINUX)
         /* PIC base is still in xdi */
         lea      REG_XBP, VAR_VIA_GOT(REG_XDI, initstack_mutex)
@@ -1710,7 +1710,7 @@ GLOBAL_LABEL(back_from_native:)
 Lback_from_native:
 #endif
         /* assume valid esp
-         * FIXME: more robust if don't use app's esp -- should use initstack
+         * FIXME: more robust if don't use app's esp -- should use d_r_initstack
          */
         /* grab exec state and pass as param in a priv_mcontext_t struct */
         PUSH_PRIV_MCXT(0 /* for priv_mcontext_t.pc */)

--- a/core/arch/x86_code.c
+++ b/core/arch/x86_code.c
@@ -123,7 +123,7 @@ dynamo_start(priv_mcontext_t *mc)
 
     /* Swap stacks so d_r_dispatch is invoked outside the application. */
     call_switch_stack(dcontext, dcontext->dstack, (void (*)(void *))d_r_dispatch,
-                      NULL /*not on initstack*/, true /*return on error*/);
+                      NULL /*not on d_r_initstack*/, true /*return on error*/);
     /* In release builds, this will simply return and continue native
      * execution.  That's better than calling unexpected_return() which
      * goes into an infinite loop.
@@ -231,7 +231,7 @@ auto_setup(ptr_uint_t appstack)
      */
     IF_WINDOWS(os_swap_context(dcontext, false /*to priv*/, DR_STATE_STACK_BOUNDS));
     call_switch_stack(dcontext, dcontext->dstack, (void (*)(void *))d_r_dispatch,
-                      NULL /*not on initstack*/, false /*shouldn't return*/);
+                      NULL /*not on d_r_initstack*/, false /*shouldn't return*/);
     ASSERT_NOT_REACHED();
 }
 
@@ -315,7 +315,7 @@ new_thread_setup(priv_mcontext_t *mc)
     thread_starting(dcontext);
 
     call_switch_stack(dcontext, dcontext->dstack, (void (*)(void *))d_r_dispatch,
-                      NULL /*not on initstack*/, false /*shouldn't return*/);
+                      NULL /*not on d_r_initstack*/, false /*shouldn't return*/);
     ASSERT_NOT_REACHED();
 }
 
@@ -358,7 +358,7 @@ new_bsdthread_setup(priv_mcontext_t *mc)
 #        endif
 
     call_switch_stack(dcontext, dcontext->dstack, (void (*)(void *))d_r_dispatch,
-                      NULL /*not on initstack*/, false /*shouldn't return*/);
+                      NULL /*not on d_r_initstack*/, false /*shouldn't return*/);
     ASSERT_NOT_REACHED();
 }
 #    endif /* MACOS */
@@ -405,7 +405,7 @@ nt_continue_setup(priv_mcontext_t *mc)
     IF_WINDOWS(swap_peb_pointer(dcontext, true /*to priv*/));
 
     call_switch_stack(dcontext, dcontext->dstack, (void (*)(void *))d_r_dispatch,
-                      NULL /*not on initstack*/, false /*shouldn't return*/);
+                      NULL /*not on d_r_initstack*/, false /*shouldn't return*/);
     ASSERT_NOT_REACHED();
 }
 

--- a/core/drlibc/drlibc_notdr_stats.c
+++ b/core/drlibc/drlibc_notdr_stats.c
@@ -39,4 +39,4 @@
 #include "../globals.h"
 
 static dr_statistics_t libmodule_stats;
-WEAK dr_statistics_t *stats = &libmodule_stats;
+WEAK dr_statistics_t *d_r_stats = &libmodule_stats;

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -138,7 +138,7 @@ bool standalone_library = false;
 bool post_execve = false;
 #endif
 /* initial stack so we don't have to use app's */
-byte *initstack;
+byte *d_r_initstack;
 
 event_t dr_app_started;
 event_t dr_attach_finished;
@@ -244,7 +244,7 @@ file_t main_logfile = INVALID_FILE;
 
 #endif /* DEBUG ****************************/
 
-dr_statistics_t *stats = NULL;
+dr_statistics_t *d_r_stats = NULL;
 
 DECLARE_FREQPROT_VAR(static int num_known_threads, 0);
 #ifdef UNIX
@@ -306,27 +306,27 @@ statistics_pre_init(void)
      */
     /* The indirection here is left over from when we used to allow alternative
      * locations for stats (namely shared memory for the old MIT gui). */
-    stats = &nonshared_stats;
-    stats->process_id = get_process_id();
-    strncpy(stats->process_name, get_application_name(), MAXIMUM_PATH);
-    stats->process_name[MAXIMUM_PATH - 1] = '\0';
-    ASSERT(strlen(stats->process_name) > 0);
-    stats->num_stats = 0;
+    d_r_stats = &nonshared_stats;
+    d_r_stats->process_id = get_process_id();
+    strncpy(d_r_stats->process_name, get_application_name(), MAXIMUM_PATH);
+    d_r_stats->process_name[MAXIMUM_PATH - 1] = '\0';
+    ASSERT(strlen(d_r_stats->process_name) > 0);
+    d_r_stats->num_stats = 0;
 }
 
 static void
 statistics_init(void)
 {
     /* should have called statistics_pre_init() first */
-    ASSERT(stats == &nonshared_stats);
-    ASSERT(stats->num_stats == 0);
+    ASSERT(d_r_stats == &nonshared_stats);
+    ASSERT(d_r_stats->num_stats == 0);
 #ifndef DEBUG
     if (!DYNAMO_OPTION(global_rstats)) {
         /* references to stat values should return 0 (static var) */
         return;
     }
 #endif
-    stats->num_stats = 0
+    d_r_stats->num_stats = 0
 #ifdef DEBUG
 #    define STATS_DEF(desc, name) +1
 #else
@@ -342,15 +342,15 @@ statistics_init(void)
      * not much in release build.
      */
 #ifdef DEBUG
-#    define STATS_DEF(desc, statname)                               \
-        strncpy(stats->statname##_pair.name, desc,                  \
-                BUFFER_SIZE_ELEMENTS(stats->statname##_pair.name)); \
-        NULL_TERMINATE_BUFFER(stats->statname##_pair.name);
+#    define STATS_DEF(desc, statname)                                   \
+        strncpy(d_r_stats->statname##_pair.name, desc,                  \
+                BUFFER_SIZE_ELEMENTS(d_r_stats->statname##_pair.name)); \
+        NULL_TERMINATE_BUFFER(d_r_stats->statname##_pair.name);
 #else
-#    define RSTATS_DEF(desc, statname)                              \
-        strncpy(stats->statname##_pair.name, desc,                  \
-                BUFFER_SIZE_ELEMENTS(stats->statname##_pair.name)); \
-        NULL_TERMINATE_BUFFER(stats->statname##_pair.name);
+#    define RSTATS_DEF(desc, statname)                                  \
+        strncpy(d_r_stats->statname##_pair.name, desc,                  \
+                BUFFER_SIZE_ELEMENTS(d_r_stats->statname##_pair.name)); \
+        NULL_TERMINATE_BUFFER(d_r_stats->statname##_pair.name);
 #endif
 #include "statsx.h"
 #undef STATS_DEF
@@ -361,14 +361,14 @@ static void
 statistics_exit(void)
 {
     if (doing_detach)
-        memset(stats, 0, sizeof(*stats)); /* for possible re-attach */
-    stats = NULL;
+        memset(d_r_stats, 0, sizeof(*d_r_stats)); /* for possible re-attach */
+    d_r_stats = NULL;
 }
 
 dr_statistics_t *
 get_dr_stats(void)
 {
-    return stats;
+    return d_r_stats;
 }
 
 /* initialize per-process dynamo state; this must be called before any
@@ -439,7 +439,7 @@ dynamorio_app_init(void)
         /* decision: nullcalls WILL create a dynamorio.log file and
          * fill it with perfctr stats!
          */
-        if (stats->loglevel > 0) {
+        if (d_r_stats->loglevel > 0) {
             main_logfile = open_log_file(main_logfile_name(), NULL, 0);
             LOG(GLOBAL, LOG_TOP, 1, "global log file fd=%d\n", main_logfile);
         } else {
@@ -448,9 +448,9 @@ dynamorio_app_init(void)
              * N.B.: when checking for no logdir, we check for empty string or
              * first char '<'!
              */
-            strncpy(stats->logdir, "<none (loglevel was 0 on startup)>",
+            strncpy(d_r_stats->logdir, "<none (loglevel was 0 on startup)>",
                     MAXIMUM_PATH - 1);
-            stats->logdir[MAXIMUM_PATH - 1] = '\0'; /* if max no null */
+            d_r_stats->logdir[MAXIMUM_PATH - 1] = '\0'; /* if max no null */
             main_logfile = INVALID_FILE;
         }
 
@@ -526,11 +526,11 @@ dynamorio_app_init(void)
 
         /* Setup for handling faults in loader_init() */
         /* initial stack so we don't have to use app's
-         * N.B.: we never de-allocate initstack (see comments in app_exit)
+         * N.B.: we never de-allocate d_r_initstack (see comments in app_exit)
          */
-        initstack = (byte *)stack_alloc(DYNAMORIO_STACK_SIZE, NULL);
-        LOG(GLOBAL, LOG_SYNCH, 2, "initstack is " PFX "-" PFX "\n",
-            initstack - DYNAMORIO_STACK_SIZE, initstack);
+        d_r_initstack = (byte *)stack_alloc(DYNAMORIO_STACK_SIZE, NULL);
+        LOG(GLOBAL, LOG_SYNCH, 2, "d_r_initstack is " PFX "-" PFX "\n",
+            d_r_initstack - DYNAMORIO_STACK_SIZE, d_r_initstack);
 
 #ifdef WINDOWS
         /* PR203701: separate stack for error reporting when the
@@ -762,12 +762,12 @@ dynamorio_fork_init(dcontext_t *dcontext)
     ASSERT(!post_execve);
 
 #    ifdef DEBUG
-    /* copy stats->logdir
-     * stats->logdir is static, so current copy is fine, don't need
+    /* copy d_r_stats->logdir
+     * d_r_stats->logdir is static, so current copy is fine, don't need
      * frozen copy
      */
-    strncpy(parent_logdir, stats->logdir, MAXIMUM_PATH - 1);
-    stats->logdir[MAXIMUM_PATH - 1] = '\0'; /* if max no null */
+    strncpy(parent_logdir, d_r_stats->logdir, MAXIMUM_PATH - 1);
+    d_r_stats->logdir[MAXIMUM_PATH - 1] = '\0'; /* if max no null */
 #    endif
 
     if (get_log_dir(PROCESS_DIR, NULL, NULL)) {
@@ -778,7 +778,7 @@ dynamorio_fork_init(dcontext_t *dcontext)
 
 #    ifdef DEBUG
     /* just like dynamorio_app_init, create main_logfile before stats */
-    if (stats->loglevel > 0) {
+    if (d_r_stats->loglevel > 0) {
         /* we want brand new log files.  os_fork_init() closed inherited files. */
         main_logfile = open_log_file(main_logfile_name(), NULL, 0);
         print_file(main_logfile, "%s\n", dynamorio_version_string);
@@ -787,11 +787,11 @@ dynamorio_fork_init(dcontext_t *dcontext)
         print_file(main_logfile, "Parent's log dir: %s\n", parent_logdir);
     }
 
-    stats->process_id = get_process_id();
+    d_r_stats->process_id = get_process_id();
 
-    if (stats->loglevel > 0) {
+    if (d_r_stats->loglevel > 0) {
         /* FIXME: share these few lines of code w/ dynamorio_app_init? */
-        LOG(GLOBAL, LOG_TOP, 1, "Running: %s\n", stats->process_name);
+        LOG(GLOBAL, LOG_TOP, 1, "Running: %s\n", d_r_stats->process_name);
 #        ifndef _WIN32_WCE
         LOG(GLOBAL, LOG_TOP, 1, "DYNAMORIO_OPTIONS: %s\n", option_string);
 #        endif
@@ -819,7 +819,7 @@ dynamorio_fork_init(dcontext_t *dcontext)
 
     GLOBAL_STAT(num_threads) = 1;
 #    ifdef DEBUG
-    if (stats->loglevel > 0) {
+    if (d_r_stats->loglevel > 0) {
         /* need a new thread-local logfile */
         dcontext->logfile = open_log_file(thread_logfile_name(), NULL, 0);
         print_file(dcontext->logfile, "%s\n", dynamorio_version_string);
@@ -860,7 +860,7 @@ standalone_init(void)
         return GLOBAL_DCONTEXT;
     standalone_library = true;
     /* We have release-build stats now so this is not just DEBUG */
-    stats = &nonshared_stats;
+    d_r_stats = &nonshared_stats;
     /* No reason to limit heap size when there's no code cache. */
     IF_X64(dynamo_options.reachable_heap = false;)
     dynamo_options.vm_base_near_app = false;
@@ -900,7 +900,7 @@ standalone_init(void)
     /* FIXME: share code w/ main init routine? */
     nonshared_stats.logmask = LOG_ALL;
     options_init();
-    if (stats->loglevel > 0) {
+    if (d_r_stats->loglevel > 0) {
         char initial_options[MAX_OPTIONS_STRING];
         main_logfile = open_log_file(main_logfile_name(), NULL, 0);
         print_file(main_logfile, "%s\n", dynamorio_version_string);
@@ -1258,7 +1258,7 @@ dynamo_process_exit_cleanup(void)
 
         dcontext = get_thread_private_dcontext();
 
-        /* we deliberately do NOT clean up initstack (which was
+        /* we deliberately do NOT clean up d_r_initstack (which was
          * allocated using a separate mmap and so is not part of some
          * large unit that is de-allocated), as it is used in special
          * circumstances to call us...FIXME: is this memory leak ok?
@@ -2302,7 +2302,7 @@ dynamo_thread_init(byte *dstack_in, priv_mcontext_t *mc,
 
     DOLOG(1, LOG_STATS, { dump_global_stats(false); });
 #ifdef DEBUG
-    if (stats->loglevel > 0) {
+    if (d_r_stats->loglevel > 0) {
         dcontext->logfile = open_log_file(thread_logfile_name(), NULL, 0);
         print_file(dcontext->logfile, "%s\n", dynamorio_version_string);
     } else {
@@ -3435,7 +3435,7 @@ exiting_dynamorio(void)
 bool
 is_on_initstack(byte *esp)
 {
-    return (esp <= initstack && esp > initstack - DYNAMORIO_STACK_SIZE);
+    return (esp <= d_r_initstack && esp > d_r_initstack - DYNAMORIO_STACK_SIZE);
 }
 
 /* Note this includes any stack guard pages */

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -558,7 +558,7 @@ typedef struct _fcache_list_t {
     /* These lists are protected by allunits_lock. */
     fcache_unit_t *units; /* list of all allocated fcache units */
     fcache_unit_t *dead;  /* list of deleted units ready for re-allocation */
-    /* FIXME: num_dead duplicates stats->fcache_num_free, but we want num_dead
+    /* FIXME: num_dead duplicates d_r_stats->fcache_num_free, but we want num_dead
      * for release build too, so it's separate...can we do better?
      */
     uint num_dead;

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -2375,7 +2375,7 @@ fragment_create(dcontext_t *dcontext, app_pc tag, int body_size, int direct_exit
      * release builds
      */
     DOSTATS({
-        if (stats != NULL &&
+        if (d_r_stats != NULL &&
             (uint)GLOBAL_STAT(num_fragments) ==
                 INTERNAL_OPTION(reset_at_fragment_count)) {
             ASSERT(INTERNAL_OPTION(reset_at_fragment_count) != 0);
@@ -2386,7 +2386,7 @@ fragment_create(dcontext_t *dcontext, app_pc tag, int body_size, int direct_exit
         if ((uint)GLOBAL_STAT(num_fragments) == INTERNAL_OPTION(log_at_fragment_count)) {
             /* we started at loglevel 1 and now we raise to the requested level */
             options_make_writable();
-            stats->loglevel = DYNAMO_OPTION(stats_loglevel);
+            d_r_stats->loglevel = DYNAMO_OPTION(stats_loglevel);
             options_restore_readonly();
             SYSLOG_INTERNAL_INFO("hit -log_at_fragment_count %d, raising loglevel to %d",
                                  INTERNAL_OPTION(log_at_fragment_count),
@@ -3916,7 +3916,7 @@ fragment_shift_fcache_pointers(dcontext_t *dcontext, fragment_t *f, ssize_t shif
     DOLOG(6, LOG_FRAGMENT, { /* print after start_pc updated so get actual code */
                              LOG(THREAD, LOG_FRAGMENT, 6,
                                  "before shifting F%d (" PFX ")\n", f->id, f->tag);
-                             disassemble_fragment(dcontext, f, stats->loglevel < 3);
+                             disassemble_fragment(dcontext, f, d_r_stats->loglevel < 3);
     });
 
 #ifdef X86
@@ -3938,7 +3938,7 @@ fragment_shift_fcache_pointers(dcontext_t *dcontext, fragment_t *f, ssize_t shif
 
     DOLOG(6, LOG_FRAGMENT, {
         LOG(THREAD, LOG_FRAGMENT, 6, "after shifting F%d (" PFX ")\n", f->id, f->tag);
-        disassemble_fragment(dcontext, f, stats->loglevel < 3);
+        disassemble_fragment(dcontext, f, d_r_stats->loglevel < 3);
     });
 }
 

--- a/core/globals.h
+++ b/core/globals.h
@@ -492,13 +492,13 @@ extern int num_execve_threads;
 #endif
 
 /* global instance of statistics struct */
-extern dr_statistics_t *stats;
+extern dr_statistics_t *d_r_stats;
 
 /* the process-wide logfile */
 extern file_t main_logfile;
 
 /* initial stack so we don't have to use app's */
-extern byte *initstack;
+extern byte *d_r_initstack;
 extern mutex_t initstack_mutex;
 extern byte *initstack_app_xsp;
 

--- a/core/hotpatch.c
+++ b/core/hotpatch.c
@@ -4625,7 +4625,7 @@ hotp_gateway(const hotp_vul_t *vul_tab, const uint num_vuls, const uint vul_inde
         ASSERT_CURIOSITY(dcontext != NULL && dcontext != GLOBAL_DCONTEXT &&
                          "unknown thread");
 
-        /* App esp should neither be on dr stack nor on initstack; see case 7058.
+        /* App esp should neither be on dr stack nor on d_r_initstack; see case 7058.
          * TODO: when the hot patch interface expands to having eip, assert that
          *       the eip isn't inside dr.
          */

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1548,8 +1548,10 @@ check_ilist_translations(instrlist_t *ilist)
             CLIENT_ASSERT(INTERNAL_OPTION(fast_client_decode), "level 0 instr found");
         } else if (instr_is_app(in)) {
             DOLOG(LOG_INTERP, 1, {
-                if (instr_get_translation(in) == NULL)
-                    loginst(get_thread_private_dcontext(), 1, in, "translation is NULL");
+                if (instr_get_translation(in) == NULL) {
+                    d_r_loginst(get_thread_private_dcontext(), 1, in,
+                                "translation is NULL");
+                }
             });
             CLIENT_ASSERT(instr_get_translation(in) != NULL,
                           "translation field must be set for every app instruction");
@@ -1559,8 +1561,10 @@ check_ilist_translations(instrlist_t *ilist)
              * empty restore event callback in that case. */
             DOLOG(LOG_INTERP, 1, {
                 if (instr_get_translation(in) != NULL && !instr_is_our_mangling(in) &&
-                    !dr_xl8_hook_exists())
-                    loginst(get_thread_private_dcontext(), 1, in, "translation != NULL");
+                    !dr_xl8_hook_exists()) {
+                    d_r_loginst(get_thread_private_dcontext(), 1, in,
+                                "translation != NULL");
+                }
             });
             CLIENT_ASSERT(instr_get_translation(in) == NULL ||
                               instr_is_our_mangling(in) || dr_xl8_hook_exists(),
@@ -1598,7 +1602,7 @@ instrument_basic_block(dcontext_t *dcontext, app_pc tag, instrlist_t *bb, bool f
 #    ifdef DEBUG
     LOG(THREAD, LOG_INTERP, 3, "\ninstrument_basic_block ******************\n");
     LOG(THREAD, LOG_INTERP, 3, "\nbefore instrumentation:\n");
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_INTERP) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_INTERP) != 0)
         instrlist_disassemble(dcontext, tag, bb, THREAD);
 #    endif
 
@@ -1628,7 +1632,7 @@ instrument_basic_block(dcontext_t *dcontext, app_pc tag, instrlist_t *bb, bool f
 
 #    ifdef DEBUG
     LOG(THREAD, LOG_INTERP, 3, "\nafter instrumentation:\n");
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_INTERP) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_INTERP) != 0)
         instrlist_disassemble(dcontext, tag, bb, THREAD);
 #    endif
 
@@ -1655,7 +1659,7 @@ instrument_trace(dcontext_t *dcontext, app_pc tag, instrlist_t *trace, bool tran
 #    ifdef DEBUG
     LOG(THREAD, LOG_INTERP, 3, "\ninstrument_trace ******************\n");
     LOG(THREAD, LOG_INTERP, 3, "\nbefore instrumentation:\n");
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_INTERP) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_INTERP) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
 
@@ -1692,7 +1696,7 @@ instrument_trace(dcontext_t *dcontext, app_pc tag, instrlist_t *trace, bool tran
 
 #    ifdef DEBUG
     LOG(THREAD, LOG_INTERP, 3, "\nafter instrumentation:\n");
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_INTERP) != 0)
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_INTERP) != 0)
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #    endif
 
@@ -4291,7 +4295,8 @@ dr_log(void *drcontext, uint mask, uint level, const char *fmt, ...)
 #    ifdef DEBUG
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     va_list ap;
-    if (stats != NULL && ((stats->logmask & mask) == 0 || stats->loglevel < level))
+    if (d_r_stats != NULL &&
+        ((d_r_stats->logmask & mask) == 0 || d_r_stats->loglevel < level))
         return;
     va_start(ap, fmt);
     if (dcontext != NULL)
@@ -6379,7 +6384,7 @@ dr_clobber_retaddr_after_read(void *drcontext, instrlist_t *ilist, instr_t *inst
          * overlap w/ any client uses (DRMGR_NOTE_NONE == 0).
          */
         label->note = 0;
-        /* these values are read back in mangle() */
+        /* these values are read back in d_r_mangle() */
         data->data[0] = (ptr_uint_t)instr;
         data->data[1] = value;
         label->flags |= INSTR_CLOBBER_RETADDR;

--- a/core/link.c
+++ b/core/link.c
@@ -1698,7 +1698,7 @@ static void inline debug_after_link_change(dcontext_t *dcontext, fragment_t *f,
 {
     DOLOG(5, LOG_LINKS, {
         LOG(THREAD, LOG_LINKS, 5, "%s\n", msg);
-        disassemble_fragment(dcontext, f, stats->loglevel < 3);
+        disassemble_fragment(dcontext, f, d_r_stats->loglevel < 3);
     });
 }
 #endif
@@ -2328,9 +2328,9 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
 
     DOLOG(4, LOG_LINKS, {
         LOG(THREAD, LOG_LINKS, 4, "Old fragment after shift:\n");
-        disassemble_fragment(dcontext, old_f, stats->loglevel < 4);
+        disassemble_fragment(dcontext, old_f, d_r_stats->loglevel < 4);
         LOG(THREAD, LOG_LINKS, 4, "New fragment after shift:\n");
-        disassemble_fragment(dcontext, new_f, stats->loglevel < 4);
+        disassemble_fragment(dcontext, new_f, d_r_stats->loglevel < 4);
     });
 }
 

--- a/core/module_list.c
+++ b/core/module_list.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -600,7 +600,7 @@ region_intersection_MD5update(struct MD5Context *ctx, app_pc region1_start,
     if (intersection_len != 0) {
         LOG(GLOBAL, LOG_SYSCALLS, 2, "adding to short hash region " PFX "-" PFX "\n",
             intersection_start, intersection_start + intersection_len);
-        MD5Update(ctx, intersection_start, intersection_len);
+        d_r_md5_update(ctx, intersection_start, intersection_len);
     }
 }
 
@@ -616,7 +616,7 @@ module_calculate_digest_helper(struct MD5Context *md5_full_cxt /* OPTIONAL */,
     LOG(GLOBAL, LOG_VMAREAS, 2, "\t%s: segment " PFX "-" PFX "\n", __FUNCTION__,
         region_start, region_start + region_len);
     if (md5_full_cxt != NULL)
-        MD5Update(md5_full_cxt, region_start, region_len);
+        d_r_md5_update(md5_full_cxt, region_start, region_len);
     if (md5_short_cxt == NULL)
         return;
     if (len_header != 0) {
@@ -793,9 +793,9 @@ module_calculate_digest(OUT module_digest_t *digest, app_pc module_base,
     ASSERT(get_module_base(module_base) == module_base);
 
     if (short_digest)
-        MD5Init(&md5_short_cxt);
+        d_r_md5_init(&md5_short_cxt);
     if (full_digest)
-        MD5Init(&md5_full_cxt);
+        d_r_md5_init(&md5_full_cxt);
 
     /* first region to consider is module header.  on linux this is
      * usually part of 1st segment so perhaps we should skip for linux
@@ -864,9 +864,9 @@ module_calculate_digest(OUT module_digest_t *digest, app_pc module_base,
     }
 
     if (short_digest)
-        MD5Final(digest->short_MD5, &md5_short_cxt);
+        d_r_md5_final(digest->short_MD5, &md5_short_cxt);
     if (full_digest)
-        MD5Final(digest->full_MD5, &md5_full_cxt);
+        d_r_md5_final(digest->full_MD5, &md5_full_cxt);
 
     DOCHECK(1, {
         if (full_digest && short_digest &&

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -197,8 +197,9 @@ create_private_copy(dcontext_t *dcontext, fragment_t *f)
     LOG(THREAD, LOG_MONITOR, 4,
         "Created private copy F%d of original F%d (" PFX ") for trace creation\n",
         md->last_fragment->id, f->id, f->tag);
-    DOLOG(2, LOG_INTERP,
-          { disassemble_fragment(dcontext, md->last_fragment, stats->loglevel <= 3); });
+    DOLOG(2, LOG_INTERP, {
+        disassemble_fragment(dcontext, md->last_fragment, d_r_stats->loglevel <= 3);
+    });
     KSTOP(temp_private_bb);
     /* FIXME - PR 215179, with current hack pad_jmps sometimes marks fragments as
      * CANNOT_BE_TRACE during emit (since we don't yet have a good way to handle
@@ -1303,7 +1304,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
     DOLOG(2, LOG_MONITOR, {
         uint i;
         LOG(THREAD, LOG_MONITOR, 2, "Ending and emitting hot trace (tag " PFX ")\n", tag);
-        if (stats->loglevel >= 4) {
+        if (d_r_stats->loglevel >= 4) {
             instrlist_disassemble(dcontext, md->trace_tag, trace, THREAD);
             LOG(THREAD, LOG_MONITOR, 4, "\n");
         }
@@ -1526,7 +1527,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
     DOLOG(2, LOG_MONITOR, {
         LOG(THREAD, LOG_MONITOR, 1, "Generated trace fragment #%d for tag " PFX "\n",
             GLOBAL_STAT(num_traces), tag);
-        disassemble_fragment(dcontext, trace_f, stats->loglevel < 3);
+        disassemble_fragment(dcontext, trace_f, d_r_stats->loglevel < 3);
     });
 
 #ifdef INTERNAL

--- a/core/native_exec.c
+++ b/core/native_exec.c
@@ -363,7 +363,7 @@ back_from_native_common(dcontext_t *dcontext, priv_mcontext_t *mc, app_pc target
     });
 
     call_switch_stack(dcontext, dcontext->dstack, (void (*)(void *))d_r_dispatch,
-                      NULL /*not on initstack*/, false /*shouldn't return*/);
+                      NULL /*not on d_r_initstack*/, false /*shouldn't return*/);
     ASSERT_NOT_REACHED();
 }
 

--- a/core/nudge.c
+++ b/core/nudge.c
@@ -175,7 +175,7 @@ nudge_thread_cleanup(dcontext_t *dcontext, bool exit_process, uint exit_code)
             }
             call_switch_stack(dcontext, dcontext->dstack,
                               (void (*)(void *))nudge_terminate_on_dstack,
-                              NULL /* not on initstack */, false /* don't return */);
+                              NULL /* not on d_r_initstack */, false /* don't return */);
         } else {
             /* Already on dstack or nudge creator will free app stack. */
             if (exit_process) {

--- a/core/options.c
+++ b/core/options.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2316,11 +2316,11 @@ check_option_compatibility_helper(int recurse_count)
 #    endif
 
 #    ifdef DEBUG
-    if (INTERNAL_OPTION(log_at_fragment_count) > 0 && stats->loglevel > 1) {
+    if (INTERNAL_OPTION(log_at_fragment_count) > 0 && d_r_stats->loglevel > 1) {
         /* start out at 1 */
         if (dynamo_options.stats_loglevel <= 1)
             USAGE_ERROR("-log_at_fragment_count expects >1 delayed loglevel");
-        stats->loglevel = 1;
+        d_r_stats->loglevel = 1;
         changed_options = true;
     }
 #    endif

--- a/core/options.c
+++ b/core/options.c
@@ -82,7 +82,7 @@ struct stats_type {
     int loglevel;
 } thestats;
 
-struct stats_type *stats = &thestats;
+struct stats_type *d_r_stats = &thestats;
 
 /* define away core only features, depending on use outside the core
  * may want to use some of these, NOTE build environments outside of the

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -249,15 +249,15 @@ OPTION_DEFAULT(pathstring_t, logdir, EMPTY_STRING, "directory for log files")
  yet we'll also have the initial value in options_t at the cost of 8 bytes */
 OPTION_COMMAND(uint, stats_logmask, 0, "logmask",
                {
-                   if (stats != NULL && for_this_process)
-                       stats->logmask = options->stats_logmask;
+                   if (d_r_stats != NULL && for_this_process)
+                       d_r_stats->logmask = options->stats_logmask;
                },
                "set mask for logging from specified modules", DYNAMIC, OP_PCACHE_NOP)
 
 OPTION_COMMAND(uint, stats_loglevel, 0, "loglevel",
                {
-                   if (stats != NULL && for_this_process)
-                       stats->loglevel = options->stats_loglevel;
+                   if (d_r_stats != NULL && for_this_process)
+                       d_r_stats->loglevel = options->stats_loglevel;
                },
                "set level of detail for logging", DYNAMIC, OP_PCACHE_NOP)
 OPTION_INTERNAL(bool, log_to_stderr, "log to stderr instead of files")

--- a/core/perfctr.c
+++ b/core/perfctr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -100,7 +100,7 @@ hardware_perfctr_init()
     if (NUM_EVENTS > 2) {
         LOG(GLOBAL, LOG_TOP, 3, "Initializing PAPI multiplexing\n");
         if (PAPI_multiplex_init() != PAPI_OK) {
-            if (stats->loglevel > 0 && (stats->logmask & LOG_TOP) != 0)
+            if (d_r_stats->loglevel > 0 && (d_r_stats->logmask & LOG_TOP) != 0)
                 LOG(GLOBAL, LOG_TOP, 1, "Error initializing PAPI multiplexing\n");
         }
     }
@@ -135,7 +135,7 @@ hardware_perfctr_exit()
     if (dynamo_options.nullcalls) {
         val_array = vals;
     } else {
-        val_array = stats->perfctr_vals;
+        val_array = d_r_stats->perfctr_vals;
     }
     if (PAPI_stop(perfctr_eventset, val_array) != PAPI_OK) {
         LOG(GLOBAL, LOG_TOP, 1,
@@ -150,7 +150,7 @@ hardware_perfctr_exit()
 void
 perfctr_update_gui()
 {
-    if (PAPI_read(perfctr_eventset, stats->perfctr_vals) != PAPI_OK) {
+    if (PAPI_read(perfctr_eventset, d_r_stats->perfctr_vals) != PAPI_OK) {
         LOG(GLOBAL, LOG_TOP, 1,
             "Error stopping and reading hardware performance counters\n");
     }

--- a/core/perscache.c
+++ b/core/perscache.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2382,18 +2382,18 @@ persist_calculate_self_digest(module_digest_t *digest, coarse_persisted_info_t *
 {
     struct MD5Context self_md5_cxt;
     if (TEST(PERSCACHE_GENFILE_MD5_COMPLETE, validation_option)) {
-        MD5Init(&self_md5_cxt);
+        d_r_md5_init(&self_md5_cxt);
         /* Even if generated w/ -persist_map_rw_separate but loaded w/o that
          * option, the md5 should match since the memory layout is the same.
          */
-        MD5Update(&self_md5_cxt, map,
-                  pers->header_len + pers->data_len - sizeof(persisted_footer_t));
-        MD5Final(digest->full_MD5, &self_md5_cxt);
+        d_r_md5_update(&self_md5_cxt, map,
+                       pers->header_len + pers->data_len - sizeof(persisted_footer_t));
+        d_r_md5_final(digest->full_MD5, &self_md5_cxt);
     }
     if (TEST(PERSCACHE_GENFILE_MD5_SHORT, validation_option)) {
-        MD5Init(&self_md5_cxt);
-        MD5Update(&self_md5_cxt, (byte *)pers, pers->header_len);
-        MD5Final(digest->short_MD5, &self_md5_cxt);
+        d_r_md5_init(&self_md5_cxt);
+        d_r_md5_update(&self_md5_cxt, (byte *)pers, pers->header_len);
+        d_r_md5_final(digest->short_MD5, &self_md5_cxt);
     }
 }
 
@@ -2417,13 +2417,13 @@ persist_calculate_module_digest(module_digest_t *digest, app_pc modbase, size_t 
          * the load-time md5 when persisting.
          */
         struct MD5Context code_md5_cxt;
-        MD5Init(&code_md5_cxt);
+        d_r_md5_init(&code_md5_cxt);
         /* Code range should be within a single memory allocation so it should
          * all be readable.  Xref case 9653.
          */
         code_end = MIN(code_end, modbase + view_size);
-        MD5Update(&code_md5_cxt, code_start, code_end - code_start);
-        MD5Final(digest->full_MD5, &code_md5_cxt);
+        d_r_md5_update(&code_md5_cxt, code_start, code_end - code_start);
+        d_r_md5_final(digest->full_MD5, &code_md5_cxt);
     }
     if (TEST(PERSCACHE_MODULE_MD5_SHORT, validation_option)) {
         /* Examine only the image header and the footer (if non-writable)

--- a/core/synch.c
+++ b/core/synch.c
@@ -316,7 +316,7 @@ is_native_thread_state_valid(dcontext_t *dcontext, app_pc pc, byte *esp)
      * here in the same manner as fcache_unit_areas.lock in at_safe_spot().  So
      * instead we just check the pc for the dr dll, interception code, and
      * do_syscall regions and check the stack against the thread's dr stack
-     * and the initstack, all of which we can do without grabbing any locks.
+     * and the d_r_initstack, all of which we can do without grabbing any locks.
      * That should be sufficient at this point, FIXME try to use something
      * like is_dynamo_address() to make this more maintainable */
     /* For sysenter system calls we also have to check the top of the stack
@@ -2259,7 +2259,7 @@ detach_on_permanent_stack(bool internal, bool do_cleanup, dr_stats_t *drstats)
     ASSERT(exit_res == SUCCESS);
     detach_finalize_cleanup();
 
-    stack_free(initstack, DYNAMORIO_STACK_SIZE);
+    stack_free(d_r_initstack, DYNAMORIO_STACK_SIZE);
 
     dynamo_exit_post_detach();
 

--- a/core/translate.c
+++ b/core/translate.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -270,8 +270,8 @@ translate_walk_track(dcontext_t *tdcontext, instr_t *inst, translate_walk_t *wal
          */
         if (walk->translation == NULL) {
             DOLOG(4, LOG_INTERP, {
-                loginst(get_thread_private_dcontext(), 4, inst,
-                        "\tin clean call arg region");
+                d_r_loginst(get_thread_private_dcontext(), 4, inst,
+                            "\tin clean call arg region");
             });
             return;
         }
@@ -419,8 +419,8 @@ translate_walk_track(dcontext_t *tdcontext, instr_t *inst, translate_walk_t *wal
          */
         else {
             DOLOG(4, LOG_INTERP,
-                  loginst(get_thread_private_dcontext(), 4, inst,
-                          "unsupported mangle instr"););
+                  d_r_loginst(get_thread_private_dcontext(), 4, inst,
+                              "unsupported mangle instr"););
             walk->unsupported_mangle = true;
         }
     }
@@ -846,8 +846,8 @@ recreate_app_state_from_ilist(dcontext_t *tdcontext, instrlist_t *ilist, byte *s
                         "translation (pc " PFX ")\n",
                         answer);
                     DOLOG(2, LOG_INTERP,
-                          loginst(get_thread_private_dcontext(), 2, prev_ok,
-                                  "\tprev instr"););
+                          d_r_loginst(get_thread_private_dcontext(), 2, prev_ok,
+                                      "\tprev instr"););
                 }
             } else {
                 answer = instr_get_translation(inst);
@@ -900,7 +900,7 @@ recreate_app_state_from_ilist(dcontext_t *tdcontext, instrlist_t *ilist, byte *s
         if (instr_get_translation(inst) != NULL) {
             prev_ok = inst;
             DOLOG(5, LOG_INTERP,
-                  loginst(get_thread_private_dcontext(), 5, prev_ok, "\tok instr"););
+                  d_r_loginst(get_thread_private_dcontext(), 5, prev_ok, "\tok instr"););
             prev_bytes = instr_get_translation(inst);
             if (instr_is_app(inst)) {
                 /* we really want the pc after the translation target since we'll
@@ -1405,7 +1405,7 @@ recreate_app_state(dcontext_t *tdcontext, priv_mcontext_t *mcontext, bool restor
     recreate_success_t res;
 
 #ifdef DEBUG
-    if (stats->loglevel >= 2 && (stats->logmask & LOG_SYNCH) != 0) {
+    if (d_r_stats->loglevel >= 2 && (d_r_stats->logmask & LOG_SYNCH) != 0) {
         LOG(THREAD_GET, LOG_SYNCH, 2, "recreate_app_state -- translating from:\n");
         dump_mcontext(mcontext, THREAD_GET, DUMP_NOT_XML);
     }
@@ -1415,7 +1415,7 @@ recreate_app_state(dcontext_t *tdcontext, priv_mcontext_t *mcontext, bool restor
 
 #ifdef DEBUG
     if (res) {
-        if (stats->loglevel >= 2 && (stats->logmask & LOG_SYNCH) != 0) {
+        if (d_r_stats->loglevel >= 2 && (d_r_stats->logmask & LOG_SYNCH) != 0) {
             LOG(THREAD_GET, LOG_SYNCH, 2, "recreate_app_state -- translation is:\n");
             dump_mcontext(mcontext, THREAD_GET, DUMP_NOT_XML);
         }

--- a/core/unix/native_elf.c
+++ b/core/unix/native_elf.c
@@ -78,7 +78,7 @@
  */
 enum { DL_RUNTIME_RESOLVE_IDX = 2 };
 
-/* The loader's _dl_fixup.  For ia32 it uses regparms. */
+/* The loader's _dl_fixup.  For ia32 it uses d_r_regparms. */
 typedef void *(*fixup_fn_t)(struct link_map *l_map, uint dynamic_index)
     IF_X86_32(__attribute__((regparm(3), stdcall, unused)));
 

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -5563,7 +5563,7 @@ handle_execve(dcontext_t *dcontext)
         SYSLOG_INTERNAL_INFO("-- execve %s --", fname);
         LOG(THREAD, LOG_SYSCALLS, 1, "syscall: execve %s\n", fname);
         LOG(GLOBAL, LOG_TOP | LOG_SYSCALLS, 1, "execve %s\n", fname);
-        if (stats->loglevel >= 3) {
+        if (d_r_stats->loglevel >= 3) {
             if (argv == NULL) {
                 LOG(THREAD, LOG_SYSCALLS, 3, "\targs are NULL\n");
             } else {
@@ -9836,7 +9836,7 @@ os_thread_take_over(priv_mcontext_t *mc, kernel_sigset_t *sigset)
 
     /* Start interpreting from the signal context. */
     call_switch_stack(dcontext, dcontext->dstack, (void (*)(void *))d_r_dispatch,
-                      NULL /*not on initstack*/, false /*shouldn't return*/);
+                      NULL /*not on d_r_initstack*/, false /*shouldn't return*/);
     ASSERT_NOT_REACHED();
     return true; /* make compiler happy */
 }

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -503,7 +503,7 @@ pcprofile_thread_exit(dcontext_t *dcontext);
 /* in stackdump.c */
 /* fork, dump core, and use gdb for complete stack trace */
 void
-stackdump(void);
+d_r_stackdump(void);
 /* use backtrace feature of glibc for quick but sometimes incomplete trace */
 void
 glibc_stackdump(int fd);

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -499,7 +499,7 @@ signal_exit()
 {
     IF_LINUX(signalfd_exit());
 #ifdef DEBUG
-    if (stats->loglevel > 0 && (stats->logmask & (LOG_ASYNCH | LOG_STATS)) != 0) {
+    if (d_r_stats->loglevel > 0 && (d_r_stats->logmask & (LOG_ASYNCH | LOG_STATS)) != 0) {
         LOG(GLOBAL, LOG_ASYNCH | LOG_STATS, 1, "Total signals delivered: %d\n",
             GLOBAL_STAT(num_signals));
     }
@@ -2048,7 +2048,7 @@ set_blocked(dcontext_t *dcontext, kernel_sigset_t *set, bool absolute)
         }
     }
 #ifdef DEBUG
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_ASYNCH) != 0) {
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_ASYNCH) != 0) {
         LOG(THREAD, LOG_ASYNCH, 3, "blocked signals are now:\n");
         dump_sigset(dcontext, &info->app_sigblocked);
     }
@@ -2173,7 +2173,7 @@ handle_sigprocmask(dcontext_t *dcontext, int how, kernel_sigset_t *app_set,
             }
         }
 #ifdef DEBUG
-        if (stats->loglevel >= 3 && (stats->logmask & LOG_ASYNCH) != 0) {
+        if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_ASYNCH) != 0) {
             LOG(THREAD, LOG_ASYNCH, 3, "blocked signals are now:\n");
             dump_sigset(dcontext, &info->app_sigblocked);
         }
@@ -2243,7 +2243,7 @@ handle_sigsuspend(dcontext_t *dcontext, kernel_sigset_t *set, size_t sigsetsize)
         }
     }
 #ifdef DEBUG
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_ASYNCH) != 0) {
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_ASYNCH) != 0) {
         LOG(THREAD, LOG_ASYNCH, 3, "in sigsuspend, blocked signals are now:\n");
         dump_sigset(dcontext, &info->app_sigblocked);
     }
@@ -4042,7 +4042,7 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
         ucxt->uc_sigmask = info->app_sigblocked;
 #endif
 #ifdef DEBUG
-        if (stats->loglevel >= 3 && (stats->logmask & LOG_ASYNCH) != 0) {
+        if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_ASYNCH) != 0) {
             LOG(THREAD, LOG_ASYNCH, 3, "after sigsuspend, blocked signals are now:\n");
             dump_sigset(dcontext, &info->app_sigblocked);
         }
@@ -4281,7 +4281,7 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
          * we do not need to mark this fragment as FRAG_CANNOT_DELETE
          */
 #ifdef DEBUG
-        if (stats->loglevel >= 2 && (stats->logmask & LOG_ASYNCH) != 0 &&
+        if (d_r_stats->loglevel >= 2 && (d_r_stats->logmask & LOG_ASYNCH) != 0 &&
             safe_is_in_fcache(dcontext, pc, xsp)) {
             ASSERT(f != NULL);
             LOG(THREAD, LOG_ASYNCH, 2, "Got signal at pc " PFX " in this fragment:\n",
@@ -4602,7 +4602,7 @@ compute_memory_target(dcontext_t *dcontext, cache_pc instr_cache_pc,
         LOG(THREAD, LOG_ALL, 2,
             "For SIGSEGV at cache pc " PFX ", computed target %s " PFX "\n",
             instr_cache_pc, *write ? "write" : "read", target);
-        loginst(dcontext, 2, &instr, "\tfaulting instr");
+        d_r_loginst(dcontext, 2, &instr, "\tfaulting instr");
     });
     instr_free(dcontext, &instr);
     return target;
@@ -5429,7 +5429,7 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
      */
 
 #ifdef DEBUG
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_ASYNCH) != 0) {
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_ASYNCH) != 0) {
         LOG(THREAD, LOG_ASYNCH, 3, "original sigcontext " PFX ":\n", sc);
         dump_sigcontext(dcontext, sc);
     }
@@ -5465,7 +5465,7 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
     save_fpstate(dcontext, frame);
 #endif /* LINUX && X86 */
 #ifdef DEBUG
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_ASYNCH) != 0) {
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_ASYNCH) != 0) {
         LOG(THREAD, LOG_ASYNCH, 3, "new sigcontext " PFX ":\n", sc);
         dump_sigcontext(dcontext, sc);
         LOG(THREAD, LOG_ASYNCH, 3, "\n");
@@ -5648,7 +5648,7 @@ terminate_via_kill_from_anywhere(dcontext_t *dcontext, int sig)
          * (i#1160) so we terminate on the dstack.
          */
         call_switch_stack(dcontext, dcontext->dstack,
-                          (void (*)(void *))terminate_via_kill, NULL /*!initstack */,
+                          (void (*)(void *))terminate_via_kill, NULL /*!d_r_initstack */,
                           false /*no return */);
     } else {
         terminate_via_kill(dcontext);
@@ -6167,7 +6167,7 @@ handle_sigreturn(dcontext_t *dcontext, void *ucxt_param, int style)
 #endif
 
 #ifdef DEBUG
-    if (stats->loglevel >= 3 && (stats->logmask & LOG_ASYNCH) != 0) {
+    if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_ASYNCH) != 0) {
         LOG(THREAD, LOG_ASYNCH, 3, "returning-to sigcontext " PFX ":\n", sc);
         dump_sigcontext(dcontext, sc);
     }
@@ -6447,7 +6447,7 @@ os_dump_core(const char *msg)
         static bool tried_stackdump = false;
         if (!tried_stackdump) {
             tried_stackdump = true;
-            stackdump();
+            d_r_stackdump();
         } else {
             static bool tried_calldump = false;
             if (!tried_calldump) {

--- a/core/unix/stackdump.c
+++ b/core/unix/stackdump.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -160,7 +160,7 @@ fork_syscall(void)
 /*-----------------------------------------------------------------------*/
 
 void
-stackdump(void)
+d_r_stackdump(void)
 {
     int pid, core_pid;
     /* get name now -- will be same for children */

--- a/core/unix/symtab.c
+++ b/core/unix/symtab.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -80,7 +81,7 @@ sort_symtab()
 
     qsort(bfd_syms, bfd_symcount, sizeof(asymbol *), compare_symbols);
 
-    if (stats->loglevel > 2) {
+    if (d_r_stats->loglevel > 2) {
         LOG(GLOBAL, LOG_ALL, 3, "\n\nSYMBOL TABLE\n");
         for (i = 0; i < bfd_symcount; i++) {
             if (bfd_syms[i]) {

--- a/core/utils.h
+++ b/core/utils.h
@@ -1185,18 +1185,18 @@ bitmap_check_consistency(bitmap_t b, uint bitmap_size, uint expect_free);
 #endif
 
 #if defined(DEBUG) && !defined(STANDALONE_DECODER)
-#    define LOG(file, mask, level, ...)                        \
-        do {                                                   \
-            if (stats != NULL && stats->loglevel >= (level) && \
-                (stats->logmask & (mask)) != 0)                \
-                print_log(file, mask, level, __VA_ARGS__);     \
+#    define LOG(file, mask, level, ...)                                \
+        do {                                                           \
+            if (d_r_stats != NULL && d_r_stats->loglevel >= (level) && \
+                (d_r_stats->logmask & (mask)) != 0)                    \
+                print_log(file, mask, level, __VA_ARGS__);             \
         } while (0)
 /* use DOELOG for customer visible logging. statement can be a {} block */
-#    define DOELOG(level, mask, statement)                     \
-        do {                                                   \
-            if (stats != NULL && stats->loglevel >= (level) && \
-                (stats->logmask & (mask)) != 0)                \
-                statement                                      \
+#    define DOELOG(level, mask, statement)                             \
+        do {                                                           \
+            if (d_r_stats != NULL && d_r_stats->loglevel >= (level) && \
+                (d_r_stats->logmask & (mask)) != 0)                    \
+                statement                                              \
         } while (0)
 /* not using DYNAMO_OPTION b/c it contains ASSERT */
 #    define DOCHECK(level, statement) \
@@ -1556,9 +1556,9 @@ enum { LONGJMP_EXCEPTION = 1 };
 /* If -no_global_rstats, all values will be 0, so user does not have to
  * use DO_GLOBAL_STATS or check runtime option.
  */
-#define GLOBAL_STAT(stat) stats->stat##_pair.value
+#define GLOBAL_STAT(stat) d_r_stats->stat##_pair.value
 /* explicit macro for addr so no assumptions on GLOBAL_STAT being lvalue */
-#define GLOBAL_STAT_ADDR(stat) &(stats->stat##_pair.value)
+#define GLOBAL_STAT_ADDR(stat) &(d_r_stats->stat##_pair.value)
 #define DO_GLOBAL_STATS(statement) \
     do {                           \
         if (GLOBAL_STATS_ON()) {   \
@@ -1728,7 +1728,7 @@ enum { LONGJMP_EXCEPTION = 1 };
  * setting of the max, otherwise you're open to race conditions involving
  * multiple threads adjusting the same stats and setting peak/max FIXME
  */
-#    define GLOBAL_STATS_ON() (stats != NULL && INTERNAL_OPTION(global_stats))
+#    define GLOBAL_STATS_ON() (d_r_stats != NULL && INTERNAL_OPTION(global_stats))
 #    define THREAD_STAT(dcontext, stat) (dcontext->thread_stats)->stat##_thread
 #    define THREAD_STATS_ON(dcontext)                         \
         (dcontext != NULL && INTERNAL_OPTION(thread_stats) && \
@@ -1769,7 +1769,7 @@ enum { LONGJMP_EXCEPTION = 1 };
 #    define THREAD_STATS_ON(dcontext) false
 #    define XSTATS_WITH_DC(var, statement) statement
 #    define DO_THREAD_STATS(dcontext, statement) /* nothing */
-#    define GLOBAL_STATS_ON() (stats != NULL && DYNAMO_OPTION(global_rstats))
+#    define GLOBAL_STATS_ON() (d_r_stats != NULL && DYNAMO_OPTION(global_rstats))
 
 /* Would be nice to catch incorrect usage of STATS_INC on a release-build
  * stat: if rename release vars, have to use separate GLOBAL_RSTAT though.
@@ -1970,16 +1970,16 @@ report_app_problem(dcontext_t *dcontext, uint appfault_flag, app_pc pc, app_pc r
                    const char *fmt, ...);
 
 void
-notify(syslog_event_type_t priority, bool internal, bool synch,
-       IF_WINDOWS_(uint message_id) uint substitution_nam, const char *prefix,
-       const char *fmt, ...);
+d_r_notify(syslog_event_type_t priority, bool internal, bool synch,
+           IF_WINDOWS_(uint message_id) uint substitution_nam, const char *prefix,
+           const char *fmt, ...);
 
-#define SYSLOG_COMMON(synch, type, id, sub, ...)                                    \
-    notify(type, false, synch, IF_WINDOWS_(MSG_##id) sub, #type, MSG_##id##_STRING, \
-           __VA_ARGS__)
+#define SYSLOG_COMMON(synch, type, id, sub, ...)                                        \
+    d_r_notify(type, false, synch, IF_WINDOWS_(MSG_##id) sub, #type, MSG_##id##_STRING, \
+               __VA_ARGS__)
 
 #define SYSLOG_INTERNAL_COMMON(synch, type, ...) \
-    notify(type, true, synch, IF_WINDOWS_(MSG_INTERNAL_##type) 0, #type, __VA_ARGS__)
+    d_r_notify(type, true, synch, IF_WINDOWS_(MSG_INTERNAL_##type) 0, #type, __VA_ARGS__)
 
 /* For security messages use passed in fmt string instead of eventlog fmt
  * string for LOG/stderr/msgbox to avoid breaking our regression suite,
@@ -1991,7 +1991,7 @@ notify(syslog_event_type_t priority, bool internal, bool synch,
  * then we could use the eventlog string.
  */
 #define SYSLOG_CUSTOM_NOTIFY(type, id, sub, ...) \
-    notify(type, false, true, IF_WINDOWS_(id) sub, #type, __VA_ARGS__)
+    d_r_notify(type, false, true, IF_WINDOWS_(id) sub, #type, __VA_ARGS__)
 
 #define SYSLOG(type, id, sub, ...) SYSLOG_COMMON(true, type, id, sub, __VA_ARGS__)
 #define SYSLOG_NO_OPTION_SYNCH(type, id, sub, ...) \
@@ -2211,8 +2211,8 @@ check_low_disk_threshold(file_t f, uint64 new_file_size);
 #define MD5_STRING_LENGTH (2 * MD5_RAW_BYTES)
 
 /* To compute the message digest of several chunks of bytes, declare
- * an MD5Context structure, pass it to MD5Init, call MD5Update as
- * needed on buffers full of bytes, and then call MD5Final, which will
+ * an MD5Context structure, pass it to d_r_md5_init, call d_r_md5_update as
+ * needed on buffers full of bytes, and then call d_r_md5_final, which will
  * fill a supplied 16-byte array with the digest.
  */
 struct MD5Context {
@@ -2222,11 +2222,11 @@ struct MD5Context {
 };
 
 void
-MD5Init(struct MD5Context *ctx);
+d_r_md5_init(struct MD5Context *ctx);
 void
-MD5Update(struct MD5Context *ctx, const unsigned char *buf, size_t len);
+d_r_md5_update(struct MD5Context *ctx, const unsigned char *buf, size_t len);
 void
-MD5Final(unsigned char digest[16], struct MD5Context *ctx);
+d_r_md5_final(unsigned char digest[16], struct MD5Context *ctx);
 
 #ifdef PROCESS_CONTROL
 bool

--- a/core/win32/drmarker.c
+++ b/core/win32/drmarker.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -272,7 +272,7 @@ init_dr_marker(dr_marker_t *marker)
     marker->dr_hotp_policy_status_table = NULL;
 #    endif
     marker->dr_marker_version = DR_MARKER_VERSION_CURRENT;
-    marker->stats = get_dr_stats();
+    marker->d_r_stats = get_dr_stats();
     dr_marker_magic_init(NT_CURRENT_PROCESS, marker);
     marker->windbg_cmds[0] = '\0';
 }

--- a/core/win32/drmarker.c
+++ b/core/win32/drmarker.c
@@ -272,7 +272,7 @@ init_dr_marker(dr_marker_t *marker)
     marker->dr_hotp_policy_status_table = NULL;
 #    endif
     marker->dr_marker_version = DR_MARKER_VERSION_CURRENT;
-    marker->d_r_stats = get_dr_stats();
+    marker->stats = get_dr_stats();
     dr_marker_magic_init(NT_CURRENT_PROCESS, marker);
     marker->windbg_cmds[0] = '\0';
 }

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -2035,7 +2035,7 @@ thread_attach_exit(dcontext_t *dcontext, priv_mcontext_t *mc)
  * As part of this I also changed the takeover to not store the context at
  * suspend time and instead only change Eip then, capturing the context when
  * the thread resumes.  This requires an assume-nothing routine, which
- * requires initstack: but these takeover points shouldn't be perf-critical.
+ * requires d_r_initstack: but these takeover points shouldn't be perf-critical.
  * This really simplifies the wow64 entry/exit corner cases.
  */
 static bool

--- a/suite/tests/api/static_symbols.c
+++ b/suite/tests/api/static_symbols.c
@@ -45,7 +45,7 @@
  */
 
 #if 0 /* i#3348: Disabling until we rename these symbols. */
-int *initstack = NULL;
+int *d_r_initstack = NULL;
 byte *initstack_app_xsp = NULL;
 
 bool
@@ -72,8 +72,8 @@ void
 test_symbol_conflicts(void)
 {
 #if 0 /* i#3348: Disabling until we rename these symbols. */
-    print("initstack is %p\n", initstack);
-    initstack = NULL;
+    print("d_r_initstack is %p\n", d_r_initstack);
+    d_r_initstack = NULL;
 #endif
     pathcmp();
 }


### PR DESCRIPTION
Renames more single-word global symbols to help reduce the chance
of name conflicts:

+ s/initstack/d_r_initstack/
+ s/loginst/d_r_loginst/
+ s/logopnd/d_r_logopnd/
+ s/logtrace/d_r_logtrace/
+ s/mangle/d_r_mangle/
+ s/mangle/d_r_mangle/
+ s/MD5Init/d_r_md5_init/
+ s/MD5Final/d_r_md5_final/
+ s/MD5Update/d_r_md5_update/
+ s/notify/d_r_notify/
+ s/stackdump/d_r_stackdump/
+ s/stats/d_r_stats/

Issue: #3348