### PR TITLE
i#1312 AVX-512 support: Add instructions vmovlpd, vmovsldup, vmovhps, vmovhpd, vmovshdup.

### DIFF
--- a/core/arch/decode.h
+++ b/core/arch/decode.h
@@ -395,7 +395,7 @@ enum {
                               */
     OPSZ_half_16_vex32_evex64, /* 64 bits, but can be half of XMM register;
                                 * if evex.L then is 256 bits (YMM or memory);
-                                * if evex.L' then is 512 bits (ZMM or memory)
+                                * if evex.L' then is 512 bits (ZMM or memory).
                                 */
     OPSZ_SUBREG_START = OPSZ_1_of_4,
     OPSZ_SUBREG_END = OPSZ_half_16_vex32_evex64,

--- a/core/arch/decode.h
+++ b/core/arch/decode.h
@@ -393,9 +393,12 @@ enum {
     OPSZ_half_16_vex32,      /* half of 128 bits (XMM or memory);
                               * if vex.L then is half of 256 bits (YMM or memory).
                               */
-    /* XXX i#1312: Augment with new types specific to AVX-512. */
+    OPSZ_half_16_vex32_evex64, /* 64 bits, but can be half of XMM register;
+                                * if evex.L then is 256 bits (YMM or memory);
+                                * if evex.L' then is 512 bits (ZMM or memory)
+                                */
     OPSZ_SUBREG_START = OPSZ_1_of_4,
-    OPSZ_SUBREG_END = OPSZ_half_16_vex32,
+    OPSZ_SUBREG_END = OPSZ_half_16_vex32_evex64,
     OPSZ_LAST_ENUM, /* note last is NOT inclusive */
 };
 

--- a/core/arch/decode_shared.c
+++ b/core/arch/decode_shared.c
@@ -162,6 +162,7 @@ const char *const size_names[] = {
     "OPSZ_8_of_16_vex32",
     "OPSZ_16_of_32",
     "OPSZ_half_16_vex32",
+    "OPSZ_half_16_vex32_evex64",
 };
 
 /* point at this when you need a canonical invalid instr

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -1180,17 +1180,17 @@ read_instruction(byte *pc, byte *orig_pc, const instr_info_t **ret_info,
         if (!TEST(REQUIRES_VEX, info->flags))
             info = NULL; /* invalid encoding */
         else if (TEST(REQUIRES_VEX_L_0, info->flags) && TEST(PREFIX_VEX_L, di->prefixes))
-            info = NULL;
+            info = NULL; /* invalid encoding */
     } else if (info != NULL && !di->vex_encoded && TEST(REQUIRES_VEX, info->flags)) {
         info = NULL; /* invalid encoding */
     } else if (info != NULL && di->evex_encoded) {
         if (!TEST(REQUIRES_EVEX, info->flags))
             info = NULL; /* invalid encoding */
         else if (TEST(REQUIRES_VEX_L_0, info->flags) && TEST(PREFIX_VEX_L, di->prefixes))
-            info = NULL;
+            info = NULL; /* invalid encoding */
         else if (TEST(REQUIRES_EVEX_LL_0, info->flags) &&
                  TEST(PREFIX_EVEX_LL, di->prefixes))
-            info = NULL;
+            info = NULL; /* invalid encoding */
     } else if (info != NULL && !di->evex_encoded && TEST(REQUIRES_EVEX, info->flags))
         info = NULL; /* invalid encoding */
     /* XXX: not currently marking these cases as invalid instructions:

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -258,8 +258,14 @@ resolve_variable_size(decode_info_t *di /*IN: x86_mode, prefixes*/, opnd_size_t 
         return (TEST(PREFIX_EVEX_LL, di->prefixes)
                     ? OPSZ_64
                     : (TEST(PREFIX_VEX_L, di->prefixes) ? OPSZ_32 : OPSZ_16));
+
     case OPSZ_half_16_vex32: return (TEST(PREFIX_VEX_L, di->prefixes) ? OPSZ_16 : OPSZ_8);
+    case OPSZ_half_16_vex32_evex64:
+        return (TEST(PREFIX_EVEX_LL, di->prefixes)
+                    ? OPSZ_32
+                    : (TEST(PREFIX_VEX_L, di->prefixes) ? OPSZ_16 : OPSZ_8));
     }
