### PR TITLE
i#4459: Do not mangle app TLS ops for -no_private_loader

### DIFF
--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1603,14 +1603,16 @@ d_r_mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags INOUT, bool man
 #endif /* X64 || ARM */
 
 #ifdef AARCHXX
-        if (!instr_is_meta(instr) && instr_reads_thread_register(instr)) {
+        if (!instr_is_meta(instr) && instr_reads_thread_register(instr) &&
+            IF_CLIENT_INTERFACE_ELSE(INTERNAL_OPTION(private_loader), false)) {
             next_instr = mangle_reads_thread_register(dcontext, ilist, instr, next_instr);
             continue;
         }
 #endif /* ARM || AARCH64 */
 
 #ifdef AARCH64
-        if (!instr_is_meta(instr) && instr_writes_thread_register(instr)) {
+        if (!instr_is_meta(instr) && instr_writes_thread_register(instr) &&
+            IF_CLIENT_INTERFACE_ELSE(INTERNAL_OPTION(private_loader), false)) {
             next_instr =
                 mangle_writes_thread_register(dcontext, ilist, instr, next_instr);
             continue;


### PR DESCRIPTION
Disables emulation of thread register reads or writes by the
application when -no_private_loader is in place, such as with
statically linked DR.  Such emulation is unnecessary as the
thread register holds native values in such cases.

Fixes #4459