### PR TITLE
i#1025: Enable decode-stress test on UNIX x86

### DIFF
--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -47,6 +47,7 @@
 #include "instrlist.h"
 #include "decode.h"
 #include "decode_fast.h"
+#include "decode_private.h"
 #include "disassemble.h"
 #include "../hashtable.h"
 #include "../fcache.h" /* for in_fcache */
@@ -1108,7 +1109,7 @@ insert_push_retaddr(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
                              opnd_create_base_disp(REG_XSP, REG_NULL, 0, -2, OPSZ_lea)));
         PRE(ilist, instr,
             INSTR_CREATE_mov_st(dcontext, OPND_CREATE_MEM16(REG_XSP, 2),
-                                OPND_CREATE_INT16(val)));
+                                OPND_CREATE_INT16((short)val)));
     } else if (opsize ==
                OPSZ_PTR IF_X64(|| (!X64_CACHE_MODE_DC(dcontext) && opsize == OPSZ_4))) {
         insert_push_immed_ptrsz(dcontext, retaddr, ilist, instr, NULL, NULL);
@@ -1371,8 +1372,11 @@ mangle_direct_call(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
  * The reg must not be used in the oldop, otherwise, the reg value
  * is corrupted.
  */
+
+static ushort tls_slots[4] = { TLS_XAX_SLOT, TLS_XCX_SLOT, TLS_XDX_SLOT, TLS_XBX_SLOT };
+
 opnd_t
-mangle_seg_ref_opnd(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
+mangle_seg_ref_opnd(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
                     opnd_t oldop, reg_id_t reg)
 {
     opnd_t newop;
@@ -1395,14 +1399,50 @@ mangle_seg_ref_opnd(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
 
     /* XXX: this mangling is pattern-matched in translation's instr_is_seg_ref_load() */
     /* get app's segment base into reg. */
-    PRE(ilist, where,
+    PRE(ilist, instr,
         instr_create_restore_from_tls(dcontext, reg, os_get_app_tls_base_offset(seg)));
+    if ((opnd_get_base(oldop) != DR_REG_NULL &&
+         reg_get_size(opnd_get_base(oldop)) == OPSZ_2) ||
+        (opnd_get_index(oldop) != DR_REG_NULL &&
+         reg_get_size(opnd_get_index(oldop)) == OPSZ_2)) {
+        /* We can't combine our full-size seg base reg with addr16 regs so we
+         * need another scratch reg to first compute thet 16-bit-reg address.
+         */
+        reg_id_t scratch2;
+        for (scratch2 = REG_XAX; scratch2 <= REG_XBX; scratch2++) {
+            if (!instr_uses_reg(instr, scratch2))
+                break;
+        }
+        ASSERT(scratch2 <= REG_XBX);
+        PRE(ilist, instr,
+            instr_create_save_to_tls(dcontext, scratch2, tls_slots[scratch2 - REG_XAX]));
+        instr_set_our_mangling(instr, true);
+        PRE(ilist, instr_get_next(instr),
+            instr_set_translation_mangling_epilogue(
+                dcontext, ilist,
+                instr_create_restore_from_tls(dcontext, scratch2,
+                                              tls_slots[scratch2 - REG_XAX])));
+        /* We add addr16 to the lea, and remove from the instr, to make the disasm
+         * easier to read (does not affect encoding or correctness).
+         */
+        PRE(ilist, instr,
+            instr_set_prefix_flag(
+                INSTR_CREATE_lea(dcontext, opnd_create_reg(scratch2),
+                                 opnd_create_base_disp(opnd_get_base(oldop),
+                                                       opnd_get_index(oldop),
+                                                       opnd_get_scale(oldop),
+                                                       opnd_get_disp(oldop), OPSZ_lea)),
+                PREFIX_ADDR));
+        uint prefixes = instr_get_prefixes(instr);
+        instr_set_prefixes(instr, prefixes & (~PREFIX_ADDR));
+        return opnd_create_base_disp(reg, scratch2, 1, 0, opnd_get_size(oldop));
+    }
     if (opnd_get_index(oldop) != REG_NULL && opnd_get_base(oldop) != REG_NULL) {
         /* if both base and index are used, use
          * lea [base, reg, 1] => reg
          * to get the base + seg_base into reg.
          */
-        PRE(ilist, where,
+        PRE(ilist, instr,
             INSTR_CREATE_lea(
                 dcontext, opnd_create_reg(reg),
                 opnd_create_base_disp(opnd_get_base(oldop), reg, 1, 0, OPSZ_lea)));
@@ -2870,8 +2910,6 @@ instr_get_seg_ref_src_idx(instr_t *instr)
     return -1;
 }
 
-static ushort tls_slots[4] = { TLS_XAX_SLOT, TLS_XCX_SLOT, TLS_XDX_SLOT, TLS_XBX_SLOT };
-
 /* mangle the instruction OP_mov_seg, i.e. the instruction that
  * read/update the segment register.
  */
@@ -3035,7 +3073,9 @@ mangle_seg_ref(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
          * (for 32-bit, top 32 bits are cleared) */
         if (reg_is_gpr(reg) && (reg_is_32bit(reg) || reg_is_64bit(reg)) &&
             /* mov [%fs:%xax] => %xax */
-            !instr_reads_from_reg(instr, reg, DR_QUERY_DEFAULT)) {
+            !instr_reads_from_reg(instr, reg, DR_QUERY_DEFAULT) &&
+            /* xsp cannot be an index reg. */
+            reg != DR_REG_XSP) {
             spill = false;
             scratch_reg = reg;
 #    ifdef X64

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1975,14 +1975,9 @@ if (X86) # FIXME i#1551, i#1569: port asm to ARM and AArch64
     endif ()
   endif (X64 OR WIN32)
 endif (X86)
-# FIXME i#1025: get working on Linux
-if (WIN32)
-  # We build all tests before running so decode will be built before
-  # ctest -j ever ran this.  If we switch to --build-and-test then we'll
-  # make these runonly tests make sure their exe is built.
-  torunonly(common.decode-stress common.decode common/decode.c
-    "-stress_recreate_state" "")
-endif (WIN32)
+if (X86) # TODO i#4680: Port to AArchXX.
+  torunonly(common.decode-stress common.decode common/decode.c "-stress_recreate_state" "")
+endif ()
 
 if (X86)
   set(control_flags "eflags")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1965,18 +1965,16 @@ endif ()
 if (NOT ANDROID) # We do not support -no_early_inject on Android (i#1873).
   tobuild_ops(common.fib common/fib.c "-no_early_inject" "")
 endif ()
-if (X86) # FIXME i#1551, i#1569: port asm to ARM and AArch64
+if (X86) # TODO i#1551, i#1569: port asm to ARM and AArch64
   tobuild(common.decode-bad common/decode-bad.c)
-  # FIXME i#105: get this working for 32-bit linux
-  if (X64 OR WIN32)
-    tobuild(common.decode common/decode.c)
-    if (proc_supports_avx512)
-      set_target_properties(common.decode PROPERTIES COMPILE_FLAGS "${CFLAGS_AVX512}")
-    endif ()
-  endif (X64 OR WIN32)
+  tobuild(common.decode common/decode.c)
+  if (proc_supports_avx512)
+    set_target_properties(common.decode PROPERTIES COMPILE_FLAGS "${CFLAGS_AVX512}")
+  endif ()
 endif (X86)
-if (X86) # TODO i#4680: Port to AArchXX.
-  torunonly(common.decode-stress common.decode common/decode.c "-stress_recreate_state" "")
+if (X86) # TODO i#4680: Port stress code to AArchXX and run on a diff test?
+  torunonly(common.decode-stress common.decode common/decode.c
+    "-stress_recreate_state" "")
 endif ()
 
 if (X86)

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -86,12 +86,6 @@ static int a[ITERS];
 
 #    ifdef UNIX
 #        define ALT_STACK_SIZE (SIGSTKSZ * 3)
-
-int
-my_setjmp(sigjmp_buf env)
-{
-    return SIGSETJMP(env);
-}
 
 static void
 signal_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
@@ -265,11 +259,9 @@ main(int argc, char *argv[])
     print("Testing far call/jmp\n");
     test_far_cti();
 
-#    ifdef WINDOWS /* FIXME i#105: crashing on Linux so disabling for now */
     /* PR 242815: data16 mbr */
     print("Testing data16 mbr\n");
     test_data16_mbr();
-#    endif
 
     /* i#1024: rip-rel ind branch */
     print("Testing rip-rel ind branch\n");
@@ -500,15 +492,20 @@ DECL_EXTERN(_setjmp3)
         CALLC2(_setjmp3, REG_XAX, 0)
 # endif
 #else
-DECL_EXTERN(my_setjmp)
+/* We can't safely have a local wrapper, since its retaddr is then exposed
+ * for the longjmp restore path.  We thus need to directly invoke sigsetjmp.
+ */
+DECL_EXTERN(__sigsetjmp)
 # ifdef X64
 #  define CALL_SETJMP \
         lea   REG_XAX, SYMREF(mark) @N@ \
-        CALLC1(GLOBAL_REF(my_setjmp), REG_XAX)
+        mov   REG_XCX, HEX(1)       @N@ \
+        CALLC2(GLOBAL_REF(__sigsetjmp), REG_XAX, REG_XCX)
 # else
 #  define CALL_SETJMP \
-        lea   REG_XAX, mark @N@\
-        CALLC1(GLOBAL_REF(my_setjmp), REG_XAX)
+        lea   REG_XAX, mark   @N@\
+        mov   REG_XCX, HEX(1) @N@ \
+        CALLC2(GLOBAL_REF(__sigsetjmp), REG_XAX, REG_XCX)
 # endif
 #endif
 
@@ -548,10 +545,11 @@ DECL_EXTERN(my_setjmp)
 #define FUNCNAME test_far_cti
         DECLARE_FUNC_SEH(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
+        ADD_STACK_ALIGNMENT
         END_PROLOG
         /* ljmp to base-disp with flat segment */
         lea   REG_XAX, PTRSZ SYMREF(test_far_cti_end_flat)
-        push  REG_XAX
+        mov   [REG_XSP], REG_XAX
         mov   REG_XCX, REG_XSP
         /* I'm having trouble getting gas to generate this from:
          *   jmp   PTRSZ SEGMEM(es,REG_XCX)
@@ -559,7 +557,6 @@ GLOBAL_LABEL(FUNCNAME:)
          */
         RAW(26) RAW(ff) RAW(21) /* jmp QWORD PTR es:[rcx] */
     ADDRTAKEN_LABEL(test_far_cti_end_flat:)
-        pop   REG_XAX
         CALL_SETJMP
         cmp   REG_XAX, 0
         jne   test_far_cti_1
@@ -598,6 +595,7 @@ GLOBAL_LABEL(FUNCNAME:)
         mov   eax, HEX(deadbeef)
         RAW(ff) RAW(18) /* lcall (%eax) */
     test_far_cti_6:
+        RESTORE_STACK_ALIGNMENT
         ret
         END_FUNC(FUNCNAME)
 

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -496,7 +496,7 @@ DECL_EXTERN(_setjmp3)
  * for the longjmp restore path.  We thus need to directly invoke sigsetjmp.
  */
 # ifdef MACOS
-#  define SIGSETJMP_NAME _sigsetjmp
+#  define SIGSETJMP_NAME sigsetjmp
 # else
 #  define SIGSETJMP_NAME __sigsetjmp
 # endif

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -495,17 +495,22 @@ DECL_EXTERN(_setjmp3)
 /* We can't safely have a local wrapper, since its retaddr is then exposed
  * for the longjmp restore path.  We thus need to directly invoke sigsetjmp.
  */
-DECL_EXTERN(__sigsetjmp)
+# ifdef MACOS
+#  define SIGSETJMP_NAME _sigsetjmp
+# else
+#  define SIGSETJMP_NAME __sigsetjmp
+# endif
+DECL_EXTERN(SIGSETJMP_NAME)
 # ifdef X64
 #  define CALL_SETJMP \
         lea   REG_XAX, SYMREF(mark) @N@ \
         mov   REG_XCX, HEX(1)       @N@ \
-        CALLC2(GLOBAL_REF(__sigsetjmp), REG_XAX, REG_XCX)
+        CALLC2(GLOBAL_REF(SIGSETJMP_NAME), REG_XAX, REG_XCX)
 # else
 #  define CALL_SETJMP \
         lea   REG_XAX, mark   @N@\
         mov   REG_XCX, HEX(1) @N@ \
-        CALLC2(GLOBAL_REF(__sigsetjmp), REG_XAX, REG_XCX)
+        CALLC2(GLOBAL_REF(SIGSETJMP_NAME), REG_XAX, REG_XCX)
 # endif
 #endif
 

--- a/suite/tests/common/decode.templatex
+++ b/suite/tests/common/decode.templatex
@@ -34,30 +34,24 @@ Access violation, instance 6
 #endif
 Access violation, instance 7
 Access violation, instance 8
-#ifdef WINDOWS
 Testing data16 mbr
 Access violation, instance 9
 Access violation, instance 10
 Access violation, instance 11
-# if defined(X64)
+#if defined(X64)
 Bad instruction, instance 12
 Bad instruction, instance 13
-# else
+#else
 Access violation, instance 12
 Access violation, instance 13
-# endif
+#endif
 Access violation, instance 14
 Access violation, instance 15
 Access violation, instance 16
 Access violation, instance 17
 Access violation, instance 18
-#endif
 Testing rip-rel ind branch
 Made it to actual_call_target
-#ifdef WINDOWS
 Bad instruction, instance 19
-#else
-Bad instruction, instance 9
-#endif
 (Testing AVX-512 VEX
 )?All done


### PR DESCRIPTION
Enables the decode-stress test for UNIX x86 after confirming all the
bugs are fixed (#4679, #4681).  The bug reported in the #1025 issue
does not reproduce.

Issue: #1025, #4679, #4681
Fixes #1025