### PR TITLE
i#4280: Add support for opcode insert instrumentation to drmgr

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -145,7 +145,7 @@ compatibility changes:
 
 Further non-compatibility-affecting changes include:
 
- - Adds drmgr_register_opcode_instrumentation_event() and
+ - Added drmgr_register_opcode_instrumentation_event() and
    drmgr_unregister_opcode_instrumentation_event() so that drmgr supports
    opcode event instrumentation.
 

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -145,7 +145,9 @@ compatibility changes:
 
 Further non-compatibility-affecting changes include:
 
- Nothing yet.
+ - Adds drmgr_register_opcode_instrumentation_event() and
+   drmgr_unregister_opcode_instrumentation_event() so that drmgr supports
+   opcode event instrumentation.
 
 **************************************************
 <hr>

--- a/ext/drmgr/CMakeLists.txt
+++ b/ext/drmgr/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(drmgr SHARED ${srcs})
 # to avoid rebase so we avoid conflict w/ client and other exts
 set(PREFERRED_BASE 0x73000000)
 configure_extension(drmgr OFF)
+use_DynamoRIO_extension(drmgr drcontainers)
 
 # Must be shared to ensure only one copy, since can be used by
 # the client and by multiple other libraries, some of which may
@@ -67,5 +68,6 @@ configure_extension(drmgr OFF)
 # we build drmgr both shared and static (i#1342).
 add_library(drmgr_static STATIC ${srcs_static})
 configure_extension(drmgr_static ON)
+use_DynamoRIO_extension(drmgr_static drcontainers)
 
 install_ext_header(drmgr.h)

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -185,7 +185,7 @@ typedef struct _cb_list_t {
 } cb_list_t;
 
 #define EVENTS_INITIAL_SZ 10
-#define EVENTS_STACK_SZ 16
+#define EVENTS_STACK_SZ 15
 
 /* Our own TLS data */
 typedef struct _per_thread_t {

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -620,7 +620,7 @@ cblist_copy(cb_list_t *src, cb_list_t *dst)
 }
 
 /* Creates a temporary local copy, using local if it's big enough but
- * otherwise allocating new space on the heap. It does a scoped allocation
+ * otherwise allocating new space on the heap. It allocates just enough space
  * for the list's array, using num_def instead of capacity for its size.
  * Caller must hold read lock. Use cblist_delete_local() to destroy.
  */

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -591,7 +591,7 @@ cblist_shift_and_resize(cb_list_t *l, uint insert_at)
 }
 
 static void
