### PR TITLE
i#4335 OOM: Fix beyond-vmm reachability constraints bug

### DIFF
--- a/core/heap.c
+++ b/core/heap.c
@@ -1631,14 +1631,17 @@ vmm_heap_reserve(size_t size, heap_error_code_t *error_code, bool executable,
     /* if we fail to allocate from our reservation we fall back to the OS */
     reached_beyond_vmm();
 #ifdef X64
-    /* PR 215395, make sure allocation satisfies heap reachability contraints */
-    p = os_heap_reserve_in_region(
-        (void *)ALIGN_FORWARD(heap_allowable_region_start, PAGE_SIZE),
-        (void *)ALIGN_BACKWARD(heap_allowable_region_end, PAGE_SIZE), size, error_code,
-        executable);
-    /* ensure future heap allocations are reachable from this allocation */
-    if (p != NULL)
-        request_region_be_heap_reachable(p, size);
+    if (TEST(VMM_REACHABLE, which) || REACHABLE_HEAP()) {
+        /* PR 215395, make sure allocation satisfies heap reachability contraints */
+        p = os_heap_reserve_in_region(
+            (void *)ALIGN_FORWARD(heap_allowable_region_start, PAGE_SIZE),
+            (void *)ALIGN_BACKWARD(heap_allowable_region_end, PAGE_SIZE), size,
+            error_code, executable);
+        /* ensure future heap allocations are reachable from this allocation */
+        if (p != NULL)
+            request_region_be_heap_reachable(p, size);
+    } else
+        p = os_heap_reserve(NULL, size, error_code, executable);
 #else
     p = os_heap_reserve(NULL, size, error_code, executable);
 #endif

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2151,6 +2151,9 @@ if (CLIENT_INTERFACE)
       # For the subtest "targeting upper 2GB of low 4GB" we move -vm_base out of the
       # way.  We also raise the checklevel so we get memory filling for client allocs.
       "-no_vm_base_near_app -vm_base 0x120000000 -checklevel 3" "")
+    # A second test for i#4335's OOM despite a reset.  We leave checklevel for CI speed.
+    tobuild_ci(client.alloc-noreset client-interface/alloc.c ""
+      "-no_enable_reset -no_vm_base_near_app -vm_base 0x120000000" "")
     # XXX i#1312, i#3504: The test doesn't currently compile with CFLAGS_AVX512 but
     # attempts to test features based on it. The compile flag needs to be added.
     tobuild_ci(client.cleancall client-interface/cleancall.c "" "" "")


### PR DESCRIPTION
Fixes a bug where beyond-vmm memory was subject to reachability
constraints even when it did not have VMM_REACHABLE set.

Adds a test by running client.alloc's current OOM test with
-no_enable_reset, which hits OOM and so fails without this fix.

Fixes #4335