### PR TITLE
i#4187 sym perf: Add -record_dynsym_only to drcachesim

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -250,6 +250,8 @@ Further non-compatibility-affecting changes include:
  - Added drwrap_get_stats().
  - Added #DRWRAP_NO_DYNAMIC_RETADDRS for reducing drwrap overhead at the cost
    of missing some post-call callbacks.
+ - Added -record_dynsym_only to drcachesim for faster function tracing symbol
+   lookups when internal symbols are not needed.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -487,6 +487,12 @@ droption_t<std::string> op_record_heap_value(
     "Functions recorded by -record_heap. The option value should fit the same"
     " format required by -record_function. These functions will not"
     " be traced unless -record_heap is specified.");
+droption_t<bool> op_record_dynsym_only(
+    DROPTION_SCOPE_ALL, "record_dynsym_only", false,
+    "Only look in .dynsym for -record_function and -record_heap.",
+    "Symbol lookup can be expensive for large applications and libraries.  This option "
+    " causes the symbol lookup for -record_function and -record_heap to look in the "
+    " dynamic symbol table *only*.");
 droption_t<unsigned int> op_miss_count_threshold(
     DROPTION_SCOPE_FRONTEND, "miss_count_threshold", 50000,
     "For cache miss analysis: minimum LLC miss count for a load to be eligible for "

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -124,6 +124,7 @@ extern droption_t<std::string> op_view_syntax;
 extern droption_t<std::string> op_record_function;
 extern droption_t<bool> op_record_heap;
 extern droption_t<std::string> op_record_heap_value;
+extern droption_t<bool> op_record_dynsym_only;
 extern droption_t<unsigned int> op_miss_count_threshold;
 extern droption_t<double> op_miss_frac_threshold;
 extern droption_t<double> op_confidence_threshold;

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -171,6 +171,9 @@ get_pc_by_symbol(const module_data_t *mod, const char *symbol)
     if (pc != NULL) {
         NOTIFY(2, "dr_get_proc_address found symbol %s at pc=" PFX "\n", symbol, pc);
         return pc;
+    } else if (op_record_dynsym_only.get_value()) {
+        NOTIFY(2, "Failed to find symbol %s in .dynsym; not recording it\n", symbol);
+        return NULL;
     } else {
         // If failed to find the symbol in the dynamic symbol table, then we try to find
         // it in the module loaded by reading the module file in mod->full_path.
@@ -432,9 +435,11 @@ func_trace_init(func_trace_append_entry_vec_t append_entry_vec_,
     hashtable_init_ex(&pc2idplus1, 8, HASH_INTPTR, false /*!strdup*/, false /*!synch*/,
                       nullptr, nullptr, nullptr);
 
-    if (!(drsym_init(0) == DRSYM_SUCCESS)) {
-        DR_ASSERT(false);
-        goto failed;
+    if (!op_record_dynsym_only.get_value()) {
+        if (!(drsym_init(0) == DRSYM_SUCCESS)) {
+            DR_ASSERT(false);
+            goto failed;
+        }
     }
     if (!drwrap_init()) {
         DR_ASSERT(false);
@@ -485,8 +490,11 @@ func_trace_exit()
     if (!drmgr_unregister_module_load_event(instru_funcs_module_load) ||
         !drmgr_unregister_module_unload_event(instru_funcs_module_unload) ||
         !drmgr_unregister_thread_init_event(event_thread_init) ||
-        !drmgr_unregister_thread_exit_event(event_thread_exit) ||
-        !(drsym_exit() == DRSYM_SUCCESS))
+        !drmgr_unregister_thread_exit_event(event_thread_exit))
         DR_ASSERT(false);
+    if (!op_record_dynsym_only.get_value()) {
+        if (drsym_exit() != DRSYM_SUCCESS)
+            DR_ASSERT(false);
+    }
     drwrap_exit();
 }


### PR DESCRIPTION
Adds a new option -record_dynsym_only to drcachesim which causes
-record_function and -record_heap to only look in .dynsym, avoiding
drsyms and the main symbol table entirely.  This is to avoid overhead
issues with two scenarios: very large applications with millions of
symbol table entries, and applications with thousands of libraries
where setting up and tearing down drsyms and DWARF information adds up
across all of those libraries.  Quite often the target functions to
trace are in .dynsym, making this a reasonable solution.

Tested manually on both scenarios.

Issue: #4187