### PR TITLE
i#4144: Fix assert in raw2trace on mapping files

### DIFF
--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -4179,7 +4179,10 @@ dr_map_executable_file(const char *filename, dr_map_executable_flags_t flags,
 bool
 dr_unmap_executable_file(byte *base, size_t size)
 {
-    return d_r_unmap_file(base, size);
+    if (standalone_library)
+        return os_unmap_file(base, size);
+    else
+        return d_r_unmap_file(base, size);
 }
 
 DR_API

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -497,7 +497,7 @@ privload_map_and_relocate(const char *filename, size_t *size OUT, modload_flags_
     /* NOTE: all but the client lib will be added to DR areas list b/c using
      * d_r_map_file()
      */
-    if (dynamo_heap_initialized) {
+    if (dynamo_heap_initialized && !standalone_library) {
         map_func = d_r_map_file;
         unmap_func = d_r_unmap_file;
         prot_func = set_protection;

--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -1030,7 +1030,7 @@ privload_map_and_relocate(const char *filename, size_t *size OUT, modload_flags_
      * an app exception: FIXME: should we raise a better error message?
      */
     *size = 0; /* map at full size */
-    if (dynamo_heap_initialized) {
+    if (dynamo_heap_initialized && !standalone_library) {
         /* These hold the DR lock and update DR areas */
         map_func = d_r_map_file;
         unmap_func = d_r_unmap_file;


### PR DESCRIPTION
raw2trace uses dr_map_executable_file() which calls
privload_map_and_relocate() which uses the DR-memory-tracking
dr_map_file(), which can hit problems in standalone mode.  We change
it to always use os_map_file() for standalone_library=true.

Fixes #4144