### PR TITLE
i#2350 rseq: Add initial handling of mainline kernel rseq

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1082,6 +1082,12 @@ if (NOT DISABLE_WARNINGS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARN}")
 endif (NOT DISABLE_WARNINGS)
 
+if (LINUX)
+  CHECK_INCLUDE_FILE("linux/rseq.h" HAVE_RSEQ)
+else ()
+  set(HAVE_RSEQ OFF)
+endif ()
+
 ###########################################################################
 
 # Issue 20: cross-arch execve depends on these being distinct and not

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -136,13 +136,13 @@ clients.
 The changes between version \DR_VERSION and 7.1.0 include the following compatibility
 changes:
 
- - Changes the enumeration of the DR_REG_ enum by adding x86 AVX-512 registers as well
+ - Changed the enumeration of the DR_REG_ enum by adding x86 AVX-512 registers as well
    as reserved ranges for future extensions.
    This is a binary compatibility change for the DR_REG_ enum.
- - Changes the enumeration of the OPSZ_ enum by moving its start back to 0. The OPSZ_
+ - Changed the enumeration of the OPSZ_ enum by moving its start back to 0. The OPSZ_
    enum now completely overlaps the DR_REG_ enum.
    This is a binary compatibility change for the OPSZ_ enum.
- - Adds a new encoding hint field to #instr_t.
+ - Added a new encoding hint field to #instr_t.
 
 The changes between version \DR_VERSION and 7.1.0 include the following minor
 compatibility changes:
@@ -200,6 +200,8 @@ Further non-compatibility-affecting changes include:
  - Added dr_mcontext_zmm_fields_valid() to query the state of lazy AVX-512 context
    switching.
  - Added the function proc_avx512_enabled().
+ - Added support for applications using the Linux kernel's restartable sequence
+   ("rseq") feature, subject to the limitations listed in \ref sec_limit_platforms.
 
 **************************************************
 <hr>
@@ -1631,6 +1633,20 @@ not supported.
     not fully decoded or encoded yet, and a few features are not yet
     ported: traces, clean call inlining and other optimizations, and
     several samples and provided tools.
+  - This release of DynamoRIO adds support for applications using the Linux kernel
+    restartable sequence ("rseq") feature, subject to the following limitations:
+    - The application must store an rseq_cs struct for each rseq region in a
+      section of its binary named "__rseq_cs", optionally with an "__rseq_cs_ptr_array"
+      section of pointers into the __rseq_cs section, per established conventions.
+    - Each rseq region's code must never be also executed as a non-restartable sequence.
+    - Each rseq region must make forward progress if its abort handler is always
+      called the first time it is executed.
+    - Each memory store instruction inside an rseq region must have no other side
+      effects: it must only write to memory and not to any registers.
+    - Each rseq region must end with a return instruction, and each abort handler
+      plus rseq code must combine into a callee following normal call-return
+      semantics.
+    - Any helper function called from within an rseq region must have no side effects.
 
 \subsection sec_limit_perf Performance Limitations
 
@@ -1751,14 +1767,14 @@ not supported.
 We hope to include the following major features in future releases:
 
  - Libraries to facilitate building tools that use shadow memory, examine
-   system calls, and insert heavyweight instrumentation
+   system calls, and insert heavyweight instrumentation.
  - Earliest Windows injection.  Today drinject injects fairly late; from a
    parent process, injection is very early (before kernel32.dll is loaded),
    but we plan to provide injection at the very first user-mode instruction
    in the future.
- - More flexible (earlier, or later via attach) Linux injection
- - Persistent and process-shared code caches
- - Full control over trace building
+ - Linux externally-triggered attaching.
+ - Persistent and process-shared code caches.
+ - Full control over trace building.
 
 To discuss current and future features, join the <a
 href="http://groups.google.com/group/dynamorio-users/">DynamoRIO Users

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -3303,7 +3303,11 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
              /* to split riprel, need to decode every instr */
              /* in x86_to_x64, need to translate every x86 instr */
              IF_X64(|| DYNAMO_OPTION(coarse_split_riprel) || DYNAMO_OPTION(x86_to_x64))
-                 IF_CLIENT_INTERFACE(|| INTERNAL_OPTION(full_decode)))
+                 IF_CLIENT_INTERFACE(|| INTERNAL_OPTION(full_decode))
+         /* We separate rseq regions into their own blocks to make this check easier. */
+         IF_LINUX(||
+                  (!vmvector_empty(d_r_rseq_areas) &&
+                   vmvector_overlap(d_r_rseq_areas, bb->start_pc, bb->start_pc + 1))))
         bb->full_decode = true;
     else {
 #if defined(STEAL_REGISTER) || defined(CHECK_RETURNS_SSE2)

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -771,6 +771,123 @@ mangle_syscall_code(dcontext_t *dcontext, fragment_t *f, byte *pc, bool skip)
 }
 #endif /* UNIX */
 
