### PR TITLE
i#2971 rm CI: Remove CLIENT_SIDELINE define; it is always on.

### DIFF
--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -1196,9 +1196,7 @@ dispatch_exit_fcache(dcontext_t *dcontext)
             USAGE_ERROR("dr_{delete,replace}_fragment() are incompatible with "
                         "-shared_{bbs,traces} at this time");
         }
-#ifdef CLIENT_SIDELINE
         d_r_mutex_lock(&(dcontext->client_data->sideline_mutex));
-#endif
         todo = dcontext->client_data->to_do;
         while (todo != NULL) {
             client_todo_list_t *next_todo = todo->next;
@@ -1269,9 +1267,7 @@ dispatch_exit_fcache(dcontext_t *dcontext)
             todo = next_todo;
         }
         dcontext->client_data->to_do = NULL;
-#ifdef CLIENT_SIDELINE
         d_r_mutex_unlock(&(dcontext->client_data->sideline_mutex));
-#endif
     }
 }
 

--- a/core/fragment.h
+++ b/core/fragment.h
@@ -500,9 +500,7 @@ typedef struct _per_thread_t {
     fragment_table_t bb;
     fragment_table_t trace;
     fragment_table_t future;
-#ifdef CLIENT_SIDELINE
     mutex_t fragment_delete_mutex;
-#endif
     file_t tracefile;
 
     /* used for unlinking other threads' caches for flushing */
@@ -830,14 +828,12 @@ rct_table_resurrect(dcontext_t *dcontext, byte *mapped_table, rct_type_t which);
 
 #endif /* RETURN_AFTER_CALL || RCT_IND_BRANCH */
 
-#ifdef CLIENT_SIDELINE
 /* synchronization routine for sideline thread */
 void
 fragment_get_fragment_delete_mutex(dcontext_t *dcontext);
 
 void
 fragment_release_fragment_delete_mutex(dcontext_t *dcontext);
-#endif
 
 /*******************************************************************************
  * COARSE-GRAIN FRAGMENT HASHTABLE

--- a/core/globals.h
+++ b/core/globals.h
@@ -428,9 +428,7 @@ typedef struct _client_data_t {
     void *user_field;
     client_todo_list_t *to_do;
     client_flush_req_t *flush_list;
-#ifdef CLIENT_SIDELINE
     mutex_t sideline_mutex;
-#endif
     /* fields for doing release and debug build checks against erroneous API usage */
     module_data_t *no_delete_mod_data;
 

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -348,15 +348,11 @@ bool client_requested_exit;
 static bool block_client_nudge_threads = false;
 DECLARE_CXTSWPROT_VAR(static int num_client_nudge_threads, 0);
 #endif
-#ifdef CLIENT_SIDELINE
 /* # of sideline threads */
 DECLARE_CXTSWPROT_VAR(static int num_client_sideline_threads, 0);
-#endif
-#if defined(WINDOWS) || defined(CLIENT_SIDELINE)
 /* protects block_client_nudge_threads and incrementing num_client_nudge_threads */
 DECLARE_CXTSWPROT_VAR(static mutex_t client_thread_count_lock,
                       INIT_LOCK_FREE(client_thread_count_lock));
-#endif
 
 static vm_area_vector_t *client_aux_libs;
 
@@ -896,9 +892,7 @@ instrument_exit(void)
 #ifdef WINDOWS
     DELETE_LOCK(client_aux_lib64_lock);
 #endif
-#if defined(WINDOWS) || defined(CLIENT_SIDELINE)
     DELETE_LOCK(client_thread_count_lock);
-#endif
     DELETE_READWRITE_LOCK(callback_registration_lock);
 }
 
@@ -1351,15 +1345,12 @@ instrument_client_thread_init(dcontext_t *dcontext, bool client_thread)
             HEAP_TYPE_ALLOC(dcontext, client_data_t, ACCT_OTHER, PROTECTED);
         memset(dcontext->client_data, 0x0, sizeof(client_data_t));
 
