### PR TITLE
i#3982: Increase size of initial brk reservation

### DIFF
--- a/core/drlibc/drlibc_module_elf.c
+++ b/core/drlibc/drlibc_module_elf.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -397,6 +397,9 @@ elf_loader_map_phdrs(elf_loader_t *elf, bool fixed, map_fn_t map_func,
                                (TEST(MODLOAD_REACHABLE, flags) ? MAP_FILE_REACHABLE : 0));
     if (lib_base == NULL)
         return NULL;
+    LOG(GLOBAL, LOG_LOADER, 3,
+        "%s: initial reservation " PFX "-" PFX " vs preferred " PFX "\n", __FUNCTION__,
+        lib_base, lib_base + initial_map_size, map_base);
     if (TEST(MODLOAD_SEPARATE_BSS, flags) && initial_map_size > elf->image_size)
         elf->image_size = initial_map_size - PAGE_SIZE;
     else

--- a/core/heap.c
+++ b/core/heap.c
@@ -834,7 +834,9 @@ vmm_place_vmcode(vm_heap_t *vmh, size_t size, heap_error_code_t *error_code)
         if (!REL32_REACHABLE(app_base, (app_pc)DYNAMO_OPTION(vm_base)) ||
             !REL32_REACHABLE(app_base,
                              (app_pc)DYNAMO_OPTION(vm_base) +
-                                 DYNAMO_OPTION(vm_max_offset))) {
+                                 DYNAMO_OPTION(vm_max_offset)) ||
+            ((app_pc)DYNAMO_OPTION(vm_base) < app_end &&
+             (app_pc)DYNAMO_OPTION(vm_base) + DYNAMO_OPTION(vm_max_offset) > app_base)) {
             byte *reach_base = MAX(REACHABLE_32BIT_START(app_base, app_end),
                                    heap_allowable_region_start);
             byte *reach_end =

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1547,8 +1547,6 @@ reserve_brk(app_pc post_app)
     if (getenv(DYNAMORIO_VAR_NO_EMULATE_BRK) == NULL) {
         /* i#1004: we're going to emulate the brk via our own mmap.
          * Reserve the initial brk now before any of DR's mmaps to avoid overlap.
-         * XXX: reserve larger APP_BRK_GAP here and then unmap back to 1 page
-         * in d_r_os_init() to ensure no DR mmap limits its size?
          */
         dynamo_options.emulate_brk = true; /* not parsed yet */
         init_emulated_brk(post_app);

--- a/ext/drsyms/CMakeLists.txt
+++ b/ext/drsyms/CMakeLists.txt
@@ -118,9 +118,6 @@ if (WIN32)
     "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/dwarf.pdb" COPYONLY)
   configure_file("${dwarf_dir}/elftc.pdb"
     "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/elftc.pdb" COPYONLY)
-  # while private loader means preferred base is not required, more efficient
-  # to avoid rebase so we avoid conflict w/ client and other exts
-  set(PREFERRED_BASE 0x76000000)
 
 elseif (UNIX)
   set(srcs
@@ -143,6 +140,10 @@ elseif (UNIX)
   endif (APPLE)
   set(srcs_static ${srcs})
 endif (WIN32)
+
+# while private loader means preferred base is not required, more efficient
+# to avoid rebase so we avoid conflict w/ client and other exts
+set(PREFERRED_BASE 0x76000000)
 
 add_library(drsyms SHARED ${srcs})
 configure_extension(drsyms OFF)


### PR DESCRIPTION
Reserves 4MB instead of just 4KB for the initial reservation for
-emulate_brk, to avoid an mmap (such as a client lib) blocking the brk
and the app running out during early init, when it can't recover and
can crash.

Fixes two related issues:
+ -vm_base_near_app was not checking for overlap with the app to see whether
  the default -vm_base will work.  Without this fix my test below does not
  reproduce the bug.
+ Sets the preferred base for drsyms to 0x76000000 for UNIX (it was already set
  for Windows) to avoid colliding with end-user clients like drmemtrace.

Tested on a static app with a certain size where libdrmemtrace.so
truncates the brk and reproduces the crash:
$ clang hello.c -g -o hello-static -static -Wl,-Ttext=0x71f54000
$ bin64/drrun -t drcachesim -dr_ops "-vm_base_near_app -vm_size 128M" -- hello-static

Fixes #3982