+#ifdef LINUX
+/* Returns whether it destroyed "instr". */
+static bool
+mangle_rseq(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr, instr_t *next_instr)
+{
+    app_pc pc = get_app_instr_xl8(instr);
+    app_pc start, end, handler;
+    if (!vmvector_lookup_data(d_r_rseq_areas, pc, &start, &end, (void **)&handler)) {
+        ASSERT_NOT_REACHED(); /* Caller was supposed to check for overlap */
+        return false;
+    }
+    int len = instr_length(dcontext, instr);
+    if (pc + len >= end) {
+        if (pc + len != end) {
+            REPORT_FATAL_ERROR_AND_EXIT(
+                RSEQ_BEHAVIOR_UNSUPPORTED, 3, get_application_name(),
+                get_application_pid(),
+                "Malformed rseq endpoint: not on instruction boundary");
+            ASSERT_NOT_REACHED();
+        }
+#    ifdef X86
+        /* We just ran the instrumented version of the rseq code, with the stores
+         * removed.  Now we need to invoke it again natively for real.  We have to
+         * invoke the abort handler, not the rseq start, as it may perform some setup.
+         *
+         * XXX i#2350: We assume the code can handle "aborting" once every time and
+         * still make forward progress.  We document this in our Limitations section.
+         * We also ignore the flags for when to restart.  It's possible the app
+         * disabled restarts on preempts and migrations and can't handle our restart
+         * here.
+         */
+        LOG(THREAD, LOG_INTERP, 4, "mangle: inserting call to native rseq " PFX "\n",
+            handler);
+        RSTATS_INC(num_rseq_native_calls_inserted);
+        /* For simplicity in this first version of the code, we assume call-return
+         * semantics for the abort handler + rseq region.  We create an extra frame
+         * and assume that causes no problems.  We assume the native invocation will
+         * come back to us.
+         * TODO i#2350: Make a copy of the rseq code and append a "return" as a jmp*
+         * through TLS.  Make a copy of the abort handler too.  Decode it and ensure
+         * it transitions directly to the rseq code (if not, bail).  "Call" the
+         * copied abort handler+rseq by setting the retaddr in TLS and jumping.  Then
+         * we have a guaranteed return and no extra frame, with verified assumptions.
+         */
+        instr_t check;
+        instr_init(dcontext, &check);
+        if (decode_cti(dcontext, end, &check) == NULL || !instr_is_return(&check)) {
+            REPORT_FATAL_ERROR_AND_EXIT(RSEQ_BEHAVIOR_UNSUPPORTED, 3,
+                                        get_application_name(), get_application_pid(),
+                                        "Rseq sequences must end with a return");
+            ASSERT_NOT_REACHED();
+        }
+        instr_free(dcontext, &check);
+        /* We assume that by making this a block end, clients will restore app state
+         * before this native invocation.
+         * TODO i#2350: Take some further action to better guarantee this in the face
+         * of future drreg optimizations, etc.  Do we need new interface features, or
+         * do we live with a fake app jump or sthg?
+         */
+        /* A direct call may not reach so we clobber a scratch register. */
+        instrlist_insert_mov_immed_ptrsz(dcontext, (ptr_int_t)handler,
+                                         opnd_create_reg(DR_REG_RAX), ilist, next_instr,
+                                         NULL, NULL);
+        /* Set up the frame and stack alignment.  We assume the rseq code was a leaf
+         * function and that rsp is 16-aligned now.
+         */
+        instrlist_meta_preinsert(ilist, next_instr,
+                                 XINST_CREATE_sub(dcontext, opnd_create_reg(DR_REG_RSP),
+                                                  OPND_CREATE_INT32(8)));
+        instrlist_meta_preinsert(
+            ilist, next_instr,
+            INSTR_CREATE_call_ind(dcontext, opnd_create_reg(DR_REG_RAX)));
+        instrlist_meta_preinsert(ilist, next_instr,
+                                 XINST_CREATE_add(dcontext, opnd_create_reg(DR_REG_RSP),
+                                                  OPND_CREATE_INT32(8)));
+#    else
+        /* TODO i#2350: Add non-x86 support. */
+        REPORT_FATAL_ERROR_AND_EXIT(RSEQ_BEHAVIOR_UNSUPPORTED, 3, get_application_name(),
+                                    get_application_pid(),
+                                    "Rseq is not yet supported for non-x86");
+        ASSERT_NOT_REACHED();
+
+#    endif
+    }
+
+    /* If we're inside a restartable sequence, this is the first run which is
+     * instrumented and will be aborted/restarted.  We need to avoid *all* stores,
+     * not just the final commit point, because the sequence could be using the wrong cpu
+     * and could be editing a per-cpu data structure that another thread is touching
+     * at the same time.
+     */
+    if (!instr_writes_memory(instr))
+        return false;
+    /* We allow a call to a helper function, since this happens in some apps we target.
+     * The helper is assumed to have no side effects.
+     */
+    if (instr_is_call(instr))
+        return false;
+    /* XXX i#2350: We want to turn just the store portion of the instr into a nop
+     * and keep any register side effects.  That is complex, however.  For now we
+     * only support simple stores.
+     */
+    if (instr_num_dsts(instr) > 1) {
+        REPORT_FATAL_ERROR_AND_EXIT(RSEQ_BEHAVIOR_UNSUPPORTED, 3, get_application_name(),
+                                    get_application_pid(),
+                                    "Store inside rseq region has multiple destinations");
+        ASSERT_NOT_REACHED();
+    }
+    LOG(THREAD, LOG_INTERP, 4, "mangle: removing store inside rseq region @" PFX "\n",
+        pc);
+    RSTATS_INC(num_rseq_stores_elided);
+    instrlist_remove(ilist, instr);
+    instr_destroy(dcontext, instr);
+    return true; /* destroyed instr */
+}
+#endif /* LINUX */
+
 /* TOP-LEVEL MANGLE
  * This routine is responsible for mangling a fragment into the form
  * we'd like prior to placing it in the code cache
@@ -856,6 +973,22 @@ d_r_mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags INOUT, bool man
             IF_WINDOWS_ELSE(is_wow64_process(NT_CURRENT_PROCESS), false) &&
             instr_get_x86_mode(instr))
             translate_x86_to_x64(dcontext, ilist, &instr);
+#endif
+
+#ifdef LINUX
+        /* Mangle stores inside restartable sequences ("rseq").  We could avoid the
+         * per-instr check if we disallowed rseq blocks in traces and prevented
+         * fall-through in a bb, but that would lead to more problems than it would
+         * solve.  We expect the vmvector_empty check to be fast enough for the common
+         * case.
+         */
+        if (instr_is_app(instr) && !vmvector_empty(d_r_rseq_areas)) {
+            app_pc pc = get_app_instr_xl8(instr);
+            if (vmvector_overlap(d_r_rseq_areas, pc, pc + 1)) {
+                if (mangle_rseq(dcontext, ilist, instr, next_instr))
+                    continue; /* instr was destroyed */
+            }
+        }
 #endif
 
 #if defined(UNIX) && defined(X86)

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -831,9 +831,8 @@ mangle_rseq(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr, instr_t *n
          * do we live with a fake app jump or sthg?
          */
         /* A direct call may not reach so we clobber a scratch register. */
-        instrlist_insert_mov_immed_ptrsz(dcontext, (ptr_int_t)handler,
-                                         opnd_create_reg(DR_REG_RAX), ilist, next_instr,
-                                         NULL, NULL);
+        insert_mov_immed_ptrsz(dcontext, (ptr_int_t)handler, opnd_create_reg(DR_REG_RAX),
+                               ilist, next_instr, NULL, NULL);
         /* Set up the frame and stack alignment.  We assume the rseq code was a leaf
          * function and that rsp is 16-aligned now.
          */

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -1237,3 +1237,8 @@ STATS_DEF("App access FS/GS seg being mangled", app_mov_seg_mangled)
 STATS_DEF("Reg spills for non-mbr mangling", non_mbr_spills)
 STATS_DEF("Reg respill for non-mbr mangling avoided", non_mbr_respill_avoided)
 #endif
+#ifdef LINUX
+RSTATS_DEF("Rseq regions identified", num_rseq_regions)
+RSTATS_DEF("Rseq instrumented stores elided", num_rseq_stores_elided)
+RSTATS_DEF("Rseq native calls inserted", num_rseq_native_calls_inserted)
+#endif

--- a/core/unix/include/syscall_linux_arm.h
+++ b/core/unix/include/syscall_linux_arm.h
@@ -403,6 +403,27 @@
 #    define __NR_setns (__NR_SYSCALL_BASE + 375)
 #    define __NR_process_vm_readv (__NR_SYSCALL_BASE + 376)
 #    define __NR_process_vm_writev (__NR_SYSCALL_BASE + 377)
+#    define __NR_kcmp (__NR_SYSCALL_BASE + 378)
+#    define __NR_finit_module (__NR_SYSCALL_BASE + 379)
+#    define __NR_sched_setattr (__NR_SYSCALL_BASE + 380)
+#    define __NR_sched_getattr (__NR_SYSCALL_BASE + 381)
+#    define __NR_renameat2 (__NR_SYSCALL_BASE + 382)
+#    define __NR_seccomp (__NR_SYSCALL_BASE + 383)
+#    define __NR_getrandom (__NR_SYSCALL_BASE + 384)
+#    define __NR_memfd_create (__NR_SYSCALL_BASE + 385)
+#    define __NR_bpf (__NR_SYSCALL_BASE + 386)
+#    define __NR_execveat (__NR_SYSCALL_BASE + 387)
+#    define __NR_userfaultfd (__NR_SYSCALL_BASE + 388)
+#    define __NR_membarrier (__NR_SYSCALL_BASE + 389)
+#    define __NR_mlock2 (__NR_SYSCALL_BASE + 390)
+#    define __NR_copy_file_range (__NR_SYSCALL_BASE + 391)
+#    define __NR_preadv2 (__NR_SYSCALL_BASE + 392)
+#    define __NR_pwritev2 (__NR_SYSCALL_BASE + 393)
+#    define __NR_pkey_mprotect (__NR_SYSCALL_BASE + 394)
+#    define __NR_pkey_alloc (__NR_SYSCALL_BASE + 395)
+#    define __NR_pkey_free (__NR_SYSCALL_BASE + 396)
+#    define __NR_statx (__NR_SYSCALL_BASE + 397)
+#    define __NR_rseq (__NR_SYSCALL_BASE + 398)
 
 /*
  * The following SWIs are ARM private.
@@ -449,6 +470,7 @@
 #    define SYS_arm_sync_file_range __NR_arm_sync_file_range
 #    define SYS_bdflush __NR_bdflush
 #    define SYS_bind __NR_bind
+#    define SYS_bpf __NR_bpf
 #    define SYS_brk __NR_brk
 #    define SYS_capget __NR_capget
 #    define SYS_capset __NR_capset
@@ -465,6 +487,7 @@
 #    define SYS_clone __NR_clone
 #    define SYS_close __NR_close
 #    define SYS_connect __NR_connect
+#    define SYS_copy_file_range __NR_copy_file_range
 #    define SYS_creat __NR_creat
 #    define SYS_delete_module __NR_delete_module
 #    define SYS_dup __NR_dup
@@ -478,6 +501,7 @@
 #    define SYS_eventfd __NR_eventfd
 #    define SYS_eventfd2 __NR_eventfd2
 #    define SYS_execve __NR_execve
+#    define SYS_execveat __NR_execveat
 #    define SYS_exit __NR_exit
 #    define SYS_exit_group __NR_exit_group
 #    define SYS_faccessat __NR_faccessat
@@ -494,6 +518,7 @@
 #    define SYS_fcntl64 __NR_fcntl64
 #    define SYS_fdatasync __NR_fdatasync
 #    define SYS_fgetxattr __NR_fgetxattr
+#    define SYS_finit_module __NR_finit_module
 #    define SYS_flistxattr __NR_flistxattr
 #    define SYS_flock __NR_flock
 #    define SYS_fork __NR_fork
@@ -530,6 +555,7 @@
 #    define SYS_getpid __NR_getpid
 #    define SYS_getppid __NR_getppid
 #    define SYS_getpriority __NR_getpriority
+#    define SYS_getrandom __NR_getrandom
 #    define SYS_getresgid __NR_getresgid
 #    define SYS_getresgid32 __NR_getresgid32
 #    define SYS_getresuid __NR_getresuid
@@ -556,6 +582,7 @@
 #    define SYS_ioctl __NR_ioctl
 #    define SYS_ioprio_get __NR_ioprio_get
 #    define SYS_ioprio_set __NR_ioprio_set
+#    define SYS_kcmp __NR_kcmp
 #    define SYS_kexec_load __NR_kexec_load
 #    define SYS_keyctl __NR_keyctl
 #    define SYS_kill __NR_kill
@@ -575,12 +602,15 @@
 #    define SYS_lstat64 __NR_lstat64
 #    define SYS_madvise __NR_madvise
 #    define SYS_mbind __NR_mbind
+#    define SYS_membarrier __NR_membarrier
+#    define SYS_memfd_create __NR_memfd_create
 #    define SYS_mincore __NR_mincore
 #    define SYS_mkdir __NR_mkdir
 #    define SYS_mkdirat __NR_mkdirat
 #    define SYS_mknod __NR_mknod
 #    define SYS_mknodat __NR_mknodat
 #    define SYS_mlock __NR_mlock
+#    define SYS_mlock2 __NR_mlock2
 #    define SYS_mlockall __NR_mlockall
 #    define SYS_mmap2 __NR_mmap2
 #    define SYS_mount __NR_mount
@@ -617,11 +647,15 @@
 #    define SYS_pipe __NR_pipe
 #    define SYS_pipe2 __NR_pipe2
 #    define SYS_pivot_root __NR_pivot_root
+#    define SYS_pkey_alloc __NR_pkey_alloc
+#    define SYS_pkey_free __NR_pkey_free
+#    define SYS_pkey_mprotect __NR_pkey_mprotect
 #    define SYS_poll __NR_poll
 #    define SYS_ppoll __NR_ppoll
 #    define SYS_prctl __NR_prctl
 #    define SYS_pread64 __NR_pread64
 #    define SYS_preadv __NR_preadv
+#    define SYS_preadv2 __NR_preadv2
 #    define SYS_prlimit64 __NR_prlimit64
 #    define SYS_process_vm_readv __NR_process_vm_readv
 #    define SYS_process_vm_writev __NR_process_vm_writev
@@ -629,6 +663,7 @@
 #    define SYS_ptrace __NR_ptrace
 #    define SYS_pwrite64 __NR_pwrite64
 #    define SYS_pwritev __NR_pwritev
+#    define SYS_pwritev2 __NR_pwritev2
 #    define SYS_quotactl __NR_quotactl
 #    define SYS_read __NR_read
 #    define SYS_readahead __NR_readahead
@@ -644,9 +679,11 @@
 #    define SYS_removexattr __NR_removexattr
 #    define SYS_rename __NR_rename
 #    define SYS_renameat __NR_renameat
+#    define SYS_renameat2 __NR_renameat2
 #    define SYS_request_key __NR_request_key
 #    define SYS_restart_syscall __NR_restart_syscall
 #    define SYS_rmdir __NR_rmdir
+#    define SYS_rseq __NR_rseq
 #    define SYS_rt_sigaction __NR_rt_sigaction
 #    define SYS_rt_sigpending __NR_rt_sigpending
 #    define SYS_rt_sigprocmask __NR_rt_sigprocmask
@@ -658,13 +695,16 @@
 #    define SYS_sched_get_priority_max __NR_sched_get_priority_max
 #    define SYS_sched_get_priority_min __NR_sched_get_priority_min
 #    define SYS_sched_getaffinity __NR_sched_getaffinity
+#    define SYS_sched_getattr __NR_sched_getattr
 #    define SYS_sched_getparam __NR_sched_getparam
 #    define SYS_sched_getscheduler __NR_sched_getscheduler
 #    define SYS_sched_rr_get_interval __NR_sched_rr_get_interval
 #    define SYS_sched_setaffinity __NR_sched_setaffinity
+#    define SYS_sched_setattr __NR_sched_setattr
 #    define SYS_sched_setparam __NR_sched_setparam
 #    define SYS_sched_setscheduler __NR_sched_setscheduler
 #    define SYS_sched_yield __NR_sched_yield
+#    define SYS_seccomp __NR_seccomp
 #    define SYS_semctl __NR_semctl
 #    define SYS_semget __NR_semget
 #    define SYS_semop __NR_semop
@@ -727,6 +767,7 @@
 #    define SYS_stat64 __NR_stat64
 #    define SYS_statfs __NR_statfs
 #    define SYS_statfs64 __NR_statfs64
+#    define SYS_statx __NR_statx
 #    define SYS_swapoff __NR_swapoff
 #    define SYS_swapon __NR_swapon
 #    define SYS_symlink __NR_symlink
@@ -759,6 +800,7 @@
 #    define SYS_unlinkat __NR_unlinkat
 #    define SYS_unshare __NR_unshare
 #    define SYS_uselib __NR_uselib
+#    define SYS_userfaultfd __NR_userfaultfd
 #    define SYS_ustat __NR_ustat
 #    define SYS_utimensat __NR_utimensat
 #    define SYS_utimes __NR_utimes

--- a/core/unix/include/syscall_linux_uapi.h
+++ b/core/unix/include/syscall_linux_uapi.h
@@ -280,6 +280,15 @@
 #define __NR_userfaultfd 282
 #define __NR_membarrier 283
 #define __NR_mlock2 284
+#define __NR_copy_file_range 285
+#define __NR_preadv2 286
+#define __NR_pwritev2 287
+#define __NR_pkey_mprotect 288
+#define __NR_pkey_alloc 289
+#define __NR_pkey_free 290
+#define __NR_statx 291
+#define __NR_io_pgetevents 292
+#define __NR_rseq 293
 
 #define SYS_accept __NR_accept
 #define SYS_accept4 __NR_accept4
@@ -301,6 +310,7 @@
 #define SYS_clone __NR_clone
 #define SYS_close __NR_close
 #define SYS_connect __NR_connect
+#define SYS_copy_file_range __NR_copy_file_range
 #define SYS_delete_module __NR_delete_module
 #define SYS_dup __NR_dup
 #define SYS_dup3 __NR_dup3
@@ -370,6 +380,7 @@
 #define SYS_io_cancel __NR_io_cancel
 #define SYS_io_destroy __NR_io_destroy
 #define SYS_io_getevents __NR_io_getevents
+#define SYS_io_pgetevents __NR_io_pgetevents
 #define SYS_io_setup __NR_io_setup
 #define SYS_io_submit __NR_io_submit
 #define SYS_ioctl __NR_ioctl
@@ -427,10 +438,14 @@
 #define SYS_personality __NR_personality
 #define SYS_pipe2 __NR_pipe2
 #define SYS_pivot_root __NR_pivot_root
+#define SYS_pkey_alloc __NR_pkey_alloc
+#define SYS_pkey_free __NR_pkey_free
+#define SYS_pkey_mprotect __NR_pkey_mprotect
 #define SYS_ppoll __NR_ppoll
 #define SYS_prctl __NR_prctl
 #define SYS_pread64 __NR_pread64
 #define SYS_preadv __NR_preadv
+#define SYS_preadv2 __NR_preadv2
 #define SYS_prlimit64 __NR_prlimit64
 #define SYS_process_vm_readv __NR_process_vm_readv
 #define SYS_process_vm_writev __NR_process_vm_writev
@@ -438,6 +453,7 @@
 #define SYS_ptrace __NR_ptrace
 #define SYS_pwrite64 __NR_pwrite64
 #define SYS_pwritev __NR_pwritev
+#define SYS_pwritev2 __NR_pwritev2
 #define SYS_quotactl __NR_quotactl
 #define SYS_read __NR_read
 #define SYS_readahead __NR_readahead
@@ -453,6 +469,7 @@
 #define SYS_renameat2 __NR_renameat2
 #define SYS_request_key __NR_request_key
 #define SYS_restart_syscall __NR_restart_syscall
+#define SYS_rseq __NR_rseq
 #define SYS_rt_sigaction __NR_rt_sigaction
 #define SYS_rt_sigpending __NR_rt_sigpending
 #define SYS_rt_sigprocmask __NR_rt_sigprocmask
@@ -516,6 +533,7 @@
 #define SYS_socketpair __NR_socketpair
 #define SYS_splice __NR_splice
 #define SYS_statfs __NR_statfs
+#define SYS_statx __NR_statx
 #define SYS_swapoff __NR_swapoff
 #define SYS_swapon __NR_swapon
 #define SYS_symlinkat __NR_symlinkat

--- a/core/unix/include/syscall_linux_x86.h
+++ b/core/unix/include/syscall_linux_x86.h
@@ -3044,4 +3044,8 @@
 #    define SYS_writev __NR_writev
 #endif
 
+#ifdef __NR_rseq
+#    define SYS_rseq __NR_rseq
+#endif
+
 #endif /* _SYSCALL_LINUX_X86_H_ */

--- a/core/unix/memcache.c
+++ b/core/unix/memcache.c
@@ -418,7 +418,8 @@ memcache_query_memory(const byte *pc, OUT dr_mem_info_t *out_info)
 #endif
     } else {
         app_pc prev, next;
-        found = vmvector_lookup_prev_next(all_memory_areas, (app_pc)pc, &prev, &next);
+        found = vmvector_lookup_prev_next(all_memory_areas, (app_pc)pc, &prev, NULL,
+                                          &next, NULL);
         ASSERT(found);
         if (prev != NULL) {
             found = vmvector_lookup_data(all_memory_areas, prev, NULL, &out_info->base_pc,

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1747,9 +1747,10 @@ rseq_is_registered_for_current_thread(void)
      */
     struct rseq test_rseq = {};
     int res = dynamorio_syscall(SYS_rseq, 4, &test_rseq, sizeof(test_rseq), 0, 0);
-    if (res == -EINVAL) { /* Our struct != registered struct. */
+    if (res == -EINVAL) /* Our struct != registered struct. */
         return true;
-    }
+    if (res == -ENOSYS)
+        return false;
     ASSERT(res == 0); /* If not, the struct size or sthg changed! */
     if (dynamorio_syscall(SYS_rseq, 4, &test_rseq, sizeof(test_rseq),
                           RSEQ_FLAG_UNREGISTER, 0) != 0) {

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -40,6 +40,28 @@
 #include "instrument.h"
 #include <stddef.h> /* offsetof */
 #include <link.h>   /* Elf_Symndx */
+#ifdef LINUX
+#    ifdef HAVE_RSEQ
+#        include <linux/rseq.h>
+#    else
+struct rseq_cs {
+    uint version;
+    uint flags;
+    uint64 start_ip;
+    uint64 post_commit_offset;
+    uint64 abort_ip;
+} __attribute__((aligned(4 * sizeof(uint64))));
+struct rseq {
+    uint cpu_id_start;
+    uint cpu_id;
+    uint64 ptr64;
+    uint flags;
+} __attribute__((aligned(4 * sizeof(uint64))));
+#        define RSEQ_FLAG_UNREGISTER 1
+#    endif
+#    include "include/syscall.h"
+#    include <errno.h>
+#endif
 
 #ifndef ANDROID
 struct tlsdesc_t {
@@ -847,7 +869,7 @@ module_get_section_with_name(app_pc image, size_t img_size, const char *sec_name
     sec_hdr = (ELF_SECTION_HEADER_TYPE *)(image + elf_hdr->e_shoff);
     ASSERT(sec_hdr[elf_hdr->e_shstrndx].sh_offset < img_size);
     strtab = (char *)(image + sec_hdr[elf_hdr->e_shstrndx].sh_offset);
-    /* walk the section table to check if a section name is ".text" */
+    /* walk the section table to check if a section name is sec_name */
     for (i = 0; i < elf_hdr->e_shnum; i++) {
         if (strcmp(sec_name, strtab + sec_hdr->sh_name) == 0)
             return sec_hdr->sh_addr;
@@ -1553,3 +1575,188 @@ module_relocate_rela(app_pc modbase, os_privmod_data_t *pd, ELF_RELA_TYPE *start
     for (rela = start; rela < end; rela++)
         module_relocate_symbol((ELF_REL_TYPE *)rela, pd, true);
 }
+
+#ifdef LINUX
+/**************************************************************************************
+ * Restartable sequence ("rseq") support (i#2350).
+ * This is a kernel feature which provides cpu-atomic regions: if a thread
+ * is pre-empted within an rseq region, an abort handler is invoked.
+ * The feature is difficult to handle under binary instrumentation.
+ * We rely on the app following certain conventions, including containing a
+ * section holding a table of all rseq sequences.
+ */
+
+static void
+rseq_process_entry(struct rseq_cs *entry, ssize_t load_offs)
+{
+    LOG(GLOBAL, LOG_LOADER, 2,
+        "Found rseq region: ver=%u; flags=%u; start=" PFX "; end=" PFX "; abort=" PFX
+        "\n",
+        entry->version, entry->flags, entry->start_ip + load_offs,
+        entry->start_ip + entry->post_commit_offset + load_offs,
+        entry->abort_ip + load_offs);
+    app_pc start_pc = (app_pc)(ptr_uint_t)entry->start_ip + load_offs;
+    vmvector_add(d_r_rseq_areas, start_pc, start_pc + entry->post_commit_offset,
+                 (void *)((ptr_uint_t)entry->abort_ip + load_offs));
+    RSTATS_INC(num_rseq_regions);
+    /* Check the start pc.  We don't take the effort to check for non-tags or
+     * interior pc's.
+     */
+    if (fragment_lookup(GLOBAL_DCONTEXT, start_pc) != NULL) {
+        /* We rely on the app not running rseq code for non-rseq purposes (since we
+         * can't easily tell the difference; plus we avoid a flush for lazy rseq
+         * activation).
+         */
+        REPORT_FATAL_ERROR_AND_EXIT(
+            RSEQ_BEHAVIOR_UNSUPPORTED, 3, get_application_name(), get_application_pid(),
+            "Rseq sequences must not be used for non-rseq purposes");
+        ASSERT_NOT_REACHED();
+    }
+}
+
+/* Returns whether successfully searched for rseq data (not whether found rseq data). */
+bool
+module_init_rseq(module_area_t *ma, bool at_map)
+{
+    bool res = false;
+    ASSERT(is_elf_so_header(ma->start, ma->end - ma->start));
+    ELF_HEADER_TYPE *elf_hdr = (ELF_HEADER_TYPE *)ma->start;
+    ASSERT(elf_hdr->e_shentsize == sizeof(ELF_SECTION_HEADER_TYPE));
+    int fd = INVALID_FILE;
+    byte *sec_map = NULL, *str_map = NULL;
+    size_t sec_size = 0, str_size = 0;
+    ELF_SECTION_HEADER_TYPE *sec_hdr = NULL;
+    char *strtab;
+    ssize_t load_offs = ma->start - ma->os_data.base_address;
+    if (at_map && elf_hdr->e_shoff + ma->start < ma->end) {
+        sec_map = elf_hdr->e_shoff + ma->start;
+        sec_hdr = (ELF_SECTION_HEADER_TYPE *)sec_map;
+        /* We assume strtab is there too. */
+        strtab = (char *)(ma->start + sec_hdr[elf_hdr->e_shstrndx].sh_offset);
+        if (strtab > (char *)ma->end)
+            goto module_init_rseq_cleanup;
+    } else {
+        /* The section headers are not mapped in.  Unfortunately this is the common
+         * case: they are typically at the end of the file.  For this reason, we delay
+         * calling this function until we see the app use rseq.
+         */
+        if (ma->full_path == NULL)
+            goto module_init_rseq_cleanup;
+        fd = os_open(ma->full_path, OS_OPEN_READ);
+        if (fd == INVALID_FILE)
+            goto module_init_rseq_cleanup;
+        off_t offs = ALIGN_BACKWARD(elf_hdr->e_shoff, PAGE_SIZE);
+        sec_size =
+            ALIGN_FORWARD(elf_hdr->e_shoff + elf_hdr->e_shnum * elf_hdr->e_shentsize,
+                          PAGE_SIZE) -
+            offs;
+        sec_map =
+            os_map_file(fd, &sec_size, offs, NULL, MEMPROT_READ, MAP_FILE_COPY_ON_WRITE);
+        if (sec_map == NULL)
+            goto module_init_rseq_cleanup;
+        sec_hdr = (ELF_SECTION_HEADER_TYPE *)(sec_map + elf_hdr->e_shoff - offs);
+        /* We also need the section header string table. */
+        offs = ALIGN_BACKWARD(sec_hdr[elf_hdr->e_shstrndx].sh_offset, PAGE_SIZE);
+        str_size = ALIGN_FORWARD(sec_hdr[elf_hdr->e_shstrndx].sh_offset +
+                                     sec_hdr[elf_hdr->e_shstrndx].sh_size,
+                                 PAGE_SIZE) -
+            offs;
+        str_map =
+            os_map_file(fd, &str_size, offs, NULL, MEMPROT_READ, MAP_FILE_COPY_ON_WRITE);
+        if (str_map == NULL)
+            goto module_init_rseq_cleanup;
+        strtab = (char *)(str_map + sec_hdr[elf_hdr->e_shstrndx].sh_offset - offs);
+    }
+    bool found_array = false;
+    uint i;
+    ELF_SECTION_HEADER_TYPE *sec_hdr_start = sec_hdr;
+    /* The section entries on disk need load_offs.  The rseq entries in memory are
+     * relocated and only need the offset if relocations have not yet been applied.
+     */
+    ssize_t entry_offs = 0;
+    if (at_map || (DYNAMO_OPTION(early_inject) && !dr_api_entry && !dynamo_started))
+        entry_offs = load_offs;
+    for (i = 0; i < elf_hdr->e_shnum; i++) {
+#    define RSEQ_PTR_ARRAY_SEC_NAME "__rseq_cs_ptr_array"
+        if (strcmp(strtab + sec_hdr->sh_name, RSEQ_PTR_ARRAY_SEC_NAME) == 0) {
+            found_array = true;
+            byte **ptrs = (byte **)(sec_hdr->sh_addr + load_offs);
+            int j;
+            for (j = 0; j < sec_hdr->sh_size / sizeof(ptrs); ++j) {
+                /* We require that the table is loaded.  If not, bail. */
+                if (ptrs > (byte **)ma->end)
+                    goto module_init_rseq_cleanup;
+                /* We assume this is a full mapping and it's safe to read the data
+                 * (a partial map shouldn't make it to module list processing).
+                 */
+                rseq_process_entry((struct rseq_cs *)(*ptrs + load_offs), entry_offs);
+                ++ptrs;
+            }
+            break;
+        }
+        ++sec_hdr;
+    }
+    if (!found_array) {
+        sec_hdr = sec_hdr_start;
+        for (i = 0; i < elf_hdr->e_shnum; i++) {
+#    define RSEQ_SEC_NAME "__rseq_cs"
+#    define RSEQ_OLD_SEC_NAME "__rseq_table"
+            if (strcmp(strtab + sec_hdr->sh_name, RSEQ_SEC_NAME) == 0 ||
+                strcmp(strtab + sec_hdr->sh_name, RSEQ_OLD_SEC_NAME) == 0) {
+                /* There may be padding at the start of the section, so ensure we skip
+                 * over it.  We're reading the loaded data, not the file, so it will
+                 * always be aligned.
+                 */
+#    define RSEQ_CS_ALIGNMENT 4 * sizeof(__u64)
+                struct rseq_cs *array = (struct rseq_cs *)ALIGN_FORWARD(
+                    sec_hdr->sh_addr + load_offs, RSEQ_CS_ALIGNMENT);
+                int j;
+                for (j = 0; j < sec_hdr->sh_size / sizeof(*array); ++j) {
+                    /* We require that the table is loaded.  If not, bail. */
+                    if (array > (struct rseq_cs *)ma->end)
+                        goto module_init_rseq_cleanup;
+                    rseq_process_entry(array, entry_offs);
+                    ++array;
+                }
+                break;
+            }
+            ++sec_hdr;
+        }
+    }
+    res = true;
+module_init_rseq_cleanup:
+    if (str_size != 0)
+        os_unmap_file(str_map, str_size);
+    if (sec_size != 0)
+        os_unmap_file(sec_map, sec_size);
+    if (fd != INVALID_FILE)
+        os_close(fd);
+    return res;
+}
+
+/* Perhaps this belongs in a non-module file, but we currently have the rseq.h
+ * structs private to this file so this is living here for now.
+ */
+bool
+rseq_is_registered_for_current_thread(void)
+{
+    /* Unfortunately there's no way to query the current rseq struct.
+     * For 64-bit we can pass a kernel address and look for EFAULT
+     * vs EINVAL, but there is no kernel address for 32-bit.
+     * So we try to perform a legitimate registration.
+     */
+    struct rseq test_rseq = {};
+    int res = dynamorio_syscall(SYS_rseq, 4, &test_rseq, sizeof(test_rseq), 0, 0);
+    if (res == -EINVAL) { /* Our struct != registered struct. */
+        return true;
+    }
+    ASSERT(res == 0); /* If not, the struct size or sthg changed! */
+    if (dynamorio_syscall(SYS_rseq, 4, &test_rseq, sizeof(test_rseq),
+                          RSEQ_FLAG_UNREGISTER, 0) != 0) {
+        ASSERT_NOT_REACHED();
+    }
+    return false;
+}
+
+/**************************************************************************************/
+#endif /* LINUX */

--- a/core/unix/module_elf.h
+++ b/core/unix/module_elf.h
@@ -309,4 +309,9 @@ elf_loader_map_phdrs(elf_loader_t *elf, bool fixed, map_fn_t map_func,
 const char *
 elf_loader_find_pt_interp(elf_loader_t *elf);
 
+#ifdef LINUX
+bool
+module_init_rseq(module_area_t *ma, bool at_map);
+#endif
+
 #endif /* MODULE_ELF_H */

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -160,6 +160,10 @@ extern uint android_tls_base_offs;
 #    define USR_TLS_COPROC_15 15
 #endif
 
+#ifdef LINUX
+extern vm_area_vector_t *d_r_rseq_areas;
+#endif
+
 void *
 d_r_get_tls(ushort tls_offs);
 void

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -466,4 +466,12 @@ void
 safe_read_tls_app_self_recover(void);
 #endif
 
+/* In module.c */
+#ifdef LINUX
+void
+module_locate_rseq_regions(void);
+bool
+rseq_is_registered_for_current_thread(void);
+#endif
+
 #endif /* _OS_PRIVATE_H_ */

--- a/core/utils.h
+++ b/core/utils.h
@@ -444,8 +444,12 @@ enum {
                                  * > coarse_info_lock, > executable_areas,
                                  * < module_data_lock */
 #    endif
-    LOCK_RANK(written_areas),             /* > executable_areas, < module_data_lock,
-                                           * < dynamo_areas < global_alloc_lock */
+    LOCK_RANK(written_areas), /* > executable_areas, < module_data_lock,
+                               * < dynamo_areas < global_alloc_lock */
+#    ifdef LINUX
+    LOCK_RANK(rseq_trigger_lock), /* < rseq_areas, < module_data_lock */
+    LOCK_RANK(rseq_areas),        /* < dynamo_areas < global_alloc_lock */
+#    endif
     LOCK_RANK(module_data_lock),          /* < loaded_module_areas, < special_heap_lock,
                                            * > executable_areas */
     LOCK_RANK(special_units_list_lock),   /* < special_heap_lock */

--- a/core/vmareas.h
+++ b/core/vmareas.h
@@ -195,14 +195,14 @@ bool
 vmvector_lookup_data(vm_area_vector_t *v, app_pc pc, app_pc *start, app_pc *end,
                      void **data);
 
-/* Returns false if pc is in a vmarea in v.
- * Otherwise, returns the start pc of the vmarea prior to pc in prev (NULL
- * if none) and the start pc of the vmarea after pc in next (POINTER_MAX
- * if none).
+/* Returns false if pc is in a vmarea in v.  Otherwise, returns the bounds of the
+ * vmarea prior to pc in [prev_start,prev_end) (both NULL if none) and the bounds of
+ * the vmarea after pc in [next_start,next_end) (both POINTER_MAX if none).
  */
 bool
-vmvector_lookup_prev_next(vm_area_vector_t *v, app_pc pc, OUT app_pc *prev,
-                          OUT app_pc *next);
+vmvector_lookup_prev_next(vm_area_vector_t *v, app_pc pc, OUT app_pc *prev_start,
+                          OUT app_pc *prev_end, OUT app_pc *next_start,
+                          OUT app_pc *next_end);
 
 bool
 vmvector_modify_data(vm_area_vector_t *v, app_pc start, app_pc end, void *data);

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -670,4 +670,12 @@ Language=English
 Application %1!s! (%2!s!): AVX-512 was detected at PC %3!s!. AVX-512 is not fully supported yet.
 .
 
+MessageId =
+Severity = Error
+Facility = DRCore
+SymbolicName = MSG_RSEQ_BEHAVIOR_UNSUPPORTED
+Language=English
+Application %1!s! (%2!s!). Restartable sequence behavior is not supported: %3!s!.
+.
+
 ;// ADD NEW MESSAGES HERE

--- a/make/configure.cmake.h
+++ b/make/configure.cmake.h
@@ -98,6 +98,7 @@
 #cmakedefine HAVE_FVISIBILITY
 #cmakedefine HAVE_TYPELIMITS_CONTROL
 #cmakedefine ANNOTATIONS
+#cmakedefine HAVE_RSEQ
 
 /* typedef conflicts */
 #cmakedefine DR_DO_NOT_DEFINE_bool

--- a/make/utils_exposed.cmake
+++ b/make/utils_exposed.cmake
@@ -195,7 +195,7 @@ function (DynamoRIO_get_full_path out target loc_suffix)
     endif ()
     # XXX i#3278: DR's win loader can't handle a path like that until full support has
     # been implemented in convert_to_NT_file_path.
-    string(REPLACE "/./" "/" output_dir ${output_dir})
+    string(REPLACE "/./" "/" output_dir "${output_dir}")
     if (output_name)
       set(${out} "${output_dir}/${prefix}${output_name}${suffix}" PARENT_SCOPE)
     else ()

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3439,6 +3439,15 @@ if (UNIX)
   endif (NOT X64 AND NOT ARM)
   # when running tests in parallel: have to generate pcaches first
   set(linux.persist-use_FLAKY_depends linux.persist_FLAKY)
+
+  if (LINUX AND X86 AND X64 AND HAVE_RSEQ)
+    # The rseq feature is Linux-only.
+    # TODO i#2350: Port the assembly in the test to 32-bit, ARM, AArch64.
+    tobuild(linux.rseq linux/rseq.c)
+    # Test attaching, which has a separate lazy rseq check.
+    tobuild_api(api.rseq linux/rseq.c "" "" OFF OFF)
+    append_property_string(TARGET api.rseq COMPILE_FLAGS "-DRSEQ_TEST_ATTACH")
+  endif ()
 else (UNIX)
   add_exe(win32.infloop win32/infloop.c)
   if (VPS)

--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -1,0 +1,150 @@
+/* **********************************************************
+ * Copyright (c) 2019 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifdef RSEQ_TEST_ATTACH
+#    include "configure.h"
+#    include "dr_api.h"
+#endif
+#include "tools.h"
+#ifndef LINUX
+#    error Only Linux is supported.
+#endif
+/* TODO i#2350: Port this to other platforms and bitwidths.  There is a lot of
+ * assembly which makes that non-trivial work.
+ */
+#if !defined(X86) || !defined(X64)
+#    error Only x86_64 is supported.
+#endif
+#include "../../core/unix/include/syscall.h"
+#ifndef HAVE_RSEQ
+#    error The linux/rseq header is required.
+#endif
+#include <linux/rseq.h>
+#include <errno.h>
+#include <assert.h>
+
+#define EXPANDSTR(x) #x
+#define STRINGIFY(x) EXPANDSTR(x)
+
+#define RSEQ_SIG 0x90909090 /* nops to disasm nicely */
+
+/* This cannot be a stack-local variable, as the kernel will force SIGSEGV on a syscall
+ * if it can't read this struct.
+ */
+static struct rseq rseq_tls;
+
+int
+test_rseq(void)
+{
+    /* We use static to avoid stack reference issues with our extra frame inside the asm.
+     */
+    static __u32 id = RSEQ_CPU_ID_UNINITIALIZED;
+    static int restarts = 0;
+    __asm__ __volatile__(
+        /* Add a table entry. */
+        ".pushsection __rseq_table, \"aw\"\n\t"
+        ".balign 32\n\t"
+        "1:\n\t"
+        ".long 0, 0\n\t"          /* version, flags */
+        ".quad 2f, 3f-2f, 4f\n\t" /* start_ip, post_commit_offset, abort_ip */
+        ".popsection\n\t"
+
+        /* Although our abort handler has to handle being called (that's all DR
+         * supports), we structure the code to allow directly calling past it, to
+         * count restart_count.
+         */
+        "call 6f\n\t"
+        "jmp 5f\n\t"
+
+        "6:\n\t"
+        /* Store the entry into the ptr. */
+        "leaq 1b(%%rip), %%rax\n\t"
+        "movq %%rax, %0\n\t"
+        /* Test "falling into" the rseq region. */
+
+        /* Restartable sequence.
+         * If I pause in gdb in here, often the thread is migrated and the abort
+         * handler invoked: a simple way to test a restart natively.
+         */
+        "2:\n\t"
+        "mov %3, %%rax\n\t"
+        "mov %%rax, %1\n\t"
+
+        /* Post-commit. */
+        "3:\n\t"
+        "ret\n\t"
+
+        /* Abort handler. */
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        ".long " STRINGIFY(RSEQ_SIG) "\n\t"
+        "4:\n\t"
+        "addl $1, %2\n\t"
+        "jmp 6b\n\t"
+
+        /* Clear the ptr. */
+        "5:\n\t"
+        "leaq 1b(%%rip), %%rax\n\t"
+        "movq $0, %0\n\t"
+        /* clang-format on */
+
+        : "=m"(rseq_tls.rseq_cs), "=m"(id), "=m"(restarts)
+        : "m"(rseq_tls.cpu_id)
+        : "rax", "memory");
+    assert(id != RSEQ_CPU_ID_UNINITIALIZED);
+    return restarts;
+}
+
+int
+main()
+{
+    int restart_count = 0;
+    rseq_tls.cpu_id = RSEQ_CPU_ID_UNINITIALIZED;
+    int res = syscall(SYS_rseq, &rseq_tls, sizeof(rseq_tls), 0, RSEQ_SIG);
+    if (res == 0) {
+#ifdef RSEQ_TEST_ATTACH
+        dr_app_setup_and_start();
+#endif
+        restart_count = test_rseq();
+#ifdef RSEQ_TEST_ATTACH
+        dr_app_stop_and_cleanup();
+#endif
+    } else {
+        /* Linux kernel 4.18+ is required. */
+        assert(errno == ENOSYS);
+        /* Make the test pass. */
+        restart_count = 1;
+    }
+    /* We expect 0 restart_count natively (ok, tiny chance of >0), and 1 under DR. */
+    print("Saw %s restarts\n", restart_count > 0 ? "some" : "no");
+    print("All done\n");
+    return 0;
+}

--- a/suite/tests/linux/rseq.expect
+++ b/suite/tests/linux/rseq.expect
@@ -1,0 +1,2 @@
+Saw some restarts
+All done


### PR DESCRIPTION
Adds initial handling for the restartable sequence ("rseq") feature
that is now in the mainline Linux kernel.

We identify rseq regions by looking for ELF sections with established
names according to upstream conventions.  Unfortunately this requires
going to disk for most libraries, so we avoid this for
full-control-mode if we have never seen an rseq system call, and for
attach if no thread has registered for rseq.

For blocks inside rseq regions, mangling removes all memory stores.
For the final commit instruction, we append a native call back to the
abort handler.  We assume this extra frame is ok, and we require the
rseq sequence to end in a return.  Future work will improve these
assumptions.

Updates the 3 Linux syscall lists up through SYS_rseq.

Adds 3 RSTATS for rseq operation.

Documents the current limitations on rseq region support:
- The application must store an rseq_cs struct for each rseq region in a
  section of its binary with an established name.
- Each rseq region's code must never be also executed as a non-restartable sequence.
- Each rseq region must make forward progress if its abort handler is always
  called the first time it is executed.
- Each memory store instruction inside an rseq region must have no other side
  effects.
- Each rseq region must end with a return instruction, and each abort handler
  plus rseq code must combine into a callee following normal call-return
  semantics.
- Any helper function called from within an rseq region must have no side effects.

Adds two tests for x86_64 Linux, one for full control and one for
attach.  However, these require a 4.18+ kernel and so are not
exercised by Travis.  The Fedora CDash machine does have 4.18 so we do
have some automated coverage.

Once this is in place, the old and now obsolete rseq support will be removed.

Issue: #2350