### PR TITLE
Pass a pointer to the accessed or replaced cache block to the cache stats accessor

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -161,10 +161,11 @@ compatibility changes:
    as part of AVX-512, e.g. xmm16 - xmm31.
  - Dropped support for clients used with statically linked DynamoRIO to reach
    the code cache with 32-bit displacements.
- - An additional parameter in the accessors to the cache stats that passes
-   a pointer to the cache block being accessed (on a hit) or being replaced
-   (on a miss). This allows users to extend the cache block and stats classes
-   in order to collect more stats.
+ - An additional parameter in the accessors to the drcachesim cache stats
+   (namely cache_stats_t and caching_device_stats_t) that passes a pointer to
+   the cache block being accessed (on a hit) or being replaced (on a miss).
+   This allows users to extend the cache block and stats classes in order to
+   collect more stats.
 
 Further non-compatibility-affecting changes include:
 

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -65,6 +65,10 @@ The following are part of the DynamoRIO release distribution:
   PR 225255: list profile library too
 \endif
 
+ - An additional parameter in the accessors to the cache stats that passes
+   a pointer to the cache block being accessed (on a hit) or being replaced
+   (on a miss). This allows users to extend the cache block and stats classes
+   in order to collect more stats.
  - Four different DynamoRIO libraries: debug and release for each of
    32-bit and 64-bit (for ARM or AArch64 builds, only a single bitwidth
    matching the ISA is provided).

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -65,10 +65,6 @@ The following are part of the DynamoRIO release distribution:
   PR 225255: list profile library too
 \endif
 
- - An additional parameter in the accessors to the cache stats that passes
-   a pointer to the cache block being accessed (on a hit) or being replaced
-   (on a miss). This allows users to extend the cache block and stats classes
-   in order to collect more stats.
  - Four different DynamoRIO libraries: debug and release for each of
    32-bit and 64-bit (for ARM or AArch64 builds, only a single bitwidth
    matching the ISA is provided).
@@ -165,6 +161,10 @@ compatibility changes:
    as part of AVX-512, e.g. xmm16 - xmm31.
  - Dropped support for clients used with statically linked DynamoRIO to reach
    the code cache with 32-bit displacements.
+ - An additional parameter in the accessors to the cache stats that passes
+   a pointer to the cache block being accessed (on a hit) or being replaced
+   (on a miss). This allows users to extend the cache block and stats classes
+   in order to collect more stats.
 
 Further non-compatibility-affecting changes include:
 

--- a/clients/drcachesim/simulator/cache_stats.cpp
+++ b/clients/drcachesim/simulator/cache_stats.cpp
@@ -55,7 +55,7 @@ cache_stats_t::access(const memref_t &memref, bool hit, addr_t replaced_block)
                 dump_miss(memref);
         }
     } else { // handle regular memory accesses
-        caching_device_stats_t::access(memref, hit);
+        caching_device_stats_t::access(memref, hit, replaced_block);
     }
 }
 

--- a/clients/drcachesim/simulator/cache_stats.cpp
+++ b/clients/drcachesim/simulator/cache_stats.cpp
@@ -43,7 +43,8 @@ cache_stats_t::cache_stats_t(const std::string &miss_file, bool warmup_enabled)
 }
 
 void
-cache_stats_t::access(const memref_t &memref, bool hit, addr_t replaced_block)
+cache_stats_t::access(const memref_t &memref, bool hit,
+                      caching_device_block_t *cache_block)
 {
     // handle prefetching requests
     if (type_is_prefetch(memref.data.type)) {
@@ -55,7 +56,7 @@ cache_stats_t::access(const memref_t &memref, bool hit, addr_t replaced_block)
                 dump_miss(memref);
         }
     } else { // handle regular memory accesses
-        caching_device_stats_t::access(memref, hit, replaced_block);
+        caching_device_stats_t::access(memref, hit, cache_block);
     }
 }
 

--- a/clients/drcachesim/simulator/cache_stats.h
+++ b/clients/drcachesim/simulator/cache_stats.h
@@ -47,7 +47,7 @@ public:
     // In addition to caching_device_stats_t::access,
     // cache_stats_t::access processes prefetching requests.
     virtual void
-    access(const memref_t &memref, bool hit, addr_t replaced_block);
+    access(const memref_t &memref, bool hit, caching_device_block_t *cache_block);
 
     // process CPU cache flushes
     virtual void

--- a/clients/drcachesim/simulator/cache_stats.h
+++ b/clients/drcachesim/simulator/cache_stats.h
@@ -46,7 +46,8 @@ public:
 
     // In addition to caching_device_stats_t::access,
     // cache_stats_t::access processes prefetching requests.
-    virtual void access(const memref_t &memref, bool hit, addr_t replaced_block);
+    virtual void
+    access(const memref_t &memref, bool hit, addr_t replaced_block);
 
     // process CPU cache flushes
     virtual void

