### PR TITLE
i#2566 anon text: Use the app path instead of maps comments

### DIFF
--- a/clients/drcachesim/tests/burst_maps.cpp
+++ b/clients/drcachesim/tests/burst_maps.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -57,6 +57,8 @@
 #define MAPS_LINE_MAX8 73 /* sum of 16  1  16  1 4 1 16 1 5 1 10 1 */
 #define MAPS_LINE_MAX MAPS_LINE_MAX8
 
+char exe_path[MAPS_LINE_LENGTH];
+
 void *
 find_exe_base()
 {
@@ -82,6 +84,8 @@ find_exe_base()
         if (len < 4)
             comment_buffer[0] = '\0';
         if (strstr(comment_buffer, "burst_maps") != 0) {
+            strncpy(exe_path, comment_buffer, BUFFER_SIZE_ELEMENTS(exe_path));
+            NULL_TERMINATE_BUFFER(exe_path);
             fclose(maps);
             return vm_start;
         }
@@ -135,6 +139,17 @@ clobber_mapping()
     copy_and_remap(exe, 0, clobber_size);
     copy_and_remap(exe, 4 * clobber_size, clobber_size);
     copy_and_remap(exe, 8 * clobber_size, clobber_size);
+}
+
+DR_EXPORT void
+dr_client_main(client_id_t id, int argc, const char *argv[])
+{
+    /* Test the full_path used by DR when the maps file comments can't be used. */
+    module_data_t *exe = dr_get_main_module();
+    assert(exe != nullptr);
+    assert(exe->full_path != nullptr);
+    assert(strcmp(exe->full_path, exe_path) == 0);
+    dr_free_module_data(exe);
 }
 
 int

--- a/clients/drcachesim/tests/burst_maps.cpp
+++ b/clients/drcachesim/tests/burst_maps.cpp
@@ -141,6 +141,10 @@ clobber_mapping()
     copy_and_remap(exe, 8 * clobber_size, clobber_size);
 }
 
+extern "C" {
+extern DR_EXPORT void
+drmemtrace_client_main(client_id_t id, int argc, const char *argv[]);
+
 DR_EXPORT void
 dr_client_main(client_id_t id, int argc, const char *argv[])
 {
@@ -150,6 +154,8 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     assert(exe->full_path != nullptr);
     assert(strcmp(exe->full_path, exe_path) == 0);
     dr_free_module_data(exe);
+    drmemtrace_client_main(id, argc, argv);
+}
 }
 
 int


### PR DESCRIPTION
For the application module, we use the application path obtained from
early injection or /proc/self/exe on Linux, rather than
/proc/self/maps comments.  The maps comments can be unreliable in the
face of anonymous or deleted-file mremaps used for hugepage backing
and other features.

Adds a test case to the existing "burst_maps" test.

Having the right module full_path helps many cases, including the
forthcoming restartable sequences ("rseq") support for #2350.

Issue: #2566, #2350