### PR TITLE
i#4446: Obtain AArch64 cache line size using ctr_el0.

### DIFF
--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -143,7 +143,6 @@ online_instru_t::append_thread_header(byte *buf_ptr, thread_id_t tid)
     byte *new_buf = buf_ptr;
     new_buf += append_tid(new_buf, tid);
     new_buf += append_pid(new_buf, dr_get_process_id());
-
     new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_CACHE_LINE_SIZE,
                              proc_get_cache_line_size());
     return (int)(new_buf - buf_ptr);

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -143,6 +143,7 @@ online_instru_t::append_thread_header(byte *buf_ptr, thread_id_t tid)
     byte *new_buf = buf_ptr;
     new_buf += append_tid(new_buf, tid);
     new_buf += append_pid(new_buf, dr_get_process_id());
+
     new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_CACHE_LINE_SIZE,
                              proc_get_cache_line_size());
     return (int)(new_buf - buf_ptr);

--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -34,25 +34,9 @@
 #include "proc.h"
 #include "instr.h"
 
-// The whitepaper below documents AArch64 words being 32 bits wide.
-// https://developer.arm.com/-/media/Files/pdf/
-// graphics-and-multimedia/Porting%20to%20ARM%2064-bit.pdf
-#define AARCH64_WORD_SIZE_BYTES 4
-
 static int num_simd_saved;
 static int num_simd_registers;
 static int num_opmask_registers;
-
-void
-set_cache_line_size_using_ctr_el0()
-{
-    uint64 ctr_el0;
-    __asm__ volatile("MRS %0, CTR_EL0" : "=r"(ctr_el0));
-    // Bits [19:16] are Log2 of the number of words in the smallest cache line
-    // of all the data caches and unified caches.
-    // https://developer.arm.com/docs/ddi0595/h/aarch64-system-registers/ctr_el0
-    cache_line_size = (1 << ((ctr_el0 >> 16) & 0xf)) * AARCH64_WORD_SIZE_BYTES;
-}
 
 void
 proc_init_arch(void)
@@ -61,7 +45,8 @@ proc_init_arch(void)
     num_simd_registers = MCXT_NUM_SIMD_SLOTS;
     num_opmask_registers = MCXT_NUM_OPMASK_SLOTS;
 
-    set_cache_line_size_using_ctr_el0();
+    set_cache_line_size_using_ctr_el0(/* dcache_line_size= */ &cache_line_size,
+                                      /* icache_line_size= */ NULL);
 
     /* FIXME i#1569: NYI */
 }

--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -45,8 +45,14 @@ proc_init_arch(void)
     num_simd_registers = MCXT_NUM_SIMD_SLOTS;
     num_opmask_registers = MCXT_NUM_OPMASK_SLOTS;
 
-    set_cache_line_size_using_ctr_el0(/* dcache_line_size= */ &cache_line_size,
-                                      /* icache_line_size= */ NULL);
+    size_t dcache_line_size;
+    // When DR_HOST_NOT_TARGET, get_cache_line_size returns false and does
+    // not set any value in given args. In that case, we do not want to
+    // overwrite the default cache_line_size.
+    if (get_cache_line_size(&dcache_line_size,
+                            /* icache_line_size= */ NULL)) {
+        cache_line_size = dcache_line_size;
+    }
 
     /* FIXME i#1569: NYI */
 }

--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -45,10 +45,8 @@ proc_init_arch(void)
     num_simd_registers = MCXT_NUM_SIMD_SLOTS;
     num_opmask_registers = MCXT_NUM_OPMASK_SLOTS;
 
-#ifndef DR_HOST_NOT_TARGET
     set_cache_line_size_using_ctr_el0(/* dcache_line_size= */ &cache_line_size,
                                       /* icache_line_size= */ NULL);
-#endif
 
     /* FIXME i#1569: NYI */
 }

--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -34,9 +34,25 @@
 #include "proc.h"
 #include "instr.h"
 
