### PR TITLE
i#3570 large vmcode: Load clients inside 1G vmcode on UNIX

### DIFF
--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -1070,9 +1070,10 @@ libraries) within 32-bit reachability of its code caches.  Typically, the
 code cache region is located in the low 4GB of the address space; thus, to
 avoid relocations at client library load time, it is recommended to set a
 preferred client library base in the low 4GB.  The \ref op_reachable_client
-"-reachable_client runtime option" can be used to remove this guarantee,
-though this would normally not be done unless the client is statically
-linked with the application.
+"-reachable_client runtime option" can be used to remove this guarantee.
+The option is automatically turned off when DynamoRIO and clients are
+statically linked with the application: for such static usage, 32-bit
+reachability to the code cache by clients is not guaranteed.
 
 The net result is that any static data or code in a client library, or any
 data allocated using DynamoRIO's API routines (except dr_raw_mem_alloc() or
@@ -1653,10 +1654,11 @@ Options available only in Code Manipulation mode and Memory Firewall mode
 
  - \b -reachable_client: \anchor op_reachable_client
    By default, DynamoRIO guarantees that client libraries are reachable
-   from its code caches by a 32-bit displacement.  Disabling this option
+   from its code caches by a 32-bit displacement (except for clients
+   statically linked into the application).  Disabling this option
    removes that guarantee and allows a client to be located elsewhere.
-   This would typically be used with client that is statically-linked
-   into the application.
+   The option is automatically turned off when DynamoRIO is statically
+   linked into the application.
 
  - \b -max_bb_instrs:
    DynamoRIO stops building a basic block if it hits this application

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -157,6 +157,8 @@ compatibility changes:
    version 7.1.0 or earlier.
  - Renamed mcontext's "ymm" structure to "simd".
  - Deprecated reg_is_xmm() and reg_is_ymm().
+ - Dropped support for clients used with statically linked DynamoRIO to reach
+   the code cache with 32-bit displacements.
 
 Further non-compatibility-affecting changes include:
 

--- a/core/drlibc/drlibc_unix.c
+++ b/core/drlibc/drlibc_unix.c
@@ -482,7 +482,7 @@ os_map_file(file_t f, size_t *size INOUT, uint64 offs, app_pc addr, uint prot,
     return map;
 }
 
