### PR TITLE
i#3759: Fix mmap handling conflicts

### DIFF
--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -2975,10 +2975,11 @@ raw_mem_alloc(size_t size, uint prot, void *addr, dr_alloc_flags_t flags)
 #    endif
         if (IF_WINDOWS(TEST(DR_ALLOC_COMMIT_ONLY, flags) &&) addr != NULL &&
             !app_memory_pre_alloc(get_thread_private_dcontext(), addr, size, prot, false,
-                                  true /*update*/, false /*!image*/))
+                                  true /*update*/, false /*!image*/)) {
             p = NULL;
-        else
+        } else {
             p = os_raw_mem_alloc(addr, size, prot, os_flags, &error_code);
+        }
     }
 
     if (p != NULL) {

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -2974,7 +2974,8 @@ raw_mem_alloc(size_t size, uint prot, void *addr, dr_alloc_flags_t flags)
             : (TEST(DR_ALLOC_COMMIT_ONLY, flags) ? RAW_ALLOC_COMMIT_ONLY : 0);
 #    endif
         if (IF_WINDOWS(TEST(DR_ALLOC_COMMIT_ONLY, flags) &&) addr != NULL &&
-            !app_memory_pre_alloc(get_thread_private_dcontext(), addr, size, prot, false))
+            !app_memory_pre_alloc(get_thread_private_dcontext(), addr, size, prot, false,
+                                  true /*update*/, false /*!image*/))
             p = NULL;
         else
             p = os_raw_mem_alloc(addr, size, prot, os_flags, &error_code);
@@ -3245,8 +3246,9 @@ dr_memory_protect(void *base, size_t size, uint new_prot)
     CLIENT_ASSERT(!standalone_library, "API not supported in standalone mode");
     if (!dynamo_vm_area_overlap(base, ((byte *)base) + size)) {
         uint mod_prot = new_prot;
-        uint res = app_memory_protection_change(get_thread_private_dcontext(), base, size,
-                                                new_prot, &mod_prot, NULL);
+        uint res =
+            app_memory_protection_change(get_thread_private_dcontext(), base, size,
+                                         new_prot, &mod_prot, NULL, false /*!image*/);
         if (res != DO_APP_MEM_PROT_CHANGE) {
             if (res == FAIL_APP_MEM_PROT_CHANGE || res == PRETEND_APP_MEM_PROT_CHANGE) {
                 return false;

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -2753,6 +2753,8 @@ add_executable_vm_area(app_pc start, app_pc end, uint vm_flags, uint frag_flags,
             }
         }
     }
+    if (!DYNAMO_OPTION(coarse_units))
+        frag_flags &= ~FRAG_COARSE_GRAIN;
 
     if (existing_area == NULL) {
         add_executable_vm_area_helper(start, end, vm_flags, frag_flags,

--- a/core/vmareas.h
+++ b/core/vmareas.h
@@ -624,13 +624,14 @@ enum {
 };
 
 bool
-app_memory_pre_alloc(dcontext_t *dcontext, byte *base, size_t size, uint prot, bool hint);
+app_memory_pre_alloc(dcontext_t *dcontext, byte *base, size_t size, uint prot, bool hint,
+                     bool update_areas, bool image);
 
 uint
 app_memory_protection_change(dcontext_t *dcontext, app_pc base, size_t size,
                              uint prot,         /* platform independent MEMPROT_ */
                              uint *new_memprot, /* OUT */
-                             uint *old_memprot /* OPTIONAL OUT*/);
+                             uint *old_memprot /* OPTIONAL OUT*/, bool image);
 
 #ifdef WINDOWS
 /* memory region base:base+size was flushed from hardware icache by app */

--- a/core/win32/drwinapi/kernel32_mem.c
+++ b/core/win32/drwinapi/kernel32_mem.c
@@ -470,7 +470,8 @@ __bcount(dwSize) LPVOID WINAPI
         !TEST(MEM_RESERVE, flAllocationType) && lpAddress != NULL) {
         /* i#1175: NtAllocateVirtualMemory can modify prot on existing pages */
         if (!app_memory_pre_alloc(get_thread_private_dcontext(), lpAddress, dwSize,
-                                  osprot_to_memprot(flProtect), false)) {
+                                  osprot_to_memprot(flProtect), false, true /*update*/,
+                                  false /*!image*/)) {
             set_last_error(ERROR_INVALID_ADDRESS);
             return NULL;
         }
@@ -517,7 +518,8 @@ redirect_VirtualProtect(__in LPVOID lpAddress, __in SIZE_T dwSize,
         uint mod_prot = osprot_to_memprot(new_prot);
         uint old_prot;
         uint res = app_memory_protection_change(get_thread_private_dcontext(), lpAddress,
-                                                dwSize, new_prot, &mod_prot, &old_prot);
+                                                dwSize, new_prot, &mod_prot, &old_prot,
+                                                false /*!image*/);
         if (res == PRETEND_APP_MEM_PROT_CHANGE) {
             if (lpflOldProtect != NULL)
                 *lpflOldProtect = memprot_to_osprot(old_prot);

--- a/core/win32/syscall.c
+++ b/core/win32/syscall.c
@@ -2202,7 +2202,8 @@ presys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, int sysnum
         size_t size;
         if (d_r_safe_read(pbase, sizeof(base), &base) &&
             d_r_safe_read(psize, sizeof(size), &size) && base != NULL &&
-            !app_memory_pre_alloc(dcontext, base, size, osprot_to_memprot(prot), false)) {
+            !app_memory_allow_alloc(dcontext, base, size, osprot_to_memprot(prot),
+                                    false)) {
             SET_RETURN_VAL(dcontext, STATUS_CONFLICTING_ADDRESSES);
             return false; /* do not execute system call */
         }
@@ -2454,8 +2455,9 @@ presys_ProtectVirtualMemory(dcontext_t *dcontext, reg_t *param_base)
                            DUMP_NOT_XML);
         });
 #endif
