### PR TITLE
i#4237: Align redirected malloc to double-ptr-sized

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -274,6 +274,8 @@ Further non-compatibility-affecting changes include:
  - Added the function dr_get_process_id_from_drcontext() for obtaining a process ID
    associated with the given drcontext, which may be different from the current
    dr_get_process_id() in some contexts.
+ - The private loader's malloc redirection now guarantees double-pointer-sized
+   alignment, to match what system-provided allocators use.
 
 **************************************************
 <hr>

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -2196,6 +2196,9 @@ DR_API
 /**
  * Allocates \p size bytes of memory from DR's memory pool specific to the
  * thread associated with \p drcontext.
+ * This memory is only guaranteed to be aligned to the pointer size:
+ * 8 byte alignment for 64-bit; 4-byte alignment for 32-bit.
+ * (The wrapped malloc() guarantees the more standard double-pointer-size.)
  */
 void *
 dr_thread_alloc(void *drcontext, size_t size);
@@ -2209,7 +2212,12 @@ void
 dr_thread_free(void *drcontext, void *mem, size_t size);
 
 DR_API
-/** Allocates \p size bytes of memory from DR's global memory pool. */
+/**
+ * Allocates \p size bytes of memory from DR's global memory pool.
+ * This memory is only guaranteed to be aligned to the pointer size:
+ * 8 byte alignment for 64-bit; 4-byte alignment for 32-bit.
+ * (The wrapped malloc() guarantees the more standard double-pointer-size.)
+ */
 void *
 dr_global_alloc(size_t size);
 
@@ -2336,6 +2344,8 @@ DR_API
  * versions that allocate memory from DR's private pool.  With -wrap,
  * clients can link to libraries that allocate heap memory without
  * interfering with application allocations.
+ * The returned address is guaranteed to be double-pointer-aligned:
+ * aligned to 16 bytes for 64-bit; aligned to 8 bytes for 32-bit.
  */
 void *
 __wrap_malloc(size_t size);
@@ -2346,6 +2356,8 @@ DR_API
  * behavior of realloc.  Memory must be freed with __wrap_free().  The
  * __wrap routines are intended to be used with ld's -wrap option; see
  * __wrap_malloc() for more information.
+ * The returned address is guaranteed to be double-pointer-aligned:
+ * aligned to 16 bytes for 64-bit; aligned to 8 bytes for 32-bit.
  */
 void *
 __wrap_realloc(void *mem, size_t size);
@@ -2356,6 +2368,8 @@ DR_API
  * behavior of calloc.  Memory must be freed with __wrap_free().  The
  * __wrap routines are intended to be used with ld's -wrap option; see
  * __wrap_malloc() for more information.
+ * The returned address is guaranteed to be double-pointer-aligned:
+ * aligned to 16 bytes for 64-bit; aligned to 8 bytes for 32-bit.
  */
 void *
 __wrap_calloc(size_t nmemb, size_t size);
@@ -2377,6 +2391,8 @@ DR_API
  * null.  Memory must be freed with __wrap_free().  The __wrap
  * routines are intended to be used with ld's -wrap option; see
  * __wrap_malloc() for more information.
+ * The returned address is guaranteed to be double-pointer-aligned:
+ * aligned to 16 bytes for 64-bit; aligned to 8 bytes for 32-bit.
  */
 char *
 __wrap_strdup(const char *str);

--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -926,27 +926,56 @@ loader_allow_unsafe_static_behavior(void)
 #endif
 }
 
