### PR TITLE
i#4045 cleanup: Remove the unsupported target-prefix feature

### DIFF
--- a/api/docs/bt.dox
+++ b/api/docs/bt.dox
@@ -1031,30 +1031,6 @@ added to the owning exit cti's.
 \endif
 
 
-\if prefixes
-********************
-\subsection sec_prefixes Prefixes
-
-Some code manipulations need to store a target address in a register and
-then jump there, but need the register to be restored as well.  DynamoRIO
-provides a single-instruction prefix that is placed on all fragments (basic
-blocks as well as traces) that restores ecx.  It is on traces for internal
-DynamoRIO use.  To have it added to basic blocks as well, call this routine
-during initialization:
-
-\code
-void dr_add_prefixes_to_basic_blocks();
-\endcode
-
-To have a cti target the prefix rather than the normal entry, use these set
-and get routines:
-
-\code
-bool instr_branch_targets_prefix(instr_t *instr);
-void instr_branch_set_prefix_target(instr_t *instr, bool val);
-\endcode
-\endif
-
 ***************************************************************************
 \htmlonly
 <table width=100% bgcolor="#000000" cellspacing=0 cellpadding=2 border=0>

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -465,17 +465,7 @@ link_direct_exit(dcontext_t *dcontext, fragment_t *f, linkstub_t *l, fragment_t 
 #endif
 
     /* change jmp target to point to the passed-in target */
-#ifdef UNSUPPORTED_API
-    if ((l->flags & LINK_TARGET_PREFIX) != 0) {
-        /* want to target just the xcx restore, not the eflags restore
-         * (only ibl targets eflags restore)
-         */
-        patch_branch(FRAG_ISA_MODE(f->flags), EXIT_CTI_PC(f, l),
-                     FCACHE_PREFIX_ENTRY_PC(targetf), hot_patch);
-    } else
-#endif
-
-        if (exit_cti_reaches_target(dcontext, f, l, (cache_pc)FCACHE_ENTRY_PC(targetf))) {
+    if (exit_cti_reaches_target(dcontext, f, l, (cache_pc)FCACHE_ENTRY_PC(targetf))) {
         patch_branch(FRAG_ISA_MODE(f->flags), EXIT_CTI_PC(f, l), FCACHE_ENTRY_PC(targetf),
                      hot_patch);
         return true; /* do not need stub anymore */

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -147,9 +147,6 @@ enum {
     INSTR_IND_JMP_PLT_EXIT = (INSTR_JMP_EXIT | INSTR_CALL_EXIT),
     INSTR_FAR_EXIT = LINK_FAR,
     INSTR_BRANCH_SPECIAL_EXIT = LINK_SPECIAL_EXIT,
-#    ifdef UNSUPPORTED_API
-    INSTR_BRANCH_TARGETS_PREFIX = LINK_TARGET_PREFIX,
-#    endif
 #    ifdef X64
     /* PR 257963: since we don't store targets of ind branches, we need a flag
      * so we know whether this is a trace cmp exit, which has its own ibl entry
@@ -167,9 +164,6 @@ enum {
     EXIT_CTI_TYPES =
         (INSTR_DIRECT_EXIT | INSTR_INDIRECT_EXIT | INSTR_RETURN_EXIT | INSTR_CALL_EXIT |
          INSTR_JMP_EXIT | INSTR_FAR_EXIT | INSTR_BRANCH_SPECIAL_EXIT |
-#    ifdef UNSUPPORTED_API
-         INSTR_BRANCH_TARGETS_PREFIX |
-#    endif
 #    ifdef X64
          INSTR_TRACE_CMP_EXIT |
 #    endif
@@ -689,42 +683,6 @@ DR_API
 /** Return true iff \p instr's opcode is OP_int, OP_into, or OP_int3. */
 bool
 instr_is_interrupt(instr_t *instr);
-
-#ifdef UNSUPPORTED_API
-DR_API
-/**
- * Returns true iff \p instr has been marked as targeting the prefix of its
- * target fragment.
- *
- * Some code manipulations need to store a target address in a
- * register and then jump there, but need the register to be restored
- * as well.  DR provides a single-instruction prefix that is
- * placed on all fragments (basic blocks as well as traces) that
- * restores ecx.  It is on traces for internal DR use.  To have
- * it added to basic blocks as well, call
- * dr_add_prefixes_to_basic_blocks() during initialization.
- */
-bool
-instr_branch_targets_prefix(instr_t *instr);
-
-DR_API
-/**
- * If \p val is true, indicates that \p instr's target fragment should be
- *   entered through its prefix, which restores ecx.
- * If \p val is false, indicates that \p instr should target the normal entry
- *   point and not the prefix.
- *
- * Some code manipulations need to store a target address in a
- * register and then jump there, but need the register to be restored
- * as well.  DR provides a single-instruction prefix that is
- * placed on all fragments (basic blocks as well as traces) that
- * restores ecx.  It is on traces for internal DR use.  To have
- * it added to basic blocks as well, call
- * dr_add_prefixes_to_basic_blocks() during initialization.
- */
-void
-instr_branch_set_prefix_target(instr_t *instr, bool val);
-#endif /* UNSUPPORTED_API */
 
 /* Returns true iff \p instr has been marked as a special fragment
  * exit cti.

--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -708,47 +708,6 @@ instr_set_predicate(instr_t *instr, dr_pred_type_t pred)
     return instr;
 }
 
-#ifdef UNSUPPORTED_API
-/* Returns true iff instr has been marked as targeting the prefix of its
- * target fragment.
- *
- * Some code manipulations need to store a target address in a
- * register and then jump there, but need the register to be restored
- * as well.  DR provides a single-instruction prefix that is
- * placed on all fragments (basic blocks as well as traces) that
- * restores ecx.  It is on traces for internal DR use.  To have
- * it added to basic blocks as well, call
- * dr_add_prefixes_to_basic_blocks() during initialization.
- */
-bool
-instr_branch_targets_prefix(instr_t *instr)
-{
-    return ((instr->flags & INSTR_BRANCH_TARGETS_PREFIX) != 0);
-}
-
-/* If val is true, indicates that instr's target fragment should be
- *   entered through its prefix, which restores ecx.
- * If val is false, indicates that instr should target the normal entry
- *   point and not the prefix.
- *
- * Some code manipulations need to store a target address in a
- * register and then jump there, but need the register to be restored
- * as well.  DR provides a single-instruction prefix that is
- * placed on all fragments (basic blocks as well as traces) that
- * restores ecx.  It is on traces for internal DR use.  To have
- * it added to basic blocks as well, call
- * dr_add_prefixes_to_basic_blocks() during initialization.
- */
-void
-instr_branch_set_prefix_target(instr_t *instr, bool val)
-{
-    if (val)
-        instr->flags |= INSTR_BRANCH_TARGETS_PREFIX;
-    else
-        instr->flags &= ~INSTR_BRANCH_TARGETS_PREFIX;
-}
-#endif /* UNSUPPORTED_API */
-
 /* Returns true iff instr has been marked as a special exit cti */
 bool
 instr_branch_special_exit(instr_t *instr)

--- a/core/emit.c
+++ b/core/emit.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -323,12 +323,6 @@ set_linkstub_fields(dcontext_t *dcontext, fragment_t *f, instrlist_t *ilist,
                            TEST(LINK_SPECIAL_EXIT, l->flags));
                 }
             });
-#ifdef UNSUPPORTED_API
-            DOCHECK(1, {
-                if (instr_branch_targets_prefix(inst))
-                    ASSERT(TEST(LINK_TARGET_PREFIX, l->flags));
-            });
-#endif
 
             if (!EXIT_HAS_STUB(l->flags, f->flags)) {
                 /* exit cti points straight at ibl routine */

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2010-2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -7465,33 +7465,6 @@ dr_trace_exists_at(void *drcontext, void *tag)
 #    endif
     return trace;
 }
-
-#    ifdef UNSUPPORTED_API
-DR_API
-/* All basic blocks created after this routine is called will have a prefix
- * that restores the ecx register.  Exit ctis can be made to target this prefix
- * instead of the normal entry point by using the instr_branch_set_prefix_target()
- * routine.
- * WARNING: this routine should almost always be called during client
- * initialization, since having a mixture of prefixed and non-prefixed basic
- * blocks can lead to trouble.
- */
-void
-dr_add_prefixes_to_basic_blocks(void)
-{
-    if (DYNAMO_OPTION(coarse_units)) {
-        /* coarse_units doesn't support prefixes in general.
-         * the variation by addr prefix according to processor type
-         * is also not stored in pcaches.
-         */
-        CLIENT_ASSERT(false,
-                      "dr_add_prefixes_to_basic_blocks() not supported with -opt_memory");
-    }
-    options_make_writable();
-    dynamo_options.bb_prefixes = true;
-    options_restore_readonly();
-}
-#    endif /* UNSUPPORTED_API */
 
 DR_API
 /* Insert code to get the segment base address pointed at by seg into

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -6385,21 +6385,6 @@ bool
 dr_trace_exists_at(void *drcontext, void *tag);
 #    endif /* CUSTOM_TRACES */
 
-#    ifdef UNSUPPORTED_API
-DR_API
-/**
- * All basic blocks created after this routine is called will have a prefix
- * that restores the ecx register.  Exit ctis can be made to target this prefix
- * instead of the normal entry point by using the
- * instr_branch_set_prefix_target() routine.
- * \warning This routine should almost always be called during client
- * initialization, since having a mixture of prefixed and non-prefixed basic
- * blocks can lead to trouble.
- */
-void
-dr_add_prefixes_to_basic_blocks(void);
-#    endif /* UNSUPPORTED_API */
-
 #endif /* CLIENT_INTERFACE */
 
 /****************************************************************************

--- a/core/link.h
+++ b/core/link.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -80,9 +80,8 @@ enum {
     /* Indicates a far cti which uses a separate ibl entry */
     LINK_FAR = 0x0020,
 
-#ifdef UNSUPPORTED_API
-    LINK_TARGET_PREFIX = 0x0040,
-#endif
+/* 0x0040 is reserved for i#4038 */
+
 #ifdef X64
     /* PR 257963: since we don't store targets of ind branches, we need a flag
      * so we know whether this is a trace cmp exit, which has its own ibl entry

--- a/tools/windbg-scripts/linkstub_flags
+++ b/tools/windbg-scripts/linkstub_flags
@@ -1,4 +1,5 @@
 $$ **********************************************************
+$$ Copyright (c) 2020 Google, Inc.  All rights reserved.
 $$ Copyright (c) 2005 VMware, Inc.  All rights reserved.
 $$ **********************************************************
 
@@ -41,7 +42,6 @@ $$ flags as of link.h 1.81
 .if ((poi(@$t1+4) & 0x000010)==0x000010) {.echo "JMP";};
 .if ((poi(@$t1+4) & 0x000020)==0x000020) {.echo "IND_JMP_PLT";};
 .if ((poi(@$t1+4) & 0x000040)==0x000040) {.echo "SELFMOD_EXIT";};
-.if ((poi(@$t1+4) & 0x000080)==0x000080) {.echo "TARGET_PREFIX";};
 .if ((poi(@$t1+4) & 0x000100)==0x000100) {.echo "*** INVALID / CUSTOM_TRACES ENDS_BLOCK";};
 .if ((poi(@$t1+4) & 0x000200)==0x000200) {.echo "CALLBACK_RETURN";};
 .if ((poi(@$t1+4) & 0x000400)==0x000400) {.echo "NI_SYSCALL";};


### PR DESCRIPTION
Removes the dr_add_prefixes_to_basic_blocks() +
instr_branch_set_prefix_target() feature and its flags
LINK_TARGET_PREFIX and INSTR_BRANCH_TARGETS_PREFIX.  These were
already under UNSUPPORTED_API and not supported.  Removing the feature
frees up a linkstub flag for #4038.