### PR TITLE
i#4719 qemu: Add user docs on running under QEMU

### DIFF
--- a/api/docs/deployment.dox
+++ b/api/docs/deployment.dox
@@ -367,6 +367,7 @@ An alternative method to run an application under DynamoRIO is the \ref
 sec_startstop "app_start()/app_stop()" interface, which requires modifying
 application source code.
 
+
 \section android_deploy Android Deployment
 
 Android deployment is generally the same as \ref lin_deploy except for the
@@ -411,6 +412,45 @@ SELinux denials (look in the logs for such denials), it may be simplest to
 disable SELinux via <tt>setenforce 0</tt>.  We have attempted to get
 everything to work without this step, but we are not able to test on all
 versions or configurations of Android.
+
+
+\section qemu_deploy Running Under QEMU
+
+To run DynamoRIO under QEMU, use the \ref op_xarch_root "-xarch_root"
+option to point at the base directory of the guest system libraries.
+This is the same path passed to QEMU's `-L` option:
+
+```
+$ qemu-arm -L /usr/arm-linux-gnueabihf bin32/drrun -xarch_root /usr/arm-linux-gnueabihf -- hello_world
+```
+
+Be sure to install both the `qemu-user` and `qemu-user-binfmt`
+packages in order for QEMU to impose itself across an execve:
+
+```
+$ sudo apt-get install qemu-user qemu-user-binfmt
+```
+
+If using a custom build of QEMU, be sure to update the binfmt rule to
+ensure the proper build is used across execve: QEMU does *not* ensure
+that the same build is preserved and instead relies on the global
+binfmt rule.  On an Ubuntu system, edit `/usr/share/binfmts/qemu-arm`
+and replace the `interpreter` path.  Then run:
+
+```
+$ sudo update-binfmts --import /usr/share/binfmts/qemu-arm
+```
+
+Confirm the change took effect:
+```
+$ update-binfmts --find bin32/drrun
+```
+
+On Fedora, edit `/usr/lib/binfmt.d/qemu-arm-dynamic.conf` and then run:
+```
+$ sudo systemctl restart systemd-binfmt.service
+```
+
 
 \section client_ops Passing Options to Clients
 
@@ -637,6 +677,13 @@ are specified via \c drconfig, \c drrun, or dr_register_process().  See
    -follow_children on (the default) and create config files that exclude
    the desired applications by running \c drconfig with the \c -norun
    option.
+
+ - \b -xarch_root: \anchor op_xarch_root
+   Support for running under an emulator, in particular QEMU.  This option takes
+   a string pointing at the base directory for guest system libraries, which DynamoRIO
+   uses to prefix the application executable's interpreter, client library paths,
+   and SYS_openat.  The option also enables workarounds for problems with QEMU's
+   threads which would otherwise cause a hang while DynamoRIO tries to take them over.
 
  - \b -opt_memory: \anchor op_memory
    Reduce memory usage, but potentially at the cost of performance.  This

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -189,6 +189,9 @@ Further non-compatibility-affecting changes include:
    drx_insert_counter_update() on AArchXX.
  - Added a preferred base field to the #_module_data_t struct and to the
    #_drmodtrack_info_t struct.
+ - Added support for running under QEMU via the \ref op_xarch_root "-xarch_root"
+   runtime option which locates guest system libraries and enables workarounds for
+   problems with QEMU's threads.
 
 **************************************************
 <hr>

--- a/api/docs/test_suite.dox
+++ b/api/docs/test_suite.dox
@@ -180,26 +180,7 @@ We also have support for running tests under QEMU emulation.  This is automatica
 $ sudo apt-get install qemu-user qemu-user-binfmt
 ```
 
-To manually run under QEMU, use the `-xarch_root` option:
-
-```
-$ qemu-arm -L /usr/arm-linux-gnueabihf bin32/drrun -xarch_root /usr/arm-linux-gnueabihf -- suite/tests/bin/simple_app
-```
-
-If using a custom build of QEMU, be sure to update the binfmt rule to ensure the proper build is used across execve: QEMU does *not* ensure that the same build is preserved and instead relies on the global binfmt rule.  On an Ubuntu system, edit `/usr/share/binfmts/qemu-arm` and replace the `interpreter` path.  Then run:
-```
-$ sudo update-binfmts --import /usr/share/binfmts/qemu-arm
-```
-
-Confirm the change took effect:
-```
-$ update-binfmts --find bin32/drrun
-```
-
-On Fedora, edit `/usr/lib/binfmt.d/qemu-arm-dynamic.conf` and then run:
-```
-$ sudo systemctl restart systemd-binfmt.service
-```
+For instructions on how to manually run under QEMU, see \ref qemu_deploy.
 
 ## Test Output
 


### PR DESCRIPTION
Adds a new section on Running Under QEMU.
Adds a documented option entry for -xarch_root.
Adds a release note on the new support.

Issue: #4719