### PR TITLE
i#4111: Generate doxygen suitable for embedding in jekyll

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -126,7 +126,7 @@ jobs:
 
     - name: Deploy Embedded Docs
       run: |
-        rsync -av --delete embed_html/ dynamorio.github.io/docs/
+        rsync -av --delete html_embed/ dynamorio.github.io/docs/
         cd dynamorio.github.io
         git config --local user.name "cronbuild"
         git config --local user.email "dynamorio-devs@googlegroups.com"

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -137,488 +137,489 @@ jobs:
         # We need a personal access token for write access to another repo.
         GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
 
-    - name: Send failure mail to dynamorio-devs
-      if: failure() && github.ref == 'refs/heads/master'
-      uses: dawidd6/action-send-mail@v2
-      with:
-        server_address: smtp.gmail.com
-        server_port: 465
-        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-        subject: |
-          [${{github.repository}}] ${{github.workflow}} FAILED
-          on ${{github.event_name}} at ${{github.ref}}
-        body: |
-          Github Actions CI workflow run FAILED!
-          Workflow: ${{github.workflow}}/linux-x86
-          Repository: ${{github.repository}}
-          Branch ref: ${{github.ref}}
-          SHA: ${{github.sha}}
-          Triggering actor: ${{github.actor}}
-          Triggering event: ${{github.event_name}}
-          Run Id: ${{github.run_id}}
-          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-        to: dynamorio-devs@googlegroups.com
-        from: Github Action package jobs
-
-  ###########################################################################
-  # Linux AArch64 tarball:
-  linux-aarch64:
-    runs-on: ubuntu-16.04
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Fetch Sources
-      run: |
-        git fetch --no-tags --depth=1 origin master
-        # Include Dr. Memory in packages.
-        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-        cd drmemory && git submodule update --init --depth 250 && cd ..
-
-    # Install cross-compilers for cross-compiling Linux build:
-    - name: Create Build Environment
-      run: |
-        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
-
-    - name: Get Version
-      id: version
-      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
-      run: |
-        if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
-        else
-          export VERSION_NUMBER=${{ github.event.inputs.version }}
-        fi
-        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
-        fi
-        echo "::set-output name=version_number::${VERSION_NUMBER}"
-
-    - name: Build Package
-      working-directory: ${{ github.workspace }}
-      run: ./suite/runsuite_wrapper.pl automated_ci 64_only
-      env:
-        CI_TARGET: package
-        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
-        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: yes
-
-    - name: Upload AArch64
-      uses: actions/upload-artifact@v2
-      with:
-        name: aarch64-tarball
-        path: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-
-    - name: Send failure mail to dynamorio-devs
-      if: failure() && github.ref == 'refs/heads/master'
-      uses: dawidd6/action-send-mail@v2
-      with:
-        server_address: smtp.gmail.com
-        server_port: 465
-        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-        subject: |
-          [${{github.repository}}] ${{github.workflow}} FAILED
-          on ${{github.event_name}} at ${{github.ref}}
-        body: |
-          Github Actions CI workflow run FAILED!
-          Workflow: ${{github.workflow}}/linux-aarch64
-          Repository: ${{github.repository}}
-          Branch ref: ${{github.ref}}
-          SHA: ${{github.sha}}
-          Triggering actor: ${{github.actor}}
-          Triggering event: ${{github.event_name}}
-          Run Id: ${{github.run_id}}
-          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-        to: dynamorio-devs@googlegroups.com
-        from: Github Action package jobs
-
-  ###########################################################################
-  # Linux ARM tarball (package.cmake does not support same job as AArch64):
-  linux-arm:
-    runs-on: ubuntu-16.04
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Fetch Sources
-      run: |
-        git fetch --no-tags --depth=1 origin master
-        # Include Dr. Memory in packages.
-        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-        cd drmemory && git submodule update --init --depth 250 && cd ..
-
-    # Install cross-compilers for cross-compiling Linux build:
-    - name: Create Build Environment
-      run: |
-        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
-
-    - name: Get Version
-      id: version
-      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
-      run: |
-        if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
-        else
-          export VERSION_NUMBER=${{ github.event.inputs.version }}
-        fi
-        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
-        fi
-        echo "::set-output name=version_number::${VERSION_NUMBER}"
-
-    - name: Build Package
-      working-directory: ${{ github.workspace }}
-      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
-      env:
-        CI_TARGET: package
-        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
-        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: yes
-
-    - name: Upload ARM
-      uses: actions/upload-artifact@v2
-      with:
-        name: arm-tarball
-        path: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
-
-    - name: Send failure mail to dynamorio-devs
-      if: failure() && github.ref == 'refs/heads/master'
-      uses: dawidd6/action-send-mail@v2
-      with:
-        server_address: smtp.gmail.com
-        server_port: 465
-        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-        subject: |
-          [${{github.repository}}] ${{github.workflow}} FAILED
-          on ${{github.event_name}} at ${{github.ref}}
-        body: |
-          Github Actions CI workflow run FAILED!
-          Workflow: ${{github.workflow}}/linux-arm
-          Repository: ${{github.repository}}
-          Branch ref: ${{github.ref}}
-          SHA: ${{github.sha}}
-          Triggering actor: ${{github.actor}}
-          Triggering event: ${{github.event_name}}
-          Run Id: ${{github.run_id}}
-          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-        to: dynamorio-devs@googlegroups.com
-        from: Github Action package jobs
-
-  ###########################################################################
-  # Android ARM tarball:
-  android-arm:
-    runs-on: ubuntu-16.04
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Fetch Sources
-      run: |
-        git fetch --no-tags --depth=1 origin master
-        # Include Dr. Memory in packages.
-        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-        cd drmemory && git submodule update --init --depth 250 && cd ..
-
-    # Fetch and install Android NDK for Andoid cross-compile build.
-    - name: Create Build Environment
-      run: |
-        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev
-        cd /tmp
-        wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
-        unzip -q android-ndk-r10e-linux-x86_64.zip
-        android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
-          --toolchain=arm-linux-androideabi-4.9 --platform=android-21 \
-          --install-dir=/tmp/android-gcc-arm-ndk-10e
-        # Manually force using ld.bfd, setting CMAKE_LINKER does not work.
-        ln -sf ld.bfd /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
-        ln -sf arm-linux-androideabi-ld.bfd \
-          /tmp/android-gcc-arm-ndk-10e/bin/arm-linux-androideabi-ld
-
-    - name: Get Version
-      id: version
-      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
-      run: |
-        if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
-        else
-          export VERSION_NUMBER=${{ github.event.inputs.version }}
-        fi
-        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
-        fi
-        echo "::set-output name=version_number::${VERSION_NUMBER}"
-
-    - name: Build Package
-      working-directory: ${{ github.workspace }}
-      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
-      env:
-        CI_TARGET: package
-        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
-        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: no
-        DYNAMORIO_CROSS_ANDROID_ONLY: yes
-        DYNAMORIO_ANDROID_TOOLCHAIN: /tmp/android-gcc-arm-ndk-10e
-
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: android-tarball
-        path: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
-
-    - name: Send failure mail to dynamorio-devs
-      if: failure() && github.ref == 'refs/heads/master'
-      uses: dawidd6/action-send-mail@v2
-      with:
-        server_address: smtp.gmail.com
-        server_port: 465
-        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-        subject: |
-          [${{github.repository}}] ${{github.workflow}} FAILED
-          on ${{github.event_name}} at ${{github.ref}}
-        body: |
-          Github Actions CI workflow run FAILED!
-          Workflow: ${{github.workflow}}/android-arm
-          Repository: ${{github.repository}}
-          Branch ref: ${{github.ref}}
-          SHA: ${{github.sha}}
-          Triggering actor: ${{github.actor}}
-          Triggering event: ${{github.event_name}}
-          Run Id: ${{github.run_id}}
-          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-        to: dynamorio-devs@googlegroups.com
-        from: Github Action package jobs
-
-  ###########################################################################
-  # Windows .zip with 32-bit and 64-bit x86 builds:
-  windows:
-    runs-on: windows-2016
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Fetch Sources
-      run: |
-        git fetch --no-tags --depth=1 origin master
-        # Include Dr. Memory in packages.
-        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-        cd drmemory && git submodule update --init --depth 250 && cd ..
-
-    - name: Download Packages
-      shell: powershell
-      run: |
-        md c:\projects\install
-        (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
-
-    - name: Get Version
-      id: version
-      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
-      run: |
-        if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
-        else
-          export VERSION_NUMBER=${{ github.event.inputs.version }}
-        fi
-        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
-        fi
-        echo "::set-output name=version_number::${VERSION_NUMBER}"
-
-    - name: Build Package
-      working-directory: ${{ github.workspace }}
-      shell: cmd
-      # We need to set up WiX for Dr. Memory.
-      run: |
-        echo ------ Setting up paths ------
-        7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
-        set PATH=c:\projects\install\ninja;%PATH%
-        7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
-        set PATH=c:\projects\install\doxygen;%PATH%
-        dir "c:\Program Files (x86)\WiX Toolset"*
-        set PATH=C:\Program Files (x86)\WiX Toolset v3.11\bin;%PATH%
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
-        echo ------ Running suite ------
-        echo PATH is "%PATH%"
-        echo Running in directory "%CD%"
-        perl suite/runsuite_wrapper.pl automated_ci use_ninja
-      env:
-        CI_TARGET: package
-        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
-
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: windows-zip
-        path: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
-
-    - name: Send failure mail to dynamorio-devs
-      if: failure() && github.ref == 'refs/heads/master'
-      uses: dawidd6/action-send-mail@v2
-      with:
-        server_address: smtp.gmail.com
-        server_port: 465
-        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-        subject: |
-          [${{github.repository}}] ${{github.workflow}} FAILED
-          on ${{github.event_name}} at ${{github.ref}}
-        body: |
-          Github Actions CI workflow run FAILED!
-          Workflow: ${{github.workflow}}/windows
-          Repository: ${{github.repository}}
-          Branch ref: ${{github.ref}}
-          SHA: ${{github.sha}}
-          Triggering actor: ${{github.actor}}
-          Triggering event: ${{github.event_name}}
-          Run Id: ${{github.run_id}}
-          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-        to: dynamorio-devs@googlegroups.com
-        from: Github Action package jobs
-
-  ###########################################################################
-  # Create release and populate with files.
-  # We can't have each OS job create the release because only the first
-  # succeeds and the others fail: there is no check in the create-release
-  # action to use an existing release if it already exists.
-  # Thus, our strategy is to share files from the build jobs with this
-  # single release job via artifacts.
-
-  create_release:
-    needs: [linux-x86, linux-aarch64, linux-arm, android-arm, windows]
-    runs-on: ubuntu-16.04
-
-    steps:
-      # We need a checkout to run git log for the version.
-    - uses: actions/checkout@v2
-
-    - name: Get Version
-      id: version
-      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
-      run: |
-        if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER="8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))"
-          export PREFIX="cronbuild-"
-        else
-          export VERSION_NUMBER=${{ github.event.inputs.version }}
-          export PREFIX="release_"
-        fi
-        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
-        fi
-        echo "::set-output name=version_number::${VERSION_NUMBER}"
-        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
-
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.version.outputs.version_string }}
-        release_name: ${{ steps.version.outputs.version_string }}
-        body: |
-          Auto-generated periodic build.
-        draft: false
-        prerelease: false
-
-    - name: Download Linux
-      uses: actions/download-artifact@v2
-      with:
-        name: linux-tarball
-    - name: Upload Linux
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        # This action doesn't seem to support a glob so we need the exact name.
-        asset_path: DynamoRIO-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_name: DynamoRIO-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_content_type: application/x-gzip
-
-    - name: Download AArch64
-      uses: actions/download-artifact@v2
-      with:
-        name: aarch64-tarball
-    - name: Upload AArch64
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        # This action doesn't seem to support a glob so we need the exact name.
-        asset_path: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_name: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_content_type: application/x-gzip
-
-    - name: Download ARM
-      uses: actions/download-artifact@v2
-      with:
-        name: arm-tarball
-    - name: Upload ARM
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        # This action doesn't seem to support a glob so we need the exact name.
-        asset_path: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_name: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_content_type: application/x-gzip
-
-    - name: Download Android
-      uses: actions/download-artifact@v2
-      with:
-        name: android-tarball
-    - name: Upload Android
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        # This action doesn't seem to support a glob so we need the exact name.
-        asset_path: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_name: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_content_type: application/x-gzip
-
-    - name: Download Windows
-      uses: actions/download-artifact@v2
-      with:
-        name: windows-zip
-    - name: Upload Windows
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        # This action doesn't seem to support a glob so we need the exact name.
-        asset_path: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
-        asset_name: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
-        asset_content_type: application/zip
-
-    - name: Send failure mail to dynamorio-devs
-      if: failure() && github.ref == 'refs/heads/master'
-      uses: dawidd6/action-send-mail@v2
-      with:
-        server_address: smtp.gmail.com
-        server_port: 465
-        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-        subject: |
-          [${{github.repository}}] ${{github.workflow}} FAILED
-          on ${{github.event_name}} at ${{github.ref}}
-        body: |
-          Github Actions CI workflow run FAILED!
-          Workflow: ${{github.workflow}}/create_release
-          Repository: ${{github.repository}}
-          Branch ref: ${{github.ref}}
-          SHA: ${{github.sha}}
-          Triggering actor: ${{github.actor}}
-          Triggering event: ${{github.event_name}}
-          Run Id: ${{github.run_id}}
-          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-        to: dynamorio-devs@googlegroups.com
-        from: Github Action package jobs
+#TEMPORARILY DISABLED TO TEST DEPLOYING EMBEDDED DOCS
+#    - name: Send failure mail to dynamorio-devs
+#      if: failure() && github.ref == 'refs/heads/master'
+#      uses: dawidd6/action-send-mail@v2
+#      with:
+#        server_address: smtp.gmail.com
+#        server_port: 465
+#        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+#        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+#        subject: |
+#          [${{github.repository}}] ${{github.workflow}} FAILED
+#          on ${{github.event_name}} at ${{github.ref}}
+#        body: |
+#          Github Actions CI workflow run FAILED!
+#          Workflow: ${{github.workflow}}/linux-x86
+#          Repository: ${{github.repository}}
+#          Branch ref: ${{github.ref}}
+#          SHA: ${{github.sha}}
+#          Triggering actor: ${{github.actor}}
+#          Triggering event: ${{github.event_name}}
+#          Run Id: ${{github.run_id}}
+#          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+#        to: dynamorio-devs@googlegroups.com
+#        from: Github Action package jobs
+#
+#  ###########################################################################
+#  # Linux AArch64 tarball:
+#  linux-aarch64:
+#    runs-on: ubuntu-16.04
+#
+#    steps:
+#    - uses: actions/checkout@v2
+#
+#    - name: Fetch Sources
+#      run: |
+#        git fetch --no-tags --depth=1 origin master
+#        # Include Dr. Memory in packages.
+#        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+#        cd drmemory && git submodule update --init --depth 250 && cd ..
+#
+#    # Install cross-compilers for cross-compiling Linux build:
+#    - name: Create Build Environment
+#      run: |
+#        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
+#          g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
+#
+#    - name: Get Version
+#      id: version
+#      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+#      run: |
+#        if test -z "${{ github.event.inputs.version }}"; then
+#          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
+#        else
+#          export VERSION_NUMBER=${{ github.event.inputs.version }}
+#        fi
+#        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+#          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+#        fi
+#        echo "::set-output name=version_number::${VERSION_NUMBER}"
+#
+#    - name: Build Package
+#      working-directory: ${{ github.workspace }}
+#      run: ./suite/runsuite_wrapper.pl automated_ci 64_only
+#      env:
+#        CI_TARGET: package
+#        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
+#        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: yes
+#
+#    - name: Upload AArch64
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: aarch64-tarball
+#        path: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
+#
+#    - name: Send failure mail to dynamorio-devs
+#      if: failure() && github.ref == 'refs/heads/master'
+#      uses: dawidd6/action-send-mail@v2
+#      with:
+#        server_address: smtp.gmail.com
+#        server_port: 465
+#        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+#        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+#        subject: |
+#          [${{github.repository}}] ${{github.workflow}} FAILED
+#          on ${{github.event_name}} at ${{github.ref}}
+#        body: |
+#          Github Actions CI workflow run FAILED!
+#          Workflow: ${{github.workflow}}/linux-aarch64
+#          Repository: ${{github.repository}}
+#          Branch ref: ${{github.ref}}
+#          SHA: ${{github.sha}}
+#          Triggering actor: ${{github.actor}}
+#          Triggering event: ${{github.event_name}}
+#          Run Id: ${{github.run_id}}
+#          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+#        to: dynamorio-devs@googlegroups.com
+#        from: Github Action package jobs
+#
+#  ###########################################################################
+#  # Linux ARM tarball (package.cmake does not support same job as AArch64):
+#  linux-arm:
+#    runs-on: ubuntu-16.04
+#
+#    steps:
+#    - uses: actions/checkout@v2
+#
+#    - name: Fetch Sources
+#      run: |
+#        git fetch --no-tags --depth=1 origin master
+#        # Include Dr. Memory in packages.
+#        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+#        cd drmemory && git submodule update --init --depth 250 && cd ..
+#
+#    # Install cross-compilers for cross-compiling Linux build:
+#    - name: Create Build Environment
+#      run: |
+#        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
+#          g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
+#
+#    - name: Get Version
+#      id: version
+#      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+#      run: |
+#        if test -z "${{ github.event.inputs.version }}"; then
+#          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
+#        else
+#          export VERSION_NUMBER=${{ github.event.inputs.version }}
+#        fi
+#        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+#          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+#        fi
+#        echo "::set-output name=version_number::${VERSION_NUMBER}"
+#
+#    - name: Build Package
+#      working-directory: ${{ github.workspace }}
+#      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
+#      env:
+#        CI_TARGET: package
+#        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
+#        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: yes
+#
+#    - name: Upload ARM
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: arm-tarball
+#        path: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
+#
+#    - name: Send failure mail to dynamorio-devs
+#      if: failure() && github.ref == 'refs/heads/master'
+#      uses: dawidd6/action-send-mail@v2
+#      with:
+#        server_address: smtp.gmail.com
+#        server_port: 465
+#        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+#        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+#        subject: |
+#          [${{github.repository}}] ${{github.workflow}} FAILED
+#          on ${{github.event_name}} at ${{github.ref}}
+#        body: |
+#          Github Actions CI workflow run FAILED!
+#          Workflow: ${{github.workflow}}/linux-arm
+#          Repository: ${{github.repository}}
+#          Branch ref: ${{github.ref}}
+#          SHA: ${{github.sha}}
+#          Triggering actor: ${{github.actor}}
+#          Triggering event: ${{github.event_name}}
+#          Run Id: ${{github.run_id}}
+#          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+#        to: dynamorio-devs@googlegroups.com
+#        from: Github Action package jobs
+#
+#  ###########################################################################
+#  # Android ARM tarball:
+#  android-arm:
+#    runs-on: ubuntu-16.04
+#
+#    steps:
+#    - uses: actions/checkout@v2
+#
+#    - name: Fetch Sources
+#      run: |
+#        git fetch --no-tags --depth=1 origin master
+#        # Include Dr. Memory in packages.
+#        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+#        cd drmemory && git submodule update --init --depth 250 && cd ..
+#
+#    # Fetch and install Android NDK for Andoid cross-compile build.
+#    - name: Create Build Environment
+#      run: |
+#        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev
+#        cd /tmp
+#        wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
+#        unzip -q android-ndk-r10e-linux-x86_64.zip
+#        android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
+#          --toolchain=arm-linux-androideabi-4.9 --platform=android-21 \
+#          --install-dir=/tmp/android-gcc-arm-ndk-10e
+#        # Manually force using ld.bfd, setting CMAKE_LINKER does not work.
+#        ln -sf ld.bfd /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
+#        ln -sf arm-linux-androideabi-ld.bfd \
+#          /tmp/android-gcc-arm-ndk-10e/bin/arm-linux-androideabi-ld
+#
+#    - name: Get Version
+#      id: version
+#      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+#      run: |
+#        if test -z "${{ github.event.inputs.version }}"; then
+#          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
+#        else
+#          export VERSION_NUMBER=${{ github.event.inputs.version }}
+#        fi
+#        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+#          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+#        fi
+#        echo "::set-output name=version_number::${VERSION_NUMBER}"
+#
+#    - name: Build Package
+#      working-directory: ${{ github.workspace }}
+#      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
+#      env:
+#        CI_TARGET: package
+#        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
+#        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: no
+#        DYNAMORIO_CROSS_ANDROID_ONLY: yes
+#        DYNAMORIO_ANDROID_TOOLCHAIN: /tmp/android-gcc-arm-ndk-10e
+#
+#    - name: Upload Artifacts
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: android-tarball
+#        path: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
+#
+#    - name: Send failure mail to dynamorio-devs
+#      if: failure() && github.ref == 'refs/heads/master'
+#      uses: dawidd6/action-send-mail@v2
+#      with:
+#        server_address: smtp.gmail.com
+#        server_port: 465
+#        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+#        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+#        subject: |
+#          [${{github.repository}}] ${{github.workflow}} FAILED
+#          on ${{github.event_name}} at ${{github.ref}}
+#        body: |
+#          Github Actions CI workflow run FAILED!
+#          Workflow: ${{github.workflow}}/android-arm
+#          Repository: ${{github.repository}}
+#          Branch ref: ${{github.ref}}
+#          SHA: ${{github.sha}}
+#          Triggering actor: ${{github.actor}}
+#          Triggering event: ${{github.event_name}}
+#          Run Id: ${{github.run_id}}
+#          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+#        to: dynamorio-devs@googlegroups.com
+#        from: Github Action package jobs
+#
+#  ###########################################################################
+#  # Windows .zip with 32-bit and 64-bit x86 builds:
+#  windows:
+#    runs-on: windows-2016
+#
+#    steps:
+#    - uses: actions/checkout@v2
+#
+#    - name: Fetch Sources
+#      run: |
+#        git fetch --no-tags --depth=1 origin master
+#        # Include Dr. Memory in packages.
+#        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+#        cd drmemory && git submodule update --init --depth 250 && cd ..
+#
+#    - name: Download Packages
+#      shell: powershell
+#      run: |
+#        md c:\projects\install
+#        (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
+#        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
+#
+#    - name: Get Version
+#      id: version
+#      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+#      run: |
+#        if test -z "${{ github.event.inputs.version }}"; then
+#          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
+#        else
+#          export VERSION_NUMBER=${{ github.event.inputs.version }}
+#        fi
+#        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+#          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+#        fi
+#        echo "::set-output name=version_number::${VERSION_NUMBER}"
+#
+#    - name: Build Package
+#      working-directory: ${{ github.workspace }}
+#      shell: cmd
+#      # We need to set up WiX for Dr. Memory.
+#      run: |
+#        echo ------ Setting up paths ------
+#        7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
+#        set PATH=c:\projects\install\ninja;%PATH%
+#        7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
+#        set PATH=c:\projects\install\doxygen;%PATH%
+#        dir "c:\Program Files (x86)\WiX Toolset"*
+#        set PATH=C:\Program Files (x86)\WiX Toolset v3.11\bin;%PATH%
+#        call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+#        echo ------ Running suite ------
+#        echo PATH is "%PATH%"
+#        echo Running in directory "%CD%"
+#        perl suite/runsuite_wrapper.pl automated_ci use_ninja
+#      env:
+#        CI_TARGET: package
+#        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
+#
+#    - name: Upload Artifacts
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: windows-zip
+#        path: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
+#
+#    - name: Send failure mail to dynamorio-devs
+#      if: failure() && github.ref == 'refs/heads/master'
+#      uses: dawidd6/action-send-mail@v2
+#      with:
+#        server_address: smtp.gmail.com
+#        server_port: 465
+#        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+#        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+#        subject: |
+#          [${{github.repository}}] ${{github.workflow}} FAILED
+#          on ${{github.event_name}} at ${{github.ref}}
+#        body: |
+#          Github Actions CI workflow run FAILED!
+#          Workflow: ${{github.workflow}}/windows
+#          Repository: ${{github.repository}}
+#          Branch ref: ${{github.ref}}
+#          SHA: ${{github.sha}}
+#          Triggering actor: ${{github.actor}}
+#          Triggering event: ${{github.event_name}}
+#          Run Id: ${{github.run_id}}
+#          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+#        to: dynamorio-devs@googlegroups.com
+#        from: Github Action package jobs
+#
+#  ###########################################################################
+#  # Create release and populate with files.
+#  # We can't have each OS job create the release because only the first
+#  # succeeds and the others fail: there is no check in the create-release
+#  # action to use an existing release if it already exists.
+#  # Thus, our strategy is to share files from the build jobs with this
+#  # single release job via artifacts.
+#
+#  create_release:
+#    needs: [linux-x86, linux-aarch64, linux-arm, android-arm, windows]
+#    runs-on: ubuntu-16.04
+#
+#    steps:
+#      # We need a checkout to run git log for the version.
+#    - uses: actions/checkout@v2
+#
+#    - name: Get Version
+#      id: version
+#      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+#      run: |
+#        if test -z "${{ github.event.inputs.version }}"; then
+#          export VERSION_NUMBER="8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+#          export PREFIX="cronbuild-"
+#        else
+#          export VERSION_NUMBER=${{ github.event.inputs.version }}
+#          export PREFIX="release_"
+#        fi
+#        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+#          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+#        fi
+#        echo "::set-output name=version_number::${VERSION_NUMBER}"
+#        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
+#
+#    - name: Create Release
+#      id: create_release
+#      uses: actions/create-release@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        tag_name: ${{ steps.version.outputs.version_string }}
+#        release_name: ${{ steps.version.outputs.version_string }}
+#        body: |
+#          Auto-generated periodic build.
+#        draft: false
+#        prerelease: false
+#
+#    - name: Download Linux
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: linux-tarball
+#    - name: Upload Linux
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ steps.create_release.outputs.upload_url }}
+#        # This action doesn't seem to support a glob so we need the exact name.
+#        asset_path: DynamoRIO-Linux-${{ steps.version.outputs.version_number }}.tar.gz
+#        asset_name: DynamoRIO-Linux-${{ steps.version.outputs.version_number }}.tar.gz
+#        asset_content_type: application/x-gzip
+#
+#    - name: Download AArch64
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: aarch64-tarball
+#    - name: Upload AArch64
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ steps.create_release.outputs.upload_url }}
+#        # This action doesn't seem to support a glob so we need the exact name.
+#        asset_path: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
+#        asset_name: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
+#        asset_content_type: application/x-gzip
+#
+#    - name: Download ARM
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: arm-tarball
+#    - name: Upload ARM
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ steps.create_release.outputs.upload_url }}
+#        # This action doesn't seem to support a glob so we need the exact name.
+#        asset_path: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
+#        asset_name: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
+#        asset_content_type: application/x-gzip
+#
+#    - name: Download Android
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: android-tarball
+#    - name: Upload Android
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ steps.create_release.outputs.upload_url }}
+#        # This action doesn't seem to support a glob so we need the exact name.
+#        asset_path: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
+#        asset_name: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
+#        asset_content_type: application/x-gzip
+#
+#    - name: Download Windows
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-zip
+#    - name: Upload Windows
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ steps.create_release.outputs.upload_url }}
+#        # This action doesn't seem to support a glob so we need the exact name.
+#        asset_path: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
+#        asset_name: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
+#        asset_content_type: application/zip
+#
+#    - name: Send failure mail to dynamorio-devs
+#      if: failure() && github.ref == 'refs/heads/master'
+#      uses: dawidd6/action-send-mail@v2
+#      with:
+#        server_address: smtp.gmail.com
+#        server_port: 465
+#        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+#        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+#        subject: |
+#          [${{github.repository}}] ${{github.workflow}} FAILED
+#          on ${{github.event_name}} at ${{github.ref}}
+#        body: |
+#          Github Actions CI workflow run FAILED!
+#          Workflow: ${{github.workflow}}/create_release
+#          Repository: ${{github.repository}}
+#          Branch ref: ${{github.ref}}
+#          SHA: ${{github.sha}}
+#          Triggering actor: ${{github.actor}}
+#          Triggering event: ${{github.event_name}}
+#          Run Id: ${{github.run_id}}
+#          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+#        to: dynamorio-devs@googlegroups.com
+#        from: Github Action package jobs

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020 Google, Inc.  All rights reserved.
+# Copyright (c) 2020-2021 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -107,7 +107,7 @@ jobs:
         name: linux-tarball
         path: DynamoRIO-Linux-${{ steps.version.outputs.version_number }}.tar.gz
 
