### PR TITLE
i#4134: Support analysis labels in drbbdup

### DIFF
--- a/core/arch/instrlist.c
+++ b/core/arch/instrlist.c
@@ -233,6 +233,14 @@ instrlist_last(instrlist_t *ilist)
     return ilist->last;
 }
 
+
+void instrlist_cut(instrlist_t *ilist, instr_t *cut_point){
+	instr_t *last_instr = instr_get_prev(cut_point);
+    instr_set_next(last_instr, NULL);
+    instr_set_prev(cut_point, NULL);
+    ilist->last = last_instr;
+}
+
 instr_t *
 instrlist_last_app(instrlist_t *ilist)
 {

--- a/core/arch/instrlist.c
+++ b/core/arch/instrlist.c
@@ -233,14 +233,6 @@ instrlist_last(instrlist_t *ilist)
     return ilist->last;
 }
 
-
-void instrlist_cut(instrlist_t *ilist, instr_t *cut_point){
-	instr_t *last_instr = instr_get_prev(cut_point);
-    instr_set_next(last_instr, NULL);
-    instr_set_prev(cut_point, NULL);
-    ilist->last = last_instr;
-}
-
 instr_t *
 instrlist_last_app(instrlist_t *ilist)
 {
@@ -250,6 +242,17 @@ instrlist_last_app(instrlist_t *ilist)
     if (instr_is_app(last))
         return last;
     return instr_get_prev_app(last);
+}
+
+void
+instrlist_cut(instrlist_t *ilist, instr_t *cut_point)
+{
+    CLIENT_ASSERT(cut_point != NULL, "instrlist_cut: instr cut point should not be NULL");
+    instr_t *last_instr = instr_get_prev(cut_point);
+    if (last_instr != NULL)
+        instr_set_next(last_instr, NULL);
+    instr_set_prev(cut_point, NULL);
+    ilist->last = last_instr;
 }
 
 static inline void

--- a/core/arch/instrlist.h
+++ b/core/arch/instrlist.h
@@ -182,10 +182,6 @@ instr_t *
 instrlist_last(instrlist_t *ilist);
 
 DR_API
-/** Cuts the list */
-void instrlist_cut(instrlist_t *ilist, instr_t *cut_point);
-
-DR_API
 /**
  * Returns the last application (non-meta) instruction in the instruction list
  * \p ilist.
@@ -201,6 +197,11 @@ DR_API
  */
 instr_t *
 instrlist_last_app(instrlist_t *ilist);
+
+DR_API
+/** Cuts off subsequent instructions starting from \p instr from \p ilist. */
+void
+instrlist_cut(instrlist_t *ilist, instr_t *instr);
 
 DR_API
 /** Adds \p instr to the end of \p ilist. */

--- a/core/arch/instrlist.h
+++ b/core/arch/instrlist.h
@@ -182,6 +182,10 @@ instr_t *
 instrlist_last(instrlist_t *ilist);
 
 DR_API
+/** Cuts the list */
+void instrlist_cut(instrlist_t *ilist, instr_t *cut_point);
+
+DR_API
 /**
  * Returns the last application (non-meta) instruction in the instruction list
  * \p ilist.

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -554,8 +554,7 @@ drbbdup_do_orig_analysis(drbbdup_manager_t *manager, void *drcontext, void *tag,
         opts.analyze_orig(drcontext, tag, case_bb, opts.user_data, &orig_analysis_data);
         instrlist_clear_and_destroy(drcontext, case_bb);
     } else {
-        /* For bb with no wanted copies, simply invoke the call-back with original bb.
-         */
+        /* For bb with no wanted copies, just invoke the call-back with original bb. */
         opts.analyze_orig(drcontext, tag, bb, opts.user_data, &orig_analysis_data);
     }
 

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -527,11 +527,9 @@ drbbdup_extract_bb_copy(void *drcontext, instrlist_t *bb, instr_t *start,
         instrlist_preinsert(bb, *post, instr_cpy);
     }
     instrlist_cut(bb, *post);
-
     *prev = start;
     start = instr_get_next(start); /* Skip START label. */
     instrlist_cut(bb, start);
