### PR TITLE
i#1312 AVX-512 support: Fix vpsrlw/d/q source operand.

### DIFF
--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -3887,7 +3887,7 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID,  0xf20fd110, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID,   0x0fd110, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf30fd110, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vpsrlw, 0x660fd110, "vpsrlw", Ve, xx, KEd, He, We, mrm|evex, x, tpe[104][10]},
+    {OP_vpsrlw, 0x660fd110, "vpsrlw", Ve, xx, KEd, He, Wdq, mrm|evex, x, tpe[104][10]},
     {INVALID, 0xf20fd110, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   }, /* prefix extension 57 */
   {
@@ -7732,14 +7732,14 @@ const instr_info_t evex_W_extensions[][2] = {
     {OP_vpsrad, 0x660f7234, "vpsrad", He, xx, KEw, Ib, We, mrm|evex, x, END_LIST},
     {OP_vpsraq, 0x660f7274, "vpsraq", He, xx, KEb, Ib, We, mrm|evex, x, END_LIST},
   }, { /* evex_W_ext 122 */
-    {OP_vpsrld, 0x660fd210, "vpsrld", Ve, xx, KEw, He, We, mrm|evex, x, tevexw[123][0]},
+    {OP_vpsrld, 0x660fd210, "vpsrld", Ve, xx, KEw, He, Wdq, mrm|evex, x, tevexw[123][0]},
     {INVALID, 0x660fd250,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
   }, { /* evex_W_ext 123 */
     {OP_vpsrld, 0x660f7232, "vpsrld", He, xx, KEw, Ib, We, mrm|evex, x, END_LIST},
     {INVALID, 0x660f7272,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
   }, { /* evex_W_ext 124 */
     {INVALID, 0x660fd310,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
-    {OP_vpsrlq, 0x660fd350, "vpsrlq", Ve, xx, KEb, He, We, mrm|evex, x, tevexw[125][1]},
+    {OP_vpsrlq, 0x660fd350, "vpsrlq", Ve, xx, KEb, He, Wdq, mrm|evex, x, tevexw[125][1]},
   }, { /* evex_W_ext 125 */
     {INVALID, 0x660f7332,"(bad)", xx,xx,xx,xx,xx,no,x,NA},
     {OP_vpsrlq, 0x660f7372, "vpsrlq", He, xx, KEb, Ib, We, mrm|evex, x, END_LIST},

--- a/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
+++ b/suite/tests/api/ir_x86_4args_avx512_evex_mask.h
@@ -4110,21 +4110,21 @@ OPCODE(vpsrlw_xhik7xhixmm, vpsrlw, vpsrlw_mask, X64_ONLY, REGARG(XMM16), REGARG(
 OPCODE(vpsrlw_xhik7xmmld, vpsrlw, vpsrlw_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
        REGARG(XMM2), MEMARG(OPSZ_16))
 OPCODE(vpsrlw_ylok0yloxmm, vpsrlw, vpsrlw_mask, 0, REGARG(YMM0), REGARG(K0), REGARG(YMM2),
-       REGARG(YMM1))
+       REGARG(XMM1))
 OPCODE(vpsrlw_ylok0xmmld, vpsrlw, vpsrlw_mask, 0, REGARG(YMM0), REGARG(K0), REGARG(YMM2),
-       MEMARG(OPSZ_32))
+       MEMARG(OPSZ_16))
 OPCODE(vpsrlw_yhik7yhixmm, vpsrlw, vpsrlw_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
-       REGARG(YMM2), REGARG(YMM17))
+       REGARG(YMM2), REGARG(XMM17))
 OPCODE(vpsrlw_yhik7xmmld, vpsrlw, vpsrlw_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
-       REGARG(YMM2), MEMARG(OPSZ_32))
+       REGARG(YMM2), MEMARG(OPSZ_16))
 OPCODE(vpsrlw_zlok0zloxmm, vpsrlw, vpsrlw_mask, 0, REGARG(ZMM0), REGARG(K0), REGARG(ZMM2),
-       REGARG(ZMM1))
+       REGARG(XMM1))
 OPCODE(vpsrlw_zlok0xmmld, vpsrlw, vpsrlw_mask, 0, REGARG(ZMM0), REGARG(K0), REGARG(ZMM2),
-       MEMARG(OPSZ_64))
+       MEMARG(OPSZ_16))
 OPCODE(vpsrlw_zhik7zhixmm, vpsrlw, vpsrlw_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
-       REGARG(ZMM2), REGARG(ZMM17))
+       REGARG(ZMM2), REGARG(XMM17))
 OPCODE(vpsrlw_zhik7xmmld, vpsrlw, vpsrlw_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
-       REGARG(ZMM2), MEMARG(OPSZ_64))
+       REGARG(ZMM2), MEMARG(OPSZ_16))
 OPCODE(vpsrld_xlok0xloxmm, vpsrld, vpsrld_mask, 0, REGARG(XMM0), REGARG(K0), REGARG(XMM2),
        REGARG(XMM1))
 OPCODE(vpsrld_xlok0xmmld, vpsrld, vpsrld_mask, 0, REGARG(XMM0), REGARG(K0), REGARG(XMM2),
@@ -4134,21 +4134,21 @@ OPCODE(vpsrld_xhik7xhixmm, vpsrld, vpsrld_mask, X64_ONLY, REGARG(XMM16), REGARG(
 OPCODE(vpsrld_xhik7xmmld, vpsrld, vpsrld_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
        REGARG(XMM2), MEMARG(OPSZ_16))
 OPCODE(vpsrld_ylok0yloxmm, vpsrld, vpsrld_mask, 0, REGARG(YMM0), REGARG(K0), REGARG(YMM2),
-       REGARG(YMM1))
+       REGARG(XMM1))
 OPCODE(vpsrld_ylok0xmmld, vpsrld, vpsrld_mask, 0, REGARG(YMM0), REGARG(K0), REGARG(YMM2),
-       MEMARG(OPSZ_32))
+       MEMARG(OPSZ_16))
 OPCODE(vpsrld_yhik7yhixmm, vpsrld, vpsrld_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
-       REGARG(YMM2), REGARG(YMM17))
+       REGARG(YMM2), REGARG(XMM17))
 OPCODE(vpsrld_yhik7xmmld, vpsrld, vpsrld_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
-       REGARG(YMM2), MEMARG(OPSZ_32))
+       REGARG(YMM2), MEMARG(OPSZ_16))
 OPCODE(vpsrld_zlok0zloxmm, vpsrld, vpsrld_mask, 0, REGARG(ZMM0), REGARG(K0), REGARG(ZMM2),
-       REGARG(ZMM1))
+       REGARG(XMM1))
 OPCODE(vpsrld_zlok0xmmld, vpsrld, vpsrld_mask, 0, REGARG(ZMM0), REGARG(K0), REGARG(ZMM2),
-       MEMARG(OPSZ_64))
+       MEMARG(OPSZ_16))
 OPCODE(vpsrld_zhik7zhixmm, vpsrld, vpsrld_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
-       REGARG(ZMM2), REGARG(ZMM17))
+       REGARG(ZMM2), REGARG(XMM17))
 OPCODE(vpsrld_zhik7xmmld, vpsrld, vpsrld_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
-       REGARG(ZMM2), MEMARG(OPSZ_64))
+       REGARG(ZMM2), MEMARG(OPSZ_16))
 OPCODE(vpsrlq_xlok0xloxmm, vpsrlq, vpsrlq_mask, 0, REGARG(XMM0), REGARG(K0), REGARG(XMM2),
        REGARG(XMM1))
 OPCODE(vpsrlq_xlok0xmmld, vpsrlq, vpsrlq_mask, 0, REGARG(XMM0), REGARG(K0), REGARG(XMM2),
@@ -4158,21 +4158,21 @@ OPCODE(vpsrlq_xhik7xhixmm, vpsrlq, vpsrlq_mask, X64_ONLY, REGARG(XMM16), REGARG(
 OPCODE(vpsrlq_xhik7xmmld, vpsrlq, vpsrlq_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
        REGARG(XMM2), MEMARG(OPSZ_16))
 OPCODE(vpsrlq_ylok0yloxmm, vpsrlq, vpsrlq_mask, 0, REGARG(YMM0), REGARG(K0), REGARG(YMM2),
-       REGARG(YMM1))
+       REGARG(XMM1))
 OPCODE(vpsrlq_ylok0xmmld, vpsrlq, vpsrlq_mask, 0, REGARG(YMM0), REGARG(K0), REGARG(YMM2),
-       MEMARG(OPSZ_32))
+       MEMARG(OPSZ_16))
 OPCODE(vpsrlq_yhik7yhixmm, vpsrlq, vpsrlq_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
-       REGARG(YMM2), REGARG(YMM17))
+       REGARG(YMM2), REGARG(XMM17))
 OPCODE(vpsrlq_yhik7xmmld, vpsrlq, vpsrlq_mask, X64_ONLY, REGARG(YMM16), REGARG(K7),
-       REGARG(YMM2), MEMARG(OPSZ_32))
+       REGARG(YMM2), MEMARG(OPSZ_16))
 OPCODE(vpsrlq_zlok0zloxmm, vpsrlq, vpsrlq_mask, 0, REGARG(ZMM0), REGARG(K0), REGARG(ZMM2),
-       REGARG(ZMM1))
+       REGARG(XMM1))
 OPCODE(vpsrlq_zlok0xmmld, vpsrlq, vpsrlq_mask, 0, REGARG(ZMM0), REGARG(K0), REGARG(ZMM2),
-       MEMARG(OPSZ_64))
+       MEMARG(OPSZ_16))
 OPCODE(vpsrlq_zhik7zhixmm, vpsrlq, vpsrlq_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
-       REGARG(ZMM2), REGARG(ZMM17))
+       REGARG(ZMM2), REGARG(XMM17))
 OPCODE(vpsrlq_zhik7xmmld, vpsrlq, vpsrlq_mask, X64_ONLY, REGARG(ZMM16), REGARG(K7),
-       REGARG(ZMM2), MEMARG(OPSZ_64))
+       REGARG(ZMM2), MEMARG(OPSZ_16))
 OPCODE(vpsravw_xlok0xloxlo, vpsravw, vpsravw_mask, 0, REGARG(XMM0), REGARG(K0),
        REGARG(XMM2), REGARG(XMM1))
 OPCODE(vpsravw_xlok0xlold, vpsravw, vpsravw_mask, 0, REGARG(XMM0), REGARG(K0),


### PR DESCRIPTION
Similar to bf6579986a0712d685c8da, fix source operand's size. The encodings were still
correct and therefore bug was not discovered by comparing binutils, llvm-mc etc. All
related similar vps* opcodes have been checked.

Fix related tests.

Issues: #1312, #3639