### PR TITLE
i#4607: Fix null pointer dereference in drwrap

### DIFF
--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -1705,9 +1705,10 @@ set_retaddr_on_stack(reg_t xsp, app_pc value)
     return res;
 }
 
-/* may not return */
+/* May not return. If it doesn't return, it decrements wrap_level and assumes
+ * it's re-starting in-callee. */
 static void
-drwrap_mark_retaddr_for_instru(void *drcontext, app_pc decorated_pc,
+drwrap_mark_retaddr_for_instru(void *drcontext, per_thread_t *pt, app_pc decorated_pc,
                                drwrap_context_t *wrapcxt, bool enabled)
 {
     post_call_entry_t *e;
@@ -1769,6 +1770,10 @@ drwrap_mark_retaddr_for_instru(void *drcontext, app_pc decorated_pc,
             /* ensure we have DR_MC_ALL */
             drwrap_get_mcontext_internal((void *)wrapcxt, DR_MC_ALL);
             wrapcxt->mc->pc = decorated_pc;
+            /* i#4607: We should decrement wrap_level, so, it won't be
+             * incremented again in drwrap_in_callee.
+             */
+            --pt->wrap_level;
             dr_redirect_execution(wrapcxt->mc);
             ASSERT(false, "dr_redirect_execution should not return");
         }
@@ -1851,7 +1856,7 @@ drwrap_ensure_postcall(void *drcontext, per_thread_t *pt, wrap_entry_t *wrap,
         dr_rwlock_write_unlock(post_call_rwlock);
         if (!TEST(DRWRAP_NO_FRILLS, global_flags))
             dr_recurlock_unlock(wrap_lock);
-        drwrap_mark_retaddr_for_instru(drcontext, decorated_pc, wrapcxt, enabled);
+        drwrap_mark_retaddr_for_instru(drcontext, pt, decorated_pc, wrapcxt, enabled);
         /* if we come back, re-lookup */
         if (!TEST(DRWRAP_NO_FRILLS, global_flags))
             dr_recurlock_lock(wrap_lock);
@@ -1931,21 +1936,8 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(reg_t lr))
                 break; /* we do need a post-call hook */
             }
         }
-        if (intercept_post && wrapcxt.retaddr != NULL) {
-            if (!TEST(DRWRAP_REPLACE_RETADDR, wrap->flags)) {
-                /* i#4607: drwrap_ensure_postcall may not return. Thus, we
-                 * should decrement wrap_level, so, it won't be incremented
-                 * again in drwrap_in_callee. We reproduce the behavior prior to
-                 * 9bb0354 commit.
-                 */
-                --pt->wrap_level;
-            }
+        if (intercept_post && wrapcxt.retaddr != NULL)
             drwrap_ensure_postcall(drcontext, pt, wrap, &wrapcxt, decorated_pc);
-            if (!TEST(DRWRAP_REPLACE_RETADDR, wrap->flags)) {
-                /* i#4607: Restore wrap_level. */
-                ++pt->wrap_level;
-            }
-        }
     }
 
     pt->last_wrap_func[pt->wrap_level] = decorated_pc;

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -1931,8 +1931,19 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(reg_t lr))
                 break; /* we do need a post-call hook */
             }
         }
-        if (intercept_post && wrapcxt.retaddr != NULL)
+        if (intercept_post && wrapcxt.retaddr != NULL) {
+            if (!TEST(DRWRAP_REPLACE_RETADDR, wrap->flags))
+                /* i#4607: drwrap_ensure_postcall may not return. Thus, we
+                 * should decrement wrap_level, so, it won't be incremented
+                 * again in drwrap_in_callee. We reproduce the behavior prior to
+                 * 9bb0354 commit.
+                 */
+                --pt->wrap_level;
             drwrap_ensure_postcall(drcontext, pt, wrap, &wrapcxt, decorated_pc);
+            if (!TEST(DRWRAP_REPLACE_RETADDR, wrap->flags))
+                /* i#4607: Restore wrap_level. */
+                ++pt->wrap_level;
+        }
     }
 
     pt->last_wrap_func[pt->wrap_level] = decorated_pc;

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -1932,17 +1932,19 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(reg_t lr))
             }
         }
         if (intercept_post && wrapcxt.retaddr != NULL) {
-            if (!TEST(DRWRAP_REPLACE_RETADDR, wrap->flags))
+            if (!TEST(DRWRAP_REPLACE_RETADDR, wrap->flags)) {
                 /* i#4607: drwrap_ensure_postcall may not return. Thus, we
                  * should decrement wrap_level, so, it won't be incremented
                  * again in drwrap_in_callee. We reproduce the behavior prior to
                  * 9bb0354 commit.
                  */
                 --pt->wrap_level;
+            }
             drwrap_ensure_postcall(drcontext, pt, wrap, &wrapcxt, decorated_pc);
-            if (!TEST(DRWRAP_REPLACE_RETADDR, wrap->flags))
+            if (!TEST(DRWRAP_REPLACE_RETADDR, wrap->flags)) {
                 /* i#4607: Restore wrap_level. */
                 ++pt->wrap_level;
+            }
         }
     }
 


### PR DESCRIPTION
drwrap_ensure_postcall may not return. Thus, we should decrement
wrap_level, so, it won't be incremented again in drwrap_in_callee. We
reproduce the behavior prior to 9bb0354 commit.

Fixes #4607