### PR TITLE
i#3940 FD leak: close the leaked file descriptor with -satisfy_w_xor_x.

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4318,8 +4318,8 @@ os_create_memory_file(const char *name, size_t size)
         return INVALID_FILE;
     }
     file_t priv_fd = fd_priv_dup(fd);
+    close_syscall(fd); /* Close the old descriptor on success *and* error. */
     if (priv_fd < 0) {
-        close_syscall(fd);
         return INVALID_FILE;
     }
     fd = priv_fd;


### PR DESCRIPTION
We need to close it in cases of successful/failed fd_priv_dup, so just
promote the existing close to before the success/failure check.

Fixes #3940