### PR TITLE
i#4537: Move OPSZ_8x16 to the correct location in size_names

### DIFF
--- a/core/ir/decode_shared.c
+++ b/core/ir/decode_shared.c
@@ -150,6 +150,7 @@ const char *const size_names[] = {
     "OPSZ_32_of_64",
     "OPSZ_4_of_32_evex64",
     "OPSZ_8_of_32_evex64",
+    "OPSZ_8x16",
     "OPSZ_1_of_4",
     "OPSZ_2_of_4",
     "OPSZ_1_of_8",
@@ -172,7 +173,6 @@ const char *const size_names[] = {
     "OPSZ_quarter_16_vex32_evex64",
     "OPSZ_eighth_16_vex32",
     "OPSZ_eighth_16_vex32_evex64",
-    "OPSZ_8x16",
 };
 
 /* point at this when you need a canonical invalid instr


### PR DESCRIPTION
This appears to be an oversight from when it was added. It got added to the very end of the list after the fractional register sizes, when it should not have been.

Fixes #4537