### PR TITLE
i#2861: Build cronbuilds as official packages

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -63,6 +63,10 @@ build:
 configuration:
   - 2017
 
+# TEMPORARY to test cron building
+environment:
+  APPVEYOR_REPO_TAG: true
+
 install:
   ##################################################
   # Install ninja so we have readable output.
@@ -105,8 +109,8 @@ build_script:
 # Automated deployment of builds to GitHub Releases.
 # We rely on a Travis cron job to push a tag to the repo which then
 # triggers this deployment.
-# We disable test running for these package builds in runsuite.cmake by
-# looking for $APPVEYOR_REPO_TAG=="true".
+# We switch to package.cmake for these builds in runsuite_wrapper.pl by looking
+# for $APPVEYOR_REPO_TAG=="true".
 artifacts:
   - path: 'DynamoRIO*.zip'
     name: DR.zip
@@ -128,6 +132,6 @@ deploy:
   # Using the default "release:" name (the tag) to match Travis.
   # This description replaces the one provided by Travis.
   description: 'Auto-generated periodic build (Appveyor build $(appveyor_build_version)).  Unlike official release builds, Dr. Memory is not included in this build, and for Linux, i686 is separated from x86_64 rather than being combined in one package.'
-  on:
-    branch: master
-    appveyor_repo_tag: true
+#TEMPORARY  on:
+#TEMPORARY    branch: master
+#TEMPORARY    appveyor_repo_tag: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -63,10 +63,6 @@ build:
 configuration:
   - 2017
 
-# TEMPORARY to test cron building
-environment:
-  APPVEYOR_REPO_TAG: true
-
 install:
   ##################################################
   # Install ninja so we have readable output.
@@ -122,7 +118,7 @@ build_script:
 # We switch to package.cmake for these builds in runsuite_wrapper.pl by looking
 # for $APPVEYOR_REPO_TAG=="true".
 artifacts:
-  - path: 'DynamoRIO*.zip'
+  - path: 'build\DynamoRIO*.zip'
     name: DR.zip
     type: zip
 deploy:
@@ -137,6 +133,6 @@ deploy:
   # Using the default "release:" name (the tag) to match Travis.
   # This description replaces the one provided by Travis.
   description: 'Auto-generated periodic build (Appveyor build $(appveyor_build_version)).  Unlike official release builds, Dr. Memory is not included in this build, and for Linux, i686 is separated from x86_64 rather than being combined in one package.'
-#TEMPORARY  on:
-#TEMPORARY    branch: master
-#TEMPORARY    appveyor_repo_tag: true
+  on:
+    branch: master
+    appveyor_repo_tag: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -94,6 +94,15 @@ install:
   ##################################################
   # XXX i#2145: point at Qt5 for testing drgui build.
 
+  # Include Dr. Memory in cronbuild packages.
+  - ps: >-
+    If ($env:APPVEYOR_REPO_TAG -Match "true") {
+      git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+      cd drmemory
+      git submodule update --init --depth 2
+      cd ..
+    }
+
 before_build:
   - if "%configuration%"=="2017" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
   - cd c:\projects\dynamorio
@@ -115,11 +124,6 @@ artifacts:
   - path: 'DynamoRIO*.zip'
     name: DR.zip
     type: zip
-before_deploy:
-  - git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-  - cd drmemory
-  - git submodule update --init --depth 2
-  - cd ..
 deploy:
   provider: GitHub
   auth_token:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -95,11 +95,13 @@ install:
   # XXX i#2145: point at Qt5 for testing drgui build.
 
   # Include Dr. Memory in cronbuild packages.
+  # We do shallow clones and assume DrM will update its DR at least once
+  # every 250 DR commits.
   - ps: >-
       If ($env:APPVEYOR_REPO_TAG -Match "true") {
         git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
         cd drmemory
-        git submodule update --init --depth 2
+        git submodule update --init --depth 250
         cd ..
       }
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
+# Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -108,9 +108,14 @@ build_script:
 # We disable test running for these package builds in runsuite.cmake by
 # looking for $APPVEYOR_REPO_TAG=="true".
 artifacts:
