### PR TITLE
i#4381: Fix drmemtrace view disasm non-x86 default style

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -388,9 +388,11 @@ droption_t<std::string>
                    "Syntax to use for disassembly.",
                    "Specifies the syntax to use when viewing disassembled offline traces."
                    // TODO i#4382: Add aarch64 syntax support.
-                   "The option can be set to one of att (default), intel, dr and arm."
-                   "An invalid specification falls back to the default, which is \"att\""
-                   "for x86, \"arm\" for ARM (32-bit), and \"dr\" for AArch64.");
+                   " The option can be set to one of \"att\" (AT&T style), \"intel\""
+                   " (Intel style), \"dr\" (DynamoRIO's native style with all implicit"
+                   " operands listed), and \"arm\" (32-bit ARM style). An invalid"
+                   " specification falls back to the default, which is \"att\" for x86,"
+                   " \"arm\" for ARM (32-bit), and \"dr\" for AArch64.");
 
 droption_t<std::string>
     op_config_file(DROPTION_SCOPE_FRONTEND, "config_file", "",

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -384,11 +384,13 @@ droption_t<bytesize_t>
                 "and the references following the simulated ones are dropped.");
 
 droption_t<std::string>
-    op_view_syntax(DROPTION_SCOPE_FRONTEND, "view_syntax", "att",
+    op_view_syntax(DROPTION_SCOPE_FRONTEND, "view_syntax", "att/arm/dr",
                    "Syntax to use for disassembly.",
                    "Specifies the syntax to use when viewing disassembled offline traces."
+                   // TODO i#4382: Add aarch64 syntax support.
                    "The option can be set to one of att (default), intel, dr and arm."
-                   "An invalid specification falls back to the default.");
+                   "An invalid specification falls back to the default, which is \"att\""
+                   "for x86, \"arm\" for ARM (32-bit), and \"dr\" for AArch64.");
 
 droption_t<std::string>
     op_config_file(DROPTION_SCOPE_FRONTEND, "config_file", "",

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -84,7 +84,8 @@ view_t::initialize()
     error = module_mapper_->get_last_error();
     if (!error.empty())
         return "Failed to load binaries: " + error;
-    dr_disasm_flags_t flags = DR_DISASM_ATT;
+    dr_disasm_flags_t flags =
+        IF_X86_ELSE(DR_DISASM_ATT, IF_AARCH64_ELSE(DR_DISASM_DR, DR_DISASM_ARM));
     if (knob_syntax_ == "intel") {
         flags = DR_DISASM_INTEL;
     } else if (knob_syntax_ == "dr") {

--- a/core/ir/disassemble.h
+++ b/core/ir/disassemble.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -105,13 +105,14 @@ typedef enum {
      */
     DR_DISASM_NO_OPND_SIZE = 0x8,
     /**
-     * Requests standard ARM assembler syntax for disassembly.  This
+     * Requests standard ARM (32-bit) assembler syntax for disassembly.  This
      * sets the same option that is controlled by the runtime option
      * \p -syntax_arm.  Implicit operands are not displayed.
      */
     DR_DISASM_ARM = 0x10,
 } dr_disasm_flags_t;
 /* DR_API EXPORT END */
+/* TODO i#4382: Add DR_DISASM_AARCH64. */
 
 void
 disassemble_options_init(void);

--- a/core/ir/disassemble_shared.c
+++ b/core/ir/disassemble_shared.c
@@ -1113,6 +1113,11 @@ internal_instr_disassemble(char *buf, size_t bufsz, size_t *sofar INOUT,
 
     if (TESTANY(DR_DISASM_INTEL | DR_DISASM_ATT | DR_DISASM_ARM,
                 DYNAMO_OPTION(disasm_mask))) {
+#    ifdef AARCH64
+        /* TODO i#4382: Implement DR_DISASM_AARCH64. */
+        SYSLOG_INTERNAL_WARNING_ONCE("Selected disassembly style is not implemented for "
+                                     "AArch64: no operands will be printed.");
+#    endif
         instr_disassemble_opnds_noimplicit(buf, bufsz, sofar, dcontext, instr);
         /* we avoid trailing spaces if no operands */
         if (*sofar == offs_pre_opnds) {

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -227,7 +227,8 @@ OPTION_INTERNAL(bool, tracedump_text, "text dump of traces (after optimization)"
 OPTION_INTERNAL(bool, tracedump_origins, "write out original instructions for each trace")
 OPTION(bool, syntax_intel, "use Intel disassembly syntax")
 OPTION(bool, syntax_att, "use AT&T disassembly syntax")
-OPTION(bool, syntax_arm, "use ARM disassembly syntax")
+OPTION(bool, syntax_arm, "use ARM (32-bit) disassembly syntax")
+/* TODO i#4382: Add syntax_aarch64. */
 /* whether to mark gray-area instrs as invalid when we know the length (i#1118) */
 OPTION(bool, decode_strict, "mark all known-invalid instructions as invalid")
 OPTION(uint, disasm_mask, "disassembly style as a dr_disasm_flags_t bitmask")


### PR DESCRIPTION
Updates the default disassembly style for the drmemtrace view tool to
proper values for ARM and AArch64.

Adds "TODO i#4382" comments for adding DR_DISASM_AARCH64 and its
associated options.

Issue: #4381, #4382
Fixes: #4381