### PR TITLE
i#3496: Fix crash in drmgr-test

### DIFF
--- a/suite/tests/client-interface/drmgr-test.c
+++ b/suite/tests/client-interface/drmgr-test.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -323,13 +323,17 @@ main(int argc, char **argv)
     /* Test xsave for drutil_opnd_mem_size_in_bytes. We're assuming that
      * xsave support is available and enabled, which should be the case
      * on all machines we're running on.
+     * Ideally we'd run whatever cpuid invocations are needed to figure out the exact
+     * size but 16K is more than enough for the foreseeable future: it's 576 bytes
+     * with SSE and ~2688 for AVX-512.
      */
-    char ALIGN_VAR(64) buffer[2048];
-    __asm("or $-1, %%eax\n"
-          "\txsave %0"
+    char ALIGN_VAR(64) buffer[16 * 1024];
+    __asm("xor %%edx, %%edx\n\t"
+          "or $-1, %%eax\n\t"
+          "xsave %0\n\t"
           : "=m"(buffer)
           :
-          : "eax");
+          : "eax", "edx", "memory");
 #    endif
 
     intervals = 10;


### PR DESCRIPTION
Makes the XSAVE buffer large enough to avoid buffer overflow which was
crashing drmgr-test.

Fixes #3496