### PR TITLE
i#1569 AArch64: Rename arm64 to aarch64

### DIFF
--- a/make/package.cmake
+++ b/make/package.cmake
@@ -107,7 +107,7 @@ if ($ENV{DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY} MATCHES "yes")
   if (arg_no32)
     set(arg_cacheappend "${arg_cacheappend}
       PACKAGE_PLATFORM:STRING=AArch64-
-      CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake")
+      CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-aarch64.cmake")
   elseif (arg_no64)
     set(arg_cacheappend "${arg_cacheappend}
       PACKAGE_PLATFORM:STRING=ARM-

--- a/make/toolchain-aarch64.cmake
+++ b/make/toolchain-aarch64.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2014-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2014-2021 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -28,11 +28,11 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-# For cross-compiling on arm64 Linux using gcc-aarch64-linux-gnu package:
+# For cross-compiling on aarch64 Linux using gcc-aarch64-linux-gnu package:
 # - install AArch64 tool chain:
 #   $ sudo apt-get install g++-aarch64-linux-gnu
 # - cross-compiling config
-#   $ cmake -DCMAKE_TOOLCHAIN_FILE=../dynamorio/make/toolchain-arm64.cmake ../dynamorio
+#   $ cmake -DCMAKE_TOOLCHAIN_FILE=../dynamorio/make/toolchain-aarch64.cmake ../dynamorio
 # You may have to set CMAKE_FIND_ROOT_PATH to point to the target enviroment, e.g.
 # by passing -DCMAKE_FIND_ROOT_PATH=/usr/aarch64-linux-gnu on Debian-like systems.
 set(CMAKE_SYSTEM_NAME Linux)

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -452,13 +452,13 @@ if (UNIX AND ARCH_IS_X86)
       set(run_tests OFF) # build tests but don't run them
     endif ()
   endif ()
-  testbuild_ex("arm-debug-internal-32" OFF "
+  testbuild_ex("arm-debug-internal" OFF "
     DEBUG:BOOL=ON
     INTERNAL:BOOL=ON
     ${build_tests}
     CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
     " OFF ${arg_package} "")
-  testbuild_ex("arm-release-external-32" OFF "
+  testbuild_ex("arm-release-external" OFF "
     DEBUG:BOOL=OFF
     INTERNAL:BOOL=OFF
     CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm32.cmake
@@ -469,16 +469,16 @@ if (UNIX AND ARCH_IS_X86)
       set(run_tests OFF) # build tests but don't run them
     endif ()
   endif ()
-  testbuild_ex("arm-debug-internal-64" ON "
+  testbuild_ex("aarch64-debug-internal" ON "
     DEBUG:BOOL=ON
     INTERNAL:BOOL=ON
     ${build_tests}
-    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
+    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-aarch64.cmake
     " OFF ${arg_package} "")
-  testbuild_ex("arm-release-external-64" ON "
+  testbuild_ex("aarch64-release-external" ON "
     DEBUG:BOOL=OFF
     INTERNAL:BOOL=OFF
-    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-arm64.cmake
+    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-aarch64.cmake
     " OFF ${arg_package} "")
 
   set(run_tests ${prev_run_tests})


### PR DESCRIPTION
Renames toolchain-arm64.cmake to toolchain-aarch64.cmake to match
conventions.

Renames the test suite runs arm-xx-yy-64 to aarch64-xx-yy and
arm-xx-yy-32 to arm-xx-yy.

Issue: #1569