### PR TITLE
Add signal and thread numbers to fatal signal message

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -5017,8 +5017,14 @@ master_signal_handler_C(byte *xsp)
         if (can_always_delay[sig])
             return;
 
-        REPORT_FATAL_ERROR_AND_EXIT(FAILED_TO_HANDLE_SIGNAL, 2, get_application_name(),
-                                    get_application_pid());
+        char signum_str[8];
+        dr_snprintf(signum_str, BUFFER_SIZE_ELEMENTS(signum_str), "%d", sig);
+        NULL_TERMINATE_BUFFER(signum_str);
+        char tid_str[16];
+        dr_snprintf(tid_str, BUFFER_SIZE_ELEMENTS(tid_str), TIDFMT, get_sys_thread_id());
+        NULL_TERMINATE_BUFFER(tid_str);
+        REPORT_FATAL_ERROR_AND_EXIT(FAILED_TO_HANDLE_SIGNAL, 4, get_application_name(),
+                                    get_application_pid(), signum_str, tid_str);
     }
 
     /* we may be entering dynamo from code cache! */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -5018,10 +5018,10 @@ master_signal_handler_C(byte *xsp)
             return;
 
         char signum_str[8];
-        dr_snprintf(signum_str, BUFFER_SIZE_ELEMENTS(signum_str), "%d", sig);
+        snprintf(signum_str, BUFFER_SIZE_ELEMENTS(signum_str), "%d", sig);
         NULL_TERMINATE_BUFFER(signum_str);
         char tid_str[16];
-        dr_snprintf(tid_str, BUFFER_SIZE_ELEMENTS(tid_str), TIDFMT, get_sys_thread_id());
+        snprintf(tid_str, BUFFER_SIZE_ELEMENTS(tid_str), TIDFMT, get_sys_thread_id());
         NULL_TERMINATE_BUFFER(tid_str);
         REPORT_FATAL_ERROR_AND_EXIT(FAILED_TO_HANDLE_SIGNAL, 4, get_application_name(),
                                     get_application_pid(), signum_str, tid_str);

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -624,7 +624,7 @@ Severity = Error
 Facility = DRCore
 SymbolicName = MSG_FAILED_TO_HANDLE_SIGNAL
 Language=English
-Application %1!s! (%2!s!). Cannot correctly handle a received signal.
+Application %1!s! (%2!s!). Cannot correctly handle received signal %3!s! in thread %4!s!.
 .
 ;#endif
 


### PR DESCRIPTION
Adds the signal number and thread id to this fatal message for better diagnostics:
  <Cannot correctly handle received signal 11 in thread 204511.>

Tested in the #4219 failures.