### PR TITLE
i#4159 marker overflow: Handle expected drcachesim marker overflows

### DIFF
--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -555,6 +555,12 @@ append_marker_seg_base(void *drcontext, func_trace_entry_vector_t *vec)
             instru->append_marker(BUF_PTR(data->seg_base), vec->entries[i].marker_type,
                                   vec->entries[i].marker_value);
     }
+    /* In a filtered data-only trace, a block with no memrefs today still has
+     * a redzone check at the end guarding a clean call to memtrace(), but to
+     * be a litte safer in case that changes we also do a redzone check here.
+     */
+    if (BUF_PTR(data->seg_base) - data->buf_base > static_cast<ssize_t>(trace_buf_size))
+        memtrace(drcontext, false);
 }
 
 static void


### PR DESCRIPTION
For drcachesim post-processing of explicit instr entries such as for
filtered traces, do not output non-xfer markers post-instr and just exit
back to the main loop instead, to avoid overflowing the buffer with
potentially unimited strings of markers before the next filtered
instr or memref entry.

For marker output during tracing, add an explicit check and buffer
dump when the redzone is hit, as a safety step, even though today's
code should not reach it.

Add a release-build check for hitting the buffer size so we can detect
pathological missing-post-call stacked function markers.  Fully
handling that is left for future work.

Issue: #4159