### PR TITLE
i#1684 xarch-IR: Remove tls.h from drlibc

### DIFF
--- a/core/drlibc/drlibc_module_elf.c
+++ b/core/drlibc/drlibc_module_elf.c
@@ -36,7 +36,7 @@
 
 #include "../globals.h"
 #include "../module_shared.h"
-#include "os_private.h"
+#include "drlibc_unix.h"
 #include "module_private.h"
 #include "../utils.h"
 #include "instrument.h"

--- a/core/drlibc/drlibc_unix.c
+++ b/core/drlibc/drlibc_unix.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -63,11 +63,7 @@
 #    undef errno
 #endif
 
-/* XXX: We've moved this code out of core/unix but we're still including a private
- * header from there.  We should try to separate the headers a little better
- * to make this a more isolated library.
- */
-#include "os_private.h"
+#include "drlibc_unix.h"
 
 #ifdef LINUX
 #    include "module_private.h" /* for ELF_AUXV_TYPE and AT_PAGESZ */

--- a/core/drlibc/drlibc_unix.h
+++ b/core/drlibc/drlibc_unix.h
@@ -1,0 +1,69 @@
+/* **********************************************************
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/*
+ * drlibc_unix.h - declarations shared among UNIX-specific drlibc files and
+ * the core.
+ */
+
+#ifndef _DRLIBC_UNIX_H_
+#define _DRLIBC_UNIX_H_ 1
+
+/* Cross arch syscall nums for use with struct stat64. */
+#ifdef MACOS64
+#    define SYSNUM_STAT SYS_stat64
+#    define SYSNUM_FSTAT SYS_fstat64
+#elif defined(X64)
+#    ifdef SYS_stat
+#        define SYSNUM_STAT SYS_stat
+#    endif
+#    define SYSNUM_FSTAT SYS_fstat
+#else
+#    define SYSNUM_STAT SYS_stat64
+#    define SYSNUM_FSTAT SYS_fstat64
+#endif
+
+/* On Mac, we use the _nocancel variant to defer app-initiated thread termination */
+#ifdef MACOS
+#    define SYSNUM_NO_CANCEL(num) num##_nocancel
+#else
+#    define SYSNUM_NO_CANCEL(num) num
+#endif
+
+/* Maximum number of arguments to Linux syscalls. */
+enum { MAX_SYSCALL_ARGS = 6 };
+
+bool
+safe_read_if_fast(const void *base, size_t size, void *out_buf);
+
+#endif /* _DRLIBC_UNIX_H_ */

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -48,20 +48,7 @@
 #include "dr_config.h" /* for dr_platform_t */
 #include "tls.h"
 #include "memquery.h"
-
-/* Cross arch syscall nums for use with struct stat64. */
-#ifdef MACOS64
-#    define SYSNUM_STAT SYS_stat64
-#    define SYSNUM_FSTAT SYS_fstat64
-#elif defined(X64)
-#    ifdef SYS_stat
-#        define SYSNUM_STAT SYS_stat
-#    endif
-#    define SYSNUM_FSTAT SYS_fstat
-#else
-#    define SYSNUM_STAT SYS_stat64
-#    define SYSNUM_FSTAT SYS_fstat64
-#endif
+#include "../drlibc/drlibc_unix.h"
 
 /* for inline asm */
 #ifdef X86
@@ -121,16 +108,6 @@
      CLONE_SETTLS | CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID)
 
 #define SYSCALL_PARAM_CLONE_STACK 1
-
-/* On Mac, we use the _nocancel variant to defer app-initiated thread termination */
-#ifdef MACOS
-#    define SYSNUM_NO_CANCEL(num) num##_nocancel
-#else
-#    define SYSNUM_NO_CANCEL(num) num
-#endif
-
-/* Maximum number of arguments to Linux syscalls. */
-enum { MAX_SYSCALL_ARGS = 6 };
 
 struct _os_local_state_t;
 
@@ -252,9 +229,6 @@ set_app_args(int *, char **);
 
 uint
 memprot_to_osprot(uint prot);
-
-bool
-safe_read_if_fast(const void *base, size_t size, void *out_buf);
 
 bool
 mmap_syscall_succeeded(byte *retval);


### PR DESCRIPTION
Adds drlibc_unix.h to better separate drlibc and prevent it including
os_private.h and thus pulling in tls.h and other headers related to DR
execution, which incorrectly mixes target and host architectures for
drdecode and drdisas.

Issue: #1684