### PR TITLE
i#4134: Add sample to highlight drbbdup API usage

### DIFF
--- a/api/docs/samples.dox
+++ b/api/docs/samples.dox
@@ -115,6 +115,9 @@ different libraries: memtrace_x86_text, which produces a readable,
 text-mode trace, but is much slower than memtrace_x86_binary, which
 produces a binary-format trace file.
 
+The sample <a href="https://github.com/DynamoRIO/dynamorio/tree/master/api/samples/hot_bbcount.c">hot_bbcount.c</a>
+uses the drbbdup extension to count the execution of hot basic blocks which have exceeded a given hit threshold.
+
 The sample <a href="https://github.com/DynamoRIO/dynamorio/tree/master/api/samples/modxfer.c">modxfer.c</a>
 reports the control flow transfers between modules.
 

--- a/api/samples/CMakeLists.txt
+++ b/api/samples/CMakeLists.txt
@@ -236,7 +236,7 @@ if (X86) # FIXME i#1551, i#1569: port to ARM and AArch64
   add_sample_client(instrcalls  "instrcalls.c;utils.c"  "drmgr;drsyms;drx")
   # dr_insert_cbr_instrument_ex is NYI
   add_sample_client(cbrtrace    "cbrtrace.c;utils.c"    "drmgr;drx")
-  add_sample_client(hot_bbcount     "hot_bbcount.c"       "drmgr;drreg;drbbdup;drx")
+  add_sample_client(hot_bbcount "hot_bbcount.c"         "drmgr;drreg;drbbdup;drx")
 endif (X86)
 add_sample_client(wrap        "wrap.c"          "drmgr;drwrap")
 add_sample_client(signal      "signal.c"        "drmgr")

--- a/api/samples/CMakeLists.txt
+++ b/api/samples/CMakeLists.txt
@@ -236,6 +236,7 @@ if (X86) # FIXME i#1551, i#1569: port to ARM and AArch64
   add_sample_client(instrcalls  "instrcalls.c;utils.c"  "drmgr;drsyms;drx")
   # dr_insert_cbr_instrument_ex is NYI
   add_sample_client(cbrtrace    "cbrtrace.c;utils.c"    "drmgr;drx")
+  add_sample_client(hot_bbcount     "hot_bbcount.c"       "drmgr;drreg;drbbdup;drx")
 endif (X86)
 add_sample_client(wrap        "wrap.c"          "drmgr;drwrap")
 add_sample_client(signal      "signal.c"        "drmgr")

--- a/api/samples/hot_bbcount.c
+++ b/api/samples/hot_bbcount.c
@@ -158,7 +158,7 @@ insert_encode(void *drcontext, void *tag, instrlist_t *bb, instr_t *where,
 {
     app_pc *bb_pc = (app_pc *)orig_analysis_data;
     dr_insert_clean_call(drcontext, bb, where, encode, false, 1,
-                         OPND_CREATE_INTPTR((intptr_t)*bb_pc));
+                         OPND_CREATE_INTPTR((intptr_t)(*bb_pc)));
 }
 
 static void
@@ -207,7 +207,8 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
             /* Basic block is cold. Therefore insert clean call to mark the hit. */
             app_pc *bb_pc = (app_pc *)orig_analysis_data;
             dr_insert_clean_call(drcontext, bb, where /* insert always at where */,
-                                 register_hit, false, 1, OPND_CREATE_INTPTR(*bb_pc));
+                                 register_hit, false, 1,
+                                 OPND_CREATE_INTPTR((intptr_t)(*bb_pc)));
         }
     }
 }

