### PR TITLE
i#2985 drx_expand_scatter_gather(): Re-factor and prepare for more state machines.

### DIFF
--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2592,21 +2592,19 @@ drx_restore_state_scatter_gather(
         params.pc = decode(drcontext, params.pc, &params.inst);
         if (params.pc == NULL) {
             /* Upon a decoding error we simply give up. */
-            goto drx_restore_state_scatter_gather_exit;
+            break;
         }
         /* If there is a gather or scatter instruction in the code cache, then it is wise
          * to assume that this is not an emulated sequence that we need to examine
          * further.
          */
         if (instr_is_gather(&params.inst))
-            goto drx_restore_state_scatter_gather_exit;
+            break;
         if (instr_is_scatter(&params.inst))
-            goto drx_restore_state_scatter_gather_exit;
+            break;
         if ((*state_machine_func)(drcontext, &params))
-            goto drx_restore_state_scatter_gather_exit;
+            break;
     }
-
-drx_restore_state_scatter_gather_exit:
     instr_free(drcontext, &params.inst);
     return true;
 }

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2832,24 +2832,24 @@ drx_avx512_gather_sequence_state_machine(
 }
 
 static bool
-drx_try_to_detect_avx512_gather_sequence(void *drcontext, dr_restore_state_info_t *info,
-                                         instr_t *inst, scatter_gather_info_t *sg_info)
+drx_restore_state_for_avx512_gather(void *drcontext, dr_restore_state_info_t *info,
+                                    instr_t *inst, scatter_gather_info_t *sg_info)
 {
     return drx_try_to_detect_scatter_gather_sequence(
         drcontext, info, inst, sg_info, drx_avx512_gather_sequence_state_machine);
 }
 
 static bool
-drx_try_to_detect_avx512_scatter_sequence(void *drcontext, dr_restore_state_info_t *info,
-                                          instr_t *inst, scatter_gather_info_t *sg_info)
+drx_restore_state_for_avx512_scatter(void *drcontext, dr_restore_state_info_t *info,
+                                     instr_t *inst, scatter_gather_info_t *sg_info)
 {
     return drx_try_to_detect_scatter_gather_sequence(
         drcontext, info, inst, sg_info, drx_avx512_scatter_sequence_state_machine);
 }
 
 static bool
-drx_try_to_detect_avx2_gather_sequence(void *drcontext, dr_restore_state_info_t *info,
-                                       instr_t *inst, scatter_gather_info_t *sg_info)
+drx_restore_state_for_avx2_gather(void *drcontext, dr_restore_state_info_t *info,
+                                  instr_t *inst, scatter_gather_info_t *sg_info)
 {
     return drx_try_to_detect_scatter_gather_sequence(
         drcontext, info, inst, sg_info, drx_avx2_gather_sequence_state_machine);
@@ -2881,17 +2881,14 @@ drx_event_restore_state(void *drcontext, bool restore_memory,
         if (instr_is_gather(&inst)) {
             if (sg_info.is_evex) {
                 success = success &&
-                    drx_try_to_detect_avx512_gather_sequence(drcontext, info, &inst,
-                                                             &sg_info);
+                    drx_restore_state_for_avx512_gather(drcontext, info, &inst, &sg_info);
             } else {
                 success = success &&
-                    drx_try_to_detect_avx2_gather_sequence(drcontext, info, &inst,
-                                                           &sg_info);
+                    drx_restore_state_for_avx2_gather(drcontext, info, &inst, &sg_info);
             }
         } else if (instr_is_scatter(&inst)) {
             success = success &&
-                drx_try_to_detect_avx512_scatter_sequence(drcontext, info, &inst,
-                                                          &sg_info);
+                drx_restore_state_for_avx512_scatter(drcontext, info, &inst, &sg_info);
         }
     }
     instr_free(drcontext, &inst);

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2661,7 +2661,7 @@ drx_avx512_gather_sequence_state_machine(
                "internal error: expected xmm register to be recorded in state "
                "machine.");
         if (instr_get_opcode(inst) == OP_vpinsrd) {
-            ASSERT(opnd_get_reg(instr_get_dst(inst, 0)),
+            ASSERT(opnd_is_reg(instr_get_dst(inst, 0)),
                    "internal error: unexpected instruction format");
             reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(inst, 0));
             if (tmp_reg == *the_scratch_xmm) {
@@ -2676,7 +2676,7 @@ drx_avx512_gather_sequence_state_machine(
         break;
     case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3:
         if (instr_get_opcode(inst) == OP_vinserti32x4) {
-            ASSERT(opnd_get_reg(instr_get_dst(inst, 0)),
+            ASSERT(opnd_is_reg(instr_get_dst(inst, 0)),
                    "internal error: unexpected instruction format");
             reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(inst, 0));
             if (tmp_reg == sg_info->gather_dst_reg) {

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2560,7 +2560,11 @@ skip_unknown_instr_inc(int reset_state, drx_state_machine_params_t *params)
     }
 }
 
-/* */
+/* Run the state machines and decode the code cache. The state machines will search the
+ * code for whether the translation pc is in one of the instruction windows that need
+ * additional handling by drx in order to restore specific state of the application's mask
+ * registers. We consider this sufficiently accurate, but this is still an approximation.
+ */
 static bool
 drx_restore_state_scatter_gather(
     void *drcontext, dr_restore_state_info_t *info, scatter_gather_info_t *sg_info,

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2523,13 +2523,21 @@ drx_expand_scatter_gather_exit:
 typedef struct _drx_state_machine_params_t {
     byte *pc;
     byte *prev_pc;
+    /* state machine's state. */
     int detect_state;
+    /* detected start pc of destination mask update */
     byte *restore_dest_mask_start_pc;
+    /* detected start pc of scratch mask usage */
     byte *restore_scratch_mask_start_pc;
+    /* counter to allow for skipping unknown instructions */
     int skip_unknown_instr_count;
+    /* detected scratch xmm register for mask update */
     reg_id_t the_scratch_xmm;
+    /* detected gpr register that holds the mask update immediate */
     reg_id_t gpr_bit_mask;
+    /* detected gpr register that holds the app's mask state */
     reg_id_t gpr_save_scratch_mask;
+    /* counter of scalar element in the scatter/gather sequence */
     uint scalar_mask_update_no;
     instr_t *inst;
     dr_restore_state_info_t *info;

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2523,7 +2523,7 @@ drx_expand_scatter_gather_exit:
 typedef struct _drx_state_machine_params_t {
     byte *pc;
     byte *prev_pc;
-    /* state machine's state. */
+    /* state machine's state */
     int detect_state;
     /* detected start pc of destination mask update */
     byte *restore_dest_mask_start_pc;


### PR DESCRIPTION
Converts calling the state machine into a function pointer call in order to be able to
more easily share code when adding an AVX-512 scatter and an AVX2 gather state machine.

The patch also fixes 2 minor assertion bugs and another minor state machine bug where we
did not skip unknown instructions.

Issue: #2985