### PR TITLE
i#2390: Replace add+ldar with ldr+dmb in AArch64 HT lookup

### DIFF
--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -685,7 +685,6 @@ emit_indirect_branch_lookup(dcontext_t *dc, generated_code_t *code, byte *pc,
 
     instr_t *load_tag = INSTR_CREATE_label(dc);
     instr_t *compare_tag = INSTR_CREATE_label(dc);
-    instr_t *try_next = INSTR_CREATE_label(dc);
     instr_t *miss = INSTR_CREATE_label(dc);
     instr_t *not_hit = INSTR_CREATE_label(dc);
     instr_t *target_delete_entry = INSTR_CREATE_label(dc);
@@ -717,29 +716,33 @@ emit_indirect_branch_lookup(dcontext_t *dc, generated_code_t *code, byte *pc,
      *     x2: app's x2
      *     TLS_REG1_SLOT: app's x0 (recovered by fragment_prefix)
      */
-
     /* Spill x0. */
-    APP(&ilist, instr_create_save_to_tls(dc, DR_REG_R0, TLS_REG3_SLOT));
-    /* Load-acquire hash mask.  We need a load-acquire to ensure we see updates
-     * properly; the corresponding store-release is in update_lookuptable_tls().
+    APP(&ilist, instr_create_save_to_tls(dc, DR_REG_X0, TLS_REG3_SLOT));
+    /* Load hash mask before loading hash_table, with DMB to prevent memory-access
+     * instructions from being reordered. A corresponding store-release is in
+     * update_lookuptable_tls() to ensure a new hast_table will be written after a
+     * new hash mask write has been issued.
      */
-    /* add x1, x28 + hash_mask_offs; ldar x1, [x1]    (ldar doesn't take an offs.) */
     APP(&ilist,
-        INSTR_CREATE_add(dc, opnd_create_reg(DR_REG_X1), opnd_create_reg(dr_reg_stolen),
-                         OPND_CREATE_INT32(TLS_MASK_SLOT(ibl_code->branch_type))));
+        INSTR_CREATE_ldr(dc, opnd_create_reg(DR_REG_X1),
+                         opnd_create_base_disp(dr_reg_stolen, DR_REG_NULL, 0,
+                                               TLS_MASK_SLOT(ibl_code->branch_type),
+                                               OPSZ_8)));
+    /* and x1, x1, x2 */
     APP(&ilist,
-        INSTR_CREATE_ldar(dc, opnd_create_reg(DR_REG_X1),
-                          OPND_CREATE_MEMPTR(DR_REG_X1, 0)));
+        INSTR_CREATE_and(dc, opnd_create_reg(DR_REG_X1), opnd_create_reg(DR_REG_X1),
+                         opnd_create_reg(DR_REG_X2)));
+    /* dmb ishld to prevent memory-access instructions from being reordered across the
+     * barrier. DMB results generally in better performances compared to LDAR in the case.
+     */
+    APP(&ilist,
+        instr_create_0dst_1src(dc, OP_dmb, OPND_CREATE_INT(/* DR_DMB_ISHLD */ 9)));
     /* ldr x0, [x28, hash_table] */
     APP(&ilist,
         INSTR_CREATE_ldr(dc, opnd_create_reg(DR_REG_X0),
                          opnd_create_base_disp(dr_reg_stolen, DR_REG_NULL, 0,
                                                TLS_TABLE_SLOT(ibl_code->branch_type),
                                                OPSZ_8)));
