### PR TITLE
i#4700: Deduce syscall numbers on Win10-1511+

### DIFF
--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -1858,8 +1858,34 @@ find_syscall_num(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
     instr_t *walk, *tgt;
 #endif
 
-    if (prev == NULL)
+    if (prev == NULL) {
+#ifdef X64
+        if (get_os_version() >= WINDOWS_VERSION_10_1511) {
+            /* Handle the branch added in 1511 that isolates OP_syscall:
+             *   7ff9`13185630 4c8bd1          mov     r10,rcx
+             *   7ff9`13185633 b843000000      mov     eax,43h
+             *   7ff9`13185638 f604250803fe7f01 test byte ptr [SharedUserData+0x308],1
+             *   7ff9`13185640 7503            jne     00007ff9`13185645
+             *   7ff9`13185642 0f05            syscall
+             */
+#    define MOV_IMMED_OFFS_FROM_SYS -15
+#    define RAW_SYS_TEST1 0xf6
+#    define RAW_SYS_TEST2 0x04
+#    define RAW_SYS_TEST3 0x25
+#    define RAW_SYS_TEST_FINAL 0x01
+            app_pc syscall_pc = get_app_instr_xl8(instr);
+            byte buf[-MOV_IMMED_OFFS_FROM_SYS];
+            if (d_r_safe_read(syscall_pc + MOV_IMMED_OFFS_FROM_SYS, sizeof(buf), buf) &&
+                buf[0] == MOV_IMM2XAX_OPCODE && buf[5] == RAW_SYS_TEST1 &&
+                buf[6] == RAW_SYS_TEST2 && buf[7] == RAW_SYS_TEST3 &&
+                buf[12] == RAW_SYS_TEST_FINAL && buf[13] == RAW_OPCODE_jne_short) {
+                syscall = *(int *)&buf[1];
+                return syscall;
+            }
+        }
+#endif
         return -1;
+    }
     prev = instr_get_prev_expanded(dcontext, ilist, instr);
     /* walk backwards looking for "mov imm->xax"
      * may be other instrs placing operands into registers

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1859,7 +1859,7 @@ find_syscall_num(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
 #endif
 
     if (prev == NULL) {
-#ifdef X64
+#if defined(WINDOWS) && defined(X64)
         if (get_os_version() >= WINDOWS_VERSION_10_1511) {
             /* Handle the branch added in 1511 that isolates OP_syscall:
              *   7ff9`13185630 4c8bd1          mov     r10,rcx

--- a/core/ir/x86/opcode.h
+++ b/core/ir/x86/opcode.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1690,6 +1690,7 @@ enum {
     RAW_OPCODE_push_imm32 = 0x68,
     RAW_OPCODE_pop_eax = 0x58,
     RAW_OPCODE_jcc_short_start = 0x70,
+    RAW_OPCODE_jne_short = 0x75,
     RAW_OPCODE_jcc_short_end = 0x7f,
     RAW_OPCODE_jcc_byte1 = 0x0f,
     RAW_OPCODE_jcc_byte2_start = 0x80,


### PR DESCRIPTION
Uses backward raw decoding to deduce 64-bit system call numbers on
Win10-1511+ where a branch isolates the syscall instruction in its own
block.

Fixes #4700