-
     instrlist_append(case_bb, start);
 
     return case_bb;

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -510,7 +510,8 @@ drbbdup_extract_bb_copy(void *drcontext, instrlist_t *bb, instr_t *start,
     instrlist_t *case_bb = instrlist_create(drcontext);
 
     ASSERT(start != NULL, "start instruction cannot be NULL");
-    ASSERT(remainder != NULL, "remainder instr storage cannot be NULL");
+    ASSERT(prev != NULL, "prev instr storage cannot be NULL");
+    ASSERT(post != NULL, "post instr storage cannot be NULL");
     ASSERT(instr_get_note(start) == (void *)DRBBDUP_LABEL_START,
            "start instruction should be a START label");
 

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -116,6 +116,10 @@ typedef bool (*drbbdup_allow_gen_t)(void *drcontext, void *tag, instrlist_t *ili
  * store the analysis result in \p orig_analysis_data. The  user data \p user_data is
  * that supplied to drbbdup_init().
  *
+ * It is not possible to insert note labels via this analysis call-back function.
+ * Any labels inserted will not persist. Such functionality is only possible via a
+ * #drbbdup_analyze_case_t call-back.
+ *
  * The user can use thread allocation for storing the analysis result.
  *
  * The analysis data is destroyed via a #drbbdup_destroy_orig_analysis_t function.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2235,6 +2235,11 @@ if (CLIENT_INTERFACE)
     use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drmgr)
     use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drreg)
     use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drbbdup)
+    
+    tobuild_ci(client.drbbdup-analysis-test client-interface/drbbdup-analysis-test.c "" "" "")
+    use_DynamoRIO_extension(client.drbbdup-analysis-test.dll drmgr)
+    use_DynamoRIO_extension(client.drbbdup-analysis-test.dll drreg)
+    use_DynamoRIO_extension(client.drbbdup-analysis-test.dll drbbdup)   
   endif (X86)
 
   if (ARM)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2235,11 +2235,11 @@ if (CLIENT_INTERFACE)
     use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drmgr)
     use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drreg)
     use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drbbdup)
-    
+
     tobuild_ci(client.drbbdup-analysis-test client-interface/drbbdup-analysis-test.c "" "" "")
     use_DynamoRIO_extension(client.drbbdup-analysis-test.dll drmgr)
     use_DynamoRIO_extension(client.drbbdup-analysis-test.dll drreg)
-    use_DynamoRIO_extension(client.drbbdup-analysis-test.dll drbbdup)   
+    use_DynamoRIO_extension(client.drbbdup-analysis-test.dll drbbdup)
   endif (X86)
 
   if (ARM)

