### PR TITLE
i#1409 core libs: remove module files from unix drinjectlib

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -377,11 +377,6 @@ if (UNIX)
     string.c
     io.c
     )
-  if (APPLE)
-    set(INJECTOR_SRCS ${INJECTOR_SRCS} unix/module_macho.c)
-  else (APPLE)
-    set(INJECTOR_SRCS ${INJECTOR_SRCS} unix/module_elf.c)
-  endif ()
 
 else (UNIX)
   set(OSNAME win32)


### PR DESCRIPTION
The module_{elf,macho}.c files are part of drlibc but 710a689 failed
to remove them from the UNIX drinjectlib source list.  We do that here.

Issue: #1409