### PR TITLE
i#1578 arm detach: Fix sigreturn crash by setting xsp

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -130,14 +130,10 @@ typedef struct rlimit64 rlimit64_t;
  */
 #define MCXT_SYSCALL_RES(mc) ((mc)->IF_X86_ELSE(xax, r0))
 #if defined(DR_HOST_AARCH64)
-#    define ASM_R2 "x2"
-#    define ASM_R3 "x3"
 #    define READ_TP_TO_R3_DISP_IN_R2    \
         "mrs " ASM_R3 ", tpidr_el0\n\t" \
         "ldr " ASM_R3 ", [" ASM_R3 ", " ASM_R2 "] \n\t"
 #elif defined(DR_HOST_ARM)
-#    define ASM_R2 "r2"
-#    define ASM_R3 "r3"
 #    define READ_TP_TO_R3_DISP_IN_R2                                           \
         "mrc p15, 0, " ASM_R3                                                  \
         ", c13, c0, " STRINGIFY(USR_TLS_REG_OPCODE) " \n\t"                    \

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -51,8 +51,8 @@
 #include "../drlibc/drlibc_unix.h"
 
 /* for inline asm */
-#ifdef X86
-#    ifdef X64
+#ifdef DR_HOST_X86
+#    ifdef DR_HOST_X64
 #        define ASM_XAX "rax"
 #        define ASM_XCX "rcx"
 #        define ASM_XDX "rdx"
@@ -66,15 +66,18 @@
 #        define ASM_XBP "ebp"
 #        define ASM_XSP "esp"
 #    endif /* 64/32-bit */
-#elif defined(AARCH64)
+#elif defined(DR_HOST_AARCH64)
 #    define ASM_R0 "x0"
 #    define ASM_R1 "x1"
-#    define ASM_XSP "sp"
+#    define ASM_R2 "x2"
+#    define ASM_R3 "x3"
 #    define ASM_XSP "sp"
 #    define ASM_INDJMP "br"
-#elif defined(ARM)
+#elif defined(DR_HOST_ARM)
 #    define ASM_R0 "r0"
 #    define ASM_R1 "r1"
+#    define ASM_R2 "r2"
+#    define ASM_R3 "r3"
 #    define ASM_XSP "sp"
 #    define ASM_INDJMP "bx"
 #endif /* X86/ARM */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -7193,7 +7193,6 @@ typedef struct _sig_detach_info_t {
 #endif
 } sig_detach_info_t;
 
-/* xsp is only set for X86 */
 static void
 notify_and_jmp_without_stack(KSYNCH_TYPE *notify_var, byte *continuation, byte *xsp)
 {
@@ -7232,6 +7231,8 @@ notify_and_jmp_without_stack(KSYNCH_TYPE *notify_var, byte *continuation, byte *
         asm("mov " ASM_R1 ", #1");
         asm("str " ASM_R1 ",[" ASM_R0 "]");
         asm("ldr " ASM_R1 ", %0" : : "m"(continuation));
+        asm("ldr " ASM_R2 ", %0" : : "m"(xsp));
+        asm("mov " ASM_XSP ", " ASM_R2);
         asm("b dynamorio_condvar_wake_and_jmp");
 #endif
     } else {
@@ -7239,11 +7240,13 @@ notify_and_jmp_without_stack(KSYNCH_TYPE *notify_var, byte *continuation, byte *
 #ifdef DR_HOST_NOT_TARGET
         ASSERT_NOT_REACHED();
 #elif defined(X86)
-        asm("mov %0, %%" ASM_XSP : : "m"(xsp));
         asm("mov %0, %%" ASM_XAX : : "m"(continuation));
+        asm("mov %0, %%" ASM_XSP : : "m"(xsp));
         asm("jmp *%" ASM_XAX);
 #elif defined(AARCHXX)
         asm("ldr " ASM_R0 ", %0" : : "m"(continuation));
+        asm("ldr " ASM_R1 ", %0" : : "m"(xsp));
+        asm("mov " ASM_XSP ", " ASM_R1);
         asm(ASM_INDJMP " " ASM_R0);
 #endif /* X86/ARM */
     }


### PR DESCRIPTION
Fixes a crash on detach on aarchxx by setting xsp to the proper value
for SYS_rt_sigreturn to find the signal frame for resuming app state.

Tested manually on aarch64 the api.detach test in gdb.  Unfortunately
there are further bugs, so the test cannot be enabled yet.

Issue: #1578