### PR TITLE
i#4058 Appveyor: Mark 64-bit client.drwrap-test-detach flaky

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -216,7 +216,8 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                    'code_api|api.detach_spawn' => 1, # i#2611
                                    'code_api|api.startstop' => 1, # i#2093
                                    'code_api|api.static_noclient' => 1,
-                                   'code_api|api.static_noinit' => 1);
+                                   'code_api|api.static_noinit' => 1,
+                                   'code_api|client.drwrap-test-detach' => 1); # i#4058
             $issue_no = "#2145";
         } elsif ($is_aarchxx) {
             # FIXME i#2416: fix flaky AArch32 tests


### PR DESCRIPTION
The 64-bit client.drwrap-test-detach test has been failing on Appveyor
but not our local machines.  Marking it flaky to keep the CI green.

Issue: #4058