### PR TITLE
i#3906: Fixes bad placement of  DR_NUM_SIMD_VECTOR_REGS

### DIFF
--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -848,11 +848,11 @@ enum {
     DR_REG_XSP = DR_REG_SP,
 #    endif
 
-/** Number of SIMD vector registers */
-#    define DR_NUM_SIMD_VECTOR_REGS MCXT_NUM_SIMD_SLOTS
-
 #endif /* X86/ARM */
 };
+
+/** Number of SIMD vector registers */
+#define DR_NUM_SIMD_VECTOR_REGS MCXT_NUM_SIMD_SLOTS
 
 /* we avoid typedef-ing the enum, as its storage size is compiler-specific */
 typedef ushort reg_id_t; /**< The type of a DR_REG_ enum value. */


### PR DESCRIPTION
Fixes bad placement of DR_NUM_SIMD_VECTOR_REGS to also include Intel (making it visible to all architectures).

Fixes #3906.