### PR TITLE
i#107 app seg: Relax assert on flat far cti using xcx

### DIFF
--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -150,7 +150,7 @@
 #  define POUND #
 #  define HEX(n) POUND 0x##n
 # endif
-# define SEGMEM(seg,mem) [seg:mem]
+# define SEGMEM(seg,mem) seg:[mem]
 # define DECL_EXTERN(symbol) /* nothing */
 /* include newline so we can put multiple on one line */
 # define RAW(n) .byte HEX(n) @N@

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -549,6 +549,17 @@ DECL_EXTERN(my_setjmp)
         DECLARE_FUNC_SEH(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
         END_PROLOG
+        /* ljmp to base-disp with flat segment */
+        lea   REG_XAX, PTRSZ SYMREF(test_far_cti_end_flat)
+        push  REG_XAX
+        mov   REG_XCX, REG_XSP
+        /* I'm having trouble getting gas to generate this from:
+         *   jmp   PTRSZ SEGMEM(es,REG_XCX)
+         * So I'm bailing and going with raw bytes.
+         */
+        RAW(26) RAW(ff) RAW(21) /* jmp QWORD PTR es:[rcx] */
+    test_far_cti_end_flat:
+        pop   REG_XAX
         CALL_SETJMP
         cmp   REG_XAX, 0
         jne   test_far_cti_1

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -558,7 +558,7 @@ GLOBAL_LABEL(FUNCNAME:)
          * So I'm bailing and going with raw bytes.
          */
         RAW(26) RAW(ff) RAW(21) /* jmp QWORD PTR es:[rcx] */
-    test_far_cti_end_flat:
+    ADDRTAKEN_LABEL(test_far_cti_end_flat:)
         pop   REG_XAX
         CALL_SETJMP
         cmp   REG_XAX, 0


### PR DESCRIPTION
An app with a far cti that uses rcx/ecx but whose segment is flat (cs,
ds, es) today raises a debug-build assert.  It works fine in release.
Here we relax the debug-build assert.

Adds a test case to common.decode which fails with the assert without
this fix.

Issue: #107