### PR TITLE
i#2861 cronbuilds: Fix cron condition in jobs matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,22 +59,22 @@ jobs:
     # Regular test jobs:
 
     # 32-bit Linux build with gcc and run tests:
-    - if: env(TRAVIS_EVENT_TYPE) != cron
+    - if: type != cron
       os: linux
       compiler: gcc
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS="32_only"
     # 64-bit Linux build with gcc and run tests:
-    - if: env(TRAVIS_EVENT_TYPE) != cron
+    - if: type != cron
       os: linux
       compiler: gcc
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS="64_only"
     # AArchXX cross-compile with gcc, no tests:
-    - if: env(TRAVIS_EVENT_TYPE) != cron
+    - if: type != cron
       os: linux
       compiler: gcc
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=yes DEPLOY=no
     # Android ARM cross-compile with gcc, no tests:
-    - if: env(TRAVIS_EVENT_TYPE) != cron
+    - if: type != cron
       os: linux
       compiler: gcc
       env: DYNAMORIO_CROSS_ANDROID_ONLY=yes DEPLOY=no DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e'
@@ -83,7 +83,7 @@ jobs:
     # We used to build 32-bit with clang but have decided that is not worth
     # the Travis resources: 64-bit hits most clang-only warnings and 64-bit
     # is the primary target these days.
-    - if: env(TRAVIS_EVENT_TYPE) != cron
+    - if: type != cron
       os: linux
       compiler: clang
       # We need clang 9.0 to avoid a compiler bug: i#3989.
@@ -98,7 +98,7 @@ jobs:
           - clang-9
           - clang-format-6.0
     # 64-bit OSX build with clang and run tests:
-    - if: env(TRAVIS_EVENT_TYPE) != cron
+    - if: type != cron
       os: osx
       # gcc on Travis claims to not be CMAKE_COMPILER_IS_GNUCC so we only run clang.
       compiler: clang
@@ -107,22 +107,22 @@ jobs:
     #######################################################################
     # Package jobs
     # Linux x86 + amd64:
-    - if: env(TRAVIS_EVENT_TYPE) = cron
+    - if: type = cron
       os: linux
       compiler: gcc
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=yes
     # Linux AArch64:
-    - if: env(TRAVIS_EVENT_TYPE) = cron
+    - if: type = cron
       os: linux
       compiler: gcc
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=yes DEPLOY=yes EXTRA_ARGS=64_only
     # Linux ARM:
-    - if: env(TRAVIS_EVENT_TYPE) = cron
+    - if: type = cron
       os: linux
       compiler: gcc
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=yes DEPLOY=yes EXTRA_ARGS=32_only
     # Android ARM:
-    - if: env(TRAVIS_EVENT_TYPE) = cron
+    - if: type = cron
       os: linux
       compiler: gcc
       env: DYNAMORIO_CROSS_ANDROID_ONLY=yes DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e' DEPLOY=yes EXTRA_ARGS=32_only


### PR DESCRIPTION
Turns out the TRAVIS_EVENT_TYPE env var is not set during jobs matrix
creation.  Instead we have to use the "type = cron" condition.

Issue: #2861