### PR TITLE
i#4334: Fix leaks on thread exit

### DIFF
--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -1252,7 +1252,7 @@ dispatch_exit_fcache(dcontext_t *dcontext)
                     todo->tag);
             }
 
-            HEAP_TYPE_FREE(dcontext, todo, client_todo_list_t, ACCT_CLIENT, UNPROTECTED);
+            HEAP_TYPE_FREE(dcontext, todo, client_todo_list_t, ACCT_CLIENT, PROTECTED);
             todo = next_todo;
         }
         dcontext->client_data->to_do = NULL;

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -2750,6 +2750,11 @@ dr_app_setup(void)
      */
     int res;
     dcontext_t *dcontext;
+    /* If this is a re-attach, .data might be read-only.
+     * We'll re-protect at the end of dynamorio_app_init().
+     */
+    if (DATASEC_WRITABLE(DATASEC_RARELY_PROT) == 0)
+        SELF_UNPROTECT_DATASEC(DATASEC_RARELY_PROT);
     dr_api_entry = true;
     res = dynamorio_app_init();
     /* For dr_api_entry, we do not install all our signal handlers during init (to avoid

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -1148,7 +1148,10 @@ hashtable_fragment_reset(dcontext_t *dcontext, fragment_table_t *table)
             ASSERT_TABLE_SYNCHRONIZED(table, WRITE);
     });
 #    if !defined(DEBUG) && defined(CLIENT_INTERFACE)
-    if (!dr_fragment_deleted_hook_exists())
+    /* We need to walk the table if either we need to notify clients, or we
+     * need to free stubs that are not in the regular heap or cache units.
+     */
+    if (!dr_fragment_deleted_hook_exists() && !DYNAMO_OPTION(separate_private_stubs))
         return;
     /* i#4226: Avoid the slow deletion code and just invoke the event. */
     for (i = 0; i < (int)table->capacity; i++) {
@@ -1161,7 +1164,8 @@ hashtable_fragment_reset(dcontext_t *dcontext, fragment_table_t *table)
          */
         instrument_fragment_deleted(dcontext, f->tag, f->flags);
     }
-    return;
+    if (!DYNAMO_OPTION(separate_private_stubs))
+        return;
 #    endif
     /* Go in reverse order (for efficiency) since using
      * hashtable_fragment_remove_helper to keep all reachable, which is required

--- a/core/globals.h
+++ b/core/globals.h
@@ -306,6 +306,16 @@ typedef struct _dr_stats_t {
      * an un-translatable spot.
      */
     uint64 synchs_not_at_safe_spot;
+    /** Peak number of memory blocks used for heaps. */
+    uint64 peak_vmm_blocks_heap;
+    /** Peak number of memory blocks used for thread stacks. */
+    uint64 peak_vmm_blocks_stack;
+    /** Peak number of memory blocks used for code caches. */
+    uint64 peak_vmm_blocks_cache;
+    /** Peak number of memory blocks used for specialized heaps. */
+    uint64 peak_vmm_blocks_special_heap;
+    /** Peak number of memory blocks used for mappings not in other categories. */
+    uint64 peak_vmm_blocks_special_mmap;
 } dr_stats_t;
 
 /**

--- a/core/heap.c
+++ b/core/heap.c
@@ -2505,6 +2505,9 @@ report_low_on_memory(oom_source_t source, heap_error_code_t os_error_code)
         SYSLOG_CUSTOM_NOTIFY(SYSLOG_CRITICAL, MSG_OUT_OF_MEMORY, 4,
                              "Out of memory.  Program aborted.", get_application_name(),
                              get_application_pid(), oom_source_code, status_hex);
+        /* Stats can be very useful to diagnose why we hit OOM. */
+        if (INTERNAL_OPTION(rstats_to_stderr))
+            dump_global_rstats_to_stderr();
 
         /* FIXME: case 7306 can't specify arguments in SYSLOG_CUSTOM_NOTIFY */
         SYSLOG_INTERNAL_WARNING("OOM Status: %s %s", oom_source_code, status_hex);
@@ -4029,6 +4032,7 @@ heap_thread_exit(dcontext_t *dcontext)
     }
     if (!REACHABLE_HEAP()) { /* If off, all heap is reachable. */
         ASSERT(th->reachable_heap != NULL);
+        threadunits_exit(th->reachable_heap, dcontext);
         global_heap_free(th->reachable_heap,
                          sizeof(thread_units_t) HEAPACCT(ACCT_MEM_MGT));
     }

--- a/core/stats.c
+++ b/core/stats.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -365,14 +365,13 @@ kstat_thread_exit(dcontext_t *dcontext)
     kstat_merge(&process_kstats, &old_thread_kstats->vars_kstats);
     d_r_mutex_unlock(&process_kstats_lock);
 
-#    ifdef DEBUG
-    /* for non-debug we do fast exit path and don't free local heap */
-    /* no clean up needed */
-    dcontext->thread_kstats = NULL; /* disable thread kstats before freeing memory */
-    HEAP_TYPE_FREE(dcontext, old_thread_kstats, thread_kstats_t, ACCT_STATS, UNPROTECTED);
-#    else
+#    ifndef DEBUG
     close_log_file(dcontext->thread_kstats->outfile_kstats);
