### PR TITLE
Clarify dr_set_itimer restrictions

### DIFF
--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -4760,8 +4760,8 @@ DR_API
  *   been translated and so may contain raw code cache values.  The function
  *   will be called from a signal handler that may have interrupted a
  *   lock holder or other critical code, so it must be careful in its
- *   operations: keep it as simple as possible, and avoid lock usage or
- *   I/O operations. If a general timer that does not interrupt client code
+ *   operations: keep it as simple as possible, and avoid any non-reentrant actions
+ *   such as lock usage. If a general timer that does not interrupt client code
  *   is required, the client should create a separate thread via
  *   dr_create_client_thread() (which is guaranteed to have a private
  *   itimer) and set the itimer there, where the callback function can


### PR DESCRIPTION
Removes the mention of I/O operations, which users found confusing,
replacing it with a proscription of non-reentrant actions inside
dr_set_itimer functions.