-#ifdef CLIENT_SIDELINE
         ASSIGN_INIT_LOCK_FREE(dcontext->client_data->sideline_mutex, sideline_mutex);
-#endif
         CLIENT_ASSERT(dynamo_initialized || thread_init_callbacks.num == 0 ||
                           client_thread,
                       "1st call to instrument_thread_init should have no cbs");
     }
 
-#ifdef CLIENT_SIDELINE
     if (client_thread) {
         ATOMIC_INC(int, num_client_sideline_threads);
         /* We don't call dynamo_thread_not_under_dynamo() b/c we want itimers. */
@@ -1367,7 +1358,6 @@ instrument_client_thread_init(dcontext_t *dcontext, bool client_thread)
         dcontext->client_data->is_client_thread = true;
         dcontext->client_data->suspendable = true;
     }
-#endif /* CLIENT_SIDELINE */
 }
 
 void
@@ -1431,7 +1421,6 @@ instrument_low_on_memory()
 void
 instrument_thread_exit_event(dcontext_t *dcontext)
 {
-#ifdef CLIENT_SIDELINE
     if (IS_CLIENT_THREAD(dcontext)
         /* if nudge thread calls dr_exit_process() it will be marked as a client
          * thread: rule it out here so we properly clean it up
@@ -1441,7 +1430,6 @@ instrument_thread_exit_event(dcontext_t *dcontext)
         /* no exit event */
         return;
     }
-#endif
 
     /* i#1394: best-effort to try to avoid crashing thread exit events
      * where thread init was never called.
@@ -1466,9 +1454,7 @@ instrument_thread_exit(dcontext_t *dcontext)
 #ifdef DEBUG
     /* i#271: avoid racy crashes by not freeing in release build. */
 
-#    ifdef CLIENT_SIDELINE
     DELETE_LOCK(dcontext->client_data->sideline_mutex);
-#    endif
 
     /* could be heap space allocated for the todo list */
     todo = dcontext->client_data->to_do;
@@ -2465,9 +2451,7 @@ int
 get_num_client_threads(void)
 {
     int num = IF_WINDOWS_ELSE(num_client_nudge_threads, 0);
-#ifdef CLIENT_SIDELINE
     num += num_client_sideline_threads;
-#endif
     return num;
 }
 
@@ -5121,7 +5105,6 @@ dr_sleep(int time_ms)
         dcontext->client_data->at_safe_to_terminate_syscall = false;
 }
 
-#ifdef CLIENT_SIDELINE
 DR_API
 bool
 dr_client_thread_set_suspendable(bool suspendable)
@@ -5134,7 +5117,6 @@ dr_client_thread_set_suspendable(bool suspendable)
     dcontext->client_data->suspendable = suspendable;
     return true;
 }
-#endif
 
 DR_API
 bool
@@ -6977,13 +6959,8 @@ dr_delete_fragment(void *drcontext, void *tag)
     waslinking = is_couldbelinking(dcontext);
     if (!waslinking)
         enter_couldbelinking(dcontext, NULL, false);
-#ifdef CLIENT_SIDELINE
     d_r_mutex_lock(&(dcontext->client_data->sideline_mutex));
     fragment_get_fragment_delete_mutex(dcontext);
-#else
-    CLIENT_ASSERT(drcontext == get_thread_private_dcontext(),
-                  "dr_delete_fragment(): drcontext does not belong to current thread");
-#endif
     f = fragment_lookup(dcontext, tag);
     if (f != NULL && (f->flags & FRAG_CANNOT_DELETE) == 0) {
         /* We avoid "local unprotected" as it is global, complicating thread exit. */
@@ -7010,10 +6987,8 @@ dr_delete_fragment(void *drcontext, void *tag)
             unlink_fragment_incoming(dcontext, f);
         fragment_remove_from_ibt_tables(dcontext, f, false);
     }
