### PR TITLE
i#1921 native sig: Account for sigaltstack when placing native frames

### DIFF
--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -632,7 +632,7 @@ Severity = Error
 Facility = DRCore
 SymbolicName = MSG_FAILED_TO_HANDLE_SIGNAL
 Language=English
-Application %1!s! (%2!s!). Cannot correctly handle received signal %3!s! in thread %4!s!.
+Application %1!s! (%2!s!). Cannot correctly handle received signal %3!s! in thread %4!s!: %5!s!.
 .
 ;#endif
 


### PR DESCRIPTION
The native frame adjustments to handle the DR handler being on the
native stack previously failed to handle an application with a
sigaltstack.  We correct that here.

Adds sigaltstack testing to the api.detach_signal test.  With a
smaller stack, this exercises the stack-too-small error message path
from DR.

Issue: #1921