### PR TITLE
i#4045: Remove custom exit stub support

### DIFF
--- a/core/arch/disassemble_shared.c
+++ b/core/arch/disassemble_shared.c
@@ -1537,18 +1537,6 @@ instrlist_disassemble(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist,
             offs += sz;
         }
         DOLOG(5, LOG_ALL, { print_file(outfile, "---- multi-instr boundary ----\n"); });
-
-#    ifdef CUSTOM_EXIT_STUBS
-        /* custom exit stub? */
-        if (instr_is_exit_cti(instr) && instr_is_app(instr)) {
-            instrlist_t *custom = instr_exit_stub_code(instr);
-            if (custom != NULL) {
-                print_file(outfile, "\t=> custom exit stub code:\n");
-                instrlist_disassemble(dcontext, instr_get_branch_target_pc(instr), custom,
-                                      outfile);
-            }
-        }
-#    endif
     }
 
     print_file(outfile, "END " PFX "\n\n", tag);

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -433,11 +433,7 @@ link_direct_exit(dcontext_t *dcontext, fragment_t *f, linkstub_t *l, fragment_t 
                  bool hot_patch)
 {
 #ifdef TRACE_HEAD_CACHE_INCR
-#    ifdef CUSTOM_EXIT_STUBS
-    byte *stub_pc = (byte *)(EXIT_FIXED_STUB_PC(dcontext, f, l));
-#    else
     byte *stub_pc = (byte *)(EXIT_STUB_PC(dcontext, f, l));
-#    endif
 #endif
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
     ASSERT(LINKSTUB_DIRECT(l->flags));
@@ -487,11 +483,7 @@ unlink_direct_exit(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
 
 #ifdef TRACE_HEAD_CACHE_INCR
     if (dl->target_fragment != NULL) { /* HACK to tell if targeted trace head */
-#    ifdef CUSTOM_EXIT_STUBS
-        byte *pc = (byte *)(EXIT_FIXED_STUB_PC(dcontext, f, l));
-#    else
         byte *pc = (byte *)(EXIT_STUB_PC(dcontext, f, l));
-#    endif
         /* FIXME: more efficient way than multiple calls to get size-5? */
         ASSERT(linkstub_size(dcontext, f, l) == DIRECT_EXIT_STUB_SIZE(f->flags));
         patch_branch(FRAG_ISA_MODE(f->flags), pc + DIRECT_EXIT_STUB_SIZE(f->flags) - 5,
@@ -521,9 +513,6 @@ link_indirect_exit(dcontext_t *dcontext, fragment_t *f, linkstub_t *l, bool hot_
      * state (we do have multi-stage modifications for inlined stubs)
      */
     byte *stub_pc = (byte *)EXIT_STUB_PC(dcontext, f, l);
-#ifdef CUSTOM_EXIT_STUBS
-    byte *fixed_stub_pc = (byte *)EXIT_FIXED_STUB_PC(dcontext, f, l);
-#endif
 
     ASSERT(!TEST(FRAG_COARSE_GRAIN, f->flags));
 
@@ -1262,11 +1251,7 @@ update_indirect_exit_stub(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
 {
     generated_code_t *code =
         get_emitted_routines_code(dcontext _IF_X86_64(FRAGMENT_GENCODE_MODE(f->flags)));
-#ifdef CUSTOM_EXIT_STUBS
-    byte *start_pc = (byte *)EXIT_FIXED_STUB_PC(dcontext, f, l);
-#else
     byte *start_pc = (byte *)EXIT_STUB_PC(dcontext, f, l);
-#endif
     ibl_branch_type_t branch_type;
 
     ASSERT(linkstub_owned_by_fragment(dcontext, f, l));

--- a/core/arch/instr.h
+++ b/core/arch/instr.h
@@ -186,7 +186,7 @@ enum {
     /* DR_API EXPORT BEGIN */
     INSTR_DO_NOT_MANGLE = 0x00200000,
     /* DR_API EXPORT END */
-    INSTR_HAS_CUSTOM_STUB = 0x00400000,
+    /* Available: 0x00400000, */
     /* used to indicate that an indirect call can be treated as a direct call */
     INSTR_IND_CALL_DIRECT = 0x00800000,
 #    ifdef WINDOWS
@@ -794,34 +794,6 @@ DR_API
  */
 void
 instr_set_ok_to_emit(instr_t *instr, bool val);
-
-#ifdef CUSTOM_EXIT_STUBS
-DR_API
-/**
- * If \p instr is not an exit cti, does nothing.
- * If \p instr is an exit cti, sets \p stub to be custom exit stub code
- * that will be inserted in the exit stub prior to the normal exit
- * stub code.  If \p instr already has custom exit stub code, that
- * existing instrlist_t is cleared and destroyed (using current thread's
- * context).  (If \p stub is NULL, any existing stub code is NOT destroyed.)
- * The creator of the instrlist_t containing \p instr is
- * responsible for destroying stub.
- * \note Custom exit stubs containing control transfer instructions to
- * other instructions inside a fragment besides the custom stub itself
- * are not fully supported in that they will not be decoded from the
- * cache properly as having instr_t targets.
- */
-void
-instr_set_exit_stub_code(instr_t *instr, instrlist_t *stub);
-
-DR_API
-/**
- * Returns the custom exit stub code instruction list that has been
- * set for this instruction.  If none exists, returns NULL.
- */
-instrlist_t *
-instr_exit_stub_code(instr_t *instr);
-#endif
 
 DR_API
 /**

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2749,9 +2749,6 @@ removed_fragment_stats(dcontext_t *dcontext, fcache_t *cache, fragment_t *f)
         if (!EXIT_HAS_LOCAL_STUB(l->flags, f->flags))
             continue; /* it's kept elsewhere */
         sz = linkstub_size(dcontext, f, l);
-#    ifdef CUSTOM_EXIT_STUBS
-        sz += l->fixed_stub_offset;
-#    endif
         if (LINKSTUB_INDIRECT(l->flags))
             STATS_FCACHE_ADD(cache, indirect_stubs, -sz);
         else {

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2512,9 +2512,6 @@ fragment_recreate_with_linkstubs(dcontext_t *dcontext, fragment_t *f_src)
         if (!EXIT_HAS_LOCAL_STUB(l->flags, f_tgt->flags))
             continue; /* it's kept elsewhere */
         size += linkstub_size(dcontext, f_tgt, l);
-#ifdef CUSTOM_EXIT_STUBS
-        size += l->fixed_stub_offset;
-#endif
     }
     ASSERT_TRUNCATE(f_tgt->size, ushort, size);
     f_tgt->size = (ushort)size;

--- a/core/globals.h
+++ b/core/globals.h
@@ -99,7 +99,6 @@
 #ifdef CLIENT_INTERFACE
 /* in Makefile, we define these (so that genapi.pl, etc. get them):
  *    define DYNAMORIO_IR_EXPORTS 1
- *    define CUSTOM_EXIT_STUBS 1
  *    define CUSTOM_TRACES 1
  * CUSTOM_TRACES_RET_REMOVAL is aggressive -- assumes calling convention kept
  * Only useful if custom traces are doing inlining => do not define for external

--- a/core/heap.c
+++ b/core/heap.c
@@ -121,9 +121,6 @@ static const uint BLOCK_SIZES[] = {
 #    else
 /* release == instr_t */
 #    endif
-#elif defined(CUSTOM_EXIT_STUBS)
-#    error "FIXME i#3611: Fix build and check the heap buckets for the correct order."
-/* all other bb/trace buckets are 8 larger but in same order */
 #else
     sizeof(fragment_t) + sizeof(direct_linkstub_t) +
         sizeof(cbr_fallthrough_linkstub_t), /* 60 dbg / 56 rel */

--- a/core/link.h
+++ b/core/link.h
@@ -166,11 +166,6 @@ struct _linkstub_t {
      * Do not directly access this field -- use EXIT_CTI_PC()
      */
     ushort cti_offset; /* offset from fragment start_pc of this cti */
-
-#ifdef CUSTOM_EXIT_STUBS
-    ushort fixed_stub_offset; /* offset in bytes of fixed part of exit stub from
-                               * stub_pc, which points to custom stub prefix */
-#endif
 };
 
 /* linkage info common to all direct fragment exits */
@@ -352,10 +347,6 @@ typedef struct _coarse_incoming_t {
          ? (((direct_linkstub_t *)(l))->target_tag)                                      \
          : (LINKSTUB_CBR_FALLTHROUGH((l)->flags) ? ((f)->tag + ((short)(l)->cti_offset)) \
                                                  : indirect_linkstub_target(dc, f, l)))
-
-#ifdef CUSTOM_EXIT_STUBS
-#    define EXIT_FIXED_STUB_PC(dc, f, l) (EXIT_STUB_PC(dc, f, l) + (l)->fixed_stub_offset)
-#endif
 
 #ifdef WINDOWS
 #    define EXIT_TARGETS_SHARED_SYSCALL(flags) \

--- a/core/options.c
+++ b/core/options.c
@@ -1212,7 +1212,7 @@ check_option_compatibility_helper(int recurse_count)
         changed_options = true;
     }
 
-#    if defined(TRACE_HEAD_CACHE_INCR) || defined(CUSTOM_EXIT_STUBS)
+#    if defined(TRACE_HEAD_CACHE_INCR)
     if (DYNAMO_OPTION(pad_jmps)) {
         USAGE_ERROR("-pad_jmps not supported in this build yet");
     }
@@ -1566,11 +1566,6 @@ check_option_compatibility_helper(int recurse_count)
             dynamo_options.indirect_stubs = true;
             changed_options = true;
         }
-#        endif
-#        ifdef CUSTOM_EXIT_STUBS
-        USAGE_ERROR("CUSTOM_EXIT_STUBS requires -indirect_stubs, enabling");
-        dynamo_options.indirect_stubs = true;
-        changed_options = true;
 #        endif
 #        ifdef HASHTABLE_STATISTICS
         if ((!DYNAMO_OPTION(shared_traces) && DYNAMO_OPTION(inline_trace_ibl)) ||
@@ -2131,11 +2126,6 @@ check_option_compatibility_helper(int recurse_count)
 #    endif
 
     if (DYNAMO_OPTION(coarse_units)) {
-#    ifdef CUSTOM_EXIT_STUBS
-        USAGE_ERROR("-coarse_units incompatible with CUSTOM_EXIT_STUBS: disabling");
-        dynamo_options.coarse_units = false;
-        changed_options = true;
-#    endif
 #    ifdef CLIENT_INTERFACE
         if (DYNAMO_OPTION(bb_prefixes)) {
             /* coarse_units doesn't support prefixes in general.

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -2769,8 +2769,8 @@ OPTION_DEFAULT(uint, early_inject_location, 4 /* INJECT_LOCATION_LdrDefault */,
     OPTION_DEFAULT(uint, prng_seed, 0 /* get a good seed from the OS */,
         "if non-0 allows reproducible pseudo random number generator sequences")
 
-    /* TODO i#4045: Remove these defines. */
-#if defined(TRACE_HEAD_CACHE_INCR) || defined(CUSTOM_EXIT_STUBS)
+    /* TODO i#4045: Remove this define. */
+#if defined(TRACE_HEAD_CACHE_INCR)
     OPTION_DEFAULT(bool, pad_jmps, false, "nop pads jmps in the cache that we might need to patch so that the offset doesn't cross a L1 cache line boundary (necessary for atomic linking/unlinking on an mp machine)")
 #else
 /* No need to pad on ARM with fixed-width instructions */

--- a/make/configure.cmake.h
+++ b/make/configure.cmake.h
@@ -194,8 +194,6 @@
 #    $(D)ANNOTATIONS -- optional instrumentation of binary annotations
 #                       in the target program
 #    $(D)DR_APP_EXPORTS
-#    $(D)CUSTOM_EXIT_STUBS -- optional part of CLIENT_INTERFACE
-#      we may want it for our own internal use too, though
 #    $(D)CUSTOM_TRACES -- optional part of CLIENT_INTERFACE
 #      has some sub-features that are aggressive and not supported by default:
 #      $(D)CUSTOM_TRACES_RET_REMOVAL = support for removing inlined rets
@@ -300,8 +298,7 @@
 # define DYNAMORIO_IR_EXPORTS
 # define CUSTOM_TRACES
 # define CLIENT_SIDELINE
-  /* TODO i#4045: Remove these completely from the code base.
-# define CUSTOM_EXIT_STUBS
+  /* TODO i#4045: Remove completely from the code base.
 # define UNSUPPORTED_API
    */
 #endif


### PR DESCRIPTION
Removes the no-longer-supported custom exit stub feature: all of the
code under the CUSTOM_EXIT_STUBS define and the INSTR_HAS_CUSTOM_STUB
flag.  Removing the flag frees it up for use in #4180.

Issue: #4045, #4180