### PR TITLE
i#4134: Adds an internal interface to drmgr

### DIFF
--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -1021,7 +1021,6 @@ drmgr_bb_event_instrument_dups(void *drcontext, void *tag, instrlist_t *bb,
         local_info->bbdup_insert_encoding_cb(drcontext, tag, bb, for_trace, translating,
                                              local_dup_info);
     }
-
     return is_dups;
 }
 
@@ -1099,7 +1098,8 @@ drmgr_bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     }
 
     bool is_dups = false;
-    if (local_info->is_bbdup_enabled /*only true if drbbdup is in use */) {
+    /*only true if drbbdup is in use */
+    if (local_info.is_bbdup_enabled) {
         is_dups = drmgr_bb_event_instrument_dups(drcontext, tag, bb, for_trace,
                                                  translating, &res, pt, &local_info,
                                                  pair_data, quartet_data);

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -1098,7 +1098,7 @@ drmgr_bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     }
 
     bool is_dups = false;
-    /*only true if drbbdup is in use */
+    /* Only true if drbbdup is in use. */
     if (local_info.is_bbdup_enabled) {
         is_dups = drmgr_bb_event_instrument_dups(drcontext, tag, bb, for_trace,
                                                  translating, &res, pt, &local_info,

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -209,7 +209,7 @@ typedef struct _local_ctx_t {
     cb_list_t iter_app2app;
     cb_list_t iter_insert;
     cb_list_t iter_instru;
-    /* used as stack storage by the cb is large enough: */
+    /* used as stack storage by the cb if large enough: */
     cb_entry_t app2app[EVENTS_STACK_SZ];
     cb_entry_t insert[EVENTS_STACK_SZ];
     cb_entry_t instru[EVENTS_STACK_SZ];

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -1017,9 +1017,10 @@ drmgr_bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     drmgr_bb_event_set_local_cb_info(drcontext, &local_info);
 
     /* We need per-thread user_data */
-    if (local_info.pair_count > 0)
+    if (local_info.pair_count > 0) {
         pair_data =
             (void **)dr_thread_alloc(drcontext, sizeof(void *) * local_info.pair_count);
+    }
     if (local_info.quartet_count > 0) {
         quartet_data = (void **)dr_thread_alloc(
             drcontext, sizeof(void *) * local_info.quartet_count);

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -221,6 +221,7 @@ typedef struct _local_ctx_t {
     int pair_count;
     int quartet_count;
     /* for bbdup events: */
+    bool is_bbdup_enabled;
     drmgr_bbdup_duplicate_bb_cb_t bbdup_duplicate_cb;
     drmgr_bbdup_extract_cb_t bbdup_extract_cb;
     drmgr_bbdup_stitch_cb_t bbdup_stitch_cb;
@@ -1050,7 +1051,8 @@ drmgr_bb_event_set_local_cb_info(void *drcontext, OUT local_cb_info_t *local_inf
      */
 
     /* Copy bbdup callbacks. */
-    if (is_bbdup_enabled()) {
+    local_info->is_bbdup_enabled = is_bbdup_enabled();
+    if (local_info->is_bbdup_enabled) {
         ASSERT(bbdup_duplicate_cb != NULL, "should not be NULL");
         ASSERT(bbdup_insert_encoding_cb != NULL, "should not be NULL");
         ASSERT(bbdup_extract_cb != NULL, "should not be NULL");
@@ -1097,7 +1099,7 @@ drmgr_bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     }
 
     bool is_dups = false;
-    if (is_bbdup_enabled() /*only true if drbbdup is in use */) {
+    if (local_info->is_bbdup_enabled /*only true if drbbdup is in use */) {
         is_dups = drmgr_bb_event_instrument_dups(drcontext, tag, bb, for_trace,
                                                  translating, &res, pt, &local_info,
                                                  pair_data, quartet_data);

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -1079,7 +1079,7 @@ static dr_emit_flags_t
 drmgr_bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                bool translating)
 {
-    dr_emit_flags_t res;
+    dr_emit_flags_t res = DR_EMIT_DEFAULT;
     local_cb_info_t local_info;
     void **pair_data = NULL, **quartet_data = NULL;
     per_thread_t *pt = (per_thread_t *)drmgr_get_tls_field(drcontext, our_tls_idx);
@@ -3223,6 +3223,12 @@ drmgr_register_bbdup_event(drmgr_bbdup_duplicate_bb_cb_t bb_dup_func,
                            drmgr_bbdup_stitch_cb_t stitch_func)
 {
     bool succ = false;
+
+    /* None of the cbs can be NULL. */
+    if (bb_dup_func == NULL || insert_encoding == NULL || extract_func == NULL ||
+        stitch_func)
+        return succ;
+
     dr_rwlock_write_lock(bb_cb_lock);
     if (!is_bbdup_enabled()) {
         bbdup_duplicate_cb = bb_dup_func;

--- a/ext/drmgr/drmgr_priv.h
+++ b/ext/drmgr/drmgr_priv.h
@@ -1,0 +1,95 @@
+/* **********************************************************
+ * Copyright (c) 2020 Google, Inc.   All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef _DRMGR_PRIV_H_
+#define _DRMGR_PRIV_H_ 1
+
+/* An internal interface that acts as a beachhead for other extensions, e.g. drbbdup,
+ * to integrate their functionalities with drmgr. The interface should only be used
+ * when tight integration with drmgr is required.
+ */
+
+/* Don't use doxygen since this is an internal interface. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "dr_defines.h"
+
+/***************************************************************************
+ * For DRBBDUP
+ */
+
+typedef bool (*drmgr_bbdup_duplicate_bb_cb_t)(void *drcontext, void *tag, instrlist_t *bb,
+                                              bool for_trace, bool translating,
+                                              OUT void **local_dup_info_opaque);
+
+typedef instrlist_t *(*drmgr_bbdup_extract_cb_t)(void *drcontext, void *tag,
+                                                 instrlist_t *bb, bool for_trace,
+                                                 bool translating,
+                                                 void *local_dup_info_opaque);
+
+typedef void (*drmgr_bbdup_stitch_cb_t)(void *drcontext, void *tag, instrlist_t *bb,
+                                        instrlist_t *case_bb, bool for_trace,
+                                        bool translating,
+
+                                        void *local_dup_info_opaque);
+
+typedef void (*drmgr_bbdup_insert_encoding_cb_t)(void *drcontext, void *tag,
+                                                 instrlist_t *bb, bool for_trace,
+                                                 bool translating,
+                                                 OUT void *local_dup_info_opaque);
+
+DR_EXPORT
+/* Used by drbbdup so that drmgr maintains basic block duplication.
+ * BBDUP events can only be registered once at the same time.
+ * Returns true on success. Use drmgr_unregister_bbdup_event() to unregister.
+ */
+bool
+drmgr_register_bbdup_event(drmgr_bbdup_duplicate_bb_cb_t bb_dup_func,
+                           drmgr_bbdup_insert_encoding_cb_t insert_encoding,
+                           drmgr_bbdup_extract_cb_t extract_func,
+                           drmgr_bbdup_stitch_cb_t stitch_func);
+
+DR_EXPORT
+/* Unregisters drbbdup events set by the prior calling of drmgr_register_bbdup_event().
+ * Returns true on success.
+ */
+bool
+drmgr_unregister_bbdup_event();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _DRMGR_PRIV_H_ */

--- a/ext/drmgr/drmgr_priv.h
+++ b/ext/drmgr/drmgr_priv.h
@@ -70,7 +70,8 @@ typedef void (*drmgr_bbdup_stitch_cb_t)(void *drcontext, void *tag, instrlist_t 
                                         bool translating, void *local_dup_info_opaque);
 
 /* Finalises the iteration process and inserts the encoder at the top of the main basic
- * block. */
+ * block.
+ */
 typedef void (*drmgr_bbdup_insert_encoding_cb_t)(void *drcontext, void *tag,
                                                  instrlist_t *bb, bool for_trace,
                                                  bool translating, void *local_info);

--- a/ext/drmgr/drmgr_priv.h
+++ b/ext/drmgr/drmgr_priv.h
@@ -50,25 +50,30 @@ extern "C" {
  * For DRBBDUP
  */
 
+/* Responsible for duplicating basic blocks. Returns local_info
+ * used to iterate over basic block copies.
+ */
 typedef bool (*drmgr_bbdup_duplicate_bb_cb_t)(void *drcontext, void *tag, instrlist_t *bb,
                                               bool for_trace, bool translating,
-                                              OUT void **local_dup_info_opaque);
+                                              OUT void **local_info);
 
+/* Extracts and returns the a pending basic block copy from the main basic block. Returns
+ * NULL, if no further copies are pending.
+ */
 typedef instrlist_t *(*drmgr_bbdup_extract_cb_t)(void *drcontext, void *tag,
                                                  instrlist_t *bb, bool for_trace,
-                                                 bool translating,
-                                                 void *local_dup_info_opaque);
+                                                 bool translating, void *local_info);
 
+/* Stitches an extract basic block copy back to the main basic block. */
 typedef void (*drmgr_bbdup_stitch_cb_t)(void *drcontext, void *tag, instrlist_t *bb,
                                         instrlist_t *case_bb, bool for_trace,
-                                        bool translating,
+                                        bool translating, void *local_dup_info_opaque);
 
-                                        void *local_dup_info_opaque);
-
+/* Finalises the iteration process and inserts the encoder at the top of the main basic
+ * block. */
 typedef void (*drmgr_bbdup_insert_encoding_cb_t)(void *drcontext, void *tag,
                                                  instrlist_t *bb, bool for_trace,
-                                                 bool translating,
-                                                 OUT void *local_dup_info_opaque);
+                                                 bool translating, void *local_info);
 
 DR_EXPORT
 /* Used by drbbdup so that drmgr maintains basic block duplication.

--- a/ext/drmgr/drmgr_priv.h
+++ b/ext/drmgr/drmgr_priv.h
@@ -50,21 +50,21 @@ extern "C" {
  * For DRBBDUP
  */
 
-/* Responsible for duplicating basic blocks. Returns local_info
+/* Responsible for duplicating basic blocks. Returns local info
  * used to iterate over basic block copies.
  */
 typedef bool (*drmgr_bbdup_duplicate_bb_cb_t)(void *drcontext, void *tag, instrlist_t *bb,
                                               bool for_trace, bool translating,
                                               OUT void **local_info);
 
-/* Extracts and returns the a pending basic block copy from the main basic block. Returns
+/* Extracts and returns a pending basic block copy from the main basic block. Returns
  * NULL, if no further copies are pending.
  */
 typedef instrlist_t *(*drmgr_bbdup_extract_cb_t)(void *drcontext, void *tag,
                                                  instrlist_t *bb, bool for_trace,
                                                  bool translating, void *local_info);
 
-/* Stitches an extract basic block copy back to the main basic block. */
+/* Stitches an extracted basic block copy back to the main basic block. */
 typedef void (*drmgr_bbdup_stitch_cb_t)(void *drcontext, void *tag, instrlist_t *bb,
                                         instrlist_t *case_bb, bool for_trace,
                                         bool translating, void *local_dup_info_opaque);


### PR DESCRIPTION
Introduces an internal interface for drmgr to enhance drbbdup's instrumentation callbacks. 
The interface enables drbbdup to register low level call-backs which drmgr can use to manage bb copies.

Issue: #4134