### PR TITLE
i#4460: Restore stolen reg on signal in auto-restart syscall

### DIFF
--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -454,7 +454,13 @@ append_restore_gpr(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
     APP(ilist, RESTORE_FROM_DC(dcontext, SCRATCH_REG0, REG_OFFSET(dr_reg_stolen)));
     APP(ilist, SAVE_TO_TLS(dcontext, SCRATCH_REG0, TLS_REG_STOLEN_SLOT));
 
-    /* Save DR's tls base into mcontext. */
+    /* Save DR's tls base into mcontext so we can blindly include it in the
+     * loop of OP_ldp instructions below.
+     * This means that the mcontext stolen reg slot holds DR's base instead of
+     * the app's value while we're in the cache, which can be confusing: but we have
+     * to get the official value from TLS on signal and other transitions anyway,
+     * and DR's base makes it easier to spot bugs than a prior app value.
+     */
     APP(ilist, SAVE_TO_DC(dcontext, dr_reg_stolen, REG_OFFSET(dr_reg_stolen)));
 
     i = (REG_DCXT == DR_REG_X0);

--- a/core/arch/arm/emit_utils.c
+++ b/core/arch/arm/emit_utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -648,6 +648,10 @@ append_restore_gpr(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
      * XXX: we just want to remove the stolen reg from the reg list,
      * so instead of having this extra store, we should provide a help
      * function to create the reg list.
+     * This means that the mcontext stolen reg slot holds DR's base instead of
+     * the app's value while we're in the cache, which can be confusing: but we have
+     * to get the official value from TLS on signal and other transitions anyway,
+     * and DR's base makes it easier to spot bugs than a prior app value.
      */
     APP(ilist, SAVE_TO_DC(dcontext, dr_reg_stolen, REG_OFFSET(dr_reg_stolen)));
     /* prepare for ldm */

--- a/core/lib/mcxtx.h
+++ b/core/lib/mcxtx.h
@@ -50,6 +50,12 @@
      * or a 32-byte or 64-byte cache line.
      * Any changes in order here must be mirrored in arch/arm.asm offsets.
      */
+    /* The stolen register slot only holds the app's value while in DR.
+     * While in the cache, the app's value is stored in TLS in
+     * dcontext->local_state->spill_space.reg_stolen, and the mcontext slot
+     * actually holds DR's TLS base just due to a quirk of how fcache_enter
+     * operates.
+     */
 #    endif
     reg_t r0;   /**< The r0 register. */
     reg_t r1;   /**< The r1 register. */


### PR DESCRIPTION
Adds a missing restore of the app's stolen register value into the
signal frame's ucontext when a signal interrupts an auto-restart
syscall.  In that case, we do not go through the full translation path
and instead perform a custom translation, which is why we missed this
step.

Adds asserts on several signal paths to help detect similar errors or
regressions in the future.

Adds comments making it more clear what is in the stolen register's
mcontext slot while in the cache.

Tested on the linux.eintr test which fails with the new asserts but
without the fix.  Additionally tested on the proprietary app where it
was first encountered.

Fixes #4460