### PR TITLE
i#1738 dr$sim perf: Improve tag lookup speed with a hashtable

### DIFF
--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -363,8 +363,11 @@ cache_simulator_t::cache_simulator_t(std::istream *config_file)
         success_ = false;
         return;
     }
-    // TODO add comment and name "32"
-    if (other_caches_.size() > 0 && (knobs_.model_coherence || knobs_.num_cores > 32)) {
+    // For larger hierarchies, especially with coherence, using hashtables
+    // for faster lookups provides performance wins as high as 15%.
+    // However, hashtables can slow down smaller hierarchies, so we only
+    // enable if we anticipate a win.
+    if (other_caches_.size() > 0 && (knobs_.model_coherence || knobs_.num_cores >= 32)) {
         for (auto &cache : all_caches_) {
             cache.second->set_hashtable_use(true);
         }

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -362,6 +362,12 @@ cache_simulator_t::cache_simulator_t(std::istream *config_file)
         ERRMSG("Usage error: failed to initialize snoop filter.\n");
         success_ = false;
         return;
+    }
+    // TODO add comment and name "32"
+    if (other_caches_.size() > 0 && (knobs_.model_coherence || knobs_.num_cores > 32)) {
+        for (auto &cache : all_caches_) {
+            cache.second->set_hashtable_use(true);
+        }
     }
 }
 

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -36,7 +36,6 @@
 #ifndef _CACHING_DEVICE_H_
 #define _CACHING_DEVICE_H_ 1
 
-#include <iostream> //NOCHECK
 #include <functional>
 #include <unordered_map>
 #include <vector>
@@ -102,16 +101,19 @@ public:
     {
         return double(loaded_blocks_) / num_blocks_;
     }
+    // Must be called prior to any call to request().
     virtual inline void
     set_hashtable_use(bool use_hashtable)
     {
+        if (!use_tag2block_table_ && use_hashtable) {
+            // Resizing from an initial small table causes noticeable overhead, so we
+            // start with a relatively large table.
+            tag2block.reserve(1 << 16);
+            // Even with the large initial size, for large caches we want to keep the
+            // load factor small.
+            tag2block.max_load_factor(0.5);
+        }
         use_tag2block_table_ = use_hashtable;
-        // Resizing from an initial small table causes noticeable overhead, so we
-        // start with a relatively large table.
-        tag2block.reserve(1 << 16);
-        // Even with the large initial size, for large caches we want to keep the
-        // load factor small.
-        tag2block.max_load_factor(0.5);
     }
 
 protected:

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -160,7 +160,7 @@ protected:
     }
 
     // Returns the block (and its way) whose tag equals `tag`.
-    // Returns <nullptr,0> is there is no such block.
+    // Returns <nullptr,0> if there is no such block.
     std::pair<caching_device_block_t *, int>
     find_caching_device_block(addr_t tag);
 

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -36,6 +36,9 @@
 #ifndef _CACHING_DEVICE_H_
 #define _CACHING_DEVICE_H_ 1
 
+#include <iostream> //NOCHECK
+#include <functional>
+#include <unordered_map>
 #include <vector>
 
 #include "caching_device_block.h"
@@ -99,6 +102,17 @@ public:
     {
         return double(loaded_blocks_) / num_blocks_;
     }
+    virtual inline void
+    set_hashtable_use(bool use_hashtable)
+    {
+        use_tag2block_table_ = use_hashtable;
+        // Resizing from an initial small table causes noticeable overhead, so we
+        // start with a relatively large table.
+        tag2block.reserve(1 << 16);
+        // Even with the large initial size, for large caches we want to keep the
+        // load factor small.
+        tag2block.max_load_factor(0.5);
+    }
 
 protected:
     virtual void
@@ -121,6 +135,33 @@ protected:
     {
         return *(blocks_[block_idx + way]);
     }
+
+    inline void
+    invalidate_caching_device_block(caching_device_block_t *block)
+    {
+        if (use_tag2block_table_)
+            tag2block.erase(block->tag_);
+        block->tag_ = TAG_INVALID;
+        // Xref cache_block_t constructor about why we set counter to 0.
+        block->counter_ = 0;
+    }
+
+    inline void
+    update_tag(caching_device_block_t *block, int way, addr_t new_tag)
+    {
+        if (use_tag2block_table_) {
+            if (block->tag_ != TAG_INVALID)
+                tag2block.erase(block->tag_);
+            tag2block[new_tag] = std::make_pair(block, way);
+        }
+        block->tag_ = new_tag;
+    }
+
+    // Returns the block (and its way) whose tag equals `tag`.
+    // Returns <nullptr,0> is there is no such block.
+    std::pair<caching_device_block_t *, int>
+    find_caching_device_block(addr_t tag);
+
     // a pure virtual function for subclasses to initialize their own block array
     virtual void
     init_blocks() = 0;
@@ -161,6 +202,16 @@ protected:
     addr_t last_tag_;
     int last_way_;
     int last_block_idx_;
+    // Optimization: keep a hashtable for quick lookup of {block,way}
+    // given a tag, if using a large cache hierarchy where serial
+    // walks over the associativity end up as bottlenecks.
+    // We can't easily remove the blocks_ array and replace with just
+    // the hashtable as replace_which_way(), etc. want quick access to
+    // every way for a given line index.
+    std::unordered_map<addr_t, std::pair<caching_device_block_t *, int>,
+                       std::function<unsigned long(addr_t)>>
+        tag2block;
+    bool use_tag2block_table_ = false;
 };
 
 #endif /* _CACHING_DEVICE_H_ */

