### PR TITLE
i#4059 faster Appveyor: No rel-32; shrink drcacheoff tests

### DIFF
--- a/clients/drcachesim/tests/TLB-simple.templatex
+++ b/clients/drcachesim/tests/TLB-simple.templatex
@@ -6,7 +6,7 @@ Core #0 \(1 thread\(s\)\)
     Hits:                      *[0-9,\.]*
     Misses:                    *[0-9,\.]*
     Invalidations:             *0
-    Miss rate:                        0[,\.]..%
+    Miss rate:                        [0-3][,\.]..%
   L1D stats:
     Hits:                      *[0-9,\.]*
     Misses:                    *[0-9,\.]*
@@ -16,7 +16,7 @@ Core #0 \(1 thread\(s\)\)
     Hits:                      *[0-9,\.]*
     Misses:                           *[0-9]..?
     Invalidations:             *0
-    Local miss rate:           *[0-9]*[,\.]..%
+    Local miss rate:        *[0-9,.]*%
     Child hits:                *[0-9,\.]*
     Total miss rate:                  0[,\.]..%
 Core #1 \(0 thread\(s\)\)

--- a/clients/drcachesim/tests/TLB-threads.templatex
+++ b/clients/drcachesim/tests/TLB-threads.templatex
@@ -5,7 +5,7 @@
      Client version .*
     ...................................................................
 
-     Matrix Size :  128
+     Matrix Size :  64
      Threads     :  4
 
 
@@ -24,19 +24,9 @@
      Finished computing current solution distance in mode 0.
      Mode changed to 0.
 
-     Started iteration 4 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 5 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
 
      The Jacobi Method For AX=B .........DONE
-     Total Number Of iterations   :  5
+     Total Number Of iterations   :  3
     ...................................................................
 ---- <application exited with code 0> ----
 TLB simulation results:
@@ -55,7 +45,7 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
     Hits:                    *[0-9,\.]*
     Misses:                  *[0-9,\.]*
     Invalidations:           *[0-9]*
-    Local miss rate:         *[0-9]*[\.,]..%
+    Local miss rate:        *[0-9,.]*%
     Child hits:              *[0-9,\.]*
     Total miss rate:         *[0-9,\.]*%
 Core #1 \([0-9] traced CPU\(s\).*

--- a/clients/drcachesim/tests/coherence.templatex
+++ b/clients/drcachesim/tests/coherence.templatex
@@ -5,7 +5,7 @@
      Client version .*
     ...................................................................
 
-     Matrix Size :  128
+     Matrix Size :  64
      Threads     :  4
 
 
@@ -24,19 +24,9 @@
      Finished computing current solution distance in mode 0.
      Mode changed to 0.
 
-     Started iteration 4 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 5 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
 
      The Jacobi Method For AX=B .........DONE
-     Total Number Of iterations   :  5
+     Total Number Of iterations   :  3
     ...................................................................
 ---- <application exited with code 0> ----
 Cache simulation results:
@@ -57,11 +47,11 @@ Core #1 \(.*\).*
 Core #2 \(.*\).*
 Core #3 \(.*\).*
 LL stats:
-    Hits:                    *[0-9,\.]*...
-    Misses:                  *[0-9,\.]*...
+    Hits:                    *[0-9,\.]*
+    Misses:                  *[0-9,\.]*
     Invalidations:           *0
-.*    Local miss rate:         *[0-9]*[\.,]..%
-    Child hits:              *[0-9,\.]*......
+.*    Local miss rate:        *[0-9,.]*%
+    Child hits:              *[0-9,\.]*
     Total miss rate:                  0[\.,]..%
 Coherence stats:
     Total writes:               *[0-9,\.]*

--- a/clients/drcachesim/tests/delay-simple.templatex
+++ b/clients/drcachesim/tests/delay-simple.templatex
@@ -5,21 +5,21 @@ Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
-    Misses:                       *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[0-9,\.]*%
   L1D stats:
     Hits:                         *[0-9,\.]*
-    Misses:                       *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[0-9,\.]*%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*.
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:             *[0-9,\.]*%
-    Child hits:                   *[0-9,\.]*.
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:              *[0-9,\.]*%

--- a/clients/drcachesim/tests/filter-no-d.templatex
+++ b/clients/drcachesim/tests/filter-no-d.templatex
@@ -4,7 +4,7 @@ Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
-    Misses:                       *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[1-9][0-9][,\.]..%
   L1D stats:
