### PR TITLE
i#4337: Fix STUR/LDUR bugs

### DIFF
--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -425,33 +425,38 @@ x0110111xxxxxxxxxxxxxxxxxxxxxxxx  tbnz   tbz
 
 ## Load/store register (unscaled immediate)
 
-00111000000xxxxxxxxx00xxxxxxxxxx  sturb  mem9 : w0  # STURB Wt,[Xn,#simm]
+# Base
+10111000000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : w0
+11111000000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : x0
+00111000000xxxxxxxxx00xxxxxxxxxx  sturb  mem9 : w0
+01111000000xxxxxxxxx00xxxxxxxxxx  sturh  mem9 : w0
+
+# SIMD
+00111100000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : b0
+01111100000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : h0
+10111100000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : s0
+11111100000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : d0
+00111100100xxxxxxxxx00xxxxxxxxxx  stur   mem9q : q0
+
+# Base
+10111000010xxxxxxxxx00xxxxxxxxxx  ldur   w0 : mem9
+11111000010xxxxxxxxx00xxxxxxxxxx  ldur   x0 : mem9
 00111000010xxxxxxxxx00xxxxxxxxxx  ldurb  w0 : mem9
+01111000010xxxxxxxxx00xxxxxxxxxx  ldurh  w0 : mem9
 00111000100xxxxxxxxx00xxxxxxxxxx  ldursb x0 : mem9
 00111000110xxxxxxxxx00xxxxxxxxxx  ldursb w0 : mem9
-00111100000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : b0
-00111100010xxxxxxxxx00xxxxxxxxxx  ldur   b0 : mem9
-00111100100xxxxxxxxx00xxxxxxxxxx  stur   mem9 : q0
-00111100110xxxxxxxxx00xxxxxxxxxx  ldur   q0 : mem9
-
-01111000000xxxxxxxxx00xxxxxxxxxx  sturh  mem9 : w0
-01111000010xxxxxxxxx00xxxxxxxxxx  ldurh  w0 : mem9
 01111000100xxxxxxxxx00xxxxxxxxxx  ldursh x0 : mem9
 01111000110xxxxxxxxx00xxxxxxxxxx  ldursh w0 : mem9
-01111100000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : h0
-01111100010xxxxxxxxx00xxxxxxxxxx  ldur   h0 : mem9
-
-10111000000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : w0
-10111000010xxxxxxxxx00xxxxxxxxxx  ldur   w0 : mem9
 10111000100xxxxxxxxx00xxxxxxxxxx  ldursw x0 : mem9
-10111100000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : s0
-10111100010xxxxxxxxx00xxxxxxxxxx  ldur   s0 : mem9
 
-11111000000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : x0
-11111000010xxxxxxxxx00xxxxxxxxxx  ldur   x0 : mem9
-11111000100xxxxxxxxx00xxxxxxxxxx  prfum  : prfop prf9  # PRFUM #imm5,[Xn,#simm]
-11111100000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : d0
+# SIMD
+00111100010xxxxxxxxx00xxxxxxxxxx  ldur   b0 : mem9
+01111100010xxxxxxxxx00xxxxxxxxxx  ldur   h0 : mem9
+10111100010xxxxxxxxx00xxxxxxxxxx  ldur   s0 : mem9
 11111100010xxxxxxxxx00xxxxxxxxxx  ldur   d0 : mem9
+00111100110xxxxxxxxx00xxxxxxxxxx  ldur   q0 : mem9q
+
+11111000100xxxxxxxxx00xxxxxxxxxx  prfum  : prfop prf9  # PRFUM #imm5,[Xn,#simm]
 
 ## Load/store register (immediate post-indexed)
 

