### PR TITLE
i#3230 split traces: fix histogram tool memory leak (#3521)

### DIFF
--- a/clients/drcachesim/tools/histogram.cpp
+++ b/clients/drcachesim/tools/histogram.cpp
@@ -56,6 +56,9 @@ histogram_t::histogram_t(unsigned int line_size, unsigned int report_top,
 
 histogram_t::~histogram_t()
 {
+    for (auto &iter : shard_map) {
+        delete iter.second;
+    }
 }
 
 bool


### PR DESCRIPTION
Fixes a memory leak in 64f09da's parallelization of the histogram tool.

Issue: #3230