### PR TITLE
Cleanup: use override keyword and enable warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -709,7 +709,7 @@ if (UNIX)
   # Prefer the new 'override' keyword.
   CHECK_CXX_COMPILER_FLAG("-Wsuggest-override" suggest_override_avail)
   if (suggest_override_avail)
-    set(BASE_CXXONLY_FLAGS "${BASE_CXXONLY_CFLAGS} -Wsuggest-override")
+    set(BASE_CXXONLY_FLAGS "${BASE_CXXONLY_FLAGS} -Wsuggest-override")
   endif ()
   # now that the user must set non-default -mNN we don't nec. need these:
   if (X86)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2019 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2020 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # Copyright (c) 2018 Arm Limited          All rights reserved.
 # **********************************************************
@@ -119,6 +119,7 @@ else ()
 endif ()
 
 include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 
 ###########################################################################
 # utility functions
@@ -705,6 +706,11 @@ if (UNIX)
   if (no_stack_protector_avail)
     set(BASE_CFLAGS "${BASE_CFLAGS} -fno-stack-protector")
   endif (no_stack_protector_avail)
+  # Prefer the new 'override' keyword.
+  CHECK_CXX_COMPILER_FLAG("-Wsuggest-override" suggest_override_avail)
+  if (suggest_override_avail)
+    set(BASE_CXXONLY_FLAGS "${BASE_CXXONLY_CFLAGS} -Wsuggest-override")
+  endif ()
   # now that the user must set non-default -mNN we don't nec. need these:
   if (X86)
     if (X64)

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -143,6 +143,7 @@ changes:
    enum now completely overlaps the DR_REG_ enum.
    This is a binary compatibility change for the OPSZ_ enum.
  - Added a new encoding hint field to #instr_t.
+ - Added a requirement that a C++11-complient compiler be used with \ref page_droption.
 
 The changes between version \DR_VERSION and 7.1.0 include the following minor
 compatibility changes:

--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -84,8 +84,8 @@ public:
     {
     }
     virtual ~file_reader_t();
-    virtual bool
-    init()
+    bool
+    init() override
     {
         at_eof = false;
         if (!open_input_files())
@@ -98,8 +98,9 @@ public:
     is_complete();
 
 protected:
-    virtual bool
-    read_next_thread_entry(size_t thread_index, OUT trace_entry_t *entry, OUT bool *eof);
+    bool
+    read_next_thread_entry(size_t thread_index, OUT trace_entry_t *entry,
+                           OUT bool *eof) override;
 
     virtual bool
     open_single_file(const std::string &path);
@@ -181,8 +182,8 @@ protected:
         return true;
     }
 
-    virtual trace_entry_t *
-    read_next_entry()
+    trace_entry_t *
+    read_next_entry() override
     {
         // We read the thread files simultaneously in lockstep and merge them into
         // a single interleaved stream in timestamp order.

--- a/clients/drcachesim/reader/ipc_reader.h
+++ b/clients/drcachesim/reader/ipc_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -48,19 +48,19 @@ public:
     ipc_reader_t();
     ipc_reader_t(const char *ipc_name, int verbosity);
     virtual ~ipc_reader_t();
-    virtual bool operator!();
+    bool operator!() override;
     // This potentially blocks.
-    virtual bool
-    init();
+    bool
+    init() override;
     std::string
     get_pipe_name() const;
 
 protected:
-    virtual trace_entry_t *
-    read_next_entry();
+    trace_entry_t *
+    read_next_entry() override;
 
-    virtual bool
-    read_next_thread_entry(size_t, trace_entry_t *, bool *)
+    bool
+    read_next_thread_entry(size_t, trace_entry_t *, bool *) override
     {
         // Only an interleaved stream is supported.
         return false;

--- a/clients/drcachesim/simulator/cache.h
+++ b/clients/drcachesim/simulator/cache.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -46,20 +46,20 @@ public:
     // to describe a CPU cache.
     // The id is an index into the snoop filter's array of caches for coherent caches.
     // If this is a coherent cache, id should be in the range [0,num_snooped_caches).
-    virtual bool
+    bool
     init(int associativity, int line_size, int total_size, caching_device_t *parent,
          caching_device_stats_t *stats, prefetcher_t *prefetcher = nullptr,
          bool inclusive = false, bool coherent_cache = false, int id_ = -1,
          snoop_filter_t *snoop_filter_ = nullptr,
-         const std::vector<caching_device_t *> &children = {});
-    virtual void
-    request(const memref_t &memref);
+         const std::vector<caching_device_t *> &children = {}) override;
+    void
+    request(const memref_t &memref) override;
     virtual void
     flush(const memref_t &memref);
 
 protected:
-    virtual void
-    init_blocks();
+    void
+    init_blocks() override;
 };
 
 #endif /* _CACHE_H_ */

