### PR TITLE
i#3692:Added pext encoding fix

### DIFF
--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1215,7 +1215,7 @@ const instr_info_t * const op_instr[] =
 
     /* Intel BMI2 */
     /* OP_bzhi          */   &prefix_extensions[142][4],
-    /* OP_pext          */   &prefix_extensions[142][6],
+    /* OP_pext          */   &prefix_extensions[142][5],
     /* OP_pdep          */   &prefix_extensions[142][7],
     /* OP_sarx          */   &prefix_extensions[141][5],
     /* OP_shlx          */   &prefix_extensions[141][6],
@@ -5071,8 +5071,8 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID,      0x6638f518, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,      0xf238f518, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
     {OP_bzhi,        0x38f518, "bzhi",    Gy, xx, Ey, By, xx, mrm|vex, fW6, END_LIST},
-    {INVALID,      0xf338f518, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-    {OP_pext,      0x6638f518, "pext",    Gy, xx, Ey, By, xx, mrm|vex, x, END_LIST},
+    {OP_pext,      0xf338f518, "pext",    Gy, xx, Ey, By, xx, mrm|vex, x, END_LIST},
+    {INVALID,      0x6638f518, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
     {OP_pdep,      0xf238f518, "pdep",    Gy, xx, Ey, By, xx, mrm|vex, x, END_LIST},
     /* TODO i#1312: Support AVX-512. */
     {INVALID,   0x38f518, "(bad)", xx, xx, xx, xx, xx, no, x, NA},

--- a/third_party/binutils/test_decenc/drdecode_decenc_x86.expect
+++ b/third_party/binutils/test_decenc/drdecode_decenc_x86.expect
@@ -1446,7 +1446,7 @@ test_s:
  8f ea 78 12 08 00 00 lwpval %eax, (%eax), $0x00000000
  00 00
  c4 e2 7b f5 00       pdep   (%eax), %eax, %eax
- c4 e2 7a f5 00       bzhi   (%eax), %eax, %eax
+ c4 e2 7a f5 00       pext   (%eax), %eax, %eax
  c4 e3 7b f0 00 00    rorx   (%eax), $0x00, %eax
  c4 e2 7a f7 00       sarx   (%eax), %eax, %eax
  c4 e2 79 f7 00       shlx   (%eax), %eax, %eax
@@ -6233,8 +6233,8 @@ test_s:
  c4 e3 7b f0 19 07    rorx   (%ecx), $0x07, %ebx
  c4 e2 63 f5 f0       pdep   %eax, %ebx, %esi
  c4 e2 63 f5 31       pdep   (%ecx), %ebx, %esi
- c4 e2 62 f5 f0       bzhi   %eax, %ebx, %esi
- c4 e2 62 f5 31       bzhi   (%ecx), %ebx, %esi
+ c4 e2 62 f5 f0       pext   %eax, %ebx, %esi
+ c4 e2 62 f5 31       pext   (%ecx), %ebx, %esi
  c4 e2 78 f5 f3       bzhi   %ebx, %eax, %esi
  c4 e2 60 f5 31       bzhi   (%ecx), %ebx, %esi
  c4 e2 7a f7 f3       sarx   %ebx, %eax, %esi
@@ -6249,9 +6249,9 @@ test_s:
  c4 e2 63 f5 f0       pdep   %eax, %ebx, %esi
  c4 e2 63 f5 31       pdep   (%ecx), %ebx, %esi
  c4 e2 63 f5 31       pdep   (%ecx), %ebx, %esi
- c4 e2 62 f5 f0       bzhi   %eax, %ebx, %esi
- c4 e2 62 f5 31       bzhi   (%ecx), %ebx, %esi
- c4 e2 62 f5 31       bzhi   (%ecx), %ebx, %esi
+ c4 e2 62 f5 f0       pext   %eax, %ebx, %esi
+ c4 e2 62 f5 31       pext   (%ecx), %ebx, %esi
+ c4 e2 62 f5 31       pext   (%ecx), %ebx, %esi
  c4 e2 78 f5 f3       bzhi   %ebx, %eax, %esi
  c4 e2 60 f5 31       bzhi   (%ecx), %ebx, %esi
  c4 e2 60 f5 31       bzhi   (%ecx), %ebx, %esi
@@ -79673,7 +79673,7 @@ test_s:
  c4 e2 78 f3 08       blsr   (%eax), %eax
  c4 e2 78 f5 00       bzhi   (%eax), %eax, %eax
  c4 e2 7b f5 00       pdep   (%eax), %eax, %eax
- c4 e2 7a f5 00       bzhi   (%eax), %eax, %eax
+ c4 e2 7a f5 00       pext   (%eax), %eax, %eax
  c4 e3 7b f0 00 00    rorx   (%eax), $0x00, %eax
  c4 e2 7a f7 00       sarx   (%eax), %eax, %eax
  c4 e2 79 f7 00       shlx   (%eax), %eax, %eax

--- a/third_party/binutils/test_decenc/drdecode_decenc_x86_64.expect
+++ b/third_party/binutils/test_decenc/drdecode_decenc_x86_64.expect
@@ -6455,8 +6455,8 @@ test_x86_64_s:
  c4 e2 63 f5 31       pdep   (%rcx), %ebx, %esi
  c4 42 03 f5 d1       pdep   %r9d, %r15d, %r10d
  c4 62 03 f5 11       pdep   (%rcx), %r15d, %r10d
- c4 e2 62 f5 f0       bzhi   %eax, %ebx, %esi
- c4 e2 62 f5 31       bzhi   (%rcx), %ebx, %esi
+ c4 e2 62 f5 f0       pext   %eax, %ebx, %esi
+ c4 e2 62 f5 31       pext   (%rcx), %ebx, %esi
  c4 42 02 f5 d1       bzhi   %r9d, %r15d, %r10d
  c4 62 02 f5 11       bzhi   (%rcx), %r15d, %r10d
  c4 e2 78 f5 f3       bzhi   %ebx, %eax, %esi
@@ -6514,7 +6514,7 @@ test_x86_64_s:
  c4 62 2b f5 39       pdep   (%rcx), %r10d, %r15d
  c4 e2 63 f5 31       pdep   (%rcx), %ebx, %esi
  c4 e2 62 f5 f0       bzhi   %eax, %ebx, %esi
- c4 e2 62 f5 31       bzhi   (%rcx), %ebx, %esi
+ c4 e2 62 f5 31       pext   (%rcx), %ebx, %esi
  c4 42 2a f5 f9       bzhi   %r9d, %r10d, %r15d
  c4 62 2a f5 39       bzhi   (%rcx), %r10d, %r15d
  c4 e2 62 f5 31       bzhi   (%rcx), %ebx, %esi
@@ -38972,7 +38972,7 @@ test_x86_64_s:
  c4 e2 78 f3 08       blsr   (%rax), %eax
  c4 e2 78 f5 00       bzhi   (%rax), %eax, %eax
  c4 e2 7b f5 00       pdep   (%rax), %eax, %eax
- c4 e2 7a f5 00       bzhi   (%rax), %eax, %eax
+ c4 e2 7a f5 00       pext   (%rax), %eax, %eax
  c4 e3 7b f0 00 00    rorx   (%rax), $0x00, %eax
  c4 e2 7a f7 00       sarx   (%rax), %eax, %eax
  c4 e2 79 f7 00       shlx   (%rax), %eax, %eax

--- a/third_party/binutils/test_decenc/drdecode_decenc_x86_64.expect
+++ b/third_party/binutils/test_decenc/drdecode_decenc_x86_64.expect
@@ -6513,11 +6513,11 @@ test_x86_64_s:
  c4 42 2b f5 f9       pdep   %r9d, %r10d, %r15d
  c4 62 2b f5 39       pdep   (%rcx), %r10d, %r15d
  c4 e2 63 f5 31       pdep   (%rcx), %ebx, %esi
- c4 e2 62 f5 f0       bzhi   %eax, %ebx, %esi
+ c4 e2 62 f5 f0       pext   %eax, %ebx, %esi
  c4 e2 62 f5 31       pext   (%rcx), %ebx, %esi
  c4 42 2a f5 f9       bzhi   %r9d, %r10d, %r15d
  c4 62 2a f5 39       bzhi   (%rcx), %r10d, %r15d
- c4 e2 62 f5 31       bzhi   (%rcx), %ebx, %esi
+ c4 e2 62 f5 31       pext   (%rcx), %ebx, %esi
  c4 e2 78 f5 f3       bzhi   %ebx, %eax, %esi
  c4 e2 60 f5 31       bzhi   (%rcx), %ebx, %esi
  c4 42 30 f5 fa       bzhi   %r10d, %r9d, %r15d

--- a/third_party/binutils/test_decenc/drdecode_decenc_x86_64.expect
+++ b/third_party/binutils/test_decenc/drdecode_decenc_x86_64.expect
@@ -6457,8 +6457,8 @@ test_x86_64_s:
  c4 62 03 f5 11       pdep   (%rcx), %r15d, %r10d
  c4 e2 62 f5 f0       pext   %eax, %ebx, %esi
  c4 e2 62 f5 31       pext   (%rcx), %ebx, %esi
- c4 42 02 f5 d1       bzhi   %r9d, %r15d, %r10d
- c4 62 02 f5 11       bzhi   (%rcx), %r15d, %r10d
+ c4 42 02 f5 d1       pext   %r9d, %r15d, %r10d
+ c4 62 02 f5 11       pext   (%rcx), %r15d, %r10d
  c4 e2 78 f5 f3       bzhi   %ebx, %eax, %esi
  c4 e2 60 f5 31       bzhi   (%rcx), %ebx, %esi
  c4 42 30 f5 d7       bzhi   %r15d, %r9d, %r10d
@@ -6483,10 +6483,10 @@ test_x86_64_s:
  c4 e2 e3 f5 31       pdep   (%rcx), %rbx, %rsi
  c4 42 83 f5 d1       pdep   %r9, %r15, %r10
  c4 62 83 f5 11       pdep   (%rcx), %r15, %r10
- c4 e2 e2 f5 f0       bzhi   %rax, %rbx, %rsi
- c4 e2 e2 f5 31       bzhi   (%rcx), %rbx, %rsi
- c4 42 82 f5 d1       bzhi   %r9, %r15, %r10
- c4 62 82 f5 11       bzhi   (%rcx), %r15, %r10
+ c4 e2 e2 f5 f0       pext   %rax, %rbx, %rsi
+ c4 e2 e2 f5 31       pext   (%rcx), %rbx, %rsi
+ c4 42 82 f5 d1       pext   %r9, %r15, %r10
+ c4 62 82 f5 11       pext   (%rcx), %r15, %r10
  c4 e2 f8 f5 f3       bzhi   %rbx, %rax, %rsi
  c4 e2 f8 f5 31       bzhi   (%rcx), %rax, %rsi
  c4 42 b0 f5 d7       bzhi   %r15, %r9, %r10
@@ -6515,8 +6515,8 @@ test_x86_64_s:
  c4 e2 63 f5 31       pdep   (%rcx), %ebx, %esi
  c4 e2 62 f5 f0       pext   %eax, %ebx, %esi
  c4 e2 62 f5 31       pext   (%rcx), %ebx, %esi
- c4 42 2a f5 f9       bzhi   %r9d, %r10d, %r15d
- c4 62 2a f5 39       bzhi   (%rcx), %r10d, %r15d
+ c4 42 2a f5 f9       pext   %r9d, %r10d, %r15d
+ c4 62 2a f5 39       pext   (%rcx), %r10d, %r15d
  c4 e2 62 f5 31       pext   (%rcx), %ebx, %esi
  c4 e2 78 f5 f3       bzhi   %ebx, %eax, %esi
  c4 e2 60 f5 31       bzhi   (%rcx), %ebx, %esi
@@ -6548,11 +6548,11 @@ test_x86_64_s:
  c4 42 83 f5 d1       pdep   %r9, %r15, %r10
  c4 62 83 f5 11       pdep   (%rcx), %r15, %r10
  c4 e2 e3 f5 31       pdep   (%rcx), %rbx, %rsi
- c4 e2 e2 f5 f0       bzhi   %rax, %rbx, %rsi
- c4 e2 e2 f5 31       bzhi   (%rcx), %rbx, %rsi
- c4 42 82 f5 d1       bzhi   %r9, %r15, %r10
- c4 62 82 f5 11       bzhi   (%rcx), %r15, %r10
- c4 e2 e2 f5 31       bzhi   (%rcx), %rbx, %rsi
+ c4 e2 e2 f5 f0       pext   %rax, %rbx, %rsi
+ c4 e2 e2 f5 31       pext   (%rcx), %rbx, %rsi
+ c4 42 82 f5 d1       pext   %r9, %r15, %r10
+ c4 62 82 f5 11       pext   (%rcx), %r15, %r10
+ c4 e2 e2 f5 31       pext   (%rcx), %rbx, %rsi
  c4 e2 f8 f5 f3       bzhi   %rbx, %rax, %rsi
  c4 e2 f8 f5 31       bzhi   (%rcx), %rax, %rsi
  c4 42 b0 f5 d7       bzhi   %r15, %r9, %r10


### PR DESCRIPTION
Arranges pext's encoding which otherwise leads to an illegal instruction exception.

Fixes: #3692