### PR TITLE
i#1312 AVX-512 support: Add get_opmask_caller_saved() function.

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -145,6 +145,9 @@ compatibility changes:
    expression and code relying on this needs to be rewritten.
    DynamoRIO_NUM_SIMD_SLOTS_COMPATIBILITY is set automatically if clients target
    version 7.1.0 or earlier.
+ - Added the type dr_zmm_t.
+ - Added the type dr_opmask_t.
+ - Added the define #MCXT_NUM_OPMASK_SLOTS for the number of AVX-512 OpMask registers.
 
 Further non-compatibility-affecting changes include:
 

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -1329,6 +1329,8 @@ void
 get_ymm_caller_saved(dr_zmm_t *ymm_caller_saved_buf);
 void
 get_zmm_caller_saved(dr_zmm_t *zmm_caller_saved_buf);
+void
+get_opmask_caller_saved(dr_opmask_t *opmask_caller_saved_buf);
 
 /* in encode.c */
 byte *

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -59,6 +59,7 @@
 #    define XMM_REG_SIZE 16
 #    define YMM_REG_SIZE 32
 #    define ZMM_REG_SIZE 64
+#    define OPMASK_REG_SIZE 8
 #    define MCXT_SIMD_SLOT_SIZE ZMM_REG_SIZE
 #    define MCXT_TOTAL_SIMD_SLOTS_SIZE (MCXT_NUM_SIMD_SLOTS * MCXT_SIMD_SLOT_SIZE)
 /* Indicates OS support, not just processor support (xref i#1278) */

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -2372,9 +2372,8 @@ GLOBAL_LABEL(get_zmm_caller_saved:)
         END_FUNC(get_zmm_caller_saved)
 
 /* void get_opmask_caller_saved(byte *opmask_caller_saved_buf)
- *   stores the values of k1 through k7 consecutively into opmask_caller_saved_buf.
- *   opmask_caller_saved_buf need not be 8-byte aligned, but each slot is 8 bytes,
- *   regardless of whether the k register's real size. k0 is not written.
+ *   stores the values of k0 through k7 consecutively in 8 byte slots each into
+ *   opmask_caller_saved_buf. opmask_caller_saved_buf need not be 8-byte aligned.
  *   The caller must ensure that the underlying processor supports AVX-512!
  *   XXX i#1312: Eventually this routine must dynamically switch the instructions
  *   used dependent on whether AVX512BW is enabled or not (2 bytes vs. 8 bytes
@@ -2384,21 +2383,23 @@ GLOBAL_LABEL(get_zmm_caller_saved:)
 GLOBAL_LABEL(get_opmask_caller_saved:)
         mov      REG_XAX, ARG1
        /*
-        * c5 f8 91 08       kmovw  %k1,0x00(%rax)
-        * c5 f8 91 50 08    kmovw  %k2,0x08(%rax)
-        * c5 f8 91 58 10    kmovw  %k3,0x10(%rax)
-        * c5 f8 91 60 18    kmovw  %k4,0x18(%rax)
-        * c5 f8 91 68 20    kmovw  %k5,0x20(%rax)
-        * c5 f8 91 70 28    kmovw  %k6,0x28(%rax)
-        * c5 f8 91 78 30    kmovw  %k7,0x30(%rax)
+        * c5 f8 91 00       kmovw  %k0,(%rax)
+        * c5 f8 91 48 08    kmovw  %k1,0x8(%rax)
+        * c5 f8 91 50 10    kmovw  %k2,0x10(%rax)
+        * c5 f8 91 58 18    kmovw  %k3,0x18(%rax)
+        * c5 f8 91 60 20    kmovw  %k4,0x20(%rax)
+        * c5 f8 91 68 28    kmovw  %k5,0x28(%rax)
+        * c5 f8 91 70 30    kmovw  %k6,0x30(%rax)
+        * c5 f8 91 78 38    kmovw  %k7,0x38(%rax)
         */
