### PR TITLE
i#4741: Split custom modtrack data by segment

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -141,6 +141,10 @@ changes:
    member fields of classes are now following a consistent style with
    an underscore suffix.  References to renamed fields will need to be
    updated.
+ - A change in the load callbacks used with drmodtrack_add_custom_data()
+   and drmemtrace_custom_module_data(): they each take an additional parameter, the
+   segment index.  The custom data field is now per-segment and not per-module,
+   and all callbacks are invoked separately for each segment.
 
 The changes between version \DR_VERSION and 8.0.0 include the following minor
 compatibility changes:

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -141,8 +141,10 @@ local_create_dir(const char *dir)
 static void *
 load_cb(module_data_t *module, int seg_idx)
 {
+#ifndef WINDOWS
     if (seg_idx > 0)
         return (void *)module->segments[seg_idx].start;
+#endif
     return (void *)module->start;
 }
 

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -139,8 +139,10 @@ local_create_dir(const char *dir)
 }
 
 static void *
-load_cb(module_data_t *module)
+load_cb(module_data_t *module, int seg_idx)
 {
+    if (seg_idx > 0)
+        return (void *)module->segments[seg_idx].start;
     return (void *)module->start;
 }
 
@@ -163,7 +165,7 @@ parse_cb(const char *src, OUT void **data)
 static std::string
 process_cb(drmodtrack_info_t *info, void *data, void *user_data)
 {
-    assert((app_pc)data == info->start || info->containing_index != info->index);
+    assert((app_pc)data == info->start);
     assert(user_data == MAGIC_VALUE);
     return "";
 }

--- a/clients/drcachesim/tracer/drmemtrace.h
+++ b/clients/drcachesim/tracer/drmemtrace.h
@@ -249,17 +249,19 @@ drmemtrace_get_funclist_path(OUT const char **path);
 DR_EXPORT
 /**
  * Adds custom data stored with each module in the module list produced for
- * offline trace post-processing.  The \p load_cb is called for each new module,
+ * offline trace post-processing.  The \p load_cb is called for each segment
+ * of each new module (with \p seg_idx indicating the segment number, starting at 0),
  * and its return value is the data that is stored.  That data is later printed
  * to a string with \p print_cb, which should return the number of characters
- * printed or -1 on error.  The data is freed with \p free_cb.
+ * printed or -1 on error.  The data is freed with \p free_cb.  Each is called
+ * separately for each segment of each module.
  *
  * On the post-processing side, the user should create a custom post-processor
  * by linking with raw2trace and calling raw2trace_t::handle_custom_data() to provide
  * parsing and processing routines for the custom data.
  */
 drmemtrace_status_t
-drmemtrace_custom_module_data(void *(*load_cb)(module_data_t *module),
+drmemtrace_custom_module_data(void *(*load_cb)(module_data_t *module, int seg_idx),
                               int (*print_cb)(void *data, char *dst, size_t max_len),
                               void (*free_cb)(void *data));
 

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -399,7 +399,7 @@ public:
                 bool repstr_expanded) override;
 
     static bool
-    custom_module_data(void *(*load_cb)(module_data_t *module),
+    custom_module_data(void *(*load_cb)(module_data_t *module, int seg_idx),
                        int (*print_cb)(void *data, char *dst, size_t max_len),
                        void (*free_cb)(void *data));
 
@@ -460,11 +460,11 @@ private:
 
     // Custom module fields are global (since drmodtrack's support is global, we don't
     // try to pass void* user data params through).
-    static void *(*user_load_)(module_data_t *module);
+    static void *(*user_load_)(module_data_t *module, int seg_idx);
     static int (*user_print_)(void *data, char *dst, size_t max_len);
     static void (*user_free_)(void *data);
     static void *
-    load_custom_module_data(module_data_t *module);
+    load_custom_module_data(module_data_t *module, int seg_idx);
     static int
     print_custom_module_data(void *data, char *dst, size_t max_len);
     static void

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -129,10 +129,15 @@ offline_instru_t::load_custom_module_data(module_data_t *module, int seg_idx)
           strstr(name, "linux-vdso.so") == name)) ||
         (module->names.file_name != NULL && strcmp(name, "[vdso]") == 0)) {
         void *alloc = dr_global_alloc(sizeof(custom_module_data_t));
+#ifdef WINDOWS
+        byte *start = module->start;
+        byte *end = module->end;
+#else
         byte *start =
             (module->num_segments > 0) ? module->segments[seg_idx].start : module->start;
         byte *end =
             (module->num_segments > 0) ? module->segments[seg_idx].end : module->end;
+#endif
         return new (alloc)
             custom_module_data_t((const char *)start, end - start, user_data);
     } else if (user_data != nullptr) {

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -47,7 +47,7 @@
 
 static const ptr_uint_t MAX_INSTR_COUNT = 64 * 1024;
 
-void *(*offline_instru_t::user_load_)(module_data_t *module);
+void *(*offline_instru_t::user_load_)(module_data_t *module, int seg_idx);
 int (*offline_instru_t::user_print_)(void *data, char *dst, size_t max_len);
 void (*offline_instru_t::user_free_)(void *data);
 
@@ -115,11 +115,11 @@ offline_instru_t::~offline_instru_t()
 }
 
 void *
