### PR TITLE
i#1312 AVX-512 support: Add valign*, vblend*, vcompress*, vexpand* and further opcodes.

### DIFF
--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1328,150 +1328,186 @@ const instr_info_t * const op_instr[] =
     /* OP_ktestd        */  &vex_W_extensions[105][1],
 
     /* AVX-512 EVEX encoded */
-    /* OP_vbroadcastf32x2  */  &evex_W_extensions[147][0],
-    /* OP_vbroadcastf32x4  */  &evex_W_extensions[148][0],
-    /* OP_vbroadcastf64x2  */  &evex_W_extensions[148][1],
-    /* OP_vbroadcastf32x8  */  &evex_W_extensions[149][0],
-    /* OP_vbroadcastf64x4  */  &evex_W_extensions[149][1],
-    /* OP_vbroadcasti32x2 */   &evex_W_extensions[151][0],
-    /* OP_vbroadcasti32x4 */   &evex_W_extensions[152][0],
-    /* OP_vbroadcasti64x2 */   &evex_W_extensions[152][1],
-    /* OP_vbroadcasti32x8 */   &evex_W_extensions[153][0],
-    /* OP_vbroadcasti64x4 */   &evex_W_extensions[153][1],
-    /* OP_vcvtpd2qq     */  &evex_W_extensions[46][1],
-    /* OP_vcvtpd2udq    */  &evex_W_extensions[47][1],
-    /* OP_vcvtpd2uqq    */  &evex_W_extensions[48][1],
-    /* OP_vcvtps2qq     */  &evex_W_extensions[46][0],
-    /* OP_vcvtps2udq    */  &evex_W_extensions[47][0],
-    /* OP_vcvtps2uqq    */  &evex_W_extensions[48][0],
-    /* OP_vcvtqq2pd     */  &evex_W_extensions[57][1],
-    /* OP_vcvtqq2ps     */  &evex_W_extensions[56][1],
-    /* OP_vcvtsd2usi    */  &evex_W_extensions[53][0],
-    /* OP_vcvtss2usi    */  &evex_W_extensions[52][0],
-    /* OP_vcvttpd2qq    */  &evex_W_extensions[50][1],
-    /* OP_vcvttpd2udq   */  &evex_W_extensions[49][1],
-    /* OP_vcvttpd2uqq   */  &evex_W_extensions[51][1],
-    /* OP_vcvttps2qq    */  &evex_W_extensions[50][0],
-    /* OP_vcvttps2udq   */  &evex_W_extensions[49][0],
-    /* OP_vcvttps2uqq   */  &evex_W_extensions[51][0],
-    /* OP_vcvttsd2usi   */  &evex_W_extensions[55][0],
-    /* OP_vcvttss2usi   */  &evex_W_extensions[54][0],
-    /* OP_vcvtudq2pd    */  &evex_W_extensions[61][0],
-    /* OP_vcvtudq2ps    */  &evex_W_extensions[60][0],
-    /* OP_vcvtuqq2pd    */  &evex_W_extensions[61][1],
-    /* OP_vcvtuqq2ps    */  &evex_W_extensions[60][1],
-    /* OP_vcvtusi2sd    */  &evex_W_extensions[59][0],
-    /* OP_vcvtusi2ss    */  &evex_W_extensions[58][0],
-    /* OP_vextractf32x4 */  &evex_W_extensions[100][0],
-    /* OP_vextractf32x8 */  &evex_W_extensions[101][0],
-    /* OP_vextractf64x2 */  &evex_W_extensions[100][1],
-    /* OP_vextractf64x4 */  &evex_W_extensions[101][1],
-    /* OP_vextracti32x4 */  &evex_W_extensions[102][0],
-    /* OP_vextracti32x8 */  &evex_W_extensions[103][0],
-    /* OP_vextracti64x2 */  &evex_W_extensions[102][1],
-    /* OP_vextracti64x4 */  &evex_W_extensions[103][1],
-    /* OP_vinsertf32x4  */  &evex_W_extensions[104][0],
-    /* OP_vinsertf32x8  */  &evex_W_extensions[105][0],
-    /* OP_vinsertf64x2  */  &evex_W_extensions[104][1],
-    /* OP_vinsertf64x4  */  &evex_W_extensions[105][1],
-    /* OP_vinserti32x4  */  &evex_W_extensions[106][0],
-    /* OP_vinserti32x8  */  &evex_W_extensions[107][0],
-    /* OP_vinserti64x2  */  &evex_W_extensions[106][1],
-    /* OP_vinserti64x4  */  &evex_W_extensions[107][1],
-    /* OP_vmovdqa32     */  &evex_W_extensions[8][0],
-    /* OP_vmovdqa64     */  &evex_W_extensions[8][1],
-    /* OP_vmovdqu16     */  &evex_W_extensions[10][1],
-    /* OP_vmovdqu32     */  &evex_W_extensions[11][0],
-    /* OP_vmovdqu64     */  &evex_W_extensions[11][1],
-    /* OP_vmovdqu8      */  &evex_W_extensions[10][0],
-    /* OP_vpabsq        */  &evex_W_extensions[146][1],
-    /* OP_vpandd        */  &evex_W_extensions[41][0],
-    /* OP_vpandnd       */  &evex_W_extensions[42][0],
-    /* OP_vpandnq       */  &evex_W_extensions[42][1],
-    /* OP_vpandq        */  &evex_W_extensions[41][1],
-    /* OP_vpcmpb        */  &evex_W_extensions[109][0],
-    /* OP_vpcmpd        */  &evex_W_extensions[111][0],
-    /* OP_vpcmpq        */  &evex_W_extensions[111][1],
-    /* OP_vpcmpw        */  &evex_W_extensions[109][1],
-    /* OP_vpcmpub       */  &evex_W_extensions[108][0],
-    /* OP_vpcmpud       */  &evex_W_extensions[110][0],
-    /* OP_vpcmpuq       */  &evex_W_extensions[110][1],
-    /* OP_vpcmpuw       */  &evex_W_extensions[108][1],
-    /* OP_vpermi2b      */  &evex_W_extensions[96][0],
-    /* OP_vpermi2d      */  &evex_W_extensions[95][0],
-    /* OP_vpermi2pd     */  &evex_W_extensions[94][1],
-    /* OP_vpermi2ps     */  &evex_W_extensions[94][0],
-    /* OP_vpermi2q      */  &evex_W_extensions[95][1],
-    /* OP_vpermi2w      */  &evex_W_extensions[96][1],
-    /* OP_vpermt2b      */  &evex_W_extensions[97][0],
-    /* OP_vpermt2d      */  &evex_W_extensions[98][0],
-    /* OP_vpermt2pd     */  &evex_W_extensions[99][1],
-    /* OP_vpermt2ps     */  &evex_W_extensions[99][0],
-    /* OP_vpermt2q      */  &evex_W_extensions[98][1],
-    /* OP_vpermt2w      */  &evex_W_extensions[97][1],
-    /* OP_vpermw        */  &third_byte_38[120],
-    /* OP_vpextrq       */  &evex_W_extensions[144][1],
-    /* OP_vpinsrq       */  &evex_W_extensions[143][1],
-    /* OP_vpmaxsq       */  &evex_W_extensions[113][1],
-    /* OP_vpmaxuq       */  &evex_W_extensions[115][1],
-    /* OP_vpminsq       */  &evex_W_extensions[112][1],
-    /* OP_vpminuq       */  &evex_W_extensions[114][1],
-    /* OP_vpmovb2m      */  &evex_W_extensions[139][0],
-    /* OP_vpmovd2m      */  &evex_W_extensions[140][0],
-    /* OP_vpmovdb       */  &prefix_extensions[169][9],
-    /* OP_vpmovdw       */  &prefix_extensions[172][9],
-    /* OP_vpmovm2b      */  &evex_W_extensions[137][0],
-    /* OP_vpmovm2w      */  &evex_W_extensions[137][1],
-    /* OP_vpmovm2d      */  &evex_W_extensions[138][0],
-    /* OP_vpmovm2q      */  &evex_W_extensions[138][1],
-    /* OP_vpmovq2m      */  &evex_W_extensions[140][1],
-    /* OP_vpmovqb       */  &prefix_extensions[160][9],
-    /* OP_vpmovqd       */  &prefix_extensions[166][9],
-    /* OP_vpmovqw       */  &prefix_extensions[163][9],
-    /* OP_vpmovsdb      */  &prefix_extensions[170][9],
-    /* OP_vpmovsdw      */  &prefix_extensions[173][9],
-    /* OP_vpmovsqb      */  &prefix_extensions[161][9],
-    /* OP_vpmovsqd      */  &prefix_extensions[167][9],
-    /* OP_vpmovsqw      */  &prefix_extensions[164][9],
-    /* OP_vpmovswb      */  &prefix_extensions[176][9],
-    /* OP_vpmovusdb     */  &prefix_extensions[171][9],
-    /* OP_vpmovusdw     */  &prefix_extensions[174][9],
-    /* OP_vpmovusqb     */  &prefix_extensions[162][9],
-    /* OP_vpmovusqd     */  &prefix_extensions[168][9],
-    /* OP_vpmovusqw     */  &prefix_extensions[165][9],
-    /* OP_vpmovuswb     */  &prefix_extensions[177][9],
-    /* OP_vpmovw2m      */  &evex_W_extensions[139][1],
-    /* OP_vpmovwb       */  &prefix_extensions[175][9],
-    /* OP_vpmullq       */  &evex_W_extensions[45][1],
-    /* OP_vpord         */  &evex_W_extensions[43][0],
-    /* OP_vporq         */  &evex_W_extensions[43][1],
-    /* OP_vprold        */  &evex_W_extensions[117][0],
-    /* OP_vprolq        */  &evex_W_extensions[117][1],
-    /* OP_vprolvd       */  &evex_W_extensions[116][0],
-    /* OP_vprolvq       */  &evex_W_extensions[116][1],
-    /* OP_vprord        */  &evex_W_extensions[119][0],
-    /* OP_vprorq        */  &evex_W_extensions[119][1],
-    /* OP_vprorvd       */  &evex_W_extensions[118][0],
-    /* OP_vprorvq       */  &evex_W_extensions[118][1],
-    /* OP_vpsllvw       */  &evex_W_extensions[129][1],
-    /* OP_vpsraq        */  &evex_W_extensions[120][1],
-    /* OP_vpsravw       */  &evex_W_extensions[126][1],
-    /* OP_vpsravq       */  &evex_W_extensions[127][1],
-    /* OP_vpsrlvw       */  &prefix_extensions[177][10],
-    /* OP_vpxord        */  &evex_W_extensions[44][0],
-    /* OP_vpxorq        */  &evex_W_extensions[44][1],
-    /* OP_vrcp14ps      */  &evex_W_extensions[131][0],
-    /* OP_vrcp14pd      */  &evex_W_extensions[131][1],
-    /* OP_vrcp14ss      */  &evex_W_extensions[132][0],
-    /* OP_vrcp14sd      */  &evex_W_extensions[132][1],
-    /* OP_vrcp28ps      */  &evex_W_extensions[133][0],
-    /* OP_vrcp28pd      */  &evex_W_extensions[133][1],
-    /* OP_vrcp28ss      */  &evex_W_extensions[134][0],
-    /* OP_vrcp28sd      */  &evex_W_extensions[134][1],
-    /* OP_vshuff32x4    */  &evex_W_extensions[141][0],
-    /* OP_vshuff64x2    */  &evex_W_extensions[141][1],
-    /* OP_vshufi32x4    */  &evex_W_extensions[142][0],
-    /* OP_vshufi64x2    */  &evex_W_extensions[142][1],
+    /* OP_valignd         */  &evex_W_extensions[154][0],
+    /* OP_valignq         */  &evex_W_extensions[154][1],
+    /* OP_vblendmpd       */  &evex_W_extensions[155][1],
+    /* OP_vblendmps       */  &evex_W_extensions[155][0],
+    /* OP_vbroadcastf32x2 */  &evex_W_extensions[147][0],
+    /* OP_vbroadcastf32x4 */  &evex_W_extensions[148][0],
+    /* OP_vbroadcastf32x8 */  &evex_W_extensions[149][0],
+    /* OP_vbroadcastf64x2 */  &evex_W_extensions[148][1],
+    /* OP_vbroadcastf64x4 */  &evex_W_extensions[149][1],
+    /* OP_vbroadcasti32x2 */  &evex_W_extensions[151][0],
+    /* OP_vbroadcasti32x4 */  &evex_W_extensions[152][0],
+    /* OP_vbroadcasti32x8 */  &evex_W_extensions[153][0],
+    /* OP_vbroadcasti64x2 */  &evex_W_extensions[152][1],
+    /* OP_vbroadcasti64x4 */  &evex_W_extensions[153][1],
+    /* OP_vcompresspd     */  &evex_W_extensions[156][1],
+    /* OP_vcompressps     */  &evex_W_extensions[156][0],
+    /* OP_vcvtpd2qq       */  &evex_W_extensions[46][1],
+    /* OP_vcvtpd2udq      */  &evex_W_extensions[47][1],
+    /* OP_vcvtpd2uqq      */  &evex_W_extensions[48][1],
+    /* OP_vcvtps2qq       */  &evex_W_extensions[46][0],
+    /* OP_vcvtps2udq      */  &evex_W_extensions[47][0],
+    /* OP_vcvtps2uqq      */  &evex_W_extensions[48][0],
+    /* OP_vcvtqq2pd       */  &evex_W_extensions[57][1],
+    /* OP_vcvtqq2ps       */  &evex_W_extensions[56][1],
+    /* OP_vcvtsd2usi      */  &evex_W_extensions[53][0],
+    /* OP_vcvtss2usi      */  &evex_W_extensions[52][0],
+    /* OP_vcvttpd2qq      */  &evex_W_extensions[50][1],
+    /* OP_vcvttpd2udq     */  &evex_W_extensions[49][1],
+    /* OP_vcvttpd2uqq     */  &evex_W_extensions[51][1],
+    /* OP_vcvttps2qq      */  &evex_W_extensions[50][0],
+    /* OP_vcvttps2udq     */  &evex_W_extensions[49][0],
+    /* OP_vcvttps2uqq     */  &evex_W_extensions[51][0],
+    /* OP_vcvttsd2usi     */  &evex_W_extensions[55][0],
+    /* OP_vcvttss2usi     */  &evex_W_extensions[54][0],
+    /* OP_vcvtudq2pd      */  &evex_W_extensions[61][0],
+    /* OP_vcvtudq2ps      */  &evex_W_extensions[60][0],
+    /* OP_vcvtuqq2pd      */  &evex_W_extensions[61][1],
+    /* OP_vcvtuqq2ps      */  &evex_W_extensions[60][1],
+    /* OP_vcvtusi2sd      */  &evex_W_extensions[59][0],
+    /* OP_vcvtusi2ss      */  &evex_W_extensions[58][0],
+    /* OP_vexpandpd       */  &evex_W_extensions[157][1],
+    /* OP_vexpandps       */  &evex_W_extensions[157][0],
+    /* OP_vextractf32x4   */  &evex_W_extensions[100][0],
+    /* OP_vextractf32x8   */  &evex_W_extensions[101][0],
+    /* OP_vextractf64x2   */  &evex_W_extensions[100][1],
+    /* OP_vextractf64x4   */  &evex_W_extensions[101][1],
+    /* OP_vextracti32x4   */  &evex_W_extensions[102][0],
+    /* OP_vextracti32x8   */  &evex_W_extensions[103][0],
+    /* OP_vextracti64x2   */  &evex_W_extensions[102][1],
+    /* OP_vextracti64x4   */  &evex_W_extensions[103][1],
+    /* OP_vfixupimmpd     */  &evex_W_extensions[158][1],
+    /* OP_vfixupimmps     */  &evex_W_extensions[158][0],
+    /* OP_vfixupimmsd     */  &evex_W_extensions[159][1],
+    /* OP_vfixupimmss     */  &evex_W_extensions[159][0],
+    /* OP_vgetexppd       */  &evex_W_extensions[160][1],
+    /* OP_vgetexpps       */  &evex_W_extensions[160][0],
+    /* OP_vgetexpsd       */  &evex_W_extensions[161][1],
+    /* OP_vgetexpss       */  &evex_W_extensions[161][0],
+    /* OP_vgetmantpd      */  &evex_W_extensions[162][1],
+    /* OP_vgetmantps      */  &evex_W_extensions[162][0],
+    /* OP_vgetmantsd      */  &evex_W_extensions[163][1],
+    /* OP_vgetmantss      */  &evex_W_extensions[163][0],
+    /* OP_vinsertf32x4    */  &evex_W_extensions[104][0],
+    /* OP_vinsertf32x8    */  &evex_W_extensions[105][0],
+    /* OP_vinsertf64x2    */  &evex_W_extensions[104][1],
+    /* OP_vinsertf64x4    */  &evex_W_extensions[105][1],
+    /* OP_vinserti32x4    */  &evex_W_extensions[106][0],
+    /* OP_vinserti32x8    */  &evex_W_extensions[107][0],
+    /* OP_vinserti64x2    */  &evex_W_extensions[106][1],
+    /* OP_vinserti64x4    */  &evex_W_extensions[107][1],
+    /* OP_vmovdqa32       */  &evex_W_extensions[8][0],
+    /* OP_vmovdqa64       */  &evex_W_extensions[8][1],
+    /* OP_vmovdqu16       */  &evex_W_extensions[10][1],
+    /* OP_vmovdqu32       */  &evex_W_extensions[11][0],
+    /* OP_vmovdqu64       */  &evex_W_extensions[11][1],
+    /* OP_vmovdqu8        */  &evex_W_extensions[10][0],
+    /* OP_vpabsq          */  &evex_W_extensions[146][1],
+    /* OP_vpandd          */  &evex_W_extensions[41][0],
+    /* OP_vpandnd         */  &evex_W_extensions[42][0],
+    /* OP_vpandnq         */  &evex_W_extensions[42][1],
+    /* OP_vpandq          */  &evex_W_extensions[41][1],
+    /* OP_vpblendmb       */  &evex_W_extensions[164][0],
+    /* OP_vpblendmd       */  &evex_W_extensions[165][0],
+    /* OP_vpblendmq       */  &evex_W_extensions[165][1],
+    /* OP_vpblendmw       */  &evex_W_extensions[164][1],
+    /* OP_vpcmpb          */  &evex_W_extensions[109][0],
+    /* OP_vpcmpd          */  &evex_W_extensions[111][0],
+    /* OP_vpcmpq          */  &evex_W_extensions[111][1],
+    /* OP_vpcmpub         */  &evex_W_extensions[108][0],
+    /* OP_vpcmpud         */  &evex_W_extensions[110][0],
+    /* OP_vpcmpuq         */  &evex_W_extensions[110][1],
+    /* OP_vpcmpuw         */  &evex_W_extensions[108][1],
+    /* OP_vpcmpw          */  &evex_W_extensions[109][1],
+    /* OP_vpcompressd     */  &evex_W_extensions[166][0],
+    /* OP_vpcompressq     */  &evex_W_extensions[166][1],
+    /* OP_vpermi2b        */  &evex_W_extensions[96][0],
+    /* OP_vpermi2d        */  &evex_W_extensions[95][0],
+    /* OP_vpermi2pd       */  &evex_W_extensions[94][1],
+    /* OP_vpermi2ps       */  &evex_W_extensions[94][0],
+    /* OP_vpermi2q        */  &evex_W_extensions[95][1],
+    /* OP_vpermi2w        */  &evex_W_extensions[96][1],
+    /* OP_vpermt2b        */  &evex_W_extensions[97][0],
+    /* OP_vpermt2d        */  &evex_W_extensions[98][0],
+    /* OP_vpermt2pd       */  &evex_W_extensions[99][1],
+    /* OP_vpermt2ps       */  &evex_W_extensions[99][0],
+    /* OP_vpermt2q        */  &evex_W_extensions[98][1],
+    /* OP_vpermt2w        */  &evex_W_extensions[97][1],
+    /* OP_vpermw          */  &third_byte_38[120],
+    /* OP_vpexpandd       */  &evex_W_extensions[167][0],
+    /* OP_vpexpandq       */  &evex_W_extensions[167][1],
+    /* OP_vpextrq         */  &evex_W_extensions[144][1],
+    /* OP_vpinsrq         */  &evex_W_extensions[143][1],
+    /* OP_vpmaxsq         */  &evex_W_extensions[113][1],
+    /* OP_vpmaxuq         */  &evex_W_extensions[115][1],
+    /* OP_vpminsq         */  &evex_W_extensions[112][1],
+    /* OP_vpminuq         */  &evex_W_extensions[114][1],
+    /* OP_vpmovb2m        */  &evex_W_extensions[139][0],
+    /* OP_vpmovd2m        */  &evex_W_extensions[140][0],
+    /* OP_vpmovdb         */  &prefix_extensions[169][9],
+    /* OP_vpmovdw         */  &prefix_extensions[172][9],
+    /* OP_vpmovm2b        */  &evex_W_extensions[137][0],
+    /* OP_vpmovm2d        */  &evex_W_extensions[138][0],
+    /* OP_vpmovm2q        */  &evex_W_extensions[138][1],
+    /* OP_vpmovm2w        */  &evex_W_extensions[137][1],
+    /* OP_vpmovq2m        */  &evex_W_extensions[140][1],
+    /* OP_vpmovqb         */  &prefix_extensions[160][9],
+    /* OP_vpmovqd         */  &prefix_extensions[166][9],
+    /* OP_vpmovqw         */  &prefix_extensions[163][9],
+    /* OP_vpmovsdb        */  &prefix_extensions[170][9],
+    /* OP_vpmovsdw        */  &prefix_extensions[173][9],
+    /* OP_vpmovsqb        */  &prefix_extensions[161][9],
+    /* OP_vpmovsqd        */  &prefix_extensions[167][9],
+    /* OP_vpmovsqw        */  &prefix_extensions[164][9],
+    /* OP_vpmovswb        */  &prefix_extensions[176][9],
+    /* OP_vpmovusdb       */  &prefix_extensions[171][9],
+    /* OP_vpmovusdw       */  &prefix_extensions[174][9],
+    /* OP_vpmovusqb       */  &prefix_extensions[162][9],
+    /* OP_vpmovusqd       */  &prefix_extensions[168][9],
+    /* OP_vpmovusqw       */  &prefix_extensions[165][9],
+    /* OP_vpmovuswb       */  &prefix_extensions[177][9],
+    /* OP_vpmovw2m        */  &evex_W_extensions[139][1],
+    /* OP_vpmovwb         */  &prefix_extensions[175][9],
+    /* OP_vpmullq         */  &evex_W_extensions[45][1],
+    /* OP_vpord           */  &evex_W_extensions[43][0],
+    /* OP_vporq           */  &evex_W_extensions[43][1],
+    /* OP_vprold          */  &evex_W_extensions[117][0],
+    /* OP_vprolq          */  &evex_W_extensions[117][1],
+    /* OP_vprolvd         */  &evex_W_extensions[116][0],
+    /* OP_vprolvq         */  &evex_W_extensions[116][1],
+    /* OP_vprord          */  &evex_W_extensions[119][0],
+    /* OP_vprorq          */  &evex_W_extensions[119][1],
+    /* OP_vprorvd         */  &evex_W_extensions[118][0],
+    /* OP_vprorvq         */  &evex_W_extensions[118][1],
+    /* OP_vpsllvw         */  &evex_W_extensions[129][1],
+    /* OP_vpsraq          */  &evex_W_extensions[120][1],
+    /* OP_vpsravq         */  &evex_W_extensions[127][1],
+    /* OP_vpsravw         */  &evex_W_extensions[126][1],
+    /* OP_vpsrlvw         */  &prefix_extensions[177][10],
+    /* OP_vptestmb        */  &evex_W_extensions[168][0],
+    /* OP_vptestmd        */  &evex_W_extensions[169][0],
+    /* OP_vptestmq        */  &evex_W_extensions[169][1],
+    /* OP_vptestmw        */  &evex_W_extensions[168][1],
+    /* OP_vptestnmb       */  &evex_W_extensions[170][0],
+    /* OP_vptestnmd       */  &evex_W_extensions[171][0],
+    /* OP_vptestnmq       */  &evex_W_extensions[171][1],
+    /* OP_vptestnmw       */  &evex_W_extensions[170][1],
+    /* OP_vpxord          */  &evex_W_extensions[44][0],
+    /* OP_vpxorq          */  &evex_W_extensions[44][1],
+    /* OP_vrcp14pd        */  &evex_W_extensions[131][1],
+    /* OP_vrcp14ps        */  &evex_W_extensions[131][0],
+    /* OP_vrcp14sd        */  &evex_W_extensions[132][1],
+    /* OP_vrcp14ss        */  &evex_W_extensions[132][0],
+    /* OP_vrcp28pd        */  &evex_W_extensions[133][1],
+    /* OP_vrcp28ps        */  &evex_W_extensions[133][0],
+    /* OP_vrcp28sd        */  &evex_W_extensions[134][1],
+    /* OP_vrcp28ss        */  &evex_W_extensions[134][0],
+    /* OP_vshuff32x4      */  &evex_W_extensions[141][0],
+    /* OP_vshuff64x2      */  &evex_W_extensions[141][1],
+    /* OP_vshufi32x4      */  &evex_W_extensions[142][0],
+    /* OP_vshufi64x2      */  &evex_W_extensions[142][1],
 };
 
 
