### PR TITLE
i#1132 split vmcode: Remove +x from TLS memory

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -487,7 +487,8 @@ static void shared_gencode_init(IF_X86_64_ELSE(gencode_mode_t gencode_mode, void
 #endif
 
     gencode =
-        heap_mmap_reserve(GENCODE_RESERVE_SIZE, GENCODE_COMMIT_SIZE, VMM_SPECIAL_MMAP);
+        heap_mmap_reserve(GENCODE_RESERVE_SIZE, GENCODE_COMMIT_SIZE,
+                          MEMPROT_EXEC | MEMPROT_READ | MEMPROT_WRITE, VMM_SPECIAL_MMAP);
     /* we would return gencode and let caller assign, but emit routines
      * that this routine calls query the shared vars so we set here
      */
@@ -1164,8 +1165,9 @@ arch_thread_init(dcontext_t *dcontext)
      */
     ASSERT(GENCODE_COMMIT_SIZE < GENCODE_RESERVE_SIZE);
     /* case 9474; share allocation unit w/ thread-private stack */
-    code = heap_mmap_reserve_post_stack(dcontext, GENCODE_RESERVE_SIZE,
-                                        GENCODE_COMMIT_SIZE, VMM_SPECIAL_MMAP);
+    code = heap_mmap_reserve_post_stack(
+        dcontext, GENCODE_RESERVE_SIZE, GENCODE_COMMIT_SIZE,
+        MEMPROT_EXEC | MEMPROT_READ | MEMPROT_WRITE, VMM_SPECIAL_MMAP);
     ASSERT(code != NULL);
     /* FIXME case 6493: if we split private from shared, remove this
      * memset since we will no longer have a bunch of fields we don't use

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -1380,7 +1380,9 @@ fcache_create_unit(dcontext_t *dcontext, fcache_t *cache, cache_pc pc, size_t si
              */
             if (commit_size > size)
                 commit_size = size;
-            u->start_pc = (cache_pc)heap_mmap_reserve(size, commit_size, VMM_CACHE);
+            u->start_pc = (cache_pc)heap_mmap_reserve(
+                size, commit_size, MEMPROT_EXEC | MEMPROT_READ | MEMPROT_WRITE,
+                VMM_CACHE);
         }
         ASSERT(u->start_pc != NULL);
         ASSERT(proc_is_cache_aligned((void *)u->start_pc));
@@ -2024,7 +2026,9 @@ fcache_increase_size(dcontext_t *dcontext, fcache_t *cache, fcache_unit_t *unit,
         ASSERT(commit_size >= slot_size);
         commit_size += unit->size;
         ASSERT(commit_size <= new_size);
-        new_memory = (cache_pc)heap_mmap_reserve(new_size, commit_size, VMM_CACHE);
+        new_memory = (cache_pc)heap_mmap_reserve(
+            new_size, commit_size, MEMPROT_EXEC | MEMPROT_READ | MEMPROT_WRITE,
+            VMM_CACHE);
         STATS_FCACHE_SUB(cache, capacity, unit->size);
         STATS_FCACHE_ADD(cache, capacity, commit_size);
         STATS_FCACHE_MAX(cache, capacity_peak, capacity);

--- a/core/heap.h
+++ b/core/heap.h
@@ -175,13 +175,13 @@ global_heap_realloc(void *ptr, size_t old_num, size_t new_num,
 bool
 lockwise_safe_to_allocate_memory(void);
 
-/* use heap_mmap to allocate large chunks of executable memory */
+/* use heap_mmap* to allocate large chunks of memory */
 void *
-heap_mmap(size_t size, which_vmm_t which);
+heap_mmap(size_t size, uint prot, which_vmm_t which);
 void
 heap_munmap(void *p, size_t size, which_vmm_t which);
 void *
-heap_mmap_reserve(size_t reserve_size, size_t commit_size, which_vmm_t which);
+heap_mmap_reserve(size_t reserve_size, size_t commit_size, uint prot, which_vmm_t which);
 
 void *
 heap_mmap_ex(size_t reserve_size, size_t commit_size, uint prot, bool guarded,
@@ -201,7 +201,7 @@ d_r_unmap_file(byte *map, size_t size);
  */
 void *
 heap_mmap_reserve_post_stack(dcontext_t *dcontext, size_t reserve_size,
-                             size_t commit_size, which_vmm_t which);
+                             size_t commit_size, uint prot, which_vmm_t which);
 void
 heap_munmap_post_stack(dcontext_t *dcontext, void *p, size_t reserve_size,
                        which_vmm_t which);

--- a/core/perscache.c
+++ b/core/perscache.c
@@ -729,7 +729,8 @@ coarse_unit_freeze(dcontext_t *dcontext, coarse_info_t *info, bool in_place)
     /* we need the stubs to start on a new page since will be +rw vs cache +r */
     frozen_cache_size = ALIGN_FORWARD(frozen_cache_size, PAGE_SIZE);
     freeze_info->cache_start_pc =
-        (cache_pc)heap_mmap(frozen_stub_size + frozen_cache_size, VMM_CACHE);
+        (cache_pc)heap_mmap(frozen_stub_size + frozen_cache_size,
+                            MEMPROT_EXEC | MEMPROT_READ | MEMPROT_WRITE, VMM_CACHE);
     /* FIXME: should show full non-frozen size as well */
     LOG(THREAD, LOG_CACHE, 2,
         "%d frozen stubs @ " SZFMT " bytes + %d fragments @ " SZFMT " bytes => " PFX "\n",
@@ -1894,7 +1895,8 @@ coarse_unit_merge(dcontext_t *dcontext, coarse_info_t *info1, coarse_info_t *inf
     merged->mmap_size = merged_cache_size + stubs1_size + stubs2_size;
     /* Our relative jmps require that we do not exceed 32-bit reachability */
     IF_X64(ASSERT(CHECK_TRUNCATE_TYPE_int(merged->mmap_size)));
-    merged->cache_start_pc = (cache_pc)heap_mmap(merged->mmap_size, VMM_CACHE);
+    merged->cache_start_pc = (cache_pc)heap_mmap(
+        merged->mmap_size, MEMPROT_EXEC | MEMPROT_READ | MEMPROT_WRITE, VMM_CACHE);
     merged->cache_end_pc = merged->cache_start_pc + cache1_size + cache2_size;
     merged->stubs_start_pc = coarse_stubs_create(
         merged, merged->cache_start_pc + merged_cache_size, stubs1_size + stubs2_size);
@@ -1989,7 +1991,8 @@ coarse_unit_merge(dcontext_t *dcontext, coarse_info_t *info1, coarse_info_t *inf
         size_t stubsz = merged->stubs_end_pc - merged->fcache_return_prefix;
         size_t newsz = cachesz_aligned + stubsz;
         size_t old_mapsz = merged->mmap_size;
-        cache_pc newmap = (cache_pc)heap_mmap(newsz, VMM_CACHE);
+        cache_pc newmap = (cache_pc)heap_mmap(
+            newsz, MEMPROT_EXEC | MEMPROT_READ | MEMPROT_WRITE, VMM_CACHE);
         ssize_t cache_shift = merged->cache_start_pc - newmap;
         /* stubs have moved too, so a relative shift not absolute */
         ssize_t stubs_shift =

--- a/core/unix/loader_android.c
+++ b/core/unix/loader_android.c
@@ -183,7 +183,7 @@ privload_tls_init(void *app_tls)
         }
     } else {
         res = heap_mmap(ALIGN_FORWARD(size_of_pthread_internal(), PAGE_SIZE),
-                        VMM_SPECIAL_MMAP);
+                        MEMPROT_READ | MEMPROT_WRITE, VMM_SPECIAL_MMAP);
         LOG(GLOBAL, LOG_LOADER, 2,
             "%s: allocated new TLS at " PFX "; copying from " PFX "\n", __FUNCTION__, res,
             app_tls);

--- a/core/unix/loader_linux.c
+++ b/core/unix/loader_linux.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * *******************************************************************************/
 
@@ -311,7 +311,8 @@ privload_tls_init(void *app_tp)
     /* FIXME: These should be a thread logs, but dcontext is not ready yet. */
     LOG(GLOBAL, LOG_LOADER, 2, "%s: app TLS segment base is " PFX "\n", __FUNCTION__,
         app_tp);
-    dr_tp = heap_mmap(client_tls_alloc_size, VMM_SPECIAL_MMAP);
+    dr_tp =
+        heap_mmap(client_tls_alloc_size, MEMPROT_READ | MEMPROT_WRITE, VMM_SPECIAL_MMAP);
     ASSERT(APP_LIBC_TLS_SIZE + TLS_PRE_TCB_SIZE + tcb_size <= client_tls_alloc_size);
 #ifdef AARCHXX
     /* GDB reads some pthread members (e.g., pid, tid), so we must make sure

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -2021,8 +2021,7 @@ os_tls_init(void)
      * FIXME PR 205276: this whole scheme currently does not check if app is using
      * segments need to watch modify_ldt syscall
      */
-    /* FIXME: heap_mmap marks as exec, we just want RW */
-    byte *segment = heap_mmap(PAGE_SIZE, VMM_SPECIAL_MMAP);
+    byte *segment = heap_mmap(PAGE_SIZE, MEMPROT_READ | MEMPROT_WRITE, VMM_SPECIAL_MMAP);
     os_local_state_t *os_tls = (os_local_state_t *)segment;
 
     LOG(GLOBAL, LOG_THREADS, 1, "os_tls_init for thread " TIDFMT "\n",
@@ -5666,9 +5665,6 @@ handle_execve(dcontext_t *dcontext)
 #endif
 
     /* Issue 20: handle cross-architecture execve */
-    /* Xref alternate solution i#145: use dual paths on
-     * LD_LIBRARY_PATH to solve cross-arch execve
-     */
     file = os_open(fname, OS_OPEN_READ);
     if (file != INVALID_FILE) {
         if (!module_file_is_module64(file, &x64,

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -8086,7 +8086,9 @@ detach_handle_callbacks(int num_threads, thread_record_t **threads,
         /* FIXME - this should (along with any do/shared syscall containing gencode) be
          * allocated outside of our vmmheap so that we can free the vmmheap reservation
          * on detach. */
-        byte *callback_buf = (byte *)heap_mmap(callback_buf_size, VMM_SPECIAL_MMAP);
+        byte *callback_buf = (byte *)heap_mmap(
+            callback_buf_size, MEMPROT_EXEC | MEMPROT_READ | MEMPROT_WRITE,
+            VMM_SPECIAL_MMAP);
         detach_callback_stack_t *per_thread =
             (detach_callback_stack_t *)(callback_buf + DETACH_CALLBACK_CODE_SIZE);
         app_pc *callback_addrs = (app_pc *)(&per_thread[num_threads_with_callbacks]);


### PR DESCRIPTION
Changes the heap_mmap(), heap_mmap_reserve(), and
heap_mmap_reserve_post_stack() functions to take in the protection
bits to use, instead of hardcoding +rwx.

Removes the +x from several mmaps used for TLS segments.

Issue: #1132