### PR TITLE
i#4187: Build a hashtable for faster ELF symbol lookups

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -250,6 +250,7 @@ Further non-compatibility-affecting changes include:
  - Added drwrap_get_stats().
  - Added #DRWRAP_NO_DYNAMIC_RETADDRS for reducing drwrap overhead at the cost
    of missing some post-call callbacks.
+ - Added free_key_func to the drcontainers hashtable_configure().
 
 **************************************************
 <hr>

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -221,6 +221,7 @@ instru_funcs_module_load(void *drcontext, const module_data_t *mod, bool loaded)
     if (drcontext == NULL || mod == NULL)
         return;
 
+    uint64 ms_start = dr_get_milliseconds();
     const char *mod_name = get_module_basename(mod);
     NOTIFY(2, "instru_funcs_module_load for %s\n", mod_name);
     for (size_t i = 0; i < func_names.entries; i++) {
@@ -270,6 +271,9 @@ instru_funcs_module_load(void *drcontext, const module_data_t *mod, bool loaded)
                    id);
         }
     }
+    uint64 ms_elapsed = dr_get_milliseconds() - ms_start;
+    NOTIFY(ms_elapsed > 10 ? 1 : 2, "Symbol queries for %s took %zums\n", mod_name,
+           ms_elapsed);
 }
 
 static void

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -272,7 +272,8 @@ instru_funcs_module_load(void *drcontext, const module_data_t *mod, bool loaded)
         }
     }
     uint64 ms_elapsed = dr_get_milliseconds() - ms_start;
-    NOTIFY(ms_elapsed > 10 ? 1 : 2, "Symbol queries for %s took %zums\n", mod_name,
+    NOTIFY((ms_elapsed > 10U) ? 1U : 2U,
+           "Symbol queries for %s took " UINT64_FORMAT_STRING "ms\n", mod_name,
            ms_elapsed);
 }
 

--- a/ext/drcontainers/hashtable.c
+++ b/ext/drcontainers/hashtable.c
@@ -226,6 +226,7 @@ hashtable_init_ex(hashtable_t *table, uint num_bits, hash_type_t hashtype, bool 
     table->config.size = sizeof(table->config);
     table->config.resizable = true;
     table->config.resize_threshold = 75;
+    table->config.free_key_func = NULL;
 }
 
 void

