### PR TITLE
Add EVEX encodings of missing vmovq variants.

### DIFF
--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -3866,11 +3866,11 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_movd, 0x660f7e10, "movd", Ey, xx, Vd_dq, xx, xx, mrm, x, END_LIST},
     {INVALID, 0xf20f7e10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f7e10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vmovq, 0xf30f7e10, "vmovq", Vdq, xx, Wq_dq, xx, xx, mrm|vex, x, tpe[61][6]},
+    {OP_vmovq, 0xf30f7e10, "vmovq", Vdq, xx, Wq_dq, xx, xx, mrm|vex, x, tpe[51][9]},
     {VEX_W_EXT, 0x660f7e10, "(vex_W ext 109)", xx, xx, xx, xx, xx, mrm|vex, x, 109},
     {INVALID, 0xf20f7e10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f7e10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0xf30f7e10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_vmovq, 0xf30f7e10, "vmovq", Vdq, xx, Wq_dq, xx, xx, mrm|evex, x, tpe[61][6]},
     {EVEX_Wb_EXT, 0x660f7e10, "(evex_Wb ext 137)", xx, xx, xx, xx, xx, mrm|evex, x, 137},
     {INVALID, 0xf20f7e10, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   }, /* prefix extension 52: all assumed to have Ib */
@@ -4008,11 +4008,11 @@ const instr_info_t prefix_extensions[][12] = {
     {OP_movdq2q, 0xf20fd610, "movdq2q", Pq, xx, Uq_dq, xx, xx, mrm, x, END_LIST},
     {INVALID,   0x0fd610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf30fd610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_vmovq, 0x660fd610, "vmovq", Wq_dq, xx, Vq_dq, xx, xx, mrm|vex, x, tvexw[108][1]},
+    {OP_vmovq, 0x660fd610, "vmovq", Wq_dq, xx, Vq_dq, xx, xx, mrm|vex, x, tpe[61][10]},
     {INVALID, 0xf20fd610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0fd610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xf30fd610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID, 0x660fd610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_vmovq, 0x660fd610, "vmovq", Wq_dq, xx, Vq_dq, xx, xx, mrm|evex, x, tvexw[108][1]},
     {INVALID, 0xf20fd610, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   }, /* prefix extension 62 */
   {

--- a/suite/tests/api/ir_x86_2args_avx512_evex.h
+++ b/suite/tests/api/ir_x86_2args_avx512_evex.h
@@ -173,6 +173,8 @@ OPCODE(vmovq_xhim64, vmovq, vmovq, X64_ONLY, REGARG(XMM31), MEMARG(OPSZ_8))
 OPCODE(vmovq_r64xhi, vmovq, vmovq, X64_ONLY, REGARG(RAX), REGARG_PARTIAL(XMM31, OPSZ_8))
 OPCODE(vmovq_m64xhi, vmovq, vmovq, X64_ONLY, MEMARG(OPSZ_8),
        REGARG_PARTIAL(XMM31, OPSZ_8))
+OPCODE(vmovq_xloxlo, vmovq, vmovq, X64_ONLY, REGARG(XMM0), REGARG_PARTIAL(XMM1, OPSZ_8))
+OPCODE(vmovq_xhixhi, vmovq, vmovq, X64_ONLY, REGARG(XMM30), REGARG_PARTIAL(XMM31, OPSZ_8))
 OPCODE(vpmovm2b_xlok0, vpmovm2b, vpmovm2b, 0, REGARG(XMM0), REGARG(K0))
 OPCODE(vpmovm2b_xhik7, vpmovm2b, vpmovm2b, X64_ONLY, REGARG(XMM31), REGARG(K7))
 OPCODE(vpmovm2b_ylok0, vpmovm2b, vpmovm2b, 0, REGARG(YMM0), REGARG(K0))


### PR DESCRIPTION
These instruction variants, which do not have a EVEX.W=0 vmovd equivalent, were missed when EVEX instructions were added. The XMM/mem forms of these instructions are redundant with existing encodings and can't be tested via the normal encoding API.

Fixes #4755.