### PR TITLE
i#1312 AVX-512 support: Add vmovdqu[8|16|32|64], vmovdqa[32|64], vmovss, vmosd.

### DIFF
--- a/core/arch/x86/decode_private.h
+++ b/core/arch/x86/decode_private.h
@@ -149,7 +149,7 @@ enum {
  *                     if bit 3 (OPCODE_MODRM) set, opcode based on entire modrm
  *                       that modrm is stored as the byte 0.
  *                       if REQUIRES_VEX or REQUIRES_EVEX then this bit instead means
- *                       that this instruction must have vex.W set.
+ *                       that this instruction must have vex.W or evex.W set.
  *                     if bit 4 (OPCODE_SUFFIX) set, opcode based on suffix byte
  *                       that byte is stored as the byte 0
  *                       if REQUIRES_VEX then this bit instead means that

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1266,7 +1266,7 @@ const instr_info_t * const op_instr[] =
     /* OP_vpbroadcastd  */   &third_byte_38[118],
     /* OP_vpbroadcastq  */   &third_byte_38[119],
 
-    /* added in Intel Skylake */
+    /* Added in Intel Skylake */
     /* OP_xsavec32      */   &rex_w_extensions[5][0],
     /* OP_xsavec64      */   &rex_w_extensions[5][1],
 
@@ -1328,6 +1328,13 @@ const instr_info_t * const op_instr[] =
     /* OP_ktestd        */  &vex_W_extensions[105][1],
 
     /* AVX-512 EVEX encoded */
+    /* OP_vmovdqu8      */  &evex_W_extensions[10][0],
+    /* OP_vmovdqu16     */  &evex_W_extensions[10][1],
+    /* OP_vmovdqu32     */  &evex_W_extensions[11][0],
+    /* OP_vmovdqu64     */  &evex_W_extensions[11][1],
+    /* OP_vmovdqa32     */  &evex_W_extensions[8][0],
+    /* OP_vmovdqa64     */  &evex_W_extensions[8][1],
+
     /* TODO i#1312. */
 };
 
@@ -1487,6 +1494,8 @@ const instr_info_t * const op_instr[] =
 #define Ved TYPE_V, OPSZ_16_vex32_evex64
 #define Wes TYPE_W, OPSZ_16_vex32_evex64
 #define Wed TYPE_W, OPSZ_16_vex32_evex64
+#define Vex TYPE_V, OPSZ_16_vex32_evex64
+#define Wex TYPE_W, OPSZ_16_vex32_evex64
 
 /* my own codes
  * size m = 32 or 16 bit depending on addr size attribute
@@ -2768,9 +2777,9 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_vmovupd, 0x660f1010, "vmovupd", Vvd, xx, Wvd, xx, xx, mrm|vex, x, tpe[1][6]},
     {MOD_EXT,    0xf20f1010, "(mod ext 9)", xx, xx, xx, xx, xx, mrm|vex, x, 9},
     {EVEX_W_EXT, 0x0f1010, "(evex_W ext 0)", xx, xx, xx, xx, xx, mrm|evex, x, 0},
-    {INVALID, 0xf30f1010, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {MOD_EXT,    0xf30f1010, "(mod ext 20)", xx, xx, xx, xx, xx, mrm|evex, x, 20},
     {EVEX_W_EXT, 0x660f1010, "(evex_W ext 2)", xx, xx, xx, xx, xx, mrm|evex, x, 2},
-    {INVALID, 0xf20f1010, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {MOD_EXT,    0xf20f1010, "(mod ext 21)", xx, xx, xx, xx, xx, mrm|evex, x, 21},
   },
   /* prefix extension 1 */
   {
@@ -2783,9 +2792,9 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_vmovupd, 0x660f1110, "vmovupd", Wvd, xx, Vvd, xx, xx, mrm|vex, x, tevexw[2][1]},
     {MOD_EXT,    0xf20f1110, "(mod ext 11)", xx, xx, xx, xx, xx, mrm|vex, x, 11},
     {EVEX_W_EXT, 0x0f1110, "(evex_W ext 1)", xx, xx, xx, xx, xx, mrm|evex, x, 1},
