### PR TITLE
i#1578,i#4474 arm detach: Enable api.startstop on arm

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2830,10 +2830,8 @@ if (CLIENT_INTERFACE)
     endif ()
   endif (ARM)
 
-  if (NOT AARCHXX) # TODO i#1578: Crashing on AArch64.
-    tobuild_api(api.startstop api/startstop.c "" "" OFF OFF)
-    link_with_pthread(api.startstop)
-  endif ()
+  tobuild_api(api.startstop api/startstop.c "" "" OFF OFF)
+  link_with_pthread(api.startstop)
   tobuild_api(api.detach api/detach.c "" "" OFF OFF)
   link_with_pthread(api.detach)
   if (LINUX AND X64) # Will take extra work to port to 32-bit.


### PR DESCRIPTION
The api.startstop test was crashing previously, but one of the many
recent fixes seems to have addressed that problem.  It now runs to
completion 1000x in a row on AArch64.

Issue: #1578, #4474