+/* For heap redirection we need to provide alignment beyond what DR's allocator
+ * provides: DR does just pointer-sized alignment (HEAP_ALIGNMENT) while we want
+ * double-pointer-size (STANDARD_HEAP_ALIGNMENT).  We take advantage of knowing
+ * that DR's alloc is either already double-aligned or is just off by one pointer:
+ * so there are only two conditions.  We use the top bit of the size to form our
+ * header word.
+ * XXX i#4243: To support redirected memalign or C++17 aligned operator new we'll
+ * need support for more general alignment.
+ */
+#define REDIRECT_HEADER_SHIFTED (1ULL << IF_X64_ELSE(63, 31))
+
 /* This routine allocates memory from DR's global memory pool.  Unlike
  * dr_global_alloc(), however, we store the size of the allocation in
- * the first few bytes so redirect_free() can retrieve it.  This memory
+ * the first few bytes so redirect_free() can retrieve it.  We also align
+ * to the standard alignment used by most allocators.  This memory
  * is also not guaranteed-reachable.
  */
 void *
 redirect_malloc(size_t size)
 {
     void *mem;
-    ASSERT(sizeof(size_t) >= HEAP_ALIGNMENT);
-    size += sizeof(size_t);
-    mem = global_heap_alloc(size HEAPACCT(ACCT_LIBDUP));
+    size_t alloc_size = size + sizeof(size_t) + STANDARD_HEAP_ALIGNMENT - HEAP_ALIGNMENT;
+    if (TEST(REDIRECT_HEADER_SHIFTED, alloc_size)) {
+        /* We do not support the top bit being set as that conflicts with the bit in
+         * our header.  This should be fine as all sytem allocators we have seen also
+         * have size limits that are this size (for 32-bit) or even smaller.
+         */
+        CLIENT_ASSERT(false, "malloc failed: size requested is too large");
+        return NULL;
+    }
+    mem = global_heap_alloc(alloc_size HEAPACCT(ACCT_LIBDUP));
     if (mem == NULL) {
         CLIENT_ASSERT(false, "malloc failed: out of memory");
         return NULL;
     }
-    *((size_t *)mem) = size;
-    /* XXX: This is not aligned to 8 for 32-bit as some callers might expect,
-     * nor to 16 for x64.
-     */
-    return (byte *)mem + sizeof(size_t);
+    ptr_uint_t res =
+        ALIGN_FORWARD((ptr_uint_t)mem + sizeof(size_t), STANDARD_HEAP_ALIGNMENT);
+    size_t header = alloc_size;
+    ASSERT(HEAP_ALIGNMENT * 2 == STANDARD_HEAP_ALIGNMENT);
+    ASSERT(!TEST(REDIRECT_HEADER_SHIFTED, header));
+    if (res == (ptr_uint_t)mem + sizeof(size_t)) {
+        /* Already aligned. */
+    } else if (res == (ptr_uint_t)mem + sizeof(size_t) * 2) {
+        /* DR's alignment is "odd" for double-pointer so we're adding one pointer. */
+        header |= REDIRECT_HEADER_SHIFTED;
+    } else
+        ASSERT_NOT_REACHED();
+    *((size_t *)(res - sizeof(size_t))) = header;
+    ASSERT(res + size <= (ptr_uint_t)mem + alloc_size);
+    return (void *)res;
 }
 
 /* This routine allocates memory from DR's global memory pool. Unlike
@@ -993,10 +1022,16 @@ redirect_free(void *mem)
     /* PR 200203: leave_call_native() is assuming this routine calls
      * no other DR routines besides global_heap_free!
      */
-    if (mem != NULL) {
-        mem = (byte *)mem - sizeof(size_t);
-        global_heap_free(mem, *((size_t *)mem)HEAPACCT(ACCT_LIBDUP));
+    if (mem == NULL)
+        return;
+    size_t *size_ptr = (size_t *)((ptr_uint_t)mem - sizeof(size_t));
+    size_t size = *((size_t *)size_ptr);
+    void *start = size_ptr;
+    if (TEST(REDIRECT_HEADER_SHIFTED, size)) {
+        start = size_ptr - 1;
+        size &= ~REDIRECT_HEADER_SHIFTED;
     }
+    global_heap_free(start, size HEAPACCT(ACCT_LIBDUP));
 }
 
 char *

--- a/core/module_shared.h
+++ b/core/module_shared.h
@@ -703,6 +703,9 @@ redirect_realloc(void *mem, size_t size);
 char *
 redirect_strdup(const char *str);
 
+size_t
+redirect_malloc_requested_size(void *mem);
+
 #ifdef DEBUG
 void *
 redirect_malloc_initonly(size_t size);

--- a/core/module_shared.h
+++ b/core/module_shared.h
@@ -682,6 +682,12 @@ privload_attach_parent_console(app_pc app_kernel32);
 extern bool disallow_unsafe_static_calls;
 #endif
 