-    - name: Deploy Docs
+    - name: Deploy Standalone Docs
       uses: crazy-max/ghaction-github-pages@v2
       with:
         build_dir: html
@@ -116,6 +116,26 @@ jobs:
       env:
         # We need a personal access token for write access to another repo.
         GH_PAT: ${{ secrets.DOCS_TOKEN }}
+
+    - name: Check Out Web
+      uses: actions/checkout@v2
+      with:
+        - repository: DynamoRIO/dynamorio.github.io
+        - token: ${{ secrets.DOCS_TOKEN }}
+        - path: dynamorio.github.io
+
+    - name: Deploy Embedded Docs
+      run: |
+        rsync -av --delete embed_html/ dynamorio.github.io/docs/
+        cd dynamorio.github.io
+        git config --local user.name "cronbuild"
+        git config --local user.email "dynamorio-devs@googlegroups.com"
+        git add -A
+        git commit -m "Snapshot for cronbuild-${{ steps.version.outputs.version_number }}"
+        git push
+      env:
+        # We need a personal access token for write access to another repo.
+        GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
 
     - name: Send failure mail to dynamorio-devs
       if: failure() && github.ref == 'refs/heads/master'

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -107,6 +107,8 @@ jobs:
         name: linux-tarball
         path: DynamoRIO-Linux-${{ steps.version.outputs.version_number }}.tar.gz
 
