### PR TITLE
i#4719 qemu: Add xarch_root option for QEMU

### DIFF
--- a/core/drlibc/drlibc_module_elf.c
+++ b/core/drlibc/drlibc_module_elf.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -407,7 +407,8 @@ elf_loader_map_phdrs(elf_loader_t *elf, bool fixed, map_fn_t map_func,
                                 * base, in which case the map can be anywhere
                                 */
                                ((fixed && map_base != NULL) ? MAP_FILE_FIXED : 0) |
-                               (TEST(MODLOAD_REACHABLE, flags) ? MAP_FILE_REACHABLE : 0));
+                               (TEST(MODLOAD_REACHABLE, flags) ? MAP_FILE_REACHABLE : 0) |
+                               (TEST(MODLOAD_IS_APP, flags) ? MAP_FILE_APP : 0));
     if (lib_base == NULL)
         return NULL;
     LOG(GLOBAL, LOG_LOADER, 3,

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -1013,6 +1013,7 @@ standalone_exit(void)
     doing_detach = false;
     standalone_library = false;
     dynamo_initialized = false;
+    dynamo_heap_initialized = false;
 }
 #endif
 

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -389,9 +389,14 @@ get_dr_stats(void)
 DYNAMORIO_EXPORT int
 dynamorio_app_init(void)
 {
-    int size;
+    dynamorio_app_init_part_one_options_and_heap();
+    return dynamorio_app_init_part_two_finalize();
+}
 
