### PR TITLE
Adds aarch64 fmla vector by element instruction

### DIFF
--- a/core/arch/aarch64/codec.txt
+++ b/core/arch/aarch64/codec.txt
@@ -975,6 +975,7 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 1001111001100111000000xxxxxxxxxx     fmov d0 : x5
 1001111010101111000000xxxxxxxxxx     fmov q0 : x5 # only sets the bit top half of q0
 
+
 # Advanced SIMD three same (FP16)
 0x001110010xxxxx000001xxxxxxxxxx     fmaxnm    dq0 : dq5 dq16 h_sz
 0x001110010xxxxx000011xxxxxxxxxx     fmla      dq0 : dq0 dq5 dq16 h_sz
@@ -1026,6 +1027,7 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0x001110xx1xxxxx101111xxxxxxxxxx     addp      dq0 : dq5 dq16 bhsd_sz
 0x0011100x1xxxxx110001xxxxxxxxxx     fmaxnm    dq0 : dq5 dq16 sd_sz
 0x0011100x1xxxxx110011xxxxxxxxxx     fmla      dq0 : dq0 dq5 dq16 sd_sz
+0x0011111xxxxxxx0001x0xxxxxxxxxx     fmla      dq0 : dq0 dq5 dq16 vindex_SD sd_sz
 0x0011100x1xxxxx110101xxxxxxxxxx     fadd      dq0 : dq5 dq16 sd_sz
 0x0011100x1xxxxx110111xxxxxxxxxx     fmulx     dq0 : dq5 dq16 sd_sz
 0x0011100x1xxxxx111001xxxxxxxxxx     fcmeq     dq0 : dq5 dq16 sd_sz

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -1765,6 +1765,12 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 0e33cfa7 : fmla v7.2s, v29.2s, v19.2s               : fmla   %d7 %d29 %d19 $0x02 -> %d7
 4e33cfa7 : fmla v7.4s, v29.4s, v19.4s               : fmla   %q7 %q29 %q19 $0x02 -> %q7
 4e73cfa7 : fmla v7.2d, v29.2d, v19.2d               : fmla   %q7 %q29 %q19 $0x03 -> %q7
+4fd11240 : fmla v0.2d, v18.2d, v17.d[0]             : fmla   %q0 %q18 %q17 $0x00 $0x03 -> %q0
+4fc4180b : fmla v11.2d, v0.2d, v4.d[1]              : fmla   %q11 %q0 %q4 $0x01 $0x03 -> %q11
+4f981382 : fmla v2.4s, v28.4s, v24.s[0]             : fmla   %q2 %q28 %q24 $0x00 $0x02 -> %q2
+4fb81343 : fmla v3.4s, v26.4s, v24.s[1]             : fmla   %q3 %q26 %q24 $0x01 $0x02 -> %q3
+4f981b88 : fmla v8.4s, v28.4s, v24.s[2]             : fmla   %q8 %q28 %q24 $0x02 $0x02 -> %q8
+4fb81b49 : fmla v9.4s, v26.4s, v24.s[3]             : fmla   %q9 %q26 %q24 $0x03 $0x02 -> %q9
 0e2bd56a : fadd v10.2s, v11.2s, v11.2s              : fadd   %d11 %d11 $0x02 -> %d10
 4e2bd56a : fadd v10.4s, v11.4s, v11.4s              : fadd   %q11 %q11 $0x02 -> %q10
 4e6bd56a : fadd v10.2d, v11.2d, v11.2d              : fadd   %q11 %q11 $0x03 -> %q10


### PR DESCRIPTION
This commit does not add the half-float version
of the instruction which is introduced in armv8.2

Signed-off-by: Vasilis Flouris <vflouris@ics.forth.gr>