### PR TITLE
Reset stderr to decimal in analysis tools

### DIFF
--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -116,6 +116,8 @@ public:
     /**
      * The heart of an analysis tool, this routine operates on a single trace entry and
      * takes whatever actions the tool needs to perform its analysis.
+     * If it prints, it should leave the i/o state in a default format
+     * (std::dec) to support multiple tools.
      * The return value indicates whether it was successful.
      * On failure, get_error_string() returns a descriptive message.
      */
@@ -123,6 +125,8 @@ public:
     process_memref(const memref_t &memref) = 0;
     /**
      * This routine reports the results of the trace analysis.
+     * It should leave the i/o state in a default format (std::dec) to support
+     * multiple tools.
      * The return value indicates whether it was successful.
      * On failure, get_error_string() returns a descriptive message.
      */

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -334,6 +334,8 @@ bool
 analyzer_t::print_stats()
 {
     for (int i = 0; i < num_tools_; ++i) {
+        // Each tool should reset i/o state, but we reset the format here just in case.
+        std::cerr << std::dec;
         if (!tools_[i]->print_results()) {
             error_string_ = tools_[i]->get_error_string();
             return false;

--- a/clients/drcachesim/simulator/cache_miss_analyzer.cpp
+++ b/clients/drcachesim/simulator/cache_miss_analyzer.cpp
@@ -205,5 +205,7 @@ cache_miss_analyzer_t::print_results()
         fclose(file);
     }
 
+    // Reset the i/o format for subsequent tool invocations.
+    std::cerr << std::dec;
     return true;
 }

--- a/clients/drcachesim/tools/func_view.cpp
+++ b/clients/drcachesim/tools/func_view.cpp
@@ -197,6 +197,8 @@ func_view_t::process_memref(const memref_t &memref)
     }
     default: break;
     }
+    // Reset the i/o format for subsequent tool invocations.
+    std::cerr << std::dec;
     return true;
 }
 
@@ -231,7 +233,7 @@ bool
 func_view_t::print_results()
 {
     std::unordered_map<int, func_stats_t> func_totals = compute_totals();
-    std::cerr << TOOL_NAME << " results:\n" << std::dec;
+    std::cerr << TOOL_NAME << " results:\n";
     if (func_totals.empty()) {
         std::cerr << "No functions founds.  Did you enable function tracing?:\n";
     }

--- a/clients/drcachesim/tools/histogram.cpp
+++ b/clients/drcachesim/tools/histogram.cpp
@@ -172,5 +172,7 @@ histogram_t::print_results()
         std::cerr << std::setw(18) << std::hex << std::showbase << (it->first << 6)
                   << ": " << std::dec << it->second << "\n";
     }
+    // Reset the i/o format for subsequent tool invocations.
+    std::cerr << std::dec;
     return true;
 }

--- a/clients/drcachesim/tools/reuse_distance.cpp
+++ b/clients/drcachesim/tools/reuse_distance.cpp
@@ -358,5 +358,7 @@ reuse_distance_t::print_results()
         }
     }
 
+    // Reset the i/o format for subsequent tool invocations.
+    std::cerr << std::dec;
     return true;
 }


### PR DESCRIPTION
Documents and implements a convention of resetting stderr to decimal
format in all print_results() and handle_memref() functions that
change the output format to hex, to better support chaining multiple
tools.