### PR TITLE
i#4669 xl8 failures: No asserts for client xl8 requests

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2418,7 +2418,8 @@ if (CLIENT_INTERFACE)
       tobuild_ci(client.events_cpp client-interface/events_cpp.cpp
         "" "${trace_arg}" "${events_appdll_path}")
       tobuild_ci(client.nudge_test client-interface/nudge_test.runall "" "" "")
-      tobuild_ci(client.timer client-interface/timer.c "" "" "")
+      # We disable traces to get bb prefixes for testing i#4669.
+      tobuild_ci(client.timer client-interface/timer.c "" "-disable_traces" "")
       if (X64)
         tobuild_ci(client.mangle_suspend client-interface/mangle_suspend.c ""
           "-vm_base 0x100000000 -no_vm_base_near_app" "")

--- a/suite/tests/client-interface/timer.c
+++ b/suite/tests/client-interface/timer.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -53,6 +53,18 @@ signal_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
         assert(0);
 }
 
+static int
+func1(int x)
+{
+    return (x > 0 ? 4 * x : x / 4);
+}
+
+static int
+func2(int x)
+{
+    return (x < 0 ? 4 * x : x / 4);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -65,6 +77,25 @@ main(int argc, char *argv[])
     t.it_value.tv_usec = 10000;
     rc = setitimer(ITIMER_REAL, &t, NULL);
     assert(rc == 0);
+
+    /* Do some work so we're in fragments more often.
+     * We run with -disable_traces and include a lot of indirect transfers here to
+     * hit i#4669 on translating bb prefixes.
+     */
+    double sum = 0.;
+    for (int i = 0; i < 1000; ++i) {
+        for (int j = 0; j < 1000; ++j) {
+            int (*func)(int) = i < j ? func2 : func1;
+            sum += (i % 2 == 0) ? ((double)func(j) / 43) : (func(j) - func(i * 6));
+            if (func(i) < 0)
+                func = func1;
+            else if (func(j) > 0)
+                func = func2;
+            else
+                func = func1;
+            sum *= (double)(func(i) - (func(j) + func(1)));
+        }
+    }
 
     struct timespec sleeptime;
     sleeptime.tv_sec = 0;

--- a/suite/tests/client-interface/timer.dll.c
+++ b/suite/tests/client-interface/timer.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -49,6 +49,11 @@
  */
 static int buckets[DR_WHERE_LAST];
 
+/* Currently only written to but we may add checks on this once i#4669 failures
+ * are fixed.
+ */
+static int xl8_failures;
+
 /* test PR 368737: add client timer support */
 static void
 event_timer(void *drcontext, dr_mcontext_t *mcontext)
@@ -69,6 +74,12 @@ event_sample(void *drcontext, dr_mcontext_t *mcontext)
 #if VERBOSE
     dr_fprintf(STDERR, "sample: %p %d %p\n", mcontext->pc, whereami, tag);
 #endif
+    if (whereami == DR_WHERE_FCACHE) {
+        /* Ask for translation to test i#4669. */
+        app_pc xl8 = dr_app_pc_from_cache_pc(mcontext->pc);
+        if (xl8 == NULL)
+            ++xl8_failures;
+    }
 }
 
 static void


### PR DESCRIPTION
Applies the existing client_data->is_translating debug flag to avoid a
curiosity and an assert on translation failure stemming from client
use of dr_app_pc_from_cache_pc() on a sampling itimer.

Augments the client.timer test to run with -disable_traces and use a
lot of indirect branches to trigger a curiosity on xl8 failure on
every run when the iterations are increased (a little too high for our
small regression tests though).  With this fix, the curiosity never
occurs.

Issue: #4669