### PR TITLE
i#2985 drx_expand_scatter_gather(): Support a drx restore event for emulation code.

### DIFF
--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2638,7 +2638,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
             ptr_int_t val;
             if (instr_is_mov_constant(inst, &val)) {
                 /* If more than one bit is set, this is not what we're looking for. */
-                if (!val || (val & (val - 1))) {
+                if (val == 0 || (val & (val - 1)) != 0) {
                     detect_state = DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0;
                     break;
                 }

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2797,8 +2797,9 @@ drx_event_restore_state(void *drcontext, bool restore_memory,
             scatter_gather_info_t sg_info;
             get_scatter_gather_info(&inst, &sg_info);
             if (sg_info.is_evex) {
-                success &= drx_try_to_detect_avx512_gather_sequence(drcontext, info,
-                                                                    &inst, &sg_info);
+                success = success &&
+                    drx_try_to_detect_avx512_gather_sequence(drcontext, info, &inst,
+                                                             &sg_info);
             } else {
                 /* TODO i#2985: support AVX2 gather. */
             }

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -106,9 +106,11 @@ drx_buf_init_library(void);
 void
 drx_buf_exit_library(void);
 
+#ifdef X86
 static bool
 drx_event_restore_state(void *drcontext, bool restore_memory,
                         dr_restore_state_info_t *info);
+#endif
 
 /***************************************************************************
  * INIT
@@ -144,9 +146,12 @@ drx_init(void)
     if (drreg_init(&ops) != DRREG_SUCCESS)
         return false;
 
+#ifdef X86
+    /* Only needed for x86 at present. */
     if (!drmgr_register_restore_state_ex_event_ex(drx_event_restore_state,
                                                   &fault_priority))
         return false;
+#endif
 
     return drx_buf_init_library();
 }
@@ -2508,6 +2513,8 @@ advance_state(int *detect_state, int new_detect_state, int *allow_for_unknown_in
     *allow_for_unknown_instr_count = 0;
 }
 
+#ifdef X86
+
 static void
 drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_t *info,
                                          instr_t *inst, scatter_gather_info_t *sg_info)
@@ -2788,3 +2795,5 @@ drx_event_restore_state(void *drcontext, bool restore_memory,
     instr_free(drcontext, &inst);
     return true;
 }
+
+#endif

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2443,6 +2443,8 @@ drx_expand_scatter_gather_exit:
 /***************************************************************************
  * RESTORE STATE
  *
+ * x86 scatter/gather emulation sequence support
+ *
  * The following state machines exist in order to detect restore events that need
  * additional attention by drx in order to fix the application state on top of the
  * fixes that drreg already makes. For the AVX-512 scatter/gather sequences this are
@@ -2497,6 +2499,8 @@ drx_expand_scatter_gather_exit:
  * as well as AVX2 gather.
  */
 
+#ifdef X86
+
 /* Returns false if counter has exceeded threshold, true otherwise. */
 static inline bool
 allow_for_unknown_instr_inc(int *allow_for_unknown_instr_count)
@@ -2512,8 +2516,6 @@ advance_state(int *detect_state, int new_detect_state, int *allow_for_unknown_in
     *detect_state = new_detect_state;
     *allow_for_unknown_instr_count = 0;
 }
-
-#ifdef X86
 
 static void
 drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_t *info,

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2546,7 +2546,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
     byte *restore_scratch_mask_start = NULL;
     int detect_state = 0;
     int allow_for_unknown_instr_count = 0;
-    reg_id_t tmp_xmm = DR_REG_NULL;
+    reg_id_t the_scratch_xmm = DR_REG_NULL;
     reg_id_t gpr_bit_mask = DR_REG_NULL;
     reg_id_t gpr_save_scratch_mask = DR_REG_NULL;
     uint scalar_mask_update_no = 0;
@@ -2591,7 +2591,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                 reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(inst, 0));
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
-                tmp_xmm = tmp_reg;
+                the_scratch_xmm = tmp_reg;
                 advance_state(&detect_state,
                               DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2,
                               &allow_for_unknown_instr_count);
@@ -2601,12 +2601,12 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
             allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2:
