### PR TITLE
i#3581 SHA/MPX/PT support: Add support for Intel PT instructions.

### DIFF
--- a/core/arch/decode.h
+++ b/core/arch/decode.h
@@ -381,6 +381,7 @@ enum {
 #define OPSZ_frstor OPSZ_108_short94 /**< Operand size for frstor memory reference. */
 #define OPSZ_fxsave OPSZ_512         /**< Operand size for fxsave memory reference. */
 #define OPSZ_fxrstor OPSZ_512        /**< Operand size for fxrstor memory reference. */
+#define OPSZ_ptwrite OPSZ_4_rex8     /**< Operand size for ptwrite memory reference. */
 /* DR_API EXPORT END */
 
 enum {

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -1591,6 +1591,9 @@ const instr_info_t * const op_instr[] =
     /* OP_bndmk           */ &prefix_extensions[187][1],
     /* OP_bndmov          */ &prefix_extensions[186][2],
     /* OP_bndstx          */ &prefix_extensions[187][0],
+
+    /* Intel PT extensions */
+    /* OP_ptwrite         */ &prefix_extensions[188][1],
 };
 
 
@@ -2959,7 +2962,7 @@ const instr_info_t base_extensions[][8] = {
     {MOD_EXT,    0x0fae31, "(group 15 mod ext 15)", xx, xx, xx, xx, xx, mrm, x, 15},
     {MOD_EXT,    0x0fae32, "(group 15 mod ext 16)", xx, xx, xx, xx, xx, mrm, x, 16},
     {MOD_EXT,    0x0fae33, "(group 15 mod ext 17)", xx, xx, xx, xx, xx, mrm, x, 17},
-    {REX_W_EXT,  0x0fae34, "(rex.w ext 2)", xx, xx, xx, xx, xx, mrm, x, 2},
+    {PREFIX_EXT, 0x0fae34, "(prefix ext 188)", xx, xx, xx, xx, xx, no, x, 188},
     {MOD_EXT,    0x0fae35, "(group 15 mod ext 6)", xx, xx, xx, xx, xx, no, x, 6},
     {MOD_EXT,    0x0fae36, "(group 15 mod ext 7)", xx, xx, xx, xx, xx, no, x, 7},
     {MOD_EXT,    0x0fae37, "(group 15 mod ext 3)", xx, xx, xx, xx, xx, no, x, 3},
@@ -5791,7 +5794,20 @@ const instr_info_t prefix_extensions[][12] = {
     {INVALID,    0xf30f1b18, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,    0x660f1b18, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,    0xf20f1b18, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  },
+  }, { /* prefix extension 188 */
+    {REX_W_EXT,    0x0fae34, "(rex.w ext 2)", xx, xx, xx, xx, xx, mrm, x, 2},
+    {OP_ptwrite, 0xf30fae34, "ptwrite",   xx, xx, Ed_q, xx, xx, mrm, x, END_LIST},
+    {INVALID,    0x660fae34, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf20fae34, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x0fae34, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf30fae34, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0x660fae34, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf20fae34, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x0fae34, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf30fae34, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0x660fae34, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,    0xf20fae34, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+  }
 };
 /****************************************************************************
  * Instructions that differ based on whether vex-encoded or not.

--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -120,6 +120,9 @@
 /** Create a memory reference operand appropriately sized for OP_fxrstor32/OP_fxrstor64.*/
 #define OPND_CREATE_MEM_fxrstor(base, index, scale, disp) \
     opnd_create_base_disp(base, index, scale, disp, OPSZ_fxrstor)
+/** Create a memory reference operand appropriately sized for OP_ptwrite.*/
+#define OPND_CREATE_MEM_ptwrite(base, index, scale, disp) \
+    opnd_create_base_disp(base, index, scale, disp, OPSZ_ptwrite)
 /**
  * Create a memory reference operand appropriately sized for OP_xsave32,
  * OP_xsave64, OP_xsaveopt32, OP_xsaveopt64, OP_xsavec32, OP_xsavec64,
@@ -651,6 +654,15 @@
 #define INSTR_CREATE_ldmxcsr(dc, s) instr_create_0dst_1src((dc), OP_ldmxcsr, (s))
 #define INSTR_CREATE_vldmxcsr(dc, s) instr_create_0dst_1src((dc), OP_vldmxcsr, (s))
 #define INSTR_CREATE_nop_modrm(dc, s) instr_create_0dst_1src((dc), OP_nop_modrm, (s))
+/**
+ * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
+ * the given explicit operands, automatically supplying any implicit operands.
+ * \param dc The void * dcontext used to allocate memory for the instr_t.
+ * \param s The opnd_t explicit source operand for the instruction, which can be
+ * a general-purpose registers or a memory reference. The latter can be created with
+ * OPND_CREATE_MEM_ptwrite() to get the appropriate operand size.
+ */
+#define INSTR_CREATE_ptwrite(dc, s) instr_create_0dst_1src((dc), OP_ptwrite, (s))
 /* @} */ /* end doxygen group */
 /** @name Prefetch */
 /* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */

--- a/core/arch/x86/opcode.h
+++ b/core/arch/x86/opcode.h
@@ -1588,6 +1588,9 @@ enum {
     /* 1415 */ OP_bndmov, /**< IA-32/AMD64 MPX OP_bndmov opcode. */
     /* 1416 */ OP_bndstx, /**< IA-32/AMD64 MPX OP_bndstx opcode. */
 
+    /* Intel PT extensions */
+    /* 1417 */ OP_ptwrite, /**< IA-32/AMD64 PT OP_ptwrite opcode. */
+
     OP_AFTER_LAST,
     OP_FIRST = OP_add,           /**< First real opcode. */
     OP_LAST = OP_AFTER_LAST - 1, /**< Last real opcode. */

--- a/suite/tests/api/ir_x86_1args.h
+++ b/suite/tests/api/ir_x86_1args.h
@@ -187,7 +187,7 @@ OPCODE(llwpcb, llwpcb, llwpcb, 0, REGARG(EAX))
 OPCODE(slwpcb, slwpcb, slwpcb, 0, REGARG(EAX))
 
 /****************************************************************************/
-/* PT NOCHECKIN */
+/* PT */
 OPCODE(ptwrite_r32, ptwrite, ptwrite, X86_ONLY, REGARG(EAX))
 OPCODE(ptwrite_r64, ptwrite, ptwrite, X64_ONLY, REGARG(RAX))
 OPCODE(ptwrite_mem, ptwrite, ptwrite, 0, MEMARG(OPSZ_ptwrite))

--- a/suite/tests/api/ir_x86_1args.h
+++ b/suite/tests/api/ir_x86_1args.h
@@ -185,3 +185,9 @@ OPCODE(xbegin, xbegin, xbegin, 0, TGTARG)
 /* LWP */
 OPCODE(llwpcb, llwpcb, llwpcb, 0, REGARG(EAX))
 OPCODE(slwpcb, slwpcb, slwpcb, 0, REGARG(EAX))
+
+/****************************************************************************/
+/* PT NOCHECKIN */
+OPCODE(ptwrite_r32, ptwrite, ptwrite, X86_ONLY, REGARG(EAX))
+OPCODE(ptwrite_r64, ptwrite, ptwrite, X64_ONLY, REGARG(RAX))
+OPCODE(ptwrite_mem, ptwrite, ptwrite, 0, MEMARG(OPSZ_ptwrite))


### PR DESCRIPTION
Adds the Intel PT instruction ptwrite.

Adds tests for above.

The opcode has been checked against llvm-mc and binutils/gas/objdump.

Fixes #3581