### PR TITLE
Cleanup: Change a for loop var to const ref

### DIFF
--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -108,7 +108,7 @@ protected:
     open_input_files()
     {
         if (!input_path_list_.empty()) {
-            for (std::string path : input_path_list_) {
+            for (const std::string &path : input_path_list_) {
                 if (!open_single_file(path)) {
                     ERRMSG("Failed to open %s\n", path.c_str());
                     return false;


### PR DESCRIPTION
Updates a for loop in drcachesim's file reader to use a const
reference.