-            ASSERT(tmp_xmm != DR_REG_NULL,
+            ASSERT(the_scratch_xmm != DR_REG_NULL,
                    "internal error: expected xmm register to be recorded in state "
                    "machine.");
             if (instr_get_opcode(inst) == OP_vpinsrd) {
                 reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(inst, 0));
-                if (tmp_reg == tmp_xmm) {
+                if (tmp_reg == the_scratch_xmm) {
                     advance_state(&detect_state,
                                   DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3,
                                   &allow_for_unknown_instr_count);

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2447,7 +2447,11 @@ drx_expand_scatter_gather_exit:
 
 /***************************************************************************
  * RESTORE STATE
- *
+ */
+
+#ifdef PLATFORM_SUPPORTS_SCATTER_GATHER
+
+/*
  * x86 scatter/gather emulation sequence support
  *
  * The following state machines exist in order to detect restore events that need
@@ -2489,24 +2493,22 @@ drx_expand_scatter_gather_exit:
  * TODO i#2985: support.
  */
 
-#define DRX_RESTORE_EVENT_ALLOW_FOR_UNKNOWN_INSTR 32
+#    define DRX_RESTORE_EVENT_ALLOW_FOR_UNKNOWN_INSTR 32
 
 /* States of the AVX-512 gather detection state machine. */
-#define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0 0
-#define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1 1
-#define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2 2
-#define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3 3
-#define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4 4
-#define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5 5
-#define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6 6
-#define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7 7
-#define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8 8
+#    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0 0
+#    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1 1
+#    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2 2
+#    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3 3
+#    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4 4
+#    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5 5
+#    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6 6
+#    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7 7
+#    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8 8
 
 /* TODO i#2985: implement a state machine for AVX-512 scatter
  * as well as AVX2 gather.
  */
-
-#ifdef PLATFORM_SUPPORTS_SCATTER_GATHER
 
 /* Returns false if counter has exceeded threshold, true otherwise. */
 static inline bool

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -1769,7 +1769,7 @@ expand_avx512_scatter_gather_update_mask(void *drcontext, instrlist_t *bb,
                                           OPND_CREATE_INT32(1 << el)),
                      orig_app_pc));
     /* TODO i#2985: We will have to detect this code in a future drx restore event in
-     * order to check whether an translation event happened within this sequence,
+     * order to check whether a translation event happened within this sequence,
      * which may make it necessary to manually restore k0 and maybe the destination
      * mask. This is not supported for AVX2 gather and AVX-512 scatter. AVX-512 gather is
      * supported.
@@ -2455,10 +2455,10 @@ drx_expand_scatter_gather_exit:
  *
  * The following state machines exist in order to detect restore events that need
  * additional attention by drx in order to fix the application state on top of the
- * fixes that drreg already makes. For the AVX-512 scatter/gather sequences this are
+ * fixes that drreg already makes. For the AVX-512 scatter/gather sequences these are
  * instruction windows where a scratch mask is being used, and the windows after
  * each scalar load/store but before the destination mask register update. For AVX2,
- * the scratch mask is a xmm register and will be handled by drreg directly (future
+ * the scratch mask is an xmm register and will be handled by drreg directly (future
  * update, xref #3844).
  *
  * The state machines allow for instructions like drreg spill/restore and instrumentation
@@ -2480,8 +2480,8 @@ drx_expand_scatter_gather_exit:
  * (a) (b) kandnw        %k0 %k1 -> %k1
  *     (b) kmovw         %edx -> %k0
  *
- * (a): The instruction window the destination mask state is stale.
- * (b): The instruction window the scratch mask is clobbered w/o support by drreg.
+ * (a): The instruction window where the destination mask state is stale.
+ * (b): The instruction window where the scratch mask is clobbered w/o support by drreg.
  *
  * AVX-512 scatter sequence detection example:
  * TODO i#2985: support.
@@ -2718,7 +2718,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                                 MAX(opnd_size_in_bytes(sg_info->scalar_index_size),
                                     opnd_size_in_bytes(sg_info->scalar_value_size));
                             if (scalar_mask_update_no > no_of_elements) {
-                                /* Unlikely that something looks identical to a emulation
+                                /* Unlikely that something looks identical to an emulation
                                  * sequence for this long, but we safely can return here.
                                  */
                                 return true;
@@ -2746,7 +2746,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                         if (reg_is_gpr(tmp_gpr)) {
                             if (restore_scratch_mask_start <= info->raw_mcontext->pc &&
                                 info->raw_mcontext->pc <= prev_pc) {
-                                /* The scratch mask is always k0. this is hard-coded
+                                /* The scratch mask is always k0. This is hard-coded
                                  * in drx. We carefully only update the lowest 16 bits
                                  * because the mask was saved with kmovw.
                                  */

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2783,6 +2783,10 @@ drx_event_restore_state(void *drcontext, bool restore_memory,
     bool success = true;
     if (info->fragment_info.cache_start_pc == NULL)
         return true; /* fault not in cache */
+    if (!expand_scatter_gather_drreg_initialized) {
+        /* Nothing to do if nobody had never called expand_scatter_gather() before. */
+        return true;
+    }
     instr_init(drcontext, &inst);
     byte *pc = decode(drcontext, dr_fragment_app_pc(info->fragment_info.tag), &inst);
     if (pc != NULL) {

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -153,7 +153,6 @@ drx_init(void)
         return false;
 
 #ifdef PLATFORM_SUPPORTS_SCATTER_GATHER
-    /* Only needed for x86 at present. */
     if (!drmgr_register_restore_state_ex_event_ex(drx_event_restore_state,
                                                   &fault_priority))
         return false;

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2462,7 +2462,9 @@ drx_expand_scatter_gather_exit:
  * in between recognized states. This is an approximation and could be broken in many
  * ways, e.g. by a client adding more than DRX_RESTORE_EVENT_ALLOW_FOR_UNKNOWN_INSTR
  * number of instructions as instrumentation, or by altering the emulation sequence's
- * code.
+ * code. A more safe way to do this would be along the lines of xref i#3801: if we had
+ * instruction lists available, we could see and pass down emulation labels instead of
+ * guessing the sequence based on decoding the code cache.
  *
  * AVX-512 gather sequence detection example:
  *

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2581,6 +2581,9 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                     break;
                 }
             }
+            /* We don't need to ignore any instructions here, because we are already in
+             * DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0.
+             */
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1:
             if (instr_get_opcode(inst) == OP_vextracti32x4) {

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2792,7 +2792,7 @@ drx_event_restore_state(void *drcontext, bool restore_memory,
     if (pc != NULL) {
         if (instr_is_gather(&inst)) {
             if (!info->fragment_info.app_code_consistent) {
-                /* Can't verify application code. Let the translation fail.
+                /* Can't verify application code.
                  * XXX i#2985: is it better to keep searching?
                  */
                 return true;

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2520,20 +2520,21 @@ drx_expand_scatter_gather_exit:
  * as well as AVX2 gather.
  */
 
-/* Returns false if counter has exceeded threshold, true otherwise. */
-static inline bool
-allow_for_unknown_instr_inc(int *allow_for_unknown_instr_count)
-{
-    if (*allow_for_unknown_instr_count++ < DRX_RESTORE_EVENT_ALLOW_FOR_UNKNOWN_INSTR)
-        return true;
-    return false;
-}
-
 static void
 advance_state(int *detect_state, int new_detect_state, int *allow_for_unknown_instr_count)
 {
     *detect_state = new_detect_state;
     *allow_for_unknown_instr_count = 0;
+}
+
+/* Advances to state 0 if counter has exceeded threshold, returns otherwise. */
+static inline void
+allow_for_unknown_instr_inc(int *detect_state, int *allow_for_unknown_instr_count)
+{
+    if (*allow_for_unknown_instr_count++ >= DRX_RESTORE_EVENT_ALLOW_FOR_UNKNOWN_INSTR) {
+        advance_state(detect_state, DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0,
+                      allow_for_unknown_instr_count);
+    }
 }
 
 static bool
@@ -2597,10 +2598,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                 break;
             }
             /* Intentionally not else if */
-            if (allow_for_unknown_instr_inc(&allow_for_unknown_instr_count))
-                break;
-            advance_state(&detect_state, DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0,
-                          &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2:
             ASSERT(tmp_xmm != DR_REG_NULL,
@@ -2615,10 +2613,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                     break;
                 }
             }
-            if (allow_for_unknown_instr_inc(&allow_for_unknown_instr_count))
-                break;
-            advance_state(&detect_state, DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0,
-                          &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3:
             if (instr_get_opcode(inst) == OP_vinserti32x4) {
@@ -2630,10 +2625,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                     break;
                 }
             }
-            if (allow_for_unknown_instr_inc(&allow_for_unknown_instr_count))
-                break;
-            advance_state(&detect_state, DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0,
-                          &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4: {
             ptr_int_t val;
@@ -2655,10 +2647,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                     }
                 }
             }
-            if (allow_for_unknown_instr_inc(&allow_for_unknown_instr_count))
-                break;
-            advance_state(&detect_state, DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0,
-                          &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
             break;
         }
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5:
@@ -2678,10 +2667,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                     }
                 }
             }
-            if (allow_for_unknown_instr_inc(&allow_for_unknown_instr_count))
-                break;
-            advance_state(&detect_state, DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0,
-                          &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6:
             ASSERT(gpr_bit_mask != DR_REG_NULL,
@@ -2700,10 +2686,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                     }
                 }
             }
-            if (allow_for_unknown_instr_inc(&allow_for_unknown_instr_count))
-                break;
-            advance_state(&detect_state, DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0,
-                          &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7:
             if (instr_get_opcode(inst) == OP_kandnw) {
@@ -2745,10 +2728,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                     }
                 }
             }
-            if (allow_for_unknown_instr_inc(&allow_for_unknown_instr_count))
-                break;
-            advance_state(&detect_state, DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0,
-                          &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8:
             if (instr_get_opcode(inst) == OP_kmovw) {
@@ -2780,10 +2760,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                     }
                 }
             }
