### PR TITLE
i#4556: Recognize stolen register mangling in translation

### DIFF
--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -1958,6 +1958,7 @@ restore_app_value_to_stolen_reg(dcontext_t *dcontext, instrlist_t *ilist, instr_
                                 reg_id_t reg, ushort slot)
 {
     insert_save_to_tls_if_necessary(dcontext, ilist, instr, reg, slot);
+    /* This precise opcode (OP_orr) is checked for in instr_is_stolen_reg_move(). */
     PRE(ilist, instr,
         XINST_CREATE_move(dcontext, opnd_create_reg(reg),
                           opnd_create_reg(dr_reg_stolen)));
@@ -2003,6 +2004,7 @@ restore_tls_base_to_stolen_reg(dcontext_t *dcontext, instrlist_t *ilist, instr_t
         });
     }
     /* restore stolen reg from spill reg */
+    /* This precise opcode (OP_orr) is checked for in instr_is_stolen_reg_move(). */
     PRE(ilist, next_instr,
         XINST_CREATE_move(dcontext, opnd_create_reg(dr_reg_stolen),
                           opnd_create_reg(reg)));

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -110,7 +110,11 @@ reg_spill_tls_offs(reg_id_t reg)
     case SCRATCH_REG3: return TLS_REG3_SLOT;
 #ifdef AARCH64
     case SCRATCH_REG4: return TLS_REG4_SLOT;
-    case SCRATCH_REG5: return TLS_REG5_SLOT;
+    case SCRATCH_REG5:
+        return TLS_REG5_SLOT;
+        /* We do not include the stolen reg slot b/c its load+stores are reversed
+         * and must be special-cased vs other spills.
+         */
 #endif
     }
     /* don't assert if another reg passed: used on random regs looking for spills */

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -447,6 +447,43 @@ instr_writes_thread_register(instr_t *instr)
             opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_TPIDR_EL0);
 }
 
+/* Identify one of the reg-reg moves inserted as part of stolen reg mangling:
+ *   +0    m4  f9000380   str    %x0 -> (%x28)[8byte]
+ * Move stolen reg to x0:
+ *   +4    m4  aa1c03e0   orr    %xzr %x28 lsl $0x0000000000000000 -> %x0
+ *   +8    m4  f9401b9c   ldr    +0x30(%x28)[8byte] -> %x28
+ *   +12   L3  f81e0ffc   str    %x28 %sp $0xffffffffffffffe0 -> -0x20(%sp)[8byte] %sp
+ * Move x0 back to stolenr eg:
+ *   +16   m4  aa0003fc   orr    %xzr %x0 lsl $0x0000000000000000 -> %x28
+ *   +20   m4  f9400380   ldr    (%x28)[8byte] -> %x0
+ */
+bool
+instr_is_stolen_reg_move(instr_t *instr, bool *save, reg_id_t *reg)
+{
+    CLIENT_ASSERT(instr != NULL, "internal error: NULL argument");
+    if (instr_is_app(instr) || instr_get_opcode(instr) != OP_orr)
+        return false;
+    ASSERT(instr_num_srcs(instr) == 4 && instr_num_dsts(instr) == 1 &&
+           opnd_is_reg(instr_get_src(instr, 1)) && opnd_is_reg(instr_get_dst(instr, 0)));
+    if (opnd_get_reg(instr_get_src(instr, 1)) == dr_reg_stolen) {
+        if (save != NULL)
+            *save = true;
+        if (reg != NULL) {
+            *reg = opnd_get_reg(instr_get_dst(instr, 0));
+            ASSERT(*reg != dr_reg_stolen);
+        }
+        return true;
+    }
+    if (opnd_get_reg(instr_get_dst(instr, 0)) == dr_reg_stolen) {
+        if (save != NULL)
+            *save = false;
+        if (reg != NULL)
+            *reg = opnd_get_reg(instr_get_src(instr, 0));
+        return true;
+    }
+    return false;
+}
+
 DR_API
 bool
 instr_is_exclusive_load(instr_t *instr)

