### PR TITLE
i#4457: Fix clobbered register on detach

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -161,7 +161,7 @@ dump_emitted_routines(dcontext_t *dcontext, file_t file, const char *code_descri
                 print_file(file, "fcache_return:\n");
             else if (last_pc == code->do_syscall)
                 print_file(file, "do_syscall:\n");
-#    ifdef ARM
+#    ifdef AARCHXX
             else if (last_pc == code->fcache_enter_gonative)
                 print_file(file, "fcache_enter_gonative:\n");
 #    endif
@@ -394,7 +394,7 @@ shared_gencode_emit(generated_code_t *gencode _IF_X86_64(bool x86_mode))
     pc = emit_new_thread_dynamo_start(GLOBAL_DCONTEXT, pc);
 #endif
 
-#ifdef ARM
+#ifdef AARCHXX
     pc = check_size_and_cache_line(isa_mode, gencode, pc);
     gencode->fcache_enter_gonative = pc;
     pc = emit_fcache_enter_gonative(GLOBAL_DCONTEXT, gencode, pc);
@@ -1870,7 +1870,7 @@ get_fcache_enter_private_routine(dcontext_t *dcontext)
 fcache_enter_func_t
 get_fcache_enter_gonative_routine(dcontext_t *dcontext)
 {
-#ifdef ARM
+#ifdef AARCHXX
     generated_code_t *code = THREAD_GENCODE(dcontext);
     return (fcache_enter_func_t)convert_data_to_function(code->fcache_enter_gonative);
 #else

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -928,7 +928,7 @@ typedef struct _generated_code_t {
 #endif
     byte *do_syscall;
     uint do_syscall_offs; /* offs of pc after actual syscall instr */
-#ifdef ARM
+#ifdef AARCHXX
     byte *fcache_enter_gonative;
 #endif
 #ifdef WINDOWS
@@ -1209,7 +1209,7 @@ emit_do_syscall(dcontext_t *dcontext, generated_code_t *code, byte *pc,
                 byte *fcache_return_pc, bool thread_shared, int interrupt,
                 uint *syscall_offs /*OUT*/);
 
-#ifdef ARM
+#ifdef AARCHXX
 byte *
 emit_fcache_enter_gonative(dcontext_t *dcontext, generated_code_t *code, byte *pc);
 #endif

--- a/core/ir/aarch64/instr_create.h
+++ b/core/ir/aarch64/instr_create.h
@@ -149,7 +149,18 @@ enum {
  * \param r   The destination register opnd.
  * \param m   The source memory opnd.
  */
-#define XINST_CREATE_load(dc, r, m) INSTR_CREATE_ldr((dc), (r), (m))
+#define XINST_CREATE_load(dc, r, m)                                                    \
+    ((opnd_is_base_disp(m) &&                                                          \
+      (opnd_get_disp(m) < 0 ||                                                         \
+       opnd_get_disp(m) % opnd_size_in_bytes(opnd_get_size(m)) != 0))                  \
+         ? INSTR_CREATE_ldur(                                                          \
+               dc,                                                                     \
+               opnd_create_reg(reg_resize_to_opsz(opnd_get_reg(r), opnd_get_size(m))), \
+               m)                                                                      \
+         : INSTR_CREATE_ldr(                                                           \
+               dc,                                                                     \
+               opnd_create_reg(reg_resize_to_opsz(opnd_get_reg(r), opnd_get_size(m))), \
+               m))
 
 /**
  * This platform-independent macro creates an instr_t which loads 1 byte
@@ -187,8 +198,9 @@ enum {
  * \param r   The source register opnd.
  */
 #define XINST_CREATE_store(dc, m, r)                                                   \
-    (opnd_is_base_disp(m) &&                                                           \
-             opnd_get_disp(m) % opnd_size_in_bytes(opnd_get_size(m)) != 0              \
+    ((opnd_is_base_disp(m) &&                                                          \
+      (opnd_get_disp(m) < 0 ||                                                         \
+       opnd_get_disp(m) % opnd_size_in_bytes(opnd_get_size(m)) != 0))                  \
          ? INSTR_CREATE_stur(                                                          \
                dc, m,                                                                  \
                opnd_create_reg(reg_resize_to_opsz(opnd_get_reg(r), opnd_get_size(m)))) \

--- a/core/ir/opnd.h
+++ b/core/ir/opnd.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2942,7 +2942,7 @@ opnd_create_sized_tls_slot(int offs, opnd_size_t size);
 #endif /* !STANDALONE_DECODER */
 
 /* stack slot width */
-#define XSP_SZ (sizeof(reg_t))
+#define XSP_SZ ((ssize_t)sizeof(reg_t))
 
 /* This should be kept in sync w/ the defines in x86/x86.asm */
 enum {

--- a/suite/tests/api/detach.c
+++ b/suite/tests/api/detach.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -213,7 +213,10 @@ main(void)
 
     /* Detach */
     VPRINT("detaching\n");
-    dr_app_stop_and_cleanup();
+    /* We use the _with_stats variant to catch register errors such as i#4457. */
+    dr_stats_t stats = { sizeof(dr_stats_t) };
+    dr_app_stop_and_cleanup_with_stats(&stats);
+    assert(stats.basic_block_count > 0);
 
     VPRINT("signaling native\n");
     signal_cond_var(go_native);


### PR DESCRIPTION
Generates a special fcache_enter_gonative routine for AArch64 (now it
matches other architectures) to restore the stolen register and to
avoid clobbering x0 on detach.

The new generated code required adding negative displacement support
to XINST_CREATE_{load,store} and tweaking some other defines.

Since on Aarch64 we can't jump through memory or write to the PC, for
now we assume we're at an ABI boundary and we clobber a caller-saved
register.

Augments the api.detach test to use the _with_stats variant, which
reproduces the original crash without the fix.

Fixes #4457