### PR TITLE
i#1312 AVX-512 support: Adds vcmp* and vpcmp* opcodes.

### DIFF
--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1360,14 +1360,14 @@ const instr_info_t * const op_instr[] =
     /* OP_vextracti32x8 */  &evex_W_extensions[103][0],
     /* OP_vextracti64x2 */  &evex_W_extensions[102][1],
     /* OP_vextracti64x4 */  &evex_W_extensions[103][1],
-    /* OP_vinsertf32x4 */   &evex_W_extensions[104][0],
-    /* OP_vinsertf32x8 */   &evex_W_extensions[105][0],
-    /* OP_vinsertf64x2 */   &evex_W_extensions[104][1],
-    /* OP_vinsertf64x4 */   &evex_W_extensions[105][1],
-    /* OP_vinserti32x4 */   &evex_W_extensions[106][0],
-    /* OP_vinserti32x8 */   &evex_W_extensions[107][0],
-    /* OP_vinserti64x2 */   &evex_W_extensions[106][1],
-    /* OP_vinserti64x4 */   &evex_W_extensions[107][1],
+    /* OP_vinsertf32x4  */  &evex_W_extensions[104][0],
+    /* OP_vinsertf32x8  */  &evex_W_extensions[105][0],
+    /* OP_vinsertf64x2  */  &evex_W_extensions[104][1],
+    /* OP_vinsertf64x4  */  &evex_W_extensions[105][1],
+    /* OP_vinserti32x4  */  &evex_W_extensions[106][0],
+    /* OP_vinserti32x8  */  &evex_W_extensions[107][0],
+    /* OP_vinserti64x2  */  &evex_W_extensions[106][1],
+    /* OP_vinserti64x4  */  &evex_W_extensions[107][1],
     /* OP_vmovdqa32     */  &evex_W_extensions[8][0],
     /* OP_vmovdqa64     */  &evex_W_extensions[8][1],
     /* OP_vmovdqu16     */  &evex_W_extensions[10][1],
@@ -1378,6 +1378,14 @@ const instr_info_t * const op_instr[] =
     /* OP_vpandnd       */  &evex_W_extensions[42][0],
     /* OP_vpandnq       */  &evex_W_extensions[42][1],
     /* OP_vpandq        */  &evex_W_extensions[41][1],
+    /* OP_vpcmpb        */  &evex_W_extensions[109][0],
+    /* OP_vpcmpd        */  &evex_W_extensions[111][0],
+    /* OP_vpcmpq        */  &evex_W_extensions[111][1],
+    /* OP_vpcmpw        */  &evex_W_extensions[109][1],
+    /* OP_vpcmpub       */  &evex_W_extensions[108][0],
+    /* OP_vpcmpud       */  &evex_W_extensions[110][0],
+    /* OP_vpcmpuq       */  &evex_W_extensions[110][1],
+    /* OP_vpcmpuw       */  &evex_W_extensions[108][1],
     /* OP_vpermi2b      */  &evex_W_extensions[96][0],
     /* OP_vpermi2d      */  &evex_W_extensions[95][0],
     /* OP_vpermi2pd     */  &evex_W_extensions[94][1],
@@ -1534,6 +1542,7 @@ const instr_info_t * const op_instr[] =
 #define Lsd TYPE_L, OPSZ_8_of_16 /* immed is 1 byte but reg is xmm/ymm */
 
 /* AVX-512 additions */
+#define KP1b TYPE_K_REG, OPSZ_1b
 #define KPb TYPE_K_REG, OPSZ_1
 #define KPw TYPE_K_REG, OPSZ_2
 #define KPd TYPE_K_REG, OPSZ_4
