### PR TITLE
i#4215 atomics: Add load and store atomics

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -259,6 +259,8 @@ Further non-compatibility-affecting changes include:
    lookups when internal symbols are not needed.
  - Added dr_merge_arith_flags() as a convenience routine to merge arithmetic flags
    for restoration done by outlined code.
+ - Added atomics for safe and visible aligned loads and stores on all platforms:
+   dr_atomic_load32(), dr_atomic_store32(), dr_atomic_load64() dr_atomic_store64().
 
 **************************************************
 <hr>

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -474,6 +474,24 @@ atomic_add_exchange_int64(volatile int64 *var, int64 value)
                                      : "+m"(*(int *)(target)), "+r"(_myval)        \
                                      :);                                           \
             } while (0)
+#        define ATOMIC_4BYTE_ALIGNED_WRITE(target, value, hot_patch)               \
+            do {                                                                   \
+                /* allow a constant to be passed in by supplying our own lvalue */ \
+                int _myval = value;                                                \
+                ASSERT(sizeof(value) == 4);                                        \
+                ASSERT(ALIGNED(target, 4));                                        \
+                __asm__ __volatile__("movl %1, %0"                                 \
+                                     : "=m"(*(int *)(target))                      \
+                                     : "r"(_myval));                               \
+            } while (0)
+#        define ATOMIC_4BYTE_ALIGNED_READ(addr_src, addr_res)         \
+            do {                                                      \
+                ASSERT(ALIGNED(addr_src, 4));                         \
+                __asm__ __volatile__("movl %1, %%eax; movl %%eax, %0" \
+                                     : "=m"(*(int *)(addr_res))       \
+                                     : "m"(*(int *)(addr_src))        \
+                                     : "eax");                        \
+            } while (0)
 #        ifdef X64
 #            define ATOMIC_8BYTE_WRITE(target, value, hot_patch)                       \
                 do {                                                                   \
@@ -489,6 +507,26 @@ atomic_add_exchange_int64(volatile int64 *var, int64 value)
                     __asm__ __volatile__("xchgq %0, %1"                                \
                                          : "+m"(*(int64 *)(target)), "+r"(_myval)      \
                                          :);                                           \
+                } while (0)
+#            define ATOMIC_8BYTE_ALIGNED_WRITE(target, value, hot_patch)               \
+                do {                                                                   \
+                    /* allow a constant to be passed in by supplying our own lvalue */ \
+                    int64 _myval = value;                                              \
+                    ASSERT(sizeof(value) == 8);                                        \
+                    /* Not currently used to write code */                             \
+                    ASSERT_CURIOSITY(!hot_patch);                                      \
+                    ASSERT(ALIGNED(target, 8));                                        \
+                    __asm__ __volatile__("movq %1, %0"                                 \
+                                         : "=m"(*(int64 *)(target))                    \
+                                         : "r"(_myval));                               \
+                } while (0)
+#            define ATOMIC_8BYTE_ALIGNED_READ(addr_src, addr_res)         \
+                do {                                                      \
+                    ASSERT(ALIGNED(addr_src, 8));                         \
+                    __asm__ __volatile__("movq %1, %%rax; movq %%rax, %0" \
+                                         : "=m"(*(int64 *)(addr_res))     \
+                                         : "m"(*(int64 *)addr_src)        \
+                                         : "rax");                        \
                 } while (0)
 #        endif /* X64 */
 #        define ATOMIC_INC_suffix(suffix, var) \
@@ -577,34 +615,55 @@ atomic_add_exchange_int64(volatile int64 *var, int64 value)
                 ASSERT(sizeof(value) == 1);                    \
                 /* Not currently used to write code */         \
                 ASSERT_CURIOSITY(!hot_patch);                  \
-                __asm__ __volatile__("strb %w0, [%1]"          \
+                __asm__ __volatile__("stlrb %w0, [%1]"         \
                                      :                         \
                                      : "r"(value), "r"(target) \
                                      : "memory");              \
             } while (0)