-#ifdef CLIENT_SIDELINE
     fragment_release_fragment_delete_mutex(dcontext);
     d_r_mutex_unlock(&(dcontext->client_data->sideline_mutex));
-#endif
     if (!waslinking)
         enter_nolinking(dcontext, NULL, false);
     return deletable;
@@ -7052,13 +7027,8 @@ dr_replace_fragment(void *drcontext, void *tag, instrlist_t *ilist)
     waslinking = is_couldbelinking(dcontext);
     if (!waslinking)
         enter_couldbelinking(dcontext, NULL, false);
-#ifdef CLIENT_SIDELINE
     d_r_mutex_lock(&(dcontext->client_data->sideline_mutex));
     fragment_get_fragment_delete_mutex(dcontext);
-#else
-    CLIENT_ASSERT(drcontext == get_thread_private_dcontext(),
-                  "dr_replace_fragment(): drcontext does not belong to current thread");
-#endif
     f = fragment_lookup(dcontext, tag);
     frag_found = (f != NULL);
     if (frag_found) {
@@ -7083,10 +7053,8 @@ dr_replace_fragment(void *drcontext, void *tag, instrlist_t *ilist)
             unlink_fragment_incoming(dcontext, f);
         fragment_remove_from_ibt_tables(dcontext, f, false);
     }
-#ifdef CLIENT_SIDELINE
     fragment_release_fragment_delete_mutex(dcontext);
     d_r_mutex_unlock(&(dcontext->client_data->sideline_mutex));
-#endif
     if (!waslinking)
         enter_nolinking(dcontext, NULL, false);
     return frag_found;
@@ -7316,13 +7284,9 @@ dr_fragment_exists_at(void *drcontext, void *tag)
 {
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     fragment_t *f;
-#ifdef CLIENT_SIDELINE
     fragment_get_fragment_delete_mutex(dcontext);
-#endif
     f = fragment_lookup(dcontext, tag);
-#ifdef CLIENT_SIDELINE
     fragment_release_fragment_delete_mutex(dcontext);
-#endif
     return f != NULL;
 }
 
@@ -7352,20 +7316,16 @@ dr_fragment_size(void *drcontext, void *tag)
     int size = 0;
     CLIENT_ASSERT(drcontext != NULL, "dr_fragment_size: drcontext cannot be NULL");
     CLIENT_ASSERT(drcontext != GLOBAL_DCONTEXT, "dr_fragment_size: drcontext is invalid");
-#ifdef CLIENT_SIDELINE
     /* used to check to see if owning thread, if so don't need lock */
     /* but the check for owning thread more expensive then just getting lock */
     /* to check if owner d_r_get_thread_id() == dcontext->owning_thread */
     fragment_get_fragment_delete_mutex(dcontext);
-#endif
     f = fragment_lookup(dcontext, tag);
     if (f == NULL)
         size = 0;
     else
         size = f->size;
-#ifdef CLIENT_SIDELINE
     fragment_release_fragment_delete_mutex(dcontext);
-#endif
     return size;
 }
 
@@ -7521,12 +7481,10 @@ dr_mark_trace_head(void *drcontext, void *tag)
      * require it.
      */
     SHARED_FLAGS_RECURSIVE_LOCK(FRAG_SHARED, acquire, change_linking_lock);
-#ifdef CLIENT_SIDELINE
     /* used to check to see if owning thread, if so don't need lock */
     /* but the check for owning thread more expensive then just getting lock */
     /* to check if owner d_r_get_thread_id() == dcontext->owning_thread */
     fragment_get_fragment_delete_mutex(dcontext);
-#endif
     f = fragment_lookup_fine_and_coarse(dcontext, tag, &coarse_f, NULL);
     if (f == NULL) {
         future_fragment_t *fut;
@@ -7538,50 +7496,19 @@ dr_mark_trace_head(void *drcontext, void *tag)
             /* don't call mark_trace_head, it will try to do some linking */
             fut->flags |= FRAG_IS_TRACE_HEAD;
         }
