### PR TITLE
iX add platform-independent macros for call ind

### DIFF
--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -899,9 +899,7 @@ insert_reachable_cti(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
                            opnd_create_reg(scratch), ilist, where, NULL, NULL);
     /* even if a call and not a jmp, we can skip this if it doesn't return */
     if (!jmp && returns) {
-        PRE(ilist, where,
-            IF_AARCH64_ELSE(INSTR_CREATE_blr,
-                            INSTR_CREATE_blx_ind)(dcontext, opnd_create_reg(scratch)));
+        PRE(ilist, where, XINST_CREATE_call_ind(dcontext, opnd_create_reg(scratch)));
     } else {
         PRE(ilist, where, XINST_CREATE_jump_reg(dcontext, opnd_create_reg(scratch)));
     }

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -899,7 +899,7 @@ insert_reachable_cti(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
                            opnd_create_reg(scratch), ilist, where, NULL, NULL);
     /* even if a call and not a jmp, we can skip this if it doesn't return */
     if (!jmp && returns) {
-        PRE(ilist, where, XINST_CREATE_call_ind(dcontext, opnd_create_reg(scratch)));
+        PRE(ilist, where, XINST_CREATE_call_reg(dcontext, opnd_create_reg(scratch)));
     } else {
         PRE(ilist, where, XINST_CREATE_jump_reg(dcontext, opnd_create_reg(scratch)));
     }