--- a/core/ir/aarch64/instr_create.h
+++ b/core/ir/aarch64/instr_create.h
@@ -556,6 +556,7 @@ enum {
 #define INSTR_CREATE_ldr(dc, Rd, mem) instr_create_1dst_1src((dc), OP_ldr, (Rd), (mem))
 #define INSTR_CREATE_ldrb(dc, Rd, mem) instr_create_1dst_1src(dc, OP_ldrb, Rd, mem)
 #define INSTR_CREATE_ldrh(dc, Rd, mem) instr_create_1dst_1src(dc, OP_ldrh, Rd, mem)
+#define INSTR_CREATE_ldur(dc, rt, mem) instr_create_1dst_1src(dc, OP_ldur, rt, mem)
 #define INSTR_CREATE_ldar(dc, Rt, mem) instr_create_1dst_1src((dc), OP_ldar, (Rt), (mem))
 #define INSTR_CREATE_ldarb(dc, Rt, mem) \
     instr_create_1dst_1src((dc), OP_ldarb, (Rt), (mem))

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -226,6 +226,26 @@
 38400400 : ldrb   w0, [x0],#0             : ldrb   (%x0)[1byte] %x0 $0x0000000000000000 -> %w0 %x0
 38400c00 : ldrb   w0, [x0,#0]!            : ldrb   (%x0)[1byte] %x0 $0x0000000000000000 -> %w0 %x0
 38481041 : ldurb  w1, [x2,#129]           : ldurb  +0x81(%x2)[1byte] -> %w1
+3c400000 : ldur   b0, [x0]                : ldur   (%x0)[1byte] -> %b0
+3c4ff021 : ldur   b1, [x1, #255]          : ldur   +0xff(%x1)[1byte] -> %b1
+7c400042 : ldur   h2, [x2]                : ldur   (%x2)[2byte] -> %h2
+7c500063 : ldur   h3, [x3, #-256]         : ldur   -0x0100(%x3)[2byte] -> %h3
+bc400084 : ldur   s4, [x4]                : ldur   (%x4)[4byte] -> %s4
+bc5000a5 : ldur   s5, [x5, #-256]         : ldur   -0x0100(%x5)[4byte] -> %s5
+fc4000c6 : ldur   d6, [x6]                : ldur   (%x6)[8byte] -> %d6
+fc5000e7 : ldur   d7, [x7, #-256]         : ldur   -0x0100(%x7)[8byte] -> %d7
+3cc00108 : ldur   q8, [x8]                : ldur   (%x8)[16byte] -> %q8
+3cd00129 : ldur   q9, [x9, #-256]         : ldur   -0x0100(%x9)[16byte] -> %q9
+3c00014a : stur   b10, [x10]              : stur   %b10 -> (%x10)[1byte]
+3c0ff16b : stur   b11, [x11, #255]        : stur   %b11 -> +0xff(%x11)[1byte]
+7c00018c : stur   h12, [x12]              : stur   %h12 -> (%x12)[2byte]
+7c0ff1ad : stur   h13, [x13, #255]        : stur   %h13 -> +0xff(%x13)[2byte]
+bc0001ce : stur   s14, [x14]              : stur   %s14 -> (%x14)[4byte]
+bc1001ef : stur   s15, [x15, #-256]       : stur   %s15 -> -0x0100(%x15)[4byte]
+fc000210 : stur   d16, [x16]              : stur   %d16 -> (%x16)[8byte]
+fc100231 : stur   d17, [x17, #-256]       : stur   %d17 -> -0x0100(%x17)[8byte]
+3c800252 : stur   q18, [x18]              : stur   %q18 -> (%x18)[16byte]
+3c900273 : stur   q19, [x19, #-256]       : stur   %q19 -> -0x0100(%x19)[16byte]
 38481441 : ldrb   w1, [x2],#129           : ldrb   (%x2)[1byte] %x2 $0x0000000000000081 -> %w1 %x2
 38481841 : ldtrb  w1, [x2,#129]           : ldtrb  +0x81(%x2)[1byte] -> %w1
 38481c41 : ldrb   w1, [x2,#129]!          : ldrb   +0x81(%x2)[1byte] %x2 $0x0000000000000081 -> %w1 %x2
@@ -416,10 +436,10 @@
 3c7ffbff : ldr    b31, [sp,xzr,sxtx #0]   : ldr    (%sp,%xzr,sxtx #0)[1byte] -> %b31
 3c800400 : str    q0, [x0],#0             : str    %q0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
 3c800c00 : str    q0, [x0,#0]!            : str    %q0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
-3c881041 : stur   q1, [x2,#129]           : stur   %q1 -> +0x81(%x2)[1byte]
+3c881041 : stur   q1, [x2,#129]           : stur   %q1 -> +0x81(%x2)[16byte]
 3c881441 : str    q1, [x2],#129           : str    %q1 %x2 $0x0000000000000081 -> (%x2)[16byte] %x2
 3c881c41 : str    q1, [x2,#129]!          : str    %q1 %x2 $0x0000000000000081 -> +0x81(%x2)[16byte] %x2
-3c9ff3ff : stur   q31, [sp,#-1]           : stur   %q31 -> -0x01(%sp)[1byte]
+3c9ff3ff : stur   q31, [sp,#-1]           : stur   %q31 -> -0x01(%sp)[16byte]
 3c9ff7ff : str    q31, [sp],#-1           : str    %q31 %sp $0xffffffffffffffff -> (%sp)[16byte] %sp
 3c9fffff : str    q31, [sp,#-1]!          : str    %q31 %sp $0xffffffffffffffff -> -0x01(%sp)[16byte] %sp
 3ca34841 : str    q1, [x2,w3,uxtw]        : str    %b1 -> (%x2,%x3,uxtw)[16byte]
@@ -440,10 +460,10 @@
 3cbffbff : str    q31, [sp,xzr,sxtx #4]   : str    %b31 -> (%sp,%xzr,sxtx #4)[16byte]
 3cc00400 : ldr    q0, [x0],#0             : ldr    (%x0)[16byte] %x0 $0x0000000000000000 -> %q0 %x0
 3cc00c00 : ldr    q0, [x0,#0]!            : ldr    (%x0)[16byte] %x0 $0x0000000000000000 -> %q0 %x0
-3cc81041 : ldur   q1, [x2,#129]           : ldur   +0x81(%x2)[1byte] -> %q1
+3cc81041 : ldur   q1, [x2,#129]           : ldur   +0x81(%x2)[16byte] -> %q1
 3cc81441 : ldr    q1, [x2],#129           : ldr    (%x2)[16byte] %x2 $0x0000000000000081 -> %q1 %x2
 3cc81c41 : ldr    q1, [x2,#129]!          : ldr    +0x81(%x2)[16byte] %x2 $0x0000000000000081 -> %q1 %x2
-3cdff3ff : ldur   q31, [sp,#-1]           : ldur   -0x01(%sp)[1byte] -> %q31
+3cdff3ff : ldur   q31, [sp,#-1]           : ldur   -0x01(%sp)[16byte] -> %q31
 3cdff7ff : ldr    q31, [sp],#-1           : ldr    (%sp)[16byte] %sp $0xffffffffffffffff -> %q31 %sp
 3cdfffff : ldr    q31, [sp,#-1]!          : ldr    -0x01(%sp)[16byte] %sp $0xffffffffffffffff -> %q31 %sp
 3ce34841 : ldr    q1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[16byte] -> %q1

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -279,6 +279,127 @@ test_ldar(void *dc)
 }
 
 static void
+test_ldur_stur(void *dc)
+{
+    byte *pc;
+    instr_t *instr;
+
+    /* LDUR <Bt>, [<Xn|SP>{, #<simm>}] */
+
+    /* LDUR B0, X0 */
+    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_B0),
+        opnd_create_base_disp(DR_REG_X0, DR_REG_NULL, 0, 0, OPSZ_1));
+    test_instr_encoding(dc, OP_ldur, instr);
+
+    /* LDUR B1, X1, 255 */
+    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_B1),
+        opnd_create_base_disp(DR_REG_X1, DR_REG_NULL, 0, 255, OPSZ_1));
+    test_instr_encoding(dc, OP_ldur, instr);
+
+    /* LDUR H2, X2 */
+    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_H2),
+        opnd_create_base_disp(DR_REG_X2, DR_REG_NULL, 0, 0, OPSZ_2));
+    test_instr_encoding(dc, OP_ldur, instr);
+
+    /* LDUR H3, X3, -256 */
+    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_H3),
+        opnd_create_base_disp(DR_REG_X3, DR_REG_NULL, 0, -256, OPSZ_2));
+    test_instr_encoding(dc, OP_ldur, instr);
+
+    /* LDUR S4, X4 */
+    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_S4),
+        opnd_create_base_disp(DR_REG_X4, DR_REG_NULL, 0, 0, OPSZ_4));
+    test_instr_encoding(dc, OP_ldur, instr);
+
+    /* LDUR S5, X5, -256 */
+    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_S5),
+        opnd_create_base_disp(DR_REG_X5, DR_REG_NULL, 0, -256, OPSZ_4));
+    test_instr_encoding(dc, OP_ldur, instr);
+
+    /* LDUR D6, X6 */
+    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_D6),
+        opnd_create_base_disp(DR_REG_X6, DR_REG_NULL, 0, 0, OPSZ_8));
+    test_instr_encoding(dc, OP_ldur, instr);
+
+    /* LDUR D7, X7, -256 */
+    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_D7),
+        opnd_create_base_disp(DR_REG_X7, DR_REG_NULL, 0, -256, OPSZ_8));
+    test_instr_encoding(dc, OP_ldur, instr);
+
+    /* LDUR Q8, X8 */
+    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_Q8),
+        opnd_create_base_disp(DR_REG_X8, DR_REG_NULL, 0, 0, OPSZ_16));
+    test_instr_encoding(dc, OP_ldur, instr);
+
+    /* LDUR Q9, X9, -256 */
+    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_Q9),
+        opnd_create_base_disp(DR_REG_X9, DR_REG_NULL, 0, -256, OPSZ_16));
+    test_instr_encoding(dc, OP_ldur, instr);
+
+    /* STUR <Bt>, [<Xn|SP>{, #<simm>}] */
+
+    /* STUR B10, X10 */
+    instr = INSTR_CREATE_stur(dc,
+        opnd_create_base_disp(DR_REG_X10, DR_REG_NULL, 0, 0, OPSZ_1),
+        opnd_create_reg(DR_REG_B10));
+    test_instr_encoding(dc, OP_stur, instr);
+
+    /* STUR B11, X11, 0xFF */
+    instr = INSTR_CREATE_stur(dc,
+        opnd_create_base_disp(DR_REG_X11, DR_REG_NULL, 0, 0xFF, OPSZ_1),
+        opnd_create_reg(DR_REG_B11));
+    test_instr_encoding(dc, OP_stur, instr);
+
+    /* STUR H12, X12 */
+    instr = INSTR_CREATE_stur(dc,
+        opnd_create_base_disp(DR_REG_X12, DR_REG_NULL, 0, 0, OPSZ_2),
+        opnd_create_reg(DR_REG_H12));
+    test_instr_encoding(dc, OP_stur, instr);
+
+    /* STUR H13, X13, 0xFF */
+    instr = INSTR_CREATE_stur(dc,
+        opnd_create_base_disp(DR_REG_X13, DR_REG_NULL, 0, 0xFF, OPSZ_2),
+        opnd_create_reg(DR_REG_H13));
+    test_instr_encoding(dc, OP_stur, instr);
+
+    /* STUR S14, X14 */
+    instr = INSTR_CREATE_stur(dc,
+        opnd_create_base_disp(DR_REG_X14, DR_REG_NULL, 0, 0, OPSZ_4),
+        opnd_create_reg(DR_REG_S14));
+    test_instr_encoding(dc, OP_stur, instr);
+
+    /* STUR S15, X15, 0xFF */
+    instr = INSTR_CREATE_stur(dc,
+        opnd_create_base_disp(DR_REG_X15, DR_REG_NULL, 0, 0xFF, OPSZ_4),
+        opnd_create_reg(DR_REG_S15));
+    test_instr_encoding(dc, OP_stur, instr);
+
+    /* STUR D16, X16 */
+    instr = INSTR_CREATE_stur(dc,
+        opnd_create_base_disp(DR_REG_X16, DR_REG_NULL, 0, 0, OPSZ_8),
+        opnd_create_reg(DR_REG_D16));
+    test_instr_encoding(dc, OP_stur, instr);
+
+    /* STUR D17, X17, 0xFF */
+    instr = INSTR_CREATE_stur(dc,
+        opnd_create_base_disp(DR_REG_X17, DR_REG_NULL, 0, 0xFF, OPSZ_8),
+        opnd_create_reg(DR_REG_D17));
+    test_instr_encoding(dc, OP_stur, instr);
+
+    /* STUR Q18, X18 */
+    instr = INSTR_CREATE_stur(dc,
+        opnd_create_base_disp(DR_REG_X18, DR_REG_NULL, 0, 0, OPSZ_16),
+        opnd_create_reg(DR_REG_Q18));
+    test_instr_encoding(dc, OP_stur, instr);
+
+    /* STUR Q19, X19, 0xFF */
+    instr = INSTR_CREATE_stur(dc,
+        opnd_create_base_disp(DR_REG_X19, DR_REG_NULL, 0, 0xFF, OPSZ_16),
+        opnd_create_reg(DR_REG_Q19));
+    test_instr_encoding(dc, OP_stur, instr);
+}
+
+static void
 test_instrs_with_logic_imm(void *dc)
 {
     byte *pc;
@@ -4031,6 +4152,9 @@ main(int argc, char *argv[])
 
     test_ldar(dcontext);
     print("test_ldar complete\n");
+
+    test_ldur_stur(dcontext);
+    print("test_ldur_stur complete\n");
 
     test_instrs_with_logic_imm(dcontext);
     print("test_instrs_with_logic_imm complete\n");

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -287,114 +287,124 @@ test_ldur_stur(void *dc)
     /* LDUR <Bt>, [<Xn|SP>{, #<simm>}] */
 
     /* LDUR B0, X0 */
-    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_B0),
-        opnd_create_base_disp(DR_REG_X0, DR_REG_NULL, 0, 0, OPSZ_1));
+    instr =
+        INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_B0),
+                          opnd_create_base_disp(DR_REG_X0, DR_REG_NULL, 0, 0, OPSZ_1));
     test_instr_encoding(dc, OP_ldur, instr);
 
     /* LDUR B1, X1, 255 */
-    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_B1),
-        opnd_create_base_disp(DR_REG_X1, DR_REG_NULL, 0, 255, OPSZ_1));
+    instr =
+        INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_B1),
+                          opnd_create_base_disp(DR_REG_X1, DR_REG_NULL, 0, 255, OPSZ_1));
     test_instr_encoding(dc, OP_ldur, instr);
 
     /* LDUR H2, X2 */
-    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_H2),
-        opnd_create_base_disp(DR_REG_X2, DR_REG_NULL, 0, 0, OPSZ_2));
+    instr =
+        INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_H2),
+                          opnd_create_base_disp(DR_REG_X2, DR_REG_NULL, 0, 0, OPSZ_2));
     test_instr_encoding(dc, OP_ldur, instr);
 
     /* LDUR H3, X3, -256 */
