### PR TITLE
i#4117: Add missing dr_standalone_init() and _exit() calls

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -446,12 +446,17 @@ if (WIN32)
   DR_install(FILES "${injectlib_loc}"  DESTINATION "${INSTALL_CLIENTS_BIN}")
   DynamoRIO_get_full_path(configlib_loc drconfiglib "${location_suffix}")
   DR_install(FILES "${configlib_loc}"  DESTINATION "${INSTALL_CLIENTS_BIN}")
+  DynamoRIO_get_full_path(drlib_loc dynamorio "${location_suffix}")
+  DR_install(FILES "${drlib_loc}"  DESTINATION "${INSTALL_CLIENTS_BIN}")
   add_custom_command(TARGET drcachesim POST_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_BASE_DIRECTORY}/drinjectlib.dll
     ${PROJECT_BINARY_DIR}/${BUILD_CLIENTS_BIN}/drinjectlib.dll VERBATIM)
   add_custom_command(TARGET drcachesim POST_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_BASE_DIRECTORY}/drconfiglib.dll
     ${PROJECT_BINARY_DIR}/${BUILD_CLIENTS_BIN}/drconfiglib.dll VERBATIM)
+  add_custom_command(TARGET drcachesim POST_BUILD
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_OUTPUT_DIRECTORY}/dynamorio.dll
+    ${PROJECT_BINARY_DIR}/${BUILD_CLIENTS_BIN}/dynamorio.dll VERBATIM)
 endif ()
 
 ##################################################

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -212,6 +212,7 @@ post_process()
     assert(error.empty());
     error = raw2trace.do_conversion();
     assert(error.empty());
+    dr_standalone_exit();
 }
 
 int

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -94,7 +94,20 @@ protected:
         app_pc last_mapped_module_start;
     };
 
