### PR TITLE
i#3867: Extend reg_is_simd() to zmm.

### DIFF
--- a/core/arch/x86/instr.c
+++ b/core/arch/x86/instr.c
@@ -2083,7 +2083,8 @@ reg_is_segment(reg_id_t reg)
 bool
 reg_is_simd(reg_id_t reg)
 {
-    return reg_is_xmm(reg) /*includes ymm*/ || reg_is_mmx(reg);
+    return reg_is_strictly_xmm(reg) || reg_is_strictly_ymm(reg) ||
+        reg_is_strictly_zmm(reg) || reg_is_mmx(reg);
 }
 
 bool


### PR DESCRIPTION
Extends reg_is_simd to consider ZMM registers.

Fixes #3867