+// The whitepaper below documents AArch64 words being 32 bits wide.
+// https://developer.arm.com/-/media/Files/pdf/
+// graphics-and-multimedia/Porting%20to%20ARM%2064-bit.pdf
+#define AARCH64_WORD_SIZE_BYTES 4
+
 static int num_simd_saved;
 static int num_simd_registers;
 static int num_opmask_registers;
+
+void
+set_cache_line_size_using_ctr_el0()
+{
+    uint64 ctr_el0;
+    __asm__ volatile("MRS %0, CTR_EL0" : "=r"(ctr_el0));
+    // Bits [19:16] are Log2 of the number of words in the smallest cache line
+    // of all the data caches and unified caches.
+    // https://developer.arm.com/docs/ddi0595/h/aarch64-system-registers/ctr_el0
+    cache_line_size = (1 << ((ctr_el0 >> 16) & 0xf)) * AARCH64_WORD_SIZE_BYTES;
+}
 
 void
 proc_init_arch(void)
@@ -44,6 +60,8 @@ proc_init_arch(void)
     num_simd_saved = MCXT_NUM_SIMD_SLOTS;
     num_simd_registers = MCXT_NUM_SIMD_SLOTS;
     num_opmask_registers = MCXT_NUM_OPMASK_SLOTS;
+
+    set_cache_line_size_using_ctr_el0();
 
     /* FIXME i#1569: NYI */
 }

--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -45,8 +45,10 @@ proc_init_arch(void)
     num_simd_registers = MCXT_NUM_SIMD_SLOTS;
     num_opmask_registers = MCXT_NUM_OPMASK_SLOTS;
 
+#ifndef DR_HOST_NOT_TARGET
     set_cache_line_size_using_ctr_el0(/* dcache_line_size= */ &cache_line_size,
                                       /* icache_line_size= */ NULL);
+#endif
 
     /* FIXME i#1569: NYI */
 }

--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -45,13 +45,12 @@ proc_init_arch(void)
     num_simd_registers = MCXT_NUM_SIMD_SLOTS;
     num_opmask_registers = MCXT_NUM_OPMASK_SLOTS;
 
