### PR TITLE
Experimental: Change top-level dist setting to bionic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ branches:
 
 # We use Xenial.
 sudo: required
-dist: xenial
+dist: bionic
 
 language:
   - c


### PR DESCRIPTION
This is to verify whether setting dist at top-level has an effect at all. If it doesn't, we'll see Travis continue to use the default xenial build environment.
 In case of osx_image, the top-level setting had to be moved to the jobs section for it to really take effect.