### PR TITLE
i#4111 web: Reduce docs cronbuilds to weekly

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -32,9 +32,12 @@
 
 name: ci-docs
 on:
-  # Built daily at 2am EST.
+  # Built weekly: 10pm EST Fridays.  A re-build even with no content
+  # changes updates timestamps on every page, increasing the repo size.
+  # We thus use manual builds for rare docs changes we want to deploy to
+  # the website and have automated builds match our weekly package builds.
   schedule:
-    - cron: '0 7 * * *'
+    - cron: '0 3 * * FRI'
   # Manual trigger using the Actions page.
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
The daily docs cronbuilds are steadily increasing the size of the
repo, due to timestamps in every single file changing every time.
Given that we rarely make docs changes that we want to make live
immediately, we reduce the cronbuild to coincide with the package
build, and rely on manually-triggered docs builds for anything else.

Issue: #4111