### PR TITLE
i3865: Extend reg_resize_to_opsz

### DIFF
--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -2418,13 +2418,19 @@ reg_32_to_opsz(reg_id_t reg, opnd_size_t sz);
 
 DR_API
 /**
- * Given a general-purpose register of any size, returns a register in the same
- * class of the given size.  For example, given \p DR_REG_AX or \p DR_REG_RAX
- * and \p OPSZ_1, this routine will return \p DR_REG_AL.
+ * Given a general-purpose or SIMD register of any size, returns a register in the same
+ * class of the given size.
+ *
+ * For example, given \p DR_REG_AX or \p DR_REG_RAX and \p OPSZ_1, this routine will
+ * return \p DR_REG_AL. Given \p DR_REG_XMM0 and \p OPSZ-64, it will return \p
+ * DR_REG_ZMM0.
+ *
  * Returns \p DR_REG_NULL when trying to get the 8-bit subregister of \p
  * DR_REG_ESI, \p DR_REG_EDI, \p DR_REG_EBP, or \p DR_REG_ESP in 32-bit mode.
  * For 64-bit versions of this library, if \p sz == OPSZ_8, returns the 64-bit
  * version of \p reg.
+ *
+ * MMX registers are not yet supported.
  */
 reg_id_t
 reg_resize_to_opsz(reg_id_t reg, opnd_size_t sz);

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -2431,6 +2431,7 @@ DR_API
  * version of \p reg.
  *
  * MMX registers are not yet supported.
+ * Moreover, ARM is not yet supported.
  */
 reg_id_t
 reg_resize_to_opsz(reg_id_t reg, opnd_size_t sz);

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -2422,7 +2422,7 @@ DR_API
  * class of the given size.
  *
  * For example, given \p DR_REG_AX or \p DR_REG_RAX and \p OPSZ_1, this routine will
- * return \p DR_REG_AL. Given \p DR_REG_XMM0 and \p OPSZ-64, it will return \p
+ * return \p DR_REG_AL. Given \p DR_REG_XMM0 and \p OPSZ_64, it will return \p
  * DR_REG_ZMM0.
  *
  * Returns \p DR_REG_NULL when trying to get the 8-bit subregister of \p

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -2431,7 +2431,7 @@ DR_API
  * version of \p reg.
  *
  * MMX registers are not yet supported.
- * Moreover, ARM is not yet supported.
+ * Moreover, ARM is not yet supported for resizing SIMD registers.
  */
 reg_id_t
 reg_resize_to_opsz(reg_id_t reg, opnd_size_t sz);

--- a/core/arch/opnd_shared.c
+++ b/core/arch/opnd_shared.c
@@ -2154,7 +2154,7 @@ reg_resize_to_opsz(reg_id_t reg, opnd_size_t sz)
         } else if (sz == OPSZ_32) {
             return reg_resize_to_ymm(reg);
         } else if (sz == OPSZ_64) {
-            reg_resize_to_zmm(reg);
+            return reg_resize_to_zmm(reg);
         } else {
             CLIENT_ASSERT(false, "invalid size for simd register");
         }

--- a/core/arch/opnd_shared.c
+++ b/core/arch/opnd_shared.c
@@ -2099,12 +2099,69 @@ reg_32_to_opsz(reg_id_t reg, opnd_size_t sz)
     return reg;
 }
 
