### PR TITLE
i#4070 drwrap-site: Add flag to skip retaddr examination

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -248,6 +248,8 @@ Further non-compatibility-affecting changes include:
    decoding in a signal handler, along with instr_noalloc_init() and
    instr_from_noalloc().
  - Added drwrap_get_stats().
+ - Added #DRWRAP_NO_DYNAMIC_RETADDRS for reducing drwrap overhead at the cost
+   of missing some post-call callbacks.
 
 **************************************************
 <hr>

--- a/ext/drwrap/drwrap.h
+++ b/ext/drwrap/drwrap.h
@@ -339,6 +339,16 @@ typedef enum {
      * heuristics are not guaranteed.
      */
     DRWRAP_UNWIND_ON_EXCEPTION = 0x01,
+    /**
+     * If this flag is set, then post-call callbacks are only invoked from return
+     * sites that can be identified statically.  Static identification happens in
+     * two ways: from observing a CALL instruction, and from drwrap_mark_as_post_call().
+     * Dynamically observing return addresses from inside callees incurs overhead
+     * due to synchronization costs, with further overhead to replace existing
+     * code with instrumented code.  When this flag is set, some post-call callbacks
+     * may be missed.
+     */
+    DRWRAP_NO_DYNAMIC_RETADDRS = 0x02,
 } drwrap_wrap_flags_t;
 
 /* offset of drwrap_callconv_t in drwrap_wrap_flags_t */

--- a/suite/tests/client-interface/drwrap-test.template
+++ b/suite/tests/client-interface/drwrap-test.template
@@ -30,6 +30,13 @@ in postonly
   <post-postonly>
 in skipme
 in postonly
+  <pre-direct1>
+  <post-direct1>
+  <pre-direct2>
+  <pre-direct1>
+  <post-direct1>
+  <post-direct2>
+  <pre-direct1>
 in runlots 1024
 #ifdef UNIX
   <pre-long0>
@@ -100,6 +107,13 @@ in postonly
   <post-postonly>
 in skipme
 in postonly
+  <pre-direct1>
+  <post-direct1>
+  <pre-direct2>
+  <pre-direct1>
+  <post-direct1>
+  <post-direct2>
+  <pre-direct1>
 in runlots 1024
   <pre-long0>
 long0 A


### PR DESCRIPTION
Adds DRWRAP_NO_DYNAMIC_RETADDRS which instructs drwrap to not look for
post-call points by examining the return address and comparing to
known sites while in the callee.  This incurs overhead, mostly due to
the locks and shared data structures, in large many-threaded
applications.  The downside is that the only post-call points in place
are those for direct calls, which drwrap always looks for with the
recent PR #4186.  Future work could add identification of
PLT-or-IAT-style indirect calls, or explore more scalable data
structures.

Adds testing to drwrap-test.

Issue: #4070