### PR TITLE
i#4134: Add statistics gathering to drbbdup

### DIFF
--- a/api/samples/hot_bbcount.c
+++ b/api/samples/hot_bbcount.c
@@ -254,6 +254,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
                                       NULL,
                                       NULL,
                                       1 /* Only one additional copy is needed. */,
+									  0 /* threshold */,
                                       false /* No statistics gathering. */ };
     if (drbbdup_init(&drbbdup_ops) != DRBBDUP_SUCCESS)
         DR_ASSERT(false);

--- a/api/samples/hot_bbcount.c
+++ b/api/samples/hot_bbcount.c
@@ -254,7 +254,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
                                       NULL,
                                       NULL,
                                       1 /* Only one additional copy is needed. */,
-									  0 /* threshold */,
+                                      0 /* threshold */,
                                       false /* No statistics gathering. */ };
     if (drbbdup_init(&drbbdup_ops) != DRBBDUP_SUCCESS)
         DR_ASSERT(false);

--- a/api/samples/hot_bbcount.c
+++ b/api/samples/hot_bbcount.c
@@ -253,7 +253,8 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
                                       instrument_instr,
                                       NULL,
                                       NULL,
-                                      1 /* Only one additional copy is needed. */ };
+                                      1 /* Only one additional copy is needed. */,
+                                      false /* No statistics gathering. */ };
     if (drbbdup_init(&drbbdup_ops) != DRBBDUP_SUCCESS)
         DR_ASSERT(false);
 

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -862,7 +862,8 @@ drbbdup_insert_dynamic_handling(void *drcontext, app_pc translation_pc, void *ta
 
     if (opts.is_stat_enabled) {
         /* Insert clean call so that we can lock stat_mutex. */
-        dr_insert_clean_call(drcontext, bb, where, drbbdup_inc_bail_count, false, 0);
+        dr_insert_clean_call(drcontext, bb, where, (void *)drbbdup_inc_bail_count, false,
+                             0);
     }
 
     instrlist_meta_preinsert(bb, where, done_label);

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -1371,11 +1371,12 @@ drbbdup_get_stats(OUT drbbdup_stats_t *stats_in)
 {
     if (!opts.is_stat_enabled)
         return DRBBDUP_ERROR_UNSET_FEATURE;
-    if (stats_in == NULL)
+    if (stats_in == NULL || stats_in->struct_size == 0 ||
+        stats_in->struct_size > stats.struct_size)
         return DRBBDUP_ERROR_INVALID_PARAMETER;
 
     dr_mutex_lock(stat_mutex);
-    memcpy(stats_in, &stats, sizeof(drbbdup_stats_t));
+    memcpy(stats_in, &stats, stats_in->struct_size);
     dr_mutex_unlock(stat_mutex);
     return DRBBDUP_SUCCESS;
 }
@@ -1491,6 +1492,7 @@ drbbdup_init(drbbdup_options_t *ops_in)
 
     if (opts.is_stat_enabled) {
         memset(&stats, 0, sizeof(drbbdup_stats_t));
+        stats.struct_size = sizeof(drbbdup_stats_t);
         stat_mutex = dr_mutex_create();
         if (stat_mutex == NULL)
             return DRBBDUP_ERROR;

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -120,6 +120,10 @@ static hashtable_t manager_table; /* Maps bbs with book-keeping data. */
 static drbbdup_options_t opts;
 static void *rw_lock = NULL;
 
+/* For tracking statistics. */
+static void *stat_mutex = NULL;
+static drbbdup_stats_t stats;
+
 /* An outlined code cache (storing a clean call) for dynamically generating a case. */
 static app_pc new_case_cache_pc = NULL;
 
@@ -391,6 +395,14 @@ drbbdup_duplicate_phase(void *drcontext, void *tag, instrlist_t *bb, bool for_tr
         manager = drbbdup_create_manager(drcontext, tag, bb);
         ASSERT(manager != NULL, "created manager cannot be NULL");
         hashtable_add(&manager_table, pc, manager);
+        if (opts.is_stat_enabled) {
+            dr_mutex_lock(stat_mutex);
+            if (!manager->enable_dup)
+                stats.no_dup_cnt++;
+            if (!manager->enable_dynamic_handling)
+                stats.no_dynamic_handling_cnt++;
+            dr_mutex_unlock(stat_mutex);
+        }
     } else {
         /* A manager is already book-keeping this bb. Two scenarios are considered:
          *   1) A new case is registered and re-instrumentation is
@@ -410,12 +422,6 @@ drbbdup_duplicate_phase(void *drcontext, void *tag, instrlist_t *bb, bool for_tr
         /* Add the copies. */
         drbbdup_set_up_copies(drcontext, bb, manager);
     }
-
-    /* XXX i#4134: statistics -- add the following stat increments here:
-     *    1) avg bb size
-     *    2) bb instrum count
-     *    3) dups enabled
-     */
 
     dr_rwlock_write_unlock(rw_lock);
 
@@ -775,6 +781,15 @@ drbbdup_do_dynamic_handling(drbbdup_manager_t *manager)
     return false;
 }
 
+/* Increments the execution count of bails to default case. */
+static void
+drbbdup_inc_bail_count()
+{
+    dr_mutex_lock(stat_mutex);
+    stats.bail_cnt++;
+    dr_mutex_unlock(stat_mutex);
+}
+
 /* Insert trigger for dynamic case handling. */
 static void
 drbbdup_insert_dynamic_handling(void *drcontext, app_pc translation_pc, void *tag,
@@ -844,7 +859,11 @@ drbbdup_insert_dynamic_handling(void *drcontext, app_pc translation_pc, void *ta
             instrlist_meta_preinsert(bb, where, instr);
         }
     }
-    /* XXX i#4134: Insert code for dynamic handling here. */
+
+    if (opts.is_stat_enabled) {
+        /* Insert clean call so that we can lock stat_mutex. */
+        dr_insert_clean_call(drcontext, bb, where, drbbdup_inc_bail_count, false, 0);
+    }
 
     instrlist_meta_preinsert(bb, where, done_label);
 }
