### PR TITLE
Use a stable URL for downloading Windows doxygen

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -391,7 +391,7 @@ jobs:
       run: |
         md c:\projects\install
         (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.9.0/doxygen-1.9.0.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
 
     - name: Get Version
       id: version

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -391,7 +391,7 @@ jobs:
       run: |
         md c:\projects\install
         (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("http://doxygen.nl/files/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.9.0/doxygen-1.9.0.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
 
     - name: Get Version
       id: version

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         md c:\projects\install
         (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("http://doxygen.nl/files/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.9.0/doxygen-1.9.0.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -136,7 +136,7 @@ jobs:
       run: |
         md c:\projects\install
         (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("http://doxygen.nl/files/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.9.0/doxygen-1.9.0.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -200,7 +200,7 @@ jobs:
       run: |
         md c:\projects\install
         (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("http://doxygen.nl/files/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.9.0/doxygen-1.9.0.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         md c:\projects\install
         (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.9.0/doxygen-1.9.0.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -136,7 +136,7 @@ jobs:
       run: |
         md c:\projects\install
         (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.9.0/doxygen-1.9.0.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -200,7 +200,7 @@ jobs:
       run: |
         md c:\projects\install
         (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.9.0/doxygen-1.9.0.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}


### PR DESCRIPTION
The doxygen.nl URL breaks every few months when they put out their
latest release and remove the old release.  We switch to their
sourceforge site which archives old releases, so we won't break in the
near future.  (Xref #4000 where we used to use chocolatey to avoid
specifying the precise version: but choco was flaky.)