--- a/clients/drcachesim/simulator/cache_stats.h
+++ b/clients/drcachesim/simulator/cache_stats.h
@@ -46,8 +46,7 @@ public:
 
     // In addition to caching_device_stats_t::access,
     // cache_stats_t::access processes prefetching requests.
-    virtual void
-    access(const memref_t &memref, bool hit, addr_t replaced_block = TAG_INVALID);
+    virtual void access(const memref_t &memref, bool hit, addr_t replaced_block);
 
     // process CPU cache flushes
     virtual void

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -112,9 +112,9 @@ caching_device_t::request(const memref_t &memref_in)
         // Make sure last_tag is properly in sync.
         assert(tag != TAG_INVALID &&
                tag == get_caching_device_block(last_block_idx, last_way).tag);
-        stats->access(memref_in, true /*hit*/);
+        stats->access(memref_in, true /*hit*/, TAG_INVALID);
         if (parent != NULL)
-            parent->stats->child_access(memref_in, true);
+            parent->stats->child_access(memref_in, true, TAG_INVALID);
         access_update(last_block_idx, last_way);
         return;
     }
@@ -130,9 +130,9 @@ caching_device_t::request(const memref_t &memref_in)
 
         for (way = 0; way < associativity; ++way) {
             if (get_caching_device_block(block_idx, way).tag == tag) {
-                stats->access(memref, true /*hit*/);
+                stats->access(memref, true /*hit*/, TAG_INVALID);
                 if (parent != NULL)
-                    parent->stats->child_access(memref, true);
+                    parent->stats->child_access(memref, true, TAG_INVALID);
                 break;
             }
         }

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -76,7 +76,8 @@ caching_device_stats_t::~caching_device_stats_t()
 }
 
 void
-caching_device_stats_t::access(const memref_t &memref, bool hit, addr_t replaced_block)
+caching_device_stats_t::access(const memref_t &memref, bool hit,
+                               caching_device_block_t *cache_block)
 {
     // We assume we're single-threaded.
     // We're only computing miss rate so we just inc counters here.
@@ -91,7 +92,7 @@ caching_device_stats_t::access(const memref_t &memref, bool hit, addr_t replaced
 
 void
 caching_device_stats_t::child_access(const memref_t &memref, bool hit,
-                                     addr_t replaced_block)
+                                     caching_device_block_t *cache_block)
 {
     if (hit)
         num_child_hits++;

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -54,11 +54,11 @@ public:
     // A multi-block memory reference invokes this routine
     // separately for each block touched.
     virtual void
-    access(const memref_t &memref, bool hit, addr_t replaced_block);
+    access(const memref_t &memref, bool hit, caching_device_block_t *cache_block);
 
     // Called on each access by a child caching device.
     virtual void
-    child_access(const memref_t &memref, bool hit, addr_t replaced_block);
+    child_access(const memref_t &memref, bool hit, caching_device_block_t *cache_block);
 
     virtual void
     print_stats(std::string prefix);

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -54,11 +54,11 @@ public:
     // A multi-block memory reference invokes this routine
     // separately for each block touched.
     virtual void
-    access(const memref_t &memref, bool hit, addr_t replaced_block = TAG_INVALID);
+    access(const memref_t &memref, bool hit, addr_t replaced_block);
 
     // Called on each access by a child caching device.
     virtual void
-    child_access(const memref_t &memref, bool hit, addr_t replaced_block = TAG_INVALID);
+    child_access(const memref_t &memref, bool hit, addr_t replaced_block);
 
     virtual void
     print_stats(std::string prefix);

--- a/clients/drcachesim/simulator/tlb.cpp
+++ b/clients/drcachesim/simulator/tlb.cpp
@@ -69,9 +69,9 @@ tlb_t::request(const memref_t &memref_in)
             tag == get_caching_device_block(last_block_idx, last_way).tag &&
             pid ==
                 ((tlb_entry_t &)get_caching_device_block(last_block_idx, last_way)).pid);
-        stats->access(memref_in, true /*hit*/);
+        stats->access(memref_in, true /*hit*/, TAG_INVALID);
         if (parent != NULL)
-            parent->get_stats()->child_access(memref_in, true);
+            parent->get_stats()->child_access(memref_in, true, TAG_INVALID);
         access_update(last_block_idx, last_way);
         return;
     }
