### PR TITLE
i#4679: Rip-relative push translation

### DIFF
--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -5451,6 +5451,7 @@ recreate_fragment_ilist(dcontext_t *dcontext, byte *pc,
                         "\n",
                         target);
                     instr_set_target(last, opnd_create_pc(target));
+                    instr_set_our_mangling(last, true); /* undone by target set */
                 }
                 if (DYNAMO_OPTION(pad_jmps) && !INTERNAL_OPTION(pad_jmps_shift_bb)) {
                     /* FIXME - hack, but pad_jmps_shift_bb will be on by

--- a/core/translate.c
+++ b/core/translate.c
@@ -216,11 +216,9 @@ translate_walk_exits_mangling_epilogue(dcontext_t *tdcontext, instr_t *inst,
 #endif
 
 static void
-translate_walk_track(dcontext_t *tdcontext, instr_t *inst, translate_walk_t *walk)
+translate_walk_track_pre_instr(dcontext_t *tdcontext, instr_t *inst,
+                               translate_walk_t *walk)
 {
-    reg_id_t reg, r;
-    bool spill, spill_tls;
-
     /* Two mangle regions can be adjacent: distinguish by translation field */
     if (walk->in_mangle_region &&
         /* On AArchXX, we spill registers across an app instr, so go solely on xl8 */
@@ -239,7 +237,7 @@ translate_walk_track(dcontext_t *tdcontext, instr_t *inst, translate_walk_t *wal
         walk->in_mangle_region_epilogue = false;
         walk->unsupported_mangle = false;
         walk->xsp_adjust = 0;
-        for (r = 0; r < REG_SPILL_NUM; r++) {
+        for (reg_id_t r = 0; r < REG_SPILL_NUM; r++) {
 #ifndef AARCHXX
             /* we should have seen a restore for every spill, unless at
              * fragment-ending jump to ibl, which shouldn't come here
@@ -271,6 +269,14 @@ translate_walk_track(dcontext_t *tdcontext, instr_t *inst, translate_walk_t *wal
 #endif
         }
     }
+}
+
+static void
+translate_walk_track_post_instr(dcontext_t *tdcontext, instr_t *inst,
+                                translate_walk_t *walk)
+{
+    reg_id_t reg, r;
+    bool spill, spill_tls;
 
     if (instr_is_our_mangling(inst)) {
         if (!walk->in_mangle_region) {
@@ -541,8 +547,21 @@ translate_walk_restore(dcontext_t *tdcontext, translate_walk_t *walk, instr_t *i
                  */
                 ASSERT_NOT_IMPLEMENTED(false);
             }
-            /* Enforcing here what mangling needs to obey. */
-            ASSERT_NOT_IMPLEMENTED(walk->xsp_adjust == 0);
+            DOCHECK(1, {
+                /* Enforcing here what mangling needs to obey.  We can, however,
+                 * have a rip-rel mangled push/pop, for which our post-instr xl8 is fine
+                 * w/o restoring anything about the stack.
+                 */
+                instr_t instr;
+                instr_init(tdcontext, &instr);
+                ASSERT(walk->translation < translate_pc);
+                app_pc npc = decode(tdcontext, walk->translation, &instr);
+                ASSERT(npc != NULL && instr_valid(&instr));
+                int opc = instr_get_opcode(&instr);
+                ASSERT_NOT_IMPLEMENTED(walk->xsp_adjust == 0 || opc == OP_push ||
+                                       opc == OP_push_imm || opc == OP_pop);
+                instr_free(tdcontext, &instr);
+            });
         });
     } else if (translate_pc != walk->translation) {
         /* When we walk we update only each instr we pass.  If we're
@@ -742,7 +761,8 @@ recreate_app_state_from_info(dcontext_t *tdcontext, const translation_info_t *in
         instr_set_our_mangling(&instr, ours);
         /* Sets the translation so that spilled registers can be restored. */
         instr_set_translation(&instr, answer);
-        translate_walk_track(tdcontext, &instr, &walk);
+        translate_walk_track_pre_instr(tdcontext, &instr, &walk);
+        translate_walk_track_post_instr(tdcontext, &instr, &walk);
 
         /* advance translation by the stride: either instr length or 0 */
         if (contig)
@@ -886,6 +906,8 @@ recreate_app_state_from_ilist(dcontext_t *tdcontext, instrlist_t *ilist, byte *s
 #    endif
 #endif
 
+        translate_walk_track_pre_instr(tdcontext, inst, &walk);
+
         LOG(THREAD_GET, LOG_INTERP, 5, "cache pc " PFX " vs " PFX "\n", cpc,
             target_cache);
         if (cpc >= target_cache) {
@@ -1028,7 +1050,7 @@ recreate_app_state_from_ilist(dcontext_t *tdcontext, instrlist_t *ilist, byte *s
             }
         }
 
-        translate_walk_track(tdcontext, inst, &walk);
+        translate_walk_track_post_instr(tdcontext, inst, &walk);
 
         cpc += len;
     }
@@ -1856,6 +1878,7 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
     static const reg_t STRESS_XSP_INIT = 0x08000000; /* arbitrary */
     bool success_so_far = true;
     bool inside_mangle_region = false;
+    bool inside_mangle_epilogue = false;
     uint spill_xcx_outstanding_offs = UINT_MAX;
     reg_id_t reg;
     bool spill;
@@ -1879,20 +1902,20 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
     cpc = FCACHE_ENTRY_PC(f);
     for (in = instrlist_first(ilist); in != NULL;
          cpc += instr_length(dcontext, in), in = instr_get_next(in)) {
-        /* PR 267260: we're only testing mangling regions.
-         * FIXME: also verify rip-relative mangling translation
-         */
+        /* PR 267260: we're only testing mangling regions. */
         if (inside_mangle_region &&
             (!instr_is_our_mangling(in) ||
              /* handle adjacent mangle regions */
-             (TEST(FRAG_IS_TRACE, f->flags) /* we have translation only for traces */ &&
-              IF_X86((prev_in != NULL &&
-                      (instr_is_our_mangling_epilogue(prev_in) ||
-                       !instr_is_our_mangling_epilogue(in))) &&)
-                      mangle_translation != instr_get_translation(in)))) {
+             IF_X86((inside_mangle_epilogue && !instr_is_our_mangling_epilogue(in)) ||)(
+                 TEST(FRAG_IS_TRACE, f->flags) /* we have translation only for traces */
+                 && mangle_translation !=
+                     instr_get_translation(in)
+                         IF_X86(&&!(!inside_mangle_epilogue &&
+                                    instr_is_our_mangling_epilogue(in)))))) {
             /* reset */
             LOG(THREAD, LOG_INTERP, 3, "  out of mangling region\n");
             inside_mangle_region = false;
+            inside_mangle_epilogue = false;
             xsp_adjust = 0;
             success_so_far = true;
             spill_xcx_outstanding_offs = UINT_MAX;
@@ -1905,6 +1928,11 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
                 inside_mangle_region = true;
                 LOG(THREAD, LOG_INTERP, 3, "  entering mangling region\n");
                 mangle_translation = instr_get_translation(in);
+            } else if (IF_X86_ELSE(!inside_mangle_epilogue &&
+                                       instr_is_our_mangling_epilogue(in),
+                                   false)) {
+                LOG(THREAD, LOG_INTERP, 3, "  entering mangling epilogue\n");
+                inside_mangle_epilogue = true;
             } else {
                 ASSERT(!TEST(FRAG_IS_TRACE, f->flags) ||
                        IF_X86(instr_is_our_mangling_epilogue(in) ||)
@@ -1920,6 +1948,11 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
             }
             mc.xsp = STRESS_XSP_INIT;
             mc.pc = cpc;
+            DOLOG(3, LOG_INTERP, {
+                LOG(THREAD, LOG_INTERP, 3, "instruction: ");
+                instr_disassemble(dcontext, in, THREAD);
+                LOG(THREAD, LOG_INTERP, 3, "\n");
+            });
             LOG(THREAD, LOG_INTERP, 3, "  restoring cpc=" PFX ", xsp=" PFX "\n", mc.pc,
                 mc.xsp);
             res = recreate_app_state(dcontext, &mc, false /*just registers*/, NULL);
@@ -1962,7 +1995,7 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
         instrlist_clear_and_destroy(dcontext, ilist);
     }
 #    else
-    /* FIXME i#1551, i#1569: NYI on ARM/AArch64 */
+    /* TODO i#4680: NYI on ARM/AArch64 */
     ASSERT_NOT_IMPLEMENTED(false);
 #    endif /* X86/ARM */
 }

--- a/core/translate.c
+++ b/core/translate.c
@@ -256,6 +256,9 @@ translate_walk_track_pre_instr(dcontext_t *tdcontext, instr_t *inst,
                 if (walk->reg_spill_offs[r] != UINT_MAX) {
                     instr_t *curr;
                     bool spill_or_restore = false;
+                    reg_id_t reg;
+                    bool spill;
+                    bool spill_tls;
                     for (curr = inst; curr != NULL; curr = instr_get_next(curr)) {
                         spill_or_restore = instr_is_DR_reg_spill_or_restore(
                             tdcontext, curr, &spill_tls, &spill, &reg, NULL);
@@ -557,9 +560,10 @@ translate_walk_restore(dcontext_t *tdcontext, translate_walk_t *walk, instr_t *i
                 ASSERT(walk->translation < translate_pc);
                 app_pc npc = decode(tdcontext, walk->translation, &instr);
                 ASSERT(npc != NULL && instr_valid(&instr));
-                int opc = instr_get_opcode(&instr);
-                ASSERT_NOT_IMPLEMENTED(walk->xsp_adjust == 0 || opc == OP_push ||
-                                       opc == OP_push_imm || opc == OP_pop);
+                IF_X86(int opc = instr_get_opcode(&instr);)
+                ASSERT_NOT_IMPLEMENTED(
+                    walk->xsp_adjust ==
+                    0 IF_X86(|| opc == OP_push || opc == OP_push_imm || opc == OP_pop));
                 instr_free(tdcontext, &instr);
             });
         });


### PR DESCRIPTION
Fixes two issues with rip-relative push translation:

1) The push must be cleared on the first instruction of a subsequent
   consecutive mangling region.  For this we split
   translate_walk_state() into pre_instr and post_instr versions.

   This split then raises an assert due to recreate_fragment_ilist()
   changing an exit jump's target without re-instating the
   instr_set_our_mangling(), which we also fix here.

2) The assert about stack changes in the epilogue must be relaxed.

Tested on the decode-stress test on Linux x86, which is not yet fully
enabled in the suite as it needs more work: that's #1025.

Issue: #1025, #4679
Fixes #4679