+static reg_id_t
+reg_resize_to_zmm(reg_id_t simd_reg)
+{
+    if (reg_is_strictly_xmm(simd_reg)) {
+        return simd_reg - DR_REG_START_XMM + DR_REG_START_ZMM;
+    } else if (reg_is_strictly_ymm(simd_reg)) {
+        return simd_reg - DR_REG_START_YMM + DR_REG_START_ZMM;
+    } else if (reg_is_strictly_zmm(simd_reg)) {
+        return simd_reg;
+    }
+    CLIENT_ASSERT(false, "Not a simd register.");
+    return DR_REG_INVALID;
+}
+
+static reg_id_t
+reg_resize_to_ymm(reg_id_t simd_reg)
+{
+    if (reg_is_strictly_xmm(simd_reg)) {
+        return simd_reg - DR_REG_START_XMM + DR_REG_START_YMM;
+    } else if (reg_is_strictly_ymm(simd_reg)) {
+        return simd_reg;
+    } else if (reg_is_strictly_zmm(simd_reg)) {
+        return simd_reg - DR_REG_START_ZMM + DR_REG_START_YMM;
+    }
+    CLIENT_ASSERT(false, "not a simd register.");
+    return DR_REG_INVALID;
+}
+
+static reg_id_t
+reg_resize_to_xmm(reg_id_t simd_reg)
+{
+    if (reg_is_strictly_xmm(simd_reg)) {
+        return simd_reg;
+    } else if (reg_is_strictly_ymm(simd_reg)) {
+        return simd_reg - DR_REG_START_YMM + DR_REG_START_XMM;
+    } else if (reg_is_strictly_zmm(simd_reg)) {
+        return simd_reg - DR_REG_START_ZMM + DR_REG_START_XMM;
+    }
+    CLIENT_ASSERT(false, "not a simd register");
+    return DR_REG_INVALID;
+}
+
 reg_id_t
 reg_resize_to_opsz(reg_id_t reg, opnd_size_t sz)
 {
-    CLIENT_ASSERT(reg_is_gpr(reg), "reg_resize_to_opsz: passed non GPR reg");
-    reg = reg_to_pointer_sized(reg);
-    return reg_32_to_opsz(IF_X64_ELSE(reg_64_to_32(reg), reg), sz);
+    if (reg_is_gpr(reg)) {
+        reg = reg_to_pointer_sized(reg);
+        return reg_32_to_opsz(IF_X64_ELSE(reg_64_to_32(reg), reg), sz);
+    } else if (reg_is_strictly_xmm(reg) || reg_is_strictly_ymm(reg) ||
+               reg_is_strictly_zmm(reg)) {
+        if (sz == OPSZ_16) {
+            return reg_resize_to_xmm(reg);
+        } else if (sz == OPSZ_32) {
+            return reg_resize_to_ymm(reg);
+        } else if (sz == OPSZ_64) {
+            reg_resize_to_zmm(reg);
+        } else {
+            CLIENT_ASSERT(false, "invalid size for simd register");
+        }
+    } else {
+        CLIENT_ASSERT(false, "reg_resize_to_opsz: unsupported reg");
+    }
+    return DR_REG_INVALID;
 }
 
 int

