### PR TITLE
i#4474 A64 testing: Enable drcachesim thread tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,7 @@ endif ()
 if (X86)
   set(ANNOTATIONS_DEFAULT ON)
 else ()
+  # TODO i#1672: Add annotation support to AArchXX.
   set(ANNOTATIONS_DEFAULT OFF)
 endif ()
 option(ANNOTATIONS "annotations" ${ANNOTATIONS_DEFAULT})

--- a/core/lib/dr_annotations_asm.h
+++ b/core/lib/dr_annotations_asm.h
@@ -1,5 +1,5 @@
 /* ******************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
  * ******************************************************/
 
 /*
@@ -49,6 +49,12 @@
                                      */
 #endif
 
+#ifndef DYNAMORIO_ANNOTATIONS_X86
+#    if defined(__x86_64__) || defined(__i386__)
+#        define DYNAMORIO_ANNOTATIONS_X86 1
+#    endif
+#endif
+
 #ifndef DYNAMORIO_ANNOTATIONS_X64
 #    ifdef _MSC_VER
 #        ifdef _WIN64
@@ -75,7 +81,21 @@
 #    endif
 #endif
 
-#ifdef _MSC_VER /* Microsoft Visual Studio */
+#ifndef DYNAMORIO_ANNOTATIONS_X86
+/* TODO i#1672: Add annotation support to AArchXX.
+ * For now, we provide a fallback so we can build the annotation-concurrency
+ * app for use with drcachesim tests.
+ */
+#    define DR_ANNOTATION_OR_NATIVE(annotation, native_version, ...) /* Nothing. */
+#    define DR_DECLARE_ANNOTATION(return_type, annotation, parameters) \
+        return_type annotation parameters
+#    define DR_DEFINE_ANNOTATION(return_type, annotation, parameters, body) \
+        return_type annotation parameters                                   \
+        {                                                                   \
+            body;                                                           \
+        }
+
+#elif defined(_MSC_VER) /* Microsoft Visual Studio */
 #    define PASTE1(x, y) x##y
 #    define PASTE(x, y) PASTE1(x, y)
 

--- a/core/lib/dr_annotations_asm.h
+++ b/core/lib/dr_annotations_asm.h
@@ -50,7 +50,7 @@
 #endif
 
 #ifndef DYNAMORIO_ANNOTATIONS_X86
-#    if defined(__x86_64__) || defined(__i386__)
+#    if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
 #        define DYNAMORIO_ANNOTATIONS_X86 1
 #    endif
 #endif
@@ -81,10 +81,11 @@
 #    endif
 #endif
 
-#ifndef DYNAMORIO_ANNOTATIONS_X86
+#if !defined(DYNAMORIO_ANNOTATIONS_X86) || defined(__clang__)
 /* TODO i#1672: Add annotation support to AArchXX.
  * For now, we provide a fallback so we can build the annotation-concurrency
  * app for use with drcachesim tests.
+ * We do the same for clang, which has no "asm goto".
  */
 #    define DR_ANNOTATION_OR_NATIVE(annotation, native_version, ...) /* Nothing. */
 #    define DR_DECLARE_ANNOTATION(return_type, annotation, parameters) \

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -558,12 +558,12 @@ function(add_exe test source)
     set(test_srcs ${test_srcs} ${asm_source})
   endif ("${srccode}" MATCHES "ifndef ASM_CODE_ONLY")
 
-  if ("${srccode}" MATCHES "include \"dr_annotations.h\"")
+  if (ANNOTATIONS AND "${srccode}" MATCHES "include \"dr_annotations.h\"")
     use_DynamoRIO_annotations(${test} test_srcs)
-  endif ("${srccode}" MATCHES "include \"dr_annotations.h\"")
+  endif ()
   if ("${srccode}" MATCHES "include \"test.*annotation.*.h\"")
     use_DynamoRIO_test_annotations(${test} test_srcs)
-  endif ("${srccode}" MATCHES "include \"test.*annotation.*.h\"")
+  endif ()
 
   add_executable(${test} ${test_srcs})
   if (DEFINED ${test}_outname)
@@ -783,12 +783,12 @@ function(tobuild_appdll test source)
       set(lib_srcs ${lib_srcs} ${asm_source})
     endif ("${srccode}" MATCHES "ifndef ASM_CODE_ONLY")
 
-    if ("${srccode}" MATCHES "include \"dr_annotations.h\"")
+    if (ANNOTATIONS AND "${srccode}" MATCHES "include \"dr_annotations.h\"")
       use_DynamoRIO_annotations(${test}.appdll lib_srcs)
-    endif ("${srccode}" MATCHES "include \"dr_annotations.h\"")
+    endif ()
     if ("${srccode}" MATCHES "include \"test.*annotation.*.h\"")
       use_DynamoRIO_test_annotations(${test}.appdll lib_srcs)
-    endif ("${srccode}" MATCHES "include \"test.*annotation.*.h\"")
+    endif ()
 
     add_library(${test}.appdll SHARED ${lib_srcs})
     set_target_properties(${test}.appdll PROPERTIES LINK_FLAGS "${ARCH_DEBUG}")
