### PR TITLE
i#1684 xarch-IR: Fix drwrap host!=target undef sym

### DIFF
--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -1624,7 +1624,10 @@ drwrap_replace_native_fini(void *drcontext)
      */
     volatile app_pc app_retaddr;
     byte *xsp = (byte *)dr_read_saved_reg(drcontext, DRWRAP_REPLACE_NATIVE_SP_SLOT);
-#ifdef AARCHXX
+#ifdef DR_HOST_NOT_TARGET
+    byte *cur_xsp = NULL;
+    ASSERT(false, "cross-arch execution is not supported");
+#elif defined(AARCHXX)
     byte *cur_xsp = get_cur_xsp();
 #endif
     ASSERT(xsp != NULL, "did client clobber TLS slot?");


### PR DESCRIPTION
Fixes an undefined symbol in drwrap when host!=target.
Only some compilers complain about it.

Issue: #1684