-#    endif /* DEBUG */
+#    endif
+    /* Disable kstats before freeing memory to avoid use-after-free on free path. */
+    dcontext->thread_kstats = NULL;
+    /* We need to free kstats even in non-debug b/c unprot local heap is global. */
+    HEAP_TYPE_FREE(dcontext, old_thread_kstats, thread_kstats_t, ACCT_STATS, UNPROTECTED);
 }
 
 #endif /* KSTATS */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -1376,9 +1376,7 @@ signal_thread_exit(dcontext_t *dcontext, bool other_thread)
     IF_LINUX(signalfd_thread_exit(dcontext, info));
     special_heap_exit(info->sigheap);
     DELETE_LOCK(info->child_lock);
-#ifdef DEBUG
-    /* for non-debug we do fast exit path and don't free local heap */
-#    ifdef HAVE_SIGALTSTACK
+#ifdef HAVE_SIGALTSTACK
     if (info->sigstack.ss_sp != NULL) {
         /* i#552: to raise client exit event, we may call dynamo_process_exit
          * on sigstack in signal handler.
@@ -1386,7 +1384,9 @@ signal_thread_exit(dcontext_t *dcontext, bool other_thread)
          */
         stack_free(info->sigstack.ss_sp + info->sigstack.ss_size, info->sigstack.ss_size);
     }
-#    endif
+#endif
+#ifdef DEBUG
+    /* for non-debug we do fast exit path and don't free local heap */
     HEAP_TYPE_FREE(dcontext, info, thread_sig_info_t, ACCT_OTHER, PROTECTED);
 #endif
 #ifdef PAPI

--- a/core/utils.c
+++ b/core/utils.c
@@ -3067,17 +3067,16 @@ stats_thread_init(dcontext_t *dcontext)
 void
 stats_thread_exit(dcontext_t *dcontext)
 {
-#    ifdef DEBUG
-    /* for non-debug we do fast exit path and don't free local heap */
-    /* no clean up needed */
+    /* We need to free even in non-debug b/c unprot local heap is global. */
     if (dcontext->thread_stats) {
         thread_local_statistics_t *old_thread_stats = dcontext->thread_stats;
+#    ifdef DEBUG
         DELETE_LOCK(old_thread_stats->thread_stats_lock);
+#    endif
         dcontext->thread_stats = NULL; /* disable thread stats before freeing memory */
         HEAP_TYPE_FREE(dcontext, old_thread_stats, thread_local_statistics_t, ACCT_STATS,
                        UNPROTECTED);
     }
-#    endif
 }
 
 void
@@ -3454,6 +3453,8 @@ utils_exit()
 {
     LOG(GLOBAL, LOG_STATS, 1, "-prng_seed " PFX " for reproducing random sequence\n",
         initial_random_seed);
+    if (doing_detach)
+        enable_new_log_dir(); /* For potential re-attach. */
 
     DELETE_LOCK(report_buf_lock);
     DELETE_RECURSIVE_LOCK(logdir_mutex);
@@ -4608,6 +4609,14 @@ stats_get_snapshot(dr_stats_t *drstats)
     drstats->num_threads_created = GLOBAL_STAT(num_threads_created);
     if (drstats->size > offsetof(dr_stats_t, synchs_not_at_safe_spot)) {
         drstats->synchs_not_at_safe_spot = GLOBAL_STAT(synchs_not_at_safe_spot);
+    }
+    if (drstats->size > offsetof(dr_stats_t, peak_vmm_blocks_heap)) {
+        /* These fields were added all at once. */
+        drstats->peak_vmm_blocks_heap = GLOBAL_STAT(peak_vmm_blocks_heap);
+        drstats->peak_vmm_blocks_stack = GLOBAL_STAT(peak_vmm_blocks_stack);
+        drstats->peak_vmm_blocks_cache = GLOBAL_STAT(peak_vmm_blocks_cache);
+        drstats->peak_vmm_blocks_special_heap = GLOBAL_STAT(peak_vmm_blocks_special_heap);
+        drstats->peak_vmm_blocks_special_mmap = GLOBAL_STAT(peak_vmm_blocks_special_mmap);
     }
     return true;
 }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2892,6 +2892,11 @@ if (CLIENT_INTERFACE)
       tobuild_static_nohide_api(api.static_maps_mixup_novars_FLAKY
          api/static_maps_mixup.c "" "" OFF)
     endif ()
+
+    if (NOT WIN32) # TODO i#4349: Fix re-attach issues to enable.
+      tobuild_api(api.thread_churn api/thread_churn.c "" "" OFF OFF)
+      link_with_pthread(api.thread_churn)
+    endif ()
   endif ()
 
   if (NOT X64 AND NOT ARM) # FIXME i#1551: port to ARM

