### PR TITLE
Fix flaky regex that doesn't match smaller miss rates

### DIFF
--- a/clients/drcachesim/tests/filter-no-d.templatex
+++ b/clients/drcachesim/tests/filter-no-d.templatex
@@ -6,7 +6,7 @@ Core #0 \(1 thread\(s\)\)
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                   *[1-9][0-9][,\.]..%
+.*   Miss rate:                   *[1-9]?[0-9][,\.]..%
   L1D stats:
     Hits:                                0
     Misses:                              0
@@ -20,4 +20,4 @@ LL stats:
     Invalidations:                *0
 .*   Local miss rate:        *[0-9,.]*%
     Child hits:                   *[0-9,\.]*
-    Total miss rate:              *[1-9][0-9][,\.]..%
+    Total miss rate:              *[1-9]?[0-9][,\.]..%

--- a/clients/drcachesim/tests/filter-no-i.templatex
+++ b/clients/drcachesim/tests/filter-no-i.templatex
@@ -10,7 +10,7 @@ Core #0 \(1 thread\(s\)\)
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                   *[1-9][0-9][,\.]..%
+.*   Miss rate:                   *[1-9]?[0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
@@ -20,4 +20,4 @@ LL stats:
     Invalidations:                *0
 .*   Local miss rate:        *[0-9,.]*%
     Child hits:                   *[0-9,\.]*
-    Total miss rate:              *[1-9][0-9][,\.]..%
+    Total miss rate:              *[1-9]?[0-9][,\.]..%

--- a/clients/drcachesim/tests/filter-simple.templatex
+++ b/clients/drcachesim/tests/filter-simple.templatex
@@ -6,12 +6,12 @@ Core #0 \(1 thread\(s\)\)
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                   *[1-9][0-9][,\.]..%
+.*   Miss rate:                   *[1-9]?[0-9][,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                   *[1-9][0-9][,\.]..%
+.*   Miss rate:                   *[1-9]?[0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
@@ -21,4 +21,4 @@ LL stats:
     Invalidations:                *0
 .*   Local miss rate:        *[0-9,.]*%
     Child hits:                   *[0-9,\.]*
-    Total miss rate:              *[1-9][0-9][,\.]..%
+    Total miss rate:              *[1-9]?[0-9][,\.]..%

--- a/clients/drcachesim/tests/offline-filter-no-i.templatex
+++ b/clients/drcachesim/tests/offline-filter-no-i.templatex
@@ -9,7 +9,7 @@ Core #0 \(1 thread\(s\)\)
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                   *[1-9][0-9][,\.]..%
+.*   Miss rate:                   *[1-9]?[0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
@@ -19,4 +19,4 @@ LL stats:
     Invalidations:                *0
 .*   Local miss rate:        *[0-9,.]*%
     Child hits:                   *[0-9,\.]*
-    Total miss rate:              *[1-9][0-9][,\.]..%
+    Total miss rate:              *[1-9]?[0-9][,\.]..%

--- a/clients/drcachesim/tests/offline-filter.templatex
+++ b/clients/drcachesim/tests/offline-filter.templatex
@@ -5,12 +5,12 @@ Core #0 \(1 thread\(s\)\)
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                   *[0-9][0-9][,\.]..%
+.*   Miss rate:                   *[0-9]?[0-9][,\.]..%
   L1D stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Invalidations:                *0
-.*   Miss rate:                   *[0-9][0-9][,\.]..%
+.*   Miss rate:                   *[0-9]?[0-9][,\.]..%
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
@@ -20,4 +20,4 @@ LL stats:
     Invalidations:                *0
 .*   Local miss rate:        *[0-9,.]*%
     Child hits:                   *[0-9,\.]*
-    Total miss rate:              *[0-9][0-9][,\.]..%
+    Total miss rate:              *[0-9]?[0-9][,\.]..%

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -179,12 +179,11 @@ else ()
   set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST OFF)
 endif ()
 
-# Revert before submitting.
 # i#4800: Run long test suite on push-to-master events.
-# if (RUN_LONG_SUITE OR ("$ENV{CI_TRIGGER}" STREQUAL "push" AND
-#                        "$ENV{CI_BRANCH}" STREQUAL "refs/heads/master"))
-set(TEST_LONG ON)
-# endif ()
+if (RUN_LONG_SUITE OR ("$ENV{CI_TRIGGER}" STREQUAL "push" AND
+                       "$ENV{CI_BRANCH}" STREQUAL "refs/heads/master"))
+  set(TEST_LONG ON)
+endif ()
 ###########################################################################
 # BUILDING
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -179,11 +179,12 @@ else ()
   set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST OFF)
 endif ()
 
+# Revert before submitting.
 # i#4800: Run long test suite on push-to-master events.
-if (RUN_LONG_SUITE OR ("$ENV{CI_TRIGGER}" STREQUAL "push" AND
-                       "$ENV{CI_BRANCH}" STREQUAL "refs/heads/master"))
-  set(TEST_LONG ON)
-endif ()
+# if (RUN_LONG_SUITE OR ("$ENV{CI_TRIGGER}" STREQUAL "push" AND
+#                        "$ENV{CI_BRANCH}" STREQUAL "refs/heads/master"))
+set(TEST_LONG ON)
+# endif ()
 ###########################################################################
 # BUILDING
 


### PR DESCRIPTION
Modifies miss rate regex to allow matching rates less than 10%, by making the first digit optional.

Due to this issue, `code_api|tool.drcachesim.filter-no-i` failed in `vs2017-32` at github.com/DynamoRIO/dynamorio/actions/runs/750037355.