### PR TITLE
i#1312 AVX-512 support: Add evex promoted vunpck* and vcvt* opcodes w/ OPSZ_16 operands.

### DIFF
--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1499,6 +1499,9 @@ const instr_info_t * const op_instr[] =
 #define Ve TYPE_V, OPSZ_16_vex32_evex64
 #define We TYPE_W, OPSZ_16_vex32_evex64
 #define Wh_e TYPE_W, OPSZ_half_16_vex32_evex64
+#define Hh_e TYPE_H, OPSZ_half_16_vex32_evex64
+#define Mes TYPE_M, OPSZ_16_vex32_evex64
+#define Med TYPE_M, OPSZ_16_vex32_evex64
 
 /* my own codes
  * size m = 32 or 16 bit depending on addr size attribute
@@ -2839,14 +2842,13 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {OP_unpcklpd, 0x660f1410, "unpcklpd", Vpd, xx, Wq_dq, Vpd, xx, mrm, x, END_LIST},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vunpcklps, 0x0f1410, "vunpcklps", Vvs, xx, Hh_x, Wh_x, xx, mrm|vex, x, END_LIST},
+    {OP_vunpcklps, 0x0f1410, "vunpcklps", Vvs, xx, Hh_x, Wh_x, xx, mrm|vex, x, tevexw[25][0]},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vunpcklpd, 0x660f1410, "vunpcklpd", Vvd, xx, Hh_x, Wh_x, xx, mrm|vex, x, END_LIST},
+    {OP_vunpcklpd, 0x660f1410, "vunpcklpd", Vvd, xx, Hh_x, Wh_x, xx, mrm|vex, x, tevexw[26][1]},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    /* TODO i#1312: Support AVX-512. */
-    {INVALID,   0x0f1410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x0f1410, "(evex_W ext 25)", xx, xx, xx, xx, xx, mrm|evex, x, 25},
     {INVALID, 0xf30f1410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f1410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x660f1410, "(evex_W ext 26)", xx, xx, xx, xx, xx, mrm|evex, x, 26},
     {INVALID, 0xf20f1410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 5 */
@@ -2855,14 +2857,13 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {OP_unpckhpd, 0x660f1510, "unpckhpd", Vpd, xx, Wq_dq, Vpd, xx, mrm, x, END_LIST},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vunpckhps, 0x0f1510, "vunpckhps", Vvs, xx, Hh_x, Wh_x, xx, mrm|vex, x, END_LIST},
+    {OP_vunpckhps, 0x0f1510, "vunpckhps", Vvs, xx, Hh_x, Wh_x, xx, mrm|vex, x, tevexw[27][0]},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vunpckhpd, 0x660f1510, "vunpckhpd", Vvd, xx, Hh_x, Wh_x, xx, mrm|vex, x, END_LIST},
+    {OP_vunpckhpd, 0x660f1510, "vunpckhpd", Vvd, xx, Hh_x, Wh_x, xx, mrm|vex, x, tevexw[28][1]},
     {INVALID, 0x00000000, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    /* TODO i#1312: Support AVX-512. */
-    {INVALID,   0x0f1510, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x0f1510, "(evex_W ext 27)", xx, xx, xx, xx, xx, mrm|evex, x, 27},
     {INVALID, 0xf30f1510, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f1510, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x660f1510, "(evex_W ext 28)", xx, xx, xx, xx, xx, mrm|evex, x, 28},
     {INVALID, 0xf20f1510, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 6 */
@@ -2936,14 +2937,13 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_cvtpi2pd, 0x660f2a10, "cvtpi2pd", Vpd, xx, Qq, xx, xx, mrm, x, END_LIST},
     {OP_cvtsi2sd, 0xf20f2a10, "cvtsi2sd", Vsd, xx, Ed_q, xx, xx, mrm, x, END_LIST},
     {INVALID,  0x0f2a10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vcvtsi2ss, 0xf30f2a10, "vcvtsi2ss", Vdq, xx, H12_dq, Ed_q, xx, mrm|vex, x, END_LIST},
+    {OP_vcvtsi2ss, 0xf30f2a10, "vcvtsi2ss", Vdq, xx, H12_dq, Ed_q, xx, mrm|vex, x, tevexw[31][0]},
     {INVALID, 0x660f2a10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vcvtsi2sd, 0xf20f2a10, "vcvtsi2sd", Vdq, xx, Hsd, Ed_q, xx, mrm|vex, x, END_LIST},
-    /* TODO i#1312: Support AVX-512. */
+    {OP_vcvtsi2sd, 0xf20f2a10, "vcvtsi2sd", Vdq, xx, Hsd, Ed_q, xx, mrm|vex, x, tevexw[32][0]},
     {INVALID,   0x0f2a10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf30f2a10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0xf30f2a10, "(evex_W ext 31)", xx, xx, xx, xx, xx, mrm|evex, x, 31},
     {INVALID, 0x660f2a10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf20f2a10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0xf20f2a10, "(evex_W ext 32)", xx, xx, xx, xx, xx, mrm|evex, x, 32},
   },
   /* prefix extension 11 */
   {
@@ -2951,15 +2951,14 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_movntss, 0xf30f2b10, "movntss", Mss, xx, Vss, xx, xx, mrm, x, END_LIST},
     {OP_movntpd, 0x660f2b10, "movntpd", Mpd, xx, Vpd, xx, xx, mrm, x, END_LIST},
     {OP_movntsd, 0xf20f2b10, "movntsd", Msd, xx, Vsd, xx, xx, mrm, x, END_LIST},
-    {OP_vmovntps,   0x0f2b10, "vmovntps", Mvs, xx, Vvs, xx, xx, mrm|vex, x, END_LIST},
+    {OP_vmovntps,   0x0f2b10, "vmovntps", Mvs, xx, Vvs, xx, xx, mrm|vex, x, tevexw[33][0]},
     /* XXX: AMD doesn't list movntss in their new manual => assuming no vex version */
     {INVALID, 0xf30f2b10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vmovntpd, 0x660f2b10, "vmovntpd", Mvd, xx, Vvd, xx, xx, mrm|vex, x, END_LIST},
