### PR TITLE
i#1312 AVX-512 support: Do not allow default write mask for scatter/gather.

### DIFF
--- a/core/arch/decode.h
+++ b/core/arch/decode.h
@@ -123,8 +123,8 @@ typedef struct instr_info_t {
     opnd_size_t src2_size;
     byte src3_type;
     opnd_size_t src3_size;
-    uint flags;  /* encoding and extra operand flags in lower half,
-                  * AVX-512 tupletype attribute in upper half.
+    uint flags;  /* encoding and extra operand flags starting at lsb,
+                  * AVX-512 tupletype attribute starting at msb.
                   */
     uint eflags; /* combination of read & write flags from instr.h */
     /* For normal entries, this points to the next entry in the encoding chain

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -1225,6 +1225,8 @@ read_instruction(byte *pc, byte *orig_pc, const instr_info_t **ret_info,
         else if (TEST(REQUIRES_EVEX_LL_0, info->flags) &&
                  TEST(PREFIX_EVEX_LL, di->prefixes))
             info = NULL; /* invalid encoding */
+        else if (TEST(REQUIRES_NOT_K0, info->flags) && di->evex_aaa == 0)
+            info = NULL; /* invalid encoding */
     } else if (info != NULL && !di->evex_encoded && TEST(REQUIRES_EVEX, info->flags))
         info = NULL; /* invalid encoding */
     /* XXX: not currently marking these cases as invalid instructions:

--- a/core/arch/x86/decode_private.h
+++ b/core/arch/x86/decode_private.h
@@ -231,7 +231,7 @@ enum {
     /* else, from OP_ enum */
 };
 
-/* instr_info_t modrm/extra operands flags == ushort only! */
+/* instr_info_t modrm/extra operands flags up to DR_TUPLE_TYPE_BITPOS bits only! */
 #define HAS_MODRM 0x01          /* else, no modrm */
 #define HAS_EXTRA_OPERANDS 0x02 /* else, <= 2 dsts, <= 3 srcs */
 /* if HAS_EXTRA_OPERANDS: */