-#ifndef CLIENT_SIDELINE
-        LOG(THREAD, LOG_MONITOR, 2,
-            "Client mark trace head : will mark fragment as trace head when built "
-            ": address " PFX "\n",
-            tag);
-#endif
     } else {
         /* check precluding conditions */
         if (TEST(FRAG_IS_TRACE, f->flags)) {
-#ifndef CLIENT_SIDELINE
-            LOG(THREAD, LOG_MONITOR, 2,
-                "Client mark trace head : not marking as trace head, is already "
-                "a trace : address " PFX "\n",
-                tag);
-#endif
             success = false;
         } else if (TEST(FRAG_CANNOT_BE_TRACE, f->flags)) {
-#ifndef CLIENT_SIDELINE
-            LOG(THREAD, LOG_MONITOR, 2,
-                "Client mark trace head : not marking as trace head, particular "
-                "fragment cannot be trace head : address " PFX "\n",
-                tag);
-#endif
             success = false;
         } else if (TEST(FRAG_IS_TRACE_HEAD, f->flags)) {
-#ifndef CLIENT_SIDELINE
-            LOG(THREAD, LOG_MONITOR, 2,
-                "Client mark trace head : fragment already marked as trace head : "
-                "address " PFX "\n",
-                tag);
-#endif
             success = true;
         } else {
             mark_trace_head(dcontext, f, NULL, NULL);
-#ifndef CLIENT_SIDELINE
-            LOG(THREAD, LOG_MONITOR, 3,
-                "Client mark trace head : just marked as trace head : address " PFX "\n",
-                tag);
-#endif
         }
     }
-#ifdef CLIENT_SIDELINE
     fragment_release_fragment_delete_mutex(dcontext);
-#endif
     SHARED_FLAGS_RECURSIVE_LOCK(FRAG_SHARED, release, change_linking_lock);
     return success;
 }
@@ -7596,9 +7523,7 @@ dr_trace_head_at(void *drcontext, void *tag)
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     fragment_t *f;
     bool trace_head;
-#ifdef CLIENT_SIDELINE
     fragment_get_fragment_delete_mutex(dcontext);
-#endif
     f = fragment_lookup(dcontext, tag);
     if (f != NULL)
         trace_head = (f->flags & FRAG_IS_TRACE_HEAD) != 0;
@@ -7609,9 +7534,7 @@ dr_trace_head_at(void *drcontext, void *tag)
         else
             trace_head = false;
     }
-#ifdef CLIENT_SIDELINE
     fragment_release_fragment_delete_mutex(dcontext);
-#endif
     return trace_head;
 }
 
@@ -7624,17 +7547,13 @@ dr_trace_exists_at(void *drcontext, void *tag)
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     fragment_t *f;
     bool trace;
-#ifdef CLIENT_SIDELINE
     fragment_get_fragment_delete_mutex(dcontext);
-#endif
     f = fragment_lookup(dcontext, tag);
     if (f != NULL)
         trace = (f->flags & FRAG_IS_TRACE) != 0;
     else
         trace = false;
-#ifdef CLIENT_SIDELINE
     fragment_release_fragment_delete_mutex(dcontext);
-#endif
     return trace;
 }
 

--- a/core/lib/instrument_api.h
+++ b/core/lib/instrument_api.h
@@ -4745,7 +4745,6 @@ dr_insert_write_raw_tls(void *drcontext, instrlist_t *ilist, instr_t *where,
  * dr_mutex_lock, and dr_messagebox are ok) then it may have performance or
  * correctness (if the synch times out) impacts.
  */
