### PR TITLE
i#4423: Split VMM stats into reachable vs unreachable

### DIFF
--- a/core/globals.h
+++ b/core/globals.h
@@ -306,16 +306,22 @@ typedef struct _dr_stats_t {
      * an un-translatable spot.
      */
     uint64 synchs_not_at_safe_spot;
-    /** Peak number of memory blocks used for heaps. */
-    uint64 peak_vmm_blocks_heap;
-    /** Peak number of memory blocks used for thread stacks. */
-    uint64 peak_vmm_blocks_stack;
-    /** Peak number of memory blocks used for code caches. */
-    uint64 peak_vmm_blocks_cache;
-    /** Peak number of memory blocks used for specialized heaps. */
-    uint64 peak_vmm_blocks_special_heap;
-    /** Peak number of memory blocks used for mappings not in other categories. */
-    uint64 peak_vmm_blocks_special_mmap;
+    /** Peak number of memory blocks used for unreachable heaps. */
+    uint64 peak_vmm_blocks_unreach_heap;
+    /** Peak number of memory blocks used for (unreachable) thread stacks. */
+    uint64 peak_vmm_blocks_unreach_stack;
+    /** Peak number of memory blocks used for unreachable specialized heaps. */
+    uint64 peak_vmm_blocks_unreach_special_heap;
+    /** Peak number of memory blocks used for other unreachable mappings. */
+    uint64 peak_vmm_blocks_unreach_special_mmap;
+    /** Peak number of memory blocks used for reachable heaps. */
+    uint64 peak_vmm_blocks_reach_heap;
+    /** Peak number of memory blocks used for (reachable) code caches. */
+    uint64 peak_vmm_blocks_reach_cache;
+    /** Peak number of memory blocks used for reachable specialized heaps. */
+    uint64 peak_vmm_blocks_reach_special_heap;
+    /** Peak number of memory blocks used for other reachable mappings. */
+    uint64 peak_vmm_blocks_reach_special_mmap;
 } dr_stats_t;
 
 /**

--- a/core/heap.c
+++ b/core/heap.c
@@ -1352,29 +1352,54 @@ rel32_reachable_from_current_vmcode(byte *tgt)
 static inline void
 vmm_update_block_stats(which_vmm_t which, uint num_blocks, bool add)
 {
+    /* We do not split the stats for cache (always reachable) nor stack (never reachable).
+     * We confirm our assumptions here.
+     */
+    ASSERT(!TESTALL(VMM_REACHABLE | VMM_STACK, which) &&
+           (TEST(VMM_REACHABLE, which) || !TEST(VMM_CACHE, which)));
     /* XXX: find some way to make a stats array */
     if (add) {
-        if (TEST(VMM_HEAP, which))
-            RSTATS_ADD_PEAK(vmm_blocks_heap, num_blocks);
-        else if (TEST(VMM_CACHE, which))
+        if (TEST(VMM_HEAP, which)) {
+            if (TEST(VMM_REACHABLE, which))
+                RSTATS_ADD_PEAK(vmm_blocks_reach_heap, num_blocks);
+            else
+                RSTATS_ADD_PEAK(vmm_blocks_unreach_heap, num_blocks);
+        } else if (TEST(VMM_CACHE, which))
             RSTATS_ADD_PEAK(vmm_blocks_cache, num_blocks);
         else if (TEST(VMM_STACK, which))
             RSTATS_ADD_PEAK(vmm_blocks_stack, num_blocks);
-        else if (TEST(VMM_SPECIAL_HEAP, which))
-            RSTATS_ADD_PEAK(vmm_blocks_special_heap, num_blocks);
-        else if (TEST(VMM_SPECIAL_MMAP, which))
-            RSTATS_ADD_PEAK(vmm_blocks_special_mmap, num_blocks);
+        else if (TEST(VMM_SPECIAL_HEAP, which)) {
+            if (TEST(VMM_REACHABLE, which))
+                RSTATS_ADD_PEAK(vmm_blocks_reach_special_heap, num_blocks);
+            else
+                RSTATS_ADD_PEAK(vmm_blocks_unreach_special_heap, num_blocks);
+        } else if (TEST(VMM_SPECIAL_MMAP, which)) {
+            if (TEST(VMM_REACHABLE, which))
+                RSTATS_ADD_PEAK(vmm_blocks_reach_special_mmap, num_blocks);
+            else
+                RSTATS_ADD_PEAK(vmm_blocks_unreach_special_mmap, num_blocks);
+        }
     } else {
-        if (TEST(VMM_HEAP, which))
-            RSTATS_SUB(vmm_blocks_heap, num_blocks);
-        else if (TEST(VMM_CACHE, which))
+        if (TEST(VMM_HEAP, which)) {
+            if (TEST(VMM_REACHABLE, which))
+                RSTATS_SUB(vmm_blocks_reach_heap, num_blocks);
+            else
+                RSTATS_SUB(vmm_blocks_unreach_heap, num_blocks);
+        } else if (TEST(VMM_CACHE, which))
             RSTATS_SUB(vmm_blocks_cache, num_blocks);
         else if (TEST(VMM_STACK, which))
             RSTATS_SUB(vmm_blocks_stack, num_blocks);
-        else if (TEST(VMM_SPECIAL_HEAP, which))
-            RSTATS_SUB(vmm_blocks_special_heap, num_blocks);
-        else if (TEST(VMM_SPECIAL_MMAP, which))
-            RSTATS_SUB(vmm_blocks_special_mmap, num_blocks);
+        else if (TEST(VMM_SPECIAL_HEAP, which)) {
+            if (TEST(VMM_REACHABLE, which))
+                RSTATS_SUB(vmm_blocks_reach_special_heap, num_blocks);
+            else
+                RSTATS_SUB(vmm_blocks_unreach_special_heap, num_blocks);
+        } else if (TEST(VMM_SPECIAL_MMAP, which)) {
+            if (TEST(VMM_REACHABLE, which))
+                RSTATS_SUB(vmm_blocks_reach_special_mmap, num_blocks);
+            else
+                RSTATS_SUB(vmm_blocks_unreach_special_mmap, num_blocks);
+        }
     }
 }
 

