### PR TITLE
i#4328: Handle AArch64 cache flush operations in drmemtrace.

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -515,6 +515,13 @@ if (BUILD_TESTS)
   add_test(NAME tool.drcachesim.unit_tests
            COMMAND tool.drcachesim.unit_tests)
 
+  if (AARCH64)
+    add_executable(tool.drcacheoff.burst_flush_aarch64 tests/burst_flush_aarch64.cpp)
+    configure_DynamoRIO_static(tool.drcacheoff.burst_flush_aarch64)
+    use_DynamoRIO_static_client(tool.drcacheoff.burst_flush_aarch64 drmemtrace_static)
+    add_win32_flags(tool.drcacheoff.burst_flush_aarch64)
+  endif ()
+
   # FIXME i#2007: fails to link on A64
   # XXX i#1997: dynamorio_static is not supported on Mac yet
   # FIXME i#2949: gcc 7.3 fails to link certain configs

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -515,7 +515,7 @@ if (BUILD_TESTS)
   add_test(NAME tool.drcachesim.unit_tests
            COMMAND tool.drcachesim.unit_tests)
 
-  if (AARCH64)
+  if (DR_HOST_AARCH64)
     add_executable(tool.drcacheoff.burst_flush_aarch64 tests/burst_flush_aarch64.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_flush_aarch64)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_flush_aarch64 drmemtrace_static)

--- a/clients/drcachesim/tests/allasm-aarch64-flush-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-aarch64-flush-basic-counts.templatex
@@ -1,18 +1,15 @@
 Hello, world!
+---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
-     .* total \(fetched\) instructions
-     .* total unique \(fetched\) instructions
-     .* total non-fetched instructions
-#if defined(X86) && !defined(X64)
+          19 total \(fetched\) instructions
+          19 total unique \(fetched\) instructions
+           0 total non-fetched instructions
            0 total prefetches
-#else
-     [ ]*[1-9][0-9]* total prefetches
-#endif
      .* total data loads
      .* total data stores
-           0 total icache flushes
-           0 total dcache flushes
+           1 total icache flushes
+           3 total dcache flushes
            1 total threads
      .* total scheduling markers
      .* total transfer markers
@@ -22,18 +19,14 @@ Total counts:
      .* total function return value markers
      .* total other markers
 Thread .* counts:
-     .* \(fetched\) instructions
-     .* unique \(fetched\) instructions
-     .* non-fetched instructions
-#if defined(X86) && !defined(X64)
+          19 \(fetched\) instructions
+          19 unique \(fetched\) instructions
+           0 non-fetched instructions
            0 prefetches
-#else
-     [ ]*[1-9][0-9]* prefetches
-#endif
      .* data loads
      .* data stores
-           0 icache flushes
-           0 dcache flushes
+           1 icache flushes
+           3 dcache flushes
      .* scheduling markers
      .* transfer markers
      .* function id markers

--- a/clients/drcachesim/tests/allasm-aarch64-prefetch-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-aarch64-prefetch-basic-counts.templatex
@@ -8,8 +8,8 @@ Total counts:
           81 total prefetches
      .* total data loads
      .* total data stores
-           0 total icache flushes
-           0 total dcache flushes
+     .* total icache flushes
+     .* total dcache flushes
            1 total threads
      .* total scheduling markers
      .* total transfer markers
@@ -25,8 +25,8 @@ Thread .* counts:
           81 prefetches
      .* data loads
      .* data stores
-           0 icache flushes
-           0 dcache flushes
+     .* icache flushes
+     .* dcache flushes
      .* scheduling markers
      .* transfer markers
      .* function id markers

--- a/clients/drcachesim/tests/allasm-aarch64-prefetch-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-aarch64-prefetch-basic-counts.templatex
@@ -8,6 +8,8 @@ Total counts:
           81 total prefetches
      .* total data loads
      .* total data stores
+           0 total icache flushes
+           0 total dcache flushes
            1 total threads
      .* total scheduling markers
      .* total transfer markers
@@ -23,6 +25,8 @@ Thread .* counts:
           81 prefetches
      .* data loads
      .* data stores
+           0 icache flushes
+           0 dcache flushes
      .* scheduling markers
      .* transfer markers
      .* function id markers

