### PR TITLE
i#1312 AVX-512 support: Make Windows simd buffer increment more general.

### DIFF
--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -246,13 +246,13 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle, char *dynamo_pa
              * the dynamorio lib.
              */
             for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
-                for (j = 0; j < IF_X64_ELSE(2, 4); j++) {
+                for (j = 0; j < XMM_REG_SIZE / sizeof(*bufptr); j++) {
                     *bufptr++ = CXT_XMM(cxt, i)->reg[j];
                 }
                 /* FIXME i#437: save ymm fields.  For now we assume we're
                  * not saving and we just skip the upper 128 bits.
                  */
-                bufptr += IF_X64_ELSE(2, 4);
+                bufptr += (YMM_REG_SIZE - XMM_REG_SIZE) / sizeof(*bufptr);
             }
         } else {
             /* skip xmm slots */

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -245,6 +245,7 @@ inject_into_thread(HANDLE phandle, CONTEXT *cxt, HANDLE thandle, char *dynamo_pa
             /* XXX i#1312: This should be proc_num_simd_registers() which is part of
              * the dynamorio lib.
              */
+            ASSERT(MCXT_SIMD_SLOT_SIZE == YMM_REG_SIZE);
             for (i = 0; i < MCXT_NUM_SIMD_SLOTS; i++) {
                 for (j = 0; j < XMM_REG_SIZE / sizeof(*bufptr); j++) {
                     *bufptr++ = CXT_XMM(cxt, i)->reg[j];


### PR DESCRIPTION
Changes a buffer increment from hardcoded number of bytes into term with YMM_REG_SIZE.
This can be more easily changed to ZMM_REG_SIZE when widening to AVX-512.

Issue: #1312