### PR TITLE
i#4313: Clarify docs regarding first, first_nonlabel, and last instr functions

### DIFF
--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -388,6 +388,7 @@ DR_EXPORT
  * Must be called via a #drbbdup_instrument_instr_t call-back function.
  *
  * @return whether successful or an error code on failure.
+ * @note when using drbbdup, do not rely on drmgr_is_first_instr().
  */
 drbbdup_status_t
 drbbdup_is_first_instr(void *drcontext, instr_t *instr, OUT bool *is_start);
@@ -400,6 +401,7 @@ DR_EXPORT
  * Must be called via a #drbbdup_instrument_instr_t call-back function.
  *
  * @return whether successful or an error code on failure.
+ * @note when using drbbdup, do not rely on drmgr_is_first_nonlabel_instr().
  */
 drbbdup_status_t
 drbbdup_is_first_nonlabel_instr(void *drcontext, instr_t *instr, bool *is_nonlabel);
@@ -412,6 +414,7 @@ DR_EXPORT
  * Must be called via a #drbbdup_instrument_instr_t call-back function.
  *
  * @return whether successful or an error code on failure.
+ * @note when using drbbdup, do not rely on drmgr_is_last_instr().
  */
 drbbdup_status_t
 drbbdup_is_last_instr(void *drcontext, instr_t *instr, OUT bool *is_last);


### PR DESCRIPTION
Add docs to clarify that users should not use drmgr variants to check for first, first_nonlabel and last instructions.

Issue: #4134