### PR TITLE
i3562: Add option for instruction-only trace collection to drcachesim.

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -148,6 +148,7 @@ Further non-compatibility-affecting changes include:
  - Added drmgr_register_opcode_instrumentation_event() and
    drmgr_unregister_opcode_instrumentation_event() so that drmgr supports
    opcode event instrumentation.
+ - Added -inst_only_trace option to drcachesim.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -177,6 +177,12 @@ droption_t<bytesize_t> op_L0D_size(
     "Must be a power of 2 and a multiple of -line_size, unless it is set to 0, "
     "which disables data entries from appearing in the trace.");
 
+droption_t<bool> op_inst_only_trace(
+    DROPTION_SCOPE_CLIENT, "inst_only_trace", false,
+    "Include only instruction fetch entries in trace",
+    "If -inst_only_trace, only instruction fetch entries are included in the "
+    "trace and data entries are omitted.");
+
 droption_t<bool> op_coherence(
     DROPTION_SCOPE_FRONTEND, "coherence", false, "Model coherence for private caches",
     "Writes to cache lines will invalidate other private caches that hold that line.");

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -79,6 +79,7 @@ extern droption_t<std::string> op_LL_miss_file;
 extern droption_t<bytesize_t> op_L0I_size;
 extern droption_t<bool> op_L0_filter;
 extern droption_t<bytesize_t> op_L0D_size;
+extern droption_t<bool> op_inst_only_trace;
 extern droption_t<bool> op_coherence;
 extern droption_t<bool> op_use_physical;
 extern droption_t<unsigned int> op_virt2phys_freq;

--- a/clients/drcachesim/tests/filter-inst-only.templatex
+++ b/clients/drcachesim/tests/filter-inst-only.templatex
@@ -1,0 +1,23 @@
+Hello, world!
+---- <application exited with code 0> ----
+Cache simulation results:
+Core #0 \(1 thread\(s\)\)
+  L1I stats:
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *0
+.*   Miss rate:                   *[1-9][0-9][,\.]..%
+  L1D stats:
+    Hits:                                0
+    Misses:                              0
+    Invalidations:                       0
+Core #1 \(0 thread\(s\)\)
+Core #2 \(0 thread\(s\)\)
+Core #3 \(0 thread\(s\)\)
+LL stats:
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *0
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
+    Total miss rate:              *[1-9][0-9][,\.]..%

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -903,6 +903,9 @@ instrument_memref(void *drcontext, user_data_t *ud, instrlist_t *ilist, instr_t 
                   reg_id_t reg_ptr, int adjust, instr_t *app, opnd_t ref, int ref_index,
                   bool write, dr_pred_type_t pred)
 {
+    if (op_inst_only_trace.get_value()) {
+      return adjust;
+    }
     instr_t *skip = INSTR_CREATE_label(drcontext);
     reg_id_t reg_third = DR_REG_NULL;
     if (op_L0_filter.get_value()) {

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2874,6 +2874,7 @@ endif ()
       torunonly_drcachesim(filter-simple ${ci_shared_app} "-L0_filter" "")
       torunonly_drcachesim(filter-no-i ${ci_shared_app} "-L0_filter -L0I_size 0" "")
       torunonly_drcachesim(filter-no-d ${ci_shared_app} "-L0_filter -L0D_size 0" "")
+      torunonly_drcachesim(filter-inst-only ${ci_shared_app} "-inst_only_trace" "")
 
       torunonly_drcachesim(delay-simple ${ci_shared_app}
         "-trace_after_instrs 20000 -exit_after_tracing 10000" "")


### PR DESCRIPTION
Add option to drcachesim to include only instruction fetch entries and omit data entries from trace.

Issue: #3562