--- a/clients/drcachesim/tests/allasm_aarch64_flush.asm
+++ b/clients/drcachesim/tests/allasm_aarch64_flush.asm
@@ -1,0 +1,69 @@
+/* **********************************************************
+ * Copyright (c) 2020 Google, Inc. All rights reserved.
+ * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of ARM Limited nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+        .global  _start
+
+        .align   6
+_start:
+        // Align stack pointer and get some space.
+        mov      x0, sp
+        bic      x0, x0, #63
+        mov      x1, x0        // x1 is top of region
+        sub      x0, x0, #1024 // x0 is bottom of region
+        mov      sp, x0
+
+        adr      x0, helloworld
+        adr      x1, .
+
+        // data cache flush operations.
+        dc       civac, x0
+        dc       cvac, x0
+        dc       cvau, x0
+
+        // instruction cache flush operations.
+        ic       ivau, x1
+
+        // Exit.
+        mov      w0, #1            // stdout
+        adr      x1, helloworld
+        mov      w2, #14           // sizeof(helloworld)
+        mov      w8, #64           // SYS_write
+        svc      #0
+        mov      w0, #0            // status
+        mov      w8, #94           // SYS_exit_group
+        svc      #0
+
+        .data
+        .align   6
+helloworld:
+        .ascii   "Hello, world!\n"

--- a/clients/drcachesim/tests/allasm_aarch64_flush.asm
+++ b/clients/drcachesim/tests/allasm_aarch64_flush.asm
@@ -45,12 +45,12 @@ _start:
         adr      x0, helloworld
         adr      x1, .
 
-        // data cache flush operations.
+        // Data cache flush operations.
         dc       civac, x0
         dc       cvac, x0
         dc       cvau, x0
 
-        // instruction cache flush operations.
+        // Instruction cache flush operations.
         ic       ivau, x1
 
         // Exit.

--- a/clients/drcachesim/tests/basic_counts.templatex
+++ b/clients/drcachesim/tests/basic_counts.templatex
@@ -26,8 +26,8 @@ Total counts:
      .* total prefetches
      .* total data loads
      .* total data stores
-           0 total icache flushes
-           0 total dcache flushes
+     .* total icache flushes
+     .* total dcache flushes
            1 total threads
      .* total scheduling markers
 #if defined(WINDOWS) && !defined(X64)
@@ -47,8 +47,8 @@ Thread .* counts:
      .* prefetches
      .* data loads
      .* data stores
-           0 icache flushes
-           0 dcache flushes
+     .* icache flushes
+     .* dcache flushes
      .* scheduling markers
 #if defined(WINDOWS) && !defined(X64)
           26 transfer markers

--- a/clients/drcachesim/tests/basic_counts.templatex
+++ b/clients/drcachesim/tests/basic_counts.templatex
@@ -26,6 +26,8 @@ Total counts:
      .* total prefetches
      .* total data loads
      .* total data stores
+           0 total icache flushes
+           0 total dcache flushes
            1 total threads
      .* total scheduling markers
 #if defined(WINDOWS) && !defined(X64)
@@ -45,6 +47,8 @@ Thread .* counts:
      .* prefetches
      .* data loads
      .* data stores
+           0 icache flushes
+           0 dcache flushes
      .* scheduling markers
 #if defined(WINDOWS) && !defined(X64)
           26 transfer markers

--- a/clients/drcachesim/tests/builtin-prefetch-basic-counts.templatex
+++ b/clients/drcachesim/tests/builtin-prefetch-basic-counts.templatex
@@ -12,8 +12,8 @@ Total counts:
 #endif
      .* total data loads
      .* total data stores
-           0 total icache flushes
-           0 total dcache flushes
+     .* total icache flushes
+     .* total dcache flushes
            1 total threads
      .* total scheduling markers
      .* total transfer markers
@@ -33,8 +33,8 @@ Thread .* counts:
 #endif
      .* data loads
      .* data stores
-           0 icache flushes
-           0 dcache flushes
+     .* icache flushes
+     .* dcache flushes
      .* scheduling markers
      .* transfer markers
      .* function id markers

--- a/clients/drcachesim/tests/builtin-prefetch-basic-counts.templatex
+++ b/clients/drcachesim/tests/builtin-prefetch-basic-counts.templatex
@@ -12,6 +12,8 @@ Total counts:
 #endif
      .* total data loads
      .* total data stores
+           0 total icache flushes
+           0 total dcache flushes
            1 total threads
      .* total scheduling markers
      .* total transfer markers
@@ -31,6 +33,8 @@ Thread .* counts:
 #endif
      .* data loads
      .* data stores
+           0 icache flushes
+           0 dcache flushes
      .* scheduling markers
      .* transfer markers
      .* function id markers

--- a/clients/drcachesim/tests/burst_flush_aarch64.cpp
+++ b/clients/drcachesim/tests/burst_flush_aarch64.cpp
@@ -1,0 +1,110 @@
+/* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* This application links in drmemtrace_static and acquires a trace during
+ * a "burst" of execution in the middle of the application.  It then detaches.
+ */
+#include "dr_api.h"
+#include <assert.h>
+#include <iostream>
+#include <signal.h>
+
+bool
+my_setenv(const char *var, const char *value)
+{
+#ifdef UNIX
+    return setenv(var, value, 1 /*override*/) == 0;
+#else
+    return SetEnvironmentVariable(var, value) == TRUE;
+#endif
+}
+
+void
+sigill_handler(int signal)
+{
+    dr_app_stop_and_cleanup();
+    std::cerr << "all done\n";
+    _Exit(0);
+}
+
+static void
+do_some_work()
+{
+    int d = 0;
+    // Expected to send SIGILL.
+    // Control will be transferred to sigill_handler
+    __asm__ __volatile__("dc ivac, %0" : : "r"(d));
+}
+
+int
+main(int argc, const char *argv[])
+{
+    signal(SIGILL, sigill_handler);
+    if (!my_setenv("DYNAMORIO_OPTIONS", "-client_lib ';;-offline'"))
+        std::cerr << "failed to set env var!\n";
+
+    std::cerr << "pre-DR init\n";
+    dr_app_setup();
+    assert(!dr_app_running_under_dynamorio());
+    std::cerr << "pre-DR start\n";
+    dr_app_start();
+    assert(dr_app_running_under_dynamorio());
+    do_some_work();
+
+    return 0;
+}
+
+/* FIXME i#2099: the weak symbol is not supported on Windows. */
+#if defined(UNIX) && defined(TEST_APP_DR_CLIENT_MAIN)
+#    ifdef __cplusplus
+extern "C" {
+#    endif
+
+/* Test if the drmemtrace_client_main() in drmemtrace will be called. */
+DR_EXPORT WEAK void
+drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
+{
+    std::cerr << "wrong drmemtrace_client_main\n";
+}
+
+/* This dr_client_main should be called instead of the one in tracer.cpp */
+DR_EXPORT void
+dr_client_main(client_id_t id, int argc, const char *argv[])
+{
+    std::cerr << "app dr_client_main\n";
+    drmemtrace_client_main(id, argc, argv);
+}
+
+#    ifdef __cplusplus
+}
+#    endif
+#endif /* UNIX && TEST_APP_DR_CLIENT_MAIN */