--- a/suite/tests/client-interface/drbbdup-analysis-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-analysis-test.dll.c
@@ -1,0 +1,167 @@
+/* **********************************************************
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* A Test for the drbbdup extension. In particular, the test inserts analysis
+ * labels during case analysis and checks that these labels persist during the
+ * insertion stage.
+ */
+
+#include "dr_api.h"
+#include "drmgr.h"
+#include "drbbdup.h"
+
+#define TEST_NOTE_VAL (void *)767
+
+#define CHECK(x, msg)                                                                \
+    do {                                                                             \
+        if (!(x)) {                                                                  \
+            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
+            dr_abort();                                                              \
+        }                                                                            \
+    } while (0);
+
+static bool instrum_called = false;
+static bool test_label_persisted = false;
+
+/* Assume single threaded. */
+static uintptr_t encode_val = 1;
+
+static uintptr_t
+set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
+               bool *enable_dups, bool *enable_dynamic_handling, void *user_data)
+{
+    drbbdup_status_t res;
+
+    CHECK(enable_dups != NULL, "should not be NULL");
+    CHECK(enable_dynamic_handling != NULL, "should not be NULL");
+
+    res = drbbdup_register_case_encoding(drbbdup_ctx, 1);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to register case 1");
+
+    *enable_dups = true;
+    *enable_dynamic_handling = false; /* disable dynamic handling */
+
+    return 0; /* return default case */
+}
+
+static void
+insert_analysis_labels(void *drcontext, instrlist_t *bb)
+{
+    instr_t *instr = instrlist_first(bb);
+    while (instr != NULL) {
+        instr_t *test_label = INSTR_CREATE_label(drcontext);
+        instr_set_note(test_label, TEST_NOTE_VAL);
+        instrlist_meta_preinsert(bb, instr, test_label);
+        instr = instr_get_next_app(instr);
+    }
+}
+
+static void
+analyse_bb(void *drcontext, void *tag, instrlist_t *bb, uintptr_t encoding,
+           void *user_data, void *orig_analysis_data, void **analysis_data)
+{
+    switch (encoding) {
+    case 0: break;
+    case 1: insert_analysis_labels(drcontext, bb); break;
+    default: CHECK(false, "invalid encoding");
+    }
+}
+
+static bool
+is_test_label(instr_t *instr)
+{
+
+    return instr_is_label(instr) && instr_get_note(instr) == TEST_NOTE_VAL;
+}
+
+static void
+instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
+                 instr_t *where, uintptr_t encoding, void *user_data,
+                 void *orig_analysis_data, void *analysis_data)
+{
+    bool is_first;
+    drbbdup_status_t res;
+
+    switch (encoding) {
+    case 0:
+        if (is_test_label(instr))
+            CHECK(false, "no test label should be present in default case");
+        break;
+    case 1:
+        if (is_test_label(instr)) {
+            test_label_persisted = true;
+        } else if (instr_is_app(instr)) {
+            bool is_label = is_test_label(instr_get_prev(where));
+            CHECK(is_label, "prev instr should be test label")
+        }
+        break;
+    default: CHECK(false, "invalid encoding");
+    }
+
+    instrum_called = true;
+}
+
+static void
+event_exit(void)
+{
+    drbbdup_status_t res = drbbdup_exit();
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup exit failed");
+
+    CHECK(instrum_called, "instrumentation was not inserted");
+    CHECK(test_label_persisted, "test label should persist to insertion stage");
+
+    drmgr_exit();
+}
+
+DR_EXPORT void
+dr_init(client_id_t id)
+{
+    drmgr_init();
+
+    drbbdup_options_t opts = { 0 };
+    opts.struct_size = sizeof(drbbdup_options_t);
+    opts.set_up_bb_dups = set_up_bb_dups;
+    opts.insert_encode = NULL;
+    opts.analyze_orig = NULL;
+    opts.destroy_orig_analysis = NULL;
+    opts.analyze_case = analyse_bb;
+    opts.destroy_case_analysis = NULL;
+    opts.instrument_instr = instrument_instr;
+    opts.runtime_case_opnd = opnd_create_abs_addr(&encode_val, OPSZ_PTR);
+    opts.user_data = NULL;
+    opts.dup_limit = 1;
+    opts.is_stat_enabled = false;
+
+    drbbdup_status_t res = drbbdup_init(&opts);
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup init failed");
+    dr_register_exit_event(event_exit);
+}

--- a/suite/tests/client-interface/drbbdup-analysis-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-analysis-test.dll.c
@@ -107,9 +107,6 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
                  instr_t *where, uintptr_t encoding, void *user_data,
                  void *orig_analysis_data, void *analysis_data)
 {
-    bool is_first;
-    drbbdup_status_t res;
-
     switch (encoding) {
     case 0:
         if (is_test_label(instr))

--- a/suite/tests/client-interface/drbbdup-analysis-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-analysis-test.dll.c
@@ -30,7 +30,7 @@
  * DAMAGE.
  */
 
-/* A Test for the drbbdup extension. In particular, the test inserts analysis
+/* A test for the drbbdup extension. In particular, the test inserts analysis
  * labels during case analysis and checks that these labels persist during the
  * insertion stage.
  */
@@ -39,7 +39,7 @@
 #include "drmgr.h"
 #include "drbbdup.h"
 
-#define TEST_NOTE_VAL (void *)767
+#define TEST_NOTE_VAL (void *)767LL
 
 #define CHECK(x, msg)                                                                \
     do {                                                                             \

--- a/suite/tests/client-interface/drbbdup-analysis-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-analysis-test.dll.c
@@ -99,7 +99,6 @@ analyse_bb(void *drcontext, void *tag, instrlist_t *bb, uintptr_t encoding,
 static bool
 is_test_label(instr_t *instr)
 {
-
     return instr_is_label(instr) && instr_get_note(instr) == TEST_NOTE_VAL;
 }
 

--- a/suite/tests/client-interface/drbbdup-analysis-test.expect
+++ b/suite/tests/client-interface/drbbdup-analysis-test.expect
@@ -1,0 +1,1 @@
+Hello, world!


### PR DESCRIPTION
Enhances the case analysis call-back interface of drbbdup to enable the user to insert analysis labels.

The extension extracts the case instruction list from the main basic block and passes it to the user during analysis. After, drbbdup stitches the instruction list back to the main basic block.

A test is also included.

Issue: #4134