### PR TITLE
Fix modern gcc/clang builds

### DIFF
--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -73,7 +73,7 @@ create_func_metadata(std::string name, int id, int arg_num)
 {
     func_metadata_t *f = (func_metadata_t *)dr_global_alloc(sizeof(func_metadata_t));
     strncpy(f->name, name.c_str(), BUFFER_SIZE_ELEMENTS(f->name) - 1);
-    f->name[BUFFER_SIZE_ELEMENTS(f->name)] = '\0';
+    NULL_TERMINATE_BUFFER(f->name);
     f->id = id;
     f->arg_num = arg_num;
     return f;

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -72,7 +72,8 @@ static func_metadata_t *
 create_func_metadata(std::string name, int id, int arg_num)
 {
     func_metadata_t *f = (func_metadata_t *)dr_global_alloc(sizeof(func_metadata_t));
-    strncpy(f->name, name.c_str(), BUFFER_SIZE_ELEMENTS(f->name));
+    strncpy(f->name, name.c_str(), BUFFER_SIZE_ELEMENTS(f->name) - 1);
+    f->name[BUFFER_SIZE_ELEMENTS(f->name)] = '\0';
     f->id = id;
     f->arg_num = arg_num;
     return f;

--- a/clients/drcov/postprocess/drcov2lcov.cpp
+++ b/clients/drcov/postprocess/drcov2lcov.cpp
@@ -675,7 +675,7 @@ search_cb(drsym_info_t *info, drsym_error_t status, void *data)
         strstr(info->name, op_test_pattern.get_value().c_str()) != NULL) {
         char *name = (char *)malloc(strlen(info->name) + 1);
         /* strdup is deprecated on Windows */
-        strcpy(name, info->name);
+        dr_snprintf(name, strlen(info->name) + 1, "%s", info->name);
         PRINT(5, "function %s: " PFX "-" PFX "\n", name, (ptr_uint_t)info->start_offs,
               (ptr_uint_t)info->end_offs);
         ASSERT(info->start_offs <= table->size, "wrong offset");

--- a/clients/drcov/postprocess/drcov2lcov.cpp
+++ b/clients/drcov/postprocess/drcov2lcov.cpp
@@ -675,7 +675,7 @@ search_cb(drsym_info_t *info, drsym_error_t status, void *data)
         strstr(info->name, op_test_pattern.get_value().c_str()) != NULL) {
         char *name = (char *)malloc(strlen(info->name) + 1);
         /* strdup is deprecated on Windows */
-        strncpy(name, info->name, strlen(info->name) + 1);
+        strcpy(name, info->name);
         PRINT(5, "function %s: " PFX "-" PFX "\n", name, (ptr_uint_t)info->start_offs,
               (ptr_uint_t)info->end_offs);
         ASSERT(info->start_offs <= table->size, "wrong offset");

--- a/core/string.c
+++ b/core/string.c
@@ -164,6 +164,50 @@ d_r_memmove(void *dst, const void *src, size_t n)
     return dst;
 }
 
+#ifdef UNIX
+/* gcc emits calls to these *_chk variants in release builds when the size of
+ * dst is known at compile time.  In C, the caller is responsible for cleaning
+ * up arguments on the stack, so we alias these *_chk routines to the non-chk
+ * routines and rely on the caller to clean up the extra dst_len arg.
+ */
+void *
+__memmove_chk(void *dst, const void *src, size_t n, size_t dst_len)
+#    ifdef MACOS
+/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
+ * XXX: better to test for support at config time: for now assuming none on Mac.
+ */
+{
+    return memmove(dst, src, n);
+}
+#    else
+    __attribute__((alias("d_r_memmove")));
+#    endif
+void *
+__strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
+#    ifdef MACOS
+/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
+ * XXX: better to test for support at config time: for now assuming none on Mac.
+ */
+{
+    return strncpy(dst, src, n);
+}
+#    else
+    __attribute__((alias("d_r_strncpy")));
+#    endif
+void *
+__strncat_chk(char *dst, const char *src, size_t n, size_t dst_len)
+#    ifdef MACOS
+/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
+ * XXX: better to test for support at config time: for now assuming none on Mac.
+ */
+{
+    return strncat(dst, src, n);
+}
+#    else
+    __attribute__((alias("d_r_strncat")));
+#    endif
+#endif
+
 /* Private strcmp. */
 int
 d_r_strcmp(const char *left, const char *right)

--- a/core/string.c
+++ b/core/string.c
@@ -172,40 +172,21 @@ d_r_memmove(void *dst, const void *src, size_t n)
  */
 void *
 __memmove_chk(void *dst, const void *src, size_t n, size_t dst_len)
-#    ifdef MACOS
-/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
- * XXX: better to test for support at config time: for now assuming none on Mac.
- */
 {
     return memmove(dst, src, n);
 }
-#    else
-    __attribute__((alias("d_r_memmove")));
-#    endif
+
 void *
 __strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
-#    ifdef MACOS
-/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
- * XXX: better to test for support at config time: for now assuming none on Mac.
- */
 {
     return strncpy(dst, src, n);
 }
-#    else
-    __attribute__((alias("d_r_strncpy")));
-#    endif
+
 void *
 __strncat_chk(char *dst, const char *src, size_t n, size_t dst_len)
-#    ifdef MACOS
-/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
- * XXX: better to test for support at config time: for now assuming none on Mac.
- */
 {
     return strncat(dst, src, n);
 }
-#    else
-    __attribute__((alias("d_r_strncat")));
-#    endif
 #endif
 
 /* Private strcmp. */

--- a/core/string.c
+++ b/core/string.c
@@ -164,50 +164,6 @@ d_r_memmove(void *dst, const void *src, size_t n)
     return dst;
 }
 