--- a/clients/drcachesim/tests/burst_flush_aarch64.cpp
+++ b/clients/drcachesim/tests/burst_flush_aarch64.cpp
@@ -69,7 +69,9 @@ int
 main(int argc, const char *argv[])
 {
     signal(SIGILL, sigill_handler);
-    if (!my_setenv("DYNAMORIO_OPTIONS", "-signal_stack_size 64K -client_lib ';;-offline'"))
+    if (!my_setenv("DYNAMORIO_OPTIONS",
+                   "-stderr_mask 0xc -signal_stack_size 64K "
+                   "-client_lib ';;-offline'"))
         std::cerr << "failed to set env var!\n";
 
     std::cerr << "pre-DR init\n";

--- a/clients/drcachesim/tests/burst_flush_aarch64.cpp
+++ b/clients/drcachesim/tests/burst_flush_aarch64.cpp
@@ -1,3 +1,4 @@
+
 /* **********************************************************
  * Copyright (c) 2020 Google, Inc.  All rights reserved.
  * **********************************************************/
@@ -37,32 +38,64 @@
 #include <assert.h>
 #include <iostream>
 #include <signal.h>
+#include <setjmp.h>
+
+static sigjmp_buf mark;
+static int handled_sigill_count = 0;
 
 bool
 my_setenv(const char *var, const char *value)
 {
-#ifdef UNIX
     return setenv(var, value, 1 /*override*/) == 0;
-#else
-    return SetEnvironmentVariable(var, value) == TRUE;
-#endif
 }
 
 void
 sigill_handler(int signal)
 {
-    dr_app_stop_and_cleanup();
-    std::cerr << "all done\n";
-    _Exit(0);
+    handled_sigill_count++;
+    siglongjmp(mark, handled_sigill_count);
+    exit(-1);
+}
+
+static void
+dc_ivac()
+{
+    int d = 0;
+    // Expected to raise SIGILL.
+    // Control will be transferred to sigill_handler
+    __asm__ __volatile__("dc ivac, %0" : : "r"(&d));
+}
+
+static void
+dc_unprivileged_flush()
+{
+    int d = 0;
+    __asm__ __volatile__("dc civac, %0" : : "r"(&d));
+    __asm__ __volatile__("dc cvac , %0" : : "r"(&d));
+    __asm__ __volatile__("dc cvau , %0" : : "r"(&d));
+}
+
+static void
+ic_unprivileged_flush()
+{
+    __asm__ __volatile__("ic ivau , %0" : : "r"(ic_unprivileged_flush));
 }
 
 static void
 do_some_work()
 {
-    int d = 0;
-    // Expected to send SIGILL.
-    // Control will be transferred to sigill_handler
-    __asm__ __volatile__("dc ivac, %0" : : "r"(d));
+    dc_unprivileged_flush();
+    ic_unprivileged_flush();
+
+    // Testing privileged instructions requires handling SIGILL.
+    // We use sigsetjmp/siglongjmp to resume execution after handling the
+    // signal.
+    handled_sigill_count = 0;
+    int i = sigsetjmp(mark, 1);
+    switch (i) {
+    case 0: dc_ivac();
+    }
+    return;
 }
 
 int
@@ -70,6 +103,8 @@ main(int argc, const char *argv[])
 {
     signal(SIGILL, sigill_handler);
     if (!my_setenv("DYNAMORIO_OPTIONS",
+                   // XXX i#4425: Fix debug-build stack overflow issue and
+                   // remove custom signal_stack_size below.
                    "-stderr_mask 0xc -signal_stack_size 64K "
                    "-client_lib ';;-offline'"))
         std::cerr << "failed to set env var!\n";
@@ -81,32 +116,7 @@ main(int argc, const char *argv[])
     dr_app_start();
     assert(dr_app_running_under_dynamorio());
     do_some_work();
-
+    dr_app_stop_and_cleanup();
+    std::cerr << "all done\n";
     return 0;
 }
-
-/* FIXME i#2099: the weak symbol is not supported on Windows. */
-#if defined(UNIX) && defined(TEST_APP_DR_CLIENT_MAIN)
-#    ifdef __cplusplus
-extern "C" {
-#    endif
-
-/* Test if the drmemtrace_client_main() in drmemtrace will be called. */
-DR_EXPORT WEAK void
-drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
-{
-    std::cerr << "wrong drmemtrace_client_main\n";
-}
-
-/* This dr_client_main should be called instead of the one in tracer.cpp */
-DR_EXPORT void
-dr_client_main(client_id_t id, int argc, const char *argv[])
-{
-    std::cerr << "app dr_client_main\n";
-    drmemtrace_client_main(id, argc, argv);
-}
-
-#    ifdef __cplusplus
-}
-#    endif
-#endif /* UNIX && TEST_APP_DR_CLIENT_MAIN */

--- a/clients/drcachesim/tests/burst_flush_aarch64.cpp
+++ b/clients/drcachesim/tests/burst_flush_aarch64.cpp
@@ -69,7 +69,7 @@ int
 main(int argc, const char *argv[])
 {
     signal(SIGILL, sigill_handler);
-    if (!my_setenv("DYNAMORIO_OPTIONS", "-client_lib ';;-offline'"))
+    if (!my_setenv("DYNAMORIO_OPTIONS", "-signal_stack_size 64K -client_lib ';;-offline'"))
         std::cerr << "failed to set env var!\n";
 
     std::cerr << "pre-DR init\n";

--- a/clients/drcachesim/tests/offline-allasm-aarch64-flush-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-aarch64-flush-basic-counts.templatex
@@ -1,0 +1,35 @@
+Hello, world!
+Basic counts tool results:
+Total counts:
+          19 total \(fetched\) instructions
+          19 total unique \(fetched\) instructions
+           0 total non-fetched instructions
+           0 total prefetches
+           0 total data loads
+           0 total data stores
+           1 total icache flushes
+           3 total dcache flushes
+           1 total threads
+           6 total scheduling markers
+           0 total transfer markers
+           0 total function id markers
+           0 total function return address markers
+           0 total function argument markers
+           0 total function return value markers
+           1 total other markers
+Thread .* counts:
+          19 \(fetched\) instructions
+          19 unique \(fetched\) instructions
+           0 non-fetched instructions
+           0 prefetches
+           0 data loads
+           0 data stores
+           1 icache flushes
+           3 dcache flushes
+           6 scheduling markers
+           0 transfer markers
+           0 function id markers
+           0 function return address markers
+           0 function argument markers
+           0 function return value markers
+           1 other markers

--- a/clients/drcachesim/tests/offline-allasm-aarch64-prefetch-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-aarch64-prefetch-counts.templatex
@@ -5,33 +5,33 @@ Total counts:
           96 total unique \(fetched\) instructions
            0 total non-fetched instructions
           81 total prefetches
-           0 total data loads
-           0 total data stores
-           0 total icache flushes
-           0 total dcache flushes
+     .* total data loads
+     .* total data stores
+     .* total icache flushes
+     .* total dcache flushes
            1 total threads
-           6 total scheduling markers
-           0 total transfer markers
-           0 total function id markers
-           0 total function return address markers
-           0 total function argument markers
-           0 total function return value markers
-           1 total other markers
+     .* total scheduling markers
+     .* total transfer markers
+     .* total function id markers
+     .* total function return address markers
+     .* total function argument markers
+     .* total function return value markers
+     .* total other markers
 Thread .* counts:
           96 \(fetched\) instructions
           96 unique \(fetched\) instructions
            0 non-fetched instructions
           81 prefetches
-           0 data loads
-           0 data stores
-           0 icache flushes
-           0 dcache flushes
-           6 scheduling markers
-           0 transfer markers
-           0 function id markers
-           0 function return address markers
-           0 function argument markers
-           0 function return value markers
+     .* data loads
+     .* data stores
+     .* icache flushes
+     .* dcache flushes
+     .* scheduling markers
+     .* transfer markers
+     .* function id markers
+     .* function return address markers
+     .* function argument markers
+     .* function return value markers
            1 other markers
 Prefetch operation frequencies:
            2 prefetch_read_l1

--- a/clients/drcachesim/tests/offline-allasm-aarch64-prefetch-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-aarch64-prefetch-counts.templatex
@@ -7,6 +7,8 @@ Total counts:
           81 total prefetches
            0 total data loads
            0 total data stores
+           0 total icache flushes
+           0 total dcache flushes
            1 total threads
            6 total scheduling markers
            0 total transfer markers
@@ -22,6 +24,8 @@ Thread .* counts:
           81 prefetches
            0 data loads
            0 data stores
+           0 icache flushes
+           0 dcache flushes
            6 scheduling markers
            0 transfer markers
            0 function id markers

--- a/clients/drcachesim/tests/offline-basic_counts.templatex
+++ b/clients/drcachesim/tests/offline-basic_counts.templatex
@@ -25,8 +25,8 @@ Total counts:
      .* total prefetches
      .* total data loads
      .* total data stores
-           0 total icache flushes
-           0 total dcache flushes
+     .* total icache flushes
+     .* total dcache flushes
            1 total threads
      .* total scheduling markers
 #if defined(WINDOWS) && !defined(X64)
@@ -46,8 +46,8 @@ Thread .* counts:
      .* prefetches
      .* data loads
      .* data stores
-           0 icache flushes
-           0 dcache flushes
+     .* icache flushes
+     .* dcache flushes
      .* scheduling markers
 #if defined(WINDOWS) && !defined(X64)
           26 transfer markers

--- a/clients/drcachesim/tests/offline-basic_counts.templatex
+++ b/clients/drcachesim/tests/offline-basic_counts.templatex
@@ -25,6 +25,8 @@ Total counts:
      .* total prefetches
      .* total data loads
      .* total data stores
+           0 total icache flushes
+           0 total dcache flushes
            1 total threads
      .* total scheduling markers
 #if defined(WINDOWS) && !defined(X64)
@@ -44,6 +46,8 @@ Thread .* counts:
      .* prefetches
      .* data loads
      .* data stores
+           0 icache flushes
+           0 dcache flushes
      .* scheduling markers
 #if defined(WINDOWS) && !defined(X64)
           26 transfer markers

--- a/clients/drcachesim/tests/offline-builtin-prefetch-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-builtin-prefetch-basic-counts.templatex
@@ -11,8 +11,8 @@ Total counts:
 #endif
      .* total data loads
      .* total data stores
-           0 total icache flushes
-           0 total dcache flushes
+     .* total icache flushes
+     .* total dcache flushes
            1 total threads
      .* total scheduling markers
      .* total transfer markers
@@ -32,8 +32,8 @@ Thread .* counts:
 #endif
      .* data loads
      .* data stores
-           0 icache flushes
-           0 dcache flushes
+     .* icache flushes
+     .* dcache flushes
      .* scheduling markers
      .* transfer markers
      .* function id markers

--- a/clients/drcachesim/tests/offline-burst_flush_aarch64.templatex
+++ b/clients/drcachesim/tests/offline-burst_flush_aarch64.templatex
@@ -1,0 +1,37 @@
+pre-DR init
+pre-DR start
+all done
+Basic counts tool results:
+Total counts:
+          15 total \(fetched\) instructions
+          15 total unique \(fetched\) instructions
+           0 total non-fetched instructions
+           0 total prefetches
+     .* total data loads
+     .* total data stores
+           0 total icache flushes
+           1 total dcache flushes
+           1 total threads
+     .* total scheduling markers
+     .* total transfer markers
+     .* total function id markers
+     .* total function return address markers
+     .* total function argument markers
+     .* total function return value markers
+     .* total other markers
+Thread .* counts:
+          15 \(fetched\) instructions
+          15 unique \(fetched\) instructions
+           0 non-fetched instructions
+           0 prefetches
+     .* data loads
+     .* data stores
+           0 icache flushes
+           1 dcache flushes
+     .* scheduling markers
+     .* transfer markers
+     .* function id markers
+     .* function return address markers
+     .* function argument markers
+     .* function return value markers
+     .* other markers

--- a/clients/drcachesim/tests/offline-burst_flush_aarch64.templatex
+++ b/clients/drcachesim/tests/offline-burst_flush_aarch64.templatex
@@ -3,14 +3,14 @@ pre-DR start
 all done
 Basic counts tool results:
 Total counts:
-          15 total \(fetched\) instructions
-          15 total unique \(fetched\) instructions
+     .* total \(fetched\) instructions
+     .* total unique \(fetched\) instructions
            0 total non-fetched instructions
      .* total prefetches
      .* total data loads
      .* total data stores
-           0 total icache flushes
-           1 total dcache flushes
+           1 total icache flushes
+           4 total dcache flushes
            1 total threads
      .* total scheduling markers
      .* total transfer markers
@@ -20,14 +20,14 @@ Total counts:
      .* total function return value markers
      .* total other markers
 Thread .* counts:
-          15 \(fetched\) instructions
-          15 unique \(fetched\) instructions
+     .* \(fetched\) instructions
+     .* unique \(fetched\) instructions
            0 non-fetched instructions
      .* prefetches
      .* data loads
      .* data stores
-           0 icache flushes
-           1 dcache flushes
+           1 icache flushes
+           4 dcache flushes
      .* scheduling markers
      .* transfer markers
      .* function id markers

--- a/clients/drcachesim/tests/offline-burst_flush_aarch64.templatex
+++ b/clients/drcachesim/tests/offline-burst_flush_aarch64.templatex
@@ -6,7 +6,7 @@ Total counts:
           15 total \(fetched\) instructions
           15 total unique \(fetched\) instructions
            0 total non-fetched instructions
-           0 total prefetches
+     .* total prefetches
      .* total data loads
      .* total data stores
            0 total icache flushes
@@ -23,7 +23,7 @@ Thread .* counts:
           15 \(fetched\) instructions
           15 unique \(fetched\) instructions
            0 non-fetched instructions
-           0 prefetches
+     .* prefetches
      .* data loads
      .* data stores
            0 icache flushes

--- a/clients/drcachesim/tests/offline-burst_threadL0filter.templatex
+++ b/clients/drcachesim/tests/offline-burst_threadL0filter.templatex
@@ -19,6 +19,8 @@ Total counts:
     *[0-9]* total prefetches
     *[0-9]* total data loads
     *[0-9]* total data stores
+           0 total icache flushes
+           0 total dcache flushes
            4 total threads
     *[0-9]* total scheduling markers
     *[0-9]* total transfer markers

--- a/clients/drcachesim/tests/offline-burst_threadL0filter.templatex
+++ b/clients/drcachesim/tests/offline-burst_threadL0filter.templatex
@@ -19,8 +19,8 @@ Total counts:
     *[0-9]* total prefetches
     *[0-9]* total data loads
     *[0-9]* total data stores
-           0 total icache flushes
-           0 total dcache flushes
+    *[0-9]* total icache flushes
+    *[0-9]* total dcache flushes
            4 total threads
     *[0-9]* total scheduling markers
     *[0-9]* total transfer markers

--- a/clients/drcachesim/tests/offline-burst_threadfilter.templatex
+++ b/clients/drcachesim/tests/offline-burst_threadfilter.templatex
@@ -19,6 +19,8 @@ Total counts:
     *[0-9]* total prefetches
     *[0-9]* total data loads
     *[0-9]* total data stores
+           0 total icache flushes
+           0 total dcache flushes
            4 total threads
     *[0-9]* total scheduling markers
     *[0-9]* total transfer markers

--- a/clients/drcachesim/tests/offline-burst_threadfilter.templatex
+++ b/clients/drcachesim/tests/offline-burst_threadfilter.templatex
@@ -19,8 +19,8 @@ Total counts:
     *[0-9]* total prefetches
     *[0-9]* total data loads
     *[0-9]* total data stores
-           0 total icache flushes
-           0 total dcache flushes
+    *[0-9]* total icache flushes
+    *[0-9]* total dcache flushes
            4 total threads
     *[0-9]* total scheduling markers
     *[0-9]* total transfer markers

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -121,6 +121,10 @@ basic_counts_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         }
     } else if (memref.data.type == TRACE_TYPE_THREAD_EXIT) {
         counters->tid = memref.exit.tid;
+    } else if (memref.data.type == TRACE_TYPE_INSTR_FLUSH) {
+        counters->icache_flushes++;
+    } else if (memref.data.type == TRACE_TYPE_DATA_FLUSH) {
+        counters->dcache_flushes++;
     }
     return true;
 }
