### PR TITLE
i2666: increase MAX_CONTEXT_SIZE

### DIFF
--- a/core/win32/os_private.h
+++ b/core/win32/os_private.h
@@ -471,11 +471,11 @@ extern uint context_xstate;
 
 #define XSTATE_HEADER_SIZE 0x40 /* 512 bits */
 #define YMMH_AREA(ymmh_area, i) (((dr_xmm_t *)ymmh_area)[i])
-#define MAX_CONTEXT_64_SIZE 0x6ef /* as observed on win10-x64 */
+#define MAX_CONTEXT_64_SIZE 0xd2f /* as observed on win10-x64 */
 #ifdef X64
 #    define MAX_CONTEXT_SIZE MAX_CONTEXT_64_SIZE
 #else
-#    define MAX_CONTEXT_SIZE 0x4e3 /* as observed on win10-x64 */
+#    define MAX_CONTEXT_SIZE 0xd2f /* as observed on win10-x64 */
 #endif
 #define CONTEXT_DYNAMICALLY_LAID_OUT(flags) (TESTALL(CONTEXT_XSTATE, flags))
 


### PR DESCRIPTION
Increase `MAX_CONTEXT_SIZE` to `0xd2f`

Issue: #2666