--- a/api/samples/hot_bbcount.c
+++ b/api/samples/hot_bbcount.c
@@ -1,0 +1,226 @@
+/* **********************************************************
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Basic Block Duplicator API Sample:
+ * hotbbcount.c
+ *
+ * Reports the dynamic execution count of hot basic blocks.
+ * Illustrates how to use drbbdup to create different versions of
+ * basic block instrumentation.
+ *
+ * Two cases of instrumentation are set for a basic block. The first
+ * version is not instrumented with .
+ * The second version is executed only when the bb is hot and has code inserted
+ * to count its execution.
+ */
+
+#include <stddef.h> /* for offsetof */
+#include "dr_api.h"
+#include "drmgr.h"
+#include "drreg.h"
+#include "drbbdup.h"
+#include "drx.h"
+#include "hashtable.h"
+
+/* Start counting once a bb has been executed at least 10 times. */
+#define HIT_THRESHOLD 10
+
+#ifdef WINDOWS
+#    define DISPLAY_STRING(msg) dr_messagebox(msg)
+#else
+#    define DISPLAY_STRING(msg) dr_printf("%s\n", msg);
+#endif
+
+#define NULL_TERMINATE(buf) buf[(sizeof(buf) / sizeof(buf[0])) - 1] = '\0'
+
+/* we only have a global count */
+static int global_count;
+
+/* Global hash table. */
+static hashtable_t hit_count_table;
+#define HASH_BITS 13
+
+static void
+event_exit(void)
+{
+#ifdef SHOW_RESULTS
+    char msg[512];
+    int len;
+    len = dr_snprintf(msg, sizeof(msg) / sizeof(msg[0]),
+                      "Instrumentation results:\n"
+                      "%10d basic block executions\n" global_count);
+    DR_ASSERT(len > 0);
+    NULL_TERMINATE(msg);
+    DISPLAY_STRING(msg);
+#endif /* SHOW_RESULTS */
+
+    /* Delete hit count table */
+    hashtable_delete(&hit_count_table);
+
+    drbbdup_exit();
+    drx_exit();
+    drreg_exit();
+    drmgr_exit();
+}
+
+static uintptr_t
+set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
+               bool *enable_dups, void *user_data)
+{
+    /* Init hit count */
+    app_pc bb_pc = instr_get_app_pc(instrlist_first_app(bb));
+    dr_fprintf(STDERR, "Set: %p\n", bb_pc);
+    hashtable_lock(&hit_count_table);
+    if (hashtable_lookup(&hit_count_table, bb_pc) == NULL) {
+        /* If hit count is not mapped to this bb, then add a new count to the table */
+        uint *hit_count = dr_global_alloc(sizeof(uint));
+        *hit_count = HIT_THRESHOLD;
+        hashtable_add(&hit_count_table, bb_pc, hit_count);
+    }
+    hashtable_unlock(&hit_count_table);
+
+    /* Enable duplication for all basic blocks. */
+    *enable_dups = true;
+
+    /* Register the case encoding for counting the execution of hot basic blocks. */
+    drbbdup_register_case_encoding(drbbdup_ctx, (uintptr_t) true /* hot */);
+
+    /* Set the default case encoding for tracking the hit count of basic blocks. */
+    return 0; /* cold */
+}
+
+static void
+encode(app_pc bb_pc)
+{
+    bool is_hot;
+    hashtable_lock(&hit_count_table);
+    uint *hit_count = hashtable_lookup(&hit_count_table, bb_pc);
+    dr_fprintf(STDERR, "Check: %p\n", bb_pc);
+    DR_ASSERT_MSG(hit_count != NULL, "hit count must be present");
+    if (*hit_count == 0)
+        is_hot = true;
+    else {
+        is_hot = false;
+        (*hit_count)--;
+    }
+    hashtable_unlock(&hit_count_table);
+
+    drbbdup_set_encoding((uintptr_t)is_hot);
+}
+
+static void
+insert_encode(void *drcontext, instrlist_t *bb, instr_t *where, void *user_data,
+              void *orig_analysis_data)
+{
+    app_pc bb_pc = instr_get_app_pc(instrlist_first_app(bb));
+    dr_insert_clean_call(drcontext, bb, where, encode, false, 1,
+                         OPND_CREATE_INTPTR(bb_pc));
+}
+
+static void
+instrument_instr(void *drcontext, instrlist_t *bb, instr_t *instr, instr_t *where,
+                 uintptr_t encoding, void *user_data, void *orig_analysis_data,
+                 void *analysis_data)
+{
+    bool is_start;
+
+    /* By default drmgr enables auto-predication, which predicates all instructions with
+     * the predicate of the current instruction on ARM.
+     * We disable it here because we want to unconditionally execute the following
+     * instrumentation.
+     */
+    drmgr_disable_auto_predication(drcontext, bb);
+
+    /* Check if hot case */
+    if (encoding == 1) {
+        drbbdup_is_first_instr(drcontext, instr, &is_start);
+        if (is_start) {
+            /* racy update on the counter for better performance */
+            drx_insert_counter_update(drcontext, bb, where /*insert always at where */,
+                                      /* We're using drmgr, so these slots
+                                       * here won't be used: drreg's slots will be.
+                                       */
+                                      SPILL_SLOT_MAX + 1, &global_count, 1, 0);
+        }
+    }
+}
+
+static void
+destroy_hit_count(void *entry)
+{
+    uint *hit_count = (uint *)entry;
+    dr_global_free(hit_count, sizeof(uint));
+}
+
+DR_EXPORT void
+dr_client_main(client_id_t id, int argc, const char *argv[])
+{
+    drreg_options_t ops = { sizeof(ops), 1 /*max slots needed: aflags*/, false };
+    dr_set_client_name("DynamoRIO Sample Client 'hot_bbcount'",
+                       "http://dynamorio.org/issues");
+    if (!drmgr_init() || !drx_init() || drreg_init(&ops) != DRREG_SUCCESS)
+        DR_ASSERT(false);
+
+    /* register events */
+    dr_register_exit_event(event_exit);
+
+    hashtable_init_ex(&hit_count_table, HASH_BITS, HASH_INTPTR, false /*!strdup*/,
+                      false /*synchronization is external*/, destroy_hit_count, NULL,
+                      NULL);
+
+    /* Initialise drbbdup. */
+    drbbdup_options_t opts = { sizeof(drbbdup_options_t),
+                               set_up_bb_dups,
+                               insert_encode,
+                               NULL,
+                               NULL,
+                               NULL,
+                               NULL,
+                               instrument_instr,
+                               NULL,
+                               1 /* num of additional copies. */ };
+    if (drbbdup_init(&opts) != DRBBDUP_SUCCESS)
+        DR_ASSERT(false);
+
+    /* make it easy to tell, by looking at log file, which client executed */
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'hot_bbcount' initializing\n");
+#ifdef SHOW_RESULTS
+    /* also give notification to stderr */
+    if (dr_is_notify_on()) {
+#    ifdef WINDOWS
+        /* ask for best-effort printing to cmd window.  must be called at init. */
+        dr_enable_console_printing();
+#    endif
+        dr_fprintf(STDERR, "Client hot_bbcount is running\n");
+    }
+#endif
+}

