### PR TITLE
i#3935 vzeroupper optimization: Set VEX prefixes in fast decoder.

### DIFF
--- a/core/arch/decode.h
+++ b/core/arch/decode.h
@@ -83,8 +83,11 @@
  */
 #    define PREFIX_SEG_FS 0x20
 #    define PREFIX_SEG_GS 0x40
+/* Prefix used for AVX */
+#    define PREFIX_VEX_2B 0x00010000
+#    define PREFIX_VEX_3B 0x00020000
 /* Prefix used for AVX-512 */
-#    define PREFIX_EVEX 0x000100000
+#    define PREFIX_EVEX 0x00100000
 #endif
 
 /* XXX: when adding prefixes, shift all the private values as they start

--- a/core/arch/x86/decode_private.h
+++ b/core/arch/x86/decode_private.h
@@ -65,17 +65,15 @@
 /* First 2 are only used during initial decode so if running out of
  * space could replace w/ byte value compare.
  */
-#define PREFIX_VEX_2B 0x000010000
-#define PREFIX_VEX_3B 0x000020000
-#define PREFIX_VEX_L 0x000040000
+#define PREFIX_VEX_L 0x00040000
 /* Also only used during initial decode */
-#define PREFIX_XOP 0x000080000
+#define PREFIX_XOP 0x00080000
 /* Prefixes which are used for AVX-512 */
-#define PREFIX_EVEX_RR 0x000200000
-#define PREFIX_EVEX_LL 0x000400000
-#define PREFIX_EVEX_z 0x000800000
-#define PREFIX_EVEX_b 0x001000000
-#define PREFIX_EVEX_VV 0x002000000
+#define PREFIX_EVEX_RR 0x00200000
+#define PREFIX_EVEX_LL 0x00400000
+#define PREFIX_EVEX_z 0x00800000
+#define PREFIX_EVEX_b 0x01000000
+#define PREFIX_EVEX_VV 0x02000000
 
 /* branch hints show up as segment modifiers */
 #define SEG_JCC_NOT_TAKEN SEG_CS


### PR DESCRIPTION
Prepares for lazy AVX code detection by always setting the VEX_2B or VEX_3B prefix in the
fast decoder, so that it is available to test in the main interpreter loop.

For the same reason, moves PREFIX_VEX_2B and PREFIX_VEX_3B definitions from
decode_private.h to decode.h.

Fixes some latent minor immediate bugs removing a superfluous leading 0.

Issue: #3935