### PR TITLE
i#4736: Fix high-loglevel issues and add test

### DIFF
--- a/core/heap.c
+++ b/core/heap.c
@@ -719,8 +719,10 @@ vmm_dump_map(vm_heap_t *vmh)
     bool is_used = bitmap_test(b, 0) == 0;
 
     LOG(GLOBAL, LOG_HEAP, 3, "vmm_dump_map(" PFX ")\n", vmh);
-    /* raw dump first - if you really want binary dump use windbg's dyd */
-    DOLOG(4, LOG_HEAP, {
+    /* We used to do raw dumps but with the shift to 4K blocks, this is just way
+     * too big.  We disable but leave the capability to enable one-off use.
+     */
+    DOLOG(20, LOG_HEAP, {
         dump_buffer_as_bytes(GLOBAL, b,
                              BITMAP_INDEX(bitmap_size) * sizeof(bitmap_element_t),
                              DUMP_RAW | DUMP_ADDRESS);

--- a/core/ir/disassemble_shared.c
+++ b/core/ir/disassemble_shared.c
@@ -1105,7 +1105,10 @@ internal_instr_disassemble(char *buf, size_t bufsz, size_t *sofar INOUT,
     print_instr_prefixes(dcontext, instr, buf, bufsz, sofar);
 
     offs_pre_name = *sofar;
-    print_opcode_name(instr, name, buf, bufsz, sofar);
+    if (instr_opcode_valid(instr)) /* Avoid assert on level-0 bundle. */
+        print_opcode_name(instr, name, buf, bufsz, sofar);
+    else
+        print_to_buffer(buf, bufsz, sofar, "%s", name);
     offs_post_name = *sofar;
     name_width -= (int)(offs_post_name - offs_pre_name);
     print_to_buffer(buf, bufsz, sofar, " ");

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -1289,7 +1289,7 @@ instr_expand(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
          * for the logger */
         instr_t *log_instr = instr_clone(dcontext, instr);
         d_r_loginst(dcontext, 4, log_instr, "instr_expand");
-        instr_free(dcontext, log_instr);
+        instr_destroy(dcontext, log_instr);
     });
 
     /* decode routines use dcontext mode, but we want instr mode */

--- a/core/stats.c
+++ b/core/stats.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -340,6 +340,8 @@ kstats_dump_stack(dcontext_t *dcontext)
 {
     uint i;
     LOG(THREAD, 1, LOG_STATS, "Thread KSTAT stack:\n");
+    if (dcontext->thread_kstats == NULL)
+        return;
     for (i = dcontext->thread_kstats->stack_kstats.depth - 1; i > 0; i--) {
         LOG(THREAD, 1, LOG_STATS, "[%d] " PIFX " %s\n", i,
             &dcontext->thread_kstats->stack_kstats.node[i],

--- a/core/unix/memquery_linux.c
+++ b/core/unix/memquery_linux.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -240,8 +240,11 @@ memquery_iterator_next(memquery_iter_t *iter)
             line = mi->buf;
         }
     }
-    LOG(GLOBAL, LOG_VMAREAS, 6, "\nget_memory_info_from_os: newline=[%s]\n",
-        mi->newline ? mi->newline : "(null)");
+    LOG(GLOBAL, LOG_VMAREAS, 6, "\nget_memory_info_from_os: newline=[%.*s]\n",
+        /* Limit the size to avoid crossing the log buffer threshold.
+         * We could be in a fragile place and don't want a heap alloc.
+         */
+        MAX_LOG_LENGTH - 128, mi->newline ? mi->newline : "(null)");
 
     /* Buffer is big enough to hold at least one line: if not, the file changed
      * underneath us after we hit the end.  Just bail.

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -745,11 +745,15 @@ print_vm_area(vm_area_vector_t *v, vm_area_t *area, file_t outf, const char *pre
     print_file(outf, " %s", area->comment);
     DOLOG(1, LOG_VMAREAS, {
         IF_NO_MEMQUERY(extern vm_area_vector_t * all_memory_areas;)
+        extern vm_area_vector_t *fcache_unit_areas;   /* fcache.c */
+        extern vm_area_vector_t *loaded_module_areas; /* module_list.c */
         app_pc modbase =
             /* avoid rank order violation */
             IF_NO_MEMQUERY(v == all_memory_areas ? NULL :)
-            /* i#1649: avoid rank order for dynamo_areas */
-            (v == dynamo_areas ? NULL : get_module_base(area->start));
+            /* i#1649: avoid rank order for dynamo_areas and for other vectors. */
+            ((v == dynamo_areas || v == fcache_unit_areas || v == loaded_module_areas)
+                 ? NULL
+                 : get_module_base(area->start));
         if (modbase != NULL &&
             /* avoid rank order violations */
             v != dynamo_areas && v != written_areas &&

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2054,22 +2054,25 @@ if (DR_HOST_AARCH64)
     "-Wl,--no-export-dynamic")
 endif ()
 
-if (DR_HOST_X86 AND DR_HOST_X64)
-  # Unfortunately it's not possible to create a tiny app on Windows, and hello,world
-  # at -loglevel 19 produces 11GB of data and takes >17 minutes to run (vs <10MB and
-  # <1s for Linux).  We live w/o a regression test on Windows for high loglevels.
-  if (LINUX)
-    tobuild_ops(common.loglevel common/allasm_x86_64.asm
-      "-loglevel 19" "")
-    set_target_properties(common.loglevel PROPERTIES LINKER_LANGUAGE C)
-    append_link_flags(common.loglevel "-nostartfiles -nodefaultlibs -static")
+if (DEBUG)
+  # A high-loglevel test.
+  if (DR_HOST_X86 AND DR_HOST_X64)
+    # Unfortunately it's not possible to create a tiny app on Windows, and hello,world
+    # at -loglevel 19 produces 11GB of data and takes >17 minutes to run (vs <10MB and
+    # <1s for Linux).  We live w/o a regression test on Windows for high loglevels.
+    if (LINUX)
+      tobuild_ops(common.loglevel common/allasm_x86_64.asm
+        "-loglevel 19" "")
+      set_target_properties(common.loglevel PROPERTIES LINKER_LANGUAGE C)
+      append_link_flags(common.loglevel "-nostartfiles -nodefaultlibs -static")
+    endif ()
+  elseif (DR_HOST_AARCH64)
+    torunonly(common.loglevel common.allasm_aarch64_cache
+      common/allasm_aarch64_cache.asm "-loglevel 19" "")
+  elseif (DR_HOST_ARM AND NOT ANDROID)
+    torunonly(common.loglevel common.allasm_thumb
+      common/allasm_thumb.asm "-loglevel 19" "")
   endif ()
-elseif (DR_HOST_AARCH64)
-  torunonly(common.loglevel common.allasm_aarch64_cache
-    common/allasm_aarch64_cache.asm "-loglevel 19" "")
-elseif (DR_HOST_ARM AND NOT ANDROID)
-  torunonly(common.loglevel common.allasm_thumb
-    common/allasm_thumb.asm "-loglevel 19" "")
 endif ()
 
 if (NOT ANDROID) # XXX i#1874: get working on Android

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4626,7 +4626,6 @@ if (NOT ANDROID AND AARCHXX)
     code_api|common.broadfun
     code_api|common.getretaddr
     code_api|common.nzcv
-    code_api|common.loglevel
     code_api|linux.app_tls
     code_api|linux.execve-null
     code_api|linux.exit
@@ -4678,6 +4677,7 @@ if (NOT ANDROID AND AARCHXX)
   if (DEBUG)
     set_tests_properties(
       code_api|common.logstderr
+      code_api|common.loglevel
       PROPERTIES LABELS RUNS_ON_QEMU)
   endif ()
   if (AARCH64)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2054,6 +2054,24 @@ if (DR_HOST_AARCH64)
     "-Wl,--no-export-dynamic")
 endif ()
 
+if (DR_HOST_X86 AND DR_HOST_X64)
+  # Unfortunately it's not possible to create a tiny app on Windows, and hello,world
+  # at -loglevel 19 produces 11GB of data and takes >17 minutes to run (vs <10MB and
+  # <1s for Linux).  We live w/o a regression test on Windows for high loglevels.
+  if (LINUX)
+    tobuild_ops(common.loglevel common/allasm_x86_64.asm
+      "-loglevel 19" "")
+    set_target_properties(common.loglevel PROPERTIES LINKER_LANGUAGE C)
+    append_link_flags(common.loglevel "-nostartfiles -nodefaultlibs -static")
+  endif ()
+elseif (DR_HOST_AARCH64)
+  torunonly(common.loglevel common.allasm_aarch64_cache
+    common/allasm_aarch64_cache.asm "-loglevel 19" "")
+elseif (DR_HOST_ARM AND NOT ANDROID)
+  torunonly(common.loglevel common.allasm_thumb
+    common/allasm_thumb.asm "-loglevel 19" "")
+endif ()
+
 if (NOT ANDROID) # XXX i#1874: get working on Android
   # We don't want to link with DR.  We hack that for now by requesting drdecode so
   # we'll get the arch defs.  XXX: Add a better way!
@@ -4605,6 +4623,7 @@ if (NOT ANDROID AND AARCHXX)
     code_api|common.broadfun
     code_api|common.getretaddr
     code_api|common.nzcv
+    code_api|common.loglevel
     code_api|linux.app_tls
     code_api|linux.execve-null
     code_api|linux.exit

--- a/suite/tests/common/allasm_x86_64.asm
+++ b/suite/tests/common/allasm_x86_64.asm
@@ -1,0 +1,60 @@
+ /* **********************************************************
+ * Copyright (c) 2021 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* This is a statically-linked app. */
+.text
+.globl _start
+.type _start, @function
+
+        .align   8
+_start:
+        and      rsp, -16         // align stack pointer to cache line
+
+        mov      rbx, 16          // loop counter
+loop:
+        mov      rdi, 1           // stdout
+        lea      rsi, hello
+        mov      rdx, 13          // sizeof(hello)
+        mov      eax, 1           // SYS_write
+        syscall
+        sub      rbx, 1
+        cmp      rbx, 0
+        jne      loop
+// exit:
+        mov      rdi, 0           // exit code
+        mov      eax, 231         // SYS_exit_group
+        syscall
+
+        .data
+        .align   8
+hello:
+        .string   "Hello world!\n"

--- a/suite/tests/common/allasm_x86_64.expect
+++ b/suite/tests/common/allasm_x86_64.expect
@@ -1,0 +1,16 @@
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+Hello world!


### PR DESCRIPTION
Fixes several problems with loglevel 5 and above:
+ Fixes a deadlock by avoiding an over-long LOG in a fragile memquery context.
+ Avoids an assert by avoiding an opcode query for a level 0 bundle.
+ Fixes a rank order violation by avoiding diagnostic module name
  lookup if holding fcache_unit_areas->lock.
+ Fixes an infinite recursion by avoiding the same module lookup for the
  loaded_module_areas vector.
+ Fixes a crash when thread_kstats is not yet allocated.
+ Fixes a memory leak at level 5.
+ Effectively disables vmm_dump_map as with 4K blocks it has enormous output now.

Adds a test of loglevel 19 that runs a pure-asm app to keep the time
and space down.  Marks it as part of the QEMU suite.

Fixes #4736