### PR TITLE
i#4041: Provide actual rseq interruption PC to clients

### DIFF
--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -56,6 +56,8 @@ analyzer_multi_t::analyzer_multi_t()
     // we still keep the serial vs parallel split for 0.
     if (worker_count == 0)
         parallel = false;
+    if (!op_indir.get_value().empty() || op_infile.get_value().empty())
+        op_offline.set_value(true); // Some tools check this.
     if (!create_analysis_tools()) {
         success = false;
         error_string = "Failed to create analysis tool: " + error_string;

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -56,8 +56,8 @@ analyzer_multi_t::analyzer_multi_t()
     // we still keep the serial vs parallel split for 0.
     if (worker_count == 0)
         parallel = false;
-    if (!op_indir.get_value().empty() || op_infile.get_value().empty())
-        op_offline.set_value(true); // Some tools check this.
+    if (!op_indir.get_value().empty() || !op_infile.get_value().empty())
+        op_offline.set_value(true); // Some tools check this on post-proc runs.
     if (!create_analysis_tools()) {
         success = false;
         error_string = "Failed to create analysis tool: " + error_string;

--- a/clients/drcachesim/tests/offline-rseq.templatex
+++ b/clients/drcachesim/tests/offline-rseq.templatex
@@ -1,0 +1,25 @@
+All done
+Cache simulation results:
+Core #0 \(1 thread\(s\)\)
+  L1I stats:
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *0
+.*   Miss rate:                   *[0-9,\.]*%
+  L1D stats:
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *0
+.*   Miss rate:                   *[0-9,\.]*%
+Core #1 \(0 thread\(s\)\)
+Core #2 \(0 thread\(s\)\)
+Core #3 \(0 thread\(s\)\)
+LL stats:
+    Hits:                         *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *0
+.*   Local miss rate:             *[0-9,\.]*%
+    Child hits:                   *[0-9,\.]*.
+    Total miss rate:              *[0-9,\.]*%
+.*
+Trace invariant checks passed

--- a/clients/drcachesim/tests/trace_invariants.cpp
+++ b/clients/drcachesim/tests/trace_invariants.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -126,6 +126,8 @@ trace_invariants_t::process_memref(const memref_t &memref)
                   prev_xfer_marker.marker.marker_type ==
                       TRACE_MARKER_TYPE_KERNEL_XFER)) ||
                 prev_instr.instr.type == TRACE_TYPE_INSTR_SYSENTER);
+            // XXX: If we had instr decoding we could check direct branch targets
+            // and look for gaps after branches.
         }
 #ifdef UNIX
         // Ensure signal handlers return to the interruption point.
@@ -138,6 +140,9 @@ trace_invariants_t::process_memref(const memref_t &memref)
                    // Nested signal.  XXX: This only works for our annotated test
                    // signal_invariants.
                    memref.instr.addr == app_handler_pc ||
+                   // Marker for rseq abort handler.  Not as unique as a prefetch, but
+                   // we need an instruction and not a data type.
+                   memref.instr.type == TRACE_TYPE_INSTR_DIRECT_JUMP ||
                    // Too hard to figure out branch targets.
                    type_is_instr_branch(pre_signal_instr.instr.type) ||
                    pre_signal_instr.instr.type == TRACE_TYPE_INSTR_SYSENTER);
@@ -166,8 +171,8 @@ trace_invariants_t::process_memref(const memref_t &memref)
         prev_xfer_marker = memref;
     }
 
-    // Look for annotations where signal_invariants.c passes info to us on what to
-    // check for.  We assume the app does not have prefetch instrs w/ low addresses.
+    // Look for annotations where signal_invariants.c and rseq.c pass info to us on what
+    // to check for.  We assume the app does not have prefetch instrs w/ low addresses.
     if (memref.data.type == TRACE_TYPE_PREFETCHT2 && memref.data.addr < 1024) {
         instrs_until_interrupt = static_cast<int>(memref.data.addr);
     }

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -978,7 +978,6 @@ private:
                 impl()->log(3, "Stopping bb at kernel interruption point +" PIFX "\n",
                             cur_modoffs);
             }
-            cur_modoffs += instr->length();
             // We need to interleave instrs with memrefs.
             // There is no following memref for (instrs_are_separate && !skip_icache).
             if (!interrupted && (!instrs_are_separate || skip_icache) &&
@@ -1011,6 +1010,7 @@ private:
                         break;
                 }
             }
+            cur_modoffs += instr->length();
             DR_CHECK((size_t)(buf - buf_start) < WRITE_BUFFER_SIZE, "Too many entries");
             if (instr->is_cti()) {
                 // In case this is the last branch prior to a thread switch, buffer it. We
@@ -1064,11 +1064,7 @@ private:
                             "Checking whether reached signal/exception +" PIFX
                             " vs cur +" PIFX "\n",
                             int_modoffs, cur_modoffs);
