### PR TITLE
i#1979 Mac64: small app support on Mojave

### DIFF
--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -311,7 +311,7 @@ ASSUME fs:_DATA @N@\
 #  define REG_R14 r14
 #  define REG_R15 r15
 #  define SEG_TLS gs /* keep in sync w/ {unix,win32}/os_exports.h defines */
-#  ifdef UNIX
+#  if defined(UNIX) && !defined(MACOS)
 #   define LIB_SEG_TLS fs /* keep in sync w/ unix/os_exports.h defines */
 #  endif
 # else /* 32-bit */

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -3721,17 +3721,15 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
             }
         }
 #else
-#    ifdef X86
+#    if defined(X86) && defined(LINUX)
         if (instr_get_prefix_flag(bb->instr,
                                   (SEG_TLS == SEG_GS) ? PREFIX_SEG_GS : PREFIX_SEG_FS)
             /* __errno_location is interpreted when global, though it's hidden in TOT */
             IF_UNIX(&&!is_in_dynamo_dll(bb->instr_start)) &&
             /* i#107 allows DR/APP using the same segment register. */
             !INTERNAL_OPTION(mangle_app_seg)) {
-            /* On linux we use a segment register and do not yet
-             * support the application using the same register!
-             */
-            CLIENT_ASSERT(false, "no support yet for application using non-NPTL segment");
+            CLIENT_ASSERT(false,
+                          "no support for app using DR's segment w/o -mangle_app_seg");
             ASSERT_BUG_NUM(205276, false);
         }
 #    endif /* X86 */

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -519,8 +519,10 @@ typedef struct _instr_t instr_t;
 
 #ifdef MACOS64
 #    define IF_MACOS64(x) x
+#    define IF_MACOS64_ELSE(x, y) x
 #else
 #    define IF_MACOS64(x)
+#    define IF_MACOS64_ELSE(x, y) y
 #endif
 
 #ifdef HAVE_MEMINFO_QUERY

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -7476,9 +7476,9 @@ dr_insert_get_seg_base(void *drcontext, instrlist_t *ilist, instr_t *instr, reg_
     CLIENT_ASSERT(reg_is_segment(seg),
                   "dr_insert_get_seg_base: seg is not a segment register");
 #        ifdef UNIX
+#            ifndef MACOS64
     CLIENT_ASSERT(INTERNAL_OPTION(mangle_app_seg),
-                  "dr_insert_get_seg_base is supported"
-                  "with -mangle_app_seg only");
+                  "dr_insert_get_seg_base is supported with -mangle_app_seg only");
     /* FIXME: we should remove the constraint below by always mangling SEG_TLS,
      * 1. Getting TLS base could be a common request by clients.
      * 2. The TLS descriptor setup and selector setup can be separated,
@@ -7486,11 +7486,11 @@ dr_insert_get_seg_base(void *drcontext, instrlist_t *ilist, instr_t *instr, reg_
      * runtime overhead for keeping track of the app's TLS segment base.
      */
     CLIENT_ASSERT(INTERNAL_OPTION(private_loader) || seg != SEG_TLS,
-                  "dr_insert_get_seg_base supports TLS seg"
-                  "only with -private_loader");
+                  "dr_insert_get_seg_base supports TLS seg only with -private_loader");
     if (!INTERNAL_OPTION(mangle_app_seg) ||
         !(INTERNAL_OPTION(private_loader) || seg != SEG_TLS))
         return false;
