### PR TITLE
i#4618 SEH fail: Fix common.decode Windows failures

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # **********************************************************
-# Copyright () 2016-2020 Google, Inc.  All rights reserved.
+# Copyright () 2016-2021 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -207,8 +207,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
             %ignore_failures_32 = (
                 # i#4131: These are failing on GA Server16 and need investigation.
                 # Some also failed on Appveyor (i#4058).
-                'code_api|common.decode' => 1, # i#4618
-                'code_api|common.decode-stress' => 1, # i#4618
                 'code_api|win32.earlythread' => 1, # i#4131
                 'code_api|client.drx-test' => 1, # i#4619
                 'code_api|client.drwrap-test' => 1, # i#4131
@@ -236,8 +234,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
             %ignore_failures_64 = (
                 # i#4131: These are failing on GA Server16 and need investigation.
                 # Some also failed on Appveyor (i#4058).
-                'code_api|common.decode' => 1, # i#4618
-                'code_api|common.decode-stress' => 1, # i#4618
                 'code_api|client.cleancall' => 1, # i#4618
                 'code_api|win32.callback' => 1, # i#4058
                 'code_api|common.nativeexec' => 1, # i#4058

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -259,9 +259,15 @@ main(int argc, char *argv[])
     print("Testing far call/jmp\n");
     test_far_cti();
 
+    /* i#4618: SEH64 has trouble recovering from the unaligned stacks
+     * and other issues in this test.  We have coverage on 64-bit Linux so
+     * we're ok permanently disabling it for Win64.
+     */
+#    if !(defined(WINDOWS) && defined(X64))
     /* PR 242815: data16 mbr */
     print("Testing data16 mbr\n");
     test_data16_mbr();
+#    endif
 
     /* i#1024: rip-rel ind branch */
     print("Testing rip-rel ind branch\n");
@@ -482,9 +488,16 @@ DECL_EXTERN(mark)
 #ifdef WINDOWS
 # ifdef X64
 DECL_EXTERN(setjmp)
+/* The 4-slot stack padding means we can't pass xsp to CALLC2 which
+ * will capture the post-padding value, which is beyond-TOS later,
+ * causing problems on longjmp.
+ * Even now it is a little fragile: probably better to subtract the 4
+ * slots at the top of the frame and do a raw call here.
+ */
 #  define CALL_SETJMP \
-        lea   REG_XAX, mark @N@\
-        CALLC2(setjmp, REG_XAX, REG_XSP)
+        lea   REG_XCX, mark @N@\
+        mov   REG_XDX, REG_XSP @N@\
+        CALLC2(setjmp, REG_XCX, REG_XDX)
 # else
 DECL_EXTERN(_setjmp3)
 #  define CALL_SETJMP \

--- a/suite/tests/common/decode.templatex
+++ b/suite/tests/common/decode.templatex
@@ -34,24 +34,30 @@ Access violation, instance 6
 #endif
 Access violation, instance 7
 Access violation, instance 8
+#if !(defined(WINDOWS) && defined(X64))
 Testing data16 mbr
 Access violation, instance 9
 Access violation, instance 10
 Access violation, instance 11
-#if defined(X64)
+# if defined(X64)
 Bad instruction, instance 12
 Bad instruction, instance 13
-#else
+# else
 Access violation, instance 12
 Access violation, instance 13
-#endif
+# endif
 Access violation, instance 14
 Access violation, instance 15
 Access violation, instance 16
 Access violation, instance 17
 Access violation, instance 18
+#endif
 Testing rip-rel ind branch
 Made it to actual_call_target
+#if !(defined(WINDOWS) && defined(X64))
 Bad instruction, instance 19
+#else
+Bad instruction, instance 9
+#endif
 (Testing AVX-512 VEX
 )?All done


### PR DESCRIPTION
Adjusts the setjmp call from common.decode's assembly to use the
pre-parameter-slot stack value, avoiding fatal crashes on longjmp.

Disables test_data16_mbr() on 64-bit Windows, as SEH64 can't handle
the unaligned stacks and other oddities of the instructions there.  We
still have coverage on 64-bit Linux which is sufficient.

Removes the ignore rules on failure for common.decode and
common.decode-stress from the runsuite_wrapper.

Issue: #4618