--- a/api/samples/hot_bbcount.c
+++ b/api/samples/hot_bbcount.c
@@ -31,7 +31,7 @@
  */
 
 /* Basic Block Duplicator API Sample:
- * hotbbcount.c
+ * hot_bbcount.c
  *
  * Reports the dynamic execution count of hot basic blocks.
  * Illustrates how to use drbbdup to create different versions of

--- a/api/samples/hot_bbcount.c
+++ b/api/samples/hot_bbcount.c
@@ -157,8 +157,8 @@ insert_encode(void *drcontext, void *tag, instrlist_t *bb, instr_t *where,
               void *user_data, void *orig_analysis_data)
 {
     app_pc *bb_pc = (app_pc *)orig_analysis_data;
-    dr_insert_clean_call(drcontext, bb, where, encode, false, 1,
-                         OPND_CREATE_INTPTR((intptr_t)(*bb_pc)));
+    dr_insert_clean_call(drcontext, bb, where, (void *)encode, false, 1,
+                         OPND_CREATE_INTPTR(*bb_pc));
 }
 
 static void
@@ -207,8 +207,8 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
             /* Basic block is cold. Therefore insert clean call to mark the hit. */
             app_pc *bb_pc = (app_pc *)orig_analysis_data;
             dr_insert_clean_call(drcontext, bb, where /* insert always at where */,
-                                 register_hit, false, 1,
-                                 OPND_CREATE_INTPTR((intptr_t)(*bb_pc)));
+                                 (void *)register_hit, false, 1,
+                                 OPND_CREATE_INTPTR(*bb_pc));
         }
     }
 }

--- a/api/samples/hot_bbcount.c
+++ b/api/samples/hot_bbcount.c
@@ -86,7 +86,7 @@ event_exit(void)
     DISPLAY_STRING(msg);
 #endif /* SHOW_RESULTS */
 
