### PR TITLE
i#4237: Fix realloc over-read

### DIFF
--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -1014,10 +1014,9 @@ redirect_realloc(void *mem, size_t size)
          */
         buf = redirect_malloc(size);
         if (buf != NULL && mem != NULL) {
-            void *old_start;
-            size_t old_size = redirect_malloc_size_and_start(mem, &old_start);
+            size_t old_size = redirect_malloc_size_and_start(mem, NULL);
             size_t min_size = MIN(old_size, size);
-            memcpy(buf, old_start, min_size);
+            memcpy(buf, mem, min_size);
         }
     }
     redirect_free(mem);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1856,8 +1856,8 @@ if (CLIENT_INTERFACE)
   if (X86) # FIXME i#1551, i#1569: port to ARM and AArch64
     tobuild_ci(client.alloc client-interface/alloc.c ""
       # For the subtest "targeting upper 2GB of low 4GB" we move -vm_base out of the
-      # way:
-      "-no_vm_base_near_app -vm_base 0x120000000" "")
+      # way.  We also raise the checklevel so we get memory filling for client allocs.
+      "-no_vm_base_near_app -vm_base 0x120000000 -checklevel 3" "")
     # XXX i#1312, i#3504: The test doesn't currently compile with CFLAGS_AVX512 but
     # attempts to test features based on it. The compile flag needs to be added.
     tobuild_ci(client.cleancall client-interface/cleancall.c "" "" "")

--- a/suite/tests/client-interface/alloc.dll.c
+++ b/suite/tests/client-interface/alloc.dll.c
@@ -550,10 +550,10 @@ alignment_test(void)
             mem[i] = realloc(mem[i], sz / 2);
             ASSERT(ALIGNED(mem[i], EXPECT_ALIGN));
             /* Write a value and ensure it gets copied. */
-            ((byte *)mem[i])[sz / 2 - 1] = 0xcd;
+            ((byte *)mem[i])[sz / 2 - 1] = 0x77;
             mem[i] = realloc(mem[i], sz + 2);
             ASSERT(ALIGNED(mem[i], EXPECT_ALIGN));
-            ASSERT(((byte *)mem[i])[sz / 2 - 1] == 0xcd);
+            ASSERT(((byte *)mem[i])[sz / 2 - 1] == 0x77);
         }
         for (int i = 0; i < NUM_TRIES; ++i)
             free(mem[i]);

