### PR TITLE
i#1698 ldstex: Add exclusive memop create and query support

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -176,6 +176,7 @@ Further non-compatibility-affecting changes include:
  - Added dr_flush_region_ex API that accepts a callback to be executed after synch
    flush but before the threads are resumed. The existing dr_flush_region API
    is modified to invoke dr_flush_region_ex with a NULL callback.
+ - Added instr_is_exclusive_load().
 
 **************************************************
 <hr>

--- a/core/ir/aarch64/build_ldstex.c
+++ b/core/ir/aarch64/build_ldstex.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2020 Google, Inc. All rights reserved.
  * Copyright (c) 2017 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -59,22 +60,6 @@
 #include "instr_create.h"
 
 #include "build_ldstex.h"
-
-static bool
-instr_is_exclusive_load(instr_t *instr)
-{
-    switch (instr_get_opcode(instr)) {
-    case OP_ldaxp:
-    case OP_ldaxr:
-    case OP_ldaxrb:
-    case OP_ldaxrh:
-    case OP_ldxp:
-    case OP_ldxr:
-    case OP_ldxrb:
-    case OP_ldxrh: return true;
-    }
-    return false;
-}
 
 static bool
 instr_is_nonbranch_pcrel(instr_t *instr)

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -445,6 +445,23 @@ instr_writes_thread_register(instr_t *instr)
     return (instr_get_opcode(instr) == OP_msr && instr_num_dsts(instr) == 1 &&
             opnd_is_reg(instr_get_dst(instr, 0)) &&
             opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_TPIDR_EL0);
+}
+
+DR_API
+bool
+instr_is_exclusive_load(instr_t *instr)
+{
+    switch (instr_get_opcode(instr)) {
+    case OP_ldaxp:
+    case OP_ldaxr:
+    case OP_ldaxrb:
+    case OP_ldaxrh:
+    case OP_ldxp:
+    case OP_ldxr:
+    case OP_ldxrb:
+    case OP_ldxrh: return true;
+    }
+    return false;
 }
 
 DR_API