-  - path: 'build\build_*\DynamoRIO*.zip'
+  - path: 'DynamoRIO*.zip'
     name: DR.zip
     type: zip
+before_deploy:
+  - git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+  - cd drmemory
+  - git submodule update --init --depth 2
+  - cd ..
 deploy:
   provider: GitHub
   auth_token:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -96,12 +96,12 @@ install:
 
   # Include Dr. Memory in cronbuild packages.
   - ps: >-
-    If ($env:APPVEYOR_REPO_TAG -Match "true") {
-      git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-      cd drmemory
-      git submodule update --init --depth 2
-      cd ..
-    }
+      If ($env:APPVEYOR_REPO_TAG -Match "true") {
+        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+        cd drmemory
+        git submodule update --init --depth 2
+        cd ..
+      }
 
 before_build:
   - if "%configuration%"=="2017" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
@@ -112,8 +112,7 @@ build_script:
   - cd build
   - echo %PATH%
   # The perl in c:\perl can't open a pipe so we use cygwin perl.
-  # XXX i#1967: can we pass "package" only when deploying to save time?
-  - c:\cygwin\bin\perl ../suite/runsuite_wrapper.pl travis use_ninja package %EXTRA_ARGS%
+  - c:\cygwin\bin\perl ../suite/runsuite_wrapper.pl travis use_ninja %EXTRA_ARGS%
 
 # Automated deployment of builds to GitHub Releases.
 # We rely on a Travis cron job to push a tag to the repo which then

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,6 +157,11 @@ install:
           ln -sf arm-linux-androideabi-ld.bfd /tmp/android-gcc-arm-ndk-10e/bin/arm-linux-androideabi-ld
           cd -
       fi
+  - >
+      if [[ "`uname`" == "Linux" && $TRAVIS_EVENT_TYPE == cron ]]; then
+          git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+          cd drmemory && git submodule update --init --depth 2 && cd ..
+      fi
 
 script:
   - suite/runsuite_wrapper.pl travis $EXTRA_ARGS
@@ -169,8 +174,6 @@ script:
 before_deploy:
   - git config --local user.name "Travis Auto-Tag"
   - git config --local user.email "dynamorio-devs@googlegroups.com"
-  - git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-  - cd drmemory && git submodule update --init --depth 2 && cd ..
   # XXX: for now we duplicate this version number here with CMakeLists.txt.
   # We should find a way to share (xref i#1565).
   # We support setting TAG_SUFFIX on triggered builds so we can have

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,12 +50,6 @@ dist: xenial
 language:
   - c
 
-# TEMPORARY to test cron builds.
-env:
-  global:
-    - TRAVIS_EVENT_TYPE=cron
-    - TAG_SUFFIX=A
-
 # We use a jobs include approach rather than an os, compiler, env matrix
 # with excludes so we can use conditional builds (plus it's clearer this way).
 jobs:
@@ -178,8 +172,8 @@ before_deploy:
   # We should find a way to share (xref i#1565).
   # We support setting TAG_SUFFIX on triggered builds so we can have
   # multiple unique tags in one day (the patchlevel here is the day number).
-#TEMPORARY  - export GIT_TAG="cronbuild-7.91.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
-#TEMPORARY  - git tag $GIT_TAG -a -m "Travis auto-generated tag for build $TRAVIS_BUILD_NUMBER."
+  - export GIT_TAG="cronbuild-7.91.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
+  - git tag $GIT_TAG -a -m "Travis auto-generated tag for build $TRAVIS_BUILD_NUMBER."
 deploy:
   provider: releases
   api_key:
@@ -188,11 +182,10 @@ deploy:
   file: "DynamoRIO*.tar.gz"
   skip_cleanup: true
   # The name must just be the tag in order to match Appveyor.
-  name: isolated_test #TEMPORARY
-#TEMPORARY  name: $GIT_TAG
+  name: $GIT_TAG
   # This body is clobbered by Appveyor.
   body: "Auto-generated periodic build (Travis build $TRAVIS_BUILD_NUMBER)."
   on:
     repo: DynamoRIO/dynamorio
