### PR TITLE
i#4049: Cleanup: Adopt trailing underscore field name style

### DIFF
--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -90,7 +90,7 @@ public:
      * error message.
      */
     analysis_tool_t()
-        : success(true){};
+        : success_(true){};
     virtual ~analysis_tool_t(){}; /**< Destructor. */
     /**
      * Tools are encouraged to perform any initialization that might fail here rather
@@ -105,13 +105,13 @@ public:
     /** Returns whether the tool was created successfully. */
     virtual bool operator!()
     {
-        return !success;
+        return !success_;
     }
     /** Returns a description of the last error. */
     virtual std::string
     get_error_string()
     {
-        return error_string;
+        return error_string_;
     }
     /**
      * The heart of an analysis tool, this routine operates on a single trace entry and
@@ -215,8 +215,8 @@ public:
     }
 
 protected:
-    bool success;
-    std::string error_string;
+    bool success_;
+    std::string error_string_;
 };
 
 #endif /* _ANALYSIS_TOOL_H_ */

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -53,11 +53,11 @@ typedef file_reader_t<std::ifstream *> default_file_reader_t;
 #endif
 
 analyzer_t::analyzer_t()
-    : success(true)
-    , num_tools(0)
-    , tools(NULL)
-    , parallel(true)
-    , worker_count(0)
+    : success_(true)
+    , num_tools_(0)
+    , tools_(NULL)
+    , parallel_(true)
+    , worker_count_(0)
 {
     /* Nothing else: child class needs to initialize. */
 }
@@ -101,20 +101,20 @@ get_reader(const std::string &path, int verbosity)
 }
 
 bool
