### PR TITLE
i#4719 qemu: Add -takeover_timeout_ms

### DIFF
--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -3200,8 +3200,13 @@ OPTION(bool, multi_thread_exit,
        "do not guarantee that process exit event callback is invoked single-threaded")
 OPTION(bool, skip_thread_exit_at_exit, "skip thread exit events at process exit")
 #endif
-OPTION(bool, ignore_takeover_timeout,
-       "ignore timeouts trying to take over one or more threads when initializing")
+OPTION(bool, unsafe_ignore_takeover_timeout,
+       "ignore timeouts trying to take over one or more threads when initializing, "
+       "leaving those threads native, which is potentially unsafe")
+OPTION_DEFAULT(uint, takeover_timeout_ms, 30000,
+               "timeout in milliseconds for each thread when taking over at "
+               "initialization/attach.  Reaching a timeout is fatal, unless "
+               "-unsafe_ignore_takeover_timeout is set.")
 
 #ifdef EXPOSE_INTERNAL_OPTIONS
 OPTION_NAME(bool, optimize, " synthethic", "set if ANY opts are on")


### PR DESCRIPTION
Fixes a problem with the hardcoded small timeout from PR #4725 by
parameterizing the timeout in a new option -takeover_timeout_ms.  It
is set to a high value by default; the plan is to have -xarch_root set
it to a low value for the common QEMU case of running a small test,
while still overridable for large apps.

Renames -ignore_takeover_timeout to -unsafe_ignore_takeover_timeout to
indicate that it can cause problems if actual application threads are
left native.

Issue: #4719