### PR TITLE
i#4111 web: Update stale wiki links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,7 @@
 ---
 name: Bug report
 about: Create a report about a specific problem to help us improve
-title: Please follow the guidelines in our wiki at https://github.com/DynamoRIO/dynamorio/wiki/Bug-Reporting
-  and use one of the CRASH, APP CRASH, HANG, or ASSERT keywords.
+title: Edit me following https:///dynamorio.org/issues with one of the CRASH, APP CRASH, HANG, or ASSERT keywords.
 labels: ''
 assignees: ''
 
@@ -38,8 +37,7 @@ paste output here
 
 **Versions**
  - What version of DynamoRIO are you using?
- - Does the latest build from
-https://github.com/DynamoRIO/dynamorio/wiki/Latest-Build solve the problem?
+ - Does the latest build from https://github.com/DynamoRIO/dynamorio/releases solve the problem?
 - What operating system version are you running on? ("Windows 10" is *not* sufficient: give the release number.)
 - Is your application 32-bit or 64-bit?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ license](https://github.com/DynamoRIO/dynamorio/blob/master/License.txt).
 Our wiki contains further information on policies, how to check out the
 code, and how to add new code:
 
-- [Contribution policies and suggestions](https://github.com/DynamoRIO/dynamorio/wiki/Contributing)
-- [Git workflow](https://github.com/DynamoRIO/dynamorio/wiki/Workflow)
-- [Code style guide](https://github.com/DynamoRIO/dynamorio/wiki/Code-Style)
-- [Code content guidelines](https://github.com/DynamoRIO/dynamorio/wiki/Code-Content)
-- [Code reviews](https://github.com/DynamoRIO/dynamorio/wiki/Code-Reviews)
+- [Contribution policies and suggestions](https://dynamorio.org/page_contributing.html)
+- [Git workflow](https://dynamorio.org/page_workflow.html)
+- [Code style guide](https://dynamorio.org/page_code_style.html)
+- [Code content guidelines](https://dynamorio.org/page_code_content.html)
+- [Code reviews](https://dynamorio.org/page_code_reviews.html)
 
 ## Reporting issues
 
@@ -25,7 +25,7 @@ the issue tracker for the tool you are using and report the crash there.
 To report issues in DynamoRIO itself, please follow the guidelines below.
 
 For the Summary, please follow the [guidelines in our
-wiki](https://github.com/DynamoRIO/dynamorio/wiki/Bug-Reporting) and use
+bug reporting page](https://dynamorio.org/issues) and use
 one of the CRASH, APP CRASH, HANG, or ASSERT keywords.
 
 Please fill in the body of the issue with this template:
@@ -34,7 +34,7 @@ Please fill in the body of the issue with this template:
 What version of DynamoRIO are you using?
 
 Does the latest build from
-https://github.com/DynamoRIO/dynamorio/wiki/Latest-Build solve the problem?
+https://github.com/DynamoRIO/dynamorio/releases solve the problem?
 
 What operating system version are you running on?
 
@@ -56,7 +56,7 @@ What steps will reproduce the problem?
 
 What is the expected output? What do you see instead?  Is this an
 application crash, a DynamoRIO crash, a DynamoRIO assert, or a hang (see
-https://github.com/DynamoRIO/dynamorio/wiki/Bug-Reporting and set the title
+https://dynamorio.org/issues and set the title
 appropriately)?
 
 

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2017 Google, Inc. licensed under the terms of the BSD.  All other rights reserved.
+Copyright (c) 2010-2021 Google, Inc. licensed under the terms of the BSD.  All other rights reserved.
 Copyright (c) 2000-2010 VMware, Inc. licensed under the terms of the BSD.  All other rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -116,10 +116,10 @@ order to execute them.
 ************************************************************
 Instructions for building:
 
-If you are building from source, please see the DynamoRIO wiki for
+If you are building from source, please see the DynamoRIO site for
 information on the required tools on both Windows and Linux:
 
-https://github.com/DynamoRIO/dynamorio/wiki/How-To-Build
+https://dynamorio.org/page_building.html
 
 ************************************************************
 Getting help and reporting bugs:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Tools built on DynamoRIO and available in the [release package](https://dynamori
   [drcpusim](https://dynamorio.org/page_drcpusim.html)
 - The "strace for Windows" tool [drstrace](http://drmemory.org/strace_for_windows.html)
 - The code coverage tool [drcov](https://dynamorio.org/page_drcov.html)
-- The library tracing tool [drltrace](http://dynamorio.org/docs/page_drltrace.html)
+- The library tracing tool [drltrace](http://dynamorio.org/page_drltrace.html)
 - The memory address tracing tool [memtrace](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/memtrace_x86.c) ([drmemtrace](https://dynamorio.org/page_drcachesim.html)'s offline traces are faster with more surrounding infrastructure, but this is a simpler starting point for customized memory address tracing)
 - The memory value tracing tool [memval](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/memval_simple.c)
 - The instruction tracing tool [instrace](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/instrace_x86.c) ([drmemtrace](https://dynamorio.org/page_drcachesim.html)'s offline traces are faster with more surrounding infrastructure, but this is a simpler starting point for customized instruction tracing)
@@ -53,8 +53,8 @@ DynamoRIO's powerful API abstracts away the details of the underlying
 infrastructure and allows the tool builder to concentrate on analyzing or
 modifying the application's runtime code stream.  API documentation is
 included in the release package and can also be [browsed
-online](http://dynamorio.org/page_user_docs.html/).  [Slides from our past tutorials are
-also available](https://github.com/DynamoRIO/dynamorio/wiki/Downloads).
+online](http://dynamorio.org/page_user_docs.html).  [Slides from our past tutorials are
+also available](https://dynamorio.org/page_slides.html).
 
 ## Downloading DynamoRIO
 

--- a/api/docs/README.md
+++ b/api/docs/README.md
@@ -1,3 +1,3 @@
 This directory contains the doxygen source for the DynamoRIO public API
 and usage documentation, found at
-[dynamorio.org](http://dynamorio.org/docs/index.html)
+[dynamorio.org](http://dynamorio.org/index.html)

--- a/api/docs/home.dox
+++ b/api/docs/home.dox
@@ -77,7 +77,7 @@ Tools built on DynamoRIO and available in the [release package](@ref page_downlo
   [drcpusim](@ref page_drcpusim)
 - The "strace for Windows" tool [drstrace](http://drmemory.org/strace_for_windows.html)
 - The code coverage tool [drcov](@ref page_drcov)
-- The library tracing tool [drltrace](http://dynamorio.org/docs/page_drltrace.html)
+- The library tracing tool [drltrace](http://dynamorio.org/page_drltrace.html)
 - The memory address tracing tool [memtrace](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/memtrace_x86.c) ([drmemtrace](@ref page_drcachesim)'s offline traces are faster with more surrounding infrastructure, but this is a simpler starting point for customized memory address tracing)
 - The memory value tracing tool [memval](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/memval_simple.c)
 - The instruction tracing tool [instrace](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/instrace_x86.c) ([drmemtrace](@ref page_drcachesim)'s offline traces are faster with more surrounding infrastructure, but this is a simpler starting point for customized instruction tracing)

--- a/api/docs/ldstex.dox
+++ b/api/docs/ldstex.dox
@@ -218,7 +218,7 @@ Disadvantages:
 
 # Proposed Solution D: Run Twice
 
-One idea is to treat these sequences in a similar manner to restartable sequences (“rseq”), which have relatively similar restrictions on execution.  We handle those by running them twice, once with instrumentation and once “for real” natively with no instrumentation: https://github.com/DynamoRIO/dynamorio/wiki/Restartable-Sequences.
+One idea is to treat these sequences in a similar manner to restartable sequences (“rseq”), which have relatively similar restrictions on execution.  We handle those by running them twice, once with instrumentation and once “for real” natively with no instrumentation: \ref page_rseq.
 
 We’d execute the whole sequence in a normal manner, with regular instrumentation.  We’d remember the prior load-exclusive.  When we see a store-exclusive, we then insert a native copy of the whole sequence since the load-exclusive, which is executed if the store-exclusive fails.  If the native store-exclusive also fails, it would loop back to the start of the instrumented load-exclusive and repeat the whole process.
 

--- a/api/docs/test_suite.dox
+++ b/api/docs/test_suite.dox
@@ -275,7 +275,7 @@ suite (if run with -V):
 
 ```
 CMake Error: Some required settings in the configuration file were missing:
-CTEST_SOURCE_DIRECTORY = E:/derek/opensource/withwiki/trunk/suite/..
+CTEST_SOURCE_DIRECTORY = E:/derek/dr/suite/..
 CTEST_BINARY_DIRECTORY = (Null)
 CTEST_COMMAND = c:/PROGRA~2/CMAKE2~1.6/bin/ctest.exe
 ```

--- a/api/docs/workflow.dox
+++ b/api/docs/workflow.dox
@@ -32,9 +32,7 @@
 
 /**
  ****************************************************************************
-\page page_workflow Workflow
-
-# DynamoRIO Development Workflow
+\page page_workflow Development Workflow
 
 We use a centralized rebase workflow for our "master" branch combined with
 feature branches.  Each commit destined for master is first
@@ -49,7 +47,7 @@ rarely used.
 
 [Code reviews use pull requests](@ref page_code_reviews).
 
-## Getting the Code
+# Getting the Code
 
 Clone the repository, either via ssh if you've set up ssh keys in your
 Github profile:
@@ -64,7 +62,7 @@ Or via https:
 git clone https://github.com/DynamoRIO/dynamorio.git
 ~~~
 
-## Configuring Author Information and Aliases
+# Configuring Author Information and Aliases
 
 Before doing anything on a fresh clone, run the development setup script (commands for updating and for code reviews depend on it):
 
@@ -74,7 +72,7 @@ make/git/devsetup.sh
 
 Additionally, make sure that your full name is listed in the `Name` field at https://github.com/settings/profile and that a legitimate email address that represents you is set as your primary Github address at https://github.com/settings/emails.  Those two fields will be used for the author line for pull requests when they are squash-and-merged into master.  You must also uncheck `Keep my email address private` in the email settings page.
 
-## Working on a Small Feature or Bug Fix
+# Working on a Small Feature or Bug Fix
 
 Small features or bug fixes, i.e., those that will become a single commit
 in the master branch, use "feature branches".
@@ -94,7 +92,7 @@ git newbranch iNNNN-myfeature
 
 Now perform your work in the feature branch, committing locally.
 
-## Branch Naming Conventions
+\section sec_branch_naming Branch Naming Conventions
 
 For a small feature or bug fix, the name should start with the issue number prefixed by `i`, followed by a dash, followed by a short description.  For example, `i2172-maps-parsing` or `i2157-reattach`.  If there is no filed issue, use the `iX-` prefix.  For example, `iX-fix-readme-typo`. If there will be multiple changes for an issue, create a different branch for each subsequent change, prefixing them with the same naming convention (i.e. `i` followed by issue number). For example: `i2172-refactoring-raw2trace`, `i2172-adding-wrappers`, etc. Note also the [change naming conventions](@ref sec_commit_messages) in such a case.
 
@@ -102,7 +100,7 @@ Although often a feature branch is short-lived, sometimes experimental work is n
 
 For an experimental branch (see below), the name should start with `experimental-`.  For example, `experimental-jitopt`.
 
-## Merging upstream changes
+# Merging upstream changes
 
 The `git pullall` alias runs a script that does the right type of update depending on whether you're in a feature branch that has not yet been pushed to the Github repository (where we want a rebase) or in a branch that has already been pushed (where we want to rebase from the remote feature branch and merge from the upstream master).
 
@@ -117,14 +115,14 @@ than a rebase to avoid losing history in the pull request, and `git pullall` wil
 
 If you've pressed the Github button to update the feature branch with changes from master, and you now want to add a commit to your local branch (or have already added one), you want to pull the Github-added commit from the feature branch rather than master as a rebase.  As mentioned, `git pullall` does that for you (along with updating from master).
 
-## Requesting a Code Review and Merging to Master
+# Requesting a Code Review and Merging to Master
 
 Code reviews are requested by pushing the feature branch to Github and then
 creating a pull request onto master.  See
 [code review details here](@ref page_code_reviews).
 Merges to master occur only via pull request.
 
-## Deleting a Feature Branch
+# Deleting a Feature Branch
 
 Once your changes have been merged into master, you can delete your feature
 branch with these commands (substituting your branch's name for "feature"):
@@ -135,7 +133,7 @@ git pullall
 git branch -d feature
 ~~~
 
-## Checking Out an Existing Feature Branch
+# Checking Out an Existing Feature Branch
 
 You can check out an existing feature branch `iNNNN-name` via:
 
@@ -151,7 +149,7 @@ git fetch origin
 git checkout -b iNNNN-name remotes/origin/iNNNN-name
 ~~~
 
-## Splitting Up a Feature Branch
+# Splitting Up a Feature Branch
 
 If you want to split off the first commit or two from a feature branch and
 you issue a command like this:
@@ -174,20 +172,20 @@ once with:
 git split tocheckin 35d4e9c87de22ec9b3a8a110cae2d83821c88ee0
 ~~~
 
-## Large Features or Projects
+# Large Features or Projects
 
 For larger features or projects which will end up containing many commits,
 the workflow is unchanged.  Work proceeds incrementally, with each small
 piece being committed to master using a feature branch and pull request.
 
-## Experimental Branches
+# Experimental Branches
 
 For experimental, quick-and-dirty work, especially where the work was already finished privately or where for time constraints and other reasons the regular development process is not suitable, we support experimental branches.  The idea is to promote sharing of academic prototypes and other projects, with the goal of sharing the ideas immediately and making it more likely that the ideas will be eventually integrated into master, by separating the initial sharing from the later clean up and incremental code review.  As described above, experimental branch names start with `experimental-`.
 
 Please note that like other contributions, code contributed to an experimental branch is
 [offered under the terms of our license](@ref page_contributing).
 
-## Useful Aliases
+# Useful Aliases
 
 Some potentially useful aliases that are not in the development setup
 script include the common tasks of looking at the log of changes versus the
@@ -203,7 +201,7 @@ And looking at the full diff versus the remote master:
 git config alias.ddiff "diff origin/master.."
 ~~~
 
-## No Merge Commits on Master
+# No Merge Commits on Master
 
 Our workflow uses fast-forward-merge and rebase when merging into the
 master branch.  We do not want any merge commits on the master

--- a/api/samples/README.md
+++ b/api/samples/README.md
@@ -1,5 +1,5 @@
 This directory contains
-[sample DynamoRIO clients](http://dynamorio.org/docs/API_samples.html),
+[sample DynamoRIO clients](http://dynamorio.org/API_samples.html),
 which can be directly
 used for analysis or extended with additional functionality. Details about
 each client can be found in the source code comments at the top of each file.

--- a/clients/drcachesim/README.md
+++ b/clients/drcachesim/README.md
@@ -1,3 +1,3 @@
-[drcachesim](http://dynamorio.org/docs/page_drcachesim.html) is a DynamoRIO client
+[drcachesim](http://dynamorio.org/page_drcachesim.html) is a DynamoRIO client
 tool that gathers memory reference information from multiple processes
 simultaneously and feeds it to an online cache simulator.

--- a/clients/drcov/README.md
+++ b/clients/drcov/README.md
@@ -1,2 +1,2 @@
-[drcov](http://dynamorio.org/docs/page_drcov.html) is a DynamoRIO client tool that
+[drcov](http://dynamorio.org/page_drcov.html) is a DynamoRIO client tool that
 collects code coverage information.

--- a/clients/drcpusim/README.md
+++ b/clients/drcpusim/README.md
@@ -1,4 +1,4 @@
-[drcpusim](http://dynamorio.org/docs/page_drcpusim.html) is a DynamoRIO
+[drcpusim](http://dynamorio.org/page_drcpusim.html) is a DynamoRIO
 client tool that emulates execution on a specified CPU model in order to
 validate that a target application does not execute any instructions that
 are illegal or not implemented on a legacy processor.

--- a/core/README.md
+++ b/core/README.md
@@ -1,4 +1,4 @@
 This directory contains the core implementation of DynamoRIO. Documentation for
-client developers can be found in the [public API](http://dynamorio.org/docs/index.html),
+client developers can be found in the [public API](http://dynamorio.org/index.html),
 where interface and data structures are found in the *Files* and *Data Structures* tabs,
 respectively.

--- a/core/annotations.c
+++ b/core/annotations.c
@@ -1,5 +1,5 @@
 /* ******************************************************
- * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2021 Google, Inc.  All rights reserved.
  * ******************************************************/
 
 /*
@@ -839,7 +839,7 @@ valgrind_running_on_valgrind(dr_vg_client_request_t *request)
  *              (note there is a special case for Windows x64, which is not inline asm)
  *     (step 7) if it matches, point `**name` to the character beyond the separator ':'
  *
- * See https://github.com/DynamoRIO/dynamorio/wiki/Annotations for complete examples.
+ * See https://dynamorio.org/page_annotations.html for complete examples.
  */
 static inline bool
 is_annotation_tag(dcontext_t *dcontext, IN OUT app_pc *cur_pc, instr_t *scratch,
@@ -947,7 +947,7 @@ identify_annotation(dcontext_t *dcontext, IN OUT annotation_layout_t *layout,
         /* If the target app contains an annotation whose argument is a function call
          * that gets inlined, and that function contains the same annotation, the
          * compiler will fuse the headers. See
-         * https://github.com/DynamoRIO/dynamorio/wiki/Annotations for a sample of
+         * https://dynamorio.org/page_annotations.html for a sample of
          * fused headers. This loop identifies and skips any fused headers.
          */
         while (true) {

--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -110,7 +110,7 @@
  * appropriate offset in ldr for the 8-byte aligned 8 byte region within it.
  *
  * For complete design details, see the following wiki
- * https://github.com/DynamoRIO/dynamorio/wiki/Linking-Far-Fragments-on-AArch64
+ * https://dynamorio.org/page_aarch64_far.html
  */
 
 byte *

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -2955,9 +2955,8 @@ mangle_icache_op(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
 
 /***************************************************************************
  * Exclusive load/store mangling.
- * See the design doc at
- * https://github.com/DynamoRIO/dynamorio/wiki/Exclusive-Monitors for background
- * information.
+ * See the design doc at https://dynamorio.org/page_ldstex.html
+ * for background information.
  */
 
 static instr_t *
@@ -3611,8 +3610,7 @@ mangle_exclusive_monitor_op(dcontext_t *dcontext, instrlist_t *ilist, instr_t *i
     /* For -ldstex2cas we convert exclusive monitor regions into compare-and-swap
      * operations in order to allow regular instrumentation, with the downside of
      * weaker synchronization semantics.
-     * See https://github.com/DynamoRIO/dynamorio/wiki/Exclusive-Monitors for
-     * background and further details.
+     * See https://dynamorio.org/page_ldstex.html for background and further details.
      * The summary is:
      * + On an exclusive load, save the address, value, opcode, and size,
      *   and convert to a non-exclusive load.

--- a/core/lib/dr_annotations_asm.h
+++ b/core/lib/dr_annotations_asm.h
@@ -1,5 +1,5 @@
 /* ******************************************************
- * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2021 Google, Inc.  All rights reserved.
  * ******************************************************/
 
 /*
@@ -34,7 +34,7 @@
 #define _DYNAMORIO_ANNOTATIONS_ASM_H_ 1
 
 /* This header defines the annotation functions and code sequences. For a high-level
- * overview, see the wiki page https://github.com/DynamoRIO/dynamorio/wiki/Annotations.
+ * overview, see https://dynamorio.org/page_annotations.html.
  */
 
 /* To simplify project configuration, this pragma excludes the file from GCC warnings. */

--- a/ext/README.md
+++ b/ext/README.md
@@ -1,3 +1,3 @@
 DynamoRIO provides additional optional capabilities via
-[DynamoRIO Extensions](http://dynamorio.org/docs/page_ext.html) separate libraries that a
+[DynamoRIO Extensions](http://dynamorio.org/page_ext.html) separate libraries that a
 client can link to.

--- a/ext/drcontainers/README.md
+++ b/ext/drcontainers/README.md
@@ -1,3 +1,3 @@
-The [drcontainers](http://dynamorio.org/docs/page_drcontainers.html) DynamoRIO Extension
+The [drcontainers](http://dynamorio.org/page_drcontainers.html) DynamoRIO Extension
 provides container data structures that use the DR API for memory allocation and
 synchronization.

--- a/ext/drgui/README.md
+++ b/ext/drgui/README.md
@@ -1,3 +1,3 @@
-The [drgui](http://dynamorio.org/docs/page_drgui.html) DynamoRIO Extension provides a
+The [drgui](http://dynamorio.org/page_drgui.html) DynamoRIO Extension provides a
 DynamoRIO independent graphical application framework that can be used to provide a
 front-end for a DynamoRIO Extension or tool.

--- a/ext/drmgr/README.md
+++ b/ext/drmgr/README.md
@@ -1,2 +1,2 @@
-The [drmgr](http://dynamorio.org/docs/page_drmgr.html) DynamoRIO Extension provides a
+The [drmgr](http://dynamorio.org/page_drmgr.html) DynamoRIO Extension provides a
 mediator for combining and coordinating multiple instrumentation passes.

--- a/ext/drsyms/README.md
+++ b/ext/drsyms/README.md
@@ -1,3 +1,3 @@
-The [drsyms](http://dynamorio.org/docs/page_drsyms.html) DynamoRIO Extension provides
+The [drsyms](http://dynamorio.org/page_drsyms.html) DynamoRIO Extension provides
 symbol information. Currently drsyms supports reading symbol information from Windows PDB
 files or Linux ELF, Mac Mach-O, or from Windows PECOFF files with DWARF2 line information.

--- a/ext/drutil/README.md
+++ b/ext/drutil/README.md
@@ -1,2 +1,2 @@
-The [drutil](http://dynamorio.org/docs/page_drutil.html) DynamoRIO Extension provides
+The [drutil](http://dynamorio.org/page_drutil.html) DynamoRIO Extension provides
 various utilities for inserting instrumentation.

--- a/ext/drwrap/README.md
+++ b/ext/drwrap/README.md
@@ -1,2 +1,2 @@
-The [drwrap](http://dynamorio.org/docs/page_drwrap.html) DynamoRIO Extension provides
+The [drwrap](http://dynamorio.org/page_drwrap.html) DynamoRIO Extension provides
 function wrapping and replacing support.

--- a/ext/drx/README.md
+++ b/ext/drx/README.md
@@ -1,3 +1,3 @@
-The [drx](http://dynamorio.org/docs/page_drx.html) DynamoRIO Extension provides various
+The [drx](http://dynamorio.org/page_drx.html) DynamoRIO Extension provides various
 utilities for instrumentation and sports a BSD license, as opposed to the drutil Extension
 which also contains instrumentation utilities but uses an LGPL 2.1 license.

--- a/libutil/README.md
+++ b/libutil/README.md
@@ -1,4 +1,4 @@
 This directory contains utilities
-[drconfiglib](http://dynamorio.org/docs/dr__config_8h.html) and
-[drfrontendlib](http://dynamorio.org/docs/dr__frontend_8h.html), along with many internal
+[drconfiglib](http://dynamorio.org/dr__config_8h.html) and
+[drfrontendlib](http://dynamorio.org/dr__frontend_8h.html), along with many internal
 utilities for which there is no public documentation.

--- a/make/README.md
+++ b/make/README.md
@@ -1,3 +1,3 @@
 This directory contains utilities for the DynamoRIO build. See the
-[wiki page](https://github.com/DynamoRIO/dynamorio/wiki/How-To-Build) for build
+[web page](https://dynamorio.org/page_building.html) for build
 instructions.

--- a/make/git/git_review.sh
+++ b/make/git/git_review.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # **********************************************************
-# Copyright (c) 2014-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2014-2021 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -40,7 +40,7 @@ if [ "${prefix}" == "${branch}" ] ||
       # Check whether a number.
       [ "${prefix:1}" -eq "${prefix:1}" ] 2>/dev/null); then
     echo "ERROR: please use the branch naming conventions documented at "
-    echo "https://github.com/DynamoRIO/dynamorio/wiki/Workflow#branch-naming-conventions"
+    echo "https://dynamorio.org/page_workflow.html#sec_branch_naming"
     exit 1
 fi
 

--- a/suite/README.md
+++ b/suite/README.md
@@ -1,3 +1,3 @@
 The black box test suite for DynamoRIO resides in this directory.
-See the [wiki page](https://github.com/DynamoRIO/dynamorio/wiki/Test-Suite) for details
-and instructions to run the tests.
+See the [web page](https://dynamorio.org/page_test_suite.html) for details
+and instructions on runnning the tests.


### PR DESCRIPTION
Updates links to the now-moved wiki pages.
Updates the Worklow page to remove a superfluous section layer.

Issue: #4111