### PR TITLE
i#3917: Fix gcc 9.2.1 build errors

### DIFF
--- a/core/unix/include/sigcontext.h
+++ b/core/unix/include/sigcontext.h
@@ -17,7 +17,9 @@
 
 #define FP_XSTATE_MAGIC1 0x46505853U
 #define FP_XSTATE_MAGIC2 0x46505845U
-#define FP_XSTATE_MAGIC2_SIZE sizeof(FP_XSTATE_MAGIC2)
+#ifndef FP_XSTATE_MAGIC2_SIZE
+#    define FP_XSTATE_MAGIC2_SIZE sizeof(FP_XSTATE_MAGIC2)
+#endif
 
 /*
  * bytes 464..511 in the current 512byte layout of fxsave/fxrstor frame

--- a/ext/drgui/drgui_main_window.h
+++ b/ext/drgui/drgui_main_window.h
@@ -64,7 +64,7 @@ public:
 
 protected:
     void
-    closeEvent(QCloseEvent *event);
+    closeEvent(QCloseEvent *event) override;
 
 private slots:
     void


### PR DESCRIPTION
Fixes a duplicate sigcontext define and adds a missing override in
drgui to address issues building with gcc 9.2.1

Fixes #3917