--- a/core/ir/instr.h
+++ b/core/ir/instr.h
@@ -3004,7 +3004,7 @@ bool
 instr_is_DR_reg_spill_or_restore(void *drcontext, instr_t *instr, bool *tls OUT,
                                  bool *spill OUT, reg_id_t *reg OUT, uint *offs OUT);
 
-#ifdef ARM
+#ifdef AARCHXX
 bool
 instr_reads_thread_register(instr_t *instr);
 bool
@@ -3012,8 +3012,6 @@ instr_is_stolen_reg_move(instr_t *instr, bool *save, reg_id_t *reg);
 #endif
 
 #ifdef AARCH64
-bool
-instr_reads_thread_register(instr_t *instr);
 bool
 instr_writes_thread_register(instr_t *instr);
 #endif

--- a/core/translate.c
+++ b/core/translate.c
@@ -223,14 +223,14 @@ translate_walk_track(dcontext_t *tdcontext, instr_t *inst, translate_walk_t *wal
 
     /* Two mangle regions can be adjacent: distinguish by translation field */
     if (walk->in_mangle_region &&
-        /* On ARM, we spill registers across an app instr, so go solely on xl8 */
+        /* On AArchXX, we spill registers across an app instr, so go solely on xl8 */
         (IF_X86(!instr_is_our_mangling(inst) ||)
          /* handle adjacent mangle regions */
          IF_X86(translate_walk_exits_mangling_epilogue(tdcontext, inst, walk) ||)
          /* Entering the mangling region's epilogue can have different xl8 */
          (IF_X86(!translate_walk_enters_mangling_epilogue(tdcontext, inst, walk) &&)
               instr_get_translation(inst) != walk->translation))) {
-        LOG(THREAD_GET, LOG_INTERP, 5, "%s: from one mangle region to another\n",
+        LOG(THREAD_GET, LOG_INTERP, 4, "%s: from one mangle region to another\n",
             __FUNCTION__);
         /* We assume our manglings are local and contiguous: once out of a
          * mangling region, we're good to go again.
@@ -240,14 +240,14 @@ translate_walk_track(dcontext_t *tdcontext, instr_t *inst, translate_walk_t *wal
         walk->unsupported_mangle = false;
         walk->xsp_adjust = 0;
         for (r = 0; r < REG_SPILL_NUM; r++) {
-#ifndef ARM
+#ifndef AARCHXX
             /* we should have seen a restore for every spill, unless at
              * fragment-ending jump to ibl, which shouldn't come here
              */
             ASSERT(walk->reg_spill_offs[r] == UINT_MAX);
             walk->reg_spill_offs[r] = UINT_MAX; /* be paranoid */
 #else
-            /* On ARM we do spill registers across app instrs and mangle
+            /* On AArchXX we do spill registers across app instrs and mangle
              * regions, though right now only the following routines do this:
              * - mangle_stolen_reg()
              * - mangle_gpr_list_read()
@@ -276,14 +276,14 @@ translate_walk_track(dcontext_t *tdcontext, instr_t *inst, translate_walk_t *wal
         if (!walk->in_mangle_region) {
             walk->in_mangle_region = true;
             walk->translation = instr_get_translation(inst);
-            LOG(THREAD_GET, LOG_INTERP, 5, "%s: entering mangle region xl8=" PFX "\n",
+            LOG(THREAD_GET, LOG_INTERP, 4, "%s: entering mangle region xl8=" PFX "\n",
                 __FUNCTION__, walk->translation);
         } else if (IF_X86_ELSE(
                        translate_walk_enters_mangling_epilogue(tdcontext, inst, walk),
                        false)) {
             walk->in_mangle_region_epilogue = true;
             walk->translation = instr_get_translation(inst);
-            LOG(THREAD_GET, LOG_INTERP, 5,
+            LOG(THREAD_GET, LOG_INTERP, 4,
                 "%s: entering mangle region epilogue xl8=" PFX "\n", __FUNCTION__,
                 walk->translation);
         } else
@@ -342,6 +342,7 @@ translate_walk_track(dcontext_t *tdcontext, instr_t *inst, translate_walk_t *wal
             /* FIXME i#1551: add ARM version of the series of trace cti checks above */
             IF_ARM(ASSERT_NOT_IMPLEMENTED(DYNAMO_OPTION(disable_traces)));
             /* reset for non-exit non-trace-jecxz cti (i.e., selfmod cti) */
+            LOG(THREAD_GET, LOG_INTERP, 4, "\treset spills on cti\n");
             for (r = 0; r < REG_SPILL_NUM; r++)
                 walk->reg_spill_offs[r] = UINT_MAX;
         }
@@ -372,15 +373,28 @@ translate_walk_track(dcontext_t *tdcontext, instr_t *inst, translate_walk_t *wal
                     walk->reg_spill_offs[r] = UINT_MAX;
                 }
                 walk->reg_tls[r] = spill_tls;
-                LOG(THREAD_GET, LOG_INTERP, 5, "\tspill update: %s %s %s\n",
+                LOG(THREAD_GET, LOG_INTERP, 4, "\tspill update: %s %s %s offs=%u\n",
                     spill ? "spill" : "restore", spill_tls ? "tls" : "mcontext",
-                    reg_names[reg]);
+                    reg_names[reg], offs);
             }
         }
