### PR TITLE
i#2666: decrease MAX_CONTEXT_SIZE for 32-bit to actual value

### DIFF
--- a/core/win32/os_private.h
+++ b/core/win32/os_private.h
@@ -475,7 +475,7 @@ extern uint context_xstate;
 #ifdef X64
 #    define MAX_CONTEXT_SIZE MAX_CONTEXT_64_SIZE
 #else
-#    define MAX_CONTEXT_SIZE 0xd2f /* as observed on win10-x64 */
+#    define MAX_CONTEXT_SIZE 0xb23 /* as observed on win10-x64 */
 #endif
 #define CONTEXT_DYNAMICALLY_LAID_OUT(flags) (TESTALL(CONTEXT_XSTATE, flags))
 


### PR DESCRIPTION
@derekbruening Sorry if I did not make it clear in #4122 that we only looked at the `MAX_CONTEXT_SIZE` for 64-bit, and for simplicity just set the same for 32-bit.

Was able to debug it again today for 32-bit, and the value is indeed lower than for 64-bit.

Issue: #2666