### PR TITLE
i#1312 AVX-512 support: Fix API comment and doxygen links.

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -145,9 +145,6 @@ compatibility changes:
    expression and code relying on this needs to be rewritten.
    DynamoRIO_NUM_SIMD_SLOTS_COMPATIBILITY is set automatically if clients target
    version 7.1.0 or earlier.
- - Added the type #dr_zmm_t.
- - Added the type #dr_opmask_t.
- - Added the define #MCXT_NUM_OPMASK_SLOTS for the number of AVX-512 OpMask registers.
 
 Further non-compatibility-affecting changes include:
 
@@ -156,6 +153,9 @@ Further non-compatibility-affecting changes include:
  - Added new fields to #dr_os_version_info_t which contain the build number,
    edition, and Windows 10 release identifier.
  - Added the function instr_is_xsave().
+ - Added the type #dr_zmm_t.
+ - Added the type #dr_opmask_t.
+ - Added the define #MCXT_NUM_OPMASK_SLOTS for the number of AVX-512 OpMask registers.
 
 **************************************************
 <hr>

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -145,8 +145,8 @@ compatibility changes:
    expression and code relying on this needs to be rewritten.
    DynamoRIO_NUM_SIMD_SLOTS_COMPATIBILITY is set automatically if clients target
    version 7.1.0 or earlier.
- - Added the type dr_zmm_t.
- - Added the type dr_opmask_t.
+ - Added the type #dr_zmm_t.
+ - Added the type #dr_opmask_t.
  - Added the define #MCXT_NUM_OPMASK_SLOTS for the number of AVX-512 OpMask registers.
 
 Further non-compatibility-affecting changes include:

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -1281,8 +1281,9 @@ typedef char liststring_t[MAX_LIST_OPTION_LENGTH];
 #    define INJECT_HELPER_DLL2_NAME "drearlyhelp2.dll"
 
 #    define DEBUGGER_INJECTION_HIVE HKEY_LOCAL_MACHINE
-#    define DEBUGGER_INJECTION_KEY \
-        "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options"
+#    define DEBUGGER_INJECTION_KEY                                               \
+        "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution " \
+        "Options"
 #    define DEBUGGER_INJECTION_VALUE_NAME "Debugger"
 
 #    define DEBUGGER_INJECTION_HIVE_L L"\\Registry\\Machine\\"
@@ -1838,9 +1839,12 @@ typedef union _dr_zmm_t {
     reg_t reg[IF_X64_ELSE(8, 16)]; /**< Representation as 8 or 16 registers. */
 } dr_zmm_t;
 
-/* OpMask (k-)register. The register may be only 16 bits on systems w/o AVX512BW, but
- * can be up to MAX_KL = 64 bits.
+/** AVX-512 OpMask (k-)register. */
+#ifdef AVOID_API_EXPORT
+/* The register may be only 16 bits wide on systems without AVX512BW, but can be up to
+ * MAX_KL = 64 bits.
  */
+#endif
 typedef uint64 dr_opmask_t;
 
 #if defined(AARCHXX)
@@ -1878,7 +1882,10 @@ typedef union _dr_simd_t {
 #    define PRE_SIMD_PADDING                                       \
         0 /**< Bytes of padding before xmm/ymm dr_mcontext_t slots \
            */
-#    define MCXT_NUM_OPMASK_SLOTS 0 /**< No simd masks */
+#    define MCXT_NUM_OPMASK_SLOTS                                    \
+        0 /**< Number of 16-64-bit OpMask Kn slots in dr_mcontext_t, \
+           * if architecture supports.                               \
+           */
 
 #elif defined(X86)
 
@@ -1912,8 +1919,9 @@ typedef union _dr_simd_t {
 #        define PRE_XMM_PADDING \
             24 /**< Bytes of padding before xmm/ymm dr_mcontext_t slots */
 #    endif
-#    define MCXT_NUM_OPMASK_SLOTS                                   \
-        8 /**< Number of 16-64-bit OpMask Kn slots in dr_mcontext_t \
+#    define MCXT_NUM_OPMASK_SLOTS                                    \
+        8 /**< Number of 16-64-bit OpMask Kn slots in dr_mcontext_t, \
+           * if architecture supports.                               \
            */
 #else
 #    error NYI

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -1281,9 +1281,8 @@ typedef char liststring_t[MAX_LIST_OPTION_LENGTH];
 #    define INJECT_HELPER_DLL2_NAME "drearlyhelp2.dll"
 
 #    define DEBUGGER_INJECTION_HIVE HKEY_LOCAL_MACHINE
-#    define DEBUGGER_INJECTION_KEY                                               \
-        "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution " \
-        "Options"
+#    define DEBUGGER_INJECTION_KEY \
+        "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options"
 #    define DEBUGGER_INJECTION_VALUE_NAME "Debugger"
 
 #    define DEBUGGER_INJECTION_HIVE_L L"\\Registry\\Machine\\"


### PR DESCRIPTION
Amends commit 851a961e2d0bedb9254025ba95 with doxygen links and fixes a documentation bug
for MCXT_NUM_OPMASK_SLOTS.

Issue: #1312