### PR TITLE
i#4807 rm defs: Remove NOBLIC

### DIFF
--- a/core/options.c
+++ b/core/options.c
@@ -1319,16 +1319,6 @@ check_option_compatibility_helper(int recurse_count)
      * warn of unfinished and untested self-protection options
      * FIXME: update once these features are complete
      */
-#    if defined(WINDOWS) && !defined(NOLIBC)
-    if (TEST(SELFPROT_ANY_DATA_SECTION, dynamo_options.protect_mask)) {
-        /* since libc routines are embedded in our dll and we run
-         * them from the code cache we hit write faults
-         */
-        USAGE_ERROR("Cannot protect data segment w/ a non-NOLIBC build");
-        dynamo_options.protect_mask &= ~SELFPROT_ANY_DATA_SECTION;
-        changed_options = true;
-    }
-#    endif
     if (
 #    ifdef WINDOWS
         /* FIXME: CACHE isn't multithread safe yet */

--- a/core/utils.h
+++ b/core/utils.h
@@ -2270,19 +2270,17 @@ utils_init(void);
 void
 utils_exit(void);
 
-#ifdef NOLIBC
-#    ifdef WINDOWS
-#        ifdef isprint
-#            undef isprint
+#ifdef WINDOWS
+#    ifdef isprint
+#        undef isprint
 bool
 isprint(int c);
-#        endif
+#    endif
 
-#        ifdef isdigit
-#            undef isdigit
+#    ifdef isdigit
+#        undef isdigit
 bool
 isdigit(int c);
-#        endif
 #    endif
 #endif
 
@@ -2320,8 +2318,9 @@ void
 divide_uint64_print(uint64 numerator, uint64 denominator, bool percentage, uint precision,
                     uint *top, uint *bottom);
 
-/* for printing a float (can't use %f on windows with NOLIBC), NOTE: you must
- * preserve floating point state to call this function!!
+/* For printing a float.
+ * NOTE: You must preserve x87 floating point state to call this function, unless
+ * you can prove the compiler will never use x87 state for float operations.
  * Usage : given double/float a; uint c, d and char *s tmp; dp==double_print
  *         parameterized on precision p width w
  * note that %f is eqv. to %.6f

--- a/core/win32/module.c
+++ b/core/win32/module.c
@@ -306,7 +306,6 @@ lookup_module_info(module_info_vector_t *v, app_pc addr)
 {
     /* BINARY SEARCH -- assumes the vector is kept sorted by add & remove! */
     module_info_t key = { addr, addr + 1 }; /* end is open */
-#    ifdef NOLIBC
     /* FIXME : copied from find_predecessor(), would be nice to share with
      * that routine and with binary range search (w/linear backsearch) in
      * vmareas.c */
@@ -325,9 +324,6 @@ lookup_module_info(module_info_vector_t *v, app_pc addr)
         }
     }
     return NULL;
-#    else
-    return bsearch(&key, v->buf, v->length, sizeof(module_info_t), module_info_compare);
-#    endif
 }
 
 #    define INITIAL_MODULE_NUMBER 4

--- a/make/configure.cmake.h
+++ b/make/configure.cmake.h
@@ -194,9 +194,6 @@
 #    ($(D)RETURN_STACK: deprecated and now removed)
 #    $(D)TRACE_HEAD_CACHE_INCR   (incompatible with security FIXME:?)
 #    $(D)DISALLOW_CACHE_RESIZING (use as temporary hack when developing)
-# transparency
-#    $(D)NOLIBC = doesn't link libc on windows, currently uses ntdll.dll libc
-#      functions, NOLIBC=0 causes the core to be linked against libc and kernel32.dll
 # external interface
 #    $(D)ANNOTATIONS -- optional instrumentation of binary annotations
 #                       in the target program
@@ -244,13 +241,6 @@
 
 ###################################
 */
-
-#ifdef WINDOWS
-   /* we do not support linking to libc.  we should probably remove
-    * this define from the code and eliminate it altogether.
-    */
-# define NOLIBC
-#endif
 
 #ifdef MACOS
 # define ASSEMBLE_WITH_NASM


### PR DESCRIPTION
We no longer support linking dynamorio.dll with libc on Windows.
We remove the NOLIBC define and assume it is always set.

Issue: #4807