### PR TITLE
i#4594: Fix a64 gcc10 zero-size-array build failures

### DIFF
--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -408,8 +408,10 @@ typedef struct _clean_call_info_t {
     bool skip_clear_flags;
     int num_simd_skip;
     bool simd_skip[MCXT_NUM_SIMD_SLOTS];
+#ifdef X86
     int num_opmask_skip;
     bool opmask_skip[MCXT_NUM_OPMASK_SLOTS];
+#endif
     uint num_regs_skip;
     bool reg_skip[DR_NUM_GPR_REGS];
     bool preserve_mcontext; /* even if skip reg save, preserve mcontext shape */
@@ -1447,20 +1449,22 @@ typedef struct _slot_t {
 
 /* data structure of clean call callee information. */
 typedef struct _callee_info_t {
-    bool bailout;        /* if we bail out on function analysis */
-    uint num_args;       /* number of args that will passed in */
-    int num_instrs;      /* total number of instructions of a function */
-    app_pc start;        /* entry point of a function  */
-    app_pc bwd_tgt;      /* earliest backward branch target */
-    app_pc fwd_tgt;      /* last forward branch target */
-    int num_simd_used;   /* number of SIMD registers (xmms) used by callee */
-    int num_opmask_used; /* number of mask registers used by callee */
+    bool bailout;      /* if we bail out on function analysis */
+    uint num_args;     /* number of args that will passed in */
+    int num_instrs;    /* total number of instructions of a function */
+    app_pc start;      /* entry point of a function  */
+    app_pc bwd_tgt;    /* earliest backward branch target */
+    app_pc fwd_tgt;    /* last forward branch target */
+    int num_simd_used; /* number of SIMD registers (xmms) used by callee */
     /* SIMD ([xyz]mm) registers usage. Part of the array might be left
      * uninitialized if proc_num_simd_registers() < MCXT_NUM_SIMD_SLOTS.
      */
     bool simd_used[MCXT_NUM_SIMD_SLOTS];
+#ifdef X86
+    int num_opmask_used; /* number of mask registers used by callee */
     /* AVX-512 mask register usage. */
     bool opmask_used[MCXT_NUM_OPMASK_SLOTS];
+#endif
     bool reg_used[DR_NUM_GPR_REGS];         /* general purpose registers usage */
     int num_callee_save_regs;               /* number of regs callee saved */
     bool callee_save_regs[DR_NUM_GPR_REGS]; /* callee-save registers */

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -326,8 +326,8 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
 #endif
         ASSERT((dstack_offs % get_ABI_stack_alignment()) == 0);
     }
-    ASSERT(cci->skip_save_flags || cci->num_simd_skip != 0 || cci->num_opmask_skip != 0 ||
-           cci->num_regs_skip != 0 ||
+    ASSERT(cci->skip_save_flags || cci->num_simd_skip != 0 ||
+           IF_X86(cci->num_opmask_skip != 0 ||) cci->num_regs_skip != 0 ||
            (int)dstack_offs ==
                (get_clean_call_switch_stack_size() + clean_call_beyond_mcontext()));
     return dstack_offs;

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -125,8 +125,10 @@ insert_get_mcontext_base(dcontext_t *dcontext, instrlist_t *ilist, instr_t *wher
 bool
 clean_call_needs_simd(clean_call_info_t *cci)
 {
-    return (cci->preserve_mcontext || cci->num_simd_skip != proc_num_simd_registers() ||
-            cci->num_opmask_skip != proc_num_opmask_registers());
+    return (cci->preserve_mcontext ||
+            cci->num_simd_skip !=
+                proc_num_simd_registers()
+                    IF_X86(|| cci->num_opmask_skip != proc_num_opmask_registers()));
 }
 
 /* Number of extra slots in addition to register slots. */

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -5628,12 +5628,14 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
 #else
         /* all 8, 16 or 32 are scratch */
         cci.num_simd_skip = proc_num_simd_registers();
-        cci.num_opmask_skip = proc_num_opmask_registers();
 #endif
         for (i = 0; i < cci.num_simd_skip; i++)
             cci.simd_skip[i] = true;
+#ifdef X86
+        cci.num_opmask_skip = proc_num_opmask_registers();
         for (i = 0; i < cci.num_opmask_skip; i++)
             cci.opmask_skip[i] = true;
+#endif
             /* now remove those used for param/retval */
 #ifdef X64
         if (TEST(DR_CLEANCALL_NOSAVE_XMM_NONPARAM, save_flags)) {

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -1239,7 +1239,9 @@ STATS_DEF("Clean Call analyzed", cleancall_analyzed)
 STATS_DEF("Clean Call inserted", cleancall_inserted)
 STATS_DEF("Clean Call inlined", cleancall_inlined)
 STATS_DEF("Clean Call [xyz]mm skipped", cleancall_simd_skipped)
+#ifdef X86
 STATS_DEF("Clean Call mask skipped", cleancall_opmask_skipped)
+#endif
 STATS_DEF("Clean Call aflags save skipped", cleancall_aflags_save_skipped)
 STATS_DEF("Clean Call aflags clear skipped", cleancall_aflags_clear_skipped)
 /* i#107 handle application using same segment register */


### PR DESCRIPTION
Adds X86 ifdefs around the AVX-512 opmask fields in the clean call
optimization structures and the code that references them, to avoid
zero-size-array compiler errors with gcc10 (and with Visual Studio).

Issue: #1684, #4594
Fixes #4594