### PR TITLE
Remove two (now tested) cases of ASSERT_NOT_TESTED for AARCH64

### DIFF
--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -5555,10 +5555,6 @@ emit_special_ibl_xfer(dcontext_t *dcontext, byte *pc, generated_code_t *code, ui
         INSTR_CREATE_cbz(dcontext, opnd_create_instr(skip_unlinked_tgt_jump),
                          opnd_create_reg(SCRATCH_REG5)));
     insert_shared_restore_dcontext_reg(dcontext, &ilist, NULL);
-    /* i#4670: The unlinking case is observed to hit very infrequently on x86. The issue
-     *  or the fix have not been observed on AArchXX yet.
-     */
-    ASSERT_NOT_TESTED();
 #        if defined(AARCH64)
     APP(&ilist,
         INSTR_CREATE_ldr(
@@ -5566,6 +5562,10 @@ emit_special_ibl_xfer(dcontext_t *dcontext, byte *pc, generated_code_t *code, ui
             OPND_TLS_FIELD(get_ibl_entry_tls_offs(dcontext, ibl_unlinked_tgt))));
     APP(&ilist, XINST_CREATE_jump_reg(dcontext, opnd_create_reg(SCRATCH_REG1)));
 #        else  /* ARM */
+    /* i#4670: The unlinking case is observed to hit very infrequently on x86.
+     * The fix has been tested on AArch64 but not on ARM yet.
+     */
+    ASSERT_NOT_TESTED();
     /* i#1906: loads to PC must use word-aligned addresses */
     ASSERT(
         ALIGNED(get_ibl_entry_tls_offs(dcontext, ibl_unlinked_tgt), PC_LOAD_ADDR_ALIGN));

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4170,11 +4170,12 @@ find_next_fragment_from_gencode(dcontext_t *dcontext, sigcontext_t *sc)
                 ASSERT(target != NULL);
                 if (target != NULL)
                     f = fragment_pclookup(dcontext, target, &wrapper);
-                /* I tried to hit this case running client.cleancallsig in a loop
-                 * and while I could on x86 and x86_64 I never did on ARM or
-                 * AArch64.  We can remove this once someone hits it and it works.
+                /* Hit this case running client.cleancallsig in a loop on x86
+                 * and x86_64, and hit it in a proprietary application with
+                 * plain DR (debug build) on AArch64. Never tested for ARM. We
+                 * can remove this once someone hits it and it works.
                  */
-                IF_AARCHXX(ASSERT_NOT_TESTED());
+                IF_ARM(ASSERT_NOT_TESTED());
             }
             instr_free(dcontext, &instr);
         }


### PR DESCRIPTION
PR #3003 added handling of a signal interrupting the ibl hit path's jump, but the introduced
client.cleancallsig test could not test the ibl jump on AArchXX leading to the insertion of an
ASSERT_NOT_TESTED() for AARCHXX. Testing on a proprietary app with plain DR (debug build)
on AArch64 hit this case without problems. Thus, we can remove the ASSERT_NOT_TESTED() 
for AARCH64.

The code inserted in PR #4797 was triggered and tested for AARCH64 on a proprietary app so 
remove the ASSERT_NOT_TESTED() for AARCH64 from there as well.