### PR TITLE
i#4424: Adjust guard pages and unit sizes for >4K pages

### DIFF
--- a/core/heap.c
+++ b/core/heap.c
@@ -1917,7 +1917,7 @@ vmh_exit(vm_heap_t *vmh, bool contains_stacks)
         uint perstack =
             (uint)(ALIGN_FORWARD_UINT(
                        DYNAMO_OPTION(stack_size) +
-                           (DYNAMO_OPTION(guard_pages)
+                           (DYNAMO_OPTION(per_thread_guard_pages)
                                 ? (2 * PAGE_SIZE)
                                 : (DYNAMO_OPTION(stack_guard_pages) ? PAGE_SIZE : 0)),
                        DYNAMO_OPTION(vmm_block_size)) /
@@ -2802,7 +2802,9 @@ get_guarded_real_memory(size_t reserve_size, size_t commit_size, uint prot, bool
     heap_error_code_t error_code;
     bool try_vmm = true;
     ASSERT(reserve_size >= commit_size);
-    if (!guarded || !dynamo_options.guard_pages) {
+    if (!guarded ||
+        (TEST(VMM_PER_THREAD, which) && !DYNAMO_OPTION(per_thread_guard_pages)) ||
+        !DYNAMO_OPTION(guard_pages)) {
         if (reserve_size == commit_size)
             return get_real_memory(reserve_size, prot, add_vm, which _IF_DEBUG(comment));
         guard_size = 0;
@@ -2898,7 +2900,9 @@ static void
 release_guarded_real_memory(vm_addr_t p, size_t size, bool remove_vm, bool guarded,
                             which_vmm_t which)
 {
-    if (!guarded || !dynamo_options.guard_pages) {
+    if (!guarded ||
+        (TEST(VMM_PER_THREAD, which) && !DYNAMO_OPTION(per_thread_guard_pages)) ||
+        !dynamo_options.guard_pages) {
         release_real_memory(p, size, remove_vm, which);
         return;
     }
@@ -3193,11 +3197,12 @@ stack_alloc(size_t size, byte *min_addr)
      * hurting us in the common case
      */
     size_t alloc_size = size;
-    if (!DYNAMO_OPTION(guard_pages) && DYNAMO_OPTION(stack_guard_pages))
+    if (!DYNAMO_OPTION(per_thread_guard_pages) && DYNAMO_OPTION(stack_guard_pages))
         alloc_size += PAGE_SIZE;
     p = get_guarded_real_memory(alloc_size, alloc_size, MEMPROT_READ | MEMPROT_WRITE,
-                                true, true, min_addr, VMM_STACK _IF_DEBUG("stack_alloc"));
-    if (!DYNAMO_OPTION(guard_pages) && DYNAMO_OPTION(stack_guard_pages))
+                                true, true, min_addr,
+                                VMM_STACK | VMM_PER_THREAD _IF_DEBUG("stack_alloc"));
+    if (!DYNAMO_OPTION(per_thread_guard_pages) && DYNAMO_OPTION(stack_guard_pages))
         p = (byte *)p + PAGE_SIZE;
 #ifdef DEBUG_MEMORY
     memset(p, HEAP_ALLOCATED_BYTE, size);
@@ -3221,11 +3226,11 @@ stack_alloc(size_t size, byte *min_addr)
          */
         heap_error_code_t error_code;
         if (vmm_heap_commit(guard, PAGE_SIZE, MEMPROT_READ | MEMPROT_WRITE, &error_code,
-                            VMM_STACK))
+                            VMM_STACK | VMM_PER_THREAD))
             mark_page_as_guard(guard);
 #else
         /* For UNIX we just mark it as inaccessible. */
-        if (!DYNAMO_OPTION(guard_pages))
+        if (!DYNAMO_OPTION(per_thread_guard_pages))
             set_protection(guard, PAGE_SIZE, MEMPROT_READ);
 #endif
     }
@@ -3244,12 +3249,13 @@ stack_free(void *p, size_t size)
         size = DYNAMORIO_STACK_SIZE;
     alloc_size = size;
     p = (void *)((vm_addr_t)p - size);
-    if (!DYNAMO_OPTION(guard_pages) && DYNAMO_OPTION(stack_guard_pages)) {
+    if (!DYNAMO_OPTION(per_thread_guard_pages) && DYNAMO_OPTION(stack_guard_pages)) {
         alloc_size += PAGE_SIZE;
         p = (byte *)p - PAGE_SIZE;
     }
     release_guarded_real_memory((vm_addr_t)p, alloc_size,
-                                true /*update DR areas immediately*/, true, VMM_STACK);
+                                true /*update DR areas immediately*/, true,
+                                VMM_STACK | VMM_PER_THREAD);
     if (IF_DEBUG_ELSE(!dynamo_exited_log_and_stats, true))
         RSTATS_SUB(stack_capacity, size);
 }
@@ -3264,7 +3270,7 @@ is_stack_overflow(dcontext_t *dcontext, byte *sp)
      * -signal_stack_size, but all dstacks and d_r_initstack should be this size.
      */
     byte *bottom = dcontext->dstack - DYNAMORIO_STACK_SIZE;
-    if (!DYNAMO_OPTION(stack_guard_pages) && !DYNAMO_OPTION(guard_pages))
+    if (!DYNAMO_OPTION(stack_guard_pages) && !DYNAMO_OPTION(per_thread_guard_pages))
         return false;
     /* see if in bottom guard page of dstack */
     if (sp >= bottom - PAGE_SIZE && sp < bottom)
@@ -3335,6 +3341,7 @@ heap_vmareas_synch_units()
 {
     heap_unit_t *u, *next;
     /* make sure to add guard page on each side, as well */
+    // NOCHECK
     uint offs = (dynamo_options.guard_pages) ? (uint)PAGE_SIZE : 0;
     /* we again have circular dependence w/ vmareas if it happens to need a
      * new unit in the course of adding these areas, so we use a recursive lock!
@@ -3792,6 +3799,14 @@ threadunits_init(dcontext_t *dcontext, thread_units_t *tu, size_t size, bool rea
     int i;
     DODEBUG({ tu->num_units = 0; });
     tu->which = VMM_HEAP | (reachable ? VMM_REACHABLE : 0);
+    if (dcontext != GLOBAL_DCONTEXT) {
+        /* Tradeoff (i#4424): no guard pages on per-thread units, to
+         * save space for many-threaded apps.  These units are rarely used.
+         * Note that this also precludes sharing dead units between thread-private
+         * and shared heaps due to the different "which" value.
+         */
+        tu->which |= VMM_PER_THREAD;
+    }
     tu->top_unit = heap_create_unit(tu, size, false /*can reuse*/);
     tu->cur_unit = tu->top_unit;
     tu->dcontext = dcontext;
@@ -4911,6 +4926,7 @@ typedef struct _special_units_t {
     bool use_lock : 1;
     bool in_iterator : 1;
     bool persistent : 1;
+    bool per_thread : 1;
     mutex_t lock;
 
     /* Yet another feature added: pclookup, but across multiple heaps,
@@ -4971,6 +4987,8 @@ get_which(special_units_t *su)
     /* We assume that +x special heap must be reachable. */
     if (su->executable)
         which |= VMM_REACHABLE;
+    if (su->per_thread)
+        which |= VMM_PER_THREAD;
     return which;
 }
 
@@ -5141,6 +5159,8 @@ special_heap_init_internal(uint block_size, uint block_alignment, bool use_lock,
     su->block_alignment = block_alignment;
     su->executable = executable;
     su->persistent = persistent;
+    /* We assume that a lockless heap is a per-thread heap. */
+    su->per_thread = !use_lock;
     su->writable = true;
     su->free_list = NULL;
     su->cfree_list = NULL;

--- a/core/heap.h
+++ b/core/heap.h
@@ -119,6 +119,12 @@ typedef enum {
     VMM_SPECIAL_MMAP = 0x0010,
     /* These modify the core types. */
     VMM_REACHABLE = 0x0020,
+    /* This is used to decide whether to add guard pages for -per_thread_guard_pages.
+     * It is not required that all thread-private allocs use this, nor that this
+     * never end up labeling a thread-shared alloc.  It is also not required that
+     * this flag be present at incremental commits: only at reserve and unreserve calls.
+     */
+    VMM_PER_THREAD = 0x0040,
 } which_vmm_t;
 
 void

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1352,6 +1352,7 @@ OPTION_DEFAULT(uint_size, cache_shared_bb_unit_init, (56 * 1024),
                   should be 32*1024 */
                "initial shared bb cache unit size, in KB or MB")
 /* default size is in Kilobytes, Examples: 4, 4k, 4m, or 0 for unlimited */
+/* May be adjusted by adjust_defaults_for_page_size(). */
 OPTION_DEFAULT(uint_size, cache_shared_bb_unit_max, (56 * 1024),
                "maximum shared bb cache unit size, in KB or MB")
 /* default size is in Kilobytes, Examples: 4, 4k, 4m, or 0 for unlimited */
@@ -1368,6 +1369,7 @@ OPTION_DEFAULT(uint_size, cache_shared_trace_unit_init, (56 * 1024),
                   should be 32*1024 */
                "initial shared trace cache unit size, in KB or MB")
 /* default size is in Kilobytes, Examples: 4, 4k, 4m, or 0 for unlimited */
+/* May be adjusted by adjust_defaults_for_page_size(). */
 OPTION_DEFAULT(uint_size, cache_shared_trace_unit_max, (56 * 1024),
                "maximum shared trace cache unit size, in KB or MB")
 /* default size is in Kilobytes, Examples: 4, 4k, 4m, or 0 for unlimited */
@@ -1849,7 +1851,12 @@ PC_OPTION_DEFAULT(bool, alt_teb_tls, true,
 OPTION_DEFAULT_INTERNAL(bool, safe_read_tls_init, IF_LINUX_ELSE(true, false),
                         "use a safe read to identify uninit TLS")
 
-OPTION_DEFAULT(bool, guard_pages, true, "add guard pages to our heap units")
+OPTION_DEFAULT(bool, guard_pages, true,
+               "add guard pages to all thread-shared vmm allocations; if disabled, also "
+               "disables -per_thread_guard_pages")
+OPTION_DEFAULT(
+    bool, per_thread_guard_pages, true,
+    "add guard pages to all thread-private vmm allocations, if -guard_pages is also on")
 /* Today we support just one stack guard page.  We may want to turn this
  * option into a number in the future to catch larger strides beyond TOS.
  * There are problems on Windows where the PAGE_GUARD pages must be used, yet

--- a/core/unix/loader_linux.c
+++ b/core/unix/loader_linux.c
@@ -311,8 +311,8 @@ privload_tls_init(void *app_tp)
     /* FIXME: These should be a thread logs, but dcontext is not ready yet. */
     LOG(GLOBAL, LOG_LOADER, 2, "%s: app TLS segment base is " PFX "\n", __FUNCTION__,
         app_tp);
-    dr_tp =
-        heap_mmap(client_tls_alloc_size, MEMPROT_READ | MEMPROT_WRITE, VMM_SPECIAL_MMAP);
+    dr_tp = heap_mmap(client_tls_alloc_size, MEMPROT_READ | MEMPROT_WRITE,
+                      VMM_SPECIAL_MMAP | VMM_PER_THREAD);
     ASSERT(APP_LIBC_TLS_SIZE + TLS_PRE_TCB_SIZE + tcb_size <= client_tls_alloc_size);
 #ifdef AARCHXX
     /* GDB reads some pthread members (e.g., pid, tid), so we must make sure
@@ -381,7 +381,7 @@ privload_tls_exit(void *dr_tp)
     if (dr_tp == NULL)
         return;
     dr_tp = dr_tp + tcb_size - client_tls_alloc_size;
-    heap_munmap(dr_tp, client_tls_alloc_size, VMM_SPECIAL_MMAP);
+    heap_munmap(dr_tp, client_tls_alloc_size, VMM_SPECIAL_MMAP | VMM_PER_THREAD);
 }
 
 /****************************************************************************

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -2110,7 +2110,8 @@ os_tls_init(void)
      */
     byte *segment = tls_get_dr_addr();
 #    else
-    byte *segment = heap_mmap(PAGE_SIZE, MEMPROT_READ | MEMPROT_WRITE, VMM_SPECIAL_MMAP);
+    byte *segment = heap_mmap(PAGE_SIZE, MEMPROT_READ | MEMPROT_WRITE,
+                              VMM_SPECIAL_MMAP | VMM_PER_THREAD);
 #    endif
     os_local_state_t *os_tls = (os_local_state_t *)segment;
 
@@ -2249,7 +2250,7 @@ os_tls_exit(local_state_t *local_state, bool other_thread)
     /* ASSUMPTION: local_state_t is laid out at same start as local_state_extended_t */
     os_local_state_t *os_tls =
         (os_local_state_t *)(((byte *)local_state) - offsetof(os_local_state_t, state));
-    heap_munmap(os_tls->self, PAGE_SIZE, VMM_SPECIAL_MMAP);
+    heap_munmap(os_tls->self, PAGE_SIZE, VMM_SPECIAL_MMAP | VMM_PER_THREAD);
 #    endif
 #else
     global_heap_free(tls_table, MAX_THREADS * sizeof(tls_slot_t) HEAPACCT(ACCT_OTHER));


### PR DESCRIPTION
Adds a new option -per_thread_guard_pages controlling whether
per-thread allocations have guard pages.  This option is turned off by
default for >4K pages, removing guard pages from thread-private
initial cache units, all thread-private heap units, thread-private
signal-pending special heap units, stacks, TLS segments (DR and
privlib), and thread-private gencode.  This saves a lot of space on
many-threaded apps, while maintaining guards throughout the VMM from
shared units, which are used far more often than private these days.

Implements the option with a new VMM flag VMM_PER_THREAD, added to the
reservation calls for the above list of unit types.

Additionally, for >4K pages, tunes the default unit sizes to take into
account the guard changes.  Increases the shared unit sizes further
for a better ratio of content to guard pages.

Tested on a large app on a 64K-page machine which originally hit OOM
without "-no_guard_pages" before (along with other now-fixed bugs:
i#4335; i#4418).  Here are some stats for a smaller version of the app
that is easier to capture statistics for:

-no_guard_pages:
              Peak threads under DynamoRIO control :               152
                              Threads ever created :               701
              Peak vmm blocks for unreachable heap :               914
                         Peak vmm blocks for stack :               610
      Peak vmm blocks for unreachable special heap :               152
      Peak vmm blocks for unreachable special mmap :               304
                Peak vmm blocks for reachable heap :               161
                         Peak vmm blocks for cache :               368
        Peak vmm blocks for reachable special mmap :                 5
            Peak vmm virtual memory in use (bytes) :         164757504

Here's this PR with -per_thread_guard_pages (i.e., overriding the new
default: so matching the HEAD defaults):
              Peak threads under DynamoRIO control :               157
                              Threads ever created :               706
              Peak vmm blocks for unreachable heap :              1690
                         Peak vmm blocks for stack :               945
      Peak vmm blocks for unreachable special heap :               471
      Peak vmm blocks for unreachable special mmap :               942
                Peak vmm blocks for reachable heap :               482
                         Peak vmm blocks for cache :               741
        Peak vmm blocks for reachable special mmap :                 7
            Peak vmm virtual memory in use (bytes) :         345899008

Vs the new defaults in this PR:
              Peak threads under DynamoRIO control :               141
                              Threads ever created :               701
              Peak vmm blocks for unreachable heap :               884
                         Peak vmm blocks for stack :               566
      Peak vmm blocks for unreachable special heap :               141
      Peak vmm blocks for unreachable special mmap :               282
                Peak vmm blocks for reachable heap :               152
                         Peak vmm blocks for cache :               411
        Peak vmm blocks for reachable special mmap :                 7
            Peak vmm virtual memory in use (bytes) :         160104448

Fixes #4424