### PR TITLE
i#4567: Handle instructions with a single source operand that's an AVX-512 mask register in AT&T style disassembly

### DIFF
--- a/core/ir/decodelib.c
+++ b/core/ir/decodelib.c
@@ -128,7 +128,7 @@ get_thread_private_dcontext(void)
 void
 external_error(const char *file, int line, const char *msg)
 {
-    printf("Usage error: %s (%s, line %d)", msg, file, line);
+    fprintf(stderr, "Usage error: %s (%s, line %d)\n", msg, file, line);
     abort();
 }
 

--- a/core/ir/disassemble_shared.c
+++ b/core/ir/disassemble_shared.c
@@ -966,7 +966,8 @@ instr_disassemble_opnds_noimplicit(char *buf, size_t bufsz, size_t *sofar INOUT,
         }
     }
     if (is_evex_mask_pending) {
-        opnd = instr_get_src(instr, 0);
+        i = 0;
+        opnd = instr_get_src(instr, i);
         CLIENT_ASSERT(IF_X86_ELSE(true, false), "evex mask can only exist for x86.");
         optype = instr_info_opnd_type(info, !dsts_first(), i);
         CLIENT_ASSERT(!instr_is_opmask(instr) && opnd_is_reg(opnd) &&

--- a/core/ir/disassemble_shared.c
+++ b/core/ir/disassemble_shared.c
@@ -966,16 +966,16 @@ instr_disassemble_opnds_noimplicit(char *buf, size_t bufsz, size_t *sofar INOUT,
         }
     }
     if (is_evex_mask_pending) {
-        i = 0;
-        opnd = instr_get_src(instr, i);
+        int mask_index = 0;
+        opnd = instr_get_src(instr, mask_index);
         CLIENT_ASSERT(IF_X86_ELSE(true, false), "evex mask can only exist for x86.");
-        optype = instr_info_opnd_type(info, !dsts_first(), i);
+        optype = instr_info_opnd_type(info, !dsts_first(), mask_index);
         CLIENT_ASSERT(!instr_is_opmask(instr) && opnd_is_reg(opnd) &&
                           reg_is_opmask(opnd_get_reg(opnd)) && opmask_with_dsts(),
                       "evex mask must always be the first source.");
         print_to_buffer(buf, bufsz, sofar, " {");
         opnd_disassemble_noimplicit(buf, bufsz, sofar, dcontext, instr, optype, opnd,
-                                    false, multiple_encodings, dsts_first(), &i);
+                                    false, multiple_encodings, dsts_first(), &mask_index);
         print_to_buffer(buf, bufsz, sofar, "}");
     }
 }


### PR DESCRIPTION
The mask register is always the first source operand. i here is stale, the result of previous loop. The `instr_get_src` correctly uses a hardcoded zero. But instr_info_opnd_type reuses i and dies if the instruction has a single source operand (because i is always out of range). is_evex_mask_pending is not ever set for Intel style disassembly which is why this bug only affects AT&T syntax.

drdisas -syntax att 62 f2 fe 48 28 c9 will trigger this bug.

This is tested in the (currently ifdefed out) binutils AVX-512 tests.

Fixes #4567