-#ifdef UNIX
-/* gcc emits calls to these *_chk variants in release builds when the size of
- * dst is known at compile time.  In C, the caller is responsible for cleaning
- * up arguments on the stack, so we alias these *_chk routines to the non-chk
- * routines and rely on the caller to clean up the extra dst_len arg.
- */
-void *
-__memmove_chk(void *dst, const void *src, size_t n, size_t dst_len)
-#    ifdef MACOS
-/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
- * XXX: better to test for support at config time: for now assuming none on Mac.
- */
-{
-    return memmove(dst, src, n);
-}
-#    else
-    __attribute__((alias("d_r_memmove")));
-#    endif
-void *
-__strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
-#    ifdef MACOS
-/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
- * XXX: better to test for support at config time: for now assuming none on Mac.
- */
-{
-    return strncpy(dst, src, n);
-}
-#    else
-    __attribute__((alias("d_r_strncpy")));
-#    endif
-void *
-__strncat_chk(char *dst, const char *src, size_t n, size_t dst_len)
-#    ifdef MACOS
-/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
- * XXX: better to test for support at config time: for now assuming none on Mac.
- */
-{
-    return strncat(dst, src, n);
-}
-#    else
-    __attribute__((alias("d_r_strncat")));
-#    endif
-#endif
-
 /* Private strcmp. */
 int
 d_r_strcmp(const char *left, const char *right)

--- a/ext/drcontainers/hashtable.c
+++ b/ext/drcontainers/hashtable.c
@@ -330,6 +330,7 @@ hashtable_add(hashtable_t *table, void *key, void *payload)
     }
     uint hindex = hash_key(table, key);
     hash_entry_t *e;
