### PR TITLE
i#4487: fix compiler warning for uninit var

### DIFF
--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1481,10 +1481,12 @@ event_delay_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t
         DR_ASSERT(false);
 
     reg_id_t scratch1, scratch2;
-    if (drreg_reserve_register(drcontext, bb, instr, NULL, &scratch1) != DRREG_SUCCESS ||
-        drreg_reserve_register(drcontext, bb, instr, NULL, &scratch2) != DRREG_SUCCESS ||
-        drreg_reserve_aflags(drcontext, bb, instr) != DRREG_SUCCESS)
-        FATAL("Fatal error: failed to reserve scratch registers and aflags");
+    if (drreg_reserve_register(drcontext, bb, instr, NULL, &scratch1) != DRREG_SUCCESS)
+        FATAL("Fatal error: failed to reserve scratch register");
+    if (drreg_reserve_register(drcontext, bb, instr, NULL, &scratch2) != DRREG_SUCCESS)
+        FATAL("Fatal error: failed to reserve scratch register");
+    if (drreg_reserve_aflags(drcontext, bb, instr) != DRREG_SUCCESS)
+        FATAL("Fatal error: failed to reserve aflags");
 
     instrlist_insert_mov_immed_ptrsz(drcontext, (ptr_int_t)&instr_count,
                                      opnd_create_reg(scratch1), bb, instr, NULL, NULL);


### PR DESCRIPTION
Fixes compilation warning for potentially uninitialized variable in tracer.cpp (drcachesim).

Issue: #4487