### PR TITLE
Replace using hardcoded names with API.

### DIFF
--- a/suite/tests/client-interface/cleancall-opt-1.dll.c
+++ b/suite/tests/client-interface/cleancall-opt-1.dll.c
@@ -35,20 +35,6 @@
 
 #include "dr_api.h"
 
-#ifdef __AVX512F__
-#    ifdef WINDOWS
-#        define BINARY_NAME "client.avx512cleancall-opt-1.exe"
-#    else
-#        define BINARY_NAME "client.avx512cleancall-opt-1"
-#    endif
-#else
-#    ifdef WINDOWS
-#        define BINARY_NAME "client.cleancall-opt-1.exe"
-#    else
-#        define BINARY_NAME "client.cleancall-opt-1"
-#    endif
-#endif
-
 /* List of instrumentation functions. */
 #define FUNCTIONS()             \
     FUNCTION(empty)             \

--- a/suite/tests/client-interface/cleancall-opt-shared.h
+++ b/suite/tests/client-interface/cleancall-opt-shared.h
@@ -147,7 +147,8 @@ lookup_pcs(void)
     module_data_t *exe;
     int i;
 
-    exe = dr_lookup_module_by_name(BINARY_NAME);
+    exe = dr_lookup_module_by_name(dr_get_application_name());
+    DR_ASSERT_MSG(exe != NULL, "Could not find application binary name in modules!");
     for (i = 0; i < N_FUNCS; i++) {
         app_pc func_pc = (app_pc)dr_get_proc_address(exe->handle, func_names[i]);
         DR_ASSERT_MSG(func_pc != NULL,

--- a/suite/tests/client-interface/inline.dll.c
+++ b/suite/tests/client-interface/inline.dll.c
@@ -36,12 +36,6 @@
 #include "dr_api.h"
 #include "client_tools.h"
 
-#ifdef WINDOWS
-#    define BINARY_NAME "client.inline.exe"
-#else
-#    define BINARY_NAME "client.inline"
-#endif
-
 /* List of instrumentation functions. */
 #ifdef X86
 #    define FUNCTIONS()             \


### PR DESCRIPTION
Changes client.avx512cleancall-opt-1, client.cleancall-opt-1, and client.inline tests
to using instrumentation API to retrieve the binary name instead of hardcoding it.

Adds a minor assertion in case name is not found, replacing it with a crash.