### PR TITLE
i#3315 memfuncs: Add memmove to drmemfuncs

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -88,7 +88,7 @@ if (UNIX AND X86)
   # glibc versioning is only an issue on x86.
   add_asm_target(arch/x86/memfuncs.asm memfuncs_asm_src memfuncs_asm_tgt
     "_memfuncs" "" "${asm_deps}")
-  add_library(drmemfuncs STATIC ${memfuncs_asm_src})
+  add_library(drmemfuncs STATIC ${memfuncs_asm_src} lib/memmove.c)
 endif ()
 
 # i#1409: to share core libc-ish code with non-core, we use the "drlibc" library.

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -2371,6 +2371,8 @@ void *
 memcpy(void *dst, const void *src, size_t n);
 void *
 memset(void *dst, int val, size_t n);
+void *
+memmove(void *dst, const void *src, size_t n);
 #endif /* UNIX */
 
 #ifdef UNIX

--- a/core/lib/memmove.c
+++ b/core/lib/memmove.c
@@ -1,0 +1,60 @@
+/* **********************************************************
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/*
+ * Private memmove for inclusion in libdrmemfuncs for isolation from libc in
+ * shared DR but not in static DR.  We need this in addition to memcpy
+ * and memset because the compiler will auto-issue a call to "memmove" when
+ * it cannot prove there are is no overlap and that memcpy is safe to call.
+ *
+ * We assume that this is not performance-critical as it is rarely called
+ * (in fact it only shows up once in the internal release build and not at
+ * all in the external release build) and so we just use simple C code.
+ */
+
+#include "../globals.h"
+
+#undef memmove
+
+void *
+memmove(void *dst, const void *src, size_t n)
+{
+    ssize_t i;
+    byte *dst_b = (byte *)dst;
+    const byte *src_b = (const byte *)src;
+    if (dst < src)
+        return memcpy(dst, src, n);
+    for (i = n - 1; i >= 0; i--) {
+        dst_b[i] = src_b[i];
+    }
+    return dst;
+}

--- a/core/string.c
+++ b/core/string.c
@@ -141,13 +141,15 @@ d_r_strncat(char *dest, const char *src, size_t n)
     return dest;
 }
 
-/* Private memcpy is in arch/<arch>/<arch>.asm */
+/* Private memcpy is in arch/<arch>/<arch>.asm or memfuncs.asm */
 
-/* Private memset is in arch/<arch>/<arch>.asm */
+/* Private memset is in arch/<arch>/<arch>.asm or memfuncs.asm */
 
 /* Private memmove.  The only difference between memcpy and memmove is that if
  * you need to shift overlapping data forwards in memory, memmove will do what
  * you want.
+ * We also have a version named "memmove" in lib/memmove.c for shared
+ * DR libc isolation.
  */
 void *
 d_r_memmove(void *dst, const void *src, size_t n)


### PR DESCRIPTION
Adds a memmove implementation to drmemfuncs to avoid an import when
the compiler generates a call to memmove in the rare cases it cannot
prove that memcpy is safe.

Issue: #3315