### PR TITLE
i#4318 xarch memtrace: Remove raw from final name

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -62,7 +62,7 @@
 
 #define OUTFILE_SUFFIX "raw"
 #ifdef HAS_ZLIB
-#    define OUTFILE_SUFFIX_GZ "gz"
+#    define OUTFILE_SUFFIX_GZ "raw.gz"
 #endif
 #define OUTFILE_SUBDIR "raw"
 #define TRACE_SUBDIR "trace"

--- a/clients/drcachesim/tracer/raw2trace_directory.cpp
+++ b/clients/drcachesim/tracer/raw2trace_directory.cpp
@@ -115,10 +115,10 @@ raw2trace_directory_t::open_thread_log_file(const char *basename)
     const char *basename_pre_suffix = nullptr;
     bool is_gzipped = false;
 #ifdef HAS_ZLIB
-    basename_pre_suffix = strstr(basename_dot, OUTFILE_SUFFIX_GZ);
+    basename_pre_suffix =
+        strstr(basename_dot - strlen(OUTFILE_SUFFIX_GZ), OUTFILE_SUFFIX_GZ);
     if (basename_pre_suffix != nullptr) {
         is_gzipped = true;
-        basename_dot = strrchr(basename_pre_suffix, '.');
     }
 #endif
     if (basename_pre_suffix == nullptr)


### PR DESCRIPTION
When raw files are gzipped and named xxx.raw.gz, the corresponding
final trace files end up named xxx.raw.trace.gz, i.e., with an extra
"raw." in there.  We fix that here.

Issue: #4318