### PR TITLE
i#1312 AVX-512 support: Add proc_num_simd_saved_abs() and replace MCXT_NUM_SIMD_SLOTS.

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -136,12 +136,16 @@ clients.
 The changes between version \DR_VERSION and 7.1.0 include the following minor
 compatibility changes:
 
- - Replaced NUM_SIMD_SLOTS with proc_num_simd_saved() and added the define
-   #MCXT_NUM_SIMD_SLOTS. Clients may set(DynamoRIO_NUM_SIMD_SLOTS_COMPATIBILITY ON)
-   in order to provide the define NUM_SIMD_SLOTS using proc_num_simd_saved().
-   The macro is not a constant expression and code relying on this needs to be
-   rewritten. DynamoRIO_NUM_SIMD_SLOTS_COMPATIBILITY is set automatically if
-   clients target version 7.1.0 or earlier.
+ - Added the function proc_num_simd_saved_abs().
+ - Added the define MCXT_NUM_SIMD_SLOTS that was renamed from NUM_SIMD_SLOTS.
+   MCXT_NUM_SIMD_SLOTS is now a constant that shall be used only to determine
+   the number of SIMD slots in DynamoRIO's mcontext.
+ - Replaced NUM_SIMD_SLOTS with proc_num_simd_saved().
+   Clients may set(DynamoRIO_NUM_SIMD_SLOTS_COMPATIBILITY ON) in order to provide
+   the define NUM_SIMD_SLOTS using proc_num_simd_saved(). The macro is not a constant
+   expression and code relying on this needs to be rewritten.
+   DynamoRIO_NUM_SIMD_SLOTS_COMPATIBILITY is set automatically if clients target
+   version 7.1.0 or earlier.
 
 Further non-compatibility-affecting changes include:
 

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -136,9 +136,9 @@ clients.
 The changes between version \DR_VERSION and 7.1.0 include the following minor
 compatibility changes:
 
- - Added the function proc_num_simd_saved_abs().
- - Added the define MCXT_NUM_SIMD_SLOTS that was renamed from NUM_SIMD_SLOTS.
-   MCXT_NUM_SIMD_SLOTS is now a constant that shall be used only to determine
+ - Added the function proc_num_simd_registers().
+ - Added the define #MCXT_NUM_SIMD_SLOTS that was renamed from NUM_SIMD_SLOTS.
+   #MCXT_NUM_SIMD_SLOTS is now a constant that shall be used only to determine
    the number of SIMD slots in DynamoRIO's mcontext.
  - Replaced NUM_SIMD_SLOTS with proc_num_simd_saved().
    Clients may set(DynamoRIO_NUM_SIMD_SLOTS_COMPATIBILITY ON) in order to provide

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -136,7 +136,6 @@ clients.
 The changes between version \DR_VERSION and 7.1.0 include the following minor
 compatibility changes:
 
- - Added the function proc_num_simd_registers().
  - Added the define #MCXT_NUM_SIMD_SLOTS that was renamed from NUM_SIMD_SLOTS.
    #MCXT_NUM_SIMD_SLOTS is now a constant that shall be used only to determine
    the number of SIMD slots in DynamoRIO's mcontext.
@@ -149,6 +148,7 @@ compatibility changes:
 
 Further non-compatibility-affecting changes include:
 
+ - Added the function proc_num_simd_registers().
  - Added drfront_set_verbose() to obtain diagnostics from drfrontendlib.
  - Added new fields to #dr_os_version_info_t which contain the build number,
    edition, and Windows 10 release identifier.

--- a/core/arch/aarch64/clean_call_opt.c
+++ b/core/arch/aarch64/clean_call_opt.c
@@ -184,9 +184,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
     /* XXX implement bitset for optimisation */
     memset(ci->reg_used, 0, sizeof(bool) * NUM_GP_REGS);
     ci->num_simd_used = 0;
-    /* Part of the array might be left uninitialized if
-     * proc_num_simd_registers() < MCXT_NUM_SIMD_SLOTS.
-     */
+    ASSERT(proc_num_simd_registers() == MCXT_NUM_SIMD_SLOTS);
     memset(ci->simd_used, 0, sizeof(bool) * proc_num_simd_registers());
     ci->write_flags = false;
 

--- a/core/arch/aarch64/clean_call_opt.c
+++ b/core/arch/aarch64/clean_call_opt.c
@@ -184,7 +184,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
     /* XXX implement bitset for optimisation */
     memset(ci->reg_used, 0, sizeof(bool) * NUM_GP_REGS);
     ci->num_simd_used = 0;
-    memset(ci->simd_used, 0, sizeof(bool) * MCXT_NUM_SIMD_SLOTS);
+    memset(ci->simd_used, 0, sizeof(bool) * proc_num_simd_saved_abs());
     ci->write_flags = false;
 
     num_regparm = MIN(ci->num_args, NUM_REGPARM);
@@ -214,7 +214,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
         }
 
         /* SIMD register usage */
