### PR TITLE
i#1312 AVX-512 support: Revert accidental vera++ check suppression.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1765,6 +1765,8 @@ endif (CLIENT_INTERFACE OR APP_EXPORTS)
 ###########################################################################
 # Style checks:
 
+option(VERA_ERROR "Turn vera++ checks into error (default)" ON)
+
 find_package(vera++ QUIET)
 if (vera++_FOUND)
   message(STATUS "Using vera++ for code style checks")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1766,7 +1766,7 @@ endif (CLIENT_INTERFACE OR APP_EXPORTS)
 # Style checks:
 
 find_package(vera++ QUIET)
-if (0 AND vera++_FOUND)
+if (vera++_FOUND)
   message(STATUS "Using vera++ for code style checks")
   include(${VERA++_USE_FILE})
   # We use our own modified copy in order to pass --error and for

--- a/third_party/vera++/use_vera++.cmake
+++ b/third_party/vera++/use_vera++.cmake
@@ -127,6 +127,11 @@ function(add_vera_targets_for_dynamorio)
           set(currentDir ".")
         endif()
         set(xmlreport ${CMAKE_CURRENT_BINARY_DIR}/vera_report_${reportNb}.xml)
+        if (VERA_ERROR)
+          set(error_or_warning --error)
+        else ()
+          set(error_or_warning --warning)
+        endif (VERA_ERROR)
         add_custom_command(
           OUTPUT ${xmlreport}
           COMMAND ${vera_program}
@@ -134,7 +139,7 @@ function(add_vera_targets_for_dynamorio)
             --profile ${profile}
             --${style}-report=-
             --show-rule
-            --error
+            ${error_or_warning}
             --xml-report=${xmlreport}
             ${exclusions}
             ${reportsrcs}
@@ -149,7 +154,7 @@ function(add_vera_targets_for_dynamorio)
             --profile ${profile}
             --${style}-report=-
             --show-rule
-            --error
+            ${error_or_warning}
             # --xml-report=${noreport}
             ${exclusions}
             ${reportsrcs}


### PR DESCRIPTION
Reverts suppressing vera++ checks incorrectly committed by e20fec822538d08.

Adds the option VERA_ERROR that optionally can be set to OFF in order to turn vera++
errors into a warning. The default is ON.

Issue: #1312