### PR TITLE
i#3556 w^x: Fix reachable address to executable view.

### DIFF
--- a/core/arch/x86/emit_utils.c
+++ b/core/arch/x86/emit_utils.c
@@ -1363,8 +1363,11 @@ append_restore_simd_reg(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
         post_restore = INSTR_CREATE_label(dcontext);
         pre_avx512_restore = INSTR_CREATE_label(dcontext);
         APP(ilist,
-            INSTR_CREATE_cmp(dcontext, OPND_CREATE_ABSMEM(d_r_avx512_code_in_use, OPSZ_1),
-                             OPND_CREATE_INT8(0)));
+            INSTR_CREATE_cmp(
+                dcontext,
+                OPND_CREATE_ABSMEM(
+                    vmcode_get_executable_addr((byte *)d_r_avx512_code_in_use), OPSZ_1),
+                OPND_CREATE_INT8(0)));
         APP(ilist,
             INSTR_CREATE_jcc(dcontext, OP_jnz, opnd_create_instr(pre_avx512_restore)));
     }
@@ -1622,8 +1625,11 @@ append_save_simd_reg(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
         post_save = INSTR_CREATE_label(dcontext);
         pre_avx512_save = INSTR_CREATE_label(dcontext);
         APP(ilist,
-            INSTR_CREATE_cmp(dcontext, OPND_CREATE_ABSMEM(d_r_avx512_code_in_use, OPSZ_1),
-                             OPND_CREATE_INT8(0)));
+            INSTR_CREATE_cmp(
+                dcontext,
+                OPND_CREATE_ABSMEM(
+                    vmcode_get_executable_addr((byte *)d_r_avx512_code_in_use), OPSZ_1),
+                OPND_CREATE_INT8(0)));
         APP(ilist,
             INSTR_CREATE_jcc(dcontext, OP_jnz, opnd_create_instr(pre_avx512_save)));
     }

--- a/core/heap.h
+++ b/core/heap.h
@@ -282,9 +282,9 @@ nonpersistent_heap_free(dcontext_t *dcontext, void *p,
                         size_t size HEAPACCT(which_heap_t which));
 
 /* Passing dcontext == GLOBAL_DCONTEXT allocates from a global pool.
- * Important note: within the W^X scheme, this will return an address of the writeable
- * view. vmcode_get_executable_addr() needs to be called in order to get the reachable
- * address.
+ * Important note: within the W^X scheme (-satisfy_w_xor_x), this will return an address
+ * of the writeable view. vmcode_get_executable_addr() needs to be called in order to get
+ * the reachable address.
  */
 void *
 heap_reachable_alloc(dcontext_t *dcontext, size_t size HEAPACCT(which_heap_t which));

--- a/core/heap.h
+++ b/core/heap.h
@@ -281,7 +281,11 @@ void
 nonpersistent_heap_free(dcontext_t *dcontext, void *p,
                         size_t size HEAPACCT(which_heap_t which));
 
-/* Passing dcontext == GLOBAL_DCONTEXT allocates from a global pool. */
+/* Passing dcontext == GLOBAL_DCONTEXT allocates from a global pool.
+ * Important note: within the W^X scheme, this will return an address of the writeable
+ * view. vmcode_get_executable_addr() needs to be called in order to get the reachable
+ * address.
+ */
 void *
 heap_reachable_alloc(dcontext_t *dcontext, size_t size HEAPACCT(which_heap_t which));
 void

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -3045,9 +3045,15 @@ custom_memory_shared(bool alloc, void *drcontext, dr_alloc_flags_t flags, size_t
                       TESTALL(DR_ALLOC_NON_HEAP | DR_ALLOC_NON_DR, flags),
                   "dr_custom_alloc: reserve/commit-only are only for non-DR non-heap");
     CLIENT_ASSERT(!TEST(DR_ALLOC_RESERVE_ONLY, flags) ||
+
                       !TEST(DR_ALLOC_COMMIT_ONLY, flags),
                   "dr_custom_alloc: cannot combine reserve-only + commit-only");
 #    endif
