### PR TITLE
i#4462: Add new global memtrace size limit

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -168,6 +168,8 @@ Further non-compatibility-affecting changes include:
    CLIENT{32,64}_{ABS,REL} in tool files.
    Added dr_get_client_info_ex() and dr_client_iterator_next_ex() to support
    querying other-bitwidth client registration.
+ - Added a new drcachesim option \p -max_global_trace_refs for specifying a global
+   trace size limit that does not terminate the process.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -226,6 +226,14 @@ droption_t<bytesize_t> op_max_trace_size(
     "of one internal buffer.  Once reached, instrumentation continues for that thread, "
     "but no further data is recorded.");
 
+droption_t<bytesize_t> op_max_global_trace_refs(
+    DROPTION_SCOPE_CLIENT, "max_global_trace_refs", 0,
+    "Cap on the total references traced",
+    "If non-zero, this sets a maximum size on the amount of trace references recorded. "
+    "Once reached, instrumented execution continues, but no further data is recorded. "
+    "This is similar to -exit_after_tracing but without terminating the process."
+    "The reference count is approximate.");
+
 droption_t<bytesize_t> op_trace_after_instrs(
     DROPTION_SCOPE_CLIENT, "trace_after_instrs", 0,
     "Do not start tracing until N instructions",
@@ -238,7 +246,8 @@ droption_t<bytesize_t> op_exit_after_tracing(
     DROPTION_SCOPE_CLIENT, "exit_after_tracing", 0,
     "Exit the process after tracing N references",
     "If non-zero, after tracing the specified number of references, the process is "
-    "exited with an exit code of 0.  The reference count is approximate.");
+    "exited with an exit code of 0.  The reference count is approximate. "
+    "Use -max_global_trace_refs instead to avoid terminating the process.");
 
 droption_t<bool> op_online_instr_types(
     DROPTION_SCOPE_CLIENT, "online_instr_types", false,

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -228,8 +228,9 @@ droption_t<bytesize_t> op_max_trace_size(
 
 droption_t<bytesize_t> op_max_global_trace_refs(
     DROPTION_SCOPE_CLIENT, "max_global_trace_refs", 0,
-    "Cap on the total references traced",
-    "If non-zero, this sets a maximum size on the amount of trace references recorded. "
+    "Cap on the total references of any type traced",
+    "If non-zero, this sets a maximum size on the amount of trace entry references "
+    "(of any type: instructions, loads, stores, markers, etc.) recorded. "
     "Once reached, instrumented execution continues, but no further data is recorded. "
     "This is similar to -exit_after_tracing but without terminating the process."
     "The reference count is approximate.");

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -86,6 +86,7 @@ extern droption_t<bool> op_use_physical;
 extern droption_t<unsigned int> op_virt2phys_freq;
 extern droption_t<bool> op_cpu_scheduling;
 extern droption_t<bytesize_t> op_max_trace_size;
+extern droption_t<bytesize_t> op_max_global_trace_refs;
 extern droption_t<bytesize_t> op_trace_after_instrs;
 extern droption_t<bytesize_t> op_exit_after_tracing;
 extern droption_t<bool> op_online_instr_types;

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -719,8 +719,21 @@ during a desired window of execution.
 
 The \p -trace_after_instrs option delays tracing by the specified number of
 dynamic instruction executions.  This can be used to skip initialization
-and arrive at the desired starting point.  The trace's length can also be
-limited by the \p -exit_after_tracing option.
+and arrive at the desired starting point.  The trace's length can be
+limited in several ways:
+
+- The \p -max_global_trace_refs option causes the recording of trace
+  data to cease once the specified threshold is exceeded by the sum of
+  all trace references across all threads.  One trace reference entry
+  equals one recorded address, but due to post-processing expansion a
+  final offline line trace will be larger.  Once recording ceases, the
+  application will continue to run.  Threads that are newly created after
+  the threshold is reached will not appear in the trace.
+- The \p -exit_after_tracing option similarly specifies a global trace
+  reference count, but once it is exceeded, the process is terminated.
+- The \p -max_trace_size option sets a cap on the number of bytes written
+  by each thread.  This is a per-thread limit, and if one thread hits the
+  limit it does not affect the trace recoding of other threads.
 
 If the application can be modified, it can be linked with the \p drcachesim
 tracer and use DynamoRIO's start/stop API routines dr_app_setup_and_start()

--- a/clients/drcachesim/tests/delay-global.templatex
+++ b/clients/drcachesim/tests/delay-global.templatex
@@ -1,0 +1,11 @@
+Hit delay threshold: enabling tracing.
+Hit -max_global_trace_refs: disabling tracing.
+.*
+     Total Number Of iterations   :  3
+    ...................................................................
+---- <application exited with code 0> ----
+Basic counts tool results:
+Total counts:
+.*
+           1 total threads
+.*

--- a/clients/drcachesim/tests/delay-global.templatex
+++ b/clients/drcachesim/tests/delay-global.templatex
@@ -6,7 +6,6 @@ Hit -max_global_trace_refs: disabling tracing.
 ---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
-       1.... total \(fetched\) instructions
 .*
            1 total threads
 .*

--- a/clients/drcachesim/tests/delay-global.templatex
+++ b/clients/drcachesim/tests/delay-global.templatex
@@ -6,6 +6,7 @@ Hit -max_global_trace_refs: disabling tracing.
 ---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
+       1.... total \(fetched\) instructions
 .*
            1 total threads
 .*

--- a/clients/drcachesim/tests/offline-max-global.templatex
+++ b/clients/drcachesim/tests/offline-max-global.templatex
@@ -1,0 +1,10 @@
+Hit delay threshold: enabling tracing.
+Hit -max_global_trace_refs: disabling tracing.
+.*
+     Total Number Of iterations   :  3
+    ...................................................................
+Basic counts tool results:
+Total counts:
+.*
+           1 total threads
+.*

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -432,7 +432,7 @@ memtrace(void *drcontext, bool skip_size_cap)
          * beyond the limit: we still instrument and come here.
          */
         do_write = false;
-        if (!data->output_disabled) {
+        if (!data->output_disabled && is_beyond_global_max()) {
             data->output_disabled = true;
             /* std::atomic *should* be safe (we can assert std::atomic_is_lock_free())
              * but to avoid any risk we use DR's atomics and add 1.  This will only

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3177,6 +3177,13 @@ if (CLIENT_INTERFACE)
       torunonly_drcachesim(delay-simple ${ci_shared_app}
         "-trace_after_instrs 20000 -exit_after_tracing 10000" "")
 
+      # We use a many-threaded test with a small max and test that we only see
+      # 1 thread, testing the thread ignore logic.  The max should be small enough
+      # to not be flaky on any platform.
+      torunonly_drcachesim(delay-global client.annotation-concurrency
+        "-simulator_type basic_counts -trace_after_instrs 20K -max_global_trace_refs 10K"
+        "${annotation_test_args_shorter}")
+
       # Test that "Warmup hits" and "Warmup misses" are printed out
       torunonly_drcachesim(warmup-valid ${ci_shared_app} "-warmup_refs 1" "")
 
@@ -3398,6 +3405,11 @@ if (CLIENT_INTERFACE)
 
       torunonly_drcacheoff(instr-only-trace ${ci_shared_app} "-instr_only_trace" "" "")
       torunonly_drcacheoff(filter-and-instr-only-trace ${ci_shared_app} "-instr_only_trace -L0_filter" "" "")
+
+      # As for the online test, we check that only 1 thread is in the final trace.
+      torunonly_drcacheoff(max-global client.annotation-concurrency
+        "-trace_after_instrs 20K -max_global_trace_refs 10K"
+        "@-simulator_type@basic_counts" "${annotation_test_args_shorter}")
 
       # __builtin_prefetch used in the test is not defined on MSVC.
       if (NOT MSVC)


### PR DESCRIPTION
Adds a new drcachesim memtrace option -max_global_trace_refs to supply
a global trace size limit that does not kill the process.  When the
maximum is reached, the tracer omits traces for new threads entirely.

Add an online and an offline test for the feature.

Adds documentation.

Fixes #4462