--- a/suite/tests/api/thread_churn.c
+++ b/suite/tests/api/thread_churn.c
@@ -1,0 +1,106 @@
+/* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "configure.h"
+#include "dr_api.h"
+#include "tools.h"
+#include "thread.h"
+#include <math.h>
+
+DR_EXPORT void
+dr_client_main(client_id_t id, int argc, const char *argv[])
+{
+    print("in dr_client_main\n");
+}
+
+static THREAD_FUNC_RETURN_TYPE
+thread_function(void *arg)
+{
+    return THREAD_FUNC_RETURN_ZERO;
+}
+
+static void
+churn_threads(int count)
+{
+    thread_t thread;
+    for (int i = 0; i < count; ++i) {
+        thread = create_thread(thread_function, NULL);
+        join_thread(thread);
+    }
+}
+
+int
+main(int argc, char **argv)
+{
+    /* We test thread exit leaks by ensuring memory usage is the same after
+     * both 5 threads and 500 threads.
+     */
+    const int count_A = 10;
+    const int count_B = 500;
+#define VERBOSE 0
+#if VERBOSE
+    if (!my_setenv("DYNAMORIO_OPTIONS", "-rstats_to_stderr -stderr_mask 0xc"))
+        print("Failed to set env var!\n");
+#endif
+
+    assert(!dr_app_running_under_dynamorio());
+    dr_app_setup_and_start();
+    assert(dr_app_running_under_dynamorio());
+    churn_threads(count_A);
+    dr_stats_t stats_A = { sizeof(dr_stats_t) };
+    dr_app_stop_and_cleanup_with_stats(&stats_A);
+    assert(!dr_app_running_under_dynamorio());
+    assert(stats_A.peak_num_threads == 2);
+    assert(stats_A.num_threads_created == count_A + 1);
+
+    assert(!dr_app_running_under_dynamorio());
+    dr_app_setup_and_start();
+    assert(dr_app_running_under_dynamorio());
+    churn_threads(count_B);
+    dr_stats_t stats_B = { sizeof(dr_stats_t) };
+    dr_app_stop_and_cleanup_with_stats(&stats_B);
+    assert(!dr_app_running_under_dynamorio());
+    assert(stats_B.peak_num_threads == 2);
+    assert(stats_B.num_threads_created == count_B + 1);
+
+    /* XXX: Somehow the first run has *more* heap blocks.  2nd and any subsequent
+     * are identical.  Just living with that and requiring <=.
+     */
+    assert(stats_B.peak_vmm_blocks_heap <= stats_A.peak_vmm_blocks_heap);
+    assert(stats_B.peak_vmm_blocks_stack <= stats_A.peak_vmm_blocks_stack);
+    assert(stats_B.peak_vmm_blocks_cache <= stats_A.peak_vmm_blocks_cache);
+    assert(stats_B.peak_vmm_blocks_special_heap <= stats_A.peak_vmm_blocks_special_heap);
+    assert(stats_B.peak_vmm_blocks_special_mmap <= stats_A.peak_vmm_blocks_special_mmap);
+
+    print("all done\n");
+    return 0;
+}

--- a/suite/tests/api/thread_churn.expect
+++ b/suite/tests/api/thread_churn.expect
@@ -1,0 +1,1 @@
+all done


### PR DESCRIPTION
These leaks are all cleaned up at process exit, which is why the
existing exit-time leak checks don't notice anything.  The global
block list lets us clean them up later, and hence a classic
reachability-based leak detector would not catch them either: so
perhaps they should be called "reachable accumulations" instead of
"leaks".

Fixes a memory leak on thread exit in all builds:
+ The private reachable_heap units were not being freed

Fixes a number of memory leaks on thread exit in release build:
+ Adds individual private fragment deletion on thread exit, to free
  stubs if -separate_private_stubs is on.
  Turns off -separate_private_stubs by default, to avoid this for
  shared caches where there are few benefits to separating private stubs.
  -thread_private turns it back on where the benefits probably outweight
  the thread exit costs.
+ Moves the privload_tls_exit call to release build too to properly
  unmap the TLS.
+ Moves the sigaltstack free to release build to properly free it.
+ Moves freeing of "local unprotected" heap to the release-build path,
  since it is actually global!  This is done for kstats, stats, and
  clone_tls.
+ Moves client_data_t, client_todo_list_t, and thread-private
  client_flush_req_t to be PROTECTED to make it thread-local and thus
  not need freeing (the free is avoided for i#271).

Adds an -rstats_to_stderr dump point when DR terminates for OOM to
make it much easier to diagnose what the problem is.

Adds a new api.thread_churn test which attaches twice, once with a few
threads and once with many threads, and confirms memory usage has not
gone up.  The 5 rstats on peak vmm block sizes are added to dr_stats_t
to facilitate this.

I tried to get api.thread_churn to work on Windows but hit a number of
issues with reattach.  I solved two of them before bailing and making
the test UNIX-only for now and filed the rest as #4349.
+ Unprotect .data on reattach
+ Clear the logfile flag on detach

Issue: #4334, #271, #4349
Fixes #4334