### PR TITLE
i#4280: Adds a sample highlighting opcode instrumentation.

### DIFF
--- a/api/docs/samples.dox
+++ b/api/docs/samples.dox
@@ -118,6 +118,9 @@ produces a binary-format trace file.
 The sample <a href="https://github.com/DynamoRIO/dynamorio/tree/master/api/samples/hot_bbcount.c">hot_bbcount.c</a>
 uses the drbbdup extension to count the execution of hot basic blocks which have exceeded a given hit threshold.
 
+The sample <a href="https://github.com/DynamoRIO/dynamorio/tree/master/api/samples/opcode_count.cpp">opcode_count.cpp</a>
+takes an opcode as input and uses drmgr's instrumentation events to count the number of times the instruction is executed.
+
 The sample <a href="https://github.com/DynamoRIO/dynamorio/tree/master/api/samples/modxfer.c">modxfer.c</a>
 reports the control flow transfers between modules.
 

--- a/api/docs/samples.dox
+++ b/api/docs/samples.dox
@@ -119,7 +119,7 @@ The sample <a href="https://github.com/DynamoRIO/dynamorio/tree/master/api/sampl
 uses the drbbdup extension to count the execution of hot basic blocks which have exceeded a given hit threshold.
 
 The sample <a href="https://github.com/DynamoRIO/dynamorio/tree/master/api/samples/opcode_count.cpp">opcode_count.cpp</a>
-takes an opcode as input and uses drmgr's instrumentation events to count the number of times instruction with that opcode
+takes an opcode as input and uses drmgr's instrumentation events to count the number of times instructions with that opcode
 are executed.
 
 The sample <a href="https://github.com/DynamoRIO/dynamorio/tree/master/api/samples/modxfer.c">modxfer.c</a>

--- a/api/docs/samples.dox
+++ b/api/docs/samples.dox
@@ -119,7 +119,8 @@ The sample <a href="https://github.com/DynamoRIO/dynamorio/tree/master/api/sampl
 uses the drbbdup extension to count the execution of hot basic blocks which have exceeded a given hit threshold.
 
 The sample <a href="https://github.com/DynamoRIO/dynamorio/tree/master/api/samples/opcode_count.cpp">opcode_count.cpp</a>
-takes an opcode as input and uses drmgr's instrumentation events to count the number of times the instruction is executed.
+takes an opcode as input and uses drmgr's instrumentation events to count the number of times instruction with that opcode
+are executed.
 
 The sample <a href="https://github.com/DynamoRIO/dynamorio/tree/master/api/samples/modxfer.c">modxfer.c</a>
 reports the control flow transfers between modules.

--- a/api/samples/CMakeLists.txt
+++ b/api/samples/CMakeLists.txt
@@ -212,6 +212,7 @@ add_sample_client(empty       "empty.c"         "")
 add_sample_client(memtrace_simple "memtrace_simple.c;utils.c" "drmgr;drreg;drutil;drx")
 add_sample_client(memval_simple   "memval_simple.c;utils.c"   "drmgr;drreg;drutil;drx")
 add_sample_client(instrace_simple "instrace_simple.c;utils.c" "drmgr;drreg;drx")
+add_sample_client(opcode_count    "opcode_count.cpp"    "drmgr;drreg;drx;droption")
 if (X86) # FIXME i#1551, i#1569: port to ARM and AArch64
   add_sample_client(cbr         "cbr.c"           "drmgr")
   add_sample_client(countcalls  "countcalls.c"    "drmgr;drreg")

