### PR TITLE
i#3437: Add generated header dependence to drmemfuncs

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -89,6 +89,7 @@ if (UNIX AND X86)
   add_asm_target(arch/x86/memfuncs.asm memfuncs_asm_src memfuncs_asm_tgt
     "_memfuncs" "" "${asm_deps}")
   add_library(drmemfuncs STATIC ${memfuncs_asm_src} lib/memmove.c)
+  add_gen_events_deps(drmemfuncs)
 endif ()
 
 # i#1409: to share core libc-ish code with non-core, we use the "drlibc" library.


### PR DESCRIPTION
Adds a dependence on the generated event headers to drmemfuncs to fix
a build race.

Issue: #3315
Fixes #3437