### PR TITLE
i#1312 AVX-512 support: Add vrcp* opcodes.

### DIFF
--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1421,6 +1421,14 @@ const instr_info_t * const op_instr[] =
     /* OP_vpsrlvw       */  &e_vex_extensions[132][2],
     /* OP_vpxord        */  &evex_W_extensions[44][0],
     /* OP_vpxorq        */  &evex_W_extensions[44][1],
+    /* OP_vrcp14ps      */  &evex_W_extensions[131][0],
+    /* OP_vrcp14pd      */  &evex_W_extensions[131][1],
+    /* OP_vrcp14ss      */  &evex_W_extensions[132][0],
+    /* OP_vrcp14sd      */  &evex_W_extensions[132][1],
+    /* OP_vrcp28ps      */  &evex_W_extensions[133][0],
+    /* OP_vrcp28pd      */  &evex_W_extensions[133][1],
+    /* OP_vrcp28ss      */  &evex_W_extensions[134][0],
+    /* OP_vrcp28sd      */  &evex_W_extensions[134][1],
 };
 
 
@@ -1595,6 +1603,7 @@ const instr_info_t * const op_instr[] =
 #define Ve TYPE_V, OPSZ_16_vex32_evex64
 #define We TYPE_W, OPSZ_16_vex32_evex64
 #define Wh_e TYPE_W, OPSZ_half_16_vex32_evex64
+#define Woq TYPE_W, OPSZ_64
 #define Hes TYPE_H, OPSZ_16_vex32_evex64
 #define Hed TYPE_H, OPSZ_16_vex32_evex64
 #define He TYPE_H, OPSZ_16_vex32_evex64
