### PR TITLE
i#4520: Restore ARM opnd_t layout

### DIFF
--- a/core/ir/opnd.h
+++ b/core/ir/opnd.h
@@ -1366,7 +1366,11 @@ struct _opnd_t {
          * Currently not included for Windows because sizeof(opnd_t) does not
          * equal EXPECTED_SIZEOF_OPND, triggering the ASSERT in d_r_arch_init().
          */
-        double immed_double; /* IMMED_DOUBLE_kind */
+        /* For 32-bit ARM we keep alignment at 4 to avoid changing the opnd_t shape.
+         * Marking this field as packed seems to do it and avoids other changes
+         * that might occur if packing the whole struct.
+         */
+        double immed_double IF_ARM(__attribute__((__packed__))); /* IMMED_DOUBLE_kind */
 #    endif
         /* PR 225937: today we provide no way of specifying a 16-bit immediate
          * (encoded as a data16 prefix, which also implies a 16-bit EIP,

--- a/core/ir/opnd.h
+++ b/core/ir/opnd.h
@@ -1369,6 +1369,9 @@ struct _opnd_t {
         /* For 32-bit ARM we keep alignment at 4 to avoid changing the opnd_t shape.
          * Marking this field as packed seems to do it and avoids other changes
          * that might occur if packing the whole struct.
+         * XXX i#4488: Do any double-loading instructions require 8-byte alignment?
+         * Perhaps we should just break compatibility and align this to 8 for
+         * x86 and ARM 32-bit.
          */
         double immed_double IF_ARM(__attribute__((__packed__))); /* IMMED_DOUBLE_kind */
 #    endif


### PR DESCRIPTION
Avoids padding due to 8-byte-alignment of the new opnd_t.immed_double
field, to keep the layout how it was before PR #4467, avoiding an
init-time assert and problems matching the "black box" exported opnd_t
struct.

Fixes #4520