### PR TITLE
i#3566 w^x: Work around IMA overhead

### DIFF
--- a/core/heap.c
+++ b/core/heap.c
@@ -1598,8 +1598,8 @@ vmm_heap_commit(vm_addr_t p, size_t size, uint prot, heap_error_code_t *error_co
              * execution from regions allocated executable, not changed to executable.
              * There is a downside: IMA policies can cause a significant (~5s) delay
              * while a hash is computed of our vmcode region on the first +x mmap.
-             * TODO i#3566: Find a workaround for this IMA slowdown for kernels where
-             * IMA is enabled.
+             * Today os_create_memory_file() does a temporary +x mmap for us, avoiding
+             * any cost here.
              */
             size_t map_size = size;
             size_t map_offs = p - vmh->start_addr;


### PR DESCRIPTION
Adds a workaround for the large latency from IMA hashing our entire
-vm_size vmcode region: it computes the hash just once, so we
temporarily map our memfd while it's tiny before we set the size.
This is not guaranteed to work for future IMA implementations,
however.

Issue: #3566