@@ -3180,7 +3189,6 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_vrcpss, 0xf30f5310, "vrcpss", Vdq, xx, H12_dq, Wss, xx, mrm|vex, x, END_LIST},
     {INVALID, 0x660f5310, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf20f5310, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    /* TODO i#1312: Support AVX-512. */
     {INVALID,   0x0f5310, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf30f5310, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0x660f5310, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
@@ -6265,7 +6273,7 @@ const byte third_byte_38_index[256] = {
     16,127,128, 88,  17, 18,111, 19,  89, 90, 91,  0,  13, 14, 15,  0,  /* 1 */
     20, 21, 22, 23,  24, 25,  0,  0,  26, 27, 28, 29,  92, 93, 94, 95,  /* 2 */
     30, 31, 32, 33,  34, 35,112, 36,  37, 38, 39, 40,  41, 42, 43, 44,  /* 3 */
-    45, 46,  0,  0,   0,113,114,115,   0,  0,  0,  0,   0,  0,  0,  0,  /* 4 */
+    45, 46,  0,  0,   0,113,114,115,   0,  0,  0,  0, 129,130,  0,  0,  /* 4 */
      0,  0,  0,  0,   0,  0,  0,  0, 118,119,108,  0,   0,  0,  0,  0,  /* 5 */
      0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,  /* 6 */
      0,  0,  0,  0,   0,123,122,121, 116,117,  0,  0,   0,124,125,126,  /* 7 */
@@ -6273,7 +6281,7 @@ const byte third_byte_38_index[256] = {
    104,105,106,107,   0,  0, 58, 59,  60, 61, 62, 63,  64, 65, 66, 67,  /* 9 */
      0,  0,  0,  0,   0,  0, 68, 69,  70, 71, 72, 73,  74, 75, 76, 77,  /* A */
      0,  0,  0,  0,   0,  0, 78, 79,  80, 81, 82, 83,  84, 85, 86, 87,  /* B */
-     0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,  /* C */
+     0,  0,  0,  0,   0,  0,  0,  0,   0,  0,131,132,   0,  0,  0,  0,  /* C */
      0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0, 51,  52, 53, 54, 55,  /* D */
      0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,  /* E */
     47, 48,100, 99,   0,101,102, 98,   0,  0,  0,  0,   0,  0,  0,  0   /* F */
@@ -6428,6 +6436,10 @@ const instr_info_t third_byte_38[] = {
   {EVEX_W_EXT, 0x66387f18, "(evex_W ext 99)", xx, xx, xx, xx, xx, mrm, x, 99},/*126*/
   {EVEX_W_EXT, 0x66381118, "(evex_W ext 126)", xx, xx, xx, xx, xx, mrm, x, 126},/*127*/
   {EVEX_W_EXT, 0x66381218, "(evex_W ext 129)", xx, xx, xx, xx, xx, mrm, x, 129},/*128*/
+  {EVEX_W_EXT, 0x66384c18, "(evex_W ext 131)", xx, xx, xx, xx, xx, mrm, x, 131},/*129*/
+  {EVEX_W_EXT, 0x66384d18, "(evex_W ext 132)", xx, xx, xx, xx, xx, mrm, x, 132},/*130*/
+  {EVEX_W_EXT, 0x6638ca18, "(evex_W ext 133)", xx, xx, xx, xx, xx, mrm, x, 133},/*131*/
+  {EVEX_W_EXT, 0x6638cb18, "(evex_W ext 134)", xx, xx, xx, xx, xx, mrm, x, 134},/*132*/
 };
 
 /* N.B.: every 0x3a instr so far has an immediate.  If a version w/o an immed
@@ -6540,6 +6552,7 @@ const instr_info_t third_byte_3a[] = {
   {EVEX_W_EXT, 0x663a3f18, "(evex_W ext 109)", xx, xx, xx, xx, xx, mrm, x, 109},/*72*/
   {EVEX_W_EXT, 0x663a1e18, "(evex_W ext 110)", xx, xx, xx, xx, xx, mrm, x, 110},/*73*/
   {EVEX_W_EXT, 0x663a1f18, "(evex_W ext 111)", xx, xx, xx, xx, xx, mrm, x, 111},/*74*/
+  {EVEX_W_EXT, 0x663a4c18, "(evex_W ext 131)", xx, xx, xx, xx, xx, mrm, x, 131},/*75*/
 };
 
 /****************************************************************************
@@ -7297,6 +7310,18 @@ const instr_info_t evex_W_extensions[][2] = {
   }, { /* evex_W_ext 130 */
     {OP_vpsllvd, 0x66384718, "vpsllvd", Ve, xx, KEw, He, We, mrm|evex|reqp,x,END_LIST},
     {OP_vpsllvq, 0x66384758, "vpsllvq", Ve, xx, KEb, He, We, mrm|evex|reqp,x,END_LIST},
+  }, { /* evex_W_ext 131 */
+    {OP_vrcp14ps, 0x66384c18, "vrcp14ps", Ve, xx, KEw, We, xx, mrm|evex|reqp,x,END_LIST},
+    {OP_vrcp14pd, 0x66384c58, "vrcp14pd", Ve, xx, KEb, We, xx, mrm|evex|reqp,x,END_LIST},
+  }, { /* evex_W_ext 132 */
+    {OP_vrcp14ss, 0x66384d18, "vrcp14ss", Vdq, xx, KE1b, H12_dq, Wss, mrm|evex|reqp,x,END_LIST},
+    {OP_vrcp14sd, 0x66384d58, "vrcp14sd", Vdq, xx, KE1b, Hsd, Wsd, mrm|evex|reqp,x,END_LIST},
+  }, { /* evex_W_ext 133 */
+    {OP_vrcp28ps, 0x6638ca18, "vrcp28ps", Voq, xx, KEw, Woq, xx, mrm|evex|reqp,x,END_LIST},
+    {OP_vrcp28pd, 0x6638ca58, "vrcp28pd", Voq, xx, KEb, Woq, xx, mrm|evex|reqp,x,END_LIST},
+  }, { /* evex_W_ext 134 */
+    {OP_vrcp28ss, 0x6638cb18, "vrcp28ss", Vdq, xx, KE1b, H12_dq, Wss, mrm|evex|reqp,x,END_LIST},
+    {OP_vrcp28sd, 0x6638cb58, "vrcp28sd", Vdq, xx, KE1b, Hsd, Wsd, mrm|evex|reqp,x,END_LIST},
   },
 };
 

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -2336,6 +2336,14 @@
     instr_create_1dst_2src((dc), OP_vcvtuqq2ps, (d), (k), (s))
 #define INSTR_CREATE_vcvtuqq2pd_mask(dc, d, k, s) \
     instr_create_1dst_2src((dc), OP_vcvtuqq2pd, (d), (k), (s))
+#define INSTR_CREATE_vrcp14ps_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vrcp14ps, (d), (k), (s))
+#define INSTR_CREATE_vrcp14pd_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vrcp14pd, (d), (k), (s))
+#define INSTR_CREATE_vrcp28ps_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vrcp28ps, (d), (k), (s))
+#define INSTR_CREATE_vrcp28pd_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vrcp28pd, (d), (k), (s))
 /* @} */ /* end doxygen group */
 
 /* 1 destination, 2 sources: 1 explicit, 1 implicit */
@@ -3350,6 +3358,14 @@
     instr_create_1dst_3src((dc), OP_vpslld, (d), (k), (s1), (s2))
 #define INSTR_CREATE_vpsllq_mask(dc, d, k, s1, s2) \
     instr_create_1dst_3src((dc), OP_vpsllq, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vrcp14ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vrcp14ss, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vrcp14sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vrcp14sd, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vrcp28ss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vrcp28ss, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vrcp28sd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vrcp28sd, (d), (k), (s1), (s2))
 /* @} */ /* end doxygen group */
 
 /** @name 1 destination, 3 sources including one immediate */

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1417,6 +1417,14 @@ enum {
     /* 1247 */ OP_vpsrlvw,       /**< IA-32/AMD64 vpsrlvw opcode. */
     /* 1248 */ OP_vpxord,        /**< IA-32/AMD64 AVX-512 OP_vpxord opcode. */
     /* 1249 */ OP_vpxorq,        /**< IA-32/AMD64 AVX-512 OP_vpxorq opcode. */
+    /* 1250 */ OP_vrcp14ps,      /**< IA-32/AMD64 AVX-512 OP_vrcp14ps opcode. */
+    /* 1251 */ OP_vrcp14pd,      /**< IA-32/AMD64 AVX-512 OP_vrcp14pd opcode. */
+    /* 1252 */ OP_vrcp14ss,      /**< IA-32/AMD64 AVX-512 OP_vrcp14ss opcode. */
+    /* 1253 */ OP_vrcp14sd,      /**< IA-32/AMD64 AVX-512 OP_vrcp14sd opcode. */
+    /* 1254 */ OP_vrcp28ps,      /**< IA-32/AMD64 AVX-512 OP_vrcp28ps opcode. */
+    /* 1255 */ OP_vrcp28pd,      /**< IA-32/AMD64 AVX-512 OP_vrcp28pd opcode. */
+    /* 1256 */ OP_vrcp28ss,      /**< IA-32/AMD64 AVX-512 OP_vrcp28ss opcode. */
+    /* 1257 */ OP_vrcp28sd,      /**< IA-32/AMD64 AVX-512 OP_vrcp28sd opcode. */
 
     OP_AFTER_LAST,
     OP_FIRST = OP_add,           /**< First real opcode. */

--- a/suite/tests/api/ir_x86_3args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_3args_avx512_evex_mask.h
@@ -999,4 +999,67 @@ OPCODE(vcvtuqq2pd_zlok0zlo, vcvtuqq2pd, vcvtuqq2pd_mask, 0, REGARG(ZMM0), REGARG
        REGARG(ZMM1))
 OPCODE(vcvtuqq2pd_zhik7zhi, vcvtuqq2pd, vcvtuqq2pd_mask, X64_ONLY, REGARG(ZMM16),
        REGARG(K7), REGARG(ZMM31))
-/* TODO i#1312: Add missing instructions. */
+OPCODE(vrcp14ps_xlok0xloxmm, vrcp14ps, vrcp14ps_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1))
+OPCODE(vrcp14ps_xlok0xmmld, vrcp14ps, vrcp14ps_mask, 0, REGARG(XMM0), REGARG(K0),
+       MEMARG(OPSZ_16))
+OPCODE(vrcp14ps_xhik7xhixmm, vrcp14ps, vrcp14ps_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG(XMM1))
+OPCODE(vrcp14ps_xhik7xmmld, vrcp14ps, vrcp14ps_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       MEMARG(OPSZ_16))
+OPCODE(vrcp14ps_ylok0yloxmm, vrcp14ps, vrcp14ps_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1))
+OPCODE(vrcp14ps_ylok0xmmld, vrcp14ps, vrcp14ps_mask, 0, REGARG(YMM0), REGARG(K0),
+       MEMARG(OPSZ_32))
+OPCODE(vrcp14ps_yhik7yhixmm, vrcp14ps, vrcp14ps_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       REGARG(YMM17))
+OPCODE(vrcp14ps_yhik7xmmld, vrcp14ps, vrcp14ps_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       MEMARG(OPSZ_32))
+OPCODE(vrcp14ps_zlok0zloxmm, vrcp14ps, vrcp14ps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1))
+OPCODE(vrcp14ps_zlok0xmmld, vrcp14ps, vrcp14ps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       MEMARG(OPSZ_64))
+OPCODE(vrcp14ps_zhik7zhixmm, vrcp14ps, vrcp14ps_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       REGARG(ZMM17))
+OPCODE(vrcp14ps_zhik7xmmld, vrcp14ps, vrcp14ps_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       MEMARG(OPSZ_64))
+OPCODE(vrcp14pd_xlok0xloxmm, vrcp14pd, vrcp14pd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1))
+OPCODE(vrcp14pd_xlok0xmmld, vrcp14pd, vrcp14pd_mask, 0, REGARG(XMM0), REGARG(K0),
+       MEMARG(OPSZ_16))
+OPCODE(vrcp14pd_xhik7xhixmm, vrcp14pd, vrcp14pd_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG(XMM17))
+OPCODE(vrcp14pd_xhik7xmmld, vrcp14pd, vrcp14pd_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       MEMARG(OPSZ_16))
+OPCODE(vrcp14pd_ylok0yloxmm, vrcp14pd, vrcp14pd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1))
+OPCODE(vrcp14pd_ylok0xmmld, vrcp14pd, vrcp14pd_mask, 0, REGARG(YMM0), REGARG(K0),
+       MEMARG(OPSZ_32))
+OPCODE(vrcp14pd_yhik7yhixmm, vrcp14pd, vrcp14pd_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       REGARG(YMM17))
+OPCODE(vrcp14pd_yhik7xmmld, vrcp14pd, vrcp14pd_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       MEMARG(OPSZ_32))
+OPCODE(vrcp14pd_zlok0zloxmm, vrcp14pd, vrcp14pd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1))
+OPCODE(vrcp14pd_zlok0xmmld, vrcp14pd, vrcp14pd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       MEMARG(OPSZ_64))
+OPCODE(vrcp14pd_zhik7zhixmm, vrcp14pd, vrcp14pd_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       REGARG(ZMM17))
+OPCODE(vrcp14pd_zhik7xmmld, vrcp14pd, vrcp14pd_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       MEMARG(OPSZ_64))
+OPCODE(vrcp28ps_zlok0zloxmm, vrcp28ps, vrcp28ps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1))
+OPCODE(vrcp28ps_zlok0xmmld, vrcp28ps, vrcp28ps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       MEMARG(OPSZ_64))
+OPCODE(vrcp28ps_zhik7zhixmm, vrcp28ps, vrcp28ps_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       REGARG(ZMM17))
+OPCODE(vrcp28ps_zhik7xmmld, vrcp28ps, vrcp28ps_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       MEMARG(OPSZ_64))
+OPCODE(vrcp28pd_zlok0zloxmm, vrcp28pd, vrcp28pd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1))
+OPCODE(vrcp28pd_zlok0xmmld, vrcp28pd, vrcp28pd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       MEMARG(OPSZ_64))
+OPCODE(vrcp28pd_zhik7zhixmm, vrcp28pd, vrcp28pd_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       REGARG(ZMM17))
+OPCODE(vrcp28pd_zhik7xmmld, vrcp28pd, vrcp28pd_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       MEMARG(OPSZ_64))

