### PR TITLE
i#4680 aarch xl8: Fix missing translation of stolen-reg cbr

### DIFF
--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -2781,6 +2781,7 @@ mangle_cbr_stolen_reg(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     instr_set_opcode(instr, OP_b);
     instr_set_num_opnds(dcontext, instr, 0, 1);
     instr_set_src(instr, 0, opnd);
+    instr_set_translation(instr, instrlist_get_translation_target(ilist));
 
     PRE(ilist, next_instr, fall);
     PRE(ilist, next_instr, instr_create_restore_from_tls(dcontext, reg, slot));


### PR DESCRIPTION
Fixes a missing translation field for a conditional branch that uses
the stolen register.

This was caught by the forthcoming common.broadfun-stress test, which
will serve as the regression test once it is added after all other
bugs it finds are addressed.

Issue: #4680