### PR TITLE
i#1698 ldstex: Enable -ldstex2cas on ARM by default

### DIFF
--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1628,8 +1628,12 @@ d_r_mangle(dcontext_t *dcontext, instrlist_t *ilist, uint *flags INOUT, bool man
         if (instr_is_app(instr) &&
             (instr_is_exclusive_load(instr) || instr_is_exclusive_store(instr) ||
              instr_get_opcode(instr) == OP_clrex)) {
-            next_instr = mangle_exclusive_monitor_op(dcontext, ilist, instr, next_instr);
-            continue;
+            instr_t *res =
+                mangle_exclusive_monitor_op(dcontext, ilist, instr, next_instr);
+            if (res != NULL) {
+                next_instr = res;
+                continue;
+            } /* Else, fall through. */
         }
 #endif
 #ifdef AARCH64

--- a/core/arch/proc.h
+++ b/core/arch/proc.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -314,6 +314,9 @@ typedef struct _cpu_info_t {
      * - arm: implementer, architecture, variant, part, revision, model name, hardware.
      */
     uint vendor;
+#ifdef AARCHXX
+    uint architecture;
+#endif
     uint family;
     uint type;
     uint model;
@@ -355,6 +358,11 @@ DR_API
 /** Returns true only if \p addr is cache-line-aligned. */
 bool
 proc_is_cache_aligned(void *addr);
+
+#ifdef AARCHXX
+uint
+proc_get_architecture(void);
+#endif
 
 void
 machine_cache_sync(void *pc_start, void *pc_end, bool flush_icache);

--- a/core/arch/proc_shared.c
+++ b/core/arch/proc_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -68,6 +68,7 @@ cpu_info_t cpu_info = { VENDOR_UNKNOWN,
                         0,
                         0,
                         0,
+                        0,
                         CACHE_SIZE_UNKNOWN,
                         CACHE_SIZE_UNKNOWN,
                         CACHE_SIZE_UNKNOWN,
@@ -108,6 +109,29 @@ proc_init(void)
     LOG(GLOBAL, LOG_TOP, 1, "Processor brand string = %s\n", cpu_info.brand_string);
     LOG(GLOBAL, LOG_TOP, 1, "Type=0x%x, Family=0x%x, Model=0x%x, Stepping=0x%x\n",
         cpu_info.type, cpu_info.family, cpu_info.model, cpu_info.stepping);
+
+#ifdef AARCHXX
+    /* XXX: Should we create an arch/aarchxx/proc.c just for this code? */
+#    define PROC_CPUINFO "/proc/cpuinfo"
+#    define CPU_ARCH_LINE_FORMAT "CPU architecture: %u\n"
+    file_t cpuinfo = os_open(PROC_CPUINFO, OS_OPEN_READ);
+    /* This can happen in a chroot or if /proc is disabled. */
+    if (cpuinfo != INVALID_FILE) {
+        char *buf = global_heap_alloc(PAGE_SIZE HEAPACCT(ACCT_OTHER));
+        ssize_t nread = os_read(cpuinfo, buf, PAGE_SIZE - 1);
+        if (nread > 0) {
+            buf[nread] = '\0';
+            char *arch_line = strstr(buf, "CPU architecture");
+            if (arch_line != NULL &&
+                sscanf(arch_line, CPU_ARCH_LINE_FORMAT, &cpu_info.architecture) == 1) {
+                LOG(GLOBAL, LOG_ALL, 2, "Processor architecture: %u\n",
+                    cpu_info.architecture);
+            }
+        }
+        global_heap_free(buf, PAGE_SIZE HEAPACCT(ACCT_OTHER));
+        os_close(cpuinfo);
+    }
+#endif
 }
 
 uint
@@ -157,6 +181,14 @@ proc_get_stepping(void)
 {
     return cpu_info.stepping;
 }
+
+#ifdef AARCHXX
+uint
+proc_get_architecture(void)
+{
+    return cpu_info.architecture;
+}
+#endif
 
 features_t *
 proc_get_all_feature_bits(void)

--- a/core/arch/proc_shared.c
+++ b/core/arch/proc_shared.c
@@ -64,7 +64,9 @@
 size_t cache_line_size = 32;
 static ptr_uint_t mask; /* bits that should be 0 to be cache-line-aligned */
 cpu_info_t cpu_info = { VENDOR_UNKNOWN,
+#ifdef AARCHXX
                         0,
+#endif
                         0,
                         0,
                         0,

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -604,12 +604,12 @@ OPTION_DEFAULT_INTERNAL(bool, unsafe_build_ldstex, false,
                         "macro-instruction (unsafe)")
 #endif
 #ifdef AARCHXX
-/* TODO i#1698: To enable for ARM we need to fix a few final pieces:
- * + Handle ldrexd to use even,even+1 regs.
- * + Handle predication.
- * + Handle acquire loads being unsupported in Thumb mode on some processors.
+/* TODO i#1698: ARM is still missing the abilty to convert the following:
+ * + ldrexd..strexd.
+ * + Predicated exclusive loads or stores.
+ * It will continue with a debug build warning if it sees those.
  */
-OPTION_DEFAULT_INTERNAL(bool, ldstex2cas, IF_ARM_ELSE(false, true),
+OPTION_DEFAULT_INTERNAL(bool, ldstex2cas, true,
                         "replace exclusive load/store with compare-and-swap to "
                         "allow instrumentation, at the risk of ABA errors")
 #endif

--- a/suite/tests/client-interface/ldstex.c
+++ b/suite/tests/client-interface/ldstex.c
@@ -598,18 +598,20 @@ GLOBAL_LABEL(FUNCNAME:)
       4:
         /* Test unpaired cases and sp as a base. */
         sub      sp, sp, #16
-        ldrex    r0, [sp]
+        ldrex    r2, [sp]
         clrex
         strex    r1, r0, [sp]
         strex    r1, r0, [sp]
         strex    r1, r0, [sp]
+#    if 0 /* XXX i#1698: This mismatch succeeds on my A32 processor!  Disabling for now. */
         /* Test wrong sizes paired. */
-        ldrexd   r2, r3, [sp]
-        strex    r4, r1, [sp]
-        cmp      r4, #0
+        ldrexd   r1, r2, [sp]
+        strex    r3, r1, [sp]
+        cmp      r3, #0
         bne      5f
         mov      r0, #8 /* Should never come here; this will fail caller. */
         bx       lr
+#    endif
       5:
         add      sp, sp, #16
         ldaex    r1, [r0]

--- a/suite/tests/client-interface/ldstex.dll.c
+++ b/suite/tests/client-interface/ldstex.dll.c
@@ -53,9 +53,21 @@ bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool trans
     for (instr = instrlist_first(bb); instr != NULL; instr = instr_get_next(instr)) {
         if (instr_is_exclusive_load(instr)) {
             insert_at = instr_get_next(instr);
+#ifdef ARM
+            /* TODO i#1698: DR does not yet convert 32-bit pairs. */
+            if (instr_get_opcode(instr) == OP_ldaexd ||
+                instr_get_opcode(instr) == OP_ldrexd)
+                insert_at = NULL;
+#endif
             break;
         } else if (instr_is_exclusive_store(instr)) {
             insert_at = instr;
+#ifdef ARM
+            /* TODO i#1698: DR does not yet convert 32-bit pairs. */
+            if (instr_get_opcode(instr) == OP_stlexd ||
+                instr_get_opcode(instr) == OP_strexd)
+                insert_at = NULL;
+#endif
             break;
         }
     }


### PR DESCRIPTION
Turns on -ldstex2cas by default for 32-bit ARM.
However, adds bailing on conversion for predication or for pair
operations, which are not yet handled.

Fixes -no_ldstex2cas to properly mangle stolen register usage in
exclusive operations.

Adds proc_get_architecture() for determining whether the processor
supports load-acquire operations.

Tested on the client.ldstex test on ARM Linux.

Issue: #1698