### PR TITLE
Add check for XSP in dr_restore_reg and dr_save_reg on AArch64

### DIFF
--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -5803,9 +5803,9 @@ dr_save_reg(void *drcontext, instrlist_t *ilist, instr_t *where, reg_id_t reg,
 
     CLIENT_ASSERT(reg_is_pointer_sized(reg), "dr_save_reg requires pointer-sized gpr");
 
-#ifdef AARCH64
+#    ifdef AARCH64
     CLIENT_ASSERT(reg != DR_REG_XSP, "dr_save_reg: store from XSP is not supported");
-#endif
+#    endif
 
     if (slot <= SPILL_SLOT_TLS_MAX) {
         ushort offs = os_tls_offset(SPILL_SLOT_TLS_OFFS[slot]);
@@ -5849,9 +5849,9 @@ dr_restore_reg(void *drcontext, instrlist_t *ilist, instr_t *where, reg_id_t reg
     CLIENT_ASSERT(reg_is_pointer_sized(reg),
                   "dr_restore_reg requires a pointer-sized gpr");
 
-#ifdef AARCH64
+#    ifdef AARCH64
     CLIENT_ASSERT(reg != DR_REG_XSP, "dr_restore_reg: load into XSP is not supported");
-#endif
+#    endif
 
     if (slot <= SPILL_SLOT_TLS_MAX) {
         ushort offs = os_tls_offset(SPILL_SLOT_TLS_OFFS[slot]);

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -5803,6 +5803,10 @@ dr_save_reg(void *drcontext, instrlist_t *ilist, instr_t *where, reg_id_t reg,
 
     CLIENT_ASSERT(reg_is_pointer_sized(reg), "dr_save_reg requires pointer-sized gpr");
 
+#ifdef AARCH64
+    CLIENT_ASSERT(reg != DR_REG_XSP, "dr_save_reg: store from XSP is not supported");
+#endif
+
     if (slot <= SPILL_SLOT_TLS_MAX) {
         ushort offs = os_tls_offset(SPILL_SLOT_TLS_OFFS[slot]);
         MINSERT(ilist, where,
@@ -5844,6 +5848,10 @@ dr_restore_reg(void *drcontext, instrlist_t *ilist, instr_t *where, reg_id_t reg
 
     CLIENT_ASSERT(reg_is_pointer_sized(reg),
                   "dr_restore_reg requires a pointer-sized gpr");
+
+#ifdef AARCH64
+    CLIENT_ASSERT(reg != DR_REG_XSP, "dr_restore_reg: load into XSP is not supported");
+#endif
 
     if (slot <= SPILL_SLOT_TLS_MAX) {
         ushort offs = os_tls_offset(SPILL_SLOT_TLS_OFFS[slot]);


### PR DESCRIPTION
This check is helpful for AArch64 target which does not support loading into and storing from XSP.
This change allows to fail early with a meaningful error message: for a debug build it will look like this:

```
<Application /usr/bin/ls (68183) DynamoRIO usage error : dr_save_reg: store from XSP is not supported>
<Usage error: dr_save_reg: store from XSP is not supported (...dynamorio/core/lib/instrument.c, line 5807)
```