### PR TITLE
i#4050: Add api_headers dependence to drdisas

### DIFF
--- a/clients/drdisas/CMakeLists.txt
+++ b/clients/drdisas/CMakeLists.txt
@@ -35,6 +35,7 @@ include(../../make/policies.cmake NO_POLICY_SCOPE)
 add_executable(drdisas drdisas.cpp)
 configure_DynamoRIO_decoder(drdisas)
 use_DynamoRIO_extension(drdisas droption)
+add_dependencies(drdisas api_headers)
 
 if (WIN32)
   append_property_string(TARGET drdisas COMPILE_FLAGS "/EHsc")


### PR DESCRIPTION
Fixes a build race by adding a missing api_headers dependence to
drdisas.

Fixes #4050