### PR TITLE
i#4654: Require doxygen for test suite builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1774,11 +1774,11 @@ if (CLIENT_INTERFACE OR APP_EXPORTS)
   if (BUILD_DOCS)
     find_package(Doxygen)
     if (NOT DOXYGEN_FOUND)
-      # We require on Linux pre-commit where it's trivial to install
-      if (TEST_SUITE AND UNIX AND NOT APPLE)
+      # We require for any automated suite on Linux or Windows.
+      if (TEST_SUITE AND NOT APPLE)
         message(FATAL_ERROR "doxygen is required to build the documentation")
       else ()
-        # Non-fatal for a single, un-official build, or on Windows
+        # Non-fatal for a single, un-official build.
         message(WARNING "doxygen not found: documentation will NOT be built")
         set(BUILD_DOCS OFF)
       endif ()


### PR DESCRIPTION
Makes doxygen required for all test suite builds, including Windows,
rather than just a soft warning.  We need it to work in order to
create release packages, after all.

Fixes #4654