@@ -166,6 +170,8 @@ basic_counts_t::print_results()
     std::cerr << std::setw(12) << total.prefetches << " total prefetches\n";
     std::cerr << std::setw(12) << total.loads << " total data loads\n";
     std::cerr << std::setw(12) << total.stores << " total data stores\n";
+    std::cerr << std::setw(12) << total.icache_flushes << " total icache flushes\n";
+    std::cerr << std::setw(12) << total.dcache_flushes << " total dcache flushes\n";
     std::cerr << std::setw(12) << shard_map_.size() << " total threads\n";
     std::cerr << std::setw(12) << total.sched_markers << " total scheduling markers\n";
     std::cerr << std::setw(12) << total.xfer_markers << " total transfer markers\n";
@@ -193,6 +199,10 @@ basic_counts_t::print_results()
         std::cerr << std::setw(12) << keyvals.second->prefetches << " prefetches\n";
         std::cerr << std::setw(12) << keyvals.second->loads << " data loads\n";
         std::cerr << std::setw(12) << keyvals.second->stores << " data stores\n";
+        std::cerr << std::setw(12) << keyvals.second->icache_flushes
+                  << " icache flushes\n";
+        std::cerr << std::setw(12) << keyvals.second->dcache_flushes
+                  << " dcache flushes\n";
         std::cerr << std::setw(12) << keyvals.second->sched_markers
                   << " scheduling markers\n";
         std::cerr << std::setw(12) << keyvals.second->xfer_markers
