### PR TITLE
i#3792: Remove alias attribute and replace by real function body.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,6 +754,23 @@ if (UNIX)
     if (nounused_avail)
       set(WARN "${WARN} -Wno-unused-but-set-variable")
     endif (nounused_avail)
+    # XXX i#3793: DynamoRIO manages '\0' termination and error states itself in
+    # too many places. In order to activate this warning, this code needs to get
+    # re-factored for no good reason.
+    CHECK_C_COMPILER_FLAG("-Wstringop-truncation" stringop_truncation_avail)
+    if (stringop_truncation_avail)
+      set(WARN "${WARN} -Wno-stringop-truncation")
+    endif (stringop_truncation_avail)
+    # XXX i#3793: see comment above.
+    CHECK_C_COMPILER_FLAG("-Wformat-truncation" format_truncation_avail)
+    if (format_truncation_avail)
+      set(WARN "${WARN} -Wno-format-truncation")
+    endif (format_truncation_avail)
+    # XXX i#3793: see comment above.
+    CHECK_C_COMPILER_FLAG("-Wstringop-overflow" stringop_overflow_avail)
+    if (stringop_overflow_avail)
+      set(WARN "${WARN} -Wno-stringop-overflow")
+    endif (stringop_overflow_avail)
     CHECK_C_COMPILER_FLAG("-Wtype-limits" HAVE_TYPELIMITS_CONTROL)
   else (NOT CMAKE_COMPILER_IS_CLANG)
     # clang turns off color when it's writing to a pipe, but the user may still

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,19 +754,19 @@ if (UNIX)
     if (nounused_avail)
       set(WARN "${WARN} -Wno-unused-but-set-variable")
     endif (nounused_avail)
-    # XXX i#3793: DynamoRIO manages '\0' termination and error states itself in
+    # XXX i#3792: DynamoRIO manages '\0' termination and error states itself in
     # too many places. In order to activate this warning, this code needs to get
     # re-factored for no good reason.
     CHECK_C_COMPILER_FLAG("-Wstringop-truncation" stringop_truncation_avail)
     if (stringop_truncation_avail)
       set(WARN "${WARN} -Wno-stringop-truncation")
     endif (stringop_truncation_avail)
-    # XXX i#3793: see comment above.
+    # XXX i#3792: see comment above.
     CHECK_C_COMPILER_FLAG("-Wformat-truncation" format_truncation_avail)
     if (format_truncation_avail)
       set(WARN "${WARN} -Wno-format-truncation")
     endif (format_truncation_avail)
-    # XXX i#3793: see comment above.
+    # XXX i#3792: see comment above.
     CHECK_C_COMPILER_FLAG("-Wstringop-overflow" stringop_overflow_avail)
     if (stringop_overflow_avail)
       set(WARN "${WARN} -Wno-stringop-overflow")

--- a/core/string.c
+++ b/core/string.c
@@ -117,32 +117,36 @@ d_r_strrchr(const char *str, int c)
 /* Private strncpy.  Standard caveat about not copying trailing null byte on
  * truncation applies.
  */
-#define D_R_STRNCPY_BODY                      \
-    size_t i;                                 \
-    for (i = 0; i < n && src[i] != '\0'; i++) \
-        dst[i] = src[i];                      \
-    /* Pad the rest with nulls. */            \
-    for (; i < n; i++)                        \
-        dst[i] = '\0';                        \
-    return dst;
+#define D_R_STRNCPY_BODY()                        \
+    do {                                          \
+        size_t i;                                 \
+        for (i = 0; i < n && src[i] != '\0'; i++) \
+            dst[i] = src[i];                      \
+        /* Pad the rest with nulls. */            \
+        for (; i < n; i++)                        \
+            dst[i] = '\0';                        \
+        return dst;                               \
+    } while (0);
 char *
 d_r_strncpy(char *dst, const char *src, size_t n)
 {
-    D_R_STRNCPY_BODY
+    D_R_STRNCPY_BODY()
 }
 
 /* Private strncat. */
-#define D_R_STRNCAT_BODY                      \
-    size_t dest_len = strlen(dest);           \
-    size_t i;                                 \
-    for (i = 0; i < n && src[i] != '\0'; i++) \
-        dest[dest_len + i] = src[i];          \
-    dest[dest_len + i] = '\0';                \
-    return dest;
+#define D_R_STRNCAT_BODY()                        \
+    do {                                          \
+        size_t dest_len = strlen(dest);           \
+        size_t i;                                 \
+        for (i = 0; i < n && src[i] != '\0'; i++) \
+            dest[dest_len + i] = src[i];          \
+        dest[dest_len + i] = '\0';                \
+        return dest;                              \
+    } while (0);
 char *
 d_r_strncat(char *dest, const char *src, size_t n)
 {
-    D_R_STRNCAT_BODY
+    D_R_STRNCAT_BODY()
 }
 
 /* Private memcpy is in arch/<arch>/<arch>.asm or memfuncs.asm */
