### PR TITLE
i#3911: Change 0 and 0LL into NULL for variable length arguments of syscall().

### DIFF
--- a/suite/tests/linux/syscall_pwait.template
+++ b/suite/tests/linux/syscall_pwait.template
@@ -50,6 +50,11 @@ Signal received: 12
 Testing raw pselect with NULL struct pointer
 Signal received: 10
 Signal received: 12
+#if defined(X86) && defined(X64)
+Testing raw pselect with NULL struct pointer, inline asm
+Signal received: 10
+Signal received: 12
+#endif
 Testing raw ppoll with NULL sigmask
 Signal received: 10
 Signal received: 12


### PR DESCRIPTION
Fixes a bug in 64-bit that led to a non-zero pointer on some systems and a subsequent
test failure. Using NULL works for both 32-bit and 64-bit.

Additionally,

Adds missing implicit registers to clobber lists of syscall inline asm.

Adds yet another version for pselect6, in inline asm. The test is semantically redundant
to the existing NULL pointer test, and would only expose unexpected changes in glibc's
syscall() implementation. Added for completeness.

Changes 2 other long long immediate arguments into passing their natural size.

Fixes i#3911