### PR TITLE
i#3456: Switches Travis to Xenial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,9 @@ branches:
   only:
   - master
 
-# We use Trusty to get cmake 3.5 via the cmake3 package.
+# We use Xenial.
 sudo: required
-dist: trusty
+dist: xenial
 
 language:
   - c
@@ -83,7 +83,7 @@ jobs:
         apt:
           sources:
           - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-6.0
+          - llvm-toolchain-xenial-7
           packages:
           - clang-format-6.0
     # 32-bit OSX build with clang and run tests:
@@ -105,7 +105,7 @@ install:
   # ImageMagick is present but these are not:
   - >
       if [[ "`uname`" == "Linux" ]]; then
-      sudo apt-get -y install doxygen transfig vera++ cmake3 zlib1g-dev libsnappy-dev; fi
+      sudo apt-get -y install ghostscript doxygen transfig vera++ cmake zlib1g-dev libsnappy-dev; fi
   # Install multilib for non-cross-compiling Linux builds:
   - >
       if [[ "`uname`" == "Linux" && $DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY == no ]]; then

--- a/make/cpp2asm_support.cmake
+++ b/make/cpp2asm_support.cmake
@@ -213,12 +213,8 @@ elseif (UNIX)
     endif (X64)
   elseif (ARM)
     # No 64-bit support yet.
-    set(ASM_FLAGS "${ASM_FLAGS} -mfpu=neon")
-    if (BUILD_TESTS)
-      # Some tests use deprecated instructions, disable warnings.
-      set(ASM_FLAGS "${ASM_FLAGS} -mno-warn-deprecated")
-    endif ()
-
+    # Some tests and libgcc/arm use deprecated instructions, disable warnings.
+    set(ASM_FLAGS "${ASM_FLAGS} -mfpu=neon -mno-warn-deprecated")
   endif ()
   set(ASM_FLAGS "${ASM_FLAGS} --noexecstack")
   if (DEBUG)


### PR DESCRIPTION
Switches Travis to Xenial and now defaults to gcc 5.

Adds the -mno-warn-deprecated flag in ARM cross-compiler build to all modules, due to
the ARM assembler of Xenial's cross compiler causing this warning for .asm files other
than just tests.

Fixes #3456