### PR TITLE
i#3872: Adds instr_reads_from_exact_reg()

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -212,6 +212,8 @@ Further non-compatibility-affecting changes include:
  - Added the functions instr_is_gather() and instr_is_scatter().
  - Added the function drx_expand_scatter_gather().
  - Added the function dr_atomic_add64_return_sum().
+ - Added the function instr_reads_from_exact_reg() to test whether instructions
+   read from exact registers.
 
 **************************************************
 <hr>

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -1793,6 +1793,13 @@ DR_API
  * Assumes that \p reg is a DR_REG_ constant.
  * Returns true iff at least one of \p instr's source operands is
  * the same register (not enough to just overlap) as \p reg.
+ *
+ * For example, false is returned if the instruction \p instr is vmov [m], zmm0
+ * and the register being tested \p reg is \p DR_REG_XMM0.
+ *
+ * Registers used in memory operands, namely base, index and segmentation registers,
+ * are checked also by this routine. This also includes destination operands.
+ *
  * Which operands are considered to be accessed for conditionally executed
  * instructions are controlled by \p flags.
  */

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -1790,6 +1790,17 @@ instr_writes_to_exact_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t fl
 
 DR_API
 /**
+ * Assumes that \p reg is a DR_REG_ constant.
+ * Returns true iff at least one of \p instr's source operands is
+ * the same register (not enough to just overlap) as \p reg.
+ * Which operands are considered to be accessed for conditionally executed
+ * instructions are controlled by \p flags.
+ */
+bool
+instr_reads_from_exact_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t flags);
+
+DR_API
+/**
  * Replaces all instances of \p old_opnd in \p instr's source operands with
  * \p new_opnd (uses opnd_same() to detect sameness).
  */

--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -1832,7 +1832,7 @@ instr_reads_from_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t flags)
     return false;
 }
 
-/* in this func, it must be the exact same register, not a sub reg. ie. eax!=ax */
+/* In this func, it must be the exact same register, not a sub reg. ie. eax!=ax */
 bool
 instr_reads_from_exact_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t flags)
 {
@@ -1845,10 +1845,10 @@ instr_reads_from_exact_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t f
 
     for (i = 0; i < instr_num_srcs(instr); i++) {
         opnd = instr_get_src(instr, i);
-        if (opnd_is_reg(opnd) && (opnd_get_reg(opnd) == reg) &&
+        if (opnd_is_reg(opnd) && opnd_get_reg(opnd) == reg &&
             opnd_get_size(opnd) == reg_get_size(reg))
             return true;
-        else if (opnd_is_base_disp(opnd) && opnd_uses_reg(opnd, reg) &&
+        else if (opnd_is_base_disp(opnd) &&
                  (opnd_get_base(opnd) == reg || opnd_get_index(opnd) == reg ||
                   opnd_get_segment(opnd) == reg))
             return true;
@@ -1856,7 +1856,7 @@ instr_reads_from_exact_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t f
 
     for (i = 0; i < instr_num_dsts(instr); i++) {
         opnd = instr_get_dst(instr, i);
-        if (opnd_is_base_disp(opnd) && opnd_uses_reg(opnd, reg) &&
+        if (opnd_is_base_disp(opnd) &&
             (opnd_get_base(opnd) == reg || opnd_get_index(opnd) == reg ||
              opnd_get_segment(opnd) == reg))
             return true;
@@ -1883,7 +1883,7 @@ instr_writes_to_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t flags)
     return false;
 }
 
-/* in this func, it must be the exact same register, not a sub reg. ie. eax!=ax */
+/* In this func, it must be the exact same register, not a sub reg. ie. eax!=ax */
 bool
 instr_writes_to_exact_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t flags)
 {

--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -1843,6 +1843,12 @@ instr_reads_from_exact_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t f
         !instr_predicate_reads_srcs(instr_get_predicate(instr)))
         return false;
 
+#ifdef X86
+    /* special case */
+    if (instr_get_opcode(instr) == OP_nop_modrm)
+        return false;
+#endif
+
     for (i = 0; i < instr_num_srcs(instr); i++) {
         opnd = instr_get_src(instr, i);
         if (opnd_is_reg(opnd) && opnd_get_reg(opnd) == reg &&

--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -1832,6 +1832,39 @@ instr_reads_from_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t flags)
     return false;
 }
 
+/* in this func, it must be the exact same register, not a sub reg. ie. eax!=ax */
+bool
+instr_reads_from_exact_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t flags)
+{
+    int i;
+    opnd_t opnd;
+
+    if (!TEST(DR_QUERY_INCLUDE_COND_SRCS, flags) && instr_is_predicated(instr) &&
+        !instr_predicate_reads_srcs(instr_get_predicate(instr)))
+        return false;
+
+    for (i = 0; i < instr_num_srcs(instr); i++) {
+        opnd = instr_get_src(instr, i);
+        if (opnd_is_reg(opnd) && (opnd_get_reg(opnd) == reg) &&
+            opnd_get_size(opnd) == reg_get_size(reg))
+            return true;
+        else if (opnd_is_base_disp(opnd) && opnd_uses_reg(opnd, reg) &&
+                 (opnd_get_base(opnd) == reg || opnd_get_index(opnd) == reg ||
+                  opnd_get_segment(opnd) == reg))
+            return true;
+    }
+
+    for (i = 0; i < instr_num_dsts(instr); i++) {
+        opnd = instr_get_dst(instr, i);
+        if (opnd_is_base_disp(opnd) && opnd_uses_reg(opnd, reg) &&
+            (opnd_get_base(opnd) == reg || opnd_get_index(opnd) == reg ||
+             opnd_get_segment(opnd) == reg))
+            return true;
+    }
+
+    return false;
+}
+
 /* this checks sub-registers */
 bool
 instr_writes_to_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t flags)
@@ -1865,7 +1898,7 @@ instr_writes_to_exact_reg(instr_t *instr, reg_id_t reg, dr_opnd_query_flags_t fl
         if (opnd_is_reg(opnd) &&
             (opnd_get_reg(opnd) == reg)
             /* for case like OP_movt on ARM and SIMD regs on X86,
-             * partial reg writen with full reg name in opnd
+             * partial reg written with full reg name in opnd
              */
             && opnd_get_size(opnd) == reg_get_size(reg))
             return true;

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -2001,6 +2001,70 @@ test_stack_pointer_size(void *dc)
            0);
 }
 
