### PR TITLE
i#3911: Change 0 and 0LL into NULL for variable length arguments of syscall().

### DIFF
--- a/suite/tests/linux/syscall_pwait.cpp
+++ b/suite/tests/linux/syscall_pwait.cpp
@@ -81,7 +81,7 @@ kick_off_child_func(void *arg)
     args_t args = *(args_t *)arg;
     if (!args.immediately) {
         /* waste some time */
-        nanosleep(&sleeptime, NULL);
+        nanosleep(&sleeptime, nullptr);
     }
     pthread_kill(args.main_thread, args.sig);
     signal_cond_var(ready_to_listen);
@@ -139,7 +139,7 @@ execute_subtest(pthread_t main_thread, sigset_t *test_set,
             }
             pthread_t child_thread =
                 kick_off_child_signal(count, main_thread, immediately);
-            pthread_sigmask(SIG_SETMASK, NULL, &pre_syscall_set);
+            pthread_sigmask(SIG_SETMASK, nullptr, &pre_syscall_set);
             if (psyscall(nullsigmask) == -1) {
                 if (errno != EINTR)
                     perror("expected EINTR");
@@ -149,13 +149,13 @@ execute_subtest(pthread_t main_thread, sigset_t *test_set,
             sigset_t post_syscall_set = {
                 0, /* Set padding to 0 so we can use memcmp */
             };
-            pthread_sigmask(SIG_SETMASK, NULL, &post_syscall_set);
+            pthread_sigmask(SIG_SETMASK, nullptr, &post_syscall_set);
             if (memcmp(&pre_syscall_set, &post_syscall_set, sizeof(pre_syscall_set)) !=
                 0) {
                 print("sigmask mismatch\n");
                 exit(1);
             }
-            pthread_join(child_thread, NULL);
+            pthread_join(child_thread, nullptr);
         }
     }
 }
@@ -177,7 +177,7 @@ main(int argc, char *argv[])
     sigemptyset(&block_set);
     sigaddset(&block_set, SIGUSR2);
     sigaddset(&block_set, SIGUSR1);
-    pthread_sigmask(SIG_BLOCK, &block_set, NULL);
+    pthread_sigmask(SIG_BLOCK, &block_set, nullptr);
     /* We need to block the signals for the purpose of this test, so that
      * the p* system call will unblock it as part of its execution.
      */
@@ -197,21 +197,22 @@ main(int argc, char *argv[])
     auto psyscall_epoll_pwait = [test_set](bool nullsigmask) -> int {
         int epoll_fd = epoll_create1(EPOLL_CLOEXEC);
         struct epoll_event events;
-        return epoll_pwait(epoll_fd, &events, 24, -1, nullsigmask ? NULL : &test_set);
+        return epoll_pwait(epoll_fd, &events, 24, -1, nullsigmask ? nullptr : &test_set);
     };
     execute_subtest(main_thread, &test_set, psyscall_epoll_pwait, false);
 
     print("Testing pselect\n");
 
     auto psyscall_pselect = [test_set](bool nullsigmask) -> int {
-        return pselect(0, NULL, NULL, NULL, NULL, nullsigmask ? NULL : &test_set);
+        return pselect(0, nullptr, nullptr, nullptr, nullptr,
+                       nullsigmask ? nullptr : &test_set);
     };
     execute_subtest(main_thread, &test_set, psyscall_pselect, false);
 
     print("Testing ppoll\n");
 
     auto psyscall_ppoll = [test_set](bool nullsigmask) -> int {
-        return ppoll(NULL, 0, NULL, nullsigmask ? NULL : &test_set);
+        return ppoll(nullptr, 0, nullptr, nullsigmask ? nullptr : &test_set);
     };
     execute_subtest(main_thread, &test_set, psyscall_ppoll, false);
 
@@ -223,7 +224,7 @@ main(int argc, char *argv[])
      */
 
     /* waste some time */
-    nanosleep(&sleeptime, NULL);
+    nanosleep(&sleeptime, nullptr);
 
     int epoll_fd = epoll_create1(EPOLL_CLOEXEC);
     struct epoll_event events;
