### PR TITLE
i#1312 AVX-512 support: Provide ymm field in mcontext.

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -156,6 +156,7 @@ Further non-compatibility-affecting changes include:
  - Added the type #dr_zmm_t.
  - Added the type #dr_opmask_t.
  - Added the define #MCXT_NUM_OPMASK_SLOTS for the number of AVX-512 OpMask registers.
+ - Renamed mcontext's ymm structure into simd.
 
 **************************************************
 <hr>

--- a/core/lib/mcxtx.h
+++ b/core/lib/mcxtx.h
@@ -260,8 +260,8 @@
 #    endif
         dr_zmm_t simd[MCXT_NUM_SIMD_SLOTS];
         /**
-         * The ymm field is provided for backward compatibility and is an alias for the
-         * simd field.
+         * \deprecated The ymm field is provided for backward compatibility and is an
+         * alias for the simd field.
          */
         dr_zmm_t ymm[MCXT_NUM_SIMD_SLOTS];
     };

--- a/core/lib/mcxtx.h
+++ b/core/lib/mcxtx.h
@@ -256,5 +256,11 @@
      * bytes.
      */
 #    endif
-    dr_zmm_t simd[MCXT_NUM_SIMD_SLOTS];
+    union {
+        dr_zmm_t simd[MCXT_NUM_SIMD_SLOTS];
+#    ifdef AVOID_API_EXPORT
+        /* The ymm field is provided for backward compat. */
+#    endif
+        dr_zmm_t ymm[MCXT_NUM_SIMD_SLOTS];
+    };
 #endif /* ARM/X86 */

--- a/core/lib/mcxtx.h
+++ b/core/lib/mcxtx.h
@@ -218,49 +218,51 @@
                                           rip/eip register. */
     };
     byte padding[PRE_XMM_PADDING]; /**< The padding to get zmm field 64-byte aligned. */
-    /**
-     * The SSE registers xmm0-xmm5 (-xmm15 on Linux) are volatile
-     * (caller-saved) for 64-bit and WOW64, and are actually zeroed out on
-     * Windows system calls.  These fields are ignored for 32-bit processes
-     * that are not WOW64, or if the underlying processor does not support
-     * SSE.  Use dr_mcontext_xmm_fields_valid() to determine whether the
-     * fields are valid.
-     *
-     * When the fields are valid, on processors with AVX enabled (i.e.,
-     * proc_has_feature(FEATURE_AVX) returns true), these fields will
-     * contain the full ymm register values; otherwise, the top 128
-     * bits of each slot will be undefined.
-     */
-#    ifdef AVOID_API_EXPORT
-    /* PR 264138: we must preserve xmm0-5 if on a 64-bit Windows kernel,
-     * and xmm0-15 if in a 64-bit Linux app (PR 302107).  (Note that
-     * mmx0-7 are also caller-saved on linux but we assume they're not
-     * going to be used by DR, libc, or client routines: overlap w/
-     * floating point).  For Windows we assume that none of our routines
-     * (or libc routines that we call, except the floating-point ones,
-     * where we explicitly save state) clobber beyond xmm0-5.  Rather than
-     * have a separate WOW64 build, we have them in the struct but ignored
-     * for normal 32-bit.
-     * PR 306394: we preserve xmm0-7 for 32-bit linux too.
-     * DrMi#665: we now preserve all of the xmm registers.
-     *
-     * The size of mcontext's simd strucure has become a potential risk for DynamoRIO's
-     * stack- and signal stack size or for general memory usage becoming too large.
-     * Compared to AVX's ymm registers, the AVX-512 zmm register slots are adding 1536
-     * bytes on 64-bit on Linux. On 32-bit Linux, it is adding 256 bytes.
-     * XXX i#1312: If this will become a problem, we may want to separate this out into a
-     * heap structure and only maintain a pointer on the stack. This would save space on
-     * memory constraint platforms as well as keep our signal stack size smaller.
-     * XXX i#1312: Currently, only 512 bytes are added on 64-bit until MCXT_NUM_SIMD_SLOTS
-     * will be 32. This excludes AVX-512 k mask registers, which will add another 64
-     * bytes.
-     */
-#    endif
     union {
-        dr_zmm_t simd[MCXT_NUM_SIMD_SLOTS];
+        /**
+         * The SSE registers xmm0-xmm5 (-xmm15 on Linux) are volatile
+         * (caller-saved) for 64-bit and WOW64, and are actually zeroed out on
+         * Windows system calls.  These fields are ignored for 32-bit processes
+         * that are not WOW64, or if the underlying processor does not support
+         * SSE.  Use dr_mcontext_xmm_fields_valid() to determine whether the
+         * fields are valid.
+         *
+         * When the fields are valid, on processors with AVX enabled (i.e.,
+         * proc_has_feature(FEATURE_AVX) returns true), these fields will
+         * contain the full ymm register values; otherwise, the top 128
+         * bits of each slot will be undefined.
+         */
 #    ifdef AVOID_API_EXPORT
-        /* The ymm field is provided for backward compat. */
+        /* PR 264138: we must preserve xmm0-5 if on a 64-bit Windows kernel,
+         * and xmm0-15 if in a 64-bit Linux app (PR 302107).  (Note that
+         * mmx0-7 are also caller-saved on linux but we assume they're not
+         * going to be used by DR, libc, or client routines: overlap w/
+         * floating point).  For Windows we assume that none of our routines
+         * (or libc routines that we call, except the floating-point ones,
+         * where we explicitly save state) clobber beyond xmm0-5.  Rather than
+         * have a separate WOW64 build, we have them in the struct but ignored
+         * for normal 32-bit.
+         * PR 306394: we preserve xmm0-7 for 32-bit linux too.
+         * DrMi#665: we now preserve all of the xmm registers.
+         *
+         * The size of mcontext's simd strucure has become a potential risk for
+         * DynamoRIO's stack- and signal stack size or for general memory usage becoming
+         * too large. Compared to AVX's ymm registers, the AVX-512 zmm register slots are
+         * adding 1536 bytes on 64-bit on Linux. On 32-bit Linux, it is adding 256 bytes.
+         * XXX i#1312: If this will become a problem, we may want to separate this out
+         * into a heap structure and only maintain a pointer on the stack. This would save
+         * space on memory constraint platforms as well as keep our signal stack size
+         * smaller.
+         * XXX i#1312: Currently, only 512 bytes are added on 64-bit until
+         * MCXT_NUM_SIMD_SLOTS will be 32. This excludes AVX-512 k mask registers, which
+         * will add another 64 bytes.
+         */
 #    endif
+        dr_zmm_t simd[MCXT_NUM_SIMD_SLOTS];
+        /**
+         * The ymm field is provided for backward compatibility and is an alias for the
+         * simd field.
+         */
         dr_zmm_t ymm[MCXT_NUM_SIMD_SLOTS];
     };
 #endif /* ARM/X86 */

--- a/core/lib/mcxtx.h
+++ b/core/lib/mcxtx.h
@@ -218,6 +218,10 @@
                                           rip/eip register. */
     };
     byte padding[PRE_XMM_PADDING]; /**< The padding to get zmm field 64-byte aligned. */
+    /**
+     * Anonymous union of alternative names for the simd structure in dr_mcontext_t. The
+     * deprecated name ymm is provided for backward compatibility.
+     */
     union {
         /**
          * The SSE registers xmm0-xmm5 (-xmm15 on Linux) are volatile


### PR DESCRIPTION
Provides a union with ymm field in addition to simd for backward compatibility. The name
was changed in f9c8364fe41752979788a35d.

Issue: #1312