### PR TITLE
i#3137: Fix drcachesim -offline launcher crash

### DIFF
--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -348,14 +348,15 @@ _tmain(int argc, const TCHAR *targv[])
     } else
         errcode = 0;
 
-    if (!analyzer->print_stats()) {
-        std::string error_string = analyzer->get_error_string();
-        FATAL_ERROR("failed to print results%s%s", error_string.empty() ? "" : ": ",
-                    error_string.c_str());
+    if (analyzer != nullptr) {
+        if (!analyzer->print_stats()) {
+            std::string error_string = analyzer->get_error_string();
+            FATAL_ERROR("failed to print results%s%s", error_string.empty() ? "" : ": ",
+                        error_string.c_str());
+        }
+        // release analyzer's space
+        delete analyzer;
     }
-
-    // release analyzer's space
-    delete analyzer;
 
     sc = drfront_cleanup_args(argv, argc);
     if (sc != DRFRONT_SUCCESS)


### PR DESCRIPTION
Fixes a deref of a nullptr causing crashes on Windows with drcachesim
-offline.  The launcher on Windows waits for the child to exit and
then prints stats from the analyzer, but there is no analyzer for
-offline.

Fixes #3137