### PR TITLE
i#3913: Add drmgr wrapper for low-on-memory events

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -220,7 +220,7 @@ Further non-compatibility-affecting changes include:
  - Added DR_NUM_SIMD_VECTOR_REGS as an alias to MCXT_NUM_SIMD_SLOTS in order
    to get the static number of supported SIMD vectors.
  - Added drmgr_register_low_on_memory_event(), drmgr_unregister_low_on_memory_event()
-   and its variants so that drmgr can support low-on-memory events.
+   and their variants so that drmgr can support low-on-memory events.
 
 **************************************************
 <hr>

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -219,6 +219,8 @@ Further non-compatibility-affecting changes include:
    either XMM, YMM or ZMM, excluding any MMX register checks.
  - Added DR_NUM_SIMD_VECTOR_REGS as an alias to MCXT_NUM_SIMD_SLOTS in order
    to get the static number of supported SIMD vectors.
+ - Added drmgr_register_low_on_memory_event(), drmgr_unregister_low_on_memory_event()
+   and its variants so that drmgr can support low-on-memory events.
 
 **************************************************
 <hr>

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -68,6 +68,8 @@
 #undef dr_unregister_exception_event
 #undef dr_register_restore_state_ex_event
 #undef dr_unregister_restore_state_ex_event
+#undef dr_register_low_on_memory_event
+#undef dr_unregister_low_on_memory_event
 
 /* currently using asserts on internal logic sanity checks (never on
  * input from user) but perhaps we shouldn't since this is a library
@@ -139,6 +141,10 @@ typedef struct _generic_event_entry_t {
             void (*cb_no_user_data)(void *, const module_data_t *);
             void (*cb_user_data)(void *, const module_data_t *, void *);
         } modunload_cb;
+        union {
+            void (*cb_no_user_data)(void *);
+            void (*cb_user_data)(void *, void *);
+        } low_on_memory_cb;
         void (*kernel_xfer_cb)(void *, const dr_kernel_xfer_info_t *);
 #ifdef UNIX
         union {
@@ -281,6 +287,9 @@ static void *modload_event_lock;
 static cb_list_t cblist_modunload;
 static void *modunload_event_lock;
 
+static cb_list_t cblist_low_on_memory;
+static void *low_on_memory_event_lock;
+
 static cb_list_t cblist_kernel_xfer;
 static void *kernel_xfer_event_lock;
 
@@ -327,6 +336,9 @@ drmgr_modload_event(void *drcontext, const module_data_t *info, bool loaded);
 
 static void
 drmgr_modunload_event(void *drcontext, const module_data_t *info);
+
+static void
+drmgr_low_on_memory_event(void *drcontext);
 
 static void
 drmgr_kernel_xfer_event(void *drcontext, const dr_kernel_xfer_info_t *info);
@@ -376,6 +388,7 @@ drmgr_init(void)
     postsys_event_lock = dr_rwlock_create();
     modload_event_lock = dr_rwlock_create();
     modunload_event_lock = dr_rwlock_create();
+    low_on_memory_event_lock = dr_rwlock_create();
     kernel_xfer_event_lock = dr_rwlock_create();
 #ifdef UNIX
     signal_event_lock = dr_rwlock_create();
@@ -389,6 +402,7 @@ drmgr_init(void)
     dr_register_thread_exit_event(drmgr_thread_exit_event);
     dr_register_module_load_event(drmgr_modload_event);
     dr_register_module_unload_event(drmgr_modunload_event);
+    dr_register_low_on_memory_event(drmgr_low_on_memory_event);
     dr_register_kernel_xfer_event(drmgr_kernel_xfer_event);
 #ifdef UNIX
     dr_register_signal_event(drmgr_signal_event);
@@ -434,6 +448,7 @@ drmgr_exit(void)
 
     dr_unregister_module_load_event(drmgr_modload_event);
     dr_unregister_module_unload_event(drmgr_modunload_event);
+    dr_unregister_low_on_memory_event(drmgr_low_on_memory_event);
     dr_unregister_kernel_xfer_event(drmgr_kernel_xfer_event);
 #ifdef UNIX
     dr_unregister_signal_event(drmgr_signal_event);
@@ -462,6 +477,7 @@ drmgr_exit(void)
     dr_rwlock_destroy(exception_event_lock);
 #endif
     dr_rwlock_destroy(kernel_xfer_event_lock);
+    dr_rwlock_destroy(low_on_memory_event_lock);
     dr_rwlock_destroy(modunload_event_lock);
     dr_rwlock_destroy(modload_event_lock);
     dr_rwlock_destroy(postsys_event_lock);
@@ -1295,6 +1311,7 @@ drmgr_event_init(void)
 
     cblist_init(&cblist_modload, sizeof(generic_event_entry_t));
     cblist_init(&cblist_modunload, sizeof(generic_event_entry_t));
+    cblist_init(&cblist_low_on_memory, sizeof(generic_event_entry_t));
     cblist_init(&cblist_kernel_xfer, sizeof(generic_event_entry_t));
 #ifdef UNIX
     cblist_init(&cblist_signal, sizeof(generic_event_entry_t));
@@ -1320,6 +1337,7 @@ drmgr_event_exit(void)
     cblist_delete(&cblist_postsys);
     cblist_delete(&cblist_modload);
     cblist_delete(&cblist_modunload);
+    cblist_delete(&cblist_low_on_memory);
     cblist_delete(&cblist_kernel_xfer);
 #ifdef UNIX
     cblist_delete(&cblist_signal);
@@ -2504,6 +2522,81 @@ bool
 drmgr_pop_cls(void *drcontext)
 {
     return drmgr_cls_stack_pop();
+}
+
+/***************************************************************************
+ * Low-on-memory
+ */
+
+DR_EXPORT
+bool
+drmgr_register_low_on_memory_event(void (*func)(void *drcontext))
+{
+    return drmgr_generic_event_add(&cblist_low_on_memory, low_on_memory_event_lock,
+                                   (void (*)(void))func, NULL, false, NULL);
+}
+
+DR_EXPORT
+bool
+drmgr_register_low_on_memory_event_ex(void (*func)(void *drcontext),
+                                      drmgr_priority_t *priority)
+{
+    return drmgr_generic_event_add(&cblist_low_on_memory, low_on_memory_event_lock,
+                                   (void (*)(void))func, priority, false, NULL);
+}
+
+DR_EXPORT
+bool
+drmgr_register_low_on_memory_event_user_data(void (*func)(void *drcontext,
+                                                          void *user_data),
+                                             drmgr_priority_t *priority, void *user_data)
+{
+    return drmgr_generic_event_add(&cblist_low_on_memory, low_on_memory_event_lock,
+                                   (void (*)(void))func, priority, true, user_data);
+}
+
+DR_EXPORT
+bool
+drmgr_unregister_low_on_memory_event(void (*func)(void *drcontext))
+{
+    return drmgr_generic_event_remove(&cblist_low_on_memory, low_on_memory_event_lock,
+                                      (void (*)(void))func);
+}
+
+DR_EXPORT
+bool
+drmgr_unregister_low_on_memory_event_user_data(void (*func)(void *drcontext,
+                                                            void *user_data))
+{
+    return drmgr_generic_event_remove(&cblist_low_on_memory, low_on_memory_event_lock,
+                                      (void (*)(void))func);
+}
+
+static void
+drmgr_low_on_memory_event(void *drcontext)
+{
+
+    generic_event_entry_t local[EVENTS_STACK_SZ];
+    cb_list_t iter;
+    uint i;
+    dr_rwlock_read_lock(low_on_memory_event_lock);
+    cblist_create_local(drcontext, &cblist_low_on_memory, &iter, (byte *)local,
+                        BUFFER_SIZE_ELEMENTS(local));
+    dr_rwlock_read_unlock(low_on_memory_event_lock);
+
+    for (i = 0; i < iter.num_def; i++) {
+        if (!iter.cbs.generic[i].pri.valid)
+            continue;
+
+        bool is_using_user_data = iter.cbs.generic[i].is_using_user_data;
+        void *user_data = iter.cbs.generic[i].user_data;
+        if (is_using_user_data == false) {
+            (*iter.cbs.generic[i].cb.low_on_memory_cb.cb_no_user_data)(drcontext);
+        } else {
+            (*iter.cbs.generic[i].cb.low_on_memory_cb.cb_user_data)(drcontext, user_data);
+        }
+    }
+    cblist_delete_local(drcontext, &iter, BUFFER_SIZE_ELEMENTS(local));
 }
 
 /***************************************************************************

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -2575,7 +2575,6 @@ drmgr_unregister_low_on_memory_event_user_data(void (*func)(void *drcontext,
 static void
 drmgr_low_on_memory_event(void *drcontext)
 {
-
     generic_event_entry_t local[EVENTS_STACK_SZ];
     cb_list_t iter;
     uint i;

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -1395,7 +1395,7 @@ DR_EXPORT
  * successful.
  */
 bool
