### PR TITLE
Improve handling and documentation about supported and unsupported value types in droption

### DIFF
--- a/ext/droption/droption.dox
+++ b/ext/droption/droption.dox
@@ -40,7 +40,7 @@ declaration and parsing for both clients and standalone programs.
 
  - \ref sec_droption_setup
  - \ref sec_droption_usage
- - \ref sec_droption_special
+ - \ref sec_droption_types
  - \ref sec_droption_html
 
 \section sec_droption_setup Setup
@@ -125,9 +125,20 @@ if (op_x.get_value() > 4) {
 The value set on the command line can be overridden with the \p set_value
 function.
 
-\section sec_droption_special Special Types
+\section sec_droption_types Supported Types
 
-\p droption provides some custom value types for options:
+\p droption only supports the following standard value types for options:
+
+- int
+- long
+- long long
+- unsigned int
+- unsigned long
+- unsigned long long
+- double
+- bool
+
+\p droption also provides some custom value types for options:
 
 - bytesize_t: this class provides an integer type that accepts suffixes
   like 'K', 'M', and 'G' when specifying sizes in units of bytes.

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -44,7 +44,7 @@
 #include <stdlib.h>
 #include <sstream>
 #include <iomanip>
-#include <stdint.h> /* for supporting 64-bit integers*/
+#include <limits.h>
 #include <assert.h>
 
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
@@ -535,61 +535,72 @@ template <>
 inline bool
 droption_t<int>::convert_from_string(const std::string s)
 {
-    value = atoi(s.c_str());
-    return true;
+    errno = 0;
+    long input = strtol(s.c_str(), NULL, 10);
+
+    // strtol returns a long, but this may not always fit into an integer.
+    if (input >= INT_MIN && input <= INT_MAX)
+        value = (int) input;
+    else
+        return false;
+
+    return errno == 0;
 }
 template <>
 inline bool
 droption_t<long>::convert_from_string(const std::string s)
 {
-    value = atol(s.c_str());
-    return true;
+    errno = 0;
+    value = strtol(s.c_str(), NULL, 10);
+    return errno == 0;
 }
 template <>
 inline bool
 droption_t<long long>::convert_from_string(const std::string s)
 {
-    value = atoll(s.c_str());
-    return true;
+    errno = 0;
+    value = strtoll(s.c_str(), NULL, 10);
+    return errno == 0;
 }
 template <>
 inline bool
 droption_t<unsigned int>::convert_from_string(const std::string s)
 {
-    int input = atoi(s.c_str());
-    if (input >= 0)
-        value = input;
-    else {
-        value = 0;
+    errno = 0;
+    long input = strtol(s.c_str(), NULL, 10);
+
+    // Is the value positive and fits into an unsigned integer?
+    if (input >= 0 && input <= UINT_MAX)
+        value = (unsigned int) input;
+    else
         return false;
-    }
-    return true;
+
+    return errno == 0;
 }
 template <>
 inline bool
 droption_t<unsigned long>::convert_from_string(const std::string s)
 {
-    long input = atol(s.c_str());
+    errno = 0;
+    long input = strtol(s.c_str(), NULL, 10);
     if (input >= 0)
-        value = input;
-    else {
-        value = 0;
+        value = (unsigned long) input;
+    else
         return false;
-    }
-    return true;
+
+    return errno == 0;
 }
 template <>
 inline bool
 droption_t<unsigned long long>::convert_from_string(const std::string s)
 {
-    long long input = atoll(s.c_str());
+    long long input = strtoll(s.c_str(), NULL, 10);
     if (input >= 0)
-        value = input;
-    else {
-        value = 0;
+        value = (unsigned long long)input;
+    else
         return false;
-    }
-    return true;
+
+    return errno == 0 ;
 }
 template <>
 inline bool

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -660,7 +660,11 @@ template <typename T>
 inline std::string
 droption_t<T>::default_as_string() const
 {
+#if __cplusplus >= 201103L
   static_assert (sizeof (T) == -1, "Use of unsupported droption_t type");
+#else
+  assert (false && "Use of unsupported droption_t type");
+#endif
   return std::string ();
 }
 

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -568,7 +568,7 @@ template <>
 inline bool
 droption_t<unsigned long>::convert_from_string(const std::string s)
 {
-    int input = atol(s.c_str());
+    long input = atol(s.c_str());
     if (input >= 0)
         value = input;
     else {
@@ -581,7 +581,7 @@ template <>
 inline bool
 droption_t<unsigned long long>::convert_from_string(const std::string s)
 {
-    int input = atoll(s.c_str());
+    long long input = atoll(s.c_str());
     if (input >= 0)
         value = input;
     else {

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -662,11 +662,11 @@ inline std::string
 droption_t<T>::default_as_string() const
 {
 #if __cplusplus >= 201103L
-  static_assert (sizeof (T) == -1, "Use of unsupported droption_t type");
+    static_assert(sizeof(T) == -1, "Use of unsupported droption_t type");
 #else
-  assert (false && "Use of unsupported droption_t type");
+    assert(false && "Use of unsupported droption_t type");
 #endif
-  return std::string ();
+    return std::string();
 }
 
 template <>

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -539,9 +539,49 @@ droption_t<int>::convert_from_string(const std::string s)
 }
 template <>
 inline bool
+droption_t<long>::convert_from_string(const std::string s)
+{
+    value = atol(s.c_str());
+    return true;
+}
+template <>
+inline bool
+droption_t<long long>::convert_from_string(const std::string s)
+{
+    value = atoll(s.c_str());
+    return true;
+}
+template <>
+inline bool
 droption_t<unsigned int>::convert_from_string(const std::string s)
 {
     int input = atoi(s.c_str());
+    if (input >= 0)
+        value = input;
+    else {
+        value = 0;
+        return false;
+    }
+    return true;
+}
+template <>
+inline bool
+droption_t<unsigned long>::convert_from_string(const std::string s)
+{
+    int input = atol(s.c_str());
+    if (input >= 0)
+        value = input;
+    else {
+        value = 0;
+        return false;
+    }
+    return true;
+}
+template <>
+inline bool
+droption_t<unsigned long long>::convert_from_string(const std::string s)
+{
+    int input = atoll(s.c_str());
     if (input >= 0)
         value = input;
     else {
@@ -621,6 +661,7 @@ inline std::string
 droption_t<T>::default_as_string() const
 {
   static_assert (sizeof (T) == -1, "Use of unsupported droption_t type");
+  return std::string ();
 }
 
 template <>
@@ -664,7 +705,39 @@ droption_t<int>::default_as_string() const
 }
 template <>
 inline std::string
+droption_t<long>::default_as_string() const
+{
+    std::ostringstream stream;
+    stream << std::dec << defval;
+    return stream.str();
+}
+template <>
+inline std::string
+droption_t<long long>::default_as_string() const
+{
+    std::ostringstream stream;
+    stream << std::dec << defval;
+    return stream.str();
+}
+template <>
+inline std::string
 droption_t<unsigned int>::default_as_string() const
+{
+    std::ostringstream stream;
+    stream << std::dec << defval;
+    return stream.str();
+}
+template <>
+inline std::string
+droption_t<unsigned long>::default_as_string() const
+{
+    std::ostringstream stream;
+    stream << std::dec << defval;
+    return stream.str();
+}
+template <>
+inline std::string
+droption_t<unsigned long long>::default_as_string() const
 {
     std::ostringstream stream;
     stream << std::dec << defval;

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -45,6 +45,7 @@
 #include <sstream>
 #include <iomanip>
 #include <stdint.h> /* for supporting 64-bit integers*/
+#include <assert.h>
 
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 #define TESTANY(mask, var) (((mask) & (var)) != 0)

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -540,8 +540,8 @@ droption_t<int>::convert_from_string(const std::string s)
     long input = strtol(s.c_str(), NULL, 10);
 
     // strtol returns a long, but this may not always fit into an integer.
-    if (input >= (long) INT_MIN && input <= (long) INT_MAX)
-        value = (int) input;
+    if (input >= (long)INT_MIN && input <= (long)INT_MAX)
+        value = (int)input;
     else
         return false;
 
@@ -571,8 +571,8 @@ droption_t<unsigned int>::convert_from_string(const std::string s)
     long input = strtol(s.c_str(), NULL, 10);
 
     // Is the value positive and fits into an unsigned integer?
-    if (input >= 0 && (unsigned long) input <= (unsigned long) UINT_MAX)
-        value = (unsigned int) input;
+    if (input >= 0 && (unsigned long)input <= (unsigned long)UINT_MAX)
+        value = (unsigned int)input;
     else
         return false;
 
@@ -585,7 +585,7 @@ droption_t<unsigned long>::convert_from_string(const std::string s)
     errno = 0;
     long input = strtol(s.c_str(), NULL, 10);
     if (input >= 0)
-        value = (unsigned long) input;
+        value = (unsigned long)input;
     else
         return false;
 
@@ -601,7 +601,7 @@ droption_t<unsigned long long>::convert_from_string(const std::string s)
     else
         return false;
 
-    return errno == 0 ;
+    return errno == 0;
 }
 template <>
 inline bool

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -600,12 +600,29 @@ droption_t<twostring_t>::convert_from_string(const std::string s)
     return false;
 }
 
+// Default implementations
+
+template <typename T>
+inline bool
+droption_t<T>::convert_from_string(const std::string sc)
+{
+    return false;
+}
+
 template <typename T>
 inline bool
 droption_t<T>::convert_from_string(const std::string s1, const std::string s2)
 {
     return false;
 }
+
+template <typename T>
+inline std::string
+droption_t<T>::default_as_string() const
+{
+  static_assert (sizeof (T) == -1, "Use of unsupported droption_t type");
+}
+
 template <>
 inline bool
 droption_t<std::string>::convert_from_string(const std::string s1, const std::string s2)

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -45,6 +45,7 @@
 #include <sstream>
 #include <iomanip>
 #include <limits.h>
+#include <stdint.h>
 
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 #define TESTANY(mask, var) (((mask) & (var)) != 0)

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -46,6 +46,7 @@
 #include <iomanip>
 #include <limits.h>
 #include <stdint.h>
+#include <errno.h>
 
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 #define TESTANY(mask, var) (((mask) & (var)) != 0)

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -539,7 +539,7 @@ droption_t<int>::convert_from_string(const std::string s)
     long input = strtol(s.c_str(), NULL, 10);
 
     // strtol returns a long, but this may not always fit into an integer.
-    if (input >= INT_MIN && input <= INT_MAX)
+    if (input >= (long) INT_MIN && input <= (long) INT_MAX)
         value = (int) input;
     else
         return false;
@@ -570,7 +570,7 @@ droption_t<unsigned int>::convert_from_string(const std::string s)
     long input = strtol(s.c_str(), NULL, 10);
 
     // Is the value positive and fits into an unsigned integer?
-    if (input >= 0 && input <= UINT_MAX)
+    if (input >= 0 && (unsigned long) input <= (unsigned long) UINT_MAX)
         value = (unsigned int) input;
     else
         return false;

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -45,7 +45,6 @@
 #include <sstream>
 #include <iomanip>
 #include <limits.h>
-#include <assert.h>
 
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 #define TESTANY(mask, var) (((mask) & (var)) != 0)
@@ -675,7 +674,7 @@ droption_t<T>::default_as_string() const
 #if __cplusplus >= 201103L
     static_assert(sizeof(T) == -1, "Use of unsupported droption_t type");
 #else
-    assert(false && "Use of unsupported droption_t type");
+    DR_ASSERT_MSG(false, "Use of unsupported droption_t type");
 #endif
     return std::string();
 }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2169,7 +2169,7 @@ if (CLIENT_INTERFACE)
     "" "" "")
 
   tobuild_ci(client.option_parse client-interface/option_parse.cpp
-    "-x;4;-y;quoted string;-z;first;-z;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-no_flag;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4;-large_bytesize;9999999999"
+    "-l;-4;-ll;-749882561;-ul;4;-ull;823636799;-x;4;-y;quoted string;-z;first;-z;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-no_flag;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4;-large_bytesize;9999999999"
     "" "")
   use_DynamoRIO_extension(client.option_parse.dll droption)
   set(client.option_parse_client_ops_islist ON)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2170,7 +2170,7 @@ if (CLIENT_INTERFACE)
     "" "" "")
 
   tobuild_ci(client.option_parse client-interface/option_parse.cpp
-    "-l;-4;-ll;-749882561;-ul;4;-ull;823636799;-x;4;-y;quoted string;-z;first;-z;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-no_flag;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4;-large_bytesize;9999999999"
+    "-l;-4;-ll;-3220721071790640321;-ul;4;-ull;1384772493926445887;-x;4;-y;quoted string;-z;first;-z;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-no_flag;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4;-large_bytesize;9999999999"
     "" "")
   use_DynamoRIO_extension(client.option_parse.dll droption)
   set(client.option_parse_client_ops_islist ON)

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -39,13 +39,13 @@
 #include <string.h>
 
 static droption_t<long> op_l(DROPTION_SCOPE_CLIENT, "l", 0L, -64, 64, "Some param",
-                                     "Longer desc of some param.");
+                             "Longer desc of some param.");
 static droption_t<long long> op_ll(DROPTION_SCOPE_CLIENT, "ll", 0LL, "Some param",
-                                     "Longer desc of some param.");
-static droption_t<unsigned long> op_ul(DROPTION_SCOPE_CLIENT, "ul", 0UL, 0, 64, "Some param",
-                                     "Longer desc of some param.");
-static droption_t<unsigned long long> op_ull(DROPTION_SCOPE_CLIENT, "ull", 0ULL, "Some param",
-                                     "Longer desc of some param.");
+                                   "Longer desc of some param.");
+static droption_t<unsigned long> op_ul(DROPTION_SCOPE_CLIENT, "ul", 0UL, 0, 64,
+                                       "Some param", "Longer desc of some param.");
+static droption_t<unsigned long long> op_ull(DROPTION_SCOPE_CLIENT, "ull", 0ULL,
+                                             "Some param", "Longer desc of some param.");
 static droption_t<unsigned int> op_x(DROPTION_SCOPE_CLIENT, "x", 0, 0, 64, "Some param",
                                      "Longer desc of some param.");
 static droption_t<std::string> op_y(DROPTION_SCOPE_CLIENT, "y", DROPTION_FLAG_ACCUMULATE,
@@ -91,7 +91,7 @@ static droption_t<bytesize_t>
 static void
 test_argv(int argc, const char *argv[])
 {
-  ASSERT(argc == 42);
+    ASSERT(argc == 42);
 
     ASSERT(strcmp(argv[1], "-l") == 0);
     ASSERT(strcmp(argv[2], "-4") == 0);
@@ -139,7 +139,7 @@ test_argv(int argc, const char *argv[])
 DR_EXPORT void
 dr_client_main(client_id_t client_id, int argc, const char *argv[])
 {
-  test_argv(argc, argv);
+    test_argv(argc, argv);
 
     // Test dr_get_option_array().
     int ask_argc;

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -38,6 +38,14 @@
 #include "droption.h"
 #include <string.h>
 
+static droption_t<long> op_l(DROPTION_SCOPE_CLIENT, "l", 0L, -64, 64, "Some param",
+                                     "Longer desc of some param.");
+static droption_t<long long> op_ll(DROPTION_SCOPE_CLIENT, "ll", 0LL, "Some param",
+                                     "Longer desc of some param.");
+static droption_t<unsigned long> op_ul(DROPTION_SCOPE_CLIENT, "ul", 0UL, 0, 64, "Some param",
+                                     "Longer desc of some param.");
+static droption_t<unsigned long long> op_ull(DROPTION_SCOPE_CLIENT, "ull", 0ULL, "Some param",
+                                     "Longer desc of some param.");
 static droption_t<unsigned int> op_x(DROPTION_SCOPE_CLIENT, "x", 0, 0, 64, "Some param",
                                      "Longer desc of some param.");
 static droption_t<std::string> op_y(DROPTION_SCOPE_CLIENT, "y", DROPTION_FLAG_ACCUMULATE,
@@ -83,46 +91,55 @@ static droption_t<bytesize_t>
 static void
 test_argv(int argc, const char *argv[])
 {
-    ASSERT(argc == 34);
-    ASSERT(strcmp(argv[1], "-x") == 0);
-    ASSERT(strcmp(argv[2], "4") == 0);
-    ASSERT(strcmp(argv[3], "-y") == 0);
-    ASSERT(strcmp(argv[4], "quoted string") == 0);
-    ASSERT(strcmp(argv[5], "-z") == 0);
-    ASSERT(strcmp(argv[6], "first") == 0);
-    ASSERT(strcmp(argv[7], "-z") == 0);
-    ASSERT(strcmp(argv[8], "single quotes -dash --dashes") == 0);
-    ASSERT(strcmp(argv[9], "-front") == 0);
-    ASSERT(strcmp(argv[10], "value") == 0);
+  ASSERT(argc == 42);
+
+    ASSERT(strcmp(argv[1], "-l") == 0);
+    ASSERT(strcmp(argv[2], "-4") == 0);
+    ASSERT(strcmp(argv[3], "-ll") == 0);
+    ASSERT(strcmp(argv[4], "-749882561") == 0);
+    ASSERT(strcmp(argv[5], "-ul") == 0);
+    ASSERT(strcmp(argv[6], "4") == 0);
+    ASSERT(strcmp(argv[7], "-ull") == 0);
+    ASSERT(strcmp(argv[8], "823636799") == 0);
+    ASSERT(strcmp(argv[9], "-x") == 0);
+    ASSERT(strcmp(argv[10], "4") == 0);
     ASSERT(strcmp(argv[11], "-y") == 0);
-    ASSERT(strcmp(argv[12], "accum") == 0);
-    ASSERT(strcmp(argv[13], "-front2") == 0);
-    ASSERT(strcmp(argv[14], "value2") == 0);
-    ASSERT(strcmp(argv[15], "-no_flag") == 0);
-    ASSERT(strcmp(argv[16], "-takes2") == 0);
-    ASSERT(strcmp(argv[17], "1_of_4") == 0);
-    ASSERT(strcmp(argv[18], "2_of_4") == 0);
-    ASSERT(strcmp(argv[19], "-takes2") == 0);
-    ASSERT(strcmp(argv[20], "3_of_4") == 0);
-    ASSERT(strcmp(argv[21], "4_of_4") == 0);
-    ASSERT(strcmp(argv[22], "-val_sep") == 0);
-    ASSERT(strcmp(argv[23], "v1.1 v1.2") == 0);
-    ASSERT(strcmp(argv[24], "-val_sep") == 0);
-    ASSERT(strcmp(argv[25], "v2.1 v2.2") == 0);
-    ASSERT(strcmp(argv[26], "-val_sep2") == 0);
-    ASSERT(strcmp(argv[27], "v1") == 0);
-    ASSERT(strcmp(argv[28], "v2") == 0);
-    ASSERT(strcmp(argv[29], "-val_sep2") == 0);
-    ASSERT(strcmp(argv[30], "v3") == 0);
-    ASSERT(strcmp(argv[31], "v4") == 0);
-    ASSERT(strcmp(argv[32], "-large_bytesize") == 0);
-    ASSERT(strcmp(argv[33], "9999999999") == 0);
+    ASSERT(strcmp(argv[12], "quoted string") == 0);
+    ASSERT(strcmp(argv[13], "-z") == 0);
+    ASSERT(strcmp(argv[14], "first") == 0);
+    ASSERT(strcmp(argv[15], "-z") == 0);
+    ASSERT(strcmp(argv[16], "single quotes -dash --dashes") == 0);
+    ASSERT(strcmp(argv[17], "-front") == 0);
+    ASSERT(strcmp(argv[18], "value") == 0);
+    ASSERT(strcmp(argv[19], "-y") == 0);
+    ASSERT(strcmp(argv[20], "accum") == 0);
+    ASSERT(strcmp(argv[21], "-front2") == 0);
+    ASSERT(strcmp(argv[22], "value2") == 0);
+    ASSERT(strcmp(argv[23], "-no_flag") == 0);
+    ASSERT(strcmp(argv[24], "-takes2") == 0);
+    ASSERT(strcmp(argv[25], "1_of_4") == 0);
+    ASSERT(strcmp(argv[26], "2_of_4") == 0);
+    ASSERT(strcmp(argv[27], "-takes2") == 0);
+    ASSERT(strcmp(argv[28], "3_of_4") == 0);
+    ASSERT(strcmp(argv[29], "4_of_4") == 0);
+    ASSERT(strcmp(argv[30], "-val_sep") == 0);
+    ASSERT(strcmp(argv[31], "v1.1 v1.2") == 0);
+    ASSERT(strcmp(argv[32], "-val_sep") == 0);
+    ASSERT(strcmp(argv[33], "v2.1 v2.2") == 0);
+    ASSERT(strcmp(argv[34], "-val_sep2") == 0);
+    ASSERT(strcmp(argv[35], "v1") == 0);
+    ASSERT(strcmp(argv[36], "v2") == 0);
+    ASSERT(strcmp(argv[37], "-val_sep2") == 0);
+    ASSERT(strcmp(argv[38], "v3") == 0);
+    ASSERT(strcmp(argv[39], "v4") == 0);
+    ASSERT(strcmp(argv[40], "-large_bytesize") == 0);
+    ASSERT(strcmp(argv[41], "9999999999") == 0);
 }
 
 DR_EXPORT void
 dr_client_main(client_id_t client_id, int argc, const char *argv[])
 {
-    test_argv(argc, argv);
+  test_argv(argc, argv);
 
     // Test dr_get_option_array().
     int ask_argc;
@@ -134,9 +151,17 @@ dr_client_main(client_id_t client_id, int argc, const char *argv[])
     // Test droption parsing and droption_t declarations above.
     ok = droption_parser_t::parse_argv(DROPTION_SCOPE_CLIENT, argc, argv, NULL, NULL);
     ASSERT(ok);
+    ASSERT(op_l.specified());
+    ASSERT(op_ll.specified());
+    ASSERT(op_ul.specified());
+    ASSERT(op_ull.specified());
     ASSERT(op_x.specified());
     ASSERT(op_y.specified());
     ASSERT(op_z.specified());
+    dr_fprintf(STDERR, "param l = %d\n", op_l.get_value());
+    dr_fprintf(STDERR, "param ll = %d\n", op_ll.get_value());
+    dr_fprintf(STDERR, "param ul = %d\n", op_ul.get_value());
+    dr_fprintf(STDERR, "param ull = %d\n", op_ull.get_value());
     dr_fprintf(STDERR, "param x = %d\n", op_x.get_value());
     dr_fprintf(STDERR, "param y = |%s|\n", op_y.get_value().c_str());
     dr_fprintf(STDERR, "param z = |%s|\n", op_z.get_value().c_str());

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -96,11 +96,11 @@ test_argv(int argc, const char *argv[])
     ASSERT(strcmp(argv[1], "-l") == 0);
     ASSERT(strcmp(argv[2], "-4") == 0);
     ASSERT(strcmp(argv[3], "-ll") == 0);
-    ASSERT(strcmp(argv[4], "-749882561") == 0);
+    ASSERT(strcmp(argv[4], "-3220721071790640321") == 0);
     ASSERT(strcmp(argv[5], "-ul") == 0);
     ASSERT(strcmp(argv[6], "4") == 0);
     ASSERT(strcmp(argv[7], "-ull") == 0);
-    ASSERT(strcmp(argv[8], "823636799") == 0);
+    ASSERT(strcmp(argv[8], "1384772493926445887") == 0);
     ASSERT(strcmp(argv[9], "-x") == 0);
     ASSERT(strcmp(argv[10], "4") == 0);
     ASSERT(strcmp(argv[11], "-y") == 0);
@@ -158,10 +158,10 @@ dr_client_main(client_id_t client_id, int argc, const char *argv[])
     ASSERT(op_x.specified());
     ASSERT(op_y.specified());
     ASSERT(op_z.specified());
-    dr_fprintf(STDERR, "param l = %d\n", op_l.get_value());
-    dr_fprintf(STDERR, "param ll = %d\n", op_ll.get_value());
-    dr_fprintf(STDERR, "param ul = %d\n", op_ul.get_value());
-    dr_fprintf(STDERR, "param ull = %d\n", op_ull.get_value());
+    dr_fprintf(STDERR, "param l = %ld\n", op_l.get_value());
+    dr_fprintf(STDERR, "param ll = %lld\n", op_ll.get_value());
+    dr_fprintf(STDERR, "param ul = %lu\n", op_ul.get_value());
+    dr_fprintf(STDERR, "param ull = %llu\n", op_ull.get_value());
     dr_fprintf(STDERR, "param x = %d\n", op_x.get_value());
     dr_fprintf(STDERR, "param y = |%s|\n", op_y.get_value().c_str());
     dr_fprintf(STDERR, "param z = |%s|\n", op_z.get_value().c_str());

--- a/suite/tests/client-interface/option_parse.expect
+++ b/suite/tests/client-interface/option_parse.expect
@@ -1,3 +1,7 @@
+param l = -4
+param ll = -749882561
+param ul = 4
+param ull = 823636799
 param x = 4
 param y = |quoted string accum|
 param z = |single quotes -dash --dashes|

--- a/suite/tests/client-interface/option_parse.expect
+++ b/suite/tests/client-interface/option_parse.expect
@@ -1,7 +1,7 @@
 param l = -4
-param ll = -749882561
+param ll = -3220721071790640321
 param ul = 4
-param ull = 823636799
+param ull = 1384772493926445887
 param x = 4
 param y = |quoted string accum|
 param z = |single quotes -dash --dashes|


### PR DESCRIPTION
- Add default implementations of convert_from_string and default_as_string to avoid crashes.
- Add implementations for long and long long value types
- Update documentation to list the supported value types