### PR TITLE
i#4134: Add drbbdup_is_first_nonlabel_instr()

### DIFF
--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -1006,6 +1006,7 @@ drbbdup_instrument_without_dups(void *drcontext, void *tag, instrlist_t *bb,
 
     if (drmgr_is_first_instr(drcontext, instr)) {
         pt->first_instr = instr;
+        pt->first_nonlabel_instr = instrlist_first_nonlabel(bb);
         pt->last_instr = instrlist_last(bb);
         ASSERT(drmgr_is_last_instr(drcontext, pt->last_instr), "instr should be last");
     }

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -111,8 +111,9 @@ typedef struct {
     void *default_analysis_data;     /* Analysis data specific to default case. */
     void **case_analysis_data;       /* Analysis data specific to cases. */
     uint16_t hit_counts[TABLE_SIZE]; /* Keeps track of hit-counts of unhandled cases. */
-    instr_t *first_instr; /* The first instr of the bb copy being considered. */
-    instr_t *last_instr;  /* The last instr of the bb copy being considered. */
+    instr_t *first_instr;          /* The first instr of the bb copy being considered. */
+    instr_t *first_nonlabel_instr; /* The first non label instr of the bb copy. */
+    instr_t *last_instr;           /* The last instr of the bb copy being considered. */
 } drbbdup_per_thread;
 
 static uint ref_count = 0;        /* Instance count of drbbdup. */
@@ -925,11 +926,22 @@ drbbdup_instrument_dups(void *drcontext, app_pc pc, void *tag, instrlist_t *bb,
         instr_t *end_instr = drbbdup_next_end(next_instr);
         ASSERT(end_instr != NULL, "end instruction cannot be NULL");
 
-        /* Cache first and last instructions. */
-        if (next_instr == end_instr && is_last_special)
+        /* Cache first, first nonlabel and last instructions. */
+        if (next_instr == end_instr && is_last_special) {
             pt->first_instr = last;
-        else
+            pt->first_nonlabel_instr = last;
+        } else {
             pt->first_instr = next_instr; /* Update cache to first instr. */
+            instr_t *first_non_label = next_instr;
+            while (instr_is_label(first_non_label) && first_non_label != end_instr) {
+                first_non_label = instr_get_next(first_non_label);
+            }
+            if (first_non_label == end_instr && is_last_special) {
+                pt->first_nonlabel_instr = last;
+            } else {
+                pt->first_nonlabel_instr = first_non_label;
+            }
+        }
 
         if (is_last_special)
             pt->last_instr = last;
@@ -1320,6 +1332,22 @@ drbbdup_is_first_instr(void *drcontext, instr_t *instr, bool *is_start)
         return DRBBDUP_ERROR;
 
     *is_start = pt->first_instr == instr;
+
+    return DRBBDUP_SUCCESS;
+}
+
+drbbdup_status_t
+drbbdup_is_first_nonlabel_instr(void *drcontext, instr_t *instr, bool *is_nonlabel)
+{
+    if (instr == NULL || is_nonlabel == NULL)
+        return DRBBDUP_ERROR_INVALID_PARAMETER;
+
+    drbbdup_per_thread *pt =
+        (drbbdup_per_thread *)drmgr_get_tls_field(drcontext, tls_idx);
+    if (pt == NULL)
+        return DRBBDUP_ERROR;
+
+    *is_nonlabel = pt->first_nonlabel_instr == instr;
 
     return DRBBDUP_SUCCESS;
 }

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -40,6 +40,10 @@
 #include <stdint.h>
 #include "../ext_utils.h"
 
+#undef drmgr_is_first_instr
+#undef drmgr_is_first_nonlabel_instr
+#undef drmgr_is_last_instr
+
 #ifdef DEBUG
 #    define ASSERT(x, msg) DR_ASSERT_MSG(x, msg)
 #    define LOG(dc, mask, level, ...) dr_log(dc, mask, level, __VA_ARGS__)

--- a/ext/drbbdup/drbbdup.dox
+++ b/ext/drbbdup/drbbdup.dox
@@ -103,6 +103,10 @@ The client may implement #drbbdup_destroy_orig_analysis_t and
 #drbbdup_destroy_case_analysis_t call-back functions to destroy the respective
 analysis data.
 
+Furthermore, should the client perform some analysis prior to duplication during the
+app2app stage via a separate event, then such data should be stored and accessed via
+TLS.
+
 \section sec_drbbdup_encoder Encoder
 
 In order for drbbdup to dispatch control to the appropriate basic block copy, it
@@ -127,9 +131,11 @@ considers for instrumentation, it also provides a "where" instruction.
 The client must insert code exactly prior to the "where" instruction
 in order to ensure correct instrumentation.
 
-drbbdup also provides drbbdup_is_first_instr() drbbdup_is_first_nonlabel_instr()
+drbbdup also provides drbbdup_is_first_instr(), drbbdup_is_first_nonlabel_instr()
 and drbbdup_is_last_instr() to determine whether the passed instruction
-is the first or last instruction of a basic block copy respectively.
+is the first, first non label and last instruction of a basic block copy respectively.
+Note the client should not use drmgr varients such as drmgr_is_first_instr() as these
+API functions do not take into account drbbdup's internals and therefore will fail.
 
 */
 

--- a/ext/drbbdup/drbbdup.dox
+++ b/ext/drbbdup/drbbdup.dox
@@ -127,9 +127,9 @@ considers for instrumentation, it also provides a "where" instruction.
 The client must insert code exactly prior to the "where" instruction
 in order to ensure correct instrumentation.
 
-drbbdup also provides drbbdup_is_first_instr() and drbbdup_is_last_instr()
-to determine whether the passed instruction is the first
-or last instruction of a basic block copy respectively.
+drbbdup also provides drbbdup_is_first_instr() drbbdup_is_first_nonlabel_instr()
+and drbbdup_is_last_instr() to determine whether the passed instruction
+is the first or last instruction of a basic block copy respectively.
 
 */
 

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -351,6 +351,18 @@ drbbdup_is_first_instr(void *drcontext, instr_t *instr, OUT bool *is_start);
 
 DR_EXPORT
 /**
+ * Indicates whether the instruction \p instr is the first non labe; instruction of
+ * the currently considered basic block copy. The result is returned in \p is_nonlabel.
+ *
+ * Must be called via a #drbbdup_instrument_instr_t call-back function.
+ *
+ * @return whether successful or an error code on failure.
+ */
+drbbdup_status_t
+drbbdup_is_first_nonlabel_instr(void *drcontext, instr_t *instr, bool *is_nonlabel);
+
+DR_EXPORT
+/**
  * Indicates whether the instruction \p instr is the last instruction of the currently
  * considered basic block copy. The result is returned in \p is_last.
  *

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -45,6 +45,13 @@
 extern "C" {
 #endif
 
+#define drmgr_is_first_instr \
+    DO_NOT_USE_drmgr_is_first_instr_USE_drbbdup_is_first_instr_instead
+#define drmgr_is_first_nonlabel_instr \
+    DO_NOT_USE_drmgr_is_first_nonlabel_instr_USE_drbbdup_is_first_nonlabel_instr_instead
+#define drmgr_is_last_instr \
+    DO_NOT_USE_drmgr_is_last_instr_USE_drbbdup_is_last_instr_instead
+
 /**
  * \addtogroup drbbdup Basic Block Duplicator
  */
@@ -351,7 +358,7 @@ drbbdup_is_first_instr(void *drcontext, instr_t *instr, OUT bool *is_start);
 
 DR_EXPORT
 /**
- * Indicates whether the instruction \p instr is the first non labe; instruction of
+ * Indicates whether the instruction \p instr is the first non label instruction of
  * the currently considered basic block copy. The result is returned in \p is_nonlabel.
  *
  * Must be called via a #drbbdup_instrument_instr_t call-back function.

--- a/suite/tests/client-interface/drbbdup-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-test.dll.c
@@ -179,7 +179,7 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
                  instr_t *where, uintptr_t encoding, void *user_data,
                  void *orig_analysis_data, void *analysis_data)
 {
-    bool is_start;
+    bool is_first, is_first_nonlabel;
     drbbdup_status_t res;
 
     CHECK(user_data == USER_DATA_VAL, "user data does not match");
@@ -198,10 +198,16 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
     default: CHECK(false, "invalid encoding");
     }
 
-    res = drbbdup_is_first_instr(drcontext, instr, &is_start);
+    res = drbbdup_is_first_instr(drcontext, instr, &is_first);
     CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is start");
 
-    if (is_start && encoding != 0) {
+    if (is_first && !instr_is_label(instr)) {
+        res = drbbdup_is_first_nonlabel_instr(drcontext, instr, &is_first_nonlabel);
+        CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is first non label");
+        CHECK(is_first_nonlabel, "should be first non label");
+    }
+
+    if (is_first && encoding != 0) {
         instrum_called = true;
         dr_insert_clean_call(drcontext, bb, where, print_case, false, 1,
                              OPND_CREATE_INTPTR(encoding));


### PR DESCRIPTION
Includes drbbdup_is_first_nonlabel_instr() to determine whether or not the instruction considered during insertion is the first non label instruction of the basic block copy. 

Issue: #4134