### PR TITLE
i#4111 web: Move License to top-level

### DIFF
--- a/api/docs/CMake_doxyfile.cmake
+++ b/api/docs/CMake_doxyfile.cmake
@@ -107,6 +107,7 @@ set(top_order "${top_order} \"${gendox_dir}/tool_gendox.dox\"")
 set(top_order "${top_order} \"${srcdir}/intro.dox\"")
 set(top_order "${top_order} \"${srcdir}/help.dox\"")
 set(top_order "${top_order} \"${srcdir}/developers.dox\"")
+set(top_order "${top_order} \"${srcdir}/license.dox\"")
 
 # Executed inside build dir, so we leave genimages alone
 # and have to fix up refs to source dir and subdirs

--- a/api/docs/bt.dox
+++ b/api/docs/bt.dox
@@ -53,7 +53,6 @@ following sections:
 - \ref sec_ldrex
 - \ref sec_rseq
 - \ref sec_pcache
-- \ref bt_examples
 
 ***************************************************************************
 \htmlonly

--- a/api/docs/deployment.dox
+++ b/api/docs/deployment.dox
@@ -649,6 +649,10 @@ dr_app_start()
 dr_app_stop()
 dr_app_cleanup()
 dr_app_take_over()
+dr_app_setup_and_start()
+dr_app_stop_and_cleanup()
+dr_app_stop_and_cleanup_with_stats()
+dr_app_running_under_dynamorio()
 \endcode
 
 When building an executable that uses DynamoRIO's Application Interface,

--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -90,8 +90,6 @@ sections:
   <br>Release notes for this release, including changes since prior
   releases and plans for future releases.
 
-- \subpage page_license
-
 <br>
 
 ***************************************************************************

--- a/api/docs/license.dox
+++ b/api/docs/license.dox
@@ -36,7 +36,7 @@
 ***************************************************************************
 ***************************************************************************
 
-\page page_license Licenses
+\page page_license License
 
 ***************************************************************************
 \section sec_bsd Primary DynamoRIO License: BSD
@@ -115,7 +115,7 @@ SUCH DAMAGE.
 \endverbatim
 
 ***************************************************************************
-\section sec_lgpl_licenses Certain Extensions are instead under the LGPL 2.1 License
+\section sec_lgpl_licenses Certain Extensions: LGPL 2.1
 
 The \p drwrap (see \ref page_drwrap) and \p drutil (see \ref page_drutil)
 Extensions are licensed under the LGPL 2.1 License and NOT the BSD license
@@ -600,7 +600,7 @@ DAMAGES.
 \endverbatim
 
 ***************************************************************************
-\section sec_gpl_licenses Code coverage genhtml script is under GPL 2
+\section sec_gpl_licenses Code Coverage genhtml: GPL 2
 
 The \p genhtml code coverage post-processing script (see \ref page_drcov)
 is licensed under the GPL 2 License and NOT the BSD license used for the

--- a/api/docs/tool.gendox
+++ b/api/docs/tool.gendox
@@ -46,7 +46,6 @@ Those interested in how the -t option works should see
 the section \ref tool_frontend.
 
 REPLACE_WITH_GENDOX_SUBPAGES
-- \subpage page_drdisas
 - \subpage page_drmemory
 - \subpage page_drstrace
 - \subpage page_drltrace

--- a/core/lib/dr_app.h
+++ b/core/lib/dr_app.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -119,10 +119,6 @@ dr_app_setup_and_start(void);
  * return from this call, and additionally frees the resources used by DR.
  * Once this is invoked, calling dr_app_start() is not supported until
  * dr_app_setup() or dr_app_setup_and_start() is called for a re-attach.
- * Re-attach, however, is considered an experimental feature and is
- * not guaranteed to be without problems, in particular when DR or
- * extension libraries are static and there is no simple way to reset
- * the state of global variables.
  *
  * This call has no effect if the application is not currently running
  * under DR control.


### PR DESCRIPTION
Moves the License page to a top-level entry and renames the sections
for shorter menu entries.

Fixes other misc layout issues:
+ Removes the bt.dox samples TOC entry since that is now on another page
+ Adds missing start/stop API entries
+ Removes a duplicate Disassembly Tool list entry

Issue: #4111