@@ -206,6 +216,7 @@ basic_counts_t::print_results()
         std::cerr << std::setw(12) << keyvals.second->func_retval_markers
                   << " function return value markers\n";
         std::cerr << std::setw(12) << keyvals.second->other_markers << " other markers\n";
+
     }
     return true;
 }

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -216,7 +216,6 @@ basic_counts_t::print_results()
         std::cerr << std::setw(12) << keyvals.second->func_retval_markers
                   << " function return value markers\n";
         std::cerr << std::setw(12) << keyvals.second->other_markers << " other markers\n";
-
     }
     return true;
 }

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -79,6 +79,8 @@ protected:
             func_arg_markers += rhs.func_arg_markers;
             func_retval_markers += rhs.func_retval_markers;
             other_markers += rhs.other_markers;
+            icache_flushes += rhs.icache_flushes;
+            dcache_flushes += rhs.dcache_flushes;
             for (const uint64_t addr : rhs.unique_pc_addrs) {
                 unique_pc_addrs.insert(addr);
             }
@@ -97,6 +99,8 @@ protected:
         int_least64_t func_arg_markers = 0;
         int_least64_t func_retval_markers = 0;
         int_least64_t other_markers = 0;
+        int_least64_t icache_flushes = 0;
+        int_least64_t dcache_flushes = 0;
         std::unordered_set<uint64_t> unique_pc_addrs;
         std::string error;
     };

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -200,7 +200,7 @@ instru_t::is_aarch64_dcache_flush_op(instr_t *instr)
     if (instr_get_opcode(instr) != OP_sys)
         return false;
     switch (opnd_get_immed_int(instr_get_src(instr, 0))) {
-    // i#4328: Handle privileged dcache operations.
+    // TODO i#4406: Handle all privileged dcache operations.
     case DR_DC_IVAC:
     case DR_DC_CVAU:
     case DR_DC_CIVAC:

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -188,6 +188,7 @@ instru_t::is_aarch64_icache_flush_op(instr_t *instr)
     if (instr_get_opcode(instr) != OP_sys)
         return false;
     switch (opnd_get_immed_int(instr_get_src(instr, 0))) {
+    // i#4328: Handle privileged icache operations.
     case DR_IC_IVAU: return true;
     }
     return false;
@@ -199,6 +200,8 @@ instru_t::is_aarch64_dcache_flush_op(instr_t *instr)
     if (instr_get_opcode(instr) != OP_sys)
         return false;
     switch (opnd_get_immed_int(instr_get_src(instr, 0))) {
+    // i#4328: Handle privileged dcache operations.
+    case DR_DC_IVAC:
     case DR_DC_CVAU:
     case DR_DC_CIVAC:
     case DR_DC_CVAC: return true;

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -188,7 +188,7 @@ instru_t::is_aarch64_icache_flush_op(instr_t *instr)
     if (instr_get_opcode(instr) != OP_sys)
         return false;
     switch (opnd_get_immed_int(instr_get_src(instr, 0))) {
-    // i#4328: Handle privileged icache operations.
+    // TODO i#4406: Handle privileged icache operations.
     case DR_IC_IVAU: return true;
     }
     return false;

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -181,6 +181,32 @@ instru_t::instr_to_prefetch_type(instr_t *instr)
     }
 }
 