-#TEMPORARY    branch: master
+    branch: master
     condition: $TRAVIS_EVENT_TYPE = cron && $DEPLOY = yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,12 @@ dist: xenial
 language:
   - c
 
+# TEMPORARY to test cron builds.
+env:
+  global:
+    - TRAVIS_EVENT_TYPE=cron
+    - TAG_SUFFIX=A
+
 # We use a jobs include approach rather than an os, compiler, env matrix
 # with excludes so we can use conditional builds (plus it's clearer this way).
 jobs:
@@ -156,8 +162,8 @@ script:
   - suite/runsuite_wrapper.pl travis $EXTRA_ARGS
 
 # For now we create packages as part of each (enabled) job.
-# We disable test running for these package builds in runsuite.cmake by
-# looking for $TRAVIS_EVENT_TYPE=="cron".
+# We switch to package.cmake for these builds in runsuite_wrapper.pl by looking
+# for $TRAVIS_EVENT_TYPE=="cron".
 # Longer-term we may want to use package.cmake instead and even make official
 # builds on Travis (i#2861).
 before_deploy:
@@ -169,8 +175,8 @@ before_deploy:
   # We should find a way to share (xref i#1565).
   # We support setting TAG_SUFFIX on triggered builds so we can have
   # multiple unique tags in one day (the patchlevel here is the day number).
-  - export GIT_TAG="cronbuild-7.91.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
-  - git tag $GIT_TAG -a -m "Travis auto-generated tag for build $TRAVIS_BUILD_NUMBER."
+#TEMPORARY  - export GIT_TAG="cronbuild-7.91.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
+#TEMPORARY  - git tag $GIT_TAG -a -m "Travis auto-generated tag for build $TRAVIS_BUILD_NUMBER."
 deploy:
   provider: releases
   api_key:
@@ -179,10 +185,11 @@ deploy:
   file: "DynamoRIO*.tar.gz"
   skip_cleanup: true
   # The name must just be the tag in order to match Appveyor.
-  name: $GIT_TAG
+  name: isolated_test #TEMPORARY
+#TEMPORARY  name: $GIT_TAG
   # This body is clobbered by Appveyor.
   body: "Auto-generated periodic build (Travis build $TRAVIS_BUILD_NUMBER)."
   on:
     repo: DynamoRIO/dynamorio
-    branch: master
+#TEMPORARY    branch: master
     condition: $TRAVIS_EVENT_TYPE = cron && $DEPLOY = yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+# Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -55,23 +55,28 @@ language:
 jobs:
   include:
     # 32-bit Linux build with gcc and run tests:
-    - os: linux
+    - if: env(TRAVIS_EVENT_TYPE) != cron
+      os: linux
       compiler: gcc
-      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=yes EXTRA_ARGS="32_only package"
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS="32_only"
     # 64-bit Linux build with gcc and run tests:
-    - os: linux
+    - if: env(TRAVIS_EVENT_TYPE) != cron
+      os: linux
       compiler: gcc
-      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=yes EXTRA_ARGS="64_only package"
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS="64_only"
     # AArchXX cross-compile with gcc, no tests:
-    - os: linux
+    - if: env(TRAVIS_EVENT_TYPE) != cron
+      os: linux
       compiler: gcc
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=yes DEPLOY=no
     # Android ARM cross-compile with gcc, no tests:
-    - os: linux
+    - if: env(TRAVIS_EVENT_TYPE) != cron
+      os: linux
       compiler: gcc
       env: DYNAMORIO_CROSS_ANDROID_ONLY=yes DEPLOY=no DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e'
     # 32-bit Linux build with clang, no tests (runsuite.cmake disables the tests):
-    - os: linux
+    - if: env(TRAVIS_EVENT_TYPE) != cron
+      os: linux
       compiler: clang
       # We need clang 9.0 to avoid a compiler bug: i#3989.
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=32_only CC=clang-9 && CXX=clang++-9
@@ -85,7 +90,8 @@ jobs:
           - clang-9
     # 64-bit Linux build with clang, no tests (runsuite.cmake disables the tests),
     # install and require clang-format:
-    - os: linux
+    - if: env(TRAVIS_EVENT_TYPE) != cron
+      os: linux
       compiler: clang
       # We need clang 9.0 to avoid a compiler bug: i#3989.
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS="64_only require_format" CC=clang-9 && CXX=clang++-9
@@ -99,11 +105,18 @@ jobs:
           - clang-9
           - clang-format-6.0
     # 32-bit OSX build with clang and run tests:
-    - os: osx
+    - if: env(TRAVIS_EVENT_TYPE) != cron
+      os: osx
       # gcc on Travis claims to not be CMAKE_COMPILER_IS_GNUCC so we only run clang.
       compiler: clang
       # We do not have 64-bit support on OSX yet (i#1979).
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=32_only
+    # Package builds.
+    - if: env(TRAVIS_EVENT_TYPE) = cron
+      os: linux
+      compiler: gcc
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=yes
+    # TODO i#3002: Build packages for AArchXX.
 
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:
@@ -150,6 +163,8 @@ script:
 before_deploy:
   - git config --local user.name "Travis Auto-Tag"
   - git config --local user.email "dynamorio-devs@googlegroups.com"
+  - git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+  - cd drmemory && git submodule update --init --depth 2 && cd ..
   # XXX: for now we duplicate this version number here with CMakeLists.txt.
   # We should find a way to share (xref i#1565).
   # We support setting TAG_SUFFIX on triggered builds so we can have
@@ -161,12 +176,12 @@ deploy:
   api_key:
     secure: V3kgcRiwijjpmcSuVio1+/oZ8cqJGaVlL42hN0w/jjO6LoELy2kknT5h80H7wMVKpZnMg+2v/yWj5hawlrwh8nCS51lYllPHN7K+ivzkyJ3R4cp1WAzL56vnYFYz1/twYpeS10Zl6JL6wt788WcibpShMOIlAnXnm1kU9BBVtYE=
   file_glob: true
-  file: "build*/DynamoRIO*.tar.gz"
+  file: "DynamoRIO*.tar.gz"
   skip_cleanup: true
   # The name must just be the tag in order to match Appveyor.
   name: $GIT_TAG
   # This body is clobbered by Appveyor.
-  body: "Auto-generated periodic build (Travis build $TRAVIS_BUILD_NUMBER).  Unlike official release builds, Dr. Memory is not included in this build, and i686 is separated from x86_64 rather than combined in one package."
+  body: "Auto-generated periodic build (Travis build $TRAVIS_BUILD_NUMBER)."
   on:
     repo: DynamoRIO/dynamorio
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,10 +151,13 @@ install:
           ln -sf arm-linux-androideabi-ld.bfd /tmp/android-gcc-arm-ndk-10e/bin/arm-linux-androideabi-ld
           cd -
       fi
+  # Include Dr. Memory in cronbuild packages.
+  # We do shallow clones and assume DrM will update its DR at least once
+  # every 250 DR commits.
   - >
       if [[ "`uname`" == "Linux" && $TRAVIS_EVENT_TYPE == cron ]]; then
           git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-          cd drmemory && git submodule update --init --depth 2 && cd ..
+          cd drmemory && git submodule update --init --depth 250 && cd ..
       fi
 
 script:

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -71,12 +71,12 @@ if ($child) {
         $res .= $_;
     }
     close(CHILD);
-} elsif ($ENV{'TRAVIS_EVENT_TYPE'} eq 'cron' OR
+} elsif ($ENV{'TRAVIS_EVENT_TYPE'} eq 'cron' ||
          $ENV{'APPVEYOR_REPO_TAG'} eq 'true') {
     # A package build.
-    $standard_args = "invoke=${mydir}/../drmemory/package.cmake;drmem_only";
+    my $def_args = "build=1;invoke=${mydir}/../drmemory/package.cmake;drmem_only";
     $args =~ s/^,/;/;
-    system("ctest -VV -S \"${mydir}/../make/package.cmake,${standard_args}${args}\" 2>&1");
+    system("ctest -VV -S \"${mydir}/../make/package.cmake,${def_args}${args}\" 2>&1");
 } else {
     # We have no way to access the log files, so we can -VV to ensure
     # we can diagnose failures, but it makes for a large online result

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -58,6 +58,15 @@ for (my $i = 0; $i <= $#ARGV; $i++) {
     }
 }
 