+/* For all heap allocation redirection routines:
+ * The returned address is guaranteed to be double-pointer-aligned:
+ * aligned to 16 bytes for 64-bit; aligned to 8 bytes for 32-bit.
+ */
+#define STANDARD_HEAP_ALIGNMENT IF_X64_ELSE(16, 8)
+
 void *
 redirect_calloc(size_t nmemb, size_t size);
 

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1366,9 +1366,12 @@ static const redirect_import_t redirect_imports[] = {
     { "free", (app_pc)redirect_free },
     { "realloc", (app_pc)redirect_realloc },
     { "strdup", (app_pc)redirect_strdup },
-/* FIXME: we should also redirect functions including:
- * malloc_usable_size, memalign, valloc, mallinfo, mallopt, etc.
- * Any other functions need to be redirected?
+/* TODO i#4243: we should also redirect functions including:
+ * + malloc_usable_size, memalign, valloc, mallinfo, mallopt, etc.
+ * + tcmalloc: tc_malloc, tc_free, etc.
+ * + __libc_malloc, __libc_free, etc.
+ * + OSX: malloc_zone_malloc, etc.?  Or just malloc_create_zone?
+ * + C++ operators in case they don't just call libc malloc?
  */
 #if defined(LINUX) && !defined(ANDROID)
     { "__tls_get_addr", (app_pc)redirect___tls_get_addr },

--- a/core/win32/drwinapi/ntdll_redir.c
+++ b/core/win32/drwinapi/ntdll_redir.c
@@ -324,7 +324,7 @@ wrapped_dr_free(byte *ptr)
 static inline size_t
 wrapped_dr_size(byte *ptr)
 {
-    return *((size_t *)(ptr - sizeof(size_t))) - sizeof(size_t);
+    return redirect_malloc_requested_size(ptr);
 }
 
 void *WINAPI

--- a/core/win32/drwinapi/ntdll_redir.c
+++ b/core/win32/drwinapi/ntdll_redir.c
@@ -299,26 +299,26 @@ RtlAllocateHeap(HANDLE heap, ULONG flags, SIZE_T size);
 void *
 wrapped_dr_alloc(ULONG flags, SIZE_T size)
 {
-    byte *mem;
-    ASSERT(sizeof(size_t) >= HEAP_ALIGNMENT);
-    size += sizeof(size_t);
-    mem = global_heap_alloc(size HEAPACCT(ACCT_LIBDUP));
+    /* HeapAlloc returns 16-byte-aligned for 64-bit and 8-byte-aligned for 32-bit.
+     * We use redirect_malloc() to get that alignment.
+     */
+    void *mem = redirect_malloc(size);
     if (mem == NULL) {
-        /* FIXME: support HEAP_GENERATE_EXCEPTIONS (xref PR 406742) */
+        /* TODO: support HEAP_GENERATE_EXCEPTIONS (xref PR 406742).
+         * redirect_malloc() already did a CLIENT_ASSERT too: we'd want to remove that.
+         */
         ASSERT_NOT_REACHED();
         return NULL;
     }
-    *((size_t *)mem) = size;
     if (TEST(HEAP_ZERO_MEMORY, flags))
-        memset(mem + sizeof(size_t), 0, size - sizeof(size_t));
-    return (void *)(mem + sizeof(size_t));
+        memset(mem, 0, size);
+    return mem;
 }
 
 void
 wrapped_dr_free(byte *ptr)
 {
-    ptr -= sizeof(size_t);
-    global_heap_free(ptr, *((size_t *)ptr)HEAPACCT(ACCT_LIBDUP));
+    redirect_free(ptr);
 }
 
 static inline size_t

--- a/suite/tests/client-interface/alloc.template
+++ b/suite/tests/client-interface/alloc.template
@@ -7,6 +7,7 @@ thank you for testing the client interface
 #else
   testing custom Linux alloc....success
 #endif
+  testing alignment....success
 thread initialization:
   testing local memory alloc....success
   testing global memory alloc...success

--- a/suite/tests/client_tools.h
+++ b/suite/tests/client_tools.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2013-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * *******************************************************************************/
 
@@ -71,6 +71,7 @@
 #define ALIGN_BACKWARD(x, alignment) (((ptr_uint_t)x) & (~((ptr_uint_t)(alignment)-1)))
 #define ALIGN_FORWARD(x, alignment) \
     ((((ptr_uint_t)x) + (((ptr_uint_t)alignment) - 1)) & (~(((ptr_uint_t)alignment) - 1)))
+#define ALIGNED(x, alignment) ((((ptr_uint_t)x) & ((alignment)-1)) == 0)
 
 /* Xref i#302 */
 #define POINTER_OVERFLOW_ON_ADD(ptr, add) \


### PR DESCRIPTION
Provides a guaranteed double-pointer-sized alignment for redirected
malloc, to match system allocators and avoid breaking private library
assumptions.

Adds a test to client.alloc.

Fixes #4237