### PR TITLE
i#1312 AVX-512 support: Fix existing VSIB element sizes of AVX2 gather.

### DIFF
--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1768,8 +1768,8 @@ const instr_info_t * const op_instr[] =
 #define Mqq  TYPE_M, OPSZ_32
 #define Mq_dq TYPE_M, OPSZ_8_rex16
 #define Mv  TYPE_M, OPSZ_4_rex8_short2
-#define MVd TYPE_VSIB, OPSZ_4
-#define MVq TYPE_VSIB, OPSZ_8
+#define MVxd TYPE_VSIB, OPSZ_4
+#define MVxq TYPE_VSIB, OPSZ_8
 #define Zb  TYPE_XLAT, OPSZ_1
 #define Bq  TYPE_MASKMOVQ, OPSZ_8
 #define Bdq  TYPE_MASKMOVQ, OPSZ_16
@@ -7170,17 +7170,17 @@ const instr_info_t vex_W_extensions[][2] = {
     /* XXX: OP_v*gather* raise #UD if any pair of the index, mask, or destination
      * registers are identical.  We don't bother trying to detect that.
      */
-    {OP_vpgatherdd,0x66389018,"vpgatherdd",Vx,Hx,MVd,Hx,xx, mrm|vex|reqp,x,END_LIST},
-    {OP_vpgatherdq,0x66389058,"vpgatherdq",Vx,Hx,MVq,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vpgatherdd,0x66389018,"vpgatherdd",Vx,Hx,MVxd,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vpgatherdq,0x66389058,"vpgatherdq",Vx,Hx,MVxd,Hx,xx, mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 67 */
-    {OP_vpgatherqd,0x66389118,"vpgatherqd",Vx,Hx,MVd,Hx,xx, mrm|vex|reqp,x,END_LIST},
-    {OP_vpgatherqq,0x66389158,"vpgatherqq",Vx,Hx,MVq,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vpgatherqd,0x66389118,"vpgatherqd",Vx,Hx,MVxq,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vpgatherqq,0x66389158,"vpgatherqq",Vx,Hx,MVxq,Hx,xx, mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 68 */
-    {OP_vgatherdps,0x66389218,"vgatherdps",Vvs,Hx,MVd,Hx,xx, mrm|vex|reqp,x,END_LIST},
-    {OP_vgatherdpd,0x66389258,"vgatherdpd",Vvd,Hx,MVq,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vgatherdps,0x66389218,"vgatherdps",Vvs,Hx,MVxd,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vgatherdpd,0x66389258,"vgatherdpd",Vvd,Hx,MVxd,Hx,xx, mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 69 */
-    {OP_vgatherqps,0x66389318,"vgatherqps",Vvs,Hx,MVd,Hx,xx, mrm|vex|reqp,x,END_LIST},
-    {OP_vgatherqpd,0x66389358,"vgatherqpd",Vvd,Hx,MVq,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vgatherqps,0x66389318,"vgatherqps",Vvs,Hx,MVxq,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vgatherqpd,0x66389358,"vgatherqpd",Vvd,Hx,MVxq,Hx,xx, mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 70 */
     {OP_vpmaskmovd,0x66388c18,"vpmaskmovd",Vx,xx,Hx,Mx,xx, mrm|vex|reqp|predcx,x,tvexw[71][0]},
     {OP_vpmaskmovq,0x66388c58,"vpmaskmovq",Vx,xx,Hx,Mx,xx, mrm|vex|reqp|predcx,x,tvexw[71][1]},

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1768,8 +1768,8 @@ const instr_info_t * const op_instr[] =
 #define Mqq  TYPE_M, OPSZ_32
 #define Mq_dq TYPE_M, OPSZ_8_rex16
 #define Mv  TYPE_M, OPSZ_4_rex8_short2
-#define MVxd TYPE_VSIB, OPSZ_4
-#define MVxq TYPE_VSIB, OPSZ_8
+#define MVd TYPE_VSIB, OPSZ_4
+#define MVq TYPE_VSIB, OPSZ_8
 #define Zb  TYPE_XLAT, OPSZ_1
 #define Bq  TYPE_MASKMOVQ, OPSZ_8
 #define Bdq  TYPE_MASKMOVQ, OPSZ_16
@@ -7170,17 +7170,17 @@ const instr_info_t vex_W_extensions[][2] = {
     /* XXX: OP_v*gather* raise #UD if any pair of the index, mask, or destination
      * registers are identical.  We don't bother trying to detect that.
      */
-    {OP_vpgatherdd,0x66389018,"vpgatherdd",Vx,Hx,MVxd,Hx,xx, mrm|vex|reqp,x,END_LIST},
-    {OP_vpgatherdq,0x66389058,"vpgatherdq",Vx,Hx,MVxd,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vpgatherdd,0x66389018,"vpgatherdd",Vx,Hx,MVd,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vpgatherdq,0x66389058,"vpgatherdq",Vx,Hx,MVd,Hx,xx, mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 67 */
-    {OP_vpgatherqd,0x66389118,"vpgatherqd",Vx,Hx,MVxq,Hx,xx, mrm|vex|reqp,x,END_LIST},
-    {OP_vpgatherqq,0x66389158,"vpgatherqq",Vx,Hx,MVxq,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vpgatherqd,0x66389118,"vpgatherqd",Vx,Hx,MVq,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vpgatherqq,0x66389158,"vpgatherqq",Vx,Hx,MVq,Hx,xx, mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 68 */
-    {OP_vgatherdps,0x66389218,"vgatherdps",Vvs,Hx,MVxd,Hx,xx, mrm|vex|reqp,x,END_LIST},
-    {OP_vgatherdpd,0x66389258,"vgatherdpd",Vvd,Hx,MVxd,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vgatherdps,0x66389218,"vgatherdps",Vvs,Hx,MVd,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vgatherdpd,0x66389258,"vgatherdpd",Vvd,Hx,MVd,Hx,xx, mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 69 */
-    {OP_vgatherqps,0x66389318,"vgatherqps",Vvs,Hx,MVxq,Hx,xx, mrm|vex|reqp,x,END_LIST},
-    {OP_vgatherqpd,0x66389358,"vgatherqpd",Vvd,Hx,MVxq,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vgatherqps,0x66389318,"vgatherqps",Vvs,Hx,MVq,Hx,xx, mrm|vex|reqp,x,END_LIST},
+    {OP_vgatherqpd,0x66389358,"vgatherqpd",Vvd,Hx,MVq,Hx,xx, mrm|vex|reqp,x,END_LIST},
   }, { /* vex_W_ext 70 */
     {OP_vpmaskmovd,0x66388c18,"vpmaskmovd",Vx,xx,Hx,Mx,xx, mrm|vex|reqp|predcx,x,tvexw[71][0]},
     {OP_vpmaskmovq,0x66388c58,"vpmaskmovq",Vx,xx,Hx,Mx,xx, mrm|vex|reqp|predcx,x,tvexw[71][1]},

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1410,8 +1410,8 @@ test_vsib(void *dc)
     ASSERT(pc != NULL);
     ASSERT(strcmp(dbuf,
                   IF_X64_ELSE(
-                      "vpgatherdq (%rdx,%xmm0,2)[8byte] %xmm2 -> %xmm4 %xmm2\n",
-                      "vpgatherdq (%edx,%xmm0,2)[8byte] %xmm2 -> %xmm4 %xmm2\n")) == 0);
+                      "vpgatherdq (%rdx,%xmm0,2)[4byte] %xmm2 -> %xmm4 %xmm2\n",
+                      "vpgatherdq (%edx,%xmm0,2)[4byte] %xmm2 -> %xmm4 %xmm2\n")) == 0);
 
     pc =
         disassemble_to_buffer(dc, (byte *)b2, (byte *)b2, false /*no pc*/,

--- a/suite/tests/api/ir_x86_3args.h
+++ b/suite/tests/api/ir_x86_3args.h
@@ -383,27 +383,27 @@ OPCODE(mulx, mulx, mulx, 0, REGARG(EAX), REGARG(EBX), MEMARG(OPSZ_4))
 /****************************************************************************/
 /* AVX2 */
 OPCODE(vpgatherdd, vpgatherdd, vpgatherdd, 0, REGARG(XMM0), VSIBX(OPSZ_4), REGARG(XMM1))
-OPCODE(vpgatherdq, vpgatherdq, vpgatherdq, 0, REGARG(XMM0), VSIBX(OPSZ_8), REGARG(XMM1))
-OPCODE(vpgatherqd, vpgatherqd, vpgatherqd, 0, REGARG(XMM0), VSIBX(OPSZ_4), REGARG(XMM1))
+OPCODE(vpgatherdq, vpgatherdq, vpgatherdq, 0, REGARG(XMM0), VSIBX(OPSZ_4), REGARG(XMM1))
+OPCODE(vpgatherqd, vpgatherqd, vpgatherqd, 0, REGARG(XMM0), VSIBX(OPSZ_8), REGARG(XMM1))
 OPCODE(vpgatherqq, vpgatherqq, vpgatherqq, 0, REGARG(XMM0), VSIBX(OPSZ_8), REGARG(XMM1))
 OPCODE(vgatherdps, vgatherdps, vgatherdps, 0, REGARG(XMM0), VSIBX(OPSZ_4), REGARG(XMM1))
-OPCODE(vgatherdpd, vgatherdpd, vgatherdpd, 0, REGARG(XMM0), VSIBX(OPSZ_8), REGARG(XMM1))
-OPCODE(vgatherqps, vgatherqps, vgatherqps, 0, REGARG(XMM0), VSIBX(OPSZ_4), REGARG(XMM1))
+OPCODE(vgatherdpd, vgatherdpd, vgatherdpd, 0, REGARG(XMM0), VSIBX(OPSZ_4), REGARG(XMM1))
+OPCODE(vgatherqps, vgatherqps, vgatherqps, 0, REGARG(XMM0), VSIBX(OPSZ_8), REGARG(XMM1))
 OPCODE(vgatherqpd, vgatherqpd, vgatherqpd, 0, REGARG(XMM0), VSIBX(OPSZ_8), REGARG(XMM1))
 
 OPCODE(vpgatherdd_256, vpgatherdd, vpgatherdd, 0, REGARG(YMM0), VSIBY(OPSZ_4),
        REGARG(YMM1))
-OPCODE(vpgatherdq_256, vpgatherdq, vpgatherdq, 0, REGARG(YMM0), VSIBY(OPSZ_8),
+OPCODE(vpgatherdq_256, vpgatherdq, vpgatherdq, 0, REGARG(YMM0), VSIBY(OPSZ_4),
        REGARG(YMM1))
-OPCODE(vpgatherqd_256, vpgatherqd, vpgatherqd, 0, REGARG(YMM0), VSIBY(OPSZ_4),
+OPCODE(vpgatherqd_256, vpgatherqd, vpgatherqd, 0, REGARG(YMM0), VSIBY(OPSZ_8),
        REGARG(YMM1))
 OPCODE(vpgatherqq_256, vpgatherqq, vpgatherqq, 0, REGARG(YMM0), VSIBY(OPSZ_8),
        REGARG(YMM1))
 OPCODE(vgatherdps_256, vgatherdps, vgatherdps, 0, REGARG(YMM0), VSIBY(OPSZ_4),
        REGARG(YMM1))
-OPCODE(vgatherdpd_256, vgatherdpd, vgatherdpd, 0, REGARG(YMM0), VSIBY(OPSZ_8),
+OPCODE(vgatherdpd_256, vgatherdpd, vgatherdpd, 0, REGARG(YMM0), VSIBY(OPSZ_4),
        REGARG(YMM1))
-OPCODE(vgatherqps_256, vgatherqps, vgatherqps, 0, REGARG(YMM0), VSIBY(OPSZ_4),
+OPCODE(vgatherqps_256, vgatherqps, vgatherqps, 0, REGARG(YMM0), VSIBY(OPSZ_8),
        REGARG(YMM1))
 OPCODE(vgatherqpd_256, vgatherqpd, vgatherqpd, 0, REGARG(YMM0), VSIBY(OPSZ_8),
        REGARG(YMM1))


### PR DESCRIPTION
Fixes vm32x/vm64x VSIB element size for existing v(p)gather instructions in AVX2.

Issue: #1312