### PR TITLE
i#4003 marker order: Add drmgr_is_first_nonlabel_instr(); use in drmemtrace

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -221,7 +221,7 @@ Further non-compatibility-affecting changes include:
    to get the static number of supported SIMD vectors.
  - Added drmgr_register_low_on_memory_event(), drmgr_unregister_low_on_memory_event()
    and their variants so that drmgr can support low-on-memory events.
- - Added drmgr_is_first_nonlabel_instr().
+ - Added drmgr_is_first_nonlabel_instr() and instrlist_first_nonlabel().
 
 **************************************************
 <hr>

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -221,6 +221,7 @@ Further non-compatibility-affecting changes include:
    to get the static number of supported SIMD vectors.
  - Added drmgr_register_low_on_memory_event(), drmgr_unregister_low_on_memory_event()
    and their variants so that drmgr can support low-on-memory events.
+ - Added drmgr_is_first_nonlabel_instr().
 
 **************************************************
 <hr>

--- a/core/arch/instrlist.c
+++ b/core/arch/instrlist.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -215,6 +215,15 @@ instrlist_first_app(instrlist_t *ilist)
         return first;
 
     return instr_get_next_app(first);
+}
+
+instr_t *
+instrlist_first_nonlabel(instrlist_t *ilist)
+{
+    instr_t *first = ilist->first;
+    while (first != NULL && instr_is_label(first))
+        first = instr_get_next(first);
+    return first;
 }
 
 /* returns the last inst in the list */

--- a/core/arch/instrlist.h
+++ b/core/arch/instrlist.h
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -166,6 +167,14 @@ DR_API
  */
 instr_t *
 instrlist_first_app(instrlist_t *ilist);
