### PR TITLE
i#4780: Run apt-get update before every install

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -66,9 +66,6 @@ jobs:
 
     # Install cross-compiler for cross-compiling Linux build:
     - name: Create Build Environment
-      # We need the apt-get update to avoid stale version 404 errors.
-      # (We assume this is limited to ubuntu-20.04 and save 30s on other
-      # jobs by not running update there.)
       run: |
         sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
@@ -122,9 +119,6 @@ jobs:
 
     # Install cross-compiler for cross-compiling Linux build:
     - name: Create Build Environment
-      # We need the apt-get update to avoid stale version 404 errors.
-      # (We assume this is limited to ubuntu-20.04 and save 30s on other
-      # jobs by not running update there.)
       run: |
         sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
@@ -178,6 +172,7 @@ jobs:
     # Fetch and install Android NDK for Andoid cross-compile build.
     - name: Create Build Environment
       run: |
+        sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev
         cd /tmp
         wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
@@ -238,6 +233,7 @@ jobs:
 
     - name: Create Build Environment
       run: |
+        sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev
 
     - name: Run Suite

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -156,7 +156,7 @@ jobs:
 
   # Android ARM cross-compile with gcc, no tests:
   android-arm-cross-compile:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v2
@@ -218,7 +218,7 @@ jobs:
 
   # AArch64 drdecode and drmemtrace on x86:
   a64-on-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -156,7 +156,7 @@ jobs:
 
   # Android ARM cross-compile with gcc, no tests:
   android-arm-cross-compile:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2
@@ -218,7 +218,7 @@ jobs:
 
   # AArch64 drdecode and drmemtrace on x86:
   a64-on-x86:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -70,7 +70,12 @@ jobs:
     # Install multilib for non-cross-compiling Linux build:
     - name: Create Build Environment
       run: |
-        sudo apt-get update
+        # Work around Github Actions apt problems installing multilib
+        # (see https://github.com/actions/virtual-environments/issues/2917).
+        sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y
+        sudo apt update
+        sudo env ACCEPT_EULA=Y apt upgrade
+        sudo apt-get purge gcc-5 gcc-5-base gcc-6-base
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-multilib
 

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          g++-multilib
+          gcc-multilib  g++-multilib
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -54,7 +54,7 @@ jobs:
   # the CI resources: 64-bit hits most clang-only warnings and 64-bit
   # is the primary target these days.
   clang-format:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2
@@ -72,7 +72,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          gcc-5-multilib g++-5-multilib
+          g++-multilib
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020 Google, Inc.  All rights reserved.
+# Copyright (c) 2020-2021 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -70,6 +70,7 @@ jobs:
     # Install multilib for non-cross-compiling Linux build:
     - name: Create Build Environment
       run: |
+        sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-multilib
 

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          gcc-multilib  g++-multilib
+          gcc-5-multilib g++-5-multilib
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -71,8 +71,8 @@ jobs:
     - name: Create Build Environment
       run: |
         sudo apt-get update
-        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          gcc-5-multilib g++-5-multilib
+        sudo apt-get -oDebug::pkgAcquire::Worker=1 -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
+          gcc-6-multilib g++-6-multilib
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -67,17 +67,9 @@ jobs:
 
     - run: git fetch --no-tags --depth=1 origin master
 
-    # Install multilib for non-cross-compiling Linux build:
     - name: Create Build Environment
       run: |
-        # Work around Github Actions apt problems installing multilib
-        # (see https://github.com/actions/virtual-environments/issues/2917).
-        sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y
-        sudo apt update
-        sudo env ACCEPT_EULA=Y apt upgrade
-        sudo apt-get purge gcc-5 gcc-5-base gcc-6-base
-        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          g++-multilib
+        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -54,7 +54,7 @@ jobs:
   # the CI resources: 64-bit hits most clang-only warnings and 64-bit
   # is the primary target these days.
   clang-format:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v2
@@ -72,7 +72,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          g++-multilib
+          gcc-5-multilib g++-5-multilib
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -71,8 +71,8 @@ jobs:
     - name: Create Build Environment
       run: |
         sudo apt-get update
-        sudo apt-get -oDebug::pkgAcquire::Worker=1 -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          gcc-6-multilib g++-6-multilib
+        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
+          g++-multilib
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -73,6 +73,7 @@ jobs:
     # Install needed packages.
     - name: Create Build Environment
       run: |
+        sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev
 
     - name: Get Version

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -72,6 +72,7 @@ jobs:
     # Install multilib for non-cross-compiling Linux build:
     - name: Create Build Environment
       run: |
+        sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-multilib
 
@@ -152,6 +153,7 @@ jobs:
     # Install cross-compilers for cross-compiling Linux build:
     - name: Create Build Environment
       run: |
+        sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
 
@@ -225,6 +227,7 @@ jobs:
     # Install cross-compilers for cross-compiling Linux build:
     - name: Create Build Environment
       run: |