--- a/clients/drcachesim/simulator/cache_fifo.h
+++ b/clients/drcachesim/simulator/cache_fifo.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,18 +40,18 @@
 
 class cache_fifo_t : public cache_t {
 public:
-    virtual bool
+    bool
     init(int associativity, int line_size, int total_size, caching_device_t *parent,
          caching_device_stats_t *stats, prefetcher_t *prefetcher, bool inclusive = false,
          bool coherent_cache = false, int id_ = -1,
          snoop_filter_t *snoop_filter_ = nullptr,
-         const std::vector<caching_device_t *> &children = {});
+         const std::vector<caching_device_t *> &children = {}) override;
 
 protected:
-    virtual void
-    access_update(int line_idx, int way);
-    virtual int
-    replace_which_way(int line_idx);
+    void
+    access_update(int line_idx, int way) override;
+    int
+    replace_which_way(int line_idx) override;
 };
 
 #endif /* _CACHE_FIFO_H_ */

--- a/clients/drcachesim/simulator/cache_lru.h
+++ b/clients/drcachesim/simulator/cache_lru.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,10 +40,10 @@
 
 class cache_lru_t : public cache_t {
 protected:
-    virtual void
-    access_update(int line_idx, int way);
-    virtual int
-    replace_which_way(int line_idx);
+    void
+    access_update(int line_idx, int way) override;
+    int
+    replace_which_way(int line_idx) override;
 };
 
 #endif /* _CACHE_LRU_H_ */

--- a/clients/drcachesim/simulator/cache_miss_analyzer.h
+++ b/clients/drcachesim/simulator/cache_miss_analyzer.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, LLC  All rights reserved.
+ * Copyright (c) 2015-2020 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -81,15 +81,15 @@ public:
         return *this;
     }
 
-    virtual void
-    reset();
+    void
+    reset() override;
 
     std::vector<prefetching_recommendation_t *>
     generate_recommendations();
 
 protected:
-    virtual void
-    dump_miss(const memref_t &memref);
+    void
+    dump_miss(const memref_t &memref) override;
 
 private:
     // Two locality levels for prefetching are supported: nta and t0.
@@ -147,8 +147,8 @@ public:
     std::vector<prefetching_recommendation_t *>
     generate_recommendations();
 
-    virtual bool
-    print_results();
+    bool
+    print_results() override;
 
 private:
     cache_miss_stats_t *ll_stats;

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -55,10 +55,10 @@ public:
     cache_simulator_t(const std::string &config_file);
 
     virtual ~cache_simulator_t();
-    virtual bool
-    process_memref(const memref_t &memref);
-    virtual bool
-    print_results();
+    bool
+    process_memref(const memref_t &memref) override;
+    bool
+    print_results() override;
 
     // Exposed to make it easy to test
     bool

--- a/clients/drcachesim/simulator/cache_stats.h
+++ b/clients/drcachesim/simulator/cache_stats.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -46,22 +46,23 @@ public:
 
     // In addition to caching_device_stats_t::access,
     // cache_stats_t::access processes prefetching requests.
-    virtual void
-    access(const memref_t &memref, bool hit, caching_device_block_t *cache_block);
+    void
+    access(const memref_t &memref, bool hit,
+           caching_device_block_t *cache_block) override;
 
     // process CPU cache flushes
     virtual void
     flush(const memref_t &memref);
 