@@ -1193,7 +1212,14 @@ drbbdup_handle_new_case()
                 manager->ref_counter++;
             }
 
-            /* XXX i#4134: statistics -- Add increment to keep track generated cases. */
+            if (opts.is_stat_enabled) {
+                dr_mutex_lock(stat_mutex);
+                if (do_gen)
+                    stats.gen_cnt++;
+                if (!manager->enable_dynamic_handling)
+                    stats.no_dynamic_handling_cnt++;
+                dr_mutex_unlock(stat_mutex);
+            }
         }
     }
     /* Regardless of whether or not flushing is going to happen, redirection will
@@ -1340,6 +1366,20 @@ drbbdup_is_last_instr(void *drcontext, instr_t *instr, bool *is_last)
     return DRBBDUP_SUCCESS;
 }
 
+drbbdup_status_t
+drbbdup_get_stats(OUT drbbdup_stats_t *stats_in)
+{
+    if (!opts.is_stat_enabled)
+        return DRBBDUP_ERROR_UNSET_FEATURE;
+    if (stats_in == NULL)
+        return DRBBDUP_ERROR_INVALID_PARAMETER;
+
+    dr_mutex_lock(stat_mutex);
+    memcpy(stats_in, &stats, sizeof(drbbdup_stats_t));
+    dr_mutex_unlock(stat_mutex);
+    return DRBBDUP_SUCCESS;
+}
+
 /****************************************************************************
  * THREAD INIT AND EXIT
  */
@@ -1449,6 +1489,13 @@ drbbdup_init(drbbdup_options_t *ops_in)
     if (rw_lock == NULL)
         return DRBBDUP_ERROR;
 
+    if (opts.is_stat_enabled) {
+        memset(&stats, 0, sizeof(drbbdup_stats_t));
+        stat_mutex = dr_mutex_create();
+        if (stat_mutex == NULL)
+            return DRBBDUP_ERROR;
+    }
+
     ref_count++;
 
     return DRBBDUP_SUCCESS;
@@ -1475,6 +1522,10 @@ drbbdup_exit(void)
 
         hashtable_delete(&manager_table);
         dr_rwlock_destroy(rw_lock);
