### PR TITLE
i#3966: Switch 32-bit x86 Linux to 16-byte stack alignment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -194,7 +194,7 @@ before_deploy:
   # use a non-zero build number when making multiple manual builds in one day.
   - >
       if test -z "${VERSION_NUMBER}"; then
-          export GIT_TAG="cronbuild-7.91.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+          export GIT_TAG="cronbuild-7.92.$((`git log -n 1 --format=%ct` / (60*60*24)))"
       else
           export GIT_TAG="release_${VERSION_NUMBER}"
       fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,7 +495,7 @@ endif (EXISTS "${PROJECT_SOURCE_DIR}/.svn")
 
 # N.B.: when updating this, update the git tag in .travis.yml.
 # We should find a way to share (xref i#1565).
-set(VERSION_NUMBER_DEFAULT "7.91.${VERSION_NUMBER_PATCHLEVEL}")
+set(VERSION_NUMBER_DEFAULT "7.92.${VERSION_NUMBER_PATCHLEVEL}")
 # do not store the default VERSION_NUMBER in the cache to prevent a stale one
 # from preventing future version updates in a pre-existing build dir
 set(VERSION_NUMBER "" CACHE STRING "Version number: leave empty for default")
@@ -722,15 +722,6 @@ if (UNIX)
       set(LD_FLAGS "-melf_x86_64")
     else (X64)
       set(BASE_CFLAGS "-m32 ${BASE_CFLAGS}")
-      # i#847 keep stack boundary 4-byte aligned (except on Mac)
-      # XXX i#1800: clang does not support -mpreferred-stack-boundary=2 or
-      # an equivalent flag, so clang's build may not run legacy binaries.
-      if (NOT CMAKE_COMPILER_IS_CLANG)
-        set(BASE_CFLAGS "${BASE_CFLAGS} -mpreferred-stack-boundary=2")
-      elseif (NOT APPLE)
-        message(STATUS "WARNING: 32-bit clang lacks stack alignment control:")
-        message(STATUS "  resulting build may not run all apps correctly")
-      endif ()
       set(LD_FLAGS "-melf_i386")
     endif (X64)
   elseif (ARM)
@@ -1246,13 +1237,14 @@ math(EXPR VERSION_NUMBER_INTEGER
   "${VERSION_NUMBER_MAJOR}*100 + ${VERSION_NUMBER_MINOR}")
 
 # Every release since has had minor compat breakages.
+# 7.92 broke backcompat by changing 32-bit stack alignment to 16.
 # 7.91 broke backcompat by adding a field to instr_t .
 # 7.90 broke backcompat in DR_REG_ enums and OPSZ_ enums.
 # 6.0 broke backcompat in Linux injection, mod load event, etc.
 # 5.0 broke backcompat in drsyms and xmm opnd sizes
 # 4.1 broke backcompat in drsyms + 64-bit core (opcodes + reachability)
 # 4.0 broke backcompat in drmgr, drsyms, drinjectlib, and dr_get_milliseconds()
-set(OLDEST_COMPATIBLE_VERSION_DEFAULT "791")
+set(OLDEST_COMPATIBLE_VERSION_DEFAULT "792")
 set(OLDEST_COMPATIBLE_VERSION "" CACHE STRING
   "Oldest compatible version: leave empty for default")
 if ("${OLDEST_COMPATIBLE_VERSION}" STREQUAL "")

--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -1189,13 +1189,6 @@ endif(NOT DynamoRIO_FOUND)
 configure_DynamoRIO_client(myclient)
 \endcode
 
-Note that when building a 32-bit client in Linux using \p gcc, the stack
-alignment should be 4-byte only.
-Using the function \p configure_DynamoRIO_client() will configure the
-build settings correctly.
-Otherwise, appropriate options should be passed to the compiler: e.g.,
-\p -mpreferred-stack-boundary=2.
-
 The \p samples/CMakeLists.txt file in the release package serves as another
 example.  The top of \p DynamoRIOConfig.cmake contains detailed
 instructions as well.

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -155,6 +155,8 @@ changes:
    of the struct, but users who were not zeroing the whole structure and who update
    and recompile without setting the field may see crashes due to
    free_key_func being uninitialized.
+ - Changed the 32-bit x86 stack alignment of DynamoRIO and clients built using
+   DR's CMake configuration from 4 to 16 on Linux to match modern conventions.
 
 The changes between version \DR_VERSION and 7.1.0 include the following minor
 compatibility changes:

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -596,11 +596,13 @@ mangle_insert_clone_code(dcontext_t *dcontext, instrlist_t *ilist,
                          instr_t *instr _IF_X86_64(gencode_mode_t mode));
 
 #ifdef X86
