### PR TITLE
i#3926: Do not clone label callbacks.

### DIFF
--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -886,7 +886,8 @@ DR_API
 /**
  * Returns a copy of \p orig with separately allocated memory for
  * operands and raw bytes if they were present in \p orig.
- * Only a shallow copy of the \p note field is made.
+ * Only a shallow copy of the \p note field is made. The clone's label callback
+ * field will not be copied at all if \p orig is a label instruction.
  */
 instr_t *
 instr_clone(dcontext_t *dcontext, instr_t *orig);

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -886,7 +886,7 @@ DR_API
 /**
  * Returns a copy of \p orig with separately allocated memory for
  * operands and raw bytes if they were present in \p orig.
- * Only a shallow copy of the \p note field is made. The clone's label callback
+ * Only a shallow copy of the \p note field is made. The \p label_cb
  * field will not be copied at all if \p orig is a label instruction.
  */
 instr_t *

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -2066,6 +2066,8 @@ DR_API
  * Set a function \p func which is called when the label instruction is freed.
  * \p instr is the label instruction allowing \p func to free the label's
  * auxiliary data.
+ * \note This data field is not copied across instr_clone(). Instead, the
+ * clone's field will be NULL.
  */
 void
 instr_set_label_callback(instr_t *instr, instr_label_callback_t func);

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -2067,7 +2067,7 @@ DR_API
  * \p instr is the label instruction allowing \p func to free the label's
  * auxiliary data.
  * \note This data field is not copied across instr_clone(). Instead, the
- * clone's field will be NULL.
+ * clone's field will be NULL (xref i#3962).
  */
 void
 instr_set_label_callback(instr_t *instr, instr_label_callback_t func);

--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -130,7 +130,7 @@ instr_clone(dcontext_t *dcontext, instr_t *orig)
         /* We don't know what this callback does, we can't copy this. The caller that
          * makes the clone needs to take care of this, xref i#3926.
          */
-        instr_setlabel_callback(instr, NULL);
+        instr_set_label_callback(instr, NULL);
     }
 #ifdef CUSTOM_EXIT_STUBS
     if ((orig->flags & INSTR_HAS_CUSTOM_STUB) != 0) {

--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -126,6 +126,11 @@ instr_clone(dcontext_t *dcontext, instr_t *orig)
         instr->bytes =
             (byte *)heap_reachable_alloc(dcontext, instr->length HEAPACCT(ACCT_IR));
         memcpy((void *)instr->bytes, (void *)orig->bytes, instr->length);
+    } else if (instr_is_label(orig)) {
+        /* We don't know what this callback does, we can't copy this. The caller that
+         * makes the clone needs to take care of this, xref i#3926.
+         */
+        instr_setlabel_callback(instr, NULL);
     }
 #ifdef CUSTOM_EXIT_STUBS
     if ((orig->flags & INSTR_HAS_CUSTOM_STUB) != 0) {

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -758,6 +758,9 @@ typedef struct _emulated_instr_t {
  * Information about the instruction being emulated can be read from the label using
  * drmgr_get_emulated_instr_data().
  *
+ * If label callbacks are used, please note that the callback will not be cloned
+ * and its use is currently not consistent (xref i#3962).
+ *
  * \return false if the caller's \p emulated_instr_t is not compatible, true otherwise.
  *
  */


### PR DESCRIPTION
Label callbacks are called every time an instruction is destroyed if the instruction is
a label instruction and the field is valid. When cloning an instruction, we can't blindly
copy the label callback field causing it to be called when the cloned instruction is
destroyed. We are adding a note to the docs of instr_clone() and prevent the field from
being copied.

Fixes #3926
Issue: #3962 