-    void *dcontext_;
+    struct dcontext_cleanup_last_t {
+    public:
+        ~dcontext_cleanup_last_t()
+        {
+            if (dcontext != nullptr)
+                dr_standalone_exit();
+        }
+        void *dcontext = nullptr;
+    };
+
+    /* We make this the first field so that dr_standalone_exit() is called after
+     * destroying the other fields which may use DR heap.
+     */
+    dcontext_cleanup_last_t dcontext_;
     std::string module_file_path_;
     std::unique_ptr<module_mapper_t> module_mapper_;
     std::mutex mapper_mutex_;

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -54,8 +54,7 @@ view_tool_create(const std::string &module_file_path, uint64_t skip_refs,
 
 view_t::view_t(const std::string &module_file_path, uint64_t skip_refs, uint64_t sim_refs,
                const std::string &syntax, unsigned int verbose)
-    : dcontext_(nullptr)
-    , module_file_path_(module_file_path)
+    : module_file_path_(module_file_path)
     , knob_verbose_(verbose)
     , instr_count_(0)
     , knob_skip_refs_(skip_refs)
@@ -70,7 +69,7 @@ view_t::initialize()
 {
     if (module_file_path_.empty())
         return "Module file path is missing";
-    dcontext_ = dr_standalone_init();
+    dcontext_.dcontext = dr_standalone_init();
     std::string error = directory_.initialize_module_file(module_file_path_);
     if (!error.empty())
         return "Failed to initialize directory: " + error;
@@ -152,10 +151,10 @@ view_t::process_memref(const memref_t &memref)
         // MAX_INSTR_DIS_SZ is set to 196 in core/arch/disassemble.h but is not
         // exported so we just use the same value here.
         char buf[196];
-        byte *next_pc =
-            disassemble_to_buffer(dcontext_, mapped_pc, orig_pc, /*show_pc=*/true,
-                                  /*show_bytes=*/true, buf, BUFFER_SIZE_ELEMENTS(buf),
-                                  /*printed=*/nullptr);
+        byte *next_pc = disassemble_to_buffer(
+            dcontext_.dcontext, mapped_pc, orig_pc, /*show_pc=*/true,
+            /*show_bytes=*/true, buf, BUFFER_SIZE_ELEMENTS(buf),
+            /*printed=*/nullptr);
         if (next_pc == nullptr) {
             error_string_ = "Failed to disassemble " + to_hex_string(memref.instr.addr);
             return false;

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -44,9 +44,6 @@ class view_t : public analysis_tool_t {
 public:
     view_t(const std::string &module_file_path, uint64_t skip_refs, uint64_t sim_refs,
            const std::string &syntax, unsigned int verbose);
-    virtual ~view_t()
-    {
-    }
     std::string
     initialize() override;
     bool
@@ -55,7 +52,20 @@ public:
     print_results() override;
 
 protected:
-    void *dcontext_;
+    struct dcontext_cleanup_last_t {
+    public:
+        ~dcontext_cleanup_last_t()
+        {
+            if (dcontext != nullptr)
+                dr_standalone_exit();
+        }
+        void *dcontext = nullptr;
+    };
+
+    /* We make this the first field so that dr_standalone_exit() is called after
+     * destroying the other fields which may use DR heap.
+     */
+    dcontext_cleanup_last_t dcontext_;
     std::string module_file_path_;
     std::unique_ptr<module_mapper_t> module_mapper_;
     raw2trace_directory_t directory_;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -593,7 +593,18 @@ protected:
      */
     trace_converter_t(void *dcontext)
         : dcontext_(dcontext == nullptr ? dr_standalone_init() : dcontext)
+        , passed_dcontext_(dcontext != nullptr)
     {
+    }
+
+    /**
+     * Destroys this #trace_converter_t object.  If a nullptr dcontext_in was passed
+     * to the constructor, calls dr_standalone_exit().
+     */
+    ~trace_converter_t()
+    {
+        if (!passed_dcontext_)
+            dr_standalone_exit();
     }
 
     /**
@@ -720,6 +731,11 @@ protected:
      * The pointer to the DR context.
      */
     void *const dcontext_;
+
+    /**
+     * Whether a non-nullptr dcontext was passed to the constructor.
+     */
+    bool passed_dcontext_ = false;
 
     /**
      * Get the module map.

--- a/clients/drcachesim/tracer/raw2trace_directory.cpp
+++ b/clients/drcachesim/tracer/raw2trace_directory.cpp
@@ -258,4 +258,5 @@ raw2trace_directory_t::~raw2trace_directory_t()
          fo != out_files_.end(); ++fo) {
         delete *fo;
     }
+    dr_standalone_exit();
 }

--- a/clients/drcachesim/tracer/raw2trace_directory.h
+++ b/clients/drcachesim/tracer/raw2trace_directory.h
@@ -48,6 +48,8 @@ public:
         , outdir_("")
         , verbosity_(verbosity)
     {
+        // We use DR API routines so we need to initialize.
+        dr_standalone_init();
     }
     ~raw2trace_directory_t();
 

--- a/clients/drcov/postprocess/drcov2lcov.cpp
+++ b/clients/drcov/postprocess/drcov2lcov.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -1389,5 +1389,6 @@ main(int argc, const char *argv[])
     }
     if (set_log != INVALID_FILE)
         dr_close_file(set_log);
+    dr_standalone_exit();
     return 0;
 }

--- a/clients/standalone/module_rsrc.c
+++ b/clients/standalone/module_rsrc.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2006 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -78,5 +79,6 @@ main(int argc, char *argv[])
     if (info.product_name != NULL)
         printf("Product Name = \"%S\"\n", info.product_name);
 
+    dr_standalone_exit();
     return 0;
 }

--- a/clients/standalone/vista_hash.c
+++ b/clients/standalone/vista_hash.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -425,6 +426,7 @@ main(int argc, char *argv[])
     while (spin_for_debugger)
         Sleep(1000);
 
+    dr_standalone_exit();
     return 0;
 }
 

--- a/clients/standalone/winsysnums.c
+++ b/clients/standalone/winsysnums.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -893,5 +893,6 @@ main(int argc, char *argv[])
     }
 
     load_and_analyze(dcontext, dll);
+    dr_standalone_exit();
     return 0;
 }

--- a/core/arch/aarch64/decode.c
+++ b/core/arch/aarch64/decode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -232,6 +232,7 @@ main()
 {
     bool res = true;
     standalone_init();
+    standalone_exit();
     return res;
 }
 

--- a/core/arch/arm/decode.c
+++ b/core/arch/arm/decode.c
@@ -3049,6 +3049,7 @@ main()
 {
     bool res = true;
     standalone_init();
+    standalone_exit();
     return res;
 }
 

--- a/core/arch/x86/decode.c
+++ b/core/arch/x86/decode.c
@@ -2835,6 +2835,7 @@ main()
     standalone_init();
     res = unit_check_sse3();
     res = unit_check_decode_ff_opcode() && res;
+    standalone_exit();
     return res;
 }
 

--- a/core/heap.c
+++ b/core/heap.c
@@ -3495,6 +3495,7 @@ global_heap_alloc(size_t size HEAPACCT(which_heap_t which))
     if (heapmgt == &temp_heapmgt &&
         /* We prevent recrusion by checking for a field that heap_init writes. */
         !heapmgt->global_heap_writable) {
+        /* XXX: We have no control point to call standalone_exit(). */
         standalone_init();
     }
 #endif
@@ -4773,6 +4774,7 @@ heap_reachable_alloc(dcontext_t *dcontext, size_t size HEAPACCT(which_heap_t whi
     if (heapmgt == &temp_heapmgt &&
         /* We prevent recrusion by checking for a field that heap_init writes. */
         !heapmgt->global_heap_writable) {
+        /* XXX: We have no control point to call standalone_exit(). */
         standalone_init();
     }
 #endif

--- a/core/unit_tests.c
+++ b/core/unit_tests.c
@@ -88,5 +88,6 @@ main(int argc, char **argv, char **envp)
     unit_test_atomic_ops();
     unit_test_jit_fragment_tree();
     print_file(STDERR, "all done\n");
+    standalone_exit();
     return 0;
 }

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4084,7 +4084,6 @@ os_open_protected(const char *fname, int os_open_flags)
     file_t res = os_open(fname, os_open_flags);
     if (res < 0)
         return res;
-
     /* we could have os_open() always switch to a private fd but it's probably
      * not worth the extra syscall for temporary open/close sequences so we
      * only use it for persistent files

--- a/core/utils.c
+++ b/core/utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2017 ARM Limited. All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
@@ -588,7 +588,8 @@ deadlock_avoidance_lock(mutex_t *lock, bool acquired, bool ownable)
         ASSERT(lock != &thread_initexit_lock || !is_self_couldbelinking());
 
         if (INTERNAL_OPTION(deadlock_avoidance) &&
-            get_thread_private_dcontext() != NULL) {
+            get_thread_private_dcontext() != NULL &&
+            get_thread_private_dcontext() != GLOBAL_DCONTEXT) {
             dcontext_t *dcontext = get_thread_private_dcontext();
             if (dcontext->thread_owned_locks != NULL) {
 #    ifdef CLIENT_INTERFACE

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -1224,7 +1224,7 @@ os_fast_exit(void)
      *
      * The curiosity is also relaxed if we enter DR using the API
      */
-    ASSERT_CURIOSITY(reached_image_entry_yet() ||
+    ASSERT_CURIOSITY(reached_image_entry_yet() || standalone_library ||
                      RUNNING_WITHOUT_CODE_CACHE() IF_APP_EXPORTS(|| dr_api_entry)
                      /* Clients can go native.  XXX: add var for whether client did? */
                      IF_CLIENT_INTERFACE(|| CLIENTS_EXIST()));

--- a/ext/drsyms/drsyms_bench.c
+++ b/ext/drsyms/drsyms_bench.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2012 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -136,4 +136,5 @@ main(int argc, char **argv)
     enumerate_with_flags(modpath, DRSYM_DEFAULT_FLAGS);
 
     drsym_exit();
+    dr_standalone_exit();
 }

--- a/suite/tests/api/dis-a64.c
+++ b/suite/tests/api/dis-a64.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2020 Google, Inc. All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -208,13 +209,17 @@ main(int argc, char *argv[])
                   "  -q FILE    Run test quietly.\n"
                   "  -v FILE    Run test verbosely.\n"
                   "  -d NUMBER  Disassemble a single instruction.\n");
+        dr_standalone_exit();
         return 0;
     }
 
     if (strcmp(argv[1], "-d") == 0) {
         run_decode(dc, argv[2]);
+        dr_standalone_exit();
         return 0;
     }
 
-    return run_test(dc, argv[2], (strcmp(argv[1], "-v") == 0));
+    int res = run_test(dc, argv[2], (strcmp(argv[1], "-v") == 0));
+    dr_standalone_exit();
+    return res;
 }

--- a/suite/tests/api/dis-create.c
+++ b/suite/tests/api/dis-create.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -165,5 +165,6 @@ main(int argc, char *argv[])
     dr_unmap_file(map_base, map_size);
     dr_close_file(f);
     dr_close_file(outf);
+    dr_standalone_exit();
     return 0;
 }

