### PR TITLE
i#4083 func view: Allow for 7-digit thread id in func_view tests

### DIFF
--- a/clients/drcachesim/tests/offline-func_view_noret.templatex
+++ b/clients/drcachesim/tests/offline-func_view_noret.templatex
@@ -1,89 +1,89 @@
-T125255 0x7f3ac9a2a9ca => tool\.fib_plus!fib\(0x5\)
-T125255     0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x5, 0x6\)
-T125255     0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x6, 0x6\)
-T125256 0x7f3ac9a2a9ca => tool\.fib_plus!fib\(0x5\)
-T125256     0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x5, 0x6\)
-T125256     0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x6, 0x6\)
-T125255     0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125255     0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x4\)
-T125255         0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x4, 0x5\)
-T125255         0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x5, 0x5\)
-T125255         0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125255         0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x3\)
-T125255             0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x3, 0x4\)
-T125255             0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x4, 0x4\)
-T125255             0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125255             0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x2\)
-T125255                 0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x2, 0x3\)
-T125255                 0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x3, 0x3\)
-T125256     0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125256     0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x4\)
-T125256         0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x4, 0x5\)
-T125256         0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x5, 0x5\)
-T125256         0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125256         0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x3\)
-T125256             0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x3, 0x4\)
-T125256             0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x4, 0x4\)
-T125256             0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125256             0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x2\)
-T125256                 0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x2, 0x3\)
-T125256                 0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x3, 0x3\)
-T125255                 0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125255                 0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x1\) => 0x1
-T125255                 0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x0\) => 0x1
-T125255             => 0x2
-T125255             0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x1\) => 0x1
-T125255         => 0x3
-T125255         0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x2\)
-T125255             0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x2, 0x3\)
-T125255             0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x3, 0x3\)
-T125256                 0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125256                 0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x1\) => 0x1
-T125256                 0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x0\) => 0x1
-T125256             => 0x2
-T125256             0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x1\) => 0x1
-T125256         => 0x3
-T125256         0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x2\)
-T125256             0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x2, 0x3\)
-T125256             0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x3, 0x3\)
-T125255             0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125255             0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x1\) => 0x1
-T125255             0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x0\) => 0x1
-T125255         => 0x2
-T125255     => 0x5
-T125255     0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x3\)
-T125255         0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x3, 0x4\)
-T125255         0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x4, 0x4\)
-T125256             0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125256             0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x1\) => 0x1
-T125256             0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x0\) => 0x1
-T125256         => 0x2
-T125256     => 0x5
-T125256     0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x3\)
-T125256         0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x3, 0x4\)
-T125256         0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x4, 0x4\)
-T125255         0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125255         0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x2\)
-T125255             0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x2, 0x3\)
-T125255             0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x3, 0x3\)
-T125256         0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125256         0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x2\)
-T125256             0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x2, 0x3\)
-T125256             0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x3, 0x3\)
-T125256             0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125256             0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x1\) => 0x1
-T125256             0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x0\) => 0x1
-T125256         => 0x2
-T125256         0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x1\) => 0x1
-T125256     => 0x3
-T125256 => 0x8
-T125255             0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
-T125255             0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x1\) => 0x1
-T125255             0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x0\) => 0x1
-T125255         => 0x2
-T125255         0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x1\) => 0x1
-T125255     => 0x3
-T125255 => 0x8
+T125255  0x7f3ac9a2a9ca => tool\.fib_plus!fib\(0x5\)
+T125255      0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x5, 0x6\)
+T125255      0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x6, 0x6\)
+T125256  0x7f3ac9a2a9ca => tool\.fib_plus!fib\(0x5\)
+T125256      0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x5, 0x6\)
+T125256      0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x6, 0x6\)
+T125255      0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125255      0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x4\)
+T125255          0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x4, 0x5\)
+T125255          0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x5, 0x5\)
+T125255          0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125255          0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x3\)
+T125255              0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x3, 0x4\)
+T125255              0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x4, 0x4\)
+T125255              0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125255              0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x2\)
+T125255                  0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x2, 0x3\)
+T125255                  0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x3, 0x3\)
+T125256      0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125256      0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x4\)
+T125256          0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x4, 0x5\)
+T125256          0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x5, 0x5\)
+T125256          0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125256          0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x3\)
+T125256              0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x3, 0x4\)
+T125256              0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x4, 0x4\)
+T125256              0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125256              0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x2\)
+T125256                  0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x2, 0x3\)
+T125256                  0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x3, 0x3\)
+T125255                  0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125255                  0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x1\) => 0x1
+T125255                  0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x0\) => 0x1
+T125255              => 0x2
+T125255              0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x1\) => 0x1
+T125255          => 0x3
+T125255          0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x2\)
+T125255              0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x2, 0x3\)
+T125255              0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x3, 0x3\)
+T125256                  0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125256                  0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x1\) => 0x1
+T125256                  0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x0\) => 0x1
+T125256              => 0x2
+T125256              0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x1\) => 0x1
+T125256          => 0x3
+T125256          0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x2\)
+T125256              0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x2, 0x3\)
+T125256              0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x3, 0x3\)
+T125255              0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125255              0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x1\) => 0x1
+T125255              0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x0\) => 0x1
+T125255          => 0x2
+T125255      => 0x5
+T125255      0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x3\)
+T125255          0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x3, 0x4\)
+T125255          0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x4, 0x4\)
+T125256              0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125256              0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x1\) => 0x1
+T125256              0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x0\) => 0x1
+T125256          => 0x2
+T125256      => 0x5
+T125256      0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x3\)
+T125256          0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x3, 0x4\)
+T125256          0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x4, 0x4\)
+T125255          0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125255          0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x2\)
+T125255              0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x2, 0x3\)
+T125255              0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x3, 0x3\)
+T125256          0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125256          0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x2\)
+T125256              0x7f3ac9a2a985 => tool\.fib_plus!noret_func\(0x2, 0x3\)
+T125256              0x7f3ac9a2a957 => tool\.fib_plus!noret_func\(0x3, 0x3\)
+T125256              0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125256              0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x1\) => 0x1
+T125256              0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x0\) => 0x1
+T125256          => 0x2
+T125256          0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x1\) => 0x1
+T125256      => 0x3
+T125256  => 0x8
+T125255              0x7f3ac9a2a98f => tool\.fib_plus!noargs\(\) => 0x42
+T125255              0x7f3ac9a2a99c => tool\.fib_plus!fib\(0x1\) => 0x1
+T125255              0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x0\) => 0x1
+T125255          => 0x2
+T125255          0x7f3ac9a2a9ab => tool\.fib_plus!fib\(0x1\) => 0x1
+T125255      => 0x3
+T125255  => 0x8
 Function view tool results:
 Function id=0: tool\.fib_plus!fib
        30 calls

