### PR TITLE
Add support for FCVTZU to DynamoRIO codec

### DIFF
--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -1119,6 +1119,19 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0001111011100010010000xxxxxxxxxx     fcvt      s0 : h5
 0001111011100010110000xxxxxxxxxx     fcvt      d0 : h5
 
+# FCVTZU (scalar, integer) FP to GPR reg
+0001111000111001000000xxxxxxxxxx     fcvtzu    w0 : s5
+1001111000111001000000xxxxxxxxxx     fcvtzu    x0 : s5
+0001111001111001000000xxxxxxxxxx     fcvtzu    w0 : d5
+1001111001111001000000xxxxxxxxxx     fcvtzu    x0 : d5
+
+# FCVTZU (vector, integer)
+0x1011101x100001101110xxxxxxxxxx     fcvtzu    dq0 : dq5 sd_sz
+
+# FCVTZU (Scalar single precision and double-precision)
+0111111010100001101110xxxxxxxxxx     fcvtzu    s0 : s5
+0111111011100001101110xxxxxxxxxx     fcvtzu    d0 : d5
+
 # Floating-point data-processing (2 source)
 00011110xx1xxxxx000010xxxxxxxxxx     fmul      float_reg0 : float_reg5 float_reg16
 00011110xx1xxxxx000110xxxxxxxxxx     fdiv      float_reg0 : float_reg5 float_reg16

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1751,7 +1751,8 @@ enum {
  * \param Rd      The output register.
  * \param Rm      The first input register.
  */
-#define INSTR_CREATE_fcvtzu_scalar(dc, Rd, Rm) instr_create_1dst_1src(dc, OP_fcvtzu, Rd, Rm)
+#define INSTR_CREATE_fcvtzu_scalar(dc, Rd, Rm) \
+    instr_create_1dst_1src(dc, OP_fcvtzu, Rd, Rm)
 
 /**
  * Creates a FRINTN floating point instruction.

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1748,8 +1748,8 @@ enum {
 /**
  * Creates a FCVTZU floating point instruction.
  * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
+ * \param Rd      Floating-point or integer output register.
+ * \param Rm      Floating-point input register.
  */
 #define INSTR_CREATE_fcvtzu_scalar(dc, Rd, Rm) \
     instr_create_1dst_1src(dc, OP_fcvtzu, Rd, Rm)

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1693,6 +1693,16 @@ enum {
 #define INSTR_CREATE_bif_vector(dc, Rd, Rm, Rn) \
     instr_create_1dst_2src(dc, OP_bif, Rd, Rm, Rn)
 
+/**
+ * Creates a FCVTZU vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param width   The input element vector width.
+ */
+#define INSTR_CREATE_fcvtzu_vector(dc, Rd, Rm, width) \
+    instr_create_1dst_2src(dc, OP_fcvtzu, Rd, Rm, width)
+
 /* -------- Floating-point data-processing (1 source) ------------------ */
 
 /**
@@ -1734,6 +1744,14 @@ enum {
  * \param Rm      The first input register.
  */
 #define INSTR_CREATE_fcvt_scalar(dc, Rd, Rm) instr_create_1dst_1src(dc, OP_fcvt, Rd, Rm)
+
+/**
+ * Creates a FCVTZU floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ */
+#define INSTR_CREATE_fcvtzu_scalar(dc, Rd, Rm) instr_create_1dst_1src(dc, OP_fcvtzu, Rd, Rm)
 
 /**
  * Creates a FRINTN floating point instruction.

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -2099,6 +2099,15 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 1e63c1fd : fcvt h29, d15                            : fcvt   %d15 -> %h29
 1ee2431c : fcvt s28, h24                            : fcvt   %h24 -> %s28
 1ee2c002 : fcvt d2, h0                              : fcvt   %h0 -> %d2
+1e390121 : fcvtzu w1, s9                            : fcvtzu %s9 -> %w1
+9e39012b : fcvtzu x11, s9                           : fcvtzu %s9 -> %x11
+1e7901a7 : fcvtzu w7, d13                           : fcvtzu %d13 -> %w7
+9e790055 : fcvtzu x21, d2                           : fcvtzu %d2 -> %x21
+2ea1b829 : fcvtzu v9.2s, v1.2s                      : fcvtzu %d1 $0x02 -> %d9
+6ea1b910 : fcvtzu v16.4s, v8.4s                     : fcvtzu %q8 $0x02 -> %q16
+6ee1b803 : fcvtzu v3.2d, v0.2d                      : fcvtzu %q0 $0x03 -> %q3
+7ea1b929 : fcvtzu s9, s9                            : fcvtzu %s9 -> %s9
+7ee1b841 : fcvtzu d1, d2                            : fcvtzu %d2 -> %d1
 
 # Floating-point data-processing (2 source)
 1e7e0b62 : fmul d2, d27, d30                        : fmul   %d27 %d30 -> %d2

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -4622,22 +4622,22 @@ test_fcvtzu_scalar(void *dc)
     instr_t *instr;
     /* FCVTZU <Wd>, <Sn> */
     instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_W7),
-                                         opnd_create_reg(DR_REG_S8));
+                                       opnd_create_reg(DR_REG_S8));
     test_instr_encoding(dc, OP_fcvtzu, instr);
 
     /* FCVTZU <Xd>, <Sn> */
     instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_X13),
-                                         opnd_create_reg(DR_REG_S21));
+                                       opnd_create_reg(DR_REG_S21));
     test_instr_encoding(dc, OP_fcvtzu, instr);
 
     /* FCVTZU <Wd>, <Dn> */
     instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_W0),
