### PR TITLE
Fix compilation on old Linux which does not have EM_ARM/EM_AARCH64 symbols

### DIFF
--- a/core/unix/module_elf.h
+++ b/core/unix/module_elf.h
@@ -193,7 +193,7 @@
 #    endif                 /* ANDROID */
 #endif                     /* X86/ARM */
 
-/* Define ARM ELF machine types to support compiling on old Linux distors. */
+/* Define ARM ELF machine types to support compiling on old Linux distros. */
 #ifndef EM_ARM
 #    define EM_ARM 40
 #endif

--- a/core/unix/module_elf.h
+++ b/core/unix/module_elf.h
@@ -195,10 +195,10 @@
 
 /* Define ARM ELF machine types to support compiling on old Linux distors. */
 #ifndef EM_ARM
-#define EM_ARM 40
+#   define EM_ARM 40
 #endif
 #ifndef EM_AARCH64
-#define EM_AARCH64 183
+#   define EM_AARCH64 183
 #endif
 
 bool

--- a/core/unix/module_elf.h
+++ b/core/unix/module_elf.h
@@ -193,6 +193,14 @@
 #    endif                 /* ANDROID */
 #endif                     /* X86/ARM */
 
+/* Define ARM ELF machine types to support compiling on old Linux distors. */
+#ifndef EM_ARM
+#define EM_ARM 40
+#endif
+#ifndef EM_AARCH64
+#define EM_AARCH64 183
+#endif
+
 bool
 get_elf_platform(file_t f, dr_platform_t *platform);
 

--- a/core/unix/module_elf.h
+++ b/core/unix/module_elf.h
@@ -195,10 +195,10 @@
 
 /* Define ARM ELF machine types to support compiling on old Linux distors. */
 #ifndef EM_ARM
-#   define EM_ARM 40
+#    define EM_ARM 40
 #endif
 #ifndef EM_AARCH64
-#   define EM_AARCH64 183
+#    define EM_AARCH64 183
 #endif
 
 bool


### PR DESCRIPTION
Hi!

I tried to build DynamoRIO on CentOS 6.9. I failed because old Linux distribution does not have EM_AARCH64 symbol which leads to compilation errrors. This merge request fixes compilation on CentOS 6.9 and maybe other old distros.