### PR TITLE
i#3966: Align stack to 16 for private library init/fini calls

### DIFF
--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -977,10 +977,10 @@ privload_call_lib_func(fp_t func)
      */
     dummy_argv[0] = dummy_str;
     dummy_argv[1] = NULL;
-#ifdef X64
+#if defined(X64) || !defined(X86)
     func(1, dummy_argv, our_environ);
 #else
-    /* DR code has 4-byte stack alignment (-mpreferred-stack-boundary=2) but other
+    /* DR x86 code has 4-byte stack alignment (-mpreferred-stack-boundary=2) but other
      * libraries often assume 16-byte (xref i#847 and i#3966).
      * TODO(i#3966): This can lead to problem on clean calls as well.  We should
      * probably just abandon 4-byte alignment and switch to 16 everywhere, since
@@ -993,7 +993,7 @@ privload_call_lib_func(fp_t func)
                          "push %[env]\n"
                          "push %[argv]\n"
                          "push $1\n"
-                         "call %[callee]\n"
+                         "call *%[callee]\n"
                          "mov %%edi, %%esp\n" /* Restore. */
                          :
                          : [env] "g"(our_environ), [argv] "g"(&dummy_argv[0]),

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -977,7 +977,29 @@ privload_call_lib_func(fp_t func)
      */
     dummy_argv[0] = dummy_str;
     dummy_argv[1] = NULL;
+#ifdef X64
     func(1, dummy_argv, our_environ);
+#else
+    /* DR code has 4-byte stack alignment (-mpreferred-stack-boundary=2) but other
+     * libraries often assume 16-byte (xref i#847 and i#3966).
+     * TODO(i#3966): This can lead to problem on clean calls as well.  We should
+     * probably just abandon 4-byte alignment and switch to 16 everywhere, since
+     * enough time has passed that there are unlikely to be legacy clients using the
+     * old ABI anymore.  If we do that we could then remove this asm code.
+     */
+    __asm__ __volatile__("mov %%esp, %%edi\n"       /* Save the pre-alignment sp. */
+                         "and $0xfffffff0, %%esp\n" /* Align to 16. */
+                         "push $0\n" /* Extra push to keep alignment w/ 3 pushes. */
+                         "push %[env]\n"
+                         "push %[argv]\n"
+                         "push $1\n"
+                         "call %[callee]\n"
+                         "mov %%edi, %%esp\n" /* Restore. */
+                         :
+                         : [env] "g"(our_environ), [argv] "g"(&dummy_argv[0]),
+                           [callee] "g"(func)
+                         : "edi", "esp", "memory");
+#endif
 }
 
 bool


### PR DESCRIPTION
For 32-bit, when the private loader calls functions in potentially
third-party libraries, it needs to align the stack to 16 to account
for the mismatch in DR's 4-byte alignment (i#847) and the new gcc ABI.

Tested on libdrmemtrace which with gcc 8.3.0 has SIMD code which
crashes without alignment.

This is a short-term fix.  More issues remain with clean calls and we
should perhaps consider changing our base alignment.

Issue: #847, #3966