### PR TITLE
i#4160: Adds parens to NULL_TERMINATE Macro

### DIFF
--- a/api/samples/bbcount.c
+++ b/api/samples/bbcount.c
@@ -51,7 +51,7 @@
 #    define DISPLAY_STRING(msg) dr_printf("%s\n", msg);
 #endif
 
-#define NULL_TERMINATE(buf) buf[(sizeof(buf) / sizeof(buf[0])) - 1] = '\0'
+#define NULL_TERMINATE(buf) (buf)[(sizeof((buf)) / sizeof((buf)[0])) - 1] = '\0'
 
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 #define TESTANY(mask, var) (((mask) & (var)) != 0)

--- a/api/samples/countcalls.c
+++ b/api/samples/countcalls.c
@@ -51,7 +51,7 @@
 #    define DISPLAY_STRING(msg) dr_printf("%s\n", msg);
 #endif
 
-#define NULL_TERMINATE(buf) buf[(sizeof(buf) / sizeof(buf[0])) - 1] = '\0'
+#define NULL_TERMINATE(buf) (buf)[(sizeof((buf)) / sizeof((buf)[0])) - 1] = '\0'
 
 /* keep separate counters for each thread, in this thread-local data
  * structure:

--- a/api/samples/div.c
+++ b/api/samples/div.c
@@ -45,7 +45,7 @@
 #    define DISPLAY_STRING(msg) dr_printf("%s\n", msg);
 #endif
 
-#define NULL_TERMINATE(buf) buf[(sizeof(buf) / sizeof(buf[0])) - 1] = '\0'
+#define NULL_TERMINATE(buf) (buf)[(sizeof((buf)) / sizeof((buf)[0])) - 1] = '\0'
 
 static dr_emit_flags_t
 event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,

--- a/api/samples/hot_bbcount.c
+++ b/api/samples/hot_bbcount.c
@@ -62,7 +62,7 @@
 #    define DISPLAY_STRING(msg) dr_printf("%s\n", msg);
 #endif
 
-#define NULL_TERMINATE(buf) buf[(sizeof(buf) / sizeof(buf[0])) - 1] = '\0'
+#define NULL_TERMINATE(buf) (buf)[(sizeof((buf)) / sizeof((buf)[0])) - 1] = '\0'
 
 /* we only have a global count */
 static int global_count;

--- a/api/samples/inscount.cpp
+++ b/api/samples/inscount.cpp
@@ -56,7 +56,7 @@
 #    define DISPLAY_STRING(msg) dr_printf("%s\n", msg);
 #endif
 
-#define NULL_TERMINATE(buf) buf[(sizeof(buf) / sizeof(buf[0])) - 1] = '\0'
+#define NULL_TERMINATE(buf) (buf)[(sizeof((buf)) / sizeof((buf)[0])) - 1] = '\0'
 
 static droption_t<bool> only_from_app(
     DROPTION_SCOPE_CLIENT, "only_from_app", false,

--- a/api/samples/modxfer_app2lib.c
+++ b/api/samples/modxfer_app2lib.c
@@ -53,7 +53,7 @@
 #    define DISPLAY_STRING(msg) dr_printf("%s\n", msg);
 #endif
 
-#define NULL_TERMINATE(buf) buf[(sizeof(buf) / sizeof(buf[0])) - 1] = '\0'
+#define NULL_TERMINATE(buf) (buf)[(sizeof((buf)) / sizeof((buf)[0])) - 1] = '\0'
 
 static uint64 app_count; /* number of instructions executed in app */
 static uint64 lib_count; /* number of instructions executed in libs */

--- a/api/samples/opcodes.c
+++ b/api/samples/opcodes.c
@@ -48,7 +48,7 @@
 #    define DISPLAY_STRING(msg) dr_printf("%s\n", msg);
 #endif
 
-#define NULL_TERMINATE(buf) buf[(sizeof(buf) / sizeof(buf[0])) - 1] = '\0'
+#define NULL_TERMINATE(buf) (buf)[(sizeof((buf)) / sizeof((buf)[0])) - 1] = '\0'
 
 /* We keep a separate execution count per opcode.
  *

--- a/api/samples/wrap.c
+++ b/api/samples/wrap.c
@@ -54,7 +54,7 @@
 #    define DISPLAY_STRING(msg) dr_printf("%s\n", msg);
 #endif
 
-#define NULL_TERMINATE(buf) buf[(sizeof(buf) / sizeof(buf[0])) - 1] = '\0'
+#define NULL_TERMINATE(buf) (buf)[(sizeof((buf)) / sizeof((buf)[0])) - 1] = '\0'
 
 static void
 event_exit(void);


### PR DESCRIPTION
Adds parentheses to the param of the NULL_TERMINATE macro found in many samples.

Fixes: #4160 