### PR TITLE
i#4203: Fix drgui build error

### DIFF
--- a/ext/drgui/drgui_main_window.cpp
+++ b/ext/drgui/drgui_main_window.cpp
@@ -1,4 +1,5 @@
 /* ***************************************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2013 Branden Clark  All rights reserved.
  * ***************************************************************************/
 
@@ -42,7 +43,6 @@
 
 #include <QMenu>
 #include <QAction>
-#include <QSignalMapper>
 #include <QString>
 #include <QTabWidget>
 #include <QInputDialog>
@@ -71,7 +71,6 @@ drgui_main_window_t::drgui_main_window_t(QString tool_name, QStringList tool_arg
     , tool_to_auto_load_args(tool_args)
 {
     qDebug().nospace() << "INFO: Entering " << __CLASS__ << __FUNCTION__;
-    window_mapper = new QSignalMapper(this);
     tab_area = new QTabWidget(this);
     tab_area->setTabsClosable(true);
     tab_area->setMovable(true);
@@ -181,9 +180,8 @@ drgui_main_window_t::update_window_menu(void)
         QAction *action = window_menu->addAction(text);
         action->setCheckable(true);
         action->setChecked(tool == active_tool());
-        connect(action, SIGNAL(triggered()), window_mapper, SLOT(map()));
-        window_mapper->setMapping(action, i);
-        connect(window_mapper, SIGNAL(mapped(int)), tab_area, SLOT(setCurrentIndex(int)));
+        connect(action, &QAction::triggered,
+                [=]() { emit tab_area->setCurrentIndex(i); });
     }
 }
 

--- a/ext/drgui/drgui_main_window.h
+++ b/ext/drgui/drgui_main_window.h
@@ -1,4 +1,5 @@
 /* ***************************************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2013 Branden Clark  All rights reserved.
  * ***************************************************************************/
 
@@ -48,7 +49,6 @@ class QAction;
 class QMenu;
 class QMdiArea;
 class QMdiSubWindow;
-class QSignalMapper;
 class QActionGroup;
 class QPluginLoader;
 
@@ -142,7 +142,6 @@ private:
     QDir plugins_dir;
     QStringList plugin_names;
     QTabWidget *tab_area;
-    QSignalMapper *window_mapper;
     QActionGroup *tool_action_group;
     QAction *separator_act;
 


### PR DESCRIPTION
Switches from the deprecated QSignalMapper to a lambda.  There are no
tests of this code so while I did run drgui I am not 100% sure that I
have maintained the same functionality.

Fixes #4203