### PR TITLE
i#4668: Fix build race on competing library copies

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2020 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2021 Google, Inc.    All rights reserved.
 # Copyright (c) 2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -77,6 +77,9 @@ endmacro()
 disable_compiler_warnings()
 # Clients don't include configure.h so they don't get DR defines
 add_dr_defines()
+
+# Avoid a race on competing copies of dynamorio.dll to the bin dir (i#4668).
+set(dr_dll_being_copied_to_client_bin_dir OFF)
 
 file(GLOB dirs "*/CMakeLists.txt")
 foreach (dir ${dirs})

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015-2020 Google, Inc.    All rights reserved.
+# Copyright (c) 2015-2021 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -491,9 +491,13 @@ if (WIN32)
   add_custom_command(TARGET drcachesim POST_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_BASE_DIRECTORY}/drconfiglib.dll
     ${PROJECT_BINARY_DIR}/${BUILD_CLIENTS_BIN}/drconfiglib.dll VERBATIM)
-  add_custom_command(TARGET drcachesim POST_BUILD
-    COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_OUTPUT_DIRECTORY}/dynamorio.dll
-    ${PROJECT_BINARY_DIR}/${BUILD_CLIENTS_BIN}/dynamorio.dll VERBATIM)
+  if (NOT dr_dll_being_copied_to_client_bin_dir)
+    # Avoid dueling racy copies (i#4668).
+    set(dr_dll_being_copied_to_client_bin_dir ON PARENT_SCOPE)
+    add_custom_command(TARGET drcachesim POST_BUILD
+      COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_OUTPUT_DIRECTORY}/dynamorio.dll
+      ${PROJECT_BINARY_DIR}/${BUILD_CLIENTS_BIN}/dynamorio.dll VERBATIM)
+  endif ()
 endif ()
 
 ##################################################

--- a/clients/drcov/CMakeLists.txt
+++ b/clients/drcov/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2020 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2021 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -106,12 +106,16 @@ if (WIN32)
   if (dbghelp_path)
     DR_install(FILES "${dbghelp_path}" DESTINATION ${INSTALL_CLIENTS_BIN})
   endif ()
-  # for build dir
-  add_custom_command(TARGET drcov2lcov POST_BUILD
-    COMMAND ${CMAKE_COMMAND}
-    ARGS -E copy ${DR_LIBRARY_OUTPUT_DIRECTORY}/dynamorio.dll
-    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll
-    VERBATIM)
+  # For the build dir:
+  if (NOT dr_dll_being_copied_to_client_bin_dir)
+    # Avoid dueling racy copies (i#4668).
+    set(dr_dll_being_copied_to_client_bin_dir ON PARENT_SCOPE)
+    add_custom_command(TARGET drcov2lcov POST_BUILD
+      COMMAND ${CMAKE_COMMAND}
+      ARGS -E copy ${DR_LIBRARY_OUTPUT_DIRECTORY}/dynamorio.dll
+      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll
+      VERBATIM)
+  endif ()
 endif (WIN32)
 
 set(INSTALL_DRCOV_CONFIG ${INSTALL_CLIENTS_BASE})


### PR DESCRIPTION
Adds a flag to arrange only one of drcov and drcachesim trying to copy
dynamorio.dll into the same directory, which can lead to failures with
bad timing.

Fixes #4668