### PR TITLE
Fix for #3633

### DIFF
--- a/core/win32/drwinapi/kernel32_proc.c
+++ b/core/win32/drwinapi/kernel32_proc.c
@@ -49,7 +49,7 @@ kernel32_redir_init_proc(void)
 {
     PEB *peb = get_own_peb();
     ASSERT(get_os_version() < WINDOWS_VERSION_2003 ||
-           peb->FlsBitmap->SizeOfBitMap == FLS_MAX_COUNT);
+           (peb->FlsBitmap == NULL || peb->FlsBitmap->SizeOfBitMap == FLS_MAX_COUNT));
 #ifdef CLIENT_INTERFACE
     /* We rely on -private_peb for FLS isolation.  Otherwise we'd have to
      * put back in place all the code to handle mixing private and app FLS

--- a/core/win32/drwinapi/kernel32_proc.c
+++ b/core/win32/drwinapi/kernel32_proc.c
@@ -48,6 +48,9 @@ void
 kernel32_redir_init_proc(void)
 {
     PEB *peb = get_own_peb();
+    /* FIXME i#3633: Implement FLS isolation in Win10 1903+ where FLS data is no longer
+     * in the PEB.
+     */
     ASSERT(get_os_version() < WINDOWS_VERSION_2003 ||
            (peb->FlsBitmap == NULL || peb->FlsBitmap->SizeOfBitMap == FLS_MAX_COUNT));
 #ifdef CLIENT_INTERFACE

--- a/core/win32/drwinapi/ntdll_redir.c
+++ b/core/win32/drwinapi/ntdll_redir.c
@@ -839,7 +839,7 @@ redirect_RtlPcToFileHeader(__in PVOID PcValue, __out PVOID *BaseOfImage)
  */
 
 #ifndef FLS_MAX_COUNT
-#define FLS_MAX_COUNT 128
+#    define FLS_MAX_COUNT 128
 #endif
 
 void

--- a/core/win32/drwinapi/ntdll_redir.c
+++ b/core/win32/drwinapi/ntdll_redir.c
@@ -847,6 +847,11 @@ ntdll_redir_fls_init(PEB *app_peb, PEB *private_peb)
 {
     /* FLS is supported in WinXP-64 or later */
     ASSERT(get_os_version() >= WINDOWS_VERSION_2003);
+
+    /* FIXME i#3633: Implement FLS isolation in Win10 1903+ where FLS data is no longer
+     * in the PEB.
+     */
+
     /* We need a deep copy of FLS structures */
     private_peb->FlsBitmap =
         HEAP_TYPE_ALLOC(GLOBAL_DCONTEXT, RTL_BITMAP, ACCT_LIBDUP, UNPROTECTED);


### PR DESCRIPTION
Temporarily fixes issue on Windows 1903 where FLS data is not held in PEB anymore. This data is now spare data to keep PEB alignment. 

Fix consists of avoiding `app_peb->FlsBitmap` when it doesn't exist. DynamoRIO will keep old FLS format in `private_peb` thus there is no problem when running on 1903. 

Better solution would be to put FLS data in global variables inside of `redir_ntdll.c` thus there is no need to worry about if we are running on older windows or 1903, as anyhow private_peb FLS is initialized always from `redir_ntdll.c` so there would be no difference.