-cblist_append_copy(cb_list_t *l, cb_list_t *l_to_copy)
+cblist_insert_other(cb_list_t *l, cb_list_t *l_to_copy)
 {
     ASSERT(l->entry_sz == l_to_copy->entry_sz, "must be of the same size");
     int i;
@@ -732,7 +732,7 @@ drmgr_set_up_local_opcode_table(IN instrlist_t *bb, IN cb_list_t *insert_list,
             if (local_opcode_cb_list == NULL) {
                 local_opcode_cb_list = dr_global_alloc(sizeof(cb_list_t));
                 cblist_create_global(insert_list, local_opcode_cb_list);
-                cblist_append_copy(local_opcode_cb_list, opcode_cb_list);
+                cblist_insert_other(local_opcode_cb_list, opcode_cb_list);
                 hashtable_add(local_opcode_instrum_table, (void *)(intptr_t)opcode,
                               local_opcode_cb_list);
             }

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -919,7 +919,7 @@ drmgr_bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
      * in prior stages also need to be looked-up (including meta instructions) when
      * iterating over the basic block.
      *
-     * Init table only if opcode events were ever registered by the user.
+     * Initialise table only if opcode events were ever registered by the user.
      */
     if (local_was_opcode_instrum_registered) {
         drmgr_init_opcode_hashtable(&local_opcode_instrum_table);
@@ -1148,8 +1148,8 @@ drmgr_bb_cb_add(cb_list_t *list, drmgr_xform_cb_t xform_func,
             new_e->has_quartet = false;
             new_e->is_opcode_insertion = true;
             new_e->cb.opcode_insertion_cb = opcode_instrum_fuc;
-            was_opcode_instrum_registered = true; /* set the flag b/c we encountered the
-                                                     registration of an opcode event */
+            /* set the flag b/c we encountered the registration of an opcode event */
+            was_opcode_instrum_registered = true;
         } else {
             new_e->has_quartet = false;
             new_e->is_opcode_insertion = false;

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -89,8 +89,8 @@
 /* priority list entry base struct */
 typedef struct _priority_event_entry_t {
     bool valid; /* is whole entry valid (not just priority) */
-    drmgr_priority_t
-        in_priority; /* Given as input by the user. Enables reorder of cb lists. */
+    /* Given as input by the user. Enables reorder of cb lists. */
+    drmgr_priority_t in_priority;
 } priority_event_entry_t;
 
 /* bb event list entry */
@@ -224,8 +224,8 @@ static cb_list_t cblist_instru2instru;
 /* For opcode specific instrumentation. */
 static hashtable_t global_opcode_instrum_table; /* maps opcodes to cb lists */
 static void *opcode_table_lock;
-static bool was_opcode_instrum_registered; /* a flag indicating whether opcode instrum was
-                                              ever registered */
+/* a flag indicating whether opcode instrum was ever registered */
+static bool was_opcode_instrum_registered;
 
 /* Count of callbacks needing user_data, protected by bb_cb_lock */
 static uint pair_count;
@@ -594,7 +594,7 @@ static void
 cblist_insert_other(cb_list_t *l, cb_list_t *l_to_copy)
 {
     ASSERT(l->entry_sz == l_to_copy->entry_sz, "must be of the same size");
-    int i;
+    size_t i;
     for (i = 0; i < l_to_copy->num_def; i++) {
         cb_entry_t *e = &l_to_copy->cbs.bb[i];
         if (!e->pri.valid)
@@ -1398,11 +1398,10 @@ drmgr_unregister_bb_instrumentation_ex_event(drmgr_app2app_ex_cb_t app2app_func,
 
 DR_EXPORT
 bool
-drmgr_register_opcode_instrumentation_event(
-    drmgr_opcode_insertion_cb_t opcode_insertion_func, int opcode,
-    drmgr_priority_t *priority)
+drmgr_register_opcode_instrumentation_event(drmgr_opcode_insertion_cb_t func, int opcode,
+                                            drmgr_priority_t *priority)
 {
-    if (opcode_insertion_func == NULL)
+    if (func == NULL)
         return false;
 
     dr_rwlock_write_lock(opcode_table_lock);
@@ -1417,16 +1416,16 @@ drmgr_register_opcode_instrumentation_event(
     }
     dr_rwlock_write_unlock(opcode_table_lock);
 
-    return drmgr_bb_cb_add(opcode_cb_list, NULL, NULL, NULL, NULL, NULL, NULL,
-                           opcode_insertion_func, priority);
+    return drmgr_bb_cb_add(opcode_cb_list, NULL, NULL, NULL, NULL, NULL, NULL, func,
+                           priority);
 }
 
 DR_EXPORT
 bool
-drmgr_unregister_opcode_instrumentation_event(
-    drmgr_opcode_insertion_cb_t opcode_insertion_func, int opcode)
+drmgr_unregister_opcode_instrumentation_event(drmgr_opcode_insertion_cb_t func,
+                                              int opcode)
 {
-    if (opcode_insertion_func == NULL)
+    if (func == NULL)
         return false;
 
     dr_rwlock_write_lock(opcode_table_lock);
@@ -1436,8 +1435,7 @@ drmgr_unregister_opcode_instrumentation_event(
         return false; /* there should be a cb list present in the table */
     dr_rwlock_write_unlock(opcode_table_lock);
 
-    return drmgr_bb_cb_remove(opcode_cb_list, NULL, NULL, NULL, NULL, NULL, NULL,
-                              opcode_insertion_func);
+    return drmgr_bb_cb_remove(opcode_cb_list, NULL, NULL, NULL, NULL, NULL, NULL, func);
 }
 
 DR_EXPORT

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -175,8 +175,8 @@ typedef dr_emit_flags_t (*drmgr_insertion_cb_t)(void *drcontext, void *tag,
  * will be stored.
  */
 typedef dr_emit_flags_t (*drmgr_opcode_insertion_cb_t)(void *drcontext, void *tag,
-                                                      instrlist_t *bb, instr_t *inst,
-                                                      bool for_trace, bool translating);
+                                                       instrlist_t *bb, instr_t *inst,
+                                                       bool for_trace, bool translating);
 
 /** Specifies the ordering of callbacks for \p drmgr's events */
 typedef struct _drmgr_priority_t {
@@ -473,7 +473,8 @@ DR_EXPORT
  * specific opcode \p opcode.
  *
  * More than one call-back function can be mapped to the same opcode. Their
- * execution sequence is determined by their priority \p priority if set.
+ * execution sequence is determined by their priority \p priority if set. Ordering
+ * based on priority is also taken in to account with respect to insert bb events.
  *
  * Since this call-back is triggered during instrumentation insertion,
  * same usage rules apply. The call-back is allowed to insert meta
@@ -483,9 +484,8 @@ DR_EXPORT
  * \return false upon failure.
  *
  * @param[in]  insertion_func  The opcode insertion callback to be called for the third
- * stage for a specific opcode instructions. Cannot be NULL.
+ * stage for a specific opcode instruction. Cannot be NULL.
  * @param[in]  opcode          The opcode to associate with the insertion callback.
- *                             Cannot be NULL.
  * @param[in]  priority        Specifies the relative ordering of both callbacks.
  *                             Can be NULL, in which case a default priority is used.
  *
@@ -501,6 +501,7 @@ DR_EXPORT
 /**
  * Unregisters the opcode-specific callback that
  * was registered via drmgr_register_opcode_instrumentation_event().
+ *
  * \return true if unregistration is successful and false if it is not
  * (e.g., \p func was not registered for the passed opcode \p opcode).
  *

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -476,7 +476,7 @@ DR_EXPORT
  * execution sequence is determined by their priority \p priority if set. Ordering
  * based on priority is also taken in to account with respect to insert bb events.
  *
- * Since this call-back is triggered during instrumentation insertion,
+ * Since this call-back is triggered during insert instrumentation,
  * same usage rules apply. The call-back is allowed to insert meta
  * instructions only immediately prior to the passed-in instruction.
  * New non-meta instructions cannot be inserted.

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -176,7 +176,8 @@ typedef dr_emit_flags_t (*drmgr_insertion_cb_t)(void *drcontext, void *tag,
  */
 typedef dr_emit_flags_t (*drmgr_opcode_insertion_cb_t)(void *drcontext, void *tag,
                                                        instrlist_t *bb, instr_t *inst,
-                                                       bool for_trace, bool translating);
+                                                       bool for_trace, bool translating,
+                                                       void *user_data);
 
 /** Specifies the ordering of callbacks for \p drmgr's events */
 typedef struct _drmgr_priority_t {
@@ -473,8 +474,8 @@ DR_EXPORT
  * specific opcode \p opcode.
  *
  * More than one callback function can be mapped to the same opcode. Their
- * execution sequence is determined by their priority \p priority if set. Ordering
- * based on priority is also taken into account with respect to insert bb events.
+ * execution sequence is determined by their priority \p priority (if set). Ordering
+ * based on priority is also taken into account with respect to insert per instr events.
  *
  * Since this callback is triggered during instrumentation insertion,
  * same usage rules apply. The callback is allowed to insert meta
@@ -488,14 +489,16 @@ DR_EXPORT
  * @param[in]  opcode          The opcode to associate with the insertion callback.
  * @param[in]  priority        Specifies the relative ordering of both callbacks.
  *                             Can be NULL, in which case a default priority is used.
+ * @param[in]  user_data       User data made available when triggering the callback
+ * \p func. Can be NULL.
  *
  * \note It is possible that this callback will be triggered for meta instructions.
- * Therefore, we recommend that the callback checks for meta instructions
+ * Therefore, we recommend that the callback check for meta instructions
  * (and ignore them, typically).
  */
 bool
 drmgr_register_opcode_instrumentation_event(drmgr_opcode_insertion_cb_t func, int opcode,
-                                            drmgr_priority_t *priority);
+                                            drmgr_priority_t *priority, void *user_data);
 
 DR_EXPORT
 /**

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -111,7 +111,7 @@ extern "C" {
  * transformations on the whole instruction list.
  *
  * See #dr_emit_flags_t for an explanation of the return value.  If
- * any instrumentation pass requests DR_EMIT_STORE_TRANSLATIONS, they
+ * any instrumentation pass requests #DR_EMIT_STORE_TRANSLATIONS, they
  * will be stored.
  */
 typedef dr_emit_flags_t (*drmgr_xform_cb_t)(void *drcontext, void *tag, instrlist_t *bb,
@@ -124,7 +124,7 @@ typedef dr_emit_flags_t (*drmgr_xform_cb_t)(void *drcontext, void *tag, instrlis
  * to the third stage.
  *
  * See #dr_emit_flags_t for an explanation of the return value.  If
- * any instrumentation pass requests DR_EMIT_STORE_TRANSLATIONS, they
+ * any instrumentation pass requests #DR_EMIT_STORE_TRANSLATIONS, they
  * will be stored.
  */
 typedef dr_emit_flags_t (*drmgr_analysis_cb_t)(void *drcontext, void *tag,
@@ -143,7 +143,7 @@ typedef drmgr_analysis_cb_t drmgr_app2app_ex_cb_t;
  * transformations on the whole instruction list.
  *
  * See #dr_emit_flags_t for an explanation of the return value.  If
- * any instrumentation pass requests DR_EMIT_STORE_TRANSLATIONS, they
+ * any instrumentation pass requests #DR_EMIT_STORE_TRANSLATIONS, they
  * will be stored.
  */
 typedef dr_emit_flags_t (*drmgr_ilist_ex_cb_t)(void *drcontext, void *tag,
@@ -151,13 +151,13 @@ typedef dr_emit_flags_t (*drmgr_ilist_ex_cb_t)(void *drcontext, void *tag,
                                                bool translating, void *user_data);
 
 /**
- * Callback function for the third stage: insert instrumentation.
+ * Callback function for the third stage: instrumentation insertion.
  *
  * The \p user_data parameter contains data passed from the second
  * stage to this stage.
  *
  * See #dr_emit_flags_t for an explanation of the return value.  If
- * any instrumentation pass requests DR_EMIT_STORE_TRANSLATIONS, they
+ * any instrumentation pass requests #DR_EMIT_STORE_TRANSLATIONS, they
  * will be stored.
  */
 typedef dr_emit_flags_t (*drmgr_insertion_cb_t)(void *drcontext, void *tag,
@@ -171,7 +171,7 @@ typedef dr_emit_flags_t (*drmgr_insertion_cb_t)(void *drcontext, void *tag,
  * third stage, i.e., instrumentation insertion.
  *
  * See #dr_emit_flags_t for an explanation of the return value.  If
- * any instrumentation pass requests DR_EMIT_STORE_TRANSLATIONS, they
+ * any instrumentation pass requests #DR_EMIT_STORE_TRANSLATIONS, they
  * will be stored.
  */
 typedef dr_emit_flags_t (*drmgr_opcode_insertion_cb_t)(void *drcontext, void *tag,
@@ -290,7 +290,7 @@ DR_EXPORT
  * \return true if unregistration is successful and false if it is not
  * (e.g., \p func was not registered).
  *
- * The recommendations for #dr_unregister_bb_event() about when it
+ * The recommendations for dr_unregister_bb_event() about when it
  * is safe to unregister apply here as well.
  */
 bool
@@ -373,7 +373,7 @@ DR_EXPORT
  * \return true if unregistration is successful and false if it is not
  * (e.g., \p func was not registered).
  *
- * The recommendations for #dr_unregister_bb_event() about when it
+ * The recommendations for dr_unregister_bb_event() about when it
  * is safe to unregister apply here as well.
  */
 bool
@@ -388,7 +388,7 @@ DR_EXPORT
  * \return true if unregistration is successful and false if it is not
  * (e.g., \p func was not registered).
  *
- * The recommendations for #dr_unregister_bb_event() about when it
+ * The recommendations for dr_unregister_bb_event() about when it
  * is safe to unregister apply here as well.
  */
 bool
@@ -424,7 +424,7 @@ DR_EXPORT
  * \return true if unregistration is successful and false if it is not
  * (e.g., \p func was not registered).
  *
- * The recommendations for #dr_unregister_bb_event() about when it
+ * The recommendations for dr_unregister_bb_event() about when it
  * is safe to unregister apply here as well.
  */
 bool
@@ -456,7 +456,7 @@ DR_EXPORT
  * \return true if unregistration is successful and false if it is not
  * (e.g., \p func was not registered).
  *
- * The recommendations for #dr_unregister_bb_event() about when it
+ * The recommendations for dr_unregister_bb_event() about when it
  * is safe to unregister apply here as well.
  */
 bool
@@ -472,12 +472,12 @@ DR_EXPORT
  * insertion.  drmgr will call \p func for each instruction with the
  * specific opcode \p opcode.
  *
- * More than one call-back function can be mapped to the same opcode. Their
+ * More than one callback function can be mapped to the same opcode. Their
  * execution sequence is determined by their priority \p priority if set. Ordering
- * based on priority is also taken in to account with respect to insert bb events.
+ * based on priority is also taken into account with respect to insert bb events.
  *
- * Since this call-back is triggered during insert instrumentation,
- * same usage rules apply. The call-back is allowed to insert meta
+ * Since this callback is triggered during instrumentation insertion,
+ * same usage rules apply. The callback is allowed to insert meta
  * instructions only immediately prior to the passed-in instruction.
  * New non-meta instructions cannot be inserted.
  *
@@ -489,8 +489,8 @@ DR_EXPORT
  * @param[in]  priority        Specifies the relative ordering of both callbacks.
  *                             Can be NULL, in which case a default priority is used.
  *
- * \note It is possible that this call-back will be triggered for meta instructions.
- * Therefore, we recommend that the call-back checks for meta instructions
+ * \note It is possible that this callback will be triggered for meta instructions.
+ * Therefore, we recommend that the callback checks for meta instructions
  * (and ignore them, typically).
  */
 bool
@@ -505,7 +505,7 @@ DR_EXPORT
  * \return true if unregistration is successful and false if it is not
  * (e.g., \p func was not registered for the passed opcode \p opcode).
  *
- * The recommendations for #dr_unregister_bb_event() about when it
+ * The recommendations for dr_unregister_bb_event() about when it
  * is safe to unregister apply here as well.
  */
 bool

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -151,7 +151,7 @@ typedef dr_emit_flags_t (*drmgr_ilist_ex_cb_t)(void *drcontext, void *tag,
                                                bool translating, void *user_data);
 
 /**
- * Callback function for the third stage: instrumentation insertion.
+ * Callback function for the third stage: insert instrumentation.
  *
  * The \p user_data parameter contains data passed from the second
  * stage to this stage.
@@ -494,8 +494,8 @@ DR_EXPORT
  * (and ignore them, typically).
  */
 bool
-drmgr_register_opcode_instrumentation_event(drmgr_opcode_insertion_cb_t insertion_func,
-                                            int opcode, drmgr_priority_t *priority);
+drmgr_register_opcode_instrumentation_event(drmgr_opcode_insertion_cb_t func, int opcode,
+                                            drmgr_priority_t *priority);
 
 DR_EXPORT
 /**
@@ -509,7 +509,7 @@ DR_EXPORT
  * is safe to unregister apply here as well.
  */
 bool
-drmgr_unregister_opcode_instrumentation_event(drmgr_opcode_insertion_cb_t insertion_func,
+drmgr_unregister_opcode_instrumentation_event(drmgr_opcode_insertion_cb_t func,
                                               int opcode);
 
 DR_EXPORT

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -483,7 +483,7 @@ DR_EXPORT
  *
  * \return false upon failure.
  *
- * @param[in]  insertion_func  The opcode insertion callback to be called for the third
+ * @param[in]  func  The opcode insertion callback to be called for the third
  * stage for a specific opcode instruction. Cannot be NULL.
  * @param[in]  opcode          The opcode to associate with the insertion callback.
  * @param[in]  priority        Specifies the relative ordering of both callbacks.

--- a/suite/tests/client-interface/drmgr-test.dll.c
+++ b/suite/tests/client-interface/drmgr-test.dll.c
@@ -58,6 +58,9 @@ static int tls_idx;
 static int cls_idx;
 static thread_id_t main_thread;
 static int cb_depth;
+static volatile bool in_opcode_A;
+static volatile bool in_insert_B;
+static volatile bool in_opcode_C;
 static volatile bool in_syscall_A;
 static volatile bool in_syscall_A_user_data;
 static volatile bool in_syscall_B;
@@ -77,6 +80,7 @@ static int thread_exit_null_user_data_events;
 static int mod_load_events;
 static int mod_unload_events;
 
+static void *opcodelock;
 static void *syslock;
 static void *threadlock;
 static uint one_time_exec;
@@ -138,6 +142,16 @@ event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
 static dr_emit_flags_t
 event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
                 bool for_trace, bool translating, void *user_data);
+
+static dr_emit_flags_t
+event_opcode_add_insert_A(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
+                          bool for_trace, bool translating);
+static dr_emit_flags_t
+event_bb_insert_B(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
+                  bool for_trace, bool translating, void *user_data);
+static dr_emit_flags_t
+event_opcode_add_insert_C(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
+                          bool for_trace, bool translating);
 
 static dr_emit_flags_t
 event_bb4_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
@@ -209,6 +223,12 @@ dr_init(client_id_t id)
     drmgr_priority_t thread_exit_null_user_data_pri = { sizeof(priority),
                                                         "drmgr-t-exit-null-usr-data-test",
                                                         NULL, NULL, 3 };
+    drmgr_priority_t opcode_pri_A = { sizeof(priority), "drmgr-opcode-test-A", NULL, NULL,
+                                      5 };
+    drmgr_priority_t insert_pri_B = { sizeof(priority), "drmgr-opcode-test-B", NULL, NULL,
+                                      6 };
+    drmgr_priority_t opcode_pri_C = { sizeof(priority), "drmgr-opcode-test-C", NULL, NULL,
+                                      7 };
 
 #ifdef UNIX
     drmgr_priority_t signal_user_data = { sizeof(priority), "drmgr-signal-usr-data-test",
@@ -250,6 +270,17 @@ dr_init(client_id_t id)
     ok = drmgr_register_bb_instrumentation_event(event_bb_analysis, event_bb_insert,
                                                  &priority);
     CHECK(ok, "drmgr register bb failed");
+
+    ok = drmgr_register_opcode_instrumentation_event(event_opcode_add_insert_A, OP_add,
+                                                     &opcode_pri_A);
+    CHECK(ok, "drmgr register opcode failed");
+
+    ok = drmgr_register_bb_instrumentation_event(NULL, event_bb_insert_B, &insert_pri_B);
+    CHECK(ok, "drmgr register bb failed");
+
+    ok = drmgr_register_opcode_instrumentation_event(event_opcode_add_insert_C, OP_add,
+                                                     &opcode_pri_C);
+    CHECK(ok, "drmgr register opcode failed");
 
     /* check register/unregister instrumentation_ex */
     ok = drmgr_register_bb_instrumentation_ex_event(event_bb4_app2app, event_bb4_analysis,
@@ -298,6 +329,7 @@ dr_init(client_id_t id)
                                                     (void *)syscall_B_user_data_test);
     CHECK(ok, "drmgr register sys failed");
 
+    opcodelock = dr_mutex_create();
     syslock = dr_mutex_create();
     threadlock = dr_mutex_create();
 
@@ -315,6 +347,7 @@ dr_init(client_id_t id)
 static void
 event_exit(void)
 {
+    dr_mutex_destroy(opcodelock);
     dr_mutex_destroy(syslock);
     dr_mutex_destroy(threadlock);
     CHECK(checked_tls_from_cache, "failed to hit clean call");
@@ -351,6 +384,15 @@ event_exit(void)
             event_bb4_app2app, event_bb4_analysis, event_bb4_insert,
             event_bb4_instru2instru))
         CHECK(false, "drmgr unregistration failed");
+
+    if (!drmgr_unregister_opcode_instrumentation_event(event_opcode_add_insert_A, OP_add))
+        CHECK(false, "drmgr opcode unregistration failed");
+
+    if (!drmgr_unregister_bb_insertion_event(event_bb_insert_B))
+        CHECK(false, "drmgr opcode unregistration failed");
+
+    if (!drmgr_unregister_opcode_instrumentation_event(event_opcode_add_insert_C, OP_add))
+        CHECK(false, "drmgr opcode unregistration failed");
 
     if (!drmgr_unregister_module_load_event_user_data(event_mod_load))
         CHECK(false, "drmgr mod load unregistration failed");
@@ -620,6 +662,58 @@ event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
         dr_restore_reg(drcontext, bb, inst, reg2, SPILL_SLOT_2);
         dr_restore_reg(drcontext, bb, inst, reg1, SPILL_SLOT_1);
     }
+    return DR_EMIT_DEFAULT;
+}
+
+static dr_emit_flags_t
+event_opcode_add_insert_A(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
+                          bool for_trace, bool translating)
+{
+    CHECK(instr_get_opcode(inst) == OP_add, "incorrect opcode");
+
+    if (!in_opcode_A) {
+        dr_mutex_lock(opcodelock);
+        if (!in_opcode_A) {
+            dr_fprintf(STDERR, "in insert A\n");
+            in_opcode_A = true;
+        }
+        dr_mutex_unlock(opcodelock);
+    }
+
+    return DR_EMIT_DEFAULT;
+}
+
+static dr_emit_flags_t
+event_bb_insert_B(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
+                  bool for_trace, bool translating, void *user_data)
+{
+    if (!in_insert_B && instr_get_opcode(inst) == OP_add) {
+        dr_mutex_lock(opcodelock);
+        if (!in_insert_B) {
+            dr_fprintf(STDERR, "in insert B\n");
+            in_insert_B = true;
+        }
+        dr_mutex_unlock(opcodelock);
+    }
+
+    return DR_EMIT_DEFAULT;
+}
+
+static dr_emit_flags_t
+event_opcode_add_insert_C(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
+                          bool for_trace, bool translating)
+{
+    CHECK(instr_get_opcode(inst) == OP_add, "incorrect opcode");
+
+    if (!in_opcode_C) {
+        dr_mutex_lock(opcodelock);
+        if (!in_opcode_C) {
+            dr_fprintf(STDERR, "in insert C\n");
+            in_opcode_C = true;
+        }
+        dr_mutex_unlock(opcodelock);
+    }
+
     return DR_EMIT_DEFAULT;
 }
 

--- a/suite/tests/client-interface/drmgr-test.templatex
+++ b/suite/tests/client-interface/drmgr-test.templatex
@@ -2,6 +2,9 @@ in event_thread_init_null_user_data
 in event_thread_init_user_data
 in event_thread_init_ex
 in event_thread_init
+in insert A
+in insert B
+in insert C
 in pre_sys_B_user_data
 in pre_sys_B
 in pre_sys_A_user_data


### PR DESCRIPTION
Adds the support of instrumentation events specific to opcode instructions to drmgr. In particular, two new API functions are introduced: drmgr_register_opcode_instrumentation_event() and drmgr_unregister_opcode_instrumentation_event().

drmgr_register_opcode_instrumentation_event() takes a call-back function and an opcode as input. The call-back is triggered during the insert per instruction stage (i.e., stage 3) only for those instructions that have the specified opcode.

Call-backs pertaining to an opcode are maintained via a hashtable. 

Some care is taken to avoid any performance hits if opcode events are not registered. For instance, with the use of flags, the code avoids locking or hash-lookups if opcode events are never registered by the user.

In order to ensure call-backs pertaining to insert-bb and insert-opcode events are jointly triggered in the right order, with respect to their priorities, drmgr combines them into a single list on the fly by performing lookups. I avoided using one monolithic cb list as clients with a long list of different registered opcode events would have required drmgr to do wasteful iterations.

Fixes: #4280