### PR TITLE
i#3526: Apply scheme of i#2089 to client threads.

### DIFF
--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -1586,8 +1586,6 @@ GLOBAL_LABEL(dynamorio_clone:)
 # endif
         cmp      REG_XAX, 0
         jne      dynamorio_clone_parent
-        /* avoid conflicts w/ parent's TLS by clearing our reg now */
-        mov      SEG_TLS, ax
         pop      REG_XCX
         call     REG_XCX
         /* shouldn't return */

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -3719,9 +3719,11 @@ dr_create_client_thread(void (*func)(void *param), void *arg)
 #        endif
     LOG(THREAD, LOG_ALL, 1, "dr_create_client_thread xsp=" PFX " dstack=" PFX "\n", xsp,
         get_clone_record_dstack(crec));
+    os_clone_pre(dcontext);
     thread_id_t newpid =
         dynamorio_clone(flags, xsp, NULL, IF_X86_ELSE(IF_X64_ELSE(NULL, &desc), NULL),
                         NULL, client_thread_run);
+    os_clone_post(dcontext);
     /* i#501 switch to app's tls before creating client thread */
     if (IF_CLIENT_INTERFACE_ELSE(INTERNAL_OPTION(private_loader), false))
         os_switch_lib_tls(dcontext, false /*to dr*/);


### PR DESCRIPTION
When creating client threads, we still attempted to invalidate the thread's TLS by writing
a null selector to its segment register. In 64-bit mode, this seemed to work most of the
time because presumably Intel and AMD are then zero'ing out the the hidden segment's
base. Intel doesn't precisely describe this in Vol. 3A 3.4.4.

This patch applies the same scheme introduced and described in #2089.

Before this patch, the test code_api|client.thread ran into all kinds of assertions,
because the client thread interfered with the parent's TLS. These failures are now gone.

Fixes #3526
Issue: #2089