### PR TITLE
i#4134: Add opnd check 

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -441,6 +441,8 @@ Further non-compatibility-affecting changes include:
    aggregate, and clean up in print_results().
  - Added module_mapper_t::find_mapped_trace_bounds() to allow callers to cache
    results and avoid global locks during parallel operation.
+ - Added a new DR extension, namely "drbbdup", which enables different case
+   instrumentation of the same basic block by duplicating code.
 
 **************************************************
 <hr>

--- a/api/samples/hot_bbcount.c
+++ b/api/samples/hot_bbcount.c
@@ -264,7 +264,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     /* The operand referring to memory storing the current runtime case encoding. */
     drbbdup_ops.runtime_case_opnd =
         dr_raw_tls_opnd(dr_get_current_drcontext(), tls_raw_reg, tls_raw_offset);
-    drbbdup_ops.dup_limit = 1; /* Only one additional copy is needed. */
+    drbbdup_ops.non_default_case_limit = 1; /* Only one additional copy is needed. */
     drbbdup_ops.is_stat_enabled = false;
 
     if (drbbdup_init(&drbbdup_ops) != DRBBDUP_SUCCESS)

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -857,7 +857,8 @@ atomic_dec_becomes_zero(volatile int *var)
  */
 /* FIXME i#1551: should we allow infinite loops for those ATOMIC ops */
 #        define ATOMIC_INC_suffix(suffix, var)                                     \