+static void
+test_reg_exact_reads(void *dc)
+{
+    instr_t *instr = INSTR_CREATE_mov_ld(dc, OPND_CREATE_MEMPTR(DR_REG_XAX, 5),
+                                         opnd_create_reg(DR_REG_XBX));
+
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XBX, DR_QUERY_DEFAULT));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XBX, DR_QUERY_INCLUDE_ALL));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XBX, DR_QUERY_INCLUDE_COND_DSTS));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XBX, 0));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XAX, DR_QUERY_DEFAULT));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XAX, DR_QUERY_INCLUDE_ALL));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XAX, DR_QUERY_INCLUDE_COND_DSTS));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XAX, 0));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_XCX, DR_QUERY_DEFAULT));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_XCX, DR_QUERY_INCLUDE_ALL));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_XCX, DR_QUERY_INCLUDE_COND_DSTS));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_XCX, 0));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_AX, DR_QUERY_DEFAULT));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_AX, DR_QUERY_INCLUDE_ALL));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_AX, DR_QUERY_INCLUDE_COND_DSTS));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_AX, 0));
+
+    instr_reset(dc, instr);
+    instr = INSTR_CREATE_mov_ld(dc, OPND_CREATE_MEM16(DR_REG_XAX, 5),
+                                opnd_create_reg(DR_REG_BX));
+
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_XBX, DR_QUERY_DEFAULT));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_XBX, DR_QUERY_INCLUDE_ALL));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_XBX, DR_QUERY_INCLUDE_COND_DSTS));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_XBX, 0));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XAX, DR_QUERY_DEFAULT));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XAX, DR_QUERY_INCLUDE_ALL));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XAX, DR_QUERY_INCLUDE_COND_DSTS));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XAX, 0));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_XCX, DR_QUERY_DEFAULT));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_XCX, DR_QUERY_INCLUDE_ALL));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_XCX, DR_QUERY_INCLUDE_COND_DSTS));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_XCX, 0));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_BX, DR_QUERY_DEFAULT));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_BX, DR_QUERY_INCLUDE_ALL));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_BX, DR_QUERY_INCLUDE_COND_DSTS));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_BX, 0));
+
+    instr_reset(dc, instr);
+    instr =
+        INSTR_CREATE_pxor(dc, opnd_create_reg(DR_REG_XMM0), opnd_create_reg(DR_REG_XMM1));
+
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XMM0, DR_QUERY_DEFAULT));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XMM0, DR_QUERY_INCLUDE_ALL));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XMM0, DR_QUERY_INCLUDE_COND_DSTS));
+    ASSERT(instr_reads_from_exact_reg(instr, DR_REG_XMM0, 0));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_YMM0, DR_QUERY_DEFAULT));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_YMM0, DR_QUERY_INCLUDE_ALL));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_YMM0, DR_QUERY_INCLUDE_COND_DSTS));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_YMM0, 0));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_ZMM0, DR_QUERY_DEFAULT));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_ZMM0, DR_QUERY_INCLUDE_ALL));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_ZMM0, DR_QUERY_INCLUDE_COND_DSTS));
+    ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_ZMM0, 0));
+
+    instr_destroy(dc, instr);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -2067,6 +2131,8 @@ main(int argc, char *argv[])
     test_xinst_create(dcontext);
 
     test_stack_pointer_size(dcontext);
+
+    test_reg_exact_reads(dcontext);
 
 #ifndef STANDALONE_DECODER /* speed up compilation */
     test_all_opcodes_2_avx512_vex(dcontext);


### PR DESCRIPTION
Introduces a new function, namely instr_reads_from_exact_reg(), to check whether or not an instruction reads directly and exactly from a given register. 

Fixes #3872