### PR TITLE
i#2928 expose stats: Update stale documentation

### DIFF
--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -6320,7 +6320,8 @@ dr_prepopulate_indirect_targets(dr_indirect_branch_type_t branch_type, app_pc *t
 
 DR_API
 /**
- * Get the number of blocks built so far, globally. The API is not thread-safe.
+ * Retrieves various statistics exported by DR as global, process-wide values.
+ * The API is not thread-safe.
  * The caller is expected to pass a pointer to a valid, initialized dr_stats_t
  * value, with the size field set (see dr_stats_t).
  * Returns false if stats are not enabled.


### PR DESCRIPTION
Updates the old docs for dr_get_stats() which talk only about the
number of blocks, while we have since added various other statistics.

Issue: #2928