-    virtual void
-    reset();
+    void
+    reset() override;
 
 protected:
     // In addition to caching_device_stats_t::print_counts,
     // cache_stats_t::print_counts prints stats for flushes and
     // prefetching requests.
-    virtual void
-    print_counts(std::string prefix);
+    void
+    print_counts(std::string prefix) override;
 
     // A CPU cache handles flushes and prefetching requests
     // as well as regular memory accesses.

--- a/clients/drcachesim/simulator/simulator.h
+++ b/clients/drcachesim/simulator/simulator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -52,8 +52,8 @@ public:
                 double warmup_fraction, uint64_t sim_refs, bool cpu_scheduling,
                 unsigned int verbose);
     virtual ~simulator_t() = 0;
-    virtual bool
-    process_memref(const memref_t &memref);
+    bool
+    process_memref(const memref_t &memref) override;
 
 protected:
     // Initialize knobs. Success or failure is indicated by setting/resetting

--- a/clients/drcachesim/simulator/tlb.h
+++ b/clients/drcachesim/simulator/tlb.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -42,12 +42,12 @@
 
 class tlb_t : public caching_device_t {
 public:
-    virtual void
-    request(const memref_t &memref);
+    void
+    request(const memref_t &memref) override;
 
 protected:
-    virtual void
-    init_blocks();
+    void
+    init_blocks() override;
 
     // Optimization: remember last pid in addition to last tag
     memref_pid_t last_pid;

--- a/clients/drcachesim/simulator/tlb_simulator.h
+++ b/clients/drcachesim/simulator/tlb_simulator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -46,10 +46,10 @@ class tlb_simulator_t : public simulator_t {
 public:
     tlb_simulator_t(const tlb_simulator_knobs_t &knobs);
     virtual ~tlb_simulator_t();
-    virtual bool
-    process_memref(const memref_t &memref);
-    virtual bool
-    print_results();
+    bool
+    process_memref(const memref_t &memref) override;
+    bool
+    print_results() override;
 
 protected:
     // Create a tlb_t object with a specific replacement policy.

--- a/clients/drcachesim/tests/trace_invariants.h
+++ b/clients/drcachesim/tests/trace_invariants.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -44,10 +44,10 @@ class trace_invariants_t : public analysis_tool_t {
 public:
     trace_invariants_t(bool offline = true, unsigned int verbose = 0);
     virtual ~trace_invariants_t();
-    virtual bool
-    process_memref(const memref_t &memref);
-    virtual bool
-    print_results();
+    bool
+    process_memref(const memref_t &memref) override;
+    bool
+    print_results() override;
 
 protected:
     bool knob_offline;

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -162,45 +162,45 @@ public:
                     bool memref_needs_info, drvector_t *reg_vector);
     virtual ~online_instru_t();
 
-    virtual trace_type_t
-    get_entry_type(byte *buf_ptr) const;
-    virtual size_t
-    get_entry_size(byte *buf_ptr) const;
-    virtual addr_t
-    get_entry_addr(byte *buf_ptr) const;
-    virtual void
-    set_entry_addr(byte *buf_ptr, addr_t addr);
+    trace_type_t
+    get_entry_type(byte *buf_ptr) const override;
+    size_t
+    get_entry_size(byte *buf_ptr) const override;
+    addr_t
+    get_entry_addr(byte *buf_ptr) const override;
+    void
+    set_entry_addr(byte *buf_ptr, addr_t addr) override;
 
-    virtual int
-    append_pid(byte *buf_ptr, process_id_t pid);
-    virtual int
-    append_tid(byte *buf_ptr, thread_id_t tid);
-    virtual int
-    append_thread_exit(byte *buf_ptr, thread_id_t tid);
-    virtual int
-    append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr_t val);
-    virtual int
-    append_iflush(byte *buf_ptr, addr_t start, size_t size);
-    virtual int
-    append_thread_header(byte *buf_ptr, thread_id_t tid);
-    virtual int
-    append_unit_header(byte *buf_ptr, thread_id_t tid);
+    int
+    append_pid(byte *buf_ptr, process_id_t pid) override;
+    int
+    append_tid(byte *buf_ptr, thread_id_t tid) override;
+    int
+    append_thread_exit(byte *buf_ptr, thread_id_t tid) override;
+    int
+    append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr_t val) override;
+    int
+    append_iflush(byte *buf_ptr, addr_t start, size_t size) override;
+    int
+    append_thread_header(byte *buf_ptr, thread_id_t tid) override;
+    int
+    append_unit_header(byte *buf_ptr, thread_id_t tid) override;
 
