### PR TITLE
i#3538 flaky maps mixup: mark static_maps_mixup_novars as FLAKY

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2460,12 +2460,17 @@ endif ()
       # Both versions utilize the dynamorio_static_nohide as a base because
       # the variables in dynamorio_static have already been resolved as a part of
       # the symbol hiding step.
-      set(api.static_maps_mixup_yesvars_expectbase "static_maps_mixup_yesvars")
-      tobuild_static_nohide_api(api.static_maps_mixup_yesvars api/static_maps_mixup.c "" "" OFF)
+      set(api.static_maps_mixup_yesvars_expectbase
+         "static_maps_mixup_yesvars")
+      tobuild_static_nohide_api(api.static_maps_mixup_yesvars
+         api/static_maps_mixup.c "" "" OFF)
       append_link_flags(api.static_maps_mixup_yesvars
           "-Wl,--defsym,dynamorio_so_start=__executable_start -Wl,--defsym,dynamorio_so_end=end")
-      set(api.static_maps_mixup_novars_expectbase "static_maps_mixup_novars")
-      tobuild_static_nohide_api(api.static_maps_mixup_novars api/static_maps_mixup.c "" "" OFF)
+
+      set(api.static_maps_mixup_novars_FLAKY_expectbase
+         "static_maps_mixup_novars")
+      tobuild_static_nohide_api(api.static_maps_mixup_novars_FLAKY
+         api/static_maps_mixup.c "" "" OFF)
     endif ()
   endif ()
 

--- a/suite/tests/api/static_maps_mixup_novars.templatex
+++ b/suite/tests/api/static_maps_mixup_novars.templatex
@@ -2,4 +2,4 @@ mix up maps
 remap base=0x[0-9a-f]+, offs=0, sz=[1-9][0-9]*
 pre-DR init
 /* Depending on the environment, sometimes we hit an assert, sometimes a segfault */
-(<Application .*api.static_maps_mixup_novars \([0-9]+\). Failed to find DynamoRIO library bounds.>)?
+(<Application .*api.static_maps_mixup_novars(_FLAKY)? \([0-9]+\). Failed to find DynamoRIO library bounds.>)?


### PR DESCRIPTION
Currently this just causes some CIs to ignore failures in this test.
Xref i#2204 for having ctest actually re-run these tests.

Issue: #3538, #2204 