### PR TITLE
i#4070 drwrap-site: Add post-call sites proactively

### DIFF
--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -244,7 +244,7 @@ fast_safe_read(void *base, size_t size, void *out_buf)
  * WRAPPING INSTRUMENTATION TRACKING
  */
 
-/* We need to know whether we've inserted instrumentation at the call site .
+/* We need to know whether we've inserted instrumentation at the call site.
  * The separate post_call_table tells us whether we've set up the return site
  * for instrumentation.
  */
@@ -317,7 +317,10 @@ post_call_entry_add(app_pc postcall, bool external)
         /* notify client somehow?  we'll carry on and invalidate on next bb */
         memset(e->prior, 0, sizeof(e->prior));
     }
-    hashtable_add(&post_call_table, (void *)postcall, (void *)e);
+    if (!hashtable_add(&post_call_table, (void *)postcall, (void *)e)) {
+        post_call_entry_free(e);
+        return NULL;
+    }
     if (!external && post_call_notify_list != NULL) {
         post_call_notify_t *cb = post_call_notify_list;
         while (cb != NULL) {
@@ -1678,6 +1681,7 @@ drwrap_mark_retaddr_for_instru(void *drcontext, app_pc decorated_pc,
     if (e == NULL || !e->existing_instrumented) {
         if (e == NULL) {
             e = post_call_entry_add(retaddr, false);
+            ASSERT(e != NULL, "holding lock so cannot already exist");
         }
         /* now that we have an entry in the synchronized post_call_table
          * any new code coming in will be instrumented
@@ -2189,9 +2193,11 @@ drwrap_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *ins
     app_pc pc =
         dr_app_pc_as_jump_target(instr_get_isa_mode(inst), instr_get_app_pc(inst));
 
-    /* Strategy: we don't bother to look at call sites; we wait for the callee
-     * and flush, under the assumption that we won't have already seen the
-     * return point and so won't have to incur the cost of a flush very often
+    /* Strategy: for the pre-hook, do not insert at the call site but rather wait for
+     * the callee.  For the post-hook, record the post-call site when we see the
+     * call instruction, and additionally record the actual retaddr when in the callee.
+     * By doing both we minimize flushes from the return point having already been
+     * reached before the callee hook can mark it.
      */
     dr_recurlock_lock(wrap_lock);
     wrap = hashtable_lookup(&wrap_table, (void *)pc);
@@ -2223,12 +2229,29 @@ drwrap_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *ins
          * vs other components' spill slots.
          */
         dr_cleancall_save_t flags = 0;
+        NOTIFY(2, "drwrap inserting post-call cb at " PFX "\n", pc);
         dr_insert_clean_call_ex(drcontext, bb, inst, (void *)drwrap_after_callee, flags,
                                 2,
                                 /* i#1689: retaddrs do have LSB=1 */
                                 OPND_CREATE_INTPTR((ptr_int_t)pc),
                                 /* pass in xsp to avoid dr_get_mcontext */
                                 opnd_create_reg(DR_REG_XSP));
+    }
+
+    if (instr_is_call(inst) && instr_is_app(inst) && opnd_is_pc(instr_get_target(inst))) {
+        app_pc target = dr_app_pc_as_jump_target(instr_get_isa_mode(inst),
+                                                 opnd_get_pc(instr_get_target(inst)));
+        dr_recurlock_lock(wrap_lock);
+        wrap = hashtable_lookup(&wrap_table, (void *)target);
+        bool wrapping = wrap != NULL && wrap->post_cb != NULL;
+        dr_recurlock_unlock(wrap_lock);
+        if (wrapping) {
+            /* Add the pc-as-load-target (so *not* "pc"). */
+            dr_rwlock_write_lock(post_call_rwlock);
+            post_call_entry_add(instr_get_app_pc(inst) + instr_length(drcontext, inst),
+                                false);
+            dr_rwlock_write_unlock(post_call_rwlock);
+        }
     }
 
     return DR_EMIT_DEFAULT;


### PR DESCRIPTION
When a direct call to a drwrap target is found, we now proactively add
the post-call point to the to-be-instrumented table, potentially
avoiding a flush if that PC were to be reached through some other
method before we find it in our callee control point.

This also enables finding post-call points even if we limited dynamic
return address investigation, which does add overhead.  A future
change will explore this further.

Issue: #4070