### PR TITLE
i#4571: Ignore drcachesim delay-simple failure

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -248,6 +248,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                    'code_api|tool.histogram.offline' => 1, # i#3980
                                    'code_api|linux.fib-conflict' => 1,
                                    'code_api|linux.fib-conflict-early' => 1,
+                                   'code_api|tool.drcachesim.delay-simple' => 1, #i#4571
                                    'code_api|linux.mangle_asynch' => 1);
             if ($is_32) {
                 $issue_no = "#2416";


### PR DESCRIPTION
Ignore failure in `tool.drcachesim.delay-simple` test on AArch64 to unblock various PRs. 

Confirmed locally that this test started failing at 893c06c2605eb8423ef4a4b33185d0fef9c75257; the failure didn't show up on the Jenkins test suite for PR #4491 somehow.



Issue: #4571