--- a/clients/drcachesim/simulator/tlb.cpp
+++ b/clients/drcachesim/simulator/tlb.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,6 +49,9 @@ tlb_t::request(const memref_t &memref_in)
     // Since pid is needed in a lot of places from the beginning to the end,
     // it might also not be a good way to write a lot of helper functions
     // to isolate them.
+    // TODO i#4816: This tag,pid pair lookup needs to be imposed on the parent
+    // methods invalidate(), contains_tag(), and propagate_eviction() by overriding
+    // them.
 
     // Unfortunately we need to make a copy for our loop so we can pass
     // the right data struct to the parent and stats collectors.

--- a/clients/drcachesim/simulator/tlb.h
+++ b/clients/drcachesim/simulator/tlb.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -44,6 +44,10 @@ class tlb_t : public caching_device_t {
 public:
     void
     request(const memref_t &memref) override;
+
+    // TODO i#4816: This tag,pid pair lookup needs to be imposed on the parent
+    // methods invalidate(), contains_tag(), and propagate_eviction() by overriding
+    // them.
 
 protected:
     void

--- a/clients/drcachesim/simulator/tlb.h
+++ b/clients/drcachesim/simulator/tlb.h
@@ -45,9 +45,9 @@ public:
     void
     request(const memref_t &memref) override;
 
-    // TODO i#4816: This tag,pid pair lookup needs to be imposed on the parent
-    // methods invalidate(), contains_tag(), and propagate_eviction() by overriding
-    // them.
+    // TODO i#4816: The addition of the pid as a lookup parameter beyond just the tag
+    // needs to be imposed on the parent methods invalidate(), contains_tag(), and
+    // propagate_eviction() by overriding them.
 
 protected:
     void

--- a/clients/drcachesim/tests/cores-1-levels-3-no-missfile.conf
+++ b/clients/drcachesim/tests/cores-1-levels-3-no-missfile.conf
@@ -5,6 +5,9 @@
 // Common params.
 num_cores       1
 line_size       64
+// Turn on coherence as another test of that option, as well as
+// to trigger hashtable optimizations in caches and test those.
+coherence       true
 
 L1I {                        // L1 I$
   type            instruction

--- a/clients/drcachesim/tests/simple-config-file.templatex
+++ b/clients/drcachesim/tests/simple-config-file.templatex
@@ -5,12 +5,14 @@ Core #0 \(1 thread\(s\)\)
   L1I stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
-    Invalidations:                *[0-9,\.]*
+    Parent invalidations:         *[0-9,\.]*
+    Write invalidations:          *[0-9,\.]*
 .*    Miss rate:                        [0-9][,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
-    Invalidations:                *[0-9,\.]*
+    Parent invalidations:         *[0-9,\.]*
+    Write invalidations:          *[0-9,\.]*
 .*   Miss rate:                        [0-9][,\.]..%
 L2 stats:
     Hits:                         *[0-9,\.]*
@@ -26,3 +28,4 @@ LLC stats:
 .*   Local miss rate:         *[0-9,\.]*%
     Child hits:                   *[0-9,\.]*
     Total miss rate:          *[0-9,\.]*%
+Coherence stats:.*

--- a/clients/drcachesim/tests/threads-with-config-file.templatex
+++ b/clients/drcachesim/tests/threads-with-config-file.templatex
@@ -34,12 +34,14 @@ Core #0 \(.*\)
   L1I stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
-    Invalidations:              *[0-9,\.]*
+    Parent invalidations:       *[0-9,\.]*
+    Write invalidations:        *[0-9,\.]*
 .*    Miss rate:                *[0-9,\.]*%
   L1D stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
-    Invalidations:              *[0-9,\.]*
+    Parent invalidations:       *[0-9,\.]*
+    Write invalidations:        *[0-9,\.]*
 .*    Miss rate:                *[0-9,\.]*%
 L2 stats:
     Hits:                       *[0-9,\.]*
@@ -55,3 +57,4 @@ LLC stats:
 .*    Local miss rate:        *[0-9,.]*%
     Child hits:                 *[0-9,\.]*
     Total miss rate:            *[0-9,\.]*%
+Coherence stats:.*


### PR DESCRIPTION
Replaces drcachesim's loops over all ways with a hashtable lookup.
For larger cache hierarchies and caches with higher associativity this
increases performance by 15% in cpu-bound tests on offline traces,
when we use a large initial table size to avoid resizes which seem to
outweigh the gains.

The hashtable unfortunately results in a 15% slowdown on simple cache
hierarchies, due to the extra time in erase() and other maintenance
operations outweighing the smaller gains in lookup.  Thus, we make the
default to *not* use a hashtable and use the original linear walk,
providing a method to optionally enable the hashtable.  The cache
simulator enables the hashtables for any 3+-level cache hierarchy with
either coherence or many cores.

Adds coherence to some existing 3-level-hierarchy tests to ensure we
have tests that cover the hashtable path.

The TLB simulator will need to tweak these hashtables: but it looks
like it is already doing the wrong thing in invalidate() and other
simulator_t methods, filed as #4816.

Issue: #1738, #4816