### PR TITLE
i#3425: Fix handling NULL sigmask parameter in ppoll, epoll_pwait and pselect6.

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7013,34 +7013,34 @@ pre_system_call(dcontext_t *dcontext)
 #ifdef LINUX
     case SYS_ppoll: {
         kernel_sigset_t *sigmask = (kernel_sigset_t *)sys_param(dcontext, 3);
-        if (sigmask != NULL) {
-            size_t sizemask = (size_t)sys_param(dcontext, 4);
-            /* The original app's sigmask parameter is now NULL effectively making the
-             * syscall a non p* version, and the mask's semantics are emulated by DR
-             * instead.
+        dcontext->sys_param3 = (reg_t)sigmask;
+        if (sigmask == NULL)
+            break;
+        size_t sizemask = (size_t)sys_param(dcontext, 4);
+        /* The original app's sigmask parameter is now NULL effectively making the
+         * syscall a non p* version, and the mask's semantics are emulated by DR
+         * instead.
+         */
+        set_syscall_param(dcontext, 3, (reg_t)NULL);
+        bool sig_pending = false;
+        if (!handle_pre_extended_syscall_sigmasks(dcontext, sigmask, sizemask,
+                                                  &sig_pending)) {
+            /* In old kernels with sizeof(kernel_sigset_t) != sizemask, we're forcing
+             * failure. We're already violating app transparency in other places in
+             * DR.
              */
-            dcontext->sys_param3 = (reg_t)sigmask;
-            set_syscall_param(dcontext, 3, (reg_t)NULL);
-            bool sig_pending = false;
-            if (!handle_pre_extended_syscall_sigmasks(dcontext, sigmask, sizemask,
-                                                      &sig_pending)) {
-                /* In old kernels with sizeof(kernel_sigset_t) != sizemask, we're forcing
-                 * failure. We're already violating app transparency in other places in
-                 * DR.
-                 */
-                set_failure_return_val(dcontext, EINVAL);
-                DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
-                execute_syscall = false;
-            }
-            if (sig_pending) {
-                /* If there had been pending signals, we revert re-writing the app's
-                 * parameter, but we leave the modified signal mask.
-                 */
-                set_syscall_param(dcontext, 3, dcontext->sys_param3);
-                set_failure_return_val(dcontext, EINTR);
-                DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
-                execute_syscall = false;
-            }
+            set_failure_return_val(dcontext, EINVAL);
+            DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
+            execute_syscall = false;
+        }
+        if (sig_pending) {
+            /* If there had been pending signals, we revert re-writing the app's
+             * parameter, but we leave the modified signal mask.
+             */
+            set_syscall_param(dcontext, 3, dcontext->sys_param3);
+            set_failure_return_val(dcontext, EINTR);
+            DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
+            execute_syscall = false;
         }
         break;
     }
@@ -7062,59 +7062,60 @@ pre_system_call(dcontext_t *dcontext)
             execute_syscall = false;
             break;
         }