--- a/suite/tests/api/dis.c
+++ b/suite/tests/api/dis.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -141,5 +141,6 @@ main(int argc, char *argv[])
 
     dr_unmap_file(map_base, map_size);
     dr_close_file(f);
+    dr_standalone_exit();
     return 0;
 }

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -4012,5 +4012,8 @@ main(int argc, char *argv[])
     print("test_asimddiff complete\n");
 
     print("All tests complete\n");
+#ifndef STANDALONE_DECODER
+    dr_standalone_exit();
+#endif
     return 0;
 }

--- a/suite/tests/api/ir_aarch64_negative.c
+++ b/suite/tests/api/ir_aarch64_negative.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2020 Google, Inc. All rights reserved.
  * Copyright (c) 2018 Arm Limited. All rights reserved.
  * **********************************************************/
 
@@ -167,5 +168,8 @@ main(int argc, char *argv[])
     print("test_sve_int_bin_pred_log complete\n");
 
     print("All tests complete\n");
+#ifndef STANDALONE_DECODER
+    dr_standalone_exit();
+#endif
     return 0;
 }

--- a/suite/tests/api/ir_arm.c
+++ b/suite/tests/api/ir_arm.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -182,5 +182,8 @@ main(int argc, char *argv[])
     test_flags(dcontext);
 
     print("all done\n");