-#    if defined(X64) || defined(MACOS)
-#        define ABI_STACK_ALIGNMENT 16
-#    else
-/* See i#847 for discussing the stack alignment on X86. */
+#    ifdef WINDOWS
 #        define ABI_STACK_ALIGNMENT 4
+#    else
+/* See i#847 for discussion of stack alignment on 32-bit Linux.
+ * We now use 16 there to match everyone else.
+ */
+#        define ABI_STACK_ALIGNMENT 16
 #    endif
 #elif defined(AARCH64)
 #    define ABI_STACK_ALIGNMENT 16
@@ -1434,6 +1436,9 @@ move_mm_reg_opcode(bool aligned16, bool aligned32);
  */
 uint
 move_mm_avx512_reg_opcode(bool aligned64);
+
+bool
+clean_call_needs_simd(clean_call_info_t *cci);
 
 /* clean call optimization */
 /* Describes usage of a scratch slot. */

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -596,13 +596,11 @@ mangle_insert_clone_code(dcontext_t *dcontext, instrlist_t *ilist,
                          instr_t *instr _IF_X86_64(gencode_mode_t mode));
 
 #ifdef X86
-#    ifdef WINDOWS
-#        define ABI_STACK_ALIGNMENT 4
-#    else
-/* See i#847 for discussion of stack alignment on 32-bit Linux.
- * We now use 16 there to match everyone else.
- */
+#    if defined(X64) || defined(UNIX)
+/* See i#847, i#3966 for discussion of stack alignment on 32-bit Linux. */
 #        define ABI_STACK_ALIGNMENT 16
+#    else
+#        define ABI_STACK_ALIGNMENT 4
 #    endif
 #elif defined(AARCH64)
 #    define ABI_STACK_ALIGNMENT 16

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -600,6 +600,13 @@ mangle_insert_clone_code(dcontext_t *dcontext, instrlist_t *ilist,
 /* See i#847, i#3966 for discussion of stack alignment on 32-bit Linux. */
 #        define ABI_STACK_ALIGNMENT 16
 #    else
+/* We follow the Windows (MSVC-based) 32-bit ABI which requires only 4-byte
+ * stack alignment.
+ * XXX i#4267: Gcc/clang through MinGW/Cygwin use 16-byte by default, but
+ * for interoperating with Windows system libraries (callbacks, e.g.) they
+ * have to hande 4-byte and we expect them to use -mstackrealign or something.
+ * Thus for now we stick with just 4-byte even for them.
+ */
 #        define ABI_STACK_ALIGNMENT 4
 #    endif
 #elif defined(AARCH64)

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -122,6 +122,13 @@ insert_get_mcontext_base(dcontext_t *dcontext, instrlist_t *ilist, instr_t *wher
     }
 }
 
