### PR TITLE
i#4527: Set ISA mode for drcachesim flush redirect PC

### DIFF
--- a/api/samples/cbr.c
+++ b/api/samples/cbr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -257,7 +257,7 @@ at_taken(app_pc src, app_pc targ)
      */
     dr_flush_region(src, 1);
     dr_get_mcontext(drcontext, &mcontext);
-    mcontext.pc = targ;
+    mcontext.pc = dr_app_pc_as_jump_target(dr_get_isa_mode(drcontext), targ);
     dr_redirect_execution(&mcontext);
 }
 

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1403,11 +1403,12 @@ hit_instr_count_threshold(app_pc next_pc)
                                 NULL /*user_data*/))
             DR_ASSERT(false);
 
+        void *drcontext = dr_get_current_drcontext();
         dr_mcontext_t mcontext;
         mcontext.size = sizeof(mcontext);
         mcontext.flags = DR_MC_ALL;
-        dr_get_mcontext(dr_get_current_drcontext(), &mcontext);
-        mcontext.pc = next_pc;
+        dr_get_mcontext(drcontext, &mcontext);
+        mcontext.pc = dr_app_pc_as_jump_target(dr_get_isa_mode(drcontext), next_pc);
         dr_redirect_execution(&mcontext);
         DR_ASSERT(false);
     }

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -5896,6 +5896,12 @@ DR_API
  * The flags field of \p context must contain DR_MC_ALL; using a partial set
  * of fields is not suported.
  *
+ * For 32-bit ARM, be sure to use dr_app_pc_as_jump_target() to properly set the ISA
+ * mode for the continuation pc if it was obtained from instr_get_app_pc() or a
+ * similar source rather than from dr_get_proc_address().  This will set the least
+ * significant bit of the mcontext pc field to 1 when in Thumb mode
+ * (#DR_ISA_ARM_THUMB), \ref sec_thumb for more information.
+ *
  * \note dr_get_mcontext() can be used to get the register state (except pc)
  * saved in dr_insert_clean_call() or dr_prepare_for_call().
  *
@@ -5917,10 +5923,6 @@ DR_API
  * called from any registered event callback except the exception event
  * (dr_register_exception_event()).  From a signal event callback, use the
  * #DR_SIGNAL_REDIRECT return value rather than calling this routine.
- *
- * \note For ARM, to redirect execution to a Thumb target (#DR_ISA_ARM_THUMB),
- * set the least significant bit of the mcontext pc to 1. Reference
- * \ref sec_thumb for more information.
  *
  * \return false if unsuccessful; if successful, does not return.
  */
@@ -6219,8 +6221,6 @@ DR_API
  * have been flushed. The context to use can be obtained via
  * dr_get_mcontext() with the exception of the pc to continue at which must be passed as
  * an argument to the callout (see instr_get_app_pc()) or otherwise determined.
- * For 32-bit ARM, be sure to use dr_app_pc_as_jump_target() to properly set the ISA
- * mode for the continuation pc.
  *
  * \note This routine may not be called while any locks are held that could block a thread
  * processing a registered event callback or cache callout.

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -6219,6 +6219,8 @@ DR_API
  * have been flushed. The context to use can be obtained via
  * dr_get_mcontext() with the exception of the pc to continue at which must be passed as
  * an argument to the callout (see instr_get_app_pc()) or otherwise determined.
+ * For 32-bit ARM, be sure to use dr_app_pc_as_jump_target() to properly set the ISA
+ * mode for the continuation pc.
  *
  * \note This routine may not be called while any locks are held that could block a thread
  * processing a registered event callback or cache callout.

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -1199,7 +1199,9 @@ drbbdup_prepare_redirect(dr_mcontext_t *mcontext, drbbdup_manager_t *manager,
                       (reg_t)drbbdup_get_tls_raw_slot_val(DRBBDUP_XAX_REG_SLOT));
     }
 
-    mcontext->pc = bb_pc; /* redirect execution to the start of the bb. */
+    mcontext->pc =
+        dr_app_pc_as_jump_target(dr_get_isa_mode(dr_get_current_drcontext()),
+                                 bb_pc); /* redirect execution to the start of the bb. */
 }
 
 static void

--- a/suite/tests/client-interface/cbr3.dll.c
+++ b/suite/tests/client-interface/cbr3.dll.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -231,7 +232,7 @@ at_taken(app_pc src, app_pc targ)
      */
     dr_flush_region(src, 1);
     dr_get_mcontext(drcontext, &mcontext);
-    mcontext.pc = targ;
+    mcontext.pc = dr_app_pc_as_jump_target(dr_get_isa_mode(drcontext), targ);
     dr_redirect_execution(&mcontext);
 }
 

--- a/suite/tests/client-interface/flush.dll.c
+++ b/suite/tests/client-interface/flush.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -199,8 +199,9 @@ callback(void *tag, app_pc next_pc)
             mcontext.size = sizeof(mcontext);
             mcontext.flags = DR_MC_ALL;
             dr_delay_flush_region((app_pc)tag - 20, 30, callback_count, flush_event);
-            dr_get_mcontext(dr_get_current_drcontext(), &mcontext);
-            mcontext.pc = next_pc;
+            void *drcontext = dr_get_current_drcontext();
+            dr_get_mcontext(drcontext, &mcontext);
+            mcontext.pc = dr_app_pc_as_jump_target(dr_get_isa_mode(drcontext), next_pc);
             dr_flush_region_ex(tag, 1, synch_flush_completion_callback, &callback_count);
             dr_redirect_execution(&mcontext);
             *(volatile uint *)NULL = 0; /* ASSERT_NOT_REACHED() */


### PR DESCRIPTION
Fixes drcachesim delayed tracing which was broken by commit 72275ad
for #4496 via PR #4507.  The fix is to decorate the target PC to
indicate the ISA mode.

Adds a reminder to the dr_flush_region_ex() documentation where it
talks about using dr_redirect_execution() to set the ISA mode.

Tested on ARM:
$ bin32/drrun -t drcachesim -trace_after_instrs 20000 -- suite/tests/bin/simple_app

Fixes #4527