### PR TITLE
i#3911: Support NULL sigmask parameter passed to pselect, ppoll, epoll_pwait.

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7245,16 +7245,18 @@ pre_system_call(dcontext_t *dcontext)
         } data_t;
         dcontext->sys_param3 = sys_param(dcontext, 5);
         data_t *data_param = (data_t *)dcontext->sys_param3;
-        data_t data;
+        data_t data = { 0 };
         /* Refer to comments in SYS_ppoll above. Taking extra steps here due to struct
          * argument in pselect6.
          */
-        if (!d_r_safe_read(data_param, sizeof(data), &data)) {
-            LOG(THREAD, LOG_SYSCALLS, 2, "\treturning EFAULT to app for pselect6\n");
-            set_failure_return_val(dcontext, EFAULT);
-            DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
-            execute_syscall = false;
-            break;
+        if (data_param != NULL) {
+            if (!d_r_safe_read(data_param, sizeof(data), &data)) {
+                LOG(THREAD, LOG_SYSCALLS, 2, "\treturning EFAULT to app for pselect6\n");
+                set_failure_return_val(dcontext, EFAULT);
+                DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
+                execute_syscall = false;
+                break;
+            }
         }
         dcontext->sys_param4 = (reg_t)data.sigmask;
         if (data.sigmask == NULL)

--- a/suite/tests/linux/syscall_pwait.cpp
+++ b/suite/tests/linux/syscall_pwait.cpp
@@ -415,6 +415,40 @@ main(int argc, char *argv[])
 
     execute_subtest(main_thread, &test_set, psyscall_ppoll, true);
 
+    auto psyscall_raw_epoll_pwait = [test_set](bool nullsigmask) -> int {
+        int epoll_fd = epoll_create1(EPOLL_CLOEXEC);
+        struct epoll_event events;
+        return syscall(SYS_epoll_pwait, epoll_fd, &events, 24, 60000, 0);
+    };
+
+    auto psyscall_raw_pselect = [test_set](bool nullsigmask) -> int {
+        fd_set fds;
+        struct timespec ts;
+        FD_ZERO(&fds);
+        ts.tv_sec = 60;
+        ts.tv_nsec = 0;
+        return syscall(SYS_pselect6, 0, 0, 0, &fds, &ts, 0);
+    };
+
+    auto psyscall_raw_ppoll = [test_set](bool nullsigmask) -> int {
+        struct timespec ts;
+        ts.tv_sec = 60;
+        ts.tv_nsec = 0;
+        return syscall(SYS_ppoll, 0, 0, &ts, 0);
+    };
+
+    print("Testing raw epoll_pwait with NULL sigmask\n");
+
+    execute_subtest(main_thread, &test_set, psyscall_raw_epoll_pwait, true);
+
+    print("Testing raw pselect with NULL sigmask\n");
+
+    execute_subtest(main_thread, &test_set, psyscall_raw_pselect, true);
+
+    print("Testing raw ppoll with NULL sigmask\n");
+
+    execute_subtest(main_thread, &test_set, psyscall_raw_ppoll, true);
+
     destroy_cond_var(ready_to_listen);
 
     return 0;

--- a/suite/tests/linux/syscall_pwait.cpp
+++ b/suite/tests/linux/syscall_pwait.cpp
@@ -427,6 +427,21 @@ main(int argc, char *argv[])
         FD_ZERO(&fds);
         ts.tv_sec = 60;
         ts.tv_nsec = 0;
+        struct {
+            const sigset_t *sigmask;
+            size_t ss_len;
+        } data;
+        data.sigmask = NULL;
+        data.ss_len = 0;
+        return syscall(SYS_pselect6, 0, 0, 0, &fds, &ts, &data);
+    };
+
+    auto psyscall_raw_pselect_nullptr = [test_set](bool nullsigmask) -> int {
+        fd_set fds;
+        struct timespec ts;
+        FD_ZERO(&fds);
+        ts.tv_sec = 60;
+        ts.tv_nsec = 0;
         return syscall(SYS_pselect6, 0, 0, 0, &fds, &ts, 0);
     };
 
@@ -444,6 +459,10 @@ main(int argc, char *argv[])
     print("Testing raw pselect with NULL sigmask\n");
 
     execute_subtest(main_thread, &test_set, psyscall_raw_pselect, true);
+
+    print("Testing raw pselect with NULL struct pointer\n");
+
+    execute_subtest(main_thread, &test_set, psyscall_raw_pselect_nullptr, true);
 
     print("Testing raw ppoll with NULL sigmask\n");
 

--- a/suite/tests/linux/syscall_pwait.template
+++ b/suite/tests/linux/syscall_pwait.template
@@ -47,6 +47,9 @@ Signal received: 12
 Testing raw pselect with NULL sigmask
 Signal received: 10
 Signal received: 12
+Testing raw pselect with NULL struct pointer
+Signal received: 10
+Signal received: 12
 Testing raw ppoll with NULL sigmask
 Signal received: 10
 Signal received: 12

--- a/suite/tests/linux/syscall_pwait.template
+++ b/suite/tests/linux/syscall_pwait.template
@@ -41,3 +41,12 @@ Signal received: 12
 Testing ppoll with NULL sigmask
 Signal received: 10
 Signal received: 12
+Testing raw epoll_pwait with NULL sigmask
+Signal received: 10
+Signal received: 12
+Testing raw pselect with NULL sigmask
+Signal received: 10
+Signal received: 12
+Testing raw ppoll with NULL sigmask
+Signal received: 10
+Signal received: 12


### PR DESCRIPTION
While the glibc wrapper seems to always pass a valid pointer to the kernel, the latter
does accept NULL pointers. This patch adds support to handle pselect6, ppoll, and
epoll_pwait system calls with NULL sigmask parameter.

Adds tests for above.

Fixes #3911