### PR TITLE
i#4496: Fix reset issues on AArch64 and x86

### DIFF
--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -752,9 +752,10 @@ dispatch_enter_dynamorio(dcontext_t *dcontext)
            wherewasi == DR_WHERE_APP ||
            /* If the thread was waiting at check_wait_at_safe_point when getting
             * suspended, we were in dispatch (ref i#3427). We will be here after the
-            * thread's context is being reset before sending it native.
+            * thread's context is being reset proactively (due to some -reset_at_*
+            * option) or before sending it native.
             */
-           (dcontext->go_native && wherewasi == DR_WHERE_DISPATCH));
+           wherewasi == DR_WHERE_DISPATCH);
     dcontext->whereami = DR_WHERE_DISPATCH;
     ASSERT_LOCAL_HEAP_UNPROTECTED(dcontext);
     ASSERT(check_should_be_protected(DATASEC_RARELY_PROT));

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -755,7 +755,8 @@ dispatch_enter_dynamorio(dcontext_t *dcontext)
             * thread's context is being reset proactively (due to some -reset_at_*
             * option) or before sending it native.
             */
-           wherewasi == DR_WHERE_DISPATCH);
+           ((dcontext->go_native || dcontext->last_exit == get_reset_linkstub()) &&
+            wherewasi == DR_WHERE_DISPATCH));
     dcontext->whereami = DR_WHERE_DISPATCH;
     ASSERT_LOCAL_HEAP_UNPROTECTED(dcontext);
     ASSERT(check_should_be_protected(DATASEC_RARELY_PROT));

--- a/core/synch.c
+++ b/core/synch.c
@@ -1820,10 +1820,11 @@ translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t sy
          * translate_mcontext.
          */
         IF_AARCHXX({
-            // XXX i#4495: Consider saving stolen reg's translated application value.
+            /* XXX i#4495: Save stolen reg's translated application value. */
             set_stolen_reg_val(mc, (reg_t)os_get_dr_tls_base(dcontext));
-            // XXX: This path is tested by linux.thread-reset and linux.clone-reset.
-            // We just haven't run those on ARM yet.
+            /* XXX: This path is tested by linux.thread-reset and linux.clone-reset.
+             * We just haven't run those on ARM yet.
+             */
             IF_ARM(ASSERT_NOT_TESTED());
         });
 #ifdef WINDOWS

--- a/core/synch.c
+++ b/core/synch.c
@@ -1815,9 +1815,17 @@ translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t sy
          */
         mc->pc = (app_pc)get_reset_exit_stub(dcontext);
         LOG(GLOBAL, LOG_CACHE, 2, "\tsent to reset exit stub " PFX "\n", mc->pc);
-        /* TODO i#4497: Replace with the official fix from PR#4498. */
-        IF_AARCHXX(set_stolen_reg_val(mc, (reg_t)os_get_dr_tls_base(dcontext)));
-        IF_AARCHXX(ASSERT_NOT_TESTED()); /* PR#4498 will improve test coverage. */
+        /* The reset exit stub expects the stolen reg to contain the TLS base address.
+         * But the stolen reg was restored to the application value during
+         * translate_mcontext.
+         */
+        IF_AARCHXX({
+            // XXX i#4495: Consider saving stolen reg's translated application value.
+            set_stolen_reg_val(mc, (reg_t)os_get_dr_tls_base(dcontext));
+            // XXX: This path is tested by linux.thread-reset and linux.clone-reset.
+            // We just haven't run those on ARM yet.
+            IF_ARM(ASSERT_NOT_TESTED());
+        });
 #ifdef WINDOWS
         /* i#25: we could have interrupted thread in DR, where has priv fls data
          * in TEB, and fcache_return blindly copies into app fls: so swap to app

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2682,7 +2682,7 @@ thread_set_self_context(void *cxt)
     frame.uc.uc_mcontext = *sc;
 #endif
     IF_ARM(ASSERT_NOT_TESTED());
-#if defined(X86)
+#if defined(LINUX) && defined(X86)
     save_fpstate(dcontext, &frame);
 #endif
     /* The kernel calls do_sigaltstack on sys_rt_sigreturn primarily to ensure
@@ -2703,7 +2703,7 @@ thread_set_self_context(void *cxt)
     /* For x86 only, we need to skip pretcode while setting xsp. */
     xsp_for_sigreturn = ((app_pc)&frame)IF_X86(+sizeof(char *));
 #ifdef DR_HOST_NOT_TARGET