-                                         opnd_create_reg(DR_REG_D9));
+                                       opnd_create_reg(DR_REG_D9));
     test_instr_encoding(dc, OP_fcvtzu, instr);
 
     /* FCVTZU <Xd>, <Dn> */
     instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_X12),
-                                         opnd_create_reg(DR_REG_D12));
+                                       opnd_create_reg(DR_REG_D12));
     test_instr_encoding(dc, OP_fcvtzu, instr);
 }
 
@@ -4647,22 +4647,22 @@ test_fcvtzu_vector(void *dc)
     instr_t *instr;
     /* FCVTZU <Vd>.<T>, <Vn>.<T> */
     instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(DR_REG_D7),
-                                          opnd_create_reg(DR_REG_D9), OPND_CREATE_SINGLE());
+                                       opnd_create_reg(DR_REG_D9), OPND_CREATE_SINGLE());
     test_instr_encoding(dc, OP_fcvtzu, instr);
     instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(DR_REG_Q1),
-                                          opnd_create_reg(DR_REG_Q24), OPND_CREATE_SINGLE());
+                                       opnd_create_reg(DR_REG_Q24), OPND_CREATE_SINGLE());
     test_instr_encoding(dc, OP_fcvtzu, instr);
     instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(DR_REG_Q5),
-                                          opnd_create_reg(DR_REG_Q18), OPND_CREATE_DOUBLE());
+                                       opnd_create_reg(DR_REG_Q18), OPND_CREATE_DOUBLE());
     test_instr_encoding(dc, OP_fcvtzu, instr);
 
     /* FCVTZU <V><d>, <V><n> */
     instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_S9),
-                                         opnd_create_reg(DR_REG_S10));
+                                       opnd_create_reg(DR_REG_S10));
     test_instr_encoding(dc, OP_fcvtzu, instr);
 
     instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_D11),
-                                         opnd_create_reg(DR_REG_D0));
+                                       opnd_create_reg(DR_REG_D0));
     test_instr_encoding(dc, OP_fcvtzu, instr);
 }
 

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -4616,6 +4616,56 @@ test_mov_instr_addr(void *dc)
     instr_destroy(dc, label_instr);
 }
 
+static void
+test_fcvtzu_scalar(void *dc)
+{
+    instr_t *instr;
+    /* FCVTZU <Wd>, <Sn> */
+    instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_W7),
+                                         opnd_create_reg(DR_REG_S8));
+    test_instr_encoding(dc, OP_fcvtzu, instr);
+
+    /* FCVTZU <Xd>, <Sn> */
+    instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_X13),
+                                         opnd_create_reg(DR_REG_S21));
+    test_instr_encoding(dc, OP_fcvtzu, instr);
+
+    /* FCVTZU <Wd>, <Dn> */
+    instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_W0),
+                                         opnd_create_reg(DR_REG_D9));
+    test_instr_encoding(dc, OP_fcvtzu, instr);
+
+    /* FCVTZU <Xd>, <Dn> */
+    instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_X12),
+                                         opnd_create_reg(DR_REG_D12));
+    test_instr_encoding(dc, OP_fcvtzu, instr);
+}
+
+static void
+test_fcvtzu_vector(void *dc)
+{
+    instr_t *instr;
+    /* FCVTZU <Vd>.<T>, <Vn>.<T> */
+    instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(DR_REG_D7),
+                                          opnd_create_reg(DR_REG_D9), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcvtzu, instr);
+    instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(DR_REG_Q1),
+                                          opnd_create_reg(DR_REG_Q24), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcvtzu, instr);
+    instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(DR_REG_Q5),
+                                          opnd_create_reg(DR_REG_Q18), OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fcvtzu, instr);
+
+    /* FCVTZU <V><d>, <V><n> */
+    instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_S9),
+                                         opnd_create_reg(DR_REG_S10));
+    test_instr_encoding(dc, OP_fcvtzu, instr);
+
+    instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_D11),
+                                         opnd_create_reg(DR_REG_D0));
+    test_instr_encoding(dc, OP_fcvtzu, instr);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -4690,6 +4740,12 @@ main(int argc, char *argv[])
 
     test_mov_instr_addr(dcontext);
     print("test_mov_instr_addr complete\n");
+
+    test_fcvtzu_scalar(dcontext);
+    print("test_fcvtzu_scalar complete\n");
+
+    test_fcvtzu_vector(dcontext);
+    print("test_fcvtzu_vector complete\n");
 
     print("All tests complete\n");
 #ifndef STANDALONE_DECODER

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -865,4 +865,15 @@ blr    %x5 -> %x30
 test_xinst complete
 test_opnd complete
 test_mov_instr_addr complete
+fcvtzu %s8 -> %w7
+fcvtzu %s21 -> %x13
+fcvtzu %d9 -> %w0
+fcvtzu %d12 -> %x12
+test_fcvtzu_scalar complete
+fcvtzu %d9 $0x02 -> %d7
+fcvtzu %q24 $0x02 -> %q1
+fcvtzu %q18 $0x03 -> %q5
+fcvtzu %s10 -> %s9
+fcvtzu %d0 -> %d11
+test_fcvtzu_vector complete
 All tests complete


### PR DESCRIPTION
FCVTZU was overlooked in the original AArch64 port.
This is the first in a series of patches to implement missing instructions in the codec.

This patch is related to issue 2626:
https://github.com/DynamoRIO/dynamorio/issues/2626