### PR TITLE
Retrieve the Windows build number, edition, and release identifier.

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -146,6 +146,8 @@ compatibility changes:
 Further non-compatibility-affecting changes include:
 
  - Added drfront_set_verbose() to obtain diagnostics from drfrontendlib.
+ - Added new fields to #dr_os_version_info_t which contain the build number,
+   edition, and Windows 10 release identifier.
 
 **************************************************
 <hr>

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -2722,8 +2722,9 @@ bool
 dr_get_os_version(dr_os_version_info_t *info)
 {
     int ver;
-    uint sp_major, sp_minor;
-    get_os_version_ex(&ver, &sp_major, &sp_minor);
+    uint sp_major, sp_minor, build_number;
+    const char *release_id, *edition;
+    get_os_version_ex(&ver, &sp_major, &sp_minor, &build_number, &release_id, &edition);
     if (info->size > offsetof(dr_os_version_info_t, version)) {
         switch (ver) {
         case WINDOWS_VERSION_10_1803: info->version = DR_WINDOWS_VERSION_10_1803; break;
@@ -2749,6 +2750,18 @@ dr_get_os_version(dr_os_version_info_t *info)
         if (info->size > offsetof(dr_os_version_info_t, service_pack_minor)) {
             info->service_pack_minor = sp_minor;
         }
+    }
+    if (info->size > offsetof(dr_os_version_info_t, build_number)) {
+        info->build_number = build_number;
+    }
+    if (info->size > offsetof(dr_os_version_info_t, release_id)) {
+        dr_snprintf(info->release_id, BUFFER_SIZE_ELEMENTS(info->release_id), "%s",
+                    release_id);
+        NULL_TERMINATE_BUFFER(info->release_id);
+    }
+    if (info->size > offsetof(dr_os_version_info_t, edition)) {
+        dr_snprintf(info->edition, BUFFER_SIZE_ELEMENTS(info->edition), "%s", edition);
+        NULL_TERMINATE_BUFFER(info->edition);
     }
     return true;
 }

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -1748,6 +1748,8 @@ dr_set_client_name(const char *name, const char *report_URL);
 DR_API
 /**
  * Sets the version string presented to users in diagnostic messages.
+ * This has a maximum length of 96 characters; anything beyond that is
+ * silently truncated.
  */
 bool
 dr_set_client_version_string(const char *version);
@@ -1833,6 +1835,12 @@ typedef struct _dr_os_version_info_t {
     uint service_pack_major;
     /** The service pack minor number */
     uint service_pack_minor;
+    /** The build number. */
+    uint build_number;
+    /** The release identifier (such as "1803" for a Windows 10 release). */
+    char release_id[64];
+    /** The edition (such as "Education" or "Professional"). */
+    char edition[64];
 } dr_os_version_info_t;
 /* DR_API EXPORT END */
 

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -113,7 +113,12 @@ void *peb_ptr;
 static int os_version;
 static uint os_service_pack_major;
 static uint os_service_pack_minor;
+static uint os_build_number;
+#    define REGISTRY_VERSION_STRING_MAX_LEN 64
+static char os_release_id[REGISTRY_VERSION_STRING_MAX_LEN];
+static char os_edition[REGISTRY_VERSION_STRING_MAX_LEN];
 static const char *os_name;
+static char os_name_buf[MAXIMUM_PATH];
 app_pc vsyscall_page_start = NULL;
 /* pc kernel will claim app is at while in syscall */
 app_pc vsyscall_after_syscall = NULL;
@@ -528,6 +533,28 @@ get_context_xstate_flag(void)
     return IF_X64_ELSE((CONTEXT_AMD64 | 0x20L), (CONTEXT_i386 | 0x40L));
 }
 
+/* Returns false and marks 'value' as an empty string when it fails. */
+static bool
+read_version_registry_value(const wchar_t *name, char *value OUT, size_t value_sz)
+{
+    reg_query_value_result_t result;
+    char buf_array[sizeof(KEY_VALUE_PARTIAL_INFORMATION) +
+                   sizeof(wchar_t) * (MAX_REGISTRY_PARAMETER + 1)];
+    KEY_VALUE_PARTIAL_INFORMATION *kvpi = (KEY_VALUE_PARTIAL_INFORMATION *)buf_array;
+    result = reg_query_value(L"\\Registry\\Machine\\SOFTWARE\\Microsoft\\"
+                             L"Windows NT\\CurrentVersion",
+                             name, KeyValuePartialInformation, kvpi,
+                             BUFFER_SIZE_BYTES(buf_array), 0);
+    if (result == REG_QUERY_SUCCESS) {
+        snprintf(value, value_sz, "%*ls", kvpi->DataLength / sizeof(wchar_t) - 1,
+                 (wchar_t *)kvpi->Data);
+        value[value_sz - 1] = '\0';
+        return true;
+    }
+    value[0] = '\0';
+    return false;
+}
+
 /* FIXME: Right now error reporting will work here, but once we have our
  * error reporting syscalls going through wrappers and requiring this
  * init routine, we'll have to have a fallback here that dynamically
@@ -535,6 +562,8 @@ get_context_xstate_flag(void)
  * We may never be able to report errors for the non-NT OS family.
  * N.B.: this is too early for LOGs so don't do any -- any errors reported
  * will not die, they will simply skip LOG.
+ * N.B.: This is before stderr_mask has been parsed, so don't print any
+ * informational-only messages, or tests will break.
  * N.B.: this is prior to eventlog_init(), but then we've been reporting
  * usage errors prior to that for a long time now anyway.
  */
@@ -556,6 +585,22 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
      */
     os_service_pack_major = (peb->OSCSDVersion & 0xff00) >> 8;
     os_service_pack_minor = (peb->OSCSDVersion & 0xff);
