### PR TITLE
i#4067 Appveyor hangs: Disable popups in Windows tests

### DIFF
--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -203,8 +203,13 @@ _tmain(int argc, const TCHAR *targv[])
 #    ifdef DEBUG
     // Avoid pop-up messageboxes in tests.
     if (!IsDebuggerPresent()) {
-        _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
-        _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+        /* Set for _CRT_{WARN,ERROR,ASSERT}. */
+        for (int i = 0; i < _CRT_ERRCNT; i++) {
+            _CrtSetReportMode(i, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+            _CrtSetReportFile(i, _CRTDBG_FILE_STDERR);
+        }
+        /* This may control assert() and _wassert() in release build. */
+        _set_error_mode(_OUT_TO_STDERR);
     }
 #    endif
 #endif

--- a/core/nudge.c
+++ b/core/nudge.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -249,7 +249,11 @@ generic_nudge_handler(nudge_arg_t *arg_dont_use)
 
     /* Xref case 552, the nudge_target value provides a reasonable measure
      * of security against an attacker leveraging this routine. */
-    if (dcontext->nudge_target != (void *)generic_nudge_target) {
+    if (dcontext->nudge_target !=
+        (void *)generic_nudge_target
+            /* Allow a syscall for our test in debug build. */
+            IF_DEBUG(&&!check_filter("win32.tls.exe",
+                                     get_short_name(get_application_name())))) {
         /* FIXME - should we report this likely attempt to attack us? need
          * a unit test for this (though will then have to tone this down). */
         ASSERT(false && "unauthorized thread tried to nudge");

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1616,7 +1616,7 @@ function(use_MT_not_MTd source_file)
   if (WIN32)
     # Appending to the target flags goes in too early: we need source to
     # override the /MTd from the top level.
-    append_property_string(SOURCE ${source_file} COMPILE_FLAGS "/MT")
+    append_property_string(SOURCE ${source_file} COMPILE_FLAGS "/MT /DNO_DBG_CRT")
   endif ()
 endfunction()
 
@@ -3740,6 +3740,11 @@ else (UNIX)
 
   tobuild_dll(win32.earlythread win32/earlythread.c "")
 
+  if (DEBUG)
+    # We have a special allowance for this test to target our nudge handler in DEBUG.
+    tobuild(win32.tls win32/tls.c)
+  endif ()
+
   if (NOT X64)
     # FIXME i#16: these tests need to be fixed to compile for x64
 
@@ -3756,7 +3761,6 @@ else (UNIX)
     tobuild(win32.rsbtest win32/rsbtest.c)
     tobuild(win32.setcxtsyscall win32/setcxtsyscall.c)
     tobuild(win32.setthreadcontext win32/setthreadcontext.c)
-    tobuild(win32.tls win32/tls.c)
 
     tobuild_dll(security-win32.aslr-ind security-win32/aslr-ind.c "")
     if (TEST_SUITE) # fails non-det so run only in suite

--- a/suite/tests/tools.h
+++ b/suite/tests/tools.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -73,6 +73,9 @@
 #else
 #    include <windows.h>
 #    include <process.h> /* _beginthreadex */
+#    if defined(DEBUG) && !defined(NO_DBG_CRT)
+#        include <crtdbg.h>
+#    endif
 #    include "../../core/win32/os_public.h"
 #    define NTSTATUS DWORD
 #    define NT_SUCCESS(status) (status >= 0)
@@ -682,7 +685,33 @@ signal_handler(int sig)
                 MessageBeep(0); \
         } while (0)
 
-#    define OS_INIT() set_global_filter()
+/* We can't put this in tools.c b/c we have some tests that link /MT even in
+ * debug build.
+ */
+#    if defined(DEBUG) && !defined(NO_DBG_CRT)
+#        define DISABLE_POPUPS()                                                      \
+            do {                                                                      \
+                /* Avoid pop-up messageboxes in tests. */                             \
+                if (!IsDebuggerPresent()) {                                           \
+                    /* Control CRT-internal asserts and _ASSERT, etc. */              \
+                    /* Set for _CRT_{WARN,ERROR,ASSERT}. */                           \
+                    for (int i = 0; i < _CRT_ERRCNT; i++) {                           \
+                        _CrtSetReportMode(i, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG); \
+                        _CrtSetReportFile(i, _CRTDBG_FILE_STDERR);                    \
+                    }                                                                 \
+                    /* This may control assert() and _wassert() in release build. */  \
+                    _set_error_mode(_OUT_TO_STDERR);                                  \
+                }                                                                     \
+            } while (0)
+#    else
+#        define DISABLE_POPUPS() /* Nothing. */
+#    endif
+
+#    define OS_INIT()            \
+        do {                     \
+            DISABLE_POPUPS();    \
+            set_global_filter(); \
+        } while (0)
 
 /* XXX: when updating here, update core/os_exports.h too */
 #    define WINDOWS_VERSION_10_1803 105

--- a/suite/tests/win32/tls.c
+++ b/suite/tests/win32/tls.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -34,235 +34,13 @@
 #include <windows.h>
 #include <process.h> /* for _beginthreadex */
 #include <stdio.h>
-#include <AccCtrl.h> /* for SE_KERNEL_OBJECT */
-#include <Aclapi.h>
 #include "tools.h"
 
 #define VERBOSE 0
 
-/***************************************************************************/
-/* This is all copied from ntdll.h, share/detach.c, and lib/globals_shared.h
- * FIXME - would be nicer to find a way to include these directly. */
-
-typedef struct _UNICODE_STRING {
-    /* Length field is size in bytes not counting final 0 */
-    USHORT Length;
-    USHORT MaximumLength;
-    PWSTR Buffer;
-} UNICODE_STRING;
-typedef UNICODE_STRING *PUNICODE_STRING;
-
-typedef struct _OBJECT_ATTRIBUTES {
-    ULONG Length;
-    HANDLE RootDirectory;
-    PUNICODE_STRING ObjectName;
-    ULONG Attributes;
-    PVOID SecurityDescriptor;       // Points to type SECURITY_DESCRIPTOR
-    PVOID SecurityQualityOfService; // Points to type SECURITY_QUALITY_OF_SERVICE
-} OBJECT_ATTRIBUTES;
-typedef OBJECT_ATTRIBUTES *POBJECT_ATTRIBUTES;
-
-#define InitializeObjectAttributes(p, n, a, r, s) \
-    {                                             \
-        (p)->Length = sizeof(OBJECT_ATTRIBUTES);  \
-        (p)->RootDirectory = r;                   \
-        (p)->Attributes = a;                      \
-        (p)->ObjectName = n;                      \
-        (p)->SecurityDescriptor = s;              \
-        (p)->SecurityQualityOfService = NULL;     \
-    }
-
-#define OBJ_CASE_INSENSITIVE 0x00000040L
-/* N.B.: this is an invalid parameter on NT4! */
-#define OBJ_KERNEL_HANDLE 0x00000200L
-typedef ULONG ACCESS_MASK;
-
-typedef struct _CLIENT_ID {
-    HANDLE UniqueProcess;
-    HANDLE UniqueThread;
-} CLIENT_ID;
-typedef CLIENT_ID *PCLIENT_ID;
-
-typedef struct _USER_STACK {
-    PVOID FixedStackBase;
-    PVOID FixedStackLimit;
-    PVOID ExpandableStackBase;
-    PVOID ExpandableStackLimit;
-    PVOID ExpandableStackBottom;
-} USER_STACK, *PUSER_STACK;
-
-/* 64kb, same as allocation granularity so is as small as we can get */
-#define STACK_RESERVE 0x10000
-/* 12kb, matches current core stack size, note can expand to
- * STACK_RESERVE - (5 * PAGE_SIZE), i.e. 44kb */
-#define STACK_COMMIT 0x3000
-
-/* returns NULL on error */
-/* FIXME - is similar to core create_thread, but uses API routines where
- * possible, could try to share. */
-/* stack_reserve and stack commit must be multiples of PAGE_SIZE and reserve
- * should be at least 5 pages larger then commit */
-/* NOTE - For !target_kernel32 :
- *  target thread routine can't exit by by returning, instead it must call
- *    ExitThread or the like
- *  caller or target thread routine is responsible for informing csrss (if
- *    necessary) and freeing the the thread stack
- */
-static HANDLE
-nt_create_thread(HANDLE hProcess, PTHREAD_START_ROUTINE start_addr, void *arg,
-                 uint stack_reserve, uint stack_commit, bool suspended, uint *tid,
-                 bool target_kernel32)
-{
-    HANDLE hThread = NULL;
-    USER_STACK stack = { 0 };
-    OBJECT_ATTRIBUTES oa;
-    CLIENT_ID cid;
-    CONTEXT context = { 0 };
-    uint num_commit_bytes, code;
-    unsigned long old_prot;
-    void *p;
-    SECURITY_DESCRIPTOR *sd = NULL;
-
-    GET_NTDLL(NtCreateThread,
-              (OUT PHANDLE ThreadHandle, IN ACCESS_MASK DesiredAccess,
-               IN POBJECT_ATTRIBUTES ObjectAttributes, IN HANDLE ProcessHandle,
-               OUT PCLIENT_ID ClientId, IN PCONTEXT ThreadContext,
-               IN PUSER_STACK UserStack, IN BOOLEAN CreateSuspended));
-
-    /* both stack size and stack reserve must be multiples of PAGE_SIZE */
-    assert((stack_reserve & (PAGE_SIZE - 1)) == 0);
-    assert((stack_commit & (PAGE_SIZE - 1)) == 0);
-    /* We stick a non-committed page on each end just to be safe and windows
-     * needs three pages at the end to properly handle end of expandable stack
-     * case (wants to pass exception back to the app on overflow, so needs some
-     * stack for that). */
-    assert(stack_reserve >= stack_commit + (5 * PAGE_SIZE));
-
-    /* Use the security descriptor from the target process for creating the
-     * thread so that once created the thread will be able to open a full
-     * access handle to itself (xref case 2096). */
-    /* NOTES - tried many ways to impersonate based on target process token
-     * so we could just use the default and was unable to get anywhere with
-     * that.  Easiest thing to do here is just create a new security descriptor
-     * with a NULL (not empty) DACL [just InitializeSecurityDescriptor();
-     * SetSecurityDescriptorDacl()], but that's a privilege escalation
-     * problem (allows anybody full access to the thread)].  If we instead get
-     * the full security descriptor from the target process and try to use that
-     * the kernel complains that its a bad choice of owner.  What we do instead
-     * is get just the DACL and leave the rest empty (will be filled in with
-     * defaults during create thread).  Thus the security descriptor for the
-     * thread will end up having the owner, group, and SACL from this
-     * process and the DACL from the target.  Upshot is the the thread pseudo
-     * handle will have full permissions (from the DACL), but the owner will be
-     * us and, even though the handle we get back from CreateThread will be
-     * fully permissioned as we request, any subsequent attempts by us to
-     * OpenThread will fail since we aren't on the DACL.  We could always add
-     * ourselves to the DACL later or we can use the SE_DEBUG_PRIVILEGE to
-     * allow us to open it anyways.  Note if for some reason we want to view the
-     * SACL we need to enable the ACCESS_SYSTEM_SECURITY privilege when opening
-     * the handle.
-     * FIXME - we could instead build our own DACL combining the two, we could
-     * also try setting the owner/group after the thread is created if we
-     * really wanted to look like the target process thread, and could also
-     * start with a NULL sd and set the DACL later if want to match
-     * CreateThread as closely as possible.  If we do anything post system
-     * call should be sure to always create the thread suspended.
-     */
-    code = GetSecurityInfo(hProcess, SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, NULL,
-                           NULL, NULL, NULL, &sd);
-    assert(code == ERROR_SUCCESS);
-
-    InitializeObjectAttributes(&oa, NULL, OBJ_CASE_INSENSITIVE, NULL, sd);
-
-    stack.ExpandableStackBottom = VirtualAllocEx(
-        hProcess, NULL, stack_reserve - PAGE_SIZE, MEM_RESERVE, PAGE_READWRITE);
-    if (stack.ExpandableStackBottom == NULL)
-        goto error;
-
-    /* We provide non-committed boundary page on each side of the stack just to
-     * be safe (note we will get a stack overflow exception if stack grows to
-     * 3rd to last page of this region (xpsp2)). */
-    stack.ExpandableStackBottom = ((byte *)stack.ExpandableStackBottom) + PAGE_SIZE;
-    stack.ExpandableStackBase =
-        ((byte *)stack.ExpandableStackBottom) + stack_reserve - (2 * PAGE_SIZE);
-
-    stack.ExpandableStackLimit = ((byte *)stack.ExpandableStackBase) - stack_commit;
-    num_commit_bytes = stack_commit + PAGE_SIZE;
-    p = ((byte *)stack.ExpandableStackBase) - num_commit_bytes;
-    p = VirtualAllocEx(hProcess, p, num_commit_bytes, MEM_COMMIT, PAGE_READWRITE);
-    if (p == NULL)
-        goto error;
-    if (!VirtualProtectEx(hProcess, p, PAGE_SIZE, PAGE_READWRITE | PAGE_GUARD, &old_prot))
-        goto error;
-
-    /* set the context: initialize with our own */
-    context.ContextFlags = CONTEXT_FULL;
-    GetThreadContext(GetCurrentThread(), &context);
-    if (target_kernel32) {
-        assert(false);
-#if 0 /* not implemented here */
-        /* For kernel32!BaseThreadStartThunk CXT_XAX contains the address of the
-         * thread routine and CXT_XBX the arg */
-        context.CXT_XSP = (ptr_uint_t)stack.ExpandableStackBase;
-        context.CXT_XIP = (ptr_uint_t)get_kernel_thread_start_thunk();
-        context.CXT_XAX = (ptr_uint_t)start_addr;
-        context.CXT_XBX = (ptr_uint_t)arg;
-#endif
-    } else {
-        ptr_uint_t buf[2];
-        bool res;
-        SIZE_T written;
-        IF_X64(assert(false)); /* FIXME won't work for x64: need a SetContext */
-        /* directly targeting the start_address */
-        context.CXT_XSP = ((ptr_uint_t)stack.ExpandableStackBase) - sizeof(buf);
-        context.CXT_XIP = (ptr_uint_t)start_addr;
-        /* set up arg on stack, give NULL return address */
-        buf[1] = (ptr_uint_t)arg;
-        buf[0] = 0;
-        res = WriteProcessMemory(hProcess, (void *)context.CXT_XSP, &buf, sizeof(buf),
-                                 &written);
-        if (!res || written != sizeof(buf)) {
-            goto error;
-        }
-    }
-    if (context.CXT_XIP == 0) {
-        goto error;
-    }
-
-    /* NOTE - CreateThread passes NULL for object attributes so despite Nebbet
-     * must be optional (checked NTsp6a, XPsp2). We don't pass NULL so we can
-     * specify the security descriptor. */
-    if (!NT_SUCCESS(NtCreateThread(&hThread, THREAD_ALL_ACCESS, &oa, hProcess, &cid,
-                                   &context, &stack, (byte)(suspended ? TRUE : FALSE)))) {
-        goto error;
-    }
-
-    if (tid != NULL)
-        *tid = (ptr_uint_t)cid.UniqueThread;
-
-exit:
-    if (sd != NULL) {
-        /* Free the security descriptor. */
-        LocalFree(sd);
-    }
-
-    return hThread;
-
-error:
-    if (stack.ExpandableStackBottom != NULL) {
-        /* Free remote stack on error. */
-        VirtualFreeEx(hProcess, stack.ExpandableStackBottom, 0, MEM_RELEASE);
-    }
-    assert(hThread == NULL);
-    hThread = NULL; /* just to be safe */
-    goto exit;
-}
-
 /* As a nice benefit of tools.h now including globals_shared.h, we have
  * the NUDGE_ defines already here.
  */
-
-/***************************************************************************/
 
 byte *
 get_nudge_target()
@@ -283,12 +61,7 @@ static bool tls_own[TLS_SLOTS];
 byte *
 get_own_teb()
 {
-    byte *teb;
-    __asm {
-        mov  eax, fs:[0x18]
-        mov  teb, eax
-    }
-    return teb;
+    return (byte *)IF_X64_ELSE(__readgsqword, __readfsdword)(IF_X64_ELSE(0x30, 0x18));
 }
 
 int WINAPI
@@ -316,11 +89,7 @@ main()
     HANDLE my_thread;
     byte *nudge_target;
     int i;
-
-#if DYNAMO
-    dynamo_init();
-    dynamo_start();
-#endif
+    INIT();
 
     my_thread = (HANDLE)_beginthreadex(NULL, 0, thread_func, NULL, 0, &tid);
 
@@ -332,6 +101,10 @@ main()
          * hole in DR by creating a thread that directly targets the DR
          * detach routine.  Hopefully this will motivate us to close
          * the hole (case 552) :)
+         * Update: rather than use raw system calls, which are complex across
+         * Windows versions and duplicate code with core/, we use a high-level
+         * thread creation API.  DR does detect and stop this, but we have a
+         * relaxation for this test in DEBUG.
          * The alternative is to create a new runall type that detaches from
          * the outside and then waits a while, but would be hard to time.
          */
@@ -343,8 +116,8 @@ main()
         arg->client_arg = 0;
         print("About to detach using underhanded methods\n");
         detach_thread =
-            (HANDLE)nt_create_thread(GetCurrentProcess(), (threadfunc_t)nudge_target, arg,
-                                     STACK_RESERVE, STACK_COMMIT, false, NULL, false);
+            (HANDLE)_beginthreadex(NULL, 0, (threadfunc_t)nudge_target, arg, 0, &tid);
+        assert(detach_thread != NULL);
         WaitForSingleObject(detach_thread, INFINITE);
 
         assert(get_nudge_target() == NULL);
@@ -381,9 +154,5 @@ main()
 
     WaitForSingleObject(my_thread, INFINITE);
 
-#if DYNAMO
-    dynamo_stop();
-    dynamo_exit();
-#endif
     return 0;
 }


### PR DESCRIPTION
Expands the pop-up disabling in drcachesim's launcher to warnings and
errors as well as asserts.

Applies the same MSVC message box disabling to the tests by adding it
to INIT() in tools.h.

Tested on win32.tls.exe which asserts on Win10.

Also fixes the assert in win32.tls on win8+ by switching from raw
NtCreateThread to high-level thread creation, with an allowance added
to the core to let this test in DEBUG target our nudge handler.  This
also makes it easy to enable the test for 64-bit mode after all that
low-level code is removed.

Issue: #4067