### PR TITLE
i#4370 cmake 3.19: Use proper target lib for rpath

### DIFF
--- a/make/utils_exposed.cmake
+++ b/make/utils_exposed.cmake
@@ -98,7 +98,7 @@ function (DynamoRIO_add_rel_rpaths target)
       # Reading the target paths at configure time is no longer supported in
       # cmake (CMP0026).  For an imported target, we can get the path; otherwise
       # the best we can do is a LOCATION property.
-      DynamoRIO_get_full_path(lib_loc_full dynamorio "")
+      DynamoRIO_get_full_path(lib_loc_full ${lib} "")
       get_filename_component(lib_loc ${lib_loc_full} PATH)
       file(RELATIVE_PATH relpath "${target_loc}" "${lib_loc}")
 


### PR DESCRIPTION
PR #4582 hardcoded "dynamorio" as the library to link to, breaking
users (like Dr. Memory) who rely on rpath linking to layers of their
own libraries.  We fix that here.

Tested on Dr. Memory, where drfuzz tests fail without this fix when
using the latest DR.

Issue: #4370