### PR TITLE
i#2629: Clarify docs on floating-point preservation

### DIFF
--- a/api/docs/samples.dox
+++ b/api/docs/samples.dox
@@ -559,11 +559,13 @@ href="https://github.com/DynamoRIO/dynamorio/tree/master/api/samples/inline.c">i
 
 
 ********************
-\subsection sec_ex6 Use of Floating Point Operation in a Client
+\subsection sec_ex6 Use of x87 Floating Point Operation in a Client
 
-Because saving the floating point state is very expensive, on x86 DynamoRIO
+Because saving the x87 floating point state is very expensive, on x86 DynamoRIO
 seeks to do so on an as needed basis.  If a client wishes to use floating point
-operations it must save and restore the application's floating point state
+operations and is unsure whether its compiler will use x87 or not, or if it
+wishes to use MMX registers, it must
+save and restore the application's floating point state
 around the usage.  For an inserted clean call out of the code cache, this
 can be conveniently done using dr_insert_clean_call() and passing true for
 the save_fpstate parameter.  It can also be done explicitly using these
@@ -574,7 +576,7 @@ void proc_save_fpstate(byte *buf);
 void proc_restore_fpstate(byte *buf);
 \endcode
 
-These routines must be used if floating point operations are performed in
+These routines must be used if x87 floating point operations are performed in
 non-inserted-call locations, such as event callbacks.  Note that there are
 restrictions on how these methods may be called: see the documentation in
 the header files for additional information.  Note also that the floating
@@ -585,6 +587,9 @@ they are being used in the initialization or termination routines.
 
 On ARM and AArch64 the SIMD/FP registers are always saved, so
 proc_save_fpstate and proc_restore_fpstate are no-ops.
+On x86, modern compilers typically do not use x87 operations, but to be
+safe clients are still advised to either avoid floating-point operations
+or use the preservation routines listed here.
 
 This example client counts the number of basic blocks processed and keeps
 statistics on their average size using floating point operations. Full code

--- a/api/docs/transp.dox
+++ b/api/docs/transp.dox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -143,16 +143,16 @@ lead to deadlocks.
 As many aspects of the application as possible should be left unchanged:
 
 \anchor sec_trans_floating_point
-\par Floating Point State Transparency
+\par X87 Floating Point State Transparency
 
 Because it is expensive to do so and rarely necessary, on x86 DynamoRIO does
-\e NOT save or restore the floating point state or MMX (64-bit) registers
+\e NOT save or restore the x87 floating point state or MMX (64-bit) registers
 during a context switch away from the application.  The larger multimedia
-registers that are separated from the floating point state (SSE and beyond)
+registers (XMM, YMM, ZMM, whether holding floating-point or integer values)
 are preserved, but if at any time a
-client wishes to use floating point or MMX operations, it
+client wishes to use x87 floating point or MMX operations, it
 must explicitly preserve the state.  The dr_insert_clean_call() routine
-takes a boolean indicating whether floating point state should be preserved
+takes a boolean indicating whether x87 floating point state should be preserved
 across the call; this is the most convenient method for saving the state.
 
 The state can alternatively be saved explicitly from C code using:
@@ -177,7 +177,8 @@ proc_save_fpstate(fp_align);
 \endcode
 
 Note that floating point operations include almost any operation that
-acts on a float, even printing one with %%f.
+acts on a float, even printing one with %%f, on older compilers.  Modern compilers
+typically do not use x87 operations.
 
 The XMM (128-bit) and larger registers are saved by DynamoRIO on context switches and
 clean calls.  See also the dr_mcontext_xmm_fields_valid() routine.

--- a/core/arch/proc.h
+++ b/core/arch/proc.h
@@ -462,7 +462,7 @@ proc_get_cache_size_str(cache_size_t size);
 
 DR_API
 /**
- * Returns the size in bytes needed for a buffer for saving the floating point state.
+ * Returns the size in bytes needed for a buffer for saving the x87 floating point state.
  */
 size_t
 proc_fpstate_save_size(void);
@@ -579,10 +579,10 @@ proc_xstate_area_hi16_zmm_offs(void);
 
 DR_API
 /**
- * Saves the floating point state into the buffer \p buf.
+ * Saves the x87 floating point state into the buffer \p buf.
  *
  * On x86, the buffer must be 16-byte-aligned, and it must be
- * 512 (DR_FPSTATE_BUF_SIZE) bytes for processors with the FXSR feature,
+ * 512 (#DR_FPSTATE_BUF_SIZE) bytes for processors with the FXSR feature,
  * and 108 bytes for those without (where this routine does not support
  * 16-bit operand sizing).  On ARM/AArch64, nothing needs to be saved as the
  * SIMD/FP registers are saved together with the general-purpose registers.
@@ -596,10 +596,11 @@ DR_API
  * The last floating-point instruction address is left in an
  * untranslated state (i.e., it may point into the code cache).
  *
- * DR does NOT save the application's floating-point or MMX state
+ * DR does NOT save the application's x87 floating-point or MMX state
  * on context switches!  Thus if a client performs any floating-point
- * operations in its main routines called by DR, the client must save
- * and restore the floating-point/MMX state.
+ * operations in its main routines called by DR and cannot prove that its
+ * compiler will not use x87 operations, the client must save
+ * and restore the x87 floating-point/MMX state.
  * If the client needs to do so inside the code cache the client should implement
  * that itself.
  * Returns number of bytes written.
@@ -609,9 +610,9 @@ proc_save_fpstate(byte *buf);
 
 DR_API
 /**
- * Restores the floating point state from the buffer \p buf.
+ * Restores the x87 floating point state from the buffer \p buf.
  * On x86, the buffer must be 16-byte-aligned, and it must be
- * 512 (DR_FPSTATE_BUF_SIZE) bytes for processors with the FXSR feature,
+ * 512 (#DR_FPSTATE_BUF_SIZE) bytes for processors with the FXSR feature,
  * and 108 bytes for those without (where this routine does not support
  * 16-bit operand sizing).  On ARM/AArch64, nothing needs to be restored as the
  * SIMD/FP registers are restored together with the general-purpose registers.


### PR DESCRIPTION
Clarifies the prose documentation and API routine documentation on
what floating-point state is preserved and what is not by DR and what
the various explicit "fpstate" preservation routines operate on: only
the *x87* floating-point state.

Fixes #2629