### PR TITLE
Revert "Fix uninitialized var in drmemtrace offline instru (#4506)"

### DIFF
--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -279,8 +279,8 @@ instru_t::insert_obtain_addr(void *drcontext, instrlist_t *ilist, instr_t *where
         dr_fprintf(STDERR, "\n");
         DR_ASSERT(ok);
     }
-    if (scratch_used != NULL)
-        *scratch_used = we_used_scratch;
+    if (scratch_used != NULL && we_used_scratch)
+        *scratch_used = true;
 }
 
 // Returns -1 on error.  It's hard for callers to omit the cpu marker though

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -478,7 +478,7 @@ offline_instru_t::insert_save_addr(void *drcontext, instrlist_t *ilist, instr_t 
         res = drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_addr);
         DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
         reserved = true;
-        bool reg_ptr_used = false;
+        bool reg_ptr_used;
         insert_obtain_addr(drcontext, ilist, where, reg_addr, reg_ptr, ref,
                            &reg_ptr_used);
         if (reg_ptr_used) {


### PR DESCRIPTION
This reverts commit 420adb01d466e134037b1db6ed7023749c3f8034
because it causes crashes in large apps linking drcachesim statically.
We believe that PR #4506 itself is actually correct and that it is
simply revealing an underlying problem, and once we find that problem
the plan is to re-instate it.

Issue: #4460