### PR TITLE
i#4059 faster Appveyor: Shrink drcachesim Jacobi tests

### DIFF
--- a/clients/drcachesim/tests/TLB-threads.templatex
+++ b/clients/drcachesim/tests/TLB-threads.templatex
@@ -5,7 +5,7 @@
      Client version .*
     ...................................................................
 
-     Matrix Size :  512
+     Matrix Size :  128
      Threads     :  4
 
 
@@ -31,37 +31,9 @@
 
      Started iteration 5 of the computation...
 
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 6 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 7 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 8 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 9 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 10 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
 
      The Jacobi Method For AX=B .........DONE
-     Total Number Of iterations   :  10
+     Total Number Of iterations   :  5
     ...................................................................
 ---- <application exited with code 0> ----
 TLB simulation results:

--- a/clients/drcachesim/tests/TLB-threads.templatex
+++ b/clients/drcachesim/tests/TLB-threads.templatex
@@ -31,6 +31,9 @@
 
      Started iteration 5 of the computation...
 
+     Finished computing current solution distance in mode 0.
+     Mode changed to 0.
+
 
      The Jacobi Method For AX=B .........DONE
      Total Number Of iterations   :  5
@@ -39,22 +42,22 @@
 TLB simulation results:
 Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
   L1I stats:
-    Hits:                    *[0-9]*[,\.]?...[,\.]?...
+    Hits:                    *[0-9,\.]*
     Misses:                  *[0-9,\.]*
-    Invalidations:           *0
-    Miss rate:                        [0-4][\.,]..%
+    Invalidations:           *[0-9]*
+    Miss rate:               *[0-9,\.]*%
   L1D stats:
-    Hits:                      *[0-9,\.]*
-    Misses:                    *[0-9,\.]*
-    Invalidations:             *0
-    Miss rate:                 *[0-9]*[\.,]..%
+    Hits:                    *[0-9,\.]*
+    Misses:                  *[0-9,\.]*
+    Invalidations:           *[0-9[*
+    Miss rate:               *[0-9,\.]*%
   LL stats:
-    Hits:                      *[0-9,\.]*
-    Misses:                    *[0-9,\.]*
-    Invalidations:             *0
-    Local miss rate:           *[0-9]*[\.,]..%
-    Child hits:                *[0-9,\.]*
-    Total miss rate:                  [0-4][\.,]..%
+    Hits:                    *[0-9,\.]*
+    Misses:                  *[0-9,\.]*
+    Invalidations:           *[0-9]*
+    Local miss rate:         *[0-9]*[\.,]..%
+    Child hits:              *[0-9,\.]*
+    Total miss rate:         *[0-9,\.]*%
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
 Core #3 \([0-9] traced CPU\(s\).*

--- a/clients/drcachesim/tests/coherence.templatex
+++ b/clients/drcachesim/tests/coherence.templatex
@@ -5,7 +5,7 @@
      Client version .*
     ...................................................................
 
-     Matrix Size :  512
+     Matrix Size :  128
      Threads     :  4
 
 
@@ -34,34 +34,9 @@
      Finished computing current solution distance in mode 0.
      Mode changed to 0.
 
-     Started iteration 6 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 7 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 8 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 9 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 10 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
 
      The Jacobi Method For AX=B .........DONE
-     Total Number Of iterations   :  10
+     Total Number Of iterations   :  5
     ...................................................................
 ---- <application exited with code 0> ----
 Cache simulation results:

--- a/clients/drcachesim/tests/threads-with-config-file.templatex
+++ b/clients/drcachesim/tests/threads-with-config-file.templatex
@@ -5,7 +5,7 @@
      Client version .*
     ...................................................................
 
-     Matrix Size :  512
+     Matrix Size :  128
      Threads     :  4
 
 
@@ -34,34 +34,9 @@
      Finished computing current solution distance in mode 0.
      Mode changed to 0.
 
-     Started iteration 6 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 7 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 8 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 9 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 10 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
 
      The Jacobi Method For AX=B .........DONE
-     Total Number Of iterations   :  10
+     Total Number Of iterations   :  5
     ...................................................................
 ---- <application exited with code 0> ----
 Cache simulation results:

--- a/clients/drcachesim/tests/threads.templatex
+++ b/clients/drcachesim/tests/threads.templatex
@@ -5,7 +5,7 @@
      Client version .*
     ...................................................................
 
-     Matrix Size :  512
+     Matrix Size :  128
      Threads     :  4
 
 
@@ -34,34 +34,9 @@
      Finished computing current solution distance in mode 0.
      Mode changed to 0.
 
-     Started iteration 6 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 7 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 8 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 9 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 10 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
 
      The Jacobi Method For AX=B .........DONE
-     Total Number Of iterations   :  10
+     Total Number Of iterations   :  5
     ...................................................................
 ---- <application exited with code 0> ----
 Cache simulation results:

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1878,8 +1878,12 @@ if (CLIENT_INTERFACE)
     set(DynamoRIO_USE_LIBC OFF)
     if (UNIX)
       set(annotation_test_args "libclient.annotation-concurrency.appdll.so" "A" "4")
+      set(annotation_test_args_shorter
+        "libclient.annotation-concurrency.appdll.so" "A" "4" "128" "5")
     else (UNIX)
       set(annotation_test_args "client.annotation-concurrency.appdll.dll" "A" "4")
+      set(annotation_test_args_shorter
+        "client.annotation-concurrency.appdll.dll" "A" "4" "128" "5")
     endif (UNIX)
     tobuild_ci(client.annotation-concurrency client-interface/annotation-concurrency.c
       "" "" "${annotation_test_args}")
@@ -2834,23 +2838,24 @@ endif ()
         # we add some dedicated multi-thread (and multi-process) tests with
         # more deterministic output.
         # We test -cpu_scheduling on several tests with many threads.
+        # We use a smaller test (_shorter) to avoid taking multiple minutes on our
+        # CI (i#4059; xref i#2063).
         torunonly_drcachesim(threads client.annotation-concurrency "-cpu_scheduling"
-          "${annotation_test_args}")
-        set(tool.drcachesim.threads_timeout 150) # This test is long.
+          "${annotation_test_args_shorter}")
 
         # Threads test that reads the cache configuration from a config file.
         torunonly_drcachesim(threads-with-config-file client.annotation-concurrency
           "-config_file ${config_files_dir}/cores-1-levels-3-no-missfile.conf"
-          "${annotation_test_args}")
+          "${annotation_test_args_shorter}")
         set(tool.drcachesim.threads_timeout 150) # This test is long.
 
         torunonly_drcachesim(coherence client.annotation-concurrency "-coherence"
-          "${annotation_test_args}")
+          "${annotation_test_args_shorter}")
         set(tool.drcachesim.coherence_timeout 150) # This test is long.
 
         # TLB simulator's multi-thread sanity check
         torunonly_drcachesim(TLB-threads client.annotation-concurrency
-          "-simulator_type TLB -cpu_scheduling" "${annotation_test_args}")
+          "-simulator_type TLB -cpu_scheduling" "${annotation_test_args_shorter}")
         # i#2063: this test can time out.
         set(tool.drcachesim.TLB-threads_timeout 150)
       endif ()