+    # XXX i#4111: Delete this step and the dynamorio_docs repository once
+    # we're happy with the embedded version.
     - name: Deploy Standalone Docs
       uses: crazy-max/ghaction-github-pages@v2
       with:
@@ -137,489 +139,488 @@ jobs:
         # We need a personal access token for write access to another repo.
         GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
 
-#TEMPORARILY DISABLED TO TEST DEPLOYING EMBEDDED DOCS
-#    - name: Send failure mail to dynamorio-devs
-#      if: failure() && github.ref == 'refs/heads/master'
-#      uses: dawidd6/action-send-mail@v2
-#      with:
-#        server_address: smtp.gmail.com
-#        server_port: 465
-#        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-#        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-#        subject: |
-#          [${{github.repository}}] ${{github.workflow}} FAILED
-#          on ${{github.event_name}} at ${{github.ref}}
-#        body: |
-#          Github Actions CI workflow run FAILED!
-#          Workflow: ${{github.workflow}}/linux-x86
-#          Repository: ${{github.repository}}
-#          Branch ref: ${{github.ref}}
-#          SHA: ${{github.sha}}
-#          Triggering actor: ${{github.actor}}
-#          Triggering event: ${{github.event_name}}
-#          Run Id: ${{github.run_id}}
-#          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-#        to: dynamorio-devs@googlegroups.com
-#        from: Github Action package jobs
-#
-#  ###########################################################################
-#  # Linux AArch64 tarball:
-#  linux-aarch64:
-#    runs-on: ubuntu-16.04
-#
-#    steps:
-#    - uses: actions/checkout@v2
-#
-#    - name: Fetch Sources
-#      run: |
-#        git fetch --no-tags --depth=1 origin master
-#        # Include Dr. Memory in packages.
-#        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-#        cd drmemory && git submodule update --init --depth 250 && cd ..
-#
-#    # Install cross-compilers for cross-compiling Linux build:
-#    - name: Create Build Environment
-#      run: |
-#        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-#          g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
-#
-#    - name: Get Version
-#      id: version
-#      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
-#      run: |
-#        if test -z "${{ github.event.inputs.version }}"; then
-#          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
-#        else
-#          export VERSION_NUMBER=${{ github.event.inputs.version }}
-#        fi
-#        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-#          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
-#        fi
-#        echo "::set-output name=version_number::${VERSION_NUMBER}"
-#
-#    - name: Build Package
-#      working-directory: ${{ github.workspace }}
-#      run: ./suite/runsuite_wrapper.pl automated_ci 64_only
-#      env:
-#        CI_TARGET: package
-#        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
-#        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: yes
-#
-#    - name: Upload AArch64
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: aarch64-tarball
-#        path: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-#
-#    - name: Send failure mail to dynamorio-devs
-#      if: failure() && github.ref == 'refs/heads/master'
-#      uses: dawidd6/action-send-mail@v2
-#      with:
-#        server_address: smtp.gmail.com
-#        server_port: 465
-#        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-#        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-#        subject: |
-#          [${{github.repository}}] ${{github.workflow}} FAILED
-#          on ${{github.event_name}} at ${{github.ref}}
-#        body: |
-#          Github Actions CI workflow run FAILED!
-#          Workflow: ${{github.workflow}}/linux-aarch64
-#          Repository: ${{github.repository}}
-#          Branch ref: ${{github.ref}}
-#          SHA: ${{github.sha}}
-#          Triggering actor: ${{github.actor}}
-#          Triggering event: ${{github.event_name}}
-#          Run Id: ${{github.run_id}}
-#          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-#        to: dynamorio-devs@googlegroups.com
-#        from: Github Action package jobs
-#
-#  ###########################################################################
-#  # Linux ARM tarball (package.cmake does not support same job as AArch64):
-#  linux-arm:
-#    runs-on: ubuntu-16.04
-#
-#    steps:
-#    - uses: actions/checkout@v2
-#
-#    - name: Fetch Sources
-#      run: |
-#        git fetch --no-tags --depth=1 origin master
-#        # Include Dr. Memory in packages.
-#        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-#        cd drmemory && git submodule update --init --depth 250 && cd ..
-#
-#    # Install cross-compilers for cross-compiling Linux build:
-#    - name: Create Build Environment
-#      run: |
-#        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-#          g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
-#
-#    - name: Get Version
-#      id: version
-#      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
-#      run: |
-#        if test -z "${{ github.event.inputs.version }}"; then
-#          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
-#        else
-#          export VERSION_NUMBER=${{ github.event.inputs.version }}
-#        fi
-#        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-#          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
-#        fi
-#        echo "::set-output name=version_number::${VERSION_NUMBER}"
-#
-#    - name: Build Package
-#      working-directory: ${{ github.workspace }}
-#      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
-#      env:
-#        CI_TARGET: package
-#        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
-#        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: yes
-#
-#    - name: Upload ARM
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: arm-tarball
-#        path: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
-#
-#    - name: Send failure mail to dynamorio-devs
-#      if: failure() && github.ref == 'refs/heads/master'
-#      uses: dawidd6/action-send-mail@v2
-#      with:
-#        server_address: smtp.gmail.com
-#        server_port: 465
-#        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-#        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-#        subject: |
-#          [${{github.repository}}] ${{github.workflow}} FAILED
-#          on ${{github.event_name}} at ${{github.ref}}
-#        body: |
-#          Github Actions CI workflow run FAILED!
-#          Workflow: ${{github.workflow}}/linux-arm
-#          Repository: ${{github.repository}}
-#          Branch ref: ${{github.ref}}
-#          SHA: ${{github.sha}}
-#          Triggering actor: ${{github.actor}}
-#          Triggering event: ${{github.event_name}}
-#          Run Id: ${{github.run_id}}
-#          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-#        to: dynamorio-devs@googlegroups.com
-#        from: Github Action package jobs
-#
-#  ###########################################################################
-#  # Android ARM tarball:
-#  android-arm:
-#    runs-on: ubuntu-16.04
-#
-#    steps:
-#    - uses: actions/checkout@v2
-#
-#    - name: Fetch Sources
-#      run: |
-#        git fetch --no-tags --depth=1 origin master
-#        # Include Dr. Memory in packages.
-#        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-#        cd drmemory && git submodule update --init --depth 250 && cd ..
-#
-#    # Fetch and install Android NDK for Andoid cross-compile build.
-#    - name: Create Build Environment
-#      run: |
-#        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev
-#        cd /tmp
-#        wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
-#        unzip -q android-ndk-r10e-linux-x86_64.zip
-#        android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
-#          --toolchain=arm-linux-androideabi-4.9 --platform=android-21 \
-#          --install-dir=/tmp/android-gcc-arm-ndk-10e
-#        # Manually force using ld.bfd, setting CMAKE_LINKER does not work.
-#        ln -sf ld.bfd /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
-#        ln -sf arm-linux-androideabi-ld.bfd \
-#          /tmp/android-gcc-arm-ndk-10e/bin/arm-linux-androideabi-ld
-#
-#    - name: Get Version
-#      id: version
-#      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
-#      run: |
-#        if test -z "${{ github.event.inputs.version }}"; then
-#          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
-#        else
-#          export VERSION_NUMBER=${{ github.event.inputs.version }}
-#        fi
-#        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-#          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
-#        fi
-#        echo "::set-output name=version_number::${VERSION_NUMBER}"
-#
-#    - name: Build Package
-#      working-directory: ${{ github.workspace }}
-#      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
-#      env:
-#        CI_TARGET: package
-#        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
-#        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: no
-#        DYNAMORIO_CROSS_ANDROID_ONLY: yes
-#        DYNAMORIO_ANDROID_TOOLCHAIN: /tmp/android-gcc-arm-ndk-10e
-#
-#    - name: Upload Artifacts
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: android-tarball
-#        path: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
-#
-#    - name: Send failure mail to dynamorio-devs
-#      if: failure() && github.ref == 'refs/heads/master'
-#      uses: dawidd6/action-send-mail@v2
-#      with:
-#        server_address: smtp.gmail.com
-#        server_port: 465
-#        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-#        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-#        subject: |
-#          [${{github.repository}}] ${{github.workflow}} FAILED
-#          on ${{github.event_name}} at ${{github.ref}}
-#        body: |
-#          Github Actions CI workflow run FAILED!
-#          Workflow: ${{github.workflow}}/android-arm
-#          Repository: ${{github.repository}}
-#          Branch ref: ${{github.ref}}
-#          SHA: ${{github.sha}}
-#          Triggering actor: ${{github.actor}}
-#          Triggering event: ${{github.event_name}}
-#          Run Id: ${{github.run_id}}
-#          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-#        to: dynamorio-devs@googlegroups.com
-#        from: Github Action package jobs
-#
-#  ###########################################################################
-#  # Windows .zip with 32-bit and 64-bit x86 builds:
-#  windows:
-#    runs-on: windows-2016
-#
-#    steps:
-#    - uses: actions/checkout@v2
-#
-#    - name: Fetch Sources
-#      run: |
-#        git fetch --no-tags --depth=1 origin master
-#        # Include Dr. Memory in packages.
-#        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-#        cd drmemory && git submodule update --init --depth 250 && cd ..
-#
-#    - name: Download Packages
-#      shell: powershell
-#      run: |
-#        md c:\projects\install
-#        (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-#        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
-#
-#    - name: Get Version
-#      id: version
-#      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
-#      run: |
-#        if test -z "${{ github.event.inputs.version }}"; then
-#          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
-#        else
-#          export VERSION_NUMBER=${{ github.event.inputs.version }}
-#        fi
-#        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-#          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
-#        fi
-#        echo "::set-output name=version_number::${VERSION_NUMBER}"
-#
-#    - name: Build Package
-#      working-directory: ${{ github.workspace }}
-#      shell: cmd
-#      # We need to set up WiX for Dr. Memory.
-#      run: |
-#        echo ------ Setting up paths ------
-#        7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
-#        set PATH=c:\projects\install\ninja;%PATH%
-#        7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
-#        set PATH=c:\projects\install\doxygen;%PATH%
-#        dir "c:\Program Files (x86)\WiX Toolset"*
-#        set PATH=C:\Program Files (x86)\WiX Toolset v3.11\bin;%PATH%
-#        call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
-#        echo ------ Running suite ------
-#        echo PATH is "%PATH%"
-#        echo Running in directory "%CD%"
-#        perl suite/runsuite_wrapper.pl automated_ci use_ninja
-#      env:
-#        CI_TARGET: package
-#        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
-#
-#    - name: Upload Artifacts
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: windows-zip
-#        path: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
-#
-#    - name: Send failure mail to dynamorio-devs
-#      if: failure() && github.ref == 'refs/heads/master'
-#      uses: dawidd6/action-send-mail@v2
-#      with:
-#        server_address: smtp.gmail.com
-#        server_port: 465
-#        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-#        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-#        subject: |
-#          [${{github.repository}}] ${{github.workflow}} FAILED
-#          on ${{github.event_name}} at ${{github.ref}}
-#        body: |
-#          Github Actions CI workflow run FAILED!
-#          Workflow: ${{github.workflow}}/windows
-#          Repository: ${{github.repository}}
-#          Branch ref: ${{github.ref}}
-#          SHA: ${{github.sha}}
-#          Triggering actor: ${{github.actor}}
-#          Triggering event: ${{github.event_name}}
-#          Run Id: ${{github.run_id}}
-#          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-#        to: dynamorio-devs@googlegroups.com
-#        from: Github Action package jobs
-#
-#  ###########################################################################
-#  # Create release and populate with files.
-#  # We can't have each OS job create the release because only the first
-#  # succeeds and the others fail: there is no check in the create-release
-#  # action to use an existing release if it already exists.
-#  # Thus, our strategy is to share files from the build jobs with this
-#  # single release job via artifacts.
-#
-#  create_release:
-#    needs: [linux-x86, linux-aarch64, linux-arm, android-arm, windows]
-#    runs-on: ubuntu-16.04
-#
-#    steps:
-#      # We need a checkout to run git log for the version.
-#    - uses: actions/checkout@v2
-#
-#    - name: Get Version
-#      id: version
-#      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
-#      run: |
-#        if test -z "${{ github.event.inputs.version }}"; then
-#          export VERSION_NUMBER="8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))"
-#          export PREFIX="cronbuild-"
-#        else
-#          export VERSION_NUMBER=${{ github.event.inputs.version }}
-#          export PREFIX="release_"
-#        fi
-#        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-#          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
-#        fi
-#        echo "::set-output name=version_number::${VERSION_NUMBER}"
-#        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
-#
-#    - name: Create Release
-#      id: create_release
-#      uses: actions/create-release@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        tag_name: ${{ steps.version.outputs.version_string }}
-#        release_name: ${{ steps.version.outputs.version_string }}
-#        body: |
-#          Auto-generated periodic build.
-#        draft: false
-#        prerelease: false
-#
-#    - name: Download Linux
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: linux-tarball
-#    - name: Upload Linux
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ steps.create_release.outputs.upload_url }}
-#        # This action doesn't seem to support a glob so we need the exact name.
-#        asset_path: DynamoRIO-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-#        asset_name: DynamoRIO-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-#        asset_content_type: application/x-gzip
-#
-#    - name: Download AArch64
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: aarch64-tarball
-#    - name: Upload AArch64
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ steps.create_release.outputs.upload_url }}
-#        # This action doesn't seem to support a glob so we need the exact name.
-#        asset_path: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-#        asset_name: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-#        asset_content_type: application/x-gzip
-#
-#    - name: Download ARM
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: arm-tarball
-#    - name: Upload ARM
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ steps.create_release.outputs.upload_url }}
-#        # This action doesn't seem to support a glob so we need the exact name.
-#        asset_path: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
-#        asset_name: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
-#        asset_content_type: application/x-gzip
-#
-#    - name: Download Android
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: android-tarball
-#    - name: Upload Android
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ steps.create_release.outputs.upload_url }}
-#        # This action doesn't seem to support a glob so we need the exact name.
-#        asset_path: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
-#        asset_name: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
-#        asset_content_type: application/x-gzip
-#
-#    - name: Download Windows
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-zip
-#    - name: Upload Windows
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ steps.create_release.outputs.upload_url }}
-#        # This action doesn't seem to support a glob so we need the exact name.
-#        asset_path: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
-#        asset_name: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
-#        asset_content_type: application/zip
-#
-#    - name: Send failure mail to dynamorio-devs
-#      if: failure() && github.ref == 'refs/heads/master'
-#      uses: dawidd6/action-send-mail@v2
-#      with:
-#        server_address: smtp.gmail.com
-#        server_port: 465
-#        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-#        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-#        subject: |
-#          [${{github.repository}}] ${{github.workflow}} FAILED
-#          on ${{github.event_name}} at ${{github.ref}}
-#        body: |
-#          Github Actions CI workflow run FAILED!
-#          Workflow: ${{github.workflow}}/create_release
-#          Repository: ${{github.repository}}
-#          Branch ref: ${{github.ref}}
-#          SHA: ${{github.sha}}
-#          Triggering actor: ${{github.actor}}
-#          Triggering event: ${{github.event_name}}
-#          Run Id: ${{github.run_id}}
-#          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-#        to: dynamorio-devs@googlegroups.com
-#        from: Github Action package jobs
+    - name: Send failure mail to dynamorio-devs
+      if: failure() && github.ref == 'refs/heads/master'
+      uses: dawidd6/action-send-mail@v2
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+        subject: |
+          [${{github.repository}}] ${{github.workflow}} FAILED
+          on ${{github.event_name}} at ${{github.ref}}
+        body: |
+          Github Actions CI workflow run FAILED!
+          Workflow: ${{github.workflow}}/linux-x86
+          Repository: ${{github.repository}}
+          Branch ref: ${{github.ref}}
+          SHA: ${{github.sha}}
+          Triggering actor: ${{github.actor}}
+          Triggering event: ${{github.event_name}}
+          Run Id: ${{github.run_id}}
+          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+        to: dynamorio-devs@googlegroups.com
+        from: Github Action package jobs
+
+  ###########################################################################
+  # Linux AArch64 tarball:
+  linux-aarch64:
+    runs-on: ubuntu-16.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Fetch Sources
+      run: |
+        git fetch --no-tags --depth=1 origin master
+        # Include Dr. Memory in packages.
+        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+        cd drmemory && git submodule update --init --depth 250 && cd ..
+
+    # Install cross-compilers for cross-compiling Linux build:
+    - name: Create Build Environment
+      run: |
+        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
+          g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
+
+    - name: Get Version
+      id: version
+      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+      run: |
+        if test -z "${{ github.event.inputs.version }}"; then
+          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
+        else
+          export VERSION_NUMBER=${{ github.event.inputs.version }}
+        fi
+        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+        fi
+        echo "::set-output name=version_number::${VERSION_NUMBER}"
+
+    - name: Build Package
+      working-directory: ${{ github.workspace }}
+      run: ./suite/runsuite_wrapper.pl automated_ci 64_only
+      env:
+        CI_TARGET: package
+        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
+        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: yes
+
+    - name: Upload AArch64
+      uses: actions/upload-artifact@v2
+      with:
+        name: aarch64-tarball
+        path: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
+
+    - name: Send failure mail to dynamorio-devs
+      if: failure() && github.ref == 'refs/heads/master'
+      uses: dawidd6/action-send-mail@v2
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+        subject: |
+          [${{github.repository}}] ${{github.workflow}} FAILED
+          on ${{github.event_name}} at ${{github.ref}}
+        body: |
+          Github Actions CI workflow run FAILED!
+          Workflow: ${{github.workflow}}/linux-aarch64
+          Repository: ${{github.repository}}
+          Branch ref: ${{github.ref}}
+          SHA: ${{github.sha}}
+          Triggering actor: ${{github.actor}}
+          Triggering event: ${{github.event_name}}
+          Run Id: ${{github.run_id}}
+          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+        to: dynamorio-devs@googlegroups.com
+        from: Github Action package jobs
+
+  ###########################################################################
+  # Linux ARM tarball (package.cmake does not support same job as AArch64):
+  linux-arm:
+    runs-on: ubuntu-16.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Fetch Sources
+      run: |
+        git fetch --no-tags --depth=1 origin master
+        # Include Dr. Memory in packages.
+        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+        cd drmemory && git submodule update --init --depth 250 && cd ..
+
+    # Install cross-compilers for cross-compiling Linux build:
+    - name: Create Build Environment
+      run: |
+        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
+          g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
+
+    - name: Get Version
+      id: version
+      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+      run: |
+        if test -z "${{ github.event.inputs.version }}"; then
+          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
+        else
+          export VERSION_NUMBER=${{ github.event.inputs.version }}
+        fi
+        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+        fi
+        echo "::set-output name=version_number::${VERSION_NUMBER}"
+
+    - name: Build Package
+      working-directory: ${{ github.workspace }}
+      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
+      env:
+        CI_TARGET: package
+        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
+        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: yes
+
+    - name: Upload ARM
+      uses: actions/upload-artifact@v2
+      with:
+        name: arm-tarball
+        path: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
+
+    - name: Send failure mail to dynamorio-devs
+      if: failure() && github.ref == 'refs/heads/master'
+      uses: dawidd6/action-send-mail@v2
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+        subject: |
+          [${{github.repository}}] ${{github.workflow}} FAILED
+          on ${{github.event_name}} at ${{github.ref}}
+        body: |
+          Github Actions CI workflow run FAILED!
+          Workflow: ${{github.workflow}}/linux-arm
+          Repository: ${{github.repository}}
+          Branch ref: ${{github.ref}}
+          SHA: ${{github.sha}}
+          Triggering actor: ${{github.actor}}
+          Triggering event: ${{github.event_name}}
+          Run Id: ${{github.run_id}}
+          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+        to: dynamorio-devs@googlegroups.com
+        from: Github Action package jobs
+
+  ###########################################################################
+  # Android ARM tarball:
+  android-arm:
+    runs-on: ubuntu-16.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Fetch Sources
+      run: |
+        git fetch --no-tags --depth=1 origin master
+        # Include Dr. Memory in packages.
+        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+        cd drmemory && git submodule update --init --depth 250 && cd ..
+
+    # Fetch and install Android NDK for Andoid cross-compile build.
+    - name: Create Build Environment
+      run: |
+        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev
+        cd /tmp
+        wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
+        unzip -q android-ndk-r10e-linux-x86_64.zip
+        android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
+          --toolchain=arm-linux-androideabi-4.9 --platform=android-21 \
+          --install-dir=/tmp/android-gcc-arm-ndk-10e
+        # Manually force using ld.bfd, setting CMAKE_LINKER does not work.
+        ln -sf ld.bfd /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
+        ln -sf arm-linux-androideabi-ld.bfd \
+          /tmp/android-gcc-arm-ndk-10e/bin/arm-linux-androideabi-ld
+
+    - name: Get Version
+      id: version
+      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+      run: |
+        if test -z "${{ github.event.inputs.version }}"; then
+          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
+        else
+          export VERSION_NUMBER=${{ github.event.inputs.version }}
+        fi
+        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+        fi
+        echo "::set-output name=version_number::${VERSION_NUMBER}"
+
+    - name: Build Package
+      working-directory: ${{ github.workspace }}
+      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
+      env:
+        CI_TARGET: package
+        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
+        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: no
+        DYNAMORIO_CROSS_ANDROID_ONLY: yes
+        DYNAMORIO_ANDROID_TOOLCHAIN: /tmp/android-gcc-arm-ndk-10e
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: android-tarball
+        path: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
+
+    - name: Send failure mail to dynamorio-devs
+      if: failure() && github.ref == 'refs/heads/master'
+      uses: dawidd6/action-send-mail@v2
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+        subject: |
+          [${{github.repository}}] ${{github.workflow}} FAILED
+          on ${{github.event_name}} at ${{github.ref}}
+        body: |
+          Github Actions CI workflow run FAILED!
+          Workflow: ${{github.workflow}}/android-arm
+          Repository: ${{github.repository}}
+          Branch ref: ${{github.ref}}
+          SHA: ${{github.sha}}
+          Triggering actor: ${{github.actor}}
+          Triggering event: ${{github.event_name}}
+          Run Id: ${{github.run_id}}
+          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+        to: dynamorio-devs@googlegroups.com
+        from: Github Action package jobs
+
+  ###########################################################################
+  # Windows .zip with 32-bit and 64-bit x86 builds:
+  windows:
+    runs-on: windows-2016
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Fetch Sources
+      run: |
+        git fetch --no-tags --depth=1 origin master
+        # Include Dr. Memory in packages.
+        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
+        cd drmemory && git submodule update --init --depth 250 && cd ..
+
+    - name: Download Packages
+      shell: powershell
+      run: |
+        md c:\projects\install
+        (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
+
+    - name: Get Version
+      id: version
+      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+      run: |
+        if test -z "${{ github.event.inputs.version }}"; then
+          export VERSION_NUMBER=8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))
+        else
+          export VERSION_NUMBER=${{ github.event.inputs.version }}
+        fi
+        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+        fi
+        echo "::set-output name=version_number::${VERSION_NUMBER}"
+
+    - name: Build Package
+      working-directory: ${{ github.workspace }}
+      shell: cmd
+      # We need to set up WiX for Dr. Memory.
+      run: |
+        echo ------ Setting up paths ------
+        7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
+        set PATH=c:\projects\install\ninja;%PATH%
+        7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
+        set PATH=c:\projects\install\doxygen;%PATH%
+        dir "c:\Program Files (x86)\WiX Toolset"*
+        set PATH=C:\Program Files (x86)\WiX Toolset v3.11\bin;%PATH%
+        call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        echo ------ Running suite ------
+        echo PATH is "%PATH%"
+        echo Running in directory "%CD%"
+        perl suite/runsuite_wrapper.pl automated_ci use_ninja
+      env:
+        CI_TARGET: package
+        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: windows-zip
+        path: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
+
+    - name: Send failure mail to dynamorio-devs
+      if: failure() && github.ref == 'refs/heads/master'
+      uses: dawidd6/action-send-mail@v2
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+        subject: |
+          [${{github.repository}}] ${{github.workflow}} FAILED
+          on ${{github.event_name}} at ${{github.ref}}
+        body: |
+          Github Actions CI workflow run FAILED!
+          Workflow: ${{github.workflow}}/windows
+          Repository: ${{github.repository}}
+          Branch ref: ${{github.ref}}
+          SHA: ${{github.sha}}
+          Triggering actor: ${{github.actor}}
+          Triggering event: ${{github.event_name}}
+          Run Id: ${{github.run_id}}
+          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+        to: dynamorio-devs@googlegroups.com
+        from: Github Action package jobs
+
+  ###########################################################################
+  # Create release and populate with files.
+  # We can't have each OS job create the release because only the first
+  # succeeds and the others fail: there is no check in the create-release
+  # action to use an existing release if it already exists.
+  # Thus, our strategy is to share files from the build jobs with this
+  # single release job via artifacts.
+
+  create_release:
+    needs: [linux-x86, linux-aarch64, linux-arm, android-arm, windows]
+    runs-on: ubuntu-16.04
+
+    steps:
+      # We need a checkout to run git log for the version.
+    - uses: actions/checkout@v2
+
+    - name: Get Version
+      id: version
+      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+      run: |
+        if test -z "${{ github.event.inputs.version }}"; then
+          export VERSION_NUMBER="8.0.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+          export PREFIX="cronbuild-"
+        else
+          export VERSION_NUMBER=${{ github.event.inputs.version }}
+          export PREFIX="release_"
+        fi
+        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+        fi
+        echo "::set-output name=version_number::${VERSION_NUMBER}"
+        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.version.outputs.version_string }}
+        release_name: ${{ steps.version.outputs.version_string }}
+        body: |
+          Auto-generated periodic build.
+        draft: false
+        prerelease: false
+
+    - name: Download Linux
+      uses: actions/download-artifact@v2
+      with:
+        name: linux-tarball
+    - name: Upload Linux
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        # This action doesn't seem to support a glob so we need the exact name.
+        asset_path: DynamoRIO-Linux-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_name: DynamoRIO-Linux-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_content_type: application/x-gzip
+
+    - name: Download AArch64
+      uses: actions/download-artifact@v2
+      with:
+        name: aarch64-tarball
+    - name: Upload AArch64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        # This action doesn't seem to support a glob so we need the exact name.
+        asset_path: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_name: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_content_type: application/x-gzip
+
+    - name: Download ARM
+      uses: actions/download-artifact@v2
+      with:
+        name: arm-tarball
+    - name: Upload ARM
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        # This action doesn't seem to support a glob so we need the exact name.
+        asset_path: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_name: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_content_type: application/x-gzip
+
+    - name: Download Android
+      uses: actions/download-artifact@v2
+      with:
+        name: android-tarball
+    - name: Upload Android
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        # This action doesn't seem to support a glob so we need the exact name.
+        asset_path: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_name: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_content_type: application/x-gzip
+
+    - name: Download Windows
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-zip
+    - name: Upload Windows
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        # This action doesn't seem to support a glob so we need the exact name.
+        asset_path: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
+        asset_name: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
+        asset_content_type: application/zip
+
+    - name: Send failure mail to dynamorio-devs
+      if: failure() && github.ref == 'refs/heads/master'
+      uses: dawidd6/action-send-mail@v2
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+        subject: |
+          [${{github.repository}}] ${{github.workflow}} FAILED
+          on ${{github.event_name}} at ${{github.ref}}
+        body: |
+          Github Actions CI workflow run FAILED!
+          Workflow: ${{github.workflow}}/create_release
+          Repository: ${{github.repository}}
+          Branch ref: ${{github.ref}}
+          SHA: ${{github.sha}}
+          Triggering actor: ${{github.actor}}
+          Triggering event: ${{github.event_name}}
+          Run Id: ${{github.run_id}}
+          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+        to: dynamorio-devs@googlegroups.com
+        from: Github Action package jobs

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -120,9 +120,9 @@ jobs:
     - name: Check Out Web
       uses: actions/checkout@v2
       with:
-        - repository: DynamoRIO/dynamorio.github.io
-        - token: ${{ secrets.DOCS_TOKEN }}
-        - path: dynamorio.github.io
+        repository: DynamoRIO/dynamorio.github.io
+        token: ${{ secrets.DOCS_TOKEN }}
+        path: dynamorio.github.io
 
     - name: Deploy Embedded Docs
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2020 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2021 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # Copyright (c) 2018 Arm Limited          All rights reserved.
 # **********************************************************
@@ -1210,6 +1210,7 @@ else (DEBUG)
 endif (DEBUG)
 set(INSTALL_INCLUDE include)
 set(INSTALL_DOCS docs)
+set(INSTALL_DOCS_EMBED docs_embed)
 # samples are installed via api/samples/ separate CMake project
 set(INSTALL_CMAKE cmake)
 set(BUILD_INCLUDE "${PROJECT_BINARY_DIR}/${INSTALL_INCLUDE}")

--- a/api/docs/CMakeLists.txt
+++ b/api/docs/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2020 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2021 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -91,78 +91,106 @@ foreach (extra ${dox_extras})
   set(doxy_extra_args ${doxy_extra_args} -Ddox_extra${extra_cnt}=${extra})
 endforeach ()
 
-set(doxyfile ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
-add_custom_command(
-  OUTPUT ${doxyfile}
-  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/API.doxy
-          ${CMAKE_CURRENT_SOURCE_DIR}/CMake_doxyfile.cmake
-          ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt
-  COMMAND ${CMAKE_COMMAND}
-  # script does not inherit any vars so we must pass them all in
-  # to work around i#84 be sure to put a space after -D for 1st arg at least
-  ARGS -D srcdir=${CMAKE_CURRENT_SOURCE_DIR} -Doutfile=${doxyfile}
-       -Dproj_srcdir=${PROJECT_SOURCE_DIR} -Dversion_number=${VERSION_NUMBER}
-       -Dproj_bindir=${PROJECT_BINARY_DIR}
-       -Dheader_dir=${BUILD_INCLUDE} -Dgendox_dir=${CMAKE_CURRENT_BINARY_DIR}
-       -DDOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
-       -Ddoxygen_ver=${doxygen_ver}
-       ${doxy_extra_args}
-       -P ${CMAKE_CURRENT_SOURCE_DIR}/CMake_doxyfile.cmake
-  VERBATIM # recommended: p260
-  )
+macro (generate_html name dest_dir embeddable)
+  set(doxyfile ${dest_dir}/Doxyfile)
+  add_custom_command(
+    OUTPUT ${doxyfile}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/API.doxy
+            ${CMAKE_CURRENT_SOURCE_DIR}/CMake_doxyfile.cmake
+            ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt
+    COMMAND ${CMAKE_COMMAND}
+    # script does not inherit any vars so we must pass them all in
+    # to work around i#84 be sure to put a space after -D for 1st arg at least
+    ARGS -D srcdir=${CMAKE_CURRENT_SOURCE_DIR} -Doutfile=${doxyfile}
+         -Dproj_srcdir=${PROJECT_SOURCE_DIR} -Dversion_number=${VERSION_NUMBER}
+         -Dproj_bindir=${PROJECT_BINARY_DIR} -Dembeddable=${embeddable}
+         -Dheader_dir=${BUILD_INCLUDE} -Dgendox_dir=${CMAKE_CURRENT_BINARY_DIR}
+         -Ddest_dir=${dest_dir}
+         -DDOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
+         -Ddoxygen_ver=${doxygen_ver}
+         ${doxy_extra_args}
+         -P ${CMAKE_CURRENT_SOURCE_DIR}/CMake_doxyfile.cmake
+    WORKING_DIRECTORY ${dest_dir}
+    VERBATIM # recommended: p260
+    )
 
-set(docsgen ${CMAKE_CURRENT_BINARY_DIR}/html/index.html)
-get_property(dox_tgts GLOBAL PROPERTY DynamoRIO_dox_targets)
+  set(docsgen ${dest_dir}/html/index.html)
+  get_property(dox_tgts GLOBAL PROPERTY DynamoRIO_dox_targets)
 
-# we depend on the samples even though we don't copy them,
-# to have them as dependencies for the install rules
-file(GLOB samples_files ../samples/*.c ../samples/Makefile)
-file(GLOB header_files  ${BUILD_INCLUDE}/*.h)
-add_custom_command(
-  OUTPUT ${docsgen} # among other files
-  DEPENDS ${dox_files}
-          ${dox_tgts}
-          ${dox_extras}
-          ${header_files}
-          ${doxyfile}
-          ${figures_eps}
-          ${figures_png}
-          ${CMAKE_CURRENT_SOURCE_DIR}/CMake_rundoxygen.cmake
-          ${samples_files}
-  # We want doxygen to fail if it has warnings like "can't find header
-  # files" so we run it through a script
-  COMMAND ${CMAKE_COMMAND}
-  # Have to quote dox_files to keep ;-separated
-  # to work around i#84 be sure to put a space after -D for 1st arg at least
-  ARGS -D DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
-       -Ddoxygen_ver=${doxygen_ver}
-       -Dversion_number=${VERSION_NUMBER}
-       -Dmodule_string_long="DynamoRIO Extension Details"
-       -Dmodule_string_short="Extension"
-       -Dhome_url="http://www.dynamorio.org"
-       -Dhome_title="DynamoRIO Home Page"
-       -Dlogo_imgfile="drlogo.png"
-       -P ${CMAKE_CURRENT_SOURCE_DIR}/CMake_rundoxygen.cmake
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  VERBATIM # recommended: p260
-  )
-set_directory_properties(PROPERTIES
-  ADDITIONAL_MAKE_CLEAN_FILES "html;latex;rtf")
+  # we depend on the samples even though we don't copy them,
+  # to have them as dependencies for the install rules
+  file(GLOB samples_files ../samples/*.c ../samples/Makefile)
+  file(GLOB header_files  ${BUILD_INCLUDE}/*.h)
+  add_custom_command(
+    OUTPUT ${docsgen} # among other files
+    DEPENDS ${dox_files}
+            ${dox_tgts}
+            ${dox_extras}
+            ${header_files}
+            ${doxyfile}
+            ${figures_eps}
+            ${figures_png}
+            ${CMAKE_CURRENT_SOURCE_DIR}/CMake_rundoxygen.cmake
+            ${samples_files}
+    # We want doxygen to fail if it has warnings like "can't find header
+    # files" so we run it through a script
+    COMMAND ${CMAKE_COMMAND}
+    # Have to quote dox_files to keep ;-separated
+    # to work around i#84 be sure to put a space after -D for 1st arg at least
+    ARGS -D DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
+         -Ddoxygen_ver=${doxygen_ver}
+         -Dversion_number=${VERSION_NUMBER}
+         -Dmodule_string_long="DynamoRIO Extension Details"
+         -Dmodule_string_short="Extension"
+         -Dhome_url="http://www.dynamorio.org"
+         -Dhome_title="DynamoRIO Home Page"
+         -Dlogo_imgfile="drlogo.png"
+         -Dembeddable=${embeddable}
+         -Dproj_srcdir=${PROJECT_SOURCE_DIR}
+         -Dproj_bindir=${PROJECT_BINARY_DIR}
+         -P ${CMAKE_CURRENT_SOURCE_DIR}/CMake_rundoxygen.cmake
+    WORKING_DIRECTORY ${dest_dir}
+    VERBATIM # recommended: p260
+    )
+  set_directory_properties(PROPERTIES
+    ADDITIONAL_MAKE_CLEAN_FILES "html;latex;rtf")
 
-add_custom_target(htmldocs ALL
-  DEPENDS ${doxyfile}
-          ${figures_eps}
-          ${figures_png}
-          ${docsgen}
-  )
-# add_custom_target DEPENDS cannot take targets!
-add_dependencies(htmldocs api_headers)
+  add_custom_target(${name} ALL
+    DEPENDS ${doxyfile}
+            ${figures_eps}
+            ${figures_png}
+            ${docsgen}
+    )
+  # add_custom_target DEPENDS cannot take targets!
+  add_dependencies(${name} api_headers)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/images/favicon.png
-  ${CMAKE_CURRENT_BINARY_DIR}/html/favicon.png
-  COPYONLY)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/images/favicon.png
+    ${dest_dir}/html/favicon.png
+    COPYONLY)
+endmacro ()
 
-# FIXME i#59: if epstopdf and latex are available, add optional pdf
+generate_html(htmldocs ${CMAKE_CURRENT_BINARY_DIR} OFF)
+
+# We create two output versions of the docs:
+# 1) A standalone html version for local viewing.
+# 2) A stripped-down version suitable for embedding inside dynamorio.org.
+# Since we only need the stripped-down version built on one platform,
+# we limit it to UNIX so we can use symlinks.
+if (UNIX)
+  set(embed_outdir ${CMAKE_CURRENT_BINARY_DIR}/embed)
+  file(MAKE_DIRECTORY ${embed_outdir})
+  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+    ${genimg_dirname} ${embed_outdir}/genimages
+    RESULT_VARIABLE ln_result ERROR_VARIABLE ln_err)
+  if (ln_result OR ln_err)
+    message(FATAL_ERROR "*** genimages symlink failed: ***\n${ln_err}")
+  endif ()
+  generate_html(embed_docs ${embed_outdir} ON)
+  # We must build the treeview version first, as we use its menu files.
+  add_dependencies(embed_docs htmldocs)
+endif ()
+
+# TODO i#59: if epstopdf and latex are available, add optional pdf
 # target that invokes fix-latex.pl and install rule.
 # Need to copy drlogo-16x16.png to latex/drlogo.png after i#80 changes.
 
@@ -172,6 +200,11 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/images/favicon.png
 DR_install(DIRECTORY
   ${CMAKE_CURRENT_BINARY_DIR}/html
   DESTINATION ${INSTALL_DOCS}
+  )
+
+DR_install(DIRECTORY
+  ${CMAKE_CURRENT_BINARY_DIR}/embed/html
+  DESTINATION ${INSTALL_DOCS_EMBED}
   )
 
 # IE for some reason won't initially load an .ico in a web page from a server,

--- a/api/docs/CMakeLists.txt
+++ b/api/docs/CMakeLists.txt
@@ -202,10 +202,12 @@ DR_install(DIRECTORY
   DESTINATION ${INSTALL_DOCS}
   )
 
-DR_install(DIRECTORY
-  ${CMAKE_CURRENT_BINARY_DIR}/embed/html
-  DESTINATION ${INSTALL_DOCS_EMBED}
-  )
+if (UNIX)
+  DR_install(DIRECTORY
+    ${CMAKE_CURRENT_BINARY_DIR}/embed/html
+    DESTINATION ${INSTALL_DOCS_EMBED}
+    )
+endif ()
 
 # IE for some reason won't initially load an .ico in a web page from a server,
 # though will show it via file: or after pointing straight at image from server.

--- a/api/docs/CMake_doxyfile.cmake
+++ b/api/docs/CMake_doxyfile.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2012-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2012-2021 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -37,9 +37,11 @@
 # * version_number
 # * header_dir
 # * gendox_dir
+# * dest_dir
 # * DOXYGEN_EXECUTABLE
 # * doxygen_ver
 # * dox_extraN where N=1,2,3,... (to get around cmake problems passing spaces)
+# * embeddable
 
 set(outdir "${CMAKE_CURRENT_BINARY_DIR}")
 set(srcdir_orig "${srcdir}")
@@ -106,10 +108,10 @@ string(REGEX REPLACE
   "\\1\"${srcdir}/images\"" string "${string}")
 string(REGEX REPLACE
   "(header.html)"
-  "\"${gendox_dir}/\\1\"" string "${string}")
+  "\"${dest_dir}/\\1\"" string "${string}")
 string(REGEX REPLACE
   "(footer.html)"
-  "\"${gendox_dir}/\\1\"" string "${string}")
+  "\"${dest_dir}/\\1\"" string "${string}")
 
 if (doxygen_ver STRGREATER "1.7.2")
   # For 1.7.3+ we use xml file to tweak treeview contents
@@ -135,6 +137,13 @@ string(REGEX REPLACE
 string(REGEX REPLACE
   "(ENABLED_SECTIONS[ \t]*=)"
   "\\1 linux" string "${string}")
+
+if (embeddable)
+  # Turn off the frames.
+  string(REGEX REPLACE "(GENERATE_TREEVIEW[ \t]*= )YES" "\\1 NO" string "${string}")
+  # Turn off the confusing search box.
+  string(REGEX REPLACE "(SEARCHENGINE[ \t]*= )YES" "\\1 NO" string "${string}")
+endif ()
 
 # We no longer support VMSAFE.
 # Here's what we used to do:

--- a/api/docs/CMake_rundoxygen.cmake
+++ b/api/docs/CMake_rundoxygen.cmake
@@ -45,6 +45,9 @@
 # + home_url            : home page URL
 # + home_title          : home page title
 # + logo_imgfile        : image file with logo
+# + embeddable          : whether to edit content for jekyll embedding
+# + proj_srcdir         : project base source dir, for editing titles
+# + proj_bindir         : project base binary dir, for editing titles
 #
 ###########################################################################
 
@@ -84,6 +87,14 @@ string(REGEX REPLACE
 if (doxygen_ver VERSION_LESS "1.7.0")
   # For some reason older doxygen doesn't replace its own vars w/ custom header
   string(REGEX REPLACE "\\$relpath\\$" "" string "${string}")
+endif ()
+if (embeddable)
+  # Add jekyll header.
+  set(string "---
+title: \"$title\"
+layout: default
+---
+${string}")
 endif ()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/header.html "${string}")
 
@@ -151,48 +162,133 @@ string(REGEX REPLACE
   string "${string}")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/html/index.html "${string}")
 
-if (doxygen_ver VERSION_LESS "1.7.3")
-  # Add link to home page to treeview pane
-  file(APPEND
-    ${CMAKE_CURRENT_BINARY_DIR}/html/tree.html
-    "<p>&nbsp;<a target=\"main\" href=\"${home_url}/\">${home_title}</a></p>")
+if (embeddable)
+  # We need to make some edits for insertion into our jekyll site.
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/html/keywords.js "---\nlayout: null\n---\n")
+  file(GLOB all_html ${CMAKE_CURRENT_BINARY_DIR}/html/*.html)
+  foreach (html ${all_html})
+    file(READ ${html} string)
+    # Remove headers and body tag.
+    string(REGEX REPLACE "<!-- HTML header.*<body>\n" "" string "${string}")
+    # Remove body and html close tags.
+    string(REGEX REPLACE "</body>.*</html>\n" "" string "${string}")
+    # Remove full paths.
+    string(REGEX REPLACE "\ntitle: \"${proj_bindir}" "\ntitle: \"" string "${string}")
+    string(REGEX REPLACE "\ntitle: \"${proj_srcdir}" "\ntitle: \"" string "${string}")
 
-  # Add our logo to treeview pane (yes there is no closing </body></html>)
-  file(APPEND
-    ${CMAKE_CURRENT_BINARY_DIR}/html/tree.html
-    "<p>&nbsp;<br><img src=\"${logo_imgfile}\"></p>")
-else ()
-  # This is a fragile insertion into the javascript used for the navbar.
-  # We insert at the end of the final function (initNavTree).
-  # This works in doxygen 1.7.4-1.8.1.
-  set(add_logo "
-        var imgdiv = document.createElement(\"div\");
-        document.getElementById(\"nav-tree-contents\").appendChild(imgdiv);
-        var img = document.createElement(\"img\");
-        imgdiv.appendChild(img);
-        img.src = \"${logo_imgfile}\";
-        img.style.marginLeft = \"80px\";
-        img.style.marginTop = \"30px\";
-    ")
-  file(READ ${CMAKE_CURRENT_BINARY_DIR}/html/navtree.js string)
-  string(REGEX REPLACE
-    "\\}\n*$"
-    "${add_logo}\n}"
-    string "${string}")
-  # Doxygen 1.9.1 has this license-end line.
-  string(REGEX REPLACE
-    "\\}\n/\\* @license-end \\*/\n$"
-    "${add_logo}\n}"
-    string "${string}")
-  # While we're here we replace Files and Data Structures, if requested
-  if (DEFINED files_string)
-    string(REGEX REPLACE "\"Files\"" "\"${files_string}\"" string "${string}")
-  endif ()
-  if (DEFINED structs_string)
-    string(REGEX REPLACE "\"Data Structures\"" "\"${structs_string}\""
+    # Collect type info for keyword searches with direct anchor links (else the
+    # search finds the page but the user then has to manually search within the long
+    # page -- and there are no doygen options to split each onto its own page).
+    # The format here is the javascript object used by search.js to set up lunr.
+    # XXX: This is fragile and highly dependent on the precise doxygen output.
+    get_filename_component(fname ${html} NAME_WE)
+    # The ;'s mess up the MATCHALL results so we remove them.
+    string(REPLACE ";" "_" nosemis "${string}")
+    string(REGEX MATCHALL "<h2 class=\"memtitle[^\n]*</h2>" types "${nosemis}")
+    foreach (type ${types})
+      string(REGEX MATCH "<a href=\"#[a-zA-Z0-9]+\"" anchor "${type}")
+      string(REGEX REPLACE "<a href=\"(#[a-zA-Z0-9]+)\"" "\\1" anchor "${anchor}")
+      string(REGEX MATCH "/span>[_a-zA-Z0-9]+" name "${type}")
+      string(REGEX REPLACE "/span>([_a-zA-Z0-9]+)" "\\1" name "${name}")
+      if (name STREQUAL "")
+        continue ()
+      endif ()
+      # Support searching by partial names.
+      set(extra "")
+      string(REPLACE "_" " " separate "${name}")
+      if (NOT separate STREQUAL name)
+        set(extra "${extra} ${separate}")
+      endif ()
+      set(prefix "${name}")
+      while (prefix MATCHES "[^_]_[^_]")
+        string(REGEX REPLACE "_[^_]*$" "" prefix "${prefix}")
+        set(extra "${extra} ${prefix}")
+      endwhile ()
+      set(keywords "window.data[\"${fname}-${name}\"]={\
+\"name\":\"${fname}-${name}\",\
+\"title\":\"${name} in ${fname} header\",\
+\"url\":\"docs/${fname}.html${anchor}\",\
+\"content\":\"${name} ${extra}\"};\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/html/keywords.js "${keywords}")
+    endforeach ()
+
+    file(WRITE ${html} "${string}")
+  endforeach ()
+
+  # We leverage the javascript menu from the non-embedded version.
+  file(GLOB all_js ${CMAKE_CURRENT_BINARY_DIR}/../html/*.js)
+  foreach (js ${all_js})
+    if (js MATCHES "navtree.js" OR
+        js MATCHES "resize.js" OR
+        js MATCHES "navtreeindex")
+      continue ()
+    endif ()
+    file(READ ${js} string)
+    # Remove the index array and subsequent vars from navtreedata.js.
+    string(REGEX REPLACE "var NAVTREEINDEX =.*$" "" string "${string}")
+    # Remove one layer from navtreedata.js.
+    string(REGEX REPLACE "\n *\\[ \"DynamoRIO API\", \"index.html\", \\[" ""
       string "${string}")
+    # Remove the home page and the end of the extra layer.
+    string(REGEX REPLACE "\n[^\n]*DynamoRIO Home Page[^\n]*\n[^\n]*" ""
+      string "${string}")
+    # Remove name so we can inline.
+    string(REGEX REPLACE "var [^\n]* =\n" "" string "${string}")
+    # Ask jekyll to inline, instead of just naming for JS.
+    string(REGEX REPLACE ", \"([^\"]+)\" \\]" ", {% include_relative docs/\\1.js %} ]"
+      string "${string}")
+    # End in a comma for inlining.
+    string(REGEX REPLACE "\\];" "]," string "${string}")
+    # Put the modified contents into our dir.
+    get_filename_component(fname ${js} NAME)
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/html/${fname} "${string}")
+  endforeach ()
+
+else ()
+  # Edit navbar.
+  if (doxygen_ver VERSION_LESS "1.7.3")
+    # Add link to home page to treeview pane
+    file(APPEND
+      ${CMAKE_CURRENT_BINARY_DIR}/html/tree.html
+      "<p>&nbsp;<a target=\"main\" href=\"${home_url}/\">${home_title}</a></p>")
+
+    # Add our logo to treeview pane (yes there is no closing </body></html>)
+    file(APPEND
+      ${CMAKE_CURRENT_BINARY_DIR}/html/tree.html
+      "<p>&nbsp;<br><img src=\"${logo_imgfile}\"></p>")
+  else ()
+    # This is a fragile insertion into the javascript used for the navbar.
+    # We insert at the end of the final function (initNavTree).
+    # This works in doxygen 1.7.4-1.8.1.
+    set(add_logo "
+          var imgdiv = document.createElement(\"div\");
+          document.getElementById(\"nav-tree-contents\").appendChild(imgdiv);
+          var img = document.createElement(\"img\");
+          imgdiv.appendChild(img);
+          img.src = \"${logo_imgfile}\";
+          img.style.marginLeft = \"80px\";
+          img.style.marginTop = \"30px\";
+      ")
+    file(READ ${CMAKE_CURRENT_BINARY_DIR}/html/navtree.js string)
+    string(REGEX REPLACE
+      "\\}\n*$"
+      "${add_logo}\n}"
+      string "${string}")
+    # Doxygen 1.9.1 has this license-end line.
+    string(REGEX REPLACE
+      "\\}\n/\\* @license-end \\*/\n$"
+      "${add_logo}\n}"
+      string "${string}")
+    # While we're here we replace Files and Data Structures, if requested
+    if (DEFINED files_string)
+      string(REGEX REPLACE "\"Files\"" "\"${files_string}\"" string "${string}")
+    endif ()
+    if (DEFINED structs_string)
+      string(REGEX REPLACE "\"Data Structures\"" "\"${structs_string}\""
+        string "${string}")
+    endif ()
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/html/navtree.js "${string}")
   endif ()
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/html/navtree.js "${string}")
 endif ()
 
 # For modules/extensions (i#277/PR 540817) we use doxygen groups which show up under

--- a/api/docs/CMake_rundoxygen.cmake
+++ b/api/docs/CMake_rundoxygen.cmake
@@ -184,12 +184,12 @@ if (embeddable)
     get_filename_component(fname ${html} NAME_WE)
     # The ;'s mess up the MATCHALL results so we remove them.
     string(REPLACE ";" "_" nosemis "${string}")
-    string(REGEX MATCHALL "<h2 class=\"memtitle[^\n]*</h2>" types "${nosemis}")
+    string(REGEX MATCHALL "<tr class=\"memitem[^\n]*</tr>" types "${nosemis}")
     foreach (type ${types})
-      string(REGEX MATCH "<a href=\"#[a-zA-Z0-9]+\"" anchor "${type}")
-      string(REGEX REPLACE "<a href=\"(#[a-zA-Z0-9]+)\"" "\\1" anchor "${anchor}")
-      string(REGEX MATCH "/span>[_a-zA-Z0-9]+" name "${type}")
-      string(REGEX REPLACE "/span>([_a-zA-Z0-9]+)" "\\1" name "${name}")
+      string(REGEX MATCH "href=\"[^\"]+\"" url "${type}")
+      string(REGEX REPLACE "href=\"([^\"]+)\"" "\\1" url "${url}")
+      string(REGEX MATCH "\">[_a-zA-Z0-9]+</a>" name "${type}")
+      string(REGEX REPLACE "\">([_a-zA-Z0-9]+)</a>" "\\1" name "${name}")
       if (name STREQUAL "")
         continue ()
       endif ()
@@ -207,7 +207,7 @@ if (embeddable)
       set(keywords "window.data[\"${fname}-${name}\"]={\
 \"name\":\"${fname}-${name}\",\
 \"title\":\"${name} in ${fname} header\",\
-\"url\":\"docs/${fname}.html${anchor}\",\
+\"url\":\"docs/${url}\",\
 \"content\":\"${name} ${extra}\"};\n")
       file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/html/keywords.js "${keywords}")
     endforeach ()

