### PR TITLE
i#1312 AVX-512 support: Add release note about instr_t compatibility breakage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ before_deploy:
   # We should find a way to share (xref i#1565).
   # We support setting TAG_SUFFIX on triggered builds so we can have
   # multiple unique tags in one day (the patchlevel here is the day number).
-  - export GIT_TAG="cronbuild-7.90.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
+  - export GIT_TAG="cronbuild-7.91.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
   - git tag $GIT_TAG -a -m "Travis auto-generated tag for build $TRAVIS_BUILD_NUMBER."
 deploy:
   provider: releases

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,7 +487,7 @@ endif (EXISTS "${PROJECT_SOURCE_DIR}/.svn")
 
 # N.B.: when updating this, update the git tag in .travis.yml.
 # We should find a way to share (xref i#1565).
-set(VERSION_NUMBER_DEFAULT "7.90.${VERSION_NUMBER_PATCHLEVEL}")
+set(VERSION_NUMBER_DEFAULT "7.91.${VERSION_NUMBER_PATCHLEVEL}")
 # do not store the default VERSION_NUMBER in the cache to prevent a stale one
 # from preventing future version updates in a pre-existing build dir
 set(VERSION_NUMBER "" CACHE STRING "Version number: leave empty for default")
@@ -1199,6 +1199,7 @@ math(EXPR VERSION_NUMBER_INTEGER
   "${VERSION_NUMBER_MAJOR}*100 + ${VERSION_NUMBER_MINOR}")
 
 # Every release since has had minor compat breakages.
+# 7.91 broke backcompat by adding a field to instr_t .
 # 7.90 broke backcompat in DR_REG_ enums and OPSZ_ enums.
 # 6.0 broke backcompat in Linux injection, mod load event, etc.
 # 5.0 broke backcompat in drsyms and xmm opnd sizes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1205,7 +1205,7 @@ math(EXPR VERSION_NUMBER_INTEGER
 # 5.0 broke backcompat in drsyms and xmm opnd sizes
 # 4.1 broke backcompat in drsyms + 64-bit core (opcodes + reachability)
 # 4.0 broke backcompat in drmgr, drsyms, drinjectlib, and dr_get_milliseconds()
-set(OLDEST_COMPATIBLE_VERSION_DEFAULT "790")
+set(OLDEST_COMPATIBLE_VERSION_DEFAULT "791")
 set(OLDEST_COMPATIBLE_VERSION "" CACHE STRING
   "Oldest compatible version: leave empty for default")
 if ("${OLDEST_COMPATIBLE_VERSION}" STREQUAL "")

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -142,6 +142,7 @@ changes:
  - Changes the enumeration of the OPSZ_ enum by moving its start back to 0. The OPSZ_
    enum now completely overlaps the DR_REG_ enum.
    This is a binary compatibility change for the OPSZ_ enum.
+ - Adds a new encoding hint field to instr_t.
 
 The changes between version \DR_VERSION and 7.1.0 include the following minor
 compatibility changes:

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -142,7 +142,7 @@ changes:
  - Changes the enumeration of the OPSZ_ enum by moving its start back to 0. The OPSZ_
    enum now completely overlaps the DR_REG_ enum.
    This is a binary compatibility change for the OPSZ_ enum.
- - Adds a new encoding hint field to instr_t.
+ - Adds a new encoding hint field to #instr_t.
 
 The changes between version \DR_VERSION and 7.1.0 include the following minor
 compatibility changes:


### PR DESCRIPTION
Adds a missing release note describing a compatibility breakage by adding a new field to
instr_t by commit 42a33b33920f7bf1d1.

Bumps the minor version number to 7.91.

Issue: #1312
Fixes #3642