### PR TITLE
Increase -vm_size default and max for 64-bit

### DIFF
--- a/core/heap.c
+++ b/core/heap.c
@@ -589,13 +589,16 @@ typedef enum {
 static void
 report_low_on_memory(oom_source_t source, heap_error_code_t os_error_code);
 
-enum {
-    /* maximum 512MB for 32-bit, 2GB for 64-bit */
-    MAX_VMM_HEAP_UNIT_SIZE = IF_X64_ELSE(2U * 1024 * 1024 * 1024, 512U * 1024 * 1024),
-    /* We should normally have only one large unit, so this is in fact
-     * the maximum we should count on in one process
-     */
-};
+/* Maximum reservation is 512MB for 32-bit or 2GB for 64-bit. */
+#ifdef X64
+#    define MAX_VMM_HEAP_UNIT_SIZE (2U * 1024 * 1024 * 1024)
+#else
+#    define MAX_VMM_HEAP_UNIT_SIZE (512U * 1024 * 1024)
+#endif
+/* We should normally have only one large unit, so this is in fact
+ * the maximum we should count on in one process
+ */
+
 /* minimum will be used only if an invalid option is set */
 #define MIN_VMM_HEAP_UNIT_SIZE DYNAMO_OPTION(vmm_block_size)
 

--- a/core/heap.c
+++ b/core/heap.c
@@ -590,8 +590,8 @@ static void
 report_low_on_memory(oom_source_t source, heap_error_code_t os_error_code);
 
 enum {
-    /* maximum 512MB for 32-bit, 1GB for 64-bit */
-    MAX_VMM_HEAP_UNIT_SIZE = IF_X64_ELSE(1024 * 1024 * 1024, 512 * 1024 * 1024),
+    /* maximum 512MB for 32-bit, 2GB for 64-bit */
+    MAX_VMM_HEAP_UNIT_SIZE = IF_X64_ELSE(2U * 1024 * 1024 * 1024, 512U * 1024 * 1024),
     /* We should normally have only one large unit, so this is in fact
      * the maximum we should count on in one process
      */
@@ -614,9 +614,11 @@ typedef struct {
        static therefore we don't grab locks on read accesses.  Anyways,
        currently the bitmap_t is used with no write intent only for ASSERTs. */
     uint num_free_blocks; /* currently free blocks */
-    /* Bitmap uses 2KB static data for granularity 64KB and static maximum 1GB on Windows,
-     * and 32KB on Linux where granularity is 4KB.  These amounts are halved for
+    /* Bitmap uses 4KB static data for granularity 64KB and static maximum 2GB on Windows,
+     * and 64KB on Linux where granularity is 4KB.  These amounts are halved for
      * 32-bit, so 1KB Windows and 16KB Linux.
+     * We could make this dynamic to save some of the 64K for 64-bit: the default
+     * is 512M so we waste 48K.
      */
     /* Since we expect only two of these, for now it is ok for users
        to have static max rather than dynamically allocating with

--- a/core/heap.h
+++ b/core/heap.h
@@ -303,7 +303,7 @@ global_unprotected_heap_free(void *p, size_t size HEAPACCT(which_heap_t which));
 #define NONPERSISTENT_HEAP_TYPE_FREE(dc, p, type, which) \
     NONPERSISTENT_HEAP_ARRAY_FREE(dc, p, type, 1, which)
 
-#define MIN_VMM_BLOCK_SIZE IF_WINDOWS_ELSE(16 * 1024, 4 * 1024)
+#define MIN_VMM_BLOCK_SIZE IF_WINDOWS_ELSE(16U * 1024, 4U * 1024)
 
 /* special heap of same-sized blocks that avoids global locks */
 void *

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1416,12 +1416,12 @@ DYNAMIC_OPTION(bool, pause_via_loop,
     OPTION_DEFAULT_INTERNAL(bool, skip_out_of_vm_reserve_curiosity, false,
         "skip the assert curiosity on out of vm_reserve (for regression tests)")
     OPTION_DEFAULT(bool, vm_reserve, true, "reserve virtual memory")
-    OPTION_DEFAULT(uint_size, vm_size, IF_X64_ELSE(256,128)*1024*1024,
+    OPTION_DEFAULT(uint_size, vm_size, IF_X64_ELSE(512,128)*1024*1024,
                    /* XXX: default value is currently not good enough for sqlserver,
                     * for which we need more than 256MB.
                     */
                    "capacity of virtual memory region reserved (maximum supported is "
-                   "512MB for 32-bit and 1GB for 64-bit)")
+                   "512MB for 32-bit and 2GB for 64-bit)")
 
     /* We hardcode an address in the mmap_text region here, but verify via
      * in vmk_init().


### PR DESCRIPTION
Increases the default -vm_size for 64-bit from 256M to 512M.
Increases the maximum supported -vm_size for 64-bit from 1G to 2G.
