### PR TITLE
i#4830: Work around GA CI VM 32-bit and clang-format toolchain regressions

### DIFF
--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -54,7 +54,7 @@ jobs:
   # the CI resources: 64-bit hits most clang-only warnings and 64-bit
   # is the primary target these days.
   clang-format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v2
@@ -69,7 +69,8 @@ jobs:
 
     - name: Create Build Environment
       run: |
-        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev
+        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
+          clang-format
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -69,8 +69,14 @@ jobs:
 
     - name: Create Build Environment
       run: |
-        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
+        sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
           clang-format-6.0
+
+    # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
+    - name: Setup newer cmake
+      uses: jwlawson/actions-setup-cmake@v1.8
+      with:
+        cmake-version: '3.19.7'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -54,7 +54,7 @@ jobs:
   # the CI resources: 64-bit hits most clang-only warnings and 64-bit
   # is the primary target these days.
   clang-format:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -76,8 +76,6 @@ jobs:
       run: ./suite/runsuite_wrapper.pl automated_ci 64_only require_format
       env:
         DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: no
-        CC: clang-9
-        CXX: clang++-9
 
     - name: Send failure mail to dynamorio-devs
       if: failure() && github.ref == 'refs/heads/master'

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Create Build Environment
       run: |
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          clang-format
+          clang-format-6
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Create Build Environment
       run: |
         sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          clang-format-6
+          clang-format-6.0
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -72,17 +72,13 @@ jobs:
         sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
           clang-format-6.0
 
-    # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
-    - name: Setup newer cmake
-      uses: jwlawson/actions-setup-cmake@v1.8
-      with:
-        cmake-version: '3.19.7'
-
     - name: Run Suite
       working-directory: ${{ github.workspace }}
       run: ./suite/runsuite_wrapper.pl automated_ci 64_only require_format
       env:
         DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: no
+        CC: clang-9
+        CXX: clang++-9
 
     - name: Send failure mail to dynamorio-devs
       if: failure() && github.ref == 'refs/heads/master'

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -73,8 +73,14 @@ jobs:
     - name: Create Build Environment
       run: |
         sudo apt update
-        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
+        sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
           g++-multilib
+
+    # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
+    - name: Setup newer cmake
+      uses: jwlawson/actions-setup-cmake@v1.8
+      with:
+        cmake-version: '3.19.7'
 
     - name: Get Version
       id: version

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -55,7 +55,7 @@ defaults:
 jobs:
   # 32-bit Linux build with gcc and run tests:
   x86-32:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     # When checking out the repository that triggered a workflow, actions/checkout@v2
     # defaults to the reference or SHA for that event. See documentation for ref at
@@ -115,7 +115,7 @@ jobs:
 
   # 64-bit Linux build with gcc and run tests:
   x86-64:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -55,7 +55,7 @@ defaults:
 jobs:
   # 32-bit Linux build with gcc and run tests:
   x86-32:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     # When checking out the repository that triggered a workflow, actions/checkout@v2
     # defaults to the reference or SHA for that event. See documentation for ref at
@@ -76,12 +76,13 @@ jobs:
     # workaround here and from every job in other Github Actions CI workflows.
     - run: git fetch --no-tags --depth=1 origin master
 
-    # Install multilib for non-cross-compiling Linux build:
+    # Install multilib for non-cross-compiling Linux build.
+    # Install g++-8 to work around 32-bit toolchain problems with 9 (i#4830).
     - name: Create Build Environment
       run: |
         sudo apt update
-        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          g++-multilib
+        sudo apt-get -y install g++-8 doxygen vera++ cmake zlib1g-dev libsnappy-dev \
+          g++-8-multilib
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -115,7 +116,7 @@ jobs:
 
   # 64-bit Linux build with gcc and run tests:
   x86-64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v2
@@ -128,12 +129,13 @@ jobs:
 
     - run: git fetch --no-tags --depth=1 origin master
 
-    # Install multilib for non-cross-compiling Linux build:
+    # Install multilib for non-cross-compiling Linux build.
+    # Install g++-8 to work around 32-bit toolchain problems with 9 (i#4830).
     - name: Create Build Environment
       run: |
         sudo apt update
-        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          g++-multilib
+        sudo apt-get -y install g++-8 doxygen vera++ cmake zlib1g-dev libsnappy-dev \
+          g++-8-multilib
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -77,12 +77,17 @@ jobs:
     - run: git fetch --no-tags --depth=1 origin master
 
     # Install multilib for non-cross-compiling Linux build.
-    # Install g++-8 to work around 32-bit toolchain problems with 9 (i#4830).
     - name: Create Build Environment
       run: |
         sudo apt update
-        sudo apt-get -y install g++-8 doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          g++-8-multilib
+        sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
+          g++-multilib
+
+    # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
+    - name: Setup newer cmake
+      uses: jwlawson/actions-setup-cmake@v1.8
+      with:
+        cmake-version: '3.19.7'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -130,12 +135,17 @@ jobs:
     - run: git fetch --no-tags --depth=1 origin master
 
     # Install multilib for non-cross-compiling Linux build.
-    # Install g++-8 to work around 32-bit toolchain problems with 9 (i#4830).
     - name: Create Build Environment
       run: |
         sudo apt update
-        sudo apt-get -y install g++-8 doxygen vera++ cmake zlib1g-dev libsnappy-dev \
-          g++-8-multilib
+        sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
+          g++-multilib
+
+    # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
+    - name: Setup newer cmake
+      uses: jwlawson/actions-setup-cmake@v1.8
+      with:
+        cmake-version: '3.19.7'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}


### PR DESCRIPTION
WIP: Try Ubuntu 20 for clang w/o the clang-9 env var;
Try Ubuntu 18 for x86 to see if toolchain is better w/o test failures

Issue: #4830