--- a/core/ir/aarch64/instr_create.h
+++ b/core/ir/aarch64/instr_create.h
@@ -479,8 +479,8 @@ enum {
 /**
  * This platform-independent macro creates an instr_t for an indirect call instr.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
- * \param t   The opnd_t explicit source operand for the instruction. This should
- * be a reg_id_t with the address of the subroutine.
+ * \param r   The opnd_t explicit source operand for the instruction. This should
+ * be a reg_id_t operand with the address of the subroutine.
  */
 #define XINST_CREATE_call_ind(dc, r) INSTR_CREATE_blr(dc, r)
 

--- a/core/ir/aarch64/instr_create.h
+++ b/core/ir/aarch64/instr_create.h
@@ -476,6 +476,14 @@ enum {
  */
 #define XINST_CREATE_nop(dc) INSTR_CREATE_nop(dc)
 
+/**
+ * This platform-independent macro creates an instr_t for an indirect call instr.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param t   The opnd_t explicit source operand for the instruction. This should
+ * be a reg_id_t with the address of the subroutine.
+ */
+#define XINST_CREATE_call_ind(dc, r) INSTR_CREATE_blr(dc, r)
+
 /* @} */ /* end doxygen group */
 
 /****************************************************************************

--- a/core/ir/aarch64/instr_create.h
+++ b/core/ir/aarch64/instr_create.h
@@ -477,12 +477,13 @@ enum {
 #define XINST_CREATE_nop(dc) INSTR_CREATE_nop(dc)
 
 /**
- * This platform-independent macro creates an instr_t for an indirect call instr.
+ * This platform-independent macro creates an instr_t for an indirect call instr
+ * through a register.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param r   The opnd_t explicit source operand for the instruction. This should
  * be a reg_id_t operand with the address of the subroutine.
  */
-#define XINST_CREATE_call_ind(dc, r) INSTR_CREATE_blr(dc, r)
+#define XINST_CREATE_call_reg(dc, r) INSTR_CREATE_blr(dc, r)
 
 /* @} */ /* end doxygen group */
 

--- a/core/ir/arm/instr_create.h
+++ b/core/ir/arm/instr_create.h
@@ -431,6 +431,14 @@ enum {
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  */
 #define XINST_CREATE_nop(dc) INSTR_CREATE_nop(dc)
+
+/**
+ * This platform-independent macro creates an instr_t for an indirect call instr.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param t   The opnd_t explicit source operand for the instruction. This should
+ * be a reg_id_t with the address of the subroutine.
+ */
+#define XINST_CREATE_call_ind(dc, r) INSTR_CREATE_blx_ind(dc, r)
 /* @} */ /* end doxygen group */
 
 /****************************************************************************

--- a/core/ir/arm/instr_create.h
+++ b/core/ir/arm/instr_create.h
@@ -433,12 +433,13 @@ enum {
 #define XINST_CREATE_nop(dc) INSTR_CREATE_nop(dc)
 
 /**
- * This platform-independent macro creates an instr_t for an indirect call instr.
+ * This platform-independent macro creates an instr_t for an indirect call instr
+ * through a register.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param r   The opnd_t explicit source operand for the instruction. This should
  * be a reg_id_t operand with the address of the subroutine.
  */
-#define XINST_CREATE_call_ind(dc, r) INSTR_CREATE_blx_ind(dc, r)
+#define XINST_CREATE_call_reg(dc, r) INSTR_CREATE_blx_ind(dc, r)
 /* @} */ /* end doxygen group */
 
 /****************************************************************************

--- a/core/ir/arm/instr_create.h
+++ b/core/ir/arm/instr_create.h
@@ -435,8 +435,8 @@ enum {
 /**
  * This platform-independent macro creates an instr_t for an indirect call instr.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
- * \param t   The opnd_t explicit source operand for the instruction. This should
- * be a reg_id_t with the address of the subroutine.
+ * \param r   The opnd_t explicit source operand for the instruction. This should
+ * be a reg_id_t operand with the address of the subroutine.
  */
 #define XINST_CREATE_call_ind(dc, r) INSTR_CREATE_blx_ind(dc, r)
 /* @} */ /* end doxygen group */

--- a/core/ir/x86/instr_create.h
+++ b/core/ir/x86/instr_create.h
@@ -466,6 +466,14 @@
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  */
 #define XINST_CREATE_nop(dc) INSTR_CREATE_nop(dc)
+
+/**
+ * This platform-independent macro creates an instr_t for an indirect call instr.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param t   The opnd_t explicit source operand for the instruction. This should
+ * be a reg_id_t with the address of the subroutine.
+ */
+#define XINST_CREATE_call_ind(dc, r) INSTR_CREATE_call_ind(dc, r)
 /* @} */ /* end doxygen group */
 
 /****************************************************************************

--- a/core/ir/x86/instr_create.h
+++ b/core/ir/x86/instr_create.h
@@ -468,12 +468,13 @@
 #define XINST_CREATE_nop(dc) INSTR_CREATE_nop(dc)
 
 /**
- * This platform-independent macro creates an instr_t for an indirect call instr.
+ * This platform-independent macro creates an instr_t for an indirect call instr
+ * through a register.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param r   The opnd_t explicit source operand for the instruction. This should
  * be a reg_id_t operand with the address of the subroutine.
  */
-#define XINST_CREATE_call_ind(dc, r) INSTR_CREATE_call_ind(dc, r)
+#define XINST_CREATE_call_reg(dc, r) INSTR_CREATE_call_ind(dc, r)
 /* @} */ /* end doxygen group */
 
 /****************************************************************************

--- a/core/ir/x86/instr_create.h
+++ b/core/ir/x86/instr_create.h
@@ -470,8 +470,8 @@
 /**
  * This platform-independent macro creates an instr_t for an indirect call instr.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
- * \param t   The opnd_t explicit source operand for the instruction. This should
- * be a reg_id_t with the address of the subroutine.
+ * \param r   The opnd_t explicit source operand for the instruction. This should
+ * be a reg_id_t operand with the address of the subroutine.
  */
 #define XINST_CREATE_call_ind(dc, r) INSTR_CREATE_call_ind(dc, r)
 /* @} */ /* end doxygen group */

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -4445,6 +4445,8 @@ test_xinst(void *dc)
         XINST_CREATE_store_pair(dc, OPND_CREATE_MEM64(DR_REG_X2, 0),
                                 opnd_create_reg(DR_REG_W0), opnd_create_reg(DR_REG_W1));
     test_instr_encoding(dc, OP_stp, instr);
+    instr = XINST_CREATE_call_reg(dc, opnd_create_reg(DR_REG_X5));
+    test_instr_encoding(dc, OP_blr, instr);
 }
 
 static void

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -861,6 +861,7 @@ clrex  $0x0000000000000000
 test_exclusive_memops complete
 ldp    (%x2)[8byte] -> %w0 %w1
 stp    %w0 %w1 -> (%x2)[8byte]
+blr    %x5 -> %x30
 test_xinst complete
 test_opnd complete
 test_mov_instr_addr complete

--- a/suite/tests/api/ir_arm.c
+++ b/suite/tests/api/ir_arm.c
@@ -67,6 +67,26 @@
 
 static byte buf[8192];
 
+static void
+test_instr_encoding(void *dc, uint opcode, instr_t *instr)
+{
+    instr_t *decin;
+    byte *pc;
+
+    ASSERT(instr_get_opcode(instr) == opcode);
+    instr_disassemble(dc, instr, STDERR);
+    print("\n");
+
+    ASSERT(instr_is_encoding_possible(instr));
+    pc = instr_encode(dc, instr, buf);
+    decin = instr_create(dc);
+    decode(dc, buf, decin);
+    ASSERT(instr_same(instr, decin));
+
+    instr_destroy(dc, instr);
+    instr_destroy(dc, decin);
+}
+
 /***************************************************************************
  * XXX i#1686: we need to add the IR consistency checks for ARM that we have on
  * x86, ensuring that these are all consistent with each other:
@@ -160,6 +180,18 @@ test_flags(void *dc)
     instr_free(dc, inst);
 }
 
+static void
+test_xinst(void *dc)
+{
+    instr_t *instr;
+    /* Sanity check of misc XINST_CREATE_ macros. */
+
+    /* XXX i#1686: add tests of remaining XINST_CREATE macros */
+    /* TODO i#1686: add expected patterns to ir_arm.expect */
+    instr = XINST_CREATE_call_reg(dc, opnd_create_reg(DR_REG_R5));
+    test_instr_encoding(dc, OP_blx_ind, instr);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -171,7 +203,8 @@ main(int argc, char *argv[])
 
     /* XXX i#1686: add tests of all opcodes for internal consistency */
 
-    /* XXX i#1686: add tests of XINST_CREATE macros */
+    test_xinst(dcontext);
+    print("test_xinst complete\n");
 
     test_pcrel(dcontext);
 

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -2071,6 +2071,16 @@ test_xinst_create(void *dc)
     ASSERT(instr_same(ins1, ins2));
     instr_destroy(dc, ins1);
     instr_destroy(dc, ins2);
+    /* indirect call through a register */
+    ins1 = XINST_CREATE_call_reg(dc, opnd_create_reg(DR_REG_XBX));
+    pc = instr_encode(dc, ins1, buf);
+    ASSERT(pc != NULL);
+    ins2 = instr_create(dc);
+    decode(dc, buf, ins2);
+    ASSERT(instr_same(ins1, ins2));
+    ASSERT(instr_get_opcode(ins2) == OP_call_ind);
+    instr_destroy(dc, ins1);
+    instr_destroy(dc, ins2);
 }
 
 static void


### PR DESCRIPTION
Adds `XINST_CREATE_call_ind` macros for ARM, AArch64 and x86. They point to the respective instrs on the platforms for transferring control to address in given register operand.