### PR TITLE
i#3828: Implement multibyte nop for AMD64 architecture

### DIFF
--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -1576,6 +1576,9 @@ canonicalize_pc_target(dcontext_t *dcontext, app_pc pc);
 void
 d_r_decode_init(void);
 
+bool
+fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size);
+
 /***************************************************************************
  * Arch-specific defines
  */
@@ -1664,8 +1667,6 @@ d_r_decode_init(void);
         (FRAG_IS_32(flags) ? STUB_COARSE_DIRECT_SIZE32 : STUB_COARSE_DIRECT_SIZE64)
 
 /* Writes nops into the address range. */
-bool
-fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size);
 #    define SET_TO_NOPS(isa_mode, addr, size) fill_with_nops(isa_mode, addr, size)
 /* writes debugbreaks into the address range */
 #    define SET_TO_DEBUG(addr, size) memset(addr, 0xcc, size)
@@ -1736,8 +1737,6 @@ fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size);
 #    define ARM_BKPT 0xe1200070
 #    define THUMB_BKPT 0xbe00
 /* writes nops into the address range */
-bool
-fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size);
 #    define SET_TO_NOPS(isa_mode, addr, size) fill_with_nops(isa_mode, addr, size)
 /* writes debugbreaks into the address range */
 #    define SET_TO_DEBUG(addr, size) ASSERT_NOT_IMPLEMENTED(false)

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -1663,10 +1663,10 @@ d_r_decode_init(void);
 #    define STUB_COARSE_DIRECT_SIZE(flags) \
         (FRAG_IS_32(flags) ? STUB_COARSE_DIRECT_SIZE32 : STUB_COARSE_DIRECT_SIZE64)
 
-/* Writes nops into the address range.
- * XXX i#3828: Better to use the newer multi-byte nops.
- */
-#    define SET_TO_NOPS(isa_mode, addr, size) memset(addr, 0x90, size)
+/* Writes nops into the address range. */
+bool
+fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size);
+#    define SET_TO_NOPS(isa_mode, addr, size) fill_with_nops(isa_mode, addr, size)
 /* writes debugbreaks into the address range */
 #    define SET_TO_DEBUG(addr, size) memset(addr, 0xcc, size)
 /* check if region is SET_TO_NOP */

--- a/core/arch/x86/emit_utils.c
+++ b/core/arch/x86/emit_utils.c
@@ -3155,46 +3155,26 @@ relink_special_ibl_xfer(dcontext_t *dcontext, int index,
     protect_generated_code(code, READONLY);
 }
 
