### PR TITLE
i#3351 snappy: Use snappy reader for serial tools.

### DIFF
--- a/clients/drcachesim/reader/snappy_file_reader.cpp
+++ b/clients/drcachesim/reader/snappy_file_reader.cpp
@@ -225,6 +225,7 @@ file_reader_t<snappy_reader_t>::open_single_file(const std::string &path)
     std::ifstream *file = new std::ifstream(path, std::ifstream::binary);
     if (!*file)
         return false;
+    VPRINT(this, 1, "Opened snappy input file %s\n", path.c_str());
     input_files.emplace_back(file);
     return true;
 }

--- a/clients/drcachesim/tests/offline-snappy-serial.templatex
+++ b/clients/drcachesim/tests/offline-snappy-serial.templatex
@@ -1,0 +1,5 @@
+Cache simulation results:
+.*
+LL stats:
+    Hits:                           58,699
+.*

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2790,8 +2790,14 @@ endif ()
 
       # Test reading a trace in sharded snappy-compressed files.
       if (libsnappy)
+        # with a parallel tool (basic_counts)
         torunonly_api(tool.drcacheoff.snappy "${drcachesim_path}" "offline-snappy.c" ""
           "-indir;${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.chase-snappy.x64.tracedir;-simulator_type;basic_counts"
+          OFF)
+
+        # with a legacy serial tool (full simulator)
+        torunonly_api(tool.drcacheoff.snappy "${drcachesim_path}" "offline-snappy-serial.c" ""
+          "-indir;${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.chase-snappy.x64.tracedir"
           OFF)
         set(tool.drcacheoff.snappy_basedir
           "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")


### PR DESCRIPTION
When using -indir and a serial tool, check if the trace directory has
.sz files. If so, use snappy_reader_t to read them.

This wasn't an issue for the gzip reader, because we default to using it
without looking at file names.

TESTED: added a test.
Fixes #3351