-            if (allow_for_unknown_instr_inc(&allow_for_unknown_instr_count))
-                break;
-            advance_state(&detect_state, DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0,
-                          &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
             break;
         default: ASSERT(false, "internal error: invalid state.");
         }

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -67,6 +67,7 @@
 #define MAX(x, y) ((x) >= (y) ? (x) : (y))
 
 #ifdef X86
+/* TODO i#2985: add ARM SIMD. */
 #    define PLATFORM_SUPPORTS_SCATTER_GATHER
 #endif
 

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2791,8 +2791,10 @@ drx_event_restore_state(void *drcontext, bool restore_memory,
     if (pc != NULL) {
         if (instr_is_gather(&inst)) {
             if (!info->fragment_info.app_code_consistent) {
-                /* Can't verify application code. Let the translation fail. */
-                return false;
+                /* Can't verify application code. Let the translation fail.
+                 * XXX i#2985: is it better to keep searching?
+                 */
+                return true;
             }
             scatter_gather_info_t sg_info;
             get_scatter_gather_info(&inst, &sg_info);

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2527,7 +2527,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
     reg_id_t tmp_xmm = DR_REG_NULL;
     reg_id_t gpr_bit_mask = DR_REG_NULL;
     reg_id_t gpr_save_scratch_mask = DR_REG_NULL;
-    int scalar_mask_update_no = 0;
+    uint scalar_mask_update_no = 0;
     pc = info->fragment_info.cache_start_pc;
     /* As the state machine is looking for blocks of code that the fault may hit, the 128
      * bytes is a conservative approximation of the block's size, see (a) and (b) above.

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2472,16 +2472,26 @@ drx_expand_scatter_gather_exit:
  *
  * AVX-512 gather sequence detection example:
  *
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0
  *         mov           (%rax,%rcx,4)[4byte] -> %ecx
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1
  * (a)     vextracti32x4 {%k0} $0x00 %zmm0 -> %xmm2
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2
  * (a)     vpinsrd       %xmm2 %ecx $0x00 -> %xmm2
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3
  * (a)     vinserti32x4  {%k0} $0x00 %zmm0 %xmm2 -> %zmm0
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4
  * (a)     mov           $0x00000001 -> %ecx
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5
  * (a)     mov           %rdx -> %gs:0x00000098[8byte]
  * (a) (b) kmovw         %k0 -> %edx
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6
  * (a) (b) kmovw         %ecx -> %k0
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7
  * (a) (b) kandnw        %k0 %k1 -> %k1
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8
  *     (b) kmovw         %edx -> %k0
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0
  *
  * (a): The instruction window where the destination mask state is stale.
  * (b): The instruction window where the scratch mask is clobbered w/o support by drreg.

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -1768,11 +1768,8 @@ expand_avx512_scatter_gather_update_mask(void *drcontext, instrlist_t *bb,
                                               reg_64_to_32(scratch_reg), scratch_reg)),
                                           OPND_CREATE_INT32(1 << el)),
                      orig_app_pc));
-    /* TODO i#2985: We will have to detect this code in a future drx restore event in
-     * order to check whether a translation event happened within this sequence,
-     * which may make it necessary to manually restore k0 and maybe the destination
-     * mask. This is not supported for AVX2 gather and AVX-512 scatter. AVX-512 gather is
-     * supported.
+    /* TODO i#2985: Support the drx restore event for AVX2 gather and AVX-512 scatter.
+     * AVX-512 gather is already supported.
      */
     if (drreg_reserve_register(drcontext, bb, sg_instr, allowed, &save_mask_reg) !=
         DRREG_SUCCESS)

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -1763,8 +1763,10 @@ expand_avx512_scatter_gather_update_mask(void *drcontext, instrlist_t *bb,
                                           OPND_CREATE_INT32(1 << el)),
                      orig_app_pc));
     /* TODO i#2985: We will have to detect this code in a future drx restore event in
-     * order to check whether an asynchronous event happened within this sequence,
-     * which will make it necessary to manually restore k0.
+     * order to check whether an translation event happened within this sequence,
+     * which may make it necessary to manually restore k0 and maybe the destination
+     * mask. This is not supported for AVX2 gather and AVX-512 scatter. AVX-512 gather is
+     * supported.
      */
     if (drreg_reserve_register(drcontext, bb, sg_instr, allowed, &save_mask_reg) !=
         DRREG_SUCCESS)

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2521,19 +2521,19 @@ drx_expand_scatter_gather_exit:
  */
 
 static void
-advance_state(int *detect_state, int new_detect_state, int *allow_for_unknown_instr_count)
+advance_state(int *detect_state, int new_detect_state, int *unknown_instr_count)
 {
     *detect_state = new_detect_state;
-    *allow_for_unknown_instr_count = 0;
+    *unknown_instr_count = 0;
 }
 
 /* Advances to state 0 if counter has exceeded threshold, returns otherwise. */
 static inline void
-allow_for_unknown_instr_inc(int *detect_state, int *allow_for_unknown_instr_count)
+allow_for_unknown_instr_inc(int *detect_state, int *unknown_instr_count)
 {
-    if (*allow_for_unknown_instr_count++ >= DRX_RESTORE_EVENT_ALLOW_FOR_UNKNOWN_INSTR) {
+    if (*unknown_instr_count++ >= DRX_RESTORE_EVENT_ALLOW_FOR_UNKNOWN_INSTR) {
         advance_state(detect_state, DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0,
-                      allow_for_unknown_instr_count);
+                      unknown_instr_count);
     }
 }
 
@@ -2545,7 +2545,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
     byte *restore_dest_mask_start = NULL;
     byte *restore_scratch_mask_start = NULL;
     int detect_state = 0;
-    int allow_for_unknown_instr_count = 0;
+    int unknown_instr_count = 0;
     reg_id_t the_scratch_xmm = DR_REG_NULL;
     reg_id_t gpr_bit_mask = DR_REG_NULL;
     reg_id_t gpr_save_scratch_mask = DR_REG_NULL;
@@ -2578,7 +2578,7 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                     restore_dest_mask_start = pc;
                     advance_state(&detect_state,
                                   DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1,
-                                  &allow_for_unknown_instr_count);
+                                  &unknown_instr_count);
                     break;
                 }
             }
