### PR TITLE
i#4474 a64 tests: Fix a64 asm error in burst_traceopts

### DIFF
--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -381,7 +381,7 @@ mysym:
         ldr      x1, [x0, #32]
         ldr      x1, [x0, #16]
         // Modify via non-memref.
-        add      x0, #8
+        add      x0, x0, #8
         ldr      x1, [x0, #32]
         // There are no conditional/predicate loads/stores.
         ret


### PR DESCRIPTION
Fixes an error in the a64 assembly in the burst_traceopts test.  The
test is not yet officially enabled for a64 but that work will be done
later and it seems worth fixing this error now.

Issue: #4474