### PR TITLE
i#3317: Generalize tool.drcacheoff.legacy template

### DIFF
--- a/clients/drcachesim/tests/offline-legacy.templatex
+++ b/clients/drcachesim/tests/offline-legacy.templatex
@@ -1,38 +1,38 @@
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Hits:                           61,531
+    Hits:                         *61,?531
     Misses:                            731
     Invalidations:                       0
-    Miss rate:                        1.17%
+    Miss rate:                        1[,\.]?17%
   L1D stats:
-    Hits:                           21,155
+    Hits:                         *21,?155
     Misses:                            808
     Invalidations:                       0
     Prefetch hits:                     182
     Prefetch misses:                   626
-    Miss rate:                        3.68%
+    Miss rate:                        3[,\.]?68%
 Core #1 \(4 thread\(s\)\)
   L1I stats:
-    Hits:                           19,428
+    Hits:                         *19,?428
     Misses:                            130
     Invalidations:                       0
-    Miss rate:                        0.66%
+    Miss rate:                        0[,\.]?66%
   L1D stats:
-    Hits:                           20,477
+    Hits:                         *20,?477
     Misses:                            258
     Invalidations:                       0
     Prefetch hits:                      66
     Prefetch misses:                   192
-    Miss rate:                        1.24%
+    Miss rate:                        1[,\.]?24%
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
     Hits:                              385
-    Misses:                          1,542
+    Misses:                        *1,?542
     Invalidations:                       0
     Prefetch hits:                     143
     Prefetch misses:                   675
-    Local miss rate:                 80.02%
-    Child hits:                    122,839
-    Total miss rate:                  1.24%
+    Local miss rate:                 80[,\.]?02%
+    Child hits:                  *122,?839
+    Total miss rate:                  1[,\.]?24%


### PR DESCRIPTION
Generalizes the test output template for tool.drcacheoff.legacy to
make thousands commas optional and decimals or commas for tenths
separators, to de-flake the test.

Tested against the AArch64 output from
http://dynamorio.org/CDash/testDetails.php?test=593481&build=43279

Fixes #3317