+
+DR_API
+/**
+ * Returns the first instruction in the instruction list \p ilist for which
+ * instr_is_label() returns false.
+ */
+instr_t *
+instrlist_first_nonlabel(instrlist_t *ilist);
 
 DR_API
 /** Returns the last instr_t in \p ilist. */

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -185,8 +185,9 @@ typedef struct _cb_list_t {
 /* Our own TLS data */
 typedef struct _per_thread_t {
     drmgr_bb_phase_t cur_phase;
-    instr_t *first_app;
-    instr_t *last_app;
+    instr_t *first_instr;
+    instr_t *first_nonlabel_instr;
+    instr_t *last_instr;
 } per_thread_t;
 
 /* Emulation note types */
@@ -704,8 +705,11 @@ drmgr_bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
 
     /* Pass 3: instru, per instr */
     pt->cur_phase = DRMGR_PHASE_INSERTION;
-    pt->first_app = instrlist_first(bb);
-    pt->last_app = instrlist_last(bb);
+    pt->first_instr = instrlist_first(bb);
+    pt->first_nonlabel_instr = instrlist_first(bb);
+    while (instr_is_label(pt->first_nonlabel_instr))
+        pt->first_nonlabel_instr = instr_get_next(pt->first_nonlabel_instr);
+    pt->last_instr = instrlist_last(bb);
     for (inst = instrlist_first(bb); inst != NULL; inst = next_inst) {
         next_inst = instr_get_next(inst);
         for (quartet_idx = 0, pair_idx = 0, i = 0; i < iter_insert.num_def; i++) {
@@ -1173,7 +1177,15 @@ bool
 drmgr_is_first_instr(void *drcontext, instr_t *instr)
 {
     per_thread_t *pt = (per_thread_t *)drmgr_get_tls_field(drcontext, our_tls_idx);
-    return instr == pt->first_app;
+    return instr == pt->first_instr;
+}
+
+DR_EXPORT
+bool
+drmgr_is_first_nonlabel_instr(void *drcontext, instr_t *instr)
+{
+    per_thread_t *pt = (per_thread_t *)drmgr_get_tls_field(drcontext, our_tls_idx);
+    return instr == pt->first_nonlabel_instr;
 }
 
 DR_EXPORT
@@ -1181,7 +1193,7 @@ bool
 drmgr_is_last_instr(void *drcontext, instr_t *instr)
 {
     per_thread_t *pt = (per_thread_t *)drmgr_get_tls_field(drcontext, our_tls_idx);
-    return instr == pt->last_app;
+    return instr == pt->last_instr;
 }
 
 static void

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -706,9 +706,7 @@ drmgr_bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     /* Pass 3: instru, per instr */
     pt->cur_phase = DRMGR_PHASE_INSERTION;
     pt->first_instr = instrlist_first(bb);
-    pt->first_nonlabel_instr = instrlist_first(bb);
-    while (instr_is_label(pt->first_nonlabel_instr))
-        pt->first_nonlabel_instr = instr_get_next(pt->first_nonlabel_instr);
+    pt->first_nonlabel_instr = instrlist_first_nonlabel(bb);
     pt->last_instr = instrlist_last(bb);
     for (inst = instrlist_first(bb); inst != NULL; inst = next_inst) {
         next_inst = instr_get_next(inst);

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -465,8 +465,8 @@ drmgr_current_bb_phase(void *drcontext);
 DR_EXPORT
 /**
  * Must be called during drmgr's insertion phase.  Returns whether \p instr is the
- * first instruction in the instruction list (as of immediately after the analysis
- * phase).
+ * first instruction (of any type) in the instruction list (as of immediately after
+ * the analysis phase).
  */
 bool
 drmgr_is_first_instr(void *drcontext, instr_t *instr);
@@ -474,8 +474,17 @@ drmgr_is_first_instr(void *drcontext, instr_t *instr);
 DR_EXPORT
 /**
  * Must be called during drmgr's insertion phase.  Returns whether \p instr is the
- * last instruction in the instruction list (as of immediately after the analysis
- * phase).
+ * first non-label instruction in the instruction list (as of immediately after
+ * the analysis phase).
+ */
+bool
+drmgr_is_first_nonlabel_instr(void *drcontext, instr_t *instr);
+
+DR_EXPORT
+/**
+ * Must be called during drmgr's insertion phase.  Returns whether \p instr is the
+ * last instruction (of any type) in the instruction list (as of immediately after
+ * the analysis phase).
  */
 bool
 drmgr_is_last_instr(void *drcontext, instr_t *instr);

--- a/suite/tests/client-interface/drmgr-test.dll.c
+++ b/suite/tests/client-interface/drmgr-test.dll.c
@@ -525,10 +525,7 @@ event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                   bool translating, OUT void **user_data)
 {
     /* point at first non-label instr */
-    instr_t *nonlabel = instrlist_first(bb);
-    while (instr_is_label(nonlabel))
-        nonlabel = instr_get_next(nonlabel);
-    *user_data = (void *)nonlabel;
+    *user_data = (void *)instrlist_first_nonlabel(bb);
     return DR_EMIT_DEFAULT;
 }
 

--- a/suite/tests/client-interface/drmgr-test.dll.c
+++ b/suite/tests/client-interface/drmgr-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -524,8 +524,11 @@ static dr_emit_flags_t
 event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                   bool translating, OUT void **user_data)
 {
-    /* point at first instr */
-    *user_data = (void *)instrlist_first(bb);
+    /* point at first non-label instr */
+    instr_t *nonlabel = instrlist_first(bb);
+    while (instr_is_label(nonlabel))
+        nonlabel = instr_get_next(nonlabel);
+    *user_data = (void *)nonlabel;
     return DR_EMIT_DEFAULT;
 }
 
@@ -584,10 +587,17 @@ event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
     CHECK(!drmgr_is_last_instr(drcontext, instrlist_first_app(bb)) ||
               instrlist_first_app(bb) == instrlist_last(bb),
           "last incorrect");
+    if (inst == (instr_t *)user_data) {
+        CHECK(drmgr_is_first_nonlabel_instr(drcontext, inst),
+              "first non-label incorrect");
+    } else {
+        CHECK(!drmgr_is_first_nonlabel_instr(drcontext, inst),
+              "first non-label incorrect");
+    }
 
     /* hack to instrument every nth bb.  assumes DR serializes bb events. */
     freq++;
-    if (freq % 100 == 0 && inst == (instr_t *)user_data /*first instr*/) {
+    if (freq % 100 == 0 && drmgr_is_first_instr(drcontext, inst)) {
         /* test read from cache */
         dr_save_reg(drcontext, bb, inst, reg1, SPILL_SLOT_1);
         drmgr_insert_read_tls_field(drcontext, tls_idx, bb, inst, reg1);
@@ -598,7 +608,7 @@ event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
                              opnd_create_reg(reg1));
         dr_restore_reg(drcontext, bb, inst, reg1, SPILL_SLOT_1);
     }
-    if (freq % 300 == 0 && inst == (instr_t *)user_data /*first instr*/) {
+    if (freq % 300 == 0 && drmgr_is_first_instr(drcontext, inst)) {
         /* test write from cache */
         dr_save_reg(drcontext, bb, inst, reg1, SPILL_SLOT_1);
         dr_save_reg(drcontext, bb, inst, reg2, SPILL_SLOT_2);


### PR DESCRIPTION
Adds a new API function drmgr_is_first_nonlabel_instr() and uses it in the
drmemtrace tracer to insert the block-PC entry after all labels but
before all app or tool instructions.  This places the PC entry at the
right position with respect to drwrap-hook-inserted marker entries.

Fixes #4003