### PR TITLE
i#2892,i#3980: Ignore known-flaky tests on A64

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -230,7 +230,9 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                    'code_api|tool.histogram.gzip' => 1);
             # FIXME i#2417: fix flaky AArch64 tests
             %ignore_failures_64 = ('code_api|linux.sigsuspend' => 1,
-                                   'code_api|pthreads.pthreads_exit' => 1);
+                                   'code_api|pthreads.pthreads_exit' => 1,
+                                   'code_api|drcachesim.invariants' => 1, # i#2892
+                                   'code_api|tool.histogram.offline' => 1); # i#3980
             if ($is_32) {
                 $issue_no = "#2416";
             } else {

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -231,7 +231,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
             # FIXME i#2417: fix flaky AArch64 tests
             %ignore_failures_64 = ('code_api|linux.sigsuspend' => 1,
                                    'code_api|pthreads.pthreads_exit' => 1,
-                                   'code_api|drcachesim.invariants' => 1, # i#2892
+                                   'code_api|tool.drcachesim.invariants' => 1, # i#2892
                                    'code_api|tool.histogram.offline' => 1); # i#3980
             if ($is_32) {
                 $issue_no = "#2416";


### PR DESCRIPTION
Adds drcachesim.invariants (i#2982) and tool.histogram.offline
(i#3980) to the tests whose failures are ignored, until we can
reproduce and fix them.

Issue: #2892, #3980