-    virtual int
+    int
     instrument_memref(void *drcontext, instrlist_t *ilist, instr_t *where,
                       reg_id_t reg_ptr, int adjust, instr_t *app, opnd_t ref,
-                      int ref_index, bool write, dr_pred_type_t pred);
-    virtual int
+                      int ref_index, bool write, dr_pred_type_t pred) override;
+    int
     instrument_instr(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app);
-    virtual int
+                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app) override;
+    int
     instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t *where,
                        reg_id_t reg_ptr, int adjust, instr_t **delay_instrs,
-                       int num_delay_instrs);
+                       int num_delay_instrs) override;
 
-    virtual void
+    void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                bool repstr_expanded);
+                bool repstr_expanded) override;
 
 private:
     void
@@ -224,50 +224,50 @@ public:
                      file_t module_file, bool disable_optimizations = false);
     virtual ~offline_instru_t();
 
-    virtual trace_type_t
-    get_entry_type(byte *buf_ptr) const;
-    virtual size_t
-    get_entry_size(byte *buf_ptr) const;
-    virtual addr_t
-    get_entry_addr(byte *buf_ptr) const;
-    virtual void
-    set_entry_addr(byte *buf_ptr, addr_t addr);
+    trace_type_t
+    get_entry_type(byte *buf_ptr) const override;
+    size_t
+    get_entry_size(byte *buf_ptr) const override;
+    addr_t
+    get_entry_addr(byte *buf_ptr) const override;
+    void
+    set_entry_addr(byte *buf_ptr, addr_t addr) override;
 
     uint64_t
     get_modoffs(void *drcontext, app_pc pc);
 
-    virtual int
-    append_pid(byte *buf_ptr, process_id_t pid);
-    virtual int
-    append_tid(byte *buf_ptr, thread_id_t tid);
-    virtual int
-    append_thread_exit(byte *buf_ptr, thread_id_t tid);
-    virtual int
-    append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr_t val);
-    virtual int
-    append_iflush(byte *buf_ptr, addr_t start, size_t size);
-    virtual int
-    append_thread_header(byte *buf_ptr, thread_id_t tid);
+    int
+    append_pid(byte *buf_ptr, process_id_t pid) override;
+    int
+    append_tid(byte *buf_ptr, thread_id_t tid) override;
+    int
+    append_thread_exit(byte *buf_ptr, thread_id_t tid) override;
+    int
+    append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr_t val) override;
+    int
+    append_iflush(byte *buf_ptr, addr_t start, size_t size) override;
+    int
+    append_thread_header(byte *buf_ptr, thread_id_t tid) override;
     virtual int
     append_thread_header(byte *buf_ptr, thread_id_t tid, offline_file_type_t file_type);
-    virtual int
-    append_unit_header(byte *buf_ptr, thread_id_t tid);
+    int
+    append_unit_header(byte *buf_ptr, thread_id_t tid) override;
 
-    virtual int
+    int
     instrument_memref(void *drcontext, instrlist_t *ilist, instr_t *where,
                       reg_id_t reg_ptr, int adjust, instr_t *app, opnd_t ref,
-                      int ref_index, bool write, dr_pred_type_t pred);
-    virtual int
+                      int ref_index, bool write, dr_pred_type_t pred) override;
+    int
     instrument_instr(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app);
-    virtual int
+                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app) override;
+    int
     instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t *where,
                        reg_id_t reg_ptr, int adjust, instr_t **delay_instrs,
-                       int num_delay_instrs);
+                       int num_delay_instrs) override;
 
