### PR TITLE
i#1730 xc docs: Enable all docs but op lists for cross-compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1452,13 +1452,7 @@ option(BUILD_SAMPLES "build client samples" ON)
 
 option(BUILD_CLIENTS "build client tools" ON)
 
-if (NOT X86)
-  # FIXME i#1551: fail to install necessary package on Linux ARM
-  # XXX i#1730: if we enable this we'll need to disable for cross-compilation
-  option(BUILD_DOCS "build documentation" OFF)
-else ()
-  option(BUILD_DOCS "build documentation" ON)
-endif ()
+option(BUILD_DOCS "build documentation" ON)
 
 if (VMSAFE)
   # I did not preserve VMSAFE docs building: to reactivate it, need to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1452,7 +1452,13 @@ option(BUILD_SAMPLES "build client samples" ON)
 
 option(BUILD_CLIENTS "build client tools" ON)
 
-option(BUILD_DOCS "build documentation" ON)
+if (ANDROID)
+  # TODO i#1874: Android does not build drcachesim or drcpusim, which have
+  # references spread throughout the docs.
+  option(BUILD_DOCS "build documentation" OFF)
+else ()
+  option(BUILD_DOCS "build documentation" ON)
+endif ()
 
 if (VMSAFE)
   # I did not preserve VMSAFE docs building: to reactivate it, need to

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2020 Google, Inc.    All rights reserved.
 # Copyright (c) 2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -82,6 +82,8 @@ file(GLOB dirs "*/CMakeLists.txt")
 foreach (dir ${dirs})
   get_filename_component(dir ${dir} PATH)
   # FIXME i#1874: named pipe not working on Android.
+  # We should build anyway since -offline should work.
+  # This also prevents us from building the docs on Android!
   if (NOT ANDROID OR NOT ${dir} MATCHES "drcachesim")
     # FIXME i#1732: drcpusim has no ARM support yet
     if (NOT ANDROID OR NOT ${dir} MATCHES "drcpusim")

--- a/clients/common/gendocs.cmake
+++ b/clients/common/gendocs.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015 Google, Inc.    All rights reserved.
+# Copyright (c) 2015-2020 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -33,14 +33,21 @@
 # * dst
 # * prog = the app that spits out the option list
 # * prog_arg = arg to app, if any
+# * CMAKE_CROSSCOMPILING = whether cross-compiling and thus this program
+#   will not execute.
 
-execute_process(COMMAND ${prog} ${prog_arg}
-  RESULT_VARIABLE prog_result
-  ERROR_VARIABLE prog_err
-  OUTPUT_VARIABLE prog_out
-  )
-if (prog_result OR prog_err)
-  message(FATAL_ERROR "*** ${prog} failed: ***\n${prog_err}")
+if (CMAKE_CROSSCOMPILING)
+  # i#1730: This is better than failing.
+  set(prog_out "The options list is not currently able to be generated for cross-compiled builds (https://github.com/DynamoRIO/dynamorio/issues/1730).  Please see the online documentation or run the tool with -help.")
+else ()
+  execute_process(COMMAND ${prog} ${prog_arg}
+    RESULT_VARIABLE prog_result
+    ERROR_VARIABLE prog_err
+    OUTPUT_VARIABLE prog_out
+    )
+  if (prog_result OR prog_err)
+    message(FATAL_ERROR "*** ${prog} failed: ***\n${prog_err}")
+  endif ()
 endif ()
 
 file(READ "${src}" content)

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015-2019 Google, Inc.    All rights reserved.
+# Copyright (c) 2015-2020 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -601,7 +601,9 @@ endif ()
 ##################################################
 # Documentation
 
-# We auto-generate the list of options in the html docs via this helper app:
+# We auto-generate the list of options in the html docs via this helper app.
+# i#1730: We cannot execute this when cross-compiling so for now we generate
+# docs without this list (better than no docs at all).
 add_executable(drcachesim_ops
   optionlist.cpp
   common/options.cpp)
@@ -629,6 +631,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND}
   ARGS -D src=${srcdoc}
        -D dst=${gendoc}
+       -D CMAKE_CROSSCOMPILING=${CMAKE_CROSSCOMPILING}
        -D prog=$<TARGET_FILE:drcachesim_ops>
        -P ${CMAKE_CURRENT_SOURCE_DIR}/../common/gendocs.cmake
   VERBATIM)

--- a/clients/drcov/CMakeLists.txt
+++ b/clients/drcov/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2016 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2020 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -174,6 +174,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND}
   ARGS -D src=${srcdoc}
        -D dst=${gendoc}
+       -D CMAKE_CROSSCOMPILING=${CMAKE_CROSSCOMPILING}
        -D prog=$<TARGET_FILE:drcov2lcov>
        -D prog_arg=-help_html
        -P ${CMAKE_CURRENT_SOURCE_DIR}/../common/gendocs.cmake

--- a/clients/drcpusim/CMakeLists.txt
+++ b/clients/drcpusim/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015 Google, Inc.    All rights reserved.
+# Copyright (c) 2015-2020 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -115,6 +115,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND}
   ARGS -D src=${srcdoc}
        -D dst=${gendoc}
+       -D CMAKE_CROSSCOMPILING=${CMAKE_CROSSCOMPILING}
        -D prog=$<TARGET_FILE:drcpusim_ops>
        -P ${CMAKE_CURRENT_SOURCE_DIR}/../common/gendocs.cmake
   VERBATIM)


### PR DESCRIPTION
Enables BUILD_DOCS by default for all architectures.

For option list documentation generation (drcpusim, drcov, drcachesim), when
cross-compiling and we cannot executed the generator, instead we place this into
the documentation:

    The parameters available are described below:

    The options list is not currently able to be generated for cross-compiled
    builds (https://github.com/DynamoRIO/dynamorio/issues/1730). Please see the
    online documentation or run the tool with -help.

This is better than having no documentation at all in our non-x86 packages.

Issue: #1730