### PR TITLE
i#4130: Fix .data write crash from VS optimization

### DIFF
--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -90,8 +90,8 @@ typedef struct _os_privmod_data_t {
     size_t tls_size;
 } os_privmod_data_t;
 
-static int tls_next_idx;
-static int tls_array_count;
+static volatile int tls_next_idx;
+static volatile int tls_array_count;
 /* It is complex to realloc this; it is rarely used so we have a simple max. */
 #define TLS_ARRAY_MAX_SIZE 32
 


### PR DESCRIPTION
Marks tls_next_idx and tls_array_count as volatile to prevent VS from
optimizing a conditional store into an unconditional store (to avoid a
branch) which causes crashes in release build with clients whose
imports use static TLS on multi-threaded applications.

Tested on drcachesim -offline on Win10 1909 with a dbghelp where the
filed crash reproduces.

Ensuring we have a regression test in the CI is trickier and out of
scope for this initial fix.

Fixes #4130