### PR TITLE
i#4719 qemu: Fix regression in interp rewrite

### DIFF
--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -2010,8 +2010,8 @@ privload_early_inject(void **sp, byte *old_libdr_base, size_t old_libdr_size)
 
     interp = elf_loader_find_pt_interp(&exe_ld);
     if (interp != NULL) {
+        char buf[MAXIMUM_PATH];
         if (!IS_STRING_OPTION_EMPTY(xarch_root) && !os_file_exists(interp, false)) {
-            char buf[MAXIMUM_PATH];
             string_option_read_lock();
             snprintf(buf, BUFFER_SIZE_ELEMENTS(buf), "%s/%s", DYNAMO_OPTION(xarch_root),
                      interp);


### PR DESCRIPTION
Fixes a bug introduced by PR #4729 which swapped a heap buffer for a
stack buffer but placed the buffer in a too-deep scope.

Manually tested via:
$ qemu-aarch64 -L /usr/aarch64-linux-gnu bin64/drrun -xarch_root /usr/aarch64-linux-gnu -- suite/tests/bin/simple_app
$ qemu-arm -L /usr/arm-linux-gnueabihf bin32/drrun -xarch_root /usr/arm-linux-gnueabihf -- suite/tests/bin/simple_app

Forthcoming test suite support for running under qemu will add CI
tests that will avoid such regressions in the future.

Issue: #4719