-bool
+WEAK bool
 os_unmap_file(byte *map, size_t size)
 {
     long res = munmap_syscall(map, size);

--- a/core/heap.h
+++ b/core/heap.h
@@ -142,8 +142,16 @@ heap_check_option_compatibility(void);
 bool
 is_vmm_reserved_address(byte *pc, size_t size, OUT byte **region_start,
                         OUT byte **region_end);
+/* Returns whether "target" is reachable from all future vmcode allocations. */
 bool
 rel32_reachable_from_vmcode(byte *target);
+/* Returns whether "target" is reachable from the current vmcode.  It may
+ * not be reachable in the future.  This should normally only be used when
+ * "target" is going to be added to the must-be-reachable region, ensuring
+ * future reachability.
+ */
+bool
+rel32_reachable_from_current_vmcode(byte *target);
 
 /* heap management */
 void
@@ -193,6 +201,12 @@ heap_mmap_ex(size_t reserve_size, size_t commit_size, uint prot, bool guarded,
              which_vmm_t which);
 void
 heap_munmap_ex(void *p, size_t size, bool guarded, which_vmm_t which);
+
+byte *
+heap_reserve_for_external_mapping(byte *preferred, size_t size, which_vmm_t which);
+
+bool
+heap_unreserve_for_external_mapping(byte *p, size_t size, which_vmm_t which);
 
 /* updates dynamo_areas and calls the os_ versions */
 byte *

--- a/core/unix/memcache.c
+++ b/core/unix/memcache.c
@@ -335,7 +335,7 @@ memcache_update_locked(app_pc start, app_pc end, uint prot, int type, bool exist
                      /* we could synch up: instead we relax the assert if DR areas not
                       * in allmem
                       */
-                     are_dynamo_vm_areas_stale());
+                     are_dynamo_vm_areas_stale() || !dynamo_initialized);
     LOG(GLOBAL, LOG_VMAREAS, 3, "\tupdating all_memory_areas " PFX "-" PFX " prot->%d\n",
         start, end, prot);
     memcache_update(start, end, prot, type);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4117,7 +4117,7 @@ os_map_file(file_t f, size_t *size INOUT, uint64 offs, app_pc addr, uint prot,
             map_flags_t map_flags)
 {
     int flags;
-    byte *map;
+    byte *map = NULL;
 #if defined(X64)
     bool loop = false;
     uint iters = 0;

--- a/core/utils.h
+++ b/core/utils.h
@@ -1148,7 +1148,8 @@ bitmap_clear(bitmap_t b, uint i)
 void
 bitmap_initialize_free(bitmap_t b, uint bitmap_size);
 uint
-bitmap_allocate_blocks(bitmap_t b, uint bitmap_size, uint request_blocks);
+bitmap_allocate_blocks(bitmap_t b, uint bitmap_size, uint request_blocks,
+                       uint start_block);
 void
 bitmap_free_blocks(bitmap_t b, uint bitmap_size, uint first_block, uint num_free);
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1793,7 +1793,10 @@ if (CLIENT_INTERFACE)
     tobuild_ci(client.modules client-interface/modules.c "" "" "${modules_libname}")
   endif ()
   if (X86) # FIXME i#1551, i#1569: port to ARM and AArch64
-    tobuild_ci(client.alloc client-interface/alloc.c "" "" "")
+    tobuild_ci(client.alloc client-interface/alloc.c ""
+      # For the subtest "targeting upper 2GB of low 4GB" we move -vm_base out of the
+      # way:
+      "-no_vm_base_near_app -vm_base 0x120000000" "")
     tobuild_ci(client.cleancall client-interface/cleancall.c "" "" "")
     if (UNIX)
       torunonly_ci(client.cleancall.prof-pcs client.cleancall client.cleancall.dll

--- a/suite/tests/client-interface/alloc.dll.c
+++ b/suite/tests/client-interface/alloc.dll.c
@@ -202,7 +202,9 @@ reachability_test(void)
 
     dr_raw_mem_free(highmem, PAGE_SIZE);
 
-    /* Test targeting upper 2GB of low 4GB */
+    /* Test targeting upper 2GB of low 4GB (this will fail with default options
+     * of -vm_size 2G and a low vm_base b/c there's no room there).
+     */
     highmem =
         dr_raw_mem_alloc(PAGE_SIZE, DR_MEMPROT_READ | DR_MEMPROT_WRITE | DR_MEMPROT_EXEC,
                          (byte *)0xabcd0000);


### PR DESCRIPTION
Adds new VMM capabilities to reserve memory at a specific address for
a file mapping and uses it to load client libs and anything else that
requires reachability inside the vmcode region.

Fixes two unmap failures which now show up as memory leaks with the
VMM managing the space:
+ The inter-segment gaps were not being unmapped.
+ The .bss separation page was not being unmapped.

Makes -vm_size, the size of the vmcode region, 1G by default on UNIX.
We do not go all the way to 2G because that causes -vm_base_near_app
to always fail, which results in always having to mangle rip-relative
accesses and corresponding increased overhead.

Leaves Windows vmcode size and library location unchanged, due to
complexities in placing file mappings inside the region (see the issue
for details).

Increases -vmheap_size to 2G as well while at it, for all platforms.

Tweaks the client.alloc test options to work with larger vmcode sizes.

Disables -reachable_client guarantees for static DR and documents
this.  Such guarantees are impossible with a 2G vmcode, and difficult
even with 1G or smaller.

Fixes a bug where reachable bounds were not reset on detach.

Issue: #3570