### PR TITLE
i#3092 genapi: Rename and clean up opcode headers

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -64,10 +64,14 @@ function (add_gen_events_deps target)
 endfunction (add_gen_events_deps)
 
 if (AARCH64)
-  # Required for opcode.h and codec headers, which are auto-generated on AArch64.
+  # Required for opcode_api.h and codec headers, which are auto-generated on AArch64.
   include(../make/CMake_aarch64_gen_codec.cmake)
   add_custom_target(gen_aarch64_codec DEPENDS "${AARCH64_CODEC_GEN_SRCS}")
   include_directories(BEFORE ${PROJECT_BINARY_DIR})
+  add_custom_command(TARGET gen_aarch64_codec POST_BUILD
+    COMMAND ${CMAKE_COMMAND}
+    ARGS -E copy ${PROJECT_BINARY_DIR}/opcode_api.h
+    ${BUILD_INCLUDE}/dr_ir_opcodes_aarch64.h VERBATIM)
 endif ()
 
 set(asm_deps
@@ -1166,6 +1170,9 @@ DR_export_header(${CMAKE_CURRENT_SOURCE_DIR}/ir/opnd_api.h dr_ir_opnd.h)
 DR_export_header(${CMAKE_CURRENT_SOURCE_DIR}/ir/instr_api.h dr_ir_instr.h)
 DR_export_header(${CMAKE_CURRENT_SOURCE_DIR}/ir/instr_inline_api.h dr_ir_instr_inline.h)
 DR_export_header(${CMAKE_CURRENT_SOURCE_DIR}/ir/instrlist_api.h dr_ir_instrlist.h)
+DR_export_header(${CMAKE_CURRENT_SOURCE_DIR}/ir/dr_ir_opcodes.h dr_ir_opcodes.h)
+DR_export_header(${CMAKE_CURRENT_SOURCE_DIR}/ir/x86/opcode_api.h dr_ir_opcodes_x86.h)
+DR_export_header(${CMAKE_CURRENT_SOURCE_DIR}/ir/arm/opcode_api.h dr_ir_opcodes_arm.h)
 DR_export_header(${CMAKE_CURRENT_SOURCE_DIR}/lib/dr_ir_utils.h dr_ir_utils.h)
 DR_export_header(${CMAKE_CURRENT_SOURCE_DIR}/lib/dr_tools.h dr_tools.h)
 DR_export_header(${CMAKE_CURRENT_SOURCE_DIR}/annotations_api.h dr_annotation.h)

--- a/core/ir/aarch64/codec.py
+++ b/core/ir/aarch64/codec.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 # **********************************************************
+# Copyright (c) 2021 Google, Inc.   All rights reserved.
 # Copyright (c) 2016 - 2018 ARM Limited. All rights reserved.
 # **********************************************************
 
@@ -31,7 +32,8 @@
 # DAMAGE.
 
 # This script reads "codec.txt" and generates "decode_gen.h", "encode_gen.h",
-# "opcode.h" and "opcode_names.h". It is automatically run by Cmake when codec.txt changes.
+# "opcode_api.h" and "opcode_names.h".
+# It is automatically run by Cmake when codec.txt changes.
 
 import os
 import re
@@ -247,11 +249,8 @@ def generate_opcodes(patterns):
     mns = dict()
     for p in patterns:
         mns[p[2]] = 1
-    c = ['#ifndef OPCODE_H',
-         '#define OPCODE_H 1',
-         '',
-         '/* DR_API EXPORT TOFILE dr_ir_opcodes_aarch64.h */',
-         '/* DR_API EXPORT BEGIN */',
+    c = ['#ifndef _DR_IR_OPCODES_AARCH64_H_',
+         '#define _DR_IR_OPCODES_AARCH64_H_ 1',
          '',
          '/****************************************************************************',
          ' * OPCODES',
@@ -294,9 +293,8 @@ def generate_opcodes(patterns):
           '',
           '/******************************'
           '**********************************************/',
-          '/* DR_API EXPORT END */',
           '',
-          '#endif /* OPCODE_H */']
+          '#endif /* _DR_IR_OPCODES_AARCH64_H */']
     return '\n'.join(c) + '\n'
 
 def generate_opcode_names(patterns):
@@ -461,7 +459,7 @@ def main():
                      header + generate_decoder(patterns, opndsettab, opndtab))
     write_if_changed(os.path.join(sys.argv[2], 'encode_gen.h'),
                      header + generate_encoder(patterns, opndsettab, opndtab))
