### PR TITLE
i#1312 AVX-512 support: Add SYSLOG warning when evex prefix is encountered.

### DIFF
--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -742,7 +742,7 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
         }
         *is_evex = true;
 #if !defined(STANDALONE_DECODER)
-        SYSLOG(SYSLOG_WARNING, AVX_512_SUPPORT_INCOMPLETE, 2, get_application_name(),
+        SYSLOG(SYSLOG_ERROR, AVX_512_SUPPORT_INCOMPLETE, 2, get_application_name(),
                get_application_pid(), pc);
 #endif
         info = &evex_prefix_extensions[0][1];

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -744,6 +744,7 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
 #if !defined(STANDALONE_DECODER)
         char pc_addr[IF_X64_ELSE(20, 12)];
         snprintf(pc_addr, BUFFER_SIZE_ELEMENTS(pc_addr), PFX, pc);
+        NULL_TERMINATE_BUFFER(pc_addr);
         SYSLOG(SYSLOG_ERROR, AVX_512_SUPPORT_INCOMPLETE, 2, get_application_name(),
                get_application_pid(), pc_addr);
 #endif

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -741,6 +741,7 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
             return pc;
         }
         *is_evex = true;
+        SYSLOG_INTERNAL_WARNING_ONCE(MSG_AVX_512_SUPPORT_INCOMPLETE_STRING " @" PFX, pc);
         info = &evex_prefix_extensions[0][1];
     } else {
         /* not evex */

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -745,8 +745,8 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
         char pc_addr[IF_X64_ELSE(20, 12)];
         snprintf(pc_addr, BUFFER_SIZE_ELEMENTS(pc_addr), PFX, pc);
         NULL_TERMINATE_BUFFER(pc_addr);
-        SYSLOG(SYSLOG_ERROR, AVX_512_SUPPORT_INCOMPLETE, 2, get_application_name(),
-               get_application_pid(), pc_addr);
+        DO_ONCE(SYSLOG(SYSLOG_ERROR, AVX_512_SUPPORT_INCOMPLETE, 2,
+                       get_application_name(), get_application_pid(), pc_addr));
 #endif
         info = &evex_prefix_extensions[0][1];
     } else {

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -742,8 +742,10 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
         }
         *is_evex = true;
 #if !defined(STANDALONE_DECODER)
+        char pc_addr[IF_X64_ELSE(20, 12)];
+        snprintf(pc_addr, BUFFER_SIZE_ELEMENTS(pc_addr), PFX, pc);
         SYSLOG(SYSLOG_ERROR, AVX_512_SUPPORT_INCOMPLETE, 2, get_application_name(),
-               get_application_pid(), pc);
+               get_application_pid(), pc_addr);
 #endif
         info = &evex_prefix_extensions[0][1];
     } else {

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -741,7 +741,10 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
             return pc;
         }
         *is_evex = true;
-        SYSLOG_INTERNAL_WARNING_ONCE(MSG_AVX_512_SUPPORT_INCOMPLETE_STRING " @" PFX, pc);
+#if !defined(STANDALONE_DECODER)
+        SYSLOG(SYSLOG_WARNING, AVX_512_SUPPORT_INCOMPLETE, 2, get_application_name(),
+               get_application_pid(), pc);
+#endif
         info = &evex_prefix_extensions[0][1];
     } else {
         /* not evex */

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -667,7 +667,7 @@ Severity = Error
 Facility = DRCore
 SymbolicName = MSG_AVX_512_SUPPORT_INCOMPLETE
 Language=English
-Application %1!s! (%2!s!): AVX-512 was detected at PC 0x%3!lx!
+Application %1!s! (%2!s!): AVX-512 was detected at PC %3!s!
 .
 
 ;// ADD NEW MESSAGES HERE

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -667,7 +667,7 @@ Severity = Error
 Facility = DRCore
 SymbolicName = MSG_AVX_512_SUPPORT_INCOMPLETE
 Language=English
-AVX-512 is not yet supported.
+Application %1!s! (%2!s!): AVX-512 was detected at PC 0x%3!lx!
 .
 
 ;// ADD NEW MESSAGES HERE

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -667,7 +667,7 @@ Severity = Error
 Facility = DRCore
 SymbolicName = MSG_AVX_512_SUPPORT_INCOMPLETE
 Language=English
-Application %1!s! (%2!s!): AVX-512 was detected at PC %3!s!.
+Application %1!s! (%2!s!): AVX-512 was detected at PC %3!s!. AVX-512 is not fully supported yet.
 .
 
 ;// ADD NEW MESSAGES HERE

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -662,4 +662,12 @@ Language=English
 Application %1!s! (%2!s!). Out of contiguous memory. %3!s!
 .
 
+MessageId =
+Severity = Error
+Facility = DRCore
+SymbolicName = MSG_AVX_512_SUPPORT_INCOMPLETE
+Language=English
+AVX-512 is not yet supported.
+.
+
 ;// ADD NEW MESSAGES HERE

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -667,7 +667,7 @@ Severity = Error
 Facility = DRCore
 SymbolicName = MSG_AVX_512_SUPPORT_INCOMPLETE
 Language=English
-Application %1!s! (%2!s!): AVX-512 was detected at PC %3!s!
+Application %1!s! (%2!s!): AVX-512 was detected at PC %3!s!.
 .
 
 ;// ADD NEW MESSAGES HERE

--- a/suite/tests/api/ir_x86.expect
+++ b/suite/tests/api/ir_x86.expect
@@ -1,1 +1,0 @@
-all done

--- a/suite/tests/api/ir_x86.templatex
+++ b/suite/tests/api/ir_x86.templatex
@@ -1,0 +1,2 @@
+(<Application .*api\.ir.*AVX-512 was detected at PC 0x[0-9a-f]+. AVX-512 is not fully supported yet.>
+)?all done


### PR DESCRIPTION
Adds a SYSLOG warning if the decoder recognizes an evex encoding until i#1312
will be completed and AVX-512 is fully supported.

Issue: #1312