+
+        if (opts.is_stat_enabled)
+            dr_mutex_destroy(stat_mutex);
+
     } else {
         /* Cannot have more than one initialisation of drbbdup. */
         return DRBBDUP_ERROR;

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -398,9 +398,9 @@ drbbdup_duplicate_phase(void *drcontext, void *tag, instrlist_t *bb, bool for_tr
         if (opts.is_stat_enabled) {
             dr_mutex_lock(stat_mutex);
             if (!manager->enable_dup)
-                stats.no_dup_cnt++;
+                stats.no_dup_count++;
             if (!manager->enable_dynamic_handling)
-                stats.no_dynamic_handling_cnt++;
+                stats.no_dynamic_handling_count++;
             dr_mutex_unlock(stat_mutex);
         }
     } else {
@@ -786,7 +786,7 @@ static void
 drbbdup_inc_bail_count()
 {
     dr_mutex_lock(stat_mutex);
-    stats.bail_cnt++;
+    stats.bail_count++;
     dr_mutex_unlock(stat_mutex);
 }
 
@@ -1215,9 +1215,9 @@ drbbdup_handle_new_case()
             if (opts.is_stat_enabled) {
                 dr_mutex_lock(stat_mutex);
                 if (do_gen)
-                    stats.gen_cnt++;
+                    stats.gen_count++;
                 if (!manager->enable_dynamic_handling)
-                    stats.no_dynamic_handling_cnt++;
+                    stats.no_dynamic_handling_count++;
                 dr_mutex_unlock(stat_mutex);
             }
         }

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -860,6 +860,9 @@ drbbdup_insert_dynamic_handling(void *drcontext, app_pc translation_pc, void *ta
         }
     }
 
