### PR TITLE
i#3719 invalid reg: Avoid an invalid mask reg when decoding

### DIFF
--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -1514,7 +1514,11 @@ decode_reg(decode_reg_t which_reg, decode_info_t *di, byte optype, opnd_size_t o
     case TYPE_K_MODRM:
     case TYPE_K_MODRM_R:
     case TYPE_K_VEX:
-    case TYPE_K_EVEX: return DR_REG_START_OPMASK + reg;
+    case TYPE_K_EVEX:
+        /* XXX i#3719: DECODE_REG_{,E}VEX above produce a number up to 15, but
+         * there are only 8 K registers!  For now truncating at 7.
+         */
+        return DR_REG_START_OPMASK + (reg & 7);
     case TYPE_E:
     case TYPE_G:
     case TYPE_R:


### PR DESCRIPTION
Caps the mask register when decoding AVX-512 operands to be a valid
0..7 register rather than generating non-existent values.

Issue: #3719, #1312