### PR TITLE
i#1312 AVX-512 support: Bugfix, EVEX.V' is bit inverted.

### DIFF
--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -825,7 +825,7 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
         di->prefixes |= PREFIX_VEX_L;
     if (TEST(0x10, prefix_byte))
         di->prefixes |= PREFIX_EVEX_b;
-    if (TEST(0x08, prefix_byte))
+    if (!TEST(0x08, prefix_byte))
         di->prefixes |= PREFIX_EVEX_VV;
 
     di->evex_aaa = prefix_byte & 0x07;
@@ -1415,7 +1415,7 @@ decode_reg(decode_reg_t which_reg, decode_info_t *di, byte optype, opnd_size_t o
          */
         reg = (~di->evex_vvvv) & 0xf; /* bit-inverted */
         extend = false;
-        avx512_extend = !TEST(PREFIX_EVEX_VV, di->prefixes); /* bit-inverted */
+        avx512_extend = TEST(PREFIX_EVEX_VV, di->prefixes); /* bit-inverted */
         break;
     case DECODE_REG_OPMASK:
         /* Part of AVX-512: evex.aaa selects opmask register. */

--- a/core/arch/x86/encode.c
+++ b/core/arch/x86/encode.c
@@ -2310,7 +2310,7 @@ encode_evex_prefixes(byte *field_ptr, decode_info_t *di, const instr_info_t *inf
         (TEST(PREFIX_EVEX_LL, di->prefixes) ? 0x40 : 0x00) |
         (TEST(PREFIX_VEX_L, di->prefixes) ? 0x20 : 0x00) |
         (TEST(PREFIX_EVEX_b, di->prefixes) ? 0x10 : 0x00) |
-        (TEST(PREFIX_EVEX_VV, di->prefixes) ? 0x08 : 0x00);
+        (TEST(PREFIX_EVEX_VV, di->prefixes) ? 0x00 : 0x08);
     /* we override OPCODE_SUFFIX for evex to mean "requires evex.L" */
     /* XXX i#1312: what about evex.L'? */
     if (TEST(OPCODE_SUFFIX, info->opcode))


### PR DESCRIPTION
Fixes EVEX decoder and inverted logic for V'. Rountrips do not test this kind of
bug. More thorough testing will be added through disassembler tests once more
instructions have been enabled.

Issue: #1312