### PR TITLE
i#4304: Fix AArch64 asm reachability

### DIFF
--- a/core/arch/aarch64/aarch64.asm
+++ b/core/arch/aarch64/aarch64.asm
@@ -100,6 +100,23 @@ START_FILE
 DECL_EXTERN(dr_setjmp_sigmask)
 #endif
 
+DECL_EXTERN(d_r_internal_error)
+
+/* For debugging: report an error if the function called by call_switch_stack()
+ * unexpectedly returns.  Also used elsewhere.
+ */
+        DECLARE_FUNC(unexpected_return)
+GLOBAL_LABEL(unexpected_return:)
+        CALLC3(GLOBAL_REF(d_r_internal_error), HEX(0), HEX(0), HEX(0))
+        /* d_r_internal_error normally never returns */
+        /* Infinite loop is intentional.  Can we do better in release build?
+         * XXX: why not a debug instr?
+         */
+        JUMP  GLOBAL_REF(unexpected_return)
+        END_FUNC(unexpected_return)
+
+END_FILE
+
 /* All CPU ID registers are accessible only in privileged modes. */
         DECLARE_FUNC(cpuid_supported)
 GLOBAL_LABEL(cpuid_supported:)

--- a/core/arch/aarch64/aarch64.asm
+++ b/core/arch/aarch64/aarch64.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2019 Google, Inc. All rights reserved.
+ * Copyright (c) 2019-2020 Google, Inc. All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -114,8 +114,6 @@ GLOBAL_LABEL(unexpected_return:)
          */
         JUMP  GLOBAL_REF(unexpected_return)
         END_FUNC(unexpected_return)
-
-END_FILE
 
 /* All CPU ID registers are accessible only in privileged modes. */
         DECLARE_FUNC(cpuid_supported)

--- a/core/drlibc/drlibc_xarch.asm
+++ b/core/drlibc/drlibc_xarch.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,6 +37,11 @@
 #include "../arch/asm_defines.asm"
 START_FILE
 
+/* For AArch64, drlibc has no references to unexpected_return, and in fact we
+ * have a relocation reachability error if we include it here (i#4304), so
+ * we limit its use in drlibc to x86 or arm.
+ */
+#ifndef AARCH64
 DECL_EXTERN(d_r_internal_error)
 
 /* For debugging: report an error if the function called by call_switch_stack()
@@ -53,3 +58,4 @@ GLOBAL_LABEL(unexpected_return:)
         END_FUNC(unexpected_return)
 
 END_FILE
+#endif

--- a/core/drlibc/drlibc_xarch.asm
+++ b/core/drlibc/drlibc_xarch.asm
@@ -56,6 +56,6 @@ GLOBAL_LABEL(unexpected_return:)
          */
         JUMP  GLOBAL_REF(unexpected_return)
         END_FUNC(unexpected_return)
+#endif
 
 END_FILE
-#endif


### PR DESCRIPTION
Moves unexpected_return() from drlibc to the core's asm file for
AArch64, to avoid a branch reachability link error when linking DR
statically into large apps.  unexpected_return() is not used in drlibc
for AArch64.

Fixes #4304