### PR TITLE
i#4749: Use proper doxygen comments for group delimiters

### DIFF
--- a/core/ir/aarch64/instr_create.h
+++ b/core/ir/aarch64/instr_create.h
@@ -133,7 +133,7 @@ enum {
  * Platform-independent INSTR_CREATE_* macros
  */
 /** @name Platform-independent macros */
-/* @{ */ /* doxygen start group */
+/** @{ */ /* doxygen start group */
 
 /**
  * This platform-independent macro creates an instr_t for a debug trap
@@ -485,7 +485,7 @@ enum {
  */
 #define XINST_CREATE_call_reg(dc, r) INSTR_CREATE_blr(dc, r)
 
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /****************************************************************************
  * Manually-added ARM-specific INSTR_CREATE_* macros

--- a/core/ir/arm/instr_create.h
+++ b/core/ir/arm/instr_create.h
@@ -111,7 +111,7 @@ enum {
  * Platform-independent XINST_CREATE_* macros
  */
 /** @name Platform-independent macros */
-/* @{ */ /* doxygen start group */
+/** @{ */ /* doxygen start group */
 
 /**
  * This platform-independent macro creates an instr_t for a debug trap
@@ -440,7 +440,7 @@ enum {
  * be a reg_id_t operand with the address of the subroutine.
  */
 #define XINST_CREATE_call_reg(dc, r) INSTR_CREATE_blx_ind(dc, r)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /****************************************************************************
  * Manually-added ARM-specific INSTR_CREATE_* macros
@@ -514,7 +514,7 @@ enum {
  */
 
 /** @name Signature: () */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -537,10 +537,10 @@ enum {
 #define INSTR_CREATE_wfe(dc) instr_create_0dst_0src((dc), OP_wfe)
 #define INSTR_CREATE_wfi(dc) instr_create_0dst_0src((dc), OP_wfi)
 #define INSTR_CREATE_yield(dc) instr_create_0dst_0src((dc), OP_yield)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -552,10 +552,10 @@ enum {
  */
 #define INSTR_CREATE_vmrs(dc, Rd) \
     instr_create_1dst_1src((dc), OP_vmrs, (Rd), opnd_create_reg(DR_REG_FPSCR))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -569,10 +569,10 @@ enum {
     instr_create_1dst_1src((dc), OP_blx_ind, opnd_create_reg(DR_REG_LR), (Rm))
 #define INSTR_CREATE_bx(dc, Rm) instr_create_0dst_1src((dc), OP_bx, (Rm))
 #define INSTR_CREATE_bxj(dc, Rm) instr_create_0dst_1src((dc), OP_bxj, (Rm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rt) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -584,10 +584,10 @@ enum {
  */
 #define INSTR_CREATE_vmsr(dc, Rt) \
     instr_create_1dst_1src((dc), OP_vmsr, opnd_create_reg(DR_REG_FPSCR), (Rt))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (pc) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -603,10 +603,10 @@ enum {
     instr_create_1dst_1src((dc), OP_bl, opnd_create_reg(DR_REG_LR), (pc))
 #define INSTR_CREATE_blx(dc, pc) \
     instr_create_1dst_1src((dc), OP_blx, opnd_create_reg(DR_REG_LR), (pc))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -624,10 +624,10 @@ enum {
 #define INSTR_CREATE_revsh(dc, Rd, Rm) instr_create_1dst_1src((dc), OP_revsh, (Rd), (Rm))
 #define INSTR_CREATE_rrx(dc, Rd, Rm) instr_create_1dst_1src((dc), OP_rrx, (Rd), (Rm))
 #define INSTR_CREATE_rrxs(dc, Rd, Rm) instr_create_1dst_1src((dc), OP_rrxs, (Rd), (Rm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rn) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -642,10 +642,10 @@ enum {
 #define INSTR_CREATE_sxth(dc, Rd, Rn) instr_create_1dst_1src((dc), OP_sxth, (Rd), (Rn))
 #define INSTR_CREATE_uxtb(dc, Rd, Rn) instr_create_1dst_1src((dc), OP_uxtb, (Rd), (Rn))
 #define INSTR_CREATE_uxth(dc, Rd, Rn) instr_create_1dst_1src((dc), OP_uxth, (Rd), (Rn))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (pc, Rn) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -658,10 +658,10 @@ enum {
  */
 #define INSTR_CREATE_cbnz(dc, pc, Rn) instr_create_0dst_2src((dc), OP_cbnz, (pc), (Rn))
 #define INSTR_CREATE_cbz(dc, pc, Rn) instr_create_0dst_2src((dc), OP_cbz, (pc), (Rn))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, statreg) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -674,10 +674,10 @@ enum {
  */
 #define INSTR_CREATE_mrs(dc, Rd, statreg) \
     instr_create_1dst_1src((dc), OP_mrs, (Rd), (statreg))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rm, Rn) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -691,10 +691,10 @@ enum {
  */
 #define INSTR_CREATE_qsub(dc, Rd, Rm, Rn) \
     instr_create_1dst_2src((dc), OP_qsub, (Rd), (Rm), (Rn))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rn, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -832,10 +832,10 @@ enum {
     instr_create_1dst_2src((dc), OP_usub16, (Rd), (Rn), (Rm))
 #define INSTR_CREATE_usub8(dc, Rd, Rn, Rm) \
     instr_create_1dst_2src((dc), OP_usub8, (Rd), (Rn), (Rm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rn, Rm, Ra) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -884,10 +884,10 @@ enum {
     instr_create_1dst_3src((dc), OP_smmlsr, (Rd), (Rn), (Rm), (Ra))
 #define INSTR_CREATE_usada8(dc, Rd, Rn, Rm, Ra) \
     instr_create_1dst_3src((dc), OP_usada8, (Rd), (Rn), (Rm), (Ra))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rd2, Rn, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -934,10 +934,10 @@ enum {
     instr_create_2dst_2src((dc), OP_umull, (Rd), (Rd2), (Rn), (Rm))
 #define INSTR_CREATE_umulls(dc, Rd, Rd2, Rn, Rm) \
     instr_create_2dst_2src((dc), OP_umulls, (Rd), (Rd2), (Rn), (Rm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -963,10 +963,10 @@ enum {
 #define INSTR_CREATE_smc(dc, imm) instr_create_0dst_1src((dc), OP_smc, (imm))
 #define INSTR_CREATE_svc(dc, imm) instr_create_0dst_1src((dc), OP_svc, (imm))
 #define INSTR_CREATE_udf(dc, imm) instr_create_0dst_1src((dc), OP_udf, (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -983,10 +983,10 @@ enum {
     instr_create_1dst_1src((dc), OP_mrs_priv, (Rd), (imm))
 #define INSTR_CREATE_vmrs_imm(dc, Rd, imm) \
     instr_create_1dst_1src((dc), OP_vmrs, (Rd), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rt, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -999,10 +999,10 @@ enum {
  */
 #define INSTR_CREATE_vmsr_imm(dc, Rt, imm) \
     instr_create_0dst_2src((dc), OP_vmsr, (Rt), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (imm, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1015,10 +1015,10 @@ enum {
  */
 #define INSTR_CREATE_msr_priv(dc, imm, Rm) \
     instr_create_0dst_2src((dc), OP_msr_priv, (imm), (Rm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (imm, imm2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1034,10 +1034,10 @@ enum {
 #define INSTR_CREATE_cpsie_noflags(dc, imm, imm2) \
     instr_create_0dst_2src((dc), OP_cpsie, (imm), (imm2))
 #define INSTR_CREATE_it(dc, imm, imm2) instr_create_0dst_2src((dc), OP_it, (imm), (imm2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rm_or_imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1062,10 +1062,10 @@ enum {
          ? INSTR_CREATE_mvns_shimm((dc), (Rd), (Rm_or_imm),                              \
                                    OPND_CREATE_INT8(DR_SHIFT_NONE), OPND_CREATE_INT8(0)) \
          : instr_create_1dst_1src((dc), OP_mvns, (Rd), (Rm_or_imm)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rn, Rm_or_imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1096,10 +1096,10 @@ enum {
          ? INSTR_CREATE_tst_shimm((dc), (Rn), (Rm_or_imm),                              \
                                   OPND_CREATE_INT8(DR_SHIFT_NONE), OPND_CREATE_INT8(0)) \
          : instr_create_0dst_2src((dc), OP_tst, (Rn), (Rm_or_imm)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rm, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1123,10 +1123,10 @@ enum {
     instr_create_1dst_2src((dc), OP_uxtb, (Rd), (Rm), (imm))
 #define INSTR_CREATE_uxth_imm(dc, Rd, Rm, imm) \
     instr_create_1dst_2src((dc), OP_uxth, (Rd), (Rm), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rn, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1142,10 +1142,10 @@ enum {
     instr_create_1dst_2src((dc), OP_addw, (Rd), (Rn), (imm))
 #define INSTR_CREATE_subw(dc, Rd, Rn, imm) \
     instr_create_1dst_2src((dc), OP_subw, (Rd), (Rn), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, imm, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1161,10 +1161,10 @@ enum {
     instr_create_1dst_2src((dc), OP_ssat16, (Rd), (imm), (Rm))
 #define INSTR_CREATE_usat16(dc, Rd, imm, Rm) \
     instr_create_1dst_2src((dc), OP_usat16, (Rd), (imm), (Rm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, imm, imm2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1178,10 +1178,10 @@ enum {
  */
 #define INSTR_CREATE_bfc(dc, Rd, imm, imm2) \
     instr_create_1dst_3src((dc), OP_bfc, (Rd), (imm), (imm2), (Rd))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rn, Rm_or_imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1319,10 +1319,10 @@ enum {
          ? INSTR_CREATE_subs_shimm((dc), (Rd), (Rn), (Rm_or_imm),                        \
                                    OPND_CREATE_INT8(DR_SHIFT_NONE), OPND_CREATE_INT8(0)) \
          : instr_create_1dst_2src((dc), OP_subs, (Rd), (Rn), (Rm_or_imm)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, statreg, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1336,10 +1336,10 @@ enum {
  */
 #define INSTR_CREATE_mrs_priv_spsr(dc, Rd, statreg, imm) \
     instr_create_1dst_2src((dc), OP_mrs_priv, (Rd), (statreg), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (statreg, imm, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1353,10 +1353,10 @@ enum {
  */
 #define INSTR_CREATE_msr_priv_spsr(dc, statreg, imm, Rm) \
     instr_create_1dst_2src((dc), OP_msr_priv, (statreg), (imm), (Rm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (statreg, imm, imm2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1370,10 +1370,10 @@ enum {
  */
 #define INSTR_CREATE_msr_imm(dc, statreg, imm, imm2) \
     instr_create_1dst_2src((dc), OP_msr, (statreg), (imm), (imm2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (statreg, imm_msr, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1387,10 +1387,10 @@ enum {
  */
 #define INSTR_CREATE_msr(dc, statreg, imm_msr, Rm) \
     instr_create_1dst_2src((dc), OP_msr, (statreg), (imm_msr), (Rm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rn, Rm, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1415,10 +1415,10 @@ enum {
     instr_create_1dst_3src((dc), OP_uxtab16, (Rd), (Rn), (Rm), (imm))
 #define INSTR_CREATE_uxtah(dc, Rd, Rn, Rm, imm) \
     instr_create_1dst_3src((dc), OP_uxtah, (Rd), (Rn), (Rm), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rm, imm, imm2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1437,10 +1437,10 @@ enum {
     instr_create_1dst_3src((dc), OP_sbfx, (Rd), (Rm), (imm), (imm2))
 #define INSTR_CREATE_ubfx(dc, Rd, Rm, imm, imm2) \
     instr_create_1dst_3src((dc), OP_ubfx, (Rd), (Rm), (imm), (imm2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rm, shift, Rs) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1461,10 +1461,10 @@ enum {
     instr_create_1dst_3src((dc), OP_mvns, (Rd),                                      \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED), \
                            opnd_add_flags((shift), DR_OPND_IS_SHIFT), (Rs))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rn, Rm, shift, Rs) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1493,10 +1493,10 @@ enum {
     instr_create_0dst_4src((dc), OP_tst, (Rn),                                       \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED), \
                            opnd_add_flags((shift), DR_OPND_IS_SHIFT), (Rs))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rn, Rm, shift, Rs) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1590,10 +1590,10 @@ enum {
     instr_create_1dst_4src((dc), OP_subs, (Rd), (Rn),                                \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED), \
                            opnd_add_flags((shift), DR_OPND_IS_SHIFT), (Rs))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rm, shift, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1614,10 +1614,10 @@ enum {
     instr_create_1dst_3src((dc), OP_mvns, (Rd),                                      \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED), \
                            opnd_add_flags((shift), DR_OPND_IS_SHIFT), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rn, Rm, shift, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1646,10 +1646,10 @@ enum {
     instr_create_0dst_4src((dc), OP_tst, (Rn),                                       \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED), \
                            opnd_add_flags((shift), DR_OPND_IS_SHIFT), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rn, Rm, shift, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1757,10 +1757,10 @@ enum {
     instr_create_1dst_4src((dc), OP_subs, (Rd), (Rn),                                \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED), \
                            opnd_add_flags((shift), DR_OPND_IS_SHIFT), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, imm, Rm, shift, imm2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1782,10 +1782,10 @@ enum {
     instr_create_1dst_4src((dc), OP_usat, (Rd), (imm),                               \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED), \
                            opnd_add_flags((shift), DR_OPND_IS_SHIFT), (imm2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1800,10 +1800,10 @@ enum {
 #define INSTR_CREATE_pli(dc, mem) instr_create_0dst_1src((dc), OP_pli, (mem))
 #define INSTR_CREATE_tbb(dc, mem) instr_create_0dst_1src((dc), OP_tbb, (mem))
 #define INSTR_CREATE_tbh(dc, mem) instr_create_0dst_1src((dc), OP_tbh, (mem))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, mem) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1845,10 +1845,10 @@ enum {
 #define INSTR_CREATE_ldrsht(dc, Rd, mem) \
     instr_create_1dst_1src((dc), OP_ldrsht, (Rd), (mem))
 #define INSTR_CREATE_ldrt(dc, Rd, mem) instr_create_1dst_1src((dc), OP_ldrt, (Rd), (mem))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1862,10 +1862,10 @@ enum {
 #define INSTR_CREATE_stl(dc, mem, Rm) instr_create_1dst_1src((dc), OP_stl, (mem), (Rm))
 #define INSTR_CREATE_stlb(dc, mem, Rm) instr_create_1dst_1src((dc), OP_stlb, (mem), (Rm))
 #define INSTR_CREATE_stlh(dc, mem, Rm) instr_create_1dst_1src((dc), OP_stlh, (mem), (Rm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Rt) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1884,10 +1884,10 @@ enum {
 #define INSTR_CREATE_strht(dc, mem, Rt) \
     instr_create_1dst_1src((dc), OP_strht, (mem), (Rt))
 #define INSTR_CREATE_strt(dc, mem, Rt) instr_create_1dst_1src((dc), OP_strt, (mem), (Rt))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (statreg, mem) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1918,10 +1918,10 @@ enum {
 #define INSTR_CREATE_rfeib_wb(dc, statreg, mem)                                 \
     instr_create_2dst_2src((dc), OP_rfeib, opnd_create_reg(opnd_get_base(mem)), \
                            (statreg), (mem), opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rd2, mem) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1939,10 +1939,10 @@ enum {
     instr_create_2dst_1src((dc), OP_ldrd, (Rd), (Rd2), (mem))
 #define INSTR_CREATE_ldrexd(dc, Rd, Rd2, mem) \
     instr_create_2dst_1src((dc), OP_ldrexd, (Rd), (Rd2), (mem))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, mem, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -1988,10 +1988,10 @@ enum {
     instr_create_2dst_2src((dc), OP_swp, (mem), (Rd), (mem), (Rm))
 #define INSTR_CREATE_swpb(dc, Rd, mem, Rm) \
     instr_create_2dst_2src((dc), OP_swpb, (mem), (Rd), (mem), (Rm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Rd, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2015,10 +2015,10 @@ enum {
     instr_create_2dst_1src((dc), OP_strexb, (mem), (Rd), (Rm))
 #define INSTR_CREATE_strexh(dc, mem, Rd, Rm) \
     instr_create_2dst_1src((dc), OP_strexh, (mem), (Rd), (Rm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Rt, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2040,10 +2040,10 @@ enum {
                            (Rt),                                                       \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED),   \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Rt, Rt2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2057,10 +2057,10 @@ enum {
  */
 #define INSTR_CREATE_strd(dc, mem, Rt, Rt2) \
     instr_create_1dst_2src((dc), OP_strd, (mem), (Rt), (Rt2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rd2, mem, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2078,10 +2078,10 @@ enum {
                            opnd_create_reg(opnd_get_base(mem)), (mem),               \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED), \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Rd, Rt, Rt2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2098,10 +2098,10 @@ enum {
     instr_create_2dst_2src((dc), OP_stlexd, (mem), (Rd), (Rt), (Rt2))
 #define INSTR_CREATE_strexd(dc, mem, Rd, Rt, Rt2) \
     instr_create_2dst_2src((dc), OP_strexd, (mem), (Rd), (Rt), (Rt2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Rt, Rt2, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2119,10 +2119,10 @@ enum {
                            (Rt), (Rt2),                                               \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED),  \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, mem, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2164,10 +2164,10 @@ enum {
 #define INSTR_CREATE_ldrt_wbimm(dc, Rd, mem, imm)                                    \
     instr_create_2dst_3src((dc), OP_ldrt, (Rd), opnd_create_reg(opnd_get_base(mem)), \
                            (mem), (imm), opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Rt, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2197,10 +2197,10 @@ enum {
 #define INSTR_CREATE_strt_wbimm(dc, mem, Rt, imm)                                     \
     instr_create_2dst_3src((dc), OP_strt, (mem), opnd_create_reg(opnd_get_base(mem)), \
                            (Rt), (imm), opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, imm, statreg) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2240,10 +2240,10 @@ enum {
     instr_create_2dst_4src((dc), OP_srsib, (mem), opnd_create_reg(opnd_get_base(mem)), \
                            (imm), opnd_create_reg(opnd_get_base(mem)),                 \
                            opnd_create_reg(DR_REG_LR), (statreg))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rd2, mem, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2260,10 +2260,10 @@ enum {
     instr_create_3dst_3src((dc), OP_ldrd, (Rd), (Rd2),                        \
                            opnd_create_reg(opnd_get_base(mem)), (mem), (imm), \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Rt, Rt2, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2279,10 +2279,10 @@ enum {
 #define INSTR_CREATE_strd_wbimm(dc, mem, Rt, Rt2, imm)                                \
     instr_create_2dst_4src((dc), OP_strd, (mem), opnd_create_reg(opnd_get_base(mem)), \
                            (Rt), (Rt2), (imm), opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, mem, Rm, shift, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2320,10 +2320,10 @@ enum {
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED), \
                            opnd_add_flags((shift), DR_OPND_IS_SHIFT), (imm),         \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Rt, Rm, shift, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2361,10 +2361,10 @@ enum {
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED),  \
                            opnd_add_flags((shift), DR_OPND_IS_SHIFT), (imm),          \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, list_len, ...) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2509,10 +2509,10 @@ enum {
     instr_create_Ndst_Msrc_varsrc((dc), OP_vstmdb, 2, 1, list_len, 0, (mem), \
                                   opnd_create_reg(opnd_get_base(mem)),       \
                                   opnd_create_reg(opnd_get_base(mem)), __VA_ARGS__)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Rm, list_len, ...) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2546,10 +2546,10 @@ enum {
         (dc), OP_vld4_dup_8, 1, 3, list_len, 0, opnd_create_reg(opnd_get_base(mem)), \
         (mem), opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED),             \
         opnd_create_reg(opnd_get_base(mem)), __VA_ARGS__)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, imm, list_len, ...) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -2843,10 +2843,10 @@ enum {
     instr_create_Ndst_Msrc_varsrc((dc), OP_vst4_8, 2, 2, list_len, 0, (mem),  \
                                   opnd_create_reg(opnd_get_base(mem)), (imm), \
                                   opnd_create_reg(opnd_get_base(mem)), __VA_ARGS__)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, imm, Rm, list_len, ...) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3064,10 +3064,10 @@ enum {
         (dc), OP_vst4_8, 2, 3, list_len, 0, (mem), opnd_create_reg(opnd_get_base(mem)), \
         (imm), opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED),                \
         opnd_create_reg(opnd_get_base(mem)), __VA_ARGS__)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, imm, imm2, list_len, ...) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3166,10 +3166,10 @@ enum {
     instr_create_Ndst_Msrc_varsrc((dc), OP_vst4_lane_8, 2, 3, list_len, 0, (mem),     \
                                   opnd_create_reg(opnd_get_base(mem)), (imm), (imm2), \
                                   opnd_create_reg(opnd_get_base(mem)), __VA_ARGS__)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, imm, imm2, Rm, list_len, ...) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3251,10 +3251,10 @@ enum {
         opnd_create_reg(opnd_get_base(mem)), (imm), (imm2),                   \
         opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED),             \
         opnd_create_reg(opnd_get_base(mem)), __VA_ARGS__)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Ra, Rd, imm, imm2, cpreg) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3272,10 +3272,10 @@ enum {
     instr_create_2dst_3src((dc), OP_mrrc, (Ra), (Rd), (imm), (imm2), (cpreg))
 #define INSTR_CREATE_mrrc2(dc, Ra, Rd, imm, imm2, cpreg) \
     instr_create_2dst_3src((dc), OP_mrrc2, (Ra), (Rd), (imm), (imm2), (cpreg))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (cpreg, Rn, Rt, imm, imm2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3293,10 +3293,10 @@ enum {
     instr_create_1dst_4src((dc), OP_mcrr, (cpreg), (Rn), (Rt), (imm), (imm2))
 #define INSTR_CREATE_mcrr2(dc, cpreg, Rn, Rt, imm, imm2) \
     instr_create_1dst_4src((dc), OP_mcrr2, (cpreg), (Rn), (Rt), (imm), (imm2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (cpreg, cpreg2, imm, imm2, Rt) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3312,10 +3312,10 @@ enum {
  */
 #define INSTR_CREATE_mcr2(dc, cpreg, cpreg2, imm, imm2, Rt) \
     instr_create_2dst_3src((dc), OP_mcr2, (cpreg), (cpreg2), (imm), (imm2), (Rt))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (cpreg, imm, imm2, cpreg2, cpreg3) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3331,10 +3331,10 @@ enum {
  */
 #define INSTR_CREATE_cdp2(dc, cpreg, imm, imm2, cpreg2, cpreg3) \
     instr_create_1dst_4src((dc), OP_cdp2, (cpreg), (imm), (imm2), (cpreg2), (cpreg3))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, imm, imm2, cpreg, cpreg2, imm3) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3353,10 +3353,10 @@ enum {
     instr_create_1dst_5src((dc), OP_mrc, (Rd), (imm), (imm2), (cpreg), (cpreg2), (imm3))
 #define INSTR_CREATE_mrc2(dc, Rd, imm, imm2, cpreg, cpreg2, imm3) \
     instr_create_1dst_5src((dc), OP_mrc2, (Rd), (imm), (imm2), (cpreg), (cpreg2), (imm3))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (cpreg, cpreg2, imm, imm2, Rt, imm3) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3373,10 +3373,10 @@ enum {
  */
 #define INSTR_CREATE_mcr(dc, cpreg, cpreg2, imm, imm2, Rt, imm3) \
     instr_create_2dst_4src((dc), OP_mcr, (cpreg), (cpreg2), (imm), (imm2), (Rt), (imm3))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (cpreg, imm, imm2, cpreg2, cpreg3, imm3) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3394,10 +3394,10 @@ enum {
 #define INSTR_CREATE_cdp(dc, cpreg, imm, imm2, cpreg2, cpreg3, imm3)                 \
     instr_create_1dst_5src((dc), OP_cdp, (cpreg), (imm), (imm2), (cpreg2), (cpreg3), \
                            (imm3))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (cpreg, mem, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3413,10 +3413,10 @@ enum {
     instr_create_1dst_2src((dc), OP_ldc, (cpreg), (mem), (imm))
 #define INSTR_CREATE_ldcl(dc, cpreg, mem, imm) \
     instr_create_1dst_2src((dc), OP_ldcl, (cpreg), (mem), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, imm, cpreg, imm2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3449,10 +3449,10 @@ enum {
 #define INSTR_CREATE_stcl_wbimm(dc, mem, imm, cpreg, imm2)                            \
     instr_create_2dst_4src((dc), OP_stcl, (mem), opnd_create_reg(opnd_get_base(mem)), \
                            (imm), (cpreg), (imm2), opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (cpreg, mem, imm, imm2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3485,10 +3485,10 @@ enum {
 #define INSTR_CREATE_ldcl_wbimm(dc, cpreg, mem, imm, imm2)                              \
     instr_create_2dst_4src((dc), OP_ldcl, (cpreg), opnd_create_reg(opnd_get_base(mem)), \
                            (mem), (imm), (imm2), opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Vn) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3501,10 +3501,10 @@ enum {
  */
 #define INSTR_CREATE_vmov_s2g(dc, Rd, Vn) \
     instr_create_1dst_1src((dc), OP_vmov, (Rd), (Vn))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, Vm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3795,10 +3795,10 @@ enum {
     instr_create_1dst_1src((dc), OP_vzip_32, (Vd), (Vm))
 #define INSTR_CREATE_vzip_8(dc, Vd, Vm) \
     instr_create_1dst_1src((dc), OP_vzip_8, (Vd), (Vm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, Rt) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3817,10 +3817,10 @@ enum {
     instr_create_1dst_1src((dc), OP_vdup_8, (Vd), (Rt))
 #define INSTR_CREATE_vmov_g2s(dc, Vd, Rt) \
     instr_create_1dst_1src((dc), OP_vmov, (Vd), (Rt))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Ra, Rd, Vm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3834,10 +3834,10 @@ enum {
  */
 #define INSTR_CREATE_vmov_s2gg(dc, Ra, Rd, Vm) \
     instr_create_2dst_1src((dc), OP_vmov, (Ra), (Rd), (Vm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, Vn, Vm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4363,10 +4363,10 @@ enum {
     instr_create_1dst_2src((dc), OP_vtst_32, (Vd), (Vn), (Vm))
 #define INSTR_CREATE_vtst_8(dc, Vd, Vn, Vm) \
     instr_create_1dst_2src((dc), OP_vtst_8, (Vd), (Vn), (Vm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, Rt, Rt2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4380,10 +4380,10 @@ enum {
  */
 #define INSTR_CREATE_vmov_gg2s(dc, Vd, Rt, Rt2) \
     instr_create_1dst_2src((dc), OP_vmov, (Vd), (Rt), (Rt2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Rd2, Vt, Vt2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4398,10 +4398,10 @@ enum {
  */
 #define INSTR_CREATE_vmov_ss2gg(dc, Rd, Rd2, Vt, Vt2) \
     instr_create_2dst_2src((dc), OP_vmov, (Rd), (Rd2), (Vt), (Vt2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, Vd2, Rt, Rt2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4416,10 +4416,10 @@ enum {
  */
 #define INSTR_CREATE_vmov_gg2ss(dc, Vd, Vd2, Rt, Rt2) \
     instr_create_2dst_2src((dc), OP_vmov, (Vd), (Vd2), (Rt), (Rt2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4450,10 +4450,10 @@ enum {
     instr_create_1dst_1src((dc), OP_vorr_i16, (Vd), (imm))
 #define INSTR_CREATE_vorr_i32(dc, Vd, imm) \
     instr_create_1dst_1src((dc), OP_vorr_i32, (Vd), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, Vm_or_imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4468,10 +4468,10 @@ enum {
     instr_create_1dst_1src((dc), OP_vmov_f32, (Vd), (Vm_or_imm))
 #define INSTR_CREATE_vmov_f64(dc, Vd, Vm_or_imm) \
     instr_create_1dst_1src((dc), OP_vmov_f64, (Vd), (Vm_or_imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vt, Vm_or_imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4494,10 +4494,10 @@ enum {
 #define INSTR_CREATE_vcmpe_f64(dc, Vt, Vm_or_imm)                                   \
     instr_create_1dst_2src((dc), OP_vcmpe_f64, opnd_create_reg(DR_REG_FPSCR), (Vt), \
                            (Vm_or_imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Rd, Vn, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4519,10 +4519,10 @@ enum {
     instr_create_1dst_2src((dc), OP_vmov_u16, (Rd), (Vn), (imm))
 #define INSTR_CREATE_vmov_u8(dc, Rd, Vn, imm) \
     instr_create_1dst_2src((dc), OP_vmov_u8, (Rd), (Vn), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, Vm, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4750,10 +4750,10 @@ enum {
     instr_create_1dst_2src((dc), OP_vsri_64, (Vd), (Vm), (imm))
 #define INSTR_CREATE_vsri_8(dc, Vd, Vm, imm) \
     instr_create_1dst_2src((dc), OP_vsri_8, (Vd), (Vm), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, Rt, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4771,10 +4771,10 @@ enum {
     instr_create_1dst_2src((dc), OP_vmov_32, (Vd), (Rt), (imm))
 #define INSTR_CREATE_vmov_8(dc, Vd, Rt, imm) \
     instr_create_1dst_2src((dc), OP_vmov_8, (Vd), (Rt), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, Vn, Vm_or_imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4826,10 +4826,10 @@ enum {
     instr_create_1dst_2src((dc), OP_vqshl_u64, (Vd), (Vn), (Vm_or_imm))
 #define INSTR_CREATE_vqshl_u8(dc, Vd, Vn, Vm_or_imm) \
     instr_create_1dst_2src((dc), OP_vqshl_u8, (Vd), (Vn), (Vm_or_imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, Vn, Vm, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4906,10 +4906,10 @@ enum {
     instr_create_1dst_3src((dc), OP_vqrdmulh_s16, (Vd), (Vn), (Vm), (imm))
 #define INSTR_CREATE_vqrdmulh_s32_imm(dc, Vd, Vn, Vm, imm) \
     instr_create_1dst_3src((dc), OP_vqrdmulh_s32, (Vd), (Vn), (Vm), (imm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, imm, Vn, Vm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4938,10 +4938,10 @@ enum {
     instr_create_1dst_3src((dc), OP_vsel_vs_f32, (Vd), (imm), (Vn), (Vm))
 #define INSTR_CREATE_vsel_vs_f64(dc, Vd, imm, Vn, Vm) \
     instr_create_1dst_3src((dc), OP_vsel_vs_f64, (Vd), (imm), (Vn), (Vm))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, mem) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4953,10 +4953,10 @@ enum {
  * \param mem The memory opnd_t operand.
  */
 #define INSTR_CREATE_vldr(dc, Vd, mem) instr_create_1dst_1src((dc), OP_vldr, (Vd), (mem))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Vt) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4968,10 +4968,10 @@ enum {
  * \param Vt The source SIMD register opnd_t operand.
  */
 #define INSTR_CREATE_vstr(dc, mem, Vt) instr_create_1dst_1src((dc), OP_vstr, (mem), (Vt))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, mem, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -4989,10 +4989,10 @@ enum {
     instr_create_2dst_3src((dc), OP_vld1_lane_8, (Vd),                        \
                            opnd_create_reg(opnd_get_base(mem)), (mem), (imm), \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Vt, imm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -5010,10 +5010,10 @@ enum {
     instr_create_2dst_3src((dc), OP_vst1_lane_8, (mem),                      \
                            opnd_create_reg(opnd_get_base(mem)), (Vt), (imm), \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, mem, imm, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -5031,10 +5031,10 @@ enum {
                            opnd_create_reg(opnd_get_base(mem)), (mem), (imm),        \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED), \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, mem, imm, imm2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -5059,10 +5059,10 @@ enum {
     instr_create_2dst_4src((dc), OP_vld1_lane_32, (Vd),                               \
                            opnd_create_reg(opnd_get_base(mem)), (mem), (imm), (imm2), \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Vt, imm, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -5080,10 +5080,10 @@ enum {
                            opnd_create_reg(opnd_get_base(mem)), (Vt), (imm),         \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED), \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Vt, imm, imm2) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -5108,10 +5108,10 @@ enum {
     instr_create_2dst_4src((dc), OP_vst1_lane_32, (mem),                             \
                            opnd_create_reg(opnd_get_base(mem)), (Vt), (imm), (imm2), \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, mem, imm, imm2, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -5135,10 +5135,10 @@ enum {
                            opnd_create_reg(opnd_get_base(mem)), (mem), (imm), (imm2), \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED),  \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (mem, Vt, imm, imm2, Rm) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -5162,10 +5162,10 @@ enum {
                            opnd_create_reg(opnd_get_base(mem)), (Vt), (imm), (imm2), \
                            opnd_create_reg_ex(opnd_get_reg(Rm), 0, DR_OPND_SHIFTED), \
                            opnd_create_reg(opnd_get_base(mem)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name Signature: (Vd, Vm, list_len, ...) */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -5185,7 +5185,7 @@ enum {
 #define INSTR_CREATE_vtbx_8(dc, Vd, Vm, list_len, ...)                            \
     instr_create_Ndst_Msrc_varsrc((dc), OP_vtbx_8, 1, 1, list_len, 0, (Vd), (Vm), \
                                   __VA_ARGS__)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* DR_API EXPORT END */
 

--- a/core/ir/x86/instr_create.h
+++ b/core/ir/x86/instr_create.h
@@ -150,7 +150,7 @@
  * Platform-independent INSTR_CREATE_* macros
  */
 /** @name Platform-independent macros */
-/* @{ */ /* doxygen start group */
+/** @{ */ /* doxygen start group */
 
 /**
  * This platform-independent macro creates an instr_t for a debug trap
@@ -475,7 +475,7 @@
  * be a reg_id_t operand with the address of the subroutine.
  */
 #define XINST_CREATE_call_reg(dc, r) INSTR_CREATE_call_ind(dc, r)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /****************************************************************************
  * x86-specific INSTR_CREATE_* macros
@@ -483,7 +483,7 @@
 
 /* no-operand instructions */
 /** @name No-operand instructions */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -532,7 +532,7 @@
 #define INSTR_CREATE_vzeroupper(dc) instr_create_0dst_0src((dc), OP_vzeroupper)
 #define INSTR_CREATE_vzeroall(dc) instr_create_0dst_0src((dc), OP_vzeroall)
 #define INSTR_CREATE_xtest(dc) instr_create_0dst_0src((dc), OP_xtest)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* no destination, 1 source */
 /**
@@ -559,7 +559,7 @@
  */
 #define INSTR_CREATE_jcc(dc, op, t) instr_create_0dst_1src((dc), (op), (t))
 /** @name Direct unconditional jump */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -570,7 +570,7 @@
 #define INSTR_CREATE_jmp(dc, t) instr_create_0dst_1src((dc), OP_jmp, (t))
 #define INSTR_CREATE_jmp_short(dc, t) instr_create_0dst_1src((dc), OP_jmp_short, (t))
 #define INSTR_CREATE_xbegin(dc, t) instr_create_0dst_1src((dc), OP_xbegin, (t))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -596,7 +596,7 @@
  */
 #define INSTR_CREATE_jmp_far_ind(dc, t) instr_create_0dst_1src((dc), OP_jmp_far_ind, (t))
 /** @name One explicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -672,9 +672,9 @@
  * OPND_CREATE_MEM_ptwrite() to get the appropriate operand size.
  */
 #define INSTR_CREATE_ptwrite(dc, s) instr_create_0dst_1src((dc), OP_ptwrite, (s))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name Prefetch */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -688,7 +688,7 @@
 #define INSTR_CREATE_prefetcht2(dc, s) instr_create_0dst_1src((dc), OP_prefetcht2, (s))
 #define INSTR_CREATE_prefetch(dc, s) instr_create_0dst_1src((dc), OP_prefetch, (s))
 #define INSTR_CREATE_prefetchw(dc, s) instr_create_0dst_1src((dc), OP_prefetchw, (s))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -734,7 +734,7 @@
 
 /* no destination, 1 implicit source */
 /** @name One implicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -752,11 +752,11 @@
     instr_create_0dst_1src((dc), OP_vmsave, opnd_create_reg(DR_REG_XAX))
 #define INSTR_CREATE_skinit(dc) \
     instr_create_0dst_1src((dc), OP_skinit, opnd_create_reg(DR_REG_EAX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* no destination, 2 explicit sources */
 /** @name No destination, 2 explicit sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -814,11 +814,11 @@
     instr_create_0dst_2src((dc), OP_invvpid, (s1), (s2))
 #define INSTR_CREATE_invpcid(dc, s1, s2) \
     instr_create_0dst_2src((dc), OP_invpcid, (s1), (s2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* no destination, 1 mask, and 1 explicit source */
 /** @name No destination, 1 mask, and 1 explicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -859,7 +859,7 @@
     instr_create_0dst_2src((dc), OP_vscatterpf1qps, (k), (s))
 #define INSTR_CREATE_vscatterpf1qpd_mask(dc, k, s) \
     instr_create_0dst_2src((dc), OP_vscatterpf1qpd, (k), (s))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* no destination, 2 sources: 1 implicit */
 /**
@@ -883,7 +883,7 @@
 
 /* no destination, 2 sources */
 /** @name No destination, 2 sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * Creates an instr_t for an OP_out instruction with a source of al
  * (INSTR_CREATE_out_1()) or eax (INSTR_CREATE_out_4()) and dx.
@@ -895,9 +895,9 @@
 #define INSTR_CREATE_out_4(dc)                                        \
     instr_create_0dst_2src((dc), OP_out, opnd_create_reg(DR_REG_EAX), \
                            opnd_create_reg(DR_REG_DX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name No destination, explicit immed source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * Creates an instr_t for an OP_out instruction with a source of al
  * (INSTR_CREATE_out_1_imm()) or eax (INSTR_CREATE_out_4_imm()) and an immediate.
@@ -909,10 +909,10 @@
     instr_create_0dst_2src((dc), OP_out, (i), opnd_create_reg(DR_REG_AL))
 #define INSTR_CREATE_out_4_imm(dc, i) \
     instr_create_0dst_2src((dc), OP_out, (i), opnd_create_reg(DR_REG_EAX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name No destination, 2 implicit sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -941,10 +941,10 @@
 #define INSTR_CREATE_xsetbv(dc)                                          \
     instr_create_0dst_3src((dc), OP_xsetbv, opnd_create_reg(DR_REG_ECX), \
                            opnd_create_reg(DR_REG_EDX), opnd_create_reg(DR_REG_EAX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name No destination, 3 sources: 1 implicit */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -965,10 +965,10 @@
 #define INSTR_CREATE_xrstor64(dc, s)                                            \
     instr_create_0dst_3src((dc), OP_xrstor64, (s), opnd_create_reg(DR_REG_EDX), \
                            opnd_create_reg(DR_REG_EAX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name No destination, 3 sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -983,11 +983,11 @@
     instr_create_0dst_3src((dc), OP_lwpins, (s1), (s2), (i))
 #define INSTR_CREATE_lwpval(dc, s1, s2, i) \
     instr_create_0dst_3src((dc), OP_lwpval, (s1), (s2), (i))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* floating-point */
 /** @name Floating-point with source of memory or fp register */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -1002,9 +1002,9 @@
     instr_create_0dst_2src((dc), OP_fcom, (s), opnd_create_reg(DR_REG_ST0))
 #define INSTR_CREATE_fcomp(dc, s) \
     instr_create_0dst_2src((dc), OP_fcomp, (s), opnd_create_reg(DR_REG_ST0))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name Floating-point with fp register source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -1025,9 +1025,9 @@
     instr_create_0dst_2src((dc), OP_fucom, opnd_create_reg(DR_REG_ST0), (f))
 #define INSTR_CREATE_fucomp(dc, f) \
     instr_create_0dst_2src((dc), OP_fucomp, opnd_create_reg(DR_REG_ST0), (f))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name Floating-point with no explicit sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx,
  * automatically supplying any implicit operands.
@@ -1039,7 +1039,7 @@
 #define INSTR_CREATE_fcompp(dc)                                          \
     instr_create_0dst_2src((dc), OP_fcompp, opnd_create_reg(DR_REG_ST0), \
                            opnd_create_reg(DR_REG_ST1))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 destination, no sources */
 /**
@@ -1052,7 +1052,7 @@
  */
 #define INSTR_CREATE_setcc(dc, op, d) instr_create_1dst_0src((dc), (op), (d))
 /** @name 1 explicit destination, no sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -1110,11 +1110,11 @@
 #define INSTR_CREATE_fxsave64(dc, d) instr_create_1dst_0src((dc), OP_fxsave64, (d))
 #define INSTR_CREATE_stmxcsr(dc, d) instr_create_1dst_0src((dc), OP_stmxcsr, (d))
 #define INSTR_CREATE_vstmxcsr(dc, d) instr_create_1dst_0src((dc), OP_vstmxcsr, (d))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* floating-point */
 /** @name Floating-point with memory destination */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -1124,7 +1124,7 @@
  */
 #define INSTR_CREATE_fnstcw(dc, m) instr_create_1dst_0src((dc), OP_fnstcw, (m))
 #define INSTR_CREATE_fnstsw(dc, m) instr_create_1dst_0src((dc), OP_fnstsw, (m))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -1143,7 +1143,7 @@
 #define INSTR_CREATE_fnsave(dc, m) instr_create_1dst_0src((dc), OP_fnsave, (m))
 
 /** @name Floating-point with float register destination, no sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -1153,11 +1153,11 @@
  */
 #define INSTR_CREATE_ffree(dc, f) instr_create_1dst_0src((dc), OP_ffree, (f))
 #define INSTR_CREATE_ffreep(dc, f) instr_create_1dst_0src((dc), OP_ffreep, (f))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 implicit destination, no sources */
 /** @name 1 implicit destination, no sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -1171,11 +1171,11 @@
     instr_create_1dst_0src((dc), OP_syscall, opnd_create_reg(DR_REG_XCX))
 #define INSTR_CREATE_salc(dc) \
     instr_create_1dst_0src((dc), OP_salc, opnd_create_reg(DR_REG_AL))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 destination, 1 source */
 /** @name 1 destination, 1 source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -1555,11 +1555,11 @@
 #define INSTR_CREATE_bndmk(dc, d, s) instr_create_1dst_1src((dc), OP_bndmk, (d), (s))
 #define INSTR_CREATE_bndldx(dc, d, s) instr_create_1dst_1src((dc), OP_bndldx, (d), (s))
 #define INSTR_CREATE_bndstx(dc, d, s) instr_create_1dst_1src((dc), OP_bndstx, (d), (s))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 destination, 1 implicit source */
 /** @name 1 destination, 1 implicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -1572,11 +1572,11 @@
 #define INSTR_CREATE_bswap(dc, d) instr_create_1dst_1src((dc), OP_bswap, (d), (d))
 #define INSTR_CREATE_not(dc, d) instr_create_1dst_1src((dc), OP_not, (d), (d))
 #define INSTR_CREATE_neg(dc, d) instr_create_1dst_1src((dc), OP_neg, (d), (d))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 implicit destination, 1 implicit source */
 /** @name 1 implicit destination, 1 implicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -1610,10 +1610,10 @@
 #define INSTR_CREATE_sysexit(dc)                                          \
     instr_create_1dst_1src((dc), OP_sysexit, opnd_create_reg(DR_REG_XSP), \
                            opnd_create_reg(DR_REG_XCX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name In with no explicit sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * Creates an instr_t for an OP_in instruction with a source of al
  * (INSTR_CREATE_in_1()) or eax (INSTR_CREATE_in_4()) and dx.
@@ -1625,9 +1625,9 @@
 #define INSTR_CREATE_in_4(dc)                                        \
     instr_create_1dst_1src((dc), OP_in, opnd_create_reg(DR_REG_EAX), \
                            opnd_create_reg(DR_REG_DX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name In with explicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * Creates an instr_t for an OP_in instruction with a source of al
  * (INSTR_CREATE_in_1_imm()) or eax (INSTR_CREATE_in_4_imm()) and an immediate.
@@ -1639,7 +1639,7 @@
     instr_create_1dst_1src((dc), OP_in, opnd_create_reg(DR_REG_AL), (i))
 #define INSTR_CREATE_in_4_imm(dc, i) \
     instr_create_1dst_1src((dc), OP_in, opnd_create_reg(DR_REG_EAX), (i))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -1664,7 +1664,7 @@
     INSTR_PRED(instr_create_1dst_1src((dc), (op), opnd_create_reg(DR_REG_ST0), (f)), \
                DR_PRED_O + instr_cmovcc_to_jcc(op) - OP_jo)
 /** @name Floating point with destination that is memory or fp register */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -1678,7 +1678,7 @@
     instr_create_1dst_1src((dc), OP_fst, (d), opnd_create_reg(DR_REG_ST0))
 #define INSTR_CREATE_fstp(dc, d) \
     instr_create_1dst_1src((dc), OP_fstp, (d), opnd_create_reg(DR_REG_ST0))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -1691,7 +1691,7 @@
 #define INSTR_CREATE_fld(dc, s) \
     instr_create_1dst_1src((dc), OP_fld, opnd_create_reg(DR_REG_ST0), (s))
 /** @name Floating-point with memory destination and implicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx_mem macro creates an instr_t with opcode OP_xxx and
  * the given explicit memory operand, automatically supplying any implicit operands.
@@ -1707,9 +1707,9 @@
     instr_create_1dst_1src((dc), OP_fisttp, (m), opnd_create_reg(DR_REG_ST0))
 #define INSTR_CREATE_fbstp(dc, m) \
     instr_create_1dst_1src((dc), OP_fbstp, (m), opnd_create_reg(DR_REG_ST0))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name Floating-point with memory source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx_mem macro creates an instr_t with opcode OP_xxx and
  * the given explicit memory operand, automatically supplying any implicit operands.
@@ -1721,9 +1721,9 @@
     instr_create_1dst_1src((dc), OP_fild, opnd_create_reg(DR_REG_ST0), (m))
 #define INSTR_CREATE_fbld(dc, m) \
     instr_create_1dst_1src((dc), OP_fbld, opnd_create_reg(DR_REG_ST0), (m))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name Floating-point implicit destination and implicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -1808,11 +1808,11 @@
     instr_create_2dst_2src((dc), OP_fprem1, opnd_create_reg(DR_REG_ST0),             \
                            opnd_create_reg(DR_REG_ST1), opnd_create_reg(DR_REG_ST0), \
                            opnd_create_reg(DR_REG_ST1))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 destination, 2 sources */
 /** @name 1 destination, 2 sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -1857,11 +1857,11 @@
     instr_create_1dst_2src((dc), OP_pinsrd, (d), (s), (i))
 #define INSTR_CREATE_aeskeygenassist(dc, d, s, i) \
     instr_create_1dst_2src((dc), OP_aeskeygenassist, (d), (s), (i))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 destination, 2 sources */
 /** @name 1 destination, 1 mask, and 2 sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -1899,10 +1899,10 @@
     instr_create_1dst_3src((dc), OP_vfpclassss, (d), (k), (i), (s))
 #define INSTR_CREATE_vfpclasssd_mask(dc, d, k, i, s) \
     instr_create_1dst_3src((dc), OP_vfpclasssd, (d), (k), (i), (s))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 1 destination, 2 non-immediate sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -2389,10 +2389,10 @@
     instr_create_1dst_2src((dc), OP_vcvtusi2sd, (d), (s1), (s2))
 #define INSTR_CREATE_vpextrq(dc, d, s1, s2) \
     instr_create_1dst_2src((dc), OP_vpextrq, (d), (s1), (s2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 1 destination, 1 mask, and 1 non-immediate source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx_mask macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands. The first source
@@ -2649,11 +2649,11 @@
 #define INSTR_CREATE_vsqrtpd_mask(dc, d, k, s) \
     instr_create_1dst_2src((dc), OP_vsqrtpd, (d), (k), (s))
 
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 destination, 2 sources: 1 explicit, 1 implicit */
 /** @name 1 destination, 2 sources: 1 explicit, 1 implicit */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -2932,10 +2932,10 @@
     instr_create_1dst_2src((dc), OP_sha256msg1, (d), (s), (d))
 #define INSTR_CREATE_sha256msg2(dc, d, s) \
     instr_create_1dst_2src((dc), OP_sha256msg2, (d), (s), (d))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 1 destination, 1 explicit register-or-immediate source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -2947,7 +2947,7 @@
 #define INSTR_CREATE_bts(dc, d, ri) instr_create_1dst_2src((dc), OP_bts, (d), (ri), (d))
 #define INSTR_CREATE_btr(dc, d, ri) instr_create_1dst_2src((dc), OP_btr, (d), (ri), (d))
 #define INSTR_CREATE_btc(dc, d, ri) instr_create_1dst_2src((dc), OP_btc, (d), (ri), (d))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /**
  * Creates an instr_t for a conditional move instruction with the given opcode
@@ -2983,7 +2983,7 @@
  */
 #define INSTR_CREATE_imul(dc, d, s) instr_create_1dst_2src((dc), OP_imul, (d), (s), (d))
 /** @name 1 implicit destination, 1 explicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx, INSTR_CREATE_xxx_1, or INSTR_CREATE_xxx_4 macro creates an
  * instr_t with opcode OP_xxx and the given explicit operands, automatically
@@ -3020,10 +3020,10 @@
     instr_create_2dst_3src((dc), OP_idiv, opnd_create_reg(DR_REG_EDX), \
                            opnd_create_reg(DR_REG_EAX), (s),           \
                            opnd_create_reg(DR_REG_EDX), opnd_create_reg(DR_REG_EAX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 1 destination, 1 explicit source that is cl, an immediate, or a constant */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -3044,10 +3044,10 @@
 #define INSTR_CREATE_shl(dc, d, ri) instr_create_1dst_2src((dc), OP_shl, (d), (ri), (d))
 #define INSTR_CREATE_shr(dc, d, ri) instr_create_1dst_2src((dc), OP_shr, (d), (ri), (d))
 #define INSTR_CREATE_sar(dc, d, ri) instr_create_1dst_2src((dc), OP_sar, (d), (ri), (d))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 1 implicit destination, 2 explicit sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -3076,11 +3076,11 @@
                                                                 OPSZ_maskmovdqu),      \
                                       (s1), (s2)),                                     \
                DR_PRED_COMPLEX)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* floating-point */
 /** @name Floating-point with explicit destination and explicit mem-or-fp-reg source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given operands, automatically supplying any further implicit operands.
@@ -3099,9 +3099,9 @@
 #define INSTR_CREATE_fdivr(dc, f, s) instr_create_1dst_2src((dc), OP_fdivr, (f), (s), (f))
 #define INSTR_CREATE_fsub(dc, f, s) instr_create_1dst_2src((dc), OP_fsub, (f), (s), (f))
 #define INSTR_CREATE_fsubr(dc, f, s) instr_create_1dst_2src((dc), OP_fsubr, (f), (s), (f))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name Floating-point with explicit destination and implicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with
  * opcode OP_xxx and the given explicit register operand, automatically
@@ -3122,9 +3122,9 @@
     instr_create_1dst_2src((dc), OP_fsubp, (f), opnd_create_reg(DR_REG_ST0), (f))
 #define INSTR_CREATE_fsubrp(dc, f) \
     instr_create_1dst_2src((dc), OP_fsubrp, (f), opnd_create_reg(DR_REG_ST0), (f))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name Floating-point with implicit destination and explicit memory source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit memory operand, automatically supplying any implicit operands.
@@ -3156,7 +3156,7 @@
 #define INSTR_CREATE_ficomp(dc, m)                                            \
     instr_create_1dst_2src((dc), OP_ficomp, opnd_create_reg(DR_REG_ST0), (m), \
                            opnd_create_reg(DR_REG_ST0))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
@@ -3209,7 +3209,7 @@
 
 /* 1 destination, 2 implicit sources */
 /** @name 1 destination, 2 implicit sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -3235,11 +3235,11 @@
 #define INSTR_CREATE_xsavec64(dc, d)                                            \
     instr_create_1dst_2src((dc), OP_xsavec64, (d), opnd_create_reg(DR_REG_EDX), \
                            opnd_create_reg(DR_REG_EAX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 implicit destination, 2 sources: 1 explicit, 1 implicit */
 /** @name 1 implicit destination, 2 sources: 1 explicit, 1 implicit */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -3253,9 +3253,9 @@
 #define INSTR_CREATE_aad(dc, i)                                           \
     instr_create_1dst_2src((dc), OP_aad, opnd_create_reg(DR_REG_AX), (i), \
                            opnd_create_reg(DR_REG_AX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name Loop instructions */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -3272,11 +3272,11 @@
 #define INSTR_CREATE_loop(dc, t)                                            \
     instr_create_1dst_2src((dc), OP_loop, opnd_create_reg(DR_REG_XCX), (t), \
                            opnd_create_reg(DR_REG_XCX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 implicit destination, 2 implicit sources */
 /** @name 1 implicit destination, 2 implicit sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -3304,11 +3304,11 @@
                            opnd_create_reg(DR_REG_XSP),                         \
                            opnd_create_base_disp(DR_REG_XSP, DR_REG_NULL, 0, 0, \
                                                  IF_X64_ELSE(OPSZ_40, OPSZ_12)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 destination, 3 sources */
 /** @name 1 destination, 3 non-immediate sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -3333,10 +3333,10 @@
     instr_create_1dst_3src((dc), OP_vpblendd, (d), (s1), (s2), (s3))
 #define INSTR_CREATE_vperm2i128(dc, d, s1, s2, s3) \
     instr_create_1dst_3src((dc), OP_vperm2i128, (d), (s1), (s2), (s3))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 1 destination, 1 mask, and 2 non-immediate sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx_mask macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands. The first source
@@ -3749,10 +3749,10 @@
     instr_create_1dst_3src((dc), OP_vsqrtss, (d), (k), (s1), (s2))
 #define INSTR_CREATE_vsqrtsd_mask(dc, d, k, s1, s2) \
     instr_create_1dst_3src((dc), OP_vsqrtsd, (d), (k), (s1), (s2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 1 destination, 3 sources including one immediate */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -3810,11 +3810,11 @@
     instr_create_1dst_3src((dc), OP_vperm2f128, (d), (s1), (s2), (i))
 #define INSTR_CREATE_vinsertf128(dc, d, s1, s2, i) \
     instr_create_1dst_3src((dc), OP_vinsertf128, (d), (s1), (s2), (i))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 destination, 3 sources: 1 implicit */
 /** @name 1 destination, 3 sources: 1 implicit */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -3830,9 +3830,9 @@
     instr_create_1dst_3src((dc), OP_shld, (d), (s), (ri), (d))
 #define INSTR_CREATE_shrd(dc, d, s, ri) \
     instr_create_1dst_3src((dc), OP_shrd, (d), (s), (ri), (d))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name 1 destination, 3 sources: 1 implicit, 1 immed */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -3850,9 +3850,9 @@
     instr_create_1dst_3src((dc), OP_blendpd, (d), (s), (i), (d))
 #define INSTR_CREATE_pblendw(dc, d, s, i) \
     instr_create_1dst_3src((dc), OP_pblendw, (d), (s), (i), (d))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name 1 explicit destination, 2 explicit sources, 1 implicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -3885,10 +3885,10 @@
 /* SHA */
 #define INSTR_CREATE_sha1rnds4(dc, d, s, i) \
     instr_create_1dst_3src((dc), OP_sha1rnds4, (d), (s), (i), (d))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 1 explicit destination, 2 explicit sources, dest is implicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -4018,10 +4018,10 @@
     instr_create_1dst_3src((dc), OP_vfnmsub231ss, (d), (s1), (s2), (d))
 #define INSTR_CREATE_vfnmsub231sd(dc, d, s1, s2) \
     instr_create_1dst_3src((dc), OP_vfnmsub231sd, (d), (s1), (s2), (d))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 1 explicit destination, 1 mask, 2 explicit sources, dest is implicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -4152,10 +4152,10 @@
     instr_create_1dst_4src((dc), OP_vfnmsub231ss, (d), (k), (s1), (s2), (d))
 #define INSTR_CREATE_vfnmsub231sd_mask(dc, d, k, s1, s2) \
     instr_create_1dst_4src((dc), OP_vfnmsub231sd, (d), (k), (s1), (s2), (d))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 1 explicit destination, 3 explicit sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -4239,9 +4239,9 @@
     instr_create_1dst_3src((dc), OP_vpermil2pd, (d), (s1), (s2), (s3))
 #define INSTR_CREATE_vpermil2ps(dc, d, s1, s2, s3) \
     instr_create_1dst_3src((dc), OP_vpermil2ps, (d), (s1), (s2), (s3))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name 1 destination, 3 sources where the final is an immediate */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -4268,10 +4268,10 @@
     instr_create_1dst_3src((dc), OP_vpcomud, (d), (s1), (s2), (i))
 #define INSTR_CREATE_vpcomuq(dc, d, s1, s2, i) \
     instr_create_1dst_3src((dc), OP_vpcomuq, (d), (s1), (s2), (i))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 1 explicit destination, 1 mask, 3 sources where the final is an immediate */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -4372,10 +4372,10 @@
     instr_create_1dst_4src((dc), OP_vpternlogd, (d), (k), (i), (s1), (s2))
 #define INSTR_CREATE_vpternlogq_mask(dc, d, k, i, s1, s2) \
     instr_create_1dst_4src((dc), OP_vpternlogq, (d), (k), (i), (s1), (s2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 1 destination, 3 sources where 2 are implicit */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -4394,11 +4394,11 @@
 #define INSTR_CREATE_sha256rnds2(dc, d, s)                                               \
     instr_create_1dst_3src((dc), OP_sha256rnds2, (d), (s), opnd_create_reg(DR_REG_XMM0), \
                            (d))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 implicit destination, 3 sources */
 /** @name 1 implicit destination, 3 sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -4420,11 +4420,11 @@
 #define INSTR_CREATE_vpcmpistri(dc, s1, s2, i)                                           \
     instr_create_1dst_3src((dc), OP_vpcmpistri, opnd_create_reg(DR_REG_ECX), (s1), (s2), \
                            (i))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 implicit destination, 3 sources: 2 implicit */
 /** @name 1 implicit destination, 3 sources: 2 implicit */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx_imm macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands. The _imm
@@ -4445,11 +4445,11 @@
                            opnd_create_reg(DR_REG_XSP),                         \
                            opnd_create_base_disp(DR_REG_XSP, DR_REG_NULL, 0, 0, \
                                                  IF_X64_ELSE(OPSZ_16, OPSZ_8)))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 1 implicit destination, 5 sources: 2 implicit */
 /** @name 1 implicit destination, 5 sources: 2 implicit */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the
  * given explicit operands, automatically supplying any implicit operands.
@@ -4476,7 +4476,7 @@
     instr_create_1dst_5src((dc), OP_vpcmpestri, opnd_create_reg(DR_REG_ECX), (s1), (s2), \
                            (i), opnd_create_reg(DR_REG_EAX),                             \
                            opnd_create_reg(DR_REG_EDX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 2 implicit destinations, no sources */
 /**
@@ -4490,7 +4490,7 @@
 
 /* 2 destinations: 1 implicit, 1 source */
 /** @name 2 destinations: 1 implicit, 1 source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -4508,11 +4508,11 @@
     instr_create_2dst_1src((dc), OP_lfs, (d), opnd_create_reg(DR_SEG_FS), (s))
 #define INSTR_CREATE_lgs(dc, d, s) \
     instr_create_2dst_1src((dc), OP_lgs, (d), opnd_create_reg(DR_SEG_GS), (s))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 2 implicit destinations, 1 implicit source */
 /** @name 2 implicit destinations, 1 implicit source */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -4532,7 +4532,7 @@
 #define INSTR_CREATE_xgetbv(dc)                                          \
     instr_create_2dst_1src((dc), OP_xgetbv, opnd_create_reg(DR_REG_EDX), \
                            opnd_create_reg(DR_REG_EAX), opnd_create_reg(DR_REG_ECX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 2 destinations: 1 implicit, 2 sources */
 /**
@@ -4546,7 +4546,7 @@
         (dc), OP_pop, (d), opnd_create_reg(DR_REG_XSP), opnd_create_reg(DR_REG_XSP), \
         opnd_create_base_disp(DR_REG_XSP, DR_REG_NULL, 0, 0, OPSZ_VARSTACK))
 /** @name 2 implicit destinations, 3 sources: 1 implicit */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -4571,10 +4571,10 @@
     instr_create_2dst_2src((dc), OP_vgatherqps, (d), (s2), (s1), (s2))
 #define INSTR_CREATE_vgatherqpd(dc, d, s1, s2) \
     instr_create_2dst_2src((dc), OP_vgatherqpd, (d), (s2), (s1), (s2))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /** @name 2 implicit destinations, 1 mask, andd 3 sources: The mask is implicit */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying the mask as an implicit operand.
@@ -4622,11 +4622,11 @@
     instr_create_2dst_2src((dc), OP_vscatterqps, (d), (k), (k), (s))
 #define INSTR_CREATE_vscatterqpd_mask(dc, d, k, s) \
     instr_create_2dst_2src((dc), OP_vscatterqpd, (d), (k), (k), (s))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 2 destinations: 1 implicit, 2 sources: 1 implicit */
 /** @name 2 destinations: 1 implicit, 2 sources: 1 implicit */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and the given
  * explicit operands, automatically supplying any implicit operands.
@@ -4638,11 +4638,11 @@
     instr_create_2dst_2src((dc), OP_xchg, (d), (s), (d), (s))
 #define INSTR_CREATE_xadd(dc, d, s) \
     instr_create_2dst_2src((dc), OP_xadd, (d), (s), (d), (s))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* string instructions */
 /** @name String instructions */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx_1 or INSTR_CREATE_xxx_4 macro creates an instr_t with opcode
  * OP_xxx, automatically supplying any implicit operands.  The _1 or _4 suffixes
@@ -4878,7 +4878,7 @@
                                                      0, 0, OPSZ_4_rex8_short2),          \
                            opnd_create_reg(DR_REG_EAX), opnd_create_reg(DR_REG_XDI),     \
                            opnd_create_reg(DR_REG_XCX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* floating point */
 /**
@@ -4983,7 +4983,7 @@
 
 /* 2 destinations: 1 implicit, 3 sources: 1 implicit */
 /** @name 2 destinations: 1 implicit, 3 sources: 1 implicit */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx_1, INSTR_CREATE_xxx_4, or INSTR_CREATE_xxx_8 macro creates an
  * instr_t with opcode OP_xxx and the given explicit operands, automatically
@@ -5002,7 +5002,7 @@
 #define INSTR_CREATE_cmpxchg_8(dc, d, s)                                                 \
     instr_create_2dst_3src((dc), OP_cmpxchg, (d), opnd_create_reg(DR_REG_RAX), (s), (d), \
                            opnd_create_reg(DR_REG_RAX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 2 implicit destinations, 3 implicit sources */
 /**
@@ -5017,7 +5017,7 @@
         opnd_create_base_disp(DR_REG_XBP, DR_REG_NULL, 0, 0, OPSZ_STACK))
 
 /** @name No destination, many implicit sources */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -5037,7 +5037,7 @@
                            opnd_create_reg(DR_REG_EBX), opnd_create_reg(DR_REG_ECX), \
                            opnd_create_reg(DR_REG_EDX), opnd_create_reg(DR_REG_EAX), \
                            opnd_create_reg(DR_REG_ECX))
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 
 /* 3 implicit destinations, 3 implicit sources */
 /**
@@ -5094,7 +5094,7 @@
 /****************************************************************************/
 
 /** @name Nops */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * Convenience routine for nop of certain size.  We choose edi as working register
  * for multibyte nops (seems least likely to impact performance: Microsoft uses it
@@ -5107,9 +5107,9 @@
 #define INSTR_CREATE_nop1byte(dc) INSTR_CREATE_nop(dc)
 #define INSTR_CREATE_nop2byte(dc) INSTR_CREATE_nop2byte_reg(dc, DR_REG_XDI)
 #define INSTR_CREATE_nop3byte(dc) INSTR_CREATE_nop3byte_reg(dc, DR_REG_XDI)
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 /** @name 2-byte reg nops */
-/* @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * Convenience routine for nop of certain size.
  * Note that Intel now recommends a different set of multi-byte nops,
@@ -5170,7 +5170,7 @@ INSTR_CREATE_nop3byte_reg(dcontext_t *dcontext, reg_id_t reg)
     }
 #endif
 }
-/* @} */ /* end doxygen group */
+/** @} */ /* end doxygen group */
 #ifndef UNSUPPORTED_API
 /* DR_API EXPORT END */
 #endif

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -55,7 +55,7 @@ extern "C" {
 /**
  * \addtogroup drbbdup Basic Block Duplicator
  */
-/*@{*/ /* begin doxygen group */
+/**@{*/ /* begin doxygen group */
 
 /** Success code for each drbbdup operation. */
 typedef enum {
@@ -432,7 +432,7 @@ DR_EXPORT
 drbbdup_status_t
 drbbdup_get_stats(OUT drbbdup_stats_t *stats);
 
-/*@}*/ /* end doxygen group */
+/**@}*/ /* end doxygen group */
 
 #ifdef __cplusplus
 }

--- a/ext/drcontainers/drtable.h
+++ b/ext/drcontainers/drtable.h
@@ -51,7 +51,7 @@ extern "C" {
 /**
  * \addtogroup drcontainers Container Data Structures
  */
-/*@{*/ /* begin doxygen group */
+/**@{*/ /* begin doxygen group */
 
 /**
  * Flags used for drtable_create
@@ -155,7 +155,7 @@ drtable_num_entries(void *tab);
 ptr_uint_t
 drtable_dump_entries(void *tab, file_t log);
 
-/*@}*/ /* end doxygen group */
+/**@}*/ /* end doxygen group */
 
 #ifdef __cplusplus
 }

--- a/ext/drcontainers/drvector.h
+++ b/ext/drcontainers/drvector.h
@@ -51,7 +51,7 @@ extern "C" {
 /**
  * \addtogroup drcontainers Container Data Structures
  */
-/*@{*/ /* begin doxygen group */
+/**@{*/ /* begin doxygen group */
 
 /** The storage for a vector. */
 typedef struct _drvector_t {
@@ -120,7 +120,7 @@ drvector_lock(drvector_t *vec);
 void
 drvector_unlock(drvector_t *vec);
 
-/*@}*/ /* end doxygen group */
+/**@}*/ /* end doxygen group */
 
 #ifdef __cplusplus
 }

--- a/ext/drcontainers/hashtable.h
+++ b/ext/drcontainers/hashtable.h
@@ -52,7 +52,7 @@ extern "C" {
 /**
  * \addtogroup drcontainers Container Data Structures
  */
-/*@{*/ /* begin doxygen group */
+/**@{*/ /* begin doxygen group */
 
 /** The type of hash key */
 typedef enum {
@@ -360,7 +360,7 @@ hashtable_resurrect(void *drcontext, byte **map /*INOUT*/, hashtable_t *table,
                     size_t entry_size, void *perscxt, hasthable_persist_flags_t flags,
                     bool (*process_payload)(void *key, void *payload, ptr_int_t shift));
 
-/*@}*/ /* end doxygen group */
+/**@}*/ /* end doxygen group */
 
 #ifdef __cplusplus
 }

--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -49,7 +49,7 @@ extern "C" {
 /**
  * \addtogroup drcovlib Code Coverage Library
  */
-/*@{*/ /* begin doxygen group */
+/**@{*/ /* begin doxygen group */
 
 /** Success code for each drcovlib operation */
 typedef enum {
@@ -392,7 +392,7 @@ drmodtrack_add_custom_data(void *(*load_cb)(module_data_t *module, int seg_idx),
                            const char *(*parse_cb)(const char *src, OUT void **data),
                            void (*free_cb)(void *data));
 
-/*@}*/ /* end doxygen group */
+/**@}*/ /* end doxygen group */
 
 #ifdef __cplusplus
 }

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -49,7 +49,7 @@ extern "C" {
 /**
  * \addtogroup drmgr Multi-Instrumentation Manager
  */
-/*@{*/ /* begin doxygen group */
+/**@{*/ /* begin doxygen group */
 
 #ifndef STATIC_DRMGR_ONLY
 /* A client can use a static function like drmgr_decode_sysnum_from_wrapper
@@ -1520,7 +1520,7 @@ DR_EXPORT
 bool
 drmgr_disable_auto_predication(void *drcontext, instrlist_t *ilist);
 
-/*@}*/ /* end doxygen group */
+/**@}*/ /* end doxygen group */
 
 #ifdef __cplusplus
 }

--- a/ext/drreg/drreg.h
+++ b/ext/drreg/drreg.h
@@ -53,7 +53,7 @@ extern "C" {
 /**
  * \addtogroup drreg Register Usage Coordinator
  */
-/*@{*/ /* begin doxygen group */
+/**@{*/ /* begin doxygen group */
 
 /** Success code for each drreg operation */
 typedef enum {
@@ -610,7 +610,7 @@ drreg_status_t
 drreg_is_instr_spill_or_restore(void *drcontext, instr_t *instr, bool *spill OUT,
                                 bool *restore OUT, reg_id_t *reg_spilled OUT);
 
-/*@}*/ /* end doxygen group */
+/**@}*/ /* end doxygen group */
 
 #ifdef __cplusplus
 }

--- a/ext/drsyms/drsyms.h
+++ b/ext/drsyms/drsyms.h
@@ -70,7 +70,7 @@ extern "C" {
 /**
  * \addtogroup drsyms Symbol Access Library
  */
-/*@{*/ /* begin doxygen group */
+/**@{*/ /* begin doxygen group */
 
 /** Success code for each DRSyms operation */
 typedef enum {
@@ -722,7 +722,7 @@ DR_EXPORT
 drsym_error_t
 drsym_enumerate_lines(const char *modpath, drsym_enumerate_lines_cb callback, void *data);
 
-/*@}*/ /* end doxygen group */
+/**@}*/ /* end doxygen group */
 
 #ifdef __cplusplus
 }

--- a/ext/drutil/drutil.h
+++ b/ext/drutil/drutil.h
@@ -37,7 +37,7 @@ extern "C" {
 /**
  * \addtogroup drutil Instrumentation Utilities
  */
-/*@{*/ /* begin doxygen group */
+/**@{*/ /* begin doxygen group */
 
 /***************************************************************************
  * INIT
@@ -185,7 +185,7 @@ bool
 drutil_expand_rep_string_ex(void *drcontext, instrlist_t *bb, OUT bool *expanded,
                             OUT instr_t **stringop);
 
-/*@}*/ /* end doxygen group */
+/**@}*/ /* end doxygen group */
 
 #ifdef __cplusplus
 }

--- a/ext/drwrap/drwrap.h
+++ b/ext/drwrap/drwrap.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2020 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2021 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /* drwrap: DynamoRIO Function Wrapping and Replacing Extension
@@ -39,7 +39,7 @@ extern "C" {
 /**
  * \addtogroup drwrap Function Wrapping and Replacing
  */
-/*@{*/ /* begin doxygen group */
+/**@{*/ /* begin doxygen group */
 
 /* Users of drwrap need to use the drmgr versions of these events to ensure
  * that drwrap's actions occur at the right time.
@@ -797,7 +797,7 @@ DR_EXPORT
 bool
 drwrap_get_stats(INOUT drwrap_stats_t *stats);
 
-/*@}*/ /* end doxygen group */
+/**@}*/ /* end doxygen group */
 
 #ifdef __cplusplus
 }

--- a/ext/drx/drx.h
+++ b/ext/drx/drx.h
@@ -47,7 +47,7 @@ extern "C" {
 /**
  * \addtogroup drx DynamoRIO eXtension utilities
  */
-/*@{*/ /* begin doxygen group */
+/**@{*/ /* begin doxygen group */
 
 /* i#1531: drx uses drmgr internally, so a client using drx cannot use
  * DR's TLS field routines directly.
@@ -534,7 +534,7 @@ DR_EXPORT
 bool
 drx_expand_scatter_gather(void *drcontext, instrlist_t *bb, OUT bool *expanded);
 
-/*@}*/ /* end doxygen group */
+/**@}*/ /* end doxygen group */
 
 #ifdef __cplusplus
 }

--- a/tools/arm_macros_gen.pl
+++ b/tools/arm_macros_gen.pl
@@ -642,7 +642,7 @@ foreach my $args (@order) {
     $sigline =~ s/\(, /(/;
     print $sigline;
     print ' */
-/* @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
+/** @{ */ /* start doxygen group (via DISTRIBUTE_GROUP_DOC=YES). */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx and
  * the given explicit operands, automatically supplying any implicit operands.
@@ -679,7 +679,7 @@ foreach my $args (@order) {
     foreach my $mac (sort @{$macro{$args}}) {
         print $mac;
     }
-    print '/* @} */ /* end doxygen group */
+    print '/** @} */ /* end doxygen group */
 ';
 }
 


### PR DESCRIPTION
The group delimiters @{ and @} in our headers were inside regular C
comments rather than Doxygen comments.  This worked fine with doxygen
through 1.8.13; but 1.8.17 and up ignore these group directives.  Here
we fix this by adding the extra asterisk.

Fixes #4749