### PR TITLE
i#1979 Mac64: Faster memquery

### DIFF
--- a/core/unix/memquery_macos.c
+++ b/core/unix/memquery_macos.c
@@ -172,6 +172,7 @@ memquery_iterator_next(memquery_iter_t *iter)
     internal_iter_t *ii = (internal_iter_t *)&iter->internal;
     kern_return_t kr = KERN_SUCCESS;
     vm_size_t size = 0;
+    vm_address_t query_addr = ii->address;
     /* 64-bit versions seem to work fine for 32-bit */
     mach_msg_type_number_t count = VM_REGION_SUBMAP_INFO_COUNT_64;
     do {
@@ -189,6 +190,7 @@ memquery_iterator_next(memquery_iter_t *iter)
         if (ii->info.is_submap) {
             /* Query again w/ greater depth */
             ii->depth++;
+            ii->address = query_addr;
         } else {
             /* Keep depth for next iter.  Kernel will reset to 0. */
             break;
@@ -261,7 +263,7 @@ memquery_from_os(const byte *pc, OUT dr_mem_info_t *info, OUT bool *have_type)
          * its overhead shows up on 64-bit so we try to be more efficient.
          */
         app_pc last_end = NULL;
-        size_t step = 16 * 1024 * 1024;
+        size_t step = 8 * 1024;
         byte *try_pc = (byte *)pc;
         while (try_pc > (byte *)step) {
             try_pc -= step;

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -6114,8 +6114,10 @@ handle_sigreturn(dcontext_t *dcontext, void *ucxt_param, int style)
     kernel_ucontext_t *ucxt = NULL;
     int sig = 0;
     app_pc next_pc;
+#if defined(DEBUG) || !defined(MACOS64)
     /* xsp was put in mcontext prior to pre_system_call() */
     reg_t xsp = get_mcontext(dcontext)->xsp;
+#endif
 #ifdef MACOS
     bool rt = true;
 #endif

--- a/core/unix/tls_macos.c
+++ b/core/unix/tls_macos.c
@@ -133,7 +133,8 @@ tls_process_init(void)
     }
     if (delete_start > 0) {
         for (pthread_key_t key = delete_start; key <= delete_end; key++) {
-            int res = pthread_key_delete(key);
+            DEBUG_DECLARE(int res =)
+            pthread_key_delete(key);
             ASSERT(res == 0); /* Can only fail with an invalid key. */
         }
     }
@@ -157,7 +158,8 @@ tls_process_exit(void)
 {
     int num_slots_needed = sizeof(os_local_state_t) / sizeof(void *);
     for (int i = 0; i < num_slots_needed; i++) {
-        int res = pthread_key_delete(keys_start + i);
+        DEBUG_DECLARE(int res =)
+        pthread_key_delete(keys_start + i);
         ASSERT(res == 0); /* Can only fail with an invalid key. */
     }
 }


### PR DESCRIPTION
When querying into a submap, we can go straight to the middle, avoiding
overhead of tons of syscalls querying from the start.  And when we walk
backward finding the prior on a free, a smaller starting step is a win for
common queries.  This drops Dr. Memory from taking 25s (!) on a tiny app
down to 8s.  Most of the 8s is still memqueries on the leak scan but that's
for another day.

Issue: #1979