### PR TITLE
i#4399: Adds Debug Assertion

### DIFF
--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -1700,6 +1700,15 @@ dr_standalone_exit(void);
  */
 #    define DR_ASSERT(x) DR_ASSERT_MSG(x, "")
 
+/**
+ * The assertion is only set if DEBUG is defined.
+ */
+#    ifdef DEBUG
+#        define DR_DEBUG_ASSERT(x, msg) DR_ASSERT_MSG(x, msg)
+#    else
+#        define DR_DEBUG_ASSERT(x, msg)
+#    endif
+
 /* DR_API EXPORT END */
 
 DR_API

--- a/suite/tests/client-interface/drmgr-test.dll.c
+++ b/suite/tests/client-interface/drmgr-test.dll.c
@@ -343,6 +343,14 @@ dr_init(client_id_t id)
     CHECK(ok, "drmgr_unregister_kernel_xfer_event failed");
     ok = drmgr_register_kernel_xfer_event_ex(event_kernel_xfer, &priority);
     CHECK(ok, "drmgr_register_kernel_xfer_event_ex failed");
+
+    /* A quick check to ensure DR_DEBUG_ASSERT works on extensions. */
+#ifdef DEBUG
+    DR_DEBUG_ASSERT(true "should not fail");
+#else
+    /* Should not trigger failed assertion. */
+    DR_DEBUG_ASSERT(false, "should not fail");
+#endif
 }
 
 static void


### PR DESCRIPTION
Adds a DR_DEBUG_ASSERT which asserts only when DEBUG is defined.

Fixes: #4399