@@ -280,14 +280,16 @@ enum {
 #define REQUIRES_VSIB_YMM 0x04000
 /* Instruction's VSIB's index reg must be zmm. */
 #define REQUIRES_VSIB_ZMM 0x08000
+/* EVEX default write mask not allowed. */
+#define REQUIRES_NOT_K0 0x10000
 /* 8-bit input size in the context of Intel's AVX-512 compressed disp8. */
-#define DR_EVEX_INPUT_OPSZ_1 0x10000
+#define DR_EVEX_INPUT_OPSZ_1 0x20000
 /* 16-bit input size in the context of Intel's AVX-512 compressed disp8. */
-#define DR_EVEX_INPUT_OPSZ_2 0x20000
+#define DR_EVEX_INPUT_OPSZ_2 0x40000
 /* 32-bit input size in the context of Intel's AVX-512 compressed disp8. */
-#define DR_EVEX_INPUT_OPSZ_4 0x40000
+#define DR_EVEX_INPUT_OPSZ_4 0x80000
 /* 64-bit input size in the context of Intel's AVX-512 compressed disp8. */
-#define DR_EVEX_INPUT_OPSZ_8 0x80000
+#define DR_EVEX_INPUT_OPSZ_8 0x100000
 
 struct _decode_info_t {
     uint opcode;

--- a/core/arch/x86/decode_table.c
+++ b/core/arch/x86/decode_table.c
@@ -2002,6 +2002,7 @@ const instr_info_t * const op_instr[] =
 #define reqLL1   REQUIRES_EVEX_LL_1
 #define vsiby    REQUIRES_VSIB_YMM
 #define vsibz    REQUIRES_VSIB_ZMM
+#define nok0     REQUIRES_NOT_K0
 
 /* flags used for AVX-512 compressed disp8 */
 #define inopsz1  DR_EVEX_INPUT_OPSZ_1
@@ -8046,32 +8047,32 @@ const instr_info_t evex_W_extensions[][2] = {
     /* XXX: OP_v*gather* raise #UD if any pair of the index, mask, or destination
      * registers are identical.  We don't bother trying to detect that.
      */
-    {OP_vpgatherdd, 0x66389018, "vpgatherdd", Ve, KEw, KEw, MVd, xx, mrm|evex|reqp|ttnone, x, END_LIST},
-    {OP_vpgatherdq, 0x66389058, "vpgatherdq", Ve, KEb, KEb, MVq, xx, mrm|evex|reqp|ttnone, x, END_LIST},
+    {OP_vpgatherdd, 0x66389018, "vpgatherdd", Ve, KEw, KEw, MVd, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
+    {OP_vpgatherdq, 0x66389058, "vpgatherdq", Ve, KEb, KEb, MVq, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
   }, { /* evex_W_ext 189 */
-    {OP_vpgatherqd, 0x66389118, "vpgatherqd", Ve, KEb, KEb, MVd, xx, mrm|evex|reqp|ttnone, x, END_LIST},
-    {OP_vpgatherqq, 0x66389158, "vpgatherqq", Ve, KEb, KEb, MVq, xx, mrm|evex|reqp|ttnone, x, END_LIST},
+    {OP_vpgatherqd, 0x66389118, "vpgatherqd", Ve, KEb, KEb, MVd, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
+    {OP_vpgatherqq, 0x66389158, "vpgatherqq", Ve, KEb, KEb, MVq, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
   }, { /* evex_W_ext 190 */
-    {OP_vgatherdps, 0x66389218, "vgatherdps", Ve, KEw, KEw, MVd, xx, mrm|evex|reqp|ttnone, x, END_LIST},
-    {OP_vgatherdpd, 0x66389258, "vgatherdpd", Ve, KEb, KEb, MVq, xx, mrm|evex|reqp|ttnone, x, END_LIST},
+    {OP_vgatherdps, 0x66389218, "vgatherdps", Ve, KEw, KEw, MVd, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
+    {OP_vgatherdpd, 0x66389258, "vgatherdpd", Ve, KEb, KEb, MVq, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
   }, { /* evex_W_ext 191 */
-    {OP_vgatherqps, 0x66389318, "vgatherqps", Ve, KEb, KEb, MVd, xx, mrm|evex|reqp|ttnone, x, END_LIST},
-    {OP_vgatherqpd, 0x66389358, "vgatherqpd", Ve, KEb, KEb, MVq, xx, mrm|evex|reqp|ttnone, x, END_LIST},
+    {OP_vgatherqps, 0x66389318, "vgatherqps", Ve, KEb, KEb, MVd, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
+    {OP_vgatherqpd, 0x66389358, "vgatherqpd", Ve, KEb, KEb, MVq, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
   }, { /* evex_W_ext 192 */
     /* XXX: OP_v*scatter* raise #UD if any pair of the index, mask, or destination
      * registers are identical.  We don't bother trying to detect that.
      */
-    {OP_vpscatterdd, 0x6638a018, "vpscatterdd", MVd, KEw, KEw, Ve, xx, mrm|evex|reqp|ttnone, x, END_LIST},
-    {OP_vpscatterdq, 0x6638a058, "vpscatterdq", MVq, KEb, KEb, Ve, xx, mrm|evex|reqp|ttnone, x, END_LIST},
+    {OP_vpscatterdd, 0x6638a018, "vpscatterdd", MVd, KEw, KEw, Ve, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
+    {OP_vpscatterdq, 0x6638a058, "vpscatterdq", MVq, KEb, KEb, Ve, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
   }, { /* evex_W_ext 193 */
-    {OP_vpscatterqd, 0x6638a118, "vpscatterqd", MVd, KEb, KEb, Ve, xx, mrm|evex|reqp|ttnone, x, END_LIST},
-    {OP_vpscatterqq, 0x6638a158, "vpscatterqq", MVq, KEb, KEb, Ve, xx, mrm|evex|reqp|ttnone, x, END_LIST},
+    {OP_vpscatterqd, 0x6638a118, "vpscatterqd", MVd, KEb, KEb, Ve, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
+    {OP_vpscatterqq, 0x6638a158, "vpscatterqq", MVq, KEb, KEb, Ve, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
   }, { /* evex_W_ext 194 */
-    {OP_vscatterdps, 0x6638a218, "vscatterdps", MVd, KEw, KEw, Ve, xx, mrm|evex|reqp|ttnone, x, END_LIST},
-    {OP_vscatterdpd, 0x6638a258, "vscatterdpd", MVq, KEb, KEb, Ve, xx, mrm|evex|reqp|ttnone, x, END_LIST},
+    {OP_vscatterdps, 0x6638a218, "vscatterdps", MVd, KEw, KEw, Ve, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
+    {OP_vscatterdpd, 0x6638a258, "vscatterdpd", MVq, KEb, KEb, Ve, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
   }, { /* evex_W_ext 195 */
-    {OP_vscatterqps, 0x6638a318, "vscatterqps", MVd, KEb, KEb, Ve, xx, mrm|evex|reqp|ttnone, x, END_LIST},
-    {OP_vscatterqpd, 0x6638a358, "vscatterqpd", MVq, KEb, KEb, Ve, xx, mrm|evex|reqp|ttnone, x, END_LIST},
+    {OP_vscatterqps, 0x6638a318, "vscatterqps", MVd, KEb, KEb, Ve, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
+    {OP_vscatterqpd, 0x6638a358, "vscatterqpd", MVq, KEb, KEb, Ve, xx, mrm|evex|reqp|ttnone|nok0, x, END_LIST},
   }, { /* evex_W_ext 196 */
        /* XXX i#1312: The encoding of this and the following gather prefetch instructions
         * is not clear. AVX-512PF seems to be specific to the Knights Landing architecture

--- a/core/arch/x86/encode.c
+++ b/core/arch/x86/encode.c
@@ -1505,6 +1505,8 @@ instr_info_extra_opnds(const instr_info_t *info)
         } else if (type_uses_evex_aaa_bits(iitype)) {                                    \
             if (!opnd_is_null(using_aaa_bits) && !opnd_same(using_aaa_bits, get_op))     \
                 return false;                                                            \
+            if (TEST(REQUIRES_NOT_K0, flags) && opnd_get_reg(get_op) == DR_REG_K0)       \
+                return false;                                                            \
             using_aaa_bits = get_op;                                                     \
         }                                                                                \
     } else if (inst_num >= iinum)                                                        \

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1715,6 +1715,105 @@ test_vsib(void *dc)
     test_vsib_helper(dc, &mc, instr, mc.xcx, 1, 2, 0x12, 0 /*nothing*/, OPSZ_4,
                      true /* evex */, true /* expect_write */);
     instr_destroy(dc, instr);
+
+    /* Test invalid k0 mask with scatter/gather opcodes. */
+
+    /* vpscatterdd %xmm0,(%rax,%xmm1,2){%k1} */
+    const byte b_vpscatterdd[] = { 0x62, 0xf2, 0x7d, 0x08, 0xa0, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vpscatterdd, (byte *)b_vpscatterdd,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vpscatterdq %xmm0,(%rax,%xmm1,2){%k1} */
+    const byte b_vpscatterdq[] = { 0x62, 0xf2, 0xfd, 0x08, 0xa0, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vpscatterdq, (byte *)b_vpscatterdq,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vpscatterqd %xmm0,(%rax,%xmm1,2){%k1} */
+    const byte b_vpscatterqd[] = { 0x62, 0xf2, 0x7d, 0x08, 0xa1, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vpscatterqd, (byte *)b_vpscatterqd,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vpscatterqq %xmm0,(%rax,%xmm1,2){%k1} */
+    const byte b_vpscatterqq[] = { 0x62, 0xf2, 0xfd, 0x08, 0xa1, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vpscatterqq, (byte *)b_vpscatterqq,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vscatterdps %xmm0,(%rax,%xmm1,2){%k1} */
+    const byte b_vscatterdps[] = { 0x62, 0xf2, 0x7d, 0x08, 0xa2, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vscatterdps, (byte *)b_vscatterdps,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vscatterdpd %xmm0,(%rax,%xmm1,2){%k1} */
+    const byte b_vscatterdpd[] = { 0x62, 0xf2, 0xfd, 0x08, 0xa2, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vscatterdpd, (byte *)b_vscatterdpd,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vscatterqps %xmm0,(%rax,%xmm1,2){%k1} */
+    const byte b_vscatterqps[] = { 0x62, 0xf2, 0x7d, 0x08, 0xa3, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vscatterqps, (byte *)b_vscatterqps,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vscatterqpd %xmm0,(%rax,%xmm1,2){%k1} */
+    const byte b_vscatterqpd[] = { 0x62, 0xf2, 0xfd, 0x08, 0xa3, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vscatterqpd, (byte *)b_vscatterqpd,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vpgatherdd (%rax,%xmm1,2),%xmm0{%k0} */
+    const byte b_vpgatherdd[] = { 0x62, 0xf2, 0x7d, 0x08, 0x90, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vpgatherdd, (byte *)b_vpgatherdd,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vpgatherdq (%rax,%xmm1,2),%xmm0{%k0} */
+    const byte b_vpgatherdq[] = { 0x62, 0xf2, 0xfd, 0x08, 0x90, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vpgatherdq, (byte *)b_vpgatherdq,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vpgatherqd (%rax,%xmm1,2),%xmm0{%k0} */
+    const byte b_vpgatherqd[] = { 0x62, 0xf2, 0x7d, 0x08, 0x91, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vpgatherqd, (byte *)b_vpgatherqd,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vpgatherqq (%rax,%xmm1,2),%xmm0{%k0} */
+    const byte b_vpgatherqq[] = { 0x62, 0xf2, 0xfd, 0x08, 0x91, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vpgatherqq, (byte *)b_vpgatherqq,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vgatherdps (%rax,%xmm1,2),%xmm0{%k0} */
+    const byte b_vgatherdps[] = { 0x62, 0xf2, 0x7d, 0x08, 0x92, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vgatherdps, (byte *)b_vgatherdps,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vgatherdpd (%rax,%xmm1,2),%xmm0{%k0} */
+    const byte b_vgatherdpd[] = { 0x62, 0xf2, 0xfd, 0x08, 0x92, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vgatherdpd, (byte *)b_vgatherdpd,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vgatherqps (%rax,%xmm1,2),%xmm0{%k0} */
+    const byte b_vgatherqps[] = { 0x62, 0xf2, 0x7d, 0x08, 0x93, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vgatherqps, (byte *)b_vgatherqps,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
+    /* vgatherqpd (%rax,%xmm1,2),%xmm0{%k0} */
+    const byte b_vgatherqpd[] = { 0x62, 0xf2, 0xfd, 0x08, 0x93, 0x04, 0x48 };
+    pc = disassemble_to_buffer(dc, (byte *)b_vgatherqpd, (byte *)b_vgatherqpd,
+                               false /*no pc*/, false /*no bytes*/, dbuf,
+                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
+    ASSERT(pc == NULL);
 }
 
 static void

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1717,103 +1717,45 @@ test_vsib(void *dc)
     instr_destroy(dc, instr);
 
     /* Test invalid k0 mask with scatter/gather opcodes. */
-
-    /* vpscatterdd %xmm0,(%rax,%xmm1,2){%k1} */
-    const byte b_vpscatterdd[] = { 0x62, 0xf2, 0x7d, 0x08, 0xa0, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vpscatterdd, (byte *)b_vpscatterdd,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vpscatterdq %xmm0,(%rax,%xmm1,2){%k1} */
-    const byte b_vpscatterdq[] = { 0x62, 0xf2, 0xfd, 0x08, 0xa0, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vpscatterdq, (byte *)b_vpscatterdq,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vpscatterqd %xmm0,(%rax,%xmm1,2){%k1} */
-    const byte b_vpscatterqd[] = { 0x62, 0xf2, 0x7d, 0x08, 0xa1, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vpscatterqd, (byte *)b_vpscatterqd,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vpscatterqq %xmm0,(%rax,%xmm1,2){%k1} */
-    const byte b_vpscatterqq[] = { 0x62, 0xf2, 0xfd, 0x08, 0xa1, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vpscatterqq, (byte *)b_vpscatterqq,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vscatterdps %xmm0,(%rax,%xmm1,2){%k1} */
-    const byte b_vscatterdps[] = { 0x62, 0xf2, 0x7d, 0x08, 0xa2, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vscatterdps, (byte *)b_vscatterdps,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vscatterdpd %xmm0,(%rax,%xmm1,2){%k1} */
-    const byte b_vscatterdpd[] = { 0x62, 0xf2, 0xfd, 0x08, 0xa2, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vscatterdpd, (byte *)b_vscatterdpd,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vscatterqps %xmm0,(%rax,%xmm1,2){%k1} */
-    const byte b_vscatterqps[] = { 0x62, 0xf2, 0x7d, 0x08, 0xa3, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vscatterqps, (byte *)b_vscatterqps,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vscatterqpd %xmm0,(%rax,%xmm1,2){%k1} */
-    const byte b_vscatterqpd[] = { 0x62, 0xf2, 0xfd, 0x08, 0xa3, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vscatterqpd, (byte *)b_vscatterqpd,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vpgatherdd (%rax,%xmm1,2),%xmm0{%k0} */
-    const byte b_vpgatherdd[] = { 0x62, 0xf2, 0x7d, 0x08, 0x90, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vpgatherdd, (byte *)b_vpgatherdd,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vpgatherdq (%rax,%xmm1,2),%xmm0{%k0} */
-    const byte b_vpgatherdq[] = { 0x62, 0xf2, 0xfd, 0x08, 0x90, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vpgatherdq, (byte *)b_vpgatherdq,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vpgatherqd (%rax,%xmm1,2),%xmm0{%k0} */
-    const byte b_vpgatherqd[] = { 0x62, 0xf2, 0x7d, 0x08, 0x91, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vpgatherqd, (byte *)b_vpgatherqd,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vpgatherqq (%rax,%xmm1,2),%xmm0{%k0} */
-    const byte b_vpgatherqq[] = { 0x62, 0xf2, 0xfd, 0x08, 0x91, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vpgatherqq, (byte *)b_vpgatherqq,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vgatherdps (%rax,%xmm1,2),%xmm0{%k0} */
-    const byte b_vgatherdps[] = { 0x62, 0xf2, 0x7d, 0x08, 0x92, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vgatherdps, (byte *)b_vgatherdps,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vgatherdpd (%rax,%xmm1,2),%xmm0{%k0} */
-    const byte b_vgatherdpd[] = { 0x62, 0xf2, 0xfd, 0x08, 0x92, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vgatherdpd, (byte *)b_vgatherdpd,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vgatherqps (%rax,%xmm1,2),%xmm0{%k0} */
-    const byte b_vgatherqps[] = { 0x62, 0xf2, 0x7d, 0x08, 0x93, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vgatherqps, (byte *)b_vgatherqps,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
-    /* vgatherqpd (%rax,%xmm1,2),%xmm0{%k0} */
-    const byte b_vgatherqpd[] = { 0x62, 0xf2, 0xfd, 0x08, 0x93, 0x04, 0x48 };
-    pc = disassemble_to_buffer(dc, (byte *)b_vgatherqpd, (byte *)b_vgatherqpd,
-                               false /*no pc*/, false /*no bytes*/, dbuf,
-                               BUFFER_SIZE_ELEMENTS(dbuf), &len);
-    ASSERT(pc == NULL);
+    const byte b_scattergatherinv[] = { /* vpscatterdd %xmm0,(%rax,%xmm1,2){%k0} */
+                                        0x62, 0xf2, 0x7d, 0x08, 0xa0, 0x04, 0x48,
+                                        /* vpscatterdq %xmm0,(%rax,%xmm1,2){%k0} */
+                                        0x62, 0xf2, 0xfd, 0x08, 0xa0, 0x04, 0x48,
+                                        /* vpscatterqd %xmm0,(%rax,%xmm1,2){%k0} */
+                                        0x62, 0xf2, 0x7d, 0x08, 0xa1, 0x04, 0x48,
+                                        /* vpscatterqq %xmm0,(%rax,%xmm1,2){%k0} */
+                                        0x62, 0xf2, 0xfd, 0x08, 0xa1, 0x04, 0x48,
+                                        /* vscatterdps %xmm0,(%rax,%xmm1,2){%k0} */
+                                        0x62, 0xf2, 0x7d, 0x08, 0xa2, 0x04, 0x48,
+                                        /* vscatterdpd %xmm0,(%rax,%xmm1,2){%k0} */
+                                        0x62, 0xf2, 0xfd, 0x08, 0xa2, 0x04, 0x48,
+                                        /* vscatterqps %xmm0,(%rax,%xmm1,2){%k0} */
+                                        0x62, 0xf2, 0x7d, 0x08, 0xa3, 0x04, 0x48,
+                                        /* vscatterqpd %xmm0,(%rax,%xmm1,2){%k0} */
+                                        0x62, 0xf2, 0xfd, 0x08, 0xa3, 0x04, 0x48,
+                                        /* vpgatherdd (%rax,%xmm1,2),%xmm0{%k0} */
+                                        0x62, 0xf2, 0x7d, 0x08, 0x90, 0x04, 0x48,
+                                        /* vpgatherdq (%rax,%xmm1,2),%xmm0{%k0} */
+                                        0x62, 0xf2, 0xfd, 0x08, 0x90, 0x04, 0x48,
+                                        /* vpgatherqd (%rax,%xmm1,2),%xmm0{%k0} */
+                                        0x62, 0xf2, 0x7d, 0x08, 0x91, 0x04, 0x48,
+                                        /* vpgatherqq (%rax,%xmm1,2),%xmm0{%k0} */
+                                        0x62, 0xf2, 0xfd, 0x08, 0x91, 0x04, 0x48,
+                                        /* vgatherdps (%rax,%xmm1,2),%xmm0{%k0} */
+                                        0x62, 0xf2, 0x7d, 0x08, 0x92, 0x04, 0x48,
+                                        /* vgatherdpd (%rax,%xmm1,2),%xmm0{%k0} */
+                                        0x62, 0xf2, 0xfd, 0x08, 0x92, 0x04, 0x48,
+                                        /* vgatherqps (%rax,%xmm1,2),%xmm0{%k0} */
+                                        0x62, 0xf2, 0x7d, 0x08, 0x93, 0x04, 0x48,
+                                        /* vgatherqpd (%rax,%xmm1,2),%xmm0{%k0} */
+                                        0x62, 0xf2, 0xfd, 0x08, 0x93, 0x04, 0x48
+    };
+    instr_t invinstr;
+    instr_init(dc, &invinstr);
+    for (int i = 0; i < sizeof(b_scattergatherinv); i += 7) {
+        pc = decode(dc, (byte *)&b_scattergatherinv[i], &invinstr);
+        ASSERT(pc == NULL);
+    }
 }
 
 static void


### PR DESCRIPTION
Fixes a missing check for a prohibited default write mask register for all
scatter/gather opcodes. Adds a new flag.

Adds a test for all scatter/gather opcodes.

A binutils/objdump bug has been filed:
https://sourceware.org/bugzilla/show_bug.cgi?id=24945

Issue: #1312