### PR TITLE
i#3850 private loader: Add a client library's rpath + runpath to search path.

### DIFF
--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -413,11 +413,12 @@ privload_insert(privmod_t *after, app_pc base, size_t size, const char *name,
      */
     if (IF_UNIX_ELSE(mod->name == NULL, false)) {
         mod->name = double_strrchr(mod->path, DIRSEP, ALT_DIRSEP);
+        /* XXX: mod->name contains the leading '/'. We probably don't want that,
+         * but it doesn't seem to break anything, leaving it for now. Other call
+         * sites of double_strrchr() do increment the '/' off the library name.
+         */
         if (mod->name == NULL)
             mod->name = mod->path;
-        /* XXX: mod->name contains the leading '/'. We probably don't want that,
-         * but it doesn't seem to break anything, leaving it for now.
-         */
     }
     mod->ref_count = 1;
     mod->externally_loaded = false;

--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -413,9 +413,8 @@ privload_insert(privmod_t *after, app_pc base, size_t size, const char *name,
      */
     if (IF_UNIX_ELSE(mod->name == NULL, false)) {
         mod->name = double_strrchr(mod->path, DIRSEP, ALT_DIRSEP);
-        /* XXX: mod->name contains the leading '/'. We probably don't want that,
-         * but it doesn't seem to break anything, leaving it for now. Other call
-         * sites of double_strrchr() do increment the '/' off the library name.
+        /* XXX: double_strrchr() returns mod->name containing the leading '/'. We probably
+         * don't want that, but it doesn't seem to break anything, leaving it for now.
          */
         if (mod->name == NULL)
             mod->name = mod->path;

--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -112,7 +112,9 @@ loader_init(void)
         char name_copy[MAXIMUM_PATH];
         mod = privload_insert(NULL, privmod_static[i].base, privmod_static[i].size,
                               privmod_static[i].name, privmod_static[i].path);
+#ifdef CLIENT_INTERFACE
         mod->is_client = true;
+#endif
         LOG(GLOBAL, LOG_LOADER, 1, "%s: processing imports for %s\n", __FUNCTION__,
             mod->name);
         /* save a copy for error msg, b/c mod will be unloaded (i#643) */

--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -112,6 +112,7 @@ loader_init(void)
         char name_copy[MAXIMUM_PATH];
         mod = privload_insert(NULL, privmod_static[i].base, privmod_static[i].size,
                               privmod_static[i].name, privmod_static[i].path);
+        mod->is_client = true;
         LOG(GLOBAL, LOG_LOADER, 1, "%s: processing imports for %s\n", __FUNCTION__,
             mod->name);
         /* save a copy for error msg, b/c mod will be unloaded (i#643) */
@@ -412,6 +413,9 @@ privload_insert(privmod_t *after, app_pc base, size_t size, const char *name,
         mod->name = double_strrchr(mod->path, DIRSEP, ALT_DIRSEP);
         if (mod->name == NULL)
             mod->name = mod->path;
+        /* XXX: mod->name contains the leading '/'. We probably don't want that,
+         * but it doesn't seem to break anything, leaving it for now.
+         */
     }
     mod->ref_count = 1;
     mod->externally_loaded = false;
@@ -443,7 +447,7 @@ privload_insert(privmod_t *after, app_pc base, size_t size, const char *name,
     return (void *)mod;
 }
 
-static bool
+bool
 privload_search_path_exists(const char *path, size_t len)
 {
     uint i;

--- a/core/module_shared.h
+++ b/core/module_shared.h
@@ -577,6 +577,9 @@ privmod_t *
 privload_insert(privmod_t *after, app_pc base, size_t size, const char *name,
                 const char *path);
 
+bool
+privload_search_path_exists(const char *path, size_t len);
+
 /* ************************************************************************* *
  * os specific functions in loader.c, can be called from loader_shared.c     *
  * ************************************************************************* */

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -794,7 +794,9 @@ privload_search_rpath(privmod_t *mod, bool runpath, const char *name,
                     module_file_has_module_header(filename)) {
                     return true;
                 }
-                list += len + 1;
+                list += len;
+                if (sep != NULL)
+                    list += 1;
             }
         }
         ++dyn;

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -569,7 +569,10 @@ privload_process_imports(privmod_t *mod)
                 if (impmod == NULL)
                     return false;
 #    ifdef CLIENT_INTERFACE
-                /* i#852: identify all libs that import from DR as client libs */
+                /* i#852: identify all libs that import from DR as client libs.
+                 * XXX: this code seems stale as libdynamorio.so is already loaded
+                 * (xref #3850).
+                 */
                 if (impmod->base == get_dynamorio_dll_start())
                     mod->is_client = true;
 #    endif

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -712,6 +712,7 @@ privload_search_rpath(privmod_t *mod, bool runpath, const char *name,
     os_privmod_data_t *opd;
     ELF_DYNAMIC_ENTRY_TYPE *dyn;
     ASSERT(mod != NULL && "can't look for rpath without a dependent module");
+    ASSERT_OWN_RECURSIVE_LOCK(true, &privload_lock);
     /* get the loading module's dir for RPATH_ORIGIN */
     opd = (os_privmod_data_t *)mod->os_privmod_data;
     /* i#460: if DT_RUNPATH exists we must ignore ignore DT_RPATH and

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -733,11 +733,6 @@ privload_search_rpath(privmod_t *mod, bool runpath, const char *name,
             const char *list = strtab + dyn->d_un.d_val;
             const char *sep, *origin;
             size_t len;
-            /* XXX: The list is already split into its elements. Currently, at least on
-             * the systems observed when writing this comment, this loops spills over
-             * across the actual rpath or runpath list, enclosed by '[' ']', and iterates
-             * over unrelated DT_NEEDED strings.
-             */
             while (*list != '\0') {
                 /* really we want strchrnul() */
                 sep = strchr(list, ':');

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -750,15 +750,15 @@ privload_search_rpath(privmod_t *mod, bool runpath, const char *name,
                 char path[MAXIMUM_PATH];
                 if (origin != NULL && origin < list + len) {
                     size_t pre_len = origin - list;
-                    snprintf(path, BUFFER_SIZE_BYTES(path), "%.*s%.*s%.*s", pre_len, list,
-                             moddir_len, mod->path,
+                    snprintf(path, BUFFER_SIZE_ELEMENTS(path), "%.*s%.*s%.*s", pre_len,
+                             list, moddir_len, mod->path,
                              /* the '/' should already be here */
                              len - strlen(RPATH_ORIGIN) - pre_len,
                              origin + strlen(RPATH_ORIGIN));
                     NULL_TERMINATE_BUFFER(path);
                     snprintf(filename, MAXIMUM_PATH, "%s/%s", path, name);
                 } else {
-                    snprintf(path, BUFFER_SIZE_BYTES(path), "%.*s", len, list);
+                    snprintf(path, BUFFER_SIZE_ELEMENTS(path), "%.*s", len, list);
                     NULL_TERMINATE_BUFFER(path);
                     snprintf(filename, MAXIMUM_PATH, "%s/%s", path, name);
                 }

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -733,7 +733,7 @@ privload_search_rpath(privmod_t *mod, bool runpath, const char *name,
             const char *list = strtab + dyn->d_un.d_val;
             const char *sep, *origin;
             size_t len;
-            /* XXX: The list is already split into it's elements. Currently, at least on
+            /* XXX: The list is already split into its elements. Currently, at least on
              * the systems observed when writing this comment, this loops spills over
              * across the actual rpath or runpath list, enclosed by '[' ']', and iterates
              * over unrelated DT_NEEDED strings.

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -741,25 +741,32 @@ privload_search_rpath(privmod_t *mod, bool runpath, const char *name,
                     len = sep - list;
                 /* support $ORIGIN expansion to lib's current directory */
                 origin = strstr(list, RPATH_ORIGIN);
+#    ifdef CLIENT_INTERFACE
                 char path[MAXIMUM_PATH];
+#    endif
                 if (origin != NULL && origin < list + len) {
                     size_t pre_len = origin - list;
+#    ifdef CLIENT_INTERFACE
                     snprintf(path, MAXIMUM_PATH, "%.*s%.*s%.*s", pre_len, list,
                              moddir_len, mod->path,
                              /* the '/' should already be here */
                              len - strlen(RPATH_ORIGIN) - pre_len,
                              origin + strlen(RPATH_ORIGIN));
+#    endif
                     snprintf(filename, MAXIMUM_PATH, "%.*s%.*s%.*s/%s", pre_len, list,
                              moddir_len, mod->path,
                              /* the '/' should already be here */
                              len - strlen(RPATH_ORIGIN) - pre_len,
                              origin + strlen(RPATH_ORIGIN), name);
                 } else {
+#    ifdef CLIENT_INTERFACE
                     snprintf(path, MAXIMUM_PATH, "%.*s", len, list);
+#    endif
                     snprintf(filename, MAXIMUM_PATH, "%.*s/%s", len, list, name);
                 }
-                NULL_TERMINATE_BUFFER(path);
                 filename[MAXIMUM_PATH - 1] = 0;
+#    ifdef CLIENT_INTERFACE
+                NULL_TERMINATE_BUFFER(path);
                 if (mod->is_client) {
                     /* We are adding a client's lib rpath to the general search path. This
                      * is not bullet proof compliant with what the loader should really
@@ -782,6 +789,7 @@ privload_search_rpath(privmod_t *mod, bool runpath, const char *name,
                         search_paths_idx++;
                     }
                 }
+#    endif
                 LOG(GLOBAL, LOG_LOADER, 2, "%s: looking for %s\n", __FUNCTION__,
                     filename);
                 if (os_file_exists(filename, false /*!is_dir*/) &&

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -764,7 +764,6 @@ privload_search_rpath(privmod_t *mod, bool runpath, const char *name,
                 }
                 filename[MAXIMUM_PATH - 1] = 0;
 #    ifdef CLIENT_INTERFACE
-                NULL_TERMINATE_BUFFER(path);
                 if (mod->is_client) {
                     /* We are adding a client's lib rpath to the general search path. This
                      * is not bullet proof compliant with what the loader should really

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1085,6 +1085,9 @@ module_lookup_symbol(ELF_SYM_TYPE *sym, os_privmod_data_t *pd)
      */
     ASSERT_OWN_RECURSIVE_LOCK(true, &privload_lock);
     mod = privload_first_module();
+    /* Symbols are currently looked up following the dependency chain depth-first instead
+     * of breadth-first as reflected in the global list 'modlist' (xref i#3850).
+     */
     while (mod != NULL) {
         pd = mod->os_privmod_data;
         ASSERT(pd != NULL && name != NULL);

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1086,7 +1086,7 @@ module_lookup_symbol(ELF_SYM_TYPE *sym, os_privmod_data_t *pd)
     ASSERT_OWN_RECURSIVE_LOCK(true, &privload_lock);
     mod = privload_first_module();
     /* FIXME i#3850: Symbols are currently looked up following the dependency chain
-     * depth-first instead of breadth-first as reflected in the global list 'modlist'.
+     * depth-first instead of breadth-first.
      */
     while (mod != NULL) {
         pd = mod->os_privmod_data;

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1085,8 +1085,8 @@ module_lookup_symbol(ELF_SYM_TYPE *sym, os_privmod_data_t *pd)
      */
     ASSERT_OWN_RECURSIVE_LOCK(true, &privload_lock);
     mod = privload_first_module();
-    /* Symbols are currently looked up following the dependency chain depth-first instead
-     * of breadth-first as reflected in the global list 'modlist' (xref i#3850).
+    /* FIXME i#3850: Symbols are currently looked up following the dependency chain
+     * depth-first instead of breadth-first as reflected in the global list 'modlist'.
      */
     while (mod != NULL) {
         pd = mod->os_privmod_data;


### PR DESCRIPTION
This patch makes DynamoRIO's private loader add a client library's rpath + runpath to the
global search path. This is considered a work around for issues stemming from the fact
that currently, DynamoRIO's private loader is traversing library dependencies depth-first
instead of breadth-first. From experiments it looks like the native Linux loader does the
latter.

This resulted into some cases where DynamoRIO's loader couldn't find libraries that
can only be found by considering the client's rpath + runpath. In those cases, the C++
toolchain was adding multiple system dependencies to the client library including a valid
rpath, but the system libraries itself did not reflect the same rpath.

The drawback of this workaround is the unability to handle potential corner cases with
libraries of the same name in different locations.

Includes a fix for a latent bug that caused overrunning the rpath + runpath string if the path
was a list.

Issue: #3850