+bool
+clean_call_needs_simd(clean_call_info_t *cci)
+{
+    return (cci->preserve_mcontext || cci->num_simd_skip != proc_num_simd_registers() ||
+            cci->num_opmask_skip != proc_num_opmask_registers());
+}
+
 /* prepare_for and cleanup_after assume that the stack looks the same after
  * the call to the instrumentation routine, since it stores the app state
  * on the stack.
@@ -136,7 +143,7 @@ insert_get_mcontext_base(dcontext_t *dcontext, instrlist_t *ilist, instr_t *wher
  *   supposedly they came out in PII
  *   on balrog: fxsave 91 cycles, fxrstor 173)
  *
- * For x64, changes the stack pointer by a multiple of 16.
+ * Keeps the final stack pointer aligned to get_ABI_stack_alignment().
  *
  * NOTE: The client interface's get/set mcontext functions and the
  * hotpatching gateway rely on the app's context being available
@@ -272,24 +279,38 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
 
     /* check if need adjust stack for alignment. */
     if (cci->should_align) {
-#if (defined(X86) && defined(X64)) || defined(MACOS)
+#if (defined(X86) && !defined(WINDOWS)) || defined(MACOS)
         /* PR 218790: maintain 16-byte rsp alignment.
          * insert_parameter_preparation() currently assumes we leave rsp aligned.
          */
+        int align = get_ABI_stack_alignment();
+        int off = align - (dstack_offs % align);
+        ASSERT(off % XSP_SZ == 0);
+        /* Make sure cleanup_after_clean_call() can compute the same offset.
+         * We could make the caller pass back in dstack_offs except for
+         * dr_cleanup_after_call().
+         */
+        int simd = 0;
+        if (clean_call_needs_simd(cci)) {
+            simd = MCXT_TOTAL_SIMD_SLOTS_SIZE + MCXT_TOTAL_OPMASK_SLOTS_SIZE +
+                PRE_XMM_PADDING;
+        }
         uint num_slots = DR_NUM_GPR_REGS + NUM_EXTRA_SLOTS;
         if (cci->skip_save_flags)
             num_slots -= 2;
-        num_slots -= cci->num_regs_skip; /* regs that not saved */
+#    ifndef X86_32 /* x86 uses pusha regardless of regs we could skip */
+        num_slots -= cci->num_regs_skip; /* regs not saved */
+#    endif
+        uint emulate_dstack_offs = simd + num_slots * XSP_SZ;
+        ASSERT(emulate_dstack_offs == dstack_offs || cci->out_of_line_swap);
         /* For out-of-line calls, the stack size gets aligned by
          * get_clean_call_switch_stack_size.
          */
-        if (!cci->out_of_line_swap && (num_slots % 2) == 1) {
-            ASSERT((dstack_offs % 16) == 8);
+        if (off != align && !cci->out_of_line_swap) {
             PRE(ilist, instr,
-                INSTR_CREATE_lea(
-                    dcontext, opnd_create_reg(REG_XSP),
-                    OPND_CREATE_MEM_lea(REG_XSP, REG_NULL, 0, -(int)XSP_SZ)));
-            dstack_offs += XSP_SZ;
+                INSTR_CREATE_lea(dcontext, opnd_create_reg(REG_XSP),
+                                 OPND_CREATE_MEM_lea(REG_XSP, REG_NULL, 0, -off)));
+            dstack_offs += off;
         }
 #endif
         ASSERT((dstack_offs % get_ABI_stack_alignment()) == 0);
@@ -309,20 +330,33 @@ cleanup_after_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
         cci = &default_clean_call_info;
         /* saved error code is currently on the top of the stack */
 
-#if (defined(X86) && defined(X64)) || defined(MACOS)
+#if (defined(X86) && !defined(WINDOWS)) || defined(MACOS)
     /* PR 218790: remove the padding we added for 16-byte rsp alignment */
     if (cci->should_align) {
+        int align = get_ABI_stack_alignment();
+        int simd = 0;
+        if (clean_call_needs_simd(cci)) {
+            simd = MCXT_TOTAL_SIMD_SLOTS_SIZE + MCXT_TOTAL_OPMASK_SLOTS_SIZE +
+                PRE_XMM_PADDING;
+        }
         uint num_slots = DR_NUM_GPR_REGS + NUM_EXTRA_SLOTS;
         if (cci->skip_save_flags)
-            num_slots += 2;
-        num_slots -= cci->num_regs_skip; /* regs that not saved */
+            num_slots -= 2;
+#    ifndef X86_32 /* x86 uses pusha regardless of regs we could skip */
+        num_slots -= cci->num_regs_skip; /* regs not saved */
+#    endif
+        int emulate_dstack_offs = simd + num_slots * XSP_SZ;
+        int off = align - (emulate_dstack_offs % align);
         /* For out-of-line calls, the stack size gets aligned by
          * get_clean_call_switch_stack_size.
          */
-        if (!cci->out_of_line_swap && (num_slots % 2) == 1) {
+        if (off != align && !cci->out_of_line_swap) {
+            /* XXX: We should optimize by combining this LEA with the LEA in
+             * insert_meta_call_vargs() which cleans up parameter space.
+             */
             PRE(ilist, instr,
                 INSTR_CREATE_lea(dcontext, opnd_create_reg(REG_XSP),
-                                 OPND_CREATE_MEM_lea(REG_XSP, REG_NULL, 0, XSP_SZ)));
+                                 OPND_CREATE_MEM_lea(REG_XSP, REG_NULL, 0, off)));
         }
     }
 #endif
@@ -402,9 +436,9 @@ parameters_stack_padded(void)
 }
 
 /* Inserts a complete call to callee with the passed-in arguments.
- * For x64, assumes the stack pointer is currently 16-byte aligned.
+ * Assumes the stack pointer is currently get_ABI_stack_alignment() aligned.
  * Clean calls ensure this by using clean base of dstack and having
- * dr_prepare_for_call pad to 16 bytes.
+ * dr_prepare_for_call pad to the ABI alignment.
  * Returns whether the call is direct.
  */
 bool
@@ -416,7 +450,7 @@ insert_meta_call_vargs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     bool direct;
     uint stack_for_params = insert_parameter_preparation(
         dcontext, ilist, instr, TEST(META_CALL_CLEAN, flags), num_args, args);
