### PR TITLE
i#3900: Add synthetic segment for VDSO 2nd page

### DIFF
--- a/core/unix/module.c
+++ b/core/unix/module.c
@@ -473,6 +473,9 @@ module_add_segment_data(OUT os_module_data_t *out_data, uint num_segments /*hint
                         size_t alignment, bool shared, uint64 offset)
 {
     uint seg, i;
+    LOG(GLOBAL, LOG_INTERP | LOG_VMAREAS, 3, "%s: #=%d " PFX "-" PFX " 0x%x\n",
+        __FUNCTION__, out_data->num_segments, segment_start, segment_start + segment_size,
+        segment_prot);
     if (out_data->alignment == 0) {
         out_data->alignment = alignment;
     } else {

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -338,7 +338,7 @@ module_fill_os_data(ELF_PROGRAM_HEADER_TYPE *prog_hdr, /* PT_DYNAMIC entry */
  * If out_data != NULL, fills in the dynamic section fields and adds
  * entries to the module list vector: so the caller must be
  * os_module_area_init() if out_data != NULL!
- * Optionally returns the first segment bounds, the max segemnt end, and the soname.
+ * Optionally returns the first segment bounds, the max segment end, and the soname.
  */
 bool
 module_walk_program_headers(app_pc base, size_t view_size, bool at_map, bool dyn_reloc,


### PR DESCRIPTION
Some VDSO instances have their only segment happening to fit on one
page, with just section headers and non-loaded sections on the second
page.  Since those non-loaded sections are still loaded because VDSO
is placed completely in memory, this causes some confusion with parts
of DR that expect the mapping end to equal the end of the final
segment.  Our solution is to add a synthetic segment for the rest of
the mapping.  It's possible this will cause confusion of its own, but
it seems the least bad thing to do.

Fixes #3900