### PR TITLE
i#1375: Use modern CMake OSX rpath support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,11 +241,6 @@ else(CMAKE_C_SIZEOF_DATA_PTR EQUAL 8)
   set(X64 OFF)
 endif (CMAKE_C_SIZEOF_DATA_PTR EQUAL 8)
 
-if (APPLE AND X64)
-  # XXX #1979: 64-bit OSX is not supported.
-  message(WARNING "64-bit Mac OSX is not supported")
-endif ()
-
 option(VMKERNEL "target VMkernel (not officially supported yet)")
 
 # high-level configurations
@@ -401,6 +396,11 @@ endforeach ()
 foreach (var CMAKE_C_FLAGS;CMAKE_CXX_FLAGS)
   set(${var} " ") # if "" defaults come back
 endforeach ()
+
+if (APPLE)
+  # Enable @rpath for all shared library install names.
+  set(CMAKE_MACOSX_RPATH 1)
+endif ()
 
 ##################################################
 # resources when packaging

--- a/api/samples/CMakeLists.txt
+++ b/api/samples/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2019 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -55,11 +55,10 @@ endif ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
 
 project(DynamoRIO_samples)
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "3.0" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "3.0")
-  # XXX i#1375: if we make 2.8.12 the minimum we can remove the @rpath
-  # Mac stuff and this policy, right?
-  cmake_policy(SET CMP0042 OLD)
+if ("${CMAKE_VERSION}" VERSION_EQUAL "3.9" OR
+   "${CMAKE_VERSION}" VERSION_GREATER "3.9")
+  # i#1375: We are ok w/ the new policy of SKIP_BUILD_RPATH not affecting install names.
+  cmake_policy(SET CMP0068 NEW)
 endif ()
 
 set(output_dir "${PROJECT_BINARY_DIR}/bin")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -526,13 +526,7 @@ function (configure_core_lib target)
     endif (APPLE)
 
     set_target_properties(${target} PROPERTIES
-      LINK_FLAGS "${dynamorio_link_flags}"
-      # XXX i#1375: if we move to cmake 2.8.12 we can use its built-in
-      # rpath: until then we add @rpath ourselves.  The downside is that
-      # everyone who uses this lib has to have the rpath set and can't
-      # just copy the lib to the local dir (should we document that?
-      # DynamoRIO_RPATH is only on for standalone by default).
-      INSTALL_NAME_DIR "@rpath")
+      LINK_FLAGS "${dynamorio_link_flags}")
 
     # XXX: FRAGMENT_SIZES_STUDY needs libm for sqrt but it's not supported by default
 

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -687,7 +687,7 @@ DYNAMIC_OPTION(bool, pause_via_loop,
 
     /* For MacOS, set to 0 to disable the check */
     OPTION_DEFAULT(uint, max_supported_os_version,
-        IF_WINDOWS_ELSE(105, IF_MACOS_ELSE(18, 0)),
+        IF_WINDOWS_ELSE(105, IF_MACOS_ELSE(19, 0)),
         /* case 447, defaults to supporting NT, 2000, XP, 2003, and Vista.
          * Windows 7 added with i#218
          * Windows 8 added with i#565

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -823,7 +823,7 @@ get_uname(void)
      * crash with no output: I'd rather have two messages than silent crashing.
      */
     if (DYNAMO_OPTION(max_supported_os_version) != 0) { /* 0 disables */
-        /* We only support OSX 10.7.5 - 10.9.1.  That means kernels 11.x-13.x. */
+        /* We only support OSX 10.7.5+.  That means kernels 11.x+. */
 #    define MIN_DARWIN_VERSION_SUPPORTED 11
         int kernel_major;
         if (sscanf(uinfo.release, "%d", &kernel_major) != 1 ||

--- a/make/policies.cmake
+++ b/make/policies.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2014-2016 Google, Inc.    All rights reserved.
+# Copyright (c) 2014-2019 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -28,13 +28,15 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-# XXX i#1375: if we make 2.8.12 the minimum we can remove the @rpath
-# Mac stuff and this policy, right?
-cmake_policy(SET CMP0042 OLD)
-
 # XXX DrMem-i#1481: dynamorio is using EXPORT_LINK_INTERFACE_LIBRARIES flag for
 # compatibility.
 cmake_policy(SET CMP0022 NEW)
 
 # Recognize literals in if statements
 cmake_policy(SET CMP0012 NEW)
+
+if ("${CMAKE_VERSION}" VERSION_EQUAL "3.9" OR
+   "${CMAKE_VERSION}" VERSION_GREATER "3.9")
+  # i#1375: We are ok w/ the new policy of SKIP_BUILD_RPATH not affecting install names.
+  cmake_policy(SET CMP0068 NEW)
+endif ()

--- a/make/utils_exposed.cmake
+++ b/make/utils_exposed.cmake
@@ -99,14 +99,15 @@ function (DynamoRIO_add_rel_rpaths target)
 
       # Append the new rpath element if it isn't there already.
       if (APPLE)
-        # @loader_path seems to work for executables too
+        # 10.5+ supports @rpath but I'm having trouble getting it to work properly,
+        # so I'm sticking with @loader_path for now, which works for executables too.
         set(new_lflag "-Wl,-rpath,'@loader_path/${relpath}'")
         get_target_property(lflags ${target} LINK_FLAGS)
         # We match the trailing ' to avoid matching a parent dir only
         if (NOT lflags MATCHES "@loader_path/${relpath}'")
           _DR_append_property_string(TARGET ${target} LINK_FLAGS "${new_lflag}")
         endif ()
-      else (APPLE)
+      else ()
         set(new_lflag "-Wl,-rpath='$ORIGIN/${relpath}'")
         get_target_property(lflags ${target} LINK_FLAGS)
         if (NOT lflags MATCHES "\\$ORIGIN/${relpath}")


### PR DESCRIPTION
Removes the CMP0042 policy setting of OLD which is now deprecated.
Sets CMAKE_MACOSX_RPATH at the top level.
Sets CMP0068 to NEW since we comply with the changes there.
Removes the old INSTALL_NAME_DIR setting on libdynamorio.

I tried using @rpath or $ORIGIN for Mac explicit rpaths but both
failed (@rpath is supposed to work) so I left @loader_path in place.

Cleans up some other OSX pieces such as the warning about 64-bit not
being supported, and the max kernel version.

Fixes #1375