### PR TITLE
i#1684 xarch-IR: Remove mangle.c from drdecode

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -238,6 +238,8 @@ set(DECODER_SRCS
   ir/${ARCH_NAME}/encode.c
   ir/disassemble_shared.c
   ir/${ARCH_NAME}/disassemble.c
+  ir/ir_utils_shared.c
+  ir/${ARCH_NAME_SHARED}/ir_utils.c
   )
 if (X86)
   set(DECODER_SRCS ${DECODER_SRCS}
@@ -268,7 +270,6 @@ set(ARCH_SRCS
   arch/proc_shared.c
   arch/${ARCH_NAME}/proc.c
   arch/mangle_shared.c
-  ir/ir_utils.c
   arch/${ARCH_NAME_SHARED}/mangle.c
   arch/clean_call_opt_shared.c
   arch/${ARCH_NAME}/clean_call_opt.c
@@ -962,8 +963,6 @@ endif (UNIX)
 # static decoding library
 add_library(drdecode
   ${DECODER_SRCS}
-  arch/${ARCH_NAME_SHARED}/mangle.c
-  ir/ir_utils.c
   ir/decodelib.c
   string.c
   io.c

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -49,6 +49,7 @@
 #include "decode.h"       /* for X64_CACHE_MODE_DC */
 #include "arch_exports.h" /* for FRAG_IS_32 and FRAG_IS_X86_TO_X64 */
 #include "../fragment.h"  /* IS_IBL_TARGET */
+#include "ir_utils.h"
 
 #if defined(X86) && defined(X64)
 static inline bool
@@ -509,24 +510,8 @@ mangle_init(void);
 void
 mangle_exit(void);
 void
-insert_mov_immed_ptrsz(dcontext_t *dcontext, ptr_int_t val, opnd_t dst,
-                       instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
-                       OUT instr_t **last);
-void
 patch_mov_immed_ptrsz(dcontext_t *dcontext, ptr_int_t val, byte *pc, instr_t *first,
                       instr_t *last);
-void
-insert_push_immed_ptrsz(dcontext_t *dcontext, ptr_int_t val, instrlist_t *ilist,
-                        instr_t *instr, OUT instr_t **first, OUT instr_t **last);
-void
-insert_mov_instr_addr(dcontext_t *dcontext, instr_t *src, byte *encode_estimate,
-                      opnd_t dst, instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
-                      OUT instr_t **last);
-void
-insert_push_instr_addr(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
-                       instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
-                       OUT instr_t **last);
-
 /* in mangle.c arch-specific implementation */
 #ifdef ARM
 int
@@ -543,16 +528,8 @@ uint
 insert_parameter_preparation(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
                              bool clean_call, uint num_args, opnd_t *args);
 void
-insert_mov_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
-                      ptr_int_t val, opnd_t dst, instrlist_t *ilist, instr_t *instr,
-                      OUT instr_t **first, OUT instr_t **last);
-void
 patch_mov_immed_arch(dcontext_t *dcontext, ptr_int_t val, byte *pc, instr_t *first,
                      instr_t *last);
-void
-insert_push_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
-                       ptr_int_t val, instrlist_t *ilist, instr_t *instr,
-                       OUT instr_t **first, OUT instr_t **last);
 instr_t *
 convert_to_near_rel_arch(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr);
 void

--- a/core/ir/aarchxx/ir_utils.c
+++ b/core/ir/aarchxx/ir_utils.c
@@ -1,0 +1,253 @@
+/* **********************************************************
+ * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of ARM Limited nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "../globals.h"
+#include "instr_create.h"
+#include "instrument.h"
+
+/* Make code more readable by shortening long lines.
+ * We mark everything we add as non-app instr.
+ */
+#define POST instrlist_meta_postinsert
+#define PRE instrlist_meta_preinsert
+
+byte *
+remangle_short_rewrite(dcontext_t *dcontext, instr_t *instr, byte *pc, app_pc target)
+{
+#ifdef AARCH64
+    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
+    return NULL;
+#else
+    uint mangled_sz = CTI_SHORT_REWRITE_LENGTH;
+    uint raw_jmp;
+    ASSERT(instr_is_cti_short_rewrite(instr, pc));
+    if (target == NULL)
+        target = decode_raw_jmp_target(dcontext, pc + CTI_SHORT_REWRITE_B_OFFS);
+    instr_set_target(instr, opnd_create_pc(target));
+    instr_allocate_raw_bits(dcontext, instr, mangled_sz);
+    instr_set_raw_bytes(instr, pc, mangled_sz);
+    encode_raw_jmp(dr_get_isa_mode(dcontext), target, (byte *)&raw_jmp,
+                   pc + CTI_SHORT_REWRITE_B_OFFS);
+    instr_set_raw_word(instr, CTI_SHORT_REWRITE_B_OFFS, raw_jmp);
+    instr_set_operands_valid(instr, true);
+    return (pc + mangled_sz);
+#endif
+}
+
+instr_t *
+convert_to_near_rel_arch(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
+{
+#ifdef AARCH64
+    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
+    return NULL;
+#else
+    int opcode = instr_get_opcode(instr);
+    if (opcode == OP_b_short) {
+        instr_set_opcode(instr, OP_b);
+        return instr;
+    } else if (opcode == OP_cbz || opcode == OP_cbnz) {
+        /* While for non-trace-mode we could get by w/o converting,
+         * as we use local stubs with a far-away link-through-stub
+         * soln needed even for regular branches and thus these would
+         * reach the stub, they won't reach for traces.
+         * Thus we mirror what x86 does for jecxz:
+         *       cbz foo
+         *  =>
+         *       cbnz fall
+         *       jmp foo
+         *  fall:
+         *
+         * The fact that we invert the cbr ends up requiring extra logic
+         * in linkstub_cbr_disambiguate().
+         */
+        app_pc target = NULL;
+        uint mangled_sz, offs, raw_jmp;
+        reg_id_t src_reg;
+
+        if (ilist != NULL) {
+            /* PR 266292: for meta instrs, insert separate instrs */
+            opnd_t tgt = instr_get_target(instr);
+            instr_t *fall = INSTR_CREATE_label(dcontext);
+            instr_t *jmp = INSTR_CREATE_b(dcontext, tgt);
+            ASSERT(instr_is_meta(instr));
+            /* reverse order */
+            instrlist_meta_postinsert(ilist, instr, fall);
+            instrlist_meta_postinsert(ilist, instr, jmp);
+            instrlist_meta_postinsert(ilist, instr, instr);
+            instr_set_target(instr, opnd_create_instr(fall));
+            instr_invert_cbr(instr);
+            return jmp; /* API specifies we return the long-reach cti */
+        }
+
+        if (opnd_is_near_pc(instr_get_target(instr)))
+            target = opnd_get_pc(instr_get_target(instr));
+        else if (opnd_is_near_instr(instr_get_target(instr))) {
+            instr_t *tgt = opnd_get_instr(instr_get_target(instr));
+            /* XXX: not using get_app_instr_xl8() b/c drdecodelib doesn't link
+             * mangle_shared.c.
+             */
+            target = instr_get_translation(tgt);
+            if (target == NULL && instr_raw_bits_valid(tgt))
+                target = instr_get_raw_bits(tgt);
+            ASSERT(target != NULL);
+        } else
+            ASSERT_NOT_REACHED();
+
+        /* PR 251646: cti_short_rewrite: target is in src0, so operands are
+         * valid, but raw bits must also be valid, since they hide the multiple
+         * instrs.  For x64, it is marked for re-relativization, but it's
+         * special since the target must be obtained from src0 and not
+         * from the raw bits (since that might not reach).
+         */
+        /* query IR before we set raw bits */
+        ASSERT(opnd_is_reg(instr_get_src(instr, 1)));
+        src_reg = opnd_get_reg(instr_get_src(instr, 1));
+        /* need 6 bytes */
+        mangled_sz = CTI_SHORT_REWRITE_LENGTH;
+        instr_allocate_raw_bits(dcontext, instr, mangled_sz);
+        offs = 0;
+        /* first 2 bytes: cbz or cbnz to "cur pc" + 2 which means immed is 1 */
+        instr_set_raw_byte(instr, offs, 0x08 | (src_reg - DR_REG_R0));
+        offs++;
+        instr_set_raw_byte(instr, offs, (opcode == OP_cbz) ? CBNZ_BYTE_A : CBZ_BYTE_A);
+        offs++;
+        /* next 4 bytes: b to target */
+        ASSERT(offs == CTI_SHORT_REWRITE_B_OFFS);
+        encode_raw_jmp(dr_get_isa_mode(dcontext),
+                       instr->bytes + offs /*not target, b/c may not reach*/,
+                       (byte *)&raw_jmp, instr->bytes + offs);
+        instr_set_raw_word(instr, offs, raw_jmp);
+        offs += sizeof(int);
+        ASSERT(offs == mangled_sz);
+        LOG(THREAD, LOG_INTERP, 2, "convert_to_near_rel: cbz/cbnz opcode\n");
+        /* original target operand is still valid */
+        instr_set_operands_valid(instr, true);
+        return instr;
+    }
+    ASSERT_NOT_REACHED();
+    return instr;
+#endif
+}
+
+void
+insert_mov_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
+                      ptr_int_t val, opnd_t dst, instrlist_t *ilist, instr_t *instr,
+                      OUT instr_t **first, OUT instr_t **last)
+{
+#ifdef AARCH64
+    instr_t *mov;
+    int i;
+
+    CLIENT_ASSERT(opnd_is_reg(dst), "AArch64 cannot store an immediate direct to memory");
+
+    if (opnd_get_reg(dst) == DR_REG_XZR) {
+        /* Moving a value to the zero register is a no-op. We insert nothing,
+         * so *first and *last are set to NULL. Caller beware!
+         */
+        if (first != NULL)
+            *first = NULL;
+        if (last != NULL)
+            *last = NULL;
+        return;
+    }
+
+    ASSERT((uint)(opnd_get_reg(dst) - DR_REG_X0) < 31);
+    if (src_inst != NULL)
+        val = (ptr_int_t)encode_estimate;
+
+    /* movz x(dst), #(val & 0xffff) */
+    mov = INSTR_CREATE_movz(dcontext, dst, OPND_CREATE_INT16(val & 0xffff),
+                            OPND_CREATE_INT8(0));
+    PRE(ilist, instr, mov);
+    if (first != NULL)
+        *first = mov;
+    for (i = 1; i < 4; i++) {
+        if ((val >> (16 * i) & 0xffff) != 0) {
+            /* movk x(dst), #(val >> sh & 0xffff), lsl #(sh) */
+            mov = INSTR_CREATE_movk(dcontext, dst,
+                                    OPND_CREATE_INT16((val >> 16 * i) & 0xffff),
+                                    OPND_CREATE_INT8(i * 16));
+            PRE(ilist, instr, mov);
+        }
+    }
+    if (last != NULL)
+        *last = mov;
+#else
+    instr_t *mov1, *mov2;
+    if (src_inst != NULL)
+        val = (ptr_int_t)encode_estimate;
+    CLIENT_ASSERT(opnd_is_reg(dst), "ARM cannot store an immediate direct to memory");
+    /* MVN writes the bitwise inverse of an immediate value to the dst register */
+    /* XXX: we could check for larger tile/rotate immed patterns */
+    if (src_inst == NULL && ~val >= 0 && ~val <= 0xff) {
+        mov1 = INSTR_CREATE_mvn(dcontext, dst, OPND_CREATE_INT(~val));
+        PRE(ilist, instr, mov1);
+        mov2 = NULL;
+    } else {
+        /* To use INT16 here and pass the size checks in opnd_create_immed_int
+         * we'd have to add UINT16 (or sign-extend the bottom half again):
+         * simpler to use INT, and our general ARM philosophy is to use INT and
+         * ignore immed sizes at instr creation time (only at encode time do we
+         * check them).
+         */
+        mov1 = INSTR_CREATE_movw(dcontext, dst,
+                                 (src_inst == NULL)
+                                     ? OPND_CREATE_INT(val & 0xffff)
+                                     : opnd_create_instr_ex(src_inst, OPSZ_2, 0));
+        PRE(ilist, instr, mov1);
+        val = (val >> 16) & 0xffff;
+        if (val == 0) {
+            /* movw zero-extends so we're done */
+            mov2 = NULL;
+        } else {
+            mov2 = INSTR_CREATE_movt(dcontext, dst,
+                                     (src_inst == NULL)
+                                         ? OPND_CREATE_INT(val)
+                                         : opnd_create_instr_ex(src_inst, OPSZ_2, 16));
+            PRE(ilist, instr, mov2);
+        }
+    }
+    if (first != NULL)
+        *first = mov1;
+    if (last != NULL)
+        *last = mov2;
+#endif
+}
+
+void
+insert_push_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
+                       ptr_int_t val, instrlist_t *ilist, instr_t *instr,
+                       OUT instr_t **first, OUT instr_t **last)
+{
+    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1551, i#1569 */
+}

