### PR TITLE
i#4571: Fix drcachesim delay-simple test on AArch64.

### DIFF
--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -6833,7 +6833,7 @@ dr_set_mcontext(void *drcontext, dr_mcontext_t *context)
 {
     priv_mcontext_t *state;
     dcontext_t *dcontext = (dcontext_t *)drcontext;
-    IF_ARM(reg_t reg_val = 0 /* silence the compiler warning */;)
+    IF_AARCHXX(reg_t reg_val = 0 /* silence the compiler warning */;)
     CLIENT_ASSERT(!TEST(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask)),
                   "DR context protection NYI");
     CLIENT_ASSERT(context != NULL, "invalid context");
@@ -6864,7 +6864,7 @@ dr_set_mcontext(void *drcontext, dr_mcontext_t *context)
      * will override any save_fpstate xmm values, as desired.
      */
     state = get_priv_mcontext_from_dstack(dcontext);
-#    ifdef ARM
+#    ifdef AARCHXX
     if (TEST(DR_MC_INTEGER, context->flags)) {
         /* Set the stolen register's app value in TLS, not on stack (we rely
          * on our stolen reg retaining its value on the stack)
@@ -6877,7 +6877,7 @@ dr_set_mcontext(void *drcontext, dr_mcontext_t *context)
 #    endif
     if (!dr_mcontext_to_priv_mcontext(state, context))
         return false;
-#    ifdef ARM
+#    ifdef AARCHXX
     if (TEST(DR_MC_INTEGER, context->flags)) {
         /* restore the reg val on the stack clobbered by the copy above */
         set_stolen_reg_val(state, reg_val);

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -6799,7 +6799,7 @@ dr_get_mcontext_priv(dcontext_t *dcontext, dr_mcontext_t *dmc, priv_mcontext_t *
     else if (TEST(DR_MC_CONTROL, dmc->flags))
         dmc->xsp = get_mcontext(dcontext)->xsp;
 
-#ifdef ARM
+#ifdef AARCHXX
     if (TEST(DR_MC_INTEGER, dmc->flags)) {
         /* get the stolen register's app value */
         if (mc != NULL) {

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -248,7 +248,6 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                    'code_api|tool.histogram.offline' => 1, # i#3980
                                    'code_api|linux.fib-conflict' => 1,
                                    'code_api|linux.fib-conflict-early' => 1,
-                                   'code_api|tool.drcachesim.delay-simple' => 1, #i#4571
                                    'code_api|linux.mangle_asynch' => 1);
             if ($is_32) {
                 $issue_no = "#2416";


### PR DESCRIPTION
Add missing stolen reg value in mcontext.

PR #4513 is already working on setting the stolen reg value. This PR is just to verify whether this also fixes the delay-simple test. I verified that it is indeed fixed locally, but this test was somewhat flaky on Jenkins CI, so need to verify that. 

Fixes: #4571