### PR TITLE
i#3974: Use two entries for large drcachesim trace marker values

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -225,6 +225,15 @@ typedef enum {
      * marker entry
      */
     TRACE_MARKER_TYPE_FUNC_RETVAL,
+
+    /* This is a non-public type only present in an offline raw trace.  To support a
+     * full 64-bit marker value in an offline trace where
+     * offline_entry_t.extended.valueA contains <64 bits, we use two consecutive
+     * entries.  We rely on these being adjacent in the trace.  This entry must come
+     * first, and its valueA is left-shited 32 and then OR-ed with the subsequent
+     * entry's valueA to produce the final marker value.
+     */
+    TRACE_MARKER_TYPE_SPLIT_VALUE,
 
     // ...
     // These values are reserved for future built-in marker types.

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -226,7 +226,7 @@ typedef enum {
      */
     TRACE_MARKER_TYPE_FUNC_RETVAL,
 
-    /* This is a non-public type only present in an offline raw trace.  To support a
+    /* This is a non-public type only present in an offline raw trace. To support a
      * full 64-bit marker value in an offline trace where
      * offline_entry_t.extended.valueA contains <64 bits, we use two consecutive
      * entries.  We rely on these being adjacent in the trace.  This entry must come

--- a/clients/drcachesim/tests/offline-burst_malloc.templatex
+++ b/clients/drcachesim/tests/offline-burst_malloc.templatex
@@ -8,7 +8,7 @@ DynamoRIO statistics:
 .*
 all done
 .*
-.* 4008 function id markers.*
-.* 2004 function return address markers.*
-.* 2005 function argument markers.*
-.* 2004 function return value markers.*
+.* 6008 function id markers.*
+.* 3004 function return address markers.*
+.* 3005 function argument markers.*
+.* 3004 function return value markers.*

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -263,14 +263,25 @@ offline_instru_t::append_thread_exit(byte *buf_ptr, thread_id_t tid)
 int
 offline_instru_t::append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr_t val)
 {
+    int extra_size = 0;
+    if ((unsigned long long)val >= 1ULL << EXT_VALUE_A_BITS) {
+        // We need two entries.
+        // XXX: What we should do is change these types to signed so we can avoid
+        // two entries for small negative numbers.  That requires a version bump
+        // though which adds complexity for backward compatibility.
+        DR_ASSERT(type != TRACE_MARKER_TYPE_SPLIT_VALUE);
+        extra_size = append_marker(buf_ptr, TRACE_MARKER_TYPE_SPLIT_VALUE, val >> 32);
+        buf_ptr += extra_size;
+        val = (uint)val;
+    }
     offline_entry_t *entry = (offline_entry_t *)buf_ptr;
+    entry->extended.valueA = val;
+    DR_ASSERT(entry->extended.valueA == val);
     entry->extended.type = OFFLINE_TYPE_EXTENDED;
     entry->extended.ext = OFFLINE_EXT_TYPE_MARKER;
-    DR_ASSERT((int)type < 1 << EXT_VALUE_B_BITS);
+    DR_ASSERT((uint)type < 1 << EXT_VALUE_B_BITS);
     entry->extended.valueB = type;
-    DR_ASSERT((unsigned long long)val < 1ULL << EXT_VALUE_A_BITS);
-    entry->extended.valueA = val;
-    return sizeof(offline_entry_t);
+    return sizeof(offline_entry_t) + extra_size;
 }
 
 int

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -264,6 +264,7 @@ int
 offline_instru_t::append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr_t val)
 {
     int extra_size = 0;
+#ifdef X64
     if ((unsigned long long)val >= 1ULL << EXT_VALUE_A_BITS) {
         // We need two entries.
         // XXX: What we should do is change these types to signed so we can avoid
@@ -274,6 +275,7 @@ offline_instru_t::append_marker(byte *buf_ptr, trace_marker_type_t type, uintptr
         buf_ptr += extra_size;
         val = (uint)val;
     }
+#endif
     offline_entry_t *entry = (offline_entry_t *)buf_ptr;
     entry->extended.valueA = val;
     DR_ASSERT(entry->extended.valueA == val);

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -629,7 +629,7 @@ protected:
                 // the ending of the current thread, etc.
                 return impl()->on_thread_end(tls);
             } else if (in_entry->extended.ext == OFFLINE_EXT_TYPE_MARKER) {
-                uintptr_t marker_val;
+                uintptr_t marker_val = 0;
                 std::string err = get_marker_value(tls, &in_entry, &marker_val);
                 if (!err.empty())
                     return err;
@@ -1086,7 +1086,7 @@ private:
                 append = true;
             }
             if (append) {
-                uintptr_t marker_val;
+                uintptr_t marker_val = 0;
                 std::string err = get_marker_value(tls, &in_entry, &marker_val);
                 if (!err.empty())
                     return err;
@@ -1109,12 +1109,16 @@ private:
     {
         uintptr_t marker_val = static_cast<uintptr_t>((*entry)->extended.valueA);
         if ((*entry)->extended.valueB == TRACE_MARKER_TYPE_SPLIT_VALUE) {
+#ifdef X64
             const offline_entry_t *next = impl()->get_next_entry(tls);
             if (next == nullptr || next->extended.ext != OFFLINE_EXT_TYPE_MARKER)
                 return "SPLIT_VALUE marker is not adjacent to 2nd entry";
             marker_val =
                 (marker_val << 32) | static_cast<uintptr_t>(next->extended.valueA);
             *entry = next;
+#else
+            return "TRACE_MARKER_TYPE_SPLIT_VALUE unexpected for 32-bit";
+#endif
         }
         *value = marker_val;
         return "";

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -629,11 +629,13 @@ protected:
                 // the ending of the current thread, etc.
                 return impl()->on_thread_end(tls);
             } else if (in_entry->extended.ext == OFFLINE_EXT_TYPE_MARKER) {
+                uintptr_t marker_val;
+                std::string err = get_marker_value(tls, &in_entry, &marker_val);
+                if (!err.empty())
+                    return err;
                 buf += trace_metadata_writer_t::write_marker(
-                    buf, (trace_marker_type_t)in_entry->extended.valueB,
-                    (uintptr_t)in_entry->extended.valueA);
-                if (in_entry->extended.ext == OFFLINE_EXT_TYPE_MARKER &&
-                    in_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT) {
+                    buf, (trace_marker_type_t)in_entry->extended.valueB, marker_val);
+                if (in_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT) {
                     impl()->log(4, "Signal/exception between bbs\n");
                 }
                 impl()->log(3, "Appended marker type %u value " PIFX "\n",
@@ -1084,20 +1086,37 @@ private:
                 append = true;
             }
             if (append) {
+                uintptr_t marker_val;
+                std::string err = get_marker_value(tls, &in_entry, &marker_val);
+                if (!err.empty())
+                    return err;
                 byte *buf = reinterpret_cast<byte *>(*buf_in);
                 buf += trace_metadata_writer_t::write_marker(
-                    buf, (trace_marker_type_t)in_entry->extended.valueB,
-                    (uintptr_t)in_entry->extended.valueA);
+                    buf, (trace_marker_type_t)in_entry->extended.valueB, marker_val);
                 *buf_in = reinterpret_cast<trace_entry_t *>(buf);
                 impl()->log(3, "Appended marker type %u value " PIFX "\n",
-                            (trace_marker_type_t)in_entry->extended.valueB,
-                            (uintptr_t)in_entry->extended.valueA);
-
+                            (trace_marker_type_t)in_entry->extended.valueB, marker_val);
             } else {
                 // Put it back.
                 impl()->unread_last_entry(tls);
             }
         } while (append);
+        return "";
+    }
+
+    std::string
+    get_marker_value(void *tls, INOUT const offline_entry_t **entry, OUT uintptr_t *value)
+    {
+        uintptr_t marker_val = static_cast<uintptr_t>((*entry)->extended.valueA);
+        if ((*entry)->extended.valueB == TRACE_MARKER_TYPE_SPLIT_VALUE) {
+            const offline_entry_t *next = impl()->get_next_entry(tls);
+            if (next == nullptr || next->extended.ext != OFFLINE_EXT_TYPE_MARKER)
+                return "SPLIT_VALUE marker is not adjacent to 2nd entry";
+            marker_val =
+                (marker_val << 32) | static_cast<uintptr_t>(next->extended.valueA);
+            *entry = next;
+        }
+        *value = marker_val;
         return "";
     }
 


### PR DESCRIPTION
For drcachesim offline traces, a single entry cannot hold a full
64-bit value.  To record large values, we use an escape type and two
entries, which raw2trace combines back into a single final trace
entry.

Adds a test case to the burst_malloc test with large return values.

Fixes #3974