### PR TITLE
Change -cache_commit_increment to uint_size to accept prefixes

### DIFF
--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1180,7 +1180,7 @@ DYNAMIC_OPTION(bool, pause_via_loop,
     /* heap_commit_increment may be adjusted by adjust_defaults_for_page_size(). */
     OPTION_DEFAULT(uint_size, heap_commit_increment, 4*1024, "heap commit increment")
     /* cache_commit_increment may be adjusted by adjust_defaults_for_page_size(). */
-    OPTION_DEFAULT(uint, cache_commit_increment, 4*1024, "cache commit increment")
+    OPTION_DEFAULT(uint_size, cache_commit_increment, 4*1024, "cache commit increment")
 
     /* cache capacity control
      * FIXME: these are external for now while we study the right way to


### PR DESCRIPTION
Updates the -cache_commit_increment option which was accidentally a
"uint" to be a "uint_size" option, so we can specify K and M prefixes
for much easier use.