### PR TITLE
i#3563: Drop support for IA32_ON_IA64.

### DIFF
--- a/core/arch/proc.h
+++ b/core/arch/proc.h
@@ -102,12 +102,6 @@ enum {
  *   Intel IvyBridge           Family 6, Model 58 (0x3a)
  *   Intel Atom                Family 6, Model 28 (0x1c), 38 (0x26), 54 (0x36)
  */
-/* DR_API EXPORT END */
-#ifdef IA32_ON_IA64 /* don't export IA64 stuff! */
-/* IA-64 */
-#    define FAMILY_IA64 7
-#endif
-/* DR_API EXPORT BEGIN */
 /* Remember that we add extended family to family as Intel suggests */
 #define FAMILY_LLANO 18        /**< proc_get_family() processor family: AMD Llano */
 #define FAMILY_ITANIUM_2_DC 17 /**< proc_get_family() processor family: Itanium 2 DC */

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -405,13 +405,6 @@ read_operand(byte *pc, decode_info_t *di, byte optype, opnd_size_t opsize)
     switch (optype) {
     case TYPE_A: {
         CLIENT_ASSERT(!X64_MODE(di), "x64 has no type A instructions");
-#ifdef IA32_ON_IA64
-        /* somewhat hacked dispatch on size */
-        if (opsize == OPSZ_4_short2) {
-            pc = read_immed(pc, di, opsize, &val);
-            break;
-        }
-#endif
         /* ok b/c only instr_info_t fields passed */
         CLIENT_ASSERT(opsize == OPSZ_6_irex10_short4, "decode A operand error");
         if (TEST(PREFIX_DATA, di->prefixes)) {
@@ -1675,18 +1668,6 @@ decode_operand(decode_info_t *di, byte optype, opnd_size_t opsize, opnd_t *opnd)
         *opnd = opnd_create_pc((app_pc)get_immed(di, opsize));
         return true;
     case TYPE_A: {
-#ifdef IA32_ON_IA64
-        if (opsize == OPSZ_4_short2) {
-            if (di->seg_override == SEG_CS || di->seg_override == SEG_DS) {
-                /* branch hint! just delete it? FIXME! */
-                di->seg_override = REG_NULL;
-                ASSERT_CURIOSITY(false); /* see if this ever happens */
-            }
-            /* just ignore other segment prefixes -- don't assert */
-            *opnd = opnd_create_pc((app_pc)get_immed(di, opsize));
-            return true;
-        }
-#endif
         /* ok since instr_info_t fields */
         CLIENT_ASSERT(!X64_MODE(di), "x64 has no type A instructions");
         CLIENT_ASSERT(opsize == OPSZ_6_irex10_short4, "decode A operand error");

--- a/core/arch/x86/decode_fast.c
+++ b/core/arch/x86/decode_fast.c
@@ -283,15 +283,17 @@ static const byte variable_length[256] = {
 /* Data table for the additional fixed part of a two-byte opcode.
  * This table is indexed by the 2nd opcode byte.  Zero entries are
  * reserved/bad opcodes.
- * N.B.: none of these (except IA32_ON_IA64) need adjustment
- * for data16 or addr16.
+ * N.B.: none of these need adjustment for data16 or addr16.
+ *
+ * 0f0f has extra suffix opcode byte
+ * 0f78 has immeds depending on prefixes: handled in decode_sizeof()
  */
 static const byte escape_fixed_length[256] = {
-    1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 2,
-    /* 0 */ /* 0f0f has extra suffix opcode byte */
+    1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 2, /* 0 */
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 1 */
     1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, /* 2 */
     1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, /* 3 */
+
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 4 */
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 5 */
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 6 */
@@ -300,20 +302,12 @@ static const byte escape_fixed_length[256] = {
     5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, /* 8 */
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 9 */
     1, 1, 1, 1, 2, 1, 0, 0, 1, 1, 1, 1, 2, 1, 1, 1, /* A */
-#ifdef IA32_ON_IA64
-    /* change is the 5, could also be 3 depending on which mode we are */
-    /* FIXME : no modrm byte so the standard variable thing won't work */
-    /* (need a escape_disp_adjustment table) */
-    1, 1, 1, 1, 1, 1, 1, 1, 5, 1, 2, 1, 1, 1, 1, 1, /* B */
-#else
-    1,1,1,1, 1,1,1,1, 1,1,2,1, 1,1,1,1,  /* B */
-#endif
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, /* B */
 
     1, 1, 2, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* C */
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* D */
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* E */
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0  /* F */
-    /* 0f78 has immeds depending on prefixes: handled in decode_sizeof() */
 };
 
 /* Some macros to make the following table look better. */
@@ -338,11 +332,8 @@ static const byte escape_variable_length[256] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0,  0, 0, 0, 0, 0, /* 8 */
     m, m, m, m, m, m, m, m, m,  m, m,  m, m, m, m, m, /* 9 */
     0, 0, 0, m, m, m, 0, 0, 0,  0, 0,  m, m, m, m, m, /* A */
-#ifdef IA32_ON_IA64
-    m, m, m, m, m, m, m, m, 0,  0, m,  m, m, m, m, m, /* B */
-#else
     m, m, m, m, m, m, m, m, m,  0, m,  m, m, m, m, m, /* B */
-#endif
+
     m, m, m, m, m, m, m, m, 0,  0, 0,  0, 0, 0, 0, 0, /* C */
     m, m, m, m, m, m, m, m, m,  m, m,  m, m, m, m, m, /* D */
     m, m, m, m, m, m, m, m, m,  m, m,  m, m, m, m, m, /* E */

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1273,12 +1273,6 @@ const instr_info_t * const op_instr[] =
     /* Intel ADX */
     /* OP_adox          */   &prefix_extensions[143][1],
     /* OP_adcx          */   &prefix_extensions[143][2],
-
-    /* Keep these at the end so that ifdefs don't change internal enum values */
-#ifdef IA32_ON_IA64
-    /* OP_jmpe      */   &base_extensions[13][6],
-    /* OP_jmpe_abs  */   &second_byte[0xb8],
-#endif
 };
 
 
@@ -1462,10 +1456,6 @@ const instr_info_t * const op_instr[] =
 #define c1  TYPE_1, OPSZ_0
 /* we pick the right constant based on the opcode */
 #define cF  TYPE_FLOATCONST, OPSZ_0
-
-#ifdef IA32_ON_IA64
-# define Av TYPE_A, OPSZ_4_short2
-#endif
 
 /* registers that are base 32 but vary down or up */
 #define eAX TYPE_VAR_REG, REG_EAX
@@ -2199,16 +2189,7 @@ const instr_info_t second_byte[] = {
   {OP_movzx, 0x0fb610, "movzx", Gv, xx, Eb, xx, xx, mrm, x, END_LIST},
   {OP_movzx, 0x0fb710, "movzx", Gv, xx, Ew, xx, xx, mrm, x, tsb[0xb6]},
   /* b8 */
-#ifdef IA32_ON_IA64
-  /* FIXME : unsure about this encoding */
-  /* had to define type Av for this to work, see decode.c/above etc.  */
-  /* is jump to absolute pc address, not realitve like all other jumps */
-  /* is like the pointer type except no segement change, no modrm byte */
-  /* should be 0x0fb800? no! 01 signals to encoder is 2 byte instruction */
-  {OP_jmpe_abs,  0x0fb810, "jmpe", xx, xx, Av, xx, xx, no, x, END_LIST},
-#else
-  {OP_popcnt,0xf30fb810, "popcnt", Gv, xx, Ev, xx, xx, mrm|reqp, fW6, END_LIST},
-#endif
+  {OP_popcnt, 0xf30fb810, "popcnt", Gv, xx, Ev, xx, xx, mrm|reqp, fW6, END_LIST},
   /* This is Group 10, but all identical (ud2b) so no reason to split opcode by /reg */
   {OP_ud2b, 0x0fb910, "ud2b", xx, xx, xx, xx, xx, no, x, END_LIST},
   {EXTENSION, 0x0fba10, "(group 8)", xx, xx, xx, xx, xx, mrm, x, 15},
@@ -2457,11 +2438,7 @@ const instr_info_t base_extensions[][8] = {
     {OP_ltr,  0x0f0033, "ltr", xx, xx, Ew, xx, xx, mrm, x, END_LIST},
     {OP_verr, 0x0f0034, "verr", xx, xx, Ew, xx, xx, mrm, fWZ, END_LIST},
     {OP_verw, 0x0f0035, "verw", xx, xx, Ew, xx, xx, mrm, fWZ, END_LIST},
-#ifdef IA32_ON_IA64
-    {OP_jmpe, 0x0f0036, "jmpe", xx, xx, i_Ev, xx, xx, mrm, x, END_LIST},
-#else
     {INVALID, 0x0f0036, "(bad)",xx, xx, xx, xx, xx, no, x, NA},
-#endif
     {INVALID, 0x0f0037, "(bad)",xx, xx, xx, xx, xx, no, x, NA},
  },
   /* group 7 (first bytes 0f 01) */

--- a/core/arch/x86/encode.c
+++ b/core/arch/x86/encode.c
@@ -1065,13 +1065,6 @@ opnd_type_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, opn
         return (opnd_is_near_pc(opnd) || opnd_is_near_instr(opnd));
     case TYPE_A: {
         CLIENT_ASSERT(!X64_MODE(di), "x64 has no type A instructions");
-#ifdef IA32_ON_IA64
-        if (opsize != OPSZ_6_irex10_short4) {
-            return (opnd_is_near_instr(opnd) ||
-                    (opnd_is_near_pc(opnd) &&
-                     immed_size_ok(di, (uint)opnd_get_pc(opnd), opsize)));
-        }
-#endif
         return (opnd_is_far_pc(opnd) || opnd_is_far_instr(opnd));
     }
     case TYPE_O:
@@ -1919,27 +1912,6 @@ encode_operand(decode_info_t *di, int optype, opnd_size_t opsize, opnd_t opnd)
     }
     case TYPE_A: {
         ptr_uint_t target;
-
-#ifdef IA32_ON_IA64
-        if (opsize == OPSZ_4_short2) {
-            if (opnd_is_near_instr(opnd)) {
-                /* assume the note fields have been set with relative offsets
-                 * from some start pc
-                 */
-                instr_t *target_instr = opnd_get_instr(opnd);
-                target = (ptr_uint_t)target_instr->note;
-                /* target is absolute address of instr ready to go */
-                set_immed(di, target, opsize);
-                di->has_instr_opnds = true;
-            } else {
-                CLIENT_ASSERT(opnd_is_near_pc(opnd), "encode error: opnd not pc");
-                target = (ptr_uint_t)opnd_get_pc(opnd);
-                set_immed(di, target, opsize);
-            }
-            return;
-        }
-#endif
-
         CLIENT_ASSERT(!X64_MODE(di), "x64 has no type A instructions");
         CLIENT_ASSERT(opsize == OPSZ_6_irex10_short4 || opsize == OPSZ_6 ||
                           opsize == OPSZ_4 ||

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -685,12 +685,6 @@
  */
 #define INSTR_CREATE_int(dc, i) instr_create_0dst_1src((dc), OP_int, (i))
 
-#ifdef IA32_ON_IA64
-/* DR_API EXPORT BEGIN */
-#    define INSTR_CREATE_jmpe(dc, t) instr_create_0dst_1src((dc), OP_jmpe, (t))
-#    define INSTR_CREATE_jmpe_abs(dc, t) instr_create_0dst_1src((dc), OP_jmpe_abs, (t))
-#endif
-
 /* floating-point */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1266,21 +1266,10 @@ enum {
     /* 1105 */ OP_adox, /**< IA-32/AMD64 adox opcode. */
     /* 1106 */ OP_adcx, /**< IA-32/AMD64 adox opcode. */
 
-/* Keep these at the end so that ifdefs don't change internal enum values */
-#ifdef IA32_ON_IA64
-    /* 1107 */ OP_jmpe,     /**< IA-32/AMD64 jmpe opcode. */
-    /* 1108 */ OP_jmpe_abs, /**< IA-32/AMD64 jmpe_abs opcode. */
-#endif
-
     OP_AFTER_LAST,
     OP_FIRST = OP_add,           /**< First real opcode. */
     OP_LAST = OP_AFTER_LAST - 1, /**< Last real opcode. */
 };
-
-#ifdef IA32_ON_IA64
-/* redefine instead of if else so works with genapi.pl script */
-#    define OP_LAST OP_jmpe_abs
-#endif
 
 /* alternative names */
 /* we do not equate the fwait+op opcodes

--- a/core/arch/x86/proc.c
+++ b/core/arch/x86/proc.c
@@ -277,11 +277,6 @@ get_processor_specific_info(void)
     } else if (cpu_info.vendor == VENDOR_AMD && cpu_info.family == FAMILY_ATHLON) {
         /* Athlon */
         cache_line_size = 64;
-#ifdef IA32_ON_IA64
-    } else if (cpu_info.vendor == VENDOR_INTEL && cpu_info.family == FAMILY_IA64) {
-        /* Itanium */
-        cache_line_size = 32;
-#endif
     } else {
         LOG(GLOBAL, LOG_TOP, 1, "Warning: running on unsupported processor family %d\n",
             cpu_info.family);

--- a/core/options.c
+++ b/core/options.c
@@ -1305,13 +1305,6 @@ check_option_compatibility_helper(int recurse_count)
         changed_options = true;
     }
 #    endif
-#    ifdef IA32_ON_IA64
-    if (dynamo_options.protect_mask != 0) {
-        USAGE_ERROR("IA32_ON_IA64 incompatible with self-protection at this time");
-        dynamo_options.protect_mask = 0;
-        changed_options = true;
-    }
-#    endif
     /****************************************************************************/
 
 #    if defined(PROFILE_RDTSC) && defined(SIDELINE)

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -2881,9 +2881,6 @@ OPTION_DEFAULT(bool, pad_jmps_mark_no_trace, false,
     OPTION(uint, aggressiveness, "level of aggressiveness in optimizations")
 #    endif
 
-#    ifdef IA32_ON_IA64
-    OPTIMIZE_OPTION(bool, test_ia64)
-#    endif
     OPTIMIZE_OPTION(bool, prefetch)
     OPTIMIZE_OPTION(bool, rlr)
     OPTIMIZE_OPTION(bool, vectorize)

--- a/core/unix/memquery_linux.c
+++ b/core/unix/memquery_linux.c
@@ -251,12 +251,7 @@ memquery_iterator_next(memquery_iter_t *iter)
     *mi->newline = '\0';
     LOG(GLOBAL, LOG_VMAREAS, 6, "\nget_memory_info_from_os: line=[%s]\n", line);
     mi->comment_buffer[0] = '\0';
-    len = sscanf(line,
-#ifdef IA32_ON_IA64
-                 MAPS_LINE_FORMAT8, /* cross-compiling! */
-#else
-                 sizeof(void *) == 4 ? MAPS_LINE_FORMAT4 : MAPS_LINE_FORMAT8,
-#endif
+    len = sscanf(line, sizeof(void *) == 4 ? MAPS_LINE_FORMAT4 : MAPS_LINE_FORMAT8,
                  (unsigned long *)&iter->vm_start, (unsigned long *)&iter->vm_end, perm,
                  (unsigned long *)&iter->offset, &iter->inode, mi->comment_buffer);
     if (iter->vm_start == iter->vm_end) {

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4432,13 +4432,6 @@ os_set_protection(byte *pc, size_t length, uint prot /*MEMPROT_*/)
     uint num_bytes = ALIGN_FORWARD(length + (pc - start_page), PAGE_SIZE);
     long res = 0;
     uint flags = memprot_to_osprot(prot);
-#ifdef IA32_ON_IA64
-    LOG(THREAD_GET, LOG_VMAREAS, 1, "protection change not supported on IA64\n");
-    LOG(THREAD_GET, LOG_VMAREAS, 1,
-        " attempted change_prot(" PFX ", " PIFX ", %s) => "
-        "mprotect(" PFX ", " PIFX ")==%d pages\n",
-        pc, length, memprot_string(prot), start_page, num_bytes, num_bytes / PAGE_SIZE);
-#else
     DOSTATS({
         /* once on each side of prot, to get on right side of writability */
         if (!TEST(PROT_WRITE, flags)) {
@@ -4454,7 +4447,6 @@ os_set_protection(byte *pc, size_t length, uint prot /*MEMPROT_*/)
         "mprotect(" PFX ", " PIFX ", %d)==%d pages\n",
         pc, length, memprot_string(prot), start_page, num_bytes, flags,
         num_bytes / PAGE_SIZE);
-#endif
     DOSTATS({
         /* once on each side of prot, to get on right side of writability */
         if (TEST(PROT_WRITE, flags)) {
@@ -4516,19 +4508,12 @@ make_writable(byte *pc, size_t size)
         prot |= PROT_WRITE;
 
     ASSERT(start_page == pc && ALIGN_FORWARD(size, PAGE_SIZE) == size);
-#ifdef IA32_ON_IA64
-    LOG(THREAD_GET, LOG_VMAREAS, 1, "protection change not supported on IA64\n");
-    LOG(THREAD_GET, LOG_VMAREAS, 3,
-        "attempted make_writable: pc " PFX " -> " PFX "-" PFX "\n", pc, start_page,
-        start_page + prot_size);
-#else
     res = mprotect_syscall((void *)start_page, prot_size, prot);
     LOG(THREAD_GET, LOG_VMAREAS, 3, "make_writable: pc " PFX " -> " PFX "-" PFX " %d\n",
         pc, start_page, start_page + prot_size, res);
     ASSERT(res == 0);
     if (res != 0)
         return false;
-#endif
     STATS_INC(protection_change_calls);
     STATS_ADD(protection_change_pages, size / PAGE_SIZE);
 
@@ -4577,25 +4562,18 @@ make_unwritable(byte *pc, size_t size)
     /* inc stats before making unwritable, in case messing w/ data segment */
     STATS_INC(protection_change_calls);
     STATS_ADD(protection_change_pages, size / PAGE_SIZE);
-#ifdef IA32_ON_IA64
-    LOG(THREAD_GET, LOG_VMAREAS, 1, "protection change not supported on IA64\n");
-    LOG(THREAD_GET, LOG_VMAREAS, 3,
-        "attempted make_writable: pc " PFX " -> " PFX "-" PFX "\n", pc, start_page,
-        start_page + prot_size);
-#else
     res = mprotect_syscall((void *)start_page, prot_size, prot);
     LOG(THREAD_GET, LOG_VMAREAS, 3, "make_unwritable: pc " PFX " -> " PFX "-" PFX "\n",
         pc, start_page, start_page + prot_size);
     ASSERT(res == 0);
 
-#    ifndef HAVE_MEMINFO_QUERY
+#ifndef HAVE_MEMINFO_QUERY
     /* update all_memory_areas list with the protection change */
     if (memcache_initialized()) {
         memcache_update_locked(start_page, start_page + prot_size,
                                osprot_to_memprot(prot), -1 /*type unchanged*/,
                                false /*!exists*/);
     }
-#    endif
 #endif
 }
 

--- a/make/configure.cmake.h
+++ b/make/configure.cmake.h
@@ -225,9 +225,6 @@
 #    $(D)X86
 #    $(D)X64
 
-# support for running in x86 emulator on IA-64
-#    $(D)IA32_ON_IA64
-
 # build script provides these
 #    $(D)BUILD_NUMBER (<64K == vmware's PRODUCT_BUILD_NUMBER)
 #    $(D)UNIQUE_BUILD_NUMBER (== vmware's BUILD_NUMBER)


### PR DESCRIPTION
Removes all old stale code for x86 emulation on Itanium which has not been touched in 10+ years and is unlikely to ever be used again.

Fixes #3563