### PR TITLE
i#2971 rm CI: Remove CUSTOM_TRACES define; it is always on.

### DIFF
--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -6133,9 +6133,6 @@ fixup_last_cti(dcontext_t *dcontext, instrlist_t *trace, app_pc next_tag, uint n
                 ASSERT_NOT_REACHED();
             }
         } else if (instr_is_ubr(targeter)) {
-#ifndef CUSTOM_TRACES
-            ASSERT(targeter == end_instr);
-#endif
             /* remove unnecessary ubr at end of block */
             delete_after = instr_get_prev(targeter);
             if (delete_after != NULL) {
@@ -6147,10 +6144,9 @@ fixup_last_cti(dcontext_t *dcontext, instrlist_t *trace, app_pc next_tag, uint n
     /* remove all instrs after this cti -- but what if internal
      * control flow jumps ahead and then comes back?
      * too expensive to check for such all the time.
-     * FIXME: what to do?
+     * XXX: what to do?
      *
-     * ifdef CUSTOM_TRACES:
-     * FIXME: rather than adding entire trace on and then chopping off where
+     * XXX: rather than adding entire trace on and then chopping off where
      * we exited, why not add after we know where to stop?
      */
     if (delete_after != NULL) {

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -2914,9 +2914,9 @@ fragment_add(dcontext_t *dcontext, fragment_t *f)
     DOCHECK(1, {
         fragment_t *existing = fragment_lookup(dcontext, f->tag);
         ASSERT(existing == NULL ||
-               IF_CUSTOM_TRACES(/* we create and persist shadowed trace heads */
-                                (TEST(FRAG_IS_TRACE_HEAD, f->flags) ||
-                                 TEST(FRAG_IS_TRACE_HEAD, existing->flags)) ||)
+               /* For custom traces, we create and persist shadowed trace heads. */
+               TEST(FRAG_IS_TRACE_HEAD, f->flags) ||
+               TEST(FRAG_IS_TRACE_HEAD, existing->flags) ||
                /* private trace or temp can shadow shared bb */
                (TESTANY(FRAG_IS_TRACE | FRAG_TEMP_PRIVATE, f->flags) &&
                 TEST(FRAG_SHARED, f->flags) != TEST(FRAG_SHARED, existing->flags)) ||

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -606,12 +606,6 @@ typedef struct _instr_t instr_t;
 #    define IF_HOTP(x)
 #endif
 
-#ifdef CUSTOM_TRACES
-#    define IF_CUSTOM_TRACES(x) x
-#else
-#    define IF_CUSTOM_TRACES(x)
-#endif
-
 #ifdef DR_APP_EXPORTS
 #    define IF_APP_EXPORTS(x) x
 #else

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -218,11 +218,9 @@ static callback_list_t bb_callbacks = {
 static callback_list_t trace_callbacks = {
     0,
 };
-#ifdef CUSTOM_TRACES
 static callback_list_t end_trace_callbacks = {
     0,
 };
-#endif
 static callback_list_t fragdel_callbacks = {
     0,
 };
@@ -827,9 +825,7 @@ free_all_callback_lists()
     free_callback_list(&low_on_memory_callbacks);
     free_callback_list(&bb_callbacks);
     free_callback_list(&trace_callbacks);
-#ifdef CUSTOM_TRACES
     free_callback_list(&end_trace_callbacks);
-#endif
     free_callback_list(&fragdel_callbacks);
     free_callback_list(&restore_state_callbacks);
     free_callback_list(&restore_state_ex_callbacks);
@@ -1007,7 +1003,6 @@ bool dr_unregister_trace_event(dr_emit_flags_t (*func)(void *drcontext, void *ta
     return remove_callback(&trace_callbacks, (void (*)(void))func, true);
 }
 
-#ifdef CUSTOM_TRACES
 void dr_register_end_trace_event(dr_custom_trace_action_t (*func)(void *drcontext,
                                                                   void *tag,
                                                                   void *next_tag))
@@ -1026,7 +1021,6 @@ bool dr_unregister_end_trace_event(dr_custom_trace_action_t (*func)(void *drcont
 {
     return remove_callback(&end_trace_callbacks, (void (*)(void))func, true);
 }
-#endif
 
 void
 dr_register_delete_event(void (*func)(void *drcontext, void *tag))
@@ -1852,7 +1846,6 @@ instrument_restore_nonfcache_state(dcontext_t *dcontext, bool restore_memory,
                                                        &client_mcontext);
 }
 
-#ifdef CUSTOM_TRACES
 /* Ask whether to end trace prior to adding next_tag fragment.
  * Return values:
  *   CUSTOM_TRACE_DR_DECIDES = use standard termination criteria
@@ -1875,7 +1868,6 @@ instrument_end_trace(dcontext_t *dcontext, app_pc trace_tag, app_pc next_tag)
 
     return ret;
 }
-#endif
 
 static module_data_t *
 create_and_initialize_module_data(app_pc start, app_pc end, app_pc entry_point,

--- a/core/lib/instrument.h
+++ b/core/lib/instrument.h
@@ -92,10 +92,8 @@ instrument_basic_block(dcontext_t *dcontext, app_pc tag, instrlist_t *bb, bool f
                        bool translating, dr_emit_flags_t *emitflags);
 dr_emit_flags_t
 instrument_trace(dcontext_t *dcontext, app_pc tag, instrlist_t *trace, bool translating);
-#ifdef CUSTOM_TRACES
 dr_custom_trace_action_t
 instrument_end_trace(dcontext_t *dcontext, app_pc trace_tag, app_pc next_tag);
-#endif
 void
 instrument_fragment_deleted(dcontext_t *dcontext, app_pc tag, uint flags);
 bool

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -483,7 +483,6 @@ bool dr_unregister_trace_event(dr_emit_flags_t (*func)(void *drcontext, void *ta
                                                        instrlist_t *trace,
                                                        bool translating));
 
-#ifdef CUSTOM_TRACES
 /* DR_API EXPORT BEGIN */
 
 /**
@@ -524,7 +523,6 @@ DR_API
 bool dr_unregister_end_trace_event(dr_custom_trace_action_t (*func)(void *drcontext,
                                                                     void *tag,
                                                                     void *next_tag));
-#endif
 
 /* For the new-bb-before-deletion-event problem (PR 495787, and
  * described in the comment below):
@@ -6490,7 +6488,6 @@ DR_API
 bool
 dr_get_stats(dr_stats_t *drstats);
 
-#ifdef CUSTOM_TRACES
 /* DR_API EXPORT BEGIN */
 
 /****************************************************************************
@@ -6541,7 +6538,6 @@ DR_API
 /** Checks to see that if there is a trace in the code cache at tag \p tag. */
 bool
 dr_trace_exists_at(void *drcontext, void *tag);
-#endif /* CUSTOM_TRACES */
 
 /****************************************************************************
  * proc.c routines exported here due to proc.h being in arch_exports.h

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -554,11 +554,9 @@ STATS_DEF("Trace fragments extended, ibl exits updated", num_traces_ibl_extended
 STATS_DEF("Trace fragments extended w/shared syscall block",
           num_traces_shared_syscall_extended)
 #endif
-#ifdef CUSTOM_TRACES
 STATS_DEF("Custom traces extended beyond normal stop", custom_traces_stop_late)
 STATS_DEF("Custom traces stopped early", custom_traces_stop_early)
 STATS_DEF("Shadowed bbs built for custom traces", custom_traces_bbs_built)
-#endif
 STATS_DEF("Recreated fragments, total", num_recreated_fragments)
 STATS_DEF("Recreated fragments, traces", num_recreated_traces)
 STATS_DEF("Recreations via app re-decode", recreate_via_app_ilist)

--- a/core/link.c
+++ b/core/link.c
@@ -2297,7 +2297,7 @@ shift_links_to_new_fragment(dcontext_t *dcontext, fragment_t *old_f, fragment_t 
     }
 
     /* For the common case of a trace shadowing a trace head
-     * (happens w/ shared traces, and with CUSTOM_TRACES),
+     * (happens w/ shared traces, and with custom traces),
      * ensure that when we delete the trace we shift back and
      * when we delete the head we don't complain that we're
      * missing links.

--- a/core/monitor.h
+++ b/core/monitor.h
@@ -41,7 +41,7 @@
 #ifndef _MONITOR_H_
 #define _MONITOR_H_ 1
 
-#include "fragment.h" /* for trace_bb_info_t, and for CUSTOM_TRACES
+#include "fragment.h" /* for trace_bb_info_t, and for custom traces
                        * the "fragment_t wrapper" struct */
 
 /* synchronization of shared traces */
@@ -190,9 +190,7 @@ typedef struct _monitor_data_t {
      */
     uint final_exit_flags;
 
-#ifdef CUSTOM_TRACES
     fragment_t wrapper; /* for creating new shadowed trace heads */
-#endif
 } monitor_data_t;
 
 /* PR 204770: use trace component bb tag for RCT source address */

--- a/core/options.c
+++ b/core/options.c
@@ -1365,16 +1365,15 @@ check_option_compatibility_helper(int recurse_count)
               SELFPROT_CACHE | SELFPROT_STACK);
         changed_options = true;
     }
-#    ifdef CUSTOM_TRACES
     if (PRIVATE_TRACES_ENABLED() && DYNAMO_OPTION(shared_bbs)) {
         /* Due to complications with shadowing, we do not support
-         * private traces and shared bbs
+         * private traces and shared bbs if we allow clients to make custom
+         * traces (which is always enabled).
          */
-        USAGE_ERROR("CUSTOM_TRACES incompatible with private traces and shared bbs");
+        USAGE_ERROR("private traces incompatible with shared bbs");
         dynamo_options.shared_bbs = false;
         changed_options = true;
     }
-#    endif
     /****************************************************************************/
 
 #    if defined(PROFILE_RDTSC) && defined(SIDELINE)

--- a/make/configure.cmake.h
+++ b/make/configure.cmake.h
@@ -188,7 +188,7 @@
 #    $(D)ANNOTATIONS -- optional instrumentation of binary annotations
 #                       in the target program
 #    $(D)DR_APP_EXPORTS
-#    $(D)CUSTOM_TRACES -- optional interface
+#    Custom traces is always on, but it
 #      has some sub-features that are aggressive and not supported by default:
 #      $(D)CUSTOM_TRACES_RET_REMOVAL = support for removing inlined rets
 #        CUSTOM_TRACES_RET_REMOVAL is aggressive -- assumes calling convention kept
@@ -285,7 +285,6 @@
 
 /* standard client interface features */
 #define DYNAMORIO_IR_EXPORTS
-#define CUSTOM_TRACES
 #define CLIENT_SIDELINE
 /* TODO i#4045: Remove completely from the code base.
 #define UNSUPPORTED_API


### PR DESCRIPTION
Removes CUSTOM_TRACES as part of removing CLIENT_INTERFACE and related
defines for interfaces that are always enabled.

Issue: #2971