### PR TITLE
i#1312 AVX-512 support: Fix OPSZ_SAVED_OPMASK for non-AVX512BW machines.

### DIFF
--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -215,7 +215,7 @@ reg_spill_tls_offs(reg_id_t reg);
 #define OPSZ_SAVED_XMM (YMM_ENABLED() ? OPSZ_32 : OPSZ_16)
 #define OPSZ_SAVED_ZMM OPSZ_64
 #define REG_SAVED_XMM0 (YMM_ENABLED() ? REG_YMM0 : REG_XMM0)
-#define OPSZ_SAVED_OPMASK OPSZ_8
+#define OPSZ_SAVED_OPMASK (proc_has_feature(FEATURE_AVX512BW) ? OPSZ_8 : OPSZ_2)
 
 /* Xref the partially overlapping CONTEXT_PRESERVE_XMM */
 /* This routine also determines whether ymm registers should be saved. */


### PR DESCRIPTION
The bug led to an invalid encoding error on machines with no support for AVX512BW,
but AVX512F.

Tested manually by setting proc_avx512_enabled to true on a machine w/o AVX-512.

Issue: #1312