### PR TITLE
i#2985 drx_expand_scatter_gather(): Add a test for updated mask register state.

### DIFF
--- a/suite/tests/client-interface/drx-scattergather-shared.h
+++ b/suite/tests/client-interface/drx-scattergather-shared.h
@@ -31,3 +31,4 @@
  */
 
 #define TEST_MASK_CLOBBER_MARKER 0x23bcfa0e
+#define TEST_MASK_UPDATE_MARKER 0xe1f53a6d

--- a/suite/tests/client-interface/drx-scattergather.c
+++ b/suite/tests/client-interface/drx-scattergather.c
@@ -156,6 +156,9 @@ test_avx512_restore_mask_fault(uint32_t *ref_sparse_test_buf, uint32_t *test_idx
 /* See comment above. */
 void
 test_avx512_restore_mask_clobber(uint32_t *ref_sparse_test_buf, uint32_t *test_idx32_vec);
+/* See comment above. */
+void
+test_avx512_restore_mask_update(uint32_t *ref_sparse_test_buf, uint32_t *test_idx32_vec);
 #    endif
 
 #    define SPARSE_FACTOR 4
@@ -181,7 +184,7 @@ get_xstate_area_offs(int xstate_component)
 }
 
 static void
-signal_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
+signal_handler_check_k0(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
 {
 #        ifdef X64
     kernel_xstate_t *xstate = (kernel_xstate_t *)ucxt->uc_mcontext.fpregs;
@@ -189,6 +192,27 @@ signal_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
         (__u32 *)((byte *)xstate + get_xstate_area_offs(CPUID_KMASK_COMP));
     if (xstate_kmask_offs[0] != 0xffff)
         print("ERROR: expected k0 == 0xffff, but is 0x%x\n", xstate_kmask_offs[0]);
+#        else
+    /* XXX i#1312: it is unclear if and how the components are arranged in
+     * 32-bit mode by the kernel.
+     */
+#        endif
+    SIGLONGJMP(mark, 1);
+}
+
+static void
+signal_handler_check_k1(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
+{
+#        ifdef X64
+    kernel_xstate_t *xstate = (kernel_xstate_t *)ucxt->uc_mcontext.fpregs;
+    __u32 *xstate_kmask_offs =
+        (__u32 *)((byte *)xstate + get_xstate_area_offs(CPUID_KMASK_COMP));
+    /* This check hardcodes an assumption that the rest of the test will make the SIGILL
+     * event appear in the mask update code right after the first scalar load, so we
+     * expect the lowest mask bit to be cleared.
+     */
+    if (xstate_kmask_offs[2] != 0xfffe)
+        print("ERROR: expected k1 == 0xfffe, but is 0x%x\n", xstate_kmask_offs[2]);
 #        else
     /* XXX i#1312: it is unclear if and how the components are arranged in
      * 32-bit mode by the kernel.
@@ -474,18 +498,23 @@ test_avx2_avx512_scatter_gather(void)
 #    ifdef UNIX
 #        ifdef __AVX512F__
     print("Test restoring the mask register upon a fault\n");
-    intercept_signal(SIGSEGV, (handler_3_t)&signal_handler, false);
+    intercept_signal(SIGSEGV, (handler_3_t)&signal_handler_check_k0, false);
     /* This index will cause a fault. The index number is arbitrary.*/
     test_idx32_vec[9] = 0xefffffff;
     if (SIGSETJMP(mark) == 0)
         test_avx512_restore_mask_fault(ref_sparse_test_buf, test_idx32_vec);
     print("Test restoring the mask register upon asynchronous events\n");
     /* We will get the SIGILL from a ud2 instruction that the client will insert. */
-    intercept_signal(SIGILL, (handler_3_t)&signal_handler, false);
+    intercept_signal(SIGILL, (handler_3_t)&signal_handler_check_k0, false);
     /* Restore to a valid value. */
     test_idx32_vec[9] = 0x24;
     if (SIGSETJMP(mark) == 0)
         test_avx512_restore_mask_clobber(ref_sparse_test_buf, test_idx32_vec);
+    print("Test updating the mask register upon asynchronous events\n");
+    /* We will get the SIGILL from a ud2 instruction that the client will insert. */
+    intercept_signal(SIGILL, (handler_3_t)&signal_handler_check_k1, false);
+    if (SIGSETJMP(mark) == 0)
+        test_avx512_restore_mask_update(ref_sparse_test_buf, test_idx32_vec);
 #        endif
 #    endif
     return true;
@@ -775,45 +804,33 @@ DECLARE_FUNC_SEH(FUNCNAME(opcode))                         @N@\
 TEST_AVX512_SCATTER_IDX64_VAL64(vpscatterqq)
 TEST_AVX512_SCATTER_IDX64_VAL64(vscatterqpd)
 
-DECLARE_FUNC_SEH(test_avx512_restore_mask_fault)
-  GLOBAL_LABEL(test_avx512_restore_mask_fault:)
-        /* uint32_t *ref_sparse_test_buf */
-        mov        REG_XAX, ARG1
-        /* uint32_t *test_idx32_vec */
-        mov        REG_XDX, ARG2
-        PUSH_CALLEE_SAVED_REGS()
-        sub        REG_XSP, FRAME_PADDING
-        END_PROLOG
-        vmovdqu32  zmm1, [REG_XDX]
-        movw       dx, 0xffff
-        kmovw      k0, edx
-        kmovw      k1, edx
-        vpgatherdd zmm0 {k1}, [REG_XAX + zmm1 * 4]
-        add        REG_XSP, FRAME_PADDING
-        POP_CALLEE_SAVED_REGS()
-        ret
-        END_FUNC(test_avx512_restore_mask_fault)
+#define TEST_AVX512_MASK_RESTORE_EVENT(name, marker)       @N@\
+DECLARE_FUNC_SEH(FUNCNAME(name))                           @N@\
+  GLOBAL_LABEL(FUNCNAME(name):)                            @N@\
+        /* uint32_t *ref_sparse_test_buf */                @N@\
+        mov        REG_XAX, ARG1                           @N@\
+        /* uint32_t *test_idx32_vec */                     @N@\
+        mov        REG_XDX, ARG2                           @N@\
+        PUSH_CALLEE_SAVED_REGS()                           @N@\
+        sub        REG_XSP, FRAME_PADDING                  @N@\
+        END_PROLOG                                         @N@\
+        mov        REG_XCX, marker                         @N@\
+        mov        REG_XCX, marker                         @N@\
+        vmovdqu32  zmm1, [REG_XDX]                         @N@\
+        movw       dx, 0xffff                              @N@\
+        kmovw      k0, edx                                 @N@\
+        kmovw      k1, edx                                 @N@\
+        vpgatherdd zmm0 {k1}, [REG_XAX + zmm1 * 4]         @N@\
+        add        REG_XSP, FRAME_PADDING                  @N@\
+        POP_CALLEE_SAVED_REGS()                            @N@\
+        ret                                                @N@\
+        END_FUNC(FUNCNAME(name))
 
-DECLARE_FUNC_SEH(test_avx512_restore_mask_clobber)
-  GLOBAL_LABEL(test_avx512_restore_mask_clobber:)
-        /* uint32_t *ref_sparse_test_buf */
-        mov        REG_XAX, ARG1
-        /* uint32_t *test_idx32_vec */
-        mov        REG_XDX, ARG2
-        PUSH_CALLEE_SAVED_REGS()
-        sub        REG_XSP, FRAME_PADDING
-        END_PROLOG
-        mov        REG_XCX, TEST_MASK_CLOBBER_MARKER
-        mov        REG_XCX, TEST_MASK_CLOBBER_MARKER
-        vmovdqu32  zmm1, [REG_XDX]
-        movw       dx, 0xffff
-        kmovw      k0, edx
-        kmovw      k1, edx
-        vpgatherdd zmm0 {k1}, [REG_XAX + zmm1 * 4]
-        add        REG_XSP, FRAME_PADDING
-        POP_CALLEE_SAVED_REGS()
-        ret
-        END_FUNC(test_avx512_restore_mask_clobber)
+/* No marker is needed for the fault test. */
+TEST_AVX512_MASK_RESTORE_EVENT(restore_mask_fault, 0x0)
+/* These tests depend on markers being present. */
+TEST_AVX512_MASK_RESTORE_EVENT(restore_mask_clobber, TEST_MASK_CLOBBER_MARKER)
+TEST_AVX512_MASK_RESTORE_EVENT(restore_mask_update, TEST_MASK_UPDATE_MARKER)
 
 #endif /* __AVX512F__ */
 

--- a/suite/tests/client-interface/drx-scattergather.dll.c
+++ b/suite/tests/client-interface/drx-scattergather.dll.c
@@ -68,6 +68,7 @@ inscount(uint num_instrs)
  * scatter/gather into separate basic blocks during expansion.
  */
 static app_pc mask_clobber_test_gather_pc;
+static app_pc mask_update_test_gather_pc;
 
 static dr_emit_flags_t
 event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
@@ -124,6 +125,31 @@ event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     return DR_EMIT_DEFAULT;
 }
 
+static void
+search_for_next_gather_pc(void *drcontext, instr_t *start_instr, byte **gather_pc)
+{
+    byte *pc = instr_get_app_pc(start_instr);
+    instr_t temp_instr;
+    instr_init(drcontext, &temp_instr);
+    /* This relies heavily on the exact test app's behavior, as well as
+     * the scatter/gather expansion's code layout.
+     */
+    while (true) {
+        instr_reset(drcontext, &temp_instr);
+        byte *next_pc = decode(drcontext, pc, &temp_instr);
+        CHECK(next_pc != NULL,
+              "Everything should be decodable in the test until a "
+              "gather instruction will be found.");
+        CHECK(!instr_is_cti(&temp_instr), "unexpected cti instruction when decoding");
+        if (instr_is_gather(&temp_instr)) {
+            *gather_pc = pc;
+            break;
+        }
+        pc = next_pc;
+    }
+    instr_free(drcontext, &temp_instr);
+}
+
 static dr_emit_flags_t
 event_bb_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                  bool translating, void **user_data)
@@ -145,33 +171,26 @@ event_bb_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
             if (next_instr != NULL) {
                 if (instr_is_mov_constant(next_instr, &val) &&
                     val == TEST_MASK_CLOBBER_MARKER) {
-                    byte *pc = instr_get_app_pc(next_instr);
-                    instr_t temp_instr;
-                    instr_init(drcontext, &temp_instr);
                     /* We're searching for the next gather instruction that will be
-                     * expanded below. We will use its pc to identify the corner case
+                     * expanded. We will use its pc to identify the corner case
                      * instructions where we will inject a ud2 after gather expansion.
-                     * This relies heavily on the exact test app's behavior, as well as
-                     * the scatter/gather expansion's code layout.
                      */
-                    while (true) {
-                        instr_reset(drcontext, &temp_instr);
-                        byte *next_pc = decode(drcontext, pc, &temp_instr);
-                        CHECK(next_pc != NULL,
-                              "Everything should be decodable in the test until a "
-                              "gather instruction will be found.");
-                        CHECK(!instr_is_cti(&temp_instr),
-                              "unexpected cti instruction when decoding");
-                        if (instr_is_gather(&temp_instr)) {
-                            CHECK(mask_clobber_test_gather_pc == NULL ||
-                                      mask_clobber_test_gather_pc == pc,
-                                  "unexpected gather instruction pc");
-                            mask_clobber_test_gather_pc = pc;
-                            break;
-                        }
-                        pc = next_pc;
-                    }
-                    instr_free(drcontext, &temp_instr);
+                    CHECK(mask_clobber_test_gather_pc == NULL,
+                          "unexpected gather instruction pc");
+                    search_for_next_gather_pc(drcontext, next_instr,
+                                              &mask_clobber_test_gather_pc);
+                }
+            }
+        } else if (instr_is_mov_constant(instr, &val) && val == TEST_MASK_UPDATE_MARKER) {
+            instr_t *next_instr = instr_get_next(instr);
+            if (next_instr != NULL) {
+                if (instr_is_mov_constant(next_instr, &val) &&
+                    val == TEST_MASK_UPDATE_MARKER) {
+                    /* Same comment as above. */
+                    CHECK(mask_update_test_gather_pc == NULL,
+                          "unexpected gather instruction pc");
+                    search_for_next_gather_pc(drcontext, next_instr,
+                                              &mask_update_test_gather_pc);
                 }
             }
         }
