### PR TITLE
i#3821: Do not reset spilled flag when doing forward scan in drreg.

### DIFF
--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -655,7 +655,6 @@ drreg_forward_analysis(void *drcontext, instr_t *start)
     for (reg = DR_REG_START_GPR; reg <= DR_REG_STOP_GPR; reg++) {
         pt->reg[GPR_IDX(reg)].app_uses = 0;
         drvector_set_entry(&pt->reg[GPR_IDX(reg)].live, 0, REG_UNKNOWN);
-        pt->reg[GPR_IDX(reg)].ever_spilled = false;
     }
 
     /* We have to consider meta instrs as well */


### PR DESCRIPTION
Re-setting the spilled flag causes earlier recorded registers's spill flag to reset. Those
registers will then not restore. Resetting the spilled flag is not needed as it will be
set in drreg_reserve_reg_internal().

Fixes #3821