### PR TITLE
First attempt at fixing i3385

### DIFF
--- a/core/module_list.c
+++ b/core/module_list.c
@@ -255,6 +255,7 @@ module_list_add(app_pc base, size_t view_size, bool at_map,
          * the loaded_module_areas vector, to support non-contiguous
          * modules (i#160/PR 562667)
          */
+        SYSLOG_INTERNAL_INFO("\nDEBUG %s %d: filepath=%s base=0x%x view_size=%d[0x%x]", __func__, __LINE__, filepath, base, view_size, view_size);
         module_area_t *ma =
             module_area_create(base, view_size, at_map, filepath _IF_UNIX(inode));
         ASSERT(ma != NULL);


### PR DESCRIPTION
This PR is a follow-on from the discussion in issue https://github.com/DynamoRIO/dynamorio/issues/3385

The sort of questions I've been trying to answer are (based on my simple understanding of the code):
- Which part(s) of the code maps the segments into memory? Just module_add_segment_data() or something else as well?
- When looking for which part of the ELF loader calls mmap() I noticed they go via post_system_call(). Why?

I suppose the main question is why not map+load the whole file into memory and populate the relevant DR data structures (os_module_data_t etc) in one go rather than mapping+loading piecemeal?