--- a/api/samples/opcode_count.cpp
+++ b/api/samples/opcode_count.cpp
@@ -1,0 +1,169 @@
+/* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Code Manipulation API Sample:
+ * opcode_count.c
+ *
+ * Reports the dynamic execution count of all instructions with a particular opcode.
+ * Illustrates how to to use drmgr to register opcode events and inline atomic
+ * counter code.
+ */
+
+#include <stdint.h> /* for intptr */
+#include <stddef.h> /* for offsetof */
+#include "dr_api.h"
+#include "drmgr.h"
+#include "drreg.h"
+#include "drx.h"
+#include "droption.h"
+
+#define SHOW_RESULTS 1
+
+#ifdef WINDOWS
+#    define DISPLAY_STRING(msg) dr_messagebox(msg)
+#else
+#    define DISPLAY_STRING(msg) dr_printf("%s\n", msg);
+#endif
+
+#define NULL_TERMINATE(buf) (buf)[(sizeof((buf)) / sizeof((buf)[0])) - 1] = '\0'
+
+static droption_t<int> opcode(DROPTION_SCOPE_CLIENT, "opcode", -1,
+                              "The opcode to consider",
+                              "The opcode to consider when counting the number of times "
+                              "the instruction is executed.");
+
+static uintptr_t global_opcode_count = 0;
+static uintptr_t global_total_count = 0;
+
+static void
+event_exit(void)
+{
+#ifdef SHOW_RESULTS
+    char msg[512];
+    int len;
+    len = dr_snprintf(msg, sizeof(msg) / sizeof(msg[0]), "%u/%u instructions executed\n",
+                      global_opcode_count, global_total_count);
+    DR_ASSERT(len > 0);
+    NULL_TERMINATE(msg);
+    DISPLAY_STRING(msg);
+#endif /* SHOW_RESULTS */
+    drx_exit();
+    drreg_exit();
+    drmgr_exit();
+}
+
+static dr_emit_flags_t
+event_opcode_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
+                         bool for_trace, bool translating, void *user_data)
+{
+    /* Insert code to update the counter for tracking the number of executed instructions
+     * having the specified opcode.
+     */
+    drx_insert_counter_update(drcontext, bb, inst,
+                              /* We're using drmgr, so these slots
+                               * here won't be used: drreg's slots will be.
+                               */
+                              static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1),
+                              IF_AARCHXX_(SPILL_SLOT_MAX + 1) & global_opcode_count, 1,
+                              DRX_COUNTER_LOCK);
+
+    return DR_EMIT_DEFAULT;
+}
+
+static dr_emit_flags_t
+event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
+                      bool for_trace, bool translating, void *user_data)
+{
+
+    /* By default drmgr enables auto-predication, which predicates all instructions with
+     * the predicate of the current instruction on ARM.
+     * We disable it here because we want to unconditionally execute the following
+     * instrumentation.
+     */
+    drmgr_disable_auto_predication(drcontext, bb);
+    if (!drmgr_is_first_instr(drcontext, inst))
+        return DR_EMIT_DEFAULT;
+
+    /* racy update on the counter for better performance */
+    drx_insert_counter_update(drcontext, bb, inst,
+                              /* We're using drmgr, so these slots
+                               * here won't be used: drreg's slots will be.
+                               */
+                              static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1),
+                              IF_AARCHXX_(SPILL_SLOT_MAX + 1) & global_total_count, 1,
+                              DRX_COUNTER_LOCK);
+
+    return DR_EMIT_DEFAULT;
+}
+
+DR_EXPORT void
+dr_client_main(client_id_t id, int argc, const char *argv[])
+{
+    /* Options */
+    if (!droption_parser_t::parse_argv(DROPTION_SCOPE_CLIENT, argc, argv, NULL, NULL))
+        DR_ASSERT(false);
+
+    /* get opcode and check if valid */
+    int valid_opcode = opcode.get_value();
+
+    if (valid_opcode < OP_FIRST || valid_opcode > OP_LAST) {
+        dr_fprintf(STDERR, "Error: give a valid opcode as a parameter\n");
+        dr_abort();
+    }
+
+    drreg_options_t ops = { sizeof(ops), 1 /*max slots needed: aflags*/, false };
+    dr_set_client_name("DynamoRIO Sample Client 'opcode_count'",
+                       "http://dynamorio.org/issues");
+    if (!drmgr_init() || !drx_init() || drreg_init(&ops) != DRREG_SUCCESS)
+        DR_ASSERT(false);
+
+    /* register opcode event */
+    dr_register_exit_event(event_exit);
+    if (!drmgr_register_opcode_instrumentation_event(event_opcode_instruction,
+                                                     valid_opcode, NULL, NULL) ||
+        !drmgr_register_bb_instrumentation_event(NULL, event_app_instruction, NULL))
+        DR_ASSERT(false);
+
+    /* make it easy to tell, by looking at log file, which client executed */
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'opcode_count' initializing\n");
+#ifdef SHOW_RESULTS
+    /* also give notification to stderr */
+    if (dr_is_notify_on()) {
+#    ifdef WINDOWS
+        /* ask for best-effort printing to cmd window.  must be called at init. */
+        dr_enable_console_printing();
+#    endif
+        dr_fprintf(STDERR, "Client opcode_count is running and considering opcode: %d.\n",
+                   valid_opcode);
+    }
+#endif
+}