-drmgr_register_low_on_memory_event(void (*func)(void *drcontext));
+drmgr_register_low_on_memory_event(void (*func)());
 
 DR_EXPORT
 /**
@@ -1405,8 +1405,7 @@ DR_EXPORT
  * \return whether successful.
  */
 bool
-drmgr_register_low_on_memory_event_ex(void (*func)(void *drcontext),
-                                      drmgr_priority_t *priority);
+drmgr_register_low_on_memory_event_ex(void (*func)(), drmgr_priority_t *priority);
 
 DR_EXPORT
 /**
@@ -1416,8 +1415,7 @@ DR_EXPORT
  * \return whether successful.
  */
 bool
-drmgr_register_low_on_memory_event_user_data(void (*func)(void *drcontext,
-                                                          void *user_data),
+drmgr_register_low_on_memory_event_user_data(void (*func)(void *user_data),
                                              drmgr_priority_t *priority, void *user_data);
 
 DR_EXPORT
@@ -1426,7 +1424,7 @@ bool
  * Unregister a callback function for the low-on-memory event.
  * \return true if the unregistration of \p func is successful.
  */
-drmgr_unregister_low_on_memory_event(void (*func)(void *drcontext));
+drmgr_unregister_low_on_memory_event(void (*func)());
 
 DR_EXPORT
 /**
@@ -1434,8 +1432,7 @@ DR_EXPORT
  * \return true if the unregistration of \p func is successful.
  */
 bool
-drmgr_unregister_low_on_memory_event_user_data(void (*func)(void *drcontext,
-                                                            void *user_data));
+drmgr_unregister_low_on_memory_event_user_data(void (*func)(void *user_data));
 
 DR_EXPORT
 /**

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -1389,6 +1389,56 @@ drmgr_unregister_restore_state_ex_event(bool (*func)(void *drcontext, bool resto
 
 DR_EXPORT
 /**
+ * Registers a callback function \p func for the low-on-memory event. The callback
+ * provides a means for the client to free any non-critical data found on the heap, which
+ * could avoid a potential out-of-memory crash (particularly on X86_32)i. \return whether
+ * successful.
+ */
+bool
+drmgr_register_low_on_memory_event(void (*func)(void *drcontext));
+
+DR_EXPORT
+/**
+ * Registers a callback function \p func for the low-on-memory event just like
+ * drmgr_register_low_on_memory_event(), but the callback is prioritised according
+ * to \p priority.
+ * \return whether successful.
+ */
+bool
+drmgr_register_low_on_memory_event_ex(void (*func)(void *drcontext),
+                                      drmgr_priority_t *priority);
+
+DR_EXPORT
+/**
+ * Registers a callback function \p func for the low-on-memory event just like
+ * drmgr_register_low_on_memory_event(), but allows the passing of user data
+ * \p user_data. The callback is prioritised according to to \p priority.
+ * \return whether successful.
+ */
+bool
+drmgr_register_low_on_memory_event_user_data(void (*func)(void *drcontext,
+                                                          void *user_data),
+                                             drmgr_priority_t *priority, void *user_data);
+
+DR_EXPORT
+bool
+/**
+ * Unregister a callback function for the low-on-memory event.
+ * \return true if the unregistration of \p func is successful.
+ */
+drmgr_unregister_low_on_memory_event(void (*func)(void *drcontext));
+
+DR_EXPORT
+/**
+ * Unregister a callback function that accepts user-data for the low-on-memory event.
+ * \return true if the unregistration of \p func is successful.
+ */
+bool
+drmgr_unregister_low_on_memory_event_user_data(void (*func)(void *drcontext,
+                                                            void *user_data));
+
+DR_EXPORT
+/**
  * Disables auto predication globally for this basic block.
  * \return whether successful.
  * \note Only to be used in the drmgr insertion event.

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -1393,7 +1393,7 @@ DR_EXPORT
 /**
  * Registers a callback function \p func for the low-on-memory event. The callback
  * provides a means for the client to free any non-critical data found on the heap, which
- * could avoid a potential out-of-memory crash (particularly on X86_32). \return whether
+ * could avoid a potential out-of-memory crash (particularly on 32-bit). \return whether
  * successful.
  */
 bool

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -1413,7 +1413,7 @@ DR_EXPORT
 /**
  * Registers a callback function \p func for the low-on-memory event just like
  * drmgr_register_low_on_memory_event(), but allows the passing of user data
- * \p user_data. The callback is prioritised according to to \p priority.
+ * \p user_data. The callback is prioritised according to \p priority.
  * \return whether successful.
  */
 bool

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -85,6 +85,8 @@ extern "C" {
         DO_NOT_USE_module_load_USE_drmgr_events_instead
 #    define dr_register_module_unload_event DO_NOT_USE_module_unload_USE_drmgr_instead
 #    define dr_unregister_module_unload_event DO_NOT_USE_module_unload_USE_drmgr_instead
+#    define dr_register_low_on_memory_event DO_NOT_USE_low_on_memory_USE_drmgr_instead
+#    define dr_unregister_low_on_memory_event DO_NOT_USE_low_on_memory_USE_drmgr_instead
 #    define dr_register_kernel_xfer_event DO_NOT_USE_kernel_xfer_event_USE_drmgr_instead
 #    define dr_unregister_kernel_xfer_event DO_NOT_USE_kernel_xfer_event_USE_drmgr_instead
 #    define dr_register_signal_event DO_NOT_USE_signal_event_USE_drmgr_instead

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -1393,7 +1393,7 @@ DR_EXPORT
 /**
  * Registers a callback function \p func for the low-on-memory event. The callback
  * provides a means for the client to free any non-critical data found on the heap, which
- * could avoid a potential out-of-memory crash (particularly on X86_32)i. \return whether
+ * could avoid a potential out-of-memory crash (particularly on X86_32). \return whether
  * successful.
  */
 bool

--- a/suite/tests/client-interface/low_on_memory.dll.c
+++ b/suite/tests/client-interface/low_on_memory.dll.c
@@ -57,10 +57,11 @@ static bool is_wrapped;
 static bool is_clear;
 static node_t *head;
 
+static const int user_value = 9909;
+
 static void
 insert_new_node()
 {
-
     node_t **node = &head;
 
     while (*node != NULL) {
@@ -104,8 +105,26 @@ low_on_memory_event()
         dr_fprintf(STDERR, "low on memory event!\n");
         is_clear = true;
         head = NULL;
+
+        dr_fprintf(STDERR, "priority A\n");
     } else {
         dr_fprintf(STDERR, "another low on memory event!\n");
+    }
+}
+
+static void
+low_on_memory_event_user(void *user_data)
+{
+    if (is_clear) {
+        if (head != NULL)
+            dr_fprintf(STDERR, "clear mismatch - head should be NULL\n");
+
+        dr_fprintf(STDERR, "priority B\n");
+
+        if (user_data != (void *)user_value)
+            dr_fprintf(STDERR, "user data mismatch\n");
+    } else {
+        dr_fprintf(STDERR, "clear mismatch\n");
     }
 }
 
@@ -118,7 +137,8 @@ exit_event(void)
     if (!is_clear)
         dr_fprintf(STDERR, "was not cleared!\n");
 
-    if (!dr_unregister_low_on_memory_event(low_on_memory_event))
+    if (!drmgr_unregister_low_on_memory_event(low_on_memory_event) ||
+        !drmgr_unregister_low_on_memory_event_user_data(low_on_memory_event_user))
         dr_fprintf(STDERR, "unregister failed!\n");
 
     drmgr_unregister_module_load_event(module_load_event);
@@ -148,5 +168,12 @@ dr_init(client_id_t id)
 
     drmgr_register_module_load_event(module_load_event);
     dr_register_exit_event(exit_event);
-    dr_register_low_on_memory_event(low_on_memory_event);
+
+    drmgr_priority_t priority = { sizeof(priority), "low-on-memory", NULL, NULL, 0 };
+    drmgr_priority_t priority_user = { sizeof(priority), "low-on-memory-user", NULL, NULL,
+                                       3 };
+
+    drmgr_register_low_on_memory_event_ex(low_on_memory_event, &priority);
+    drmgr_register_low_on_memory_event_user_data(low_on_memory_event_user, &priority_user,
+                                                 (void *)user_value);
 }

--- a/suite/tests/client-interface/low_on_memory.dll.c
+++ b/suite/tests/client-interface/low_on_memory.dll.c
@@ -43,6 +43,7 @@
 #include "client_tools.h"
 #include "drmgr.h"
 #include "drwrap.h"
+#include <stdint.h> /* uintptr_t */
 
 #define MALLOC_ROUTINE_NAME IF_WINDOWS_ELSE("HeapAlloc", "malloc")
 
@@ -57,7 +58,7 @@ static bool is_wrapped;
 static bool is_clear;
 static node_t *head;
 
-static const int user_value = 9909;
+static const uintptr_t user_value = 9909;
 
 static void
 insert_new_node()

--- a/suite/tests/client-interface/low_on_memory.templatex
+++ b/suite/tests/client-interface/low_on_memory.templatex
@@ -1,2 +1,4 @@
 low on memory event!
+priority A
+priority B
 My total is 1800


### PR DESCRIPTION
Enhances drmgr to support low-on-memory events.

Fixes: #3913