@@ -238,12 +239,11 @@ main(int argc, char *argv[])
     print("Testing pselect failure\n");
 
     /* waste some time */
-    nanosleep(&sleeptime, NULL);
+    nanosleep(&sleeptime, nullptr);
 
     data_t data_wrong = { &test_set, 0 };
 
-    if (syscall(SYS_pselect6, 0, (fd_set *)NULL, (fd_set *)NULL, (fd_set *)NULL,
-                (const struct timespec *)NULL, &data_wrong) == 0) {
+    if (syscall(SYS_pselect6, 0, nullptr, nullptr, nullptr, nullptr, &data_wrong) == 0) {
         print("expected syscall failure");
         exit(1);
     } else if (errno != EINVAL) {
@@ -254,10 +254,9 @@ main(int argc, char *argv[])
     print("Testing ppoll failure\n");
 
     /* waste some time */
-    nanosleep(&sleeptime, NULL);
+    nanosleep(&sleeptime, nullptr);
 
-    if (syscall(SYS_ppoll, (struct pollfd *)NULL, (nfds_t)0,
-                (const struct timespec *)NULL, &test_set, (size_t)0) == 0) {
+    if (syscall(SYS_ppoll, nullptr, (nfds_t)0, nullptr, &test_set, (size_t)0) == 0) {
         print("expected syscall failure");
         exit(1);
     } else if (errno != EINVAL) {
@@ -282,7 +281,7 @@ main(int argc, char *argv[])
          */
         asm volatile(
             "mov %7, %%rbx\n\t"
-            "movq %[sys_num], %%rax\n\t"
+            "movl %[sys_num], %%eax\n\t"
             "movl %[epfd], %%edi\n\t"
             "movq %[events], %%rsi\n\t"
             "movl %[maxevents], %%edx\n\t"
@@ -302,7 +301,7 @@ main(int argc, char *argv[])
             "no_mask_error%=:\n"
             /* early-clobber outputs */
             : [syscall_error] "=&r"(syscall_error), [mask_error] "=&r"(mask_error)
-            : [sys_num] "rm"((long)SYS_epoll_pwait), [epfd] "rm"(epoll_fd),
+            : [sys_num] "rm"(SYS_epoll_pwait), [epfd] "rm"(epoll_fd),
               [events] "rm"(&events), [maxevents] "rm"(24), [timeout] "rm"((int64_t)-1),
               [sigmask] "rm"(&test_set), [ss_len] "rm"((size_t)(_NSIG / 8))
             : "rax", "rdi", "rsi", "rdx", "r10", "r8", "r9", "rbx", "rcx", "r11");
@@ -315,7 +314,7 @@ main(int argc, char *argv[])
              */
             perror("expected syscall to preserve mask parameter");
         }
-        pthread_join(child_thread, NULL);
+        pthread_join(child_thread, nullptr);
     }
 
     data_t data = { &test_set, _NSIG / 8 };
@@ -329,7 +328,7 @@ main(int argc, char *argv[])
         pthread_t child_thread = kick_off_child_signal(count, main_thread, true);
         asm volatile(
             "movq 0(%8), %%rbx\n\t"
-            "movq %[sys_num], %%rax\n\t"
+            "movl %[sys_num], %%eax\n\t"
             "movl %[nfds], %%edi\n\t"
             "movq %[readfds], %%rsi\n\t"
             "movq %[writefds], %%rdx\n\t"
@@ -349,16 +348,15 @@ main(int argc, char *argv[])
             "no_mask_error%=:\n"
             /* early-clobber ouputs */
             : [syscall_error] "=&r"(syscall_error), [mask_error] "=&r"(mask_error)
-            : [sys_num] "rm"((long)SYS_pselect6), [nfds] "rm"(0),
-              [readfds] "rm"((fd_set *)NULL), [writefds] "rm"((fd_set *)NULL),
-              [exceptfds] "rm"((fd_set *)NULL), [timeout] "rm"((struct timeval *)NULL),
-              [sigmaskstruct] "r"(&data)
+            : [sys_num] "rm"(SYS_pselect6), [nfds] "rm"(0), [readfds] "rm"(nullptr),
+              [writefds] "rm"(nullptr), [exceptfds] "rm"(nullptr),
+              [timeout] "rm"(nullptr), [sigmaskstruct] "r"(&data)
             : "rax", "rdi", "rsi", "rdx", "r10", "r8", "r9", "rbx", "rcx", "r11");
         if (syscall_error == 0)
             perror("expected syscall error EINTR");
         if (mask_error == 1)
             perror("expected syscall to preserve mask parameter");
-        pthread_join(child_thread, NULL);
+        pthread_join(child_thread, nullptr);
     }
 
     print("Testing ppoll, preserve mask\n");
@@ -368,36 +366,36 @@ main(int argc, char *argv[])
         int syscall_error = 0;
         int mask_error = 0;
         pthread_t child_thread = kick_off_child_signal(count, main_thread, true);
-        asm volatile(
-            "movq %6, %%rbx\n\t"
-            "movq %[sys_num], %%rax\n\t"
-            "movq %[fds], %%rdi\n\t"
-            "movq %[nfds], %%rsi\n\t"
-            "movq %[tmo_p], %%rdx\n\t"
-            "movq %[sigmask], %%r10\n\t"
-            "movq %[ss_len], %%r8\n\t"
-            "syscall\n\t"
-            "mov $0, %[syscall_error]\n\t"
-            "cmp $-4095, %%rax\n\t"
-            "jl no_syscall_error%=\n\t"
-            "mov $1, %[syscall_error]\n\t"
-            "no_syscall_error%=:\n\t"
-            "mov $0, %[mask_error]\n\t"
-            "cmp %%rbx, %%r10\n\t"
-            "je no_mask_error%=\n\t"
-            "mov $1, %[mask_error]\n\t"
-            "no_mask_error%=:\n"
-            /* early-clobber outputs */
-            : [syscall_error] "=&r"(syscall_error), [mask_error] "=&r"(mask_error)
-            : [sys_num] "r"((long)SYS_ppoll), [fds] "rm"((struct pollfd *)NULL),
-              [nfds] "rm"((nfds_t)0), [tmo_p] "rm"((const struct timespec *)NULL),
-              [sigmask] "rm"(&test_set), [ss_len] "rm"((size_t)(_NSIG / 8))
-            : "rax", "rdi", "rsi", "rdx", "r10", "r8", "rbx", "rcx", "r11");
+        asm volatile("movq %6, %%rbx\n\t"
+                     "movl %[sys_num], %%eax\n\t"
+                     "movq %[fds], %%rdi\n\t"
+                     "movq %[nfds], %%rsi\n\t"
+                     "movq %[tmo_p], %%rdx\n\t"
+                     "movq %[sigmask], %%r10\n\t"
+                     "movq %[ss_len], %%r8\n\t"
+                     "syscall\n\t"
+                     "mov $0, %[syscall_error]\n\t"
+                     "cmp $-4095, %%rax\n\t"
+                     "jl no_syscall_error%=\n\t"
+                     "mov $1, %[syscall_error]\n\t"
+                     "no_syscall_error%=:\n\t"
+                     "mov $0, %[mask_error]\n\t"
+                     "cmp %%rbx, %%r10\n\t"
+                     "je no_mask_error%=\n\t"
+                     "mov $1, %[mask_error]\n\t"
+                     "no_mask_error%=:\n"
+                     /* early-clobber outputs */
+                     :
+                     [syscall_error] "=&r"(syscall_error), [mask_error] "=&r"(mask_error)
+                     : [sys_num] "r"(SYS_ppoll), [fds] "rm"(nullptr),
+                       [nfds] "rm"((nfds_t)0), [tmo_p] "rm"(nullptr),
+                       [sigmask] "rm"(&test_set), [ss_len] "rm"((size_t)(_NSIG / 8))
+                     : "rax", "rdi", "rsi", "rdx", "r10", "r8", "rbx", "rcx", "r11");
         if (syscall_error == 0)
             perror("expected syscall error EINTR");
         if (mask_error == 1)
             perror("expected syscall to preserve mask parameter");
-        pthread_join(child_thread, NULL);
+        pthread_join(child_thread, nullptr);
     }
 
 #endif
