### PR TITLE
Adds optional '-logprefix' command line option to drcov

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -157,6 +157,7 @@ Further non-compatibility-affecting changes include:
  - Added the type #dr_opmask_t.
  - Added the define #MCXT_NUM_OPMASK_SLOTS for the number of AVX-512 OpMask registers.
  - Renamed mcontext's ymm structure into simd.
+ - Added a new option -logprefix to drcov.
 
 **************************************************
 <hr>

--- a/clients/drcov/drcov.c
+++ b/clients/drcov/drcov.c
@@ -139,6 +139,9 @@ options_init(client_id_t id, int argc, const char *argv[], drcovlib_options_t *o
         else if (strcmp(token, "-logdir") == 0) {
             USAGE_CHECK((i + 1) < argc, "missing logdir path");
             ops->logdir = argv[++i];
+        } else if (strcmp(token, "-logprefix") == 0) {
+            USAGE_CHECK((i + 1) < argc, "missing logprefix string");
+            ops->logprefix = argv[++i];
         } else if (strcmp(token, "-native_until_thread") == 0) {
             USAGE_CHECK((i + 1) < argc, "missing -native_until_thread number");
             token = argv[++i];

--- a/ext/drcovlib/drcovlib.c
+++ b/ext/drcovlib/drcovlib.c
@@ -95,8 +95,7 @@ log_file_create_helper(void *drcontext, const char *suffix, char *buf, size_t bu
     file_t log = drx_open_unique_appid_file(
         options.logdir,
         drcontext == NULL ? dr_get_process_id() : dr_get_thread_id(drcontext),
-        options.logprefix,
-        suffix,
+        options.logprefix, suffix,
 #ifndef WINDOWS
         DR_FILE_CLOSE_ON_FORK |
 #endif

--- a/ext/drcovlib/drcovlib.c
+++ b/ext/drcovlib/drcovlib.c
@@ -94,7 +94,8 @@ log_file_create_helper(void *drcontext, const char *suffix, char *buf, size_t bu
 {
     file_t log = drx_open_unique_appid_file(
         options.logdir,
-        drcontext == NULL ? dr_get_process_id() : dr_get_thread_id(drcontext), "drcov",
+        drcontext == NULL ? dr_get_process_id() : dr_get_thread_id(drcontext),
+        options.logprefix,
         suffix,
 #ifndef WINDOWS
         DR_FILE_CLOSE_ON_FORK |
@@ -557,6 +558,8 @@ drcovlib_init(drcovlib_options_t *ops)
         dr_snprintf(logdir, BUFFER_SIZE_ELEMENTS(logdir), ".");
     NULL_TERMINATE_BUFFER(logdir);
     options.logdir = logdir;
+    if (options.logprefix == NULL)
+        options.logprefix = "drcov";
     if (options.native_until_thread > 0)
         go_native = true;
 

--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -92,6 +92,11 @@ typedef struct _drcovlib_options_t {
      */
     const char *logdir;
     /**
+     * By default, log file names are prefixed with "drcov".  This option overrides
+     * that default.
+     */
+    const char *logprefix;
+    /**
      * This is an experimental option for running natively (i.e., not under
      * DynamoRIO control) until the nth thread, where n is the value of this
      * option, is created.  This option only works under Windows.


### PR DESCRIPTION
## TL;DR

This PR adds an optional `-logprefix` command line toggle to the `drcov` tool. 

By default, `drcov` will prefix log files with 'drcov', eg `drcov.ls.57735.0000.proc.log`. The addition of this command line option allows users to change the prefix to a string of their choosing. This can be used to build a clear relationship between which invocation produced which log file.

## Problem Usecase

A growing number of DynamoRIO users have been integrating `drcov` into their fuzzing and instrumentation workflows. A common nuisance among these users is that there isn't a great way for a fuzz harness (or anything) that wraps `drcov` to specify an output filename for the coverage log.

As a result, it can be difficult to correlate which fuzzed input testcase generated which log after the fact with any certainty. 

```
doom@upwn64:~/projects/dynamorio/testing$ ../build/bin64/drrun -t drcov -- /bin/ls /what/the/fuzz
/bin/ls: cannot access '/what/the/fuzz': No such file or directory

doom@upwn64:~/projects/dynamorio/testing$ ../build/bin64/drrun -t drcov -- /bin/ls .
drcov.ls.57735.0000.proc.log  drcov.ls.57736.0000.proc.log

doom@upwn64:~/projects/dynamorio/testing$ ls -al
total 80
drwxrwxr-x  2 doom doom  4096 Apr  4 14:21 .
drwxrwxr-x 14 doom doom  4096 Apr  4 13:57 ..
-rw-rw----  1 doom doom 37465 Apr  4 14:21 drcov.ls.57735.0000.proc.log
-rw-rw----  1 doom doom 32505 Apr  4 14:21 drcov.ls.57736.0000.proc.log
```

Which log is which? Obviously, this becomes increasingly tedious when there are tens of thousands of executions / logs being generated simultaneously.

## Example Usage

The example below demonstrates the usage of the new `-logprefix`  option:

```
doom@upwn64:~/projects/dynamorio/testing$ ../build/bin64/drrun -t drcov -- /bin/ls
1.txt  2.txt  drcov.ls.57606.0000.proc.log

doom@upwn64:~/projects/dynamorio/testing$ ../build/bin64/drrun -t drcov -logprefix "testcase_123" -- /bin/ls
1.txt  2.txt  drcov.ls.57606.0000.proc.log  testcase_123.ls.57609.0000.proc.log

doom@upwn64:~/projects/dynamorio/testing$ ls -al
total 76
drwxrwxr-x  2 doom doom  4096 Apr  4 13:58 .
drwxrwxr-x 14 doom doom  4096 Apr  4 13:57 ..
-rw-rw-r--  1 doom doom     0 Apr  4 13:57 1.txt
-rw-rw-r--  1 doom doom     7 Apr  4 13:57 2.txt
-rw-rw----  1 doom doom 32041 Apr  4 13:58 drcov.ls.57606.0000.proc.log
-rw-rw----  1 doom doom 32201 Apr  4 13:58 testcase_123.ls.57609.0000.proc.log
```

## Additional Comments

Most users would prefer the ability to specify a static / known log filename. But being able to change the log file prefix seemed like a fair compromise and the path of least resistance for the existing codebase.

I am open to alternative solutions, but would like to see a change like this integrated in one form or another.