@@ -87,18 +87,18 @@ tlb_t::request(const memref_t &memref_in)
         for (way = 0; way < associativity; ++way) {
             if (get_caching_device_block(block_idx, way).tag == tag &&
                 ((tlb_entry_t &)get_caching_device_block(block_idx, way)).pid == pid) {
-                stats->access(memref, true /*hit*/);
+                stats->access(memref, true /*hit*/, TAG_INVALID);
                 if (parent != NULL)
-                    parent->get_stats()->child_access(memref, true);
+                    parent->get_stats()->child_access(memref, true, TAG_INVALID);
                 break;
             }
         }
 
         if (way == associativity) {
-            stats->access(memref, false /*miss*/);
+            stats->access(memref, false /*miss*/, TAG_INVALID);
             // If no parent we assume we get the data from main memory
             if (parent != NULL) {
-                parent->get_stats()->child_access(memref, false);
+                parent->get_stats()->child_access(memref, false, TAG_INVALID);
                 parent->request(memref);
             }
 

--- a/clients/drcachesim/simulator/tlb.cpp
+++ b/clients/drcachesim/simulator/tlb.cpp
@@ -64,14 +64,14 @@ tlb_t::request(const memref_t &memref_in)
     // Optimization: check last tag and pid if single-block
     if (tag == final_tag && tag == last_tag && pid == last_pid) {
         // Make sure last_tag and pid are properly in sync.
-        assert(
-            tag != TAG_INVALID &&
-            tag == get_caching_device_block(last_block_idx, last_way).tag &&
-            pid ==
-                ((tlb_entry_t &)get_caching_device_block(last_block_idx, last_way)).pid);
-        stats->access(memref_in, true /*hit*/, TAG_INVALID);
+        caching_device_block_t *tlb_entry =
+            &get_caching_device_block(last_block_idx, last_way);
+        assert(tag != TAG_INVALID &&
+               tag == get_caching_device_block(last_block_idx, last_way)->tag &&
+               pid == ((tlb_entry_t *)tlb_entry)->pid);
+        stats->access(memref_in, true /*hit*/, tlb_entry);
         if (parent != NULL)
-            parent->get_stats()->child_access(memref_in, true, TAG_INVALID);
+            parent->get_stats()->child_access(memref_in, true, tlb_entry);
         access_update(last_block_idx, last_way);
         return;
     }
@@ -85,28 +85,30 @@ tlb_t::request(const memref_t &memref_in)
             memref.data.size = ((tag + 1) << block_size_bits) - memref.data.addr;
 
         for (way = 0; way < associativity; ++way) {
-            if (get_caching_device_block(block_idx, way).tag == tag &&
-                ((tlb_entry_t &)get_caching_device_block(block_idx, way)).pid == pid) {
-                stats->access(memref, true /*hit*/, TAG_INVALID);
+            caching_device_block_t *tlb_entry = &get_caching_device_block(block_idx, way);
+            if (tlb_entry->tag == tag && ((tlb_entry_t *)tlb_entry)->pid == pid) {
+                stats->access(memref, true /*hit*/, tlb_entry);
                 if (parent != NULL)
-                    parent->get_stats()->child_access(memref, true, TAG_INVALID);
+                    parent->get_stats()->child_access(memref, true, tlb_entry);
                 break;
             }
         }
 
         if (way == associativity) {
-            stats->access(memref, false /*miss*/, TAG_INVALID);
+            way = replace_which_way(block_idx);
+            caching_device_block_t *tlb_entry = &get_caching_device_block(block_idx, way);
+
+            stats->access(memref, false /*miss*/, tlb_entry);
             // If no parent we assume we get the data from main memory
             if (parent != NULL) {
-                parent->get_stats()->child_access(memref, false, TAG_INVALID);
+                parent->get_stats()->child_access(memref, false, tlb_entry);
                 parent->request(memref);
             }
 
             // XXX: do we need to handle TLB coherency?
 
-            way = replace_which_way(block_idx);
-            get_caching_device_block(block_idx, way).tag = tag;
-            ((tlb_entry_t &)get_caching_device_block(block_idx, way)).pid = pid;
+            tlb_entry->tag = tag;
+            ((tlb_entry_t *)tlb_entry)->pid = pid;
         }
 
         access_update(block_idx, way);

--- a/clients/drcachesim/simulator/tlb.cpp
+++ b/clients/drcachesim/simulator/tlb.cpp
@@ -66,8 +66,7 @@ tlb_t::request(const memref_t &memref_in)
         // Make sure last_tag and pid are properly in sync.
         caching_device_block_t *tlb_entry =
             &get_caching_device_block(last_block_idx, last_way);
-        assert(tag != TAG_INVALID &&
-               tag == get_caching_device_block(last_block_idx, last_way)->tag &&
+        assert(tag != TAG_INVALID && tag == tlb_entry->tag &&
                pid == ((tlb_entry_t *)tlb_entry)->pid);
         stats->access(memref_in, true /*hit*/, tlb_entry);
         if (parent != NULL)


### PR DESCRIPTION
Passes a pointer to the accessed (hit) or replaced (miss) cache block to the cache stats accessor This is a follow up to PR #3637.