-    ASSERT_NOT_REACHED();
+        ASSERT_NOT_REACHED();
 #elif X86
     asm("mov  %0, %%" ASM_XSP : : "m"(xsp_for_sigreturn));
 #    ifdef MACOS
@@ -5580,7 +5580,7 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
     /* FIXME: we should clear fpstate for app handler itself as that's
      * how our own handler is executed.
      */
-#if defined(X86)
+#if defined(LINUX) && defined(X86)
     ASSERT(sc->fpstate != NULL); /* not doing i#641 yet */
     save_fpstate(dcontext, frame);
 #endif /* LINUX && X86 */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2682,7 +2682,7 @@ thread_set_self_context(void *cxt)
     frame.uc.uc_mcontext = *sc;
 #endif
     IF_ARM(ASSERT_NOT_TESTED());
-#if defined(LINUX) && defined(X86)
+#if defined(X86)
     save_fpstate(dcontext, &frame);
 #endif
     /* The kernel calls do_sigaltstack on sys_rt_sigreturn primarily to ensure
@@ -2703,7 +2703,7 @@ thread_set_self_context(void *cxt)
     /* For x86 only, we need to skip pretcode while setting xsp. */
     xsp_for_sigreturn = ((app_pc)&frame)IF_X86(+sizeof(char *));
 #ifdef DR_HOST_NOT_TARGET
-        ASSERT_NOT_REACHED();
+    ASSERT_NOT_REACHED();
 #elif X86
     asm("mov  %0, %%" ASM_XSP : : "m"(xsp_for_sigreturn));
 #    ifdef MACOS
@@ -5580,7 +5580,7 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
     /* FIXME: we should clear fpstate for app handler itself as that's
      * how our own handler is executed.
      */
-#if defined(LINUX) && defined(X86)
+#if defined(X86)
     ASSERT(sc->fpstate != NULL); /* not doing i#641 yet */
     save_fpstate(dcontext, frame);
 #endif /* LINUX && X86 */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2702,7 +2702,9 @@ thread_set_self_context(void *cxt)
     /* set up xsp to point at &frame + sizeof(char*) */
     /* For x86 only, we need to skip pretcode while setting xsp. */
     xsp_for_sigreturn = ((app_pc)&frame)IF_X86(+sizeof(char *));
-#ifdef X86
+#ifdef DR_HOST_NOT_TARGET
+        ASSERT_NOT_REACHED();
+#elif X86
     asm("mov  %0, %%" ASM_XSP : : "m"(xsp_for_sigreturn));
 #    ifdef MACOS
     ASSERT_NOT_IMPLEMENTED(false && "need to pass 2 params to SYS_sigreturn");
@@ -2715,7 +2717,7 @@ thread_set_self_context(void *cxt)
     asm("mov  %0, %%" ASM_XCX : : "m"(asm_jmp_tgt));
     asm("jmp  *%" ASM_XCX);
 #    endif /* MACOS/LINUX */
-#elif defined(AARCH64) && !defined(DR_HOST_NOT_TARGET)
+#elif defined(AARCH64)
     asm("mov  " ASM_XSP ", %0" : : "r"(xsp_for_sigreturn));
     asm("b    dynamorio_sigreturn");
 #elif defined(ARM)

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2673,9 +2673,11 @@ thread_set_self_context(void *cxt)
     ASSERT_NOT_IMPLEMENTED(false); /* PR 405694: can't use regular sigreturn! */
 #endif
     memset(&frame, 0, sizeof(frame));
+#if defined(LINUX) && defined(X86)
+    dcontext_t *dcontext = get_thread_private_dcontext();
+#endif
 #ifdef LINUX
 #    ifdef X86
