### PR TITLE
i#1132 split vmcode: Fix Mac build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,9 +92,6 @@ jobs:
       compiler: clang
       # We do not have 64-bit support on OSX yet (i#1979).
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=32_only
-      # XXX i#2764: Travis OSX resources are over-subscribed and it can take
-      # hours to get an OSX machine, so we skip running PR's for now.
-      if: type = push
 
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -8867,12 +8867,14 @@ found_vsyscall_page(memquery_iter_t *iter _IF_DEBUG(OUT const char **map_type))
 #endif
 }
 
+#ifndef HAVE_MEMINFO_QUERY
 static void
 add_to_memcache(byte *region_start, byte *region_end, void *user_data)
 {
     memcache_update_locked(region_start, region_end, MEMPROT_NONE, DR_MEMTYPE_DATA,
                            false /*!exists*/);
 }
+#endif
 
 int
 os_walk_address_space(memquery_iter_t *iter, bool add_modules)


### PR DESCRIPTION
Fixes a Mac build caused by 99fd6ce.
Enables Mac builds on pull requests.

Issue: #1132, #2764