### PR TITLE
Make the xmm/mem operand of vinserti128 the correct size (16 bytes).

### DIFF
--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -5122,7 +5122,7 @@ const instr_info_t third_byte_3a[] = {
   /* BMI2 */
   {OP_rorx,  0xf23af018, "rorx",  Gy, xx, Ey, Ib, xx, mrm|vex|reqp, x, END_LIST},/*56*/
   /* AVX2 */
-  {OP_vinserti128,0x663a3818,"vinserti128",Vqq,xx,Hqq,Wqq,Ib,mrm|vex|reqp,x,END_LIST},/*57*/
+  {OP_vinserti128,0x663a3818,"vinserti128",Vqq,xx,Hqq,Wdq,Ib,mrm|vex|reqp,x,END_LIST},/*57*/
   {OP_vextracti128,0x663a3918,"vextracti128",Wdq,xx,Vqq,Ib,xx,mrm|vex|reqp,x,END_LIST},/*58*/
   {OP_vpermq, 0x663a0058, "vpermq", Vqq,xx,Wqq,Ib,xx,mrm|vex|reqp,x,END_LIST},/*59*/
   /* Following Intel and not marking as packed float vs ints: just "qq". */

--- a/suite/tests/api/ir_x86_4args.h
+++ b/suite/tests/api/ir_x86_4args.h
@@ -309,7 +309,7 @@ OPCODE(vmpsadbw_256, vmpsadbw, vmpsadbw, 0, REGARG(YMM0), REGARG(YMM1), MEMARG(O
        IMMARG(OPSZ_1))
 
 OPCODE(vinserti128, vinserti128, vinserti128, 0, REGARG(YMM0), REGARG(YMM1),
-       MEMARG(OPSZ_32), IMMARG(OPSZ_1))
+       MEMARG(OPSZ_16), IMMARG(OPSZ_1))
 OPCODE(vpblendd, vpblendd, vpblendd, 0, REGARG(XMM0), REGARG(XMM1), MEMARG(OPSZ_16),
        IMMARG(OPSZ_1))
 OPCODE(vpblendd_256, vpblendd, vpblendd, 0, REGARG(YMM0), REGARG(YMM1), MEMARG(OPSZ_32),


### PR DESCRIPTION
The memory operand of vinserti128 is, unsurprisingly, 128 bits wide.