-    {INVALID, 0xf30f1110, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {MOD_EXT,    0xf30f1110, "(mod ext 22)", xx, xx, xx, xx, xx, mrm|evex, x, 22},
     {EVEX_W_EXT, 0x660f1110, "(evex_W ext 3)", xx, xx, xx, xx, xx, mrm|evex, x, 3},
-    {INVALID, 0xf20f1110, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {MOD_EXT,    0xf20f1110, "(mod ext 23)", xx, xx, xx, xx, xx, mrm|evex, x, 23},
   },
   /* prefix extension 2 */
   {
@@ -4572,11 +4581,10 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_vmovdqu, 0xf30f6f10, "vmovdqu", Vx, xx, Wx, xx, xx, mrm|vex, x, tpe[113][5]},
     {OP_vmovdqa, 0x660f6f10, "vmovdqa", Vx, xx, Wx, xx, xx, mrm|vex, x, tpe[113][6]},
     {INVALID,   0xf20f6f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    /* TODO i#1312: Support AVX-512. */
     {INVALID,   0x0f6f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf30f6f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f6f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf20f6f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0xf30f6f10, "(evex_W ext 11)", xx, xx, xx, xx, xx, mrm|evex, x, 11},
+    {EVEX_W_EXT, 0x660f6f10, "(evex_W ext 8)", xx, xx, xx, xx, xx, mrm|evex, x, 8},
+    {EVEX_W_EXT, 0xf20f6f10, "(evex_W ext 10)", xx, xx, xx, xx, xx, mrm|evex, x, 10},
   },
   /* prefix extension 113 */
   {
@@ -4588,11 +4596,10 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_vmovdqu, 0xf30f7f10, "vmovdqu", Wx, xx, Vx, xx, xx, mrm|vex, x, END_LIST},
     {OP_vmovdqa, 0x660f7f10, "vmovdqa", Wx, xx, Vx, xx, xx, mrm|vex, x, END_LIST},
     {INVALID,   0xf20f7f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    /* TODO i#1312: Support AVX-512. */
     {INVALID,   0x0f7f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf30f7f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f7f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf20f7f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0xf30f7f10, "(evex_W ext 13)", xx, xx, xx, xx, xx, mrm|evex, x, 13},
+    {EVEX_W_EXT, 0x660f7f10, "(evex_W ext 9)", xx, xx, xx, xx, xx, mrm|evex, x, 9},
+    {EVEX_W_EXT, 0xf20f7f10, "(evex_W ext 12)", xx, xx, xx, xx, xx, mrm|evex, x, 12},
   },
   /* prefix extension 114 */
   {
@@ -5721,11 +5728,11 @@ const instr_info_t mod_extensions[][2] = {
   },
   { /* mod extension 10 */
     {OP_vmovss,  0xf30f1110, "vmovss",  Wss, xx, Vss,  xx, xx, mrm|vex, x, modx[ 8][1]},
-    {OP_vmovss,  0xf30f1110, "vmovss",  Udq, xx, H12_dq, Vss, xx, mrm|vex, x, END_LIST},
+    {OP_vmovss,  0xf30f1110, "vmovss",  Udq, xx, H12_dq, Vss, xx, mrm|vex, x, modx[20][0]},
   },
   { /* mod extension 11 */
     {OP_vmovsd,  0xf20f1110, "vmovsd",  Wsd, xx, Vsd,  xx, xx, mrm|vex, x, modx[ 9][1]},
-    {OP_vmovsd,  0xf20f1110, "vmovsd",  Udq, xx, Hsd, Vsd, xx, mrm|vex, x, END_LIST},
+    {OP_vmovsd,  0xf20f1110, "vmovsd",  Udq, xx, Hsd, Vsd, xx, mrm|vex, x, modx[21][0]},
   },
   { /* mod extension 12 */
     {PREFIX_EXT, 0x0fc736, "(prefix ext 137)", xx, xx, xx, xx, xx, no, x, 137},
@@ -5766,6 +5773,22 @@ const instr_info_t mod_extensions[][2] = {
     /* load from memory zeroes top bits */
     {OP_movsd,  0xf20f1010, "movsd",  Vdq, xx, Msd, xx, xx, mrm, x, modx[19][1]},
     {OP_movsd,  0xf20f1010, "movsd",  Vsd, xx, Usd, xx, xx, mrm, x, tpe[1][3]},
+  },
+  { /* mod extension 20 */
+    {OP_vmovss,  0xf30f1010, "vmovss",  Vss, xx, KEb, Wss,  xx, mrm|evex, x, modx[22][0]},
+    {OP_vmovss,  0xf30f1010, "vmovss",  Vdq, xx, KEb, H12_dq, Uss, mrm|evex, x, modx[22][1]},
+  },
+  { /* mod extension 21 */
+    {OP_vmovsd,  0xf20f1010, "vmovsd",  Vsd, xx, KEb, Wsd,  xx, mrm|evex, x, modx[23][0]},
+    {OP_vmovsd,  0xf20f1010, "vmovsd",  Vdq, xx, KEb, Hsd, Usd, mrm|evex, x, modx[23][1]},
+  },
+  { /* mod extension 22 */
+    {OP_vmovss,  0xf30f1110, "vmovss",  Wss, xx, KEb, Vss,  xx, mrm|evex, x, modx[20][1]},
+    {OP_vmovss,  0xf30f1110, "vmovss",  Udq, xx, KEb, H12_dq, Vss, mrm|evex, x, END_LIST},
+  },
+  { /* mod extension 23 */
+    {OP_vmovsd,  0xf20f1110, "vmovsd",  Wsd, xx, KEb, Vsd,  xx, mrm|evex, x, modx[21][1]},
+    {OP_vmovsd,  0xf20f1110, "vmovsd",  Udq, xx, KEb, Hsd, Vsd, mrm|evex, x, END_LIST},
   },
 };
 
@@ -6643,6 +6666,30 @@ const instr_info_t evex_W_extensions[][2] = {
   {    /* evex_W_ext 7 */
     {INVALID, 0x660f2910,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vmovapd, 0x660f2950,"vmovapd", Wed,xx,KEd,Ved,xx,mrm|evex,x,END_LIST},
+  },
+  {    /* evex_W_ext 8 */
+    {OP_vmovdqa32, 0x660f6f10,"vmovdqa32",Vex,xx,KEw,Wex,xx,mrm|evex,x,tevexw[9][0]},
+    {OP_vmovdqa64, 0x660f6f50,"vmovdqa64",Vex,xx,KEw,Wex,xx,mrm|evex,x,tevexw[9][1]},
+  },
+  {    /* evex_W_ext 9 */
+    {OP_vmovdqa32, 0x660f7f10,"vmovdqa32",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
+    {OP_vmovdqa64, 0x660f7f50,"vmovdqa64",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
+  },
+  {    /* evex_W_ext 10 */
+    {OP_vmovdqu8, 0xf20f6f10,"vmovdqu8",Vex,xx,KEw,Wex,xx,mrm|evex,x,tevexw[12][0]},
+    {OP_vmovdqu16, 0xf20f6f50,"vmovdqu16",Vex,xx,KEw,Wex,xx,mrm|evex,x,tevexw[12][1]},
+  },
+  {    /* evex_W_ext 11 */
+    {OP_vmovdqu32, 0xf30f6f10,"vmovdqu32",Vex,xx,KEw,Wex,xx,mrm|evex,x,tevexw[13][0]},
+    {OP_vmovdqu64, 0xf30f6f50,"vmovdqu64",Vex,xx,KEw,Wex,xx,mrm|evex,x,tevexw[13][1]},
+  },
+  {    /* evex_W_ext 12 */
+    {OP_vmovdqu8, 0xf20f7f10,"vmovdqu8",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
+    {OP_vmovdqu16, 0xf20f7f50,"vmovdqu16",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
+  },
+  {    /* evex_W_ext 13 */
+    {OP_vmovdqu32, 0xf30f7f10,"vmovdqu32",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
+    {OP_vmovdqu64, 0xf30f7f50,"vmovdqu64",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
   },
 };
 

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1328,12 +1328,12 @@ const instr_info_t * const op_instr[] =
     /* OP_ktestd        */  &vex_W_extensions[105][1],
 
     /* AVX-512 EVEX encoded */
+    /* OP_vmovdqa32     */  &evex_W_extensions[8][0],
+    /* OP_vmovdqa64     */  &evex_W_extensions[8][1],
     /* OP_vmovdqu8      */  &evex_W_extensions[10][0],
     /* OP_vmovdqu16     */  &evex_W_extensions[10][1],
     /* OP_vmovdqu32     */  &evex_W_extensions[11][0],
     /* OP_vmovdqu64     */  &evex_W_extensions[11][1],
-    /* OP_vmovdqa32     */  &evex_W_extensions[8][0],
-    /* OP_vmovdqa64     */  &evex_W_extensions[8][1],
 
     /* TODO i#1312. */
 };

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1266,7 +1266,7 @@ const instr_info_t * const op_instr[] =
     /* OP_vpbroadcastd  */   &third_byte_38[118],
     /* OP_vpbroadcastq  */   &third_byte_38[119],
 
-    /* Added in Intel Skylake */
+    /* added in Intel Skylake */
     /* OP_xsavec32      */   &rex_w_extensions[5][0],
     /* OP_xsavec64      */   &rex_w_extensions[5][1],
 

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -1438,7 +1438,8 @@
 #define INSTR_CREATE_ktestd(dc, d, s) instr_create_1dst_1src((dc), OP_ktestd, (d), (s))
 /* AVX-512 EVEX */
 /* TODO i#1312: AVX-512 promoted AVX opcodes with default mask k0 should be covered by
- * macros above, but encoder should assign default mask. */
+ * macros above, but encoder should assign default mask.
+ */
 
 /* @} */ /* end doxygen group */
 
@@ -2254,6 +2255,22 @@
     instr_create_1dst_2src((dc), OP_vmovaps, (d), (k), (s))
 #define INSTR_CREATE_vmovapd_mask(dc, d, k, s) \
     instr_create_1dst_2src((dc), OP_vmovapd, (d), (k), (s))
+#define INSTR_CREATE_vmovdqa32_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vmovdqa32, (d), (k), (s))
+#define INSTR_CREATE_vmovdqa64_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vmovdqa64, (d), (k), (s))
+#define INSTR_CREATE_vmovdqu8_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vmovdqu8, (d), (k), (s))
+#define INSTR_CREATE_vmovdqu16_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vmovdqu16, (d), (k), (s))
+#define INSTR_CREATE_vmovdqu32_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vmovdqu32, (d), (k), (s))
+#define INSTR_CREATE_vmovdqu64_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vmovdqu64, (d), (k), (s))
+#define INSTR_CREATE_vmovss_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vmovss, (d), (k), (s))
+#define INSTR_CREATE_vmovsd_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vmovsd, (d), (k), (s))
 /* @} */ /* end doxygen group */
 
 /* 1 destination, 2 sources: 1 explicit, 1 implicit */
@@ -2930,6 +2947,26 @@
     instr_create_1dst_3src((dc), OP_vpblendd, (d), (s1), (s2), (s3))
 #define INSTR_CREATE_vperm2i128(dc, d, s1, s2, s3) \
     instr_create_1dst_3src((dc), OP_vperm2i128, (d), (s1), (s2), (s3))
+/* @} */ /* end doxygen group */
+
+/** @name 1 destination, 1 mask, and 2 non-immediate sources */
+/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/**
+ * This INSTR_CREATE_xxx_mask macro creates an instr_t with opcode OP_xxx and the given
+ * explicit operands, automatically supplying any implicit operands. The first source
+ * operand is the instruction's mask.
+ *
+ * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * \param d The opnd_t explicit destination operand for the instruction.
+ * \param k The opnd_t explicit mask source operand for the instruction.
+ * \param s1 The opnd_t explicit first source operand for the instruction
+ * \param s2 The opnd_t explicit second source operand for the instruction
+ */
+/* AVX-512 EVEX */
+#define INSTR_CREATE_vmovss_NDS_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vmovss, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vmovsd_NDS_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vmovsd, (d), (k), (s1), (s2))
 /* @} */ /* end doxygen group */
 
 /** @name 1 destination, 3 sources including one immediate */

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1320,6 +1320,10 @@ enum {
     /* 1157 */ OP_ktestd,   /**< IA-32/AMD64 AVX-512 ktestd opcode. */
 
     /* Intel AVX-512 EVEX */
+    /* XXX i#1312: The opcode enum numbers here are changing as long as
+     * AVX-512 instructions are being added to DynamoRIO. Users are advised
+     * not to rely on the numerical value until i#1312 has been completed.
+     */
     /* 1158 */ OP_vmovdqa32, /**< IA-32/AMD64 AVX-512 vmovdqa32 opcode. */
     /* 1159 */ OP_vmovdqa64, /**< IA-32/AMD64 AVX-512 vmovdqa64 opcode. */
     /* 1160 */ OP_vmovdqu8,  /**< IA-32/AMD64 AVX-512 vmovdqu8 opcode. */

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1266,7 +1266,7 @@ enum {
     /* 1105 */ OP_adox, /**< IA-32/AMD64 adox opcode. */
     /* 1106 */ OP_adcx, /**< IA-32/AMD64 adox opcode. */
 
-    /* Intel AVX-512 */
+    /* Intel AVX-512 VEX */
     /* 1107 */ OP_kmovw,    /**< IA-32/AMD64 AVX-512 kmovw opcode. */
     /* 1108 */ OP_kmovb,    /**< IA-32/AMD64 AVX-512 kmovb opcode. */
     /* 1109 */ OP_kmovq,    /**< IA-32/AMD64 AVX-512 kmovq opcode. */
@@ -1319,12 +1319,13 @@ enum {
     /* 1156 */ OP_ktestq,   /**< IA-32/AMD64 AVX-512 ktestd opcode. */
     /* 1157 */ OP_ktestd,   /**< IA-32/AMD64 AVX-512 ktestd opcode. */
 
-    /* 1158 */ OP_vmovdqu8,  /**< IA-32/AMD64 AVX-512 vmovdqu8 opcode. */
-    /* 1159 */ OP_vmovdqu16, /**< IA-32/AMD64 AVX-512 vmovdqu16 opcode. */
-    /* 1160 */ OP_vmovdqu32, /**< IA-32/AMD64 AVX-512 vmovdqu32 opcode. */
-    /* 1161 */ OP_vmovdqu64, /**< IA-32/AMD64 AVX-512 vmovdqu64 opcode. */
-    /* 1162 */ OP_vmovdqa32, /**< IA-32/AMD64 AVX-512 vmovdqa32 opcode. */
-    /* 1163 */ OP_vmovdqa64, /**< IA-32/AMD64 AVX-512 vmovdqa64 opcode. */
+    /* Intel AVX-512 EVEX */
+    /* 1158 */ OP_vmovdqa32, /**< IA-32/AMD64 AVX-512 vmovdqa32 opcode. */
+    /* 1159 */ OP_vmovdqa64, /**< IA-32/AMD64 AVX-512 vmovdqa64 opcode. */
+    /* 1160 */ OP_vmovdqu8,  /**< IA-32/AMD64 AVX-512 vmovdqu8 opcode. */
+    /* 1161 */ OP_vmovdqu16, /**< IA-32/AMD64 AVX-512 vmovdqu16 opcode. */
+    /* 1162 */ OP_vmovdqu32, /**< IA-32/AMD64 AVX-512 vmovdqu32 opcode. */
+    /* 1163 */ OP_vmovdqu64, /**< IA-32/AMD64 AVX-512 vmovdqu64 opcode. */
 
     OP_AFTER_LAST,
     OP_FIRST = OP_add,           /**< First real opcode. */

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1319,6 +1319,13 @@ enum {
     /* 1156 */ OP_ktestq,   /**< IA-32/AMD64 AVX-512 ktestd opcode. */
     /* 1157 */ OP_ktestd,   /**< IA-32/AMD64 AVX-512 ktestd opcode. */
 
+    /* 1158 */ OP_vmovdqu8,  /**< IA-32/AMD64 AVX-512 vmovdqu8 opcode. */
+    /* 1159 */ OP_vmovdqu16, /**< IA-32/AMD64 AVX-512 vmovdqu16 opcode. */
+    /* 1160 */ OP_vmovdqu32, /**< IA-32/AMD64 AVX-512 vmovdqu32 opcode. */
+    /* 1161 */ OP_vmovdqu64, /**< IA-32/AMD64 AVX-512 vmovdqu64 opcode. */
+    /* 1162 */ OP_vmovdqa32, /**< IA-32/AMD64 AVX-512 vmovdqa32 opcode. */
+    /* 1163 */ OP_vmovdqa64, /**< IA-32/AMD64 AVX-512 vmovdqa64 opcode. */
+
     OP_AFTER_LAST,
     OP_FIRST = OP_add,           /**< First real opcode. */
     OP_LAST = OP_AFTER_LAST - 1, /**< Last real opcode. */

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -304,6 +304,14 @@ test_all_opcodes_4(void *dc)
 #    undef INCLUDE_NAME
 }
 
+static void
+test_all_opcodes_4_avx512_evex_mask(void *dc)
+{
+#    define INCLUDE_NAME "ir_x86_4args_avx512_evex_mask.h"
+#    include "ir_x86_all_opc.h"
+#    undef INCLUDE_NAME
+}
+
 #    undef OPCODE_FOR_CREATE
 #    undef XOPCODE_FOR_CREATE
 
@@ -1694,6 +1702,7 @@ main(int argc, char *argv[])
      */
     test_all_opcodes_3_avx512_evex_mask(dcontext);
     test_disas_3_avx512_evex_mask(dcontext);
+    test_all_opcodes_4_avx512_evex_mask(dcontext);
 #endif
 
     print("all done\n");

--- a/suite/tests/api/ir_x86_3args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_3args_avx512_evex_mask.h
@@ -175,4 +175,316 @@ OPCODE(vmovapd_xlok7xhi, vmovapd, vmovapd_mask, X64_ONLY, REGARG(XMM0), REGARG(K
        REGARG(XMM16))
 OPCODE(vmovapd_xlokm, vmovapd, vmovapd_mask, 0, REGARG(XMM0), REGARG(K7), MEMARG(OPSZ_16))
 OPCODE(vmovapd_mkxlo, vmovapd, vmovapd_mask, 0, MEMARG(OPSZ_16), REGARG(K7), REGARG(XMM0))
+OPCODE(vmovdqa32_zlok0zlo, vmovdqa32, vmovdqa32_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1))
+OPCODE(vmovdqa32_zhik0zlo, vmovdqa32, vmovdqa32_mask, X64_ONLY, REGARG(ZMM16), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vmovdqa32_zlok0zhi, vmovdqa32, vmovdqa32_mask, X64_ONLY, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM16))
+OPCODE(vmovdqa32_zlok7zlo, vmovdqa32, vmovdqa32_mask, 0, REGARG(ZMM0), REGARG(K7),
+       REGARG(ZMM1))
+OPCODE(vmovdqa32_zhik7zlo, vmovdqa32, vmovdqa32_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       REGARG(ZMM0))
+OPCODE(vmovdqa32_zlok7zhi, vmovdqa32, vmovdqa32_mask, X64_ONLY, REGARG(ZMM0), REGARG(K7),
+       REGARG(ZMM16))
+OPCODE(vmovdqa32_zlokm, vmovdqa32, vmovdqa32_mask, 0, REGARG(ZMM0), REGARG(K7),
+       MEMARG(OPSZ_64))
+OPCODE(vmovdqa32_mkzlo, vmovdqa32, vmovdqa32_mask, 0, MEMARG(OPSZ_64), REGARG(K7),
+       REGARG(ZMM0))
+OPCODE(vmovdqa32_ylok0ylo, vmovdqa32, vmovdqa32_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1))
+OPCODE(vmovdqa32_yhik0ylo, vmovdqa32, vmovdqa32_mask, X64_ONLY, REGARG(YMM16), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vmovdqa32_ylok0yhi, vmovdqa32, vmovdqa32_mask, X64_ONLY, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM16))
+OPCODE(vmovdqa32_ylok7ylo, vmovdqa32, vmovdqa32_mask, 0, REGARG(YMM0), REGARG(K7),
+       REGARG(YMM1))
+OPCODE(vmovdqa32_yhik7ylo, vmovdqa32, vmovdqa32_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       REGARG(YMM0))
+OPCODE(vmovdqa32_ylok7yhi, vmovdqa32, vmovdqa32_mask, X64_ONLY, REGARG(YMM0), REGARG(K7),
+       REGARG(YMM16))
+OPCODE(vmovdqa32_ylokm, vmovdqa32, vmovdqa32_mask, 0, REGARG(YMM0), REGARG(K7),
+       MEMARG(OPSZ_32))
+OPCODE(vmovdqa32_mkylo, vmovdqa32, vmovdqa32_mask, 0, MEMARG(OPSZ_32), REGARG(K7),
+       REGARG(YMM0))
+OPCODE(vmovdqa32_xlok0xlo, vmovdqa32, vmovdqa32_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1))
+OPCODE(vmovdqa32_xhik0xlo, vmovdqa32, vmovdqa32_mask, X64_ONLY, REGARG(XMM16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vmovdqa32_xlok0xhi, vmovdqa32, vmovdqa32_mask, X64_ONLY, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM16))
+OPCODE(vmovdqa32_xlok7xlo, vmovdqa32, vmovdqa32_mask, 0, REGARG(XMM0), REGARG(K7),
+       REGARG(XMM1))
+OPCODE(vmovdqa32_xhik7xlo, vmovdqa32, vmovdqa32_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG(XMM0))
+OPCODE(vmovdqa32_xlok7xhi, vmovdqa32, vmovdqa32_mask, X64_ONLY, REGARG(XMM0), REGARG(K7),
+       REGARG(XMM16))
+OPCODE(vmovdqa32_xlokm, vmovdqa32, vmovdqa32_mask, 0, REGARG(XMM0), REGARG(K7),
+       MEMARG(OPSZ_16))
+OPCODE(vmovdqa32_mkxlo, vmovdqa32, vmovdqa32_mask, 0, MEMARG(OPSZ_16), REGARG(K7),
+       REGARG(XMM0))
+OPCODE(vmovdqa64_zlok0zlo, vmovdqa64, vmovdqa64_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1))
+OPCODE(vmovdqa64_zhik0zlo, vmovdqa64, vmovdqa64_mask, X64_ONLY, REGARG(ZMM16), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vmovdqa64_zlok0zhi, vmovdqa64, vmovdqa64_mask, X64_ONLY, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM16))
+OPCODE(vmovdqa64_zlok7zlo, vmovdqa64, vmovdqa64_mask, 0, REGARG(ZMM0), REGARG(K7),
+       REGARG(ZMM1))
+OPCODE(vmovdqa64_zhik7zlo, vmovdqa64, vmovdqa64_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       REGARG(ZMM0))
+OPCODE(vmovdqa64_zlok7zhi, vmovdqa64, vmovdqa64_mask, X64_ONLY, REGARG(ZMM0), REGARG(K7),
+       REGARG(ZMM16))
+OPCODE(vmovdqa64_zlokm, vmovdqa64, vmovdqa64_mask, 0, REGARG(ZMM0), REGARG(K7),
+       MEMARG(OPSZ_64))
+OPCODE(vmovdqa64_mkzlo, vmovdqa64, vmovdqa64_mask, 0, MEMARG(OPSZ_64), REGARG(K7),
+       REGARG(ZMM0))
+OPCODE(vmovdqa64_ylok0ylo, vmovdqa64, vmovdqa64_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1))
+OPCODE(vmovdqa64_yhik0ylo, vmovdqa64, vmovdqa64_mask, X64_ONLY, REGARG(YMM16), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vmovdqa64_ylok0yhi, vmovdqa64, vmovdqa64_mask, X64_ONLY, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM16))
+OPCODE(vmovdqa64_ylok7ylo, vmovdqa64, vmovdqa64_mask, 0, REGARG(YMM0), REGARG(K7),
+       REGARG(YMM1))
+OPCODE(vmovdqa64_yhik7ylo, vmovdqa64, vmovdqa64_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       REGARG(YMM0))
+OPCODE(vmovdqa64_ylok7yhi, vmovdqa64, vmovdqa64_mask, X64_ONLY, REGARG(YMM0), REGARG(K7),
+       REGARG(YMM16))
+OPCODE(vmovdqa64_ylokm, vmovdqa64, vmovdqa64_mask, 0, REGARG(YMM0), REGARG(K7),
+       MEMARG(OPSZ_32))
+OPCODE(vmovdqa64_mkylo, vmovdqa64, vmovdqa64_mask, 0, MEMARG(OPSZ_32), REGARG(K7),
+       REGARG(YMM0))
+OPCODE(vmovdqa64_xlok0xlo, vmovdqa64, vmovdqa64_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1))
+OPCODE(vmovdqa64_xhik0xlo, vmovdqa64, vmovdqa64_mask, X64_ONLY, REGARG(XMM16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vmovdqa64_xlok0xhi, vmovdqa64, vmovdqa64_mask, X64_ONLY, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM16))
+OPCODE(vmovdqa64_xlok7xlo, vmovdqa64, vmovdqa64_mask, 0, REGARG(XMM0), REGARG(K7),
+       REGARG(XMM1))
+OPCODE(vmovdqa64_xhik7xlo, vmovdqa64, vmovdqa64_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG(XMM0))
+OPCODE(vmovdqa64_xlok7xhi, vmovdqa64, vmovdqa64_mask, X64_ONLY, REGARG(XMM0), REGARG(K7),
+       REGARG(XMM16))
+OPCODE(vmovdqa64_xlokm, vmovdqa64, vmovdqa64_mask, 0, REGARG(XMM0), REGARG(K7),
+       MEMARG(OPSZ_16))
+OPCODE(vmovdqa64_mkxlo, vmovdqa64, vmovdqa64_mask, 0, MEMARG(OPSZ_16), REGARG(K7),
+       REGARG(XMM0))
+OPCODE(vmovdqu8_zlok0zlo, vmovdqu8, vmovdqu8_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1))
+OPCODE(vmovdqu8_zhik0zlo, vmovdqu8, vmovdqu8_mask, X64_ONLY, REGARG(ZMM16), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vmovdqu8_zlok0zhi, vmovdqu8, vmovdqu8_mask, X64_ONLY, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM16))
+OPCODE(vmovdqu8_zlok7zlo, vmovdqu8, vmovdqu8_mask, 0, REGARG(ZMM0), REGARG(K7),
+       REGARG(ZMM1))
+OPCODE(vmovdqu8_zhik7zlo, vmovdqu8, vmovdqu8_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       REGARG(ZMM0))
+OPCODE(vmovdqu8_zlok7zhi, vmovdqu8, vmovdqu8_mask, X64_ONLY, REGARG(ZMM0), REGARG(K7),
+       REGARG(ZMM16))
+OPCODE(vmovdqu8_zlokm, vmovdqu8, vmovdqu8_mask, 0, REGARG(ZMM0), REGARG(K7),
+       MEMARG(OPSZ_64))
+OPCODE(vmovdqu8_mkzlo, vmovdqu8, vmovdqu8_mask, 0, MEMARG(OPSZ_64), REGARG(K7),
+       REGARG(ZMM0))
+OPCODE(vmovdqu8_ylok0ylo, vmovdqu8, vmovdqu8_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1))
+OPCODE(vmovdqu8_yhik0ylo, vmovdqu8, vmovdqu8_mask, X64_ONLY, REGARG(YMM16), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vmovdqu8_ylok0yhi, vmovdqu8, vmovdqu8_mask, X64_ONLY, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM16))
+OPCODE(vmovdqu8_ylok7ylo, vmovdqu8, vmovdqu8_mask, 0, REGARG(YMM0), REGARG(K7),
+       REGARG(YMM1))
+OPCODE(vmovdqu8_yhik7ylo, vmovdqu8, vmovdqu8_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       REGARG(YMM0))
+OPCODE(vmovdqu8_ylok7yhi, vmovdqu8, vmovdqu8_mask, X64_ONLY, REGARG(YMM0), REGARG(K7),
+       REGARG(YMM16))
+OPCODE(vmovdqu8_ylokm, vmovdqu8, vmovdqu8_mask, 0, REGARG(YMM0), REGARG(K7),
+       MEMARG(OPSZ_32))
+OPCODE(vmovdqu8_mkylo, vmovdqu8, vmovdqu8_mask, 0, MEMARG(OPSZ_32), REGARG(K7),
+       REGARG(YMM0))
+OPCODE(vmovdqu8_xlok0xlo, vmovdqu8, vmovdqu8_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1))
+OPCODE(vmovdqu8_xhik0xlo, vmovdqu8, vmovdqu8_mask, X64_ONLY, REGARG(XMM16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vmovdqu8_xlok0xhi, vmovdqu8, vmovdqu8_mask, X64_ONLY, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM16))
+OPCODE(vmovdqu8_xlok7xlo, vmovdqu8, vmovdqu8_mask, 0, REGARG(XMM0), REGARG(K7),
+       REGARG(XMM1))
+OPCODE(vmovdqu8_xhik7xlo, vmovdqu8, vmovdqu8_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG(XMM0))
+OPCODE(vmovdqu8_xlok7xhi, vmovdqu8, vmovdqu8_mask, X64_ONLY, REGARG(XMM0), REGARG(K7),
+       REGARG(XMM16))
+OPCODE(vmovdqu8_xlokm, vmovdqu8, vmovdqu8_mask, 0, REGARG(XMM0), REGARG(K7),
+       MEMARG(OPSZ_16))
+OPCODE(vmovdqu8_mkxlo, vmovdqu8, vmovdqu8_mask, 0, MEMARG(OPSZ_16), REGARG(K7),
+       REGARG(XMM0))
+OPCODE(vmovdqu16_zlok0zlo, vmovdqu16, vmovdqu16_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1))
+OPCODE(vmovdqu16_zhik0zlo, vmovdqu16, vmovdqu16_mask, X64_ONLY, REGARG(ZMM16), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vmovdqu16_zlok0zhi, vmovdqu16, vmovdqu16_mask, X64_ONLY, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM16))
+OPCODE(vmovdqu16_zlok7zlo, vmovdqu16, vmovdqu16_mask, 0, REGARG(ZMM0), REGARG(K7),
+       REGARG(ZMM1))
+OPCODE(vmovdqu16_zhik7zlo, vmovdqu16, vmovdqu16_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       REGARG(ZMM0))
+OPCODE(vmovdqu16_zlok7zhi, vmovdqu16, vmovdqu16_mask, X64_ONLY, REGARG(ZMM0), REGARG(K7),
+       REGARG(ZMM16))
+OPCODE(vmovdqu16_zlokm, vmovdqu16, vmovdqu16_mask, 0, REGARG(ZMM0), REGARG(K7),
+       MEMARG(OPSZ_64))
+OPCODE(vmovdqu16_mkzlo, vmovdqu16, vmovdqu16_mask, 0, MEMARG(OPSZ_64), REGARG(K7),
+       REGARG(ZMM0))
+OPCODE(vmovdqu16_ylok0ylo, vmovdqu16, vmovdqu16_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1))
+OPCODE(vmovdqu16_yhik0ylo, vmovdqu16, vmovdqu16_mask, X64_ONLY, REGARG(YMM16), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vmovdqu16_ylok0yhi, vmovdqu16, vmovdqu16_mask, X64_ONLY, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM16))
+OPCODE(vmovdqu16_ylok7ylo, vmovdqu16, vmovdqu16_mask, 0, REGARG(YMM0), REGARG(K7),
+       REGARG(YMM1))
+OPCODE(vmovdqu16_yhik7ylo, vmovdqu16, vmovdqu16_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       REGARG(YMM0))
+OPCODE(vmovdqu16_ylok7yhi, vmovdqu16, vmovdqu16_mask, X64_ONLY, REGARG(YMM0), REGARG(K7),
+       REGARG(YMM16))
+OPCODE(vmovdqu16_ylokm, vmovdqu16, vmovdqu16_mask, 0, REGARG(YMM0), REGARG(K7),
+       MEMARG(OPSZ_32))
+OPCODE(vmovdqu16_mkylo, vmovdqu16, vmovdqu16_mask, 0, MEMARG(OPSZ_32), REGARG(K7),
+       REGARG(YMM0))
+OPCODE(vmovdqu16_xlok0xlo, vmovdqu16, vmovdqu16_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1))
+OPCODE(vmovdqu16_xhik0xlo, vmovdqu16, vmovdqu16_mask, X64_ONLY, REGARG(XMM16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vmovdqu16_xlok0xhi, vmovdqu16, vmovdqu16_mask, X64_ONLY, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM16))
+OPCODE(vmovdqu16_xlok7xlo, vmovdqu16, vmovdqu16_mask, 0, REGARG(XMM0), REGARG(K7),
+       REGARG(XMM1))
+OPCODE(vmovdqu16_xhik7xlo, vmovdqu16, vmovdqu16_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG(XMM0))
+OPCODE(vmovdqu16_xlok7xhi, vmovdqu16, vmovdqu16_mask, X64_ONLY, REGARG(XMM0), REGARG(K7),
+       REGARG(XMM16))
+OPCODE(vmovdqu16_xlokm, vmovdqu16, vmovdqu16_mask, 0, REGARG(XMM0), REGARG(K7),
+       MEMARG(OPSZ_16))
+OPCODE(vmovdqu16_mkxlo, vmovdqu16, vmovdqu16_mask, 0, MEMARG(OPSZ_16), REGARG(K7),
+       REGARG(XMM0))
+OPCODE(vmovdqu32_zlok0zlo, vmovdqu32, vmovdqu32_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1))
+OPCODE(vmovdqu32_zhik0zlo, vmovdqu32, vmovdqu32_mask, X64_ONLY, REGARG(ZMM16), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vmovdqu32_zlok0zhi, vmovdqu32, vmovdqu32_mask, X64_ONLY, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM16))
+OPCODE(vmovdqu32_zlok7zlo, vmovdqu32, vmovdqu32_mask, 0, REGARG(ZMM0), REGARG(K7),
+       REGARG(ZMM1))
+OPCODE(vmovdqu32_zhik7zlo, vmovdqu32, vmovdqu32_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       REGARG(ZMM0))
+OPCODE(vmovdqu32_zlok7zhi, vmovdqu32, vmovdqu32_mask, X64_ONLY, REGARG(ZMM0), REGARG(K7),
+       REGARG(ZMM16))
+OPCODE(vmovdqu32_zlokm, vmovdqu32, vmovdqu32_mask, 0, REGARG(ZMM0), REGARG(K7),
+       MEMARG(OPSZ_64))
+OPCODE(vmovdqu32_mkzlo, vmovdqu32, vmovdqu32_mask, 0, MEMARG(OPSZ_64), REGARG(K7),
+       REGARG(ZMM0))
+OPCODE(vmovdqu32_ylok0ylo, vmovdqu32, vmovdqu32_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1))
+OPCODE(vmovdqu32_yhik0ylo, vmovdqu32, vmovdqu32_mask, X64_ONLY, REGARG(YMM16), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vmovdqu32_ylok0yhi, vmovdqu32, vmovdqu32_mask, X64_ONLY, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM16))
+OPCODE(vmovdqu32_ylok7ylo, vmovdqu32, vmovdqu32_mask, 0, REGARG(YMM0), REGARG(K7),
+       REGARG(YMM1))
+OPCODE(vmovdqu32_yhik7ylo, vmovdqu32, vmovdqu32_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       REGARG(YMM0))
+OPCODE(vmovdqu32_ylok7yhi, vmovdqu32, vmovdqu32_mask, X64_ONLY, REGARG(YMM0), REGARG(K7),
+       REGARG(YMM16))
+OPCODE(vmovdqu32_ylokm, vmovdqu32, vmovdqu32_mask, 0, REGARG(YMM0), REGARG(K7),
+       MEMARG(OPSZ_32))
+OPCODE(vmovdqu32_mkylo, vmovdqu32, vmovdqu32_mask, 0, MEMARG(OPSZ_32), REGARG(K7),
+       REGARG(YMM0))
+OPCODE(vmovdqu32_xlok0xlo, vmovdqu32, vmovdqu32_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1))
+OPCODE(vmovdqu32_xhik0xlo, vmovdqu32, vmovdqu32_mask, X64_ONLY, REGARG(XMM16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vmovdqu32_xlok0xhi, vmovdqu32, vmovdqu32_mask, X64_ONLY, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM16))
+OPCODE(vmovdqu32_xlok7xlo, vmovdqu32, vmovdqu32_mask, 0, REGARG(XMM0), REGARG(K7),
+       REGARG(XMM1))
+OPCODE(vmovdqu32_xhik7xlo, vmovdqu32, vmovdqu32_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG(XMM0))
+OPCODE(vmovdqu32_xlok7xhi, vmovdqu32, vmovdqu32_mask, X64_ONLY, REGARG(XMM0), REGARG(K7),
+       REGARG(XMM16))
+OPCODE(vmovdqu32_xlokm, vmovdqu32, vmovdqu32_mask, 0, REGARG(XMM0), REGARG(K7),
+       MEMARG(OPSZ_16))
+OPCODE(vmovdqu32_mkxlo, vmovdqu32, vmovdqu32_mask, 0, MEMARG(OPSZ_16), REGARG(K7),
+       REGARG(XMM0))
+OPCODE(vmovdqu64_zlok0zlo, vmovdqu64, vmovdqu64_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1))
+OPCODE(vmovdqu64_zhik0zlo, vmovdqu64, vmovdqu64_mask, X64_ONLY, REGARG(ZMM16), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vmovdqu64_zlok0zhi, vmovdqu64, vmovdqu64_mask, X64_ONLY, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM16))
+OPCODE(vmovdqu64_zlok7zlo, vmovdqu64, vmovdqu64_mask, 0, REGARG(ZMM0), REGARG(K7),
+       REGARG(ZMM1))
+OPCODE(vmovdqu64_zhik7zlo, vmovdqu64, vmovdqu64_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       REGARG(ZMM0))
+OPCODE(vmovdqu64_zlok7zhi, vmovdqu64, vmovdqu64_mask, X64_ONLY, REGARG(ZMM0), REGARG(K7),
+       REGARG(ZMM16))
+OPCODE(vmovdqu64_zlokm, vmovdqu64, vmovdqu64_mask, 0, REGARG(ZMM0), REGARG(K7),
+       MEMARG(OPSZ_64))
+OPCODE(vmovdqu64_mkzlo, vmovdqu64, vmovdqu64_mask, 0, MEMARG(OPSZ_64), REGARG(K7),
+       REGARG(ZMM0))
+OPCODE(vmovdqu64_ylok0ylo, vmovdqu64, vmovdqu64_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1))
+OPCODE(vmovdqu64_yhik0ylo, vmovdqu64, vmovdqu64_mask, X64_ONLY, REGARG(YMM16), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vmovdqu64_ylok0yhi, vmovdqu64, vmovdqu64_mask, X64_ONLY, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM16))
+OPCODE(vmovdqu64_ylok7ylo, vmovdqu64, vmovdqu64_mask, 0, REGARG(YMM0), REGARG(K7),
+       REGARG(YMM1))
+OPCODE(vmovdqu64_yhik7ylo, vmovdqu64, vmovdqu64_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       REGARG(YMM0))
+OPCODE(vmovdqu64_ylok7yhi, vmovdqu64, vmovdqu64_mask, X64_ONLY, REGARG(YMM0), REGARG(K7),
+       REGARG(YMM16))
+OPCODE(vmovdqu64_ylokm, vmovdqu64, vmovdqu64_mask, 0, REGARG(YMM0), REGARG(K7),
+       MEMARG(OPSZ_32))
+OPCODE(vmovdqu64_mkylo, vmovdqu64, vmovdqu64_mask, 0, MEMARG(OPSZ_32), REGARG(K7),
+       REGARG(YMM0))
+OPCODE(vmovdqu64_xlok0xlo, vmovdqu64, vmovdqu64_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1))
+OPCODE(vmovdqu64_xhik0xlo, vmovdqu64, vmovdqu64_mask, X64_ONLY, REGARG(XMM16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vmovdqu64_xlok0xhi, vmovdqu64, vmovdqu64_mask, X64_ONLY, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM16))
+OPCODE(vmovdqu64_xlok7xlo, vmovdqu64, vmovdqu64_mask, 0, REGARG(XMM0), REGARG(K7),
+       REGARG(XMM1))
+OPCODE(vmovdqu64_xhik7xlo, vmovdqu64, vmovdqu64_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG(XMM0))
+OPCODE(vmovdqu64_xlok7xhi, vmovdqu64, vmovdqu64_mask, X64_ONLY, REGARG(XMM0), REGARG(K7),
+       REGARG(XMM16))
+OPCODE(vmovdqu64_xlokm, vmovdqu64, vmovdqu64_mask, 0, REGARG(XMM0), REGARG(K7),
+       MEMARG(OPSZ_16))
+OPCODE(vmovdqu64_mkxlo, vmovdqu64, vmovdqu64_mask, 0, MEMARG(OPSZ_16), REGARG(K7),
+       REGARG(XMM0))
+OPCODE(vmovss_xlok0ld, vmovss, vmovss_mask, 0, REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0),
+       MEMARG(OPSZ_4))
+OPCODE(vmovsd_xlok0ld, vmovsd, vmovsd_mask, 0, REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0),
+       MEMARG(OPSZ_8))
+OPCODE(vmovss_k0stxlo, vmovss, vmovss_mask, 0, MEMARG(OPSZ_4), REGARG(K0),
+       REGARG_PARTIAL(XMM0, OPSZ_4))
+OPCODE(vmovsd_k0stxlo, vmovsd, vmovsd_mask, 0, MEMARG(OPSZ_8), REGARG(K0),
+       REGARG_PARTIAL(XMM0, OPSZ_8))
+OPCODE(vmovss_xlok7ld, vmovss, vmovss_mask, 0, REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K7),
+       MEMARG(OPSZ_4))
+OPCODE(vmovsd_xlok7ld, vmovsd, vmovsd_mask, 0, REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K7),
+       MEMARG(OPSZ_8))
+OPCODE(vmovss_k7stxlo, vmovss, vmovss_mask, 0, MEMARG(OPSZ_4), REGARG(K7),
+       REGARG_PARTIAL(XMM0, OPSZ_4))
+OPCODE(vmovsd_k7stxlo, vmovsd, vmovsd_mask, 0, MEMARG(OPSZ_8), REGARG(K7),
+       REGARG_PARTIAL(XMM0, OPSZ_8))
+OPCODE(vmovss_xhik7ld, vmovss, vmovss_mask, X64_ONLY, REGARG_PARTIAL(XMM16, OPSZ_4),
+       REGARG(K7), MEMARG(OPSZ_4))
+OPCODE(vmovsd_xhik7ld, vmovsd, vmovsd_mask, X64_ONLY, REGARG_PARTIAL(XMM16, OPSZ_8),
+       REGARG(K7), MEMARG(OPSZ_8))
+OPCODE(vmovss_k7stxhi, vmovss, vmovss_mask, X64_ONLY, MEMARG(OPSZ_4), REGARG(K7),
+       REGARG_PARTIAL(XMM16, OPSZ_4))
+OPCODE(vmovsd_k7stxhi, vmovsd, vmovsd_mask, X64_ONLY, MEMARG(OPSZ_8), REGARG(K7),
+       REGARG_PARTIAL(XMM16, OPSZ_8))
 /* TODO i#1312: Add missing instructions. */