-    IF_X64(ASSERT(ALIGNED(stack_for_params, 16)));
+    ASSERT(ALIGNED(stack_for_params, get_ABI_stack_alignment()));
 
 #ifdef CLIENT_INTERFACE
     if (TEST(META_CALL_CLEAN, flags) && should_track_where_am_i()) {
@@ -468,6 +502,8 @@ insert_meta_call_vargs(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     if (stack_for_params > 0) {
         /* XXX PR 245936: let user decide whether to clean up?
          * i.e., support calling a stdcall routine?
+         * XXX: Combine with the LEA in cleanup_after_clean_call() which undoes
+         * alignment padding from prepare_for_clean_call().
          */
         PRE(ilist, instr,
             XINST_CREATE_add(dcontext, opnd_create_reg(REG_XSP),

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -301,7 +301,7 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
 #    ifndef X86_32 /* x86 uses pusha regardless of regs we could skip */
         num_slots -= cci->num_regs_skip; /* regs not saved */
 #    endif
-        uint emulate_dstack_offs = simd + num_slots * XSP_SZ;
+        IF_DEBUG(uint emulate_dstack_offs = simd + num_slots * XSP_SZ;)
         ASSERT(emulate_dstack_offs == dstack_offs || cci->out_of_line_swap);
         /* For out-of-line calls, the stack size gets aligned by
          * get_clean_call_switch_stack_size.

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -279,7 +279,7 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
 
     /* check if need adjust stack for alignment. */
     if (cci->should_align) {
-#if !(defined(X86_32) && defined(WINDOWS))
+#if defined(X86) && (defined(X64) || defined(UNIX))
         /* PR 218790: maintain 16-byte rsp alignment.
          * insert_parameter_preparation() currently assumes we leave rsp aligned.
          */
@@ -330,7 +330,7 @@ cleanup_after_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
         cci = &default_clean_call_info;
         /* saved error code is currently on the top of the stack */
 
-#if !(defined(X86_32) && defined(WINDOWS))
+#if defined(X86) && (defined(X64) || defined(UNIX))
     /* PR 218790: remove the padding we added for 16-byte rsp alignment */
     if (cci->should_align) {
         int align = get_ABI_stack_alignment();

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -279,7 +279,7 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
 
     /* check if need adjust stack for alignment. */
     if (cci->should_align) {
-#if (defined(X86) && !defined(WINDOWS)) || defined(MACOS)
+#if !(defined(X86_32) && defined(WINDOWS))
         /* PR 218790: maintain 16-byte rsp alignment.
          * insert_parameter_preparation() currently assumes we leave rsp aligned.
          */
@@ -330,7 +330,7 @@ cleanup_after_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
         cci = &default_clean_call_info;
         /* saved error code is currently on the top of the stack */
 
-#if (defined(X86) && !defined(WINDOWS)) || defined(MACOS)
+#if !(defined(X86_32) && defined(WINDOWS))
     /* PR 218790: remove the padding we added for 16-byte rsp alignment */
     if (cci->should_align) {
         int align = get_ABI_stack_alignment();

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -132,7 +132,8 @@ clean_call_needs_simd(clean_call_info_t *cci)
 /* Number of extra slots in addition to register slots. */
 #define NUM_EXTRA_SLOTS 2 /* pc, aflags */
 
-static int
+#if defined(X86) && (defined(X64) || defined(UNIX))
+static uint
 clean_call_prepare_stack_size(clean_call_info_t *cci)
 {
     int simd = 0;
@@ -143,11 +144,12 @@ clean_call_prepare_stack_size(clean_call_info_t *cci)
     uint num_slots = DR_NUM_GPR_REGS + NUM_EXTRA_SLOTS;
     if (cci->skip_save_flags)
         num_slots -= 2;
-#ifndef X86_32                       /* x86 uses pusha regardless of regs we could skip */
+#    ifndef X86_32                   /* x86 uses pusha regardless of regs we could skip */
     num_slots -= cci->num_regs_skip; /* regs not saved */
-#endif
+#    endif
     return simd + num_slots * XSP_SZ;
 }
+#endif
 
 /* prepare_for and cleanup_after assume that the stack looks the same after
  * the call to the instrumentation routine, since it stores the app state

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -1154,7 +1154,8 @@ GLOBAL_LABEL(_start:)
          */
         cmp     REG_XDI, 0 /* if reloaded, skip for speed + preserve xdi and xsi */
         jne     reloaded_xfer
-        CALLC3(GLOBAL_REF(relocate_dynamorio), 0, 0, REG_XSP)
+        mov     REG_XAX, REG_XSP /* The CALLC3 may change xsp so grab it first. */
+        CALLC3(GLOBAL_REF(relocate_dynamorio), 0, 0, REG_XAX)
         mov     REG_XDI, 0 /* xdi should be callee-saved but is not always: i#2641 */
 
 reloaded_xfer:

--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * ********************************************************** */
 
@@ -273,7 +273,7 @@ GLOBAL_LABEL(call_switch_stack:)
         mov      [3*ARG_SZ + REG_XAX], ARG3
         mov      [4*ARG_SZ + REG_XAX], ARG4
 #else
-        /* stack alignment doesn't matter */
+        /* Stack alignment doesn't matter b/c we're swapping. */
         mov      REG_XAX, REG_XSP
 #endif
         /* we need a callee-saved reg across our call so save it onto stack */
@@ -362,7 +362,7 @@ GLOBAL_LABEL(dr_call_on_clean_stack:)
         mov      [3*ARG_SZ + REG_XAX], ARG3
         mov      [4*ARG_SZ + REG_XAX], ARG4
 # else
-        /* stack alignment doesn't matter */
+        /* Stack alignment doesn't matter b/c we're swapping. */
         mov      REG_XAX, REG_XSP
 # endif
 # if defined(X64) && !defined(WINDOWS)
@@ -469,7 +469,7 @@ GLOBAL_LABEL(clone_and_swap_stack:)
 #ifdef DR_APP_EXPORTS
         DECLARE_EXPORTED_FUNC(dr_app_start)
 GLOBAL_LABEL(dr_app_start:)
-        sub     REG_XSP, FRAME_ALIGNMENT - ARG_SZ  /* Maintain alignment. */
+        ADD_STACK_ALIGNMENT_NOSEH
 
         /* grab exec state and pass as param in a priv_mcontext_t struct */
         PUSH_PRIV_MCXT(PTRSZ [FRAME_ALIGNMENT - ARG_SZ + REG_XSP -\
@@ -479,8 +479,7 @@ GLOBAL_LABEL(dr_app_start:)
         lea     REG_XAX, [REG_XSP] /* stack grew down, so priv_mcontext_t at tos */
         CALLC1(GLOBAL_REF(dr_app_start_helper), REG_XAX)
 
-        /* if we come back, then DR is not taking control so
-         * clean up stack and return */
+        /* If we come back, then DR is not taking control so clean up stack and return. */
         add      REG_XSP, PRIV_MCXT_SIZE + FRAME_ALIGNMENT - ARG_SZ
         ret
         END_FUNC(dr_app_start)
@@ -514,7 +513,7 @@ GLOBAL_LABEL(dr_app_running_under_dynamorio: )
  */
         DECLARE_EXPORTED_FUNC(dynamorio_app_take_over)
 GLOBAL_LABEL(dynamorio_app_take_over:)
-        sub     REG_XSP, FRAME_ALIGNMENT - ARG_SZ  /* Maintain alignment. */
+        ADD_STACK_ALIGNMENT_NOSEH
 
         /* grab exec state and pass as param in a priv_mcontext_t struct */
         PUSH_PRIV_MCXT(PTRSZ [FRAME_ALIGNMENT - ARG_SZ + REG_XSP -\
@@ -524,8 +523,7 @@ GLOBAL_LABEL(dynamorio_app_take_over:)
         lea      REG_XAX, [REG_XSP] /* stack grew down, so priv_mcontext_t at tos */
         CALLC1(GLOBAL_REF(dynamorio_app_take_over_helper), REG_XAX)
 
-        /* if we come back, then DR is not taking control so
-         * clean up stack and return */
+        /* If we come back, then DR is not taking control so clean up stack and return. */
         add      REG_XSP, PRIV_MCXT_SIZE + FRAME_ALIGNMENT - ARG_SZ
         ret
         END_FUNC(dynamorio_app_take_over)

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -5600,13 +5600,13 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
     else
         encode_pc = vmcode_get_start();
     dstack_offs = prepare_for_call_ex(dcontext, &cci, ilist, where, encode_pc);
-#ifdef X64
     /* PR 218790: we assume that dr_prepare_for_call() leaves stack 16-byte
-     * aligned, which is what insert_meta_call_vargs requires. */
+     * aligned, which is what insert_meta_call_vargs requires.
+     */
     if (cci.should_align) {
-        CLIENT_ASSERT(ALIGNED(dstack_offs, 16), "internal error: bad stack alignment");
+        CLIENT_ASSERT(ALIGNED(dstack_offs, get_ABI_stack_alignment()),
+                      "internal error: bad stack alignment");
     }
-#endif
     if (save_fpstate) {
         /* save on the stack: xref PR 202669 on clients using more stack */
         buf_sz = proc_fpstate_save_size();

--- a/ext/drgui/CMakeLists.txt
+++ b/ext/drgui/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ***************************************************************************
-# Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+# Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
 # Copyright (c) 2013 Branden Clark  All rights reserved.
 # ***************************************************************************
 
@@ -52,14 +52,6 @@ else () # Qt5 and CMake 3.2+
   include(../../make/policies.cmake NO_POLICY_SCOPE)
 
   cmake_policy(SET CMP0043 OLD)
-
-  # DR's boundary of 2 causes alignment issues with Qt, so we stick to default.
-  # This is okay because this is a standalone app, and does not need to match
-  # DynamoRIO.
-  if (NOT WIN32)
-    string(REPLACE "-mpreferred-stack-boundary=2 " "" CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS}")
-  endif (NOT WIN32)
 
   # Set ouput_dir since drgui_qt is the only executable extension
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/ext/${INSTALL_BIN}")

--- a/ext/drwrap/drwrap_asm_x86.asm
+++ b/ext/drwrap/drwrap_asm_x86.asm
@@ -65,18 +65,14 @@ GLOBAL_LABEL(FUNCNAME:)
          *
          * XXX: what about xmm0 return reg?
          */
-#ifdef MACOS
         push     0 /* maintain 16-byte alignment for call */
-#endif
         push     REG_XAX
         push     REG_XDX
         CALLC0(GLOBAL_REF(replace_native_xfer_stack_adjust))
         mov      ecx, eax
         pop      REG_XDX
         pop      REG_XAX
-#ifdef MACOS
         lea      REG_XSP, [ ARG_SZ + REG_XSP ]
-#endif
         /* DrMem i#1217: zero out these slots as they can contain retaddrs, which
          * messes up high-performance callstack stack scans.  This is beyond TOS,
          * but these are writes so it's signal-safe.
@@ -92,7 +88,6 @@ GLOBAL_LABEL(FUNCNAME:)
         push     REG_XAX
         push     REG_XDX
 
-#ifdef MACOS
         /* We have to align the stack for our calls: o/w dyld lazy resolution
          * crashes there.  Current alignment could be anything so we save a ptr
          * and mask off esp.
@@ -100,24 +95,17 @@ GLOBAL_LABEL(FUNCNAME:)
         push     REG_XBX
         mov      REG_XBX, REG_XSP
         and      REG_XSP, -16 /* align to 16 */
-#endif
 
         /* put app retaddr into the slot we made above the 2 pushes */
         CALLC0(GLOBAL_REF(replace_native_xfer_app_retaddr))
-#ifdef MACOS
         mov      PTRSZ [3 * ARG_SZ + REG_XBX], REG_XAX
-#else
-        mov      PTRSZ [2 * ARG_SZ + REG_XSP], REG_XAX
-#endif
 
         /* now get our target */
         CALLC0(GLOBAL_REF(replace_native_xfer_target))
         mov      REG_XCX, REG_XAX
 
-#ifdef MACOS
         mov      REG_XSP, REG_XBX
         pop      REG_XBX
-#endif
 
         pop      REG_XDX
         pop      REG_XAX

--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2019 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2020 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -736,20 +736,6 @@ function (_DR_set_compile_flags target is_client extra_flags)
       endif (flag_present)
 
     endif (is_client)
-
-    # i#847 keep stack boundary 4-byte aligned for compatibility.
-    # The new gcc may use different stack alignment for using SSE
-    # instructions. We make both DynamoRIO and clients use 4-byte
-    # stack alignment to avoid any back compatibility issue without
-    # using extra stack space or changing performance.
-    # On Mac we have to use the ABI's 16-byte alignment, but we have
-    # no compatibility there as we're starting fresh.
-    # On ARM, '-mpreferred-stack-boundary' is unrecognized.
-    # i#1800: '-mpreferred-stack-boundary' is not supported by clang,
-    # so clang's build may not run legacy binaries.
-    if (NOT tgt_x64 AND NOT APPLE AND NOT ARM AND NOT CMAKE_COMPILER_IS_CLANG)
-      set(extra_flags "${extra_flags} -mpreferred-stack-boundary=2")
-    endif (NOT tgt_x64 AND NOT APPLE AND NOT ARM AND NOT CMAKE_COMPILER_IS_CLANG)
 
     if (NOT APPLE AND NOT ANDROID) # no .gnu.hash support on Android
       # Generate the .hash section in addition to .gnu.hash for every target, to

--- a/suite/tests/client-interface/cleancall.dll.c
+++ b/suite/tests/client-interface/cleancall.dll.c
@@ -233,13 +233,6 @@ check_zmm()
 #endif
 
 static void
-inc_counter(int count)
-{
-    static int global_counter;
-    global_counter += count;
-}
-
-static void
 ind_call(reg_t a1, reg_t a2)
 {
     dr_fprintf(STDERR, "bar " PFX " " PFX "\n", a1, a2);
@@ -366,10 +359,6 @@ bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool trans
 #    endif
 #endif
     }
-
-    /* Inlineable call (cleancall-opt does further tests there). */
-    dr_insert_clean_call(drcontext, bb, instrlist_first(bb), inc_counter, false, 1,
-                         OPND_CREATE_INT32(42));
 
     /* Look for 3 nops to indicate handler is set up */
     for (instr = instrlist_first(bb); instr != NULL; instr = next_instr) {

--- a/suite/tests/client-interface/cleancall.dll.c
+++ b/suite/tests/client-interface/cleancall.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -57,6 +57,7 @@ print_error_on_fail(bool check)
 static void
 set_gpr()
 {
+    check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
     dr_mcontext_t mcontext = {
         sizeof(mcontext),
@@ -77,6 +78,7 @@ set_gpr()
 static void
 check_gpr()
 {
+    check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
     dr_mcontext_t mcontext = {
         sizeof(mcontext),
@@ -95,6 +97,7 @@ check_gpr()
 static void
 set_xmm()
 {
+    check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
     dr_mcontext_t mcontext = {
         sizeof(mcontext),
@@ -115,6 +118,7 @@ set_xmm()
 static void
 check_xmm()
 {
+    check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
     dr_mcontext_t mcontext = {
         sizeof(mcontext),
@@ -133,6 +137,7 @@ check_xmm()
 static void
 set_ymm()
 {
+    check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
     dr_mcontext_t mcontext = {
         sizeof(mcontext),
@@ -155,6 +160,7 @@ set_ymm()
 static void
 check_ymm()
 {
+    check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
     dr_mcontext_t mcontext = {
         sizeof(mcontext),
@@ -176,6 +182,7 @@ check_ymm()
 static void
 set_zmm()
 {
+    check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
     dr_mcontext_t mcontext = {
         sizeof(mcontext),
@@ -201,6 +208,7 @@ set_zmm()
 static void
 check_zmm()
 {
+    check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
     dr_mcontext_t mcontext = {
         sizeof(mcontext),
@@ -225,6 +233,13 @@ check_zmm()
 #endif
 
 static void
+inc_counter(int count)
+{
+    static int global_counter;
+    global_counter += count;
+}
+
+static void
 ind_call(reg_t a1, reg_t a2)
 {
     dr_fprintf(STDERR, "bar " PFX " " PFX "\n", a1, a2);
@@ -235,6 +250,7 @@ static void (*ind_call_ptr)(reg_t a1, reg_t a2) = ind_call;
 static void
 foo(reg_t a1, reg_t a2, reg_t a3, reg_t a4, reg_t a5, reg_t a6, reg_t a7, reg_t a8)
 {
+    check_stack_alignment();
     dr_fprintf(
         STDERR,
         "foo " PFX " " PFX " " PFX " " PFX "\n    " PFX " " PFX " " PFX " " PFX "\n", a1,
@@ -245,6 +261,7 @@ foo(reg_t a1, reg_t a2, reg_t a3, reg_t a4, reg_t a5, reg_t a6, reg_t a7, reg_t 
 static void
 bar(reg_t a1, reg_t a2)
 {
+    check_stack_alignment();
     /* test indirect call handling in clean call analysis */
     ind_call_ptr(a1, a2);
 }
@@ -252,6 +269,7 @@ bar(reg_t a1, reg_t a2)
 static void
 save_test()
 {
+    check_stack_alignment();
     int i;
     void *drcontext = dr_get_current_drcontext();
     dr_fprintf(STDERR, "verifying values\n");
@@ -348,6 +366,10 @@ bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool trans
 #    endif
 #endif
     }
+
+    /* Inlineable call (cleancall-opt does further tests there). */
+    dr_insert_clean_call(drcontext, bb, instrlist_first(bb), inc_counter, false, 1,
+                         OPND_CREATE_INT32(42));
 
     /* Look for 3 nops to indicate handler is set up */
     for (instr = instrlist_first(bb); instr != NULL; instr = next_instr) {

--- a/suite/tests/client-interface/cleancallparams.dll.c
+++ b/suite/tests/client-interface/cleancallparams.dll.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2020 Google, Inc. All rights reserved.
  * Copyright (c) 2017 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -188,6 +189,7 @@ callee(int num_args, ...)
     va_list ap;
     int i;
 
+    check_stack_alignment();
     if (call_count >= NUM_TESTS)
         fail("too many calls");
     if (num_args != tests[call_count].num_args) {

--- a/suite/tests/client-interface/cleancallsig.dll.c
+++ b/suite/tests/client-interface/cleancallsig.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,6 +37,7 @@ static void
 cleancallee(app_pc pc)
 {
     /* Include enough complexity to avoid inlining. */
+    check_stack_alignment();
     if (pc == NULL) {
         dr_fprintf(STDERR, "pc is NULL\n");
     }

--- a/suite/tests/client-interface/drwrap-test.appdll.c
+++ b/suite/tests/client-interface/drwrap-test.appdll.c
@@ -378,7 +378,7 @@ DECL_EXTERN(print_from_asm)
         DECLARE_EXPORTED_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
 # ifdef X86
-        push     REG_XBP  /* Needed only to maintain 16-byte alignment. */
+        ADD_STACK_ALIGNMENT_NOSEH
 # elif defined(AARCH64)
         stp      x29, x30, [sp, #-16]!
 # elif defined(ARM)
@@ -388,7 +388,7 @@ GLOBAL_LABEL(FUNCNAME:)
         mov      REG_SCRATCH0, HEX(1)
         CALLC1(GLOBAL_REF(print_from_asm), REG_SCRATCH0)
 # ifdef X86
-        pop      REG_XBP
+        RESTORE_STACK_ALIGNMENT
 # elif defined(AARCH64)
         ldp      x29, x30, [sp], #16
 # elif defined(ARM)
@@ -404,7 +404,7 @@ GLOBAL_LABEL(FUNCNAME:)
         DECLARE_EXPORTED_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
 # ifdef X86
-        push     REG_XBP  /* Needed only to maintain 16-byte alignment. */
+        ADD_STACK_ALIGNMENT_NOSEH
 # elif defined(AARCH64)
         stp      x29, x30, [sp, #-16]!
 # elif defined(ARM)
@@ -414,7 +414,7 @@ GLOBAL_LABEL(FUNCNAME:)
         mov      REG_SCRATCH0, HEX(7)
         CALLC1(GLOBAL_REF(print_from_asm), REG_SCRATCH0)
 # ifdef X86
-        pop      REG_XBP
+        RESTORE_STACK_ALIGNMENT
         ret
 # elif defined(AARCH64)
         ldp      x29, x30, [sp], #16

--- a/suite/tests/client_tools.h
+++ b/suite/tests/client_tools.h
@@ -118,8 +118,8 @@ check_stack_alignment(void)
 #    define STACK_ALIGNMENT 8
     ASSERT(ALIGNED(sp, STACK_ALIGNMENT));
 #else
-    /* We could have a separate-file asm routine for Windows but for now we just test
-     * on x86 UNIX.
+    /* TODO i#4267: If we change Windows to be more than 4-byte alignment we should
+     * add a separate-file asm routine to check alignment there.
      */
 #endif
 }

--- a/suite/tests/client_tools.h
+++ b/suite/tests/client_tools.h
@@ -99,4 +99,29 @@
 #    define IF_WINDOWS(x)
 #endif
 
+static inline void
+check_stack_alignment(void)
+{
+#if defined(X86) && defined(UNIX)
+    reg_t sp;
+    __asm__ __volatile__("mov %%" IF_X64_ELSE("rsp", "esp") ", %0" : "=m"(sp));
+#    define STACK_ALIGNMENT 16
+    ASSERT(ALIGNED(sp, STACK_ALIGNMENT));
+#elif defined(AARCH64)
+    reg_t sp;
+    __asm__ __volatile__("mov %0, sp" : "=r"(sp));
+#    define STACK_ALIGNMENT 16
+    ASSERT(ALIGNED(sp, STACK_ALIGNMENT));
+#elif defined(ARM)
+    reg_t sp;
+    __asm__ __volatile__("str sp, %0" : "=m"(sp));
+#    define STACK_ALIGNMENT 8
+    ASSERT(ALIGNED(sp, STACK_ALIGNMENT));
+#else
+    /* We could have a separate-file asm routine for Windows but for now we just test
+     * on x86 UNIX.
+     */
+#endif
+}
+
 #endif /* DR_CLIENT_TOOLS_H */

--- a/suite/tests/common/nativeexec.c
+++ b/suite/tests/common/nativeexec.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2005 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -222,6 +222,7 @@ main(int argc, char **argv)
 /* clang-format off */
 START_FILE
 
+/* TODO i#3966: Maintain 16-byte alignment for 32-bit too in these routines. */
         DECLARE_FUNC(call_plt)
 GLOBAL_LABEL(call_plt:)
         /* XXX: Not doing SEH prologue for test code. */


### PR DESCRIPTION
Abandons the 4-byte stack alignment DR was using for 32-bit x86 Linux
(for compatibility with legacy code).  The SysV ABI breakage by gcc
4.5 was 10 years ago and in that time other compilers have followed
suit, making 16-byte the de facto standard.  Clang doesn't even
support requesting 4-byte stack alignment.  DR is now switching to the
modern ABI of 16-byte stack alignment.

Bumps the version to 7.92 and marks OLDEST_COMPATIBLE_VERSION as 791
to indicate the binary compatbility break for 32-bit x86 DR.

Leaves Windows as 4-byte-aligned, since changing the injection
assembly code and other pieces would be a bunch of extra work for
little benefit: Windows 32-bit only requires 4-byte alignment, and the
code is not that much more complex with a split alignment.

Aligns the stack after clean call preparation (state saving) and again
after clean call argument setup.  Currently the stack restores can end
up with two LEA's in a row; we leave removing that for future work.

Adds stack alignment checks to some of the clean call tests.

Updates the manual stack alignment in DR assembly code.  I only found
a few places to update and I expected to find more.  We should monitor
usage outside the test suite and look for problems.

Issue: #847, #3966, #4200
Fixes: #3966
Fixes: #4200