@@ -3421,12 +3430,11 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID,    0xf20f6410, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,      0x0f6410, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,    0xf30f6410, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    {OP_vpcmpgtb, 0x660f6410, "vpcmpgtb", Vx, xx, Hx, Wx, xx, mrm|vex, x, END_LIST},
+    {OP_vpcmpgtb, 0x660f6410, "vpcmpgtb", Vx, xx, Hx, Wx, xx, mrm|vex, x, tpe[36][10]},
     {INVALID,    0xf20f6410, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    /* TODO i#1312: Support AVX-512. */
     {INVALID,   0x0f6410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf30f6410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f6410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_vpcmpgtb, 0x660f6410, "vpcmpgtb", KPq, xx, KEq, He, We, mrm|evex, x, END_LIST},
     {INVALID, 0xf20f6410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 37 */
@@ -3437,12 +3445,11 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID,    0xf20f6510, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,      0x0f6510, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,    0xf30f6510, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    {OP_vpcmpgtw, 0x660f6510, "vpcmpgtw", Vx, xx, Hx, Wx, xx, mrm|vex, x, END_LIST},
+    {OP_vpcmpgtw, 0x660f6510, "vpcmpgtw", Vx, xx, Hx, Wx, xx, mrm|vex, x, tpe[37][10]},
     {INVALID,    0xf20f6510, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    /* TODO i#1312: Support AVX-512. */
     {INVALID,   0x0f6510, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf30f6510, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f6510, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_vpcmpgtw, 0x660f6510, "vpcmpgtw", KPd, xx, KEd, He, We, mrm|evex, x, END_LIST},
     {INVALID, 0xf20f6510, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 38 */
@@ -3453,12 +3460,11 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID,    0xf20f6610, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,      0x0f6610, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,    0xf30f6610, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    {OP_vpcmpgtd, 0x660f6610, "vpcmpgtd", Vx, xx, Hx, Wx, xx, mrm|vex, x, END_LIST},
+    {OP_vpcmpgtd, 0x660f6610, "vpcmpgtd", Vx, xx, Hx, Wx, xx, mrm|vex, x, tpe[38][10]},
     {INVALID,    0xf20f6610, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    /* TODO i#1312: Support AVX-512. */
     {INVALID,   0x0f6610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf30f6610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f6610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_vpcmpgtd, 0x660f6610, "vpcmpgtd", KPb, xx, KEb, He, We, mrm|evex, x, END_LIST},
     {INVALID, 0xf20f6610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 39 */
@@ -3607,12 +3613,11 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID,    0xf20f7410, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,      0x0f7410, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,    0xf30f7410, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    {OP_vpcmpeqb, 0x660f7410, "vpcmpeqb", Vx, xx, Hx, Wx, xx, mrm|vex, x, END_LIST},
+    {OP_vpcmpeqb, 0x660f7410, "vpcmpeqb", Vx, xx, Hx, Wx, xx, mrm|vex, x, tpe[48][10]},
     {INVALID,    0xf20f7410, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    /* TODO i#1312: Support AVX-512. */
     {INVALID,   0x0f7410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf30f7410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f7410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_vpcmpeqb, 0x660f7410, "vpcmpeqb", KPq, xx, KEq, He, We, mrm|evex, x, END_LIST},
     {INVALID, 0xf20f7410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 49 */
@@ -3623,12 +3628,11 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID,    0xf20f7510, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,      0x0f7510, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,    0xf30f7510, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    {OP_vpcmpeqw, 0x660f7510, "vpcmpeqw", Vx, xx, Hx, Wx, xx, mrm|vex, x, END_LIST},
+    {OP_vpcmpeqw, 0x660f7510, "vpcmpeqw", Vx, xx, Hx, Wx, xx, mrm|vex, x, tpe[49][10]},
     {INVALID,    0xf20f7510, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    /* TODO i#1312: Support AVX-512. */
     {INVALID,   0x0f7510, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf30f7510, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f7510, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_vpcmpeqw, 0x660f7510, "vpcmpeqw", KPd, xx, KEd, He, We, mrm|evex, x, END_LIST},
     {INVALID, 0xf20f7510, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 50 */
@@ -3639,12 +3643,11 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID,    0xf20f7610, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,      0x0f7610, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,    0xf30f7610, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    {OP_vpcmpeqd, 0x660f7610, "vpcmpeqd", Vx, xx, Hx, Wx, xx, mrm|vex, x, END_LIST},
+    {OP_vpcmpeqd, 0x660f7610, "vpcmpeqd", Vx, xx, Hx, Wx, xx, mrm|vex, x, tpe[50][10]},
     {INVALID,    0xf20f7610, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
-    /* TODO i#1312: Support AVX-512. */
     {INVALID,   0x0f7610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf30f7610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660f7610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_vpcmpeqd, 0x660f7610, "vpcmpeqd", KPw, xx, KEw, He, We, mrm|evex, x, END_LIST},
     {INVALID, 0xf20f7610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   },
   /* prefix extension 51 */
@@ -3670,15 +3673,14 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_cmpss, 0xf30fc210, "cmpss", Vss, xx, Wss, Ib, Vss, mrm, x, END_LIST},
     {OP_cmppd, 0x660fc210, "cmppd", Vpd, xx, Wpd, Ib, Vpd, mrm, x, END_LIST},
     {OP_cmpsd, 0xf20fc210, "cmpsd", Vsd, xx, Wsd, Ib, Vsd, mrm, x, END_LIST},
-    {OP_vcmpps, 0x0fc210, "vcmpps", Vvs, xx, Hvs, Wvs, Ib, mrm|vex, x, END_LIST},
-    {OP_vcmpss, 0xf30fc210, "vcmpss", Vdq, xx, Hdq, Wss, Ib, mrm|vex, x, END_LIST},
-    {OP_vcmppd, 0x660fc210, "vcmppd", Vvd, xx, Hvd, Wvd, Ib, mrm|vex, x, END_LIST},
-    {OP_vcmpsd, 0xf20fc210, "vcmpsd", Vdq, xx, Hdq, Wsd, Ib, mrm|vex, x, END_LIST},
-    /* TODO i#1312: Support AVX-512. */
-    {INVALID,   0x0fc210, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf30fc210, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660fc210, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf20fc210, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_vcmpps, 0x0fc210, "vcmpps", Vvs, xx, Hvs, Wvs, Ib, mrm|vex, x, tpe[52][8]},
+    {OP_vcmpss, 0xf30fc210, "vcmpss", Vdq, xx, Hdq, Wss, Ib, mrm|vex, x, tpe[52][9]},
+    {OP_vcmppd, 0x660fc210, "vcmppd", Vvd, xx, Hvd, Wvd, Ib, mrm|vex, x, tpe[52][10]},
+    {OP_vcmpsd, 0xf20fc210, "vcmpsd", Vdq, xx, Hdq, Wsd, Ib, mrm|vex, x, tpe[52][11]},
+    {OP_vcmpps, 0x0fc210, "vcmpps", KPw, xx, KEw, Ib, Hes, xop|mrm|evex, x, exop[90]},
+    {OP_vcmpss, 0xf30fc210, "vcmpss", KP1b, xx, KE1b, Ib, Hdq, xop|mrm|evex, x, exop[91]},
+    {OP_vcmppd, 0x660fc210, "vcmppd", KPb, xx, KEb, Ib, Hed, xop|mrm|evex, x, exop[92]},
+    {OP_vcmpsd, 0xf20fc210, "vcmpsd", KP1b, xx, KE1b, Ib, Hdq, xop|mrm|evex, x, exop[93]},
   },
   /* prefix extension 53: all assumed to have Ib */
   { /* note that gnu tools print immed first: pinsrw $0x0,(%esp),%xmm0 */
@@ -5409,8 +5411,8 @@ const instr_info_t e_vex_extensions[][3] = {
     {OP_vpmuldq,  0x66382858, "vpmuldq",   Ve, xx, KEb,He,We, mrm|evex|reqp, x, END_LIST},
   }, { /* e_vex ext 11 */
     {OP_pcmpeqq,  0x66382918, "pcmpeqq",  Vdq, xx, Wdq,Vdq, xx, mrm|reqp, x, END_LIST},
-    {OP_vpcmpeqq, 0x66382918, "vpcmpeqq",  Vx, xx, Hx,Wx, xx, mrm|vex|reqp, x, END_LIST},
-    {INVALID, 0x66382918, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_vpcmpeqq, 0x66382918, "vpcmpeqq",  Vx, xx, Hx,Wx, xx, mrm|vex|reqp, x, tvex[11][2]},
+    {OP_vpcmpeqq, 0x66382918, "vpcmpeqq", KPb, xx, KEb, He, We, mrm|evex, x, END_LIST},
   }, { /* e_vex ext 12 */
     {OP_movntdqa,  0x66382a18, "movntdqa", Mdq, xx, Vdq, xx, xx, mrm|reqp, x, END_LIST},
     {OP_vmovntdqa, 0x66382a18, "vmovntdqa", Mx, xx, Vx, xx, xx, mrm|vex|reqp, x, tvex[12][2]},
@@ -5444,9 +5446,9 @@ const instr_info_t e_vex_extensions[][3] = {
     {OP_vpmovzxdq, 0x66383518, "vpmovzxdq", Vx, xx, Wx, xx, xx, mrm|vex|reqp, x, END_LIST},
     {INVALID, 0x66383518, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   }, { /* e_vex ext 20 */
-    {OP_pcmpgtq,  0x66383718, "pcmpgtq",  Vdq, xx, Wdq,Vdq, xx, mrm|reqp, x, END_LIST},
-    {OP_vpcmpgtq, 0x66383718, "vpcmpgtq",  Vx, xx, Hx,Wx, xx, mrm|vex|reqp, x, END_LIST},
-    {INVALID, 0x66383718, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_pcmpgtq,  0x66383718, "pcmpgtq",  Vdq, xx, Wdq, Vdq, xx, mrm|reqp, x, END_LIST},
+    {OP_vpcmpgtq, 0x66383718, "vpcmpgtq",  Vx, xx, Hx, Wx, xx, mrm|vex|reqp, x, tvex[20][2]},
+    {OP_vpcmpgtq, 0x66383758, "vpcmpgtq",  KPb, xx, KEb, He, We, mrm|evex|reqp, x, END_LIST},
   }, { /* e_vex ext 21 */
     {OP_pminsb,   0x66383818, "pminsb",   Vdq, xx, Wdq,Vdq, xx, mrm|reqp, x, END_LIST},
     {OP_vpminsb,  0x66383818, "vpminsb",   Vx, xx, Hx,Wx, xx, mrm|vex|reqp, x, END_LIST},
@@ -6414,9 +6416,9 @@ const instr_info_t third_byte_38[] = {
 const byte third_byte_3a_index[256] = {
   /* 0  1  2  3   4  5  6  7   8  9  A  B   C  D  E  F */
     59,60,61, 0, 28,29,30, 0,  6, 7, 8, 9, 10,11,12, 1,  /* 0 */
-     0, 0, 0, 0,  2, 3, 4, 5, 31,32,69,67,  0,33, 0, 0,  /* 1 */
+     0, 0, 0, 0,  2, 3, 4, 5, 31,32,69,67,  0,33,73,74,  /* 1 */
     13,14,15, 0,  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  /* 2 */
-    63,64,65,66,  0, 0, 0, 0, 57,58,70,68,  0, 0, 0, 0,  /* 3 */
+    63,64,65,66,  0, 0, 0, 0, 57,58,70,68,  0, 0,71,72,  /* 3 */
     16,17,18, 0, 23, 0,62, 0, 54,55,25,26, 27, 0, 0, 0,  /* 4 */
      0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 34,35,36,37,  /* 5 */
     19,20,21,22,  0, 0, 0, 0, 38,39,40,41, 42,43,44,45,  /* 6 */
@@ -6514,6 +6516,10 @@ const instr_info_t third_byte_3a[] = {
   {EVEX_W_EXT, 0x663a3b18, "(evex_W ext 103)", xx, xx, xx, xx, xx, mrm, x, 103},/*68*/
   {EVEX_W_EXT, 0x663a1a18, "(evex_W ext 105)", xx, xx, xx, xx, xx, mrm, x, 105},/*69*/
   {EVEX_W_EXT, 0x663a3a18, "(evex_W ext 107)", xx, xx, xx, xx, xx, mrm, x, 107},/*70*/
+  {EVEX_W_EXT, 0x663a3e18, "(evex_W ext 108)", xx, xx, xx, xx, xx, mrm, x, 108},/*71*/
+  {EVEX_W_EXT, 0x663a3f18, "(evex_W ext 109)", xx, xx, xx, xx, xx, mrm, x, 109},/*72*/
+  {EVEX_W_EXT, 0x663a1e18, "(evex_W ext 110)", xx, xx, xx, xx, xx, mrm, x, 110},/*73*/
+  {EVEX_W_EXT, 0x663a1f18, "(evex_W ext 111)", xx, xx, xx, xx, xx, mrm, x, 111},/*74*/
 };
 
 /****************************************************************************
@@ -7202,6 +7208,18 @@ const instr_info_t evex_W_extensions[][2] = {
   }, { /* evex_W_ext 107 */
     {OP_vinserti32x8, 0x663a3a18, "vinserti32x8", Voq, xx, KEw, Ib, Hdq_f, xop|mrm|evex|reqp, x, exop[80]},
     {OP_vinserti64x4, 0x663a3a58, "vinserti64x4", Voq, xx, KEb, Ib, Hdq_f, xop|mrm|evex|reqp, x, exop[81]},
+  }, { /* evex_W_ext 108 */
+    {OP_vpcmpub, 0x663a3e18, "vpcmpub", KPq, xx, KEq, Ib, He, xop|evex|mrm|reqp, x, exop[82]},
+    {OP_vpcmpuw, 0x663a3e58, "vpcmpuw", KPd, xx, KEd, Ib, He, xop|evex|mrm|reqp, x, exop[84]},
+  }, { /* evex_W_ext 109 */
+    {OP_vpcmpb, 0x663a3f18, "vpcmpb", KPq, xx, KEq, Ib, He, xop|evex|mrm|reqp, x, exop[83]},
+    {OP_vpcmpw, 0x663a3f58, "vpcmpw", KPd, xx, KEd, Ib, He, xop|evex|mrm|reqp, x, exop[85]},
+  }, { /* evex_W_ext 110 */
+    {OP_vpcmpud, 0x663a1e18, "vpcmpud", KPw, xx, KEw, Ib, He, xop|evex|mrm|reqp, x, exop[86]},
+    {OP_vpcmpuq, 0x663a1e58, "vpcmpuq", KPb, xx, KEb, Ib, He, xop|evex|mrm|reqp, x, exop[87]},
+  }, { /* evex_W_ext 111 */
+    {OP_vpcmpd, 0x663a1f18, "vpcmpd", KPw, xx, KEw, Ib, He, xop|evex|mrm|reqp, x, exop[88]},
+    {OP_vpcmpq, 0x663a1f58, "vpcmpq", KPb, xx, KEb, Ib, He, xop|evex|mrm|reqp, x, exop[89]},
   },
 };
 
@@ -8294,6 +8312,24 @@ const instr_info_t extra_operands[] =
     /* 80 */
     {OP_CONTD, 0x663a3a18, "vinserti32x8 cont'd", xx, xx, Wdq, xx, xx, mrm|evex, x, END_LIST},
     {OP_CONTD, 0x663a3a58, "vinserti64x4 cont'd", xx, xx, Wdq, xx, xx, mrm|evex, x, END_LIST},
+    /* 82 */
+    {OP_CONTD, 0x663a3e18, "vpcmpub cont'd", xx, xx, We, xx, xx, evex|mrm, x, END_LIST},
+    {OP_CONTD, 0x663a3f18, "vpcmpb cont'd", xx, xx, We, xx, xx, evex|mrm, x, END_LIST},
+    /* 84 */
+    {OP_CONTD, 0x663a3e18, "vpcmpuw cont'd", xx, xx, We, xx, xx, evex|mrm, x, END_LIST},
+    {OP_CONTD, 0x663a3f18, "vpcmpw cont'd", xx, xx, We, xx, xx, evex|mrm, x, END_LIST},
+    /* 86 */
+    {OP_CONTD, 0x663a1e18, "vpcmpud cont'd", xx, xx, We, xx, xx, evex|mrm, x, END_LIST},
+    {OP_CONTD, 0x663a1f18, "vpcmpd cont'd", xx, xx, We, xx, xx, evex|mrm, x, END_LIST},
+    /* 88 */
+    {OP_CONTD, 0x663a1e18, "vpcmpuq cont'd", xx, xx, We, xx, xx, evex|mrm, x, END_LIST},
+    {OP_CONTD, 0x663a1f18, "vpcmpq cont'd", xx, xx, We, xx, xx, evex|mrm, x, END_LIST},
+    /* 90 */
+    {OP_CONTD,   0x0fc210, "vcmpps cont'd", xx, xx, Wes, xx, xx, evex|mrm, x, END_LIST},
+    {OP_CONTD, 0xf30fc210, "vcmpss cont'd", xx, xx, Wss, xx, xx, evex|mrm, x, END_LIST},
+    /* 92 */
+    {OP_CONTD, 0x660fc210, "vcmppd cont'd", xx, xx, Wed, xx, xx, evex|mrm, x, END_LIST},
+    {OP_CONTD, 0xf20fc210, "vcmpsd cont'd", xx, xx, Wsd, xx, xx, evex|mrm, x, END_LIST},
 };
 
 /* clang-format on */

--- a/core/arch/x86/encode.c
+++ b/core/arch/x86/encode.c
@@ -967,10 +967,12 @@ reg_size_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, reg_
         }
         return true;
     }
-    if (optype == TYPE_K_REG || optype == TYPE_K_MODRM || optype == TYPE_K_MODRM_R ||
-        optype == TYPE_K_VEX) {
+    if (optype == TYPE_K_MODRM || optype == TYPE_K_MODRM_R || optype == TYPE_K_VEX) {
         return (opsize == OPSZ_1 || opsize == OPSZ_2 || opsize == OPSZ_4 ||
                 opsize == OPSZ_8);
+    } else if (optype == TYPE_K_REG) {
+        return (opsize == OPSZ_1b || opsize == OPSZ_1 || opsize == OPSZ_2 ||
+                opsize == OPSZ_4 || opsize == OPSZ_8);
     } else if (optype == TYPE_K_EVEX) {
         return (opsize == OPSZ_1b || opsize == OPSZ_2b || opsize == OPSZ_4b ||
                 opsize == OPSZ_1 || opsize == OPSZ_2 || opsize == OPSZ_4 ||

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -3256,6 +3256,22 @@
     instr_create_1dst_3src((dc), OP_vextracti32x8, (d), (k), (s1), (s2))
 #define INSTR_CREATE_vextracti64x4_mask(dc, d, k, s1, s2) \
     instr_create_1dst_3src((dc), OP_vextracti64x4, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vpcmpgtb_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vpcmpgtb, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vpcmpgtw_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vpcmpgtw, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vpcmpgtd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vpcmpgtd, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vpcmpgtq_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vpcmpgtq, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vpcmpeqb_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vpcmpeqb, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vpcmpeqw_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vpcmpeqw, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vpcmpeqd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vpcmpeqd, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vpcmpeqq_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vpcmpeqq, (d), (k), (s1), (s2))
 /* @} */ /* end doxygen group */
 
 /** @name 1 destination, 3 sources including one immediate */
@@ -3802,6 +3818,30 @@
     instr_create_1dst_4src((dc), OP_vinserti32x8, (d), (k), (i), (s1), (s2))
 #define INSTR_CREATE_vinserti64x4_mask(dc, d, k, i, s1, s2) \
     instr_create_1dst_4src((dc), OP_vinserti64x4, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vpcmpb_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vpcmpb, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vpcmpw_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vpcmpw, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vpcmpd_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vpcmpd, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vpcmpq_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vpcmpq, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vpcmpub_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vpcmpub, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vpcmpuw_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vpcmpuw, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vpcmpud_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vpcmpud, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vpcmpuq_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vpcmpuq, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vcmpps_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vcmpps, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vcmpss_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vcmpss, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vcmppd_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vcmppd, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vcmpsd_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vcmpsd, (d), (k), (i), (s1), (s2))
 /* @} */ /* end doxygen group */
 
 /** @name 1 destination, 3 sources where 2 are implicit */

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1374,24 +1374,32 @@ enum {
     /* 1205 */ OP_vpandnd,       /**< IA-32/AMD64 AVX-512 OP_vpandnd opcode. */
     /* 1206 */ OP_vpandnq,       /**< IA-32/AMD64 AVX-512 OP_vpandnq opcode. */
     /* 1207 */ OP_vpandq,        /**< IA-32/AMD64 AVX-512 OP_vpandq opcode. */
-    /* 1208 */ OP_vpermi2b,      /**< IA-32/AMD64 AVX-512 OP_vpermi2b opcode. */
-    /* 1209 */ OP_vpermi2d,      /**< IA-32/AMD64 AVX-512 OP_vpermi2d opcode. */
-    /* 1210 */ OP_vpermi2pd,     /**< IA-32/AMD64 AVX-512 OP_vpermi2pd opcode. */
-    /* 1211 */ OP_vpermi2ps,     /**< IA-32/AMD64 AVX-512 OP_vpermi2ps opcode. */
-    /* 1212 */ OP_vpermi2q,      /**< IA-32/AMD64 AVX-512 OP_vpermi2q opcode. */
-    /* 1213 */ OP_vpermi2w,      /**< IA-32/AMD64 AVX-512 OP_vpermi2w opcode. */
-    /* 1214 */ OP_vpermt2b,      /**< IA-32/AMD64 AVX-512 OP_vpermt2b opcode. */
-    /* 1215 */ OP_vpermt2d,      /**< IA-32/AMD64 AVX-512 OP_vpermt2d opcode. */
-    /* 1216 */ OP_vpermt2pd,     /**< IA-32/AMD64 AVX-512 OP_vpermt2pd opcode. */
-    /* 1217 */ OP_vpermt2ps,     /**< IA-32/AMD64 AVX-512 OP_vpermt2ps opcode. */
-    /* 1218 */ OP_vpermt2q,      /**< IA-32/AMD64 AVX-512 OP_vpermt2q opcode. */
-    /* 1219 */ OP_vpermt2w,      /**< IA-32/AMD64 AVX-512 OP_vpermt2w opcode. */
-    /* 1220 */ OP_vpermw,        /**< IA-32/AMD64 AVX-512 OP_vpermw opcode. */
-    /* 1221 */ OP_vpmullq,       /**< IA-32/AMD64 AVX-512 OP_vpmullq opcode. */
-    /* 1222 */ OP_vpord,         /**< IA-32/AMD64 AVX-512 OP_vpord opcode. */
-    /* 1223 */ OP_vporq,         /**< IA-32/AMD64 AVX-512 OP_vporq opcode. */
-    /* 1224 */ OP_vpxord,        /**< IA-32/AMD64 AVX-512 OP_vpxord opcode. */
-    /* 1225 */ OP_vpxorq,        /**< IA-32/AMD64 AVX-512 OP_vpxorq opcode. */
+    /* 1208 */ OP_vpcmpb,        /**< IA-32/AMD64 AVX-512 OP_vpcmpb opcode. */
+    /* 1209 */ OP_vpcmpd,        /**< IA-32/AMD64 AVX-512 OP_vpcmpd opcode. */
+    /* 1210 */ OP_vpcmpq,        /**< IA-32/AMD64 AVX-512 OP_vpcmpq opcode. */
+    /* 1211 */ OP_vpcmpw,        /**< IA-32/AMD64 AVX-512 OP_vpcmpw opcode. */
+    /* 1212 */ OP_vpcmpub,       /**< IA-32/AMD64 AVX-512 OP_vpcmpub opcode. */
+    /* 1213 */ OP_vpcmpud,       /**< IA-32/AMD64 AVX-512 OP_vpcmpud opcode. */
+    /* 1214 */ OP_vpcmpuq,       /**< IA-32/AMD64 AVX-512 OP_vpcmpuq opcode. */
+    /* 1215 */ OP_vpcmpuw,       /**< IA-32/AMD64 AVX-512 OP_vpcmpuw opcode. */
+    /* 1216 */ OP_vpermi2b,      /**< IA-32/AMD64 AVX-512 OP_vpermi2b opcode. */
+    /* 1217 */ OP_vpermi2d,      /**< IA-32/AMD64 AVX-512 OP_vpermi2d opcode. */
+    /* 1218 */ OP_vpermi2pd,     /**< IA-32/AMD64 AVX-512 OP_vpermi2pd opcode. */
+    /* 1219 */ OP_vpermi2ps,     /**< IA-32/AMD64 AVX-512 OP_vpermi2ps opcode. */
+    /* 1220 */ OP_vpermi2q,      /**< IA-32/AMD64 AVX-512 OP_vpermi2q opcode. */
+    /* 1221 */ OP_vpermi2w,      /**< IA-32/AMD64 AVX-512 OP_vpermi2w opcode. */
+    /* 1222 */ OP_vpermt2b,      /**< IA-32/AMD64 AVX-512 OP_vpermt2b opcode. */
+    /* 1223 */ OP_vpermt2d,      /**< IA-32/AMD64 AVX-512 OP_vpermt2d opcode. */
+    /* 1224 */ OP_vpermt2pd,     /**< IA-32/AMD64 AVX-512 OP_vpermt2pd opcode. */
+    /* 1225 */ OP_vpermt2ps,     /**< IA-32/AMD64 AVX-512 OP_vpermt2ps opcode. */
+    /* 1226 */ OP_vpermt2q,      /**< IA-32/AMD64 AVX-512 OP_vpermt2q opcode. */
+    /* 1227 */ OP_vpermt2w,      /**< IA-32/AMD64 AVX-512 OP_vpermt2w opcode. */
+    /* 1228 */ OP_vpermw,        /**< IA-32/AMD64 AVX-512 OP_vpermw opcode. */
+    /* 1229 */ OP_vpmullq,       /**< IA-32/AMD64 AVX-512 OP_vpmullq opcode. */
+    /* 1230 */ OP_vpord,         /**< IA-32/AMD64 AVX-512 OP_vpord opcode. */
+    /* 1231 */ OP_vporq,         /**< IA-32/AMD64 AVX-512 OP_vporq opcode. */
+    /* 1232 */ OP_vpxord,        /**< IA-32/AMD64 AVX-512 OP_vpxord opcode. */
+    /* 1233 */ OP_vpxorq,        /**< IA-32/AMD64 AVX-512 OP_vpxorq opcode. */
 
     OP_AFTER_LAST,
     OP_FIRST = OP_add,           /**< First real opcode. */

--- a/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
@@ -3109,3 +3109,195 @@ OPCODE(vextracti64x4_k0zloist, vextracti64x4, vextracti64x4_mask, 0, MEMARG(OPSZ
        REGARG(K0), IMMARG(OPSZ_1), REGARG_PARTIAL(ZMM1, OPSZ_32))
 OPCODE(vextracti64x4_k7zhiist, vextracti64x4, vextracti64x4_mask, X64_ONLY,
        MEMARG(OPSZ_32), REGARG(K7), IMMARG(OPSZ_1), REGARG_PARTIAL(ZMM31, OPSZ_32))
+OPCODE(vpcmpgtb_k0k0xloxlo, vpcmpgtb, vpcmpgtb_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpgtb_k1k7xhixhi, vpcmpgtb, vpcmpgtb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vpcmpgtb_k0k0xlold, vpcmpgtb, vpcmpgtb_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpgtb_k1k7xhild, vpcmpgtb, vpcmpgtb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), MEMARG(OPSZ_16))
+OPCODE(vpcmpgtb_k0k0yloylo, vpcmpgtb, vpcmpgtb_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpgtb_k1k7yhiyhi, vpcmpgtb, vpcmpgtb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vpcmpgtb_k0k0ylold, vpcmpgtb, vpcmpgtb_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpgtb_k1k7yhild, vpcmpgtb, vpcmpgtb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), MEMARG(OPSZ_32))
+OPCODE(vpcmpgtb_k0k0zlozlo, vpcmpgtb, vpcmpgtb_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpgtb_k1k7zhizhi, vpcmpgtb, vpcmpgtb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vpcmpgtb_k0k0zlold, vpcmpgtb, vpcmpgtb_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpgtb_k1k7zhild, vpcmpgtb, vpcmpgtb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), MEMARG(OPSZ_64))
+OPCODE(vpcmpgtw_k0k0xloxlo, vpcmpgtw, vpcmpgtw_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpgtw_k1k7xhixhi, vpcmpgtw, vpcmpgtw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vpcmpgtw_k0k0xlold, vpcmpgtw, vpcmpgtw_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpgtw_k1k7xhild, vpcmpgtw, vpcmpgtw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), MEMARG(OPSZ_16))
+OPCODE(vpcmpgtw_k0k0yloylo, vpcmpgtw, vpcmpgtw_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpgtw_k1k7yhiyhi, vpcmpgtw, vpcmpgtw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vpcmpgtw_k0k0ylold, vpcmpgtw, vpcmpgtw_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpgtw_k1k7yhild, vpcmpgtw, vpcmpgtw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), MEMARG(OPSZ_32))
+OPCODE(vpcmpgtw_k0k0zlozlo, vpcmpgtw, vpcmpgtw_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpgtw_k1k7zhizhi, vpcmpgtw, vpcmpgtw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vpcmpgtw_k0k0zlold, vpcmpgtw, vpcmpgtw_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpgtw_k1k7zhild, vpcmpgtw, vpcmpgtw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), MEMARG(OPSZ_64))
+OPCODE(vpcmpgtd_k0k0xloxlo, vpcmpgtd, vpcmpgtd_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpgtd_k1k7xhixhi, vpcmpgtd, vpcmpgtd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vpcmpgtd_k0k0xlold, vpcmpgtd, vpcmpgtd_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpgtd_k1k7xhild, vpcmpgtd, vpcmpgtd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), MEMARG(OPSZ_16))
+OPCODE(vpcmpgtd_k0k0yloylo, vpcmpgtd, vpcmpgtd_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpgtd_k1k7yhiyhi, vpcmpgtd, vpcmpgtd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vpcmpgtd_k0k0ylold, vpcmpgtd, vpcmpgtd_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpgtd_k1k7yhild, vpcmpgtd, vpcmpgtd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), MEMARG(OPSZ_32))
+OPCODE(vpcmpgtd_k0k0zlozlo, vpcmpgtd, vpcmpgtd_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpgtd_k1k7zhizhi, vpcmpgtd, vpcmpgtd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vpcmpgtd_k0k0zlold, vpcmpgtd, vpcmpgtd_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpgtd_k1k7zhild, vpcmpgtd, vpcmpgtd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), MEMARG(OPSZ_64))
+OPCODE(vpcmpgtq_k0k0xloxlo, vpcmpgtq, vpcmpgtq_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpgtq_k1k7xhixhi, vpcmpgtq, vpcmpgtq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vpcmpgtq_k0k0xlold, vpcmpgtq, vpcmpgtq_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpgtq_k1k7xhild, vpcmpgtq, vpcmpgtq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), MEMARG(OPSZ_16))
+OPCODE(vpcmpgtq_k0k0yloylo, vpcmpgtq, vpcmpgtq_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpgtq_k1k7yhiyhi, vpcmpgtq, vpcmpgtq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vpcmpgtq_k0k0ylold, vpcmpgtq, vpcmpgtq_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpgtq_k1k7yhild, vpcmpgtq, vpcmpgtq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), MEMARG(OPSZ_32))
+OPCODE(vpcmpgtq_k0k0zlozlo, vpcmpgtq, vpcmpgtq_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpgtq_k1k7zhizhi, vpcmpgtq, vpcmpgtq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vpcmpgtq_k0k0zlold, vpcmpgtq, vpcmpgtq_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpgtq_k1k7zhild, vpcmpgtq, vpcmpgtq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), MEMARG(OPSZ_64))
+OPCODE(vpcmpeqb_k0k0xloxlo, vpcmpeqb, vpcmpeqb_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpeqb_k1k7xhixhi, vpcmpeqb, vpcmpeqb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vpcmpeqb_k0k0xlold, vpcmpeqb, vpcmpeqb_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpeqb_k1k7xhild, vpcmpeqb, vpcmpeqb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), MEMARG(OPSZ_16))
+OPCODE(vpcmpeqb_k0k0yloylo, vpcmpeqb, vpcmpeqb_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpeqb_k1k7yhiyhi, vpcmpeqb, vpcmpeqb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vpcmpeqb_k0k0ylold, vpcmpeqb, vpcmpeqb_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpeqb_k1k7yhild, vpcmpeqb, vpcmpeqb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), MEMARG(OPSZ_32))
+OPCODE(vpcmpeqb_k0k0zlozlo, vpcmpeqb, vpcmpeqb_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpeqb_k1k7zhizhi, vpcmpeqb, vpcmpeqb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vpcmpeqb_k0k0zlold, vpcmpeqb, vpcmpeqb_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpeqb_k1k7zhild, vpcmpeqb, vpcmpeqb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), MEMARG(OPSZ_64))
+OPCODE(vpcmpeqw_k0k0xloxlo, vpcmpeqw, vpcmpeqw_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpeqw_k1k7xhixhi, vpcmpeqw, vpcmpeqw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vpcmpeqw_k0k0xlold, vpcmpeqw, vpcmpeqw_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpeqw_k1k7xhild, vpcmpeqw, vpcmpeqw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), MEMARG(OPSZ_16))
+OPCODE(vpcmpeqw_k0k0yloylo, vpcmpeqw, vpcmpeqw_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpeqw_k1k7yhiyhi, vpcmpeqw, vpcmpeqw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vpcmpeqw_k0k0ylold, vpcmpeqw, vpcmpeqw_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpeqw_k1k7yhild, vpcmpeqw, vpcmpeqw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), MEMARG(OPSZ_32))
+OPCODE(vpcmpeqw_k0k0zlozlo, vpcmpeqw, vpcmpeqw_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpeqw_k1k7zhizhi, vpcmpeqw, vpcmpeqw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vpcmpeqw_k0k0zlold, vpcmpeqw, vpcmpeqw_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpeqw_k1k7zhild, vpcmpeqw, vpcmpeqw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), MEMARG(OPSZ_64))
+OPCODE(vpcmpeqd_k0k0xloxlo, vpcmpeqd, vpcmpeqd_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpeqd_k1k7xhixhi, vpcmpeqd, vpcmpeqd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vpcmpeqd_k0k0xlold, vpcmpeqd, vpcmpeqd_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpeqd_k1k7xhild, vpcmpeqd, vpcmpeqd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), MEMARG(OPSZ_16))
+OPCODE(vpcmpeqd_k0k0yloylo, vpcmpeqd, vpcmpeqd_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpeqd_k1k7yhiyhi, vpcmpeqd, vpcmpeqd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vpcmpeqd_k0k0ylold, vpcmpeqd, vpcmpeqd_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpeqd_k1k7yhild, vpcmpeqd, vpcmpeqd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), MEMARG(OPSZ_32))
+OPCODE(vpcmpeqd_k0k0zlozlo, vpcmpeqd, vpcmpeqd_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpeqd_k1k7zhizhi, vpcmpeqd, vpcmpeqd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vpcmpeqd_k0k0zlold, vpcmpeqd, vpcmpeqd_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpeqd_k1k7zhild, vpcmpeqd, vpcmpeqd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), MEMARG(OPSZ_64))
+OPCODE(vpcmpeqq_k0k0xloxlo, vpcmpeqq, vpcmpeqq_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpeqq_k1k7xhixhi, vpcmpeqq, vpcmpeqq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vpcmpeqq_k0k0xlold, vpcmpeqq, vpcmpeqq_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpeqq_k1k7xhild, vpcmpeqq, vpcmpeqq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(XMM16), MEMARG(OPSZ_16))
+OPCODE(vpcmpeqq_k0k0yloylo, vpcmpeqq, vpcmpeqq_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpeqq_k1k7yhiyhi, vpcmpeqq, vpcmpeqq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vpcmpeqq_k0k0ylold, vpcmpeqq, vpcmpeqq_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpeqq_k1k7yhild, vpcmpeqq, vpcmpeqq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(YMM16), MEMARG(OPSZ_32))
+OPCODE(vpcmpeqq_k0k0zlozlo, vpcmpeqq, vpcmpeqq_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpeqq_k1k7zhizhi, vpcmpeqq, vpcmpeqq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vpcmpeqq_k0k0zlold, vpcmpeqq, vpcmpeqq_mask, 0, REGARG(K0), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpeqq_k1k7zhild, vpcmpeqq, vpcmpeqq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       REGARG(ZMM16), MEMARG(OPSZ_64))

