### PR TITLE
i#4658: Fix fragment_prefix_size on AArch64.

### DIFF
--- a/core/options.c
+++ b/core/options.c
@@ -1234,6 +1234,7 @@ check_option_compatibility_helper(int recurse_count)
     bool changed_options = false;
 #    if defined(CLIENT_INTERFACE) && defined(AARCH64)
     if (!DYNAMO_OPTION(bb_prefixes)) {
+        USAGE_ERROR("bb_prefixes must be true on AArch64");
         dynamo_options.bb_prefixes = true;
         changed_options = true;
     }

--- a/core/options.c
+++ b/core/options.c
@@ -1232,6 +1232,12 @@ static bool
 check_option_compatibility_helper(int recurse_count)
 {
     bool changed_options = false;
+#    if defined(CLIENT_INTERFACE) && defined(AARCH64)
+    if (!DYNAMO_OPTION(bb_prefixes)) {
+        dynamo_options.bb_prefixes = true;
+        changed_options = true;
+    }
+#    endif
 #    ifdef EXPOSE_INTERNAL_OPTIONS
     if (DYNAMO_OPTION(vmm_block_size) < MIN_VMM_BLOCK_SIZE) {
         USAGE_ERROR("vmm_block_size (%d) must be >= %d, setting to min",

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -497,7 +497,8 @@ OPTION_COMMAND(bool, opt_memory, false, "opt_memory",
                "enable memory savings at potential loss in performance", STATIC,
                OP_PCACHE_NOP)
 
-PC_OPTION_INTERNAL(bool, bb_prefixes, "give all bbs a prefix")
+PC_OPTION_DEFAULT_INTERNAL(bool, bb_prefixes, IF_AARCH64_ELSE(1, 0),
+                           "give all bbs a prefix")
 /* If a client registers a bb hook, we force a full decode.  This option
  * requests a full decode regardless of whether there is a bb hook.
  * Note that there is no way to make this available for non-CI builds

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -497,7 +497,7 @@ OPTION_COMMAND(bool, opt_memory, false, "opt_memory",
                "enable memory savings at potential loss in performance", STATIC,
                OP_PCACHE_NOP)
 
-PC_OPTION_DEFAULT_INTERNAL(bool, bb_prefixes, IF_AARCH64_ELSE(1, 0),
+PC_OPTION_DEFAULT_INTERNAL(bool, bb_prefixes, IF_AARCH64_ELSE(true, false),
                            "give all bbs a prefix")
 /* If a client registers a bb hook, we force a full decode.  This option
  * requests a full decode regardless of whether there is a bb hook.


### PR DESCRIPTION
`fragment_prefix_size` returns an incorrect value on AArch64 when `-shared_bb_ibt_tables` is set. To fix this, we set the default value of `-bb_prefixes` to true on AArch64.

Fixes: #4658