-    dcontext_t *dcontext = get_thread_private_dcontext();
     byte *xstate = get_and_initialize_xstate_buffer(dcontext);
     frame.uc.uc_mcontext.fpstate = &((kernel_xstate_t *)xstate)->fpstate;
 #    endif /* X86 */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2703,8 +2703,8 @@ thread_set_self_context(void *cxt)
     /* For x86 only, we need to skip pretcode while setting xsp. */
     xsp_for_sigreturn = ((app_pc)&frame)IF_X86(+sizeof(char *));
 #ifdef DR_HOST_NOT_TARGET
-        ASSERT_NOT_REACHED();
-#elif X86
+    ASSERT_NOT_REACHED();
+#elif defined(X86)
     asm("mov  %0, %%" ASM_XSP : : "m"(xsp_for_sigreturn));
 #    ifdef MACOS
     ASSERT_NOT_IMPLEMENTED(false && "need to pass 2 params to SYS_sigreturn");

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2698,8 +2698,8 @@ thread_set_self_context(void *cxt)
     LOG(THREAD_GET, LOG_ASYNCH, 2, "thread_set_self_context: pc=" PFX "\n", sc->SC_XIP);
     LOG(THREAD_GET, LOG_ASYNCH, 3, "full sigcontext\n");
     DOLOG(LOG_ASYNCH, 3, {
-        dcontext_t *dcontext = get_thread_private_dcontext();
-        dump_sigcontext(dcontext, get_sigcontext_from_rt_frame(&frame));
+        dcontext_t *dc = get_thread_private_dcontext();
+        dump_sigcontext(dc, get_sigcontext_from_rt_frame(&frame));
     });
     /* set up xsp to point at &frame + sizeof(char*) */
     /* For x86 only, we need to skip pretcode while setting xsp. */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2715,7 +2715,7 @@ thread_set_self_context(void *cxt)
     asm("mov  %0, %%" ASM_XCX : : "m"(asm_jmp_tgt));
     asm("jmp  *%" ASM_XCX);
 #    endif /* MACOS/LINUX */
-#elif defined(AARCH64)
+#elif defined(AARCH64) && !defined(DR_HOST_NOT_TARGET)
     asm("mov  " ASM_XSP ", %0" : : "r"(xsp_for_sigreturn));
     asm("b    dynamorio_sigreturn");
 #elif defined(ARM)

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -3430,7 +3430,7 @@ transfer_from_sig_handler_to_fcache_return(dcontext_t *dcontext, kernel_ucontext
      * from DR's handler.
      */
     ASSERT(get_sigcxt_stolen_reg(sc) != (reg_t)*get_dr_tls_base_addr());
-    // XXX i#4495: Consider saving stolen reg's translated application value.
+    /* XXX i#4495: Save stolen reg's translated application value. */
     set_sigcxt_stolen_reg(sc, (reg_t)*get_dr_tls_base_addr());
 #    ifndef AARCH64
     /* We're going to our fcache_return gencode which uses DEFAULT_ISA_MODE */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2684,7 +2684,7 @@ thread_set_self_context(void *cxt)
     frame.uc.uc_mcontext = *sc;
 #endif
     IF_ARM(ASSERT_NOT_TESTED());
-#if defined(LINUX) && defined(X86)
+#if defined(X86)
     save_fpstate(dcontext, &frame);
 #endif
     /* The kernel calls do_sigaltstack on sys_rt_sigreturn primarily to ensure

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2661,7 +2661,6 @@ thread_set_self_context(void *cxt)
     }
 #endif
 
-    dcontext_t *dcontext = get_thread_private_dcontext();
     /* Unlike Windows we can't say "only set this subset of the
      * full machine state", so we need to get the rest of the state,
      */
@@ -2676,6 +2675,7 @@ thread_set_self_context(void *cxt)
     memset(&frame, 0, sizeof(frame));
 #ifdef LINUX
 #    ifdef X86
+    dcontext_t *dcontext = get_thread_private_dcontext();
     byte *xstate = get_and_initialize_xstate_buffer(dcontext);
     frame.uc.uc_mcontext.fpstate = &((kernel_xstate_t *)xstate)->fpstate;
 #    endif /* X86 */
@@ -2695,8 +2695,10 @@ thread_set_self_context(void *cxt)
                         sizeof(frame.uc.uc_sigmask));
     LOG(THREAD_GET, LOG_ASYNCH, 2, "thread_set_self_context: pc=" PFX "\n", sc->SC_XIP);
     LOG(THREAD_GET, LOG_ASYNCH, 3, "full sigcontext\n");
