### PR TITLE
Add test for offline traces with no instructions.

### DIFF
--- a/clients/drcachesim/tests/offline-filter-no-i.templatex
+++ b/clients/drcachesim/tests/offline-filter-no-i.templatex
@@ -1,0 +1,22 @@
+Hello, world!
+Cache simulation results:
+Core #0 \(1 thread\(s\)\)
+  L1I stats:
+    Hits:                                0
+    Misses:                              0
+    Invalidations:                       0
+  L1D stats:
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *0
+.*   Miss rate:                   *[1-9][0-9][,\.]..%
+Core #1 \(0 thread\(s\)\)
+Core #2 \(0 thread\(s\)\)
+Core #3 \(0 thread\(s\)\)
+LL stats:
+    Hits:                         *[0-9,\.]*
+    Misses:                       *[0-9,\.]*
+    Invalidations:                *0
+.*   Local miss rate:        *[0-9,.]*%
+    Child hits:                   *[0-9,\.]*
+    Total miss rate:              *[1-9][0-9][,\.]..%

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3096,6 +3096,7 @@ endif ()
       endif ()
 
       torunonly_drcacheoff(filter ${ci_shared_app} "-L0_filter" "" "")
+      torunonly_drcacheoff(filter-no-i ${ci_shared_app} "-L0_filter -L0I_size 0" "" "")
       torunonly_drcacheoff(filter-no-d ${ci_shared_app} "-L0_filter -L0D_size 0" "" "")
 
       torunonly_drcacheoff(instr-only-trace ${ci_shared_app} "-instr_only_trace" "" "")


### PR DESCRIPTION
Offline traces generated using '-L0_filter -L0I_size 0' have no instruction entries. Add a test to verify this.