### PR TITLE
i#3348 sym conflicts: Rename more multi-word globals

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -644,7 +644,7 @@ far_ibl_set_targets(ibl_code_t src_ibl[], ibl_code_t tgt_ibl[])
 
 /* arch-specific initializations */
 void
-arch_init(void)
+d_r_arch_init(void)
 {
     ASSERT(sizeof(opnd_t) == EXPECTED_SIZEOF_OPND);
     IF_X86(ASSERT(CHECK_TRUNCATE_TYPE_byte(OPSZ_LAST)));
@@ -853,7 +853,7 @@ arch_profile_exit()
 #endif /* WINDOWS_PC_SAMPLE */
 
 /* arch-specific atexit cleanup */
-void arch_exit(IF_WINDOWS_ELSE_NP(bool detach_stacked_callbacks, void))
+void d_r_arch_exit(IF_WINDOWS_ELSE_NP(bool detach_stacked_callbacks, void))
 {
     /* we only need to unprotect shared_code for profile extraction
      * so we do it there to also cover the fast exit path

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -1025,8 +1025,8 @@ get_time(void);
 #endif
 
 void
-arch_init(void);
-void arch_exit(IF_WINDOWS_ELSE_NP(bool detach_stacked_callbacks, void));
+d_r_arch_init(void);
+void d_r_arch_exit(IF_WINDOWS_ELSE_NP(bool detach_stacked_callbacks, void));
 void
 arch_thread_init(dcontext_t *dcontext);
 void
@@ -1527,7 +1527,7 @@ app_pc
 canonicalize_pc_target(dcontext_t *dcontext, app_pc pc);
 
 void
-decode_init(void);
+d_r_decode_init(void);
 
 /***************************************************************************
  * Arch-specific defines

--- a/core/arch/arm/emit_utils.c
+++ b/core/arch/arm/emit_utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -884,7 +884,7 @@ insert_mode_change_handling(dcontext_t *dc, instrlist_t *ilist, instr_t *where,
     /* Get LSB from target address */
     PRE(ilist, where,
         INSTR_CREATE_and(dc, OPREG(scratch1), OPREG(addr_reg), OPND_CREATE_INT(1)));
-    /* Get right enum value. arch_init() ensures A32 + 1 == Thumb. */
+    /* Get right enum value. d_r_arch_init() ensures A32 + 1 == Thumb. */
     PRE(ilist, where,
         INSTR_CREATE_add(dc, OPREG(scratch1), OPREG(scratch1),
                          OPND_CREATE_INT(DR_ISA_ARM_A32)));

--- a/core/arch/decode.h
+++ b/core/arch/decode.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -177,7 +177,7 @@ enum {
  * as opnd_size_t when we have the type available, so we can overlap
  * the two enums by adding new registers consecutively to the reg enum.
  * The reg_id_t type is now wider, but for x86 we ensure our values
- * all fit via an assert in arch_init().
+ * all fit via an assert in d_r_arch_init().
  * To maintain backward compatibility we keep the OPSZ_ constants
  * starting at the same spot, now midway through the reg enum:
  */

--- a/core/arch/decode_shared.c
+++ b/core/arch/decode_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -314,7 +314,7 @@ const instr_info_t invalid_instr = { OP_INVALID, 0x000000, "(bad)", xx, xx, xx,
 
 /* PR 302344: used for shared traces -tracedump_origins where we
  * need to change the mode but we have no dcontext.
- * We update this in decode_init() once we have runtime options,
+ * We update this in d_r_decode_init() once we have runtime options,
  * but this is the only version for drdecodelib.
  */
 static dr_isa_mode_t initexit_isa_mode = DEFAULT_ISA_MODE_STATIC;
@@ -389,7 +389,7 @@ decode_debug_checks(void)
 #endif
 
 void
-decode_init(void)
+d_r_decode_init(void)
 {
     /* DEFAULT_ISA_MODE is no longer constant so we set it here */
     initexit_isa_mode = DEFAULT_ISA_MODE;

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -762,7 +762,7 @@ enum {
 /* we avoid typedef-ing the enum, as its storage size is compiler-specific */
 typedef ushort reg_id_t; /**< The type of a DR_REG_ enum value. */
 /* For x86 we do store reg_id_t here, but the x86 DR_REG_ enum is small enough
- * (checked in arch_init().
+ * (checked in d_r_arch_init().
  */
 typedef byte opnd_size_t; /**< The type of an OPSZ_ enum value. */
 
@@ -1299,7 +1299,7 @@ struct _opnd_t {
 };
 #endif
 
-/* We assert that our fields are packed properly in arch_init().
+/* We assert that our fields are packed properly in d_r_arch_init().
  * We could use #pragma pack to shrink x64 back down to 12 bytes (it's at 16
  * b/c the struct is aligned to its max field align which is 8), but
  * probably not much gain since in either case it's passed/returned as a pointer

--- a/core/config.c
+++ b/core/config.c
@@ -709,7 +709,7 @@ get_parameter_ex(const char *name, char *value, int maxlen, bool ignore_cache)
 }
 
 int
-get_parameter(const char *name, char *value, int maxlen)
+d_r_get_parameter(const char *name, char *value, int maxlen)
 {
     return get_parameter_ex(name, value, maxlen, false);
 }
@@ -718,7 +718,7 @@ int
 get_unqualified_parameter(const char *name, char *value, int maxlen)
 {
     /* we don't use qualified names w/ our config files yet */
-    return get_parameter(name, value, maxlen);
+    return d_r_get_parameter(name, value, maxlen);
 }
 
 #    ifdef UNIX

--- a/core/config.h
+++ b/core/config.h
@@ -77,7 +77,7 @@ get_config_val_other_arch(const char *var, char *val, size_t valsz, bool *app_sp
 #    define PARAM_STR(name) L_IF_WIN(name)
 /* redeclared in inject_shared.h */
 int
-get_parameter(const wchar_t *name, char *value, int maxlen);
+d_r_get_parameter(const wchar_t *name, char *value, int maxlen);
 
 int
 get_parameter_ex(const wchar_t *name, char *value, int maxlen, bool ignore_cache);
@@ -88,7 +88,7 @@ get_parameter_ex(const wchar_t *name, char *value, int maxlen, bool ignore_cache
 #    define PARAM_STR(name) name
 
 int
-get_parameter(const char *name, char *value, int maxlen);
+d_r_get_parameter(const char *name, char *value, int maxlen);
 
 int
 get_parameter_ex(const char *name, char *value, int maxlen, bool ignore_cache);

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -1016,13 +1016,13 @@ dispatch_exit_fcache(dcontext_t *dcontext)
         ASSERT(!is_dynamo_address((byte *)dcontext->app_stack_base - 1) ||
                IS_CLIENT_THREAD(dcontext));
         ASSERT((SWAP_TEB_STACKBASE() &&
-                is_dynamo_address((byte *)get_tls(TOP_STACK_TIB_OFFSET) - 1)) ||
+                is_dynamo_address((byte *)d_r_get_tls(TOP_STACK_TIB_OFFSET) - 1)) ||
                (!SWAP_TEB_STACKBASE() &&
-                !is_dynamo_address((byte *)get_tls(TOP_STACK_TIB_OFFSET) - 1)));
+                !is_dynamo_address((byte *)d_r_get_tls(TOP_STACK_TIB_OFFSET) - 1)));
         ASSERT((SWAP_TEB_STACKLIMIT() &&
-                is_dynamo_address(get_tls(BASE_STACK_TIB_OFFSET))) ||
+                is_dynamo_address(d_r_get_tls(BASE_STACK_TIB_OFFSET))) ||
                (!SWAP_TEB_STACKLIMIT() &&
-                !is_dynamo_address(get_tls(BASE_STACK_TIB_OFFSET))));
+                !is_dynamo_address(d_r_get_tls(BASE_STACK_TIB_OFFSET))));
         /* DrMi#1723: ensure client hitting app guard page updated TEB.StackLimit.
          * Unfortunately this does happen with fiber code that updates TEB before
          * swapping the stack in the next bb so we make it a curiosity.
@@ -1031,7 +1031,7 @@ dispatch_exit_fcache(dcontext_t *dcontext)
             (SWAP_TEB_STACKLIMIT() &&
              get_mcontext(dcontext)->xsp >= (reg_t)dcontext->app_stack_limit) ||
             (!SWAP_TEB_STACKLIMIT() &&
-             get_mcontext(dcontext)->xsp >= (reg_t)get_tls(BASE_STACK_TIB_OFFSET)));
+             get_mcontext(dcontext)->xsp >= (reg_t)d_r_get_tls(BASE_STACK_TIB_OFFSET)));
         ASSERT(dcontext->app_nls_cache == NULL ||
                dcontext->app_nls_cache != dcontext->priv_nls_cache);
     }

--- a/core/drlibc/drlibc_notdr_printlog.c
+++ b/core/drlibc/drlibc_notdr_printlog.c
@@ -39,7 +39,7 @@
 #include "../globals.h"
 
 WEAK void
-print_log(file_t logfile, uint mask, uint level, const char *fmt, ...)
+d_r_print_log(file_t logfile, uint mask, uint level, const char *fmt, ...)
 {
     /* Do nothing for non-core. */
 }

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -1478,7 +1478,7 @@ fcache_free_unit(dcontext_t *dcontext, fcache_unit_t *unit, bool dealloc_or_reus
     }
     /* heuristic: don't keep around more dead units than max(5, 1/4 num threads) */
     else if (allunits->num_dead < 5 ||
-             allunits->num_dead * 4U <= (uint)get_num_threads()) {
+             allunits->num_dead * 4U <= (uint)d_r_get_num_threads()) {
         /* Keep dead list sorted small-to-large to avoid grabbing large
          * when can take small and then needing to allocate when only
          * have small left.  Helps out with lots of small threads.

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -859,7 +859,8 @@ fragment_add_to_hashtable(dcontext_t *dcontext, fragment_t *e, fragment_table_t 
      * thread in the process.
      */
     DOCHECK(1, {
-        if (TEST(FRAG_TABLE_IBL_TARGETED, table->table_flags) && get_num_threads() == 1)
+        if (TEST(FRAG_TABLE_IBL_TARGETED, table->table_flags) &&
+            d_r_get_num_threads() == 1)
             ASSERT(!TEST(FRAG_IS_TRACE_HEAD, e->flags));
     });
 

--- a/core/globals.h
+++ b/core/globals.h
@@ -571,7 +571,7 @@ remove_thread(IF_WINDOWS_(HANDLE hthread) thread_id_t tid);
 uint
 get_thread_num(thread_id_t tid);
 int
-get_num_threads(void);
+d_r_get_num_threads(void);
 bool
 is_last_app_thread(void);
 void

--- a/core/heap.c
+++ b/core/heap.c
@@ -1576,7 +1576,7 @@ heap_reset_init()
 
 /* initialization */
 void
-heap_init()
+d_r_heap_init()
 {
     int i;
     uint prev_sz = 0;
@@ -1693,7 +1693,7 @@ heap_reset_free()
 
 /* atexit cleanup */
 void
-heap_exit()
+d_r_heap_exit()
 {
     heap_unit_t *u, *next_u;
     heap_management_t *temp;
@@ -2564,8 +2564,8 @@ is_stack_overflow(dcontext_t *dcontext, byte *sp)
 }
 
 byte *
-map_file(file_t f, size_t *size INOUT, uint64 offs, app_pc addr, uint prot,
-         map_flags_t map_flags)
+d_r_map_file(file_t f, size_t *size INOUT, uint64 offs, app_pc addr, uint prot,
+             map_flags_t map_flags)
 {
     byte *view;
     /* memory alloc/dealloc and updating DR list must be atomic */
@@ -2582,7 +2582,7 @@ map_file(file_t f, size_t *size INOUT, uint64 offs, app_pc addr, uint prot,
 }
 
 bool
-unmap_file(byte *map, size_t size)
+d_r_unmap_file(byte *map, size_t size)
 {
     bool success;
     ASSERT(map != NULL && ALIGNED(map, PAGE_SIZE));
@@ -2990,7 +2990,7 @@ heap_free_unit(heap_unit_t *unit, dcontext_t *dcontext)
      */
     if (UNITALLOC(unit) <= HEAP_UNIT_MAX_SIZE &&
         (heapmgt->heap.num_dead < 5 ||
-         heapmgt->heap.num_dead * 4U <= (uint)get_num_threads())) {
+         heapmgt->heap.num_dead * 4U <= (uint)d_r_get_num_threads())) {
         /* Keep dead list sorted small-to-large to avoid grabbing large
          * when can take small and then needing to allocate when only
          * have small left.  Helps out with lots of small threads.

--- a/core/heap.h
+++ b/core/heap.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -142,9 +142,9 @@ rel32_reachable_from_vmcode(byte *target);
 
 /* heap management */
 void
-heap_init(void);
+d_r_heap_init(void);
 void
-heap_exit(void);
+d_r_heap_exit(void);
 void
 heap_post_exit(void); /* post exit to support reattach */
 void
@@ -191,10 +191,10 @@ heap_munmap_ex(void *p, size_t size, bool guarded, which_vmm_t which);
 
 /* updates dynamo_areas and calls the os_ versions */
 byte *
-map_file(file_t f, size_t *size INOUT, uint64 offs, app_pc addr, uint prot,
-         map_flags_t map_flags);
+d_r_map_file(file_t f, size_t *size INOUT, uint64 offs, app_pc addr, uint prot,
+             map_flags_t map_flags);
 bool
-unmap_file(byte *map, size_t size);
+d_r_unmap_file(byte *map, size_t size);
 
 /* Allocates executable memory in the same allocation region as this thread's
  * stack, to save address space (case 9474).

--- a/core/hotpatch.c
+++ b/core/hotpatch.c
@@ -839,10 +839,10 @@ hotp_read_data_file(uint type, size_t *buf_len /* OUT */)
 
     *buf_len = 0;
 
-    retval =
-        get_parameter(type == POLICY_FILE ? PARAM_STR(DYNAMORIO_VAR_HOT_PATCH_POLICIES)
-                                          : PARAM_STR(DYNAMORIO_VAR_HOT_PATCH_MODES),
-                      file, BUFFER_SIZE_ELEMENTS(file));
+    retval = d_r_get_parameter(type == POLICY_FILE
+                                   ? PARAM_STR(DYNAMORIO_VAR_HOT_PATCH_POLICIES)
+                                   : PARAM_STR(DYNAMORIO_VAR_HOT_PATCH_MODES),
+                               file, BUFFER_SIZE_ELEMENTS(file));
     if (IS_GET_PARAMETER_FAILURE(retval)) {
         SYSLOG_INTERNAL_WARNING("Can't find %s definition directory name.",
                                 (type == POLICY_FILE) ? "policy" : "mode");
@@ -1145,8 +1145,8 @@ hotp_load_hotp_dlls(hotp_vul_t *vul_tab, uint num_vuls)
          * disable all associated vuls?   We are going to assert/log if we can't
          * find the dll (below) anyway.
          */
-        retval = get_parameter(PARAM_STR(DYNAMORIO_VAR_HOME), hotp_dll_cache,
-                               BUFFER_SIZE_ELEMENTS(hotp_dll_cache));
+        retval = d_r_get_parameter(PARAM_STR(DYNAMORIO_VAR_HOME), hotp_dll_cache,
+                                   BUFFER_SIZE_ELEMENTS(hotp_dll_cache));
         if (IS_GET_PARAMETER_FAILURE(retval)) {
             SYSLOG_INTERNAL_WARNING("Can't read %s.  Hot patch dll loading "
                                     "failed; hot patching won't work.",
@@ -2446,7 +2446,7 @@ hotp_process_image_helper(const app_pc base, const bool loaded,
                             /* gbop is only in -client mode, i.e., hotp_only */
                             ASSERT(DYNAMO_OPTION(hotp_only));
 
-                            func_addr = (app_pc)get_proc_address(
+                            func_addr = (app_pc)d_r_get_proc_address(
                                 (module_handle_t)base, GLOBAL_VUL(vul_idx).vul_id);
                             if (func_addr != NULL) { /* fix for case 7969 */
                                 ASSERT(func_addr > base);

--- a/core/jit_opt.c
+++ b/core/jit_opt.c
@@ -713,7 +713,7 @@ unit_test_insert_random_node(bb_node_t **node_list, app_pc random_base, uint ran
         node_list[index] = fragment_tree_insert(fragment_tree, random_start, random_end);
         return true;
     } else {
-        set_random_seed((uint)query_time_millis());
+        d_r_set_random_seed((uint)query_time_millis());
         return false;
     }
 }
@@ -873,7 +873,7 @@ unit_test_jit_fragment_tree()
     dynamo_options.opt_jit = true;
 
     fragment_tree = fragment_tree_create();
-    set_random_seed((uint)query_time_millis());
+    d_r_set_random_seed((uint)query_time_millis());
 
     for (i = 0; i < 3; i++) {
         print_file(STDERR, "pass %d... ", i + 1);

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1731,7 +1731,7 @@ typedef struct {
 /* These constants & macros are used by core, share and preinject, so this is
  * the only place they will build for win32 and linux! */
 /* return codes for [gs]et_parameter style functions
- * failure == 0 for compatibility with get_parameter()
+ * failure == 0 for compatibility with d_r_get_parameter()
  * if GET_PARAMETER_NOAPPSPECIFIC is returned, that means the
  *  parameter returned is from the global options, because there
  *  was no app-specific key present.

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -6523,10 +6523,10 @@ dr_get_mcontext_priv(dcontext_t *dcontext, dr_mcontext_t *dmc, priv_mcontext_t *
 #ifdef ARM
     if (TEST(DR_MC_INTEGER, dmc->flags)) {
         /* get the stolen register's app value */
-        if (mc != NULL)
+        if (mc != NULL) {
             set_stolen_reg_val(mc,
                                (reg_t)d_r_get_tls(os_tls_offset(TLS_REG_STOLEN_SLOT)));
-        else {
+        } else {
             set_stolen_reg_val(dr_mcontext_as_priv_mcontext(dmc),
                                (reg_t)d_r_get_tls(os_tls_offset(TLS_REG_STOLEN_SLOT)));
         }

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -2814,14 +2814,14 @@ DR_API
 void
 dr_set_random_seed(uint seed)
 {
-    set_random_seed(seed);
+    d_r_set_random_seed(seed);
 }
 
 DR_API
 uint
 dr_get_random_seed(void)
 {
-    return get_random_seed();
+    return d_r_get_random_seed();
 }
 
 /***************************************************************************
@@ -4035,7 +4035,7 @@ dr_get_proc_address(module_handle_t lib, const char *name)
 #    ifdef WINDOWS
     return get_proc_address_resolve_forward(lib, name);
 #    else
-    return get_proc_address(lib, name);
+    return d_r_get_proc_address(lib, name);
 #    endif
 }
 
@@ -4076,7 +4076,7 @@ dr_map_executable_file(const char *filename, dr_map_executable_flags_t flags,
 bool
 dr_unmap_executable_file(byte *base, size_t size)
 {
-    return unmap_file(base, size);
+    return d_r_unmap_file(base, size);
 }
 
 DR_API
@@ -4269,7 +4269,7 @@ DR_API
 void *
 dr_map_file(file_t f, size_t *size INOUT, uint64 offs, app_pc addr, uint prot, uint flags)
 {
-    return (void *)map_file(
+    return (void *)d_r_map_file(
         f, size, offs, addr, prot,
         (TEST(DR_MAP_PRIVATE, flags) ? MAP_FILE_COPY_ON_WRITE : 0) |
             IF_WINDOWS((TEST(DR_MAP_IMAGE, flags) ? MAP_FILE_IMAGE : 0) |)
@@ -4298,7 +4298,7 @@ dr_unmap_file(void *map, size_t size)
     } else
         size = info.size;
 #    endif
-    return unmap_file((byte *)map, size);
+    return d_r_unmap_file((byte *)map, size);
 }
 
 DR_API
@@ -6524,10 +6524,11 @@ dr_get_mcontext_priv(dcontext_t *dcontext, dr_mcontext_t *dmc, priv_mcontext_t *
     if (TEST(DR_MC_INTEGER, dmc->flags)) {
         /* get the stolen register's app value */
         if (mc != NULL)
-            set_stolen_reg_val(mc, (reg_t)get_tls(os_tls_offset(TLS_REG_STOLEN_SLOT)));
+            set_stolen_reg_val(mc,
+                               (reg_t)d_r_get_tls(os_tls_offset(TLS_REG_STOLEN_SLOT)));
         else {
             set_stolen_reg_val(dr_mcontext_as_priv_mcontext(dmc),
-                               (reg_t)get_tls(os_tls_offset(TLS_REG_STOLEN_SLOT)));
+                               (reg_t)d_r_get_tls(os_tls_offset(TLS_REG_STOLEN_SLOT)));
         }
     }
 #endif
@@ -6592,7 +6593,7 @@ dr_set_mcontext(void *drcontext, dr_mcontext_t *context)
          * on our stolen reg retaining its value on the stack)
          */
         priv_mcontext_t *mc = dr_mcontext_as_priv_mcontext(context);
-        set_tls(os_tls_offset(TLS_REG_STOLEN_SLOT), (void *)get_stolen_reg_val(mc));
+        d_r_set_tls(os_tls_offset(TLS_REG_STOLEN_SLOT), (void *)get_stolen_reg_val(mc));
         /* save the reg val on the stack to be clobbered by the the copy below */
         reg_val = get_stolen_reg_val(state);
     }

--- a/core/link.c
+++ b/core/link.c
@@ -309,14 +309,14 @@ link_reset_free(void)
 }
 
 void
-link_init()
+d_r_link_init()
 {
     link_reset_init();
     coarse_stubs_init();
 }
 
 void
-link_exit()
+d_r_link_exit()
 {
     coarse_stubs_free();
     link_reset_free();

--- a/core/link.h
+++ b/core/link.h
@@ -375,9 +375,9 @@ typedef struct _coarse_incoming_t {
     (EXIT_HAS_STUB(l_flags, f_flags) && !TEST(LINK_SEPARATE_STUB, (l_flags)))
 
 void
-link_init(void);
+d_r_link_init(void);
 void
-link_exit(void);
+d_r_link_exit(void);
 void
 link_reset_init(void);
 void

--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -610,7 +610,7 @@ privload_unload(privmod_t *privmod)
             /* this routine may modify modlist, but we're done with it */
             privload_unload_imports(privmod);
             privload_remove_areas(privmod);
-            /* unmap_file removes from DR areas and calls unmap_file().
+            /* unmap_file removes from DR areas and calls d_r_unmap_file().
              * It's ok to call this for client libs: ok to remove what's not there.
              */
             privload_unmap_file(privmod);

--- a/core/module_shared.h
+++ b/core/module_shared.h
@@ -352,7 +352,7 @@ os_get_module_info_all_names(const app_pc pc,
 typedef void *module_base_t;
 
 generic_func_t
-get_proc_address(module_base_t lib, const char *name);
+d_r_get_proc_address(module_base_t lib, const char *name);
 
 #ifdef UNIX
 /* if we add any more values, switch to a globally-defined dr_export_info_t

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -297,7 +297,7 @@ mangle_trace_at_end(void)
 /* Initialization */
 /* thread-shared init does nothing, thread-private init does it all */
 void
-monitor_init()
+d_r_monitor_init()
 {
     /* to reduce memory, we use ushorts for some offsets in fragment bodies,
      * so we have to stop a trace at that size
@@ -331,7 +331,7 @@ trace_abort_and_delete(dcontext_t *dcontext)
 }
 
 void
-monitor_exit()
+d_r_monitor_exit()
 {
     LOG(GLOBAL, LOG_MONITOR | LOG_STATS, 1, "Trace fragments generated: %d\n",
         GLOBAL_STAT(num_traces));

--- a/core/monitor.h
+++ b/core/monitor.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -48,9 +48,9 @@
 extern mutex_t trace_building_lock;
 
 void
-monitor_init(void);
+d_r_monitor_init(void);
 void
-monitor_exit(void);
+d_r_monitor_exit(void);
 void
 monitor_thread_init(dcontext_t *dcontext);
 void

--- a/core/options.c
+++ b/core/options.c
@@ -2379,8 +2379,8 @@ options_init()
     ASSERT(sizeof(dynamo_options) == sizeof(options_t));
     /* get dynamo options */
     adjust_defaults_for_page_size(&dynamo_options);
-    retval = get_parameter(PARAM_STR(DYNAMORIO_VAR_OPTIONS), option_string,
-                           sizeof(option_string));
+    retval = d_r_get_parameter(PARAM_STR(DYNAMORIO_VAR_OPTIONS), option_string,
+                               sizeof(option_string));
     if (IS_GET_PARAMETER_SUCCESS(retval))
         ret = set_dynamo_options(&dynamo_options, option_string);
 #    if defined(STATIC_LIBRARY) && defined(CLIENT_INTERFACE)

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -46,7 +46,7 @@ struct _local_state_t; /* in arch_exports.h */
 
 /* in os.c */
 void
-os_init(void);
+d_r_os_init(void);
 /* called on detach and on process exit in debug builds */
 void
 os_slow_exit(void);

--- a/core/perscache.c
+++ b/core/perscache.c
@@ -306,15 +306,15 @@ coarse_unit_reset_free_internal(dcontext_t *dcontext, coarse_info_t *info,
             ASSERT(info->mmap_pc != NULL);
             if (info->mmap_ro_size > 0) {
                 /* two views */
-                DEBUG_DECLARE(ok =) unmap_file(info->mmap_pc, info->mmap_ro_size);
+                DEBUG_DECLARE(ok =) d_r_unmap_file(info->mmap_pc, info->mmap_ro_size);
                 ASSERT(ok);
                 DEBUG_DECLARE(ok =)
-                unmap_file(info->mmap_pc + info->mmap_ro_size,
-                           info->mmap_size - info->mmap_ro_size);
+                d_r_unmap_file(info->mmap_pc + info->mmap_ro_size,
+                               info->mmap_size - info->mmap_ro_size);
                 ASSERT(ok);
                 info->mmap_ro_size = 0;
             } else {
-                DEBUG_DECLARE(ok =) unmap_file(info->mmap_pc, info->mmap_size);
+                DEBUG_DECLARE(ok =) d_r_unmap_file(info->mmap_pc, info->mmap_size);
                 ASSERT(ok);
             }
             if (DYNAMO_OPTION(persist_lock_file)) {
@@ -2120,7 +2120,7 @@ perscache_dirname(char *directory /* OUT */, uint directory_len)
     const char *param_name = DYNAMO_OPTION(persist_per_user)
         ? PARAM_STR(DYNAMORIO_VAR_PERSCACHE_ROOT)
         : PARAM_STR(DYNAMORIO_VAR_PERSCACHE_SHARED);
-    retval = get_parameter(param_name, directory, directory_len);
+    retval = d_r_get_parameter(param_name, directory, directory_len);
     if (IS_GET_PARAMETER_FAILURE(retval)) {
         string_option_read_lock();
         if (DYNAMO_OPTION(persist_per_user) && !IS_STRING_OPTION_EMPTY(persist_dir)) {
@@ -3491,9 +3491,9 @@ coarse_unit_persist(dcontext_t *dcontext, coarse_info_t *info)
         if (TEST(PERSCACHE_GENFILE_MD5_COMPLETE, DYNAMO_OPTION(persist_gen_validation))) {
             /* FIXME if mmap up front (case 9758) don't need this mmap */
             sz = pers.header_len + pers.data_len - sizeof(persisted_footer_t);
-            map = map_file(fd, &sz, 0, NULL, MEMPROT_READ,
-                           /* won't change so save pagefile by not asking for COW */
-                           MAP_FILE_REACHABLE);
+            map = d_r_map_file(fd, &sz, 0, NULL, MEMPROT_READ,
+                               /* won't change so save pagefile by not asking for COW */
+                               MAP_FILE_REACHABLE);
             ASSERT(map != NULL);
             if (map == NULL) {
                 /* give up */
@@ -3506,7 +3506,7 @@ coarse_unit_persist(dcontext_t *dcontext, coarse_info_t *info)
         if (TEST(PERSCACHE_GENFILE_MD5_COMPLETE, DYNAMO_OPTION(persist_gen_validation)) &&
             map != (byte *)&pers) {
             ASSERT(map != NULL); /* we cleared _COMPLETE so shouldn't get here */
-            unmap_file(map, sz);
+            d_r_unmap_file(map, sz);
         }
     } else {
         memset(&footer, 0, sizeof(footer));
@@ -3821,14 +3821,14 @@ coarse_unit_load(dcontext_t *dcontext, app_pc start, app_pc end, bool for_execut
     /* FIXME case 9642: control where in address space we map the file:
      * right after vmheap?  Randomized?
      */
-    map = map_file(fd, &map_size, 0, NULL,
-                   /* Ask for max, then restrict pieces */
-                   MEMPROT_READ | MEMPROT_WRITE | MEMPROT_EXEC,
-                   /* case 9599: asking for COW commits pagefile space
-                    * up front, so we map two separate views later: see below
-                    */
-                   MAP_FILE_COPY_ON_WRITE /*writes should not change file*/ |
-                       MAP_FILE_REACHABLE);
+    map = d_r_map_file(fd, &map_size, 0, NULL,
+                       /* Ask for max, then restrict pieces */
+                       MEMPROT_READ | MEMPROT_WRITE | MEMPROT_EXEC,
+                       /* case 9599: asking for COW commits pagefile space
+                        * up front, so we map two separate views later: see below
+                        */
+                       MAP_FILE_COPY_ON_WRITE /*writes should not change file*/ |
+                           MAP_FILE_REACHABLE);
     /* case 9925: if we keep the file handle open we can prevent writes
      * to the file while it's mapped in, but it prevents our rename replacement
      * scheme (case 9701/9720) so we have it under option control.
@@ -4010,20 +4010,20 @@ coarse_unit_load(dcontext_t *dcontext, app_pc start, app_pc end, bool for_execut
         }
         ASSERT(fd != INVALID_FILE);
         if (fd != INVALID_FILE) {
-            unmap_file(map, map_size);
+            d_r_unmap_file(map, map_size);
             pers = NULL;
             map_size = ro_size;
             /* we know the whole thing fit @map, so try there */
-            map = map_file(fd, &map_size, 0, map,
-                           /* Ask for max, then restrict pieces */
-                           MEMPROT_READ | MEMPROT_EXEC,
-                           /* no COW to avoid pagefile cost */
-                           MAP_FILE_REACHABLE);
-            map2 = map_file(fd, &map2_size, map_size, map + map_size,
-                            /* Ask for max, then restrict pieces */
-                            MEMPROT_READ | MEMPROT_WRITE | MEMPROT_EXEC,
-                            MAP_FILE_COPY_ON_WRITE /*writes should not change file*/ |
-                                MAP_FILE_REACHABLE);
+            map = d_r_map_file(fd, &map_size, 0, map,
+                               /* Ask for max, then restrict pieces */
+                               MEMPROT_READ | MEMPROT_EXEC,
+                               /* no COW to avoid pagefile cost */
+                               MAP_FILE_REACHABLE);
+            map2 = d_r_map_file(fd, &map2_size, map_size, map + map_size,
+                                /* Ask for max, then restrict pieces */
+                                MEMPROT_READ | MEMPROT_WRITE | MEMPROT_EXEC,
+                                MAP_FILE_COPY_ON_WRITE /*writes should not change file*/ |
+                                    MAP_FILE_REACHABLE);
             /* FIXME: try again if racy alloc and they both don't fit */
             if (!DYNAMO_OPTION(persist_lock_file)) {
                 os_close(fd);
@@ -4305,9 +4305,9 @@ coarse_unit_load_exit:
             info = NULL;
         } else {
             if (map != NULL)
-                unmap_file(map, map_size);
+                d_r_unmap_file(map, map_size);
             if (map2 != NULL)
-                unmap_file(map2, map2_size);
+                d_r_unmap_file(map2, map2_size);
             if (fd != INVALID_FILE)
                 os_close(fd);
         }

--- a/core/translate.c
+++ b/core/translate.c
@@ -1754,10 +1754,10 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
             }
 
             if (spill_xcx_outstanding_offs != UINT_MAX) {
-                mc.xcx = (reg_t)get_tls(spill_xcx_outstanding_offs) + 1;
+                mc.xcx = (reg_t)d_r_get_tls(spill_xcx_outstanding_offs) + 1;
             } else {
-                mc.xcx =
-                    (reg_t)get_tls(os_tls_offset((ushort)reg_spill_tls_offs(REG_XCX))) +
+                mc.xcx = (reg_t)d_r_get_tls(
+                             os_tls_offset((ushort)reg_spill_tls_offs(REG_XCX))) +
                     1;
             }
             mc.xsp = STRESS_XSP_INIT;
@@ -1769,7 +1769,7 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
                 "  restored res=%d pc=" PFX ", xsp=" PFX " vs " PFX ", xcx=" PFX
                 " vs " PFX "\n",
                 res, mc.pc, mc.xsp, STRESS_XSP_INIT - /*negate*/ xsp_adjust, mc.xcx,
-                get_tls(os_tls_offset((ushort)reg_spill_tls_offs(REG_XCX))));
+                d_r_get_tls(os_tls_offset((ushort)reg_spill_tls_offs(REG_XCX))));
             /* We should only have failures at tail end of mangle regions.
              * No instrs after a failing instr should touch app memory.
              */
@@ -1782,7 +1782,7 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
             /* check that xsp and xcx are adjusted properly */
             ASSERT(mc.xsp == STRESS_XSP_INIT - /*negate*/ xsp_adjust);
             ASSERT(spill_xcx_outstanding_offs == UINT_MAX ||
-                   mc.xcx == (reg_t)get_tls(spill_xcx_outstanding_offs));
+                   mc.xcx == (reg_t)d_r_get_tls(spill_xcx_outstanding_offs));
 
             if (success_so_far && !res)
                 success_so_far = false;

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -407,8 +407,8 @@ privload_unmap_file(privmod_t *privmod)
 
     /* unmap segments */
     for (i = 0; i < opd->os_data.num_segments; i++) {
-        unmap_file(opd->os_data.segments[i].start,
-                   opd->os_data.segments[i].end - opd->os_data.segments[i].start);
+        d_r_unmap_file(opd->os_data.segments[i].start,
+                       opd->os_data.segments[i].end - opd->os_data.segments[i].start);
     }
     /* free segments */
     HEAP_ARRAY_FREE(GLOBAL_DCONTEXT, opd->os_data.segments, module_segment_t,
@@ -467,11 +467,11 @@ privload_map_and_relocate(const char *filename, size_t *size OUT, modload_flags_
     ASSERT_OWN_RECURSIVE_LOCK(!TEST(MODLOAD_NOT_PRIVLIB, flags), &privload_lock);
     /* get appropriate function */
     /* NOTE: all but the client lib will be added to DR areas list b/c using
-     * map_file()
+     * d_r_map_file()
      */
     if (dynamo_heap_initialized) {
-        map_func = map_file;
-        unmap_func = unmap_file;
+        map_func = d_r_map_file;
+        unmap_func = d_r_unmap_file;
         prot_func = set_protection;
     } else {
         map_func = os_map_file;
@@ -1455,7 +1455,7 @@ reserve_brk(app_pc post_app)
         /* i#1004: we're going to emulate the brk via our own mmap.
          * Reserve the initial brk now before any of DR's mmaps to avoid overlap.
          * XXX: reserve larger APP_BRK_GAP here and then unmap back to 1 page
-         * in os_init() to ensure no DR mmap limits its size?
+         * in d_r_os_init() to ensure no DR mmap limits its size?
          */
         dynamo_options.emulate_brk = true; /* not parsed yet */
         init_emulated_brk(post_app);

--- a/core/unix/loader_android.c
+++ b/core/unix/loader_android.c
@@ -73,8 +73,8 @@ init_android_version(void)
     uint read_ver = 0;
     if (fd != INVALID_FILE) {
         size_t sz = PAGE_SIZE;
-        byte *map = map_file(fd, &sz, 0, NULL, MEMPROT_READ | MEMPROT_WRITE,
-                             MAP_FILE_COPY_ON_WRITE);
+        byte *map = d_r_map_file(fd, &sz, 0, NULL, MEMPROT_READ | MEMPROT_WRITE,
+                                 MAP_FILE_COPY_ON_WRITE);
         if (map != NULL) {
             const char *prop;
             *(map + sz - 1) = '\0'; /* ensure our strstr stops */
@@ -83,7 +83,7 @@ init_android_version(void)
                 if (sscanf(prop + strlen(VER_PROP), "%d", &read_ver) == 1)
                     android_version = read_ver;
             }
-            unmap_file(map, sz);
+            d_r_unmap_file(map, sz);
         }
     }
     LOG(GLOBAL, LOG_LOADER, 1, "Android version %s is %d\n",

--- a/core/unix/memcache.c
+++ b/core/unix/memcache.c
@@ -127,7 +127,7 @@ memcache_lock(void)
      * during heap init and before we can allocate it.  no lock needed then.
      */
     ASSERT(all_memory_areas != NULL ||
-           get_num_threads() <= 1 /* must be only DR thread */);
+           d_r_get_num_threads() <= 1 /* must be only DR thread */);
     if (all_memory_areas == NULL)
         return;
     if (self_owns_write_lock(&all_memory_areas->lock)) {
@@ -147,7 +147,8 @@ memcache_unlock(void)
     /* ok to ask for locks or mark stale before all_memory_areas is allocated,
      * during heap init and before we can allocate it.  no lock needed then.
      */
-    ASSERT(all_memory_areas != NULL || get_num_threads() <= 1 /*must be only DR thread*/);
+    ASSERT(all_memory_areas != NULL ||
+           d_r_get_num_threads() <= 1 /*must be only DR thread*/);
     if (all_memory_areas == NULL)
         return;
     if (all_memory_areas_recursion > 0) {

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -749,7 +749,7 @@ get_proc_address_ex(module_base_t lib, const char *name, bool *is_indirect_code 
 }
 
 generic_func_t
-get_proc_address(module_base_t lib, const char *name)
+d_r_get_proc_address(module_base_t lib, const char *name)
 {
     return get_proc_address_ex(lib, name, NULL);
 }

--- a/core/unix/module_macho.c
+++ b/core/unix/module_macho.c
@@ -465,7 +465,7 @@ get_proc_address_ex(module_base_t lib, const char *name, bool *is_indirect_code 
 }
 
 generic_func_t
-get_proc_address(module_base_t lib, const char *name)
+d_r_get_proc_address(module_base_t lib, const char *name)
 {
     return get_proc_address_ex(lib, name, NULL);
 }

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -147,9 +147,9 @@ extern uint android_tls_base_offs;
 #endif
 
 void *
-get_tls(ushort tls_offs);
+d_r_get_tls(ushort tls_offs);
 void
-set_tls(ushort tls_offs, void *value);
+d_r_set_tls(ushort tls_offs, void *value);
 byte *
 os_get_dr_tls_base(dcontext_t *dcontext);
 

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -282,9 +282,9 @@ typedef kernel_sigaction_t prev_sigaction_t;
 #endif
 
 void
-signal_init(void);
+d_r_signal_init(void);
 void
-signal_exit(void);
+d_r_signal_exit(void);
 void
 signal_thread_init(dcontext_t *dcontext, void *os_data);
 void

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -466,7 +466,7 @@ unset_initial_crash_handlers(dcontext_t *dcontext)
 }
 
 void
-signal_init(void)
+d_r_signal_init(void)
 {
     kernel_sigset_t set;
     IF_LINUX(IF_X86_64(ASSERT(ALIGNED(offsetof(sigpending_t, xstate), AVX_ALIGNMENT))));
@@ -495,7 +495,7 @@ signal_init(void)
 }
 
 void
-signal_exit()
+d_r_signal_exit()
 {
     IF_LINUX(signalfd_exit());
 #ifdef DEBUG
@@ -1060,7 +1060,7 @@ signal_thread_inherit(dcontext_t *dcontext, void *clone_record)
         }
 
         /* should be 1st thread */
-        if (get_num_threads() > 1)
+        if (d_r_get_num_threads() > 1)
             ASSERT_NOT_REACHED();
     }
 
@@ -4824,7 +4824,7 @@ master_signal_handler_C(byte *xsp)
         dcontext = GLOBAL_DCONTEXT;
     }
 
-    if (dynamo_exited && get_num_threads() > 1 && sig == SIGSEGV) {
+    if (dynamo_exited && d_r_get_num_threads() > 1 && sig == SIGSEGV) {
         /* PR 470957: this is almost certainly a race so just squelch it.
          * We live w/ the risk that it was holding a lock our release-build
          * exit code needs.

--- a/core/utils.c
+++ b/core/utils.c
@@ -1826,7 +1826,7 @@ print_to_buffer(char *buf, size_t bufsz, size_t *sofar INOUT, const char *fmt, .
  * For now I'm assuming this routine changes little.
  */
 void
-print_log(file_t logfile, uint mask, uint level, const char *fmt, ...)
+d_r_print_log(file_t logfile, uint mask, uint level, const char *fmt, ...)
 {
     va_list ap;
 
@@ -2707,8 +2707,8 @@ create_log_dir(int dir_type)
         strncpy(old_basedir, basedir, sizeof(old_basedir));
         /* option takes precedence over config var */
         if (IS_STRING_OPTION_EMPTY(logdir)) {
-            retval = get_parameter(PARAM_STR(DYNAMORIO_VAR_LOGDIR), basedir,
-                                   BUFFER_SIZE_ELEMENTS(basedir));
+            retval = d_r_get_parameter(PARAM_STR(DYNAMORIO_VAR_LOGDIR), basedir,
+                                       BUFFER_SIZE_ELEMENTS(basedir));
             if (IS_GET_PARAMETER_FAILURE(retval))
                 basedir[0] = '\0';
         } else {
@@ -3497,13 +3497,13 @@ get_random_offset(size_t max_offset)
 }
 
 void
-set_random_seed(uint seed)
+d_r_set_random_seed(uint seed)
 {
     random_seed = seed;
 }
 
 uint
-get_random_seed(void)
+d_r_get_random_seed(void)
 {
     return random_seed;
 }

--- a/core/utils.h
+++ b/core/utils.h
@@ -1189,7 +1189,7 @@ bitmap_check_consistency(bitmap_t b, uint bitmap_size, uint expect_free);
         do {                                                           \
             if (d_r_stats != NULL && d_r_stats->loglevel >= (level) && \
                 (d_r_stats->logmask & (mask)) != 0)                    \
-                print_log(file, mask, level, __VA_ARGS__);             \
+                d_r_print_log(file, mask, level, __VA_ARGS__);         \
         } while (0)
 /* use DOELOG for customer visible logging. statement can be a {} block */
 #    define DOELOG(level, mask, statement)                             \
@@ -1228,7 +1228,7 @@ bitmap_check_consistency(bitmap_t b, uint bitmap_size, uint expect_free);
 #    define DOCHECK(level, statement) /* nothing */
 #endif
 void
-print_log(file_t logfile, uint mask, uint level, const char *fmt, ...);
+d_r_print_log(file_t logfile, uint mask, uint level, const char *fmt, ...);
 void
 print_file(file_t f, const char *fmt, ...);
 
@@ -2250,10 +2250,10 @@ size_t
 get_random_offset(size_t max_offset);
 
 void
-set_random_seed(uint seed);
+d_r_set_random_seed(uint seed);
 
 uint
-get_random_seed(void);
+d_r_get_random_seed(void);
 
 void
 convert_millis_to_date(uint64 millis, dr_time_t *time OUT);

--- a/core/win32/aslr.c
+++ b/core/win32/aslr.c
@@ -2582,9 +2582,9 @@ open_relocated_dlls_filecache_directory(void)
      * DYNAMORIO_VAR_CACHE_ROOT (\cache) in addition to the a per USER
      * subdirectory \cache\SID
      */
-    retval = get_parameter((per_user ? PARAM_STR(DYNAMORIO_VAR_CACHE_ROOT)
-                                     : PARAM_STR(DYNAMORIO_VAR_CACHE_SHARED)),
-                           base_directory, sizeof(base_directory));
+    retval = d_r_get_parameter((per_user ? PARAM_STR(DYNAMORIO_VAR_CACHE_ROOT)
+                                         : PARAM_STR(DYNAMORIO_VAR_CACHE_SHARED)),
+                               base_directory, sizeof(base_directory));
     if (IS_GET_PARAMETER_FAILURE(retval) || strchr(base_directory, DIRSEP) == NULL) {
         SYSLOG_INTERNAL_ERROR(
             " %s not set!"
@@ -6078,10 +6078,10 @@ gbop_exclude_filter(const gbop_hook_desc_t *gbop_hook)
         os_exclude_list = "shell32.dll!RealShellExecuteW;shell32.dll!RealShellExecuteExW";
         DODEBUG_ONCE({
             HANDLE shell_mod = get_module_handle(L"shell32.dll");
-            ASSERT(get_proc_address(shell_mod, "RealShellExecuteA") ==
-                   get_proc_address(shell_mod, "RealShellExecuteW"));
-            ASSERT(get_proc_address(shell_mod, "RealShellExecuteExA") ==
-                   get_proc_address(shell_mod, "RealShellExecuteExW"));
+            ASSERT(d_r_get_proc_address(shell_mod, "RealShellExecuteA") ==
+                   d_r_get_proc_address(shell_mod, "RealShellExecuteW"));
+            ASSERT(d_r_get_proc_address(shell_mod, "RealShellExecuteExA") ==
+                   d_r_get_proc_address(shell_mod, "RealShellExecuteExW"));
         });
     }
 

--- a/core/win32/diagnost.c
+++ b/core/win32/diagnost.c
@@ -438,7 +438,7 @@ report_internal_data_structures(IN file_t diagnostics_file,
                "dynamo_initialized : %d\ndynamo_exited      : %d\n"
                "num_threads        : %d\ndynamorio.dll      = " PFX "\n",
                automatic_startup, control_all_threads, dynamo_initialized, dynamo_exited,
-               get_num_threads(), get_dynamorio_dll_start());
+               d_r_get_num_threads(), get_dynamorio_dll_start());
 
     /* skip for non-attack calls to avoid risk of any global locks */
     if (violation_type != NO_VIOLATION_BAD_INTERNAL_STATE) {

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -59,7 +59,7 @@
  * to use DR's d_r_get_proc_address().  We're already linking w/ the files we need.
  */
 #include "os_private.h" /* for d_r_get_proc_address() and load_dynamo */
-#define GET_PROC_ADDR get_proc_address
+#define GET_PROC_ADDR d_r_get_proc_address
 
 /* this entry point is hardcoded, FIXME : abstract */
 #define DYNAMORIO_ENTRY "dynamo_auto_start"

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -41,7 +41,7 @@
 
 /* FIXME: Unicode support?!?! case 61 */
 #include "../globals.h"       /* for pragma warning's and assert defines */
-#include "../module_shared.h" /* for get_proc_address() */
+#include "../module_shared.h" /* for d_r_get_proc_address() */
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -56,9 +56,9 @@
 /* i#1597: to prevent an IAT hooking injected library in drrun or a tool
  * front-end from redirecting kernel32!LoadLibrary and kernel32!GetProcAddress
  * to the inject lib itself, which won't be there in the child, it's best
- * to use DR's get_proc_address().  We're already linking w/ the files we need.
+ * to use DR's d_r_get_proc_address().  We're already linking w/ the files we need.
  */
-#include "os_private.h" /* for get_proc_address() and load_dynamo */
+#include "os_private.h" /* for d_r_get_proc_address() and load_dynamo */
 #define GET_PROC_ADDR get_proc_address
 
 /* this entry point is hardcoded, FIXME : abstract */

--- a/core/win32/inject_shared.c
+++ b/core/win32/inject_shared.c
@@ -760,7 +760,7 @@ get_process_qualified_name(HANDLE process_handle, wchar_t *w_exename,
     ASSERT_CURIOSITY(wcslen(w_exename) < max_exename_length - 1);
 }
 
-/* NOTE - get_own_*_name routines cache their values and are primed by os_init() since
+/* NOTE - get_own_*_name routines cache their values and are primed by d_r_os_init() since
  * it might not be safe to read the process parameters later. */
 
 /* Returns the cached full path of the image, including the command line qualifier when
@@ -920,7 +920,7 @@ get_process_parameter(HANDLE phandle, const wchar_t *name, char *value, int maxl
 
 /* get parameter for current process */
 int
-get_parameter(const wchar_t *name, char *value, int maxlen)
+d_r_get_parameter(const wchar_t *name, char *value, int maxlen)
 {
     return get_process_parameter_internal(NULL, name, value, maxlen, true /*qual*/,
                                           REGISTRY_DEFAULT);
@@ -930,7 +930,7 @@ get_parameter(const wchar_t *name, char *value, int maxlen)
 int
 get_parameter_ex(const wchar_t *name, char *value, int maxlen, bool ignore_cache)
 {
-    return get_parameter(name, value, maxlen);
+    return d_r_get_parameter(name, value, maxlen);
 }
 
 #        ifdef X64
@@ -1027,7 +1027,7 @@ get_process_parameter_ex(HANDLE phandle, const char *name, char *value, int maxl
     process_id_t pid;
     if (phandle == NULL) {
 #            if !defined(NOT_DYNAMORIO_CORE) && !defined(NOT_DYNAMORIO_CORE_PROPER)
-        return get_parameter(name, value, maxlen);
+        return d_r_get_parameter(name, value, maxlen);
 #            else
         pid = process_id_from_handle(NT_CURRENT_PROCESS);
 #            endif

--- a/core/win32/inject_shared.h
+++ b/core/win32/inject_shared.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -75,7 +75,7 @@ set_process_parameter(HANDLE phandle, const wchar_t *name, const char *value);
  * intact (may not be true if GET_PARAMETER_BUF_TOO_SMALL is returned).
  */
 int
-get_parameter(const wchar_t *name, char *value, int maxlen);
+d_r_get_parameter(const wchar_t *name, char *value, int maxlen);
 
 /* Identical to get_parameter: for compatibility w/ non-PARAMS_IN_REGISTRY */
 int
@@ -123,7 +123,7 @@ get_parameter_64(const char *name, char *value, int maxlen);
 #endif /* PARAMS_IN_REGISTRY */
 /***************************************************************************/
 
-/* get_own_*_name routines cache their values and are primed by os_init() */
+/* get_own_*_name routines cache their values and are primed by d_r_os_init() */
 const wchar_t *
 get_own_qualified_name(void);
 

--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -222,9 +222,9 @@ os_loader_init_prologue(void)
         LOG(GLOBAL, LOG_LOADER, 2, "private peb=" PFX "\n", private_peb);
 
         if (should_swap_teb_nonstack_fields()) {
-            pre_nls_cache = get_tls(NLS_CACHE_TIB_OFFSET);
-            pre_fls_data = get_tls(FLS_DATA_TIB_OFFSET);
-            pre_nt_rpc = get_tls(NT_RPC_TIB_OFFSET);
+            pre_nls_cache = d_r_get_tls(NLS_CACHE_TIB_OFFSET);
+            pre_fls_data = d_r_get_tls(FLS_DATA_TIB_OFFSET);
+            pre_nt_rpc = d_r_get_tls(NT_RPC_TIB_OFFSET);
             /* Clear state to separate priv from app.
              * XXX: if we attach or something it seems possible that ntdll or user32
              * or some other shared resource might set these and we want to share
@@ -232,9 +232,9 @@ os_loader_init_prologue(void)
              * and should relax the asserts in d_r_dispatch and is_using_app_peb to
              * allow app==priv if both ==pre.
              */
-            set_tls(NLS_CACHE_TIB_OFFSET, NULL);
-            set_tls(FLS_DATA_TIB_OFFSET, NULL);
-            set_tls(NT_RPC_TIB_OFFSET, NULL);
+            d_r_set_tls(NLS_CACHE_TIB_OFFSET, NULL);
+            d_r_set_tls(FLS_DATA_TIB_OFFSET, NULL);
+            d_r_set_tls(NT_RPC_TIB_OFFSET, NULL);
             LOG(GLOBAL, LOG_LOADER, 2, "initial thread TEB->NlsCache=" PFX "\n",
                 pre_nls_cache);
             LOG(GLOBAL, LOG_LOADER, 2, "initial thread TEB->FlsData=" PFX "\n",
@@ -293,7 +293,7 @@ os_loader_init_prologue(void)
      * the old KUSER_SHARED_DATA so make sure we're on an old OS.
      */
     ntdll_NtTickCount =
-        (ntdll_NtTickCount_t)get_proc_address(get_ntdll_base(), "NtGetTickCount");
+        (ntdll_NtTickCount_t)d_r_get_proc_address(get_ntdll_base(), "NtGetTickCount");
     ASSERT(ntdll_NtTickCount != NULL || get_os_version() <= WINDOWS_VERSION_XP);
 }
 
@@ -349,18 +349,18 @@ os_loader_thread_init_prologue(dcontext_t *dcontext)
             /* For first thread use cached pre-priv-lib value for app and
              * whatever value priv libs have set for priv
              */
-            dcontext->app_stack_limit = get_tls(BASE_STACK_TIB_OFFSET);
-            dcontext->app_stack_base = get_tls(TOP_STACK_TIB_OFFSET);
+            dcontext->app_stack_limit = d_r_get_tls(BASE_STACK_TIB_OFFSET);
+            dcontext->app_stack_base = d_r_get_tls(TOP_STACK_TIB_OFFSET);
             if (should_swap_teb_nonstack_fields()) {
-                dcontext->priv_nls_cache = get_tls(NLS_CACHE_TIB_OFFSET);
-                dcontext->priv_fls_data = get_tls(FLS_DATA_TIB_OFFSET);
-                dcontext->priv_nt_rpc = get_tls(NT_RPC_TIB_OFFSET);
+                dcontext->priv_nls_cache = d_r_get_tls(NLS_CACHE_TIB_OFFSET);
+                dcontext->priv_fls_data = d_r_get_tls(FLS_DATA_TIB_OFFSET);
+                dcontext->priv_nt_rpc = d_r_get_tls(NT_RPC_TIB_OFFSET);
                 dcontext->app_nls_cache = pre_nls_cache;
                 dcontext->app_fls_data = pre_fls_data;
                 dcontext->app_nt_rpc = pre_nt_rpc;
-                set_tls(NLS_CACHE_TIB_OFFSET, dcontext->app_nls_cache);
-                set_tls(FLS_DATA_TIB_OFFSET, dcontext->app_fls_data);
-                set_tls(NT_RPC_TIB_OFFSET, dcontext->app_nt_rpc);
+                d_r_set_tls(NLS_CACHE_TIB_OFFSET, dcontext->app_nls_cache);
+                d_r_set_tls(FLS_DATA_TIB_OFFSET, dcontext->app_fls_data);
+                d_r_set_tls(NT_RPC_TIB_OFFSET, dcontext->app_nt_rpc);
             }
         } else {
             /* The real value will be set by swap_peb_pointer */
@@ -390,7 +390,7 @@ os_loader_thread_init_prologue(dcontext_t *dcontext)
         /* For swapping teb fields (detach, reset i#25) we'll need to
          * know the teb base from another thread
          */
-        dcontext->teb_base = (byte *)get_tls(SELF_TIB_OFFSET);
+        dcontext->teb_base = (byte *)d_r_get_tls(SELF_TIB_OFFSET);
         swap_peb_pointer(dcontext, true /*to priv*/);
     }
 #endif
@@ -435,7 +435,7 @@ get_private_peb(void)
  * We'd like to do so if there are no private WinAPI libs
  * (we assume libs not in the system dir will not write to PEB or TEB fields we
  * care about (mainly Fls ones)), but kernel32 can be loaded in dr_client_main()
- * (which is after arch_init()) via dr_enable_console_printing(); plus,
+ * (which is after d_r_arch_init()) via dr_enable_console_printing(); plus,
  * a client could load kernel32 via dr_load_aux_library(), or a 3rd-party
  * priv lib could load anything at any time.  Xref i#984.
  * This does not indicate whether TEB fields should be swapped: we need
@@ -460,7 +460,7 @@ get_teb_field(dcontext_t *dcontext, ushort offs)
 {
     if (dcontext == NULL || dcontext == GLOBAL_DCONTEXT) {
         /* get our own */
-        return get_tls(offs);
+        return d_r_get_tls(offs);
     } else {
         byte *teb = dcontext->teb_base;
         return *((void **)(teb + offs));
@@ -472,7 +472,7 @@ set_teb_field(dcontext_t *dcontext, ushort offs, void *value)
 {
     if (dcontext == NULL || dcontext == GLOBAL_DCONTEXT) {
         /* set our own */
-        set_tls(offs, value);
+        d_r_set_tls(offs, value);
     } else {
         byte *teb = dcontext->teb_base;
         ASSERT(dcontext->teb_base != NULL);
@@ -835,7 +835,7 @@ privload_remove_areas(privmod_t *privmod)
 void
 privload_unmap_file(privmod_t *mod)
 {
-    unmap_file(mod->base, mod->size);
+    d_r_unmap_file(mod->base, mod->size);
 }
 
 bool
@@ -1871,7 +1871,7 @@ privload_attach_parent_console(app_pc app_kernel32)
     ASSERT(app_kernel32 != NULL);
     if (kernel32_AttachConsole == NULL) {
         kernel32_AttachConsole =
-            (kernel32_AttachConsole_t)get_proc_address(app_kernel32, "AttachConsole");
+            (kernel32_AttachConsole_t)d_r_get_proc_address(app_kernel32, "AttachConsole");
     }
     if (kernel32_AttachConsole != NULL) {
         if (kernel32_AttachConsole(ATTACH_PARENT_PROCESS) != 0)
@@ -1912,7 +1912,7 @@ privload_console_share(app_pc priv_kernel32, app_pc app_kernel32)
          */
         if (get_os_version() >= WINDOWS_VERSION_8) {
             kernel32_FreeConsole =
-                (kernel32_FreeConsole_t)get_proc_address(app_kernel32, "FreeConsole");
+                (kernel32_FreeConsole_t)d_r_get_proc_address(app_kernel32, "FreeConsole");
             if (kernel32_FreeConsole != NULL) {
                 if (kernel32_FreeConsole() == 0)
                     return false;
@@ -1931,7 +1931,7 @@ privload_console_share(app_pc priv_kernel32, app_pc app_kernel32)
     /* Below here is win7-specific */
     if (get_os_version() != WINDOWS_VERSION_7)
         return true;
-    get_console_cp = (app_pc)get_proc_address(app_kernel32, "GetConsoleCP");
+    get_console_cp = (app_pc)d_r_get_proc_address(app_kernel32, "GetConsoleCP");
     ASSERT(get_console_cp != NULL);
     /* No exported routines directly reference the globals. The easiest and shortest
      * path is through GetConsoleCP, where we look for a call to ConsoleClientCallServer

--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -910,8 +910,8 @@ privload_map_and_relocate(const char *filename, size_t *size OUT, modload_flags_
     *size = 0; /* map at full size */
     if (dynamo_heap_initialized) {
         /* These hold the DR lock and update DR areas */
-        map_func = map_file;
-        unmap_func = unmap_file;
+        map_func = d_r_map_file;
+        unmap_func = d_r_unmap_file;
     } else {
         map_func = os_map_file;
         unmap_func = os_unmap_file;

--- a/core/win32/module.c
+++ b/core/win32/module.c
@@ -891,7 +891,7 @@ find_ntdll_mod_rbtree(module_handle_t ntdllh, RTL_RB_TREE *tomatch)
     instr_t inst;
     bool found_call = false;
     byte *pc;
-    byte *start = (byte *)get_proc_address(ntdllh, "LdrDisableThreadCalloutsForDll");
+    byte *start = (byte *)d_r_get_proc_address(ntdllh, "LdrDisableThreadCalloutsForDll");
     if (start == NULL)
         return NULL;
     instr_init(GLOBAL_DCONTEXT, &inst);
@@ -949,7 +949,7 @@ hide_from_rbtree(LDR_MODULE *mod)
     LOG(GLOBAL, LOG_ALL, 2, "Attempting to remove dll from rbtree\n");
 
     ntdllh = get_ntdll_base();
-    RtlRbRemoveNode = (RtlRbRemoveNode_t)get_proc_address(ntdllh, "RtlRbRemoveNode");
+    RtlRbRemoveNode = (RtlRbRemoveNode_t)d_r_get_proc_address(ntdllh, "RtlRbRemoveNode");
     if (RtlRbRemoveNode == NULL) {
         SYSLOG_INTERNAL_WARNING("cannot remove dll from rbtree: no RtlRbRemoveNode");
         return;
@@ -1290,7 +1290,7 @@ check_for_unsupported_modules()
     const char *short_name;
     uint traversed = 0;
     int retval =
-        get_parameter(PARAM_STR(DYNAMORIO_VAR_UNSUPPORTED), filter, sizeof(filter));
+        d_r_get_parameter(PARAM_STR(DYNAMORIO_VAR_UNSUPPORTED), filter, sizeof(filter));
     if (IS_GET_PARAMETER_FAILURE(retval) || filter[0] == 0 /* empty UNSUPPORTED list */) {
         /* no unsupported list, so nothing to look for */
         return false;
@@ -3814,7 +3814,7 @@ os_modules_init(void)
 
 #ifndef STATIC_LIBRARY
     if (DYNAMO_OPTION(hide) && !dr_earliest_injected) {
-        /* retrieve path before hiding, since this is called before os_init() */
+        /* retrieve path before hiding, since this is called before d_r_os_init() */
         get_dynamorio_library_path();
         hide_from_module_lists();
     }

--- a/core/win32/module_shared.c
+++ b/core/win32/module_shared.c
@@ -542,7 +542,7 @@ get_module_exports_directory_check(app_pc base_addr,
 }
 
 generic_func_t
-get_proc_address(module_base_t lib, const char *name)
+d_r_get_proc_address(module_base_t lib, const char *name)
 {
     return get_proc_address_common(lib, name, UINT_MAX _IF_NOT_X64(false), NULL);
 }
@@ -570,7 +570,7 @@ generic_func_t
 get_proc_address_resolve_forward(module_base_t lib, const char *name)
 {
     /* We match GetProcAddress and follow forwarded exports (i#428).
-     * Not doing this inside get_proc_address() b/c I'm not certain the core
+     * Not doing this inside d_r_get_proc_address() b/c I'm not certain the core
      * never relies on the answer being inside the asked-about module.
      */
     const char *forwarder, *forwfunc;

--- a/core/win32/ntdll.c
+++ b/core/win32/ntdll.c
@@ -374,10 +374,10 @@ syscalls_init_get_num(HANDLE ntdllh, int sys_enum)
     app_pc wrapper;
     ASSERT(ntdllh != NULL);
     /* We can't check syscalls[] for SYSCALL_NOT_PRESENT b/c it's not set up yet */
-    /* get_proc_address() does invoke NtQueryVirtualMemory, but we go through the
+    /* d_r_get_proc_address() does invoke NtQueryVirtualMemory, but we go through the
      * ntdll wrapper for that syscall and thus it works this early.
      */
-    wrapper = (app_pc)get_proc_address(ntdllh, syscall_names[sys_enum]);
+    wrapper = (app_pc)d_r_get_proc_address(ntdllh, syscall_names[sys_enum]);
     if (wrapper != NULL && !ALLOW_HOOKER(wrapper))
         return *((int *)((wrapper) + SYSNUM_OFFS));
     else
@@ -556,7 +556,7 @@ syscalls_init()
              * which requires looking at the vsyscall code.
              */
             KiFastSystemCallRet_address =
-                (app_pc)get_proc_address(ntdllh, "KiFastSystemCallRet");
+                (app_pc)d_r_get_proc_address(ntdllh, "KiFastSystemCallRet");
 #    endif
             set_syscall_method(SYSCALL_METHOD_SYSENTER);
             dr_which_syscall_t = DR_SYSCALL_SYSENTER;
@@ -570,11 +570,12 @@ syscalls_init()
         /* win8: call followed by ret */
         IF_X64(ASSERT_NOT_IMPLEMENTED(false));
         /* kernel returns control to KiFastSystemCallRet, not local sysenter, of course */
-        sysenter_ret_address = (app_pc)get_proc_address(ntdllh, "KiFastSystemCallRet");
+        sysenter_ret_address =
+            (app_pc)d_r_get_proc_address(ntdllh, "KiFastSystemCallRet");
         ASSERT(sysenter_ret_address != NULL);
 #    ifdef CLIENT_INTERFACE
         KiFastSystemCallRet_address =
-            (app_pc)get_proc_address(ntdllh, "KiFastSystemCallRet");
+            (app_pc)d_r_get_proc_address(ntdllh, "KiFastSystemCallRet");
 #    endif
         set_syscall_method(SYSCALL_METHOD_SYSENTER);
         dr_which_syscall_t = DR_SYSCALL_SYSENTER;
@@ -600,7 +601,7 @@ syscalls_init()
         for (i = 0; i < SYS_MAX; i++) {
             if (syscalls[i] == SYSCALL_NOT_PRESENT) /* presumably matches known ver */
                 continue;
-            wrapper = (app_pc)get_proc_address(ntdllh, syscall_names[i]);
+            wrapper = (app_pc)d_r_get_proc_address(ntdllh, syscall_names[i]);
             if (wrapper != NULL && !ALLOW_HOOKER(wrapper))
                 syscalls[i] = *((int *)((wrapper) + SYSNUM_OFFS));
             /* We ignore TestAlert complications: we don't call it anyway */
@@ -618,7 +619,7 @@ syscalls_init()
             /* note that this check allows a hooker so we'll need a
              * better way of determining syscall numbers
              */
-            CHECK_SYSNUM_AT((byte *)get_proc_address(ntdllh, syscall_names[i]), i);
+            CHECK_SYSNUM_AT((byte *)d_r_get_proc_address(ntdllh, syscall_names[i]), i);
         }
     });
     return true;
@@ -642,7 +643,7 @@ use_ki_syscall_routines()
      * work just as well. */
     static generic_func_t ki_fastsyscall_addr = (generic_func_t)PTR_UINT_MINUS_1;
     if (ki_fastsyscall_addr == (generic_func_t)PTR_UINT_MINUS_1) {
-        ki_fastsyscall_addr = get_proc_address(get_ntdll_base(), "KiFastSystemCall");
+        ki_fastsyscall_addr = d_r_get_proc_address(get_ntdll_base(), "KiFastSystemCall");
         ASSERT(ki_fastsyscall_addr != (generic_func_t)PTR_UINT_MINUS_1);
     }
     return (ki_fastsyscall_addr != NULL);
@@ -653,13 +654,14 @@ nt_get_context_extended_functions(app_pc base)
 {
     if (YMM_ENABLED()) { /* indicates OS support, not just processor support */
         ntdll_RtlGetExtendedContextLength =
-            (ntdll_RtlGetExtendedContextLength_t)get_proc_address(
+            (ntdll_RtlGetExtendedContextLength_t)d_r_get_proc_address(
                 base, "RtlGetExtendedContextLength");
         ntdll_RtlInitializeExtendedContext =
-            (ntdll_RtlInitializeExtendedContext_t)get_proc_address(
+            (ntdll_RtlInitializeExtendedContext_t)d_r_get_proc_address(
                 base, "RtlInitializeExtendedContext");
-        ntdll_RtlLocateLegacyContext = (ntdll_RtlLocateLegacyContext_t)get_proc_address(
-            base, "RtlLocateLegacyContext");
+        ntdll_RtlLocateLegacyContext =
+            (ntdll_RtlLocateLegacyContext_t)d_r_get_proc_address(
+                base, "RtlLocateLegacyContext");
         ASSERT(ntdll_RtlGetExtendedContextLength != NULL &&
                ntdll_RtlInitializeExtendedContext != NULL &&
                ntdll_RtlLocateLegacyContext != NULL);
@@ -669,7 +671,7 @@ nt_get_context_extended_functions(app_pc base)
 static void
 nt_init_dynamic_syscall_wrappers(app_pc base)
 {
-    NtGetNextThread = (NtGetNextThread_t)get_proc_address(base, "NtGetNextThread");
+    NtGetNextThread = (NtGetNextThread_t)d_r_get_proc_address(base, "NtGetNextThread");
 }
 #endif /* !NOT_DYNAMORIO_CORE_PROPER */
 
@@ -2146,7 +2148,7 @@ NTSTATUS
 nt_remote_query_virtual_memory(HANDLE process, const byte *pc,
                                MEMORY_BASIC_INFORMATION *mbi, size_t mbilen, size_t *got)
 {
-    /* XXX: we can't switch this to a raw syscall as we rely on get_proc_address()
+    /* XXX: we can't switch this to a raw syscall as we rely on d_r_get_proc_address()
      * working in syscalls_init_get_num(), and it calls get_allocation_size()
      * which ends up here.
      */
@@ -5007,7 +5009,7 @@ are_mapped_files_the_same(app_pc addr1, app_pc addr2)
 
     /* FIXME: this doesn't exist on NT4 - make sure we handle
      * gracefully not finding the target - needs a very explicit
-     * get_proc_address() here.
+     * d_r_get_proc_address() here.
      */
     GET_NTDLL(ZwAreMappedFilesTheSame, (
                                         IN PVOID Address1,

--- a/core/win32/ntdll_shared.c
+++ b/core/win32/ntdll_shared.c
@@ -95,7 +95,7 @@ nt_wow64_read_virtual_memory64(HANDLE process, uint64 base, void *buffer,
 #    ifdef NOT_DYNAMORIO_CORE
             GetProcAddress(GetModuleHandle("ntdll.dll"), "NtWow64ReadVirtualMemory64");
 #    else
-            get_proc_address(get_ntdll_base(), "NtWow64ReadVirtualMemory64");
+            d_r_get_proc_address(get_ntdll_base(), "NtWow64ReadVirtualMemory64");
 #    endif
 #    if !defined(NOT_DYNAMORIO_CORE) && !defined(NOT_DYNAMORIO_CORE_PROPER)
         if (dynamo_initialized)

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -613,7 +613,8 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
             /* Win10 does not provide a version number so we use the presence
              * of newly added syscalls to distinguish major updates.
              */
-            if (get_proc_address(get_ntdll_base(), "NtAllocateVirtualMemoryEx") != NULL) {
+            if (d_r_get_proc_address(get_ntdll_base(), "NtAllocateVirtualMemoryEx") !=
+                NULL) {
                 if (module_is_64bit(get_ntdll_base())) {
                     syscalls = (int *)windows_10_1803_x64_syscalls;
                     os_name = "Microsoft Windows 10-1803 x64";
@@ -625,7 +626,7 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
                     os_name = "Microsoft Windows 10-1803";
                 }
                 os_version = WINDOWS_VERSION_10_1803;
-            } else if (get_proc_address(get_ntdll_base(), "NtCallEnclave") != NULL) {
+            } else if (d_r_get_proc_address(get_ntdll_base(), "NtCallEnclave") != NULL) {
                 if (module_is_64bit(get_ntdll_base())) {
                     syscalls = (int *)windows_10_1709_x64_syscalls;
                     os_name = "Microsoft Windows 10-1709 x64";
@@ -637,7 +638,7 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
                     os_name = "Microsoft Windows 10-1709";
                 }
                 os_version = WINDOWS_VERSION_10_1709;
-            } else if (get_proc_address(get_ntdll_base(), "NtLoadHotPatch") != NULL) {
+            } else if (d_r_get_proc_address(get_ntdll_base(), "NtLoadHotPatch") != NULL) {
                 if (module_is_64bit(get_ntdll_base())) {
                     syscalls = (int *)windows_10_1703_x64_syscalls;
                     os_name = "Microsoft Windows 10-1703 x64";
@@ -649,8 +650,8 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
                     os_name = "Microsoft Windows 10-1703";
                 }
                 os_version = WINDOWS_VERSION_10_1703;
-            } else if (get_proc_address(get_ntdll_base(),
-                                        "NtCreateRegistryTransaction") != NULL) {
+            } else if (d_r_get_proc_address(get_ntdll_base(),
+                                            "NtCreateRegistryTransaction") != NULL) {
                 if (module_is_64bit(get_ntdll_base())) {
                     syscalls = (int *)windows_10_1607_x64_syscalls;
                     os_name = "Microsoft Windows 10-1607 x64";
@@ -662,7 +663,8 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
                     os_name = "Microsoft Windows 10-1607";
                 }
                 os_version = WINDOWS_VERSION_10_1607;
-            } else if (get_proc_address(get_ntdll_base(), "NtCreateEnclave") != NULL) {
+            } else if (d_r_get_proc_address(get_ntdll_base(), "NtCreateEnclave") !=
+                       NULL) {
                 if (module_is_64bit(get_ntdll_base())) {
                     syscalls = (int *)windows_10_1511_x64_syscalls;
                     os_name = "Microsoft Windows 10-1511 x64";
@@ -728,7 +730,7 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
             /* i#437: ymm/avx is supported after Win-7 SP1 */
             if (os_service_pack_major >= 1) {
                 /* Sanity check on our SP ver retrieval */
-                ASSERT(get_proc_address(ntdllh, "RtlCopyContext") != NULL);
+                ASSERT(d_r_get_proc_address(ntdllh, "RtlCopyContext") != NULL);
                 if (module_is_64bit(get_ntdll_base()) ||
                     is_wow64_process(NT_CURRENT_PROCESS)) {
                     syscalls = (int *)windows_7_x64_syscalls;
@@ -738,7 +740,7 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
                     os_name = "Microsoft Windows 7 SP1";
                 }
             } else {
-                ASSERT(get_proc_address(ntdllh, "RtlCopyContext") == NULL);
+                ASSERT(d_r_get_proc_address(ntdllh, "RtlCopyContext") == NULL);
                 if (module_is_64bit(get_ntdll_base()) ||
                     is_wow64_process(NT_CURRENT_PROCESS)) {
                     syscalls = (int *)windows_7_x64_syscalls;
@@ -757,7 +759,7 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
                  * for sp1 - see PR 246402.  They also differ for
                  * 32-bit vs 64-bit/wow64.
                  */
-                ASSERT(get_proc_address(ntdllh, "NtReplacePartitionUnit") != NULL);
+                ASSERT(d_r_get_proc_address(ntdllh, "NtReplacePartitionUnit") != NULL);
                 if (module_is_64bit(get_ntdll_base()) ||
                     is_wow64_process(NT_CURRENT_PROCESS)) {
                     syscalls = (int *)windows_vista_sp1_x64_syscalls;
@@ -767,7 +769,7 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
                     os_name = "Microsoft Windows Vista SP1";
                 }
             } else {
-                ASSERT(get_proc_address(ntdllh, "NtReplacePartitionUnit") == NULL);
+                ASSERT(d_r_get_proc_address(ntdllh, "NtReplacePartitionUnit") == NULL);
                 if (module_is_64bit(get_ntdll_base()) ||
                     is_wow64_process(NT_CURRENT_PROCESS)) {
                     syscalls = (int *)windows_vista_sp0_x64_syscalls;
@@ -819,12 +821,12 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
              *   SP3: + Nt{Read,Write}FileScatter
              *   SP4: - NtW32Call
              */
-            if (get_proc_address(ntdllh, "NtW32Call") != NULL) {
+            if (d_r_get_proc_address(ntdllh, "NtW32Call") != NULL) {
                 /* < SP4 */
                 /* we don't know whether SP1 and SP2 fall in line w/ SP0 or w/ SP3,
                  * or possibly are different from both, but we don't support them
                  */
-                if (get_proc_address(ntdllh, "NtReadFileScatter") != NULL) {
+                if (d_r_get_proc_address(ntdllh, "NtReadFileScatter") != NULL) {
                     /* > SP0 */
                     syscalls = (int *)windows_NT_sp3_syscalls;
                     os_name = "Microsoft Windows NT SP3";
@@ -849,7 +851,7 @@ windows_version_init(int num_GetContextThread, int num_AllocateVirtualMemory)
                                  : "");
                     NULL_TERMINATE_BUFFER(os_name_buf);
                     os_name = os_name_buf;
-                    /* We print a notification in os_init() after stderr_mask options
+                    /* We print a notification in d_r_os_init() after stderr_mask options
                      * have been parsed.
                      */
                 } else {
@@ -952,7 +954,7 @@ print_mem_quota()
 
 /* os-specific initializations */
 void
-os_init(void)
+d_r_os_init(void)
 {
     PEB *peb = get_own_peb();
     uint alignment = 0;
@@ -1042,9 +1044,9 @@ os_init(void)
          */
         /* initializing so get_module_handle should be safe, FIXME */
         module_handle_t ntdllh = get_ntdll_base();
-        app_pc return_point = (app_pc)get_proc_address(ntdllh, "KiFastSystemCallRet");
+        app_pc return_point = (app_pc)d_r_get_proc_address(ntdllh, "KiFastSystemCallRet");
         if (return_point != NULL) {
-            app_pc syscall_pc = (app_pc)get_proc_address(ntdllh, "KiFastSystemCall");
+            app_pc syscall_pc = (app_pc)d_r_get_proc_address(ntdllh, "KiFastSystemCall");
             vsyscall_after_syscall = (app_pc)return_point;
             /* we'll re-set this once we see the 1st syscall, but we set an
              * initial value to what it should be for go-native scenarios
@@ -4549,14 +4551,14 @@ get_thread_private_dcontext(void)
      * We don't need to check whether this thread has been initialized under us -
      * Windows sets the value to 0 for us, so we'll just return NULL.
      */
-    return (dcontext_t *)get_tls(tls_dcontext_offs);
+    return (dcontext_t *)d_r_get_tls(tls_dcontext_offs);
 }
 
 /* sets the thread-private dcontext pointer for the calling thread */
 void
 set_thread_private_dcontext(dcontext_t *dcontext)
 {
-    set_tls(tls_dcontext_offs, dcontext);
+    d_r_set_tls(tls_dcontext_offs, dcontext);
 }
 
 #    ifdef WINDOWS_PC_SAMPLE
@@ -5385,7 +5387,7 @@ load_shared_library(const char *name, bool client)
 shlib_routine_ptr_t
 lookup_library_routine(shlib_handle_t lib, const char *name)
 {
-    return (shlib_routine_ptr_t)get_proc_address(lib, name);
+    return (shlib_routine_ptr_t)d_r_get_proc_address(lib, name);
 }
 
 void
@@ -5775,8 +5777,8 @@ get_stack_bounds(dcontext_t *dcontext, byte **base, byte **top)
          *   PVOID   pvStackUserBase;    // 08h Base of user stack
          * and assume fs is always a valid TIB pointer when called here
          */
-        stack_top = (byte *)get_tls(TOP_STACK_TIB_OFFSET);
-        stack_base = (byte *)get_tls(BASE_STACK_TIB_OFFSET);
+        stack_top = (byte *)d_r_get_tls(TOP_STACK_TIB_OFFSET);
+        stack_base = (byte *)d_r_get_tls(BASE_STACK_TIB_OFFSET);
         LOG(THREAD, LOG_THREADS, 1, "app stack now is " PFX "-" PFX "\n", stack_base,
             stack_top); /* NULL dcontext => nop */
         /* we only have current base, we need to find reserved base */
@@ -7861,8 +7863,8 @@ os_dump_core_external_dump()
     };
 
     /* the ONCRASH key tells us exactly what to launch, with our pid appended */
-    int retval =
-        get_parameter(PARAM_STR(DYNAMORIO_VAR_ONCRASH), oncrash_var, sizeof(oncrash_var));
+    int retval = d_r_get_parameter(PARAM_STR(DYNAMORIO_VAR_ONCRASH), oncrash_var,
+                                   sizeof(oncrash_var));
     if (IS_GET_PARAMETER_SUCCESS(retval)) {
         HANDLE child;
         /* ASSUMPTION: no spaces in exe name, should be ok since only developers will
@@ -9177,8 +9179,9 @@ open_trusted_cache_root_directory(void)
 
     if (DYNAMO_OPTION(aslr) != 0 || DYNAMO_OPTION(aslr_cache) != 0) {
         /* only use cache config var */
-        int retval = get_parameter(PARAM_STR(DYNAMORIO_VAR_CACHE_ROOT), base_directory,
-                                   BUFFER_SIZE_ELEMENTS(base_directory));
+        int retval =
+            d_r_get_parameter(PARAM_STR(DYNAMORIO_VAR_CACHE_ROOT), base_directory,
+                              BUFFER_SIZE_ELEMENTS(base_directory));
         param_ok = !IS_GET_PARAMETER_FAILURE(retval);
     } else {
         /* no aslr so this is just for pcache */

--- a/core/win32/os_exports.h
+++ b/core/win32/os_exports.h
@@ -77,7 +77,7 @@ get_os_version_ex(int *version OUT, uint *service_pack_major OUT,
 /* TEB offsets
  * we'd like to use offsetof(TEB, field) but that would require
  * everyone to include ntdll.h, and wouldn't work for inline assembly,
- * so we hardcode the fields we need here.  We check vs offsetof() in os_init().
+ * so we hardcode the fields we need here.  We check vs offsetof() in d_r_os_init().
  */
 enum {
 #ifdef X64
@@ -123,18 +123,18 @@ enum {
 
 /* even INLINE_FORCED isn't inlining this into d_r_get_thread_id() in debug build (i#655)
  */
-#define get_tls(/*ushort*/ tls_offs) \
+#define d_r_get_tls(/*ushort*/ tls_offs) \
     ((void *)IF_X64_ELSE(__readgsqword, __readfsdword)(tls_offs))
 
 static inline void
-set_tls(ushort tls_offs, void *value)
+d_r_set_tls(ushort tls_offs, void *value)
 {
     IF_X64_ELSE(__writegsqword, __writefsdword)(tls_offs, (ptr_uint_t)value);
 }
 
 /* even INLINE_FORCED isn't inlining this into d_r_get_thread_id() in debug build (i#655)
  */
-#define get_own_teb() ((TEB *)get_tls(SELF_TIB_OFFSET))
+#define get_own_teb() ((TEB *)d_r_get_tls(SELF_TIB_OFFSET))
 
 /* We need to meet these requirements:
  * + DrMi#1676: cur esp is in [StackLimit..StackBase) at all times on Win8.1.

--- a/core/win32/pre_inject.c
+++ b/core/win32/pre_inject.c
@@ -191,7 +191,7 @@ static bool load_dynamorio_lib(IF_NOT_X64(bool x64_in_wow64))
         retval = get_parameter_64(PARAM_STR(DYNAMORIO_VAR_AUTOINJECT), path, MAX_PATH);
     } else
 #endif
-        retval = get_parameter(PARAM_STR(DYNAMORIO_VAR_AUTOINJECT), path, MAX_PATH);
+        retval = d_r_get_parameter(PARAM_STR(DYNAMORIO_VAR_AUTOINJECT), path, MAX_PATH);
     if (IS_GET_PARAMETER_SUCCESS(retval)) {
         dr_marker_t mark;
         VERBOSE_MESSAGE("Loading \"%hs\"", path);
@@ -365,7 +365,7 @@ static int parameters_present(IF_NOT_X64(bool x64_in_wow64))
         retval = get_parameter_64(PARAM_STR(DYNAMORIO_VAR_AUTOINJECT), path, MAX_PATH);
     } else
 #endif
-        retval = get_parameter(PARAM_STR(DYNAMORIO_VAR_AUTOINJECT), path, MAX_PATH);
+        retval = d_r_get_parameter(PARAM_STR(DYNAMORIO_VAR_AUTOINJECT), path, MAX_PATH);
     if (IS_GET_PARAMETER_SUCCESS(retval)) {
         return 1;
     } else {

--- a/core/win32/syscall.c
+++ b/core/win32/syscall.c
@@ -886,7 +886,8 @@ init_syscall_trampolines(void)
             fpo_adjustment = &syscall_trampoline_gbop_fpo_offset[i];
 #endif
 
-            syscall_trampoline_hook_pc[i] = (app_pc)get_proc_address(h, syscall_names[i]);
+            syscall_trampoline_hook_pc[i] =
+                (app_pc)d_r_get_proc_address(h, syscall_names[i]);
             syscall_trampoline_pc[i] =
                 /* FIXME: would like to use static references to entry points -- yet,
                  * set of those we care about varies dynamically by platform, and
@@ -981,7 +982,7 @@ check_syscall_numbers(dcontext_t *dcontext)
     for (i = 0; i < SYS_MAX; i++) {
         if (syscalls[i] == SYSCALL_NOT_PRESENT)
             continue;
-        addr = (byte *)get_proc_address(h, syscall_names[i]);
+        addr = (byte *)d_r_get_proc_address(h, syscall_names[i]);
         ASSERT(addr != NULL);
         LOG(GLOBAL, LOG_SYSCALLS, 4, "\tsyscall 0x%x %s: addr " PFX "\n", i,
             syscall_names[i], addr);
@@ -1857,7 +1858,7 @@ presys_TerminateProcess(dcontext_t *dcontext, reg_t *param_base)
          * w/ > 1 thread perhaps we should do the synchall.
          */
         LOG(THREAD, LOG_SYSCALLS, 2, "\tterminating process w/ %d running thread(s)\n",
-            get_num_threads());
+            d_r_get_num_threads());
         KSTOP(pre_syscall);
         KSTOP(num_exits_dir_syscall);
         if (is_thread_currently_native(dcontext->thread_record)) {
@@ -1929,7 +1930,7 @@ presys_TerminateThread(dcontext_t *dcontext, reg_t *param_base)
     } else {
         /* case 9347 - racy early thread, yet primary is not yet 'known' */
         /* we should evaluate dr_late_injected_primary_thread before
-         * get_num_threads()
+         * d_r_get_num_threads()
          */
         bool secondary = dr_injected_secondary_thread && !dr_late_injected_primary_thread;
 
@@ -4623,7 +4624,7 @@ dr_syscall_intercept_natively(const char *name, int sysnum, int num_args, int wo
         if (intercept_native_syscall(i) && strcmp(syscall_names[i], name) == 0)
             return true;
     }
-    if (get_proc_address(get_ntdll_base(), name) == NULL)
+    if (d_r_get_proc_address(get_ntdll_base(), name) == NULL)
         return false;
     /* no lock needed since only supported during dr_client_main */
     idx = SYS_MAX + syscall_extra_idx;


### PR DESCRIPTION
Renames more global variables whose names are popular in other
third-party C libraries:

+ s/get_parameter/d_r_get_parameter/
+ s/get_proc_address/d_r_get_proc_address/
+ s/print_log/d_r_print_log/
+ s/map_file/d_r_map_file/
+ s/unmap_file/d_r_unmap_file/
+ s/get_tls/d_r_get_tls/
+ s/set_tls/d_r_set_tls/
+ s/get_num_threads/d_r_get_num_threads/
+ s/get_random_seed/d_r_get_random_seed/
+ s/set_random_seed/d_r_set_random_seed/
+ s/heap_init/d_r_heap_init/
+ s/heap_exit/d_r_heap_exit/
+ s/decode_init/d_r_decode_init/
+ s/monitor_init/d_r_monitor_init/
+ s/monitor_exit/d_r_monitor_exit/
+ s/os_init/d_r_os_init/
+ s/os_exit/d_r_os_exit/
+ s/signal_init/d_r_signal_init/
+ s/signal_exit/d_r_signal_exit/
+ s/link_init/d_r_link_init/
+ s/link_exit/d_r_link_exit/
+ s/arch_init/d_r_arch_init/
+ s/arch_exit/d_r_arch_exit/

Issue: #3348
