### PR TITLE
i#4640: Pass static "client" faults to the app

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -5285,6 +5285,14 @@ master_signal_handler_C(byte *xsp)
             if (is_write && !is_couldbelinking(dcontext) && OWN_NO_LOCKS(dcontext) &&
                 check_for_modified_code(dcontext, pc, ucxt, target, true /*native*/))
                 break;
+#    ifdef STATIC_LIBRARY
+            /* i#4640: We cannot distinguish the client from DR or the app.  Though
+             * it's rare, original app instructions can come here for some app
+             * setups for static DR during init.  We send to the app handler.
+             */
+            execute_native_handler(dcontext, sig, frame);
+            return;
+#    endif
             abort_on_fault(dcontext, DUMPCORE_CLIENT_EXCEPTION, pc, target, sig, frame,
                            exception_label_client, (sig == SIGSEGV) ? "SEGV" : "BUS",
                            " client library");

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -5911,7 +5911,6 @@ execute_native_handler(dcontext_t *dcontext, int sig, sigframe_rt_t *our_frame)
         dynamo_started) {
         info = (thread_sig_info_t *)dcontext->signal_field;
     } else {
-        dcontext = NULL; /* Clear for the not-yet-start or not-init cases above. */
         if (atomic_read_bool(&multiple_handlers_present)) {
             /* See i#1921 comment up top: we don't handle this. */
             report_unhandleable_signal_and_exit(sig, "multiple native handlers");
@@ -5926,10 +5925,20 @@ execute_native_handler(dcontext_t *dcontext, int sig, sigframe_rt_t *our_frame)
         memcpy(&sigact_struct, &detached_sigact[sig], sizeof(sigact_struct));
         d_r_read_unlock(&detached_sigact_lock);
 #ifdef HAVE_SIGALTSTACK
-        IF_DEBUG(int rc =)
-        sigaltstack_syscall(NULL, &synthetic.app_sigstack);
-        ASSERT(rc == 0);
+        if (dcontext != NULL && is_thread_signal_info_initialized(dcontext)) {
+            thread_sig_info_t *info = (thread_sig_info_t *)dcontext->signal_field;
+            memcpy(&synthetic.app_sigstack, &info->app_sigstack,
+                   sizeof(synthetic.app_sigstack));
+        } else {
+            IF_DEBUG(int rc =)
+            sigaltstack_syscall(NULL, &synthetic.app_sigstack);
+            ASSERT(rc == 0);
+            if (synthetic.app_sigstack.ss_sp != NULL &&
+                is_dynamo_address(synthetic.app_sigstack.ss_sp))
+                memset(&synthetic.app_sigstack, 0, sizeof(synthetic.app_sigstack));
+        }
 #endif
+        dcontext = NULL; /* Clear for the not-yet-start or not-init cases above. */
     }
     kernel_ucontext_t *uc = get_ucontext_from_rt_frame(our_frame);
     sigcontext_t *sc = SIGCXT_FROM_UCXT(uc);

--- a/suite/tests/api/static_crash.c
+++ b/suite/tests/api/static_crash.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,7 +40,8 @@
 #include <unistd.h>
 #include <signal.h>
 
-#define ALT_STACK_SIZE (SIGSTKSZ * 2)
+/* SIGSTKSZ*2 results in a fatal error from DR on fitting the copied frame. */
+#define ALT_STACK_SIZE (SIGSTKSZ * 4)
 
 static int num_bbs;
 static int num_signals;

--- a/suite/tests/api/static_crash.c
+++ b/suite/tests/api/static_crash.c
@@ -40,9 +40,6 @@
 #include <unistd.h>
 #include <signal.h>
 
-/* SIGSTKSZ*2 results in a fatal error from DR on fitting the copied frame. */
-#define ALT_STACK_SIZE (SIGSTKSZ * 4)
-
 static int num_bbs;
 static int num_signals;
 

--- a/suite/tests/api/static_crash.templatex
+++ b/suite/tests/api/static_crash.templatex
@@ -3,5 +3,4 @@ in dr_client_main
 #ifdef DEBUG
 <Crashing the process deliberately!>
 #endif
-.*Tool internal crash at PC.*
 Got SIGSEGV in app handler.


### PR DESCRIPTION
A fault in the executable that has a statically-linked client and DR
is currently reported as a client crash, even though we have no way to
distinguish client code from app code in such a situation.  We change
that here to invoke execute_native_handler(), which solves problems
where the application has a fault handler in place and a tool or other
mechanism that generates faults during DR init or other points.

I tried to reproduce this by making a static version of
api.detach_signal but it requires a fault-generating allocator
replacement (hit by droption and other places that use the system
allocator) or something similar, which is non-trivial to replicate in
a small test.  I did test on the original proprietary application.

Fixes #4640