### PR TITLE
Add markers to drcachesim trace view tool output

### DIFF
--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -435,8 +435,15 @@ set a start point and end point for the disassembled view. Note that these
 flags compute the number of instructions which are skipped or displayed which
 is distinct from the number of trace entries.
 
+The tool also displays metadata marker entries for timestamps, on
+which core and thread the subsequent instruction sequence was
+executed, and kernel and system call transfers (these correspond to
+signal or event handler interruptions of the regular execution flow).
+
 \code
 $ bin64/drrun -t drcachesim -simulator_type view -sim_refs 20 -indir drmemtrace.*.dir
+<marker: timestamp 13218166936578899>
+<marker: tid 46977 on core 7>
   0x00007f3a5127d870  48 83 ec 48          sub    $0x48, %rsp
   0x00007f3a5127d874  0f 31                rdtsc
   0x00007f3a5127d876  48 c1 e2 20          shl    $0x20, %rdx

--- a/clients/drcachesim/tests/offline-view.templatex
+++ b/clients/drcachesim/tests/offline-view.templatex
@@ -1,4 +1,7 @@
 Hello, world!
 .*
+<marker: timestamp.*
+<marker: tid [0-9]* on core [0-9]*>
+.*
 View tool results:
     *[0-9]* : total disassembled instructions

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -95,14 +95,33 @@ view_t::initialize()
 bool
 view_t::process_memref(const memref_t &memref)
 {
+    if (instr_count < knob_skip_refs || instr_count >= (knob_skip_refs + knob_sim_refs)) {
+        if (type_is_instr(memref.instr.type) ||
+            memref.data.type == TRACE_TYPE_INSTR_NO_FETCH)
+            ++instr_count;
+        return true;
+    }
+
+    if (memref.marker.type == TRACE_TYPE_MARKER) {
+        if (memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP)
+            std::cerr << "<marker: timestamp " << memref.marker.marker_value << ">\n";
+        else if (memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID) {
+            // We include the thread ID here under the assumption that we will always
+            // see a cpuid marker on a thread switch.  To avoid that assumption
+            // we would want to track the prior tid and print out a thread switch
+            // message whenever it changes.
+            std::cerr << "<marker: tid " << memref.marker.tid << " on core "
+                      << memref.marker.marker_value << ">\n";
+        } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT)
+            std::cerr << "<marker: kernel xfer to handler>\n";
+        else if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER)
+            std::cerr << "<marker: syscall xfer>\n";
+        return true;
+    }
+
     if (!type_is_instr(memref.instr.type) &&
         memref.data.type != TRACE_TYPE_INSTR_NO_FETCH)
         return true;
-
-    if (instr_count < knob_skip_refs || instr_count >= (knob_skip_refs + knob_sim_refs)) {
-        ++instr_count;
-        return true;
-    }
 
     ++instr_count;
 

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -103,19 +103,28 @@ view_t::process_memref(const memref_t &memref)
     }
 
     if (memref.marker.type == TRACE_TYPE_MARKER) {
-        if (memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP)
+        switch (memref.marker.marker_type) {
+        case TRACE_MARKER_TYPE_TIMESTAMP:
             std::cerr << "<marker: timestamp " << memref.marker.marker_value << ">\n";
-        else if (memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID) {
+            break;
+        case TRACE_MARKER_TYPE_CPU_ID:
             // We include the thread ID here under the assumption that we will always
             // see a cpuid marker on a thread switch.  To avoid that assumption
             // we would want to track the prior tid and print out a thread switch
             // message whenever it changes.
             std::cerr << "<marker: tid " << memref.marker.tid << " on core "
                       << memref.marker.marker_value << ">\n";
-        } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT)
+            break;
+        case TRACE_MARKER_TYPE_KERNEL_EVENT:
             std::cerr << "<marker: kernel xfer to handler>\n";
-        else if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER)
+            break;
+        case TRACE_MARKER_TYPE_KERNEL_XFER:
             std::cerr << "<marker: syscall xfer>\n";
+            break;
+        default:
+            // We ignore other markers such as call/ret profiling for now.
+            break;
+        }
         return true;
     }
 


### PR DESCRIPTION
Adds printing of timestamp, core, and kernel transfer markers to the
drcachesim trace view tool.  The markers embedded in the disassembly
make it much easier to see signal handlers and thread transitions.

Adds a sanity check to the view test and updates the docs.