### PR TITLE
i#4053: Restore attached-but-never-scheduled threads on exit

### DIFF
--- a/core/synch.c
+++ b/core/synch.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -8721,6 +8721,7 @@ thread_attach_takeover_callee(app_state_at_intercept_t *state)
      */
     thread_attach_setup(&state->mc);
     ASSERT(standalone_library);
+    ASSERT_NOT_REACHED(); /* We cannot recover: there's no PC to go back to. */
     return AFTER_INTERCEPT_LET_GO;
 }
 


### PR DESCRIPTION
Fixes crashes on detach by walking the takeover_table on exit and
setting the context back to the interruption point for threads that we
tried to attach but were never scheduled.

Also adds a revert point in thread_attach_setup() if
init_apc_go_native() is set, for threads that are scheduled during
detach.

Tested on the tool.drcacheoff.burst_static test with VS2017, which
will soon become a regression test when we move to VS2017 (#2924).

Fixes #4053