### PR TITLE
i#1312 AVX-512 support: Move encoding_hint API to instr_shared.

### DIFF
--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -1266,6 +1266,19 @@ instr_length(dcontext_t *dcontext, instr_t *instr)
     return private_instr_encode(dcontext, instr, false /*don't need to cache*/);
 }
 
+instr_t *
+instr_set_encoding_hint(instr_t *instr, dr_encoding_hint_type_t hint)
+{
+    instr->encoding_hints |= hint;
+    return instr;
+}
+
+bool
+instr_has_encoding_hint(instr_t *instr, dr_encoding_hint_type_t hint)
+{
+    return TEST(hint, instr->encoding_hints);
+}
+
 /***********************************************************************/
 /* decoding routines */
 

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -94,19 +94,6 @@ instr_get_isa_mode(instr_t *instr)
 #endif
 }
 
-instr_t *
-instr_set_encoding_hint(instr_t *instr, dr_encoding_hint_type_t hint)
-{
-    instr->encoding_hints |= hint;
-    return instr;
-}
-
-bool
-instr_has_encoding_hint(instr_t *instr, dr_encoding_hint_type_t hint)
-{
-    return TEST(hint, instr->encoding_hints);
-}
-
 int
 instr_length_arch(dcontext_t *dcontext, instr_t *instr)
 {


### PR DESCRIPTION
Moves instr_set_encoding_hints and instr_has_encoding_hint to instr_shared where they
belong.

Issue: #1312