+#            endif
     if (seg == SEG_FS || seg == SEG_GS) {
         instrlist_meta_preinsert(ilist, instr,
                                  instr_create_restore_from_tls(

--- a/core/unix/memquery_macos.c
+++ b/core/unix/memquery_macos.c
@@ -217,6 +217,15 @@ memquery_iterator_next(memquery_iter_t *iter)
     return true;
 }
 
+/* Not exported.  More efficient than stop+start. */
+static void
+memquery_reset_internal_iterator(memquery_iter_t *iter, const byte *new_pc)
+{
+    internal_iter_t *ii = (internal_iter_t *)&iter->internal;
+    ii->address = (vm_address_t)new_pc;
+    ii->depth = 0;
+}
+
 bool
 memquery_from_os(const byte *pc, OUT dr_mem_info_t *info, OUT bool *have_type)
 {
@@ -224,7 +233,8 @@ memquery_from_os(const byte *pc, OUT dr_mem_info_t *info, OUT bool *have_type)
     bool res = false;
     bool free = true;
     memquery_iterator_start(&iter, (app_pc)pc, false /*won't alloc*/);
-    if (memquery_iterator_next(&iter) && iter.vm_start <= pc) {
+    bool ok = memquery_iterator_next(&iter);
+    if (ok && iter.vm_start <= pc) {
         /* There may be some inner regions we have to wade through */
         while (iter.vm_end <= pc) {
             if (!memquery_iterator_next(&iter))
@@ -247,13 +257,27 @@ memquery_from_os(const byte *pc, OUT dr_mem_info_t *info, OUT bool *have_type)
     }
     if (free) {
         /* Unlike Windows, the Mach queries skip free regions, so we have to
-         * find the prior allocated region.  We could try just a few pages back,
-         * but querying a free region is rare so we go with simple.
+         * find the prior allocated region.  While starting at 0 seems fine on 32-bit
+         * its overhead shows up on 64-bit so we try to be more efficient.
          */
-        internal_iter_t *ii = (internal_iter_t *)&iter.internal;
         app_pc last_end = NULL;
+        size_t step = 16 * 1024 * 1024;
+        byte *try_pc = (byte *)pc;
+        while (try_pc > (byte *)step) {
+            try_pc -= step;
+            memquery_reset_internal_iterator(&iter, try_pc);
+            if (memquery_iterator_next(&iter) && iter.vm_start <= pc)
+                break;
+            if (step * 2 < step)
+                break;
+            step *= 2;
+        }
+        if (iter.vm_start > pc)
+            last_end = 0;
+        else
+            last_end = iter.vm_end;
         app_pc next_start = (app_pc)POINTER_MAX;
-        ii->address = 0;
+        memquery_reset_internal_iterator(&iter, last_end);
         while (memquery_iterator_next(&iter)) {
             if (iter.vm_start > pc) {
                 next_start = iter.vm_start;

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -335,15 +335,7 @@ static byte *app_brk_end;
 #endif
 
 #ifdef MACOS
-/* xref i#1404: we should expose these via the dr_get_os_version() API */
 static int macos_version;
-#    define MACOS_VERSION_HIGH_SIERRA 17
-#    define MACOS_VERSION_SIERRA 16
-#    define MACOS_VERSION_EL_CAPITAN 15
-#    define MACOS_VERSION_YOSEMITE 14
-#    define MACOS_VERSION_MAVERICKS 13
-#    define MACOS_VERSION_MOUNTAIN_LION 12
-#    define MACOS_VERSION_LION 11
 #endif
 
 static bool
@@ -788,6 +780,12 @@ sysctl_query(int level0, int level1, void *buf, size_t bufsz)
     name[1] = level1;
     res = dynamorio_syscall(SYS___sysctl, 6, &name, 2, buf, &len, NULL, 0);
     return (res >= 0);
+}
+
+int
+os_get_version(void)
+{
+    return macos_version;
 }
 #endif
 

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -50,7 +50,10 @@
 #include "memquery.h"
 
 /* Cross arch syscall nums for use with struct stat64. */
-#ifdef X64
+#ifdef MACOS64
+#    define SYSNUM_STAT SYS_stat64
+#    define SYSNUM_FSTAT SYS_fstat64
+#elif defined(X64)
 #    ifdef SYS_stat
 #        define SYSNUM_STAT SYS_stat
 #    endif
@@ -225,6 +228,20 @@ os_tls_thread_exit(local_state_t *local_state);
 #ifdef AARCHXX
 bool
 os_set_app_tls_base(dcontext_t *dcontext, reg_id_t reg, void *base);
+#endif
+
+#ifdef MACOS
+/* xref i#1404: we should expose these via the dr_get_os_version() API */
+#    define MACOS_VERSION_MOJAVE 18
+#    define MACOS_VERSION_HIGH_SIERRA 17
+#    define MACOS_VERSION_SIERRA 16
+#    define MACOS_VERSION_EL_CAPITAN 15
+#    define MACOS_VERSION_YOSEMITE 14
+#    define MACOS_VERSION_MAVERICKS 13
+#    define MACOS_VERSION_MOUNTAIN_LION 12
+#    define MACOS_VERSION_LION 11
+int
+os_get_version(void);
 #endif
 
 void

--- a/core/unix/os_public.h
+++ b/core/unix/os_public.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -56,13 +56,21 @@
 
 #ifdef MACOS
 /* mcontext_t is a pointer and we want the real thing */
-/* We need room for avx.  If we end up with !YMM_ENABLED() we'll just end
- * up wasting some space in synched thread allocations.
+/* We need room for AVX512.  If we end up with !YMM_ENABLED() or !ZMM_ENABLED() we'll
+ * just end up wasting some space in synched thread allocations.
  */
 #    ifdef X64
+/* TODO i#1979/i#1312: This should become _STRUCT_MCONTEXT_AVX512_64 ==
+ * __darwin_mcontext_avx512_64.  However, we need to resolve the copy in
+ * sigframe_rt_t as well (which currently is not labeled as a sigcontext_t).  We may
+ * want to use a similar strategy to handle the different struct sizes for both.
+ */
 typedef _STRUCT_MCONTEXT_AVX64 sigcontext_t; /* == __darwin_mcontext_avx64 */
 #    else
-typedef _STRUCT_MCONTEXT_AVX32 sigcontext_t; /* == __darwin_mcontext_avx32 */
+/* TODO i#1979/i#1312: Like for X64, this should become _STRUCT_MCONTEXT_AVX512_32 ==
+ * __darwin_mcontext_avx512_32.
+ */
+typedef _STRUCT_MCONTEXT_AVX512_32 sigcontext_t; /* == __darwin_mcontext_avx32 */
 #    endif
 #else
 typedef kernel_sigcontext_t sigcontext_t;

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -3120,7 +3120,7 @@ fixup_rtframe_pointers(dcontext_t *dcontext, int sig, sigframe_rt_t *f_old,
     IF_X64(ASSERT(ALIGNED(f_new->uc.uc_mcontext.fpstate, 16)));
 #elif defined(MACOS)
 #    ifdef X64
-    ASSERT_NOT_IMPLEMENTED(false);
+    /* Nothing to do. */
 #    else
     f_new->pinfo = &(f_new->info);
     f_new->puc = &(f_new->uc);
@@ -3316,14 +3316,10 @@ copy_frame_to_stack(dcontext_t *dcontext, int sig, sigframe_rt_t *frame, byte *s
 #endif /* LINUX && !X64 */
     }
 
-#ifdef MACOS
-#    ifdef X64
-    ASSERT_NOT_IMPLEMENTED(false);
-#    else
+#if defined(MACOS) && !defined(X64)
     /* Update handler field, which is passed to the libc trampoline, to app */
     ASSERT(info->app_sigaction[sig] != NULL);
     ((sigframe_rt_t *)sp)->handler = (app_pc)info->app_sigaction[sig]->handler;
-#    endif
 #endif
 }
 
@@ -4815,7 +4811,20 @@ void
 master_signal_handler_C(byte *xsp)
 #endif
 {
+#ifdef MACOS64
+    /* The kernel aligns to 16 after setting up the frame, so we instead compute
+     * from the siginfo pointer.
+     * XXX: 32-bit does the same thing: how was it working?!?
+     */
+    sigframe_rt_t *frame = (sigframe_rt_t *)((byte *)siginfo - sizeof(frame->mc));
+    /* The kernel's method of aligning overshoots. */
+#    define KERNEL_ALIGN_BACK(val, align) (((val)-align) & -(align))
+    /* If this assert fails, we may be seeing an AVX512 frame. */
+    ASSERT(KERNEL_ALIGN_BACK((ptr_uint_t)frame, 16) - 8 == (ptr_uint_t)xsp &&
+           "AVX512 frames not yet supported");
+#else
     sigframe_rt_t *frame = (sigframe_rt_t *)xsp;
+#endif
 #ifdef X86_32
     /* Read the normal arguments from the frame. */
     int sig = frame->sig;
@@ -5645,7 +5654,16 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
     /* Set up args to handler: int sig, kernel_siginfo_t *siginfo,
      * kernel_ucontext_t *ucxt.
      */
-#ifdef X86_64
+#ifdef MACOS64
+    mcontext->xdi = (reg_t)info->app_sigaction[sig]->handler;
+    int infostyle = TEST(SA_SIGINFO, info->app_sigaction[sig]->flags)
+        ? SIGHAND_STYLE_UC_FLAVOR
+        : SIGHAND_STYLE_UC_TRAD;
+    mcontext->xsi = infostyle;
+    mcontext->xdx = sig;
+    mcontext->xcx = (reg_t) & ((sigframe_rt_t *)xsp)->info;
+    mcontext->r8 = (reg_t) & ((sigframe_rt_t *)xsp)->uc;
+#elif defined(X86_64)
     mcontext->xdi = sig;
     mcontext->xsi = (reg_t) & ((sigframe_rt_t *)xsp)->info;
     mcontext->xdx = (reg_t) & ((sigframe_rt_t *)xsp)->uc;
@@ -6143,13 +6161,6 @@ handle_sigreturn(dcontext_t *dcontext, void *ucxt_param, int style)
              *(int *)((byte *)sc->fpstate + sc->fpstate->sw_reserved.extended_size -
                       FP_XSTATE_MAGIC2_SIZE) == FP_XSTATE_MAGIC2)));
 #elif defined(MACOS)
-        /* The initial frame fields on the stack are messed up due to
-         * params to handler from tramp, so use params to syscall.
-         * XXX: we don't have signal # though: so we have to rely on app
-         * not clobbering the sig param field.
-         */
-        sig = *(int *)xsp;
-        LOG(THREAD, LOG_ASYNCH, 3, "\tsignal was %d\n", sig);
         ucxt = (kernel_ucontext_t *)ucxt_param;
         if (ucxt == NULL) {
             /* On Mac the kernel seems to store state on whether the process is
@@ -6160,6 +6171,18 @@ handle_sigreturn(dcontext_t *dcontext, void *ucxt_param, int style)
             LOG(THREAD, LOG_ASYNCH, 3, "\tsigunalstack sigreturn: no context\n");
             return true;
         }
+#    ifdef X64
+        kernel_siginfo_t *siginfo = (kernel_siginfo_t *)ucxt - 1;
+        sig = siginfo->si_signo;
+#    else
+        /* The initial frame fields on the stack are messed up due to
+         * params to handler from tramp, so use params to syscall.
+         * XXX: we don't have signal # though: so we have to rely on app
+         * not clobbering the sig param field.
+         */
+        sig = *(int *)xsp;
+#    endif
+        LOG(THREAD, LOG_ASYNCH, 3, "\tsignal was %d\n", sig);
         sc = SIGCXT_FROM_UCXT(ucxt);
 #endif
         ASSERT(sig > 0 && sig <= MAX_SIGNUM && IS_RT_FOR_APP(info, sig));

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -69,6 +69,8 @@ typedef void (*handler_t)(int, kernel_siginfo_t *, void *);
 
 #ifdef MACOS
 typedef void (*tramp_t)(handler_t, int, int, kernel_siginfo_t *, void *);
+#    define SIGHAND_STYLE_UC_TRAD 1
+#    define SIGHAND_STYLE_UC_FLAVOR 30
 #endif
 
 /* default actions */
@@ -276,7 +278,16 @@ typedef struct rt_sigframe {
 
 #elif defined(MACOS)
 #    ifdef X64
-    /* kernel places padding to align to 16, and then puts retaddr slot */
+    /* Kernel places padding to align to 16 (via an inefficient alignment macro!),
+     * and then skips the retaddr slot to align to 8.
+     */
+    /* TODO i#1979/i#1312: This will be __darwin_mcontext_avx512_64 if AVX512 is
+     * enabled.  Given that it's inlined here *first*, though, we need to figure
+     * out how best to handle this variability.  Multiple sigframe_rt_t struct
+     * definitions?  Do we want a discovery signal to find the size at init time
+     * like on Linux?  We would get the size by counting from "info".
+     * Also, should we change this to sigcontext_t.
+     */
     struct __darwin_mcontext_avx64 mc; /* sigcontext, "struct mcontext_avx64" to kernel */
     kernel_siginfo_t info;             /* matches user-mode sys/signal.h struct */
     struct __darwin_ucontext64 uc;     /* "struct user_ucontext64" to kernel */

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -8292,7 +8292,10 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
     }
 
     /* we are building a real bb, assert consistency checks */
-    DOCHECK(1, {
+    /* XXX i#1979: These memqueries are surprisingly slow on Mac64.
+     * Investigation is needed.
+     */
+    DOCHECK(IF_MACOS64_ELSE(3, 1), {
         uint prot2;
         ok = get_memory_info(pc, NULL, NULL, &prot2);
         ASSERT(!ok || !TEST(MEMPROT_WRITE, prot2) ||


### PR DESCRIPTION
Fixes several issues to get small 64-bit apps to run on Mojave:

+ Fixes library discovery problems with the dyld shared cache.
  On Mojave, SYS_shared_region_check_np returns the whole lib region,
  while the existing code assumed its return value was the shared
  __LINKEDIT segment.

+ Demotes a DOCHECK at level 1 in check_thread_vm_area to 3 for
  Mac64 as it shows up as a large performance hit apparently due
  to slow memory queries.

+ Segment fixes: fixes two issues hit due to DR and lib segments being
  equal: a bb building assert for -no_mangle_app_seg and a
  dr_insert_get_seg_base() assert.

+ Attempts to reduce overhead in memquery_from_os() where it needs extra
  iterations to find the surrounding bounds of a free area, by walking
  backward instead of starting from 0.

+ Uses SYS_stat64 and SYS_fstat64 for stat syscalls.

+ Basic signal support:
  + dynamorio_sigreturn() syscall number.
  + master_signal_handler() setup to invoke sigreturn with the proper arguments.
  + Accessing the frame within master_signal_handler_C().
  + No support yet for AVX512 but put some pieces in place and comments for
    future work.
  + fixup_rtframe_pointers() and copy_frame_to_stack().
  + execute_handler_from_dispatch(): set up arguments for app handler,
    including the style.
  + handle_sigreturn(): obtain signal number from siginfo.

Issue: #1979