### PR TITLE
Fixed bug where multiple drwrap_skip_call calls would fail

### DIFF
--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -1994,6 +1994,7 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(reg_t lr))
     if (pt->skip[pt->wrap_level]) {
         /* drwrap_skip_call already adjusted the stack and pc */
         /* ensure we have DR_MC_ALL */
+        pt->wrap_level--;
         dr_redirect_execution(drwrap_get_mcontext_internal((void *)&wrapcxt, DR_MC_ALL));
         ASSERT(false, "dr_redirect_execution should not return");
     }


### PR DESCRIPTION
wrap_level was not being decremented when a function call is skipped, this
eventually lead to the MAX_WRAP_NESTING limit being hit