-    size_t dcache_line_size;
-    // When DR_HOST_NOT_TARGET, get_cache_line_size returns false and does
-    // not set any value in given args. In that case, we do not want to
-    // overwrite the default cache_line_size.
-    if (get_cache_line_size(&dcache_line_size,
-                            /* icache_line_size= */ NULL)) {
-        cache_line_size = dcache_line_size;
+    /* When DR_HOST_NOT_TARGET, get_cache_line_size returns false and does
+     * not set any value in given args.
+     */
+    if (!get_cache_line_size(&cache_line_size,
+                             /* icache_line_size= */ NULL)) {
+        LOG(GLOBAL, LOG_TOP, 1, "Unable to obtain cache line size");
     }
 
     /* FIXME i#1569: NYI */

--- a/core/drlibc/drlibc.c
+++ b/core/drlibc/drlibc.c
@@ -159,9 +159,7 @@ clear_icache(void *beg, void *end)
 void
 set_cache_line_size_using_ctr_el0(size_t *dcache_line_size, size_t *icache_line_size)
 {
-#    ifdef DR_HOST_NOT_TARGET
-    ASSERT_NOT_REACHED();
-#    else
+#    ifndef DR_HOST_NOT_TARGET
     static size_t cache_info = 0;
 
     /* "Cache Type Register" contains:

--- a/core/drlibc/drlibc.c
+++ b/core/drlibc/drlibc.c
@@ -157,7 +157,8 @@ clear_icache(void *beg, void *end)
 }
 
 void
-set_cache_line_size_using_ctr_el0(size_t *dcache_line_size, size_t *icache_line_size)
+set_cache_line_size_using_ctr_el0(OUT size_t *dcache_line_size,
+                                  OUT size_t *icache_line_size)
 {
 #    ifndef DR_HOST_NOT_TARGET
     static size_t cache_info = 0;

--- a/core/drlibc/drlibc.c
+++ b/core/drlibc/drlibc.c
@@ -159,6 +159,9 @@ clear_icache(void *beg, void *end)
 void
 set_cache_line_size_using_ctr_el0(size_t *dcache_line_size, size_t *icache_line_size)
 {
+#    ifdef DR_HOST_NOT_TARGET
+    ASSERT_NOT_REACHED();
+#    else
     static size_t cache_info = 0;
 
     /* "Cache Type Register" contains:
@@ -177,6 +180,7 @@ set_cache_line_size_using_ctr_el0(size_t *dcache_line_size, size_t *icache_line_
         *dcache_line_size = 4 << (cache_info >> 16 & 0xf);
     if (icache_line_size != NULL)
         *icache_line_size = 4 << (cache_info & 0xf);
+#    endif
 }
 #endif
 

--- a/core/drlibc/drlibc.c
+++ b/core/drlibc/drlibc.c
@@ -130,9 +130,10 @@ clear_icache(void *beg, void *end)
         return;
 
     if (!get_cache_line_size(&dcache_line_size, &icache_line_size)) {
-        // We don't expect get_cache_line_size to return false, as this code is
-        // invoked only when (not DR_HOST_NOT_TARGET).
-        ASSERT(false);
+        /* We don't expect get_cache_line_size to return false, as this code is
+         * invoked only when (not DR_HOST_NOT_TARGET).
+         */
+        ASSERT_NOT_REACHED();
     }
 
     /* Flush data cache to point of unification, one line at a time. */
@@ -164,6 +165,13 @@ clear_icache(void *beg, void *end)
  * Returns false if no value was written.
  * This is required to be called at init time when linked into DR. This is to
  * avoid races and write issues with the static variable used.
+ *
+ * XXX i#1684: Design better support for builds where host!=target, e.g.
+ * a64-on-x86 for which this function does not set any cache line size; also
+ * x86-on-a64 for which we currently attempt to use cpuid (which is not available
+ * on a64) to set cache line size in core/arch/x86/proc.c.
+ * For these builds, it may be better to set some properties like cache_line_size
+ * to the host's value, but not for all e.g. num_simd_registers.
  */
 bool
 get_cache_line_size(OUT size_t *dcache_line_size, OUT size_t *icache_line_size)

--- a/core/drlibc/drlibc.h
+++ b/core/drlibc/drlibc.h
@@ -67,7 +67,8 @@ void
 clear_icache(void *beg, void *end);
 
 void
-set_cache_line_size_using_ctr_el0(size_t *dcache_line_size, size_t *icache_line_size);
+set_cache_line_size_using_ctr_el0(OUT size_t *dcache_line_size,
+                                  OUT size_t *icache_line_size);
 #endif
 
 void

--- a/core/drlibc/drlibc.h
+++ b/core/drlibc/drlibc.h
@@ -66,9 +66,8 @@ dynamorio_syscall(uint sysnum, uint num_args, ...);
 void
 clear_icache(void *beg, void *end);
 
-void
-set_cache_line_size_using_ctr_el0(OUT size_t *dcache_line_size,
-                                  OUT size_t *icache_line_size);
+bool
+get_cache_line_size(OUT size_t *dcache_line_size, OUT size_t *icache_line_size);
 #endif
 
 void

--- a/core/drlibc/drlibc.h
+++ b/core/drlibc/drlibc.h
@@ -65,6 +65,9 @@ dynamorio_syscall(uint sysnum, uint num_args, ...);
 #ifdef AARCH64
 void
 clear_icache(void *beg, void *end);
+
+void
+set_cache_line_size_using_ctr_el0(size_t *dcache_line_size, size_t *icache_line_size);
 #endif
 
 void


### PR DESCRIPTION
Uses the CTR_EL0 system register to obtain cache line size in proc_get_cache_line_size on AArch64.

Fixes: #4446