### PR TITLE
i#1698 ldstex2cas: Add comments on mismatched pair handling

### DIFF
--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -3206,6 +3206,14 @@ mangle_exclusive_load(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
             (instr_is_exclusive_load(in) || instr_get_opcode(in) == OP_clrex))
             break;
         if (instr_is_app(in) && instr_is_exclusive_store(in)) {
+            /* Warn on a mismatched pair. */
+            if (opnd_get_size(instr_get_dst(in, 0)) !=
+                opnd_get_size(instr_get_src(instr, 0))) {
+                /* See comment below about CONSTRAINED UNPREDICTABLE. */
+                SYSLOG_INTERNAL_WARNING_ONCE(
+                    "Encountered mismatched-size ldex-stex pair: behavior may not "
+                    "exactly match CONSTRAINED UNPREDICTABLE hardware");
+            }
             if (opnd_get_size(instr_get_dst(in, 0)) ==
                     opnd_get_size(instr_get_src(instr, 0)) &&
                 /* Bail on one side being a pair of 4-byte and the other a single 8-byte:
@@ -3509,7 +3517,7 @@ mangle_exclusive_store(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         /* Compare size, arranging op_res to show failure on mismatch.  On some
          * processors, if the stxr's address range is a subset of the ldxp's range, it
          * will succeed, even if the size or base address are not identical.  However,
-         * the manual states that this is Constrained Unpredictable behavior: B2.9.5 says
+         * the manual states that this is CONSTRAINED UNPREDICTABLE behavior: B2.9.5 says
          * "software can rely on a LoadExcl / StoreExcl pair to eventually succeed only
          * if the LoadExcl and the StoreExcl have the same transaction size."  Similarly
          * for the target VA and reg count.  Thus, given the complexity of trying to

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -3506,9 +3506,16 @@ mangle_exclusive_store(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
                                           opnd_create_reg(reg_base),
                                           opnd_create_reg(scratch), no_match);
 
-        /* Compare size, arranging op_res to show failure on mismatch.
-         * TODO i#1698: Size mismatches do not seem to always fail on all processors:
-         * but we assume they cannot be relied upon to succeed.
+        /* Compare size, arranging op_res to show failure on mismatch.  On some
+         * processors, if the stxr's address range is a subset of the ldxp's range, it
+         * will succeed, even if the size or base address are not identical.  However,
+         * the manual states that this is Constrained Unpredictable behavior: B2.9.5 says
+         * "software can rely on a LoadExcl / StoreExcl pair to eventually succeed only
+         * if the LoadExcl and the StoreExcl have the same transaction size."  Similarly
+         * for the target VA and reg count.  Thus, given the complexity of trying to
+         * match the actual processor behavior and comparing ranges and whatnot, we're ok
+         * with DR enforcing a strict equality, until or unless we see real apps relying
+         * on processor quirks.
          */
         PRE(ilist, instr,
             instr_create_restore_from_tls(dcontext, scratch, TLS_LDSTEX_SIZE_SLOT));

--- a/suite/tests/client-interface/ldstex.c
+++ b/suite/tests/client-interface/ldstex.c
@@ -550,8 +550,8 @@ GLOBAL_LABEL(FUNCNAME:)
         stxr     w1, x0, [sp]
         /* Test wrong sizes paired.
          * On some processors, if the stxr's address range is a subset of the ldxp's
-         * range, it will succeed.  However, the manual states that this is Constrained
-         * Unpredictable behavior: B2.9.5 says "software can rely on a LoadExcl /
+         * range, it will succeed.  However, the manual states that this is CONSTRAINED
+         * UNPREDICTABLE behavior: B2.9.5 says "software can rely on a LoadExcl /
          * StoreExcl pair to eventually succeed only if the LoadExcl and the StoreExcl
          * have the same transaction size."  Similarly for the target VA and reg count.
          * Thus, given the complexity of trying to match the actual processor behavior

--- a/suite/tests/client-interface/ldstex.c
+++ b/suite/tests/client-interface/ldstex.c
@@ -548,7 +548,19 @@ GLOBAL_LABEL(FUNCNAME:)
         stxr     w1, x0, [sp]
         stxr     w1, x0, [sp]
         stxr     w1, x0, [sp]
-        /* Test wrong sizes paired. */
+        /* Test wrong sizes paired.
+         * On some processors, if the stxr's address range is a subset of the ldxp's
+         * range, it will succeed.  However, the manual states that this is Constrained
+         * Unpredictable behavior: B2.9.5 says "software can rely on a LoadExcl /
+         * StoreExcl pair to eventually succeed only if the LoadExcl and the StoreExcl
+         * have the same transaction size."  Similarly for the target VA and reg count.
+         * Thus, given the complexity of trying to match the actual processor behavior
+         * and comparing ranges and whatnot, we're ok with DR enforcing a strict
+         * equality, until or unless we see real apps relying on processor quirks.
+         * That means that while this ldxp;stxr might succeed natively on some processors
+         * (symptoms: "Error in ldstex_inc_shapes: 43"), it will fail under DR and
+         * our test will pass.
+         */
         ldxp     x1, x2, [sp]
         stxr     w3, x1, [sp]
         cbnz     w3, 5f
@@ -603,15 +615,15 @@ GLOBAL_LABEL(FUNCNAME:)
         strex    r1, r0, [sp]
         strex    r1, r0, [sp]
         strex    r1, r0, [sp]
-#    if 0 /* XXX i#1698: This mismatch succeeds on my A32 processor!  Disabling for now. */
-        /* Test wrong sizes paired. */
-        ldrexd   r1, r2, [sp]
-        strex    r3, r1, [sp]
+        /* Test wrong sizes paired.
+         * See comment above about the unpredictability of behavior here.
+         */
+        ldrexd   r2, r3, [sp]
+        strex    r3, r2, [sp]
         cmp      r3, #0
         bne      5f
         mov      r0, #8 /* Should never come here; this will fail caller. */
         bx       lr
-#    endif
       5:
         add      sp, sp, #16
         ldaex    r1, [r0]


### PR DESCRIPTION
Adds comments explaining why we're leaving DR's strict equality checks
on the base address and size between the exclusive-load and
exclusive-store.

Issue: #1698