+    size_t hash_key_size;
     for (e = table->table[hindex]; e != NULL; e = e->next) {
         if (keys_equal(table, e->key, key)) {
             /* we have a use where payload != existing entry so we don't assert on that */
@@ -341,8 +342,9 @@ hashtable_add(hashtable_t *table, void *key, void *payload)
     e = (hash_entry_t *)hash_alloc(sizeof(*e));
     if (table->str_dup) {
         const char *s = (const char *)key;
-        e->key = hash_alloc(strlen(s) + 1);
-        strncpy((char *)e->key, s, sizeof(*e));
+        hash_key_size = strlen(s) + 1;
+        e->key = hash_alloc(hash_key_size);
+        strncpy((char *)e->key, s, hash_key_size);
     } else
         e->key = key;
     e->payload = payload;

--- a/ext/drcontainers/hashtable.c
+++ b/ext/drcontainers/hashtable.c
@@ -342,7 +342,7 @@ hashtable_add(hashtable_t *table, void *key, void *payload)
     if (table->str_dup) {
         const char *s = (const char *)key;
         e->key = hash_alloc(strlen(s) + 1);
-        strncpy((char *)e->key, s, strlen(s) + 1);
+        strncpy((char *)e->key, s, sizeof(*e));
     } else
         e->key = key;
     e->payload = payload;
@@ -370,7 +370,7 @@ hashtable_add_replace(hashtable_t *table, void *key, void *payload)
     if (table->str_dup) {
         const char *s = (const char *)key;
         new_e->key = hash_alloc(strlen(s) + 1);
-        strncpy((char *)new_e->key, s, strlen(s) + 1);
+        strncpy((char *)new_e->key, s, sizeof(*e));
     } else
         new_e->key = key;
     new_e->payload = payload;

--- a/ext/drsyms/drsyms_unix_common.c
+++ b/ext/drsyms/drsyms_unix_common.c
@@ -237,7 +237,7 @@ follow_debuglink(const char *modpath, dbg_module_t *mod, const char *debuglink,
 
     /* For non-GNU we might be handed an absolute path */
     if (debuglink[0] == '/' && dr_file_exists(debuglink)) {
-        strncpy(debug_modpath, debuglink, MAXIMUM_PATH);
+        strncpy(debug_modpath, debuglink, MAXIMUM_PATH - 1);
         debug_modpath[MAXIMUM_PATH - 1] = '\0';
         return true;
     }

--- a/libutil/dr_config.c
+++ b/libutil/dr_config.c
@@ -271,7 +271,7 @@ add_extra_option(opt_info_t *opt_info, const TCHAR *opt)
             return DR_FAILURE;
         }
 
-        len = strnlen(opt, DR_MAX_OPTIONS_LENGTH);
+        len = _dr_nlen(opt, DR_MAX_OPTIONS_LENGTH);
         opt_info->extra_opts[idx] =
             malloc((len + 1) * sizeof(opt_info->extra_opts[idx][0]));
         _tcsncpy(opt_info->extra_opts[idx], opt, len);

--- a/libutil/dr_config.c
+++ b/libutil/dr_config.c
@@ -473,17 +473,17 @@ get_config_dir_done:
     /* On failure, we still want to copy the last-tried dir out so drdeploy can have a
      * nicer error msg.
      */
-#   ifdef __GNUC__
-#       ifndef __clang__
-#           pragma GCC diagnostic ignored "-Wformat-truncation"
-#       endif
-#   endif
+#    ifdef __GNUC__
+#        ifndef __clang__
+#            pragma GCC diagnostic ignored "-Wformat-truncation"
+#        endif
+#    endif
     _snprintf(fname, fname_len, "%s/%s", dir, subdir);
-#   ifdef __GNUC__
-#       ifndef __clang__
-#           pragma GCC diagnostic pop
-#       endif
-#   endif
+#    ifdef __GNUC__
+#        ifndef __clang__
+#            pragma GCC diagnostic pop
+#        endif
+#    endif
     fname[fname_len - 1] = '\0';
     return res;
 }
@@ -692,17 +692,17 @@ write_config_param(FILE *f, const char *var, const TCHAR *val)
     int len;
     char buf[MAX_CONFIG_VALUE];
     DO_ASSERT(f != NULL);
-#   ifdef __GNUC__
-#       ifndef __clang__
-#           pragma GCC diagnostic ignored "-Wformat-truncation"
-#       endif
-#   endif
+#    ifdef __GNUC__
+#        ifndef __clang__
+#            pragma GCC diagnostic ignored "-Wformat-truncation"
+#        endif
+#    endif
     len = _snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%s=" TSTR_FMT "\n", var, val);
-#   ifdef __GNUC__
-#       ifndef __clang__
-#           pragma GCC diagnostic pop
-#       endif
-#   endif
+#    ifdef __GNUC__
+#        ifndef __clang__
+#            pragma GCC diagnostic pop
+#        endif
+#    endif
     /* don't remove the newline: better to truncate options than to have none (i#547) */
     buf[BUFFER_SIZE_ELEMENTS(buf) - 2] = '\n';
     buf[BUFFER_SIZE_ELEMENTS(buf) - 1] = '\0';

--- a/libutil/dr_config.c
+++ b/libutil/dr_config.c
@@ -473,9 +473,17 @@ get_config_dir_done:
     /* On failure, we still want to copy the last-tried dir out so drdeploy can have a
      * nicer error msg.
      */
-    #pragma GCC diagnostic ignored "-Wformat-truncation"
+#   ifdef __GNUC__
+#       ifndef __clang__
+#           pragma GCC diagnostic ignored "-Wformat-truncation"
+#       endif
+#   endif
     _snprintf(fname, fname_len, "%s/%s", dir, subdir);
-    #pragma GCC diagnostic pop
+#   ifdef __GNUC__
+#       ifndef __clang__
+#           pragma GCC diagnostic pop
+#       endif
+#   endif
     fname[fname_len - 1] = '\0';
     return res;
 }
@@ -684,9 +692,17 @@ write_config_param(FILE *f, const char *var, const TCHAR *val)
     int len;
     char buf[MAX_CONFIG_VALUE];
     DO_ASSERT(f != NULL);
-    #pragma GCC diagnostic ignored "-Wformat-truncation"
+#   ifdef __GNUC__
+#       ifndef __clang__
+#           pragma GCC diagnostic ignored "-Wformat-truncation"
+#       endif
+#   endif
     len = _snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%s=" TSTR_FMT "\n", var, val);
-    #pragma GCC diagnostic pop
+#   ifdef __GNUC__
+#       ifndef __clang__
+#           pragma GCC diagnostic pop
+#       endif
+#   endif
     /* don't remove the newline: better to truncate options than to have none (i#547) */
     buf[BUFFER_SIZE_ELEMENTS(buf) - 2] = '\n';
     buf[BUFFER_SIZE_ELEMENTS(buf) - 1] = '\0';