@@ -2596,12 +2596,12 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                     the_scratch_xmm = tmp_reg;
                     advance_state(&detect_state,
                                   DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2,
-                                  &allow_for_unknown_instr_count);
+                                  &unknown_instr_count);
                     break;
                 }
             }
             /* Intentionally not else if */
-            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2:
             ASSERT(the_scratch_xmm != DR_REG_NULL,
@@ -2614,11 +2614,11 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                 if (tmp_reg == the_scratch_xmm) {
                     advance_state(&detect_state,
                                   DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3,
-                                  &allow_for_unknown_instr_count);
+                                  &unknown_instr_count);
                     break;
                 }
             }
-            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3:
             if (instr_get_opcode(inst) == OP_vinserti32x4) {
@@ -2628,11 +2628,11 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                 if (tmp_reg == sg_info->gather_dst_reg) {
                     advance_state(&detect_state,
                                   DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4,
-                                  &allow_for_unknown_instr_count);
+                                  &unknown_instr_count);
                     break;
                 }
             }
-            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4: {
             ptr_int_t val;
@@ -2649,12 +2649,12 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                         gpr_bit_mask = tmp_gpr;
                         advance_state(&detect_state,
                                       DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5,
-                                      &allow_for_unknown_instr_count);
+                                      &unknown_instr_count);
                         break;
                     }
                 }
             }