+my $osdir = $mydir;
+if ($^O eq 'cygwin') {
+    # CMake is native Windows so pass it a Windows path.
+    # We use the full path to cygpath as git's cygpath is earlier on
+    # the PATH for AppVeyor and it fails.
+    $osdir = `/usr/bin/cygpath -wi \"$mydir\"`;
+    chomp $osdir;
+}
+
 # We tee to stdout to provide incremental output and avoid the 10-min
 # no-output timeout on Travis.
 my $res = '';
@@ -74,9 +83,10 @@ if ($child) {
 } elsif ($ENV{'TRAVIS_EVENT_TYPE'} eq 'cron' ||
          $ENV{'APPVEYOR_REPO_TAG'} eq 'true') {
     # A package build.
-    my $def_args = "build=1;invoke=${mydir}/../drmemory/package.cmake;drmem_only";
+    my $def_args = "build=1;invoke=${osdir}/../drmemory/package.cmake;drmem_only";
     $args =~ s/^,/;/;
-    system("ctest -VV -S \"${mydir}/../make/package.cmake,${def_args}${args}\" 2>&1");
+    system("ctest -VV -S \"${osdir}/../make/package.cmake,${def_args}${args}\" 2>&1");
+    exit 0;
 } else {
     # We have no way to access the log files, so we can -VV to ensure
     # we can diagnose failures, but it makes for a large online result
@@ -86,13 +96,8 @@ if ($child) {
     my $verbose = "-V";
     if ($^O eq 'cygwin') {
         $verbose = "-VV";
-        # CMake is native Windows so pass it a Windows path.
-        # We use the full path to cygpath as git's cygpath is earlier on
-        # the PATH for AppVeyor and it fails.
-        $mydir = `/usr/bin/cygpath -wi \"$mydir\"`;
-        chomp $mydir;
     }
-    system("ctest --output-on-failure ${verbose} -S \"${mydir}/runsuite.cmake${args}\" 2>&1");
+    system("ctest --output-on-failure ${verbose} -S \"${osdir}/runsuite.cmake${args}\" 2>&1");
     exit 0;
 }
 

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -71,6 +71,12 @@ if ($child) {
         $res .= $_;
     }
     close(CHILD);
+} elsif ($ENV{'TRAVIS_EVENT_TYPE'} eq 'cron' OR
+         $ENV{'APPVEYOR_REPO_TAG'} eq 'true') {
+    # A package build.
+    $standard_args = "invoke=${mydir}/../drmemory/package.cmake;drmem_only";
+    $args =~ s/^,/;/;
+    system("ctest -VV -S \"${mydir}/../make/package.cmake,${standard_args}${args}\" 2>&1");
 } else {
     # We have no way to access the log files, so we can -VV to ensure
     # we can diagnose failures, but it makes for a large online result

--- a/third_party/vera++/use_vera++.cmake
+++ b/third_party/vera++/use_vera++.cmake
@@ -113,7 +113,9 @@ function(add_vera_targets_for_dynamorio)
         NOT s MATCHES "/third_party/" AND
         # Somehow on Travis vera checks build-dir files.
         NOT s MATCHES "/build_" AND
-        NOT s MATCHES "/install/")
+        NOT s MATCHES "/install/" AND
+        # We check out drmemory for package builds.
+        NOT s MATCHES "/drmemory/")
       get_filename_component(d ${s} PATH)
       if(NOT "${d}" STREQUAL "${currentDir}")
         # this is a new dir - lets generate everything needed for the previous dir


### PR DESCRIPTION
Switches to a separate invocation of package.cmake for cronbuilds, to
make them look like release packages.

Checks out Dr. Memory to include it in the package.

Fixes #2861