--- a/core/ir/aarchxx/ir_utils.c
+++ b/core/ir/aarchxx/ir_utils.c
@@ -41,6 +41,9 @@
 #define POST instrlist_meta_postinsert
 #define PRE instrlist_meta_preinsert
 
+/* XXX: Best to move DR-execution-related things like this out of core/ir/ and into
+ * core/arch/, but untangling them all will take some work, so for now it lives here.
+ */
 byte *
 remangle_short_rewrite(dcontext_t *dcontext, instr_t *instr, byte *pc, app_pc target)
 {

--- a/core/ir/ir_utils.h
+++ b/core/ir/ir_utils.h
@@ -1,8 +1,7 @@
-/* ******************************************************************************
+/* **********************************************************
  * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
- * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
- * ******************************************************************************/
+ * **********************************************************/
 
 /*
  * Redistribution and use in source and binary forms, with or without
@@ -36,42 +35,36 @@
 /* Copyright (c) 2001-2003 Massachusetts Institute of Technology */
 /* Copyright (c) 2000-2001 Hewlett-Packard Company */
 
-/* file "ir_utils.c": multi-instruction manipulation shared between the core
- * and drdecode.
- */
+/* ir_utils.h -- IR utility functions */
 
-#include "../globals.h"
-#include "arch.h"
+#ifndef _IR_UTILS_H_
+#define _IR_UTILS_H_ 1
 
+/* Public */
 void
 insert_mov_immed_ptrsz(dcontext_t *dcontext, ptr_int_t val, opnd_t dst,
                        instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
-                       OUT instr_t **last)
-{
-    insert_mov_immed_arch(dcontext, NULL, NULL, val, dst, ilist, instr, first, last);
-}
-
+                       OUT instr_t **last);
+void
+insert_push_immed_ptrsz(dcontext_t *dcontext, ptr_int_t val, instrlist_t *ilist,
+                        instr_t *instr, OUT instr_t **first, OUT instr_t **last);
 void
 insert_mov_instr_addr(dcontext_t *dcontext, instr_t *src, byte *encode_estimate,
                       opnd_t dst, instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
-                      OUT instr_t **last)
-{
-    insert_mov_immed_arch(dcontext, src, encode_estimate, 0, dst, ilist, instr, first,
-                          last);
-}
-
-void
-insert_push_immed_ptrsz(dcontext_t *dcontext, ptr_int_t val, instrlist_t *ilist,
-                        instr_t *instr, OUT instr_t **first, OUT instr_t **last)
-{
-    insert_push_immed_arch(dcontext, NULL, NULL, val, ilist, instr, first, last);
-}
-
+                      OUT instr_t **last);
 void
 insert_push_instr_addr(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
                        instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
-                       OUT instr_t **last)
-{
-    insert_push_immed_arch(dcontext, src_inst, encode_estimate, 0, ilist, instr, first,
-                           last);
-}
+                       OUT instr_t **last);
+
+/* Private */
+void
+insert_mov_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
+                      ptr_int_t val, opnd_t dst, instrlist_t *ilist, instr_t *instr,
+                      OUT instr_t **first, OUT instr_t **last);
+void
+insert_push_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
+                       ptr_int_t val, instrlist_t *ilist, instr_t *instr,
+                       OUT instr_t **first, OUT instr_t **last);
+
+#endif /* _IR_UTILS_H_ */