-#ifdef CLIENT_SIDELINE
 DR_API
 /**
  * Creates a new thread that is marked as a non-application thread (i.e., DR
@@ -4811,7 +4810,6 @@ DR_API
  */
 bool
 dr_client_thread_set_suspendable(bool suspendable);
-#endif /* CLIENT_SIDELINE */
 
 DR_API
 /** Current thread sleeps for \p time_ms milliseconds. */

--- a/core/synch.c
+++ b/core/synch.c
@@ -508,7 +508,6 @@ waiting_at_safe_spot(thread_record_t *trec, thread_synch_state_t desired_state)
     return false;
 }
 
-#ifdef CLIENT_SIDELINE
 static bool
 should_suspend_client_thread(dcontext_t *dcontext, thread_synch_state_t desired_state)
 {
@@ -516,7 +515,6 @@ should_suspend_client_thread(dcontext_t *dcontext, thread_synch_state_t desired_
     ASSERT(IS_CLIENT_THREAD(dcontext));
     return (THREAD_SYNCH_IS_CLEANED(desired_state) || dcontext->client_data->suspendable);
 }
-#endif
 
 /* checks whether the thread trec is at a spot suitable for requested define
  * desired_state
@@ -1542,13 +1540,11 @@ synch_with_all_abort:
         if (threads[i]->id != my_id) {
             if (synch_array[i] == SYNCH_WITH_ALL_SYNCHED) {
                 bool resume = true;
-#ifdef CLIENT_SIDELINE
                 if (IS_CLIENT_THREAD(threads[i]->dcontext) &&
                     threads[i]->dcontext->client_data->left_unsuspended) {
                     /* PR 609569: we did not suspend this thread */
                     resume = false;
                 }
