### PR TITLE
i#4066: patch out sysenter on x86_64

### DIFF
--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -796,11 +796,7 @@ GLOBAL_LABEL(global_do_syscall_sygate_int:)
  */
         DECLARE_FUNC(global_do_syscall_sysenter)
 GLOBAL_LABEL(global_do_syscall_sysenter:)
-#if defined(X64)
-        syscall  /* FIXME ml64 won't take "sysenter" so half-fixing now */
-#else
-        sysenter
-#endif
+        RAW(0f) RAW(34) /* sysenter */
 #ifdef DEBUG
         /* We'll never ever reach here, sysenter won't/can't return to this
          * address since it doesn't know it, but we'll put in a jmp to

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -796,7 +796,7 @@ GLOBAL_LABEL(global_do_syscall_sygate_int:)
  */
         DECLARE_FUNC(global_do_syscall_sysenter)
 GLOBAL_LABEL(global_do_syscall_sysenter:)
-#if defined(X64) && defined(WINDOWS)
+#if defined(X64)
         syscall  /* FIXME ml64 won't take "sysenter" so half-fixing now */
 #else
         sysenter


### PR DESCRIPTION
Removes the use of sysenter when building on x86_64 in order to avoid compilation errors.

The use of the sysenter gateway is most likely never used on 64-bit. Therefore, patching out sysenter should be okay.

Fixes #4066 