### PR TITLE
i#3937 memtrace sigs: fix missing near-signal instructions

### DIFF
--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -117,8 +117,8 @@ analyzer_multi_t::analyzer_multi_t()
     } else if (op_infile.get_value().empty()) {
         // XXX i#3323: Add parallel analysis support for online tools.
         parallel = false;
-        serial_trace_iter =
-            std::unique_ptr<reader_t>(new ipc_reader_t(op_ipc_name.get_value().c_str()));
+        serial_trace_iter = std::unique_ptr<reader_t>(
+            new ipc_reader_t(op_ipc_name.get_value().c_str(), op_verbose.get_value()));
         trace_end = std::unique_ptr<reader_t>(new ipc_reader_t());
         if (!*serial_trace_iter) {
             success = false;

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -171,7 +171,8 @@ typedef enum {
     /**
      * The subsequent instruction is the start of a handler for a kernel-initiated
      * event: a signal handler on UNIX, or an APC, exception, or callback dispatcher
-     * on Windows.
+     * on Windows.  The value holds the module offset of the interruption point PC,
+     * which is used in post-processing.
      */
     TRACE_MARKER_TYPE_KERNEL_EVENT,
     /**

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -865,7 +865,9 @@ inflating instruction fetch statistics.
 Offline traces guarantee that a branch target instruction entry in a
 trace must immediately follow the branch instruction with no intervening
 thread switch.  This allows a core simulator to identify the target of a
-branch by looking at the subsequent trace entry.
+branch by looking at the subsequent trace entry.  However, this guarantee
+does not hold when a kernel event such as a signal is delivered
+immediately after a branch.
 
 Traces include scheduling markers providing the timestamp and hardware
 thread identifier on each thread transition, allowing a simulator to more

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -470,6 +470,45 @@ View tool results:
              20 : total disassembled instructions
 \endcode
 
+Here is an example of a signal handler interrupting the regular flow:
+
+\code
+  0x00007fa87c6c0512  eb 5a                jmp    $0x00007fa87c6c056e
+  0x00007fa87c6c056e  80 bd 7c ff ff ff 00 cmp    -0x84(%rbp), $0x00
+  0x00007fa87c6c0575  0f 85 e5 03 00 00    jnz    $0x00007fa87c6c0960
+<marker: kernel xfer to handler>
+<marker: timestamp 13218875821472138>
+<marker: tid 159754 on core 0>
+  0x00007fa879bb88dc  55                   push   %rbp
+  0x00007fa879bb88dd  48 89 e5             mov    %rsp, %rbp
+  0x00007fa879bb88e0  48 83 ec 40          sub    $0x40, %rsp
+  0x00007fa879bb88e4  89 7d dc             mov    %edi, -0x24(%rbp)
+  0x00007fa879bb88e7  48 89 75 d0          mov    %rsi, -0x30(%rbp)
+  0x00007fa879bb88eb  48 89 55 c8          mov    %rdx, -0x38(%rbp)
+  0x00007fa879bb88ef  83 7d dc 0a          cmp    -0x24(%rbp), $0x0a
+  0x00007fa879bb88f3  74 0e                jz     $0x00007fa879bb8903
+  0x00007fa879bb8903  48 8b 45 c8          mov    -0x38(%rbp), %rax
+  0x00007fa879bb8907  48 83 c0 28          add    $0x28, %rax
+  0x00007fa879bb890b  48 89 45 f8          mov    %rax, -0x08(%rbp)
+  0x00007fa879bb890f  48 8b 45 f8          mov    -0x08(%rbp), %rax
+  0x00007fa879bb8913  48 8b 80 80 00 00 00 mov    0x80(%rax), %rax
+  0x00007fa879bb891a  48 89 45 f0          mov    %rax, -0x10(%rbp)
+  0x00007fa879bb891e  eb 6d                jmp    $0x00007fa879bb898d
+  0x00007fa879bb898d  90                   nop
+  0x00007fa879bb898e  c9                   leave
+  0x00007fa879bb898f  c3                   ret
+  0x00007fa87c6ca3a0  48 c7 c0 0f 00 00 00 mov    $0x0000000f, %rax
+  0x00007fa87c6ca3a7  0f 05                syscall
+<marker: timestamp 13218875821472148>
+<marker: tid 159754 on core 0>
+<marker: syscall xfer>
+<marker: timestamp 13218875821475975>
+<marker: tid 159754 on core 4>
+  0x00007fa87c6c057b  48 8b 75 c8          mov    -0x38(%rbp), %rsi
+  0x00007fa87c6c057f  64 48 33 34 25 28 00 xor    %fs:0x28, %rsi
+                      00 00
+\endcode
+
 The top referenced cache lines are displayed by the \p histogram tool:
 
 \code
@@ -984,6 +1023,13 @@ these areas of missing functionality:
   dynamically generated code (https://github.com/DynamoRIO/dynamorio/issues/2062).
   All data references are included, but instruction fetches may be skipped.
   This problem is limited to offline traces.
+- If an instruction with multiple memory accesses faults on the
+  non-final access, the trace may incorrectly contain subsequent
+  accesses which did not actually happen
+  (https://github.com/DynamoRIO/dynamorio/issues/3958).
+- Online traces may skip instructions immediately prior to
+  non-load-or-store-related kernel transfer events
+  (https://github.com/DynamoRIO/dynamorio/issues/3937).
 - Application phase marking is not yet implemented
   (https://github.com/DynamoRIO/dynamorio/issues/2478).
 

--- a/clients/drcachesim/reader/ipc_reader.cpp
+++ b/clients/drcachesim/reader/ipc_reader.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -46,8 +46,9 @@ ipc_reader_t::ipc_reader_t()
     /* Empty. */
 }
 
-ipc_reader_t::ipc_reader_t(const char *ipc_name)
-    : pipe(ipc_name)
+ipc_reader_t::ipc_reader_t(const char *ipc_name, int verbosity_in)
+    : reader_t(verbosity_in, "IPC")
+    , pipe(ipc_name)
 {
     // We create the pipe here so the user can set up a pipe writer
     // *before* calling the blocking analyzer_t::run().

--- a/clients/drcachesim/reader/ipc_reader.h
+++ b/clients/drcachesim/reader/ipc_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -46,7 +46,7 @@
 class ipc_reader_t : public reader_t {
 public:
     ipc_reader_t();
-    explicit ipc_reader_t(const char *ipc_name);
+    ipc_reader_t(const char *ipc_name, int verbosity);
     virtual ~ipc_reader_t();
     virtual bool operator!();
     // This potentially blocks.

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -64,7 +64,7 @@ reader_t::operator++()
             // We've already presented the thread exit entry to the analyzer.
             continue;
         }
-        VPRINT(this, 4, "RECV: type=%d, size=%d, addr=%zd\n", input_entry->type,
+        VPRINT(this, 4, "RECV: type=%d, size=%d, addr=0x%zx\n", input_entry->type,
                input_entry->size, input_entry->addr);
         bool have_memref = false;
         switch (input_entry->type) {

--- a/clients/drcachesim/tests/signal_invariants.c
+++ b/clients/drcachesim/tests/signal_invariants.c
@@ -1,0 +1,251 @@
+/* **********************************************************
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Adapted from suite/tests/pthreads/ptsig.c, with extra cases added.
+ * This is a test of signal corner cases.  It partners with trace_invariants.cpp,
+ * passing annotations to indicate places to check.
+ */
+
+#ifndef ASM_CODE_ONLY /* C code */
+
+#    include "tools.h"
+#    include <stdio.h>
+#    include <stdlib.h>
+#    include <pthread.h>
+#    include <signal.h>
+#    include <ucontext.h>
+#    include <unistd.h>
+#    include <assert.h>
+#    include <setjmp.h>
+
+#    ifndef X86
+/* We really just need one test of signal corner cases, so there is little need
+ * to port the asm here beyond x86.
+ */
+#        error ARM is not supported in test assembly code
+#    endif
+
+/* asm routines */
+void
+signal_handler_asm();
+void
+test_signal_midbb(void);
+void
+test_signal_startbb(void);
+void
+test_signal_midmemref(void);
+void
+test_signal_sigsegv_resume(void);
+
+volatile double pi = 0.0;        /* Approximation to pi (shared). */
+pthread_mutex_t pi_lock;         /* The lock for "pi". */
+static const int intervals = 10; /* How many intervals should we run? */
+static SIGJMP_BUF mark;
+
+static volatile bool resume_sigsegv = false;
+
+void /* non-static since called from asm */
+signal_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
+{
+    switch (sig) {
+    case SIGUSR1: {
+        sigcontext_t *sc = SIGCXT_FROM_UCXT(ucxt);
+        void *pc = (void *)sc->SC_XIP;
+        break;
+    }
+    case SIGSEGV:
+        /* We have two cases: one where we longjmp and another where we tweak
+         * xax to be readable and then re-execute.
+         */
+        if (!resume_sigsegv)
+            SIGLONGJMP(mark, 1);
+        sigcontext_t *sc = SIGCXT_FROM_UCXT(ucxt);
+        sc->SC_XAX = sc->SC_XSP;
+        break;
+    case SIGILL: SIGLONGJMP(mark, 1); break;
+    default: assert(0);
+    }
+}
+
+void *
+process(void *arg)
+{
+    char *id = (char *)arg;
+    register double width, localsum;
+    register int i;
+    register int iproc;
+
+    /* More signals for testing. */
+    kill(getpid(), SIGUSR1);
+
+    iproc = (*id - '0');
+
+    width = 1.0 / intervals;
+
+    /* Perform the local computations. */
+    localsum = 0;
+    for (i = iproc; i < intervals; i += 2) {
+        register double x = (i + 0.5) * width;
+        localsum += 4.0 / (1.0 + x * x);
+    }
+    localsum *= width;
+
+    /* Lock pi for update, update it, and unlock. */
+    pthread_mutex_lock(&pi_lock);
+    pi += localsum;
+    pthread_mutex_unlock(&pi_lock);
+
+    return (NULL);
+}
+
+int
+main(int argc, char **argv)
+{
+    intercept_signal(SIGUSR1, signal_handler_asm, false);
+    intercept_signal(SIGSEGV, signal_handler_asm, false);
+    intercept_signal(SIGILL, signal_handler_asm, false);
+
+    /* Perform our assembly tests. */
+    if (SIGSETJMP(mark) == 0) {
+        test_signal_midbb();
+    }
+    if (SIGSETJMP(mark) == 0) {
+        test_signal_startbb();
+    }
+    if (SIGSETJMP(mark) == 0) {
+        test_signal_midmemref();
+    }
+    resume_sigsegv = true;
+    test_signal_sigsegv_resume();
+
+    pthread_t thread0, thread1;
+    void *retval;
+
+    pthread_mutex_init(&pi_lock, NULL);
+
+    if (pthread_create(&thread0, NULL, process, (void *)"0") ||
+        pthread_create(&thread1, NULL, process, (void *)"1")) {
+        print("%s: cannot make thread\n", argv[0]);
+        exit(1);
+    }
+
+    if (pthread_join(thread0, &retval) || pthread_join(thread1, &retval)) {
+        print("%s: thread join failed\n", argv[0]);
+        exit(1);
+    }
+
+    /* More signals for testing. */
+    kill(getpid(), SIGUSR1);
+
+    print("Estimation of pi is %16.15f\n", pi);
+
+    return 0;
+}
+
+#else /* asm code *************************************************************/
+#    include "asm_defines.asm"
+/* clang-format off */
+START_FILE
+DECL_EXTERN(signal_handler)
+
+#define FUNCNAME signal_handler_asm
+        DECLARE_FUNC(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        /* prefetcht0 with address 1 marks the handler */
+        prefetcht0 [1]
+        jmp signal_handler
+        END_FUNC(FUNCNAME)
+#undef FUNCNAME
+
+#define FUNCNAME test_signal_midbb
+        DECLARE_FUNC(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        /* prefetcht2's address is the instr count until a signal */
+        prefetcht2 [3]
+        nop
+        nop
+        ud2a
+        nop
+        nop
+        nop
+        ret
+        END_FUNC(FUNCNAME)
+#undef FUNCNAME
+
+#define FUNCNAME test_signal_startbb
+        DECLARE_FUNC(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        /* prefetcht2's address is the instr count until a signal */
+        prefetcht2 [2]
+        jmp      new_bb
+    new_bb:
+        ud2a
+        ret
+        END_FUNC(FUNCNAME)
+#undef FUNCNAME
+
+#define FUNCNAME test_signal_midmemref
+        DECLARE_FUNC(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        /* Set up a multi-memref instr where the 1st memref faults.
+         * XXX i#3958: Today the 2nd movs memref is incorrectly included *before*
+         * the fault.
+         */
+        /* prefetcht2's address is the instr count until a signal */
+        prefetcht2 [5]
+        /* prefetcht1's address is the memref count until a signal */
+        prefetcht1 [3]
+        mov      REG_XSI, HEX(42)
+        mov      REG_XDI, REG_XSP
+        push     REG_XAX
+        movsq
+        pop      REG_XAX
+        ret
+        END_FUNC(FUNCNAME)
+#undef FUNCNAME
+
+#define FUNCNAME test_signal_sigsegv_resume
+        DECLARE_FUNC(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        /* This is a test case of a signal handler resuming at the interruption point.
+         * The handler changes xax to hold a valid address.
+         */
+        mov      REG_XAX, HEX(42)
+        mov      REG_XCX, PTRSZ [REG_XAX]
+        ret
+        END_FUNC(FUNCNAME)
+#undef FUNCNAME
+
+END_FILE
+/* clang-format on */
+#endif

--- a/clients/drcachesim/tests/signal_invariants.c
+++ b/clients/drcachesim/tests/signal_invariants.c
@@ -228,7 +228,7 @@ GLOBAL_LABEL(FUNCNAME:)
         mov      REG_XSI, HEX(42)
         mov      REG_XDI, REG_XSP
         push     REG_XAX
-        movsq
+        movsd
         pop      REG_XAX
         ret
         END_FUNC(FUNCNAME)

--- a/clients/drcachesim/tests/trace_invariants.cpp
+++ b/clients/drcachesim/tests/trace_invariants.cpp
@@ -38,9 +38,15 @@
 trace_invariants_t::trace_invariants_t(bool offline, unsigned int verbose)
     : knob_offline(offline)
     , knob_verbose(verbose)
+    , instrs_until_interrupt(-1)
+    , memrefs_until_interrupt(-1)
+    , app_handler_pc(0)
 {
     memset(&prev_instr, 0, sizeof(prev_instr));
-    memset(&prev_marker, 0, sizeof(prev_marker));
+    memset(&pre_signal_instr, 0, sizeof(pre_signal_instr));
+    memset(&prev_xfer_marker, 0, sizeof(prev_xfer_marker));
+    memset(&prev_entry, 0, sizeof(prev_entry));
+    memset(&prev_prev_entry, 0, sizeof(prev_prev_entry));
 }
 
 trace_invariants_t::~trace_invariants_t()
@@ -50,6 +56,33 @@ trace_invariants_t::~trace_invariants_t()
 bool
 trace_invariants_t::process_memref(const memref_t &memref)
 {
+    // Check conditions specific to the signal_invariants app, where it
+    // has annotations in prefetch instructions telling us how many instrs
+    // and/or memrefs until a signal should arrive.
+    if ((instrs_until_interrupt == 0 && memrefs_until_interrupt == -1) ||
+        (instrs_until_interrupt == -1 && memrefs_until_interrupt == 0) ||
+        (instrs_until_interrupt == 0 && memrefs_until_interrupt == 0)) {
+        assert((memref.marker.type == TRACE_TYPE_MARKER &&
+                memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) ||
+               // TODO i#3937: Online instr bundles currently violate this.
+               !knob_offline);
+        instrs_until_interrupt = -1;
+        memrefs_until_interrupt = -1;
+    }
+    if (memrefs_until_interrupt >= 0 &&
+        (memref.data.type == TRACE_TYPE_READ || memref.data.type == TRACE_TYPE_WRITE)) {
+        assert(memrefs_until_interrupt != 0);
+        --memrefs_until_interrupt;
+    }
+    // Check that the signal delivery marker is immediately followed by the
+    // app's signal handler, which we have annotated with "prefetcht0 [1]".
+    if (memref.data.type == TRACE_TYPE_PREFETCHT0 && memref.data.addr == 1) {
+        assert(type_is_instr(prev_entry.instr.type) &&
+               prev_prev_entry.marker.type == TRACE_TYPE_MARKER &&
+               prev_xfer_marker.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT);
+        app_handler_pc = prev_entry.instr.addr;
+    }
+
     if (memref.exit.type == TRACE_TYPE_THREAD_EXIT)
         thread_exited[memref.exit.tid] = true;
     if (type_is_instr(memref.instr.type) ||
@@ -63,6 +96,9 @@ trace_invariants_t::process_memref(const memref_t &memref)
                               : "")
                       << " instr x" << memref.instr.size << "\n";
         }
+        assert(instrs_until_interrupt != 0);
+        if (instrs_until_interrupt > 0)
+            --instrs_until_interrupt;
         // Invariant: offline traces guarantee that a branch target must immediately
         // follow the branch w/ no intervening trace switch.
         if (knob_offline && type_is_instr_branch(prev_instr.instr.type)) {
@@ -80,28 +116,62 @@ trace_invariants_t::process_memref(const memref_t &memref)
                 // String loop.
                 (prev_instr.instr.addr == memref.instr.addr &&
                  memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH) ||
-                // Kernel-mediated.
-                (prev_marker.instr.tid == memref.instr.tid &&
-                 (prev_marker.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-                  prev_marker.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER)) ||
+                // Kernel-mediated, but we can't tell if we had a thread swap.
+                (prev_xfer_marker.instr.tid != memref.instr.tid ||
+                 (prev_xfer_marker.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+                  prev_xfer_marker.marker.marker_type ==
+                      TRACE_MARKER_TYPE_KERNEL_XFER)) ||
                 prev_instr.instr.type == TRACE_TYPE_INSTR_SYSENTER);
         }
+#ifdef UNIX
+        // Ensure signal handlers return to the interruption point.
+        if (prev_xfer_marker.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER) {
+            assert(memref.instr.tid != pre_signal_instr.instr.tid ||
+                   memref.instr.addr == pre_signal_instr.instr.addr ||
+                   // Asynch will go to the subsequent instr.
+                   memref.instr.addr ==
+                       pre_signal_instr.instr.addr + pre_signal_instr.instr.size ||
+                   // Nested signal.  XXX: This only works for our annotated test
+                   // signal_invariants.
+                   memref.instr.addr == app_handler_pc ||
+                   // Too hard to figure out branch targets.
+                   type_is_instr_branch(pre_signal_instr.instr.type));
+        }
+#endif
         prev_instr = memref;
+        // Clear prev_xfer_marker on an instr (not a memref which could come between an
+        // instr and a kernel-mediated far-away instr) to ensure it's *immediately*
+        // prior (i#3937).
+        memset(&prev_xfer_marker, 0, sizeof(prev_xfer_marker));
     }
-    if (memref.marker.type == TRACE_TYPE_MARKER) {
+    if (memref.marker.type == TRACE_TYPE_MARKER &&
+        // Ignore timestamp, etc. markers which show up a signal delivery boundaries
+        // b/c the tracer does a buffer flush there.
+        (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+         memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER)) {
         if (knob_verbose >= 3) {
             std::cerr << "::" << memref.data.pid << ":" << memref.data.tid << ":: "
                       << "marker type " << memref.marker.marker_type << " value "
                       << memref.marker.marker_value << "\n";
         }
-        prev_marker = memref;
-        // Clear prev_instr to avoid a branch-gap failure above for things like
-        // wow64 call* NtContinue syscall.
-        memset(&prev_instr, 0, sizeof(prev_instr));
-    } else {
-        // Clear prev_marker to ensure it's *immediately* prior (i#3937). */
-        memset(&prev_marker, 0, sizeof(prev_marker));
+        if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT &&
+            // Give up on back-to-back signals.
+            prev_xfer_marker.marker.marker_type != TRACE_MARKER_TYPE_KERNEL_XFER)
+            pre_signal_instr = prev_instr;
+        prev_xfer_marker = memref;
     }
+
+    // Look for annotations where signal_invariants.c passes info to us on what to
+    // check for.  We assume the app does not have prefetch instrs w/ low addresses.
+    if (memref.data.type == TRACE_TYPE_PREFETCHT2 && memref.data.addr < 1024) {
+        instrs_until_interrupt = static_cast<int>(memref.data.addr);
+    }
+    if (memref.data.type == TRACE_TYPE_PREFETCHT1 && memref.data.addr < 1024) {
+        memrefs_until_interrupt = static_cast<int>(memref.data.addr);
+    }
+
+    prev_prev_entry = prev_entry;
+    prev_entry = memref;
     return true;
 }
 

--- a/clients/drcachesim/tests/trace_invariants.h
+++ b/clients/drcachesim/tests/trace_invariants.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -53,7 +53,13 @@ protected:
     bool knob_offline;
     unsigned int knob_verbose;
     memref_t prev_instr;
-    memref_t prev_marker;
+    memref_t prev_xfer_marker;
+    memref_t prev_entry;
+    memref_t prev_prev_entry;
+    memref_t pre_signal_instr;
+    int instrs_until_interrupt;
+    int memrefs_until_interrupt;
+    addr_t app_handler_pc;
     std::unordered_map<memref_tid_t, bool> thread_exited;
 };
 

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -222,6 +222,9 @@ public:
     get_entry_addr(byte *buf_ptr) const;
     virtual void
     set_entry_addr(byte *buf_ptr, addr_t addr);
+
+    uint64_t
+    get_modoffs(void *drcontext, app_pc pc);
 
     virtual int
     append_pid(byte *buf_ptr, process_id_t pid);

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -313,6 +313,15 @@ offline_instru_t::insert_save_entry(void *drcontext, instrlist_t *ilist, instr_t
                                opnd_create_reg(scratch)));
 #endif
     return sizeof(offline_entry_t);
+}
+
+uint64_t
+offline_instru_t::get_modoffs(void *drcontext, app_pc pc)
+{
+    app_pc modbase;
+    if (drmodtrack_lookup(drcontext, pc, NULL, &modbase) != DRCOVLIB_SUCCESS)
+        return 0;
+    return pc - modbase;
 }
 
 int

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -546,7 +546,8 @@ raw2trace_t::process_thread_file(raw2trace_thread_data_t *tdata)
                     return tdata->error;
             } else {
                 std::stringstream ss;
-                ss << "Failed to process file for thread " << (uint)tdata->tid;
+                ss << "Failed to process file for thread " << (uint)tdata->tid << ": "
+                   << tdata->error;
                 tdata->error = ss.str();
                 return tdata->error;
             }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2910,10 +2910,16 @@ endif ()
       # We run an app w/ kernel xfers to test trace_invariants online.
       # Offline invariants are tested in the tool.histogram.offline test below.
       if (UNIX)
-        add_exe(drmemtrace.signal_invariants
-          "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/signal_invariants.c")
-        link_with_pthread(drmemtrace.signal_invariants)
-        set(kernel_xfer_app drmemtrace.signal_invariants)
+        # The signal_invariants asm is x86-only.  The extra checks are cross-arch
+        # so we do not try to port it to ARM or Mac but use a different app there.
+        if (X86 AND NOT APPLE)
+          add_exe(drmemtrace.signal_invariants
+            "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/signal_invariants.c")
+          link_with_pthread(drmemtrace.signal_invariants)
+          set(kernel_xfer_app drmemtrace.signal_invariants)
+        else ()
+          set(kernel_xfer_app pthreads.ptsig)
+        endif ()
       else ()
         if (CLIENT_INTERFACE)
           set(kernel_xfer_app client.winxfer) # We want threads and xfers.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -538,7 +538,8 @@ function(add_exe test source)
   if ("${srccode}" MATCHES "ifndef ASM_CODE_ONLY")
     # we rely on the asm rule doing preprocessing for us, so we just make
     # a copy and set the ASM_CODE_ONLY define
-    add_split_asm_target("${CMAKE_CURRENT_SOURCE_DIR}/${source}" asm_source gen_asm_tgt
+    get_filename_component(source_abs "${source}" ABSOLUTE)
+    add_split_asm_target("${source_abs}" asm_source gen_asm_tgt
       "_asm" "${asm_defs}" "${asm_deps}")
     set(test_srcs ${test_srcs} ${asm_source})
   endif ("${srccode}" MATCHES "ifndef ASM_CODE_ONLY")
@@ -2909,7 +2910,10 @@ endif ()
       # We run an app w/ kernel xfers to test trace_invariants online.
       # Offline invariants are tested in the tool.histogram.offline test below.
       if (UNIX)
-        set(kernel_xfer_app pthreads.ptsig)
+        add_exe(drmemtrace.signal_invariants
+          "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/signal_invariants.c")
+        link_with_pthread(drmemtrace.signal_invariants)
+        set(kernel_xfer_app drmemtrace.signal_invariants)
       else ()
         if (CLIENT_INTERFACE)
           set(kernel_xfer_app client.winxfer) # We want threads and xfers.


### PR DESCRIPTION
Adds the module offset of the interruption point PC to the kernel
event marker to record when a signal happened.  Refactors
raw2trace to check for signals after every insruction and not
just every memref, and to look at the offset for correct
placement.

Adds a new test application signal_invariants which uses assembly
for precise control over tests around signal marker placement.
Changes the trace_invariants tests to use this new application.
The test uses prefetch instructions as annotations to communicate
with the trace_invariants reader.  Uses the new test to add
several additional invariant checks to trace_invariants: signal
placement mid-bb, placement mid-memref, handler resumption,
handler immediacy.

Updates the docs to show an example of a signal handler
interruption in the view tool.

Documents the multi-memref fault issue (#3958) and the online
trace missing instruction issue (#3739).

Passes -verbose to the IPC reader for online trace debugging.

Solving signal placement in the middle of online trace
instruction bundles is left for future work.  Comments in the
code and docs make this clear.

Issue: #3937