### PR TITLE
i#4792 cbr4 failure: Add client.cbr4 to ignore list

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -218,6 +218,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'code_api|tool.drcacheoff.burst_static' => 1, # i#4486
                 'code_api|api.symtest' => 1, # i#4131
                 'code_api|client.drwrap-test-detach' => 1, # i#4616
+                'code_api|client.cbr4' => 1, # i#4792
                 # These are from earlier runs on Appveyor:
                 'code_api|security-common.retnonexisting' => 1,
                 'code_api|security-win32.gbop-test' => 1, # i#2972


### PR DESCRIPTION
The client.cbr4 test has been failing on master merges, but passing on
pull requests.  The failure does not reproduce locally.  We add it to
the ignore list here to keep the suite green until someone is able to
act on it.

Issue: #4792