### PR TITLE
i#4087 redirect alloc: Cleanup decl vs def param name mismatches

### DIFF
--- a/core/module_shared.h
+++ b/core/module_shared.h
@@ -689,10 +689,10 @@ void *
 redirect_malloc(size_t size);
 
 void
-redirect_free(void *ptr);
+redirect_free(void *mem);
 
 void *
-redirect_realloc(void *ptr, size_t size);
+redirect_realloc(void *mem, size_t size);
 
 char *
 redirect_strdup(const char *str);


### PR DESCRIPTION
Fixes the declaration parameter names of redirect_free() and
redirect_realloc() to match the definitions.

Issue: #4087