### PR TITLE
i#1312 AVX-512 support: Add vfmadd*, vfnmadd*, vfmsub*, and vfnmsub* opcodes.

### DIFF
--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -5327,426 +5327,6 @@ const instr_info_t prefix_extensions[][12] = {
     {EVEX_W_EXT,   0x660f7a10, "(evex_W ext 50)", xx, xx, xx, xx, xx, mrm|evex, x, 50},
     {EVEX_W_EXT,   0xf20f7a10, "(evex_W ext 60)", xx, xx, xx, xx, xx, mrm|evex, x, 60},
   },
-  { /* prefix extension 160 */
-    {INVALID,        0x389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x66389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf2389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x66389818, "(vex_W ext 0)", xx, xx, xx, xx, xx, mrm|vex, x, 0},
-    {INVALID,      0xf2389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x66389818, "(evex_W ext 62)", xx, xx, xx, xx, xx, mrm|evex, x, 62},
-    {INVALID,      0xf2389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 161 */
-    {INVALID,        0x38a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638a818, "(vex_W ext 1)", xx, xx, xx, xx, xx, mrm|vex, x, 1},
-    {INVALID,      0xf238a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638a818, "(evex_W ext 63)", xx, xx, xx, xx, xx, mrm|evex, x, 63},
-    {INVALID,      0xf238a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 162 */
-    {INVALID,        0x38b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638b818, "(vex_W ext 2)", xx, xx, xx, xx, xx, mrm|vex, x, 2},
-    {INVALID,      0xf238b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638b818, "(evex_W ext 64)", xx, xx, xx, xx, xx, mrm|evex, x, 64},
-    {INVALID,      0xf238b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 163 */
-    {INVALID,        0x389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x66389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf2389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x66389918, "(vex_W ext 3)", xx, xx, xx, xx, xx, mrm|vex, x, 3},
-    {INVALID,      0xf2389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x66389918, "(evex_W ext 65)", xx, xx, xx, xx, xx, mrm|evex, x, 65},
-    {INVALID,      0xf2389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 164 */
-    {INVALID,        0x38a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638a918, "(vex_W ext 4)", xx, xx, xx, xx, xx, mrm|vex, x, 4},
-    {INVALID,      0xf238a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638a918, "(evex_W ext 66)", xx, xx, xx, xx, xx, mrm|evex, x, 66},
-    {INVALID,      0xf238a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 165 */
-    {INVALID,        0x38b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638b918, "(vex_W ext 5)", xx, xx, xx, xx, xx, mrm|vex, x, 5},
-    {INVALID,      0xf238b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638b918, "(evex_W ext 67)", xx, xx, xx, xx, xx, mrm|evex, x, 67},
-    {INVALID,      0xf238b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 166 */
-    {INVALID,        0x389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x66389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf2389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x66389618, "(vex_W ext 6)", xx, xx, xx, xx, xx, mrm|vex, x, 6},
-    {INVALID,      0xf2389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x66389618, "(evex_W ext 68)", xx, xx, xx, xx, xx, mrm|evex, x, 68},
-    {INVALID,      0xf2389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 167 */
-    {INVALID,        0x38a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638a618, "(vex_W ext 7)", xx, xx, xx, xx, xx, mrm|vex, x, 7},
-    {INVALID,      0xf238a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638a618, "(evex_W ext 69)", xx, xx, xx, xx, xx, mrm|evex, x, 69},
-    {INVALID,      0xf238a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 168 */
-    {INVALID,        0x38b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638b618, "(vex_W ext 8)", xx, xx, xx, xx, xx, mrm|vex, x, 8},
-    {INVALID,      0xf238b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638b618, "(evex_W ext 70)", xx, xx, xx, xx, xx, mrm|evex, x, 70},
-    {INVALID,      0xf238b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 169 */
-    {INVALID,        0x389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x66389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf2389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x66389718, "(vex_W ext 9)", xx, xx, xx, xx, xx, mrm|vex, x, 9},
-    {INVALID,      0xf2389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x66389718, "(evex_W ext 71)", xx, xx, xx, xx, xx, mrm|evex, x, 71},
-    {INVALID,      0xf2389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 170 */
-    {INVALID,        0x38a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638a718, "(vex_W ext 10)", xx, xx, xx, xx, xx, mrm|vex, x, 10},
-    {INVALID,      0xf238a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638a718, "(evex_W ext 72)", xx, xx, xx, xx, xx, mrm|evex, x, 72},
-    {INVALID,      0xf238a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 171 */
-    {INVALID,        0x38b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638b718, "(vex_W ext 11)", xx, xx, xx, xx, xx, mrm|vex, x, 11},
-    {INVALID,      0xf238b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638b718, "(evex_W ext 73)", xx, xx, xx, xx, xx, mrm|evex, x, 73},
-    {INVALID,      0xf238b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 172 */
-    {INVALID,        0x389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x66389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf2389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x66389a18, "(vex_W ext 12)", xx, xx, xx, xx, xx, mrm|vex, x, 12},
-    {INVALID,      0xf2389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x66389a18, "(evex_W ext 74)", xx, xx, xx, xx, xx, mrm|evex, x, 74},
-    {INVALID,      0xf2389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 173 */
-    {INVALID,        0x38aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638aa18, "(vex_W ext 13)", xx, xx, xx, xx, xx, mrm|vex, x, 13},
-    {INVALID,      0xf238aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638aa18, "(evex_W ext 75)", xx, xx, xx, xx, xx, mrm|evex, x, 75},
-    {INVALID,      0xf238aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 174 */
-    {INVALID,        0x38ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638ba18, "(vex_W ext 14)", xx, xx, xx, xx, xx, mrm|vex, x, 14},
-    {INVALID,      0xf238ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638ba18, "(evex_W ext 76)", xx, xx, xx, xx, xx, mrm|evex, x, 76},
-    {INVALID,      0xf238ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 175 */
-    {INVALID,        0x389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x66389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf2389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x66389b18, "(vex_W ext 15)", xx, xx, xx, xx, xx, mrm|vex, x, 15},
-    {INVALID,      0xf2389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x66389b18, "(evex_W ext 77)", xx, xx, xx, xx, xx, mrm|evex, x, 77},
-    {INVALID,      0xf2389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 176 */
-    {INVALID,        0x38ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638ab18, "(vex_W ext 16)", xx, xx, xx, xx, xx, mrm|vex, x, 16},
-    {INVALID,      0xf238ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638ab18, "(evex_W ext 78)", xx, xx, xx, xx, xx, mrm|evex, x, 78},
-    {INVALID,      0xf238ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 177 */
-    {INVALID,        0x38bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638bb18, "(vex_W ext 17)", xx, xx, xx, xx, xx, mrm|vex, x, 17},
-    {INVALID,      0xf238bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638bb18, "(evex_W ext 79)", xx, xx, xx, xx, xx, mrm|evex, x, 79},
-    {INVALID,      0xf238bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 178 */
-    {INVALID,        0x389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x66389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf2389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x66389c18, "(vex_W ext 18)", xx, xx, xx, xx, xx, mrm|vex, x, 18},
-    {INVALID,      0xf2389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x66389c18, "(evex_W ext 80)", xx, xx, xx, xx, xx, mrm|evex, x, 80},
-    {INVALID,      0xf2389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 179 */
-    {INVALID,        0x38ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638ac18, "(vex_W ext 19)", xx, xx, xx, xx, xx, mrm|vex, x, 19},
-    {INVALID,      0xf238ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638ac18, "(evex_W ext 81)", xx, xx, xx, xx, xx, mrm|evex, x, 81},
-    {INVALID,      0xf238ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 180 */
-    {INVALID,        0x38bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638bc18, "(vex_W ext 20)", xx, xx, xx, xx, xx, mrm|vex, x, 20},
-    {INVALID,      0xf238bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638bc18, "(evex_W ext 82)", xx, xx, xx, xx, xx, mrm|evex, x, 82},
-    {INVALID,      0xf238bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 181 */
-    {INVALID,        0x389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x66389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf2389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x66389d18, "(vex_W ext 21)", xx, xx, xx, xx, xx, mrm|vex, x, 21},
-    {INVALID,      0xf2389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x66389d18, "(evex_W ext 83)", xx, xx, xx, xx, xx, mrm|evex, x, 83},
-    {INVALID,      0xf2389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 182 */
-    {INVALID,        0x38ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638ad18, "(vex_W ext 22)", xx, xx, xx, xx, xx, mrm|vex, x, 22},
-    {INVALID,      0xf238ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638ad18, "(evex_W ext 84)", xx, xx, xx, xx, xx, mrm|evex, x, 84},
-    {INVALID,      0xf238ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 183 */
-    {INVALID,        0x38bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638bd18, "(vex_W ext 23)", xx, xx, xx, xx, xx, mrm|vex, x, 23},
-    {INVALID,      0xf238bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638bd18, "(evex_W ext 85)", xx, xx, xx, xx, xx, mrm|evex, x, 85},
-    {INVALID,      0xf238bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 184 */
-    {INVALID,        0x389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x66389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf2389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x66389e18, "(vex_W ext 24)", xx, xx, xx, xx, xx, mrm|vex, x, 24},
-    {INVALID,      0xf2389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x66389e18, "(evex_W ext 86)", xx, xx, xx, xx, xx, mrm|evex, x, 86},
-    {INVALID,      0xf2389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 185 */
-    {INVALID,        0x38ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638ae18, "(vex_W ext 25)", xx, xx, xx, xx, xx, mrm|vex, x, 25},
-    {INVALID,      0xf238ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638ae18, "(evex_W ext 87)", xx, xx, xx, xx, xx, mrm|evex, x, 87},
-    {INVALID,      0xf238ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 186 */
-    {INVALID,        0x38be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638be18, "(vex_W ext 26)", xx, xx, xx, xx, xx, mrm|vex, x, 26},
-    {INVALID,      0xf238be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638be18, "(evex_W ext 88)", xx, xx, xx, xx, xx, mrm|evex, x, 88},
-    {INVALID,      0xf238be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 187 */
-    {INVALID,        0x389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x66389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf2389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x66389f18, "(vex_W ext 27)", xx, xx, xx, xx, xx, mrm|vex, x, 27},
-    {INVALID,      0xf2389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf3389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x66389f18, "(evex_W ext 89)", xx, xx, xx, xx, xx, mrm|evex, x, 89},
-    {INVALID,      0xf2389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 188 */
-    {INVALID,        0x38af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638af18, "(vex_W ext 28)", xx, xx, xx, xx, xx, mrm|vex, x, 28},
-    {INVALID,      0xf238af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638af18, "(evex_W ext 90)", xx, xx, xx, xx, xx, mrm|evex, x, 90},
-    {INVALID,      0xf238af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
-  { /* prefix extension 189 */
-    {INVALID,        0x38bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0x6638bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf238bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {VEX_W_EXT,    0x6638bf18, "(vex_W ext 29)", xx, xx, xx, xx, xx, mrm|vex, x, 29},
-    {INVALID,      0xf238bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,        0x38bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,      0xf338bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {EVEX_W_EXT,   0x6638bf18, "(evex_W ext 91)", xx, xx, xx, xx, xx, mrm|evex, x, 91},
-    {INVALID,      0xf238bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
 };
 /****************************************************************************
  * Instructions that differ based on whether vex-encoded or not.
@@ -6137,6 +5717,126 @@ const instr_info_t e_vex_extensions[][3] = {
     {OP_setns,   0x0f9910,            "setns", Eb, xx, xx, xx, xx, mrm, fRS, END_LIST},
     {PREFIX_EXT, 0x0f9910, "(prefix ext 157)", xx, xx, xx, xx, xx, mrm,   x, 157},
     {INVALID, 0x0f9910, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+  }, { /* e_vex ext 93 */
+    {INVALID,      0x66389810,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389818,   "(vex_W ext 0)", xx, xx, xx, xx, xx, mrm|vex, x, 0},
+    {EVEX_W_EXT,   0x66389818, "(evex_W ext 62)", xx, xx, xx, xx, xx, mrm|evex, x, 62},
+  }, { /* e_vex ext 94 */
+    {INVALID,      0x6638a810,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638a818,   "(vex_W ext 1)", xx, xx, xx, xx, xx, mrm|vex, x, 1},
+    {EVEX_W_EXT,   0x6638a818, "(evex_W ext 63)", xx, xx, xx, xx, xx, mrm|evex, x, 63},
+  }, { /* e_vex ext 95 */
+    {INVALID,      0x6638b810,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638b818,   "(vex_W ext 2)", xx, xx, xx, xx, xx, mrm|vex, x, 2},
+    {EVEX_W_EXT,   0x6638b818, "(evex_W ext 64)", xx, xx, xx, xx, xx, mrm|evex, x, 64},
+  }, { /* e_vex ext 96 */
+    {INVALID,      0x66389910,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389918,   "(vex_W ext 3)", xx, xx, xx, xx, xx, mrm|vex, x, 3},
+    {EVEX_W_EXT,   0x66389918, "(evex_W ext 65)", xx, xx, xx, xx, xx, mrm|evex, x, 65},
+  }, { /* e_vex ext 97 */
+    {INVALID,      0x6638a910,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638a918,   "(vex_W ext 4)", xx, xx, xx, xx, xx, mrm|vex, x, 4},
+    {EVEX_W_EXT,   0x6638a918, "(evex_W ext 66)", xx, xx, xx, xx, xx, mrm|evex, x, 66},
+  }, { /* e_vex ext 98 */
+    {INVALID,      0x6638b910,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638b918,   "(vex_W ext 5)", xx, xx, xx, xx, xx, mrm|vex, x, 5},
+    {EVEX_W_EXT,   0x6638b918, "(evex_W ext 67)", xx, xx, xx, xx, xx, mrm|evex, x, 67},
+  }, { /* e_vex ext 99 */
+    {INVALID,      0x66389610,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389618,   "(vex_W ext 6)", xx, xx, xx, xx, xx, mrm|vex, x, 6},
+    {EVEX_W_EXT,   0x66389618, "(evex_W ext 68)", xx, xx, xx, xx, xx, mrm|evex, x, 68},
+  }, { /* e_vex ext 100 */
+    {INVALID,      0x6638a610,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638a618,   "(vex_W ext 7)", xx, xx, xx, xx, xx, mrm|vex, x, 7},
+    {EVEX_W_EXT,   0x6638a618, "(evex_W ext 69)", xx, xx, xx, xx, xx, mrm|evex, x, 69},
+  }, { /* e_vex ext 101 */
+    {INVALID,      0x6638b610,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638b618,   "(vex_W ext 8)", xx, xx, xx, xx, xx, mrm|vex, x, 8},
+    {EVEX_W_EXT,   0x6638b618, "(evex_W ext 70)", xx, xx, xx, xx, xx, mrm|evex, x, 70},
+  }, { /* e_vex ext 102 */
+    {INVALID,      0x66389710,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389718,   "(vex_W ext 9)", xx, xx, xx, xx, xx, mrm|vex, x, 9},
+    {EVEX_W_EXT,   0x66389718, "(evex_W ext 71)", xx, xx, xx, xx, xx, mrm|evex, x, 71},
+  }, { /* e_vex ext 103 */
+    {INVALID,      0x6638a710,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638a718,  "(vex_W ext 10)", xx, xx, xx, xx, xx, mrm|vex, x, 10},
+    {EVEX_W_EXT,   0x6638a718, "(evex_W ext 72)", xx, xx, xx, xx, xx, mrm|evex, x, 72},
+  }, { /* e_vex ext 104 */
+    {INVALID,      0x6638b710,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638b718,  "(vex_W ext 11)", xx, xx, xx, xx, xx, mrm|vex, x, 11},
+    {EVEX_W_EXT,   0x6638b718, "(evex_W ext 73)", xx, xx, xx, xx, xx, mrm|evex, x, 73},
+  }, { /* e_vex ext 105 */
+    {INVALID,      0x66389a10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389a18,  "(vex_W ext 12)", xx, xx, xx, xx, xx, mrm|vex, x, 12},
+    {EVEX_W_EXT,   0x66389a18, "(evex_W ext 74)", xx, xx, xx, xx, xx, mrm|evex, x, 74},
+  }, { /* e_vex ext 106 */
+    {INVALID,      0x6638aa10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638aa18,  "(vex_W ext 13)", xx, xx, xx, xx, xx, mrm|vex, x, 13},
+    {EVEX_W_EXT,   0x6638aa18, "(evex_W ext 75)", xx, xx, xx, xx, xx, mrm|evex, x, 75},
+  }, { /* e_vex ext 107 */
+    {INVALID,      0x6638ba10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638ba18,  "(vex_W ext 14)", xx, xx, xx, xx, xx, mrm|vex, x, 14},
+    {EVEX_W_EXT,   0x6638ba18, "(evex_W ext 76)", xx, xx, xx, xx, xx, mrm|evex, x, 76},
+  }, { /* e_vex ext 108 */
+    {INVALID,      0x66389b10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389b18,  "(vex_W ext 15)", xx, xx, xx, xx, xx, mrm|vex, x, 15},
+    {EVEX_W_EXT,   0x66389b18, "(evex_W ext 77)", xx, xx, xx, xx, xx, mrm|evex, x, 77},
+  }, { /* e_vex ext 109 */
+    {INVALID,      0x6638ab10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638ab18,  "(vex_W ext 16)", xx, xx, xx, xx, xx, mrm|vex, x, 16},
+    {EVEX_W_EXT,   0x6638ab18, "(evex_W ext 78)", xx, xx, xx, xx, xx, mrm|evex, x, 78},
+  }, { /* e_vex ext 110 */
+    {INVALID,      0x6638bb10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638bb18,  "(vex_W ext 17)", xx, xx, xx, xx, xx, mrm|vex, x, 17},
+    {EVEX_W_EXT,   0x6638bb18, "(evex_W ext 79)", xx, xx, xx, xx, xx, mrm|evex, x, 79},
+  }, { /* e_vex ext 111 */
+    {INVALID,      0x66389c10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389c18,  "(vex_W ext 18)", xx, xx, xx, xx, xx, mrm|vex, x, 18},
+    {EVEX_W_EXT,   0x66389c18, "(evex_W ext 80)", xx, xx, xx, xx, xx, mrm|evex, x, 80},
+  }, { /* e_vex ext 112 */
+    {INVALID,      0x6638ac10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638ac18,  "(vex_W ext 19)", xx, xx, xx, xx, xx, mrm|vex, x, 19},
+    {EVEX_W_EXT,   0x6638ac18, "(evex_W ext 81)", xx, xx, xx, xx, xx, mrm|evex, x, 81},
+  }, { /* e_vex ext 113 */
+    {INVALID,      0x6638bc10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638bc18,  "(vex_W ext 20)", xx, xx, xx, xx, xx, mrm|vex, x, 20},
+    {EVEX_W_EXT,   0x6638bc18, "(evex_W ext 82)", xx, xx, xx, xx, xx, mrm|evex, x, 82},
+  }, { /* e_vex ext 114 */
+    {INVALID,      0x66389d10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389d18,  "(vex_W ext 21)", xx, xx, xx, xx, xx, mrm|vex, x, 21},
+    {EVEX_W_EXT,   0x66389d18, "(evex_W ext 83)", xx, xx, xx, xx, xx, mrm|evex, x, 83},
+  }, { /* e_vex ext 115 */
+    {INVALID,      0x6638ad10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638ad18,  "(vex_W ext 22)", xx, xx, xx, xx, xx, mrm|vex, x, 22},
+    {EVEX_W_EXT,   0x6638ad18, "(evex_W ext 84)", xx, xx, xx, xx, xx, mrm|evex, x, 84},
+  }, { /* e_vex ext 116 */
+    {INVALID,      0x6638bd10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638bd18,  "(vex_W ext 23)", xx, xx, xx, xx, xx, mrm|vex, x, 23},
+    {EVEX_W_EXT,   0x6638bd18, "(evex_W ext 85)", xx, xx, xx, xx, xx, mrm|evex, x, 85},
+  }, { /* e_vex ext 117 */
+    {INVALID,      0x66389e10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389e18,  "(vex_W ext 24)", xx, xx, xx, xx, xx, mrm|vex, x, 24},
+    {EVEX_W_EXT,   0x66389e18, "(evex_W ext 86)", xx, xx, xx, xx, xx, mrm|evex, x, 86},
+  }, { /* e_vex ext 118 */
+    {INVALID,      0x6638ae10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638ae18,  "(vex_W ext 25)", xx, xx, xx, xx, xx, mrm|vex, x, 25},
+    {EVEX_W_EXT,   0x6638ae18, "(evex_W ext 87)", xx, xx, xx, xx, xx, mrm|evex, x, 87},
+  }, { /* e_vex ext 119 */
+    {INVALID,      0x6638be10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638be18,  "(vex_W ext 26)", xx, xx, xx, xx, xx, mrm|vex, x, 26},
+    {EVEX_W_EXT,   0x6638be18, "(evex_W ext 88)", xx, xx, xx, xx, xx, mrm|evex, x, 88},
+  }, { /* e_vex ext 120 */
+    {INVALID,      0x66389f10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389f18,  "(vex_W ext 27)", xx, xx, xx, xx, xx, mrm|vex, x, 27},
+    {EVEX_W_EXT,   0x66389f18, "(evex_W ext 89)", xx, xx, xx, xx, xx, mrm|evex, x, 89},
+  }, { /* e_vex ext 121 */
+    {INVALID,      0x6638af10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638af18,  "(vex_W ext 28)", xx, xx, xx, xx, xx, mrm|vex, x, 28},
+    {EVEX_W_EXT,   0x6638af18, "(evex_W ext 90)", xx, xx, xx, xx, xx, mrm|evex, x, 90},
+  }, { /* e_vex ext 122 */
+    {INVALID,      0x6638bf10,           "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638bf18,  "(vex_W ext 29)", xx, xx, xx, xx, xx, mrm|vex, x, 29},
+    {EVEX_W_EXT,   0x6638bf18, "(evex_W ext 91)", xx, xx, xx, xx, xx, mrm|evex, x, 91},
   },
 };
 
@@ -6579,38 +6279,38 @@ const instr_info_t third_byte_38[] = {
   {E_VEX_EXT,  0x66380e18, "(e_vex ext 59)", xx, xx, xx, xx, xx, mrm, x, 59},/*56*/
   {E_VEX_EXT,  0x66380f18, "(e_vex ext 60)", xx, xx, xx, xx, xx, mrm, x, 60},/*57*/
   /* FMA 96-9f */
-  {PREFIX_EXT,  0x389618, "(prefix ext 166)", xx, xx, xx, xx, xx, mrm, x, 166},/*58*/
-  {PREFIX_EXT,  0x389718, "(prefix ext 169)", xx, xx, xx, xx, xx, mrm, x, 169},/*59*/
-  {PREFIX_EXT,  0x389818, "(prefix ext 160)", xx, xx, xx, xx, xx, mrm, x, 160},/*60*/
-  {PREFIX_EXT,  0x389918, "(prefix ext 163)", xx, xx, xx, xx, xx, mrm, x, 163},/*61*/
-  {PREFIX_EXT,  0x389a18, "(prefix ext 172)", xx, xx, xx, xx, xx, mrm, x, 172},/*62*/
-  {PREFIX_EXT,  0x389b18, "(prefix ext 175)", xx, xx, xx, xx, xx, mrm, x, 175},/*63*/
-  {PREFIX_EXT,  0x389c18, "(prefix ext 178)", xx, xx, xx, xx, xx, mrm, x, 178},/*64*/
-  {PREFIX_EXT,  0x389d18, "(prefix ext 181)", xx, xx, xx, xx, xx, mrm, x, 181},/*65*/
-  {PREFIX_EXT,  0x389e18, "(prefix ext 184)", xx, xx, xx, xx, xx, mrm, x, 184},/*66*/
-  {PREFIX_EXT,  0x389f18, "(prefix ext 187)", xx, xx, xx, xx, xx, mrm, x, 187},/*67*/
+  {E_VEX_EXT,   0x389618,  "(e_vex ext 99)", xx, xx, xx, xx, xx, mrm, x, 99},/*58*/
+  {E_VEX_EXT,   0x389718, "(e_vex ext 102)", xx, xx, xx, xx, xx, mrm, x, 102},/*59*/
+  {E_VEX_EXT,   0x389818,  "(e_vex ext 93)", xx, xx, xx, xx, xx, mrm, x, 93},/*60*/
+  {E_VEX_EXT,   0x389918,  "(e_vex ext 96)", xx, xx, xx, xx, xx, mrm, x, 96},/*61*/
+  {E_VEX_EXT,   0x389a18, "(e_vex ext 105)", xx, xx, xx, xx, xx, mrm, x, 105},/*62*/
+  {E_VEX_EXT,   0x389b18, "(e_vex ext 108)", xx, xx, xx, xx, xx, mrm, x, 108},/*63*/
+  {E_VEX_EXT,   0x389c18, "(e_vex ext 111)", xx, xx, xx, xx, xx, mrm, x, 111},/*64*/
+  {E_VEX_EXT,   0x389d18, "(e_vex ext 114)", xx, xx, xx, xx, xx, mrm, x, 114},/*65*/
+  {E_VEX_EXT,   0x389e18, "(e_vex ext 117)", xx, xx, xx, xx, xx, mrm, x, 117},/*66*/
+  {E_VEX_EXT,   0x389f18, "(e_vex ext 120)", xx, xx, xx, xx, xx, mrm, x, 120},/*67*/
   /* FMA a6-af */
-  {PREFIX_EXT,  0x38a618, "(prefix ext 167)", xx, xx, xx, xx, xx, mrm, x, 167},/*68*/
-  {PREFIX_EXT,  0x38a718, "(prefix ext 170)", xx, xx, xx, xx, xx, mrm, x, 170},/*69*/
-  {PREFIX_EXT,  0x38a818, "(prefix ext 161)", xx, xx, xx, xx, xx, mrm, x, 161},/*70*/
-  {PREFIX_EXT,  0x38a918, "(prefix ext 164)", xx, xx, xx, xx, xx, mrm, x, 164},/*71*/
-  {PREFIX_EXT,  0x38aa18, "(prefix ext 173)", xx, xx, xx, xx, xx, mrm, x, 173},/*72*/
-  {PREFIX_EXT,  0x38ab18, "(prefix ext 176)", xx, xx, xx, xx, xx, mrm, x, 176},/*73*/
-  {PREFIX_EXT,  0x38ac18, "(prefix ext 179)", xx, xx, xx, xx, xx, mrm, x, 179},/*74*/
-  {PREFIX_EXT,  0x38ad18, "(prefix ext 182)", xx, xx, xx, xx, xx, mrm, x, 182},/*75*/
-  {PREFIX_EXT,  0x38ae18, "(prefix ext 185)", xx, xx, xx, xx, xx, mrm, x, 185},/*76*/
-  {PREFIX_EXT,  0x38af18, "(prefix ext 188)", xx, xx, xx, xx, xx, mrm, x, 188},/*77*/
+  {E_VEX_EXT,   0x38a618, "(e_vex ext 100)", xx, xx, xx, xx, xx, mrm, x, 100},/*68*/
+  {E_VEX_EXT,   0x38a718, "(e_vex ext 103)", xx, xx, xx, xx, xx, mrm, x, 103},/*69*/
+  {E_VEX_EXT,   0x38a818,  "(e_vex ext 94)", xx, xx, xx, xx, xx, mrm, x, 94},/*70*/
+  {E_VEX_EXT,   0x38a918,  "(e_vex ext 97)", xx, xx, xx, xx, xx, mrm, x, 97},/*71*/
+  {E_VEX_EXT,   0x38aa18, "(e_vex ext 106)", xx, xx, xx, xx, xx, mrm, x, 106},/*72*/
+  {E_VEX_EXT,   0x38ab18, "(e_vex ext 109)", xx, xx, xx, xx, xx, mrm, x, 109},/*73*/
+  {E_VEX_EXT,   0x38ac18, "(e_vex ext 112)", xx, xx, xx, xx, xx, mrm, x, 112},/*74*/
+  {E_VEX_EXT,   0x38ad18, "(e_vex ext 115)", xx, xx, xx, xx, xx, mrm, x, 115},/*75*/
+  {E_VEX_EXT,   0x38ae18, "(e_vex ext 118)", xx, xx, xx, xx, xx, mrm, x, 118},/*76*/
+  {E_VEX_EXT,   0x38af18, "(e_vex ext 121)", xx, xx, xx, xx, xx, mrm, x, 121},/*77*/
   /* FMA b6-bf */
-  {PREFIX_EXT,  0x38b618, "(prefix ext 168)", xx, xx, xx, xx, xx, mrm, x, 168},/*78*/
-  {PREFIX_EXT,  0x38b718, "(prefix ext 171)", xx, xx, xx, xx, xx, mrm, x, 171},/*79*/
-  {PREFIX_EXT,  0x38b818, "(prefix ext 162)", xx, xx, xx, xx, xx, mrm, x, 162},/*80*/
-  {PREFIX_EXT,  0x38b918, "(prefix ext 165)", xx, xx, xx, xx, xx, mrm, x, 165},/*81*/
-  {PREFIX_EXT,  0x38ba18, "(prefix ext 174)", xx, xx, xx, xx, xx, mrm, x, 174},/*82*/
-  {PREFIX_EXT,  0x38bb18, "(prefix ext 177)", xx, xx, xx, xx, xx, mrm, x, 177},/*83*/
-  {PREFIX_EXT,  0x38bc18, "(prefix ext 180)", xx, xx, xx, xx, xx, mrm, x, 180},/*84*/
-  {PREFIX_EXT,  0x38bd18, "(prefix ext 183)", xx, xx, xx, xx, xx, mrm, x, 183},/*85*/
-  {PREFIX_EXT,  0x38be18, "(prefix ext 186)", xx, xx, xx, xx, xx, mrm, x, 186},/*86*/
-  {PREFIX_EXT,  0x38bf18, "(prefix ext 189)", xx, xx, xx, xx, xx, mrm, x, 189},/*87*/
+  {E_VEX_EXT,   0x38b618, "(e_vex ext 101)", xx, xx, xx, xx, xx, mrm, x, 101},/*78*/
+  {E_VEX_EXT,   0x38b718, "(e_vex ext 104)", xx, xx, xx, xx, xx, mrm, x, 104},/*79*/
+  {E_VEX_EXT,   0x38b818,  "(e_vex ext 95)", xx, xx, xx, xx, xx, mrm, x, 95},/*80*/
+  {E_VEX_EXT,   0x38b918,  "(e_vex ext 98)", xx, xx, xx, xx, xx, mrm, x, 98},/*81*/
+  {E_VEX_EXT,   0x38ba18, "(e_vex ext 107)", xx, xx, xx, xx, xx, mrm, x, 107},/*82*/
+  {E_VEX_EXT,   0x38bb18, "(e_vex ext 110)", xx, xx, xx, xx, xx, mrm, x, 110},/*83*/
+  {E_VEX_EXT,   0x38bc18, "(e_vex ext 113)", xx, xx, xx, xx, xx, mrm, x, 113},/*84*/
+  {E_VEX_EXT,   0x38bd18, "(e_vex ext 116)", xx, xx, xx, xx, xx, mrm, x, 116},/*85*/
+  {E_VEX_EXT,   0x38be18, "(e_vex ext 119)", xx, xx, xx, xx, xx, mrm, x, 119},/*86*/
+  {E_VEX_EXT,   0x38bf18, "(e_vex ext 122)", xx, xx, xx, xx, xx, mrm, x, 122},/*87*/
   /* AVX overlooked in original pass */
   {E_VEX_EXT, 0x66381318, "(e_vex ext 63)", xx, xx, xx, xx, xx, mrm, x, 63},/*88*/
   {E_VEX_EXT, 0x66381818, "(e_vex ext 64)", xx, xx, xx, xx, xx, mrm, x, 64},/*89*/
@@ -6762,95 +6462,95 @@ const instr_info_t third_byte_3a[] = {
  */
 const instr_info_t vex_W_extensions[][2] = {
   {    /* vex_W_ext 0 */
-    {OP_vfmadd132ps,0x66389818,"vfmadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[62][0]},
-    {OP_vfmadd132pd,0x66389858,"vfmadd132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[62][1]},
+    {OP_vfmadd132ps,0x66389818,"vfmadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[62][0]},
+    {OP_vfmadd132pd,0x66389858,"vfmadd132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[62][1]},
   }, { /* vex_W_ext 1 */
-    {OP_vfmadd213ps,0x6638a818,"vfmadd213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[63][0]},
-    {OP_vfmadd213pd,0x6638a858,"vfmadd213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[63][1]},
+    {OP_vfmadd213ps,0x6638a818,"vfmadd213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[63][0]},
+    {OP_vfmadd213pd,0x6638a858,"vfmadd213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[63][1]},
   }, { /* vex_W_ext 2 */
-    {OP_vfmadd231ps,0x6638b818,"vfmadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[64][0]},
-    {OP_vfmadd231pd,0x6638b858,"vfmadd231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[64][1]},
+    {OP_vfmadd231ps,0x6638b818,"vfmadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[64][0]},
+    {OP_vfmadd231pd,0x6638b858,"vfmadd231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[64][1]},
   }, { /* vex_W_ext 3 */
-    {OP_vfmadd132ss,0x66389918,"vfmadd132ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[65][0]},
-    {OP_vfmadd132sd,0x66389958,"vfmadd132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[65][1]},
+    {OP_vfmadd132ss,0x66389918,"vfmadd132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,tevexw[65][0]},
+    {OP_vfmadd132sd,0x66389958,"vfmadd132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,tevexw[65][1]},
   }, { /* vex_W_ext 4 */
-    {OP_vfmadd213ss,0x6638a918,"vfmadd213ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[66][0]},
-    {OP_vfmadd213sd,0x6638a958,"vfmadd213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[66][1]},
+    {OP_vfmadd213ss,0x6638a918,"vfmadd213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,tevexw[66][0]},
+    {OP_vfmadd213sd,0x6638a958,"vfmadd213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,tevexw[66][1]},
   }, { /* vex_W_ext 5 */
-    {OP_vfmadd231ss,0x6638b918,"vfmadd231ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[67][0]},
-    {OP_vfmadd231sd,0x6638b958,"vfmadd231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[67][1]},
+    {OP_vfmadd231ss,0x6638b918,"vfmadd231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,tevexw[67][0]},
+    {OP_vfmadd231sd,0x6638b958,"vfmadd231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,tevexw[67][1]},
   }, { /* vex_W_ext 6 */
-    {OP_vfmaddsub132ps,0x66389618,"vfmaddsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[68][0]},
-    {OP_vfmaddsub132pd,0x66389658,"vfmaddsub132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[68][1]},
+    {OP_vfmaddsub132ps,0x66389618,"vfmaddsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[68][0]},
+    {OP_vfmaddsub132pd,0x66389658,"vfmaddsub132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[68][1]},
   }, { /* vex_W_ext 7 */
-    {OP_vfmaddsub213ps,0x6638a618,"vfmaddsub213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[69][0]},
-    {OP_vfmaddsub213pd,0x6638a658,"vfmaddsub213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[69][1]},
+    {OP_vfmaddsub213ps,0x6638a618,"vfmaddsub213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[69][0]},
+    {OP_vfmaddsub213pd,0x6638a658,"vfmaddsub213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[69][1]},
   }, { /* vex_W_ext 8 */
-    {OP_vfmaddsub231ps,0x6638b618,"vfmaddsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[70][0]},
-    {OP_vfmaddsub231pd,0x6638b658,"vfmaddsub231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[70][1]},
+    {OP_vfmaddsub231ps,0x6638b618,"vfmaddsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[70][0]},
+    {OP_vfmaddsub231pd,0x6638b658,"vfmaddsub231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[70][1]},
   }, { /* vex_W_ext 9 */
-    {OP_vfmsubadd132ps,0x66389718,"vfmsubadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[71][0]},
-    {OP_vfmsubadd132pd,0x66389758,"vfmsubadd132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[71][1]},
+    {OP_vfmsubadd132ps,0x66389718,"vfmsubadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[71][0]},
+    {OP_vfmsubadd132pd,0x66389758,"vfmsubadd132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[71][1]},
   }, { /* vex_W_ext 10 */
-    {OP_vfmsubadd213ps,0x6638a718,"vfmsubadd213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[72][0]},
-    {OP_vfmsubadd213pd,0x6638a758,"vfmsubadd213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[72][1]},
+    {OP_vfmsubadd213ps,0x6638a718,"vfmsubadd213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[72][0]},
+    {OP_vfmsubadd213pd,0x6638a758,"vfmsubadd213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[72][1]},
   }, { /* vex_W_ext 11 */
-    {OP_vfmsubadd231ps,0x6638b718,"vfmsubadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[73][0]},
-    {OP_vfmsubadd231pd,0x6638b758,"vfmsubadd231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[73][1]},
+    {OP_vfmsubadd231ps,0x6638b718,"vfmsubadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[73][0]},
+    {OP_vfmsubadd231pd,0x6638b758,"vfmsubadd231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[73][1]},
   }, { /* vex_W_ext 12 */
-    {OP_vfmsub132ps,0x66389a18,"vfmsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[74][0]},
-    {OP_vfmsub132pd,0x66389a58,"vfmsub132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[74][1]},
+    {OP_vfmsub132ps,0x66389a18,"vfmsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[74][0]},
+    {OP_vfmsub132pd,0x66389a58,"vfmsub132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[74][1]},
   }, { /* vex_W_ext 13 */
-    {OP_vfmsub213ps,0x6638aa18,"vfmsub213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[75][0]},
-    {OP_vfmsub213pd,0x6638aa58,"vfmsub213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[75][1]},
+    {OP_vfmsub213ps,0x6638aa18,"vfmsub213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[75][0]},
+    {OP_vfmsub213pd,0x6638aa58,"vfmsub213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[75][1]},
   }, { /* vex_W_ext 14 */
-    {OP_vfmsub231ps,0x6638ba18,"vfmsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[76][0]},
-    {OP_vfmsub231pd,0x6638ba58,"vfmsub231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[76][1]},
+    {OP_vfmsub231ps,0x6638ba18,"vfmsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[76][0]},
+    {OP_vfmsub231pd,0x6638ba58,"vfmsub231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[76][1]},
   }, { /* vex_W_ext 15 */
-    {OP_vfmsub132ss,0x66389b18,"vfmsub132ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[77][0]},
-    {OP_vfmsub132sd,0x66389b58,"vfmsub132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[77][1]},
+    {OP_vfmsub132ss,0x66389b18,"vfmsub132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,tevexw[77][0]},
+    {OP_vfmsub132sd,0x66389b58,"vfmsub132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,tevexw[77][1]},
   }, { /* vex_W_ext 16 */
-    {OP_vfmsub213ss,0x6638ab18,"vfmsub213ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[78][0]},
-    {OP_vfmsub213sd,0x6638ab58,"vfmsub213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[78][1]},
+    {OP_vfmsub213ss,0x6638ab18,"vfmsub213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,tevexw[78][0]},
+    {OP_vfmsub213sd,0x6638ab58,"vfmsub213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,tevexw[78][1]},
   }, { /* vex_W_ext 17 */
-    {OP_vfmsub231ss,0x6638bb18,"vfmsub231ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[79][0]},
-    {OP_vfmsub231sd,0x6638bb58,"vfmsub231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[79][1]},
+    {OP_vfmsub231ss,0x6638bb18,"vfmsub231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,tevexw[79][0]},
+    {OP_vfmsub231sd,0x6638bb58,"vfmsub231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,tevexw[79][1]},
   }, { /* vex_W_ext 18 */
-    {OP_vfnmadd132ps,0x66389c18,"vfnmadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[80][0]},
-    {OP_vfnmadd132pd,0x66389c58,"vfnmadd132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[80][1]},
+    {OP_vfnmadd132ps,0x66389c18,"vfnmadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[80][0]},
+    {OP_vfnmadd132pd,0x66389c58,"vfnmadd132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[80][1]},
   }, { /* vex_W_ext 19 */
-    {OP_vfnmadd213ps,0x6638ac18,"vfnmadd213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[81][0]},
-    {OP_vfnmadd213pd,0x6638ac58,"vfnmadd213pd",Vvd,xx,Hvd,Wvd,Vvs,mrm|vex,x,tevexw[81][1]},
+    {OP_vfnmadd213ps,0x6638ac18,"vfnmadd213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[81][0]},
+    {OP_vfnmadd213pd,0x6638ac58,"vfnmadd213pd",Vvd,xx,Hvd,Wvd,Vvs,mrm|vex|reqp,x,tevexw[81][1]},
   }, { /* vex_W_ext 20 */
-    {OP_vfnmadd231ps,0x6638bc18,"vfnmadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[82][0]},
-    {OP_vfnmadd231pd,0x6638bc58,"vfnmadd231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[82][1]},
+    {OP_vfnmadd231ps,0x6638bc18,"vfnmadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[82][0]},
+    {OP_vfnmadd231pd,0x6638bc58,"vfnmadd231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[82][1]},
   }, { /* vex_W_ext 21 */
-    {OP_vfnmadd132ss,0x66389d18,"vfnmadd132ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[83][0]},
-    {OP_vfnmadd132sd,0x66389d58,"vfnmadd132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[83][1]},
+    {OP_vfnmadd132ss,0x66389d18,"vfnmadd132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,tevexw[83][0]},
+    {OP_vfnmadd132sd,0x66389d58,"vfnmadd132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,tevexw[83][1]},
   }, { /* vex_W_ext 22 */
-    {OP_vfnmadd213ss,0x6638ad18,"vfnmadd213ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[84][0]},
-    {OP_vfnmadd213sd,0x6638ad58,"vfnmadd213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[84][1]},
+    {OP_vfnmadd213ss,0x6638ad18,"vfnmadd213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,tevexw[84][0]},
+    {OP_vfnmadd213sd,0x6638ad58,"vfnmadd213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,tevexw[84][1]},
   }, { /* vex_W_ext 23 */
-    {OP_vfnmadd231ss,0x6638bd18,"vfnmadd231ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[85][0]},
-    {OP_vfnmadd231sd,0x6638bd58,"vfnmadd231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[85][1]},
+    {OP_vfnmadd231ss,0x6638bd18,"vfnmadd231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,tevexw[85][0]},
+    {OP_vfnmadd231sd,0x6638bd58,"vfnmadd231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,tevexw[85][1]},
   }, { /* vex_W_ext 24 */
-    {OP_vfnmsub132ps,0x66389e18,"vfnmsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[86][0]},
-    {OP_vfnmsub132pd,0x66389e58,"vfnmsub132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[86][1]},
+    {OP_vfnmsub132ps,0x66389e18,"vfnmsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[86][0]},
+    {OP_vfnmsub132pd,0x66389e58,"vfnmsub132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[86][1]},
   }, { /* vex_W_ext 25 */
-    {OP_vfnmsub213ps,0x6638ae18,"vfnmsub213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[87][0]},
-    {OP_vfnmsub213pd,0x6638ae58,"vfnmsub213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[87][1]},
+    {OP_vfnmsub213ps,0x6638ae18,"vfnmsub213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[87][0]},
+    {OP_vfnmsub213pd,0x6638ae58,"vfnmsub213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[87][1]},
   }, { /* vex_W_ext 26 */
-    {OP_vfnmsub231ps,0x6638be18,"vfnmsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[88][0]},
-    {OP_vfnmsub231pd,0x6638be58,"vfnmsub231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[88][1]},
+    {OP_vfnmsub231ps,0x6638be18,"vfnmsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,tevexw[88][0]},
+    {OP_vfnmsub231pd,0x6638be58,"vfnmsub231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex|reqp,x,tevexw[88][1]},
   }, { /* vex_W_ext 27 */
-    {OP_vfnmsub132ss,0x66389f18,"vfnmsub132ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[89][0]},
-    {OP_vfnmsub132sd,0x66389f58,"vfnmsub132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[89][1]},
+    {OP_vfnmsub132ss,0x66389f18,"vfnmsub132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,tevexw[89][0]},
+    {OP_vfnmsub132sd,0x66389f58,"vfnmsub132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,tevexw[89][1]},
   }, { /* vex_W_ext 28 */
-    {OP_vfnmsub213ss,0x6638af18,"vfnmsub213ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[90][0]},
-    {OP_vfnmsub213sd,0x6638af58,"vfnmsub213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[90][1]},
+    {OP_vfnmsub213ss,0x6638af18,"vfnmsub213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,tevexw[90][0]},
+    {OP_vfnmsub213sd,0x6638af58,"vfnmsub213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,tevexw[90][1]},
   }, { /* vex_W_ext 29 */
-    {OP_vfnmsub231ss,0x6638bf18,"vfnmsub231ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[91][0]},
-    {OP_vfnmsub231sd,0x6638bf58,"vfnmsub231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[91][1]},
+    {OP_vfnmsub231ss,0x6638bf18,"vfnmsub231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,tevexw[91][0]},
+    {OP_vfnmsub231sd,0x6638bf58,"vfnmsub231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,tevexw[91][1]},
   }, { /* vex_W_ext 30 */
     {OP_vfmaddsubps,0x663a5c18,"vfmaddsubps",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[30][1]},
     {OP_vfmaddsubps,0x663a5c58,"vfmaddsubps",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
@@ -7305,95 +7005,95 @@ const instr_info_t evex_W_extensions[][2] = {
     {OP_vcvtudq2pd, 0xf30f7a10, "vcvtudq2pd", Ve, xx, KEb, We, xx, mrm|evex, x, END_LIST},
     {OP_vcvtuqq2pd, 0xf30f7a50, "vcvtuqq2pd", Ve, xx, KEb, We, xx, mrm|evex, x, END_LIST},
   }, { /* evex_W_ext 62 */
-    {OP_vfmadd132ps,0x66389818,"vfmadd132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[14]},
-    {OP_vfmadd132pd,0x66389858,"vfmadd132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[15]},
+    {OP_vfmadd132ps,0x66389818,"vfmadd132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[14]},
+    {OP_vfmadd132pd,0x66389858,"vfmadd132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[15]},
   }, { /* evex_W_ext 63 */
-    {OP_vfmadd213ps,0x6638a818,"vfmadd213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[16]},
-    {OP_vfmadd213pd,0x6638a858,"vfmadd213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[17]},
+    {OP_vfmadd213ps,0x6638a818,"vfmadd213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[16]},
+    {OP_vfmadd213pd,0x6638a858,"vfmadd213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[17]},
   }, { /* evex_W_ext 64 */
-    {OP_vfmadd231ps,0x6638b818,"vfmadd231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[18]},
-    {OP_vfmadd231pd,0x6638b858,"vfmadd231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[19]},
+    {OP_vfmadd231ps,0x6638b818,"vfmadd231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[18]},
+    {OP_vfmadd231pd,0x6638b858,"vfmadd231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[19]},
   }, { /* evex_W_ext 65 */
-    {OP_vfmadd132ss,0x66389918,"vfmadd132ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[20]},
-    {OP_vfmadd132sd,0x66389958,"vfmadd132sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[21]},
+    {OP_vfmadd132ss,0x66389918,"vfmadd132ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex|reqp,x,exop[20]},
+    {OP_vfmadd132sd,0x66389958,"vfmadd132sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex|reqp,x,exop[21]},
   }, { /* evex_W_ext 66 */
-    {OP_vfmadd213ss,0x6638a918,"vfmadd213ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[22]},
-    {OP_vfmadd213sd,0x6638a958,"vfmadd213sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[23]},
+    {OP_vfmadd213ss,0x6638a918,"vfmadd213ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex|reqp,x,exop[22]},
+    {OP_vfmadd213sd,0x6638a958,"vfmadd213sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex|reqp,x,exop[23]},
   }, { /* evex_W_ext 67 */
-    {OP_vfmadd231ss,0x6638b918,"vfmadd231ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[24]},
-    {OP_vfmadd231sd,0x6638b958,"vfmadd231sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[25]},
+    {OP_vfmadd231ss,0x6638b918,"vfmadd231ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex|reqp,x,exop[24]},
+    {OP_vfmadd231sd,0x6638b958,"vfmadd231sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex|reqp,x,exop[25]},
   }, { /* evex_W_ext 68 */
-    {OP_vfmaddsub132ps,0x66389618,"vfmaddsub132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[26]},
-    {OP_vfmaddsub132pd,0x66389658,"vfmaddsub132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[27]},
+    {OP_vfmaddsub132ps,0x66389618,"vfmaddsub132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[26]},
+    {OP_vfmaddsub132pd,0x66389658,"vfmaddsub132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[27]},
   }, { /* evex_W_ext 69 */
-    {OP_vfmaddsub213ps,0x6638a618,"vfmaddsub213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[28]},
-    {OP_vfmaddsub213pd,0x6638a658,"vfmaddsub213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[29]},
+    {OP_vfmaddsub213ps,0x6638a618,"vfmaddsub213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[28]},
+    {OP_vfmaddsub213pd,0x6638a658,"vfmaddsub213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[29]},
   }, { /* evex_W_ext 70 */
-    {OP_vfmaddsub231ps,0x6638b618,"vfmaddsub231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[30]},
-    {OP_vfmaddsub231pd,0x6638b658,"vfmaddsub231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[31]},
+    {OP_vfmaddsub231ps,0x6638b618,"vfmaddsub231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[30]},
+    {OP_vfmaddsub231pd,0x6638b658,"vfmaddsub231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[31]},
   }, { /* evex_W_ext 71 */
-    {OP_vfmsubadd132ps,0x66389718,"vfmsubadd132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[32]},
-    {OP_vfmsubadd132pd,0x66389758,"vfmsubadd132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[33]},
+    {OP_vfmsubadd132ps,0x66389718,"vfmsubadd132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[32]},
+    {OP_vfmsubadd132pd,0x66389758,"vfmsubadd132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[33]},
   }, { /* evex_W_ext 72 */
-    {OP_vfmsubadd213ps,0x6638a718,"vfmsubadd213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[34]},
-    {OP_vfmsubadd213pd,0x6638a758,"vfmsubadd213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[35]},
+    {OP_vfmsubadd213ps,0x6638a718,"vfmsubadd213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[34]},
+    {OP_vfmsubadd213pd,0x6638a758,"vfmsubadd213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[35]},
   }, { /* evex_W_ext 73 */
-    {OP_vfmsubadd231ps,0x6638b718,"vfmsubadd231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[36]},
-    {OP_vfmsubadd231pd,0x6638b758,"vfmsubadd231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[37]},
+    {OP_vfmsubadd231ps,0x6638b718,"vfmsubadd231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[36]},
+    {OP_vfmsubadd231pd,0x6638b758,"vfmsubadd231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[37]},
   }, { /* evex_W_ext 74 */
-    {OP_vfmsub132ps,0x66389a18,"vfmsub132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[38]},
-    {OP_vfmsub132pd,0x66389a58,"vfmsub132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[39]},
+    {OP_vfmsub132ps,0x66389a18,"vfmsub132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[38]},
+    {OP_vfmsub132pd,0x66389a58,"vfmsub132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[39]},
   }, { /* evex_W_ext 75 */
-    {OP_vfmsub213ps,0x6638aa18,"vfmsub213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[40]},
-    {OP_vfmsub213pd,0x6638aa58,"vfmsub213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[41]},
+    {OP_vfmsub213ps,0x6638aa18,"vfmsub213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[40]},
+    {OP_vfmsub213pd,0x6638aa58,"vfmsub213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[41]},
   }, { /* evex_W_ext 76 */
-    {OP_vfmsub231ps,0x6638ba18,"vfmsub231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[42]},
-    {OP_vfmsub231pd,0x6638ba58,"vfmsub231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[43]},
+    {OP_vfmsub231ps,0x6638ba18,"vfmsub231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[42]},
+    {OP_vfmsub231pd,0x6638ba58,"vfmsub231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[43]},
   }, { /* evex_W_ext 77 */
-    {OP_vfmsub132ss,0x66389b18,"vfmsub132ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[44]},
-    {OP_vfmsub132sd,0x66389b58,"vfmsub132sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[45]},
+    {OP_vfmsub132ss,0x66389b18,"vfmsub132ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex|reqp,x,exop[44]},
+    {OP_vfmsub132sd,0x66389b58,"vfmsub132sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex|reqp,x,exop[45]},
   }, { /* evex_W_ext 78 */
-    {OP_vfmsub213ss,0x6638ab18,"vfmsub213ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[46]},
-    {OP_vfmsub213sd,0x6638ab58,"vfmsub213sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[47]},
+    {OP_vfmsub213ss,0x6638ab18,"vfmsub213ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex|reqp,x,exop[46]},
+    {OP_vfmsub213sd,0x6638ab58,"vfmsub213sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex|reqp,x,exop[47]},
   }, { /* evex_W_ext 79 */
-    {OP_vfmsub231ss,0x6638bb18,"vfmsub231ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[48]},
-    {OP_vfmsub231sd,0x6638bb58,"vfmsub231sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[49]},
+    {OP_vfmsub231ss,0x6638bb18,"vfmsub231ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex|reqp,x,exop[48]},
+    {OP_vfmsub231sd,0x6638bb58,"vfmsub231sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex|reqp,x,exop[49]},
   }, { /* evex_W_ext 80 */
-    {OP_vfnmadd132ps,0x66389c18,"vfnmadd132ps",Ves,xx,KEb,Hes,Wes,xop|mrm|evex,x,exop[50]},
-    {OP_vfnmadd132pd,0x66389c58,"vfnmadd132pd",Ved,xx,KEw,Hed,Wed,xop|mrm|evex,x,exop[51]},
+    {OP_vfnmadd132ps,0x66389c18,"vfnmadd132ps",Ves,xx,KEb,Hes,Wes,xop|mrm|evex|reqp,x,exop[50]},
+    {OP_vfnmadd132pd,0x66389c58,"vfnmadd132pd",Ved,xx,KEw,Hed,Wed,xop|mrm|evex|reqp,x,exop[51]},
   }, { /* evex_W_ext 81 */
-    {OP_vfnmadd213ps,0x6638ac18,"vfnmadd213ps",Ves,xx,KEb,Hes,Wes,xop|mrm|evex,x,exop[52]},
-    {OP_vfnmadd213pd,0x6638ac58,"vfnmadd213pd",Ved,xx,KEw,Hed,Wed,xop|mrm|evex,x,exop[53]},
+    {OP_vfnmadd213ps,0x6638ac18,"vfnmadd213ps",Ves,xx,KEb,Hes,Wes,xop|mrm|evex|reqp,x,exop[52]},
+    {OP_vfnmadd213pd,0x6638ac58,"vfnmadd213pd",Ved,xx,KEw,Hed,Wed,xop|mrm|evex|reqp,x,exop[53]},
   }, { /* evex_W_ext 82 */
-    {OP_vfnmadd231ps,0x6638bc18,"vfnmadd231ps",Ves,xx,KEb,Hes,Wes,xop|mrm|evex,x,exop[54]},
-    {OP_vfnmadd231pd,0x6638bc58,"vfnmadd231pd",Ved,xx,KEw,Hed,Wed,xop|mrm|evex,x,exop[55]},
+    {OP_vfnmadd231ps,0x6638bc18,"vfnmadd231ps",Ves,xx,KEb,Hes,Wes,xop|mrm|evex|reqp,x,exop[54]},
+    {OP_vfnmadd231pd,0x6638bc58,"vfnmadd231pd",Ved,xx,KEw,Hed,Wed,xop|mrm|evex|reqp,x,exop[55]},
   }, { /* evex_W_ext 83 */
-    {OP_vfnmadd132ss,0x66389d18,"vfnmadd132ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[56]},
-    {OP_vfnmadd132sd,0x66389d58,"vfnmadd132sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[57]},
+    {OP_vfnmadd132ss,0x66389d18,"vfnmadd132ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex|reqp,x,exop[56]},
+    {OP_vfnmadd132sd,0x66389d58,"vfnmadd132sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex|reqp,x,exop[57]},
   }, { /* evex_W_ext 84 */
-    {OP_vfnmadd213ss,0x6638ad18,"vfnmadd213ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[58]},
-    {OP_vfnmadd213sd,0x6638ad58,"vfnmadd213sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[59]},
+    {OP_vfnmadd213ss,0x6638ad18,"vfnmadd213ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex|reqp,x,exop[58]},
+    {OP_vfnmadd213sd,0x6638ad58,"vfnmadd213sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex|reqp,x,exop[59]},
   }, { /* evex_W_ext 85 */
-    {OP_vfnmadd231ss,0x6638bd18,"vfnmadd231ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[60]},
-    {OP_vfnmadd231sd,0x6638bd58,"vfnmadd231sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[61]},
+    {OP_vfnmadd231ss,0x6638bd18,"vfnmadd231ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex|reqp,x,exop[60]},
+    {OP_vfnmadd231sd,0x6638bd58,"vfnmadd231sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex|reqp,x,exop[61]},
   }, { /* evex_W_ext 86 */
-    {OP_vfnmsub132ps,0x66389e18,"vfnmsub132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[62]},
-    {OP_vfnmsub132pd,0x66389e58,"vfnmsub132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[63]},
+    {OP_vfnmsub132ps,0x66389e18,"vfnmsub132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[62]},
+    {OP_vfnmsub132pd,0x66389e58,"vfnmsub132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[63]},
   }, { /* evex_W_ext 87 */
-    {OP_vfnmsub213ps,0x6638ae18,"vfnmsub213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[64]},
-    {OP_vfnmsub213pd,0x6638ae58,"vfnmsub213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[65]},
+    {OP_vfnmsub213ps,0x6638ae18,"vfnmsub213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[64]},
+    {OP_vfnmsub213pd,0x6638ae58,"vfnmsub213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[65]},
   }, { /* evex_W_ext 88 */
-    {OP_vfnmsub231ps,0x6638be18,"vfnmsub231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[66]},
-    {OP_vfnmsub231pd,0x6638be58,"vfnmsub231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[67]},
+    {OP_vfnmsub231ps,0x6638be18,"vfnmsub231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex|reqp,x,exop[66]},
+    {OP_vfnmsub231pd,0x6638be58,"vfnmsub231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex|reqp,x,exop[67]},
   }, { /* evex_W_ext 89 */
-    {OP_vfnmsub132ss,0x66389f18,"vfnmsub132ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[68]},
-    {OP_vfnmsub132sd,0x66389f58,"vfnmsub132sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[69]},
+    {OP_vfnmsub132ss,0x66389f18,"vfnmsub132ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex|reqp,x,exop[68]},
+    {OP_vfnmsub132sd,0x66389f58,"vfnmsub132sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex|reqp,x,exop[69]},
   }, { /* evex_W_ext 90 */
-    {OP_vfnmsub213ss,0x6638af18,"vfnmsub213ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[70]},
-    {OP_vfnmsub213sd,0x6638af58,"vfnmsub213sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[71]},
+    {OP_vfnmsub213ss,0x6638af18,"vfnmsub213ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex|reqp,x,exop[70]},
+    {OP_vfnmsub213sd,0x6638af58,"vfnmsub213sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex|reqp,x,exop[71]},
   }, { /* evex_W_ext 91 */
-    {OP_vfnmsub231ss,0x6638bf18,"vfnmsub231ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[72]},
-    {OP_vfnmsub231sd,0x6638bf58,"vfnmsub231sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[73]},
+    {OP_vfnmsub231ss,0x6638bf18,"vfnmsub231ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex|reqp,x,exop[72]},
+    {OP_vfnmsub231sd,0x6638bf58,"vfnmsub231sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex|reqp,x,exop[73]},
   },
 };
 

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1500,6 +1500,7 @@ const instr_info_t * const op_instr[] =
 #define Ldq TYPE_L, OPSZ_16 /* immed is 1 byte but reg is xmm */
 #define Lx TYPE_L, OPSZ_16_vex32 /* immed is 1 byte but reg is xmm/ymm */
 #define Lvs TYPE_L, OPSZ_16_vex32 /* immed is 1 byte but reg is xmm/ymm */
+#define Lvd TYPE_L, OPSZ_16_vex32 /* immed is 1 byte but reg is xmm/ymm */
 #define Lss TYPE_L, OPSZ_4_of_16 /* immed is 1 byte but reg is xmm/ymm */
 #define Lsd TYPE_L, OPSZ_8_of_16 /* immed is 1 byte but reg is xmm/ymm */
 
@@ -5326,6 +5327,426 @@ const instr_info_t prefix_extensions[][12] = {
     {EVEX_W_EXT,   0x660f7a10, "(evex_W ext 50)", xx, xx, xx, xx, xx, mrm|evex, x, 50},
     {EVEX_W_EXT,   0xf20f7a10, "(evex_W ext 60)", xx, xx, xx, xx, xx, mrm|evex, x, 60},
   },
+  { /* prefix extension 160 */
+    {INVALID,        0x389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x66389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf2389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389818, "(vex_W ext 0)", xx, xx, xx, xx, xx, mrm|vex, x, 0},
+    {INVALID,      0xf2389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x66389818, "(evex_W ext 62)", xx, xx, xx, xx, xx, mrm|evex, x, 62},
+    {INVALID,      0xf2389810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 161 */
+    {INVALID,        0x38a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638a818, "(vex_W ext 1)", xx, xx, xx, xx, xx, mrm|vex, x, 1},
+    {INVALID,      0xf238a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638a818, "(evex_W ext 63)", xx, xx, xx, xx, xx, mrm|evex, x, 63},
+    {INVALID,      0xf238a810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 162 */
+    {INVALID,        0x38b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638b818, "(vex_W ext 2)", xx, xx, xx, xx, xx, mrm|vex, x, 2},
+    {INVALID,      0xf238b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638b818, "(evex_W ext 64)", xx, xx, xx, xx, xx, mrm|evex, x, 64},
+    {INVALID,      0xf238b810, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 163 */
+    {INVALID,        0x389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x66389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf2389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389918, "(vex_W ext 3)", xx, xx, xx, xx, xx, mrm|vex, x, 3},
+    {INVALID,      0xf2389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x66389918, "(evex_W ext 65)", xx, xx, xx, xx, xx, mrm|evex, x, 65},
+    {INVALID,      0xf2389910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 164 */
+    {INVALID,        0x38a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638a918, "(vex_W ext 4)", xx, xx, xx, xx, xx, mrm|vex, x, 4},
+    {INVALID,      0xf238a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638a918, "(evex_W ext 66)", xx, xx, xx, xx, xx, mrm|evex, x, 66},
+    {INVALID,      0xf238a910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 165 */
+    {INVALID,        0x38b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638b918, "(vex_W ext 5)", xx, xx, xx, xx, xx, mrm|vex, x, 5},
+    {INVALID,      0xf238b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638b918, "(evex_W ext 67)", xx, xx, xx, xx, xx, mrm|evex, x, 67},
+    {INVALID,      0xf238b910, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 166 */
+    {INVALID,        0x389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x66389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf2389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389618, "(vex_W ext 6)", xx, xx, xx, xx, xx, mrm|vex, x, 6},
+    {INVALID,      0xf2389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x66389618, "(evex_W ext 68)", xx, xx, xx, xx, xx, mrm|evex, x, 68},
+    {INVALID,      0xf2389610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 167 */
+    {INVALID,        0x38a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638a618, "(vex_W ext 7)", xx, xx, xx, xx, xx, mrm|vex, x, 7},
+    {INVALID,      0xf238a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638a618, "(evex_W ext 69)", xx, xx, xx, xx, xx, mrm|evex, x, 69},
+    {INVALID,      0xf238a610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 168 */
+    {INVALID,        0x38b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638b618, "(vex_W ext 8)", xx, xx, xx, xx, xx, mrm|vex, x, 8},
+    {INVALID,      0xf238b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638b618, "(evex_W ext 70)", xx, xx, xx, xx, xx, mrm|evex, x, 70},
+    {INVALID,      0xf238b610, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 169 */
+    {INVALID,        0x389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x66389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf2389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389718, "(vex_W ext 9)", xx, xx, xx, xx, xx, mrm|vex, x, 9},
+    {INVALID,      0xf2389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x66389718, "(evex_W ext 71)", xx, xx, xx, xx, xx, mrm|evex, x, 71},
+    {INVALID,      0xf2389710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 170 */
+    {INVALID,        0x38a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638a718, "(vex_W ext 10)", xx, xx, xx, xx, xx, mrm|vex, x, 10},
+    {INVALID,      0xf238a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638a718, "(evex_W ext 72)", xx, xx, xx, xx, xx, mrm|evex, x, 72},
+    {INVALID,      0xf238a710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 171 */
+    {INVALID,        0x38b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638b718, "(vex_W ext 11)", xx, xx, xx, xx, xx, mrm|vex, x, 11},
+    {INVALID,      0xf238b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638b718, "(evex_W ext 73)", xx, xx, xx, xx, xx, mrm|evex, x, 73},
+    {INVALID,      0xf238b710, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 172 */
+    {INVALID,        0x389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x66389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf2389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389a18, "(vex_W ext 12)", xx, xx, xx, xx, xx, mrm|vex, x, 12},
+    {INVALID,      0xf2389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x66389a18, "(evex_W ext 74)", xx, xx, xx, xx, xx, mrm|evex, x, 74},
+    {INVALID,      0xf2389a10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 173 */
+    {INVALID,        0x38aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638aa18, "(vex_W ext 13)", xx, xx, xx, xx, xx, mrm|vex, x, 13},
+    {INVALID,      0xf238aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638aa18, "(evex_W ext 75)", xx, xx, xx, xx, xx, mrm|evex, x, 75},
+    {INVALID,      0xf238aa10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 174 */
+    {INVALID,        0x38ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638ba18, "(vex_W ext 14)", xx, xx, xx, xx, xx, mrm|vex, x, 14},
+    {INVALID,      0xf238ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638ba18, "(evex_W ext 76)", xx, xx, xx, xx, xx, mrm|evex, x, 76},
+    {INVALID,      0xf238ba10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 175 */
+    {INVALID,        0x389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x66389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf2389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389b18, "(vex_W ext 15)", xx, xx, xx, xx, xx, mrm|vex, x, 15},
+    {INVALID,      0xf2389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x66389b18, "(evex_W ext 77)", xx, xx, xx, xx, xx, mrm|evex, x, 77},
+    {INVALID,      0xf2389b10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 176 */
+    {INVALID,        0x38ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638ab18, "(vex_W ext 16)", xx, xx, xx, xx, xx, mrm|vex, x, 16},
+    {INVALID,      0xf238ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638ab18, "(evex_W ext 78)", xx, xx, xx, xx, xx, mrm|evex, x, 78},
+    {INVALID,      0xf238ab10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 177 */
+    {INVALID,        0x38bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638bb18, "(vex_W ext 17)", xx, xx, xx, xx, xx, mrm|vex, x, 17},
+    {INVALID,      0xf238bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638bb18, "(evex_W ext 79)", xx, xx, xx, xx, xx, mrm|evex, x, 79},
+    {INVALID,      0xf238bb10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 178 */
+    {INVALID,        0x389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x66389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf2389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389c18, "(vex_W ext 18)", xx, xx, xx, xx, xx, mrm|vex, x, 18},
+    {INVALID,      0xf2389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x66389c18, "(evex_W ext 80)", xx, xx, xx, xx, xx, mrm|evex, x, 80},
+    {INVALID,      0xf2389c10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 179 */
+    {INVALID,        0x38ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638ac18, "(vex_W ext 19)", xx, xx, xx, xx, xx, mrm|vex, x, 19},
+    {INVALID,      0xf238ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638ac18, "(evex_W ext 81)", xx, xx, xx, xx, xx, mrm|evex, x, 81},
+    {INVALID,      0xf238ac10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 180 */
+    {INVALID,        0x38bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638bc18, "(vex_W ext 20)", xx, xx, xx, xx, xx, mrm|vex, x, 20},
+    {INVALID,      0xf238bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638bc18, "(evex_W ext 82)", xx, xx, xx, xx, xx, mrm|evex, x, 82},
+    {INVALID,      0xf238bc10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 181 */
+    {INVALID,        0x389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x66389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf2389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389d18, "(vex_W ext 21)", xx, xx, xx, xx, xx, mrm|vex, x, 21},
+    {INVALID,      0xf2389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x66389d18, "(evex_W ext 83)", xx, xx, xx, xx, xx, mrm|evex, x, 83},
+    {INVALID,      0xf2389d10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 182 */
+    {INVALID,        0x38ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638ad18, "(vex_W ext 22)", xx, xx, xx, xx, xx, mrm|vex, x, 22},
+    {INVALID,      0xf238ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638ad18, "(evex_W ext 84)", xx, xx, xx, xx, xx, mrm|evex, x, 84},
+    {INVALID,      0xf238ad10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 183 */
+    {INVALID,        0x38bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638bd18, "(vex_W ext 23)", xx, xx, xx, xx, xx, mrm|vex, x, 23},
+    {INVALID,      0xf238bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638bd18, "(evex_W ext 85)", xx, xx, xx, xx, xx, mrm|evex, x, 85},
+    {INVALID,      0xf238bd10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 184 */
+    {INVALID,        0x389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x66389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf2389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389e18, "(vex_W ext 24)", xx, xx, xx, xx, xx, mrm|vex, x, 24},
+    {INVALID,      0xf2389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x66389e18, "(evex_W ext 86)", xx, xx, xx, xx, xx, mrm|evex, x, 86},
+    {INVALID,      0xf2389e10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 185 */
+    {INVALID,        0x38ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638ae18, "(vex_W ext 25)", xx, xx, xx, xx, xx, mrm|vex, x, 25},
+    {INVALID,      0xf238ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638ae18, "(evex_W ext 87)", xx, xx, xx, xx, xx, mrm|evex, x, 87},
+    {INVALID,      0xf238ae10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 186 */
+    {INVALID,        0x38be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638be18, "(vex_W ext 26)", xx, xx, xx, xx, xx, mrm|vex, x, 26},
+    {INVALID,      0xf238be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638be18, "(evex_W ext 88)", xx, xx, xx, xx, xx, mrm|evex, x, 88},
+    {INVALID,      0xf238be10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 187 */
+    {INVALID,        0x389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x66389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf2389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x66389f18, "(vex_W ext 27)", xx, xx, xx, xx, xx, mrm|vex, x, 27},
+    {INVALID,      0xf2389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf3389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x66389f18, "(evex_W ext 89)", xx, xx, xx, xx, xx, mrm|evex, x, 89},
+    {INVALID,      0xf2389f10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 188 */
+    {INVALID,        0x38af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638af18, "(vex_W ext 28)", xx, xx, xx, xx, xx, mrm|vex, x, 28},
+    {INVALID,      0xf238af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638af18, "(evex_W ext 90)", xx, xx, xx, xx, xx, mrm|evex, x, 90},
+    {INVALID,      0xf238af10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 189 */
+    {INVALID,        0x38bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6638bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf238bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {VEX_W_EXT,    0x6638bf18, "(vex_W ext 29)", xx, xx, xx, xx, xx, mrm|vex, x, 29},
+    {INVALID,      0xf238bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x38bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf338bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT,   0x6638bf18, "(evex_W ext 91)", xx, xx, xx, xx, xx, mrm|evex, x, 91},
+    {INVALID,      0xf238bf10, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
 };
 /****************************************************************************
  * Instructions that differ based on whether vex-encoded or not.
@@ -6158,38 +6579,38 @@ const instr_info_t third_byte_38[] = {
   {E_VEX_EXT,  0x66380e18, "(e_vex ext 59)", xx, xx, xx, xx, xx, mrm, x, 59},/*56*/
   {E_VEX_EXT,  0x66380f18, "(e_vex ext 60)", xx, xx, xx, xx, xx, mrm, x, 60},/*57*/
   /* FMA 96-9f */
-  {VEX_W_EXT, 0x66389618, "(vex_W ext  6)", xx, xx, xx, xx, xx, mrm, x,  6},/*58*/
-  {VEX_W_EXT, 0x66389718, "(vex_W ext  9)", xx, xx, xx, xx, xx, mrm, x,  9},/*59*/
-  {VEX_W_EXT, 0x66389818, "(vex_W ext  0)", xx, xx, xx, xx, xx, mrm, x,  0},/*60*/
-  {VEX_W_EXT, 0x66389918, "(vex_W ext  3)", xx, xx, xx, xx, xx, mrm, x,  3},/*61*/
-  {VEX_W_EXT, 0x66389a18, "(vex_W ext 12)", xx, xx, xx, xx, xx, mrm, x, 12},/*62*/
-  {VEX_W_EXT, 0x66389b18, "(vex_W ext 15)", xx, xx, xx, xx, xx, mrm, x, 15},/*63*/
-  {VEX_W_EXT, 0x66389c18, "(vex_W ext 18)", xx, xx, xx, xx, xx, mrm, x, 18},/*64*/
-  {VEX_W_EXT, 0x66389d18, "(vex_W ext 21)", xx, xx, xx, xx, xx, mrm, x, 21},/*65*/
-  {VEX_W_EXT, 0x66389e18, "(vex_W ext 24)", xx, xx, xx, xx, xx, mrm, x, 24},/*66*/
-  {VEX_W_EXT, 0x66389f18, "(vex_W ext 27)", xx, xx, xx, xx, xx, mrm, x, 27},/*67*/
+  {PREFIX_EXT,  0x389618, "(prefix ext 166)", xx, xx, xx, xx, xx, mrm, x, 166},/*58*/
+  {PREFIX_EXT,  0x389718, "(prefix ext 169)", xx, xx, xx, xx, xx, mrm, x, 169},/*59*/
+  {PREFIX_EXT,  0x389818, "(prefix ext 160)", xx, xx, xx, xx, xx, mrm, x, 160},/*60*/
+  {PREFIX_EXT,  0x389918, "(prefix ext 163)", xx, xx, xx, xx, xx, mrm, x, 163},/*61*/
+  {PREFIX_EXT,  0x389a18, "(prefix ext 172)", xx, xx, xx, xx, xx, mrm, x, 172},/*62*/
+  {PREFIX_EXT,  0x389b18, "(prefix ext 175)", xx, xx, xx, xx, xx, mrm, x, 175},/*63*/
+  {PREFIX_EXT,  0x389c18, "(prefix ext 178)", xx, xx, xx, xx, xx, mrm, x, 178},/*64*/
+  {PREFIX_EXT,  0x389d18, "(prefix ext 181)", xx, xx, xx, xx, xx, mrm, x, 181},/*65*/
+  {PREFIX_EXT,  0x389e18, "(prefix ext 184)", xx, xx, xx, xx, xx, mrm, x, 184},/*66*/
+  {PREFIX_EXT,  0x389f18, "(prefix ext 187)", xx, xx, xx, xx, xx, mrm, x, 187},/*67*/
   /* FMA a6-af */
-  {VEX_W_EXT, 0x6638a618, "(vex_W ext  7)", xx, xx, xx, xx, xx, mrm, x,  7},/*68*/
-  {VEX_W_EXT, 0x6638a718, "(vex_W ext 10)", xx, xx, xx, xx, xx, mrm, x, 10},/*69*/
-  {VEX_W_EXT, 0x6638a818, "(vex_W ext  1)", xx, xx, xx, xx, xx, mrm, x,  1},/*70*/
-  {VEX_W_EXT, 0x6638a918, "(vex_W ext  4)", xx, xx, xx, xx, xx, mrm, x,  4},/*71*/
-  {VEX_W_EXT, 0x6638aa18, "(vex_W ext 13)", xx, xx, xx, xx, xx, mrm, x, 13},/*72*/
-  {VEX_W_EXT, 0x6638ab18, "(vex_W ext 16)", xx, xx, xx, xx, xx, mrm, x, 16},/*73*/
-  {VEX_W_EXT, 0x6638ac18, "(vex_W ext 19)", xx, xx, xx, xx, xx, mrm, x, 19},/*74*/
-  {VEX_W_EXT, 0x6638ad18, "(vex_W ext 22)", xx, xx, xx, xx, xx, mrm, x, 22},/*75*/
-  {VEX_W_EXT, 0x6638ae18, "(vex_W ext 25)", xx, xx, xx, xx, xx, mrm, x, 25},/*76*/
-  {VEX_W_EXT, 0x6638af18, "(vex_W ext 28)", xx, xx, xx, xx, xx, mrm, x, 28},/*77*/
+  {PREFIX_EXT,  0x38a618, "(prefix ext 167)", xx, xx, xx, xx, xx, mrm, x, 167},/*68*/
+  {PREFIX_EXT,  0x38a718, "(prefix ext 170)", xx, xx, xx, xx, xx, mrm, x, 170},/*69*/
+  {PREFIX_EXT,  0x38a818, "(prefix ext 161)", xx, xx, xx, xx, xx, mrm, x, 161},/*70*/
+  {PREFIX_EXT,  0x38a918, "(prefix ext 164)", xx, xx, xx, xx, xx, mrm, x, 164},/*71*/
+  {PREFIX_EXT,  0x38aa18, "(prefix ext 173)", xx, xx, xx, xx, xx, mrm, x, 173},/*72*/
+  {PREFIX_EXT,  0x38ab18, "(prefix ext 176)", xx, xx, xx, xx, xx, mrm, x, 176},/*73*/
+  {PREFIX_EXT,  0x38ac18, "(prefix ext 179)", xx, xx, xx, xx, xx, mrm, x, 179},/*74*/
+  {PREFIX_EXT,  0x38ad18, "(prefix ext 182)", xx, xx, xx, xx, xx, mrm, x, 182},/*75*/
+  {PREFIX_EXT,  0x38ae18, "(prefix ext 185)", xx, xx, xx, xx, xx, mrm, x, 185},/*76*/
+  {PREFIX_EXT,  0x38af18, "(prefix ext 188)", xx, xx, xx, xx, xx, mrm, x, 188},/*77*/
   /* FMA b6-bf */
-  {VEX_W_EXT, 0x6638b618, "(vex_W ext  8)", xx, xx, xx, xx, xx, mrm, x,  8},/*78*/
-  {VEX_W_EXT, 0x6638b718, "(vex_W ext 11)", xx, xx, xx, xx, xx, mrm, x, 11},/*79*/
-  {VEX_W_EXT, 0x6638b818, "(vex_W ext  2)", xx, xx, xx, xx, xx, mrm, x,  2},/*80*/
-  {VEX_W_EXT, 0x6638b918, "(vex_W ext  5)", xx, xx, xx, xx, xx, mrm, x,  5},/*81*/
-  {VEX_W_EXT, 0x6638ba18, "(vex_W ext 14)", xx, xx, xx, xx, xx, mrm, x, 14},/*82*/
-  {VEX_W_EXT, 0x6638bb18, "(vex_W ext 17)", xx, xx, xx, xx, xx, mrm, x, 17},/*83*/
-  {VEX_W_EXT, 0x6638bc18, "(vex_W ext 20)", xx, xx, xx, xx, xx, mrm, x, 20},/*84*/
-  {VEX_W_EXT, 0x6638bd18, "(vex_W ext 23)", xx, xx, xx, xx, xx, mrm, x, 23},/*85*/
-  {VEX_W_EXT, 0x6638be18, "(vex_W ext 26)", xx, xx, xx, xx, xx, mrm, x, 26},/*86*/
-  {VEX_W_EXT, 0x6638bf18, "(vex_W ext 29)", xx, xx, xx, xx, xx, mrm, x, 29},/*87*/
+  {PREFIX_EXT,  0x38b618, "(prefix ext 168)", xx, xx, xx, xx, xx, mrm, x, 168},/*78*/
+  {PREFIX_EXT,  0x38b718, "(prefix ext 171)", xx, xx, xx, xx, xx, mrm, x, 171},/*79*/
+  {PREFIX_EXT,  0x38b818, "(prefix ext 162)", xx, xx, xx, xx, xx, mrm, x, 162},/*80*/
+  {PREFIX_EXT,  0x38b918, "(prefix ext 165)", xx, xx, xx, xx, xx, mrm, x, 165},/*81*/
+  {PREFIX_EXT,  0x38ba18, "(prefix ext 174)", xx, xx, xx, xx, xx, mrm, x, 174},/*82*/
+  {PREFIX_EXT,  0x38bb18, "(prefix ext 177)", xx, xx, xx, xx, xx, mrm, x, 177},/*83*/
+  {PREFIX_EXT,  0x38bc18, "(prefix ext 180)", xx, xx, xx, xx, xx, mrm, x, 180},/*84*/
+  {PREFIX_EXT,  0x38bd18, "(prefix ext 183)", xx, xx, xx, xx, xx, mrm, x, 183},/*85*/
+  {PREFIX_EXT,  0x38be18, "(prefix ext 186)", xx, xx, xx, xx, xx, mrm, x, 186},/*86*/
+  {PREFIX_EXT,  0x38bf18, "(prefix ext 189)", xx, xx, xx, xx, xx, mrm, x, 189},/*87*/
   /* AVX overlooked in original pass */
   {E_VEX_EXT, 0x66381318, "(e_vex ext 63)", xx, xx, xx, xx, xx, mrm, x, 63},/*88*/
   {E_VEX_EXT, 0x66381818, "(e_vex ext 64)", xx, xx, xx, xx, xx, mrm, x, 64},/*89*/
@@ -6341,113 +6762,113 @@ const instr_info_t third_byte_3a[] = {
  */
 const instr_info_t vex_W_extensions[][2] = {
   {    /* vex_W_ext 0 */
-    {OP_vfmadd132ps,0x66389818,"vfmadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmadd132pd,0x66389858,"vfmadd132pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd132ps,0x66389818,"vfmadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[62][0]},
+    {OP_vfmadd132pd,0x66389858,"vfmadd132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[62][1]},
   }, { /* vex_W_ext 1 */
-    {OP_vfmadd213ps,0x6638a818,"vfmadd213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmadd213pd,0x6638a858,"vfmadd213pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd213ps,0x6638a818,"vfmadd213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[63][0]},
+    {OP_vfmadd213pd,0x6638a858,"vfmadd213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[63][1]},
   }, { /* vex_W_ext 2 */
-    {OP_vfmadd231ps,0x6638b818,"vfmadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmadd231pd,0x6638b858,"vfmadd231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd231ps,0x6638b818,"vfmadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[64][0]},
+    {OP_vfmadd231pd,0x6638b858,"vfmadd231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[64][1]},
   }, { /* vex_W_ext 3 */
-    {OP_vfmadd132ss,0x66389918,"vfmadd132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmadd132sd,0x66389958,"vfmadd132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd132ss,0x66389918,"vfmadd132ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[65][0]},
+    {OP_vfmadd132sd,0x66389958,"vfmadd132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[65][1]},
   }, { /* vex_W_ext 4 */
-    {OP_vfmadd213ss,0x6638a918,"vfmadd213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmadd213sd,0x6638a958,"vfmadd213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd213ss,0x6638a918,"vfmadd213ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[66][0]},
+    {OP_vfmadd213sd,0x6638a958,"vfmadd213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[66][1]},
   }, { /* vex_W_ext 5 */
-    {OP_vfmadd231ss,0x6638b918,"vfmadd231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmadd231sd,0x6638b958,"vfmadd231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmadd231ss,0x6638b918,"vfmadd231ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[67][0]},
+    {OP_vfmadd231sd,0x6638b958,"vfmadd231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[67][1]},
   }, { /* vex_W_ext 6 */
-    {OP_vfmaddsub132ps,0x66389618,"vfmaddsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmaddsub132pd,0x66389658,"vfmaddsub132pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmaddsub132ps,0x66389618,"vfmaddsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[68][0]},
+    {OP_vfmaddsub132pd,0x66389658,"vfmaddsub132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[68][1]},
   }, { /* vex_W_ext 7 */
-    {OP_vfmaddsub213ps,0x6638a618,"vfmaddsub213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmaddsub213pd,0x6638a658,"vfmaddsub213pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmaddsub213ps,0x6638a618,"vfmaddsub213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[69][0]},
+    {OP_vfmaddsub213pd,0x6638a658,"vfmaddsub213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[69][1]},
   }, { /* vex_W_ext 8 */
-    {OP_vfmaddsub231ps,0x6638b618,"vfmaddsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmaddsub231pd,0x6638b658,"vfmaddsub231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmaddsub231ps,0x6638b618,"vfmaddsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[70][0]},
+    {OP_vfmaddsub231pd,0x6638b658,"vfmaddsub231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[70][1]},
   }, { /* vex_W_ext 9 */
-    {OP_vfmsubadd132ps,0x66389718,"vfmsubadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsubadd132pd,0x66389758,"vfmsubadd132pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsubadd132ps,0x66389718,"vfmsubadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[71][0]},
+    {OP_vfmsubadd132pd,0x66389758,"vfmsubadd132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[71][1]},
   }, { /* vex_W_ext 10 */
-    {OP_vfmsubadd213ps,0x6638a718,"vfmsubadd213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsubadd213pd,0x6638a758,"vfmsubadd213pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsubadd213ps,0x6638a718,"vfmsubadd213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[72][0]},
+    {OP_vfmsubadd213pd,0x6638a758,"vfmsubadd213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[72][1]},
   }, { /* vex_W_ext 11 */
-    {OP_vfmsubadd231ps,0x6638b718,"vfmsubadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsubadd231pd,0x6638b758,"vfmsubadd231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsubadd231ps,0x6638b718,"vfmsubadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[73][0]},
+    {OP_vfmsubadd231pd,0x6638b758,"vfmsubadd231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[73][1]},
   }, { /* vex_W_ext 12 */
-    {OP_vfmsub132ps,0x66389a18,"vfmsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsub132pd,0x66389a58,"vfmsub132pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub132ps,0x66389a18,"vfmsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[74][0]},
+    {OP_vfmsub132pd,0x66389a58,"vfmsub132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[74][1]},
   }, { /* vex_W_ext 13 */
-    {OP_vfmsub213ps,0x6638aa18,"vfmsub213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsub213pd,0x6638aa58,"vfmsub213pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub213ps,0x6638aa18,"vfmsub213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[75][0]},
+    {OP_vfmsub213pd,0x6638aa58,"vfmsub213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[75][1]},
   }, { /* vex_W_ext 14 */
-    {OP_vfmsub231ps,0x6638ba18,"vfmsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsub231pd,0x6638ba58,"vfmsub231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub231ps,0x6638ba18,"vfmsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[76][0]},
+    {OP_vfmsub231pd,0x6638ba58,"vfmsub231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[76][1]},
   }, { /* vex_W_ext 15 */
-    {OP_vfmsub132ss,0x66389b18,"vfmsub132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsub132sd,0x66389b58,"vfmsub132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub132ss,0x66389b18,"vfmsub132ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[77][0]},
+    {OP_vfmsub132sd,0x66389b58,"vfmsub132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[77][1]},
   }, { /* vex_W_ext 16 */
-    {OP_vfmsub213ss,0x6638ab18,"vfmsub213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsub213sd,0x6638ab58,"vfmsub213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub213ss,0x6638ab18,"vfmsub213ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[78][0]},
+    {OP_vfmsub213sd,0x6638ab58,"vfmsub213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[78][1]},
   }, { /* vex_W_ext 17 */
-    {OP_vfmsub231ss,0x6638bb18,"vfmsub231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfmsub231sd,0x6638bb58,"vfmsub231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsub231ss,0x6638bb18,"vfmsub231ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[79][0]},
+    {OP_vfmsub231sd,0x6638bb58,"vfmsub231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[79][1]},
   }, { /* vex_W_ext 18 */
-    {OP_vfnmadd132ps,0x66389c18,"vfnmadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmadd132pd,0x66389c58,"vfnmadd132pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd132ps,0x66389c18,"vfnmadd132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[80][0]},
+    {OP_vfnmadd132pd,0x66389c58,"vfnmadd132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[80][1]},
   }, { /* vex_W_ext 19 */
-    {OP_vfnmadd213ps,0x6638ac18,"vfnmadd213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmadd213pd,0x6638ac58,"vfnmadd213pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd213ps,0x6638ac18,"vfnmadd213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[81][0]},
+    {OP_vfnmadd213pd,0x6638ac58,"vfnmadd213pd",Vvd,xx,Hvd,Wvd,Vvs,mrm|vex,x,tevexw[81][1]},
   }, { /* vex_W_ext 20 */
-    {OP_vfnmadd231ps,0x6638bc18,"vfnmadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmadd231pd,0x6638bc58,"vfnmadd231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd231ps,0x6638bc18,"vfnmadd231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[82][0]},
+    {OP_vfnmadd231pd,0x6638bc58,"vfnmadd231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[82][1]},
   }, { /* vex_W_ext 21 */
-    {OP_vfnmadd132ss,0x66389d18,"vfnmadd132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmadd132sd,0x66389d58,"vfnmadd132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd132ss,0x66389d18,"vfnmadd132ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[83][0]},
+    {OP_vfnmadd132sd,0x66389d58,"vfnmadd132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[83][1]},
   }, { /* vex_W_ext 22 */
-    {OP_vfnmadd213ss,0x6638ad18,"vfnmadd213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmadd213sd,0x6638ad58,"vfnmadd213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd213ss,0x6638ad18,"vfnmadd213ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[84][0]},
+    {OP_vfnmadd213sd,0x6638ad58,"vfnmadd213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[84][1]},
   }, { /* vex_W_ext 23 */
-    {OP_vfnmadd231ss,0x6638bd18,"vfnmadd231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmadd231sd,0x6638bd58,"vfnmadd231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmadd231ss,0x6638bd18,"vfnmadd231ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[85][0]},
+    {OP_vfnmadd231sd,0x6638bd58,"vfnmadd231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[85][1]},
   }, { /* vex_W_ext 24 */
-    {OP_vfnmsub132ps,0x66389e18,"vfnmsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmsub132pd,0x66389e58,"vfnmsub132pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub132ps,0x66389e18,"vfnmsub132ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[86][0]},
+    {OP_vfnmsub132pd,0x66389e58,"vfnmsub132pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[86][1]},
   }, { /* vex_W_ext 25 */
-    {OP_vfnmsub213ps,0x6638ae18,"vfnmsub213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmsub213pd,0x6638ae58,"vfnmsub213pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub213ps,0x6638ae18,"vfnmsub213ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[87][0]},
+    {OP_vfnmsub213pd,0x6638ae58,"vfnmsub213pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[87][1]},
   }, { /* vex_W_ext 26 */
-    {OP_vfnmsub231ps,0x6638be18,"vfnmsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmsub231pd,0x6638be58,"vfnmsub231pd",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub231ps,0x6638be18,"vfnmsub231ps",Vvs,xx,Hvs,Wvs,Vvs,mrm|vex,x,tevexw[88][0]},
+    {OP_vfnmsub231pd,0x6638be58,"vfnmsub231pd",Vvd,xx,Hvd,Wvd,Vvd,mrm|vex,x,tevexw[88][1]},
   }, { /* vex_W_ext 27 */
-    {OP_vfnmsub132ss,0x66389f18,"vfnmsub132ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmsub132sd,0x66389f58,"vfnmsub132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub132ss,0x66389f18,"vfnmsub132ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[89][0]},
+    {OP_vfnmsub132sd,0x66389f58,"vfnmsub132sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[89][1]},
   }, { /* vex_W_ext 28 */
-    {OP_vfnmsub213ss,0x6638af18,"vfnmsub213ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmsub213sd,0x6638af58,"vfnmsub213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub213ss,0x6638af18,"vfnmsub213ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[90][0]},
+    {OP_vfnmsub213sd,0x6638af58,"vfnmsub213sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[90][1]},
   }, { /* vex_W_ext 29 */
-    {OP_vfnmsub231ss,0x6638bf18,"vfnmsub231ss",Vss,xx,Hss,Wss,Vss,mrm|vex|reqp,x,END_LIST},
-    {OP_vfnmsub231sd,0x6638bf58,"vfnmsub231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsub231ss,0x6638bf18,"vfnmsub231ss",Vss,xx,Hss,Wss,Vss,mrm|vex,x,tevexw[91][0]},
+    {OP_vfnmsub231sd,0x6638bf58,"vfnmsub231sd",Vsd,xx,Hsd,Wsd,Vsd,mrm|vex,x,tevexw[91][1]},
   }, { /* vex_W_ext 30 */
     {OP_vfmaddsubps,0x663a5c18,"vfmaddsubps",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[30][1]},
     {OP_vfmaddsubps,0x663a5c58,"vfmaddsubps",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 31 */
-    {OP_vfmaddsubpd,0x663a5d18,"vfmaddsubpd",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[31][1]},
-    {OP_vfmaddsubpd,0x663a5d58,"vfmaddsubpd",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmaddsubpd,0x663a5d18,"vfmaddsubpd",Vvd,xx,Lvd,Wvd,Hvd,mrm|vex|reqp,x,tvexw[31][1]},
+    {OP_vfmaddsubpd,0x663a5d58,"vfmaddsubpd",Vvd,xx,Lvd,Hvd,Wvd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 32 */
     {OP_vfmsubaddps,0x663a5e18,"vfmsubaddps",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[32][1]},
     {OP_vfmsubaddps,0x663a5e58,"vfmsubaddps",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 33 */
-    {OP_vfmsubaddpd,0x663a5f18,"vfmsubaddpd",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[33][1]},
-    {OP_vfmsubaddpd,0x663a5f58,"vfmsubaddpd",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsubaddpd,0x663a5f18,"vfmsubaddpd",Vvd,xx,Lvd,Wvd,Hvd,mrm|vex|reqp,x,tvexw[33][1]},
+    {OP_vfmsubaddpd,0x663a5f58,"vfmsubaddpd",Vvd,xx,Lvd,Hvd,Wvd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 34 */
     {OP_vfmaddps,0x663a6818,"vfmaddps",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[34][1]},
     {OP_vfmaddps,0x663a6858,"vfmaddps",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 35 */
-    {OP_vfmaddpd,0x663a6918,"vfmaddpd",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[35][1]},
-    {OP_vfmaddpd,0x663a6958,"vfmaddpd",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmaddpd,0x663a6918,"vfmaddpd",Vvd,xx,Lvd,Wvd,Hvd,mrm|vex|reqp,x,tvexw[35][1]},
+    {OP_vfmaddpd,0x663a6958,"vfmaddpd",Vvd,xx,Lvd,Hvd,Wvd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 36 */
     {OP_vfmaddss,0x663a6a18,"vfmaddss",Vdq,xx,Lss,Wss,Hss,mrm|vex|reqp,x,tvexw[36][1]},
     {OP_vfmaddss,0x663a6a58,"vfmaddss",Vdq,xx,Lss,Hss,Wss,mrm|vex|reqp,x,END_LIST},
@@ -6458,8 +6879,8 @@ const instr_info_t vex_W_extensions[][2] = {
     {OP_vfmsubps,0x663a6c18,"vfmsubps",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[38][1]},
     {OP_vfmsubps,0x663a6c58,"vfmsubps",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 39 */
-    {OP_vfmsubpd,0x663a6d18,"vfmsubpd",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[39][1]},
-    {OP_vfmsubpd,0x663a6d58,"vfmsubpd",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfmsubpd,0x663a6d18,"vfmsubpd",Vvd,xx,Lvd,Wvd,Hvd,mrm|vex|reqp,x,tvexw[39][1]},
+    {OP_vfmsubpd,0x663a6d58,"vfmsubpd",Vvd,xx,Lvd,Hvd,Wvd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 40 */
     {OP_vfmsubss,0x663a6e18,"vfmsubss",Vdq,xx,Lss,Wss,Hss,mrm|vex|reqp,x,tvexw[40][1]},
     {OP_vfmsubss,0x663a6e58,"vfmsubss",Vdq,xx,Lss,Hss,Wss,mrm|vex|reqp,x,END_LIST},
@@ -6470,8 +6891,8 @@ const instr_info_t vex_W_extensions[][2] = {
     {OP_vfnmaddps,0x663a7818,"vfnmaddps",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[42][1]},
     {OP_vfnmaddps,0x663a7858,"vfnmaddps",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 43 */
-    {OP_vfnmaddpd,0x663a7918,"vfnmaddpd",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[43][1]},
-    {OP_vfnmaddpd,0x663a7958,"vfnmaddpd",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmaddpd,0x663a7918,"vfnmaddpd",Vvd,xx,Lvd,Wvd,Hvd,mrm|vex|reqp,x,tvexw[43][1]},
+    {OP_vfnmaddpd,0x663a7958,"vfnmaddpd",Vvd,xx,Lvd,Hvd,Wvd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 44 */
     {OP_vfnmaddss,0x663a7a18,"vfnmaddss",Vdq,xx,Lss,Wss,Hss,mrm|vex|reqp,x,tvexw[44][1]},
     {OP_vfnmaddss,0x663a7a58,"vfnmaddss",Vdq,xx,Lss,Hss,Wss,mrm|vex|reqp,x,END_LIST},
@@ -6482,8 +6903,8 @@ const instr_info_t vex_W_extensions[][2] = {
     {OP_vfnmsubps,0x663a7c18,"vfnmsubps",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[46][1]},
     {OP_vfnmsubps,0x663a7c58,"vfnmsubps",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 47 */
-    {OP_vfnmsubpd,0x663a7d18,"vfnmsubpd",Vvs,xx,Lvs,Wvs,Hvs,mrm|vex|reqp,x,tvexw[47][1]},
-    {OP_vfnmsubpd,0x663a7d58,"vfnmsubpd",Vvs,xx,Lvs,Hvs,Wvs,mrm|vex|reqp,x,END_LIST},
+    {OP_vfnmsubpd,0x663a7d18,"vfnmsubpd",Vvd,xx,Lvd,Wvd,Hvd,mrm|vex|reqp,x,tvexw[47][1]},
+    {OP_vfnmsubpd,0x663a7d58,"vfnmsubpd",Vvd,xx,Lvd,Hvd,Wvd,mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 48 */
     {OP_vfnmsubss,0x663a7e18,"vfnmsubss",Vdq,xx,Lss,Wss,Hss,mrm|vex|reqp,x,tvexw[48][1]},
     {OP_vfnmsubss,0x663a7e58,"vfnmsubss",Vdq,xx,Lss,Hss,Wss,mrm|vex|reqp,x,END_LIST},
@@ -6679,271 +7100,300 @@ const instr_info_t evex_W_extensions[][2] = {
   {    /* evex_W_ext 0 */
     {OP_vmovups, 0x0f1010,"vmovups", Ves,xx,KEd,Wes,xx,mrm|evex,x,tevexw[1][0]},
     {INVALID, 0x0f1050,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 1 */
+  }, { /* evex_W_ext 1 */
     {OP_vmovups, 0x0f1110,"vmovups", Wes,xx,KEd,Ves,xx,mrm|evex,x,END_LIST},
     {INVALID, 0x0f1150,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 2 */
+  }, { /* evex_W_ext 2 */
     {INVALID, 0x660f1010,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vmovupd, 0x660f1050,"vmovupd", Ved,xx,KEd,Wed,xx,mrm|evex,x,tevexw[3][1]},
-  },
-  {    /* evex_W_ext 3 */
+  }, { /* evex_W_ext 3 */
     {INVALID, 0x660f1110,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vmovupd, 0x660f1150,"vmovupd", Wed,xx,KEd,Ved,xx,mrm|evex,x,END_LIST},
-  },
-  {    /* evex_W_ext 4 */
+  }, { /* evex_W_ext 4 */
     {OP_vmovaps, 0x0f2810,"vmovaps", Ves,xx,KEd,Wes,xx,mrm|evex,x,tevexw[5][0]},
     {INVALID, 0x0f2850,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 5 */
+  }, { /* evex_W_ext 5 */
     {OP_vmovaps, 0x0f2910,"vmovaps", Wes,xx,KEd,Ves,xx,mrm|evex,x,END_LIST},
     {INVALID, 0x0f2950,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 6 */
+  }, { /* evex_W_ext 6 */
     {INVALID, 0x660f2810,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vmovapd, 0x660f2850,"vmovapd", Ved,xx,KEd,Wed,xx,mrm|evex,x,tevexw[7][1]},
-  },
-  {    /* evex_W_ext 7 */
+  }, { /* evex_W_ext 7 */
     {INVALID, 0x660f2910,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vmovapd, 0x660f2950,"vmovapd", Wed,xx,KEd,Ved,xx,mrm|evex,x,END_LIST},
-  },
-  {    /* evex_W_ext 8 */
+  }, { /* evex_W_ext 8 */
     {OP_vmovdqa32, 0x660f6f10,"vmovdqa32",Ve,xx,KEw,We,xx,mrm|evex,x,tevexw[9][0]},
     {OP_vmovdqa64, 0x660f6f50,"vmovdqa64",Ve,xx,KEw,We,xx,mrm|evex,x,tevexw[9][1]},
-  },
-  {    /* evex_W_ext 9 */
+  }, { /* evex_W_ext 9 */
     {OP_vmovdqa32, 0x660f7f10,"vmovdqa32",We,xx,KEw,Ve,xx,mrm|evex,x,END_LIST},
     {OP_vmovdqa64, 0x660f7f50,"vmovdqa64",We,xx,KEw,Ve,xx,mrm|evex,x,END_LIST},
-  },
-  {    /* evex_W_ext 10 */
+  }, { /* evex_W_ext 10 */
     {OP_vmovdqu8, 0xf20f6f10,"vmovdqu8",Ve,xx,KEw,We,xx,mrm|evex,x,tevexw[12][0]},
     {OP_vmovdqu16, 0xf20f6f50,"vmovdqu16",Ve,xx,KEw,We,xx,mrm|evex,x,tevexw[12][1]},
-  },
-  {    /* evex_W_ext 11 */
+  }, { /* evex_W_ext 11 */
     {OP_vmovdqu32, 0xf30f6f10,"vmovdqu32",Ve,xx,KEw,We,xx,mrm|evex,x,tevexw[13][0]},
     {OP_vmovdqu64, 0xf30f6f50,"vmovdqu64",Ve,xx,KEw,We,xx,mrm|evex,x,tevexw[13][1]},
-  },
-  {    /* evex_W_ext 12 */
+  }, { /* evex_W_ext 12 */
     {OP_vmovdqu8, 0xf20f7f10,"vmovdqu8",We,xx,KEw,Ve,xx,mrm|evex,x,END_LIST},
     {OP_vmovdqu16, 0xf20f7f50,"vmovdqu16",We,xx,KEw,Ve,xx,mrm|evex,x,END_LIST},
-  },
-  {    /* evex_W_ext 13 */
+  }, { /* evex_W_ext 13 */
     {OP_vmovdqu32, 0xf30f7f10,"vmovdqu32",We,xx,KEw,Ve,xx,mrm|evex,x,END_LIST},
     {OP_vmovdqu64, 0xf30f7f50,"vmovdqu64",We,xx,KEw,Ve,xx,mrm|evex,x,END_LIST},
-  },
-  {    /* evex_W_ext 14 */
+  }, { /* evex_W_ext 14 */
     {OP_vmovlps, 0x0f1210, "vmovlps", Vq_dq, xx, Hq_dq, Wq_dq, xx, mrm|evex|reqL0|reqLL0, x, tevexw[15][0]}, /*"vmovhlps" if reg-reg */
     {INVALID, 0x0f1250,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 15 */
+  }, { /* evex_W_ext 15 */
     {OP_vmovlps, 0x0f1310, "vmovlps", Mq, xx, Vq_dq, xx, xx, mrm|evex, x, END_LIST},
     {INVALID, 0x0f1350,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 16 */
+  }, { /* evex_W_ext 16 */
     {INVALID, 0x660f1210,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vmovlpd, 0x660f1250, "vmovlpd", Vq_dq, xx, Hq_dq, Mq, xx, mrm|evex|reqL0|reqLL0, x, tevexw[17][1]},
-  },
-  {    /* evex_W_ext 17 */
+  }, { /* evex_W_ext 17 */
     {INVALID, 0x660f1310,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vmovlpd, 0x660f1350, "vmovlpd", Mq, xx, Vq_dq, xx, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 18 */
+  }, { /* evex_W_ext 18 */
     {OP_vmovsldup,0xf30f1210, "vmovsldup", Ves, xx, KEw, Wes, xx, mrm|evex, x, END_LIST},
     {INVALID, 0xf30f1250,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 19 */
+  }, { /* evex_W_ext 19 */
     {INVALID, 0xf20f1210,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vmovddup, 0xf20f1250, "vmovddup", Ved, xx, KEb, Wh_e, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 20 */
+  }, { /* evex_W_ext 20 */
     {OP_vmovhps, 0x0f1610, "vmovhps", Vq_dq, xx, Hq_dq, Wq_dq, xx, mrm|evex|reqL0|reqLL0, x, tevexw[21][0]}, /*"vmovlhps" if reg-reg */
     {INVALID, 0x0f1650,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 21 */
+  }, { /* evex_W_ext 21 */
     {OP_vmovhps, 0x0f1710, "vmovhps", Mq, xx, Vq_dq, xx, xx, mrm|evex|reqL0|reqLL0, x, END_LIST},
     {INVALID, 0x0f1750,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 22 */
+  }, { /* evex_W_ext 22 */
     {INVALID, 0x660f1610,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vmovhpd, 0x660f1650, "vmovhpd", Vq_dq, xx, Hq_dq, Mq, xx, mrm|evex|reqL0|reqLL0, x, tevexw[23][1]},
-  },
-  {    /* evex_W_ext 23 */
+  }, { /* evex_W_ext 23 */
     {INVALID, 0x660f1710,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vmovhpd, 0x660f1750, "vmovhpd", Mq, xx, Vq_dq, xx, xx, mrm|evex|reqL0|reqLL0, x, END_LIST},
-  },
-  {    /* evex_W_ext 24 */
+  }, { /* evex_W_ext 24 */
     {OP_vmovshdup, 0xf30f1610, "vmovshdup", Ves, xx, KEw, Wes, xx, mrm|evex, x, END_LIST},
     {INVALID, 0xf30f1650,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 25 */
+  }, { /* evex_W_ext 25 */
     {OP_vunpcklps, 0x0f1410, "vunpcklps", Ves, xx, KEw, Hh_e, Wh_e, mrm|evex, x, END_LIST},
     {INVALID, 0x0f1450,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 26 */
+  }, { /* evex_W_ext 26 */
     {INVALID, 0x660f1410,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vunpcklpd, 0x660f1450, "vunpcklpd", Ved, xx, KEb, Hh_e, Wh_e, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 27 */
+  }, { /* evex_W_ext 27 */
     {OP_vunpckhps, 0x0f1510, "vunpckhps", Ves, xx, KEw, Hh_e, Wh_e, mrm|evex, x, END_LIST},
     {INVALID, 0x0f1550,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 28 */
+  }, { /* evex_W_ext 28 */
     {INVALID, 0x660f1510,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vunpckhpd, 0x660f1550, "vunpckhpd", Ved, xx, KEb, Hh_e, Wh_e, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 29 */
+  }, { /* evex_W_ext 29 */
     {OP_vcvtss2si, 0xf30f2d10, "vcvtss2si",   Gd, xx, Wss, xx, xx, mrm|evex, x, tevexw[29][1]},
     {OP_vcvtss2si, 0xf30f2d50, "vcvtss2si", Gd_q, xx, Wss, xx, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 30 */
+  }, { /* evex_W_ext 30 */
     {OP_vcvtsd2si, 0xf20f2d10, "vcvtsd2si",   Gd, xx, Wsd, xx, xx, mrm|evex, x, tevexw[30][1]},
     {OP_vcvtsd2si, 0xf20f2d50, "vcvtsd2si", Gd_q, xx, Wsd, xx, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 31 */
+  }, { /* evex_W_ext 31 */
     {OP_vcvtsi2ss, 0xf30f2a10, "vcvtsi2ss", Vdq, xx, H12_dq,   Ed, xx, mrm|evex, x, tevexw[31][1]},
     {OP_vcvtsi2ss, 0xf30f2a50, "vcvtsi2ss", Vdq, xx, H12_dq, Ed_q, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 32 */
+  }, { /* evex_W_ext 32 */
     {OP_vcvtsi2sd, 0xf20f2a10, "vcvtsi2sd", Vdq, xx, Hsd,   Ed, xx, mrm|evex, x, tevexw[32][1]},
     {OP_vcvtsi2sd, 0xf20f2a50, "vcvtsi2sd", Vdq, xx, Hsd, Ed_q, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 33 */
+  }, { /* evex_W_ext 33 */
     {OP_vmovntps, 0x0f2b10, "vmovntps", Mes, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
     {INVALID, 0x0f2b50,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 34 */
+  }, { /* evex_W_ext 34 */
     {INVALID, 0x660f2b10,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vmovntpd, 0x660f2b50, "vmovntpd", Med, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 35 */
+  }, { /* evex_W_ext 35 */
     {OP_vcvttss2si, 0xf30f2c10, "vcvttss2si",   Gd, xx, Wss, xx, xx, mrm|evex, x, tevexw[35][1]},
     {OP_vcvttss2si, 0xf30f2c50, "vcvttss2si", Gd_q, xx, Wss, xx, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 36 */
+  }, { /* evex_W_ext 36 */
     {OP_vcvttsd2si, 0xf20f2c10, "vcvttsd2si",   Gd, xx, Wsd, xx, xx, mrm|evex, x, tevexw[36][1]},
     {OP_vcvttsd2si, 0xf20f2c50, "vcvttsd2si", Gd_q, xx, Wsd, xx, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 37 */
+  }, { /* evex_W_ext 37 */
     {OP_vucomiss, 0x0f2e10, "vucomiss", xx, xx, Vss, Wss, xx, mrm|evex, fW6, END_LIST},
     {INVALID, 0x0f2e50,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 38 */
+  }, { /* evex_W_ext 38 */
     {INVALID, 0x660f2e10,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vucomisd, 0x660f2e50, "vucomisd", xx, xx, Vsd, Wsd, xx, mrm|evex, fW6, END_LIST},
-  },
-  {    /* evex_W_ext 39 */
+  }, { /* evex_W_ext 39 */
     {OP_vcomiss,  0x0f2f10, "vcomiss",  xx, xx, Vss, Wss, xx, mrm|evex, fW6, END_LIST},
     {INVALID, 0x0f2f50,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-  },
-  {    /* evex_W_ext 40 */
+  }, { /* evex_W_ext 40 */
     {INVALID, 0x660f2e10,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vcomisd,  0x660f2f50, "vcomisd",  xx, xx, Vsd, Wsd, xx, mrm|evex, fW6, END_LIST},
-  },
-  {    /* evex_W_ext 41 */
+  }, { /* evex_W_ext 41 */
     {OP_vpandd, 0x660fdb10, "vpandd", Ve, xx, KEw, He, We, mrm|evex, x, END_LIST},
     {OP_vpandq, 0x660fdb50, "vpandq", Ve, xx, KEb, He, We, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 42 */
+  }, { /* evex_W_ext 42 */
     {OP_vpandnd, 0x660fdf10, "vpandnd", Ve, xx, KEw, He, We, mrm|evex, x, END_LIST},
     {OP_vpandnq, 0x660fdf50, "vpandnq", Ve, xx, KEb, He, We, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 43 */
+  }, { /* evex_W_ext 43 */
     {OP_vpord, 0x660feb10, "vpord", Ve, xx, KEw, He, We, mrm|evex, x, END_LIST},
     {OP_vporq, 0x660feb50, "vporq", Ve, xx, KEb, He, We, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 44 */
+  }, { /* evex_W_ext 44 */
     {OP_vpxord, 0x660fef10, "vpxord", Ve, xx, KEw, He, We, mrm|evex, x, END_LIST},
     {OP_vpxorq, 0x660fef50, "vpxorq", Ve, xx, KEb, He, We, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 45 */
+  }, { /* evex_W_ext 45 */
     {OP_vpmulld,  0x66384018, "vpmulld",   Ve, xx, KEw,He,We, mrm|evex|reqp, x, END_LIST},
     {OP_vpmullq,  0x66384058, "vpmullq",   Ve, xx, KEb,He,We, mrm|evex|reqp, x, END_LIST},
-  },
-  {    /* evex_W_ext 46 */
+  }, { /* evex_W_ext 46 */
     /* XXX i#3639, tools tend to give source/destination different register size mnemonic.
      * This also affects the existing VEX version if it exists.
      */
     {OP_vcvtps2qq, 0x660f7b10, "vcvtps2qq", Ve, xx, KEb, Wes, xx, mrm|evex, x, END_LIST},
     {OP_vcvtpd2qq, 0x660f7b50, "vcvtpd2qq", Ve, xx, KEb, Wed, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 47 */
+  }, { /* evex_W_ext 47 */
     {OP_vcvtps2udq, 0x0f7910, "vcvtps2udq", Ve, xx, KEw, Wes, xx, mrm|evex, x, END_LIST},
     {OP_vcvtpd2udq, 0x0f7950, "vcvtpd2udq", Ve, xx, KEb, Wed, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 48 */
+  }, { /* evex_W_ext 48 */
     /* XXX i#3639, tools tend to give source/destination different register size mnemonic.
      * This also affects the existing VEX version if it exists.
      */
     {OP_vcvtps2uqq, 0x660f7910, "vcvtps2uqq", Ve, xx, KEw, Wes, xx, mrm|evex, x, END_LIST},
     {OP_vcvtpd2uqq, 0x660f7950, "vcvtpd2uqq", Ve, xx, KEb, Wed, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 49 */
+  }, { /* evex_W_ext 49 */
     {OP_vcvttps2udq, 0x0f7810, "vcvttps2udq", Ve, xx, KEw, Wes, xx, mrm|evex, x, END_LIST},
     /* XXX i#3639, tools tend to give source/destination different register size mnemonic.
      * This also affects the existing VEX version if it exists.
      */
     {OP_vcvttpd2udq, 0x0f7850, "vcvttpd2udq", Ve, xx, KEb, Wed, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 50 */
+  }, { /* evex_W_ext 50 */
     /* XXX i#3639, tools tend to give source/destination different register size mnemonic.
      * This also affects the existing VEX version if it exists.
      */
     {OP_vcvttps2qq,0x660f7a10, "vcvttps2qq", Ve, xx, KEb, Wes, xx, mrm|evex, x, END_LIST},
     {OP_vcvttpd2qq,0x660f7a50, "vcvttpd2qq", Ve, xx, KEb, Wed, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 51 */
+  }, { /* evex_W_ext 51 */
     /* XXX i#3639, tools tend to give source/destination different register size mnemonic.
      * This also affects the existing VEX version if it exists.
      */
     {OP_vcvttps2uqq, 0x660f7810, "vcvttps2uqq", Ve, xx, KEb, Wes, xx, mrm|evex, x, END_LIST},
     {OP_vcvttpd2uqq, 0x660f7850, "vcvttpd2uqq", Ve, xx, KEb, Wed, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 52 */
+  }, { /* evex_W_ext 52 */
    {OP_vcvtss2usi, 0xf30f7910, "vcvtss2usi",   Gd, xx, Wss, xx, xx, mrm|evex, x, tevexw[52][1]},
    {OP_vcvtss2usi, 0xf30f7950, "vcvtss2usi", Gd_q, xx, Wss, xx, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 53 */
+  }, { /* evex_W_ext 53 */
    {OP_vcvtsd2usi, 0xf20f7910, "vcvtsd2usi",   Gd, xx, Wsd, xx, xx, mrm|evex, x, tevexw[53][1]},
    {OP_vcvtsd2usi, 0xf20f7950, "vcvtsd2usi", Gd_q, xx, Wsd, xx, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 54 */
+  }, { /* evex_W_ext 54 */
    {OP_vcvttss2usi, 0xf30f7810, "vcvttss2usi",   Gd, xx, Wss, xx, xx, mrm|evex, x, tevexw[54][1]},
    {OP_vcvttss2usi, 0xf30f7850, "vcvttss2usi", Gd_q, xx, Wss, xx, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 55 */
+  }, { /* evex_W_ext 55 */
    {OP_vcvttsd2usi, 0xf20f7810, "vcvttsd2usi",   Gd, xx, Wsd, xx, xx, mrm|evex, x, tevexw[55][1]},
    {OP_vcvttsd2usi, 0xf20f7850, "vcvttsd2usi", Gd_q, xx, Wsd, xx, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 56 */
+  }, { /* evex_W_ext 56 */
     {OP_vcvtdq2ps, 0x0f5b10, "vcvtdq2ps", Ves, xx, KEw, We, xx, mrm|evex, x, END_LIST},
     /* XXX i#3639, tools tend to give source/destination different register size mnemonic.
      * This also affects the existing VEX version if it exists.
      */
     {OP_vcvtqq2ps, 0x0f5b50, "vcvtqq2ps", Ves, xx, KEb, We, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 57 */
+  }, { /* evex_W_ext 57 */
     /* XXX i#3639, tools tend to give source/destination different register size mnemonic.
      * This also affects the existing VEX version if it exists.
      */
     {OP_vcvtdq2pd, 0xf30fe610, "vcvtdq2pd",  Ved, xx, KEb, We, xx, mrm|evex, x, END_LIST},
     {OP_vcvtqq2pd, 0xf30fe650, "vcvtqq2pd",  Ved, xx, KEb, We, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 58 */
+  }, { /* evex_W_ext 58 */
     {OP_vcvtusi2ss, 0xf30f7b10, "vcvtusi2ss", Vdq, xx, H12_dq,   Ed, xx, mrm|evex, x, tevexw[58][1]},
     {OP_vcvtusi2ss, 0xf30f7b50, "vcvtusi2ss", Vdq, xx, H12_dq, Ed_q, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 59 */
+  }, { /* evex_W_ext 59 */
     {OP_vcvtusi2sd, 0xf20f7b10, "vcvtusi2sd", Vdq, xx, Hsd,   Ed, xx, mrm|evex, x, tevexw[59][1]},
     {OP_vcvtusi2sd, 0xf20f7b50, "vcvtusi2sd", Vdq, xx, Hsd, Ed_q, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 60 */
+  }, { /* evex_W_ext 60 */
     {OP_vcvtudq2ps, 0xf20f7a10, "vcvtudq2ps", Ve, xx, KEw, We, xx, mrm|evex, x, END_LIST},
     {OP_vcvtuqq2ps, 0xf20f7a50, "vcvtuqq2ps", Ve, xx, KEb, We, xx, mrm|evex, x, END_LIST},
-  },
-  {    /* evex_W_ext 61 */
+  }, { /* evex_W_ext 61 */
     {OP_vcvtudq2pd, 0xf30f7a10, "vcvtudq2pd", Ve, xx, KEb, We, xx, mrm|evex, x, END_LIST},
     {OP_vcvtuqq2pd, 0xf30f7a50, "vcvtuqq2pd", Ve, xx, KEb, We, xx, mrm|evex, x, END_LIST},
+  }, { /* evex_W_ext 62 */
+    {OP_vfmadd132ps,0x66389818,"vfmadd132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[14]},
+    {OP_vfmadd132pd,0x66389858,"vfmadd132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[15]},
+  }, { /* evex_W_ext 63 */
+    {OP_vfmadd213ps,0x6638a818,"vfmadd213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[16]},
+    {OP_vfmadd213pd,0x6638a858,"vfmadd213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[17]},
+  }, { /* evex_W_ext 64 */
+    {OP_vfmadd231ps,0x6638b818,"vfmadd231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[18]},
+    {OP_vfmadd231pd,0x6638b858,"vfmadd231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[19]},
+  }, { /* evex_W_ext 65 */
+    {OP_vfmadd132ss,0x66389918,"vfmadd132ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[20]},
+    {OP_vfmadd132sd,0x66389958,"vfmadd132sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[21]},
+  }, { /* evex_W_ext 66 */
+    {OP_vfmadd213ss,0x6638a918,"vfmadd213ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[22]},
+    {OP_vfmadd213sd,0x6638a958,"vfmadd213sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[23]},
+  }, { /* evex_W_ext 67 */
+    {OP_vfmadd231ss,0x6638b918,"vfmadd231ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[24]},
+    {OP_vfmadd231sd,0x6638b958,"vfmadd231sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[25]},
+  }, { /* evex_W_ext 68 */
+    {OP_vfmaddsub132ps,0x66389618,"vfmaddsub132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[26]},
+    {OP_vfmaddsub132pd,0x66389658,"vfmaddsub132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[27]},
+  }, { /* evex_W_ext 69 */
+    {OP_vfmaddsub213ps,0x6638a618,"vfmaddsub213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[28]},
+    {OP_vfmaddsub213pd,0x6638a658,"vfmaddsub213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[29]},
+  }, { /* evex_W_ext 70 */
+    {OP_vfmaddsub231ps,0x6638b618,"vfmaddsub231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[30]},
+    {OP_vfmaddsub231pd,0x6638b658,"vfmaddsub231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[31]},
+  }, { /* evex_W_ext 71 */
+    {OP_vfmsubadd132ps,0x66389718,"vfmsubadd132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[32]},
+    {OP_vfmsubadd132pd,0x66389758,"vfmsubadd132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[33]},
+  }, { /* evex_W_ext 72 */
+    {OP_vfmsubadd213ps,0x6638a718,"vfmsubadd213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[34]},
+    {OP_vfmsubadd213pd,0x6638a758,"vfmsubadd213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[35]},
+  }, { /* evex_W_ext 73 */
+    {OP_vfmsubadd231ps,0x6638b718,"vfmsubadd231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[36]},
+    {OP_vfmsubadd231pd,0x6638b758,"vfmsubadd231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[37]},
+  }, { /* evex_W_ext 74 */
+    {OP_vfmsub132ps,0x66389a18,"vfmsub132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[38]},
+    {OP_vfmsub132pd,0x66389a58,"vfmsub132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[39]},
+  }, { /* evex_W_ext 75 */
+    {OP_vfmsub213ps,0x6638aa18,"vfmsub213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[40]},
+    {OP_vfmsub213pd,0x6638aa58,"vfmsub213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[41]},
+  }, { /* evex_W_ext 76 */
+    {OP_vfmsub231ps,0x6638ba18,"vfmsub231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[42]},
+    {OP_vfmsub231pd,0x6638ba58,"vfmsub231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[43]},
+  }, { /* evex_W_ext 77 */
+    {OP_vfmsub132ss,0x66389b18,"vfmsub132ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[44]},
+    {OP_vfmsub132sd,0x66389b58,"vfmsub132sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[45]},
+  }, { /* evex_W_ext 78 */
+    {OP_vfmsub213ss,0x6638ab18,"vfmsub213ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[46]},
+    {OP_vfmsub213sd,0x6638ab58,"vfmsub213sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[47]},
+  }, { /* evex_W_ext 79 */
+    {OP_vfmsub231ss,0x6638bb18,"vfmsub231ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[48]},
+    {OP_vfmsub231sd,0x6638bb58,"vfmsub231sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[49]},
+  }, { /* evex_W_ext 80 */
+    {OP_vfnmadd132ps,0x66389c18,"vfnmadd132ps",Ves,xx,KEb,Hes,Wes,xop|mrm|evex,x,exop[50]},
+    {OP_vfnmadd132pd,0x66389c58,"vfnmadd132pd",Ved,xx,KEw,Hed,Wed,xop|mrm|evex,x,exop[51]},
+  }, { /* evex_W_ext 81 */
+    {OP_vfnmadd213ps,0x6638ac18,"vfnmadd213ps",Ves,xx,KEb,Hes,Wes,xop|mrm|evex,x,exop[52]},
+    {OP_vfnmadd213pd,0x6638ac58,"vfnmadd213pd",Ved,xx,KEw,Hed,Wed,xop|mrm|evex,x,exop[53]},
+  }, { /* evex_W_ext 82 */
+    {OP_vfnmadd231ps,0x6638bc18,"vfnmadd231ps",Ves,xx,KEb,Hes,Wes,xop|mrm|evex,x,exop[54]},
+    {OP_vfnmadd231pd,0x6638bc58,"vfnmadd231pd",Ved,xx,KEw,Hed,Wed,xop|mrm|evex,x,exop[55]},
+  }, { /* evex_W_ext 83 */
+    {OP_vfnmadd132ss,0x66389d18,"vfnmadd132ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[56]},
+    {OP_vfnmadd132sd,0x66389d58,"vfnmadd132sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[57]},
+  }, { /* evex_W_ext 84 */
+    {OP_vfnmadd213ss,0x6638ad18,"vfnmadd213ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[58]},
+    {OP_vfnmadd213sd,0x6638ad58,"vfnmadd213sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[59]},
+  }, { /* evex_W_ext 85 */
+    {OP_vfnmadd231ss,0x6638bd18,"vfnmadd231ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[60]},
+    {OP_vfnmadd231sd,0x6638bd58,"vfnmadd231sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[61]},
+  }, { /* evex_W_ext 86 */
+    {OP_vfnmsub132ps,0x66389e18,"vfnmsub132ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[62]},
+    {OP_vfnmsub132pd,0x66389e58,"vfnmsub132pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[63]},
+  }, { /* evex_W_ext 87 */
+    {OP_vfnmsub213ps,0x6638ae18,"vfnmsub213ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[64]},
+    {OP_vfnmsub213pd,0x6638ae58,"vfnmsub213pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[65]},
+  }, { /* evex_W_ext 88 */
+    {OP_vfnmsub231ps,0x6638be18,"vfnmsub231ps",Ves,xx,KEw,Hes,Wes,xop|mrm|evex,x,exop[66]},
+    {OP_vfnmsub231pd,0x6638be58,"vfnmsub231pd",Ved,xx,KEb,Hed,Wed,xop|mrm|evex,x,exop[67]},
+  }, { /* evex_W_ext 89 */
+    {OP_vfnmsub132ss,0x66389f18,"vfnmsub132ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[68]},
+    {OP_vfnmsub132sd,0x66389f58,"vfnmsub132sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[69]},
+  }, { /* evex_W_ext 90 */
+    {OP_vfnmsub213ss,0x6638af18,"vfnmsub213ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[70]},
+    {OP_vfnmsub213sd,0x6638af58,"vfnmsub213sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[71]},
+  }, { /* evex_W_ext 91 */
+    {OP_vfnmsub231ss,0x6638bf18,"vfnmsub231ss",Vss,xx,KEb,Hss,Wss,xop|mrm|evex,x,exop[72]},
+    {OP_vfnmsub231sd,0x6638bf58,"vfnmsub231sd",Vsd,xx,KEb,Hsd,Wsd,xop|mrm|evex,x,exop[73]},
   },
 };
 
@@ -7914,18 +8364,18 @@ const instr_info_t suffix_extensions[] = {
  */
 const instr_info_t extra_operands[] =
 {
-    /* 0x00 */
+    /* 0 */
     {OP_CONTD, 0x000000, "<pusha cont'd>", xx, xx, eCX, eDX, eBP, xop, x, exop[0x01]},
     {OP_CONTD, 0x000000, "<pusha cont'd>", xx, xx, eSI, eDI, xx, no, x, END_LIST},
-    /* 0x02 */
+    /* 2 */
     {OP_CONTD, 0x000000, "<popa cont'd>", eBX, eCX, xx, xx, xx, xop, x, exop[0x03]},
     {OP_CONTD, 0x000000, "<popa cont'd>", eDX, eBP, xx, xx, xx, xop, x, exop[0x04]},
     {OP_CONTD, 0x000000, "<popa cont'd>", eSI, eDI, xx, xx, xx, no, x, END_LIST},
-    /* 0x05 */
+    /* 5 */
     {OP_CONTD, 0x000000, "<enter cont'd>", xbp, xx, xbp, xx, xx, no, x, END_LIST},
-    /* 0x06 */
+    /* 6 */
     {OP_CONTD, 0x000000, "<cpuid cont'd>", ecx, edx, xx, xx, xx, no, x, END_LIST},
-    /* 0x07 */
+    /* 7 */
     {OP_CONTD, 0x000000, "<cmpxchg8b cont'd>", eDX, xx, eCX, eBX, xx, mrm, fWZ, END_LIST},
     {OP_CONTD,0x663a6018, "<pcmpestrm cont'd", xx, xx, eax, edx, xx, mrm|reqp, fW6, END_LIST},
     {OP_CONTD,0x663a6018, "<pcmpestri cont'd", xx, xx, eax, edx, xx, mrm|reqp, fW6, END_LIST},
@@ -7934,6 +8384,96 @@ const instr_info_t extra_operands[] =
     {OP_CONTD,0x663a6018, "<vpcmpestrm cont'd", xx, xx, eax, edx, xx, mrm|vex|reqp, fW6, END_LIST},
     {OP_CONTD,0x663a6018, "<vpcmpestri cont'd", xx, xx, eax, edx, xx, mrm|vex|reqp, fW6, END_LIST},
     {OP_CONTD,0x0f3710, "<getsec cont'd", ecx, xx, xx, xx, xx, predcx, x, END_LIST},
+    /* 14 */
+    {OP_CONTD,0x66389818, "<vfmadd132ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x66389858, "<vfmadd132pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 16 */
+    {OP_CONTD,0x6638a818, "<vfmadd213ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638a858, "<vfmadd213pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 18 */
+    {OP_CONTD,0x6638b818, "<vfmadd231ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638b858, "<vfmadd231pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 20 */
+    {OP_CONTD,0x66389918, "<vfmadd132ss cont'd", xx, xx, Vss, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x66389958, "<vfmadd132sd cont'd", xx, xx, Vsd, xx, xx, mrm|evex, x, END_LIST},
+    /* 22 */
+    {OP_CONTD,0x6638a918, "<vfmadd213ss cont'd", xx, xx, Vss, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638a958, "<vfmadd213sd cont'd", xx, xx, Vsd, xx, xx, mrm|evex, x, END_LIST},
+    /* 24 */
+    {OP_CONTD,0x6638b918, "<vfmadd231ss cont'd", xx, xx, Vss, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638b958, "<vfmadd231sd cont'd", xx, xx, Vsd, xx, xx, mrm|evex, x, END_LIST},
+    /* 26 */
+    {OP_CONTD,0x66389618, "<vfmaddsub132ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x66389658, "<vfmaddsub132pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 28 */
+    {OP_CONTD,0x6638a618, "<vfmaddsub213ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638a658, "<vfmaddsub213pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 30 */
+    {OP_CONTD,0x6638b618, "<vfmaddsub231ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638b658, "<vfmaddsub231pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 32 */
+    {OP_CONTD,0x66389718, "<vfmsubadd132ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x66389758, "<vfmsubadd132pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 34 */
+    {OP_CONTD,0x6638a718, "<vfmsubadd213ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638a758, "<vfmsubadd213pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 36 */
+    {OP_CONTD,0x6638b718, "<vfmsubadd231ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638b758, "<vfmsubadd231pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 38 */
+    {OP_CONTD,0x66389a18, "<vfmsub132ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x66389a58, "<vfmsub132pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 40 */
+    {OP_CONTD,0x6638aa18, "<vfmsub213ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638aa58, "<vfmsub213pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 42 */
+    {OP_CONTD,0x6638ba18, "<vfmsub231ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638ba58, "<vfmsub231pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 44 */
+    {OP_CONTD,0x66389b18, "<vfmsub132ss cont'd", xx, xx, Vss, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x66389b58, "<vfmsub132sd cont'd", xx, xx, Vsd, xx, xx, mrm|evex, x, END_LIST},
+    /* 46 */
+    {OP_CONTD,0x6638ab18, "<vfmsub213ss cont'd", xx, xx, Vss, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638ab58, "<vfmsub213sd cont'd", xx, xx, Vsd, xx, xx, mrm|evex, x, END_LIST},
+    /* 48 */
+    {OP_CONTD,0x6638bb18, "<vfmsub231ss cont'd", xx, xx, Vss, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638bb58, "<vfmsub231sd cont'd", xx, xx, Vsd, xx, xx, mrm|evex, x, END_LIST},
+    /* 50 */
+    {OP_CONTD,0x66389c18, "<vfnmadd132ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x66389c58, "<vfnmadd132pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 52 */
+    {OP_CONTD,0x6638ac18, "<vfnmadd213ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638ac58, "<vfnmadd213pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 54 */
+    {OP_CONTD,0x6638bc18, "<vfnmadd231ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638bc58, "<vfnmadd231pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 56 */
+    {OP_CONTD,0x66389d18, "<vfnmadd132ss cont'd", xx, xx, Vss, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x66389d58, "<vfnmadd132sd cont'd", xx, xx, Vsd, xx, xx, mrm|evex, x, END_LIST},
+    /* 58 */
+    {OP_CONTD,0x6638ad18, "<vfnmadd213ss cont'd", xx, xx, Vss, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638ad58, "<vfnmadd213sd cont'd", xx, xx, Vsd, xx, xx, mrm|evex, x, END_LIST},
+    /* 60 */
+    {OP_CONTD,0x6638bd18, "<vfnmadd231ss cont'd", xx, xx, Vss, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638bd58, "<vfnmadd231sd cont'd", xx, xx, Vsd, xx, xx, mrm|evex, x, END_LIST},
+    /* 62 */
+    {OP_CONTD,0x66389e18, "<vfnmsub132ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x66389e58, "<vfnmsub132pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 64 */
+    {OP_CONTD,0x6638ae18, "<vfnmsub213ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638ae58, "<vfnmsub213pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 66 */
+    {OP_CONTD,0x6638be18, "<vfnmsub231ps cont'd", xx, xx, Ves, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638be58, "<vfnmsub231pd cont'd", xx, xx, Ved, xx, xx, mrm|evex, x, END_LIST},
+    /* 68 */
+    {OP_CONTD,0x66389f18, "<vfnmsub132ss cont'd", xx, xx, Vss, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x66389f58, "<vfnmsub132sd cont'd", xx, xx, Vsd, xx, xx, mrm|evex, x, END_LIST},
+    /* 70 */
+    {OP_CONTD,0x6638af18, "<vfnmsub213ss cont'd", xx, xx, Vss, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638af58, "<vfnmsub213sd cont'd", xx, xx, Vsd, xx, xx, mrm|evex, x, END_LIST},
+    /* 72 */
+    {OP_CONTD,0x6638bf18, "<vfnmsub231ss cont'd", xx, xx, Vss, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD,0x6638bf58, "<vfnmsub231sd cont'd", xx, xx, Vsd, xx, xx, mrm|evex, x, END_LIST},
 };
 
 /* clang-format on */

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -3420,6 +3420,140 @@
     instr_create_1dst_3src((dc), OP_vfnmsub231sd, (d), (s1), (s2), (d))
 /* @} */ /* end doxygen group */
 
+/** @name 1 explicit destination, 1 mask, 2 explicit sources, dest is implicit source */
+/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/**
+ * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
+ * given explicit operands, automatically supplying any implicit operands.
+ * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * \param d The opnd_t explicit destination operand for the instruction.
+ * \param k The opnd_t explicit mask source operand for the instruction.
+ * \param s1 The opnd_t explicit first source operand for the instruction.
+ * \param s2 The opnd_t explicit second source operand for the instruction.
+ */
+/* AVX-512 FMA */
+#define INSTR_CREATE_vfmadd132ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmadd132ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmadd132pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmadd132pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmadd213ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmadd213ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmadd213pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmadd213pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmadd231ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmadd231ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmadd231pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmadd231pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmadd132ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmadd132ss, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmadd132sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmadd132sd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmadd213ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmadd213ss, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmadd213sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmadd213sd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmadd231ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmadd231ss, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmadd231sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmadd231sd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmaddsub132ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmaddsub132ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmaddsub132pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmaddsub132pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmaddsub213ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmaddsub213ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmaddsub213pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmaddsub213pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmaddsub231ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmaddsub231ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmaddsub231pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmaddsub231pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsubadd132ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsubadd132ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsubadd132pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsubadd132pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsubadd213ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsubadd213ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsubadd213pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsubadd213pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsubadd231ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsubadd231ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsubadd231pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsubadd231pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsub132ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsub132ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsub132pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsub132pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsub213ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsub213ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsub213pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsub213pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsub231ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsub231ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsub231pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsub231pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsub132ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsub132ss, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsub132sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsub132sd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsub213ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsub213ss, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsub213sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsub213sd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsub231ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsub231ss, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfmsub231sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfmsub231sd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmadd132ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmadd132ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmadd132pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmadd132pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmadd213ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmadd213ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmadd213pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmadd213pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmadd231ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmadd231ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmadd231pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmadd231pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmadd132ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmadd132ss, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmadd132sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmadd132sd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmadd213ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmadd213ss, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmadd213sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmadd213sd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmadd231ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmadd231ss, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmadd231sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmadd231sd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmsub132ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmsub132ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmsub132pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmsub132pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmsub213ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmsub213ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmsub213pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmsub213pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmsub231ps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmsub231ps, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmsub231pd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmsub231pd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmsub132ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmsub132ss, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmsub132sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmsub132sd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmsub213ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmsub213ss, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmsub213sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmsub213sd, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmsub231ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmsub231ss, (d), (k), (s1), (s2), (d))
+#define INSTR_CREATE_vfnmsub231sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfnmsub231sd, (d), (k), (s1), (s2), (d))
+/* @} */ /* end doxygen group */
+
 /** @name 1 explicit destination, 3 explicit sources */
 /* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**

--- a/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
@@ -1037,4 +1037,1108 @@ OPCODE(vcvtps2ph_zlok0zlo, vcvtps2ph, vcvtps2ph_mask, 0, REGARG(ZMM0), REGARG(K0
        REGARG(ZMM1), IMMARG(OPSZ_1))
 OPCODE(vcvtps2ph_zhik7zhi, vcvtps2ph, vcvtps2ph_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
        REGARG(ZMM31), IMMARG(OPSZ_1))
+OPCODE(vfmadd132ps_xlok0xloxlo, vfmadd132ps, vfmadd132ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmadd132ps_ylok0yloylo, vfmadd132ps, vfmadd132ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmadd132ps_zlok0zlozlo, vfmadd132ps, vfmadd132ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmadd132ps_xhik7xhixhi, vfmadd132ps, vfmadd132ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmadd132ps_yhik7yhiyhi, vfmadd132ps, vfmadd132ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmadd132ps_zhik7zhizhi, vfmadd132ps, vfmadd132ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmadd132ps_xlok0xlom, vfmadd132ps, vfmadd132ps_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmadd132ps_ylok0ylom, vfmadd132ps, vfmadd132ps_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmadd132ps_zlok0zlom, vfmadd132ps, vfmadd132ps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmadd132ps_xhik0xhim, vfmadd132ps, vfmadd132ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmadd132ps_yhik0yhim, vfmadd132ps, vfmadd132ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmadd132ps_zhik0zhim, vfmadd132ps, vfmadd132ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfmadd132pd_xlok0xloxlo, vfmadd132pd, vfmadd132pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmadd132pd_ylok0yloylo, vfmadd132pd, vfmadd132pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmadd132pd_zlok0zlozlo, vfmadd132pd, vfmadd132pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmadd132pd_xhik7xhixhi, vfmadd132pd, vfmadd132pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmadd132pd_yhik7yhiyhi, vfmadd132pd, vfmadd132pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmadd132pd_zhik7zhizhi, vfmadd132pd, vfmadd132pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmadd132pd_xlok0xlom, vfmadd132pd, vfmadd132pd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmadd132pd_ylok0ylom, vfmadd132pd, vfmadd132pd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmadd132pd_zlok0zlom, vfmadd132pd, vfmadd132pd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmadd132pd_xhik0xhim, vfmadd132pd, vfmadd132pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmadd132pd_yhik0yhim, vfmadd132pd, vfmadd132pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmadd132pd_zhik0zhim, vfmadd132pd, vfmadd132pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfmadd213ps_xlok0xloxlo, vfmadd213ps, vfmadd213ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmadd213ps_ylok0yloylo, vfmadd213ps, vfmadd213ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmadd213ps_zlok0zlozlo, vfmadd213ps, vfmadd213ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmadd213ps_xhik7xhixhi, vfmadd213ps, vfmadd213ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmadd213ps_yhik7yhiyhi, vfmadd213ps, vfmadd213ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmadd213ps_zhik7zhizhi, vfmadd213ps, vfmadd213ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmadd213ps_xlok0xlom, vfmadd213ps, vfmadd213ps_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmadd213ps_ylok0ylom, vfmadd213ps, vfmadd213ps_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmadd213ps_zlok0zlom, vfmadd213ps, vfmadd213ps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmadd213ps_xhik0xhim, vfmadd213ps, vfmadd213ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmadd213ps_yhik0yhim, vfmadd213ps, vfmadd213ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmadd213ps_zhik0zhim, vfmadd213ps, vfmadd213ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfmadd213pd_xlok0xloxlo, vfmadd213pd, vfmadd213pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmadd213pd_ylok0yloylo, vfmadd213pd, vfmadd213pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmadd213pd_zlok0zlozlo, vfmadd213pd, vfmadd213pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmadd213pd_xhik7xhixhi, vfmadd213pd, vfmadd213pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmadd213pd_yhik7yhiyhi, vfmadd213pd, vfmadd213pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmadd213pd_zhik7zhizhi, vfmadd213pd, vfmadd213pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmadd213pd_xlok0xlom, vfmadd213pd, vfmadd213pd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmadd213pd_ylok0ylom, vfmadd213pd, vfmadd213pd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmadd213pd_zlok0zlom, vfmadd213pd, vfmadd213pd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmadd213pd_xhik0xhim, vfmadd213pd, vfmadd213pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmadd213pd_yhik0yhim, vfmadd213pd, vfmadd213pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmadd213pd_zhik0zhim, vfmadd213pd, vfmadd213pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfmadd231ps_xlok0xloxlo, vfmadd231ps, vfmadd231ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmadd231ps_ylok0yloylo, vfmadd231ps, vfmadd231ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmadd231ps_zlok0zlozlo, vfmadd231ps, vfmadd231ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmadd231ps_xhik7xhixhi, vfmadd231ps, vfmadd231ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmadd231ps_yhik7yhiyhi, vfmadd231ps, vfmadd231ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmadd231ps_zhik7zhizhi, vfmadd231ps, vfmadd231ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmadd231ps_xlok0xlom, vfmadd231ps, vfmadd231ps_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmadd231ps_ylok0ylom, vfmadd231ps, vfmadd231ps_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmadd231ps_zlok0zlom, vfmadd231ps, vfmadd231ps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmadd231ps_xhik0xhim, vfmadd231ps, vfmadd231ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmadd231ps_yhik0yhim, vfmadd231ps, vfmadd231ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmadd231ps_zhik0zhim, vfmadd231ps, vfmadd231ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfmadd231pd_xlok0xloxlo, vfmadd231pd, vfmadd231pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmadd231pd_ylok0yloylo, vfmadd231pd, vfmadd231pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmadd231pd_zlok0zlozlo, vfmadd231pd, vfmadd231pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmadd231pd_xhik7xhixhi, vfmadd231pd, vfmadd231pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmadd231pd_yhik7yhiyhi, vfmadd231pd, vfmadd231pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmadd231pd_zhik7zhizhi, vfmadd231pd, vfmadd231pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmadd231pd_xlok0xlom, vfmadd231pd, vfmadd231pd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmadd231pd_ylok0ylom, vfmadd231pd, vfmadd231pd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmadd231pd_zlok0zlom, vfmadd231pd, vfmadd231pd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmadd231pd_xhik0xhim, vfmadd231pd, vfmadd231pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmadd231pd_yhik0yhim, vfmadd231pd, vfmadd231pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmadd231pd_zhik0zhim, vfmadd231pd, vfmadd231pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfmadd132ss_xlok0xloxlo, vfmadd132ss, vfmadd132ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfmadd132ss_xhik7xhixhi, vfmadd132ss, vfmadd132ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_4),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfmadd132ss_xlok0xlom, vfmadd132ss, vfmadd132ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfmadd132ss_xhik0xhim, vfmadd132ss, vfmadd132ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfmadd132sd_xlok0xloxlo, vfmadd132sd, vfmadd132sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfmadd132sd_xhik7xhixhi, vfmadd132sd, vfmadd132sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfmadd132sd_xlok0xlom, vfmadd132sd, vfmadd132sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfmadd132sd_xhik0xhim, vfmadd132sd, vfmadd132sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfmadd213ss_xlok0xloxlo, vfmadd213ss, vfmadd213ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfmadd213ss_xhik7xhixhi, vfmadd213ss, vfmadd213ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_4),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfmadd213ss_xlok0xlom, vfmadd213ss, vfmadd213ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfmadd213ss_xhik0xhim, vfmadd213ss, vfmadd213ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfmadd213sd_xlok0xloxlo, vfmadd213sd, vfmadd213sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfmadd213sd_xhik7xhixhi, vfmadd213sd, vfmadd213sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfmadd213sd_xlok0xlom, vfmadd213sd, vfmadd213sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfmadd213sd_xhik0xhim, vfmadd213sd, vfmadd213sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfmadd231ss_xlok0xloxlo, vfmadd231ss, vfmadd231ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfmadd231ss_xhik7xhixhi, vfmadd231ss, vfmadd231ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_4),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfmadd231ss_xlok0xlom, vfmadd231ss, vfmadd231ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfmadd231ss_xhik0xhim, vfmadd231ss, vfmadd231ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfmadd231sd_xlok0xloxlo, vfmadd231sd, vfmadd231sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfmadd231sd_xhik7xhixhi, vfmadd231sd, vfmadd231sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfmadd231sd_xlok0xlom, vfmadd231sd, vfmadd231sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfmadd231sd_xhik0xhim, vfmadd231sd, vfmadd231sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfmaddsub132ps_xlok0xloxlo, vfmaddsub132ps, vfmaddsub132ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmaddsub132ps_ylok0yloylo, vfmaddsub132ps, vfmaddsub132ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmaddsub132ps_zlok0zlozlo, vfmaddsub132ps, vfmaddsub132ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmaddsub132ps_xhik7xhixhi, vfmaddsub132ps, vfmaddsub132ps_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmaddsub132ps_yhik7yhiyhi, vfmaddsub132ps, vfmaddsub132ps_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmaddsub132ps_zhik7zhizhi, vfmaddsub132ps, vfmaddsub132ps_mask, X64_ONLY,
+       REGARG(ZMM16), REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmaddsub132ps_xlok0xlom, vfmaddsub132ps, vfmaddsub132ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmaddsub132ps_ylok0ylom, vfmaddsub132ps, vfmaddsub132ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmaddsub132ps_zlok0zlom, vfmaddsub132ps, vfmaddsub132ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmaddsub132ps_xhik0xhim, vfmaddsub132ps, vfmaddsub132ps_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmaddsub132ps_yhik0yhim, vfmaddsub132ps, vfmaddsub132ps_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmaddsub213ps_xlok0xloxlo, vfmaddsub213ps, vfmaddsub213ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmaddsub213ps_ylok0yloylo, vfmaddsub213ps, vfmaddsub213ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmaddsub213ps_zlok0zlozlo, vfmaddsub213ps, vfmaddsub213ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmaddsub213ps_xhik7xhixhi, vfmaddsub213ps, vfmaddsub213ps_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmaddsub213ps_yhik7yhiyhi, vfmaddsub213ps, vfmaddsub213ps_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmaddsub213ps_zhik7zhizhi, vfmaddsub213ps, vfmaddsub213ps_mask, X64_ONLY,
+       REGARG(ZMM16), REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmaddsub213ps_xlok0xlom, vfmaddsub213ps, vfmaddsub213ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmaddsub213ps_ylok0ylom, vfmaddsub213ps, vfmaddsub213ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmaddsub213ps_zlok0zlom, vfmaddsub213ps, vfmaddsub213ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmaddsub213ps_xhik0xhim, vfmaddsub213ps, vfmaddsub213ps_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmaddsub213ps_yhik0yhim, vfmaddsub213ps, vfmaddsub213ps_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmaddsub231ps_xlok0xloxlo, vfmaddsub231ps, vfmaddsub231ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmaddsub231ps_ylok0yloylo, vfmaddsub231ps, vfmaddsub231ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmaddsub231ps_zlok0zlozlo, vfmaddsub231ps, vfmaddsub231ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmaddsub231ps_xhik7xhixhi, vfmaddsub231ps, vfmaddsub231ps_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmaddsub231ps_yhik7yhiyhi, vfmaddsub231ps, vfmaddsub231ps_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmaddsub231ps_zhik7zhizhi, vfmaddsub231ps, vfmaddsub231ps_mask, X64_ONLY,
+       REGARG(ZMM16), REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmaddsub231ps_xlok0xlom, vfmaddsub231ps, vfmaddsub231ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmaddsub231ps_ylok0ylom, vfmaddsub231ps, vfmaddsub231ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmaddsub231ps_zlok0zlom, vfmaddsub231ps, vfmaddsub231ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmaddsub231ps_xhik0xhim, vfmaddsub231ps, vfmaddsub231ps_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmaddsub231ps_yhik0yhim, vfmaddsub231ps, vfmaddsub231ps_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmaddsub132pd_xlok0xloxlo, vfmaddsub132pd, vfmaddsub132pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmaddsub132pd_ylok0yloylo, vfmaddsub132pd, vfmaddsub132pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmaddsub132pd_zlok0zlozlo, vfmaddsub132pd, vfmaddsub132pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmaddsub132pd_xhik7xhixhi, vfmaddsub132pd, vfmaddsub132pd_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmaddsub132pd_yhik7yhiyhi, vfmaddsub132pd, vfmaddsub132pd_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmaddsub132pd_zhik7zhizhi, vfmaddsub132pd, vfmaddsub132pd_mask, X64_ONLY,
+       REGARG(ZMM16), REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmaddsub132pd_xlok0xlom, vfmaddsub132pd, vfmaddsub132pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmaddsub132pd_ylok0ylom, vfmaddsub132pd, vfmaddsub132pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmaddsub132pd_zlok0zlom, vfmaddsub132pd, vfmaddsub132pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmaddsub132pd_xhik0xhim, vfmaddsub132pd, vfmaddsub132pd_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmaddsub132pd_yhik0yhim, vfmaddsub132pd, vfmaddsub132pd_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmaddsub213pd_xlok0xloxlo, vfmaddsub213pd, vfmaddsub213pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmaddsub213pd_ylok0yloylo, vfmaddsub213pd, vfmaddsub213pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmaddsub213pd_zlok0zlozlo, vfmaddsub213pd, vfmaddsub213pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmaddsub213pd_xhik7xhixhi, vfmaddsub213pd, vfmaddsub213pd_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmaddsub213pd_yhik7yhiyhi, vfmaddsub213pd, vfmaddsub213pd_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmaddsub213pd_zhik7zhizhi, vfmaddsub213pd, vfmaddsub213pd_mask, X64_ONLY,
+       REGARG(ZMM16), REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmaddsub213pd_xlok0xlom, vfmaddsub213pd, vfmaddsub213pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmaddsub213pd_ylok0ylom, vfmaddsub213pd, vfmaddsub213pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmaddsub213pd_zlok0zlom, vfmaddsub213pd, vfmaddsub213pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmaddsub213pd_xhik0xhim, vfmaddsub213pd, vfmaddsub213pd_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmaddsub213pd_yhik0yhim, vfmaddsub213pd, vfmaddsub213pd_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmaddsub231pd_xlok0xloxlo, vfmaddsub231pd, vfmaddsub231pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmaddsub231pd_ylok0yloylo, vfmaddsub231pd, vfmaddsub231pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmaddsub231pd_zlok0zlozlo, vfmaddsub231pd, vfmaddsub231pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmaddsub231pd_xhik7xhixhi, vfmaddsub231pd, vfmaddsub231pd_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmaddsub231pd_yhik7yhiyhi, vfmaddsub231pd, vfmaddsub231pd_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmaddsub231pd_zhik7zhizhi, vfmaddsub231pd, vfmaddsub231pd_mask, X64_ONLY,
+       REGARG(ZMM16), REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmaddsub231pd_xlok0xlom, vfmaddsub231pd, vfmaddsub231pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmaddsub231pd_ylok0ylom, vfmaddsub231pd, vfmaddsub231pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmaddsub231pd_zlok0zlom, vfmaddsub231pd, vfmaddsub231pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmaddsub231pd_xhik0xhim, vfmaddsub231pd, vfmaddsub231pd_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmaddsub231pd_yhik0yhim, vfmaddsub231pd, vfmaddsub231pd_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsubadd132ps_xlok0xloxlo, vfmsubadd132ps, vfmsubadd132ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmsubadd132ps_ylok0yloylo, vfmsubadd132ps, vfmsubadd132ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmsubadd132ps_zlok0zlozlo, vfmsubadd132ps, vfmsubadd132ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmsubadd132ps_xhik7xhixhi, vfmsubadd132ps, vfmsubadd132ps_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmsubadd132ps_yhik7yhiyhi, vfmsubadd132ps, vfmsubadd132ps_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmsubadd132ps_zhik7zhizhi, vfmsubadd132ps, vfmsubadd132ps_mask, X64_ONLY,
+       REGARG(ZMM16), REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmsubadd132ps_xlok0xlom, vfmsubadd132ps, vfmsubadd132ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmsubadd132ps_ylok0ylom, vfmsubadd132ps, vfmsubadd132ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmsubadd132ps_zlok0zlom, vfmsubadd132ps, vfmsubadd132ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmsubadd132ps_xhik0xhim, vfmsubadd132ps, vfmsubadd132ps_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmsubadd132ps_yhik0yhim, vfmsubadd132ps, vfmsubadd132ps_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsubadd213ps_xlok0xloxlo, vfmsubadd213ps, vfmsubadd213ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmsubadd213ps_ylok0yloylo, vfmsubadd213ps, vfmsubadd213ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmsubadd213ps_zlok0zlozlo, vfmsubadd213ps, vfmsubadd213ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmsubadd213ps_xhik7xhixhi, vfmsubadd213ps, vfmsubadd213ps_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmsubadd213ps_yhik7yhiyhi, vfmsubadd213ps, vfmsubadd213ps_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmsubadd213ps_zhik7zhizhi, vfmsubadd213ps, vfmsubadd213ps_mask, X64_ONLY,
+       REGARG(ZMM16), REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmsubadd213ps_xlok0xlom, vfmsubadd213ps, vfmsubadd213ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmsubadd213ps_ylok0ylom, vfmsubadd213ps, vfmsubadd213ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmsubadd213ps_zlok0zlom, vfmsubadd213ps, vfmsubadd213ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmsubadd213ps_xhik0xhim, vfmsubadd213ps, vfmsubadd213ps_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmsubadd213ps_yhik0yhim, vfmsubadd213ps, vfmsubadd213ps_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsubadd231ps_xlok0xloxlo, vfmsubadd231ps, vfmsubadd231ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmsubadd231ps_ylok0yloylo, vfmsubadd231ps, vfmsubadd231ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmsubadd231ps_zlok0zlozlo, vfmsubadd231ps, vfmsubadd231ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmsubadd231ps_xhik7xhixhi, vfmsubadd231ps, vfmsubadd231ps_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmsubadd231ps_yhik7yhiyhi, vfmsubadd231ps, vfmsubadd231ps_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmsubadd231ps_zhik7zhizhi, vfmsubadd231ps, vfmsubadd231ps_mask, X64_ONLY,
+       REGARG(ZMM16), REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmsubadd231ps_xlok0xlom, vfmsubadd231ps, vfmsubadd231ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmsubadd231ps_ylok0ylom, vfmsubadd231ps, vfmsubadd231ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmsubadd231ps_zlok0zlom, vfmsubadd231ps, vfmsubadd231ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmsubadd231ps_xhik0xhim, vfmsubadd231ps, vfmsubadd231ps_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmsubadd231ps_yhik0yhim, vfmsubadd231ps, vfmsubadd231ps_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsubadd132pd_xlok0xloxlo, vfmsubadd132pd, vfmsubadd132pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmsubadd132pd_ylok0yloylo, vfmsubadd132pd, vfmsubadd132pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmsubadd132pd_zlok0zlozlo, vfmsubadd132pd, vfmsubadd132pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmsubadd132pd_xhik7xhixhi, vfmsubadd132pd, vfmsubadd132pd_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmsubadd132pd_yhik7yhiyhi, vfmsubadd132pd, vfmsubadd132pd_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmsubadd132pd_zhik7zhizhi, vfmsubadd132pd, vfmsubadd132pd_mask, X64_ONLY,
+       REGARG(ZMM16), REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmsubadd132pd_xlok0xlom, vfmsubadd132pd, vfmsubadd132pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmsubadd132pd_ylok0ylom, vfmsubadd132pd, vfmsubadd132pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmsubadd132pd_zlok0zlom, vfmsubadd132pd, vfmsubadd132pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmsubadd132pd_xhik0xhim, vfmsubadd132pd, vfmsubadd132pd_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmsubadd132pd_yhik0yhim, vfmsubadd132pd, vfmsubadd132pd_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsubadd213pd_xlok0xloxlo, vfmsubadd213pd, vfmsubadd213pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmsubadd213pd_ylok0yloylo, vfmsubadd213pd, vfmsubadd213pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmsubadd213pd_zlok0zlozlo, vfmsubadd213pd, vfmsubadd213pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmsubadd213pd_xhik7xhixhi, vfmsubadd213pd, vfmsubadd213pd_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmsubadd213pd_yhik7yhiyhi, vfmsubadd213pd, vfmsubadd213pd_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmsubadd213pd_zhik7zhizhi, vfmsubadd213pd, vfmsubadd213pd_mask, X64_ONLY,
+       REGARG(ZMM16), REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmsubadd213pd_xlok0xlom, vfmsubadd213pd, vfmsubadd213pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmsubadd213pd_ylok0ylom, vfmsubadd213pd, vfmsubadd213pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmsubadd213pd_zlok0zlom, vfmsubadd213pd, vfmsubadd213pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmsubadd213pd_xhik0xhim, vfmsubadd213pd, vfmsubadd213pd_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmsubadd213pd_yhik0yhim, vfmsubadd213pd, vfmsubadd213pd_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsubadd231pd_xlok0xloxlo, vfmsubadd231pd, vfmsubadd231pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmsubadd231pd_ylok0yloylo, vfmsubadd231pd, vfmsubadd231pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmsubadd231pd_zlok0zlozlo, vfmsubadd231pd, vfmsubadd231pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmsubadd231pd_xhik7xhixhi, vfmsubadd231pd, vfmsubadd231pd_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmsubadd231pd_yhik7yhiyhi, vfmsubadd231pd, vfmsubadd231pd_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmsubadd231pd_zhik7zhizhi, vfmsubadd231pd, vfmsubadd231pd_mask, X64_ONLY,
+       REGARG(ZMM16), REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmsubadd231pd_xlok0xlom, vfmsubadd231pd, vfmsubadd231pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmsubadd231pd_ylok0ylom, vfmsubadd231pd, vfmsubadd231pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmsubadd231pd_zlok0zlom, vfmsubadd231pd, vfmsubadd231pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmsubadd231pd_xhik0xhim, vfmsubadd231pd, vfmsubadd231pd_mask, X64_ONLY,
+       REGARG(XMM16), REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmsubadd231pd_yhik0yhim, vfmsubadd231pd, vfmsubadd231pd_mask, X64_ONLY,
+       REGARG(YMM16), REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsub132ps_xlok0xloxlo, vfmsub132ps, vfmsub132ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmsub132ps_ylok0yloylo, vfmsub132ps, vfmsub132ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmsub132ps_zlok0zlozlo, vfmsub132ps, vfmsub132ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmsub132ps_xhik7xhixhi, vfmsub132ps, vfmsub132ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmsub132ps_yhik7yhiyhi, vfmsub132ps, vfmsub132ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmsub132ps_zhik7zhizhi, vfmsub132ps, vfmsub132ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmsub132ps_xlok0xlom, vfmsub132ps, vfmsub132ps_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmsub132ps_ylok0ylom, vfmsub132ps, vfmsub132ps_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmsub132ps_zlok0zlom, vfmsub132ps, vfmsub132ps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmsub132ps_xhik0xhim, vfmsub132ps, vfmsub132ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmsub132ps_yhik0yhim, vfmsub132ps, vfmsub132ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsub213ps_xlok0xloxlo, vfmsub213ps, vfmsub213ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmsub213ps_ylok0yloylo, vfmsub213ps, vfmsub213ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmsub213ps_zlok0zlozlo, vfmsub213ps, vfmsub213ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmsub213ps_xhik7xhixhi, vfmsub213ps, vfmsub213ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmsub213ps_yhik7yhiyhi, vfmsub213ps, vfmsub213ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmsub213ps_zhik7zhizhi, vfmsub213ps, vfmsub213ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmsub213ps_xlok0xlom, vfmsub213ps, vfmsub213ps_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmsub213ps_ylok0ylom, vfmsub213ps, vfmsub213ps_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmsub213ps_zlok0zlom, vfmsub213ps, vfmsub213ps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmsub213ps_xhik0xhim, vfmsub213ps, vfmsub213ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmsub213ps_yhik0yhim, vfmsub213ps, vfmsub213ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsub231ps_xlok0xloxlo, vfmsub231ps, vfmsub231ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmsub231ps_ylok0yloylo, vfmsub231ps, vfmsub231ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmsub231ps_zlok0zlozlo, vfmsub231ps, vfmsub231ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmsub231ps_xhik7xhixhi, vfmsub231ps, vfmsub231ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmsub231ps_yhik7yhiyhi, vfmsub231ps, vfmsub231ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmsub231ps_zhik7zhizhi, vfmsub231ps, vfmsub231ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmsub231ps_xlok0xlom, vfmsub231ps, vfmsub231ps_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmsub231ps_ylok0ylom, vfmsub231ps, vfmsub231ps_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmsub231ps_zlok0zlom, vfmsub231ps, vfmsub231ps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmsub231ps_xhik0xhim, vfmsub231ps, vfmsub231ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmsub231ps_yhik0yhim, vfmsub231ps, vfmsub231ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsub132pd_xlok0xloxlo, vfmsub132pd, vfmsub132pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmsub132pd_ylok0yloylo, vfmsub132pd, vfmsub132pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmsub132pd_zlok0zlozlo, vfmsub132pd, vfmsub132pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmsub132pd_xhik7xhixhi, vfmsub132pd, vfmsub132pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmsub132pd_yhik7yhiyhi, vfmsub132pd, vfmsub132pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmsub132pd_zhik7zhizhi, vfmsub132pd, vfmsub132pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmsub132pd_xlok0xlom, vfmsub132pd, vfmsub132pd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmsub132pd_ylok0ylom, vfmsub132pd, vfmsub132pd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmsub132pd_zlok0zlom, vfmsub132pd, vfmsub132pd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmsub132pd_xhik0xhim, vfmsub132pd, vfmsub132pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmsub132pd_yhik0yhim, vfmsub132pd, vfmsub132pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsub213pd_xlok0xloxlo, vfmsub213pd, vfmsub213pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmsub213pd_ylok0yloylo, vfmsub213pd, vfmsub213pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmsub213pd_zlok0zlozlo, vfmsub213pd, vfmsub213pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmsub213pd_xhik7xhixhi, vfmsub213pd, vfmsub213pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmsub213pd_yhik7yhiyhi, vfmsub213pd, vfmsub213pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmsub213pd_zhik7zhizhi, vfmsub213pd, vfmsub213pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmsub213pd_xlok0xlom, vfmsub213pd, vfmsub213pd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmsub213pd_ylok0ylom, vfmsub213pd, vfmsub213pd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmsub213pd_zlok0zlom, vfmsub213pd, vfmsub213pd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmsub213pd_xhik0xhim, vfmsub213pd, vfmsub213pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmsub213pd_yhik0yhim, vfmsub213pd, vfmsub213pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsub231pd_xlok0xloxlo, vfmsub231pd, vfmsub231pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfmsub231pd_ylok0yloylo, vfmsub231pd, vfmsub231pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfmsub231pd_zlok0zlozlo, vfmsub231pd, vfmsub231pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfmsub231pd_xhik7xhixhi, vfmsub231pd, vfmsub231pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfmsub231pd_yhik7yhiyhi, vfmsub231pd, vfmsub231pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfmsub231pd_zhik7zhizhi, vfmsub231pd, vfmsub231pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfmsub231pd_xlok0xlom, vfmsub231pd, vfmsub231pd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfmsub231pd_ylok0ylom, vfmsub231pd, vfmsub231pd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfmsub231pd_zlok0zlom, vfmsub231pd, vfmsub231pd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfmsub231pd_xhik0xhim, vfmsub231pd, vfmsub231pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfmsub231pd_yhik0yhim, vfmsub231pd, vfmsub231pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfmsub132ss_xlok0xloxlo, vfmsub132ss, vfmsub132ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfmsub132ss_xhik7xhixhi, vfmsub132ss, vfmsub132ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_4),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfmsub132ss_xlok0xlom, vfmsub132ss, vfmsub132ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfmsub132ss_xhik0xhim, vfmsub132ss, vfmsub132ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfmsub132sd_xlok0xloxlo, vfmsub132sd, vfmsub132sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfmsub132sd_xhik7xhixhi, vfmsub132sd, vfmsub132sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfmsub132sd_xlok0xlom, vfmsub132sd, vfmsub132sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfmsub132sd_xhik0xhim, vfmsub132sd, vfmsub132sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfmsub213ss_xlok0xloxlo, vfmsub213ss, vfmsub213ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfmsub213ss_xhik7xhixhi, vfmsub213ss, vfmsub213ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_4),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfmsub213ss_xlok0xlom, vfmsub213ss, vfmsub213ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfmsub213ss_xhik0xhim, vfmsub213ss, vfmsub213ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfmsub213sd_xlok0xloxlo, vfmsub213sd, vfmsub213sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfmsub213sd_xhik7xhixhi, vfmsub213sd, vfmsub213sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfmsub213sd_xlok0xlom, vfmsub213sd, vfmsub213sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfmsub213sd_xhik0xhim, vfmsub213sd, vfmsub213sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfmsub231ss_xlok0xloxlo, vfmsub231ss, vfmsub231ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfmsub231ss_xhik7xhixhi, vfmsub231ss, vfmsub231ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_4),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfmsub231ss_xlok0xlom, vfmsub231ss, vfmsub231ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfmsub231ss_xhik0xhim, vfmsub231ss, vfmsub231ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfmsub231sd_xlok0xloxlo, vfmsub231sd, vfmsub231sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfmsub231sd_xhik7xhixhi, vfmsub231sd, vfmsub231sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfmsub231sd_xlok0xlom, vfmsub231sd, vfmsub231sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfmsub231sd_xhik0xhim, vfmsub231sd, vfmsub231sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfnmadd132ps_xlok0xloxlo, vfnmadd132ps, vfnmadd132ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfnmadd132ps_ylok0yloylo, vfnmadd132ps, vfnmadd132ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfnmadd132ps_zlok0zlozlo, vfnmadd132ps, vfnmadd132ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfnmadd132ps_xhik7xhixhi, vfnmadd132ps, vfnmadd132ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfnmadd132ps_yhik7yhiyhi, vfnmadd132ps, vfnmadd132ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfnmadd132ps_zhik7zhizhi, vfnmadd132ps, vfnmadd132ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfnmadd132ps_xlok0xlom, vfnmadd132ps, vfnmadd132ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfnmadd132ps_ylok0ylom, vfnmadd132ps, vfnmadd132ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfnmadd132ps_zlok0zlom, vfnmadd132ps, vfnmadd132ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfnmadd132ps_xhik0xhim, vfnmadd132ps, vfnmadd132ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfnmadd132ps_yhik0yhim, vfnmadd132ps, vfnmadd132ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfnmadd132ps_zhik0zhim, vfnmadd132ps, vfnmadd132ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfnmadd132pd_xlok0xloxlo, vfnmadd132pd, vfnmadd132pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfnmadd132pd_ylok0yloylo, vfnmadd132pd, vfnmadd132pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfnmadd132pd_zlok0zlozlo, vfnmadd132pd, vfnmadd132pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfnmadd132pd_xhik7xhixhi, vfnmadd132pd, vfnmadd132pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfnmadd132pd_yhik7yhiyhi, vfnmadd132pd, vfnmadd132pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfnmadd132pd_zhik7zhizhi, vfnmadd132pd, vfnmadd132pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfnmadd132pd_xlok0xlom, vfnmadd132pd, vfnmadd132pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfnmadd132pd_ylok0ylom, vfnmadd132pd, vfnmadd132pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfnmadd132pd_zlok0zlom, vfnmadd132pd, vfnmadd132pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfnmadd132pd_xhik0xhim, vfnmadd132pd, vfnmadd132pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfnmadd132pd_yhik0yhim, vfnmadd132pd, vfnmadd132pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfnmadd132pd_zhik0zhim, vfnmadd132pd, vfnmadd132pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfnmadd213ps_xlok0xloxlo, vfnmadd213ps, vfnmadd213ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfnmadd213ps_ylok0yloylo, vfnmadd213ps, vfnmadd213ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfnmadd213ps_zlok0zlozlo, vfnmadd213ps, vfnmadd213ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfnmadd213ps_xhik7xhixhi, vfnmadd213ps, vfnmadd213ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfnmadd213ps_yhik7yhiyhi, vfnmadd213ps, vfnmadd213ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfnmadd213ps_zhik7zhizhi, vfnmadd213ps, vfnmadd213ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfnmadd213ps_xlok0xlom, vfnmadd213ps, vfnmadd213ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfnmadd213ps_ylok0ylom, vfnmadd213ps, vfnmadd213ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfnmadd213ps_zlok0zlom, vfnmadd213ps, vfnmadd213ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfnmadd213ps_xhik0xhim, vfnmadd213ps, vfnmadd213ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfnmadd213ps_yhik0yhim, vfnmadd213ps, vfnmadd213ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfnmadd213ps_zhik0zhim, vfnmadd213ps, vfnmadd213ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfnmadd213pd_xlok0xloxlo, vfnmadd213pd, vfnmadd213pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfnmadd213pd_ylok0yloylo, vfnmadd213pd, vfnmadd213pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfnmadd213pd_zlok0zlozlo, vfnmadd213pd, vfnmadd213pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfnmadd213pd_xhik7xhixhi, vfnmadd213pd, vfnmadd213pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfnmadd213pd_yhik7yhiyhi, vfnmadd213pd, vfnmadd213pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfnmadd213pd_zhik7zhizhi, vfnmadd213pd, vfnmadd213pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfnmadd213pd_xlok0xlom, vfnmadd213pd, vfnmadd213pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfnmadd213pd_ylok0ylom, vfnmadd213pd, vfnmadd213pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfnmadd213pd_zlok0zlom, vfnmadd213pd, vfnmadd213pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfnmadd213pd_xhik0xhim, vfnmadd213pd, vfnmadd213pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfnmadd213pd_yhik0yhim, vfnmadd213pd, vfnmadd213pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfnmadd213pd_zhik0zhim, vfnmadd213pd, vfnmadd213pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfnmadd231ps_xlok0xloxlo, vfnmadd231ps, vfnmadd231ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfnmadd231ps_ylok0yloylo, vfnmadd231ps, vfnmadd231ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfnmadd231ps_zlok0zlozlo, vfnmadd231ps, vfnmadd231ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfnmadd231ps_xhik7xhixhi, vfnmadd231ps, vfnmadd231ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfnmadd231ps_yhik7yhiyhi, vfnmadd231ps, vfnmadd231ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfnmadd231ps_zhik7zhizhi, vfnmadd231ps, vfnmadd231ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfnmadd231ps_xlok0xlom, vfnmadd231ps, vfnmadd231ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfnmadd231ps_ylok0ylom, vfnmadd231ps, vfnmadd231ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfnmadd231ps_zlok0zlom, vfnmadd231ps, vfnmadd231ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfnmadd231ps_xhik0xhim, vfnmadd231ps, vfnmadd231ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfnmadd231ps_yhik0yhim, vfnmadd231ps, vfnmadd231ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfnmadd231ps_zhik0zhim, vfnmadd231ps, vfnmadd231ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfnmadd231pd_xlok0xloxlo, vfnmadd231pd, vfnmadd231pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfnmadd231pd_ylok0yloylo, vfnmadd231pd, vfnmadd231pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfnmadd231pd_zlok0zlozlo, vfnmadd231pd, vfnmadd231pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfnmadd231pd_xhik7xhixhi, vfnmadd231pd, vfnmadd231pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfnmadd231pd_yhik7yhiyhi, vfnmadd231pd, vfnmadd231pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfnmadd231pd_zhik7zhizhi, vfnmadd231pd, vfnmadd231pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfnmadd231pd_xlok0xlom, vfnmadd231pd, vfnmadd231pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfnmadd231pd_ylok0ylom, vfnmadd231pd, vfnmadd231pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfnmadd231pd_zlok0zlom, vfnmadd231pd, vfnmadd231pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfnmadd231pd_xhik0xhim, vfnmadd231pd, vfnmadd231pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfnmadd231pd_yhik0yhim, vfnmadd231pd, vfnmadd231pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfnmadd231pd_zhik0zhim, vfnmadd231pd, vfnmadd231pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfnmadd132ss_xlok0xloxlo, vfnmadd132ss, vfnmadd132ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfnmadd132ss_xhik7xhixhi, vfnmadd132ss, vfnmadd132ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_4),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfnmadd132ss_xlok0xlom, vfnmadd132ss, vfnmadd132ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfnmadd132ss_xhik0xhim, vfnmadd132ss, vfnmadd132ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfnmadd132sd_xlok0xloxlo, vfnmadd132sd, vfnmadd132sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfnmadd132sd_xhik7xhixhi, vfnmadd132sd, vfnmadd132sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfnmadd132sd_xlok0xlom, vfnmadd132sd, vfnmadd132sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfnmadd132sd_xhik0xhim, vfnmadd132sd, vfnmadd132sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfnmadd213ss_xlok0xloxlo, vfnmadd213ss, vfnmadd213ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfnmadd213ss_xhik7xhixhi, vfnmadd213ss, vfnmadd213ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_4),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfnmadd213ss_xlok0xlom, vfnmadd213ss, vfnmadd213ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfnmadd213ss_xhik0xhim, vfnmadd213ss, vfnmadd213ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfnmadd213sd_xlok0xloxlo, vfnmadd213sd, vfnmadd213sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfnmadd213sd_xhik7xhixhi, vfnmadd213sd, vfnmadd213sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfnmadd213sd_xlok0xlom, vfnmadd213sd, vfnmadd213sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfnmadd213sd_xhik0xhim, vfnmadd213sd, vfnmadd213sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfnmadd231ss_xlok0xloxlo, vfnmadd231ss, vfnmadd231ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfnmadd231ss_xhik7xhixhi, vfnmadd231ss, vfnmadd231ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_4),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfnmadd231ss_xlok0xlom, vfnmadd231ss, vfnmadd231ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfnmadd231ss_xhik0xhim, vfnmadd231ss, vfnmadd231ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfnmadd231sd_xlok0xloxlo, vfnmadd231sd, vfnmadd231sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfnmadd231sd_xhik7xhixhi, vfnmadd231sd, vfnmadd231sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfnmadd231sd_xlok0xlom, vfnmadd231sd, vfnmadd231sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfnmadd231sd_xhik0xhim, vfnmadd231sd, vfnmadd231sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfnmsub132ps_xlok0xloxlo, vfnmsub132ps, vfnmsub132ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfnmsub132ps_ylok0yloylo, vfnmsub132ps, vfnmsub132ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfnmsub132ps_zlok0zlozlo, vfnmsub132ps, vfnmsub132ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfnmsub132ps_xhik7xhixhi, vfnmsub132ps, vfnmsub132ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfnmsub132ps_yhik7yhiyhi, vfnmsub132ps, vfnmsub132ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfnmsub132ps_zhik7zhizhi, vfnmsub132ps, vfnmsub132ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfnmsub132ps_xlok0xlom, vfnmsub132ps, vfnmsub132ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfnmsub132ps_ylok0ylom, vfnmsub132ps, vfnmsub132ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfnmsub132ps_zlok0zlom, vfnmsub132ps, vfnmsub132ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfnmsub132ps_xhik0xhim, vfnmsub132ps, vfnmsub132ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfnmsub132ps_yhik0yhim, vfnmsub132ps, vfnmsub132ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfnmsub213ps_xlok0xloxlo, vfnmsub213ps, vfnmsub213ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfnmsub213ps_ylok0yloylo, vfnmsub213ps, vfnmsub213ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfnmsub213ps_zlok0zlozlo, vfnmsub213ps, vfnmsub213ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfnmsub213ps_xhik7xhixhi, vfnmsub213ps, vfnmsub213ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfnmsub213ps_yhik7yhiyhi, vfnmsub213ps, vfnmsub213ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfnmsub213ps_zhik7zhizhi, vfnmsub213ps, vfnmsub213ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfnmsub213ps_xlok0xlom, vfnmsub213ps, vfnmsub213ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfnmsub213ps_ylok0ylom, vfnmsub213ps, vfnmsub213ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfnmsub213ps_zlok0zlom, vfnmsub213ps, vfnmsub213ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfnmsub213ps_xhik0xhim, vfnmsub213ps, vfnmsub213ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfnmsub213ps_yhik0yhim, vfnmsub213ps, vfnmsub213ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfnmsub231ps_xlok0xloxlo, vfnmsub231ps, vfnmsub231ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfnmsub231ps_ylok0yloylo, vfnmsub231ps, vfnmsub231ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfnmsub231ps_zlok0zlozlo, vfnmsub231ps, vfnmsub231ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfnmsub231ps_xhik7xhixhi, vfnmsub231ps, vfnmsub231ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfnmsub231ps_yhik7yhiyhi, vfnmsub231ps, vfnmsub231ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfnmsub231ps_zhik7zhizhi, vfnmsub231ps, vfnmsub231ps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfnmsub231ps_xlok0xlom, vfnmsub231ps, vfnmsub231ps_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfnmsub231ps_ylok0ylom, vfnmsub231ps, vfnmsub231ps_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfnmsub231ps_zlok0zlom, vfnmsub231ps, vfnmsub231ps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfnmsub231ps_xhik0xhim, vfnmsub231ps, vfnmsub231ps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfnmsub231ps_yhik0yhim, vfnmsub231ps, vfnmsub231ps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfnmsub132pd_xlok0xloxlo, vfnmsub132pd, vfnmsub132pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfnmsub132pd_ylok0yloylo, vfnmsub132pd, vfnmsub132pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfnmsub132pd_zlok0zlozlo, vfnmsub132pd, vfnmsub132pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfnmsub132pd_xhik7xhixhi, vfnmsub132pd, vfnmsub132pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfnmsub132pd_yhik7yhiyhi, vfnmsub132pd, vfnmsub132pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfnmsub132pd_zhik7zhizhi, vfnmsub132pd, vfnmsub132pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfnmsub132pd_xlok0xlom, vfnmsub132pd, vfnmsub132pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfnmsub132pd_ylok0ylom, vfnmsub132pd, vfnmsub132pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfnmsub132pd_zlok0zlom, vfnmsub132pd, vfnmsub132pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfnmsub132pd_xhik0xhim, vfnmsub132pd, vfnmsub132pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfnmsub132pd_yhik0yhim, vfnmsub132pd, vfnmsub132pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfnmsub213pd_xlok0xloxlo, vfnmsub213pd, vfnmsub213pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfnmsub213pd_ylok0yloylo, vfnmsub213pd, vfnmsub213pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfnmsub213pd_zlok0zlozlo, vfnmsub213pd, vfnmsub213pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfnmsub213pd_xhik7xhixhi, vfnmsub213pd, vfnmsub213pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfnmsub213pd_yhik7yhiyhi, vfnmsub213pd, vfnmsub213pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfnmsub213pd_zhik7zhizhi, vfnmsub213pd, vfnmsub213pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfnmsub213pd_xlok0xlom, vfnmsub213pd, vfnmsub213pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfnmsub213pd_ylok0ylom, vfnmsub213pd, vfnmsub213pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfnmsub213pd_zlok0zlom, vfnmsub213pd, vfnmsub213pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfnmsub213pd_xhik0xhim, vfnmsub213pd, vfnmsub213pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfnmsub213pd_yhik0yhim, vfnmsub213pd, vfnmsub213pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfnmsub231pd_xlok0xloxlo, vfnmsub231pd, vfnmsub231pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfnmsub231pd_ylok0yloylo, vfnmsub231pd, vfnmsub231pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfnmsub231pd_zlok0zlozlo, vfnmsub231pd, vfnmsub231pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfnmsub231pd_xhik7xhixhi, vfnmsub231pd, vfnmsub231pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfnmsub231pd_yhik7yhiyhi, vfnmsub231pd, vfnmsub231pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfnmsub231pd_zhik7zhizhi, vfnmsub231pd, vfnmsub231pd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfnmsub231pd_xlok0xlom, vfnmsub231pd, vfnmsub231pd_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfnmsub231pd_ylok0ylom, vfnmsub231pd, vfnmsub231pd_mask, 0, REGARG(YMM0),
+       REGARG(K0), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfnmsub231pd_zlok0zlom, vfnmsub231pd, vfnmsub231pd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfnmsub231pd_xhik0xhim, vfnmsub231pd, vfnmsub231pd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfnmsub231pd_yhik0yhim, vfnmsub231pd, vfnmsub231pd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfnmsub132ss_xlok0xloxlo, vfnmsub132ss, vfnmsub132ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfnmsub132ss_xhik7xhixhi, vfnmsub132ss, vfnmsub132ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_4),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfnmsub132ss_xlok0xlom, vfnmsub132ss, vfnmsub132ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfnmsub132ss_xhik0xhim, vfnmsub132ss, vfnmsub132ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfnmsub132sd_xlok0xloxlo, vfnmsub132sd, vfnmsub132sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfnmsub132sd_xhik7xhixhi, vfnmsub132sd, vfnmsub132sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfnmsub132sd_xlok0xlom, vfnmsub132sd, vfnmsub132sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfnmsub132sd_xhik0xhim, vfnmsub132sd, vfnmsub132sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfnmsub213ss_xlok0xloxlo, vfnmsub213ss, vfnmsub213ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfnmsub213ss_xhik7xhixhi, vfnmsub213ss, vfnmsub213ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_4),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfnmsub213ss_xlok0xlom, vfnmsub213ss, vfnmsub213ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfnmsub213ss_xhik0xhim, vfnmsub213ss, vfnmsub213ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfnmsub213sd_xlok0xloxlo, vfnmsub213sd, vfnmsub213sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfnmsub213sd_xhik7xhixhi, vfnmsub213sd, vfnmsub213sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfnmsub213sd_xlok0xlom, vfnmsub213sd, vfnmsub213sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfnmsub213sd_xhik0xhim, vfnmsub213sd, vfnmsub213sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfnmsub231ss_xlok0xloxlo, vfnmsub231ss, vfnmsub231ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfnmsub231ss_xhik7xhixhi, vfnmsub231ss, vfnmsub231ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_4),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfnmsub231ss_xlok0xlom, vfnmsub231ss, vfnmsub231ss_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_4), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfnmsub231ss_xhik0xhim, vfnmsub231ss, vfnmsub231ss_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_4), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4),
+       MEMARG(OPSZ_4))
+OPCODE(vfnmsub231sd_xlok0xloxlo, vfnmsub231sd, vfnmsub231sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfnmsub231sd_xhik7xhixhi, vfnmsub231sd, vfnmsub231sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfnmsub231sd_xlok0xlom, vfnmsub231sd, vfnmsub231sd_mask, 0,
+       REGARG_PARTIAL(XMM0, OPSZ_8), REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8))
+OPCODE(vfnmsub231sd_xhik0xhim, vfnmsub231sd, vfnmsub231sd_mask, X64_ONLY,
+       REGARG_PARTIAL(XMM16, OPSZ_8), REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8),
+       MEMARG(OPSZ_8))
 /* TODO i#1312: Add missing instructions. */


### PR DESCRIPTION
Adds the evex-promoted opcodes vfmadd132ps, vfmadd132pd, vfmadd213ps, vfmadd213pd,
vfmadd231ps, vfmadd231pd, vfmadd132ss, vfmadd132sd, vfmadd213ss, vfmadd213sd, vfmadd231ss,
vfmadd231sd, vfmaddsub132ps, vfmaddsub132pd, vfmaddsub213ps, vfmaddsub213pd,
vfmaddsub231ps, vfmaddsub231pd, vfmsubadd132ps, vfmsubadd132pd, vfmsubadd213ps,
vfmsubadd213pd, vfmsubadd231ps, vfmsubadd231pd, vfmsub132ps, vfmsub132pd, vfmsub213ps,
vfmsub213pd, vfmsub231ps, vfmsub231pd, vfmsub132ss, vfmsub132sd, vfmsub213ss, vfmsub213sd,
vfmsub231ss, vfmsub231sd, vfnmadd132ps, vfnmadd132pd, vfnmadd213ps, vfnmadd213pd,
vfnmadd231ps, vfnmadd231pd, vfnmadd132ss, vfnmadd132sd, vfnmadd213ss, vfnmadd213sd,
vfnmadd231ss, vfnmadd231sd, vfnmsub132ps, vfnmsub132pd, vfnmsub213ps, vfnmsub213pd,
vfnmsub231ps, vfnmsub231pd, vfnmsub132ss, vfnmsub132sd, vfnmsub213ss, vfnmsub213sd,
vfnmsub231ss, vfnmsub231sd.

Adds api.ir tests for above.

Fixes *s and *d operand types of existing VEX FMA instructions.

Issue: #1312