-        RAW(c5) RAW(f8) RAW(91) RAW(08)
-        RAW(c5) RAW(f8) RAW(91) RAW(50) RAW(08)
-        RAW(c5) RAW(f8) RAW(91) RAW(58) RAW(10)
-        RAW(c5) RAW(f8) RAW(91) RAW(60) RAW(18)
-        RAW(c5) RAW(f8) RAW(91) RAW(68) RAW(20)
-        RAW(c5) RAW(f8) RAW(91) RAW(70) RAW(28)
-        RAW(c5) RAW(f8) RAW(91) RAW(78) RAW(30)
+        RAW(c5) RAW(f8) RAW(91) RAW(00)
+        RAW(c5) RAW(f8) RAW(91) RAW(48) RAW(08)
+        RAW(c5) RAW(f8) RAW(91) RAW(50) RAW(10)
+        RAW(c5) RAW(f8) RAW(91) RAW(58) RAW(18)
+        RAW(c5) RAW(f8) RAW(91) RAW(60) RAW(20)
+        RAW(c5) RAW(f8) RAW(91) RAW(68) RAW(28)
+        RAW(c5) RAW(f8) RAW(91) RAW(70) RAW(30)
+        RAW(c5) RAW(f8) RAW(91) RAW(78) RAW(38)
         ret
         END_FUNC(get_opmask_caller_saved)
 

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -2372,8 +2372,9 @@ GLOBAL_LABEL(get_zmm_caller_saved:)
         END_FUNC(get_zmm_caller_saved)
 
 /* void get_opmask_caller_saved(byte *opmask_caller_saved_buf)
- *   stores the values of k0 through k7 consecutively in 8 byte slots each into
- *   opmask_caller_saved_buf. opmask_caller_saved_buf need not be 8-byte aligned.
+ *   stores the values of k1 through k7 consecutively into opmask_caller_saved_buf.
+ *   opmask_caller_saved_buf need not be 8-byte aligned, but each slot is 8 bytes,
+ *   regardless of whether the k register's real size. k0 is not written.
  *   The caller must ensure that the underlying processor supports AVX-512!
  *   XXX i#1312: Eventually this routine must dynamically switch the instructions
  *   used dependent on whether AVX512BW is enabled or not (2 bytes vs. 8 bytes
@@ -2383,23 +2384,21 @@ GLOBAL_LABEL(get_zmm_caller_saved:)
 GLOBAL_LABEL(get_opmask_caller_saved:)
         mov      REG_XAX, ARG1
        /*
-        * c5 f8 91 00       kmovw  %k0,(%rax)
-        * c5 f8 91 48 08    kmovw  %k1,0x8(%rax)
-        * c5 f8 91 50 10    kmovw  %k2,0x10(%rax)
-        * c5 f8 91 58 18    kmovw  %k3,0x18(%rax)
-        * c5 f8 91 60 20    kmovw  %k4,0x20(%rax)
-        * c5 f8 91 68 28    kmovw  %k5,0x28(%rax)
-        * c5 f8 91 70 30    kmovw  %k6,0x30(%rax)
-        * c5 f8 91 78 38    kmovw  %k7,0x38(%rax)
+        * c5 f8 91 08       kmovw  %k1,0x00(%rax)
+        * c5 f8 91 50 08    kmovw  %k2,0x08(%rax)
+        * c5 f8 91 58 10    kmovw  %k3,0x10(%rax)
+        * c5 f8 91 60 18    kmovw  %k4,0x18(%rax)
+        * c5 f8 91 68 20    kmovw  %k5,0x20(%rax)
+        * c5 f8 91 70 28    kmovw  %k6,0x28(%rax)
+        * c5 f8 91 78 30    kmovw  %k7,0x30(%rax)
         */
-        RAW(c5) RAW(f8) RAW(91) RAW(00)
-        RAW(c5) RAW(f8) RAW(91) RAW(48) RAW(08)
-        RAW(c5) RAW(f8) RAW(91) RAW(50) RAW(10)
-        RAW(c5) RAW(f8) RAW(91) RAW(58) RAW(18)
-        RAW(c5) RAW(f8) RAW(91) RAW(60) RAW(20)
-        RAW(c5) RAW(f8) RAW(91) RAW(68) RAW(28)
-        RAW(c5) RAW(f8) RAW(91) RAW(70) RAW(30)
-        RAW(c5) RAW(f8) RAW(91) RAW(78) RAW(38)
+        RAW(c5) RAW(f8) RAW(91) RAW(08)
+        RAW(c5) RAW(f8) RAW(91) RAW(50) RAW(08)
+        RAW(c5) RAW(f8) RAW(91) RAW(58) RAW(10)
+        RAW(c5) RAW(f8) RAW(91) RAW(60) RAW(18)
+        RAW(c5) RAW(f8) RAW(91) RAW(68) RAW(20)
+        RAW(c5) RAW(f8) RAW(91) RAW(70) RAW(28)
+        RAW(c5) RAW(f8) RAW(91) RAW(78) RAW(30)
         ret
         END_FUNC(get_opmask_caller_saved)
 

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -2371,6 +2371,38 @@ GLOBAL_LABEL(get_zmm_caller_saved:)
         ret
         END_FUNC(get_zmm_caller_saved)
 