+    {OP_vmovntpd, 0x660f2b10, "vmovntpd", Mvd, xx, Vvd, xx, xx, mrm|vex, x, tevexw[34][1]},
     {INVALID, 0xf20f2b10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    /* TODO i#1312: Support AVX-512. */
-    {INVALID,   0x0f2b10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x0f2b10, "(evex_W ext 33)", xx, xx, xx, xx, xx, mrm|evex, x, 33},
     {INVALID, 0xf30f2b10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f2b10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x660f2b10, "(evex_W ext 34)", xx, xx, xx, xx, xx, mrm|evex, x, 34},
     {INVALID, 0xf20f2b10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 12 */
@@ -2969,14 +2968,13 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_cvttpd2pi, 0x660f2c10, "cvttpd2pi", Pq, xx, Wpd, xx, xx, mrm, x, END_LIST},
     {OP_cvttsd2si, 0xf20f2c10, "cvttsd2si", Gd_q, xx, Wsd, xx, xx, mrm, x, END_LIST},
     {INVALID, 0x0f2c10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vcvttss2si, 0xf30f2c10, "vcvttss2si", Gd_q, xx, Wss, xx, xx, mrm|vex, x, END_LIST},
+    {OP_vcvttss2si, 0xf30f2c10, "vcvttss2si", Gd_q, xx, Wss, xx, xx, mrm|vex, x, tevexw[35][0]},
     {INVALID, 0x660f2c10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vcvttsd2si, 0xf20f2c10, "vcvttsd2si", Gd_q, xx, Wsd, xx, xx, mrm|vex, x, END_LIST},
-    /* TODO i#1312: Support AVX-512. */
+    {OP_vcvttsd2si, 0xf20f2c10, "vcvttsd2si", Gd_q, xx, Wsd, xx, xx, mrm|vex, x, tevexw[36][0]},
     {INVALID,   0x0f2c10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf30f2c10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0xf30f2c10, "(evex_W ext 35)", xx, xx, xx, xx, xx, mrm|evex, x, 35},
     {INVALID, 0x660f2c10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf20f2c10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0xf20f2c10, "(evex_W ext 36)", xx, xx, xx, xx, xx, mrm|evex, x, 36},
   },
   /* prefix extension 13 */
   {
@@ -2985,14 +2983,13 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_cvtpd2pi, 0x660f2d10, "cvtpd2pi", Pq, xx, Wpd, xx, xx, mrm, x, END_LIST},
     {OP_cvtsd2si, 0xf20f2d10, "cvtsd2si", Gd_q, xx, Wsd, xx, xx, mrm, x, END_LIST},
     {INVALID, 0x0f2d10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vcvtss2si, 0xf30f2d10, "vcvtss2si", Gd_q, xx, Wss, xx, xx, mrm|vex, x, END_LIST},
+    {OP_vcvtss2si, 0xf30f2d10, "vcvtss2si", Gd_q, xx, Wss, xx, xx, mrm|vex, x, tevexw[29][0]},
     {INVALID, 0x660f2d10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vcvtsd2si, 0xf20f2d10, "vcvtsd2si", Gd_q, xx, Wsd, xx, xx, mrm|vex, x, END_LIST},
