### PR TITLE
i#4560: Handle AArch64 zero registers consistently

### DIFF
--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -332,7 +332,8 @@ instr_predicate_is_cond(dr_pred_type_t pred)
 bool
 reg_is_gpr(reg_id_t reg)
 {
-    return (DR_REG_X0 <= reg && reg <= DR_REG_WSP);
+    return (reg >= DR_REG_START_64 && reg <= DR_REG_STOP_64) ||
+        (reg >= DR_REG_START_32 && reg <= DR_REG_STOP_32);
 }
 
 bool

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -4518,6 +4518,15 @@ test_opnd(void *dc)
     ASSERT(opnd_get_reg(instr_get_src(instr, 1)) == DR_REG_W1);
     instr_destroy(dc, instr);
 
+    /* Test reg corner cases. */
+    ASSERT(reg_to_pointer_sized(DR_REG_WZR) == DR_REG_XZR);
+    ASSERT(reg_32_to_64(DR_REG_WZR) == DR_REG_XZR);
+    ASSERT(reg_64_to_32(DR_REG_XZR) == DR_REG_WZR);
+    ASSERT(reg_resize_to_opsz(DR_REG_XZR, OPSZ_4) == DR_REG_WZR);
+    ASSERT(reg_resize_to_opsz(DR_REG_WZR, OPSZ_8) == DR_REG_XZR);
+    ASSERT(!reg_is_gpr(DR_REG_XZR));
+    ASSERT(!reg_is_gpr(DR_REG_WZR));
+
     /* XXX: test other routines like opnd_defines_use(); test every flag such as
      * register negate and shift across replace and other operations.
      */


### PR DESCRIPTION
Fixes reg_is_gpr() to return false for both XZR and WZR.

Adds handling of the two zero register names to the register resize routines.

Adds some tests to api.ir.

Fixes #4560