-    virtual void
+    void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                bool repstr_expanded);
+                bool repstr_expanded) override;
 
     static bool
     custom_module_data(void *(*load_cb)(module_data_t *module),

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -50,6 +50,12 @@
 
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 #define TESTANY(mask, var) (((mask) & (var)) != 0)
+
+// We are no longer supporting pre-C++11 as it complicates the code too
+// much, requiring macros for 'override', etc.
+#if __cplusplus < 201103L
+#    error This library requires C++11
+#endif
 
 #define DROPTION_DEFAULT_VALUE_SEP " "
 
@@ -436,7 +442,7 @@ public:
 
 protected:
     bool
-    clamp_value()
+    clamp_value() override
     {
         if (has_range) {
             if (value < minval) {
@@ -451,17 +457,17 @@ protected:
     }
 
     bool
-    option_takes_arg() const;
+    option_takes_arg() const override;
     bool
-    option_takes_2args() const;
+    option_takes_2args() const override;
     bool
-    name_match(const char *arg);
+    name_match(const char *arg) override;
     bool
-    convert_from_string(const std::string s);
+    convert_from_string(const std::string s) override;
     bool
-    convert_from_string(const std::string s1, const std::string s2);
+    convert_from_string(const std::string s1, const std::string s2) override;
     std::string
-    default_as_string() const;
+    default_as_string() const override;
 
     T value;
     T defval;

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -53,7 +53,9 @@
 
 // We are no longer supporting pre-C++11 as it complicates the code too
 // much, requiring macros for 'override', etc.
-#if __cplusplus < 201103L
+// MSVC 2013 accepts 'override' but returns 199711.
+#if (defined(UNIX) && __cplusplus < 201103L) || \
+    (defined(WINDOWS) && __cplusplus < 199711L)
 #    error This library requires C++11
 #endif
 

--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -1189,6 +1189,11 @@ function (use_DynamoRIO_extension target extname)
     target_link_libraries(${target} ${extname})
   endif (NOT DynamoRIO_EXT_${extname}_NOLIB)
 
+  if ("${extname}" MATCHES "^droption$")
+    if (NOT WIN32)
+      _DR_append_property_string(TARGET ${target} COMPILE_FLAGS "-std=c++11")
+    endif ()
+  endif ()
 endfunction (use_DynamoRIO_extension)
 
 # For clients to configure their custom annotations
@@ -1229,7 +1234,9 @@ function (use_DynamoRIO_drmemtrace target)
       _DR_append_property_string(TARGET ${target} COMPILE_FLAGS "/MT")
     endif ()
   endif ()
-  _DR_append_property_string(TARGET ${target} COMPILE_FLAGS "-std=c++11")
+  if (NOT WIN32)
+    _DR_append_property_string(TARGET ${target} COMPILE_FLAGS "-std=c++11")
+  endif ()
 endfunction ()
 
 function (use_DynamoRIO_drmemtrace_tracer target)

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -77,7 +77,7 @@ if ($child) {
     # that has to be manually downloaded.  We thus stick with -V for
     # Travis.  For Appveyor where many devs have no local Visual
     # Studio we do use -VV so build warning details are visible.
-    my $verbose = "-VV"; #TEMPORARY
+    my $verbose = "-V";
     if ($^O eq 'cygwin') {
         $verbose = "-VV";
         # CMake is native Windows so pass it a Windows path.

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -77,7 +77,7 @@ if ($child) {
     # that has to be manually downloaded.  We thus stick with -V for
     # Travis.  For Appveyor where many devs have no local Visual
     # Studio we do use -VV so build warning details are visible.
-    my $verbose = "-V";
+    my $verbose = "-VV"; #TEMPORARY
     if ($^O eq 'cygwin') {
         $verbose = "-VV";
         # CMake is native Windows so pass it a Windows path.


### PR DESCRIPTION
Enables -Wsuggest-override and uses it to replace 'virtual' with
'override' in the C++ code that was not already using 'override'.

This is done in droption.h as well.  Rather than generating macros to
support pre-C++11, I decided that enough time has passed to drop
support for pre-C++11 for users using droption.  The documentation
adds a note about this change.