### PR TITLE
i#3194: Publish doxygen docs to Github Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ jobs:
     - if: type = cron OR env(TRAVIS_EVENT_TYPE) = cron
       os: linux
       compiler: gcc
-      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=yes
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=yes DEPLOY_DOCS=yes
     # Linux AArch64:
     - if: type = cron OR env(TRAVIS_EVENT_TYPE) = cron
       os: linux
@@ -175,11 +175,12 @@ install:
 script:
   - suite/runsuite_wrapper.pl travis $EXTRA_ARGS
 
-# For now we create packages as part of each (enabled) job.
 # We switch to package.cmake for these builds in runsuite_wrapper.pl by looking
 # for $TRAVIS_EVENT_TYPE=="cron".
 # Longer-term we may want to use package.cmake instead and even make official
 # builds on Travis (i#2861).
+# The before_deploy commands are run before each deployer, so they are also
+# run for DEPLOY_DOCS.  We'll just have a git tag failure since it exists.
 before_deploy:
   - git config --local user.name "Travis Auto-Tag"
   - git config --local user.email "dynamorio-devs@googlegroups.com"
@@ -200,17 +201,26 @@ before_deploy:
   # type of error.
   - (git tag $GIT_TAG -a -m "Travis auto-generated tag for build $TRAVIS_BUILD_NUMBER." || true)
 deploy:
-  provider: releases
-  api_key:
-    secure: V3kgcRiwijjpmcSuVio1+/oZ8cqJGaVlL42hN0w/jjO6LoELy2kknT5h80H7wMVKpZnMg+2v/yWj5hawlrwh8nCS51lYllPHN7K+ivzkyJ3R4cp1WAzL56vnYFYz1/twYpeS10Zl6JL6wt788WcibpShMOIlAnXnm1kU9BBVtYE=
-  file_glob: true
-  file: "DynamoRIO*.tar.gz"
-  skip_cleanup: true
-  # The name must just be the tag in order to match Appveyor.
-  name: $GIT_TAG
-  # This body is clobbered by Appveyor.
-  body: "Auto-generated periodic build (Travis build $TRAVIS_BUILD_NUMBER)."
-  on:
-    repo: DynamoRIO/dynamorio
-    branch: master
-    condition: $TRAVIS_EVENT_TYPE = cron && $DEPLOY = yes
+  - provider: releases
+    api_key:
+      secure: V3kgcRiwijjpmcSuVio1+/oZ8cqJGaVlL42hN0w/jjO6LoELy2kknT5h80H7wMVKpZnMg+2v/yWj5hawlrwh8nCS51lYllPHN7K+ivzkyJ3R4cp1WAzL56vnYFYz1/twYpeS10Zl6JL6wt788WcibpShMOIlAnXnm1kU9BBVtYE=
+      file_glob: true
+      file: "DynamoRIO*.tar.gz"
+      skip_cleanup: true
+      # The name must just be the tag in order to match Appveyor.
+      name: $GIT_TAG
+      # This body is clobbered by Appveyor.
+      body: "Auto-generated periodic build (Travis build $TRAVIS_BUILD_NUMBER)."
+      on:
+        repo: DynamoRIO/dynamorio
+        branch: master
+        condition: $TRAVIS_EVENT_TYPE = cron && $DEPLOY = yes
+  - provider: pages
+    repo: DynamoRIO/dynamorio_docs
+    local_dir: html
+    github_token:
+      secure: N8TKftuS4f2GfaZ53dIlBHrfxfmDUvXvZzZT7lcAO0Fps0TSxLZ3+VcjNj/hoTk8HpDLnSsDLu/+FthzPYnROCeR3iiIRcrtHv71Zsf0h3SJ9fMDNpEgz6y0LMhhmSSMcQtbsKWhVwamUhmaSGXZdxBm0Irc7INYajkv1xKs5a0=
+      skip_cleanup: true
+      on:
+        branch: master
+        condition: $TRAVIS_EVENT_TYPE = cron && $DEPLOY_DOCS = yes

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -108,6 +108,9 @@ if ($child) {
         my $version = $1;
         $args .= ";version=${version}";
     }
+    if ($ENV{'DEPLOY_DOCS'} eq 'yes') {
+        $args .= ";copy_docs";
+    }
     # Include Dr. Memory.
     if (($is_aarchxx || $ENV{'DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY'} eq 'yes') &&
         $args =~ /64_only/) {


### PR DESCRIPTION
Has package.cmake copy docs into a top-level html/ directory.
Sets up Travis to push the html/ directory to the dynamorio_docs repository.
The x86 build sets DEPLOY_DOCS which runsuite_wrapper turns into a
copy_docs parameter to package.cmake and which is used as a condition
for the Travis deployment.

Travis will not do deployments on pull requests so this can only be
tested once it is merged into master.

Fixes #3194