### PR TITLE
i#3048 func-trace: Improve function tracing re-attach

### DIFF
--- a/clients/drcachesim/tests/burst_malloc.cpp
+++ b/clients/drcachesim/tests/burst_malloc.cpp
@@ -122,13 +122,13 @@ main(int argc, const char *argv[])
                    " -record_function \"malloc|1&return_big_value|1\"'"))
         std::cerr << "failed to set env var!\n";
 
-    drmemtrace_status_t res = drmemtrace_buffer_handoff(nullptr, exit_cb, nullptr);
-    assert(res == DRMEMTRACE_SUCCESS);
-
     for (int i = 0; i < 3; i++) {
         std::cerr << "pre-DR init\n";
         dr_app_setup();
         assert(!dr_app_running_under_dynamorio());
+
+        drmemtrace_status_t res = drmemtrace_buffer_handoff(nullptr, exit_cb, nullptr);
+        assert(res == DRMEMTRACE_SUCCESS);
 
         std::cerr << "pre-DR start\n";
         if (do_some_work(i * 1) < 0)

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -488,6 +488,9 @@ func_trace_exit()
 
     if (funcs_str.empty())
         return;
+    /* Clear for re-attach. */
+    funcs_str.clear();
+    funcs_str_sep.clear();
     hashtable_delete(&pc2idplus1);
     if (!drvector_delete(&funcs_wrapped) || !drvector_delete(&func_names))
         DR_ASSERT(false);


### PR DESCRIPTION
Clears the list of traced functions on exit to avoid accumulation on re-attach.

Sets the handoff separately for each attach in the burst_malloc test.

There are still problems with re-setting options: droption #4139 and
core #2661 (with the '#' prefix workaround).  Those are left to their
respective issues.

Issue: #3048, #2661, #4139