### PR TITLE
i#4370 cmake 3.19: Do no clobber client defines

### DIFF
--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -930,9 +930,9 @@ function (_DR_set_compile_flags target is_client extra_flags)
     endif ()
   endforeach (src)
 
-  set_target_properties(${target} PROPERTIES
-    COMPILE_DEFINITIONS "${extra_defines};${tgt_defines}"
-    COMPILE_FLAGS "${tgt_inc}")
+  set_target_properties(${target} PROPERTIES COMPILE_FLAGS "${tgt_inc}")
+  _DR_append_property_list(TARGET ${target}
+    COMPILE_DEFINITIONS "${extra_defines};${tgt_defines}")
 endfunction(_DR_set_compile_flags)
 
 


### PR DESCRIPTION
Changes the absolute set of COMPILE_DEFINITIONS from PR #4582 for
clients to an append, to avoid breaking clients who set their own
defines (like Dr. Memory).

Tested on Dr. Memory, which fails to configure without this fix when
using the latest DR.

Issue: #4370