@@ -156,21 +160,23 @@ d_r_strncat(char *dest, const char *src, size_t n)
  * DR libc isolation.
  */
 
-#define D_R_MEMMOVE_BODY                            \
-    ssize_t i;                                      \
-    byte *dst_b = (byte *)dst;                      \
-    const byte *src_b = (const byte *)src;          \
-    if (dst < src)                                  \
-        return memcpy(dst, src, n);                 \
-    /* FIXME: Could use reverse DF and rep movs. */ \
-    for (i = n - 1; i >= 0; i--) {                  \
-        dst_b[i] = src_b[i];                        \
-    }                                               \
-    return dst;
+#define D_R_MEMMOVE_BODY()                              \
+    do {                                                \
+        ssize_t i;                                      \
+        byte *dst_b = (byte *)dst;                      \
+        const byte *src_b = (const byte *)src;          \
+        if (dst < src)                                  \
+            return memcpy(dst, src, n);                 \
+        /* FIXME: Could use reverse DF and rep movs. */ \
+        for (i = n - 1; i >= 0; i--) {                  \
+            dst_b[i] = src_b[i];                        \
+        }                                               \
+        return dst;                                     \
+    } while (0);
 void *
 d_r_memmove(void *dst, const void *src, size_t n)
 {
-    D_R_MEMMOVE_BODY
+    D_R_MEMMOVE_BODY()
 }
 
 #ifdef UNIX
@@ -184,17 +190,17 @@ d_r_memmove(void *dst, const void *src, size_t n)
 void *
 __memmove_chk(void *dst, const void *src, size_t n, size_t dst_len)
 {
-    D_R_MEMMOVE_BODY
+    D_R_MEMMOVE_BODY()
 }
 void *
 __strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
 {
-    D_R_STRNCPY_BODY
+    D_R_STRNCPY_BODY()
 }
 void *
 __strncat_chk(char *dest, const char *src, size_t n, size_t dst_len)
 {
-    D_R_STRNCAT_BODY
+    D_R_STRNCAT_BODY()
 }
 #endif
 

--- a/core/string.c
+++ b/core/string.c
@@ -117,28 +117,32 @@ d_r_strrchr(const char *str, int c)
 /* Private strncpy.  Standard caveat about not copying trailing null byte on
  * truncation applies.
  */
+#define D_R_STRNCPY_BODY                      \
+    size_t i;                                 \
+    for (i = 0; i < n && src[i] != '\0'; i++) \
+        dst[i] = src[i];                      \
+    /* Pad the rest with nulls. */            \
+    for (; i < n; i++)                        \
+        dst[i] = '\0';                        \
+    return dst;
 char *
 d_r_strncpy(char *dst, const char *src, size_t n)
 {
-    size_t i;
-    for (i = 0; i < n && src[i] != '\0'; i++)
-        dst[i] = src[i];
-    /* Pad the rest with nulls. */
-    for (; i < n; i++)
-        dst[i] = '\0';
-    return dst;
+    D_R_STRNCPY_BODY
 }
 
 /* Private strncat. */
+#define D_R_STRNCAT_BODY                      \
+    size_t dest_len = strlen(dest);           \
+    size_t i;                                 \
+    for (i = 0; i < n && src[i] != '\0'; i++) \
+        dest[dest_len + i] = src[i];          \
+    dest[dest_len + i] = '\0';                \
+    return dest;
 char *
 d_r_strncat(char *dest, const char *src, size_t n)
 {
-    size_t dest_len = strlen(dest);
-    size_t i;
-    for (i = 0; i < n && src[i] != '\0'; i++)
-        dest[dest_len + i] = src[i];
-    dest[dest_len + i] = '\0';
-    return dest;
+    D_R_STRNCAT_BODY
 }
 
 /* Private memcpy is in arch/<arch>/<arch>.asm or memfuncs.asm */
@@ -151,19 +155,22 @@ d_r_strncat(char *dest, const char *src, size_t n)
  * We also have a version named "memmove" in lib/memmove.c for shared
  * DR libc isolation.
  */
+
+#define D_R_MEMMOVE_BODY                            \
+    ssize_t i;                                      \
+    byte *dst_b = (byte *)dst;                      \
+    const byte *src_b = (const byte *)src;          \
+    if (dst < src)                                  \
+        return memcpy(dst, src, n);                 \
+    /* FIXME: Could use reverse DF and rep movs. */ \
+    for (i = n - 1; i >= 0; i--) {                  \
+        dst_b[i] = src_b[i];                        \
+    }                                               \
+    return dst;
 void *
 d_r_memmove(void *dst, const void *src, size_t n)
 {
-    ssize_t i;
-    byte *dst_b = (byte *)dst;
-    const byte *src_b = (const byte *)src;
-    if (dst < src)
-        return memcpy(dst, src, n);
-    /* FIXME: Could use reverse DF and rep movs. */
-    for (i = n - 1; i >= 0; i--) {
-        dst_b[i] = src_b[i];
-    }
-    return dst;
+    D_R_MEMMOVE_BODY
 }
 
 #ifdef UNIX
