### PR TITLE
i#1312 AVX-512 support: Fix alignment parameters when calling move_mm_reg_opcode.

### DIFF
--- a/core/arch/x86/emit_utils.c
+++ b/core/arch/x86/emit_utils.c
@@ -1352,7 +1352,7 @@ append_restore_simd_reg(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
          * cost of vmovdqu and whether worth arranging 32-byte alignment
          */
         int i;
-        uint opcode = move_mm_reg_opcode(true /*align32*/, true /*align16*/);
+        uint opcode = move_mm_reg_opcode(true /*align16*/, true /*align32*/);
         ASSERT(proc_has_feature(FEATURE_SSE));
         for (i = 0; i < proc_num_simd_saved(); i++) {
             APP(ilist,
@@ -1575,7 +1575,7 @@ append_save_simd_reg(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
          * cost of vmovdqu and whether worth arranging 32-byte alignment
          */
         int i;
-        uint opcode = move_mm_reg_opcode(true /*align32*/, true /*align16*/);
+        uint opcode = move_mm_reg_opcode(true /*align16*/, true /*align32*/);
         ASSERT(proc_has_feature(FEATURE_SSE));
         for (i = 0; i < proc_num_simd_saved(); i++) {
             APP(ilist,

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -514,7 +514,7 @@ insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
         int i;
         /* See discussion in emit_fcache_enter_shared on which opcode
          * is better. */
-        uint opcode = move_mm_reg_opcode(ALIGNED(alignment, 32), ALIGNED(alignment, 16));
+        uint opcode = move_mm_reg_opcode(ALIGNED(alignment, 16), ALIGNED(alignment, 32));
         ASSERT(proc_has_feature(FEATURE_SSE));
         /* XXX i#1312: This assumption will change and the code below will need
          * to take this into account.


### PR DESCRIPTION
Fixes two comments and one real bug when passing alignment flags to move_mm_reg_opcode().
This patch is not directly related to AVX-512.

Issue: #1312