### PR TITLE
i#4257 slow memquery: Avoid slow vmarea check on AArch64

### DIFF
--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -8307,10 +8307,10 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
     }
 
     /* we are building a real bb, assert consistency checks */
-    /* XXX i#1979: These memqueries are surprisingly slow on Mac64.
-     * Investigation is needed.
+    /* XXX i#4257: These memqueries are surprisingly slow on Mac64 and AArch64.
+     * Investigation is needed.  For now we avoid them in default debug runs.
      */
-    DOCHECK(IF_MACOS64_ELSE(3, 1), {
+    DOCHECK(IF_MACOS64_ELSE(3, IF_AARCH64_ELSE(3, 1)), {
         uint prot2;
         ok = get_memory_info(pc, NULL, NULL, &prot2);
         ASSERT(!ok || !TEST(MEMPROT_WRITE, prot2) ||


### PR DESCRIPTION
Raises the consistency check at the end of check_thread_vm_area to
default to checklevel 3 on AArch64, matching Mac64 where it is also
observed to be quite slow.

Issue: #4257