+    CLIENT_ASSERT(!TEST(DR_ALLOC_CACHE_REACHABLE, flags) ||
+                      !TESTALL(DR_MEMPROT_WRITE | DR_MEMPROT_EXEC, prot) ||
+                      !DYNAMO_OPTION(satisfy_w_xor_x),
+                  "dr_custom_alloc: DR_ALLOC_CACHE_REACHABLE memory is not "
+                  "supported with -satisfy_w_xor_x");
     if (TEST(DR_ALLOC_NON_HEAP, flags)) {
         CLIENT_ASSERT(drcontext == NULL,
                       "dr_custom_alloc: drcontext must be NULL for non-heap");

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -3045,7 +3045,6 @@ custom_memory_shared(bool alloc, void *drcontext, dr_alloc_flags_t flags, size_t
                       TESTALL(DR_ALLOC_NON_HEAP | DR_ALLOC_NON_DR, flags),
                   "dr_custom_alloc: reserve/commit-only are only for non-DR non-heap");
     CLIENT_ASSERT(!TEST(DR_ALLOC_RESERVE_ONLY, flags) ||
-
                       !TEST(DR_ALLOC_COMMIT_ONLY, flags),
                   "dr_custom_alloc: cannot combine reserve-only + commit-only");
 #    endif

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -3049,7 +3049,6 @@ custom_memory_shared(bool alloc, void *drcontext, dr_alloc_flags_t flags, size_t
                   "dr_custom_alloc: cannot combine reserve-only + commit-only");
 #    endif
     CLIENT_ASSERT(!TEST(DR_ALLOC_CACHE_REACHABLE, flags) ||
-                      !TESTALL(DR_MEMPROT_WRITE | DR_MEMPROT_EXEC, prot) ||
                       !DYNAMO_OPTION(satisfy_w_xor_x),
                   "dr_custom_alloc: DR_ALLOC_CACHE_REACHABLE memory is not "
                   "supported with -satisfy_w_xor_x");

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1479,10 +1479,10 @@ DYNAMIC_OPTION(bool, pause_via_loop,
 #endif
     /* XXX i#3566: Support for W^X has some current limitations:
      * + It is not implemented for Windows or Mac.
-     * + Fork is not perfectly supported: there is overhead and a race.
      * + Pcaches are not supported.
      * + -native_exec_list is not supported.
      * + dr_nonheap_alloc(rwx) is not supported.
+     * + DR_ALLOC_CACHE_REACHABLE is not supported.
      *   Clients using other non-vmcode sources of +wx memory will also not comply.
      */
     OPTION_DEFAULT(bool, satisfy_w_xor_x, false,

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2536,13 +2536,15 @@ endif ()
       "" "-thread_private -cache_bb_unit_init 4K" "")
   endif ()
 
-  if (X64) # Tests x86 reachability.
-    tobuild_ci(client.reachability client-interface/reachability.c ""
-      # The vm_base options were added in order to expose bugs that fail to xl8 reachable
-      # addresses to the executable view within the scheme of satisfy_w_xor_x.
-      "-no_vm_base_near_app -vm_base 0x100000000" "")
-  elseif (X86)
-    tobuild_ci(client.reachability client-interface/reachability.c "" "" "")
+  if (X86)
+    if (X64) # Tests x86 reachability.
+      tobuild_ci(client.reachability client-interface/reachability.c ""
+        # The vm_base options were added in order to expose bugs that fail to xl8 reachable
+        # addresses to the executable view within the scheme of satisfy_w_xor_x.
+        "-no_vm_base_near_app -vm_base 0x100000000" "")
+    else ()
+      tobuild_ci(client.reachability client-interface/reachability.c "" "" "")
+    endif ()
   endif ()
 
   if (X86) # FIXME i#1551, i#1569: fix bugs on ARM and AArch64

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2537,7 +2537,10 @@ endif ()
   endif ()
 
   if (X86) # Tests x86 reachability.
-    tobuild_ci(client.reachability client-interface/reachability.c "" "" "")
+    tobuild_ci(client.reachability client-interface/reachability.c ""
+      # The vm_base options were added in order to expose bugs that fail to xl8 reachable
+      # addresses to the executable view within the scheme of satisfy_w_xor_x.
+      "-no_vm_base_near_app -vm_base 0x100000000" "")
   endif ()
 
   if (X86) # FIXME i#1551, i#1569: fix bugs on ARM and AArch64

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2536,11 +2536,13 @@ endif ()
       "" "-thread_private -cache_bb_unit_init 4K" "")
   endif ()
 
-  if (X86) # Tests x86 reachability.
+  if (X64) # Tests x86 reachability.
     tobuild_ci(client.reachability client-interface/reachability.c ""
       # The vm_base options were added in order to expose bugs that fail to xl8 reachable
       # addresses to the executable view within the scheme of satisfy_w_xor_x.
-      "-no_vm_base_near_app -vm_base 0x10000000" "")
+      "-no_vm_base_near_app -vm_base 0x100000000" "")
+  elseif (X86)
+    tobuild_ci(client.reachability client-interface/reachability.c "" "" "")
   endif ()
 
   if (X86) # FIXME i#1551, i#1569: fix bugs on ARM and AArch64

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2540,7 +2540,7 @@ endif ()
     tobuild_ci(client.reachability client-interface/reachability.c ""
       # The vm_base options were added in order to expose bugs that fail to xl8 reachable
       # addresses to the executable view within the scheme of satisfy_w_xor_x.
-      "-no_vm_base_near_app -vm_base 0x100000000" "")
+      "-no_vm_base_near_app -vm_base 0x10000000" "")
   endif ()
 
   if (X86) # FIXME i#1551, i#1569: fix bugs on ARM and AArch64


### PR DESCRIPTION
Fixes a bug introduced in 1beb5463c6cd2, missing the translation to the executable address
view, leading to unreachable 32-bit displacements.

Adds vm_base options to an existing w^x test in order to expose future bugs like above.

Issues: #1312, #3556