+#ifndef STANDALONE_DECODER
+    dr_standalone_exit();
+#endif
     return 0;
 }

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1200,7 +1200,7 @@ test_x86_mode(void *dc)
     ASSERT(instr_get_opcode(instr) == OP_sysexit);
     ASSERT(opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_ESP);
 
-    instr_free(dc, instr);
+    instr_destroy(dc, instr);
     set_x86_mode(dc, false /*64-bit*/);
 }
 
@@ -1478,8 +1478,8 @@ test_instr_opnds(void *dc)
     ASSERT(opnd_get_disp(instr_get_src(instr, 0)) == (ptr_int_t)pc + disp);
 #endif
 
-    instr_free(dc, instr);
-    instrlist_destroy(dc, ilist);
+    instr_destroy(dc, instr);
+    instrlist_clear_and_destroy(dc, ilist);
 }
 
 static void
@@ -1859,6 +1859,7 @@ test_vsib(void *dc)
         pc = decode(dc, (byte *)&b_scattergatherinv[i], &invinstr);
         ASSERT(pc == NULL);
     }
+    instr_free(dc, &invinstr);
 }
 
 static void
@@ -1940,7 +1941,7 @@ test_predication(void *dc)
     ASSERT(instr_writes_to_reg(instr, DR_REG_XMM0, DR_QUERY_INCLUDE_COND_DSTS));
     ASSERT(!instr_writes_to_reg(instr, DR_REG_XMM0, 0));
 
-    instr_reset(dc, instr);
+    instr_destroy(dc, instr);
     instr = INSTR_CREATE_cmovcc(dc, OP_cmovnle, opnd_create_reg(DR_REG_EAX),
                                 opnd_create_reg(DR_REG_ECX));
     ASSERT(instr_reads_from_reg(instr, DR_REG_ECX, DR_QUERY_DEFAULT));
@@ -1965,7 +1966,7 @@ test_predication(void *dc)
     ASSERT(!instr_writes_to_reg(instr, DR_REG_EAX, 0));
 
     /* bsf always writes to eflags */
-    instr_reset(dc, instr);
+    instr_destroy(dc, instr);
     instr =
         INSTR_CREATE_bsf(dc, opnd_create_reg(DR_REG_EAX), opnd_create_reg(DR_REG_ECX));
     ASSERT(TESTALL(EFLAGS_WRITE_6, instr_get_eflags(instr, DR_QUERY_DEFAULT)));
@@ -2006,8 +2007,8 @@ test_xinst_create(void *dc)
     ins2 = instr_create(dc);
     decode(dc, buf, ins2);
     ASSERT(instr_same(ins1, ins2));
-    instr_reset(dc, ins1);
-    instr_reset(dc, ins2);
+    instr_destroy(dc, ins1);
+    instr_destroy(dc, ins2);
     /* load 1 byte */
     ins1 = XINST_CREATE_load_1byte(dc, opnd_create_reg(reg_resize_to_opsz(reg, OPSZ_1)),
                                    MEMARG(OPSZ_1));
@@ -2016,8 +2017,8 @@ test_xinst_create(void *dc)
     ins2 = instr_create(dc);
     decode(dc, buf, ins2);
     ASSERT(instr_same(ins1, ins2));
-    instr_reset(dc, ins1);
-    instr_reset(dc, ins2);
+    instr_destroy(dc, ins1);
+    instr_destroy(dc, ins2);
     /* load 2 bytes */
     ins1 = XINST_CREATE_load_2bytes(dc, opnd_create_reg(reg_resize_to_opsz(reg, OPSZ_2)),
                                     MEMARG(OPSZ_2));
