### PR TITLE
i#3048 func-trace: Fix thread filter + func trace crash

### DIFF
--- a/clients/drcachesim/tests/burst_threadfilter.cpp
+++ b/clients/drcachesim/tests/burst_threadfilter.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -213,9 +213,10 @@ main(int argc, const char *argv[])
     /* While the start/stop thread only runs 4 iters, the other threads end up
      * running more and their trace files get up to 65MB or more, with the
      * merged result several GB's: too much for a test.  We thus cap each thread.
+     * We run with -record_heap to ensure we test that combination.
      */
-    std::string ops =
-        std::string("-stderr_mask 0xc -client_lib ';;-offline -max_trace_size 256K ");
+    std::string ops = std::string(
+        "-stderr_mask 0xc -client_lib ';;-offline -record_heap -max_trace_size 256K ");
     /* Support passing in extra tracer options. */
     for (int i = 1; i < argc; ++i)
         ops += std::string(argv[i]) + " ";

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -548,7 +548,7 @@ static void
 append_marker_seg_base(void *drcontext, func_trace_entry_vector_t *vec)
 {
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
-    if (data->seg_base == NULL)
+    if (BUF_PTR(data->seg_base) == NULL)
         return; /* This thread was filtered out. */
     for (int i = 0; i < vec->size; i++) {
         BUF_PTR(data->seg_base) +=


### PR DESCRIPTION
Fixes an incorrect test in the combination of thread filtering and
function tracing in drcachesim.

Adds -record_heap to the threadfilter test, though I had trouble
reproducing the crash there.  I tested the fix on a third_party app
where it was hit but is unfortunately difficult to add as a regression
test here.

Issue: #3048