--- a/ext/drcontainers/hashtable.h
+++ b/ext/drcontainers/hashtable.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -80,6 +80,11 @@ typedef struct _hashtable_config_t {
     size_t size;           /**< The size of the hashtable_config_t struct used */
     bool resizable;        /**< Whether the table should be resized */
     uint resize_threshold; /**< Resize the table at this % full */
+    /**
+     * Called whenever an entry is removed, with the key passed in.  If "str_dup" is set
+     * to true in hashtable_init() or hashtable_init_ex(), this field is ignored.
+     */
+    void (*free_key_func)(void *);
 } hashtable_config_t;
 
 typedef struct _hashtable_t {

--- a/ext/drsyms/drsyms_unix_common.c
+++ b/ext/drsyms/drsyms_unix_common.c
@@ -38,6 +38,7 @@
 #include "drsyms.h"
 #include "drsyms_private.h"
 #include "drsyms_obj.h"
+#include "hashtable.h"
 
 #include "dwarf.h"
 #include "libdwarf.h"
@@ -73,6 +74,8 @@ typedef struct _dbg_module_t {
      * while the primary mod has symtab+strtab.
      */
     struct _dbg_module_t *mod_with_dwarf;
+#define SYMTABLE_HASH_BITS 12
+    hashtable_t symtable;
 } dbg_module_t;
 
 /******************************************************************************
@@ -84,6 +87,8 @@ unload_module(dbg_module_t *mod);
 static bool
 follow_debuglink(const char *modpath, dbg_module_t *mod, const char *debuglink,
                  char debug_modpath[MAXIMUM_PATH]);
+static void
+drsym_free_hash_key(void *key);
 
 /******************************************************************************
  * Module loading and unloading.
@@ -135,6 +140,18 @@ load_module(const char *modpath)
         NOTIFY("%s: unable to map %s\n", __FUNCTION__, modpath);
         goto error;
     }
+
+    /* We have to duplicate most of the strings we add ourselves, so we do not ask for
+     * additional duplication and use a key freeing function.
+     */
+    hashtable_init_ex(&mod->symtable, SYMTABLE_HASH_BITS, HASH_STRING, false /*strdup*/,
+                      false /*!synch*/, NULL, NULL, NULL);
+    hashtable_config_t config;
+    config.size = sizeof(config);
+    config.resizable = true;
+    config.resize_threshold = 70;
+    config.free_key_func = drsym_free_hash_key;
+    hashtable_configure(&mod->symtable, &config);
 
     /* We need to partially initialize in order to get the debug info */
     mod->obj_info = drsym_obj_mod_init_pre(mod->map_base, mod->file_size);
@@ -307,6 +324,8 @@ unload_module(dbg_module_t *mod)
         drsym_dwarf_exit(mod->dwarf_info);
     if (mod->obj_info != NULL)
         drsym_obj_mod_exit(mod->obj_info);
+    if (mod->symtable.table != NULL)
+        hashtable_delete(&mod->symtable);
     if (mod->map_base != NULL)
         dr_unmap_file(mod->map_base, mod->map_size);
     if (mod->fd != INVALID_FILE)
@@ -365,8 +384,10 @@ symsearch_symtab(dbg_module_t *mod, drsym_enumerate_cb callback,
                 drsym_obj_symbol_offs(mod->obj_info, i, &out->start_offs, &out->end_offs);
         } else
             res = drsym_obj_symbol_offs(mod->obj_info, i, &modoffs, NULL);
-        if (res == DRSYM_ERROR_SYMBOL_NOT_FOUND) { /* an import, so skip */
-            res = DRSYM_SUCCESS;                   /* if go off end of loop */
+        /* Skip imports and missing symbols. */
+        if (res == DRSYM_ERROR_SYMBOL_NOT_FOUND ||
+            (callback_ex == NULL && modoffs == 0) || mangled[0] == '\0') {
+            res = DRSYM_SUCCESS; /* if go off end of loop */
             continue;
         }
         if (res != DRSYM_SUCCESS)
@@ -440,6 +461,120 @@ addrsearch_symtab(dbg_module_t *mod, size_t modoffs, drsym_info_t *info INOUT, u
 }
 
 /******************************************************************************
+ * Hashtable building for symbol lookup.
+ *
+ * We use __wrap_malloc because our demangled strings have larger capacities
+ * than strlen() will find.
+ * XXX: Should DR export a malloc-matching heap API that does not start with
+ * underscores for cleaner usage?  Most non-static-DR usage though can just
+ * use malloc().  Here we want to support static DR.
+ *
+ * We do not want to pay the cost of hashtable_t doing a further
+ * strdup on our just-allocated strings so we free keys ourselves.
+ */
+
+static void
+drsym_free_hash_key(void *key)
+{
+    __wrap_free(key);
+}
+
+static char *
+drsym_dup_string_until_char(const char *sym, char stop)
+{
+    /* We skip the first char to avoid empty strings. */
+    const char *found = strchr(sym + 1, stop);
+    if (found != NULL) {
+        size_t no_found_sz = found - sym;
+        char *no_found = (char *)__wrap_malloc(no_found_sz + 1);
+        dr_snprintf(no_found, no_found_sz, "%s", sym);
+        no_found[no_found_sz] = '\0';
+        return no_found;
+    }
+    return NULL;
+}
+
+static char *
+drsym_demangle_helper(const char *sym, uint flags)
+{
+    /* We look for "_Z" to avoid the copy of the same symbol for non-mangled cases. */
+    if (sym[0] != '_' || sym[1] != 'Z')
+        return NULL;
+    size_t len;
+    size_t buf_size = 1024;
+    char *buf = (char *)__wrap_malloc(buf_size);
+    /* Resize until it's big enough. */
+    while ((len = drsym_demangle_symbol(buf, buf_size, sym, flags)) > buf_size) {
+        __wrap_free(buf);
+        buf_size = len;
+        buf = (char *)__wrap_malloc(buf_size);
+    }
+    if (len == 0) {
+        __wrap_free(buf);
+        return NULL;
+    }
+    return buf;
+}
+
+static bool
+drsym_add_hash_entry(dbg_module_t *mod, const char *copy, size_t modoffs)
+{
+    if (hashtable_add(&mod->symtable, (void *)copy, (void *)modoffs))
+        return true;
+    drsym_free_hash_key((void *)copy);
+    return false;
+}
+
+/* Symbol enumeration callback for doing a single lookup.
+ */
+static bool
+drsym_fill_symtable_cb(const char *sym, size_t modoffs, void *data INOUT)
+{
+    dbg_module_t *mod = (dbg_module_t *)data;
+    NOTIFY("%s: adding %s\n", __FUNCTION__, sym);
+    size_t len = strlen(sym);
+    char *copy = __wrap_malloc(len + 1);
+    dr_snprintf(copy, len, "%s", sym);
+    copy[len] = '\0';
+    if (!drsym_add_hash_entry(mod, copy, modoffs))
+        return true;
+
+    /* We match the name part of versioned symbols: so "foo" will match
+     * "foo@@GLIBC_2.1".  If there are multiple, a user who wants one in
+     * particular needs to include the version name in the search target.
+     */
+    char *toadd = drsym_dup_string_until_char(sym, '@');
+    if (toadd != NULL) {
+        NOTIFY("%s: adding %s\n", __FUNCTION__, toadd);
+        drsym_add_hash_entry(mod, toadd, modoffs);
+    }
+    /* Add the demanglings. */
+    toadd = drsym_demangle_helper(sym, DRSYM_DEMANGLE);
+    if (toadd == NULL)
+        return true;
+    NOTIFY("%s: adding %s\n", __FUNCTION__, toadd);
+    if (!drsym_add_hash_entry(mod, toadd, modoffs))
+        return true;
+
+    /* Add a version without parameters to allow the user to ignore overloads. */
+    char *noparen = drsym_dup_string_until_char(toadd, '(');
+    if (noparen != NULL) {
+        NOTIFY("%s: adding %s\n", __FUNCTION__, noparen);
+        drsym_add_hash_entry(mod, noparen, modoffs);
+    }
+
+#ifdef DRSYM_HAVE_LIBELFTC
+    toadd = drsym_demangle_helper(sym, DRSYM_DEMANGLE_FULL);
+    if (toadd != NULL) {
+        NOTIFY("%s: adding %s\n", __FUNCTION__, toadd);
+        drsym_add_hash_entry(mod, toadd, modoffs);
+    }
+#endif
+
+    return true;
+}
+
+/******************************************************************************
  * Exports
  */
 
@@ -479,49 +614,12 @@ drsym_unix_enumerate_symbols(void *mod_in, drsym_enumerate_cb callback,
     return symsearch_symtab(mod, callback, callback_ex, info_size, data, flags);
 }
 
-/* Params to sym_lookup_cb passed through data. */
-typedef struct _sym_lookup_params_t {
-    const char *search_sym;
-    size_t search_sym_len;
-    size_t *modoffs;
-} sym_lookup_params_t;
-
-/* Symbol enumeration callback for doing a single lookup.
- */
-static bool
-sym_lookup_cb(const char *sym, size_t modoffs, void *data INOUT)
-{
-    sym_lookup_params_t *p = (sym_lookup_params_t *)data;
-
-    if (strncmp(sym, p->search_sym, p->search_sym_len) == 0 &&
-        strlen(sym) >= p->search_sym_len &&
-        (sym[p->search_sym_len] == '\0' ||
-         /* Left paren means the beginning of the parameter list.  Since the
-          * parameter list starts where our search string ends, we assume the
-          * user doesn't care about possible overloads.
-          */
-         sym[p->search_sym_len] == '(' ||
-         /* We match the name part of versioned symbols: so "foo" will match
-          * "foo@@GLIBC_2.1".  If there are multiple, a user who wants one in
-          * particular needs to include the version name in the search target.
-          */
-         sym[p->search_sym_len] == '@')) {
-        NOTIFY("Looked up symbol: %s %s\n", p->search_sym, sym);
-        *p->modoffs = modoffs;
-        /* Stop after the first match. */
-        return false;
-    }
-    return true;
-}
-
 drsym_error_t
 drsym_unix_lookup_symbol(void *mod_in, const char *symbol, size_t *modoffs OUT,
                          uint flags)
 {
     dbg_module_t *mod = (dbg_module_t *)mod_in;
-    drsym_error_t r;
     const char *sym_no_mod;
-    sym_lookup_params_t params;
 
     if (symbol == NULL) {
         sym_no_mod = NULL;
@@ -552,13 +650,12 @@ drsym_unix_lookup_symbol(void *mod_in, const char *symbol, size_t *modoffs OUT,
     }
 
     if (*modoffs == 0) {
-        params.search_sym = sym_no_mod;
-        params.search_sym_len = strlen(sym_no_mod);
-        params.modoffs = modoffs;
-        r = drsym_unix_enumerate_symbols(mod, sym_lookup_cb, NULL, sizeof(drsym_info_t),
-                                         &params, flags);
-        if (r != DRSYM_SUCCESS)
-            return r;
+        if (mod->symtable.entries == 0) {
+            /* Initialize the hashtable. */
+            symsearch_symtab(mod, drsym_fill_symtable_cb, NULL, sizeof(drsym_info_t), mod,
+                             DRSYM_LEAVE_MANGLED);
+        }
+        *modoffs = (size_t)hashtable_lookup(&mod->symtable, (void *)sym_no_mod);
     }
     if (*modoffs == 0)
         return DRSYM_ERROR_SYMBOL_NOT_FOUND;


### PR DESCRIPTION
Instead of a linear search through the symbol table on every lookup,
on the first lookup drsyms now builds a hashtable of all symbol
variants and uses it on subsequent lookups.

Adds a new option to the drcontainers hashtable to supply a key
freeing callback, needed here because we are duplicating most strings
ourselves before adding and do not want to have drcontainers
re-duplicate.

Adds a -verbose 1 notification for libraries taking long amounts of
time to be processed, for easier diagnostics in the future.

Performance-tested on large applications where it reduces drcachesim
-record_heap query times by 5x for less-optimized code and 2x for
highly-optimized code.

Fixes #4187