### PR TITLE
i#2350 rseq: Fix __rseq_cs_ptr_array parsing crash

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -1638,6 +1638,7 @@ not supported.
     - The application must store an rseq_cs struct for each rseq region in a
       section of its binary named "__rseq_cs", optionally with an "__rseq_cs_ptr_array"
       section of pointers into the __rseq_cs section, per established conventions.
+      These sections must be located in loaded segments.
     - Each rseq region's code must never be also executed as a non-restartable sequence.
     - Each rseq region must make forward progress if its abort handler is always
       called the first time it is executed.

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1691,12 +1691,13 @@ module_init_rseq(module_area_t *ma, bool at_map)
                  * We do perform a sanity check to handle unusual non-relocated
                  * cases (it's possible this array is not in a loaded segment?).
                  */
-                if (*ptrs < ma->start || *ptrs > ma->end) {
+                byte *entry = *ptrs + entry_offs;
+                if (entry < ma->start || entry > ma->end) {
                     SYSLOG_INTERNAL_WARNING(RSEQ_PTR_ARRAY_SEC_NAME
                                             " is not in memory. Aborting rseq parsing.");
                     goto module_init_rseq_cleanup;
                 }
-                rseq_process_entry((struct rseq_cs *)(*ptrs), entry_offs);
+                rseq_process_entry((struct rseq_cs *)entry, entry_offs);
                 ++ptrs;
             }
             break;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3457,6 +3457,13 @@ if (UNIX)
     # The rseq feature is Linux-only.
     # TODO i#2350: Port the assembly in the test to 32-bit, ARM, AArch64.
     tobuild(linux.rseq linux/rseq.c)
+    # Test the other sections.  Unfortunately we need a separate binary for each.
+    tobuild(linux.rseq_table linux/rseq.c)
+    append_property_string(TARGET linux.rseq_table
+      COMPILE_FLAGS "-DRSEQ_TEST_USE_OLD_SECTION_NAME")
+    tobuild(linux.rseq_noarray linux/rseq.c)
+    append_property_string(TARGET linux.rseq_noarray
+      COMPILE_FLAGS "-DRSEQ_TEST_USE_NO_ARRAY")
     # Test attaching, which has a separate lazy rseq check.
     tobuild_api(api.rseq linux/rseq.c "" "" OFF OFF)
     append_property_string(TARGET api.rseq COMPILE_FLAGS "-DRSEQ_TEST_ATTACH")

--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -70,13 +70,23 @@ test_rseq(void)
     static __u32 id = RSEQ_CPU_ID_UNINITIALIZED;
     static int restarts = 0;
     __asm__ __volatile__(
+#ifdef RSEQ_TEST_USE_OLD_SECTION_NAME
         /* Add a table entry. */
         ".pushsection __rseq_table, \"aw\"\n\t"
+#else
+        ".pushsection __rseq_cs, \"aw\"\n\t"
+#endif
         ".balign 32\n\t"
         "1:\n\t"
         ".long 0, 0\n\t"          /* version, flags */
         ".quad 2f, 3f-2f, 4f\n\t" /* start_ip, post_commit_offset, abort_ip */
         ".popsection\n\t"
+#if !defined(RSEQ_TEST_USE_OLD_SECTION_NAME) && !defined(RSEQ_TEST_USE_NO_ARRAY)
+        /* Add an array section. */
+        ".pushsection __rseq_cs_ptr_array, \"aw\"\n\t"
+        ".quad 1b\n\t"
+        ".popsection\n\t"
+#endif
 
         /* Although our abort handler has to handle being called (that's all DR
          * supports), we structure the code to allow directly calling past it, to


### PR DESCRIPTION
The __rseq_cs_ptr_array will be relocated, so we should not add the
load offset.

Adds an array to the suite test (previously arrays were only tested
manually using a librseq app).  Creates 2 separate tests to test all 3
section types.

Issue: #2350