-    /* and x1, x1, x2 */
-    APP(&ilist,
-        INSTR_CREATE_and(dc, opnd_create_reg(DR_REG_X1), opnd_create_reg(DR_REG_X1),
-                         opnd_create_reg(DR_REG_X2)));
     /* Get table entry. */
     /* add x1, x0, x1, LSL #4 */
     APP(&ilist,
@@ -750,11 +753,13 @@ emit_indirect_branch_lookup(dcontext_t *dc, generated_code_t *code, byte *pc,
     /* x1 now holds the fragment_entry_t* in the hashtable. */
     APP(&ilist, load_tag);
     /* Load tag from fragment_entry_t* in the hashtable to x0. */
-    /* ldr x0, [x1, #tag_fragment_offset] */
-    APP(&ilist,
-        INSTR_CREATE_ldr(
-            dc, opnd_create_reg(DR_REG_X0),
-            OPND_CREATE_MEMPTR(DR_REG_X1, offsetof(fragment_entry_t, tag_fragment))));
+    /* ldr x0, [x1], #tag_fragment_offset */
+    instr_t *instr = instr_create_2dst_3src(
+        dc, OP_ldr, opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_X1),
+        OPND_CREATE_MEMPTR(DR_REG_X1, 0), opnd_create_reg(DR_REG_X1),
+        OPND_CREATE_INTPTR(sizeof(fragment_entry_t)));
+    instr->src0.value.base_disp.pre_index = 0; /* Post-index */
+    APP(&ilist, instr);
     /* Did we hit? */
     APP(&ilist, compare_tag);
     /* cbz x0, not_hit */
@@ -763,50 +768,40 @@ emit_indirect_branch_lookup(dcontext_t *dc, generated_code_t *code, byte *pc,
     /* sub x0, x0, x2 */
     APP(&ilist,
         XINST_CREATE_sub(dc, opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_X2)));
-    /* cbnz x0, try_next */
+    /* cbnz x0, load_tag */
     APP(&ilist,
-        INSTR_CREATE_cbnz(dc, opnd_create_instr(try_next), opnd_create_reg(DR_REG_X0)));
+        INSTR_CREATE_cbnz(dc, opnd_create_instr(load_tag), opnd_create_reg(DR_REG_X0)));
 
     /* Hit path: load the app's original value of x0 and x1. */
-    /* ldp x0, x2, [x28] */
-    APP(&ilist,
-        INSTR_CREATE_ldp(dc, opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_X2),
-                         opnd_create_base_disp(dr_reg_stolen, DR_REG_NULL, 0,
-                                               TLS_REG0_SLOT, OPSZ_16)));
-    /* Store x0 in TLS_REG1_SLOT as requied in the fragment prefix. */
-    APP(&ilist, instr_create_save_to_tls(dc, DR_REG_R0, TLS_REG1_SLOT));
-    /* ldr x0, [x1, #start_pc_fragment_offset] */
+    /* sub x1, x1, #16, restore x1 from last post-index increment */
+    APP(&ilist, XINST_CREATE_sub(dc, opnd_create_reg(DR_REG_X1), OPND_CREATE_INT8(16)));
+
+    /* ldr x0, [x1, #start_pc_fragment_offset - fragment_entry_t] */
     APP(&ilist,
         INSTR_CREATE_ldr(dc, opnd_create_reg(DR_REG_X0),
                          OPND_CREATE_MEMPTR(
                              DR_REG_X1, offsetof(fragment_entry_t, start_pc_fragment))));
-    /* mov x1, x2 */
+    /* ldp x2, x1, [x28] */
     APP(&ilist,
-        XINST_CREATE_move(dc, opnd_create_reg(DR_REG_X1), opnd_create_reg(DR_REG_X2)));
+        INSTR_CREATE_ldp(dc, opnd_create_reg(DR_REG_X2), opnd_create_reg(DR_REG_X1),
+                         opnd_create_base_disp(dr_reg_stolen, DR_REG_NULL, 0,
+                                               TLS_REG0_SLOT, OPSZ_16)));
+    /* Store x2 in TLS_REG1_SLOT as required in the fragment prefix. */
+    APP(&ilist, instr_create_save_to_tls(dc, DR_REG_X2, TLS_REG1_SLOT));
     /* Recover app's original x2. */
-    APP(&ilist, instr_create_restore_from_tls(dc, DR_REG_R2, TLS_REG2_SLOT));
+    APP(&ilist, instr_create_restore_from_tls(dc, DR_REG_X2, TLS_REG2_SLOT));
     /* br x0
      * (keep in sync with instr_is_ibl_hit_jump())
      */
     APP(&ilist, INSTR_CREATE_br(dc, opnd_create_reg(DR_REG_X0)));
 
