### PR TITLE
i#4704: Update thread IBT on exit due to delete

### DIFF
--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -1133,6 +1133,12 @@ dispatch_exit_fcache(dcontext_t *dcontext)
          */
         SELF_PROTECT_LOCAL(dcontext, READONLY);
     } /* LINKSTUB_INDIRECT */
+    else if (dcontext->last_exit == get_ibl_deleted_linkstub()) {
+        /* We don't know which table it was, so we update all of them.  Otherwise
+         * we'll keep coming back here on hits in the outdated table.
+         */
+        fragment_update_ibl_tables(dcontext);
+    }
 
     /* ref bug 2323, we need monitor to restore last fragment now,
      * before we break out of the loop to build a new fragment

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -4053,6 +4053,18 @@ is_fragment_index_wraparound(dcontext_t *dcontext, ibl_table_t *ftable, fragment
 }
 #endif /* DEBUG */
 
+void
+fragment_update_ibl_tables(dcontext_t *dcontext)
+{
+    per_thread_t *pt = (per_thread_t *)dcontext->fragment_field;
+    DEBUG_DECLARE(bool tables_updated =)
+    update_all_private_ibt_table_ptrs(dcontext, pt);
+    DODEBUG({
+        if (tables_updated)
+            STATS_INC(num_shared_tables_updated_delete);
+    });
+}
+
 static void
 fragment_add_ibl_target_helper(dcontext_t *dcontext, fragment_t *f,
                                ibl_table_t *ibl_table)

--- a/core/fragment.h
+++ b/core/fragment.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -738,6 +738,9 @@ fragment_pclookup_by_htable(dcontext_t *dcontext, cache_pc pc, fragment_t *wrapp
 void
 fragment_shift_fcache_pointers(dcontext_t *dcontext, fragment_t *f, ssize_t shift,
                                cache_pc start, cache_pc end, size_t old_size);
+
+void
+fragment_update_ibl_tables(dcontext_t *dcontext);
 
 fragment_t *
 fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t branch_type);

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -514,6 +514,8 @@ STATS_DEF("Dead shared IBT tables freed: at exit",
 STATS_DEF("Shared IBT tables freed: immediately", num_shared_ibt_tables_freed_immediately)
 STATS_DEF("Pvt ptrs to shared tables updated at-sys walks",
           num_shared_tables_updated_atsyscall)
+STATS_DEF("Pvt ptrs to shared tables updated at delete exits",
+          num_shared_tables_updated_delete)
 STATS_DEF("IBT unlinked entries NOT moved on resize", num_ibt_unlinked_entries_not_moved)
 STATS_DEF("BB fragments in 3 IBL tables", num_bbs_in_3_ibl_tables)
 STATS_DEF("BB fragments in 2 IBL tables", num_bbs_in_2_ibl_tables)


### PR DESCRIPTION
When an indirect branch lookup table (IBT) is resized, the old table
is filled with "target deleted" markers.  Another thread that hits in
the table is redirected to a cache exit due to the deleted marker.
However, previously that thread would *not* update its thread-local
pointer to the table on such an exit; it would only update on an
actual miss in the table.  This can lead to repeated cache exits on
hits until a miss is reached.

The problem is solved here with an explicit update of all tables on a
target-deleted exit.

Tested on "bin32/drrun -disable_traces -shared_bb_ibt_tables
-shared_ibt_table_bb_init 2 -- suite/tests/bin/linux.signest" on ARM.

Fixes #4704