### PR TITLE
i#3230 split traces: parallelize the histogram tool

### DIFF
--- a/clients/drcachesim/tools/histogram.cpp
+++ b/clients/drcachesim/tools/histogram.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -59,17 +59,69 @@ histogram_t::~histogram_t()
 }
 
 bool
-histogram_t::process_memref(const memref_t &memref)
+histogram_t::parallel_shard_supported()
 {
+    return true;
+}
+
+void *
+histogram_t::parallel_worker_init(int worker_index)
+{
+    return nullptr;
+}
+
+std::string
+histogram_t::parallel_worker_exit(void *worker_data)
+{
+    return "";
+}
+
+void *
+histogram_t::parallel_shard_init(int shard_index, void *worker_data)
+{
+    auto shard = new shard_data_t;
+    std::lock_guard<std::mutex> guard(shard_map_mutex);
+    shard_map[shard_index] = shard;
+    return reinterpret_cast<void *>(shard);
+}
+
+bool
+histogram_t::parallel_shard_exit(void *shard_data)
+{
+    // Nothing (we read the shard data in print_results).
+    return true;
+}
+
+bool
+histogram_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
+{
+    shard_data_t *shard = reinterpret_cast<shard_data_t *>(shard_data);
     if (type_is_instr(memref.instr.type) ||
         memref.instr.type == TRACE_TYPE_PREFETCH_INSTR)
-        ++icache_map[memref.instr.addr >> line_size_bits];
+        ++shard->icache_map[memref.instr.addr >> line_size_bits];
     else if (memref.data.type == TRACE_TYPE_READ ||
              memref.data.type == TRACE_TYPE_WRITE ||
              // We may potentially handle prefetches differently.
              // TRACE_TYPE_PREFETCH_INSTR is handled above.
              type_is_prefetch(memref.data.type))
-        ++dcache_map[memref.data.addr >> line_size_bits];
+        ++shard->dcache_map[memref.data.addr >> line_size_bits];
+    return true;
+}
+
+std::string
+histogram_t::parallel_shard_error(void *shard_data)
+{
+    shard_data_t *shard = reinterpret_cast<shard_data_t *>(shard_data);
+    return shard->error;
+}
+
+bool
+histogram_t::process_memref(const memref_t &memref)
+{
+    if (!parallel_shard_memref(reinterpret_cast<void *>(&serial_shard), memref)) {
+        error_string = serial_shard.error;
+        return false;
+    }
     return true;
 }
 
@@ -82,12 +134,25 @@ cmp(const std::pair<addr_t, uint64_t> &l, const std::pair<addr_t, uint64_t> &r)
 bool
 histogram_t::print_results()
 {
+    shard_data_t total;
+    if (shard_map.empty()) {
+        total = serial_shard;
+    } else {
+        for (const auto &shard : shard_map) {
+            for (const auto &keyvals : shard.second->icache_map) {
+                total.icache_map[keyvals.first] += keyvals.second;
+            }
+            for (const auto &keyvals : shard.second->dcache_map) {
+                total.dcache_map[keyvals.first] += keyvals.second;
+            }
+        }
+    }
     std::cerr << TOOL_NAME << " results:\n";
-    std::cerr << "icache: " << icache_map.size() << " unique cache lines\n";
-    std::cerr << "dcache: " << dcache_map.size() << " unique cache lines\n";
+    std::cerr << "icache: " << total.icache_map.size() << " unique cache lines\n";
+    std::cerr << "dcache: " << total.dcache_map.size() << " unique cache lines\n";
     std::vector<std::pair<addr_t, uint64_t>> top(knob_report_top);
-    std::partial_sort_copy(icache_map.begin(), icache_map.end(), top.begin(), top.end(),
-                           cmp);
+    std::partial_sort_copy(total.icache_map.begin(), total.icache_map.end(), top.begin(),
+                           top.end(), cmp);
     std::cerr << "icache top " << top.size() << "\n";
     for (std::vector<std::pair<addr_t, uint64_t>>::iterator it = top.begin();
          it != top.end(); ++it) {
@@ -96,8 +161,8 @@ histogram_t::print_results()
     }
     top.clear();
     top.resize(knob_report_top);
-    std::partial_sort_copy(dcache_map.begin(), dcache_map.end(), top.begin(), top.end(),
-                           cmp);
+    std::partial_sort_copy(total.dcache_map.begin(), total.dcache_map.end(), top.begin(),
+                           top.end(), cmp);
     std::cerr << "dcache top " << top.size() << "\n";
     for (std::vector<std::pair<addr_t, uint64_t>>::iterator it = top.begin();
          it != top.end(); ++it) {

--- a/clients/drcachesim/tools/histogram.h
+++ b/clients/drcachesim/tools/histogram.h
@@ -47,10 +47,10 @@ class histogram_t : public analysis_tool_t {
 public:
     histogram_t(unsigned int line_size, unsigned int report_top, unsigned int verbose);
     virtual ~histogram_t();
-    virtual bool
-    process_memref(const memref_t &memref);
-    virtual bool
-    print_results();
+    bool
+    process_memref(const memref_t &memref) override;
+    bool
+    print_results() override;
     bool
     parallel_shard_supported() override;
     void *

--- a/clients/drcachesim/tools/histogram.h
+++ b/clients/drcachesim/tools/histogram.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -36,8 +36,10 @@
 #ifndef _HISTOGRAM_H_
 #define _HISTOGRAM_H_ 1
 
-#include <unordered_map>
+#include <mutex>
 #include <string>
+#include <unordered_map>
+
 #include "analysis_tool.h"
 #include "memref.h"
 
@@ -49,15 +51,37 @@ public:
     process_memref(const memref_t &memref);
     virtual bool
     print_results();
+    bool
+    parallel_shard_supported() override;
+    void *
+    parallel_worker_init(int worker_index) override;
+    std::string
+    parallel_worker_exit(void *worker_data) override;
+    void *
+    parallel_shard_init(int shard_index, void *worker_data) override;
+    bool
+    parallel_shard_exit(void *shard_data) override;
+    bool
+    parallel_shard_memref(void *shard_data, const memref_t &memref) override;
+    std::string
+    parallel_shard_error(void *shard_data) override;
 
 protected:
-    std::unordered_map<addr_t, uint64_t> icache_map;
-    std::unordered_map<addr_t, uint64_t> dcache_map;
+    struct shard_data_t {
+        std::unordered_map<addr_t, uint64_t> icache_map;
+        std::unordered_map<addr_t, uint64_t> dcache_map;
+        std::string error;
+    };
 
     unsigned int knob_line_size;
     unsigned int knob_report_top; /* most accessed lines */
     size_t line_size_bits;
     static const std::string TOOL_NAME;
+    std::unordered_map<memref_tid_t, shard_data_t *> shard_map;
+    // This mutex is only needed in parallel_shard_init.  In all other accesses to
+    // shard_map (process_memref, print_results) we are single-threaded.
+    std::mutex shard_map_mutex;
+    shard_data_t serial_shard;
 };
 
 #endif /* _HISTOGRAM_H_ */


### PR DESCRIPTION
Adds parallel analysis support to the histogram tool.
I see a 4x speedup or so in small tests.

Issue: #3230