-offline_instru_t::load_custom_module_data(module_data_t *module)
+offline_instru_t::load_custom_module_data(module_data_t *module, int seg_idx)
 {
     void *user_data = nullptr;
     if (user_load_ != nullptr)
-        user_data = (*user_load_)(module);
+        user_data = (*user_load_)(module, seg_idx);
     const char *name = dr_module_preferred_name(module);
     // For vdso we include the entire contents so we can decode it during
     // post-processing.
@@ -129,8 +129,12 @@ offline_instru_t::load_custom_module_data(module_data_t *module)
           strstr(name, "linux-vdso.so") == name)) ||
         (module->names.file_name != NULL && strcmp(name, "[vdso]") == 0)) {
         void *alloc = dr_global_alloc(sizeof(custom_module_data_t));
-        return new (alloc) custom_module_data_t((const char *)module->start,
-                                                module->end - module->start, user_data);
+        byte *start =
+            (module->num_segments > 0) ? module->segments[seg_idx].start : module->start;
+        byte *end =
+            (module->num_segments > 0) ? module->segments[seg_idx].end : module->end;
+        return new (alloc)
+            custom_module_data_t((const char *)start, end - start, user_data);
     } else if (user_data != nullptr) {
         void *alloc = dr_global_alloc(sizeof(custom_module_data_t));
         return new (alloc) custom_module_data_t(nullptr, 0, user_data);
@@ -190,7 +194,7 @@ offline_instru_t::free_custom_module_data(void *data)
 }
 
 bool
-offline_instru_t::custom_module_data(void *(*load_cb)(module_data_t *module),
+offline_instru_t::custom_module_data(void *(*load_cb)(module_data_t *module, int seg_idx),
                                      int (*print_cb)(void *data, char *dst,
                                                      size_t max_len),
                                      void (*free_cb)(void *data))

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * ******************************************************************************/
 
@@ -282,7 +282,7 @@ drmemtrace_get_funclist_path(OUT const char **path)
 }
 
 drmemtrace_status_t