--- a/suite/tests/client-interface/alloc.dll.c
+++ b/suite/tests/client-interface/alloc.dll.c
@@ -557,19 +557,19 @@ alignment_test(void)
         for (int i = 0; i < NUM_TRIES; ++i) {
             mem[i] = malloc(sz);
             ASSERT(ALIGNED(mem[i], EXPECT_ALIGN));
-            int smaller_sz = sz / 2;
-            int larger_sz = sz * 2 + 2;
+            size_t smaller_sz = sz / 2;
+            size_t larger_sz = sz * 2 + 2;
             mem[i] = realloc(mem[i], smaller_sz);
             ASSERT(ALIGNED(mem[i], EXPECT_ALIGN));
             /* Ensure the values get preserved. */
             memset(mem[i], PATTERN, smaller_sz);
             mem[i] = realloc(mem[i], larger_sz);
             ASSERT(ALIGNED(mem[i], EXPECT_ALIGN));
-            for (int j = 0; j < smaller_sz; ++j)
+            for (size_t j = 0; j < smaller_sz; ++j)
                 ASSERT(((byte *)mem[i])[j] == PATTERN);
             if (filled) {
                 /* Make sure we copied the right size and no more. */
-                for (int j = smaller_sz; j < larger_sz; ++j) {
+                for (size_t j = smaller_sz; j < larger_sz; ++j) {
                     ASSERT(((byte *)mem[i])[j] == DR_PATTERN);
                 }
             }

--- a/suite/tests/client-interface/alloc.dll.c
+++ b/suite/tests/client-interface/alloc.dll.c
@@ -547,6 +547,13 @@ alignment_test(void)
         for (int i = 0; i < NUM_TRIES; ++i) {
             mem[i] = malloc(sz);
             ASSERT(ALIGNED(mem[i], EXPECT_ALIGN));
+            mem[i] = realloc(mem[i], sz / 2);
+            ASSERT(ALIGNED(mem[i], EXPECT_ALIGN));
+            /* Write a value and ensure it gets copied. */
+            ((byte *)mem[i])[sz / 2 - 1] = 0xcd;
+            mem[i] = realloc(mem[i], sz + 2);
+            ASSERT(ALIGNED(mem[i], EXPECT_ALIGN));
+            ASSERT(((byte *)mem[i])[sz / 2 - 1] == 0xcd);
         }
         for (int i = 0; i < NUM_TRIES; ++i)
             free(mem[i]);

--- a/suite/tests/client-interface/alloc.dll.c
+++ b/suite/tests/client-interface/alloc.dll.c
@@ -41,6 +41,7 @@
 #endif
 #include <limits.h>
 #include <stdlib.h>
+#include <string.h>
 
 char *global;
 #define SIZE 10
@@ -539,7 +540,16 @@ alignment_test(void)
      * and if there are free list entries it could be more than half.
      */
 #define NUM_TRIES 8
+    /* We use a bit pattern that doesn't match DR's 0xab, 0xbc, and 0xcd fills. */
+#define PATTERN 0x77
+#define DR_PATTERN 0xab
     void *mem[NUM_TRIES];
+    /* See if DR is using a known fill pattern (we have to pass -checklevel 3
+     * to get the pattern for client/privlib allocs).
+     */
+    mem[0] = malloc(4);
+    bool filled = ((byte *)mem[0])[0] == DR_PATTERN;
+    free(mem[0]);
     /* Try several sizes since DR's bucket sizes can make one particular bucket
      * over-align more often than others.
      */
@@ -547,13 +557,22 @@ alignment_test(void)
         for (int i = 0; i < NUM_TRIES; ++i) {
             mem[i] = malloc(sz);
             ASSERT(ALIGNED(mem[i], EXPECT_ALIGN));
-            mem[i] = realloc(mem[i], sz / 2);
+            int smaller_sz = sz / 2;
+            int larger_sz = sz * 2 + 2;
+            mem[i] = realloc(mem[i], smaller_sz);
             ASSERT(ALIGNED(mem[i], EXPECT_ALIGN));
-            /* Write a value and ensure it gets copied. */
-            ((byte *)mem[i])[sz / 2 - 1] = 0x77;
-            mem[i] = realloc(mem[i], sz + 2);
+            /* Ensure the values get preserved. */
+            memset(mem[i], PATTERN, smaller_sz);
+            mem[i] = realloc(mem[i], larger_sz);
             ASSERT(ALIGNED(mem[i], EXPECT_ALIGN));
-            ASSERT(((byte *)mem[i])[sz / 2 - 1] == 0x77);
+            for (int j = 0; j < smaller_sz; ++j)
+                ASSERT(((byte *)mem[i])[j] == PATTERN);
+            if (filled) {
+                /* Make sure we copied the right size and no more. */
+                for (int j = smaller_sz; j < larger_sz; ++j) {
+                    ASSERT(((byte *)mem[i])[j] == DR_PATTERN);
+                }
+            }
         }
         for (int i = 0; i < NUM_TRIES; ++i)
             free(mem[i]);


### PR DESCRIPTION
Fixes a bug from 228933d #4237 where redirect_realloc() was not
updated to read the new malloc header, resulting in a memcpy that
reads beyond the end of the original allocation, which can crash if
it's at the end of a heap block with a subsequent guard page.

Adds at least some sanity checks of realloc to the alignment test.  I
tried to construct a regression test to reproduce the crash in the
bug, but it is not possible in a straightforward way just using the
public interface as it requires knowing what is beyond an allocation
or how two allocations are arranged and what headers or other bytes
are in between.

Fixes #4237