### PR TITLE
i#4091: Fix crash due to AMD stack segment bug

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -106,6 +106,8 @@ set(DRLIBC_SRCS
   ${drlibc_arch_asm_src}
   drlibc/drlibc.c
   drlibc/drlibc_notdr_dcxt.c
+  drlibc/drlibc_notdr_error.c
+  drlibc/drlibc_notdr_ignoreassert.c
   drlibc/drlibc_notdr_logfile.c
   drlibc/drlibc_notdr_printlog.c
   drlibc/drlibc_notdr_report.c

--- a/core/drlibc/drlibc.c
+++ b/core/drlibc/drlibc.c
@@ -59,18 +59,6 @@ safe_read_if_fast(const void *base, size_t size, void *out_buf)
     return d_r_safe_read(base, size, out_buf);
 }
 
-WEAK void
-d_r_internal_error(const char *file, int line, const char *expr)
-{
-    /* Do nothing for non-core. */
-}
-
-WEAK bool
-ignore_assert(const char *assert_file_line, const char *expr)
-{
-    return true;
-}
-
 WEAK int
 d_r_strcmp(const char *left, const char *right)
 {
@@ -308,4 +296,15 @@ find_script_interpreter(OUT script_interpreter_t *result, IN const char *fname,
     result->argv[argc] = NULL;
     return true;
 }
+#endif
+
+#ifdef WINDOWS
+/***************************************************************************
+ * Windows mode switching support.
+ */
+
+/* We set a default equal to the observed 0x2b value on every Windows version.
+ * The core calls d_r_set_ss_selector() to update to the underlying value.
+ */
+int d_r_ss_value = 0x2b;
 #endif

--- a/core/drlibc/drlibc.h
+++ b/core/drlibc/drlibc.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -124,5 +124,13 @@ bool
 find_script_interpreter(OUT script_interpreter_t *result, IN const char *fname,
                         ssize_t (*reader)(const char *pathname, void *buf, size_t count));
 #endif /* UNIX */
+
+#if defined(WINDOWS) && !defined(X64)
+/* Meant to be called at initialization time when .data is writable and races are
+ * not a concern.
+ */
+void
+d_r_set_ss_selector();
+#endif
 
 #endif /* _DR_LIBC_H_ */

--- a/core/drlibc/drlibc_notdr_error.c
+++ b/core/drlibc/drlibc_notdr_error.c
@@ -1,0 +1,45 @@
+/* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Default implementation to avoid the user of drlibc having to supply one.
+ * We need to separate these as the MSVC linker will not complain about duplicate
+ * symbols if an .obj has just one symbol in it.
+ */
+
+#define DR_NO_FAST_IR /* Avoid pulling in deps from instr_inline.h from globals.h */
+#include "../globals.h"
+
+WEAK void
+d_r_internal_error(const char *file, int line, const char *expr)
+{
+    /* Do nothing for non-core. */
+}

--- a/core/drlibc/drlibc_notdr_ignoreassert.c
+++ b/core/drlibc/drlibc_notdr_ignoreassert.c
@@ -1,0 +1,45 @@
+/* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Default implementation to avoid the user of drlibc having to supply one.
+ * We need to separate these as the MSVC linker will not complain about duplicate
+ * symbols if an .obj has just one symbol in it.
+ */
+
+#define DR_NO_FAST_IR /* Avoid pulling in deps from instr_inline.h from globals.h */
+#include "../globals.h"
+
+WEAK bool
+ignore_assert(const char *assert_file_line, const char *expr)
+{
+    return true;
+}

--- a/core/drlibc/drlibc_x86.asm
+++ b/core/drlibc/drlibc_x86.asm
@@ -517,6 +517,19 @@ sml_return_to_32:
         END_FUNC(FUNCNAME)
 
 /*
+ * void d_r_set_ss_selector()
+ */
+DECL_EXTERN(d_r_ss_value)
+# undef FUNCNAME
+# define FUNCNAME d_r_set_ss_selector
+        DECLARE_FUNC(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        mov      eax, ss
+        mov      DWORD SYMREF(d_r_ss_value), eax
+        ret
+        END_FUNC(FUNCNAME)
+
+/*
  * int switch_modes_and_call(uint64 func, void *arg1, void *arg2, void *arg3)
  */
 # undef FUNCNAME
@@ -564,6 +577,15 @@ smc_transfer_to_64:
         jmp      fword ptr [esp]
 smc_return_to_32:
         add      esp, 8          /* clean up far jmp target */
+        /* i#4091: Work around an AMD processor bug where after switching from 64-bit
+         * back to 32-bit, if a thread switch happens around the same time, the
+         * SS segment descriptor gets corrupted somehow and any ESP reference
+         * raises an access violation with an undocumented Parameter[0]=00000003.
+         * Re-instating the proper descriptor by re-loading the selector seems
+         * to solve the problem.
+         */
+        mov      eax, DWORD SYMREF(d_r_ss_value)
+        mov      ss, eax
         pop      ebx             /* restore callee-saved reg */
         ret                      /* return value already in eax */
         END_FUNC(FUNCNAME)

--- a/core/drlibc/drlibc_x86.asm
+++ b/core/drlibc/drlibc_x86.asm
@@ -584,8 +584,8 @@ smc_return_to_32:
          * Re-instating the proper descriptor by re-loading the selector seems
          * to solve the problem.
          */
-        mov      eax, DWORD SYMREF(d_r_ss_value)
-        mov      ss, eax
+        mov      ebx, DWORD SYMREF(d_r_ss_value)
+        mov      ss, ebx
         pop      ebx             /* restore callee-saved reg */
         ret                      /* return value already in eax */
         END_FUNC(FUNCNAME)

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -1895,6 +1895,9 @@ os_take_over_init(void)
         GLOBAL_DCONTEXT, INIT_HTABLE_SIZE_TAKEOVER,
         80 /* load factor: not perf-critical */, HASHTABLE_SHARED | HASHTABLE_PERSISTENT,
         takeover_table_entry_free _IF_DEBUG("takeover table"));
+#    ifndef X64
+    d_r_set_ss_selector();
+#    endif
 }
 
 /* We need to distinguish a thread intercepted via APC hook but that is in ntdll


### PR DESCRIPTION
On AMD there is a processor bug where the stack segment descriptor is
corrupted after a mode switch from 64-bit to 32-bit which coincides
with a thread context switch.  We fix that by re-loading the
descriptor from the selector, using the value observed at
initialization time.

Duplicate symbol errors which are somehow raised in VS2017 with the
new drlibc call from the core are resolved by moving
d_r_internal_error and d_r_ignore_assert to their own source files.

Tested the code path on an Intel processor.  Will ask those with AMD
processors to test it out before committing.

Fixes #4091