### PR TITLE
i#2971 rm CI: Remove DYNAMORIO_IR_EXPORTS; it is always on.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,10 @@ endif ()
 option(VMKERNEL "target VMkernel (not officially supported yet)")
 
 # We no longer support building without a client interface: it is always enabled.
-# TODO i#2971: Remove the APP_EXPORTS option and define.
+
+# TODO i#4819: Remove {DR_}APP_EXPORTS and replace with a runtime option.
+# We'll still need something to swap DR_APP_API from import to export and
+# set that for static DR, but the rest of the defines can go.
 set(APP_EXPORTS 1)
 
 # TODO: Consider removing these no-longer-maintained options:
@@ -364,6 +367,7 @@ else ()
   # TODO i#1672: Add annotation support to AArchXX.
   set(ANNOTATIONS_DEFAULT OFF)
 endif ()
+# TODO i#4819: Remove the define and replace with a runtime option.
 option(ANNOTATIONS "annotations" ${ANNOTATIONS_DEFAULT})
 
 if (WIN32)

--- a/core/globals.h
+++ b/core/globals.h
@@ -109,11 +109,8 @@
 #    define DYNAMORIO_EXPORT
 #endif
 
-#ifdef DYNAMORIO_IR_EXPORTS
-#    define DR_API DYNAMORIO_EXPORT
-#else
-#    define DR_API
-#endif
+/* We always export nowadays. */
+#define DR_API DYNAMORIO_EXPORT
 #if (defined(DEBUG) && defined(BUILD_TESTS)) || defined(UNSUPPORTED_API)
 #    define DR_UNS_EXCEPT_TESTS_API DR_API
 #else

--- a/core/lib/genapi.pl
+++ b/core/lib/genapi.pl
@@ -518,15 +518,12 @@ sub process_header_line($)
 
     if ($output_routine) {
         if ($filter) {
-            # only export these guys for DYNAMORIO_IR_EXPORTS
-            if (defined($defines{DYNAMORIO_IR_EXPORTS})) {
-                # symbol export list (-filter option)
-                if ($l =~ /^([A-Za-z0-9_]+)\s*\(/ ||
-                    # order is important: 2nd line might pick up _IF_X64
-                    # inside param list
-                    $l =~ /^[a-zA-Z_].*\s+([A-Za-z0-9_]+)\s*\(/) {
-                    print OUT "$1;\n";
-                }
+            # symbol export list (-filter option)
+            if ($l =~ /^([A-Za-z0-9_]+)\s*\(/ ||
+                # order is important: 2nd line might pick up _IF_X64
+                # inside param list
+                $l =~ /^[a-zA-Z_].*\s+([A-Za-z0-9_]+)\s*\(/) {
+                print OUT "$1;\n";
             }
             if ($l =~ /;\s*$/ &&
                 $l !~ /^\s*\*/ && $l !~ /^\s*\/\*/) { # ignore ; inside comment

--- a/make/configure.cmake.h
+++ b/make/configure.cmake.h
@@ -281,8 +281,6 @@
 # define RCT_IND_BRANCH
 #endif
 
-/* standard client interface features */
-#define DYNAMORIO_IR_EXPORTS
 /* TODO i#4045: Remove completely from the code base.
 #define UNSUPPORTED_API
  */
@@ -297,6 +295,7 @@
 # define PROBE_API
 #endif
 
+/* TODO i#4819: Remove this define and replace with a runtime option. */
 #ifdef APP_EXPORTS
 # define DR_APP_EXPORTS
 #endif


### PR DESCRIPTION
Removes the DYNAMORIO_IR_EXPORTS define as part of removing
CLIENT_INTERFACE and related defines for interfaces that are always
enabled.

Adds comments about removing {DR_}APP_EXPORTS in the future: #4819.

Issue: #2971, #4819
Fixes #2971