--- a/api/samples/opcode_count.cpp
+++ b/api/samples/opcode_count.cpp
@@ -138,8 +138,6 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 #ifdef SHOW_RESULTS
         dr_fprintf(STDERR, "Error: give a valid opcode as a parameter.\n");
         dr_abort();
-#else
-        dr_abort_with_code(0); /* just exist now since no results are wanted. */
 #endif
     }
 

--- a/api/samples/opcode_count.cpp
+++ b/api/samples/opcode_count.cpp
@@ -86,13 +86,15 @@ event_opcode_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *i
     /* Insert code to update the counter for tracking the number of executed instructions
      * having the specified opcode.
      */
-    drx_insert_counter_update(drcontext, bb, inst,
-                              /* We're using drmgr, so these slots
-                               * here won't be used: drreg's slots will be.
-                               */
-                              static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1),
-                              IF_AARCHXX_(SPILL_SLOT_MAX + 1) & global_opcode_count, 1,
-                              DRX_COUNTER_LOCK);
+    drx_insert_counter_update(
+        drcontext, bb, inst,
+        /* We're using drmgr, so these slots
+         * here won't be used: drreg's slots will be.
+         */
+        static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1),
+        IF_AARCHXX_(static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1)) &
+            global_opcode_count,
+        1, DRX_COUNTER_LOCK);
 
     return DR_EMIT_DEFAULT;
 }
@@ -110,13 +112,15 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     if (!drmgr_is_first_instr(drcontext, inst))
         return DR_EMIT_DEFAULT;
 
-    drx_insert_counter_update(drcontext, bb, inst,
-                              /* We're using drmgr, so these slots
-                               * here won't be used: drreg's slots will be.
-                               */
-                              static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1),
-                              IF_AARCHXX_(SPILL_SLOT_MAX + 1) & global_total_count, 1,
-                              DRX_COUNTER_LOCK);
+    drx_insert_counter_update(
+        drcontext, bb, inst,
+        /* We're using drmgr, so these slots
+         * here won't be used: drreg's slots will be.
+         */
+        static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1),
+        IF_AARCHXX_(static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1)) &
+            global_total_count,
+        1, DRX_COUNTER_LOCK);
 
     return DR_EMIT_DEFAULT;
 }

--- a/api/samples/opcode_count.cpp
+++ b/api/samples/opcode_count.cpp
@@ -54,9 +54,10 @@
 
 #define NULL_TERMINATE(buf) (buf)[(sizeof((buf)) / sizeof((buf)[0])) - 1] = '\0'
 
-static droption_t<int> opcode(DROPTION_SCOPE_CLIENT, "opcode", -1, "The opcode to count",
-                              "The opcode to consider when counting the number of times "
-                              "the instruction is executed.");
+static droption_t<int>
+    opcode(DROPTION_SCOPE_CLIENT, "opcode", OP_add, "The opcode to count",
+           "The opcode to consider when counting the number of times "
+           "the instruction is executed. Default opcode is set to add.");
 
 static uintptr_t global_opcode_count = 0;
 static uintptr_t global_total_count = 0;