-analyzer_t::init_file_reader(const std::string &trace_path, int verbosity_in)
+analyzer_t::init_file_reader(const std::string &trace_path, int verbosity)
 {
-    verbosity = verbosity_in;
+    verbosity_ = verbosity;
     if (trace_path.empty()) {
         ERRMSG("Trace file name is empty\n");
         return false;
     }
-    for (int i = 0; i < num_tools; ++i) {
-        if (parallel && !tools[i]->parallel_shard_supported()) {
-            parallel = false;
+    for (int i = 0; i < num_tools_; ++i) {
+        if (parallel_ && !tools_[i]->parallel_shard_supported()) {
+            parallel_ = false;
             break;
         }
     }
-    if (parallel && directory_iterator_t::is_directory(trace_path)) {
+    if (parallel_ && directory_iterator_t::is_directory(trace_path)) {
         directory_iterator_t end;
         directory_iterator_t iter(trace_path);
         if (!iter) {
@@ -131,73 +131,73 @@ analyzer_t::init_file_reader(const std::string &trace_path, int verbosity_in)
             if (!reader) {
                 return false;
             }
-            thread_data.push_back(analyzer_shard_data_t(
-                static_cast<int>(thread_data.size()), std::move(reader), path));
+            thread_data_.push_back(analyzer_shard_data_t(
+                static_cast<int>(thread_data_.size()), std::move(reader), path));
             VPRINT(this, 2, "Opened reader for %s\n", path.c_str());
         }
         // Like raw2trace, we use a simple round-robin static work assigment.  This
         // could be improved later with dynamic work queue for better load balancing.
-        if (worker_count <= 0)
-            worker_count = std::thread::hardware_concurrency();
-        worker_tasks.resize(worker_count);
+        if (worker_count_ <= 0)
+            worker_count_ = std::thread::hardware_concurrency();
+        worker_tasks_.resize(worker_count_);
         int worker = 0;
-        for (size_t i = 0; i < thread_data.size(); ++i) {
+        for (size_t i = 0; i < thread_data_.size(); ++i) {
             VPRINT(this, 2, "Worker %d assigned trace shard %zd\n", worker, i);
-            worker_tasks[worker].push_back(&thread_data[i]);
-            thread_data[i].worker = worker;
-            worker = (worker + 1) % worker_count;
+            worker_tasks_[worker].push_back(&thread_data_[i]);
+            thread_data_[i].worker = worker;
+            worker = (worker + 1) % worker_count_;
         }
     } else {
-        parallel = false;
-        serial_trace_iter = get_reader(trace_path, verbosity);
-        if (!serial_trace_iter) {
+        parallel_ = false;
+        serial_trace_iter_ = get_reader(trace_path, verbosity);
+        if (!serial_trace_iter_) {
             return false;
         }
         VPRINT(this, 2, "Opened serial reader for %s\n", trace_path.c_str());
     }
-    // It's ok if trace_end is a different type from serial_trace_iter, they
+    // It's ok if trace_end is a different type from serial_trace_iter_, they
     // will still compare true if both at EOF.
-    trace_end = std::unique_ptr<default_file_reader_t>(new default_file_reader_t());
+    trace_end_ = std::unique_ptr<default_file_reader_t>(new default_file_reader_t());
     return true;
 }
 
-analyzer_t::analyzer_t(const std::string &trace_path, analysis_tool_t **tools_in,
-                       int num_tools_in, int worker_count_in)
-    : success(true)
-    , num_tools(num_tools_in)
-    , tools(tools_in)
-    , parallel(true)
-    , worker_count(worker_count_in)
+analyzer_t::analyzer_t(const std::string &trace_path, analysis_tool_t **tools,
+                       int num_tools, int worker_count)
+    : success_(true)
+    , num_tools_(num_tools)
+    , tools_(tools)
+    , parallel_(true)
+    , worker_count_(worker_count)
 {
     for (int i = 0; i < num_tools; ++i) {
-        if (tools[i] == NULL || !*tools[i]) {
-            success = false;
-            error_string = "Tool is not successfully initialized";
-            if (tools[i] != NULL)
-                error_string += ": " + tools[i]->get_error_string();
+        if (tools_[i] == NULL || !*tools_[i]) {
+            success_ = false;
+            error_string_ = "Tool is not successfully initialized";
+            if (tools_[i] != NULL)
+                error_string_ += ": " + tools_[i]->get_error_string();
             return;
         }
-        const std::string error = tools[i]->initialize();
+        const std::string error = tools_[i]->initialize();
         if (!error.empty()) {
-            success = false;
-            error_string = "Tool failed to initialize: " + error;
+            success_ = false;
+            error_string_ = "Tool failed to initialize: " + error;
             return;
         }
     }
     if (!init_file_reader(trace_path))
-        success = false;
+        success_ = false;
 }
 
 analyzer_t::analyzer_t(const std::string &trace_path)
-    : success(true)
-    , num_tools(0)
-    , tools(NULL)
-    // This external-iterator interface does not support parallel analysis.
-    , parallel(false)
-    , worker_count(0)
+    : success_(true)
+    , num_tools_(0)
+    , tools_(NULL)
+    // This external-iterator interface does not support parallel_ analysis.
+    , parallel_(false)
+    , worker_count_(0)
 {
     if (!init_file_reader(trace_path))
-        success = false;
+        success_ = false;
 }
 
 analyzer_t::~analyzer_t()
@@ -211,20 +211,20 @@ bool
 analyzer_t::operator!()
 // clang-format on
 {
-    return !success;
+    return !success_;
 }
 
 std::string
 analyzer_t::get_error_string()
 {
-    return error_string;
+    return error_string_;
 }
 
 // Used only for serial iteration.
 bool
 analyzer_t::start_reading()
 {
-    if (!serial_trace_iter->init()) {
+    if (!serial_trace_iter_->init()) {
         ERRMSG("Failed to read from trace\n");
         return false;
     }
@@ -240,9 +240,9 @@ analyzer_t::process_tasks(std::vector<analyzer_shard_data_t *> *tasks)
     }
     VPRINT(this, 1, "Worker %d assigned %zd task(s)\n", (*tasks)[0]->worker,
            tasks->size());
-    std::vector<void *> worker_data(num_tools);
-    for (int i = 0; i < num_tools; ++i)
-        worker_data[i] = tools[i]->parallel_worker_init((*tasks)[0]->worker);
+    std::vector<void *> worker_data(num_tools_);
+    for (int i = 0; i < num_tools_; ++i)
+        worker_data[i] = tools_[i]->parallel_worker_init((*tasks)[0]->worker);
     for (analyzer_shard_data_t *tdata : *tasks) {
         VPRINT(this, 1, "Worker %d starting on trace shard %d\n", tdata->worker,
                tdata->index);
@@ -250,15 +250,15 @@ analyzer_t::process_tasks(std::vector<analyzer_shard_data_t *> *tasks)
             tdata->error = "Failed to read from trace" + tdata->trace_file;
             return;
         }
-        std::vector<void *> shard_data(num_tools);
-        for (int i = 0; i < num_tools; ++i)
-            shard_data[i] = tools[i]->parallel_shard_init(tdata->index, worker_data[i]);
+        std::vector<void *> shard_data(num_tools_);
+        for (int i = 0; i < num_tools_; ++i)
+            shard_data[i] = tools_[i]->parallel_shard_init(tdata->index, worker_data[i]);
         VPRINT(this, 1, "shard_data[0] is %p\n", shard_data[0]);
-        for (; *tdata->iter != *trace_end; ++(*tdata->iter)) {
-            for (int i = 0; i < num_tools; ++i) {
+        for (; *tdata->iter != *trace_end_; ++(*tdata->iter)) {
+            for (int i = 0; i < num_tools_; ++i) {
                 const memref_t &memref = **tdata->iter;
-                if (!tools[i]->parallel_shard_memref(shard_data[i], memref)) {
-                    tdata->error = tools[i]->parallel_shard_error(shard_data[i]);
+                if (!tools_[i]->parallel_shard_memref(shard_data[i], memref)) {
+                    tdata->error = tools_[i]->parallel_shard_error(shard_data[i]);
                     VPRINT(this, 1,
                            "Worker %d hit shard memref error %s on trace shard %d\n",
                            tdata->worker, tdata->error.c_str(), tdata->index);
@@ -268,17 +268,17 @@ analyzer_t::process_tasks(std::vector<analyzer_shard_data_t *> *tasks)
         }
         VPRINT(this, 1, "Worker %d finished trace shard %d\n", tdata->worker,
                tdata->index);
-        for (int i = 0; i < num_tools; ++i) {
-            if (!tools[i]->parallel_shard_exit(shard_data[i])) {
-                tdata->error = tools[i]->parallel_shard_error(shard_data[i]);
+        for (int i = 0; i < num_tools_; ++i) {
+            if (!tools_[i]->parallel_shard_exit(shard_data[i])) {
+                tdata->error = tools_[i]->parallel_shard_error(shard_data[i]);
                 VPRINT(this, 1, "Worker %d hit shard exit error %s on trace shard %d\n",
                        tdata->worker, tdata->error.c_str(), tdata->index);
                 return;
             }
         }
     }
-    for (int i = 0; i < num_tools; ++i) {
-        const std::string error = tools[i]->parallel_worker_exit(worker_data[i]);
+    for (int i = 0; i < num_tools_; ++i) {
+        const std::string error = tools_[i]->parallel_worker_exit(worker_data[i]);
         if (!error.empty()) {
             (*tasks)[0]->error = error;
             VPRINT(this, 1, "Worker %d hit worker exit error %s\n", (*tasks)[0]->worker,
@@ -292,38 +292,38 @@ bool
 analyzer_t::run()
 {
     // XXX i#3286: Add a %-completed progress message by looking at the file sizes.
-    if (!parallel) {
+    if (!parallel_) {
         if (!start_reading())
             return false;
-        for (; *serial_trace_iter != *trace_end; ++(*serial_trace_iter)) {
-            for (int i = 0; i < num_tools; ++i) {
-                memref_t memref = **serial_trace_iter;
+        for (; *serial_trace_iter_ != *trace_end_; ++(*serial_trace_iter_)) {
+            for (int i = 0; i < num_tools_; ++i) {
+                memref_t memref = **serial_trace_iter_;
                 // We short-circuit and exit on an error to avoid confusion over
                 // the results and avoid wasted continued work.
-                if (!tools[i]->process_memref(memref)) {
-                    error_string = tools[i]->get_error_string();
+                if (!tools_[i]->process_memref(memref)) {
+                    error_string_ = tools_[i]->get_error_string();
                     return false;
                 }
             }
         }
         return true;
     }
-    if (worker_count <= 0) {
-        error_string = "Invalid worker count: must be > 0";
+    if (worker_count_ <= 0) {
+        error_string_ = "Invalid worker count: must be > 0";
         return false;
     }
     std::vector<std::thread> threads;
-    VPRINT(this, 1, "Creating %d worker threads\n", worker_count);
-    threads.reserve(worker_count);
-    for (int i = 0; i < worker_count; ++i) {
+    VPRINT(this, 1, "Creating %d worker threads\n", worker_count_);
+    threads.reserve(worker_count_);
+    for (int i = 0; i < worker_count_; ++i) {
         threads.emplace_back(
-            std::thread(&analyzer_t::process_tasks, this, &worker_tasks[i]));
+            std::thread(&analyzer_t::process_tasks, this, &worker_tasks_[i]));
     }
     for (std::thread &thread : threads)
         thread.join();
-    for (auto &tdata : thread_data) {
+    for (auto &tdata : thread_data_) {
         if (!tdata.error.empty()) {
-            error_string = tdata.error;
+            error_string_ = tdata.error;
             return false;
         }
     }
@@ -333,12 +333,12 @@ analyzer_t::run()
 bool
 analyzer_t::print_stats()
 {
-    for (int i = 0; i < num_tools; ++i) {
-        if (!tools[i]->print_results()) {
-            error_string = tools[i]->get_error_string();
+    for (int i = 0; i < num_tools_; ++i) {
+        if (!tools_[i]->print_results()) {
+            error_string_ = tools_[i]->get_error_string();
             return false;
         }
-        if (i + 1 < num_tools) {
+        if (i + 1 < num_tools_) {
             // Separate tool output.
             std::cerr << "\n=========================================================="
                          "=================\n";
@@ -353,12 +353,12 @@ reader_t &
 analyzer_t::begin()
 {
     if (!start_reading())
-        return *trace_end;
-    return *serial_trace_iter;
+        return *trace_end_;
+    return *serial_trace_iter_;
 }
 
 reader_t &
 analyzer_t::end()
 {
-    return *trace_end;
+    return *trace_end_;
 }

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -155,7 +155,7 @@ analyzer_t::init_file_reader(const std::string &trace_path, int verbosity)
         }
         VPRINT(this, 2, "Opened serial reader for %s\n", trace_path.c_str());
     }
-    // It's ok if trace_end is a different type from serial_trace_iter_, they
+    // It's ok if trace_end_ is a different type from serial_trace_iter_, they
     // will still compare true if both at EOF.
     trace_end_ = std::unique_ptr<default_file_reader_t>(new default_file_reader_t());
     return true;
@@ -192,7 +192,7 @@ analyzer_t::analyzer_t(const std::string &trace_path)
     : success_(true)
     , num_tools_(0)
     , tools_(NULL)
-    // This external-iterator interface does not support parallel_ analysis.
+    // This external-iterator interface does not support parallel analysis.
     , parallel_(false)
     , worker_count_(0)
 {

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -112,12 +112,12 @@ protected:
     // Data for one trace shard.  Our concurrency model has each shard
     // analyzed by a single worker thread, eliminating the need for locks.
     struct analyzer_shard_data_t {
-        analyzer_shard_data_t(int index_in, std::unique_ptr<reader_t> iter_in,
-                              const std::string &trace_file_in)
-            : index(index_in)
+        analyzer_shard_data_t(int index, std::unique_ptr<reader_t> iter,
+                              const std::string &trace_file)
+            : index(index)
             , worker(0)
-            , iter(std::move(iter_in))
-            , trace_file(trace_file_in)
+            , iter(std::move(iter))
+            , trace_file(trace_file)
         {
         }
         analyzer_shard_data_t(analyzer_shard_data_t &&src)
@@ -152,18 +152,18 @@ protected:
     void
     process_tasks(std::vector<analyzer_shard_data_t *> *tasks);
 
-    bool success;
-    std::string error_string;
-    std::vector<analyzer_shard_data_t> thread_data;
-    std::unique_ptr<reader_t> serial_trace_iter;
-    std::unique_ptr<reader_t> trace_end;
-    int num_tools;
-    analysis_tool_t **tools;
-    bool parallel;
-    int worker_count;
-    std::vector<std::vector<analyzer_shard_data_t *>> worker_tasks;
-    int verbosity = 0;
-    const char *output_prefix = "[analyzer]";
+    bool success_;
+    std::string error_string_;
+    std::vector<analyzer_shard_data_t> thread_data_;
+    std::unique_ptr<reader_t> serial_trace_iter_;
+    std::unique_ptr<reader_t> trace_end_;
+    int num_tools_;
+    analysis_tool_t **tools_;
+    bool parallel_;
+    int worker_count_;
+    std::vector<std::vector<analyzer_shard_data_t *>> worker_tasks_;
+    int verbosity_ = 0;
+    const char *output_prefix_ = "[analyzer]";
 };
 
 #endif /* _ANALYZER_H_ */

--- a/clients/drcachesim/analyzer_multi.h
+++ b/clients/drcachesim/analyzer_multi.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -52,7 +52,7 @@ protected:
     void
     destroy_analysis_tools();
 
-    static const int max_num_tools = 8;
+    static const int max_num_tools_ = 8;
 };
 
 #endif /* _ANALYZER_MULTI_H_ */

--- a/clients/drcachesim/common/directory_iterator.cpp
+++ b/clients/drcachesim/common/directory_iterator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,36 +39,36 @@
 directory_iterator_t::directory_iterator_t(const std::string &directory)
 {
 #ifdef UNIX
-    dir = opendir(directory.c_str());
-    if (dir == nullptr) {
-        error_descr = "Failed to access directory.";
+    dir_ = opendir(directory.c_str());
+    if (dir_ == nullptr) {
+        error_descr_ = "Failed to access directory.";
         return;
     }
     ++*this;
 #else
-    find = INVALID_HANDLE_VALUE;
+    find_ = INVALID_HANDLE_VALUE;
     // Append \*
-    _snprintf(path, BUFFER_SIZE_ELEMENTS(path), "%s\\*", directory.c_str());
-    NULL_TERMINATE_BUFFER(path);
-    if (drfront_char_to_tchar(path, wdir, BUFFER_SIZE_ELEMENTS(wdir)) !=
+    _snprintf(path_, BUFFER_SIZE_ELEMENTS(path_), "%s\\*", directory.c_str());
+    NULL_TERMINATE_BUFFER(path_);
+    if (drfront_char_to_tchar(path_, wdir_, BUFFER_SIZE_ELEMENTS(wdir_)) !=
         DRFRONT_SUCCESS) {
-        error_descr = "Failed to convert from utf-8 to utf-16";
+        error_descr_ = "Failed to convert from utf-8 to utf-16";
         return;
     }
-    path[0] = '\0';
+    path_[0] = '\0';
     ++*this;
 #endif
-    at_eof = false;
+    at_eof_ = false;
 }
 
 directory_iterator_t::~directory_iterator_t()
 {
 #ifdef UNIX
-    if (dir != nullptr)
-        closedir(dir);
+    if (dir_ != nullptr)
+        closedir(dir_);
 #else
-    if (find != INVALID_HANDLE_VALUE)
-        FindClose(find);
+    if (find_ != INVALID_HANDLE_VALUE)
+        FindClose(find_);
 #endif
 }
 
@@ -78,43 +78,43 @@ const std::string &
 directory_iterator_t::operator*()
 // clang-format on
 {
-    return cur_file;
+    return cur_file_;
 }
 
 directory_iterator_t &
 directory_iterator_t::operator++()
 {
 #ifdef UNIX
-    ent = readdir(dir);
-    if (ent == nullptr)
-        at_eof = true;
+    ent_ = readdir(dir_);
+    if (ent_ == nullptr)
+        at_eof_ = true;
     else
-        cur_file = ent->d_name;
+        cur_file_ = ent_->d_name;
 #else
-    if (find == INVALID_HANDLE_VALUE) {
-        find = FindFirstFileW(wdir, &data);
-        if (find == INVALID_HANDLE_VALUE) {
-            error_descr = "Failed to list directory";
-            at_eof = true;
+    if (find_ == INVALID_HANDLE_VALUE) {
+        find_ = FindFirstFileW(wdir_, &data_);
+        if (find_ == INVALID_HANDLE_VALUE) {
+            error_descr_ = "Failed to list directory";
+            at_eof_ = true;
             return *this;
         }
-    } else if (!FindNextFile(find, &data)) {
-        at_eof = true;
+    } else if (!FindNextFile(find_, &data_)) {
+        at_eof_ = true;
         return *this;
     }
-    while (TESTANY(data.dwFileAttributes, FILE_ATTRIBUTE_DIRECTORY)) {
-        if (!FindNextFile(find, &data)) {
-            at_eof = true;
+    while (TESTANY(data_.dwFileAttributes, FILE_ATTRIBUTE_DIRECTORY)) {
+        if (!FindNextFile(find_, &data_)) {
+            at_eof_ = true;
             return *this;
         }
     }
-    if (drfront_tchar_to_char(data.cFileName, path, BUFFER_SIZE_ELEMENTS(path)) !=
+    if (drfront_tchar_to_char(data_.cFileName, path_, BUFFER_SIZE_ELEMENTS(path_)) !=
         DRFRONT_SUCCESS) {
-        error_descr = "Failed to convert from utf-16 to utf-8";
-        at_eof = true;
+        error_descr_ = "Failed to convert from utf-16 to utf-8";
+        at_eof_ = true;
         return *this;
     }
-    cur_file = path;
+    cur_file_ = path_;
 #endif
     return *this;
 }

--- a/clients/drcachesim/common/directory_iterator.h
+++ b/clients/drcachesim/common/directory_iterator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -64,7 +64,7 @@ public:
     std::string
     error_string() const
     {
-        return error_descr;
+        return error_descr_;
     }
 
     virtual const std::string &operator*();
@@ -77,12 +77,12 @@ public:
     virtual bool
     operator==(const directory_iterator_t &rhs) const
     {
-        return BOOLS_MATCH(at_eof, rhs.at_eof);
+        return BOOLS_MATCH(at_eof_, rhs.at_eof_);
     }
     virtual bool
     operator!=(const directory_iterator_t &rhs) const
     {
-        return !BOOLS_MATCH(at_eof, rhs.at_eof);
+        return !BOOLS_MATCH(at_eof_, rhs.at_eof_);
     }
 
     virtual directory_iterator_t &
@@ -90,7 +90,7 @@ public:
 
     virtual bool operator!()
     {
-        return at_eof;
+        return at_eof_;
     }
 
     // We do not bother to support the post-increment operator.
@@ -102,17 +102,17 @@ public:
     create_directory(const std::string &path);
 
 private:
-    bool at_eof = true;
-    std::string error_descr;
-    std::string cur_file;
+    bool at_eof_ = true;
+    std::string error_descr_;
+    std::string cur_file_;
 #ifdef WINDOWS
-    HANDLE find = INVALID_HANDLE_VALUE;
-    WIN32_FIND_DATAW data;
-    TCHAR wdir[MAX_PATH];
-    char path[MAX_PATH];
+    HANDLE find_ = INVALID_HANDLE_VALUE;
+    WIN32_FIND_DATAW data_;
+    TCHAR wdir_[MAX_PATH];
+    char path_[MAX_PATH];
 #else
-    DIR *dir = nullptr;
-    struct dirent *ent = nullptr;
+    DIR *dir_ = nullptr;
+    struct dirent *ent_ = nullptr;
 #endif
 };
 

--- a/clients/drcachesim/common/gzip_ostream.h
+++ b/clients/drcachesim/common/gzip_ostream.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -53,24 +53,24 @@ class gzip_streambuf_t : public std::basic_streambuf<char, std::char_traits<char
 public:
     gzip_streambuf_t(const std::string &path)
     {
-        file = gzopen(path.c_str(), "wb");
-        if (file != nullptr) {
-            buf = new char[buffer_size];
+        file_ = gzopen(path.c_str(), "wb");
+        if (file_ != nullptr) {
+            buf_ = new char[buffer_size_];
             // We leave an extra slot for extra_char on overflow.
-            setp(buf, buf + buffer_size - 1);
+            setp(buf_, buf_ + buffer_size_ - 1);
         }
     }
     virtual ~gzip_streambuf_t() override
     {
         sync();
-        delete[] buf;
-        if (file != nullptr)
-            gzclose(file);
+        delete[] buf_;
+        if (file_ != nullptr)
+            gzclose(file_);
     }
     virtual int
     overflow(int extra_char) override
     {
-        if (file == nullptr)
+        if (file_ == nullptr)
             return traits_type::eof();
         if (extra_char != traits_type::eof()) {
             // Put the extra char into the buffer.  We left an extra slot for it.
@@ -79,11 +79,11 @@ public:
         }
         int res = traits_type::not_eof(extra_char);
         if (pptr() > pbase()) {
-            int len = gzwrite(file, pbase(), pptr() - pbase());
+            int len = gzwrite(file_, pbase(), pptr() - pbase());
             if (len < pptr() - pbase())
                 res = traits_type::eof();
         }
-        setp(buf, buf + buffer_size - 1);
+        setp(buf_, buf_ + buffer_size_ - 1);
         return res;
     }
     virtual int
@@ -93,9 +93,9 @@ public:
     }
 
 private:
-    static const int buffer_size = 4096;
-    gzFile file = nullptr;
-    char *buf = nullptr;
+    static const int buffer_size_ = 4096;
+    gzFile file_ = nullptr;
+    char *buf_ = nullptr;
 };
 
 class gzip_ostream_t : public std::ostream {

--- a/clients/drcachesim/common/named_pipe.h
+++ b/clients/drcachesim/common/named_pipe.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -116,11 +116,11 @@ public:
 
 private:
 #ifdef WINDOWS
-    HANDLE fd;
+    HANDLE fd_;
 #else
-    int fd;
+    int fd_;
 #endif
-    std::string pipe_name;
+    std::string pipe_name_;
 };
 
 #endif /* _NAMED_PIPE_H_ */

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -298,7 +298,7 @@ _tmain(int argc, const TCHAR *targv[])
         NOTIFY(1, "INFO", "DynamoRIO configuration directory is %s", buf);
 
 #ifdef UNIX
-        // We could try to arrange for the child to auto-exit if the parent_ dies via
+        // We could try to arrange for the child to auto-exit if the parent dies via
         // prctl(PR_SET_PDEATHSIG, SIGTERM) on Linux and kqueue on Mac, plus
         // checking for ppid changes for up front races, but that won't propagate
         // to grandchildren.

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -283,9 +283,9 @@ _tmain(int argc, const TCHAR *targv[])
     } else {
         analyzer = new analyzer_multi_t;
         if (!*analyzer) {
-            std::string error_string = analyzer->get_error_string();
+            std::string error_string_ = analyzer->get_error_string();
             FATAL_ERROR("failed to initialize analyzer%s%s",
-                        error_string.empty() ? "" : ": ", error_string.c_str());
+                        error_string_.empty() ? "" : ": ", error_string_.c_str());
         }
     }
 
@@ -298,7 +298,7 @@ _tmain(int argc, const TCHAR *targv[])
         NOTIFY(1, "INFO", "DynamoRIO configuration directory is %s", buf);
 
 #ifdef UNIX
-        // We could try to arrange for the child to auto-exit if the parent dies via
+        // We could try to arrange for the child to auto-exit if the parent_ dies via
         // prctl(PR_SET_PDEATHSIG, SIGTERM) on Linux and kqueue on Mac, plus
         // checking for ppid changes for up front races, but that won't propagate
         // to grandchildren.
@@ -318,7 +318,7 @@ _tmain(int argc, const TCHAR *targv[])
             }
             FATAL_ERROR("failed to exec application");
         }
-        /* parent */
+        /* parent_ */
 #else
         if (!configure_application(app_name, app_argv, tracer_ops, &inject_data) ||
             !dr_inject_process_inject(inject_data, false /*!force*/, NULL)) {
@@ -330,9 +330,9 @@ _tmain(int argc, const TCHAR *targv[])
 
     if (!op_offline.get_value() || have_trace_file) {
         if (!analyzer->run()) {
-            std::string error_string = analyzer->get_error_string();
-            FATAL_ERROR("failed to run analyzer%s%s", error_string.empty() ? "" : ": ",
-                        error_string.c_str());
+            std::string error_string_ = analyzer->get_error_string();
+            FATAL_ERROR("failed to run analyzer%s%s", error_string_.empty() ? "" : ": ",
+                        error_string_.c_str());
         }
     }
 
@@ -362,9 +362,9 @@ _tmain(int argc, const TCHAR *targv[])
 
     if (analyzer != nullptr) {
         if (!analyzer->print_stats()) {
-            std::string error_string = analyzer->get_error_string();
-            FATAL_ERROR("failed to print results%s%s", error_string.empty() ? "" : ": ",
-                        error_string.c_str());
+            std::string error_string_ = analyzer->get_error_string();
+            FATAL_ERROR("failed to print results%s%s", error_string_.empty() ? "" : ": ",
+                        error_string_.c_str());
         }
         // release analyzer's space
         delete analyzer;

--- a/clients/drcachesim/reader/compressed_file_reader.cpp
+++ b/clients/drcachesim/reader/compressed_file_reader.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,9 +37,9 @@ template <>
 /* clang-format on */
 file_reader_t<gzFile>::~file_reader_t<gzFile>()
 {
-    for (auto file : input_files)
+    for (auto file : input_files_)
         gzclose(file);
-    delete[] thread_eof;
+    delete[] thread_eof_;
 }
 
 template <>
@@ -50,7 +50,7 @@ file_reader_t<gzFile>::open_single_file(const std::string &path)
     if (file == nullptr)
         return false;
     VPRINT(this, 1, "Opened input file %s\n", path.c_str());
-    input_files.push_back(file);
+    input_files_.push_back(file);
     return true;
 }
 
@@ -59,7 +59,7 @@ bool
 file_reader_t<gzFile>::read_next_thread_entry(size_t thread_index,
                                               OUT trace_entry_t *entry, OUT bool *eof)
 {
-    int len = gzread(input_files[thread_index], (char *)entry, sizeof(*entry));
+    int len = gzread(input_files_[thread_index], (char *)entry, sizeof(*entry));
     // Returns less than asked-for for end of file, or –1 for error.
     if (len < (int)sizeof(*entry)) {
         *eof = (len >= 0);

--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018 Google, LLC  All rights reserved.
+ * Copyright (c) 2018-2020 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -42,7 +42,7 @@ config_reader_t::config_reader_t()
 
 config_reader_t::~config_reader_t()
 {
-    fin.close();
+    fin_.close();
 }
 
 bool
@@ -50,30 +50,30 @@ config_reader_t::configure(const std::string &config_file, cache_simulator_knobs
                            std::map<std::string, cache_params_t> &caches)
 {
     // Open the config file.
-    fin.open(config_file);
-    if (!fin.is_open()) {
+    fin_.open(config_file);
+    if (!fin_.is_open()) {
         ERRMSG("Failed to open the config file '%s'\n", config_file.c_str());
         return false;
     }
 
     // Walk through the configuration file.
-    while (!fin.eof()) {
+    while (!fin_.eof()) {
         std::string param;
 
-        if (!(fin >> ws >> param)) {
+        if (!(fin_ >> ws >> param)) {
             ERRMSG("Unable to read from the configuration file\n");
             return false;
         }
 
         if (param == "//") {
             // A comment.
-            if (!getline(fin, param)) {
+            if (!getline(fin_, param)) {
                 ERRMSG("Comment expected but not found\n");
                 return false;
             }
         } else if (param == "num_cores") {
             // Number of cache cores.
-            if (!(fin >> knobs.num_cores)) {
+            if (!(fin_ >> knobs.num_cores)) {
                 ERRMSG("Error reading num_cores from the configuration file\n");
                 return false;
             }
@@ -86,7 +86,7 @@ config_reader_t::configure(const std::string &config_file, cache_simulator_knobs
         // configure TLBs.
         else if (param == "line_size") {
             // Cache line size in bytes.
-            if (!(fin >> knobs.line_size)) {
+            if (!(fin_ >> knobs.line_size)) {
                 ERRMSG("Error reading line_size from the configuration file\n");
                 return false;
             }
@@ -96,20 +96,20 @@ config_reader_t::configure(const std::string &config_file, cache_simulator_knobs
             }
         } else if (param == "skip_refs") {
             // Number of references to skip.
-            if (!(fin >> knobs.skip_refs)) {
+            if (!(fin_ >> knobs.skip_refs)) {
                 ERRMSG("Error reading skip_refs from the configuration file\n");
                 return false;
             }
         } else if (param == "warmup_refs") {
             // Number of references to use for caches warmup.
-            if (!(fin >> knobs.warmup_refs)) {
+            if (!(fin_ >> knobs.warmup_refs)) {
                 ERRMSG("Error reading warmup_refs from "
                        "the configuration file\n");
                 return false;
             }
         } else if (param == "warmup_fraction") {
             // Fraction of cache lines that must be filled to end the warmup.
-            if (!(fin >> knobs.warmup_fraction)) {
+            if (!(fin_ >> knobs.warmup_fraction)) {
                 ERRMSG("Error reading warmup_fraction from "
                        "the configuration file\n");
                 return false;
@@ -120,14 +120,14 @@ config_reader_t::configure(const std::string &config_file, cache_simulator_knobs
             }
         } else if (param == "sim_refs") {
             // Number of references to simulate.
-            if (!(fin >> knobs.sim_refs)) {
+            if (!(fin_ >> knobs.sim_refs)) {
                 ERRMSG("Error reading sim_refs from the configuration file\n");
                 return false;
             }
         } else if (param == "cpu_scheduling") {
             // Whether to simulate CPU scheduling or not.
             std::string bool_val;
-            if (!(fin >> bool_val)) {
+            if (!(fin_ >> bool_val)) {
                 ERRMSG("Error reading cpu_scheduling from "
                        "the configuration file\n");
                 return false;
@@ -139,14 +139,14 @@ config_reader_t::configure(const std::string &config_file, cache_simulator_knobs
             }
         } else if (param == "verbose") {
             // Verbose level.
-            if (!(fin >> knobs.verbose)) {
+            if (!(fin_ >> knobs.verbose)) {
                 ERRMSG("Error reading verbose from the configuration file\n");
                 return false;
             }
         } else if (param == "coherence") {
             // Whether to simulate coherence
             std::string bool_val;
-            if (!(fin >> bool_val)) {
+            if (!(fin_ >> bool_val)) {
                 ERRMSG("Error reading coherence from the configuration file\n");
                 return false;
             }
@@ -165,7 +165,7 @@ config_reader_t::configure(const std::string &config_file, cache_simulator_knobs
             caches[cache.name] = cache;
         }
 
-        if (!(fin >> ws)) {
+        if (!(fin_ >> ws)) {
             ERRMSG("Unable to read from the configuration file\n");
             return false;
         }
@@ -182,7 +182,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
     std::string error_msg;
 
     char c;
-    if (!(fin >> ws >> c)) {
+    if (!(fin_ >> ws >> c)) {
         ERRMSG("Unable to read from the configuration file\n");
         return false;
     }
@@ -191,9 +191,9 @@ config_reader_t::configure_cache(cache_params_t &cache)
         return false;
     }
 
-    while (!fin.eof()) {
+    while (!fin_.eof()) {
         std::string param;
-        if (!(fin >> ws >> param)) {
+        if (!(fin_ >> ws >> param)) {
             ERRMSG("Unable to read from the configuration file\n");
             return false;
         }
@@ -202,14 +202,14 @@ config_reader_t::configure_cache(cache_params_t &cache)
             return true;
         } else if (param == "//") {
             // A comment.
-            if (!getline(fin, param)) {
+            if (!getline(fin_, param)) {
                 ERRMSG("Comment expected but not found\n");
                 return false;
             }
         } else if (param == "type") {
             // Cache type: CACHE_TYPE_INSTRUCTION, CACHE_TYPE_DATA,
             // or CACHE_TYPE_UNIFIED.
-            if (!(fin >> cache.type)) {
+            if (!(fin_ >> cache.type)) {
                 ERRMSG("Error reading cache type from "
                        "the configuration file\n");
                 return false;
@@ -221,7 +221,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
             }
         } else if (param == "core") {
             // CPU core this cache is associated with.
-            if (!(fin >> cache.core)) {
+            if (!(fin_ >> cache.core)) {
                 ERRMSG("Error reading cache core from "
                        "the configuration file\n");
                 return false;
@@ -229,7 +229,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
         } else if (param == "size") {
             // Cache size in bytes.
             std::string size_str;
-            if (!(fin >> size_str)) {
+            if (!(fin_ >> size_str)) {
                 ERRMSG("Error reading cache size from "
                        "the configuration file\n");
                 return false;
@@ -244,21 +244,21 @@ config_reader_t::configure_cache(cache_params_t &cache)
                 return false;
             }
         } else if (param == "assoc") {
-            // Cache associativity. Must be a power of 2.
-            if (!(fin >> cache.assoc)) {
+            // Cache associativity_. Must be a power of 2.
+            if (!(fin_ >> cache.assoc)) {
                 ERRMSG("Error reading cache assoc from "
                        "the configuration file\n");
                 return false;
             }
             if (cache.assoc <= 0 || !IS_POWER_OF_2(cache.assoc)) {
-                ERRMSG("Cache associativity (%u) must be >0 and a power of 2\n",
+                ERRMSG("Cache associativity_ (%u) must be >0 and a power of 2\n",
                        cache.assoc);
                 return false;
             }
         } else if (param == "inclusive") {
             // Is the cache inclusive of its children.
             std::string bool_val;
-            if (!(fin >> bool_val)) {
+            if (!(fin_ >> bool_val)) {
                 ERRMSG("Error reading cache inclusivity from "
                        "the configuration file\n");
                 return false;
@@ -268,18 +268,18 @@ config_reader_t::configure_cache(cache_params_t &cache)
             } else {
                 cache.inclusive = false;
             }
-        } else if (param == "parent") {
-            // Name of the cache's parent. LLC's parent is main memory
+        } else if (param == "parent_") {
+            // Name of the cache's parent_. LLC's parent_ is main memory
             // (CACHE_PARENT_MEMORY).
-            if (!(fin >> cache.parent)) {
-                ERRMSG("Error reading cache parent from "
+            if (!(fin_ >> cache.parent)) {
+                ERRMSG("Error reading cache parent_ from "
                        "the configuration file\n");
                 return false;
             }
         } else if (param == "replace_policy") {
             // Cache replacement policy: REPLACE_POLICY_LRU (default),
             // REPLACE_POLICY_LFU or REPLACE_POLICY_FIFO.
-            if (!(fin >> cache.replace_policy)) {
+            if (!(fin_ >> cache.replace_policy)) {
                 ERRMSG("Error reading cache replace_policy from "
                        "the configuration file\n");
                 return false;
@@ -294,7 +294,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
         } else if (param == "prefetcher") {
             // Type of prefetcher: PREFETCH_POLICY_NEXTLINE
             // or PREFETCH_POLICY_NONE.
-            if (!(fin >> cache.prefetcher)) {
+            if (!(fin_ >> cache.prefetcher)) {
                 ERRMSG("Error reading cache prefetcher from "
                        "the configuration file\n");
                 return false;
@@ -306,7 +306,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
             }
         } else if (param == "miss_file") {
             // Name of the file to use to dump cache misses info.
-            if (!(fin >> cache.miss_file)) {
+            if (!(fin_ >> cache.miss_file)) {
                 ERRMSG("Error reading cache miss_file from "
                        "the configuration file\n");
                 return false;
@@ -316,7 +316,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
             return false;
         }
 
-        if (!(fin >> ws)) {
+        if (!(fin_ >> ws)) {
             ERRMSG("Unable to read from the configuration file\n");
             return false;
         }
@@ -357,31 +357,31 @@ config_reader_t::check_cache_config(int num_cores,
             }
         }
 
-        // Associate a cache with its parent and children caches.
+        // Associate a cache with its parent_ and children caches.
         if (cache.parent != CACHE_PARENT_MEMORY) {
             auto parent_it = caches_map.find(cache.parent);
             if (parent_it != caches_map.end()) {
-                auto &parent = parent_it->second;
+                auto &parent_ = parent_it->second;
                 // Check that the cache types are compatible.
-                if (parent.type != CACHE_TYPE_UNIFIED && cache.type != parent.type) {
-                    ERRMSG("Cache %s and its parent have incompatible types\n",
+                if (parent_.type != CACHE_TYPE_UNIFIED && cache.type != parent_.type) {
+                    ERRMSG("Cache %s and its parent_ have incompatible types\n",
                            cache_name.c_str());
                     return false;
                 }
 
-                // Add the cache to its parents children.
-                parent.children.push_back(cache_name);
+                // Add the cache to its parent_s children.
+                parent_.children.push_back(cache_name);
             } else {
-                ERRMSG("Cache %s has a listed parent %s that does not exist\n",
+                ERRMSG("Cache %s has a listed parent_ %s that does not exist\n",
                        cache_name.c_str(), cache.parent.c_str());
                 return false;
             }
 
-            // Check for cycles between the cache and its parent.
+            // Check for cycles between the cache and its parent_.
             std::string parent = cache.parent;
             while (parent != CACHE_PARENT_MEMORY) {
                 if (parent == cache_name) {
-                    ERRMSG("Cache %s & its parent %s have a cyclic reference\n",
+                    ERRMSG("Cache %s & its parent_ %s have a cyclic reference\n",
                            cache_name.c_str(), cache.parent.c_str());
                     return false;
                 }

--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -251,7 +251,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
                 return false;
             }
             if (cache.assoc <= 0 || !IS_POWER_OF_2(cache.assoc)) {
-                ERRMSG("Cache associativity_ (%u) must be >0 and a power of 2\n",
+                ERRMSG("Cache associativity (%u) must be >0 and a power of 2\n",
                        cache.assoc);
                 return false;
             }
@@ -268,11 +268,11 @@ config_reader_t::configure_cache(cache_params_t &cache)
             } else {
                 cache.inclusive = false;
             }
-        } else if (param == "parent_") {
-            // Name of the cache's parent_. LLC's parent_ is main memory
+        } else if (param == "parent") {
+            // Name of the cache's parent. LLC's parent is main memory
             // (CACHE_PARENT_MEMORY).
             if (!(fin_ >> cache.parent)) {
-                ERRMSG("Error reading cache parent_ from "
+                ERRMSG("Error reading cache parent from "
                        "the configuration file\n");
                 return false;
             }
@@ -357,31 +357,31 @@ config_reader_t::check_cache_config(int num_cores,
             }
         }
 
-        // Associate a cache with its parent_ and children caches.
+        // Associate a cache with its parent and children caches.
         if (cache.parent != CACHE_PARENT_MEMORY) {
             auto parent_it = caches_map.find(cache.parent);
             if (parent_it != caches_map.end()) {
-                auto &parent_ = parent_it->second;
+                auto &parent = parent_it->second;
                 // Check that the cache types are compatible.
-                if (parent_.type != CACHE_TYPE_UNIFIED && cache.type != parent_.type) {
-                    ERRMSG("Cache %s and its parent_ have incompatible types\n",
+                if (parent.type != CACHE_TYPE_UNIFIED && cache.type != parent.type) {
+                    ERRMSG("Cache %s and its parent have incompatible types\n",
                            cache_name.c_str());
                     return false;
                 }
 
-                // Add the cache to its parent_s children.
-                parent_.children.push_back(cache_name);
+                // Add the cache to its parents children.
+                parent.children.push_back(cache_name);
             } else {
-                ERRMSG("Cache %s has a listed parent_ %s that does not exist\n",
+                ERRMSG("Cache %s has a listed parent %s that does not exist\n",
                        cache_name.c_str(), cache.parent.c_str());
                 return false;
             }
 
-            // Check for cycles between the cache and its parent_.
+            // Check for cycles between the cache and its parent.
             std::string parent = cache.parent;
             while (parent != CACHE_PARENT_MEMORY) {
                 if (parent == cache_name) {
-                    ERRMSG("Cache %s & its parent_ %s have a cyclic reference\n",
+                    ERRMSG("Cache %s & its parent %s have a cyclic reference\n",
                            cache_name.c_str(), cache.parent.c_str());
                     return false;
                 }

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018 Google, LLC  All rights reserved.
+ * Copyright (c) 2018-2020 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -99,7 +99,7 @@ public:
               std::map<std::string, cache_params_t> &caches);
 
 private:
-    std::ifstream fin;
+    std::ifstream fin_;
 
     bool
     configure_cache(cache_params_t &cache);

--- a/clients/drcachesim/reader/ipc_reader.h
+++ b/clients/drcachesim/reader/ipc_reader.h
@@ -67,17 +67,17 @@ protected:
     }
 
 private:
-    named_pipe_t pipe;
-    bool creation_success;
+    named_pipe_t pipe_;
+    bool creation_success_;
 
     // For efficiency we want to read large chunks at a time.
     // The atomic write size for a pipe on Linux is 4096 bytes but
     // we want to go ahead and read as much data as we can at one
     // time.
     static const int BUF_SIZE = 16 * 1024;
-    trace_entry_t buf[BUF_SIZE];
-    trace_entry_t *cur_buf;
-    trace_entry_t *end_buf;
+    trace_entry_t buf_[BUF_SIZE];
+    trace_entry_t *cur_buf_;
+    trace_entry_t *end_buf_;
 };
 
 #endif /* _IPC_READER_H_ */

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -47,12 +47,12 @@
 #define OUT /* just a marker */
 
 #ifdef DEBUG
-#    define VPRINT(reader, level, ...)                           \
-        do {                                                     \
-            if ((reader)->verbosity >= (level)) {                \
-                fprintf(stderr, "%s ", (reader)->output_prefix); \
-                fprintf(stderr, __VA_ARGS__);                    \
-            }                                                    \
+#    define VPRINT(reader, level, ...)                            \
+        do {                                                      \
+            if ((reader)->verbosity_ >= (level)) {                \
+                fprintf(stderr, "%s ", (reader)->output_prefix_); \
+                fprintf(stderr, __VA_ARGS__);                     \
+            }                                                     \
         } while (0)
 #else
 #    define VPRINT(reader, level, ...) /* nothing */
@@ -63,9 +63,9 @@ public:
     reader_t()
     {
     }
-    reader_t(int verbosity_in, const char *prefix)
-        : verbosity(verbosity_in)
-        , output_prefix(prefix)
+    reader_t(int verbosity, const char *prefix)
+        : verbosity_(verbosity)
+        , output_prefix_(prefix)
     {
     }
     virtual ~reader_t()
@@ -86,12 +86,12 @@ public:
     virtual bool
     operator==(const reader_t &rhs) const
     {
-        return BOOLS_MATCH(at_eof, rhs.at_eof);
+        return BOOLS_MATCH(at_eof_, rhs.at_eof_);
     }
     virtual bool
     operator!=(const reader_t &rhs) const
     {
-        return !BOOLS_MATCH(at_eof, rhs.at_eof);
+        return !BOOLS_MATCH(at_eof_, rhs.at_eof_);
     }
 
     virtual reader_t &
@@ -125,21 +125,21 @@ protected:
     // produces an EOF object.
     // This should be set to false by subclasses in init() and set
     // back to true when actual EOF is hit.
-    bool at_eof = true;
+    bool at_eof_ = true;
 
-    int verbosity = 0;
-    const char *output_prefix = "[reader]";
+    int verbosity_ = 0;
+    const char *output_prefix_ = "[reader]";
 
 private:
-    trace_entry_t *input_entry = nullptr;
-    memref_t cur_ref;
-    memref_tid_t cur_tid = 0;
-    memref_pid_t cur_pid = 0;
-    addr_t cur_pc = 0;
-    addr_t next_pc;
-    addr_t prev_instr_addr = 0;
-    int bundle_idx = 0;
-    std::unordered_map<memref_tid_t, memref_pid_t> tid2pid;
+    trace_entry_t *input_entry_ = nullptr;
+    memref_t cur_ref_;
+    memref_tid_t cur_tid_ = 0;
+    memref_pid_t cur_pid_ = 0;
+    addr_t cur_pc_ = 0;
+    addr_t next_pc_;
+    addr_t prev_instr_addr_ = 0;
+    int bundle_idx_ = 0;
+    std::unordered_map<memref_tid_t, memref_pid_t> tid2pid_;
 };
 
 #endif /* _READER_H_ */

--- a/clients/drcachesim/reader/snappy_file_reader.h
+++ b/clients/drcachesim/reader/snappy_file_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -59,9 +59,9 @@ public:
     bool
     eof()
     {
-        if (!fstream)
+        if (!fstream_)
             return true;
-        return fstream->eof();
+        return fstream_->eof();
     }
 
 private:
@@ -90,25 +90,25 @@ private:
     read_magic(uint32_t size);
 
     // The compressed file we're reading from.
-    std::unique_ptr<std::ifstream> fstream;
+    std::unique_ptr<std::ifstream> fstream_;
     // Reader into the decompressed buffer.
-    std::unique_ptr<snappy::Source> src;
+    std::unique_ptr<snappy::Source> src_;
     // Buffer holding decompressed chunk data.
-    std::vector<char> uncompressed_buf;
+    std::vector<char> uncompressed_buf_;
     // BUffer hodling the compressed chunks themselves.
-    std::vector<char> compressed_buf;
+    std::vector<char> compressed_buf_;
 
-    bool seen_magic;
+    bool seen_magic_;
 
     // Maximum uncompressed chunk size. Fixed by the framing format.
-    static constexpr size_t max_block_size = 65536;
+    static constexpr size_t max_block_size_ = 65536;
     // Maximum compressed chunk size. <= max_block_size, since the compressor only
     // emits a compressed chunk if sizes actually shrink.
-    static constexpr size_t max_compressed_size = 65536;
+    static constexpr size_t max_compressed_size_ = 65536;
     // Checksum is always 4 bytes. Buffers should reserve space for it as well.
-    static constexpr size_t checksum_size = sizeof(uint32_t);
+    static constexpr size_t checksum_size_ = sizeof(uint32_t);
     // Magic string identifying the snappy chunked format.
-    static constexpr char magic[] = "sNaPpY";
+    static constexpr char magic_[] = "sNaPpY";
 };
 
 typedef file_reader_t<snappy_reader_t> snappy_file_reader_t;

--- a/clients/drcachesim/simulator/cache_fifo.cpp
+++ b/clients/drcachesim/simulator/cache_fifo.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,25 +39,25 @@
 // be cleared. The counter of the next block will be set to 1.
 
 bool
-cache_fifo_t::init(int associativity_, int block_size_, int total_size,
-                   caching_device_t *parent_, caching_device_stats_t *stats_,
-                   prefetcher_t *prefetcher_, bool inclusive_, bool coherent_cache_,
-                   int id_, snoop_filter_t *snoop_filter_,
-                   const std::vector<caching_device_t *> &children_)
+cache_fifo_t::init(int associativity, int block_size, int total_size,
+                   caching_device_t *parent, caching_device_stats_t *stats,
+                   prefetcher_t *prefetcher, bool inclusive, bool coherent_cache, int id,
+                   snoop_filter_t *snoop_filter,
+                   const std::vector<caching_device_t *> &children)
 {
     // Works in the same way as the base class,
     // except that the counters are initialized in a different way.
 
-    bool ret_val = cache_t::init(associativity_, block_size_, total_size, parent_, stats_,
-                                 prefetcher_, inclusive_, coherent_cache_, id_,
-                                 snoop_filter_, children_);
+    bool ret_val =
+        cache_t::init(associativity, block_size, total_size, parent, stats, prefetcher,
+                      inclusive, coherent_cache, id, snoop_filter, children);
     if (ret_val == false)
         return false;
 
     // Create a replacement pointer for each set, and
     // initialize it to point to the first block.
-    for (int i = 0; i < blocks_per_set; i++) {
-        get_caching_device_block(i << assoc_bits, 0).counter = 1;
+    for (int i = 0; i < blocks_per_set_; i++) {
+        get_caching_device_block(i << assoc_bits_, 0).counter_ = 1;
     }
     return true;
 }
@@ -74,12 +74,12 @@ int
 cache_fifo_t::replace_which_way(int block_idx)
 {
     // We replace the block whose counter is 1.
-    for (int i = 0; i < associativity; i++) {
-        if (get_caching_device_block(block_idx, i).counter == 1) {
+    for (int i = 0; i < associativity_; i++) {
+        if (get_caching_device_block(block_idx, i).counter_ == 1) {
             // clear the counter of the victim block
-            get_caching_device_block(block_idx, i).counter = 0;
+            get_caching_device_block(block_idx, i).counter_ = 0;
             // set the next block as victim
-            get_caching_device_block(block_idx, (i + 1) & (associativity - 1)).counter =
+            get_caching_device_block(block_idx, (i + 1) & (associativity_ - 1)).counter_ =
                 1;
             return i;
         }

--- a/clients/drcachesim/simulator/cache_lru.cpp
+++ b/clients/drcachesim/simulator/cache_lru.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,17 +40,17 @@
 void
 cache_lru_t::access_update(int line_idx, int way)
 {
-    int cnt = get_caching_device_block(line_idx, way).counter;
+    int cnt = get_caching_device_block(line_idx, way).counter_;
     // Optimization: return early if it is a repeated access.
     if (cnt == 0)
         return;
     // We inc all the counters that are not larger than cnt for LRU.
-    for (int i = 0; i < associativity; ++i) {
-        if (i != way && get_caching_device_block(line_idx, i).counter <= cnt)
-            get_caching_device_block(line_idx, i).counter++;
+    for (int i = 0; i < associativity_; ++i) {
+        if (i != way && get_caching_device_block(line_idx, i).counter_ <= cnt)
+            get_caching_device_block(line_idx, i).counter_++;
     }
     // Clear the counter for LRU.
-    get_caching_device_block(line_idx, way).counter = 0;
+    get_caching_device_block(line_idx, way).counter_ = 0;
 }
 
 int
@@ -59,17 +59,17 @@ cache_lru_t::replace_which_way(int line_idx)
     // We implement LRU by picking the slot with the largest counter value.
     int max_counter = 0;
     int max_way = 0;
-    for (int way = 0; way < associativity; ++way) {
-        if (get_caching_device_block(line_idx, way).tag == TAG_INVALID) {
+    for (int way = 0; way < associativity_; ++way) {
+        if (get_caching_device_block(line_idx, way).tag_ == TAG_INVALID) {
             max_way = way;
             break;
         }
-        if (get_caching_device_block(line_idx, way).counter > max_counter) {
-            max_counter = get_caching_device_block(line_idx, way).counter;
+        if (get_caching_device_block(line_idx, way).counter_ > max_counter) {
+            max_counter = get_caching_device_block(line_idx, way).counter_;
             max_way = way;
         }
     }
     // Set to non-zero for later access_update optimization on repeated access
-    get_caching_device_block(line_idx, max_way).counter = 1;
+    get_caching_device_block(line_idx, max_way).counter_ = 1;
     return max_way;
 }

--- a/clients/drcachesim/simulator/cache_miss_analyzer.h
+++ b/clients/drcachesim/simulator/cache_miss_analyzer.h
@@ -120,10 +120,10 @@ private:
     // instructions that miss in the LLC.
     // Key is the PC of the load instruction.
     // Value is a vector of data memory cache line addresses.
-    std::unordered_map<addr_t, std::vector<addr_t>> pc_cache_misses;
+    std::unordered_map<addr_t, std::vector<addr_t>> pc_cache_misses_;
 
     // Total number of LLC misses added to the hash map above.
-    int total_misses = 0;
+    int total_misses_ = 0;
 };
 
 class cache_miss_analyzer_t : public cache_simulator_t {
@@ -151,10 +151,10 @@ public:
     print_results() override;
 
 private:
-    cache_miss_stats_t *ll_stats;
+    cache_miss_stats_t *ll_stats_;
 
     // Recommendations are written to this file for use by the LLVM compiler.
-    std::string recommendation_file = "";
+    std::string recommendation_file_ = "";
 };
 
 #endif /* _CACHE_MISS_ANALYZER_H_ */

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -63,132 +63,135 @@ cache_simulator_create(const std::string &config_file)
     return new cache_simulator_t(config_file);
 }
 
-cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs_)
-    : simulator_t(knobs_.num_cores, knobs_.skip_refs, knobs_.warmup_refs,
-                  knobs_.warmup_fraction, knobs_.sim_refs, knobs_.cpu_scheduling,
-                  knobs_.verbose)
-    , knobs(knobs_)
-    , l1_icaches(NULL)
-    , l1_dcaches(NULL)
-    , is_warmed_up(false)
+cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs)
+    : simulator_t(knobs.num_cores, knobs.skip_refs, knobs.warmup_refs,
+                  knobs.warmup_fraction, knobs.sim_refs, knobs.cpu_scheduling,
+                  knobs.verbose)
+    , knobs_(knobs)
+    , l1_icaches_(NULL)
+    , l1_dcaches_(NULL)
+    , is_warmed_up_(false)
 {
     // XXX i#1703: get defaults from hardware being run on.
 
     // This configuration allows for one shared LLC only.
-    cache_t *llc = create_cache(knobs.replace_policy);
+    cache_t *llc = create_cache(knobs_.replace_policy);
     if (llc == NULL) {
-        success = false;
+        success_ = false;
         return;
     }
 
     std::string cache_name = "LL";
-    all_caches[cache_name] = llc;
-    llcaches[cache_name] = llc;
+    all_caches_[cache_name] = llc;
+    llcaches_[cache_name] = llc;
 
-    if (knobs.data_prefetcher != PREFETCH_POLICY_NEXTLINE &&
-        knobs.data_prefetcher != PREFETCH_POLICY_NONE) {
+    if (knobs_.data_prefetcher != PREFETCH_POLICY_NEXTLINE &&
+        knobs_.data_prefetcher != PREFETCH_POLICY_NONE) {
         // Unknown value.
-        success = false;
+        success_ = false;
         return;
     }
 
-    bool warmup_enabled = ((knobs.warmup_refs > 0) || (knobs.warmup_fraction > 0.0));
+    bool warmup_enabled_ = ((knobs_.warmup_refs > 0) || (knobs_.warmup_fraction > 0.0));
 
-    if (!llc->init(knobs.LL_assoc, (int)knobs.line_size, (int)knobs.LL_size, NULL,
-                   new cache_stats_t(knobs.LL_miss_file, warmup_enabled))) {
-        error_string = "Usage error: failed to initialize LL cache.  Ensure sizes and "
-                       "associativity are powers of 2, that the total size is a multiple "
-                       "of the line size, and that any miss file path is writable.";
-        success = false;
+    if (!llc->init(knobs_.LL_assoc, (int)knobs_.line_size, (int)knobs_.LL_size, NULL,
+                   new cache_stats_t(knobs_.LL_miss_file, warmup_enabled_))) {
+        error_string_ =
+            "Usage error: failed to initialize LL cache.  Ensure sizes and "
+            "associativity_ are powers of 2, that the total size is a multiple "
+            "of the line size, and that any miss file path is writable.";
+        success_ = false;
         return;
     }
 
-    l1_icaches = new cache_t *[knobs.num_cores];
-    l1_dcaches = new cache_t *[knobs.num_cores];
-    unsigned int total_snooped_caches = 2 * knobs.num_cores;
-    snooped_caches = new cache_t *[total_snooped_caches];
-    if (knobs.model_coherence) {
-        snoop_filter = new snoop_filter_t;
+    l1_icaches_ = new cache_t *[knobs_.num_cores];
+    l1_dcaches_ = new cache_t *[knobs_.num_cores];
+    unsigned int total_snooped_caches = 2 * knobs_.num_cores;
+    snooped_caches_ = new cache_t *[total_snooped_caches];
+    if (knobs_.model_coherence) {
+        snoop_filter_ = new snoop_filter_t;
     }
 
-    for (unsigned int i = 0; i < knobs.num_cores; i++) {
-        l1_icaches[i] = create_cache(knobs.replace_policy);
-        if (l1_icaches[i] == NULL) {
-            success = false;
+    for (unsigned int i = 0; i < knobs_.num_cores; i++) {
+        l1_icaches_[i] = create_cache(knobs_.replace_policy);
+        if (l1_icaches_[i] == NULL) {
+            success_ = false;
             return;
         }
-        snooped_caches[2 * i] = l1_icaches[i];
-        l1_dcaches[i] = create_cache(knobs.replace_policy);
-        if (l1_dcaches[i] == NULL) {
-            success = false;
+        snooped_caches_[2 * i] = l1_icaches_[i];
+        l1_dcaches_[i] = create_cache(knobs_.replace_policy);
+        if (l1_dcaches_[i] == NULL) {
+            success_ = false;
             return;
         }
-        snooped_caches[(2 * i) + 1] = l1_dcaches[i];
+        snooped_caches_[(2 * i) + 1] = l1_dcaches_[i];
 
-        if (!l1_icaches[i]->init(
-                knobs.L1I_assoc, (int)knobs.line_size, (int)knobs.L1I_size, llc,
-                new cache_stats_t("", warmup_enabled, knobs.model_coherence),
-                nullptr /*prefetcher*/, false /*inclusive*/, knobs.model_coherence, 2 * i,
-                snoop_filter) ||
-            !l1_dcaches[i]->init(
-                knobs.L1D_assoc, (int)knobs.line_size, (int)knobs.L1D_size, llc,
-                new cache_stats_t("", warmup_enabled, knobs.model_coherence),
-                knobs.data_prefetcher == PREFETCH_POLICY_NEXTLINE
-                    ? new prefetcher_t((int)knobs.line_size)
+        if (!l1_icaches_[i]->init(
+                knobs_.L1I_assoc, (int)knobs_.line_size, (int)knobs_.L1I_size, llc,
+                new cache_stats_t("", warmup_enabled_, knobs_.model_coherence),
+                nullptr /*prefetcher*/, false /*inclusive*/, knobs_.model_coherence,
+                2 * i, snoop_filter_) ||
+            !l1_dcaches_[i]->init(
+                knobs_.L1D_assoc, (int)knobs_.line_size, (int)knobs_.L1D_size, llc,
+                new cache_stats_t("", warmup_enabled_, knobs_.model_coherence),
+                knobs_.data_prefetcher == PREFETCH_POLICY_NEXTLINE
+                    ? new prefetcher_t((int)knobs_.line_size)
                     : nullptr,
-                false /*inclusive*/, knobs.model_coherence, (2 * i) + 1, snoop_filter)) {
-            error_string = "Usage error: failed to initialize L1 caches.  Ensure sizes "
-                           "and associativity are powers of 2 "
-                           "and that the total sizes are multiples of the line size.";
-            success = false;
+                false /*inclusive*/, knobs_.model_coherence, (2 * i) + 1,
+                snoop_filter_)) {
+            error_string_ = "Usage error: failed to initialize L1 caches.  Ensure sizes "
+                            "and associativity_ are powers of 2 "
+                            "and that the total sizes are multiples of the line size.";
+            success_ = false;
             return;
         }
 
         cache_name = "L1_I_Cache_" + std::to_string(i);
-        all_caches[cache_name] = l1_icaches[i];
+        all_caches_[cache_name] = l1_icaches_[i];
         cache_name = "L1_D_Cache_" + std::to_string(i);
-        all_caches[cache_name] = l1_dcaches[i];
+        all_caches_[cache_name] = l1_dcaches_[i];
     }
 
-    if (knobs.model_coherence &&
-        !snoop_filter->init(snooped_caches, total_snooped_caches)) {
+    if (knobs_.model_coherence &&
+        !snoop_filter_->init(snooped_caches_, total_snooped_caches)) {
         ERRMSG("Usage error: failed to initialize snoop filter.\n");
-        success = false;
+        success_ = false;
         return;
     }
 }
 
 cache_simulator_t::cache_simulator_t(const std::string &config_file)
     : simulator_t()
-    , l1_icaches(NULL)
-    , l1_dcaches(NULL)
-    , snooped_caches(NULL)
-    , snoop_filter(NULL)
-    , is_warmed_up(false)
+    , l1_icaches_(NULL)
+    , l1_dcaches_(NULL)
+    , snooped_caches_(NULL)
+    , snoop_filter_(NULL)
+    , is_warmed_up_(false)
 {
     std::map<std::string, cache_params_t> cache_params;
     config_reader_t config_reader;
-    if (!config_reader.configure(config_file, knobs, cache_params)) {
-        error_string =
+    if (!config_reader.configure(config_file, knobs_, cache_params)) {
+        error_string_ =
             "Usage error: Failed to read/parse configuration file " + config_file;
-        success = false;
+        success_ = false;
         return;
     }
 
-    init_knobs(knobs.num_cores, knobs.skip_refs, knobs.warmup_refs, knobs.warmup_fraction,
-               knobs.sim_refs, knobs.cpu_scheduling, knobs.verbose);
+    init_knobs(knobs_.num_cores, knobs_.skip_refs, knobs_.warmup_refs,
+               knobs_.warmup_fraction, knobs_.sim_refs, knobs_.cpu_scheduling,
+               knobs_.verbose);
 
-    if (knobs.data_prefetcher != PREFETCH_POLICY_NEXTLINE &&
-        knobs.data_prefetcher != PREFETCH_POLICY_NONE) {
+    if (knobs_.data_prefetcher != PREFETCH_POLICY_NEXTLINE &&
+        knobs_.data_prefetcher != PREFETCH_POLICY_NONE) {
         // Unknown prefetcher type.
-        success = false;
+        success_ = false;
         return;
     }
 
-    bool warmup_enabled = ((knobs.warmup_refs > 0) || (knobs.warmup_fraction > 0.0));
+    bool warmup_enabled_ = ((knobs_.warmup_refs > 0) || (knobs_.warmup_fraction > 0.0));
 
-    l1_icaches = new cache_t *[knobs.num_cores];
-    l1_dcaches = new cache_t *[knobs.num_cores];
+    l1_icaches_ = new cache_t *[knobs_.num_cores];
+    l1_dcaches_ = new cache_t *[knobs_.num_cores];
 
     // Create all the caches in the hierarchy.
     for (const auto &cache_params_it : cache_params) {
@@ -197,23 +200,23 @@ cache_simulator_t::cache_simulator_t(const std::string &config_file)
 
         cache_t *cache = create_cache(cache_config.replace_policy);
         if (cache == NULL) {
-            success = false;
+            success_ = false;
             return;
         }
 
-        all_caches[cache_name] = cache;
+        all_caches_[cache_name] = cache;
     }
 
     int num_LL = 0;
     unsigned int total_snooped_caches = 0;
     std::string lowest_shared_cache = "";
-    if (knobs.model_coherence) {
-        snoop_filter = new snoop_filter_t;
+    if (knobs_.model_coherence) {
+        snoop_filter_ = new snoop_filter_t;
         std::string LL_name;
         /* This block determines where in the cache hierarchy to place the snoop filter.
          * If there is more than one LLC, the snoop filter is above those.
          */
-        for (const auto &cache_it : all_caches) {
+        for (const auto &cache_it : all_caches_) {
             std::string cache_name = cache_it.first;
             const auto &cache_config = cache_params.find(cache_name)->second;
             if (cache_config.parent == CACHE_PARENT_MEMORY) {
@@ -227,10 +230,10 @@ cache_simulator_t::cache_simulator_t(const std::string &config_file)
              * Fully shared caches are marked as non-coherent.
              */
             cache_params_t current_cache = cache_params.find(LL_name)->second;
-            non_coherent_caches[LL_name] = all_caches[LL_name];
+            non_coherent_caches_[LL_name] = all_caches_[LL_name];
             while (current_cache.children.size() == 1) {
                 std::string child_name = current_cache.children[0];
-                non_coherent_caches[child_name] = all_caches[child_name];
+                non_coherent_caches_[child_name] = all_caches_[child_name];
                 current_cache = cache_params.find(child_name)->second;
             }
             if (current_cache.children.size() > 0) {
@@ -240,47 +243,48 @@ cache_simulator_t::cache_simulator_t(const std::string &config_file)
         } else {
             total_snooped_caches = num_LL;
         }
-        snooped_caches = new cache_t *[total_snooped_caches];
+        snooped_caches_ = new cache_t *[total_snooped_caches];
     }
 
     // Initialize all the caches in the hierarchy and identify both
     // the L1 caches and LLC(s).
     int snoop_id = 0;
-    for (const auto &cache_it : all_caches) {
+    for (const auto &cache_it : all_caches_) {
         std::string cache_name = cache_it.first;
         cache_t *cache = cache_it.second;
 
         // Locate the cache's configuration.
         const auto &cache_config_it = cache_params.find(cache_name);
         if (cache_config_it == cache_params.end()) {
-            error_string = "Error locating the configuration of the cache: " + cache_name;
-            success = false;
+            error_string_ =
+                "Error locating the configuration of the cache: " + cache_name;
+            success_ = false;
             return;
         }
         auto &cache_config = cache_config_it->second;
 
-        // Locate the cache's parent.
-        cache_t *parent = NULL;
+        // Locate the cache's parent_.
+        cache_t *parent_ = NULL;
         if (cache_config.parent != CACHE_PARENT_MEMORY) {
-            const auto &parent_it = all_caches.find(cache_config.parent);
-            if (parent_it == all_caches.end()) {
-                error_string = "Error locating the configuration of the parent cache: " +
+            const auto &parent_it = all_caches_.find(cache_config.parent);
+            if (parent_it == all_caches_.end()) {
+                error_string_ = "Error locating the configuration of the parent cache: " +
                     cache_config.parent;
-                success = false;
+                success_ = false;
                 return;
             }
-            parent = parent_it->second;
+            parent_ = parent_it->second;
         }
 
         // Locate the cache's children.
         std::vector<caching_device_t *> children;
         children.clear();
         for (std::string &child_name : cache_config.children) {
-            const auto &child_it = all_caches.find(child_name);
-            if (child_it == all_caches.end()) {
-                error_string =
+            const auto &child_it = all_caches_.find(child_name);
+            if (child_it == all_caches_.end()) {
+                error_string_ =
                     "Error locating the configuration of the cache: " + child_name;
-                success = false;
+                success_ = false;
                 return;
             }
             children.push_back(child_it->second);
@@ -291,109 +295,110 @@ cache_simulator_t::cache_simulator_t(const std::string &config_file)
         bool mid_snooped = total_snooped_caches > 1 &&
             cache_config.parent.compare(lowest_shared_cache) == 0;
 
-        bool is_snooped = knobs.model_coherence && (LL_snooped || mid_snooped);
+        bool is_snooped = knobs_.model_coherence && (LL_snooped || mid_snooped);
 
         // If cache is below a snoop filter, it should be marked as coherent.
-        bool is_coherent = knobs.model_coherence &&
-            (non_coherent_caches.find(cache_name) == non_coherent_caches.end());
+        bool is_coherent_ = knobs_.model_coherence &&
+            (non_coherent_caches_.find(cache_name) == non_coherent_caches_.end());
 
         if (!cache->init(
-                (int)cache_config.assoc, (int)knobs.line_size, (int)cache_config.size,
-                parent,
-                new cache_stats_t(cache_config.miss_file, warmup_enabled, is_coherent),
+                (int)cache_config.assoc, (int)knobs_.line_size, (int)cache_config.size,
+                parent_,
+                new cache_stats_t(cache_config.miss_file, warmup_enabled_, is_coherent_),
                 cache_config.prefetcher == PREFETCH_POLICY_NEXTLINE
-                    ? new prefetcher_t((int)knobs.line_size)
+                    ? new prefetcher_t((int)knobs_.line_size)
                     : nullptr,
-                cache_config.inclusive, is_coherent, is_snooped ? snoop_id : -1,
-                is_snooped ? snoop_filter : nullptr, children)) {
-            error_string = "Usage error: failed to initialize the cache " + cache_name;
-            success = false;
+                cache_config.inclusive, is_coherent_, is_snooped ? snoop_id : -1,
+                is_snooped ? snoop_filter_ : nullptr, children)) {
+            error_string_ = "Usage error: failed to initialize the cache " + cache_name;
+            success_ = false;
             return;
         }
 
         // Next snooped cache should have a different ID.
         if (is_snooped) {
-            snooped_caches[snoop_id] = cache;
+            snooped_caches_[snoop_id] = cache;
             snoop_id++;
         }
 
         bool is_l1_or_llc = false;
 
         // Assign the pointers to the L1 instruction and data caches.
-        if (cache_config.core >= 0 && cache_config.core < (int)knobs.num_cores) {
+        if (cache_config.core >= 0 && cache_config.core < (int)knobs_.num_cores) {
             is_l1_or_llc = true;
             if (cache_config.type == CACHE_TYPE_INSTRUCTION ||
                 cache_config.type == CACHE_TYPE_UNIFIED) {
-                l1_icaches[cache_config.core] = cache;
+                l1_icaches_[cache_config.core] = cache;
             }
             if (cache_config.type == CACHE_TYPE_DATA ||
                 cache_config.type == CACHE_TYPE_UNIFIED) {
-                l1_dcaches[cache_config.core] = cache;
+                l1_dcaches_[cache_config.core] = cache;
             }
         }
 
         // Assign the pointer(s) to the LLC(s).
         if (cache_config.parent == CACHE_PARENT_MEMORY) {
             is_l1_or_llc = true;
-            llcaches[cache_name] = cache;
+            llcaches_[cache_name] = cache;
         }
 
         // Keep track of non-L1 and non-LLC caches.
         if (!is_l1_or_llc) {
-            other_caches[cache_name] = cache;
+            other_caches_[cache_name] = cache;
         }
     }
-    if (knobs.model_coherence && !snoop_filter->init(snooped_caches, snoop_id)) {
+    if (knobs_.model_coherence && !snoop_filter_->init(snooped_caches_, snoop_id)) {
         ERRMSG("Usage error: failed to initialize snoop filter.\n");
-        success = false;
+        success_ = false;
         return;
     }
 }
 
 cache_simulator_t::~cache_simulator_t()
 {
-    for (auto &caches_it : all_caches) {
+    for (auto &caches_it : all_caches_) {
         cache_t *cache = caches_it.second;
         delete cache->get_stats();
         delete cache->get_prefetcher();
         delete cache;
     }
 
-    if (l1_icaches != NULL) {
-        delete[] l1_icaches;
+    if (l1_icaches_ != NULL) {
+        delete[] l1_icaches_;
     }
-    if (l1_dcaches != NULL) {
-        delete[] l1_dcaches;
+    if (l1_dcaches_ != NULL) {
+        delete[] l1_dcaches_;
     }
-    if (snooped_caches != NULL) {
-        delete[] snooped_caches;
+    if (snooped_caches_ != NULL) {
+        delete[] snooped_caches_;
     }
-    if (snoop_filter != NULL) {
-        delete snoop_filter;
+    if (snoop_filter_ != NULL) {
+        delete snoop_filter_;
     }
 }
 
 uint64_t
 cache_simulator_t::remaining_sim_refs() const
 {
-    return knobs.sim_refs;
+    return knobs_.sim_refs;
 }
 
 bool
 cache_simulator_t::process_memref(const memref_t &memref)
 {
-    if (knobs.skip_refs > 0) {
-        knobs.skip_refs--;
+    if (knobs_.skip_refs > 0) {
+        knobs_.skip_refs--;
         return true;
     }
 
     // If no warmup is specified and we have simulated sim_refs then
     // we are done.
-    if ((knobs.warmup_refs == 0 && knobs.warmup_fraction == 0.0) && knobs.sim_refs == 0)
+    if ((knobs_.warmup_refs == 0 && knobs_.warmup_fraction == 0.0) &&
+        knobs_.sim_refs == 0)
         return true;
 
     // The references after warmup and simulated ones are dropped.
-    if (check_warmed_up() && knobs.sim_refs == 0)
+    if (check_warmed_up() && knobs_.sim_refs == 0)
         return true;
 
     // Both warmup and simulated references are simulated.
@@ -404,7 +409,7 @@ cache_simulator_t::process_memref(const memref_t &memref)
     if (memref.marker.type == TRACE_TYPE_MARKER) {
         // We ignore markers before we ask core_for_thread, to avoid asking
         // too early on a timestamp marker.
-        if (knobs.verbose >= 3) {
+        if (knobs_.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: "
                       << "marker type " << memref.marker.marker_type << " value "
                       << memref.marker.marker_value << "\n";
@@ -416,112 +421,112 @@ cache_simulator_t::process_memref(const memref_t &memref)
     // not practical to measure which core each thread actually
     // ran on for each memref.
     int core;
-    if (memref.data.tid == last_thread)
-        core = last_core;
+    if (memref.data.tid == last_thread_)
+        core = last_core_;
     else {
         core = core_for_thread(memref.data.tid);
-        last_thread = memref.data.tid;
-        last_core = core;
+        last_thread_ = memref.data.tid;
+        last_core_ = core;
     }
 
     if (type_is_instr(memref.instr.type) ||
         memref.instr.type == TRACE_TYPE_PREFETCH_INSTR) {
-        if (knobs.verbose >= 3) {
+        if (knobs_.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: "
                       << " @" << (void *)memref.instr.addr << " instr x"
                       << memref.instr.size << "\n";
         }
-        l1_icaches[core]->request(memref);
+        l1_icaches_[core]->request(memref);
     } else if (memref.data.type == TRACE_TYPE_READ ||
                memref.data.type == TRACE_TYPE_WRITE ||
                // We may potentially handle prefetches differently.
                // TRACE_TYPE_PREFETCH_INSTR is handled above.
                type_is_prefetch(memref.data.type)) {
-        if (knobs.verbose >= 3) {
+        if (knobs_.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: "
                       << " @" << (void *)memref.data.pc << " "
                       << trace_type_names[memref.data.type] << " "
                       << (void *)memref.data.addr << " x" << memref.data.size << "\n";
         }
-        l1_dcaches[core]->request(memref);
+        l1_dcaches_[core]->request(memref);
     } else if (memref.flush.type == TRACE_TYPE_INSTR_FLUSH) {
-        if (knobs.verbose >= 3) {
+        if (knobs_.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: "
                       << " @" << (void *)memref.data.pc << " iflush "
                       << (void *)memref.data.addr << " x" << memref.data.size << "\n";
         }
-        l1_icaches[core]->flush(memref);
+        l1_icaches_[core]->flush(memref);
     } else if (memref.flush.type == TRACE_TYPE_DATA_FLUSH) {
-        if (knobs.verbose >= 3) {
+        if (knobs_.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: "
                       << " @" << (void *)memref.data.pc << " dflush "
                       << (void *)memref.data.addr << " x" << memref.data.size << "\n";
         }
-        l1_dcaches[core]->flush(memref);
+        l1_dcaches_[core]->flush(memref);
     } else if (memref.exit.type == TRACE_TYPE_THREAD_EXIT) {
         handle_thread_exit(memref.exit.tid);
-        last_thread = 0;
+        last_thread_ = 0;
     } else if (memref.marker.type == TRACE_TYPE_INSTR_NO_FETCH) {
         // Just ignore.
-        if (knobs.verbose >= 3) {
+        if (knobs_.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: "
                       << " @" << (void *)memref.instr.addr << " non-fetched instr x"
                       << memref.instr.size << "\n";
         }
     } else {
-        error_string = "Unhandled memref type " + std::to_string(memref.data.type);
+        error_string_ = "Unhandled memref type " + std::to_string(memref.data.type);
         return false;
     }
 
     // reset cache stats when warming up is completed
-    if (!is_warmed_up && check_warmed_up()) {
-        for (auto &cache_it : all_caches) {
+    if (!is_warmed_up_ && check_warmed_up()) {
+        for (auto &cache_it : all_caches_) {
             cache_t *cache = cache_it.second;
             cache->get_stats()->reset();
         }
-        if (knobs.verbose >= 1) {
+        if (knobs_.verbose >= 1) {
             std::cerr << "Cache simulation warmed up\n";
         }
     } else {
-        knobs.sim_refs--;
+        knobs_.sim_refs--;
     }
 
     return true;
 }
 
 // Return true if the number of warmup references have been executed or if
-// specified fraction of the llcaches has been loaded. Also return true if the
+// specified fraction of the llcaches_ has been loaded. Also return true if the
 // cache has already been warmed up. When there are multiple last level caches
 // this function only returns true when all of them have been warmed up.
 bool
 cache_simulator_t::check_warmed_up()
 {
     // If the cache has already been warmed up return true
-    if (is_warmed_up)
+    if (is_warmed_up_)
         return true;
 
     // If the warmup_fraction option is set then check if the last level has
     // loaded enough data to be warmed up.
-    if (knobs.warmup_fraction > 0.0) {
-        is_warmed_up = true;
-        for (auto &cache : llcaches) {
-            if (cache.second->get_loaded_fraction() < knobs.warmup_fraction) {
-                is_warmed_up = false;
+    if (knobs_.warmup_fraction > 0.0) {
+        is_warmed_up_ = true;
+        for (auto &cache : llcaches_) {
+            if (cache.second->get_loaded_fraction() < knobs_.warmup_fraction) {
+                is_warmed_up_ = false;
                 break;
             }
         }
 
-        if (is_warmed_up) {
+        if (is_warmed_up_) {
             return true;
         }
     }
 
     // If warmup_refs is set then decrement and indicate warmup done when
     // counter hits zero.
-    if (knobs.warmup_refs > 0) {
-        knobs.warmup_refs--;
-        if (knobs.warmup_refs == 0) {
-            is_warmed_up = true;
+    if (knobs_.warmup_refs > 0) {
+        knobs_.warmup_refs--;
+        if (knobs_.warmup_refs == 0) {
+            is_warmed_up_ = true;
             return true;
         }
     }
@@ -535,35 +540,35 @@ cache_simulator_t::print_results()
 {
     std::cerr << "Cache simulation results:\n";
     // Print core and associated L1 cache stats first.
-    for (unsigned int i = 0; i < knobs.num_cores; i++) {
+    for (unsigned int i = 0; i < knobs_.num_cores; i++) {
         print_core(i);
-        if (thread_ever_counts[i] > 0) {
-            if (l1_icaches[i] != l1_dcaches[i]) {
+        if (thread_ever_counts_[i] > 0) {
+            if (l1_icaches_[i] != l1_dcaches_[i]) {
                 std::cerr << "  L1I stats:" << std::endl;
-                l1_icaches[i]->get_stats()->print_stats("    ");
+                l1_icaches_[i]->get_stats()->print_stats("    ");
                 std::cerr << "  L1D stats:" << std::endl;
-                l1_dcaches[i]->get_stats()->print_stats("    ");
+                l1_dcaches_[i]->get_stats()->print_stats("    ");
             } else {
                 std::cerr << "  unified L1 stats:" << std::endl;
-                l1_icaches[i]->get_stats()->print_stats("    ");
+                l1_icaches_[i]->get_stats()->print_stats("    ");
             }
         }
     }
 
     // Print non-L1, non-LLC cache stats.
-    for (auto &caches_it : other_caches) {
+    for (auto &caches_it : other_caches_) {
         std::cerr << caches_it.first << " stats:" << std::endl;
         caches_it.second->get_stats()->print_stats("    ");
     }
 
     // Print LLC stats.
-    for (auto &caches_it : llcaches) {
+    for (auto &caches_it : llcaches_) {
         std::cerr << caches_it.first << " stats:" << std::endl;
         caches_it.second->get_stats()->print_stats("    ");
     }
 
-    if (knobs.model_coherence) {
-        snoop_filter->print_stats();
+    if (knobs_.model_coherence) {
+        snoop_filter_->print_stats();
     }
 
     return true;

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -98,7 +98,7 @@ cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs)
                    new cache_stats_t(knobs_.LL_miss_file, warmup_enabled_))) {
         error_string_ =
             "Usage error: failed to initialize LL cache.  Ensure sizes and "
-            "associativity_ are powers of 2, that the total size is a multiple "
+            "associativity are powers of 2, that the total size is a multiple "
             "of the line size, and that any miss file path is writable.";
         success_ = false;
         return;
@@ -140,7 +140,7 @@ cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs)
                 false /*inclusive*/, knobs_.model_coherence, (2 * i) + 1,
                 snoop_filter_)) {
             error_string_ = "Usage error: failed to initialize L1 caches.  Ensure sizes "
-                            "and associativity_ are powers of 2 "
+                            "and associativity are powers of 2 "
                             "and that the total sizes are multiples of the line size.";
             success_ = false;
             return;

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -71,28 +71,28 @@ protected:
     virtual cache_t *
     create_cache(const std::string &policy);
 
-    cache_simulator_knobs_t knobs;
+    cache_simulator_knobs_t knobs_;
 
     // Implement a set of ICaches and DCaches with pointer arrays.
     // This is useful for implementing polymorphism correctly.
-    cache_t **l1_icaches;
-    cache_t **l1_dcaches;
+    cache_t **l1_icaches_;
+    cache_t **l1_dcaches_;
     // This is an array of coherent caches for the snoop filter.
     // Cache IDs index into this array.
-    cache_t **snooped_caches;
+    cache_t **snooped_caches_;
 
     // The following unordered maps map a cache's name to a pointer to it.
-    std::unordered_map<std::string, cache_t *> llcaches;     // LLC(s)
-    std::unordered_map<std::string, cache_t *> other_caches; // Non-L1, non-LLC caches
-    std::unordered_map<std::string, cache_t *> all_caches;   // All caches.
+    std::unordered_map<std::string, cache_t *> llcaches_;     // LLC(s)
+    std::unordered_map<std::string, cache_t *> other_caches_; // Non-L1, non-LLC caches
+    std::unordered_map<std::string, cache_t *> all_caches_;   // All caches.
     // This is a list of non-coherent caches for shared caches above snoop filter.
-    std::unordered_map<std::string, cache_t *> non_coherent_caches;
+    std::unordered_map<std::string, cache_t *> non_coherent_caches_;
 
     // Snoop filter tracks ownership of cache lines across private caches.
-    snoop_filter_t *snoop_filter = nullptr;
+    snoop_filter_t *snoop_filter_ = nullptr;
 
 private:
-    bool is_warmed_up;
+    bool is_warmed_up_;
 };
 
 #endif /* _CACHE_SIMULATOR_H_ */

--- a/clients/drcachesim/simulator/cache_stats.cpp
+++ b/clients/drcachesim/simulator/cache_stats.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -34,12 +34,12 @@
 #include <iomanip>
 #include "cache_stats.h"
 
-cache_stats_t::cache_stats_t(const std::string &miss_file, bool warmup_enabled,
-                             bool is_coherent)
-    : caching_device_stats_t(miss_file, warmup_enabled, is_coherent)
-    , num_flushes(0)
-    , num_prefetch_hits(0)
-    , num_prefetch_misses(0)
+cache_stats_t::cache_stats_t(const std::string &miss_file, bool warmup_enabled_,
+                             bool is_coherent_)
+    : caching_device_stats_t(miss_file, warmup_enabled_, is_coherent_)
+    , num_flushes_(0)
+    , num_prefetch_hits_(0)
+    , num_prefetch_misses_(0)
 {
 }
 
@@ -50,10 +50,10 @@ cache_stats_t::access(const memref_t &memref, bool hit,
     // handle prefetching requests
     if (type_is_prefetch(memref.data.type)) {
         if (hit)
-            num_prefetch_hits++;
+            num_prefetch_hits_++;
         else {
-            num_prefetch_misses++;
-            if (dump_misses && memref.data.type != TRACE_TYPE_HARDWARE_PREFETCH)
+            num_prefetch_misses_++;
+            if (dump_misses_ && memref.data.type != TRACE_TYPE_HARDWARE_PREFETCH)
                 dump_miss(memref);
         }
     } else { // handle regular memory accesses
@@ -64,24 +64,24 @@ cache_stats_t::access(const memref_t &memref, bool hit,
 void
 cache_stats_t::flush(const memref_t &memref)
 {
-    num_flushes++;
+    num_flushes_++;
 }
 
 void
 cache_stats_t::print_counts(std::string prefix)
 {
     caching_device_stats_t::print_counts(prefix);
-    if (num_flushes != 0) {
+    if (num_flushes_ != 0) {
         std::cerr << prefix << std::setw(18) << std::left << "Flushes:" << std::setw(20)
-                  << std::right << num_flushes << std::endl;
+                  << std::right << num_flushes_ << std::endl;
     }
-    if (num_prefetch_hits + num_prefetch_misses != 0) {
+    if (num_prefetch_hits_ + num_prefetch_misses_ != 0) {
         std::cerr << prefix << std::setw(18) << std::left
-                  << "Prefetch hits:" << std::setw(20) << std::right << num_prefetch_hits
+                  << "Prefetch hits:" << std::setw(20) << std::right << num_prefetch_hits_
                   << std::endl;
         std::cerr << prefix << std::setw(18) << std::left
                   << "Prefetch misses:" << std::setw(20) << std::right
-                  << num_prefetch_misses << std::endl;
+                  << num_prefetch_misses_ << std::endl;
     }
 }
 
@@ -89,7 +89,7 @@ void
 cache_stats_t::reset()
 {
     caching_device_stats_t::reset();
-    num_flushes = 0;
-    num_prefetch_hits = 0;
-    num_prefetch_misses = 0;
+    num_flushes_ = 0;
+    num_prefetch_hits_ = 0;
+    num_prefetch_misses_ = 0;
 }

--- a/clients/drcachesim/simulator/cache_stats.h
+++ b/clients/drcachesim/simulator/cache_stats.h
@@ -66,9 +66,9 @@ protected:
 
     // A CPU cache handles flushes and prefetching requests
     // as well as regular memory accesses.
-    int_least64_t num_flushes;
-    int_least64_t num_prefetch_hits;
-    int_least64_t num_prefetch_misses;
+    int_least64_t num_flushes_;
+    int_least64_t num_prefetch_hits_;
+    int_least64_t num_prefetch_misses_;
 };
 
 #endif /* _CACHE_STATS_H_ */

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,28 +39,28 @@
 #include <assert.h>
 
 caching_device_t::caching_device_t()
-    : blocks(NULL)
-    , stats(NULL)
-    , prefetcher(NULL)
+    : blocks_(NULL)
+    , stats_(NULL)
+    , prefetcher_(NULL)
 {
     /* Empty. */
 }
 
 caching_device_t::~caching_device_t()
 {
-    if (blocks == NULL)
+    if (blocks_ == NULL)
         return;
-    for (int i = 0; i < num_blocks; i++)
-        delete blocks[i];
-    delete[] blocks;
+    for (int i = 0; i < num_blocks_; i++)
+        delete blocks_[i];
+    delete[] blocks_;
 }
 
 bool
-caching_device_t::init(int associativity_, int block_size_, int num_blocks_,
-                       caching_device_t *parent_, caching_device_stats_t *stats_,
-                       prefetcher_t *prefetcher_, bool inclusive_, bool coherent_cache_,
-                       int id_, snoop_filter_t *snoop_filter_,
-                       const std::vector<caching_device_t *> &children_)
+caching_device_t::init(int associativity, int block_size, int num_blocks,
+                       caching_device_t *parent, caching_device_stats_t *stats,
+                       prefetcher_t *prefetcher, bool inclusive, bool coherent_cache,
+                       int id, snoop_filter_t *snoop_filter,
+                       const std::vector<caching_device_t *> &children)
 {
     if (!IS_POWER_OF_2(associativity_) || !IS_POWER_OF_2(block_size_) ||
         !IS_POWER_OF_2(num_blocks_) ||
@@ -71,30 +71,30 @@ caching_device_t::init(int associativity_, int block_size_, int num_blocks_,
         return false; // A stats must be provided for perf: avoid conditional code
     else if (!*stats_)
         return false;
-    associativity = associativity_;
-    block_size = block_size_;
-    num_blocks = num_blocks_;
-    loaded_blocks = 0;
-    blocks_per_set = num_blocks / associativity;
-    assoc_bits = compute_log2(associativity);
-    block_size_bits = compute_log2(block_size);
-    blocks_per_set_mask = blocks_per_set - 1;
-    if (assoc_bits == -1 || block_size_bits == -1 || !IS_POWER_OF_2(blocks_per_set))
+    associativity_ = associativity;
+    block_size = block_size;
+    num_blocks_ = num_blocks;
+    loaded_blocks_ = 0;
+    blocks_per_set_ = num_blocks_ / associativity;
+    assoc_bits_ = compute_log2(associativity_);
+    block_size_bits_ = compute_log2(block_size);
+    blocks_per_set_mask_ = blocks_per_set_ - 1;
+    if (assoc_bits_ == -1 || block_size_bits_ == -1 || !IS_POWER_OF_2(blocks_per_set_))
         return false;
-    parent = parent_;
-    stats = stats_;
-    prefetcher = prefetcher_;
-    id = id_;
-    snoop_filter = snoop_filter_;
-    coherent_cache = coherent_cache_;
+    parent_ = parent;
+    stats_ = stats;
+    prefetcher_ = prefetcher;
+    id_ = id;
+    snoop_filter_ = snoop_filter;
+    coherent_cache_ = coherent_cache;
 
-    blocks = new caching_device_block_t *[num_blocks];
+    blocks_ = new caching_device_block_t *[num_blocks_];
     init_blocks();
 
-    last_tag = TAG_INVALID; // sentinel
+    last_tag_ = TAG_INVALID; // sentinel
 
-    inclusive = inclusive_;
-    children = children_;
+    inclusive_ = inclusive;
+    children_ = children;
 
     return true;
 }
@@ -103,7 +103,7 @@ void
 caching_device_t::request(const memref_t &memref_in)
 {
     // Unfortunately we need to make a copy for our loop so we can pass
-    // the right data struct to the parent and stats collectors.
+    // the right data struct to the parent_ and stats collectors.
     memref_t memref;
     // We support larger sizes to improve the IPC perf.
     // This means that one memref could touch multiple blocks.
@@ -113,15 +113,15 @@ caching_device_t::request(const memref_t &memref_in)
     addr_t tag = compute_tag(memref_in.data.addr);
 
     // Optimization: check last tag if single-block
-    if (tag == final_tag && tag == last_tag && memref_in.data.type != TRACE_TYPE_WRITE) {
-        // Make sure last_tag is properly in sync.
+    if (tag == final_tag && tag == last_tag_ && memref_in.data.type != TRACE_TYPE_WRITE) {
+        // Make sure last_tag_ is properly in sync.
         caching_device_block_t *cache_block =
-            &get_caching_device_block(last_block_idx, last_way);
-        assert(tag != TAG_INVALID && tag == cache_block->tag);
-        stats->access(memref_in, true /*hit*/, cache_block);
-        if (parent != NULL)
-            parent->stats->child_access(memref_in, true, cache_block);
-        access_update(last_block_idx, last_way);
+            &get_caching_device_block(last_block_idx_, last_way_);
+        assert(tag != TAG_INVALID && tag == cache_block->tag_);
+        stats_->access(memref_in, true /*hit*/, cache_block);
+        if (parent_ != NULL)
+            parent_->stats_->child_access(memref_in, true, cache_block);
+        access_update(last_block_idx_, last_way_);
         return;
     }
 
@@ -132,31 +132,32 @@ caching_device_t::request(const memref_t &memref_in)
         bool missed = false;
 
         if (tag + 1 <= final_tag)
-            memref.data.size = ((tag + 1) << block_size_bits) - memref.data.addr;
+            memref.data.size = ((tag + 1) << block_size_bits_) - memref.data.addr;
 
-        for (way = 0; way < associativity; ++way) {
+        for (way = 0; way < associativity_; ++way) {
             caching_device_block_t *cache_block =
                 &get_caching_device_block(block_idx, way);
-            if (cache_block->tag == tag) {
+            if (cache_block->tag_ == tag) {
                 break;
             }
         }
 
-        if (way != associativity) {
+        if (way != associativity_) {
             // Access is a hit.
             caching_device_block_t *cache_block =
                 &get_caching_device_block(block_idx, way);
-            stats->access(memref, true /*hit*/, cache_block);
-            if (parent != NULL)
-                parent->stats->child_access(memref, true, cache_block);
-            if (coherent_cache && memref.data.type == TRACE_TYPE_WRITE) {
+            stats_->access(memref, true /*hit*/, cache_block);
+            if (parent_ != NULL)
+                parent_->stats_->child_access(memref, true, cache_block);
+            if (coherent_cache_ && memref.data.type == TRACE_TYPE_WRITE) {
                 // On a hit, we must notify the snoop filter of the write or propagate
                 // the write to a snooped cache.
-                if (snoop_filter != NULL) {
-                    snoop_filter->snoop(tag, id, (memref.data.type == TRACE_TYPE_WRITE));
-                } else if (parent != NULL) {
-                    // On a miss, the parent access will inherently propagate the write.
-                    parent->propagate_write(tag, this);
+                if (snoop_filter_ != NULL) {
+                    snoop_filter_->snoop(tag, id_,
+                                         (memref.data.type == TRACE_TYPE_WRITE));
+                } else if (parent_ != NULL) {
+                    // On a miss, the parent_ access will inherently propagate the write.
+                    parent_->propagate_write(tag, this);
                 }
             }
         } else {
@@ -165,38 +166,38 @@ caching_device_t::request(const memref_t &memref_in)
             caching_device_block_t *cache_block =
                 &get_caching_device_block(block_idx, way);
 
-            stats->access(memref, false /*miss*/, cache_block);
+            stats_->access(memref, false /*miss*/, cache_block);
             missed = true;
-            // If no parent we assume we get the data from main memory
-            if (parent != NULL) {
-                parent->stats->child_access(memref, false, cache_block);
-                parent->request(memref);
+            // If no parent_ we assume we get the data from main memory
+            if (parent_ != NULL) {
+                parent_->stats_->child_access(memref, false, cache_block);
+                parent_->request(memref);
             }
-            if (snoop_filter != NULL) {
+            if (snoop_filter_ != NULL) {
                 // Update snoop filter, other private caches invalidated on write.
-                snoop_filter->snoop(tag, id, (memref.data.type == TRACE_TYPE_WRITE));
+                snoop_filter_->snoop(tag, id_, (memref.data.type == TRACE_TYPE_WRITE));
             }
 
-            addr_t victim_tag = cache_block->tag;
+            addr_t victim_tag = cache_block->tag_;
             // Check if we are inserting a new block, if we are then increment
             // the block loaded count.
             if (victim_tag == TAG_INVALID) {
-                loaded_blocks++;
+                loaded_blocks_++;
             } else {
-                if (!children.empty() && inclusive) {
-                    for (auto &child : children) {
+                if (!children_.empty() && inclusive_) {
+                    for (auto &child : children_) {
                         child->invalidate(victim_tag, INVALIDATION_INCLUSIVE);
                     }
                 }
-                if (coherent_cache) {
+                if (coherent_cache_) {
                     bool child_holds_tag = false;
-                    if (!children.empty()) {
+                    if (!children_.empty()) {
                         /* We must check child caches to find out if the snoop filter
                          * should clear the ownership bit for this evicted tag.
                          * If any of this cache's children contain the evicted tag the
                          * snoop filter should still consider this cache an owner.
                          */
-                        for (auto &child : children) {
+                        for (auto &child : children_) {
                             if (child->contains_tag(victim_tag)) {
                                 child_holds_tag = true;
                                 break;
@@ -204,36 +205,36 @@ caching_device_t::request(const memref_t &memref_in)
                         }
                     }
                     if (!child_holds_tag) {
-                        if (snoop_filter != NULL) {
+                        if (snoop_filter_ != NULL) {
                             // Inform snoop filter of evicted line.
-                            snoop_filter->snoop_eviction(victim_tag, id);
-                        } else if (parent != NULL) {
-                            // Inform parent of evicted line.
-                            parent->propagate_eviction(victim_tag, this);
+                            snoop_filter_->snoop_eviction(victim_tag, id_);
+                        } else if (parent_ != NULL) {
+                            // Inform parent_ of evicted line.
+                            parent_->propagate_eviction(victim_tag, this);
                         }
                     }
                 }
             }
-            cache_block->tag = tag;
+            cache_block->tag_ = tag;
         }
 
         access_update(block_idx, way);
 
         // Issue a hardware prefetch, if any, before we remember the last tag,
         // so we remember this line and not the prefetched line.
-        if (missed && !type_is_prefetch(memref.data.type) && prefetcher != nullptr)
-            prefetcher->prefetch(this, memref);
+        if (missed && !type_is_prefetch(memref.data.type) && prefetcher_ != nullptr)
+            prefetcher_->prefetch(this, memref);
 
         if (tag + 1 <= final_tag) {
-            addr_t next_addr = (tag + 1) << block_size_bits;
+            addr_t next_addr = (tag + 1) << block_size_bits_;
             memref.data.addr = next_addr;
             memref.data.size = final_addr - next_addr + 1 /*undo the -1*/;
         }
 
         // Optimization: remember last tag
-        last_tag = tag;
-        last_way = way;
-        last_block_idx = block_idx;
+        last_tag_ = tag;
+        last_way_ = way;
+        last_block_idx_ = block_idx;
     }
 }
 
@@ -241,7 +242,7 @@ void
 caching_device_t::access_update(int block_idx, int way)
 {
     // We just inc the counter for LFU.  We live with any blip on overflow.
-    get_caching_device_block(block_idx, way).counter++;
+    get_caching_device_block(block_idx, way).counter_++;
 }
 
 int
@@ -252,18 +253,18 @@ caching_device_t::replace_which_way(int block_idx)
     // some other scheme.
     int min_counter = 0; /* avoid "may be used uninitialized" with GCC 4.4.7 */
     int min_way = 0;
-    for (int way = 0; way < associativity; ++way) {
-        if (get_caching_device_block(block_idx, way).tag == TAG_INVALID) {
+    for (int way = 0; way < associativity_; ++way) {
+        if (get_caching_device_block(block_idx, way).tag_ == TAG_INVALID) {
             min_way = way;
             break;
         }
-        if (way == 0 || get_caching_device_block(block_idx, way).counter < min_counter) {
-            min_counter = get_caching_device_block(block_idx, way).counter;
+        if (way == 0 || get_caching_device_block(block_idx, way).counter_ < min_counter) {
+            min_counter = get_caching_device_block(block_idx, way).counter_;
             min_way = way;
         }
     }
     // Clear the counter for LFU.
-    get_caching_device_block(block_idx, min_way).counter = 0;
+    get_caching_device_block(block_idx, min_way).counter_ = 0;
     return min_way;
 }
 
@@ -272,20 +273,20 @@ caching_device_t::invalidate(addr_t tag, invalidation_type_t invalidation_type_)
 {
     int block_idx = compute_block_idx(tag);
 
-    for (int way = 0; way < associativity; ++way) {
+    for (int way = 0; way < associativity_; ++way) {
         auto &cache_block = get_caching_device_block(block_idx, way);
-        if (cache_block.tag == tag) {
-            cache_block.tag = TAG_INVALID;
-            cache_block.counter = 0;
-            stats->invalidate(invalidation_type_);
-            // Invalidate last_tag if it was this tag.
-            if (last_tag == tag) {
-                last_tag = TAG_INVALID;
+        if (cache_block.tag_ == tag) {
+            cache_block.tag_ = TAG_INVALID;
+            cache_block.counter_ = 0;
+            stats_->invalidate(invalidation_type_);
+            // Invalidate last_tag_ if it was this tag.
+            if (last_tag_ == tag) {
+                last_tag_ = TAG_INVALID;
             }
             // Invalidate the block in the children's caches.
-            if (invalidation_type_ == INVALIDATION_INCLUSIVE && inclusive &&
-                !children.empty()) {
-                for (auto &child : children) {
+            if (invalidation_type_ == INVALIDATION_INCLUSIVE && inclusive_ &&
+                !children_.empty()) {
+                for (auto &child : children_) {
                     child->invalidate(tag, invalidation_type_);
                 }
             }
@@ -293,8 +294,8 @@ caching_device_t::invalidate(addr_t tag, invalidation_type_t invalidation_type_)
         }
     }
     // If this is a coherence invalidation, we must invalidate children caches.
-    if (invalidation_type_ == INVALIDATION_COHERENCE && !children.empty()) {
-        for (auto &child : children) {
+    if (invalidation_type_ == INVALIDATION_COHERENCE && !children_.empty()) {
+        for (auto &child : children_) {
             child->invalidate(tag, invalidation_type_);
         }
     }
@@ -305,15 +306,15 @@ bool
 caching_device_t::contains_tag(addr_t tag)
 {
     int block_idx = compute_block_idx(tag);
-    for (int way = 0; way < associativity; way++) {
-        if (get_caching_device_block(block_idx, way).tag == tag) {
+    for (int way = 0; way < associativity_; way++) {
+        if (get_caching_device_block(block_idx, way).tag_ == tag) {
             return true;
         }
     }
-    if (children.empty()) {
+    if (children_.empty()) {
         return false;
     }
-    for (auto &child : children) {
+    for (auto &child : children_) {
         if (child->contains_tag(tag)) {
             return true;
         }
@@ -328,16 +329,16 @@ caching_device_t::propagate_eviction(addr_t tag, const caching_device_t *request
 {
     // Check our own cache for this line.
     int block_idx = compute_block_idx(tag);
-    for (int way = 0; way < associativity; way++) {
-        if (get_caching_device_block(block_idx, way).tag == tag) {
+    for (int way = 0; way < associativity_; way++) {
+        if (get_caching_device_block(block_idx, way).tag_ == tag) {
             return;
         }
     }
 
     // Check if other children contain this line.
-    if (children.size() != 1) {
+    if (children_.size() != 1) {
         // If another child contains the line, we don't need to do anything.
-        for (auto &child : children) {
+        for (auto &child : children_) {
             if (child != requester && child->contains_tag(tag)) {
                 return;
             }
@@ -346,10 +347,10 @@ caching_device_t::propagate_eviction(addr_t tag, const caching_device_t *request
 
     // Neither this cache nor its children hold line,
     // inform snoop filter or propagate eviction.
-    if (snoop_filter != NULL) {
-        snoop_filter->snoop_eviction(tag, id);
-    } else if (parent != NULL) {
-        parent->propagate_eviction(tag, this);
+    if (snoop_filter_ != NULL) {
+        snoop_filter_->snoop_eviction(tag, id_);
+    } else if (parent_ != NULL) {
+        parent_->propagate_eviction(tag, this);
     }
 }
 
@@ -361,16 +362,16 @@ void
 caching_device_t::propagate_write(addr_t tag, const caching_device_t *requester)
 {
     // Invalidate other children.
-    for (auto &child : children) {
+    for (auto &child : children_) {
         if (child != requester) {
             child->invalidate(tag, INVALIDATION_COHERENCE);
         }
     }
 
-    // Propagate write to snoop filter or to parent.
-    if (snoop_filter != NULL) {
-        snoop_filter->snoop(tag, id, true);
-    } else if (parent != NULL) {
-        parent->propagate_write(tag, this);
+    // Propagate write to snoop filter or to parent_.
+    if (snoop_filter_ != NULL) {
+        snoop_filter_->snoop(tag, id_, true);
+    } else if (parent_ != NULL) {
+        parent_->propagate_write(tag, this);
     }
 }

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -62,17 +62,17 @@ caching_device_t::init(int associativity, int block_size, int num_blocks,
                        int id, snoop_filter_t *snoop_filter,
                        const std::vector<caching_device_t *> &children)
 {
-    if (!IS_POWER_OF_2(associativity_) || !IS_POWER_OF_2(block_size_) ||
-        !IS_POWER_OF_2(num_blocks_) ||
+    if (!IS_POWER_OF_2(associativity) || !IS_POWER_OF_2(block_size) ||
+        !IS_POWER_OF_2(num_blocks) ||
         // Assuming caching device block size is at least 4 bytes
-        block_size_ < 4)
+        block_size < 4)
         return false;
-    if (stats_ == NULL)
+    if (stats == NULL)
         return false; // A stats must be provided for perf: avoid conditional code
-    else if (!*stats_)
+    else if (!*stats)
         return false;
     associativity_ = associativity;
-    block_size = block_size;
+    block_size_ = block_size;
     num_blocks_ = num_blocks;
     loaded_blocks_ = 0;
     blocks_per_set_ = num_blocks_ / associativity;
@@ -103,7 +103,7 @@ void
 caching_device_t::request(const memref_t &memref_in)
 {
     // Unfortunately we need to make a copy for our loop so we can pass
-    // the right data struct to the parent_ and stats collectors.
+    // the right data struct to the parent and stats collectors.
     memref_t memref;
     // We support larger sizes to improve the IPC perf.
     // This means that one memref could touch multiple blocks.
@@ -156,7 +156,7 @@ caching_device_t::request(const memref_t &memref_in)
                     snoop_filter_->snoop(tag, id_,
                                          (memref.data.type == TRACE_TYPE_WRITE));
                 } else if (parent_ != NULL) {
-                    // On a miss, the parent_ access will inherently propagate the write.
+                    // On a miss, the parent access will inherently propagate the write.
                     parent_->propagate_write(tag, this);
                 }
             }
@@ -168,7 +168,7 @@ caching_device_t::request(const memref_t &memref_in)
 
             stats_->access(memref, false /*miss*/, cache_block);
             missed = true;
-            // If no parent_ we assume we get the data from main memory
+            // If no parent we assume we get the data from main memory
             if (parent_ != NULL) {
                 parent_->stats_->child_access(memref, false, cache_block);
                 parent_->request(memref);
@@ -209,7 +209,7 @@ caching_device_t::request(const memref_t &memref_in)
                             // Inform snoop filter of evicted line.
                             snoop_filter_->snoop_eviction(victim_tag, id_);
                         } else if (parent_ != NULL) {
-                            // Inform parent_ of evicted line.
+                            // Inform parent of evicted line.
                             parent_->propagate_eviction(victim_tag, this);
                         }
                     }

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -77,27 +77,27 @@ public:
     caching_device_stats_t *
     get_stats() const
     {
-        return stats;
+        return stats_;
     }
     void
-    set_stats(caching_device_stats_t *stats_)
+    set_stats(caching_device_stats_t *stats)
     {
-        stats = stats_;
+        stats_ = stats;
     }
     prefetcher_t *
     get_prefetcher() const
     {
-        return prefetcher;
+        return prefetcher_;
     }
     caching_device_t *
     get_parent() const
     {
-        return parent;
+        return parent_;
     }
     inline double
     get_loaded_fraction() const
     {
-        return double(loaded_blocks) / num_blocks;
+        return double(loaded_blocks_) / num_blocks_;
     }
 
 protected:
@@ -109,58 +109,58 @@ protected:
     inline addr_t
     compute_tag(addr_t addr)
     {
-        return addr >> block_size_bits;
+        return addr >> block_size_bits_;
     }
     inline int
     compute_block_idx(addr_t tag)
     {
-        return (tag & blocks_per_set_mask) << assoc_bits;
+        return (tag & blocks_per_set_mask_) << assoc_bits_;
     }
     inline caching_device_block_t &
     get_caching_device_block(int block_idx, int way)
     {
-        return *(blocks[block_idx + way]);
+        return *(blocks_[block_idx + way]);
     }
     // a pure virtual function for subclasses to initialize their own block array
     virtual void
     init_blocks() = 0;
 
-    int associativity;
-    int block_size;
-    int num_blocks;
-    bool coherent_cache;
+    int associativity_;
+    int block_size_;
+    int num_blocks_;
+    bool coherent_cache_;
     // This is an index into snoop filter's array of caches.
-    int id;
+    int id_;
 
     // Current valid blocks in the cache
-    int loaded_blocks;
+    int loaded_blocks_;
 
     // Pointers to the caching device's parent and children devices.
-    caching_device_t *parent;
-    std::vector<caching_device_t *> children;
+    caching_device_t *parent_;
+    std::vector<caching_device_t *> children_;
 
-    snoop_filter_t *snoop_filter;
+    snoop_filter_t *snoop_filter_;
 
     // If true, this device is inclusive of its children.
-    bool inclusive;
+    bool inclusive_;
 
     // This should be an array of caching_device_block_t pointers, otherwise
     // an extended block class which has its own member variables cannot be indexed
     // correctly by base class pointers.
-    caching_device_block_t **blocks;
-    int blocks_per_set;
+    caching_device_block_t **blocks_;
+    int blocks_per_set_;
     // Optimization fields for fast bit operations
-    int blocks_per_set_mask;
-    int assoc_bits;
-    int block_size_bits;
+    int blocks_per_set_mask_;
+    int assoc_bits_;
+    int block_size_bits_;
 
-    caching_device_stats_t *stats;
-    prefetcher_t *prefetcher;
+    caching_device_stats_t *stats_;
+    prefetcher_t *prefetcher_;
 
     // Optimization: remember last tag
-    addr_t last_tag;
-    int last_way;
-    int last_block_idx;
+    addr_t last_tag_;
+    int last_way_;
+    int last_block_idx_;
 };
 
 #endif /* _CACHING_DEVICE_H_ */

--- a/clients/drcachesim/simulator/caching_device_block.h
+++ b/clients/drcachesim/simulator/caching_device_block.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -52,8 +52,8 @@ public:
     // we expect any use of counter to only occur *after* a valid tag is put in place,
     // where for the current replacement code we also set the counter at that time.
     caching_device_block_t()
-        : tag(TAG_INVALID)
-        , counter(0)
+        : tag_(TAG_INVALID)
+        , counter_(0)
     {
     }
     // Destructor must be virtual and default is not.
@@ -61,12 +61,12 @@ public:
     {
     }
 
-    addr_t tag;
+    addr_t tag_;
 
     // XXX: using int_least64_t here results in a ~4% slowdown for 32-bit apps.
     // A 32-bit counter should be sufficient but we may want to revisit.
     // We already have stdint.h so we can reinstate int_least64_t easily.
-    int counter; // for use by replacement policies
+    int counter_; // for use by replacement policies
 };
 
 #endif /* _CACHING_DEVICE_BLOCK_H_ */

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,42 +37,42 @@
 
 caching_device_stats_t::caching_device_stats_t(const std::string &miss_file,
                                                bool warmup_enabled, bool is_coherent)
-    : success(true)
-    , num_hits(0)
-    , num_misses(0)
-    , num_child_hits(0)
-    , num_inclusive_invalidates(0)
-    , num_coherence_invalidates(0)
-    , num_hits_at_reset(0)
-    , num_misses_at_reset(0)
-    , num_child_hits_at_reset(0)
-    , warmup_enabled(warmup_enabled)
-    , is_coherent(is_coherent)
-    , file(nullptr)
+    : success_(true)
+    , num_hits_(0)
+    , num_misses_(0)
+    , num_child_hits_(0)
+    , num_inclusive_invalidates_(0)
+    , num_coherence_invalidates_(0)
+    , num_hits_at_reset_(0)
+    , num_misses_at_reset_(0)
+    , num_child_hits_at_reset_(0)
+    , warmup_enabled_(warmup_enabled)
+    , is_coherent_(is_coherent)
+    , file_(nullptr)
 {
     if (miss_file.empty()) {
-        dump_misses = false;
+        dump_misses_ = false;
     } else {
 #ifdef HAS_ZLIB
-        file = gzopen(miss_file.c_str(), "w");
+        file_ = gzopen(miss_file.c_str(), "w");
 #else
-        file = fopen(miss_file.c_str(), "w");
+        file_ = fopen(miss_file.c_str(), "w");
 #endif
-        if (file == nullptr) {
-            dump_misses = false;
-            success = false;
+        if (file_ == nullptr) {
+            dump_misses_ = false;
+            success_ = false;
         } else
-            dump_misses = true;
+            dump_misses_ = true;
     }
 }
 
 caching_device_stats_t::~caching_device_stats_t()
 {
-    if (file != nullptr) {
+    if (file_ != nullptr) {
 #ifdef HAS_ZLIB
-        gzclose(file);
+        gzclose(file_);
 #else
-        fclose(file);
+        fclose(file_);
 #endif
     }
 }
@@ -84,10 +84,10 @@ caching_device_stats_t::access(const memref_t &memref, bool hit,
     // We assume we're single-threaded.
     // We're only computing miss rate so we just inc counters here.
     if (hit)
-        num_hits++;
+        num_hits_++;
     else {
-        num_misses++;
-        if (dump_misses)
+        num_misses_++;
+        if (dump_misses_)
             dump_miss(memref);
     }
 }
@@ -97,7 +97,7 @@ caching_device_stats_t::child_access(const memref_t &memref, bool hit,
                                      caching_device_block_t *cache_block)
 {
     if (hit)
-        num_child_hits++;
+        num_child_hits_++;
     // else being computed in access()
 }
 
@@ -115,9 +115,9 @@ caching_device_stats_t::dump_miss(const memref_t &memref)
     }
     addr = memref.data.addr;
 #ifdef HAS_ZLIB
-    gzprintf(file, "0x%zx,0x%zx\n", pc, addr);
+    gzprintf(file_, "0x%zx,0x%zx\n", pc, addr);
 #else
-    fprintf(file, "0x%zx,0x%zx\n", pc, addr);
+    fprintf(file_, "0x%zx,0x%zx\n", pc, addr);
 #endif
 }
 
@@ -125,42 +125,42 @@ void
 caching_device_stats_t::print_warmup(std::string prefix)
 {
     std::cerr << prefix << std::setw(18) << std::left << "Warmup hits:" << std::setw(20)
-              << std::right << num_hits_at_reset << std::endl;
+              << std::right << num_hits_at_reset_ << std::endl;
     std::cerr << prefix << std::setw(18) << std::left << "Warmup misses:" << std::setw(20)
-              << std::right << num_misses_at_reset << std::endl;
+              << std::right << num_misses_at_reset_ << std::endl;
 }
 
 void
 caching_device_stats_t::print_counts(std::string prefix)
 {
     std::cerr << prefix << std::setw(18) << std::left << "Hits:" << std::setw(20)
-              << std::right << num_hits << std::endl;
+              << std::right << num_hits_ << std::endl;
     std::cerr << prefix << std::setw(18) << std::left << "Misses:" << std::setw(20)
-              << std::right << num_misses << std::endl;
-    if (is_coherent) {
+              << std::right << num_misses_ << std::endl;
+    if (is_coherent_) {
         std::cerr << prefix << std::setw(21) << std::left
                   << "Parent invalidations:" << std::setw(17) << std::right
-                  << num_inclusive_invalidates << std::endl;
+                  << num_inclusive_invalidates_ << std::endl;
         std::cerr << prefix << std::setw(20) << std::left
                   << "Write invalidations:" << std::setw(18) << std::right
-                  << num_coherence_invalidates << std::endl;
+                  << num_coherence_invalidates_ << std::endl;
     } else {
         std::cerr << prefix << std::setw(18) << std::left
                   << "Invalidations:" << std::setw(20) << std::right
-                  << num_inclusive_invalidates << std::endl;
+                  << num_inclusive_invalidates_ << std::endl;
     }
 }
 
 void
 caching_device_stats_t::print_rates(std::string prefix)
 {
-    if (num_hits + num_misses > 0) {
+    if (num_hits_ + num_misses_ > 0) {
         std::string miss_label = "Miss rate:";
-        if (num_child_hits != 0)
+        if (num_child_hits_ != 0)
             miss_label = "Local miss rate:";
         std::cerr << prefix << std::setw(18) << std::left << miss_label << std::setw(20)
                   << std::fixed << std::setprecision(2) << std::right
-                  << ((float)num_misses * 100 / (num_hits + num_misses)) << "%"
+                  << ((float)num_misses_ * 100 / (num_hits_ + num_misses_)) << "%"
                   << std::endl;
     }
 }
@@ -168,14 +168,15 @@ caching_device_stats_t::print_rates(std::string prefix)
 void
 caching_device_stats_t::print_child_stats(std::string prefix)
 {
-    if (num_child_hits != 0) {
+    if (num_child_hits_ != 0) {
         std::cerr << prefix << std::setw(18) << std::left
-                  << "Child hits:" << std::setw(20) << std::right << num_child_hits
+                  << "Child hits:" << std::setw(20) << std::right << num_child_hits_
                   << std::endl;
         std::cerr << prefix << std::setw(18) << std::left
                   << "Total miss rate:" << std::setw(20) << std::fixed
                   << std::setprecision(2) << std::right
-                  << ((float)num_misses * 100 / (num_hits + num_child_hits + num_misses))
+                  << ((float)num_misses_ * 100 /
+                      (num_hits_ + num_child_hits_ + num_misses_))
                   << "%" << std::endl;
     }
 }
@@ -184,7 +185,7 @@ void
 caching_device_stats_t::print_stats(std::string prefix)
 {
     std::cerr.imbue(std::locale("")); // Add commas, at least for my locale
-    if (warmup_enabled) {
+    if (warmup_enabled_) {
         print_warmup(prefix);
     }
     print_counts(prefix);
@@ -196,22 +197,22 @@ caching_device_stats_t::print_stats(std::string prefix)
 void
 caching_device_stats_t::reset()
 {
-    num_hits_at_reset = num_hits;
-    num_misses_at_reset = num_misses;
-    num_child_hits_at_reset = num_child_hits;
-    num_hits = 0;
-    num_misses = 0;
-    num_child_hits = 0;
-    num_inclusive_invalidates = 0;
-    num_coherence_invalidates = 0;
+    num_hits_at_reset_ = num_hits_;
+    num_misses_at_reset_ = num_misses_;
+    num_child_hits_at_reset_ = num_child_hits_;
+    num_hits_ = 0;
+    num_misses_ = 0;
+    num_child_hits_ = 0;
+    num_inclusive_invalidates_ = 0;
+    num_coherence_invalidates_ = 0;
 }
 
 void
-caching_device_stats_t::invalidate(invalidation_type_t invalidation_type_)
+caching_device_stats_t::invalidate(invalidation_type_t invalidation_type)
 {
-    if (invalidation_type_ == INVALIDATION_INCLUSIVE) {
-        num_inclusive_invalidates++;
-    } else if (invalidation_type_ == INVALIDATION_COHERENCE) {
-        num_coherence_invalidates++;
+    if (invalidation_type == INVALIDATION_INCLUSIVE) {
+        num_inclusive_invalidates_++;
+    } else if (invalidation_type == INVALIDATION_COHERENCE) {
+        num_coherence_invalidates_++;
     }
 }

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -74,15 +74,15 @@ public:
 
     virtual bool operator!()
     {
-        return !success;
+        return !success_;
     }
 
     // Process invalidations due to cache inclusions or external writes.
     virtual void
-    invalidate(invalidation_type_t invalidation_type_);
+    invalidate(invalidation_type_t invalidation_type);
 
 protected:
-    bool success;
+    bool success_;
 
     // print different groups of information, beneficial for code reuse
     virtual void
@@ -97,30 +97,30 @@ protected:
     virtual void
     dump_miss(const memref_t &memref);
 
-    int_least64_t num_hits;
-    int_least64_t num_misses;
-    int_least64_t num_child_hits;
+    int_least64_t num_hits_;
+    int_least64_t num_misses_;
+    int_least64_t num_child_hits_;
 
-    int_least64_t num_inclusive_invalidates;
-    int_least64_t num_coherence_invalidates;
+    int_least64_t num_inclusive_invalidates_;
+    int_least64_t num_coherence_invalidates_;
 
     // Stats saved when the last reset was called. This helps us get insight
     // into what the stats were when the cache was warmed up.
-    int_least64_t num_hits_at_reset;
-    int_least64_t num_misses_at_reset;
-    int_least64_t num_child_hits_at_reset;
+    int_least64_t num_hits_at_reset_;
+    int_least64_t num_misses_at_reset_;
+    int_least64_t num_child_hits_at_reset_;
     // Enabled if options warmup_refs > 0 || warmup_fraction > 0
-    bool warmup_enabled;
+    bool warmup_enabled_;
 
     // Print out write invalidations if cache is coherent.
-    bool is_coherent;
+    bool is_coherent_;
 
     // We provide a feature of dumping misses to a file.
-    bool dump_misses;
+    bool dump_misses_;
 #ifdef HAS_ZLIB
-    gzFile file;
+    gzFile file_;
 #else
-    FILE *file;
+    FILE *file_;
 #endif
 };
 

--- a/clients/drcachesim/simulator/prefetcher.cpp
+++ b/clients/drcachesim/simulator/prefetcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,7 +37,7 @@
 #include "../common/memref.h"
 
 prefetcher_t::prefetcher_t(int block_size)
-    : block_size(block_size)
+    : block_size_(block_size)
 {
     // Nothing else to do.
 }
@@ -47,7 +47,7 @@ prefetcher_t::prefetch(caching_device_t *cache, const memref_t &memref_in)
 {
     // We implement a simple next-line prefetcher.
     memref_t memref = memref_in;
-    memref.data.addr += block_size;
+    memref.data.addr += block_size_;
     memref.data.type = TRACE_TYPE_HARDWARE_PREFETCH;
     cache->request(memref);
 }

--- a/clients/drcachesim/simulator/prefetcher.h
+++ b/clients/drcachesim/simulator/prefetcher.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -51,7 +51,7 @@ public:
     prefetch(caching_device_t *cache, const memref_t &memref);
 
 private:
-    int block_size;
+    int block_size_;
 };
 
 #endif /* _PREFETCHER_H_ */

--- a/clients/drcachesim/simulator/simulator.cpp
+++ b/clients/drcachesim/simulator/simulator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -57,22 +57,22 @@ simulator_t::init_knobs(unsigned int num_cores, uint64_t skip_refs, uint64_t war
                         double warmup_fraction, uint64_t sim_refs, bool cpu_scheduling,
                         unsigned int verbose)
 {
-    knob_num_cores = num_cores;
-    knob_skip_refs = skip_refs;
-    knob_warmup_refs = warmup_refs;
-    knob_warmup_fraction = warmup_fraction;
-    knob_sim_refs = sim_refs;
-    knob_cpu_scheduling = cpu_scheduling;
-    knob_verbose = verbose;
-    last_thread = 0;
-    last_core = 0;
-    cpu_counts.resize(knob_num_cores, 0);
-    thread_counts.resize(knob_num_cores, 0);
-    thread_ever_counts.resize(knob_num_cores, 0);
+    knob_num_cores_ = num_cores;
+    knob_skip_refs_ = skip_refs;
+    knob_warmup_refs_ = warmup_refs;
+    knob_warmup_fraction_ = warmup_fraction;
+    knob_sim_refs_ = sim_refs;
+    knob_cpu_scheduling_ = cpu_scheduling;
+    knob_verbose_ = verbose;
+    last_thread_ = 0;
+    last_core_ = 0;
+    cpu_counts_.resize(knob_num_cores_, 0);
+    thread_counts_.resize(knob_num_cores_, 0);
+    thread_ever_counts_.resize(knob_num_cores_, 0);
 
-    if (knob_warmup_refs > 0 && (knob_warmup_fraction > 0.0)) {
+    if (knob_warmup_refs_ > 0 && (knob_warmup_fraction_ > 0.0)) {
         ERRMSG("Usage error: Either warmup_refs OR warmup_fraction can be set");
-        success = false;
+        success_ = false;
         return;
     }
 }
@@ -81,28 +81,28 @@ bool
 simulator_t::process_memref(const memref_t &memref)
 {
     if (memref.marker.type == TRACE_TYPE_MARKER &&
-        memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID && knob_cpu_scheduling) {
+        memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID && knob_cpu_scheduling_) {
         int cpu = (int)(intptr_t)memref.marker.marker_value;
         if (cpu < 0)
             return true;
         int min_core;
-        auto exists = cpu2core.find(cpu);
-        if (exists == cpu2core.end()) {
-            min_core = find_emptiest_core(cpu_counts);
-            ++cpu_counts[min_core];
-            cpu2core[cpu] = min_core;
-            if (knob_verbose >= 1) {
+        auto exists = cpu2core_.find(cpu);
+        if (exists == cpu2core_.end()) {
+            min_core = find_emptiest_core(cpu_counts_);
+            ++cpu_counts_[min_core];
+            cpu2core_[cpu] = min_core;
+            if (knob_verbose_ >= 1) {
                 std::cerr << "new cpu " << cpu << " => core " << min_core
-                          << " (count=" << cpu_counts[min_core] << ")" << std::endl;
+                          << " (count=" << cpu_counts_[min_core] << ")" << std::endl;
             }
         } else
             min_core = exists->second;
-        auto prior = thread2core.find(memref.marker.tid);
-        if (prior != thread2core.end())
-            --thread_counts[prior->second];
-        thread2core[memref.marker.tid] = min_core;
-        ++thread_counts[min_core];
-        ++thread_ever_counts[min_core];
+        auto prior = thread2core_.find(memref.marker.tid);
+        if (prior != thread2core_.end())
+            --thread_counts_[prior->second];
+        thread2core_[memref.marker.tid] = min_core;
+        ++thread_counts_[min_core];
+        ++thread_ever_counts_[min_core];
     }
     return true;
 }
@@ -116,7 +116,7 @@ simulator_t::find_emptiest_core(std::vector<int> &counts) const
     // versus maintaining some kind of sorted data structure.
     int min_count = INT_MAX;
     int min_core = 0;
-    for (unsigned int i = 0; i < knob_num_cores; i++) {
+    for (unsigned int i = 0; i < knob_num_cores_; i++) {
         if (counts[i] < min_count) {
             min_count = counts[i];
             min_core = i;
@@ -128,57 +128,57 @@ simulator_t::find_emptiest_core(std::vector<int> &counts) const
 int
 simulator_t::core_for_thread(memref_tid_t tid)
 {
-    auto exists = thread2core.find(tid);
-    if (exists != thread2core.end())
+    auto exists = thread2core_.find(tid);
+    if (exists != thread2core_.end())
         return exists->second;
-    // Either knob_cpu_scheduling is off and we're ignoring cpu
+    // Either knob_cpu_scheduling_is off and we're ignoring cpu
     // markers, or there has not yet been a cpu marker for this
     // thread.  We fall back to scheduling threads directly to cores.
-    int min_core = find_emptiest_core(thread_counts);
-    if (!knob_cpu_scheduling && knob_verbose >= 1) {
+    int min_core = find_emptiest_core(thread_counts_);
+    if (!knob_cpu_scheduling_ && knob_verbose_ >= 1) {
         std::cerr << "new thread " << tid << " => core " << min_core
-                  << " (count=" << thread_counts[min_core] << ")" << std::endl;
-    } else if (knob_cpu_scheduling && knob_verbose >= 1) {
+                  << " (count=" << thread_counts_[min_core] << ")" << std::endl;
+    } else if (knob_cpu_scheduling_ && knob_verbose_ >= 1) {
         std::cerr << "missing cpu marker, so placing thread " << tid << " => core "
-                  << min_core << " (count=" << thread_counts[min_core] << ")"
+                  << min_core << " (count=" << thread_counts_[min_core] << ")"
                   << std::endl;
     }
-    ++thread_counts[min_core];
-    ++thread_ever_counts[min_core];
-    thread2core[tid] = min_core;
+    ++thread_counts_[min_core];
+    ++thread_ever_counts_[min_core];
+    thread2core_[tid] = min_core;
     return min_core;
 }
 
 void
 simulator_t::handle_thread_exit(memref_tid_t tid)
 {
-    std::unordered_map<memref_tid_t, int>::iterator exists = thread2core.find(tid);
-    assert(exists != thread2core.end());
-    assert(thread_counts[exists->second] > 0);
-    --thread_counts[exists->second];
-    if (knob_verbose >= 1) {
+    std::unordered_map<memref_tid_t, int>::iterator exists = thread2core_.find(tid);
+    assert(exists != thread2core_.end());
+    assert(thread_counts_[exists->second] > 0);
+    --thread_counts_[exists->second];
+    if (knob_verbose_ >= 1) {
         std::cerr << "thread " << tid << " exited from core " << exists->second
-                  << " (count=" << thread_counts[exists->second] << ")" << std::endl;
+                  << " (count=" << thread_counts_[exists->second] << ")" << std::endl;
     }
-    thread2core.erase(tid);
+    thread2core_.erase(tid);
 }
 
 void
 simulator_t::print_core(int core) const
 {
-    if (!knob_cpu_scheduling) {
-        std::cerr << "Core #" << core << " (" << thread_ever_counts[core] << " thread(s))"
-                  << std::endl;
+    if (!knob_cpu_scheduling_) {
+        std::cerr << "Core #" << core << " (" << thread_ever_counts_[core]
+                  << " thread(s))" << std::endl;
     } else {
         std::cerr << "Core #" << core;
-        if (cpu_counts[core] == 0) {
+        if (cpu_counts_[core] == 0) {
             // We keep the "(s)" mainly to simplify test templates.
             std::cerr << " (0 traced CPU(s))" << std::endl;
             return;
         }
-        std::cerr << " (" << cpu_counts[core] << " traced CPU(s): ";
+        std::cerr << " (" << cpu_counts_[core] << " traced CPU(s): ";
         bool need_comma = false;
-        for (auto iter = cpu2core.begin(); iter != cpu2core.end(); ++iter) {
+        for (auto iter = cpu2core_.begin(); iter != cpu2core_.end(); ++iter) {
             if (iter->second == core) {
                 if (need_comma)
                     std::cerr << ", ";

--- a/clients/drcachesim/simulator/simulator.h
+++ b/clients/drcachesim/simulator/simulator.h
@@ -71,23 +71,23 @@ protected:
     virtual void
     handle_thread_exit(memref_tid_t tid);
 
-    unsigned int knob_num_cores;
-    uint64_t knob_skip_refs;
-    uint64_t knob_warmup_refs;
-    double knob_warmup_fraction;
-    uint64_t knob_sim_refs;
-    bool knob_cpu_scheduling;
-    unsigned int knob_verbose;
+    unsigned int knob_num_cores_;
+    uint64_t knob_skip_refs_;
+    uint64_t knob_warmup_refs_;
+    double knob_warmup_fraction_;
+    uint64_t knob_sim_refs_;
+    bool knob_cpu_scheduling_;
+    unsigned int knob_verbose_;
 
-    memref_tid_t last_thread;
-    int last_core;
+    memref_tid_t last_thread_;
+    int last_core_;
 
     // For thread mapping to cores:
-    std::unordered_map<int, int> cpu2core;
-    std::unordered_map<memref_tid_t, int> thread2core;
-    std::vector<int> cpu_counts;
-    std::vector<int> thread_counts;
-    std::vector<int> thread_ever_counts;
+    std::unordered_map<int, int> cpu2core_;
+    std::unordered_map<memref_tid_t, int> thread2core_;
+    std::vector<int> cpu_counts_;
+    std::vector<int> thread_counts_;
+    std::vector<int> thread_ever_counts_;
 };
 
 #endif /* _SIMULATOR_H_ */

--- a/clients/drcachesim/simulator/snoop_filter.h
+++ b/clients/drcachesim/simulator/snoop_filter.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,22 +49,22 @@ public:
     {
     }
     virtual bool
-    init(cache_t **caches_, int num_snooped_caches_);
+    init(cache_t **caches, int num_snooped_caches);
     virtual void
-    snoop(addr_t tag, int id_in, bool is_write);
+    snoop(addr_t tag, int id, bool is_write);
     virtual void
-    snoop_eviction(addr_t tag, int id_in);
+    snoop_eviction(addr_t tag, int id);
     void
     print_stats(void);
 
 protected:
     // XXX: This initial coherence implementation uses a perfect snoop filter.
-    std::unordered_map<addr_t, coherence_table_entry_t> coherence_table;
-    cache_t **caches;
-    int num_snooped_caches;
-    int_least64_t num_writes;
-    int_least64_t num_writebacks;
-    int_least64_t num_invalidates;
+    std::unordered_map<addr_t, coherence_table_entry_t> coherence_table_;
+    cache_t **caches_;
+    int num_snooped_caches_;
+    int_least64_t num_writes_;
+    int_least64_t num_writebacks_;
+    int_least64_t num_invalidates_;
 };
 
 #endif /* _SNOOP_FILTER_H_ */

--- a/clients/drcachesim/simulator/tlb.cpp
+++ b/clients/drcachesim/simulator/tlb.cpp
@@ -51,7 +51,7 @@ tlb_t::request(const memref_t &memref_in)
     // to isolate them.
 
     // Unfortunately we need to make a copy for our loop so we can pass
-    // the right data struct to the parent_ and stats collectors.
+    // the right data struct to the parent and stats collectors.
     memref_t memref;
     // We support larger sizes to improve the IPC perf.
     // This means that one memref could touch multiple blocks.
@@ -98,7 +98,7 @@ tlb_t::request(const memref_t &memref_in)
             caching_device_block_t *tlb_entry = &get_caching_device_block(block_idx, way);
 
             stats_->access(memref, false /*miss*/, tlb_entry);
-            // If no parent_ we assume we get the data from main memory
+            // If no parent we assume we get the data from main memory
             if (parent_ != NULL) {
                 parent_->get_stats()->child_access(memref, false, tlb_entry);
                 parent_->request(memref);

--- a/clients/drcachesim/simulator/tlb.cpp
+++ b/clients/drcachesim/simulator/tlb.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,8 +37,8 @@
 void
 tlb_t::init_blocks()
 {
-    for (int i = 0; i < num_blocks; i++) {
-        blocks[i] = new tlb_entry_t;
+    for (int i = 0; i < num_blocks_; i++) {
+        blocks_[i] = new tlb_entry_t;
     }
 }
 
@@ -51,7 +51,7 @@ tlb_t::request(const memref_t &memref_in)
     // to isolate them.
 
     // Unfortunately we need to make a copy for our loop so we can pass
-    // the right data struct to the parent and stats collectors.
+    // the right data struct to the parent_ and stats collectors.
     memref_t memref;
     // We support larger sizes to improve the IPC perf.
     // This means that one memref could touch multiple blocks.
@@ -62,16 +62,16 @@ tlb_t::request(const memref_t &memref_in)
     memref_pid_t pid = memref_in.data.pid;
 
     // Optimization: check last tag and pid if single-block
-    if (tag == final_tag && tag == last_tag && pid == last_pid) {
-        // Make sure last_tag and pid are properly in sync.
+    if (tag == final_tag && tag == last_tag_ && pid == last_pid_) {
+        // Make sure last_tag_ and pid are properly in sync.
         caching_device_block_t *tlb_entry =
-            &get_caching_device_block(last_block_idx, last_way);
-        assert(tag != TAG_INVALID && tag == tlb_entry->tag &&
-               pid == ((tlb_entry_t *)tlb_entry)->pid);
-        stats->access(memref_in, true /*hit*/, tlb_entry);
-        if (parent != NULL)
-            parent->get_stats()->child_access(memref_in, true, tlb_entry);
-        access_update(last_block_idx, last_way);
+            &get_caching_device_block(last_block_idx_, last_way_);
+        assert(tag != TAG_INVALID && tag == tlb_entry->tag_ &&
+               pid == ((tlb_entry_t *)tlb_entry)->pid_);
+        stats_->access(memref_in, true /*hit*/, tlb_entry);
+        if (parent_ != NULL)
+            parent_->get_stats()->child_access(memref_in, true, tlb_entry);
+        access_update(last_block_idx_, last_way_);
         return;
     }
 
@@ -81,46 +81,46 @@ tlb_t::request(const memref_t &memref_in)
         int block_idx = compute_block_idx(tag);
 
         if (tag + 1 <= final_tag)
-            memref.data.size = ((tag + 1) << block_size_bits) - memref.data.addr;
+            memref.data.size = ((tag + 1) << block_size_bits_) - memref.data.addr;
 
-        for (way = 0; way < associativity; ++way) {
+        for (way = 0; way < associativity_; ++way) {
             caching_device_block_t *tlb_entry = &get_caching_device_block(block_idx, way);
-            if (tlb_entry->tag == tag && ((tlb_entry_t *)tlb_entry)->pid == pid) {
-                stats->access(memref, true /*hit*/, tlb_entry);
-                if (parent != NULL)
-                    parent->get_stats()->child_access(memref, true, tlb_entry);
+            if (tlb_entry->tag_ == tag && ((tlb_entry_t *)tlb_entry)->pid_ == pid) {
+                stats_->access(memref, true /*hit*/, tlb_entry);
+                if (parent_ != NULL)
+                    parent_->get_stats()->child_access(memref, true, tlb_entry);
                 break;
             }
         }
 
-        if (way == associativity) {
+        if (way == associativity_) {
             way = replace_which_way(block_idx);
             caching_device_block_t *tlb_entry = &get_caching_device_block(block_idx, way);
 
-            stats->access(memref, false /*miss*/, tlb_entry);
-            // If no parent we assume we get the data from main memory
-            if (parent != NULL) {
-                parent->get_stats()->child_access(memref, false, tlb_entry);
-                parent->request(memref);
+            stats_->access(memref, false /*miss*/, tlb_entry);
+            // If no parent_ we assume we get the data from main memory
+            if (parent_ != NULL) {
+                parent_->get_stats()->child_access(memref, false, tlb_entry);
+                parent_->request(memref);
             }
 
             // XXX: do we need to handle TLB coherency?
 
-            tlb_entry->tag = tag;
-            ((tlb_entry_t *)tlb_entry)->pid = pid;
+            tlb_entry->tag_ = tag;
+            ((tlb_entry_t *)tlb_entry)->pid_ = pid;
         }
 
         access_update(block_idx, way);
 
         if (tag + 1 <= final_tag) {
-            addr_t next_addr = (tag + 1) << block_size_bits;
+            addr_t next_addr = (tag + 1) << block_size_bits_;
             memref.data.addr = next_addr;
             memref.data.size = final_addr - next_addr + 1 /*undo the -1*/;
         }
         // Optimization: remember last tag and pid
-        last_tag = tag;
-        last_way = way;
-        last_block_idx = block_idx;
-        last_pid = pid;
+        last_tag_ = tag;
+        last_way_ = way;
+        last_block_idx_ = block_idx;
+        last_pid_ = pid;
     }
 }

--- a/clients/drcachesim/simulator/tlb.h
+++ b/clients/drcachesim/simulator/tlb.h
@@ -50,7 +50,7 @@ protected:
     init_blocks() override;
 
     // Optimization: remember last pid in addition to last tag
-    memref_pid_t last_pid;
+    memref_pid_t last_pid_;
 };
 
 #endif /* _TLB_H_ */

--- a/clients/drcachesim/simulator/tlb_entry.h
+++ b/clients/drcachesim/simulator/tlb_entry.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -42,7 +42,7 @@ class tlb_entry_t : public caching_device_block_t {
 public:
     // process ID to differentiate virtual pages
     // that have the same VPN but belong to different processes.
-    memref_pid_t pid;
+    memref_pid_t pid_;
 
     // XXX: support page privilege and MMU-related exceptions
 };

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -50,49 +50,50 @@ tlb_simulator_create(const tlb_simulator_knobs_t &knobs)
     return new tlb_simulator_t(knobs);
 }
 
-tlb_simulator_t::tlb_simulator_t(const tlb_simulator_knobs_t &knobs_)
-    : simulator_t(knobs_.num_cores, knobs_.skip_refs, knobs_.warmup_refs,
-                  knobs_.warmup_fraction, knobs_.sim_refs, knobs_.cpu_scheduling,
-                  knobs_.verbose)
-    , knobs(knobs_)
+tlb_simulator_t::tlb_simulator_t(const tlb_simulator_knobs_t &knobs)
+    : simulator_t(knobs.num_cores, knobs.skip_refs, knobs.warmup_refs,
+                  knobs.warmup_fraction, knobs.sim_refs, knobs.cpu_scheduling,
+                  knobs.verbose)
+    , knobs_(knobs)
 {
-    itlbs = new tlb_t *[knobs.num_cores];
-    dtlbs = new tlb_t *[knobs.num_cores];
-    lltlbs = new tlb_t *[knobs.num_cores];
-    for (unsigned int i = 0; i < knobs.num_cores; i++) {
-        itlbs[i] = NULL;
-        dtlbs[i] = NULL;
-        lltlbs[i] = NULL;
+    itlbs_ = new tlb_t *[knobs_.num_cores];
+    dtlbs_ = new tlb_t *[knobs_.num_cores];
+    lltlbs_ = new tlb_t *[knobs_.num_cores];
+    for (unsigned int i = 0; i < knobs_.num_cores; i++) {
+        itlbs_[i] = NULL;
+        dtlbs_[i] = NULL;
+        lltlbs_[i] = NULL;
     }
-    for (unsigned int i = 0; i < knobs.num_cores; i++) {
-        itlbs[i] = create_tlb(knobs.TLB_replace_policy);
-        if (itlbs[i] == NULL) {
-            error_string = "Failed to create itlbs";
-            success = false;
+    for (unsigned int i = 0; i < knobs_.num_cores; i++) {
+        itlbs_[i] = create_tlb(knobs_.TLB_replace_policy);
+        if (itlbs_[i] == NULL) {
+            error_string_ = "Failed to create itlbs_";
+            success_ = false;
             return;
         }
-        dtlbs[i] = create_tlb(knobs.TLB_replace_policy);
-        if (dtlbs[i] == NULL) {
-            error_string = "Failed to create dtlbs";
-            success = false;
+        dtlbs_[i] = create_tlb(knobs_.TLB_replace_policy);
+        if (dtlbs_[i] == NULL) {
+            error_string_ = "Failed to create dtlbs_";
+            success_ = false;
             return;
         }
-        lltlbs[i] = create_tlb(knobs.TLB_replace_policy);
-        if (lltlbs[i] == NULL) {
-            error_string = "Failed to create lltlbs";
-            success = false;
+        lltlbs_[i] = create_tlb(knobs_.TLB_replace_policy);
+        if (lltlbs_[i] == NULL) {
+            error_string_ = "Failed to create lltlbs_";
+            success_ = false;
             return;
         }
 
-        if (!itlbs[i]->init(knobs.TLB_L1I_assoc, (int)knobs.page_size,
-                            knobs.TLB_L1I_entries, lltlbs[i], new tlb_stats_t) ||
-            !dtlbs[i]->init(knobs.TLB_L1D_assoc, (int)knobs.page_size,
-                            knobs.TLB_L1D_entries, lltlbs[i], new tlb_stats_t) ||
-            !lltlbs[i]->init(knobs.TLB_L2_assoc, (int)knobs.page_size,
-                             knobs.TLB_L2_entries, NULL, new tlb_stats_t)) {
-            error_string = "Usage error: failed to initialize TLBs. Ensure entry number, "
-                           "page size and associativity are powers of 2.";
-            success = false;
+        if (!itlbs_[i]->init(knobs_.TLB_L1I_assoc, (int)knobs_.page_size,
+                             knobs_.TLB_L1I_entries, lltlbs_[i], new tlb_stats_t) ||
+            !dtlbs_[i]->init(knobs_.TLB_L1D_assoc, (int)knobs_.page_size,
+                             knobs_.TLB_L1D_entries, lltlbs_[i], new tlb_stats_t) ||
+            !lltlbs_[i]->init(knobs_.TLB_L2_assoc, (int)knobs_.page_size,
+                              knobs_.TLB_L2_entries, NULL, new tlb_stats_t)) {
+            error_string_ =
+                "Usage error: failed to initialize TLbs_. Ensure entry number, "
+                "page size and associativity_ are powers of 2.";
+            success_ = false;
             return;
         }
     }
@@ -100,36 +101,36 @@ tlb_simulator_t::tlb_simulator_t(const tlb_simulator_knobs_t &knobs_)
 
 tlb_simulator_t::~tlb_simulator_t()
 {
-    for (unsigned int i = 0; i < knobs.num_cores; i++) {
+    for (unsigned int i = 0; i < knobs_.num_cores; i++) {
         // Try to handle failure during construction.
-        if (itlbs[i] == NULL)
+        if (itlbs_[i] == NULL)
             return;
-        delete itlbs[i]->get_stats();
-        delete itlbs[i];
-        if (dtlbs[i] == NULL)
+        delete itlbs_[i]->get_stats();
+        delete itlbs_[i];
+        if (dtlbs_[i] == NULL)
             return;
-        delete dtlbs[i]->get_stats();
-        delete dtlbs[i];
-        if (lltlbs[i] == NULL)
+        delete dtlbs_[i]->get_stats();
+        delete dtlbs_[i];
+        if (lltlbs_[i] == NULL)
             return;
-        delete lltlbs[i]->get_stats();
-        delete lltlbs[i];
+        delete lltlbs_[i]->get_stats();
+        delete lltlbs_[i];
     }
-    delete[] itlbs;
-    delete[] dtlbs;
-    delete[] lltlbs;
+    delete[] itlbs_;
+    delete[] dtlbs_;
+    delete[] lltlbs_;
 }
 
 bool
 tlb_simulator_t::process_memref(const memref_t &memref)
 {
-    if (knobs.skip_refs > 0) {
-        knobs.skip_refs--;
+    if (knobs_.skip_refs > 0) {
+        knobs_.skip_refs--;
         return true;
     }
 
     // The references after warmup and simulated ones are dropped.
-    if (knobs.warmup_refs == 0 && knobs.sim_refs == 0)
+    if (knobs_.warmup_refs == 0 && knobs_.sim_refs == 0)
         return true;
 
     // Both warmup and simulated references are simulated.
@@ -147,21 +148,21 @@ tlb_simulator_t::process_memref(const memref_t &memref)
     // not practical to measure which core each thread actually
     // ran on for each memref.
     int core;
-    if (memref.data.tid == last_thread)
-        core = last_core;
+    if (memref.data.tid == last_thread_)
+        core = last_core_;
     else {
         core = core_for_thread(memref.data.tid);
-        last_thread = memref.data.tid;
-        last_core = core;
+        last_thread_ = memref.data.tid;
+        last_core_ = core;
     }
 
     if (type_is_instr(memref.instr.type))
-        itlbs[core]->request(memref);
+        itlbs_[core]->request(memref);
     else if (memref.data.type == TRACE_TYPE_READ || memref.data.type == TRACE_TYPE_WRITE)
-        dtlbs[core]->request(memref);
+        dtlbs_[core]->request(memref);
     else if (memref.exit.type == TRACE_TYPE_THREAD_EXIT) {
         handle_thread_exit(memref.exit.tid);
-        last_thread = 0;
+        last_thread_ = 0;
     } else if (type_is_prefetch(memref.data.type) ||
                memref.flush.type == TRACE_TYPE_INSTR_FLUSH ||
                memref.flush.type == TRACE_TYPE_DATA_FLUSH ||
@@ -169,11 +170,11 @@ tlb_simulator_t::process_memref(const memref_t &memref)
                memref.marker.type == TRACE_TYPE_INSTR_NO_FETCH) {
         // TLB simulator ignores prefetching, cache flushing, and markers
     } else {
-        error_string = "Unhandled memref type " + std::to_string(memref.data.type);
+        error_string_ = "Unhandled memref type " + std::to_string(memref.data.type);
         return false;
     }
 
-    if (knobs.verbose >= 3) {
+    if (knobs_.verbose >= 3) {
         std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: "
                   << " @" << (void *)memref.data.pc << " "
                   << trace_type_names[memref.data.type] << " " << (void *)memref.data.addr
@@ -181,18 +182,18 @@ tlb_simulator_t::process_memref(const memref_t &memref)
     }
 
     // process counters for warmup and simulated references
-    if (knobs.warmup_refs > 0) { // warm tlbs up
-        knobs.warmup_refs--;
+    if (knobs_.warmup_refs > 0) { // warm tlbs_ up
+        knobs_.warmup_refs--;
         // reset tlb stats when warming up is completed
-        if (knobs.warmup_refs == 0) {
-            for (unsigned int i = 0; i < knobs.num_cores; i++) {
-                itlbs[i]->get_stats()->reset();
-                dtlbs[i]->get_stats()->reset();
-                lltlbs[i]->get_stats()->reset();
+        if (knobs_.warmup_refs == 0) {
+            for (unsigned int i = 0; i < knobs_.num_cores; i++) {
+                itlbs_[i]->get_stats()->reset();
+                dtlbs_[i]->get_stats()->reset();
+                lltlbs_[i]->get_stats()->reset();
             }
         }
     } else {
-        knobs.sim_refs--;
+        knobs_.sim_refs--;
     }
     return true;
 }
@@ -201,15 +202,15 @@ bool
 tlb_simulator_t::print_results()
 {
     std::cerr << "TLB simulation results:\n";
-    for (unsigned int i = 0; i < knobs.num_cores; i++) {
+    for (unsigned int i = 0; i < knobs_.num_cores; i++) {
         print_core(i);
-        if (thread_ever_counts[i] > 0) {
+        if (thread_ever_counts_[i] > 0) {
             std::cerr << "  L1I stats:" << std::endl;
-            itlbs[i]->get_stats()->print_stats("    ");
+            itlbs_[i]->get_stats()->print_stats("    ");
             std::cerr << "  L1D stats:" << std::endl;
-            dtlbs[i]->get_stats()->print_stats("    ");
+            dtlbs_[i]->get_stats()->print_stats("    ");
             std::cerr << "  LL stats:" << std::endl;
-            lltlbs[i]->get_stats()->print_stats("    ");
+            lltlbs_[i]->get_stats()->print_stats("    ");
         }
     }
     return true;

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -92,7 +92,7 @@ tlb_simulator_t::tlb_simulator_t(const tlb_simulator_knobs_t &knobs)
                               knobs_.TLB_L2_entries, NULL, new tlb_stats_t)) {
             error_string_ =
                 "Usage error: failed to initialize TLbs_. Ensure entry number, "
-                "page size and associativity_ are powers of 2.";
+                "page size and associativity are powers of 2.";
             success_ = false;
             return;
         }
@@ -182,7 +182,7 @@ tlb_simulator_t::process_memref(const memref_t &memref)
     }
 
     // process counters for warmup and simulated references
-    if (knobs_.warmup_refs > 0) { // warm tlbs_ up
+    if (knobs_.warmup_refs > 0) { // warm tlbs up
         knobs_.warmup_refs--;
         // reset tlb stats when warming up is completed
         if (knobs_.warmup_refs == 0) {

--- a/clients/drcachesim/simulator/tlb_simulator.h
+++ b/clients/drcachesim/simulator/tlb_simulator.h
@@ -56,13 +56,13 @@ protected:
     virtual tlb_t *
     create_tlb(std::string policy);
 
-    tlb_simulator_knobs_t knobs;
+    tlb_simulator_knobs_t knobs_;
 
     // Each CPU core contains a L1 ITLB, L1 DTLB and L2 TLB.
     // All of them are private to the core.
-    tlb_t **itlbs;
-    tlb_t **dtlbs;
-    tlb_t **lltlbs;
+    tlb_t **itlbs_;
+    tlb_t **dtlbs_;
+    tlb_t **lltlbs_;
 };
 
 #endif /* _TLB_SIMULATOR_H_ */

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -189,10 +189,10 @@ post_process()
         std::string dir_err = dir.initialize(raw_dir, "");
         assert(dir_err.empty());
         std::unique_ptr<module_mapper_t> module_mapper = module_mapper_t::create(
-            dir.modfile_bytes, parse_cb, process_cb, MAGIC_VALUE, free_cb);
+            dir.modfile_bytes_, parse_cb, process_cb, MAGIC_VALUE, free_cb);
         assert(module_mapper->get_last_error().empty());
         // Test back-compat of deprecated APIs.
-        raw2trace_t raw2trace(dir.modfile_bytes, dir.in_files, dir.out_files, NULL);
+        raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_, NULL);
         std::string error =
             raw2trace.handle_custom_data(parse_cb, process_cb, MAGIC_VALUE, free_cb);
         assert(error.empty());
@@ -205,7 +205,8 @@ post_process()
     raw2trace_directory_t dir;
     std::string dir_err = dir.initialize(raw_dir, "");
     assert(dir_err.empty());
-    raw2trace_t raw2trace(dir.modfile_bytes, dir.in_files, dir.out_files, dr_context, 0);
+    raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_, dr_context,
+                          0);
     std::string error =
         raw2trace.handle_custom_data(parse_cb, process_cb, MAGIC_VALUE, free_cb);
     assert(error.empty());

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -145,7 +145,8 @@ post_process(const std::string &out_subdir)
         }
         std::string dir_err = dir.initialize(raw_dir, outdir);
         assert(dir_err.empty());
-        raw2trace_t raw2trace(dir.modfile_bytes, dir.in_files, dir.out_files, dr_context,
+        raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_,
+                              dr_context,
                               0
 #    ifdef WINDOWS
                               /* FIXME i#3983: Creating threads in standalone mode

--- a/clients/drcachesim/tests/config_reader_test.cpp
+++ b/clients/drcachesim/tests/config_reader_test.cpp
@@ -38,7 +38,7 @@
 static void
 check_cache(const std::map<std::string, cache_params_t> &caches, std::string name,
             std::string type, int core, uint64_t size, unsigned int assoc, bool inclusive,
-            std::string parent, std::string replace_policy, std::string prefetcher,
+            std::string parent_, std::string replace_policy, std::string prefetcher,
             std::string miss_file)
 {
     auto cache_it = caches.find(name);
@@ -51,7 +51,7 @@ check_cache(const std::map<std::string, cache_params_t> &caches, std::string nam
     auto &cache = cache_it->second;
 
     if (cache.type != type || cache.core != core || cache.size != size ||
-        cache.assoc != assoc || cache.inclusive != inclusive || cache.parent != parent ||
+        cache.assoc != assoc || cache.inclusive != inclusive || cache.parent != parent_ ||
         cache.replace_policy != replace_policy || cache.prefetcher != prefetcher ||
         cache.miss_file != miss_file) {
         std::cerr << "drcachesim config_reader_test failed (cache: " << cache.name

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -90,7 +90,7 @@ test_raw2trace(raw2trace_directory_t *dir)
         return false;
     }
     if (pid != 0) {
-        /* parent */
+        /* parent_ */
         long res;
         int status;
         while (true) {
@@ -141,13 +141,13 @@ test_raw2trace(raw2trace_directory_t *dir)
             perror("ptrace me failed");
             return false;
         }
-        /* Force a wait until parent attaches, so we don't race on the fork. */
+        /* Force a wait until parent_ attaches, so we don't race on the fork. */
         raise(SIGSTOP);
 
         /* Sycalls below will be ptraced. We don't expect any open/close calls outside of
          * raw2trace::read_and_map_modules().
          */
-        raw2trace_t raw2trace(dir->modfile_bytes, dir->in_files, dir->out_files,
+        raw2trace_t raw2trace(dir->modfile_bytes_, dir->in_files_, dir->out_files_,
                               GLOBAL_DCONTEXT, 1);
         std::string error = raw2trace.do_conversion();
         if (!error.empty()) {
@@ -171,7 +171,7 @@ bool
 test_module_mapper(const raw2trace_directory_t *dir)
 {
     std::unique_ptr<module_mapper_t> mapper = module_mapper_t::create(
-        dir->modfile_bytes, nullptr, nullptr, nullptr, &my_user_free);
+        dir->modfile_bytes_, nullptr, nullptr, nullptr, &my_user_free);
     EXPECT(mapper->get_last_error().empty(), "Module mapper construction failed");
     REPORT("About to load modules");
     const auto &loaded_modules = mapper->get_loaded_modules();
@@ -194,7 +194,7 @@ test_module_mapper(const raw2trace_directory_t *dir)
 bool
 test_trace_timestamp_reader(const raw2trace_directory_t *dir)
 {
-    std::istream *file = dir->in_files[0];
+    std::istream *file = dir->in_files_[0];
     // Seek back to the beginning to undo raw2trace_directory_t's validation
     file->seekg(0);
     offline_entry_t buffer[4];

--- a/clients/drcachesim/tests/trace_invariants.cpp
+++ b/clients/drcachesim/tests/trace_invariants.cpp
@@ -36,17 +36,17 @@
 #include <string.h>
 
 trace_invariants_t::trace_invariants_t(bool offline, unsigned int verbose)
-    : knob_offline(offline)
-    , knob_verbose(verbose)
-    , instrs_until_interrupt(-1)
-    , memrefs_until_interrupt(-1)
-    , app_handler_pc(0)
+    : knob_offline_(offline)
+    , knob_verbose_(verbose)
+    , instrs_until_interrupt_(-1)
+    , memrefs_until_interrupt_(-1)
+    , app_handler_pc_(0)
 {
-    memset(&prev_instr, 0, sizeof(prev_instr));
-    memset(&pre_signal_instr, 0, sizeof(pre_signal_instr));
-    memset(&prev_xfer_marker, 0, sizeof(prev_xfer_marker));
-    memset(&prev_entry, 0, sizeof(prev_entry));
-    memset(&prev_prev_entry, 0, sizeof(prev_prev_entry));
+    memset(&prev_instr_, 0, sizeof(prev_instr_));
+    memset(&pre_signal_instr_, 0, sizeof(pre_signal_instr_));
+    memset(&prev_xfer_marker_, 0, sizeof(prev_xfer_marker_));
+    memset(&prev_entry_, 0, sizeof(prev_entry_));
+    memset(&prev_prev_entry_, 0, sizeof(prev_prev_entry_));
 }
 
 trace_invariants_t::~trace_invariants_t()
@@ -59,36 +59,36 @@ trace_invariants_t::process_memref(const memref_t &memref)
     // Check conditions specific to the signal_invariants app, where it
     // has annotations in prefetch instructions telling us how many instrs
     // and/or memrefs until a signal should arrive.
-    if ((instrs_until_interrupt == 0 && memrefs_until_interrupt == -1) ||
-        (instrs_until_interrupt == -1 && memrefs_until_interrupt == 0) ||
-        (instrs_until_interrupt == 0 && memrefs_until_interrupt == 0)) {
+    if ((instrs_until_interrupt_ == 0 && memrefs_until_interrupt_ == -1) ||
+        (instrs_until_interrupt_ == -1 && memrefs_until_interrupt_ == 0) ||
+        (instrs_until_interrupt_ == 0 && memrefs_until_interrupt_ == 0)) {
         assert((memref.marker.type == TRACE_TYPE_MARKER &&
                 memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) ||
                // TODO i#3937: Online instr bundles currently violate this.
-               !knob_offline);
-        instrs_until_interrupt = -1;
-        memrefs_until_interrupt = -1;
+               !knob_offline_);
+        instrs_until_interrupt_ = -1;
+        memrefs_until_interrupt_ = -1;
     }
-    if (memrefs_until_interrupt >= 0 &&
+    if (memrefs_until_interrupt_ >= 0 &&
         (memref.data.type == TRACE_TYPE_READ || memref.data.type == TRACE_TYPE_WRITE)) {
-        assert(memrefs_until_interrupt != 0);
-        --memrefs_until_interrupt;
+        assert(memrefs_until_interrupt_ != 0);
+        --memrefs_until_interrupt_;
     }
     // Check that the signal delivery marker is immediately followed by the
     // app's signal handler, which we have annotated with "prefetcht0 [1]".
     if (memref.data.type == TRACE_TYPE_PREFETCHT0 && memref.data.addr == 1) {
-        assert(type_is_instr(prev_entry.instr.type) &&
-               prev_prev_entry.marker.type == TRACE_TYPE_MARKER &&
-               prev_xfer_marker.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT);
-        app_handler_pc = prev_entry.instr.addr;
+        assert(type_is_instr(prev_entry_.instr.type) &&
+               prev_prev_entry_.marker.type == TRACE_TYPE_MARKER &&
+               prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT);
+        app_handler_pc_ = prev_entry_.instr.addr;
     }
 
     if (memref.exit.type == TRACE_TYPE_THREAD_EXIT)
-        thread_exited[memref.exit.tid] = true;
+        thread_exited_[memref.exit.tid] = true;
     if (type_is_instr(memref.instr.type) ||
         memref.instr.type == TRACE_TYPE_PREFETCH_INSTR ||
         memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH) {
-        if (knob_verbose >= 3) {
+        if (knob_verbose_ >= 3) {
             std::cerr << "::" << memref.data.pid << ":" << memref.data.tid << ":: "
                       << " @" << (void *)memref.instr.addr
                       << ((memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH)
@@ -96,93 +96,94 @@ trace_invariants_t::process_memref(const memref_t &memref)
                               : "")
                       << " instr x" << memref.instr.size << "\n";
         }
-        assert(instrs_until_interrupt != 0);
-        if (instrs_until_interrupt > 0)
-            --instrs_until_interrupt;
+        assert(instrs_until_interrupt_ != 0);
+        if (instrs_until_interrupt_ > 0)
+            --instrs_until_interrupt_;
         // Invariant: offline traces guarantee that a branch target must immediately
         // follow the branch w/ no intervening trace switch.
-        if (knob_offline && type_is_instr_branch(prev_instr.instr.type)) {
+        if (knob_offline_ && type_is_instr_branch(prev_instr_.instr.type)) {
             assert(
-                prev_instr.instr.tid == memref.instr.tid ||
+                prev_instr_.instr.tid == memref.instr.tid ||
                 // For limited-window traces a thread might exit after a branch.
-                thread_exited[prev_instr.instr.tid] ||
+                thread_exited_[prev_instr_.instr.tid] ||
                 // The invariant is relaxed for a signal.
-                (prev_xfer_marker.instr.tid == prev_instr.instr.tid &&
-                 prev_xfer_marker.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT));
+                (prev_xfer_marker_.instr.tid == prev_instr_.instr.tid &&
+                 prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT));
         }
         // Invariant: non-explicit control flow (i.e., kernel-mediated) is indicated
         // by markers.
-        if (prev_instr.instr.addr != 0 /*first*/ &&
-            prev_instr.instr.tid == memref.instr.tid &&
-            !type_is_instr_branch(prev_instr.instr.type)) {
+        if (prev_instr_.instr.addr != 0 /*first*/ &&
+            prev_instr_.instr.tid == memref.instr.tid &&
+            !type_is_instr_branch(prev_instr_.instr.type)) {
             assert( // Regular fall-through.
-                (prev_instr.instr.addr + prev_instr.instr.size == memref.instr.addr) ||
+                (prev_instr_.instr.addr + prev_instr_.instr.size == memref.instr.addr) ||
                 // String loop.
-                (prev_instr.instr.addr == memref.instr.addr &&
+                (prev_instr_.instr.addr == memref.instr.addr &&
                  memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH) ||
                 // Kernel-mediated, but we can't tell if we had a thread swap.
-                (prev_xfer_marker.instr.tid != 0 &&
-                 (prev_xfer_marker.instr.tid != memref.instr.tid ||
-                  prev_xfer_marker.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-                  prev_xfer_marker.marker.marker_type ==
+                (prev_xfer_marker_.instr.tid != 0 &&
+                 (prev_xfer_marker_.instr.tid != memref.instr.tid ||
+                  prev_xfer_marker_.marker.marker_type ==
+                      TRACE_MARKER_TYPE_KERNEL_EVENT ||
+                  prev_xfer_marker_.marker.marker_type ==
                       TRACE_MARKER_TYPE_KERNEL_XFER)) ||
-                prev_instr.instr.type == TRACE_TYPE_INSTR_SYSENTER);
+                prev_instr_.instr.type == TRACE_TYPE_INSTR_SYSENTER);
             // XXX: If we had instr decoding we could check direct branch targets
             // and look for gaps after branches.
         }
 #ifdef UNIX
         // Ensure signal handlers return to the interruption point.
-        if (prev_xfer_marker.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER) {
-            assert(memref.instr.tid != pre_signal_instr.instr.tid ||
-                   memref.instr.addr == pre_signal_instr.instr.addr ||
+        if (prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER) {
+            assert(memref.instr.tid != pre_signal_instr_.instr.tid ||
+                   memref.instr.addr == pre_signal_instr_.instr.addr ||
                    // Asynch will go to the subsequent instr.
                    memref.instr.addr ==
-                       pre_signal_instr.instr.addr + pre_signal_instr.instr.size ||
+                       pre_signal_instr_.instr.addr + pre_signal_instr_.instr.size ||
                    // Nested signal.  XXX: This only works for our annotated test
                    // signal_invariants.
-                   memref.instr.addr == app_handler_pc ||
+                   memref.instr.addr == app_handler_pc_ ||
                    // Marker for rseq abort handler.  Not as unique as a prefetch, but
                    // we need an instruction and not a data type.
                    memref.instr.type == TRACE_TYPE_INSTR_DIRECT_JUMP ||
                    // Too hard to figure out branch targets.
-                   type_is_instr_branch(pre_signal_instr.instr.type) ||
-                   pre_signal_instr.instr.type == TRACE_TYPE_INSTR_SYSENTER);
+                   type_is_instr_branch(pre_signal_instr_.instr.type) ||
+                   pre_signal_instr_.instr.type == TRACE_TYPE_INSTR_SYSENTER);
         }
 #endif
-        prev_instr = memref;
-        // Clear prev_xfer_marker on an instr (not a memref which could come between an
+        prev_instr_ = memref;
+        // Clear prev_xfer_marker_ on an instr (not a memref which could come between an
         // instr and a kernel-mediated far-away instr) to ensure it's *immediately*
         // prior (i#3937).
-        memset(&prev_xfer_marker, 0, sizeof(prev_xfer_marker));
+        memset(&prev_xfer_marker_, 0, sizeof(prev_xfer_marker_));
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         // Ignore timestamp, etc. markers which show up a signal delivery boundaries
         // b/c the tracer does a buffer flush there.
         (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
          memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER)) {
-        if (knob_verbose >= 3) {
+        if (knob_verbose_ >= 3) {
             std::cerr << "::" << memref.data.pid << ":" << memref.data.tid << ":: "
                       << "marker type " << memref.marker.marker_type << " value "
                       << memref.marker.marker_value << "\n";
         }
         if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT &&
             // Give up on back-to-back signals.
-            prev_xfer_marker.marker.marker_type != TRACE_MARKER_TYPE_KERNEL_XFER)
-            pre_signal_instr = prev_instr;
-        prev_xfer_marker = memref;
+            prev_xfer_marker_.marker.marker_type != TRACE_MARKER_TYPE_KERNEL_XFER)
+            pre_signal_instr_ = prev_instr_;
+        prev_xfer_marker_ = memref;
     }
 
     // Look for annotations where signal_invariants.c and rseq.c pass info to us on what
     // to check for.  We assume the app does not have prefetch instrs w/ low addresses.
     if (memref.data.type == TRACE_TYPE_PREFETCHT2 && memref.data.addr < 1024) {
-        instrs_until_interrupt = static_cast<int>(memref.data.addr);
+        instrs_until_interrupt_ = static_cast<int>(memref.data.addr);
     }
     if (memref.data.type == TRACE_TYPE_PREFETCHT1 && memref.data.addr < 1024) {
-        memrefs_until_interrupt = static_cast<int>(memref.data.addr);
+        memrefs_until_interrupt_ = static_cast<int>(memref.data.addr);
     }
 
-    prev_prev_entry = prev_entry;
-    prev_entry = memref;
+    prev_prev_entry_ = prev_entry_;
+    prev_entry_ = memref;
     return true;
 }
 

--- a/clients/drcachesim/tests/trace_invariants.h
+++ b/clients/drcachesim/tests/trace_invariants.h
@@ -50,17 +50,17 @@ public:
     print_results() override;
 
 protected:
-    bool knob_offline;
-    unsigned int knob_verbose;
-    memref_t prev_instr;
-    memref_t prev_xfer_marker;
-    memref_t prev_entry;
-    memref_t prev_prev_entry;
-    memref_t pre_signal_instr;
-    int instrs_until_interrupt;
-    int memrefs_until_interrupt;
-    addr_t app_handler_pc;
-    std::unordered_map<memref_tid_t, bool> thread_exited;
+    bool knob_offline_;
+    unsigned int knob_verbose_;
+    memref_t prev_instr_;
+    memref_t prev_xfer_marker_;
+    memref_t prev_entry_;
+    memref_t prev_prev_entry_;
+    memref_t pre_signal_instr_;
+    int instrs_until_interrupt_;
+    int memrefs_until_interrupt_;
+    addr_t app_handler_pc_;
+    std::unordered_map<memref_tid_t, bool> thread_exited_;
 };
 
 #endif /* _TRACE_INVARIANTS_H_ */

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -105,11 +105,11 @@ protected:
                  const std::pair<memref_tid_t, counters_t *> &r);
 
     // The keys here are int for parallel, tid for serial.
-    std::unordered_map<memref_tid_t, counters_t *> shard_map;
+    std::unordered_map<memref_tid_t, counters_t *> shard_map_;
     // This mutex is only needed in parallel_shard_init.  In all other accesses to
     // shard_map (process_memref, print_results) we are single-threaded.
-    std::mutex shard_map_mutex;
-    unsigned int knob_verbose;
+    std::mutex shard_map_mutex_;
+    unsigned int knob_verbose_;
     static const std::string TOOL_NAME;
 };
 

--- a/clients/drcachesim/tools/histogram.h
+++ b/clients/drcachesim/tools/histogram.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -73,15 +73,15 @@ protected:
         std::string error;
     };
 
-    unsigned int knob_line_size;
-    unsigned int knob_report_top; /* most accessed lines */
-    size_t line_size_bits;
+    unsigned int knob_line_size_;
+    unsigned int knob_report_top_; /* most accessed lines */
+    size_t line_size_bits_;
     static const std::string TOOL_NAME;
-    std::unordered_map<memref_tid_t, shard_data_t *> shard_map;
+    std::unordered_map<memref_tid_t, shard_data_t *> shard_map_;
     // This mutex is only needed in parallel_shard_init.  In all other accesses to
     // shard_map (process_memref, print_results) we are single-threaded.
-    std::mutex shard_map_mutex;
-    shard_data_t serial_shard;
+    std::mutex shard_map_mutex_;
+    shard_data_t serial_shard_;
 };
 
 #endif /* _HISTOGRAM_H_ */

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -77,8 +77,8 @@ protected:
             , instr_count(0)
         {
         }
-        shard_data_t(worker_data_t *worker_in)
-            : worker(worker_in)
+        shard_data_t(worker_data_t *worker)
+            : worker(worker)
             , instr_count(0)
             , last_trace_module_start(nullptr)
             , last_trace_module_size(0)
@@ -94,22 +94,23 @@ protected:
         app_pc last_mapped_module_start;
     };
 
-    void *dcontext;
-    std::string module_file_path;
-    std::unique_ptr<module_mapper_t> module_mapper;
-    std::mutex mapper_mutex;
+    void *dcontext_;
+    std::string module_file_path_;
+    std::unique_ptr<module_mapper_t> module_mapper_;
+    std::mutex mapper_mutex_;
+
     // We reference directory.modfile_bytes throughout operation, so its lifetime
     // must match ours.
-    raw2trace_directory_t directory;
-    std::unordered_map<memref_tid_t, shard_data_t *> shard_map;
+    raw2trace_directory_t directory_;
+    std::unordered_map<memref_tid_t, shard_data_t *> shard_map_;
     // This mutex is only needed in parallel_shard_init.  In all other accesses to
     // shard_map (process_memref, print_results) we are single-threaded.
-    std::mutex shard_map_mutex;
-    unsigned int knob_verbose;
+    std::mutex shard_map_mutex_;
+    unsigned int knob_verbose_;
     static const std::string TOOL_NAME;
     // For serial operation.
-    worker_data_t serial_worker;
-    shard_data_t serial_shard;
+    worker_data_t serial_worker_;
+    shard_data_t serial_shard_;
 };
 
 #endif /* _OPCODE_MIX_H_ */

--- a/clients/drcachesim/tools/reuse_distance.h
+++ b/clients/drcachesim/tools/reuse_distance.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -103,14 +103,14 @@ protected:
     void
     print_shard_results(const shard_data_t *shard);
 
-    const reuse_distance_knobs_t knobs;
-    const size_t line_size_bits;
+    const reuse_distance_knobs_t knobs_;
+    const size_t line_size_bits_;
     static const std::string TOOL_NAME;
     // In parallel operation the keys are "shard indices": just ints.
-    std::unordered_map<memref_tid_t, shard_data_t *> shard_map;
+    std::unordered_map<memref_tid_t, shard_data_t *> shard_map_;
     // This mutex is only needed in parallel_shard_init.  In all other accesses to
     // shard_map (process_memref, print_results) we are single-threaded.
-    std::mutex shard_map_mutex;
+    std::mutex shard_map_mutex_;
 };
 
 /* A doubly linked list node for the cache line reference info */
@@ -157,22 +157,22 @@ struct line_ref_t {
 // more efficient computation of the depth.  Each node in the skip
 // list stores its depth from the front.
 struct line_ref_list_t {
-    line_ref_t *head;       // the most recently accessed cache line
-    line_ref_t *gate;       // the earliest cache line refs within the threshold
-    uint64_t cur_time;      // current time stamp
-    uint64_t unique_lines;  // the total number of unique cache lines accessed
-    uint64_t threshold;     // the reuse distance threshold
-    uint64_t skip_distance; // distance between skip list nodes
-    bool verify_skip;       // check results using brute-force walks
+    line_ref_t *head_;       // the most recently accessed cache line
+    line_ref_t *gate_;       // the earliest cache line refs within the threshold
+    uint64_t cur_time_;      // current time stamp
+    uint64_t unique_lines_;  // the total number of unique cache lines accessed
+    uint64_t threshold_;     // the reuse distance threshold
+    uint64_t skip_distance_; // distance between skip list nodes
+    bool verify_skip_;       // check results using brute-force walks
 
-    line_ref_list_t(uint64_t reuse_threshold, uint64_t skip_dist, bool verify)
-        : head(NULL)
-        , gate(NULL)
-        , cur_time(0)
-        , unique_lines(0)
-        , threshold(reuse_threshold)
-        , skip_distance(skip_dist)
-        , verify_skip(verify)
+    line_ref_list_t(uint64_t reuse_threshold_, uint64_t skip_dist, bool verify)
+        : head_(NULL)
+        , gate_(NULL)
+        , cur_time_(0)
+        , unique_lines_(0)
+        , threshold_(reuse_threshold_)
+        , skip_distance_(skip_dist)
+        , verify_skip_(verify)
     {
     }
 
@@ -180,9 +180,9 @@ struct line_ref_list_t {
     {
         line_ref_t *ref;
         line_ref_t *next;
-        if (head == NULL)
+        if (head_ == NULL)
             return;
-        for (ref = head; ref != NULL; ref = next) {
+        for (ref = head_; ref != NULL; ref = next) {
             next = ref->next;
             delete ref;
         }
@@ -191,7 +191,7 @@ struct line_ref_list_t {
     bool
     ref_is_distant(line_ref_t *ref)
     {
-        if (gate == NULL || ref->time_stamp >= gate->time_stamp)
+        if (gate_ == NULL || ref->time_stamp >= gate_->time_stamp)
             return false;
         return true;
     }
@@ -200,7 +200,7 @@ struct line_ref_list_t {
     print_list()
     {
         std::cerr << "Reuse tag list:\n";
-        for (line_ref_t *node = head; node != NULL; node = node->next) {
+        for (line_ref_t *node = head_; node != NULL; node = node->next) {
             std::cerr << "\tTag 0x" << std::hex << node->tag;
             if (node->depth != -1) {
                 std::cerr << " depth=" << std::dec << node->depth << " prev=" << std::hex
@@ -230,41 +230,41 @@ struct line_ref_list_t {
     }
 
     // Add a new cache line to the front of the list.
-    // We may need to move gate forward if there are more cache lines
-    // than the threshold so that the gate points to the earliest
-    // referenced cache line within the threshold.
+    // We may need to move gate_ forward if there are more cache lines
+    // than the threshold_ so that the gate_ points to the earliest
+    // referenced cache line within the threshold_.
     void
     add_to_front(line_ref_t *ref)
     {
         if (DEBUG_VERBOSE(3))
             std::cerr << "Add tag 0x" << std::hex << ref->tag << "\n";
-        // update head
-        ref->next = head;
-        if (head != NULL)
-            head->prev = ref;
-        head = ref;
-        if (gate == NULL)
-            gate = head;
-        // move gate forward if necessary
-        if (unique_lines > threshold)
-            gate = gate->prev;
-        unique_lines++;
-        head->time_stamp = cur_time++;
+        // update head_
+        ref->next = head_;
+        if (head_ != NULL)
+            head_->prev = ref;
+        head_ = ref;
+        if (gate_ == NULL)
+            gate_ = head_;
+        // move gate_ forward if necessary
+        if (unique_lines_ > threshold_)
+            gate_ = gate_->prev;
+        unique_lines_++;
+        head_->time_stamp = cur_time_++;
 
         // Add a new skip node if necessary.
-        // We don't bother keeping one right at the front: too much overhead.
+        // We don't bother keeping one right at the front: too much overhead_.
         uint64_t count = 0;
         line_ref_t *node, *skip = NULL;
-        for (node = head; node != NULL && node->depth == -1; node = node->next) {
+        for (node = head_; node != NULL && node->depth == -1; node = node->next) {
             ++count;
-            if (count == skip_distance)
+            if (count == skip_distance_)
                 skip = node;
         }
-        if (count >= 2 * skip_distance - 1) {
+        if (count >= 2 * skip_distance_ - 1) {
             assert(skip != NULL);
             if (DEBUG_VERBOSE(3))
                 std::cerr << "New skip node for tag 0x" << std::hex << skip->tag << "\n";
-            skip->depth = skip_distance - 1;
+            skip->depth = skip_distance_ - 1;
             if (node != NULL) {
                 assert(node->prev_skip == NULL);
                 node->prev_skip = skip;
@@ -280,8 +280,8 @@ struct line_ref_list_t {
     }
 
     // Move a referenced cache line to the front of the list.
-    // We need to move the gate pointer forward if the referenced cache
-    // line is the gate cache line or any cache line after.
+    // We need to move the gate_ pointer forward if the referenced cache
+    // line is the gate_ cache line or any cache line after.
     // Returns the reuse distance of ref.
     int_least64_t
     move_to_front(line_ref_t *ref)
@@ -292,14 +292,14 @@ struct line_ref_list_t {
         line_ref_t *next;
 
         ref->total_refs++;
-        if (ref == head)
+        if (ref == head_)
             return 0;
         if (ref_is_distant(ref)) {
             ref->distant_refs++;
-            gate = gate->prev;
-        } else if (ref == gate) {
-            // move gate if ref is the gate.
-            gate = gate->prev;
+            gate_ = gate_->prev;
+        } else if (ref == gate_) {
+            // move gate_ if ref is the gate_.
+            gate_ = gate_->prev;
         }
 
         // Compute reuse distance.
@@ -312,12 +312,12 @@ struct line_ref_list_t {
         else
             --dist; // Don't count self.
 
-        if (DEBUG_VERBOSE(0) && verify_skip) {
+        if (DEBUG_VERBOSE(0) && verify_skip_) {
             // Compute reuse distance with a full list walk as a sanity check.
             // This is a debug-only option, so we guard with DEBUG_VERBOSE(0).
-            // Yes, the option check branch shows noticeable overhead without it.
+            // Yes, the option check branch shows noticeable overhead_ without it.
             int_least64_t brute_dist = 0;
-            for (prev = head; prev != ref; prev = prev->next)
+            for (prev = head_; prev != ref; prev = prev->next)
                 ++brute_dist;
             if (brute_dist != dist) {
                 std::cerr << "Mismatch!  Brute=" << brute_dist << " vs skip=" << dist
@@ -327,7 +327,7 @@ struct line_ref_list_t {
             }
         }
 
-        // Shift skip nodes between where ref was and head one earlier to
+        // Shift skip nodes between where ref was and head_ one earlier to
         // maintain spacing.  This means their depths remain the same.
         if (skip != NULL) {
             for (; skip != NULL; skip = next) {
@@ -347,10 +347,10 @@ struct line_ref_list_t {
             next->prev = prev;
         // move ref to the front
         ref->prev = NULL;
-        ref->next = head;
-        head->prev = ref;
-        head = ref;
-        head->time_stamp = cur_time++;
+        ref->next = head_;
+        head_->prev = ref;
+        head_ = ref;
+        head_->time_stamp = cur_time_++;
 
         if (DEBUG_VERBOSE(3))
             print_list();

--- a/clients/drcachesim/tools/reuse_distance.h
+++ b/clients/drcachesim/tools/reuse_distance.h
@@ -231,8 +231,8 @@ struct line_ref_list_t {
 
     // Add a new cache line to the front of the list.
     // We may need to move gate_ forward if there are more cache lines
-    // than the threshold_ so that the gate_ points to the earliest
-    // referenced cache line within the threshold_.
+    // than the threshold so that the gate points to the earliest
+    // referenced cache line within the threshold.
     void
     add_to_front(line_ref_t *ref)
     {
@@ -315,7 +315,7 @@ struct line_ref_list_t {
         if (DEBUG_VERBOSE(0) && verify_skip_) {
             // Compute reuse distance with a full list walk as a sanity check.
             // This is a debug-only option, so we guard with DEBUG_VERBOSE(0).
-            // Yes, the option check branch shows noticeable overhead_ without it.
+            // Yes, the option check branch shows noticeable overhead without it.
             int_least64_t brute_dist = 0;
             for (prev = head_; prev != ref; prev = prev->next)
                 ++brute_dist;
@@ -327,7 +327,7 @@ struct line_ref_list_t {
             }
         }
 
-        // Shift skip nodes between where ref was and head_ one earlier to
+        // Shift skip nodes between where ref was and head one earlier to
         // maintain spacing.  This means their depths remain the same.
         if (skip != NULL) {
             for (; skip != NULL; skip = next) {

--- a/clients/drcachesim/tools/reuse_time.h
+++ b/clients/drcachesim/tools/reuse_time.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -73,17 +73,17 @@ protected:
     void
     print_shard_results(const shard_data_t *shard);
 
-    const unsigned int knob_verbose;
-    const unsigned int knob_line_size;
-    const unsigned int line_size_bits;
+    const unsigned int knob_verbose_;
+    const unsigned int knob_line_size_;
+    const unsigned int line_size_bits_;
 
     static const std::string TOOL_NAME;
 
     // In parallel operation the keys are "shard indices": just ints.
-    std::unordered_map<memref_tid_t, shard_data_t *> shard_map;
+    std::unordered_map<memref_tid_t, shard_data_t *> shard_map_;
     // This mutex is only needed in parallel_shard_init.  In all other accesses to
     // shard_map (process_memref, print_results) we are single-threaded.
-    std::mutex shard_map_mutex;
+    std::mutex shard_map_mutex_;
 };
 
 #endif /* _REUSE_TIME_H_ */

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -55,18 +55,18 @@ public:
     print_results() override;
 
 protected:
-    void *dcontext;
-    std::string module_file_path;
-    std::unique_ptr<module_mapper_t> module_mapper;
-    raw2trace_directory_t directory;
-    unsigned int knob_verbose;
-    uint64_t instr_count;
+    void *dcontext_;
+    std::string module_file_path_;
+    std::unique_ptr<module_mapper_t> module_mapper_;
+    raw2trace_directory_t directory_;
+    unsigned int knob_verbose_;
+    uint64_t instr_count_;
     static const std::string TOOL_NAME;
-    uint64_t knob_skip_refs;
-    uint64_t knob_sim_refs;
-    std::string knob_syntax;
-    uint64_t num_disasm_instrs;
-    std::unordered_map<app_pc, std::string> disasm_cache;
+    uint64_t knob_skip_refs_;
+    uint64_t knob_sim_refs_;
+    std::string knob_syntax_;
+    uint64_t num_disasm_instrs_;
+    std::unordered_map<app_pc, std::string> disasm_cache_;
 };
 
 #endif /* _VIEW_H_ */

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -57,13 +57,13 @@ public:
     // to insert code to re-load the current trace buffer pointer into a register.
     // We require that this is passed at construction time:
     instru_t(void (*insert_load_buf)(void *, instrlist_t *, instr_t *, reg_id_t),
-             bool memref_needs_info, drvector_t *reg_vector_in, size_t instruction_size,
+             bool memref_needs_info, drvector_t *reg_vector, size_t instruction_size,
              bool disable_opts = false)
-        : insert_load_buf_ptr(insert_load_buf)
-        , memref_needs_full_info(memref_needs_info)
-        , reg_vector(reg_vector_in)
-        , disable_optimizations(disable_opts)
-        , instr_size(instruction_size)
+        : insert_load_buf_ptr_(insert_load_buf)
+        , memref_needs_full_info_(memref_needs_info)
+        , reg_vector_(reg_vector)
+        , disable_optimizations_(disable_opts)
+        , instr_size_(instruction_size)
     {
     }
     virtual ~instru_t()
@@ -76,7 +76,7 @@ public:
     size_t
     sizeof_entry() const
     {
-        return instr_size;
+        return instr_size_;
     }
 
     virtual trace_type_t
@@ -140,20 +140,20 @@ public:
                        OUT bool *scratch_used = NULL);
 
 protected:
-    void (*insert_load_buf_ptr)(void *, instrlist_t *, instr_t *, reg_id_t);
+    void (*insert_load_buf_ptr_)(void *, instrlist_t *, instr_t *, reg_id_t);
     // Whether each data ref needs its own PC and type entry (i.e.,
     // this info cannot be inferred from surrounding icache entries).
-    bool memref_needs_full_info;
-    drvector_t *reg_vector;
-    bool disable_optimizations;
+    bool memref_needs_full_info_;
+    drvector_t *reg_vector_;
+    bool disable_optimizations_;
 
 private:
     instru_t()
-        : instr_size(0)
+        : instr_size_(0)
     {
     }
 
-    const size_t instr_size;
+    const size_t instr_size_;
 };
 
 class online_instru_t : public instru_t {
@@ -316,8 +316,8 @@ private:
     insert_save_type_and_size(void *drcontext, instrlist_t *ilist, instr_t *where,
                               reg_id_t reg_ptr, reg_id_t scratch, int adjust,
                               instr_t *app, opnd_t ref, bool write);
-    ssize_t (*write_file_func)(file_t file, const void *data, size_t count);
-    file_t modfile;
+    ssize_t (*write_file_func_)(file_t file, const void *data, size_t count);
+    file_t modfile_;
 
     void
     opnd_check_elidable(void *drcontext, instrlist_t *ilist, instr_t *instr, opnd_t memop,
@@ -326,9 +326,9 @@ private:
 
     // Custom module fields are global (since drmodtrack's support is global, we don't
     // try to pass void* user data params through).
-    static void *(*user_load)(module_data_t *module);
-    static int (*user_print)(void *data, char *dst, size_t max_len);
-    static void (*user_free)(void *data);
+    static void *(*user_load_)(module_data_t *module);
+    static int (*user_print_)(void *data, char *dst, size_t max_len);
+    static void (*user_free_)(void *data);
     static void *
     load_custom_module_data(module_data_t *module);
     static int
@@ -341,8 +341,8 @@ private:
     static CONSTEXPR int LABEL_DATA_ELIDED_MEMOP_INDEX = 1; // Index among memory ops.
     static CONSTEXPR int LABEL_DATA_ELIDED_IS_WRITE = 2;
     static CONSTEXPR int LABEL_DATA_ELIDED_NEEDS_BASE = 3;
-    ptr_uint_t elide_memref_note;
-    bool standalone = false;
+    ptr_uint_t elide_memref_note_;
+    bool standalone_ = false;
 };
 
 #endif /* _INSTRU_H_ */

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -58,7 +58,7 @@ offline_instru_t::offline_instru_t()
     , write_file_func_(nullptr)
     , modfile_(INVALID_FILE)
 {
-    // We can't use drmgr in standalone_ mode, but for post-processing it's just us,
+    // We can't use drmgr in standalone mode, but for post-processing it's just us,
     // so we just pick a note value.
     elide_memref_note_ = 1;
     standalone_ = true;

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -47,21 +47,21 @@
 
 static const ptr_uint_t MAX_INSTR_COUNT = 64 * 1024;
 
-void *(*offline_instru_t::user_load)(module_data_t *module);
-int (*offline_instru_t::user_print)(void *data, char *dst, size_t max_len);
-void (*offline_instru_t::user_free)(void *data);
+void *(*offline_instru_t::user_load_)(module_data_t *module);
+int (*offline_instru_t::user_print_)(void *data, char *dst, size_t max_len);
+void (*offline_instru_t::user_free_)(void *data);
 
 // This constructor is for use in post-processing when we just need the
 // elision utility functions.
 offline_instru_t::offline_instru_t()
     : instru_t(nullptr, false, nullptr, sizeof(offline_entry_t))
-    , write_file_func(nullptr)
-    , modfile(INVALID_FILE)
+    , write_file_func_(nullptr)
+    , modfile_(INVALID_FILE)
 {
-    // We can't use drmgr in standalone mode, but for post-processing it's just us,
+    // We can't use drmgr in standalone_ mode, but for post-processing it's just us,
     // so we just pick a note value.
-    elide_memref_note = 1;
-    standalone = true;
+    elide_memref_note_ = 1;
+    standalone_ = true;
 }
 
 offline_instru_t::offline_instru_t(void (*insert_load_buf)(void *, instrlist_t *,
@@ -72,8 +72,8 @@ offline_instru_t::offline_instru_t(void (*insert_load_buf)(void *, instrlist_t *
                                    file_t module_file, bool disable_optimizations)
     : instru_t(insert_load_buf, memref_needs_info, reg_vector, sizeof(offline_entry_t),
                disable_optimizations)
-    , write_file_func(write_file)
-    , modfile(module_file)
+    , write_file_func_(write_file)
+    , modfile_(module_file)
 {
     drcovlib_status_t res = drmodtrack_init();
     DR_ASSERT(res == DRCOVLIB_SUCCESS);
@@ -87,13 +87,13 @@ offline_instru_t::offline_instru_t(void (*insert_load_buf)(void *, instrlist_t *
 
     if (!drmgr_init())
         DR_ASSERT(false);
-    elide_memref_note = drmgr_reserve_note_range(1);
-    DR_ASSERT(elide_memref_note != DRMGR_NOTE_NONE);
+    elide_memref_note_ = drmgr_reserve_note_range(1);
+    DR_ASSERT(elide_memref_note_ != DRMGR_NOTE_NONE);
 }
 
 offline_instru_t::~offline_instru_t()
 {
-    if (standalone)
+    if (standalone_)
         return;
     drcovlib_status_t res;
     size_t size = 8192;
@@ -103,7 +103,7 @@ offline_instru_t::~offline_instru_t()
         buf = (char *)dr_global_alloc(size);
         res = drmodtrack_dump_buf(buf, size, &wrote);
         if (res == DRCOVLIB_SUCCESS) {
-            ssize_t written = write_file_func(modfile, buf, wrote - 1 /*no null*/);
+            ssize_t written = write_file_func_(modfile_, buf, wrote - 1 /*no null*/);
             DR_ASSERT(written == (ssize_t)wrote - 1);
         }
         dr_global_free(buf, size);
@@ -118,8 +118,8 @@ void *
 offline_instru_t::load_custom_module_data(module_data_t *module)
 {
     void *user_data = nullptr;
-    if (user_load != nullptr)
-        user_data = (*user_load)(module);
+    if (user_load_ != nullptr)
+        user_data = (*user_load_)(module);
     const char *name = dr_module_preferred_name(module);
     // For vdso we include the entire contents so we can decode it during
     // post-processing.
@@ -159,8 +159,8 @@ offline_instru_t::print_custom_module_data(void *data, char *dst, size_t max_len
         memcpy(cur, custom->base, custom->size);
         cur += custom->size;
     }
-    if (user_print != nullptr) {
-        int res = (*user_print)(custom->user_data, cur, max_len - (cur - dst));
+    if (user_print_ != nullptr) {
+        int res = (*user_print_)(custom->user_data, cur, max_len - (cur - dst));
         if (res == -1)
             return -1;
         cur += res;
@@ -174,8 +174,8 @@ offline_instru_t::free_custom_module_data(void *data)
     custom_module_data_t *custom = (custom_module_data_t *)data;
     if (custom == nullptr)
         return;
-    if (user_free != nullptr)
-        (*user_free)(custom->user_data);
+    if (user_free_ != nullptr)
+        (*user_free_)(custom->user_data);
     custom->~custom_module_data_t();
     dr_global_free(custom, sizeof(*custom));
 }
@@ -186,9 +186,9 @@ offline_instru_t::custom_module_data(void *(*load_cb)(module_data_t *module),
                                                      size_t max_len),
                                      void (*free_cb)(void *data))
 {
-    user_load = load_cb;
-    user_print = print_cb;
-    user_free = free_cb;
+    user_load_ = load_cb;
+    user_print_ = print_cb;
+    user_free_ = free_cb;
     return true;
 }
 
@@ -426,7 +426,7 @@ offline_instru_t::insert_save_type_and_size(void *drcontext, instrlist_t *ilist,
 bool
 offline_instru_t::opnd_disp_is_elidable(opnd_t memop)
 {
-    return !disable_optimizations && opnd_is_near_base_disp(memop) &&
+    return !disable_optimizations_ && opnd_is_near_base_disp(memop) &&
         opnd_get_base(memop) != DR_REG_NULL &&
         opnd_get_index(memop) == DR_REG_NULL
 #ifdef AARCH64
@@ -462,7 +462,7 @@ offline_instru_t::insert_save_addr(void *drcontext, instrlist_t *ilist, instr_t 
             have_addr = true;
     }
     if (!have_addr) {
-        res = drreg_reserve_register(drcontext, ilist, where, reg_vector, &reg_addr);
+        res = drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_addr);
         DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
         reserved = true;
         bool reg_ptr_used;
@@ -470,7 +470,7 @@ offline_instru_t::insert_save_addr(void *drcontext, instrlist_t *ilist, instr_t 
                            &reg_ptr_used);
         if (reg_ptr_used) {
             // Re-load because reg_ptr was clobbered.
-            insert_load_buf_ptr(drcontext, ilist, where, reg_ptr);
+            insert_load_buf_ptr_(drcontext, ilist, where, reg_ptr);
         }
         reserved = true;
     }
@@ -534,14 +534,14 @@ offline_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t
         }
     }
     // Post-processor distinguishes read, write, prefetch, flush, and finds size.
-    if (!memref_needs_full_info) // For full info we skip this for !pred
+    if (!memref_needs_full_info_) // For full info we skip this for !pred
         instrlist_set_auto_predicate(ilist, pred);
     // We allow either 0 or all 1's as the type so no need to write anything else,
     // unless a filter is in place in which case we need a PC entry.
-    if (memref_needs_full_info) {
+    if (memref_needs_full_info_) {
         reg_id_t reg_tmp;
         drreg_status_t res =
-            drreg_reserve_register(drcontext, ilist, where, reg_vector, &reg_tmp);
+            drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_tmp);
         DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
         adjust += insert_save_pc(drcontext, ilist, where, reg_ptr, reg_tmp, adjust,
                                  instr_get_app_pc(app), 0);
@@ -569,7 +569,7 @@ offline_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
 {
     app_pc pc;
     reg_id_t reg_tmp;
-    if (!memref_needs_full_info) {
+    if (!memref_needs_full_info_) {
         // We write just once per bb, if not filtering.
         if ((ptr_uint_t)*bb_field > MAX_INSTR_COUNT)
             return adjust;
@@ -579,11 +579,11 @@ offline_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
         pc = instr_get_app_pc(app);
     }
     drreg_status_t res =
-        drreg_reserve_register(drcontext, ilist, where, reg_vector, &reg_tmp);
+        drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_tmp);
     DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
     adjust += insert_save_pc(drcontext, ilist, where, reg_ptr, reg_tmp, adjust, pc,
-                             memref_needs_full_info ? 1 : (uint)(ptr_uint_t)*bb_field);
-    if (!memref_needs_full_info)
+                             memref_needs_full_info_ ? 1 : (uint)(ptr_uint_t)*bb_field);
+    if (!memref_needs_full_info_)
         *(ptr_uint_t *)bb_field = MAX_INSTR_COUNT + 1;
     res = drreg_unreserve_register(drcontext, ilist, where, reg_tmp);
     DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
@@ -676,7 +676,7 @@ offline_instru_t::opnd_check_elidable(void *drcontext, instrlist_t *ilist, instr
     // we find a base that has not changed or a rip-relative operand.
     if (base == DR_REG_NULL || saw_base.find(base) != saw_base.end()) {
         instr_t *note = INSTR_CREATE_label(drcontext);
-        instr_set_note(note, (void *)elide_memref_note);
+        instr_set_note(note, (void *)elide_memref_note_);
         dr_instr_label_data_t *data = instr_get_label_data_area(note);
         data->data[LABEL_DATA_ELIDED_INDEX] = op_index;
         data->data[LABEL_DATA_ELIDED_MEMOP_INDEX] = memop_index;
@@ -694,7 +694,7 @@ offline_instru_t::label_marks_elidable(instr_t *instr, OUT int *opnd_index,
 {
     if (!instr_is_label(instr))
         return false;
-    if (instr_get_note(instr) != (void *)elide_memref_note)
+    if (instr_get_note(instr) != (void *)elide_memref_note_)
         return false;
     dr_instr_label_data_t *data = instr_get_label_data_area(instr);
     if (opnd_index != nullptr)
@@ -715,10 +715,10 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
 {
     // Analysis for eliding redundant addresses we can reconstruct during
     // post-processing.
-    if (disable_optimizations)
+    if (disable_optimizations_)
         return;
     // We can't elide when doing filtering.
-    if (memref_needs_full_info)
+    if (memref_needs_full_info_)
         return;
     reg_id_set_t saw_base;
     for (instr_t *instr = instrlist_first_app(ilist); instr != NULL;

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -192,7 +192,7 @@ online_instru_t::insert_save_addr(void *drcontext, instrlist_t *ilist, instr_t *
     insert_obtain_addr(drcontext, ilist, where, reg_addr, reg_ptr, ref, &reg_ptr_used);
     if (reg_ptr_used) {
         // drutil_insert_get_mem_addr clobbered reg_ptr, so we need to reload reg_ptr.
-        insert_load_buf_ptr(drcontext, ilist, where, reg_ptr);
+        insert_load_buf_ptr_(drcontext, ilist, where, reg_ptr);
     }
     MINSERT(ilist, where,
             XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(reg_ptr, disp),
@@ -268,11 +268,11 @@ online_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t 
     ushort size = (ushort)drutil_opnd_mem_size_in_bytes(ref, app);
     reg_id_t reg_tmp;
     drreg_status_t res =
-        drreg_reserve_register(drcontext, ilist, where, reg_vector, &reg_tmp);
+        drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_tmp);
     DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
-    if (!memref_needs_full_info)     // For full info we skip this for !pred
+    if (!memref_needs_full_info_)    // For full info we skip this for !pred
         instrlist_set_auto_predicate(ilist, pred);
-    if (memref_needs_full_info) {
+    if (memref_needs_full_info_) {
         // When filtering we have to insert a PC entry for every memref.
         // The 0 size indicates it's a non-icache entry.
         insert_save_type_and_size(drcontext, ilist, where, reg_ptr, reg_tmp,
@@ -310,7 +310,7 @@ online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
     app_pc pc = repstr_expanded ? dr_fragment_app_pc(tag) : instr_get_app_pc(app);
     reg_id_t reg_tmp;
     drreg_status_t res =
-        drreg_reserve_register(drcontext, ilist, where, reg_vector, &reg_tmp);
+        drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_tmp);
     DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
     // To handle zero-iter repstr loops this routine is called at the top of the bb
     // where "app" is jecxz so we have to hardcode the rep str type and get length
@@ -338,7 +338,7 @@ online_instru_t::instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t
     int i;
     reg_id_t reg_tmp;
     drreg_status_t res =
-        drreg_reserve_register(drcontext, ilist, where, reg_vector, &reg_tmp);
+        drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_tmp);
     DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
     entry.type = TRACE_TYPE_INSTR_BUNDLE;
     entry.size = 0;

--- a/clients/drcachesim/tracer/physaddr.h
+++ b/clients/drcachesim/tracer/physaddr.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -51,11 +51,11 @@ public:
 private:
     // Assumed to be single-threaded
 #ifdef LINUX
-    addr_t last_vpage;
-    addr_t last_ppage;
-    int fd;
-    std::unordered_map<addr_t, addr_t> v2p;
-    unsigned int count;
+    addr_t last_vpage_;
+    addr_t last_ppage_;
+    int fd_;
+    std::unordered_map<addr_t, addr_t> v2p_;
+    unsigned int count_;
 #endif
 };
 

--- a/clients/drcachesim/tracer/raw2trace_directory.h
+++ b/clients/drcachesim/tracer/raw2trace_directory.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -41,12 +41,12 @@
 
 class raw2trace_directory_t {
 public:
-    raw2trace_directory_t(unsigned int verbosity_in = 0)
-        : modfile_bytes(nullptr)
-        , modfile(INVALID_FILE)
-        , indir("")
-        , outdir("")
-        , verbosity(verbosity_in)
+    raw2trace_directory_t(unsigned int verbosity = 0)
+        : modfile_bytes_(nullptr)
+        , modfile_(INVALID_FILE)
+        , indir_("")
+        , outdir_("")
+        , verbosity_(verbosity)
     {
     }
     ~raw2trace_directory_t();
@@ -64,9 +64,9 @@ public:
     static std::string
     tracedir_from_rawdir(const std::string &rawdir);
 
-    char *modfile_bytes;
-    std::vector<std::istream *> in_files;
-    std::vector<std::ostream *> out_files;
+    char *modfile_bytes_;
+    std::vector<std::istream *> in_files_;
+    std::vector<std::ostream *> out_files_;
 
 private:
     std::string
@@ -75,10 +75,10 @@ private:
     open_thread_files();
     std::string
     open_thread_log_file(const char *basename);
-    file_t modfile;
-    std::string indir;
-    std::string outdir;
-    unsigned int verbosity;
+    file_t modfile_;
+    std::string indir_;
+    std::string outdir_;
+    unsigned int verbosity_;
 };
 
 #endif /* _RAW2TRACE_DIRECTORY_H_ */

--- a/clients/drcachesim/tracer/raw2trace_launcher.cpp
+++ b/clients/drcachesim/tracer/raw2trace_launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -93,7 +93,7 @@ _tmain(int argc, const TCHAR *targv[])
     std::string dir_err = dir.initialize(op_indir.get_value(), op_outdir.get_value());
     if (!dir_err.empty())
         FATAL_ERROR("Directory parsing failed: %s", dir_err.c_str());
-    raw2trace_t raw2trace(dir.modfile_bytes, dir.in_files, dir.out_files, NULL,
+    raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_, NULL,
                           op_verbose.get_value(), op_jobs.get_value());
     std::string error = raw2trace.do_conversion();
     if (!error.empty())


### PR DESCRIPTION
Updates all of our C++ code in ext/ and clients/ to use a consistent
style with a trail underscore on field names in a class (or a struct
with more methods than just a constructor).

Does not update suite, drgui, DRstats, or DRinstall.  They are either
using a completely different style or are not worth spending time on
at this stage.

Fixes #4049