### PR TITLE
Remove IA-32 from general IR statements

### DIFF
--- a/api/docs/bt.dox
+++ b/api/docs/bt.dox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -76,7 +76,7 @@ following sections:
 \section sec_IR Instruction Representation
 
 The primary data structures involved in instruction manipulation are
-the \c instr_t, which represents a single IA-32 instruction, and the \c
+the \c instr_t, which represents a single instruction, and the \c
 instrlist_t, which is a linked list of instructions.  The header files
 dr_ir_instrlist.h and dr_ir_instr.h list a number of functions that
 operate on these data structures, including:
@@ -663,7 +663,7 @@ functionality.
 \subsection sec_Decoding Decoding
 
 DynamoRIO provides several routines for decoding and disassembling
-IA-32 instructions.  The most common method for decoding is the
+instructions.  The most common method for decoding is the
 decode() routine, which populates an \c instr_t data structure with all
 information about the instruction (e.g., opcode and operand
 information).
@@ -721,7 +721,7 @@ determine the order.
 \subsection sec_Encoding Encoding
 
 DynamoRIO's encoding routines take an instruction or list of
-instructions and encode them into the corresponding IA-32 bit pattern:
+instructions and encode them into the corresponding bit pattern:
 
 \code instr_encode(), instrlist_encode() \endcode
 

--- a/api/docs/bt.dox
+++ b/api/docs/bt.dox
@@ -136,7 +136,7 @@ instructions and safely using instructions in signal handlers.
 ********************
 \subsection sec_IR_adaptive Adaptive Level of Detail
 
-It is costly to decode IA-32 instructions.  Fortunately, DynamoRIO is
+It is costly to decode instructions.  Fortunately, DynamoRIO is
 often only interested in high-level information for a subset of
 instructions, such as just the control-flow instructions.  Each
 instruction can be at one of five levels of detail.  To simplify clients,
@@ -179,7 +179,7 @@ information than raw bytes:
 \par Level 2: Opcode and Eflags
 
 At Level 2, \c instr_t has been decoded just enough to determine opcode and
-flags effects (flags are important when analyzing IA-32 code).  Raw bytes
+flags effects (flags are important when analyzing code).  Raw bytes
 are still used for encoding.  The flags effects below are only shown for
 reading (R) or writing (W) the six arithmetic flags (Carry, Parity, Adjust,
 Zero, Sign, and Overflow).
@@ -217,7 +217,7 @@ Zero, Sign, and Overflow).
 \par Level 3: Operands
 
 A Level 3 \c instr_t contains dynamically allocated arrays of source and
-destination operands (dynamic because IA-32 is so variable) that are now
+destination operands (dynamic because some ISA's are quite variable) that are now
 filled in.  Raw bytes are still valid and are used for encoding.  This
 level combines high-level information with quick encoding.
 

--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -2068,7 +2068,7 @@ require initialization.
 Neither the context returned by dr_standalone_init() nor \p
 GLOBAL_DCONTEXT can be used as the drcontext for a thread running under
 DynamoRIO control!  It is only for standalone programs that wish to use
-DynamoRIO as a library of routines for IA-32 instruction manipulation or
+DynamoRIO as a library of routines for instruction manipulation or
 other purposes.
 
 In standalone mode, the dr_set_isa_mode() routine operates globally rather


### PR DESCRIPTION
Removes several cases where the documentation about the IR says
"IA-32" when it means all the ISA'ss we support.