### PR TITLE
i#4155: Fix raw2trace crash on Windows

### DIFF
--- a/core/stats.h
+++ b/core/stats.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -129,10 +129,11 @@ typedef struct {
 
 extern timestamp_t kstat_ignore_context_switch;
 
-#    define KSTAT_THREAD_NO_PV_START(dc)                                       \
-        do {                                                                   \
-            dcontext_t *cur_dcontext = (dc);                                   \
-            if (cur_dcontext != NULL && cur_dcontext->thread_kstats != NULL) { \
+#    define KSTAT_THREAD_NO_PV_START(dc)                                   \
+        do {                                                               \
+            dcontext_t *cur_dcontext = (dc);                               \
+            if (cur_dcontext != NULL && cur_dcontext != GLOBAL_DCONTEXT && \
+                cur_dcontext->thread_kstats != NULL) {                     \
                 kstat_stack_t *ks = &cur_dcontext->thread_kstats->stack_kstats;
 
 #    define KSTAT_THREAD_NO_PV_END() \

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3076,12 +3076,9 @@ endif ()
       torunonly_drcacheoff(view ${ci_shared_app} ""
         "@-simulator_type@view@-sim_refs@16384" "")
 
-      # TODO i#4155: This passes locally but is failing on Appveyor.
-      if (NOT WIN32)
-        set(tool.drcacheoff.func_view_full_run ON) # Fails on Windows if truncated.
-        torunonly_drcacheoff(func_view common.fib "-record_function fib|1"
-          "@-simulator_type@func_view" "only_5")
-      endif ()
+      set(tool.drcacheoff.func_view_full_run ON) # Fails on Windows if truncated.
+      torunonly_drcacheoff(func_view common.fib "-record_function fib|1"
+        "@-simulator_type@func_view" "only_5")
 
       if (LINUX AND X86 AND X64 AND HAVE_RSEQ)
         torunonly_drcacheoff(rseq linux.rseq "" "@-test_mode" "")


### PR DESCRIPTION
Adds a check for the current dcontext being GLOBAL_DCONTEXT in the
kstats code to avoid a raw2trace crash.

Enables the func_view test on Windows.

Fixes #4155