@@ -996,7 +996,9 @@ function (use_DynamoRIO_test_annotations target target_srcs)
   set(dr_annotation_test_srcs
     "${dr_annotation_test_dir}/test_mode_annotations.c"
     "${dr_annotation_test_dir}/test_annotation_arguments.c")
-  configure_DynamoRIO_annotation_sources("${dr_annotation_test_srcs}")
+  if (ANNOTATIONS)
+    configure_DynamoRIO_annotation_sources("${dr_annotation_test_srcs}")
+  endif ()
   set(${target_srcs} ${${target_srcs}} ${dr_annotation_test_srcs} PARENT_SCOPE)
 endfunction (use_DynamoRIO_test_annotations target target_srcs)
 
@@ -2196,18 +2198,18 @@ if (CLIENT_INTERFACE)
     endif ()
   endif ()
 
+  if (UNIX)
+    set(annotation_test_args "libclient.annotation-concurrency.appdll.so" "A" "4")
+    set(annotation_test_args_shorter
+      "libclient.annotation-concurrency.appdll.so" "A" "4" "64" "3")
+  else (UNIX)
+    set(annotation_test_args "client.annotation-concurrency.appdll.dll" "A" "4")
+    set(annotation_test_args_shorter
+      "client.annotation-concurrency.appdll.dll" "A" "4" "64" "3")
+  endif (UNIX)
   # FIXME i#1799: clang does not support "asm goto"
   if (ANNOTATIONS AND NOT CMAKE_COMPILER_IS_CLANG)
     set(DynamoRIO_USE_LIBC OFF)
-    if (UNIX)
-      set(annotation_test_args "libclient.annotation-concurrency.appdll.so" "A" "4")
-      set(annotation_test_args_shorter
-        "libclient.annotation-concurrency.appdll.so" "A" "4" "64" "3")
-    else (UNIX)
-      set(annotation_test_args "client.annotation-concurrency.appdll.dll" "A" "4")
-      set(annotation_test_args_shorter
-        "client.annotation-concurrency.appdll.dll" "A" "4" "64" "3")
-    endif (UNIX)
     tobuild_ci(client.annotation-concurrency client-interface/annotation-concurrency.c
       "" "" "${annotation_test_args}")
     tobuild_appdll(client.annotation-concurrency
@@ -2318,6 +2320,18 @@ if (CLIENT_INTERFACE)
       client.annotation-detection-opt annotation-detection.native
       client-interface/annotation-detection.c "")
     set(DynamoRIO_USE_LIBC ON)
+  else (ANNOTATIONS AND NOT CMAKE_COMPILER_IS_CLANG)
+    # We build the client.annotation-concurrency app even if we have no annotation
+    # support, since it is used in drcachesim tests.
+    add_exe(client.annotation-concurrency
+      client-interface/annotation-concurrency.c)
+    append_property_string(TARGET client.annotation-concurrency COMPILE_FLAGS
+      "-DANNOTATIONS_DISABLED")
+    link_with_pthread(client.annotation-concurrency)
+    tobuild_appdll(client.annotation-concurrency
+      client-interface/annotation-concurrency.c)
+    append_property_string(TARGET client.annotation-concurrency.appdll COMPILE_FLAGS
+      "-DANNOTATIONS_DISABLED")
   endif (ANNOTATIONS AND NOT CMAKE_COMPILER_IS_CLANG)
 
   if (UNIX)
@@ -3169,36 +3183,32 @@ if (CLIENT_INTERFACE)
       # Test that warmup was enabled but not triggered.
       torunonly_drcachesim(warmup-zeros ${ci_shared_app} "-warmup_refs 1000000000" "")
 
-      # FIXME i#1799: clang does not support "asm goto" used in annotation
-      # FIXME i#1551, i#1569: get working on ARM/AArch64
-      if (NOT ARM AND NOT AARCH64 AND NOT CMAKE_COMPILER_IS_CLANG)
-        # Our pthreads tests don't have many threads so we run this annot test,
-        # though it is a little slow under drcachesim.
-        # XXX i#1703: this may be too flaky: we may want to remove this once
-        # we add some dedicated multi-thread (and multi-process) tests with
-        # more deterministic output.
-        # We test -cpu_scheduling on several tests with many threads.
-        # We use a smaller test (_shorter) to avoid taking multiple minutes on our
-        # CI (i#4059; xref i#2063).
-        torunonly_drcachesim(threads client.annotation-concurrency "-cpu_scheduling"
-          "${annotation_test_args_shorter}")
+      # Our pthreads tests don't have many threads so we run this annot test,
+      # though it is a little slow under drcachesim.
+      # XXX i#1703: this may be too flaky: we may want to remove this once
+      # we add some dedicated multi-thread (and multi-process) tests with
+      # more deterministic output.
+      # We test -cpu_scheduling on several tests with many threads.
+      # We use a smaller test (_shorter) to avoid taking multiple minutes on our
+      # CI (i#4059; xref i#2063).
+      torunonly_drcachesim(threads client.annotation-concurrency "-cpu_scheduling"
+        "${annotation_test_args_shorter}")
 