@@ -2026,8 +2027,8 @@ test_xinst_create(void *dc)
     ins2 = instr_create(dc);
     decode(dc, buf, ins2);
     ASSERT(instr_same(ins1, ins2));
-    instr_reset(dc, ins1);
-    instr_reset(dc, ins2);
+    instr_destroy(dc, ins1);
+    instr_destroy(dc, ins2);
     /* store 1 byte */
     ins1 = XINST_CREATE_store_1byte(dc, MEMARG(OPSZ_1),
                                     opnd_create_reg(reg_resize_to_opsz(reg, OPSZ_1)));
@@ -2036,8 +2037,8 @@ test_xinst_create(void *dc)
     ins2 = instr_create(dc);
     decode(dc, buf, ins2);
     ASSERT(instr_same(ins1, ins2));
-    instr_reset(dc, ins1);
-    instr_reset(dc, ins2);
+    instr_destroy(dc, ins1);
+    instr_destroy(dc, ins2);
     /* store 1 byte */
     ins1 = XINST_CREATE_store_2bytes(dc, MEMARG(OPSZ_2),
                                      opnd_create_reg(reg_resize_to_opsz(reg, OPSZ_2)));
@@ -2046,8 +2047,8 @@ test_xinst_create(void *dc)
     ins2 = instr_create(dc);
     decode(dc, buf, ins2);
     ASSERT(instr_same(ins1, ins2));
-    instr_reset(dc, ins1);
-    instr_reset(dc, ins2);
+    instr_destroy(dc, ins1);
+    instr_destroy(dc, ins2);
 }
 
 static void
@@ -2127,7 +2128,7 @@ test_reg_exact_reads(void *dc)
     ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_AX, DR_QUERY_INCLUDE_COND_DSTS));
     ASSERT(!instr_reads_from_exact_reg(instr, DR_REG_AX, 0));
 
-    instr_reset(dc, instr);
+    instr_destroy(dc, instr);
     instr = INSTR_CREATE_mov_ld(dc, OPND_CREATE_MEM16(DR_REG_XAX, 5),
                                 opnd_create_reg(DR_REG_BX));
 
@@ -2148,7 +2149,7 @@ test_reg_exact_reads(void *dc)
     ASSERT(instr_reads_from_exact_reg(instr, DR_REG_BX, DR_QUERY_INCLUDE_COND_DSTS));
     ASSERT(instr_reads_from_exact_reg(instr, DR_REG_BX, 0));
 
-    instr_reset(dc, instr);
+    instr_destroy(dc, instr);
     instr =
         INSTR_CREATE_pxor(dc, opnd_create_reg(DR_REG_XMM0), opnd_create_reg(DR_REG_XMM1));
 
@@ -2358,5 +2359,8 @@ main(int argc, char *argv[])
 #endif
 
     print("all done\n");
+#ifndef STANDALONE_DECODER
+    dr_standalone_exit();
+#endif
     return 0;
 }

--- a/suite/tests/api/it_arm.c
+++ b/suite/tests/api/it_arm.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -181,5 +181,6 @@ main(int argc, char *argv[])
     /* i#1702: test that a cti terminates the IT-block */
     test_dr_insert_it_instrs_cti(dcontext);
 
+    dr_standalone_exit();
     return 0;
 }

--- a/suite/tests/api/reenc-a64.c
+++ b/suite/tests/api/reenc-a64.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2020 Google, Inc. All rights reserved.
  * Copyright (c) 2017 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -100,5 +101,6 @@ main(int argc, char *argv[])
         test1(dc, i, sizeof(uint));
     } while (i++ != b);
 
+    dr_standalone_exit();
     return 0;
 }

--- a/suite/tests/api/symtest.c
+++ b/suite/tests/api/symtest.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -72,5 +72,6 @@ main(int argc, char *argv[])
 
     symres = drsym_exit();
     assert(symres == DRSYM_SUCCESS);
+    dr_standalone_exit();
     return 0;
 }


### PR DESCRIPTION
The filed bug is about raw2trace_directory using the DR API without
initializing DR, but I expanded this to clean up the whole code base:

Adds dr_standalone_init() and _exit() to raw2trace_directory_t.
This fixes an assert when calling dr_open_file() due to uninitialized state.

Adds {dr_,}standalone_exit() calls to all cases where _init() is
called, except where we can't do that (drdecode heap usage).

For the C++ view and opcode_mix tools, uses a first-field destructor
to ensure dr_standalone_exit() is called after any DR heap used by
other fields is freed.

Fixes several bugs where IR cleanup calls were missing in the api.ir
test, revealed by dr_standalone_exit's unfreed-memory check.

Fixes #4117