### PR TITLE
i#3937 memtrace sigs: Order delayed branch before signal markers

### DIFF
--- a/clients/drcachesim/tests/trace_invariants.cpp
+++ b/clients/drcachesim/tests/trace_invariants.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -98,6 +98,9 @@ trace_invariants_t::process_memref(const memref_t &memref)
         // Clear prev_instr to avoid a branch-gap failure above for things like
         // wow64 call* NtContinue syscall.
         memset(&prev_instr, 0, sizeof(prev_instr));
+    } else {
+        // Clear prev_marker to ensure it's *immediately* prior (i#3937). */
+        memset(&prev_marker, 0, sizeof(prev_marker));
     }
     return true;
 }

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -434,6 +434,10 @@ struct trace_header_t {
  *
  * <LI>void log(uint level, const char *fmt, ...)
  *
+ * <LI>void log_instruction(uint level, app_pc decode_pc, app_pc orig_pc);
+ *
+ * Similar to log() but this disassembles the given PC.</LI>
+ *
  * Implementers are given the opportunity to implement their own logging. The level
  * parameter represents severity: the lower the level, the higher the severity.</LI>
  *
@@ -671,6 +675,7 @@ private:
             // To avoid repeatedly decoding the same instruction on every one of its
             // dynamic executions, we cache the decoding in a hashtable.
             pc = decode_pc;
+            impl()->log_instruction(4, decode_pc, orig_pc);
             instr = impl()->get_instr_summary(tls, in_entry->pc.modidx,
                                               in_entry->pc.modoffs, &pc, orig_pc);
             if (instr == nullptr) {
@@ -941,6 +946,8 @@ protected:
     on_thread_end(void *tls);
     virtual void
     log(uint level, const char *fmt, ...);
+    virtual void
+    log_instruction(uint level, app_pc decode_pc, app_pc orig_pc);
 
     // Per-traced-thread data is stored here and accessed without locks by having each
     // traced thread processed by only one processing thread.


### PR DESCRIPTION
Fixes a bug where drcachesim's raw2trace places delayed branches
*after* signal markers, leading to confusing trace orderings.

Improves the checking for markers in trace_invariants, but
unfortunately it still will not catch this case as it does not know
the targets of branches nor the addresses of signal handlers.

Adds log_instruction() to trace_converter_t and uses it to disassemble
memtrace instructions on *every* instance, instead of just the first
time encountered.  This is essential for debugging these types of
issues.

Issue: #3937