--- a/libutil/dr_config.c
+++ b/libutil/dr_config.c
@@ -271,7 +271,7 @@ add_extra_option(opt_info_t *opt_info, const TCHAR *opt)
             return DR_FAILURE;
         }
 
-        len = MIN(DR_MAX_OPTIONS_LENGTH - 1, _tcslen(opt));
+        len = strnlen(opt, DR_MAX_OPTIONS_LENGTH);
         opt_info->extra_opts[idx] =
             malloc((len + 1) * sizeof(opt_info->extra_opts[idx][0]));
         _tcsncpy(opt_info->extra_opts[idx], opt, len);
@@ -749,7 +749,7 @@ read_options(opt_info_t *opt_info, IF_REG_ELSE(ConfigGroup *proc_policy, FILE *f
      * approach would be to keep track of a string length and pass
      * that to get_next_token().
      */
-    len = MIN(DR_MAX_OPTIONS_LENGTH - 1, _tcslen(ptr));
+    len = strnlen(ptr, DR_MAX_OPTIONS_LENGTH);
     _tcsncpy(tmp, ptr, len);
     tmp[len] = _T('\0');
 

--- a/libutil/dr_config.c
+++ b/libutil/dr_config.c
@@ -473,7 +473,9 @@ get_config_dir_done:
     /* On failure, we still want to copy the last-tried dir out so drdeploy can have a
      * nicer error msg.
      */
+    #pragma GCC diagnostic ignored "-Wformat-truncation"
     _snprintf(fname, fname_len, "%s/%s", dir, subdir);
+    #pragma GCC diagnostic pop
     fname[fname_len - 1] = '\0';
     return res;
 }
@@ -682,7 +684,9 @@ write_config_param(FILE *f, const char *var, const TCHAR *val)
     int len;
     char buf[MAX_CONFIG_VALUE];
     DO_ASSERT(f != NULL);
+    #pragma GCC diagnostic ignored "-Wformat-truncation"
     len = _snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%s=" TSTR_FMT "\n", var, val);
+    #pragma GCC diagnostic pop
     /* don't remove the newline: better to truncate options than to have none (i#547) */
     buf[BUFFER_SIZE_ELEMENTS(buf) - 2] = '\n';
     buf[BUFFER_SIZE_ELEMENTS(buf) - 1] = '\0';

--- a/libutil/dr_frontend.h
+++ b/libutil/dr_frontend.h
@@ -95,6 +95,11 @@ typedef int ssize_t;
 
 #ifdef WINDOWS
 #    include <tchar.h>
+#    ifdef _UNICODE
+#        define _dr_nlen wcsnlen
+#    else
+#        define _dr_nlen strnlen
+#    endif
 #else
 #    define TCHAR char
 #    define _tmain main
@@ -110,6 +115,7 @@ typedef int ssize_t;
 #    define _ftprintf fprintf
 #    define _tfopen fopen
 #    define _T(s) s
+#    define _dr_nlen strnlen
 #endif
 /* DR_API EXPORT VERBATIM */
 #ifdef _UNICODE

--- a/libutil/dr_frontend_unix.c
+++ b/libutil/dr_frontend_unix.c
@@ -266,7 +266,7 @@ drfront_get_env_var(const char *name, OUT char *buf, size_t buflen /*# elements*
     if (len_var + 1 > buflen) {
         return DRFRONT_ERROR_INVALID_SIZE;
     }
-    strncpy(buf, tmp_buf, len_var + 1);
+    strncpy(buf, tmp_buf, buflen);
     buf[buflen - 1] = '\0';
     return DRFRONT_SUCCESS;
 }

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -837,6 +837,7 @@ read_tool_file(const char *toolname, const char *dr_root, dr_platform_t dr_platf
             }
         } else if (strstr(line, "CLIENT_ABS=") == line) {
             strncpy(client, line + strlen("CLIENT_ABS="), client_size - 1);
+            client[client_size - 1] = '\0';
             found_client = true;
             if (native_path[0] != '\0') {
                 add_extra_option(tool_ops, tool_ops_size, tool_ops_sofar, "\"%s\"",

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -836,7 +836,7 @@ read_tool_file(const char *toolname, const char *dr_root, dr_platform_t dr_platf
                                  client);
             }
         } else if (strstr(line, "CLIENT_ABS=") == line) {
-            strncpy(client, line + strlen("CLIENT_ABS="), client_size);
+            strncpy(client, line + strlen("CLIENT_ABS="), client_size - 1);
             found_client = true;
             if (native_path[0] != '\0') {
                 add_extra_option(tool_ops, tool_ops_size, tool_ops_sofar, "\"%s\"",


### PR DESCRIPTION
This set of patches fixes up all warnings being presented as errors. Since -Werror is enabled, this allows building on current versions of gcc and clang, 8.2 and 6.0 respectively. Most of these changes are trivial, but a few towards the end probably should be more closely looked at.