### PR TITLE
i#4680 aarch xl8: Fix IT state tracking bugs

### DIFF
--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -2738,6 +2738,11 @@ get_mcontext_frame_ptr(dcontext_t *dcontext, priv_mcontext_t *mc)
 /* reset the encode state stored in dcontext used by A32 Thumb mode */
 void
 encode_reset_it_block(dcontext_t *dcontext);
+/* Reset the encode state stored in dcontext used by A32 Thumb mode if the
+ * being-freed instr is involved.
+ */
+void
+encode_instr_freed_event(dcontext_t *dcontext, instr_t *instr);
 #endif
 
 #ifdef LINUX

--- a/core/emit.c
+++ b/core/emit.c
@@ -108,6 +108,8 @@ stress_test_recreate(dcontext_t *dcontext, fragment_t *f, instrlist_t *ilist)
         DOLOG(3, LOG_INTERP, { translation_info_print(info, f->start_pc, THREAD); });
         translation_info_free(dcontext, info);
         /* handy reference of app code and fragment -- only 1st part of trace though */
+        LOG(THREAD, LOG_INTERP, 3,
+            "Re-printing app bb and cache disasm for convenience:\n");
         DOLOG(3, LOG_INTERP, { disassemble_app_bb(dcontext, f->tag, THREAD); });
         DOLOG(3, LOG_INTERP, { disassemble_fragment(dcontext, f, false); });
     });

--- a/core/ir/arm/encode.c
+++ b/core/ir/arm/encode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -730,12 +730,33 @@ encode_track_it_block_di(dcontext_t *dcontext, decode_info_t *di, instr_t *instr
         encode_state_init(&di->encode_state, di, instr);
         set_encode_state(dcontext, &di->encode_state);
     } else if (di->encode_state.itb_info.num_instrs != 0) {
+        LOG(THREAD, LOG_EMIT, 4, "%s: num_instrs=%d\n", __FUNCTION__,
         if (encode_in_it_block(&di->encode_state, instr)) {
             LOG(THREAD, LOG_EMIT, ENC_LEVEL, "inside IT block\n");
             /* encode_state is reset if reach the end of IT block */
             encode_state_advance(&di->encode_state, instr);
         }
         set_encode_state(dcontext, &di->encode_state);
+    } else if (instr_get_isa_mode(instr) == DR_ISA_ARM_THUMB &&
+               instr_get_predicate(instr) != DR_PRED_NONE) {
+        /* Our state might have been reset due to an instr or insrlist free. */
+        instr_t *prev = instr_get_prev(instr);
+        int count = 0;
+        while (prev != NULL && count < 4) {
+            if (instr_opcode_valid(prev) && instr_get_opcode(prev) == OP_it) {
+                encode_state_init(&di->encode_state, di, prev);
+                prev = instr_get_next(prev);
+                while (prev != instr) {
+                    if (encode_in_it_block(&di->encode_state, prev))
+                        encode_state_advance(&di->encode_state, prev);
+                    prev = instr_get_next(prev);
+                }
+                set_encode_state(dcontext, &di->encode_state);
+                break;
+            }
+            ++count;
+            prev = instr_get_prev(prev);
+        }
     }
 }
 
@@ -753,6 +774,14 @@ encode_reset_it_block(dcontext_t *dcontext)
     encode_state_t state;
     encode_state_reset(&state);
     set_encode_state(dcontext, &state);
+}
+
+void
+encode_instr_freed_event(dcontext_t *dcontext, instr_t *instr)
+{
+    encode_state_t *state = get_encode_state(dcontext);
+    if (state->instr == instr)
+        encode_reset_it_block(dcontext);
 }
 
 #ifdef DEBUG

--- a/core/ir/arm/encode.c
+++ b/core/ir/arm/encode.c
@@ -730,7 +730,6 @@ encode_track_it_block_di(dcontext_t *dcontext, decode_info_t *di, instr_t *instr
         encode_state_init(&di->encode_state, di, instr);
         set_encode_state(dcontext, &di->encode_state);
     } else if (di->encode_state.itb_info.num_instrs != 0) {
-        LOG(THREAD, LOG_EMIT, 4, "%s: num_instrs=%d\n", __FUNCTION__,
         if (encode_in_it_block(&di->encode_state, instr)) {
             LOG(THREAD, LOG_EMIT, ENC_LEVEL, "inside IT block\n");
             /* encode_state is reset if reach the end of IT block */

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -100,6 +100,13 @@ instr_create(dcontext_t *dcontext)
 void
 instr_destroy(dcontext_t *dcontext, instr_t *instr)
 {
+#ifdef ARM
+    /* i#4680: Reset encode state to avoid dangling pointers.  This doesn't cover
+     * auto-scope instr_t vars so the whole IT tracking is still fragile.
+     */
+    if (instr_get_isa_mode(instr) == DR_ISA_ARM_THUMB)
+        encode_instr_freed_event(dcontext, instr);
+#endif
     instr_free(dcontext, instr);
 
     /* CAUTION: assumes that instr is not part of any instrlist */

--- a/core/ir/instrlist.c
+++ b/core/ir/instrlist.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -95,6 +95,12 @@ instrlist_destroy(dcontext_t *dcontext, instrlist_t *ilist)
 void
 instrlist_clear(dcontext_t *dcontext, instrlist_t *ilist)
 {
+#ifdef ARM
+    /* XXX i#4680: Reset encode state to avoid dangling pointers. */
+    if (instrlist_first(ilist) != NULL &&
+        instr_get_isa_mode(instrlist_first(ilist)) == DR_ISA_ARM_THUMB)
+        encode_reset_it_block(dcontext);
+#endif
     instr_t *instr;
     while (NULL != (instr = instrlist_first(ilist))) {
         instrlist_remove(ilist, instr);


### PR DESCRIPTION
Fixes 3 issues with IT state tracking for ad-hoc decoding/encoding
uncovered by -stress_recreate_state:

+ Fixes a use-after-free by adding a hook in instr_destroy() to reset
  the IT state if the stored instruction is freed, along with a state
  reset in instrlist_clear().

+ On decode, limit advance-undo prior-instruction matching to the
  current instruction's Thumb size, to avoid incorrect advance-undo
  when switching between decoding sequences.
  Also, check for the current instruction being OP_it via raw
  byte checks to again avoid incorrect advance-undo.

+ On encode, walk backward to re-identify IT blocks after a state reset.

Tested on the forthcoming common.broadfun-stress test on ARM.

Issue: #4680