### PR TITLE
More test robustness fixes.

### DIFF
--- a/suite/tests/client-interface/cleancall.c
+++ b/suite/tests/client-interface/cleancall.c
@@ -112,7 +112,9 @@ main(int argc, char *argv[])
 #endif
 
 /* Each test in cleancall.dll.c crashes at the end */
-#pragma nounroll
+#ifdef UNIX
+#    pragma nounroll
+#endif
     for (j = 0; j < 5; j++) {
         i = SIGSETJMP(mark);
         if (i == 0) {

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -94,7 +94,7 @@ my_setjmp(sigjmp_buf env)
 }
 
 static void
-signal_handler(int sig, siginfo_t *siginfo)
+signal_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
 {
     if (sig == SIGILL) {
         count++;
@@ -365,7 +365,7 @@ GLOBAL_LABEL(FUNCNAME:)
 #endif
         mov  ecx, 0
         mov  edx, 0
-        RAW(0f) RAW(01) RAW(c8) /* monitor */
+        RAW(0f) RAW(01) RAW(c8) /* monitor. %rax from ARG1 above is live-in */
         RAW(0f) RAW(01) RAW(c9) /* mwait */
         /* we want failure on sse3 machine, to have constant output
          * (this will produce "Invalid opcode encountered" warning) */

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -94,7 +94,7 @@ my_setjmp(sigjmp_buf env)
 }
 
 static void
-signal_handler(int sig)
+signal_handler(int sig, siginfo_t *siginfo)
 {
     if (sig == SIGILL) {
         count++;
@@ -363,7 +363,6 @@ GLOBAL_LABEL(FUNCNAME:)
         RAW(41) RAW(0f) RAW(12) RAW(f4) /* i#319: movlhps %xmm12, xmm6 */
         RAW(41) RAW(0f) RAW(16) RAW(f4) /* i#319: movhlps %xmm12, xmm6 */
 #endif
-        mov  eax, 0
         mov  ecx, 0
         mov  edx, 0
         RAW(0f) RAW(01) RAW(c8) /* monitor */


### PR DESCRIPTION
client.cleancall: Prevent foo() from being optimized away, which was observed with new
toolchains. This is more a bandaid than a fix, and we should re-write this test into
using clean assembler instead. Furthermore, adds a pragma to prevent loop unrolling
that caused the test to break on such systems.

common.decode: On some systems, the monitor instruction is enabled and does not cause
an UD fault. This change here keeps the eax address valid so the monitor instruction will not
throw an GP exception.