### PR TITLE
i#3844 extend drreg support: Add raw read/write TLS slot convenient methods.

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -219,6 +219,7 @@ Further non-compatibility-affecting changes include:
    either XMM, YMM or ZMM, excluding any MMX register checks.
  - Added DR_NUM_SIMD_VECTOR_REGS as an alias to MCXT_NUM_SIMD_SLOTS in order
    to get the static number of supported SIMD vectors.
+ - Added dr_raw_read_tls_slot() and dr_raw_write_tls_slot().
 
 **************************************************
 <hr>

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -4882,6 +4882,20 @@ dr_raw_tls_cfree(uint offset, uint num_slots)
 }
 
 DR_API
+void
+dr_raw_write_tls_slot(reg_id_t *tls_register, ushort offset, void *value)
+{
+    d_r_set_tls(offset, value);
+}
+
+DR_API
+void *
+dr_raw_read_tls_slot(reg_id_t *tls_register, ushort offset)
+{
+    return d_r_get_tls(offset);
+}
+
+DR_API
 opnd_t
 dr_raw_tls_opnd(void *drcontext, reg_id_t tls_register, uint tls_offs)
 {

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -4553,6 +4553,22 @@ DR_API
 bool
 dr_raw_tls_cfree(uint offset, uint num_slots);
 
+/**
+ * Provides raw access to offset \p offset from TLS base \p tls_register
+ * and writes value \p value.
+ */
+DR_API
+void
+dr_raw_write_tls_slot(reg_id_t *tls_register, ushort offset, void *value);
+
+/**
+ * Provides raw access to offset \p offset from TLS base \p tls_register.
+ * Returns the slot's value.
+ */
+DR_API
+void *
+dr_raw_read_tls_slot(reg_id_t *tls_register, ushort offset);
+
 DR_API
 /**
  * Returns an operand that refers to the raw TLS slot with offset \p


### PR DESCRIPTION
Adds the functions dr_raw_read_tls_slot() and dr_raw_write_tls_slot(), so extensions or
clients have API to access raw slots instead of having to fetch the TLS base and to linearize
the address.

Issue: #3844