### PR TITLE
i#3839: Do not block SIGSEGV and SIGBUS at exit time

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1309,9 +1309,9 @@ block_cleanup_and_terminate(dcontext_t *dcontext, int sysnum, ptr_uint_t sys_arg
      * to reply to (i#2921).
      */
     if (sysnum == SYS_kill)
-        block_all_signals_except(NULL, 2, dcontext->sys_param0, SUSPEND_SIGNAL);
+        block_all_noncrash_signals_except(NULL, 2, dcontext->sys_param0, SUSPEND_SIGNAL);
     else
-        block_all_signals_except(NULL, 1, SUSPEND_SIGNAL);
+        block_all_noncrash_signals_except(NULL, 1, SUSPEND_SIGNAL);
     cleanup_and_terminate(dcontext, sysnum, sys_arg1, sys_arg2, exitproc, sys_arg3,
                           sys_arg4);
 }

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -308,7 +308,7 @@ void
 signal_thread_exit(dcontext_t *dcontext, bool other_thread);
 /* In addition to the list, does not block SIGSEGV or SIGBUS. */
 void
-block_all_signals_except(kernel_sigset_t *oset, int num_signals, ...);
+block_all_noncrash_signals_except(kernel_sigset_t *oset, int num_signals, ...);
 void
 block_cleanup_and_terminate(dcontext_t *dcontext, int sysnum, ptr_uint_t sys_arg1,
                             ptr_uint_t sys_arg2, bool exitproc,

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -306,6 +306,7 @@ void
 signal_thread_init(dcontext_t *dcontext, void *os_data);
 void
 signal_thread_exit(dcontext_t *dcontext, bool other_thread);
+/* In addition to the list, does not block SIGSEGV or SIGBUS. */
 void
 block_all_signals_except(kernel_sigset_t *oset, int num_signals, ...);
 void

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -348,8 +348,8 @@ sigprocmask_syscall(int how, kernel_sigset_t *set, kernel_sigset_t *oset,
 }
 
 void
-block_all_signals_except(kernel_sigset_t *oset, int num_signals,
-                         ... /* list of signals */)
+block_all_noncrash_signals_except(kernel_sigset_t *oset, int num_signals,
+                                  ... /* list of signals */)
 {
     kernel_sigset_t set;
     kernel_sigfillset(&set);

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -359,6 +359,11 @@ block_all_signals_except(kernel_sigset_t *oset, int num_signals,
         kernel_sigdelset(&set, va_arg(ap, int));
     }
     va_end(ap);
+    /* We never block SIGSEGV or SIGBUS: we need them for various safe reads and to
+     * properly report crashes.
+     */
+    kernel_sigdelset(&set, SIGSEGV);
+    kernel_sigdelset(&set, SIGBUS);
     sigprocmask_syscall(SIG_SETMASK, &set, oset, sizeof(set));
 }
 


### PR DESCRIPTION
Fixes a regression from edb2eed where all signals, including SIGSEGV and
SIGBUS, were blocked while running exit code.  This meant that DR wouldn't
catch and report crashes, and more importantly clients couldn't use safe_read
and other features in their exit events.  Now we avoid blocking those two
key signals.

Tested: Dr. Memory's safe_read uses during exit no longer crash or hang.

Fixes #3839