### PR TITLE
Stop searching for additional prefixes in decode_cti after a c5 VEX prefix is found

### DIFF
--- a/core/ir/x86/decode_fast.c
+++ b/core/ir/x86/decode_fast.c
@@ -1359,6 +1359,9 @@ decode_cti(dcontext_t *dcontext, byte *pc, instr_t *instr)
                 /* VEX 2-byte prefix implies 0x0f opcode */
                 byte0 = 0x0f;
                 byte1 = *(pc + prefixes);
+                /* There are no prefixes after vex. */
+                pc = start_pc + prefixes;
+                i = prefixes;
                 break;
             case EVEX_PREFIX_OPCODE:
                 instr_set_prefix_flag(instr, PREFIX_EVEX);

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -888,7 +888,7 @@ test_cti_prefixes(void *dc)
     ASSERT(decode_next_pc(dc, buf) == (byte *)&buf[6]);
 
 #if defined(DEBUG) && defined(BUILD_TESTS)
-    /* PR 4667, a c5 vex encoding where the second byte is c4
+    /* Issue 4652, a c5 vex encoding where the second byte is c4
      *   c5 c4 54 2d 68 1d 0c 0a vandps 0xa0c1d68(%rip),%ymm7,%ymm5
      */
     buf[0] = 0xc5;

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -887,6 +887,7 @@ test_cti_prefixes(void *dc)
 #endif
     ASSERT(decode_next_pc(dc, buf) == (byte *)&buf[6]);
 
+#if defined(DEBUG) && defined(BUILD_TESTS)
     /* PR 4667, a c5 vex encoding where the second byte is c4
      *   c5 c4 54 2d 68 1d 0c 0a vandps 0xa0c1d68(%rip),%ymm7,%ymm5
      */
@@ -909,6 +910,7 @@ test_cti_prefixes(void *dc)
     ASSERT(decode_cti(dc, buf, &instr) == (byte *)&buf[8]);
 
     instr_free(dc, &instr);
+#endif
 }
 
 static void

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -900,9 +900,9 @@ test_cti_prefixes(void *dc)
     buf[6] = 0x0c;
     buf[7] = 0x0a;
 
-#if VERBOSE
+#    if VERBOSE
     disassemble_with_info(dc, buf, STDOUT, true, true);
-#endif
+#    endif
     instr_t instr;
 
     instr_init(dc, &instr);

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -886,6 +886,29 @@ test_cti_prefixes(void *dc)
     disassemble_with_info(dc, buf, STDOUT, true, true);
 #endif
     ASSERT(decode_next_pc(dc, buf) == (byte *)&buf[6]);
+
+    /* PR 4667, a c5 vex encoding where the second byte is c4
+     *   c5 c4 54 2d 68 1d 0c 0a vandps 0xa0c1d68(%rip),%ymm7,%ymm5
+     */
+    buf[0] = 0xc5;
+    buf[1] = 0xc4;
+    buf[2] = 0x54;
+    buf[3] = 0x2d;
+    buf[4] = 0x68;
+    buf[5] = 0x1d;
+    buf[6] = 0x0c;
+    buf[7] = 0x0a;
+
+#if VERBOSE
+    disassemble_with_info(dc, buf, STDOUT, true, true);
+#endif
+    instr_t instr;
+
+    instr_init(dc, &instr);
+
+    ASSERT(decode_cti(dc, buf, &instr) == (byte *)&buf[8]);
+
+    instr_free(dc, &instr);
 }
 
 static void


### PR DESCRIPTION
When decoding the two-byte c5 VEX prefix, currently the second byte of the prefix is not skipped and is instead treated as its own prefix. If the second byte is, say, c4, that will trigger the three-byte c4 VEX prefix code path which will cause decode_cti to fail spuriously. Since VEX prefixes are always the final prefix, just copy what we do for c4 VEX and EVEX prefixes and stop looking for additional prefixes after we see a c5 VEX prefix.