--- a/suite/tests/client-interface/annotation-concurrency.c
+++ b/suite/tests/client-interface/annotation-concurrency.c
@@ -1,5 +1,5 @@
 /* ******************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * ******************************************************/
 
 /*
@@ -107,8 +107,8 @@ static void (*jacobi)(double *dst, double *src, double **coefficients, double *r
 static void
 print_usage()
 {
-    print("usage: jacobi { A | B | C }<thread-count>\n");
-    print(" e.g.: jacobi A4\n");
+    print("usage: jacobi { A | B | C } <thread-count> [matrix-size iters]\n");
+    print(" e.g.: jacobi A 4\n");
 }
 
 #ifdef WINDOWS
@@ -188,8 +188,8 @@ main(int argc, char **argv)
 #endif
 
     /* Parse and evaluate arguments */
-    if (argc != 4) {
-        print("Wrong number of arguments--found %d but expected 3.\n", argc);
+    if (argc != 4 && argc != 6) {
+        print("Wrong number of arguments--found %d but expected 3 or 5.\n", argc);
         for (i = 1; i < argc; i++)
             print("\targ: '%s'\n", argv[i]);
         print_usage();
@@ -234,13 +234,19 @@ main(int argc, char **argv)
 
     class_id = *argv[2] - 'A';
     num_threads = atoi(argv[3]);
+    int total_iterations = MAX_ITERATIONS;
+    matrix_size = 512;
+    if (argc == 6) {
+        matrix_size = atoi(argv[4]);
+        total_iterations = atoi(argv[5]);
+    }
 
     if (num_threads > MAX_THREADS) {
         print("\nMaximum thread count is %d. Exiting now.\n", MAX_THREADS);
         exit(1);
     }
     if ((class_id >= 0) && (class_id <= 2))
-        matrix_size = 512 * (1 << class_id);
+        matrix_size = matrix_size * (1 << class_id);
     else {
         print("Unknown class id\n");
         print_usage();
@@ -388,7 +394,7 @@ main(int argc, char **argv)
 
         TEST_ANNOTATION_EIGHT_ARGS(iteration, 2, 3, 4, 5, 6, 7, 18);
         TEST_ANNOTATION_EIGHT_ARGS(1, 2, 3, 4, 5, 6, 7, 28);
-    } while ((distance(x_old, x_new) >= TOLERANCE) && (iteration < MAX_ITERATIONS));
+    } while ((distance(x_old, x_new) >= TOLERANCE) && (iteration < total_iterations));
 
     print("\n");
     print("\n     The Jacobi Method For AX=B .........DONE");


### PR DESCRIPTION
Parametrizes the client.annotation-concurrency test to optionally take
in the matrix size and iteration count.  Changes the 4 drcachesim
tests that use this application to pass in a 128 size and 5
iterations, instead of the default 512 and 10, shrinking their
execution time by 7x.

Issue: #4059