--- a/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
@@ -4453,3 +4453,35 @@ OPCODE(vpsllq_zhik7zhixmm, vpsllq, vpsllq_mask, X64_ONLY, REGARG(ZMM16), REGARG(
        REGARG(ZMM2), REGARG(ZMM17))
 OPCODE(vpsllq_zhik7xmmld, vpsllq, vpsllq_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
        REGARG(ZMM2), MEMARG(OPSZ_64))
+OPCODE(vrcp14ss_xlok0xloxmm, vrcp14ss, vrcp14ss_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM2, OPSZ_12), REGARG_PARTIAL(XMM1, OPSZ_4))
+OPCODE(vrcp14ss_xlok0xmmld, vrcp14ss, vrcp14ss_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM2, OPSZ_12), MEMARG(OPSZ_4))
+OPCODE(vrcp14ss_xhik7xhixmm, vrcp14ss, vrcp14ss_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG_PARTIAL(XMM2, OPSZ_12), REGARG_PARTIAL(XMM17, OPSZ_4))
+OPCODE(vrcp14ss_xhik7xmmld, vrcp14ss, vrcp14ss_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG_PARTIAL(XMM2, OPSZ_12), MEMARG(OPSZ_4))
+OPCODE(vrcp14sd_xlok0xloxmm, vrcp14sd, vrcp14sd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM2, OPSZ_8), REGARG_PARTIAL(XMM1, OPSZ_8))
+OPCODE(vrcp14sd_xlok0xmmld, vrcp14sd, vrcp14sd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM2, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vrcp14sd_xhik7xhixmm, vrcp14sd, vrcp14sd_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG_PARTIAL(XMM2, OPSZ_8), REGARG_PARTIAL(XMM17, OPSZ_8))
+OPCODE(vrcp14sd_xhik7xmmld, vrcp14sd, vrcp14sd_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG_PARTIAL(XMM2, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vrcp28ss_xlok0xloxmm, vrcp28ss, vrcp28ss_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM2, OPSZ_12), REGARG_PARTIAL(XMM1, OPSZ_4))
+OPCODE(vrcp28ss_xlok0xmmld, vrcp28ss, vrcp28ss_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM2, OPSZ_12), MEMARG(OPSZ_4))
+OPCODE(vrcp28ss_xhik7xhixmm, vrcp28ss, vrcp28ss_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG_PARTIAL(XMM2, OPSZ_12), REGARG_PARTIAL(XMM17, OPSZ_4))
+OPCODE(vrcp28ss_xhik7xmmld, vrcp28ss, vrcp28ss_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG_PARTIAL(XMM2, OPSZ_12), MEMARG(OPSZ_4))
+OPCODE(vrcp28sd_xlok0xloxmm, vrcp28sd, vrcp28sd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM2, OPSZ_8), REGARG_PARTIAL(XMM1, OPSZ_8))
+OPCODE(vrcp28sd_xlok0xmmld, vrcp28sd, vrcp28sd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM2, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vrcp28sd_xhik7xhixmm, vrcp28sd, vrcp28sd_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG_PARTIAL(XMM2, OPSZ_8), REGARG_PARTIAL(XMM17, OPSZ_8))
+OPCODE(vrcp28sd_xhik7xmmld, vrcp28sd, vrcp28sd_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG_PARTIAL(XMM2, OPSZ_8), MEMARG(OPSZ_8))


### PR DESCRIPTION
Adds the new AVX-512 opcodes vrcp14ps, vrcp14pd, vrcp14ss, vrcp14sd, vrcp28ps,
vrcp28pd, vrcp28ss, vrcp28sd.

Adds tests for above.

Opcodes have been checked against llvm-mc, binutils/gas/objdump and capstone.

Issue: #1312