### PR TITLE
i#4516: Add client thread support for AArchXX

### DIFF
--- a/core/arch/aarch64/aarch64.asm
+++ b/core/arch/aarch64/aarch64.asm
@@ -515,10 +515,21 @@ GLOBAL_LABEL(_dynamorio_runtime_resolve:)
 #endif /* UNIX */
 
 #ifdef LINUX
-
+/* thread_id_t dynamorio_clone(uint flags, byte *newsp, void *ptid, void *tls,
+ *                             void *ctid, void (*func)(void))
+ */
         DECLARE_FUNC(dynamorio_clone)
 GLOBAL_LABEL(dynamorio_clone:)
-        bl       GLOBAL_REF(unexpected_return) /* FIXME i#1569: NYI */
+        stp      ARG6, x0, [ARG2, #-16]! /* func is now on TOS of newsp */
+        /* All args are already in syscall registers. */
+        mov      w8, #SYS_clone
+        svc      #0
+        cbnz     x0, dynamorio_clone_parent
+        ldp      x0, x1, [sp], #16
+        blr      x0
+        bl       GLOBAL_REF(unexpected_return)
+dynamorio_clone_parent:
+        ret
         END_FUNC(dynamorio_clone)
 
         DECLARE_FUNC(dynamorio_sigreturn)

--- a/core/arch/arm/arm.asm
+++ b/core/arch/arm/arm.asm
@@ -494,12 +494,28 @@ GLOBAL_LABEL(_dynamorio_runtime_resolve:)
 #endif /* UNIX */
 
 #ifdef LINUX
-
+/* thread_id_t dynamorio_clone(uint flags, byte *newsp, void *ptid, void *tls,
+ *                             void *ctid, void (*func)(void))
+ */
         DECLARE_FUNC(dynamorio_clone)
 GLOBAL_LABEL(dynamorio_clone:)
-        /* FIXME i#1551: NYI on ARM */
-        mov      r0, #0
+        /* Save callee-saved regs we clobber in the parent. */
+        push     {r4, r5, r7}
+        ldr      r4, [sp, #12] /* ARG5 minus the pushes above */
+        ldr      r5, [sp, #16] /* ARG6 minus the pushes above */
+        /* All args are now in syscall registers. */
+        /* Push func on the new stack. */
+        stmdb    ARG2!, {r5}
+        mov      r7, #SYS_clone
+        svc      0
+        cmp      r0, #0
+        bne      dynamorio_clone_parent
+        ldmia    sp!, {r0}
+        blx      r0
         bl       GLOBAL_REF(unexpected_return)
+dynamorio_clone_parent:
+        pop      {r4, r5, r7}
+        bx       lr
         END_FUNC(dynamorio_clone)
 
         DECLARE_FUNC(dynamorio_sigreturn)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2407,9 +2407,9 @@ if (CLIENT_INTERFACE)
     if (X86 OR AARCH64) # FIXME i#1551: port asm to AArch32
       tobuild_ci(client.syscall-mod client-interface/syscall-mod.c "" "" "")
     endif (X86 OR AARCH64)
+    tobuild_ci(client.signal client-interface/signal.c "" "" "")
+    link_with_pthread(client.signal)
     if (X86) # FIXME i#1551, i#1569: port asm to ARM and AArch64
-      tobuild_ci(client.signal client-interface/signal.c "" "" "")
-      link_with_pthread(client.signal)
       tobuild_ci(client.cbr-retarget client-interface/cbr-retarget.c "" "" "")
     endif (X86)
     tobuild_ci(client.cleancallsig client-interface/cleancallsig.c "" "" "")

--- a/suite/tests/client-interface/signal.c
+++ b/suite/tests/client-interface/signal.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -127,16 +127,17 @@ main(int argc, char **argv)
         kill(getpid(), SIGUSR2);
     }
 
-    /* generate SIGSEGV; we'll re-crash post-handler unless client
-     * modifies mcontext
+    /* Generate SIGSEGV in a manner that will re-crash post-handler unless the client
+     * modifies the mcontext register values.
      */
-#ifdef X64
-#    define EAX "%rax"
-#    define ECX "%rcx"
-#else
-#    define EAX "%eax"
-#    define ECX "%ecx"
-#endif
+#ifdef X86
+#    ifdef X64
+#        define EAX "%rax"
+#        define ECX "%rcx"
+#    else
+#        define EAX "%eax"
+#        define ECX "%ecx"
+#    endif
     asm("push " EAX);
     asm("push " ECX);
     asm("mov %0, %" ECX "" : : "g"(&bar)); /* ok place to read from */
@@ -144,6 +145,27 @@ main(int argc, char **argv)
     asm("mov (" EAX "), " EAX);
     asm("pop " ECX);
     asm("pop " EAX);
+#elif defined(AARCH64)
+    __asm__ __volatile__("stp x0, x1, [sp, #-16]!\n\t"
+                         "mov x1, %0\n\t"
+                         "mov x0, #0\n\t"
+                         "ldr x0, [x0]\n\t"
+                         "ldp x0, x1, [sp], #16\n\t"
+                         :
+                         : "r"(&bar)
+                         : "x0", "x1", "memory");
+#elif defined(ARM)
+    __asm__ __volatile__("stm sp!, {r0, r1}\n\t"
+                         "mov r1, %0\n\t"
+                         "mov r0, #0\n\t"
+                         "ldr r0, [r0]\n\t"
+                         "ldm sp!, {r0, r1}\n\t"
+                         :
+                         : "r"(&bar)
+                         : "r0", "r1", "memory");
+#else
+#    error Unsupported arch
+#endif
 
     print("Sending SIGUSR1\n");
     kill(getpid(), SIGUSR1);

--- a/suite/tests/client-interface/signal.dll.c
+++ b/suite/tests/client-interface/signal.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -122,7 +122,7 @@ signal_event(void *dcontext, dr_siginfo_t *info)
             /* test mcontext changes on delivery.
              * fix up to avoid crash on re-execution.
              */
-            info->mcontext->xax = info->mcontext->xcx;
+            info->mcontext->IF_X86_ELSE(xax, r0) = info->mcontext->IF_X86_ELSE(xcx, r1);
             return DR_SIGNAL_DELIVER;
         }
     } else if (info->sig == SIGCHLD) {
@@ -212,7 +212,7 @@ bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool trans
         if (instr_is_nop(instr) && next_instr != NULL && instr_is_nop(next_instr) &&
             next_next_instr != NULL && instr_is_call_direct(next_next_instr)) {
 
-            redirect_tag = tag;
+            redirect_tag = dr_app_pc_as_jump_target(instr_get_isa_mode(instr), tag);
             break;
         }
     }


### PR DESCRIPTION
Adds client thread support to AArchXX.
Implements dynamorio_clone for both ARM and AArch64 and adds necessary
TLS swapping, including handling initial tpidr* values pointing at
read-only memory.

Ports the client.signal test's assembly to a64 and arm.  Enables the
client.signal test on aarchxx.  The test covers the client thread support
here, as well as general client signal handling and manipulating.
Tested manually on arm with the #4522 fix.

Issue: #4474, #4516, #4522
Fixes #4516