-            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &unknown_instr_count);
             break;
         }
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5:
@@ -2668,13 +2668,13 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                             gpr_save_scratch_mask = tmp_gpr;
                             advance_state(&detect_state,
                                           DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6,
-                                          &allow_for_unknown_instr_count);
+                                          &unknown_instr_count);
                             break;
                         }
                     }
                 }
             }
-            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6:
             ASSERT(gpr_bit_mask != DR_REG_NULL,
@@ -2688,12 +2688,12 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                         restore_scratch_mask_start = pc;
                         advance_state(&detect_state,
                                       DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7,
-                                      &allow_for_unknown_instr_count);
+                                      &unknown_instr_count);
                         break;
                     }
                 }
             }
-            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7:
             if (instr_get_opcode(inst) == OP_kandnw) {
@@ -2729,13 +2729,13 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                             }
                             advance_state(&detect_state,
                                           DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8,
-                                          &allow_for_unknown_instr_count);
+                                          &unknown_instr_count);
                             break;
                         }
                     }
                 }
             }
-            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &unknown_instr_count);
             break;
         case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8:
             if (instr_get_opcode(inst) == OP_kmovw) {
@@ -2761,13 +2761,13 @@ drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_
                                 advance_state(
                                     &detect_state,
                                     DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0,
-                                    &allow_for_unknown_instr_count);
+                                    &unknown_instr_count);
                             }
                         }
                     }
                 }
             }
