### PR TITLE
i#3615: Handle copy!=final when encoding instr_t immed

### DIFF
--- a/core/arch/x86/decode_private.h
+++ b/core/arch/x86/decode_private.h
@@ -303,7 +303,7 @@ struct _decode_info_t {
     ushort immed_shift;
     ptr_int_t immed;
     ptr_int_t immed2; /* this additional field could be 32-bit on all platforms */
-    /* These fields are only used when decoding rip-relative data refs */
+    /* These fields are used for decoding/encoding rip-relative data refs. */
     byte *start_pc;
     byte *final_pc;
     uint len;

--- a/core/arch/x86/encode.c
+++ b/core/arch/x86/encode.c
@@ -1516,8 +1516,8 @@ encode_immed(decode_info_t *di, byte *pc)
              */
             val = di->immed - (len + di->modrm);
         } else if (di->immed_pc_rel_offs) {
-            /* this code means that the immed holds not the absolute pc but
-             * the offset
+            /* This code means that the immed currently holds not the absolute pc but
+             * the offset, but wants to hold the absolute pc.
              */
             size = di->size_immed; /* TYPE_I put real size there */
             CLIENT_ASSERT((size == OPSZ_4_short2 && !TEST(PREFIX_DATA, di->prefixes)) ||
@@ -1528,7 +1528,7 @@ encode_immed(decode_info_t *di, byte *pc)
              * HACK: di->modrm was set with the number of instruction bytes
              * prior to this immed
              */
-            val = di->immed + (ptr_int_t)pc - di->modrm;
+            val = di->immed + (ptr_int_t)(pc - di->start_pc + di->final_pc) - di->modrm;
             if (di->immed_shift > 0)
                 val >>= di->immed_shift;
 #ifdef X64

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3699,9 +3699,11 @@ if (X64 AND NOT AARCH64) # FIXME i#1569: get working on AArch64
   torunonly(low4GB security-common.selfmod security-common/selfmod.c
     "-heap_in_lower_4GB -reachable_heap" "")
   if (UNIX AND NOT APPLE)
-    # XXX i#3556: NYI on Windows and Mac.
-    torunonly(w_xor_x security-common.selfmod security-common/selfmod.c
+    # XXX i#3556: NYI on Windows, Mac, and non-x86 (and not supported on 32-bit).
+    torunonly(w-x.selfmod security-common.selfmod security-common/selfmod.c
       "-satisfy_w_xor_x" "")
+    torunonly_ci(w-x.reachability ${ci_shared_app} client.reachability.dll
+      client-interface/reachability.c "" "-satisfy_w_xor_x" "")
   endif ()
 endif (X64 AND NOT AARCH64)
 


### PR DESCRIPTION
Adds proper handling of encoding an instr_t immed to a copy.
Adds a test: client.reachability with -satisfy_w_xor_x.

Issue: #3556
Fixes #3615