### PR TITLE
i#3048 func-trace: Add new+delete to -record_heap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -695,6 +695,7 @@ endmacro()
 set(BASE_CFLAGS "")
 set(BASE_CONLY_FLAGS "")
 set(BASE_CXXONLY_FLAGS "")
+CHECK_CXX_COMPILER_FLAG("-std=c++17" cxx17_available)
 if (UNIX)
   set(BASE_CXXONLY_FLAGS "${BASE_CXXONLY_FLAGS} -std=c++11")
   # -std=c99 doesn't quite work

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -454,7 +454,34 @@ droption_t<std::string> op_record_heap_value(
     "malloc|1" OP_RECORD_FUNC_ITEM_SEP "free|1|noret" OP_RECORD_FUNC_ITEM_SEP
     "tc_malloc|1" OP_RECORD_FUNC_ITEM_SEP "tc_free|1|noret" OP_RECORD_FUNC_ITEM_SEP
     "__libc_malloc|1" OP_RECORD_FUNC_ITEM_SEP
-    "__libc_free|1|noret" OP_RECORD_FUNC_ITEM_SEP "calloc|2",
+    "__libc_free|1|noret" OP_RECORD_FUNC_ITEM_SEP "calloc|2" OP_RECORD_FUNC_ITEM_SEP
+#ifdef UNIX
+    // i#3048: We only have Itanium ABI manglings for now so we disable for MSVC.
+    // XXX: This is getting quite long.  I would change the option to point at
+    // a file, except that does not work well with some third-party uses.
+    // Another option would be to support wildcards and give up on extra args like
+    // alignment and nothrow: so we'd do "_Zn*|1&_Zd*|1|noret".
+    "_Znwm|1" OP_RECORD_FUNC_ITEM_SEP "_ZnwmRKSt9nothrow_t|2" OP_RECORD_FUNC_ITEM_SEP
+    "_ZnwmSt11align_val_t|2" OP_RECORD_FUNC_ITEM_SEP
+    "_ZnwmSt11align_val_tRKSt9nothrow_t|3" OP_RECORD_FUNC_ITEM_SEP
+    "_ZnwmPv|2" OP_RECORD_FUNC_ITEM_SEP "_Znam|1" OP_RECORD_FUNC_ITEM_SEP
+    "_ZnamRKSt9nothrow_t|2" OP_RECORD_FUNC_ITEM_SEP
+    "_ZnamSt11align_val_t|2" OP_RECORD_FUNC_ITEM_SEP
+    "_ZnamSt11align_val_tRKSt9nothrow_t|3" OP_RECORD_FUNC_ITEM_SEP
+    "_ZnamPv|2" OP_RECORD_FUNC_ITEM_SEP "_ZdlPv|1|noret" OP_RECORD_FUNC_ITEM_SEP
+    "_ZdlPvRKSt9nothrow_t|2|noret" OP_RECORD_FUNC_ITEM_SEP
+    "_ZdlPvSt11align_val_t|2|noret" OP_RECORD_FUNC_ITEM_SEP
+    "_ZdlPvSt11align_val_tRKSt9nothrow_t|3|noret" OP_RECORD_FUNC_ITEM_SEP
+    "_ZdlPvm|2|noret" OP_RECORD_FUNC_ITEM_SEP
+    "_ZdlPvmSt11align_val_t|3|noret" OP_RECORD_FUNC_ITEM_SEP
+    "_ZdlPvS_|2|noret" OP_RECORD_FUNC_ITEM_SEP "_ZdaPv|1|noret" OP_RECORD_FUNC_ITEM_SEP
+    "_ZdaPvRKSt9nothrow_t|2|noret" OP_RECORD_FUNC_ITEM_SEP
+    "_ZdaPvSt11align_val_t|2|noret" OP_RECORD_FUNC_ITEM_SEP
+    "_ZdaPvSt11align_val_tRKSt9nothrow_t|3|noret" OP_RECORD_FUNC_ITEM_SEP
+    "_ZdaPvm|2|noret" OP_RECORD_FUNC_ITEM_SEP
+    "_ZdaPvmSt11align_val_t|3|noret" OP_RECORD_FUNC_ITEM_SEP "_ZdaPvS_|2|noret"
+#endif
+    ,
     "Functions recorded by -record_heap",
     "Functions recorded by -record_heap. The option value should fit the same"
     " format required by -record_function. These functions will not"

--- a/clients/drcachesim/tests/heap_test.cpp
+++ b/clients/drcachesim/tests/heap_test.cpp
@@ -1,0 +1,149 @@
+/* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "tools.h"
+#include <new>
+#include <stdio.h>
+
+static void
+test_operators()
+{
+    const int iters = 99;
+    for (int i = 0; i < iters; ++i) {
+        // Invoke all of the global operator news and deletes.
+        // We do not call destructors for our explicit operator calls: we are
+        // not allocating anything that needs it.
+
+        // void *operator new(std::size_t count);
+        int *int_ptr = new int;
+        // void operator delete(void *ptr) noexcept;
+        delete int_ptr;
+
+        // void *operator new[](std::size_t count);
+        int_ptr = new int[42];
+        // void operator delete[](void *ptr) noexcept;
+        delete[] int_ptr;
+
+        // void *operator new(std::size_t count, const std::nothrow_t &tag);
+        int_ptr = new (std::nothrow) int;
+        // void operator delete(void *ptr, const std::nothrow_t &tag) noexcept;
+        ::operator delete(int_ptr, std::nothrow);
+        // void *operator new[](std::size_t count, const std::nothrow_t &tag);
+        int_ptr = new (std::nothrow) int[42];
+        // void operator delete[](void *ptr, const std::nothrow_t &tag) noexcept;
+        ::operator delete[](int_ptr, std::nothrow);
+
+#if defined(__cpp_aligned_new)
+        // void *operator new(std::size_t count, std::align_val_t al);
+        class alignas(64) align64 {
+            int x = 0;
+        };
+        auto *aligned_class = new align64;
+        int *aligned_int = new (std::align_val_t{ 64 }) int;
+        // void operator delete(void *ptr, std::align_val_t al) noexcept;
+        delete aligned_class;
+        // Some compilers (MSVC) will complain with just "delete".
+        ::operator delete (aligned_int, std::align_val_t{ 64 });
+
+        // void *operator new[](std::size_t count, std::align_val_t al);
+        aligned_class = new align64[4];
+        aligned_int = new (std::align_val_t{ 64 }) int[42];
+        // void operator delete[](void *ptr, std::align_val_t al) noexcept;
+        delete[] aligned_class;
+        // Some compilers (MSVC) will complain with just "delete[]".
+        ::operator delete[](aligned_int, std::align_val_t{ 64 });
+
+        // void *operator new(std::size_t count, std::align_val_t al,
+        //                    const std::nothrow_t &);
+        aligned_class = new (std::nothrow) align64;
+        aligned_int = new (std::align_val_t{ 64 }, std::nothrow) int;
+        // void operator delete(void *ptr, std::align_val_t al,
+        //                      const std::nothrow_t &tag) noexcept;
+        ::operator delete(aligned_class, std::nothrow);
+        ::operator delete (aligned_int, std::align_val_t{ 64 }, std::nothrow);
+        // void *operator new[](std::size_t count, std::align_val_t al,
+        //                     const std::nothrow_t &);
+        aligned_class = new (std::nothrow) align64[4];
+        aligned_int = new (std::align_val_t{ 64 }, std::nothrow) int[42];
+        // void operator delete[](void *ptr, std::align_val_t al,
+        //                        const std::nothrow_t &tag) noexcept;
+        ::operator delete[](aligned_class, std::nothrow);
+        ::operator delete[](aligned_int, std::align_val_t{ 64 }, std::nothrow);
+#endif
+#if defined(__cpp_sized_deallocation)
+        // void operator delete(void *ptr, std::size_t sz) noexcept;
+        int_ptr = new int;
+        ::operator delete(int_ptr, sizeof(*int_ptr));
+        // void operator delete[](void *ptr, std::size_t sz) noexcept;
+        int_ptr = new int[42];
+        ::operator delete(int_ptr, 42 * sizeof(*int_ptr));
+#endif
+#if defined(__cpp_aligned_new) && defined(__cpp_sized_deallocation)
+        aligned_class = new align64;
+        aligned_int = new (std::align_val_t{ 64 }) int;
+        // void operator delete(void *ptr, std::size_t sz, std::align_val_t al) noexcept;
+        ::operator delete (aligned_class, sizeof(*aligned_class),
+                           std::align_val_t{ alignof(*aligned_class) });
+        ::operator delete (aligned_int, sizeof(*aligned_int), std::align_val_t{ 64 });
+
+        aligned_class = new align64[4];
+        aligned_int = new (std::align_val_t{ 64 }) int[42];
+        // void operator delete[](void *ptr, std::size_t sz, std::align_val_t al)
+        // noexcept;
+        ::operator delete[](aligned_class, 4 * sizeof(*aligned_class),
+                            std::align_val_t{ alignof(*aligned_class) });
+        ::operator delete[](aligned_int, 42 * sizeof(*aligned_int),
+                            std::align_val_t{ 64 });
+#endif
+        // void *operator new(std::size_t count, void *ptr);
+        void *buf = malloc(sizeof(*int_ptr));
+        int_ptr = new (buf) int;
+        // void operator delete(void *ptr, void *place) noexcept;
+        ::operator delete(int_ptr, buf);
+        free(buf);
+
+        // void *operator new[](std::size_t count, void *ptr);
+        buf = malloc(42 * sizeof(*int_ptr));
+        int_ptr = new (buf) int[42];
+        // void operator delete[](void *ptr, void *place) noexcept;
+        ::operator delete[](int_ptr, buf);
+        free(buf);
+    }
+}
+
+int
+main()
+{
+    test_operators();
+    print("All done.\n");
+    return 0;
+}

--- a/clients/drcachesim/tests/offline-burst_malloc.templatex
+++ b/clients/drcachesim/tests/offline-burst_malloc.templatex
@@ -8,7 +8,7 @@ DynamoRIO statistics:
 .*
 all done
 .*
-.* 5006 function id markers.*
-.* 3004 function return address markers.*
-.* 3005 function argument markers.*
-.* 2002 function return value markers.*
+.* 50.. function id markers.*
+.* 30.. function return address markers.*
+.* 30.. function argument markers.*
+.* 20.. function return value markers.*

--- a/clients/drcachesim/tests/offline-func_view_heap.templatex
+++ b/clients/drcachesim/tests/offline-func_view_heap.templatex
@@ -1,0 +1,9 @@
+All done.
+Function view tool results:
+// XXX: It is not easy to check the output in a non-flaky way as it varies completely
+// by compiler and C++ library.  What I want to check is that ifdef CXX17 then
+// we covered one of each operator (in *some* module: there will be some never-hit
+// functions due to duplication in other libraries).  The comparison is
+// order-sensitive so we can't safely list any symbols here.
+// For now we only test that we successfully traced.
+.*

--- a/clients/drcachesim/tests/offline-func_view_heap.templatex
+++ b/clients/drcachesim/tests/offline-func_view_heap.templatex
@@ -4,6 +4,6 @@ Function view tool results:
 // by compiler and C++ library.  What I want to check is that ifdef CXX17 then
 // we covered one of each operator (in *some* module: there will be some never-hit
 // functions due to duplication in other libraries).  The comparison is
-// order-sensitive so we can't safely list any symbols here.
+// order-sensitive so we cannot safely list any symbols here.
 // For now we only test that we successfully traced.
 .*

--- a/clients/drcachesim/tools/func_view.cpp
+++ b/clients/drcachesim/tools/func_view.cpp
@@ -247,6 +247,10 @@ func_view_t::cmp_func_stats(const std::pair<int, func_stats_t> &l,
 {
     if (l.second.num_calls > r.second.num_calls)
         return true;
+    if (l.second.num_calls < r.second.num_calls)
+        return false;
+    if (l.second.num_returns > r.second.num_returns)
+        return true;
     if (l.second.num_returns < r.second.num_returns)
         return false;
     return l.first < r.first;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3105,6 +3105,21 @@ endif ()
         set(tool.drcacheoff.func_view_noret_rawtemp ON) # no preprocessor
       endif ()
 
+      if (UNIX) # i#3048: Our mangled operator new/delete tracing is UNIX-only.
+        set(heap_test_src ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/heap_test.cpp)
+        add_exe(tool.heap_test ${heap_test_src})
+        if (cxx17_available)
+          # Enable recent operator new/delete variants.
+          set_source_files_properties(${heap_test_src} PROPERTIES
+            # XXX: c++17 seems to warn more about the static functions in tools.h.
+            # We should move those to tools.c.  For now we disable the warning.
+            COMPILE_FLAGS "${ORIG_CMAKE_CXX_FLAGS} -std=c++17 -Wno-unused-function")
+        endif ()
+        torunonly_drcacheoff(func_view_heap tool.heap_test
+          "-record_heap" "@-simulator_type@func_view@-no_show_func_trace" "")
+        unset(tool.drcacheoff.func_view_heap_rawtemp) # use preprocessor
+      endif ()
+
       if (LINUX AND X86 AND X64 AND HAVE_RSEQ)
         torunonly_drcacheoff(rseq linux.rseq "" "@-test_mode" "")
       endif ()

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3105,7 +3105,12 @@ endif ()
         set(tool.drcacheoff.func_view_noret_rawtemp ON) # no preprocessor
       endif ()
 
-      if (UNIX) # i#3048: Our mangled operator new/delete tracing is UNIX-only.
+      # i#3048: Our mangled operator new/delete tracing is UNIX-only.
+      # PR#4178: Despite the aligned-new code in this test being guarded by
+      # "if defined(__cpp_aligned_new)" it fails to build on Travis clang-9 and
+      # OSX presumably due to runtime vs compiler mismatches.  We just disable
+      # for clang for now and can re-enable later w/ more recent runtimes.
+      if (UNIX AND NOT CMAKE_COMPILER_IS_CLANG)
         set(heap_test_src ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/heap_test.cpp)
         add_exe(tool.heap_test ${heap_test_src})
         if (cxx17_available)


### PR DESCRIPTION
Adds all 24 global operator new and delete variants to the default
-record_heap_value, since in some implementations they do not simply
call malloc and free.  We include the Itanium ABI manglings only here.
MSVC and Windows heap interception is even more complex with more
layers and we leave that for future work.

Adds a new test which calls each one, though some are only compiled
and called if C++17 is available in the compiler.  It is not easy to
check the output so for now we do not have good automated validation
that all operators were caught, only manual checking.

Issue: #3048