### PR TITLE
i#2285: Support cross-compile target-arch zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1749,16 +1749,10 @@ function (link_with_pthread target)
 endfunction ()
 
 # zlib and snappy are used for some clients/ and tests.
-if (CMAKE_CROSSCOMPILING)
-  # find_package looks at the host system.
-  # XXX i#2285: we should re-visit the CMAKE_FIND_ROOT_PATH settings!
-  set(ZLIB_FOUND OFF)
-else ()
-  find_package(ZLIB)
-  # On Ubuntu 14.10, 32-bit builds fail to link with -lsnappy, just ignore.
-  if (UNIX AND X64)
-    find_library(libsnappy snappy)
-  endif ()
+find_package(ZLIB)
+# On Ubuntu 14.10, 32-bit builds fail to link with -lsnappy, just ignore.
+if (UNIX AND X64)
+  find_library(libsnappy snappy)
 endif ()
 
 if (BUILD_CLIENTS)


### PR DESCRIPTION
Removes the stale workaround put in place that disabled zlib
altogether for cross-compiling before we had CMAKE_FIND_ROOT_PATH set
properly in all of our toolchain files.  Now that we're seeing the
find-root properly we need to remove the workaround to allow finding a
target zlib when cross-compiling.

Tested manually on an aarch64 cross-compilation.

The core of i#2285 was fixed earlier by PR #2551; this finishes off
the issue.

Fixes #2285