-    if (dynamo_initialized) {
+void
+dynamorio_app_init_part_one_options_and_heap(void)
+{
+    if (dynamo_initialized || dynamo_heap_initialized) {
         if (standalone_library) {
             REPORT_FATAL_ERROR_AND_EXIT(STANDALONE_ALREADY, 2, get_application_name(),
                                         get_application_pid());
@@ -479,9 +484,7 @@ dynamorio_app_init(void)
 
         /* now exit if nullcalls, now that perfctrs are set up */
         if (INTERNAL_OPTION(nullcalls)) {
-            print_file(main_logfile,
-                       "** nullcalls is set, NOT taking over execution **\n\n");
-            return SUCCESS;
+            return;
         }
 
         LOG(GLOBAL, LOG_TOP, 1, PRODUCT_NAME "'s stack size: %d Kb\n",
@@ -510,7 +513,25 @@ dynamorio_app_init(void)
 #endif
         d_r_heap_init();
         dynamo_heap_initialized = true;
+    }
+}
 
+int
+dynamorio_app_init_part_two_finalize(void)
+{
+    if (!dynamo_heap_initialized) {
+        /* Part one was never called. */
+        return FAILURE;
+    } else if (dynamo_initialized) {
+        if (standalone_library) {
+            REPORT_FATAL_ERROR_AND_EXIT(STANDALONE_ALREADY, 2, get_application_name(),
+                                        get_application_pid());
+        }
+        /* Nop. */
+    } else if (INTERNAL_OPTION(nullcalls)) {
+        print_file(main_logfile, "** nullcalls is set, NOT taking over execution **\n\n");
+        return SUCCESS;
+    } else {
         /* The process start event should be done after d_r_os_init() but before
          * process_control_int() because the former initializes event logging
          * and the latter can kill the process if a violation occurs.
@@ -618,7 +639,7 @@ dynamorio_app_init(void)
          * For now, leave it in there unless thin_client footprint becomes an
          * issue.
          */
-        size = HASHTABLE_SIZE(ALL_THREADS_HASH_BITS) * sizeof(thread_record_t *);
+        int size = HASHTABLE_SIZE(ALL_THREADS_HASH_BITS) * sizeof(thread_record_t *);
         all_threads =
             (thread_record_t **)global_heap_alloc(size HEAPACCT(ACCT_THREAD_MGT));
         memset(all_threads, 0, size);

--- a/core/globals.h
+++ b/core/globals.h
@@ -612,6 +612,11 @@ extern thread_record_t **all_threads;
 extern mutex_t all_threads_lock;
 DYNAMORIO_EXPORT int
 dynamorio_app_init(void);
+/* dynamorio_app_init() can be called in two parts: */
+void
+dynamorio_app_init_part_one_options_and_heap();
+int
+dynamorio_app_init_part_two_finalize();
 int
 dynamorio_app_exit(void);
 #if defined(CLIENT_INTERFACE) || defined(STANDALONE_UNIT_TEST)

--- a/core/heap.h
+++ b/core/heap.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -91,6 +91,7 @@ typedef enum {
     MAP_FILE_FIXED = 0x0004,      /* Linux-only */
     MAP_FILE_REACHABLE = 0x0008,  /* Map at location reachable from vmcode */
     MAP_FILE_VMM_COMMIT = 0x0010, /* Map address is pre-reserved inside VMM. */
+    MAP_FILE_APP = 0x0020,        /* Mapping is for the app, not DR/client. */
 } map_flags_t;
 
 typedef byte *heap_pc;

--- a/core/module_shared.h
+++ b/core/module_shared.h
@@ -544,6 +544,10 @@ typedef enum {
     MODLOAD_SEPARATE_BSS = 0x0008,
     /* Indicates that the module is being loaded in another process. */
     MODLOAD_SEPARATE_PROCESS = 0x0010,
+    /* For use with elf_loader_map_phdrs().  Avoids MAP_32BIT and other DR-mem-only
+     * distortions for app mappings (e.g., early inject mapping the interpreter).
+     */
+    MODLOAD_IS_APP = 0x0020,
 } modload_flags_t;
 
 /* This function is used for loading non-private libs as well as private. */

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -334,6 +334,22 @@ OPTION_NAME(bool, profile_pcs, "prof_pcs", "pc-sampling profiling")
 /* XXX i#1114: enable by default when the implementation is complete */
 OPTION_DEFAULT(bool, opt_jit, false, "optimize translation of dynamically generated code")
 
+#ifdef UNIX
+OPTION_COMMAND(pathstring_t, xarch_root, EMPTY_STRING, "xarch_root",
+               {
+                   /* Running under QEMU requires ignoring failure to take
+                    * over QEMU threads at initialization so we bundle it
+                    * here for convenience.
+                    */
+                   if (options->xarch_root[0] != '\0') {
+                       options->ignore_takeover_timeout = true;
+                   }
+               },
+               "QEMU support: prefix to add to opened files for emulation; also sets "
+               "-ignore_takeover_timeout",
+               STATIC, OP_PCACHE_NOP)
+#endif
+
 #ifdef EXPOSE_INTERNAL_OPTIONS
 #    ifdef PROFILE_RDTSC
 OPTION_NAME_INTERNAL(bool, profile_times, "prof_times", "profiling via measuring time")
@@ -396,19 +412,6 @@ OPTION_DEFAULT_INTERNAL(bool, private_loader,
                                                IF_MACOS_ELSE(false, true)),
                         "use private loader for clients and dependents")
 #        ifdef UNIX
-OPTION_COMMAND_INTERNAL(pathstring_t, xarch_root, EMPTY_STRING, "xarch_root",
-                        {
-                            /* Running under QEMU requires ignoring failure to take
-                             * over QEMU threads at initialization so we bundle it
-                             * here for convenience.
-                             */
-                            if (options->xarch_root[0] != '\0') {
-                                options->ignore_takeover_timeout = true;
-                            }
-                        },
-                        "prefix to add to opened files for emulation; also sets "
-                        "-ignore_takeover_timeout",
-                        STATIC, OP_PCACHE_NOP)
 /* We cannot know the total tls size when allocating tls in os_tls_init,
  * so use the runtime option to control the tls size.
  */

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -337,16 +337,18 @@ OPTION_DEFAULT(bool, opt_jit, false, "optimize translation of dynamically genera
 #ifdef UNIX
 OPTION_COMMAND(pathstring_t, xarch_root, EMPTY_STRING, "xarch_root",
                {
-                   /* Running under QEMU requires ignoring failure to take
-                    * over QEMU threads at initialization so we bundle it
-                    * here for convenience.
+                   /* Running under QEMU requires timing out and then leaving
+                    * the failed-takeover QEMU thread native, so we bundle that
+                    * here for convenience.  We target the common use case of a
+                    * small app, for which we want a small timeout.
                     */
                    if (options->xarch_root[0] != '\0') {
-                       options->ignore_takeover_timeout = true;
+                       options->unsafe_ignore_takeover_timeout = true;
+                       options->takeover_timeout_ms = 400;
                    }
                },
                "QEMU support: prefix to add to opened files for emulation; also sets "
-               "-ignore_takeover_timeout",
+               "-unsafe_ignore_takeover_timeout and -takeover_timeout_ms 400",
                STATIC, OP_PCACHE_NOP)
 #endif
 

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -396,6 +396,19 @@ OPTION_DEFAULT_INTERNAL(bool, private_loader,
                                                IF_MACOS_ELSE(false, true)),
                         "use private loader for clients and dependents")
 #        ifdef UNIX
+OPTION_COMMAND_INTERNAL(pathstring_t, xarch_root, EMPTY_STRING, "xarch_root",
+                        {
+                            /* Running under QEMU requires ignoring failure to take
+                             * over QEMU threads at initialization so we bundle it
+                             * here for convenience.
+                             */
+                            if (options->xarch_root[0] != '\0') {
+                                options->ignore_takeover_timeout = true;
+                            }
+                        },
+                        "prefix to add to opened files for emulation; also sets "
+                        "-ignore_takeover_timeout",
+                        STATIC, OP_PCACHE_NOP)
 /* We cannot know the total tls size when allocating tls in os_tls_init,
  * so use the runtime option to control the tls size.
  */

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * *******************************************************************************/
 
@@ -887,8 +887,19 @@ privload_locate(const char *name, privmod_t *dep,
     if (dep != NULL && privload_search_rpath(dep, true /*runpath*/, name, filename))
         return true;
 
-    /* 5) FIXME: i#460, we use our system paths instead of /etc/ld.so.cache. */
+    /* 5) XXX i#460: We use our system paths instead of /etc/ld.so.cache. */
     for (i = 0; i < NUM_SYSTEM_LIB_PATHS; i++) {
+        /* First try -xarch_root for emulation. */
+        if (!IS_STRING_OPTION_EMPTY(xarch_root)) {
+            string_option_read_lock();
+            snprintf(filename, MAXIMUM_PATH, "%s/%s/%s", INTERNAL_OPTION(xarch_root),
+                     system_lib_paths[i], name);
+            filename[MAXIMUM_PATH - 1] = '\0';
+            string_option_read_unlock();
+            if (os_file_exists(filename, false /*!is_dir*/) &&
+                module_file_has_module_header(filename))
+                return true;
+        }
         snprintf(filename, MAXIMUM_PATH, "%s/%s", system_lib_paths[i], name);
         /* NULL_TERMINATE_BUFFER(filename) */
         filename[MAXIMUM_PATH - 1] = 0;
@@ -1992,11 +2003,29 @@ privload_early_inject(void **sp, byte *old_libdr_base, size_t old_libdr_size)
     reserve_brk(exe_map + exe_ld.image_size +
                 (INTERNAL_OPTION(separate_private_bss) ? PAGE_SIZE : 0));
 
+    /* Initialize DR's options and heap for the -xarch_root option. */
+    dynamorio_app_init_part_one_options_and_heap();
+
     interp = elf_loader_find_pt_interp(&exe_ld);
     if (interp != NULL) {
+        char *buf = NULL;
+        if (!IS_STRING_OPTION_EMPTY(xarch_root) && !os_file_exists(interp, false)) {
+            buf = global_heap_alloc(MAXIMUM_PATH HEAPACCT(ACCT_OTHER));
+            string_option_read_lock();
+            snprintf(buf, MAXIMUM_PATH, "%s/%s", INTERNAL_OPTION(xarch_root), interp);
+            buf[MAXIMUM_PATH - 1] = '\0';
+            string_option_read_unlock();
+            if (os_file_exists(buf, false)) {
+                LOG(GLOBAL, LOG_SYSCALLS, 2, "replacing interpreter |%s| with |%s|\n",
+                    interp, buf);
+                interp = buf;
+            }
+        }
         /* Load the ELF pointed at by PT_INTERP, usually ld.so. */
         elf_loader_t interp_ld;
         success = elf_loader_read_headers(&interp_ld, interp);
+        if (buf != NULL)
+            global_heap_free(buf, MAXIMUM_PATH HEAPACCT(ACCT_OTHER));
         apicheck(success, "Failed to read ELF interpreter headers.");
         interp_map = elf_loader_map_phdrs(
             &interp_ld, false /* fixed */, os_map_file, os_unmap_file, os_set_protection,
@@ -2021,13 +2050,15 @@ privload_early_inject(void **sp, byte *old_libdr_base, size_t old_libdr_size)
 
     elf_loader_destroy(&exe_ld);
 
-    /* Initialize DR *after* we map the app image.  This is consistent with our
-     * old behavior, and allows the client to do things like call
+    /* Initialize the rest of DR *after* we map the app and interp images.  This is
+     * consistent with our old behavior, and allows the client to do things like call
      * dr_get_proc_address() on the app from dr_client_main().  We let
      * find_executable_vm_areas re-discover the mappings we made for the app and
-     * interp images.
+     * interp images.  We do not do the full init before mapping the interp image
+     * as it complicates recording the mappings for the interp.
      */
-    dynamorio_app_init();
+    if (dynamorio_app_init_part_two_finalize() != SUCCESS)
+        apicheck(false, "Failed to initialize part two.");
 
     LOG(GLOBAL, LOG_TOP, 1, "early injected into app with this cmdline:\n");
     DOLOG(1, LOG_TOP, {

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -892,7 +892,7 @@ privload_locate(const char *name, privmod_t *dep,
         /* First try -xarch_root for emulation. */
         if (!IS_STRING_OPTION_EMPTY(xarch_root)) {
             string_option_read_lock();
-            snprintf(filename, MAXIMUM_PATH, "%s/%s/%s", INTERNAL_OPTION(xarch_root),
+            snprintf(filename, MAXIMUM_PATH, "%s/%s/%s", DYNAMO_OPTION(xarch_root),
                      system_lib_paths[i], name);
             filename[MAXIMUM_PATH - 1] = '\0';
             string_option_read_unlock();
@@ -2012,7 +2012,7 @@ privload_early_inject(void **sp, byte *old_libdr_base, size_t old_libdr_size)
         if (!IS_STRING_OPTION_EMPTY(xarch_root) && !os_file_exists(interp, false)) {
             buf = global_heap_alloc(MAXIMUM_PATH HEAPACCT(ACCT_OTHER));
             string_option_read_lock();
-            snprintf(buf, MAXIMUM_PATH, "%s/%s", INTERNAL_OPTION(xarch_root), interp);
+            snprintf(buf, MAXIMUM_PATH, "%s/%s", DYNAMO_OPTION(xarch_root), interp);
             buf[MAXIMUM_PATH - 1] = '\0';
             string_option_read_unlock();
             if (os_file_exists(buf, false)) {

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1965,7 +1965,7 @@ privload_early_inject(void **sp, byte *old_libdr_base, size_t old_libdr_size)
                                    /* ensure there's space for the brk */
                                    map_exe_file_and_brk, os_unmap_file, os_set_protection,
                                    privload_check_new_map_bounds,
-                                   privload_map_flags(0 /*!reachable*/));
+                                   privload_map_flags(MODLOAD_IS_APP /*!reachable*/));
     apicheck(exe_map != NULL,
              "Failed to load application.  "
              "Check path and architecture.");
@@ -2029,7 +2029,8 @@ privload_early_inject(void **sp, byte *old_libdr_base, size_t old_libdr_size)
         apicheck(success, "Failed to read ELF interpreter headers.");
         interp_map = elf_loader_map_phdrs(
             &interp_ld, false /* fixed */, os_map_file, os_unmap_file, os_set_protection,
-            privload_check_new_map_bounds, privload_map_flags(0 /*!reachable*/));
+            privload_check_new_map_bounds,
+            privload_map_flags(MODLOAD_IS_APP /*!reachable*/));
         apicheck(interp_map != NULL && is_elf_so_header(interp_map, 0),
                  "Failed to map ELF interpreter.");
         /* On Android, the system loader /system/bin/linker sets itself

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4255,7 +4255,8 @@ os_map_file(file_t f, size_t *size INOUT, uint64 offs, app_pc addr, uint prot,
      * in particular): for low 4GB, easiest to just pass MAP_32BIT (which is
      * low 2GB, but good enough).
      */
-    if (DYNAMO_OPTION(heap_in_lower_4GB) && !TEST(MAP_FILE_FIXED, map_flags))
+    if (DYNAMO_OPTION(heap_in_lower_4GB) &&
+        !TESTANY(MAP_FILE_FIXED | MAP_FILE_APP, map_flags))
         flags |= MAP_32BIT;
 #endif
     /* Allows memory request instead of mapping a file,

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7730,7 +7730,7 @@ pre_system_call(dcontext_t *dcontext)
         if (!IS_STRING_OPTION_EMPTY(xarch_root) && !os_file_exists(path, false)) {
             char *buf = heap_alloc(dcontext, MAXIMUM_PATH HEAPACCT(ACCT_OTHER));
             string_option_read_lock();
-            snprintf(buf, MAXIMUM_PATH, "%s/%s", INTERNAL_OPTION(xarch_root), path);
+            snprintf(buf, MAXIMUM_PATH, "%s/%s", DYNAMO_OPTION(xarch_root), path);
             buf[MAXIMUM_PATH - 1] = '\0';
             string_option_read_unlock();
             if (os_file_exists(buf, false)) {


### PR DESCRIPTION
Adds a new option -xarch_root which sets a path that is prepended to:
+ The application executable's interpreter, if the original does not exist.
+ SYS_openat paths, if the original does not exist.
+ System paths ued for loading private libraries: here the prefix is prepended
  before checking whether the original exists.

Splits dynamorio_app_init() into two pieces in order to have the
options set up at the time the loader maps the interpreter, while
avoiding ordering problems with the rest of the initialization.

The new option also auto-sets -ignore_takeover_timeout for
convenience, as that is always needed when running under QEMU.

Manually tested in cross-compile AArchXX setups on a Debian system.
Test suite integration is forthcoming.

Issue: #4719