### PR TITLE
i#1312 AVX-512 support: Support VSIB addressing in instr_compute_address_ex[_pos].

### DIFF
--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -2237,6 +2237,21 @@ instr_compute_address_helper(instr_t *instr, priv_mcontext_t *mc, size_t mc_size
     for (i = 0; i < instr_num_dsts(instr); i++) {
         curop = instr_get_dst(instr, i);
         if (opnd_is_memory_reference(curop)) {
+            if (opnd_is_vsib(curop)) {
+#ifdef X86
+                if (instr_compute_address_VSIB(instr, mc, mc_size, mc_flags, curop, index,
+                                               &have_addr, addr, &write)) {
+                    CLIENT_ASSERT(
+                        write,
+                        "VSIB found in destination but instruction is not a scatter");
+                    break;
+                } else {
+                    return false;
+                }
+#else
+                CLIENT_ASSERT(false, "VSIB should be x86-only");
+#endif
+            }
             memcount++;
             if (memcount == (int)index) {
                 write = true;
@@ -2244,7 +2259,7 @@ instr_compute_address_helper(instr_t *instr, priv_mcontext_t *mc, size_t mc_size
             }
         }
     }
-    if (memcount != (int)index &&
+    if (!write && memcount != (int)index &&
         /* lea has a mem_ref source operand, but doesn't actually read */
         !opc_is_not_a_real_memory_load(instr_get_opcode(instr))) {
         for (i = 0; i < instr_num_srcs(instr); i++) {

--- a/core/arch/opnd_shared.c
+++ b/core/arch/opnd_shared.c
@@ -170,7 +170,10 @@ opnd_is_far_abs_addr(opnd_t opnd)
 bool
 opnd_is_vsib(opnd_t op)
 {
-    return (opnd_is_base_disp(op) && reg_is_xmm(opnd_get_index(op)));
+    return (opnd_is_base_disp(op) &&
+            (reg_is_strictly_xmm(opnd_get_index(op)) ||
+             reg_is_strictly_ymm(opnd_get_index(op)) ||
+             reg_is_strictly_zmm(opnd_get_index(op))));
 }
 
 bool

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -393,10 +393,10 @@ instr_compute_VSIB_index(bool *selected OUT, app_pc *result OUT, bool *is_write 
     CLIENT_ASSERT(mc_size >= sizeof(dr_mcontext_t), "dr_mcontext_t.size is invalid");
     CLIENT_ASSERT(TEST(DR_MC_MULTIMEDIA, mc_flags),
                   "dr_mcontext_t.flags must include DR_MC_MULTIMEDIA");
-    opnd_t memop = instr_get_src(instr, 0);
+    opnd_t src0 = instr_get_src(instr, 0);
     /* We detect whether the instruction is EVEX by looking at its potential mask operand.
      */
-    bool is_evex = opnd_is_reg(memop) && reg_is_opmask(opnd_get_reg(memop));
+    bool is_evex = opnd_is_reg(src0) && reg_is_opmask(opnd_get_reg(src0));
     return instr_compute_VSIB_index_internal(selected, result, is_write, instr, ordinal,
                                              mc, mc_size, mc_flags, is_evex);
 }

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -324,9 +324,8 @@ instr_compute_VSIB_index_internal(bool *selected OUT, app_pc *result OUT,
     CLIENT_ASSERT(!index_is_zmm || is_evex, "invalid index size");
 
     LOG(THREAD_GET, LOG_ALL, 4,
-        "%s: ordinal=%d: index=%s, mem=%s, xmm=%d, ymm=%d, zmm=%d\n", __FUNCTION__,
-        ordinal, size_names[index_size], size_names[mem_size], index_is_xmm, index_is_ymm,
-        index_is_zmm);
+        "%s: ordinal=%d: index size=%s, mem size=%s, index reg=%s\n", __FUNCTION__,
+        ordinal, size_names[index_size], size_names[mem_size], reg_names[index_reg]);
 
     if (index_size == OPSZ_4) {
         int mask;

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -347,8 +347,8 @@ instr_compute_VSIB_index(bool *selected OUT, app_pc *result OUT, bool *is_write 
 
     if (index_size == OPSZ_4) {
         int mask;
-        if (ordinal >=
-            opnd_size_in_bytes(reg_get_size(index_reg)) / opnd_size_in_bytes(mem_size))
+        if (ordinal >= (int)opnd_size_in_bytes(reg_get_size(index_reg)) /
+                (int)opnd_size_in_bytes(mem_size))
             return false;
         if (is_evex) {
             mask = (mc->opmask[mask_reg - mask_reg_start] >> ordinal) & 0x1;
@@ -367,8 +367,8 @@ instr_compute_VSIB_index(bool *selected OUT, app_pc *result OUT, bool *is_write 
         index_addr = mc->simd[index_reg - index_reg_start].u32[ordinal];
     } else if (index_size == OPSZ_8) {
         int mask;
-        if (ordinal >=
-            opnd_size_in_bytes(reg_get_size(index_reg)) / opnd_size_in_bytes(index_size))
+        if (ordinal >= (int)opnd_size_in_bytes(reg_get_size(index_reg)) /
+                (int)opnd_size_in_bytes(index_size))
             return false;
         if (is_evex) {
             mask = (mc->opmask[mask_reg - mask_reg_start] >> ordinal) & 0x1;

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -416,16 +416,16 @@ instr_compute_address_VSIB(instr_t *instr, priv_mcontext_t *mc, size_t mc_size,
      * full iteration on each call
      */
     uint vsib_idx = 0;
-    bool is_scatter = false;
+    bool is_write = false;
     *have_addr = true;
-    while (instr_compute_VSIB_index(&selected, addr, &is_scatter, instr, vsib_idx, mc,
+    while (instr_compute_VSIB_index(&selected, addr, &is_write, instr, vsib_idx, mc,
                                     mc_size, mc_flags) &&
            (!selected || vsib_idx < index)) {
         vsib_idx++;
         selected = false;
     }
     if (selected && vsib_idx == index) {
-        *write = is_scatter;
+        *write = is_write;
         if (addr != NULL) {
             /* Add in seg, base, and disp */
             *addr = opnd_compute_address_helper(curop, mc, (ptr_int_t)*addr);

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -366,7 +366,7 @@ instr_compute_VSIB_index(bool *selected OUT, app_pc *result OUT, bool *is_write 
         *selected = true;
         index_addr = mc->simd[index_reg - index_reg_start].u32[ordinal];
     } else if (index_size == OPSZ_8) {
-        int mask; /* just top half */
+        int mask;
         if (ordinal >=
             opnd_size_in_bytes(reg_get_size(index_reg)) / opnd_size_in_bytes(index_size))
             return false;
@@ -377,6 +377,7 @@ instr_compute_VSIB_index(bool *selected OUT, app_pc *result OUT, bool *is_write 
                 return true;
             }
         } else {
+            /* just top half */
             mask = (int)mc->simd[mask_reg - mask_reg_start].u32[ordinal * 2 + 1];
             if (mask >= 0) { /* top bit not set */
                 *selected = false;

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -316,7 +316,7 @@ instr_compute_VSIB_index(bool *selected OUT, app_pc *result OUT, bool *is_write 
     if (reg_get_size(index_reg) == OPSZ_64) {
         CLIENT_ASSERT(mc_size >= offsetof(dr_mcontext_t, simd) +
                               MCXT_NUM_SIMD_SSE_AVX_SLOTS * ZMM_REG_SIZE,
-                      "Incompatible client, invalid size.");
+                      "Incompatible client, invalid dr_mcontext_t.size.");
         index_reg_start = DR_REG_START_ZMM;
     } else if (reg_get_size(index_reg) == OPSZ_32) {
         CLIENT_ASSERT(
@@ -325,12 +325,12 @@ instr_compute_VSIB_index(bool *selected OUT, app_pc *result OUT, bool *is_write 
                      * there, and this is what we need to make the version check for.
                      */
                     MCXT_NUM_SIMD_SSE_AVX_SLOTS * YMM_REG_SIZE,
-            "Incompatible client, invalid size.");
+            "Incompatible client, invalid dr_mcontext_t.size.");
         index_reg_start = DR_REG_START_YMM;
     } else {
         CLIENT_ASSERT(mc_size >= offsetof(dr_mcontext_t, simd) +
                               MCXT_NUM_SIMD_SSE_AVX_SLOTS * YMM_REG_SIZE,
-                      "Incompatible client, invalid size.");
+                      "Incompatible client, invalid dr_mcontext_t.size.");
         index_reg_start = DR_REG_START_XMM;
     }
     /* Size check for upper 16 AVX-512 registers, requiring updated dr_mcontext_t simd
@@ -339,7 +339,7 @@ instr_compute_VSIB_index(bool *selected OUT, app_pc *result OUT, bool *is_write 
     CLIENT_ASSERT(index_reg - index_reg_start < MCXT_NUM_SIMD_SSE_AVX_SLOTS ||
                       mc_size >= offsetof(dr_mcontext_t, simd) +
                               MCXT_NUM_SIMD_SSE_AVX_SLOTS * ZMM_REG_SIZE,
-                  "Incompatible client, invalid size.");
+                  "Incompatible client, invalid dr_mcontext_t.size.");
     if (is_evex)
         mask_reg_start = DR_REG_START_OPMASK;
     else

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -196,7 +196,7 @@ instr_compute_VSIB_index(bool *selected OUT, app_pc *result OUT, bool *is_write 
                          dr_mcontext_flags_t mc_flags)
 {
     CLIENT_ASSERT(selected != NULL && result != NULL && mc != NULL,
-                  "instr_compute_address_ex[_pos]: invalid args");
+                  "vsib address computation: invalid args");
     CLIENT_ASSERT(TEST(DR_MC_MULTIMEDIA, mc_flags),
                   "dr_mcontext_t.flags must include DR_MC_MULTIMEDIA");
     opnd_t src0 = instr_get_src(instr, 0);

--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -195,7 +195,8 @@ instr_compute_VSIB_index(bool *selected OUT, app_pc *result OUT, bool *is_write 
                          instr_t *instr, int ordinal, priv_mcontext_t *mc, size_t mc_size,
                          dr_mcontext_flags_t mc_flags)
 {
-    CLIENT_ASSERT(selected != NULL && result != NULL && mc != NULL, "invalid args");
+    CLIENT_ASSERT(selected != NULL && result != NULL && mc != NULL,
+                  "instr_compute_address_ex[_pos]: invalid args");
     CLIENT_ASSERT(TEST(DR_MC_MULTIMEDIA, mc_flags),
                   "dr_mcontext_t.flags must include DR_MC_MULTIMEDIA");
     opnd_t src0 = instr_get_src(instr, 0);

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1450,8 +1450,9 @@ test_tsx(void *dc)
 }
 
 static void
-test_vsib_helper(void *dc, dr_mcontext_t *mc, instr_t *instr, reg_t base, int mask_idx,
-                 int index_idx, int scale, int disp, int count, opnd_size_t index_sz)
+test_vsib_helper(void *dc, dr_mcontext_t *mc, instr_t *instr, reg_t base, int index_idx,
+                 int scale, int disp, int count, opnd_size_t index_sz, bool is_evex,
+                 bool expect_write)
 {
     uint memopidx, memoppos;
     app_pc addr;
@@ -1473,8 +1474,9 @@ test_vsib_helper(void *dc, dr_mcontext_t *mc, instr_t *instr, reg_t base, int ma
                                    mc->simd[index_idx].u32[memopidx * 2])
 #endif
             );
-        ASSERT(!write);
-        ASSERT(memoppos == 0);
+        ASSERT(write == expect_write);
+        ASSERT((is_evex && !write && memoppos == 1) ||
+               (is_evex && write && memoppos == 0) || memoppos == 0);
         ASSERT((ptr_int_t)addr == base + disp + scale * index);
     }
     ASSERT(memopidx == count);
@@ -1508,6 +1510,8 @@ test_vsib(void *dc)
                               false /*no bytes*/, dbuf, BUFFER_SIZE_ELEMENTS(dbuf), &len);
     ASSERT(pc == NULL);
 
+    /* AVX VEX opcodes */
+
     /* Test mem addr emulation */
     mc.size = sizeof(mc);
     mc.flags = DR_MC_ALL;
@@ -1535,7 +1539,8 @@ test_vsib(void *dc)
         dc, opnd_create_reg(DR_REG_XMM0),
         opnd_create_base_disp(DR_REG_XCX, DR_REG_XMM1, 2, 0x12, OPSZ_8),
         opnd_create_reg(DR_REG_XMM2));
-    test_vsib_helper(dc, &mc, instr, mc.xcx, 2, 1, 2, 0x12, 2, OPSZ_4);
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 2, OPSZ_4, false /* !evex */,
+                     false /* !expect_write */);
     instr_destroy(dc, instr);
 
     /* test index size 8 and mem size 4 */
@@ -1543,7 +1548,8 @@ test_vsib(void *dc)
         dc, opnd_create_reg(DR_REG_XMM0),
         opnd_create_base_disp(DR_REG_XCX, DR_REG_XMM1, 2, 0x12, OPSZ_8),
         opnd_create_reg(DR_REG_XMM2));
-    test_vsib_helper(dc, &mc, instr, mc.xcx, 2, 1, 2, 0x12, 2, OPSZ_8);
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 2, OPSZ_8, false /* !evex */,
+                     false /* !expect_write */);
     instr_destroy(dc, instr);
 
     /* test index size 4 and mem size 4 */
@@ -1551,7 +1557,8 @@ test_vsib(void *dc)
         dc, opnd_create_reg(DR_REG_XMM0),
         opnd_create_base_disp(DR_REG_XCX, DR_REG_XMM1, 2, 0x12, OPSZ_4),
         opnd_create_reg(DR_REG_XMM2));
-    test_vsib_helper(dc, &mc, instr, mc.xcx, 2, 1, 2, 0x12, 4, OPSZ_4);
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 4, OPSZ_4, false /* !evex */,
+                     false /* !expect_write */);
     instr_destroy(dc, instr);
 
     /* test index size 8 and mem size 4 */
@@ -1559,7 +1566,8 @@ test_vsib(void *dc)
         dc, opnd_create_reg(DR_REG_XMM0),
         opnd_create_base_disp(DR_REG_XCX, DR_REG_XMM1, 2, 0x12, OPSZ_4),
         opnd_create_reg(DR_REG_XMM2));
-    test_vsib_helper(dc, &mc, instr, mc.xcx, 2, 1, 2, 0x12, 2, OPSZ_8);
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 2, OPSZ_8, false /* !evex */,
+                     false /* !expect_write */);
     instr_destroy(dc, instr);
 
     /* test 256-byte */
@@ -1567,7 +1575,8 @@ test_vsib(void *dc)
         dc, opnd_create_reg(DR_REG_YMM0),
         opnd_create_base_disp(DR_REG_XCX, DR_REG_YMM1, 2, 0x12, OPSZ_4),
         opnd_create_reg(DR_REG_YMM2));
-    test_vsib_helper(dc, &mc, instr, mc.xcx, 2, 1, 2, 0x12, 8, OPSZ_4);
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 8, OPSZ_4, false /* !evex */,
+                     false /* !expect_write */);
     instr_destroy(dc, instr);
 
     /* test mask not selecting things -- in the middle complicates
@@ -1585,7 +1594,122 @@ test_vsib(void *dc)
         dc, opnd_create_reg(DR_REG_YMM0),
         opnd_create_base_disp(DR_REG_XCX, DR_REG_YMM1, 2, 0x12, OPSZ_4),
         opnd_create_reg(DR_REG_YMM2));
-    test_vsib_helper(dc, &mc, instr, mc.xcx, 2, 1, 2, 0x12, 0 /*nothing*/, OPSZ_4);
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 0 /*nothing*/, OPSZ_4,
+                     false /* !evex */, false /* !expect_write */);
+    instr_destroy(dc, instr);
+
+    /* AVX-512 EVEX opcodes */
+
+    /* evex mask */
+    mc.opmask[0] = 0xffff;
+
+    /* test index size 4 and mem size 8 */
+    instr = INSTR_CREATE_vgatherdpd_mask(
+        dc, opnd_create_reg(DR_REG_XMM0), opnd_create_reg(DR_REG_K0),
+        opnd_create_base_disp(DR_REG_XCX, DR_REG_XMM1, 2, 0x12, OPSZ_8));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 2, OPSZ_4, true /* evex */,
+                     false /* !expect_write */);
+    instr_destroy(dc, instr);
+
+    instr = INSTR_CREATE_vscatterdpd_mask(
+        dc, opnd_create_base_disp(DR_REG_XCX, DR_REG_XMM1, 2, 0x12, OPSZ_8),
+        opnd_create_reg(DR_REG_K0), opnd_create_reg(DR_REG_XMM0));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 2, OPSZ_4, true /* evex */,
+                     true /* expect_write */);
+    instr_destroy(dc, instr);
+
+    /* test index size 8 and mem size 4 */
+    instr = INSTR_CREATE_vgatherqpd_mask(
+        dc, opnd_create_reg(DR_REG_XMM0), opnd_create_reg(DR_REG_K0),
+        opnd_create_base_disp(DR_REG_XCX, DR_REG_XMM1, 2, 0x12, OPSZ_8));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 2, OPSZ_8, true /* evex */,
+                     false /* !expect_write */);
+    instr_destroy(dc, instr);
+
+    instr = INSTR_CREATE_vscatterqpd_mask(
+        dc, opnd_create_base_disp(DR_REG_XCX, DR_REG_XMM1, 2, 0x12, OPSZ_8),
+        opnd_create_reg(DR_REG_K0), opnd_create_reg(DR_REG_XMM0));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 2, OPSZ_8, true /* evex */,
+                     true /* expect_write */);
+    instr_destroy(dc, instr);
+
+    /* test index size 4 and mem size 4 */
+    instr = INSTR_CREATE_vgatherdps_mask(
+        dc, opnd_create_reg(DR_REG_XMM0), opnd_create_reg(DR_REG_K0),
+        opnd_create_base_disp(DR_REG_XCX, DR_REG_XMM1, 2, 0x12, OPSZ_4));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 4, OPSZ_4, true /* evex */,
+                     false /* !expect_write */);
+    instr_destroy(dc, instr);
+
+    instr = INSTR_CREATE_vscatterdps_mask(
+        dc, opnd_create_base_disp(DR_REG_XCX, DR_REG_XMM1, 2, 0x12, OPSZ_4),
+        opnd_create_reg(DR_REG_K0), opnd_create_reg(DR_REG_XMM0));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 4, OPSZ_4, true /* evex */,
+                     true /* expect_write */);
+    instr_destroy(dc, instr);
+
+    /* test index size 8 and mem size 4 */
+    instr = INSTR_CREATE_vgatherqps_mask(
+        dc, opnd_create_reg(DR_REG_XMM0), opnd_create_reg(DR_REG_K0),
+        opnd_create_base_disp(DR_REG_XCX, DR_REG_XMM1, 2, 0x12, OPSZ_4));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 2, OPSZ_8, true /* evex */,
+                     false /* !expect_write */);
+    instr_destroy(dc, instr);
+
+    instr = INSTR_CREATE_vscatterqps_mask(
+        dc, opnd_create_base_disp(DR_REG_XCX, DR_REG_XMM1, 2, 0x12, OPSZ_4),
+        opnd_create_reg(DR_REG_K0), opnd_create_reg(DR_REG_XMM0));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 2, OPSZ_8, true /* evex */,
+                     true /* expect_write */);
+    instr_destroy(dc, instr);
+
+    /* test 256-bit */
+    instr = INSTR_CREATE_vgatherdps_mask(
+        dc, opnd_create_reg(DR_REG_YMM0), opnd_create_reg(DR_REG_K0),
+        opnd_create_base_disp(DR_REG_XCX, DR_REG_YMM1, 2, 0x12, OPSZ_4));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 8, OPSZ_4, true /* evex */,
+                     false /* !expect_write */);
+    instr_destroy(dc, instr);
+
+    instr = INSTR_CREATE_vscatterdps_mask(
+        dc, opnd_create_base_disp(DR_REG_XCX, DR_REG_YMM1, 2, 0x12, OPSZ_4),
+        opnd_create_reg(DR_REG_K0), opnd_create_reg(DR_REG_YMM0));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 8, OPSZ_4, true /* evex */,
+                     true /* expect_write */);
+    instr_destroy(dc, instr);
+
+    /* test 512-bit */
+    instr = INSTR_CREATE_vgatherdps_mask(
+        dc, opnd_create_reg(DR_REG_ZMM0), opnd_create_reg(DR_REG_K0),
+        opnd_create_base_disp(DR_REG_XCX, DR_REG_ZMM1, 2, 0x12, OPSZ_4));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 16, OPSZ_4, true /* evex */,
+                     false /* !expect_write */);
+    instr_destroy(dc, instr);
+
+    instr = INSTR_CREATE_vscatterdps_mask(
+        dc, opnd_create_base_disp(DR_REG_XCX, DR_REG_ZMM1, 2, 0x12, OPSZ_4),
+        opnd_create_reg(DR_REG_K0), opnd_create_reg(DR_REG_ZMM0));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 16, OPSZ_4, true /* evex */,
+                     true /* expect_write */);
+    instr_destroy(dc, instr);
+
+    /* test mask not selecting things -- in the middle complicates
+     * our helper checks so we just do the ends
+     */
+    mc.opmask[0] = 0x0;
+
+    instr = INSTR_CREATE_vgatherdps_mask(
+        dc, opnd_create_reg(DR_REG_YMM0), opnd_create_reg(DR_REG_K0),
+        opnd_create_base_disp(DR_REG_XCX, DR_REG_YMM1, 2, 0x12, OPSZ_4));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 0 /*nothing*/, OPSZ_4,
+                     true /* evex */, false /* !expect_write */);
+    instr_destroy(dc, instr);
+
+    instr = INSTR_CREATE_vscatterdps_mask(
+        dc, opnd_create_base_disp(DR_REG_XCX, DR_REG_YMM1, 2, 0x12, OPSZ_4),
+        opnd_create_reg(DR_REG_K0), opnd_create_reg(DR_REG_YMM0));
+    test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 0 /*nothing*/, OPSZ_4,
+                     true /* evex */, true /* expect_write */);
     instr_destroy(dc, instr);
 }
 


### PR DESCRIPTION
Adds AVX-512 VSIB addressing support to instr_compute_address_ex and
instr_compute_address_ex_pos.

Adds scatter opcodes handling to above.

Augments api.ir with tests for above.

Issue: #1312