### PR TITLE
i#4049 style: Add source compatibility break release note

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -136,7 +136,11 @@ clients.
 The changes between version \DR_VERSION and 8.0.0 include the following compatibility
 changes:
 
- Nothing yet.
+ - A source compatibilty change in drcachesim analysis tools for users
+   who have created derived classes from existing analysis tools:
+   member fields of classes are now following a consistent style with
+   an underscore suffix.  References to renamed fields will need to be
+   updated.
 
 The changes between version \DR_VERSION and 8.0.0 include the following minor
 compatibility changes:


### PR DESCRIPTION
Commit 5ed1a118 (PR #4084) renamed fields in drcachesim classes to
adopt a consistent naming style.  This is a source compatibility break
for users who have created derived classes with references to those
fields.  Here we add a release note about this.

Issue: #4049