### PR TITLE
i#3479: Move RUN_IN_RELEASE labeling to test lists.

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1459,6 +1459,18 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out)
     # global reg keys and can thus run multiple instances of the same
     # app name simultaneously so we do not need to mark RUN_SERIAL
   endif (WIN32)
+
+  # A subset of release tests has been added and labeled with RUN_IN_RELEASE. It focuses
+  # on Google's use of the drcachesim client. We do not want to extend the Travis
+  # regression time by too much and keep the following list concise.
+  # amhere
+  if (NOT DEBUG AND UNIX AND X64 AND NOT CMAKE_COMPILER_IS_CLANG)
+    if (${test} MATCHES "common" OR
+        ${test} MATCHES "drcachesim" OR
+        ${test} MATCHES "drcacheoff")
+      set_tests_properties(${test} PROPERTIES LABELS RUN_IN_RELEASE)
+    endif()
+  endif ()
   set(${added_out} ON PARENT_SCOPE)
 endfunction(torun)
 
@@ -3747,55 +3759,6 @@ foreach (run ${run_list})
 
   endif (enabled)
 endforeach(run)
-
-# A subset of release tests has been added and labeled with RUN_IN_RELEASE. It focuses on
-# Google's use of the drcachesim client. We do not want to extend the Travis regression
-# time by too much and keep the following list concise.
-if (NOT DEBUG AND UNIX AND X64 AND NOT CMAKE_COMPILER_IS_CLANG)
-  # XXX i#3479: We might want to add the label to individual tests above instead.
-  if (X86)
-    set_tests_properties(
-      code_api|tool.drcachesim.threads
-      code_api|tool.drcachesim.threads-with-config-file
-      code_api|tool.drcachesim.TLB-threads
-      code_api|tool.drcacheoff.basic_counts
-      code_api|tool.drcacheoff.burst_static
-      code_api|tool.drcacheoff.burst_replace
-      code_api|tool.drcacheoff.burst_replaceall
-      code_api|tool.drcacheoff.burst_noreach
-      code_api|tool.drcacheoff.burst_maps
-      code_api|tool.drcacheoff.burst_threads
-      code_api|tool.drcacheoff.burst_malloc
-      code_api|tool.drcacheoff.burst_threadfilter
-      code_api|tool.drcacheoff.burst_threadL0filter
-      code_api|tool.drcacheoff.burst_client
-      code_api|tool.drcacheoff.legacy
-      PROPERTIES LABELS RUN_IN_RELEASE)
-  endif (X86)
-  set_tests_properties(
-    samples_proj
-    code_api|common.${control_flags}
-    code_api|tool.drcachesim.simple
-    code_api|tool.drcachesim.simple-config-file
-    code_api|tool.drcachesim.TLB-simple
-    code_api|tool.drcachesim.missfile
-    code_api|tool.drcachesim.missfile-config-file
-    code_api|tool.drcachesim.phys
-    code_api|tool.drcachesim.filter-simple
-    code_api|tool.drcachesim.filter-no-i
-    code_api|tool.drcachesim.filter-no-d
-    code_api|tool.drcachesim.delay-simple
-    code_api|tool.drcachesim.warmup-valid
-    code_api|tool.drcachesim.warmup-zeros
-    code_api|tool.drcachesim.multiproc
-    code_api|tool.drcachesim.miss_analyzer
-    code_api|tool.drcacheoff.simple
-    code_api|tool.drcacheoff.multiproc
-    code_api|tool.drcacheoff.filter
-    code_api|tool.drcacheoff.opcode_mix
-    code_api|tool.drcacheoff.view
-    PROPERTIES LABELS RUN_IN_RELEASE)
-endif ()
 
 if (APPLE)
   # Enable just the quarter of the tests that pass, to get our test suite started

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1463,7 +1463,6 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out)
   # A subset of release tests has been added and labeled with RUN_IN_RELEASE. It focuses
   # on Google's use of the drcachesim client. We do not want to extend the Travis
   # regression time by too much and keep the following list concise.
-  # amhere
   if (NOT DEBUG AND UNIX AND X64 AND NOT CMAKE_COMPILER_IS_CLANG)
     if (${test} MATCHES "common" OR
         ${test} MATCHES "drcachesim" OR


### PR DESCRIPTION
Moves the assignment of RUN_IN_RELEASE label to the "torun" function in order to make
it independent from architecture and other flags. 'drcachesim', 'drcacheoff' and 'common'
tests have been added. This is a slight increase over the previous RUN_IN_RELEASE list,
as now all 'common' tests are part of this label.

Fixes #3479