### PR TITLE
i#2985 drx_expand_scatter_gather(): Add more test output to drx-scattergather.

### DIFF
--- a/suite/tests/client-interface/drx-scattergather.c
+++ b/suite/tests/client-interface/drx-scattergather.c
@@ -166,6 +166,7 @@ test_avx512_gather(void (*test_func)(uint32_t *, uint32_t *, uint32_t *),
         print("ERROR: gather result does not match\n");
         return false;
     }
+    print("AVX-512 gather ok\n");
     return true;
 }
 
@@ -180,6 +181,7 @@ test_avx2_gather(void (*test_func)(uint32_t *, uint32_t *, uint32_t *),
         print("ERROR: gather result does not match\n");
         return false;
     }
+    print("AVX2 gather ok\n");
     return true;
 }
 
@@ -208,6 +210,7 @@ test_avx512_scatter(void (*test_func)(uint32_t *, uint32_t *, uint32_t *),
             }
         }
     }
+    print("AVX-512 scatter ok\n");
     return true;
 }
 

--- a/suite/tests/client-interface/drx-scattergather.expect
+++ b/suite/tests/client-interface/drx-scattergather.expect
@@ -1,2 +1,26 @@
+AVX-512 gather ok
+AVX-512 gather ok
+AVX-512 gather ok
+AVX-512 gather ok
+AVX-512 gather ok
+AVX-512 gather ok
+AVX-512 gather ok
+AVX-512 gather ok
+AVX-512 scatter ok
+AVX-512 scatter ok
+AVX-512 scatter ok
+AVX-512 scatter ok
+AVX-512 scatter ok
+AVX-512 scatter ok
+AVX-512 scatter ok
+AVX-512 scatter ok
+AVX2 gather ok
+AVX2 gather ok
+AVX2 gather ok
+AVX2 gather ok
+AVX2 gather ok
+AVX2 gather ok
+AVX2 gather ok
+AVX2 gather ok
 AVX2/AVX-512 scatter/gather checks ok
 event_exit

--- a/suite/tests/client-interface/drx-scattergather.templatex
+++ b/suite/tests/client-interface/drx-scattergather.templatex
@@ -1,3 +1,4 @@
+#ifdef __AVX512F__
 AVX-512 gather ok
 AVX-512 gather ok
 AVX-512 gather ok
@@ -14,6 +15,8 @@ AVX-512 scatter ok
 AVX-512 scatter ok
 AVX-512 scatter ok
 AVX-512 scatter ok
+#endif
+#ifdef __AVX__
 AVX2 gather ok
 AVX2 gather ok
 AVX2 gather ok
@@ -22,5 +25,6 @@ AVX2 gather ok
 AVX2 gather ok
 AVX2 gather ok
 AVX2 gather ok
+#endif
 AVX2/AVX-512 scatter/gather checks ok
 event_exit


### PR DESCRIPTION
When instructions get expanded into the emulation sequence, it may result in skipping some
of the checks. To prepare and make sure they were passed, this patch adds a little bit
more output to the test.

Issue: #2985