### PR TITLE
i#3812 avx sigreturn: Fix 32-bit avx-512 build error

### DIFF
--- a/suite/tests/api/detach_state_shared.h
+++ b/suite/tests/api/detach_state_shared.h
@@ -61,10 +61,12 @@
 #    if defined(__AVX512F__)
 #        define NUM_SIMD_AVX512_REGS 8
 #        define NUM_OPMASK_REGS 8
+#        define OPMASK_REG_SIZE 2
+#    else
+#        define NUM_OPMASK_REGS 0
+#        define OPMASK_REG_SIZE 0
 #    endif
 #    define NUM_SIMD_REGS 8
-#    define NUM_OPMASK_REGS 0
-#    define OPMASK_REG_SIZE 0
 #endif
 
 #ifdef X64


### PR DESCRIPTION
Fixes a build error in 32-bit on an avx-512-enabled toolchain from 2a6bc3c.

Issue: #3812