-                // Because we increment the instr fetch first, the signal modoffs may be
-                // less than the current for a memref fault.
-                // It might also be 0, which means it should be on the first instruction.
-                if (int_modoffs == 0 || int_modoffs == cur_modoffs ||
-                    int_modoffs + instr_length == cur_modoffs) {
+                if (int_modoffs == 0 || int_modoffs == cur_modoffs) {
                     impl()->log(4, "Signal/exception interrupted the bb @ +" PIFX "\n",
                                 int_modoffs);
                     append = true;

--- a/core/globals.h
+++ b/core/globals.h
@@ -434,6 +434,10 @@ typedef struct _client_data_t {
 #    ifdef DEBUG
     bool is_translating;
 #    endif
+#    ifdef LINUX
+    /* i#4041: Pass the real translation for signals in rseq sequences. */
+    app_pc last_special_xl8;
+#    endif
 
     /* flags for asserts on linux and for getting param base right on windows */
     bool in_pre_syscall;

--- a/core/translate.h
+++ b/core/translate.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -111,5 +111,13 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
 
 bool
 at_syscall_translation(dcontext_t *dcontext, app_pc pc);
+
+#ifdef CLIENT_INTERFACE
+/* Returns the direct translation when given the "official" translation.
+ * Some special cases like rseq sequences obfuscate the interrupted PC: i#4041.
+ */
+app_pc
+translate_last_direct_translation(dcontext_t *dcontext, app_pc pc);
+#endif
 
 #endif /* _TRANSLATE_H_ */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -3393,9 +3393,14 @@ transfer_from_sig_handler_to_fcache_return(dcontext_t *dcontext, kernel_ucontext
         sig_full_cxt_t sc_full;
         sig_full_initialize(&sc_full, uc);
         sc->SC_XIP = (ptr_uint_t)next_pc;
+        /* i#4041: Provide the actually-interrupted mid-rseq PC to this event. */
+        ptr_uint_t official_xl8 = sc_interrupted->SC_XIP;
+        sc_interrupted->SC_XIP =
+            (ptr_uint_t)translate_last_direct_translation(dcontext, (app_pc)official_xl8);
         if (instrument_kernel_xfer(dcontext, DR_XFER_SIGNAL_DELIVERY, sc_interrupted_full,
                                    NULL, NULL, next_pc, sc->SC_XSP, sc_full, NULL, sig))
             next_pc = canonicalize_pc_target(dcontext, (app_pc)sc->SC_XIP);
+        sc_interrupted->SC_XIP = official_xl8;
     }
 #endif
     dcontext->next_tag = canonicalize_pc_target(dcontext, next_pc);
@@ -5700,10 +5705,15 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
 #ifdef CLIENT_INTERFACE
     mcontext->pc = dcontext->next_tag;
     sig_full_cxt_t sc_full = { sc, NULL /*not provided*/ };
+    /* i#4041: Provide the actually-interrupted mid-rseq PC to this event. */
+    ptr_uint_t official_xl8 = sc->SC_XIP;
+    sc->SC_XIP =
+        (ptr_uint_t)translate_last_direct_translation(dcontext, (app_pc)official_xl8);
     if (instrument_kernel_xfer(dcontext, DR_XFER_SIGNAL_DELIVERY, sc_full, NULL, NULL,
                                dcontext->next_tag, mcontext->xsp, osc_empty, mcontext,
                                sig))
         dcontext->next_tag = canonicalize_pc_target(dcontext, mcontext->pc);
+    sc->SC_XIP = official_xl8;
 #endif
 
     LOG(THREAD, LOG_ASYNCH, 3, "\tset xsp to " PFX "\n", xsp);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3033,7 +3033,7 @@ endif ()
       torunonly_drcacheoff(view ${ci_shared_app} ""
         "@-simulator_type@view" "")
 
-      if (LINUX)
+      if (LINUX AND X86 AND X64 AND HAVE_RSEQ)
         torunonly_drcacheoff(rseq linux.rseq "" "@-test_mode" "")
       endif ()
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3033,6 +3033,10 @@ endif ()
       torunonly_drcacheoff(view ${ci_shared_app} ""
         "@-simulator_type@view" "")
 
+      if (LINUX)
+        torunonly_drcacheoff(rseq linux.rseq "" "@-test_mode" "")
+      endif ()
+
       # FIXME i#2007: fails to link on A64
       # XXX i#1551: startstop API is NYI on ARM
       # XXX i#1997: dynamorio_static is not supported on Mac yet

--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -147,6 +147,11 @@ test_rseq_call_once(bool force_restart_in, int *completions_out, int *restarts_o
         /* Test a restart in the middle of the sequence via ud2a SIGILL. */
         "cmpb $0, %[force_restart]\n\t"
         "jz 7f\n\t"
+        /* For -test_mode trace_invariants: expect a signal after ud2a.
+         * (An alternative is to add decoding to trace_invariants but with
+         * i#2007 and other problems that liimts the test.)
+         */
+        "prefetcht2 1\n\t"
         "ud2a\n\t"
         "7:\n\t"
         "addl $1, %[completions]\n\t"
@@ -159,6 +164,9 @@ test_rseq_call_once(bool force_restart_in, int *completions_out, int *restarts_o
         /* clang-format off */ /* (avoid indenting next few lines) */
         ".long " STRINGIFY(RSEQ_SIG) "\n\t"
         "4:\n\t"
+        /* Start with jmp to avoid trace_invariants assert on return to u2da. */
+        "jmp 42f\n\t"
+        "42:\n\t"
         "addl $1, %[restarts]\n\t"
         "movb $0, %[force_restart_write]\n\t"
         "jmp 6b\n\t"
@@ -229,6 +237,7 @@ test_rseq_branches_once(bool force_restart, int *completions_out, int *restarts_
         /* Test a restart via ud2a SIGILL. */
         "cmpb $0, %[force_restart]\n\t"
         "jz 7f\n\t"
+        "prefetcht2 1\n\t" /* See above: annotation for trace_invariants. */
         "ud2a\n\t"
         "7:\n\t"
         "addl $1, %[completions]\n\t"
@@ -241,6 +250,9 @@ test_rseq_branches_once(bool force_restart, int *completions_out, int *restarts_
         /* clang-format off */ /* (avoid indenting next few lines) */
         ".long " STRINGIFY(RSEQ_SIG) "\n\t"
         "4:\n\t"
+        /* Start with jmp to avoid trace_invariants assert on return to u2da. */
+        "jmp 42f\n\t"
+        "42:\n\t"
         "addl $1, %[restarts]\n\t"
         "movb $0, %[force_restart_write]\n\t"
         "jmp 6b\n\t"
@@ -321,6 +333,9 @@ test_rseq_native_fault(void)
         /* clang-format off */ /* (avoid indenting next few lines) */
         ".long " STRINGIFY(RSEQ_SIG) "\n\t"
         "4:\n\t"
+        /* Start with jmp to avoid trace_invariants assert on return to u2da. */
+        "jmp 42f\n\t"
+        "42:\n\t"
         "addl $1, %[restarts]\n\t"
         "jmp 2b\n\t"
 


### PR DESCRIPTION
When a signal occurs inside an rseq region, DR now provides the actual
interruption PC to the kernel xfer event (but not the signal event, to
match kernel behavior).  This is required to accurately place the
signal in a drmemtrace offline trace.

What this looks like:
Before:
      0x00007fe36b1ea8f1  74 02                jz     $0x00007fe36b1ea8f5
      0x00007fe36b1ea8f3  0f 0b                ud2a
      0x00007fe36b1ea8f5  83 05 74 38 00 00 01 addl   $0x01, <rel> 0x00007fe36b1ee170
    <marker: kernel xfer to handler>
    <marker: timestamp 13224196441528495>
    <marker: tid 74400 on core 0>
      0x00007fe36b1ea85c  55                   push   %rbp
After:
      0x00007f15e71d78f1  74 02                jz     $0x00007f15e71d78f5
      0x00007f15e71d78f3  0f 0b                ud2a
    <marker: kernel xfer to handler>
    <marker: timestamp 13224196672834337>
    <marker: tid 78727 on core 1>
      0x00007f15e71d785c  55                   push   %rbp

Adds a trace_invariants check for a signal immediately after UD2A.  I
first went through and added module_mapper and decoding to
trace_invariants: but then we have to link in static DR (even if we do
our own raw decoding as module_mapper uses DR) and thus we can't run
the test anymore on AArch64 (#2007) or Mac.  Instead, I went with a
simpler solution of putting the annotations that signal_invariants.c
uses into rseq.c.

I had to fix 2 bugs to get the marker in the right place and to get
this invariants check to fire:

1) raw2trace was adding to cur_modoffs before memrefs and then having
  an extra check for where to put the the signal, which doesn't make
  sense.  It ended up putting the marker too early.  After fixing, the
  other tests still pass, so it is not clear why I had it that way.

2) op_offline was off inside trace_invariants, so the assert on a
  signal after ud2a was not firing.  I now have analyzer_multi setting
  op_offline up front as a synthetic option for post-processing usage.

I also added a direct jump as an annotation as the start of the abort
handler in rseq.c to avoid trace_invariants complaining about a signal not
returning to the interruption point.

I added a drcachesim offline regression test tracing the rseq test's
code.  This same test will be separately used for #4019.

Issue: #4019, #4041
Fixes #4041