--- a/core/ir/ir_utils_shared.c
+++ b/core/ir/ir_utils_shared.c
@@ -1,0 +1,77 @@
+/* ******************************************************************************
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
+ * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
+ * ******************************************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Copyright (c) 2003-2007 Determina Corp. */
+/* Copyright (c) 2001-2003 Massachusetts Institute of Technology */
+/* Copyright (c) 2000-2001 Hewlett-Packard Company */
+
+/* file "ir_utils.c": multi-instruction manipulation shared between the core
+ * and drdecode.
+ */
+
+#include "../globals.h"
+#include "ir_utils.h"
+
+void
+insert_mov_immed_ptrsz(dcontext_t *dcontext, ptr_int_t val, opnd_t dst,
+                       instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
+                       OUT instr_t **last)
+{
+    insert_mov_immed_arch(dcontext, NULL, NULL, val, dst, ilist, instr, first, last);
+}
+
+void
+insert_mov_instr_addr(dcontext_t *dcontext, instr_t *src, byte *encode_estimate,
+                      opnd_t dst, instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
+                      OUT instr_t **last)
+{
+    insert_mov_immed_arch(dcontext, src, encode_estimate, 0, dst, ilist, instr, first,
+                          last);
+}
+
+void
+insert_push_immed_ptrsz(dcontext_t *dcontext, ptr_int_t val, instrlist_t *ilist,
+                        instr_t *instr, OUT instr_t **first, OUT instr_t **last)
+{
+    insert_push_immed_arch(dcontext, NULL, NULL, val, ilist, instr, first, last);
+}
+
+void
+insert_push_instr_addr(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
+                       instrlist_t *ilist, instr_t *instr, OUT instr_t **first,
+                       OUT instr_t **last)
+{
+    insert_push_immed_arch(dcontext, src_inst, encode_estimate, 0, ilist, instr, first,
+                           last);
+}