-#ifdef ARM
-        else if (instr_is_stolen_reg_move(inst, &spill, &reg)) {
+#ifdef AARCHXX
+        else if (instr_is_stolen_reg_move(inst, &spill, &reg) ||
+                 /* Accessing the stolen reg TLS slot does not satisfy the
+                  * instr_is_DR_reg_spill_or_restore() check above b/c it's not
+                  * a regular spill slot per reg_spill_tls_offs.
+                  * We assume it does not need tracking: restore_stolen_register()
+                  * is all we need as the window where we've swapped regs is just
+                  * one app instr w/ no mangling or instru between.
+                  */
+                 instr_is_tls_restore(inst, dr_reg_stolen, TLS_REG_STOLEN_SLOT) ||
+                 /* The store has the swapped register as the base. */
+                 (instr_get_opcode(inst) == OP_store &&
+                  opnd_get_reg(instr_get_src(inst, 0)) == dr_reg_stolen &&
+                  opnd_get_disp(instr_get_dst(inst, 0)) ==
+                      os_tls_offset(TLS_REG_STOLEN_SLOT))) {
             /* do nothing */
-            LOG(THREAD_GET, LOG_INTERP, 5, "%s: stolen reg move\n", __FUNCTION__);
+            LOG(THREAD_GET, LOG_INTERP, 4, "%s: stolen reg move\n", __FUNCTION__);
         }
 #endif
         /* PR 267260: Track our own mangle-inserted pushes and pops, for
@@ -976,8 +990,8 @@ recreate_app_state_from_ilist(dcontext_t *tdcontext, instrlist_t *ilist, byte *s
         /* we only use translation pointers, never just raw bit pointers */
         if (instr_get_translation(inst) != NULL) {
             prev_ok = inst;
-            DOLOG(5, LOG_INTERP,
-                  d_r_loginst(get_thread_private_dcontext(), 5, prev_ok, "\tok instr"););
+            DOLOG(4, LOG_INTERP,
+                  d_r_loginst(get_thread_private_dcontext(), 4, prev_ok, "\tok instr"););
             prev_bytes = instr_get_translation(inst);
             if (instr_is_app(inst)) {
                 /* we really want the pc after the translation target since we'll


### PR DESCRIPTION
Adds recognition of stolen register mangling moves and the special
spills and restores when translating.  Tested by ensuring the
'unsupported mangle instr' messages are gone when running the
client.stolen-reg test.

Fixes #4556