### PR TITLE
i#3535: Solve detach handler race

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -627,6 +627,11 @@ dynamorio_app_init(void)
             sideline_init();
 #endif
 
+        /* We can't clear this on detach like other vars b/c we need native threads
+         * to continue to avoid safe_read_tls_magic() in is_thread_tls_initialized().
+         * So we clear it on (re-)init.
+         */
+        detacher_tid = INVALID_THREAD_ID;
         /* thread-specific initialization for the first thread we inject in
          * (in a race with injected threads, sometimes it is not the primary thread)
          */

--- a/core/globals.h
+++ b/core/globals.h
@@ -533,6 +533,7 @@ extern bool dynamo_all_threads_synched; /* are all other threads suspended safel
  * go through the app interface.
  */
 extern bool doing_detach;
+extern thread_id_t detacher_tid;
 
 extern event_t dr_app_started;
 extern event_t dr_attach_finished;

--- a/core/synch.c
+++ b/core/synch.c
@@ -48,6 +48,7 @@ extern vm_area_vector_t *fcache_unit_areas; /* from fcache.c */
 
 static bool started_detach = false; /* set before synchall */
 bool doing_detach = false;          /* set after synchall */
+thread_id_t detacher_tid = INVALID_THREAD_ID;
 
 static void
 synch_thread_yield(void);
@@ -2111,6 +2112,7 @@ detach_on_permanent_stack(bool internal, bool do_cleanup, dr_stats_t *drstats)
 
     ASSERT(!doing_detach);
     doing_detach = true;
+    detacher_tid = d_r_get_thread_id();
 
 #ifdef HOT_PATCHING_INTERFACE
     /* In hotp_only mode, we must remove patches when detaching; we don't want


### PR DESCRIPTION
Eliminates a race on detach where the detaching thread removes DR's
SIGSEGV handler while a now-native detached thread is in the middle of
having a signal delivered (natively) and invokes a TLS magic field
safe read, whose SIGSEGV then goes to the application.

The detaching thread is the one doing all the real cleanup, so we
simply avoid any safe reads or TLS for detaching threads by recording
the detacher's ID when we start the detach process.  This var is not
cleared until re-init, so we have no race with the end of detach.

Tested on api.detach_signal with the forthcoming signal mask checks,
which trigger when the handler is invoked for a DR signal instead of
an app-generated signal.  Without this fix, the test fails easily:
about 1 in 5 runs in debug build.  With this fix, it succeeds 200x in
a loop.  I still see one type of crash in debug build, a rare race
where d_r_stats is set to NULL in between the check and use of a
LOG(), but that is limited to debug and is beyond the scope of this
fix and is much lower priority: I filed it as #4641.

Fixes #3535