-drmemtrace_custom_module_data(void *(*load_cb)(module_data_t *module),
+drmemtrace_custom_module_data(void *(*load_cb)(module_data_t *module, int seg_idx),
                               int (*print_cb)(void *data, char *dst, size_t max_len),
                               void (*free_cb)(void *data))
 {

--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.   All rights reserved.
+ * Copyright (c) 2016-2021 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -378,15 +378,16 @@ DR_EXPORT
  * and writes the parsed data to its output parameter, which can subsequently be
  * retrieved from drmodtrack_offline_lookup()'s \p custom output parameter.
  *
- * If a module contains non-contiguous segments, \p load_cb is called
- * only once, and the resulting custom field is shared among all
- * separate entries returned by drmodtrack_offline_lookup().
+ * If a module contains multiple segments, \p load_cb is called
+ * multiple times, once for each segment, with \p seg_idx indicating the segment.
+ * Each segment stores its own custom field, and each callback is invoked separately
+ * for each segment.
  *
  * Only one value for each callback is supported.  Calling this routine again
  * with a different value will replace the existing callbacks.
  */
 drcovlib_status_t
-drmodtrack_add_custom_data(void *(*load_cb)(module_data_t *module),
+drmodtrack_add_custom_data(void *(*load_cb)(module_data_t *module, int seg_idx),
                            int (*print_cb)(void *data, char *dst, size_t max_len),
                            const char *(*parse_cb)(const char *src, OUT void **data),
                            void (*free_cb)(void *data));

--- a/suite/tests/client-interface/drmodtrack-test.dll.cpp
+++ b/suite/tests/client-interface/drmodtrack-test.dll.cpp
@@ -57,8 +57,10 @@ static client_id_t client_id;
 static void *
 load_cb(module_data_t *module, int seg_idx)
 {
+#ifndef WINDOWS
     if (seg_idx > 0)
         return (void *)module->segments[seg_idx].start;
+#endif
     return (void *)module->start;
 }
 

--- a/suite/tests/client-interface/drmodtrack-test.dll.cpp
+++ b/suite/tests/client-interface/drmodtrack-test.dll.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -55,8 +55,10 @@
 static client_id_t client_id;
 
 static void *
-load_cb(module_data_t *module)
+load_cb(module_data_t *module, int seg_idx)
 {
+    if (seg_idx > 0)
+        return (void *)module->segments[seg_idx].start;
     return (void *)module->start;
 }
 
@@ -189,8 +191,7 @@ event_exit(void)
         };
         res = drmodtrack_offline_lookup(modhandle, i, &info);
         CHECK(res == DRCOVLIB_SUCCESS, "lookup failed");
-        CHECK(((app_pc)info.custom) == info.start || info.containing_index != i,
-              "custom field doesn't match");
+        CHECK(((app_pc)info.custom) == info.start, "custom field doesn't match");
         CHECK(info.index == i, "index field doesn't match");
 #ifndef WINDOWS
         if (info.struct_size > offsetof(drmodtrack_info_t, offset)) {


### PR DESCRIPTION
Changes the drmodtrack_add_custom_data() and
drmemtrace_custom_module_data() interfaces to call each load and free
callback separately for each module segment, adding a new parameter
with the segment index to the load callback.

This eliminates a superfluous vdso map when the vdso is split into two
segments (#3900), and properly handles a gap between segments with
custom data.

Updates the documentation to indicate the compatibility break.  Since
this is isolated to rarely used extension libraries and drcachesim
interfaces, we do not bump DR's own release major or minor numbers.
Compatibility is maintained for drcachesim offline traces, so the
offline trace and custom module versions are not changed.

Tested by running opcode_mix with -verbose 1.
Before we mapped 8K twice and never used the 2nd:
```
  --------------------------------------------------
  11,  11, 0x00007fffec594000, 0x00007fffec595000, 0x00007fffec594680, 0000000000000000, v#1,8192,^?ELF^
  12,  12, 0x00007fffec595000, 0x00007fffec596000, 0x00007fffec594680, 0000000000001000, v#1,8192,^?ELF^
  [drmemtrace]: Using module 11 [vdso] stored 8192-byte contents @0x55d569b449ef
  [drmemtrace]: Using module 12 [vdso] stored 8192-byte contents @0x55d569b46a58
  Mapped vdso1+0x10 to 55d569b449ff; range 55d569b449ef size 2000
  Mapped vdso2+0x10 to 55d569b459ff; range 55d569b449ef size 2000
  --------------------------------------------------
```
After, we map 4K separately and use each:
```
  --------------------------------------------------
  11,  11, 0x00007ffc41350000, 0x00007ffc41351000, 0x00007ffc41350680, 0000000000000000, v#2,4096,^?ELF<...>
  12,  11, 0x00007ffc41351000, 0x00007ffc41352000, 0x00007ffc41350680, 0000000000001000, v#2,4096, ^A<...>
  [drmemtrace]: Using module 11 [vdso] stored 4096-byte contents @0x557fbaec09ef
  [drmemtrace]: Using module 12 [vdso] stored 4096-byte contents @0x557fbaec1a58
  Mapped vdso1+0x10 to 557fbaec09ff; range 557fbaec09ef size 1000
  Mapped vdso2+0x10 to 557fbaec1a68; range 557fbaec1a58 size 1000
  --------------------------------------------------
```

Fixes #4741