### PR TITLE
i#731 re-rel: Convert native rseq PC targets to instrs

### DIFF
--- a/core/arch/disassemble_shared.c
+++ b/core/arch/disassemble_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1509,13 +1509,8 @@ instrlist_disassemble(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist,
              * as much about raw bytes
              */
             int extra_sz;
-            if (level == 3) {
-                print_file(outfile, " +%-4d %c%d " IF_X64_ELSE("%20s", "%12s"), offs,
-                           instr_is_app(instr) ? 'L' : 'm', level, " ");
-            } else {
-                print_file(outfile, " +%-4d %c%d @" PFX " ", offs,
-                           instr_is_app(instr) ? 'L' : 'm', level, instr);
-            }
+            print_file(outfile, " +%-4d %c%d @" PFX " ", offs,
+                       instr_is_app(instr) ? 'L' : 'm', level, instr);
             extra_sz = print_bytes_to_file(outfile, addr, addr + len, instr);
             instr_disassemble(dcontext, instr, outfile);
             print_file(outfile, "\n");


### PR DESCRIPTION
For i#731 with automatic re-relativization of absolute PC's, in
d6f5fca we simply kept the hardcoded offset for intra-region branch
targets in our native rseq copy.  However, with subsequent mangling
that offset can become incorrect and target the middle of an
instruction, leading to a crash.  We instead take the time to convert
these PC targets to instr_t* targets.

We also tweak the disassembly output to show the instr_t pointer value
for level 3 instructions too, since jumps can target them as well as
synthetic instructions.  This helped with verifying and debugging this
change.

Tested on an inserted system call for locally forcing rseq restarts,
which leads to system call mangling and crashes without this fix.

Issue: #731, #2350