### PR TITLE
i#3674: Add stack alignment to test calling "vfprintf".

### DIFF
--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -198,8 +198,8 @@ ASSUME fs:_DATA @N@\
 #  define PUSH_SEH(reg) push reg @N@ .pushreg reg
 /* Push a volatile register or an immed in prolog: */
 #  define PUSH_NONCALLEE_SEH(reg) push reg @N@ .allocstack 8
-# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGMMENT - ARG_SZ @N@ .allocstack 16
-# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGMMENT - ARG_SZ @N@ .allocstack 16
+# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGMMENT - ARG_SZ @N@ .allocstack 8
+# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGMMENT - ARG_SZ @N@
 #  define END_PROLOG .endprolog
 # else
 #  define DECLARE_FUNC_SEH(symbol) DECLARE_FUNC(symbol)
@@ -403,6 +403,9 @@ ASSUME fs:_DATA @N@\
 #  define SAVE_PRESERVED_REGS    stp REG_PRESERVED_1, LR, [sp, #-16]!
 #  define RESTORE_PRESERVED_REGS ldp REG_PRESERVED_1, LR, [sp], #16
 # endif
+
+# define ADD_STACK_ALIGNMENT
+# define RESTORE_STACK_ALIGNMENT
 
 #else /* Intel X86 */
 # ifdef X64

--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -134,8 +134,8 @@
 # define DECLARE_FUNC_SEH(symbol) DECLARE_FUNC(symbol)
 # define PUSH_SEH(reg) push reg
 # define PUSH_NONCALLEE_SEH(reg) push reg
-# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGMMENT - ARG_SZ
-# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGMMENT - ARG_SZ
+# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGNMENT - ARG_SZ
+# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGNMENT - ARG_SZ
 # define END_PROLOG /* nothing */
 /* PR 212290: avoid text relocations.
  * @GOT returns the address and is for extern vars; @GOTOFF gets the value.
@@ -198,15 +198,15 @@ ASSUME fs:_DATA @N@\
 #  define PUSH_SEH(reg) push reg @N@ .pushreg reg
 /* Push a volatile register or an immed in prolog: */
 #  define PUSH_NONCALLEE_SEH(reg) push reg @N@ .allocstack 8
-# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGMMENT - ARG_SZ @N@ .allocstack 8
-# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGMMENT - ARG_SZ @N@
+# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGNMENT - ARG_SZ @N@ .allocstack 8
+# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGNMENT - ARG_SZ @N@
 #  define END_PROLOG .endprolog
 # else
 #  define DECLARE_FUNC_SEH(symbol) DECLARE_FUNC(symbol)
 #  define PUSH_SEH(reg) push reg @N@ /* add a line to match x64 line count */
 #  define PUSH_NONCALLEE_SEH(reg) push reg @N@ /* add a line to match x64 line count */
-# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGMMENT - ARG_SZ @N@
-# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGMMENT - ARG_SZ @N@
+# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGNMENT - ARG_SZ @N@
+# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGNMENT - ARG_SZ @N@
 #  define END_PROLOG /* nothing */
 # endif
 /****************************************************/
@@ -242,8 +242,8 @@ ASSUME fs:_DATA @N@\
 # define DECLARE_FUNC_SEH(symbol) DECLARE_FUNC(symbol)
 # define PUSH_SEH(reg) push reg
 # define PUSH_NONCALLEE_SEH(reg) push reg
-# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGMMENT - ARG_SZ
-# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGMMENT - ARG_SZ
+# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGNMENT - ARG_SZ
+# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGNMENT - ARG_SZ
 # define END_PROLOG /* nothing */
 /****************************************************/
 #else

--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -404,9 +404,6 @@ ASSUME fs:_DATA @N@\
 #  define RESTORE_PRESERVED_REGS ldp REG_PRESERVED_1, LR, [sp], #16
 # endif
 
-# define ADD_STACK_ALIGNMENT
-# define RESTORE_STACK_ALIGNMENT
-
 #else /* Intel X86 */
 # ifdef X64
 #  ifdef WINDOWS

--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -71,6 +71,13 @@
 
 #undef WEAK /* avoid conflict with C define */
 
+/* This is really the alignment needed by x64 code.  For now, when we bother to
+ * align the stack pointer, we just go for 16 byte alignment.  We do *not*
+ * assume 16-byte alignment across the code base.
+ * i#847: Investigate using aligned SSE ops (see get_xmm_caller_saved).
+ */
+#define FRAME_ALIGNMENT 16
+
 /****************************************************/
 #if defined(ASSEMBLE_WITH_GAS)
 # define START_FILE .text
@@ -534,9 +541,6 @@ ASSUME fs:_DATA @N@\
 #  endif /* WINDOWS/UNIX */
 # endif /* 64/32-bit */
 #endif /* ARM/X86 */
-
-/* Keep in sync with arch_exports.h. */
-#define FRAME_ALIGNMENT 16
 
 /* From globals_shared.h, but we can't include that into asm code. */
 #ifdef X64

--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -134,6 +134,8 @@
 # define DECLARE_FUNC_SEH(symbol) DECLARE_FUNC(symbol)
 # define PUSH_SEH(reg) push reg
 # define PUSH_NONCALLEE_SEH(reg) push reg
+# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGMMENT - ARG_SZ
+# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGMMENT - ARG_SZ
 # define END_PROLOG /* nothing */
 /* PR 212290: avoid text relocations.
  * @GOT returns the address and is for extern vars; @GOTOFF gets the value.
@@ -196,11 +198,15 @@ ASSUME fs:_DATA @N@\
 #  define PUSH_SEH(reg) push reg @N@ .pushreg reg
 /* Push a volatile register or an immed in prolog: */
 #  define PUSH_NONCALLEE_SEH(reg) push reg @N@ .allocstack 8
+# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGMMENT - ARG_SZ @N@ .allocstack 16
+# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGMMENT - ARG_SZ @N@ .allocstack 16
 #  define END_PROLOG .endprolog
 # else
 #  define DECLARE_FUNC_SEH(symbol) DECLARE_FUNC(symbol)
 #  define PUSH_SEH(reg) push reg @N@ /* add a line to match x64 line count */
 #  define PUSH_NONCALLEE_SEH(reg) push reg @N@ /* add a line to match x64 line count */
+# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGMMENT - ARG_SZ @N@
+# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGMMENT - ARG_SZ @N@
 #  define END_PROLOG /* nothing */
 # endif
 /****************************************************/
@@ -236,6 +242,8 @@ ASSUME fs:_DATA @N@\
 # define DECLARE_FUNC_SEH(symbol) DECLARE_FUNC(symbol)
 # define PUSH_SEH(reg) push reg
 # define PUSH_NONCALLEE_SEH(reg) push reg
+# define ADD_STACK_ALIGNMENT sub REG_XSP, FRAME_ALIGMMENT - ARG_SZ
+# define RESTORE_STACK_ALIGNMENT add REG_XSP, FRAME_ALIGMMENT - ARG_SZ
 # define END_PROLOG /* nothing */
 /****************************************************/
 #else

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -138,13 +138,6 @@ START_FILE
         POPF                                            @N@\
         lea      REG_XSP, [REG_XSP - PUSH_PRIV_MCXT_PRE_PC_SHIFT + ARG_SZ/*pc*/]
 
-/* This is really the alignment needed by x64 code.  For now, when we bother to
- * align the stack pointer, we just go for 16 byte alignment.  We do *not*
- * assume 16-byte alignment across the code base.
- * i#847: Investigate using aligned SSE ops (see get_xmm_caller_saved).
- */
-#define FRAME_ALIGNMENT 16
-
 /****************************************************************************/
 /****************************************************************************/
 

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -708,15 +708,15 @@ DECL_EXTERN(func_ptr)
 #define FUNCNAME test_rip_rel_ind
         DECLARE_FUNC_SEH(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
-        sub      REG_XSP, FRAME_ALIGNMENT - ARG_SZ  /* Maintain alignment. Some system's
-                                                     * libc may decide to callee-save xmm
-                                                     * registers which requires alignment.
-                                                     * (xref i#3674).
-                                                     */
+        ADD_STACK_ALIGMMENT  /* Maintain alignment. Some system's
+                              * libc may decide to callee-save xmm
+                              * registers which requires alignment.
+                              * (xref i#3674).
+                              */
         END_PROLOG
         CALL_SETJMP
         call     PTRSZ SYMREF(func_ptr)
-        add      REG_XSP, FRAME_ALIGNMENT - ARG_SZ
+        RESTORE_STACK_ALIGNMENT
         ret
         END_FUNC(FUNCNAME)
 

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -708,7 +708,7 @@ DECL_EXTERN(func_ptr)
 #define FUNCNAME test_rip_rel_ind
         DECLARE_FUNC_SEH(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
-        ADD_STACK_ALIGMMENT  /* Maintain alignment. Some system's
+        ADD_STACK_ALIGNMENT  /* Maintain alignment. Some system's
                               * libc may decide to callee-save xmm
                               * registers which requires alignment.
                               * (xref i#3674).

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -708,9 +708,15 @@ DECL_EXTERN(func_ptr)
 #define FUNCNAME test_rip_rel_ind
         DECLARE_FUNC_SEH(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
+        sub      REG_XSP, FRAME_ALIGNMENT - ARG_SZ  /* Maintain alignment. Some systemn's
+                                                    * libc may decide to callee-save xmm
+                                                    * registers which requires alignment.
+                                                    * (xref i#3674).
+                                                    */
         END_PROLOG
         CALL_SETJMP
         call     PTRSZ SYMREF(func_ptr)
+        add      REG_XSP, FRAME_ALIGNMENT - ARG_SZ
         ret
         END_FUNC(FUNCNAME)
 

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -708,7 +708,7 @@ DECL_EXTERN(func_ptr)
 #define FUNCNAME test_rip_rel_ind
         DECLARE_FUNC_SEH(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
-        sub      REG_XSP, FRAME_ALIGNMENT - ARG_SZ  /* Maintain alignment. Some systemn's
+        sub      REG_XSP, FRAME_ALIGNMENT - ARG_SZ  /* Maintain alignment. Some system's
                                                     * libc may decide to callee-save xmm
                                                     * registers which requires alignment.
                                                     * (xref i#3674).

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -709,10 +709,10 @@ DECL_EXTERN(func_ptr)
         DECLARE_FUNC_SEH(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
         sub      REG_XSP, FRAME_ALIGNMENT - ARG_SZ  /* Maintain alignment. Some system's
-                                                    * libc may decide to callee-save xmm
-                                                    * registers which requires alignment.
-                                                    * (xref i#3674).
-                                                    */
+                                                     * libc may decide to callee-save xmm
+                                                     * registers which requires alignment.
+                                                     * (xref i#3674).
+                                                     */
         END_PROLOG
         CALL_SETJMP
         call     PTRSZ SYMREF(func_ptr)


### PR DESCRIPTION
An Ubuntu 18 system's libc, even with older gcc versions 4.8 (we did not try
< 4.5), decided to callee-save a xmm register on the stack. This patch aligns
the stack in the function in the test that is calling vfprintf. This problem generally
affects all functions that we are hand-coding in asm and calling from a test.
Absent a complete review of all hand-coded functions in the code base, this
fixes this one only single case where a test failure was observed.

Fixes #3674