### PR TITLE
i#3485: Cut down runtime of tool.drcachesim.miss_analyzer.

### DIFF
--- a/clients/drcachesim/tests/stride_benchmark.cpp
+++ b/clients/drcachesim/tests/stride_benchmark.cpp
@@ -61,9 +61,9 @@ main(int argc, const char *argv[])
     const int kStride = 7;
     // Number of 1-byte elements in the array.
     // (200+ MiB to guarantee the array doesn't fit in Skylake caches)
-    const size_t kArraySize = 256 * 1024 * 1024;
+    const size_t kArraySize = 64 * 1024 * 1024;
     // Number of iterations in the main loop.
-    const int kIterations = 1000000;
+    const int kIterations = 100000;
     // The main vector/array used for emulating pointer chasing.
     unsigned char *buffer = new unsigned char[kArraySize];
     memset(buffer, kStride, kArraySize);


### PR DESCRIPTION
Cuts down runtime of the drcachesim.miss_analyzer test by cutting down the number of
the main loop's iterations as well as the array size in the test.

Fixes #3485