### PR TITLE
i#2985 drx_expand_scatter_gather(): Add drx restore state machine for AVX2 gather.

### DIFF
--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2782,8 +2782,8 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                         if (params->restore_dest_mask_start_pc <=
                                 params->info->raw_mcontext->pc &&
                             params->info->raw_mcontext->pc <= params->prev_pc) {
-                            /* Fix the gather's destination mask here and zeroe
-                             * out the bit that the emulation sequence hadn't done
+                            /* Fix the gather's destination mask here and zero out
+                             * the bit that the emulation sequence hadn't done
                              * before the fault hit.
                              */
                             ASSERT(reg_is_strictly_xmm(params->sg_info->mask_reg) ||
@@ -2971,8 +2971,8 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                         if (params->restore_dest_mask_start_pc <=
                                 params->info->raw_mcontext->pc &&
                             params->info->raw_mcontext->pc <= params->prev_pc) {
-                            /* Fix the gather's destination mask here and zeroe
-                             * out the bit that the emulation sequence hadn't done
+                            /* Fix the gather's destination mask here and zero out
+                             * the bit that the emulation sequence hadn't done
                              * before the fault hit.
                              */
                             params->info->mcontext

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -64,6 +64,7 @@
 #endif                     /* DEBUG */
 
 #define XMM_REG_SIZE 16
+#define YMM_REG_SIZE 32
 #define MAX(x, y) ((x) >= (y) ? (x) : (y))
 
 #ifdef X86
@@ -2493,14 +2494,34 @@ drx_expand_scatter_gather_exit:
  *     (b) kmovw         %edx -> %k0
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0
  *
- * (a): The instruction window where the destination mask state is stale.
+ * (a): The instruction window where the destination mask state hadn't been updated yet.
  * (b): The instruction window where the scratch mask is clobbered w/o support by drreg.
  *
  * AVX-512 scatter sequence detection example:
  * TODO i#2985: support.
  *
  * AVX2 gather sequence detection example:
- * TODO i#2985: support.
+ *
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0
+ *         mov           (%rax,%rcx,4)[4byte] -> %ecx
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1
+ * (a)     vextracti128  %ymm0 $0x00 -> %xmm3
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2
+ * (a)     vpinsrd       %xmm3 %ecx $0x00 -> %xmm3
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3
+ * (a)     vinserti128   %ymm0 %xmm3 $0x00 -> %ymm0
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4
+ * (a)     xor           %ecx %ecx -> %ecx
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5
+ * (a)     vextracti128  %ymm2 $0x00 -> %xmm3
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6
+ * (a)     vpinsrd       %xmm3 %ecx $0x00 -> %xmm3
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7
+ * (a)     vinserti128   %ymm2 %xmm3 $0x00 -> %ymm2
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0
+ *
+ * (a): The instruction window where the destination mask state hadn't been updated yet.
+ *
  */
 
 #    define DRX_RESTORE_EVENT_SKIP_UNKNOWN_INSTR_MAX 32
@@ -2516,9 +2537,17 @@ drx_expand_scatter_gather_exit:
 #    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7 7
 #    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8 8
 
-/* TODO i#2985: implement a state machine for AVX-512 scatter
- * as well as AVX2 gather.
- */
+/* States of the AVX2 gather detection state machine. */
+#    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0 0
+#    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1 1
+#    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2 2
+#    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3 3
+#    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4 4
+#    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5 5
+#    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6 6
+#    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7 7
+
+/* TODO i#2985: implement a state machine for AVX-512 scatter. */
 
 typedef struct _drx_state_machine_params_t {
     byte *pc;
@@ -2614,8 +2643,186 @@ static bool
 drx_avx2_gather_sequence_state_machine(void *drcontext,
                                        drx_state_machine_params_t *params)
 {
-    /* TODO i#2985: support AVX2 gather. */
-    return true;
+    switch (params->detect_state) {
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0:
+        if (instr_reads_memory(&params->inst)) {
+            opnd_t dst0 = instr_get_dst(&params->inst, 0);
+            if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
+                params->restore_dest_mask_start_pc = params->pc;
+                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
+                break;
+            }
+        }
+        /* We don't need to ignore any instructions here, because we are already in
+         * DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0.
+         */
+        break;
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1:
+        if (instr_get_opcode(&params->inst) == OP_vextracti128) {
+            opnd_t dst0 = instr_get_dst(&params->inst, 0);
+            if (opnd_is_reg(dst0)) {
+                reg_id_t tmp_reg = opnd_get_reg(dst0);
+                if (!reg_is_strictly_xmm(tmp_reg))
+                    break;
+                params->the_scratch_xmm = tmp_reg;
+                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+                break;
+            }
+        }
+        /* Intentionally not else if */
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        break;
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2:
+        ASSERT(params->the_scratch_xmm != DR_REG_NULL,
+               "internal error: expected xmm register to be recorded in state "
+               "machine.");
+        if (instr_get_opcode(&params->inst) == OP_vpinsrd) {
+            ASSERT(opnd_is_reg(instr_get_dst(&params->inst, 0)),
+                   "internal error: unexpected instruction format");
+            reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
+            if (tmp_reg == params->the_scratch_xmm) {
+                params->the_scratch_xmm = DR_REG_NULL;
+                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3, params);
+                break;
+            }
+        }
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        break;
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3:
+        if (instr_get_opcode(&params->inst) == OP_vinserti128) {
+            ASSERT(opnd_is_reg(instr_get_dst(&params->inst, 0)),
+                   "internal error: unexpected instruction format");
+            reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
+            if (tmp_reg == params->sg_info->gather_dst_reg) {
+                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4, params);
+                break;
+            }
+        }
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        break;
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4:
+        if (instr_get_opcode(&params->inst) == OP_xor) {
+            opnd_t dst0 = instr_get_dst(&params->inst, 0);
+            opnd_t src0 = instr_get_src(&params->inst, 0);
+            opnd_t src1 = instr_get_src(&params->inst, 1);
+            if (opnd_is_reg(dst0) && opnd_is_reg(src0) && opnd_is_reg(src1)) {
+                reg_id_t reg_dst0 = opnd_get_reg(dst0);
+                reg_id_t reg_src0 = opnd_get_reg(src0);
+                reg_id_t reg_src1 = opnd_get_reg(src1);
+                ASSERT(reg_is_gpr(reg_dst0) && reg_is_gpr(reg_src0) &&
+                           reg_is_gpr(reg_src1),
+                       "internal error: unexpected instruction format");
+                if (reg_dst0 == reg_src0 && reg_src0 == reg_src1) {
+                    params->gpr_bit_mask = reg_dst0;
+                    advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5, params);
+                }
+            }
+        }
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        break;
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5:
+        if (instr_get_opcode(&params->inst) == OP_vextracti128) {
+            opnd_t src0 = instr_get_src(&params->inst, 0);
+            if (opnd_is_reg(src0)) {
+                if (opnd_get_reg(src0) == params->sg_info->mask_reg) {
+                    opnd_t dst0 = instr_get_dst(&params->inst, 0);
+                    if (opnd_is_reg(dst0)) {
+                        reg_id_t tmp_reg = opnd_get_reg(dst0);
+                        if (!reg_is_strictly_xmm(tmp_reg))
+                            break;
+                        params->the_scratch_xmm = tmp_reg;
+                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6,
+                                      params);
+                        break;
+                    }
+                }
+            }
+        }
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        break;
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6:
+        ASSERT(params->the_scratch_xmm != DR_REG_NULL,
+               "internal error: expected xmm register to be recorded in state "
+               "machine.");
+        if (instr_get_opcode(&params->inst) == OP_vpinsrd) {
+            opnd_t src1 = instr_get_src(&params->inst, 1);
+            if (opnd_is_reg(src1)) {
+                if (opnd_get_reg(src1) == params->gpr_bit_mask) {
+                    ASSERT(opnd_is_reg(instr_get_dst(&params->inst, 0)),
+                           "internal error: unexpected instruction format");
+                    reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
+                    if (tmp_reg == params->the_scratch_xmm) {
+                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7,
+                                      params);
+                        break;
+                    }
+                }
+            }
+        }
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        break;
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7:
+        if (instr_get_opcode(&params->inst) == OP_vinserti128) {
+            ASSERT(opnd_is_reg(instr_get_dst(&params->inst, 0)) &&
+                       opnd_is_reg(instr_get_src(&params->inst, 0)) &&
+                       opnd_is_reg(instr_get_src(&params->inst, 1)),
+                   "internal error: unexpected instruction format");
+            reg_id_t dst0 = opnd_get_reg(instr_get_dst(&params->inst, 0));
+            reg_id_t src0 = opnd_get_reg(instr_get_src(&params->inst, 0));
+            reg_id_t src1 = opnd_get_reg(instr_get_src(&params->inst, 1));
+            if (src1 == params->the_scratch_xmm) {
+                if (src0 == params->sg_info->mask_reg) {
+                    if (dst0 == params->sg_info->mask_reg) {
+                        if (params->restore_dest_mask_start_pc <=
+                                params->info->raw_mcontext->pc &&
+                            params->info->raw_mcontext->pc <= params->prev_pc) {
+                            /* Fix the gather's destination mask here and zeroe
+                             * out the bit that the emulation sequence hadn't done
+                             * before the fault hit.
+                             */
+                            ASSERT(reg_is_strictly_xmm(params->sg_info->mask_reg) ||
+                                       reg_is_strictly_ymm(params->sg_info->mask_reg),
+                                   "internal error: unexpected instruction format");
+                            byte val[YMM_REG_SIZE];
+                            if (!reg_get_value_ex(params->sg_info->mask_reg,
+                                                  params->info->mcontext, val)) {
+                                ASSERT(
+                                    false,
+                                    "internal error: can't read mcontext's mask value");
+                            }
+                            uint mask_byte =
+                                opnd_size_in_bytes(params->sg_info->scalar_index_size) *
+                                    (params->scalar_mask_update_no + 1) -
+                                1;
+                            val[mask_byte] &= ~(byte)128;
+                            reg_set_value_ex(params->sg_info->mask_reg,
+                                             params->info->mcontext, val);
+                            /* We are done. */
+                            return true;
+                        }
+                        params->scalar_mask_update_no++;
+                        uint no_of_elements =
+                            opnd_size_in_bytes(params->sg_info->scatter_gather_size) /
+                            MAX(opnd_size_in_bytes(params->sg_info->scalar_index_size),
+                                opnd_size_in_bytes(params->sg_info->scalar_value_size));
+                        if (params->scalar_mask_update_no > no_of_elements) {
+                            /* Unlikely that something looks identical to an emulation
+                             * sequence for this long, but we safely can return here.
+                             */
+                            return true;
+                        }
+                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0,
+                                      params);
+                        break;
+                    }
+                }
+            }
+        }
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        break;
+    default: ASSERT(false, "internal error: invalid state.");
+    }
+    return false;
 }
 
 /* Returns true if done, false otherwise. */
