### PR TITLE
i#4260: Fix opnd_is_memory_ref() to check abs addr for all 64-bit archs

### DIFF
--- a/core/arch/opnd_shared.c
+++ b/core/arch/opnd_shared.c
@@ -999,7 +999,7 @@ opnd_get_addr(opnd_t opnd)
 bool
 opnd_is_memory_reference(opnd_t opnd)
 {
-    return (opnd_is_base_disp(opnd) IF_X86_64(|| opnd_is_abs_addr(opnd)) ||
+    return (opnd_is_base_disp(opnd) IF_X64(|| opnd_is_abs_addr(opnd)) ||
 #if defined(X64) || defined(ARM)
             opnd_is_rel_addr(opnd) ||
 #endif


### PR DESCRIPTION
Adds fix to opnd_is_memory_ref to check absolute address operands for all 64-bit archs

Fixes: #4260