### PR TITLE
i#4223: Fix truncated log issue for macOS on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,10 +136,6 @@ jobs:
       compiler: gcc
       env: DYNAMORIO_CROSS_ANDROID_ONLY=yes DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e' DEPLOY=yes EXTRA_ARGS=32_only
 
-before_install:
-  # workaround for https://github.com/travis-ci/travis-ci/issues/8973
-  - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
-
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:
   - uname -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,6 +136,10 @@ jobs:
       compiler: gcc
       env: DYNAMORIO_CROSS_ANDROID_ONLY=yes DYNAMORIO_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e' DEPLOY=yes EXTRA_ARGS=32_only
 
+before_install:
+  # workaround for https://github.com/travis-ci/travis-ci/issues/8973
+  - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
+
 # For C/C++ there is no default install, so we set "install", not "before_install".
 install:
   - uname -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ jobs:
       os: osx
       # gcc on Travis claims to not be CMAKE_COMPILER_IS_GNUCC so we only run clang.
       compiler: clang
-      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=64_only
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=64_only SLEEP_AFTER_SCRIPT_OR_FAILURE=yes
     # AArch64 drdecode and drmemtrace on x86:
     - if: type != cron AND env(TRAVIS_EVENT_TYPE) != cron
       os: linux
@@ -185,11 +185,13 @@ script:
   - travis_wait 45 suite/runsuite_wrapper.pl travis $EXTRA_ARGS
 
 after_script:
-  - sleep 10
+  # Workaround for DynamoRIO/dynamorio#4223
+  - test $SLEEP_AFTER_SCRIPT_OR_FAILURE = "yes" && sleep 10
   - echo "--end--"
 
 after_failure:
-  - sleep 10
+  # Workaround for DynamoRIO/dynamorio#4223
+  - test $SLEEP_AFTER_SCRIPT_OR_FAILURE = "yes" && sleep 10
   - echo "--end--"
 
 # We switch to package.cmake for these builds in runsuite_wrapper.pl by looking

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,14 +109,12 @@ jobs:
       env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=64_only
       after_script:
         # Travis logs for OSX builds are truncated because the VM exits early.
-        # Sleep to allow Travis to capture complete log. More context on
-        # DynamoRIO/dynamorio#4223.
+        # Sleep to allow Travis to capture complete log. More context on i#4223.
         - sleep 10
         - echo "--end--"
       after_failure:
         # Travis logs for OSX builds are truncated because the VM exits early.
-        # Sleep to allow Travis to capture complete log. More context on
-        # DynamoRIO/dynamorio#4223.
+        # Sleep to allow Travis to capture complete log. More context on i#4223.
         - sleep 10
         - echo "--end--"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -184,6 +184,14 @@ install:
 script:
   - travis_wait 45 suite/runsuite_wrapper.pl travis $EXTRA_ARGS
 
+after_script:
+  - sleep 10
+  - echo "--end--"
+
+after_failure:
+  - sleep 10
+  - echo "--end--"
+
 # We switch to package.cmake for these builds in runsuite_wrapper.pl by looking
 # for $TRAVIS_EVENT_TYPE=="cron".
 # The before_deploy commands are run before each deployer, so they are also

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,20 @@ jobs:
       os: osx
       # gcc on Travis claims to not be CMAKE_COMPILER_IS_GNUCC so we only run clang.
       compiler: clang
-      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=64_only SLEEP_AFTER_SCRIPT_OR_FAILURE=yes
+      env: DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY=no DEPLOY=no EXTRA_ARGS=64_only
+      after_script:
+        # Travis logs for OSX builds are truncated because the VM exits early.
+        # Sleep to allow Travis to capture complete log. More context on
+        # DynamoRIO/dynamorio#4223.
+        - sleep 10
+        - echo "--end--"
+      after_failure:
+        # Travis logs for OSX builds are truncated because the VM exits early.
+        # Sleep to allow Travis to capture complete log. More context on
+        # DynamoRIO/dynamorio#4223.
+        - sleep 10
+        - echo "--end--"
+
     # AArch64 drdecode and drmemtrace on x86:
     - if: type != cron AND env(TRAVIS_EVENT_TYPE) != cron
       os: linux
@@ -185,17 +198,9 @@ script:
   - travis_wait 45 suite/runsuite_wrapper.pl travis $EXTRA_ARGS
 
 after_script:
-  # Travis logs for OSX builds are truncated because the VM exits early.
-  # Sleep to allow Travis to capture complete log. More context on
-  # DynamoRIO/dynamorio#4223.
-  - test $SLEEP_AFTER_SCRIPT_OR_FAILURE = "yes" && sleep 10
   - echo "--end--"
 
 after_failure:
-  # Travis logs for OSX builds are truncated because the VM exits early.
-  # Sleep to allow Travis to capture complete log. More context on
-  # DynamoRIO/dynamorio#4223.
-  - test $SLEEP_AFTER_SCRIPT_OR_FAILURE = "yes" && sleep 10
   - echo "--end--"
 
 # We switch to package.cmake for these builds in runsuite_wrapper.pl by looking

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,12 +185,16 @@ script:
   - travis_wait 45 suite/runsuite_wrapper.pl travis $EXTRA_ARGS
 
 after_script:
-  # Workaround for DynamoRIO/dynamorio#4223
+  # Travis logs for OSX builds are truncated because the VM exits early.
+  # Sleep to allow Travis to capture complete log. More context on
+  # DynamoRIO/dynamorio#4223.
   - test $SLEEP_AFTER_SCRIPT_OR_FAILURE = "yes" && sleep 10
   - echo "--end--"
 
 after_failure:
-  # Workaround for DynamoRIO/dynamorio#4223
+  # Travis logs for OSX builds are truncated because the VM exits early.
+  # Sleep to allow Travis to capture complete log. More context on
+  # DynamoRIO/dynamorio#4223.
   - test $SLEEP_AFTER_SCRIPT_OR_FAILURE = "yes" && sleep 10
   - echo "--end--"
 


### PR DESCRIPTION
Sleep for 10 seconds after script run/failure to allow some time for Travis to capture the complete log.  It was used as a workaround also at travis-ci/travis-ci#6018.

Also attempted another workaround (using fcntl) from travis-ci/travis-ci#8973 but it didn't work as expected.

Fixes: #4223 