### PR TITLE
i#1312 AVX-512 support: Fix vbroadcastss destination operand constraint.

### DIFF
--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -6031,7 +6031,7 @@ const instr_info_t e_vex_extensions[][3] = {
   }, { /* e_vex ext 64 */
     {INVALID,   0x66381818, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {OP_vbroadcastss, 0x66381818, "vbroadcastss", Vx, xx, Wd_dq, xx, xx, mrm|vex|reqp, x, tvex[64][2]},
-    {OP_vbroadcastss, 0x66381818, "vbroadcastss", Vf, xx, KEw, Wd_dq, xx, mrm|evex|reqp, x, END_LIST},
+    {OP_vbroadcastss, 0x66381818, "vbroadcastss", Ve, xx, KEw, Wd_dq, xx, mrm|evex|reqp, x, END_LIST},
   }, { /* e_vex ext 65 */
     {INVALID,   0x66381918, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {OP_vbroadcastsd, 0x66381918, "vbroadcastsd", Vqq, xx, Wq_dq, xx, xx, mrm|vex|reqp|reqL1, x, tevexw[147][1]},

--- a/suite/tests/api/ir_x86_3args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_3args_avx512_evex_mask.h
@@ -1847,6 +1847,14 @@ OPCODE(vbroadcastsd_zhik7xhi, vbroadcastsd, vbroadcastsd_mask, X64_ONLY, REGARG(
        REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_8))
 OPCODE(vbroadcastsd_zhik7ld, vbroadcastsd, vbroadcastsd_mask, X64_ONLY, REGARG(ZMM16),
        REGARG(K7), MEMARG(OPSZ_8))
+OPCODE(vbroadcastss_xlok0xlo, vbroadcastss, vbroadcastss_mask, 0, REGARG(XMM0),
+       REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4))
+OPCODE(vbroadcastss_xlok0ld, vbroadcastss, vbroadcastss_mask, 0, REGARG(XMM0), REGARG(K0),
+       MEMARG(OPSZ_4))
+OPCODE(vbroadcastss_xhik7xhi, vbroadcastss, vbroadcastss_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vbroadcastss_xhik7ld, vbroadcastss, vbroadcastss_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), MEMARG(OPSZ_4))
 OPCODE(vbroadcastss_ylok0xlo, vbroadcastss, vbroadcastss_mask, 0, REGARG(YMM0),
        REGARG(K0), REGARG_PARTIAL(XMM1, OPSZ_4))
 OPCODE(vbroadcastss_ylok0ld, vbroadcastss, vbroadcastss_mask, 0, REGARG(YMM0), REGARG(K0),


### PR DESCRIPTION
Fix a minor bug introduced in b39962496373a. Unlike vbroadcastsd, vbroadcastss allows for
a OPSZ_16 destination size.

Issue: #1312