### PR TITLE
i#3790 AVX-512 support: Move AVX-512 warning to interpreter loop.

### DIFF
--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -251,6 +251,17 @@ d_r_is_avx512_code_in_use()
 static inline void
 d_r_set_avx512_code_in_use(bool in_use)
 {
+#    if !defined(UNIX) || !defined(X64)
+    /* We warn about unsupported AVX-512 present in the app. */
+    DO_ONCE({
+        char pc_addr[IF_X64_ELSE(20, 12)];
+        snprintf(pc_addr, BUFFER_SIZE_ELEMENTS(pc_addr), PFX,
+                 instr_get_app_pc(bb->instr));
+        NULL_TERMINATE_BUFFER(pc_addr);
+        SYSLOG(SYSLOG_ERROR, AVX_512_SUPPORT_INCOMPLETE, 2, get_application_name(),
+               get_application_pid(), pc_addr);
+    });
+#    endif
     SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
     ATOMIC_1BYTE_WRITE(d_r_avx512_code_in_use, in_use, false);
     SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -249,17 +249,18 @@ d_r_is_avx512_code_in_use()
 }
 
 static inline void
-d_r_set_avx512_code_in_use(bool in_use)
+d_r_set_avx512_code_in_use(bool in_use, app_pc pc)
 {
 #    if !defined(UNIX) || !defined(X64)
     /* We warn about unsupported AVX-512 present in the app. */
     DO_ONCE({
-        char pc_addr[IF_X64_ELSE(20, 12)];
-        snprintf(pc_addr, BUFFER_SIZE_ELEMENTS(pc_addr), PFX,
-                 instr_get_app_pc(bb->instr));
-        NULL_TERMINATE_BUFFER(pc_addr);
-        SYSLOG(SYSLOG_ERROR, AVX_512_SUPPORT_INCOMPLETE, 2, get_application_name(),
-               get_application_pid(), pc_addr);
+        if (pc != NULL) {
+            char pc_addr[IF_X64_ELSE(20, 12)];
+            snprintf(pc_addr, BUFFER_SIZE_ELEMENTS(pc_addr), PFX, pc);
+            NULL_TERMINATE_BUFFER(pc_addr);
+            SYSLOG(SYSLOG_ERROR, AVX_512_SUPPORT_INCOMPLETE, 2, get_application_name(),
+                   get_application_pid(), pc_addr);
+        }
     });
 #    endif
     SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -3515,6 +3515,15 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
                         LOG(THREAD, LOG_INTERP, 2, "Detected AVX-512 code in use\n");
                         d_r_set_avx512_code_in_use(true);
                         proc_set_num_simd_saved(MCXT_NUM_SIMD_SLOTS);
+#    if !defined(UNIX) || !defined(X64)
+                        /* We warn about unsupported AVX-512 present in the app. */
+                        char pc_addr[IF_X64_ELSE(20, 12)];
+                        snprintf(pc_addr, BUFFER_SIZE_ELEMENTS(pc_addr), PFX,
+                                 instr_get_app_pc(bb->instr));
+                        NULL_TERMINATE_BUFFER(pc_addr);
+                        SYSLOG(SYSLOG_ERROR, AVX_512_SUPPORT_INCOMPLETE, 2,
+                               get_application_name(), get_application_pid(), pc_addr);
+#    endif
                     }
                 }
             }

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -2864,7 +2864,7 @@ client_process_bb(dcontext_t *dcontext, build_bb_t *bb)
             if (ZMM_ENABLED()) {
                 if (instr_may_write_zmm_or_opmask_register(inst)) {
                     LOG(THREAD, LOG_INTERP, 2, "Detected AVX-512 code in use\n");
-                    d_r_set_avx512_code_in_use(true);
+                    d_r_set_avx512_code_in_use(true, NULL);
                     proc_set_num_simd_saved(MCXT_NUM_SIMD_SLOTS);
                 }
             }
@@ -3513,7 +3513,7 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
                          * are checked with instr_may_write_zmm_register.
                          */
                         LOG(THREAD, LOG_INTERP, 2, "Detected AVX-512 code in use\n");
-                        d_r_set_avx512_code_in_use(true);
+                        d_r_set_avx512_code_in_use(true, instr_get_app_pc(bb->instr));
                         proc_set_num_simd_saved(MCXT_NUM_SIMD_SLOTS);
                     }
                 }

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -3515,15 +3515,6 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
                         LOG(THREAD, LOG_INTERP, 2, "Detected AVX-512 code in use\n");
                         d_r_set_avx512_code_in_use(true);
                         proc_set_num_simd_saved(MCXT_NUM_SIMD_SLOTS);
-#    if !defined(UNIX) || !defined(X64)
-                        /* We warn about unsupported AVX-512 present in the app. */
-                        char pc_addr[IF_X64_ELSE(20, 12)];
-                        snprintf(pc_addr, BUFFER_SIZE_ELEMENTS(pc_addr), PFX,
-                                 instr_get_app_pc(bb->instr));
-                        NULL_TERMINATE_BUFFER(pc_addr);
-                        SYSLOG(SYSLOG_ERROR, AVX_512_SUPPORT_INCOMPLETE, 2,
-                               get_application_name(), get_application_pid(), pc_addr);
-#    endif
                     }
                 }
             }

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -773,15 +773,6 @@ read_evex(byte *pc, decode_info_t *di, byte instr_byte,
             return pc;
         }
         *is_evex = true;
-#if !defined(STANDALONE_DECODER)
-        DO_ONCE({
-            char pc_addr[IF_X64_ELSE(20, 12)];
-            snprintf(pc_addr, BUFFER_SIZE_ELEMENTS(pc_addr), PFX, pc);
-            NULL_TERMINATE_BUFFER(pc_addr);
-            SYSLOG(SYSLOG_ERROR, AVX_512_SUPPORT_INCOMPLETE, 2, get_application_name(),
-                   get_application_pid(), pc_addr);
-        });
-#endif
         info = &evex_prefix_extensions[0][1];
     } else {
         /* not evex */

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -711,7 +711,7 @@ instrument_init(void)
          * state. AVX-512 context switching will not be lazy in this case.
          */
         if (d_r_is_client_avx512_code_in_use())
-            d_r_set_avx512_code_in_use(true);
+            d_r_set_avx512_code_in_use(true, NULL);
     }
 #    endif
 


### PR DESCRIPTION
In order to avoid self-detection of AVX-512 gencode, this patch moves the warning to the
main interpreter loop instead.

The warning also has been disabled for UNIX 64-bit. This build has been supported since
cf1ec32e9b89c1d8a28e.

A warning is issued only for AVX-512 application code, not client code.

Fixes #3790