### PR TITLE
i#3906: Fix DR_NUM_SIMD_VECTOR_REGS to reflect the architectural number of registers.

### DIFF
--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -843,9 +843,11 @@ enum {
 
     DR_NUM_GPR_REGS = DR_REG_STOP_GPR - DR_REG_START_GPR + 1,
 #    ifdef AARCH64
+    /* XXX: may need more distinct names for AArch64, like SVE, Neon etc. */
     DR_NUM_SIMD_VECTOR_REGS = DR_REG_Z31 - DR_REG_Z0 + 1,
 #    else
-    DR_NUM_SIMD_VECTOR_REGS = DR_REG_Q31 - DR_REG_Q0 + 1,
+    /* XXX: may need more distinct names for ARM types of SIMD registers. */
+    DR_NUM_SIMD_VECTOR_REGS = DR_REG_Q15 - DR_REG_Q0 + 1,
 #    endif
 
 #    ifndef AARCH64

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -843,10 +843,11 @@ enum {
 
     DR_NUM_GPR_REGS = DR_REG_STOP_GPR - DR_REG_START_GPR + 1,
 #    ifdef AARCH64
-    /* XXX: may need more distinct names for AArch64, like SVE, Neon etc. */
     DR_NUM_SIMD_VECTOR_REGS = DR_REG_Z31 - DR_REG_Z0 + 1,
 #    else
-    /* XXX: may need more distinct names for ARM types of SIMD registers. */
+    /* XXX: maybe want more distinct names for whether we are counting 64-bit D or 32-bit
+     * S registers.
+     */
     DR_NUM_SIMD_VECTOR_REGS = DR_REG_Q15 - DR_REG_Q0 + 1,
 #    endif
 

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -845,7 +845,7 @@ enum {
 #    ifdef AARCH64
     DR_NUM_SIMD_VECTOR_REGS = DR_REG_Z31 - DR_REG_Z0 + 1,
 #    else
-    /* XXX: maybe want more distinct names for whether we are counting 64-bit D or 32-bit
+    /* XXX: maybe we want more distinct names that provide counts for 64-bit D or 32-bit
      * S registers.
      */
     DR_NUM_SIMD_VECTOR_REGS = DR_REG_Q15 - DR_REG_Q0 + 1,

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -842,7 +842,11 @@ enum {
 #    endif
 
     DR_NUM_GPR_REGS = DR_REG_STOP_GPR - DR_REG_START_GPR + 1,
+#    ifdef AARCH64
     DR_NUM_SIMD_VECTOR_REGS = DR_REG_Z31 - DR_REG_Z0 + 1,
+#    else
+    DR_NUM_SIMD_VECTOR_REGS = 0,
+#    endif
 
 #    ifndef AARCH64
     /** Platform-independent way to refer to stack pointer. */

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -913,6 +913,7 @@ extern const reg_id_t dr_reg_fixer[];
 #    endif
 /** Number of general registers */
 #    define DR_NUM_GPR_REGS (DR_REG_STOP_GPR - DR_REG_START_GPR + 1)
+/** Number of SIMD vector registers */
 #    define DR_NUM_SIMD_VECTOR_REGS (DR_REG_STOP_ZMM - DR_REG_START_ZMM + 1)
 #    define DR_REG_START_64 \
         DR_REG_RAX                    /**< Start of 64-bit general register enum values */

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -842,6 +842,7 @@ enum {
 #    endif
 
     DR_NUM_GPR_REGS = DR_REG_STOP_GPR - DR_REG_START_GPR + 1,
+    DR_NUM_SIMD_VECTOR_REGS = DR_REG_Z31 - DR_REG_Z0 + 1,
 
 #    ifndef AARCH64
     /** Platform-independent way to refer to stack pointer. */
@@ -850,9 +851,6 @@ enum {
 
 #endif /* X86/ARM */
 };
-
-/** Number of SIMD vector registers */
-#define DR_NUM_SIMD_VECTOR_REGS MCXT_NUM_SIMD_SLOTS
 
 /* we avoid typedef-ing the enum, as its storage size is compiler-specific */
 typedef ushort reg_id_t; /**< The type of a DR_REG_ enum value. */
@@ -915,6 +913,7 @@ extern const reg_id_t dr_reg_fixer[];
 #    endif
 /** Number of general registers */
 #    define DR_NUM_GPR_REGS (DR_REG_STOP_GPR - DR_REG_START_GPR + 1)
+#    define DR_NUM_SIMD_VECTOR_REGS (DR_REG_STOP_ZMM - DR_REG_START_ZMM + 1)
 #    define DR_REG_START_64 \
         DR_REG_RAX                    /**< Start of 64-bit general register enum values */
 #    define DR_REG_STOP_64 DR_REG_R15 /**< End of 64-bit general register enum values */
@@ -942,14 +941,20 @@ extern const reg_id_t dr_reg_fixer[];
         DR_REG_SPL /**< Start of 8-bit x64-only register enum values*/
 #    define DR_REG_STOP_x64_8 \
         DR_REG_DIL /**< Stop of 8-bit x64-only register enum values */
-#    define DR_REG_START_MMX DR_REG_MM0   /**< Start of mmx register enum values */
-#    define DR_REG_STOP_MMX DR_REG_MM7    /**< End of mmx register enum values */
-#    define DR_REG_START_XMM DR_REG_XMM0  /**< Start of sse xmm register enum values */
-#    define DR_REG_STOP_XMM DR_REG_XMM31  /**< End of sse xmm register enum values */
-#    define DR_REG_START_YMM DR_REG_YMM0  /**< Start of ymm register enum values */
-#    define DR_REG_STOP_YMM DR_REG_YMM31  /**< End of ymm register enum values */
-#    define DR_REG_START_ZMM DR_REG_ZMM0  /**< Start of zmm register enum values */
-#    define DR_REG_STOP_ZMM DR_REG_ZMM31  /**< End of zmm register enum values */
+#    define DR_REG_START_MMX DR_REG_MM0  /**< Start of mmx register enum values */
+#    define DR_REG_STOP_MMX DR_REG_MM7   /**< End of mmx register enum values */
+#    define DR_REG_START_XMM DR_REG_XMM0 /**< Start of sse xmm register enum values */
+#    define DR_REG_START_YMM DR_REG_YMM0 /**< Start of ymm register enum values */
+#    define DR_REG_START_ZMM DR_REG_ZMM0 /**< Start of zmm register enum values */
+#    ifdef X64
+#        define DR_REG_STOP_XMM DR_REG_XMM31 /**< End of sse xmm register enum values */
+#        define DR_REG_STOP_YMM DR_REG_YMM31 /**< End of ymm register enum values */
+#        define DR_REG_STOP_ZMM DR_REG_ZMM31 /**< End of zmm register enum values */
+#    else
+#        define DR_REG_STOP_XMM DR_REG_XMM7 /**< End of sse xmm register enum values */
+#        define DR_REG_STOP_YMM DR_REG_YMM7 /**< End of ymm register enum values */
+#        define DR_REG_STOP_ZMM DR_REG_ZMM7 /**< End of zmm register enum values */
+#    endif
 #    define DR_REG_START_OPMASK DR_REG_K0 /**< Start of opmask register enum values */
 #    define DR_REG_STOP_OPMASK DR_REG_K7  /**< End of opmask register enum values */
 #    define DR_REG_START_BND DR_REG_BND0  /**< Start of bounds register enum values */

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -917,7 +917,7 @@ extern const reg_id_t dr_reg_fixer[];
 #    endif
 /** Number of general registers */
 #    define DR_NUM_GPR_REGS (DR_REG_STOP_GPR - DR_REG_START_GPR + 1)
-/** Number of SIMD vector registers */
+/** The number of SIMD vector registers. */
 #    define DR_NUM_SIMD_VECTOR_REGS (DR_REG_STOP_ZMM - DR_REG_START_ZMM + 1)
 #    define DR_REG_START_64 \
         DR_REG_RAX                    /**< Start of 64-bit general register enum values */

--- a/core/arch/opnd.h
+++ b/core/arch/opnd.h
@@ -845,7 +845,7 @@ enum {
 #    ifdef AARCH64
     DR_NUM_SIMD_VECTOR_REGS = DR_REG_Z31 - DR_REG_Z0 + 1,
 #    else
-    DR_NUM_SIMD_VECTOR_REGS = 0,
+    DR_NUM_SIMD_VECTOR_REGS = DR_REG_Q31 - DR_REG_Q0 + 1,
 #    endif
 
 #    ifndef AARCH64


### PR DESCRIPTION
Change DR_NUM_SIMD_VECTOR_REGS to reflect the actual architectural number of registers
instead of the preserved number of registers as given by MCXT_NUM_SIMD_SLOTS, as it
was intended by beb2ded8ac9e83a02fe418.

Fix the upper bound of number of simd registers of xmm, ymm, and zmm in x86 reflected
by DR_REG_STOP_XMM, DR_REG_STOP_YMM, and DR_REG_STOP_ZMM in 32-bit mode.

Fixes #3906