### PR TITLE
i#3474: CMake property rename

### DIFF
--- a/ext/drsyms/CMakeLists.txt
+++ b/ext/drsyms/CMakeLists.txt
@@ -188,7 +188,7 @@ endif ()
 # i#693: CMake will try to export the path to the static libs we use via
 # IMPORTED_LINK_INTERFACE_LIBRARIES_NOCONFIG, but they won't exist on the
 # user's machine.  Clearing this property prevents that.
-set_target_properties(drsyms PROPERTIES LINK_INTERFACE_LIBRARIES "")
+set_target_properties(drsyms PROPERTIES INTERFACE_LINK_LIBRARIES "")
 
 # If drsyms is built static we need to include these with an exports path
 # in DynamoRIOTarget*.cmake and not with the source path here:

--- a/ext/drsyms/CMakeLists.txt
+++ b/ext/drsyms/CMakeLists.txt
@@ -188,6 +188,8 @@ endif ()
 # i#693: CMake will try to export the path to the static libs we use via
 # IMPORTED_LINK_INTERFACE_LIBRARIES_NOCONFIG, but they won't exist on the
 # user's machine.  Clearing this property prevents that.
+# i#3474: LINK_INTERFACE_LIBRARIES is deprecated, which is overridden by
+#  the INTERFACE_LINK_LIBRARIES property if policy CMP0022 is NEW.
 set_target_properties(drsyms PROPERTIES INTERFACE_LINK_LIBRARIES "")
 
 # If drsyms is built static we need to include these with an exports path


### PR DESCRIPTION
#3263 has switched CMP0022 policy to NEW. However, CMake uses INTERFACE_LINK_LIBRARIES instead of LINK_INTERFACE_LIBRARIES when CMP0022 policy is NEW.[link](https://cmake.org/cmake/help/latest/prop_tgt/LINK_INTERFACE_LIBRARIES.html)

LINK_INTERFACE_LIBRARIES is used in #693 to clear hard-coded path in CMake cache, we should also change it when switch CMP0022 to NEW.