--- a/suite/tests/api/ir_x86_5args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_5args_avx512_evex_mask.h
@@ -139,3 +139,259 @@ OPCODE(vinserti64x4_zhik7zhixhii, vinserti64x4, vinserti64x4_mask, X64_ONLY,
        REGARG(XMM31))
 OPCODE(vinserti64x4_zhik7zhildi, vinserti64x4, vinserti64x4_mask, X64_ONLY, REGARG(ZMM16),
        REGARG(K7), IMMARG(OPSZ_1), REGARG_PARTIAL(ZMM31, OPSZ_16), MEMARG(OPSZ_16))
+OPCODE(vpcmpb_k0k0xloxlo, vpcmpb, vpcmpb_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpb_k0k0xlold, vpcmpb, vpcmpb_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpb_k1k7xhixhi, vpcmpb, vpcmpb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpb_k1k7xhild, vpcmpb, vpcmpb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpb_k0k0yloylo, vpcmpb, vpcmpb_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpb_k0k0ylold, vpcmpb, vpcmpb_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpb_k1k7yhiyhi, vpcmpb, vpcmpb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpb_k1k7yhild, vpcmpb, vpcmpb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpb_k0k0zlozlo, vpcmpb, vpcmpb_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpb_k0k0zlold, vpcmpb, vpcmpb_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpb_k1k7zhizhi, vpcmpb, vpcmpb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpb_k1k7zhild, vpcmpb, vpcmpb_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpub_k0k0xloxlo, vpcmpub, vpcmpub_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpub_k0k0xlold, vpcmpub, vpcmpub_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpub_k1k7xhixhi, vpcmpub, vpcmpub_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpub_k1k7xhild, vpcmpub, vpcmpub_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpub_k0k0yloylo, vpcmpub, vpcmpub_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpub_k0k0ylold, vpcmpub, vpcmpub_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpub_k1k7yhiyhi, vpcmpub, vpcmpub_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpub_k1k7yhild, vpcmpub, vpcmpub_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpub_k0k0zlozlo, vpcmpub, vpcmpub_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpub_k0k0zlold, vpcmpub, vpcmpub_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpub_k1k7zhizhi, vpcmpub, vpcmpub_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpub_k1k7zhild, vpcmpub, vpcmpub_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpw_k0k0xloxlo, vpcmpw, vpcmpw_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpw_k0k0xlold, vpcmpw, vpcmpw_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpw_k1k7xhixhi, vpcmpw, vpcmpw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpw_k1k7xhild, vpcmpw, vpcmpw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpw_k0k0yloylo, vpcmpw, vpcmpw_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpw_k0k0ylold, vpcmpw, vpcmpw_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpw_k1k7yhiyhi, vpcmpw, vpcmpw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpw_k1k7yhild, vpcmpw, vpcmpw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpw_k0k0zlozlo, vpcmpw, vpcmpw_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpw_k0k0zlold, vpcmpw, vpcmpw_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpw_k1k7zhizhi, vpcmpw, vpcmpw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpw_k1k7zhild, vpcmpw, vpcmpw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpuw_k0k0xloxlo, vpcmpuw, vpcmpuw_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpuw_k0k0xlold, vpcmpuw, vpcmpuw_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpuw_k1k7xhixhi, vpcmpuw, vpcmpuw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpuw_k1k7xhild, vpcmpuw, vpcmpuw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpuw_k0k0yloylo, vpcmpuw, vpcmpuw_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpuw_k0k0ylold, vpcmpuw, vpcmpuw_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpuw_k1k7yhiyhi, vpcmpuw, vpcmpuw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpuw_k1k7yhild, vpcmpuw, vpcmpuw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpuw_k0k0zlozlo, vpcmpuw, vpcmpuw_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpuw_k0k0zlold, vpcmpuw, vpcmpuw_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpuw_k1k7zhizhi, vpcmpuw, vpcmpuw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpuw_k1k7zhild, vpcmpuw, vpcmpuw_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpd_k0k0xloxlo, vpcmpd, vpcmpd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpd_k0k0xlold, vpcmpd, vpcmpd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpd_k1k7xhixhi, vpcmpd, vpcmpd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpd_k1k7xhild, vpcmpd, vpcmpd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpd_k0k0yloylo, vpcmpd, vpcmpd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpd_k0k0ylold, vpcmpd, vpcmpd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpd_k1k7yhiyhi, vpcmpd, vpcmpd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpd_k1k7yhild, vpcmpd, vpcmpd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpd_k0k0zlozlo, vpcmpd, vpcmpd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpd_k0k0zlold, vpcmpd, vpcmpd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpd_k1k7zhizhi, vpcmpd, vpcmpd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpd_k1k7zhild, vpcmpd, vpcmpd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpud_k0k0xloxlo, vpcmpud, vpcmpud_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpud_k0k0xlold, vpcmpud, vpcmpud_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpud_k1k7xhixhi, vpcmpud, vpcmpud_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpud_k1k7xhild, vpcmpud, vpcmpud_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpud_k0k0yloylo, vpcmpud, vpcmpud_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpud_k0k0ylold, vpcmpud, vpcmpud_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpud_k1k7yhiyhi, vpcmpud, vpcmpud_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpud_k1k7yhild, vpcmpud, vpcmpud_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpud_k0k0zlozlo, vpcmpud, vpcmpud_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpud_k0k0zlold, vpcmpud, vpcmpud_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpud_k1k7zhizhi, vpcmpud, vpcmpud_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpud_k1k7zhild, vpcmpud, vpcmpud_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpq_k0k0xloxlo, vpcmpq, vpcmpq_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpq_k0k0xlold, vpcmpq, vpcmpq_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpq_k1k7xhixhi, vpcmpq, vpcmpq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpq_k1k7xhild, vpcmpq, vpcmpq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpq_k0k0yloylo, vpcmpq, vpcmpq_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpq_k0k0ylold, vpcmpq, vpcmpq_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpq_k1k7yhiyhi, vpcmpq, vpcmpq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpq_k1k7yhild, vpcmpq, vpcmpq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpq_k0k0zlozlo, vpcmpq, vpcmpq_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpq_k0k0zlold, vpcmpq, vpcmpq_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpq_k1k7zhizhi, vpcmpq, vpcmpq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpq_k1k7zhild, vpcmpq, vpcmpq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpuq_k0k0xloxlo, vpcmpuq, vpcmpuq_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpuq_k0k0xlold, vpcmpuq, vpcmpuq_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpuq_k1k7xhixhi, vpcmpuq, vpcmpuq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vpcmpuq_k1k7xhild, vpcmpuq, vpcmpuq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vpcmpuq_k0k0yloylo, vpcmpuq, vpcmpuq_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpuq_k0k0ylold, vpcmpuq, vpcmpuq_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpuq_k1k7yhiyhi, vpcmpuq, vpcmpuq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vpcmpuq_k1k7yhild, vpcmpuq, vpcmpuq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vpcmpuq_k0k0zlozlo, vpcmpuq, vpcmpuq_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpuq_k0k0zlold, vpcmpuq, vpcmpuq_mask, 0, REGARG(K0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vpcmpuq_k1k7zhizhi, vpcmpuq, vpcmpuq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vpcmpuq_k1k7zhild, vpcmpuq, vpcmpuq_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vcmpps_k0k0xloxlo, vcmpps, vcmpps_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vcmpps_k0k0xlold, vcmpps, vcmpps_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vcmpps_k1k7xhixhi, vcmpps, vcmpps_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vcmpps_k1k7xhild, vcmpps, vcmpps_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vcmpps_k0k0yloylo, vcmpps, vcmpps_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vcmpps_k0k0ylold, vcmpps, vcmpps_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vcmpps_k1k7yhiyhi, vcmpps, vcmpps_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vcmpps_k1k7yhild, vcmpps, vcmpps_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vcmpps_k0k0zlozlo, vcmpps, vcmpps_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vcmpps_k0k0zlold, vcmpps, vcmpps_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vcmpps_k1k7zhizhi, vcmpps, vcmpps_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vcmpps_k1k7zhild, vcmpps, vcmpps_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vcmpss_k0k0xloxlo, vcmpss, vcmpss_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_4))
+OPCODE(vcmpss_k0k0xlold, vcmpss, vcmpss_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), MEMARG(OPSZ_4))
+OPCODE(vcmpss_k1k7xhixhi, vcmpss, vcmpss_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_4))
+OPCODE(vcmpss_k1k7xhild, vcmpss, vcmpss_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_4))
+OPCODE(vcmppd_k0k0xloxlo, vcmppd, vcmppd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vcmppd_k0k0xlold, vcmppd, vcmppd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vcmppd_k1k7xhixhi, vcmppd, vcmppd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG(XMM1))
+OPCODE(vcmppd_k1k7xhild, vcmppd, vcmppd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vcmppd_k0k0yloylo, vcmppd, vcmppd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vcmppd_k0k0ylold, vcmppd, vcmppd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vcmppd_k1k7yhiyhi, vcmppd, vcmppd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), REGARG(YMM1))
+OPCODE(vcmppd_k1k7yhild, vcmppd, vcmppd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vcmppd_k0k0zlozlo, vcmppd, vcmppd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vcmppd_k0k0zlold, vcmppd, vcmppd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vcmppd_k1k7zhizhi, vcmppd, vcmppd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vcmppd_k1k7zhild, vcmppd, vcmppd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vcmpsd_k0k0xloxlo, vcmpsd, vcmpsd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_8))
+OPCODE(vcmpsd_k0k0xlold, vcmpsd, vcmpsd_mask, 0, REGARG(K0), REGARG(K0), IMMARG(OPSZ_1),
+       REGARG(XMM0), MEMARG(OPSZ_8))
+OPCODE(vcmpsd_k1k7xhixhi, vcmpsd, vcmpsd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_8))
+OPCODE(vcmpsd_k1k7xhild, vcmpsd, vcmpsd_mask, X64_ONLY, REGARG(K1), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM0), MEMARG(OPSZ_8))


### PR DESCRIPTION
Adds the evex-promoted opcodes vpcmpgtb, vpcmpgtw, vpcmpgtd, vpcmpgtq, vcmpps, vcmpss,
vcmppd, vcmpsd, vpcmpeqb, vpcmpeqw, vpcmpeqd, vpcmpeqq.

Adds the new AVX-512 opcodes vpcmpub, vpcmpb, vpcmpuw, vpcmpw, vpcmpud, vpcmpd, vpcmpuq,
vpcmpq.

Adds tests for above.

Opcodes have been checked against llvm-mc, binutils/gas/objdump and capstone.

Fixes a few minor white spaces in the decode table.

Issue: #1312