### PR TITLE
i#4058 flaky tests: Relax winxfer output regex

### DIFF
--- a/suite/tests/client-interface/winxfer.templatex
+++ b/suite/tests/client-interface/winxfer.templatex
@@ -1,44 +1,11 @@
-(kernel_xfer_event: type 2
-kernel_xfer_event: type 7
-)?About to create thread
-kernel_xfer_event: type 2
-kernel_xfer_event: type 7
-kernel_xfer_event: type 5
-kernel_xfer_event: type 6
-kernel_xfer_event: type 5
-(kernel_xfer_event: type 5
-kernel_xfer_event: type 6
-kernel_xfer_event: type 5
-)?kernel_xfer_event: type 6
-kernel_xfer_event: type 5
-kernel_xfer_event: type 6
-(kernel_xfer_event: type 6
-kernel_xfer_event: type 5
-kernel_xfer_event: type 6
-)?kernel_xfer_event: type 5
-in wnd_callback 0x0*0000024 0
+.*About to create thread
+.*in wnd_callback 0x0*0000024 0
 kernel_xfer_event: type 6
 kernel_xfer_event: type 5
 in wnd_callback 0x0*0000081 0
 kernel_xfer_event: type 6
 kernel_xfer_event: type 5
-kernel_xfer_event: type 6
-kernel_xfer_event: type 5
-kernel_xfer_event: type 6
-kernel_xfer_event: type 5
-kernel_xfer_event: type 6
-kernel_xfer_event: type 5
-kernel_xfer_event: type 6
-kernel_xfer_event: type 5
-kernel_xfer_event: type 6
-kernel_xfer_event: type 5
-kernel_xfer_event: type 6
-kernel_xfer_event: type 5
-kernel_xfer_event: type 6
-kernel_xfer_event: type 5
-(kernel_xfer_event: type 6
-kernel_xfer_event: type 5
-)?in wnd_callback 0x0*0000083 0
+.*in wnd_callback 0x0*0000083 0
 kernel_xfer_event: type 6
 kernel_xfer_event: type 5
 in wnd_callback 0x0*0000001 0


### PR DESCRIPTION
Relaxes the client.winxfer test golden output regex further based on
observed output on Appveyor.

Issue: #4058