### PR TITLE
Add the tag of the replaced cache block in the cache stats interface

### DIFF
--- a/clients/drcachesim/simulator/cache_stats.cpp
+++ b/clients/drcachesim/simulator/cache_stats.cpp
@@ -43,7 +43,7 @@ cache_stats_t::cache_stats_t(const std::string &miss_file, bool warmup_enabled)
 }
 
 void
-cache_stats_t::access(const memref_t &memref, bool hit)
+cache_stats_t::access(const memref_t &memref, bool hit, addr_t replaced_block)
 {
     // handle prefetching requests
     if (type_is_prefetch(memref.data.type)) {

--- a/clients/drcachesim/simulator/cache_stats.h
+++ b/clients/drcachesim/simulator/cache_stats.h
@@ -47,7 +47,7 @@ public:
     // In addition to caching_device_stats_t::access,
     // cache_stats_t::access processes prefetching requests.
     virtual void
-    access(const memref_t &memref, bool hit);
+    access(const memref_t &memref, bool hit, addr_t replaced_block = TAG_INVALID);
 
     // process CPU cache flushes
     virtual void

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -76,7 +76,7 @@ caching_device_stats_t::~caching_device_stats_t()
 }
 
 void
-caching_device_stats_t::access(const memref_t &memref, bool hit)
+caching_device_stats_t::access(const memref_t &memref, bool hit, addr_t replaced_block)
 {
     // We assume we're single-threaded.
     // We're only computing miss rate so we just inc counters here.
@@ -90,7 +90,8 @@ caching_device_stats_t::access(const memref_t &memref, bool hit)
 }
 
 void
-caching_device_stats_t::child_access(const memref_t &memref, bool hit)
+caching_device_stats_t::child_access(const memref_t &memref, bool hit,
+                                     addr_t replaced_block)
 {
     if (hit)
         num_child_hits++;

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -36,6 +36,7 @@
 #ifndef _CACHING_DEVICE_STATS_H_
 #define _CACHING_DEVICE_STATS_H_ 1
 
+#include "caching_device_block.h"
 #include <string>
 #include <stdint.h>
 #ifdef HAS_ZLIB
@@ -53,11 +54,11 @@ public:
     // A multi-block memory reference invokes this routine
     // separately for each block touched.
     virtual void
-    access(const memref_t &memref, bool hit);
+    access(const memref_t &memref, bool hit, addr_t replaced_block = TAG_INVALID);
 
     // Called on each access by a child caching device.
     virtual void
-    child_access(const memref_t &memref, bool hit);
+    child_access(const memref_t &memref, bool hit, addr_t replaced_block = TAG_INVALID);
 
     virtual void
     print_stats(std::string prefix);


### PR DESCRIPTION
Add the tag of the replaced cache block in the cache stats interface. This would allow us to perform analyses on replaced cache blocks by extending the cache_stats_t class. Example of useful analyses: fraction of blocks that never get accessed while in the cache.