### PR TITLE
i#3092 genapi: Avoid superfluous header copies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1688,7 +1688,7 @@ set(EXTRA_HEADERS ${BUILD_INCLUDE}/dr_defines.h)
 add_custom_target(api_headers
   DEPENDS ${EXTRA_HEADERS})
 if (AARCH64)
-  add_dependencies(api_headers gen_aarch64_codec)
+  add_dependencies(api_headers gen_aarch64_codec gen_aarch64_opcodes)
 endif()
 
 DR_export_header(${PROJECT_SOURCE_DIR}/core/lib/dr_app.h dr_app.h)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -68,7 +68,12 @@ if (AARCH64)
   include(../make/CMake_aarch64_gen_codec.cmake)
   add_custom_target(gen_aarch64_codec DEPENDS "${AARCH64_CODEC_GEN_SRCS}")
   include_directories(BEFORE ${PROJECT_BINARY_DIR})
-  add_custom_command(TARGET gen_aarch64_codec POST_BUILD
+  # Export the generated opcode header.  Use a custom target and command to avoid
+  # repeated re-copying (a POST_BUILD with copy_if_different doesn't seem to work how
+  # it should: it still runs the command every time, though it doesn't copy anything).
+  add_custom_target(gen_aarch64_opcodes DEPENDS ${BUILD_INCLUDE}/dr_ir_opcodes_aarch64.h)
+  add_custom_command(OUTPUT ${BUILD_INCLUDE}/dr_ir_opcodes_aarch64.h
+    DEPENDS ${PROJECT_BINARY_DIR}/opcode_api.h
     COMMAND ${CMAKE_COMMAND}
     ARGS -E copy ${PROJECT_BINARY_DIR}/opcode_api.h
     ${BUILD_INCLUDE}/dr_ir_opcodes_aarch64.h VERBATIM)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -71,12 +71,13 @@ if (AARCH64)
   # Export the generated opcode header.  Use a custom target and command to avoid
   # repeated re-copying (a POST_BUILD with copy_if_different doesn't seem to work how
   # it should: it still runs the command every time, though it doesn't copy anything).
-  add_custom_target(gen_aarch64_opcodes DEPENDS ${BUILD_INCLUDE}/dr_ir_opcodes_aarch64.h)
-  add_custom_command(OUTPUT ${BUILD_INCLUDE}/dr_ir_opcodes_aarch64.h
+  set(aarch64_exported_opcodes ${BUILD_INCLUDE}/dr_ir_opcodes_aarch64.h)
+  add_custom_target(gen_aarch64_opcodes DEPENDS ${aarch64_exported_opcodes})
+  add_custom_command(OUTPUT ${aarch64_exported_opcodes}
     DEPENDS ${PROJECT_BINARY_DIR}/opcode_api.h
     COMMAND ${CMAKE_COMMAND}
     ARGS -E copy ${PROJECT_BINARY_DIR}/opcode_api.h
-    ${BUILD_INCLUDE}/dr_ir_opcodes_aarch64.h VERBATIM)
+    ${aarch64_exported_opcodes} VERBATIM)
 endif ()
 
 set(asm_deps


### PR DESCRIPTION
Adds a custom target to avoid AArch64 builds repeatedly copying the
opcode header and rebuilding affected targets.

Issue: #3092