+        sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
 
@@ -298,6 +301,7 @@ jobs:
     # Fetch and install Android NDK for Andoid cross-compile build.
     - name: Create Build Environment
       run: |
+        sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev
         cd /tmp
         wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -55,7 +55,7 @@ jobs:
   ###########################################################################
   # Linux x86 tarball with 64-bit and 32-bit builds:
   linux-x86:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2
@@ -138,7 +138,7 @@ jobs:
   ###########################################################################
   # Linux AArch64 tarball:
   linux-aarch64:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2
@@ -212,7 +212,7 @@ jobs:
   ###########################################################################
   # Linux ARM tarball (package.cmake does not support same job as AArch64):
   linux-arm:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2
@@ -286,7 +286,7 @@ jobs:
   ###########################################################################
   # Android ARM tarball:
   android-arm:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2
@@ -465,7 +465,7 @@ jobs:
 
   create_release:
     needs: [linux-x86, linux-aarch64, linux-arm, android-arm, windows]
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
       # We need a checkout to run git log for the version.

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -55,7 +55,7 @@ jobs:
   ###########################################################################
   # Linux x86 tarball with 64-bit and 32-bit builds:
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v2
@@ -138,7 +138,7 @@ jobs:
   ###########################################################################
   # Linux AArch64 tarball:
   linux-aarch64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v2
@@ -212,7 +212,7 @@ jobs:
   ###########################################################################
   # Linux ARM tarball (package.cmake does not support same job as AArch64):
   linux-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v2
@@ -286,7 +286,7 @@ jobs:
   ###########################################################################
   # Android ARM tarball:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v2
@@ -465,7 +465,7 @@ jobs:
 
   create_release:
     needs: [linux-x86, linux-aarch64, linux-arm, android-arm, windows]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     steps:
       # We need a checkout to run git log for the version.

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -72,7 +72,12 @@ jobs:
     # Install multilib for non-cross-compiling Linux build:
     - name: Create Build Environment
       run: |
-        sudo apt-get update
+        # Work around Github Actions apt problems installing multilib
+        # (see https://github.com/actions/virtual-environments/issues/2917).
+        sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y
+        sudo apt update
+        sudo env ACCEPT_EULA=Y apt upgrade
+        sudo apt-get purge gcc-5 gcc-5-base gcc-6-base
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-multilib
 

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -55,7 +55,7 @@ defaults:
 jobs:
   # 32-bit Linux build with gcc and run tests:
   x86-32:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     # When checking out the repository that triggered a workflow, actions/checkout@v2
     # defaults to the reference or SHA for that event. See documentation for ref at
@@ -115,7 +115,7 @@ jobs:
 
   # 64-bit Linux build with gcc and run tests:
   x86-64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -55,7 +55,7 @@ defaults:
 jobs:
   # 32-bit Linux build with gcc and run tests:
   x86-32:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     # When checking out the repository that triggered a workflow, actions/checkout@v2
     # defaults to the reference or SHA for that event. See documentation for ref at
@@ -115,7 +115,7 @@ jobs:
 
   # 64-bit Linux build with gcc and run tests:
   x86-64:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020 Google, Inc.  All rights reserved.
+# Copyright (c) 2020-2021 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -79,6 +79,7 @@ jobs:
     # Install multilib for non-cross-compiling Linux build:
     - name: Create Build Environment
       run: |
+        sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-multilib
 
@@ -130,6 +131,7 @@ jobs:
     # Install multilib for non-cross-compiling Linux build:
     - name: Create Build Environment
       run: |
+        sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-multilib
 

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -79,7 +79,12 @@ jobs:
     # Install multilib for non-cross-compiling Linux build:
     - name: Create Build Environment
       run: |
-        sudo apt-get update
+        # Work around Github Actions apt problems installing multilib
+        # (see https://github.com/actions/virtual-environments/issues/2917).
+        sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y
+        sudo apt update
+        sudo env ACCEPT_EULA=Y apt upgrade
+        sudo apt-get purge gcc-5 gcc-5-base gcc-6-base
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-multilib
 
@@ -131,7 +136,12 @@ jobs:
     # Install multilib for non-cross-compiling Linux build:
     - name: Create Build Environment
       run: |
-        sudo apt-get update
+        # Work around Github Actions apt problems installing multilib
+        # (see https://github.com/actions/virtual-environments/issues/2917).
+        sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y
+        sudo apt update
+        sudo env ACCEPT_EULA=Y apt upgrade
+        sudo apt-get purge gcc-5 gcc-5-base gcc-6-base
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-multilib
 


### PR DESCRIPTION
Avoids installation errors due to stale data by running "apt-get
update" prior to every install.  Unfortunately this adds 30s to each
job, but it is unavoidable it seems on these GA CI VM's.

Fixes #4780