### PR TITLE
i#1312 AVX-512 support: Add read_evex function to decoder.

### DIFF
--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -701,6 +701,127 @@ read_vex(byte *pc, decode_info_t *di, byte instr_byte,
     return pc;
 }
 
+#ifdef DISABLED_UNTIL_BUG_1312_IS_FIXED
+
+/* Given the potential first evex byte at pc, reads any subsequent evex
+ * bytes (and any prefix bytes) and sets the appropriate prefix flags in di.
+ * Sets info to the entry for the first opcode byte, and pc to point past
+ * the first opcode byte.
+ */
+static byte *
+read_evex(byte *pc, decode_info_t *di, byte instr_byte,
+          const instr_info_t **ret_info INOUT, bool *is_evex)
+{
+
+    const instr_info_t *info;
+    byte prefix_byte = 0, evex_pp = 0;
+    ASSERT(ret_info != NULL && *ret_info != NULL && is_evex != NULL);
+    info = *ret_info;
+
+    CLIENT_ASSERT(info->type == EVEX_PREFIX_EXT, "internal evex decoding error");
+    /* If 32-bit mode and mod selects for memory, this is not evex */
+    if (X64_MODE(di) || TESTALL(MODRM_BYTE(3, 0, 0), *pc)) {
+        /* P[3:2] must be 0 and P[10] must be 1, otherwise #UD */
+        if (TEST(0xC, *pc) || !TEST(0x04, *(pc + 1))) {
+            *ret_info = &invalid_instr;
+            return pc;
+        }
+
+        *is_evex = true;
+        info = &evex_prefix_extensions[0][1];
+    } else {
+        /* not evex */
+        *is_evex = false;
+        *ret_info = &evex_prefix_extensions[0][0];
+        return pc;
+    }
+
+    CLIENT_ASSERT(info->code == PREFIX_EVEX, "internal evex decoding error");
+
+    /* read 2nd evex byte */
+    instr_byte = *pc;
+    prefix_byte = instr_byte;
+    pc++;
+
+    if (TESTANY(PREFIX_REX_ALL | PREFIX_LOCK, di->prefixes) || di->data_prefix ||
+        di->rep_prefix || di->repne_prefix) {
+        /* #UD if combined w/ EVEX prefix */
+        *ret_info = &invalid_instr;
+        return pc;
+    }
+
+    byte evex_mm;
+    CLIENT_ASSERT(info->type == PREFIX, "internal evex decoding error");
+    /* fields are: R, X, B, R', 00, mm.  R, X, B and R' are inverted.
+     * The patent WO2012134532A1 mentions that the bits are in fact inverted
+     * the same way as in the VEX prefix, in order to make it distinct
+     * from the bound instruction in 32-bit mode.
+     */
+    if (!TEST(0x80, prefix_byte))
+        di->prefixes |= PREFIX_REX_R;
+    if (!TEST(0x40, prefix_byte))
+        di->prefixes |= PREFIX_REX_X;
+    if (!TEST(0x20, prefix_byte))
+        di->prefixes |= PREFIX_REX_B;
+    if (!TEST(0x10, prefix_byte))
+        di->prefixes |= PREFIX_EVEX_RR;
+
+    evex_mm = instr_byte & 0x3;
+
+    if (evex_mm == 1) {
+        *ret_info = &escape_instr;
+    } else if (evex_mm == 2) {
+        *ret_info = &escape_38_instr;
+    } else if (evex_mm == 3) {
+        *ret_info = &escape_3a_instr;
+    } else {
+        /* #UD: reserved for future use */
+        *ret_info = &invalid_instr;
+        return pc;
+    }
+
+    /* read 3rd evex byte */
+    prefix_byte = *pc;
+    pc++;
+
+    /* fields are: W, vvvv, 1, PP */
+    if (TEST(0x80, prefix_byte)) {
+        di->prefixes |= PREFIX_REX_W;
+    }
+
+    evex_pp = prefix_byte & 0x03;
+    di->evex_vvvv = (prefix_byte & 0x78) >> 3;
+
+    if (evex_pp == 0x1)
+        di->data_prefix = true;
+    else if (evex_pp == 0x2)
+        di->rep_prefix = true;
+    else if (evex_pp == 0x3)
+        di->repne_prefix = true;
+
+    /* read 4th evex byte */
+    prefix_byte = *pc;
+    pc++;
+
+    /* fields are: z, L', L, b, V' and aaa */
+    if (TEST(0x80, prefix_byte))
+        di->prefixes |= PREFIX_EVEX_z;
+    if (TEST(0x40, prefix_byte))
+        di->prefixes |= PREFIX_EVEX_LL;
+    if (TEST(0x20, prefix_byte))
+        di->prefixes |= PREFIX_VEX_L;
+    if (TEST(0x10, prefix_byte))
+        di->prefixes |= PREFIX_EVEX_b;
+    if (TEST(0x08, prefix_byte))
+        di->prefixes |= PREFIX_EVEX_VV;
+
+    di->evex_aaa = prefix_byte & 0x07;
+    di->evex_encoded = true;
+    return pc;
+}
+
+#endif
+
 /* Given an instr_info_t PREFIX_EXT entry, reads the next entry based on the prefixes.
  * Note that this function does not initialize the opcode field in \p di but is set in
  * \p info->type.

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -712,7 +712,6 @@ static byte *
 read_evex(byte *pc, decode_info_t *di, byte instr_byte,
           const instr_info_t **ret_info INOUT, bool *is_evex)
 {
-
     const instr_info_t *info;
     byte prefix_byte = 0, evex_pp = 0;
     ASSERT(ret_info != NULL && *ret_info != NULL && is_evex != NULL);
@@ -726,7 +725,6 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
             *ret_info = &invalid_instr;
             return pc;
         }
-
         *is_evex = true;
         info = &evex_prefix_extensions[0][1];
     } else {
@@ -750,7 +748,6 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
         return pc;
     }
 
-    byte evex_mm;
     CLIENT_ASSERT(info->type == PREFIX, "internal evex decoding error");
     /* fields are: R, X, B, R', 00, mm.  R, X, B and R' are inverted.
      * The patent WO2012134532A1 mentions that the bits are in fact inverted
@@ -766,7 +763,7 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
     if (!TEST(0x10, prefix_byte))
         di->prefixes |= PREFIX_EVEX_RR;
 
-    evex_mm = instr_byte & 0x3;
+    byte evex_mm = instr_byte & 0x3;
 
     if (evex_mm == 1) {
         *ret_info = &escape_instr;

--- a/core/arch/x86/decode_private.h
+++ b/core/arch/x86/decode_private.h
@@ -312,9 +312,12 @@ struct _decode_info_t {
     bool data_prefix;
     bool rep_prefix;
     bool repne_prefix;
-    byte vex_vvvv; /* vvvv bits for extra operand */
+    /* vvvv bits for extra operand */
+    union {
+        byte vex_vvvv;
+        byte evex_vvvv;
+    };
     bool vex_encoded;
