### PR TITLE
i#4226: Faster fragment deletion event

### DIFF
--- a/core/fragment.c
+++ b/core/fragment.c
@@ -1143,10 +1143,14 @@ hashtable_fragment_reset(dcontext_t *dcontext, fragment_table_t *table)
     if (!dr_fragment_deleted_hook_exists())
         return;
     /* i#4226: Avoid the slow deletion code and just invoke the event. */
-    for (i = 0; i < table->capacity; i++) {
+    for (i = 0; i < (int)table->capacity; i++) {
         f = table->table[i];
         if (!REAL_FRAGMENT(f))
             continue;
+        /* This is a full delete (i.e., it is neither FRAGDEL_NO_HEAP nor
+         * FRAGDEL_NO_FCACHE: see the fragment_delete() call in the debug path
+         * below) so we call the event for every (real) fragment.
+         */
         instrument_fragment_deleted(dcontext, f->tag, f->flags);
     }
     return;
@@ -3086,6 +3090,10 @@ fragment_delete(dcontext_t *dcontext, fragment_t *f, uint actions)
         sideline_fragment_delete(f);
 #endif
 #ifdef CLIENT_INTERFACE
+    /* For exit-time deletion we invoke instrument_fragment_deleted() directly from
+     * hashtable_fragment_reset().  If we add any further conditions on when it should
+     * be invoked we should keep the two calls in synch.
+     */
     if (dr_fragment_deleted_hook_exists() &&
         (!TEST(FRAGDEL_NO_HEAP, actions) || !TEST(FRAGDEL_NO_FCACHE, actions)))
         instrument_fragment_deleted(dcontext, f->tag, f->flags);

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -1159,6 +1159,11 @@ hashtable_fragment_reset(dcontext_t *dcontext, fragment_table_t *table)
              * the assert.
              */
             ASSERT(!TEST(FRAG_TRACE_BUILDING, f->flags));
+#    if !defined(DEBUG) && defined(CLIENT_INTERFACE)
+            if (dr_fragment_deleted_hook_exists() && !REAL_FRAGMENT(f))
+                instrument_fragment_deleted(dcontext, f->tag, f->flags);
+            continue;
+#    endif
             hashtable_fragment_remove_helper(table, i, &table->table[i]);
             if (!REAL_FRAGMENT(f))
                 continue;

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -880,9 +880,6 @@ drwrap_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *ins
 static void
 drwrap_event_module_unload(void *drcontext, const module_data_t *info);
 
-static void
-drwrap_fragment_delete(void *dc /*may be NULL*/, void *tag);
-
 static bool
 drwrap_event_restore_state_ex(void *drcontext, bool restore_memory,
                               dr_restore_state_info_t *info);
@@ -960,7 +957,6 @@ drwrap_init(void)
     post_call_rwlock = dr_rwlock_create();
     wrap_lock = dr_recurlock_create();
     drmgr_register_module_unload_event(drwrap_event_module_unload);
-    dr_register_delete_event(drwrap_fragment_delete);
 
     tls_idx = drmgr_register_tls_field();
     if (tls_idx == -1)
@@ -1005,8 +1001,7 @@ drwrap_exit(void)
         !drmgr_unregister_bb_instrumentation_event(drwrap_event_bb_analysis) ||
         !drmgr_unregister_restore_state_ex_event(drwrap_event_restore_state_ex) ||
         !drmgr_unregister_module_unload_event(drwrap_event_module_unload) ||
-        !drmgr_unregister_tls_field(tls_idx) ||
-        !dr_unregister_delete_event(drwrap_fragment_delete))
+        !drmgr_unregister_tls_field(tls_idx))
         ASSERT(false, "failed to unregister in drwrap_exit");
 
     for (int i = 0; i < POSTCALL_CACHE_SIZE; i++) {
@@ -2377,12 +2372,6 @@ drwrap_event_module_unload(void *drcontext, const module_data_t *info)
      * and we wrap something weird, we could blame the client.  That's the current
      * approach.
      */
-}
-
-static void
-drwrap_fragment_delete(void *dc /*may be NULL*/, void *tag)
-{
-    /* switched to checking consistency at lookup time (DrMemi#673) */
 }
 
 static bool

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -880,6 +880,9 @@ drwrap_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *ins
 static void
 drwrap_event_module_unload(void *drcontext, const module_data_t *info);
 
+static void
+drwrap_fragment_delete(void *dc /*may be NULL*/, void *tag);
+
 static bool
 drwrap_event_restore_state_ex(void *drcontext, bool restore_memory,
                               dr_restore_state_info_t *info);
@@ -957,6 +960,7 @@ drwrap_init(void)
     post_call_rwlock = dr_rwlock_create();
     wrap_lock = dr_recurlock_create();
     drmgr_register_module_unload_event(drwrap_event_module_unload);
+    dr_register_delete_event(drwrap_fragment_delete);
 
     tls_idx = drmgr_register_tls_field();
     if (tls_idx == -1)
@@ -1001,7 +1005,8 @@ drwrap_exit(void)
         !drmgr_unregister_bb_instrumentation_event(drwrap_event_bb_analysis) ||
         !drmgr_unregister_restore_state_ex_event(drwrap_event_restore_state_ex) ||
         !drmgr_unregister_module_unload_event(drwrap_event_module_unload) ||
-        !drmgr_unregister_tls_field(tls_idx))
+        !drmgr_unregister_tls_field(tls_idx) ||
+        !dr_unregister_delete_event(drwrap_fragment_delete))
         ASSERT(false, "failed to unregister in drwrap_exit");
 
     for (int i = 0; i < POSTCALL_CACHE_SIZE; i++) {
@@ -2372,6 +2377,12 @@ drwrap_event_module_unload(void *drcontext, const module_data_t *info)
      * and we wrap something weird, we could blame the client.  That's the current
      * approach.
      */
+}
+
+static void
+drwrap_fragment_delete(void *dc /*may be NULL*/, void *tag)
+{
+    /* switched to checking consistency at lookup time (DrMemi#673) */
 }
 
 static bool


### PR DESCRIPTION
i#4226: Faster fragment deletion event

Adds a dedicated loop to call the fragment deletion event without
calling all the other fragment freeing code.  This speeds up detach
and process exit in general by 2x.

Tested performance and correctness on a third-party app; also tested
correctness on a hacked drwrap-detach-test to ensure the same number
of deletion event calls were made.  I don't think it's easy to make a
performance regression test unfortunately.

Fixes #4226