+#ifdef AARCH64
+bool
+instru_t::is_aarch64_icache_flush_op(instr_t *instr)
+{
+    if (instr_get_opcode(instr) != OP_sys)
+        return false;
+    switch (opnd_get_immed_int(instr_get_src(instr, 0))) {
+    case DR_IC_IVAU: return true;
+    }
+    return false;
+}
+
+bool
+instru_t::is_aarch64_dcache_flush_op(instr_t *instr)
+{
+    if (instr_get_opcode(instr) != OP_sys)
+        return false;
+    switch (opnd_get_immed_int(instr_get_src(instr, 0))) {
+    case DR_DC_CVAU:
+    case DR_DC_CIVAC:
+    case DR_DC_CVAC: return true;
+    }
+    return false;
+}
+#endif
+
 bool
 instru_t::instr_is_flush(instr_t *instr)
 {
@@ -189,7 +215,31 @@ instru_t::instr_is_flush(instr_t *instr)
     if (instr_get_opcode(instr) == OP_clflush)
         return true;
 #endif
+#ifdef AARCH64
+    if (is_aarch64_dcache_flush_op(instr) || is_aarch64_icache_flush_op(instr))
+        return true;
+#endif
     return false;
+}
+
+unsigned short
+instru_t::instr_to_flush_type(instr_t *instr)
+{
+    DR_ASSERT(instr_is_flush(instr));
+#ifdef X86
+    // XXX: OP_clflush invalidates all levels of the processor cache
+    // hierarchy (data and instruction)
+    if (instr_get_opcode(instr) == OP_clflush)
+        return TRACE_TYPE_DATA_FLUSH;
+#endif
+#ifdef AARCH64
+    if (is_aarch64_icache_flush_op(instr))
+        return TRACE_TYPE_INSTR_FLUSH;
+    if (is_aarch64_dcache_flush_op(instr))
+        return TRACE_TYPE_DATA_FLUSH;
+#endif
+    DR_ASSERT(false);
+    return TRACE_TYPE_DATA_FLUSH; // unreachable.
 }
 
 void

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -131,6 +131,11 @@ public:
     get_aarch64_prefetch_op_type(ptr_int_t prfop);
     static unsigned short
     get_aarch64_prefetch_type(ptr_int_t prfop);
