### PR TITLE
i#4124: Fix AArch64 leaks in tests

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -960,7 +960,10 @@ standalone_exit(void)
     config_heap_exit();
     os_fast_exit();
     os_slow_exit();
+#    if !defined(STANDALONE_UNIT_TEST) || !defined(AARCH64)
+    /* XXX: The lock setup is somehow messed up on AArch64.  Disabling cleanup. */
     dynamo_vm_areas_exit();
+#    endif
 #    ifndef STANDALONE_UNIT_TEST
     /* We have a leak b/c we can't call os_tls_exit().  For now we simplify
      * and leave it alone.

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -75,6 +75,7 @@ if ($^O eq 'cygwin') {
 
 # We tee to stdout to provide incremental output and avoid the 10-min
 # no-output timeout on Travis.
+print "Forking child for stdout tee\n";
 my $res = '';
 my $child = open(CHILD, '-|');
 die "Failed to fork: $!" if (!defined($child));
@@ -132,7 +133,8 @@ if ($child) {
     if ($^O eq 'cygwin') {
         $verbose = "-VV";
     }
-    system("ctest --output-on-failure ${verbose} -S \"${osdir}/runsuite.cmake${args}\" 2>&1");
+    my $cmd = "ctest --output-on-failure ${verbose} -S \"${osdir}/runsuite.cmake${args}\"";
+    system("${cmd} 2>&1");
     exit 0;
 }
 

--- a/suite/tests/api/dis-a64.c
+++ b/suite/tests/api/dis-a64.c
@@ -109,6 +109,7 @@ check_inst(void *dc, uint enc, const char *dis, size_t len, bool verbose, bool *
         dr_printf("\n");
         *failed = true;
     }
+    instr_free(dc, &instr);
 }
 
 void

--- a/suite/tests/api/ir_aarch64_negative.c
+++ b/suite/tests/api/ir_aarch64_negative.c
@@ -71,14 +71,17 @@ test_fmov_general(void *dc)
     instr = INSTR_CREATE_fmov_general(dc, opnd_create_reg(DR_REG_D10),
                                       opnd_create_reg(DR_REG_W9));
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     instr = INSTR_CREATE_fmov_general(dc, opnd_create_reg(DR_REG_S10),
                                       opnd_create_reg(DR_REG_X9));
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     instr = INSTR_CREATE_fmov_general(dc, opnd_create_reg(DR_REG_W10),
                                       opnd_create_reg(DR_REG_X9));
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 }
 
 static void
@@ -95,61 +98,74 @@ test_sve_int_bin_pred_log(void *dc)
         dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P7),
         opnd_create_reg(DR_REG_Z5), opnd_create_reg(DR_REG_Z13), OPND_CREATE_BYTE());
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     instr = INSTR_CREATE_eor_sve_pred(
         dc, opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_P4),
         opnd_create_reg(DR_REG_Z9), opnd_create_reg(DR_REG_Z2), OPND_CREATE_DOUBLE());
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     instr = INSTR_CREATE_and_sve_pred(
         dc, opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_P1),
         opnd_create_reg(DR_REG_Z1), opnd_create_reg(DR_REG_Z23), OPND_CREATE_SINGLE());
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     instr = INSTR_CREATE_bic_sve_pred(
         dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P2),
         opnd_create_reg(DR_REG_Z3), opnd_create_reg(DR_REG_Z24), OPND_CREATE_HALF());
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     /* Make sure predicate registers P8-P15 are not accepted. */
     instr = INSTR_CREATE_orr_sve_pred(
         dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P8),
         opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z13), OPND_CREATE_BYTE());
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     instr = INSTR_CREATE_eor_sve_pred(
         dc, opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_P9),
         opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_Z2), OPND_CREATE_DOUBLE());
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     instr = INSTR_CREATE_and_sve_pred(
         dc, opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_P10),
         opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_Z23), OPND_CREATE_SINGLE());
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     instr = INSTR_CREATE_and_sve_pred(
         dc, opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_P11),
         opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_Z23), OPND_CREATE_SINGLE());
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     instr = INSTR_CREATE_bic_sve_pred(
         dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P12),
         opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z24), OPND_CREATE_HALF());
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     instr = INSTR_CREATE_and_sve_pred(
         dc, opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_P13),
         opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_Z23), OPND_CREATE_SINGLE());
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     instr = INSTR_CREATE_bic_sve_pred(
         dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P14),
         opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z24), OPND_CREATE_HALF());
+    ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 
     instr = INSTR_CREATE_bic_sve_pred(
         dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P15),
         opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z24), OPND_CREATE_HALF());
     ASSERT(!instr_is_encoding_possible(instr));
+    instr_destroy(dc, instr);
 }
 
 int


### PR DESCRIPTION
Fixes leaks in the api.dis-a64 and api.ir_negative AArch64 tests.
    
Adds extra printing to runsuite_wrapper to try and help with the
AArch64 Travis hang.
    
Issue: #4126
Fixes #4124