@@ -174,40 +181,19 @@ d_r_memmove(void *dst, const void *src, size_t n)
  */
 void *
 __memmove_chk(void *dst, const void *src, size_t n, size_t dst_len)
-#    ifdef MACOS
-/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
- * XXX: better to test for support at config time: for now assuming none on Mac.
- */
 {
-    return memmove(dst, src, n);
+    D_R_MEMMOVE_BODY
 }
-#    else
-    __attribute__((alias("d_r_memmove")));
-#    endif
 void *
 __strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
-#    ifdef MACOS
-/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
- * XXX: better to test for support at config time: for now assuming none on Mac.
- */
 {
-    return strncpy(dst, src, n);
+    D_R_STRNCPY_BODY
 }
-#    else
-    __attribute__((alias("d_r_strncpy")));
-#    endif
 void *
-__strncat_chk(char *dst, const char *src, size_t n, size_t dst_len)
-#    ifdef MACOS
-/* OSX 10.7 gcc 4.2.1 doesn't support the alias attribute.
- * XXX: better to test for support at config time: for now assuming none on Mac.
- */
+__strncat_chk(char *dest, const char *src, size_t n, size_t dst_len)
 {
-    return strncat(dst, src, n);
+    D_R_STRNCAT_BODY
 }
-#    else
-    __attribute__((alias("d_r_strncat")));
-#    endif
 #endif
 
 /* Private strcmp. */

--- a/core/string.c
+++ b/core/string.c
@@ -126,11 +126,11 @@ d_r_strrchr(const char *str, int c)
         for (; i < n; i++)                        \
             dst[i] = '\0';                        \
         return dst;                               \
-    } while (0);
+    } while (0)
 char *
 d_r_strncpy(char *dst, const char *src, size_t n)
 {
-    D_R_STRNCPY_BODY()
+    D_R_STRNCPY_BODY();
 }
 
 /* Private strncat. */
@@ -142,11 +142,11 @@ d_r_strncpy(char *dst, const char *src, size_t n)
             dest[dest_len + i] = src[i];          \
         dest[dest_len + i] = '\0';                \
         return dest;                              \
-    } while (0);
+    } while (0)
 char *
 d_r_strncat(char *dest, const char *src, size_t n)
 {
-    D_R_STRNCAT_BODY()
+    D_R_STRNCAT_BODY();
 }
 
 /* Private memcpy is in arch/<arch>/<arch>.asm or memfuncs.asm */
@@ -172,11 +172,11 @@ d_r_strncat(char *dest, const char *src, size_t n)
             dst_b[i] = src_b[i];                        \
         }                                               \
         return dst;                                     \
-    } while (0);
+    } while (0)
 void *
 d_r_memmove(void *dst, const void *src, size_t n)
 {
-    D_R_MEMMOVE_BODY()
+    D_R_MEMMOVE_BODY();
 }
 
 #ifdef UNIX
@@ -190,17 +190,17 @@ d_r_memmove(void *dst, const void *src, size_t n)
 void *
 __memmove_chk(void *dst, const void *src, size_t n, size_t dst_len)
 {
-    D_R_MEMMOVE_BODY()
+    D_R_MEMMOVE_BODY();
 }
 void *
 __strncpy_chk(char *dst, const char *src, size_t n, size_t dst_len)
 {
-    D_R_STRNCPY_BODY()
+    D_R_STRNCPY_BODY();
 }
 void *
 __strncat_chk(char *dest, const char *src, size_t n, size_t dst_len)
 {
-    D_R_STRNCAT_BODY()
+    D_R_STRNCAT_BODY();
 }
 #endif
 

--- a/core/string.c
+++ b/core/string.c
@@ -176,8 +176,10 @@ d_r_memmove(void *dst, const void *src, size_t n)
 #ifdef UNIX
 /* gcc emits calls to these *_chk variants in release builds when the size of
  * dst is known at compile time.  In C, the caller is responsible for cleaning
- * up arguments on the stack, so we alias these *_chk routines to the non-chk
- * routines and rely on the caller to clean up the extra dst_len arg.
+ * up arguments on the stack. We used to alias these *_chk routines to the non-chk
+ * routines. Current gcc versions don't accept aliases with a different function
+ * signature. Instead, we are now manually inlining the function body. We rely
+ * on the caller to clean up the extra dst_len arg.
  */
 void *
 __memmove_chk(void *dst, const void *src, size_t n, size_t dst_len)


### PR DESCRIPTION
GCC >= 8.2 does not accept a different function declaration used for the alias macro
without a warning. Instead of subduing the warning and relying on aliasing it, we now
inline the function body directly with a macro.

Disables the warning errors -Wstringop-truncation, -Wformat-truncation, and
-Wno-stringop-overflow. All 3 warnings are related to '\0' string termination. DynamoRIO
manages string termination and error handling itself in many places. Various re-factoring
would be required in order to turn on the warnings.

Fixes #3792