### PR TITLE
i#1312 AVX-512 support: Re-enable partial support for UNIX 32-bit.

### DIFF
--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -266,11 +266,16 @@ d_r_set_avx512_code_in_use(bool in_use, app_pc pc)
                    get_application_pid(), pc_addr);
         }
     });
-#    else
+#    endif
+#    if !defined(UNIX)
+    /* All non-UNIX builds are completely unsupported, while 32-bit UNIX builds are
+     * partially supported, see comment in proc.c.
+     */
+    return;
+#    endif
     SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
     ATOMIC_1BYTE_WRITE(d_r_avx512_code_in_use, in_use, false);
     SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
-#    endif
 }
 
 static inline bool

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -268,7 +268,7 @@ d_r_set_avx512_code_in_use(bool in_use, app_pc pc)
     });
 #    endif
 #    if !defined(UNIX)
-    /* All non-UNIX builds are completely unsupported, while 32-bit UNIX builds are
+    /* All non-UNIX builds are completely unsupported. 32-bit UNIX builds are
      * partially supported, see comment in proc.c.
      */
     return;

--- a/core/arch/x86/proc.c
+++ b/core/arch/x86/proc.c
@@ -443,9 +443,9 @@ proc_init_arch(void)
                  * lazy context switch optimization for AVX-512 at this time.
                  *
                  * Please note that the 32-bit UNIX build is missing support for
-                 * handling AVX-512 state with signals and a SYSLOG_INTERNAL_ERROR_ONCE
-                 * will be issued if AVX-512 code is encountered. 64-bit builds are
-                 * fully supported.
+                 * handling AVX-512 state with signals. A SYSLOG_INTERNAL_ERROR_ONCE
+                 * will be issued if AVX-512 code is encountered for 32-bit. 64-bit
+                 * builds are fully supported.
                  */
                 avx512_enabled = true;
                 num_simd_registers = MCXT_NUM_SIMD_SLOTS;

--- a/core/arch/x86/proc.c
+++ b/core/arch/x86/proc.c
@@ -427,13 +427,12 @@ proc_init_arch(void)
         }
         if (proc_has_feature(FEATURE_AVX512F)) {
             if (TESTALL(XCR0_HI16_ZMM | XCR0_ZMM_HI256 | XCR0_OPMASK, bv_low)) {
-#if !defined(UNIX) || !defined(X64)
-                /* FIXME i#1312: AVX-512 is not fully supported or is untested on all
-                 * non-UNIX builds and in 32-bit yet. A SYSLOG_INTERNAL_ERROR_ONCE is
-                 * issued on Windows and by any 32-bit build if AVX-512 code is
-                 * encountered. Setting DynamoRIO to a state that partially supports
-                 * AVX-512 is causing problems, xref i#3949. We therefore completely
-                 * disable AVX-512 support in these builds for now.
+#if !defined(UNIX)
+                /* FIXME i#1312: AVX-512 is not fully supported and is untested on all
+                 * non-UNIX builds. A SYSLOG_INTERNAL_ERROR_ONCE is issued on Windows
+                 * if AVX-512 code is encountered. Setting DynamoRIO to a state that
+                 * partially supports AVX-512 is causing problems, xref i#3949. We
+                 * therefore completely disable AVX-512 support in these builds for now.
                  */
 #else
                 /* XXX i#1312: It had been unclear whether the kernel uses CR0
@@ -442,6 +441,11 @@ proc_init_arch(void)
                  * interfere with the kernel's and more support would be needed.
                  * We have concluded that the Linux kernel does not do its own
                  * lazy context switch optimization for AVX-512 at this time.
+                 *
+                 * Please note that the 32-bit UNIX build is missing support for
+                 * handling AVX-512 state with signals and a SYSLOG_INTERNAL_ERROR_ONCE
+                 * will be issued if AVX-512 code is encountered. 64-bit builds are
+                 * fully supported.
                  */
                 avx512_enabled = true;
                 num_simd_registers = MCXT_NUM_SIMD_SLOTS;
@@ -528,7 +532,7 @@ proc_num_opmask_registers(void)
 void
 proc_set_num_simd_saved(int num)
 {
-#if !defined(UNIX) || !defined(X64)
+#if !defined(UNIX)
     /* FIXME i#1312: support and test. */
 #else
     SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);


### PR DESCRIPTION
In dadb8ff2eeb173, we disabled support for AVX-512 for all 32-bit UNIX builds completely.
Yet those builds are only missing support for AVX-512 state in signal frames. Various
tests already exist for existing context switching in 32-bit. In order to keep these tests
working, we are re-enabling partial AVX-512 support for UNIX 32-bit. A warning is issued
if AVX-512 code is encountered.

Issue: #1312