### PR TITLE
Minor test cleanups and uninitialized variable fix.

### DIFF
--- a/suite/tests/linux/exit.c
+++ b/suite/tests/linux/exit.c
@@ -34,12 +34,12 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "tools.h"
 
 int
 main(int argc, char *argv[])
 {
-    printf("Inside main\n");
-    fflush(stdout);
+    print("Inside main\n");
 
     exit(0);
     return 0;

--- a/suite/tests/linux/fork.c
+++ b/suite/tests/linux/fork.c
@@ -42,62 +42,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
-
-/***************************************************************************/
-/* a hopefuly portable /proc/@self/maps reader */
-
-/* these are defined in /usr/src/linux/fs/proc/array.c */
-#define MAPS_LINE_LENGTH 4096
-/* for systems with sizeof(void*) == 4: */
-#define MAPS_LINE_FORMAT4 "%08lx-%08lx %s %*x %*s %*u %4096s"
-#define MAPS_LINE_MAX4 49 /* sum of 8  1  8  1 4 1 8 1 5 1 10 1 */
-/* for systems with sizeof(void*) == 8: */
-#define MAPS_LINE_FORMAT8 "%016lx-%016lx %s %*x %*s %*u %4096s"
-#define MAPS_LINE_MAX8 73 /* sum of 16  1  16  1 4 1 16 1 5 1 10 1 */
-
-#define MAPS_LINE_MAX MAPS_LINE_MAX8
-
-int
-find_dynamo_library()
-{
-    pid_t pid = getpid();
-    char proc_pid_maps[64]; /* file name */
-
-    FILE *maps;
-    char line[MAPS_LINE_LENGTH];
-    int count = 0;
-
-    // open file's /proc/id/maps virtual map description
-    int n = snprintf(proc_pid_maps, sizeof(proc_pid_maps), "/proc/%d/maps", pid);
-    if (n < 0 || n == sizeof(proc_pid_maps))
-        assert(0); /* paranoia */
-
-    maps = fopen(proc_pid_maps, "r");
-
-    while (!feof(maps)) {
-        void *vm_start, *vm_end;
-        char perm[16];
-        char comment_buffer[MAPS_LINE_LENGTH];
-        int len;
-
-        if (NULL == fgets(line, sizeof(line), maps))
-            break;
-        len = sscanf(line, sizeof(void *) == 4 ? MAPS_LINE_FORMAT4 : MAPS_LINE_FORMAT8,
-                     (unsigned long *)&vm_start, (unsigned long *)&vm_end, perm,
-                     comment_buffer);
-        if (len < 4)
-            comment_buffer[0] = '\0';
-        if (strstr(comment_buffer, "dynamorio") != 0) {
-            fclose(maps);
-            return 1;
-        }
-    }
-
-    fclose(maps);
-    return 0;
-}
-
-/***************************************************************************/
+#include "tools.h"
 
 int
 main(int argc, char **argv)
@@ -105,22 +50,22 @@ main(int argc, char **argv)
     pid_t child;
 
     if (find_dynamo_library())
-        printf("parent is running under DynamoRIO\n");
+        print("parent is running under DynamoRIO\n");
     else
-        printf("parent is running natively\n");
+        print("parent is running natively\n");
     child = fork();
     if (child < 0) {
         perror("ERROR on fork");
     } else if (child > 0) {
         pid_t result;
-        printf("parent waiting for child\n");
+        print("parent waiting for child\n");
         result = waitpid(child, NULL, 0);
         assert(result == child);
-        printf("child has exited\n");
+        print("child has exited\n");
     } else {
         if (find_dynamo_library())
-            printf("child is running under DynamoRIO\n");
+            print("child is running under DynamoRIO\n");
         else
-            printf("child is running natively\n");
+            print("child is running natively\n");
     }
 }

--- a/suite/tests/linux/fork.expect
+++ b/suite/tests/linux/fork.expect
@@ -1,5 +1,4 @@
 parent is running under DynamoRIO
