### PR TITLE
i#1979 Mac64: Update Travis to test 64-bit Mac and not 32-bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,13 +107,12 @@ jobs:
           packages:
           - clang-9
           - clang-format-6.0
-    # 32-bit OSX build with clang and run tests:
+    # 64-bit OSX build with clang and run tests:
     - if: env(TRAVIS_EVENT_TYPE) != cron
       os: osx
       # gcc on Travis claims to not be CMAKE_COMPILER_IS_GNUCC so we only run clang.
       compiler: clang
-      # We do not have 64-bit support on OSX yet (i#1979).
-      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=32_only
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=64_only
 
     #######################################################################
     # Package jobs

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -131,8 +131,8 @@ else (UNIX)
 endif (UNIX)
 
 if (APPLE)
-  # DRi#58: core DR does not yet support 64-bit Mac
-  set(arg_32_only ON)
+  # We no longer support 32-bit Mac since Apple itself does not either.
+  set(arg_64_only ON)
 endif ()
 
 ##################################################

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4155,7 +4155,6 @@ if (APPLE)
   set_tests_properties(
     samples_proj
     code_api|common.broadfun
-    code_api|common.decode-bad
     code_api|common.fib
     code_api|common.floatpc
     code_api|common.floatpc_xl8all
@@ -4174,11 +4173,9 @@ if (APPLE)
     code_api|security-common.codemod
     code_api|security-common.retexisting
     code_api|security-common.ret_noncall_trace
-    code_api|client.abort
     code_api|client.crashmsg
     code_api|client.count-ctis-noopt
     code_api|client.exception
-    code_api|client.timer
     code_api|client.syscall-mod
     code_api|client.cbr-retarget
     code_api|client.truncate
@@ -4189,7 +4186,6 @@ if (APPLE)
     code_api|client.drcontainers-test
     code_api|client.destructor
     code_api|sample.signal
-    code_api|tool.drcpusim.simple
     code_api|tool.drcpusim.cpuid-Prescott
     code_api|tool.drcpusim.cpuid-Presler
     code_api|tool.drcpusim.cpuid-Merom


### PR DESCRIPTION
We no longer support 32-bit Mac as it does not really exist anymore.

Issue: #1979