### PR TITLE
i#3898: Added Alias to MCXT_NUM_SIMD_SLOTS

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -216,8 +216,8 @@ Further non-compatibility-affecting changes include:
    read from exact registers.
  - Added the function reg_is_vector_simd() to test whether registers are
    either XMM, YMM or ZMM, excluding any MMX register checks.
- - Added DR_NUM_SIMD_VECTOR_REGS defintion to easily get the number of supported
-   SIMD vectors.
+ - Added DR_NUM_SIMD_VECTOR_REGS as an alias to MCXT_NUM_SIMD_SLOTS in order
+   to get the static number of supported SIMD vectors.
 
 **************************************************
 <hr>

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -216,7 +216,7 @@ Further non-compatibility-affecting changes include:
    read from exact registers.
  - Added the function reg_is_vector_simd() to test whether registers are
    either XMM, YMM or ZMM, excluding any MMX register checks.
- - Added DR_NUM_SIMD_VECTOR_REGS defintion to easily get the number of SIMD
+ - Added DR_NUM_SIMD_VECTOR_REGS defintion to easily get the number of supported
    SIMD vectors.
 
 **************************************************

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -216,6 +216,8 @@ Further non-compatibility-affecting changes include:
    read from exact registers.
  - Added the function reg_is_vector_simd() to test whether registers are
    either XMM, YMM or ZMM, excluding any MMX register checks.
+ - Added DR_NUM_SIMD_VECTOR_REGS defintion to easily get the number of SIMD
+   SIMD vectors.
 
 **************************************************
 <hr>

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -910,6 +910,8 @@ extern const reg_id_t dr_reg_fixer[];
 #    else
 #        define DR_REG_STOP_GPR DR_REG_XDI /**< End of general register enum values */
 #    endif
+/** Number of SIMD vector registers */
+#    define DR_NUM_SIMD_VECTOR_REGS MCXT_NUM_SIMD_SLOTS
 /** Number of general registers */
 #    define DR_NUM_GPR_REGS (DR_REG_STOP_GPR - DR_REG_START_GPR + 1)
 #    define DR_REG_START_64 \

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -910,8 +910,6 @@ extern const reg_id_t dr_reg_fixer[];
 #    else
 #        define DR_REG_STOP_GPR DR_REG_XDI /**< End of general register enum values */
 #    endif
-/** Number of SIMD vector registers */
-#    define DR_NUM_SIMD_VECTOR_REGS MCXT_NUM_SIMD_SLOTS
 /** Number of general registers */
 #    define DR_NUM_GPR_REGS (DR_REG_STOP_GPR - DR_REG_START_GPR + 1)
 #    define DR_REG_START_64 \
@@ -943,6 +941,8 @@ extern const reg_id_t dr_reg_fixer[];
         DR_REG_DIL /**< Stop of 8-bit x64-only register enum values */
 #    define DR_REG_START_MMX DR_REG_MM0   /**< Start of mmx register enum values */
 #    define DR_REG_STOP_MMX DR_REG_MM7    /**< End of mmx register enum values */
+/** Number of SIMD vector registers */
+#    define DR_NUM_SIMD_VECTOR_REGS MCXT_NUM_SIMD_SLOTS
 #    define DR_REG_START_XMM DR_REG_XMM0  /**< Start of sse xmm register enum values */
 #    define DR_REG_STOP_XMM DR_REG_XMM31  /**< End of sse xmm register enum values */
 #    define DR_REG_START_YMM DR_REG_YMM0  /**< Start of ymm register enum values */

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -939,8 +939,8 @@ extern const reg_id_t dr_reg_fixer[];
         DR_REG_SPL /**< Start of 8-bit x64-only register enum values*/
 #    define DR_REG_STOP_x64_8 \
         DR_REG_DIL /**< Stop of 8-bit x64-only register enum values */
-#    define DR_REG_START_MMX DR_REG_MM0   /**< Start of mmx register enum values */
-#    define DR_REG_STOP_MMX DR_REG_MM7    /**< End of mmx register enum values */
+#    define DR_REG_START_MMX DR_REG_MM0 /**< Start of mmx register enum values */
+#    define DR_REG_STOP_MMX DR_REG_MM7  /**< End of mmx register enum values */
 /** Number of SIMD vector registers */
 #    define DR_NUM_SIMD_VECTOR_REGS MCXT_NUM_SIMD_SLOTS
 #    define DR_REG_START_XMM DR_REG_XMM0  /**< Start of sse xmm register enum values */

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -848,6 +848,9 @@ enum {
     DR_REG_XSP = DR_REG_SP,
 #    endif
 
+/** Number of SIMD vector registers */
+#    define DR_NUM_SIMD_VECTOR_REGS MCXT_NUM_SIMD_SLOTS
+
 #endif /* X86/ARM */
 };
 
@@ -939,10 +942,8 @@ extern const reg_id_t dr_reg_fixer[];
         DR_REG_SPL /**< Start of 8-bit x64-only register enum values*/
 #    define DR_REG_STOP_x64_8 \
         DR_REG_DIL /**< Stop of 8-bit x64-only register enum values */
-#    define DR_REG_START_MMX DR_REG_MM0 /**< Start of mmx register enum values */
-#    define DR_REG_STOP_MMX DR_REG_MM7  /**< End of mmx register enum values */
-/** Number of SIMD vector registers */
-#    define DR_NUM_SIMD_VECTOR_REGS MCXT_NUM_SIMD_SLOTS
+#    define DR_REG_START_MMX DR_REG_MM0   /**< Start of mmx register enum values */
+#    define DR_REG_STOP_MMX DR_REG_MM7    /**< End of mmx register enum values */
 #    define DR_REG_START_XMM DR_REG_XMM0  /**< Start of sse xmm register enum values */
 #    define DR_REG_STOP_XMM DR_REG_XMM31  /**< End of sse xmm register enum values */
 #    define DR_REG_START_YMM DR_REG_YMM0  /**< Start of ymm register enum values */


### PR DESCRIPTION
Defines DR_NUM_SIMD_VECTOR_REGS as an alias to MCXT_NUM_SIMD_SLOTS for better code clarity.

Note that the dynamic variant, proc_num_simd_registers(), should be used instead whenever possible.

Fixes #3898 