### PR TITLE
i#4542: Allow XINST_CREATE_sub with sp source on A64

### DIFF
--- a/core/ir/aarch64/instr_create.h
+++ b/core/ir/aarch64/instr_create.h
@@ -466,8 +466,10 @@ enum {
  */
 
 /** \cond disabled_until_i4106_is_fixed */
-#define INSTR_CREATE_add(dc, rd, rn, rm_or_imm) \
-    INSTR_CREATE_add_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(), OPND_CREATE_INT(0))
+#define INSTR_CREATE_add(dc, rd, rn, rm_or_imm)                                     \
+    /* _extend supports sp in rn, so prefer it. */                                  \
+    INSTR_CREATE_add_extend(dc, rd, rn, rm_or_imm, OPND_CREATE_INT(DR_EXTEND_UXTX), \
+                            OPND_CREATE_INT(0))
 #define INSTR_CREATE_add_extend(dc, rd, rn, rm, ext, exa)                             \
     instr_create_1dst_4src(dc, OP_add, rd, rn,                                        \
                            opnd_create_reg_ex(opnd_get_reg(rm), 0, DR_OPND_EXTENDED), \
@@ -595,8 +597,10 @@ enum {
 #define INSTR_CREATE_strh(dc, mem, rt) instr_create_1dst_1src(dc, OP_strh, mem, rt)
 #define INSTR_CREATE_stur(dc, mem, rt) instr_create_1dst_1src(dc, OP_stur, mem, rt)
 #define INSTR_CREATE_sturh(dc, mem, rt) instr_create_1dst_1src(dc, OP_sturh, mem, rt)
-#define INSTR_CREATE_sub(dc, rd, rn, rm_or_imm) \
-    INSTR_CREATE_sub_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(), OPND_CREATE_INT(0))
+#define INSTR_CREATE_sub(dc, rd, rn, rm_or_imm)                                     \
+    /* _extend supports sp in rn, so prefer it. */                                  \
+    INSTR_CREATE_sub_extend(dc, rd, rn, rm_or_imm, OPND_CREATE_INT(DR_EXTEND_UXTX), \
+                            OPND_CREATE_INT(0))
 #define INSTR_CREATE_sub_extend(dc, rd, rn, rm, ext, exa)                             \
     instr_create_1dst_4src(dc, OP_sub, rd, rn,                                        \
                            opnd_create_reg_ex(opnd_get_reg(rm), 0, DR_OPND_EXTENDED), \

--- a/core/ir/aarch64/instr_create.h
+++ b/core/ir/aarch64/instr_create.h
@@ -466,10 +466,13 @@ enum {
  */
 
 /** \cond disabled_until_i4106_is_fixed */
-#define INSTR_CREATE_add(dc, rd, rn, rm_or_imm)                                     \
-    /* _extend supports sp in rn, so prefer it. */                                  \
-    INSTR_CREATE_add_extend(dc, rd, rn, rm_or_imm, OPND_CREATE_INT(DR_EXTEND_UXTX), \
-                            OPND_CREATE_INT(0))
+#define INSTR_CREATE_add(dc, rd, rn, rm_or_imm)                                         \
+    opnd_is_reg(rm_or_imm)                                                              \
+        ? /* _extend supports sp in rn, so prefer it, but it does not support imm. */   \
+        INSTR_CREATE_add_extend(dc, rd, rn, rm_or_imm, OPND_CREATE_INT(DR_EXTEND_UXTX), \
+                                OPND_CREATE_INT(0))                                     \
+        : INSTR_CREATE_add_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(),              \
+                                 OPND_CREATE_INT(0))
 #define INSTR_CREATE_add_extend(dc, rd, rn, rm, ext, exa)                             \
     instr_create_1dst_4src(dc, OP_add, rd, rn,                                        \
                            opnd_create_reg_ex(opnd_get_reg(rm), 0, DR_OPND_EXTENDED), \
@@ -597,10 +600,13 @@ enum {
 #define INSTR_CREATE_strh(dc, mem, rt) instr_create_1dst_1src(dc, OP_strh, mem, rt)
 #define INSTR_CREATE_stur(dc, mem, rt) instr_create_1dst_1src(dc, OP_stur, mem, rt)
 #define INSTR_CREATE_sturh(dc, mem, rt) instr_create_1dst_1src(dc, OP_sturh, mem, rt)
-#define INSTR_CREATE_sub(dc, rd, rn, rm_or_imm)                                     \
-    /* _extend supports sp in rn, so prefer it. */                                  \
-    INSTR_CREATE_sub_extend(dc, rd, rn, rm_or_imm, OPND_CREATE_INT(DR_EXTEND_UXTX), \
-                            OPND_CREATE_INT(0))
+#define INSTR_CREATE_sub(dc, rd, rn, rm_or_imm)                                         \
+    opnd_is_reg(rm_or_imm)                                                              \
+        ? /* _extend supports sp in rn, so prefer it, but it does not support imm. */   \
+        INSTR_CREATE_sub_extend(dc, rd, rn, rm_or_imm, OPND_CREATE_INT(DR_EXTEND_UXTX), \
+                                OPND_CREATE_INT(0))                                     \
+        : INSTR_CREATE_sub_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(),              \
+                                 OPND_CREATE_INT(0))
 #define INSTR_CREATE_sub_extend(dc, rd, rn, rm, ext, exa)                             \
     instr_create_1dst_4src(dc, OP_sub, rd, rn,                                        \
                            opnd_create_reg_ex(opnd_get_reg(rm), 0, DR_OPND_EXTENDED), \

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -148,6 +148,16 @@ test_add(void *dc)
                               opnd_create_reg(DR_REG_X2));
     test_instr_encoding(dc, OP_adcs, instr);
 
+    /* Add to sp (tests shift vs extend). */
+    instr = INSTR_CREATE_add(dc, opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_SP),
+                             opnd_create_reg(DR_REG_X1));
+    test_instr_encoding(dc, OP_add, instr);
+
+    /* Sub from sp (tests shift vs extend). */
+    instr = INSTR_CREATE_sub(dc, opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_SP),
+                             opnd_create_reg(DR_REG_X1));
+    test_instr_encoding(dc, OP_sub, instr);
+
 /* Add and set flags (shifted register, 32-bit)
  * ADDS <Wd>, <Wn>, <Wm>{, <shift> #<amount>}
  */

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -3,6 +3,8 @@ adc    %w1 %w2 -> %w0
 adc    %x1 %x2 -> %x0
 adcs   %w1 %w2 -> %w0
 adcs   %x1 %x2 -> %x0
+add    %sp %x1 uxtx $0x0000000000000000 -> %x0
+sub    %sp %x1 uxtx $0x0000000000000000 -> %x0
 adds   %w1 %w2 lsl $0x00 -> %w0
 adds   %w1 %w2 lsl $0x1f -> %w0
 adds   %w1 %w2 lsr $0x00 -> %w0


### PR DESCRIPTION
Adds a fix allowing the 'sp' register as the first source operand of
an ADD or SUB by using the extended-register rather than
shifted-register form on AArch64.

Adds a test which fails without the fix.

Fixes #4542