@@ -406,7 +404,7 @@ main(int argc, char *argv[])
      * parameter should behave as if it was a non-p* version syscall.
      */
 
-    pthread_sigmask(SIG_UNBLOCK, &block_set, NULL);
+    pthread_sigmask(SIG_UNBLOCK, &block_set, nullptr);
 
     print("Signal unblocked: %d\n", SIGUSR2);
     print("Signal unblocked: %d\n", SIGUSR1);
@@ -426,7 +424,7 @@ main(int argc, char *argv[])
     auto psyscall_raw_epoll_pwait = [test_set](bool nullsigmask) -> int {
         int epoll_fd = epoll_create1(EPOLL_CLOEXEC);
         struct epoll_event events;
-        return syscall(SYS_epoll_pwait, epoll_fd, &events, 24, 60000, (sigset_t *)NULL,
+        return syscall(SYS_epoll_pwait, epoll_fd, &events, 24, 60000, nullptr,
                        (size_t)_NSIG / 8);
     };
 
@@ -440,9 +438,9 @@ main(int argc, char *argv[])
             const sigset_t *sigmask;
             size_t ss_len;
         } data;
-        data.sigmask = NULL;
+        data.sigmask = nullptr;
         data.ss_len = 0;
-        return syscall(SYS_pselect6, 0, (fd_set *)NULL, (fd_set *)NULL, &fds, &ts, &data);
+        return syscall(SYS_pselect6, 0, nullptr, nullptr, &fds, &ts, &data);
     };
 
     auto psyscall_raw_pselect_nullptr = [test_set](bool nullsigmask) -> int {
@@ -451,8 +449,7 @@ main(int argc, char *argv[])
         FD_ZERO(&fds);
         ts.tv_sec = 60;
         ts.tv_nsec = 0;
-        return syscall(SYS_pselect6, 0, (fd_set *)NULL, (fd_set *)NULL, &fds, &ts,
-                       (void *)NULL);
+        return syscall(SYS_pselect6, 0, nullptr, nullptr, &fds, &ts, nullptr);
     };
 
 #if defined(X86) && defined(X64)
