### PR TITLE
Fix linux.sigcontext when running with AVX-512.

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3411,6 +3411,13 @@ if (UNIX)
     if (proc_supports_avx512)
       append_property_string(TARGET linux.sigcontext COMPILE_FLAGS "${CFLAGS_AVX512}")
       set(linux.sigcontext_runavx512 1)
+      if (CLANG)
+        append_property_string(TARGET linux.sigcontext COMPILE_FLAGS
+          "-mllvm -x86-use-vzeroupper=0")
+      else ()
+        append_property_string(TARGET linux.sigcontext COMPILE_FLAGS
+          "-mno-vzeroupper")
+      endif ()
     elseif (proc_supports_avx)
       append_property_string(TARGET linux.sigcontext COMPILE_FLAGS "${CFLAGS_AVX}")
       set(linux.sigcontext_runavx 1)


### PR DESCRIPTION
Fixes incorrect buffer sizes in the test.
Adds clobbers making the test more robust.
Adds no vzeroupper flag, necessary on some platforms that are adding the instruction.

Even with above, the test is not bullet proof and could be broken by an existing or
future toolchain. Ideally, some parts should get rewritten in assembly.