### PR TITLE
i#3212: Unify invalid app instr handling

### DIFF
--- a/core/translate.c
+++ b/core/translate.c
@@ -655,6 +655,13 @@ recreate_app_state_from_info(dcontext_t *tdcontext, const translation_info_t *in
         instr_reset(tdcontext, &instr);
         prev_cpc = cpc;
         cpc = decode(tdcontext, cpc, &instr);
+        if (cpc == NULL) {
+            LOG(THREAD_GET, LOG_INTERP, 2,
+                "recreate_app -- failed to decode cache pc " PFX "\n", cpc);
+            ASSERT_NOT_REACHED();
+            instr_free(tdcontext, &instr);
+            return RECREATE_FAILURE;
+        }
         instr_set_our_mangling(&instr, ours);
         /* Sets the translation so that spilled registers can be restored. */
         instr_set_translation(&instr, answer);

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2606,7 +2606,7 @@ translate_sigcontext(dcontext_t *dcontext, kernel_ucontext_t *uc, bool avoid_fai
         success = true;
     } else {
         if (avoid_failure) {
-            ASSERT_NOT_REACHED(); /* is ok to break things, is UNIX :) */
+            ASSERT_NOT_REACHED(); /* Raise a visible debug error: sthg is wrong. */
             /* FIXME : what to do? reg state might be wrong at least get pc */
             if (safe_is_in_fcache(dcontext, (cache_pc)sc->SC_XIP, (app_pc)sc->SC_XSP)) {
                 sc->SC_XIP = (ptr_uint_t)recreate_app_pc(dcontext, mcontext.pc, f);


### PR DESCRIPTION
Removes the problematic Linux approach for handling an invalid
application instruction in a basic block, where we would isolate it to
its own bb and then copy 17 bytes for native execution, assuming the
processor would raise a fault.  This is very fragile and caused
real-world problems with the crc32w decoder bug (#2431).  Those 17
bytes often end mid-instruction, causing the exit cti to not exist and
DR to execute junk instructions, leading to all kinds of bad behavior.

Now, Linux does what Windows does: we immediately forge an illegal
instruction fault (SIGILL for Linux).  While it might be nicer to try
to continue execution for instructions whose length we can guess at,
there are just too many risks here as described above.  It's better to
have a clear fault that someone can identify and debug easily to
address decoder issues, instead of mysterious behavior and strange
crashes that take a lot of effort to track back to the decoder.

Tested on crc32w with the #2431 removed locally for a
valid-but-we-think-it's-not test.  The common.decode-bad test has
several cases of legitimately-invalid instructions.

Adds error handling of a failed cache decode in
recreate_app_state_from_info() so we're more robust there.  Tested
with a local revert of the above removal of invalid_instr_hack.

Fixes #3212