### PR TITLE
i#4593 drwrap-detach-test: Add to ignore list

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -307,8 +307,10 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'code_api|client.timer' => 1, # i#3127
                                    'code_api|sample.signal' => 1); # i#3127
         } else {
-            # FIXME i#2921: fix flaky ptsig test
-            %ignore_failures_32 = ('code_api|pthreads.ptsig' => 1);
+            %ignore_failures_32 = (
+                'code_api|pthreads.ptsig' => 1, # i#2921
+                'code_api|client.drwrap-test-detach' => 1, # i#4593
+                );
             # FIXME i#2941: fix flaky threadfilter test
             %ignore_failures_64 = ('code_api|tool.drcacheoff.burst_threadfilter' => 1);
             $issue_no = "#2941";


### PR DESCRIPTION
Adds client.drwrap-test-detach to the 32-bit Linux ignore list as it
is a known flaky failure.

Issue: #4593