-    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_H3),
-        opnd_create_base_disp(DR_REG_X3, DR_REG_NULL, 0, -256, OPSZ_2));
+    instr =
+        INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_H3),
+                          opnd_create_base_disp(DR_REG_X3, DR_REG_NULL, 0, -256, OPSZ_2));
     test_instr_encoding(dc, OP_ldur, instr);
 
     /* LDUR S4, X4 */
-    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_S4),
-        opnd_create_base_disp(DR_REG_X4, DR_REG_NULL, 0, 0, OPSZ_4));
+    instr =
+        INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_S4),
+                          opnd_create_base_disp(DR_REG_X4, DR_REG_NULL, 0, 0, OPSZ_4));
     test_instr_encoding(dc, OP_ldur, instr);
 
     /* LDUR S5, X5, -256 */
-    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_S5),
-        opnd_create_base_disp(DR_REG_X5, DR_REG_NULL, 0, -256, OPSZ_4));
+    instr =
+        INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_S5),
+                          opnd_create_base_disp(DR_REG_X5, DR_REG_NULL, 0, -256, OPSZ_4));
     test_instr_encoding(dc, OP_ldur, instr);
 
     /* LDUR D6, X6 */
-    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_D6),
-        opnd_create_base_disp(DR_REG_X6, DR_REG_NULL, 0, 0, OPSZ_8));
+    instr =
+        INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_D6),
+                          opnd_create_base_disp(DR_REG_X6, DR_REG_NULL, 0, 0, OPSZ_8));
     test_instr_encoding(dc, OP_ldur, instr);
 
     /* LDUR D7, X7, -256 */
