### PR TITLE
i#4059 faster Appveyor: Disable rel test build + some 32-bit tests

### DIFF
--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -112,6 +112,14 @@ else (TEST_LONG)
   set(DO_ALL_BUILDS OFF)
 endif (TEST_LONG)
 
+# i#4059: Speed up Appveyor on PR's by not building 64-bit tests.
+# We're only running tests on Travis.
+if (DEFINED ENV{APPVEYOR_PULL_REQUEST_NUMBER})
+  set(build_release_tests "")
+else ()
+  set(build_release_tests ${build_tests})
+endif ()
+
 if (UNIX)
   # For cross-arch execve tests we need to run from an install dir
   set(installpath "${BINARY_BASE}/install")
@@ -327,7 +335,7 @@ if (NOT cross_aarchxx_linux_only AND NOT cross_android_only)
   testbuild_ex("release-external-64" ON "
     DEBUG:BOOL=OFF
     INTERNAL:BOOL=OFF
-    ${build_tests}
+    ${build_release_tests}
     ${install_path_cache}
     ${32bit_path}
     " OFF ${arg_package} "${install_build_args}")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -231,7 +231,7 @@ endif (CALLPROF AND TEST_SUITE)
 # This assumes that 32-bit Windows is not as important these days.
 # We remove some of the less differentiated tests.
 # We still run the full set for merges to master.
-if (NOT X64 AND DEFINED ENV{APPVEYOR_PULL_REQUEST_NUMBER})
+if (WIN32 AND NOT X64 AND DEFINED ENV{APPVEYOR_PULL_REQUEST_NUMBER})
   set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST ON)
 else ()
   set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST OFF)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -227,6 +227,16 @@ else (CALLPROF AND TEST_SUITE)
   set(run_list "")
 endif (CALLPROF AND TEST_SUITE)
 
+# i#4059: Reduce Appveyor time by reducing the # of tests run for 32-bit.
+# This assumes that 32-bit Windows is not as important these days.
+# We remove some of the less differentiated tests.
+# We still run the full set for merges to master.
+if (NOT X64 AND DEFINED ENV{APPVEYOR_PULL_REQUEST_NUMBER})
+  set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST ON)
+else ()
+  set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST OFF)
+endif ()
+
 ###########################################################################
 # BUILDING
 
@@ -4016,7 +4026,23 @@ function(is_test_enabled_by_name output name regex)
   set(enabled OFF)
   if (NOT SKIP_FLAKY_TESTS OR NOT "${name}" MATCHES "_FLAKY")
     if (NOT regex OR "${name}" MATCHES "${regex}")
-      set(enabled ON)
+      if (SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST AND
+          # See above: for particular builds we skip some of the similar tests from
+          # some of the test groups.
+          ("${name}" MATCHES "tool.drcache" AND
+            NOT "${name}" MATCHES "(simple|invariants|burst_malloc|burst_replaceall)") OR
+          ("${name}" MATCHES "tool.drcpusim" AND
+            NOT "${name}" MATCHES "Pentium3") OR
+          ("${name}" MATCHES "tool.[^d]" AND
+            NOT "${name}" MATCHES "(basic_counts|reuse_offline)") OR
+          # instrcalls is the slowest of the samples.
+          "${name}" MATCHES "sample.instrcalls" OR
+          ("${name}" MATCHES "client.annotation-" AND
+            NOT "${name}" MATCHES "(-opt|tiny-bb)"))
+        set(enabled OFF)
+      else ()
+        set(enabled ON)
+      endif ()
     endif ()
   endif ()
   set(${output} ${enabled} PARENT_SCOPE)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4029,7 +4029,7 @@ function(is_test_enabled_by_name output name regex)
       if (SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST AND
           # See above: for particular builds we skip some of the similar tests from
           # some of the test groups.
-          ("${name}" MATCHES "tool.drcache" AND
+          (("${name}" MATCHES "tool.drcache" AND
             NOT "${name}" MATCHES "(simple|invariants|burst_malloc|burst_replaceall)") OR
           ("${name}" MATCHES "tool.drcpusim" AND
             NOT "${name}" MATCHES "Pentium3") OR
@@ -4038,7 +4038,7 @@ function(is_test_enabled_by_name output name regex)
           # instrcalls is the slowest of the samples.
           "${name}" MATCHES "sample.instrcalls" OR
           ("${name}" MATCHES "client.annotation-" AND
-            NOT "${name}" MATCHES "(-opt|tiny-bb)"))
+            NOT "${name}" MATCHES "(-opt|tiny-bb)")))
         set(enabled OFF)
       else ()
         set(enabled ON)


### PR DESCRIPTION
For Appveyor PR's (master merges remain unchanged):

+ Disables building tests for the 64-bit release build, since we're
  not running those (only running on Linux).

+ Disables less-differentiated tests for 32-bit: removes most from
  each group of tool.drcachesim, tool.drcpusim, tool.[^d],
  client.annotation-*.

Issue: #4059