### PR TITLE
i#4712: Fix doxygen 1.9.1 build errors

### DIFF
--- a/api/docs/API.doxy
+++ b/api/docs/API.doxy
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
+# Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
 # Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
 # **********************************************************/
 
@@ -132,7 +132,6 @@ VERBATIM_HEADERS       = NO
 # configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = NO
-COLS_IN_ALPHA_INDEX    = 5
 IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
 # configuration options related to the HTML output

--- a/clients/drcachesim/tracer/drmemtrace.h
+++ b/clients/drcachesim/tracer/drmemtrace.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -83,7 +83,7 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[]);
  *
  * \return the opened file id.
  */
-typedef file_t (*drmemtrace_open_file_func_t)(const char *fname, uint mode_flag);
+typedef file_t (*drmemtrace_open_file_func_t)(const char *fname, uint mode_flags);
 
 /**
  * Function for file read.


### PR DESCRIPTION
Removes the obsolete Doxyfile entry COLS_IN_ALPHA_INDEX.

Fixes a code vs docs mismatch on a parameter name in drmemtrace.h.

Tested with a local doxygen 1.9.1 build.

Fixes #4712