### PR TITLE
i#4137: add API for getting a process id associated with a drcontext

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -271,6 +271,9 @@ Further non-compatibility-affecting changes include:
  - The state restore event (dr_register_restore_state_event()) is now called for
    all translation attempts, even when the register state already contains
    application values, to allow clients to restore memory.
+ - Added the function dr_get_process_id_from_drcontext() for obtaining a process ID
+   associated with the given drcontext, which may be different from the current
+   dr_get_process_id() in some contexts.
 
 **************************************************
 <hr>

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -2791,12 +2791,13 @@ dr_get_process_id(void)
 }
 
 DR_API process_id_t
-dr_get_process_id_ext(void *drcontext)
+dr_get_process_id_from_drcontext(void *drcontext)
 {
     dcontext_t *dcontext = (dcontext_t *)drcontext;
-    CLIENT_ASSERT(drcontext != NULL, "dr_get_process_id_ext: drcontext cannot be NULL");
+    CLIENT_ASSERT(drcontext != NULL,
+                  "dr_get_process_id_from_drcontext: drcontext cannot be NULL");
     CLIENT_ASSERT(drcontext != GLOBAL_DCONTEXT,
-                  "dr_get_process_id_ext: drcontext is invalid");
+                  "dr_get_process_id_from_drcontext: drcontext is invalid");
 #    ifdef UNIX
     return dcontext->owning_process;
 #    else

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -2790,6 +2790,20 @@ dr_get_process_id(void)
     return (process_id_t)get_process_id();
 }
 
+DR_API process_id_t
+dr_get_process_id_ext(void *drcontext)
+{
+    dcontext_t *dcontext = (dcontext_t *)drcontext;
+    CLIENT_ASSERT(drcontext != NULL, "dr_get_process_id_ext: drcontext cannot be NULL");
+    CLIENT_ASSERT(drcontext != GLOBAL_DCONTEXT,
+                  "dr_get_process_id_ext: drcontext is invalid");
+#    ifdef UNIX
+    return dcontext->owning_process;
+#    else
+    return dr_get_process_id();
+#    endif
+}
+
 #    ifdef UNIX
 DR_API
 process_id_t

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -796,7 +796,7 @@ DR_API
  * Clients may want to avoid touching resources shared between processes,
  * like files, from the post-fork execution of the callback. The post-fork
  * version of the callback can be recognized by dr_get_process_id()
- * returning a different value than dr_get_process_id_from_drcontext(drcontext).
+ * returning a different value than dr_get_process_id_from_drcontext().
  *
  * See dr_set_process_exit_behavior() for options controlling performance
  * and whether thread exit events are invoked at process exit time in
@@ -1812,7 +1812,8 @@ process_id_t
 dr_get_process_id(void);
 
 DR_API
-/** Returns the process id of the process associated with drcontext \p drcontext.
+/**
+ * Returns the process id of the process associated with drcontext \p drcontext.
  * The returned value may be different from dr_get_process_id() if the passed context
  * was created in a different process, which may happen in thread exit callbacks.
  */

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -796,7 +796,7 @@ DR_API
  * Clients may want to avoid touching resources shared between processes,
  * like files, from the post-fork execution of the callback. The post-fork
  * version of the callback can be recognized by dr_get_process_id()
- * returning a different value than dr_get_process_id_ext(drcontext).
+ * returning a different value than dr_get_process_id_from_drcontext(drcontext).
  *
  * See dr_set_process_exit_behavior() for options controlling performance
  * and whether thread exit events are invoked at process exit time in
@@ -1817,7 +1817,7 @@ DR_API
  * was created in a different process, which may happen in thread exit callbacks.
  */
 process_id_t
-dr_get_process_id_ext(void *drcontext);
+dr_get_process_id_from_drcontext(void *drcontext);
 
 #    ifdef UNIX
 DR_API

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -796,8 +796,7 @@ DR_API
  * Clients may want to avoid touching resources shared between processes,
  * like files, from the post-fork execution of the callback. The post-fork
  * version of the callback can be recognized by dr_get_process_id()
- * returning a different value than it returned during the corresponding
- * thread init event.
+ * returning a different value than dr_get_process_id_ext(drcontext).
  *
  * See dr_set_process_exit_behavior() for options controlling performance
  * and whether thread exit events are invoked at process exit time in
@@ -1811,6 +1810,14 @@ DR_API
 /** Returns the process id of the current process. */
 process_id_t
 dr_get_process_id(void);
+
+DR_API
+/** Returns the process id of the process associated with drcontext \p drcontext.
+ * The returned value may be different from dr_get_process_id() if the passed context
+ * was created in a different process, which may happen in thread exit callbacks.
+ */
+process_id_t
+dr_get_process_id_ext(void *drcontext);
 
 #    ifdef UNIX
 DR_API

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2241,6 +2241,11 @@ if (CLIENT_INTERFACE)
       ${CMAKE_CURRENT_SOURCE_DIR}/client-interface)
   endif (ARM)
 
+  if (UNIX)
+    tobuild_ci(client.process-id client-interface/process-id.c "" "" "")
+    link_with_pthread(client.process-id)
+  endif (UNIX)
+
   tobuild_ci(client.drreg-test client-interface/drreg-test.c "" "" "")
   use_DynamoRIO_extension(client.drreg-test.dll drmgr)
   use_DynamoRIO_extension(client.drreg-test.dll drreg)

--- a/suite/tests/client-interface/process-id.c
+++ b/suite/tests/client-interface/process-id.c
@@ -1,0 +1,25 @@
+#include <pthread.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+volatile unsigned i = 0;
+
+static void *
+thread(void *unused)
+{
+    while (1) {
+        ++i;
+    }
+    return NULL;
+}
+
+int
+main()
+{
+    pthread_t t;
+    pthread_create(&t, NULL, thread, NULL);
+    pid_t pid = fork();
+    if (pid > 0) {
+        wait(NULL); /* for reproducible output */
+    }
+}

--- a/suite/tests/client-interface/process-id.c
+++ b/suite/tests/client-interface/process-id.c
@@ -1,3 +1,35 @@
+/* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
 #include <pthread.h>
 #include <unistd.h>
 #include <sys/wait.h>

--- a/suite/tests/client-interface/process-id.dll.c
+++ b/suite/tests/client-interface/process-id.dll.c
@@ -1,3 +1,35 @@
+/* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
 #include "dr_api.h"
 
 static void

--- a/suite/tests/client-interface/process-id.dll.c
+++ b/suite/tests/client-interface/process-id.dll.c
@@ -1,0 +1,14 @@
+#include "dr_api.h"
+
+static void
+thread_exit(void *drcontext)
+{
+    bool same = dr_get_process_id() == dr_get_process_id_from_drcontext(drcontext);
+    dr_fprintf(STDERR, "thread exit: %s process id\n", same ? "same" : "different");
+}
+
+DR_EXPORT void
+dr_init(client_id_t id)
+{
+    dr_register_thread_exit_event(thread_exit);
+}

--- a/suite/tests/client-interface/process-id.expect
+++ b/suite/tests/client-interface/process-id.expect
@@ -1,0 +1,4 @@
+thread exit: different process id
+thread exit: same process id
+thread exit: same process id
+thread exit: same process id


### PR DESCRIPTION
Fixes: #4137