### PR TITLE
i#4777: Fix uninitialized drmodtrack offset on Windows

### DIFF
--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -256,6 +256,7 @@ typedef struct _drmodtrack_info_t {
     uint index;
     /**
      * The offset of this segment from the beginning of this backing file.
+     * On Windows this field is always 0.
      */
     uint64 offset;
 } drmodtrack_info_t;

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -459,8 +459,9 @@ module_table_entry_print(module_entry_t *entry, char *buf, size_t size)
 #endif
     read_entry.path = full_path;
     read_entry.custom = entry->custom;
-    // For unices we record the physical offset from the backing file
-    // (always 0 on Windows).
+    /* For unices we record the physical offset from the backing file
+     *(always 0 on Windows).
+     */
     read_entry.offset = entry->offset;
     return module_read_entry_print(&read_entry, entry->id, buf, size);
 }

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -1,5 +1,5 @@
 /* ***************************************************************************
- * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
  * ***************************************************************************/
 
 /*
@@ -55,10 +55,8 @@ typedef struct _module_entry_t {
      */
     module_data_t *data;
     void *custom;
-#ifndef WINDOWS
     /* The file offset of the segment */
     uint64 offset;
-#endif
 } module_entry_t;
 
 typedef struct _module_table_t {
@@ -191,7 +189,9 @@ event_module_load(void *drcontext, const module_data_t *data, bool loaded)
         if (module_load_cb != NULL)
             entry->custom = module_load_cb(entry->data, 0);
         drvector_append(&module_table.vector, entry);
-#ifndef WINDOWS
+#ifdef WINDOWS
+        entry->offset = 0;
+#else
         entry->offset = data->segments[0].offset;
         uint j;
         module_entry_t *sub_entry;
@@ -459,10 +459,9 @@ module_table_entry_print(module_entry_t *entry, char *buf, size_t size)
 #endif
     read_entry.path = full_path;
     read_entry.custom = entry->custom;
-#ifndef WINDOWS
-    // For unices we record the physical offset from the backing file.
+    // For unices we record the physical offset from the backing file
+    // (always 0 on Windows).
     read_entry.offset = entry->offset;
-#endif
     return module_read_entry_print(&read_entry, entry->id, buf, size);
 }
 


### PR DESCRIPTION
PR #2940 and #2973 added an offset field to drmodtrack for #2939, but
they ifdef-ed the field in some places but not others, resulting in
uninitialized output.  Since it's already locked into the interface,
we always set it to 0 here and include it in internal structures to
fix the problem.

Tested on drmodtrack-test where the fields were manually confirmed to
no longer contain bogus values, and where the test doesn't fail when
i#4474 adds a new field that shifts the test buffer to avoid the
happens-to-match scenario that masked this bug in that test before.

Issue: #2939, #4474, #4777
Fixes #4777