### PR TITLE
Optimise mcontext init by avoiding excessive zeroing.

### DIFF
--- a/api/samples/cbr.c
+++ b/api/samples/cbr.c
@@ -232,10 +232,9 @@ insert(hash_table_t table, app_pc addr, cbr_state_t state)
 static void
 at_taken(app_pc src, app_pc targ)
 {
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     void *drcontext = dr_get_current_drcontext();
 
     /*
@@ -261,10 +260,9 @@ at_taken(app_pc src, app_pc targ)
 static void
 at_not_taken(app_pc src, app_pc fall)
 {
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     void *drcontext = dr_get_current_drcontext();
 
     /*

--- a/api/samples/cbr.c
+++ b/api/samples/cbr.c
@@ -232,6 +232,11 @@ insert(hash_table_t table, app_pc addr, cbr_state_t state)
 static void
 at_taken(app_pc src, app_pc targ)
 {
+    /*
+     * We've found that the time taken to zero a large struct shows up as
+     * noticeable overhead for optimized clients. So, instead of using partial
+     * struct initialization, we set the fields required individually.
+     */
     dr_mcontext_t mcontext;
     mcontext.size = sizeof(mcontext);
     mcontext.flags = DR_MC_ALL;
@@ -260,6 +265,11 @@ at_taken(app_pc src, app_pc targ)
 static void
 at_not_taken(app_pc src, app_pc fall)
 {
+    /*
+     * We've found that the time taken to zero a large struct shows up as
+     * noticeable overhead for optimized clients. So, instead of using partial
+     * struct initialization, we set the fields required individually.
+     */
     dr_mcontext_t mcontext;
     mcontext.size = sizeof(mcontext);
     mcontext.flags = DR_MC_ALL;

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -1211,10 +1211,9 @@ drbbdup_handle_new_case()
         (drbbdup_per_thread *)drmgr_get_tls_field(drcontext, tls_idx);
 
     /* Must use DR_MC_ALL due to dr_redirect_execution. */
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     dr_get_mcontext(drcontext, &mcontext);
 
     /* Scratch register holds the tag. */

--- a/suite/tests/client-interface/avx512ctx.dll.c
+++ b/suite/tests/client-interface/avx512ctx.dll.c
@@ -86,10 +86,9 @@ read_avx512_state()
     dr_fprintf(STDERR, "Reading application state\n");
 
     void *drcontext = dr_get_current_drcontext();
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     dr_get_mcontext(drcontext, &mcontext);
 
     bool get_reg_value_ok = true;

--- a/suite/tests/client-interface/cbr3.dll.c
+++ b/suite/tests/client-interface/cbr3.dll.c
@@ -210,10 +210,9 @@ insert(hash_table_t table, app_pc addr, cbr_state_t state)
 static void
 at_taken(app_pc src, app_pc targ)
 {
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     void *drcontext = dr_get_current_drcontext();
 
     /*
@@ -239,10 +238,9 @@ at_taken(app_pc src, app_pc targ)
 static void
 at_not_taken(app_pc src, app_pc fall)
 {
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     void *drcontext = dr_get_current_drcontext();
 
     /*

--- a/suite/tests/client-interface/cleancall.dll.c
+++ b/suite/tests/client-interface/cleancall.dll.c
@@ -59,10 +59,9 @@ set_gpr()
 {
     check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     dr_get_mcontext(drcontext, &mcontext);
     reg_get_value_ex(DR_REG_XAX, &mcontext, orig_reg_val_buf);
     reg_get_value_ex(DR_REG_XAX, &mcontext, new_reg_val_buf);
@@ -80,10 +79,9 @@ check_gpr()
 {
     check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     dr_get_mcontext(drcontext, &mcontext);
     reg_get_value_ex(DR_REG_XAX, &mcontext, new_reg_val_buf);
     print_error_on_fail(new_reg_val_buf[0] == 0x75);
@@ -99,10 +97,9 @@ set_xmm()
 {
     check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     dr_get_mcontext(drcontext, &mcontext);
     reg_get_value_ex(DR_REG_XMM0, &mcontext, orig_reg_val_buf);
     reg_get_value_ex(DR_REG_XMM0, &mcontext, new_reg_val_buf);
@@ -120,10 +117,9 @@ check_xmm()
 {
     check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     dr_get_mcontext(drcontext, &mcontext);
     reg_get_value_ex(DR_REG_XMM0, &mcontext, new_reg_val_buf);
     print_error_on_fail(new_reg_val_buf[0] == 0x77);
@@ -139,10 +135,9 @@ set_ymm()
 {
     check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     dr_get_mcontext(drcontext, &mcontext);
     reg_get_value_ex(DR_REG_YMM0, &mcontext, orig_reg_val_buf);
     reg_get_value_ex(DR_REG_YMM0, &mcontext, new_reg_val_buf);
@@ -162,10 +157,9 @@ check_ymm()
 {
     check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     dr_get_mcontext(drcontext, &mcontext);
     reg_get_value_ex(DR_REG_YMM0, &mcontext, new_reg_val_buf);
     print_error_on_fail(new_reg_val_buf[0] == 0x77);
@@ -184,10 +178,9 @@ set_zmm()
 {
     check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     dr_get_mcontext(drcontext, &mcontext);
     reg_get_value_ex(DR_REG_ZMM0, &mcontext, orig_reg_val_buf);
     reg_get_value_ex(DR_REG_ZMM0, &mcontext, new_reg_val_buf);
@@ -210,10 +203,9 @@ check_zmm()
 {
     check_stack_alignment();
     void *drcontext = dr_get_current_drcontext();
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     dr_get_mcontext(drcontext, &mcontext);
     reg_get_value_ex(DR_REG_ZMM0, &mcontext, new_reg_val_buf);
     print_error_on_fail(new_reg_val_buf[0] == 0x77);

--- a/suite/tests/client-interface/drreg-end-restore.dll.c
+++ b/suite/tests/client-interface/drreg-end-restore.dll.c
@@ -129,10 +129,9 @@ event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
 static reg_t
 get_val_from_ctx(void *drcontext, reg_id_t reg_id)
 {
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
     dr_get_mcontext(drcontext, &mcontext);
     return reg_get_value(reg_id, &mcontext);
 }

--- a/suite/tests/client-interface/events.dll.c
+++ b/suite/tests/client-interface/events.dll.c
@@ -452,7 +452,8 @@ kernel_xfer_event2(void *drcontext, const dr_kernel_xfer_info_t *info)
     if (info->type == DR_XFER_CLIENT_REDIRECT) {
         /* Test for exception event redirect. */
         ASSERT(info->source_mcontext != NULL);
-        dr_mcontext_t mc = { sizeof(mc) };
+        dr_mcontext_t mc;
+        mc.size = sizeof(mc);
         mc.flags = DR_MC_CONTROL;
         bool ok = dr_get_mcontext(drcontext, &mc);
         ASSERT(ok);
@@ -469,10 +470,7 @@ static bool
 exception_event_redirect(void *dcontext, dr_exception_t *excpt)
 {
     app_pc addr;
-    dr_mcontext_t mcontext = {
-        sizeof(mcontext),
-        DR_MC_ALL,
-    };
+    dr_mcontext_t mcontext;
     module_data_t *data = dr_lookup_module_by_name("client." EVENTS ".exe");
     dr_fprintf(STDERR, "exception event redirect\n");
     if (data == NULL) {

--- a/suite/tests/client-interface/flush.dll.c
+++ b/suite/tests/client-interface/flush.dll.c
@@ -188,11 +188,9 @@ callback(void *tag, app_pc next_pc)
     if (callback_count % 100 == 0) {
         if (callback_count % 200 == 0) {
             /* For windows test dr_flush_region() half the time */
-            dr_mcontext_t mcontext = {
-                sizeof(mcontext),
-                DR_MC_ALL,
-            };
-
+            dr_mcontext_t mcontext;
+            mcontext.size = sizeof(mcontext);
+            mcontext.flags = DR_MC_ALL;
             dr_delay_flush_region((app_pc)tag - 20, 30, callback_count, flush_event);
             dr_get_mcontext(dr_get_current_drcontext(), &mcontext);
             mcontext.pc = next_pc;
@@ -285,7 +283,8 @@ kernel_xfer_event(void *drcontext, const dr_kernel_xfer_info_t *info)
     /* Test kernel xfer on dr_redirect_execution */
     dr_fprintf(STDERR, "%s: type %d\n", __FUNCTION__, info->type);
     ASSERT(info->source_mcontext != NULL);
-    dr_mcontext_t mc = { sizeof(mc) };
+    dr_mcontext_t mc;
+    mc.size = sizeof(mc);
     mc.flags = DR_MC_CONTROL;
     bool ok = dr_get_mcontext(drcontext, &mc);
     ASSERT(ok);

--- a/suite/tests/client-interface/syscall.dll.c
+++ b/suite/tests/client-interface/syscall.dll.c
@@ -47,10 +47,9 @@ static void
 at_syscall()
 {
     if (monitoring) {
-        dr_mcontext_t mcontext = {
-            sizeof(mcontext),
-            DR_MC_ALL,
-        };
+        dr_mcontext_t mcontext;
+        mcontext.size = sizeof(mcontext);
+        mcontext.flags = DR_MC_ALL;
         void *drcontext = dr_get_current_drcontext();
         dr_get_mcontext(drcontext, &mcontext);
         dr_fprintf(STDERR, PFX "\n", mcontext.xax);


### PR DESCRIPTION
Instead of using partial struct initialisation, simply initialise the required fields.