### PR TITLE
i#1312 AVX-512 support: Add a compile error for AVX-512 in DynamoRIO's core.

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -87,6 +87,11 @@
 #    include "vmkuw.h"
 #endif
 
+#ifdef __AVX512F__
+#    error "DynamoRIO core should run without AVX-512 instructions to remain \
+portable and to avoid frequency scaling."
+#endif
+
 /* global thread-shared variables */
 bool dynamo_initialized = false;
 bool dynamo_heap_initialized = false;


### PR DESCRIPTION
We do not want AVX-512 instructions in DynamoRIO itself. This way, DynamoRIO remains portable and also avoids unintended frequency scaling of the processor when running applications that itself don't contain AVX-512 code.

Issues: #1312, #3169