-child is running under DynamoRIO
-parent is running under DynamoRIO
 parent waiting for child
+child is running under DynamoRIO
 child has exited

--- a/suite/tests/linux/longjmp.c
+++ b/suite/tests/linux/longjmp.c
@@ -34,14 +34,14 @@
 #include <stdio.h>
 #include <setjmp.h>
 #include <stdlib.h>
+#include "tools.h"
 
 jmp_buf mark;
 
 void
 foo()
 {
-    printf("about to do longjmp\n");
-    fflush(stdout);
+    print("about to do longjmp\n");
     longjmp(mark, -1);
 }
 
@@ -56,10 +56,10 @@ main()
      */
     jmpret = setjmp(mark);
     if (jmpret == 0) {
-        printf("doing stuff\n");
+        print("doing stuff\n");
         foo();
     } else {
-        printf("after longjmp\n");
+        print("after longjmp\n");
     }
     return 0;
 }

--- a/suite/tests/linux/syscall_pwait.cpp
+++ b/suite/tests/linux/syscall_pwait.cpp
@@ -91,7 +91,7 @@ kick_off_child_func(void *arg)
 pthread_t
 kick_off_child_signal(int count, pthread_t main_thread, bool immediately)
 {
-    pthread_t child_thread;
+    pthread_t child_thread = 0;
     reset_cond_var(ready_to_listen);
     args.main_thread = main_thread;
     args.immediately = immediately;

--- a/suite/tests/pthreads/pthreads.c
+++ b/suite/tests/pthreads/pthreads.c
@@ -39,6 +39,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
+#include "tools.h"
 
 volatile double pi = 0.0;  /* Approximation to pi (shared) */
 pthread_mutex_t pi_lock;   /* Lock for above */
@@ -53,7 +54,7 @@ process(void *arg)
     register int iproc;
 
 #if VERBOSE
-    fprintf(stderr, "\tthread %s starting\n", id);
+    print("\tthread %s starting\n", id);
 #endif
     iproc = (*((char *)arg) - '0');
 
@@ -74,7 +75,7 @@ process(void *arg)
     pthread_mutex_unlock(&pi_lock);
 
 #if VERBOSE
-    fprintf(stderr, "\tthread %s exiting\n", id);
+    print("\tthread %s exiting\n", id);
 #endif
     return (NULL);
 }
@@ -88,7 +89,7 @@ main(int argc, char **argv)
 #if 0
     /* Get the number of intervals */
     if (argc != 2) {
-        fprintf(stderr, "Usage: %s <intervals>\n", argv[0]);
+        print("Usage: %s <intervals>\n", argv[0]);
         exit(0);
     }
     intervals = atoi(argv[1]);
@@ -102,16 +103,16 @@ main(int argc, char **argv)
     /* Make the two threads */
     if (pthread_create(&thread0, NULL, process, (void *)"0") ||
         pthread_create(&thread1, NULL, process, (void *)"1")) {
-        fprintf(stderr, "%s: cannot make thread\n", argv[0]);
+        print("%s: cannot make thread\n", argv[0]);
         exit(1);
     }
 
     /* Join (collapse) the two threads */
     if (pthread_join(thread0, &retval) || pthread_join(thread1, &retval)) {
-        fprintf(stderr, "%s: thread join failed\n", argv[0]);
+        print("%s: thread join failed\n", argv[0]);
         exit(1);
     }
 
     /* Print the result */
-    printf("Estimation of pi is %16.15f\n", pi);
+    print("Estimation of pi is %16.15f\n", pi);
 }


### PR DESCRIPTION
Re-factors linux.fork to using tools.
Fixes an uninitialized variable in linux.syscall_pwait.
Changes using printf to using tools in tests linux.exit, linux.longjmp, and pthreads.pthreads.

Please note the stdout change above is somewhat random, and there are various tests left
using printf and a future patch should address changing all remaining tests to using tools.