-/*
-RAW(66) RAW(90)
-RAW(67) RAW(90)
-RAW(f2) RAW(90)
-RAW(f3) RAW(90)
-RAW(66) RAW(66) RAW(66) RAW(66) RAW(66) RAW(90)
-RAW(0f) RAW(1f) RAW(00)
-RAW(0f) RAW(1f) RAW(40) RAW(00)
-RAW(0f) RAW(1f) RAW(44) RAW(00) RAW(00)
-RAW(66) RAW(0f) RAW(1f) RAW(44) RAW(00) RAW(00)
-RAW(0f) RAW(1f) RAW(80) RAW(00) RAW(00) RAW(00) RAW(00)
-RAW(0f) RAW(1f) RAW(84) RAW(00) RAW(00) RAW(00) RAW(00) RAW(00)
-RAW(66) RAW(0f) RAW(1f) RAW(84) RAW(00) RAW(00) RAW(00) RAW(00) RAW(00)
-*/
 bool
 fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size)
 {
-    if (isa_mode == DR_ISA_AMD64) {
-        /* 64 bit mode can take advantage of multibyte nops.
-         * ref. AMD Software Optimization Guide for AMD Family 15h Processors, document
-         * #47414, section 5.8 "Code Padding with Operand-Size Override and Multibyte
-         * NOP", page 94)
-         */
-        switch (size) {
-        case 1: memcpy(addr, "\x90", 1); break;
-        case 2: memcpy(addr, "\x66\x90", 2); break;
-        case 3: memcpy(addr, "\x0f\x1f\x00", 3); break;
-        case 4: memcpy(addr, "\x0f\x1f\x40\x00", 4); break;
-        case 5: memcpy(addr, "\x0f\x1f\x44\x00\x00", 5); break;
-        case 6: memcpy(addr, "\x66\x0f\x1f\x44\x00\x00", 6); break;
-        case 7: memcpy(addr, "\x0f\x1f\x80\x00\x00\x00\x00", 7); break;
-        case 8: memcpy(addr, "\x0f\x1f\x84\x00\x00\x00\x00\x00", 8); break;
-        case 9: memcpy(addr, "\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 9); break;
-        case 10: memcpy(addr, "\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 10); break;
-        case 11: memcpy(addr, "\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 11); break;
-        default: memset(addr, 0x90, size);
-        }
-    } else {
-        /* 32 bit defaults to multiple nop instructions */
-        memset(addr, 0x90, size);
+    /* ref. AMD Software Optimization Guide for AMD Family 15h Processors, document
+     * #47414, section 5.8 "Code Padding with Operand-Size Override and Multibyte
+     * NOP", page 94)
+     */
+    switch (size) {
+    case 1: memcpy(addr, "\x90", 1); break;
+    case 2: memcpy(addr, "\x66\x90", 2); break;
+    case 3: memcpy(addr, "\x0f\x1f\x00", 3); break;
+    case 4: memcpy(addr, "\x0f\x1f\x40\x00", 4); break;
+    case 5: memcpy(addr, "\x0f\x1f\x44\x00\x00", 5); break;
+    case 6: memcpy(addr, "\x66\x0f\x1f\x44\x00\x00", 6); break;
+    case 7: memcpy(addr, "\x0f\x1f\x80\x00\x00\x00\x00", 7); break;
+    case 8: memcpy(addr, "\x0f\x1f\x84\x00\x00\x00\x00\x00", 8); break;
+    case 9: memcpy(addr, "\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 9); break;
+    case 10: memcpy(addr, "\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 10); break;
+    case 11: memcpy(addr, "\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 11); break;
+    default: memset(addr, 0x90, size);
     }
     return true;
 }

--- a/core/arch/x86/emit_utils.c
+++ b/core/arch/x86/emit_utils.c
@@ -3161,6 +3161,9 @@ fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size)
     /* ref. AMD Software Optimization Guide for AMD Family 15h Processors, document
      * #47414, section 5.8 "Code Padding with Operand-Size Override and Multibyte
      * NOP", page 94)
+     * For specification compatibility with Intel case 10 and 11 are left out.
+     * ref. Intel, see Vol. 2B 4-167 "Table 4-12. Recommended Multi-Byte Sequence of NOP
+     * Instruction"
      */
     switch (size) {
     case 1: memcpy(addr, "\x90", 1); break;
@@ -3172,8 +3175,6 @@ fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size)
     case 7: memcpy(addr, "\x0f\x1f\x80\x00\x00\x00\x00", 7); break;
     case 8: memcpy(addr, "\x0f\x1f\x84\x00\x00\x00\x00\x00", 8); break;
     case 9: memcpy(addr, "\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 9); break;
-    case 10: memcpy(addr, "\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 10); break;
-    case 11: memcpy(addr, "\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 11); break;
     default: memset(addr, 0x90, size);
     }
     return true;

--- a/core/arch/x86/emit_utils.c
+++ b/core/arch/x86/emit_utils.c
@@ -3158,12 +3158,12 @@ relink_special_ibl_xfer(dcontext_t *dcontext, int index,
 bool
 fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size)
 {
-    /* ref. AMD Software Optimization Guide for AMD Family 15h Processors, document
+    /* Xref AMD Software Optimization Guide for AMD Family 15h Processors, document
      * #47414, section 5.8 "Code Padding with Operand-Size Override and Multibyte
-     * NOP", page 94)
-     * For specification compatibility with Intel case 10 and 11 are left out.
-     * ref. Intel, see Vol. 2B 4-167 "Table 4-12. Recommended Multi-Byte Sequence of NOP
-     * Instruction"
+     * NOP".
+     * For compatibility with Intel case 10 and 11 are left out.
+     * Xref Intel, see Vol. 2B 4-167 "Table 4-12. Recommended Multi-Byte Sequence of NOP
+     * Instruction".
      */
     switch (size) {
     case 1: memcpy(addr, "\x90", 1); break;

--- a/core/arch/x86/emit_utils.c
+++ b/core/arch/x86/emit_utils.c
@@ -3155,6 +3155,20 @@ relink_special_ibl_xfer(dcontext_t *dcontext, int index,
     protect_generated_code(code, READONLY);
 }
 
+/*
+RAW(66) RAW(90)
+RAW(67) RAW(90)
+RAW(f2) RAW(90)
+RAW(f3) RAW(90)
+RAW(66) RAW(66) RAW(66) RAW(66) RAW(66) RAW(90)
+RAW(0f) RAW(1f) RAW(00)
+RAW(0f) RAW(1f) RAW(40) RAW(00)
+RAW(0f) RAW(1f) RAW(44) RAW(00) RAW(00)
+RAW(66) RAW(0f) RAW(1f) RAW(44) RAW(00) RAW(00)
+RAW(0f) RAW(1f) RAW(80) RAW(00) RAW(00) RAW(00) RAW(00)
+RAW(0f) RAW(1f) RAW(84) RAW(00) RAW(00) RAW(00) RAW(00) RAW(00)
+RAW(66) RAW(0f) RAW(1f) RAW(84) RAW(00) RAW(00) RAW(00) RAW(00) RAW(00)
+*/
 bool
 fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size)
 {
@@ -3165,18 +3179,18 @@ fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size)
          * NOP", page 94)
          */
         switch (size) {
-        case 1: memcpy(addr, "\x90", 1);
-        case 2: memcpy(addr, "\x66\x90", 2);
-        case 3: memcpy(addr, "\x0f\x1f\x00", 3);
-        case 4: memcpy(addr, "\x0f\x1f\x40\x00", 4);
-        case 5: memcpy(addr, "\x0f\x1f\x44\x00\x00", 5);
-        case 6: memcpy(addr, "\x66\x0f\x1f\x44\x00\x00", 6);
-        case 7: memcpy(addr, "\x0f\x1f\x80\x00\x00\x00\x00", 7);
-        case 8: memcpy(addr, "\x0f\x1f\x84\x00\x00\x00\x00\x00", 8);
-        case 9: memcpy(addr, "\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 9);
-        case 10: memcpy(addr, "\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 10);
-        case 11: memcpy(addr, "\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 11);
-        default: memset(addr, 0x90, size);
+        case 1: memcpy(addr, "\x90", 1); break;
+        case 2: memcpy(addr, "\x66\x90", 2); break;
+        case 3: memcpy(addr, "\x0f\x1f\x00", 3); break;
+        case 4: memcpy(addr, "\x0f\x1f\x40\x00", 4); break;
+        case 5: memcpy(addr, "\x0f\x1f\x44\x00\x00", 5); break;
+        case 6: memcpy(addr, "\x66\x0f\x1f\x44\x00\x00", 6); break;
+        case 7: memcpy(addr, "\x0f\x1f\x80\x00\x00\x00\x00", 7); break;
+        case 8: memcpy(addr, "\x0f\x1f\x84\x00\x00\x00\x00\x00", 8); break;
+        case 9: memcpy(addr, "\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 9); break;
+        case 10: memcpy(addr, "\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 10); break;
+        case 11: memcpy(addr, "\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 11); break;
+        default: memset(addr, 0x90, size); break;
         }
     } else {
         /* 32 bit defaults to multiple nop instructions */

--- a/core/arch/x86/emit_utils.c
+++ b/core/arch/x86/emit_utils.c
@@ -3190,7 +3190,7 @@ fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size)
         case 9: memcpy(addr, "\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 9); break;
         case 10: memcpy(addr, "\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 10); break;
         case 11: memcpy(addr, "\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00", 11); break;
-        default: memset(addr, 0x90, size); break;
+        default: memset(addr, 0x90, size);
         }
     } else {
         /* 32 bit defaults to multiple nop instructions */


### PR DESCRIPTION
This is my first PR to DR so I hope this conforms the guidelines, I've looked how the other architectures did it and adapted the same style. I used the AMD manual as reference to multibyte nops and also left it as a comment.

Fixes #3828