### PR TITLE
Fix leak which occurs if the LLC init fails

### DIFF
--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -78,6 +78,10 @@ cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs_)
         success = false;
         return;
     }
+    
+    std::string cache_name = "LL";
+    all_caches[cache_name] = llc;
+    llcaches[cache_name] = llc;
 
     if (knobs.data_prefetcher != PREFETCH_POLICY_NEXTLINE &&
         knobs.data_prefetcher != PREFETCH_POLICY_NONE) {
@@ -96,10 +100,6 @@ cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs_)
         success = false;
         return;
     }
-
-    std::string cache_name = "LL";
-    all_caches[cache_name] = llc;
-    llcaches[cache_name] = llc;
 
     l1_icaches = new cache_t *[knobs.num_cores];
     l1_dcaches = new cache_t *[knobs.num_cores];

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -78,7 +78,7 @@ cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs_)
         success = false;
         return;
     }
-    
+
     std::string cache_name = "LL";
     all_caches[cache_name] = llc;
     llcaches[cache_name] = llc;


### PR DESCRIPTION
This change fixes a leak which occurs if we fail to initialize the last level cache. Adding the pointer to the all_caches map ensures that the destructor frees the appropriate memory that has been allocated.