@@ -188,19 +207,36 @@ event_bb_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     for (instr = instrlist_first(bb); instr != NULL; instr = instr_get_next(instr)) {
         if (instr_get_opcode(instr) == OP_kandnw &&
             instr_get_app_pc(instr) == mask_clobber_test_gather_pc) {
-            /* We've found the clobber case of the scatter/gather sequence that clobbers
-             * the k0 mask register. Then we're inserting a ud2 app instruction right
-             * after it, so we will SIGILL and the value will be tested in the app's
-             * signal handler. We will be here twice: one time during bb creation, and
-             * another time when translating. After that, the app itself will longjmp to
-             * the next subtest and we will neither recreate this code nor translate it.
+            /* We've found the clobber case of the scatter/gather sequence
+             * that clobbers the k0 mask register. Then we're inserting a ud2
+             * app instruction right after it, so we will SIGILL and the value
+             * will be tested in the app's signal handler. We will be here
+             * twice: one time during bb creation, and another time when
+             * translating. After that, the app itself will longjmp to the
+             * next subtest and we will neither recreate this code nor
+             * translate it.
              */
             instrlist_postinsert(
                 bb, instr,
                 INSTR_XL8(INSTR_CREATE_ud2a(drcontext),
-                          /* It's guaranteed by the test that there will be a next app
-                           * instruction, because the emulated sequence consists of 16
-                           * mask updates, and this is just the first.
+                          /* It's guaranteed by the test that there will be a next
+                           * app instruction, because the emulated sequence consists
+                           * of 16 mask updates, and this is just the first.
+                           */
+                          instr_get_app_pc(instr_get_next_app(instr))));
+            /* We don't need to do anything else. */
+            break;
+        } else if (instr_get_opcode(instr) == OP_kandnw &&
+                   instr_get_app_pc(instr) == mask_update_test_gather_pc) {
+            /* Same as above, but this time, we inject the ud2 right before the mask
+             * update.
+             */
+            instrlist_preinsert(
+                bb, instr,
+                INSTR_XL8(INSTR_CREATE_ud2a(drcontext),
+                          /* It's guaranteed by the test that there will be a next
+                           * app instruction, because the emulated sequence consists
+                           * of 16 mask updates, and this is just the first.
                            */
                           instr_get_app_pc(instr_get_next_app(instr))));
             /* We don't need to do anything else. */

--- a/suite/tests/client-interface/drx-scattergather.templatex
+++ b/suite/tests/client-interface/drx-scattergather.templatex
@@ -34,12 +34,16 @@ Test restoring the mask register upon asynchronous events
 #ifdef X64
 ERROR: expected k0 == 0xffff, but is 0x1
 #endif
+Test updating the mask register upon asynchronous events
+#ifdef X64
+ERROR: expected k1 == 0xfffe, but is 0xffff
+#endif
 #endif
 #endif
 AVX2/AVX-512 scatter/gather checks ok
 #ifdef X64
 #ifdef __AVX512F__
-event_exit, 66 scatter/gather instructions
+event_exit, 67 scatter/gather instructions
 #elif defined(__AVX__)
 event_exit, 16 scatter/gather instructions
 #else
@@ -47,7 +51,7 @@ event_exit, 0 scatter/gather instructions
 #endif
 #else
 #ifdef __AVX512F__
-event_exit, 18 scatter/gather instructions
+event_exit, 19 scatter/gather instructions
 #elif defined(__AVX__)
 event_exit, 4 scatter/gather instructions
 #else


### PR DESCRIPTION
Adds a test to check for the correct state of the gather instruction's mask register if an
asynchronous event hits the sequence after a completed load, but before the mask register
update. Note that the restore event is not implemented yet, and the test is currently
expected to report an error.

Re-factors the tests and puts the functions test_avx512_restore_mask_fault,
test_avx512_restore_mask_clobber, and test_avx512_restore_mask_update
in one common macro.

A future patch that will add support for restoring the mask register will also
include an update to this test.

Issue: #2985