### PR TITLE
i#3574 x86 dec/enc tests: Print two-complement neg displacement.

### DIFF
--- a/core/arch/disassemble_shared.c
+++ b/core/arch/disassemble_shared.c
@@ -312,6 +312,11 @@ opnd_base_disp_disassemble(char *buf, size_t bufsz, size_t *sofar INOUT, opnd_t 
                 else if (!TEST(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask)))
                     print_to_buffer(buf, bufsz, sofar, "+");
             }
+        } else if (TEST(DR_DISASM_ATT, DYNAMO_OPTION(disasm_mask))) {
+            if (IF_X64_ELSE(disp < 0, (disp & 0xff000000) == 0xff000000)) {
+                disp = -disp;
+                print_to_buffer(buf, bufsz, sofar, "-");
+            }
         }
         if (TEST(DR_DISASM_ARM, DYNAMO_OPTION(disasm_mask)))
             print_to_buffer(buf, bufsz, sofar, "%d", disp);

--- a/core/arch/disassemble_shared.c
+++ b/core/arch/disassemble_shared.c
@@ -313,7 +313,12 @@ opnd_base_disp_disassemble(char *buf, size_t bufsz, size_t *sofar INOUT, opnd_t 
                     print_to_buffer(buf, bufsz, sofar, "+");
             }
         } else if (TEST(DR_DISASM_ATT, DYNAMO_OPTION(disasm_mask))) {
-            if (IF_X64_ELSE(disp < 0, (disp & 0xff000000) == 0xff000000)) {
+            /* There seems to be a discrepency between windbg and binutils. The latter
+             * prints a '-' displacement for negative displacements both for att and
+             * intel. We are doing the same for att syntax, while we're following windbg
+             * for intel's syntax. XXX i#3574: should we do the same for intel's syntax?
+             */
+            if (disp < 0) {
                 disp = -disp;
                 print_to_buffer(buf, bufsz, sofar, "-");
             }


### PR DESCRIPTION
Prints the negative hex number instead of the raw displacement for att syntax as it does
for intel syntax. 'objdump' seems to print it the same way.

Issue: #3574