### PR TITLE
i#3485: Cut down the runtime of the test tool.drcachesim.miss_analyzer

### DIFF
--- a/clients/drcachesim/tests/stride_benchmark.cpp
+++ b/clients/drcachesim/tests/stride_benchmark.cpp
@@ -60,10 +60,9 @@ main(int argc, const char *argv[])
     // Number of cache lines skipped by the stream every iteration.
     const int kStride = 7;
     // Number of 1-byte elements in the array.
-    // (200+ MiB to guarantee the array doesn't fit in Skylake caches)
-    const size_t kArraySize = 64 * 1024 * 1024;
+    const size_t kArraySize = 16 * 1024 * 1024;
     // Number of iterations in the main loop.
-    const int kIterations = 100000;
+    const int kIterations = 20000;
     // The main vector/array used for emulating pointer chasing.
     unsigned char *buffer = new unsigned char[kArraySize];
     memset(buffer, kStride, kArraySize);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2661,7 +2661,8 @@ endif ()
       if (UNIX)
         add_exe(stride_benchmark
           ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/stride_benchmark.cpp)
-        torunonly_drcachesim(miss_analyzer stride_benchmark "-simulator_type miss_analyzer" "")
+        torunonly_drcachesim(miss_analyzer stride_benchmark
+          "-simulator_type miss_analyzer -miss_count_threshold 5000 -miss_frac_threshold 0.25" "")
       endif ()
 
       # Test other analysis tools


### PR DESCRIPTION
Cut down the runtime of the test tool.drcachesim.miss_analyzer by reducing the array size and number of iterations in the main loop.