@@ -15,9 +15,9 @@ Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*.
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:             *[1-9][0-9][,\.]..%
-    Child hits:                   *[0-9,\.]*.
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:              *[1-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/filter-no-i.templatex
+++ b/clients/drcachesim/tests/filter-no-i.templatex
@@ -8,16 +8,16 @@ Core #0 \(1 thread\(s\)\)
     Invalidations:                       0
   L1D stats:
     Hits:                         *[0-9,\.]*
-    Misses:                       *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[1-9][0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*.
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:             *[1-9][0-9][,\.]..%
-    Child hits:                   *[0-9,\.]*.
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:              *[1-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/filter-simple.templatex
+++ b/clients/drcachesim/tests/filter-simple.templatex
@@ -4,21 +4,21 @@ Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
-    Misses:                       *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[1-9][0-9][,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*
-    Misses:                       *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[1-9][0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*.
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:             *[1-9][0-9][,\.]..%
-    Child hits:                   *[0-9,\.]*.
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:              *[1-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/missfile-config-file.templatex
+++ b/clients/drcachesim/tests/missfile-config-file.templatex
@@ -3,26 +3,26 @@ Hello, world!
 Cache simulation results:
 Core #0 \([0-9] traced CPU\(s\): #.*\)
   L1I stats:
-    Warmup hits:                  *[0-9,\.]*....
-    Warmup misses:                *[0-9,\.]*..
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*..
-    Invalidations:                *[0-9,\.]*..
+    Warmup hits:                  *[0-9,\.]*
+    Warmup misses:                *[0-9,\.]*
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *[0-9,\.]*
 .*L1D stats:
-    Warmup hits:                  *[0-9,\.]*....
-    Warmup misses:                *[0-9,\.]*..
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*..
-    Invalidations:                *[0-9,\.]*..
+    Warmup hits:                  *[0-9,\.]*
+    Warmup misses:                *[0-9,\.]*
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *[0-9,\.]*
 .*L2 stats:
-    Warmup hits:                  *[0-9,\.]*....
-    Warmup misses:                *[0-9,\.]*..
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*...
-    Invalidations:                *[0-9,\.]*..
+    Warmup hits:                  *[0-9,\.]*
+    Warmup misses:                *[0-9,\.]*
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *[0-9,\.]*
 .*LLC stats:
-    Warmup hits:                  *[0-9,\.]*....
-    Warmup misses:                *[0-9,\.]*..
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*...
+    Warmup hits:                  *[0-9,\.]*
+    Warmup misses:                *[0-9,\.]*
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0.*

--- a/clients/drcachesim/tests/multiproc.templatex
+++ b/clients/drcachesim/tests/multiproc.templatex
@@ -6,18 +6,18 @@ Core #0 \(1 thread\(s\)\)
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9,\.]*
     Invalidations:           *0
-.*    Miss rate:                        0[,\.]..%
+.*    Miss rate:                        [0-3][,\.]..%
   L1D stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9\.,]*
     Invalidations:           *0
-.*   Miss rate:                        0[,\.]..%
+.*   Miss rate:                        [0-3][,\.]..%
 Core #1 \(1 thread\(s\)\)
   L1I stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9,\.]*
     Invalidations:           *0
-.*    Miss rate:                        0[,\.]..%
+.*    Miss rate:                        [0-3][,\.]..%
   L1D stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9]*[,\.]?...
@@ -29,6 +29,6 @@ LL stats:
     Hits:                    *[0-9]*
     Misses:                  *[0-9]*[,\.]?...
     Invalidations:           *0
-.*    Local miss rate:         *[1-9][0-9][,\.]..%
+.*    Local miss rate:        *[0-9,.]*%
     Child hits:              *[0-9,\.]*[,\.]?...[,\.]?...
     Total miss rate:                  [0-9][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_client.templatex
+++ b/clients/drcachesim/tests/offline-burst_client.templatex
@@ -25,22 +25,22 @@ all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*.....
-    Misses:                       *[0-9,\.]*...
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*    Miss rate:                        0[,\.]..%
+.*    Miss rate:                        [0-3][,\.]..%
   L1D stats:
-    Hits:                         *[0-9,\.]*.....
-    Misses:                       *[0-9,\.]*.
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                        0[,\.]..%
+.*   Miss rate:                        [0-3][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*.
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:                *[0-9]*[,\.]..%
-    Child hits:                   *[0-9,\.]*...
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_maps.templatex
+++ b/clients/drcachesim/tests/offline-burst_maps.templatex
@@ -13,22 +13,22 @@ all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*.....
-    Misses:                       *[0-9,\.]*...
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*    Miss rate:                        0[,\.]..%
+.*    Miss rate:                        [0-3][,\.]..%
   L1D stats:
-    Hits:                         *[0-9,\.]*.....
-    Misses:                       *[0-9,\.]*.
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                        0[,\.]..%
+.*   Miss rate:                        [0-3][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*.
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:                *[0-9]*[,\.]..%
-    Child hits:                   *[0-9,\.]*...
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_noreach.templatex
+++ b/clients/drcachesim/tests/offline-burst_noreach.templatex
@@ -13,22 +13,22 @@ all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*.....
-    Misses:                       *[0-9,\.]*...
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*    Miss rate:                        0[,\.]..%
+.*    Miss rate:                        [0-3][,\.]..%
   L1D stats:
-    Hits:                         *[0-9,\.]*.....
-    Misses:                       *[0-9,\.]*.
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                        0[,\.]..%
+.*   Miss rate:                        [0-3][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*.
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:                *[0-9]*[,\.]..%
-    Child hits:                   *[0-9,\.]*...
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_replace.templatex
+++ b/clients/drcachesim/tests/offline-burst_replace.templatex
@@ -17,22 +17,22 @@ all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*.....
-    Misses:                       *[0-9,\.]*...
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*    Miss rate:                        0[,\.]..%
+.*    Miss rate:                        [0-3][,\.]..%
   L1D stats:
-    Hits:                         *[0-9,\.]*.....
-    Misses:                       *[0-9,\.]*.
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                        0[,\.]..%
+.*   Miss rate:                        [0-3][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*.
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:                *[0-9]*[,\.]..%
-    Child hits:                   *[0-9,\.]*...
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_replaceall.templatex
+++ b/clients/drcachesim/tests/offline-burst_replaceall.templatex
@@ -8,22 +8,22 @@ all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*.....
-    Misses:                       *[0-9,\.]*...
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*    Miss rate:                        0[,\.]..%
+.*    Miss rate:                        [0-3][,\.]..%
   L1D stats:
-    Hits:                         *[0-9,\.]*.....
-    Misses:                       *[0-9,\.]*.
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                        0[,\.]..%
+.*   Miss rate:                        [0-3][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*.
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:                *[0-9]*[,\.]..%
-    Child hits:                   *[0-9,\.]*...
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_static.templatex
+++ b/clients/drcachesim/tests/offline-burst_static.templatex
@@ -22,22 +22,22 @@ all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*.....
-    Misses:                       *[0-9,\.]*...
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*    Miss rate:                        0[,\.]..%
+.*    Miss rate:                        [0-3][,\.]..%
   L1D stats:
-    Hits:                         *[0-9,\.]*.....
-    Misses:                       *[0-9,\.]*.
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                        0[,\.]..%
+.*   Miss rate:                        [0-3][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*.
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:                *[0-9]*[,\.]..%
-    Child hits:                   *[0-9,\.]*...
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-1][,\.]..%

--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -28,6 +28,6 @@ LL stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Invalidations:              *0
-.*    Local miss rate:          *[0-9,\.]*%
+.*    Local miss rate:        *[0-9,.]*%
     Child hits:                 *[0-9,\.]*
     Total miss rate:            *[0-9,\.]*%

--- a/clients/drcachesim/tests/offline-filter.templatex
+++ b/clients/drcachesim/tests/offline-filter.templatex
@@ -3,21 +3,21 @@ Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
-    Misses:                       *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[0-9][0-9][,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*
-    Misses:                       *[0-9,\.]*.
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[0-9][0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*.
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:             *[0-9][0-9][,\.]..%
-    Child hits:                   *[0-9,\.]*.
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:              *[0-9][0-9][,\.]..%

--- a/clients/drcachesim/tests/offline-multiproc.templatex
+++ b/clients/drcachesim/tests/offline-multiproc.templatex
@@ -18,6 +18,6 @@ LL stats:
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9\.,]*
     Invalidations:           *0
-.*    Local miss rate:       *[0-9]*[,\.]..%
+.*    Local miss rate:        *[0-9,.]*%
     Child hits:              *[0-9\.,]*
     Total miss rate:         *[0-9]*[,\.]..%

--- a/clients/drcachesim/tests/offline-rseq.templatex
+++ b/clients/drcachesim/tests/offline-rseq.templatex
@@ -15,11 +15,11 @@ Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*.
+    Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:             *[0-9,\.]*%
-    Child hits:                   *[0-9,\.]*.
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:              *[0-9,\.]*%
 .*
 Trace invariant checks passed

--- a/clients/drcachesim/tests/offline-simple.templatex
+++ b/clients/drcachesim/tests/offline-simple.templatex
@@ -2,22 +2,22 @@ Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*...
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*    Miss rate:                        0[,\.]..%
+.*    Miss rate:                        [0-3][,\.]..%
   L1D stats:
-    Hits:                         *[0-9,\.]*...
-    Misses:                       *[0-9,\.]*...
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*...
-    Misses:                       *[0-9,\.]*...
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:                 [0-9].[,\.]..%
-    Child hits:                   *[0-9,\.]*...
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-4][,\.]..%

--- a/clients/drcachesim/tests/phys.templatex
+++ b/clients/drcachesim/tests/phys.templatex
@@ -6,7 +6,7 @@ Core #0 \(1 thread\(s\)\)
     Hits:                         *[0-9]*[,\.]?...
     Misses:                       *[0-9]..?
     Invalidations:                *0
-.*    Miss rate:                        0[,\.]..%
+.*    Miss rate:                        [0-3][,\.]..%
   L1D stats:
     Hits:                         *[0-9].[,\.]?...
     Misses:                       *[0-9]*[,\.]?..?.?
@@ -19,6 +19,6 @@ LL stats:
     Hits:                         *[0-9]..?
     Misses:                       *[0-9]*[,\.]?..?.?
     Invalidations:                *0
-.*   Local miss rate:                 [0-9].[,\.]..%
+.*   Local miss rate:        *[0-9,.]*%
     Child hits:                   *([3-9]|[1-9].).[,\.]?...
     Total miss rate:                  [0-2][,\.]..%

--- a/clients/drcachesim/tests/simple-config-file.templatex
+++ b/clients/drcachesim/tests/simple-config-file.templatex
@@ -3,26 +3,26 @@ Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*..
-    Invalidations:                *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *[0-9,\.]*
 .*    Miss rate:                        [0-9][,\.]..%
   L1D stats:
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*...
-    Invalidations:                *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *[0-9,\.]*
 .*   Miss rate:                        [0-9][,\.]..%
 L2 stats:
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*...
-    Invalidations:                *[0-9,\.]*..
-.*   Local miss rate:                 [0-9].[,\.]..%
-    Child hits:                   *[0-9,\.]*.....
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *[0-9,\.]*
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-3][,\.]..%
 LLC stats:
-    Hits:                         *[0-9,\.]*..
-    Misses:                       *[0-9,\.]*...
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:                 *[0-9,\.]*...
-    Child hits:                   *[0-9]*.....
-    Total miss rate:                  *[0-9].[,\.]..%
+.*   Local miss rate:         *[0-9,\.]*%
+    Child hits:                   *[0-9]*
+    Total miss rate:          *[0-9,\.]*%

--- a/clients/drcachesim/tests/simple-config-file.templatex
+++ b/clients/drcachesim/tests/simple-config-file.templatex
@@ -24,5 +24,5 @@ LLC stats:
     Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Local miss rate:         *[0-9,\.]*%
-    Child hits:                   *[0-9]*
+    Child hits:                   *[0-9,\.]*
     Total miss rate:          *[0-9,\.]*%

--- a/clients/drcachesim/tests/simple.templatex
+++ b/clients/drcachesim/tests/simple.templatex
@@ -3,22 +3,22 @@ Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*..
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-1][,\.]..%
   L1D stats:
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*...
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Hits:                         *[0-9,\.]*..
-    Misses:                       *[0-9,\.]*...
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:                 [0-9].[,\.]..%
-    Child hits:                   *[0-9,\.]*.....
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-3][,\.]..%

--- a/clients/drcachesim/tests/threads-with-config-file.templatex
+++ b/clients/drcachesim/tests/threads-with-config-file.templatex
@@ -5,7 +5,7 @@
      Client version .*
     ...................................................................
 
-     Matrix Size :  128
+     Matrix Size :  64
      Threads     :  4
 
 
@@ -24,19 +24,9 @@
      Finished computing current solution distance in mode 0.
      Mode changed to 0.
 
-     Started iteration 4 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 5 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
 
      The Jacobi Method For AX=B .........DONE
-     Total Number Of iterations   :  5
+     Total Number Of iterations   :  3
     ...................................................................
 ---- <application exited with code 0> ----
 Cache simulation results:
@@ -55,13 +45,13 @@ L2 stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Invalidations:              *[0-9,\.]*
-.*    Local miss rate:            *[0-9,\.]*%
+.*    Local miss rate:        *[0-9,.]*%
     Child hits:                 *[0-9,\.]*
     Total miss rate:            *[0-9,\.]*%
 LLC stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Invalidations:                      *0
-.*    Local miss rate:            *[0-9,\.]*%
+.*    Local miss rate:        *[0-9,.]*%
     Child hits:                 *[0-9,\.]*
     Total miss rate:            *[0-9,\.]*%

--- a/clients/drcachesim/tests/threads.templatex
+++ b/clients/drcachesim/tests/threads.templatex
@@ -5,7 +5,7 @@
      Client version .*
     ...................................................................
 
-     Matrix Size :  128
+     Matrix Size :  64
      Threads     :  4
 
 
@@ -24,19 +24,9 @@
      Finished computing current solution distance in mode 0.
      Mode changed to 0.
 
-     Started iteration 4 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
-     Started iteration 5 of the computation...
-
-     Finished computing current solution distance in mode 0.
-     Mode changed to 0.
-
 
      The Jacobi Method For AX=B .........DONE
-     Total Number Of iterations   :  5
+     Total Number Of iterations   :  3
     ...................................................................
 ---- <application exited with code 0> ----
 Cache simulation results:
@@ -55,9 +45,9 @@ Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
 Core #3 \([0-9] traced CPU\(s\).*
 LL stats:
-    Hits:                    *[0-9,\.]*...
-    Misses:                  *[0-9,\.]*...
+    Hits:                    *[0-9,\.]*
+    Misses:                  *[0-9,\.]*
     Invalidations:           *0
-.*    Local miss rate:         *[0-9]*[\.,]..%
-    Child hits:              *[0-9,\.]*......
+.*    Local miss rate:        *[0-9,.]*%
+    Child hits:              *[0-9,\.]*
     Total miss rate:                  0[\.,]..%

--- a/clients/drcachesim/tests/warmup-valid.templatex
+++ b/clients/drcachesim/tests/warmup-valid.templatex
@@ -3,28 +3,28 @@ Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Warmup hits:                  *[0-9,\.]*..
-    Warmup misses:                *[0-9,\.]*..
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*..
+    Warmup hits:                  *[0-9,\.]*
+    Warmup misses:                *[0-9,\.]*
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-1][,\.]..%
   L1D stats:
-    Warmup hits:                  *[0-9,\.]*..
-    Warmup misses:                *[0-9,\.]*..
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*...
+    Warmup hits:                  *[0-9,\.]*
+    Warmup misses:                *[0-9,\.]*
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Warmup hits:                  *[0-9,\.]*..
-    Warmup misses:                *[0-9,\.]*..
-    Hits:                         *[0-9,\.]*..
-    Misses:                       *[0-9,\.]*...
+    Warmup hits:                  *[0-9,\.]*
+    Warmup misses:                *[0-9,\.]*
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:                 [0-9].[,\.]..%
-    Child hits:                   *[0-9,\.]*.....
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-3][,\.]..%

--- a/clients/drcachesim/tests/warmup-zeros.templatex
+++ b/clients/drcachesim/tests/warmup-zeros.templatex
@@ -3,28 +3,28 @@ Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
-    Warmup hits:                  *[0]*..
-    Warmup misses:                *[0]*..
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*..
+    Warmup hits:                  *[0]*
+    Warmup misses:                *[0]*
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-1][,\.]..%
   L1D stats:
-    Warmup hits:                  *[0]*..
-    Warmup misses:                *[0]*..
-    Hits:                         *[0-9,\.]*....
-    Misses:                       *[0-9,\.]*...
+    Warmup hits:                  *[0]*
+    Warmup misses:                *[0]*
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                        [0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
 LL stats:
-    Warmup hits:                  *[0]*..
-    Warmup misses:                *[0]*..
-    Hits:                         *[0-9,\.]*..
-    Misses:                       *[0-9,\.]*...
+    Warmup hits:                  *[0]*
+    Warmup misses:                *[0]*
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Local miss rate:                 [0-9].[,\.]..%
-    Child hits:                   *[0-9,\.]*.....
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-3][,\.]..%

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -320,11 +320,15 @@ if (NOT cross_aarchxx_linux_only AND NOT cross_android_only)
       INTERNAL:BOOL=OFF
       ")
   endif ()
-  testbuild_ex("release-external-32" OFF "
-    DEBUG:BOOL=OFF
-    INTERNAL:BOOL=OFF
-    ${install_path_cache}
-    " OFF ${arg_package} "${install_build_args}")
+  # i#4059: We skip 32-bit release build in Appveyor PR's to speed things up.
+  # The 64-bit release should cover nearly all 32-bit release-only warnings.
+  if (NOT DEFINED ENV{APPVEYOR_PULL_REQUEST_NUMBER})
+    testbuild_ex("release-external-32" OFF "
+      DEBUG:BOOL=OFF
+      INTERNAL:BOOL=OFF
+      ${install_path_cache}
+      " OFF ${arg_package} "${install_build_args}")
+  endif ()
   if (last_build_dir MATCHES "-32")
     set(32bit_path "TEST_32BIT_PATH:PATH=${last_build_dir}/suite/tests/bin")
   else ()

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1889,11 +1889,11 @@ if (CLIENT_INTERFACE)
     if (UNIX)
       set(annotation_test_args "libclient.annotation-concurrency.appdll.so" "A" "4")
       set(annotation_test_args_shorter
-        "libclient.annotation-concurrency.appdll.so" "A" "4" "128" "5")
+        "libclient.annotation-concurrency.appdll.so" "A" "4" "64" "3")
     else (UNIX)
       set(annotation_test_args "client.annotation-concurrency.appdll.dll" "A" "4")
       set(annotation_test_args_shorter
-        "client.annotation-concurrency.appdll.dll" "A" "4" "128" "5")
+        "client.annotation-concurrency.appdll.dll" "A" "4" "64" "3")
     endif (UNIX)
     tobuild_ci(client.annotation-concurrency client-interface/annotation-concurrency.c
       "" "" "${annotation_test_args}")
@@ -2984,10 +2984,15 @@ endif ()
         else ()
           set(dir_prefix "${testname_full}")
         endif ()
+        set(extra_ops "")
+        if (WIN32 AND NOT ${testname_full}_full_run)
+          # Shrink test times on Appveyor.
+          set(extra_ops "-max_trace_size 1M")
+        endif ()
         torunonly_ci(tool.drcacheoff.${testname} ${exetgt} drcachesim
           "offline-${testname}.c" # for templatex basename
           # Set a test-unique prefix to avoid races removing/finding output.
-          "-offline -subdir_prefix ${testname_full} ${tracer_ops}"
+          "-offline -subdir_prefix ${testname_full} ${extra_ops} ${tracer_ops}"
           "" "${app_args}")
         set(${testname_full}_toolname "drcachesim")
         set(${testname_full}_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
@@ -3045,6 +3050,9 @@ endif ()
 
       # We run common.decode-bad to test markers for faults
       if (X86) # decode-bad is x86-only
+        # Do not cap the trace size (done to shorten tests) b/c it will then miss
+        # kernel transfer events.
+        set(tool.drcacheoff.basic_counts_full_run ON)
         torunonly_drcacheoff(basic_counts common.decode-bad ""
           "@-simulator_type@basic_counts" "")
         unset(tool.drcacheoff.basic_counts_rawtemp)
@@ -3054,7 +3062,7 @@ endif ()
         "@-simulator_type@opcode_mix" "")
 
       torunonly_drcacheoff(view ${ci_shared_app} ""
-        "@-simulator_type@view" "")
+        "@-simulator_type@view@-sim_refs@16384" "")
 
       if (LINUX AND X86 AND X64 AND HAVE_RSEQ)
         torunonly_drcacheoff(rseq linux.rseq "" "@-test_mode" "")


### PR DESCRIPTION
Removes the 32-bit release build from PR builds (the 64-bit should
catch nearly all warnings).

Further shrinks drcachesim tests using the Jacobi app by dropping to a
64 matrix size and 3 instead of 5 iterations.

Shrinks drcacheoff tests on Windows by capping the trace sizes at 1M,
except for basic_counts which needs the full run to see kernel events.
Relaxes all of the templates to allow for correspondingly varying
simulator statistics.

Issue: #4059