### PR TITLE
Add missing system registers for AArch64

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -211,6 +211,8 @@ decode_sysreg(uint imm15)
     case 0x5a20: sysreg = DR_REG_FPCR; break;
     case 0x5a21: sysreg = DR_REG_FPSR; break;
     case 0x5e82: sysreg = DR_REG_TPIDR_EL0; break;
+    case 0x5e83: sysreg = DR_REG_TPIDRRO_EL0; break;
+    case 0x5f02: sysreg = DR_REG_CNTVCT_EL0; break;
     default: return opnd_create_immed_uint(imm15, OPSZ_2);
     }
     return opnd_create_reg(sysreg);
@@ -225,6 +227,8 @@ encode_sysreg(OUT uint *imm15, opnd_t opnd)
         case DR_REG_FPCR: *imm15 = 0x5a20; break;
         case DR_REG_FPSR: *imm15 = 0x5a21; break;
         case DR_REG_TPIDR_EL0: *imm15 = 0x5e82; break;
+        case DR_REG_TPIDRRO_EL0: *imm15 = 0x5e83; break;
+        case DR_REG_CNTVCT_EL0: *imm15 = 0x5f02; break;
         default: return false;
         }
         return true;

--- a/core/ir/opnd.h
+++ b/core/ir/opnd.h
@@ -708,6 +708,11 @@ enum {
     DR_REG_TPIDRURO, /**< User Read-Only Thread ID Register */
 
 #    ifdef AARCH64
+    /* AArch64 Counter/Timer Register(s) */
+    DR_REG_CNTVCT_EL0, /**< Virtual Timer Count Register, EL0. */
+#    endif
+
+#    ifdef AARCH64
     /* SVE vector registers */
     DR_REG_Z0,
     DR_REG_Z1,

--- a/core/ir/opnd.h
+++ b/core/ir/opnd.h
@@ -821,8 +821,8 @@ enum {
     /** Thread Pointer/ID Register, Read-Only, EL0. */
     DR_REG_TPIDRRO_EL0 = DR_REG_TPIDRURO,
     /* ARMv7 Thread Registers */
-    DR_REG_CP15_C13_2 = DR_REG_TPIDRURW, /**< User Read/Write Thread ID Register */
-    DR_REG_CP15_C13_3 = DR_REG_TPIDRURO, /**< User Read-Olny Thread ID Register */
+    DR_REG_CP15_C13_2 = DR_REG_TPIDRURW,        /**< User Read/Write Thread ID Register */
+    DR_REG_CP15_C13_3 = DR_REG_TPIDRURO,        /**< User Read-Only Thread ID Register */
 
 #    ifdef AARCH64
     DR_REG_LAST_VALID_ENUM = DR_REG_CNTVCT_EL0, /**< Last valid register enum */

--- a/core/ir/opnd.h
+++ b/core/ir/opnd.h
@@ -708,11 +708,6 @@ enum {
     DR_REG_TPIDRURO, /**< User Read-Only Thread ID Register */
 
 #    ifdef AARCH64
-    /* AArch64 Counter/Timer Register(s) */
-    DR_REG_CNTVCT_EL0, /**< Virtual Timer Count Register, EL0. */
-#    endif
-
-#    ifdef AARCH64
     /* SVE vector registers */
     DR_REG_Z0,
     DR_REG_Z1,
@@ -764,6 +759,11 @@ enum {
     DR_REG_P13,
     DR_REG_P14,
     DR_REG_P15,
+#    endif
+
+#    ifdef AARCH64
+    /* AArch64 Counter/Timer Register(s) */
+    DR_REG_CNTVCT_EL0, /**< Virtual Timer Count Register, EL0. */
 #    endif
 
 /* Aliases below here: */
@@ -825,8 +825,8 @@ enum {
     DR_REG_CP15_C13_3 = DR_REG_TPIDRURO, /**< User Read-Olny Thread ID Register */
 
 #    ifdef AARCH64
-    DR_REG_LAST_VALID_ENUM = DR_REG_P15, /**< Last valid register enum */
-    DR_REG_LAST_ENUM = DR_REG_P15,       /**< Last value of register enums */
+    DR_REG_LAST_VALID_ENUM = DR_REG_CNTVCT_EL0, /**< Last valid register enum */
+    DR_REG_LAST_ENUM = DR_REG_CNTVCT_EL0,       /**< Last value of register enums */
 #    else
     DR_REG_LAST_VALID_ENUM = DR_REG_TPIDRURO, /**< Last valid register enum */
     DR_REG_LAST_ENUM = DR_REG_TPIDRURO,       /**< Last value of register enums */


### PR DESCRIPTION
#1569 Add decoding and encoding for system registers TPIDRRO_EL0 and CNTVCT_EL0.