-        if (data.sigmask != NULL) {
-            dcontext->sys_param4 = (reg_t)data.sigmask;
-            kernel_sigset_t *nullsigmaskptr = NULL;
+        if (data.sigmask == NULL) {
+            dcontext->sys_param3 = (reg_t)NULL;
+            break;
+        }
+        dcontext->sys_param4 = (reg_t)data.sigmask;
+        kernel_sigset_t *nullsigmaskptr = NULL;
+        if (!safe_write_ex((void *)&data_param->sigmask, sizeof(data_param->sigmask),
+                           &nullsigmaskptr, NULL)) {
+            set_failure_return_val(dcontext, EFAULT);
+            DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
+            execute_syscall = false;
+            break;
+        }
+        bool sig_pending = false;
+        if (!handle_pre_extended_syscall_sigmasks(dcontext, data.sigmask, data.sizemask,
+                                                  &sig_pending)) {
+            set_failure_return_val(dcontext, EINVAL);
+            DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
+            execute_syscall = false;
+        }
+        if (sig_pending) {
             if (!safe_write_ex((void *)&data_param->sigmask, sizeof(data_param->sigmask),
-                               &nullsigmaskptr, NULL)) {
+                               &dcontext->sys_param4, NULL)) {
                 set_failure_return_val(dcontext, EFAULT);
                 DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
                 execute_syscall = false;
                 break;
             }
-            bool sig_pending = false;
-            if (!handle_pre_extended_syscall_sigmasks(dcontext, data.sigmask,
-                                                      data.sizemask, &sig_pending)) {
-                set_failure_return_val(dcontext, EINVAL);
-                DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
-                execute_syscall = false;
-            }
-            if (sig_pending) {
-                if (!safe_write_ex((void *)&data_param->sigmask,
-                                   sizeof(data_param->sigmask), &dcontext->sys_param4,
-                                   NULL)) {
-                    set_failure_return_val(dcontext, EFAULT);
-                    DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
-                    execute_syscall = false;
-                    break;
-                }
-                set_failure_return_val(dcontext, EINTR);
-                DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
-                execute_syscall = false;
-            }
+            set_failure_return_val(dcontext, EINTR);
+            DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
+            execute_syscall = false;
         }
         break;
     }
     case SYS_epoll_pwait: {
         kernel_sigset_t *sigmask = (kernel_sigset_t *)sys_param(dcontext, 4);
-        if (sigmask != NULL) {
-            size_t sizemask = (size_t)sys_param(dcontext, 5);
-            /* Refer to comments in SYS_ppoll above. */
-            dcontext->sys_param4 = (reg_t)sigmask;
-            set_syscall_param(dcontext, 4, (reg_t)NULL);
-            bool sig_pending = false;
-            if (!handle_pre_extended_syscall_sigmasks(dcontext, sigmask, sizemask,
-                                                      &sig_pending)) {
-                set_failure_return_val(dcontext, EINVAL);
-                DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
-                execute_syscall = false;
-            }
-            if (sig_pending) {
-                set_syscall_param(dcontext, 4, dcontext->sys_param4);
-                set_failure_return_val(dcontext, EINTR);
-                DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
-                execute_syscall = false;
-            }
+        dcontext->sys_param4 = (reg_t)sigmask;
+        if (sigmask == NULL)
+            break;
+        size_t sizemask = (size_t)sys_param(dcontext, 5);
+        /* Refer to comments in SYS_ppoll above. */
+        set_syscall_param(dcontext, 4, (reg_t)NULL);
+        bool sig_pending = false;
+        if (!handle_pre_extended_syscall_sigmasks(dcontext, sigmask, sizemask,
+                                                  &sig_pending)) {
+            set_failure_return_val(dcontext, EINVAL);
+            DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
+            execute_syscall = false;
+        }
+        if (sig_pending) {
+            set_syscall_param(dcontext, 4, dcontext->sys_param4);
+            set_failure_return_val(dcontext, EINTR);
+            DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
+            execute_syscall = false;
         }
         break;
     }
@@ -8289,27 +8290,32 @@ post_system_call(dcontext_t *dcontext)
 #endif
 #ifdef LINUX
     case SYS_ppoll: {
-        if (handle_post_extended_syscall_sigmasks(dcontext, success))
-            set_syscall_param(dcontext, 3, dcontext->sys_param3);
+      if (dcontext->sys_param3 == (reg_t)NULL)
+            break;
+        handle_post_extended_syscall_sigmasks(dcontext, success);
+        set_syscall_param(dcontext, 3, dcontext->sys_param3);
         break;
     }
     case SYS_pselect6: {
+        if (dcontext->sys_param3 == (reg_t)NULL)
+            break;
         typedef struct {
             kernel_sigset_t *sigmask;
             size_t sizemask;
         } data_t;
         data_t *data_param = (data_t *)dcontext->sys_param3;
-        if (handle_post_extended_syscall_sigmasks(dcontext, success)) {
-            if (!safe_write_ex((void *)&data_param->sigmask, sizeof(data_param->sigmask),
-                               &dcontext->sys_param4, NULL)) {
-                LOG(THREAD, LOG_SYSCALLS, 2, "\tEFAULT for pselect6 post syscall\n");
-            }
+        handle_post_extended_syscall_sigmasks(dcontext, success);
+        if (!safe_write_ex((void *)&data_param->sigmask, sizeof(data_param->sigmask),
+                           &dcontext->sys_param4, NULL)) {
+            LOG(THREAD, LOG_SYSCALLS, 2, "\tEFAULT for pselect6 post syscall\n");
         }
         break;
     }
     case SYS_epoll_pwait: {
-        if (handle_post_extended_syscall_sigmasks(dcontext, success))
-            set_syscall_param(dcontext, 4, dcontext->sys_param4);
+        if (dcontext->sys_param4 == (reg_t)NULL)
+            break;
+        handle_post_extended_syscall_sigmasks(dcontext, success);
+        set_syscall_param(dcontext, 4, dcontext->sys_param4);
         break;
     }
 #endif

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7017,17 +7017,15 @@ pre_system_call(dcontext_t *dcontext)
         if (sigmask == NULL)
             break;
         size_t sizemask = (size_t)sys_param(dcontext, 4);
-        /* The original app's sigmask parameter is now NULL effectively making the
-         * syscall a non p* version, and the mask's semantics are emulated by DR
-         * instead.
+        /* The original app's sigmask parameter is now NULL effectively making the syscall
+         * a non p* version, and the mask's semantics are emulated by DR instead.
          */
         set_syscall_param(dcontext, 3, (reg_t)NULL);
         bool sig_pending = false;
         if (!handle_pre_extended_syscall_sigmasks(dcontext, sigmask, sizemask,
                                                   &sig_pending)) {
             /* In old kernels with sizeof(kernel_sigset_t) != sizemask, we're forcing
-             * failure. We're already violating app transparency in other places in
-             * DR.
+             * failure. We're already violating app transparency in other places in DR.
              */
             set_failure_return_val(dcontext, EINVAL);
             DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
@@ -7062,11 +7060,9 @@ pre_system_call(dcontext_t *dcontext)
             execute_syscall = false;
             break;
         }
-        if (data.sigmask == NULL) {
-            dcontext->sys_param3 = (reg_t)NULL;
-            break;
-        }
         dcontext->sys_param4 = (reg_t)data.sigmask;
+        if (data.sigmask == NULL)
+            break;
         kernel_sigset_t *nullsigmaskptr = NULL;
         if (!safe_write_ex((void *)&data_param->sigmask, sizeof(data_param->sigmask),
                            &nullsigmaskptr, NULL)) {
@@ -8297,7 +8293,7 @@ post_system_call(dcontext_t *dcontext)
         break;
     }
     case SYS_pselect6: {
-        if (dcontext->sys_param3 == (reg_t)NULL)
+        if (dcontext->sys_param4 == (reg_t)NULL)
             break;
         typedef struct {
             kernel_sigset_t *sigmask;

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -8286,7 +8286,7 @@ post_system_call(dcontext_t *dcontext)
 #endif
 #ifdef LINUX
     case SYS_ppoll: {
-      if (dcontext->sys_param3 == (reg_t)NULL)
+        if (dcontext->sys_param3 == (reg_t)NULL)
             break;
         handle_post_extended_syscall_sigmasks(dcontext, success);
         set_syscall_param(dcontext, 3, dcontext->sys_param3);

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -338,7 +338,7 @@ bool
 handle_pre_extended_syscall_sigmasks(dcontext_t *dcontext, kernel_sigset_t *sigmask,
                                      size_t sizemask, bool *pending);
 
-void
+bool
 handle_post_extended_syscall_sigmasks(dcontext_t *dcontext, bool success);
 #endif
 

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -338,7 +338,7 @@ bool
 handle_pre_extended_syscall_sigmasks(dcontext_t *dcontext, kernel_sigset_t *sigmask,
                                      size_t sizemask, bool *pending);
 
-bool
+void
 handle_post_extended_syscall_sigmasks(dcontext_t *dcontext, bool success);
 #endif
 

--- a/core/unix/signal_linux.c
+++ b/core/unix/signal_linux.c
@@ -361,11 +361,11 @@ handle_pre_extended_syscall_sigmasks(dcontext_t *dcontext, kernel_sigset_t *sigm
      * are not properly emulated w.r.t. their atomicity setting the sigprocmask and
      * executing the syscall.
      */
+    *pending = false;
     if (sizemask != sizeof(kernel_sigset_t))
         return false;
+    ASSERT(sigmask != NULL);
     ASSERT(!info->pre_syscall_app_sigprocmask_valid);
-    if (sigmask == NULL)
-        return true;
     info->pre_syscall_app_sigprocmask_valid = true;
     info->pre_syscall_app_sigprocmask = info->app_sigblocked;
     signal_set_mask(dcontext, sigmask);
@@ -375,14 +375,15 @@ handle_pre_extended_syscall_sigmasks(dcontext_t *dcontext, kernel_sigset_t *sigm
     return true;
 }
 
-void
+bool
 handle_post_extended_syscall_sigmasks(dcontext_t *dcontext, bool success)
 {
     thread_sig_info_t *info = (thread_sig_info_t *)dcontext->signal_field;
     if (!info->pre_syscall_app_sigprocmask_valid)
-        return;
+        return false;
     info->pre_syscall_app_sigprocmask_valid = false;
     signal_set_mask(dcontext, &info->pre_syscall_app_sigprocmask);
+    return true;
 }
 
 ptr_int_t

--- a/core/unix/signal_linux.c
+++ b/core/unix/signal_linux.c
@@ -375,15 +375,13 @@ handle_pre_extended_syscall_sigmasks(dcontext_t *dcontext, kernel_sigset_t *sigm
     return true;
 }
 
-bool
+void
 handle_post_extended_syscall_sigmasks(dcontext_t *dcontext, bool success)
 {
     thread_sig_info_t *info = (thread_sig_info_t *)dcontext->signal_field;
-    if (!info->pre_syscall_app_sigprocmask_valid)
-        return false;
+    ASSERT(info->pre_syscall_app_sigprocmask_valid);
     info->pre_syscall_app_sigprocmask_valid = false;
     signal_set_mask(dcontext, &info->pre_syscall_app_sigprocmask);
-    return true;
 }
 
 ptr_int_t

--- a/core/unix/signal_linux.c
+++ b/core/unix/signal_linux.c
@@ -364,6 +364,8 @@ handle_pre_extended_syscall_sigmasks(dcontext_t *dcontext, kernel_sigset_t *sigm
     if (sizemask != sizeof(kernel_sigset_t))
         return false;
     ASSERT(!info->pre_syscall_app_sigprocmask_valid);
+    if (sigmask == NULL)
+        return true;
     info->pre_syscall_app_sigprocmask_valid = true;
     info->pre_syscall_app_sigprocmask = info->app_sigblocked;
     signal_set_mask(dcontext, sigmask);
@@ -377,6 +379,8 @@ void
 handle_post_extended_syscall_sigmasks(dcontext_t *dcontext, bool success)
 {
     thread_sig_info_t *info = (thread_sig_info_t *)dcontext->signal_field;
+    if (!info->pre_syscall_app_sigprocmask_valid)
+        return;
     info->pre_syscall_app_sigprocmask_valid = false;
     signal_set_mask(dcontext, &info->pre_syscall_app_sigprocmask);
 }

--- a/suite/tests/linux/syscall_pwait.template
+++ b/suite/tests/linux/syscall_pwait.template
@@ -1,32 +1,43 @@
-handlers for signals: 10, 12
-signal blocked: 12
-signal blocked: 10
+Handlers for signals: 10, 12
+Signal blocked: 12
+Signal blocked: 10
 Testing epoll_pwait
-signal received: 10
-signal received: 12
-signal received: 10
-signal received: 12
+Signal received: 10
+Signal received: 12
+Signal received: 10
+Signal received: 12
 Testing pselect
-signal received: 10
-signal received: 12
-signal received: 10
-signal received: 12
+Signal received: 10
+Signal received: 12
+Signal received: 10
+Signal received: 12
 Testing ppoll
-signal received: 10
-signal received: 12
-signal received: 10
-signal received: 12
+Signal received: 10
+Signal received: 12
+Signal received: 10
+Signal received: 12
 Testing epoll_pwait failure
 Testing pselect failure
 Testing ppoll failure
 #if defined(X86) && defined(X64)
 Testing epoll_pwait, preserve mask
-signal received: 10
-signal received: 12
+Signal received: 10
+Signal received: 12
 Testing pselect, preserve mask
-signal received: 10
-signal received: 12
+Signal received: 10
+Signal received: 12
 Testing ppoll, preserve mask
-signal received: 10
-signal received: 12
+Signal received: 10
+Signal received: 12
 #endif
+Signal unblocked: 12
+Signal unblocked: 10
+Testing epoll_pwait with NULL sigmask
+Signal received: 10
+Signal received: 12
+Testing pselect with NULL sigmask
+Signal received: 10
+Signal received: 12
+Testing ppoll with NULL sigmask
+Signal received: 10
+Signal received: 12


### PR DESCRIPTION
This patch adds support to the emulation of ppoll, epoll_pwait and pselect6 system calls to perform no sigmask manipulation if NULL is passed.

Adds subtests to linux.syscall_pwait for above. It also adds minor changes to print upper case letters in test output.

Fixes #3425