--- a/core/heap.c
+++ b/core/heap.c
@@ -1365,9 +1365,9 @@ vmm_update_block_stats(which_vmm_t which, uint num_blocks, bool add)
             else
                 RSTATS_ADD_PEAK(vmm_blocks_unreach_heap, num_blocks);
         } else if (TEST(VMM_CACHE, which))
-            RSTATS_ADD_PEAK(vmm_blocks_cache, num_blocks);
+            RSTATS_ADD_PEAK(vmm_blocks_reach_cache, num_blocks);
         else if (TEST(VMM_STACK, which))
-            RSTATS_ADD_PEAK(vmm_blocks_stack, num_blocks);
+            RSTATS_ADD_PEAK(vmm_blocks_unreach_stack, num_blocks);
         else if (TEST(VMM_SPECIAL_HEAP, which)) {
             if (TEST(VMM_REACHABLE, which))
                 RSTATS_ADD_PEAK(vmm_blocks_reach_special_heap, num_blocks);
@@ -1386,9 +1386,9 @@ vmm_update_block_stats(which_vmm_t which, uint num_blocks, bool add)
             else
                 RSTATS_SUB(vmm_blocks_unreach_heap, num_blocks);
         } else if (TEST(VMM_CACHE, which))
-            RSTATS_SUB(vmm_blocks_cache, num_blocks);
+            RSTATS_SUB(vmm_blocks_reach_cache, num_blocks);
         else if (TEST(VMM_STACK, which))