+
     return sz;
 }
 
@@ -282,6 +288,7 @@ expand_subreg_size(opnd_size_t sz)
     case OPSZ_16_of_32: return OPSZ_32;
     case OPSZ_8_of_16_vex32:
     case OPSZ_half_16_vex32: return OPSZ_16_vex32;
+    case OPSZ_half_16_vex32_evex64: return OPSZ_16_vex32_evex64;
     }
     return sz;
 }
@@ -1179,9 +1186,11 @@ read_instruction(byte *pc, byte *orig_pc, const instr_info_t **ret_info,
     } else if (info != NULL && di->evex_encoded) {
         if (!TEST(REQUIRES_EVEX, info->flags))
             info = NULL; /* invalid encoding */
-        /* XXX i#1312: This might need checks for REQUIRES_EVEX_L_0 and
-         * REQUIRES_EVEX_LL_0.
-         */
+        else if (TEST(REQUIRES_VEX_L_0, info->flags) && TEST(PREFIX_VEX_L, di->prefixes))
+            info = NULL;
+        else if (TEST(REQUIRES_EVEX_LL_0, info->flags) &&
+                 TEST(PREFIX_EVEX_LL, di->prefixes))
+            info = NULL;
     } else if (info != NULL && !di->evex_encoded && TEST(REQUIRES_EVEX, info->flags))
         info = NULL; /* invalid encoding */
     /* XXX: not currently marking these cases as invalid instructions:

--- a/core/arch/x86/decode_private.h
+++ b/core/arch/x86/decode_private.h
@@ -272,6 +272,9 @@ enum {
  * is invalid if encoded using evex.
  */
 #define REQUIRES_EVEX 0x01000
