### PR TITLE
i#4036: Fix size increase of empty drvector

### DIFF
--- a/ext/drcontainers/drvector.c
+++ b/ext/drcontainers/drvector.c
@@ -94,8 +94,12 @@ drvector_set_entry(drvector_t *vec, uint idx, void *data)
         return false;
     if (vec->synch)
         dr_mutex_lock(vec->lock);
-    if (idx >= vec->capacity)
-        drvector_increase_size(vec, idx * 2);
+    if (idx >= vec->capacity) {
+        if (idx == 0)
+            drvector_increase_size(vec, INITIAL_CAPACITY_IF_ZERO_REQUESTED);
+        else
+            drvector_increase_size(vec, idx * 2);
+    }
     vec->array[idx] = data;
     if (idx >= vec->entries)
         vec->entries = idx + 1; /* ensure append goes beyond this entry */

--- a/suite/tests/client-interface/drcontainers-test.dll.c
+++ b/suite/tests/client-interface/drcontainers-test.dll.c
@@ -82,6 +82,17 @@ test_vector(void)
 
     ok = drvector_delete(&vec);
     CHECK(ok, "drvector_delete failed");
+
+    ok = drvector_init(&vec, 0, false /*!synch*/, NULL);
+    CHECK(ok, "drvector_init failed");
+
+    drvector_set_entry(&vec, 0, (void *)&vec);
+    CHECK(vec.entries == 1, "should add 1");
+    CHECK(drvector_get_entry(&vec, 0) == (void *)&vec, "entries not equal");
+    CHECK(vec.array[0] == (void *)&vec, "entries not equal");
+
+    ok = drvector_delete(&vec);
+    CHECK(ok, "drvector_delete failed");
 }
 
 unsigned int c;


### PR DESCRIPTION
Fixes a bug that occurs when the size of an empty vector is increased to set a value at index 0.

Fixes #4036