### PR TITLE
i#4640 static client: Detect mixing standalone and full DR

### DIFF
--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -391,7 +391,12 @@ dynamorio_app_init(void)
 {
     int size;
 
-    if (!dynamo_initialized /* we do enter if nullcalls is on */) {
+    if (dynamo_initialized) {
+        if (standalone_library) {
+            REPORT_FATAL_ERROR_AND_EXIT(STANDALONE_ALREADY, 2, get_application_name(),
+                                        get_application_pid());
+        }
+    } else /* we do enter if nullcalls is on */ {
 
 #ifdef UNIX
         os_page_size_init((const char **)our_environ, is_our_environ_followed_by_auxv());

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -718,4 +718,12 @@ Language=English
 Application %1!s! (%2!s!). Failed to follow into child process: %3!s!.
 .
 
+MessageId =
+Severity = Error
+Facility = DRCore
+SymbolicName = MSG_STANDALONE_ALREADY
+Language=English
+Application %1!s! (%2!s!). Standalone mode is in progress: cannot switch to full mode.
+.
+
 ;// ADD NEW MESSAGES HERE


### PR DESCRIPTION
Adds a check and a fatal error when calling dr_app_setup() in the
middle of standalone library usage (such as from a custom allocator
using DR heap outside of DR-managed windows).  This is much nicer than
a mysterious crash that happens otherwise.

Tested on a proposed #4640 solution to eliminate application heap from
droption where the droption static initializers use DR heap and thus
invoke standalone mode behind the scenes, while later the app tries to
run dr_app_setup().

Issue: #4640