### PR TITLE
i#4197 replace RA: Fix Mac build

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2314,11 +2314,13 @@ if (CLIENT_INTERFACE)
     use_DynamoRIO_extension(client.drwrap-test-callconv.dll drwrap)
   endif ()
   if (NOT ARM AND NOT AARCH64) # FIXME i#1578: fix detach on ARM/AArch64
-    set(client.drwrap-test-detach_no_reg_compat)
-    tobuild_api(client.drwrap-test-detach client-interface/drwrap-test-detach.cpp
-      "" "" OFF ON)
-    use_DynamoRIO_extension(client.drwrap-test-detach drwrap_static)
-    link_with_pthread(client.drwrap-test-detach)
+    if (NOT APPLE) # XXX i#1997: static DR not fully supported on Mac yet
+      set(client.drwrap-test-detach_no_reg_compat)
+      tobuild_api(client.drwrap-test-detach client-interface/drwrap-test-detach.cpp
+        "" "" OFF ON)
+      use_DynamoRIO_extension(client.drwrap-test-detach drwrap_static)
+      link_with_pthread(client.drwrap-test-detach)
+    endif ()
   endif ()
 
   # We rely on dbghelp >= 6.0 for our drsyms and sample.instrcalls tests,

--- a/suite/tests/client-interface/drwrap-test.appdll.c
+++ b/suite/tests/client-interface/drwrap-test.appdll.c
@@ -395,7 +395,7 @@ GLOBAL_LABEL(FUNCNAME:)
         add      sp, #12
         pop      {lr}
 # endif
-        JUMP     tailcall_tail
+        JUMP     GLOBAL_REF(tailcall_tail)
         END_FUNC(FUNCNAME)
 #  undef FUNCNAME
 


### PR DESCRIPTION
PR #4221 broke the Mac build, but Travis failed to show the failure in
the logs in the PR builds (some buffering issue filed as #4223).  We
fix the Mac build here.

Issue: #4197, #4223