### PR TITLE
i#2892 A64 tests: Fix flakiness in delay-simple test

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2831,7 +2831,7 @@ endif ()
       torunonly_drcachesim(filter-no-d ${ci_shared_app} "-L0_filter -L0D_size 0" "")
 
       torunonly_drcachesim(delay-simple ${ci_shared_app}
-        "-trace_after_instrs 50000 -exit_after_tracing 10000" "")
+        "-trace_after_instrs 20000 -exit_after_tracing 10000" "")
 
       # Test that "Warmup hits" and "Warmup misses" are printed out
       torunonly_drcachesim(warmup-valid ${ci_shared_app} "-warmup_refs 1" "")


### PR DESCRIPTION
Drops the -trace_after_instrs flag from 50K to 20K to ensure it will
hit the 2nd trigger on shorter executions such as on AArch64.

Issue: #2892