### PR TITLE
Avoid blind syslog during init

### DIFF
--- a/core/globals.h
+++ b/core/globals.h
@@ -614,7 +614,7 @@ DYNAMORIO_EXPORT int
 dynamorio_app_init(void);
 /* dynamorio_app_init() can be called in two parts: */
 void
-dynamorio_app_init_part_one_options_and_heap();
+dynamorio_app_init_part_one_options();
 int
 dynamorio_app_init_part_two_finalize();
 int


### PR DESCRIPTION
Avoids printing of an internal warning during early initialization for
single-bitwidth setups regardless of -stderr_mask by moving options
init even earlier.

To avoid DR heap init messing up the app's brk setup, moves heap init
out of the options init and into the later half.  This undoes the
early heap init from PR #4726, which is worked around by switching to
a stack buffer for -arch_init.  This seems safer in any case, delaying
heap init and client lib loads until after the app's interpreter is
loaded.

Issue: #4719