+    /* XXX i#4215: Use atomic counter when 64-bit sized integers can be used
+     * on 32-bit platforms.
+     */
     if (opts.is_stat_enabled) {
         /* Insert clean call so that we can lock stat_mutex. */
         dr_insert_clean_call(drcontext, bb, where, (void *)drbbdup_inc_bail_count, false,

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -54,11 +54,11 @@ extern "C" {
 typedef enum {
     DRBBDUP_SUCCESS,                       /**< Operation succeeded. */
     DRBBDUP_ERROR_INVALID_PARAMETER,       /**< Operation failed: invalid parameter. */
-    DRBBDUP_ERROR_UNSET_FEATURE,           /**< Operation failed: feature not set. */
     DRBBDUP_ERROR_CASE_ALREADY_REGISTERED, /**< Operation failed: already registered. */
     DRBBDUP_ERROR_CASE_LIMIT_REACHED,      /**< Operation failed: case limit reached. */
     DRBBDUP_ERROR_ALREADY_INITIALISED,     /**< DRBBDUP can only be initialised once. */
     DRBBDUP_ERROR,                         /**< Operation failed. */
+    DRBBDUP_ERROR_UNSET_FEATURE,           /**< Operation failed: feature not set. */
 } drbbdup_status_t;
 
 /***************************************************************************
@@ -259,10 +259,12 @@ typedef struct {
      */
     ushort hit_threshold;
     /**
-     * Determines whether drbbdup should track a variety of statistics. Note keeping track
-     * of statistics incurs additional overhead and it is not recommended at deployment.
+     * Determines whether drbbdup should track a variety of statistics. Note, keeping
+     * track of statistics incurs additional overhead and it is not recommended at
+     * deployment.
      *
-     * Set to true if the client calls drbbdup_get_stats().
+     * In order for the client to successfully call drbbdup_get_stats(), the flag must be
+     * set to true.
      */
     bool is_stat_enabled;
 } drbbdup_options_t;
@@ -271,12 +273,14 @@ typedef struct {
  * Various statistics related to drbbdup.
  */
 typedef struct {
+    /** Set this to the size of this structure. */
+    size_t struct_size;
     /** Number of fragments which have case handling turned off. */
-    unsigned long no_dup_cnt;
+    unsigned long no_dup_count;
     /** Number of fragments which have dynamic case handling turned off. */
-    unsigned long no_dynamic_handling_cnt;
+    unsigned long no_dynamic_handling_count;
     /** Number of cases handled via dynamic generation. */
-    unsigned long gen_cnt;
+    unsigned long gen_counnt;
     /**
      * Execution count of bails to the default case due to encountered unhandled
      * cases.

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -280,12 +280,12 @@ typedef struct {
     /** Number of fragments which have dynamic case handling turned off. */
     unsigned long no_dynamic_handling_count;
     /** Number of cases handled via dynamic generation. */
-    unsigned long gen_counnt;
+    unsigned long gen_count;
     /**
      * Execution count of bails to the default case due to encountered unhandled
      * cases.
      */
-    unsigned long bail_cnt;
+    unsigned long bail_count;
 } drbbdup_stats_t;
 
 /**

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -271,15 +271,15 @@ typedef struct {
  * Various statistics related to drbbdup.
  */
 typedef struct {
-    /** Set this to the size of this structure. */
-    size_t struct_size;
     /** Number of fragments which have case handling turned off. */
     unsigned long no_dup_cnt;
     /** Number of fragments which have dynamic case handling turned off. */
     unsigned long no_dynamic_handling_cnt;
     /** Number of cases handled via dynamic generation. */
     unsigned long gen_cnt;
-    /** Execution count of bails to the default case due to encountered unhandled cases.
+    /**
+     * Execution count of bails to the default case due to encountered unhandled
+     * cases.
      */
     unsigned long bail_cnt;
 } drbbdup_stats_t;

--- a/suite/tests/client-interface/drbbdup-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-test.dll.c
@@ -220,7 +220,7 @@ event_exit(void)
 {
     drbbdup_status_t res;
 
-    drbbdup_stats_t stats = {sizeof(drbbdup_stats_t)};
+    drbbdup_stats_t stats = { sizeof(drbbdup_stats_t) };
     res = drbbdup_get_stats(&stats);
     CHECK(res == DRBBDUP_SUCCESS, "drbbdup statistics gathering failed");
 

--- a/suite/tests/client-interface/drbbdup-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-test.dll.c
@@ -221,7 +221,8 @@ event_exit(void)
     drbbdup_status_t res;
 
     drbbdup_stats_t stats;
-    drbbdup_get_stats(&stats);
+    res = drbbdup_get_stats(&stats);
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup statistics gathering failed");
 
     CHECK(stats.no_dup_cnt == no_dup_cnt, "no dup count should match");
     CHECK(stats.no_dynamic_handling_cnt == no_dynamic_handling_cnt,
@@ -264,6 +265,7 @@ dr_init(client_id_t id)
                                NULL,
                                USER_DATA_VAL,
                                2 /* num of cases */,
+                               0 /* threshold */,
                                true /* enable stats */ };
 
     res = drbbdup_init(&opts);

--- a/suite/tests/client-interface/drbbdup-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-test.dll.c
@@ -62,8 +62,8 @@ static bool instrum_called = false;
 static uintptr_t encode_val = 1;
 static bool enable_dups_flag = false;
 /* Counters to test statistics provided by drbbdup. */
-static unsigned long no_dup_cnt = 0;
-static unsigned long no_dynamic_handling_cnt = 0;
+static unsigned long no_dup_count = 0;
+static unsigned long no_dynamic_handling_count = 0;
 
 static uintptr_t
 set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
@@ -82,8 +82,8 @@ set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
     CHECK(res == DRBBDUP_SUCCESS, "failed to register case 2");
 
     if (!enable_dups_flag)
-        no_dup_cnt++;
-    no_dynamic_handling_cnt++;
+        no_dup_count++;
+    no_dynamic_handling_count++;
 
     *enable_dups = enable_dups_flag;
     enable_dups_flag = !enable_dups_flag; /* alternate flag */
@@ -220,15 +220,15 @@ event_exit(void)
 {
     drbbdup_status_t res;
 
-    drbbdup_stats_t stats;
+    drbbdup_stats_t stats = {sizeof(drbbdup_stats_t)};
     res = drbbdup_get_stats(&stats);
     CHECK(res == DRBBDUP_SUCCESS, "drbbdup statistics gathering failed");
 
-    CHECK(stats.no_dup_cnt == no_dup_cnt, "no dup count should match");
-    CHECK(stats.no_dynamic_handling_cnt == no_dynamic_handling_cnt,
+    CHECK(stats.no_dup_count == no_dup_count, "no dup count should match");
+    CHECK(stats.no_dynamic_handling_count == no_dynamic_handling_count,
           "no dynamic handling count should match");
-    CHECK(stats.bail_cnt == 0, "should be 0 since dynamic case gen is turned off");
-    CHECK(stats.gen_cnt == 0, "should be 0 since dynamic case gen is turned off");
+    CHECK(stats.bail_count == 0, "should be 0 since dynamic case gen is turned off");
+    CHECK(stats.gen_count == 0, "should be 0 since dynamic case gen is turned off");
 
     res = drbbdup_exit();
     CHECK(res == DRBBDUP_SUCCESS, "drbbdup exit failed");


### PR DESCRIPTION
Adds statistics gathering to drbbdup. In particular, the PR includes drbbdup_get_stats(), which populates a passed struct with current stat values.

Issue: #4134