### PR TITLE
i#4180 noalloc IR: Fix instr_reset to preserve noalloc status

### DIFF
--- a/core/arch/instr_shared.c
+++ b/core/arch/instr_shared.c
@@ -229,7 +229,12 @@ void
 instr_reset(dcontext_t *dcontext, instr_t *instr)
 {
     instr_free(dcontext, instr);
-    instr_init(dcontext, instr);
+    if (TEST(INSTR_IS_NOALLOC_STRUCT, instr->flags)) {
+        instr_init(dcontext, instr);
+        instr->flags |= INSTR_IS_NOALLOC_STRUCT;
+    } else {
+        instr_init(dcontext, instr);
+    }
 }
 
 /* Frees all dynamically allocated storage that was allocated by instr,

--- a/suite/tests/api/drdecode_x86.c
+++ b/suite/tests/api/drdecode_x86.c
@@ -149,7 +149,8 @@ test_noalloc(void)
     ASSERT(opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_XAX);
 
     /* There should be no leak reported even w/o a reset b/c there's no
-     * extra heap.
+     * extra heap.  However, drdecode is used in a mode where DR does not check
+     * for leaks!  So we repeat this test inside the api.ir test.
      */
 }
 


### PR DESCRIPTION
The noalloc flag was stripped out by instr_reset, and the
heap-leak-based test was in api.drdecode, which doesn't actually check
for leaks and so did not catch the bug.  Here we fix the bug to
preserve the flag, and place a test in api.ir which does do the leak
check.  Confirmed that the test fails without the fix.

Issue: #4180