### PR TITLE
i#1312 AVX-512 support: Add missing instr_create macro for vpinsrq.

### DIFF
--- a/core/arch/x86/instr_create.h
+++ b/core/arch/x86/instr_create.h
@@ -3757,6 +3757,8 @@
     instr_create_1dst_3src((dc), OP_vinsertps, (d), (s1), (s2), (i))
 #define INSTR_CREATE_vpinsrd(dc, d, s1, s2, i) \
     instr_create_1dst_3src((dc), OP_vpinsrd, (d), (s1), (s2), (i))
+#define INSTR_CREATE_vpinsrq(dc, d, s1, s2, i) \
+    instr_create_1dst_3src((dc), OP_vpinsrq, (d), (s1), (s2), (i))
 #define INSTR_CREATE_vdpps(dc, d, s1, s2, i) \
     instr_create_1dst_3src((dc), OP_vdpps, (d), (s1), (s2), (i))
 #define INSTR_CREATE_vdppd(dc, d, s1, s2, i) \

--- a/suite/tests/api/ir_x86_4args.h
+++ b/suite/tests/api/ir_x86_4args.h
@@ -80,8 +80,10 @@ OPCODE(vpinsrd_r, vpinsrd, vpinsrd, 0, REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_1
        REGARG(EAX), IMMARG(OPSZ_1))
 OPCODE(vpinsrd_m, vpinsrd, vpinsrd, 0, REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_12),
        MEMARG(OPSZ_4), IMMARG(OPSZ_1))
-OPCODE(vpinsrq, vpinsrd, vpinsrd, X64_ONLY, REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_8),
+OPCODE(vpinsrq_r, vpinsrq, vpinsrq, X64_ONLY, REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_8),
        REGARG(RAX), IMMARG(OPSZ_1))
+OPCODE(vpinsrq_m, vpinsrq, vpinsrq, X64_ONLY, REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8), IMMARG(OPSZ_1))
 OPCODE(vdpps, vdpps, vdpps, 0, REGARG(XMM0), REGARG(XMM1), MEMARG(OPSZ_16),
        IMMARG(OPSZ_1))
 OPCODE(vdppd, vdppd, vdppd, 0, REGARG(XMM0), REGARG(XMM1), MEMARG(OPSZ_16),

--- a/suite/tests/api/ir_x86_4args_avx512_evex.h
+++ b/suite/tests/api/ir_x86_4args_avx512_evex.h
@@ -59,3 +59,11 @@ OPCODE(vpinsrd_xhixhir, vpinsrd, vpinsrd, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_12), REGARG(EAX), IMMARG(OPSZ_1))
 OPCODE(vpinsrd_xhixhim, vpinsrd, vpinsrd, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_12), MEMARG(OPSZ_4), IMMARG(OPSZ_1))
+OPCODE(vpinsrq_xloxlor, vpinsrq, vpinsrq, 0, REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       REGARG(RAX), IMMARG(OPSZ_1))
+OPCODE(vpinsrq_xloxlom, vpinsrq, vpinsrq, 0, REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_8),
+       MEMARG(OPSZ_8), IMMARG(OPSZ_1))
+OPCODE(vpinsrq_xhixhir, vpinsrq, vpinsrq, X64_ONLY, REGARG(XMM16),
+       REGARG_PARTIAL(XMM31, OPSZ_8), REGARG(RAX), IMMARG(OPSZ_1))
+OPCODE(vpinsrq_xhixhim, vpinsrq, vpinsrq, X64_ONLY, REGARG(XMM16),
+       REGARG_PARTIAL(XMM31, OPSZ_8), MEMARG(OPSZ_8), IMMARG(OPSZ_1))

--- a/suite/tests/api/ir_x86_4args_avx512_evex.h
+++ b/suite/tests/api/ir_x86_4args_avx512_evex.h
@@ -59,10 +59,10 @@ OPCODE(vpinsrd_xhixhir, vpinsrd, vpinsrd, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_12), REGARG(EAX), IMMARG(OPSZ_1))
 OPCODE(vpinsrd_xhixhim, vpinsrd, vpinsrd, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_12), MEMARG(OPSZ_4), IMMARG(OPSZ_1))
-OPCODE(vpinsrq_xloxlor, vpinsrq, vpinsrq, 0, REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_8),
-       REGARG(RAX), IMMARG(OPSZ_1))
-OPCODE(vpinsrq_xloxlom, vpinsrq, vpinsrq, 0, REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_8),
-       MEMARG(OPSZ_8), IMMARG(OPSZ_1))
+OPCODE(vpinsrq_xloxlor, vpinsrq, vpinsrq, X64_ONLY, REGARG(XMM0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), REGARG(RAX), IMMARG(OPSZ_1))
+OPCODE(vpinsrq_xloxlom, vpinsrq, vpinsrq, X64_ONLY, REGARG(XMM0),
+       REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8), IMMARG(OPSZ_1))
 OPCODE(vpinsrq_xhixhir, vpinsrq, vpinsrq, X64_ONLY, REGARG(XMM16),
        REGARG_PARTIAL(XMM31, OPSZ_8), REGARG(RAX), IMMARG(OPSZ_1))
 OPCODE(vpinsrq_xhixhim, vpinsrq, vpinsrq, X64_ONLY, REGARG(XMM16),


### PR DESCRIPTION
The macro was missing both for AVX and AVX-512. The existing AVX roundtrip test was
incorrectly using the vpinsrd version.

Adds tests for AVX-512.

Issue: #1312