### PR TITLE
i#4668 build race: Fix DR copy race via single target

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -78,16 +78,18 @@ disable_compiler_warnings()
 # Clients don't include configure.h so they don't get DR defines
 add_dr_defines()
 
-# Avoid a race on competing copies of dynamorio.dll to the bin dir from
-# drcachsim and drcov via a higher-level target here (i#4668).
-add_custom_target(client_dr_copy ALL
-  DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll)
-add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll
-  DEPENDS dynamorio
-  COMMAND ${CMAKE_COMMAND}
-  ARGS -E copy ${DR_LIBRARY_OUTPUT_DIRECTORY}/dynamorio.dll
-  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll
-  VERBATIM)
+if (WIN32)
+  # Avoid a race on competing copies of dynamorio.dll to the bin dir from
+  # drcachsim and drcov via a higher-level target here (i#4668).
+  add_custom_target(client_dr_copy ALL
+    DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll)
+  add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll
+    DEPENDS dynamorio
+    COMMAND ${CMAKE_COMMAND}
+    ARGS -E copy ${DR_LIBRARY_OUTPUT_DIRECTORY}/dynamorio.dll
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll
+    VERBATIM)
+endif ()
 
 file(GLOB dirs "*/CMakeLists.txt")
 foreach (dir ${dirs})

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -78,8 +78,16 @@ disable_compiler_warnings()
 # Clients don't include configure.h so they don't get DR defines
 add_dr_defines()
 
-# Avoid a race on competing copies of dynamorio.dll to the bin dir (i#4668).
-set(dr_dll_being_copied_to_client_bin_dir OFF)
+# Avoid a race on competing copies of dynamorio.dll to the bin dir from
+# drcachsim and drcov via a higher-level target here (i#4668).
+add_custom_target(client_dr_copy ALL
+  DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll)
+add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll
+  DEPENDS dynamorio
+  COMMAND ${CMAKE_COMMAND}
+  ARGS -E copy ${DR_LIBRARY_OUTPUT_DIRECTORY}/dynamorio.dll
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll
+  VERBATIM)
 
 file(GLOB dirs "*/CMakeLists.txt")
 foreach (dir ${dirs})

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -491,13 +491,8 @@ if (WIN32)
   add_custom_command(TARGET drcachesim POST_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_BASE_DIRECTORY}/drconfiglib.dll
     ${PROJECT_BINARY_DIR}/${BUILD_CLIENTS_BIN}/drconfiglib.dll VERBATIM)
-  if (NOT dr_dll_being_copied_to_client_bin_dir)
-    # Avoid dueling racy copies (i#4668).
-    set(dr_dll_being_copied_to_client_bin_dir ON PARENT_SCOPE)
-    add_custom_command(TARGET drcachesim POST_BUILD
-      COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_OUTPUT_DIRECTORY}/dynamorio.dll
-      ${PROJECT_BINARY_DIR}/${BUILD_CLIENTS_BIN}/dynamorio.dll VERBATIM)
-  endif ()
+  # Avoid dueling racy copies (i#4668).
+  add_dependencies(drcachesim client_dr_copy)
 endif ()
 
 ##################################################

--- a/clients/drcov/CMakeLists.txt
+++ b/clients/drcov/CMakeLists.txt
@@ -106,16 +106,8 @@ if (WIN32)
   if (dbghelp_path)
     DR_install(FILES "${dbghelp_path}" DESTINATION ${INSTALL_CLIENTS_BIN})
   endif ()
-  # For the build dir:
-  if (NOT dr_dll_being_copied_to_client_bin_dir)
-    # Avoid dueling racy copies (i#4668).
-    set(dr_dll_being_copied_to_client_bin_dir ON PARENT_SCOPE)
-    add_custom_command(TARGET drcov2lcov POST_BUILD
-      COMMAND ${CMAKE_COMMAND}
-      ARGS -E copy ${DR_LIBRARY_OUTPUT_DIRECTORY}/dynamorio.dll
-      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dynamorio.dll
-      VERBATIM)
-  endif ()
+  # We need a copy of DR for the build dir:
+  add_dependencies(drcov2lcov client_dr_copy)
 endif (WIN32)
 
 set(INSTALL_DRCOV_CONFIG ${INSTALL_CLIENTS_BASE})


### PR DESCRIPTION
Adds a new target at the clients/ level to copy dynamorio.dll into the
bin dir for use by both drcov and drcachesim, to avoid races between
the two.  The prior solution avoided dueling copies, but left a race
where the doc generation of one could be left without a copy in place.

Fixes #4668