-    DOLOG(LOG_ASYNCH, 3,
-          { dump_sigcontext(dcontext, get_sigcontext_from_rt_frame(&frame)); });
+    DOLOG(LOG_ASYNCH, 3, {
+        dcontext_t *dcontext = get_thread_private_dcontext();
+        dump_sigcontext(dcontext, get_sigcontext_from_rt_frame(&frame));
+    });
     /* set up xsp to point at &frame + sizeof(char*) */
     /* For x86 only, we need to skip pretcode while setting xsp. */
     xsp_for_sigreturn = ((app_pc)&frame) IF_X86(+ sizeof(char *));

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2701,7 +2701,7 @@ thread_set_self_context(void *cxt)
     });
     /* set up xsp to point at &frame + sizeof(char*) */
     /* For x86 only, we need to skip pretcode while setting xsp. */
-    xsp_for_sigreturn = ((app_pc)&frame) IF_X86(+ sizeof(char *));
+    xsp_for_sigreturn = ((app_pc)&frame)IF_X86(+sizeof(char *));
 #ifdef X86
     asm("mov  %0, %%" ASM_XSP : : "m"(xsp_for_sigreturn));
 #    ifdef MACOS
@@ -2721,7 +2721,7 @@ thread_set_self_context(void *cxt)
 #elif defined(ARM)
     asm("ldr  " ASM_XSP ", %0" : : "m"(xsp_for_sigreturn));
     asm("b    dynamorio_sigreturn");
-#endif /* X86/ARM */
+#endif /* X86/AARCH64/ARM */
     ASSERT_NOT_REACHED();
 }
 

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2673,7 +2673,7 @@ thread_set_self_context(void *cxt)
     ASSERT_NOT_IMPLEMENTED(false); /* PR 405694: can't use regular sigreturn! */
 #endif
     memset(&frame, 0, sizeof(frame));
-#if defined(LINUX) && defined(X86)
+#if defined(X86)
     dcontext_t *dcontext = get_thread_private_dcontext();
 #endif
 #ifdef LINUX

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4069,14 +4069,10 @@ if (UNIX)
   #tobuild(linux.vfork-fib linux/vfork-fib.c)
 
   # runs of other builds with custom DR options
-  # TODO i#4497: The following two tests need to trigger reset when multiple
-  # threads are active. But, the current -reset_at_fragment_count value does
-  # not ensure that. We need to make these tests more robust, perhaps by
-  # using a different trigger like -reset_at_nth_thread (pending i#4496).
   torunonly(linux.thread-reset linux.thread linux/thread.c
-    "-enable_reset -reset_at_fragment_count 100" "")
+    "-enable_reset -reset_at_nth_thread 2" "")
   torunonly(linux.clone-reset linux.clone linux/clone.c
-    "-enable_reset -reset_at_fragment_count 100" "")
+    "-enable_reset -reset_at_nth_thread 2" "")
   if (AARCHXX)
     # Test our diagnostic option -steal_reg_at_reset, which is also a stress
     # test of reset and register stealing.


### PR DESCRIPTION
Changes reset trigger for `linux.thread-reset` and `linux.clone-reset` tests to `-reset_at_nth_thread`. To increase coverage of these tests, we need to trigger reset at a time when multiple threads are active. This is difficult to do using the existing` -reset_at_fragment_count` option in tests, which may need to be tuned regularly to its ideal value, which also differs based on platform.

Implements some missing AArch64 pieces for `dynamorio_sigreturn`.

Relaxes dispatch assert to allow threads to enter dispatch after reset. The current condition allows it only when sending threads native.

Fixes #4496
Fixes #4497