### PR TITLE
i#1578 arm detach: Disable hanging drwrap detach test

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2650,12 +2650,14 @@ if (CLIENT_INTERFACE)
       "" "" "")
     use_DynamoRIO_extension(client.drwrap-test-callconv.dll drwrap)
   endif ()
-  if (NOT APPLE) # XXX i#1997: static DR not fully supported on Mac yet
-    set(client.drwrap-test-detach_no_reg_compat)
-    tobuild_api(client.drwrap-test-detach client-interface/drwrap-test-detach.cpp
-      "" "" OFF ON)
-    use_DynamoRIO_extension(client.drwrap-test-detach drwrap_static)
-    link_with_pthread(client.drwrap-test-detach)
+  if (NOT AARCHXX) # TODO i#1578: Hanging on AArch64.
+    if (NOT APPLE) # XXX i#1997: static DR not fully supported on Mac yet
+      set(client.drwrap-test-detach_no_reg_compat)
+      tobuild_api(client.drwrap-test-detach client-interface/drwrap-test-detach.cpp
+        "" "" OFF ON)
+      use_DynamoRIO_extension(client.drwrap-test-detach drwrap_static)
+      link_with_pthread(client.drwrap-test-detach)
+    endif ()
   endif ()
 
   # We rely on dbghelp >= 6.0 for our drsyms and sample.instrcalls tests,


### PR DESCRIPTION
PR #4470 for #4468 enabled client.drwrap-test-detach but it seems to
still have problems: PR #4467 found that it hangs 28 out of 100 times.
We re-disable it here for now.

Issue: #1578