@@ -5754,6 +5790,34 @@ const instr_info_t prefix_extensions[][12] = {
     {EVEX_W_EXT, 0x66383918, "(evex_W ext 112)", xx, xx, xx, xx, xx, mrm|evex, x, 112},
     {INVALID,    0xf2383918, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
   },
+  { /* prefix extension 182 */
+    {INVALID,      0x382618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf3382618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0x66382618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf2382618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x382618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf3382618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0x66382618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf2382618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x382618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0xf3382618, "(evex_W ext 170)", xx, xx, xx, xx, xx, mrm, x, 170},
+    {EVEX_W_EXT, 0x66382618, "(evex_W ext 168)", xx, xx, xx, xx, xx, mrm, x, 168},
+    {INVALID,    0xf2382618, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
+  { /* prefix extension 183 */
+    {INVALID,      0x382718, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf3382718, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0x66382718, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf2382718, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x382718, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf3382718, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0x66382718, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf2382718, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x382718, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {EVEX_W_EXT, 0xf3382718, "(evex_W ext 171)", xx, xx, xx, xx, xx, mrm, x, 171},
+    {EVEX_W_EXT, 0x66382718, "(evex_W ext 169)", xx, xx, xx, xx, xx, mrm, x, 169},
+    {INVALID,    0xf2382718, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  },
 };
 /****************************************************************************
  * Instructions that differ based on whether vex-encoded or not.
@@ -6692,13 +6756,13 @@ const byte third_byte_38_index[256] = {
   /* 0   1   2   3    4   5   6   7    8   9   A   B    C   D   E   F */
      1,  2,  3,  4,   5,  6,  7,  8,   9, 10, 11, 12,  96, 97, 56, 57,  /* 0 */
     16,127,128, 88,  17, 18,111, 19,  89, 90, 91,134,  13, 14, 15,133,  /* 1 */
-    20, 21, 22, 23,  24, 25,  0,  0,  26, 27, 28, 29,  92, 93, 94, 95,  /* 2 */
+    20, 21, 22, 23,  24, 25,148,149,  26, 27, 28, 29,  92, 93, 94, 95,  /* 2 */
     30, 31, 32, 33,  34, 35,112, 36,  37, 38, 39, 40,  41, 42, 43, 44,  /* 3 */
-    45, 46,  0,  0,   0,113,114,115,   0,  0,  0,  0, 129,130,  0,  0,  /* 4 */
+    45, 46,142,143,   0,113,114,115,   0,  0,  0,  0, 129,130,  0,  0,  /* 4 */
      0,  0,  0,  0,   0,  0,  0,  0, 118,119,108,138,   0,  0,  0,  0,  /* 5 */
-     0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,  /* 6 */
+     0,  0,  0,  0, 145,139,144,  0,   0,  0,  0,  0,   0,  0,  0,  0,  /* 6 */
      0,  0,  0,  0,   0,123,122,121, 116,117,135,136, 137,124,125,126,  /* 7 */
-    49, 50,103,  0,   0,  0,  0,  0,   0,  0,  0,  0, 109,120,110,  0,  /* 8 */
+    49, 50,103,  0,   0,  0,  0,  0, 141,147,140,146, 109,120,110,  0,  /* 8 */
    104,105,106,107,   0,  0, 58, 59,  60, 61, 62, 63,  64, 65, 66, 67,  /* 9 */
      0,  0,  0,  0,   0,  0, 68, 69,  70, 71, 72, 73,  74, 75, 76, 77,  /* A */
      0,  0,  0,  0,   0,  0, 78, 79,  80, 81, 82, 83,  84, 85, 86, 87,  /* B */
@@ -6867,6 +6931,17 @@ const instr_info_t third_byte_38[] = {
   {OP_vpbroadcastw, 0x66387b18, "vpbroadcastw", Ve, xx, KEd, Ed, xx, mrm|evex|reqp, x, END_LIST},/*136*/
   {EVEX_W_EXT, 0x66387c18, "(evex_W ext 150)", xx, xx, xx, xx, xx, mrm|reqp, x, 150},/*137*/
   {EVEX_W_EXT, 0x66385b18, "(evex_W ext 153)", xx, xx, xx, xx, xx, mrm|reqp, x, 153},/*138*/
+  {EVEX_W_EXT, 0x66386518, "(evex_W ext 155)", xx, xx, xx, xx, xx, mrm|reqp, x, 155},/*139*/
+  {EVEX_W_EXT, 0x66388a18, "(evex_W ext 156)", xx, xx, xx, xx, xx, mrm|reqp, x, 156},/*140*/
+  {EVEX_W_EXT, 0x66388818, "(evex_W ext 157)", xx, xx, xx, xx, xx, mrm|reqp, x, 157},/*141*/
+  {EVEX_W_EXT, 0x66384218, "(evex_W ext 160)", xx, xx, xx, xx, xx, mrm|reqp, x, 160},/*142*/
+  {EVEX_W_EXT, 0x66384318, "(evex_W ext 161)", xx, xx, xx, xx, xx, mrm|reqp, x, 161},/*143*/
+  {EVEX_W_EXT, 0x66386618, "(evex_W ext 164)", xx, xx, xx, xx, xx, mrm|reqp, x, 164},/*144*/
+  {EVEX_W_EXT, 0x66386418, "(evex_W ext 165)", xx, xx, xx, xx, xx, mrm|reqp, x, 165},/*145*/
+  {EVEX_W_EXT, 0x66388b18, "(evex_W ext 166)", xx, xx, xx, xx, xx, mrm|reqp, x, 166},/*146*/
+  {EVEX_W_EXT, 0x66388918, "(evex_W ext 167)", xx, xx, xx, xx, xx, mrm|reqp, x, 167},/*147*/
+  {PREFIX_EXT, 0x382618, "(prefix ext 182)", xx, xx, xx, xx, xx, mrm, x, 182},/*148*/
+  {PREFIX_EXT, 0x382718, "(prefix ext 183)", xx, xx, xx, xx, xx, mrm, x, 183},/*149*/
 };
 
 /* N.B.: every 0x3a instr so far has an immediate.  If a version w/o an immed
@@ -6874,12 +6949,12 @@ const instr_info_t third_byte_38[] = {
  */
 const byte third_byte_3a_index[256] = {
   /* 0  1  2  3   4  5  6  7   8  9  A  B   C  D  E  F */
-    59,60,61, 0, 28,29,30, 0,  6, 7, 8, 9, 10,11,12, 1,  /* 0 */
+    59,60,61,77, 28,29,30, 0,  6, 7, 8, 9, 10,11,12, 1,  /* 0 */
      0, 0, 0, 0,  2, 3, 4, 5, 31,32,69,67,  0,33,73,74,  /* 1 */
-    13,14,15,75,  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  /* 2 */
+    13,14,15,75,  0, 0,80,81,  0, 0, 0, 0,  0, 0, 0, 0,  /* 2 */
     63,64,65,66,  0, 0, 0, 0, 57,58,70,68,  0, 0,71,72,  /* 3 */
     16,17,18,76, 23, 0,62, 0, 54,55,25,26, 27, 0, 0, 0,  /* 4 */
-     0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 34,35,36,37,  /* 5 */
+     0, 0, 0, 0, 78,79, 0, 0,  0, 0, 0, 0, 34,35,36,37,  /* 5 */
     19,20,21,22,  0, 0, 0, 0, 38,39,40,41, 42,43,44,45,  /* 6 */
      0, 0, 0, 0,  0, 0, 0, 0, 46,47,48,49, 50,51,52,53,  /* 7 */
      0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,  /* 8 */
@@ -6967,20 +7042,25 @@ const instr_info_t third_byte_3a[] = {
   {OP_vpblendd,0x663a0218,"vpblendd",Vx,xx,Hx,Wx,Ib, mrm|vex|reqp,x,END_LIST},/*61*/
   {OP_vperm2i128,0x663a4618,"vperm2i128",Vqq,xx,Hqq,Wqq,Ib, mrm|vex|reqp,x,END_LIST},/*62*/
   /* AVX-512 */
-  {VEX_W_EXT, 0x663a3010, "(vex_W ext 102)", xx, xx, xx, xx, xx, mrm|vex|reqp, x, 102 },/*63*/
-  {VEX_W_EXT, 0x663a3110, "(vex_W ext 103)", xx, xx, xx, xx, xx, mrm|vex|reqp, x, 103 },/*64*/
-  {VEX_W_EXT, 0x663a3210, "(vex_W ext 100)", xx, xx, xx, xx, xx, mrm|vex|reqp, x, 100 },/*65*/
-  {VEX_W_EXT, 0x663a3310, "(vex_W ext 101)", xx, xx, xx, xx, xx, mrm|vex|reqp, x, 101 },/*66*/
-  {EVEX_W_EXT, 0x663a1b18, "(evex_W ext 101)", xx, xx, xx, xx, xx, mrm|evex, x, 101},/*67*/
-  {EVEX_W_EXT, 0x663a3b18, "(evex_W ext 103)", xx, xx, xx, xx, xx, mrm|evex, x, 103},/*68*/
-  {EVEX_W_EXT, 0x663a1a18, "(evex_W ext 105)", xx, xx, xx, xx, xx, mrm|evex, x, 105},/*69*/
-  {EVEX_W_EXT, 0x663a3a18, "(evex_W ext 107)", xx, xx, xx, xx, xx, mrm|evex, x, 107},/*70*/
-  {EVEX_W_EXT, 0x663a3e18, "(evex_W ext 108)", xx, xx, xx, xx, xx, mrm|evex, x, 108},/*71*/
-  {EVEX_W_EXT, 0x663a3f18, "(evex_W ext 109)", xx, xx, xx, xx, xx, mrm|evex, x, 109},/*72*/
-  {EVEX_W_EXT, 0x663a1e18, "(evex_W ext 110)", xx, xx, xx, xx, xx, mrm|evex, x, 110},/*73*/
-  {EVEX_W_EXT, 0x663a1f18, "(evex_W ext 111)", xx, xx, xx, xx, xx, mrm|evex, x, 111},/*74*/
-  {EVEX_W_EXT, 0x663a2318, "(evex_W ext 141)", xx, xx, xx, xx, xx, mrm|evex, x, 141},/*75*/
-  {EVEX_W_EXT, 0x663a4318, "(evex_W ext 142)", xx, xx, xx, xx, xx, mrm|evex, x, 142},/*76*/
+  {VEX_W_EXT, 0x663a3010, "(vex_W ext 102)", xx, xx, xx, xx, xx, mrm|reqp, x, 102 },/*63*/
+  {VEX_W_EXT, 0x663a3110, "(vex_W ext 103)", xx, xx, xx, xx, xx, mrm|reqp, x, 103 },/*64*/
+  {VEX_W_EXT, 0x663a3210, "(vex_W ext 100)", xx, xx, xx, xx, xx, mrm|reqp, x, 100 },/*65*/
+  {VEX_W_EXT, 0x663a3310, "(vex_W ext 101)", xx, xx, xx, xx, xx, mrm|reqp, x, 101 },/*66*/
+  {EVEX_W_EXT, 0x663a1b18, "(evex_W ext 101)", xx, xx, xx, xx, xx, mrm, x, 101},/*67*/
+  {EVEX_W_EXT, 0x663a3b18, "(evex_W ext 103)", xx, xx, xx, xx, xx, mrm, x, 103},/*68*/
+  {EVEX_W_EXT, 0x663a1a18, "(evex_W ext 105)", xx, xx, xx, xx, xx, mrm, x, 105},/*69*/
+  {EVEX_W_EXT, 0x663a3a18, "(evex_W ext 107)", xx, xx, xx, xx, xx, mrm, x, 107},/*70*/
+  {EVEX_W_EXT, 0x663a3e18, "(evex_W ext 108)", xx, xx, xx, xx, xx, mrm, x, 108},/*71*/
+  {EVEX_W_EXT, 0x663a3f18, "(evex_W ext 109)", xx, xx, xx, xx, xx, mrm, x, 109},/*72*/
+  {EVEX_W_EXT, 0x663a1e18, "(evex_W ext 110)", xx, xx, xx, xx, xx, mrm, x, 110},/*73*/
+  {EVEX_W_EXT, 0x663a1f18, "(evex_W ext 111)", xx, xx, xx, xx, xx, mrm, x, 111},/*74*/
+  {EVEX_W_EXT, 0x663a2318, "(evex_W ext 141)", xx, xx, xx, xx, xx, mrm, x, 141},/*75*/
+  {EVEX_W_EXT, 0x663a4318, "(evex_W ext 142)", xx, xx, xx, xx, xx, mrm, x, 142},/*76*/
+  {EVEX_W_EXT, 0x663a0318, "(evex_W ext 154)", xx, xx, xx, xx, xx, mrm, x, 154},/*77*/
+  {EVEX_W_EXT, 0x663a5418, "(evex_W ext 158)", xx, xx, xx, xx, xx, mrm, x, 158},/*78*/
+  {EVEX_W_EXT, 0x663a5518, "(evex_W ext 159)", xx, xx, xx, xx, xx, mrm, x, 159},/*79*/
+  {EVEX_W_EXT, 0x663a2618, "(evex_W ext 162)", xx, xx, xx, xx, xx, mrm, x, 162},/*80*/
+  {EVEX_W_EXT, 0x663a2718, "(evex_W ext 163)", xx, xx, xx, xx, xx, mrm, x, 163},/*81*/
 };
 
 /****************************************************************************
@@ -7813,6 +7893,60 @@ const instr_info_t evex_W_extensions[][2] = {
   }, { /* evex_W_ext 153 */
     {OP_vbroadcasti32x8, 0x66385b18, "vbroadcasti32x8", Vf, xx, KEw, Mqq, xx, mrm|evex|reqp, x, END_LIST},
     {OP_vbroadcasti64x4, 0x66385b58, "vbroadcasti64x4", Vf, xx, KEb, Mqq, xx, mrm|evex|reqp, x, END_LIST},
+  }, { /* evex_W_ext 154 */
+    {OP_valignd, 0x663a0318, "valignd", Ve, xx, KEw, Ib, He, xop|mrm|evex|reqp, x, exop[101]},
+    {OP_valignq, 0x663a0358, "valignq", Ve, xx, KEb, Ib, He, xop|mrm|evex|reqp, x, exop[102]},
+  }, { /* evex_W_ext 155 */
+    {OP_vblendmps, 0x66386518, "vblendmps", Ve, xx, KEw, He, We, mrm|evex|reqp, x, END_LIST},
+    {OP_vblendmpd, 0x66386558, "vblendmpd", Ve, xx, KEb, He, We, mrm|evex|reqp, x, END_LIST},
+  }, { /* evex_W_ext 156 */
+    {OP_vcompressps, 0x66388a18, "vcompressps", We, xx, KEw, Ve, xx, mrm|evex|reqp, x, END_LIST},
+    {OP_vcompresspd, 0x66388a58, "vcompresspd", We, xx, KEb, Ve, xx, mrm|evex|reqp, x, END_LIST},
+  }, { /* evex_W_ext 157 */
+    {OP_vexpandps, 0x66388818, "vexpandps", We, xx, KEw, Ve, xx, mrm|evex|reqp, x, END_LIST},
+    {OP_vexpandpd, 0x66388858, "vexpandpd", We, xx, KEb, Ve, xx, mrm|evex|reqp, x, END_LIST},
+  }, { /* evex_W_ext 158 */
+    {OP_vfixupimmps, 0x663a5418, "vfixupimmps", Ve, xx, KEw, Ib, He, xop|mrm|evex|reqp, x, exop[103]},
+    {OP_vfixupimmpd, 0x663a5458, "vfixupimmpd", Ve, xx, KEb, Ib, He, xop|mrm|evex|reqp, x, exop[104]},
+  }, { /* evex_W_ext 159 */
+    {OP_vfixupimmss, 0x663a5518, "vfixupimmss", Vdq, xx, KE1b, Ib, Hdq, xop|mrm|evex|reqp, x, exop[105]},
+    {OP_vfixupimmsd, 0x663a5558, "vfixupimmsd", Vdq, xx, KE1b, Ib, Hdq, xop|mrm|evex|reqp, x, exop[106]},
+  }, { /* evex_W_ext 160 */
+    {OP_vgetexpps, 0x66384218, "vgetexpps", Ve, xx, KEw, We, xx, mrm|evex|reqp, x, END_LIST},
+    {OP_vgetexppd, 0x66384258, "vgetexppd", Ve, xx, KEb, We, xx, mrm|evex|reqp, x, END_LIST},
+  }, { /* evex_W_ext 161 */
+    {OP_vgetexpss, 0x66384318, "vgetexpss", Vdq, xx, KE1b, H12_dq, Wd_dq, mrm|evex|reqp, x, END_LIST},
+    {OP_vgetexpsd, 0x66384358, "vgetexpsd", Vdq, xx, KE1b,    Hsd, Wq_dq, mrm|evex|reqp, x, END_LIST},
+  }, { /* evex_W_ext 162 */
+    {OP_vgetmantps, 0x663a2618, "vgetmantps", Ve, xx, KEw, Ib, We, mrm|evex|reqp, x, END_LIST},
+    {OP_vgetmantpd, 0x663a2658, "vgetmantpd", Ve, xx, KEb, Ib, We, mrm|evex|reqp, x, END_LIST},
+  }, { /* evex_W_ext 163 */
+    {OP_vgetmantss, 0x663a2718, "vgetmantss", Vdq, xx, KE1b, Ib, H12_dq, xop|mrm|evex|reqp, x, exop[107]},
+    {OP_vgetmantsd, 0x663a2758, "vgetmantsd", Vdq, xx, KE1b, Ib,    Hsd, xop|mrm|evex|reqp, x, exop[108]},
+  }, { /* evex_W_ext 164 */
+    {OP_vpblendmb, 0x66386618, "vpblendmb", Ve, xx, KEq, He, We, mrm|evex|reqp, x, END_LIST},
+    {OP_vpblendmw, 0x66386658, "vpblendmw", Ve, xx, KEd, He, We, mrm|evex|reqp, x, END_LIST},
+  }, { /* evex_W_ext 165 */
+    {OP_vpblendmd, 0x66386418, "vpblendmd", Ve, xx, KEw, He, We, mrm|evex|reqp, x, END_LIST},
+    {OP_vpblendmq, 0x66386458, "vpblendmq", Ve, xx, KEb, He, We, mrm|evex|reqp, x, END_LIST},
+  }, { /* evex_W_ext 166 */
+    {OP_vpcompressd, 0x66388b18, "vpcompressd", We, xx, KEw, Ve, xx, mrm|evex|reqp, x, END_LIST},
+    {OP_vpcompressq, 0x66388b58, "vpcompressq", We, xx, KEb, Ve, xx, mrm|evex|reqp, x, END_LIST},
+  }, { /* evex_W_ext 167 */
+    {OP_vpexpandd, 0x66388918, "vpexpandd", We, xx, KEw, Ve, xx, mrm|evex|reqp, x, END_LIST},
+    {OP_vpexpandq, 0x66388958, "vpexpandq", We, xx, KEb, Ve, xx, mrm|evex|reqp, x, END_LIST},
+  }, { /* evex_W_ext 168 */
+    {OP_vptestmb, 0x66382618, "vptestmb", KPq, xx, KEq, He, We, mrm|evex, x, END_LIST},
+    {OP_vptestmw, 0x66382658, "vptestmw", KPd, xx, KEd, He, We, mrm|evex, x, END_LIST},
+  }, { /* evex_W_ext 169 */
+    {OP_vptestmd, 0x66382718, "vptestmd", KPw, xx, KEw, He, We, mrm|evex, x, END_LIST},
+    {OP_vptestmq, 0x66382758, "vptestmq", KPb, xx, KEb, He, We, mrm|evex, x, END_LIST},
+  }, { /* evex_W_ext 170 */
+    {OP_vptestnmb, 0xf3382618, "vptestnmb", KPq, xx, KEq, He, We, mrm|evex, x, END_LIST},
+    {OP_vptestnmw, 0xf3382658, "vptestnmw", KPd, xx, KEd, He, We, mrm|evex, x, END_LIST},
+  }, { /* evex_W_ext 171 */
+    {OP_vptestnmd, 0xf3382718, "vptestnmd", KPw, xx, KEw, He, We, mrm|evex, x, END_LIST},
+    {OP_vptestnmq, 0xf3382758, "vptestnmq", KPb, xx, KEb, He, We, mrm|evex, x, END_LIST},
   },
 };
 
@@ -8934,6 +9068,18 @@ const instr_info_t extra_operands[] =
     {OP_CONTD, 0x663a4358, "vshufi64x2 cont'd", xx, xx, Wfd, xx, xx, evex|mrm, x, END_LIST},
     /* 100 */
     {OP_CONTD, 0x663a0f18, "vpalignr cont'd", xx, xx, We, xx, xx, mrm|evex, x, END_LIST},
+    {OP_CONTD, 0x663a0318, "valignd cont'd", xx, xx, We, xx, xx, mrm|evex|reqp, x, END_LIST},
+    /* 102 */
+    {OP_CONTD, 0x663a0358, "valignq cont'd", xx, xx, We, xx, xx, mrm|evex|reqp, x, END_LIST},
+    {OP_CONTD, 0x663a5418, "vfixupimmps cont'd", xx, xx, We, xx, xx, mrm|evex|reqp, x, END_LIST},
+    /* 104 */
+    {OP_CONTD, 0x663a5458, "vfixupimmpd cont'd", xx, xx, We, xx, xx, mrm|evex|reqp, x, END_LIST},
+    {OP_CONTD, 0x663a5518, "vfixupimmss cont'd", xx, xx, Wd_dq, xx, xx, mrm|evex|reqp, x, END_LIST},
+    /* 106 */
+    {OP_CONTD, 0x663a5558, "vfixupimmsd cont'd", xx, xx, Wq_dq, xx, xx, mrm|evex|reqp, x, END_LIST},
+    {OP_CONTD, 0x663a2718, "vgetmantss cont'd", xx, xx, Wd_dq, xx, xx, mrm|evex|reqp, x, END_LIST},
+    /* 108 */
+    {OP_CONTD, 0x663a2758, "vgetmantsd cont'd", xx, xx, Wq_dq, xx, xx, mrm|evex|reqp, x, END_LIST},
 };
 
 /* clang-format on */

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -1789,6 +1789,10 @@
     instr_create_1dst_3src((dc), OP_vpshufd, (d), (k), (i), (s))
 #define INSTR_CREATE_vpshuflw_mask(dc, d, k, i, s) \
     instr_create_1dst_3src((dc), OP_vpshuflw, (d), (k), (i), (s))
+#define INSTR_CREATE_vgetmantps_mask(dc, d, k, i, s) \
+    instr_create_1dst_3src((dc), OP_vgetmantps, (d), (k), (i), (s))
+#define INSTR_CREATE_vgetmantpd_mask(dc, d, k, i, s) \
+    instr_create_1dst_3src((dc), OP_vgetmantpd, (d), (k), (i), (s))
 /* @} */ /* end doxygen group */
 
 /** @name 1 destination, 2 non-immediate sources */
@@ -2494,6 +2498,26 @@
     instr_create_1dst_2src((dc), OP_vbroadcasti32x8, (d), (k), (s))
 #define INSTR_CREATE_vbroadcasti64x4_mask(dc, d, k, s) \
     instr_create_1dst_2src((dc), OP_vbroadcasti64x4, (d), (k), (s))
+#define INSTR_CREATE_vcompressps_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vcompressps, (d), (k), (s))
+#define INSTR_CREATE_vcompresspd_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vcompresspd, (d), (k), (s))
+#define INSTR_CREATE_vexpandps_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vexpandps, (d), (k), (s))
+#define INSTR_CREATE_vexpandpd_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vexpandpd, (d), (k), (s))
+#define INSTR_CREATE_vgetexpps_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vgetexpps, (d), (k), (s))
+#define INSTR_CREATE_vgetexppd_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vgetexppd, (d), (k), (s))
+#define INSTR_CREATE_vpcompressd_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vpcompressd, (d), (k), (s))
+#define INSTR_CREATE_vpcompressq_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vpcompressq, (d), (k), (s))
+#define INSTR_CREATE_vpexpandd_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vpexpandd, (d), (k), (s))
+#define INSTR_CREATE_vpexpandq_mask(dc, d, k, s) \
+    instr_create_1dst_2src((dc), OP_vpexpandq, (d), (k), (s))
 /* @} */ /* end doxygen group */
 
 /* 1 destination, 2 sources: 1 explicit, 1 implicit */
@@ -3522,6 +3546,38 @@
     instr_create_1dst_3src((dc), OP_vpavgb, (d), (k), (s1), (s2))
 #define INSTR_CREATE_vpavgw_mask(dc, d, k, s1, s2) \
     instr_create_1dst_3src((dc), OP_vpavgw, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vblendmps_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vblendmps, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vblendmpd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vblendmpd, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vgetexpss_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vgetexpss, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vgetexpsd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vgetexpsd, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vpblendmb_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vpblendmb, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vpblendmw_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vpblendmw, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vpblendmd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vpblendmd, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vpblendmq_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vpblendmq, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vptestmb_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vptestmb, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vptestmw_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vptestmw, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vptestmd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vptestmd, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vptestmq_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vptestmq, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vptestnmb_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vptestnmb, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vptestnmw_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vptestnmw, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vptestnmd_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vptestnmd, (d), (k), (s1), (s2))
+#define INSTR_CREATE_vptestnmq_mask(dc, d, k, s1, s2) \
+    instr_create_1dst_3src((dc), OP_vptestnmq, (d), (k), (s1), (s2))
 /* @} */ /* end doxygen group */
 
 /** @name 1 destination, 3 sources including one immediate */
@@ -4106,6 +4162,22 @@
     instr_create_1dst_4src((dc), OP_vshufi64x2, (d), (k), (i), (s1), (s2))
 #define INSTR_CREATE_vpalignr_mask(dc, d, k, i, s1, s2) \
     instr_create_1dst_4src((dc), OP_vpalignr, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_valignd_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_valignd, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_valignq_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_valignq, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vfixupimmps_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfixupimmps, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vfixupimmpd_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfixupimmpd, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vfixupimmss_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfixupimmss, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vfixupimmsd_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vfixupimmsd, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vgetmantss_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vgetmantss, (d), (k), (i), (s1), (s2))
+#define INSTR_CREATE_vgetmantsd_mask(dc, d, k, i, s1, s2) \
+    instr_create_1dst_4src((dc), OP_vgetmantsd, (d), (k), (i), (s1), (s2))
 /* @} */ /* end doxygen group */
 
 /** @name 1 destination, 3 sources where 2 are implicit */

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1324,150 +1324,186 @@ enum {
      * AVX-512 instructions are being added to DynamoRIO. Users are advised
      * not to rely on the numerical value until i#1312 has been completed.
      */
-    /* 1158 */ OP_vbroadcastf32x2, /**< IA-32/AMD64 AVX-512 OP_vbroadcastf32x2 opcode. */
-    /* 1159 */ OP_vbroadcastf32x4, /**< IA-32/AMD64 AVX-512 OP_vbroadcastf32x4 opcode. */
-    /* 1160 */ OP_vbroadcastf64x2, /**< IA-32/AMD64 AVX-512 OP_vbroadcastf64x2 opcode. */
-    /* 1161 */ OP_vbroadcastf32x8, /**< IA-32/AMD64 AVX-512 OP_vbroadcastf32x8 opcode. */
-    /* 1162 */ OP_vbroadcastf64x4, /**< IA-32/AMD64 AVX-512 OP_vbroadcastf64x4 opcode. */
-    /* 1163 */ OP_vbroadcasti32x2, /**< IA-32/AMD64 AVX-512 OP_vbroadcasti32x2 opcode. */
-    /* 1164 */ OP_vbroadcasti32x4, /**< IA-32/AMD64 AVX-512 OP_vbroadcasti32x4 opcode. */
-    /* 1165 */ OP_vbroadcasti64x2, /**< IA-32/AMD64 AVX-512 OP_vbroadcasti64x2 opcode. */
-    /* 1166 */ OP_vbroadcasti32x8, /**< IA-32/AMD64 AVX-512 OP_vbroadcasti32x8 opcode. */
-    /* 1167 */ OP_vbroadcasti64x4, /**< IA-32/AMD64 AVX-512 OP_vbroadcasti64x4 opcode. */
-    /* 1168 */ OP_vcvtpd2qq,       /**< IA-32/AMD64 AVX-512 OP_vcvtpd2qq opcode. */
-    /* 1169 */ OP_vcvtpd2udq,      /**< IA-32/AMD64 AVX-512 OP_vcvtpd2udq opcode. */
-    /* 1170 */ OP_vcvtpd2uqq,      /**< IA-32/AMD64 AVX-512 OP_vcvtpd2uqq opcode. */
-    /* 1171 */ OP_vcvtps2qq,       /**< IA-32/AMD64 AVX-512 OP_vcvtps2qq opcode. */
-    /* 1172 */ OP_vcvtps2udq,      /**< IA-32/AMD64 AVX-512 OP_vcvtps2udq opcode. */
-    /* 1173 */ OP_vcvtps2uqq,      /**< IA-32/AMD64 AVX-512 OP_vcvtps2uqq opcode. */
-    /* 1174 */ OP_vcvtqq2pd,       /**< IA-32/AMD64 AVX-512 OP_vcvtqq2pd opcode. */
-    /* 1175 */ OP_vcvtqq2ps,       /**< IA-32/AMD64 AVX-512 OP_vcvtqq2ps opcode. */
-    /* 1176 */ OP_vcvtsd2usi,      /**< IA-32/AMD64 AVX-512 OP_vcvtsd2usi opcode. */
-    /* 1177 */ OP_vcvtss2usi,      /**< IA-32/AMD64 AVX-512 OP_vcvtss2usi opcode. */
-    /* 1178 */ OP_vcvttpd2qq,      /**< IA-32/AMD64 AVX-512 OP_vcvttpd2qq opcode. */
-    /* 1179 */ OP_vcvttpd2udq,     /**< IA-32/AMD64 AVX-512 OP_vcvttpd2udq opcode. */
-    /* 1180 */ OP_vcvttpd2uqq,     /**< IA-32/AMD64 AVX-512 OP_vcvttpd2uqq opcode. */
-    /* 1181 */ OP_vcvttps2qq,      /**< IA-32/AMD64 AVX-512 OP_vcvttps2qq opcode. */
-    /* 1182 */ OP_vcvttps2udq,     /**< IA-32/AMD64 AVX-512 OP_vcvttps2udq opcode. */
-    /* 1183 */ OP_vcvttps2uqq,     /**< IA-32/AMD64 AVX-512 OP_vcvttps2uqq opcode. */
-    /* 1184 */ OP_vcvttsd2usi,     /**< IA-32/AMD64 AVX-512 OP_vcvttsd2usi opcode. */
-    /* 1185 */ OP_vcvttss2usi,     /**< IA-32/AMD64 AVX-512 OP_vcvttss2usi opcode. */
-    /* 1186 */ OP_vcvtudq2pd,      /**< IA-32/AMD64 AVX-512 OP_vcvtudq2pd opcode. */
-    /* 1187 */ OP_vcvtudq2ps,      /**< IA-32/AMD64 AVX-512 OP_vcvtudq2ps opcode. */
-    /* 1188 */ OP_vcvtuqq2pd,      /**< IA-32/AMD64 AVX-512 OP_vcvtuqq2pd opcode. */
-    /* 1189 */ OP_vcvtuqq2ps,      /**< IA-32/AMD64 AVX-512 OP_vcvtuqq2ps opcode. */
-    /* 1190 */ OP_vcvtusi2sd,      /**< IA-32/AMD64 AVX-512 OP_vcvtusi2sd opcode. */
-    /* 1191 */ OP_vcvtusi2ss,      /**< IA-32/AMD64 AVX-512 OP_vcvtusi2ss opcode. */
-    /* 1192 */ OP_vextractf32x4,   /**< IA-32/AMD64 AVX-512 OP_vextractf32x4 opcode. */
-    /* 1193 */ OP_vextractf32x8,   /**< IA-32/AMD64 AVX-512 OP_vextractf32x8 opcode. */
-    /* 1194 */ OP_vextractf64x2,   /**< IA-32/AMD64 AVX-512 OP_vextractf64x2 opcode. */
-    /* 1195 */ OP_vextractf64x4,   /**< IA-32/AMD64 AVX-512 OP_vextractf64x4 opcode. */
-    /* 1196 */ OP_vextracti32x4,   /**< IA-32/AMD64 AVX-512 OP_vextracti32x4 opcode. */
-    /* 1197 */ OP_vextracti32x8,   /**< IA-32/AMD64 AVX-512 OP_vextracti32x8 opcode. */
-    /* 1198 */ OP_vextracti64x2,   /**< IA-32/AMD64 AVX-512 OP_vextracti64x2 opcode. */
-    /* 1199 */ OP_vextracti64x4,   /**< IA-32/AMD64 AVX-512 OP_vextracti64x4 opcode. */
-    /* 1200 */ OP_vinsertf32x4,    /**< IA-32/AMD64 AVX-512 OP_vinsertf32x4 opcode. */
-    /* 1201 */ OP_vinsertf32x8,    /**< IA-32/AMD64 AVX-512 OP_vinsertf32x8 opcode. */
-    /* 1202 */ OP_vinsertf64x2,    /**< IA-32/AMD64 AVX-512 OP_vinsertf64x2 opcode. */
-    /* 1203 */ OP_vinsertf64x4,    /**< IA-32/AMD64 AVX-512 OP_vinsertf64x4 opcode. */
-    /* 1204 */ OP_vinserti32x4,    /**< IA-32/AMD64 AVX-512 OP_vinserti32x4 opcode. */
-    /* 1205 */ OP_vinserti32x8,    /**< IA-32/AMD64 AVX-512 OP_vinserti32x8 opcode. */
-    /* 1206 */ OP_vinserti64x2,    /**< IA-32/AMD64 AVX-512 OP_vinserti64x2 opcode. */
-    /* 1207 */ OP_vinserti64x4,    /**< IA-32/AMD64 AVX-512 OP_vinserti64x4 opcode. */
-    /* 1208 */ OP_vmovdqa32,       /**< IA-32/AMD64 AVX-512 OP_vmovdqa32 opcode. */
-    /* 1209 */ OP_vmovdqa64,       /**< IA-32/AMD64 AVX-512 OP_vmovdqa64 opcode. */
-    /* 1210 */ OP_vmovdqu16,       /**< IA-32/AMD64 AVX-512 OP_vmovdqu16 opcode. */
-    /* 1211 */ OP_vmovdqu32,       /**< IA-32/AMD64 AVX-512 OP_vmovdqu32 opcode. */
-    /* 1212 */ OP_vmovdqu64,       /**< IA-32/AMD64 AVX-512 OP_vmovdqu64 opcode. */
-    /* 1213 */ OP_vmovdqu8,        /**< IA-32/AMD64 AVX-512 OP_vmovdqu8 opcode. */
-    /* 1214 */ OP_vpabsq,          /**< IA-32/AMD64 AVX-512 OP_vpabsq opcode. */
-    /* 1215 */ OP_vpandd,          /**< IA-32/AMD64 AVX-512 OP_vpandd opcode. */
-    /* 1216 */ OP_vpandnd,         /**< IA-32/AMD64 AVX-512 OP_vpandnd opcode. */
-    /* 1217 */ OP_vpandnq,         /**< IA-32/AMD64 AVX-512 OP_vpandnq opcode. */
-    /* 1218 */ OP_vpandq,          /**< IA-32/AMD64 AVX-512 OP_vpandq opcode. */
-    /* 1219 */ OP_vpcmpb,          /**< IA-32/AMD64 AVX-512 OP_vpcmpb opcode. */
-    /* 1220 */ OP_vpcmpd,          /**< IA-32/AMD64 AVX-512 OP_vpcmpd opcode. */
-    /* 1221 */ OP_vpcmpq,          /**< IA-32/AMD64 AVX-512 OP_vpcmpq opcode. */
-    /* 1222 */ OP_vpcmpw,          /**< IA-32/AMD64 AVX-512 OP_vpcmpw opcode. */
-    /* 1223 */ OP_vpcmpub,         /**< IA-32/AMD64 AVX-512 OP_vpcmpub opcode. */
-    /* 1224 */ OP_vpcmpud,         /**< IA-32/AMD64 AVX-512 OP_vpcmpud opcode. */
-    /* 1225 */ OP_vpcmpuq,         /**< IA-32/AMD64 AVX-512 OP_vpcmpuq opcode. */
-    /* 1226 */ OP_vpcmpuw,         /**< IA-32/AMD64 AVX-512 OP_vpcmpuw opcode. */
-    /* 1227 */ OP_vpermi2b,        /**< IA-32/AMD64 AVX-512 OP_vpermi2b opcode. */
-    /* 1228 */ OP_vpermi2d,        /**< IA-32/AMD64 AVX-512 OP_vpermi2d opcode. */
-    /* 1229 */ OP_vpermi2pd,       /**< IA-32/AMD64 AVX-512 OP_vpermi2pd opcode. */
-    /* 1230 */ OP_vpermi2ps,       /**< IA-32/AMD64 AVX-512 OP_vpermi2ps opcode. */
-    /* 1231 */ OP_vpermi2q,        /**< IA-32/AMD64 AVX-512 OP_vpermi2q opcode. */
-    /* 1232 */ OP_vpermi2w,        /**< IA-32/AMD64 AVX-512 OP_vpermi2w opcode. */
-    /* 1233 */ OP_vpermt2b,        /**< IA-32/AMD64 AVX-512 OP_vpermt2b opcode. */
-    /* 1234 */ OP_vpermt2d,        /**< IA-32/AMD64 AVX-512 OP_vpermt2d opcode. */
-    /* 1235 */ OP_vpermt2pd,       /**< IA-32/AMD64 AVX-512 OP_vpermt2pd opcode. */
-    /* 1236 */ OP_vpermt2ps,       /**< IA-32/AMD64 AVX-512 OP_vpermt2ps opcode. */
-    /* 1237 */ OP_vpermt2q,        /**< IA-32/AMD64 AVX-512 OP_vpermt2q opcode. */
-    /* 1238 */ OP_vpermt2w,        /**< IA-32/AMD64 AVX-512 OP_vpermt2w opcode. */
-    /* 1239 */ OP_vpermw,          /**< IA-32/AMD64 AVX-512 OP_vpermw opcode. */
-    /* 1240 */ OP_vpextrq,         /**< IA-32/AMD64 AVX-512 OP_vpextrq opcode. */
-    /* 1241 */ OP_vpinsrq,         /**< IA-32/AMD64 AVX-512 OP_vpinsrq opcode. */
-    /* 1242 */ OP_vpmaxsq,         /**< IA-32/AMD64 vpmaxsq opcode. */
-    /* 1243 */ OP_vpmaxuq,         /**< IA-32/AMD64 vpmaxuq opcode. */
-    /* 1244 */ OP_vpminsq,         /**< IA-32/AMD64 vpminsq opcode. */
-    /* 1245 */ OP_vpminuq,         /**< IA-32/AMD64 vpminuq opcode. */
-    /* 1246 */ OP_vpmovb2m,        /**< IA-32/AMD64 vpmovb2m opcode. */
-    /* 1247 */ OP_vpmovd2m,        /**< IA-32/AMD64 vpmovd2m opcode. */
-    /* 1248 */ OP_vpmovdb,         /**< IA-32/AMD64 vpmovdb opcode. */
-    /* 1249 */ OP_vpmovdw,         /**< IA-32/AMD64 vpmovdw opcode. */
-    /* 1250 */ OP_vpmovm2b,        /**< IA-32/AMD64 vpmovm2b opcode. */
-    /* 1251 */ OP_vpmovm2w,        /**< IA-32/AMD64 vpmovm2w opcode. */
-    /* 1252 */ OP_vpmovm2d,        /**< IA-32/AMD64 vpmovm2d opcode. */
-    /* 1253 */ OP_vpmovm2q,        /**< IA-32/AMD64 vpmovm2q opcode. */
-    /* 1254 */ OP_vpmovq2m,        /**< IA-32/AMD64 vpmovq2m opcode. */
-    /* 1255 */ OP_vpmovqb,         /**< IA-32/AMD64 vpmovqb opcode. */
-    /* 1256 */ OP_vpmovqd,         /**< IA-32/AMD64 vpmovqd opcode. */
-    /* 1257 */ OP_vpmovqw,         /**< IA-32/AMD64 vpmovqw opcode. */
-    /* 1258 */ OP_vpmovsdb,        /**< IA-32/AMD64 vpmovsdb opcode. */
-    /* 1259 */ OP_vpmovsdw,        /**< IA-32/AMD64 vpmovsdw opcode. */
-    /* 1260 */ OP_vpmovsqb,        /**< IA-32/AMD64 vpmovsqb opcode. */
-    /* 1261 */ OP_vpmovsqd,        /**< IA-32/AMD64 vpmovsqd opcode. */
-    /* 1262 */ OP_vpmovsqw,        /**< IA-32/AMD64 vpmovsqw opcode. */
-    /* 1263 */ OP_vpmovswb,        /**< IA-32/AMD64 vpmovswb opcode. */
-    /* 1264 */ OP_vpmovusdb,       /**< IA-32/AMD64 vpmovusdb opcode. */
-    /* 1265 */ OP_vpmovusdw,       /**< IA-32/AMD64 vpmovusdw opcode. */
-    /* 1266 */ OP_vpmovusqb,       /**< IA-32/AMD64 vpmovusqb opcode. */
-    /* 1267 */ OP_vpmovusqd,       /**< IA-32/AMD64 vpmovusqd opcode. */
-    /* 1268 */ OP_vpmovusqw,       /**< IA-32/AMD64 vpmovusqw opcode. */
-    /* 1269 */ OP_vpmovuswb,       /**< IA-32/AMD64 vpmovuswb opcode. */
-    /* 1270 */ OP_vpmovw2m,        /**< IA-32/AMD64 vpmovw2m opcode. */
-    /* 1271 */ OP_vpmovwb,         /**< IA-32/AMD64 vpmovwb opcode. */
-    /* 1272 */ OP_vpmullq,         /**< IA-32/AMD64 AVX-512 OP_vpmullq opcode. */
-    /* 1273 */ OP_vpord,           /**< IA-32/AMD64 AVX-512 OP_vpord opcode. */
-    /* 1274 */ OP_vporq,           /**< IA-32/AMD64 AVX-512 OP_vporq opcode. */
-    /* 1275 */ OP_vprold,          /**< IA-32/AMD64 AVX-512 OP_vprold opcode. */
-    /* 1276 */ OP_vprolq,          /**< IA-32/AMD64 AVX-512 OP_vprolq opcode. */
-    /* 1277 */ OP_vprolvd,         /**< IA-32/AMD64 AVX-512 OP_vprolvd opcode. */
-    /* 1278 */ OP_vprolvq,         /**< IA-32/AMD64 AVX-512 OP_vprolvq opcode. */
-    /* 1279 */ OP_vprord,          /**< IA-32/AMD64 AVX-512 OP_vprord opcode. */
-    /* 1280 */ OP_vprorq,          /**< IA-32/AMD64 AVX-512 OP_vprorq opcode. */
-    /* 1281 */ OP_vprorvd,         /**< IA-32/AMD64 AVX-512 OP_vprorvd opcode. */
-    /* 1282 */ OP_vprorvq,         /**< IA-32/AMD64 AVX-512 OP_vprorvq opcode. */
-    /* 1283 */ OP_vpsllvw,         /**< IA-32/AMD64 AVX-512 OP_vpsllvw opcode. */
-    /* 1284 */ OP_vpsraq,          /**< IA-32/AMD64 AVX-512 OP_vpsraq opcode. */
-    /* 1285 */ OP_vpsravw,         /**< IA-32/AMD64 vpsravw opcode. */
-    /* 1286 */ OP_vpsravq,         /**< IA-32/AMD64 vpsravq opcode. */
-    /* 1287 */ OP_vpsrlvw,         /**< IA-32/AMD64 vpsrlvw opcode. */
-    /* 1288 */ OP_vpxord,          /**< IA-32/AMD64 AVX-512 OP_vpxord opcode. */
-    /* 1289 */ OP_vpxorq,          /**< IA-32/AMD64 AVX-512 OP_vpxorq opcode. */
-    /* 1290 */ OP_vrcp14ps,        /**< IA-32/AMD64 AVX-512 OP_vrcp14ps opcode. */
-    /* 1291 */ OP_vrcp14pd,        /**< IA-32/AMD64 AVX-512 OP_vrcp14pd opcode. */
-    /* 1292 */ OP_vrcp14ss,        /**< IA-32/AMD64 AVX-512 OP_vrcp14ss opcode. */
-    /* 1293 */ OP_vrcp14sd,        /**< IA-32/AMD64 AVX-512 OP_vrcp14sd opcode. */
-    /* 1294 */ OP_vrcp28ps,        /**< IA-32/AMD64 AVX-512 OP_vrcp28ps opcode. */
-    /* 1295 */ OP_vrcp28pd,        /**< IA-32/AMD64 AVX-512 OP_vrcp28pd opcode. */
-    /* 1296 */ OP_vrcp28ss,        /**< IA-32/AMD64 AVX-512 OP_vrcp28ss opcode. */
-    /* 1297 */ OP_vrcp28sd,        /**< IA-32/AMD64 AVX-512 OP_vrcp28sd opcode. */
-    /* 1298 */ OP_vshuff32x4,      /**< IA-32/AMD64 AVX-512 OP_vshuff32x4 opcode. */
-    /* 1299 */ OP_vshuff64x2,      /**< IA-32/AMD64 AVX-512 OP_vshuff64x2 opcode. */
-    /* 1301 */ OP_vshufi32x4,      /**< IA-32/AMD64 AVX-512 OP_vshufi32x4 opcode. */
-    /* 1302 */ OP_vshufi64x2,      /**< IA-32/AMD64 AVX-512 OP_vshufi64x2 opcode. */
+    /* 1158 */ OP_valignd,         /**< IA-32/AMD64 AVX-512 OP_valignd opcode. */
+    /* 1159 */ OP_valignq,         /**< IA-32/AMD64 AVX-512 OP_valignq opcode. */
+    /* 1160 */ OP_vblendmpd,       /**< IA-32/AMD64 AVX-512 OP_vblendmpd opcode. */
+    /* 1161 */ OP_vblendmps,       /**< IA-32/AMD64 AVX-512 OP_vblendmps opcode. */
+    /* 1162 */ OP_vbroadcastf32x2, /**< IA-32/AMD64 AVX-512 OP_vbroadcastf32x2 opcode. */
+    /* 1163 */ OP_vbroadcastf32x4, /**< IA-32/AMD64 AVX-512 OP_vbroadcastf32x4 opcode. */
+    /* 1164 */ OP_vbroadcastf32x8, /**< IA-32/AMD64 AVX-512 OP_vbroadcastf32x8 opcode. */
+    /* 1165 */ OP_vbroadcastf64x2, /**< IA-32/AMD64 AVX-512 OP_vbroadcastf64x2 opcode. */
+    /* 1166 */ OP_vbroadcastf64x4, /**< IA-32/AMD64 AVX-512 OP_vbroadcastf64x4 opcode. */
+    /* 1167 */ OP_vbroadcasti32x2, /**< IA-32/AMD64 AVX-512 OP_vbroadcasti32x2 opcode. */
+    /* 1168 */ OP_vbroadcasti32x4, /**< IA-32/AMD64 AVX-512 OP_vbroadcasti32x4 opcode. */
+    /* 1169 */ OP_vbroadcasti32x8, /**< IA-32/AMD64 AVX-512 OP_vbroadcasti32x8 opcode. */
+    /* 1170 */ OP_vbroadcasti64x2, /**< IA-32/AMD64 AVX-512 OP_vbroadcasti64x2 opcode. */
+    /* 1171 */ OP_vbroadcasti64x4, /**< IA-32/AMD64 AVX-512 OP_vbroadcasti64x4 opcode. */
+    /* 1172 */ OP_vcompresspd,     /**< IA-32/AMD64 AVX-512 OP_vcompresspd opcode. */
+    /* 1173 */ OP_vcompressps,     /**< IA-32/AMD64 AVX-512 OP_vcompressps opcode. */
+    /* 1174 */ OP_vcvtpd2qq,       /**< IA-32/AMD64 AVX-512 OP_vcvtpd2qq opcode. */
+    /* 1175 */ OP_vcvtpd2udq,      /**< IA-32/AMD64 AVX-512 OP_vcvtpd2udq opcode. */
+    /* 1176 */ OP_vcvtpd2uqq,      /**< IA-32/AMD64 AVX-512 OP_vcvtpd2uqq opcode. */
+    /* 1177 */ OP_vcvtps2qq,       /**< IA-32/AMD64 AVX-512 OP_vcvtps2qq opcode. */
+    /* 1178 */ OP_vcvtps2udq,      /**< IA-32/AMD64 AVX-512 OP_vcvtps2udq opcode. */
+    /* 1179 */ OP_vcvtps2uqq,      /**< IA-32/AMD64 AVX-512 OP_vcvtps2uqq opcode. */
+    /* 1180 */ OP_vcvtqq2pd,       /**< IA-32/AMD64 AVX-512 OP_vcvtqq2pd opcode. */
+    /* 1181 */ OP_vcvtqq2ps,       /**< IA-32/AMD64 AVX-512 OP_vcvtqq2ps opcode. */
+    /* 1182 */ OP_vcvtsd2usi,      /**< IA-32/AMD64 AVX-512 OP_vcvtsd2usi opcode. */
+    /* 1183 */ OP_vcvtss2usi,      /**< IA-32/AMD64 AVX-512 OP_vcvtss2usi opcode. */
+    /* 1184 */ OP_vcvttpd2qq,      /**< IA-32/AMD64 AVX-512 OP_vcvttpd2qq opcode. */
+    /* 1185 */ OP_vcvttpd2udq,     /**< IA-32/AMD64 AVX-512 OP_vcvttpd2udq opcode. */
+    /* 1186 */ OP_vcvttpd2uqq,     /**< IA-32/AMD64 AVX-512 OP_vcvttpd2uqq opcode. */
+    /* 1187 */ OP_vcvttps2qq,      /**< IA-32/AMD64 AVX-512 OP_vcvttps2qq opcode. */
+    /* 1188 */ OP_vcvttps2udq,     /**< IA-32/AMD64 AVX-512 OP_vcvttps2udq opcode. */
+    /* 1189 */ OP_vcvttps2uqq,     /**< IA-32/AMD64 AVX-512 OP_vcvttps2uqq opcode. */
+    /* 1190 */ OP_vcvttsd2usi,     /**< IA-32/AMD64 AVX-512 OP_vcvttsd2usi opcode. */
+    /* 1191 */ OP_vcvttss2usi,     /**< IA-32/AMD64 AVX-512 OP_vcvttss2usi opcode. */
+    /* 1192 */ OP_vcvtudq2pd,      /**< IA-32/AMD64 AVX-512 OP_vcvtudq2pd opcode. */
+    /* 1193 */ OP_vcvtudq2ps,      /**< IA-32/AMD64 AVX-512 OP_vcvtudq2ps opcode. */
+    /* 1194 */ OP_vcvtuqq2pd,      /**< IA-32/AMD64 AVX-512 OP_vcvtuqq2pd opcode. */
+    /* 1195 */ OP_vcvtuqq2ps,      /**< IA-32/AMD64 AVX-512 OP_vcvtuqq2ps opcode. */
+    /* 1196 */ OP_vcvtusi2sd,      /**< IA-32/AMD64 AVX-512 OP_vcvtusi2sd opcode. */
+    /* 1197 */ OP_vcvtusi2ss,      /**< IA-32/AMD64 AVX-512 OP_vcvtusi2ss opcode. */
+    /* 1198 */ OP_vexpandpd,       /**< IA-32/AMD64 AVX-512 OP_vexpandpd opcode. */
+    /* 1199 */ OP_vexpandps,       /**< IA-32/AMD64 AVX-512 OP_vexpandps opcode. */
+    /* 1200 */ OP_vextractf32x4,   /**< IA-32/AMD64 AVX-512 OP_vextractf32x4 opcode. */
+    /* 1201 */ OP_vextractf32x8,   /**< IA-32/AMD64 AVX-512 OP_vextractf32x8 opcode. */
+    /* 1202 */ OP_vextractf64x2,   /**< IA-32/AMD64 AVX-512 OP_vextractf64x2 opcode. */
+    /* 1203 */ OP_vextractf64x4,   /**< IA-32/AMD64 AVX-512 OP_vextractf64x4 opcode. */
+    /* 1204 */ OP_vextracti32x4,   /**< IA-32/AMD64 AVX-512 OP_vextracti32x4 opcode. */
+    /* 1205 */ OP_vextracti32x8,   /**< IA-32/AMD64 AVX-512 OP_vextracti32x8 opcode. */
+    /* 1206 */ OP_vextracti64x2,   /**< IA-32/AMD64 AVX-512 OP_vextracti64x2 opcode. */
+    /* 1207 */ OP_vextracti64x4,   /**< IA-32/AMD64 AVX-512 OP_vextracti64x4 opcode. */
+    /* 1208 */ OP_vfixupimmpd,     /**< IA-32/AMD64 AVX-512 OP_vfixupimmpd opcode. */
+    /* 1209 */ OP_vfixupimmps,     /**< IA-32/AMD64 AVX-512 OP_vfixupimmps opcode. */
+    /* 1210 */ OP_vfixupimmsd,     /**< IA-32/AMD64 AVX-512 OP_vfixupimmsd opcode. */
+    /* 1211 */ OP_vfixupimmss,     /**< IA-32/AMD64 AVX-512 OP_vfixupimmss opcode. */
+    /* 1212 */ OP_vgetexppd,       /**< IA-32/AMD64 AVX-512 OP_vgetexppd opcode. */
+    /* 1213 */ OP_vgetexpps,       /**< IA-32/AMD64 AVX-512 OP_vgetexpps opcode. */
+    /* 1214 */ OP_vgetexpsd,       /**< IA-32/AMD64 AVX-512 OP_vgetexpsd opcode. */
+    /* 1215 */ OP_vgetexpss,       /**< IA-32/AMD64 AVX-512 OP_vgetexpss opcode. */
+    /* 1216 */ OP_vgetmantpd,      /**< IA-32/AMD64 AVX-512 OP_vgetmantpd opcode. */
+    /* 1217 */ OP_vgetmantps,      /**< IA-32/AMD64 AVX-512 OP_vgetmantps opcode. */
+    /* 1218 */ OP_vgetmantsd,      /**< IA-32/AMD64 AVX-512 OP_vgetmantsd opcode. */
+    /* 1219 */ OP_vgetmantss,      /**< IA-32/AMD64 AVX-512 OP_vgetmantss opcode. */
+    /* 1220 */ OP_vinsertf32x4,    /**< IA-32/AMD64 AVX-512 OP_vinsertf32x4 opcode. */
+    /* 1221 */ OP_vinsertf32x8,    /**< IA-32/AMD64 AVX-512 OP_vinsertf32x8 opcode. */
+    /* 1222 */ OP_vinsertf64x2,    /**< IA-32/AMD64 AVX-512 OP_vinsertf64x2 opcode. */
+    /* 1223 */ OP_vinsertf64x4,    /**< IA-32/AMD64 AVX-512 OP_vinsertf64x4 opcode. */
+    /* 1224 */ OP_vinserti32x4,    /**< IA-32/AMD64 AVX-512 OP_vinserti32x4 opcode. */
+    /* 1225 */ OP_vinserti32x8,    /**< IA-32/AMD64 AVX-512 OP_vinserti32x8 opcode. */
+    /* 1226 */ OP_vinserti64x2,    /**< IA-32/AMD64 AVX-512 OP_vinserti64x2 opcode. */
+    /* 1227 */ OP_vinserti64x4,    /**< IA-32/AMD64 AVX-512 OP_vinserti64x4 opcode. */
+    /* 1228 */ OP_vmovdqa32,       /**< IA-32/AMD64 AVX-512 OP_vmovdqa32 opcode. */
+    /* 1229 */ OP_vmovdqa64,       /**< IA-32/AMD64 AVX-512 OP_vmovdqa64 opcode. */
+    /* 1230 */ OP_vmovdqu16,       /**< IA-32/AMD64 AVX-512 OP_vmovdqu16 opcode. */
+    /* 1231 */ OP_vmovdqu32,       /**< IA-32/AMD64 AVX-512 OP_vmovdqu32 opcode. */
+    /* 1232 */ OP_vmovdqu64,       /**< IA-32/AMD64 AVX-512 OP_vmovdqu64 opcode. */
+    /* 1233 */ OP_vmovdqu8,        /**< IA-32/AMD64 AVX-512 OP_vmovdqu8 opcode. */
+    /* 1234 */ OP_vpabsq,          /**< IA-32/AMD64 AVX-512 OP_vpabsq opcode. */
+    /* 1235 */ OP_vpandd,          /**< IA-32/AMD64 AVX-512 OP_vpandd opcode. */
+    /* 1236 */ OP_vpandnd,         /**< IA-32/AMD64 AVX-512 OP_vpandnd opcode. */
+    /* 1237 */ OP_vpandnq,         /**< IA-32/AMD64 AVX-512 OP_vpandnq opcode. */
+    /* 1238 */ OP_vpandq,          /**< IA-32/AMD64 AVX-512 OP_vpandq opcode. */
+    /* 1239 */ OP_vpblendmb,       /**< IA-32/AMD64 AVX-512 OP_vpblendmd opcode. */
+    /* 1240 */ OP_vpblendmd,       /**< IA-32/AMD64 AVX-512 OP_vpblendmq opcode. */
+    /* 1241 */ OP_vpblendmq,       /**< IA-32/AMD64 AVX-512 OP_vpblendmd opcode. */
+    /* 1242 */ OP_vpblendmw,       /**< IA-32/AMD64 AVX-512 OP_vpblendmq opcode. */
+    /* 1243 */ OP_vpcmpb,          /**< IA-32/AMD64 AVX-512 OP_vpcmpb opcode. */
+    /* 1244 */ OP_vpcmpd,          /**< IA-32/AMD64 AVX-512 OP_vpcmpd opcode. */
+    /* 1245 */ OP_vpcmpq,          /**< IA-32/AMD64 AVX-512 OP_vpcmpq opcode. */
+    /* 1246 */ OP_vpcmpub,         /**< IA-32/AMD64 AVX-512 OP_vpcmpub opcode. */
+    /* 1247 */ OP_vpcmpud,         /**< IA-32/AMD64 AVX-512 OP_vpcmpud opcode. */
+    /* 1248 */ OP_vpcmpuq,         /**< IA-32/AMD64 AVX-512 OP_vpcmpuq opcode. */
+    /* 1249 */ OP_vpcmpuw,         /**< IA-32/AMD64 AVX-512 OP_vpcmpuw opcode. */
+    /* 1250 */ OP_vpcmpw,          /**< IA-32/AMD64 AVX-512 OP_vpcmpw opcode. */
+    /* 1251 */ OP_vpcompressd,     /**< IA-32/AMD64 AVX-512 OP_vpcompressd opcode. */
+    /* 1252 */ OP_vpcompressq,     /**< IA-32/AMD64 AVX-512 OP_vpcompressq opcode. */
+    /* 1253 */ OP_vpermi2b,        /**< IA-32/AMD64 AVX-512 OP_vpermi2b opcode. */
+    /* 1254 */ OP_vpermi2d,        /**< IA-32/AMD64 AVX-512 OP_vpermi2d opcode. */
+    /* 1255 */ OP_vpermi2pd,       /**< IA-32/AMD64 AVX-512 OP_vpermi2pd opcode. */
+    /* 1256 */ OP_vpermi2ps,       /**< IA-32/AMD64 AVX-512 OP_vpermi2ps opcode. */
+    /* 1257 */ OP_vpermi2q,        /**< IA-32/AMD64 AVX-512 OP_vpermi2q opcode. */
+    /* 1258 */ OP_vpermi2w,        /**< IA-32/AMD64 AVX-512 OP_vpermi2w opcode. */
+    /* 1259 */ OP_vpermt2b,        /**< IA-32/AMD64 AVX-512 OP_vpermt2b opcode. */
+    /* 1260 */ OP_vpermt2d,        /**< IA-32/AMD64 AVX-512 OP_vpermt2d opcode. */
+    /* 1261 */ OP_vpermt2pd,       /**< IA-32/AMD64 AVX-512 OP_vpermt2pd opcode. */
+    /* 1262 */ OP_vpermt2ps,       /**< IA-32/AMD64 AVX-512 OP_vpermt2ps opcode. */
+    /* 1263 */ OP_vpermt2q,        /**< IA-32/AMD64 AVX-512 OP_vpermt2q opcode. */
+    /* 1264 */ OP_vpermt2w,        /**< IA-32/AMD64 AVX-512 OP_vpermt2w opcode. */
+    /* 1265 */ OP_vpermw,          /**< IA-32/AMD64 AVX-512 OP_vpermw opcode. */
+    /* 1266 */ OP_vpexpandd,       /**< IA-32/AMD64 AVX-512 OP_vpexpandd opcode. */
+    /* 1267 */ OP_vpexpandq,       /**< IA-32/AMD64 AVX-512 OP_vpexpandq opcode. */
+    /* 1268 */ OP_vpextrq,         /**< IA-32/AMD64 AVX-512 OP_vpextrq opcode. */
+    /* 1269 */ OP_vpinsrq,         /**< IA-32/AMD64 AVX-512 OP_vpinsrq opcode. */
+    /* 1270 */ OP_vpmaxsq,         /**< IA-32/AMD64 AVX-512 OP_vpmaxsq opcode. */
+    /* 1271 */ OP_vpmaxuq,         /**< IA-32/AMD64 AVX-512 OP_vpmaxuq opcode. */
+    /* 1272 */ OP_vpminsq,         /**< IA-32/AMD64 AVX-512 OP_vpminsq opcode. */
+    /* 1273 */ OP_vpminuq,         /**< IA-32/AMD64 AVX-512 OP_vpminuq opcode. */
+    /* 1274 */ OP_vpmovb2m,        /**< IA-32/AMD64 AVX-512 OP_vpmovb2m opcode. */
+    /* 1275 */ OP_vpmovd2m,        /**< IA-32/AMD64 AVX-512 OP_vpmovd2m opcode. */
+    /* 1276 */ OP_vpmovdb,         /**< IA-32/AMD64 AVX-512 OP_vpmovdb opcode. */
+    /* 1277 */ OP_vpmovdw,         /**< IA-32/AMD64 AVX-512 OP_vpmovdw opcode. */
+    /* 1278 */ OP_vpmovm2b,        /**< IA-32/AMD64 AVX-512 OP_vpmovm2b opcode. */
+    /* 1279 */ OP_vpmovm2d,        /**< IA-32/AMD64 AVX-512 OP_vpmovm2d opcode. */
+    /* 1280 */ OP_vpmovm2q,        /**< IA-32/AMD64 AVX-512 OP_vpmovm2q opcode. */
+    /* 1281 */ OP_vpmovm2w,        /**< IA-32/AMD64 AVX-512 OP_vpmovm2w opcode. */
+    /* 1282 */ OP_vpmovq2m,        /**< IA-32/AMD64 AVX-512 OP_vpmovq2m opcode. */
+    /* 1283 */ OP_vpmovqb,         /**< IA-32/AMD64 AVX-512 OP_vpmovqb opcode. */
+    /* 1284 */ OP_vpmovqd,         /**< IA-32/AMD64 AVX-512 OP_vpmovqd opcode. */
+    /* 1285 */ OP_vpmovqw,         /**< IA-32/AMD64 AVX-512 OP_vpmovqw opcode. */
+    /* 1286 */ OP_vpmovsdb,        /**< IA-32/AMD64 AVX-512 OP_vpmovsdb opcode. */
+    /* 1287 */ OP_vpmovsdw,        /**< IA-32/AMD64 AVX-512 OP_vpmovsdw opcode. */
+    /* 1288 */ OP_vpmovsqb,        /**< IA-32/AMD64 AVX-512 OP_vpmovsqb opcode. */
+    /* 1289 */ OP_vpmovsqd,        /**< IA-32/AMD64 AVX-512 OP_vpmovsqd opcode. */
+    /* 1290 */ OP_vpmovsqw,        /**< IA-32/AMD64 AVX-512 OP_vpmovsqw opcode. */
+    /* 1291 */ OP_vpmovswb,        /**< IA-32/AMD64 AVX-512 OP_vpmovswb opcode. */
+    /* 1292 */ OP_vpmovusdb,       /**< IA-32/AMD64 AVX-512 OP_vpmovusdb opcode. */
+    /* 1293 */ OP_vpmovusdw,       /**< IA-32/AMD64 AVX-512 OP_vpmovusdw opcode. */
+    /* 1294 */ OP_vpmovusqb,       /**< IA-32/AMD64 AVX-512 OP_vpmovusqb opcode. */
+    /* 1295 */ OP_vpmovusqd,       /**< IA-32/AMD64 AVX-512 OP_vpmovusqd opcode. */
+    /* 1296 */ OP_vpmovusqw,       /**< IA-32/AMD64 AVX-512 OP_vpmovusqw opcode. */
+    /* 1297 */ OP_vpmovuswb,       /**< IA-32/AMD64 AVX-512 OP_vpmovuswb opcode. */
+    /* 1298 */ OP_vpmovw2m,        /**< IA-32/AMD64 AVX-512 OP_vpmovw2m opcode. */
+    /* 1299 */ OP_vpmovwb,         /**< IA-32/AMD64 AVX-512 OP_vpmovwb opcode. */
+    /* 1300 */ OP_vpmullq,         /**< IA-32/AMD64 AVX-512 OP_vpmullq opcode. */
+    /* 1301 */ OP_vpord,           /**< IA-32/AMD64 AVX-512 OP_vpord opcode. */
+    /* 1302 */ OP_vporq,           /**< IA-32/AMD64 AVX-512 OP_vporq opcode. */
+    /* 1303 */ OP_vprold,          /**< IA-32/AMD64 AVX-512 OP_vprold opcode. */
+    /* 1304 */ OP_vprolq,          /**< IA-32/AMD64 AVX-512 OP_vprolq opcode. */
+    /* 1305 */ OP_vprolvd,         /**< IA-32/AMD64 AVX-512 OP_vprolvd opcode. */
+    /* 1306 */ OP_vprolvq,         /**< IA-32/AMD64 AVX-512 OP_vprolvq opcode. */
+    /* 1307 */ OP_vprord,          /**< IA-32/AMD64 AVX-512 OP_vprord opcode. */
+    /* 1308 */ OP_vprorq,          /**< IA-32/AMD64 AVX-512 OP_vprorq opcode. */
+    /* 1309 */ OP_vprorvd,         /**< IA-32/AMD64 AVX-512 OP_vprorvd opcode. */
+    /* 1310 */ OP_vprorvq,         /**< IA-32/AMD64 AVX-512 OP_vprorvq opcode. */
+    /* 1311 */ OP_vpsllvw,         /**< IA-32/AMD64 AVX-512 OP_vpsllvw opcode. */
+    /* 1312 */ OP_vpsraq,          /**< IA-32/AMD64 AVX-512 OP_vpsraq opcode. */
+    /* 1313 */ OP_vpsravq,         /**< IA-32/AMD64 AVX-512 OP_vpsravq opcode. */
+    /* 1314 */ OP_vpsravw,         /**< IA-32/AMD64 AVX-512 OP_vpsravw opcode. */
+    /* 1315 */ OP_vpsrlvw,         /**< IA-32/AMD64 AVX-512 OP_vpsrlvw opcode. */
+    /* 1316 */ OP_vptestmb,        /**< IA-32/AMD64 AVX-512 OP_vptestmb opcode. */
+    /* 1317 */ OP_vptestmd,        /**< IA-32/AMD64 AVX-512 OP_vptestmd opcode. */
+    /* 1318 */ OP_vptestmq,        /**< IA-32/AMD64 AVX-512 OP_vptestmq opcode. */
+    /* 1319 */ OP_vptestmw,        /**< IA-32/AMD64 AVX-512 OP_vptestmw opcode. */
+    /* 1320 */ OP_vptestnmb,       /**< IA-32/AMD64 AVX-512 OP_vptestnmb opcode. */
+    /* 1321 */ OP_vptestnmd,       /**< IA-32/AMD64 AVX-512 OP_vptestnmd opcode. */
+    /* 1322 */ OP_vptestnmq,       /**< IA-32/AMD64 AVX-512 OP_vptestnmq opcode. */
+    /* 1323 */ OP_vptestnmw,       /**< IA-32/AMD64 AVX-512 OP_vptestnmw opcode. */
+    /* 1324 */ OP_vpxord,          /**< IA-32/AMD64 AVX-512 OP_vpxordvpxord opcode. */
+    /* 1325 */ OP_vpxorq,          /**< IA-32/AMD64 AVX-512 OP_vpxorq opcode. */
+    /* 1326 */ OP_vrcp14pd,        /**< IA-32/AMD64 AVX-512 OP_vrcp14pd opcode. */
+    /* 1327 */ OP_vrcp14ps,        /**< IA-32/AMD64 AVX-512 OP_vrcp14ps opcode. */
+    /* 1328 */ OP_vrcp14sd,        /**< IA-32/AMD64 AVX-512 OP_vrcp14sd opcode. */
+    /* 1329 */ OP_vrcp14ss,        /**< IA-32/AMD64 AVX-512 OP_vrcp14ss opcode. */
+    /* 1330 */ OP_vrcp28pd,        /**< IA-32/AMD64 AVX-512 OP_vrcp28pd opcode. */
+    /* 1331 */ OP_vrcp28ps,        /**< IA-32/AMD64 AVX-512 OP_vrcp28ps opcode. */
+    /* 1332 */ OP_vrcp28sd,        /**< IA-32/AMD64 AVX-512 OP_vrcp28sd opcode. */
+    /* 1333 */ OP_vrcp28ss,        /**< IA-32/AMD64 AVX-512 OP_vrcp28ss opcode. */
+    /* 1334 */ OP_vshuff32x4,      /**< IA-32/AMD64 AVX-512 OP_vshuff32x4 opcode. */
+    /* 1335 */ OP_vshuff64x2,      /**< IA-32/AMD64 AVX-512 OP_vshuff64x2 opcode. */
+    /* 1336 */ OP_vshufi32x4,      /**< IA-32/AMD64 AVX-512 OP_vshufi32x4 opcode. */
+    /* 1337 */ OP_vshufi64x2,      /**< IA-32/AMD64 AVX-512 OP_vshufi64x2 opcode. */
 
     OP_AFTER_LAST,
     OP_FIRST = OP_add,           /**< First real opcode. */

--- a/suite/tests/api/ir_x86_3args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_3args_avx512_evex_mask.h
@@ -2103,3 +2103,184 @@ OPCODE(vbroadcasti64x4_zlok0ld, vbroadcasti64x4, vbroadcasti64x4_mask, 0, REGARG
        REGARG(K0), MEMARG(OPSZ_32))
 OPCODE(vbroadcasti64x4_zhik7ld, vbroadcasti64x4, vbroadcasti64x4_mask, X64_ONLY,
        REGARG(ZMM16), REGARG(K7), MEMARG(OPSZ_32))
+OPCODE(vcompressps_xlok0st, vcompressps, vcompressps_mask, 0, MEMARG(OPSZ_16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vcompressps_xlok0xlo, vcompressps, vcompressps_mask, 0, REGARG(XMM1), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vcompressps_xhik7xhi, vcompressps, vcompressps_mask, X64_ONLY, REGARG(XMM31),
+       REGARG(K7), REGARG(XMM16))
+OPCODE(vcompressps_ylok0st, vcompressps, vcompressps_mask, 0, MEMARG(OPSZ_32), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vcompressps_ylok0ylo, vcompressps, vcompressps_mask, 0, REGARG(YMM1), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vcompressps_yhik7yhi, vcompressps, vcompressps_mask, X64_ONLY, REGARG(YMM31),
+       REGARG(K7), REGARG(YMM16))
+OPCODE(vcompressps_zlok0st, vcompressps, vcompressps_mask, 0, MEMARG(OPSZ_64), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vcompressps_zlok0zlo, vcompressps, vcompressps_mask, 0, REGARG(ZMM1), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vcompressps_zhik7zhi, vcompressps, vcompressps_mask, X64_ONLY, REGARG(ZMM31),
+       REGARG(K7), REGARG(ZMM16))
+OPCODE(vcompresspd_xlok0st, vcompresspd, vcompresspd_mask, 0, MEMARG(OPSZ_16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vcompresspd_xlok0xlo, vcompresspd, vcompresspd_mask, 0, REGARG(XMM1), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vcompresspd_xhik7xhi, vcompresspd, vcompresspd_mask, X64_ONLY, REGARG(XMM31),
+       REGARG(K7), REGARG(XMM16))
+OPCODE(vcompresspd_ylok0st, vcompresspd, vcompresspd_mask, 0, MEMARG(OPSZ_32), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vcompresspd_ylok0ylo, vcompresspd, vcompresspd_mask, 0, REGARG(YMM1), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vcompresspd_yhik7yhi, vcompresspd, vcompresspd_mask, X64_ONLY, REGARG(YMM31),
+       REGARG(K7), REGARG(YMM16))
+OPCODE(vcompresspd_zlok0st, vcompresspd, vcompresspd_mask, 0, MEMARG(OPSZ_64), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vcompresspd_zlok0zlo, vcompresspd, vcompresspd_mask, 0, REGARG(ZMM1), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vcompresspd_zhik7zhi, vcompresspd, vcompresspd_mask, X64_ONLY, REGARG(ZMM31),
+       REGARG(K7), REGARG(ZMM16))
+OPCODE(vexpandps_xlok0st, vexpandps, vexpandps_mask, 0, MEMARG(OPSZ_16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vexpandps_xlok0xlo, vexpandps, vexpandps_mask, 0, REGARG(XMM1), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vexpandps_xhik7xhi, vexpandps, vexpandps_mask, X64_ONLY, REGARG(XMM31), REGARG(K7),
+       REGARG(XMM16))
+OPCODE(vexpandps_ylok0st, vexpandps, vexpandps_mask, 0, MEMARG(OPSZ_32), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vexpandps_ylok0ylo, vexpandps, vexpandps_mask, 0, REGARG(YMM1), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vexpandps_yhik7yhi, vexpandps, vexpandps_mask, X64_ONLY, REGARG(YMM31), REGARG(K7),
+       REGARG(YMM16))
+OPCODE(vexpandps_zlok0st, vexpandps, vexpandps_mask, 0, MEMARG(OPSZ_64), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vexpandps_zlok0zlo, vexpandps, vexpandps_mask, 0, REGARG(ZMM1), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vexpandps_zhik7zhi, vexpandps, vexpandps_mask, X64_ONLY, REGARG(ZMM31), REGARG(K7),
+       REGARG(ZMM16))
+OPCODE(vexpandpd_xlok0st, vexpandpd, vexpandpd_mask, 0, MEMARG(OPSZ_16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vexpandpd_xlok0xlo, vexpandpd, vexpandpd_mask, 0, REGARG(XMM1), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vexpandpd_xhik7xhi, vexpandpd, vexpandpd_mask, X64_ONLY, REGARG(XMM31), REGARG(K7),
+       REGARG(XMM16))
+OPCODE(vexpandpd_ylok0st, vexpandpd, vexpandpd_mask, 0, MEMARG(OPSZ_32), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vexpandpd_ylok0ylo, vexpandpd, vexpandpd_mask, 0, REGARG(YMM1), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vexpandpd_yhik7yhi, vexpandpd, vexpandpd_mask, X64_ONLY, REGARG(YMM31), REGARG(K7),
+       REGARG(YMM16))
+OPCODE(vexpandpd_zlok0st, vexpandpd, vexpandpd_mask, 0, MEMARG(OPSZ_64), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vexpandpd_zlok0zlo, vexpandpd, vexpandpd_mask, 0, REGARG(ZMM1), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vexpandpd_zhik7zhi, vexpandpd, vexpandpd_mask, X64_ONLY, REGARG(ZMM31), REGARG(K7),
+       REGARG(ZMM16))
+OPCODE(vgetexpps_xlok0ld, vgetexpps, vgetexpps_mask, 0, REGARG(XMM0), REGARG(K0),
+       MEMARG(OPSZ_16))
+OPCODE(vgetexpps_xlok0xlo, vgetexpps, vgetexpps_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1))
+OPCODE(vgetexpps_xhik7xhi, vgetexpps, vgetexpps_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG(XMM31))
+OPCODE(vgetexpps_ylok0ld, vgetexpps, vgetexpps_mask, 0, REGARG(YMM0), REGARG(K0),
+       MEMARG(OPSZ_32))
+OPCODE(vgetexpps_ylok0ylo, vgetexpps, vgetexpps_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1))
+OPCODE(vgetexpps_yhik7yhi, vgetexpps, vgetexpps_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       REGARG(YMM31))
+OPCODE(vgetexpps_zlok0ld, vgetexpps, vgetexpps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       MEMARG(OPSZ_64))
+OPCODE(vgetexpps_zlok0zlo, vgetexpps, vgetexpps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1))
+OPCODE(vgetexpps_zhik7zhi, vgetexpps, vgetexpps_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       REGARG(ZMM31))
+OPCODE(vgetexppd_xlok0ld, vgetexppd, vgetexppd_mask, 0, REGARG(XMM0), REGARG(K0),
+       MEMARG(OPSZ_16))
+OPCODE(vgetexppd_xlok0xlo, vgetexppd, vgetexppd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1))
+OPCODE(vgetexppd_xhik7xhi, vgetexppd, vgetexppd_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       REGARG(XMM31))
+OPCODE(vgetexppd_ylok0ld, vgetexppd, vgetexppd_mask, 0, REGARG(YMM0), REGARG(K0),
+       MEMARG(OPSZ_32))
+OPCODE(vgetexppd_ylok0ylo, vgetexppd, vgetexppd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1))
+OPCODE(vgetexppd_yhik7yhi, vgetexppd, vgetexppd_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       REGARG(YMM31))
+OPCODE(vgetexppd_zlok0ld, vgetexppd, vgetexppd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       MEMARG(OPSZ_64))
+OPCODE(vgetexppd_zlok0zlo, vgetexppd, vgetexppd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1))
+OPCODE(vgetexppd_zhik7zhi, vgetexppd, vgetexppd_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       REGARG(ZMM31))
+OPCODE(vpcompressd_xlok0st, vpcompressd, vpcompressd_mask, 0, MEMARG(OPSZ_16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vpcompressd_xlok0xlo, vpcompressd, vpcompressd_mask, 0, REGARG(XMM1), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vpcompressd_xhik7xhi, vpcompressd, vpcompressd_mask, X64_ONLY, REGARG(XMM31),
+       REGARG(K7), REGARG(XMM16))
+OPCODE(vpcompressd_ylok0st, vpcompressd, vpcompressd_mask, 0, MEMARG(OPSZ_32), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vpcompressd_ylok0ylo, vpcompressd, vpcompressd_mask, 0, REGARG(YMM1), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vpcompressd_yhik7yhi, vpcompressd, vpcompressd_mask, X64_ONLY, REGARG(YMM31),
+       REGARG(K7), REGARG(YMM16))
+OPCODE(vpcompressd_zlok0st, vpcompressd, vpcompressd_mask, 0, MEMARG(OPSZ_64), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vpcompressd_zlok0zlo, vpcompressd, vpcompressd_mask, 0, REGARG(ZMM1), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vpcompressd_zhik7zhi, vpcompressd, vpcompressd_mask, X64_ONLY, REGARG(ZMM31),
+       REGARG(K7), REGARG(ZMM16))
+OPCODE(vpcompressq_xlok0st, vpcompressq, vpcompressq_mask, 0, MEMARG(OPSZ_16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vpcompressq_xlok0xlo, vpcompressq, vpcompressq_mask, 0, REGARG(XMM1), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vpcompressq_xhik7xhi, vpcompressq, vpcompressq_mask, X64_ONLY, REGARG(XMM31),
+       REGARG(K7), REGARG(XMM16))
+OPCODE(vpcompressq_ylok0st, vpcompressq, vpcompressq_mask, 0, MEMARG(OPSZ_32), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vpcompressq_ylok0ylo, vpcompressq, vpcompressq_mask, 0, REGARG(YMM1), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vpcompressq_yhik7yhi, vpcompressq, vpcompressq_mask, X64_ONLY, REGARG(YMM31),
+       REGARG(K7), REGARG(YMM16))
+OPCODE(vpcompressq_zlok0st, vpcompressq, vpcompressq_mask, 0, MEMARG(OPSZ_64), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vpcompressq_zlok0zlo, vpcompressq, vpcompressq_mask, 0, REGARG(ZMM1), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vpcompressq_zhik7zhi, vpcompressq, vpcompressq_mask, X64_ONLY, REGARG(ZMM31),
+       REGARG(K7), REGARG(ZMM16))
+/* NOCHECKIN */
+OPCODE(vpexpandd_xlok0st, vpexpandd, vpexpandd_mask, 0, MEMARG(OPSZ_16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vpexpandd_xlok0xlo, vpexpandd, vpexpandd_mask, 0, REGARG(XMM1), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vpexpandd_xhik7xhi, vpexpandd, vpexpandd_mask, X64_ONLY, REGARG(XMM31), REGARG(K7),
+       REGARG(XMM16))
+OPCODE(vpexpandd_ylok0st, vpexpandd, vpexpandd_mask, 0, MEMARG(OPSZ_32), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vpexpandd_ylok0ylo, vpexpandd, vpexpandd_mask, 0, REGARG(YMM1), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vpexpandd_yhik7yhi, vpexpandd, vpexpandd_mask, X64_ONLY, REGARG(YMM31), REGARG(K7),
+       REGARG(YMM16))
+OPCODE(vpexpandd_zlok0st, vpexpandd, vpexpandd_mask, 0, MEMARG(OPSZ_64), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vpexpandd_zlok0zlo, vpexpandd, vpexpandd_mask, 0, REGARG(ZMM1), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vpexpandd_zhik7zhi, vpexpandd, vpexpandd_mask, X64_ONLY, REGARG(ZMM31), REGARG(K7),
+       REGARG(ZMM16))
+OPCODE(vpexpandq_xlok0st, vpexpandq, vpexpandq_mask, 0, MEMARG(OPSZ_16), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vpexpandq_xlok0xlo, vpexpandq, vpexpandq_mask, 0, REGARG(XMM1), REGARG(K0),
+       REGARG(XMM0))
+OPCODE(vpexpandq_xhik7xhi, vpexpandq, vpexpandq_mask, X64_ONLY, REGARG(XMM31), REGARG(K7),
+       REGARG(XMM16))
+OPCODE(vpexpandq_ylok0st, vpexpandq, vpexpandq_mask, 0, MEMARG(OPSZ_32), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vpexpandq_ylok0ylo, vpexpandq, vpexpandq_mask, 0, REGARG(YMM1), REGARG(K0),
+       REGARG(YMM0))
+OPCODE(vpexpandq_yhik7yhi, vpexpandq, vpexpandq_mask, X64_ONLY, REGARG(YMM31), REGARG(K7),
+       REGARG(YMM16))
+OPCODE(vpexpandq_zlok0st, vpexpandq, vpexpandq_mask, 0, MEMARG(OPSZ_64), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vpexpandq_zlok0zlo, vpexpandq, vpexpandq_mask, 0, REGARG(ZMM1), REGARG(K0),
+       REGARG(ZMM0))
+OPCODE(vpexpandq_zhik7zhi, vpexpandq, vpexpandq_mask, X64_ONLY, REGARG(ZMM31), REGARG(K7),
+       REGARG(ZMM16))

--- a/suite/tests/api/ir_x86_3args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_3args_avx512_evex_mask.h
@@ -2247,7 +2247,6 @@ OPCODE(vpcompressq_zlok0zlo, vpcompressq, vpcompressq_mask, 0, REGARG(ZMM1), REG
        REGARG(ZMM0))
 OPCODE(vpcompressq_zhik7zhi, vpcompressq, vpcompressq_mask, X64_ONLY, REGARG(ZMM31),
        REGARG(K7), REGARG(ZMM16))
-/* NOCHECKIN */
 OPCODE(vpexpandd_xlok0st, vpexpandd, vpexpandd_mask, 0, MEMARG(OPSZ_16), REGARG(K0),
        REGARG(XMM0))
 OPCODE(vpexpandd_xlok0xlo, vpexpandd, vpexpandd_mask, 0, REGARG(XMM1), REGARG(K0),

--- a/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
@@ -4631,3 +4631,403 @@ OPCODE(vpavgw_zhik7zhizhi, vpavgw, vpavgw_mask, X64_ONLY, REGARG(ZMM16), REGARG(
        REGARG(ZMM17), REGARG(ZMM31))
 OPCODE(vpavgw_zhik7zhild, vpavgw, vpavgw_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
        REGARG(ZMM17), MEMARG(OPSZ_64))
+OPCODE(vblendmps_xlok0xloxlo, vblendmps, vblendmps_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), REGARG(XMM2))
+OPCODE(vblendmps_xlok0xlold, vblendmps, vblendmps_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vblendmps_xhik7xhixhi, vblendmps, vblendmps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vblendmps_xhik7xhild, vblendmps, vblendmps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), MEMARG(OPSZ_16))
+OPCODE(vblendmps_ylok0yloylo, vblendmps, vblendmps_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), REGARG(YMM2))
+OPCODE(vblendmps_ylok0ylold, vblendmps, vblendmps_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vblendmps_yhik7yhiyhi, vblendmps, vblendmps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vblendmps_yhik7yhild, vblendmps, vblendmps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), MEMARG(OPSZ_32))
+OPCODE(vblendmps_zlok0zlozlo, vblendmps, vblendmps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vblendmps_zlok0zlold, vblendmps, vblendmps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vblendmps_zhik7zhizhi, vblendmps, vblendmps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vblendmps_zhik7zhild, vblendmps, vblendmps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), MEMARG(OPSZ_64))
+OPCODE(vblendmpd_xlok0xloxlo, vblendmpd, vblendmpd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), REGARG(XMM2))
+OPCODE(vblendmpd_xlok0xlold, vblendmpd, vblendmpd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vblendmpd_xhik7xhixhi, vblendmpd, vblendmpd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vblendmpd_xhik7xhild, vblendmpd, vblendmpd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), MEMARG(OPSZ_16))
+OPCODE(vblendmpd_ylok0yloylo, vblendmpd, vblendmpd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), REGARG(YMM2))
+OPCODE(vblendmpd_ylok0ylold, vblendmpd, vblendmpd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vblendmpd_yhik7yhiyhi, vblendmpd, vblendmpd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vblendmpd_yhik7yhild, vblendmpd, vblendmpd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), MEMARG(OPSZ_32))
+OPCODE(vblendmpd_zlok0zlozlo, vblendmpd, vblendmpd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vblendmpd_zlok0zlold, vblendmpd, vblendmpd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vblendmpd_zhik7zhizhi, vblendmpd, vblendmpd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vblendmpd_zhik7zhild, vblendmpd, vblendmpd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), MEMARG(OPSZ_64))
+OPCODE(vgetexpss_xlok0xloxmm, vgetexpss, vgetexpss_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM2, OPSZ_12), REGARG_PARTIAL(XMM1, OPSZ_4))
+OPCODE(vgetexpss_xlok0xmmld, vgetexpss, vgetexpss_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM2, OPSZ_12), MEMARG(OPSZ_4))
+OPCODE(vgetexpss_xhik7xhixmm, vgetexpss, vgetexpss_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG_PARTIAL(XMM2, OPSZ_12), REGARG_PARTIAL(XMM17, OPSZ_4))
+OPCODE(vgetexpss_xhik7xmmld, vgetexpss, vgetexpss_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG_PARTIAL(XMM2, OPSZ_12), MEMARG(OPSZ_4))
+OPCODE(vgetexpsd_xlok0xloxmm, vgetexpsd, vgetexpsd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM2, OPSZ_8), REGARG_PARTIAL(XMM1, OPSZ_8))
+OPCODE(vgetexpsd_xlok0xmmld, vgetexpsd, vgetexpsd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG_PARTIAL(XMM2, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vgetexpsd_xhik7xhixmm, vgetexpsd, vgetexpsd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG_PARTIAL(XMM2, OPSZ_8), REGARG_PARTIAL(XMM17, OPSZ_8))
+OPCODE(vgetexpsd_xhik7xmmld, vgetexpsd, vgetexpsd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG_PARTIAL(XMM2, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vgetmantps_xlok0xlo, vgetmantps, vgetmantps_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM1))
+OPCODE(vgetmantps_xlok0ld, vgetmantps, vgetmantps_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), MEMARG(OPSZ_16))
+OPCODE(vgetmantps_xhik7xhi, vgetmantps, vgetmantps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(XMM31))
+OPCODE(vgetmantps_xhik7ld, vgetmantps, vgetmantps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), MEMARG(OPSZ_16))
+OPCODE(vgetmantps_ylok0ylo, vgetmantps, vgetmantps_mask, 0, REGARG(YMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM1))
+OPCODE(vgetmantps_ylok0ld, vgetmantps, vgetmantps_mask, 0, REGARG(YMM0), REGARG(K0),
+       IMMARG(OPSZ_1), MEMARG(OPSZ_32))
+OPCODE(vgetmantps_yhik7yhi, vgetmantps, vgetmantps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(YMM31))
+OPCODE(vgetmantps_yhik7ld, vgetmantps, vgetmantps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), IMMARG(OPSZ_1), MEMARG(OPSZ_32))
+OPCODE(vgetmantps_zlok0zlo, vgetmantps, vgetmantps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM1))
+OPCODE(vgetmantps_zlok0ld, vgetmantps, vgetmantps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       IMMARG(OPSZ_1), MEMARG(OPSZ_64))
+OPCODE(vgetmantps_zhik7zhi, vgetmantps, vgetmantps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(ZMM31))
+OPCODE(vgetmantps_zhik7ld, vgetmantps, vgetmantps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), IMMARG(OPSZ_1), MEMARG(OPSZ_64))
+OPCODE(vgetmantpd_xlok0xlo, vgetmantpd, vgetmantpd_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM1))
+OPCODE(vgetmantpd_xlok0ld, vgetmantpd, vgetmantpd_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), MEMARG(OPSZ_16))
+OPCODE(vgetmantpd_xhik7xhi, vgetmantpd, vgetmantpd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(XMM31))
+OPCODE(vgetmantpd_xhik7ld, vgetmantpd, vgetmantpd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), MEMARG(OPSZ_16))
+OPCODE(vgetmantpd_ylok0ylo, vgetmantpd, vgetmantpd_mask, 0, REGARG(YMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM1))
+OPCODE(vgetmantpd_ylok0ld, vgetmantpd, vgetmantpd_mask, 0, REGARG(YMM0), REGARG(K0),
+       IMMARG(OPSZ_1), MEMARG(OPSZ_32))
+OPCODE(vgetmantpd_yhik7yhi, vgetmantpd, vgetmantpd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(YMM31))
+OPCODE(vgetmantpd_yhik7ld, vgetmantpd, vgetmantpd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), IMMARG(OPSZ_1), MEMARG(OPSZ_32))
+OPCODE(vgetmantpd_zlok0zlo, vgetmantpd, vgetmantpd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM1))
+OPCODE(vgetmantpd_zlok0ld, vgetmantpd, vgetmantpd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       IMMARG(OPSZ_1), MEMARG(OPSZ_64))
+OPCODE(vgetmantpd_zhik7zhi, vgetmantpd, vgetmantpd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(ZMM31))
+OPCODE(vgetmantpd_zhik7ld, vgetmantpd, vgetmantpd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), IMMARG(OPSZ_1), MEMARG(OPSZ_64))
+OPCODE(vpblendmb_xlok0xloxlo, vpblendmb, vpblendmb_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), REGARG(XMM2))
+OPCODE(vpblendmb_xlok0xlold, vpblendmb, vpblendmb_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vpblendmb_xhik7xhixhi, vpblendmb, vpblendmb_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vpblendmb_xhik7xhild, vpblendmb, vpblendmb_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vpblendmb_ylok0yloylo, vpblendmb, vpblendmb_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), REGARG(YMM2))
+OPCODE(vpblendmb_ylok0ylold, vpblendmb, vpblendmb_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vpblendmb_yhik7yhiyhi, vpblendmb, vpblendmb_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vpblendmb_yhik7yhild, vpblendmb, vpblendmb_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vpblendmb_zlok0zlozlo, vpblendmb, vpblendmb_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vpblendmb_zlok0zlold, vpblendmb, vpblendmb_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vpblendmb_zhik7zhizhi, vpblendmb, vpblendmb_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vpblendmb_zhik7zhild, vpblendmb, vpblendmb_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vpblendmw_xlok0xloxlo, vpblendmw, vpblendmw_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), REGARG(XMM2))
+OPCODE(vpblendmw_xlok0xlold, vpblendmw, vpblendmw_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vpblendmw_xhik7xhixhi, vpblendmw, vpblendmw_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vpblendmw_xhik7xhild, vpblendmw, vpblendmw_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vpblendmw_ylok0yloylo, vpblendmw, vpblendmw_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), REGARG(YMM2))
+OPCODE(vpblendmw_ylok0ylold, vpblendmw, vpblendmw_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vpblendmw_yhik7yhiyhi, vpblendmw, vpblendmw_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vpblendmw_yhik7yhild, vpblendmw, vpblendmw_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vpblendmw_zlok0zlozlo, vpblendmw, vpblendmw_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vpblendmw_zlok0zlold, vpblendmw, vpblendmw_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vpblendmw_zhik7zhizhi, vpblendmw, vpblendmw_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vpblendmw_zhik7zhild, vpblendmw, vpblendmw_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vpblendmd_xlok0xloxlo, vpblendmd, vpblendmd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), REGARG(XMM2))
+OPCODE(vpblendmd_xlok0xlold, vpblendmd, vpblendmd_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vpblendmd_xhik7xhixhi, vpblendmd, vpblendmd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vpblendmd_xhik7xhild, vpblendmd, vpblendmd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vpblendmd_ylok0yloylo, vpblendmd, vpblendmd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), REGARG(YMM2))
+OPCODE(vpblendmd_ylok0ylold, vpblendmd, vpblendmd_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vpblendmd_yhik7yhiyhi, vpblendmd, vpblendmd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vpblendmd_yhik7yhild, vpblendmd, vpblendmd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vpblendmd_zlok0zlozlo, vpblendmd, vpblendmd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vpblendmd_zlok0zlold, vpblendmd, vpblendmd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vpblendmd_zhik7zhizhi, vpblendmd, vpblendmd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vpblendmd_zhik7zhild, vpblendmd, vpblendmd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vpblendmq_xlok0xloxlo, vpblendmq, vpblendmq_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), REGARG(XMM2))
+OPCODE(vpblendmq_xlok0xlold, vpblendmq, vpblendmq_mask, 0, REGARG(XMM0), REGARG(K0),
+       REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vpblendmq_xhik7xhixhi, vpblendmq, vpblendmq_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vpblendmq_xhik7xhild, vpblendmq, vpblendmq_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vpblendmq_ylok0yloylo, vpblendmq, vpblendmq_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), REGARG(YMM2))
+OPCODE(vpblendmq_ylok0ylold, vpblendmq, vpblendmq_mask, 0, REGARG(YMM0), REGARG(K0),
+       REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vpblendmq_yhik7yhiyhi, vpblendmq, vpblendmq_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vpblendmq_yhik7yhild, vpblendmq, vpblendmq_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vpblendmq_zlok0zlozlo, vpblendmq, vpblendmq_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vpblendmq_zlok0zlold, vpblendmq, vpblendmq_mask, 0, REGARG(ZMM0), REGARG(K0),
+       REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vpblendmq_zhik7zhizhi, vpblendmq, vpblendmq_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vpblendmq_zhik7zhild, vpblendmq, vpblendmq_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vptestmb_k1k0xloxlo, vptestmb, vptestmb_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vptestmb_k1k0xlold, vptestmb, vptestmb_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vptestmb_k6k7xhixhi, vptestmb, vptestmb_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vptestmb_k6k7xhild, vptestmb, vptestmb_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vptestmb_k1k0yloylo, vptestmb, vptestmb_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vptestmb_k1k0ylold, vptestmb, vptestmb_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vptestmb_k6k7yhiyhi, vptestmb, vptestmb_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vptestmb_k6k7yhild, vptestmb, vptestmb_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vptestmb_k1k0zlozlo, vptestmb, vptestmb_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vptestmb_k1k0zlold, vptestmb, vptestmb_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vptestmb_k6k7zhizhi, vptestmb, vptestmb_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vptestmb_k6k7zhild, vptestmb, vptestmb_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vptestmw_k1k0xloxlo, vptestmw, vptestmw_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vptestmw_k1k0xlold, vptestmw, vptestmw_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vptestmw_k6k7xhixhi, vptestmw, vptestmw_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vptestmw_k6k7xhild, vptestmw, vptestmw_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vptestmw_k1k0yloylo, vptestmw, vptestmw_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vptestmw_k1k0ylold, vptestmw, vptestmw_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vptestmw_k6k7yhiyhi, vptestmw, vptestmw_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vptestmw_k6k7yhild, vptestmw, vptestmw_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vptestmw_k1k0zlozlo, vptestmw, vptestmw_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vptestmw_k1k0zlold, vptestmw, vptestmw_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vptestmw_k6k7zhizhi, vptestmw, vptestmw_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vptestmw_k6k7zhild, vptestmw, vptestmw_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vptestmd_k1k0xloxlo, vptestmd, vptestmd_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vptestmd_k1k0xlold, vptestmd, vptestmd_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vptestmd_k6k7xhixhi, vptestmd, vptestmd_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vptestmd_k6k7xhild, vptestmd, vptestmd_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vptestmd_k1k0yloylo, vptestmd, vptestmd_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vptestmd_k1k0ylold, vptestmd, vptestmd_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vptestmd_k6k7yhiyhi, vptestmd, vptestmd_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vptestmd_k6k7yhild, vptestmd, vptestmd_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vptestmd_k1k0zlozlo, vptestmd, vptestmd_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vptestmd_k1k0zlold, vptestmd, vptestmd_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vptestmd_k6k7zhizhi, vptestmd, vptestmd_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vptestmd_k6k7zhild, vptestmd, vptestmd_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vptestmq_k1k0xloxlo, vptestmq, vptestmq_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vptestmq_k1k0xlold, vptestmq, vptestmq_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vptestmq_k6k7xhixhi, vptestmq, vptestmq_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vptestmq_k6k7xhild, vptestmq, vptestmq_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vptestmq_k1k0yloylo, vptestmq, vptestmq_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vptestmq_k1k0ylold, vptestmq, vptestmq_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vptestmq_k6k7yhiyhi, vptestmq, vptestmq_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vptestmq_k6k7yhild, vptestmq, vptestmq_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vptestmq_k1k0zlozlo, vptestmq, vptestmq_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vptestmq_k1k0zlold, vptestmq, vptestmq_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vptestmq_k6k7zhizhi, vptestmq, vptestmq_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vptestmq_k6k7zhild, vptestmq, vptestmq_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vptestnmb_k1k0xloxlo, vptestnmb, vptestnmb_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vptestnmb_k1k0xlold, vptestnmb, vptestnmb_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vptestnmb_k6k7xhixhi, vptestnmb, vptestnmb_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vptestnmb_k6k7xhild, vptestnmb, vptestnmb_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vptestnmb_k1k0yloylo, vptestnmb, vptestnmb_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vptestnmb_k1k0ylold, vptestnmb, vptestnmb_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vptestnmb_k6k7yhiyhi, vptestnmb, vptestnmb_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vptestnmb_k6k7yhild, vptestnmb, vptestnmb_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vptestnmb_k1k0zlozlo, vptestnmb, vptestnmb_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vptestnmb_k1k0zlold, vptestnmb, vptestnmb_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vptestnmb_k6k7zhizhi, vptestnmb, vptestnmb_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vptestnmb_k6k7zhild, vptestnmb, vptestnmb_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vptestnmw_k1k0xloxlo, vptestnmw, vptestnmw_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vptestnmw_k1k0xlold, vptestnmw, vptestnmw_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vptestnmw_k6k7xhixhi, vptestnmw, vptestnmw_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vptestnmw_k6k7xhild, vptestnmw, vptestnmw_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vptestnmw_k1k0yloylo, vptestnmw, vptestnmw_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vptestnmw_k1k0ylold, vptestnmw, vptestnmw_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vptestnmw_k6k7yhiyhi, vptestnmw, vptestnmw_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vptestnmw_k6k7yhild, vptestnmw, vptestnmw_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vptestnmw_k1k0zlozlo, vptestnmw, vptestnmw_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vptestnmw_k1k0zlold, vptestnmw, vptestnmw_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vptestnmw_k6k7zhizhi, vptestnmw, vptestnmw_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vptestnmw_k6k7zhild, vptestnmw, vptestnmw_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vptestnmd_k1k0xloxlo, vptestnmd, vptestnmd_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vptestnmd_k1k0xlold, vptestnmd, vptestnmd_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vptestnmd_k6k7xhixhi, vptestnmd, vptestnmd_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vptestnmd_k6k7xhild, vptestnmd, vptestnmd_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vptestnmd_k1k0yloylo, vptestnmd, vptestnmd_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vptestnmd_k1k0ylold, vptestnmd, vptestnmd_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vptestnmd_k6k7yhiyhi, vptestnmd, vptestnmd_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vptestnmd_k6k7yhild, vptestnmd, vptestnmd_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vptestnmd_k1k0zlozlo, vptestnmd, vptestnmd_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vptestnmd_k1k0zlold, vptestnmd, vptestnmd_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vptestnmd_k6k7zhizhi, vptestnmd, vptestnmd_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vptestnmd_k6k7zhild, vptestnmd, vptestnmd_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vptestnmq_k1k0xloxlo, vptestnmq, vptestnmq_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), REGARG(XMM1))
+OPCODE(vptestnmq_k1k0xlold, vptestnmq, vptestnmq_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(XMM0), MEMARG(OPSZ_16))
+OPCODE(vptestnmq_k6k7xhixhi, vptestnmq, vptestnmq_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM16), REGARG(XMM31))
+OPCODE(vptestnmq_k6k7xhild, vptestnmq, vptestnmq_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vptestnmq_k1k0yloylo, vptestnmq, vptestnmq_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), REGARG(YMM1))
+OPCODE(vptestnmq_k1k0ylold, vptestnmq, vptestnmq_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(YMM0), MEMARG(OPSZ_32))
+OPCODE(vptestnmq_k6k7yhiyhi, vptestnmq, vptestnmq_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM16), REGARG(YMM31))
+OPCODE(vptestnmq_k6k7yhild, vptestnmq, vptestnmq_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vptestnmq_k1k0zlozlo, vptestnmq, vptestnmq_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), REGARG(ZMM1))
+OPCODE(vptestnmq_k1k0zlold, vptestnmq, vptestnmq_mask, 0, REGARG(K1), REGARG(K0),
+       REGARG(ZMM0), MEMARG(OPSZ_64))
+OPCODE(vptestnmq_k6k7zhizhi, vptestnmq, vptestnmq_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM16), REGARG(ZMM31))
+OPCODE(vptestnmq_k6k7zhild, vptestnmq, vptestnmq_mask, X64_ONLY, REGARG(K6), REGARG(K7),
+       REGARG(ZMM31), MEMARG(OPSZ_64))