-    APP(&ilist, try_next);
-
-    /* Try next entry, in case of collision. No wraparound check is needed
-     * because of the sentinel at the end.
-     * ldr x0, [x1, #tag_fragment_offset]! */
-    APP(&ilist,
-        instr_create_2dst_3src(
-            dc, OP_ldr, opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_X1),
-            OPND_CREATE_MEMPTR(DR_REG_X1, sizeof(fragment_entry_t)),
-            opnd_create_reg(DR_REG_X1), OPND_CREATE_INTPTR(sizeof(fragment_entry_t))));
-    /* b compare_tag */
-    APP(&ilist, INSTR_CREATE_b(dc, opnd_create_instr(compare_tag)));
-
     APP(&ilist, not_hit);
 
     if (INTERNAL_OPTION(ibl_sentinel_check)) {
         /* Load start_pc from fragment_entry_t* in the hashtable to x0. */
+        /* sub x1, x1, #16, restore x1 from last post-index increment */
+        APP(&ilist,
+            XINST_CREATE_sub(dc, opnd_create_reg(DR_REG_X1), OPND_CREATE_INT8(16)));
         /* ldr x0, [x1, #start_pc_fragment] */
         APP(&ilist,
             XINST_CREATE_load(
@@ -822,7 +817,7 @@ emit_indirect_branch_lookup(dcontext_t *dc, generated_code_t *code, byte *pc,
             XINST_CREATE_sub(dc, opnd_create_reg(DR_REG_X0), OPND_CREATE_INT8(1)));
         /* cbnz x0, miss */
         APP(&ilist,
-            INSTR_CREATE_cbnz(dc, opnd_create_instr(miss), opnd_create_reg(DR_REG_R0)));
+            INSTR_CREATE_cbnz(dc, opnd_create_instr(miss), opnd_create_reg(DR_REG_X0)));
         /* Point at the first table slot and then go load and compare its tag */
         /* ldr x1, [x28, #table_base] */
         APP(&ilist,
@@ -835,7 +830,7 @@ emit_indirect_branch_lookup(dcontext_t *dc, generated_code_t *code, byte *pc,
 
     APP(&ilist, miss);
     /* Recover the dcontext->last_exit to x0 */
-    APP(&ilist, instr_create_restore_from_tls(dc, DR_REG_R0, TLS_REG3_SLOT));
+    APP(&ilist, instr_create_restore_from_tls(dc, DR_REG_X0, TLS_REG3_SLOT));
 
     /* Target delete entry */
     APP(&ilist, target_delete_entry);
@@ -851,9 +846,9 @@ emit_indirect_branch_lookup(dcontext_t *dc, generated_code_t *code, byte *pc,
 
     /* Put ib tgt into dcontext->next_tag */
     insert_shared_get_dcontext(dc, &ilist, NULL, true);
-    APP(&ilist, SAVE_TO_DC(dc, DR_REG_R2, NEXT_TAG_OFFSET));
-    APP(&ilist, instr_create_restore_from_tls(dc, DR_REG_R5, DCONTEXT_BASE_SPILL_SLOT));
-    APP(&ilist, instr_create_restore_from_tls(dc, DR_REG_R2, TLS_REG2_SLOT));
+    APP(&ilist, SAVE_TO_DC(dc, DR_REG_X2, NEXT_TAG_OFFSET));
+    APP(&ilist, instr_create_restore_from_tls(dc, DR_REG_X5, DCONTEXT_BASE_SPILL_SLOT));
+    APP(&ilist, instr_create_restore_from_tls(dc, DR_REG_X2, TLS_REG2_SLOT));
 
     /* ldr x1, [x(stolen), #(offs)] */
     APP(&ilist,


### PR DESCRIPTION
Replace the add+ldar with a ldr+dmb pair in HT lookup and results in
-3% to -28% (reduction) in overhead (instrument vs. native) ratios
of SPECInt 2006 and 2017. Although, found a regression in 657.xz_s
model (+7%).

An add+ldar pair was used to prevent memory-access instructions from
being reordered to ensure a hash mask is always loaded before a
hash_table is loaded. The same ordering restriction is also imposed
in the corresponding update_lookuptable_tls() routine.

With the ldr+dmb pair replacement, an add instruction is eliminated
from the critical path and contributed majorly to overhead reductions.

In addition, a frequently taken branch of the inner-loop epilogue is
converged into a more condensed (4 instr.) and smaller inner-loop,
with the cost of adding 1 more sub instruction in both 2 exit paths.

Since exit paths are not as hot as HT lookup, the impact of adding
a sub instruction in both is quite trivial (not seen).

In order to condense the inner-loop down to 4 instructions, a
pre-index ldr is replaced with a post-index version in the prologue.

On the hit-exit path, register use is carefully swapped and results in a
move instruction elimination. The number of instructions on the path
remains unchanged since a sub instruction is added to its entry.

Tests: SPECInt 2006 and 2017 ran on ARM Juno r2 (w/ 8GB RAM, Debian)