### PR TITLE
i#3605: Support 64-bit literals for droption bytesize_t

### DIFF
--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -584,9 +584,7 @@ droption_t<bytesize_t>::convert_from_string(const std::string s)
     std::string toparse = s;
     if (scale > 1)
         toparse = s.substr(0, s.size() - 1); // s.pop_back() only in C++11
-    // While the overall size is likely too large to be represented
-    // by a 32-bit integer, the prefix number is usually not.
-    int input = atoi(toparse.c_str());
+    long long input = atoll(toparse.c_str());
     if (input >= 0)
         value = (uint64_t)input * scale;
     else {

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2169,7 +2169,7 @@ if (CLIENT_INTERFACE)
     "" "" "")
 
   tobuild_ci(client.option_parse client-interface/option_parse.cpp
-    "-x;4;-y;quoted string;-z;first;-z;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-no_flag;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4"
+    "-x;4;-y;quoted string;-z;first;-z;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-no_flag;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4;-large_bytesize;9999999999"
     "" "")
   use_DynamoRIO_extension(client.option_parse.dll droption)
   set(client.option_parse_client_ops_islist ON)

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -78,7 +78,7 @@ static droption_t<twostring_t>
 static droption_t<bytesize_t>
     op_large_bytesize(DROPTION_SCOPE_CLIENT, "large_bytesize", DROPTION_FLAG_ACCUMULATE,
                 0, "Param that takes in a large bytesize value",
-                "Longer desc of pagam that takes in a large bytesize value");
+                "Longer desc of param that takes in a large bytesize value");
 
 static void
 test_argv(int argc, const char *argv[])

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -77,8 +77,8 @@ static droption_t<twostring_t>
                 "Longer desc of param that takes 2 and uses customized separator \"+\"");
 static droption_t<bytesize_t>
     op_large_bytesize(DROPTION_SCOPE_CLIENT, "large_bytesize", DROPTION_FLAG_ACCUMULATE,
-                0, "Param that takes in a large bytesize value",
-                "Longer desc of param that takes in a large bytesize value");
+                      0, "Param that takes in a large bytesize value",
+                      "Longer desc of param that takes in a large bytesize value");
 
 static void
 test_argv(int argc, const char *argv[])

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -75,11 +75,15 @@ static droption_t<twostring_t>
                 twostring_t("", ""),
                 "Param that takes 2 and uses customized separator \"+\"",
                 "Longer desc of param that takes 2 and uses customized separator \"+\"");
+static droption_t<bytesize_t>
+    op_large_bytesize(DROPTION_SCOPE_CLIENT, "large_bytesize", DROPTION_FLAG_ACCUMULATE,
+                0, "Param that takes in a large bytesize value",
+                "Longer desc of pagam that takes in a large bytesize value");
 
 static void
 test_argv(int argc, const char *argv[])
 {
-    ASSERT(argc == 32);
+    ASSERT(argc == 34);
     ASSERT(strcmp(argv[1], "-x") == 0);
     ASSERT(strcmp(argv[2], "4") == 0);
     ASSERT(strcmp(argv[3], "-y") == 0);
@@ -111,6 +115,8 @@ test_argv(int argc, const char *argv[])
     ASSERT(strcmp(argv[29], "-val_sep2") == 0);
     ASSERT(strcmp(argv[30], "v3") == 0);
     ASSERT(strcmp(argv[31], "v4") == 0);
+    ASSERT(strcmp(argv[32], "-large_bytesize") == 0);
+    ASSERT(strcmp(argv[33], "9999999999") == 0);
 }
 
 DR_EXPORT void
@@ -144,6 +150,7 @@ dr_client_main(client_id_t client_id, int argc, const char *argv[])
     dr_fprintf(STDERR, "param val_sep2 = |%s|,|%s|\n",
                op_val_sep2.get_value().first.c_str(),
                op_val_sep2.get_value().second.c_str());
+    dr_fprintf(STDERR, "param large_bytesize = %lld\n", op_large_bytesize.get_value());
     ASSERT(!op_foo.specified());
     ASSERT(!op_bar.specified());
 

--- a/suite/tests/client-interface/option_parse.expect
+++ b/suite/tests/client-interface/option_parse.expect
@@ -8,4 +8,5 @@ param sweep = |-front value -front2 value2|
 param takes2 = |1_of_4 3_of_4|,|2_of_4 4_of_4|
 param val_sep = |v1.1 v1.2+v2.1 v2.2|
 param val_sep2 = |v1+v3|,|v2+v4|
+param large_bytesize = 9999999999
 Hello, world!


### PR DESCRIPTION
Modifies convert_from_string() to read into a 64-bit value for the bytesize_t droptions.

Fixes #3605