--- a/suite/tests/api/ir_x86_5args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_5args_avx512_evex_mask.h
@@ -531,3 +531,133 @@ OPCODE(vpalignr_zhik7zhizhi, vpalignr, vpalignr_mask, X64_ONLY, REGARG(ZMM16), R
        IMMARG(OPSZ_1), REGARG(ZMM17), REGARG(ZMM31))
 OPCODE(vpalignr_zhik7zhild, vpalignr, vpalignr_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
        IMMARG(OPSZ_1), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(valignd_xlok0xloxlo, valignd, valignd_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM1), REGARG(XMM2))
+OPCODE(valignd_xlok0xlold, valignd, valignd_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(valignd_xhik7xhixhi, valignd, valignd_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM17), REGARG(XMM31))
+OPCODE(valignd_xhik7xhild, valignd, valignd_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(valignd_ylok0yloylo, valignd, valignd_mask, 0, REGARG(YMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM1), REGARG(YMM2))
+OPCODE(valignd_ylok0ylold, valignd, valignd_mask, 0, REGARG(YMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(valignd_yhik7yhiyhi, valignd, valignd_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM17), REGARG(YMM31))
+OPCODE(valignd_yhik7yhild, valignd, valignd_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(valignd_zlok0zlozlo, valignd, valignd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(valignd_zlok0zlold, valignd, valignd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(valignd_zhik7zhizhi, valignd, valignd_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(valignd_zhik7zhild, valignd, valignd_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(valignq_xlok0xloxlo, valignq, valignq_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM1), REGARG(XMM2))
+OPCODE(valignq_xlok0xlold, valignq, valignq_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(valignq_xhik7xhixhi, valignq, valignq_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM17), REGARG(XMM31))
+OPCODE(valignq_xhik7xhild, valignq, valignq_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(valignq_ylok0yloylo, valignq, valignq_mask, 0, REGARG(YMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM1), REGARG(YMM2))
+OPCODE(valignq_ylok0ylold, valignq, valignq_mask, 0, REGARG(YMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(valignq_yhik7yhiyhi, valignq, valignq_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM17), REGARG(YMM31))
+OPCODE(valignq_yhik7yhild, valignq, valignq_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(valignq_zlok0zlozlo, valignq, valignq_mask, 0, REGARG(ZMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(valignq_zlok0zlold, valignq, valignq_mask, 0, REGARG(ZMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(valignq_zhik7zhizhi, valignq, valignq_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(valignq_zhik7zhild, valignq, valignq_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
+       IMMARG(OPSZ_1), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfixupimmps_xlok0xloxlo, vfixupimmps, vfixupimmps_mask, 0, REGARG(XMM0),
+       REGARG(K0), IMMARG(OPSZ_1), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfixupimmps_xlok0xlold, vfixupimmps, vfixupimmps_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfixupimmps_xhik7xhixhi, vfixupimmps, vfixupimmps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfixupimmps_xhik7xhild, vfixupimmps, vfixupimmps_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfixupimmps_ylok0yloylo, vfixupimmps, vfixupimmps_mask, 0, REGARG(YMM0),
+       REGARG(K0), IMMARG(OPSZ_1), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfixupimmps_ylok0ylold, vfixupimmps, vfixupimmps_mask, 0, REGARG(YMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfixupimmps_yhik7yhiyhi, vfixupimmps, vfixupimmps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfixupimmps_yhik7yhild, vfixupimmps, vfixupimmps_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfixupimmps_zlok0zlozlo, vfixupimmps, vfixupimmps_mask, 0, REGARG(ZMM0),
+       REGARG(K0), IMMARG(OPSZ_1), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfixupimmps_zlok0zlold, vfixupimmps, vfixupimmps_mask, 0, REGARG(ZMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfixupimmps_zhik7zhizhi, vfixupimmps, vfixupimmps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfixupimmps_zhik7zhild, vfixupimmps, vfixupimmps_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfixupimmpd_xlok0xloxlo, vfixupimmpd, vfixupimmpd_mask, 0, REGARG(XMM0),
+       REGARG(K0), IMMARG(OPSZ_1), REGARG(XMM1), REGARG(XMM2))
+OPCODE(vfixupimmpd_xlok0xlold, vfixupimmpd, vfixupimmpd_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM1), MEMARG(OPSZ_16))
+OPCODE(vfixupimmpd_xhik7xhixhi, vfixupimmpd, vfixupimmpd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(XMM17), REGARG(XMM31))
+OPCODE(vfixupimmpd_xhik7xhild, vfixupimmpd, vfixupimmpd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(XMM31), MEMARG(OPSZ_16))
+OPCODE(vfixupimmpd_ylok0yloylo, vfixupimmpd, vfixupimmpd_mask, 0, REGARG(YMM0),
+       REGARG(K0), IMMARG(OPSZ_1), REGARG(YMM1), REGARG(YMM2))
+OPCODE(vfixupimmpd_ylok0ylold, vfixupimmpd, vfixupimmpd_mask, 0, REGARG(YMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(YMM1), MEMARG(OPSZ_32))
+OPCODE(vfixupimmpd_yhik7yhiyhi, vfixupimmpd, vfixupimmpd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(YMM17), REGARG(YMM31))
+OPCODE(vfixupimmpd_yhik7yhild, vfixupimmpd, vfixupimmpd_mask, X64_ONLY, REGARG(YMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(YMM31), MEMARG(OPSZ_32))
+OPCODE(vfixupimmpd_zlok0zlozlo, vfixupimmpd, vfixupimmpd_mask, 0, REGARG(ZMM0),
+       REGARG(K0), IMMARG(OPSZ_1), REGARG(ZMM1), REGARG(ZMM2))
+OPCODE(vfixupimmpd_zlok0zlold, vfixupimmpd, vfixupimmpd_mask, 0, REGARG(ZMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(ZMM1), MEMARG(OPSZ_64))
+OPCODE(vfixupimmpd_zhik7zhizhi, vfixupimmpd, vfixupimmpd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(ZMM17), REGARG(ZMM31))
+OPCODE(vfixupimmpd_zhik7zhild, vfixupimmpd, vfixupimmpd_mask, X64_ONLY, REGARG(ZMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(ZMM31), MEMARG(OPSZ_64))
+OPCODE(vfixupimmss_xlok0xloxlo, vfixupimmss, vfixupimmss_mask, 0, REGARG(XMM0),
+       REGARG(K0), IMMARG(OPSZ_1), REGARG(XMM1), REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vfixupimmss_xlok0xlold, vfixupimmss, vfixupimmss_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM1), MEMARG(OPSZ_4))
+OPCODE(vfixupimmss_xhik7xhixhi, vfixupimmss, vfixupimmss_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(XMM17), REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vfixupimmss_xhik7xhild, vfixupimmss, vfixupimmss_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(XMM31), MEMARG(OPSZ_4))
+OPCODE(vfixupimmsd_xlok0xloxlo, vfixupimmsd, vfixupimmsd_mask, 0, REGARG(XMM0),
+       REGARG(K0), IMMARG(OPSZ_1), REGARG(XMM1), REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vfixupimmsd_xlok0xlold, vfixupimmsd, vfixupimmsd_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG(XMM1), MEMARG(OPSZ_8))
+OPCODE(vfixupimmsd_xhik7xhixhi, vfixupimmsd, vfixupimmsd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(XMM17), REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vfixupimmsd_xhik7xhild, vfixupimmsd, vfixupimmsd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG(XMM31), MEMARG(OPSZ_8))
+OPCODE(vgetmantss_xlok0xloxlo, vgetmantss, vgetmantss_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG_PARTIAL(XMM1, OPSZ_12), REGARG_PARTIAL(XMM2, OPSZ_4))
+OPCODE(vgetmantss_xlok0xlold, vgetmantss, vgetmantss_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG_PARTIAL(XMM1, OPSZ_12), MEMARG(OPSZ_4))
+OPCODE(vgetmantss_xhik7xhixhi, vgetmantss, vgetmantss_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG_PARTIAL(XMM17, OPSZ_12),
+       REGARG_PARTIAL(XMM31, OPSZ_4))
+OPCODE(vgetmantss_xhik7xhild, vgetmantss, vgetmantss_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG_PARTIAL(XMM31, OPSZ_12), MEMARG(OPSZ_4))
+OPCODE(vgetmantsd_xlok0xloxlo, vgetmantsd, vgetmantsd_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG_PARTIAL(XMM1, OPSZ_8), REGARG_PARTIAL(XMM2, OPSZ_8))
+OPCODE(vgetmantsd_xlok0xlold, vgetmantsd, vgetmantsd_mask, 0, REGARG(XMM0), REGARG(K0),
+       IMMARG(OPSZ_1), REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
+OPCODE(vgetmantsd_xhik7xhixhi, vgetmantsd, vgetmantsd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG_PARTIAL(XMM17, OPSZ_8),
+       REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vgetmantsd_xhik7xhild, vgetmantsd, vgetmantsd_mask, X64_ONLY, REGARG(XMM16),
+       REGARG(K7), IMMARG(OPSZ_1), REGARG_PARTIAL(XMM31, OPSZ_8), MEMARG(OPSZ_8))


### PR DESCRIPTION
Adds the new AVX-512 opcodes valignd, valignq, vblendmps, vblendmpd, vcompressps,
vcompresspd, vexpandps, vexpandpd, vfixupimmps, vfixupimmpd, vfixupimmss, vfixupimmsd,
vgetexppd, vgetexpps, vgetexpsd, vgetexpss, vgetmantpd, vgetmantps, vgetmantsd,
vgetmantss, vpblendmb, vpblendmw, vpblendmd, vpblendmq, vpcompressq, vpcompressd,
vpexpandd, vpexpandq, vptestmb, vptestmw, vptestmd, vptestmq, vptestnmb, vptestnmw,
vptestnmd, vptestnmq.

Adds tests for above.

Opcodes have been checked against llvm-mc, binutils/gas/objdump and capstone.

Issue: #1312