### PR TITLE
i#3850 private loader: Always add all client library's rpaths.

### DIFF
--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -755,15 +755,10 @@ privload_search_rpath(privmod_t *mod, bool runpath, const char *name,
                              len - strlen(RPATH_ORIGIN) - pre_len,
                              origin + strlen(RPATH_ORIGIN));
                     NULL_TERMINATE_BUFFER(path);
-                    if (!lib_found)
-                        snprintf(filename, MAXIMUM_PATH, "%s/%s", path, name);
                 } else {
                     snprintf(path, BUFFER_SIZE_ELEMENTS(path), "%.*s", len, list);
                     NULL_TERMINATE_BUFFER(path);
-                    if (!lib_found)
-                        snprintf(filename, MAXIMUM_PATH, "%s/%s", path, name);
                 }
-                filename[MAXIMUM_PATH - 1] = 0;
 #    ifdef CLIENT_INTERFACE
                 if (mod->is_client) {
                     /* We are adding a client's lib rpath to the general search path. This
@@ -789,9 +784,11 @@ privload_search_rpath(privmod_t *mod, bool runpath, const char *name,
                     }
                 }
 #    endif
-                LOG(GLOBAL, LOG_LOADER, 2, "%s: looking for %s\n", __FUNCTION__,
-                    filename);
                 if (!lib_found) {
+                    snprintf(filename, MAXIMUM_PATH, "%s/%s", path, name);
+                    filename[MAXIMUM_PATH - 1] = 0;
+                    LOG(GLOBAL, LOG_LOADER, 2, "%s: looking for %s\n", __FUNCTION__,
+                        filename);
                     if (os_file_exists(filename, false /*!is_dir*/) &&
                         module_file_has_module_header(filename)) {
 #    ifdef CLIENT_INTERFACE

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -794,7 +794,11 @@ privload_search_rpath(privmod_t *mod, bool runpath, const char *name,
                 if (!lib_found) {
                     if (os_file_exists(filename, false /*!is_dir*/) &&
                         module_file_has_module_header(filename)) {
+#    ifdef CLIENT_INTERFACE
                         lib_found = true;
+#    else
+                        return true;
+#    endif
                     }
                 }
                 list += len;


### PR DESCRIPTION
This adds to d33ed98bdb4fb666 by adding all rpaths of the client library to the global
search list before walking dependencies depth-first. This was originally intended like
this and missed by d33ed98bdb4fb666, which stops adding the client library's rpaths to
the list once a library is found.

Issue: #3850