### PR TITLE
i#4680 aarch xl8: Add intra-short-cti-bundle translation

### DIFF
--- a/core/emit.c
+++ b/core/emit.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -99,19 +99,20 @@ stress_test_recreate(dcontext_t *dcontext, fragment_t *f, instrlist_t *ilist)
         "Testing recreating Fragment %d for tag " PFX " at " PFX "\n", f->id, f->tag,
         f->start_pc);
 
-    DOLOG(3, LOG_INTERP, {
-        /* visualize translation info if it were to be recorded for every
-         * fragment, not just deleted ones -- for debugging only
+    DOCHECK(2, {
+        /* Visualize translation info if it were to be recorded for every
+         * fragment, not just deleted ones -- for debugging only.  But we run
+         * the info-creation code at checklevel 2 as a sanity check.
          */
         translation_info_t *info = record_translation_info(dcontext, f, NULL);
-        translation_info_print(info, f->start_pc, THREAD);
+        DOLOG(3, LOG_INTERP, { translation_info_print(info, f->start_pc, THREAD); });
         translation_info_free(dcontext, info);
         /* handy reference of app code and fragment -- only 1st part of trace though */
         DOLOG(3, LOG_INTERP, { disassemble_app_bb(dcontext, f->tag, THREAD); });
         DOLOG(3, LOG_INTERP, { disassemble_fragment(dcontext, f, false); });
     });
 
-    DOLOG(2, LOG_MONITOR, {
+    DOCHECK(2, {
         /* Translate them all.
          * Useful when verifying manually, o/w we just ensure no asserts or crashes.
          */

--- a/core/translate.c
+++ b/core/translate.c
@@ -931,6 +931,15 @@ recreate_app_state_from_ilist(dcontext_t *tdcontext, instrlist_t *ilist, byte *s
 
         LOG(THREAD_GET, LOG_INTERP, 5, "cache pc " PFX " vs " PFX "\n", cpc,
             target_cache);
+        if (cpc + len > target_cache && instr_is_cti_short_rewrite(inst, cpc)) {
+            /* The target is inside the short-cti bundle.  Everything should be fine:
+             * there are no state changes inside.
+             */
+            LOG(THREAD_GET, LOG_INTERP, 3,
+                "recreate_app -- target is inside short-cti bundle %p-%p\n", cpc,
+                cpc + len);
+            cpc = target_cache;
+        }
         if (cpc >= target_cache) {
             if (cpc > target_cache) {
                 if (cpc == start_cache) {

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -71,6 +71,8 @@ void
 test_SSE2(void);
 void
 test_mangle_seg(void);
+void
+test_jecxz(void);
 
 SIGJMP_BUF mark;
 static int count = 0;
@@ -283,6 +285,9 @@ main(int argc, char *argv[])
 
     /* i#1493: segment register mangling */
     test_mangle_seg();
+
+    /* i#4680: Test jecxz mangling. */
+    test_jecxz();
 
 #    ifdef UNIX
     free(sigstack.ss_sp);
@@ -808,6 +813,20 @@ GLOBAL_LABEL(FUNCNAME:)
         RAW(48) RAW(8c) RAW(24) RAW(24) /* mov QWORD [REG_XSP], fs */
 #endif
         pop      REG_XAX
+        add      REG_XSP, 0 /* make a legal SEH64 epilog */
+        ret
+        END_FUNC(FUNCNAME)
+END_FILE
+#undef FUNCNAME
+
+#define FUNCNAME test_jecxz
+        /* i#4680: test jecxz mangling code */
+        DECLARE_FUNC_SEH(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        END_PROLOG
+        jecxz    jecxz_zero
+        nop
+jecxz_zero:
         add      REG_XSP, 0 /* make a legal SEH64 epilog */
         ret
         END_FUNC(FUNCNAME)

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -816,9 +816,8 @@ GLOBAL_LABEL(FUNCNAME:)
         add      REG_XSP, 0 /* make a legal SEH64 epilog */
         ret
         END_FUNC(FUNCNAME)
-END_FILE
-#undef FUNCNAME
 
+#undef FUNCNAME
 #define FUNCNAME test_jecxz
         /* i#4680: test jecxz mangling code */
         DECLARE_FUNC_SEH(FUNCNAME)
@@ -830,6 +829,7 @@ jecxz_zero:
         add      REG_XSP, 0 /* make a legal SEH64 epilog */
         ret
         END_FUNC(FUNCNAME)
+
 END_FILE
 /* clang-format on */
 #endif /* ASM_CODE_ONLY */


### PR DESCRIPTION
Adds handling of translation inside short-cti-rewrite bundles.

Adds an OP_jecxz to common.decode as a test of short cti mangling.

Changes the DOLOG stress test qualifiers for -stress_recreate_* to
DOCHECK so we run them every time and not just at high loglevel.

Tested on arm on the forthcoming common.broadfun-stress test.

Issue: #4680