+/* void get_opmask_caller_saved(byte *opmask_caller_saved_buf)
+ *   stores the values of k0 through k7 consecutively in 8 byte slots each into
+ *   opmask_caller_saved_buf. opmask_caller_saved_buf need not be 8-byte aligned.
+ *   The caller must ensure that the underlying processor supports AVX-512!
+ *   XXX i#1312: Eventually this routine must dynamically switch the instructions
+ *   used dependent on whether AVX512BW is enabled or not (2 bytes vs. 8 bytes
+ *   OpMask registers).
+ */
+        DECLARE_FUNC(get_opmask_caller_saved)
+GLOBAL_LABEL(get_opmask_caller_saved:)
+        mov      REG_XAX, ARG1
+       /*
+        * c5 f8 91 00       kmovw  %k0,(%rax)
+        * c5 f8 91 48 08    kmovw  %k1,0x8(%rax)
+        * c5 f8 91 50 10    kmovw  %k2,0x10(%rax)
+        * c5 f8 91 58 18    kmovw  %k3,0x18(%rax)
+        * c5 f8 91 60 20    kmovw  %k4,0x20(%rax)
+        * c5 f8 91 68 28    kmovw  %k5,0x28(%rax)
+        * c5 f8 91 70 30    kmovw  %k6,0x30(%rax)
+        * c5 f8 91 78 38    kmovw  %k7,0x38(%rax)
+        */
+        RAW(c5) RAW(f8) RAW(91) RAW(00)
+        RAW(c5) RAW(f8) RAW(91) RAW(48) RAW(08)
+        RAW(c5) RAW(f8) RAW(91) RAW(50) RAW(10)
+        RAW(c5) RAW(f8) RAW(91) RAW(58) RAW(18)
+        RAW(c5) RAW(f8) RAW(91) RAW(60) RAW(20)
+        RAW(c5) RAW(f8) RAW(91) RAW(68) RAW(28)
+        RAW(c5) RAW(f8) RAW(91) RAW(70) RAW(30)
+        RAW(c5) RAW(f8) RAW(91) RAW(78) RAW(38)
+        ret
+        END_FUNC(get_opmask_caller_saved)
+
 /* void hashlookup_null_handler(void)
  * PR 305731: if the app targets NULL, it ends up here, which indirects
  * through hashlookup_null_target to end up in an ibl miss routine.

--- a/core/arch/x86_code_test.c
+++ b/core/arch/x86_code_test.c
@@ -342,7 +342,7 @@ unit_test_get_opmask_caller_saved()
      * the type will be __mmask64. Also DynamoRIO's get_opmask_caller_saved has to
      * dynamically switch dependent on a proc_ flag indicating AVX512BW is enabled.
      */
-    FAIL();
+#            error "Unimplemented. Should test using __mmask64 instructions."
 #        else
     ASSERT(MCXT_NUM_OPMASK_SLOTS == 8);
     register __mmask16 k0 asm("k0");

