### PR TITLE
i#4495: Preserve translated stolen register

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -3717,6 +3717,8 @@ thread_get_mcontext(thread_record_t *tr, priv_mcontext_t *mc)
         return false;
     ASSERT(ostd->suspended_sigcxt != NULL);
     sigcontext_to_mcontext(mc, ostd->suspended_sigcxt, DR_MC_ALL);
+    IF_ARM(dr_set_isa_mode(tr->dcontext, get_sigcontext_isa_mode(ostd->suspended_sigcxt),
+                           NULL));
     return true;
 }
 
@@ -3733,6 +3735,8 @@ thread_set_mcontext(thread_record_t *tr, priv_mcontext_t *mc)
         return false;
     ASSERT(ostd->suspended_sigcxt != NULL);
     mcontext_to_sigcontext(ostd->suspended_sigcxt, mc, DR_MC_ALL);
+    IF_ARM(
+        set_sigcontext_isa_mode(ostd->suspended_sigcxt, dr_get_isa_mode(tr->dcontext)));
     return true;
 }
 

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -418,6 +418,13 @@ void
 set_clone_record_fields(void *record, reg_t app_thread_xsp, app_pc continuation_pc,
                         uint clone_sysnum, uint clone_flags);
 
+#ifdef ARM
+dr_isa_mode_t
+get_sigcontext_isa_mode(sig_full_cxt_t *sc_full);
+void
+set_sigcontext_isa_mode(sig_full_cxt_t *sc_full, dr_isa_mode_t isa_mode);
+#endif
+
 /* in pcprofile.c */
 void
 pcprofile_thread_init(dcontext_t *dcontext, bool shared_itimer, void *parent_info);

--- a/core/unix/os_public.h
+++ b/core/unix/os_public.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -139,6 +139,7 @@ typedef kernel_sigcontext_t sigcontext_t;
 #    define SC_R0 SC_FIELD(regs[0])
 #    define SC_R1 SC_FIELD(regs[1])
 #    define SC_R2 SC_FIELD(regs[2])
+#    define SC_R28 SC_FIELD(regs[28])
 #    define SC_LR SC_FIELD(regs[30])
 #    define SC_XSP SC_FIELD(sp)
 #    define SC_XFLAGS SC_FIELD(pstate)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2754,6 +2754,11 @@ if (CLIENT_INTERFACE)
     set(DynamoRIO_SET_PREFERRED_BASE OFF)
   endif (X86)
 
+  if (AARCHXX)
+    tobuild_ci(client.stolen-reg client-interface/stolen-reg.c "" "" "")
+    link_with_pthread(client.stolen-reg)
+  endif ()
+
   if (ARM AND NOT ANDROID)
     # i#2580: DT_RUNPATH is not yet supported on android so we disable this test on
     # android