-            __asm__ __volatile__("1: ldrex" suffix " r2, %0         \n\t"          \
+            __asm__ __volatile__("   dmb ish                        \n\t"          \
+                                 "1: ldrex" suffix " r2, %0         \n\t"          \
                                  "   add" suffix " r2, r2, #1     \n\t"            \
                                  "   strex" suffix " r3, r2, %0     \n\t"          \
                                  "   cmp   r3, #0                   \n\t"          \
@@ -870,7 +871,8 @@ atomic_dec_becomes_zero(volatile int *var)
 #        define ATOMIC_INC_int64(var) ATOMIC_INC_suffix("d", var)
 #        define ATOMIC_INC(type, var) ATOMIC_INC_##type(var)
 #        define ATOMIC_DEC_suffix(suffix, var)                                     \
-            __asm__ __volatile__("1: ldrex" suffix " r2, %0         \n\t"          \
+            __asm__ __volatile__("   dmb ish                        \n\t"          \
+                                 "1: ldrex" suffix " r2, %0         \n\t"          \
                                  "   sub" suffix " r2, r2, #1     \n\t"            \
                                  "   strex" suffix " r3, r2, %0     \n\t"          \
                                  "   cmp   r3, #0                   \n\t"          \
@@ -883,7 +885,8 @@ atomic_dec_becomes_zero(volatile int *var)
 #        define ATOMIC_DEC_int64(var) ATOMIC_DEC_suffix("d", var)
 #        define ATOMIC_DEC(type, var) ATOMIC_DEC_##type(var)
 #        define ATOMIC_ADD_suffix(suffix, var, value)                              \
-            __asm__ __volatile__("1: ldrex" suffix " r2, %0         \n\t"          \
+            __asm__ __volatile__("   dmb ish                        \n\t"          \
+                                 "1: ldrex" suffix " r2, %0         \n\t"          \
                                  "   add" suffix " r2, r2, %1     \n\t"            \
                                  "   strex" suffix " r3, r2, %0     \n\t"          \
                                  "   cmp   r3, #0                   \n\t"          \
@@ -897,7 +900,8 @@ atomic_dec_becomes_zero(volatile int *var)
 #        define ATOMIC_ADD(type, var, val) ATOMIC_ADD_##type(var, val)
 /* Not safe for general use, just for atomic_add_exchange(), undefed below */
 #        define ATOMIC_ADD_EXCHANGE_suffix(suffix, var, value, result)    \
-            __asm__ __volatile__("1: ldrex" suffix " r2, %0         \n\t" \
+            __asm__ __volatile__("   dmb ish                        \n\t" \
+                                 "1: ldrex" suffix " r2, %0         \n\t" \
                                  "   add" suffix " r2, r2, %2     \n\t"   \
                                  "   strex" suffix " r3, r2, %0     \n\t" \
                                  "   cmp   r3, #0                   \n\t" \
@@ -912,7 +916,8 @@ atomic_dec_becomes_zero(volatile int *var)
 #        define ATOMIC_ADD_EXCHANGE_int64(var, val, res) \
             ATOMIC_ADD_EXCHANGE_suffix("d", var, val, res)
 #        define ATOMIC_COMPARE_EXCHANGE_suffix(suffix, var, compare, exchange)           \
-            __asm__ __volatile__("2: ldrex" suffix " r2, %0       \n\t"                  \
+            __asm__ __volatile__("   dmb ish                      \n\t"                  \
+                                 "2: ldrex" suffix " r2, %0       \n\t"                  \
                                  "   cmp" suffix " r2, %1       \n\t"                    \
                                  "   bne    1f                    \n\t"                  \
                                  "   strex" suffix " r3, %2, %0   \n\t"                  \
@@ -928,7 +933,8 @@ atomic_dec_becomes_zero(volatile int *var)
 #        define ATOMIC_COMPARE_EXCHANGE_int64(var, compare, exchange) \
             ATOMIC_COMPARE_EXCHANGE_suffix("d", var, compare, exchange)
 #        define ATOMIC_EXCHANGE(var, newval, result)            \
-            __asm__ __volatile__("1: ldrex r2, %0         \n\t" \
+            __asm__ __volatile__("   dmb ish              \n\t" \
+                                 "1: ldrex r2, %0         \n\t" \
                                  "   strex r3, %2, %0     \n\t" \
                                  "   cmp   r3, #0         \n\t" \
                                  "   bne   1b             \n\t" \

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -1476,7 +1476,19 @@ static bool
 drbbdup_check_options(drbbdup_options_t *ops_in)
 {
     if (ops_in != NULL && ops_in->set_up_bb_dups != NULL && ops_in->instrument_instr &&
-        ops_in->dup_limit > 0 && opnd_is_memory_reference(ops_in->runtime_case_opnd))
+        ops_in->dup_limit > 0)
+        return true;
+
+    return false;
+}
+
+static bool
+drbbdup_check_case_opnd(opnd_t case_opnd)
+{
+    /* As stated in the docs, runtime case operand must be a memory reference
+     * and pointer-sized.
+     * */
+    if (opnd_is_memory_reference(case_opnd) && opnd_get_size(case_opnd) == OPSZ_PTR)
         return true;
 
     return false;
@@ -1491,6 +1503,9 @@ drbbdup_init(drbbdup_options_t *ops_in)
 
     if (!drbbdup_check_options(ops_in))
         return DRBBDUP_ERROR_INVALID_PARAMETER;
+    if (!drbbdup_check_case_opnd(ops_in->runtime_case_opnd))
+        return DRBBDUP_ERROR_INVALID_OPND;
+
     memcpy(&opts, ops_in, sizeof(drbbdup_options_t));
 
     drreg_options_t drreg_ops = { sizeof(drreg_ops), 0 /* no regs needed */, false, NULL,

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -213,7 +213,7 @@ drbbdup_count(drbbdup_manager_t *manager)
 
     uint count = 0;
     int i;
-    for (i = 0; i < opts.dup_limit; i++) {
+    for (i = 0; i < opts.non_default_case_limit; i++) {
         /* If case is defined, increment the counter. */
         if (manager->cases[i].is_defined)
             count++;
@@ -245,9 +245,10 @@ drbbdup_create_manager(void *drcontext, void *tag, instrlist_t *bb)
     memset(manager, 0, sizeof(drbbdup_manager_t));
 
     manager->cases = NULL;
-    ASSERT(opts.dup_limit > 0, "dup limit should be greater than zero");
-    manager->cases = dr_global_alloc(sizeof(drbbdup_case_t) * opts.dup_limit);
-    memset(manager->cases, 0, sizeof(drbbdup_case_t) * opts.dup_limit);
+    ASSERT(opts.non_default_case_limit > 0, "dup limit should be greater than zero");
+    manager->cases =
+        dr_global_alloc(sizeof(drbbdup_case_t) * opts.non_default_case_limit);
+    memset(manager->cases, 0, sizeof(drbbdup_case_t) * opts.non_default_case_limit);
     manager->enable_dup = true;
     manager->enable_dynamic_handling = true;
     manager->is_gen = false;
@@ -268,7 +269,8 @@ drbbdup_create_manager(void *drcontext, void *tag, instrlist_t *bb)
     /* Check whether user wants copies for this particular bb. */
     if (!manager->enable_dup && manager->cases != NULL) {
         /* Multiple cases not wanted. Destroy cases. */
-        dr_global_free(manager->cases, sizeof(drbbdup_case_t) * opts.dup_limit);
+        dr_global_free(manager->cases,
+                       sizeof(drbbdup_case_t) * opts.non_default_case_limit);
         manager->cases = NULL;
     }
 
@@ -640,7 +642,7 @@ drbbdup_analyse_phase(void *drcontext, void *tag, instrlist_t *bb, bool for_trac
     if (manager->enable_dup) {
         ASSERT(manager->cases != NULL, "case information must exit");
         int i;
-        for (i = 0; i < opts.dup_limit; i++) {
+        for (i = 0; i < opts.non_default_case_limit; i++) {
             case_info = &manager->cases[i];
             if (case_info->is_defined) {
                 pt->case_analysis_data[i] =
@@ -801,7 +803,7 @@ drbbdup_do_dynamic_handling(drbbdup_manager_t *manager)
 {
     drbbdup_case_t *drbbdup_case;
     int i;
-    for (i = 0; i < opts.dup_limit; i++) {
+    for (i = 0; i < opts.non_default_case_limit; i++) {
         drbbdup_case = &manager->cases[i];
         /* Search for empty undefined slot. */
         if (!drbbdup_case->is_defined)
@@ -937,7 +939,7 @@ drbbdup_instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *i
     } else {
         ASSERT(pt->case_analysis_data != NULL,
                "container for analysis data cannot be NULL");
-        ASSERT(pt->case_index >= 0 && pt->case_index < opts.dup_limit,
+        ASSERT(pt->case_index >= 0 && pt->case_index < opts.non_default_case_limit,
                "case index cannot be out-of-bounds");
         ASSERT(manager->enable_dup, "bb dup must be enabled");
 
@@ -1008,7 +1010,7 @@ drbbdup_instrument_dups(void *drcontext, app_pc pc, void *tag, instrlist_t *bb,
             /* We have reached the start of a new bb version (not the last one). */
             bool found = false;
             int i;
-            for (i = pt->case_index + 1; i < opts.dup_limit; i++) {
+            for (i = pt->case_index + 1; i < opts.non_default_case_limit; i++) {
                 drbbdup_case = &manager->cases[i];
                 if (drbbdup_case->is_defined) {
                     found = true;
@@ -1077,7 +1079,7 @@ drbbdup_destroy_all_analyses(void *drcontext, drbbdup_manager_t *manager,
     if (opts.destroy_case_analysis != NULL) {
         if (pt->case_analysis_data != NULL) {
             int i;
-            for (i = 0; i < opts.dup_limit; i++) {
+            for (i = 0; i < opts.non_default_case_limit; i++) {
                 if (pt->case_analysis_data[i] != NULL) {
                     opts.destroy_case_analysis(drcontext, manager->cases[i].encoding,
                                                opts.user_data, pt->orig_analysis_data,
@@ -1143,7 +1145,7 @@ drbbdup_encoding_already_included(drbbdup_manager_t *manager, uintptr_t encoding
     drbbdup_case_t *drbbdup_case;
     if (manager->enable_dup) {
         int i;
-        for (i = 0; i < opts.dup_limit; i++) {
+        for (i = 0; i < opts.non_default_case_limit; i++) {
             drbbdup_case = &manager->cases[i];
             if (drbbdup_case->is_defined && drbbdup_case->encoding == encoding_check)
                 return true;
@@ -1166,7 +1168,7 @@ drbbdup_include_encoding(drbbdup_manager_t *manager, uintptr_t new_encoding)
     if (manager->enable_dup) {
         int i;
         drbbdup_case_t *dup_case;
-        for (i = 0; i < opts.dup_limit; i++) {
+        for (i = 0; i < opts.non_default_case_limit; i++) {
             dup_case = &manager->cases[i];
             if (!dup_case->is_defined) {
                 dup_case->is_defined = true;
@@ -1430,8 +1432,9 @@ drbbdup_destroy_manager(void *manager_opaque)
     ASSERT(manager != NULL, "manager should not be NULL");
 
     if (manager->enable_dup && manager->cases != NULL) {
-        ASSERT(opts.dup_limit > 0, "dup limit should be greater than zero");
-        dr_global_free(manager->cases, sizeof(drbbdup_case_t) * opts.dup_limit);
+        ASSERT(opts.non_default_case_limit > 0, "dup limit should be greater than zero");
+        dr_global_free(manager->cases,
+                       sizeof(drbbdup_case_t) * opts.non_default_case_limit);
     }
     dr_global_free(manager, sizeof(drbbdup_manager_t));
 }
@@ -1444,9 +1447,10 @@ drbbdup_thread_init(void *drcontext)
 
     pt->case_index = 0;
     pt->orig_analysis_data = NULL;
-    ASSERT(opts.dup_limit > 0, "dup limit should be greater than zero");
-    pt->case_analysis_data = dr_thread_alloc(drcontext, sizeof(void *) * opts.dup_limit);
-    memset(pt->case_analysis_data, 0, sizeof(void *) * opts.dup_limit);
+    ASSERT(opts.non_default_case_limit > 0, "dup limit should be greater than zero");
+    pt->case_analysis_data =
+        dr_thread_alloc(drcontext, sizeof(void *) * opts.non_default_case_limit);
+    memset(pt->case_analysis_data, 0, sizeof(void *) * opts.non_default_case_limit);
 
     /* Init hit table. */
     for (int i = 0; i < TABLE_SIZE; i++)
@@ -1462,9 +1466,10 @@ drbbdup_thread_exit(void *drcontext)
     drbbdup_per_thread *pt =
         (drbbdup_per_thread *)drmgr_get_tls_field(drcontext, tls_idx);
     ASSERT(pt != NULL, "thread-local storage should not be NULL");
-    ASSERT(opts.dup_limit > 0, "dup limit should be greater than zero");
+    ASSERT(opts.non_default_case_limit > 0, "dup limit should be greater than zero");
 
-    dr_thread_free(drcontext, pt->case_analysis_data, sizeof(void *) * opts.dup_limit);
+    dr_thread_free(drcontext, pt->case_analysis_data,
+                   sizeof(void *) * opts.non_default_case_limit);
     dr_thread_free(drcontext, pt, sizeof(drbbdup_per_thread));
 }
 
@@ -1476,7 +1481,7 @@ static bool
 drbbdup_check_options(drbbdup_options_t *ops_in)
 {
     if (ops_in != NULL && ops_in->set_up_bb_dups != NULL && ops_in->instrument_instr &&
-        ops_in->dup_limit > 0)
+        ops_in->non_default_case_limit > 0)
         return true;
 
     return false;
@@ -1487,7 +1492,7 @@ drbbdup_check_case_opnd(opnd_t case_opnd)
 {
     /* As stated in the docs, runtime case operand must be a memory reference
      * and pointer-sized.
-     * */
+     */
     if (opnd_is_memory_reference(case_opnd) && opnd_get_size(case_opnd) == OPSZ_PTR)
         return true;
 

--- a/ext/drbbdup/drbbdup.dox
+++ b/ext/drbbdup/drbbdup.dox
@@ -129,11 +129,13 @@ guarantees that it does not modify the set encoding on its own accord.
 
 drbbdup invokes the #drbbdup_instrument_instr_t call-back function to
 trigger the instrumentation of an instruction. Instrumentation must be
-done with respect to the currently considered case which is provided by
+done with respect to the currently considered case which is passed as a parameter by
 drbbdup. Moreover, while drbbdup supplies the instruction which the client
 considers for instrumentation, it also provides a "where" instruction.
 The client must insert code exactly prior to the "where" instruction
-in order to ensure correct instrumentation.
+in order to ensure correct instrumentation. Internally, this approach enables
+instructions (e.g., syscall and jmp), which cannot be duplicated due to the breaking
+of basic block structure, to have different case instrumentation nonetheless. 
 
 drbbdup also provides drbbdup_is_first_instr(), drbbdup_is_first_nonlabel_instr()
 and drbbdup_is_last_instr() to determine whether the passed instruction

--- a/ext/drbbdup/drbbdup.dox
+++ b/ext/drbbdup/drbbdup.dox
@@ -135,7 +135,7 @@ considers for instrumentation, it also provides a "where" instruction.
 The client must insert code exactly prior to the "where" instruction
 in order to ensure correct instrumentation. Internally, this approach enables
 instructions (e.g., syscall and jmp), which cannot be duplicated due to the breaking
-of basic block structure, to have different case instrumentation nonetheless. 
+of basic block structure, to have different case instrumentation nonetheless.
 
 drbbdup also provides drbbdup_is_first_instr(), drbbdup_is_first_nonlabel_instr()
 and drbbdup_is_last_instr() to determine whether the passed instruction

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -61,6 +61,7 @@ extern "C" {
 typedef enum {
     DRBBDUP_SUCCESS,                       /**< Operation succeeded. */
     DRBBDUP_ERROR_INVALID_PARAMETER,       /**< Operation failed: invalid parameter. */
+    DRBBDUP_ERROR_INVALID_OPND,            /**< Operation failed: invalid case opnd. */
     DRBBDUP_ERROR_CASE_ALREADY_REGISTERED, /**< Operation failed: already registered. */
     DRBBDUP_ERROR_CASE_LIMIT_REACHED,      /**< Operation failed: case limit reached. */
     DRBBDUP_ERROR_ALREADY_INITIALISED,     /**< DRBBDUP can only be initialised once. */
@@ -265,7 +266,8 @@ typedef struct {
     /**
      * An operand that refers to the memory containing the current runtime case encoding.
      * During runtime, the dispatcher loads the runtime encoding via this operand
-     * in order to direct control to the appropriate basic block.
+     * in order to direct control to the appropriate basic block. The opnd must be
+     * pointer-sized.
      */
     opnd_t runtime_case_opnd;
     /**
@@ -279,9 +281,9 @@ typedef struct {
      */
     void *user_data;
     /**
-     * The maximum number of cases, excluding the default case, that can be associated
-     * with a basic block. Once the limit is reached and an unhandled case is encountered,
-     * control is directed to the default case.
+     * The maximum number of alternative cases, excluding the default case, that can be
+     * associated with a basic block. Once the limit is reached and an unhandled case is
+     * encountered, control is directed to the default case.
      */
     ushort dup_limit;
     /**

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -210,7 +210,8 @@ typedef void (*drbbdup_instrument_instr_t)(void *drcontext, void *tag, instrlist
 
 /**
  * Specifies the options when initialising drbbdup. \p set_up_bb_dups
- * and \p instrument_instr cannot be NULL, while \p dup_limit must be greater than zero.
+ * and \p instrument_instr cannot be NULL, while \p non_default_case_limit must be
+ * greater than zero.
  */
 typedef struct {
     /** Set this to the size of this structure. */
@@ -285,7 +286,7 @@ typedef struct {
      * associated with a basic block. Once the limit is reached and an unhandled case is
      * encountered, control is directed to the default case.
      */
-    ushort dup_limit;
+    ushort non_default_case_limit;
     /**
      * Approximately, the number of times an unhandled case should be encountered by a
      * thread before it becomes a candidate for dynamic generation.

--- a/suite/tests/client-interface/drbbdup-analysis-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-analysis-test.dll.c
@@ -154,7 +154,7 @@ dr_init(client_id_t id)
     opts.instrument_instr = instrument_instr;
     opts.runtime_case_opnd = opnd_create_abs_addr(&encode_val, OPSZ_PTR);
     opts.user_data = NULL;
-    opts.dup_limit = 1;
+    opts.non_default_case_limit = 1;
     opts.is_stat_enabled = false;
 
     drbbdup_status_t res = drbbdup_init(&opts);

--- a/suite/tests/client-interface/drbbdup-no-encode-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-no-encode-test.dll.c
@@ -121,7 +121,7 @@ dr_init(client_id_t id)
     opts.runtime_case_opnd = opnd_create_abs_addr(&case_encoding, OPSZ_PTR);
     opts.atomic_load_encoding = false;
     opts.user_data = USER_DATA_VAL;
-    opts.dup_limit = 1;
+    opts.non_default_case_limit = 1;
 
     drbbdup_status_t res = drbbdup_init(&opts);
     CHECK(res == DRBBDUP_SUCCESS, "drbbdup init failed");

--- a/suite/tests/client-interface/drbbdup-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-test.dll.c
@@ -265,7 +265,7 @@ dr_init(client_id_t id)
     opts.instrument_instr = instrument_instr;
     opts.runtime_case_opnd = opnd_create_abs_addr(&encode_val, OPSZ_PTR);
     opts.user_data = USER_DATA_VAL;
-    opts.dup_limit = 2;
+    opts.non_default_case_limit = 2;
     opts.is_stat_enabled = true;
 
     drbbdup_status_t res = drbbdup_init(&opts);


### PR DESCRIPTION
Makes minor changes to docs to better clarify some assumptions made by drbbdup.

Also adds a check to ensure that the runtime case operand provided by the user is of pointer-size.

Issue: #4134 