### PR TITLE
Set WinSDK version to use current ENV WindowsSDKVersion value when using MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,10 @@ include(make/policies.cmake NO_POLICY_SCOPE)
 # this must be done prior to the project() command and the var
 # must be set in the cache.
 if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
-  set(CMAKE_SYSTEM_VERSION_TEMP  $ENV{WindowsSDKVersion})
-  string(REGEX REPLACE "([0-9.]+).*" "\\1" CMAKE_SYSTEM_VERSION_TEMP "${CMAKE_SYSTEM_VERSION_TEMP}" )
-  if(CMAKE_SYSTEM_VERSION_TEMP)
+  # Workaround for https://gitlab.kitware.com/cmake/cmake/issues/17992
+  set(CMAKE_SYSTEM_VERSION_TEMP $ENV{WindowsSDKVersion})
+  string(REGEX REPLACE "([0-9.]+).*" "\\1" CMAKE_SYSTEM_VERSION_TEMP "${CMAKE_SYSTEM_VERSION_TEMP}")
+  if (CMAKE_SYSTEM_VERSION_TEMP)
     set(CMAKE_SYSTEM_VERSION ${CMAKE_SYSTEM_VERSION_TEMP} CACHE INTERNAL "")
   endif()
   if (DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ include(make/policies.cmake NO_POLICY_SCOPE)
 # this must be done prior to the project() command and the var
 # must be set in the cache.
 if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
+  set(CMAKE_SYSTEM_VERSION_TEMP  $ENV{WindowsSDKVersion})
+  string(REGEX REPLACE "([0-9.]+).*" "\\1" CMAKE_SYSTEM_VERSION_TEMP "${CMAKE_SYSTEM_VERSION_TEMP}" )
+  if(CMAKE_SYSTEM_VERSION_TEMP)
+    set(CMAKE_SYSTEM_VERSION ${CMAKE_SYSTEM_VERSION_TEMP} CACHE INTERNAL "")
+  endif()
   if (DEBUG)
     set(CMAKE_CONFIGURATION_TYPES "Debug" CACHE STRING "" FORCE)
   else (DEBUG)


### PR DESCRIPTION
I am using Cmake 3.14 with more than one windows sdk availables, eg.: 8.1.x, 10.0.x, ...
The generated solution use default to 8.1 (not set), which failed during build. It should be set to 10.x  regarding to WindowsSDKVersion ENV variable eg. "10.0.17763.0".

Resource:
* https://stackoverflow.com/questions/45692367/how-to-set-msvc-target-platform-version-with-cmake
* https://gitlab.kitware.com/cmake/cmake/issues/17992