### PR TITLE
i#1718: Remove CMP0054 OLD behavior policy.

### DIFF
--- a/make/policies.cmake
+++ b/make/policies.cmake
@@ -28,9 +28,6 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-# XXX i#1718: update our code to satisfy the changes in 3.x
-cmake_policy(SET CMP0054 OLD)
-
 # XXX i#1375: if we make 2.8.12 the minimum we can remove the @rpath
 # Mac stuff and this policy, right?
 cmake_policy(SET CMP0042 OLD)


### PR DESCRIPTION
Our cmake code was manually inspected, and I couldn't find a single instance where we
depend on cmake implicitly expanding a quoted variable in an 'if' statement. Therefore,
we're removing this policy.

Fixes #1718