### PR TITLE
i#1409 core libs: remove STATIC_LIBRARY from drlibc

### DIFF
--- a/core/drlibc/drlibc_unix.c
+++ b/core/drlibc/drlibc_unix.c
@@ -582,15 +582,17 @@ os_page_size(void)
 }
 
 void
-os_page_size_init(const char **env)
+os_page_size_init(const char **env, bool env_followed_by_auxv)
 {
-#if defined(LINUX) && !defined(STATIC_LIBRARY)
+#ifdef LINUX
     /* On Linux we get the page size from the auxiliary vector, which is what
      * the C library typically does for implementing sysconf(_SC_PAGESIZE).
      * However, for STATIC_LIBRARY, our_environ is not guaranteed to point
      * at the stack as we're so late, so we do not try to read off the end of it
      * (i#2122).
      */
+    if (!env_followed_by_auxv)
+        return;
     size_t size = page_size; /* atomic read */
     if (size == 0) {
         ELF_AUXV_TYPE *auxv;

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -383,7 +383,7 @@ dynamorio_app_init(void)
     if (!dynamo_initialized /* we do enter if nullcalls is on */) {
 
 #ifdef UNIX
-        os_page_size_init((const char **)our_environ);
+        os_page_size_init((const char **)our_environ, is_our_environ_followed_by_auxv());
 #endif
 #ifdef WINDOWS
         /* MUST do this before making any system calls */
@@ -869,7 +869,7 @@ standalone_init(void)
     dynamo_options.deadlock_avoidance = false;
 #    endif
 #    ifdef UNIX
-    os_page_size_init((const char **)our_environ);
+    os_page_size_init((const char **)our_environ, is_our_environ_followed_by_auxv());
 #    endif
 #    ifdef WINDOWS
     /* MUST do this before making any system calls */

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -602,7 +602,7 @@ size_t
 os_page_size(void);
 #ifdef UNIX
 void
-os_page_size_init(const char **env);
+os_page_size_init(const char **env, bool env_followed_by_auxv);
 #endif
 bool
 get_memory_info(const byte *pc, byte **base_pc, size_t *size, uint *prot);

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1639,7 +1639,7 @@ relocate_dynamorio(byte *dr_map, size_t dr_size, byte *sp)
     const char **env = (const char **)sp + argc + 2;
     os_privmod_data_t opd = { { 0 } };
 
-    os_page_size_init(env);
+    os_page_size_init(env, true);
 
     if (dr_map == NULL) {
         /* we do not know where dynamorio is, so check backward page by page */

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -667,6 +667,19 @@ our_getenv(const char *name)
     return NULL;
 }
 
+bool
+is_our_environ_followed_by_auxv(void)
+{
+#ifdef STATIC_LIBRARY
+    /* Since we initialize late, our_environ is likely no longer pointed at
+     * the stack (i#2122).
+     */
+    return false;
+#else
+    return true;
+#endif
+}
+
 /* Work around drpreload's _init going first.  We can get envp in our own _init
  * routine down below, but drpreload.so comes first and calls
  * dynamorio_app_init before our own _init routine gets called.  Apps using the

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -230,6 +230,8 @@ extern char **environ;
 #else
 extern char **our_environ;
 #endif
+bool
+is_our_environ_followed_by_auxv(void);
 void
 dynamorio_set_envp(char **envp);
 #if !defined(NOT_DYNAMORIO_CORE_PROPER) && !defined(NOT_DYNAMORIO_CORE)


### PR DESCRIPTION
Since we want a single build of drlibc for both static and shared DR
libs, we do not want any STATIC_LIBRARY defines in there.  Here we
remove the define in os_page_size_init() by adding a parameter
"env_followed_by_auxv" and a function
"is_our_environ_followed_by_auxv()" and effectively moving the
STATIC_LIBRARY to the callers.

This fixes a regression for #2122 caused by creating drlibc in
710a6898.

Issue: #1409, #2122