### PR TITLE
i#638: set preprocessor location and flag on MSYS2 MinGW same as on Unix

### DIFF
--- a/make/cpp2asm_support.cmake
+++ b/make/cpp2asm_support.cmake
@@ -139,7 +139,7 @@ if (MSVC)
   set(CPP_NO_LINENUM /EP)
   set(CPP_KEEP_WHITESPACE "")
   set(CMAKE_CPP_FLAGS "/nologo")
-else()
+else ()
   # "gcc -E" on a non-.c-extension file gives message:
   #   "linker input file unused because linking not done"
   # and doesn't produce any output, so we must use cpp for our .asm files.
@@ -160,7 +160,7 @@ else()
   set(CPP_NO_LINENUM -P)
   set(CPP_KEEP_WHITESPACE -traditional-cpp)
   set(CMAKE_CPP_FLAGS "")
-endif ()
+endif (MSVC)
 
 ##################################################
 # Assembler location and flags

--- a/make/cpp2asm_support.cmake
+++ b/make/cpp2asm_support.cmake
@@ -132,7 +132,14 @@ endif ()
 ##################################################
 # Preprocessor location and flags
 
-if (UNIX OR (WIN32 AND "${CMAKE_GENERATOR}" MATCHES "MSYS Makefiles"))
+if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
+  set(CMAKE_CPP ${CMAKE_C_COMPILER})
+
+  set(CPP_KEEP_COMMENTS /C)
+  set(CPP_NO_LINENUM /EP)
+  set(CPP_KEEP_WHITESPACE "")
+  set(CMAKE_CPP_FLAGS "/nologo")
+else()
   # "gcc -E" on a non-.c-extension file gives message:
   #   "linker input file unused because linking not done"
   # and doesn't produce any output, so we must use cpp for our .asm files.
@@ -153,13 +160,6 @@ if (UNIX OR (WIN32 AND "${CMAKE_GENERATOR}" MATCHES "MSYS Makefiles"))
   set(CPP_NO_LINENUM -P)
   set(CPP_KEEP_WHITESPACE -traditional-cpp)
   set(CMAKE_CPP_FLAGS "")
-else (UNIX)
-  set(CMAKE_CPP ${CMAKE_C_COMPILER})
-
-  set(CPP_KEEP_COMMENTS /C)
-  set(CPP_NO_LINENUM /EP)
-  set(CPP_KEEP_WHITESPACE "")
-  set(CMAKE_CPP_FLAGS "/nologo")
 endif ()
 
 ##################################################

--- a/make/cpp2asm_support.cmake
+++ b/make/cpp2asm_support.cmake
@@ -132,7 +132,7 @@ endif ()
 ##################################################
 # Preprocessor location and flags
 
-if (UNIX)
+if (UNIX OR (WIN32 AND "${CMAKE_GENERATOR}" MATCHES "MSYS Makefiles"))
   # "gcc -E" on a non-.c-extension file gives message:
   #   "linker input file unused because linking not done"
   # and doesn't produce any output, so we must use cpp for our .asm files.
@@ -160,7 +160,7 @@ else (UNIX)
   set(CPP_NO_LINENUM /EP)
   set(CPP_KEEP_WHITESPACE "")
   set(CMAKE_CPP_FLAGS "/nologo")
-endif (UNIX)
+endif ()
 
 ##################################################
 # Assembler location and flags

--- a/make/cpp2asm_support.cmake
+++ b/make/cpp2asm_support.cmake
@@ -132,7 +132,7 @@ endif ()
 ##################################################
 # Preprocessor location and flags
 
-if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
+if (MSVC)
   set(CMAKE_CPP ${CMAKE_C_COMPILER})
 
   set(CPP_KEEP_COMMENTS /C)


### PR DESCRIPTION
i#638: Preprocessor location and flags on MSYS2 MinGW are same as on Unix-like system. This is just a second step toward building with MinGW.

Issue: https://github.com/DynamoRIO/dynamorio/issues/638
Signed-off-by: ofry <tim4job@bmail.ru>