--- a/core/ir/aarch64/instr_create.h
+++ b/core/ir/aarch64/instr_create.h
@@ -466,8 +466,10 @@ enum {
  */
 
 /** \cond disabled_until_i4106_is_fixed */
-#define INSTR_CREATE_add(dc, rd, rn, rm_or_imm) \
-    INSTR_CREATE_add_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(), OPND_CREATE_INT(0))
+#define INSTR_CREATE_add(dc, rd, rn, rm_or_imm)                                     \
+    /* _extend supports sp in rn, so prefer it. */                                  \
+    INSTR_CREATE_add_extend(dc, rd, rn, rm_or_imm, OPND_CREATE_INT(DR_EXTEND_UXTX), \
+                            OPND_CREATE_INT(0))
 #define INSTR_CREATE_add_extend(dc, rd, rn, rm, ext, exa)                             \
     instr_create_1dst_4src(dc, OP_add, rd, rn,                                        \
                            opnd_create_reg_ex(opnd_get_reg(rm), 0, DR_OPND_EXTENDED), \
@@ -595,8 +597,10 @@ enum {
 #define INSTR_CREATE_strh(dc, mem, rt) instr_create_1dst_1src(dc, OP_strh, mem, rt)
 #define INSTR_CREATE_stur(dc, mem, rt) instr_create_1dst_1src(dc, OP_stur, mem, rt)
 #define INSTR_CREATE_sturh(dc, mem, rt) instr_create_1dst_1src(dc, OP_sturh, mem, rt)
-#define INSTR_CREATE_sub(dc, rd, rn, rm_or_imm) \
-    INSTR_CREATE_sub_shift(dc, rd, rn, rm_or_imm, OPND_CREATE_LSL(), OPND_CREATE_INT(0))
+#define INSTR_CREATE_sub(dc, rd, rn, rm_or_imm)                                     \
+    /* _extend supports sp in rn, so prefer it. */                                  \
+    INSTR_CREATE_sub_extend(dc, rd, rn, rm_or_imm, OPND_CREATE_INT(DR_EXTEND_UXTX), \
+                            OPND_CREATE_INT(0))
 #define INSTR_CREATE_sub_extend(dc, rd, rn, rm, ext, exa)                             \
     instr_create_1dst_4src(dc, OP_sub, rd, rn,                                        \
                            opnd_create_reg_ex(opnd_get_reg(rm), 0, DR_OPND_EXTENDED), \

--- a/core/ir/aarch64/instr_create.h
+++ b/core/ir/aarch64/instr_create.h
@@ -578,6 +578,36 @@ enum {
     instr_create_1dst_1src((dc), OP_ldarb, (Rt), (mem))
 #define INSTR_CREATE_ldarh(dc, Rt, mem) \
     instr_create_1dst_1src((dc), OP_ldarh, (Rt), (mem))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_ldxr(dc, Rd, mem)                                        \
+    instr_create_1dst_3src((dc), OP_ldxr, (Rd), (mem), OPND_CREATE_INT(0x1f), \
+                           OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_ldxrb(dc, Rd, mem)                                        \
+    instr_create_1dst_3src((dc), OP_ldxrb, (Rd), (mem), OPND_CREATE_INT(0x1f), \
+                           OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_ldxrh(dc, Rd, mem)                                        \
+    instr_create_1dst_3src((dc), OP_ldxrh, (Rd), (mem), OPND_CREATE_INT(0x1f), \
+                           OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_ldxp(dc, rt1, rt2, mem) \
+    instr_create_2dst_2src((dc), OP_ldxp, rt1, rt2, (mem), OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_ldaxr(dc, Rd, mem)                                        \
+    instr_create_1dst_3src((dc), OP_ldaxr, (Rd), (mem), OPND_CREATE_INT(0x1f), \
+                           OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_ldaxrb(dc, Rd, mem)                                        \
+    instr_create_1dst_3src((dc), OP_ldaxrb, (Rd), (mem), OPND_CREATE_INT(0x1f), \
+                           OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_ldaxrh(dc, Rd, mem)                                        \
+    instr_create_1dst_3src((dc), OP_ldaxrh, (Rd), (mem), OPND_CREATE_INT(0x1f), \
+                           OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_ldaxp(dc, rt1, rt2, mem) \
+    instr_create_2dst_2src((dc), OP_ldaxp, rt1, rt2, (mem), OPND_CREATE_INT(0x1f))
 #define INSTR_CREATE_movk(dc, rt, imm16, lsl) \
     instr_create_1dst_4src(dc, OP_movk, rt, rt, imm16, OPND_CREATE_LSL(), lsl)
 #define INSTR_CREATE_movn(dc, rt, imm16, lsl) \
@@ -597,6 +627,30 @@ enum {
 #define INSTR_CREATE_strh(dc, mem, rt) instr_create_1dst_1src(dc, OP_strh, mem, rt)
 #define INSTR_CREATE_stur(dc, mem, rt) instr_create_1dst_1src(dc, OP_stur, mem, rt)
 #define INSTR_CREATE_sturh(dc, mem, rt) instr_create_1dst_1src(dc, OP_sturh, mem, rt)
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_stxr(dc, mem, rs, rt) \
+    instr_create_2dst_2src(dc, OP_stxr, mem, rs, rt, OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_stxrb(dc, mem, rs, rt) \
+    instr_create_2dst_2src(dc, OP_stxrb, mem, rs, rt, OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_stxrh(dc, mem, rs, rt) \
+    instr_create_2dst_2src(dc, OP_stxrh, mem, rs, rt, OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_stxp(dc, mem, rs, rt1, rt2) \
+    instr_create_2dst_2src(dc, OP_stxp, mem, rs, rt1, rt2)
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_stlxr(dc, mem, rs, rt) \
+    instr_create_2dst_2src(dc, OP_stlxr, mem, rs, rt, OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_stlxrb(dc, mem, rs, rt) \
+    instr_create_2dst_2src(dc, OP_stlxrb, mem, rs, rt, OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_stlxrh(dc, mem, rs, rt) \
+    instr_create_2dst_2src(dc, OP_stlxrh, mem, rs, rt, OPND_CREATE_INT(0x1f))
+/* TODO i#4532: Remove these superfluous 0x1f non-operands. */
+#define INSTR_CREATE_stlxp(dc, mem, rs, rt1, rt2) \
+    instr_create_2dst_2src(dc, OP_stlxp, mem, rs, rt1, rt2)
 #define INSTR_CREATE_sub(dc, rd, rn, rm_or_imm)                                     \
     /* _extend supports sp in rn, so prefer it. */                                  \
     INSTR_CREATE_sub_extend(dc, rd, rn, rm_or_imm, OPND_CREATE_INT(DR_EXTEND_UXTX), \
@@ -630,6 +684,12 @@ enum {
 #define INSTR_CREATE_adrp(dc, rt, imm) instr_create_1dst_1src(dc, OP_adrp, rt, imm)
 
 #define INSTR_CREATE_sys(dc, op, Rn) instr_create_0dst_2src(dc, OP_sys, op, Rn)
+
+/**
+ * Creates a CLREX instruction.
+ * \param dc   The void * dcontext used to allocate memory for the instr_t.
+ */
+#define INSTR_CREATE_clrex(dc) instr_create_0dst_0src(dc, OP_clrex)
 
 /* FIXME i#1569: these two should perhaps not be provided */
 #define INSTR_CREATE_add_shimm(dc, rd, rn, rm_or_imm, sht, sha) \

--- a/core/ir/arm/instr.c
+++ b/core/ir/arm/instr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -883,11 +883,22 @@ instr_is_stolen_reg_move(instr_t *instr, bool *save, reg_id_t *reg)
 
 DR_API
 bool
+instr_is_exclusive_load(instr_t *instr)
+{
+    int opcode = instr_get_opcode(instr);
+    return (opcode == OP_ldrex || opcode == OP_ldrexb || opcode == OP_ldrexd ||
+            opcode == OP_ldrexh || opcode == OP_ldaex || opcode == OP_ldaexb ||
+            opcode == OP_ldaexd || opcode == OP_ldaexh);
+}
+
+DR_API
+bool
 instr_is_exclusive_store(instr_t *instr)
 {
     int opcode = instr_get_opcode(instr);
     return (opcode == OP_strex || opcode == OP_strexb || opcode == OP_strexd ||
-            opcode == OP_strexh);
+            opcode == OP_strexh || opcode == OP_stlex || opcode == OP_stlexb ||
+            opcode == OP_stlexd || opcode == OP_stlexh);
 }
 
 DR_API

--- a/core/ir/instr.h
+++ b/core/ir/instr.h
@@ -1409,8 +1409,16 @@ instr_it_block_create(dcontext_t *dcontext, dr_pred_type_t pred0, dr_pred_type_t
 
 DR_API
 /**
+ * Returns true iff \p instr is an exclusive load instruction,
+ * e.g., #OP_ldrex on ARM.
+ */
+bool
+instr_is_exclusive_load(instr_t *instr);
+
+DR_API
+/**
  * Returns true iff \p instr is an exclusive store instruction,
- * e.g., OP_strex on ARM.
+ * e.g., #OP_strex on ARM.
  */
 bool
 instr_is_exclusive_store(instr_t *instr);

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2272,6 +2272,13 @@ instr_is_nop(instr_t *inst)
           opnd_get_base(instr_get_src(inst, 0)) == REG_NULL &&
           opnd_get_scale(instr_get_src(inst, 0)) == 1)))
         return true;
+    return false;
+}
+
+DR_API
+bool
+instr_is_exclusive_load(instr_t *instr)
+{
     return false;
 }
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1432,6 +1432,7 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out)
       -D postcmd3=${${key}_postcmd3}
       -D cmp=${CMAKE_CURRENT_BINARY_DIR}/${expectbase}.expect
       -D code=${${key}_code}
+      -D capture=${${key}_runcmp_capture}
       -P ${runcmp_script})
     # No support for regex here (ctest can't handle large regex)
     set(ALREADY_REGEX ON)
@@ -1824,6 +1825,11 @@ if (CLIENT_INTERFACE)
   if (NOT ANDROID)
     # XXX i#1874: get working on Android
     tobuild_api(api.ir api/ir_${sfx}.c "" "" OFF OFF)
+    if (AARCH64)
+      # The ir_aarch64.expect file is too large for CMake's regexes.
+      set(api.ir_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runcmp.cmake")
+      set(api.ir_runcmp_capture "stderr")
+    endif ()
     # XXX i#1686: add ARM's headers too once they are all created
     if (NOT ARM AND NOT AARCH64 AND "${CMAKE_GENERATOR}" MATCHES "Unix Makefiles")
       # CMake's Unix Makefiles dependence analysis doesn't run the preprocessor
@@ -1850,7 +1856,7 @@ if (CLIENT_INTERFACE)
     endif ()
 
     if (AARCH64)
-        tobuild_api(api.ir_negative api/ir_aarch64_negative.c "" "" OFF OFF)
+      tobuild_api(api.ir_negative api/ir_aarch64_negative.c "" "" OFF OFF)
     endif (AARCH64)
   endif ()
 

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -148,6 +148,16 @@ test_add(void *dc)
                               opnd_create_reg(DR_REG_X2));
     test_instr_encoding(dc, OP_adcs, instr);
 
+    /* Add to sp (tests shift vs extend). */
+    instr = INSTR_CREATE_add(dc, opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_SP),
+                             opnd_create_reg(DR_REG_X1));
+    test_instr_encoding(dc, OP_add, instr);
+
+    /* Sub from sp (tests shift vs extend). */
+    instr = INSTR_CREATE_sub(dc, opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_SP),
+                             opnd_create_reg(DR_REG_X1));
+    test_instr_encoding(dc, OP_sub, instr);
+
 /* Add and set flags (shifted register, 32-bit)
  * ADDS <Wd>, <Wn>, <Wm>{, <shift> #<amount>}
  */

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -105,7 +105,7 @@ test_instr_encoding(void *dc, uint opcode, instr_t *instr)
     byte *pc;
 
     ASSERT(instr_get_opcode(instr) == opcode);
-    instr_disassemble(dc, instr, STDOUT);
+    instr_disassemble(dc, instr, STDERR);
     print("\n");
 
     ASSERT(instr_is_encoding_possible(instr));
@@ -4342,6 +4342,84 @@ test_sys(void *dc)
     test_instr_encoding(dc, OP_sys, instr);
 }
 
+static void
+test_exclusive_memops(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_ldxr(dc, opnd_create_reg(DR_REG_X0),
+                              OPND_CREATE_MEM64(DR_REG_X1, 0));
+    ASSERT(instr_is_exclusive_load(instr));
+    test_instr_encoding(dc, OP_ldxr, instr);
+    instr = INSTR_CREATE_ldxrb(dc, opnd_create_reg(DR_REG_W0),
+                               OPND_CREATE_MEM8(DR_REG_X1, 0));
+    ASSERT(instr_is_exclusive_load(instr));
+    test_instr_encoding(dc, OP_ldxrb, instr);
+    instr = INSTR_CREATE_ldxrh(dc, opnd_create_reg(DR_REG_W0),
+                               OPND_CREATE_MEM16(DR_REG_X1, 0));
+    ASSERT(instr_is_exclusive_load(instr));
+    test_instr_encoding(dc, OP_ldxrh, instr);
+    instr = INSTR_CREATE_ldxp(dc, opnd_create_reg(DR_REG_W0), opnd_create_reg(DR_REG_W1),
+                              OPND_CREATE_MEM64(DR_REG_X2, 0));
+    ASSERT(instr_is_exclusive_load(instr));
+    test_instr_encoding(dc, OP_ldxp, instr);
+    instr = INSTR_CREATE_ldaxr(dc, opnd_create_reg(DR_REG_X0),
+                               OPND_CREATE_MEM64(DR_REG_X1, 0));
+    ASSERT(instr_is_exclusive_load(instr));
+    test_instr_encoding(dc, OP_ldaxr, instr);
+    instr = INSTR_CREATE_ldaxrb(dc, opnd_create_reg(DR_REG_W0),
+                                OPND_CREATE_MEM8(DR_REG_X1, 0));
+    ASSERT(instr_is_exclusive_load(instr));
+    test_instr_encoding(dc, OP_ldaxrb, instr);
+    instr = INSTR_CREATE_ldaxrh(dc, opnd_create_reg(DR_REG_W0),
+                                OPND_CREATE_MEM16(DR_REG_X1, 0));
+    ASSERT(instr_is_exclusive_load(instr));
+    test_instr_encoding(dc, OP_ldaxrh, instr);
+    instr = INSTR_CREATE_ldaxp(dc, opnd_create_reg(DR_REG_W0), opnd_create_reg(DR_REG_W1),
+                               OPND_CREATE_MEM64(DR_REG_X2, 0));
+    ASSERT(instr_is_exclusive_load(instr));
+    test_instr_encoding(dc, OP_ldaxp, instr);
+
+    instr = INSTR_CREATE_stxr(dc, OPND_CREATE_MEM64(DR_REG_X1, 0),
+                              opnd_create_reg(DR_REG_W2), opnd_create_reg(DR_REG_X0));
+    ASSERT(instr_is_exclusive_store(instr));
+    test_instr_encoding(dc, OP_stxr, instr);
+    instr = INSTR_CREATE_stxrb(dc, OPND_CREATE_MEM8(DR_REG_X1, 0),
+                               opnd_create_reg(DR_REG_W2), opnd_create_reg(DR_REG_W0));
+    ASSERT(instr_is_exclusive_store(instr));
+    test_instr_encoding(dc, OP_stxrb, instr);
+    instr = INSTR_CREATE_stxrh(dc, OPND_CREATE_MEM16(DR_REG_X1, 0),
+                               opnd_create_reg(DR_REG_W2), opnd_create_reg(DR_REG_W0));
+    ASSERT(instr_is_exclusive_store(instr));
+    test_instr_encoding(dc, OP_stxrh, instr);
+    instr =
+        INSTR_CREATE_stxp(dc, OPND_CREATE_MEM64(DR_REG_X2, 0), opnd_create_reg(DR_REG_W3),
+                          opnd_create_reg(DR_REG_W0), opnd_create_reg(DR_REG_W1));
+    ASSERT(instr_is_exclusive_store(instr));
+    test_instr_encoding(dc, OP_stxp, instr);
+    instr = INSTR_CREATE_stlxr(dc, OPND_CREATE_MEM64(DR_REG_X1, 0),
+                               opnd_create_reg(DR_REG_W2), opnd_create_reg(DR_REG_X0));
+    ASSERT(instr_is_exclusive_store(instr));
+    test_instr_encoding(dc, OP_stlxr, instr);
+    instr = INSTR_CREATE_stlxrb(dc, OPND_CREATE_MEM8(DR_REG_X1, 0),
+                                opnd_create_reg(DR_REG_W2), opnd_create_reg(DR_REG_W0));
+    ASSERT(instr_is_exclusive_store(instr));
+    test_instr_encoding(dc, OP_stlxrb, instr);
+    instr = INSTR_CREATE_stlxrh(dc, OPND_CREATE_MEM16(DR_REG_X1, 0),
+                                opnd_create_reg(DR_REG_W2), opnd_create_reg(DR_REG_W0));
+    ASSERT(instr_is_exclusive_store(instr));
+    test_instr_encoding(dc, OP_stlxrh, instr);
+    instr = INSTR_CREATE_stlxp(dc, OPND_CREATE_MEM64(DR_REG_X2, 0),
+                               opnd_create_reg(DR_REG_W3), opnd_create_reg(DR_REG_W0),
+                               opnd_create_reg(DR_REG_W1));
+    ASSERT(instr_is_exclusive_store(instr));
+    test_instr_encoding(dc, OP_stlxp, instr);
+
+    instr = INSTR_CREATE_clrex(dc);
+    ASSERT(!instr_is_exclusive_store(instr) && !instr_is_exclusive_load(instr));
+    test_instr_encoding(dc, OP_clrex, instr);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -4404,6 +4482,9 @@ main(int argc, char *argv[])
 
     test_sys(dcontext);
     print("test_sys complete\n");
+
+    test_exclusive_memops(dcontext);
+    print("test_exclusive_memops complete\n");
 
     print("All tests complete\n");
 #ifndef STANDALONE_DECODER

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -3,6 +3,8 @@ adc    %w1 %w2 -> %w0
 adc    %x1 %x2 -> %x0
 adcs   %w1 %w2 -> %w0
 adcs   %x1 %x2 -> %x0
+add    %sp %x1 uxtx $0x0000000000000000 -> %x0
+sub    %sp %x1 uxtx $0x0000000000000000 -> %x0
 adds   %w1 %w2 lsl $0x00 -> %w0
 adds   %w1 %w2 lsl $0x1f -> %w0
 adds   %w1 %w2 lsr $0x00 -> %w0

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -839,4 +839,22 @@ sys    $0x1bd9 (%x29)[1byte]
 sys    $0x1bf1 (%x30)[1byte]
 sys    $0x1ba9 (%x1)[1byte]
 test_sys complete
+ldxr   (%x1)[8byte] $0x000000000000001f $0x000000000000001f -> %x0
+ldxrb  (%x1)[1byte] $0x000000000000001f $0x000000000000001f -> %w0
+ldxrh  (%x1)[2byte] $0x000000000000001f $0x000000000000001f -> %w0
+ldxp   (%x2)[8byte] $0x000000000000001f -> %w0 %w1
+ldaxr  (%x1)[8byte] $0x000000000000001f $0x000000000000001f -> %x0
+ldaxrb (%x1)[1byte] $0x000000000000001f $0x000000000000001f -> %w0
+ldaxrh (%x1)[2byte] $0x000000000000001f $0x000000000000001f -> %w0
+ldaxp  (%x2)[8byte] $0x000000000000001f -> %w0 %w1
+stxr   %x0 $0x000000000000001f -> (%x1)[8byte] %w2
+stxrb  %w0 $0x000000000000001f -> (%x1)[1byte] %w2
+stxrh  %w0 $0x000000000000001f -> (%x1)[2byte] %w2
+stxp   %w0 %w1 -> (%x2)[8byte] %w3
+stlxr  %x0 $0x000000000000001f -> (%x1)[8byte] %w2
+stlxrb %w0 $0x000000000000001f -> (%x1)[1byte] %w2
+stlxrh %w0 $0x000000000000001f -> (%x1)[2byte] %w2
+stlxp  %w0 %w1 -> (%x2)[8byte] %w3
+clrex  $0x0000000000000000
+test_exclusive_memops complete
 All tests complete

--- a/suite/tests/runcmp.cmake
+++ b/suite/tests/runcmp.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015 Google, Inc.    All rights reserved.
+# Copyright (c) 2015-2020 Google, Inc.    All rights reserved.
 # Copyright (c) 2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -35,6 +35,7 @@
 # * cmd = command to run
 #     should have intra-arg space=@@ and inter-arg space=@ and ;=!
 # * cmp = file containing output to compare stdout to
+# * capture = if "stderr", captures stderr instead of stdout
 
 # intra-arg space=@@ and inter-arg space=@
 string(REGEX REPLACE "@@" " " cmd "${cmd}")
@@ -62,10 +63,15 @@ file(READ "${cmp}" str)
 # file, but that gets really slow (30s for 750KB strings) so now we require
 # strict matches.
 
-if (NOT "${cmd_out}" STREQUAL "${str}")
+set(output "${cmd_out}")
+if ("${capture}" STREQUAL "stderr")
+  set(output "${cmd_err}")
+endif ()
+
+if (NOT "${output}" STREQUAL "${str}")
   # make it easier to debug
   set(tmp "${cmp}-out")
-  file(WRITE "${tmp}" "${cmd_out}")
+  file(WRITE "${tmp}" "${output}")
   set(tmp2 "${cmp}-expect")
   file(WRITE "${tmp2}" "${str}")
 


### PR DESCRIPTION
i#1698 ldstex: Add exclusive memop create and query support

Adds a new API function instr_is_exclusive_load().  Moves the existing
private implementation (for -unsafe_build_ldstex) to become a public
function on AArch64.

Adds new instruction creation macros for exclusive load, store, and
clear opcodes.

Adds tests to api.ir for instr_is_exclusive_* and the new creation
macros.  This necessitated switching api.ir to use runcmp.cmake, since
its output is now too large for a CMake regular expression match.

Issue: #1698
