### PR TITLE
i#3886: Compute alignment of MachO segments and do not page align

### DIFF
--- a/core/unix/module_private.h
+++ b/core/unix/module_private.h
@@ -104,10 +104,12 @@ extern bool disallow_unsafe_static_calls;
 #    ifdef X64
 typedef struct mach_header_64 mach_header_t;
 typedef struct segment_command_64 segment_command_t;
+typedef struct section_64 section_t;
 typedef struct nlist_64 nlist_t;
 #    else
 typedef struct mach_header mach_header_t;
 typedef struct segment_command segment_command_t;
+typedef struct section section_t;
 typedef struct nlist nlist_t;
 #    endif
 bool


### PR DESCRIPTION
We were previously blindly page-aligning MachO segments, yet on
Catalina libraries have sub-page alignment and DR fails due to library
overlap.  We fix this by computing the alignment from the section
alignments, but in the end I'm just leaving the given addresses since
they're already aligned.  We also relax a curiosity about all segments
having the same alignment to only apply to ELF.

Fixes #3886