### PR TITLE
i#4070 drwrap-site: Add drwrap_get_stats() with flush count

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -247,6 +247,7 @@ Further non-compatibility-affecting changes include:
  - Added a non-heap-using instruction structure #instr_noalloc_t for use when
    decoding in a signal handler, along with instr_noalloc_init() and
    instr_from_noalloc().
+ - Added drwrap_get_stats().
 
 **************************************************
 <hr>

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -221,6 +221,9 @@ typedef struct _per_thread_t {
  * UTILITIES
  */
 
+/* Rather than a mutex we use atomic increments. */
+static drwrap_stats_t drwrap_stats;
+
 /* XXX: should DR provide this variant of dr_safe_read?  DrMem uses this too. */
 bool
 fast_safe_read(void *base, size_t size, void *out_buf)
@@ -1190,6 +1193,7 @@ drwrap_replace_common(hashtable_t *table, app_pc original, void *payload, bool o
          * we can't use dr_unlink_flush_region() unless we require that
          * caller hold no locks and be in clean call or syscall event.
          */
+        dr_atomic_add64_return_sum(&drwrap_stats.flush_count, 1);
         if (!dr_delay_flush_region(original, 1, 0, NULL))
             ASSERT(false, "replace update flush failed");
     }
@@ -1635,6 +1639,7 @@ drwrap_replace_native_fini(void *drcontext)
 static void
 drwrap_flush_func(app_pc func)
 {
+    dr_atomic_add64_return_sum(&drwrap_stats.flush_count, 1);
     /* we can't flush while holding the lock.
      * we do not guarantee faster than a lazy flush.
      */
@@ -1704,9 +1709,7 @@ drwrap_mark_retaddr_for_instru(void *drcontext, app_pc decorated_pc,
                 disabled_count = DISABLED_COUNT_FLUSH_THRESHOLD + 1;
                 dr_recurlock_unlock(wrap_lock);
             }
-            /* XXX: have a STATS mechanism to count flushes and add call
-             * site analysis if too many flushes.
-             */
+            dr_atomic_add64_return_sum(&drwrap_stats.flush_count, 1);
             dr_flush_region(retaddr, 1);
             /* now we are guaranteed no thread is inside the fragment */
             /* another thread may have done a racy competing flush: should be fine */
@@ -2319,6 +2322,7 @@ drwrap_wrap_ex(app_pc func, void (*pre_func_cb)(void *wrapcxt, INOUT void **user
         hashtable_add(&wrap_table, (void *)func, (void *)wrap_new);
         /* XXX: we're assuming void* tag == pc */
         if (dr_fragment_exists_at(dr_get_current_drcontext(), func)) {
+            dr_atomic_add64_return_sum(&drwrap_stats.flush_count, 1);
             /* we do not guarantee faster than a lazy flush */
             if (!dr_unlink_flush_region(func, 1))
                 ASSERT(false, "wrap update flush failed");
@@ -2399,6 +2403,16 @@ drwrap_is_post_wrap(app_pc pc)
     res = (hashtable_lookup(&post_call_table, (void *)pc) != NULL);
     dr_rwlock_read_unlock(post_call_rwlock);
     return res;
+}
+
+DR_EXPORT
+bool
+drwrap_get_stats(INOUT drwrap_stats_t *stats)
+{
+    if (stats == NULL || stats->size != sizeof(*stats))
+        return false;
+    stats->flush_count = drwrap_stats.flush_count;
+    return true;
 }
 
 /***************************************************************************

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -2427,7 +2427,7 @@ drwrap_get_stats(INOUT drwrap_stats_t *stats)
 {
     if (stats == NULL || stats->size != sizeof(*stats))
         return false;
-    stats->flush_count = drwrap_stats.flush_count;
+    stats->flush_count = dr_atomic_add64_return_sum(&drwrap_stats.flush_count, 0);
     return true;
 }
 

--- a/ext/drwrap/drwrap.dox
+++ b/ext/drwrap/drwrap.dox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2012 Google, Inc.   All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /* drwrap: DynamoRIO Function Wrapping and Replacing Extension
@@ -31,6 +31,7 @@ support.
  - \ref sec_drwrap_setup
  - \ref sec_drwrap_events
  - \ref sec_drwrap_api
+ - \ref sec_drwrap_perf
  - \ref sec_drwrap_license
 
 \section sec_drwrap_setup Setup
@@ -87,6 +88,18 @@ i.e., it executes after the \p call instruction but before any instructions
 within the body of the wrapped function. The post-function callback occurs
 after the wrapped function returns, as if inserted just after the call
 instruction.
+
+\section sec_drwrap_perf Performance
+
+For the lowest overhead, if your use case is compatible with the
+(relatively minor) limitations imposed by the two flags
+#DRWRAP_NO_FRILLS and #DRWRAP_FAST_CLEANCALLS, we recommend setting
+them both.
+
+A major cause of overhead is flushing when a post-call point is
+dynamically discovered and it is already present in the code cache.
+The drwrap_get_stats() interface can be used to measure the number of
+flushes triggered by drwrap.
 
 \section sec_drwrap_license LGPL 2.1 License
 

--- a/ext/drwrap/drwrap.h
+++ b/ext/drwrap/drwrap.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /* drwrap: DynamoRIO Function Wrapping and Replacing Extension
@@ -747,6 +747,31 @@ DR_EXPORT
  */
 bool
 drwrap_is_post_wrap(app_pc pc);
+
+/**
+ * Contains statistics retrievable by drwrap_get_stats().
+ */
+typedef struct _drwrap_stats_t {
+    /** The size of this structure. Set this to sizeof(drwrap_stats_t). */
+    size_t size;
+    /**
+     * The total number of code cache flushes.  These occur due to return points
+     * already existing in the cache; replacing existing instrumentation; and
+     * removing wrap or replace instrumentation.
+     */
+    int64 flush_count;
+} drwrap_stats_t;
+
+DR_EXPORT
+/**
+ * Retrieves various statistics exported by DR as global, process-wide values.
+ * The API is not thread-safe.
+ * The caller is expected to pass a pointer to a valid, initialized dr_stats_t
+ * value, with the size field set (see dr_stats_t).
+ * Returns false if stats are not enabled.
+ */
+bool
+drwrap_get_stats(INOUT drwrap_stats_t *stats);
 
 /*@}*/ /* end doxygen group */
 

--- a/ext/drwrap/drwrap.h
+++ b/ext/drwrap/drwrap.h
@@ -748,6 +748,9 @@ DR_EXPORT
 bool
 drwrap_is_post_wrap(app_pc pc);
 
+/** An integer sized for support by dr_atomic_addX_return_sum(). */
+typedef ptr_int_t atomic_int_t;
+
 /**
  * Contains statistics retrievable by drwrap_get_stats().
  */
@@ -759,7 +762,7 @@ typedef struct _drwrap_stats_t {
      * already existing in the cache; replacing existing instrumentation; and
      * removing wrap or replace instrumentation.
      */
-    int64 flush_count;
+    atomic_int_t flush_count;
 } drwrap_stats_t;
 
 DR_EXPORT

--- a/suite/tests/client-interface/drwrap-test.dll.c
+++ b/suite/tests/client-interface/drwrap-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -309,6 +309,12 @@ dr_init(client_id_t id)
 static void
 event_exit(void)
 {
+    drwrap_stats_t stats = {
+        sizeof(stats),
+    };
+    bool ok = drwrap_get_stats(&stats);
+    CHECK(ok, "get_stats failed");
+    CHECK(stats.flush_count > 0, "force-replaces should result in some flushes");
     drmgr_unregister_tls_field(tls_idx);
     drwrap_exit();
     drmgr_exit();


### PR DESCRIPTION
Adds a new interface drwrap_get_stats() which returns the count of
flushes triggered by drwrap, for use when evaluating performance
overhead.  Adds documentation and a test.

Issue: #4070