### PR TITLE
i#1312 AVX-512 support: Fix AVX vcvtss2sd, vcvtsd2ss's destination in decode table.

### DIFF
--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -3188,9 +3188,9 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_cvtpd2ps, 0x660f5a10, "cvtpd2ps", Vps, xx, Wpd, xx, xx, mrm, x, END_LIST},
     {OP_cvtsd2ss, 0xf20f5a10, "cvtsd2ss", Vss, xx, Wsd, xx, xx, mrm, x, END_LIST},
     {OP_vcvtps2pd, 0x0f5a10, "vcvtps2pd", Vvd, xx, Wvs, xx, xx, mrm|vex, x, END_LIST},
-    {OP_vcvtss2sd, 0xf30f5a10, "vcvtss2sd", Vsd, xx, Hsd, Wss, xx, mrm|vex, x, END_LIST},
+    {OP_vcvtss2sd, 0xf30f5a10, "vcvtss2sd", Vdq, xx, Hsd, Wss, xx, mrm|vex, x, END_LIST},
     {OP_vcvtpd2ps, 0x660f5a10, "vcvtpd2ps", Vvs, xx, Wvd, xx, xx, mrm|vex, x, END_LIST},
-    {OP_vcvtsd2ss, 0xf20f5a10, "vcvtsd2ss", Vss, xx, H12_dq, Wsd, xx, mrm|vex, x, END_LIST},
+    {OP_vcvtsd2ss, 0xf20f5a10, "vcvtsd2ss", Vdq, xx, H12_dq, Wsd, xx, mrm|vex, x, END_LIST},
     /* TODO i#1312: Support AVX-512. */
     {INVALID,   0x0f5a10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf30f5a10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -6279,14 +6279,14 @@ const instr_info_t vex_W_extensions[][2] = {
     {OP_vfmadd231ps,0x6638b818,"vfmadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfmadd231pd,0x6638b858,"vfmadd231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 3 */
-    {OP_vfmadd132ss,0x66389918,"vfmadd132ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmadd132sd,0x66389958,"vfmadd132sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd132ss,0x66389918,"vfmadd132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd132sd,0x66389958,"vfmadd132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 4 */
-    {OP_vfmadd213ss,0x6638a918,"vfmadd213ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmadd213sd,0x6638a958,"vfmadd213sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd213ss,0x6638a918,"vfmadd213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd213sd,0x6638a958,"vfmadd213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 5 */
-    {OP_vfmadd231ss,0x6638b918,"vfmadd231ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmadd231sd,0x6638b958,"vfmadd231sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd231ss,0x6638b918,"vfmadd231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd231sd,0x6638b958,"vfmadd231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 6 */
     {OP_vfmaddsub132ps,0x66389618,"vfmaddsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfmaddsub132pd,0x66389658,"vfmaddsub132pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
@@ -6315,14 +6315,14 @@ const instr_info_t vex_W_extensions[][2] = {
     {OP_vfmsub231ps,0x6638ba18,"vfmsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfmsub231pd,0x6638ba58,"vfmsub231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 15 */
-    {OP_vfmsub132ss,0x66389b18,"vfmsub132ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsub132sd,0x66389b58,"vfmsub132sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub132ss,0x66389b18,"vfmsub132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub132sd,0x66389b58,"vfmsub132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 16 */
-    {OP_vfmsub213ss,0x6638ab18,"vfmsub213ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsub213sd,0x6638ab58,"vfmsub213sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub213ss,0x6638ab18,"vfmsub213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub213sd,0x6638ab58,"vfmsub213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 17 */
-    {OP_vfmsub231ss,0x6638bb18,"vfmsub231ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsub231sd,0x6638bb58,"vfmsub231sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub231ss,0x6638bb18,"vfmsub231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub231sd,0x6638bb58,"vfmsub231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 18 */
     {OP_vfnmadd132ps,0x66389c18,"vfnmadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfnmadd132pd,0x66389c58,"vfnmadd132pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
@@ -6333,14 +6333,14 @@ const instr_info_t vex_W_extensions[][2] = {
     {OP_vfnmadd231ps,0x6638bc18,"vfnmadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfnmadd231pd,0x6638bc58,"vfnmadd231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 21 */
-    {OP_vfnmadd132ss,0x66389d18,"vfnmadd132ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmadd132sd,0x66389d58,"vfnmadd132sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd132ss,0x66389d18,"vfnmadd132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd132sd,0x66389d58,"vfnmadd132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 22 */
-    {OP_vfnmadd213ss,0x6638ad18,"vfnmadd213ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmadd213sd,0x6638ad58,"vfnmadd213sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd213ss,0x6638ad18,"vfnmadd213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd213sd,0x6638ad58,"vfnmadd213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 23 */
-    {OP_vfnmadd231ss,0x6638bd18,"vfnmadd231ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmadd231sd,0x6638bd58,"vfnmadd231sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd231ss,0x6638bd18,"vfnmadd231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd231sd,0x6638bd58,"vfnmadd231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 24 */
     {OP_vfnmsub132ps,0x66389e18,"vfnmsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfnmsub132pd,0x66389e58,"vfnmsub132pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
@@ -6351,14 +6351,14 @@ const instr_info_t vex_W_extensions[][2] = {
     {OP_vfnmsub231ps,0x6638be18,"vfnmsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfnmsub231pd,0x6638be58,"vfnmsub231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 27 */
-    {OP_vfnmsub132ss,0x66389f18,"vfnmsub132ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmsub132sd,0x66389f58,"vfnmsub132sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub132ss,0x66389f18,"vfnmsub132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub132sd,0x66389f58,"vfnmsub132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 28 */
-    {OP_vfnmsub213ss,0x6638af18,"vfnmsub213ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmsub213sd,0x6638af58,"vfnmsub213sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub213ss,0x6638af18,"vfnmsub213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub213sd,0x6638af58,"vfnmsub213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 29 */
-    {OP_vfnmsub231ss,0x6638bf18,"vfnmsub231ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmsub231sd,0x6638bf58,"vfnmsub231sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub231ss,0x6638bf18,"vfnmsub231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub231sd,0x6638bf58,"vfnmsub231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 30 */
     {OP_vfmaddsubps,0x663a5c18,"vfmaddsubps",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[30][1]},
     {OP_vfmaddsubps,0x663a5c58,"vfmaddsubps",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -6279,14 +6279,14 @@ const instr_info_t vex_W_extensions[][2] = {
     {OP_vfmadd231ps,0x6638b818,"vfmadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfmadd231pd,0x6638b858,"vfmadd231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 3 */
-    {OP_vfmadd132ss,0x66389918,"vfmadd132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmadd132sd,0x66389958,"vfmadd132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd132ss,0x66389918,"vfmadd132ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd132sd,0x66389958,"vfmadd132sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 4 */
-    {OP_vfmadd213ss,0x6638a918,"vfmadd213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmadd213sd,0x6638a958,"vfmadd213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd213ss,0x6638a918,"vfmadd213ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd213sd,0x6638a958,"vfmadd213sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 5 */
-    {OP_vfmadd231ss,0x6638b918,"vfmadd231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmadd231sd,0x6638b958,"vfmadd231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd231ss,0x6638b918,"vfmadd231ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd231sd,0x6638b958,"vfmadd231sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 6 */
     {OP_vfmaddsub132ps,0x66389618,"vfmaddsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfmaddsub132pd,0x66389658,"vfmaddsub132pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
@@ -6315,14 +6315,14 @@ const instr_info_t vex_W_extensions[][2] = {
     {OP_vfmsub231ps,0x6638ba18,"vfmsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfmsub231pd,0x6638ba58,"vfmsub231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 15 */
-    {OP_vfmsub132ss,0x66389b18,"vfmsub132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsub132sd,0x66389b58,"vfmsub132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub132ss,0x66389b18,"vfmsub132ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub132sd,0x66389b58,"vfmsub132sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 16 */
-    {OP_vfmsub213ss,0x6638ab18,"vfmsub213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsub213sd,0x6638ab58,"vfmsub213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub213ss,0x6638ab18,"vfmsub213ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub213sd,0x6638ab58,"vfmsub213sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 17 */
-    {OP_vfmsub231ss,0x6638bb18,"vfmsub231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsub231sd,0x6638bb58,"vfmsub231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub231ss,0x6638bb18,"vfmsub231ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub231sd,0x6638bb58,"vfmsub231sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 18 */
     {OP_vfnmadd132ps,0x66389c18,"vfnmadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfnmadd132pd,0x66389c58,"vfnmadd132pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
@@ -6333,14 +6333,14 @@ const instr_info_t vex_W_extensions[][2] = {
     {OP_vfnmadd231ps,0x6638bc18,"vfnmadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfnmadd231pd,0x6638bc58,"vfnmadd231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 21 */
-    {OP_vfnmadd132ss,0x66389d18,"vfnmadd132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmadd132sd,0x66389d58,"vfnmadd132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd132ss,0x66389d18,"vfnmadd132ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd132sd,0x66389d58,"vfnmadd132sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 22 */
-    {OP_vfnmadd213ss,0x6638ad18,"vfnmadd213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmadd213sd,0x6638ad58,"vfnmadd213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd213ss,0x6638ad18,"vfnmadd213ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd213sd,0x6638ad58,"vfnmadd213sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 23 */
-    {OP_vfnmadd231ss,0x6638bd18,"vfnmadd231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmadd231sd,0x6638bd58,"vfnmadd231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd231ss,0x6638bd18,"vfnmadd231ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd231sd,0x6638bd58,"vfnmadd231sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 24 */
     {OP_vfnmsub132ps,0x66389e18,"vfnmsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfnmsub132pd,0x66389e58,"vfnmsub132pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
@@ -6351,14 +6351,14 @@ const instr_info_t vex_W_extensions[][2] = {
     {OP_vfnmsub231ps,0x6638be18,"vfnmsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
     {OP_vfnmsub231pd,0x6638be58,"vfnmsub231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 27 */
-    {OP_vfnmsub132ss,0x66389f18,"vfnmsub132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmsub132sd,0x66389f58,"vfnmsub132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub132ss,0x66389f18,"vfnmsub132ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub132sd,0x66389f58,"vfnmsub132sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 28 */
-    {OP_vfnmsub213ss,0x6638af18,"vfnmsub213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmsub213sd,0x6638af58,"vfnmsub213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub213ss,0x6638af18,"vfnmsub213ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub213sd,0x6638af58,"vfnmsub213sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 29 */
-    {OP_vfnmsub231ss,0x6638bf18,"vfnmsub231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmsub231sd,0x6638bf58,"vfnmsub231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub231ss,0x6638bf18,"vfnmsub231ss",Vdq,xx,Hss,Wss,Vdq,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub231sd,0x6638bf58,"vfnmsub231sd",Vdq,xx,Hsd,Wsd,Vdq,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 30 */
     {OP_vfmaddsubps,0x663a5c18,"vfmaddsubps",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[30][1]},
     {OP_vfmaddsubps,0x663a5c58,"vfmaddsubps",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},

--- a/suite/tests/api/ir_x86_3args.h
+++ b/suite/tests/api/ir_x86_3args.h
@@ -159,10 +159,10 @@ OPCODE(vmulps, vmulps, vmulps, 0, REGARG(XMM0), REGARG(XMM1), MEMARG(OPSZ_16))
 OPCODE(vmulss, vmulss, vmulss, 0, REGARG(XMM0), REGARG(XMM1), MEMARG(OPSZ_4))
 OPCODE(vmulpd, vmulpd, vmulpd, 0, REGARG(XMM0), REGARG(XMM1), MEMARG(OPSZ_16))
 OPCODE(vmulsd, vmulsd, vmulsd, 0, REGARG(XMM0), REGARG(XMM1), MEMARG(OPSZ_8))
-OPCODE(vcvtss2sd, vcvtss2sd, vcvtss2sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
-       REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_4))
-OPCODE(vcvtsd2ss, vcvtsd2ss, vcvtsd2ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
-       REGARG_PARTIAL(XMM1, OPSZ_12), MEMARG(OPSZ_8))
+OPCODE(vcvtss2sd, vcvtss2sd, vcvtss2sd, 0, REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_4))
+OPCODE(vcvtsd2ss, vcvtsd2ss, vcvtsd2ss, 0, REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_12),
+       MEMARG(OPSZ_8))
 OPCODE(vsubps, vsubps, vsubps, 0, REGARG(XMM0), REGARG(XMM1), MEMARG(OPSZ_16))
 OPCODE(vsubss, vsubss, vsubss, 0, REGARG(XMM0), REGARG(XMM1), MEMARG(OPSZ_4))
 OPCODE(vsubpd, vsubpd, vsubpd, 0, REGARG(XMM0), REGARG(XMM1), MEMARG(OPSZ_16))

--- a/suite/tests/api/ir_x86_3args_avx.h
+++ b/suite/tests/api/ir_x86_3args_avx.h
@@ -241,17 +241,17 @@ OPCODE(vfmadd231ps, vfmadd231ps, vfmadd231ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
 OPCODE(vfmadd231pd, vfmadd231pd, vfmadd231pd, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
-OPCODE(vfmadd132ss, vfmadd132ss, vfmadd132ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
+OPCODE(vfmadd132ss, vfmadd132ss, vfmadd132ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfmadd132sd, vfmadd132sd, vfmadd132sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+OPCODE(vfmadd132sd, vfmadd132sd, vfmadd132sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfmadd213ss, vfmadd213ss, vfmadd213ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
+OPCODE(vfmadd213ss, vfmadd213ss, vfmadd213ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfmadd213sd, vfmadd213sd, vfmadd213sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+OPCODE(vfmadd213sd, vfmadd213sd, vfmadd213sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfmadd231ss, vfmadd231ss, vfmadd231ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
+OPCODE(vfmadd231ss, vfmadd231ss, vfmadd231ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfmadd231sd, vfmadd231sd, vfmadd231sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+OPCODE(vfmadd231sd, vfmadd231sd, vfmadd231sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
 OPCODE(vfmaddsub132ps, vfmaddsub132ps, vfmaddsub132ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
@@ -289,17 +289,17 @@ OPCODE(vfmsub231ps, vfmsub231ps, vfmsub231ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
 OPCODE(vfmsub231pd, vfmsub231pd, vfmsub231pd, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
-OPCODE(vfmsub132ss, vfmsub132ss, vfmsub132ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
+OPCODE(vfmsub132ss, vfmsub132ss, vfmsub132ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfmsub132sd, vfmsub132sd, vfmsub132sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+OPCODE(vfmsub132sd, vfmsub132sd, vfmsub132sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfmsub213ss, vfmsub213ss, vfmsub213ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
+OPCODE(vfmsub213ss, vfmsub213ss, vfmsub213ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfmsub213sd, vfmsub213sd, vfmsub213sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+OPCODE(vfmsub213sd, vfmsub213sd, vfmsub213sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfmsub231ss, vfmsub231ss, vfmsub231ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
+OPCODE(vfmsub231ss, vfmsub231ss, vfmsub231ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfmsub231sd, vfmsub231sd, vfmsub231sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+OPCODE(vfmsub231sd, vfmsub231sd, vfmsub231sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
 OPCODE(vfnmadd132ps, vfnmadd132ps, vfnmadd132ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
@@ -313,17 +313,17 @@ OPCODE(vfnmadd231ps, vfnmadd231ps, vfnmadd231ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
 OPCODE(vfnmadd231pd, vfnmadd231pd, vfnmadd231pd, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
-OPCODE(vfnmadd132ss, vfnmadd132ss, vfnmadd132ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
+OPCODE(vfnmadd132ss, vfnmadd132ss, vfnmadd132ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfnmadd132sd, vfnmadd132sd, vfnmadd132sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+OPCODE(vfnmadd132sd, vfnmadd132sd, vfnmadd132sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfnmadd213ss, vfnmadd213ss, vfnmadd213ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
+OPCODE(vfnmadd213ss, vfnmadd213ss, vfnmadd213ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfnmadd213sd, vfnmadd213sd, vfnmadd213sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+OPCODE(vfnmadd213sd, vfnmadd213sd, vfnmadd213sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfnmadd231ss, vfnmadd231ss, vfnmadd231ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
+OPCODE(vfnmadd231ss, vfnmadd231ss, vfnmadd231ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfnmadd231sd, vfnmadd231sd, vfnmadd231sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+OPCODE(vfnmadd231sd, vfnmadd231sd, vfnmadd231sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
 OPCODE(vfnmsub132ps, vfnmsub132ps, vfnmsub132ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
@@ -337,17 +337,17 @@ OPCODE(vfnmsub231ps, vfnmsub231ps, vfnmsub231ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
 OPCODE(vfnmsub231pd, vfnmsub231pd, vfnmsub231pd, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
-OPCODE(vfnmsub132ss, vfnmsub132ss, vfnmsub132ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
+OPCODE(vfnmsub132ss, vfnmsub132ss, vfnmsub132ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfnmsub132sd, vfnmsub132sd, vfnmsub132sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+OPCODE(vfnmsub132sd, vfnmsub132sd, vfnmsub132sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfnmsub213ss, vfnmsub213ss, vfnmsub213ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
+OPCODE(vfnmsub213ss, vfnmsub213ss, vfnmsub213ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfnmsub213sd, vfnmsub213sd, vfnmsub213sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+OPCODE(vfnmsub213sd, vfnmsub213sd, vfnmsub213sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfnmsub231ss, vfnmsub231ss, vfnmsub231ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
+OPCODE(vfnmsub231ss, vfnmsub231ss, vfnmsub231ss, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfnmsub231sd, vfnmsub231sd, vfnmsub231sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
+OPCODE(vfnmsub231sd, vfnmsub231sd, vfnmsub231sd, 0, REGARG(XMM0),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
 
 /* FMA 256-bit */

--- a/suite/tests/api/ir_x86_3args_avx.h
+++ b/suite/tests/api/ir_x86_3args_avx.h
@@ -241,17 +241,17 @@ OPCODE(vfmadd231ps, vfmadd231ps, vfmadd231ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
 OPCODE(vfmadd231pd, vfmadd231pd, vfmadd231pd, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
-OPCODE(vfmadd132ss, vfmadd132ss, vfmadd132ss, 0, REGARG(XMM0),
+OPCODE(vfmadd132ss, vfmadd132ss, vfmadd132ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfmadd132sd, vfmadd132sd, vfmadd132sd, 0, REGARG(XMM0),
+OPCODE(vfmadd132sd, vfmadd132sd, vfmadd132sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfmadd213ss, vfmadd213ss, vfmadd213ss, 0, REGARG(XMM0),
+OPCODE(vfmadd213ss, vfmadd213ss, vfmadd213ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfmadd213sd, vfmadd213sd, vfmadd213sd, 0, REGARG(XMM0),
+OPCODE(vfmadd213sd, vfmadd213sd, vfmadd213sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfmadd231ss, vfmadd231ss, vfmadd231ss, 0, REGARG(XMM0),
+OPCODE(vfmadd231ss, vfmadd231ss, vfmadd231ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfmadd231sd, vfmadd231sd, vfmadd231sd, 0, REGARG(XMM0),
+OPCODE(vfmadd231sd, vfmadd231sd, vfmadd231sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
 OPCODE(vfmaddsub132ps, vfmaddsub132ps, vfmaddsub132ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
@@ -289,17 +289,17 @@ OPCODE(vfmsub231ps, vfmsub231ps, vfmsub231ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
 OPCODE(vfmsub231pd, vfmsub231pd, vfmsub231pd, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
-OPCODE(vfmsub132ss, vfmsub132ss, vfmsub132ss, 0, REGARG(XMM0),
+OPCODE(vfmsub132ss, vfmsub132ss, vfmsub132ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfmsub132sd, vfmsub132sd, vfmsub132sd, 0, REGARG(XMM0),
+OPCODE(vfmsub132sd, vfmsub132sd, vfmsub132sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfmsub213ss, vfmsub213ss, vfmsub213ss, 0, REGARG(XMM0),
+OPCODE(vfmsub213ss, vfmsub213ss, vfmsub213ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfmsub213sd, vfmsub213sd, vfmsub213sd, 0, REGARG(XMM0),
+OPCODE(vfmsub213sd, vfmsub213sd, vfmsub213sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfmsub231ss, vfmsub231ss, vfmsub231ss, 0, REGARG(XMM0),
+OPCODE(vfmsub231ss, vfmsub231ss, vfmsub231ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfmsub231sd, vfmsub231sd, vfmsub231sd, 0, REGARG(XMM0),
+OPCODE(vfmsub231sd, vfmsub231sd, vfmsub231sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
 OPCODE(vfnmadd132ps, vfnmadd132ps, vfnmadd132ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
@@ -313,17 +313,17 @@ OPCODE(vfnmadd231ps, vfnmadd231ps, vfnmadd231ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
 OPCODE(vfnmadd231pd, vfnmadd231pd, vfnmadd231pd, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
-OPCODE(vfnmadd132ss, vfnmadd132ss, vfnmadd132ss, 0, REGARG(XMM0),
+OPCODE(vfnmadd132ss, vfnmadd132ss, vfnmadd132ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfnmadd132sd, vfnmadd132sd, vfnmadd132sd, 0, REGARG(XMM0),
+OPCODE(vfnmadd132sd, vfnmadd132sd, vfnmadd132sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfnmadd213ss, vfnmadd213ss, vfnmadd213ss, 0, REGARG(XMM0),
+OPCODE(vfnmadd213ss, vfnmadd213ss, vfnmadd213ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfnmadd213sd, vfnmadd213sd, vfnmadd213sd, 0, REGARG(XMM0),
+OPCODE(vfnmadd213sd, vfnmadd213sd, vfnmadd213sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfnmadd231ss, vfnmadd231ss, vfnmadd231ss, 0, REGARG(XMM0),
+OPCODE(vfnmadd231ss, vfnmadd231ss, vfnmadd231ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfnmadd231sd, vfnmadd231sd, vfnmadd231sd, 0, REGARG(XMM0),
+OPCODE(vfnmadd231sd, vfnmadd231sd, vfnmadd231sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
 OPCODE(vfnmsub132ps, vfnmsub132ps, vfnmsub132ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
@@ -337,17 +337,17 @@ OPCODE(vfnmsub231ps, vfnmsub231ps, vfnmsub231ps, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
 OPCODE(vfnmsub231pd, vfnmsub231pd, vfnmsub231pd, 0, REGARG(XMM0), REGARG(XMM1),
        MEMARG(OPSZ_16))
-OPCODE(vfnmsub132ss, vfnmsub132ss, vfnmsub132ss, 0, REGARG(XMM0),
+OPCODE(vfnmsub132ss, vfnmsub132ss, vfnmsub132ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfnmsub132sd, vfnmsub132sd, vfnmsub132sd, 0, REGARG(XMM0),
+OPCODE(vfnmsub132sd, vfnmsub132sd, vfnmsub132sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfnmsub213ss, vfnmsub213ss, vfnmsub213ss, 0, REGARG(XMM0),
+OPCODE(vfnmsub213ss, vfnmsub213ss, vfnmsub213ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfnmsub213sd, vfnmsub213sd, vfnmsub213sd, 0, REGARG(XMM0),
+OPCODE(vfnmsub213sd, vfnmsub213sd, vfnmsub213sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
-OPCODE(vfnmsub231ss, vfnmsub231ss, vfnmsub231ss, 0, REGARG(XMM0),
+OPCODE(vfnmsub231ss, vfnmsub231ss, vfnmsub231ss, 0, REGARG_PARTIAL(XMM0, OPSZ_4),
        REGARG_PARTIAL(XMM1, OPSZ_4), MEMARG(OPSZ_4))
-OPCODE(vfnmsub231sd, vfnmsub231sd, vfnmsub231sd, 0, REGARG(XMM0),
+OPCODE(vfnmsub231sd, vfnmsub231sd, vfnmsub231sd, 0, REGARG_PARTIAL(XMM0, OPSZ_8),
        REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
 
 /* FMA 256-bit */


### PR DESCRIPTION
Submission 738842b missed to fix some of the convert opcodes.

Issue: #1312