### PR TITLE
i#1726 coherence: Remove stale comments

### DIFF
--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -1082,8 +1082,6 @@ these areas of missing functionality:
 
 - Multi-process online application simulation on Windows
   (https://github.com/DynamoRIO/dynamorio/issues/1727)
-- Arbitrary cache hierarchy support via an input config file
-  (https://github.com/DynamoRIO/dynamorio/issues/1715)
 - Offline traces do not currently accurately record instruction fetches in
   dynamically generated code (https://github.com/DynamoRIO/dynamorio/issues/2062).
   All data references are included, but instruction fetches may be skipped.

--- a/clients/drcachesim/simulator/cache.cpp
+++ b/clients/drcachesim/simulator/cache.cpp
@@ -59,8 +59,6 @@ cache_t::init_blocks()
 void
 cache_t::request(const memref_t &memref)
 {
-    // FIXME i#1726: if the request is a data write, we should check the
-    // instr cache and invalidate the cache line there if necessary on x86.
     caching_device_t::request(memref);
 }
 

--- a/clients/drcachesim/simulator/cache_line.h
+++ b/clients/drcachesim/simulator/cache_line.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -44,8 +44,6 @@ class cache_line_t : public caching_device_block_t {
     // cache_line_t is probably to be extended to have distinct member variables
     // and functions, e.g., coherency-related ones. Therefore, it is
     // reasonable to keep two identical classes now rather than use one instead.
-
-    // FIXME i#1726: implement cache coherency protocols
 };
 
 #endif /* _CACHE_LINE_H_ */


### PR DESCRIPTION
Removes stale comments about needing to implement coherence in
drcachesim.

Removes an input config file from the list of limitations in the docs,
since we do have that support now.

Issue: #1726