--- a/make/package.cmake
+++ b/make/package.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2020 Google, Inc.    All rights reserved.
+# Copyright (c) 2011-2021 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -234,7 +234,7 @@ endif (EXISTS "${results}")
 if (arg_copy_docs)
   # Prepare for copying the documentation to our Github Pages site by placing it
   # in a single fixed-name location with a .nojekyll file.
-  message("Copying documentation into ${arg_outdir}/html")
+  message("Copying standalone documentation into ${arg_outdir}/html")
   message("Looking for ${last_package_build_dir}/_CPack_Packages/*/*/DynamoRIO-*/docs/html")
   file(GLOB allhtml "${last_package_build_dir}/_CPack_Packages/*/*/DynamoRIO-*/docs/html")
   # If there's a source package we'll have multiple.  Just take the first one.
@@ -246,6 +246,21 @@ if (arg_copy_docs)
     # Create a .nojekyll file so Github Pages will display this as raw html.
     execute_process(COMMAND ${CMAKE_COMMAND} -E touch "${arg_outdir}/html/.nojekyll")
     message("Successully copied docs")
+  else ()
+    message(FATAL_ERROR "failed to find html docs")
+  endif ()
+
+  message("Copying embedded documentation into ${arg_outdir}/html_embed")
+  message("Looking for ${last_package_build_dir}/_CPack_Packages/*/*/DynamoRIO-*/docs_embed/html")
+  file(GLOB allembed
+    "${last_package_build_dir}/_CPack_Packages/*/*/DynamoRIO-*/docs_embed/html")
+  # If there's a source package we'll have multiple.  Just take the first one.
+  list(GET allembed 0 embed)
+  if (EXISTS "${embed}")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${arg_outdir}/html_embed")
+    execute_process(COMMAND
+      ${CMAKE_COMMAND} -E copy_directory ${embed} "${arg_outdir}/html_embed")
+    message("Successully copied embedded docs")
   else ()
     message(FATAL_ERROR "failed to find html docs")
   endif ()


### PR DESCRIPTION
Creates a second version of the doxygen html output suitable for
embedding in our jekyll-based web site.  This version turns off the
doxygen treeview, but then borrows the javascript menu files from the
treeview version.  We then edit the html to remove the headers, and
edit the menu files for inlining into our web site's single array.

Furthermore, we generate keyword search term data so that searches
using lunr for functions or types result in direct links to their
anchors within their pages.  It generates keyword tokens for each
component of an underscore-separated multi-word type, along with
tokens for each prefix (e.g., so that "dr_mutex" will find
"dr_mutex_*").

Adds installation into a "docs_embed" directory.

Adds deployment logic to package.cmake to copy the embedded html to a
top level "html_embed", along with new steps in the ci-package GA
workflow to take the embedded html files and push them to the
dynamorio.github.io repository.

Issue: #4111