### PR TITLE
Fix gcc 10 build warnings

### DIFF
--- a/suite/tests/client-interface/alloc.dll.c
+++ b/suite/tests/client-interface/alloc.dll.c
@@ -631,7 +631,8 @@ inline_alloc_test(void)
 #if defined(LINUX) && defined(X86_64)
     /* i#4335: Test allocation of more than 2.8GB in unreachable heap */
     for (int i = 0; i != 50; ++i) {
-        malloc(100000000);
+        if (malloc(100000000) == NULL)
+            dr_fprintf(STDERR, "Failed to allocate\n");
     }
 #endif
 }

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -161,7 +161,7 @@ else (UNIX)
 endif (UNIX)
 
 # We generate 3 different tools from drdeploy.c.
-if (CMAKE_COMPILER_IS_GNUCC)
+if (CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_COMPILER_IS_CLANG)
   # Work around a false positive snprintf warning from gcc: i#4363.
   # XXX i#4363: A better solution would be nice to avoid missing
   # warnings on real snprintf issues.

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2019 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2020 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -160,7 +160,13 @@ else (UNIX)
 
 endif (UNIX)
 
-# we generate 3 different tools from drdeploy.c
+# We generate 3 different tools from drdeploy.c.
+if (CMAKE_COMPILER_IS_GNUCC)
+  # Work around a false positive snprintf warning from gcc: i#4363.
+  # XXX i#4363: A better solution would be nice to avoid missing
+  # warnings on real snprintf issues.
+  set_source_files_properties(drdeploy.c PROPERTIES COMPILE_FLAGS "-Wno-restrict")
+endif ()
 add_executable(drconfig drdeploy.c ${RESOURCES})
 set_target_properties(drconfig PROPERTIES
   COMPILE_FLAGS "${tool_cflags} -DRC_IS_drconfig -DDRCONFIG")


### PR DESCRIPTION
Fixes a gcc 10 build warning on snprintf overlapping in drdeploy.c by
disabling the warning type.  A better solution would be nice to avoid
missing warnings on real problems but this will do for now.

Fixes a warning about ignoring a return value in the client.alloc test.

Fixes #4363
Fixes #4511