### PR TITLE
i#3794: Export opnd.h to all of core/

### DIFF
--- a/core/arch/aarch64/clean_call_opt.c
+++ b/core/arch/aarch64/clean_call_opt.c
@@ -162,7 +162,7 @@ find_nzcv_spill_reg(callee_info_t *ci)
 {
     int i;
     reg_id_t spill_reg = DR_REG_INVALID;
-    for (i = NUM_GP_REGS - 2; i >= 0; i--) {
+    for (i = DR_NUM_GPR_REGS - 2; i >= 0; i--) {
         reg_id_t reg = DR_REG_START_GPR + (reg_id_t)i;
         ASSERT(reg != DR_REG_XSP && "hit SP starting at x30");
         if (reg == ci->spill_reg || ci->reg_used[i])
@@ -182,7 +182,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
     int i, num_regparm;
 
     /* XXX implement bitset for optimisation */
-    memset(ci->reg_used, 0, sizeof(bool) * NUM_GP_REGS);
+    memset(ci->reg_used, 0, sizeof(bool) * DR_NUM_GPR_REGS);
     ci->num_simd_used = 0;
     /* num_opmask_used is not applicable to ARM/AArch64. */
     ASSERT(proc_num_simd_registers() == MCXT_NUM_SIMD_SLOTS);
@@ -204,7 +204,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
     for (instr = instrlist_first(ilist); instr != NULL; instr = instr_get_next(instr)) {
 
         /* General purpose registers */
-        for (i = 0; i < NUM_GP_REGS; i++) {
+        for (i = 0; i < DR_NUM_GPR_REGS; i++) {
             reg_id_t reg = DR_REG_START_GPR + (reg_id_t)i;
             if (!ci->reg_used[i] && instr_uses_reg(instr, reg)) {
                 LOG(THREAD, LOG_CLEANCALL, 2,
@@ -469,7 +469,8 @@ insert_inline_reg_save(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
 {
     callee_info_t *ci = cci->callee_info;
     /* Don't spill anything if we don't have to. */
-    if (cci->num_regs_skip == NUM_GP_REGS && cci->skip_save_flags && !ci->has_locals) {
+    if (cci->num_regs_skip == DR_NUM_GPR_REGS && cci->skip_save_flags &&
+        !ci->has_locals) {
         return;
     }
     /* Spill a register to TLS and point it at our unprotected_context_t.*/
@@ -498,7 +499,8 @@ insert_inline_reg_restore(dcontext_t *dcontext, clean_call_info_t *cci,
     callee_info_t *ci = cci->callee_info;
 
     /* Don't restore regs if we don't have to. */
-    if (cci->num_regs_skip == NUM_GP_REGS && cci->skip_save_flags && !ci->has_locals) {
+    if (cci->num_regs_skip == DR_NUM_GPR_REGS && cci->skip_save_flags &&
+        !ci->has_locals) {
         return;
     }
 

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -681,7 +681,6 @@ d_r_arch_init(void)
      * masks. Also priv_mcontext_t.opmask slots are AVX512BW wide.
      */
     IF_X86(ASSERT(sizeof(dr_opmask_t) == OPMASK_AVX512BW_REG_SIZE));
-    ASSERT(NUM_GP_REGS == DR_NUM_GPR_REGS);
 
     /* Verify that the structures used for a register spill area and to hold IBT
      * table addresses & masks for IBL code are laid out as expected. We expect

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -401,7 +401,7 @@ typedef struct _clean_call_info_t {
     int num_opmask_skip;
     bool opmask_skip[MCXT_NUM_OPMASK_SLOTS];
     uint num_regs_skip;
-    bool reg_skip[NUM_GP_REGS];
+    bool reg_skip[DR_NUM_GPR_REGS];
     bool preserve_mcontext; /* even if skip reg save, preserve mcontext shape */
     bool out_of_line_swap;  /* whether we use clean_call_{save,restore} gencode */
     void *callee_info;      /* callee information */
@@ -1462,10 +1462,10 @@ typedef struct _callee_info_t {
     bool simd_used[MCXT_NUM_SIMD_SLOTS];
     /* AVX-512 mask register usage. */
     bool opmask_used[MCXT_NUM_OPMASK_SLOTS];
-    bool reg_used[NUM_GP_REGS];         /* general purpose registers usage */
-    int num_callee_save_regs;           /* number of regs callee saved */
-    bool callee_save_regs[NUM_GP_REGS]; /* callee-save registers */
-    bool has_locals;                    /* if reference local via stack */
+    bool reg_used[DR_NUM_GPR_REGS];         /* general purpose registers usage */
+    int num_callee_save_regs;               /* number of regs callee saved */
+    bool callee_save_regs[DR_NUM_GPR_REGS]; /* callee-save registers */
+    bool has_locals;                        /* if reference local via stack */
     bool standard_fp;   /* if standard reg (xbp/x29) is used as frame pointer */
     bool opt_inline;    /* can be inlined or not */
     bool write_flags;   /* if the function changes flags */

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -45,9 +45,6 @@
 #ifndef _ARCH_EXPORTS_H_
 #define _ARCH_EXPORTS_H_ 1
 
-/* stack slot width */
-#define XSP_SZ (sizeof(reg_t))
-
 /* We export all of opnd.h for reg_id_t, DR_NUM_GPR_REGS, etc. */
 #include "opnd.h"
 

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -48,6 +48,9 @@
 /* stack slot width */
 #define XSP_SZ (sizeof(reg_t))
 
+/* We export all of opnd.h for reg_id_t, DR_NUM_GPR_REGS, etc. */
+#include "opnd.h"
+
 #ifdef X86
 /* PR 264138: we must preserve xmm0-5 if on a 64-bit kernel.
  * On Linux we must preserve all xmm registers.
@@ -2546,23 +2549,10 @@ void
 encode_reset_it_block(dcontext_t *dcontext);
 #endif
 
-/* DR_NUM_GPR_REGS is not exported.  We use our own defines here.
- * These are checked vs DR_NUM_GPR_REGS in d_r_arch_init().
- */
-#ifdef X86_32
-#    define NUM_GP_REGS 8
-#elif defined(X86_64)
-#    define NUM_GP_REGS 16
-#elif defined(ARM)
-#    define NUM_GP_REGS 16
-#elif defined(AARCH64)
-#    define NUM_GP_REGS 32
-#endif
-
 #ifdef LINUX
 /* Register state preserved on input to restartable sequences ("rseq"). */
 typedef struct _rseq_entry_state_t {
-    reg_t gpr[NUM_GP_REGS];
+    reg_t gpr[DR_NUM_GPR_REGS];
 } rseq_entry_state_t;
 #endif
 

--- a/core/arch/clean_call_opt_shared.c
+++ b/core/arch/clean_call_opt_shared.c
@@ -79,7 +79,7 @@ callee_info_init(callee_info_t *ci)
         ci->simd_used[i] = true;
     for (i = 0; i < proc_num_opmask_registers(); i++)
         ci->opmask_used[i] = true;
-    for (i = 0; i < NUM_GP_REGS; i++)
+    for (i = 0; i < DR_NUM_GPR_REGS; i++)
         ci->reg_used[i] = true;
     ci->spill_reg = DR_REG_INVALID;
 }
@@ -376,7 +376,7 @@ static void
 analyze_callee_pick_spill_reg(dcontext_t *dcontext, callee_info_t *ci)
 {
     uint i;
-    for (i = 0; i < NUM_GP_REGS; i++) {
+    for (i = 0; i < DR_NUM_GPR_REGS; i++) {
         reg_id_t reg = DR_REG_START_GPR + (reg_id_t)i;
         if (reg == DR_REG_XSP IF_X86(|| reg == DR_REG_XAX) IF_X86_64(|| reg == REGPARM_0))
             continue;
@@ -529,7 +529,7 @@ analyze_clean_call_regs(dcontext_t *dcontext, clean_call_info_t *cci)
         cci->should_align = false;
     /* 2. general purpose registers */
     /* set regs not to be saved for clean call */
-    for (i = 0; i < NUM_GP_REGS; i++) {
+    for (i = 0; i < DR_NUM_GPR_REGS; i++) {
         if (info->reg_used[i]) {
             cci->reg_skip[i] = false;
         } else {
@@ -656,11 +656,11 @@ analyze_clean_call_inline(dcontext_t *dcontext, clean_call_info_t *cci)
                 ", save all regs in priv_mcontext_t layout.\n",
                 info->start);
             cci->num_regs_skip = 0;
-            memset(cci->reg_skip, 0, sizeof(bool) * NUM_GP_REGS);
+            memset(cci->reg_skip, 0, sizeof(bool) * DR_NUM_GPR_REGS);
             cci->should_align = true;
         } else {
             uint i;
-            for (i = 0; i < NUM_GP_REGS; i++) {
+            for (i = 0; i < DR_NUM_GPR_REGS; i++) {
                 if (!cci->reg_skip[i] && info->callee_save_regs[i]) {
                     cci->reg_skip[i] = true;
                     cci->num_regs_skip++;
@@ -748,7 +748,7 @@ analyze_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instr_t *where,
     /* On X86, a single pusha instruction is used to save the GPRs, so we do not take
      * the number of GPRs that need saving into account.
      */
-#            define GPR_SAVE_THRESHOLD NUM_GP_REGS
+#            define GPR_SAVE_THRESHOLD DR_NUM_GPR_REGS
 #        endif
 #    elif defined(AARCH64)
     /* Use out-of-line calls if more than 6 SIMD registers need to be saved. */
@@ -767,7 +767,7 @@ analyze_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instr_t *where,
      */
     if ((proc_num_simd_registers() - cci->num_simd_skip) > SIMD_SAVE_THRESHOLD ||
         (proc_num_opmask_registers() - cci->num_opmask_skip) > OPMASK_SAVE_THRESHOLD ||
-        (NUM_GP_REGS - cci->num_regs_skip) > GPR_SAVE_THRESHOLD || always_out_of_line)
+        (DR_NUM_GPR_REGS - cci->num_regs_skip) > GPR_SAVE_THRESHOLD || always_out_of_line)
         cci->out_of_line_swap = true;
 #    endif
 

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -276,7 +276,7 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
         /* PR 218790: maintain 16-byte rsp alignment.
          * insert_parameter_preparation() currently assumes we leave rsp aligned.
          */
-        uint num_slots = NUM_GP_REGS + NUM_EXTRA_SLOTS;
+        uint num_slots = DR_NUM_GPR_REGS + NUM_EXTRA_SLOTS;
         if (cci->skip_save_flags)
             num_slots -= 2;
         num_slots -= cci->num_regs_skip; /* regs that not saved */
@@ -312,7 +312,7 @@ cleanup_after_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
 #if (defined(X86) && defined(X64)) || defined(MACOS)
     /* PR 218790: remove the padding we added for 16-byte rsp alignment */
     if (cci->should_align) {
-        uint num_slots = NUM_GP_REGS + NUM_EXTRA_SLOTS;
+        uint num_slots = DR_NUM_GPR_REGS + NUM_EXTRA_SLOTS;
         if (cci->skip_save_flags)
             num_slots += 2;
         num_slots -= cci->num_regs_skip; /* regs that not saved */

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -2897,6 +2897,9 @@ opnd_t
 opnd_create_sized_tls_slot(int offs, opnd_size_t size);
 #endif /* !STANDALONE_DECODER */
 
+/* stack slot width */
+#define XSP_SZ (sizeof(reg_t))
+
 /* This should be kept in sync w/ the defines in x86/x86.asm */
 enum {
 #ifdef X86

--- a/core/arch/x86/clean_call_opt.c
+++ b/core/arch/x86/clean_call_opt.c
@@ -69,7 +69,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
      */
     memset(ci->simd_used, 0, sizeof(bool) * proc_num_simd_registers());
     memset(ci->opmask_used, 0, sizeof(bool) * MCXT_NUM_OPMASK_SLOTS);
-    memset(ci->reg_used, 0, sizeof(bool) * NUM_GP_REGS);
+    memset(ci->reg_used, 0, sizeof(bool) * DR_NUM_GPR_REGS);
     ci->write_flags = false;
     for (instr = instrlist_first(ilist); instr != NULL; instr = instr_get_next(instr)) {
         /* XXX: this is not efficient as instr_uses_reg will iterate over
@@ -102,7 +102,7 @@ analyze_callee_regs_usage(dcontext_t *dcontext, callee_info_t *ci)
             }
         }
         /* General purpose registers */
-        for (i = 0; i < NUM_GP_REGS; i++) {
+        for (i = 0; i < DR_NUM_GPR_REGS; i++) {
             reg_id_t reg = DR_REG_XAX + (reg_id_t)i;
             if (!ci->reg_used[i] &&
                 /* Later we'll rewrite stack accesses to not use XSP or XBP. */
@@ -620,7 +620,8 @@ insert_inline_reg_save(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
     int i;
 
     /* Don't spill anything if we don't have to. */
-    if (cci->num_regs_skip == NUM_GP_REGS && cci->skip_save_flags && !ci->has_locals) {
+    if (cci->num_regs_skip == DR_NUM_GPR_REGS && cci->skip_save_flags &&
+        !ci->has_locals) {
         return;
     }
 
@@ -631,7 +632,7 @@ insert_inline_reg_save(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
     /* Save used registers. */
     ASSERT(cci->num_simd_skip == proc_num_simd_registers());
     ASSERT(cci->num_opmask_skip == proc_num_opmask_registers());
-    for (i = 0; i < NUM_GP_REGS; i++) {
+    for (i = 0; i < DR_NUM_GPR_REGS; i++) {
         if (!cci->reg_skip[i]) {
             reg_id_t reg_id = DR_REG_XAX + (reg_id_t)i;
             LOG(THREAD, LOG_CLEANCALL, 2,
@@ -667,7 +668,8 @@ insert_inline_reg_restore(dcontext_t *dcontext, clean_call_info_t *cci,
     callee_info_t *ci = cci->callee_info;
 
     /* Don't restore regs if we don't have to. */
-    if (cci->num_regs_skip == NUM_GP_REGS && cci->skip_save_flags && !ci->has_locals) {
+    if (cci->num_regs_skip == DR_NUM_GPR_REGS && cci->skip_save_flags &&
+        !ci->has_locals) {
         return;
     }
 
@@ -680,7 +682,7 @@ insert_inline_reg_restore(dcontext_t *dcontext, clean_call_info_t *cci,
     }
 
     /* Now restore all registers. */
-    for (i = NUM_GP_REGS - 1; i >= 0; i--) {
+    for (i = DR_NUM_GPR_REGS - 1; i >= 0; i--) {
         if (!cci->reg_skip[i]) {
             reg_id_t reg_id = DR_REG_XAX + (reg_id_t)i;
             LOG(THREAD, LOG_CLEANCALL, 2,

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -488,7 +488,7 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
         PRE(ilist, instr, INSTR_CREATE_push(dcontext, opnd_create_reg(REG_RSI)));
     if (!cci->reg_skip[REG_RDI - REG_XAX])
         PRE(ilist, instr, INSTR_CREATE_push(dcontext, opnd_create_reg(REG_RDI)));
-    dstack_offs += (NUM_GP_REGS - cci->num_regs_skip) * XSP_SZ;
+    dstack_offs += (DR_NUM_GPR_REGS - cci->num_regs_skip) * XSP_SZ;
 #    else
     PRE(ilist, instr, INSTR_CREATE_pusha(dcontext));
     dstack_offs += 8 * XSP_SZ;

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -45,6 +45,11 @@
 #include <stdarg.h>
 #include "../os_shared.h"
 #include "os_public.h"
+/* arch_exports.h exports opnd.h, but relies on kernel_sigset_t from this header.
+ * We thus directly include opnd.h here for reg_id_t to resolve the circular
+ * dependence (cleaner than having to use ushort instead of reg_id_t).
+ */
+#include "../arch/opnd.h"
 
 #ifndef NOT_DYNAMORIO_CORE_PROPER
 #    define getpid getpid_forbidden_use_get_process_id
@@ -192,13 +197,12 @@ void
 os_signal_thread_detach(dcontext_t *dcontext);
 void
 os_tls_pre_init(int gdt_index);
-/* XXX: reg_id_t is not defined here, use ushort instead */
 ushort
-os_get_app_tls_base_offset(ushort /*reg_id_t*/ seg);
+os_get_app_tls_base_offset(reg_id_t seg);
 ushort
-os_get_app_tls_reg_offset(ushort /*reg_id_t*/ seg);
+os_get_app_tls_reg_offset(reg_id_t seg);
 void *
-os_get_app_tls_base(dcontext_t *dcontext, ushort /*reg_id_t*/ seg);
+os_get_app_tls_base(dcontext_t *dcontext, reg_id_t seg);
 void
 os_swap_context_go_native(dcontext_t *dcontext, dr_state_flags_t flags);
 


### PR DESCRIPTION
Adds opnd.h to arch_exports.h, allowing replacement of the duplicate
NUM_GP_REGS with DR_NUM_GPR_REGS.

Adds opnd.h to os_exports.h, allowing the use of reg_id_t instead of
ushort.

Fixes #3794