### PR TITLE
i#4549 Github Actions: Trigger on pull requests

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -38,6 +38,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [opened, reopened, synchronize, edited]
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -32,8 +32,12 @@
 
 name: ci-aarchxx
 on:
-  # Run on pushes to any repository branch.
+  # Run on pull requests and pushes to master.
+  # We do not run on pushes to feature branches: pull requests cover those.
   push:
+    branches:
+      - master
+  pull_request:
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -32,8 +32,12 @@
 
 name: ci-clang-format
 on:
-  # Run on pushes to any repository branch.
+  # Run on pull requests and pushes to master.
+  # We do not run on pushes to feature branches: pull requests cover those.
   push:
+    branches:
+      - master
+  pull_request:
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -38,6 +38,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [opened, reopened, synchronize, edited]
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -38,6 +38,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [opened, reopened, synchronize, edited]
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -32,8 +32,12 @@
 
 name: ci-osx
 on:
-  # Run on pushes to any repository branch.
+  # Run on pull requests and pushes to master.
+  # We do not run on pushes to feature branches: pull requests cover those.
   push:
+    branches:
+      - master
+  pull_request:
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -38,6 +38,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [opened, reopened, synchronize, edited]
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -32,8 +32,12 @@
 
 name: ci-x86
 on:
-  # Run on pushes to any repository branch.
+  # Run on pull requests and pushes to master.
+  # We do not run on pushes to feature branches: pull requests cover those.
   push:
+    branches:
+      - master
+  pull_request:
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:


### PR DESCRIPTION
Changes the Github Actions trigger from pushes on all branches, which
fails to trigger on a pull request from a forked repository, to pull
requests and pushes on master.

Issue: #4549