### PR TITLE
i#4038: Mark exit cti padding and remove it when trace building

### DIFF
--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -299,7 +299,7 @@ extend_trace_pad_bytes(fragment_t *add_frag)
         ? DYNAMO_OPTION(inline_trace_ibl)
         : DYNAMO_OPTION(inline_bb_ibl);
     int num_patchables = 0;
-    for (linkstub_t *l = FRAGMENT_EXIT_STUBS(add_frag); !LINKSTUB_FINAL(l);
+    for (linkstub_t *l = FRAGMENT_EXIT_STUBS(add_frag); l != NULL;
          l = LINKSTUB_NEXT_EXIT(l)) {
         num_patchables++;
         if (LINKSTUB_INDIRECT(l->flags) && inline_ibl_head)

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -294,26 +294,19 @@ bytes_for_exitstub_alignment(dcontext_t *dcontext, linkstub_t *l, fragment_t *f,
 uint
 extend_trace_pad_bytes(fragment_t *add_frag)
 {
-    /* FIXME : this is a poor estimate, we could do better by looking at the
-     * linkstubs and checking if we are inlining ibl, but since this is just
-     * used by monitor.c for a max size check should be fine to overestimate
-     * we'll just end up with slightly shorter max size traces */
-    /* we don't trace through traces in normal builds, so don't worry about
-     * number of exits (FIXME this also assumes bbs don't trace through
-     * conditional or indirect branches) */
-    ASSERT_NOT_IMPLEMENTED(!TEST(FRAG_IS_TRACE, add_frag->flags));
-    /* Also, if -pad_jmps_shift_bb we assume that we don't need to remove
-     * any nops from fragments added to traces since there shouldn't be any if
-     * we only add bbs (nop_pad_ilist has an assert that verifies we don't add
-     * any nops to bbs when -pad_jmps_shift_bb without marking as CANNOT_BE_TRACE,
-     * so here we also verify that we only add bbs) - Xref PR 215179, UNIX syscall
-     * fence exits and CLIENT_INTERFACE added/moved exits can lead to bbs with
-     * additional hot_patchable locations.  We mark such bb fragments as CANNOT_BE_TRACE
-     * in nop_pad_ilist() if -pad_jmps_mark_no_trace is set or assert otherwise to avoid
-     * various difficulties so should not see them here. */
-    /* A standard bb has at most 2 patchable locations (ends in conditional or ends
-     * in indirect that is promoted to inlined). */
-    return 2 * MAX_PAD_SIZE;
+    /* To estimate we count the number of exit ctis by counting the linkstubs. */
+    bool inline_ibl_head = TEST(FRAG_IS_TRACE, add_frag->flags)
+        ? DYNAMO_OPTION(inline_trace_ibl)
+        : DYNAMO_OPTION(inline_bb_ibl);
+    int num_patchables = 0;
+    for (linkstub_t *l = FRAGMENT_EXIT_STUBS(add_frag); !LINKSTUB_FINAL(l);
+         l = LINKSTUB_NEXT_EXIT(l)) {
+        num_patchables++;
+        if (LINKSTUB_INDIRECT(l->flags) && inline_ibl_head)
+            num_patchables += 2;
+        /* We ignore cbr_fallthrough: only one of them should need nops. */
+    }
+    return num_patchables * MAX_PAD_SIZE;
 }
 
 /* return startpc shifted by the necessary bytes to pad patchable jmps of the

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -147,6 +147,7 @@ enum {
     INSTR_IND_JMP_PLT_EXIT = (INSTR_JMP_EXIT | INSTR_CALL_EXIT),
     INSTR_FAR_EXIT = LINK_FAR,
     INSTR_BRANCH_SPECIAL_EXIT = LINK_SPECIAL_EXIT,
+    INSTR_BRANCH_PADDED = LINK_PADDED,
 #    ifdef X64
     /* PR 257963: since we don't store targets of ind branches, we need a flag
      * so we know whether this is a trace cmp exit, which has its own ibl entry
@@ -161,18 +162,18 @@ enum {
     INSTR_NI_SYSCALL = LINK_NI_SYSCALL,
     INSTR_NI_SYSCALL_ALL = LINK_NI_SYSCALL_ALL,
     /* meta-flag */
-    EXIT_CTI_TYPES =
-        (INSTR_DIRECT_EXIT | INSTR_INDIRECT_EXIT | INSTR_RETURN_EXIT | INSTR_CALL_EXIT |
-         INSTR_JMP_EXIT | INSTR_FAR_EXIT | INSTR_BRANCH_SPECIAL_EXIT |
+    EXIT_CTI_TYPES = (INSTR_DIRECT_EXIT | INSTR_INDIRECT_EXIT | INSTR_RETURN_EXIT |
+                      INSTR_CALL_EXIT | INSTR_JMP_EXIT | INSTR_FAR_EXIT |
+                      INSTR_BRANCH_SPECIAL_EXIT | INSTR_BRANCH_PADDED |
 #    ifdef X64
-         INSTR_TRACE_CMP_EXIT |
+                      INSTR_TRACE_CMP_EXIT |
 #    endif
 #    ifdef WINDOWS
-         INSTR_CALLBACK_RETURN |
+                      INSTR_CALLBACK_RETURN |
 #    else
-         INSTR_NI_SYSCALL_INT |
+                      INSTR_NI_SYSCALL_INT |
 #    endif
-         INSTR_NI_SYSCALL),
+                      INSTR_NI_SYSCALL),
 
     /* instr_t-internal flags (not shared with LINK_) */
     INSTR_OPERANDS_VALID = 0x00010000,
@@ -683,6 +684,12 @@ DR_API
 /** Return true iff \p instr's opcode is OP_int, OP_into, or OP_int3. */
 bool
 instr_is_interrupt(instr_t *instr);
+
+bool
+instr_branch_is_padded(instr_t *instr);
+
+void
+instr_branch_set_padded(instr_t *instr, bool val);
 
 /* Returns true iff \p instr has been marked as a special fragment
  * exit cti.

--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -708,6 +708,21 @@ instr_set_predicate(instr_t *instr, dr_pred_type_t pred)
     return instr;
 }
 
+bool
+instr_branch_is_padded(instr_t *instr)
+{
+    return TEST(INSTR_BRANCH_PADDED, instr->flags);
+}
+
+void
+instr_branch_set_padded(instr_t *instr, bool val)
+{
+    if (val)
+        instr->flags |= INSTR_BRANCH_PADDED;
+    else
+        instr->flags &= ~INSTR_BRANCH_PADDED;
+}
+
 /* Returns true iff instr has been marked as a special exit cti */
 bool
 instr_branch_special_exit(instr_t *instr)

--- a/core/arch/x86/emit_utils.c
+++ b/core/arch/x86/emit_utils.c
@@ -411,27 +411,9 @@ nop_pad_ilist(dcontext_t *dcontext, fragment_t *f, instrlist_t *ilist, bool emit
                             instr_shrink_to_32_bits(nop_inst);
                         }
 #endif
-                        /* We expect bbs to never need this if
-                         * -pad_jmps_shift_bb except on UNIX (signal fence exit) and
-                         * CLIENT_INTERFACE (client can re-arrange fragment) where we
-                         * -pad_jmps_mark_no_trace.  We rely on having not
-                         * inserted any nops into traceable bbs in interp (so that we
-                         * don't have to remove them when we build the trace).
-                         * FIXME i#4038: add tracing support so we don't have to mark
-                         * CANNOT_BE_TRACE.
-                         */
-                        if (emitting && DYNAMO_OPTION(pad_jmps_mark_no_trace) &&
-                            !TEST(FRAG_IS_TRACE, f->flags)) {
-                            LOG(THREAD, LOG_INTERP, 2,
-                                "Marking F%d as cannot-be-trace for nop padding\n",
-                                f->id);
-                            f->flags |= FRAG_CANNOT_BE_TRACE;
-                            STATS_INC(pad_jmps_mark_no_trace);
-                        } else {
-                            ASSERT(TEST(FRAG_IS_TRACE, f->flags) ||
-                                   TEST(FRAG_CANNOT_BE_TRACE, f->flags) ||
-                                   !INTERNAL_OPTION(pad_jmps_shift_bb));
-                        }
+                        LOG(THREAD, LOG_INTERP, 4,
+                            "Marking exit branch as having nop padding\n");
+                        instr_branch_set_padded(inst, true);
                         instrlist_preinsert(ilist, inst, nop_inst);
                         /* sanity check */
                         ASSERT((int)nop_length == instr_length(dcontext, nop_inst));

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1034,8 +1034,6 @@ STATS_DEF("-pad_jmps no shift stubs shared bb", pad_jmps_shared_bb_num_stubs_no_
 STATS_DEF("-pad_jmps inserted nops shared bb", pad_jmps_shared_bb_num_nops)
 STATS_DEF("-pad_jmps inserted nop bytes shared bb", pad_jmps_shared_bb_nop_bytes)
 STATS_DEF("-pad_jmps no pad exits shared bb", pad_jmps_shared_bb_num_no_pad_exits)
-STATS_DEF("-pad_jmps_mark_no_trace untraceable bbs", pad_jmps_mark_no_trace)
-STATS_DEF("-pad_jmps_mark_no_trace block trace on reemit", pad_jmps_block_trace_reemit)
 
 /* shtrace to avoid going over 60 columns */
 STATS_DEF("-pad_jmps body bytes shtrace", pad_jmps_shared_trace_body_bytes)

--- a/core/link.h
+++ b/core/link.h
@@ -80,7 +80,10 @@ enum {
     /* Indicates a far cti which uses a separate ibl entry */
     LINK_FAR = 0x0020,
 
-/* 0x0040 is reserved for i#4038 */
+    /* This exit cti has a preceding NOP to avoid its immediate from crossing a cache
+     * line.  This flag lets us identify NOPs which we added as opposed to the client.
+     */
+    LINK_PADDED = 0x0040,
 
 #ifdef X64
     /* PR 257963: since we don't store targets of ind branches, we need a flag

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -143,10 +143,7 @@ delete_private_copy(dcontext_t *dcontext)
     }
 }
 
-/* Returns false if f has been deleted and no copy can be made. FIXME - also returns
- * false if the emitted private fragment can't be added to a trace (for pad_jmps
- * insertion reasons: i#4038. */
-static bool
+static void
 create_private_copy(dcontext_t *dcontext, fragment_t *f)
 {
     monitor_data_t *md = (monitor_data_t *)dcontext->monitor_field;
@@ -201,29 +198,7 @@ create_private_copy(dcontext_t *dcontext, fragment_t *f)
         disassemble_fragment(dcontext, md->last_fragment, d_r_stats->loglevel <= 3);
     });
     KSTOP(temp_private_bb);
-    /* FIXME i#4038: With current hack pad_jmps sometimes marks fragments as
-     * CANNOT_BE_TRACE during emit (since we don't yet have a good way to handle
-     * inserted nops during tracing). This can happen for UNIX syscall fence exits and
-     * CLIENT_INTERFACE added exits.  However, it depends on the starting alignment of
-     * the fragment! So it's possible to have a fragment that is ok turn into a
-     * fragment that isn't when re-emitted here.  We could keep the ilist around and
-     * use that to extend the trace later (instead of decoding the TEMP bb), but better
-     * to come up with a general fix for tracing through nops.
-     */
-    /* PR 299808: this can happen even more easily now that we re-pass the bb
-     * to the client.  FRAG_MUST_END_TRACE is handled in internal_extend_trace.
-     */
-    if (TEST(FRAG_CANNOT_BE_TRACE, md->last_fragment->flags)) {
-        LOG(THREAD, LOG_MONITOR, 4,
-            "Private copy F%d of original F%d is marked cannot-be-trace!  Aborting.\n",
-            md->last_fragment->id, f->id);
-        delete_private_copy(dcontext);
-        md->last_fragment = NULL;
-        md->last_copy = NULL;
-        STATS_INC(pad_jmps_block_trace_reemit);
-        return false;
-    }
-    return true;
+    ASSERT(!TEST(FRAG_CANNOT_BE_TRACE, md->last_fragment->flags));
 }
 
 #ifdef CLIENT_INTERFACE
@@ -2038,28 +2013,25 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
                  * determinism issues that arise when check_thread_vm_area()
                  * changes its mind over time.
                  */
-                if (create_private_copy(dcontext, f)) {
-                    /* operate on new f from here on */
-                    if (md->trace_tag == NULL) {
-                        /* trace was aborted b/c our new fragment clobbered
-                         * someone (see comments in create_private_copy) --
-                         * when emitting our private bb we can kill the
-                         * last_fragment): just exit now
-                         */
-                        LOG(THREAD, LOG_MONITOR, 4,
-                            "Private copy ended up aborting trace!\n");
-                        STATS_INC(num_trace_private_copy_abort);
-                        /* trace abort happened in emit_fragment, so we went and
-                         * undid the clearing of last_fragment by assigning it
-                         * to last_copy, must re-clear!
-                         */
-                        md->last_fragment = NULL;
-                        return f;
-                    }
-                    f = md->last_fragment;
-                } else {
-                    end_trace = true;
+                create_private_copy(dcontext, f);
+                /* operate on new f from here on */
+                if (md->trace_tag == NULL) {
+                    /* trace was aborted b/c our new fragment clobbered
+                     * someone (see comments in create_private_copy) --
+                     * when emitting our private bb we can kill the
+                     * last_fragment): just exit now
+                     */
+                    LOG(THREAD, LOG_MONITOR, 4,
+                        "Private copy ended up aborting trace!\n");
+                    STATS_INC(num_trace_private_copy_abort);
+                    /* trace abort happened in emit_fragment, so we went and
+                     * undid the clearing of last_fragment by assigning it
+                     * to last_copy, must re-clear!
+                     */
+                    md->last_fragment = NULL;
+                    return f;
                 }
+                f = md->last_fragment;
             }
 
             if (!end_trace &&
@@ -2249,22 +2221,9 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
          * determinism issues that arise when check_thread_vm_area()
          * changes its mind over time.
          */
-        if (create_private_copy(dcontext, f)) {
-            /* operate on new f from here on */
-            f = md->last_fragment;
-        } else {
-            /* FIXME i#4038: This avoids asserts, but it might just happen over and
-             * over if the private copy repeatedly fails!  We will finish executing
-             * the app but with a performance hit from the repeated attempts to start
-             * a trace.
-             */
-            SYSLOG_INTERNAL_WARNING_ONCE(
-                "Private trace copy marked cannot-be-trace: may incur performance hit");
-            start_trace = false;
-            acquire_recursive_lock(&change_linking_lock);
-            f->flags &= ~FRAG_TRACE_BUILDING;
-            release_recursive_lock(&change_linking_lock);
-        }
+        create_private_copy(dcontext, f);
+        /* operate on new f from here on */
+        f = md->last_fragment;
     }
     if (!start_trace && ctr->counter >= INTERNAL_OPTION(trace_threshold)) {
         /* Back up the counter by one. This ensures that the

--- a/core/options.c
+++ b/core/options.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1082,9 +1082,6 @@ options_enable_code_api_dependences(options_t *options)
 
     /* Don't randomize dynamorio.dll */
     IF_WINDOWS(options->aslr_dr = false;)
-
-    /* FIXME PR 215179 on getting rid of this tracing restriction. */
-    options->pad_jmps_mark_no_trace = true;
 }
 #endif
 
@@ -1218,18 +1215,6 @@ check_option_compatibility_helper(int recurse_count)
 #    if defined(TRACE_HEAD_CACHE_INCR) || defined(CUSTOM_EXIT_STUBS)
     if (DYNAMO_OPTION(pad_jmps)) {
         USAGE_ERROR("-pad_jmps not supported in this build yet");
-    }
-#    endif
-
-#    if defined(UNIX) || defined(CLIENT_INTERFACE)
-    if (DYNAMO_OPTION(pad_jmps) && !DYNAMO_OPTION(pad_jmps_mark_no_trace) &&
-        DYNAMO_OPTION(enable_traces)
-#        ifndef UNIX
-        && INTERNAL_OPTION(code_api)
-#        endif
-    ) {
-        USAGE_ERROR("-pad_jmps isn't safe with code_api or on Linux without "
-                    "-pad_jmps_mark_no_trace when traces are enabled");
     }
 #    endif
 

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -2768,7 +2768,7 @@ OPTION_DEFAULT(uint, early_inject_location, 4 /* INJECT_LOCATION_LdrDefault */,
     OPTION_DEFAULT(uint, prng_seed, 0 /* get a good seed from the OS */,
         "if non-0 allows reproducible pseudo random number generator sequences")
 
-    /* FIXME PR 215179 on enabling pad_jmps in all builds */
+    /* TODO i#4045: Remove these defines. */
 #if defined(TRACE_HEAD_CACHE_INCR) || defined(CUSTOM_EXIT_STUBS)
     OPTION_DEFAULT(bool, pad_jmps, false, "nop pads jmps in the cache that we might need to patch so that the offset doesn't cross a L1 cache line boundary (necessary for atomic linking/unlinking on an mp machine)")
 #else
@@ -2777,19 +2777,6 @@ OPTION_DEFAULT(bool, pad_jmps, IF_X86_ELSE(true, false),
                "nop pads jmps in the cache that we might need to patch so that the "
                "offset doesn't cross a L1 cache line boundary (necessary for atomic "
                "linking/unlinking on an mp machine)")
-#endif
-    /* FIXME PR 215179 on getting rid of this tracing restriction. */
-#if defined(UNIX)
-    OPTION_DEFAULT(bool, pad_jmps_mark_no_trace, true, "mark bbs that require added nops "
-                   "for multiple hot patchable exits with CANNOT_BE_TRACE, since tracing "
-                   "through fragments with inserted nops isn't well supported (see PR "
-                   "215179 on fixing this)")
-#else
-OPTION_DEFAULT(bool, pad_jmps_mark_no_trace, false,
-               "mark bbs that require added nops "
-               "for multiple hot patchable exits with CANNOT_BE_TRACE, since tracing "
-               "through fragments with inserted nops isn't well supported (see PR "
-               "215179 on fixing this)")
 #endif
     OPTION_DEFAULT_INTERNAL(bool, pad_jmps_return_excess_padding, true, "if -pad_jmps returns any excess requested memory to fcache")
     OPTION_DEFAULT_INTERNAL(bool, pad_jmps_shift_bb, true,

--- a/make/configure.cmake.h
+++ b/make/configure.cmake.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -299,8 +299,7 @@
 # define DYNAMORIO_IR_EXPORTS
 # define CUSTOM_TRACES
 # define CLIENT_SIDELINE
-  /* PR 200409: not part of our current API, xref PR 215179 on -pad_jmps
-   * issues with CUSTOM_EXIT_STUBS
+  /* TODO i#4045: Remove these completely from the code base.
 # define CUSTOM_EXIT_STUBS
 # define UNSUPPORTED_API
    */

--- a/tools/windbg-scripts/linkstub_flags
+++ b/tools/windbg-scripts/linkstub_flags
@@ -32,24 +32,20 @@ $$ DAMAGE.
 $$ usage: set $t1 to linkstub pointer
 $$ example: r $t1=@@(dcontext->last_exit)
 
-$$ flags as of link.h 1.81
-
 ? @$t1; .echo =>; ? low(poi(@$t1+4));
 .if ((poi(@$t1+4) & 0x000001)==0x000001) {.echo "DIRECT";};
 .if ((poi(@$t1+4) & 0x000002)==0x000002) {.echo "INDIRECT";};
 .if ((poi(@$t1+4) & 0x000004)==0x000004) {.echo "RETURN";};
 .if ((poi(@$t1+4) & 0x000008)==0x000008) {.echo "CALL";};
 .if ((poi(@$t1+4) & 0x000010)==0x000010) {.echo "JMP";};
-.if ((poi(@$t1+4) & 0x000020)==0x000020) {.echo "IND_JMP_PLT";};
-.if ((poi(@$t1+4) & 0x000040)==0x000040) {.echo "SELFMOD_EXIT";};
-.if ((poi(@$t1+4) & 0x000100)==0x000100) {.echo "*** INVALID / CUSTOM_TRACES ENDS_BLOCK";};
+.if ((poi(@$t1+4) & 0x000020)==0x000020) {.echo "FAR";};
+.if ((poi(@$t1+4) & 0x000040)==0x000040) {.echo "PADDED";};
+.if ((poi(@$t1+4) & 0x000080)==0x000080) {.echo "TRACE_CMP";};
+.if ((poi(@$t1+4) & 0x000100)==0x000100) {.echo "SPECIAL";};
 .if ((poi(@$t1+4) & 0x000200)==0x000200) {.echo "CALLBACK_RETURN";};
 .if ((poi(@$t1+4) & 0x000400)==0x000400) {.echo "NI_SYSCALL";};
-$$ START_OF_LIST
-$$ END_OF_LIST
-.if ((poi(@$t1+4) & 0x001000)==0x002000) {.echo "NEVER_LINKED";};
+.if ((poi(@$t1+4) & 0x000800)==0x000800) {.echo "FRAG_OFFS_AT_END";};
+.if ((poi(@$t1+4) & 0x000800)==0x001000) {.echo "END_OF_LIST";};
+.if ((poi(@$t1+4) & 0x001000)==0x002000) {.echo "FAKE";};
 .if ((poi(@$t1+4) & 0x004000)==0x004000) {.echo "LINKED";};
 .if ((poi(@$t1+4) & 0x008000)==0x008000) {.echo "SEPARATE_STUB";};
-
-.if ((poi(@$t1+4) & 0x000800)==0x000800) {.echo "START_OF_LIST";};
-.if ((poi(@$t1+4) & 0x000800)==0x001000) {.echo "END_OF_LIST";};


### PR DESCRIPTION
Adds new flags LINK_PADDED and INSTR_BRANCH_PADDED and uses them to
mark exit cti padding added for safe patching.  Reads the link flag in
decode_fragment() to remove the padding during trace building.  This
avoids prior trace barriers from extra basic block exits from inlined
syscall exits, rseq mangling, and client changes.

Removes the option and stats around -pad_jmps_mark_no_trace which is
no longer needed.

Tested on the linux.rseq test which now successfully traces through
the rseq mangling.

Fixes #4038