+/* Instr must be encoded with EVEX.LL=0.  If EVEX.LL=1 this is an invalid instr.
+ */
+#define REQUIRES_EVEX_LL_0 0x02000
 
 struct _decode_info_t {
     uint opcode;

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1498,7 +1498,7 @@ const instr_info_t * const op_instr[] =
 #define Wed TYPE_W, OPSZ_16_vex32_evex64
 #define Vex TYPE_V, OPSZ_16_vex32_evex64
 #define Wex TYPE_W, OPSZ_16_vex32_evex64
-#define Weh_x TYPE_W, OPSZ_half_16_vex32_evex64
+#define Wh_e TYPE_W, OPSZ_half_16_vex32_evex64
 
 /* my own codes
  * size m = 32 or 16 bit depending on addr size attribute
@@ -6712,7 +6712,7 @@ const instr_info_t evex_W_extensions[][2] = {
   },
   {    /* evex_W_ext 19 */
     {INVALID, 0xf20f1210,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-    {OP_vmovddup, 0xf20f1250, "vmovddup", Ved, xx, KEb, Weh_x, xx, mrm|evex, x, END_LIST},
+    {OP_vmovddup, 0xf20f1250, "vmovddup", Ved, xx, KEb, Wh_e, xx, mrm|evex, x, END_LIST},
   },
   {    /* evex_W_ext 20 */
     {OP_vmovhps, 0x0f1610, "vmovhps", Vq_dq, xx, Hq_dq, Wq_dq, xx, mrm|evex|reqL0|reqLL0, x, tevexw[21][0]}, /*"vmovlhps" if reg-reg */

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1498,6 +1498,7 @@ const instr_info_t * const op_instr[] =
 #define Wed TYPE_W, OPSZ_16_vex32_evex64
 #define Vex TYPE_V, OPSZ_16_vex32_evex64
 #define Wex TYPE_W, OPSZ_16_vex32_evex64
+#define Weh_x TYPE_W, OPSZ_half_16_vex32_evex64
 
 /* my own codes
  * size m = 32 or 16 bit depending on addr size attribute
@@ -2809,13 +2810,13 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_movlpd, 0x660f1210, "movlpd", Vq_dq, xx, Mq, xx, xx, mrm, x, tpe[3][2]},
     {OP_movddup, 0xf20f1210, "movddup", Vpd, xx, Wq_dq, xx, xx, mrm, x, END_LIST},
     {OP_vmovlps,    0x0f1210, "vmovlps", Vq_dq, xx, Hq_dq, Wq_dq, xx, mrm|vex|reqL0, x, tpe[3][4]}, /*"vmovhlps" if reg-reg */
-    {OP_vmovsldup,0xf30f1210, "vmovsldup", Vvs, xx, Wvs, xx, xx, mrm|vex, x, END_LIST},
+    {OP_vmovsldup,0xf30f1210, "vmovsldup", Vvs, xx, Wvs, xx, xx, mrm|vex, x, tevexw[18][0]},
     {OP_vmovlpd,  0x660f1210, "vmovlpd", Vq_dq, xx, Hq_dq, Mq, xx, mrm|vex, x, tpe[3][6]},
-    {OP_vmovddup, 0xf20f1210, "vmovddup", Vvd, xx, Wh_x, xx, xx, mrm|vex, x, END_LIST},
+    {OP_vmovddup, 0xf20f1210, "vmovddup", Vvd, xx, Wh_x, xx, xx, mrm|vex, x, tevexw[19][1]},
     {EVEX_W_EXT, 0x0f1210, "(evex_W ext 14)", xx, xx, xx, xx, xx, mrm|evex, x, 14},
-    {INVALID, 0xf30f1210, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f1210, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf20f1210, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0xf30f1210, "(evex_W ext 18)", xx, xx, xx, xx, xx, mrm|evex, x, 18},
+    {EVEX_W_EXT, 0x660f1210, "(evex_W ext 16)", xx, xx, xx, xx, xx, mrm|evex, x, 16},
+    {EVEX_W_EXT, 0xf20f1210, "(evex_W ext 19)", xx, xx, xx, xx, xx, mrm|evex, x, 19},
   },
   /* prefix extension 3 */
   {
@@ -2825,11 +2826,11 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {OP_vmovlps, 0x0f1310, "vmovlps", Mq, xx, Vq_dq, xx, xx, mrm|vex, x, tevexw[14][0]},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vmovlpd, 0x660f1310, "vmovlpd", Mq, xx, Vq_dq, xx, xx, mrm|vex, x, END_LIST},
+    {OP_vmovlpd, 0x660f1310, "vmovlpd", Mq, xx, Vq_dq, xx, xx, mrm|vex, x, tevexw[16][1]},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {EVEX_W_EXT, 0x0f1310, "(evex_W ext 15)", xx, xx, xx, xx, xx, mrm|evex, x, 15},
     {INVALID, 0xf30f1310, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f1310, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x660f1310, "(evex_W ext 17)", xx, xx, xx, xx, xx, mrm|evex, x, 17},
     {INVALID, 0xf20f1310, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 4 */
@@ -2875,13 +2876,12 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_movhpd, 0x660f1610, "movhpd", Vq_dq, xx, Mq, xx, xx, mrm, x, tpe[7][2]},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {OP_vmovhps, 0x0f1610, "vmovhps", Vq_dq, xx, Hq_dq, Wq_dq, xx, mrm|vex|reqL0, x, tpe[7][4]}, /*"vmovlhps" if reg-reg */
-    {OP_vmovshdup, 0xf30f1610, "vmovshdup", Vvs, xx, Wvs, xx, xx, mrm|vex, x, END_LIST},
+    {OP_vmovshdup, 0xf30f1610, "vmovshdup", Vvs, xx, Wvs, xx, xx, mrm|vex, x, tevexw[24][0]},
     {OP_vmovhpd, 0x660f1610, "vmovhpd", Vq_dq, xx, Hq_dq, Mq, xx, mrm|vex|reqL0, x, tpe[7][6]},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    /* TODO i#1312: Support AVX-512. */
-    {INVALID,   0x0f1610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf30f1610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f1610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x0f1610, "(evex_W ext 20)", xx, xx, xx, xx, xx, mrm|evex, x, 20},
+    {EVEX_W_EXT, 0xf30f1610, "(evex_W ext 24)", xx, xx, xx, xx, xx, mrm|evex, x, 24},
+    {EVEX_W_EXT, 0x660f1610, "(evex_W ext 22)", xx, xx, xx, xx, xx, mrm|evex, x, 22},
     {INVALID, 0xf20f1610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 7 */
@@ -2890,14 +2890,13 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {OP_movhpd, 0x660f1710, "movhpd", Mq, xx, Vq_dq, xx, xx, mrm, x, END_LIST},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vmovhps, 0x0f1710, "vmovhps", Mq, xx, Vq_dq, xx, xx, mrm|vex|reqL0, x, END_LIST},
+    {OP_vmovhps, 0x0f1710, "vmovhps", Mq, xx, Vq_dq, xx, xx, mrm|vex|reqL0, x, tevexw[20][0]},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vmovhpd, 0x660f1710, "vmovhpd", Mq, xx, Vq_dq, xx, xx, mrm|vex|reqL0, x, END_LIST},
+    {OP_vmovhpd, 0x660f1710, "vmovhpd", Mq, xx, Vq_dq, xx, xx, mrm|vex|reqL0, x, tevexw[22][1]},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    /* TODO i#1312: Support AVX-512. */
-    {INVALID,   0x0f1710, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x0f1710, "(evex_W ext 21)", xx, xx, xx, xx, xx, mrm|evex, x, 21},
     {INVALID, 0xf30f1710, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f1710, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x660f1710, "(evex_W ext 23)", xx, xx, xx, xx, xx, mrm|evex, x, 23},
     {INVALID, 0xf20f1710, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 8 */
@@ -6692,12 +6691,48 @@ const instr_info_t evex_W_extensions[][2] = {
     {OP_vmovdqu64, 0xf30f7f50,"vmovdqu64",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
   },
   {    /* evex_W_ext 14 */
-    {OP_vmovlps, 0x0f1210, "vmovlps", Vq_dq, xx, Hq_dq, Wq_dq, xx, mrm|evex|reqL0, x, tevexw[15][0]}, /*"vmovhlps" if reg-reg */
+    {OP_vmovlps, 0x0f1210, "vmovlps", Vq_dq, xx, Hq_dq, Wq_dq, xx, mrm|evex|reqL0|reqLL0, x, tevexw[15][0]}, /*"vmovhlps" if reg-reg */
     {INVALID, 0x0f1250,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
   },
   {    /* evex_W_ext 15 */
     {OP_vmovlps, 0x0f1310, "vmovlps", Mq, xx, Vq_dq, xx, xx, mrm|evex, x, END_LIST},
     {INVALID, 0x0f1350,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+  },
+  {    /* evex_W_ext 16 */
+    {INVALID, 0x660f1210,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+    {OP_vmovlpd, 0x660f1250, "vmovlpd", Vq_dq, xx, Hq_dq, Mq, xx, mrm|evex|reqL0|reqLL0, x, tevexw[17][1]},
+  },
+  {    /* evex_W_ext 17 */
+    {INVALID, 0x660f1310,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+    {OP_vmovlpd, 0x660f1350, "vmovlpd", Mq, xx, Vq_dq, xx, xx, mrm|evex, x, END_LIST},
+  },
+  {    /* evex_W_ext 18 */
+    {OP_vmovsldup,0xf30f1210, "vmovsldup", Ves, xx, KEw, Wes, xx, mrm|evex, x, END_LIST},
+    {INVALID, 0xf30f1250,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+  },
+  {    /* evex_W_ext 19 */
+    {INVALID, 0xf20f1210,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+    {OP_vmovddup, 0xf20f1250, "vmovddup", Ved, xx, KEb, Weh_x, xx, mrm|evex, x, END_LIST},
+  },
+  {    /* evex_W_ext 20 */
+    {OP_vmovhps, 0x0f1610, "vmovhps", Vq_dq, xx, Hq_dq, Wq_dq, xx, mrm|evex|reqL0|reqLL0, x, tevexw[21][0]}, /*"vmovlhps" if reg-reg */
+    {INVALID, 0x0f1650,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+  },
+  {    /* evex_W_ext 21 */
+    {OP_vmovhps, 0x0f1710, "vmovhps", Mq, xx, Vq_dq, xx, xx, mrm|evex|reqL0|reqLL0, x, END_LIST},
+    {INVALID, 0x0f1750,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+  },
+  {    /* evex_W_ext 22 */
+    {INVALID, 0x660f1610,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+    {OP_vmovhpd, 0x660f1650, "vmovhpd", Vq_dq, xx, Hq_dq, Mq, xx, mrm|evex|reqL0|reqLL0, x, tevexw[23][1]},
+  },
+  {    /* evex_W_ext 23 */
+    {INVALID, 0x660f1710,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+    {OP_vmovhpd, 0x660f1750, "vmovhpd", Mq, xx, Vq_dq, xx, xx, mrm|evex|reqL0|reqLL0, x, END_LIST},
+  },
+  {    /* evex_W_ext 24 */
+    {OP_vmovshdup, 0xf30f1610, "vmovshdup", Ves, xx, KEw, Wes, xx, mrm|evex, x, END_LIST},
+    {INVALID, 0xf30f1650,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
   },
 };
 

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1496,8 +1496,8 @@ const instr_info_t * const op_instr[] =
 #define Ved TYPE_V, OPSZ_16_vex32_evex64
 #define Wes TYPE_W, OPSZ_16_vex32_evex64
 #define Wed TYPE_W, OPSZ_16_vex32_evex64
-#define Vex TYPE_V, OPSZ_16_vex32_evex64
-#define Wex TYPE_W, OPSZ_16_vex32_evex64
+#define Ve TYPE_V, OPSZ_16_vex32_evex64
+#define We TYPE_W, OPSZ_16_vex32_evex64
 #define Wh_e TYPE_W, OPSZ_half_16_vex32_evex64
 
 /* my own codes
@@ -6667,28 +6667,28 @@ const instr_info_t evex_W_extensions[][2] = {
     {OP_vmovapd, 0x660f2950,"vmovapd", Wed,xx,KEd,Ved,xx,mrm|evex,x,END_LIST},
   },
   {    /* evex_W_ext 8 */
-    {OP_vmovdqa32, 0x660f6f10,"vmovdqa32",Vex,xx,KEw,Wex,xx,mrm|evex,x,tevexw[9][0]},
-    {OP_vmovdqa64, 0x660f6f50,"vmovdqa64",Vex,xx,KEw,Wex,xx,mrm|evex,x,tevexw[9][1]},
+    {OP_vmovdqa32, 0x660f6f10,"vmovdqa32",Ve,xx,KEw,We,xx,mrm|evex,x,tevexw[9][0]},
+    {OP_vmovdqa64, 0x660f6f50,"vmovdqa64",Ve,xx,KEw,We,xx,mrm|evex,x,tevexw[9][1]},
   },
   {    /* evex_W_ext 9 */
-    {OP_vmovdqa32, 0x660f7f10,"vmovdqa32",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
-    {OP_vmovdqa64, 0x660f7f50,"vmovdqa64",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
+    {OP_vmovdqa32, 0x660f7f10,"vmovdqa32",We,xx,KEw,Ve,xx,mrm|evex,x,END_LIST},
+    {OP_vmovdqa64, 0x660f7f50,"vmovdqa64",We,xx,KEw,Ve,xx,mrm|evex,x,END_LIST},
   },
   {    /* evex_W_ext 10 */
-    {OP_vmovdqu8, 0xf20f6f10,"vmovdqu8",Vex,xx,KEw,Wex,xx,mrm|evex,x,tevexw[12][0]},
-    {OP_vmovdqu16, 0xf20f6f50,"vmovdqu16",Vex,xx,KEw,Wex,xx,mrm|evex,x,tevexw[12][1]},
+    {OP_vmovdqu8, 0xf20f6f10,"vmovdqu8",Ve,xx,KEw,We,xx,mrm|evex,x,tevexw[12][0]},
+    {OP_vmovdqu16, 0xf20f6f50,"vmovdqu16",Ve,xx,KEw,We,xx,mrm|evex,x,tevexw[12][1]},
   },
   {    /* evex_W_ext 11 */
-    {OP_vmovdqu32, 0xf30f6f10,"vmovdqu32",Vex,xx,KEw,Wex,xx,mrm|evex,x,tevexw[13][0]},
-    {OP_vmovdqu64, 0xf30f6f50,"vmovdqu64",Vex,xx,KEw,Wex,xx,mrm|evex,x,tevexw[13][1]},
+    {OP_vmovdqu32, 0xf30f6f10,"vmovdqu32",Ve,xx,KEw,We,xx,mrm|evex,x,tevexw[13][0]},
+    {OP_vmovdqu64, 0xf30f6f50,"vmovdqu64",Ve,xx,KEw,We,xx,mrm|evex,x,tevexw[13][1]},
   },
   {    /* evex_W_ext 12 */
-    {OP_vmovdqu8, 0xf20f7f10,"vmovdqu8",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
-    {OP_vmovdqu16, 0xf20f7f50,"vmovdqu16",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
+    {OP_vmovdqu8, 0xf20f7f10,"vmovdqu8",We,xx,KEw,Ve,xx,mrm|evex,x,END_LIST},
+    {OP_vmovdqu16, 0xf20f7f50,"vmovdqu16",We,xx,KEw,Ve,xx,mrm|evex,x,END_LIST},
   },
   {    /* evex_W_ext 13 */
-    {OP_vmovdqu32, 0xf30f7f10,"vmovdqu32",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
-    {OP_vmovdqu64, 0xf30f7f50,"vmovdqu64",Wex,xx,KEw,Vex,xx,mrm|evex,x,END_LIST},
+    {OP_vmovdqu32, 0xf30f7f10,"vmovdqu32",We,xx,KEw,Ve,xx,mrm|evex,x,END_LIST},
+    {OP_vmovdqu64, 0xf30f7f50,"vmovdqu64",We,xx,KEw,Ve,xx,mrm|evex,x,END_LIST},
   },
   {    /* evex_W_ext 14 */
     {OP_vmovlps, 0x0f1210, "vmovlps", Vq_dq, xx, Hq_dq, Wq_dq, xx, mrm|evex|reqL0|reqLL0, x, tevexw[15][0]}, /*"vmovhlps" if reg-reg */

--- a/core/arch/x86/encode.c
+++ b/core/arch/x86/encode.c
@@ -882,18 +882,18 @@ reg_size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, reg_
         opnd_size_t expanded = expand_subreg_size(opsize);
         if (expanded == OPSZ_8 &&
             (optype == TYPE_P || optype == TYPE_Q || optype == TYPE_P_MODRM))
-            return (reg >= DR_REG_START_MMX && reg <= DR_REG_STOP_MMX);
+            return (reg >= REG_START_MMX && reg <= REG_STOP_MMX);
         if (expanded == OPSZ_16 &&
             (optype == TYPE_V || optype == TYPE_V_MODRM || optype == TYPE_W ||
              optype == TYPE_H || optype == TYPE_L))
-            return (reg >= DR_REG_START_XMM && reg <= DR_REG_STOP_XMM);
+            return (reg >= REG_START_XMM && reg <= REG_STOP_XMM);
     }
 
     if (opsize == OPSZ_8_of_16_vex32 || opsize == OPSZ_half_16_vex32 ||
         opsize == OPSZ_half_16_vex32_evex64 || optype == TYPE_VSIB) {
-        if (reg >= DR_REG_START_XMM && reg <= DR_REG_STOP_XMM)
+        if (reg >= REG_START_XMM && reg <= REG_STOP_XMM)
             return !TEST(PREFIX_VEX_L, di->prefixes);
-        if (reg >= DR_REG_START_YMM && reg <= DR_REG_STOP_YMM) {
+        if (reg >= REG_START_YMM && reg <= REG_STOP_YMM) {
             di->prefixes |= PREFIX_VEX_L;
             return true;
         }
@@ -904,7 +904,7 @@ reg_size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, reg_
         return false;
     }
     if (opsize == OPSZ_16_of_32) {
-        if (reg >= DR_REG_START_YMM && reg <= DR_REG_STOP_YMM) {
+        if (reg >= REG_START_YMM && reg <= REG_STOP_YMM) {
             /* Set VEX.L since required for some opcodes and the rest don't care */
             di->prefixes |= PREFIX_VEX_L;
             return true;
@@ -917,7 +917,7 @@ reg_size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, reg_
     if (opsize == OPSZ_6_irex10_short4)
         return false; /* no register of size p */
     if (size_ok(di, reg_get_size(reg), resolve_var_reg_size(opsize, true), addr)) {
-        if (reg >= DR_REG_START_YMM && reg <= DR_REG_STOP_YMM) {
+        if (reg >= REG_START_YMM && reg <= REG_STOP_YMM) {
             /* Set VEX.L since required for some opcodes and the rest don't care */
             di->prefixes |= PREFIX_VEX_L;
         } else if (reg >= DR_REG_START_ZMM && reg <= DR_REG_STOP_ZMM) {

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -2266,6 +2266,12 @@
     instr_create_1dst_2src((dc), OP_vmovss, (d), (k), (s))
 #define INSTR_CREATE_vmovsd_mask(dc, d, k, s) \
     instr_create_1dst_2src((dc), OP_vmovsd, (d), (k), (s))
+#define INSTR_CREATE_vmovsldup_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vmovsldup, (d), (k), (s))
+#define INSTR_CREATE_vmovddup_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vmovddup, (d), (k), (s))
+#define INSTR_CREATE_vmovshdup_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vmovshdup, (d), (k), (s))
 /* @} */ /* end doxygen group */
 
 /* 1 destination, 2 sources: 1 explicit, 1 implicit */

--- a/suite/tests/api/ir_x86_2args_avx512_evex.h
+++ b/suite/tests/api/ir_x86_2args_avx512_evex.h
@@ -31,10 +31,12 @@
  */
 
 /* AVX-512 EVEX instructions with 1 destination, and 1 source, no mask. */
-OPCODE(vmovlps_mxlo_evex, vmovlps, vmovlps, VERIFY_EVEX, MEMARG(OPSZ_8),
+OPCODE(vmovlps_mxlo, vmovlps, vmovlps, VERIFY_EVEX, MEMARG(OPSZ_8),
        REGARG_PARTIAL(XMM0, OPSZ_8))
-OPCODE(vmovlps_mxhi_evex, vmovlps, vmovlps, X64_ONLY, MEMARG(OPSZ_8),
-       REGARG_PARTIAL(XMM16, OPSZ_8))
 OPCODE(vmovlps_mxhi, vmovlps, vmovlps, X64_ONLY, MEMARG(OPSZ_8),
+       REGARG_PARTIAL(XMM16, OPSZ_8))
+OPCODE(vmovlpd_mxlo, vmovlpd, vmovlpd, VERIFY_EVEX, MEMARG(OPSZ_8),
+       REGARG_PARTIAL(XMM0, OPSZ_8))
+OPCODE(vmovlpd_mxhi, vmovlpd, vmovlpd, X64_ONLY, MEMARG(OPSZ_8),
        REGARG_PARTIAL(XMM16, OPSZ_8))
 /* TODO i#1312: Add missing instructions. */

--- a/suite/tests/api/ir_x86_3args_avx512_evex.h
+++ b/suite/tests/api/ir_x86_3args_avx512_evex.h
@@ -39,4 +39,20 @@ OPCODE(vmovlps_xhixhim, vmovlps, vmovlps_NDS, X64_ONLY, REGARG_PARTIAL(XMM16, OP
        REGARG_PARTIAL(XMM17, OPSZ_8), MEMARG(OPSZ_8))
 OPCODE(vmovlps_xhixhixhi, vmovlps, vmovlps_NDS, X64_ONLY, REGARG_PARTIAL(XMM16, OPSZ_8),
        REGARG_PARTIAL(XMM17, OPSZ_8), REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vmovlpd_xloxlom, vmovlpd, vmovlpd_NDS, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+       REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vmovlpd_xhixhim, vmovlpd, vmovlpd_NDS, X64_ONLY, REGARG_PARTIAL(XMM16, OPSZ_8),
+       REGARG_PARTIAL(XMM17, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vmovhps_xloxlom, vmovhps, vmovhps_NDS, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+       REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vmovhps_xloxloxlo, vmovhps, vmovhps_NDS, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+       REGARG_PARTIAL(XMM1, OPSZ_8), REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vmovhps_xhixhim, vmovhps, vmovhps_NDS, X64_ONLY, REGARG_PARTIAL(XMM16, OPSZ_8),
+       REGARG_PARTIAL(XMM17, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vmovhps_xhixhixhi, vmovhps, vmovhps_NDS, X64_ONLY, REGARG_PARTIAL(XMM16, OPSZ_8),
+       REGARG_PARTIAL(XMM17, OPSZ_8), REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vmovhpd_xloxlom, vmovhpd, vmovhpd_NDS, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+       REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vmovhpd_xhixhim, vmovhpd, vmovhpd_NDS, X64_ONLY, REGARG_PARTIAL(XMM16, OPSZ_8),
+       REGARG_PARTIAL(XMM17, OPSZ_8), MEMARG(OPSZ_8))
 /* TODO i#1312: Add missing instructions. */

--- a/suite/tests/api/ir_x86_3args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_3args_avx512_evex_mask.h
@@ -487,4 +487,40 @@ OPCODE(vmovss_k7stxhi, vmovss, vmovss_mask, X64_ONLY, MEMARG(OPSZ_4), REGARG(K7)
        REGARG_PARTIAL(XMM16, OPSZ_4))
 OPCODE(vmovsd_k7stxhi, vmovsd, vmovsd_mask, X64_ONLY, MEMARG(OPSZ_8), REGARG(K7),
        REGARG_PARTIAL(XMM16, OPSZ_8))
+OPCODE(vmovsldup_xlok0ld, vmovsldup, vmovsldup_mask, 0, REGARG(XMM0), REGARG(K0),
+       MEMARG(OPSZ_16))
+OPCODE(vmovsldup_xhik7ld, vmovsldup, vmovsldup_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       MEMARG(OPSZ_16))
+OPCODE(vmovsldup_ylok0ld, vmovsldup, vmovsldup_mask, 0, REGARG(YMM0), REGARG(K0),
+       MEMARG(OPSZ_32))
+OPCODE(vmovsldup_yhik7ld, vmovsldup, vmovsldup_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       MEMARG(OPSZ_32))
+OPCODE(vmovsldup_zlok0ld, vmovsldup, vmovsldup_mask, 0, REGARG(ZMM0), REGARG(K0),
+       MEMARG(OPSZ_64))
+OPCODE(vmovsldup_zhik7ld, vmovsldup, vmovsldup_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       MEMARG(OPSZ_64))
+OPCODE(vmovddup_xlok0ld, vmovddup, vmovddup_mask, 0, REGARG(XMM0), REGARG(K0),
+       MEMARG(OPSZ_8))
+OPCODE(vmovddup_xhik7ld, vmovddup, vmovddup_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       MEMARG(OPSZ_8))
+OPCODE(vmovddup_ylok0ld, vmovddup, vmovddup_mask, 0, REGARG(YMM0), REGARG(K0),
+       MEMARG(OPSZ_16))
+OPCODE(vmovddup_yhik7ld, vmovddup, vmovddup_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       MEMARG(OPSZ_16))
+OPCODE(vmovddup_zlok0ld, vmovddup, vmovddup_mask, 0, REGARG(ZMM0), REGARG(K0),
+       MEMARG(OPSZ_32))
+OPCODE(vmovddup_zhik7ld, vmovddup, vmovddup_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       MEMARG(OPSZ_32))
+OPCODE(vmovshdup_xlok0ld, vmovshdup, vmovshdup_mask, 0, REGARG(XMM0), REGARG(K0),
+       MEMARG(OPSZ_16))
+OPCODE(vmovshdup_xhik7ld, vmovshdup, vmovshdup_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       MEMARG(OPSZ_16))
+OPCODE(vmovshdup_ylok0ld, vmovshdup, vmovshdup_mask, 0, REGARG(YMM0), REGARG(K0),
+       MEMARG(OPSZ_32))
+OPCODE(vmovshdup_yhik7ld, vmovshdup, vmovshdup_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       MEMARG(OPSZ_32))
+OPCODE(vmovshdup_zlok0ld, vmovshdup, vmovshdup_mask, 0, REGARG(ZMM0), REGARG(K0),
+       MEMARG(OPSZ_64))
+OPCODE(vmovshdup_zhik7ld, vmovshdup, vmovshdup_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       MEMARG(OPSZ_64))
 /* TODO i#1312: Add missing instructions. */


### PR DESCRIPTION
Adds the evex form of instructions vmovsldup, vmovddup, vmovhps, vmovhpd, vmovshdup.

Adds the new subreg type OPSZ_half_16_vex32_evex64 for AVX-512.

Adds the decoder flag and check for EVEX.LL.

Adds tests for instructions above.

Issue: #1312