-        # Threads test that reads the cache configuration from a config file.
-        torunonly_drcachesim(threads-with-config-file client.annotation-concurrency
-          "-config_file ${config_files_dir}/cores-1-levels-3-no-missfile.conf"
-          "${annotation_test_args_shorter}")
-        set(tool.drcachesim.threads_timeout 150) # This test is long.
+      # Threads test that reads the cache configuration from a config file.
+      torunonly_drcachesim(threads-with-config-file client.annotation-concurrency
+        "-config_file ${config_files_dir}/cores-1-levels-3-no-missfile.conf"
+        "${annotation_test_args_shorter}")
+      set(tool.drcachesim.threads_timeout 150) # This test is long.
 
-        torunonly_drcachesim(coherence client.annotation-concurrency "-coherence"
-          "${annotation_test_args_shorter}")
-        set(tool.drcachesim.coherence_timeout 150) # This test is long.
+      torunonly_drcachesim(coherence client.annotation-concurrency "-coherence"
+        "${annotation_test_args_shorter}")
+      set(tool.drcachesim.coherence_timeout 150) # This test is long.
 
-        # TLB simulator's multi-thread sanity check
-        torunonly_drcachesim(TLB-threads client.annotation-concurrency
-          "-simulator_type TLB -cpu_scheduling" "${annotation_test_args_shorter}")
-        # i#2063: this test can time out.
-        set(tool.drcachesim.TLB-threads_timeout 150)
-      endif ()
+      # TLB simulator's multi-thread sanity check
+      torunonly_drcachesim(TLB-threads client.annotation-concurrency
+        "-simulator_type TLB -cpu_scheduling" "${annotation_test_args_shorter}")
+      # i#2063: this test can time out.
+      set(tool.drcachesim.TLB-threads_timeout 150)
 
       if (ARM)
         torunonly_drcachesim(allasm-thumb common.allasm_thumb "" "")

--- a/suite/tests/client-interface/annotation-concurrency.appdll.c
+++ b/suite/tests/client-interface/annotation-concurrency.appdll.c
@@ -1,5 +1,5 @@
 /* ******************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
  * ******************************************************/
 
 /*
@@ -38,7 +38,8 @@
 #include "test_annotation_arguments.h"
 #include "test_mode_annotations.h"
 
-#if !(defined(WINDOWS) && defined(X64))
+#if !(defined(WINDOWS) && defined(X64)) && !defined(ANNOTATIONS_DISABLED)
+#    define USE_ANNOTATIONS 1
 #    include "memcheck.h"
 #endif
 
@@ -74,7 +75,7 @@ jacobi(double *dst, double *src, double **coefficients, double *rhs_vector, int 
     for (i = 0; i < limit; i++) {
         x_temp[i] = rhs_vector[i];
 
-#if !(defined(WINDOWS) && defined(X64))
+#ifdef USE_ANNOTATIONS
         if (invoke_annotations && worker_id < 3) {
             switch (worker_id) {
             case 0:
@@ -95,7 +96,7 @@ jacobi(double *dst, double *src, double **coefficients, double *rhs_vector, int 
 #endif
             for (j = 0; j < i; j++)
                 x_temp[i] -= src[j] * coefficients[i][j];
-#if !(defined(WINDOWS) && defined(X64))
+#ifdef USE_ANNOTATIONS
         }
 #endif
 

--- a/suite/tests/client-interface/annotation-concurrency.c
+++ b/suite/tests/client-interface/annotation-concurrency.c
@@ -63,6 +63,15 @@
 #    include <unistd.h>
 #endif
 
+#ifdef ANNOTATIONS_DISABLED
+/* TODO i#1672: Add annotation support to AArchXX.
+ * For now, we provide a fallback so we can build this app for use with
+ * drcachesim tests.
+ */
+#    undef DYNAMORIO_ANNOTATE_RUNNING_ON_DYNAMORIO
+#    define DYNAMORIO_ANNOTATE_RUNNING_ON_DYNAMORIO() (true)
+#endif
+
 #define MAX_ITERATIONS 10
 #define MAX_THREADS 8
 #define TOLERANCE 1.0E-5

--- a/suite/tests/client-interface/annotation-concurrency.c
+++ b/suite/tests/client-interface/annotation-concurrency.c
@@ -135,7 +135,7 @@ find_function(MODULE_TYPE jacobi_module, const char *name)
 static void *
 find_function(MODULE_TYPE jacobi_module, const char *name)
 {
-    char *error;
+    const char *error;
     void *function = dlsym(jacobi_module, name);
     error = dlerror();
     if (error != NULL) {


### PR DESCRIPTION
Adds custom annotation macro defines to enable building the
client.annotation-concurrency executable and its shared library on
AArchXX.

Enables the 4 tests that require that executable, but do not need
annotation support: tool.drcachesim.threads,
tool.drcachesim.threads-with-config-file, tool.drcachesim.coherence,
and tool.drcachesim.TLB-threads.

Issue: #4474, #1672