--- a/core/arch/opnd_shared.c
+++ b/core/arch/opnd_shared.c
@@ -2102,6 +2102,7 @@ reg_32_to_opsz(reg_id_t reg, opnd_size_t sz)
 static reg_id_t
 reg_resize_to_zmm(reg_id_t simd_reg)
 {
+#ifdef X86
     if (reg_is_strictly_xmm(simd_reg)) {
         return simd_reg - DR_REG_START_XMM + DR_REG_START_ZMM;
     } else if (reg_is_strictly_ymm(simd_reg)) {
@@ -2110,12 +2111,14 @@ reg_resize_to_zmm(reg_id_t simd_reg)
         return simd_reg;
     }
     CLIENT_ASSERT(false, "Not a simd register.");
+#endif
     return DR_REG_INVALID;
 }
 
 static reg_id_t
 reg_resize_to_ymm(reg_id_t simd_reg)
 {
+#ifdef X86
     if (reg_is_strictly_xmm(simd_reg)) {
         return simd_reg - DR_REG_START_XMM + DR_REG_START_YMM;
     } else if (reg_is_strictly_ymm(simd_reg)) {
@@ -2124,12 +2127,14 @@ reg_resize_to_ymm(reg_id_t simd_reg)
         return simd_reg - DR_REG_START_ZMM + DR_REG_START_YMM;
     }
     CLIENT_ASSERT(false, "not a simd register.");
+#endif
     return DR_REG_INVALID;
 }
 
 static reg_id_t
 reg_resize_to_xmm(reg_id_t simd_reg)
 {
+#ifdef X86
     if (reg_is_strictly_xmm(simd_reg)) {
         return simd_reg;
     } else if (reg_is_strictly_ymm(simd_reg)) {
@@ -2138,6 +2143,7 @@ reg_resize_to_xmm(reg_id_t simd_reg)
         return simd_reg - DR_REG_START_ZMM + DR_REG_START_XMM;
     }
     CLIENT_ASSERT(false, "not a simd register");
+#endif
     return DR_REG_INVALID;
 }
 

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -1535,43 +1535,19 @@ get_scatter_gather_info(instr_t *instr, scatter_gather_info_t *sg_info)
 static reg_id_t
 simd_reg_to_zmm(reg_id_t simd_reg)
 {
-    if (reg_is_strictly_xmm(simd_reg)) {
-        return simd_reg - DR_REG_START_XMM + DR_REG_START_ZMM;
-    } else if (reg_is_strictly_ymm(simd_reg)) {
-        return simd_reg - DR_REG_START_YMM + DR_REG_START_ZMM;
-    } else if (reg_is_strictly_zmm(simd_reg)) {
-        return simd_reg;
-    }
-    ASSERT(false, "Not a simd register.");
-    return DR_REG_INVALID;
+    return reg_resize_to_opsz(simd_reg, OPSZ_64);
 }
 
 static reg_id_t
 simd_reg_to_ymm(reg_id_t simd_reg)
 {
-    if (reg_is_strictly_xmm(simd_reg)) {
-        return simd_reg - DR_REG_START_XMM + DR_REG_START_YMM;
-    } else if (reg_is_strictly_ymm(simd_reg)) {
-        return simd_reg;
-    } else if (reg_is_strictly_zmm(simd_reg)) {
-        return simd_reg - DR_REG_START_ZMM + DR_REG_START_YMM;
-    }
-    ASSERT(false, "Not a simd register.");
-    return DR_REG_INVALID;
+    return reg_resize_to_opsz(simd_reg, OPSZ_32);
 }
 
 static reg_id_t
 simd_reg_to_xmm(reg_id_t simd_reg)
 {
-    if (reg_is_strictly_xmm(simd_reg)) {
-        return simd_reg;
-    } else if (reg_is_strictly_ymm(simd_reg)) {
-        return simd_reg - DR_REG_START_YMM + DR_REG_START_XMM;
-    } else if (reg_is_strictly_zmm(simd_reg)) {
-        return simd_reg - DR_REG_START_ZMM + DR_REG_START_XMM;
-    }
-    ASSERT(false, "Not a simd register.");
-    return DR_REG_INVALID;
+    return reg_resize_to_opsz(simd_reg, OPSZ_16);
 }
 
 static bool

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -1532,24 +1532,6 @@ get_scatter_gather_info(instr_t *instr, scatter_gather_info_t *sg_info)
     sg_info->scale = opnd_get_scale(memopnd);
 }
 
