### PR TITLE
i#xxxx: Stub out rseq_is_registered_for_current_thread if HAVE_RSEQ is false

### DIFF
--- a/core/unix/rseq_linux.c
+++ b/core/unix/rseq_linux.c
@@ -269,6 +269,7 @@ rseq_shared_fragment_flushtime_update(dcontext_t *dcontext)
     rseq_clear_tls_ptr(dcontext);
 }
 
+#ifdef HAVE_RSEQ
 bool
 rseq_is_registered_for_current_thread(void)
 {
@@ -296,6 +297,13 @@ rseq_is_registered_for_current_thread(void)
     }
     return false;
 }
+#else
+bool
+rseq_is_registered_for_current_thread(void)
+{
+    return false;
+}
+#endif
 
 static void
 rseq_analyze_instructions(rseq_region_t *info)


### PR DESCRIPTION
HAVE_RSEQ allows disabling all use of the rseq syscall at compile time, except for the function `rseq_is_registered_for_current_thread` which uses rseq to infer whether rseq is in use. If HAVE_RSEQ is false, just stub out `rseq_is_registered_for_current_thread` and always return false.