@@ -135,7 +136,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     int valid_opcode = opcode.get_value();
     if (valid_opcode < OP_FIRST || valid_opcode > OP_LAST) {
 #ifdef SHOW_RESULTS
-        dr_fprintf(STDERR, "Error: give a valid opcode as a parameter\n");
+        dr_fprintf(STDERR, "Error: give a valid opcode as a parameter.\n");
         dr_abort();
 #else
         dr_abort_with_code(0); /* just exist now since no results are wanted. */

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -594,13 +594,22 @@ cblist_shift_and_resize(cb_list_t *l, uint insert_at)
 static void
 cblist_insert_other(cb_list_t *l, cb_list_t *l_to_copy)
 {
+    drmgr_priority_t *pri = NULL;
     ASSERT(l->entry_sz == l_to_copy->entry_sz, "must be of the same size");
     size_t i;
     for (i = 0; i < l_to_copy->num_def; i++) {
         cb_entry_t *e = &l_to_copy->cbs.bb[i];
         if (!e->pri.valid)
             continue;
-        int idx = priority_event_add(l, &e->pri.in_priority);
+
+        pri = &e->pri.in_priority;
+        if (strcmp(pri->name, default_priority.name) == 0) {
+            /* Nullify here so that we do not bypass user validation done by
+             * priority_event_add. */
+            pri = NULL;
+        }
+
+        int idx = priority_event_add(l, pri);
         if (idx >= 0) {
             cb_entry_t *new_e = &l->cbs.bb[idx];
             *new_e = *e;
@@ -617,6 +626,8 @@ cblist_copy(cb_list_t *src, cb_list_t *dst)
     ASSERT(src->num_def <= dst->capacity, "dst must have large enough capacity");
     dst->entry_sz = src->entry_sz;
     dst->num_def = src->num_def;
+    dst->num_valid = src->num_valid;
+
     memcpy(dst->cbs.array, src->cbs.array, src->num_def * src->entry_sz);
 }
 
@@ -650,6 +661,7 @@ cblist_delete_local(void *drcontext, cb_list_t *l, size_t local_num)
 static void
 cblist_create_global(cb_list_t *src, cb_list_t *dst)
 {
+    memset(dst, 0, sizeof(cb_list_t));
     dst->capacity = src->capacity;
     dst->cbs.array = dr_global_alloc(src->capacity * src->entry_sz);
     cblist_copy(src, dst);

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -627,7 +627,6 @@ cblist_copy(cb_list_t *src, cb_list_t *dst)
     dst->entry_sz = src->entry_sz;
     dst->num_def = src->num_def;
     dst->num_valid = src->num_valid;
-
     memcpy(dst->cbs.array, src->cbs.array, src->num_def * src->entry_sz);
 }
 

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -660,7 +660,7 @@ cblist_delete_local(void *drcontext, cb_list_t *l, size_t local_num)
 static void
 cblist_create_global(cb_list_t *src, cb_list_t *dst)
 {
-    memset(dst, 0, sizeof(cb_list_t));
+    memset(dst, 0, sizeof(*dst));
     dst->capacity = src->capacity;
     dst->cbs.array = dr_global_alloc(src->capacity * src->entry_sz);
     cblist_copy(src, dst);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2775,7 +2775,7 @@ endif ()
                 client-interface/memval-test.c "" "" "")
           endif(X86 AND (NOT X64) AND UNIX)
         elseif (sample STREQUAL "opcode_count")
-          torunonly_ci(sample.${sample}.cleancall common.${control_flags} ${sample}
+          torunonly_ci(sample.${sample} common.${control_flags} ${sample}
             common/${control_flags}.c "" "-opt_opcode 5" "")
         endif()
       endforeach ()

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2774,6 +2774,9 @@ endif ()
             torunonly_ci(sample.${sample} client.memval-test ${sample}
                 client-interface/memval-test.c "" "" "")
           endif(X86 AND (NOT X64) AND UNIX)
+        elseif (sample STREQUAL "opcode_count")
+          torunonly_ci(sample.${sample}.cleancall common.${control_flags} ${sample}
+            common/${control_flags}.c "" "-opt_opcode 5" "")
         endif()
       endforeach ()
     endif (NOT ANDROID)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2776,7 +2776,7 @@ endif ()
           endif(X86 AND (NOT X64) AND UNIX)
         elseif (sample STREQUAL "opcode_count")
           torunonly_ci(sample.${sample} common.${control_flags} ${sample}
-            common/${control_flags}.c "" "-opt_opcode 5" "")
+            common/${control_flags}.c "" "-opcode 5" "")
         endif()
       endforeach ()
     endif (NOT ANDROID)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2776,7 +2776,7 @@ endif ()
           endif(X86 AND (NOT X64) AND UNIX)
         elseif (sample STREQUAL "opcode_count")
           torunonly_ci(sample.${sample} common.${control_flags} ${sample}
-            common/${control_flags}.c "" "-opcode 5" "")
+            common/${control_flags}.c "-opcode 5" "" "")
         endif()
       endforeach ()
     endif (NOT ANDROID)


### PR DESCRIPTION
Adds a new sample client to show how drmgr's opcode instrumentation can be used to count the number of executions of an instruction (with a specific opcode). The opcode number is given by the user as a parameter (the client uses droptions for parsing).

In addition, the PR also includes a bug fix in drmgr. In particular, drmgr was confusing the default priority as a different priority when used again for another event registration. The bug was only triggered if cblist_insert_other() is used - this function is only called for opcode registration at the moment so the bug's severity is low.   