### PR TITLE
i#4318 xarch memtrace: Bump version and add message for arch tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,10 +136,6 @@ jobs:
       compiler: gcc
       env: DYNAMORIO_CROSS_ANDROID_ONLY=yes DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e' DEPLOY=yes EXTRA_ARGS=32_only
 
-before_install:
-  # workaround for https://github.com/travis-ci/travis-ci/issues/8973
-  - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
-
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:
   - uname -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,6 +136,10 @@ jobs:
       compiler: gcc
       env: DYNAMORIO_CROSS_ANDROID_ONLY=yes DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e' DEPLOY=yes EXTRA_ARGS=32_only
 
+before_install:
+  # workaround for https://github.com/travis-ci/travis-ci/issues/8973
+  - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
+
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:
   - uname -a

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -53,7 +53,7 @@
 
 typedef uintptr_t addr_t; /**< The type of a memory address. */
 
-#define TRACE_ENTRY_VERSION 1 /**< The version of the trace format. */
+#define TRACE_ENTRY_VERSION 2 /**< The version of the trace format. */
 
 /** The type of a trace entry in a #memref_t structure. */
 // The type identifier for trace entries in the raw trace_entry_t passed to

--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -163,8 +163,17 @@ protected:
         trace_entry_t header, next, pid = {};
         for (index_ = 0; index_ < input_files_.size(); ++index_) {
             if (!read_next_thread_entry(index_, &header, &thread_eof_[index_]) ||
-                header.type != TRACE_TYPE_HEADER || header.addr != TRACE_ENTRY_VERSION) {
+                header.type != TRACE_TYPE_HEADER) {
                 ERRMSG("Invalid header for input file #%zu\n", index_);
+                return false;
+            }
+            // We can handle the older version 1 as well which simply omits the
+            // early marker with the arch tag.
+            if (header.addr > TRACE_ENTRY_VERSION) {
+                ERRMSG(
+                    "Cannot handle version #%zu (expect version <= #%u) for input file "
+                    "#%zu\n",
+                    header.addr, TRACE_ENTRY_VERSION, index_);
                 return false;
             }
             // Read the meta entries until we hit the pid.


### PR DESCRIPTION
PR #4331 commit 5d49675c added a new marker with the architecture
early in a trace, enough to break the file_reader_t assumptions.  The
file reader was updated, but it's best to also bump the version for
old binary code.  Additionally, we provide a separate distinct message
about a version mismatch (otherwise the error message from the old
reader is the same as without the version bump).

Issue: #4318