### PR TITLE
i#4780 apt: Remove multilib workaround

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -72,12 +72,7 @@ jobs:
     # Install multilib for non-cross-compiling Linux build:
     - name: Create Build Environment
       run: |
-        # Work around Github Actions apt problems installing multilib
-        # (see https://github.com/actions/virtual-environments/issues/2917).
-        sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y
         sudo apt update
-        sudo env ACCEPT_EULA=Y apt upgrade
-        sudo apt-get purge gcc-5 gcc-5-base gcc-6-base
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-multilib
 

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -79,12 +79,7 @@ jobs:
     # Install multilib for non-cross-compiling Linux build:
     - name: Create Build Environment
       run: |
-        # Work around Github Actions apt problems installing multilib
-        # (see https://github.com/actions/virtual-environments/issues/2917).
-        sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y
         sudo apt update
-        sudo env ACCEPT_EULA=Y apt upgrade
-        sudo apt-get purge gcc-5 gcc-5-base gcc-6-base
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-multilib
 
@@ -136,12 +131,7 @@ jobs:
     # Install multilib for non-cross-compiling Linux build:
     - name: Create Build Environment
       run: |
-        # Work around Github Actions apt problems installing multilib
-        # (see https://github.com/actions/virtual-environments/issues/2917).
-        sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y
         sudo apt update
-        sudo env ACCEPT_EULA=Y apt upgrade
-        sudo apt-get purge gcc-5 gcc-5-base gcc-6-base
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
           g++-multilib
 


### PR DESCRIPTION
The underlying issue behind the multilib apt problems has been
resolved so we no longer need the workaround.

Issue: #4780