@@ -2762,6 +2969,9 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                             params->info->mcontext
                                 ->opmask[params->sg_info->mask_reg - DR_REG_K0] &=
                                 ~(1 << params->scalar_mask_update_no);
+                            /* We are not done yet, we have to fix up the scratch
+                             * mask as well.
+                             */
                         }
                         /* We are counting the scalar load number in the sequence
                          * here.
@@ -2809,8 +3019,10 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                                 reg_get_value(params->gpr_save_scratch_mask,
                                               params->info->mcontext) &
                                 0xffff;
-                            advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0,
-                                          params);
+                            /* We are done. If we did fix up the gather's destination
+                             * mask, this already has happened.
+                             */
+                            return true;
                         }
                     }
                 }

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -1769,8 +1769,8 @@ expand_avx512_scatter_gather_update_mask(void *drcontext, instrlist_t *bb,
                                               reg_64_to_32(scratch_reg), scratch_reg)),
                                           OPND_CREATE_INT32(1 << el)),
                      orig_app_pc));
-    /* TODO i#2985: Support the drx restore event for AVX2 gather and AVX-512 scatter.
-     * AVX-512 gather is already supported.
+    /* TODO i#2985: Support the drx restore event for AVX-512 scatter.
+     * AVX-512 gather and AVX2 gather is already supported.
      */
     if (drreg_reserve_register(drcontext, bb, sg_instr, allowed, &save_mask_reg) !=
         DRREG_SUCCESS)

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2676,7 +2676,10 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
-        if (instr_get_opcode(&params->inst) == OP_vpinsrd) {
+        if ((params->sg_info->scalar_value_size == OPSZ_4 &&
+             instr_get_opcode(&params->inst) == OP_vpinsrd) ||
+            (params->sg_info->scalar_value_size == OPSZ_8 &&
+             instr_get_opcode(&params->inst) == OP_vpinsrq)) {
             ASSERT(opnd_is_reg(instr_get_dst(&params->inst, 0)),
                    "internal error: unexpected instruction format");
             reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
@@ -2744,7 +2747,10 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
-        if (instr_get_opcode(&params->inst) == OP_vpinsrd) {
+        if ((params->sg_info->scalar_value_size == OPSZ_4 &&
+             instr_get_opcode(&params->inst) == OP_vpinsrd) ||
+            (params->sg_info->scalar_value_size == OPSZ_8 &&
+             instr_get_opcode(&params->inst) == OP_vpinsrq)) {
             opnd_t src1 = instr_get_src(&params->inst, 1);
             if (opnd_is_reg(src1)) {
                 if (opnd_get_reg(src1) == params->gpr_bit_mask) {
@@ -2872,7 +2878,10 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
-        if (instr_get_opcode(&params->inst) == OP_vpinsrd) {
+        if ((params->sg_info->scalar_value_size == OPSZ_4 &&
+             instr_get_opcode(&params->inst) == OP_vpinsrd) ||
+            (params->sg_info->scalar_value_size == OPSZ_8 &&
+             instr_get_opcode(&params->inst) == OP_vpinsrq)) {
             ASSERT(opnd_is_reg(instr_get_dst(&params->inst, 0)),
                    "internal error: unexpected instruction format");
             reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));

--- a/suite/tests/client-interface/drx-scattergather.c
+++ b/suite/tests/client-interface/drx-scattergather.c
@@ -255,7 +255,7 @@ signal_handler_check_ymm1(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
 #        ifdef X64
     if (((fp->xmm_space[8] >> 31) & 0x1) != 0) {
 #        else
-    if (((fp->_xmm[2].element[3] >> 31) & 0x1) != 0) {
+    if (((fp->_xmm[2].element[0] >> 31) & 0x1) != 0) {
 #        endif
         print("ERROR: expected xmm2[31:30] == 0\n");
     }

--- a/suite/tests/client-interface/drx-scattergather.templatex
+++ b/suite/tests/client-interface/drx-scattergather.templatex
@@ -43,7 +43,6 @@ ERROR: expected k1 == 0xfffe, but is 0xffff
 #endif
 #endif
 Test updating the AVX2 gather mask register upon translation events
-ERROR: expected xmm2\[31:30\] == 0
 #endif
 AVX2/AVX-512 scatter/gather checks ok
 #ifdef X64


### PR DESCRIPTION
Adds support for restoring the destination mask in the AVX2 gather emulation sequence. As
before, detection is done by a state machine that attempts to match a known pattern of the
emulation sequence.

Removes the relevant error from client.drx-scattergather and fixes a bug in the test for AVX2
gather in 32-bit mode.

Fixes a bug in the AVX-512 state machine if index is OPSZ_8. Only OPSZ_4 is currently
tested in drx.scattergather.

Issue: #2985