-    /* TODO i#1312: Support AVX-512. */
+    {OP_vcvtsd2si, 0xf20f2d10, "vcvtsd2si", Gd_q, xx, Wsd, xx, xx, mrm|vex, x, tevexw[30][0]},
     {INVALID,   0x0f2d10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf30f2d10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0xf30f2d10, "(evex_W ext 29)", xx, xx, xx, xx, xx, mrm|evex, x, 29},
     {INVALID, 0x660f2d10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf20f2d10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0xf20f2d10, "(evex_W ext 30)", xx, xx, xx, xx, xx, mrm|evex, x, 30},
   },
   /* prefix extension 14 */
   {
@@ -3000,14 +2997,13 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID, 0xf30f2e10, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {OP_ucomisd, 0x660f2e10, "ucomisd", xx, xx, Vsd, Wsd, xx, mrm, fW6, END_LIST},
     {INVALID, 0xf20f2e10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vucomiss, 0x0f2e10, "vucomiss", xx, xx, Vss, Wss, xx, mrm|vex, fW6, END_LIST},
+    {OP_vucomiss, 0x0f2e10, "vucomiss", xx, xx, Vss, Wss, xx, mrm|vex, fW6, tevexw[37][0]},
     {INVALID, 0xf30f2e10, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    {OP_vucomisd, 0x660f2e10, "vucomisd", xx, xx, Vsd, Wsd, xx, mrm|vex, fW6, END_LIST},
+    {OP_vucomisd, 0x660f2e10, "vucomisd", xx, xx, Vsd, Wsd, xx, mrm|vex, fW6, tevexw[38][1]},
     {INVALID, 0xf20f2e10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    /* TODO i#1312: Support AVX-512. */
-    {INVALID,   0x0f2e10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x0f2e10, "(evex_W ext 37)", xx, xx, xx, xx, xx, mrm|evex, x, 37},
     {INVALID, 0xf30f2e10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f2e10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x660f2e10, "(evex_W ext 38)", xx, xx, xx, xx, xx, mrm|evex, x, 38},
     {INVALID, 0xf20f2e10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 15 */
@@ -3016,14 +3012,13 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID, 0xf30f2f10, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {OP_comisd,  0x660f2f10, "comisd",  xx, xx, Vsd, Wsd, xx, mrm, fW6, END_LIST},
     {INVALID, 0xf20f2f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vcomiss,  0x0f2f10, "vcomiss",  xx, xx, Vss, Wss, xx, mrm|vex, fW6, END_LIST},
+    {OP_vcomiss,  0x0f2f10, "vcomiss",  xx, xx, Vss, Wss, xx, mrm|vex, fW6, tevexw[39][0]},
     {INVALID, 0xf30f2f10, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    {OP_vcomisd,  0x660f2f10, "vcomisd",  xx, xx, Vsd, Wsd, xx, mrm|vex, fW6, END_LIST},
+    {OP_vcomisd,  0x660f2f10, "vcomisd",  xx, xx, Vsd, Wsd, xx, mrm|vex, fW6, tevexw[40][1]},
     {INVALID, 0xf20f2f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    /* TODO i#1312: Support AVX-512. */
-    {INVALID,   0x0f2f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x0f2e10, "(evex_W ext 39)", xx, xx, xx, xx, xx, mrm|evex, x, 39},
     {INVALID, 0xf30f2f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f2f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0x660f2e10, "(evex_W ext 40)", xx, xx, xx, xx, xx, mrm|evex, x, 40},
     {INVALID, 0xf20f2f10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 16 */
@@ -3036,7 +3031,6 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID, 0xf30f5010, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {OP_vmovmskpd, 0x660f5010, "vmovmskpd", Gr, xx, Uvd, xx, xx, mrm|vex, x, END_LIST},
     {INVALID, 0xf20f5010, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    /* TODO i#1312: Support AVX-512. */
     {INVALID,   0x0f5010, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf30f5010, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0x660f5010, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
@@ -6733,6 +6727,70 @@ const instr_info_t evex_W_extensions[][2] = {
   {    /* evex_W_ext 24 */
     {OP_vmovshdup, 0xf30f1610, "vmovshdup", Ves, xx, KEw, Wes, xx, mrm|evex, x, END_LIST},
     {INVALID, 0xf30f1650,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+  },
+  {    /* evex_W_ext 25 */
+    {OP_vunpcklps, 0x0f1410, "vunpcklps", Ves, xx, KEw, Hh_e, Wh_e, mrm|evex, x, END_LIST},
+    {INVALID, 0x0f1450,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+  },
+  {    /* evex_W_ext 26 */
+    {INVALID, 0x660f1410,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+    {OP_vunpcklpd, 0x660f1450, "vunpcklpd", Ved, xx, KEb, Hh_e, Wh_e, mrm|evex, x, END_LIST},
+  },
+  {    /* evex_W_ext 27 */
+    {OP_vunpckhps, 0x0f1510, "vunpckhps", Ves, xx, KEw, Hh_e, Wh_e, mrm|evex, x, END_LIST},
+    {INVALID, 0x0f1550,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+  },
+  {    /* evex_W_ext 28 */
+    {INVALID, 0x660f1510,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+    {OP_vunpckhpd, 0x660f1550, "vunpckhpd", Ved, xx, KEb, Hh_e, Wh_e, mrm|evex, x, END_LIST},
+  },
+  {    /* evex_W_ext 29 */
+    {OP_vcvtss2si, 0xf30f2d10, "vcvtss2si", Gd_q, xx, Wss, xx, xx, mrm|evex, x, tevexw[29][1]},
+    {OP_vcvtss2si, 0xf30f2d50, "vcvtss2si", Gd_q, xx, Wss, xx, xx, mrm|evex, x, END_LIST},
+  },
+  {    /* evex_W_ext 30 */
+    {OP_vcvtsd2si, 0xf20f2d10, "vcvtsd2si", Gd_q, xx, Wsd, xx, xx, mrm|evex, x, tevexw[30][1]},
+    {OP_vcvtsd2si, 0xf20f2d50, "vcvtsd2si", Gd_q, xx, Wsd, xx, xx, mrm|evex, x, END_LIST},
+  },
+  {    /* evex_W_ext 31 */
+    {OP_vcvtsi2ss, 0xf30f2a10, "vcvtsi2ss", Vdq, xx, H12_dq, Ed_q, xx, mrm|evex, x, tevexw[31][1]},
+    {OP_vcvtsi2ss, 0xf30f2a50, "vcvtsi2ss", Vdq, xx, H12_dq, Ed_q, xx, mrm|evex, x, END_LIST},
+  },
+  {    /* evex_W_ext 32 */
+    {OP_vcvtsi2sd, 0xf20f2a10, "vcvtsi2sd", Vdq, xx, Hsd, Ed_q, xx, mrm|evex, x, tevexw[32][1]},
+    {OP_vcvtsi2sd, 0xf20f2a50, "vcvtsi2sd", Vdq, xx, Hsd, Ed_q, xx, mrm|evex, x, END_LIST},
+  },
+  {    /* evex_W_ext 33 */
+    {OP_vmovntps, 0x0f2b10, "vmovntps", Mes, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {INVALID, 0x0f2b50,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+  },
+  {    /* evex_W_ext 34 */
+    {INVALID, 0x660f2b10,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+    {OP_vmovntpd, 0x660f2b50, "vmovntpd", Med, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+  },
+  {    /* evex_W_ext 35 */
+    {OP_vcvttss2si, 0xf30f2c10, "vcvttss2si", Gd_q, xx, Wss, xx, xx, mrm|evex, x, tevexw[35][1]},
+    {OP_vcvttss2si, 0xf30f2c50, "vcvttss2si", Gd_q, xx, Wss, xx, xx, mrm|evex, x, END_LIST},
+  },
+  {    /* evex_W_ext 36 */
+    {OP_vcvttsd2si, 0xf20f2c10, "vcvttsd2si", Gd_q, xx, Wsd, xx, xx, mrm|evex, x, tevexw[36][1]},
+    {OP_vcvttsd2si, 0xf20f2c50, "vcvttsd2si", Gd_q, xx, Wsd, xx, xx, mrm|evex, x, END_LIST},
+  },
+  {    /* evex_W_ext 37 */
+    {OP_vucomiss, 0x0f2e10, "vucomiss", xx, xx, Vss, Wss, xx, mrm|evex, fW6, END_LIST},
+    {INVALID, 0x0f2e50,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+  },
+  {    /* evex_W_ext 38 */
+    {INVALID, 0x660f2e10,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+    {OP_vucomisd, 0x660f2e50, "vucomisd", xx, xx, Vsd, Wsd, xx, mrm|evex, fW6, END_LIST},
+  },
+  {    /* evex_W_ext 39 */
+    {OP_vcomiss,  0x0f2f10, "vcomiss",  xx, xx, Vss, Wss, xx, mrm|evex, fW6, END_LIST},
+    {INVALID, 0x0f2f50,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+  },
+  {    /* evex_W_ext 40 */
+    {INVALID, 0x660f2e10,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
+    {OP_vcomisd,  0x660f2f50, "vcomisd",  xx, xx, Vsd, Wsd, xx, mrm|evex, fW6, END_LIST},
   },
 };
 

--- a/core/arch/x86/encode.c
+++ b/core/arch/x86/encode.c
@@ -1304,7 +1304,9 @@ opnd_type_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, opn
     case TYPE_L:
         return (opnd_is_reg(opnd) &&
                 reg_size_ok(di, opnd_get_reg(opnd), optype, opsize, false /*!addr*/) &&
-                reg_is_xmm(opnd_get_reg(opnd)));
+                (reg_is_strictly_xmm(opnd_get_reg(opnd)) ||
+                 reg_is_strictly_ymm(opnd_get_reg(opnd)) ||
+                 reg_is_strictly_zmm(opnd_get_reg(opnd))));
     case TYPE_K_REG:
         /* TYPE_K_REG, TYPE_K_MODRM_R, TYPE_K_MODRM (can be mem addr) and TYPE_K_VEX
          * are k registers used in AVX-512 VEX encoded instructions with implicit size
@@ -2182,11 +2184,10 @@ encode_operand(decode_info_t *di, int optype, opnd_size_t opsize, opnd_t opnd)
     }
     case TYPE_H: {
         reg_id_t reg = opnd_get_reg(opnd);
-        CLIENT_ASSERT(!reg_is_strictly_zmm(reg), "FIXME i#1312: unsupported.");
         encode_avx512_reg_ext_prefixes(di, opnd_get_reg(opnd), PREFIX_EVEX_VV);
         /* vex_vvvv abd evex_vvvv is a union. */
         if (reg_is_strictly_zmm(reg))
-            di->vex_vvvv = (byte)(reg - DR_REG_START_ZMM);
+            di->evex_vvvv = (byte)(reg - DR_REG_START_ZMM);
         else if (reg_is_strictly_ymm(reg))
             di->vex_vvvv = (byte)(reg - DR_REG_START_YMM);
         else

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -2968,6 +2968,14 @@
     instr_create_1dst_3src((dc), OP_vmovss, (d), (k), (s1), (s2))
 #define INSTR_CREATE_vmovsd_NDS_mask(dc, d, k, s1, s2) \
     instr_create_1dst_3src((dc), OP_vmovsd, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vunpcklps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vunpcklps, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vunpcklpd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vunpcklpd, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vunpckhps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vunpckhps, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vunpckhpd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vunpckhpd, (d), (k), (s1), (s2))
 /* @} */ /* end doxygen group */
 
 /** @name 1 destination, 3 sources including one immediate */

--- a/suite/tests/api/ir_x86_2args_avx512_evex.h
+++ b/suite/tests/api/ir_x86_2args_avx512_evex.h
@@ -40,65 +40,67 @@ OPCODE(vmovlpd_mxlo, vmovlpd, vmovlpd, VERIFY_EVEX, MEMARG(OPSZ_8),
 OPCODE(vmovlpd_mxhi, vmovlpd, vmovlpd, X64_ONLY, MEMARG(OPSZ_8),
        REGARG_PARTIAL(XMM16, OPSZ_8))
 OPCODE(vcvtss2si_r32m, vcvtss2si, vcvtss2si, 0, REGARG(EAX), MEMARG(OPSZ_4))
-OPCODE(vcvtss2si_r64m, vcvtss2si, vcvtss2si, 0, REGARG(RAX), MEMARG(OPSZ_4))
+OPCODE(vcvtss2si_r64m, vcvtss2si, vcvtss2si, X64_ONLY, REGARG(RAX), MEMARG(OPSZ_4))
 OPCODE(vcvtss2si_r32xlo, vcvtss2si, vcvtss2si, 0, REGARG(EAX),
        REGARG_PARTIAL(XMM0, OPSZ_4))
-OPCODE(vcvtss2si_r32xhi, vcvtss2si, vcvtss2si, 0, REGARG(EAX),
+OPCODE(vcvtss2si_r32xhi, vcvtss2si, vcvtss2si, X64_ONLY, REGARG(EAX),
        REGARG_PARTIAL(XMM16, OPSZ_4))
-OPCODE(vcvtss2si_r64xlo, vcvtss2si, vcvtss2si, 0, REGARG(RAX),
+OPCODE(vcvtss2si_r64xlo, vcvtss2si, vcvtss2si, X64_ONLY, REGARG(RAX),
        REGARG_PARTIAL(XMM0, OPSZ_4))
-OPCODE(vcvtss2si_r64xhi, vcvtss2si, vcvtss2si, 0, REGARG(RAX),
+OPCODE(vcvtss2si_r64xhi, vcvtss2si, vcvtss2si, X64_ONLY, REGARG(RAX),
        REGARG_PARTIAL(XMM16, OPSZ_4))
 OPCODE(vcvtsd2si_r32m, vcvtsd2si, vcvtsd2si, 0, REGARG(EAX), MEMARG(OPSZ_8))
-OPCODE(vcvtsd2si_r64m, vcvtsd2si, vcvtsd2si, 0, REGARG(RAX), MEMARG(OPSZ_8))
+OPCODE(vcvtsd2si_r64m, vcvtsd2si, vcvtsd2si, X64_ONLY, REGARG(RAX), MEMARG(OPSZ_8))
 OPCODE(vcvtsd2si_r32xlo, vcvtsd2si, vcvtsd2si, 0, REGARG(EAX),
        REGARG_PARTIAL(XMM0, OPSZ_8))
-OPCODE(vcvtsd2si_r32xhi, vcvtsd2si, vcvtsd2si, 0, REGARG(EAX),
+OPCODE(vcvtsd2si_r32xhi, vcvtsd2si, vcvtsd2si, X64_ONLY, REGARG(EAX),
        REGARG_PARTIAL(XMM16, OPSZ_8))
-OPCODE(vcvtsd2si_r64xlo, vcvtsd2si, vcvtsd2si, 0, REGARG(RAX),
+OPCODE(vcvtsd2si_r64xlo, vcvtsd2si, vcvtsd2si, X64_ONLY, REGARG(RAX),
        REGARG_PARTIAL(XMM0, OPSZ_8))
-OPCODE(vcvtsd2si_r64xhi, vcvtsd2si, vcvtsd2si, 0, REGARG(RAX),
+OPCODE(vcvtsd2si_r64xhi, vcvtsd2si, vcvtsd2si, X64_ONLY, REGARG(RAX),
        REGARG_PARTIAL(XMM16, OPSZ_8))
 OPCODE(vcvttss2si_r32m, vcvttss2si, vcvttss2si, 0, REGARG(EAX), MEMARG(OPSZ_4))
-OPCODE(vcvttss2si_r64m, vcvttss2si, vcvttss2si, 0, REGARG(RAX), MEMARG(OPSZ_4))
+OPCODE(vcvttss2si_r64m, vcvttss2si, vcvttss2si, X64_ONLY, REGARG(RAX), MEMARG(OPSZ_4))
 OPCODE(vcvttss2si_r32xlo, vcvttss2si, vcvttss2si, 0, REGARG(EAX),
        REGARG_PARTIAL(XMM0, OPSZ_4))
-OPCODE(vcvttss2si_r32xhi, vcvttss2si, vcvttss2si, 0, REGARG(EAX),
+OPCODE(vcvttss2si_r32xhi, vcvttss2si, vcvttss2si, X64_ONLY, REGARG(EAX),
        REGARG_PARTIAL(XMM16, OPSZ_4))
-OPCODE(vcvttss2si_r64xlo, vcvttss2si, vcvttss2si, 0, REGARG(RAX),
+OPCODE(vcvttss2si_r64xlo, vcvttss2si, vcvttss2si, X64_ONLY, REGARG(RAX),
        REGARG_PARTIAL(XMM0, OPSZ_4))
-OPCODE(vcvttss2si_r64xhi, vcvttss2si, vcvttss2si, 0, REGARG(RAX),
+OPCODE(vcvttss2si_r64xhi, vcvttss2si, vcvttss2si, X64_ONLY, REGARG(RAX),
        REGARG_PARTIAL(XMM16, OPSZ_4))
 OPCODE(vcvttsd2si_r32m, vcvttsd2si, vcvttsd2si, 0, REGARG(EAX), MEMARG(OPSZ_8))
-OPCODE(vcvttsd2si_r64m, vcvttsd2si, vcvttsd2si, 0, REGARG(RAX), MEMARG(OPSZ_8))
+OPCODE(vcvttsd2si_r64m, vcvttsd2si, vcvttsd2si, X64_ONLY, REGARG(RAX), MEMARG(OPSZ_8))
 OPCODE(vcvttsd2si_r32xlo, vcvttsd2si, vcvttsd2si, 0, REGARG(EAX),
        REGARG_PARTIAL(XMM0, OPSZ_8))
-OPCODE(vcvttsd2si_r32xhi, vcvttsd2si, vcvttsd2si, 0, REGARG(EAX),
+OPCODE(vcvttsd2si_r32xhi, vcvttsd2si, vcvttsd2si, X64_ONLY, REGARG(EAX),
        REGARG_PARTIAL(XMM16, OPSZ_8))
-OPCODE(vcvttsd2si_r64xlo, vcvttsd2si, vcvttsd2si, 0, REGARG(RAX),
+OPCODE(vcvttsd2si_r64xlo, vcvttsd2si, vcvttsd2si, X64_ONLY, REGARG(RAX),
        REGARG_PARTIAL(XMM0, OPSZ_8))
-OPCODE(vcvttsd2si_r64xhi, vcvttsd2si, vcvttsd2si, 0, REGARG(RAX),
+OPCODE(vcvttsd2si_r64xhi, vcvttsd2si, vcvttsd2si, X64_ONLY, REGARG(RAX),
        REGARG_PARTIAL(XMM16, OPSZ_8))
 OPCODE(vmovntps_mxlo, vmovntps, vmovntps, 0, MEMARG(OPSZ_16), REGARG(XMM0))
-OPCODE(vmovntps_mxhi, vmovntps, vmovntps, 0, MEMARG(OPSZ_16), REGARG(XMM16))
+OPCODE(vmovntps_mxhi, vmovntps, vmovntps, X64_ONLY, MEMARG(OPSZ_16), REGARG(XMM16))
 OPCODE(vmovntps_mylo, vmovntps, vmovntps, 0, MEMARG(OPSZ_32), REGARG(YMM0))
-OPCODE(vmovntps_myhi, vmovntps, vmovntps, 0, MEMARG(OPSZ_32), REGARG(YMM16))
+OPCODE(vmovntps_myhi, vmovntps, vmovntps, X64_ONLY, MEMARG(OPSZ_32), REGARG(YMM16))
 OPCODE(vmovntps_mzlo, vmovntps, vmovntps, 0, MEMARG(OPSZ_64), REGARG(ZMM0))
-OPCODE(vmovntps_mzhi, vmovntps, vmovntps, 0, MEMARG(OPSZ_64), REGARG(ZMM16))
+OPCODE(vmovntps_mzhi, vmovntps, vmovntps, X64_ONLY, MEMARG(OPSZ_64), REGARG(ZMM16))
 OPCODE(vmovntpd_mxlo, vmovntpd, vmovntpd, 0, MEMARG(OPSZ_16), REGARG(XMM0))
-OPCODE(vmovntpd_mxhi, vmovntpd, vmovntpd, 0, MEMARG(OPSZ_16), REGARG(XMM16))
+OPCODE(vmovntpd_mxhi, vmovntpd, vmovntpd, X64_ONLY, MEMARG(OPSZ_16), REGARG(XMM16))
 OPCODE(vmovntpd_mylo, vmovntpd, vmovntpd, 0, MEMARG(OPSZ_32), REGARG(YMM0))
-OPCODE(vmovntpd_myhi, vmovntpd, vmovntpd, 0, MEMARG(OPSZ_32), REGARG(YMM16))
+OPCODE(vmovntpd_myhi, vmovntpd, vmovntpd, X64_ONLY, MEMARG(OPSZ_32), REGARG(YMM16))
 OPCODE(vmovntpd_mzlo, vmovntpd, vmovntpd, 0, MEMARG(OPSZ_64), REGARG(ZMM0))
-OPCODE(vmovntpd_mzhi, vmovntpd, vmovntpd, 0, MEMARG(OPSZ_64), REGARG(ZMM16))
+OPCODE(vmovntpd_mzhi, vmovntpd, vmovntpd, X64_ONLY, MEMARG(OPSZ_64), REGARG(ZMM16))
 OPCODE(vucomiss_xlom, vucomiss, vucomiss, 0, REGARG_PARTIAL(XMM0, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vucomiss_xhim, vucomiss, vucomiss, 0, REGARG_PARTIAL(XMM16, OPSZ_4),
+OPCODE(vucomiss_xhim, vucomiss, vucomiss, X64_ONLY, REGARG_PARTIAL(XMM16, OPSZ_4),
        MEMARG(OPSZ_4))
 OPCODE(vucomisd_xlom, vucomisd, vucomisd, 0, REGARG_PARTIAL(XMM0, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vucomisd_xhim, vucomisd, vucomisd, 0, REGARG_PARTIAL(XMM16, OPSZ_8),
+OPCODE(vucomisd_xhim, vucomisd, vucomisd, X64_ONLY, REGARG_PARTIAL(XMM16, OPSZ_8),
        MEMARG(OPSZ_8))
 OPCODE(vcomiss_xlom, vcomiss, vcomiss, 0, REGARG_PARTIAL(XMM0, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vcomiss_xhim, vcomiss, vcomiss, 0, REGARG_PARTIAL(XMM16, OPSZ_4), MEMARG(OPSZ_4))
+OPCODE(vcomiss_xhim, vcomiss, vcomiss, X64_ONLY, REGARG_PARTIAL(XMM16, OPSZ_4),
+       MEMARG(OPSZ_4))
 OPCODE(vcomisd_xlom, vcomisd, vcomisd, 0, REGARG_PARTIAL(XMM0, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vcomisd_xhim, vcomisd, vcomisd, 0, REGARG_PARTIAL(XMM16, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vcomisd_xhim, vcomisd, vcomisd, X64_ONLY, REGARG_PARTIAL(XMM16, OPSZ_8),
+       MEMARG(OPSZ_8))
 /* TODO i#1312: Add missing instructions. */

--- a/suite/tests/api/ir_x86_2args_avx512_evex.h
+++ b/suite/tests/api/ir_x86_2args_avx512_evex.h
@@ -39,4 +39,66 @@ OPCODE(vmovlpd_mxlo, vmovlpd, vmovlpd, VERIFY_EVEX, MEMARG(OPSZ_8),
        REGARG_PARTIAL(XMM0, OPSZ_8))
 OPCODE(vmovlpd_mxhi, vmovlpd, vmovlpd, X64_ONLY, MEMARG(OPSZ_8),
        REGARG_PARTIAL(XMM16, OPSZ_8))
+OPCODE(vcvtss2si_r32m, vcvtss2si, vcvtss2si, 0, REGARG(EAX), MEMARG(OPSZ_4))
+OPCODE(vcvtss2si_r64m, vcvtss2si, vcvtss2si, 0, REGARG(RAX), MEMARG(OPSZ_4))
+OPCODE(vcvtss2si_r32xlo, vcvtss2si, vcvtss2si, 0, REGARG(EAX),
+       REGARG_PARTIAL(XMM0, OPSZ_4))
+OPCODE(vcvtss2si_r32xhi, vcvtss2si, vcvtss2si, 0, REGARG(EAX),
+       REGARG_PARTIAL(XMM16, OPSZ_4))
+OPCODE(vcvtss2si_r64xlo, vcvtss2si, vcvtss2si, 0, REGARG(RAX),
+       REGARG_PARTIAL(XMM0, OPSZ_4))
+OPCODE(vcvtss2si_r64xhi, vcvtss2si, vcvtss2si, 0, REGARG(RAX),
+       REGARG_PARTIAL(XMM16, OPSZ_4))
+OPCODE(vcvtsd2si_r32m, vcvtsd2si, vcvtsd2si, 0, REGARG(EAX), MEMARG(OPSZ_8))
+OPCODE(vcvtsd2si_r64m, vcvtsd2si, vcvtsd2si, 0, REGARG(RAX), MEMARG(OPSZ_8))
+OPCODE(vcvtsd2si_r32xlo, vcvtsd2si, vcvtsd2si, 0, REGARG(EAX),
+       REGARG_PARTIAL(XMM0, OPSZ_8))
+OPCODE(vcvtsd2si_r32xhi, vcvtsd2si, vcvtsd2si, 0, REGARG(EAX),
+       REGARG_PARTIAL(XMM16, OPSZ_8))
+OPCODE(vcvtsd2si_r64xlo, vcvtsd2si, vcvtsd2si, 0, REGARG(RAX),
+       REGARG_PARTIAL(XMM0, OPSZ_8))
+OPCODE(vcvtsd2si_r64xhi, vcvtsd2si, vcvtsd2si, 0, REGARG(RAX),
+       REGARG_PARTIAL(XMM16, OPSZ_8))
+OPCODE(vcvttss2si_r32m, vcvttss2si, vcvttss2si, 0, REGARG(EAX), MEMARG(OPSZ_4))
+OPCODE(vcvttss2si_r64m, vcvttss2si, vcvttss2si, 0, REGARG(RAX), MEMARG(OPSZ_4))
+OPCODE(vcvttss2si_r32xlo, vcvttss2si, vcvttss2si, 0, REGARG(EAX),
+       REGARG_PARTIAL(XMM0, OPSZ_4))
+OPCODE(vcvttss2si_r32xhi, vcvttss2si, vcvttss2si, 0, REGARG(EAX),
+       REGARG_PARTIAL(XMM16, OPSZ_4))
+OPCODE(vcvttss2si_r64xlo, vcvttss2si, vcvttss2si, 0, REGARG(RAX),
+       REGARG_PARTIAL(XMM0, OPSZ_4))
+OPCODE(vcvttss2si_r64xhi, vcvttss2si, vcvttss2si, 0, REGARG(RAX),
+       REGARG_PARTIAL(XMM16, OPSZ_4))
+OPCODE(vcvttsd2si_r32m, vcvttsd2si, vcvttsd2si, 0, REGARG(EAX), MEMARG(OPSZ_8))
+OPCODE(vcvttsd2si_r64m, vcvttsd2si, vcvttsd2si, 0, REGARG(RAX), MEMARG(OPSZ_8))
+OPCODE(vcvttsd2si_r32xlo, vcvttsd2si, vcvttsd2si, 0, REGARG(EAX),
+       REGARG_PARTIAL(XMM0, OPSZ_8))
+OPCODE(vcvttsd2si_r32xhi, vcvttsd2si, vcvttsd2si, 0, REGARG(EAX),
+       REGARG_PARTIAL(XMM16, OPSZ_8))
+OPCODE(vcvttsd2si_r64xlo, vcvttsd2si, vcvttsd2si, 0, REGARG(RAX),
+       REGARG_PARTIAL(XMM0, OPSZ_8))
+OPCODE(vcvttsd2si_r64xhi, vcvttsd2si, vcvttsd2si, 0, REGARG(RAX),
+       REGARG_PARTIAL(XMM16, OPSZ_8))
+OPCODE(vmovntps_mxlo, vmovntps, vmovntps, 0, MEMARG(OPSZ_16), REGARG(XMM0))
+OPCODE(vmovntps_mxhi, vmovntps, vmovntps, 0, MEMARG(OPSZ_16), REGARG(XMM16))
+OPCODE(vmovntps_mylo, vmovntps, vmovntps, 0, MEMARG(OPSZ_32), REGARG(YMM0))
+OPCODE(vmovntps_myhi, vmovntps, vmovntps, 0, MEMARG(OPSZ_32), REGARG(YMM16))
+OPCODE(vmovntps_mzlo, vmovntps, vmovntps, 0, MEMARG(OPSZ_64), REGARG(ZMM0))
+OPCODE(vmovntps_mzhi, vmovntps, vmovntps, 0, MEMARG(OPSZ_64), REGARG(ZMM16))
+OPCODE(vmovntpd_mxlo, vmovntpd, vmovntpd, 0, MEMARG(OPSZ_16), REGARG(XMM0))
+OPCODE(vmovntpd_mxhi, vmovntpd, vmovntpd, 0, MEMARG(OPSZ_16), REGARG(XMM16))
+OPCODE(vmovntpd_mylo, vmovntpd, vmovntpd, 0, MEMARG(OPSZ_32), REGARG(YMM0))
+OPCODE(vmovntpd_myhi, vmovntpd, vmovntpd, 0, MEMARG(OPSZ_32), REGARG(YMM16))
+OPCODE(vmovntpd_mzlo, vmovntpd, vmovntpd, 0, MEMARG(OPSZ_64), REGARG(ZMM0))
+OPCODE(vmovntpd_mzhi, vmovntpd, vmovntpd, 0, MEMARG(OPSZ_64), REGARG(ZMM16))
+OPCODE(vucomiss_xlom, vucomiss, vucomiss, 0, REGARG_PARTIAL(XMM0, OPSZ_4), MEMARG(OPSZ_4))
+OPCODE(vucomiss_xhim, vucomiss, vucomiss, 0, REGARG_PARTIAL(XMM16, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vucomisd_xlom, vucomisd, vucomisd, 0, REGARG_PARTIAL(XMM0, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vucomisd_xhim, vucomisd, vucomisd, 0, REGARG_PARTIAL(XMM16, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vcomiss_xlom, vcomiss, vcomiss, 0, REGARG_PARTIAL(XMM0, OPSZ_4), MEMARG(OPSZ_4))
+OPCODE(vcomiss_xhim, vcomiss, vcomiss, 0, REGARG_PARTIAL(XMM16, OPSZ_4), MEMARG(OPSZ_4))
+OPCODE(vcomisd_xlom, vcomisd, vcomisd, 0, REGARG_PARTIAL(XMM0, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vcomisd_xhim, vcomisd, vcomisd, 0, REGARG_PARTIAL(XMM16, OPSZ_8), MEMARG(OPSZ_8))
 /* TODO i#1312: Add missing instructions. */

--- a/suite/tests/api/ir_x86_3args_avx512_evex.h
+++ b/suite/tests/api/ir_x86_3args_avx512_evex.h
@@ -55,4 +55,36 @@ OPCODE(vmovhpd_xloxlom, vmovhpd, vmovhpd_NDS, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
 OPCODE(vmovhpd_xhixhim, vmovhpd, vmovhpd_NDS, X64_ONLY, REGARG_PARTIAL(XMM16, OPSZ_8),
        REGARG_PARTIAL(XMM17, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vcvtsi2ss_xloxlom32, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM0),
+       REGARG_PARTIAL(XMM1, OPSZ_12), MEMARG(OPSZ_4))
+OPCODE(vcvtsi2ss_xloxlom64, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM0),
+       REGARG_PARTIAL(XMM1, OPSZ_12), MEMARG(OPSZ_8))
+OPCODE(vcvtsi2ss_xloxlor32, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM0),
+       REGARG_PARTIAL(XMM1, OPSZ_12), REGARG(EAX))
+OPCODE(vcvtsi2ss_xloxlor64, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM0),
+       REGARG_PARTIAL(XMM1, OPSZ_12), REGARG(RAX))
+OPCODE(vcvtsi2ss_xhixhim32, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM16),
+       REGARG_PARTIAL(XMM31, OPSZ_12), MEMARG(OPSZ_4))
+OPCODE(vcvtsi2ss_xhixhim64, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM16),
+       REGARG_PARTIAL(XMM31, OPSZ_12), MEMARG(OPSZ_8))
+OPCODE(vcvtsi2ss_xhixhir32, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM16),
+       REGARG_PARTIAL(XMM31, OPSZ_12), REGARG(EAX))
+OPCODE(vcvtsi2ss_xhixhir64, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM16),
+       REGARG_PARTIAL(XMM31, OPSZ_12), REGARG(RAX))
+OPCODE(vcvtsi2sd_xloxlom32, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_4))
+OPCODE(vcvtsi2sd_xloxlom64, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vcvtsi2sd_xloxlor32, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), REGARG(EAX))
+OPCODE(vcvtsi2sd_xloxlor64, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), REGARG(RAX))
+OPCODE(vcvtsi2sd_xhixhim32, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM16),
+       REGARG_PARTIAL(XMM31, OPSZ_8), MEMARG(OPSZ_4))
+OPCODE(vcvtsi2sd_xhixhim64, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM16),
+       REGARG_PARTIAL(XMM31, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vcvtsi2sd_xhixhir32, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM16),
+       REGARG_PARTIAL(XMM31, OPSZ_8), REGARG(EAX))
+OPCODE(vcvtsi2sd_xhixhir64, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM16),
+       REGARG_PARTIAL(XMM31, OPSZ_8), REGARG(RAX))
 /* TODO i#1312: Add missing instructions. */

--- a/suite/tests/api/ir_x86_3args_avx512_evex.h
+++ b/suite/tests/api/ir_x86_3args_avx512_evex.h
@@ -57,34 +57,34 @@ OPCODE(vmovhpd_xhixhim, vmovhpd, vmovhpd_NDS, X64_ONLY, REGARG_PARTIAL(XMM16, OP
        REGARG_PARTIAL(XMM17, OPSZ_8), MEMARG(OPSZ_8))
 OPCODE(vcvtsi2ss_xloxlom32, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_12), MEMARG(OPSZ_4))
-OPCODE(vcvtsi2ss_xloxlom64, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM0),
+OPCODE(vcvtsi2ss_xloxlom64, vcvtsi2ss, vcvtsi2ss, X64_ONLY, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_12), MEMARG(OPSZ_8))
 OPCODE(vcvtsi2ss_xloxlor32, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_12), REGARG(EAX))
-OPCODE(vcvtsi2ss_xloxlor64, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM0),
+OPCODE(vcvtsi2ss_xloxlor64, vcvtsi2ss, vcvtsi2ss, X64_ONLY, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_12), REGARG(RAX))
-OPCODE(vcvtsi2ss_xhixhim32, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM16),
+OPCODE(vcvtsi2ss_xhixhim32, vcvtsi2ss, vcvtsi2ss, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_12), MEMARG(OPSZ_4))
-OPCODE(vcvtsi2ss_xhixhim64, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM16),
+OPCODE(vcvtsi2ss_xhixhim64, vcvtsi2ss, vcvtsi2ss, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_12), MEMARG(OPSZ_8))
-OPCODE(vcvtsi2ss_xhixhir32, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM16),
+OPCODE(vcvtsi2ss_xhixhir32, vcvtsi2ss, vcvtsi2ss, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_12), REGARG(EAX))
-OPCODE(vcvtsi2ss_xhixhir64, vcvtsi2ss, vcvtsi2ss, 0, REGARG(XMM16),
+OPCODE(vcvtsi2ss_xhixhir64, vcvtsi2ss, vcvtsi2ss, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_12), REGARG(RAX))
 OPCODE(vcvtsi2sd_xloxlom32, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_4))
-OPCODE(vcvtsi2sd_xloxlom64, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM0),
+OPCODE(vcvtsi2sd_xloxlom64, vcvtsi2sd, vcvtsi2sd, X64_ONLY, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
 OPCODE(vcvtsi2sd_xloxlor32, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), REGARG(EAX))
-OPCODE(vcvtsi2sd_xloxlor64, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM0),
+OPCODE(vcvtsi2sd_xloxlor64, vcvtsi2sd, vcvtsi2sd, X64_ONLY, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), REGARG(RAX))
-OPCODE(vcvtsi2sd_xhixhim32, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM16),
+OPCODE(vcvtsi2sd_xhixhim32, vcvtsi2sd, vcvtsi2sd, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_8), MEMARG(OPSZ_4))
-OPCODE(vcvtsi2sd_xhixhim64, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM16),
+OPCODE(vcvtsi2sd_xhixhim64, vcvtsi2sd, vcvtsi2sd, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vcvtsi2sd_xhixhir32, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM16),
+OPCODE(vcvtsi2sd_xhixhir32, vcvtsi2sd, vcvtsi2sd, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_8), REGARG(EAX))
-OPCODE(vcvtsi2sd_xhixhir64, vcvtsi2sd, vcvtsi2sd, 0, REGARG(XMM16),
+OPCODE(vcvtsi2sd_xhixhir64, vcvtsi2sd, vcvtsi2sd, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_8), REGARG(RAX))
 /* TODO i#1312: Add missing instructions. */

--- a/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
@@ -55,4 +55,52 @@ OPCODE(vmovsd_xhik7xlo, vmovsd, vmovsd_NDS_mask, X64_ONLY, REGARG(XMM16), REGARG
        REGARG_PARTIAL(XMM1, OPSZ_8), REGARG_PARTIAL(XMM0, OPSZ_8))
 OPCODE(vmovsd_xlok7xhi, vmovsd, vmovsd_NDS_mask, X64_ONLY, REGARG(XMM0), REGARG(K7),
        REGARG_PARTIAL(XMM1, OPSZ_8), REGARG_PARTIAL(XMM16, OPSZ_8))
+OPCODE(vunpcklps_xlok0xlold, vunpcklps, vunpcklps_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vunpcklps_xhik7xhild, vunpcklps, vunpcklps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vunpcklps_ylok0ylold, vunpcklps, vunpcklps_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG_PARTIAL(YMM1, OPSZ_16), MEMARG(OPSZ_16))
+OPCODE(vunpcklps_yhik7yhild, vunpcklps, vunpcklps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG_PARTIAL(YMM31, OPSZ_16), MEMARG(OPSZ_16))
+OPCODE(vunpcklps_zlok0zlold, vunpcklps, vunpcklps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG_PARTIAL(ZMM1, OPSZ_32), MEMARG(OPSZ_32))
+OPCODE(vunpcklps_zhik7zhild, vunpcklps, vunpcklps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG_PARTIAL(ZMM31, OPSZ_32), MEMARG(OPSZ_32))
+OPCODE(vunpcklpd_xlok0xlold, vunpcklpd, vunpcklpd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vunpcklpd_xhik7xhild, vunpcklpd, vunpcklpd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vunpcklpd_ylok0ylold, vunpcklpd, vunpcklpd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG_PARTIAL(YMM1, OPSZ_16), MEMARG(OPSZ_16))
+OPCODE(vunpcklpd_yhik7yhild, vunpcklpd, vunpcklpd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG_PARTIAL(YMM31, OPSZ_16), MEMARG(OPSZ_16))
+OPCODE(vunpcklpd_zlok0zlold, vunpcklpd, vunpcklpd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG_PARTIAL(ZMM1, OPSZ_32), MEMARG(OPSZ_32))
+OPCODE(vunpcklpd_zhik7zhild, vunpcklpd, vunpcklpd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG_PARTIAL(ZMM31, OPSZ_32), MEMARG(OPSZ_32))
+OPCODE(vunpckhps_xlok0xlold, vunpckhps, vunpckhps_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vunpckhps_xhik7xhild, vunpckhps, vunpckhps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vunpckhps_ylok0ylold, vunpckhps, vunpckhps_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG_PARTIAL(YMM1, OPSZ_16), MEMARG(OPSZ_16))
+OPCODE(vunpckhps_yhik7yhild, vunpckhps, vunpckhps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG_PARTIAL(YMM31, OPSZ_16), MEMARG(OPSZ_16))
+OPCODE(vunpckhps_zlok0zlold, vunpckhps, vunpckhps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG_PARTIAL(ZMM1, OPSZ_32), MEMARG(OPSZ_32))
+OPCODE(vunpckhps_zhik7zhild, vunpckhps, vunpckhps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG_PARTIAL(ZMM31, OPSZ_32), MEMARG(OPSZ_32))
+OPCODE(vunpckhpd_xlok0xlold, vunpckhpd, vunpckhpd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vunpckhpd_xhik7xhild, vunpckhpd, vunpckhpd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vunpckhpd_ylok0ylold, vunpckhpd, vunpckhpd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG_PARTIAL(YMM1, OPSZ_16), MEMARG(OPSZ_16))
+OPCODE(vunpckhpd_yhik7yhild, vunpckhpd, vunpckhpd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG_PARTIAL(YMM31, OPSZ_16), MEMARG(OPSZ_16))
+OPCODE(vunpckhpd_zlok0zlold, vunpckhpd, vunpckhpd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG_PARTIAL(ZMM1, OPSZ_32), MEMARG(OPSZ_32))
+OPCODE(vunpckhpd_zhik7zhild, vunpckhpd, vunpckhpd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG_PARTIAL(ZMM31, OPSZ_32), MEMARG(OPSZ_32))
 /* TODO i#1312: Add missing instructions. */


### PR DESCRIPTION
Adds the evex instructions vunpcklps, vunpcklpd, vunpckhps, vunpckhpd, vcvtss2si,
vcvtsd2si, vcvtsi2ss, vcvtsi2sd, vcvttss2si, vcvttsd2si, vmovntps, vmovntpd, vcomiss,
vcomisd, vucomiss, vucomisd.

Adds to decoding support of evex type 'H' and type 'L'.

Adds tests for above.

Issue: #1312