### PR TITLE
i#4326: Fix opcode_count sample to check for DRX_COUNTER_LOCK support on ARM

### DIFF
--- a/api/samples/opcode_count.cpp
+++ b/api/samples/opcode_count.cpp
@@ -94,7 +94,9 @@ event_opcode_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *i
         static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1),
         IF_AARCHXX_(static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1)) &
             global_opcode_count,
-        1, DRX_COUNTER_LOCK);
+        1,
+        /* DRX_COUNTER_LOCK is not yet supported on ARM */
+        IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
 
     return DR_EMIT_DEFAULT;
 }

--- a/api/samples/opcode_count.cpp
+++ b/api/samples/opcode_count.cpp
@@ -95,7 +95,7 @@ event_opcode_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *i
         IF_AARCHXX_(static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1)) &
             global_opcode_count,
         1,
-        /* DRX_COUNTER_LOCK is not yet supported on ARM */
+        /* TODO i#4215: DRX_COUNTER_LOCK is not yet supported on ARM. */
         IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
 
     return DR_EMIT_DEFAULT;
@@ -123,7 +123,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         IF_AARCHXX_(static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1)) &
             global_total_count,
         1,
-        /* DRX_COUNTER_LOCK is not yet supported on ARM */
+        /* TODO i#4215: DRX_COUNTER_LOCK is not yet supported on ARM. */
         IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
 
     return DR_EMIT_DEFAULT;

--- a/api/samples/opcode_count.cpp
+++ b/api/samples/opcode_count.cpp
@@ -120,7 +120,9 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1),
         IF_AARCHXX_(static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1)) &
             global_total_count,
-        1, DRX_COUNTER_LOCK);
+        1,
+        /* DRX_COUNTER_LOCK is not yet supported on ARM */
+        IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
 
     return DR_EMIT_DEFAULT;
 }

--- a/ext/drx/drx.h
+++ b/ext/drx/drx.h
@@ -159,7 +159,8 @@ DR_EXPORT
  * \note The counter update is racy (i.e., not synchronized among threads)
  * unless #DRX_COUNTER_LOCK is specified in \p flags. When #DRX_COUNTER_LOCK
  * is set, the instrumentation may fail if a 64-bit counter is updated in
- * a 32-bit application or the counter crosses cache lines.
+ * a 32-bit application or the counter crosses cache lines. Currently,
+ * #DRX_COUNTER_LOCK is not yet supported on ARM.
  *
  * \note To update multiple counters at the same place, multiple
  * drx_insert_counter_update() invocations should be made in a row with the


### PR DESCRIPTION
DRX_COUNTER_LOCK is not currently supported on ARM. The opcode_count sample did not have a check and therefore failed to count instructions properly. This check is added now.

Fixes: #4326