-#        define ATOMIC_4BYTE_WRITE(target, value, hot_patch)                 \
-            do {                                                             \
-                ASSERT(sizeof(value) == 4);                                  \
-                /* Not currently used to write code */                       \
-                ASSERT_CURIOSITY(!hot_patch);                                \
-                /* Aligned load/store instructions are atomic on AArch64. */ \
-                ASSERT(ALIGNED(target, 4));                                  \
-                __asm__ __volatile__("str %w0, [%1]"                         \
-                                     :                                       \
-                                     : "r"(value), "r"(target)               \
-                                     : "memory");                            \
+#        define ATOMIC_4BYTE_WRITE(target, value, hot_patch)                    \
+            do {                                                                \
+                ASSERT(sizeof(value) == 4);                                     \
+                /* Not currently used to write code */                          \
+                ASSERT_CURIOSITY(!hot_patch);                                   \
+                /* We use "store-release" to add a barrier to make the store */ \
+                /* visible promptly and not just atomic as in untorn which */   \
+                /* alignment gives us by itself. */                             \
+                ASSERT(ALIGNED(target, 4));                                     \
+                __asm__ __volatile__("stlr %w0, [%1]"                           \
+                                     :                                          \
+                                     : "r"(value), "r"(target)                  \
+                                     : "memory");                               \
             } while (0)
-#        define ATOMIC_8BYTE_WRITE(target, value, hot_patch)                 \
-            do {                                                             \
-                ASSERT(sizeof(value) == 8);                                  \
-                /* Not currently used to write code */                       \
-                ASSERT_CURIOSITY(!hot_patch);                                \
-                /* Aligned load/store instructions are atomic on AArch64. */ \
-                ASSERT(ALIGNED(target, 8));                                  \
-                __asm__ __volatile__("str %0, [%1]"                          \
-                                     :                                       \
-                                     : "r"(value), "r"(target)               \
-                                     : "memory");                            \
+#        define ATOMIC_4BYTE_ALIGNED_WRITE ATOMIC_4BYTE_WRITE
+#        define ATOMIC_4BYTE_ALIGNED_READ(addr_src, addr_res)       \
+            do {                                                    \
+                ASSERT(ALIGNED(addr_src, 4));                       \
+                /* We use "load-acquire" to add a barrier. */       \
+                __asm__ __volatile__("ldar w0, [%0]; str w0, [%1]"  \
+                                     :                              \
+                                     : "r"(addr_src), "r"(addr_res) \
+                                     : "w0", "memory");             \
+            } while (0)
+#        define ATOMIC_8BYTE_WRITE(target, value, hot_patch)   \
+            do {                                               \
+                ASSERT(sizeof(value) == 8);                    \
+                /* Not currently used to write code */         \
+                ASSERT_CURIOSITY(!hot_patch);                  \
+                ASSERT(ALIGNED(target, 8));                    \
+                __asm__ __volatile__("stlr %0, [%1]"           \
+                                     :                         \
+                                     : "r"(value), "r"(target) \
+                                     : "memory");              \
+            } while (0)
+#        define ATOMIC_8BYTE_ALIGNED_WRITE ATOMIC_8BYTE_WRITE
+#        define ATOMIC_8BYTE_ALIGNED_READ(addr_src, addr_res)       \
+            do {                                                    \
+                ASSERT(ALIGNED(addr_src, 8));                       \
+                /* We use "load-acquire" to add a barrier. */       \
+                __asm__ __volatile__("ldar x0, [%0]; str x0, [%1]"  \
+                                     :                              \
+                                     : "r"(addr_src), "r"(addr_res) \
+                                     : "x0", "memory");             \
             } while (0)
 
 #        define DEF_ATOMIC_incdec(fname, type, r, op)                             \
@@ -739,7 +798,7 @@ atomic_dec_becomes_zero(volatile int *var)
 #        define ATOMIC_1BYTE_WRITE(target, value, hot_patch)   \
             do {                                               \
                 ASSERT(sizeof(value) == 1);                    \
-                __asm__ __volatile__("strb %0, [%1]"           \
+                __asm__ __volatile__("dmb ish; strb %0, [%1]"  \
                                      :                         \
                                      : "r"(value), "r"(target) \
                                      : "memory");              \
@@ -750,10 +809,19 @@ atomic_dec_becomes_zero(volatile int *var)
                 /* Load and store instructions are atomic on ARM if aligned. */  \
                 /* FIXME i#1551: we need patch the whole instruction instead. */ \
                 ASSERT(ALIGNED(target, 4));                                      \
-                __asm__ __volatile__("str %0, [%1]"                              \
+                __asm__ __volatile__("dmb ish; str %0, [%1]"                     \
                                      :                                           \
                                      : "r"(value), "r"(target)                   \
                                      : "memory");                                \
+            } while (0)
+#        define ATOMIC_4BYTE_ALIGNED_WRITE ATOMIC_4BYTE_WRITE
+#        define ATOMIC_4BYTE_ALIGNED_READ(addr_src, addr_res)              \
+            do {                                                           \
+                ASSERT(ALIGNED(addr_src, 4));                              \
+                __asm__ __volatile__("ldr r0, [%1]; dmb ish; str r0, [%0]" \
+                                     :                                     \
+                                     : "r"(addr_src), "r"(addr_res)        \
+                                     : "r0", "memory");                    \
             } while (0)
 
 /* OP_swp is deprecated and OP_ldrex and OP_strex are introduced in
@@ -999,6 +1067,24 @@ atomic_add_exchange_int64(volatile int64 *var, int64 value)
 #    endif /* !AARCH64 */
 
 #endif /* UNIX */
+
+static inline int
+atomic_aligned_read_int(volatile int *var)
+{
+    int temp;
+    ATOMIC_4BYTE_ALIGNED_READ(var, &temp);
+    return temp;
+}
+
+#ifdef X64
+static inline int64
+atomic_aligned_read_int64(volatile int64 *var)
+{
+    int64 temp;
+    ATOMIC_8BYTE_ALIGNED_READ(var, &temp);
+    return temp;
+}
+#endif
 
 #define atomic_compare_exchange atomic_compare_exchange_int
 #ifdef X64

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -818,7 +818,7 @@ atomic_dec_becomes_zero(volatile int *var)
 #        define ATOMIC_4BYTE_ALIGNED_READ(addr_src, addr_res)              \
             do {                                                           \
                 ASSERT(ALIGNED(addr_src, 4));                              \
-                __asm__ __volatile__("ldr r0, [%1]; dmb ish; str r0, [%0]" \
+                __asm__ __volatile__("ldr r0, [%0]; dmb ish; str r0, [%1]" \
                                      :                                     \
                                      : "r"(addr_src), "r"(addr_res)        \
                                      : "r0", "memory");                    \

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -3905,6 +3905,36 @@ dr_atomic_add64_return_sum(volatile int64 *dest, int64 val)
 }
 #    endif
 
+DR_API
+int
+dr_atomic_load32(volatile int *src)
+{
+    return atomic_aligned_read_int(src);
+}
+
+DR_API
+void
+dr_atomic_store32(volatile int *dest, int val)
+{
+    ATOMIC_4BYTE_ALIGNED_WRITE(dest, val, false);
+}
+
+#    ifdef X64
+DR_API
+int64
+dr_atomic_load64(volatile int64 *src)
+{
+    return atomic_aligned_read_int64(src);
+}
+
+DR_API
+void
+dr_atomic_store64(volatile int64 *dest, int64 val)
+{
+    ATOMIC_8BYTE_ALIGNED_WRITE(dest, val, false);
+}
+#    endif
+
 /***************************************************************************
  * MODULES
  */

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -2973,9 +2973,38 @@ DR_API
 /**
  * Atomically adds \p val to \p *dest and returns the sum.
  * \p dest must not straddle two cache lines.
+ * Currently 64-bit-build only.
  */
 int64
 dr_atomic_add64_return_sum(volatile int64 *dest, int64 val);
+#    endif
+
+DR_API
+/** Atomically and visibly loads the value at \p src and returns it. */
+int
+dr_atomic_load32(volatile int *src);
+
+DR_API
+/** Atomically and visibly stores \p val to \p dest. */
+void
+dr_atomic_store32(volatile int *dest, int val);
+
+#    ifdef X64
+DR_API
+/**
+ * Atomically and visibly loads the value at \p src and returns it.
+ * Currently 64-bit-build only.
+ */
+int64
+dr_atomic_load64(volatile int64 *src);
+
+DR_API
+/**
+ * Atomically and visibly stores \p val to \p dest.
+ * Currently 64-bit-build only.
+ */
+void
+dr_atomic_store64(volatile int64 *dest, int64 val);
 #    endif
 
 /* DR_API EXPORT BEGIN */

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -80,10 +80,13 @@ static uint verbose = 0;
 #    define CALL_POINT_SCRATCH_REG DR_REG_NULL
 #endif
 
+/* XXX i#4215: DR should provide 64-bit-sized atomics for 32-bit code. */
 #ifdef X64
 #    define dr_atomic_add_stat_return_sum dr_atomic_add64_return_sum
+#    define dr_atomic_load_stat dr_atomic_load64
 #else
 #    define dr_atomic_add_stat_return_sum dr_atomic_add32_return_sum
+#    define dr_atomic_load_stat dr_atomic_load32
 #endif
 
 /* protected by wrap_lock */
@@ -2445,7 +2448,7 @@ drwrap_get_stats(INOUT drwrap_stats_t *stats)
 {
     if (stats == NULL || stats->size != sizeof(*stats))
         return false;
-    stats->flush_count = dr_atomic_add_stat_return_sum(&drwrap_stats.flush_count, 0);
+    stats->flush_count = dr_atomic_load_stat(&drwrap_stats.flush_count);
     return true;
 }
 

--- a/suite/tests/client-interface/thread.dll.c
+++ b/suite/tests/client-interface/thread.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -111,9 +111,19 @@ thread_func(void *arg)
      */
     int count = dr_atomic_add32_return_sum(&counter32, 1);
     ASSERT(count > 0 && count <= counter32);
+    int local_counter;
+    dr_atomic_store32(&local_counter, 42);
+    count = dr_atomic_load32(&local_counter);
+    ASSERT(count == 42);
+    ASSERT(local_counter == 42);
 #ifdef X64
     int64 count64 = dr_atomic_add64_return_sum(&counter64, 1);
     ASSERT(count64 > 0 && count64 <= counter64);
+    int64 local_counter64;
+    dr_atomic_store64(&local_counter64, 42);
+    count64 = dr_atomic_load64(&local_counter64);
+    ASSERT(count64 == 42);
+    ASSERT(local_counter64 == 42);
 #endif
 
 #ifdef UNIX

--- a/suite/tests/client-interface/tls.dll.cpp
+++ b/suite/tests/client-interface/tls.dll.cpp
@@ -122,6 +122,30 @@ event_thread_init(void *drcontext)
 #endif
     thread_init_called = true;
     check();
+
+    /* Just a sanity check that these functions operate.  We do not take the
+     * time to set up racing threads or sthg.
+     * This is a duplicate of the test in thread.dll.c, placed here b/c that test
+     * is not yet enabled for AArchXX.
+     */
+    static int counter32;
+    int count = dr_atomic_add32_return_sum(&counter32, 1);
+    ASSERT(count > 0 && count <= counter32);
+    int local_counter;
+    dr_atomic_store32(&local_counter, 42);
+    count = dr_atomic_load32(&local_counter);
+    ASSERT(count == 42);
+    ASSERT(local_counter == 42);
+#ifdef X64
+    static int64 counter64;
+    int64 count64 = dr_atomic_add64_return_sum(&counter64, 1);
+    ASSERT(count64 > 0 && count64 <= counter64);
+    int64 local_counter64;
+    dr_atomic_store64(&local_counter64, 42);
+    count64 = dr_atomic_load64(&local_counter64);
+    ASSERT(count64 == 42);
+    ASSERT(local_counter64 == 42);
+#endif
 }
 
 static void


### PR DESCRIPTION
Adds 32-bit and 64-bit load and store atomics to core DR and exports
them to the client API.

Adds missing barriers to the existing store atomic macros on both ARM
and AArch64.

Adds a sanity test that at least exercises the functions.  Adds the
test sequence to client.thread and client.tls (only client.tls is
currently enabled on AArchXX).

Uses dr_atomic_load* in drwrap in place of a previously overkill
dr_atomic_add*.

These will also help with #2502.

The next step is to add gencode versions of these, either to the core
or drx.

Issue: #4215, #2502