### PR TITLE
i#1356: Break down instrumentation pass

### DIFF
--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -209,7 +209,7 @@ typedef struct _local_ctx_t {
     cb_list_t iter_app2app;
     cb_list_t iter_insert;
     cb_list_t iter_instru;
-    /* used as stack storage by the cb is large enough: */
+    /* used as stack storage by the cb if large enough: */
     cb_entry_t app2app[EVENTS_STACK_SZ];
     cb_entry_t insert[EVENTS_STACK_SZ];
     cb_entry_t instru[EVENTS_STACK_SZ];

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -1017,9 +1017,10 @@ drmgr_bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     drmgr_bb_event_set_local_cb_info(drcontext, &local_info);
 
     /* We need per-thread user_data */
-    if (local_info.pair_count > 0)
+    if (local_info.pair_count > 0) {
         pair_data =
             (void **)dr_thread_alloc(drcontext, sizeof(void *) * local_info.pair_count);
+    }
     if (local_info.quartet_count > 0) {
         quartet_data = (void **)dr_thread_alloc(
             drcontext, sizeof(void *) * local_info.quartet_count);


### PR DESCRIPTION
Breaks down the code intended for copying cb information to local temporary storage into smaller helper functions. The main instrumentation pass of a basic block is also moved to a separate helper function.

This is a preliminary PR to help with the integration of drbbdup and drmgr.

Issue: #1356
