### PR TITLE
i#3567: Restore check for 8-bit register enum size.

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -650,6 +650,11 @@ d_r_arch_init(void)
 {
     ASSERT(sizeof(opnd_t) == EXPECTED_SIZEOF_OPND);
     IF_X86(ASSERT(CHECK_TRUNCATE_TYPE_byte(OPSZ_LAST)));
+    /* This ensures that DR_REG_ enums that may be used as opnd_size_t fit its size.
+     * Only DR_REG_ enums covered by types listed in template_optype_is_reg can fall
+     * into this category.
+     */
+    IF_X86(ASSERT(CHECK_TRUNCATE_TYPE_byte(DR_REG_INVALID)));
     /* ensure our flag sharing is done properly */
     ASSERT((uint)LINK_FINAL_INSTR_SHARED_FLAG < (uint)INSTR_FIRST_NON_LINK_SHARED_FLAG);
     ASSERT_TRUNCATE(byte, byte, OPSZ_LAST_ENUM);

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -654,7 +654,7 @@ d_r_arch_init(void)
      * Only DR_REG_ enums covered by types listed in template_optype_is_reg can fall
      * into this category.
      */
-    IF_X86(ASSERT(CHECK_TRUNCATE_TYPE_byte(DR_REG_INVALID)));
+    IF_X86(ASSERT(CHECK_TRUNCATE_TYPE_byte(DR_REG_MAX_AS_OPSZ)));
     /* ensure our flag sharing is done properly */
     ASSERT((uint)LINK_FINAL_INSTR_SHARED_FLAG < (uint)INSTR_FIRST_NON_LINK_SHARED_FLAG);
     ASSERT_TRUNCATE(byte, byte, OPSZ_LAST_ENUM);

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -300,6 +300,7 @@ enum {
     DR_REG_CR13,
     DR_REG_CR14,
     DR_REG_CR15,
+    DR_REG_MAX_AS_OPSZ = DR_REG_CR15,
     DR_REG_INVALID, /**< Sentinel value indicating an invalid register. */
     /* 256-BIT YMM */
     DR_REG_YMM0,

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -300,6 +300,10 @@ enum {
     DR_REG_CR13,
     DR_REG_CR14,
     DR_REG_CR15,
+    /* All registers above this point may be used as opnd_size_t and therefore
+     * need to fit into a byte (checked in d_r_arch_init()). Register enums
+     * below this point must not be used as opnd_size_t.
+     */
     DR_REG_MAX_AS_OPSZ = DR_REG_CR15,
     DR_REG_INVALID, /**< Sentinel value indicating an invalid register. */
     /* 256-BIT YMM */
@@ -843,7 +847,7 @@ enum {
 /* we avoid typedef-ing the enum, as its storage size is compiler-specific */
 typedef ushort reg_id_t; /**< The type of a DR_REG_ enum value. */
 /* For x86 we do store reg_id_t here, but the x86 DR_REG_ enum is small enough
- * (checked in d_r_arch_init().
+ * (checked in d_r_arch_init()).
  */
 typedef byte opnd_size_t; /**< The type of an OPSZ_ enum value. */
 


### PR DESCRIPTION
Certain DR_REG_ enums are used as type opnd_size_t in x86. This patch restores an
assertion to ensure these enums fit into a byte. The affected DR_REG_ enums are
available in combination with a type and template_optype_is_reg is used to identify them.

Fixes #3567