### PR TITLE
i#4291: append to LD_PRELOAD when using -late

### DIFF
--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -213,16 +213,18 @@ report_dynamorio_problem(dcontext_t *dcontext, uint dumpcore_flag, app_pc except
 static void
 pre_execve_ld_preload(const char *dr_path)
 {
-    char ld_preload_libs[MAX_OPTIONS_STRING];
     char ld_lib_path[MAX_OPTIONS_STRING];
     const char *last_slash = NULL;
     const char *mode_slash = NULL;
     const char *lib_slash = NULL;
+    const char *cur_path = getenv("LD_LIBRARY_PATH");
+    const char *cur = dr_path;
+#ifdef LINUX
+    char ld_preload_libs[MAX_OPTIONS_STRING];
     const char *ld_preload = NULL;
     const char *dr_ld_preload_libs = "libdynamorio.so libdrpreload.so";
     const char *cur_preload = getenv("LD_PRELOAD");
-    const char *cur_path = getenv("LD_LIBRARY_PATH");
-    const char *cur = dr_path;
+#endif
     /* Find last three occurrences of '/'. */
     while (*cur != '\0') {
         if (*cur == '/') {

--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -259,9 +259,8 @@ pre_execve_ld_preload(const char *dr_path)
     setenv("DYLD_LIBRARY_PATH", ld_lib_path, true /*overwrite*/);
     /* XXX: why does it not work w/o the full path? */
     snprintf(ld_lib_path, BUFFER_SIZE_ELEMENTS(ld_lib_path), "%s%.*s/%s:%.*s/%s",
-             preload_prefix,
-             last_slash - dr_path, dr_path, "libdrpreload.dylib", last_slash - dr_path,
-             dr_path, "libdynamorio.dylib");
+             preload_prefix, last_slash - dr_path, dr_path, "libdrpreload.dylib",
+             last_slash - dr_path, dr_path, "libdynamorio.dylib");
     NULL_TERMINATE_BUFFER(ld_lib_path);
 
     setenv("DYLD_INSERT_LIBRARIES", ld_lib_path, true /*overwrite*/);
@@ -273,8 +272,8 @@ pre_execve_ld_preload(const char *dr_path)
 #else
     setenv("LD_LIBRARY_PATH", ld_lib_path, true /*overwrite*/);
 
-    snprintf(ld_lib_path, BUFFER_SIZE_ELEMENTS(ld_lib_path), "%s%s",
-             preload_prefix, "libdynamorio.so libdrpreload.so");
+    snprintf(ld_lib_path, BUFFER_SIZE_ELEMENTS(ld_lib_path), "%s%s", preload_prefix,
+             "libdynamorio.so libdrpreload.so");
     NULL_TERMINATE_BUFFER(ld_lib_path);
 
     setenv("LD_PRELOAD", ld_lib_path, true /*overwrite*/);

--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -214,16 +214,18 @@ static void
 pre_execve_ld_preload(const char *dr_path)
 {
     char ld_lib_path[MAX_OPTIONS_STRING];
+    char preload_prefix[MAX_OPTIONS_STRING];
     const char *last_slash = NULL;
     const char *mode_slash = NULL;
     const char *lib_slash = NULL;
     const char *cur_path = getenv("LD_LIBRARY_PATH");
     const char *cur = dr_path;
-#ifdef LINUX
-    char ld_preload_libs[MAX_OPTIONS_STRING];
-    const char *ld_preload = NULL;
-    const char *dr_ld_preload_libs = "libdynamorio.so libdrpreload.so";
+#ifdef MACOS
+    const char *cur_preload = getenv("DYLD_INSERT_LIBRARIES");
+    const char preload_delimiter = ':';
+#else
     const char *cur_preload = getenv("LD_PRELOAD");
+    const char preload_delimiter = ' ';
 #endif
     /* Find last three occurrences of '/'. */
     while (*cur != '\0') {
@@ -246,12 +248,22 @@ pre_execve_ld_preload(const char *dr_path)
              last_slash - lib_slash, lib_slash, /* libNN component */
              cur_path == NULL ? "" : ":", cur_path == NULL ? "" : cur_path);
     NULL_TERMINATE_BUFFER(ld_lib_path);
+
+    preload_prefix[0] = '\0';
+    if (cur_preload != NULL) {
+        snprintf(preload_prefix, BUFFER_SIZE_ELEMENTS(preload_prefix), "%s%c",
+                 cur_preload, preload_delimiter);
+        NULL_TERMINATE_BUFFER(preload_prefix);
+    }
 #ifdef MACOS
     setenv("DYLD_LIBRARY_PATH", ld_lib_path, true /*overwrite*/);
     /* XXX: why does it not work w/o the full path? */
-    snprintf(ld_lib_path, BUFFER_SIZE_ELEMENTS(ld_lib_path), "%.*s/%s:%.*s/%s",
+    snprintf(ld_lib_path, BUFFER_SIZE_ELEMENTS(ld_lib_path), "%s%.*s/%s:%.*s/%s",
+             preload_prefix,
              last_slash - dr_path, dr_path, "libdrpreload.dylib", last_slash - dr_path,
              dr_path, "libdynamorio.dylib");
+    NULL_TERMINATE_BUFFER(ld_lib_path);
+
     setenv("DYLD_INSERT_LIBRARIES", ld_lib_path, true /*overwrite*/);
     /* This is required to use DYLD_INSERT_LIBRARIES on apps that use
      * two-level naming, but it can cause an app to run incorrectly.
@@ -261,16 +273,11 @@ pre_execve_ld_preload(const char *dr_path)
 #else
     setenv("LD_LIBRARY_PATH", ld_lib_path, true /*overwrite*/);
 
-    if (cur_preload != NULL) {
-        snprintf(ld_preload_libs, BUFFER_SIZE_ELEMENTS(ld_preload_libs), "%s %s",
-                 cur_preload, dr_ld_preload_libs);
-        NULL_TERMINATE_BUFFER(ld_preload_libs);
-        ld_preload = ld_preload_libs;
-    } else {
-        ld_preload = dr_ld_preload_libs;
-    }
+    snprintf(ld_lib_path, BUFFER_SIZE_ELEMENTS(ld_lib_path), "%s%s",
+             preload_prefix, "libdynamorio.so libdrpreload.so");
+    NULL_TERMINATE_BUFFER(ld_lib_path);
 
-    setenv("LD_PRELOAD", ld_preload, true /*overwrite*/);
+    setenv("LD_PRELOAD", ld_lib_path, true /*overwrite*/);
 #endif
     if (verbose) {
         printf("Setting LD_USE_LOAD_BIAS for PIEs so the loader will honor "


### PR DESCRIPTION
When using -late, append to LD_PRELOAD rather than overwrite it.

Fixes #4291