-    byte evex_vvvv; /* vvvv bits for extra operand */
     bool evex_encoded;
     byte evex_aaa; /* aaa bits for opmask */
     /* for instr_t* target encoding */

--- a/core/arch/x86/decode_private.h
+++ b/core/arch/x86/decode_private.h
@@ -70,6 +70,13 @@
 #define PREFIX_VEX_L 0x000040000
 /* Also only used during initial decode */
 #define PREFIX_XOP 0x000080000
+/* Prefixes which used for AVX-512 */
+#define PREFIX_EVEX 0x000100000
+#define PREFIX_EVEX_RR 0x000200000
+#define PREFIX_EVEX_LL 0x000400000
+#define PREFIX_EVEX_z 0x000800000
+#define PREFIX_EVEX_b 0x001000000
+#define PREFIX_EVEX_VV 0x002000000
 
 /* branch hints show up as segment modifiers */
 #define SEG_JCC_NOT_TAKEN SEG_CS
@@ -307,6 +314,9 @@ struct _decode_info_t {
     bool repne_prefix;
     byte vex_vvvv; /* vvvv bits for extra operand */
     bool vex_encoded;
+    byte evex_vvvv; /* vvvv bits for extra operand */
+    bool evex_encoded;
+    byte evex_aaa; /* aaa bits for opmask */
     /* for instr_t* target encoding */
     ptr_int_t cur_note;
     bool has_instr_opnds;
@@ -484,6 +494,7 @@ extern const byte xop_9_index[256];
 extern const byte xop_a_index[256];
 extern const instr_info_t xop_prefix_extensions[][2];
 extern const instr_info_t xop_extensions[];
+extern const instr_info_t evex_prefix_extensions[][2];
 
 /* table that translates opcode enums into pointers into decoding tables */
 extern const instr_info_t *const op_instr[];

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -4786,6 +4786,7 @@ const instr_info_t vex_extensions[][2] = {
 /****************************************************************************
 * Instructions that differ depending on whether evex-encoded
 * Index 0 = no evex, 1 = evex
+* XXX i#1312: This is currently unused but will resolve with future patches.
 */
 const instr_info_t evex_prefix_extensions[][2] = {
     { /* evex_prefix_ext */

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -4784,6 +4784,17 @@ const instr_info_t vex_extensions[][2] = {
 };
 
 /****************************************************************************
+* Instructions that differ depending on whether evex-encoded
+* Index 0 = no evex, 1 = evex
+*/
+const instr_info_t evex_prefix_extensions[][2] = {
+    { /* evex_prefix_ext */
+      {OP_bound, 0x620000, "bound", xx, xx, Gv, Ma, xx, mrm | i64, x, END_LIST},
+      {PREFIX,   0x620000, "(evex prefix)", xx, xx, xx, xx, xx, mrm, x, PREFIX_EVEX},
+    }
+};
+
+/****************************************************************************
  * Instructions that differ depending on mod and rm bits in modrm byte
  * For mod, entry 0 is all mem ref mod values (0,1,2) while entry 1 is 3.
  * For the mem ref, we give just one of the 3 possible modrm bytes


### PR DESCRIPTION
Adds a read_evex function to decoder.

Prepares a switch table for bound instruction and EVEX prefix.

Issue: #1312