-            allow_for_unknown_instr_inc(&detect_state, &allow_for_unknown_instr_count);
+            allow_for_unknown_instr_inc(&detect_state, &unknown_instr_count);
             break;
         default: ASSERT(false, "internal error: invalid state.");
         }

--- a/ext/drx/drx.h
+++ b/ext/drx/drx.h
@@ -63,6 +63,18 @@ extern "C" {
  * INIT
  */
 
+enum {
+    /**
+     * Priority of drx fault handling event.
+     */
+    DRMGR_PRIORITY_FAULT_DRX = -7500,
+};
+
+/**
+ * Name of drx fault handling event.
+ */
+#define DRMGR_PRIORITY_NAME_DRX_FAULT "drx_fault"
+
 DR_EXPORT
 /**
  * Initializes the drx extension.  Must be called prior to any drx routine

--- a/suite/tests/client-interface/drx-scattergather.c
+++ b/suite/tests/client-interface/drx-scattergather.c
@@ -553,21 +553,21 @@ test_avx2_avx512_scatter_gather(void)
     intercept_signal(SIGILL, (handler_3_t)&signal_handler_check_k0, false);
     /* Restore to a valid value. */
     test_idx32_vec[9] = 0x24;
-    print("Test restoring the AVX-512 gather mask register upon asynchronous events\n");
+    print("Test restoring the AVX-512 gather mask register upon translation events\n");
     if (SIGSETJMP(mark) == 0)
         test_avx512_restore_gather_mask_clobber(ref_sparse_test_buf, test_idx32_vec);
-    print("Test restoring the AVX-512 scatter mask register upon asynchronous events\n");
+    print("Test restoring the AVX-512 scatter mask register upon translation events\n");
     if (SIGSETJMP(mark) == 0) {
         test_avx512_restore_scatter_mask_clobber(ref_sparse_test_buf, test_idx32_vec,
                                                  output_sparse_test_buf);
     }
     /* We will get the SIGILL from a ud2 instruction that the client will insert. */
     intercept_signal(SIGILL, (handler_3_t)&signal_handler_check_k1, false);
-    print("Test updating the AVX-512 gather mask register upon asynchronous events\n");
+    print("Test updating the AVX-512 gather mask register upon translation events\n");
     if (SIGSETJMP(mark) == 0)
         test_avx512_restore_gather_mask_update(ref_idx32_val32_xmm_ymm_zmm,
                                                test_idx32_vec);
-    print("Test updating the AVX-512 scatter mask register upon asynchronous events\n");
+    print("Test updating the AVX-512 scatter mask register upon translation events\n");
     if (SIGSETJMP(mark) == 0) {
         test_avx512_restore_scatter_mask_update(ref_idx32_val32_xmm_ymm_zmm,
                                                 test_idx32_vec, output_sparse_test_buf);
@@ -581,7 +581,7 @@ test_avx2_avx512_scatter_gather(void)
      */
     /* We will get the SIGILL from a ud2 instruction that the client will insert. */
     intercept_signal(SIGILL, (handler_3_t)&signal_handler_check_ymm1, false);
-    print("Test updating the AVX2 gather mask register upon asynchronous events\n");
+    print("Test updating the AVX2 gather mask register upon translation events\n");
     if (SIGSETJMP(mark) == 0)
         test_avx2_restore_gather_mask_update(ref_idx32_val32_xmm_ymm_zmm, test_idx32_vec);
 #    endif

--- a/suite/tests/client-interface/drx-scattergather.templatex
+++ b/suite/tests/client-interface/drx-scattergather.templatex
@@ -30,19 +30,19 @@ AVX2 gather ok
 #ifdef __AVX512F__
 Test restoring the AVX-512 gather scratch mask register upon a fault
 Test restoring the AVX-512 scatter scratch mask register upon a fault
-Test restoring the AVX-512 gather mask register upon asynchronous events
+Test restoring the AVX-512 gather mask register upon translation events
 /* FIXME i2985: remove all errors below once restore event has been implemented in drx. */
-Test restoring the AVX-512 scatter mask register upon asynchronous events
+Test restoring the AVX-512 scatter mask register upon translation events
 #ifdef X64
 ERROR: expected k0 == 0xffff, but is 0x1
 #endif
-Test updating the AVX-512 gather mask register upon asynchronous events
-Test updating the AVX-512 scatter mask register upon asynchronous events
+Test updating the AVX-512 gather mask register upon translation events
+Test updating the AVX-512 scatter mask register upon translation events
 #ifdef X64
 ERROR: expected k1 == 0xfffe, but is 0xffff
 #endif
 #endif
-Test updating the AVX2 gather mask register upon asynchronous events
+Test updating the AVX2 gather mask register upon translation events
 ERROR: expected xmm2\[31:30\] == 0
 #endif
 AVX2/AVX-512 scatter/gather checks ok

--- a/suite/tests/client-interface/drx-scattergather.templatex
+++ b/suite/tests/client-interface/drx-scattergather.templatex
@@ -31,20 +31,12 @@ AVX2 gather ok
 Test restoring the AVX-512 gather scratch mask register upon a fault
 Test restoring the AVX-512 scatter scratch mask register upon a fault
 Test restoring the AVX-512 gather mask register upon asynchronous events
-/* FIXME i2985: remove once restore event has been implemented in drx. This
- * applies to all errors below.
- */
-#ifdef X64
-ERROR: expected k0 == 0xffff, but is 0x1
-#endif
+/* FIXME i2985: remove all errors below once restore event has been implemented in drx. */
 Test restoring the AVX-512 scatter mask register upon asynchronous events
 #ifdef X64
 ERROR: expected k0 == 0xffff, but is 0x1
 #endif
 Test updating the AVX-512 gather mask register upon asynchronous events
-#ifdef X64
-ERROR: expected k1 == 0xfffe, but is 0xffff
-#endif
 Test updating the AVX-512 scatter mask register upon asynchronous events
 #ifdef X64
 ERROR: expected k1 == 0xfffe, but is 0xffff


### PR DESCRIPTION
Adds a drx restore event that will eventually handle fixing AVX-512 gather, AVX-512
scatter and AVX2 gather emulation sequence application state.

This patch adds drx support to detect and restore the scratch mask as well as the
destination mask state in the AVX-512 gather emulation sequence. This is necessary if
a translation event hits the AVX-512 gather emulation sequence in certain parts of the
emulation code. Detection is done by a state machine that attempts to match a known
pattern of the emulation sequence.

AVX-512 scatter and AVX2 gather is not yet supported.

Removes the relevant errors from client.drx-scattergather.

Issue: #2985