### PR TITLE
i#4669 xl8 failures: Include DR base in assert messages

### DIFF
--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2009 Derek Bruening   All rights reserved.
  * *******************************************************************************/
@@ -892,6 +892,10 @@ bool
 privload_print_modules(bool path, bool lock, char *buf, size_t bufsz, size_t *sofar)
 {
     privmod_t *mod;
+    if (!print_to_buffer(buf, bufsz, sofar, "%s=" PFX "\n",
+                         path ? get_dynamorio_library_path() : PRODUCT_NAME,
+                         get_dynamorio_dll_start()))
+        return false;
     if (lock)
         acquire_recursive_lock(&privload_lock);
     for (mod = modlist; mod != NULL; mod = mod->next) {


### PR DESCRIPTION
This is a general diagnostic improvement identified under issue #4669:
having the DR library (or static exe for static linking) included in
the callstack simplifies offline symbolization.  Client library bases
were already included.

Here is what the new output looks like, tested on client.timer with
the prior #4669 fix from PR #4672 disabled so the curiosity showed up:

<CURIOSITY : tdcontext != ...
version 8.0.18639, custom build
-no_dynamic_options ...
0x00007fa69912a0a0 0x00007fa8dd273fa5
0x00007fa69912a1b0 0x00007fa8dd276688
0x00007fa69912b4c0 0x00007fa8dd2769fc
0x00007fa69912be10 0x00007fa8dd26f2ae
0x00007fa69912be50 0x00007fa8990742c0
0x00007fa69912be90 0x00007fa8dd366d63
0x00007fa69912c810 0x00007fa8dd35f3d2
0x00007fa69912c9b0 0x00007fa8dd31d034
0x00007ffdf0bb12b0 0x00007fa8dce7cd0a
0x00007fa8d906d6c0 0x5541d68949564100
/home/bruening/dr/git/build_x64_dbg_tests/lib64/debug/libdynamorio.so=0x00007fa8dd072000
/home/bruening/dr/git/build_x64_dbg_tests/suite/tests/bin/libclient.timer.dll.so=0x00007fa899073000>

Issue: #4669