### PR TITLE
Modification for SIMD management for AArch64

### DIFF
--- a/core/arch/aarch64/instr.c
+++ b/core/arch/aarch64/instr.c
@@ -336,6 +336,12 @@ reg_is_gpr(reg_id_t reg)
 }
 
 bool
+reg_is_simd(reg_id_t reg)
+{
+    return (DR_REG_Q0 <= reg && reg <= DR_REG_B31);
+}
+
+bool
 reg_is_opmask(reg_id_t reg)
 {
     return false;

--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -223,7 +223,7 @@
  * \param r   The destination register opnd.
  * \param m   The source memory opnd.
  */
-#define XINST_CREATE_load_simd(dc, r, m) INSTR_CREATE_ldr((dc), (r), (m))
+#define XINST_CREATE_load_simd(dc, r, m) INSTR_CREATE_ld1((dc), (r), (m))
 
 /**
  * This platform-independent macro creates an instr_t for a multimedia
@@ -232,7 +232,7 @@
  * \param m   The destination memory opnd.
  * \param r   The source register opnd.
  */
-#define XINST_CREATE_store_simd(dc, m, r) INSTR_CREATE_str((dc), (m), (r))
+#define XINST_CREATE_store_simd(dc, m, r) INSTR_CREATE_st1((dc), (m), (r))
 
 /**
  * This platform-independent macro creates an instr_t for an indirect

--- a/core/arch/aarch64/instr_create.h
+++ b/core/arch/aarch64/instr_create.h
@@ -530,6 +530,14 @@
 #define INSTR_CREATE_ldp(dc, rt1, rt2, mem) \
     instr_create_2dst_1src(dc, OP_ldp, rt1, rt2, mem)
 #define INSTR_CREATE_ldr(dc, Rd, mem) instr_create_1dst_1src((dc), OP_ldr, (Rd), (mem))
+#define INSTR_CREATE_ld1(dc, Rd1, mem) \
+    instr_create_1dst_1src((dc), OP_ld1, (Rd1), (mem))
+#define INSTR_CREATE_ld2(dc, Rd1, Rd2, mem) \
+    instr_create_1dst_2src((dc), OP_ld2, (Rd1), (Rd2), (mem))
+#define INSTR_CREATE_ld3(dc, Rd1, Rd2, Rd3, mem) \
+    instr_create_1dst_3src((dc), OP_ld3, (Rd1), (Rd2), (Rd3), (mem))
+#define INSTR_CREATE_ld4(dc, Rd1, Rd2, Rd3, Rd4, mem) \
+    instr_create_1dst_4src((dc), OP_ld4, (Rd1), (Rd2), (Rd3), (Rd4), (mem))
 #define INSTR_CREATE_ldrb(dc, Rd, mem) instr_create_1dst_1src(dc, OP_ldrb, Rd, mem)
 #define INSTR_CREATE_ldrh(dc, Rd, mem) instr_create_1dst_1src(dc, OP_ldrh, Rd, mem)
 #define INSTR_CREATE_ldar(dc, Rt, mem) instr_create_1dst_1src((dc), OP_ldar, (Rt), (mem))
@@ -552,6 +560,14 @@
 #define INSTR_CREATE_stp(dc, mem, rt1, rt2) \
     instr_create_1dst_2src(dc, OP_stp, mem, rt1, rt2)
 #define INSTR_CREATE_str(dc, mem, rt) instr_create_1dst_1src(dc, OP_str, mem, rt)
+#define INSTR_CREATE_st1(dc, mem, rt1) \
+    instr_create_1dst_1src(dc, OP_st1, mem, rt1)
+#define INSTR_CREATE_st2(dc, mem, rt1, rt2) \
+    instr_create_1dst_2src(dc, OP_st2, mem, rt1, rt2)
+#define INSTR_CREATE_st3(dc, mem, rt1, rt2, rt3) \
+    instr_create_1dst_3src(dc, OP_st3, mem, rt1, rt2, rt3)
+#define INSTR_CREATE_st4(dc, mem, rt1, rt2, rt3, rt4) \
+    instr_create_1dst_4src(dc, OP_st4, mem, rt1, rt2, rt3, rt4)
 #define INSTR_CREATE_strb(dc, mem, rt) instr_create_1dst_1src(dc, OP_strb, mem, rt)
 #define INSTR_CREATE_strh(dc, mem, rt) instr_create_1dst_1src(dc, OP_strh, mem, rt)
 #define INSTR_CREATE_stur(dc, mem, rt) instr_create_1dst_1src(dc, OP_stur, mem, rt)

--- a/core/arch/arm/opcode.h
+++ b/core/arch/arm/opcode.h
@@ -994,6 +994,15 @@ enum {
     /* 924 */ OP_wfe,            /**< ARM wfe opcode. */
     /* 925 */ OP_wfi,            /**< ARM wfi opcode. */
     /* 926 */ OP_yield,          /**< ARM yield opcode. */
+        
+    /* 927 */ OP_ld1,            /**< ARM ld1 opcode. */
+    /* 928 */ OP_ld2,            /**< ARM ld2 opcode. */
+    /* 929 */ OP_ld3,            /**< ARM ld3 opcode. */
+    /* 930 */ OP_ld4,            /**< ARM ld4 opcode. */
+    /* 931 */ OP_st1,            /**< ARM st1 opcode. */
+    /* 932 */ OP_st2,            /**< ARM st2 opcode. */
+    /* 933 */ OP_st3,            /**< ARM st3 opcode. */
+    /* 934 */ OP_st4,            /**< ARM st4 opcode. */
 
     OP_AFTER_LAST,
     OP_FIRST = OP_adc,           /**< First real opcode. */


### PR DESCRIPTION
Modification of the SIMD Macros, creation of the ld1/2/3/4 and st1/2/3/4 Macros, added the opcodes for those instructions, added the missing reg_is_simd function to AArch64.