+    static bool
+    is_aarch64_icache_flush_op(instr_t *instr);
+    static bool
+    is_aarch64_dcache_flush_op(instr_t *instr);
+
 #endif
     static unsigned short
     instr_to_prefetch_type(instr_t *instr);
@@ -138,6 +143,8 @@ public:
     instr_to_instr_type(instr_t *instr, bool repstr_expanded = false);
     static bool
     instr_is_flush(instr_t *instr);
+    static unsigned short
+    instr_to_flush_type(instr_t *instr);
     static int
     get_cpu_id();
     static uint64

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -423,6 +423,8 @@ offline_instru_t::insert_save_type_and_size(void *drcontext, instrlist_t *ilist,
         type = instru_t::instr_to_prefetch_type(app);
         // Prefetch instruction may have zero sized mem reference.
         size = 1;
+    } else if (instr_is_flush(app)) {
+        type = instru_t::instr_to_flush_type(app);
     }
     offline_entry_t entry;
     entry.extended.type = OFFLINE_TYPE_EXTENDED;

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -289,9 +289,7 @@ online_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t 
         // Prefetch instruction may have zero sized mem reference.
         size = 1;
     } else if (instru_t::instr_is_flush(app)) {
-        // XXX: OP_clflush invalidates all levels of the processor cache
-        // hierarchy (data and instruction)
-        type = TRACE_TYPE_DATA_FLUSH;
+        type = instru_t::instr_to_flush_type(app);
     }
     insert_save_type_and_size(drcontext, ilist, where, reg_ptr, reg_tmp, type, size,
                               adjust);

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -845,6 +845,7 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, INOUT app_pc *pc,
     desc->packed_ = 0;
 
     bool is_prefetch = instr_is_prefetch(instr);
+    bool is_flush = instru_t::instr_is_flush(instr);
     bool reads_memory = instr_reads_memory(instr);
     bool writes_memory = instr_writes_memory(instr);
 
@@ -861,6 +862,7 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, INOUT app_pc *pc,
 
     desc->type_ = instru_t::instr_to_instr_type(instr);
     desc->prefetch_type_ = is_prefetch ? instru_t::instr_to_prefetch_type(instr) : 0;
