### PR TITLE
Print AArch64 register values in dump_mcontext()

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -3603,7 +3603,7 @@ dump_mcontext(priv_mcontext_t *context, file_t f, bool dump_xml)
                    "\n\t\tr12=\"" PFX "\"\n\t\tr13=\"" PFX "\""
                    "\n\t\tr14=\"" PFX "\"\n\t\tr15=\"" PFX "\""
 #    endif /* X64 */
-#elif defined(ARM)
+#elif defined(AARCHXX)
                    "\n\t\tr0=\"" PFX "\"\n\t\tr1=\"" PFX "\""
                    "\n\t\tr2=\"" PFX "\"\n\t\tr3=\"" PFX "\""
                    "\n\t\tr4=\"" PFX "\"\n\t\tr5=\"" PFX "\""
@@ -3631,7 +3631,7 @@ dump_mcontext(priv_mcontext_t *context, file_t f, bool dump_xml)
                    "\tr8  = " PFX "\n\tr9  = " PFX "\n\tr10 = " PFX "\n\tr11 = " PFX "\n"
                    "\tr12 = " PFX "\n\tr13 = " PFX "\n\tr14 = " PFX "\n\tr15 = " PFX "\n"
 #    endif /* X64 */
-#elif defined(ARM)
+#elif defined(AARCHXX)
                    "\tr0  = " PFX "\n\tr1  = " PFX "\n\tr2  = " PFX "\n\tr3  = " PFX "\n"
                    "\tr4  = " PFX "\n\tr5  = " PFX "\n\tr6  = " PFX "\n\tr7  = " PFX "\n"
                    "\tr8  = " PFX "\n\tr9  = " PFX "\n\tr10 = " PFX "\n\tr11 = " PFX "\n"
@@ -3699,7 +3699,7 @@ dump_mcontext(priv_mcontext_t *context, file_t f, bool dump_xml)
             }
         });
     }
-#elif defined(ARM)
+#elif defined(AARCHXX)
     {
         int i, j;
         /* XXX: should be proc_num_simd_saved(). */


### PR DESCRIPTION
Fixes some ARM defines to be AARCHXX to enable printing AArch64
register values in dump_mcontext().