-        res = app_memory_protection_change(dcontext, base, size, osprot_to_memprot(prot),
-                                           &subset_memprot, &old_memprot);
+        res =
+            app_memory_protection_change(dcontext, base, size, osprot_to_memprot(prot),
+                                         &subset_memprot, &old_memprot, false /*!image*/);
         if (res != DO_APP_MEM_PROT_CHANGE) {
             /* from experimentation it seems to return
              * STATUS_CONFLICTING_ADDRESSES

--- a/core/win32/syscall.c
+++ b/core/win32/syscall.c
@@ -2202,8 +2202,8 @@ presys_AllocateVirtualMemory(dcontext_t *dcontext, reg_t *param_base, int sysnum
         size_t size;
         if (d_r_safe_read(pbase, sizeof(base), &base) &&
             d_r_safe_read(psize, sizeof(size), &size) && base != NULL &&
-            !app_memory_allow_alloc(dcontext, base, size, osprot_to_memprot(prot),
-                                    false)) {
+            !app_memory_pre_alloc(dcontext, base, size, osprot_to_memprot(prot),
+                                  false /*!hint*/, true /*update*/, false /*!image*/)) {
             SET_RETURN_VAL(dcontext, STATUS_CONFLICTING_ADDRESSES);
             return false; /* do not execute system call */
         }

--- a/suite/tests/linux/mmap.c
+++ b/suite/tests/linux/mmap.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -67,5 +67,33 @@ main()
 #    endif
 #endif
     munmap(p, newsize);
+
+    /* Test some transition sequences that have been problematic in the past
+     * b/c they look like ld.so's ELF loading.
+     */
+    p = mmap(0, newsize, PROT_READ, MAP_ANON | MAP_PRIVATE, -1, 0);
+    if (p == MAP_FAILED) {
+        print("mmap ERROR " PFX "\n", p);
+        return 1;
+    }
+    p = mmap(p, size, PROT_READ | PROT_EXEC, MAP_ANON | MAP_PRIVATE | MAP_FIXED, -1, 0);
+    if (p == MAP_FAILED) {
+        print("mmap ERROR " PFX "\n", p);
+        return 1;
+    }
+    munmap(p, newsize);
+
+    p = mmap(0, newsize, PROT_READ | PROT_EXEC, MAP_ANON | MAP_PRIVATE, -1, 0);
+    if (p == MAP_FAILED) {
+        print("mmap ERROR " PFX "\n", p);
+        return 1;
+    }
+    p = mmap(p, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE | MAP_FIXED, -1, 0);
+    if (p == MAP_FAILED) {
+        print("mmap ERROR " PFX "\n", p);
+        return 1;
+    }
+    munmap(p, newsize);
+
     return 0;
 }


### PR DESCRIPTION
Fixes problems with pre-syscall versus post-syscall mmap handling
which can lead to asserts.  Adds a check-only version of
app_memory_protection_change() for use in pre-syscall, delaying all
vmarea updates to post-syscall.  Adds protection change checking
inside app_memory_allocation(), simplifying caller usage and providing
broader coverage of mmap behavior.

Adds a vmm attribute to all_memory_areas and disallows merging across
that boundary, to match kernel behavior and avoid mismatch warnings
with the above fix in place which does extra memory querying on each
mmap.

Adds some mmap sequences to linux.mmap to provide some test coverage
for these particular page protection change orderings.

Fixes #3759