+    desc->flush_type_ = is_flush ? instru_t::instr_to_flush_type(instr) : 0;
     desc->length_ = static_cast<byte>(instr_length(dcontext, instr));
 
     if (reads_memory || writes_memory) {

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -194,6 +194,11 @@ private:
     {
         return prefetch_type_;
     }
+    uint16_t
+    flush_type() const
+    {
+        return flush_type_;
+    }
 
     bool
     reads_memory() const
@@ -258,6 +263,7 @@ private:
     app_pc pc_ = 0;
     uint16_t type_ = 0;
     uint16_t prefetch_type_ = 0;
+    uint16_t flush_type_ = 0;
     byte length_ = 0;
     app_pc next_pc_ = 0;
 
@@ -1268,7 +1274,7 @@ private:
                 buf->type = instr->prefetch_type();
                 buf->size = 1;
             } else if (instr->is_flush()) {
-                buf->type = TRACE_TYPE_DATA_FLUSH;
+                buf->type = instr->flush_type();
                 buf->size = (ushort)opnd_size_in_bytes(opnd_get_size(memref.opnd));
             } else {
                 if (write)

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1276,7 +1276,8 @@ private:
             } else if (instr->is_flush()) {
                 buf->type = instr->flush_type();
                 // i#4398: Handle flush sizes larger than ushort.
-                buf->size = (ushort)opnd_size_in_bytes(opnd_get_size(memref.opnd));
+                // i#4406: Handle flush instrs with sizes other than cache line.
+                buf->size = (ushort)proc_get_cache_line_size();
             } else {
                 if (write)
                     buf->type = TRACE_TYPE_WRITE;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1275,8 +1275,8 @@ private:
                 buf->size = 1;
             } else if (instr->is_flush()) {
                 buf->type = instr->flush_type();
-                // i#4398: Handle flush sizes larger than ushort.
-                // i#4406: Handle flush instrs with sizes other than cache line.
+                // TODO i#4398: Handle flush sizes larger than ushort.
+                // TODO i#4406: Handle flush instrs with sizes other than cache line.
                 buf->size = (ushort)proc_get_cache_line_size();
             } else {
                 if (write)

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1275,6 +1275,7 @@ private:
                 buf->size = 1;
             } else if (instr->is_flush()) {
                 buf->type = instr->flush_type();
+                // i#4398: Handle flush sizes larger than ushort.
                 buf->size = (ushort)opnd_size_in_bytes(opnd_get_size(memref.opnd));
             } else {
                 if (write)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2090,6 +2090,18 @@ if (DR_HOST_AARCH64)
     # with some tool chains (such as SUSE GCC 6.2) results in an executable that
     # is not properly static. Adding --no-export-dynamic avoids the problem.
     "-Wl,--no-export-dynamic")
+
+  add_exe(allasm_aarch64_flush
+    ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_aarch64_flush.asm
+    "-early_inject" "")
+  set_target_properties(allasm_aarch64_flush PROPERTIES LINKER_LANGUAGE C)
+  append_link_flags(allasm_aarch64_flush
+    "-nostartfiles -nodefaultlibs -static")
+  append_property_string(TARGET allasm_aarch64_flush LINK_FLAGS
+    # The default value of CMAKE_SHARED_LIBRARY_LINK_C_FLAGS has -rdynamic, which
+    # with some tool chains (such as SUSE GCC 6.2) results in an executable that
+    # is not properly static. Adding --no-export-dynamic avoids the problem.
+    "-Wl,--no-export-dynamic")
 endif ()
 
 if (CLIENT_INTERFACE AND NOT ANDROID) # XXX i#1874: get working on Android
@@ -3197,6 +3209,9 @@ if (CLIENT_INTERFACE)
 
         torunonly_drcachesim(allasm-aarch64-prefetch-basic-counts allasm_aarch64_prefetch
           "-simulator_type basic_counts" "")
+
+        torunonly_drcachesim(allasm-aarch64-flush-basic-counts allasm_aarch64_flush
+          "-simulator_type basic_counts" "")
       endif ()
 
       # XXX i#1703: add more dedicated tests (in suite/tests/clients/) for which
@@ -3374,6 +3389,10 @@ if (CLIENT_INTERFACE)
       if (NOT MSVC)
         torunonly_drcacheoff(builtin-prefetch-basic-counts builtin_prefetch "" "@-simulator_type@basic_counts" "")
         unset(tool.drcacheoff.builtin-prefetch-basic-counts_rawtemp) # use preprocessor
+      endif ()
+
+      if (AARCH64)
+        torunonly_drcacheoff(allasm-aarch64-flush-basic-counts allasm_aarch64_flush "" "@-simulator_type@basic_counts" "")
       endif ()
 
       # We run common.decode-bad to test markers for faults

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3464,6 +3464,11 @@ if (CLIENT_INTERFACE)
         torunonly_drcacheoff(rseq linux.rseq "" "@-test_mode" "")
       endif ()
 
+      if (AARCH64)
+        set(tool.drcacheoff.burst_flush_aarch64_nodr ON)
+        torunonly_drcacheoff(burst_flush_aarch64 tool.drcacheoff.burst_flush_aarch64 "" "@-simulator_type@basic_counts" "")
+      endif ()
+
       # FIXME i#2007: fails to link on A64
       # XXX i#1551: startstop API is NYI on ARM
       # XXX i#1997: dynamorio_static is not supported on Mac yet

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2092,8 +2092,7 @@ if (DR_HOST_AARCH64)
     "-Wl,--no-export-dynamic")
 
   add_exe(allasm_aarch64_flush
-    ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_aarch64_flush.asm
-    "-early_inject" "")
+    ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_aarch64_flush.asm "" "")
   set_target_properties(allasm_aarch64_flush PROPERTIES LINKER_LANGUAGE C)
   append_link_flags(allasm_aarch64_flush
     "-nostartfiles -nodefaultlibs -static")
@@ -3389,10 +3388,6 @@ if (CLIENT_INTERFACE)
       if (NOT MSVC)
         torunonly_drcacheoff(builtin-prefetch-basic-counts builtin_prefetch "" "@-simulator_type@basic_counts" "")
         unset(tool.drcacheoff.builtin-prefetch-basic-counts_rawtemp) # use preprocessor
-      endif ()
-
-      if (AARCH64)
-        torunonly_drcacheoff(allasm-aarch64-flush-basic-counts allasm_aarch64_flush "" "@-simulator_type@basic_counts" "")
       endif ()
 
       # We run common.decode-bad to test markers for faults


### PR DESCRIPTION
Maps variants of AArch64 flush instructions to existing instr and data flush trace types. Also adds count of instr and data flush operations to basic_counts simulator.

Issue: #4328