-static reg_id_t
-simd_reg_to_zmm(reg_id_t simd_reg)
-{
-    return reg_resize_to_opsz(simd_reg, OPSZ_64);
-}
-
-static reg_id_t
-simd_reg_to_ymm(reg_id_t simd_reg)
-{
-    return reg_resize_to_opsz(simd_reg, OPSZ_32);
-}
-
-static reg_id_t
-simd_reg_to_xmm(reg_id_t simd_reg)
-{
-    return reg_resize_to_opsz(simd_reg, OPSZ_16);
-}
-
 static bool
 expand_gather_insert_scalar(void *drcontext, instrlist_t *bb, instr_t *sg_instr, int el,
                             scatter_gather_info_t *sg_info, reg_id_t simd_reg,
@@ -1558,8 +1540,8 @@ expand_gather_insert_scalar(void *drcontext, instrlist_t *bb, instr_t *sg_instr,
 {
     /* Used by both AVX2 and AVX-512. */
     ASSERT(instr_is_gather(sg_instr), "Internal error: only gather instructions.");
-    reg_id_t simd_reg_zmm = simd_reg_to_zmm(simd_reg);
-    reg_id_t simd_reg_ymm = simd_reg_to_ymm(simd_reg);
+    reg_id_t simd_reg_zmm = reg_resize_to_opsz(simd_reg, OPSZ_64);
+    reg_id_t simd_reg_ymm = reg_resize_to_opsz(simd_reg, OPSZ_32);
     uint scalar_value_bytes = opnd_size_in_bytes(sg_info->scalar_value_size);
     int scalarxmmimm = el * scalar_value_bytes / XMM_REG_SIZE;
     if (is_avx512) {
@@ -1667,8 +1649,8 @@ expand_scatter_gather_extract_scalar(void *drcontext, instrlist_t *bb, instr_t *
                                      reg_id_t scratch_reg, bool is_avx512,
                                      app_pc orig_app_pc)
 {
-    reg_id_t from_simd_reg_zmm = simd_reg_to_zmm(from_simd_reg);
-    reg_id_t from_simd_reg_ymm = simd_reg_to_ymm(from_simd_reg);
+    reg_id_t from_simd_reg_zmm = reg_resize_to_opsz(from_simd_reg, OPSZ_64);
+    reg_id_t from_simd_reg_ymm = reg_resize_to_opsz(from_simd_reg, OPSZ_32);
     int scalarxmmimm = el * scalar_bytes / XMM_REG_SIZE;
     if (is_avx512) {
         PREXL8(bb, sg_instr,
@@ -2257,10 +2239,11 @@ drx_expand_scatter_gather(void *drcontext, instrlist_t *bb, OUT bool *expanded)
     reg_id_t scratch_xmm;
     /* Search the instruction for an unused xmm register we will use as a temp. */
     for (scratch_xmm = DR_REG_START_XMM; scratch_xmm <= DR_REG_STOP_XMM; ++scratch_xmm) {
-        if ((sg_info.is_evex || scratch_xmm != simd_reg_to_xmm(sg_info.mask_reg)) &&
-            scratch_xmm != simd_reg_to_xmm(sg_info.index_reg) &&
+        if ((sg_info.is_evex ||
+             scratch_xmm != reg_resize_to_opsz(sg_info.mask_reg, OPSZ_16)) &&
+            scratch_xmm != reg_resize_to_opsz(sg_info.index_reg, OPSZ_16) &&
             /* redundant with scatter_src_reg */
-            scratch_xmm != simd_reg_to_xmm(sg_info.gather_dst_reg))
+            scratch_xmm != reg_resize_to_opsz(sg_info.gather_dst_reg, OPSZ_16))
             break;
     }
     /* FIXME i#2985: spill kTmp and xmmTmp. kTmp will always be k0, because it is never

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1289,6 +1289,7 @@ test_regs(void *dc)
     reg = reg_resize_to_opsz(DR_REG_XBP, OPSZ_2);
     ASSERT(reg == DR_REG_BP);
 
+#ifdef X86
     /* SIMD only XMM, OPSZ 16. */
     reg = reg_resize_to_opsz(DR_REG_XMM0, OPSZ_16);
     ASSERT(reg == DR_REG_XMM0);
@@ -1344,6 +1345,7 @@ test_regs(void *dc)
     ASSERT(reg != DR_REG_XMM0);
     reg = reg_resize_to_opsz(DR_REG_ZMM1, OPSZ_64);
     ASSERT(reg != DR_REG_XMM1);
+#endif
 }
 
 static void

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1319,7 +1319,6 @@ test_regs(void *dc)
 
     /* SIMD only ZMM, OPSZ 64. */
     reg = reg_resize_to_opsz(DR_REG_XMM0, OPSZ_64);
-    dr_fprintf(STDERR, "%d\n", reg);
     ASSERT(reg == DR_REG_ZMM0);
     reg = reg_resize_to_opsz(DR_REG_XMM1, OPSZ_64);
     ASSERT(reg == DR_REG_ZMM1);

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1343,7 +1343,7 @@ test_regs(void *dc)
     reg = reg_resize_to_opsz(DR_REG_ZMM0, OPSZ_64);
     ASSERT(reg != DR_REG_XMM0);
     reg = reg_resize_to_opsz(DR_REG_ZMM1, OPSZ_64);
-    ASSERT(reg == DR_REG_XMM1);
+    ASSERT(reg != DR_REG_XMM1);
 }
 
 static void

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1288,6 +1288,63 @@ test_regs(void *dc)
     ASSERT(reg == DR_REG_SP);
     reg = reg_resize_to_opsz(DR_REG_XBP, OPSZ_2);
     ASSERT(reg == DR_REG_BP);
+
+    /* SIMD only XMM, OPSZ 16. */
+    reg = reg_resize_to_opsz(DR_REG_XMM0, OPSZ_16);
+    ASSERT(reg == DR_REG_XMM0);
+    reg = reg_resize_to_opsz(DR_REG_XMM1, OPSZ_16);
+    ASSERT(reg == DR_REG_XMM1);
+    reg = reg_resize_to_opsz(DR_REG_YMM0, OPSZ_16);
+    ASSERT(reg == DR_REG_XMM0);
+    reg = reg_resize_to_opsz(DR_REG_YMM1, OPSZ_16);
+    ASSERT(reg == DR_REG_XMM1);
+    reg = reg_resize_to_opsz(DR_REG_ZMM0, OPSZ_16);
+    ASSERT(reg == DR_REG_XMM0);
+    reg = reg_resize_to_opsz(DR_REG_ZMM1, OPSZ_16);
+    ASSERT(reg == DR_REG_XMM1);
+
+    /* SIMD only YMM, OPSZ 32. */
+    reg = reg_resize_to_opsz(DR_REG_XMM0, OPSZ_32);
+    ASSERT(reg == DR_REG_YMM0);
+    reg = reg_resize_to_opsz(DR_REG_XMM1, OPSZ_32);
+    ASSERT(reg == DR_REG_YMM1);
+    reg = reg_resize_to_opsz(DR_REG_YMM0, OPSZ_32);
+    ASSERT(reg == DR_REG_YMM0);
+    reg = reg_resize_to_opsz(DR_REG_YMM1, OPSZ_32);
+    ASSERT(reg == DR_REG_YMM1);
+    reg = reg_resize_to_opsz(DR_REG_ZMM0, OPSZ_32);
+    ASSERT(reg == DR_REG_YMM0);
+    reg = reg_resize_to_opsz(DR_REG_ZMM1, OPSZ_32);
+    ASSERT(reg == DR_REG_YMM1);
+
+    /* SIMD only ZMM, OPSZ 64. */
+    reg = reg_resize_to_opsz(DR_REG_XMM0, OPSZ_64);
+    dr_fprintf(STDERR, "%d\n", reg);
+    ASSERT(reg == DR_REG_ZMM0);
+    reg = reg_resize_to_opsz(DR_REG_XMM1, OPSZ_64);
+    ASSERT(reg == DR_REG_ZMM1);
+    reg = reg_resize_to_opsz(DR_REG_YMM0, OPSZ_64);
+    ASSERT(reg == DR_REG_ZMM0);
+    reg = reg_resize_to_opsz(DR_REG_YMM1, OPSZ_64);
+    ASSERT(reg == DR_REG_ZMM1);
+    reg = reg_resize_to_opsz(DR_REG_ZMM0, OPSZ_64);
+    ASSERT(reg == DR_REG_ZMM0);
+    reg = reg_resize_to_opsz(DR_REG_ZMM1, OPSZ_64);
+    ASSERT(reg == DR_REG_ZMM1);
+
+    /* SIMD only ZMM, Negation, OPSZ 64. */
+    reg = reg_resize_to_opsz(DR_REG_XMM0, OPSZ_64);
+    ASSERT(reg != DR_REG_XMM0);
+    reg = reg_resize_to_opsz(DR_REG_XMM1, OPSZ_64);
+    ASSERT(reg != DR_REG_XMM1);
+    reg = reg_resize_to_opsz(DR_REG_YMM0, OPSZ_64);
+    ASSERT(reg != DR_REG_XMM0);
+    reg = reg_resize_to_opsz(DR_REG_YMM1, OPSZ_64);
+    ASSERT(reg != DR_REG_XMM1);
+    reg = reg_resize_to_opsz(DR_REG_ZMM0, OPSZ_64);
+    ASSERT(reg != DR_REG_XMM0);
+    reg = reg_resize_to_opsz(DR_REG_ZMM1, OPSZ_64);
+    ASSERT(reg == DR_REG_XMM1);
 }
 
 static void


### PR DESCRIPTION
Extends reg_resize_to_opsz to support SIMD resizing.

Issue: #3865 