### PR TITLE
i#975 static DR: add dr_standalone_exit()

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -196,6 +196,7 @@ Further non-compatibility-affecting changes include:
  - Added the functions instr_set_encoding_hint(), instr_has_encoding_hint().
  - Added the type #dr_encoding_hint_type_t.
  - Added #INSTR_ENCODING_HINT macro.
+ - Added dr_standalone_exit() with support for re-attaching afterward.
 
 **************************************************
 <hr>

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -942,8 +942,19 @@ standalone_init(void)
 void
 standalone_exit(void)
 {
-    /* should clean up here */
+    /* We support re-attach by setting doing_detach. */
+    doing_detach = true;
+    config_heap_exit();
+    os_fast_exit();
+    os_slow_exit();
+    dynamo_vm_areas_exit();
+    d_r_heap_exit();
+    vmm_heap_exit();
+    options_exit();
     d_r_config_exit();
+    doing_detach = false;
+    standalone_library = false;
+    dynamo_initialized = false;
 }
 #endif
 
@@ -2708,7 +2719,7 @@ dr_app_setup(void)
     dcontext_t *dcontext;
     dr_api_entry = true;
     res = dynamorio_app_init();
-    /* For dr_api_entry, we do not install signal handlers during init (to avoid
+    /* For dr_api_entry, we do not install all our signal handlers during init (to avoid
      * races: i#2335): we delay until dr_app_start().  Plus the vsyscall hook is
      * not set up until we find out the syscall method.  Thus we're already
      * "os_process_not_under_dynamorio".

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -2456,6 +2456,13 @@ dr_standalone_init(void)
 }
 
 DR_API
+void
+dr_standalone_exit(void)
+{
+    standalone_exit();
+}
+
+DR_API
 /* Aborts the process immediately */
 void
 dr_abort(void)

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -1615,6 +1615,14 @@ DR_API
 void *
 dr_standalone_init(void);
 
+DR_API
+/**
+ * Restores application state modified by dr_standalone_init(), which can
+ * include some signal handlers.
+ */
+void
+dr_standalone_exit(void);
+
 /* DR_API EXPORT BEGIN */
 
 #    ifdef API_EXPORT_ONLY

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -1572,6 +1572,13 @@ dynamo_vm_areas_init()
     VMVECTOR_ALLOC_VECTOR(dynamo_areas, GLOBAL_DCONTEXT, VECTOR_SHARED, dynamo_areas);
 }
 
+void
+dynamo_vm_areas_exit()
+{
+    vmvector_delete_vector(GLOBAL_DCONTEXT, dynamo_areas);
+    dynamo_areas = NULL;
+}
+
 /* calls find_executable_vm_areas to get per-process map
  * N.B.: add_dynamo_vm_area can be called before this init routine!
  * N.B.: this is called after vm_areas_thread_init()
@@ -1754,8 +1761,7 @@ vm_areas_exit()
             LOG(GLOBAL, LOG_VMAREAS, 1, "\n");
         }
     });
-    vmvector_delete_vector(GLOBAL_DCONTEXT, dynamo_areas);
-    dynamo_areas = NULL;
+    dynamo_vm_areas_exit();
     DOLOG(1, LOG_VMAREAS, {
         if (written_areas->buf != NULL) {
             LOG(GLOBAL, LOG_VMAREAS, 1, "Code write and selfmod exec counts:\n");

--- a/core/vmareas.h
+++ b/core/vmareas.h
@@ -240,6 +240,9 @@ vmvector_iterator_stop(vmvector_iterator_t *vmvi);
 void
 dynamo_vm_areas_init(void);
 
+void
+dynamo_vm_areas_exit(void);
+
 /* initialize per process */
 int
 vm_areas_init(void);

--- a/suite/tests/api/static_noclient.c
+++ b/suite/tests/api/static_noclient.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -35,6 +35,7 @@
 #include "configure.h"
 #include "dr_api.h"
 #include "tools.h"
+#include <assert.h>
 #include <math.h>
 
 static int
@@ -49,9 +50,24 @@ do_some_work(int seed)
     return (val > 0);
 }
 
-int
-main(int argc, const char *argv[])
+static void
+test_static_decode_before_attach(void)
 {
+    /* FIXME i#2040: this hits the app_fls_data assert on Windows. */
+#ifdef UNIX
+    /* Test restoration of signal state. */
+    int res;
+    sigset_t mask = {
+        0, /* Set padding to 0 so we can use memcmp */
+    };
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGBUS);
+    sigaddset(&mask, SIGUSR2);
+    res = sigprocmask(SIG_BLOCK, &mask, NULL);
+    assert(res == 0);
+    intercept_signal(SIGUSR1, (handler_3_t)SIG_IGN, false);
+    intercept_signal(SIGBUS, (handler_3_t)SIG_IGN, false);
+
     /* We test using DR IR routines when statically linked.  We can't use
      * drdecode when statically linked with DR as drdecode relies on symbol
      * replacement, so instead we initialize DR and then "detach" to do a full
@@ -59,15 +75,30 @@ main(int argc, const char *argv[])
      * attach+detach testing.
      * XXX: When there's a client, this requires a flag to skip the client init
      * in this first dr_app_setup().
-     * FIXME i#2040: this hits the app_fls_data assert on Windows.
      */
-#ifdef UNIX
-    dr_app_setup();
+    dr_standalone_init();
     instr_t *instr = XINST_CREATE_return(GLOBAL_DCONTEXT);
     assert(instr_is_return(instr));
     instr_destroy(GLOBAL_DCONTEXT, instr);
-    dr_app_stop_and_cleanup();
+    dr_standalone_exit();
+
+    sigset_t check_mask = {
+        0, /* Set padding to 0 so we can use memcmp */
+    };
+    res = sigprocmask(SIG_BLOCK, NULL, &check_mask);
+    assert(res == 0 && memcmp(&mask, &check_mask, sizeof(mask)) == 0);
+    struct sigaction act;
+    res = sigaction(SIGUSR1, NULL, &act);
+    assert(res == 0 && (handler_3_t)act.sa_sigaction == (handler_3_t)SIG_IGN);
+    res = sigaction(SIGBUS, NULL, &act);
+    assert(res == 0 && (handler_3_t)act.sa_sigaction == (handler_3_t)SIG_IGN);
 #endif
+}
+
+int
+main(int argc, const char *argv[])
+{
+    test_static_decode_before_attach();
 
     print("pre-DR init\n");
     dr_app_setup();


### PR DESCRIPTION
Adds dr_standalone_exit() with support for subsequent DR use,
including full attach.  This is a better solution than setup;detach
support added in de99d45 for the use case of performing DR
decode/encode with DR statically linked (which precludes using
drdecodelib), followed by a separate use of DR for instrumentation.

Updates the test of this use case in api.static_noclient.

Issue: #975