-    write_if_changed(os.path.join(sys.argv[2], 'opcode.h'),
+    write_if_changed(os.path.join(sys.argv[2], 'opcode_api.h'),
                      header + generate_opcodes(patterns))
     write_if_changed(os.path.join(sys.argv[2], 'opcode_names.h'),
                      header + generate_opcode_names(patterns))

--- a/core/ir/arm/opcode_api.h
+++ b/core/ir/arm/opcode_api.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -30,13 +30,8 @@
  * DAMAGE.
  */
 
-/* file "opcode.h" -- opcode definitions and utilities */
-
-#ifndef _OPCODE_H_
-#define _OPCODE_H_ 1
-
-/* DR_API EXPORT TOFILE dr_ir_opcodes_arm.h */
-/* DR_API EXPORT BEGIN */
+#ifndef _DR_IR_OPCODES_ARM_H_
+#define _DR_IR_OPCODES_ARM_H_ 1
 
 /****************************************************************************
  * OPCODES
@@ -45,7 +40,6 @@
  * @file dr_ir_opcodes_arm.h
  * @brief Instruction opcode constants for ARM.
  */
-#ifdef AVOID_API_EXPORT
 /*
  * This enum corresponds with the arrays in table_*.c.
  * They must be kept consistent, using tools/x86opnums.pl (pass -arm).
@@ -59,7 +53,6 @@
  *   5) instr_create macros
  *   6) suite/tests/api/ir* tests
  */
-#endif
 /** Opcode constants for use in the instr_t data structure. */
 enum {
     /*   0 */ OP_INVALID,
@@ -1021,12 +1014,4 @@ enum {
 #define OP_load OP_ldr          /**< Platform-independent opcode name for load. */
 #define OP_store OP_str         /**< Platform-independent opcode name for store. */
 
-/****************************************************************************/
-/* DR_API EXPORT END */
-
-enum {
-    CBZ_BYTE_A = 0xb1,  /* this assumes the top bit of the disp is 0 */
-    CBNZ_BYTE_A = 0xb9, /* this assumes the top bit of the disp is 0 */
-};
-
-#endif /* _OPCODE_H_ */
+#endif /* _DR_IR_OPCODES_ARM_H_ */

--- a/core/ir/arm/table_encode.c
+++ b/core/ir/arm/table_encode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,10 +39,10 @@
 /* clang-format off */
 
 /* When adding new opcodes here, run tools/x86opnums.pl (with the -arm option) on
- * this file and update opcode.h using the resulting output.
+ * this file and update opcode_api.h using the resulting output.
  * Also run tools/arm_table_chain.pl to update the
  * encoding chains in the tables.
- * See the list of other places to edit when adding new opcodes in opcode.h.
+ * See the list of other places to edit when adding new opcodes in opcode_api.h.
  *
  * DO NOT MANUALLY EDIT THE ENCODING CHAINS, INCLUDING THE STARTING POINTS
  * STORED IN THIS ARRAY!  Use tools/arm_table_chain.pl instead.

--- a/core/ir/dr_ir_opcodes.h
+++ b/core/ir/dr_ir_opcodes.h
@@ -1,0 +1,45 @@
+/* **********************************************************
+ * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef _DR_IR_OPCODES_H_
+#define _DR_IR_OPCODES_H_ 1
+
+#ifdef X86
+#    include "dr_ir_opcodes_x86.h"
+#elif defined(AARCH64)
+#    include "dr_ir_opcodes_aarch64.h"
+#elif defined(ARM)
+#    include "dr_ir_opcodes_arm.h"
+#endif
+
+#endif /* _DR_IR_OPCODES_H_ */

--- a/core/ir/instr.h
+++ b/core/ir/instr.h
@@ -44,7 +44,7 @@
 #ifndef _INSTR_H_
 #define _INSTR_H_ 1
 
-#include "opcode.h"
+#include "opcode_api.h"
 #include "opnd.h"
 
 /* To avoid duplicating code we use our own exported macros, unless an includer
@@ -61,19 +61,6 @@
 
 /* can't include decode.h, it includes us, just declare struct */
 struct instr_info_t;
-
-/* DR_API EXPORT TOFILE dr_ir_opcodes.h */
-/* DR_API EXPORT BEGIN */
-#ifdef API_EXPORT_ONLY
-#    ifdef X86
-#        include "dr_ir_opcodes_x86.h"
-#    elif defined(AARCH64)
-#        include "dr_ir_opcodes_aarch64.h"
-#    elif defined(ARM)
-#        include "dr_ir_opcodes_arm.h"
-#    endif
-#endif
-/* DR_API EXPORT END */
 
 /* If INSTR_INLINE is already defined, that means we've been included by
  * instr_shared.c, which wants to use C99 extern inline.  Otherwise, DR_FAST_IR
@@ -790,6 +777,94 @@ instr_raw_is_rip_rel_lea(byte *pc, byte *read_end);
 /* cbz/cbnz + b */
 #    define CTI_SHORT_REWRITE_LENGTH 6
 #    define CTI_SHORT_REWRITE_B_OFFS 2
+#endif
+
+#ifdef X86
+enum {
+    RAW_OPCODE_nop = 0x90,
+    RAW_OPCODE_jmp_short = 0xeb,
+    RAW_OPCODE_call = 0xe8,
+    RAW_OPCODE_ret = 0xc3,
+    RAW_OPCODE_jmp = 0xe9,
+    RAW_OPCODE_push_imm32 = 0x68,
+    RAW_OPCODE_pop_eax = 0x58,
+    RAW_OPCODE_jcc_short_start = 0x70,
+    RAW_OPCODE_jne_short = 0x75,
+    RAW_OPCODE_jcc_short_end = 0x7f,
+    RAW_OPCODE_jcc_byte1 = 0x0f,
+    RAW_OPCODE_jcc_byte2_start = 0x80,
+    RAW_OPCODE_jcc_byte2_end = 0x8f,
+    RAW_OPCODE_loop_start = 0xe0,
+    RAW_OPCODE_loop_end = 0xe3,
+    RAW_OPCODE_lea = 0x8d,
+    RAW_OPCODE_SIGILL = 0x0b0f,
+    RAW_PREFIX_jcc_not_taken = 0x2e,
+    RAW_PREFIX_jcc_taken = 0x3e,
+    RAW_PREFIX_lock = 0xf0,
+    RAW_PREFIX_xacquire = 0xf2,
+    RAW_PREFIX_xrelease = 0xf3,
+};
+
+enum { /* FIXME: vs RAW_OPCODE_* enum */
+       CS_SEG_OPCODE = RAW_PREFIX_jcc_not_taken,
+       DS_SEG_OPCODE = RAW_PREFIX_jcc_taken,
+       ES_SEG_OPCODE = 0x26,
+       FS_SEG_OPCODE = 0x64,
+       GS_SEG_OPCODE = 0x65,
+       SS_SEG_OPCODE = 0x36,
+
+/* For Windows, we piggyback on native TLS via gs for x64 and fs for x86.
+ * For Linux, we steal a segment register, and so use fs for x86 (where
+ * pthreads uses gs) and gs for x64 (where pthreads uses fs) (presumably
+ * to avoid conflicts w/ wine).
+ */
+#    ifdef X64
+       TLS_SEG_OPCODE = GS_SEG_OPCODE,
+#    else
+       TLS_SEG_OPCODE = FS_SEG_OPCODE,
+#    endif
+
+       DATA_PREFIX_OPCODE = 0x66,
+       ADDR_PREFIX_OPCODE = 0x67,
+       REPNE_PREFIX_OPCODE = 0xf2,
+       REP_PREFIX_OPCODE = 0xf3,
+       REX_PREFIX_BASE_OPCODE = 0x40,
+       REX_PREFIX_W_OPFLAG = 0x8,
+       REX_PREFIX_R_OPFLAG = 0x4,
+       REX_PREFIX_X_OPFLAG = 0x2,
+       REX_PREFIX_B_OPFLAG = 0x1,
+       REX_PREFIX_ALL_OPFLAGS = 0xf,
+       MOV_REG2MEM_OPCODE = 0x89,
+       MOV_MEM2REG_OPCODE = 0x8b,
+       MOV_XAX2MEM_OPCODE = 0xa3, /* no ModRm */
+       MOV_MEM2XAX_OPCODE = 0xa1, /* no ModRm */
+       MOV_IMM2XAX_OPCODE = 0xb8, /* no ModRm */
+       MOV_IMM2XBX_OPCODE = 0xbb, /* no ModRm */
+       MOV_IMM2MEM_OPCODE = 0xc7, /* has ModRm */
+       JECXZ_OPCODE = 0xe3,
+       JMP_SHORT_OPCODE = 0xeb,
+       JMP_OPCODE = 0xe9,
+       JNE_OPCODE_1 = 0x0f,
+       SAHF_OPCODE = 0x9e,
+       LAHF_OPCODE = 0x9f,
+       SETO_OPCODE_1 = 0x0f,
+       SETO_OPCODE_2 = 0x90,
+       ADD_AL_OPCODE = 0x04,
+       INC_MEM32_OPCODE_1 = 0xff, /* has /0 as well */
+       MODRM16_DISP16 = 0x06,     /* see vol.2 Table 2-1 for modR/M */
+       SIB_DISP32 = 0x25,         /* see vol.2 Table 2-1 for modR/M */
+       RET_NOIMM_OPCODE = 0xc3,
+       RET_IMM_OPCODE = 0xc2,
+       MOV_IMM_EDX_OPCODE = 0xba,
+       VEX_2BYTE_PREFIX_OPCODE = 0xc5,
+       VEX_3BYTE_PREFIX_OPCODE = 0xc4,
+       EVEX_PREFIX_OPCODE = 0x62,
+};
+#elif defined(ARM)
+enum {
+    CBZ_BYTE_A = 0xb1,  /* this assumes the top bit of the disp is 0 */
+    CBNZ_BYTE_A = 0xb9, /* this assumes the top bit of the disp is 0 */
+};
 #endif
 
 #include "instr_inline_api.h"

--- a/core/ir/opnd.h
+++ b/core/ir/opnd.h
@@ -133,6 +133,29 @@ struct _opnd_t {
  */
 #define EXPECTED_SIZEOF_OPND (3 * sizeof(uint) IF_X64(+4 /*struct size padding*/))
 
+#ifdef X86
+/* Debug registers are used for breakpoint with x86.
+ * DynamoRIO needs to keep track of their values process-wide.
+ */
+#    define DEBUG_REGISTERS_NB 4
+/* Dr7 flags mask to enable debug registers */
+#    define DEBUG_REGISTERS_FLAG_ENABLE_DR0 0x3
+#    define DEBUG_REGISTERS_FLAG_ENABLE_DR1 0xc
+#    define DEBUG_REGISTERS_FLAG_ENABLE_DR2 0x30
+#    define DEBUG_REGISTERS_FLAG_ENABLE_DR3 0xc0
+extern app_pc d_r_debug_register[DEBUG_REGISTERS_NB];
+
+/* Tells if instruction will trigger an exception because of debug register. */
+static inline bool
+debug_register_fire_on_addr(app_pc pc)
+{
+    ASSERT(DEBUG_REGISTERS_NB == 4);
+    return (pc != NULL &&
+            (pc == d_r_debug_register[0] || pc == d_r_debug_register[1] ||
+             pc == d_r_debug_register[2] || pc == d_r_debug_register[3]));
+}
+#endif
+
 /* functions to build an operand */
 
 /* not exported */

--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -69,7 +69,7 @@
  * Operand pointers into tables
  * When there are multiple encodings of an opcode, this points to the first
  * entry in a linked list.
- * This array corresponds with the enum in opcode.h
+ * This array corresponds with the enum in opcode_api.h
  * IF YOU CHANGE ONE YOU MUST CHANGE THE OTHER
  */
 const instr_info_t * const op_instr[] =

--- a/core/ir/x86/opcode_api.h
+++ b/core/ir/x86/opcode_api.h
@@ -35,13 +35,8 @@
 /* Copyright (c) 2001-2003 Massachusetts Institute of Technology */
 /* Copyright (c) 2000-2001 Hewlett-Packard Company */
 
-/* file "opcode.h" -- opcode definitions and utilities */
-
-#ifndef _OPCODE_H_
-#define _OPCODE_H_ 1
-
-/* DR_API EXPORT TOFILE dr_ir_opcodes_x86.h */
-/* DR_API EXPORT BEGIN */
+#ifndef _DR_IR_OPCODES_X86_H_
+#define _DR_IR_OPCODES_X86_H_ 1
 
 /****************************************************************************
  * OPCODES
@@ -50,7 +45,6 @@
  * @file dr_ir_opcodes_x86.h
  * @brief Instruction opcode constants for IA-32 and AMD64.
  */
-#ifdef AVOID_API_EXPORT
 /*
  * This enum corresponds with the array in decode_table.c
  * IF YOU CHANGE ONE YOU MUST CHANGE THE OTHER
@@ -65,7 +59,6 @@
  *   6) instr_create macros
  *   7) suite/tests/api/ir* tests
  */
-#endif
 /** Opcode constants for use in the instr_t data structure. */
 enum {
     /*   0 */ OP_INVALID,
@@ -1678,109 +1671,4 @@ enum {
 #define OP_icebp OP_int1
 #define OP_setalc OP_salc
 
-/****************************************************************************/
-/* DR_API EXPORT END */
-
-enum {
-    RAW_OPCODE_nop = 0x90,
-    RAW_OPCODE_jmp_short = 0xeb,
-    RAW_OPCODE_call = 0xe8,
-    RAW_OPCODE_ret = 0xc3,
-    RAW_OPCODE_jmp = 0xe9,
-    RAW_OPCODE_push_imm32 = 0x68,
-    RAW_OPCODE_pop_eax = 0x58,
-    RAW_OPCODE_jcc_short_start = 0x70,
-    RAW_OPCODE_jne_short = 0x75,
-    RAW_OPCODE_jcc_short_end = 0x7f,
-    RAW_OPCODE_jcc_byte1 = 0x0f,
-    RAW_OPCODE_jcc_byte2_start = 0x80,
-    RAW_OPCODE_jcc_byte2_end = 0x8f,
-    RAW_OPCODE_loop_start = 0xe0,
-    RAW_OPCODE_loop_end = 0xe3,
-    RAW_OPCODE_lea = 0x8d,
-    RAW_OPCODE_SIGILL = 0x0b0f,
-    RAW_PREFIX_jcc_not_taken = 0x2e,
-    RAW_PREFIX_jcc_taken = 0x3e,
-    RAW_PREFIX_lock = 0xf0,
-    RAW_PREFIX_xacquire = 0xf2,
-    RAW_PREFIX_xrelease = 0xf3,
-};
-
-enum { /* FIXME: vs RAW_OPCODE_* enum */
-       CS_SEG_OPCODE = RAW_PREFIX_jcc_not_taken,
-       DS_SEG_OPCODE = RAW_PREFIX_jcc_taken,
-       ES_SEG_OPCODE = 0x26,
-       FS_SEG_OPCODE = 0x64,
-       GS_SEG_OPCODE = 0x65,
-       SS_SEG_OPCODE = 0x36,
-
-/* For Windows, we piggyback on native TLS via gs for x64 and fs for x86.
- * For Linux, we steal a segment register, and so use fs for x86 (where
- * pthreads uses gs) and gs for x64 (where pthreads uses fs) (presumably
- * to avoid conflicts w/ wine).
- */
-#ifdef X64
-       TLS_SEG_OPCODE = GS_SEG_OPCODE,
-#else
-       TLS_SEG_OPCODE = FS_SEG_OPCODE,
-#endif
-
-       DATA_PREFIX_OPCODE = 0x66,
-       ADDR_PREFIX_OPCODE = 0x67,
-       REPNE_PREFIX_OPCODE = 0xf2,
-       REP_PREFIX_OPCODE = 0xf3,
-       REX_PREFIX_BASE_OPCODE = 0x40,
-       REX_PREFIX_W_OPFLAG = 0x8,
-       REX_PREFIX_R_OPFLAG = 0x4,
-       REX_PREFIX_X_OPFLAG = 0x2,
-       REX_PREFIX_B_OPFLAG = 0x1,
-       REX_PREFIX_ALL_OPFLAGS = 0xf,
-       MOV_REG2MEM_OPCODE = 0x89,
-       MOV_MEM2REG_OPCODE = 0x8b,
-       MOV_XAX2MEM_OPCODE = 0xa3, /* no ModRm */
-       MOV_MEM2XAX_OPCODE = 0xa1, /* no ModRm */
-       MOV_IMM2XAX_OPCODE = 0xb8, /* no ModRm */
-       MOV_IMM2XBX_OPCODE = 0xbb, /* no ModRm */
-       MOV_IMM2MEM_OPCODE = 0xc7, /* has ModRm */
-       JECXZ_OPCODE = 0xe3,
-       JMP_SHORT_OPCODE = 0xeb,
-       JMP_OPCODE = 0xe9,
-       JNE_OPCODE_1 = 0x0f,
-       SAHF_OPCODE = 0x9e,
-       LAHF_OPCODE = 0x9f,
-       SETO_OPCODE_1 = 0x0f,
-       SETO_OPCODE_2 = 0x90,
-       ADD_AL_OPCODE = 0x04,
-       INC_MEM32_OPCODE_1 = 0xff, /* has /0 as well */
-       MODRM16_DISP16 = 0x06,     /* see vol.2 Table 2-1 for modR/M */
-       SIB_DISP32 = 0x25,         /* see vol.2 Table 2-1 for modR/M */
-       RET_NOIMM_OPCODE = 0xc3,
-       RET_IMM_OPCODE = 0xc2,
-       MOV_IMM_EDX_OPCODE = 0xba,
-       VEX_2BYTE_PREFIX_OPCODE = 0xc5,
-       VEX_3BYTE_PREFIX_OPCODE = 0xc4,
-       EVEX_PREFIX_OPCODE = 0x62,
-};
-
-/* Debug registers are used for breakpoint with x86.
- * DynamoRIO needs to keep track of their values process-wide.
- */
-#define DEBUG_REGISTERS_NB 4
-/* Dr7 flags mask to enable debug registers */
-#define DEBUG_REGISTERS_FLAG_ENABLE_DR0 0x3
-#define DEBUG_REGISTERS_FLAG_ENABLE_DR1 0xc
-#define DEBUG_REGISTERS_FLAG_ENABLE_DR2 0x30
-#define DEBUG_REGISTERS_FLAG_ENABLE_DR3 0xc0
-extern app_pc d_r_debug_register[DEBUG_REGISTERS_NB];
-
-/* Tells if instruction will trigger an exception because of debug register. */
-static inline bool
-debug_register_fire_on_addr(app_pc pc)
-{
-    ASSERT(DEBUG_REGISTERS_NB == 4);
-    return (pc != NULL &&
-            (pc == d_r_debug_register[0] || pc == d_r_debug_register[1] ||
-             pc == d_r_debug_register[2] || pc == d_r_debug_register[3]));
-}
-
-#endif /* _OPCODE_H_ */
+#endif /* _DR_IR_OPCODES_X86_H_ */

--- a/core/lib/genapi.pl
+++ b/core/lib/genapi.pl
@@ -163,6 +163,10 @@ if ($header) {
                 "$existing[$index]" eq "$dir/dr_ir_instr_inline.h" ||
                 "$existing[$index]" eq "$dir/dr_ir_instrlist.h" ||
                 "$existing[$index]" eq "$dir/dr_ir_opnd.h" ||
+                "$existing[$index]" eq "$dir/dr_ir_opcodes.h" ||
+                "$existing[$index]" eq "$dir/dr_ir_opcodes_x86.h" ||
+                "$existing[$index]" eq "$dir/dr_ir_opcodes_arm.h" ||
+                "$existing[$index]" eq "$dir/dr_ir_opcodes_aarch64.h" ||
                 "$existing[$index]" eq "$dir/dr_events.h") {
                 delete $existing[$index];
             }
@@ -188,9 +192,6 @@ $arch = (defined($defines{"AARCH64"}) ? "aarch64" :
      "$core/lib/c_defines.h", # defs
      "$core/globals.h",
      "$core/arch/proc.h",
-     "$core/ir/x86/opcode.h",
-     "$core/ir/arm/opcode.h",
-     "$core/ir/instr.h",
      "$core/ir/instr_create_shared.h",
      "$core/ir/x86/instr_create.h",
      "$core/ir/aarch64/instr_create.h",
@@ -199,12 +200,6 @@ $arch = (defined($defines{"AARCH64"}) ? "aarch64" :
      "$core/hotpatch.c",         # probe api
      "$core/../libutil/dr_frontend.h",
      );
-
-# AArch64's opcode.h is auto-generated. We expect $dir point to a directory
-# one level deep in the build directory.
-if (defined($defines{"AARCH64"})) {
-    push(@headers, "$dir/../opcode.h");
-}
 
 # PR 214947: VMware retroactively holds the copyright.
 $copyright = q+/* **********************************************************

--- a/make/CMake_aarch64_gen_codec.cmake
+++ b/make/CMake_aarch64_gen_codec.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020 Google, Inc.   All rights reserved.
+# Copyright (c) 2020-2021 Google, Inc.   All rights reserved.
 # Copyright (c) 2018 Arm Limited    All rights reserved.
 # **********************************************************
 
@@ -37,7 +37,7 @@ if (NOT PYTHONINTERP_FOUND)
 endif ()
 
 set(AARCH64_CODEC_GEN_SRCS
-  ${PROJECT_BINARY_DIR}/opcode.h
+  ${PROJECT_BINARY_DIR}/opcode_api.h
   ${PROJECT_BINARY_DIR}/decode_gen.h
   ${PROJECT_BINARY_DIR}/encode_gen.h
   ${PROJECT_BINARY_DIR}/opcode_names.h

--- a/tools/x86opnums.pl
+++ b/tools/x86opnums.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # **********************************************************
-# Copyright (c) 2013-2020 Google, Inc.  All rights reserved.
+# Copyright (c) 2013-2021 Google, Inc.  All rights reserved.
 # Copyright (c) 2004-2008 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -32,7 +32,7 @@
 # DAMAGE.
 
 ### I use this script to add the numbers in comments in the OP_
-### enum in src/ir/*/opcode.h
+### enum in src/ir/*/opcode_api.h
 ### Instructions: send the modified enum from decode_table.c
 ### or table_encode.c as stdin for this script.  Pass
 ### -arm first for ARM.  The script sends to standard out the enum


### PR DESCRIPTION
Moves the small non-public parts of core/ir/*/opcode.h into instr.h
and opnd.h.

Cleans up core/ir/*/opcode.h and codec.py's generated content such
that these files are now just directly copied to the public include/
directory.

Renames opcode.h to opcode_api.h for all 3 arches to make it clear
they are part of the public interface.

Issue: #3092