### PR TITLE
i#4518: Handle NULL fp_simd_state signal frame pointer

### DIFF
--- a/core/unix/signal_linux_aarch64.c
+++ b/core/unix/signal_linux_aarch64.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -70,6 +70,8 @@ void
 sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
 {
     struct fpsimd_context *fpc = (struct fpsimd_context *)sc_full->fp_simd_state;
+    if (fpc == NULL)
+        return;
     ASSERT(fpc->head.magic == FPSIMD_MAGIC);
     ASSERT(fpc->head.size == sizeof(struct fpsimd_context));
     mc->fpsr = fpc->fpsr;
@@ -82,6 +84,8 @@ void
 mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
 {
     struct fpsimd_context *fpc = (struct fpsimd_context *)sc_full->fp_simd_state;
+    if (fpc == NULL)
+        return;
     struct _aarch64_ctx *next = (void *)((char *)fpc + sizeof(struct fpsimd_context));
     fpc->head.magic = FPSIMD_MAGIC;
     fpc->head.size = sizeof(struct fpsimd_context);

--- a/core/unix/signal_linux_arm.c
+++ b/core/unix/signal_linux_arm.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -103,6 +103,8 @@ static bool vfp_is_offset = false;
 void
 sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
 {
+    if (sc_full->fp_simd_state == NULL)
+        return;
     char *frame = ((char *)sc_full->fp_simd_state +
                    (vfp_is_offset ? sizeof(kernel_iwmmxt_sigframe_t) : 0));
     kernel_vfp_sigframe_t *vfp = (kernel_vfp_sigframe_t *)frame;
@@ -115,6 +117,8 @@ sigcontext_to_mcontext_simd(priv_mcontext_t *mc, sig_full_cxt_t *sc_full)
 void
 mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
 {
+    if (sc_full->fp_simd_state == NULL)
+        return;
     char *frame = (char *)sc_full->fp_simd_state;
     kernel_vfp_sigframe_t *vfp;
     if (vfp_is_offset) {


### PR DESCRIPTION
Fixes a crash when an aarch64 signal frame has a NULL fp_simd_state
pointer, which is a legitimate situation.

Tested on the client.signal test's forthcoming port to a64.

Fixes #4518