--- a/suite/tests/client-interface/stolen-reg.c
+++ b/suite/tests/client-interface/stolen-reg.c
@@ -104,7 +104,7 @@ cause_sigsegv(void)
 {
     uintptr_t val = 0;
     /* Generate SIGSEGV with a sentinel in the stolen reg.
-     * This precise instruction sequence is matched by the client.
+     * This precise instruction sequence is matched by the stolen-reg.dll.c client.
      */
 #if defined(AARCH64)
     __asm__ __volatile__("mov x28, #" STRINGIFY(STOLEN_REG_SENTINEL) "\n\t"
@@ -131,7 +131,7 @@ cause_sigsegv(void)
 THREAD_FUNC_RETURN_TYPE
 thread_func(void *arg)
 {
-    /* The client looks for this exact sequence of instructions. */
+    /* The stolen-reg.dll.c client looks for this exact sequence of instructions. */
 #if defined(AARCH64)
     __asm__ __volatile__("mov x28, #" STRINGIFY(STOLEN_REG_SENTINEL) "\n\t"
                                                                      "nop\n\t"
@@ -182,7 +182,7 @@ main(int argc, char **argv)
 
     /* Now test synchall from another thread (the initiating thread does not
      * hit the i#4495 issue).
-     * The client looks for this exact sequence of instructions.
+     * The stolen-reg.dll.c client looks for this exact sequence of instructions.
      */
 #if defined(AARCH64)
     __asm__ __volatile__("mov x28, #" STRINGIFY(STOLEN_REG_SENTINEL) "\n\t"

--- a/suite/tests/client-interface/stolen-reg.c
+++ b/suite/tests/client-interface/stolen-reg.c
@@ -1,0 +1,218 @@
+/* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/*
+ * API regression test for stolen register translation.
+ */
+
+#include "tools.h"
+#include "thread.h"
+#include <stdio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdint.h> /* uintptr_t */
+#include <ucontext.h>
+
+#define STOLEN_REG_SENTINEL 42
+
+/* We assume a single thread when these are used. */
+static SIGJMP_BUF mark;
+static int sigsegv_count;
+
+static volatile int thread_finished;
+
+static uintptr_t
+get_stolen_reg_val(void)
+{
+    uintptr_t val = 0;
+#if defined(AARCH64)
+    __asm__ __volatile__("str x28, %0\n\t" : "=m"(val) : :);
+#elif defined(ARM)
+    __asm__ __volatile__("str r10, %0\n\t" : "=m"(val) : :);
+#else
+#    error Unsupported arch
+#endif
+    return val;
+}
+
+/* This can't be a regular function since the stolen reg is callee-saved. */
+#if defined(AARCH64)
+#    define SET_STOLEN_REG_TO_SENTINEL() \
+        __asm__ __volatile__("mov x28, #" STRINGIFY(STOLEN_REG_SENTINEL) : : : "x28")
+#elif defined(ARM)
+#    define SET_STOLEN_REG_TO_SENTINEL() \
+        __asm__ __volatile__("mov r10, #" STRINGIFY(STOLEN_REG_SENTINEL) : : : "r10")
+#else
+#    error Unsupported arch
+#endif
+
+static void
+signal_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
+{
+    if (sig != SIGSEGV)
+        return;
+    print("Got SIGSEGV\n");
+    uintptr_t val = get_stolen_reg_val();
+    if (val != STOLEN_REG_SENTINEL) {
+        print("ERROR: Stolen register %d not preserved on handler entry: %d\n",
+              STOLEN_REG_SENTINEL, val);
+    }
+    sigcontext_t *sc = SIGCXT_FROM_UCXT(ucxt);
+    if (sc->IF_ARM_ELSE(SC_R10, SC_R28) != STOLEN_REG_SENTINEL) {
+        print("ERROR: Stolen register %d not preserved in signal context: %d\n",
+              STOLEN_REG_SENTINEL, sc->IF_ARM_ELSE(SC_R10, SC_R28));
+    }
+    if (sigsegv_count == 0) {
+        /* Allow re-execution to no longer fault. */
+        sc->SC_R0 = sc->SC_XSP;
+    } else {
+        SIGLONGJMP(mark, 1);
+    }
+}
+
+static uintptr_t
+cause_sigsegv(void)
+{
+    uintptr_t val = 0;
+    /* Generate SIGSEGV with a sentinel in the stolen reg.
+     * This precise instruction sequence is matched by the client.
+     */
+#if defined(AARCH64)
+    __asm__ __volatile__("mov x28, #" STRINGIFY(STOLEN_REG_SENTINEL) "\n\t"
+                                                                     "mov x0, #0\n\t"
+                                                                     "ldr x1, [x0]\n\t"
+                                                                     "str x28, %0\n\t"
+                         : "=m"(val)
+                         :
+                         : "x0", "x1", "x28");
+#elif defined(ARM)
+    __asm__ __volatile__("mov r10, #" STRINGIFY(STOLEN_REG_SENTINEL) "\n\t"
+                                                                     "mov r0, #0\n\t"
+                                                                     "ldr r1, [r0]\n\t"
+                                                                     "str r10, %0\n\t"
+                         : "=m"(val)
+                         :
+                         : "r0", "r1", "r10");
+#else
+#    error Unsupported arch
+#endif
+    return val;
+}
+
+THREAD_FUNC_RETURN_TYPE
+thread_func(void *arg)
+{
+    /* The client looks for this exact sequence of instructions. */
+#if defined(AARCH64)
+    __asm__ __volatile__("mov x28, #" STRINGIFY(STOLEN_REG_SENTINEL) "\n\t"
+                                                                     "nop\n\t"
+                                                                     "nop\n\t"
+                         :
+                         :
+                         : "x28");
+#elif defined(ARM)
+    __asm__ __volatile__("mov r10, #" STRINGIFY(STOLEN_REG_SENTINEL) "\n\t"
+                                                                     "nop\n\t"
+                                                                     "nop\n\t"
+                         :
+                         :
+                         : "r10");
+#else
+#    error Unsupported arch
+#endif
+    thread_finished = 1;
+    return THREAD_FUNC_RETURN_ZERO;
+}
+
+int
+main(int argc, char **argv)
+{
+    intercept_signal(SIGSEGV, signal_handler, false);
+
+    /* First, raise SIGSEGV and continue at the same context. */
+    uintptr_t val = cause_sigsegv();
+    if (val != STOLEN_REG_SENTINEL) {
+        print("ERROR: Stolen register %d not preserved past handler: %d\n",
+              STOLEN_REG_SENTINEL, val);
+    }
+    /* Now, raise SIGSEGV and longjmp from the handler. */
+    ++sigsegv_count;
+    /* We assume the stolen register doesn't change between our inlined asm and
+     * later C code.  If necessary we could put the whole thing in asm but that
+     * does not seem needed.
+     */
+    SET_STOLEN_REG_TO_SENTINEL();
+    if (SIGSETJMP(mark) == 0) {
+        cause_sigsegv();
+    }
+    val = get_stolen_reg_val();
+    if (val != STOLEN_REG_SENTINEL) {
+        print("ERROR: Stolen register %d not preserved past longjmp: %d\n",
+              STOLEN_REG_SENTINEL, val);
+    }
+
+    /* Now test synchall from another thread (the initiating thread does not
+     * hit the i#4495 issue).
+     * The client looks for this exact sequence of instructions.
+     */
+#if defined(AARCH64)
+    __asm__ __volatile__("mov x28, #" STRINGIFY(STOLEN_REG_SENTINEL) "\n\t"
+                                                                     "mov x0, #0\n\t"
+                                                                     "nop\n\t"
+                         :
+                         :
+                         : "x0", "x28");
+#elif defined(ARM)
+    __asm__ __volatile__("mov r10, #" STRINGIFY(STOLEN_REG_SENTINEL) "\n\t"
+                                                                     "mov r0, #0\n\t"
+                                                                     "nop\n\t"
+                         :
+                         :
+                         : "r0", "r10");
+#else
+#    error Unsupported arch
+#endif
+    thread_t thread = create_thread(thread_func, NULL);
+    while (!thread_finished) {
+        /* We need to ensure we're *translated* which won't always happen if we're sitting
+         * at a syscall.  So we deliberately spin.
+         */
+    }
+    join_thread(thread);
+    val = get_stolen_reg_val();
+    if (val != STOLEN_REG_SENTINEL) {
+        print("ERROR: Stolen register %d not preserved past synchall: %d\n",
+              STOLEN_REG_SENTINEL, val);
+    }
+
+    print("Done\n");
+}

--- a/suite/tests/client-interface/stolen-reg.dll.c
+++ b/suite/tests/client-interface/stolen-reg.dll.c
@@ -1,0 +1,138 @@
+/* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/*
+ * API regression test for stolen register translation.
+ */
+
+#include "dr_api.h"
+#include "client_tools.h"
+
+#define BAD_VALUE 0xdeadbeef
+
+/* We assume the app is single-threaded and don't worry about races. */
+static ptr_int_t app_stolen_reg_val;
+
+static void
+restore_event(void *drcontext, void *tag, dr_mcontext_t *mcontext, bool restore_memory,
+              bool app_code_consistent)
+{
+    dr_log(drcontext, DR_LOG_ALL, 2, "Changing the stolen reg value from %ld to %ld\n",
+           mcontext->IF_ARM_ELSE(r10, r28), app_stolen_reg_val);
+    mcontext->IF_ARM_ELSE(r10, r28) = app_stolen_reg_val;
+}
+
+static void
+do_flush(app_pc next_pc)
+{
+    dr_fprintf(STDERR, "Performing synchall flush\n");
+    if (!dr_flush_region(NULL, ~0UL))
+        DR_ASSERT(false);
+    void *drcontext = dr_get_current_drcontext();
+    dr_mcontext_t mcontext;
+    mcontext.size = sizeof(mcontext);
+    mcontext.flags = DR_MC_ALL;
+    dr_get_mcontext(drcontext, &mcontext);
+    mcontext.pc = dr_app_pc_as_jump_target(dr_get_isa_mode(drcontext), next_pc);
+    dr_redirect_execution(&mcontext);
+    DR_ASSERT(false);
+}
+
+static dr_emit_flags_t
+bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool translating)
+{
+    instr_t *instr, *next_instr, *next_next_instr;
+    for (instr = instrlist_first(bb); instr != NULL; instr = next_instr) {
+        next_instr = instr_get_next(instr);
+        if (next_instr != NULL)
+            next_next_instr = instr_get_next(next_instr);
+        else
+            next_next_instr = NULL;
+        /* Look for the sentinel-SIGSEGV sequence from the app.
+         * Look for "mov <stolen-reg>, <const>; mov r0, <const>; ldr rx, [r0].
+         */
+        ptr_int_t stolen_val, substitute_val;
+        if (instr_is_mov_constant(instr, &stolen_val) &&
+            opnd_is_reg(instr_get_dst(instr, 0)) &&
+            opnd_get_reg(instr_get_dst(instr, 0)) == dr_get_stolen_reg() &&
+            next_instr != NULL && instr_is_mov_constant(next_instr, &substitute_val) &&
+            substitute_val != stolen_val && opnd_is_reg(instr_get_dst(next_instr, 0)) &&
+            opnd_get_reg(instr_get_dst(next_instr, 0)) == DR_REG_R0 &&
+            next_next_instr != NULL && instr_reads_memory(next_next_instr) &&
+            opnd_is_base_disp(instr_get_src(next_next_instr, 0)) &&
+            opnd_get_base(instr_get_src(next_next_instr, 0)) == DR_REG_R0) {
+            /* Now change the stolen reg value to be r0's value, before the crash. */
+            dr_log(drcontext, DR_LOG_ALL, 2, "Setting stolen reg val in block %p\n", tag);
+            app_stolen_reg_val = stolen_val;
+            dr_insert_set_stolen_reg_value(drcontext, bb, next_next_instr, DR_REG_R0);
+            break;
+        }
+        /* Look for the sentinel-nop sequence prior to 2nd thread creation.
+         * Look for "mov <stolen-reg>, <const>; mov r0, <const>; nop.
+         */
+        if (instr_is_mov_constant(instr, &stolen_val) &&
+            opnd_is_reg(instr_get_dst(instr, 0)) &&
+            opnd_get_reg(instr_get_dst(instr, 0)) == dr_get_stolen_reg() &&
+            next_instr != NULL && instr_is_mov_constant(next_instr, &substitute_val) &&
+            substitute_val != stolen_val && opnd_is_reg(instr_get_dst(next_instr, 0)) &&
+            opnd_get_reg(instr_get_dst(next_instr, 0)) == DR_REG_R0 &&
+            next_next_instr != NULL && instr_is_nop(next_next_instr)) {
+            /* Change the stolen reg value. */
+            dr_log(drcontext, DR_LOG_ALL, 2, "Setting stolen reg val in block %p\n", tag);
+            app_stolen_reg_val = stolen_val;
+            dr_insert_set_stolen_reg_value(drcontext, bb, next_next_instr, DR_REG_R0);
+            break;
+        }
+        /* Look for the sentinel-nop sequence from the app's 2nd thread.
+         * Look for "mov <stolen-reg>, <const>; nop; nop.
+         */
+        if (instr_is_mov_constant(instr, &stolen_val) &&
+            opnd_is_reg(instr_get_dst(instr, 0)) &&
+            opnd_get_reg(instr_get_dst(instr, 0)) == dr_get_stolen_reg() &&
+            next_instr != NULL && instr_is_nop(next_instr) && next_next_instr != NULL &&
+            instr_is_nop(next_next_instr)) {
+            dr_insert_clean_call(
+                drcontext, bb, next_next_instr, (void *)do_flush, false /*fpstate */, 1,
+                OPND_CREATE_INTPTR((ptr_uint_t)instr_get_app_pc(next_next_instr)));
+            break;
+        }
+    }
+    return DR_EMIT_DEFAULT;
+}
+
+DR_EXPORT
+void
+dr_init(client_id_t id)
+{
+    dr_register_bb_event(bb_event);
+    dr_register_restore_state_event(restore_event);
+}

--- a/suite/tests/client-interface/stolen-reg.expect
+++ b/suite/tests/client-interface/stolen-reg.expect
@@ -1,0 +1,4 @@
+Got SIGSEGV
+Got SIGSEGV
+Performing synchall flush
+Done


### PR DESCRIPTION
Currently, a stolen register value that is translated by a client is
discarded both in a synchall and a synchronous signal.  We fix both
paths here.

Adds a new test client.stolen-reg which tests both a synchronous fault
signal translation path as well as a synchall translation path via a
synchall flush.  The test was confirmed to fail without either of the
fixes in place.

Ensures the new test passes on 32-bit ARM.  This exercised the
translate_from_synchall_to_dispatch() path and found some ARM bugs:
the reset exit stub is A32 mode, so we need to change the mode for the
suspended sigcontext; yet thread_set_mcontext() did not support that.
That is all fixed now and verified.

Fixes #4495