### PR TITLE
i#4719 qemu: Add -ignore_takeover_timeout

### DIFF
--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -3200,6 +3200,8 @@ OPTION(bool, multi_thread_exit,
        "do not guarantee that process exit event callback is invoked single-threaded")
 OPTION(bool, skip_thread_exit_at_exit, "skip thread exit events at process exit")
 #endif
+OPTION(bool, ignore_takeover_timeout,
+       "ignore timeouts trying to take over one or more threads when initializing")
 
 #ifdef EXPOSE_INTERNAL_OPTIONS
 OPTION_NAME(bool, optimize, " synthethic", "set if ANY opts are on")

--- a/core/win32/events.mc
+++ b/core/win32/events.mc
@@ -644,6 +644,14 @@ Language=English
 Application %1!s! (%2!s!). Failed to take over all threads after multiple attempts.
 .
 
+MessageId =
+Severity = Error
+Facility = DRCore
+SymbolicName = MSG_THREAD_TAKEOVER_TIMED_OUT
+Language=English
+Application %1!s! (%2!s!). Timed out attempting to take over one or more threads. %3!s!
+.
+
 ;#ifdef UNIX
 MessageId =
 Severity = Error


### PR DESCRIPTION
Adds a maximum tries when waiting for a thread to be taken over at
initialization time, instead of looping forever.  When the max is hit,
a fatal error is raised, unless a newly added option
-ignore_takeover_timeout is set.

The new option is used to ignore QEMU's own thread when running DR
under QEMU.  QEMU is not fully transparent and unfortunately does not
hide its thread from DR in procfs.

Manually tested both option settings under QEMU.  Regression tests
with QEMU are planned for the test suite for ARM.

Issue: #4719