### PR TITLE
Fix uninitialized var in drmemtrace offline instru

### DIFF
--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -279,8 +279,8 @@ instru_t::insert_obtain_addr(void *drcontext, instrlist_t *ilist, instr_t *where
         dr_fprintf(STDERR, "\n");
         DR_ASSERT(ok);
     }
-    if (scratch_used != NULL && we_used_scratch)
-        *scratch_used = true;
+    if (scratch_used != NULL)
+        *scratch_used = we_used_scratch;
 }
 
 // Returns -1 on error.  It's hard for callers to omit the cpu marker though

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -478,7 +478,7 @@ offline_instru_t::insert_save_addr(void *drcontext, instrlist_t *ilist, instr_t 
         res = drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_addr);
         DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
         reserved = true;
-        bool reg_ptr_used;
+        bool reg_ptr_used = false;
         insert_obtain_addr(drcontext, ilist, where, reg_addr, reg_ptr, ref,
                            &reg_ptr_used);
         if (reg_ptr_used) {


### PR DESCRIPTION
While investigating #4460 I found that reg_ptr_used in
insert_save_addr is uninitialized locally and insert_obtain_addr only
writes it when true, leaving it uninitialized for the false case: thus
we may re-instate the buffer pointer in cases where we don't need to.
I believe this is only a performance issue.

Issue: #4460