### PR TITLE
i#3556 w^x: Handle fork races

### DIFF
--- a/core/heap.h
+++ b/core/heap.h
@@ -127,6 +127,10 @@ void
 vmm_heap_exit(void);
 #ifdef UNIX
 void
+vmm_heap_fork_pre(dcontext_t *dcontext);
+void
+vmm_heap_fork_post(dcontext_t *dcontext, bool parent);
+void
 vmm_heap_fork_init(dcontext_t *dcontext);
 #endif
 void

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -2413,6 +2413,8 @@ os_fork_pre(dcontext_t *dcontext)
         ASSERT_CURIOSITY(false);
     }
 
+    vmm_heap_fork_pre(dcontext);
+
     /* We go back to the code cache to execute the syscall, so we can't hold
      * locks.  If the synch succeeded, no one else is running, so it should be
      * safe to release these locks.  However, if there are any rogue threads,
@@ -2442,6 +2444,7 @@ os_fork_post(dcontext_t *dcontext, bool parent)
                                parent /*resume in parent, not in child*/);
     ostd->fork_threads = NULL; /* Freed by end_synch_with_all_threads. */
     ostd->fork_num_threads = 0;
+    vmm_heap_fork_post(dcontext, parent);
 }
 
 /* this one is called before child's new logfiles are set up */

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -2134,7 +2134,8 @@ static void
 vmvector_free_vector(dcontext_t *dcontext, vm_area_vector_t *v)
 {
     vmvector_reset_vector(dcontext, v);
-    DELETE_READWRITE_LOCK(v->lock);
+    if (!TEST(VECTOR_NO_LOCK, v->flags))
+        DELETE_READWRITE_LOCK(v->lock);
 }
 
 /* frees the vm_area_vector_t v and its associated memory */

--- a/core/vmareas.h
+++ b/core/vmareas.h
@@ -116,10 +116,11 @@ struct vm_area_vector_t {
 /* vm_area_vectors should NOT be declared statically if their locks need to be
  * accessed on a regular basis.  Instead, allocate them on the heap with this macro:
  */
-#define VMVECTOR_ALLOC_VECTOR(v, dc, flags, lockname)         \
-    do {                                                      \
-        v = vmvector_create_vector((dc), (flags));            \
-        ASSIGN_INIT_READWRITE_LOCK_FREE((v)->lock, lockname); \
+#define VMVECTOR_ALLOC_VECTOR(v, dc, flags, lockname)             \
+    do {                                                          \
+        v = vmvector_create_vector((dc), (flags));                \
+        if (!TEST(VECTOR_NO_LOCK, (flags)))                       \
+            ASSIGN_INIT_READWRITE_LOCK_FREE((v)->lock, lockname); \
     } while (0);
 
 /* iterator over a vm_area_vector_t */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -108,7 +108,7 @@ set(vmap_run_list
   "SHORT::X86::ONLY::client.events$::-code_api -thread_private -disable_traces"
   "SHORT::X86::LIN::ONLY::client.events$::-code_api -no_early_inject" # only early on ARM
   # XXX i#3556: NYI on Windows, Mac, and non-x86 (and not supported on 32-bit).
-  "SHORT::X86::X64::LIN::ONLY::drcache.*\\.simple$|selfmod2|racesys|reachability::-code_api -satisfy_w_xor_x"
+  "SHORT::X86::X64::LIN::ONLY::drcache.*\\.simple$|selfmod2|racesys|reachability|fork$::-code_api -satisfy_w_xor_x"
   # maybe this should be SHORT as -coarse_units will eventually be the default?
   "X86::-code_api -opt_memory"       # i#1575: ARM -coarse_units NYI
   "X86::-code_api -opt_speed"        # i#1551: ARM indcall2direct NYI
@@ -1524,7 +1524,6 @@ function(set_properties name test myprefix)
     # CTest seems ok with a dep on a non-existent test.
     foreach (prefix ${prior_prefixes})
       if (NOT "${prefix}" STREQUAL "${myprefix}")
-        message("For ${name} |${myprefix}|, not equal: |${prefix}|,|${myprefix}|")
         set_property(TEST ${name} APPEND PROPERTY DEPENDS "${prefix}${test}")
       endif ()
     endforeach ()


### PR DESCRIPTION
Changes how fork is handled to avoid races.  Now the parent makes an
anonymous private temporary copy of vmcode pre-fork, freeing it
post-fork.  The child sets up its new mappings from the temporary
copy, avoiding any issues with copying the parent's live data.

Adds a sanity fork regression test.

Issue: #3556