### PR TITLE
i#4130 static TLS: Enable fatal message on late static TLS

### DIFF
--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -2468,12 +2468,12 @@ privload_os_finalize(privmod_t *mod)
     SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
     opd->tls_idx = tls_next_idx++;
     if (opd->tls_idx >= TLS_ARRAY_MAX_SIZE ||
-        (tls_array_count > 0 && opd->tls_idx > tls_array_count)) {
+        (tls_array_count > 0 && opd->tls_idx >= tls_array_count)) {
         /* XXX: It is not easy to resize for all threads.  We do not support for now. */
         REPORT_FATAL_ERROR_AND_EXIT(
             PRIVATE_LIBRARY_TLS_LIMIT_CROSSED, 3, get_application_name(),
             get_application_pid(),
-            (opd->tls_idx > tls_array_count)
+            (opd->tls_idx >= tls_array_count)
                 ? "Late-loaded libraries with static TLS not supported"
                 : "Too many libaries with static TLS");
     }


### PR DESCRIPTION
Fixes a bug in the check for a late-loaded library with static TLS,
which we do not currently support.

Tested by temporarily adding LoadLibrary("dbghelp.dll") to the
client.tls test client.

Issue: #4130