### PR TITLE
i#3978: Fix decode_cti bug on particular (e)vex byte sequences

### DIFF
--- a/core/arch/decode_fast.h
+++ b/core/arch/decode_fast.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -87,7 +87,7 @@ DR_UNS_API
 byte *
 decode_raw(dcontext_t *dcontext, byte *pc, instr_t *instr);
 
-DR_UNS_API
+DR_UNS_EXCEPT_TESTS_API
 /**
  * Decodes only enough of the instruction at address \p pc to determine
  * its size, its effects on the 6 arithmetic eflags, and whether it is

--- a/core/arch/x86/decode_fast.c
+++ b/core/arch/x86/decode_fast.c
@@ -1359,7 +1359,9 @@ decode_cti(dcontext_t *dcontext, byte *pc, instr_t *instr)
                     instr_set_opcode(instr, OP_INVALID);
                     return NULL;
                 }
-                break;
+                /* There are no prefixes after (e)vex. */
+                pc = start_pc + prefixes;
+                i = prefixes;
             }
             default: break;
             }

--- a/core/globals.h
+++ b/core/globals.h
@@ -127,6 +127,11 @@
 #else
 #    define DR_API
 #endif
+#if (defined(DEBUG) && defined(BUILD_TESTS)) || defined(UNSUPPORTED_API)
+#    define DR_UNS_EXCEPT_TESTS_API DR_API
+#else
+#    define DR_UNS_EXCEPT_TESTS_API /* nothing */
+#endif
 #ifdef UNSUPPORTED_API
 #    define DR_UNS_API DR_API
 #else

--- a/make/configure.cmake.h
+++ b/make/configure.cmake.h
@@ -84,6 +84,7 @@
 #endif
 #cmakedefine PARAMS_IN_REGISTRY
 #cmakedefine RECORD_MEMQUERY
+#cmakedefine BUILD_TESTS
 
 /* when packaging */
 #cmakedefine VERSION_NUMBER ${VERSION_NUMBER}

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -58,6 +58,12 @@
 #    include <math.h> /* for M_PI, M_LN2, and M_LN10 for OP_fldpi, etc. */
 #endif
 
+#if defined(DEBUG) && defined(BUILD_TESTS)
+/* Not in the headers because it is not generally exported. */
+extern byte *
+decode_cti(void *dcontext, byte *pc, instr_t *instr);
+#endif
+
 #define VERBOSE 0
 
 #ifdef STANDALONE_DECODER

--- a/suite/tests/api/ir_x86_3args.h
+++ b/suite/tests/api/ir_x86_3args.h
@@ -367,6 +367,8 @@ OPCODE(lwpval, lwpval, lwpval, 0, REGARG(EAX), MEMARG(OPSZ_4), IMMARG(OPSZ_4))
 /****************************************************************************/
 /* BMI1 */
 OPCODE(andn, andn, andn, 0, REGARG(EAX), REGARG(EBX), MEMARG(OPSZ_4))
+/* Test the 2nd byte looking like a different prefix (i#3978). */
+OPCODE(andn_ext, andn, andn, X64_ONLY, REGARG(R12), REGARG(R12), REGARG(RAX))
 
 /****************************************************************************/
 /* BMI2 */


### PR DESCRIPTION
Fixes a bug in decode_cti() with a (e)vex prefix with its 2nd or 3rd
byte also looking like the first byte of a (e)vex prefix where the
instruction is considered invalid, crashing the application.

Adds testing of decode_cti() to api.ir by export decode_cti() in DEBUG
and BUILD_TESTS builds.  Adds a test case that triggers the observed
bug without the fix.

Fixes #3978