@@ -464,7 +461,7 @@ main(int argc, char *argv[])
         ts.tv_sec = 60;
         ts.tv_nsec = 0;
         int syscall_error = 0;
-        asm volatile("movq %[sys_num], %%rax\n\t"
+        asm volatile("movl %[sys_num], %%eax\n\t"
                      "movl %[nfds], %%edi\n\t"
                      "movq %[readfds], %%rsi\n\t"
                      "movq %[writefds], %%rdx\n\t"
@@ -479,10 +476,10 @@ main(int argc, char *argv[])
                      "no_syscall_error%=:\n"
                      /* early-clobber ouputs */
                      : [syscall_error] "=&r"(syscall_error)
-                     : [sys_num] "rm"((long)SYS_pselect6), [nfds] "rm"(0),
-                       [readfds] "rm"((fd_set *)NULL), [writefds] "rm"((fd_set *)NULL),
+                     : [sys_num] "rm"(SYS_pselect6), [nfds] "rm"(0),
+                       [readfds] "rm"(nullptr), [writefds] "rm"(nullptr),
                        [exceptfds] "rm"(fds), [timeout] "rm"(ts),
-                       [sigmaskstruct] "rm"((void *)NULL)
+                       [sigmaskstruct] "rm"(nullptr)
                      : "rax", "rdi", "rsi", "rdx", "r10", "r8", "r9", "rcx", "r11");
         return syscall_error;
     };
@@ -493,8 +490,7 @@ main(int argc, char *argv[])
         struct timespec ts;
         ts.tv_sec = 60;
         ts.tv_nsec = 0;
-        return syscall(SYS_ppoll, (struct pollfd *)NULL, (nfds_t)NULL, &ts,
-                       (const sigset_t *)NULL);
+        return syscall(SYS_ppoll, nullptr, nullptr, &ts, nullptr);
     };
 
     print("Testing raw epoll_pwait with NULL sigmask\n");