--- a/core/ir/x86/ir_utils.c
+++ b/core/ir/x86/ir_utils.c
@@ -325,6 +325,9 @@ convert_to_near_rel_arch(dcontext_t *dcontext, instrlist_t *ilist, instr_t *inst
     return instr;
 }
 
+/* XXX: Best to move DR-execution-related things like this out of core/ir/ and into
+ * core/arch/, but untangling them all will take some work, so for now it lives here.
+ */
 /* For jecxz and loop*, we create 3 instructions in a single
  * instr that we treat like a single conditional branch.
  * On re-decoding our own output we need to recreate that instr.

--- a/core/ir/x86/ir_utils.c
+++ b/core/ir/x86/ir_utils.c
@@ -1,0 +1,366 @@
+/* ******************************************************************************
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
+ * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
+ * ******************************************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Copyright (c) 2003-2007 Determina Corp. */
+/* Copyright (c) 2001-2003 Massachusetts Institute of Technology */
+/* Copyright (c) 2000-2001 Hewlett-Packard Company */
+
+/* file "ir_utils.c": multi-instruction manipulation shared between the core
+ * and drdecode.
+ */
+
+#include "../globals.h"
+#include "decode.h"
+#include "instr_create.h"
+#include "instrument.h"
+
+/* Make code more readable by shortening long lines.
+ * We mark everything we add as non-app instr.
+ */
+#define POST instrlist_meta_postinsert
+#define PRE instrlist_meta_preinsert
+
+/* If src_inst != NULL, uses it (and assumes it will be encoded at
+ * encode_estimate to determine whether > 32 bits or not: so if unsure where
+ * it will be encoded, pass a high address) as the immediate; else
+ * uses val.
+ * Keep this in sync with patch_mov_immed_arch().
+ */
+void
+insert_mov_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
+                      ptr_int_t val, opnd_t dst, instrlist_t *ilist, instr_t *instr,
+                      OUT instr_t **first, OUT instr_t **last)
+{
+    instr_t *mov1, *mov2;
+    if (src_inst != NULL)
+        val = (ptr_int_t)encode_estimate;
+#ifdef X64
+    if (X64_MODE_DC(dcontext) && !opnd_is_reg(dst)) {
+        if (val <= INT_MAX && val >= INT_MIN) {
+            /* mov is sign-extended, so we can use one move if it is all
+             * 0 or 1 in top 33 bits
+             */
+            mov1 = INSTR_CREATE_mov_imm(dcontext, dst,
+                                        (src_inst == NULL)
+                                            ? OPND_CREATE_INT32((int)val)
+                                            : opnd_create_instr_ex(src_inst, OPSZ_4, 0));
+            PRE(ilist, instr, mov1);
+            mov2 = NULL;
+        } else {
+            /* do mov-64-bit-immed in two pieces.  tiny corner-case risk of racy
+             * access to [dst] if this thread is suspended in between or another
+             * thread is trying to read [dst], but o/w we have to spill and
+             * restore a register.
+             */
+            CLIENT_ASSERT(opnd_is_memory_reference(dst), "invalid dst opnd");
+            /* mov low32 => [mem32] */
+            opnd_set_size(&dst, OPSZ_4);
+            mov1 = INSTR_CREATE_mov_st(dcontext, dst,
+                                       (src_inst == NULL)
+                                           ? OPND_CREATE_INT32((int)val)
+                                           : opnd_create_instr_ex(src_inst, OPSZ_4, 0));
+            PRE(ilist, instr, mov1);
+            /* mov high32 => [mem32+4] */
+            if (opnd_is_base_disp(dst)) {
+                int disp = opnd_get_disp(dst);
+                CLIENT_ASSERT(disp + 4 > disp, "disp overflow");
+                opnd_set_disp(&dst, disp + 4);
+            } else {
+                byte *addr = opnd_get_addr(dst);
+                CLIENT_ASSERT(!POINTER_OVERFLOW_ON_ADD(addr, 4), "addr overflow");
+                dst = OPND_CREATE_ABSMEM(addr + 4, OPSZ_4);
+            }
+            mov2 = INSTR_CREATE_mov_st(dcontext, dst,
+                                       (src_inst == NULL)
+                                           ? OPND_CREATE_INT32((int)(val >> 32))
+                                           : opnd_create_instr_ex(src_inst, OPSZ_4, 32));
+            PRE(ilist, instr, mov2);
+        }
+    } else {
+#endif
+        mov1 = INSTR_CREATE_mov_imm(dcontext, dst,
+                                    (src_inst == NULL)
+                                        ? OPND_CREATE_INTPTR(val)
+                                        : opnd_create_instr_ex(src_inst, OPSZ_PTR, 0));
+        PRE(ilist, instr, mov1);
+        mov2 = NULL;
+#ifdef X64
+    }
+#endif
+    if (first != NULL)
+        *first = mov1;
+    if (last != NULL)
+        *last = mov2;
+}
+
+/* If src_inst != NULL, uses it (and assumes it will be encoded at
+ * encode_estimate to determine whether > 32 bits or not: so if unsure where
+ * it will be encoded, pass a high address) as the immediate; else
+ * uses val.
+ */
+void
+insert_push_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
+                       ptr_int_t val, instrlist_t *ilist, instr_t *instr,
+                       OUT instr_t **first, OUT instr_t **last)
+{
+    instr_t *push, *mov;
+    if (src_inst != NULL)
+        val = (ptr_int_t)encode_estimate;
+#ifdef X64
+    if (X64_MODE_DC(dcontext)) {
+        /* do push-64-bit-immed in two pieces.  tiny corner-case risk of racy
+         * access to TOS if this thread is suspended in between or another
+         * thread is trying to read its stack, but o/w we have to spill and
+         * restore a register.
+         */
+        push = INSTR_CREATE_push_imm(dcontext,
+                                     (src_inst == NULL)
+                                         ? OPND_CREATE_INT32((int)val)
+                                         : opnd_create_instr_ex(src_inst, OPSZ_4, 0));
+        PRE(ilist, instr, push);
+        /* push is sign-extended, so we can skip top half if it is all 0 or 1
+         * in top 33 bits
+         */
+        if (val <= INT_MAX && val >= INT_MIN) {
+            mov = NULL;
+        } else {
+            mov = INSTR_CREATE_mov_st(dcontext, OPND_CREATE_MEM32(REG_XSP, 4),
+                                      (src_inst == NULL)
+                                          ? OPND_CREATE_INT32((int)(val >> 32))
+                                          : opnd_create_instr_ex(src_inst, OPSZ_4, 32));
+            PRE(ilist, instr, mov);
+        }
+    } else {
+#endif
+        push = INSTR_CREATE_push_imm(dcontext,
+                                     (src_inst == NULL)
+                                         ? OPND_CREATE_INT32(val)
+                                         : opnd_create_instr_ex(src_inst, OPSZ_4, 0));
+        PRE(ilist, instr, push);
+        mov = NULL;
+#ifdef X64
+    }
+#endif
+    if (first != NULL)
+        *first = push;
+    if (last != NULL)
+        *last = mov;
+}
+
+/* Convert a short-format CTI into an equivalent one using
+ * near-rel-format.
+ * Remember, the target is kept in the 0th src array position,
+ * and has already been converted from an 8-bit offset to an
+ * absolute PC, so we can just pretend instructions are longer
+ * than they really are.
+ */
+instr_t *
+convert_to_near_rel_arch(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
+{
+    int opcode = instr_get_opcode(instr);
+    app_pc target = NULL;
+
+    if (opcode == OP_jmp_short) {
+        instr_set_opcode(instr, OP_jmp);
+        return instr;
+    }
+
+    if (OP_jo_short <= opcode && opcode <= OP_jnle_short) {
+        /* WARNING! following is OP_ enum order specific */
+        instr_set_opcode(instr, opcode - OP_jo_short + OP_jo);
+        return instr;
+    }
+
+    if (OP_loopne <= opcode && opcode <= OP_jecxz) {
+        uint mangled_sz;
+        uint offs;
+        /*
+         * from "info as" on GNU/linux system:
+       Note that the `jcxz', `jecxz', `loop', `loopz', `loope', `loopnz'
+       and `loopne' instructions only come in byte displacements, so that if
+       you use these instructions (`gcc' does not use them) you may get an
+       error message (and incorrect code).  The AT&T 80386 assembler tries to
+       get around this problem by expanding `jcxz foo' to
+                     jcxz cx_zero
+                     jmp cx_nonzero
+            cx_zero: jmp foo
+            cx_nonzero:
+        *
+        * We use that same expansion, but we want to treat the entire
+        * three-instruction sequence as a single conditional branch.
+        * Thus we use a special instruction that stores the entire
+        * instruction sequence as mangled bytes, yet w/ a valid target operand
+        * (xref PR 251646).
+        * patch_branch and instr_invert_cbr
+        * know how to find the target pc (final 4 of 9 bytes).
+        * When decoding anything we've written we know the only jcxz or
+        * loop* instructions are part of these rewritten packages, and
+        * we use remangle_short_rewrite to read back in the instr.
+        * (have to do this everywhere call decode() except original
+        * interp, plus in input_trace())
+        *
+        * An alternative is to change 'jcxz foo' to:
+                    <save eflags>
+                    cmpb %cx,$0
+                    je   foo_restore
+                    <restore eflags>
+                    ...
+       foo_restore: <restore eflags>
+               foo:
+        * However the added complications of restoring the eflags on
+        * the taken-branch path made me choose the former solution.
+        */
+
+        /* SUMMARY:
+         * expand 'shortjump foo' to:
+                          shortjump taken
+                          jmp-short nottaken
+                   taken: jmp foo
+                nottaken:
+        */
+        if (ilist != NULL) {
+            /* PR 266292: for meta instrs, insert separate instrs */
+            /* reverse order */
+            opnd_t tgt = instr_get_target(instr);
+            instr_t *nottaken = INSTR_CREATE_label(dcontext);
+            instr_t *taken = INSTR_CREATE_jmp(dcontext, tgt);
+            ASSERT(instr_is_meta(instr));
+            instrlist_meta_postinsert(ilist, instr, nottaken);
+            instrlist_meta_postinsert(ilist, instr, taken);
+            instrlist_meta_postinsert(
+                ilist, instr,
+                INSTR_CREATE_jmp_short(dcontext, opnd_create_instr(nottaken)));
+            instr_set_target(instr, opnd_create_instr(taken));
+            return taken;
+        }
+
+        if (opnd_is_near_pc(instr_get_target(instr)))
+            target = opnd_get_pc(instr_get_target(instr));
+        else if (opnd_is_near_instr(instr_get_target(instr))) {
+            instr_t *tgt = opnd_get_instr(instr_get_target(instr));
+            /* XXX: not using get_app_instr_xl8() b/c drdecodelib doesn't link
+             * mangle_shared.c.
+             */
+            target = instr_get_translation(tgt);
+            if (target == NULL && instr_raw_bits_valid(tgt))
+                target = instr_get_raw_bits(tgt);
+            ASSERT(target != NULL);
+        } else
+            ASSERT_NOT_REACHED();
+
+        /* PR 251646: cti_short_rewrite: target is in src0, so operands are
+         * valid, but raw bits must also be valid, since they hide the multiple
+         * instrs.  For x64, it is marked for re-relativization, but it's
+         * special since the target must be obtained from src0 and not
+         * from the raw bits (since that might not reach).
+         */
+        /* need 9 bytes + possible addr prefix */
+        mangled_sz = CTI_SHORT_REWRITE_LENGTH;
+        if (!reg_is_pointer_sized(opnd_get_reg(instr_get_src(instr, 1))))
+            mangled_sz++; /* need addr prefix */
+        instr_allocate_raw_bits(dcontext, instr, mangled_sz);
+        offs = 0;
+        if (mangled_sz > CTI_SHORT_REWRITE_LENGTH) {
+            instr_set_raw_byte(instr, offs, ADDR_PREFIX_OPCODE);
+            offs++;
+        }
+        /* first 2 bytes: jecxz 8-bit-offset */
+        instr_set_raw_byte(instr, offs, decode_first_opcode_byte(opcode));
+        offs++;
+        /* remember pc-relative offsets are from start of next instr */
+        instr_set_raw_byte(instr, offs, (byte)2);
+        offs++;
+        /* next 2 bytes: jmp-short 8-bit-offset */
+        instr_set_raw_byte(instr, offs, decode_first_opcode_byte(OP_jmp_short));
+        offs++;
+        instr_set_raw_byte(instr, offs, (byte)5);
+        offs++;
+        /* next 5 bytes: jmp 32-bit-offset */
+        instr_set_raw_byte(instr, offs, decode_first_opcode_byte(OP_jmp));
+        offs++;
+        /* for x64 we may not reach, but we go ahead and try */
+        instr_set_raw_word(instr, offs, (int)(target - (instr->bytes + mangled_sz)));
+        offs += sizeof(int);
+        ASSERT(offs == mangled_sz);
+        LOG(THREAD, LOG_INTERP, 2, "convert_to_near_rel: jecxz/loop* opcode\n");
+        /* original target operand is still valid */
+        instr_set_operands_valid(instr, true);
+        return instr;
+    }
+
+    LOG(THREAD, LOG_INTERP, 1, "convert_to_near_rel: unknown opcode: %d %s\n", opcode,
+        decode_opcode_name(opcode));
+    ASSERT_NOT_REACHED(); /* conversion not possible OR not a short-form cti */
+    return instr;
+}
+
+/* For jecxz and loop*, we create 3 instructions in a single
+ * instr that we treat like a single conditional branch.
+ * On re-decoding our own output we need to recreate that instr.
+ * This routine assumes that the instructions encoded at pc
+ * are indeed a mangled cti short.
+ * Assumes that the first instr has already been decoded into instr,
+ * that pc points to the start of that instr.
+ * Converts instr into a new 3-raw-byte-instr with a private copy of the
+ * original raw bits.
+ * Optionally modifies the target to "target" if "target" is non-null.
+ * Returns the pc of the instruction after the remangled sequence.
+ */
+byte *
+remangle_short_rewrite(dcontext_t *dcontext, instr_t *instr, byte *pc, app_pc target)
+{
+    uint mangled_sz = CTI_SHORT_REWRITE_LENGTH;
+    ASSERT(instr_is_cti_short_rewrite(instr, pc));
+    if (*pc == ADDR_PREFIX_OPCODE)
+        mangled_sz++;
+
+    /* first set the target in the actual operand src0 */
+    if (target == NULL) {
+        /* acquire existing absolute target */
+        int rel_target = *((int *)(pc + mangled_sz - 4));
+        target = pc + mangled_sz + rel_target;
+    }
+    instr_set_target(instr, opnd_create_pc(target));
+    /* now set up the bundle of raw instructions
+     * we've already read the first 2-byte instruction, jecxz/loop*
+     * they all take up mangled_sz bytes
+     */
+    instr_allocate_raw_bits(dcontext, instr, mangled_sz);
+    instr_set_raw_bytes(instr, pc, mangled_sz);
+    /* for x64 we may not reach, but we go ahead and try */
+    instr_set_raw_word(instr, mangled_sz - 4, (int)(target - (pc + mangled_sz)));
+    /* now make operands valid */
+    instr_set_operands_valid(instr, true);
+    return (pc + mangled_sz);
+}

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -43,12 +43,12 @@
 #include "../globals.h" /* just to disable warning C4206 about an empty file */
 
 #include "instrument.h"
-#include "arch.h"
 #include "instr.h"
 #include "instr_create.h"
 #include "instrlist.h"
 #include "decode.h"
 #include "disassemble.h"
+#include "ir_utils.h"
 #include "../fragment.h"
 #include "../fcache.h"
 #include "../emit.h"


### PR DESCRIPTION
Moves the handful of functions from mangle.c used by drdecode (things
that are difficult to untangle from the IR functions) into ir_utils.c
Renames the top-level ir_utils.c to ir_utils_shared.c.  Adds
ir_utils.h.

Issue: #1684