+
+    /* Get various further data needed to distinguish Win10 and other versions. */
+    char buf[64];
+    if (read_version_registry_value(L"CurrentBuild", buf, BUFFER_SIZE_ELEMENTS(buf))) {
+        if (sscanf(buf, "%u", &os_build_number) != 1) {
+            SYSLOG_INTERNAL_WARNING("Failed to parse CurrentBuild '%s'", buf);
+        }
+    } /* Else just leave it blank. */
+    read_version_registry_value(L"EditionId", os_edition,
+                                BUFFER_SIZE_ELEMENTS(os_edition));
+    read_version_registry_value(L"ReleaseId", os_release_id,
+                                BUFFER_SIZE_ELEMENTS(os_release_id));
+    ASSERT(REGISTRY_VERSION_STRING_MAX_LEN >=
+           sizeof(((dr_os_version_info_t *)0)->release_id));
+    ASSERT(REGISTRY_VERSION_STRING_MAX_LEN >=
+           sizeof(((dr_os_version_info_t *)0)->edition));
 
     if (peb->OSPlatformId == VER_PLATFORM_WIN32_NT) {
         /* WinNT or descendents */
@@ -793,9 +838,23 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
         }
         if (syscalls == NULL) {
             if (peb->OSMajorVersion == 10 && peb->OSMinorVersion == 0) {
-                SYSLOG_INTERNAL_WARNING(
-                    "WARNING: Running on unsupported Windows 10+ version");
-                os_name = "Unknown Windows 10+ version";
+                if (os_release_id[0] != '\0') {
+                    snprintf(os_name_buf, BUFFER_SIZE_ELEMENTS(os_name_buf) - 1,
+                             "Microsoft Windows 10-%s%s", os_release_id,
+                             (module_is_64bit(get_ntdll_base()) ||
+                              is_wow64_process(NT_CURRENT_PROCESS))
+                                 ? " x64"
+                                 : "");
+                    NULL_TERMINATE_BUFFER(os_name_buf);
+                    os_name = os_name_buf;
+                    /* We print a notification in os_init() after stderr_mask options
+                     * have been parsed.
+                     */
+                } else {
+                    os_name = "Unknown Windows 10+ version";
+                    SYSLOG_INTERNAL_WARNING("WARNING: Running on unknown "
+                                            "Windows 10+ version");
+                }
             } else {
                 SYSLOG_INTERNAL_ERROR("Unknown Windows NT-family version: %d.%d",
                                       peb->OSMajorVersion, peb->OSMinorVersion);
@@ -903,6 +962,14 @@ os_init(void)
         peb->OSMajorVersion * 10 + peb->OSMinorVersion) {
         SYSLOG(SYSLOG_WARNING, UNSUPPORTED_OS_VERSION, 3, get_application_name(),
                get_application_pid(), os_name);
+    }
+    if (peb->OSMajorVersion == 10 && peb->OSMinorVersion == 0 &&
+        os_release_id[0] != '\0') {
+        /* Not a warning since we can rely on dynamically finding DR's
+         * syscalls (in the absense of hooks, for which we might want
+         * a solution like Dr. Memory's: i#2713).
+         */
+        SYSLOG_INTERNAL_INFO("Running on newer-than-this-build \"%s\"", os_name);
     }
 
     /* make sure we create the message box title string before we are
@@ -2806,7 +2873,8 @@ get_os_version()
 
 void
 get_os_version_ex(int *version OUT, uint *service_pack_major OUT,
-                  uint *service_pack_minor OUT)
+                  uint *service_pack_minor OUT, uint *build_number OUT,
+                  const char **release_id OUT, const char **edition OUT)
 {
     if (version != NULL)
         *version = os_version;
@@ -2814,6 +2882,12 @@ get_os_version_ex(int *version OUT, uint *service_pack_major OUT,
         *service_pack_major = os_service_pack_major;
     if (service_pack_minor != NULL)
         *service_pack_minor = os_service_pack_minor;
+    if (build_number != NULL)
+        *build_number = os_build_number;
+    if (release_id != NULL)
+        *release_id = os_release_id;
+    if (edition != NULL)
+        *edition = os_edition;
 }
 
 bool

--- a/core/win32/os_exports.h
+++ b/core/win32/os_exports.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -71,7 +71,8 @@ int
 get_os_version(void);
 void
 get_os_version_ex(int *version OUT, uint *service_pack_major OUT,
-                  uint *service_pack_minor OUT);
+                  uint *service_pack_minor OUT, uint *build_number OUT,
+                  const char **release_id OUT, const char **edition OUT);
 
 /* TEB offsets
  * we'd like to use offsetof(TEB, field) but that would require

--- a/suite/tests/client-interface/events.dll.c
+++ b/suite/tests/client-interface/events.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -663,6 +663,8 @@ dr_init(client_id_t id)
      */
     if (!dr_get_os_version(&info))
         dr_fprintf(STDERR, "dr_get_os_version failed!\n");
+    if (info.build_number == 0 || info.edition[0] == '\0')
+        dr_fprintf(STDERR, "dr_get_os_version failed to get new fields\n");
 #endif
 
     for (i = 0; i < EVENT_last; i++)


### PR DESCRIPTION
Adds new fields to the exported dr_os_version_info_t which contain the
build number, edition, and Windows 10 release identifier.  Adds code to
retrieve them.  The release identifier is used to create an OS name string
and downgrade the warning about an unsupported OS version to a simple
informational message, since we expect a new Windows 10 release to work,
barring hooks blocking dynamic system call analysis or deeper problematic
changes.

Adds a sanity check that the build number and edition are successfully
acquired.