### PR TITLE
i#4585 CI autocancel: Add missing auto-cancel to 3 jobs

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -82,6 +82,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
+
     - run: git fetch --no-tags --depth=1 origin master
 
     # Fetch and install Android NDK for Andoid cross-compile build.
@@ -112,6 +118,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
 
     - run: git fetch --no-tags --depth=1 origin master
 

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -95,6 +95,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
+
     - run: git fetch --no-tags --depth=1 origin master
 
     # Install multilib for non-cross-compiling Linux build:


### PR DESCRIPTION
PR #4599 failed to add auto-cancel to jobs beyond the first in each
workflow, thus missing 3 jobs.  We correct that here.

Issue: #4585