### PR TITLE
i#4086: Fix inline asm warning

### DIFF
--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -998,7 +998,10 @@ privload_call_lib_func(fp_t func)
                          :
                          : [env] "g"(our_environ), [argv] "g"(&dummy_argv[0]),
                            [callee] "g"(func)
-                         : "edi", "esp", "memory");
+                         /* We do *not* list "esp" because doing so is disallowed
+                          * (i#4086).  We do restore esp so we're fine.
+                          */
+                         : "edi", "memory");
 #endif
 }
 


### PR DESCRIPTION
Listing "esp" in an inline asm clobber list is now deprecated.  The
asm block in question does restore esp, so we are fine just removing
the entry.

Fixes #4086