### PR TITLE
i#3348 sym conflicts: Rename multi-word global symbols (#3414)

### DIFF
--- a/core/annotations.c
+++ b/core/annotations.c
@@ -339,7 +339,7 @@ instrument_annotation(dcontext_t *dcontext, IN OUT app_pc *start_pc,
     if (hint_is_safe) {
         hint_byte = *hint_pc;
     } else {
-        if (!safe_read(hint_pc, 1, &hint_byte))
+        if (!d_r_safe_read(hint_pc, 1, &hint_byte))
             return false;
     }
     if (hint_byte != WINDOWS_X64_ANNOTATION_HINT_BYTE)
@@ -711,7 +711,7 @@ handle_vg_annotation(app_pc request_args)
     dr_vg_client_request_t request;
     ptr_uint_t result;
 
-    if (!safe_read(request_args, sizeof(dr_vg_client_request_t), &request)) {
+    if (!d_r_safe_read(request_args, sizeof(dr_vg_client_request_t), &request)) {
         LOG(THREAD, LOG_ANNOTATIONS, 2,
             "Failed to read Valgrind client request args at " PFX
             ". Skipping the annotation.\n",
@@ -846,7 +846,7 @@ is_annotation_tag(dcontext_t *dcontext, IN OUT app_pc *cur_pc, instr_t *scratch,
             if (!IS_ANNOTATION_LABEL_GOT_OFFSET_REFERENCE(src)) /* step 4 */
                 return false;
             opnd_ptr += opnd_get_disp(src); /* step 5 */
-            if (!safe_read(opnd_ptr, sizeof(app_pc), &got_ptr))
+            if (!d_r_safe_read(opnd_ptr, sizeof(app_pc), &got_ptr))
                 return false;
             opnd_ptr = got_ptr;
 #    endif
@@ -856,7 +856,7 @@ is_annotation_tag(dcontext_t *dcontext, IN OUT app_pc *cur_pc, instr_t *scratch,
              * pointer must be an immediate operand to that `prefetch`.
              */
             if (instr_get_opcode(scratch) == OP_prefetchw) { /* step 6 */
-                if (!safe_read(opnd_ptr, DYNAMORIO_ANNOTATION_LABEL_LENGTH, buf))
+                if (!d_r_safe_read(opnd_ptr, DYNAMORIO_ANNOTATION_LABEL_LENGTH, buf))
                     return false;
                 buf[DYNAMORIO_ANNOTATION_LABEL_LENGTH] = '\0';
                 if (strcmp(buf, DYNAMORIO_ANNOTATION_LABEL) == 0) {
@@ -867,9 +867,9 @@ is_annotation_tag(dcontext_t *dcontext, IN OUT app_pc *cur_pc, instr_t *scratch,
                 }
             } /* else the label pointer is the usual `mov` operand: */
 #    endif
-            if (!safe_read(opnd_ptr, sizeof(app_pc), &buf_ptr)) /* step 6 */
+            if (!d_r_safe_read(opnd_ptr, sizeof(app_pc), &buf_ptr)) /* step 6 */
                 return false;
-            if (!safe_read(buf_ptr, DYNAMORIO_ANNOTATION_LABEL_LENGTH, buf))
+            if (!d_r_safe_read(buf_ptr, DYNAMORIO_ANNOTATION_LABEL_LENGTH, buf))
                 return false;
             buf[DYNAMORIO_ANNOTATION_LABEL_LENGTH] = '\0';
             if (strcmp(buf, DYNAMORIO_ANNOTATION_LABEL) != 0)

--- a/core/annotations.h
+++ b/core/annotations.h
@@ -1,5 +1,5 @@
 /* ******************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * ******************************************************/
 
 /*
@@ -404,7 +404,7 @@ is_encoded_valgrind_annotation(app_pc xchg_start_pc, app_pc bb_start, app_pc pag
     if (safe_to_read) {
         word1 = *(uint64 *)(xchg_start_pc - (2 * sizeof(uint64)));
     } else {
-        if (!safe_read(xchg_start_pc - (2 * sizeof(uint64)), sizeof(uint64), &word1))
+        if (!d_r_safe_read(xchg_start_pc - (2 * sizeof(uint64)), sizeof(uint64), &word1))
             return false; /* If it's not safe to read, it must not be an annotation. */
     }
     /* This word must be safe to read because it lies directly between two pcs that are
@@ -441,7 +441,7 @@ is_encoded_valgrind_annotation(app_pc xchg_start_pc, app_pc bb_start, app_pc pag
     if (safe_to_read) {
         word1 = *(uint *)(xchg_start_pc - (3 * sizeof(uint)));
     } else {
-        if (!safe_read(xchg_start_pc - (3 * sizeof(uint)), sizeof(uint), &word1))
+        if (!d_r_safe_read(xchg_start_pc - (3 * sizeof(uint)), sizeof(uint), &word1))
             return false; /* If it's not safe to read, it must not be an annotation. */
     }
     /* These words must be safe to read because they lie directly between two pcs that are

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -763,7 +763,7 @@ arch_extract_profile(dcontext_t *dcontext _IF_X86_64(gencode_mode_t mode))
         protect_generated_code(tpc, WRITABLE);
 
         stop_profile(tpc->profile);
-        mutex_lock(&profile_dump_lock);
+        d_r_mutex_lock(&profile_dump_lock);
 
         /* Print the thread id so even if it has no hits we can
          * count the # total threads. */
@@ -836,7 +836,7 @@ arch_extract_profile(dcontext_t *dcontext _IF_X86_64(gencode_mode_t mode))
                                tpc->profile->end);
         }
 
-        mutex_unlock(&profile_dump_lock);
+        d_r_mutex_unlock(&profile_dump_lock);
         free_profile(tpc->profile);
         tpc->profile = NULL;
     }

--- a/core/arch/disassemble_shared.c
+++ b/core/arch/disassemble_shared.c
@@ -1548,7 +1548,7 @@ internal_dump_callstack_to_buffer(char *buf, size_t bufsz, size_t *sofar, app_pc
                                                        : "Thread " TIDFMT
                                                          " call stack:\n",
                         /* We avoid TLS tid to work on crashes */
-                        IF_WINDOWS_ELSE(get_thread_id(), get_sys_thread_id()));
+                        IF_WINDOWS_ELSE(d_r_get_thread_id(), get_sys_thread_id()));
     }
 
     if (cur_pc != NULL) {

--- a/core/arch/sideline.c
+++ b/core/arch/sideline.c
@@ -529,7 +529,7 @@ sideline_examine_traces()
      * to make sure no fragments are deleted until our last dereference of
      * the hot fragment
      */
-    mutex_lock(&do_not_delete_lock);
+    d_r_mutex_lock(&do_not_delete_lock);
 
     /* now find hottest trace */
     e = find_hottest_entry();
@@ -537,7 +537,7 @@ sideline_examine_traces()
         LOG(logfile, LOG_SIDELINE, VERB_3,
             "\tSIDELINE: cannot find a hot entry w/ count > %d\n",
             SAMPLE_COUNT_THRESHOLD);
-        mutex_unlock(&do_not_delete_lock);
+        d_r_mutex_unlock(&do_not_delete_lock);
         return;
     }
 
@@ -553,7 +553,7 @@ sideline_examine_traces()
         LOG(logfile, LOG_SIDELINE, VERB_3,
             "\tSIDELINE: hottest entry F%d already sidelined\n", f->id);
         /* don't loop here looking for another entry -- let run() loop */
-        mutex_unlock(&do_not_delete_lock);
+        d_r_mutex_unlock(&do_not_delete_lock);
         return;
     } else {
         LOG(logfile, LOG_SIDELINE, VERB_2,
@@ -567,7 +567,7 @@ sideline_examine_traces()
 #    endif
     }
 
-    mutex_unlock(&do_not_delete_lock);
+    d_r_mutex_unlock(&do_not_delete_lock);
 }
 
 fragment_t *
@@ -612,9 +612,9 @@ sideline_optimize(fragment_t *f,
              * delete other fragments than f
              */
             fragment_now_optimizing = f;
-            mutex_unlock(&do_not_delete_lock);
+            d_r_mutex_unlock(&do_not_delete_lock);
             wait_for_event(paused_for_sideline_event, 0);
-            mutex_lock(&do_not_delete_lock);
+            d_r_mutex_lock(&do_not_delete_lock);
             /* if f was deleted, exit now */
             if (fragment_now_optimizing == NULL)
                 goto exit_sideline_optimize;
@@ -715,10 +715,10 @@ sideline_optimize(fragment_t *f,
 
 exit_sideline_optimize:
     pause_for_sideline = (thread_id_t)0;
-    if (!mutex_trylock(&sideline_lock)) {
+    if (!d_r_mutex_trylock(&sideline_lock)) {
         /* thread is waiting in d_r_dispatch */
         signal_event(resume_from_sideline_event);
-        mutex_lock(&sideline_lock);
+        d_r_mutex_lock(&sideline_lock);
         /* at this point we know thread has read our resume event
          * clear all state
          */
@@ -729,7 +729,7 @@ exit_sideline_optimize:
     else
         num_opt_with_no_synch++;
 #    endif
-    mutex_unlock(&sideline_lock);
+    d_r_mutex_unlock(&sideline_lock);
     /* see HACK above */
     set_thread_private_dcontext(NULL);
 
@@ -750,7 +750,7 @@ sideline_cleanup_replacement(dcontext_t *dcontext)
      */
     sideline_trace = NULL;
 
-    mutex_lock(&remember_lock);
+    d_r_mutex_lock(&remember_lock);
     for (l = remember, prev_l = NULL; l != NULL; prev_l = l, l = l->next) {
         if (l->dcontext == dcontext) {
             e = l->list;
@@ -776,11 +776,11 @@ sideline_cleanup_replacement(dcontext_t *dcontext)
             else
                 remember = l->next;
             global_heap_free(l, sizeof(remember_list_t) HEAPACCT(ACCT_SIDELINE));
-            mutex_unlock(&remember_lock);
+            d_r_mutex_unlock(&remember_lock);
             return;
         }
     }
-    mutex_unlock(&remember_lock);
+    d_r_mutex_unlock(&remember_lock);
 }
 
 static sample_entry_t *
@@ -790,7 +790,7 @@ find_hottest_entry()
     sample_entry_t *e, *max = NULL;
     int max_counter = 0;
 
-    mutex_lock(&table.lock);
+    d_r_mutex_lock(&table.lock);
     for (i = 0; i < table.capacity; i++) {
         for (e = table.table[i]; e; e = e->next) {
             if (e->counter > max_counter) {
@@ -799,7 +799,7 @@ find_hottest_entry()
             }
         }
     }
-    mutex_unlock(&table.lock);
+    d_r_mutex_unlock(&table.lock);
     return max;
 }
 
@@ -811,7 +811,7 @@ update_sample_entry(ptr_uint_t tag)
     bool found = false;
 
     /* look up entry for id */
-    mutex_lock(&table.lock);
+    d_r_mutex_lock(&table.lock);
     hindex = HASH_FUNC((ptr_uint_t)tag, &table);
     for (e = table.table[hindex]; e; e = e->next) {
         if (e->tag == tag) {
@@ -832,7 +832,7 @@ update_sample_entry(ptr_uint_t tag)
         table.table[hindex] = e;
     }
 
-    mutex_unlock(&table.lock);
+    d_r_mutex_unlock(&table.lock);
     return e;
 }
 
@@ -842,7 +842,7 @@ sideline_fragment_delete(fragment_t *f)
 {
     if ((f->flags & FRAG_IS_TRACE) != 0) {
         /* see notes above on reasons for this extra lock */
-        mutex_lock(&do_not_delete_lock);
+        d_r_mutex_lock(&do_not_delete_lock);
         /* clear sample entry, it could still contain a pointer to f */
         sideline_trace = NULL;
         remove_sample_entry((ptr_uint_t)f);
@@ -850,7 +850,7 @@ sideline_fragment_delete(fragment_t *f)
         if (fragment_now_optimizing == f)
             fragment_now_optimizing = NULL;
 
-        mutex_unlock(&do_not_delete_lock);
+        d_r_mutex_unlock(&do_not_delete_lock);
     }
 }
 
@@ -860,7 +860,7 @@ remove_sample_entry(ptr_uint_t tag)
     uint hindex;
     sample_entry_t *e, *preve;
 
-    mutex_lock(&table.lock);
+    d_r_mutex_lock(&table.lock);
     hindex = HASH_FUNC((ptr_uint_t)tag, &table);
     for (e = table.table[hindex], preve = NULL; e != NULL; preve = e, e = e->next) {
         if (e->tag == tag) {
@@ -872,7 +872,7 @@ remove_sample_entry(ptr_uint_t tag)
             break;
         }
     }
-    mutex_unlock(&table.lock);
+    d_r_mutex_unlock(&table.lock);
 }
 
 static void
@@ -880,7 +880,7 @@ add_remember_entry(dcontext_t *dcontext, fragment_t *f)
 {
     remember_list_t *l;
     remember_entry_t *e;
-    mutex_lock(&remember_lock);
+    d_r_mutex_lock(&remember_lock);
     l = remember;
     while (l != NULL) {
         if (l->dcontext == dcontext) {
@@ -890,7 +890,7 @@ add_remember_entry(dcontext_t *dcontext, fragment_t *f)
             e->f = f;
             e->next = l->list;
             l->list = e;
-            mutex_unlock(&remember_lock);
+            d_r_mutex_unlock(&remember_lock);
             return;
         }
         l = l->next;
@@ -905,7 +905,7 @@ add_remember_entry(dcontext_t *dcontext, fragment_t *f)
     l->list->next = NULL;
     l->next = remember;
     remember = l;
-    mutex_unlock(&remember_lock);
+    d_r_mutex_unlock(&remember_lock);
 }
 
 #    ifdef UNIX /***************************************************************/

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -705,10 +705,10 @@ instr_is_wow64_syscall(instr_t *instr)
         if (xl8 == NULL)
             return false;
         if (/* Is the "call edx" followed by a "ret"? */
-            safe_read(xl8 + CTI_IND1_LENGTH, sizeof(opbyte), &opbyte) &&
+            d_r_safe_read(xl8 + CTI_IND1_LENGTH, sizeof(opbyte), &opbyte) &&
             (opbyte == RET_NOIMM_OPCODE || opbyte == RET_IMM_OPCODE) &&
             /* Is the "call edx" preceded by a "mov imm into edx"? */
-            safe_read(xl8 - sizeof(imm) - 1, sizeof(opbyte), &opbyte) &&
+            d_r_safe_read(xl8 - sizeof(imm) - 1, sizeof(opbyte), &opbyte) &&
             opbyte == MOV_IMM_EDX_OPCODE) {
             /* Slightly worried: let's at least have some kind of marker a user
              * could see to make it easier to diagnose problems.
@@ -718,11 +718,11 @@ instr_is_wow64_syscall(instr_t *instr)
              * cache the bounds of multiple libs.
              */
             ASSERT_CURIOSITY(
-                safe_read(xl8 - sizeof(imm), sizeof(imm), &imm) &&
-                    (safe_read((app_pc)(ptr_uint_t)imm, sizeof(tgt_code), tgt_code) &&
+                d_r_safe_read(xl8 - sizeof(imm), sizeof(imm), &imm) &&
+                    (d_r_safe_read((app_pc)(ptr_uint_t)imm, sizeof(tgt_code), tgt_code) &&
                      memcmp(tgt_code, WOW64_SYSSVC, sizeof(tgt_code)) == 0) ||
-                (safe_read((app_pc)(ptr_uint_t)imm, sizeof(WOW64_SYSSVC_1609),
-                           tgt_code) &&
+                (d_r_safe_read((app_pc)(ptr_uint_t)imm, sizeof(WOW64_SYSSVC_1609),
+                               tgt_code) &&
                  memcmp(tgt_code, WOW64_SYSSVC_1609, sizeof(WOW64_SYSSVC_1609)) == 0));
             return true;
         } else
@@ -1816,8 +1816,8 @@ instr_predicate_triggered(instr_t *instr, dr_mcontext_t *mc)
                     : DR_PRED_TRIGGER_MISMATCH;
             } else if (opnd_is_memory_reference(src)) {
                 ptr_int_t val;
-                if (!safe_read(opnd_compute_address(src, mc),
-                               MIN(opnd_get_size(src), sizeof(val)), &val))
+                if (!d_r_safe_read(opnd_compute_address(src, mc),
+                                   MIN(opnd_get_size(src), sizeof(val)), &val))
                     return false;
                 return (val != 0) ? DR_PRED_TRIGGER_MATCH : DR_PRED_TRIGGER_MISMATCH;
             } else

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -2514,9 +2514,9 @@ float_pc_update(dcontext_t *dcontext)
         }
     }
     /* We must either grab thread_initexit_lock or be couldbelinking to translate */
-    mutex_lock(&thread_initexit_lock);
+    d_r_mutex_lock(&thread_initexit_lock);
     xl8_pc = recreate_app_pc(dcontext, orig_pc, NULL);
-    mutex_unlock(&thread_initexit_lock);
+    d_r_mutex_unlock(&thread_initexit_lock);
     LOG(THREAD, LOG_INTERP, 2, "%s: translated " PFX " to " PFX "\n", __FUNCTION__,
         orig_pc, xl8_pc);
 

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -166,7 +166,7 @@ DECL_EXTERN(dynamorio_app_take_over_helper)
 DECL_EXTERN(found_modified_code)
 DECL_EXTERN(get_cleanup_and_terminate_global_do_syscall_entry)
 #ifdef INTERNAL
-DECL_EXTERN(internal_error)
+DECL_EXTERN(d_r_internal_error)
 #endif
 DECL_EXTERN(internal_exception_info)
 DECL_EXTERN(is_currently_on_dstack)

--- a/core/arch/x86_code.c
+++ b/core/arch/x86_code.c
@@ -181,7 +181,7 @@ auto_setup(ptr_uint_t appstack)
     ASSERT(dcontext);
 #ifdef WINDOWS
     LOG(THREAD, LOG_INTERP, 2, "thread_starting: interpreting thread " TIDFMT "\n",
-        get_thread_id());
+        d_r_get_thread_id());
 #endif
 
     /* Despite what *should* happen, there can be other threads if a statically
@@ -278,7 +278,7 @@ new_thread_setup(priv_mcontext_t *mc)
     crec = get_clone_record(mc->xsp);
     LOG(GLOBAL, LOG_INTERP, 1,
         "new_thread_setup: thread " TIDFMT ", dstack " PFX " clone record " PFX "\n",
-        get_thread_id(), get_clone_record_dstack(crec), crec);
+        d_r_get_thread_id(), get_clone_record_dstack(crec), crec);
 
     /* As we used dstack as app thread stack to pass clone record, we now need
      * to switch back to the real app thread stack before continuing.
@@ -340,7 +340,7 @@ new_bsdthread_setup(priv_mcontext_t *mc)
     func_arg = (void *)get_clone_record_thread_arg(crec);
     LOG(GLOBAL, LOG_INTERP, 1,
         "new_thread_setup: thread " TIDFMT ", dstack " PFX " clone record " PFX "\n",
-        get_thread_id(), get_clone_record_dstack(crec), crec);
+        d_r_get_thread_id(), get_clone_record_dstack(crec), crec);
 
     rc = dynamo_thread_init(get_clone_record_dstack(crec), mc,
                             crec _IF_CLIENT_INTERFACE(false));

--- a/core/config.c
+++ b/core/config.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -619,7 +619,7 @@ get_config_val_other_arch(const char *var, char *val, size_t valsz, bool *app_sp
 }
 
 void
-config_init(void)
+d_r_config_init(void)
 {
     config.u.v = &myvals;
     config_read(&config, NULL, 0, CFG_SFX);
@@ -672,7 +672,7 @@ config_heap_exit(void)
 #    endif
 
 void
-config_exit(void)
+d_r_config_exit(void)
 {
 #    if !defined(NOT_DYNAMORIO_CORE) && !defined(NOT_DYNAMORIO_CORE_PROPER)
     if (doing_detach)
@@ -750,12 +750,12 @@ should_inject_from_rununder(const char *runstr, bool app_specific, bool from_env
 #else /* !PARAMS_IN_REGISTRY around whole file */
 
 void
-config_init(void)
+d_r_config_init(void)
 {
 }
 
 void
-config_exit(void)
+d_r_config_exit(void)
 {
 }
 

--- a/core/config.h
+++ b/core/config.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -41,10 +41,10 @@
 #include "dr_config.h" /* for dr_platform_t */
 
 void
-config_init(void);
+d_r_config_init(void);
 
 void
-config_exit(void);
+d_r_config_exit(void);
 
 void
 config_heap_init(void);

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -589,7 +589,7 @@ handle_special_tag(dcontext_t *dcontext)
         LOG(THREAD, LOG_INTERP, 1, "\n%s: thread " TIDFMT " returning to app @" PFX "\n",
             dcontext->go_native ? "Requested to go native"
                                 : "Found DynamoRIO stopping point",
-            get_thread_id(), dcontext->next_tag);
+            d_r_get_thread_id(), dcontext->next_tag);
 #ifdef DR_APP_EXPORTS
         if (dcontext->next_tag == (app_pc)dr_app_stop)
             send_all_other_threads_native();
@@ -1123,21 +1123,21 @@ dispatch_exit_fcache(dcontext_t *dcontext)
 #ifdef SIDELINE
     /* sideline synchronization */
     if (dynamo_options.sideline) {
-        thread_id_t tid = get_thread_id();
+        thread_id_t tid = d_r_get_thread_id();
         if (pause_for_sideline == tid) {
-            mutex_lock(&sideline_lock);
+            d_r_mutex_lock(&sideline_lock);
             if (pause_for_sideline == tid) {
                 LOG(THREAD, LOG_DISPATCH | LOG_THREADS | LOG_SIDELINE, 2,
                     "Thread %d waiting for sideline thread\n", tid);
                 signal_event(paused_for_sideline_event);
                 STATS_INC(num_wait_sideline);
                 wait_for_event(resume_from_sideline_event, 0);
-                mutex_unlock(&sideline_lock);
+                d_r_mutex_unlock(&sideline_lock);
                 LOG(THREAD, LOG_DISPATCH | LOG_THREADS | LOG_SIDELINE, 2,
                     "Thread %d resuming after sideline thread\n", tid);
                 sideline_cleanup_replacement(dcontext);
             } else
-                mutex_unlock(&sideline_lock);
+                d_r_mutex_unlock(&sideline_lock);
         }
     }
 #endif
@@ -1167,7 +1167,7 @@ dispatch_exit_fcache(dcontext_t *dcontext)
                         " at this time");
         }
 #    ifdef CLIENT_SIDELINE
-        mutex_lock(&(dcontext->client_data->sideline_mutex));
+        d_r_mutex_lock(&(dcontext->client_data->sideline_mutex));
 #    endif
         todo = dcontext->client_data->to_do;
         while (todo != NULL) {
@@ -1240,7 +1240,7 @@ dispatch_exit_fcache(dcontext_t *dcontext)
         }
         dcontext->client_data->to_do = NULL;
 #    ifdef CLIENT_SIDELINE
-        mutex_unlock(&(dcontext->client_data->sideline_mutex));
+        d_r_mutex_unlock(&(dcontext->client_data->sideline_mutex));
 #    endif
     }
 #endif /* CLIENT_INTERFACE */

--- a/core/drlibc/drlibc.c
+++ b/core/drlibc/drlibc.c
@@ -56,11 +56,11 @@
 WEAK bool
 safe_read_if_fast(const void *base, size_t size, void *out_buf)
 {
-    return safe_read(base, size, out_buf);
+    return d_r_safe_read(base, size, out_buf);
 }
 
 WEAK void
-internal_error(const char *file, int line, const char *expr)
+d_r_internal_error(const char *file, int line, const char *expr)
 {
     /* Do nothing for non-core. */
 }

--- a/core/drlibc/drlibc_module_elf.c
+++ b/core/drlibc/drlibc_module_elf.c
@@ -79,7 +79,7 @@ is_elf_so_header_common(app_pc base, size_t size, bool memory)
         if (!safe_read_if_fast(base, sizeof(ELF_HEADER_TYPE), &elf_header))
             return false;
     } else if (size == 0) {
-        if (!safe_read(base, sizeof(ELF_HEADER_TYPE), &elf_header))
+        if (!d_r_safe_read(base, sizeof(ELF_HEADER_TYPE), &elf_header))
             return false;
     } else {
         return false;

--- a/core/drlibc/drlibc_module_macho.c
+++ b/core/drlibc/drlibc_module_macho.c
@@ -61,7 +61,7 @@ is_macho_header(app_pc base, size_t size)
     if (size >= sizeof(hdr_safe)) {
         hdr = (struct mach_header *)base;
     } else {
-        if (!safe_read(base, sizeof(hdr_safe), &hdr_safe))
+        if (!d_r_safe_read(base, sizeof(hdr_safe), &hdr_safe))
             return false;
         hdr = &hdr_safe;
     }

--- a/core/drlibc/drlibc_notdr_saferead.c
+++ b/core/drlibc/drlibc_notdr_saferead.c
@@ -39,7 +39,7 @@
 #include "../globals.h"
 
 WEAK bool
-safe_read(const void *base, size_t size, void *out_buf)
+d_r_safe_read(const void *base, size_t size, void *out_buf)
 {
     memcpy(out_buf, base, size);
     return true;

--- a/core/drlibc/drlibc_xarch.asm
+++ b/core/drlibc/drlibc_xarch.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,15 +37,15 @@
 #include "asm_defines.asm"
 START_FILE
 
-DECL_EXTERN(internal_error)
+DECL_EXTERN(d_r_internal_error)
 
 /* For debugging: report an error if the function called by call_switch_stack()
  * unexpectedly returns.  Also used elsewhere.
  */
         DECLARE_FUNC(unexpected_return)
 GLOBAL_LABEL(unexpected_return:)
-        CALLC3(GLOBAL_REF(internal_error), HEX(0), HEX(0), HEX(0))
-        /* internal_error normally never returns */
+        CALLC3(GLOBAL_REF(d_r_internal_error), HEX(0), HEX(0), HEX(0))
+        /* d_r_internal_error normally never returns */
         /* Infinite loop is intentional.  Can we do better in release build?
          * XXX: why not a debug instr?
          */

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -543,7 +543,7 @@ typedef struct _fcache_thread_units_t {
 #define PROTECT_CACHE(cache, op)                                  \
     do {                                                          \
         if ((cache)->is_shared && !is_self_allsynch_flushing()) { \
-            mutex_##op(&(cache)->lock);                           \
+            d_r_mutex_##op(&(cache)->lock);                       \
         }                                                         \
     } while (0);
 

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -905,7 +905,7 @@ fcache_unit_profile_stop(fcache_unit_t *u)
             shared = u->cache->is_shared;
             trace = u->cache->is_trace;
         }
-        mutex_lock(&profile_dump_lock);
+        d_r_mutex_lock(&profile_dump_lock);
         if (shared) {
             print_file(profile_file,
                        "\nDumping fcache %s unit profile (Shared)\n%d hits\n",
@@ -916,7 +916,7 @@ fcache_unit_profile_stop(fcache_unit_t *u)
                        trace ? "trace" : "bb", u->dcontext->owning_thread, sum);
         }
         dump_profile(profile_file, u->profile);
-        mutex_unlock(&profile_dump_lock);
+        d_r_mutex_unlock(&profile_dump_lock);
     }
 }
 #endif
@@ -1042,7 +1042,7 @@ fcache_reset_free(void)
      * we must free the units here as they are unreachable elsewhere.
      * their fragments will be freed by the fragment htable walk.
      */
-    mutex_lock(&unit_flush_lock);
+    d_r_mutex_lock(&unit_flush_lock);
     u = allunits->units_to_flush;
     while (u != NULL) {
         next_u = u->next_local;
@@ -1053,12 +1053,12 @@ fcache_reset_free(void)
         u = next_u;
     }
     allunits->units_to_flush = NULL;
-    mutex_unlock(&unit_flush_lock);
+    d_r_mutex_unlock(&unit_flush_lock);
 
     /* should be freed via vm_area_check_shared_pending() */
     ASSERT(allunits->units_to_free == NULL);
 
-    mutex_lock(&allunits_lock);
+    d_r_mutex_lock(&allunits_lock);
     u = allunits->dead;
     while (u != NULL) {
         next_u = u->next_global;
@@ -1068,7 +1068,7 @@ fcache_reset_free(void)
     /* clear fields for reset_init() */
     allunits->dead = NULL;
     allunits->num_dead = 0;
-    mutex_unlock(&allunits_lock);
+    d_r_mutex_unlock(&allunits_lock);
 }
 
 /* atexit cleanup -- needs no locks */
@@ -1085,14 +1085,14 @@ fcache_exit()
     fcache_reset_free();
 
     /* free heap for all live units (reset did dead ones) */
-    mutex_lock(&allunits_lock);
+    d_r_mutex_lock(&allunits_lock);
     u = allunits->units;
     while (u != NULL) {
         next_u = u->next_global;
         fcache_really_free_unit(u, false /*live*/, true /*dealloc*/);
         u = next_u;
     }
-    mutex_unlock(&allunits_lock);
+    d_r_mutex_unlock(&allunits_lock);
 
     ASSERT(vmvector_empty(fcache_unit_areas));
     vmvector_delete_vector(GLOBAL_DCONTEXT, fcache_unit_areas);
@@ -1110,7 +1110,7 @@ void
 fcache_profile_exit()
 {
     fcache_unit_t *u;
-    mutex_lock(&allunits_lock);
+    d_r_mutex_lock(&allunits_lock);
     for (u = allunits->units; u != NULL; u = u->next_global) {
         if (u->profile) {
             fcache_unit_profile_stop(u);
@@ -1118,7 +1118,7 @@ fcache_profile_exit()
             u->profile = NULL;
         }
     }
-    mutex_unlock(&allunits_lock);
+    d_r_mutex_unlock(&allunits_lock);
 }
 #endif
 
@@ -1285,7 +1285,7 @@ fcache_change_fragment_protection(dcontext_t *dcontext, fragment_t *f, bool writ
         /* FIXME: right now no synch here, so one thread could unprot, another prots,
          * and the first segfaults
          */
-        mutex_lock(&allunits_lock);
+        d_r_mutex_lock(&allunits_lock);
         u = allunits->units;
         while (u != NULL) {
             if (u->writable != writable) {
@@ -1294,7 +1294,7 @@ fcache_change_fragment_protection(dcontext_t *dcontext, fragment_t *f, bool writ
             }
             u = u->next_global;
         }
-        mutex_unlock(&allunits_lock);
+        d_r_mutex_unlock(&allunits_lock);
     }
 }
 
@@ -1330,7 +1330,7 @@ fcache_create_unit(dcontext_t *dcontext, fcache_t *cache, cache_pc pc, size_t si
 
     if (pc == NULL) {
         /* take from dead list if possible */
-        mutex_lock(&allunits_lock);
+        d_r_mutex_lock(&allunits_lock);
         if (allunits->dead != NULL) {
             fcache_unit_t *prev_u = NULL;
             u = allunits->dead;
@@ -1360,7 +1360,7 @@ fcache_create_unit(dcontext_t *dcontext, fcache_t *cache, cache_pc pc, size_t si
                 u = u->next_global;
             }
         }
-        mutex_unlock(&allunits_lock);
+        d_r_mutex_unlock(&allunits_lock);
     }
 
     if (u == NULL) {
@@ -1417,7 +1417,7 @@ fcache_create_unit(dcontext_t *dcontext, fcache_t *cache, cache_pc pc, size_t si
     STATS_FCACHE_MAX(u->cache, capacity_peak, capacity);
 
     u->next_local = NULL; /* must be set by caller */
-    mutex_lock(&allunits_lock);
+    d_r_mutex_lock(&allunits_lock);
 
     if (allunits->units != NULL)
         allunits->units->prev_global = u;
@@ -1438,7 +1438,7 @@ fcache_create_unit(dcontext_t *dcontext, fcache_t *cache, cache_pc pc, size_t si
         }
     }
 
-    mutex_unlock(&allunits_lock);
+    d_r_mutex_unlock(&allunits_lock);
 
     return u;
 }
@@ -1458,7 +1458,7 @@ fcache_free_unit(dcontext_t *dcontext, fcache_unit_t *unit, bool dealloc_or_reus
             ASSERT(dynamo_exited || dynamo_resetting || CACHE_PROTECTED(unit->cache));
         }
     });
-    mutex_lock(&allunits_lock);
+    d_r_mutex_lock(&allunits_lock);
     /* remove from live list */
     if (unit->prev_global != NULL)
         unit->prev_global->next_global = unit->next_global;
@@ -1472,7 +1472,7 @@ fcache_free_unit(dcontext_t *dcontext, fcache_unit_t *unit, bool dealloc_or_reus
 
     if (!dealloc_or_reuse) {
         /* up to caller to dealloc */
-        mutex_unlock(&allunits_lock);
+        d_r_mutex_unlock(&allunits_lock);
         /* we do want to update cache->size and fcache_unit_areas: */
         fcache_really_free_unit(unit, false /*live*/, false /*do not dealloc unit*/);
     }
@@ -1506,9 +1506,9 @@ fcache_free_unit(dcontext_t *dcontext, fcache_unit_t *unit, bool dealloc_or_reus
 #endif
         /* this is done by fcache_really_free_unit for else path */
         remove_unit_from_cache(unit);
-        mutex_unlock(&allunits_lock);
+        d_r_mutex_unlock(&allunits_lock);
     } else {
-        mutex_unlock(&allunits_lock);
+        d_r_mutex_unlock(&allunits_lock);
         fcache_really_free_unit(unit, false /*live*/, true /*dealloc*/);
     }
 }
@@ -1947,7 +1947,7 @@ fcache_increase_size(dcontext_t *dcontext, fcache_t *cache, fcache_unit_t *unit,
     /* take from dead list if possible */
     if (allunits->dead != NULL) {
         fcache_unit_t *u, *prev_u;
-        mutex_lock(&allunits_lock);
+        d_r_mutex_lock(&allunits_lock);
         u = allunits->dead;
         prev_u = NULL;
         while (u != NULL) {
@@ -2008,7 +2008,7 @@ fcache_increase_size(dcontext_t *dcontext, fcache_t *cache, fcache_unit_t *unit,
             prev_u = u;
             u = u->next_global;
         }
-        mutex_unlock(&allunits_lock);
+        d_r_mutex_unlock(&allunits_lock);
     }
     if (new_memory == NULL) {
         /* allocate new memory for unit */
@@ -2591,7 +2591,7 @@ try_for_more_space(dcontext_t *dcontext, fcache_t *cache, fcache_unit_t *unit,
                     if (unit == oldest)
                         unit = NULL;
 
-                    mutex_lock(&unit_flush_lock);
+                    d_r_mutex_lock(&unit_flush_lock);
                     oldest->next_local = allunits->units_to_flush;
                     allunits->units_to_flush = oldest;
                     STATS_ADD_PEAK(cache_units_toflush, 1);
@@ -2603,7 +2603,7 @@ try_for_more_space(dcontext_t *dcontext, fcache_t *cache, fcache_unit_t *unit,
                      * This does mean that cache->size is too big from now until
                      * then, so we don't really support hardcoded cache sizes.
                      */
-                    mutex_unlock(&unit_flush_lock);
+                    d_r_mutex_unlock(&unit_flush_lock);
 
                     tu->pending_flush = true;
                     STATS_INC(cache_units_wset_flushed);
@@ -3572,16 +3572,16 @@ get_cache_for_new_fragment(dcontext_t *dcontext, fragment_t *f)
                  * before acquiring the info->lock
                  */
                 cache = fcache_cache_init(GLOBAL_DCONTEXT, f->flags, true);
-                mutex_lock(&info->lock);
+                d_r_mutex_lock(&info->lock);
                 if (info->cache == NULL) {
                     cache->coarse_info = info;
                     coarse_unit_init(info, cache);
                     ASSERT(cache == info->cache);
-                    mutex_unlock(&info->lock);
+                    d_r_mutex_unlock(&info->lock);
                 } else {
                     /* w/ bb_building_lock we shouldn't have a race here */
                     ASSERT_CURIOSITY(false && "race in creating coarse cache");
-                    mutex_unlock(&info->lock);
+                    d_r_mutex_unlock(&info->lock);
                     fcache_cache_free(GLOBAL_DCONTEXT, cache, true);
                 }
             }
@@ -3746,7 +3746,7 @@ fcache_is_flush_pending(dcontext_t *dcontext)
 static void
 append_units_to_free_list(fcache_unit_t *u)
 {
-    mutex_lock(&unit_flush_lock);
+    d_r_mutex_lock(&unit_flush_lock);
 
     /* must append to keep in increasing flushtime order */
     if (allunits->units_to_free_tail == NULL) {
@@ -3775,7 +3775,7 @@ append_units_to_free_list(fcache_unit_t *u)
     allunits->units_to_free_tail = u;
     ASSERT(allunits->units_to_free_tail->next_local == NULL);
 
-    mutex_unlock(&unit_flush_lock);
+    d_r_mutex_unlock(&unit_flush_lock);
 }
 
 /* It is up to the caller to ensure it's safe to string the fragments in
@@ -3914,10 +3914,10 @@ fcache_flush_pending_units(dcontext_t *dcontext, fragment_t *was_I_flushed)
     /* we grab a local copy to deal w/ races to flush these units up front
      * rather than getting into the flush synch and finding someone beat us
      */
-    mutex_lock(&unit_flush_lock);
+    d_r_mutex_lock(&unit_flush_lock);
     local_to_flush = allunits->units_to_flush;
     allunits->units_to_flush = NULL;
-    mutex_unlock(&unit_flush_lock);
+    d_r_mutex_unlock(&unit_flush_lock);
     if (local_to_flush == NULL)
         return not_flushed;
 
@@ -4002,7 +4002,7 @@ void
 fcache_free_pending_units(dcontext_t *dcontext, uint flushtime)
 {
     fcache_unit_t *u, *nxt;
-    mutex_lock(&unit_flush_lock);
+    d_r_mutex_lock(&unit_flush_lock);
     for (u = allunits->units_to_free; u != NULL; u = nxt) {
         nxt = u->next_local;
         /* free list must be sorted in increasing flushtime */
@@ -4025,7 +4025,7 @@ fcache_free_pending_units(dcontext_t *dcontext, uint flushtime)
         } else
             break; /* sorted! */
     }
-    mutex_unlock(&unit_flush_lock);
+    d_r_mutex_unlock(&unit_flush_lock);
 }
 
 /* Used to prevent shared units earmarked for freeing from being re-used.
@@ -4130,7 +4130,7 @@ fcache_reset_all_caches_proactively(uint target)
     /* FIXME: use a cleaner model than having callers grab this lock? */
     ASSERT_OWN_MUTEX(true, &reset_pending_lock);
     if (reset_in_progress) {
-        mutex_unlock(&reset_pending_lock);
+        d_r_mutex_unlock(&reset_pending_lock);
         return;
     }
     /* N.B.: we relax various synch checks if dynamo_resetting is true, since
@@ -4143,12 +4143,12 @@ fcache_reset_all_caches_proactively(uint target)
     /* this lock is only for synchronizing resets and we do not give it the
      * rank it would need to be held across the whole routine
      */
-    mutex_unlock(&reset_pending_lock);
+    d_r_mutex_unlock(&reset_pending_lock);
 
     LOG(GLOBAL, LOG_CACHE, 2,
         "\nfcache_reset_all_caches_proactively: thread " TIDFMT
         " suspending all threads\n",
-        get_thread_id());
+        d_r_get_thread_id());
 
     /* Suspend all DR-controlled threads at safe locations.
      * Case 6821: other synch-all-thread uses can be ignored, as none of them carry
@@ -4361,10 +4361,10 @@ schedule_reset(uint target)
 {
     bool added_target;
     ASSERT(target != 0);
-    mutex_lock(&reset_pending_lock);
+    d_r_mutex_lock(&reset_pending_lock);
     added_target = !TESTALL(target, reset_pending);
     reset_pending |= target;
-    mutex_unlock(&reset_pending_lock);
+    d_r_mutex_unlock(&reset_pending_lock);
     return added_target;
 }
 
@@ -4503,7 +4503,7 @@ fcache_low_on_memory()
      */
     if (lockwise_safe_to_allocate_memory() && !self_owns_dynamo_vm_area_lock() &&
         !self_owns_write_lock(&fcache_unit_areas->lock)) {
-        mutex_lock(&allunits_lock);
+        d_r_mutex_lock(&allunits_lock);
         u = allunits->dead;
         while (u != NULL) {
             next_u = u->next_global;
@@ -4512,7 +4512,7 @@ fcache_low_on_memory()
             u = next_u;
         }
         allunits->dead = NULL;
-        mutex_unlock(&allunits_lock);
+        d_r_mutex_unlock(&allunits_lock);
         LOG(GLOBAL, LOG_CACHE | LOG_STATS, 1, "fcache_low_on_memory: freed %d KB\n",
             freed / 1024);
     } else {

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -352,7 +352,7 @@ reset_shared_block_table(shared_entry_t **table, mutex_t *lock)
     shared_entry_t *e, *nxte;
     uint i;
     uint size = HASHTABLE_SIZE(SHARED_HASH_BITS);
-    mutex_lock(lock);
+    d_r_mutex_lock(lock);
     for (i = 0; i < size; i++) {
         for (e = table[i]; e != NULL; e = nxte) {
             thread_list_t *tl = e->threads;
@@ -367,7 +367,7 @@ reset_shared_block_table(shared_entry_t **table, mutex_t *lock)
         }
     }
     global_heap_free(table, size * sizeof(shared_entry_t *) HEAPACCT(ACCT_OTHER));
-    mutex_unlock(lock);
+    d_r_mutex_unlock(lock);
 }
 
 static void
@@ -378,9 +378,9 @@ add_shared_block(shared_entry_t **table, mutex_t *lock, fragment_t *f)
     int num_direct = 0, num_indirect = 0;
     linkstub_t *l = FRAGMENT_EXIT_STUBS(f);
     /* use num to avoid thread_id_t recycling problems */
-    uint tnum = get_thread_num(get_thread_id());
+    uint tnum = get_thread_num(d_r_get_thread_id());
 
-    mutex_lock(lock);
+    d_r_mutex_lock(lock);
     e = shared_block_lookup(table, f);
     if (e != NULL) {
         thread_list_t *tl = e->threads;
@@ -390,7 +390,7 @@ add_shared_block(shared_entry_t **table, mutex_t *lock, fragment_t *f)
                 LOG(GLOBAL, LOG_ALL, 2,
                     "add_shared_block: tag " PFX ", but re-add #%d for thread #%d\n",
                     e->tag, tl->count, tnum);
-                mutex_unlock(lock);
+                d_r_mutex_unlock(lock);
                 return;
             }
         }
@@ -403,7 +403,7 @@ add_shared_block(shared_entry_t **table, mutex_t *lock, fragment_t *f)
         LOG(GLOBAL, LOG_ALL, 2,
             "add_shared_block: tag " PFX " thread #%d => %d threads\n", e->tag, tnum,
             e->num_threads);
-        mutex_unlock(lock);
+        d_r_mutex_unlock(lock);
         return;
     }
 
@@ -434,7 +434,7 @@ add_shared_block(shared_entry_t **table, mutex_t *lock, fragment_t *f)
     hindex = HASH_FUNC_BITS((ptr_uint_t)f->tag, SHARED_HASH_BITS);
     e->next = table[hindex];
     table[hindex] = e;
-    mutex_unlock(lock);
+    d_r_mutex_unlock(lock);
 }
 
 static void
@@ -445,7 +445,7 @@ print_shared_table_stats(shared_entry_t **table, mutex_t *lock, const char *name
     uint size = HASHTABLE_SIZE(SHARED_HASH_BITS);
     uint tot = 0, shared_tot = 0, shared = 0, heap = 0, cache = 0, creation_count = 0;
 
-    mutex_lock(lock);
+    d_r_mutex_lock(lock);
     for (i = 0; i < size; i++) {
         for (e = table[i]; e != NULL; e = e->next) {
             thread_list_t *tl = e->threads;
@@ -463,7 +463,7 @@ print_shared_table_stats(shared_entry_t **table, mutex_t *lock, const char *name
             }
         }
     }
-    mutex_unlock(lock);
+    d_r_mutex_unlock(lock);
     LOG(GLOBAL, LOG_ALL, 1, "Shared %s statistics:\n", name);
     LOG(GLOBAL, LOG_ALL, 1, "\ttotal blocks:   %10d\n", tot);
     LOG(GLOBAL, LOG_ALL, 1, "\tcreation count: %10d\n", creation_count);
@@ -963,7 +963,7 @@ add_to_dead_table_list(dcontext_t *alloc_dc, ibl_table_t *ftable, uint old_capac
      * younger tables. A FIFO will yield faster searches than, say, a
      * stack.
      */
-    mutex_lock(&dead_tables_lock);
+    d_r_mutex_lock(&dead_tables_lock);
     if (dead_lists->dead_tables == NULL) {
         ASSERT(dead_lists->dead_tables_tail == NULL);
         dead_lists->dead_tables = item;
@@ -973,7 +973,7 @@ add_to_dead_table_list(dcontext_t *alloc_dc, ibl_table_t *ftable, uint old_capac
         dead_lists->dead_tables_tail->next = item;
     }
     dead_lists->dead_tables_tail = item;
-    mutex_unlock(&dead_tables_lock);
+    d_r_mutex_unlock(&dead_tables_lock);
     STATS_ADD_PEAK(num_dead_shared_ibt_tables, 1);
     STATS_INC(num_total_dead_shared_ibt_tables);
 }
@@ -1280,12 +1280,12 @@ fragment_reset_init(void)
     if (RUNNING_WITHOUT_CODE_CACHE())
         return;
 
-    mutex_lock(&shared_cache_flush_lock);
+    d_r_mutex_lock(&shared_cache_flush_lock);
     /* ASSUMPTION: a reset frees all deletions that use flushtimes, so we can
      * reset the global flushtime here
      */
     flushtime_global = 0;
-    mutex_unlock(&shared_cache_flush_lock);
+    d_r_mutex_unlock(&shared_cache_flush_lock);
 
     if (SHARED_FRAGMENTS_ENABLED()) {
         if (DYNAMO_OPTION(shared_bbs)) {
@@ -1470,7 +1470,7 @@ fragment_reset_free(void)
 
         /* Delete dead tables. */
         /* grab lock for consistency, although we expect a single thread */
-        mutex_lock(&dead_tables_lock);
+        d_r_mutex_lock(&dead_tables_lock);
         current = dead_lists->dead_tables;
         while (current != NULL) {
             DODEBUG({ table_count++; });
@@ -1492,7 +1492,7 @@ fragment_reset_free(void)
         }
         dead_lists->dead_tables = dead_lists->dead_tables_tail = NULL;
         ASSERT(table_count == dead_tables);
-        mutex_unlock(&dead_tables_lock);
+        d_r_mutex_unlock(&dead_tables_lock);
     }
 
     /* FIXME: Take in a flag "permanent" that controls whether exiting or
@@ -1754,7 +1754,7 @@ dec_table_ref_count(dcontext_t *dcontext, ibl_table_t *table, bool could_be_live
          * entry is about to be removed by another thread but the
          * dead_tables_lock hasn't been acquired yet by that thread.
          */
-        mutex_lock(&dead_tables_lock);
+        d_r_mutex_lock(&dead_tables_lock);
         for (current = dead_lists->dead_tables; current != NULL;
              prev = current, current = current->next) {
             if (current->table_unaligned == table->table_unaligned) {
@@ -1784,7 +1784,7 @@ dec_table_ref_count(dcontext_t *dcontext, ibl_table_t *table, bool could_be_live
                 break;
             }
         }
-        mutex_unlock(&dead_tables_lock);
+        d_r_mutex_unlock(&dead_tables_lock);
         ASSERT(current != NULL);
     }
 }
@@ -2053,9 +2053,9 @@ fragment_thread_reset_free(dcontext_t *dcontext)
      * flushed after enter_threadexit() due to os_thread_stack_exit(),
      * so we need to check the flush queue here
      */
-    mutex_lock(&pt->linking_lock);
+    d_r_mutex_lock(&pt->linking_lock);
     check_flush_queue(dcontext, NULL);
-    mutex_unlock(&pt->linking_lock);
+    d_r_mutex_unlock(&pt->linking_lock);
 
     /* For consistency we remove entries from the IBL targets
      * tables before we remove them from the trace table.  However,
@@ -2610,7 +2610,7 @@ fragment_get_fragment_delete_mutex(dcontext_t *dcontext)
 {
     if (dynamo_exited || dcontext == GLOBAL_DCONTEXT)
         return;
-    mutex_lock(&(((per_thread_t *)dcontext->fragment_field)->fragment_delete_mutex));
+    d_r_mutex_lock(&(((per_thread_t *)dcontext->fragment_field)->fragment_delete_mutex));
 }
 
 void
@@ -2618,7 +2618,8 @@ fragment_release_fragment_delete_mutex(dcontext_t *dcontext)
 {
     if (dynamo_exited || dcontext == GLOBAL_DCONTEXT)
         return;
-    mutex_unlock(&(((per_thread_t *)dcontext->fragment_field)->fragment_delete_mutex));
+    d_r_mutex_unlock(
+        &(((per_thread_t *)dcontext->fragment_field)->fragment_delete_mutex));
 }
 #endif
 
@@ -2655,10 +2656,10 @@ fragment_lookup_type(dcontext_t *dcontext, app_pc tag, uint lookup_flags)
                     if (DYNAMO_OPTION(shared_traces)) {
                         /* ensure private trace never shadows shared trace */
                         fragment_t *sf;
-                        read_lock(&shared_trace->rwlock);
+                        d_r_read_lock(&shared_trace->rwlock);
                         sf = hashtable_fragment_lookup(dcontext, (ptr_uint_t)tag,
                                                        shared_trace);
-                        read_unlock(&shared_trace->rwlock);
+                        d_r_read_unlock(&shared_trace->rwlock);
                         ASSERT(sf->tag == NULL);
                     }
                 });
@@ -2677,10 +2678,10 @@ fragment_lookup_type(dcontext_t *dcontext, app_pc tag, uint lookup_flags)
                          * temp privates for trace building
                          */
                         fragment_t *sf;
-                        read_lock(&shared_bb->rwlock);
+                        d_r_read_lock(&shared_bb->rwlock);
                         sf = hashtable_fragment_lookup(dcontext, (ptr_uint_t)tag,
                                                        shared_bb);
-                        read_unlock(&shared_bb->rwlock);
+                        d_r_read_unlock(&shared_bb->rwlock);
                         ASSERT(sf->tag == NULL || TEST(FRAG_TEMP_PRIVATE, f->flags));
                     }
                 });
@@ -2695,9 +2696,9 @@ fragment_lookup_type(dcontext_t *dcontext, app_pc tag, uint lookup_flags)
             /* MUST look at shared trace table before shared bb table,
              * since a shared trace can shadow a shared trace head
              */
-            read_lock(&shared_trace->rwlock);
+            d_r_read_lock(&shared_trace->rwlock);
             f = hashtable_fragment_lookup(dcontext, (ptr_uint_t)tag, shared_trace);
-            read_unlock(&shared_trace->rwlock);
+            d_r_read_unlock(&shared_trace->rwlock);
             if (f->tag != NULL) {
                 ASSERT(f->tag == tag);
                 ASSERT(!TESTANY(FRAG_FAKE | FRAG_COARSE_GRAIN, f->flags));
@@ -2709,9 +2710,9 @@ fragment_lookup_type(dcontext_t *dcontext, app_pc tag, uint lookup_flags)
             /* MUST look at private trace table before shared bb table,
              * since a private trace can shadow a shared trace head
              */
-            read_lock(&shared_bb->rwlock);
+            d_r_read_lock(&shared_bb->rwlock);
             f = hashtable_fragment_lookup(dcontext, (ptr_uint_t)tag, shared_bb);
-            read_unlock(&shared_bb->rwlock);
+            d_r_read_unlock(&shared_bb->rwlock);
             if (f->tag != NULL) {
                 ASSERT(f->tag == tag);
                 ASSERT(!TESTANY(FRAG_FAKE | FRAG_COARSE_GRAIN, f->flags));
@@ -2820,17 +2821,17 @@ fragment_pclookup_by_htable(dcontext_t *dcontext, cache_pc pc, fragment_t *wrapp
     }
     if (DYNAMO_OPTION(shared_traces)) {
         /* then shared traces */
-        read_lock(&shared_trace->rwlock);
+        d_r_read_lock(&shared_trace->rwlock);
         f = hashtable_pclookup(dcontext, shared_trace, pc);
-        read_unlock(&shared_trace->rwlock);
+        d_r_read_unlock(&shared_trace->rwlock);
         if (f != NULL)
             return f;
     }
     if (DYNAMO_OPTION(shared_bbs)) {
         /* then shared basic blocks */
-        read_lock(&shared_bb->rwlock);
+        d_r_read_lock(&shared_bb->rwlock);
         f = hashtable_pclookup(dcontext, shared_bb, pc);
-        read_unlock(&shared_bb->rwlock);
+        d_r_read_unlock(&shared_bb->rwlock);
         if (f != NULL)
             return f;
     }
@@ -3160,19 +3161,19 @@ fragment_remove_shared_no_flush(dcontext_t *dcontext, fragment_t *f)
     LOG(THREAD, LOG_FRAGMENT, 3, "fragment_remove_shared_no_flush: F%d\n", f->id);
     ASSERT(TEST(FRAG_SHARED, f->flags));
     if (TEST(FRAG_IS_TRACE, f->flags)) {
-        mutex_lock(&trace_building_lock);
+        d_r_mutex_lock(&trace_building_lock);
     }
     /* grab bb building lock even for traces to further prevent link changes */
-    mutex_lock(&bb_building_lock);
+    d_r_mutex_lock(&bb_building_lock);
 
     if (TEST(FRAG_WAS_DELETED, f->flags)) {
         /* since caller can't grab locks, we can have a race where someone
          * else deletes first -- in that case nothing to do
          */
         STATS_INC(shared_delete_noflush_race);
-        mutex_unlock(&bb_building_lock);
+        d_r_mutex_unlock(&bb_building_lock);
         if (TEST(FRAG_IS_TRACE, f->flags))
-            mutex_unlock(&trace_building_lock);
+            d_r_mutex_unlock(&trace_building_lock);
         return;
     }
 
@@ -3224,9 +3225,9 @@ fragment_remove_shared_no_flush(dcontext_t *dcontext, fragment_t *f)
     ASSERT(!TEST(FRAG_LINKED_OUTGOING, f->flags));
     ASSERT(!TEST(FRAG_LINKED_INCOMING, f->flags));
 
-    mutex_unlock(&bb_building_lock);
+    d_r_mutex_unlock(&bb_building_lock);
     if (TEST(FRAG_IS_TRACE, f->flags)) {
-        mutex_unlock(&trace_building_lock);
+        d_r_mutex_unlock(&trace_building_lock);
     }
 
     /* no locks can be held when calling this, but f is already unreachable,
@@ -4125,7 +4126,7 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
                     if (coarse->persisted &&
                         exists_coarse_ibl_pending_table(dcontext, coarse, branch_type)) {
                         bool in_persisted_ibl = false;
-                        mutex_lock(&coarse->lock);
+                        d_r_mutex_lock(&coarse->lock);
                         if (exists_coarse_ibl_pending_table(dcontext, coarse,
                                                             branch_type)) {
                             ibl_table_t *ibl_table =
@@ -4137,11 +4138,11 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
                                 in_persisted_ibl = true;
                             TABLE_RWLOCK(ibl_table, read, unlock);
                             if (in_persisted_ibl) {
-                                mutex_unlock(&coarse->lock);
+                                d_r_mutex_unlock(&coarse->lock);
                                 return f;
                             }
                         }
-                        mutex_unlock(&coarse->lock);
+                        d_r_mutex_unlock(&coarse->lock);
                     }
                 }
 #endif /* defined(RETURN_AFTER_CALL) || defined(RCT_IND_BRANCH) */
@@ -4843,7 +4844,7 @@ rct_module_table_copy(dcontext_t *dcontext, app_pc modpc, rct_type_t which,
     app_pc_table_t *merged = NULL;
     rct_module_table_t *permod;
     mutex_t *lock = (which == RCT_RAC) ? &after_call_lock : &rct_module_lock;
-    mutex_lock(lock);
+    d_r_mutex_lock(lock);
     if (which == RCT_RAC) {
         ASSERT(DYNAMO_OPTION(ret_after_call));
         if (!DYNAMO_OPTION(ret_after_call))
@@ -4883,7 +4884,7 @@ rct_module_table_copy(dcontext_t *dcontext, app_pc modpc, rct_type_t which,
         }
     }
     os_get_module_info_unlock();
-    mutex_unlock(lock);
+    d_r_mutex_unlock(lock);
     return merged;
 }
 
@@ -4898,7 +4899,7 @@ rct_module_table_set(dcontext_t *dcontext, app_pc modpc, app_pc_table_t *table,
     rct_module_table_t *permod;
     bool used = false;
     mutex_t *lock = (which == RCT_RAC) ? &after_call_lock : &rct_module_lock;
-    mutex_lock(lock);
+    d_r_mutex_lock(lock);
     os_get_module_info_lock();
     permod = rct_get_table(modpc, which);
     ASSERT(permod != NULL);
@@ -4932,7 +4933,7 @@ rct_module_table_set(dcontext_t *dcontext, app_pc modpc, app_pc_table_t *table,
         STATS_RCT_ADD(which, persisted_entries, permod->persisted_table->entries);
     }
     os_get_module_info_unlock();
-    mutex_unlock(lock);
+    d_r_mutex_unlock(lock);
     return used;
 }
 
@@ -5082,21 +5083,21 @@ fragment_after_call_lookup(dcontext_t *dcontext, app_pc tag)
 void
 fragment_add_after_call(dcontext_t *dcontext, app_pc tag)
 {
-    mutex_lock(&after_call_lock);
+    d_r_mutex_lock(&after_call_lock);
     if (!rct_table_add(dcontext, tag, RCT_RAC))
         STATS_INC(num_existing_after_call);
     else
         STATS_INC(num_future_after_call);
-    mutex_unlock(&after_call_lock);
+    d_r_mutex_unlock(&after_call_lock);
 }
 
 /* flushing a fragment invalidates the after call entry */
 void
 fragment_flush_after_call(dcontext_t *dcontext, app_pc tag)
 {
-    mutex_lock(&after_call_lock);
+    d_r_mutex_lock(&after_call_lock);
     rct_table_flush_entry(dcontext, tag, RCT_RAC);
-    mutex_unlock(&after_call_lock);
+    d_r_mutex_unlock(&after_call_lock);
     STATS_INC(num_future_after_call_removed);
     STATS_DEC(num_future_after_call);
 }
@@ -5107,9 +5108,9 @@ invalidate_after_call_target_range(dcontext_t *dcontext, app_pc text_start,
                                    app_pc text_end)
 {
     uint entries_removed;
-    mutex_lock(&after_call_lock);
+    d_r_mutex_lock(&after_call_lock);
     entries_removed = rct_table_invalidate_range(dcontext, RCT_RAC, text_start, text_end);
-    mutex_unlock(&after_call_lock);
+    d_r_mutex_unlock(&after_call_lock);
 
     STATS_ADD(num_future_after_call_removed, entries_removed);
     STATS_SUB(num_future_after_call, entries_removed);
@@ -5537,12 +5538,12 @@ wait_for_flusher_nolinking(dcontext_t *dcontext)
             "Thread " TIDFMT " waiting for flush (flusher is %d @flushtime %d)\n",
             /* safe to deref flusher since flusher is waiting for our signal */
             dcontext->owning_thread, flusher->owning_thread, flushtime_global);
-        mutex_unlock(&pt->linking_lock);
+        d_r_mutex_unlock(&pt->linking_lock);
         STATS_INC(num_wait_flush);
         wait_for_event(pt->finished_all_unlink, 0);
         LOG(THREAD, LOG_DISPATCH | LOG_THREADS, 2,
             "Thread " TIDFMT " resuming after flush\n", dcontext->owning_thread);
-        mutex_lock(&pt->linking_lock);
+        d_r_mutex_lock(&pt->linking_lock);
     }
 }
 
@@ -5559,13 +5560,13 @@ wait_for_flusher_linking(dcontext_t *dcontext)
             "Thread " TIDFMT " waiting for flush (flusher is %d @flushtime %d)\n",
             /* safe to deref flusher since flusher is waiting for our signal */
             dcontext->owning_thread, flusher->owning_thread, flushtime_global);
-        mutex_unlock(&pt->linking_lock);
+        d_r_mutex_unlock(&pt->linking_lock);
         signal_event(pt->waiting_for_unlink);
         STATS_INC(num_wait_flush);
         wait_for_event(pt->finished_with_unlink, 0);
         LOG(THREAD, LOG_DISPATCH | LOG_THREADS, 2,
             "Thread " TIDFMT " resuming after flush\n", dcontext->owning_thread);
-        mutex_lock(&pt->linking_lock);
+        d_r_mutex_lock(&pt->linking_lock);
     }
 }
 
@@ -5648,13 +5649,13 @@ enter_nolinking(dcontext_t *dcontext, fragment_t *was_I_flushed, bool cache_tran
     /* FIXME: once we have this working correctly, come up with scheme
      * that avoids synch in common case
      */
-    mutex_lock(&pt->linking_lock);
+    d_r_mutex_lock(&pt->linking_lock);
     ASSERT(pt->could_be_linking);
 
     wait_for_flusher_linking(dcontext);
     not_flushed = not_flushed && check_flush_queue(dcontext, was_I_flushed);
     pt->could_be_linking = false;
-    mutex_unlock(&pt->linking_lock);
+    d_r_mutex_unlock(&pt->linking_lock);
 
     if (!cache_transition)
         return not_flushed;
@@ -5666,7 +5667,7 @@ enter_nolinking(dcontext_t *dcontext, fragment_t *was_I_flushed, bool cache_tran
      */
 
     if (reset_pending != 0) {
-        mutex_lock(&reset_pending_lock);
+        d_r_mutex_lock(&reset_pending_lock);
         if (reset_pending != 0) {
             uint target = reset_pending;
             reset_pending = 0;
@@ -5677,7 +5678,7 @@ enter_nolinking(dcontext_t *dcontext, fragment_t *was_I_flushed, bool cache_tran
             /* fragment is gone for sure, so return false */
             return false;
         }
-        mutex_unlock(&reset_pending_lock);
+        d_r_mutex_unlock(&reset_pending_lock);
     }
 
     /* FIXME: perf opt: make global flag can check w/ making a call,
@@ -5722,10 +5723,10 @@ enter_nolinking(dcontext_t *dcontext, fragment_t *was_I_flushed, bool cache_tran
     /* global list */
     if (client_flush_requests != NULL) { /* avoid acquiring lock every cxt switch */
         client_flush_req_t *req;
-        mutex_lock(&client_flush_request_lock);
+        d_r_mutex_lock(&client_flush_request_lock);
         req = client_flush_requests;
         client_flush_requests = NULL;
-        mutex_unlock(&client_flush_request_lock);
+        d_r_mutex_unlock(&client_flush_request_lock);
         /* NOTE - we must release the lock before doing the flush. */
         process_client_flush_requests(dcontext, GLOBAL_DCONTEXT, req, true /*flush*/);
         /* FIXME - this is an ugly, yet effective, hack.  The problem is there is no
@@ -5755,7 +5756,7 @@ enter_couldbelinking(dcontext_t *dcontext, fragment_t *was_I_flushed,
 
     DOCHECK(1, { check_safe_for_flush_synch(dcontext); });
 
-    mutex_lock(&pt->linking_lock);
+    d_r_mutex_lock(&pt->linking_lock);
     ASSERT(!pt->could_be_linking);
     /* ensure not still marked at_syscall */
     ASSERT(!DYNAMO_OPTION(syscalls_synch_flush) || !get_at_syscall(dcontext) ||
@@ -5777,7 +5778,7 @@ enter_couldbelinking(dcontext_t *dcontext, fragment_t *was_I_flushed,
 
     pt->could_be_linking = true;
     not_flushed = check_flush_queue(dcontext, was_I_flushed);
-    mutex_unlock(&pt->linking_lock);
+    d_r_mutex_unlock(&pt->linking_lock);
 
     return not_flushed;
 }
@@ -5795,7 +5796,7 @@ enter_threadexit(dcontext_t *dcontext)
     if (RUNNING_WITHOUT_CODE_CACHE() || pt == NULL /*PR 536058: no pt*/)
         return;
 
-    mutex_lock(&pt->linking_lock);
+    d_r_mutex_lock(&pt->linking_lock);
     /* must dec ref count on shared regions before we die */
     check_flush_queue(dcontext, NULL);
     pt->could_be_linking = false;
@@ -5804,7 +5805,7 @@ enter_threadexit(dcontext_t *dcontext)
         pt->about_to_exit = true;             /* let flusher know can ignore us */
         signal_event(pt->waiting_for_unlink); /* wake flusher up */
     }
-    mutex_unlock(&pt->linking_lock);
+    d_r_mutex_unlock(&pt->linking_lock);
 }
 
 /* caller must hold shared_cache_flush_lock */
@@ -5938,7 +5939,7 @@ flush_fragments_synchall_start(dcontext_t *ignored, app_pc base, size_t size,
     KSTART(synchall_flush);
     LOG(GLOBAL, LOG_FRAGMENT, 2,
         "\nflush_fragments_synchall_start: thread " TIDFMT " suspending all threads\n",
-        get_thread_id());
+        d_r_get_thread_id());
 
     STATS_INC(flush_synchall);
     /* suspend all DR-controlled threads at safe locations */
@@ -6273,7 +6274,7 @@ flush_fragments_synch_priv(dcontext_t *dcontext, app_pc base, size_t size,
      * is grabbed, to avoid deadlocks!  we already do for a thread exiting.
      */
     if (!own_initexit_lock)
-        mutex_lock(&thread_initexit_lock);
+        d_r_mutex_lock(&thread_initexit_lock);
     ASSERT_OWN_MUTEX(true, &thread_initexit_lock);
     flusher = dcontext;
     get_list_of_threads(&flush_threads, &flush_num_threads);
@@ -6327,7 +6328,7 @@ flush_fragments_synch_priv(dcontext_t *dcontext, app_pc base, size_t size,
          * region, until sure thread is in fcache or somewhere that won't change
          * vm areas or linking state
          */
-        mutex_lock(&tgt_pt->linking_lock);
+        d_r_mutex_lock(&tgt_pt->linking_lock);
         /* Must explicitly check for self and avoid synch then, o/w will lock up
          * if ever called from a could_be_linking location (currently only
          * happens w/ app syscalls)
@@ -6339,9 +6340,9 @@ flush_fragments_synch_priv(dcontext_t *dcontext, app_pc base, size_t size,
             LOG(THREAD, LOG_FRAGMENT, 2, "\twaiting for thread " TIDFMT "\n",
                 tgt_dcontext->owning_thread);
             tgt_pt->wait_for_unlink = true;
-            mutex_unlock(&tgt_pt->linking_lock);
+            d_r_mutex_unlock(&tgt_pt->linking_lock);
             wait_for_event(tgt_pt->waiting_for_unlink, 0);
-            mutex_lock(&tgt_pt->linking_lock);
+            d_r_mutex_lock(&tgt_pt->linking_lock);
             tgt_pt->wait_for_unlink = false;
             LOG(THREAD, LOG_FRAGMENT, 2, "\tdone waiting for thread " TIDFMT "\n",
                 tgt_dcontext->owning_thread);
@@ -6396,7 +6397,7 @@ flush_fragments_synch_priv(dcontext_t *dcontext, app_pc base, size_t size,
          */
         if (tgt_dcontext != dcontext && !tgt_pt->could_be_linking)
             tgt_pt->wait_for_unlink = true; /* stop at cache exit */
-        mutex_unlock(&tgt_pt->linking_lock);
+        d_r_mutex_unlock(&tgt_pt->linking_lock);
     }
 }
 
@@ -6538,7 +6539,7 @@ flush_fragments_unlink_shared(dcontext_t *dcontext, app_pc base, size_t size,
              * flushtime_global and the adding of pending deletion fragments with
              * that flushtime, wrt other threads checking the pending list.
              */
-            mutex_lock(&shared_cache_flush_lock);
+            d_r_mutex_lock(&shared_cache_flush_lock);
         }
         /* Increment flush count for shared deletion algorithm and for list-based
          * flushing (such as for shared cache units).  We could wait
@@ -6560,7 +6561,7 @@ flush_fragments_unlink_shared(dcontext_t *dcontext, app_pc base, size_t size,
                                                            pending_delete_threads);
         }
         if (DYNAMO_OPTION(shared_deletion))
-            mutex_unlock(&shared_cache_flush_lock);
+            d_r_mutex_unlock(&shared_cache_flush_lock);
 
         DODEBUG({
             num_flushed += shared_flushed;
@@ -6677,7 +6678,7 @@ flush_fragments_end_synch(dcontext_t *dcontext, bool keep_initexit_lock)
         tgt_dcontext = flush_threads[i]->dcontext;
         tgt_pt = (per_thread_t *)tgt_dcontext->fragment_field;
         /* re-acquire lock */
-        mutex_lock(&tgt_pt->linking_lock);
+        d_r_mutex_lock(&tgt_pt->linking_lock);
 
         /* Optimization for shared deletion strategy: perform flush work
          * for a thread waiting at a system call, as we didn't add it to the
@@ -6721,7 +6722,7 @@ flush_fragments_end_synch(dcontext_t *dcontext, bool keep_initexit_lock)
                     signal_event(tgt_pt->finished_all_unlink);
             }
         }
-        mutex_unlock(&tgt_pt->linking_lock);
+        d_r_mutex_unlock(&tgt_pt->linking_lock);
     }
 
     /* thread init/exit can proceed now */
@@ -6731,7 +6732,7 @@ flush_fragments_end_synch(dcontext_t *dcontext, bool keep_initexit_lock)
                          sizeof(thread_record_t *) HEAPACCT(ACCT_THREAD_MGT));
     flush_threads = NULL;
     if (!keep_initexit_lock)
-        mutex_unlock(&thread_initexit_lock);
+        d_r_mutex_unlock(&thread_initexit_lock);
 }
 
 /* This routine performs flush stages 1 and 2 (synch_unlink_priv()
@@ -7105,7 +7106,7 @@ output_trace(dcontext_t *dcontext, per_thread_t *pt, fragment_t *f,
         /* We must grab shared_vm_areas lock first to avoid rank order (i#1157) */
         if (SHARED_FRAGMENTS_ENABLED())
             locked_vmareas = acquire_vm_areas_lock_if_not_already(dcontext, FRAG_SHARED);
-        mutex_lock(&tracedump_mutex);
+        d_r_mutex_lock(&tracedump_mutex);
     }
     trace_num = tcount;
     tcount++;
@@ -7115,7 +7116,7 @@ output_trace(dcontext_t *dcontext, per_thread_t *pt, fragment_t *f,
          * for ex.) caller is responsible for the necessary synchronization. */
         ASSERT(pt != shared_pt);
         if (!dynamo_resetting) {
-            mutex_unlock(&tracedump_mutex);
+            d_r_mutex_unlock(&tracedump_mutex);
             if (locked_vmareas) {
                 locked_vmareas = false;
                 release_vm_areas_lock(dcontext, FRAG_SHARED);
@@ -7155,7 +7156,7 @@ output_trace(dcontext_t *dcontext, per_thread_t *pt, fragment_t *f,
     print_file(pt->tracefile, "Fragment # %d\n", f->id);
 #    endif
     print_file(pt->tracefile, "Tag = " PFX "\n", f->tag);
-    print_file(pt->tracefile, "Thread = %d\n", get_thread_id());
+    print_file(pt->tracefile, "Thread = %d\n", d_r_get_thread_id());
     if (deleted_at > -1) {
         print_file(pt->tracefile, "*** Flushed from cache when top fragment id was %d\n",
                    deleted_at);
@@ -7245,7 +7246,7 @@ output_trace_done:
     dr_set_isa_mode(dcontext, old_mode, NULL);
     if (TEST(FRAG_SHARED, f->flags) && !dynamo_resetting) {
         ASSERT_OWN_MUTEX(true, &tracedump_mutex);
-        mutex_unlock(&tracedump_mutex);
+        d_r_mutex_unlock(&tracedump_mutex);
         if (locked_vmareas)
             release_vm_areas_lock(dcontext, FRAG_SHARED);
     } else {
@@ -8223,7 +8224,7 @@ fragment_coarse_pclookup(dcontext_t *dcontext, coarse_info_t *info, cache_pc pc,
          * it seems reasonable to simply store all lookups.
          * Then the worst case is some extra memory, not 4x slowdowns.
          */
-        mutex_lock(&info->lock);
+        d_r_mutex_lock(&info->lock);
         if (info->pclookup_last_htable == NULL) {
             /* coarse_table_t isn't quite enough b/c we need the body pc,
              * which would require an extra lookup w/ coarse_table_t
@@ -8237,7 +8238,7 @@ fragment_coarse_pclookup(dcontext_t *dcontext, coarse_info_t *info, cache_pc pc,
             /* Only when fully initialized can we set it, as we hold no lock for it */
             info->pclookup_last_htable = (void *)pc_htable;
         }
-        mutex_unlock(&info->lock);
+        d_r_mutex_unlock(&info->lock);
     }
 
     pc_htable = (generic_table_t *)info->pclookup_last_htable;
@@ -8332,7 +8333,7 @@ fragment_coarse_create_entry_pclookup_table(dcontext_t *dcontext, coarse_info_t 
     if (info->htable == NULL)
         return;
     if (info->pclookup_htable == NULL) {
-        mutex_lock(&info->lock);
+        d_r_mutex_lock(&info->lock);
         if (info->pclookup_htable == NULL) {
             /* set up reverse lookup table */
             main_htable = (coarse_table_t *)info->htable;
@@ -8393,7 +8394,7 @@ fragment_coarse_create_entry_pclookup_table(dcontext_t *dcontext, coarse_info_t 
             /* Only when fully initialized can we set it, as we hold no lock for it */
             info->pclookup_htable = (void *)pc_htable;
         }
-        mutex_unlock(&info->lock);
+        d_r_mutex_unlock(&info->lock);
     }
 }
 

--- a/core/globals.h
+++ b/core/globals.h
@@ -1149,7 +1149,7 @@ d_r_sscanf(const char *str, const char *format, ...);
 int
 d_r_vsscanf(const char *str, const char *fmt, va_list ap);
 const char *
-parse_int(const char *sp, uint64 *res_out, uint base, uint width, bool is_signed);
+d_r_parse_int(const char *sp, uint64 *res_out, uint base, uint width, bool is_signed);
 ssize_t
 utf16_to_utf8_size(const wchar_t *src, size_t max_chars,
                    size_t *written /*unicode chars*/);

--- a/core/hashtable.h
+++ b/core/hashtable.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -91,10 +91,10 @@
                                !INTERNAL_OPTION(single_thread_in_DR),         \
                            &(ptable)->rwlock)
 
-#define TABLE_RWLOCK(ptable, rw, lock)      \
-    do {                                    \
-        if (TABLE_NEEDS_LOCK(ptable))       \
-            rw##_##lock(&(ptable)->rwlock); \
+#define TABLE_RWLOCK(ptable, rw, lock)            \
+    do {                                          \
+        if (TABLE_NEEDS_LOCK(ptable))             \
+            d_r_##rw##_##lock(&(ptable)->rwlock); \
     } while (0)
 
 #define TABLE_MEMOP(table_flags, op) \

--- a/core/hashtablex.h
+++ b/core/hashtablex.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1611,7 +1611,7 @@ static void HTNAME(hashtable_, NAME_KEY,
                    _groom_table)(dcontext_t *dcontext,
                                  HTNAME(, NAME_KEY, _table_t) * table)
 {
-    DOLOG(1, LOG_STATS, { print_timestamp(THREAD); });
+    DOLOG(1, LOG_STATS, { d_r_print_timestamp(THREAD); });
     LOG(THREAD, LOG_HTABLE, 1, "hashtable_" KEY_STRING "_groom_table %s\n", table->name);
 
     /* flush only tables caching data persistent in another table */
@@ -1943,7 +1943,7 @@ void HTNAME(hashtable_, NAME_KEY,
     /* mostly a copy of dump_table but printing only entries with non 0 stats */
     uint i;
     uint max_age = 0;
-    DOLOG(1, LOG_STATS, { print_timestamp(THREAD); });
+    DOLOG(1, LOG_STATS, { d_r_print_timestamp(THREAD); });
     LOG(THREAD, LOG_HTABLE, 1, "dump_and_clean_entry_statistics: %s\n", htable->name);
 
     DOLOG(1, LOG_HTABLE | LOG_STATS, {

--- a/core/heap.c
+++ b/core/heap.c
@@ -472,7 +472,7 @@ request_region_be_heap_reachable(byte *start, size_t size)
     ASSERT(!POINTER_OVERFLOW_ON_ADD(start, size));
     ASSERT(size > 0);
 
-    mutex_lock(&request_region_be_heap_reachable_lock);
+    d_r_mutex_lock(&request_region_be_heap_reachable_lock);
     if (start < must_reach_region_start) {
         byte *allowable_end_tmp;
         SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
@@ -502,7 +502,7 @@ request_region_be_heap_reachable(byte *start, size_t size)
     /* verify can be addressed absolutely (if required), correctness check */
     ASSERT(!DYNAMO_OPTION(heap_in_lower_4GB) ||
            heap_allowable_region_end <= (byte *)POINTER_MAX_32BIT);
-    mutex_unlock(&request_region_be_heap_reachable_lock);
+    d_r_mutex_unlock(&request_region_be_heap_reachable_lock);
 
     LOG(GLOBAL, LOG_HEAP, 1,
         "Added must-be-reachable-from-heap region " PFX "-" PFX "\n"
@@ -716,11 +716,11 @@ vmm_dump_map(vm_heap_t *vmh)
 void
 print_vmm_heap_data(file_t outf)
 {
-    mutex_lock(&heapmgt->vmheap.lock);
+    d_r_mutex_lock(&heapmgt->vmheap.lock);
     print_file(outf, "VM heap: addr range " PFX "--" PFX ", # free blocks %d\n",
                heapmgt->vmheap.start_addr, heapmgt->vmheap.end_addr,
                heapmgt->vmheap.num_free_blocks);
-    mutex_unlock(&heapmgt->vmheap.lock);
+    d_r_mutex_unlock(&heapmgt->vmheap.lock);
 }
 
 static inline void
@@ -1087,16 +1087,16 @@ vmm_heap_reserve_blocks(vm_heap_t *vmh, size_t size_in, which_vmm_t which)
         "vmm_heap_reserve_blocks: size=%d => %d in blocks=%d free_blocks~=%d\n", size_in,
         size, request, vmh->num_free_blocks);
 
-    mutex_lock(&vmh->lock);
+    d_r_mutex_lock(&vmh->lock);
     if (vmh->num_free_blocks < request) {
-        mutex_unlock(&vmh->lock);
+        d_r_mutex_unlock(&vmh->lock);
         return NULL;
     }
     first_block = bitmap_allocate_blocks(vmh->blocks, vmh->num_blocks, request);
     if (first_block != BITMAP_NOT_FOUND) {
         vmh->num_free_blocks -= request;
     }
-    mutex_unlock(&vmh->lock);
+    d_r_mutex_unlock(&vmh->lock);
 
     if (first_block != BITMAP_NOT_FOUND) {
         p = vmm_block_to_addr(vmh, first_block);
@@ -1136,10 +1136,10 @@ vmm_heap_free_blocks(vm_heap_t *vmh, vm_addr_t p, size_t size_in, which_vmm_t wh
     LOG(GLOBAL, LOG_HEAP, 2, "vmm_heap_free_blocks: size=%d blocks=%d p=" PFX "\n", size,
         request, p);
 
-    mutex_lock(&vmh->lock);
+    d_r_mutex_lock(&vmh->lock);
     bitmap_free_blocks(vmh->blocks, vmh->num_blocks, first_block, request);
     vmh->num_free_blocks += request;
-    mutex_unlock(&vmh->lock);
+    d_r_mutex_unlock(&vmh->lock);
 
     ASSERT(vmh->num_free_blocks <= vmh->num_blocks);
     RSTATS_SUB(vmm_vsize_used, size);
@@ -4311,10 +4311,10 @@ special_heap_init_internal(uint block_size, uint block_alignment, bool use_lock,
 #if defined(WINDOWS_PC_SAMPLE) && !defined(DEBUG)
     if (special_heap_profile_enabled()) {
         /* Add to the global master list, which requires a lock */
-        mutex_lock(&special_units_list_lock);
+        d_r_mutex_lock(&special_units_list_lock);
         su->next = special_units_list;
         special_units_list = su;
-        mutex_unlock(&special_units_list_lock);
+        d_r_mutex_unlock(&special_units_list_lock);
     }
 #endif
 
@@ -4402,10 +4402,10 @@ special_heap_profile_stop(special_heap_unit_t *u)
     stop_profile(u->profile);
     sum = sum_profile(u->profile);
     if (sum > 0) {
-        mutex_lock(&profile_dump_lock);
+        d_r_mutex_lock(&profile_dump_lock);
         print_file(profile_file, "\nDumping special heap unit profile\n%d hits\n", sum);
         dump_profile(profile_file, u->profile);
-        mutex_unlock(&profile_dump_lock);
+        d_r_mutex_unlock(&profile_dump_lock);
     }
 }
 #endif
@@ -4418,19 +4418,19 @@ special_heap_profile_exit()
     special_heap_unit_t *u;
     special_units_t *su;
     ASSERT(special_heap_profile_enabled()); /* will never be compiled in I guess :) */
-    mutex_lock(&special_units_list_lock);
+    d_r_mutex_lock(&special_units_list_lock);
     for (su = special_units_list; su != NULL; su = su->next) {
         if (su->use_lock)
-            mutex_lock(&su->lock);
+            d_r_mutex_lock(&su->lock);
         for (u = su->top_unit; u != NULL; u = u->next) {
             if (u->profile != NULL)
                 special_heap_profile_stop(u);
             /* fast exit path: do not bother to free */
         }
         if (su->use_lock)
-            mutex_unlock(&su->lock);
+            d_r_mutex_unlock(&su->lock);
     }
-    mutex_unlock(&special_units_list_lock);
+    d_r_mutex_unlock(&special_units_list_lock);
 }
 #endif
 
@@ -4487,7 +4487,7 @@ special_heap_exit(void *special)
 #if defined(WINDOWS_PC_SAMPLE) && !defined(DEBUG)
     if (special_heap_profile_enabled()) {
         /* Removed this special_units_t from the master list */
-        mutex_lock(&special_units_list_lock);
+        d_r_mutex_lock(&special_units_list_lock);
         if (special_units_list == su)
             special_units_list = su->next;
         else {
@@ -4498,7 +4498,7 @@ special_heap_exit(void *special)
             ASSERT(prev->next == su);
             prev->next = su->next;
         }
-        mutex_unlock(&special_units_list_lock);
+        d_r_mutex_unlock(&special_units_list_lock);
     }
 #endif
     if (su->use_lock)
@@ -4524,7 +4524,7 @@ special_heap_calloc(void *special, uint num)
     bool took_free = false;
     ASSERT(num > 0);
     if (su->use_lock)
-        mutex_lock(&su->lock);
+        d_r_mutex_lock(&su->lock);
     u = su->cur_unit;
     if (su->free_list != NULL && num == 1) {
         p = (void *)su->free_list;
@@ -4608,7 +4608,7 @@ special_heap_calloc(void *special, uint num)
                           su->block_size * num);
     }
     if (su->use_lock)
-        mutex_unlock(&su->lock);
+        d_r_mutex_unlock(&su->lock);
 
 #ifdef DEBUG_MEMORY
     DOCHECK(CHKLVL_MEMFILL, memset(p, HEAP_ALLOCATED_BYTE, su->block_size * num););
@@ -4632,7 +4632,7 @@ special_heap_cfree(void *special, void *p, uint num)
     /* Allow freeing while iterating w/o deadlock (iterator holds lock) */
     ASSERT(!su->in_iterator || OWN_MUTEX(&su->lock));
     if (su->use_lock && !su->in_iterator)
-        mutex_lock(&su->lock);
+        d_r_mutex_lock(&su->lock);
 #ifdef DEBUG_MEMORY
     /* FIXME: ensure that p is in allocated state */
     DOCHECK(CHKLVL_MEMFILL, memset(p, HEAP_UNALLOCATED_BYTE, su->block_size * num););
@@ -4651,7 +4651,7 @@ special_heap_cfree(void *special, void *p, uint num)
     ACCOUNT_FOR_FREE(su, ACCT_SPECIAL, su->block_size * num);
 #endif
     if (su->use_lock && !su->in_iterator)
-        mutex_unlock(&su->lock);
+        d_r_mutex_unlock(&su->lock);
 }
 
 void
@@ -4668,7 +4668,7 @@ special_heap_can_calloc(void *special, uint num)
 
     ASSERT(num > 0);
     if (su->use_lock)
-        mutex_lock(&su->lock);
+        d_r_mutex_lock(&su->lock);
     if (su->free_list != NULL && num == 1) {
         can_calloc = true;
     } else if (su->cfree_list != NULL && num > 1) {
@@ -4687,7 +4687,7 @@ special_heap_can_calloc(void *special, uint num)
                       !POINTER_OVERFLOW_ON_ADD(u->cur_pc, su->block_size * num));
     }
     if (su->use_lock)
-        mutex_unlock(&su->lock);
+        d_r_mutex_unlock(&su->lock);
 
     return can_calloc;
 }
@@ -4710,7 +4710,7 @@ special_heap_iterator_start(void *heap, special_heap_iterator_t *shi)
     special_units_t *su = (special_units_t *)heap;
     ASSERT(heap != NULL);
     ASSERT(shi != NULL);
-    mutex_lock(&su->lock);
+    d_r_mutex_lock(&su->lock);
     shi->heap = heap;
     shi->next_unit = (void *)su->top_unit;
     su->in_iterator = true;
@@ -4764,7 +4764,7 @@ special_heap_iterator_stop(special_heap_iterator_t *shi)
     ASSERT(su != NULL);
     ASSERT_OWN_MUTEX(true, &su->lock);
     su->in_iterator = false;
-    mutex_unlock(&su->lock);
+    d_r_mutex_unlock(&su->lock);
     DODEBUG({
         shi->heap = NULL;
         shi->next_unit = NULL;
@@ -4895,7 +4895,7 @@ alloc_landing_pad(app_pc addr_to_hook)
     /* Check if there is an existing landing pad area within the reachable
      * region for the hook location.  If so use it, else allocate one.
      */
-    write_lock(&landing_pad_areas->lock);
+    d_r_write_lock(&landing_pad_areas->lock);
     if (vmvector_overlap(landing_pad_areas, alloc_region_start, alloc_region_end)) {
         /* Now we have to get that landing pad area that is FULLY contained
          * within alloc_region_start and alloc_region_end.  If a landing pad
@@ -5028,7 +5028,7 @@ alloc_landing_pad(app_pc addr_to_hook)
 
     /* Boundary check to make sure the allocation is within the landing pad area. */
     ASSERT(lpad_area->cur_ptr <= lpad_area->end);
-    write_unlock(&landing_pad_areas->lock);
+    d_r_write_unlock(&landing_pad_areas->lock);
     return lpad;
 }
 
@@ -5042,14 +5042,14 @@ trim_landing_pad(byte *lpad_start, size_t space_used)
 {
     landing_pad_area_t *lpad_area = NULL;
     bool res = false;
-    write_lock(&landing_pad_areas->lock);
+    d_r_write_lock(&landing_pad_areas->lock);
     if (vmvector_lookup_data(landing_pad_areas, lpad_start, NULL, NULL, &lpad_area)) {
         if (lpad_start == lpad_area->cur_ptr - LANDING_PAD_SIZE) {
             lpad_area->cur_ptr -= (LANDING_PAD_SIZE - space_used);
             res = true;
         }
     }
-    write_unlock(&landing_pad_areas->lock);
+    d_r_write_unlock(&landing_pad_areas->lock);
     return res;
 }
 

--- a/core/hotpatch.c
+++ b/core/hotpatch.c
@@ -2185,13 +2185,13 @@ hotp_process_image_helper(const app_pc base, const bool loaded,
          */
         ASSERT_CURIOSITY(check_sole_thread());
         ASSERT(!own_hot_patch_lock); /* can't get hotp lock before sync locks */
-        mutex_lock(&all_threads_synch_lock);
-        mutex_lock(&thread_initexit_lock);
+        d_r_mutex_lock(&all_threads_synch_lock);
+        d_r_mutex_lock(&thread_initexit_lock);
     }
 #    endif
 
     if (!own_hot_patch_lock)
-        write_lock(&hotp_vul_table_lock);
+        d_r_write_lock(&hotp_vul_table_lock);
     ASSERT_OWN_READWRITE_LOCK(true, &hotp_vul_table_lock);
 
     /* Caller doesn't want to process the image, but to know if it matches. */
@@ -2548,7 +2548,7 @@ hotp_process_image_exit:
      */
     /* TODO: or does this go after flush? */
     if (!own_hot_patch_lock)
-        write_unlock(&hotp_vul_table_lock);
+        d_r_write_unlock(&hotp_vul_table_lock);
         /* TODO: also there are some race conditions with nudging & policy lookup/
          *       injection; sort those out; flushing before or after reading the
          *       policy plays a role too.
@@ -2558,8 +2558,8 @@ hotp_process_image_exit:
         ASSERT(DYNAMO_OPTION(hotp_only));
         ASSERT(!just_check);
         ASSERT_CURIOSITY(check_sole_thread());
-        mutex_unlock(&thread_initexit_lock);
-        mutex_unlock(&all_threads_synch_lock);
+        d_r_mutex_unlock(&thread_initexit_lock);
+        d_r_mutex_unlock(&all_threads_synch_lock);
     }
 #    endif
 }
@@ -2662,7 +2662,7 @@ hotp_point_not_on_list(const app_pc start, const app_pc end, bool own_hot_patch_
     DEBUG_DECLARE(bool matched = false;)
     ASSERT(modbase == get_module_base(end));
     if (!own_hot_patch_lock)
-        read_lock(&hotp_vul_table_lock);
+        d_r_read_lock(&hotp_vul_table_lock);
     ASSERT_OWN_READWRITE_LOCK(true, &hotp_vul_table_lock);
     if (GLOBAL_VUL_TABLE == NULL)
         goto hotp_policy_list_exit;
@@ -2707,7 +2707,7 @@ hotp_point_not_on_list(const app_pc start, const app_pc end, bool own_hot_patch_
     }
 hotp_policy_list_exit:
     if (!own_hot_patch_lock)
-        read_unlock(&hotp_vul_table_lock);
+        d_r_read_unlock(&hotp_vul_table_lock);
     DOSTATS({
         if (matched && !not_on_list) {
             ASSERT(hotp_ppoint_vec != NULL && DYNAMO_OPTION(use_persisted_hotp));
@@ -2804,7 +2804,7 @@ hotp_init(void)
                               hotp_only_tramp_areas_lock);
     }
 
-    write_lock(&hotp_vul_table_lock);
+    d_r_write_lock(&hotp_vul_table_lock);
 
 #    ifdef DEBUG
     hotp_globals =
@@ -2849,7 +2849,7 @@ hotp_init(void)
     }
 
     /* Release locks. */
-    write_unlock(&hotp_vul_table_lock);
+    d_r_write_unlock(&hotp_vul_table_lock);
 
     /* Can't hold any locks at the end of hot patch initializations. */
     ASSERT_OWN_NO_LOCKS();
@@ -2875,7 +2875,7 @@ hotp_reset_free(void)
     hotp_vul_tab_t *current_tab, *temp_tab;
     if (!DYNAMO_OPTION(hot_patching))
         return;
-    write_lock(&hotp_vul_table_lock);
+    d_r_write_lock(&hotp_vul_table_lock);
     temp_tab = hotp_old_vul_tabs;
     while (temp_tab != NULL) {
         current_tab = temp_tab;
@@ -2885,7 +2885,7 @@ hotp_reset_free(void)
                   sizeof(hotp_vul_tab_t) HEAPACCT(ACCT_HOT_PATCHING));
     }
     hotp_old_vul_tabs = NULL;
-    write_unlock(&hotp_vul_table_lock);
+    d_r_write_unlock(&hotp_vul_table_lock);
 }
 
 /* Free up all allocated memory and delete hot patching lock. */
@@ -2898,7 +2898,7 @@ hotp_exit(void)
      */
     ASSERT(dynamo_exited);
     ASSERT(DYNAMO_OPTION(hot_patching));
-    write_lock(&hotp_vul_table_lock);
+    d_r_write_lock(&hotp_vul_table_lock);
 
     /* Release the hot patch policy status table if allocated.  This table
      * may not be allocated till the end if there were no hot patch definitions
@@ -2924,7 +2924,7 @@ hotp_exit(void)
     HEAP_TYPE_FREE(GLOBAL_DCONTEXT, hotp_globals, hotp_globals_t, ACCT_HOT_PATCHING,
                    PROTECTED);
 #    endif
-    write_unlock(&hotp_vul_table_lock);
+    d_r_write_unlock(&hotp_vul_table_lock);
 
     hotp_reset_free();
 
@@ -3058,7 +3058,7 @@ nudge_action_read_policies(void)
          * done in that order with the table lock held as all of them
          * update the global table.
          */
-        write_lock(&hotp_vul_table_lock);
+        d_r_write_lock(&hotp_vul_table_lock);
 
         /* For hotp_only, all patches have to be removed before doing
          * anything with new vulnerability data, and nothing after that,
@@ -3092,7 +3092,7 @@ nudge_action_read_policies(void)
         SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
 
         /* Release all locks. */
-        write_unlock(&hotp_vul_table_lock);
+        d_r_write_unlock(&hotp_vul_table_lock);
 #    ifdef WINDOWS
         if (DYNAMO_OPTION(hotp_only)) {
             end_synch_with_all_threads(all_threads, num_threads, true /*resume*/);
@@ -3155,12 +3155,12 @@ nudge_action_read_policies(void)
                                    PROTECTED);
             temp->vul_tab = old_vul_table;
             temp->num_vuls = num_old_vuls;
-            write_lock(&hotp_vul_table_lock);
+            d_r_write_lock(&hotp_vul_table_lock);
             SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
             temp->next = hotp_old_vul_tabs;
             hotp_old_vul_tabs = temp;
             SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
-            write_unlock(&hotp_vul_table_lock);
+            d_r_write_unlock(&hotp_vul_table_lock);
         }
     } else {
         /* Note, if the new table wasn't read in successfully, then the old
@@ -3220,7 +3220,7 @@ hotp_nudge_handler(uint nudge_action_mask)
                                    THREAD_SYNCH_SUSPEND_FAILURE_IGNORE);
             ASSERT(ok);
         }
-        write_lock(&hotp_vul_table_lock);
+        d_r_write_lock(&hotp_vul_table_lock);
 
         /* For hotp_only, all patches have to be removed before doing anything
          * with new mode data; loader list walking will inject new ones.
@@ -3247,7 +3247,7 @@ hotp_nudge_handler(uint nudge_action_mask)
                               false /* !probe_init */);
 
         /* Release all locks. */
-        write_unlock(&hotp_vul_table_lock);
+        d_r_write_unlock(&hotp_vul_table_lock);
         if (DYNAMO_OPTION(hotp_only)) {
             end_synch_with_all_threads(all_threads, num_threads, true /*resume*/);
         }
@@ -3388,7 +3388,7 @@ hotp_lookup_patch_addr(const app_pc pc, hotp_offset_match_t *match,
     ASSERT(hotp_patch_point_areas != NULL);
 
     if (!own_hot_patch_lock) /* Fix for case 5323. */
-        read_lock(&hotp_vul_table_lock);
+        d_r_read_lock(&hotp_vul_table_lock);
 
     /* Can come here with either the read lock (during instruction matching) or
      * with the write lock (during injection).
@@ -3434,7 +3434,7 @@ hotp_lookup_patch_addr(const app_pc pc, hotp_offset_match_t *match,
 
 hotp_lookup_patch_addr_exit:
     if (!own_hot_patch_lock)
-        read_unlock(&hotp_vul_table_lock);
+        d_r_read_unlock(&hotp_vul_table_lock);
     return res;
 }
 
@@ -3468,7 +3468,7 @@ hotp_does_region_need_patch(const app_pc start, const app_pc end, bool own_hot_p
     ASSERT(hotp_patch_point_areas != NULL);
 
     if (!own_hot_patch_lock) /* Fix for case 5323. */
-        read_lock(&hotp_vul_table_lock);
+        d_r_read_lock(&hotp_vul_table_lock);
 
     /* Caller must come in with lock - that is the use today.  However, this
      * doesn't need the caller to hold the hotp_vul_table_lock; can do so by
@@ -3480,7 +3480,7 @@ hotp_does_region_need_patch(const app_pc start, const app_pc end, bool own_hot_p
     res = vmvector_overlap(hotp_patch_point_areas, start, end);
 
     if (!own_hot_patch_lock)
-        read_unlock(&hotp_vul_table_lock);
+        d_r_read_unlock(&hotp_vul_table_lock);
 
     return res;
 }
@@ -3693,7 +3693,7 @@ hotp_inject(dcontext_t *dcontext, instrlist_t *ilist)
     ASSERT(!DYNAMO_OPTION(hotp_only));
 
     if (!caller_owns_hotp_lock)
-        write_lock(&hotp_vul_table_lock); /* Fix for case 5323. */
+        d_r_write_lock(&hotp_vul_table_lock); /* Fix for case 5323. */
 
     /* Expand the ilist corresponding to the basic block and for each
      * instruction in the ilist, check if one or more injections to
@@ -3761,7 +3761,7 @@ hotp_inject(dcontext_t *dcontext, instrlist_t *ilist)
         instr = next;
     }
     if (!caller_owns_hotp_lock)
-        write_unlock(&hotp_vul_table_lock);
+        d_r_write_unlock(&hotp_vul_table_lock);
     return injected_hot_patch;
 }
 
@@ -4206,7 +4206,7 @@ hotp_only_inject_patch(const hotp_offset_match_t *ppoint_desc,
         bool res;
         app_pc eip;
         CONTEXT cxt;
-        thread_id_t my_tid = get_thread_id();
+        thread_id_t my_tid = d_r_get_thread_id();
 
         for (i = 0; i < num_threads; i++) {
             /* Skip the current thread; nudge thread's Eip isn't relevant. */
@@ -4392,9 +4392,9 @@ hotp_only_detach_helper(void)
     ASSERT_OWN_MUTEX(true, &all_threads_synch_lock);
     ASSERT_OWN_MUTEX(true, &thread_initexit_lock);
 
-    write_lock(&hotp_vul_table_lock);
+    d_r_write_lock(&hotp_vul_table_lock);
     hotp_remove_hot_patches(GLOBAL_VUL_TABLE, NUM_GLOBAL_VULS, true, NULL);
-    write_unlock(&hotp_vul_table_lock);
+    d_r_write_unlock(&hotp_vul_table_lock);
 }
 
 /* This function is used to handle loader safe injection for hotp_only mode.
@@ -4452,7 +4452,7 @@ hotp_only_mem_prot_change(const app_pc start, const size_t size, const bool remo
 
 #    ifdef WINDOWS
     DODEBUG({
-        if (get_loader_lock_owner() != get_thread_id()) {
+        if (get_loader_lock_owner() != d_r_get_thread_id()) {
             LOG(GLOBAL, LOG_HOT_PATCHING, 1,
                 "Warning: Loader lock not held "
                 "during image memory protection change; possible incompatible "
@@ -4489,7 +4489,7 @@ hotp_only_mem_prot_change(const app_pc start, const size_t size, const bool remo
                            THREAD_SYNCH_SUSPEND_FAILURE_IGNORE);
     ASSERT(ok);
 #    endif
-    write_lock(&hotp_vul_table_lock);
+    d_r_write_lock(&hotp_vul_table_lock);
 
     /* Using hotp_process_image to inject is inefficient because it goes
      * through the whole vul table.
@@ -4516,7 +4516,7 @@ hotp_only_mem_prot_change(const app_pc start, const size_t size, const bool remo
         /* Used to detect double removal while handling loader-safety. */
         DODEBUG(hotp_globals->ldr_safe_hook_removal = true;); /* Case 7832. */
     }
-    write_unlock(&hotp_vul_table_lock);
+    d_r_write_unlock(&hotp_vul_table_lock);
 #    ifdef WINDOWS
     end_synch_with_all_threads(all_threads, num_threads, true /*resume*/);
 #    endif
@@ -4535,7 +4535,7 @@ hotp_only_gateway(app_state_at_intercept_t *state)
     app_pc hook_addr = (app_pc)state->callee_arg;
     after_intercept_action_t res = AFTER_INTERCEPT_LET_GO;
 
-    read_lock(&hotp_vul_table_lock);
+    d_r_read_lock(&hotp_vul_table_lock);
     ASSERT(DYNAMO_OPTION(hotp_only));
 
     /* Callee_arg contains the application eip to be patched.  It better be
@@ -4567,7 +4567,7 @@ hotp_only_gateway(app_state_at_intercept_t *state)
          */
         ASSERT_NOT_REACHED();
     }
-    read_unlock(&hotp_vul_table_lock);
+    d_r_read_unlock(&hotp_vul_table_lock);
     return res;
 }
 
@@ -4650,7 +4650,7 @@ hotp_gateway(const hotp_vul_t *vul_tab, const uint num_vuls, const uint vul_inde
          * are alive, so we don't need to grab the lock here; if we do an
          * indirect access then we need it.  It is left in there for safety.
          */
-        read_lock(&hotp_vul_table_lock); /* Part of fix for case 5521. */
+        d_r_read_lock(&hotp_vul_table_lock); /* Part of fix for case 5521. */
     } else
         ASSERT_OWN_READ_LOCK(true, &hotp_vul_table_lock);
 
@@ -4902,7 +4902,7 @@ hotp_gateway(const hotp_vul_t *vul_tab, const uint num_vuls, const uint vul_inde
                 VUL(vul_tab, vul_index).vul_id);
 
             /* Release the lock because control flow change won't return. */
-            read_unlock(&hotp_vul_table_lock); /* Part of fix for case 5521. */
+            d_r_read_unlock(&hotp_vul_table_lock); /* Part of fix for case 5521. */
             hotp_change_control_flow(app_reg_ptr, module_base + return_rva);
             ASSERT_NOT_REACHED();
         }
@@ -4910,7 +4910,7 @@ hotp_gateway(const hotp_vul_t *vul_tab, const uint num_vuls, const uint vul_inde
 
 hotp_gateway_ret:
     if (!own_hot_patch_lock)
-        read_unlock(&hotp_vul_table_lock); /* Part of fix for case 5521. */
+        d_r_read_unlock(&hotp_vul_table_lock); /* Part of fix for case 5521. */
 
     /* if we change this to be invoked from d_r_dispatch, should remove this */
     EXITING_DR();
@@ -6213,7 +6213,7 @@ dr_register_probes(dr_probe_desc_t *probes, unsigned int num_probes)
      * hotp lock and setting the global hotp table.  If we have our own loader
      * (PR 209430) we won't need to do this.
      */
-    write_lock(&hotp_vul_table_lock);
+    d_r_write_lock(&hotp_vul_table_lock);
 
     SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
     GLOBAL_VUL_TABLE = tab;
@@ -6229,7 +6229,7 @@ dr_register_probes(dr_probe_desc_t *probes, unsigned int num_probes)
     }
     SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
 
-    write_unlock(&hotp_vul_table_lock);
+    d_r_write_unlock(&hotp_vul_table_lock);
 
     /* Unlike hotp_init(), client init happens after vmareas_init(), i.e.,
      * after module processing, so we have to walk the module list again.  It
@@ -6299,7 +6299,7 @@ dr_get_probe_status(unsigned int id, dr_probe_status_t *status)
         return res;
 
     *status = DR_PROBE_STATUS_INVALID_ID;
-    read_lock(&hotp_vul_table_lock);
+    d_r_read_lock(&hotp_vul_table_lock);
     for (i = 0; i < NUM_GLOBAL_VULS; i++) {
         if (id == GLOBAL_VUL(i).id) {
             *status = *(GLOBAL_VUL(i).info->inject_status);
@@ -6308,7 +6308,7 @@ dr_get_probe_status(unsigned int id, dr_probe_status_t *status)
         }
     }
 
-    read_unlock(&hotp_vul_table_lock);
+    d_r_read_unlock(&hotp_vul_table_lock);
     return res;
 }
 #    endif /* CLIENT_INTERFACE */

--- a/core/io.c
+++ b/core/io.c
@@ -396,7 +396,7 @@ in_charset(const char *charset, int c)
 }
 
 const char *
-parse_int(const char *sp, uint64 *res_out, uint base, uint width, bool is_signed)
+d_r_parse_int(const char *sp, uint64 *res_out, uint base, uint width, bool is_signed)
 {
     bool negative = false;
     uint64 res = 0;
@@ -666,7 +666,7 @@ d_r_vsscanf(const char *str, const char *fmt, va_list ap)
             /* C sscanf skips leading whitespace before parsing integers. */
             while (*sp != '\0' && our_isspace(*sp))
                 sp++;
-            sp = parse_int(sp, &res, base, width, is_signed);
+            sp = d_r_parse_int(sp, &res, base, width, is_signed);
             if (sp == NULL)
                 return num_parsed;
 

--- a/core/jit_opt.c
+++ b/core/jit_opt.c
@@ -30,10 +30,10 @@ annotation_unmanage_code_area(void *start, size_t size)
         "Remove code area " PFX "-" PFX " from JIT managed regions\n", start,
         (app_pc)start + size);
 
-    mutex_lock(&thread_initexit_lock);
+    d_r_mutex_lock(&thread_initexit_lock);
     flush_fragments_and_remove_region(dcontext, start, size, true /*own initexit_lock*/,
                                       false /*keep futures*/);
-    mutex_unlock(&thread_initexit_lock);
+    d_r_mutex_unlock(&thread_initexit_lock);
 
     jitopt_clear_span(start, (app_pc)start + size);
 }

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -152,14 +152,14 @@ typedef struct _callback_list_t {
             /* we will be called even if no callbacks (i.e., (vec).num == 0) */      \
             /* we guarantee we're in DR state at all callbacks and clean calls */    \
             /* XXX: add CLIENT_ASSERT here */                                        \
-            read_lock(&callback_registration_lock);                                  \
+            d_r_read_lock(&callback_registration_lock);                              \
             num = (vec).num;                                                         \
             if (num == 0) {                                                          \
-                read_unlock(&callback_registration_lock);                            \
+                d_r_read_unlock(&callback_registration_lock);                        \
             } else if (num <= FAST_COPY_SIZE) {                                      \
                 callback_t tmp[FAST_COPY_SIZE];                                      \
                 memcpy(tmp, (vec).callbacks, num * sizeof(callback_t));              \
-                read_unlock(&callback_registration_lock);                            \
+                d_r_read_unlock(&callback_registration_lock);                        \
                 for (idx = 0; idx < num; idx++) {                                    \
                     ret retop(((type)tmp[num - idx - 1])(__VA_ARGS__)) postop;       \
                 }                                                                    \
@@ -167,7 +167,7 @@ typedef struct _callback_list_t {
                 callback_t *tmp = HEAP_ARRAY_ALLOC(GLOBAL_DCONTEXT, callback_t, num, \
                                                    ACCT_OTHER, UNPROTECTED);         \
                 memcpy(tmp, (vec).callbacks, num * sizeof(callback_t));              \
-                read_unlock(&callback_registration_lock);                            \
+                d_r_read_unlock(&callback_registration_lock);                        \
                 for (idx = 0; idx < num; idx++) {                                    \
                     ret retop(((type)tmp[num - idx - 1])(__VA_ARGS__)) postop;       \
                 }                                                                    \
@@ -428,7 +428,7 @@ add_callback(callback_list_t *vec, void (*func)(void), bool unprotect)
         return;
     }
 
-    write_lock(&callback_registration_lock);
+    d_r_write_lock(&callback_registration_lock);
     /* Although we're receiving a pointer to a callback_list_t, we're
      * usually modifying a static var.
      */
@@ -447,7 +447,7 @@ add_callback(callback_list_t *vec, void (*func)(void), bool unprotect)
 
         if (tmp == NULL) {
             CLIENT_ASSERT(false, "out of memory: can't register callback");
-            write_unlock(&callback_registration_lock);
+            d_r_write_unlock(&callback_registration_lock);
             return;
         }
 
@@ -466,7 +466,7 @@ add_callback(callback_list_t *vec, void (*func)(void), bool unprotect)
     if (unprotect) {
         SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
     }
-    write_unlock(&callback_registration_lock);
+    d_r_write_unlock(&callback_registration_lock);
 }
 
 static bool
@@ -480,7 +480,7 @@ remove_callback(callback_list_t *vec, void (*func)(void), bool unprotect)
         return false;
     }
 
-    write_lock(&callback_registration_lock);
+    d_r_write_lock(&callback_registration_lock);
     /* Although we're receiving a pointer to a callback_list_t, we're
      * usually modifying a static var.
      */
@@ -505,7 +505,7 @@ remove_callback(callback_list_t *vec, void (*func)(void), bool unprotect)
     if (unprotect) {
         SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
     }
-    write_unlock(&callback_registration_lock);
+    d_r_write_unlock(&callback_registration_lock);
 
     return found;
 }
@@ -2328,18 +2328,18 @@ instrument_nudge(dcontext_t *dcontext, client_id_t id, uint64 arg)
     /* count the number of nudge events so we can make sure they're
      * all finished before exiting
      */
-    mutex_lock(&client_thread_count_lock);
+    d_r_mutex_lock(&client_thread_count_lock);
     if (block_client_nudge_threads) {
         /* FIXME - would be nice if there was a way to let the external agent know that
          * the nudge event wasn't delivered (but this only happens when the process
          * is detaching or exiting). */
-        mutex_unlock(&client_thread_count_lock);
+        d_r_mutex_unlock(&client_thread_count_lock);
         return;
     }
 
     /* atomic to avoid locking around the dec */
     ATOMIC_INC(int, num_client_nudge_threads);
-    mutex_unlock(&client_thread_count_lock);
+    d_r_mutex_unlock(&client_thread_count_lock);
 
     /* We need to mark this as a client controlled thread for synch_with_all_threads
      * and otherwise treat it as native.  Xref PR 230836 on what to do if this
@@ -2392,7 +2392,7 @@ void
 wait_for_outstanding_nudges()
 {
     /* block any new nudge threads from starting */
-    mutex_lock(&client_thread_count_lock);
+    d_r_mutex_lock(&client_thread_count_lock);
     SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
     block_client_nudge_threads = true;
     SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
@@ -2412,17 +2412,17 @@ wait_for_outstanding_nudges()
      * a finite timeout)
      */
     if (client_requested_exit) {
-        mutex_unlock(&client_thread_count_lock);
+        d_r_mutex_unlock(&client_thread_count_lock);
         return;
     }
 
     while (num_client_nudge_threads > 0) {
         /* yield with lock released to allow nudges to finish */
-        mutex_unlock(&client_thread_count_lock);
+        d_r_mutex_unlock(&client_thread_count_lock);
         dr_thread_yield();
-        mutex_lock(&client_thread_count_lock);
+        d_r_mutex_lock(&client_thread_count_lock);
     }
-    mutex_unlock(&client_thread_count_lock);
+    d_r_mutex_unlock(&client_thread_count_lock);
 }
 #    endif /* WINDOWS */
 
@@ -3458,7 +3458,7 @@ dr_load_aux_x64_library(const char *name)
      * x64 libs, but another thread in this client could, so we
      * serialize here.
      */
-    mutex_lock(&client_aux_lib64_lock);
+    d_r_mutex_lock(&client_aux_lib64_lock);
     /* XXX: if we switch to our private loader we'll need to add custom
      * search support to look in 64-bit system dir
      */
@@ -3467,7 +3467,7 @@ dr_load_aux_x64_library(const char *name)
      * Not bothering for now.
      */
     h = load_library_64(name);
-    mutex_unlock(&client_aux_lib64_lock);
+    d_r_mutex_unlock(&client_aux_lib64_lock);
     return (dr_auxlib64_handle_t)h;
 }
 
@@ -3484,9 +3484,9 @@ bool
 dr_unload_aux_x64_library(dr_auxlib64_handle_t lib)
 {
     bool res;
-    mutex_lock(&client_aux_lib64_lock);
+    d_r_mutex_lock(&client_aux_lib64_lock);
     res = free_library_64((HANDLE)(uint)lib); /* uint cast to avoid cl warning */
-    mutex_unlock(&client_aux_lib64_lock);
+    d_r_mutex_unlock(&client_aux_lib64_lock);
     return res;
 }
 #    endif
@@ -3534,7 +3534,7 @@ dr_mutex_lock(void *mutex)
          */
         dcontext->client_data->mutex_count++;
     }
-    mutex_lock((mutex_t *)mutex);
+    d_r_mutex_lock((mutex_t *)mutex);
     if (IS_CLIENT_THREAD(dcontext))
         dcontext->client_data->client_grab_mutex = NULL;
 }
@@ -3546,7 +3546,7 @@ void
 dr_mutex_unlock(void *mutex)
 {
     dcontext_t *dcontext = get_thread_private_dcontext();
-    mutex_unlock((mutex_t *)mutex);
+    d_r_mutex_unlock((mutex_t *)mutex);
     /* We do this on the outside so that we're conservative wrt races
      * in the direction of not killing the thread while it has a lock
      */
@@ -3574,7 +3574,7 @@ dr_mutex_trylock(void *mutex)
          */
         dcontext->client_data->mutex_count++;
     }
-    success = mutex_trylock((mutex_t *)mutex);
+    success = d_r_mutex_trylock((mutex_t *)mutex);
     if (IS_CLIENT_THREAD(dcontext)) {
         if (!success)
             dcontext->client_data->mutex_count--;
@@ -3595,7 +3595,7 @@ bool
 dr_mutex_mark_as_app(void *mutex)
 {
     mutex_t *lock = (mutex_t *)mutex;
-    mutex_mark_as_app(lock);
+    d_r_mutex_mark_as_app(lock);
     return true;
 }
 
@@ -3622,35 +3622,35 @@ DR_API
 void
 dr_rwlock_read_lock(void *rwlock)
 {
-    read_lock((read_write_lock_t *)rwlock);
+    d_r_read_lock((read_write_lock_t *)rwlock);
 }
 
 DR_API
 void
 dr_rwlock_read_unlock(void *rwlock)
 {
-    read_unlock((read_write_lock_t *)rwlock);
+    d_r_read_unlock((read_write_lock_t *)rwlock);
 }
 
 DR_API
 void
 dr_rwlock_write_lock(void *rwlock)
 {
-    write_lock((read_write_lock_t *)rwlock);
+    d_r_write_lock((read_write_lock_t *)rwlock);
 }
 
 DR_API
 void
 dr_rwlock_write_unlock(void *rwlock)
 {
-    write_unlock((read_write_lock_t *)rwlock);
+    d_r_write_unlock((read_write_lock_t *)rwlock);
 }
 
 DR_API
 bool
 dr_rwlock_write_trylock(void *rwlock)
 {
-    return write_trylock((read_write_lock_t *)rwlock);
+    return d_r_write_trylock((read_write_lock_t *)rwlock);
 }
 
 DR_API
@@ -3665,7 +3665,7 @@ bool
 dr_rwlock_mark_as_app(void *rwlock)
 {
     read_write_lock_t *lock = (read_write_lock_t *)rwlock;
-    mutex_mark_as_app(&lock->lock);
+    d_r_mutex_mark_as_app(&lock->lock);
     return true;
 }
 
@@ -3731,7 +3731,7 @@ bool
 dr_recurlock_mark_as_app(void *reclock)
 {
     recursive_lock_t *lock = (recursive_lock_t *)reclock;
-    mutex_mark_as_app(&lock->lock);
+    d_r_mutex_mark_as_app(&lock->lock);
     return true;
 }
 
@@ -4666,7 +4666,7 @@ dr_get_token(const char *str, char *buf, size_t buflen)
      */
     const char *pos = str;
     CLIENT_ASSERT(CHECK_TRUNCATE_TYPE_uint(buflen), "buflen too large");
-    if (parse_word(str, &pos, buf, (uint)buflen) == NULL)
+    if (d_r_parse_word(str, &pos, buf, (uint)buflen) == NULL)
         return NULL;
     else
         return pos;
@@ -4919,7 +4919,7 @@ dr_suspend_all_other_threads_ex(OUT void ***drcontexts, OUT uint *num_suspended,
                   "dr_suspend_all_other_threads invalid params");
     LOG(GLOBAL, LOG_FRAGMENT, 2,
         "\ndr_suspend_all_other_threads: thread " TIDFMT " suspending all threads\n",
-        get_thread_id());
+        d_r_get_thread_id());
 
     /* suspend all DR-controlled threads at safe locations */
     if (!synch_with_all_threads(THREAD_SYNCH_SUSPENDED_VALID_MCONTEXT_OR_NO_XFER,
@@ -6722,7 +6722,7 @@ dr_delete_fragment(void *drcontext, void *tag)
     if (!waslinking)
         enter_couldbelinking(dcontext, NULL, false);
 #    ifdef CLIENT_SIDELINE
-    mutex_lock(&(dcontext->client_data->sideline_mutex));
+    d_r_mutex_lock(&(dcontext->client_data->sideline_mutex));
     fragment_get_fragment_delete_mutex(dcontext);
 #    else
     CLIENT_ASSERT(drcontext == get_thread_private_dcontext(),
@@ -6755,7 +6755,7 @@ dr_delete_fragment(void *drcontext, void *tag)
     }
 #    ifdef CLIENT_SIDELINE
     fragment_release_fragment_delete_mutex(dcontext);
-    mutex_unlock(&(dcontext->client_data->sideline_mutex));
+    d_r_mutex_unlock(&(dcontext->client_data->sideline_mutex));
 #    endif
     if (!waslinking)
         enter_nolinking(dcontext, NULL, false);
@@ -6796,7 +6796,7 @@ dr_replace_fragment(void *drcontext, void *tag, instrlist_t *ilist)
     if (!waslinking)
         enter_couldbelinking(dcontext, NULL, false);
 #    ifdef CLIENT_SIDELINE
-    mutex_lock(&(dcontext->client_data->sideline_mutex));
+    d_r_mutex_lock(&(dcontext->client_data->sideline_mutex));
     fragment_get_fragment_delete_mutex(dcontext);
 #    else
     CLIENT_ASSERT(drcontext == get_thread_private_dcontext(),
@@ -6827,7 +6827,7 @@ dr_replace_fragment(void *drcontext, void *tag, instrlist_t *ilist)
     }
 #    ifdef CLIENT_SIDELINE
     fragment_release_fragment_delete_mutex(dcontext);
-    mutex_unlock(&(dcontext->client_data->sideline_mutex));
+    d_r_mutex_unlock(&(dcontext->client_data->sideline_mutex));
 #    endif
     if (!waslinking)
         enter_nolinking(dcontext, NULL, false);
@@ -7024,10 +7024,10 @@ dr_delay_flush_region(app_pc start, size_t size, uint flush_id,
     flush->flush_id = flush_id;
     flush->flush_callback = flush_completion_callback;
 
-    mutex_lock(&client_flush_request_lock);
+    d_r_mutex_lock(&client_flush_request_lock);
     flush->next = client_flush_requests;
     client_flush_requests = flush;
-    mutex_unlock(&client_flush_request_lock);
+    d_r_mutex_unlock(&client_flush_request_lock);
 
     return true;
 }
@@ -7079,7 +7079,7 @@ dr_fragment_size(void *drcontext, void *tag)
 #    ifdef CLIENT_SIDELINE
     /* used to check to see if owning thread, if so don't need lock */
     /* but the check for owning thread more expensive then just getting lock */
-    /* to check if owner get_thread_id() == dcontext->owning_thread */
+    /* to check if owner d_r_get_thread_id() == dcontext->owning_thread */
     fragment_get_fragment_delete_mutex(dcontext);
 #    endif
     f = fragment_lookup(dcontext, tag);
@@ -7248,7 +7248,7 @@ dr_mark_trace_head(void *drcontext, void *tag)
 #    ifdef CLIENT_SIDELINE
     /* used to check to see if owning thread, if so don't need lock */
     /* but the check for owning thread more expensive then just getting lock */
-    /* to check if owner get_thread_id() == dcontext->owning_thread */
+    /* to check if owner d_r_get_thread_id() == dcontext->owning_thread */
     fragment_get_fragment_delete_mutex(dcontext);
 #    endif
     f = fragment_lookup_fine_and_coarse(dcontext, tag, &coarse_f, NULL);
@@ -7539,7 +7539,7 @@ dr_prepopulate_cache(app_pc *tags, size_t tags_count)
      * want to enable our signal handlers, which might disrupt the app running
      * natively in parallel with us.
      */
-    thread_record_t *tr = thread_lookup(get_thread_id());
+    thread_record_t *tr = thread_lookup(d_r_get_thread_id());
     dcontext_t *dcontext = tr->dcontext;
     uint i;
     if (dcontext == NULL)
@@ -7588,7 +7588,7 @@ dr_prepopulate_indirect_targets(dr_indirect_branch_type_t branch_type, app_pc *t
                                 size_t tags_count)
 {
     /* We do the same setup as for dr_prepopulate_cache(). */
-    thread_record_t *tr = thread_lookup(get_thread_id());
+    thread_record_t *tr = thread_lookup(d_r_get_thread_id());
     dcontext_t *dcontext = tr->dcontext;
     ibl_branch_type_t ibl_type;
     uint i;

--- a/core/link.c
+++ b/core/link.c
@@ -1259,20 +1259,20 @@ incoming_find_link(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
         coarse_incoming_t *e;
         coarse_info_t *info = get_fragment_coarse_info(targetf);
         ASSERT(info != NULL);
-        mutex_lock(&info->incoming_lock);
+        d_r_mutex_lock(&info->incoming_lock);
         for (e = info->incoming; e != NULL; e = e->next) {
             if (!e->coarse) {
                 linkstub_t *ls;
                 for (ls = e->in.fine_l; ls != NULL; ls = LINKSTUB_NEXT_INCOMING(ls)) {
                     if (incoming_direct_linkstubs_match(((common_direct_linkstub_t *)ls),
                                                         dl)) {
-                        mutex_unlock(&info->incoming_lock);
+                        d_r_mutex_unlock(&info->incoming_lock);
                         return ls;
                     }
                 }
             }
         }
-        mutex_unlock(&info->incoming_lock);
+        d_r_mutex_unlock(&info->incoming_lock);
     } else {
         for (s = *inlist; s != NULL; s = (common_direct_linkstub_t *)s->next_incoming) {
             ASSERT(LINKSTUB_DIRECT(s->l.flags));
@@ -2171,7 +2171,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
         new_f->flags |= FRAG_LINKED_INCOMING;
 
         /* Now re-route incoming from outside the unit */
-        mutex_lock(&info->incoming_lock);
+        d_r_mutex_lock(&info->incoming_lock);
         for (e = info->incoming; e != NULL; e = next_e) {
             next_e = e->next;
             remove_entry = false;
@@ -2249,7 +2249,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
             } else
                 prev_e = e;
         }
-        mutex_unlock(&info->incoming_lock);
+        d_r_mutex_unlock(&info->incoming_lock);
 
     } else if (TEST(FRAG_COARSE_GRAIN, new_f->flags)) {
         /* Change the entrance stub to point to the trace head routine again
@@ -2619,14 +2619,14 @@ prepend_new_coarse_incoming(coarse_info_t *info, cache_pc coarse, linkstub_t *fi
         });
     }
     ASSERT(info != NULL);
-    mutex_lock(&info->incoming_lock);
+    d_r_mutex_lock(&info->incoming_lock);
     entry->next = info->incoming;
     info->incoming = entry;
     DOLOG(5, LOG_LINKS, {
         LOG(GLOBAL, LOG_LINKS, 4, "after adding new incoming " PFX ":\n", entry);
         print_coarse_incoming(GLOBAL_DCONTEXT, info);
     });
-    mutex_unlock(&info->incoming_lock);
+    d_r_mutex_unlock(&info->incoming_lock);
     return entry;
 }
 
@@ -3094,7 +3094,7 @@ coarse_remove_incoming(dcontext_t *dcontext, fragment_t *src_f, linkstub_t *src_
     LOG(THREAD, LOG_LINKS, 4, "coarse_remove_incoming %s " PFX " to " PFX "\n",
         info->module, src_f->tag, targetf->tag);
 
-    mutex_lock(&info->incoming_lock);
+    d_r_mutex_lock(&info->incoming_lock);
     for (prev_e = NULL, e = info->incoming; e != NULL; prev_e = e, e = e->next) {
         if (!e->coarse) {
             if (incoming_remove_link_search(dcontext, src_f, src_l, targetf,
@@ -3117,7 +3117,7 @@ coarse_remove_incoming(dcontext_t *dcontext, fragment_t *src_f, linkstub_t *src_
         LOG(THREAD, LOG_LINKS, 4, "after removing incoming:\n");
         print_coarse_incoming(dcontext, info);
     });
-    mutex_unlock(&info->incoming_lock);
+    d_r_mutex_unlock(&info->incoming_lock);
 }
 
 /* Removes any incoming data recording the outgoing link from stub */
@@ -3151,7 +3151,7 @@ coarse_remove_outgoing(dcontext_t *dcontext, cache_pc stub, coarse_info_t *src_i
             unlink_entrance_stub(dcontext, stub, 0, src_info);
             LOG(THREAD, LOG_LINKS, 4, "    removing coarse link " PFX " -> %s " PFX "\n",
                 stub, target_info->module, target_tag);
-            mutex_lock(&target_info->incoming_lock);
+            d_r_mutex_lock(&target_info->incoming_lock);
             for (e = target_info->incoming; e != NULL; e = e->next) {
                 if (e->coarse && e->in.stub_pc == stub) {
                     if (prev_e == NULL)
@@ -3170,7 +3170,7 @@ coarse_remove_outgoing(dcontext_t *dcontext, cache_pc stub, coarse_info_t *src_i
                 LOG(THREAD, LOG_LINKS, 4, "after removing outgoing, target:\n");
                 print_coarse_incoming(dcontext, target_info);
             });
-            mutex_unlock(&target_info->incoming_lock);
+            d_r_mutex_unlock(&target_info->incoming_lock);
             ASSERT(found);
         } else {
             /* an intra-unit link, so no incoming entry */
@@ -3221,14 +3221,14 @@ coarse_unit_unlink(dcontext_t *dcontext, coarse_info_t *info)
     ASSERT_OWN_MUTEX(true, &info->lock);
     if (info->stubs == NULL) /* lazily initialized, so common to have empty units */
         return;
-    mutex_lock(&info->incoming_lock);
+    d_r_mutex_lock(&info->incoming_lock);
 #ifndef DEBUG
     /* case 8599: fast exit/reset path: all incoming links are in
      * nonpersistent memory
      */
     if (dynamo_exited || dynamo_resetting) {
         info->incoming = NULL;
-        mutex_unlock(&info->incoming_lock);
+        d_r_mutex_unlock(&info->incoming_lock);
         return;
     }
 #endif
@@ -3287,7 +3287,7 @@ coarse_unit_unlink(dcontext_t *dcontext, coarse_info_t *info)
                                      ACCT_COARSE_LINK);
     }
     info->incoming = NULL;
-    mutex_unlock(&info->incoming_lock);
+    d_r_mutex_unlock(&info->incoming_lock);
 
     coarse_unit_unlink_outgoing(dcontext, info);
 }
@@ -3328,7 +3328,7 @@ coarse_unit_outgoing_linked(dcontext_t *dcontext, coarse_info_t *info)
     cache_pc pc;
     bool linked = false;
     ASSERT(info != NULL);
-    mutex_lock(&info->lock);
+    d_r_mutex_lock(&info->lock);
 
     /* Check outgoing links by walking the stubs */
     coarse_stubs_iterator_start(info, &csi);
@@ -3341,7 +3341,7 @@ coarse_unit_outgoing_linked(dcontext_t *dcontext, coarse_info_t *info)
     }
 coarse_unit_outgoing_linked_done:
     coarse_stubs_iterator_stop(&csi);
-    mutex_unlock(&info->lock);
+    d_r_mutex_unlock(&info->lock);
     return linked;
 }
 #endif
@@ -3704,7 +3704,7 @@ coarse_update_outgoing(dcontext_t *dcontext, cache_pc old_stub, cache_pc new_stu
                 replace ? "updating" : "adding", old_stub, new_stub, target_info->module,
                 target_tag);
             if (replace) {
-                mutex_lock(&target_info->incoming_lock);
+                d_r_mutex_lock(&target_info->incoming_lock);
                 for (e = target_info->incoming; e != NULL; e = e->next) {
                     if (e->coarse && e->in.stub_pc == old_stub) {
                         e->in.stub_pc = new_stub;
@@ -3716,7 +3716,7 @@ coarse_update_outgoing(dcontext_t *dcontext, cache_pc old_stub, cache_pc new_stu
                     LOG(THREAD, LOG_LINKS, 4, "after updating outgoing, target:\n");
                     print_coarse_incoming(dcontext, target_info);
                 });
-                mutex_unlock(&target_info->incoming_lock);
+                d_r_mutex_unlock(&target_info->incoming_lock);
                 ASSERT(found);
             } else {
                 prepend_new_coarse_incoming(target_info, new_stub, NULL);
@@ -3752,7 +3752,7 @@ coarse_unit_shift_links(dcontext_t *dcontext, coarse_info_t *info)
         return;
     LOG(THREAD, LOG_LINKS, 4, "coarse_unit_shift_links %s\n", info->module);
 
-    mutex_lock(&info->incoming_lock);
+    d_r_mutex_lock(&info->incoming_lock);
     DOLOG(5, LOG_LINKS, {
         LOG(THREAD, LOG_LINKS, 4, "about to patch all incoming links:\n");
         print_coarse_incoming(dcontext, info);
@@ -3787,7 +3787,7 @@ coarse_unit_shift_links(dcontext_t *dcontext, coarse_info_t *info)
             }
         }
     }
-    mutex_unlock(&info->incoming_lock);
+    d_r_mutex_unlock(&info->incoming_lock);
 }
 
 /* Updates the info pointers embedded in the coarse_stub_areas vector */

--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2009 Derek Bruening   All rights reserved.
  * *******************************************************************************/
@@ -209,7 +209,7 @@ loader_thread_exit(dcontext_t *dcontext)
          * we're not worried about leaks from not calling DLL_THREAD_EXIT.
          * (We can't check get_thread_private_dcontext() b/c it's already cleared.)
          */
-        dcontext->owning_thread == get_thread_id()) {
+        dcontext->owning_thread == d_r_get_thread_id()) {
         acquire_recursive_lock(&privload_lock);
         /* Walk forward and call independent libs last */
         for (mod = modlist; mod != NULL; mod = mod->next) {

--- a/core/module_list.c
+++ b/core/module_list.c
@@ -64,7 +64,7 @@ void
 os_get_module_info_lock(void)
 {
     if (loaded_module_areas != NULL)
-        read_lock(&module_data_lock);
+        d_r_read_lock(&module_data_lock);
     /* else we assume past exit: FIXME: best to have exited bool */
 }
 
@@ -73,7 +73,7 @@ os_get_module_info_unlock(void)
 {
     if (loaded_module_areas != NULL) {
         ASSERT_OWN_READ_LOCK(true, &module_data_lock);
-        read_unlock(&module_data_lock);
+        d_r_read_unlock(&module_data_lock);
     }
 }
 
@@ -81,7 +81,7 @@ void
 os_get_module_info_write_lock(void)
 {
     if (loaded_module_areas != NULL)
-        write_lock(&module_data_lock);
+        d_r_write_lock(&module_data_lock);
     /* else we assume past exit: FIXME: best to have exited bool */
 }
 
@@ -89,7 +89,7 @@ void
 os_get_module_info_write_unlock(void)
 {
     if (loaded_module_areas != NULL)
-        write_unlock(&module_data_lock);
+        d_r_write_unlock(&module_data_lock);
     /* else we assume past exit: FIXME: best to have exited bool */
 }
 

--- a/core/moduledb.c
+++ b/core/moduledb.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -88,13 +88,13 @@ moduledb_update_exempt_list(char **list, const char *name, bool add)
 {
     LOG(GLOBAL, LOG_MODULEDB, 2, "\tlist before update \"%s\"\n",
         (*list == NULL) ? "" : *list);
-    write_lock(&moduledb_lock);
+    d_r_write_lock(&moduledb_lock);
     if (add && (*list == NULL || !check_filter(*list, name))) {
         *list = moduledb_add_to_exempt_list(*list, name);
     } else if (!add && *list != NULL && check_filter(*list, name)) {
         *list = moduledb_remove_from_exempt_list(*list, name);
     }
-    write_unlock(&moduledb_lock);
+    d_r_write_unlock(&moduledb_lock);
     LOG(GLOBAL, LOG_MODULEDB, 2, "\tlist after update \"%s\"\n",
         (*list == NULL) ? "" : *list);
 }
@@ -294,7 +294,7 @@ moduledb_check_exempt_list(moduledb_exempt_list_t list, const char *name)
 {
     bool found = false;
     ASSERT(exemption_lists != NULL);
-    read_lock(&moduledb_lock);
+    d_r_read_lock(&moduledb_lock);
     if (GET_EXEMPT_LIST(list) != NULL) {
         LOG(GLOBAL, LOG_MODULEDB, 2,
             "Moduledb checking %s exempt list =\"%s\" for module \"%s\"\n",
@@ -302,7 +302,7 @@ moduledb_check_exempt_list(moduledb_exempt_list_t list, const char *name)
             GET_EXEMPT_LIST(list) == NULL ? "" : GET_EXEMPT_LIST(list), name);
         found = check_filter(GET_EXEMPT_LIST(list), name);
     }
-    read_unlock(&moduledb_lock);
+    d_r_read_unlock(&moduledb_lock);
     return found;
 }
 
@@ -311,13 +311,13 @@ print_moduledb_exempt_lists(file_t file)
 {
     int i;
     ASSERT(exemption_lists != NULL);
-    read_lock(&moduledb_lock);
+    d_r_read_lock(&moduledb_lock);
     for (i = 0; i < MODULEDB_EXEMPT_NUM_LISTS; i++) {
         ASSERT(exempt_list_names[i] != NULL);
         print_file(file, "moduledb %s exemption list =\"%s\"\n", exempt_list_names[i],
                    GET_EXEMPT_LIST(i) == NULL ? "" : GET_EXEMPT_LIST(i));
     }
-    read_unlock(&moduledb_lock);
+    d_r_read_unlock(&moduledb_lock);
 }
 
 #ifdef PROCESS_CONTROL

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -644,9 +644,9 @@ unlink_ibt_trace_head(dcontext_t *dcontext, fragment_t *f)
          * remove completely here */
         fragment_remove_from_ibt_tables(dcontext, f, false /*leave in shared ibt*/);
         /* Remove the fragment from other thread's tables. */
-        mutex_lock(&thread_initexit_lock);
+        d_r_mutex_lock(&thread_initexit_lock);
         get_list_of_threads(&threads, &num_threads);
-        mutex_unlock(&thread_initexit_lock);
+        d_r_mutex_unlock(&thread_initexit_lock);
         for (i = 0; i < num_threads; i++) {
             dcontext_t *tgt_dcontext = threads[i]->dcontext;
             LOG(THREAD, LOG_FRAGMENT, 2, "  considering thread %d/%d = " TIDFMT "\n",
@@ -1367,13 +1367,13 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
      */
     if (TEST(FRAG_SHARED, md->trace_flags)) {
         ASSERT(DYNAMO_OPTION(shared_traces));
-        mutex_lock(&trace_building_lock);
+        d_r_mutex_lock(&trace_building_lock);
         /* we left the bb there, so we rely on any shared trace shadowing it */
         trace_f = fragment_lookup_trace(dcontext, tag);
         if (trace_f != NULL) {
             /* someone beat us to it!  tough luck -- throw it all away */
             ASSERT(TEST(FRAG_IS_TRACE, trace_f->flags));
-            mutex_unlock(&trace_building_lock);
+            d_r_mutex_unlock(&trace_building_lock);
             trace_abort(dcontext);
             STATS_INC(num_aborted_traces_race);
 #ifdef DEBUG
@@ -1517,7 +1517,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
         trace_tr->bbs[i] = md->blk_info[i].info;
 
     if (TEST(FRAG_SHARED, md->trace_flags))
-        mutex_unlock(&trace_building_lock);
+        d_r_mutex_unlock(&trace_building_lock);
 
     RSTATS_INC(num_traces);
     DOSTATS(
@@ -1973,7 +1973,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
                  */
                 fragment_t *head = NULL;
                 if (USE_BB_BUILDING_LOCK())
-                    mutex_lock(&bb_building_lock);
+                    d_r_mutex_lock(&bb_building_lock);
                 if (DYNAMO_OPTION(coarse_units)) {
                     /* the existing lookup routines will shadow a coarse bb so we do
                      * a custom lookup
@@ -2016,7 +2016,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
                     }
                 }
                 if (USE_BB_BUILDING_LOCK())
-                    mutex_unlock(&bb_building_lock);
+                    d_r_mutex_unlock(&bb_building_lock);
                 /* use the bb from here on out */
                 f = head;
             }

--- a/core/nudge.c
+++ b/core/nudge.c
@@ -209,10 +209,10 @@ generic_nudge_handler(nudge_arg_t *arg_dont_use)
         swap_peb_pointer(dcontext, true /*to priv*/);
 #    endif
 
-    /* To be extra safe we use safe_read() to access the nudge argument, though once
+    /* To be extra safe we use d_r_safe_read() to access the nudge argument, though once
      * we get past the checks below we are trusting its content. */
     ASSERT(arg_dont_use != NULL && "invalid nudge argument");
-    if (!safe_read(arg_dont_use, sizeof(nudge_arg_t), &safe_arg)) {
+    if (!d_r_safe_read(arg_dont_use, sizeof(nudge_arg_t), &safe_arg)) {
         ASSERT(false && "invalid nudge argument");
         goto nudge_finished;
     }
@@ -418,7 +418,7 @@ handle_nudge(dcontext_t *dcontext, nudge_arg_t *arg)
     if (TEST(NUDGE_GENERIC(reset), nudge_action_mask)) {
         nudge_action_mask &= ~NUDGE_GENERIC(reset);
         if (DYNAMO_OPTION(enable_reset)) {
-            mutex_lock(&reset_pending_lock);
+            d_r_mutex_lock(&reset_pending_lock);
             /* fcache_reset_all_caches_proactively() will unlock */
             fcache_reset_all_caches_proactively(RESET_ALL);
             /* NOTE - reset is safe since we won't return to the code cache below (we

--- a/core/options.h
+++ b/core/options.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -293,7 +293,7 @@ bool
 has_pcache_dynamo_options(options_t *options, op_pcache_t pcache_effect);
 
 char *
-parse_word(const char *str, const char **strpos, char *wordbuf, uint wordbuflen);
+d_r_parse_word(const char *str, const char **strpos, char *wordbuf, uint wordbuflen);
 
 void
 options_enable_code_api_dependences(options_t *options);
@@ -402,12 +402,12 @@ extern read_write_lock_t options_lock;
 static inline void
 string_option_read_lock()
 {
-    read_lock(&options_lock);
+    d_r_read_lock(&options_lock);
 }
 static inline void
 string_option_read_unlock()
 {
-    read_unlock(&options_lock);
+    d_r_read_unlock(&options_lock);
 }
 
 typedef enum {

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -180,7 +180,7 @@ bool
 os_heap_get_commit_limit(size_t *commit_used, size_t *commit_limit);
 
 thread_id_t
-get_thread_id(void);
+d_r_get_thread_id(void);
 process_id_t
 get_process_id(void);
 void
@@ -633,7 +633,7 @@ get_stack_bounds(dcontext_t *dcontext, byte **base, byte **top);
  */
 #define SAFE_READ_VAL(dst_var, src_ptr)           \
     (ASSERT(sizeof(dst_var) == sizeof(*src_ptr)), \
-     safe_read(src_ptr, sizeof(dst_var), &dst_var))
+     d_r_safe_read(src_ptr, sizeof(dst_var), &dst_var))
 
 bool
 is_readable_without_exception(const byte *pc, size_t size);
@@ -642,7 +642,7 @@ is_readable_without_exception_query_os(byte *pc, size_t size);
 bool
 is_readable_without_exception_query_os_noblock(byte *pc, size_t size);
 bool
-safe_read(const void *base, size_t size, void *out_buf);
+d_r_safe_read(const void *base, size_t size, void *out_buf);
 bool
 safe_read_ex(const void *base, size_t size, void *out_buf, size_t *bytes_read);
 bool

--- a/core/perscache.c
+++ b/core/perscache.c
@@ -269,7 +269,7 @@ coarse_unit_reset_free_internal(dcontext_t *dcontext, coarse_info_t *info,
         if (unlink)
             acquire_recursive_lock(&change_linking_lock);
         if (need_info_lock)
-            mutex_lock(&info->lock);
+            d_r_mutex_lock(&info->lock);
     }
     ASSERT(!unlink || self_owns_recursive_lock(&change_linking_lock));
     ASSERT_OWN_MUTEX(need_info_lock, &info->lock);
@@ -361,7 +361,7 @@ coarse_unit_reset_free_internal(dcontext_t *dcontext, coarse_info_t *info,
     memset(info, 0, offsetof(coarse_info_t, lock));
     if (!have_locks) {
         if (need_info_lock)
-            mutex_unlock(&info->lock);
+            d_r_mutex_unlock(&info->lock);
         if (unlink)
             release_recursive_lock(&change_linking_lock);
     }
@@ -616,11 +616,11 @@ coarse_replace_unit(dcontext_t *dcontext, coarse_info_t *dst, coarse_info_t *src
     mutex_t temp_lock, temp_incoming_lock;
     DEBUG_DECLARE(const char *modname;)
     ASSERT_OWN_MUTEX(true, &dst->lock);
-    mutex_lock(&dst->incoming_lock);
+    d_r_mutex_lock(&dst->incoming_lock);
     ASSERT(src->incoming == NULL); /* else we leak */
     src->incoming = dst->incoming;
     dst->incoming = NULL; /* do not free incoming */
-    mutex_unlock(&dst->incoming_lock);
+    d_r_mutex_unlock(&dst->incoming_lock);
     non_frozen = dst->non_frozen;
     coarse_unit_reset_free(dcontext, dst, true /*have locks*/, false /*do not unlink*/,
                            false /*keep primary*/);
@@ -695,7 +695,7 @@ coarse_unit_freeze(dcontext_t *dcontext, coarse_info_t *info, bool in_place)
      */
     fragment_coarse_create_entry_pclookup_table(dcontext, info);
 
-    mutex_lock(&info->lock);
+    d_r_mutex_lock(&info->lock);
     ASSERT(info->cache != NULL); /* don't freeze empty units */
     ASSERT(!info->frozen);       /* don't freeze already frozen units */
     if (info->cache == NULL || info->frozen)
@@ -834,7 +834,7 @@ coarse_unit_freeze_exit:
     HEAP_TYPE_FREE(dcontext, freeze_info, coarse_freeze_info_t,
                    ACCT_MEM_MGT /*appropriate?*/, PROTECTED);
 
-    mutex_unlock(&info->lock);
+    d_r_mutex_unlock(&info->lock);
 
     /* be sure to free to avoid missing entries if we add to info later */
     fragment_coarse_free_entry_pclookup_table(dcontext, info);
@@ -1853,13 +1853,13 @@ coarse_unit_merge(dcontext_t *dcontext, coarse_info_t *info1, coarse_info_t *inf
 #ifdef HOT_PATCHING_INTERFACE
     /* we may call coarse_unit_calculate_persist_info() */
     if (DYNAMO_OPTION(hot_patching))
-        read_lock(hotp_get_lock());
+        d_r_read_lock(hotp_get_lock());
 #endif
     /* We can't grab both locks due to deadlock potential.  Currently we are
      * always fully synched, so we rely on that to synch with info2.
      */
     ASSERT(dynamo_all_threads_synched);
-    mutex_lock(&info1->lock);
+    d_r_mutex_lock(&info1->lock);
     ASSERT(info1->cache != NULL && info2->cache != NULL); /* don't merge empty units */
     ASSERT(info1->frozen && info2->frozen);
 
@@ -2061,7 +2061,7 @@ coarse_unit_merge(dcontext_t *dcontext, coarse_info_t *info1, coarse_info_t *inf
         /* case 10877: must combine the incoming lists
          * targets should be unique, so can just append
          */
-        mutex_lock(&info1->incoming_lock);
+        d_r_mutex_lock(&info1->incoming_lock);
         /* can't grab info2 lock, so just like for main lock we rely on synchall */
         DODEBUG({
             /* Make sure no inter-incoming left */
@@ -2081,7 +2081,7 @@ coarse_unit_merge(dcontext_t *dcontext, coarse_info_t *info1, coarse_info_t *inf
                 e = e->next;
             e->next = info2->incoming;
         }
-        mutex_unlock(&info1->incoming_lock);
+        d_r_mutex_unlock(&info1->incoming_lock);
         info2->incoming = NULL; /* ensure not freed when info2 is freed */
         coarse_unit_shift_links(dcontext, info1);
 
@@ -2090,11 +2090,11 @@ coarse_unit_merge(dcontext_t *dcontext, coarse_info_t *info1, coarse_info_t *inf
         /* we made separate copy that has no outgoing or incoming links */
         res = merged;
     }
-    mutex_unlock(&info1->lock);
+    d_r_mutex_unlock(&info1->lock);
 #ifdef HOT_PATCHING_INTERFACE
     /* we may call coarse_unit_calculate_persist_info() */
     if (DYNAMO_OPTION(hot_patching))
-        read_unlock(hotp_get_lock());
+        d_r_read_unlock(hotp_get_lock());
 #endif
     release_recursive_lock(&change_linking_lock);
     return res;
@@ -3327,7 +3327,7 @@ coarse_unit_persist(dcontext_t *dcontext, coarse_info_t *info)
      * Note the prescribed order of unmap and then flush in case 9696.
      */
 
-    mutex_lock(&info->lock);
+    d_r_mutex_lock(&info->lock);
     /* Get info that is not needed for online coarse units but is needed at persist
      * time (RCT, RAC, and hotp info) now, so we can merge it more easily.
      */
@@ -3338,7 +3338,7 @@ coarse_unit_persist(dcontext_t *dcontext, coarse_info_t *info)
      * release since coarse_unit_merge() will acquire.  Should we not grab any
      * info lock?  We're already relying on dynamo_all_threads_synched.
      */
-    mutex_unlock(&info->lock);
+    d_r_mutex_unlock(&info->lock);
 
     /* Attempt to merge with any new on-disk file */
     if (DYNAMO_OPTION(coarse_lone_merge) || DYNAMO_OPTION(coarse_disk_merge)) {
@@ -3350,7 +3350,7 @@ coarse_unit_persist(dcontext_t *dcontext, coarse_info_t *info)
         }
     }
 
-    mutex_lock(&info->lock);
+    d_r_mutex_lock(&info->lock);
 
     /* Fill in the rest of pers */
     coarse_unit_set_persist_data(dcontext, info, &pers, modbase, option_level,
@@ -3548,7 +3548,7 @@ coarse_unit_persist_exit:
         }
     }
     if (created_temp)
-        mutex_unlock(&info->lock);
+        d_r_mutex_unlock(&info->lock);
     if (free_info) {
         /* if we dup-ed when merging with disk, free now */
         coarse_unit_reset_free(dcontext, info, false /*no locks*/, false /*no unlink*/,
@@ -3645,7 +3645,7 @@ pcache_dir_check_permissions(dcontext_t *dcontext, const char *filename)
     /* `dirname filename` */
     const char *file_parent = double_strrchr(filename, DIRSEP, ALT_DIRSEP);
     size_t per_user_len;
-    mutex_lock(&pcache_dir_check_lock);
+    d_r_mutex_lock(&pcache_dir_check_lock);
     if (DYNAMO_OPTION(persist_per_app)) {
         /* back up one level higher */
         /* note that we only need to check whether the per-user directory
@@ -3668,7 +3668,7 @@ pcache_dir_check_permissions(dcontext_t *dcontext, const char *filename)
         pcache_dir_check_temp);
     ASSERT(!os_rename_file(pcache_dir_check_root, pcache_dir_check_temp, false) &&
            "directory can be bumped!");
-    mutex_unlock(&pcache_dir_check_lock);
+    d_r_mutex_unlock(&pcache_dir_check_lock);
 }
 #endif
 

--- a/core/rct.c
+++ b/core/rct.c
@@ -388,12 +388,12 @@ rct_ind_branch_check(dcontext_t *dcontext, app_pc target_addr, app_pc src_addr)
         /* Grab the rct_module_lock to ensure no duplicates if two threads
          * attempt to add the same module
          */
-        mutex_lock(&rct_module_lock);
+        d_r_mutex_lock(&rct_module_lock);
         /* NOTE - under current default options (analyze_at_load) this routine will have
          * no effect and is only being used for its is_in_code_section (&IMAGE) return
          * value.  For x64 it is used to scan on violation (PR 277044/277064). */
         is_code_section = rct_analyze_module_at_violation(dcontext, target_addr);
-        mutex_unlock(&rct_module_lock);
+        d_r_mutex_unlock(&rct_module_lock);
 
         /* In fact, we have to let all regions that are not modules - so
          * .A and .B attacks will still be marked as such instead of failing here.
@@ -519,9 +519,9 @@ rct_ind_branch_check(dcontext_t *dcontext, app_pc target_addr, app_pc src_addr)
          * threads do not fail.
          */
         if (DYNAMO_OPTION(rct_cache_exempt) != RCT_CACHE_EXEMPT_NONE) {
-            mutex_lock(&rct_module_lock);
+            d_r_mutex_lock(&rct_module_lock);
             rct_add_valid_ind_branch_target(dcontext, target_addr);
-            mutex_unlock(&rct_module_lock);
+            d_r_mutex_unlock(&rct_module_lock);
         }
         return res;
     }
@@ -548,7 +548,7 @@ rct_known_targets_init(void)
     /* Allow targeting dynamorio!generic_nudge_target and
      * dynamorio!safe_apc_or_thread_target (case 7266)
      */
-    mutex_lock(&rct_module_lock);
+    d_r_mutex_lock(&rct_module_lock);
 
     ASSERT(is_in_dynamo_dll((app_pc)generic_nudge_target));
     rct_add_valid_ind_branch_target(GLOBAL_DCONTEXT, (app_pc)generic_nudge_target);
@@ -556,7 +556,7 @@ rct_known_targets_init(void)
     ASSERT(is_in_dynamo_dll((app_pc)safe_apc_or_thread_target));
     rct_add_valid_ind_branch_target(GLOBAL_DCONTEXT, (app_pc)safe_apc_or_thread_target);
 
-    mutex_unlock(&rct_module_lock);
+    d_r_mutex_unlock(&rct_module_lock);
 }
 #    endif
 

--- a/core/stats.c
+++ b/core/stats.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -212,10 +212,10 @@ kstat_exit()
         return;
 
     /* report merged process statistics */
-    mutex_lock(&process_kstats_lock);
+    d_r_mutex_lock(&process_kstats_lock);
     print_file(process_kstats_outfile, "Process KSTATS:\n");
     kstat_report(process_kstats_outfile, &process_kstats);
-    mutex_unlock(&process_kstats_lock);
+    d_r_mutex_unlock(&process_kstats_lock);
 
     DELETE_LOCK(process_kstats_lock);
 
@@ -264,7 +264,7 @@ kstat_thread_init(dcontext_t *dcontext)
     /* add a dummy node to save one branch in UPDATE_CURRENT_COUNTER */
     new_thread_kstats->stack_kstats.depth = 1;
 
-    new_thread_kstats->thread_id = get_thread_id();
+    new_thread_kstats->thread_id = d_r_get_thread_id();
 #    ifdef DEBUG
     new_thread_kstats->outfile_kstats = THREAD;
 #    else
@@ -361,9 +361,9 @@ kstat_thread_exit(dcontext_t *dcontext)
     dump_thread_kstats(dcontext);
 
     /* a good time to combine all of these with the global statistics */
-    mutex_lock(&process_kstats_lock);
+    d_r_mutex_lock(&process_kstats_lock);
     kstat_merge(&process_kstats, &old_thread_kstats->vars_kstats);
-    mutex_unlock(&process_kstats_lock);
+    d_r_mutex_unlock(&process_kstats_lock);
 
 #    ifdef DEBUG
     /* for non-debug we do fast exit path and don't free local heap */

--- a/core/string.c
+++ b/core/string.c
@@ -306,7 +306,7 @@ unsigned long
 d_r_strtoul(const char *str, char **end, int base)
 {
     uint64 num;
-    const char *parse_end = parse_int(str, &num, base, 0 /*width*/, true /*signed*/);
+    const char *parse_end = d_r_parse_int(str, &num, base, 0 /*width*/, true /*signed*/);
     if (end != NULL)
         *end = (char *)parse_end;
     if (parse_end == NULL)

--- a/core/unit-rct.c
+++ b/core/unit-rct.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -154,7 +154,7 @@ test_small_array(dcontext_t *dcontext)
     arr[4 + 2] = 2;
     arr[4 + 3] = 1;
 
-    mutex_lock(&rct_module_lock); /* around whole sequence */
+    d_r_mutex_lock(&rct_module_lock); /* around whole sequence */
 
     EXPECT(find_address_references(dcontext, (app_pc)arr, (app_pc)(arr + 8),
                                    (app_pc)0x01020304, (app_pc)0x01020304),
@@ -255,7 +255,7 @@ test_small_array(dcontext_t *dcontext)
 
     EXPECT(invalidate_ind_branch_target_range(dcontext, 0, (app_pc)-1), 0);
 
-    mutex_unlock(&rct_module_lock);
+    d_r_mutex_unlock(&rct_module_lock);
 
     return 1;
 }
@@ -268,10 +268,10 @@ test_lookup_delete(dcontext_t *dcontext)
     fragment_t *f = rct_ind_branch_target_lookup(dcontext, tag);
     EXPECT_RELATION((ptr_uint_t)f, ==, 0);
 
-    mutex_lock(&rct_module_lock);
+    d_r_mutex_lock(&rct_module_lock);
     EXPECT(rct_add_valid_ind_branch_target(dcontext, tag), true);
     EXPECT(rct_add_valid_ind_branch_target(dcontext, tag), false);
-    mutex_unlock(&rct_module_lock);
+    d_r_mutex_unlock(&rct_module_lock);
 
     f = rct_ind_branch_target_lookup(dcontext, tag);
     EXPECT_RELATION((ptr_uint_t)f, !=, 0);
@@ -301,10 +301,10 @@ test_self_direct(dcontext_t *dcontext)
     get_memory_info((app_pc)test_self_direct, &base_pc, &size, NULL);
 #endif
 
-    mutex_lock(&rct_module_lock);
+    d_r_mutex_lock(&rct_module_lock);
     found = find_address_references(dcontext, base_pc, base_pc + size, base_pc,
                                     base_pc + size);
-    mutex_unlock(&rct_module_lock);
+    d_r_mutex_unlock(&rct_module_lock);
 
     /* guesstimate */
     EXPECT_RELATION(found, >, 140);
@@ -326,15 +326,15 @@ test_self_direct(dcontext_t *dcontext)
     EXPECT(is_address_taken(dcontext, (app_pc)f2 + 1), false);
     EXPECT(is_address_taken(dcontext, (app_pc)f7 + 1), false);
 
-    mutex_lock(&rct_module_lock);
+    d_r_mutex_lock(&rct_module_lock);
     EXPECT(invalidate_ind_branch_target_range(dcontext, 0, (app_pc)-1), found);
     EXPECT_RELATION(invalidate_ind_branch_target_range(dcontext, 0, (app_pc)-1), ==,
                     0); /* nothing missed */
-    mutex_unlock(&rct_module_lock);
+    d_r_mutex_unlock(&rct_module_lock);
 
     /* now try manually rct_analyze_module_at_violation */
 
-    mutex_lock(&rct_module_lock);
+    d_r_mutex_lock(&rct_module_lock);
     EXPECT(rct_analyze_module_at_violation(dcontext, (app_pc)test_self_direct), true);
 
     /* should be all found */
@@ -349,7 +349,7 @@ test_self_direct(dcontext_t *dcontext)
 
     EXPECT_RELATION(invalidate_ind_branch_target_range(dcontext, 0, (app_pc)-1), ==,
                     0); /* nothing missed */
-    mutex_unlock(&rct_module_lock);
+    d_r_mutex_unlock(&rct_module_lock);
 }
 
 static void
@@ -380,9 +380,9 @@ test_rct_ind_branch_check(void)
     EXPECT(rct_ind_branch_check(dcontext, (app_pc)0xbad), 2);
 
     /* starting over */
-    mutex_lock(&rct_module_lock);
+    d_r_mutex_lock(&rct_module_lock);
     invalidate_ind_branch_target_range(dcontext, 0, (app_pc)-1);
-    mutex_unlock(&rct_module_lock);
+    d_r_mutex_unlock(&rct_module_lock);
 
     EXPECT(rct_ind_branch_check(dcontext, (app_pc)f3), 1);
     EXPECT(rct_ind_branch_check(dcontext, (app_pc)f2), 1);
@@ -396,9 +396,9 @@ test_rct_ind_branch_check(void)
     EXPECT(rct_ind_branch_check(dcontext, (app_pc)f2 + 1), -1);
     EXPECT(rct_ind_branch_check(dcontext, (app_pc)f7 + 1), -1);
 
-    mutex_lock(&rct_module_lock);
+    d_r_mutex_lock(&rct_module_lock);
     found = invalidate_ind_branch_target_range(dcontext, 0, (app_pc)-1);
-    mutex_unlock(&rct_module_lock);
+    d_r_mutex_unlock(&rct_module_lock);
 
     EXPECT_RELATION(found, >, 140);
 }

--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -171,7 +171,7 @@ get_application_short_name(void)
     return "";
 }
 
-/* Shadow DR's internal_error so assertions work in standalone mode.  DR tries
+/* Shadow DR's d_r_internal_error so assertions work in standalone mode.  DR tries
  * to use safe_read to take a stack trace, but none of its signal handlers are
  * installed, so it will segfault before it prints our error.
  */

--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -176,7 +176,7 @@ get_application_short_name(void)
  * installed, so it will segfault before it prints our error.
  */
 void
-internal_error(const char *file, int line, const char *expr)
+d_r_internal_error(const char *file, int line, const char *expr)
 {
     fprintf(stderr, "ASSERT failed: %s:%d (%s)\n", file, line, expr);
     fflush(stderr);

--- a/core/unix/loader_android.c
+++ b/core/unix/loader_android.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -194,7 +194,7 @@ privload_tls_init(void *app_tls)
             thrd = (android_v5_pthread_internal_t *)res;
             thrd->tls[ANDROID_TLS_SLOT_SELF] = thrd->tls;
             thrd->tls[ANDROID_TLS_SLOT_THREAD_ID] = thrd;
-            thrd->tid = get_thread_id();
+            thrd->tid = d_r_get_thread_id();
             thrd->dr_tls_base = NULL;
             res = thrd->tls[ANDROID_TLS_SLOT_SELF];
             LOG(GLOBAL, LOG_LOADER, 2, "%s: TLS set to " PFX "\n", __FUNCTION__,
@@ -204,7 +204,7 @@ privload_tls_init(void *app_tls)
             thrd = (android_v6_pthread_internal_t *)res;
             thrd->tls[ANDROID_TLS_SLOT_SELF] = thrd->tls;
             thrd->tls[ANDROID_TLS_SLOT_THREAD_ID] = thrd;
-            thrd->tid = get_thread_id();
+            thrd->tid = d_r_get_thread_id();
             thrd->dr_tls_base = NULL;
             res = thrd->tls[ANDROID_TLS_SLOT_SELF];
             LOG(GLOBAL, LOG_LOADER, 2, "%s: TLS set to " PFX "\n", __FUNCTION__,

--- a/core/unix/memcache.c
+++ b/core/unix/memcache.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -138,7 +138,7 @@ memcache_lock(void)
          */
         ASSERT_CURIOSITY(all_memory_areas_recursion <= 4);
     } else
-        write_lock(&all_memory_areas->lock);
+        d_r_write_lock(&all_memory_areas->lock);
 }
 
 void
@@ -154,7 +154,7 @@ memcache_unlock(void)
         ASSERT_OWN_WRITE_LOCK(true, &all_memory_areas->lock);
         all_memory_areas_recursion--;
     } else
-        write_unlock(&all_memory_areas->lock);
+        d_r_write_unlock(&all_memory_areas->lock);
 }
 
 /* vmvector callbacks */

--- a/core/unix/memquery_linux.c
+++ b/core/unix/memquery_linux.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -131,9 +131,9 @@ memquery_from_os_will_block(void)
 #else
     /* "may_alloc" is false for memquery_from_os() */
     bool res = true;
-    if (mutex_trylock(&memory_info_buf_lock)) {
+    if (d_r_mutex_trylock(&memory_info_buf_lock)) {
         res = false;
-        mutex_unlock(&memory_info_buf_lock);
+        d_r_mutex_unlock(&memory_info_buf_lock);
     }
     return res;
 #endif
@@ -148,11 +148,11 @@ memquery_iterator_start(memquery_iter_t *iter, app_pc start, bool may_alloc)
     /* Don't assign the local ptrs until the lock is grabbed to make
      * their relationship clear. */
     if (may_alloc) {
-        mutex_lock(&maps_iter_buf_lock);
+        d_r_mutex_lock(&maps_iter_buf_lock);
         mi->buf = (char *)&buf_iter;
         mi->comment_buffer = (char *)&comment_buf_iter;
     } else {
-        mutex_lock(&memory_info_buf_lock);
+        d_r_mutex_lock(&memory_info_buf_lock);
         mi->buf = (char *)&buf_scratch;
         mi->comment_buffer = (char *)&comment_buf_scratch;
     }
@@ -162,7 +162,7 @@ memquery_iterator_start(memquery_iter_t *iter, app_pc start, bool may_alloc)
      * has exited.
      */
     snprintf(maps_name, BUFFER_SIZE_ELEMENTS(maps_name), "/proc/%d/maps",
-             get_thread_id());
+             d_r_get_thread_id());
     mi->maps = os_open(maps_name, OS_OPEN_READ);
     ASSERT(mi->maps != INVALID_FILE);
     mi->buf[BUFSIZE - 1] = '\0'; /* permanently */
@@ -191,9 +191,9 @@ memquery_iterator_stop(memquery_iter_t *iter)
            (!iter->may_alloc && OWN_MUTEX(&memory_info_buf_lock)));
     os_close(mi->maps);
     if (iter->may_alloc)
-        mutex_unlock(&maps_iter_buf_lock);
+        d_r_mutex_unlock(&maps_iter_buf_lock);
     else
-        mutex_unlock(&memory_info_buf_lock);
+        d_r_mutex_unlock(&memory_info_buf_lock);
 }
 
 bool

--- a/core/unix/memquery_macos.c
+++ b/core/unix/memquery_macos.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -101,9 +101,9 @@ memquery_from_os_will_block(void)
 #else
     /* "may_alloc" is false for memquery_from_os() */
     bool res = true;
-    if (mutex_trylock(&memquery_backing_lock)) {
+    if (d_r_mutex_trylock(&memquery_backing_lock)) {
         res = false;
-        mutex_unlock(&memquery_backing_lock);
+        d_r_mutex_unlock(&memquery_backing_lock);
     }
     return res;
 #endif
@@ -148,7 +148,7 @@ memquery_iterator_start(memquery_iter_t *iter, app_pc start, bool may_alloc)
         ii->backing = HEAP_TYPE_ALLOC(ii->dcontext, struct proc_regionwithpathinfo,
                                       ACCT_MEM_MGT, PROTECTED);
     } else {
-        mutex_lock(&memquery_backing_lock);
+        d_r_mutex_lock(&memquery_backing_lock);
         ii->backing = &backing_info;
         ii->dcontext = NULL;
     }
@@ -163,7 +163,7 @@ memquery_iterator_stop(memquery_iter_t *iter)
         HEAP_TYPE_FREE(ii->dcontext, ii->backing, struct proc_regionwithpathinfo,
                        ACCT_MEM_MGT, PROTECTED);
     } else
-        mutex_unlock(&memquery_backing_lock);
+        d_r_mutex_unlock(&memquery_backing_lock);
 }
 
 bool

--- a/core/unix/module.c
+++ b/core/unix/module.c
@@ -737,13 +737,13 @@ at_dl_runtime_resolve_ret(dcontext_t *dcontext, app_pc source_fragment, int *ret
     byte buf[MAX(sizeof(DL_RUNTIME_RESOLVE_MAGIC_1),
                  sizeof(DL_RUNTIME_RESOLVE_MAGIC_2))] = { 0 };
 
-    if (safe_read(source_fragment, sizeof(DL_RUNTIME_RESOLVE_MAGIC_1), buf) &&
+    if (d_r_safe_read(source_fragment, sizeof(DL_RUNTIME_RESOLVE_MAGIC_1), buf) &&
         memcmp(buf, DL_RUNTIME_RESOLVE_MAGIC_1, sizeof(DL_RUNTIME_RESOLVE_MAGIC_1)) ==
             0) {
         *ret_imm = 0x8;
         return true;
     }
-    if (safe_read(source_fragment, sizeof(DL_RUNTIME_RESOLVE_MAGIC_2), buf) &&
+    if (d_r_safe_read(source_fragment, sizeof(DL_RUNTIME_RESOLVE_MAGIC_2), buf) &&
         memcmp(buf, DL_RUNTIME_RESOLVE_MAGIC_2, sizeof(DL_RUNTIME_RESOLVE_MAGIC_2)) ==
             0) {
         LOG(THREAD, LOG_INTERP, 1,

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -66,7 +66,7 @@ typedef struct _elf_symbol_iterator_t {
     dr_symbol_export_t symbol_export; /* symbol export returned by next() */
 
     ELF_SYM_TYPE *symbol;      /* safe_cur_sym or NULL */
-    ELF_SYM_TYPE safe_cur_sym; /* safe_read() copy of current symbol */
+    ELF_SYM_TYPE safe_cur_sym; /* d_r_safe_read() copy of current symbol */
 
     /* This data is copied from os_module_data_t so we don't have to hold the
      * module area lock while the client iterates.

--- a/core/unix/native_elf.c
+++ b/core/unix/native_elf.c
@@ -774,8 +774,8 @@ native_module_at_runtime_resolve_ret(app_pc xsp, int ret_imm)
 {
     app_pc call_tgt, ret_tgt;
 
-    if (!safe_read(xsp, sizeof(app_pc), &call_tgt) ||
-        !safe_read(xsp + ret_imm + sizeof(XSP_SZ), sizeof(app_pc), &ret_tgt)) {
+    if (!d_r_safe_read(xsp, sizeof(app_pc), &call_tgt) ||
+        !d_r_safe_read(xsp + ret_imm + sizeof(XSP_SZ), sizeof(app_pc), &ret_tgt)) {
         ASSERT(false && "fail to read app stack!\n");
         return;
     }

--- a/core/unix/preload.c
+++ b/core/unix/preload.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -118,7 +118,7 @@ take_over(const char *pname)
         return true;
 
     /* i#85/PR 212034: use config files */
-    config_init();
+    d_r_config_init();
     runstr = get_config_val_ex(DYNAMORIO_VAR_RUNUNDER, &app_specific, &from_env);
     if (!should_inject_from_rununder(runstr, app_specific, from_env, &rununder_on) ||
         !rununder_on)

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -925,7 +925,7 @@ signal_thread_inherit(dcontext_t *dcontext, void *clone_record)
             info->shared_lock = record->info.shared_lock;
             info->app_sigaction = record->info.app_sigaction;
             info->we_intercept = record->info.we_intercept;
-            mutex_lock(info->shared_lock);
+            d_r_mutex_lock(info->shared_lock);
             (*info->shared_refcount)++;
 #ifdef DEBUG
             for (i = 1; i <= MAX_SIGNUM; i++) {
@@ -935,7 +935,7 @@ signal_thread_inherit(dcontext_t *dcontext, void *clone_record)
                 }
             }
 #endif
-            mutex_unlock(info->shared_lock);
+            d_r_mutex_unlock(info->shared_lock);
         } else {
             /* copy handlers */
             LOG(THREAD, LOG_ASYNCH, 2, "inheriting signal handlers from parent\n");
@@ -957,13 +957,13 @@ signal_thread_inherit(dcontext_t *dcontext, void *clone_record)
                 (bool *)handler_alloc(dcontext, SIGARRAY_SIZE * sizeof(bool));
             memcpy(info->we_intercept, record->info.we_intercept,
                    SIGARRAY_SIZE * sizeof(bool));
-            mutex_lock(&record->info.child_lock);
+            d_r_mutex_lock(&record->info.child_lock);
             record->info.num_unstarted_children--;
-            mutex_unlock(&record->info.child_lock);
+            d_r_mutex_unlock(&record->info.child_lock);
             /* this should be safe since parent should wait for us */
-            mutex_lock(&record->parent_info->child_lock);
+            d_r_mutex_lock(&record->parent_info->child_lock);
             record->parent_info->num_unstarted_children--;
-            mutex_unlock(&record->parent_info->child_lock);
+            d_r_mutex_unlock(&record->parent_info->child_lock);
         }
 
         /* itimers are either private or shared */
@@ -1244,9 +1244,9 @@ signal_thread_exit(dcontext_t *dcontext, bool other_thread)
      * can children keep living w/ a copy of the handlers?
      */
     if (info->shared_app_sigaction) {
-        mutex_lock(info->shared_lock);
+        d_r_mutex_lock(info->shared_lock);
         (*info->shared_refcount)--;
-        mutex_unlock(info->shared_lock);
+        d_r_mutex_unlock(info->shared_lock);
     }
     if (!info->shared_app_sigaction || *info->shared_refcount == 0) {
         LOG(THREAD, LOG_ASYNCH, 2, "signal handler cleanup:\n");
@@ -1437,7 +1437,7 @@ set_handler_and_record_app(dcontext_t *dcontext, thread_sig_info_t *info, int si
         /* save the app's action for sig */
         if (info->shared_app_sigaction) {
             /* app_sigaction structure is shared */
-            mutex_lock(info->shared_lock);
+            d_r_mutex_lock(info->shared_lock);
         }
         if (info->app_sigaction[sig] != NULL) {
             /* go ahead and toss the old one, it's up to the app to store
@@ -1451,7 +1451,7 @@ set_handler_and_record_app(dcontext_t *dcontext, thread_sig_info_t *info, int si
         /* clear cache */
         info->restorer_valid[sig] = -1;
         if (info->shared_app_sigaction)
-            mutex_unlock(info->shared_lock);
+            d_r_mutex_unlock(info->shared_lock);
 #ifdef DEBUG
         if (oldact.handler == (handler_t)SIG_IGN) {
             LOG(THREAD, LOG_ASYNCH, 2,
@@ -1468,11 +1468,11 @@ set_handler_and_record_app(dcontext_t *dcontext, thread_sig_info_t *info, int si
             oldact.handler, master_signal_handler, oldact.flags, sig);
         if (info->app_sigaction[sig] != NULL) {
             if (info->shared_app_sigaction)
-                mutex_lock(info->shared_lock);
+                d_r_mutex_lock(info->shared_lock);
             handler_free(dcontext, info->app_sigaction[sig], sizeof(kernel_sigaction_t));
             info->app_sigaction[sig] = NULL;
             if (info->shared_app_sigaction)
-                mutex_unlock(info->shared_lock);
+                d_r_mutex_unlock(info->shared_lock);
         }
     }
     LOG(THREAD, LOG_ASYNCH, 3, "\twe intercept signal %d\n", sig);
@@ -1656,9 +1656,9 @@ handle_clone(dcontext_t *dcontext, uint flags)
         /* child will inherit copy of current table -> cannot modify it
          * until child is scheduled!  FIXME: any other way?
          */
-        mutex_lock(&info->child_lock);
+        d_r_mutex_lock(&info->child_lock);
         info->num_unstarted_children++;
-        mutex_unlock(&info->child_lock);
+        d_r_mutex_unlock(&info->child_lock);
     }
 
     if (TEST(CLONE_THREAD, flags) && os_itimers_thread_shared()) {
@@ -1700,7 +1700,7 @@ handle_sigaction(dcontext_t *dcontext, int sig, const kernel_sigaction_t *act,
     }
     if (act != NULL) {
         /* Linux checks readability before checking the signal number. */
-        if (!safe_read(act, sizeof(local_act), &local_act)) {
+        if (!d_r_safe_read(act, sizeof(local_act), &local_act)) {
             *result = EFAULT;
             return false;
         }
@@ -1722,7 +1722,7 @@ handle_sigaction(dcontext_t *dcontext, int sig, const kernel_sigaction_t *act,
     }
     if (info->shared_app_sigaction) {
         /* app_sigaction structure is shared */
-        mutex_lock(info->shared_lock);
+        d_r_mutex_lock(info->shared_lock);
     }
     if (oact != NULL) {
         /* Keep a copy of the prior one for post-syscall to hand to the app. */
@@ -1750,7 +1750,7 @@ handle_sigaction(dcontext_t *dcontext, int sig, const kernel_sigaction_t *act,
                  * handler.  we delete the stored app_sigaction in post_
                  */
                 if (info->shared_app_sigaction)
-                    mutex_unlock(info->shared_lock);
+                    d_r_mutex_unlock(info->shared_lock);
                 return true;
             }
         } else {
@@ -1783,7 +1783,7 @@ handle_sigaction(dcontext_t *dcontext, int sig, const kernel_sigaction_t *act,
         info->restorer_valid[sig] = -1;
     }
     if (info->shared_app_sigaction)
-        mutex_unlock(info->shared_lock);
+        d_r_mutex_unlock(info->shared_lock);
     if (info->we_intercept[sig]) {
         /* cancel the syscall */
         *result = handle_post_sigaction(dcontext, true, sig, act, oact, sigsetsize);
@@ -1867,12 +1867,12 @@ handle_post_sigaction(dcontext_t *dcontext, bool success, int sig,
          !info->we_intercept[sig]) &&
         info->app_sigaction[sig] != NULL) {
         if (info->shared_app_sigaction)
-            mutex_lock(info->shared_lock);
+            d_r_mutex_lock(info->shared_lock);
         /* remove old stored app action */
         handler_free(dcontext, info->app_sigaction[sig], sizeof(kernel_sigaction_t));
         info->app_sigaction[sig] = NULL;
         if (info->shared_app_sigaction)
-            mutex_unlock(info->shared_lock);
+            d_r_mutex_unlock(info->shared_lock);
     }
     return 0;
 }
@@ -1988,7 +1988,7 @@ handle_sigaltstack(dcontext_t *dcontext, const stack_t *stack, stack_t *old_stac
     }
     if (stack != NULL) {
         /* Fail in the same way the kernel does. */
-        if (!safe_read(stack, sizeof(local_stack), &local_stack)) {
+        if (!d_r_safe_read(stack, sizeof(local_stack), &local_stack)) {
             *result = EFAULT;
             return false;
         }
@@ -2079,7 +2079,7 @@ signal_swap_mask(dcontext_t *dcontext, bool to_app)
         unblock_all_signals(&info->app_sigblocked);
         DOLOG(2, LOG_ASYNCH, {
             LOG(THREAD, LOG_ASYNCH, 2, "thread %d's initial app signal mask:\n",
-                get_thread_id());
+                d_r_get_thread_id());
             dump_sigset(dcontext, &info->app_sigblocked);
         });
     }
@@ -2124,7 +2124,7 @@ handle_sigprocmask(dcontext_t *dcontext, int how, kernel_sigset_t *app_set,
     LOG(THREAD, LOG_ASYNCH, 2, "handle_sigprocmask\n");
     if (oset != NULL)
         info->pre_syscall_app_sigblocked = info->app_sigblocked;
-    if (app_set != NULL && safe_read(app_set, sizeof(safe_set), &safe_set)) {
+    if (app_set != NULL && d_r_safe_read(app_set, sizeof(safe_set), &safe_set)) {
         if (execute_syscall) {
             /* The syscall will execute, so remove from the set passed
              * to it.   We restore post-syscall.
@@ -2552,7 +2552,7 @@ translate_sigcontext(dcontext_t *dcontext, kernel_ucontext_t *uc, bool avoid_fai
      * initexit lock (to keep someone from flushing current fragment), the
      * initexit lock is easier
      */
-    mutex_lock(&thread_initexit_lock);
+    d_r_mutex_lock(&thread_initexit_lock);
     /* PR 214962: we assume we're going to relocate to this stored context,
      * so we restore memory now
      */
@@ -2573,7 +2573,7 @@ translate_sigcontext(dcontext_t *dcontext, kernel_ucontext_t *uc, bool avoid_fai
             }
         }
     }
-    mutex_unlock(&thread_initexit_lock);
+    d_r_mutex_unlock(&thread_initexit_lock);
 
     /* FIXME i#2095: restore the app's segment register value(s). */
 
@@ -2774,7 +2774,7 @@ sig_has_restorer(thread_sig_info_t *info, int sig)
             { 0x68, 0x11, 0x80, 0x52, 0x01, 0x00, 0x00, 0xd4 };
 #    endif
         byte buf[MAX(sizeof(SIGRET_NONRT), sizeof(SIGRET_RT))] = { 0 };
-        if (safe_read(info->app_sigaction[sig]->restorer, sizeof(buf), buf) &&
+        if (d_r_safe_read(info->app_sigaction[sig]->restorer, sizeof(buf), buf) &&
             ((IS_RT_FOR_APP(info, sig) &&
               memcmp(buf, SIGRET_RT, sizeof(SIGRET_RT)) == 0) ||
              (!IS_RT_FOR_APP(info, sig) &&
@@ -3576,7 +3576,7 @@ abort_on_fault(dcontext_t *dcontext, uint dumpcore_flag, app_pc pc, byte *target
     report_dynamorio_problem(
         dcontext, dumpcore_flag | (stack_overflow ? DUMPCORE_STACK_OVERFLOW : 0), pc,
         (app_pc)sc->SC_FP, fmt, prefix, stack_overflow ? STACK_OVERFLOW_NAME : CRASH_NAME,
-        pc, signame, where, pc, get_thread_id(), get_dynamorio_dll_start(),
+        pc, signame, where, pc, d_r_get_thread_id(), get_dynamorio_dll_start(),
 #ifdef X86
         sc->SC_XAX, sc->SC_XBX, sc->SC_XCX, sc->SC_XDX, sc->SC_XSI, sc->SC_XDI,
         sc->SC_XSP, sc->SC_XBP,
@@ -3899,7 +3899,7 @@ find_next_fragment_from_gencode(dcontext_t *dcontext, sigcontext_t *sc)
         /* The extra x86 slot is only there for save. */
         if (in_clean_call_save(dcontext, pc))
             ra_slot -= get_clean_call_temp_stack_size();
-        if (safe_read(ra_slot, sizeof(retaddr), &retaddr))
+        if (d_r_safe_read(ra_slot, sizeof(retaddr), &retaddr))
             f = fragment_pclookup(dcontext, retaddr, &wrapper);
 #else
 #    error Unsupported arch.
@@ -4638,12 +4638,12 @@ check_for_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc,
              * the initexit lock (to keep someone from flushing current
              * fragment), the initexit lock is easier
              */
-            mutex_lock(&thread_initexit_lock);
+            d_r_mutex_lock(&thread_initexit_lock);
             /* cache the fragment since pclookup is expensive for coarse units (i#658) */
             f = fragment_pclookup(dcontext, instr_cache_pc, &wrapper);
             translated_pc = recreate_app_pc(dcontext, instr_cache_pc, f);
             ASSERT(translated_pc != NULL);
-            mutex_unlock(&thread_initexit_lock);
+            d_r_mutex_unlock(&thread_initexit_lock);
         }
 
         next_pc =
@@ -5177,7 +5177,7 @@ master_signal_handler_C(byte *xsp)
         /* pass it to the application (or client) */
         LOG(THREAD, LOG_ALL, 1,
             "** Received SIG%s at cache pc " PFX " in thread " TIDFMT "\n",
-            (sig == SIGSEGV) ? "SEGV" : "BUS", pc, get_thread_id());
+            (sig == SIGSEGV) ? "SEGV" : "BUS", pc, d_r_get_thread_id());
         ASSERT(syscall_signal || safe_is_in_fcache(dcontext, pc, (byte *)sc->SC_XSP));
         /* we do not call trace_abort() here since we may need to
          * translate from a temp private bb (i#376): but all paths
@@ -5697,7 +5697,7 @@ os_terminate_via_signal(dcontext_t *dcontext, terminate_flags_t flags, int sig)
         terminate_via_kill_from_anywhere(dcontext, sig);
     } else {
         /* general clean up is unsafe: just remove .1config file */
-        config_exit();
+        d_r_config_exit();
         dynamorio_syscall(SYS_kill, 2, get_process_id(), sig);
         /* We try both the SYS_kill and the immediate crash since on some platforms
          * the SIGKILL is delayed and on others the *-1 is hanging(?): should investigate
@@ -5765,7 +5765,7 @@ execute_default_action(dcontext_t *dcontext, int sig, sigframe_rt_t *frame,
             LOG(THREAD, LOG_ASYNCH, 1,
                 "WARNING: having to install SIG_DFL for thread " TIDFMT ", but will be "
                 "shared!\n",
-                get_thread_id());
+                d_r_get_thread_id());
         }
         if (default_action[sig] == DEFAULT_TERMINATE ||
             default_action[sig] == DEFAULT_TERMINATE_CORE) {
@@ -5889,7 +5889,7 @@ execute_default_action(dcontext_t *dcontext, int sig, sigframe_rt_t *frame,
                 fragment_t *f;
                 LOG(THREAD, LOG_ALL, 1,
                     "Received SIGSEGV at pc " PFX " in thread " TIDFMT "\n", pc,
-                    get_thread_id());
+                    d_r_get_thread_id());
                 f = fragment_pclookup(dcontext, pc, &wrapper);
                 if (f)
                     disassemble_fragment(dcontext, f, false);
@@ -6884,7 +6884,7 @@ start_itimer(dcontext_t *dcontext)
          */
         int which;
         LOG(THREAD, LOG_ASYNCH, 2, "starting DR itimers from thread " TIDFMT "\n",
-            get_thread_id());
+            d_r_get_thread_id());
         for (which = 0; which < NUM_ITIMERS; which++) {
             if (info->shared_itimer)
                 acquire_recursive_lock(&(*info->itimer)[which].lock);
@@ -6922,7 +6922,7 @@ stop_itimer(dcontext_t *dcontext)
          */
         int which;
         LOG(THREAD, LOG_ASYNCH, 2, "stopping DR itimers from thread " TIDFMT "\n",
-            get_thread_id());
+            d_r_get_thread_id());
         for (which = 0; which < NUM_ITIMERS; which++) {
             if (info->shared_itimer)
                 acquire_recursive_lock(&(*info->itimer)[which].lock);
@@ -6951,7 +6951,7 @@ handle_pre_setitimer(dcontext_t *dcontext, int which, const struct itimerval *ne
     thread_sig_info_t *info = (thread_sig_info_t *)dcontext->signal_field;
     ASSERT(info != NULL && info->itimer != NULL);
     struct itimerval val;
-    if (safe_read(new_timer, sizeof(val), &val)) {
+    if (d_r_safe_read(new_timer, sizeof(val), &val)) {
         if (info->shared_itimer)
             acquire_recursive_lock(&(*info->itimer)[which].lock);
         /* save a copy in case the syscall fails */
@@ -7009,7 +7009,7 @@ handle_post_getitimer(dcontext_t *dcontext, bool success, int which,
         IF_DEBUG(ok =)
         safe_write_ex(&cur_timer->it_interval, sizeof(val), &val, NULL);
         ASSERT(ok);
-        if (safe_read(&cur_timer->it_value, sizeof(val), &val)) {
+        if (d_r_safe_read(&cur_timer->it_value, sizeof(val), &val)) {
             /* subtract the difference between last-asked-for value
              * and current value to reflect elapsed time
              */
@@ -7384,7 +7384,7 @@ handle_nudge_signal(dcontext_t *dcontext, kernel_siginfo_t *siginfo,
      */
     ASSERT(NUDGESIG_SIGNUM == SIGILL); /* else this check makes no sense */
     instr_init(dcontext, &instr);
-    if (safe_read((byte *)sc->SC_XIP, sizeof(buf), buf) &&
+    if (d_r_safe_read((byte *)sc->SC_XIP, sizeof(buf), buf) &&
         (decode(dcontext, (byte *)buf, &instr) == NULL ||
          /* check for ud2 (xref PR 523161) */
          instr_is_undefined(&instr))) {

--- a/core/unix/stackdump.c
+++ b/core/unix/stackdump.c
@@ -185,7 +185,7 @@ d_r_stackdump(void)
 #if VERBOSE
         SYSLOG_INTERNAL_ERROR("about to dump core in process %d parent %d thread " TIDFMT
                               "",
-                              get_process_id(), get_parent_id(), get_thread_id());
+                              get_process_id(), get_parent_id(), d_r_get_thread_id());
 #endif
         /* We used to use abort here, but that had lots of complications with
          * pthreads and libc, so now we just dereference NULL.
@@ -205,7 +205,7 @@ d_r_stackdump(void)
     }
 #if VERBOSE
     SYSLOG_INTERNAL_ERROR("parent %d %d waiting for child %d", get_process_id(),
-                          get_thread_id(), pid);
+                          d_r_get_thread_id(), pid);
 #endif
     /* Parent continues */
     core_pid = pid;

--- a/core/unix/tls_linux_x86.c
+++ b/core/unix/tls_linux_x86.c
@@ -941,6 +941,6 @@ tls_handle_post_arch_prctl(dcontext_t *dcontext, int code, reg_t base)
     LOG(THREAD_GET, LOG_THREADS, 2,
         "thread " TIDFMT " segment change => app lib tls base: " PFX ", "
         "alt tls base: " PFX "\n",
-        get_thread_id(), os_tls->app_lib_tls_base, os_tls->app_alt_tls_base);
+        d_r_get_thread_id(), os_tls->app_lib_tls_base, os_tls->app_alt_tls_base);
 }
 #endif /* X64 */

--- a/core/utils.c
+++ b/core/utils.c
@@ -131,7 +131,7 @@ ignore_assert(const char *assert_stmt, const char *expr)
     return ignore;
 }
 
-/* Hand-made DO_ONCE used in internal_error b/c ifdefs in
+/* Hand-made DO_ONCE used in d_r_internal_error b/c ifdefs in
  * report_dynamorio_problem prevent DO_ONCE itself
  */
 DECLARE_FREQPROT_VAR(static bool do_once_internal_error, false);

--- a/core/utils.c
+++ b/core/utils.c
@@ -138,7 +138,7 @@ DECLARE_FREQPROT_VAR(static bool do_once_internal_error, false);
 
 /* abort on internal dynamo error */
 void
-internal_error(const char *file, int line, const char *expr)
+d_r_internal_error(const char *file, int line, const char *expr)
 {
     /* note that we no longer obfuscate filenames in non-internal builds
      * xref PR 303817 */
@@ -357,7 +357,7 @@ dump_process_locks()
 
     LOG(GLOBAL, LOG_STATS, 2, "Currently live process locks:\n");
     /* global list access needs to be synchronized */
-    mutex_lock(&innermost_lock);
+    d_r_mutex_lock(&innermost_lock);
     cur_lock = &innermost_lock;
     do {
         depth++;
@@ -378,7 +378,7 @@ dump_process_locks()
         ASSERT(cur_lock->prev_process_lock != cur_lock || cur_lock == &innermost_lock);
         ASSERT(cur_lock->next_process_lock != cur_lock || cur_lock == &innermost_lock);
     } while (cur_lock != &innermost_lock);
-    mutex_unlock(&innermost_lock);
+    d_r_mutex_unlock(&innermost_lock);
     LOG(GLOBAL, LOG_STATS, 1,
         "Currently live process locks: %d, acquired %d, contended %d (current only)\n",
         depth, total_acquired, total_contended);
@@ -402,7 +402,7 @@ locks_not_closed()
      * is too much hassle to find a good place to DELETE them -- though we
      * now use a global mutex for DEADLOCK_AVOIDANCE so that's not the case.
      */
-    mutex_lock(&innermost_lock);
+    d_r_mutex_lock(&innermost_lock);
     /* innermost will stay */
     cur_lock = innermost_lock.next_process_lock;
     while (cur_lock != &innermost_lock) {
@@ -424,7 +424,7 @@ locks_not_closed()
         }
         cur_lock = cur_lock->next_process_lock;
     }
-    mutex_unlock(&innermost_lock);
+    d_r_mutex_unlock(&innermost_lock);
     LOG(GLOBAL, LOG_STATS, 3, "locks_not_closed= %d remaining, %d ignored\n", forgotten,
         ignored);
     return forgotten;
@@ -472,12 +472,12 @@ add_process_lock(mutex_t *lock)
     /* add to global locks circular double linked list */
     LOG(THREAD_GET, LOG_THREADS, 5,
         "add_process_lock" DUMP_LOCK_INFO_ARGS(0, lock, lock->prev_process_lock));
-    mutex_lock(&innermost_lock);
+    d_r_mutex_lock(&innermost_lock);
     if (lock->prev_process_lock != NULL) {
         /* race: someone already added (can only happen for read locks) */
         LOG(THREAD_GET, LOG_THREADS, 2, "\talready added\n");
         ASSERT(lock->next_process_lock != NULL);
-        mutex_unlock(&innermost_lock);
+        d_r_mutex_unlock(&innermost_lock);
         return;
     }
     ASSERT(lock->next_process_lock == NULL || lock == &innermost_lock);
@@ -494,7 +494,7 @@ add_process_lock(mutex_t *lock)
     ASSERT(lock->prev_process_lock->next_process_lock == lock);
     ASSERT(lock->prev_process_lock != lock || lock == &innermost_lock);
     ASSERT(lock->next_process_lock != lock || lock == &innermost_lock);
-    mutex_unlock(&innermost_lock);
+    d_r_mutex_unlock(&innermost_lock);
 }
 
 static void
@@ -512,13 +512,13 @@ remove_process_lock(mutex_t *lock)
     ASSERT(lock->prev_process_lock && "if ever acquired should be on the list");
     ASSERT(lock != &innermost_lock && "innermost will be 'leaked'");
     /* remove from global locks list */
-    mutex_lock(&innermost_lock);
+    d_r_mutex_lock(&innermost_lock);
     /* innermost should always have both fields set here */
     lock->next_process_lock->prev_process_lock = lock->prev_process_lock;
     lock->prev_process_lock->next_process_lock = lock->next_process_lock;
     lock->next_process_lock = NULL;
     lock->prev_process_lock = NULL; /* so we catch uses after closing */
-    mutex_unlock(&innermost_lock);
+    d_r_mutex_unlock(&innermost_lock);
 }
 
 #    ifdef MUTEX_CALLSTACK
@@ -528,7 +528,7 @@ mutex_collect_callstack(mutex_t *lock)
 {
     uint max_depth = INTERNAL_OPTION(mutex_callstack);
     uint depth = 0;
-    uint skip = 2; /* ignore calls from deadlock_avoidance() and mutex_lock() */
+    uint skip = 2; /* ignore calls from deadlock_avoidance() and d_r_mutex_lock() */
     /* FIXME: write_lock could ignore one level further */
     byte *fp;
     dcontext_t *dcontext = get_thread_private_dcontext();
@@ -568,13 +568,13 @@ deadlock_avoidance_lock(mutex_t *lock, bool acquired, bool ownable)
         LOG(GLOBAL, LOG_THREADS, 6,
             "acquired lock " PFX " %s rank=%d, %s dcontext, tid:%d, %d time\n", lock,
             lock->name, lock->rank, get_thread_private_dcontext() ? "valid" : "not valid",
-            get_thread_id(), lock->count_times_acquired);
+            d_r_get_thread_id(), lock->count_times_acquired);
         LOG(THREAD_GET, LOG_THREADS, 6, "acquired lock " PFX " %s rank=%d\n", lock,
             lock->name, lock->rank);
         ASSERT(lock->rank > 0 && "initialize with INIT_LOCK_FREE");
         if (ownable) {
             ASSERT(!lock->owner);
-            lock->owner = get_thread_id();
+            lock->owner = d_r_get_thread_id();
             lock->owning_dcontext = get_thread_private_dcontext();
         }
         /* add to global list */
@@ -612,7 +612,8 @@ deadlock_avoidance_lock(mutex_t *lock, bool acquired, bool ownable)
                     SYSLOG_INTERNAL_NO_OPTION_SYNCH(
                         SYSLOG_CRITICAL,
                         "rank order violation %s acquired after %s in tid:%x", lock->name,
-                        dcontext->thread_owned_locks->last_lock->name, get_thread_id());
+                        dcontext->thread_owned_locks->last_lock->name,
+                        d_r_get_thread_id());
                     dump_owned_locks(dcontext);
                 }
                 ASSERT((dcontext->thread_owned_locks->last_lock->rank <
@@ -638,7 +639,8 @@ deadlock_avoidance_lock(mutex_t *lock, bool acquired, bool ownable)
          * calls are made on the non acquired path here */
         ASSERT(lock->rank > 0 && "initialize with INIT_LOCK_FREE");
         if (INTERNAL_OPTION(deadlock_avoidance) && ownable) {
-            ASSERT(lock->owner != get_thread_id() && "deadlock on recursive mutex_lock");
+            ASSERT(lock->owner != d_r_get_thread_id() &&
+                   "deadlock on recursive mutex_lock");
         }
         lock->count_times_contended++;
     }
@@ -656,13 +658,13 @@ deadlock_avoidance_unlock(mutex_t *lock, bool ownable)
     LOG(GLOBAL, LOG_THREADS, 6,
         "released lock " PFX " %s rank=%d, %s dcontext, tid:%d \n", lock, lock->name,
         lock->rank, get_thread_private_dcontext() ? "valid" : "not valid",
-        get_thread_id());
+        d_r_get_thread_id());
     LOG(THREAD_GET, LOG_THREADS, 6, "released lock " PFX " %s rank=%d\n", lock,
         lock->name, lock->rank);
     if (!ownable)
         return;
 
-    ASSERT(lock->owner == get_thread_id());
+    ASSERT(lock->owner == d_r_get_thread_id());
     if (INTERNAL_OPTION(deadlock_avoidance) && lock->owning_dcontext != NULL &&
         lock->owning_dcontext != GLOBAL_DCONTEXT) {
         dcontext_t *dcontext = get_thread_private_dcontext();
@@ -707,7 +709,7 @@ deadlock_avoidance_unlock(mutex_t *lock, bool ownable)
 
 #ifdef UNIX
 void
-mutex_fork_reset(mutex_t *mutex)
+d_r_mutex_fork_reset(mutex_t *mutex)
 {
     /* i#239/PR 498752: need to free locks held by other threads at fork time.
      * We can't call ASSIGN_INIT_LOCK_FREE as that clobbers any contention event
@@ -819,7 +821,7 @@ void
 spinmutex_delete(spin_mutex_t *spin_lock)
 {
     ASSERT(!ksynch_var_initialized(&spin_lock->lock.contended_event));
-    mutex_delete(&spin_lock->lock);
+    d_r_mutex_delete(&spin_lock->lock);
 }
 
 #ifdef DEADLOCK_AVOIDANCE
@@ -839,7 +841,7 @@ mutex_ownable(mutex_t *lock)
 #endif
 
 void
-mutex_lock_app(mutex_t *lock _IF_CLIENT_INTERFACE(priv_mcontext_t *mc))
+d_r_mutex_lock_app(mutex_t *lock _IF_CLIENT_INTERFACE(priv_mcontext_t *mc))
 {
     bool acquired;
 #ifdef DEADLOCK_AVOIDANCE
@@ -853,7 +855,7 @@ mutex_lock_app(mutex_t *lock _IF_CLIENT_INTERFACE(priv_mcontext_t *mc))
     if (spinlock_count) {
         uint i;
         /* in the common case we'll just get it */
-        if (mutex_trylock(lock))
+        if (d_r_mutex_trylock(lock))
             return;
 
         /* otherwise contended, we should spin for some time */
@@ -897,14 +899,14 @@ mutex_lock_app(mutex_t *lock _IF_CLIENT_INTERFACE(priv_mcontext_t *mc))
 }
 
 void
-mutex_lock(mutex_t *lock)
+d_r_mutex_lock(mutex_t *lock)
 {
-    mutex_lock_app(lock _IF_CLIENT_INTERFACE(NULL));
+    d_r_mutex_lock_app(lock _IF_CLIENT_INTERFACE(NULL));
 }
 
 /* try once to grab the lock, return whether or not successful */
 bool
-mutex_trylock(mutex_t *lock)
+d_r_mutex_trylock(mutex_t *lock)
 {
     bool acquired;
 #ifdef DEADLOCK_AVOIDANCE
@@ -924,7 +926,7 @@ mutex_trylock(mutex_t *lock)
 
 /* free the lock */
 void
-mutex_unlock(mutex_t *lock)
+d_r_mutex_unlock(mutex_t *lock)
 {
 #ifdef DEADLOCK_AVOIDANCE
     bool ownable = mutex_ownable(lock);
@@ -943,7 +945,7 @@ mutex_unlock(mutex_t *lock)
 
 /* releases any associated kernel objects */
 void
-mutex_delete(mutex_t *lock)
+d_r_mutex_delete(mutex_t *lock)
 {
     LOG(GLOBAL, LOG_THREADS, 3, "mutex_delete lock " PFX "\n", lock);
     /* When doing detach, application locks may be held on threads which have
@@ -984,7 +986,7 @@ mutex_delete(mutex_t *lock)
 
 #ifdef CLIENT_INTERFACE
 void
-mutex_mark_as_app(mutex_t *lock)
+d_r_mutex_mark_as_app(mutex_t *lock)
 {
 #    ifdef DEADLOCK_AVOIDANCE
     lock->app_lock = true;
@@ -997,7 +999,7 @@ own_recursive_lock(recursive_lock_t *lock)
 {
     ASSERT(lock->owner == INVALID_THREAD_ID);
     ASSERT(lock->count == 0);
-    lock->owner = get_thread_id();
+    lock->owner = d_r_get_thread_id();
     ASSERT(lock->owner != INVALID_THREAD_ID);
     lock->count = 1;
 }
@@ -1011,10 +1013,10 @@ acquire_recursive_app_lock(
     */
 
     /* ASSUMPTION: reading owner field is atomic */
-    if (lock->owner == get_thread_id()) {
+    if (lock->owner == d_r_get_thread_id()) {
         lock->count++;
     } else {
-        mutex_lock_app(&lock->lock _IF_CLIENT_INTERFACE(mc));
+        d_r_mutex_lock_app(&lock->lock _IF_CLIENT_INTERFACE(mc));
         own_recursive_lock(lock);
     }
 }
@@ -1030,10 +1032,10 @@ bool
 try_recursive_lock(recursive_lock_t *lock)
 {
     /* ASSUMPTION: reading owner field is atomic */
-    if (lock->owner == get_thread_id()) {
+    if (lock->owner == d_r_get_thread_id()) {
         lock->count++;
     } else {
-        if (!mutex_trylock(&lock->lock))
+        if (!d_r_mutex_trylock(&lock->lock))
             return false;
         own_recursive_lock(lock);
     }
@@ -1043,12 +1045,12 @@ try_recursive_lock(recursive_lock_t *lock)
 void
 release_recursive_lock(recursive_lock_t *lock)
 {
-    ASSERT(lock->owner == get_thread_id());
+    ASSERT(lock->owner == d_r_get_thread_id());
     ASSERT(lock->count > 0);
     lock->count--;
     if (lock->count == 0) {
         lock->owner = INVALID_THREAD_ID;
-        mutex_unlock(&lock->lock);
+        d_r_mutex_unlock(&lock->lock);
     }
 }
 
@@ -1056,7 +1058,7 @@ bool
 self_owns_recursive_lock(recursive_lock_t *lock)
 {
     /* ASSUMPTION: reading owner field is atomic */
-    return (lock->owner == get_thread_id());
+    return (lock->owner == d_r_get_thread_id());
 }
 
 /* Read write locks */
@@ -1107,7 +1109,7 @@ self_owns_recursive_lock(recursive_lock_t *lock)
 */
 
 void
-read_lock(read_write_lock_t *rw)
+d_r_read_lock(read_write_lock_t *rw)
 {
     /* wait for writer here if lock is held
      * FIXME: generalize DEADLOCK_AVOIDANCE to both detect
@@ -1120,16 +1122,16 @@ read_lock(read_write_lock_t *rw)
                 /* contended read */
                 /* am I the writer?
                  * ASSUMPTION: reading field is atomic
-                 * For linux get_thread_id() is expensive -- we
+                 * For linux d_r_get_thread_id() is expensive -- we
                  * should either address that through special handling
                  * of native and new thread cases, or switch this
                  * routine to pass in dcontext and use that.
-                 * Update: linux get_thread_id() now calls get_tls_thread_id()
+                 * Update: linux d_r_get_thread_id() now calls get_tls_thread_id()
                  * and avoids the syscall (xref PR 473640).
                  * FIXME: we could also reorganize this check so that it is done only once
                  * instead of in the loop body but it doesn't seem wortwhile
                  */
-                if (rw->writer == get_thread_id()) {
+                if (rw->writer == d_r_get_thread_id()) {
                     /* we would share the code below but we do not want
                      * the deadlock avoidance to consider this an acquire
                      */
@@ -1156,14 +1158,14 @@ read_lock(read_write_lock_t *rw)
             /* contended read */
             /* am I the writer?
              * ASSUMPTION: reading field is atomic
-             * For linux get_thread_id() is expensive -- we
+             * For linux d_r_get_thread_id() is expensive -- we
              * should either address that through special handling
              * of native and new thread cases, or switch this
              * routine to pass in dcontext and use that.
-             * Update: linux get_thread_id() now calls get_tls_thread_id()
+             * Update: linux d_r_get_thread_id() now calls get_tls_thread_id()
              * and avoids the syscall (xref PR 473640).
              */
-            if (rw->writer == get_thread_id()) {
+            if (rw->writer == d_r_get_thread_id()) {
                 /* we would share the code below but we do not want
                  * the deadlock avoidance to consider this an acquire
                  */
@@ -1224,25 +1226,25 @@ read_lock(read_write_lock_t *rw)
 }
 
 void
-write_lock(read_write_lock_t *rw)
+d_r_write_lock(read_write_lock_t *rw)
 {
     /* we do not follow the pattern of having lock call trylock in
      * a loop because that would be unfair to writers -- first guy
      * in this implementation gets to write
      */
     if (INTERNAL_OPTION(spin_yield_rwlock)) {
-        mutex_lock(&rw->lock);
+        d_r_mutex_lock(&rw->lock);
         while (rw->num_readers > 0) {
             /* contended write */
             DEADLOCK_AVOIDANCE_LOCK(&rw->lock, false, LOCK_NOT_OWNABLE);
             /* FIXME: last places where we yield instead of wait */
             os_thread_yield();
         }
-        rw->writer = get_thread_id();
+        rw->writer = d_r_get_thread_id();
         return;
     }
 
-    mutex_lock(&rw->lock);
+    d_r_mutex_lock(&rw->lock);
     /* We still do this in a loop, since the event signal doesn't guarantee
        that num_readers is 0 when unblocked.
      */
@@ -1251,22 +1253,22 @@ write_lock(read_write_lock_t *rw)
         DEADLOCK_AVOIDANCE_LOCK(&rw->lock, false, LOCK_NOT_OWNABLE);
         rwlock_wait_contended_writer(rw);
     }
-    rw->writer = get_thread_id();
+    rw->writer = d_r_get_thread_id();
 }
 
 bool
-write_trylock(read_write_lock_t *rw)
+d_r_write_trylock(read_write_lock_t *rw)
 {
-    if (mutex_trylock(&rw->lock)) {
+    if (d_r_mutex_trylock(&rw->lock)) {
         ASSERT_NOT_TESTED();
         if (rw->num_readers == 0) {
-            rw->writer = get_thread_id();
+            rw->writer = d_r_get_thread_id();
             return true;
         } else {
-            /* We need to duplicate the bottom of write_unlock() */
+            /* We need to duplicate the bottom of d_r_write_unlock() */
             /* since if a new reader has appeared after we have acquired the lock
                that one may already be waiting on the broadcast event */
-            mutex_unlock(&rw->lock);
+            d_r_mutex_unlock(&rw->lock);
             /* check whether any reader is currently waiting */
             if (rw->num_pending_readers > 0) {
                 /* after we've released the write lock, pending
@@ -1280,7 +1282,7 @@ write_trylock(read_write_lock_t *rw)
 }
 
 void
-read_unlock(read_write_lock_t *rw)
+d_r_read_unlock(read_write_lock_t *rw)
 {
     if (INTERNAL_OPTION(spin_yield_rwlock)) {
         ATOMIC_DEC(int, rw->num_readers);
@@ -1293,13 +1295,13 @@ read_unlock(read_write_lock_t *rw)
 
     /* unfortunately even on the hot path (of a single reader) we have
        to check if the writer is in fact waiting.  Even though this is
-       not atomic we don't need to loop here - write_lock() will loop.
+       not atomic we don't need to loop here - d_r_write_lock() will loop.
     */
     if (atomic_dec_becomes_zero(&rw->num_readers)) {
         /* if the writer is waiting it definitely needs to hold the mutex */
         if (mutex_testlock(&rw->lock)) {
             /* test that it was not this thread owning both write and read lock */
-            if (rw->writer != get_thread_id()) {
+            if (rw->writer != d_r_get_thread_id()) {
                 /* we're assuming the writer has been forced to wait,
                    but since we can't tell whether it did indeed wait this
                    notify may leave signaled the event for the next turn
@@ -1320,14 +1322,14 @@ read_unlock(read_write_lock_t *rw)
 }
 
 void
-write_unlock(read_write_lock_t *rw)
+d_r_write_unlock(read_write_lock_t *rw)
 {
 #ifdef DEADLOCK_AVOIDANCE
     ASSERT(rw->writer == rw->lock.owner);
 #endif
     rw->writer = INVALID_THREAD_ID;
     if (INTERNAL_OPTION(spin_yield_rwlock)) {
-        mutex_unlock(&rw->lock);
+        d_r_mutex_unlock(&rw->lock);
         return;
     }
     /* we need to signal all waiting readers (if any) that they can now go
@@ -1338,7 +1340,7 @@ write_unlock(read_write_lock_t *rw)
        progress as soon as they are notified.  Further field
        accesses however have to be assumed unprotected.
     */
-    mutex_unlock(&rw->lock);
+    d_r_mutex_unlock(&rw->lock);
     /* check whether any reader is currently waiting */
     if (rw->num_pending_readers > 0) {
         /* after we've released the write lock, pending readers will no longer wait */
@@ -1350,7 +1352,7 @@ bool
 self_owns_write_lock(read_write_lock_t *rw)
 {
     /* ASSUMPTION: reading owner field is atomic */
-    return (rw->writer == get_thread_id());
+    return (rw->writer == d_r_get_thread_id());
 }
 
 /****************************************************************************/
@@ -2026,7 +2028,7 @@ under_internal_exception()
 {
 #    ifdef DEADLOCK_AVOIDANCE
     /* ASSUMPTION: reading owner field is atomic */
-    return (report_buf_lock.owner == get_thread_id());
+    return (report_buf_lock.owner == d_r_get_thread_id());
 #    else
     /* mutexes normally don't have an owner, stay safe no matter who owns */
     return mutex_testlock(&report_buf_lock);
@@ -2132,12 +2134,12 @@ report_dynamorio_problem(dcontext_t *dcontext, uint dumpcore_flag, app_pc except
     if (dcontext == NULL)
         dcontext = GLOBAL_DCONTEXT;
 
-    if (report_buf_lock_owner == get_thread_id()) {
+    if (report_buf_lock_owner == d_r_get_thread_id()) {
         /* nested report: can't do much except bail on inner */
         return;
     }
-    mutex_lock(&report_buf_lock);
-    report_buf_lock_owner = get_thread_id();
+    d_r_mutex_lock(&report_buf_lock);
+    report_buf_lock_owner = d_r_get_thread_id();
     /* we assume the caller does a DO_ONCE to prevent hanging on a
      * fault in this routine, if called to report a fatal error.
      */
@@ -2237,7 +2239,7 @@ report_dynamorio_problem(dcontext_t *dcontext, uint dumpcore_flag, app_pc except
 #endif
     } else if (TEST(DUMPCORE_ASSERTION, dumpcore_flag)) {
         /* We need to report ASSERTS in DEBUG=1 INTERNAL=0 builds since we're still
-         * going to kill the process. Xref PR 232783. internal_error() already
+         * going to kill the process. Xref PR 232783. d_r_internal_error() already
          * obfuscated the which file info. */
         SYSLOG_NO_OPTION_SYNCH(SYSLOG_ERROR, INTERNAL_SYSLOG_ERROR, 3,
                                get_application_name(), get_application_pid(), reportbuf);
@@ -2270,7 +2272,7 @@ report_dynamorio_problem(dcontext_t *dcontext, uint dumpcore_flag, app_pc except
     });
 
     report_buf_lock_owner = 0;
-    mutex_unlock(&report_buf_lock);
+    d_r_mutex_unlock(&report_buf_lock);
 
     if (dumpcore_flag != DUMPCORE_CURIOSITY) {
         /* print out stats, can't be done inside the report_buf_lock
@@ -2865,8 +2867,8 @@ open_log_file(const char *basename, char *finalname_with_path, uint maxlen)
     if (name[0] == '\0')
         return INVALID_FILE;
     snprintf(&name[strlen(name)], BUFFER_SIZE_ELEMENTS(name) - strlen(name),
-             "%c%s.%d." TIDFMT ".html", DIRSEP, basename, get_thread_num(get_thread_id()),
-             get_thread_id());
+             "%c%s.%d." TIDFMT ".html", DIRSEP, basename,
+             get_thread_num(d_r_get_thread_id()), d_r_get_thread_id());
     NULL_TERMINATE_BUFFER(name);
 #ifdef UNIX
     if (post_execve) /* reuse same log file */
@@ -3045,7 +3047,7 @@ stats_thread_init(dcontext_t *dcontext)
         sizeof(thread_local_statistics_t));
     /* initialize any thread stats bookkeeping fields before assigning to dcontext */
     memset(new_thread_stats, 0x0, sizeof(thread_local_statistics_t));
-    new_thread_stats->thread_id = get_thread_id();
+    new_thread_stats->thread_id = d_r_get_thread_id();
     ASSIGN_INIT_LOCK_FREE(new_thread_stats->thread_stats_lock, thread_stats_lock);
     dcontext->thread_stats = new_thread_stats;
 }
@@ -3091,11 +3093,11 @@ dump_thread_stats(dcontext_t *dcontext, bool raw)
     LOG(logfile, LOG_STATS, 1,
         "(Begin) Thread statistics @%d global, %d thread fragments ",
         GLOBAL_STAT(num_fragments), THREAD_STAT(dcontext, num_fragments));
-    DOLOG(1, LOG_STATS, { print_timestamp(logfile); });
+    DOLOG(1, LOG_STATS, { d_r_print_timestamp(logfile); });
     /* give up right away if thread stats lock already held, will dump next time
        most likely thread interrupted while dumping state
      */
-    if (!mutex_trylock(&dcontext->thread_stats->thread_stats_lock)) {
+    if (!d_r_mutex_trylock(&dcontext->thread_stats->thread_stats_lock)) {
         LOG(logfile, LOG_STATS, 1, " WARNING: skipped! Another dump in progress.\n");
         return;
     }
@@ -3116,7 +3118,7 @@ dump_thread_stats(dcontext_t *dcontext, bool raw)
 #    undef STATS_DEF
 
     LOG(logfile, LOG_STATS, 1, "(End) Thread statistics\n");
-    mutex_unlock(&dcontext->thread_stats->thread_stats_lock);
+    d_r_mutex_unlock(&dcontext->thread_stats->thread_stats_lock);
     /* TODO: update thread statistics, using the thread stats delta when implemented */
 
 #    ifdef KSTATS
@@ -3136,7 +3138,7 @@ dump_global_stats(bool raw)
     if (GLOBAL_STATS_ON()) {
         LOG(GLOBAL, LOG_STATS, 1, "(Begin) All statistics @%d ",
             GLOBAL_STAT(num_fragments));
-        DOLOG(1, LOG_STATS, { print_timestamp(GLOBAL); });
+        DOLOG(1, LOG_STATS, { d_r_print_timestamp(GLOBAL); });
         LOG(GLOBAL, LOG_STATS, 1, ":\n");
 #    define STATS_DEF(desc, stat)                                                       \
         if (GLOBAL_STAT(stat)) {                                                        \
@@ -3196,7 +3198,7 @@ print_timestamp_to_buffer(char *buffer, size_t len)
  * TODO: and relative time from thread start
  */
 uint
-print_timestamp(file_t logfile)
+d_r_print_timestamp(file_t logfile)
 {
     char buffer[PRINT_TIMESTAMP_MAX_LENGTH];
     uint len = print_timestamp_to_buffer(buffer, PRINT_TIMESTAMP_MAX_LENGTH);
@@ -3479,7 +3481,7 @@ get_random_offset(size_t max_offset)
         return 0;
 
     /* process-shared random sequence */
-    mutex_lock(&prng_lock);
+    d_r_mutex_lock(&prng_lock);
     /* FIXME: this is not getting the best randomness
      * see srand() comments why taking higher order bits is usually better
      * j=1+(int) (10.0*rand()/(RAND_MAX+1.0));
@@ -3488,7 +3490,7 @@ get_random_offset(size_t max_offset)
     value = random_seed % max_offset;
 
     random_seed = LCM_A * (random_seed % LCM_Q) - LCM_R * (random_seed / LCM_Q);
-    mutex_unlock(&prng_lock);
+    d_r_mutex_unlock(&prng_lock);
     LOG(GLOBAL, LOG_ALL, 2, "get_random_offset: value=%d (mod %d), new rs=%d\n", value,
         max_offset, random_seed);
     return value;
@@ -4247,7 +4249,7 @@ profile_callers()
      * DR and thus are safe to read, but checks for dstack, etc.
      * Should combine the two into a general routine.
      */
-    while (pc != NULL && safe_read((byte *)pc, sizeof(saferead), saferead)) {
+    while (pc != NULL && d_r_safe_read((byte *)pc, sizeof(saferead), saferead)) {
         caller[num] = saferead[1];
         num++;
         /* yes I've seen weird recursive cases before */
@@ -4276,10 +4278,10 @@ profile_callers()
         entry = global_heap_alloc(sizeof(profile_callers_t) HEAPACCT(ACCT_OTHER));
         memcpy(entry->caller, caller, sizeof(caller));
         entry->count = 1;
-        mutex_lock(&profile_callers_lock);
+        d_r_mutex_lock(&profile_callers_lock);
         entry->next = profcalls;
         profcalls = entry;
-        mutex_unlock(&profile_callers_lock);
+        d_r_mutex_unlock(&profile_callers_lock);
     }
 }
 
@@ -4289,7 +4291,7 @@ profile_callers_exit()
     profile_callers_t *entry, *next;
     file_t file;
     if (DYNAMO_OPTION(prof_caller) > 0) {
-        mutex_lock(&profile_callers_lock);
+        d_r_mutex_lock(&profile_callers_lock);
         file = open_log_file("callprof", NULL, 0);
         for (entry = profcalls; entry != NULL; entry = next) {
             uint num;
@@ -4302,7 +4304,7 @@ profile_callers_exit()
         }
         close_log_file(file);
         profcalls = NULL;
-        mutex_unlock(&profile_callers_lock);
+        d_r_mutex_unlock(&profile_callers_lock);
     }
     DELETE_LOCK(profile_callers_lock);
 }

--- a/core/utils.h
+++ b/core/utils.h
@@ -66,16 +66,16 @@
  * FIXME: cl debug build allocates a local for each ?:, so if this gets
  * unrolled in some optionsx or other expansion we could have stack problems!
  */
-#        define ASSERT(x)                                             \
-            ((void)((DEBUG_CHECKS(CHKLVL_ASSERTS) && !(x))            \
-                        ? (internal_error(__FILE__, __LINE__, #x), 0) \
+#        define ASSERT(x)                                                 \
+            ((void)((DEBUG_CHECKS(CHKLVL_ASSERTS) && !(x))                \
+                        ? (d_r_internal_error(__FILE__, __LINE__, #x), 0) \
                         : 0))
 /* make type void to avoid gcc 4.1 warnings about "value computed is not used"
  * (case 7851).  can also use statement expr ({;}) but only w/ gcc, not w/ cl.
  */
-#        define ASSERT_MESSAGE(level, msg, x)                                 \
-            ((DEBUG_CHECKS(level) && !(x))                                    \
-                 ? (internal_error(msg " @" __FILE__, __LINE__, #x), (void)0) \
+#        define ASSERT_MESSAGE(level, msg, x)                                     \
+            ((DEBUG_CHECKS(level) && !(x))                                        \
+                 ? (d_r_internal_error(msg " @" __FILE__, __LINE__, #x), (void)0) \
                  : (void)0)
 #        define REPORT_CURIOSITY(x)                                                   \
             do {                                                                      \
@@ -100,13 +100,13 @@
             } while (0)
 #    else
 /* cast to void to avoid gcc warning "statement with no effect" */
-#        define ASSERT(x)                                             \
-            ((void)((DEBUG_CHECKS(CHKLVL_ASSERTS) && !(x))            \
-                        ? (internal_error(__FILE__, __LINE__, ""), 0) \
+#        define ASSERT(x)                                                 \
+            ((void)((DEBUG_CHECKS(CHKLVL_ASSERTS) && !(x))                \
+                        ? (d_r_internal_error(__FILE__, __LINE__, ""), 0) \
                         : 0))
-#        define ASSERT_MESSAGE(level, msg, x)                         \
-            ((void)((DEBUG_CHECKS(level) && !(x))                     \
-                        ? (internal_error(__FILE__, __LINE__, ""), 0) \
+#        define ASSERT_MESSAGE(level, msg, x)                             \
+            ((void)((DEBUG_CHECKS(level) && !(x))                         \
+                        ? (d_r_internal_error(__FILE__, __LINE__, ""), 0) \
                         : 0))
 #        define ASSERT_CURIOSITY(x) ((void)0)
 #        define ASSERT_CURIOSITY_ONCE(x) ((void)0)
@@ -128,7 +128,7 @@
 
 #if defined(INTERNAL) || defined(DEBUG)
 void
-internal_error(const char *file, int line, const char *expr);
+d_r_internal_error(const char *file, int line, const char *expr);
 bool
 ignore_assert(const char *assert_file_line, const char *expr);
 #endif
@@ -748,35 +748,35 @@ thread_owns_first_or_both_locks_only(dcontext_t *dcontext, mutex_t *lock1,
     }
 
 /* in order to use parallel names to the above INIT_*LOCK routines */
-#define DELETE_LOCK(lock) mutex_delete(&lock)
+#define DELETE_LOCK(lock) d_r_mutex_delete(&lock)
 #define DELETE_SPINMUTEX(spinmutex) spinmutex_delete(&spinmutex)
-#define DELETE_RECURSIVE_LOCK(rec_lock) mutex_delete(&(rec_lock).lock)
-#define DELETE_READWRITE_LOCK(rwlock) mutex_delete(&(rwlock).lock)
+#define DELETE_RECURSIVE_LOCK(rec_lock) d_r_mutex_delete(&(rec_lock).lock)
+#define DELETE_READWRITE_LOCK(rwlock) d_r_mutex_delete(&(rwlock).lock)
 /* mutexes need to release any kernel objects that were created */
 void
-mutex_delete(mutex_t *lock);
+d_r_mutex_delete(mutex_t *lock);
 
 /* basic synchronization functions */
 void
-mutex_lock(mutex_t *mutex);
+d_r_mutex_lock(mutex_t *mutex);
 bool
-mutex_trylock(mutex_t *mutex);
+d_r_mutex_trylock(mutex_t *mutex);
 void
-mutex_unlock(mutex_t *mutex);
+d_r_mutex_unlock(mutex_t *mutex);
 #ifdef UNIX
 void
-mutex_fork_reset(mutex_t *mutex);
+d_r_mutex_fork_reset(mutex_t *mutex);
 #endif
 #ifdef CLIENT_INTERFACE
 void
-mutex_mark_as_app(mutex_t *lock);
+d_r_mutex_mark_as_app(mutex_t *lock);
 /* Use this version of 'lock' when obtaining a lock in an app context. In the
  * case that there is contention on this lock, this thread will be marked safe
  * to be relocated and even detached. The current thread's mcontext may be
  * clobbered with the provided value even if the thread is not suspended.
  */
 void
-mutex_lock_app(mutex_t *mutex, priv_mcontext_t *mc);
+d_r_mutex_lock_app(mutex_t *mutex, priv_mcontext_t *mc);
 #endif
 
 /* spinmutex synchronization */
@@ -834,15 +834,15 @@ acquire_recursive_app_lock(recursive_lock_t *mutex, priv_mcontext_t *mc);
 
 /* A read write lock allows multiple readers or alternatively a single writer */
 void
-read_lock(read_write_lock_t *rw);
+d_r_read_lock(read_write_lock_t *rw);
 void
-write_lock(read_write_lock_t *rw);
+d_r_write_lock(read_write_lock_t *rw);
 bool
-write_trylock(read_write_lock_t *rw);
+d_r_write_trylock(read_write_lock_t *rw);
 void
-read_unlock(read_write_lock_t *rw);
+d_r_read_unlock(read_write_lock_t *rw);
 void
-write_unlock(read_write_lock_t *rw);
+d_r_write_unlock(read_write_lock_t *rw);
 bool
 self_owns_write_lock(read_write_lock_t *rw);
 
@@ -856,7 +856,7 @@ self_owns_write_lock(read_write_lock_t *rw);
  * knowing for sure.
  */
 #ifdef DEADLOCK_AVOIDANCE
-#    define OWN_MUTEX(m) ((m)->owner == get_thread_id())
+#    define OWN_MUTEX(m) ((m)->owner == d_r_get_thread_id())
 #    define ASSERT_OWN_MUTEX(pred, m) ASSERT(!(pred) || OWN_MUTEX(m))
 #    define ASSERT_DO_NOT_OWN_MUTEX(pred, m) ASSERT(!(pred) || !OWN_MUTEX(m))
 #    define OWN_NO_LOCKS(dc) thread_owns_no_locks(dc)
@@ -907,10 +907,10 @@ dr_modload_hook_exists(void); /* hard to include instrument.h here */
      dr_modload_hook_exists())
 /* anyone guarding the bb_building_lock with this must use SHARED_BB_{UN,}LOCK */
 #define USE_BB_BUILDING_LOCK() (USE_BB_BUILDING_LOCK_STEADY_STATE() && bb_lock_start)
-#define SHARED_BB_LOCK()                     \
-    do {                                     \
-        if (USE_BB_BUILDING_LOCK())          \
-            mutex_lock(&(bb_building_lock)); \
+#define SHARED_BB_LOCK()                         \
+    do {                                         \
+        if (USE_BB_BUILDING_LOCK())              \
+            d_r_mutex_lock(&(bb_building_lock)); \
     } while (0)
 /* We explicitly check the lock_requests to handle a thread from appearing
  * suddenly and causing USE_BB_BUILDING_LOCK() to return true while we're
@@ -924,7 +924,7 @@ dr_modload_hook_exists(void); /* hard to include instrument.h here */
 #define SHARED_BB_UNLOCK()                                                              \
     do {                                                                                \
         if (USE_BB_BUILDING_LOCK() && bb_building_lock.lock_requests > LOCK_FREE_STATE) \
-            mutex_unlock(&(bb_building_lock));                                          \
+            d_r_mutex_unlock(&(bb_building_lock));                                      \
     } while (0)
 /* we assume dynamo_resetting is only done w/ all threads suspended */
 #define NEED_SHARED_LOCK(flags)                                             \
@@ -1353,13 +1353,13 @@ extern mutex_t do_threshold_mutex;
     {                                                                           \
         DECLARE_THRESHOLD_LOCK(section)                                         \
         static uint do_threshold_cur VAR_IN_SECTION(section) = 0;               \
-        mutex_lock(&do_threshold_mutex);                                        \
+        d_r_mutex_lock(&do_threshold_mutex);                                    \
         if (do_threshold_cur < threshold) {                                     \
             do_threshold_cur++;                                                 \
-            mutex_unlock(&do_threshold_mutex);                                  \
+            d_r_mutex_unlock(&do_threshold_mutex);                              \
             statement_below;                                                    \
         } else {                                                                \
-            mutex_unlock(&do_threshold_mutex);                                  \
+            d_r_mutex_unlock(&do_threshold_mutex);                              \
             statement_after; /* or at */                                        \
         }                                                                       \
     }
@@ -2133,7 +2133,7 @@ stats_thread_exit(dcontext_t *dcontext);
 uint
 print_timestamp_to_buffer(char *buffer, size_t len);
 uint
-print_timestamp(file_t logfile);
+d_r_print_timestamp(file_t logfile);
 
 /* prints a symbolic name, or best guess of it into a caller provided buffer */
 void

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -241,7 +241,7 @@ typedef struct thread_data_t {
     do {                                 \
         if (SHOULD_LOCK_VECTOR(v)) {     \
             (release_lock) = true;       \
-            RW##_lock(&(v)->lock);       \
+            d_r_##RW##_lock(&(v)->lock); \
         } else                           \
             (release_lock) = false;      \
     } while (0);
@@ -252,7 +252,7 @@ typedef struct thread_data_t {
             ASSERT(TEST(VECTOR_SHARED, (v)->flags));     \
             ASSERT(!TEST(VECTOR_NO_LOCK, (v)->flags));   \
             ASSERT_OWN_READWRITE_LOCK(true, &(v)->lock); \
-            RW##_unlock(&v->lock);                       \
+            d_r_##RW##_unlock(&v->lock);                 \
         }                                                \
     } while (0);
 
@@ -431,7 +431,7 @@ DECLARE_CXTSWPROT_VAR(static mutex_t lazy_delete_lock, INIT_LOCK_FREE(lazy_delet
     do {                                        \
         if (TEST(VECTOR_SHARED, (v)->flags)) {  \
             ASSERT(SHARED_FRAGMENTS_ENABLED()); \
-            rw##_##op(&(v)->lock);              \
+            d_r_##rw##_##op(&(v)->lock);        \
         }                                       \
     } while (0)
 #define ASSERT_VMAREA_DATA_PROTECTED(data, RW)                          \

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -697,7 +697,7 @@ revert_memory_regions()
     /* executable_areas doesn't exist in thin_client mode. */
     ASSERT(!DYNAMO_OPTION(thin_client));
 
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     for (i = 0; i < executable_areas->length; i++) {
         if (DR_MADE_READONLY(executable_areas->buf[i].vm_flags)) {
             /* this is a region that dynamorio has marked read only, fix */
@@ -710,7 +710,7 @@ revert_memory_regions()
                                  executable_areas->buf[i].start);
         }
     }
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
 }
 
 static void
@@ -2157,7 +2157,7 @@ vmvector_iterator_start(vm_area_vector_t *v, vmvector_iterator_t *vmvi)
     ASSERT(v != NULL);
     ASSERT(vmvi != NULL);
     if (SHOULD_LOCK_VECTOR(v))
-        read_lock(&v->lock);
+        d_r_read_lock(&v->lock);
     vmvi->vector = v;
     vmvi->index = -1;
 }
@@ -2221,7 +2221,7 @@ vmvector_iterator_stop(vmvector_iterator_t *vmvi)
 {
     ASSERT_VMAREA_VECTOR_PROTECTED(vmvi->vector, READWRITE);
     if (SHOULD_LOCK_VECTOR(vmvi->vector))
-        read_unlock(&vmvi->vector->lock);
+        d_r_read_unlock(&vmvi->vector->lock);
     DODEBUG({
         vmvi->vector = NULL; /* crash incorrect reuse */
         vmvi->index = -1;
@@ -2679,9 +2679,9 @@ add_executable_vm_area(app_pc start, app_pc end, uint vm_flags, uint frag_flags,
 #ifdef HOT_PATCHING_INTERFACE
         /* case 9970: need to check hotp vs perscache; rank order hotp < exec_areas */
         if (DYNAMO_OPTION(hot_patching))
-            read_lock(hotp_get_lock());
+            d_r_read_lock(hotp_get_lock());
 #endif
-        write_lock(&executable_areas->lock);
+        d_r_write_lock(&executable_areas->lock);
     }
     ASSERT_OWN_WRITE_LOCK(true, &executable_areas->lock);
     /* FIXME: rather than change all callers who already hold exec_areas lock
@@ -2734,10 +2734,10 @@ add_executable_vm_area(app_pc start, app_pc end, uint vm_flags, uint frag_flags,
     });
 
     if (!have_writelock) {
-        write_unlock(&executable_areas->lock);
+        d_r_write_unlock(&executable_areas->lock);
 #ifdef HOT_PATCHING_INTERFACE
         if (DYNAMO_OPTION(hot_patching))
-            read_unlock(hotp_get_lock());
+            d_r_read_unlock(hotp_get_lock());
 #endif
     }
     if (tofree != NULL) {
@@ -2776,10 +2776,10 @@ remove_executable_vm_area(app_pc start, app_pc end, bool have_writelock)
     LOG(GLOBAL, LOG_VMAREAS, 2, "removing executable vm area: " PFX "-" PFX "\n", start,
         end);
     if (!have_writelock)
-        write_lock(&executable_areas->lock);
+        d_r_write_lock(&executable_areas->lock);
     ok = remove_vm_area(executable_areas, start, end, true /*restore writability!*/);
     if (!have_writelock)
-        write_unlock(&executable_areas->lock);
+        d_r_write_unlock(&executable_areas->lock);
     return ok;
 }
 
@@ -2806,7 +2806,7 @@ vm_area_delay_load_coarse_units(void)
         /* we already loaded if there's no client */
         !CLIENTS_EXIST())
         return;
-    write_lock(&executable_areas->lock);
+    d_r_write_lock(&executable_areas->lock);
     for (i = 0; i < executable_areas->length; i++) {
         if (TEST(FRAG_COARSE_GRAIN, executable_areas->buf[i].frag_flags)) {
             vm_area_t *a = &executable_areas->buf[i];
@@ -2830,7 +2830,7 @@ vm_area_delay_load_coarse_units(void)
                 ASSERT_NOT_REACHED(); /* shouldn't have been loaded already */
         }
     }
-    write_unlock(&executable_areas->lock);
+    d_r_write_unlock(&executable_areas->lock);
 }
 #endif
 
@@ -2901,10 +2901,10 @@ add_futureexec_vm_area(app_pc start, app_pc end,
         mark_unload_future_added(start, end - start);
     }
 
-    write_lock(&futureexec_areas->lock);
+    d_r_write_lock(&futureexec_areas->lock);
     add_vm_area(futureexec_areas, start, end, (once_only ? VM_ONCE_ONLY : 0),
                 0 /* frag_flags */, NULL _IF_DEBUG(comment));
-    write_unlock(&futureexec_areas->lock);
+    d_r_write_unlock(&futureexec_areas->lock);
     return true;
 }
 
@@ -2915,9 +2915,9 @@ remove_futureexec_vm_area(app_pc start, app_pc end)
     bool ok;
     LOG(GLOBAL, LOG_VMAREAS, 2, "removing FUTURE executable vm area: " PFX "-" PFX "\n",
         start, end);
-    write_lock(&futureexec_areas->lock);
+    d_r_write_lock(&futureexec_areas->lock);
     ok = remove_vm_area(futureexec_areas, start, end, false);
-    write_unlock(&futureexec_areas->lock);
+    d_r_write_unlock(&futureexec_areas->lock);
     return ok;
 }
 
@@ -2926,9 +2926,9 @@ static bool
 futureexec_vm_area_overlap(app_pc start, app_pc end)
 {
     bool overlap;
-    read_lock(&futureexec_areas->lock);
+    d_r_read_lock(&futureexec_areas->lock);
     overlap = vm_area_overlap(futureexec_areas, start, end);
-    read_unlock(&futureexec_areas->lock);
+    d_r_read_unlock(&futureexec_areas->lock);
     return overlap;
 }
 #endif /* PROGRAM_SHEPHERDING */
@@ -2938,9 +2938,9 @@ bool
 is_executable_address(app_pc addr)
 {
     bool found;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     found = lookup_addr(executable_areas, addr, NULL);
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     return found;
 }
 
@@ -2953,12 +2953,12 @@ get_executable_area_vm_flags(app_pc addr, uint *vm_flags)
 {
     bool found = false;
     vm_area_t *area;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     if (lookup_addr(executable_areas, addr, &area)) {
         *vm_flags = area->vm_flags;
         found = true;
     }
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     return found;
 }
 
@@ -2973,12 +2973,12 @@ get_executable_area_flags(app_pc addr, uint *frag_flags)
 {
     bool found = false;
     vm_area_t *area;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     if (lookup_addr(executable_areas, addr, &area)) {
         *frag_flags = area->frag_flags;
         found = true;
     }
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     return found;
 }
 
@@ -3001,7 +3001,7 @@ get_coarse_info_internal(app_pc addr, bool init, bool have_shvm_lock)
     bool reset_unit = false;
     /* FIXME perf opt: have a last_area */
     /* FIXME: could use vmvector_lookup_data() but I need area->{vm,frag}_flags */
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     if (lookup_addr(executable_areas, addr, &area)) {
         ASSERT(area != NULL);
         /* The custom field is initialized to 0 in add_vm_area */
@@ -3034,7 +3034,7 @@ get_coarse_info_internal(app_pc addr, bool init, bool have_shvm_lock)
             DODEBUG({ area_copy = *area; }); /* for ASSERT below */
         }
     }
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
 
     if (coarse != NULL && init) {
         /* For 4.3, bounds check is done at post-rebind validation;
@@ -3083,8 +3083,8 @@ mark_executable_area_coarse_frozen(coarse_info_t *frozen)
 {
     vm_area_t *area = NULL;
     coarse_info_t *info;
-    ASSERT(frozen->frozen);              /* caller should mark */
-    write_lock(&executable_areas->lock); /* since writing flags */
+    ASSERT(frozen->frozen);                  /* caller should mark */
+    d_r_write_lock(&executable_areas->lock); /* since writing flags */
     if (lookup_addr(executable_areas, frozen->base_pc, &area)) {
         ASSERT(area != NULL);
         /* The custom field is initialized to 0 in add_vm_area */
@@ -3100,7 +3100,7 @@ mark_executable_area_coarse_frozen(coarse_info_t *frozen)
         } else
             ASSERT(!TEST(FRAG_COARSE_GRAIN, area->frag_flags));
     }
-    write_unlock(&executable_areas->lock);
+    d_r_write_unlock(&executable_areas->lock);
 }
 
 /* iterates through all executable areas overlapping the pages touched
@@ -3165,10 +3165,10 @@ bool
 is_executable_area_writable(app_pc addr)
 {
     bool writable;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     writable = executable_areas_match_flags(addr, addr + 1 /* open ended */, NULL, NULL,
                                             false /* EXISTS */, VM_MADE_READONLY, 0);
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     return writable;
 }
 
@@ -3177,10 +3177,10 @@ is_executable_area_writable_overlap(app_pc start, app_pc end)
 {
     app_pc match_start = NULL;
     bool writable;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     writable = executable_areas_match_flags(start, end, NULL, &match_start,
                                             false /* EXISTS */, VM_MADE_READONLY, 0);
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     return match_start;
 }
 
@@ -3199,10 +3199,10 @@ is_executable_area_overlap(app_pc start, app_pc end, bool are_all_matching,
                            uint match_vm_flags)
 {
     bool writable;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     writable = executable_areas_match_flags(start, end, NULL, NULL, are_all_matching,
                                             match_vm_flags, 0);
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     return writable;
 }
 #endif
@@ -3223,10 +3223,10 @@ bool
 executable_vm_area_coarse_overlap(app_pc start, app_pc end)
 {
     bool match;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     match = executable_areas_match_flags(start, end, NULL, NULL,
                                          false /*exists, not all*/, 0, FRAG_COARSE_GRAIN);
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     return match;
 }
 
@@ -3237,10 +3237,10 @@ bool
 executable_vm_area_persisted_overlap(app_pc start, app_pc end)
 {
     bool match;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     match = executable_areas_match_flags(
         start, end, NULL, NULL, false /*exists, not all*/, VM_PERSISTED_CACHE, 0);
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     return match;
 }
 
@@ -3249,10 +3249,10 @@ bool
 executable_vm_area_executed_from(app_pc start, app_pc end)
 {
     bool match;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     match = executable_areas_match_flags(start, end, NULL, NULL,
                                          false /*exists, not all*/, VM_EXECUTED_FROM, 0);
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     return match;
 }
 
@@ -3280,7 +3280,7 @@ executable_area_overlap_bounds(app_pc start, app_pc end, app_pc *overlap_start /
     int start_index, end_index; /* must be signed */
     int i;                      /* must be signed */
     ASSERT(overlap_start != NULL && overlap_end != NULL);
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
 
     /* Find first overlapping region */
     if (!binary_search(executable_areas, start, end, NULL, &start_index, true /*first*/))
@@ -3316,7 +3316,7 @@ executable_area_overlap_bounds(app_pc start, app_pc end, app_pc *overlap_start /
     } else /* no extension asked for, or nowhere to extend to */
         *overlap_end = executable_areas->buf[end_index].end;
 
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     return true;
 }
 
@@ -3389,10 +3389,10 @@ is_executable_area_on_all_selfmod_pages(app_pc start, app_pc end)
 {
     bool all_selfmod;
     bool found;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     all_selfmod = executable_areas_match_flags(start, end, &found, NULL, true /* ALL */,
                                                0, FRAG_SELFMOD_SANDBOXED);
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     /* we require at least one area to be present */
     return all_selfmod && found;
 }
@@ -3408,7 +3408,7 @@ bool
 was_executable_area_writable(app_pc addr)
 {
     bool found_area = false, was_writable = false;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     was_writable = executable_areas_match_flags(addr, addr + 1, &found_area, NULL,
                                                 false /* EXISTS */, VM_MADE_READONLY, 0);
     /* seg fault could have happened, then area was made writable before
@@ -3428,7 +3428,7 @@ was_executable_area_writable(app_pc addr)
         if (get_memory_info(addr, NULL, NULL, &prot))
             was_writable = TEST(MEMPROT_WRITE, prot) && !is_dynamo_address(addr);
     }
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     return was_writable;
 }
 
@@ -3536,7 +3536,7 @@ dynamo_vm_areas_lock()
          */
         ASSERT_CURIOSITY(dynamo_areas_recursion <= 4);
     } else
-        write_lock(&dynamo_areas->lock);
+        d_r_write_lock(&dynamo_areas->lock);
 }
 
 void
@@ -3552,7 +3552,7 @@ dynamo_vm_areas_unlock()
         ASSERT_OWN_WRITE_LOCK(true, &dynamo_areas->lock);
         dynamo_areas_recursion--;
     } else
-        write_unlock(&dynamo_areas->lock);
+        d_r_write_unlock(&dynamo_areas->lock);
     all_memory_areas_unlock();
 }
 
@@ -3572,14 +3572,14 @@ self_owns_dynamo_vm_area_lock()
 static void
 dynamo_vm_areas_start_reading()
 {
-    read_lock(&dynamo_areas->lock);
+    d_r_read_lock(&dynamo_areas->lock);
     while (!dynamo_areas_uptodate) {
         /* switch to write lock
          * cannot rely on uptodate value prior to a lock so must
          * grab read and then check it, and back out if necessary
          * as we have no reader->writer transition
          */
-        read_unlock(&dynamo_areas->lock);
+        d_r_read_unlock(&dynamo_areas->lock);
         dynamo_vm_areas_lock();
         update_dynamo_vm_areas(true);
         /* FIXME: more efficient if we could safely drop from write to read
@@ -3588,14 +3588,14 @@ dynamo_vm_areas_start_reading()
          * elsewhere
          */
         dynamo_vm_areas_unlock();
-        read_lock(&dynamo_areas->lock);
+        d_r_read_lock(&dynamo_areas->lock);
     }
 }
 
 static void
 dynamo_vm_areas_done_reading()
 {
-    read_unlock(&dynamo_areas->lock);
+    d_r_read_unlock(&dynamo_areas->lock);
 }
 
 /* add dynamo-internal area to the dynamo-internal area list
@@ -3731,9 +3731,9 @@ is_pretend_writable_address(app_pc addr)
            DYNAMO_OPTION(handle_ntdll_modify) == DR_MODIFY_NOP ||
            !IS_STRING_OPTION_EMPTY(patch_proof_list) ||
            !IS_STRING_OPTION_EMPTY(patch_proof_default_list));
-    read_lock(&pretend_writable_areas->lock);
+    d_r_read_lock(&pretend_writable_areas->lock);
     found = lookup_addr(pretend_writable_areas, addr, NULL);
-    read_unlock(&pretend_writable_areas->lock);
+    d_r_read_unlock(&pretend_writable_areas->lock);
     return found;
 }
 
@@ -3742,9 +3742,9 @@ static bool
 pretend_writable_vm_area_overlap(app_pc start, app_pc end)
 {
     bool overlap;
-    read_lock(&pretend_writable_areas->lock);
+    d_r_read_lock(&pretend_writable_areas->lock);
     overlap = vm_area_overlap(pretend_writable_areas, start, end);
-    read_unlock(&pretend_writable_areas->lock);
+    d_r_read_unlock(&pretend_writable_areas->lock);
     return overlap;
 }
 
@@ -3757,17 +3757,17 @@ get_address_comment(app_pc addr)
     char *res = NULL;
     vm_area_t *area;
     bool ok;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     ok = lookup_addr(executable_areas, addr, &area);
     if (ok)
         res = area->comment;
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
     if (!ok) {
-        read_lock(&dynamo_areas->lock);
+        d_r_read_lock(&dynamo_areas->lock);
         ok = lookup_addr(dynamo_areas, addr, &area);
         if (ok)
             res = area->comment;
-        read_unlock(&dynamo_areas->lock);
+        d_r_read_unlock(&dynamo_areas->lock);
     }
     return res;
 }
@@ -3781,24 +3781,24 @@ executable_vm_area_overlap(app_pc start, app_pc end, bool have_writelock)
 {
     bool overlap;
     if (!have_writelock)
-        read_lock(&executable_areas->lock);
+        d_r_read_lock(&executable_areas->lock);
     overlap = vm_area_overlap(executable_areas, start, end);
     if (!have_writelock)
-        read_unlock(&executable_areas->lock);
+        d_r_read_unlock(&executable_areas->lock);
     return overlap;
 }
 
 void
 executable_areas_lock()
 {
-    write_lock(&executable_areas->lock);
+    d_r_write_lock(&executable_areas->lock);
 }
 
 void
 executable_areas_unlock()
 {
     ASSERT_OWN_WRITE_LOCK(true, &executable_areas->lock);
-    write_unlock(&executable_areas->lock);
+    d_r_write_unlock(&executable_areas->lock);
 }
 
 /* returns true if the passed in area overlaps any dynamo areas */
@@ -3973,14 +3973,14 @@ get_security_violation_name(dcontext_t *dcontext, app_pc addr, char *name,
         /* Fifth character is a '.' */
         name[4] = '.';
 
-        unreadable_addr = !safe_read(addr, sizeof(target_contents), &target_contents);
+        unreadable_addr = !d_r_safe_read(addr, sizeof(target_contents), &target_contents);
 
         /* if at unreadable memory see if an ASLR preferred address can be used */
         if (unreadable_addr) {
             app_pc likely_target_pc = aslr_possible_preferred_address(addr);
             if (likely_target_pc != NULL) {
-                unreadable_addr = !safe_read(likely_target_pc, sizeof(target_contents),
-                                             &target_contents);
+                unreadable_addr = !d_r_safe_read(
+                    likely_target_pc, sizeof(target_contents), &target_contents);
             } else {
                 unreadable_addr = true;
             }
@@ -4211,9 +4211,9 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
         LOG(THREAD, LOG_VMAREAS, 2, "executable areas are:\n");
         print_executable_areas(THREAD);
         LOG(THREAD, LOG_VMAREAS, 2, "future executable areas are:\n");
-        read_lock(&futureexec_areas->lock);
+        d_r_read_lock(&futureexec_areas->lock);
         print_vm_areas(futureexec_areas, THREAD);
-        read_unlock(&futureexec_areas->lock);
+        d_r_read_unlock(&futureexec_areas->lock);
     });
 
     /* case 8075: we no longer unprot .data on the violation path */
@@ -4313,19 +4313,19 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
                                     "security_violation: allowing violation #%d "
                                     "[max %d], tid=" TIDFMT "\n",
                                     do_threshold_cur, DYNAMO_OPTION(detect_mode_max),
-                                    get_thread_id());
+                                    d_r_get_thread_id());
                               },
                               { /* >= max */
                                 allow = false;
                                 LOG(GLOBAL, LOG_ALL, 1,
                                     "security_violation: reached maximum allowed %d, "
                                     "tid=" TIDFMT "\n",
-                                    DYNAMO_OPTION(detect_mode_max), get_thread_id());
+                                    DYNAMO_OPTION(detect_mode_max), d_r_get_thread_id());
                               });
         } else {
             LOG(GLOBAL, LOG_ALL, 1,
                 "security_violation: allowing violation, no max, tid=%d\n",
-                get_thread_id());
+                d_r_get_thread_id());
         }
         if (allow) {
             /* we have priority over other handling options */
@@ -4405,7 +4405,8 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
                 { /* < max */
                   LOG(GLOBAL, LOG_ALL, 1,
                       "security_violation: \t killing thread #%d [max %d], tid=%d\n",
-                      do_threshold_cur, DYNAMO_OPTION(kill_thread_max), get_thread_id());
+                      do_threshold_cur, DYNAMO_OPTION(kill_thread_max),
+                      d_r_get_thread_id());
                   /* FIXME: can't check if get_num_threads()==1 then say we're
                    * killing process because it is possible that another
                    * thread has not been scheduled yet and we wouldn't have
@@ -4504,7 +4505,7 @@ security_violation_internal_main(dcontext_t *dcontext, app_pc addr,
                violation_type == HOT_PATCH_PROTECTOR_VIOLATION);
 #        endif
         ASSERT_OWN_READ_LOCK(true, lock);
-        read_unlock(lock);
+        d_r_read_unlock(lock);
     }
 #    endif
 
@@ -4640,9 +4641,9 @@ bool
 is_in_futureexec_area(app_pc addr)
 {
     bool future;
-    read_lock(&futureexec_areas->lock);
+    d_r_read_lock(&futureexec_areas->lock);
     future = lookup_addr(futureexec_areas, addr, NULL);
-    read_unlock(&futureexec_areas->lock);
+    d_r_read_unlock(&futureexec_areas->lock);
     return future;
 }
 
@@ -5044,10 +5045,10 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
     if (USING_FUTURE_EXEC_LIST) {
         bool ok;
         bool once_only;
-        read_lock(&futureexec_areas->lock);
+        d_r_read_lock(&futureexec_areas->lock);
         ok = lookup_addr(futureexec_areas, addr, &fut_area);
         if (!ok)
-            read_unlock(&futureexec_areas->lock);
+            d_r_read_unlock(&futureexec_areas->lock);
         else {
             LOG(THREAD, LOG_INTERP | LOG_VMAREAS, 2,
                 "WARNING: pc = " PFX " is future executable, allowing\n", addr);
@@ -5066,7 +5067,7 @@ check_origins_helper(dcontext_t *dcontext, app_pc addr, app_pc *base, size_t *si
             }
             once_only = TEST(VM_ONCE_ONLY, fut_area->vm_flags);
             /* now done w/ fut_area */
-            read_unlock(&futureexec_areas->lock);
+            d_r_read_unlock(&futureexec_areas->lock);
             fut_area = NULL;
             if (is_on_stack(dcontext, addr, NULL)) {
                 /* normally futureexec regions are persistent, to allow app to
@@ -5583,13 +5584,13 @@ vm_area_fragment_self_write(dcontext_t *dcontext, app_pc tag)
         bool ok;
         vm_area_t *area = NULL;
         app_pc start, end;
-        read_lock(&executable_areas->lock);
+        d_r_read_lock(&executable_areas->lock);
         ok = lookup_addr(executable_areas, tag, &area);
         ASSERT(ok);
         /* grab fields since can't hold lock entire time */
         start = area->start;
         end = area->end;
-        read_unlock(&executable_areas->lock);
+        d_r_read_unlock(&executable_areas->lock);
         LOG(THREAD, LOG_INTERP | LOG_VMAREAS, 1,
             "WARNING: code on stack " PFX "-" PFX " @tag " PFX " written to\n", start,
             end, tag);
@@ -5718,7 +5719,7 @@ simulate_attack(dcontext_t *dcontext, app_pc pc)
 
     /* prepare for what to do next */
     if (attack || action == SIMULATE_INIT) {
-        mutex_lock(&simulate_lock);
+        d_r_mutex_lock(&simulate_lock);
         string_option_read_lock();
         tokpos = dynamo_options.simulate_at;
         if (action == SIMULATE_INIT) {
@@ -5730,7 +5731,7 @@ simulate_attack(dcontext_t *dcontext, app_pc pc)
         ASSERT(tokpos < strchr(dynamo_options.simulate_at, '\0'));
         string_option_read_unlock();
         /* FIXME: tokpos ptr is kept beyond release of lock! */
-        mutex_unlock(&simulate_lock);
+        d_r_mutex_unlock(&simulate_lock);
     }
 
     if (attack) {
@@ -5900,9 +5901,9 @@ dyngen_diagnostics(dcontext_t *dcontext, app_pc pc, app_pc base_pc, size_t size,
     char buf[MAXIMUM_SYMBOL_LENGTH];
     app_pc translated_pc;
 
-    read_lock(&futureexec_areas->lock);
+    d_r_read_lock(&futureexec_areas->lock);
     future = lookup_addr(futureexec_areas, pc, NULL);
-    read_unlock(&futureexec_areas->lock);
+    d_r_read_unlock(&futureexec_areas->lock);
     stack = is_on_stack(dcontext, pc, NULL);
 
     if (!future)
@@ -6284,7 +6285,7 @@ set_region_jit_managed(app_pc start, size_t len)
     vm_area_t *region;
 
     ASSERT(DYNAMO_OPTION(opt_jit));
-    write_lock(&executable_areas->lock);
+    d_r_write_lock(&executable_areas->lock);
     if (lookup_addr(executable_areas, start, &region)) {
         LOG(GLOBAL, LOG_VMAREAS, 1, "set_region_jit_managed(" PFX " +0x%x)\n", start,
             len);
@@ -6304,7 +6305,7 @@ set_region_jit_managed(app_pc start, size_t len)
         add_vm_area(executable_areas, start, start + len, VM_JIT_MANAGED, 0,
                     NULL _IF_DEBUG("jit-managed"));
     }
-    write_unlock(&executable_areas->lock);
+    d_r_write_unlock(&executable_areas->lock);
 }
 
 /* memory region base:base+size now has privileges prot
@@ -6465,7 +6466,7 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
                 ASSERT_CURIOSITY(ALIGNED(size, PAGE_SIZE));
                 page_base = (app_pc)PAGE_START(base);
                 page_size = ALIGN_FORWARD(base + size, PAGE_SIZE) - (size_t)page_base;
-                write_lock(&pretend_writable_areas->lock);
+                d_r_write_lock(&pretend_writable_areas->lock);
                 if (TEST(MEMPROT_WRITE, prot)) {
                     LOG(THREAD, LOG_VMAREAS, 2,
                         "adding pretend-writable region " PFX "-" PFX "\n", page_base,
@@ -6479,7 +6480,7 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
                     remove_vm_area(pretend_writable_areas, page_base,
                                    page_base + page_size, false);
                 }
-                write_unlock(&pretend_writable_areas->lock);
+                d_r_write_unlock(&pretend_writable_areas->lock);
                 LOG(THREAD, LOG_VMAREAS, 2, "turning system call into a nop\n");
 
                 if (old_memprot != NULL) {
@@ -6512,11 +6513,11 @@ app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
         /* FIXME: again we have the race -- if we could go from read to write
          * it would be a simple fix, else have to grab write up front, or check again
          */
-        write_lock(&pretend_writable_areas->lock);
+        d_r_write_lock(&pretend_writable_areas->lock);
         LOG(THREAD, LOG_VMAREAS, 2, "removing pretend-writable region " PFX "-" PFX "\n",
             base, base + size);
         remove_vm_area(pretend_writable_areas, base, base + size, false);
-        write_unlock(&pretend_writable_areas->lock);
+        d_r_write_unlock(&pretend_writable_areas->lock);
     }
 
 #ifdef PROGRAM_SHEPHERDING
@@ -7155,11 +7156,11 @@ check_thread_vm_area_cleanup(dcontext_t *dcontext, bool abort, bool clean_bb,
 {
     if (own_execareas_writelock && (!caller_execareas_writelock || abort)) {
         ASSERT(self_owns_write_lock(&executable_areas->lock));
-        write_unlock(&executable_areas->lock);
+        d_r_write_unlock(&executable_areas->lock);
 #ifdef HOT_PATCHING_INTERFACE
         if (DYNAMO_OPTION(hot_patching)) {
             ASSERT(self_owns_write_lock(hotp_get_lock()));
-            write_unlock(hotp_get_lock());
+            d_r_write_unlock(hotp_get_lock());
         }
 #endif
     }
@@ -7376,14 +7377,14 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
         instrument_module_load_trigger(pc);
 #endif
         if (!own_execareas_writelock)
-            read_lock(&executable_areas->lock);
+            d_r_read_lock(&executable_areas->lock);
         ok = lookup_addr(executable_areas, pc, &area);
         if (ok && TEST(VM_DELAY_READONLY, area->vm_flags)) {
             /* need to mark region read only for consistency
              * need to upgrade to write lock, have to release lock first
              * then recheck conditions after grabbing hotp + write lock */
             if (!own_execareas_writelock) {
-                read_unlock(&executable_areas->lock);
+                d_r_read_unlock(&executable_areas->lock);
 #ifdef HOT_PATCHING_INTERFACE
                 /* Case 8780: due to lock rank issues we must grab the hotp lock
                  * prior to the exec areas lock, as the hotp lock may be needed
@@ -7391,9 +7392,9 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
                  * not cause noticeable lock contention.
                  */
                 if (DYNAMO_OPTION(hot_patching))
-                    write_lock(hotp_get_lock());
+                    d_r_write_lock(hotp_get_lock());
 #endif
-                write_lock(&executable_areas->lock);
+                d_r_write_lock(&executable_areas->lock);
                 own_execareas_writelock = true;
                 ok = lookup_addr(executable_areas, pc, &area);
             }
@@ -7410,12 +7411,12 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
              * (if we didn't support thread-private, we would just grab write
              * lock up front and not bother with read lock).
              */
-            read_unlock(&executable_areas->lock);
+            d_r_read_unlock(&executable_areas->lock);
 #ifdef HOT_PATCHING_INTERFACE
             if (DYNAMO_OPTION(hot_patching))
-                write_lock(hotp_get_lock()); /* case 8780 -- see comments above */
+                d_r_write_lock(hotp_get_lock()); /* case 8780 -- see comments above */
 #endif
-            write_lock(&executable_areas->lock);
+            d_r_write_lock(&executable_areas->lock);
             own_execareas_writelock = true;
             ok = lookup_addr(executable_areas, pc, &area);
         }
@@ -7433,15 +7434,15 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
              */
             if (own_execareas_writelock) {
                 if (!caller_execareas_writelock) {
-                    write_unlock(&executable_areas->lock);
+                    d_r_write_unlock(&executable_areas->lock);
 #ifdef HOT_PATCHING_INTERFACE
                     if (DYNAMO_OPTION(hot_patching))
-                        write_unlock(hotp_get_lock()); /* case 8780 -- see above */
+                        d_r_write_unlock(hotp_get_lock()); /* case 8780 -- see above */
 #endif
                     own_execareas_writelock = false;
                 }
             } else
-                read_unlock(&executable_areas->lock);
+                d_r_read_unlock(&executable_areas->lock);
         }
         /* if ok we should not own the readlock but we can't assert on that */
         ASSERT(
@@ -7771,9 +7772,9 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
             if (!own_execareas_writelock) {
 #    ifdef HOT_PATCHING_INTERFACE
                 if (DYNAMO_OPTION(hot_patching))
-                    write_lock(hotp_get_lock()); /* case 8780 -- see comments above */
+                    d_r_write_lock(hotp_get_lock()); /* case 8780 -- see comments above */
 #    endif
-                write_lock(&executable_areas->lock);
+                d_r_write_lock(&executable_areas->lock);
                 own_execareas_writelock = true;
             }
         }
@@ -7805,7 +7806,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
             /* see whether this region has been cycling on and off the list due
              * to being written to -- if so, switch to sandboxing
              */
-            read_lock(&written_areas->lock);
+            d_r_read_lock(&written_areas->lock);
             ok = lookup_addr(written_areas, pc, &w_area);
             if (ok)
                 ro2s = (ro_vs_sandbox_data_t *)w_area->custom.client;
@@ -7848,7 +7849,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
                     "\tsandboxing just the page " PFX "-" PFX "\n", base_pc,
                     base_pc + size);
             }
-            read_unlock(&written_areas->lock);
+            d_r_read_unlock(&written_areas->lock);
         } else
             STATS_INC(num_ro2sandbox_other_sub);
     }
@@ -8076,7 +8077,7 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
         if (!TESTANY(VM_UNMOD_IMAGE | VM_WAS_FUTURE, area->vm_flags)) {
             LOG(GLOBAL, LOG_VMAREAS, 1,
                 "DYNGEN in %d: non-unmod-image exec area " PFX "-" PFX " %s\n",
-                get_thread_id(), area->start, area->end, area->comment);
+                d_r_get_thread_id(), area->start, area->end, area->comment);
         }
 #endif
 #ifdef PROGRAM_SHEPHERDING
@@ -8257,8 +8258,8 @@ check_in_last_thread_vm_area(dcontext_t *dcontext, app_pc pc)
      * a region and another thread decoding in that region (xref case 7103).
      */
     if (!in_last && data != NULL &&
-        safe_read(&data->last_decode_area_page_pc, sizeof(last_decode_area_page_pc),
-                  &last_decode_area_page_pc) &&
+        d_r_safe_read(&data->last_decode_area_page_pc, sizeof(last_decode_area_page_pc),
+                      &last_decode_area_page_pc) &&
         /* I think the above "safety" checks are ridiculous so not doing them here */
         data->last_decode_area_valid) {
         /* Check the last decoded pc's current page and the page after. */
@@ -8517,7 +8518,7 @@ exec_area_bounds_match(dcontext_t *dcontext, thread_data_t *data)
 {
     vm_area_vector_t *v = &data->areas;
     int i;
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     for (i = 0; i < v->length; i++) {
         vm_area_t *thread_area = &v->buf[i];
         vm_area_t *exec_area;
@@ -8540,7 +8541,7 @@ exec_area_bounds_match(dcontext_t *dcontext, thread_data_t *data)
             });
         }
     }
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
 }
 #endif /* DEBUG */
 
@@ -9002,7 +9003,7 @@ bool
 remove_from_lazy_deletion_list(dcontext_t *dcontext, fragment_t *remove)
 {
     fragment_t *f, *prev_f = NULL;
-    mutex_lock(&lazy_delete_lock);
+    d_r_mutex_lock(&lazy_delete_lock);
     /* FIXME: start using prev_vmarea?!? (case 7165) */
     for (f = todelete->lazy_delete_list; f != NULL; prev_f = f, f = f->next_vmarea) {
         if (f == remove) {
@@ -9013,11 +9014,11 @@ remove_from_lazy_deletion_list(dcontext_t *dcontext, fragment_t *remove)
             if (f == todelete->lazy_delete_tail)
                 todelete->lazy_delete_tail = prev_f;
             todelete->lazy_delete_count--;
-            mutex_unlock(&lazy_delete_lock);
+            d_r_mutex_unlock(&lazy_delete_lock);
             return true;
         }
     }
-    mutex_unlock(&lazy_delete_lock);
+    d_r_mutex_unlock(&lazy_delete_lock);
     return false;
 }
 
@@ -9039,11 +9040,11 @@ move_lazy_list_to_pending_delete(dcontext_t *dcontext)
      * to avoid this nolinking trouble.
      */
     enter_nolinking(dcontext, NULL, false /*not a cache transition*/);
-    mutex_lock(&thread_initexit_lock);
+    d_r_mutex_lock(&thread_initexit_lock);
     /* to ensure no deletion queue checks happen in the middle of our update */
-    mutex_lock(&shared_cache_flush_lock);
-    mutex_lock(&shared_delete_lock);
-    mutex_lock(&lazy_delete_lock);
+    d_r_mutex_lock(&shared_cache_flush_lock);
+    d_r_mutex_lock(&shared_delete_lock);
+    d_r_mutex_lock(&lazy_delete_lock);
     if (todelete->move_pending) {
         /* it's possible for remove_from_lazy_deletion_list to drop the count */
 #ifdef X86
@@ -9078,10 +9079,10 @@ move_lazy_list_to_pending_delete(dcontext_t *dcontext)
     } else /* should not happen */
         ASSERT(false && "race in move_lazy_list_to_pending_delete");
     DODEBUG({ check_lazy_deletion_list_consistency(); });
-    mutex_unlock(&lazy_delete_lock);
-    mutex_unlock(&shared_delete_lock);
-    mutex_unlock(&shared_cache_flush_lock);
-    mutex_unlock(&thread_initexit_lock);
+    d_r_mutex_unlock(&lazy_delete_lock);
+    d_r_mutex_unlock(&shared_delete_lock);
+    d_r_mutex_unlock(&shared_cache_flush_lock);
+    d_r_mutex_unlock(&thread_initexit_lock);
     enter_couldbelinking(dcontext, NULL, false /*not a cache transition*/);
 }
 
@@ -9104,8 +9105,8 @@ add_to_lazy_deletion_list(dcontext_t *dcontext, fragment_t *f)
     bool perform_move = false;
     ASSERT_OWN_NO_LOCKS();
     ASSERT(is_self_couldbelinking());
-    mutex_lock(&shared_cache_flush_lock); /* for consistent flushtime */
-    mutex_lock(&lazy_delete_lock);
+    d_r_mutex_lock(&shared_cache_flush_lock); /* for consistent flushtime */
+    d_r_mutex_lock(&lazy_delete_lock);
     /* We need a flushtime as we are compared to shared deletion pending
      * entries, but we don't need to inc flushtime_global.  We need a value
      * larger than any thread has already signed off on, and thus larger than
@@ -9164,8 +9165,8 @@ add_to_lazy_deletion_list(dcontext_t *dcontext, fragment_t *f)
         perform_move = true;
         todelete->move_pending = true;
     }
-    mutex_unlock(&lazy_delete_lock);
-    mutex_unlock(&shared_cache_flush_lock);
+    d_r_mutex_unlock(&lazy_delete_lock);
+    d_r_mutex_unlock(&shared_cache_flush_lock);
     if (perform_move) {
         /* hit threshold -- move to real pending deletion entry */
         /* had to release lazy_delete_lock and re-grab for proper rank order */
@@ -9179,7 +9180,7 @@ static void
 check_lazy_deletion_list(dcontext_t *dcontext, uint flushtime)
 {
     fragment_t *f, *next_f;
-    mutex_lock(&lazy_delete_lock);
+    d_r_mutex_lock(&lazy_delete_lock);
     LOG(THREAD, LOG_VMAREAS, 3, "checking lazy list @ timestamp %u\n", flushtime);
     for (f = todelete->lazy_delete_list; f != NULL; f = next_f) {
         next_f = f->next_vmarea; /* may be freed so cache now */
@@ -9224,7 +9225,7 @@ check_lazy_deletion_list(dcontext_t *dcontext, uint flushtime)
                                  "Lazy deletion list after freeing fragments:\n");
     });
     DODEBUG({ check_lazy_deletion_list_consistency(); });
-    mutex_unlock(&lazy_delete_lock);
+    d_r_mutex_unlock(&lazy_delete_lock);
 }
 
 /* Prepares a list of shared fragments for deletion..
@@ -9264,11 +9265,11 @@ unlink_fragments_for_deletion(dcontext_t *dcontext, fragment_t *list,
     }
     release_recursive_lock(&change_linking_lock);
 
-    mutex_lock(&shared_delete_lock);
+    d_r_mutex_lock(&shared_delete_lock);
     /* add area's fragments as a new entry in the pending deletion list */
     add_to_pending_list(dcontext, list, pending_delete_threads,
                         flushtime_global _IF_DEBUG(NULL) _IF_DEBUG(NULL));
-    mutex_unlock(&shared_delete_lock);
+    d_r_mutex_unlock(&shared_delete_lock);
     STATS_ADD(list_entries_unlinked_for_deletion, num);
     return num;
 }
@@ -9287,7 +9288,7 @@ vm_area_unlink_fragments(dcontext_t *dcontext, app_pc start, app_pc end,
     int num = 0, i;
     if (data == shared_data) {
         /* we also need to add to the deletion list */
-        mutex_lock(&shared_delete_lock);
+        d_r_mutex_lock(&shared_delete_lock);
 
         acquire_recursive_lock(&change_linking_lock);
 
@@ -9459,7 +9460,7 @@ vm_area_unlink_fragments(dcontext_t *dcontext, app_pc start, app_pc end,
     if (data == shared_data) {
         SHARED_VECTOR_RWLOCK(&data->areas, write, unlock);
         release_recursive_lock(&change_linking_lock);
-        mutex_unlock(&shared_delete_lock);
+        d_r_mutex_unlock(&shared_delete_lock);
     }
 
     LOG(thread_log, LOG_FRAGMENT | LOG_VMAREAS, 2, "  Unlinked %d frags\n", num);
@@ -9526,7 +9527,7 @@ vm_area_check_shared_pending(dcontext_t *dcontext, fragment_t *was_I_flushed)
     LOG(THREAD, LOG_FRAGMENT | LOG_VMAREAS, 2,
         "thread " TIDFMT " (flushtime %d) walking pending deletion list "
         "(was_I_flushed==F%d)\n",
-        get_thread_id(),
+        d_r_get_thread_id(),
         dcontext == GLOBAL_DCONTEXT ? flushtime_global
                                     : get_flushtime_last_update(dcontext),
         (was_I_flushed == NULL) ? -1 : was_I_flushed->id);
@@ -9536,7 +9537,7 @@ vm_area_check_shared_pending(dcontext_t *dcontext, fragment_t *was_I_flushed)
      * value when adding to the shared deletion list (currently flushers
      * and lazy list transfers).
      */
-    mutex_lock(&shared_cache_flush_lock);
+    d_r_mutex_lock(&shared_cache_flush_lock);
 
     /* check if was_I_flushed has been flushed, prior to dec ref count and
      * allowing anyone to be fully freed
@@ -9557,7 +9558,7 @@ vm_area_check_shared_pending(dcontext_t *dcontext, fragment_t *was_I_flushed)
         last_exit_deleted(dcontext);
     }
 
-    mutex_lock(&shared_delete_lock);
+    d_r_mutex_lock(&shared_delete_lock);
     for (pend = todelete->shared_delete; pend != NULL; pend = pend_nxt) {
         bool delete_area = false;
         pend_nxt = pend->next;
@@ -9704,18 +9705,18 @@ vm_area_check_shared_pending(dcontext_t *dcontext, fragment_t *was_I_flushed)
         /* reset_every_nth_pending relies on this */
         ASSERT(todelete->shared_delete_count == 0);
     }
-    mutex_unlock(&shared_delete_lock);
+    d_r_mutex_unlock(&shared_delete_lock);
     STATS_TRACK_MAX(num_shared_flush_maxpending, i);
 
     /* last_area cleared in vm_area_unlink_fragments */
     LOG(THREAD, LOG_FRAGMENT | LOG_VMAREAS, 2,
-        "thread " TIDFMT " done walking pending list @flushtime %d\n", get_thread_id(),
-        flushtime_global);
+        "thread " TIDFMT " done walking pending list @flushtime %d\n",
+        d_r_get_thread_id(), flushtime_global);
     if (dcontext != GLOBAL_DCONTEXT) {
         /* update thread timestamp */
         set_flushtime_last_update(dcontext, flushtime_global);
     }
-    mutex_unlock(&shared_cache_flush_lock);
+    d_r_mutex_unlock(&shared_cache_flush_lock);
 
     LOG(THREAD, LOG_FRAGMENT | LOG_VMAREAS, 2, "  Flushed %d frags\n", num);
     return not_flushed;
@@ -9928,9 +9929,9 @@ vm_area_allsynch_flush_fragments(dcontext_t *dcontext, dcontext_t *del_dcontext,
          */
 #ifdef HOT_PATCHING_INTERFACE
         if (DYNAMO_OPTION(hot_patching))
-            read_lock(hotp_get_lock()); /* case 9970: rank hotp < exec_areas */
+            d_r_read_lock(hotp_get_lock()); /* case 9970: rank hotp < exec_areas */
 #endif
-        read_lock(&executable_areas->lock); /* no need to write */
+        d_r_read_lock(&executable_areas->lock); /* no need to write */
         for (i = 0; i < executable_areas->length; i++) {
             if (TEST(FRAG_COARSE_GRAIN, executable_areas->buf[i].frag_flags) &&
                 start < executable_areas->buf[i].end &&
@@ -9979,10 +9980,10 @@ vm_area_allsynch_flush_fragments(dcontext_t *dcontext, dcontext_t *del_dcontext,
                 }
             }
         }
-        read_unlock(&executable_areas->lock);
+        d_r_read_unlock(&executable_areas->lock);
 #ifdef HOT_PATCHING_INTERFACE
         if (DYNAMO_OPTION(hot_patching))
-            read_unlock(hotp_get_lock());
+            d_r_read_unlock(hotp_get_lock());
 #endif
     }
 
@@ -10124,14 +10125,14 @@ coarse_region_should_persist(dcontext_t *dcontext, coarse_info_t *info)
     /* Must hold lock to get size but ok for size to change afterward;
      * normal usage has all threads synched */
     if (!info->persisted) {
-        mutex_lock(&info->lock);
+        d_r_mutex_lock(&info->lock);
         cache_size += coarse_frozen_cache_size(dcontext, info);
-        mutex_unlock(&info->lock);
+        d_r_mutex_unlock(&info->lock);
     }
     if (info->non_frozen != NULL) {
-        mutex_lock(&info->non_frozen->lock);
+        d_r_mutex_lock(&info->non_frozen->lock);
         cache_size += coarse_frozen_cache_size(dcontext, info->non_frozen);
-        mutex_unlock(&info->non_frozen->lock);
+        d_r_mutex_unlock(&info->non_frozen->lock);
     }
     LOG(THREAD, LOG_FRAGMENT | LOG_VMAREAS, 2,
         "\tconsidering persisting coarse unit %s with cache size %d\n", info->module,
@@ -10313,7 +10314,7 @@ vm_area_coarse_units_freeze(bool in_place)
     acquire_recursive_lock(&change_linking_lock);
 #ifdef HOT_PATCHING_INTERFACE
     if (DYNAMO_OPTION(hot_patching))
-        read_lock(hotp_get_lock());
+        d_r_read_lock(hotp_get_lock());
 #endif
     /* We would grab executable_areas_lock but coarse_unit_freeze() grabs
      * change_linking_lock and coarse_info_lock, both of higher rank.  We could
@@ -10333,7 +10334,7 @@ vm_area_coarse_units_freeze(bool in_place)
     }
 #ifdef HOT_PATCHING_INTERFACE
     if (DYNAMO_OPTION(hot_patching))
-        read_unlock(hotp_get_lock());
+        d_r_read_unlock(hotp_get_lock());
 #endif
     release_recursive_lock(&change_linking_lock);
 }
@@ -10429,7 +10430,7 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
     ASSERT(ok);
     SYSLOG_INTERNAL_WARNING_ONCE("writing to executable region.");
     STATS_INC(num_write_faults);
-    read_lock(&executable_areas->lock);
+    d_r_read_lock(&executable_areas->lock);
     lookup_addr(executable_areas, (app_pc)target, &a);
     if (a == NULL) {
         LOG(THREAD, LOG_VMAREAS, 1,
@@ -10456,7 +10457,7 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
             ((prot & MEMPROT_EXEC) != 0) ? "E" : "", target, instr_cache_pc,
             instr_app_pc);
     }
-    read_unlock(&executable_areas->lock);
+    d_r_read_unlock(&executable_areas->lock);
 #ifdef DGC_DIAGNOSTICS
     DOLOG(1, LOG_VMAREAS, {
         /* it's hard to locate frag owning an app pc in the cache, so we wait until
@@ -10727,7 +10728,7 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
          * at which point we'll just add the page
          */
         ro_vs_sandbox_data_t *ro2s;
-        write_lock(&written_areas->lock);
+        d_r_write_lock(&written_areas->lock);
         /* use the add routine to lookup if present, add if not */
         add_written_area(written_areas, target, (app_pc)PAGE_START(target),
                          (app_pc)PAGE_START(target + opnd_size) + PAGE_SIZE, &a);
@@ -10740,7 +10741,7 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
             LOG(GLOBAL, LOG_VMAREAS, 2, "\nwritten areas:\n");
             print_vm_areas(written_areas, GLOBAL);
         });
-        write_unlock(&written_areas->lock);
+        d_r_write_unlock(&written_areas->lock);
     }
 
     if (
@@ -10819,12 +10820,12 @@ get_selfmod_exec_counter(app_pc tag)
     ro_vs_sandbox_data_t *ro2s;
     uint *counter;
     bool ok;
-    read_lock(&written_areas->lock);
+    d_r_read_lock(&written_areas->lock);
     ok = lookup_addr(written_areas, tag, &area);
     if (!ok) {
-        read_unlock(&written_areas->lock);
-        read_lock(&executable_areas->lock);
-        write_lock(&written_areas->lock);
+        d_r_read_unlock(&written_areas->lock);
+        d_r_read_lock(&executable_areas->lock);
+        d_r_write_lock(&written_areas->lock);
         ok = lookup_addr(executable_areas, tag, &area);
         ASSERT(ok && area != NULL);
         /* FIXME: do this addition whenever add new exec area marked as
@@ -10847,13 +10848,13 @@ get_selfmod_exec_counter(app_pc tag)
          * the heap.  add_written_area already asserts but we double-check here.
          */
         ASSERT(ALIGNED(counter, sizeof(uint)));
-        write_unlock(&written_areas->lock);
-        read_unlock(&executable_areas->lock);
+        d_r_write_unlock(&written_areas->lock);
+        d_r_read_unlock(&executable_areas->lock);
     } else {
         ASSERT(ok && area != NULL);
         ro2s = (ro_vs_sandbox_data_t *)area->custom.client;
         counter = &ro2s->selfmod_execs;
-        read_unlock(&written_areas->lock);
+        d_r_read_unlock(&written_areas->lock);
     }
     /* ref to counter will be accessed in-cache w/o read lock but
      * written_areas is never merged and counter won't be freed until
@@ -10879,14 +10880,14 @@ vm_area_selfmod_check_clear_exec_count(dcontext_t *dcontext, fragment_t *f)
      * lock since we read and write to it from the cache.  Should change to read lock
      * if contention ever becomes an issue.  Note that we would then have to later
      * grab the write lock if we need to write to ro2s->written_count below. */
-    write_lock(&written_areas->lock);
+    d_r_write_lock(&written_areas->lock);
 
     ok = lookup_addr(written_areas, f->tag, &written_area);
     if (ok) {
         ro2s = (ro_vs_sandbox_data_t *)written_area->custom.client;
     } else {
         /* never had instrumentation */
-        write_unlock(&written_areas->lock);
+        d_r_write_unlock(&written_areas->lock);
         return false;
     }
     if (ro2s->selfmod_execs < DYNAMO_OPTION(sandbox2ro_threshold)) {
@@ -10901,7 +10902,7 @@ vm_area_selfmod_check_clear_exec_count(dcontext_t *dcontext, fragment_t *f)
          * 4 byte write is atomic on the architectures we support. */
         ASSERT(sizeof(ro2s->selfmod_execs) == 4 && ALIGNED(&(ro2s->selfmod_execs), 4));
         ro2s->selfmod_execs = 0;
-        write_unlock(&written_areas->lock);
+        d_r_write_unlock(&written_areas->lock);
         return false;
     }
 
@@ -10947,7 +10948,7 @@ vm_area_selfmod_check_clear_exec_count(dcontext_t *dcontext, fragment_t *f)
         print_vm_areas(written_areas, THREAD);
     });
 
-    write_unlock(&written_areas->lock);
+    d_r_write_unlock(&written_areas->lock);
 
     /* Convert the selfmod region to a ro region.
      * FIXME case 8161: should we flush and make ro the executable area,
@@ -11037,11 +11038,11 @@ mark_unload_start(app_pc module_base, size_t module_size)
     /* we may have a race, or a thread killed during unload syscall,
      * either way we just mark our last region on top of the old one
      */
-    mutex_lock(&last_deallocated_lock);
+    d_r_mutex_lock(&last_deallocated_lock);
     last_deallocated->last_unload_base = module_base;
     last_deallocated->last_unload_size = module_size;
     last_deallocated->unload_in_progress = true;
-    mutex_unlock(&last_deallocated_lock);
+    d_r_mutex_unlock(&last_deallocated_lock);
 }
 
 void
@@ -11127,7 +11128,7 @@ mark_unload_end(app_pc module_base)
      * the flag is atomic even without it.
      * is_unreadable_or_currently_unloaded_region() when used in
      * proper order doesn't need to synchronize with this lock either */
-    mutex_lock(&last_deallocated_lock);
+    d_r_mutex_lock(&last_deallocated_lock);
 
     /* note, we mark_unload_start on MEM_IMAGE but mark_unload_end on
      * MEM_MAPPED as well.  Note base doesn't have to match as long as
@@ -11147,7 +11148,7 @@ mark_unload_end(app_pc module_base)
 
     /* multiple racy unmaps can't be handled simultaneously anyways */
     last_deallocated->unload_in_progress = false;
-    mutex_unlock(&last_deallocated_lock);
+    d_r_mutex_unlock(&last_deallocated_lock);
 }
 
 bool
@@ -11158,7 +11159,7 @@ is_in_last_unloaded_region(app_pc pc)
         return false;
     ASSERT(DYNAMO_OPTION(unloaded_target_exception));
 
-    mutex_lock(&last_deallocated_lock);
+    d_r_mutex_lock(&last_deallocated_lock);
     /* if we are in such a tight race that we're no longer
      * last_deallocated->unload_in_progress we can still use the
      * already unloaded module
@@ -11166,7 +11167,7 @@ is_in_last_unloaded_region(app_pc pc)
     if ((pc < last_deallocated->last_unload_base) ||
         (pc >= (last_deallocated->last_unload_base + last_deallocated->last_unload_size)))
         in_last = false;
-    mutex_unlock(&last_deallocated_lock);
+    d_r_mutex_unlock(&last_deallocated_lock);
     return in_last;
 }
 
@@ -11302,7 +11303,7 @@ apc_thread_policy_helper(app_pc *apc_target_location, /* IN/OUT */
         return; /* not a match */
     }
 
-    if (safe_read(injected_target, sizeof(injected_code), &injected_code)) {
+    if (d_r_safe_read(injected_target, sizeof(injected_code), &injected_code)) {
         LOG(GLOBAL, LOG_ASYNCH, 2,
             "ASYNCH intercepted APC: APC pc=" PFX ", APC code=" PFX " %s\n",
             injected_target, injected_code,

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -509,9 +509,9 @@ if (AFTER_INTERCEPT_TAKE_OVER || AFTER_INTERCEPT_TAKE_OVER_SINGLE_SHOT
       call asynch_take_over
       # should never reach here
       push $0
-      push $-3  # internal_error will report -3 as line number
+      push $-3  # d_r_internal_error will report -3 as line number
       push $0
-      call internal_error
+      call d_r_internal_error
 endif
 if (AFTER_INTERCEPT_DYNAMIC_DECISION && alternate target provided)
   let_go_alt:
@@ -1277,7 +1277,7 @@ emit_intercept_code(dcontext_t *dcontext, byte *pc, intercept_function_t callee,
         IF_DEBUG(direct =)
         dr_insert_call_ex(dcontext, &ilist, NULL,
                           /* we're not in vmcode, so avoid indirect call */
-                          pc, (app_pc)internal_error, 3, OPND_CREATE_INTPTR(0),
+                          pc, (app_pc)d_r_internal_error, 3, OPND_CREATE_INTPTR(0),
                           OPND_CREATE_INT32(-3), OPND_CREATE_INTPTR(0));
         ASSERT(direct);
 #endif

--- a/core/win32/diagnost.c
+++ b/core/win32/diagnost.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -487,12 +487,12 @@ report_internal_data_structures(IN file_t diagnostics_file,
     }
 #endif
 
-    mutex_lock(&reg_mutex);
+    d_r_mutex_lock(&reg_mutex);
     get_dynamo_options_string(&dynamo_options, optstring_buf,
                               BUFFER_SIZE_ELEMENTS(optstring_buf), true);
     NULL_TERMINATE_BUFFER(optstring_buf);
     print_file(diagnostics_file, "option string = \"%s\"\n", optstring_buf);
-    mutex_unlock(&reg_mutex);
+    d_r_mutex_unlock(&reg_mutex);
 
     DOLOG(1, LOG_ALL, {
         uchar test_buf[UCHAR_MAX + 2];
@@ -761,7 +761,7 @@ report_current_process(IN file_t diagnostics_file, IN PSYSTEM_PROCESSES sp,
      */
     ASSERT(!report_thread_list || violation_type >= 0 /*non-violation*/);
     if (report_thread_list) {
-        mutex_lock(&thread_initexit_lock);
+        d_r_mutex_lock(&thread_initexit_lock);
         get_list_of_threads(&threads, &num_threads);
         for (i = 0; i < num_threads; i++) {
             if (threads[i]->dcontext != NULL) {
@@ -769,7 +769,7 @@ report_current_process(IN file_t diagnostics_file, IN PSYSTEM_PROCESSES sp,
                               conservative);
             }
         }
-        mutex_unlock(&thread_initexit_lock);
+        d_r_mutex_unlock(&thread_initexit_lock);
         if (couldbelinking) {
             enter_couldbelinking(get_thread_private_dcontext(), NULL,
                                  false /*not a cache transition*/);
@@ -777,8 +777,8 @@ report_current_process(IN file_t diagnostics_file, IN PSYSTEM_PROCESSES sp,
         global_heap_free(
             threads, num_threads * sizeof(thread_record_t *) HEAPACCT(ACCT_THREAD_MGT));
     } else {
-        report_thread(diagnostics_file, 0, get_thread_id(), get_thread_private_dcontext(),
-                      conservative);
+        report_thread(diagnostics_file, 0, d_r_get_thread_id(),
+                      get_thread_private_dcontext(), conservative);
     }
 
     print_file(diagnostics_file, "</thread-list>\n</current-process>\n\n");
@@ -1308,7 +1308,7 @@ report_diagnostics_common(file_t diagnostics_file, const char *message, const ch
 
     report_system_diagnostics(diagnostics_file);
 
-    mutex_lock(&reg_mutex);
+    d_r_mutex_lock(&reg_mutex);
     print_file(diagnostics_file, "<registry-settings>\n<![CDATA[\n");
     report_registry_settings(diagnostics_file, DYNAMORIO_REGISTRY_BASE,
                              (DIAGNOSTICS_REG_ALLKEYS | DIAGNOSTICS_REG_ALLSUBKEYS |
@@ -1339,7 +1339,7 @@ report_diagnostics_common(file_t diagnostics_file, const char *message, const ch
     print_file(diagnostics_file, "]]>\n</registry-settings>\n\n");
     report_ntdll_info(diagnostics_file);
     report_autostart_programs(diagnostics_file);
-    mutex_unlock(&reg_mutex);
+    d_r_mutex_unlock(&reg_mutex);
 
     report_internal_data_structures(diagnostics_file, violation_type);
 

--- a/core/win32/drwinapi/kernel32_mem.c
+++ b/core/win32/drwinapi/kernel32_mem.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2017 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -254,14 +254,14 @@ redirect_LocalFree(__deref HLOCAL hMem)
     if (hMem == NULL)
         return NULL;
     hdr = local_header_from_handle(hMem);
-    mutex_lock(&localheap_lock);
+    d_r_mutex_lock(&localheap_lock);
     /* XXX: supposed to raise debug msg + bp if freeing locked object */
     if (hdr->alloc != NULL) {
         ASSERT(TEST(LMEM_MOVEABLE, hdr->flags));
         redirect_RtlFreeHeap(heap, HEAP_NO_SERIALIZE, hdr->alloc);
     }
     redirect_RtlFreeHeap(heap, HEAP_NO_SERIALIZE, hdr);
-    mutex_unlock(&localheap_lock);
+    d_r_mutex_unlock(&localheap_lock);
     return NULL;
 }
 
@@ -275,7 +275,7 @@ redirect_LocalReAlloc(__in HLOCAL hMem, __in SIZE_T uBytes, __in UINT uFlags)
     uint rtl_flags = HEAP_NO_SERIALIZE | HEAP_CREATE_ENABLE_EXECUTE;
     if (TEST(LMEM_ZEROINIT, uFlags))
         rtl_flags |= HEAP_ZERO_MEMORY;
-    mutex_lock(&localheap_lock);
+    d_r_mutex_lock(&localheap_lock);
     if (TEST(LMEM_MODIFY, uFlags)) {
         /* no realloc, just update flags */
         if ((uFlags & 0xffff0000) != 0 || /* flags should be in ushort range */
@@ -335,7 +335,7 @@ redirect_LocalReAlloc(__in HLOCAL hMem, __in SIZE_T uBytes, __in UINT uFlags)
         }
     }
 redirect_LocalReAlloc_done:
-    mutex_unlock(&localheap_lock);
+    d_r_mutex_unlock(&localheap_lock);
     return res;
 }
 
@@ -345,14 +345,14 @@ redirect_LocalLock(__in HLOCAL hMem)
 {
     LPVOID res = NULL;
     local_header_t *hdr = local_header_from_handle(hMem);
-    mutex_lock(&localheap_lock);
+    d_r_mutex_lock(&localheap_lock);
     if (TEST(LMEM_MOVEABLE, hdr->flags))
         hdr->lock_count++;
     if (hdr->alloc != NULL)
         res = (LPVOID)(hdr->alloc + 1);
     else
         res = (LPVOID)hMem;
-    mutex_unlock(&localheap_lock);
+    d_r_mutex_unlock(&localheap_lock);
     return res;
 }
 
@@ -373,7 +373,7 @@ redirect_LocalUnlock(__in HLOCAL hMem)
 {
     BOOL res = FALSE;
     local_header_t *hdr = local_header_from_handle(hMem);
-    mutex_lock(&localheap_lock);
+    d_r_mutex_lock(&localheap_lock);
     if (hdr->lock_count == 0) {
         res = FALSE;
         set_last_error(ERROR_NOT_LOCKED);
@@ -385,7 +385,7 @@ redirect_LocalUnlock(__in HLOCAL hMem)
         } else
             res = TRUE;
     }
-    mutex_unlock(&localheap_lock);
+    d_r_mutex_unlock(&localheap_lock);
     return res;
 }
 
@@ -396,7 +396,7 @@ redirect_LocalSize(__in HLOCAL hMem)
     SIZE_T res = 0;
     local_header_t *hdr = local_header_from_handle(hMem);
     HANDLE heap = redirect_GetProcessHeap();
-    mutex_lock(&localheap_lock);
+    d_r_mutex_lock(&localheap_lock);
     if (hdr->alloc != NULL) {
         ASSERT(TEST(LMEM_MOVEABLE, hdr->flags));
         res = redirect_RtlSizeHeap(heap, 0, (byte *)hdr->alloc);
@@ -406,7 +406,7 @@ redirect_LocalSize(__in HLOCAL hMem)
         ASSERT(res >= sizeof(local_header_t));
         res -= sizeof(local_header_t);
     }
-    mutex_unlock(&localheap_lock);
+    d_r_mutex_unlock(&localheap_lock);
     return res;
 }
 
@@ -416,14 +416,14 @@ redirect_LocalFlags(__in HLOCAL hMem)
     UINT res = 0;
     local_header_t *hdr = local_header_from_handle(hMem);
     HANDLE heap = redirect_GetProcessHeap();
-    mutex_lock(&localheap_lock);
+    d_r_mutex_lock(&localheap_lock);
     res |= (hdr->lock_count & LMEM_LOCKCOUNT);
     if ((hdr->alloc != NULL &&
          redirect_RtlSizeHeap(heap, 0, (byte *)hdr->alloc) == sizeof(local_header_t)) ||
         (hdr->alloc == NULL &&
          redirect_RtlSizeHeap(heap, 0, (byte *)hdr) == sizeof(local_header_t)))
         res |= LMEM_DISCARDABLE;
-    mutex_unlock(&localheap_lock);
+    d_r_mutex_unlock(&localheap_lock);
     return res;
 }
 

--- a/core/win32/drwinapi/kernel32_proc.c
+++ b/core/win32/drwinapi/kernel32_proc.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2017 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -133,7 +133,7 @@ DWORD
 WINAPI
 redirect_GetCurrentThreadId(VOID)
 {
-    return (DWORD)get_thread_id();
+    return (DWORD)d_r_get_thread_id();
 }
 
 /***************************************************************************

--- a/core/win32/eventlog.c
+++ b/core/win32/eventlog.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -807,7 +807,7 @@ eventlog_init()
     /* may have already been allocated for early syslogs */
     eventlog_alloc();
 
-    mutex_lock(&shared_eventlog_connection->eventlog_mutex);
+    d_r_mutex_lock(&shared_eventlog_connection->eventlog_mutex);
     if (!shared_eventlog_connection->eventlog_pipe) {
         /* initialize thread shared connection */
         res = eventlog_register(shared_eventlog_connection);
@@ -815,18 +815,18 @@ eventlog_init()
             LOG(GLOBAL, LOG_TOP, 1, "WARNING: Could not register event source.\n");
         }
     }
-    mutex_unlock(&shared_eventlog_connection->eventlog_mutex);
+    d_r_mutex_unlock(&shared_eventlog_connection->eventlog_mutex);
 }
 
 void
 eventlog_fast_exit(void)
 {
     uint res = 1; /* maybe nothing to do */
-    mutex_lock(&shared_eventlog_connection->eventlog_mutex);
+    d_r_mutex_lock(&shared_eventlog_connection->eventlog_mutex);
     if (shared_eventlog_connection->eventlog_pipe)
         res = eventlog_deregister(shared_eventlog_connection);
     shared_eventlog_connection->eventlog_pipe = 0;
-    mutex_unlock(&shared_eventlog_connection->eventlog_mutex);
+    d_r_mutex_unlock(&shared_eventlog_connection->eventlog_mutex);
     DOLOG(1, LOG_TOP, if (!res) {
         LOG(GLOBAL, LOG_TOP, 1, "WARNING: DeregisterEventSource failed.\n");
     });
@@ -873,7 +873,7 @@ os_eventlog(syslog_event_type_t priority, uint message_id, uint substitutions_nu
 
     if (shared_eventlog_connection == NULL)
         eventlog_alloc();
-    mutex_lock(&shared_eventlog_connection->eventlog_mutex);
+    d_r_mutex_lock(&shared_eventlog_connection->eventlog_mutex);
     if (!shared_eventlog_connection->eventlog_pipe) {
         /* Retry to open connection, since may have been unable
            to do that early on for system services started before EventLog */
@@ -896,7 +896,7 @@ os_eventlog(syslog_event_type_t priority, uint message_id, uint substitutions_nu
                               message_id, NULL, /* pSID */
                               (WORD)substitutions_num, size_data, arguments, raw_data);
     }
-    mutex_unlock(&shared_eventlog_connection->eventlog_mutex);
+    d_r_mutex_unlock(&shared_eventlog_connection->eventlog_mutex);
 
     DOLOG(1, LOG_TOP, if (!res) {
         LOG(GLOBAL, LOG_TOP, 1, "WARNING: Could not report event 0x%x. \n", message_id);

--- a/core/win32/inject_shared.c
+++ b/core/win32/inject_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -66,7 +66,7 @@
 /* avoid mistake of lower-case assert */
 #    define assert assert_no_good_use_ASSERT_instead
 extern void
-internal_error(const char *file, int line, const char *msg);
+d_r_internal_error(const char *file, int line, const char *msg);
 #    ifdef DEBUG
 extern void
 display_error(char *msg);
@@ -78,11 +78,11 @@ display_error(char *msg);
 #            ifdef INTERNAL
 #                define ASSERT(x) \
                     if (!(x))     \
-                    internal_error(__FILE__, __LINE__, #x)
+                    d_r_internal_error(__FILE__, __LINE__, #x)
 #            else
 #                define ASSERT(x) \
                     if (!(x))     \
-                    internal_error(__FILE__, __LINE__, "")
+                    d_r_internal_error(__FILE__, __LINE__, "")
 #            endif /* INTERNAL */
 #        elif !defined(NOT_DYNAMORIO_CORE)
 #            define display_warning SYSLOG_INTERNAL_WARNING

--- a/core/win32/injector.c
+++ b/core/win32/injector.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -113,20 +113,20 @@ static double wallclock;            /* in seconds */
 /* avoid mistake of lower-case assert */
 #define assert assert_no_good_use_ASSERT_instead
 void
-internal_error(const char *file, int line, const char *msg);
+d_r_internal_error(const char *file, int line, const char *msg);
 #undef ASSERT
 #ifdef DEBUG
 void
 display_error(char *msg);
 #    ifdef INTERNAL
-#        define ASSERT(x)                               \
-            if (!(x)) {                                 \
-                internal_error(__FILE__, __LINE__, #x); \
+#        define ASSERT(x)                                   \
+            if (!(x)) {                                     \
+                d_r_internal_error(__FILE__, __LINE__, #x); \
             }
 #    else
-#        define ASSERT(x)                               \
-            if (!(x)) {                                 \
-                internal_error(__FILE__, __LINE__, ""); \
+#        define ASSERT(x)                                   \
+            if (!(x)) {                                     \
+                d_r_internal_error(__FILE__, __LINE__, ""); \
             }
 #    endif /* INTERNAL */
 #else
@@ -161,7 +161,7 @@ display_error_helper(wchar_t *msg)
 }
 
 void
-internal_error(const char *file, int line, const char *expr)
+d_r_internal_error(const char *file, int line, const char *expr)
 {
 #ifdef INTERNAL
 #    define FILENAME_LENGTH L""

--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -2141,7 +2141,7 @@ privload_set_security_cookie(privmod_t *mod)
     /* 64-bit seems to sign-extend so we use ptr_int_t */
     cookie = (ptr_int_t)(time100ns >> 32) ^ (ptr_int_t)time100ns;
     cookie ^= get_process_id();
-    cookie ^= get_thread_id();
+    cookie ^= d_r_get_thread_id();
     cookie ^= get_tick_count();
     nt_query_performance_counter(&perfctr, NULL);
 #ifdef X64

--- a/core/win32/module.c
+++ b/core/win32/module.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -274,13 +274,13 @@ print_module_list(module_info_vector_t *v)
         "print_module_list(" PFX ") capacity=%d, length=%d, lock=%d, buf=" PFX, v,
         v->capacity, v->length, v->lock, v->buf);
 
-    mutex_lock(&v->lock);
+    d_r_mutex_lock(&v->lock);
     for (i = 0; i < v->length; i++) {
         LOG(GLOBAL, LOG_SYMBOLS, 3, "  " PFX "-" PFX " %s, %d exports [" SZFMT " size]\n",
             v->buf[i].start, v->buf[i].end, v->buf[i].module_name, v->buf[i].exports_num,
             v->buf[i].exports_size);
     }
-    mutex_unlock(&v->lock);
+    d_r_mutex_unlock(&v->lock);
 }
 
 /* For binary search */
@@ -354,7 +354,7 @@ module_info_create(module_info_vector_t *v, app_pc start, app_pc end, char *modu
         new_module.exports_table = NULL;
     }
 
-    mutex_lock(&v->lock);
+    d_r_mutex_lock(&v->lock);
     /* FIXME: the question is what to do when an overlap occurs.
      * If we assume that we should have removed the references from an old DLL.
      * A possibly new DLL overlapping the same range should not show up,
@@ -384,7 +384,7 @@ module_info_create(module_info_vector_t *v, app_pc start, app_pc end, char *modu
 
     v->buf[i] = new_module;
     v->length++;
-    mutex_unlock(&v->lock);
+    d_r_mutex_unlock(&v->lock);
     DOLOG(3, LOG_SYMBOLS, { print_module_list(v); });
 
     /* we can not return &v->buf[i] since buf may get realloc-ed, or buf[i] may be
@@ -402,7 +402,7 @@ remove_module_info_vector(module_info_vector_t *v, app_pc start, app_pc end)
     export_entry_t *exports_table = NULL;
     size_t exports_size = 0;
 
-    mutex_lock(&v->lock);
+    d_r_mutex_lock(&v->lock);
     /* linear search, we don't have a find_predecessor on module_info_t's to get i */
     for (i = 0; i < v->length; i++) {
         if (start == v->buf[i].start && end == v->buf[i].end) {
@@ -417,7 +417,7 @@ remove_module_info_vector(module_info_vector_t *v, app_pc start, app_pc end)
     ASSERT_CURIOSITY(exports_table); /* curiosity */
     if (!exports_table) {
         /* it could have disappeared since we last checked */
-        mutex_unlock(&v->lock);
+        d_r_mutex_unlock(&v->lock);
         return;
     }
 
@@ -425,7 +425,7 @@ remove_module_info_vector(module_info_vector_t *v, app_pc start, app_pc end)
     for (j = i + 1; j < v->length; j++)
         v->buf[j - 1] = v->buf[j];
     v->length--;
-    mutex_unlock(&v->lock);
+    d_r_mutex_unlock(&v->lock);
 
     if (exports_size > 0) {
         global_heap_free(exports_table,
@@ -443,9 +443,9 @@ int
 remove_module_info(app_pc start, size_t size)
 {
     module_info_t *pmod;
-    mutex_lock(&process_module_vector.lock);
+    d_r_mutex_lock(&process_module_vector.lock);
     pmod = lookup_module_info(&process_module_vector, start);
-    mutex_unlock(&process_module_vector.lock);
+    d_r_mutex_unlock(&process_module_vector.lock);
 
     if (!pmod) { /* FIXME: need a real overlap check */
         LOG(GLOBAL, LOG_SYMBOLS, 2,
@@ -469,7 +469,7 @@ module_cleanup(void)
     int i;
     export_entry_t *exports_table = NULL;
     size_t exports_size = 0;
-    mutex_lock(&v->lock);
+    d_r_mutex_lock(&v->lock);
     /* linear search, we don't have a find_predecessor on module_info_t's to get i */
     for (i = 0; i < v->length; i++) {
         exports_table = v->buf[i].exports_table;
@@ -487,7 +487,7 @@ module_cleanup(void)
     v->buf = NULL;
     v->capacity = 0;
     v->length = 0;
-    mutex_unlock(&v->lock);
+    d_r_mutex_unlock(&v->lock);
 }
 
 void
@@ -570,7 +570,8 @@ print_symbolic_address(app_pc tag, char *buf, int max_chars, bool exact_only)
     if (under_internal_exception()) {
         pmod = NULL;
     } else {
-        mutex_lock(&process_module_vector.lock); /* FIXME: can be a shared read lock */
+        d_r_mutex_lock(
+            &process_module_vector.lock); /* FIXME: can be a shared read lock */
         {
             pmod = lookup_module_info(&process_module_vector, tag);
             if (pmod) {
@@ -579,7 +580,7 @@ print_symbolic_address(app_pc tag, char *buf, int max_chars, bool exact_only)
                    where some other thread frees the library */
             }
         }
-        mutex_unlock(&process_module_vector.lock);
+        d_r_mutex_unlock(&process_module_vector.lock);
     }
 
     buf[0] = '\0';
@@ -769,7 +770,7 @@ add_module_info(app_pc base_addr, size_t image_size)
               sizeof(export_entry_t), export_entry_compare);
 
         /* need to remove duplicates and update entry in process_module_vector */
-        mutex_lock(&process_module_vector.lock);
+        d_r_mutex_lock(&process_module_vector.lock);
         {
             module_info_t *pmod;
             int unique_num = remove_export_duplicates(exports_table, exports_num);
@@ -779,7 +780,7 @@ add_module_info(app_pc base_addr, size_t image_size)
             ASSERT(pmod);
             pmod->exports_num = unique_num;
         }
-        mutex_unlock(&process_module_vector.lock);
+        d_r_mutex_unlock(&process_module_vector.lock);
         return 1;
     } else {
         DOLOG(SYMBOLS_LOGLEVEL, LOG_SYMBOLS, {
@@ -911,7 +912,7 @@ find_ntdll_mod_rbtree(module_handle_t ntdllh, RTL_RB_TREE *tomatch)
                 byte *addr = opnd_get_addr(src);
                 if (is_in_ntdll(addr)) {
                     RTL_RB_TREE local;
-                    if (safe_read(addr, sizeof(local), &local) &&
+                    if (d_r_safe_read(addr, sizeof(local), &local) &&
                         local.Root == tomatch->Root && local.Min == tomatch->Min) {
                         LOG(GLOBAL, LOG_ALL, 2,
                             "Found LdrpModuleBaseAddressIndex @" PFX "\n", addr);
@@ -1147,7 +1148,7 @@ print_modules_ldrlist_and_ourlist(file_t f, bool dump_xml, bool conservative)
     lock = (RTL_CRITICAL_SECTION *)peb->LoaderLock;
     owner = (thread_id_t)lock->OwningThread;
     LOG(GLOBAL, LOG_ALL, 2, "LoaderLock owned by %d\n", owner);
-    if (owner != 0 && owner != get_thread_id()) {
+    if (owner != 0 && owner != d_r_get_thread_id()) {
         LOG(GLOBAL, LOG_ALL, 1, "WARNING: print_modules called w/o holding LoaderLock\n");
         DOLOG_ONCE(2, LOG_ALL,
                    { SYSLOG_INTERNAL_WARNING("print_modules w/o holding LoaderLock"); });
@@ -2202,7 +2203,7 @@ get_ldr_module_by_pc(app_pc pc)
 #ifdef DEBUG
     lock = (RTL_CRITICAL_SECTION *)peb->LoaderLock;
     owner = (thread_id_t)lock->OwningThread;
-    if (owner != 0 && owner != get_thread_id()) {
+    if (owner != 0 && owner != d_r_get_thread_id()) {
         /* This will be a risky operation but we'll live with it.
            In case we walk in a list in an inconsistent state
            1) we may get trapped in an infinite loop when following a partially updated
@@ -2515,7 +2516,7 @@ is_module_patch_region(dcontext_t *dcontext, app_pc start, app_pc end, bool cons
      * Even worse, we've seen apps that create a 2nd thread prior to the entry
      * point, meaning we cannot safely walk the list.
      */
-    if ((thread_id_t)lock->OwningThread == get_thread_id()) {
+    if ((thread_id_t)lock->OwningThread == d_r_get_thread_id()) {
         /* Walk the list
          * FIXME: just look at the last entry, since it's appended to the memory-order
          * list?
@@ -2807,7 +2808,7 @@ add_SEH_to_rct_table(dcontext_t *dcontext, app_pc module_base)
                 chain_func = (PIMAGE_RUNTIME_FUNCTION_ENTRY)ptr;
             else /* inlined */
                 chain_func = (PIMAGE_RUNTIME_FUNCTION_ENTRY)UNWIND_INFO_PTR_ADDR(info);
-            if (!safe_read(&chain_func->UnwindInfoAddress, sizeof(rva), &rva)) {
+            if (!d_r_safe_read(&chain_func->UnwindInfoAddress, sizeof(rva), &rva)) {
                 ASSERT_CURIOSITY(false && "unwind_info_t corrupted/misinterpreted");
                 continue;
             }
@@ -2945,7 +2946,7 @@ rct_add_rip_rel_addr(dcontext_t *dcontext, app_pc tgt _IF_DEBUG(app_pc src))
                 print_symbolic_address(tgt, symbuf, sizeof(symbuf), true);
                 LOG(GLOBAL, LOG_SYMBOLS, 3, "\t%s\n", symbuf);
             });
-            mutex_lock(&rct_module_lock);
+            d_r_mutex_lock(&rct_module_lock);
             if (rct_add_valid_ind_branch_target(dcontext, tgt)) {
                 STATS_INC(rct_ind_branch_valid_targets);
                 STATS_INC(rct_ind_rip_rel_new);
@@ -2954,7 +2955,7 @@ rct_add_rip_rel_addr(dcontext_t *dcontext, app_pc tgt _IF_DEBUG(app_pc src))
                 STATS_INC(rct_ind_rip_rel_old);
                 ASSERT_CURIOSITY(false && "TOCTOU race");
             }
-            mutex_unlock(&rct_module_lock);
+            d_r_mutex_unlock(&rct_module_lock);
         }
     } else {
         DOSTATS({
@@ -3663,7 +3664,7 @@ rct_process_module_mmap(app_pc module_base, size_t module_size, bool add,
         /* Grab the rct_module_lock to ensure no conflicts while
          * processing entries
          */
-        mutex_lock(&rct_module_lock);
+        d_r_mutex_lock(&rct_module_lock);
         if (DYNAMO_OPTION(rct_analyze_at_load)) {
             /* should use GLOBAL_DCONTEXT since called early */
             rct_analyze_module_at_load(GLOBAL_DCONTEXT, module_base, module_size, delta);
@@ -3758,7 +3759,7 @@ rct_process_module_mmap(app_pc module_base, size_t module_size, bool add,
             }
         }
 
-        mutex_unlock(&rct_module_lock);
+        d_r_mutex_unlock(&rct_module_lock);
     } else {
         /* case 9672: we now use per-module tables, so we don't need to
          * take any explicit action here; the tables will simply be removed.
@@ -3776,7 +3777,8 @@ bool
 rct_is_exported_function(app_pc tag)
 {
     module_info_t mod = { 0 }, *pmod;
-    mutex_lock(&process_module_vector.lock); /* FIXME: this can be a shared read lock */
+    d_r_mutex_lock(
+        &process_module_vector.lock); /* FIXME: this can be a shared read lock */
     {
         pmod = lookup_module_info(&process_module_vector, tag);
         if (pmod) {
@@ -3786,7 +3788,7 @@ rct_is_exported_function(app_pc tag)
              */
         }
     }
-    mutex_unlock(&process_module_vector.lock);
+    d_r_mutex_unlock(&process_module_vector.lock);
 
     if (pmod) {
         int i = find_predecessor(mod.exports_table, mod.exports_num, tag);
@@ -6243,7 +6245,7 @@ get_module_resource_version_info(app_pc mod_base, version_info_t *info_out)
             DOCHECK(1, {
                 DWORD val;
                 ASSERT_CURIOSITY(
-                    safe_read(ver_info.string_or_var_info, sizeof(val), &val) &&
+                    d_r_safe_read(ver_info.string_or_var_info, sizeof(val), &val) &&
                     val == 0 && "unknown data at end of .rsrc");
             });
 #endif

--- a/core/win32/module_shared.c
+++ b/core/win32/module_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -121,7 +121,7 @@ typedef struct _pe_symbol_export_iterator_t {
  * !not_readable() below.
  * FIXME : beware of multi-thread races, just because this returns true,
  * doesn't mean another thread can't make the region unreadable between the
- * check here and the actual read later.  See safe_read() as an alt.
+ * check here and the actual read later.  See d_r_safe_read() as an alt.
  */
 /* throw-away buffer */
 DECLARE_NEVERPROT_VAR(static char is_readable_buf[4 /*efficient read*/], { 0 });

--- a/core/win32/module_shared.c
+++ b/core/win32/module_shared.c
@@ -57,7 +57,7 @@
 #else
 /* we include globals.h mainly for ASSERT, even though we're
  * used by preinject.
- * preinject just defines its own internal_error!
+ * preinject just defines its own d_r_internal_error!
  */
 #    include "../globals.h"
 #    if !defined(NOT_DYNAMORIO_CORE_PROPER)

--- a/core/win32/ntdll.c
+++ b/core/win32/ntdll.c
@@ -58,7 +58,7 @@
 #else
 /* we include globals.h mainly for ASSERT, even though we're
  * used by preinject.
- * preinject just defines its own internal_error!
+ * preinject just defines its own d_r_internal_error!
  */
 #    include "../globals.h"
 #    include "../module_shared.h"

--- a/core/win32/ntdll_shared.c
+++ b/core/win32/ntdll_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -60,7 +60,7 @@
 #else
 /* we include globals.h mainly for ASSERT, even though we're
  * used by preinject.
- * preinject just defines its own internal_error!
+ * preinject just defines its own d_r_internal_error!
  */
 #    include "../globals.h"
 #    include "../module_shared.h"

--- a/core/win32/os_exports.h
+++ b/core/win32/os_exports.h
@@ -121,7 +121,8 @@ enum {
 
 #define DR_REG_SYSNUM REG_EAX
 
-/* even INLINE_FORCED isn't inlining this into get_thread_id() in debug build (i#655) */
+/* even INLINE_FORCED isn't inlining this into d_r_get_thread_id() in debug build (i#655)
+ */
 #define get_tls(/*ushort*/ tls_offs) \
     ((void *)IF_X64_ELSE(__readgsqword, __readfsdword)(tls_offs))
 
@@ -131,7 +132,8 @@ set_tls(ushort tls_offs, void *value)
     IF_X64_ELSE(__writegsqword, __writefsdword)(tls_offs, (ptr_uint_t)value);
 }
 
-/* even INLINE_FORCED isn't inlining this into get_thread_id() in debug build (i#655) */
+/* even INLINE_FORCED isn't inlining this into d_r_get_thread_id() in debug build (i#655)
+ */
 #define get_own_teb() ((TEB *)get_tls(SELF_TIB_OFFSET))
 
 /* We need to meet these requirements:

--- a/core/win32/pre_inject.c
+++ b/core/win32/pre_inject.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -87,17 +87,17 @@
 /* avoid mistake of lower-case assert */
 #define assert assert_no_good_use_ASSERT_instead
 void
-internal_error(char *file, int line, char *msg);
+d_r_internal_error(char *file, int line, char *msg);
 #ifdef DEBUG
 #    ifdef INTERNAL
-#        define ASSERT(x)                               \
-            if (!(x)) {                                 \
-                internal_error(__FILE__, __LINE__, #x); \
+#        define ASSERT(x)                                   \
+            if (!(x)) {                                     \
+                d_r_internal_error(__FILE__, __LINE__, #x); \
             }
 #    else
-#        define ASSERT(x)                               \
-            if (!(x)) {                                 \
-                internal_error(__FILE__, __LINE__, ""); \
+#        define ASSERT(x)                                   \
+            if (!(x)) {                                     \
+                d_r_internal_error(__FILE__, __LINE__, ""); \
             }
 #    endif /* INTERNAL */
 #else
@@ -142,7 +142,7 @@ display_error_helper(wchar_t *msg)
 }
 
 void
-internal_error(char *file, int line, char *expr)
+d_r_internal_error(char *file, int line, char *expr)
 {
 #ifdef INTERNAL
 #    define FILENAME_LENGTH L""
@@ -401,7 +401,7 @@ process_attach()
     ntdll_init();
 #ifndef PARAMS_IN_REGISTRY
     /* i#85/PR 212034: use config files */
-    config_init();
+    d_r_config_init();
 #endif
 
 #if VERBOSE

--- a/core/win32/syscall.c
+++ b/core/win32/syscall.c
@@ -1892,7 +1892,7 @@ presys_TerminateThread(dcontext_t *dcontext, reg_t *param_base)
      * equivalence, we have to get the thread id
      */
     thread_id_t tid;
-    thread_record_t *tr = thread_lookup(get_thread_id());
+    thread_record_t *tr = thread_lookup(d_r_get_thread_id());
     ASSERT(tr != NULL);
     if (thread_handle == 0)
         thread_handle = NT_CURRENT_THREAD;
@@ -1973,14 +1973,14 @@ presys_SetContextThread(dcontext_t *dcontext, reg_t *param_base)
         "syscall: NtSetContextThread handle=" PFX " tid=%d cxt->Xip=" PFX " flags=" PFX
         "\n",
         thread_handle, tid, cxt->CXT_XIP, cxt->ContextFlags);
-    if (get_thread_id() == tid) {
+    if (d_r_get_thread_id() == tid) {
         /* Simple case when called on own thread. */
         /* FIXME i#2249 : we should handle these flags. */
         ASSERT_NOT_IMPLEMENTED(!TEST(CONTEXT_CONTROL, cxt->ContextFlags) &&
                                !TEST(CONTEXT_DEBUG_REGISTERS, cxt->ContextFlags));
         return execute_syscall;
     }
-    mutex_lock(&thread_initexit_lock); /* need lock to lookup thread */
+    d_r_mutex_lock(&thread_initexit_lock); /* need lock to lookup thread */
     if (intercept_asynch_for_thread(tid, false /*no unknown threads*/)) {
         priv_mcontext_t mcontext;
         thread_record_t *tr = thread_lookup(tid);
@@ -2089,7 +2089,7 @@ presys_SetContextThread(dcontext_t *dcontext, reg_t *param_base)
         }
         SELF_PROTECT_LOCAL(tr->dcontext, READONLY);
     }
-    mutex_unlock(&thread_initexit_lock);
+    d_r_mutex_unlock(&thread_initexit_lock);
     return execute_syscall;
 }
 
@@ -2199,8 +2199,8 @@ presys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, int sysnum
         !TEST(MEM_RESERVE, type)) {
         /* i#1175: NtAllocateVirtualMemory can modify prot on existing pages */
         size_t size;
-        if (safe_read(pbase, sizeof(base), &base) &&
-            safe_read(psize, sizeof(size), &size) && base != NULL &&
+        if (d_r_safe_read(pbase, sizeof(base), &base) &&
+            d_r_safe_read(psize, sizeof(size), &size) && base != NULL &&
             !app_memory_pre_alloc(dcontext, base, size, osprot_to_memprot(prot), false)) {
             SET_RETURN_VAL(dcontext, STATUS_CONFLICTING_ADDRESSES);
             return false; /* do not execute system call */
@@ -2220,7 +2220,7 @@ presys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, int sysnum
         /* unfortunately no way to avoid syscall to check readability
          * (unless have try...except)
          */
-        if (safe_read(pbase, sizeof(base), &base)) {
+        if (d_r_safe_read(pbase, sizeof(base), &base)) {
             dcontext->alloc_no_reserve =
                 (base == NULL ||
                  (TEST(MEM_RESERVE, type) && !get_memory_info(base, NULL, NULL, NULL)));
@@ -2237,7 +2237,7 @@ presys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, int sysnum
          * their alloc to fail, but may end up eliminating any security
          * advantage anyway.
          */
-        if (safe_read(pbase, sizeof(base), &base)) {
+        if (d_r_safe_read(pbase, sizeof(base), &base)) {
             if (base == NULL) {
                 /* FIXME: make the above check stronger */
                 ASSERT_CURIOSITY(prot == PAGE_READWRITE);
@@ -2290,8 +2290,8 @@ presys_FreeVirtualMemory(dcontext_t *dcontext, reg_t *param_base)
     /* check for common argument problems, apps tend to screw this call
      * up a lot (who cares about a memory leak, esp. at process exit) */
     /* ref case 3536, 545, 4046 */
-    if (!safe_read(pbase, sizeof(base), &base) || base == NULL ||
-        !safe_read(psize, sizeof(size), &size) ||
+    if (!d_r_safe_read(pbase, sizeof(base), &base) || base == NULL ||
+        !d_r_safe_read(psize, sizeof(size), &size) ||
         !(type == MEM_RELEASE || type == MEM_DECOMMIT)) {
         /* we expect the system call to fail */
         DODEBUG(dcontext->expect_last_syscall_to_fail = true;);
@@ -2415,8 +2415,8 @@ presys_ProtectVirtualMemory(dcontext_t *dcontext, reg_t *param_base)
                                          * or PRETEND_APP_MEM_PROT_CHANGE */
     uint subset_memprot = MEMPROT_NONE; /* for SUBSET_APP_MEM_PROT_CHANGE */
 
-    if (!safe_read(pbase, sizeof(base), &base) ||
-        !safe_read(psize, sizeof(size), &size)) {
+    if (!d_r_safe_read(pbase, sizeof(base), &base) ||
+        !d_r_safe_read(psize, sizeof(size), &size)) {
         /* we expect the system call to fail */
         DODEBUG(dcontext->expect_last_syscall_to_fail = true;);
         return true;
@@ -3014,7 +3014,7 @@ pre_system_call(dcontext_t *dcontext)
         uint *pnum_pages = (uint *)sys_param(dcontext, param_base, 1);
         uint *page_frame_nums = (uint *)sys_param(dcontext, param_base, 2);
         uint num_pages;
-        if (safe_read(pnum_pages, sizeof(num_pages), &num_pages)) {
+        if (d_r_safe_read(pnum_pages, sizeof(num_pages), &num_pages)) {
             LOG(THREAD, LOG_SYSCALLS | LOG_VMAREAS, IF_DGCDIAG_ELSE(1, 2),
                 "syscall: NtMapUserPhysicalPages " PFX " pages=%d\n", base, num_pages);
             base = proc_get_containing_page(base);
@@ -3083,8 +3083,8 @@ postsys_CreateUserProcess(dcontext_t *dcontext, reg_t *param_base, bool success)
     });
 
     /* Even though syscall succeeded we use safe_read to be sure */
-    if (success && safe_read(proc_handle_ptr, sizeof(proc_handle), &proc_handle) &&
-        safe_read(thread_handle_ptr, sizeof(thread_handle), &thread_handle)) {
+    if (success && d_r_safe_read(proc_handle_ptr, sizeof(proc_handle), &proc_handle) &&
+        d_r_safe_read(thread_handle_ptr, sizeof(thread_handle), &thread_handle)) {
         ACCESS_MASK rights = nt_get_handle_access_rights(proc_handle);
 
         if (TESTALL(PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_VM_WRITE |
@@ -3187,7 +3187,7 @@ postsys_GetContextThread(dcontext_t *dcontext, reg_t *param_base, bool success)
      * at the os call, but there could always be multi-thread races */
 
     /* so trec remains valid, we are !could_be_linking */
-    mutex_lock(&thread_initexit_lock);
+    d_r_mutex_lock(&thread_initexit_lock);
     trec = thread_lookup(tid);
     if (trec == NULL) {
         /* this can occur if the target thread hasn't been scheduled yet
@@ -3230,7 +3230,7 @@ postsys_GetContextThread(dcontext_t *dcontext, reg_t *param_base, bool success)
             /* if asking for own context, thread_get_context() will point at
              * dynamorio_syscall_* and we'll fail to translate so we special-case
              */
-            if (tid == get_thread_id()) {
+            if (tid == d_r_get_thread_id()) {
                 /* only fields that DR might change are propagated to cxt below,
                  * so set set_cur_seg to false.
                  */
@@ -3310,7 +3310,7 @@ postsys_GetContextThread(dcontext_t *dcontext, reg_t *param_base, bool success)
         }
         SELF_PROTECT_LOCAL(trec->dcontext, READONLY);
     }
-    mutex_unlock(&thread_initexit_lock);
+    d_r_mutex_unlock(&thread_initexit_lock);
 }
 
 /* NtSuspendThread */
@@ -3332,7 +3332,7 @@ postsys_SuspendThread(dcontext_t *dcontext, reg_t *param_base, bool success)
     /* if we suspended ourselves then skip synchronization,
      * already resumed, FIXME : what if someone else resumes the thread
      * while we are trying to synch with it */
-    if (!success || tid == get_thread_id())
+    if (!success || tid == d_r_get_thread_id())
         return;
 
     pid = thread_handle_to_pid(thread_handle, tid);
@@ -3346,7 +3346,7 @@ postsys_SuspendThread(dcontext_t *dcontext, reg_t *param_base, bool success)
 
     /* as optimization check if at good spot already before resuming for
      * synch, use trylocks in case suspended thread is holding any locks */
-    if (mutex_trylock(&thread_initexit_lock)) {
+    if (d_r_mutex_trylock(&thread_initexit_lock)) {
         if (!mutex_testlock(&all_threads_lock)) {
             char buf[MAX_CONTEXT_SIZE];
             CONTEXT *cxt = nt_initialize_context(buf, CONTEXT_DR_STATE);
@@ -3368,7 +3368,7 @@ postsys_SuspendThread(dcontext_t *dcontext, reg_t *param_base, bool success)
                 SELF_PROTECT_LOCAL(tr->dcontext, WRITABLE);
                 if (at_safe_spot(tr, &mc_thread, THREAD_SYNCH_SUSPENDED_VALID_MCONTEXT)) {
                     /* suspended at good spot, skip synch */
-                    mutex_unlock(&thread_initexit_lock);
+                    d_r_mutex_unlock(&thread_initexit_lock);
                     LOG(THREAD, LOG_SYNCH, 2,
                         "SuspendThread suspended thread " TIDFMT " at good place\n", tid);
                     SELF_PROTECT_LOCAL(tr->dcontext, READONLY);
@@ -3382,7 +3382,7 @@ postsys_SuspendThread(dcontext_t *dcontext, reg_t *param_base, bool success)
                 " at good spot without resuming\n",
                 tid);
         }
-        mutex_unlock(&thread_initexit_lock);
+        d_r_mutex_unlock(&thread_initexit_lock);
     } else {
         LOG(THREAD, LOG_SYNCH, 2,
             "SuspendThread couldn't get thread_initexit_lock to test if thread " TIDFMT
@@ -3405,7 +3405,7 @@ postsys_SuspendThread(dcontext_t *dcontext, reg_t *param_base, bool success)
         /* we hold the initexit lock for case 9489, see comment below in failure
          * to synch path for details why */
         if (DYNAMO_OPTION(suspend_on_synch_failure_for_app_suspend))
-            mutex_lock(&thread_initexit_lock);
+            d_r_mutex_lock(&thread_initexit_lock);
         synch_res = synch_with_thread(
             tid, true /* block */,
             /* initexit lock status */
@@ -3447,7 +3447,7 @@ postsys_SuspendThread(dcontext_t *dcontext, reg_t *param_base, bool success)
             }
         }
         if (DYNAMO_OPTION(suspend_on_synch_failure_for_app_suspend))
-            mutex_unlock(&thread_initexit_lock);
+            d_r_mutex_unlock(&thread_initexit_lock);
 
         /* FIXME - if the thread exited we should prob. change the return value to
          * the app to a failure value. Only an assert_curiosity for now to see if any
@@ -3530,8 +3530,8 @@ postsys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, bool succ
          */
         return;
     }
-    if (!safe_read(pbase, sizeof(base), &base) ||
-        !safe_read(psize, sizeof(size), &size)) {
+    if (!d_r_safe_read(pbase, sizeof(base), &base) ||
+        !d_r_safe_read(psize, sizeof(size), &size)) {
         LOG(THREAD, LOG_SYSCALLS | LOG_VMAREAS, 1,
             "syscall: NtAllocateVirtualMemory: failed to read params " PFX " " PFX "\n",
             pbase, psize);
@@ -3759,7 +3759,7 @@ postsys_create_or_open_section(dcontext_t *dcontext, HANDLE *unsafe_section_hand
 {
     HANDLE section_handle = INVALID_HANDLE_VALUE;
     if (DYNAMO_OPTION(track_module_filenames) &&
-        safe_read(unsafe_section_handle, sizeof(section_handle), &section_handle)) {
+        d_r_safe_read(unsafe_section_handle, sizeof(section_handle), &section_handle)) {
         /* Case 1272: keep file name around to use for module identification */
         FILE_NAME_INFORMATION name_info; /* note: large struct */
         wchar_t buf[MAXIMUM_PATH];
@@ -3915,8 +3915,8 @@ postsys_OpenSection(dcontext_t *dcontext, reg_t *param_base, bool success)
          * based on access_mask, although most users use
          * SECTION_ALL_ACCESS */
         HANDLE root_directory = NULL;
-        bool ok =
-            safe_read(&obj_attr->RootDirectory, sizeof(root_directory), &root_directory);
+        bool ok = d_r_safe_read(&obj_attr->RootDirectory, sizeof(root_directory),
+                                &root_directory);
         if (ok && root_directory != NULL && aslr_is_handle_KnownDlls(root_directory)) {
 
             if (aslr_recreate_known_dll_file(obj_attr, &new_file_handle)) {
@@ -4166,7 +4166,7 @@ postsys_DuplicateObject(dcontext_t *dcontext, reg_t *param_base, bool success)
             const char *file = section_to_file_lookup(src);
             if (file != NULL) {
                 HANDLE dup;
-                if (safe_read(dst, sizeof(dup), &dup)) {
+                if (d_r_safe_read(dst, sizeof(dup), &dup)) {
                     /* Should already be converted to Dos path */
                     section_to_file_add(dup, file);
                     LOG(THREAD, LOG_SYSCALLS | LOG_VMAREAS, 2,
@@ -4241,8 +4241,8 @@ post_system_call(dcontext_t *dcontext)
         /* FIXME : we modified the passed in context, we should restore it
          * to app state (same for SYS_Continue though is more difficult there)
          */
-        if (tid != get_thread_id()) {
-            mutex_lock(&thread_initexit_lock); /* need lock to lookup thread */
+        if (tid != d_r_get_thread_id()) {
+            d_r_mutex_lock(&thread_initexit_lock); /* need lock to lookup thread */
             if (intercept_asynch_for_thread(tid, false /*no unknown threads*/)) {
                 /* Case 10101: we shouldn't get here since we now skip the system call,
                  * unless it should fail for permission issues */
@@ -4250,7 +4250,7 @@ post_system_call(dcontext_t *dcontext)
                 /* must wake up thread so it can go to nt_continue_dynamo_start */
                 nt_thread_resume(thread_handle, NULL);
             }
-            mutex_unlock(&thread_initexit_lock); /* need lock to lookup thread */
+            d_r_mutex_unlock(&thread_initexit_lock); /* need lock to lookup thread */
         }
     } else if (sysnum == syscalls[SYS_OpenThread]) {
         postsys_OpenThread(dcontext, param_base, success);
@@ -4297,7 +4297,7 @@ post_system_call(dcontext_t *dcontext)
             LOG(THREAD, LOG_SYSCALLS, IF_DGCDIAG_ELSE(1, 2),
                 "syscall post: NtCreateProcess section @" PFX "\n", base);
         });
-        if (success && safe_read(process_handle, sizeof(proc_handle), &proc_handle))
+        if (success && d_r_safe_read(process_handle, sizeof(proc_handle), &proc_handle))
             maybe_inject_into_process(dcontext, proc_handle, NULL);
     } else if (sysnum == syscalls[SYS_CreateProcessEx]) {
         HANDLE *process_handle = (HANDLE *)postsys_param(dcontext, param_base, 0);
@@ -4320,7 +4320,7 @@ post_system_call(dcontext_t *dcontext)
                     "syscall: NtCreateProcessEx section @" PFX "\n", base);
             }
         });
-        if (success && safe_read(process_handle, sizeof(proc_handle), &proc_handle))
+        if (success && d_r_safe_read(process_handle, sizeof(proc_handle), &proc_handle))
             maybe_inject_into_process(dcontext, proc_handle, NULL);
     } else if (sysnum == syscalls[SYS_CreateUserProcess]) {
         postsys_CreateUserProcess(dcontext, param_base, success);
@@ -4357,7 +4357,7 @@ post_system_call(dcontext_t *dcontext)
         if (thread_handle != 0) {
             thread_id_t tid = thread_handle_to_tid(thread_handle);
             process_id_t pid = thread_handle_to_pid(thread_handle, tid);
-            ASSERT(tid != get_thread_id()); /* not current thread */
+            ASSERT(tid != d_r_get_thread_id()); /* not current thread */
             /* FIXME : if is thread in this process and syscall fails then
              * no way to recover since we already cleaned up the thread */
             /* Don't allow success && handle == us since we should never get


### PR DESCRIPTION
Renames multi-word global symbols with popular names in other software
to help reduce the chance of name conflicts:

s/config_{in,ex}it/d_r_config_{in,ex}it/
s/mutex_lock/d_r_mutex_lock/
s/mutex_unlock/d_r_mutex_unlock/
s/mutex_trylock/d_r_mutex_trylock/
s/mutex_delete/d_r_mutex_delete/
s/mutex_lock_app/d_r_mutex_lock_app/
s/mutex_mark_as_app/d_r_mutex_mark_as_app/
s/mutex_fork_reset/d_r_mutex_fork_reset/
s/read_lock/d_r_read_lock/
s/write_lock/d_r_write_lock/
s/write_unlock/d_r_write_unlock/
s/read_unlock/d_r_read_unlock/
s/write_trylock/d_r_write_trylock/
s/parse_word/d_r_parse_word/
s/parse_int/d_r_parse_int/
s/print_timestamp/d_r_print_timestamp/
s/get_thread_id/d_r_get_thread_id/
s/internal_error/d_r_internal_error/
s/safe_read/d_r_safe_read/

Issue: #3348