--- a/core/arch/x86_code_test.c
+++ b/core/arch/x86_code_test.c
@@ -329,10 +329,12 @@ unit_test_get_opmask_caller_saved()
 {
     /* While DynamoRIO's dr_opmask_t type is 8 bytes, the actual machine register is
      * really only 8 bytes if the processor and OS support AVX512BW. Otherwise it is
-     * 2 Bytes.
+     * 2 Bytes. We're only testing k1 - k7, since k0 is a hard-wired register used
+     * for unmasked operations in AVX-512. That said, it looks like writing and reading
+     * of k0 is still possible, but this might not be guaranteed on every processor.
      */
-    dr_opmask_t ref_buffer[MCXT_NUM_OPMASK_SLOTS];
-    dr_opmask_t get_buffer[MCXT_NUM_OPMASK_SLOTS];
+    dr_opmask_t ref_buffer[MCXT_NUM_OPMASK_SLOTS - 1];
+    dr_opmask_t get_buffer[MCXT_NUM_OPMASK_SLOTS - 1];
     ASSERT(sizeof(dr_opmask_t) == OPMASK_REG_SIZE);
     uint base = 0x0000348e;
 
@@ -345,7 +347,6 @@ unit_test_get_opmask_caller_saved()
 #            error "Unimplemented. Should test using __mmask64 instructions."
 #        else
     ASSERT(MCXT_NUM_OPMASK_SLOTS == 8);
-    register __mmask16 k0 asm("k0");
     register __mmask16 k1 asm("k1");
     register __mmask16 k2 asm("k2");
     register __mmask16 k3 asm("k3");
@@ -355,16 +356,18 @@ unit_test_get_opmask_caller_saved()
     register __mmask16 k7 asm("k7");
 #        endif
 
-    for (int regno = 0; regno < MCXT_NUM_OPMASK_SLOTS; ++regno) {
+    for (int regno = 0; regno < MCXT_NUM_OPMASK_SLOTS - 1; ++regno) {
         get_buffer[regno] = 0;
         ref_buffer[regno] = base++;
     }
 
 #        define MAKE_OPMASK_REG(num) k##num
-#        define MOVE_TO_OPMASK(buf, num) \
-            asm volatile("kmovw %1, %0" : "=k"(MAKE_OPMASK_REG(num)) : "m"(buf[num]) :);
+#        define MOVE_TO_OPMASK(buf, num)              \
+            asm volatile("kmovw %1, %0"               \
+                         : "=k"(MAKE_OPMASK_REG(num)) \
+                         : "m"(buf[num - 1])          \
+                         :);
 
-    MOVE_TO_OPMASK(ref_buffer, 0)
     MOVE_TO_OPMASK(ref_buffer, 1)
     MOVE_TO_OPMASK(ref_buffer, 2)
     MOVE_TO_OPMASK(ref_buffer, 3)
@@ -378,17 +381,18 @@ unit_test_get_opmask_caller_saved()
     /* Barrier, as described in unit_test_get_zmm_caller_saved. */
     asm volatile("" ::: "k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7");
 
-    for (int regno = 0; regno < MCXT_NUM_OPMASK_SLOTS; ++regno) {
+    for (int regno = 1; regno < MCXT_NUM_OPMASK_SLOTS; ++regno) {
         print_file(STDERR, "K%d ref\n:", regno);
-        dump_buffer_as_bytes(STDERR, &ref_buffer[regno], sizeof(ref_buffer[regno]),
-                             DUMP_RAW | DUMP_DWORD);
+        dump_buffer_as_bytes(STDERR, &ref_buffer[regno - 1],
+                             sizeof(ref_buffer[regno - 1]), DUMP_RAW | DUMP_DWORD);
         print_file(STDERR, "\nK%d get\n:", regno);
-        dump_buffer_as_bytes(STDERR, &get_buffer[regno], sizeof(get_buffer[regno]),
-                             DUMP_RAW | DUMP_DWORD);
+        dump_buffer_as_bytes(STDERR, &get_buffer[regno - 1],
+                             sizeof(get_buffer[regno - 1]), DUMP_RAW | DUMP_DWORD);
         print_file(STDERR, "\n");
     }
-    EXPECT(memcmp(ref_buffer, get_buffer, MCXT_NUM_OPMASK_SLOTS * sizeof(dr_opmask_t)),
-           0);
+    EXPECT(
+        memcmp(ref_buffer, get_buffer, (MCXT_NUM_OPMASK_SLOTS - 1) * sizeof(dr_opmask_t)),
+        0);
 }
 
 #    endif

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -1838,6 +1838,9 @@ typedef union _dr_zmm_t {
     reg_t reg[IF_X64_ELSE(8, 16)]; /**< Representation as 8 or 16 registers. */
 } dr_zmm_t;
 
+/* OpMask (k-)register. The register may be only 16 bits on systems w/o AVX512BW, but
+ * can be up to MAX_KL = 64 bits.
+ */
 typedef uint64 dr_opmask_t;
 
 #if defined(AARCHXX)

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -1838,6 +1838,8 @@ typedef union _dr_zmm_t {
     reg_t reg[IF_X64_ELSE(8, 16)]; /**< Representation as 8 or 16 registers. */
 } dr_zmm_t;
 
+typedef uint64 dr_opmask_t;
+
 #if defined(AARCHXX)
 /**
  * 128-bit ARM SIMD Vn register.
@@ -1873,6 +1875,7 @@ typedef union _dr_simd_t {
 #    define PRE_SIMD_PADDING                                       \
         0 /**< Bytes of padding before xmm/ymm dr_mcontext_t slots \
            */
+#    define MCXT_NUM_OPMASK_SLOTS 0 /**< No simd masks */
 
 #elif defined(X86)
 
@@ -1906,7 +1909,9 @@ typedef union _dr_simd_t {
 #        define PRE_XMM_PADDING \
             24 /**< Bytes of padding before xmm/ymm dr_mcontext_t slots */
 #    endif
-
+#    define MCXT_NUM_OPMASK_SLOTS                                   \
+        8 /**< Number of 16-64-bit OpMask Kn slots in dr_mcontext_t \
+           */
 #else
 #    error NYI
 #endif /* AARCHXX/X86 */


### PR DESCRIPTION
Adds function get_opmask_caller_saved() that saves 16-bit AVX-512 OpMask registers to a
buffer. It still lacks support for AVX512BW, which will save 64-bit registers.

Adds a test for get_opmask_caller_saved().

Adds the define MCXT_NUM_OPMASK_SLOTS that will also be used for a future structure in
DynamoRIO's mcontext.

Adds a missing release note that dr_zmm_t was added and adds release notes for this patch.

Issue: #1312