--- a/suite/tests/linux/syscall_pwait.cpp
+++ b/suite/tests/linux/syscall_pwait.cpp
@@ -197,7 +197,8 @@ main(int argc, char *argv[])
     auto psyscall_epoll_pwait = [test_set](bool nullsigmask) -> int {
         int epoll_fd = epoll_create1(EPOLL_CLOEXEC);
         struct epoll_event events;
-        return epoll_pwait(epoll_fd, &events, 24, -1, nullsigmask ? NULL : &test_set);
+        return epoll_pwait(epoll_fd, &events, IF_X64_ELSE(24LL, 24L),
+                           IF_X64_ELSE(-1LL, -1L), nullsigmask ? NULL : &test_set);
     };
     execute_subtest(main_thread, &test_set, psyscall_epoll_pwait, false);
 
@@ -227,7 +228,8 @@ main(int argc, char *argv[])
 
     int epoll_fd = epoll_create1(EPOLL_CLOEXEC);
     struct epoll_event events;
-    if (syscall(SYS_epoll_pwait, epoll_fd, &events, 24LL, -1LL, &test_set, 0) == 0) {
+    if (syscall(SYS_epoll_pwait, epoll_fd, &events, IF_X64_ELSE(24LL, 24L),
+                IF_X64_ELSE(-1LL, -1L), &test_set, NULL) == 0) {
         print("expected syscall failure");
         exit(1);
     } else if (errno != EINVAL) {
@@ -242,7 +244,7 @@ main(int argc, char *argv[])
 
     data_t data_wrong = { &test_set, 0 };
 
-    if (syscall(SYS_pselect6, 0, NULL, NULL, NULL, NULL, &data_wrong) == 0) {
+    if (syscall(SYS_pselect6, NULL, NULL, NULL, NULL, NULL, &data_wrong) == 0) {
         print("expected syscall failure");
         exit(1);
     } else if (errno != EINVAL) {
@@ -255,7 +257,7 @@ main(int argc, char *argv[])
     /* waste some time */
     nanosleep(&sleeptime, NULL);
 
-    if (syscall(SYS_ppoll, NULL, 0, NULL, &test_set, 0) == 0) {
+    if (syscall(SYS_ppoll, NULL, NULL, NULL, &test_set, NULL) == 0) {
         print("expected syscall failure");
         exit(1);
     } else if (errno != EINVAL) {
@@ -278,31 +280,31 @@ main(int argc, char *argv[])
          * of the call and restore it post syscall. The mask check is making sure
          * that save/restore is done properly.
          */
-        asm volatile("mov %7, %%rbx\n\t"
-                     "movq %2, %%rax\n\t"
-                     "movq %3, %%rdi\n\t"
-                     "movq %4, %%rsi\n\t"
-                     "movq %5, %%rdx\n\t"
-                     "movq %6, %%r10\n\t"
-                     "movq %7, %%r8\n\t"
-                     "movq %8, %%r9\n\t"
-                     "syscall\n\t"
-                     "mov $0, %0\n\t"
-                     "cmp $-4095, %%rax\n\t"
-                     "jl no_syscall_error%=\n\t"
-                     "mov $1, %0\n\t"
-                     "no_syscall_error%=:\n\t"
-                     "mov $0, %1\n\t"
-                     "cmp %%rbx, %%r8\n\t"
-                     "je no_mask_error%=\n\t"
-                     "mov $1, %1\n\t"
-                     "no_mask_error%=:\n"
-                     /* early-clobber outputs */
-                     : "=&r"(syscall_error), "=&r"(mask_error)
-                     : "r"((int64_t)SYS_epoll_pwait), "rm"((int64_t)epoll_fd),
-                       "rm"(&events), "r"(24LL), "r"(-1LL), "rm"(&test_set),
-                       "r"((int64_t)(_NSIG / 8))
-                     : "rax", "rdi", "rsi", "rdx", "r10", "r8", "r9", "rbx");
+        asm volatile(
+            "mov %7, %%rbx\n\t"
+            "movq %2, %%rax\n\t"
+            "movq %3, %%rdi\n\t"
+            "movq %4, %%rsi\n\t"
+            "movq %5, %%rdx\n\t"
+            "movq %6, %%r10\n\t"
+            "movq %7, %%r8\n\t"
+            "movq %8, %%r9\n\t"
+            "syscall\n\t"
+            "mov $0, %0\n\t"
+            "cmp $-4095, %%rax\n\t"
+            "jl no_syscall_error%=\n\t"
+            "mov $1, %0\n\t"
+            "no_syscall_error%=:\n\t"
+            "mov $0, %1\n\t"
+            "cmp %%rbx, %%r8\n\t"
+            "je no_mask_error%=\n\t"
+            "mov $1, %1\n\t"
+            "no_mask_error%=:\n"
+            /* early-clobber outputs */
+            : "=&r"(syscall_error), "=&r"(mask_error)
+            : "rm"((int64_t)SYS_epoll_pwait), "rm"((int64_t)epoll_fd), "rm"(&events),
+              "rm"(24LL), "rm"(-1LL), "rm"(&test_set), "rm"((int64_t)(_NSIG / 8))
+            : "rax", "rdi", "rsi", "rdx", "r10", "r8", "r9", "rbx", "rcx", "r11");
         if (syscall_error == 0)
             perror("expected syscall error EINTR");
         if (mask_error == 1) {
@@ -345,9 +347,10 @@ main(int argc, char *argv[])
                      "no_mask_error%=:\n"
                      /* early-clobber ouputs */
                      : "=&r"(syscall_error), "=&r"(mask_error)
-                     : "r"((int64_t)SYS_pselect6), "r"(0LL), "rm"(NULL), "rm"(NULL),
+                     : "rm"((int64_t)SYS_pselect6), "rm"(NULL), "rm"(NULL), "rm"(NULL),
                        "rm"(NULL), "rm"(NULL), "r"(&data)
-                     : "rax", "rdi", "rsi", "rdx", "r10", "r8", "r9", "rbx");
+                     : "rax", "rdi", "rsi", "rdx", "r10", "r8", "r9", "rbx", "rcx",
+                       "r11");
         if (syscall_error == 0)
             perror("expected syscall error EINTR");
         if (mask_error == 1)
@@ -382,9 +385,9 @@ main(int argc, char *argv[])
                      "no_mask_error%=:\n"
                      /* early-clobber outputs */
                      : "=&r"(syscall_error), "=&r"(mask_error)
-                     : "r"((int64_t)SYS_ppoll), "rm"(NULL), "r"(0LL), "rm"(NULL),
+                     : "r"((int64_t)SYS_ppoll), "rm"(NULL), "r"(NULL), "rm"(NULL),
                        "rm"(&test_set), "r"((int64_t)(_NSIG / 8))
-                     : "rax", "rdi", "rsi", "rdx", "r10", "r8", "rbx");
+                     : "rax", "rdi", "rsi", "rdx", "r10", "r8", "rbx", "rcx", "r11");
         if (syscall_error == 0)
             perror("expected syscall error EINTR");
         if (mask_error == 1)
@@ -418,7 +421,8 @@ main(int argc, char *argv[])
     auto psyscall_raw_epoll_pwait = [test_set](bool nullsigmask) -> int {
         int epoll_fd = epoll_create1(EPOLL_CLOEXEC);
         struct epoll_event events;
-        return syscall(SYS_epoll_pwait, epoll_fd, &events, 24, 60000, 0);
+        return syscall(SYS_epoll_pwait, epoll_fd, &events, IF_X64_ELSE(24LL, 24L),
+                       IF_X64_ELSE(60000LL, 60000L), NULL);
     };
 
     auto psyscall_raw_pselect = [test_set](bool nullsigmask) -> int {
@@ -433,7 +437,7 @@ main(int argc, char *argv[])
         } data;
         data.sigmask = NULL;
         data.ss_len = 0;
-        return syscall(SYS_pselect6, 0, 0, 0, &fds, &ts, &data);
+        return syscall(SYS_pselect6, NULL, NULL, NULL, &fds, &ts, &data);
     };
 
     auto psyscall_raw_pselect_nullptr = [test_set](bool nullsigmask) -> int {
@@ -442,14 +446,46 @@ main(int argc, char *argv[])
         FD_ZERO(&fds);
         ts.tv_sec = 60;
         ts.tv_nsec = 0;
-        return syscall(SYS_pselect6, 0, 0, 0, &fds, &ts, 0);
+        return syscall(SYS_pselect6, NULL, NULL, NULL, &fds, &ts, NULL);
     };
+
+#if defined(X86) && defined(X64)
+
+    auto psyscall_raw_pselect_nullptr_inline_asm = [test_set](bool nullsigmask) -> int {
+        fd_set fds;
+        struct timespec ts;
+        FD_ZERO(&fds);
+        ts.tv_sec = 60;
+        ts.tv_nsec = 0;
+        int syscall_error = 0;
+        asm volatile("movq %1, %%rax\n\t"
+                     "movq %2, %%rdi\n\t"
+                     "movq %3, %%rsi\n\t"
+                     "movq %4, %%rdx\n\t"
+                     "movq %5, %%r10\n\t"
+                     "movq %6, %%r8\n\t"
+                     "movq %7, %%r9\n\t"
+                     "syscall\n\t"
+                     "movl $0, %0\n\t"
+                     "cmp $-4095, %%rax\n\t"
+                     "jl no_syscall_error%=\n\t"
+                     "movl $-1, %0\n\t"
+                     "no_syscall_error%=:\n\t"
+                     /* early-clobber ouputs */
+                     : "=&r"(syscall_error)
+                     : "rm"((int64_t)SYS_pselect6), "rm"(NULL), "rm"(NULL), "rm"(NULL),
+                       "rm"(fds), "rm"(ts), "rm"(NULL)
+                     : "rax", "rdi", "rsi", "rdx", "r10", "r8", "r9", "rcx", "r11");
+        return syscall_error;
+    };
+
+#endif
 
     auto psyscall_raw_ppoll = [test_set](bool nullsigmask) -> int {
         struct timespec ts;
         ts.tv_sec = 60;
         ts.tv_nsec = 0;
-        return syscall(SYS_ppoll, 0, 0, &ts, 0);
+        return syscall(SYS_ppoll, NULL, NULL, &ts, NULL);
     };
 
     print("Testing raw epoll_pwait with NULL sigmask\n");
@@ -463,6 +499,18 @@ main(int argc, char *argv[])
     print("Testing raw pselect with NULL struct pointer\n");
 
     execute_subtest(main_thread, &test_set, psyscall_raw_pselect_nullptr, true);
+
+#if defined(X86) && defined(X64)
+
+    print("Testing raw pselect with NULL struct pointer, inline asm\n");
+
+    /* We are adding this raw asm version of the same test just in case syscall() does
+     * sth funny.
+     */
+    execute_subtest(main_thread, &test_set, psyscall_raw_pselect_nullptr_inline_asm,
+                    true);
+
+#endif
 
     print("Testing raw ppoll with NULL sigmask\n");
 

--- a/suite/tests/linux/syscall_pwait.template
+++ b/suite/tests/linux/syscall_pwait.template
@@ -50,6 +50,11 @@ Signal received: 12
 Testing raw pselect with NULL struct pointer
 Signal received: 10
 Signal received: 12
+#if defined(X86) && defined(X64)
+Testing raw pselect with NULL struct pointer, inline asm
+Signal received: 10
+Signal received: 12
+#endif
 Testing raw ppoll with NULL sigmask
 Signal received: 10
 Signal received: 12


### PR DESCRIPTION
Fixes a 64-bit bug that led to a non-zero pointer on some systems and a subsequent test
failure. Using NULL works for both 32-bit and 64-bit.

Additionally:
* Adds missing implicit registers to clobber list of syscall inline asm.
* Adds yet another version for pselect6, in inline asm. The test is semantically redundant
to the existing NULL pointer test, and would only expose unexpected changes in glibc's
syscall() implementation. Added for completeness.
* Casts every parameter passed to variadic function syscall() into their safe type according
to their function definiton.
* Fixes all types passed in asm volatile statements as well.
* Makes all parameters named in asm volatile statements.

Fixes #3911