-#endif
                 if (resume) {
                     DEBUG_DECLARE(ok =)
                     os_thread_resume(threads[i]);
@@ -1592,14 +1588,12 @@ resume_all_threads(thread_record_t **threads, const uint num_threads)
     for (i = 0; i < num_threads; i++) {
         if (my_tid == threads[i]->id)
             continue;
-#ifdef CLIENT_SIDELINE
         if (IS_CLIENT_THREAD(threads[i]->dcontext) &&
             threads[i]->dcontext->client_data->left_unsuspended) {
             /* PR 609569: we did not suspend this thread */
             threads[i]->dcontext->client_data->left_unsuspended = false;
             continue;
         }
-#endif
 
         /* This routine assumes that each thread in the array was suspended, so
          * each one has to successfully resume.

--- a/core/utils.h
+++ b/core/utils.h
@@ -379,9 +379,7 @@ enum {
 
     LOCK_RANK(protect_info), /* < cache and heap traversal locks */
 
-#    ifdef CLIENT_SIDELINE
     LOCK_RANK(sideline_mutex),
-#    endif
 
     LOCK_RANK(shared_cache_flush_lock), /* < shared_cache_count_lock,
                                            < shared_delete_lock,
@@ -399,9 +397,7 @@ enum {
     LOCK_RANK(shared_vm_areas), /* > change_linking_lock, < executable_areas  */
     LOCK_RANK(shared_cache_count_lock),
 
-#    ifdef CLIENT_SIDELINE
     LOCK_RANK(fragment_delete_mutex), /* > shared_vm_areas */
-#    endif
 
     LOCK_RANK(tracedump_mutex), /* > fragment_delete_mutex, > shared_vm_areas */
 

--- a/core/win32/callback.c
+++ b/core/win32/callback.c
@@ -3033,13 +3033,11 @@ possible_new_thread_wait_for_dr_init(CONTEXT *cxt)
      * let the thread continue since dynamo_thread_init will imediately
      * return. */
     uint idx;
-#ifdef CLIENT_SIDELINE
     /* We allow a client init routine to create client threads: DR is
      * initialized enough by now
      */
     if (is_new_thread_client_thread(cxt, NULL))
         return;
-#endif
 
     if (dynamo_initialized || dynamo_exited)
         return;
@@ -3104,7 +3102,6 @@ intercept_new_thread(CONTEXT *cxt)
      */
 
     /* initialize thread now */
-#ifdef CLIENT_SIDELINE
     /* i#41/PR 222812: client threads target a certain routine and always
      * directly never via win API (so we don't check THREAT_START_ADDR)
      */
@@ -3125,7 +3122,6 @@ intercept_new_thread(CONTEXT *cxt)
          */
         wait_for_event(dr_app_started, 0);
     }
-#endif
     /* FIXME i#2718: we want the app_state_at_intercept_t context, which is
      * the actual code to be run by the thread *now*, and not this CONTEXT which
      * is what will be run later!  We should make sure nobody is relying on
@@ -3138,7 +3134,6 @@ intercept_new_thread(CONTEXT *cxt)
         LOG_DECLARE(char sym_buf[MAXIMUM_SYMBOL_LENGTH];)
         bool is_nudge_thread = false;
 
-#ifdef CLIENT_SIDELINE
         if (is_client) {
             /* PR 210591: hide our threads from DllMain by not executing rest
              * of Ldr init code and going straight to target.  our_create_thread()
@@ -3147,7 +3142,6 @@ intercept_new_thread(CONTEXT *cxt)
             nt_continue(cxt);
             ASSERT_NOT_REACHED();
         }
-#endif
 
         /* Xref case 552, to ameliorate the risk of an attacker
          * leveraging our detach routines etc. against us, we detect

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -2827,7 +2827,6 @@ thread_attach_setup(priv_mcontext_t *mc)
  * CLIENT THREADS
  */
 
-#    ifdef CLIENT_SIDELINE /* PR 222812: tied to sideline usage */
 /* i#41/PR 222812: client threads
  * * thread must have dcontext since many API routines require one and we
  *   don't expose GLOBAL_DCONTEXT (xref PR 243008, PR 216936, PR 536058)
@@ -2926,7 +2925,6 @@ dr_create_client_thread(void (*func)(void *param), void *arg)
     CLIENT_ASSERT(res, "error closing thread handle");
     return res;
 }
-#    endif CLIENT_SIDELINE /* PR 222812: tied to sideline usage */
 
 int
 get_os_version()

--- a/core/win32/os_private.h
+++ b/core/win32/os_private.h
@@ -129,13 +129,11 @@ process_mmap(dcontext_t *dcontext, app_pc pc, size_t size, bool add,
 void
 check_for_ldrpLoadImportModule(byte *base, uint *ebp);
 
-#ifdef CLIENT_SIDELINE
 void
 client_thread_target(void *param);
 
 bool
 is_new_thread_client_thread(CONTEXT *cxt, OUT byte **dstack);
-#endif
 
 bool
 os_delete_file_w(const wchar_t *file_name, file_t directory_handle);

--- a/make/configure.cmake.h
+++ b/make/configure.cmake.h
@@ -195,8 +195,6 @@
 #        Only useful if custom traces are doing inlining => do not define for external
 #        release, or even by default for internal since it's always on even if
 #        not building custom traces!
-#      $(D)CLIENT_SIDELINE = allows adaptive interface methods to be called
-#                            from other threads safely, performance hit
 #    $(D)UNSUPPORTED_API -- part of 0.9.4 MIT API but not supported in current API
 #    $(D)NOT_DYNAMORIO_CORE - should be defined by non core components sharing our code
 
@@ -286,7 +284,6 @@
 /* standard client interface features */
 #define DYNAMORIO_IR_EXPORTS
 #define CUSTOM_TRACES
-#define CLIENT_SIDELINE
 /* TODO i#4045: Remove completely from the code base.
 #define UNSUPPORTED_API
  */


### PR DESCRIPTION
Removes the CLIENT_SIDELINE define as part of removing
CLIENT_INTERFACE and related defines for interfaces that are always
enabled.

Issue: #2971