### PR TITLE
Don't use libc's stderr in libdrdecode

### DIFF
--- a/core/ir/decodelib.c
+++ b/core/ir/decodelib.c
@@ -47,11 +47,15 @@
 /* initialize to all zeros.  disassemble_set_syntax will write to it. */
 options_t dynamo_options;
 
+#undef STDERR
+
 /* support use of STD* macros so user doesn't have to use "stdout->_fileno" */
 #    ifdef UNIX
 file_t our_stdout = STDOUT_FILENO;
 file_t our_stderr = STDERR_FILENO;
 file_t our_stdin = STDIN_FILENO;
+
+#define STDERR (our_stderr)
 #    endif
 
 #    ifdef WINDOWS
@@ -72,6 +76,8 @@ dr_get_stdin_file(void)
 {
     return GetStdHandle(STD_INPUT_HANDLE);
 }
+
+#define STDERR (dr_get_stderr_file())
 #    endif
 
 static uint vendor = VENDOR_INTEL; /* default */

--- a/core/ir/decodelib.c
+++ b/core/ir/decodelib.c
@@ -128,7 +128,7 @@ get_thread_private_dcontext(void)
 void
 external_error(const char *file, int line, const char *msg)
 {
-    fprintf(stderr, "Usage error: %s (%s, line %d)\n", msg, file, line);
+    print_file(STDERR, "Usage error: %s (%s, line %d)\n", msg, file, line);
     abort();
 }
 

--- a/core/ir/decodelib.c
+++ b/core/ir/decodelib.c
@@ -47,7 +47,7 @@
 /* initialize to all zeros.  disassemble_set_syntax will write to it. */
 options_t dynamo_options;
 
-#undef STDERR
+#    undef STDERR
 
 /* support use of STD* macros so user doesn't have to use "stdout->_fileno" */
 #    ifdef UNIX
@@ -55,7 +55,7 @@ file_t our_stdout = STDOUT_FILENO;
 file_t our_stderr = STDERR_FILENO;
 file_t our_stdin = STDIN_FILENO;
 
-#define STDERR (our_stderr)
+#        define STDERR (our_stderr)
 #    endif
 
 #    ifdef WINDOWS
@@ -77,7 +77,7 @@ dr_get_stdin_file(void)
     return GetStdHandle(STD_INPUT_HANDLE);
 }
 
-#define STDERR (dr_get_stderr_file())
+#        define STDERR (dr_get_stderr_file())
 #    endif
 
 static uint vendor = VENDOR_INTEL; /* default */


### PR DESCRIPTION
This fixes a regression introduced in #4567.