### PR TITLE
i#2861 cronbuilds: Add control over version and build numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -193,9 +193,15 @@ before_deploy:
   - git config --local user.email "dynamorio-devs@googlegroups.com"
   # XXX: for now we duplicate this version number here with CMakeLists.txt.
   # We should find a way to share (xref i#1565).
-  # We support setting TAG_SUFFIX on triggered builds so we can have
-  # multiple unique tags in one day (the patchlevel here is the day number).
-  - export GIT_TAG="cronbuild-7.91.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
+  # We support setting VERSION_NUMBER for manual builds to override all
+  # parts of the version.  If a build is included (leading dash and number
+  # at the end), it will be parsed and passed to package.cmake.  We only
+  # use a non-zero build number when making multiple manual builds in one day.
+  - >
+      if test -z "${VERSION_NUMBER}"; then
+          export VERSION_NUMBER="7.91.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+      fi
+  - export GIT_TAG="cronbuild-${VERSION_NUMBER}"
   # We handle races among our 4 package jobs by ignoring failure here.
   # XXX: That could mask a real failure: we could try to distinguish the
   # type of error.

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,9 +199,10 @@ before_deploy:
   # use a non-zero build number when making multiple manual builds in one day.
   - >
       if test -z "${VERSION_NUMBER}"; then
-          export VERSION_NUMBER="7.91.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+          export GIT_TAG="cronbuild-7.91.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+      else
+          export GIT_TAG="release_${VERSION_NUMBER}"
       fi
-  - export GIT_TAG="cronbuild-${VERSION_NUMBER}"
   # We handle races among our 4 package jobs by ignoring failure here.
   # XXX: That could mask a real failure: we could try to distinguish the
   # type of error.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2007,8 +2007,14 @@ string(REGEX REPLACE
 # CPACK_TEMPORARY_PACKAGE_FILE_NAME if I hardcode the extension: but maybe
 # having the full version in the base dir is a good thing, though I'm not
 # sure about the caps.
+# We omit the -NN suffix for the build number if it is zero.
+if ("${BUILD_NUMBER}" STREQUAL "0")
+  set(PACKAGE_SUFFIX "")
+else ()
+  set(PACKAGE_SUFFIX "-${BUILD_NUMBER}")
+endif ()
 set(CPACK_PACKAGE_FILE_NAME
-  "DynamoRIO-${PACKAGE_PLATFORM}${CPACK_SYSTEM_NAME}${PACKAGE_SUBSYS}-${CPACK_PACKAGE_VERSION}-${BUILD_NUMBER}")
+  "DynamoRIO-${PACKAGE_PLATFORM}${CPACK_SYSTEM_NAME}${PACKAGE_SUBSYS}-${CPACK_PACKAGE_VERSION}${PACKAGE_SUFFIX}")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "dynamorio")
 set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "DynamoRIO")
 set(CPACK_PACKAGE_RELOCATABLE "true")


### PR DESCRIPTION
If the build number is 0, we omit it from the package name, rather than appending it.

.travis.yml now takes in VERSION_NUMBER and uses it directly.  There
is no more TAG_SUFFIX: VERSION_NUMBER has to include the build number
if that's desired, and that will be part of the tag as well.
If VERSION_NUMBER is not set it uses the default as before.

runsuite_wrapper.pl parses VERSION_NUMBER and if it has a -NNN it passes that
as the build= arg to package.cmake.  It also passes a version= argument.

Testing:
$ TRAVIS_EVENT_TYPE=cron ~/dr/git/src/suite/runsuite_wrapper.pl travis 64_only
Running ctest -VV -S "/home/bruening/dr/git/src/suite/../make/package.cmake,travis;64_only;build=0;invoke=/home/bruening/dr/git/src/suite/../drmemory/package.cmake;drmem_only"
$ VERSION_NUMBER=8.1.2 TRAVIS_EVENT_TYPE=cron ~/dr/git/src/suite/runsuite_wrapper.pl travis 64_only
Running ctest -VV -S "/home/bruening/dr/git/src/suite/../make/package.cmake,travis;64_only;build=0;version=8.1.2;invoke=/home/bruening/dr/git/src/suite/../drmemory/package.cmake;drmem_only"
$ VERSION_NUMBER=8.21.42-39 TRAVIS_EVENT_TYPE=cron ~/dr/git/src/suite/runsuite_wrapper.pl travis 64_only
Running ctest -VV -S "/home/bruening/dr/git/src/suite/../make/package.cmake,travis;64_only;build=39;version=8.21.42;invoke=/home/bruening/dr/git/src/suite/../drmemory/package.cmake;drmem_only"

Fixes #2861