-            RSTATS_SUB(vmm_blocks_stack, num_blocks);
+            RSTATS_SUB(vmm_blocks_unreach_stack, num_blocks);
         else if (TEST(VMM_SPECIAL_HEAP, which)) {
             if (TEST(VMM_REACHABLE, which))
                 RSTATS_SUB(vmm_blocks_reach_special_heap, num_blocks);

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -974,16 +974,28 @@ STATS_DEF("Peak total unallocatable free space", peak_total_wasted_vsize)
 STATS_DEF("Number of unaligned allocations (TEB's etc.)", unaligned_allocations)
 STATS_DEF("Peak unaligned allocations", peak_unaligned_allocations)
 #endif
-RSTATS_DEF("Current vmm blocks for heap", vmm_blocks_heap)
-RSTATS_DEF("Peak vmm blocks for heap", peak_vmm_blocks_heap)
-RSTATS_DEF("Current vmm blocks for cache", vmm_blocks_cache)
-RSTATS_DEF("Peak vmm blocks for cache", peak_vmm_blocks_cache)
+RSTATS_DEF("Current vmm blocks for unreachable heap", vmm_blocks_unreach_heap)
+RSTATS_DEF("Peak vmm blocks for unreachable heap", peak_vmm_blocks_unreach_heap)
 RSTATS_DEF("Current vmm blocks for stack", vmm_blocks_stack)
 RSTATS_DEF("Peak vmm blocks for stack", peak_vmm_blocks_stack)
-RSTATS_DEF("Current vmm blocks for special heap", vmm_blocks_special_heap)
-RSTATS_DEF("Peak vmm blocks for special heap", peak_vmm_blocks_special_heap)
-RSTATS_DEF("Current vmm blocks for special mmap", vmm_blocks_special_mmap)
-RSTATS_DEF("Peak vmm blocks for special mmap", peak_vmm_blocks_special_mmap)
+RSTATS_DEF("Current vmm blocks for unreachable special heap",
+           vmm_blocks_unreach_special_heap)
+RSTATS_DEF("Peak vmm blocks for unreachable special heap",
+           peak_vmm_blocks_unreach_special_heap)
+RSTATS_DEF("Current vmm blocks for unreachable special mmap",
+           vmm_blocks_unreach_special_mmap)
+RSTATS_DEF("Peak vmm blocks for unreachable special mmap",
+           peak_vmm_blocks_unreach_special_mmap)
+RSTATS_DEF("Current vmm blocks for reachable heap", vmm_blocks_reach_heap)
+RSTATS_DEF("Peak vmm blocks for reachable heap", peak_vmm_blocks_reach_heap)
+RSTATS_DEF("Current vmm blocks for cache", vmm_blocks_cache)
+RSTATS_DEF("Peak vmm blocks for cache", peak_vmm_blocks_cache)
+RSTATS_DEF("Current vmm blocks for reachable special heap", vmm_blocks_reach_special_heap)
+RSTATS_DEF("Peak vmm blocks for reachable special heap",
+           peak_vmm_blocks_reach_special_heap)
+RSTATS_DEF("Current vmm blocks for reachable special mmap", vmm_blocks_reach_special_mmap)
+RSTATS_DEF("Peak vmm blocks for reachable special mmap",
+           peak_vmm_blocks_reach_special_mmap)
 STATS_DEF("Our virtual memory blocks in use", vmm_vsize_blocks_used)
 STATS_DEF("Peak our virtual memory blocks in use", peak_vmm_vsize_blocks_used)
 STATS_DEF("Wasted vmm space due to alignment", vmm_vsize_wasted)

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -976,8 +976,8 @@ STATS_DEF("Peak unaligned allocations", peak_unaligned_allocations)
 #endif
 RSTATS_DEF("Current vmm blocks for unreachable heap", vmm_blocks_unreach_heap)
 RSTATS_DEF("Peak vmm blocks for unreachable heap", peak_vmm_blocks_unreach_heap)
-RSTATS_DEF("Current vmm blocks for stack", vmm_blocks_stack)
-RSTATS_DEF("Peak vmm blocks for stack", peak_vmm_blocks_stack)
+RSTATS_DEF("Current vmm blocks for stack", vmm_blocks_unreach_stack)
+RSTATS_DEF("Peak vmm blocks for stack", peak_vmm_blocks_unreach_stack)
 RSTATS_DEF("Current vmm blocks for unreachable special heap",
            vmm_blocks_unreach_special_heap)
 RSTATS_DEF("Peak vmm blocks for unreachable special heap",
@@ -988,8 +988,8 @@ RSTATS_DEF("Peak vmm blocks for unreachable special mmap",
            peak_vmm_blocks_unreach_special_mmap)
 RSTATS_DEF("Current vmm blocks for reachable heap", vmm_blocks_reach_heap)
 RSTATS_DEF("Peak vmm blocks for reachable heap", peak_vmm_blocks_reach_heap)
-RSTATS_DEF("Current vmm blocks for cache", vmm_blocks_cache)
-RSTATS_DEF("Peak vmm blocks for cache", peak_vmm_blocks_cache)
+RSTATS_DEF("Current vmm blocks for cache", vmm_blocks_reach_cache)
+RSTATS_DEF("Peak vmm blocks for cache", peak_vmm_blocks_reach_cache)
 RSTATS_DEF("Current vmm blocks for reachable special heap", vmm_blocks_reach_special_heap)
 RSTATS_DEF("Peak vmm blocks for reachable special heap",
            peak_vmm_blocks_reach_special_heap)

--- a/core/utils.c
+++ b/core/utils.c
@@ -4610,13 +4610,20 @@ stats_get_snapshot(dr_stats_t *drstats)
     if (drstats->size > offsetof(dr_stats_t, synchs_not_at_safe_spot)) {
         drstats->synchs_not_at_safe_spot = GLOBAL_STAT(synchs_not_at_safe_spot);
     }
-    if (drstats->size > offsetof(dr_stats_t, peak_vmm_blocks_heap)) {
+    if (drstats->size > offsetof(dr_stats_t, peak_vmm_blocks_unreach_heap)) {
         /* These fields were added all at once. */
-        drstats->peak_vmm_blocks_heap = GLOBAL_STAT(peak_vmm_blocks_heap);
-        drstats->peak_vmm_blocks_stack = GLOBAL_STAT(peak_vmm_blocks_stack);
-        drstats->peak_vmm_blocks_cache = GLOBAL_STAT(peak_vmm_blocks_cache);
-        drstats->peak_vmm_blocks_special_heap = GLOBAL_STAT(peak_vmm_blocks_special_heap);
-        drstats->peak_vmm_blocks_special_mmap = GLOBAL_STAT(peak_vmm_blocks_special_mmap);
+        drstats->peak_vmm_blocks_unreach_heap = GLOBAL_STAT(peak_vmm_blocks_unreach_heap);
+        drstats->peak_vmm_blocks_unreach_stack = GLOBAL_STAT(peak_vmm_blocks_stack);
+        drstats->peak_vmm_blocks_unreach_special_heap =
+            GLOBAL_STAT(peak_vmm_blocks_unreach_special_heap);
+        drstats->peak_vmm_blocks_unreach_special_mmap =
+            GLOBAL_STAT(peak_vmm_blocks_unreach_special_mmap);
+        drstats->peak_vmm_blocks_reach_heap = GLOBAL_STAT(peak_vmm_blocks_reach_heap);
+        drstats->peak_vmm_blocks_reach_cache = GLOBAL_STAT(peak_vmm_blocks_cache);
+        drstats->peak_vmm_blocks_reach_special_heap =
+            GLOBAL_STAT(peak_vmm_blocks_reach_special_heap);
+        drstats->peak_vmm_blocks_reach_special_mmap =
+            GLOBAL_STAT(peak_vmm_blocks_reach_special_mmap);
     }
     return true;
 }

--- a/core/utils.c
+++ b/core/utils.c
@@ -4613,13 +4613,14 @@ stats_get_snapshot(dr_stats_t *drstats)
     if (drstats->size > offsetof(dr_stats_t, peak_vmm_blocks_unreach_heap)) {
         /* These fields were added all at once. */
         drstats->peak_vmm_blocks_unreach_heap = GLOBAL_STAT(peak_vmm_blocks_unreach_heap);
-        drstats->peak_vmm_blocks_unreach_stack = GLOBAL_STAT(peak_vmm_blocks_stack);
+        drstats->peak_vmm_blocks_unreach_stack =
+            GLOBAL_STAT(peak_vmm_blocks_unreach_stack);
         drstats->peak_vmm_blocks_unreach_special_heap =
             GLOBAL_STAT(peak_vmm_blocks_unreach_special_heap);
         drstats->peak_vmm_blocks_unreach_special_mmap =
             GLOBAL_STAT(peak_vmm_blocks_unreach_special_mmap);
         drstats->peak_vmm_blocks_reach_heap = GLOBAL_STAT(peak_vmm_blocks_reach_heap);
-        drstats->peak_vmm_blocks_reach_cache = GLOBAL_STAT(peak_vmm_blocks_cache);
+        drstats->peak_vmm_blocks_reach_cache = GLOBAL_STAT(peak_vmm_blocks_reach_cache);
         drstats->peak_vmm_blocks_reach_special_heap =
             GLOBAL_STAT(peak_vmm_blocks_reach_special_heap);
         drstats->peak_vmm_blocks_reach_special_mmap =

--- a/suite/tests/api/thread_churn.c
+++ b/suite/tests/api/thread_churn.c
@@ -95,11 +95,19 @@ main(int argc, char **argv)
     /* XXX: Somehow the first run has *more* heap blocks.  2nd and any subsequent
      * are identical.  Just living with that and requiring <=.
      */
-    assert(stats_B.peak_vmm_blocks_heap <= stats_A.peak_vmm_blocks_heap);
-    assert(stats_B.peak_vmm_blocks_stack <= stats_A.peak_vmm_blocks_stack);
-    assert(stats_B.peak_vmm_blocks_cache <= stats_A.peak_vmm_blocks_cache);
-    assert(stats_B.peak_vmm_blocks_special_heap <= stats_A.peak_vmm_blocks_special_heap);
-    assert(stats_B.peak_vmm_blocks_special_mmap <= stats_A.peak_vmm_blocks_special_mmap);
+    assert(stats_B.peak_vmm_blocks_unreach_heap <= stats_A.peak_vmm_blocks_unreach_heap);
+    assert(stats_B.peak_vmm_blocks_unreach_stack <=
+           stats_A.peak_vmm_blocks_unreach_stack);
+    assert(stats_B.peak_vmm_blocks_unreach_special_heap <=
+           stats_A.peak_vmm_blocks_unreach_special_heap);
+    assert(stats_B.peak_vmm_blocks_unreach_special_mmap <=
+           stats_A.peak_vmm_blocks_unreach_special_mmap);
+    assert(stats_B.peak_vmm_blocks_reach_heap <= stats_A.peak_vmm_blocks_reach_heap);
+    assert(stats_B.peak_vmm_blocks_reach_cache <= stats_A.peak_vmm_blocks_reach_cache);
+    assert(stats_B.peak_vmm_blocks_reach_special_heap <=
+           stats_A.peak_vmm_blocks_reach_special_heap);
+    assert(stats_B.peak_vmm_blocks_reach_special_mmap <=
+           stats_A.peak_vmm_blocks_reach_special_mmap);
 
     print("all done\n");
     return 0;


### PR DESCRIPTION
Given the vmcode vs vmheap split and completely different size limits
on the two, the VMM stats need to be split to be useful.  Here we
split the heap, special heap, and special mmap stats into reachable
and unreachable versions.  We also split the public versions in
dr_statistics_t, renaming and reordering fields, which is not
considered a compatibility break because we are in between releases.

Additionally tested on a large AArch64 app where the stats used to
look something like this:
                          Peak vmm blocks for heap :             14679
                         Peak vmm blocks for cache :              5139
                         Peak vmm blocks for stack :              9039
                  Peak vmm blocks for special heap :              4518
                  Peak vmm blocks for special mmap :              9043
Now they are more useful as this (different params so not perfect
numeric comparison) to see that vmcode is using 470M while vmheap is
at 2120M:
              Peak vmm blocks for unreachable heap :              8401
                         Peak vmm blocks for stack :             14586
      Peak vmm blocks for unreachable special heap :              3646
      Peak vmm blocks for unreachable special mmap :              7292
                Peak vmm blocks for reachable heap :              3650
                         Peak vmm blocks for cache :              3863
        Peak vmm blocks for reachable special mmap :                 5

Fixes #4423