### PR TITLE
i#4425: handle unspecified-by-the-app sigaction restorer for AArch64

### DIFF
--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -177,9 +177,7 @@ static std::string
 gather_trace()
 {
     if (!my_setenv("DYNAMORIO_OPTIONS",
-                   // XXX i#4425: Fix debug-build stack overflow issue and
-                   // remove custom signal_stack_size below.
-                   "-stderr_mask 0xc -signal_stack_size 64K "
+                   "-stderr_mask 0xc "
                    "-client_lib ';;-offline'"))
         std::cerr << "failed to set env var!\n";
 

--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -176,9 +176,7 @@ post_process()
 static std::string
 gather_trace()
 {
-    if (!my_setenv("DYNAMORIO_OPTIONS",
-                   "-stderr_mask 0xc "
-                   "-client_lib ';;-offline'"))
+    if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -client_lib ';;-offline'"))
         std::cerr << "failed to set env var!\n";
 
     std::cerr << "pre-DR init\n";


### PR DESCRIPTION
Prevents a seg fault in the burst_aarch64_sys test that was caused by reading an unspecified
sigaction restorer in sig_has_restorer() in unix/signal.c. Does so by returning false early
in sig_has_restorer() for AArch64 when the SA_RESTORER flag is not set.

By preventing the seg fault, it also prevents the nested signal handling and consequently
the stack overflow in burst_aarch64_sys test when the -signal_stack_size is not specified.

Issue: #4425