### PR TITLE
i#4049: Cleanup: Trailing underscore in parameters

### DIFF
--- a/clients/drcachesim/simulator/cache_miss_analyzer.cpp
+++ b/clients/drcachesim/simulator/cache_miss_analyzer.cpp
@@ -47,11 +47,11 @@ cache_miss_analyzer_create(const cache_simulator_knobs_t &knobs,
                                      confidence_threshold);
 }
 
-cache_miss_stats_t::cache_miss_stats_t(bool warmup_enabled_, unsigned int line_size,
+cache_miss_stats_t::cache_miss_stats_t(bool warmup_enabled, unsigned int line_size,
                                        unsigned int miss_count_threshold,
                                        double miss_frac_threshold,
                                        double confidence_threshold)
-    : cache_stats_t("", warmup_enabled_, false)
+    : cache_stats_t("", warmup_enabled, false)
     , kLineSize(line_size)
     , kMissCountThreshold(miss_count_threshold)
     , kMissFracThreshold(miss_frac_threshold)

--- a/clients/drcachesim/simulator/cache_stats.cpp
+++ b/clients/drcachesim/simulator/cache_stats.cpp
@@ -34,9 +34,9 @@
 #include <iomanip>
 #include "cache_stats.h"
 
-cache_stats_t::cache_stats_t(const std::string &miss_file, bool warmup_enabled_,
-                             bool is_coherent_)
-    : caching_device_stats_t(miss_file, warmup_enabled_, is_coherent_)
+cache_stats_t::cache_stats_t(const std::string &miss_file, bool warmup_enabled,
+                             bool is_coherent)
+    : caching_device_stats_t(miss_file, warmup_enabled, is_coherent)
     , num_flushes_(0)
     , num_prefetch_hits_(0)
     , num_prefetch_misses_(0)

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -269,7 +269,7 @@ caching_device_t::replace_which_way(int block_idx)
 }
 
 void
-caching_device_t::invalidate(addr_t tag, invalidation_type_t invalidation_type_)
+caching_device_t::invalidate(addr_t tag, invalidation_type_t invalidation_type)
 {
     int block_idx = compute_block_idx(tag);
 
@@ -278,25 +278,25 @@ caching_device_t::invalidate(addr_t tag, invalidation_type_t invalidation_type_)
         if (cache_block.tag_ == tag) {
             cache_block.tag_ = TAG_INVALID;
             cache_block.counter_ = 0;
-            stats_->invalidate(invalidation_type_);
+            stats_->invalidate(invalidation_type);
             // Invalidate last_tag_ if it was this tag.
             if (last_tag_ == tag) {
                 last_tag_ = TAG_INVALID;
             }
             // Invalidate the block in the children's caches.
-            if (invalidation_type_ == INVALIDATION_INCLUSIVE && inclusive_ &&
+            if (invalidation_type == INVALIDATION_INCLUSIVE && inclusive_ &&
                 !children_.empty()) {
                 for (auto &child : children_) {
-                    child->invalidate(tag, invalidation_type_);
+                    child->invalidate(tag, invalidation_type);
                 }
             }
             break;
         }
     }
     // If this is a coherence invalidation, we must invalidate children caches.
-    if (invalidation_type_ == INVALIDATION_COHERENCE && !children_.empty()) {
+    if (invalidation_type == INVALIDATION_COHERENCE && !children_.empty()) {
         for (auto &child : children_) {
-            child->invalidate(tag, invalidation_type_);
+            child->invalidate(tag, invalidation_type);
         }
     }
 }

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -289,10 +289,10 @@ public:
 
 private:
     struct custom_module_data_t {
-        custom_module_data_t(const char *base_, size_t size_, void *user_)
-            : base(base_)
-            , size(size_)
-            , user_data(user_)
+        custom_module_data_t(const char *base_in, size_t size_in, void *user_in)
+            : base(base_in)
+            , size(size_in)
+            , user_data(user_in)
         {
         }
         const char *base;


### PR DESCRIPTION
This removes some underscores from 5ed1a118e that were placed where we
do not want them: in function parameters.

Issue: #4049