### PR TITLE
i#1312 AVX-512 support: Suppress incomplete AVX-512 support on non-UNIX and 32-bit.

### DIFF
--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -266,10 +266,11 @@ d_r_set_avx512_code_in_use(bool in_use, app_pc pc)
                    get_application_pid(), pc_addr);
         }
     });
-#    endif
+#    else
     SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
     ATOMIC_1BYTE_WRITE(d_r_avx512_code_in_use, in_use, false);
     SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
+#    endif
 }
 
 static inline bool

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -256,7 +256,7 @@ static inline void
 d_r_set_avx512_code_in_use(bool in_use, app_pc pc)
 {
 #    if !defined(UNIX) || !defined(X64)
-    /* We warn about unsupported AVX-512 present in the app. */
+    /* FIXME i#1312: we warn about unsupported AVX-512 present in the app. */
     DO_ONCE({
         if (pc != NULL) {
             char pc_addr[IF_X64_ELSE(20, 12)];

--- a/core/arch/x86/proc.c
+++ b/core/arch/x86/proc.c
@@ -427,17 +427,27 @@ proc_init_arch(void)
         }
         if (proc_has_feature(FEATURE_AVX512F)) {
             if (TESTALL(XCR0_HI16_ZMM | XCR0_ZMM_HI256 | XCR0_OPMASK, bv_low)) {
-                /* XXX i#1312: It had been unclear whether the kernel uses CR0 bits to
-                 * disable AVX-512 for its own lazy context switching optimization. If it
-                 * did, then our lazy context switch would interfere with the kernel's and
-                 * more support would be needed. We have concluded that the Linux kernel
-                 * does not do its own lazy context switch optimization for AVX-512 at
-                 * this time.
+#if !defined(UNIX) || !defined(X64)
+                /* FIXME i#1312: AVX-512 is not fully supported or untested on all
+                 * non-UNIX builds and in 32-bit yet. A SYSLOG_INTERNAL_ERROR_ONCE is
+                 * issued on Windows and by any 32-bit build if AVX-512 code is
+                 * encountered. Setting DynamoRIO to a state that partially supports
+                 * AVX-512 is causing problems, xref i#3949. We therefore completely
+                 * disable AVX-512 support in these builds.
+                 */
+#else
+                /* XXX i#1312: It had been unclear whether the kernel uses CR0
+                 * bits to disable AVX-512 for its own lazy context switching
+                 * optimization. If it did, then our lazy context switch would
+                 * interfere with the kernel's and more support would be needed.
+                 * We have concluded that the Linux kernel does not do its own
+                 * lazy context switch optimization for AVX-512 at this time.
                  */
                 avx512_enabled = true;
                 num_simd_registers = MCXT_NUM_SIMD_SLOTS;
                 num_opmask_registers = MCXT_NUM_OPMASK_SLOTS;
                 LOG(GLOBAL, LOG_TOP, 1, "\tProcessor and OS fully support AVX-512\n");
+#endif
             } else {
                 LOG(GLOBAL, LOG_TOP, 1, "\tOS does NOT support AVX-512\n");
             }

--- a/core/arch/x86/proc.c
+++ b/core/arch/x86/proc.c
@@ -528,9 +528,13 @@ proc_num_opmask_registers(void)
 void
 proc_set_num_simd_saved(int num)
 {
+#if !defined(UNIX) || !defined(X64)
+    /* FIXME i#1312: support and test. */
+#else
     SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
     ATOMIC_4BYTE_WRITE(&num_simd_saved, num, false);
     SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
+#endif
 }
 
 int

--- a/core/arch/x86/proc.c
+++ b/core/arch/x86/proc.c
@@ -428,12 +428,12 @@ proc_init_arch(void)
         if (proc_has_feature(FEATURE_AVX512F)) {
             if (TESTALL(XCR0_HI16_ZMM | XCR0_ZMM_HI256 | XCR0_OPMASK, bv_low)) {
 #if !defined(UNIX) || !defined(X64)
-                /* FIXME i#1312: AVX-512 is not fully supported or untested on all
+                /* FIXME i#1312: AVX-512 is not fully supported or is untested on all
                  * non-UNIX builds and in 32-bit yet. A SYSLOG_INTERNAL_ERROR_ONCE is
                  * issued on Windows and by any 32-bit build if AVX-512 code is
                  * encountered. Setting DynamoRIO to a state that partially supports
                  * AVX-512 is causing problems, xref i#3949. We therefore completely
-                 * disable AVX-512 support in these builds.
+                 * disable AVX-512 support in these builds for now.
                  */
 #else
                 /* XXX i#1312: It had been unclear whether the kernel uses CR0


### PR DESCRIPTION
As pointed out in cf1ec32e9b89c1d8a28e0f3, AVX-512 context management by DynamoRIO is not
fully supported or is untested on non-UNIX as well as on 32-bit builds. Yet processor
detection and certain AVX-512 functionality was enabled on those builds when running on
machines with AVX-512 support enabled by the OS. This was causing problems (xref #3949).
For now, this patch completely disables all AVX-512 features on unsupported and untested
builds.

Fixes #3949
Issue: #1312