-    /* Delete hit count table */
+    /* Delete hit count table. */
     hashtable_delete(&hit_count_table);
 
     drbbdup_exit();
@@ -206,7 +206,7 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
         } else {
             /* Basic block is cold. Therefore insert clean call to mark the hit. */
             app_pc *bb_pc = (app_pc *)orig_analysis_data;
-            dr_insert_clean_call(drcontext, bb, where /*insert always at where */,
+            dr_insert_clean_call(drcontext, bb, where /* insert always at where */,
                                  register_hit, false, 1, OPND_CREATE_INTPTR(*bb_pc));
         }
     }
@@ -222,7 +222,7 @@ destroy_hit_count(void *entry)
 DR_EXPORT void
 dr_client_main(client_id_t id, int argc, const char *argv[])
 {
-    drreg_options_t drreg_ops = { sizeof(drreg_ops), 1 /*max slots needed: aflags*/,
+    drreg_options_t drreg_ops = { sizeof(drreg_ops), 1 /* max slots needed: aflags */,
                                   false };
     dr_set_client_name("DynamoRIO Sample Client 'hot_bbcount'",
                        "http://dynamorio.org/issues");
@@ -248,7 +248,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
                                       NULL,
                                       instrument_instr,
                                       NULL,
-                                      1 /* num of additional copies. */ };
+                                      1 /* Only one additional copy is needed. */ };
     if (drbbdup_init(&drbbdup_ops) != DRBBDUP_SUCCESS)
         DR_ASSERT(false);
 

--- a/api/samples/hot_bbcount.c
+++ b/api/samples/hot_bbcount.c
@@ -41,7 +41,7 @@
  * version is executed when a basic block is cold. The basic block's hit
  * count is recorded by performing a clean call in this instrumentation case.
  * The second version is executed when the basic block has reached the appropriate
- * hit count (i.e., it is not considered hot). Code is inserted to count the
+ * hit count (i.e., it is now considered hot). Code is inserted to count the
  * execution of the hot basic block similar to the bbcount client.
  */
 
@@ -148,6 +148,7 @@ encode(app_pc bb_pc)
     is_hot = *hit_count == 0;
     hashtable_unlock(&hit_count_table);
 
+    /* Set current runtime case encoding. */
     drbbdup_set_encoding((uintptr_t)is_hot);
 }
 

--- a/api/samples/hot_bbcount.c
+++ b/api/samples/hot_bbcount.c
@@ -121,7 +121,7 @@ set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
 }
 
 static void
-analyse_orig_bb(void *drcontext, instrlist_t *bb, void *user_data,
+analyse_orig_bb(void *drcontext, void *tag, instrlist_t *bb, void *user_data,
                 IN void **orig_analysis_data)
 {
     /* Extract bb_pc and set store it as analysis data. */
@@ -152,8 +152,8 @@ encode(app_pc bb_pc)
 }
 
 static void
-insert_encode(void *drcontext, instrlist_t *bb, instr_t *where, void *user_data,
-              void *orig_analysis_data)
+insert_encode(void *drcontext, void *tag, instrlist_t *bb, instr_t *where,
+              void *user_data, void *orig_analysis_data)
 {
     app_pc *bb_pc = (app_pc *)orig_analysis_data;
     dr_insert_clean_call(drcontext, bb, where, encode, false, 1,
@@ -175,9 +175,9 @@ register_hit(app_pc bb_pc)
 }
 
 static void
-instrument_instr(void *drcontext, instrlist_t *bb, instr_t *instr, instr_t *where,
-                 uintptr_t encoding, void *user_data, void *orig_analysis_data,
-                 void *analysis_data)
+instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
+                 instr_t *where, uintptr_t encoding, void *user_data,
+                 void *orig_analysis_data, void *analysis_data)
 {
     bool is_start;
 


### PR DESCRIPTION
Includes a sample to demonstrate how to use drbbdup.

The client sets up two instrumentation cases per basic block. One case tracks the hit count of  a basic block when _cold_ to determine whether it exceeds a threshold and should be considered _hot_. The second version simply counts the number of times a hot basic block is executed.

Issue: #4134 