-        for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
             if (!ci->simd_used[i] && instr_uses_reg(instr, (DR_REG_Q0 + (reg_id_t)i))) {
                 LOG(THREAD, LOG_CLEANCALL, 2,
                     "CLEANCALL: callee " PFX " uses VREG%d at " PFX "\n", ci->start, i,

--- a/core/arch/aarch64/clean_call_opt.c
+++ b/core/arch/aarch64/clean_call_opt.c
@@ -184,7 +184,10 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
     /* XXX implement bitset for optimisation */
     memset(ci->reg_used, 0, sizeof(bool) * NUM_GP_REGS);
     ci->num_simd_used = 0;
-    memset(ci->simd_used, 0, sizeof(bool) * proc_num_simd_saved_abs());
+    /* Part of the array might be left uninitialized if
+     * proc_num_simd_registers() < MCXT_NUM_SIMD_SLOTS.
+     */
+    memset(ci->simd_used, 0, sizeof(bool) * proc_num_simd_registers());
     ci->write_flags = false;
 
     num_regparm = MIN(ci->num_args, NUM_REGPARM);
@@ -214,7 +217,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
         }
 
         /* SIMD register usage */
-        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+        for (i = 0; i < proc_num_simd_registers(); i++) {
             if (!ci->simd_used[i] && instr_uses_reg(instr, (DR_REG_Q0 + (reg_id_t)i))) {
                 LOG(THREAD, LOG_CLEANCALL, 2,
                     "CLEANCALL: callee " PFX " uses VREG%d at " PFX "\n", ci->start, i,

--- a/core/arch/aarch64/clean_call_opt.c
+++ b/core/arch/aarch64/clean_call_opt.c
@@ -179,7 +179,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
 {
     instrlist_t *ilist = ci->ilist;
     instr_t *instr;
-    uint i, num_regparm;
+    int i, num_regparm;
 
     /* XXX implement bitset for optimisation */
     memset(ci->reg_used, 0, sizeof(bool) * NUM_GP_REGS);

--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -35,13 +35,13 @@
 #include "instr.h"
 
 static int num_simd_saved;
-static int num_simd_saved_abs;
+static int num_simd_registers;
 
 void
 proc_init_arch(void)
 {
     num_simd_saved = MCXT_NUM_SIMD_SLOTS;
-    num_simd_saved_abs = MCXT_NUM_SIMD_SLOTS;
+    num_simd_registers = MCXT_NUM_SIMD_SLOTS;
 
     /* FIXME i#1569: NYI */
 }
@@ -76,9 +76,9 @@ proc_num_simd_saved(void)
 
 DR_API
 int
-proc_num_simd_saved_abs(void)
+proc_num_simd_registers(void)
 {
-    return num_simd_saved_abs;
+    return num_simd_registers;
 }
 
 DR_API

--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -35,11 +35,13 @@
 #include "instr.h"
 
 static int num_simd_saved;
+static int num_simd_saved_abs;
 
 void
 proc_init_arch(void)
 {
     num_simd_saved = MCXT_NUM_SIMD_SLOTS;
+    num_simd_saved_abs = MCXT_NUM_SIMD_SLOTS;
 
     /* FIXME i#1569: NYI */
 }
@@ -70,6 +72,13 @@ int
 proc_num_simd_saved(void)
 {
     return num_simd_saved;
+}
+
+DR_API
+int
+proc_num_simd_saved_abs(void)
+{
+    return num_simd_saved_abs;
 }
 
 DR_API

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -409,8 +409,8 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
 #    endif
     if (cci == NULL)
         cci = &default_clean_call_info;
-    ASSERT(proc_num_simd_saved_abs() == MCXT_NUM_SIMD_SLOTS);
-    if (cci->preserve_mcontext || cci->num_simd_skip != proc_num_simd_saved_abs()) {
+    ASSERT(proc_num_simd_registers() == MCXT_NUM_SIMD_SLOTS);
+    if (cci->preserve_mcontext || cci->num_simd_skip != proc_num_simd_registers()) {
         /* FIXME i#1551: once we add skipping of regs, need to keep shape here */
     }
     /* FIXME i#1551: once we have cci->num_simd_skip, skip this if possible */
@@ -524,8 +524,8 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
     insert_save_registers(dcontext, ilist, instr, cci->simd_skip, DR_REG_X0, DR_REG_Q0,
                           false /* is_gpr */);
 
-    dstack_offs += (proc_num_simd_saved_abs() * sizeof(dr_simd_t));
-    ASSERT(proc_num_simd_saved_abs() == MCXT_NUM_SIMD_SLOTS);
+    dstack_offs += (proc_num_simd_registers() * sizeof(dr_simd_t));
+    ASSERT(proc_num_simd_registers() == MCXT_NUM_SIMD_SLOTS);
 
     /* Restore the registers we used. */
     /* ldp x0, x1, [sp] */
@@ -547,8 +547,8 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
         INSTR_CREATE_vstmdb(dcontext, OPND_CREATE_MEMLIST(DR_REG_SP), SIMD_REG_LIST_LEN,
                             SIMD_REG_LIST_0_15));
 
-    dstack_offs += proc_num_simd_saved_abs() * sizeof(dr_simd_t);
-    ASSERT(proc_num_simd_saved_abs() == MCXT_NUM_SIMD_SLOTS);
+    dstack_offs += proc_num_simd_registers() * sizeof(dr_simd_t);
+    ASSERT(proc_num_simd_registers() == MCXT_NUM_SIMD_SLOTS);
 
     /* pc and aflags */
     if (cci->skip_save_flags) {
@@ -640,8 +640,8 @@ insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
                           opnd_create_reg(DR_REG_SP)));
 
     current_offs = get_clean_call_switch_stack_size() -
-        proc_num_simd_saved_abs() * sizeof(dr_simd_t);
-    ASSERT(proc_num_simd_saved_abs() == MCXT_NUM_SIMD_SLOTS);
+        proc_num_simd_registers() * sizeof(dr_simd_t);
+    ASSERT(proc_num_simd_registers() == MCXT_NUM_SIMD_SLOTS);
 
     /* add x0, x0, current_offs */
     PRE(ilist, instr,

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -3487,6 +3487,7 @@ dump_mcontext(priv_mcontext_t *context, file_t f, bool dump_xml)
     );
 
 #ifdef X86
+    /* XXX i#1312: this needs to get extended to AVX-512. */
     if (preserve_xmm_caller_saved()) {
         int i, j;
         for (i = 0; i < proc_num_simd_saved(); i++) {
@@ -3518,7 +3519,7 @@ dump_mcontext(priv_mcontext_t *context, file_t f, bool dump_xml)
     {
         int i, j;
         /* XXX: should be proc_num_simd_saved(). */
-        for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
             print_file(f, dump_xml ? "\t\tqd= \"0x" : "\tq%-3d= 0x", i);
             for (j = 0; j < 4; j++) {
                 print_file(f, "%08x ", context->simd[i].u32[j]);

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -3519,7 +3519,7 @@ dump_mcontext(priv_mcontext_t *context, file_t f, bool dump_xml)
     {
         int i, j;
         /* XXX: should be proc_num_simd_saved(). */
-        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+        for (i = 0; i < proc_num_simd_registers(); i++) {
             print_file(f, dump_xml ? "\t\tqd= \"0x" : "\tq%-3d= 0x", i);
             for (j = 0; j < 4; j++) {
                 print_file(f, "%08x ", context->simd[i].u32[j]);

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -337,7 +337,7 @@ typedef struct _clean_call_info_t {
     bool save_all_regs;
     bool skip_save_flags;
     bool skip_clear_flags;
-    uint num_simd_skip;
+    int num_simd_skip;
     bool simd_skip[MCXT_NUM_SIMD_SLOTS];
     uint num_regs_skip;
     bool reg_skip[NUM_GP_REGS];

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -1377,16 +1377,14 @@ typedef struct _callee_info_t {
     app_pc bwd_tgt;    /* earliest backward branch target */
     app_pc fwd_tgt;    /* last forward branch target */
     int num_simd_used; /* number of SIMD registers (xmms) used by callee */
-
-    bool simd_used[MCXT_NUM_SIMD_SLOTS]; /* SIMD (xmm/ymm) registers usage. Part of
-                                          * the array might left uninitialized if
-                                          * proc_num_simd_registers() <
-                                          * MCXT_NUM_SIMD_SLOTS.
-                                          */
-    bool reg_used[NUM_GP_REGS];          /* general purpose registers usage */
-    int num_callee_save_regs;            /* number of regs callee saved */
-    bool callee_save_regs[NUM_GP_REGS];  /* callee-save registers */
-    bool has_locals;                     /* if reference local via stack */
+    /* SIMD (xmm/ymm) registers usage. Part of the array might be left
+     * uninitialized if proc_num_simd_registers() < MCXT_NUM_SIMD_SLOTS.
+     */
+    bool simd_used[MCXT_NUM_SIMD_SLOTS];
+    bool reg_used[NUM_GP_REGS];         /* general purpose registers usage */
+    int num_callee_save_regs;           /* number of regs callee saved */
+    bool callee_save_regs[NUM_GP_REGS]; /* callee-save registers */
+    bool has_locals;                    /* if reference local via stack */
     bool standard_fp;   /* if standard reg (xbp/x29) is used as frame pointer */
     bool opt_inline;    /* can be inlined or not */
     bool write_flags;   /* if the function changes flags */

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -1377,7 +1377,12 @@ typedef struct _callee_info_t {
     app_pc bwd_tgt;    /* earliest backward branch target */
     app_pc fwd_tgt;    /* last forward branch target */
     int num_simd_used; /* number of SIMD registers (xmms) used by callee */
-    bool simd_used[MCXT_NUM_SIMD_SLOTS]; /* SIMD (xmm/ymm) registers usage */
+
+    bool simd_used[MCXT_NUM_SIMD_SLOTS]; /* SIMD (xmm/ymm) registers usage. Part of
+                                          * the array might left uninitialized if
+                                          * proc_num_simd_registers() <
+                                          * MCXT_NUM_SIMD_SLOTS.
+                                          */
     bool reg_used[NUM_GP_REGS];          /* general purpose registers usage */
     int num_callee_save_regs;            /* number of regs callee saved */
     bool callee_save_regs[NUM_GP_REGS];  /* callee-save registers */

--- a/core/arch/arm/proc.c
+++ b/core/arch/arm/proc.c
@@ -44,12 +44,14 @@
 #endif
 
 static int num_simd_saved;
+static int num_simd_saved_abs;
 
 /* arch specific proc info */
 void
 proc_init_arch(void)
 {
     num_simd_saved = MCXT_NUM_SIMD_SLOTS;
+    num_simd_saved_abs = MCXT_NUM_SIMD_SLOTS;
 
     /* FIXME i#1551: NYI on ARM */
     /* all of the CPUID registers are only accessible in privileged modes
@@ -95,6 +97,13 @@ int
 proc_num_simd_saved(void)
 {
     return num_simd_saved;
+}
+
+DR_API
+int
+proc_num_simd_saved_abs(void)
+{
+    return num_simd_saved_abs;
 }
 
 DR_API

--- a/core/arch/arm/proc.c
+++ b/core/arch/arm/proc.c
@@ -44,14 +44,14 @@
 #endif
 
 static int num_simd_saved;
-static int num_simd_saved_abs;
+static int num_simd_registers;
 
 /* arch specific proc info */
 void
 proc_init_arch(void)
 {
     num_simd_saved = MCXT_NUM_SIMD_SLOTS;
-    num_simd_saved_abs = MCXT_NUM_SIMD_SLOTS;
+    num_simd_registers = MCXT_NUM_SIMD_SLOTS;
 
     /* FIXME i#1551: NYI on ARM */
     /* all of the CPUID registers are only accessible in privileged modes
@@ -101,9 +101,9 @@ proc_num_simd_saved(void)
 
 DR_API
 int
-proc_num_simd_saved_abs(void)
+proc_num_simd_registers(void)
 {
-    return num_simd_saved_abs;
+    return num_simd_registers;
 }
 
 DR_API

--- a/core/arch/clean_call_opt_shared.c
+++ b/core/arch/clean_call_opt_shared.c
@@ -73,8 +73,8 @@ callee_info_init(callee_info_t *ci)
      * but then later in analyze_callee_regs_usage, we have to use the loop.
      */
     /* assuming all xmm registers are used */
-    ci->num_simd_used = proc_num_simd_saved_abs();
-    for (i = 0; i < proc_num_simd_saved_abs(); i++)
+    ci->num_simd_used = proc_num_simd_registers();
+    for (i = 0; i < proc_num_simd_registers(); i++)
         ci->simd_used[i] = true;
     for (i = 0; i < NUM_GP_REGS; i++)
         ci->reg_used[i] = true;
@@ -493,7 +493,7 @@ analyze_clean_call_regs(dcontext_t *dcontext, clean_call_info_t *cci)
     callee_info_t *info = cci->callee_info;
 
     /* 1. xmm registers */
-    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+    for (i = 0; i < proc_num_simd_registers(); i++) {
         if (info->simd_used[i]) {
             cci->simd_skip[i] = false;
         } else {
@@ -505,7 +505,7 @@ analyze_clean_call_regs(dcontext_t *dcontext, clean_call_info_t *cci)
         }
     }
     if (INTERNAL_OPTION(opt_cleancall) > 2 &&
-        cci->num_simd_skip != proc_num_simd_saved_abs())
+        cci->num_simd_skip != proc_num_simd_registers())
         cci->should_align = false;
     /* 2. general purpose registers */
     /* set regs not to be saved for clean call */
@@ -647,7 +647,7 @@ analyze_clean_call_inline(dcontext_t *dcontext, clean_call_info_t *cci)
                 }
             }
         }
-        if (cci->num_simd_skip == proc_num_simd_saved_abs()) {
+        if (cci->num_simd_skip == proc_num_simd_registers()) {
             STATS_INC(cleancall_simd_skipped);
         }
         if (cci->skip_save_flags) {
@@ -736,7 +736,7 @@ analyze_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instr_t *where,
      * to be saved or if more than GPR_SAVE_TRESHOLD GP registers have to be saved.
      * XXX: This should probably be in arch-specific clean_call_opt.c.
      */
-    if ((proc_num_simd_saved_abs() - cci->num_simd_skip) > SIMD_SAVE_TRESHOLD ||
+    if ((proc_num_simd_registers() - cci->num_simd_skip) > SIMD_SAVE_TRESHOLD ||
         (NUM_GP_REGS - cci->num_regs_skip) > GPR_SAVE_TRESHOLD || always_out_of_line)
         cci->out_of_line_swap = true;
 #    endif

--- a/core/arch/clean_call_opt_shared.c
+++ b/core/arch/clean_call_opt_shared.c
@@ -60,7 +60,7 @@ static bool callee_info_table_exit = false;
 static void
 callee_info_init(callee_info_t *ci)
 {
-    uint i;
+    int i;
     memset(ci, 0, sizeof(*ci));
     ci->bailout = true;
     /* to be conservative */
@@ -489,7 +489,7 @@ analyze_callee_ilist(dcontext_t *dcontext, callee_info_t *ci)
 static void
 analyze_clean_call_regs(dcontext_t *dcontext, clean_call_info_t *cci)
 {
-    uint i, num_regparm;
+    int i, num_regparm;
     callee_info_t *info = cci->callee_info;
 
     /* 1. xmm registers */

--- a/core/arch/clean_call_opt_shared.c
+++ b/core/arch/clean_call_opt_shared.c
@@ -73,8 +73,8 @@ callee_info_init(callee_info_t *ci)
      * but then later in analyze_callee_regs_usage, we have to use the loop.
      */
     /* assuming all xmm registers are used */
-    ci->num_simd_used = MCXT_NUM_SIMD_SLOTS;
-    for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++)
+    ci->num_simd_used = proc_num_simd_saved_abs();
+    for (i = 0; i < proc_num_simd_saved_abs(); i++)
         ci->simd_used[i] = true;
     for (i = 0; i < NUM_GP_REGS; i++)
         ci->reg_used[i] = true;
@@ -493,7 +493,7 @@ analyze_clean_call_regs(dcontext_t *dcontext, clean_call_info_t *cci)
     callee_info_t *info = cci->callee_info;
 
     /* 1. xmm registers */
-    for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
         if (info->simd_used[i]) {
             cci->simd_skip[i] = false;
         } else {
@@ -504,7 +504,8 @@ analyze_clean_call_regs(dcontext_t *dcontext, clean_call_info_t *cci)
             cci->num_simd_skip++;
         }
     }
-    if (INTERNAL_OPTION(opt_cleancall) > 2 && cci->num_simd_skip != MCXT_NUM_SIMD_SLOTS)
+    if (INTERNAL_OPTION(opt_cleancall) > 2 &&
+        cci->num_simd_skip != proc_num_simd_saved_abs())
         cci->should_align = false;
     /* 2. general purpose registers */
     /* set regs not to be saved for clean call */
@@ -646,7 +647,7 @@ analyze_clean_call_inline(dcontext_t *dcontext, clean_call_info_t *cci)
                 }
             }
         }
-        if (cci->num_simd_skip == MCXT_NUM_SIMD_SLOTS) {
+        if (cci->num_simd_skip == proc_num_simd_saved_abs()) {
             STATS_INC(cleancall_simd_skipped);
         }
         if (cci->skip_save_flags) {
@@ -735,7 +736,7 @@ analyze_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instr_t *where,
      * to be saved or if more than GPR_SAVE_TRESHOLD GP registers have to be saved.
      * XXX: This should probably be in arch-specific clean_call_opt.c.
      */
-    if ((MCXT_NUM_SIMD_SLOTS - cci->num_simd_skip) > SIMD_SAVE_TRESHOLD ||
+    if ((proc_num_simd_saved_abs() - cci->num_simd_skip) > SIMD_SAVE_TRESHOLD ||
         (NUM_GP_REGS - cci->num_regs_skip) > GPR_SAVE_TRESHOLD || always_out_of_line)
         cci->out_of_line_swap = true;
 #    endif

--- a/core/arch/proc.h
+++ b/core/arch/proc.h
@@ -461,8 +461,7 @@ DR_API
 /**
  * Returns the number of SIMD registers preserved for a context switch. DynamoRIO
  * may decide to optimize the number of registers saved, in which case this number
- * may be less than proc_num_simd_registers(). For x86 this only includes the
- * vector registers (xmm/ymm/zmm).
+ * may be less than proc_num_simd_registers(). For x86 this only includes xmm/ymm/zmm.
  *
  * The number of saved SIMD registers may be variable. For example, we may decide
  * to optimize the number of saved registers in a context switch to avoid frequency
@@ -495,7 +494,7 @@ DR_API
 /**
  * Returns the number of SIMD registers. The number returned here depends on the
  * processor and OS feature bits on a given machine. For x86 this only includes
- * the vector registers (xmm/ymm/zmm).
+ * xmm/ymm/zmm.
  *
  */
 int

--- a/core/arch/proc.h
+++ b/core/arch/proc.h
@@ -461,13 +461,14 @@ DR_API
 /**
  * Returns the number of SIMD registers preserved for a context switch. DynamoRIO
  * may decide to optimize the number of registers saved, in which case this number
- * may be less than proc_num_simd_saved_abs().
+ * may be less than proc_num_simd_registers().
  *
  * The number of saved SIMD registers may be variable. For example, we may decide
  * to optimize the number of saved registers in a context switch to avoid frequency
  * scaling (https://github.com/DynamoRIO/dynamorio/issues/3169).
  */
-/* XXX i#1312: Implement lazy update mechanism.
+/* XXX i#1312: Implement lazy update mechanism and add a callback so clients
+ * can adjust for changes mid-run.
  *
  * PR 306394: for 32-bit xmm0-7 are caller-saved, and are touched by
  * libc routines invoked by DR in some Linux systems (xref i#139),
@@ -491,14 +492,12 @@ proc_num_simd_saved(void);
 
 DR_API
 /**
- * Returns the number of SIMD registers preserved for an context switch. The number
- * returned here depends only on the processor and OS feature bits and reflects the
- * number of active SIMD registers, regardless of whether DynamoRIO may be optimizing
- * context switches or not.
+ * Returns the number of SIMD registers. The number returned here depends on the
+ * processor and OS feature bits on a given machine.
  *
  */
 int
-proc_num_simd_saved_abs(void);
+proc_num_simd_registers(void);
 
 DR_API
 /**
@@ -550,9 +549,9 @@ proc_restore_fpstate(byte *buf);
 
 DR_API
 /**
- * Returns whether AVX(2) is enabled by both the processor and the OS. Even
- * if the processor supports AVX(2), if the OS does not enable AVX(2), then
- * AVX(2) instructions will fault.
+ * Returns whether AVX (or AVX2) is enabled by both the processor and the OS.
+ * Even if the processor supports AVX, if the OS does not enable AVX, then
+ * AVX instructions will fault.
  */
 bool
 proc_avx_enabled(void);

--- a/core/arch/proc.h
+++ b/core/arch/proc.h
@@ -461,7 +461,8 @@ DR_API
 /**
  * Returns the number of SIMD registers preserved for a context switch. DynamoRIO
  * may decide to optimize the number of registers saved, in which case this number
- * may be less than proc_num_simd_registers().
+ * may be less than proc_num_simd_registers(). For x86 this only includes the
+ * vector registers (xmm/ymm/zmm).
  *
  * The number of saved SIMD registers may be variable. For example, we may decide
  * to optimize the number of saved registers in a context switch to avoid frequency
@@ -493,7 +494,8 @@ proc_num_simd_saved(void);
 DR_API
 /**
  * Returns the number of SIMD registers. The number returned here depends on the
- * processor and OS feature bits on a given machine.
+ * processor and OS feature bits on a given machine. For x86 this only includes
+ * the vector registers (xmm/ymm/zmm).
  *
  */
 int

--- a/core/arch/proc.h
+++ b/core/arch/proc.h
@@ -459,13 +459,17 @@ proc_fpstate_save_size(void);
 
 DR_API
 /**
- * Returns the number of SIMD registers to be saved.
+ * Returns the number of SIMD registers preserved for a context switch. DynamoRIO
+ * may decide to optimize the number of registers saved, in which case this number
+ * may be less than proc_num_simd_saved_abs().
  *
  * The number of saved SIMD registers may be variable. For example, we may decide
  * to optimize the number of saved registers in a context switch to avoid frequency
  * scaling (https://github.com/DynamoRIO/dynamorio/issues/3169).
  */
-/* PR 306394: for 32-bit xmm0-7 are caller-saved, and are touched by
+/* XXX i#1312: Implement lazy update mechanism.
+ *
+ * PR 306394: for 32-bit xmm0-7 are caller-saved, and are touched by
  * libc routines invoked by DR in some Linux systems (xref i#139),
  * so they should be saved in 32-bit Linux.
  *
@@ -484,6 +488,17 @@ DR_API
  */
 int
 proc_num_simd_saved(void);
+
+DR_API
+/**
+ * Returns the number of SIMD registers preserved for an context switch. The number
+ * returned here depends only on the processor and OS feature bits and reflects the
+ * number of active SIMD registers, regardless of whether DynamoRIO may be optimizing
+ * context switches or not.
+ *
+ */
+int
+proc_num_simd_saved_abs(void);
 
 DR_API
 /**
@@ -534,9 +549,10 @@ void
 proc_restore_fpstate(byte *buf);
 
 DR_API
-/** Returns whether AVX is enabled by both the processor and the operating system.
- * Even if the processor supports AVX, if the operating system does not enable
- * AVX state saving, then AVX instructions will fault.
+/**
+ * Returns whether AVX(2) is enabled by both the processor and the OS. Even
+ * if the processor supports AVX(2), if the OS does not enable AVX(2), then
+ * AVX(2) instructions will fault.
  */
 bool
 proc_avx_enabled(void);

--- a/core/arch/x86/clean_call_opt.c
+++ b/core/arch/x86/clean_call_opt.c
@@ -63,7 +63,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
     int i, num_regparm;
 
     ci->num_simd_used = 0;
-    memset(ci->simd_used, 0, sizeof(bool) * proc_num_simd_saved_abs());
+    memset(ci->simd_used, 0, sizeof(bool) * proc_num_simd_registers());
     memset(ci->reg_used, 0, sizeof(bool) * NUM_GP_REGS);
     ci->write_flags = false;
     for (instr = instrlist_first(ilist); instr != NULL; instr = instr_get_next(instr)) {
@@ -74,10 +74,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
          * impact unless there are a lot of different clean call callees.
          */
         /* XMM registers usage */
-        /* XXX: This looks like it is missing support for AVX/AVX2.
-         * XXX i#1312: Support AVX-512.
-         */
-        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+        for (i = 0; i < proc_num_simd_registers(); i++) {
             if (!ci->simd_used[i] && instr_uses_reg(instr, (DR_REG_XMM0 + (reg_id_t)i))) {
                 LOG(THREAD, LOG_CLEANCALL, 2,
                     "CLEANCALL: callee " PFX " uses XMM%d at " PFX "\n", ci->start, i,
@@ -608,7 +605,7 @@ insert_inline_reg_save(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
     insert_get_mcontext_base(dcontext, ilist, where, ci->spill_reg);
 
     /* Save used registers. */
-    ASSERT(cci->num_simd_skip == proc_num_simd_saved_abs());
+    ASSERT(cci->num_simd_skip == proc_num_simd_registers());
     for (i = 0; i < NUM_GP_REGS; i++) {
         if (!cci->reg_skip[i]) {
             reg_id_t reg_id = DR_REG_XAX + (reg_id_t)i;

--- a/core/arch/x86/clean_call_opt.c
+++ b/core/arch/x86/clean_call_opt.c
@@ -63,6 +63,9 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
     int i, num_regparm;
 
     ci->num_simd_used = 0;
+    /* Part of the array might be left uninitialized if
+     * proc_num_simd_registers() < MCXT_NUM_SIMD_SLOTS.
+     */
     memset(ci->simd_used, 0, sizeof(bool) * proc_num_simd_registers());
     memset(ci->reg_used, 0, sizeof(bool) * NUM_GP_REGS);
     ci->write_flags = false;

--- a/core/arch/x86/clean_call_opt.c
+++ b/core/arch/x86/clean_call_opt.c
@@ -63,7 +63,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
     uint i, num_regparm;
 
     ci->num_simd_used = 0;
-    memset(ci->simd_used, 0, sizeof(bool) * MCXT_NUM_SIMD_SLOTS);
+    memset(ci->simd_used, 0, sizeof(bool) * proc_num_simd_saved_abs());
     memset(ci->reg_used, 0, sizeof(bool) * NUM_GP_REGS);
     ci->write_flags = false;
     for (instr = instrlist_first(ilist); instr != NULL; instr = instr_get_next(instr)) {
@@ -74,7 +74,10 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
          * impact unless there are a lot of different clean call callees.
          */
         /* XMM registers usage */
-        for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+        /* XXX: This looks like it is missing support for AVX/AVX2.
+         * XXX i#1312: Support AVX-512.
+         */
+        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
             if (!ci->simd_used[i] && instr_uses_reg(instr, (DR_REG_XMM0 + (reg_id_t)i))) {
                 LOG(THREAD, LOG_CLEANCALL, 2,
                     "CLEANCALL: callee " PFX " uses XMM%d at " PFX "\n", ci->start, i,
@@ -605,7 +608,7 @@ insert_inline_reg_save(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
     insert_get_mcontext_base(dcontext, ilist, where, ci->spill_reg);
 
     /* Save used registers. */
-    ASSERT(cci->num_simd_skip == MCXT_NUM_SIMD_SLOTS);
+    ASSERT(cci->num_simd_skip == proc_num_simd_saved_abs());
     for (i = 0; i < NUM_GP_REGS; i++) {
         if (!cci->reg_skip[i]) {
             reg_id_t reg_id = DR_REG_XAX + (reg_id_t)i;

--- a/core/arch/x86/clean_call_opt.c
+++ b/core/arch/x86/clean_call_opt.c
@@ -60,7 +60,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
 {
     instrlist_t *ilist = ci->ilist;
     instr_t *instr;
-    uint i, num_regparm;
+    int i, num_regparm;
 
     ci->num_simd_used = 0;
     memset(ci->simd_used, 0, sizeof(bool) * proc_num_simd_saved_abs());

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -342,8 +342,8 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
     /* XXX i#1312: This assumption will change and the code below will need
      * to take this into account.
      */
-    ASSERT(proc_num_simd_saved_abs() == MCXT_NUM_SIMD_SLOTS);
-    if (cci->preserve_mcontext || cci->num_simd_skip != proc_num_simd_saved_abs()) {
+    ASSERT(proc_num_simd_registers() == MCXT_NUM_SIMD_SLOTS);
+    if (cci->preserve_mcontext || cci->num_simd_skip != proc_num_simd_registers()) {
         int offs = MCXT_TOTAL_SIMD_SLOTS_SIZE + PRE_XMM_PADDING;
         if (cci->preserve_mcontext && cci->skip_save_flags) {
             offs_beyond_xmm = 2 * XSP_SZ; /* pc and flags */
@@ -372,7 +372,7 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
         /* XXX i#1312: This assumption will change and the code below will need
          * to take this into account.
          */
-        ASSERT(proc_num_simd_saved() == proc_num_simd_saved_abs());
+        ASSERT(proc_num_simd_saved() == proc_num_simd_registers());
         for (i = 0; i < proc_num_simd_saved(); i++) {
             if (!cci->simd_skip[i]) {
                 PRE(ilist, instr,
@@ -517,7 +517,7 @@ insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
         /* XXX i#1312: This assumption will change and the code below will need
          * to take this into account.
          */
-        ASSERT(proc_num_simd_saved() == proc_num_simd_saved_abs());
+        ASSERT(proc_num_simd_saved() == proc_num_simd_registers());
         for (i = 0; i < proc_num_simd_saved(); i++) {
             if (!cci->simd_skip[i]) {
                 PRE(ilist, instr,

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -339,7 +339,11 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
     int offs_beyond_xmm = 0;
     if (cci == NULL)
         cci = &default_clean_call_info;
-    if (cci->preserve_mcontext || cci->num_simd_skip != MCXT_NUM_SIMD_SLOTS) {
+    /* XXX i#1312: This assumption will change and the code below will need
+     * to take this into account.
+     */
+    ASSERT(proc_num_simd_saved_abs() == MCXT_NUM_SIMD_SLOTS);
+    if (cci->preserve_mcontext || cci->num_simd_skip != proc_num_simd_saved_abs()) {
         int offs = MCXT_TOTAL_SIMD_SLOTS_SIZE + PRE_XMM_PADDING;
         if (cci->preserve_mcontext && cci->skip_save_flags) {
             offs_beyond_xmm = 2 * XSP_SZ; /* pc and flags */
@@ -365,6 +369,10 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
          */
         uint opcode = move_mm_reg_opcode(ALIGNED(alignment, 16), ALIGNED(alignment, 32));
         ASSERT(proc_has_feature(FEATURE_SSE));
+        /* XXX i#1312: This assumption will change and the code below will need
+         * to take this into account.
+         */
+        ASSERT(proc_num_simd_saved() == proc_num_simd_saved_abs());
         for (i = 0; i < proc_num_simd_saved(); i++) {
             if (!cci->simd_skip[i]) {
                 PRE(ilist, instr,
@@ -506,6 +514,10 @@ insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
          * is better. */
         uint opcode = move_mm_reg_opcode(ALIGNED(alignment, 32), ALIGNED(alignment, 16));
         ASSERT(proc_has_feature(FEATURE_SSE));
+        /* XXX i#1312: This assumption will change and the code below will need
+         * to take this into account.
+         */
+        ASSERT(proc_num_simd_saved() == proc_num_simd_saved_abs());
         for (i = 0; i < proc_num_simd_saved(); i++) {
             if (!cci->simd_skip[i]) {
                 PRE(ilist, instr,

--- a/core/arch/x86/proc.c
+++ b/core/arch/x86/proc.c
@@ -70,7 +70,7 @@
 static bool avx_enabled;
 
 static int num_simd_saved;
-static int num_simd_saved_abs;
+static int num_simd_registers;
 
 /* global writable variable for debug registers value */
 DECLARE_NEVERPROT_VAR(app_pc d_r_debug_register[DEBUG_REGISTERS_NB], { 0 });
@@ -358,7 +358,7 @@ proc_init_arch(void)
                   "Unsupported processor type: SSE and FXSR must match");
 
     num_simd_saved = MCXT_NUM_SIMD_SLOTS;
-    num_simd_saved_abs = MCXT_NUM_SIMD_SLOTS;
+    num_simd_registers = MCXT_NUM_SIMD_SLOTS;
 
     if (proc_has_feature(FEATURE_AVX) && proc_has_feature(FEATURE_OSXSAVE)) {
         /* Even if the processor supports AVX, it will #UD on any AVX instruction
@@ -435,9 +435,9 @@ proc_num_simd_saved(void)
 
 DR_API
 int
-proc_num_simd_saved_abs(void)
+proc_num_simd_registers(void)
 {
-    return num_simd_saved_abs;
+    return num_simd_registers;
 }
 
 DR_API

--- a/core/arch/x86/proc.c
+++ b/core/arch/x86/proc.c
@@ -70,6 +70,7 @@
 static bool avx_enabled;
 
 static int num_simd_saved;
+static int num_simd_saved_abs;
 
 /* global writable variable for debug registers value */
 DECLARE_NEVERPROT_VAR(app_pc d_r_debug_register[DEBUG_REGISTERS_NB], { 0 });
@@ -357,6 +358,7 @@ proc_init_arch(void)
                   "Unsupported processor type: SSE and FXSR must match");
 
     num_simd_saved = MCXT_NUM_SIMD_SLOTS;
+    num_simd_saved_abs = MCXT_NUM_SIMD_SLOTS;
 
     if (proc_has_feature(FEATURE_AVX) && proc_has_feature(FEATURE_OSXSAVE)) {
         /* Even if the processor supports AVX, it will #UD on any AVX instruction
@@ -429,6 +431,13 @@ int
 proc_num_simd_saved(void)
 {
     return num_simd_saved;
+}
+
+DR_API
+int
+proc_num_simd_saved_abs(void)
+{
+    return num_simd_saved_abs;
 }
 
 DR_API

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -5380,7 +5380,7 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
         cci.num_simd_skip = 6;
 #else
         /* all 8 (or 16) are scratch */
-        cci.num_simd_skip = MCXT_NUM_SIMD_SLOTS;
+        cci.num_simd_skip = proc_num_simd_saved_abs();
 #endif
         for (i = 0; i < cci.num_simd_skip; i++)
             cci.simd_skip[i] = true;

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -5372,7 +5372,7 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
     if (TESTANY(DR_CLEANCALL_NOSAVE_XMM | DR_CLEANCALL_NOSAVE_XMM_NONPARAM |
                     DR_CLEANCALL_NOSAVE_XMM_NONRET,
                 save_flags)) {
-        uint i;
+        int i;
         /* even if we remove xmm saves we want to keep mcontext shape */
         cci.preserve_mcontext = true;
         /* start w/ all */

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -5380,7 +5380,7 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
         cci.num_simd_skip = 6;
 #else
         /* all 8 (or 16) are scratch */
-        cci.num_simd_skip = proc_num_simd_saved_abs();
+        cci.num_simd_skip = proc_num_simd_registers();
 #endif
         for (i = 0; i < cci.num_simd_skip; i++)
             cci.simd_skip[i] = true;

--- a/core/unix/signal_linux_x86.c
+++ b/core/unix/signal_linux_x86.c
@@ -219,6 +219,7 @@ save_xmm(dcontext_t *dcontext, sigframe_rt_t *frame)
         asm volatile("xsave %0" : "=m"(*xstate));
 #endif
     }
+    /* XXX i#1312: this needs to get extended to AVX-512. */
     if (YMM_ENABLED()) {
         /* all ymm regs are in our mcontext.  the only other thing
          * in xstate is the xgetbv.
@@ -368,7 +369,8 @@ dump_fpstate(dcontext_t *dcontext, kernel_fpstate_t *fp)
         LOG(THREAD, LOG_ASYNCH, 1, "\n");
     }
 #    endif
-    /* ignore padding */
+    /* XXX i#1312: this needs to get extended to AVX-512. */
+    /* Ignore padding */
     if (YMM_ENABLED()) {
         kernel_xstate_t *xstate = (kernel_xstate_t *)fp;
         if (fp->sw_reserved.magic1 == FP_XSTATE_MAGIC1) {
@@ -379,7 +381,7 @@ dump_fpstate(dcontext_t *dcontext, kernel_fpstate_t *fp)
             ASSERT(TEST(XCR0_AVX, fp->sw_reserved.xstate_bv));
             LOG(THREAD, LOG_ASYNCH, 1, "\txstate_bv = 0x" HEX64_FORMAT_STRING "\n",
                 xstate->xstate_hdr.xstate_bv);
-            for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+            for (i = 0; i < proc_num_simd_saved_abs(); i++) {
                 LOG(THREAD, LOG_ASYNCH, 1, "\tymmh%d = ", i);
                 for (j = 0; j < 4; j++) {
                     LOG(THREAD, LOG_ASYNCH, 1, "%04x ",
@@ -442,10 +444,11 @@ dump_sigcontext(dcontext_t *dcontext, sigcontext_t *sc)
 void
 sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
 {
+    /* XXX i#1312: this needs to get extended to AVX-512. */
     sigcontext_t *sc = sc_full->sc;
     if (sc->fpstate != NULL) {
         int i;
-        for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
             memcpy(&mc->ymm[i], &sc->fpstate->IF_X64_ELSE(xmm_space[i * 4], _xmm[i]),
                    XMM_REG_SIZE);
         }
@@ -457,7 +460,7 @@ sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
                  */
                 ASSERT(sc->fpstate->sw_reserved.extended_size >= sizeof(*xstate));
                 ASSERT(TEST(XCR0_AVX, sc->fpstate->sw_reserved.xstate_bv));
-                for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+                for (i = 0; i < proc_num_simd_saved_abs(); i++) {
                     memcpy(&mc->ymm[i].u32[4], &xstate->ymmh.ymmh_space[i * 4],
                            YMMH_REG_SIZE);
                 }
@@ -469,10 +472,11 @@ sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
 void
 mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
 {
+    /* XXX i#1312: this needs to get extended to AVX-512. */
     sigcontext_t *sc = sc_full->sc;
     if (sc->fpstate != NULL) {
         int i;
-        for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
             memcpy(&sc->fpstate->IF_X64_ELSE(xmm_space[i * 4], _xmm[i]), &mc->ymm[i],
                    XMM_REG_SIZE);
         }
@@ -484,7 +488,7 @@ mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
                  */
                 ASSERT(sc->fpstate->sw_reserved.extended_size >= sizeof(*xstate));
                 ASSERT(TEST(XCR0_AVX, sc->fpstate->sw_reserved.xstate_bv));
-                for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+                for (i = 0; i < proc_num_simd_saved_abs(); i++) {
                     memcpy(&xstate->ymmh.ymmh_space[i * 4], &mc->ymm[i].u32[4],
                            YMMH_REG_SIZE);
                 }

--- a/core/unix/signal_linux_x86.c
+++ b/core/unix/signal_linux_x86.c
@@ -370,7 +370,7 @@ dump_fpstate(dcontext_t *dcontext, kernel_fpstate_t *fp)
     }
 #    endif
     /* XXX i#1312: this needs to get extended to AVX-512. */
-    /* Ignore padding */
+    /* Ignore padding. */
     if (YMM_ENABLED()) {
         kernel_xstate_t *xstate = (kernel_xstate_t *)fp;
         if (fp->sw_reserved.magic1 == FP_XSTATE_MAGIC1) {
@@ -381,7 +381,7 @@ dump_fpstate(dcontext_t *dcontext, kernel_fpstate_t *fp)
             ASSERT(TEST(XCR0_AVX, fp->sw_reserved.xstate_bv));
             LOG(THREAD, LOG_ASYNCH, 1, "\txstate_bv = 0x" HEX64_FORMAT_STRING "\n",
                 xstate->xstate_hdr.xstate_bv);
-            for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+            for (i = 0; i < proc_num_simd_registers(); i++) {
                 LOG(THREAD, LOG_ASYNCH, 1, "\tymmh%d = ", i);
                 for (j = 0; j < 4; j++) {
                     LOG(THREAD, LOG_ASYNCH, 1, "%04x ",
@@ -448,7 +448,7 @@ sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
     sigcontext_t *sc = sc_full->sc;
     if (sc->fpstate != NULL) {
         int i;
-        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+        for (i = 0; i < proc_num_simd_registers(); i++) {
             memcpy(&mc->ymm[i], &sc->fpstate->IF_X64_ELSE(xmm_space[i * 4], _xmm[i]),
                    XMM_REG_SIZE);
         }
@@ -460,7 +460,7 @@ sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
                  */
                 ASSERT(sc->fpstate->sw_reserved.extended_size >= sizeof(*xstate));
                 ASSERT(TEST(XCR0_AVX, sc->fpstate->sw_reserved.xstate_bv));
-                for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+                for (i = 0; i < proc_num_simd_registers(); i++) {
                     memcpy(&mc->ymm[i].u32[4], &xstate->ymmh.ymmh_space[i * 4],
                            YMMH_REG_SIZE);
                 }
@@ -476,7 +476,7 @@ mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
     sigcontext_t *sc = sc_full->sc;
     if (sc->fpstate != NULL) {
         int i;
-        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+        for (i = 0; i < proc_num_simd_registers(); i++) {
             memcpy(&sc->fpstate->IF_X64_ELSE(xmm_space[i * 4], _xmm[i]), &mc->ymm[i],
                    XMM_REG_SIZE);
         }
@@ -488,7 +488,7 @@ mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
                  */
                 ASSERT(sc->fpstate->sw_reserved.extended_size >= sizeof(*xstate));
                 ASSERT(TEST(XCR0_AVX, sc->fpstate->sw_reserved.xstate_bv));
-                for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+                for (i = 0; i < proc_num_simd_registers(); i++) {
                     memcpy(&xstate->ymmh.ymmh_space[i * 4], &mc->ymm[i].u32[4],
                            YMMH_REG_SIZE);
                 }

--- a/core/unix/signal_macos.c
+++ b/core/unix/signal_macos.c
@@ -153,11 +153,15 @@ sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
      */
     sigcontext_t *sc = sc_full->sc;
     int i;
-    for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+    /* XXX i#1312: This assumption will change and the code below may need
+     * to take this into account.
+     */
+    ASSERT(MCXT_NUM_SIMD_SLOTS == proc_num_simd_saved_abs());
+    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
         memcpy(&mc->ymm[i], &sc->__fs.__fpu_xmm0 + i, XMM_REG_SIZE);
     }
     if (YMM_ENABLED()) {
-        for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
             memcpy(&mc->ymm[i].u32[4], &sc->__fs.__fpu_ymmh0 + i, YMMH_REG_SIZE);
         }
     }
@@ -168,11 +172,15 @@ mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
 {
     sigcontext_t *sc = sc_full->sc;
     int i;
-    for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+    /* XXX i#1312: This assumption will change and the code below may need
+     * to take this into account.
+     */
+    ASSERT(MCXT_NUM_SIMD_SLOTS == proc_num_simd_saved_abs());
+    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
         memcpy(&sc->__fs.__fpu_xmm0 + i, &mc->ymm[i], XMM_REG_SIZE);
     }
     if (YMM_ENABLED()) {
-        for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
             memcpy(&sc->__fs.__fpu_ymmh0 + i, &mc->ymm[i].u32[4], YMMH_REG_SIZE);
         }
     }
@@ -200,7 +208,8 @@ dump_fpstate(dcontext_t *dcontext, sigcontext_t *sc)
         }
         LOG(THREAD, LOG_ASYNCH, 1, "\n");
     }
-    for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+    /* XXX i#1312: this needs to get extended to AVX-512. */
+    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
         LOG(THREAD, LOG_ASYNCH, 1, "\txmm%d = ", i);
         for (j = 0; j < 4; j++) {
             LOG(THREAD, LOG_ASYNCH, 1, "%08x ",
@@ -209,7 +218,7 @@ dump_fpstate(dcontext_t *dcontext, sigcontext_t *sc)
         LOG(THREAD, LOG_ASYNCH, 1, "\n");
     }
     if (YMM_ENABLED()) {
-        for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
             LOG(THREAD, LOG_ASYNCH, 1, "\tymmh%d = ", i);
             for (j = 0; j < 4; j++) {
                 LOG(THREAD, LOG_ASYNCH, 1, "%08x ",

--- a/core/unix/signal_macos.c
+++ b/core/unix/signal_macos.c
@@ -156,12 +156,12 @@ sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
     /* XXX i#1312: This assumption will change and the code below may need
      * to take this into account.
      */
-    ASSERT(MCXT_NUM_SIMD_SLOTS == proc_num_simd_saved_abs());
-    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+    ASSERT(MCXT_NUM_SIMD_SLOTS == proc_num_simd_registers());
+    for (i = 0; i < proc_num_simd_registers(); i++) {
         memcpy(&mc->ymm[i], &sc->__fs.__fpu_xmm0 + i, XMM_REG_SIZE);
     }
     if (YMM_ENABLED()) {
-        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+        for (i = 0; i < proc_num_simd_registers(); i++) {
             memcpy(&mc->ymm[i].u32[4], &sc->__fs.__fpu_ymmh0 + i, YMMH_REG_SIZE);
         }
     }
@@ -175,12 +175,12 @@ mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
     /* XXX i#1312: This assumption will change and the code below may need
      * to take this into account.
      */
-    ASSERT(MCXT_NUM_SIMD_SLOTS == proc_num_simd_saved_abs());
-    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+    ASSERT(MCXT_NUM_SIMD_SLOTS == proc_num_simd_registers());
+    for (i = 0; i < proc_num_simd_registers(); i++) {
         memcpy(&sc->__fs.__fpu_xmm0 + i, &mc->ymm[i], XMM_REG_SIZE);
     }
     if (YMM_ENABLED()) {
-        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+        for (i = 0; i < proc_num_simd_registers(); i++) {
             memcpy(&sc->__fs.__fpu_ymmh0 + i, &mc->ymm[i].u32[4], YMMH_REG_SIZE);
         }
     }
@@ -209,7 +209,7 @@ dump_fpstate(dcontext_t *dcontext, sigcontext_t *sc)
         LOG(THREAD, LOG_ASYNCH, 1, "\n");
     }
     /* XXX i#1312: this needs to get extended to AVX-512. */
-    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+    for (i = 0; i < proc_num_simd_registers(); i++) {
         LOG(THREAD, LOG_ASYNCH, 1, "\txmm%d = ", i);
         for (j = 0; j < 4; j++) {
             LOG(THREAD, LOG_ASYNCH, 1, "%08x ",
@@ -218,7 +218,7 @@ dump_fpstate(dcontext_t *dcontext, sigcontext_t *sc)
         LOG(THREAD, LOG_ASYNCH, 1, "\n");
     }
     if (YMM_ENABLED()) {
-        for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+        for (i = 0; i < proc_num_simd_registers(); i++) {
             LOG(THREAD, LOG_ASYNCH, 1, "\tymmh%d = ", i);
             for (j = 0; j < 4; j++) {
                 LOG(THREAD, LOG_ASYNCH, 1, "%08x ",

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -4718,6 +4718,10 @@ dump_context_info(CONTEXT *context, file_t file, bool all)
     /* Even if all, we have to ensure we have the ExtendedRegister fields,
      * which for a dynamically-laid-out context may not exist (i#1223).
      */
+    /* XXX i#1312: This will need attention for AVX-512, specifically the different
+     * xstate formats supported by the processor, compacted and standard, as well as
+     * MPX.
+     */
     if ((all && !CONTEXT_DYNAMICALLY_LAID_OUT(context->ContextFlags)) ||
         TESTALL(CONTEXT_XMM_FLAG, context->ContextFlags)) {
         int i, j;

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -1,7 +1,7 @@
-\/* **********************************************************
-  * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
-  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
-  * **********************************************************/
+/* **********************************************************
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
+ * **********************************************************/
 
 /*
  * Redistribution and use in source and binary forms, with or without
@@ -65,10 +65,10 @@
 #define DYNAMORIO_ENTRY "dynamo_auto_start"
 
 #ifdef DEBUG
-    /* for asserts, we import globals.h now (for pragmas) so don't need to
-     * duplicate assert defines, declarations */
-    extern void
-    display_error(char *msg);
+/* for asserts, we import globals.h now (for pragmas) so don't need to
+ * duplicate assert defines, declarations */
+extern void
+display_error(char *msg);
 #else
 #    define display_error(msg) ((void)0)
 #endif
@@ -243,7 +243,8 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle, char *dynamo_pa
             /* For x86, ensure we have ExtendedRegisters space (i#1223) */
             IF_NOT_X64(ASSERT(TEST(CONTEXT_XMM_FLAG, cxt->ContextFlags)));
             /* XXX i#1312: This should be proc_num_simd_saved_abs() which is part of
-             * the dynamorio lib. */
+             * the dynamorio lib.
+             */
             for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
                 for (j = 0; j < IF_X64_ELSE(2, 4); j++) {
                     *bufptr++ = CXT_XMM(cxt, i)->reg[j];

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -1,7 +1,7 @@
-/* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
- * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
- * **********************************************************/
+\/* **********************************************************
+  * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
+  * **********************************************************/
 
 /*
  * Redistribution and use in source and binary forms, with or without
@@ -64,13 +64,11 @@
 /* this entry point is hardcoded, FIXME : abstract */
 #define DYNAMORIO_ENTRY "dynamo_auto_start"
 
-extern int proc_num_simd_saved_abs();
-
 #ifdef DEBUG
-/* for asserts, we import globals.h now (for pragmas) so don't need to
- * duplicate assert defines, declarations */
-extern void
-display_error(char *msg);
+    /* for asserts, we import globals.h now (for pragmas) so don't need to
+     * duplicate assert defines, declarations */
+    extern void
+    display_error(char *msg);
 #else
 #    define display_error(msg) ((void)0)
 #endif
@@ -244,7 +242,9 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle, char *dynamo_pa
             int i, j;
             /* For x86, ensure we have ExtendedRegisters space (i#1223) */
             IF_NOT_X64(ASSERT(TEST(CONTEXT_XMM_FLAG, cxt->ContextFlags)));
-            for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+            /* XXX i#1312: This should be proc_num_simd_saved_abs() which is part of
+             * the dynamorio lib. */
+            for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
                 for (j = 0; j < IF_X64_ELSE(2, 4); j++) {
                     *bufptr++ = CXT_XMM(cxt, i)->reg[j];
                 }

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -242,7 +242,7 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle, char *dynamo_pa
             int i, j;
             /* For x86, ensure we have ExtendedRegisters space (i#1223) */
             IF_NOT_X64(ASSERT(TEST(CONTEXT_XMM_FLAG, cxt->ContextFlags)));
-            /* XXX i#1312: This should be proc_num_simd_saved_abs() which is part of
+            /* XXX i#1312: This should be proc_num_simd_registers() which is part of
              * the dynamorio lib.
              */
             for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -242,7 +242,7 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle, char *dynamo_pa
             int i, j;
             /* For x86, ensure we have ExtendedRegisters space (i#1223) */
             IF_NOT_X64(ASSERT(TEST(CONTEXT_XMM_FLAG, cxt->ContextFlags)));
-            for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+            for (i = 0; i < proc_num_simd_saved_abs(); i++) {
                 for (j = 0; j < IF_X64_ELSE(2, 4); j++) {
                     *bufptr++ = CXT_XMM(cxt, i)->reg[j];
                 }

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -64,6 +64,8 @@
 /* this entry point is hardcoded, FIXME : abstract */
 #define DYNAMORIO_ENTRY "dynamo_auto_start"
 
+extern int proc_num_simd_saved_abs();
+
 #ifdef DEBUG
 /* for asserts, we import globals.h now (for pragmas) so don't need to
  * duplicate assert defines, declarations */

--- a/core/win32/ntdll.c
+++ b/core/win32/ntdll.c
@@ -1120,11 +1120,15 @@ context_to_mcontext_internal(priv_mcontext_t *mcontext, CONTEXT *cxt)
     mcontext->r14 = cxt->R14;
     mcontext->r15 = cxt->R15;
 #        endif
+    /* XXX i#1312: This will need attention for AVX-512, specifically the different
+     * xstate formats supported by the processor, compacted and standard, as well as
+     * MPX.
+     */
     if (CONTEXT_PRESERVE_XMM && TESTALL(CONTEXT_XMM_FLAG, cxt->ContextFlags)) {
         /* no harm done if no sse support */
         /* CONTEXT_FLOATING_POINT or CONTEXT_EXTENDED_REGISTERS */
         int i;
-        for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++)
+        for (i = 0; i < proc_num_simd_saved_abs(); i++)
             memcpy(&mcontext->ymm[i], CXT_XMM(cxt, i), XMM_REG_SIZE);
     }
     /* if XSTATE is NOT set, the app has NOT used any ymm state and
@@ -1134,7 +1138,7 @@ context_to_mcontext_internal(priv_mcontext_t *mcontext, CONTEXT *cxt)
         byte *ymmh_area = context_ymmh_saved_area(cxt);
         if (ymmh_area != NULL) {
             int i;
-            for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+            for (i = 0; i < proc_num_simd_saved_abs(); i++) {
                 memcpy(&mcontext->ymm[i].u32[4], &YMMH_AREA(ymmh_area, i).u32[0],
                        YMMH_REG_SIZE);
             }
@@ -1225,9 +1229,13 @@ mcontext_to_context(CONTEXT *cxt, priv_mcontext_t *mcontext, bool set_cur_seg)
         memcpy(&cxt->ExtendedRegisters, fpstate, written);
 #        endif
         /* Now update w/ the xmm values from mcontext */
-        for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++)
+        for (i = 0; i < proc_num_simd_saved_abs(); i++)
             memcpy(CXT_XMM(cxt, i), &mcontext->ymm[i], XMM_REG_SIZE);
     }
+    /* XXX i#1312: This will need attention for AVX-512, specifically the different
+     * xstate formats supported by the processor, compacted and standard, as well as
+     * MPX.
+     */
     if (CONTEXT_PRESERVE_YMM && TESTALL(CONTEXT_XSTATE, cxt->ContextFlags)) {
         byte *ymmh_area = context_ymmh_saved_area(cxt);
         if (ymmh_area != NULL) {
@@ -1255,7 +1263,7 @@ mcontext_to_context(CONTEXT *cxt, priv_mcontext_t *mcontext, bool set_cur_seg)
             memcpy(&YMMH_AREA(ymmh_area, 6).u32[0], &ymms[0].u32[4], YMMH_REG_SIZE);
             memcpy(&YMMH_AREA(ymmh_area, 7).u32[0], &ymms[1].u32[4], YMMH_REG_SIZE);
 #        endif
-            for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+            for (i = 0; i < proc_num_simd_saved_abs(); i++) {
                 memcpy(&YMMH_AREA(ymmh_area, i).u32[0], &mcontext->ymm[i].u32[4],
                        YMMH_REG_SIZE);
             }

--- a/core/win32/ntdll.c
+++ b/core/win32/ntdll.c
@@ -1128,7 +1128,7 @@ context_to_mcontext_internal(priv_mcontext_t *mcontext, CONTEXT *cxt)
         /* no harm done if no sse support */
         /* CONTEXT_FLOATING_POINT or CONTEXT_EXTENDED_REGISTERS */
         int i;
-        for (i = 0; i < proc_num_simd_saved_abs(); i++)
+        for (i = 0; i < proc_num_simd_registers(); i++)
             memcpy(&mcontext->ymm[i], CXT_XMM(cxt, i), XMM_REG_SIZE);
     }
     /* if XSTATE is NOT set, the app has NOT used any ymm state and
@@ -1138,7 +1138,7 @@ context_to_mcontext_internal(priv_mcontext_t *mcontext, CONTEXT *cxt)
         byte *ymmh_area = context_ymmh_saved_area(cxt);
         if (ymmh_area != NULL) {
             int i;
-            for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+            for (i = 0; i < proc_num_simd_registers(); i++) {
                 memcpy(&mcontext->ymm[i].u32[4], &YMMH_AREA(ymmh_area, i).u32[0],
                        YMMH_REG_SIZE);
             }
@@ -1229,7 +1229,7 @@ mcontext_to_context(CONTEXT *cxt, priv_mcontext_t *mcontext, bool set_cur_seg)
         memcpy(&cxt->ExtendedRegisters, fpstate, written);
 #        endif
         /* Now update w/ the xmm values from mcontext */
-        for (i = 0; i < proc_num_simd_saved_abs(); i++)
+        for (i = 0; i < proc_num_simd_registers(); i++)
             memcpy(CXT_XMM(cxt, i), &mcontext->ymm[i], XMM_REG_SIZE);
     }
     /* XXX i#1312: This will need attention for AVX-512, specifically the different
@@ -1263,7 +1263,7 @@ mcontext_to_context(CONTEXT *cxt, priv_mcontext_t *mcontext, bool set_cur_seg)
             memcpy(&YMMH_AREA(ymmh_area, 6).u32[0], &ymms[0].u32[4], YMMH_REG_SIZE);
             memcpy(&YMMH_AREA(ymmh_area, 7).u32[0], &ymms[1].u32[4], YMMH_REG_SIZE);
 #        endif
-            for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+            for (i = 0; i < proc_num_simd_registers(); i++) {
                 memcpy(&YMMH_AREA(ymmh_area, i).u32[0], &mcontext->ymm[i].u32[4],
                        YMMH_REG_SIZE);
             }

--- a/suite/tests/api/opnd-a64.c
+++ b/suite/tests/api/opnd-a64.c
@@ -58,7 +58,7 @@ test_get_size()
     }
 
     // Check sizes of FP/SIMD regs.
-    for (uint i = 0; i < proc_num_simd_saved_abs(); i++) {
+    for (int i = 0; i < proc_num_simd_saved_abs(); i++) {
         ASSERT(reg_get_size((reg_id_t)DR_REG_H0 + i) == OPSZ_2);
         ASSERT(reg_get_size((reg_id_t)DR_REG_S0 + i) == OPSZ_4);
         ASSERT(reg_get_size((reg_id_t)DR_REG_D0 + i) == OPSZ_8);

--- a/suite/tests/api/opnd-a64.c
+++ b/suite/tests/api/opnd-a64.c
@@ -58,7 +58,7 @@ test_get_size()
     }
 
     // Check sizes of FP/SIMD regs.
-    for (uint i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+    for (uint i = 0; i < proc_num_simd_saved_abs(); i++) {
         ASSERT(reg_get_size((reg_id_t)DR_REG_H0 + i) == OPSZ_2);
         ASSERT(reg_get_size((reg_id_t)DR_REG_S0 + i) == OPSZ_4);
         ASSERT(reg_get_size((reg_id_t)DR_REG_D0 + i) == OPSZ_8);

--- a/suite/tests/api/opnd-a64.c
+++ b/suite/tests/api/opnd-a64.c
@@ -58,7 +58,7 @@ test_get_size()
     }
 
     // Check sizes of FP/SIMD regs.
-    for (int i = 0; i < proc_num_simd_saved_abs(); i++) {
+    for (int i = 0; i < proc_num_simd_registers(); i++) {
         ASSERT(reg_get_size((reg_id_t)DR_REG_H0 + i) == OPSZ_2);
         ASSERT(reg_get_size((reg_id_t)DR_REG_S0 + i) == OPSZ_4);
         ASSERT(reg_get_size((reg_id_t)DR_REG_D0 + i) == OPSZ_8);

--- a/suite/tests/client-interface/cleancall-opt-1.dll.c
+++ b/suite/tests/client-interface/cleancall-opt-1.dll.c
@@ -125,7 +125,7 @@ event_basic_block(void *dc, void *tag, instrlist_t *bb, bool for_trace, bool tra
 static instrlist_t *
 codegen_out_of_line(void *dc)
 {
-    uint i;
+    int i;
     instrlist_t *ilist = instrlist_create(dc);
 
     codegen_prologue(dc, ilist);

--- a/suite/tests/client-interface/cleancall-opt-1.dll.c
+++ b/suite/tests/client-interface/cleancall-opt-1.dll.c
@@ -139,7 +139,7 @@ codegen_out_of_line(void *dc)
     /* FIXME i#1569: FMOV support is NYI on AArch64 */
     /* XXX i#1312: check if test can get extended to AVX, AVX2 and AVX-512. */
 #ifdef X86
-    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+    for (i = 0; i < proc_num_simd_registers(); i++) {
         reg_id_t reg = DR_REG_XMM0 + (reg_id_t)i;
         APP(ilist,
             INSTR_CREATE_movd(dc, opnd_create_reg(reg),

--- a/suite/tests/client-interface/cleancall-opt-1.dll.c
+++ b/suite/tests/client-interface/cleancall-opt-1.dll.c
@@ -137,8 +137,9 @@ codegen_out_of_line(void *dc)
             XINST_CREATE_load_int(dc, opnd_create_reg(reg), OPND_CREATE_INTPTR(0xf1f1)));
     }
     /* FIXME i#1569: FMOV support is NYI on AArch64 */
+    /* XXX i#1312: check if test can get extended to AVX, AVX2 and AVX-512. */
 #ifdef X86
-    for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
         reg_id_t reg = DR_REG_XMM0 + (reg_id_t)i;
         APP(ilist,
             INSTR_CREATE_movd(dc, opnd_create_reg(reg),

--- a/suite/tests/client-interface/cleancall-opt-shared.h
+++ b/suite/tests/client-interface/cleancall-opt-shared.h
@@ -270,12 +270,12 @@ mcontexts_equal(dr_mcontext_t *mc_a, dr_mcontext_t *mc_b, int func_index)
     /* Only look at the initialized bits of the SSE regs. */
     /* XXX i#1312: check if test can get extended to AVX-512. */
     ymm_bytes_used = (proc_has_feature(FEATURE_AVX) ? 32 : 16);
-    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+    for (i = 0; i < proc_num_simd_registers(); i++) {
         if (memcmp(&mc_a->ymm[i], &mc_b->ymm[i], ymm_bytes_used) != 0)
             return false;
     }
 #elif defined(AARCH64)
-    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+    for (i = 0; i < proc_num_simd_registers(); i++) {
         if (memcmp(&mc_a->simd[i], &mc_b->simd[i], sizeof(dr_simd_t)) != 0)
             return false;
     }
@@ -303,7 +303,7 @@ dump_diff_mcontexts(void)
 
     dr_fprintf(STDERR, "Printing XMM regs:\n");
     /* XXX i#1312: check if test can get extended to AVX-512. */
-    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
+    for (i = 0; i < proc_num_simd_registers(); i++) {
 #ifdef X86
         dr_ymm_t before_reg = before_mcontext.ymm[i];
         dr_ymm_t after_reg = after_mcontext.ymm[i];

--- a/suite/tests/client-interface/cleancall-opt-shared.h
+++ b/suite/tests/client-interface/cleancall-opt-shared.h
@@ -287,7 +287,7 @@ mcontexts_equal(dr_mcontext_t *mc_a, dr_mcontext_t *mc_b, int func_index)
 static void
 dump_diff_mcontexts(void)
 {
-    uint i;
+    int i;
     dr_fprintf(STDERR,
                "Registers clobbered by supposedly clean call!\n"
                "Printing GPRs + flags:\n");

--- a/suite/tests/client-interface/cleancall-opt-shared.h
+++ b/suite/tests/client-interface/cleancall-opt-shared.h
@@ -268,13 +268,14 @@ mcontexts_equal(dr_mcontext_t *mc_a, dr_mcontext_t *mc_b, int func_index)
 
 #ifdef X86
     /* Only look at the initialized bits of the SSE regs. */
+    /* XXX i#1312: check if test can get extended to AVX-512. */
     ymm_bytes_used = (proc_has_feature(FEATURE_AVX) ? 32 : 16);
-    for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
         if (memcmp(&mc_a->ymm[i], &mc_b->ymm[i], ymm_bytes_used) != 0)
             return false;
     }
 #elif defined(AARCH64)
-    for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
         if (memcmp(&mc_a->simd[i], &mc_b->simd[i], sizeof(dr_simd_t)) != 0)
             return false;
     }
@@ -301,7 +302,8 @@ dump_diff_mcontexts(void)
     }
 
     dr_fprintf(STDERR, "Printing XMM regs:\n");
-    for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
+    /* XXX i#1312: check if test can get extended to AVX-512. */
+    for (i = 0; i < proc_num_simd_saved_abs(); i++) {
 #ifdef X86
         dr_ymm_t before_reg = before_mcontext.ymm[i];
         dr_ymm_t after_reg = after_mcontext.ymm[i];


### PR DESCRIPTION
This patch takes the next step towards migrating all of DynamoRIO's context switching to support AVX-512. The function proc_num_simd_saved_abs() is introduced that returns the total number of SIMD registers on a given processor and OS. In the future, this number may be different from proc_num_simd_saved() that returns the number of SIMD registers that are actually saved by DynamoRIO and may be optimized. MCXT_NUM_SIMD_SLOTS is now the static number of slots in DynamoRIO's mcontext, regardless of what processor and OS actually support.

Issue: #1312