-    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_D7),
-        opnd_create_base_disp(DR_REG_X7, DR_REG_NULL, 0, -256, OPSZ_8));
+    instr =
+        INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_D7),
+                          opnd_create_base_disp(DR_REG_X7, DR_REG_NULL, 0, -256, OPSZ_8));
     test_instr_encoding(dc, OP_ldur, instr);
 
     /* LDUR Q8, X8 */
-    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_Q8),
-        opnd_create_base_disp(DR_REG_X8, DR_REG_NULL, 0, 0, OPSZ_16));
+    instr =
+        INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_Q8),
+                          opnd_create_base_disp(DR_REG_X8, DR_REG_NULL, 0, 0, OPSZ_16));
     test_instr_encoding(dc, OP_ldur, instr);
 
     /* LDUR Q9, X9, -256 */
-    instr = INSTR_CREATE_ldur(dc, opnd_create_reg(DR_REG_Q9),
+    instr = INSTR_CREATE_ldur(
+        dc, opnd_create_reg(DR_REG_Q9),
         opnd_create_base_disp(DR_REG_X9, DR_REG_NULL, 0, -256, OPSZ_16));
     test_instr_encoding(dc, OP_ldur, instr);
 
     /* STUR <Bt>, [<Xn|SP>{, #<simm>}] */
 
     /* STUR B10, X10 */
-    instr = INSTR_CREATE_stur(dc,
-        opnd_create_base_disp(DR_REG_X10, DR_REG_NULL, 0, 0, OPSZ_1),
+    instr = INSTR_CREATE_stur(
+        dc, opnd_create_base_disp(DR_REG_X10, DR_REG_NULL, 0, 0, OPSZ_1),
         opnd_create_reg(DR_REG_B10));
     test_instr_encoding(dc, OP_stur, instr);
 
     /* STUR B11, X11, 0xFF */
-    instr = INSTR_CREATE_stur(dc,
-        opnd_create_base_disp(DR_REG_X11, DR_REG_NULL, 0, 0xFF, OPSZ_1),
+    instr = INSTR_CREATE_stur(
+        dc, opnd_create_base_disp(DR_REG_X11, DR_REG_NULL, 0, 0xFF, OPSZ_1),
         opnd_create_reg(DR_REG_B11));
     test_instr_encoding(dc, OP_stur, instr);
 
     /* STUR H12, X12 */
-    instr = INSTR_CREATE_stur(dc,
-        opnd_create_base_disp(DR_REG_X12, DR_REG_NULL, 0, 0, OPSZ_2),
+    instr = INSTR_CREATE_stur(
+        dc, opnd_create_base_disp(DR_REG_X12, DR_REG_NULL, 0, 0, OPSZ_2),
         opnd_create_reg(DR_REG_H12));
     test_instr_encoding(dc, OP_stur, instr);
 
     /* STUR H13, X13, 0xFF */
-    instr = INSTR_CREATE_stur(dc,
-        opnd_create_base_disp(DR_REG_X13, DR_REG_NULL, 0, 0xFF, OPSZ_2),
+    instr = INSTR_CREATE_stur(
+        dc, opnd_create_base_disp(DR_REG_X13, DR_REG_NULL, 0, 0xFF, OPSZ_2),
         opnd_create_reg(DR_REG_H13));
     test_instr_encoding(dc, OP_stur, instr);
 
     /* STUR S14, X14 */
-    instr = INSTR_CREATE_stur(dc,
-        opnd_create_base_disp(DR_REG_X14, DR_REG_NULL, 0, 0, OPSZ_4),
+    instr = INSTR_CREATE_stur(
+        dc, opnd_create_base_disp(DR_REG_X14, DR_REG_NULL, 0, 0, OPSZ_4),
         opnd_create_reg(DR_REG_S14));
     test_instr_encoding(dc, OP_stur, instr);
 
     /* STUR S15, X15, 0xFF */
-    instr = INSTR_CREATE_stur(dc,
-        opnd_create_base_disp(DR_REG_X15, DR_REG_NULL, 0, 0xFF, OPSZ_4),
+    instr = INSTR_CREATE_stur(
+        dc, opnd_create_base_disp(DR_REG_X15, DR_REG_NULL, 0, 0xFF, OPSZ_4),
         opnd_create_reg(DR_REG_S15));
     test_instr_encoding(dc, OP_stur, instr);
 
     /* STUR D16, X16 */
-    instr = INSTR_CREATE_stur(dc,
-        opnd_create_base_disp(DR_REG_X16, DR_REG_NULL, 0, 0, OPSZ_8),
+    instr = INSTR_CREATE_stur(
+        dc, opnd_create_base_disp(DR_REG_X16, DR_REG_NULL, 0, 0, OPSZ_8),
         opnd_create_reg(DR_REG_D16));
     test_instr_encoding(dc, OP_stur, instr);
 
     /* STUR D17, X17, 0xFF */
-    instr = INSTR_CREATE_stur(dc,
-        opnd_create_base_disp(DR_REG_X17, DR_REG_NULL, 0, 0xFF, OPSZ_8),
+    instr = INSTR_CREATE_stur(
+        dc, opnd_create_base_disp(DR_REG_X17, DR_REG_NULL, 0, 0xFF, OPSZ_8),
         opnd_create_reg(DR_REG_D17));
     test_instr_encoding(dc, OP_stur, instr);
 
     /* STUR Q18, X18 */
-    instr = INSTR_CREATE_stur(dc,
-        opnd_create_base_disp(DR_REG_X18, DR_REG_NULL, 0, 0, OPSZ_16),
+    instr = INSTR_CREATE_stur(
+        dc, opnd_create_base_disp(DR_REG_X18, DR_REG_NULL, 0, 0, OPSZ_16),
         opnd_create_reg(DR_REG_Q18));
     test_instr_encoding(dc, OP_stur, instr);
 
     /* STUR Q19, X19, 0xFF */
-    instr = INSTR_CREATE_stur(dc,
-        opnd_create_base_disp(DR_REG_X19, DR_REG_NULL, 0, 0xFF, OPSZ_16),
+    instr = INSTR_CREATE_stur(
+        dc, opnd_create_base_disp(DR_REG_X19, DR_REG_NULL, 0, 0xFF, OPSZ_16),
         opnd_create_reg(DR_REG_Q19));
     test_instr_encoding(dc, OP_stur, instr);
 }

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -41,6 +41,27 @@ ldar   (%x1)[8byte] -> %x0
 ldarb  (%x1)[1byte] -> %w0
 ldarh  (%x1)[2byte] -> %w0
 test_ldar complete
+ldur   (%x0)[1byte] -> %b0
+ldur   +0xff(%x1)[1byte] -> %b1
+ldur   (%x2)[2byte] -> %h2
+ldur   -0x0100(%x3)[2byte] -> %h3
+ldur   (%x4)[4byte] -> %s4
+ldur   -0x0100(%x5)[4byte] -> %s5
+ldur   (%x6)[8byte] -> %d6
+ldur   -0x0100(%x7)[8byte] -> %d7
+ldur   (%x8)[16byte] -> %q8
+ldur   -0x0100(%x9)[16byte] -> %q9
+stur   %b10 -> (%x10)[1byte]
+stur   %b11 -> +0xff(%x11)[1byte]
+stur   %h12 -> (%x12)[2byte]
+stur   %h13 -> +0xff(%x13)[2byte]
+stur   %s14 -> (%x14)[4byte]
+stur   %s15 -> +0xff(%x15)[4byte]
+stur   %d16 -> (%x16)[8byte]
+stur   %d17 -> +0xff(%x17)[8byte]
+stur   %q18 -> (%x18)[16byte]
+stur   %q19 -> +0xff(%x19)[16byte]
+test_ldur_stur complete
 and    %x9 $0x000000000000ffff -> %x10
 and    %w5 $0x00000000000000ff -> %w5
 ands   %x19 $0x0000000000ffffff -> %x23


### PR DESCRIPTION
This fixes bugs in the 128-bit SIMD variant of STUR/LDUR instructions (#4337) and adds extra IR and disassembly tests.