### PR TITLE
i#3522 unix self-prot: Enable SELFPROT_GENCODE for UNIX and static

### DIFF
--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -4952,6 +4952,8 @@ void
 update_syscalls(dcontext_t *dcontext)
 {
     byte *pc;
+    generated_code_t *code = THREAD_GENCODE(dcontext);
+    protect_generated_code(code, WRITABLE);
     pc = get_do_syscall_entry(dcontext);
     update_syscall(dcontext, pc);
 #    ifdef X64
@@ -4962,6 +4964,7 @@ update_syscalls(dcontext_t *dcontext)
     pc = get_do_clone_syscall_entry(dcontext);
     update_syscall(dcontext, pc);
 #    endif
+    protect_generated_code(code, READONLY);
 }
 #endif /* !WINDOWS */
 

--- a/core/options.c
+++ b/core/options.c
@@ -1237,13 +1237,6 @@ check_option_compatibility_helper(int recurse_count)
      * warn of unfinished and untested self-protection options
      * FIXME: update once these features are complete
      */
-#    ifdef UNIX
-    if (dynamo_options.protect_mask != 0) {
-        USAGE_ERROR("selfprot not supported on unix: case 8023");
-        dynamo_options.protect_mask = 0;
-        changed_options = true;
-    }
-#    endif
 #    if defined(WINDOWS) && !defined(NOLIBC)
     if (TEST(SELFPROT_ANY_DATA_SECTION, dynamo_options.protect_mask)) {
         /* since libc routines are embedded in our dll and we run

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1013,10 +1013,11 @@ DYNAMIC_OPTION(bool, pause_via_loop,
 
     OPTION_DEFAULT(uint, max_trace_bbs, 128, "maximum number of basic blocks in a trace")
 
-    /* FIXME: case 8023 covers re-enabling on linux */
+    /* FIXME i#3522: re-enable SELFPROT_DATA_RARE on linux */
     OPTION_DEFAULT(uint, protect_mask,
-        IF_STATIC_LIBRARY_ELSE(0,
-            IF_WINDOWS_ELSE(0x101/*SELFPROT_DATA_RARE|SELFPROT_GENCODE*/, 0/*NYI*/)),
+        IF_STATIC_LIBRARY_ELSE(0x100/*SELFPROT_GENCODE*/,
+            IF_WINDOWS_ELSE(0x101/*SELFPROT_DATA_RARE|SELFPROT_GENCODE*/,
+                            0x100/*SELFPROT_GENCODE*/)),
         "which memory regions to protect")
     OPTION_INTERNAL(bool, single_privileged_thread, "suspend all other threads when one is out of cache")
 

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4440,8 +4440,11 @@ set_protection(byte *pc, size_t length, uint prot /*MEMPROT_*/)
 bool
 change_protection(byte *pc, size_t length, bool writable)
 {
-    uint flags = (writable) ? (MEMPROT_READ | MEMPROT_WRITE) : (MEMPROT_READ);
-    return set_protection(pc, length, flags);
+    if (writable)
+        return make_writable(pc, length);
+    else
+        make_unwritable(pc, length);
+    return true;
 }
 
 /* make pc's page writable */


### PR DESCRIPTION
Enables SELFPROT_GENCODE as the default -protect_mask for UNIX and for
STATIC_LIBRARY.

Fixes two problems that were blocking that:
+ Adds temporary unprotection for update_syscalls().
+ Fixes change_protection() to preserve +x (by delegating to make_{un,}writable()).

Issue: #3522