--- a/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
@@ -1,0 +1,58 @@
+/* **********************************************************
+ * Copyright (c) 2019 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* AVX-512 EVEX instructions with 1 destination, 1 mask and 2 sources. */
+OPCODE(vmovss_xlok0xlo, vmovss, vmovss_NDS_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM1, OPSZ_12), REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vmovss_xhik0xlo, vmovss, vmovss_NDS_mask, X64_ONLY, REGARG(XMM16), REGARG(K0),
+       REGARG_PARTIAL(XMM1, OPSZ_12), REGARG_PARTIAL(XMM0, OPSZ_4))
+OPCODE(vmovss_xlok0xhi, vmovss, vmovss_NDS_mask, X64_ONLY, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM1, OPSZ_12), REGARG_PARTIAL(XMM16, OPSZ_4))
+OPCODE(vmovss_xlok7xlo, vmovss, vmovss_NDS_mask, 0, REGARG(XMM0), REGARG(K7),
+       REGARG_PARTIAL(XMM1, OPSZ_12), REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vmovss_xhik7xlo, vmovss, vmovss_NDS_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG_PARTIAL(XMM1, OPSZ_12), REGARG_PARTIAL(XMM0, OPSZ_4))
+OPCODE(vmovss_xlok7xhi, vmovss, vmovss_NDS_mask, X64_ONLY, REGARG(XMM0), REGARG(K7),
+       REGARG_PARTIAL(XMM1, OPSZ_12), REGARG_PARTIAL(XMM16, OPSZ_4))
+OPCODE(vmovsd_xlok0xlo, vmovsd, vmovsd_NDS_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vmovsd_xhik0xlo, vmovsd, vmovsd_NDS_mask, X64_ONLY, REGARG(XMM16), REGARG(K0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), REGARG_PARTIAL(XMM0, OPSZ_8))
+OPCODE(vmovsd_xlok0xhi, vmovsd, vmovsd_NDS_mask, X64_ONLY, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), REGARG_PARTIAL(XMM16, OPSZ_8))
+OPCODE(vmovsd_xlok7xlo, vmovsd, vmovsd_NDS_mask, 0, REGARG(XMM0), REGARG(K7),
+       REGARG_PARTIAL(XMM1, OPSZ_8), REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vmovsd_xhik7xlo, vmovsd, vmovsd_NDS_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG_PARTIAL(XMM1, OPSZ_8), REGARG_PARTIAL(XMM0, OPSZ_8))
+OPCODE(vmovsd_xlok7xhi, vmovsd, vmovsd_NDS_mask, X64_ONLY, REGARG(XMM0), REGARG(K7),
+       REGARG_PARTIAL(XMM1, OPSZ_8), REGARG_PARTIAL(XMM16, OPSZ_8))
+/* TODO i#1312: Add missing instructions. */


### PR DESCRIPTION
Adds OP_vmovdqu8, OP_vmovdqu16, OP_vmovdqu32, OP_vmovdqu64, OP_vmovdqa32,
OP_vmovdqa64, OP_vmovss, OP_vmovsd.

Adds tests for above.

Issue: #1312