--- a/clients/drcachesim/tools/func_view.cpp
+++ b/clients/drcachesim/tools/func_view.cpp
@@ -196,7 +196,7 @@ func_view_t::process_memref(const memref_t &memref)
         std::string indent(shard->nesting_level * 4, ' ');
         // Print a "Tnnn" prefix so threads can be distinguished.
         std::cerr << ((was_nested && shard->prev_was_arg) ? "\n" : "") << "T" << std::dec
-                  << std::left << std::setw(7) << memref.marker.tid
+                  << std::left << std::setw(8) << memref.marker.tid
                   << std::right /*restore*/;
         std::cerr << indent << "0x" << std::hex << memref.marker.marker_value << " => "
                   << *id2info_[shard->last_func_id].names.begin() << "(";
@@ -226,7 +226,7 @@ func_view_t::process_memref(const memref_t &memref)
         std::string indent;
         if (!shard->prev_was_arg) {
             std::cerr
-                << "T" << std::dec << std::left << std::setw(7) << memref.marker.tid
+                << "T" << std::dec << std::left << std::setw(8) << memref.marker.tid
                 << std::right /*restore*/ << std::string(shard->nesting_level * 4, ' ');
         }
         std::cerr << (shard->prev_was_arg ? " =>" : "=>") << std::hex << " 0x"


### PR DESCRIPTION
After an upgdate, my machine has 7-digit thread id's, causing the
func_view tests to fail.  Here I widen the printed field and update
the expected output for the stored trace.

Issue: #4083