### PR TITLE
Further test robustness fixes.

### DIFF
--- a/suite/tests/client-interface/cleancall-opt-1.c
+++ b/suite/tests/client-interface/cleancall-opt-1.c
@@ -31,6 +31,8 @@
  * DAMAGE.
  */
 
+#include "tools.h"
+
 /* Export instrumented functions so we can easily find them in client.  */
 #ifdef WINDOWS
 #    define EXPORT __declspec(dllexport)
@@ -50,9 +52,11 @@
     LAST_FUNCTION()
 
 /* Definitions for every function. */
-#define FUNCTION(FUNCNAME)     \
-    EXPORT void FUNCNAME(void) \
-    {                          \
+volatile int val;
+#define FUNCTION(FUNCNAME)              \
+    EXPORT NOINLINE void FUNCNAME(void) \
+    {                                   \
+        val = 4;                        \
     }
 #define LAST_FUNCTION()
 FUNCTIONS()

--- a/suite/tests/client-interface/inline.c
+++ b/suite/tests/client-interface/inline.c
@@ -32,6 +32,7 @@
  */
 
 #include "configure.h"
+#include "tools.h"
 
 /* Export instrumented functions so we can easily find them in client.  */
 #ifdef WINDOWS
@@ -65,9 +66,11 @@
 #endif
 
 /* Definitions for every function. */
-#define FUNCTION(FUNCNAME)     \
-    EXPORT void FUNCNAME(void) \
-    {                          \
+volatile int val;
+#define FUNCTION(FUNCNAME)              \
+    EXPORT NOINLINE void FUNCNAME(void) \
+    {                                   \
+        val = 4;                        \
     }
 #define LAST_FUNCTION()
 FUNCTIONS()
@@ -77,7 +80,7 @@ FUNCTIONS()
 /* For bbcount, do arithmetic to clobber flags so the flag saving optimization
  * kicks in.
  */
-EXPORT void
+EXPORT NOINLINE void
 bbcount(void)
 {
     static int count;


### PR DESCRIPTION
client.cleancall-opt-1, client.inline: Prevent test functions from being optimized away
and from getting inlined.