### PR TITLE
i#2350 rseq: Support cache pre-population

### DIFF
--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1731,6 +1731,19 @@ module_init_rseq_cleanup:
         os_unmap_file(sec_map, sec_size);
     if (fd != INVALID_FILE)
         os_close(fd);
+    DODEBUG({
+        if (!res) {
+            const char *name = GET_MODULE_NAME(&ma->names);
+            if (name == NULL)
+                name = "(null)";
+            LOG(GLOBAL, LOG_INTERP | LOG_VMAREAS, 2,
+                "%s: error looking for rseq table in %s\n", __FUNCTION__, name);
+            if (strstr(name, "linux-vdso.so") == NULL) {
+                SYSLOG_INTERNAL_WARNING_ONCE(
+                    "Failed to identify whether a module has an rseq table");
+            }
+        }
+    });
     return res;
 }
 

--- a/core/utils.h
+++ b/core/utils.h
@@ -448,10 +448,12 @@ enum {
                                * < dynamo_areas < global_alloc_lock */
 #    ifdef LINUX
     LOCK_RANK(rseq_trigger_lock), /* < rseq_areas, < module_data_lock */
-    LOCK_RANK(rseq_areas),        /* < dynamo_areas < global_alloc_lock */
 #    endif
-    LOCK_RANK(module_data_lock),          /* < loaded_module_areas, < special_heap_lock,
-                                           * > executable_areas */
+    LOCK_RANK(module_data_lock), /* < loaded_module_areas, < special_heap_lock,
+                                  * > executable_areas */
+#    ifdef LINUX
+    LOCK_RANK(rseq_areas), /* < dynamo_areas < global_alloc_lock, > module_data_lock */
+#    endif
     LOCK_RANK(special_units_list_lock),   /* < special_heap_lock */
     LOCK_RANK(special_heap_lock),         /* > bb_building_lock, > hotp_vul_table_lock
                                            * < dynamo_areas, < heap_unit_lock */


### PR DESCRIPTION
Fixes the lazy rseq support to handle code cache pre-population.
Previously rseq code blocks could be created without rseq handling due
to the lazy checks not triggered until after pre-population.

Issue: #2350