### PR TITLE
i#4316 a64 rseq: Port linux.rseq test to AArch64

### DIFF
--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -213,11 +213,8 @@ test_rseq_call_once(bool force_restart_in, int *completions_out, int *restarts_o
         /* Test a restart in the middle of the sequence via udf SIGILL. */
         "ldrb w0, %[force_restart]\n\t"
         "cbz x0, 7f\n\t"
-        /* For -test_mode trace_invariants: expect a signal after ud2a.
-         * (An alternative is to add decoding to trace_invariants but with
-         * i#2007 and other problems that liimts the test.)
-         */
-        "prfm pldl1keep, [x0]\n\t"
+        "mov x0, #1\n\t"
+        "prfm pldl3keep, [x0]\n\t" /* See above: annotation for trace_invariants. */
         "udf #0\n\t"
         "7:\n\t"
         "ldr x1, %[completions]\n\t"
@@ -377,7 +374,8 @@ test_rseq_branches_once(bool force_restart, int *completions_out, int *restarts_
         /* Test a restart via ud2a SIGILL. */
         "ldrb w0, %[force_restart]\n\t"
         "cbz x0, 7f\n\t"
-        "prfm pldl1keep, [x0]\n\t" /* See above: annotation for trace_invariants. */
+        "mov x0, #1\n\t"
+        "prfm pldl3keep, [x0]\n\t" /* See above: annotation for trace_invariants. */
         "udf #0\n\t"
         "7:\n\t"
         "ldr x1, %[completions]\n\t"

--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2019-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,7 @@
 #ifdef RSEQ_TEST_ATTACH
 #    include "thread.h"
 #    include "condvar.h"
+#    include <stdatomic.h>
 #endif
 #ifndef LINUX
 #    error Only Linux is supported.
@@ -45,8 +46,8 @@
 /* TODO i#2350: Port this to other platforms and bitwidths.  There is a lot of
  * assembly which makes that non-trivial work.
  */
-#if !defined(X86) || !defined(X64)
-#    error Only x86_64 is supported.
+#if !defined(X64)
+#    error Only x86_64 and aarch64 are supported.
 #endif
 #include "../../core/unix/include/syscall.h"
 #ifndef HAVE_RSEQ
@@ -63,7 +64,7 @@
 #define EXPANDSTR(x) #x
 #define STRINGIFY(x) EXPANDSTR(x)
 
-#define RSEQ_SIG 0x90909090 /* nops to disasm nicely */
+#define RSEQ_SIG IF_X86_ELSE(0x90909090, 0xd503201f) /* nops to disasm nicely */
 #ifdef RSEQ_TEST_USE_OLD_SECTION_NAME
 #    define RSEQ_SECTION_NAME "__rseq_table"
 #else
@@ -95,7 +96,7 @@ static __thread volatile struct rseq rseq_tls;
 static __thread volatile struct rseq fill_up_tls[128];
 
 #ifdef RSEQ_TEST_ATTACH
-static volatile int exit_requested;
+static atomic_int exit_requested;
 static void *thread_ready;
 #endif
 
@@ -121,6 +122,7 @@ test_rseq_call_once(bool force_restart_in, int *completions_out, int *restarts_o
     restarts = 0;
     force_restart = force_restart_in;
     sigill_count = 0;
+#ifdef X86
     __asm__ __volatile__(
         RSEQ_ADD_TABLE_ENTRY(simple, 2f, 3f, 4f)
 
@@ -175,13 +177,84 @@ test_rseq_call_once(bool force_restart_in, int *completions_out, int *restarts_o
         "5:\n\t"
         "movq $0, %[rseq_tls]\n\t"
         /* clang-format on */
-
         : [rseq_tls] "=m"(rseq_tls.rseq_cs), [id] "=m"(id),
           [completions] "=m"(completions), [restarts] "=m"(restarts),
           [force_restart_write] "=m"(force_restart)
         : [cpu_id] "m"(rseq_tls.cpu_id), [cpu_id_uninit] "i"(RSEQ_CPU_ID_UNINITIALIZED),
           [force_restart] "m"(force_restart)
         : "rax", "memory");
+#elif defined(AARCH64)
+    __asm__ __volatile__(
+        RSEQ_ADD_TABLE_ENTRY(simple, 2f, 3f, 4f)
+
+        /* See the x86 notes: test call-return pattern. */
+        "bl 6f\n\t"
+        "b 5f\n\t"
+
+        "6:\n\t"
+        /* Store the entry into the ptr. */
+        "adrp x0, rseq_cs_simple\n\t"
+        "add x0, x0, :lo12:rseq_cs_simple\n\t"
+        /* We ask the compiler to load these references into registers
+         * before this asm sequence for us.  Thus there are a bunch of
+         * inputs but that's simpler than manually computing all these
+         * addresses inside the sequence.
+         */
+        "str x0, %[rseq_tls]\n\t"
+        /* Test a register input to the sequence. */
+        "ldr x0, %[cpu_id]\n\t"
+        /* Test "falling into" the rseq region. */
+
+        /* Restartable sequence. */
+        "2:\n\t"
+        "str x0, %[id]\n\t"
+        /* Test clobbering an input register. */
+        "mov x0, #%[cpu_id_uninit]\n\t"
+        /* Test a restart in the middle of the sequence via udf SIGILL. */
+        "ldrb w0, %[force_restart]\n\t"
+        "cbz x0, 7f\n\t"
+        /* For -test_mode trace_invariants: expect a signal after ud2a.
+         * (An alternative is to add decoding to trace_invariants but with
+         * i#2007 and other problems that liimts the test.)
+         */
+        "prfm pldl1keep, [x0]\n\t"
+        "udf #0\n\t"
+        "7:\n\t"
+        "ldr x1, %[completions]\n\t"
+        "add x1, x1, #1\n\t"
+        "str x1, %[completions]\n\t"
+
+        /* Post-commit. */
+        "3:\n\t"
+        "ret\n\t"
+
+        /* Abort handler. */
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        ".long " STRINGIFY(RSEQ_SIG) "\n\t"
+        "4:\n\t"
+        /* Start with jmp to avoid trace_invariants assert on return to udf. */
+        "b 42f\n\t"
+        "42:\n\t"
+        "ldr x1, %[restarts]\n\t"
+        "add x1, x1, #1\n\t"
+        "str x1, %[restarts]\n\t"
+        "str xzr, %[force_restart_write]\n\t"
+        "b 6b\n\t"
+
+        /* Clear the ptr. */
+        "5:\n\t"
+        "str xzr, %[rseq_tls]\n\t"
+        /* clang-format on */
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [id] "=m"(id),
+          [completions] "=m"(completions), [restarts] "=m"(restarts),
+          [force_restart_write] "=m"(force_restart)
+        : [cpu_id] "m"(rseq_tls.cpu_id), [cpu_id_uninit] "i"(RSEQ_CPU_ID_UNINITIALIZED),
+          [force_restart] "m"(force_restart)
+        : "x0", "x1", "memory");
+#else
+#    error Unsupported arch
+#endif
+
     assert(id != RSEQ_CPU_ID_UNINITIALIZED);
     *completions_out = completions;
     *restarts_out = restarts;
@@ -205,6 +278,7 @@ test_rseq_branches_once(bool force_restart, int *completions_out, int *restarts_
     __u32 id = RSEQ_CPU_ID_UNINITIALIZED;
     int completions = 0;
     int restarts = 0;
+#ifdef X86
     __asm__ __volatile__(
         /* clang-format off */ /* (avoid indenting next few lines) */
         RSEQ_ADD_TABLE_ENTRY(branches, 2f, 3f, 4f)
@@ -269,7 +343,80 @@ test_rseq_branches_once(bool force_restart, int *completions_out, int *restarts_
           [force_restart_write] "=m"(force_restart)
         : [cpu_id] "m"(rseq_tls.cpu_id), [cpu_id_uninit] "i"(RSEQ_CPU_ID_UNINITIALIZED),
           [force_restart] "m"(force_restart)
-        : "rax", "rcx", "rdx", "memory");
+        : "rax", "rcx", "memory");
+#elif defined(AARCH64)
+    __asm__ __volatile__(
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        RSEQ_ADD_TABLE_ENTRY(branches, 2f, 3f, 4f)
+        /* clang-format on */
+
+        "6:\n\t"
+        /* Store the entry into the ptr. */
+        "adrp x0, rseq_cs_branches\n\t"
+        "add x0, x0, :lo12:rseq_cs_branches\n\t"
+        "str x0, %[rseq_tls]\n\t"
+        /* Test a register input to the sequence. */
+        "ldr x0, %[cpu_id]\n\t"
+        /* Test "falling into" the rseq region. */
+
+        /* Restartable sequence.  We include control flow to test a
+         * complex sequence with midpoint branches, but no exits.
+         * TODO i#2350: Support for exits has not yet been added and
+         * once finished separate tests will be added.
+         */
+        "2:\n\t"
+        "str x0, %[id]\n\t"
+        "mov x0, #0\n\t"
+        "cbz x0, 11f\n\t"
+        "mov x1, #4\n\t"
+        "11:\n\t"
+        "cmp x0, #1\n\t"
+        "b.eq 12f\n\t"
+        "cmp x0, #2\n\t"
+        "b.eq 13f\n\t"
+        /* Test a restart via ud2a SIGILL. */
+        "ldrb w0, %[force_restart]\n\t"
+        "cbz x0, 7f\n\t"
+        "prfm pldl1keep, [x0]\n\t" /* See above: annotation for trace_invariants. */
+        "udf #0\n\t"
+        "7:\n\t"
+        "ldr x1, %[completions]\n\t"
+        "add x1, x1, #1\n\t"
+        "str x1, %[completions]\n\t"
+
+        /* Post-commit. */
+        "3:\n\t"
+        "b 5f\n\t"
+
+        /* Abort handler. */
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        ".long " STRINGIFY(RSEQ_SIG) "\n\t"
+        "4:\n\t"
+        /* Start with jmp to avoid trace_invariants assert on return to udf. */
+        "b 42f\n\t"
+        "42:\n\t"
+        "ldr x1, %[restarts]\n\t"
+        "add x1, x1, #1\n\t"
+        "str x1, %[restarts]\n\t"
+        "str xzr, %[force_restart_write]\n\t"
+        "b 6b\n\t"
+
+        /* Clear the ptr. */
+        "13:\n\t"
+        "12:\n\t"
+        "5:\n\t"
+        "str xzr, %[rseq_tls]\n\t"
+        /* clang-format on */
+
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [id] "=m"(id),
+          [completions] "=m"(completions), [restarts] "=m"(restarts),
+          [force_restart_write] "=m"(force_restart)
+        : [cpu_id] "m"(rseq_tls.cpu_id), [cpu_id_uninit] "i"(RSEQ_CPU_ID_UNINITIALIZED),
+          [force_restart] "m"(force_restart)
+        : "x0", "x1", "memory");
+#else
+#    error Unsupported arch
+#endif
     assert(id != RSEQ_CPU_ID_UNINITIALIZED);
 }
 
@@ -290,13 +437,14 @@ test_rseq_branches(void)
  * it would happen on the instrumentation execution and never make it to the
  * native run, but an asynchronous signal could arrive.
  * It's complicated to set up an asynchronous signal at the right spot, so
- * we cheat and take advantage of DR not restoring XMM state to have different
+ * we cheat and take advantage of DR not restoring SIMD state to have different
  * behavior in the two DR executions of the rseq code.
  */
 static void
 test_rseq_native_fault(void)
 {
     int restarts = 0;
+#ifdef X86
     __asm__ __volatile__(
         /* clang-format off */ /* (avoid indenting next few lines) */
         RSEQ_ADD_TABLE_ENTRY(fault, 2f, 3f, 4f)
@@ -346,14 +494,71 @@ test_rseq_native_fault(void)
 
         : [rseq_tls] "=m"(rseq_tls.rseq_cs), [restarts] "=m"(restarts)
         :
-        : "rax", "rcx", "rdx", "xmm0", "xmm1", "memory");
+        : "rax", "rcx", "xmm0", "xmm1", "memory");
+#elif defined(AARCH64)
+    __asm__ __volatile__(
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        RSEQ_ADD_TABLE_ENTRY(fault, 2f, 3f, 4f)
+        /* clang-format on */
+
+        "6:\n\t"
+        /* Store the entry into the ptr. */
+        "adrp x0, rseq_cs_fault\n\t"
+        "add x0, x0, :lo12:rseq_cs_fault\n\t"
+        "str x0, %[rseq_tls]\n\t"
+        "eor v0.16b, v0.16b, v0.16b\n\t"
+        "mov x1, #1\n\t"
+        "mov v1.D[0], x1\n\t"
+
+        /* Restartable sequence. */
+        "2:\n\t"
+        /* Increase xmm0 every time.  DR (currently) won't restore xmm inputs
+         * to rseq sequences, nor does it detect that it needs to.
+         */
+        "add d0, d0, d1\n\t"
+        "mov x0, v0.D[0]\n\t"
+        /* Only raise the signal on the 2nd run == native run. */
+        "cmp x0, #2\n\t"
+        "b.ne 11f\n\t"
+        /* Raise a signal on the native run. */
+        "udf #0\n\t"
+        "11:\n\t"
+        "nop\n\t"
+
+        /* Post-commit. */
+        "3:\n\t"
+        "b 5f\n\t"
+
+        /* Abort handler. */
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        ".long " STRINGIFY(RSEQ_SIG) "\n\t"
+        "4:\n\t"
+        /* Start with jmp to avoid trace_invariants assert on return to u2da. */
+        "b 42f\n\t"
+        "42:\n\t"
+        "ldr x1, %[restarts]\n\t"
+        "add x1, x1, #1\n\t"
+        "str x1, %[restarts]\n\t"
+        "b 2b\n\t"
+
+        /* Clear the ptr. */
+        "5:\n\t"
+        "str xzr, %[rseq_tls]\n\t"
+        /* clang-format on */
+
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [restarts] "=m"(restarts)
+        :
+        : "x0", "x1", "q0", "q1", "memory");
+#else
+#    error Unsupported arch
+#endif
     /* This is expected to fail on a native run where restarts will be 0. */
     assert(restarts > 0);
 }
 
 /* Tests that DR handles an rseq abort from migration or context switch (a signal
  * is tested in test_rseq_native_fault()) in the native rseq execution.
- * We again cheat and take advantage of DR not restoring XMM state to have different
+ * We again cheat and take advantage of DR not restoring SIMD state to have different
  * behavior in the two DR executions of the rseq code.
  * The only reliable way we can force a context switch or migration is to use
  * a system call, which is officially disallowed.  We have special exceptions in
@@ -364,6 +569,7 @@ test_rseq_native_abort(void)
 {
 #ifdef DEBUG /* See above: special code in core/ is DEBUG-only> */
     int restarts = 0;
+#    ifdef X86
     __asm__ __volatile__(
         /* clang-format off */ /* (avoid indenting next few lines) */
         RSEQ_ADD_TABLE_ENTRY(abort, 2f, 3f, 4f)
@@ -428,6 +634,80 @@ test_rseq_native_abort(void)
         : [cpu_mask_size] "i"(sizeof(cpu_set_t)),
           [sysnum_setaffinity] "i"(SYS_sched_setaffinity)
         : "rax", "rcx", "rdx", "xmm0", "xmm1", "memory");
+#    elif defined(AARCH64)
+    __asm__ __volatile__(
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        RSEQ_ADD_TABLE_ENTRY(abort, 2f, 3f, 4f)
+        /* clang-format on */
+
+        "6:\n\t"
+        /* Store the entry into the ptr. */
+        "adrp x0, rseq_cs_abort\n\t"
+        "add x0, x0, :lo12:rseq_cs_abort\n\t"
+        "str x0, %[rseq_tls]\n\t"
+        "eor v0.16b, v0.16b, v0.16b\n\t"
+        "mov x1, #1\n\t"
+        "mov v1.D[0], x1\n\t"
+
+        /* Restartable sequence. */
+        "2:\n\t"
+        /* Increase xmm0 every time.  DR (currently) won't restore xmm inputs
+         * to rseq sequences, nor does it detect that it needs to.
+         */
+        "add d0, d0, d1\n\t"
+        "mov x0, v0.D[0]\n\t"
+        /* Only force the abort on the 2nd run == native run. */
+        "cmp x0, #2\n\t"
+        "b.ne 11f\n\t"
+        /* Force a migration by setting the affinity mask to two different singleton
+         * CPU's.
+         */
+        "mov x0, #0\n\t"
+        "mov w1, #%[cpu_mask_size]\n\t"
+        "adrp x2, sched_mask_1\n\t"
+        "add x2, x2, :lo12:sched_mask_1\n\t"
+        "mov w8, #%[sysnum_setaffinity]\n\t"
+        "svc #0\n\t"
+        "mov x0, #0\n\t"
+        "mov w1, #%[cpu_mask_size]\n\t"
+        "adrp x2, sched_mask_2\n\t"
+        "add x2, x2, :lo12:sched_mask_2\n\t"
+        "mov w8, #%[sysnum_setaffinity]\n\t"
+        "svc #0\n\t"
+        "11:\n\t"
+        "nop\n\t"
+
+        /* Post-commit. */
+        "3:\n\t"
+        "b 5f\n\t"
+
+        /* Abort handler. */
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        ".long " STRINGIFY(RSEQ_SIG) "\n\t"
+        "4:\n\t"
+        "ldr x1, %[restarts]\n\t"
+        "add x1, x1, #1\n\t"
+        "str x1, %[restarts]\n\t"
+        "b 2b\n\t"
+
+        ".balign 32\n\t"
+        "sched_mask_1:\n\t"
+        ".long 0x1, 0, 0, 0\n\t" /* cpu #1 */
+        "sched_mask_2:\n\t"
+        ".long 0x2, 0, 0, 0\n\t" /* cpu #2 */
+
+        /* Clear the ptr. */
+        "5:\n\t"
+        "str xzr, %[rseq_tls]\n\t"
+        /* clang-format on */
+
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [restarts] "=m"(restarts)
+        : [cpu_mask_size] "i"(sizeof(cpu_set_t)),
+          [sysnum_setaffinity] "i"(SYS_sched_setaffinity)
+        : "x0", "x1", "x2", "x8", "q0", "q1", "memory");
+#    else
+#        error Unsupported arch
+#    endif
     /* This is expected to fail on a native run where restarts will be 0. */
     assert(restarts > 0);
 #endif /* DEBUG */
@@ -446,6 +726,7 @@ rseq_thread_loop(void *arg)
     if (res != 0)
         return NULL;
     static int zero;
+#    ifdef X86
     __asm__ __volatile__(
         /* clang-format off */ /* (avoid indenting next few lines) */
         RSEQ_ADD_TABLE_ENTRY(thread, 2f, 3f, 4f)
@@ -495,6 +776,60 @@ rseq_thread_loop(void *arg)
         : [rseq_tls] "=m"(rseq_tls.rseq_cs), [zero] "=m"(zero)
         : [exit_requested] "m"(exit_requested)
         : "rax", "memory");
+#    elif defined(AARCH64)
+    __asm__ __volatile__(
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        RSEQ_ADD_TABLE_ENTRY(thread, 2f, 3f, 4f)
+        /* clang-format on */
+
+        "6:\n\t"
+        /* Store the entry into the ptr. */
+        "adrp x0, rseq_cs_thread\n\t"
+        "add x0, x0, :lo12:rseq_cs_thread\n\t"
+        "str x0, %[rseq_tls]\n\t"
+        /* Test "falling into" the rseq region. */
+
+        /* Restartable sequence.  We loop to ensure we're in the region on
+         * detach.  If DR fails to translate this thread to the abort handler
+         * on detach, it will loop forever and the test will timeout and fail.
+         * Note that this breaks DR's assumptions: the instrumented run
+         * never exits the loop, and thus never reaches the "commit point" of the
+         * nop, and thus never invokes the handler natively.  However, we don't
+         * care: we just want to test detach.
+         */
+        "2:\n\t"
+        /* I was going to assert that zero==0 at the end, but that requires more
+         * synch to not reach here natively before DR attaches.  Decided against it.
+         */
+        "mov x1, #1\n\t"
+        "str x1, %[zero]\n\t"
+        "b 2b\n\t"
+        /* We can't end the sequence in a branch (DR can't handle it). */
+        "nop\n\t"
+
+        /* Post-commit. */
+        "3:\n\t"
+        "b 5f\n\t"
+
+        /* Abort handler: if we're done, exit; else, re-enter. */
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        ".long " STRINGIFY(RSEQ_SIG) "\n\t"
+        "4:\n\t"
+        "ldar w0, %[exit_requested]\n\t"
+        "cbnz x0, 3b\n\t"
+        "b 6b\n\t"
+
+        /* Clear the ptr. */
+        "5:\n\t"
+        "str xzr, %[rseq_tls]\n\t"
+        /* clang-format on */
+
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [zero] "=m"(zero)
+        : [exit_requested] "m"(exit_requested)
+        : "x0", "x1", "memory");
+#    else
+#        error Unsupported arch
+#    endif
     return NULL;
 }
 
@@ -555,7 +890,7 @@ main()
             test_rseq_branches();
 #ifdef RSEQ_TEST_ATTACH
         /* Detach while the thread is in its rseq region loop. */
-        exit_requested = 1; /* atomic on x86; ARM will need more. */
+        atomic_store(&exit_requested, 1);
         dr_app_stop_and_cleanup();
         join_thread(mythread);
         destroy_cond_var(thread_ready);

--- a/suite/tests/linux/rseq_disable.c
+++ b/suite/tests/linux/rseq_disable.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,12 +38,6 @@
 #include "tools.h"
 #ifndef LINUX
 #    error Only Linux is supported.
-#endif
-/* TODO i#2350: Port this to other platforms and bitwidths.  There is a lot of
- * assembly which makes that non-trivial work.
- */
-#if !defined(X86) || !defined(X64)
-#    error Only x86_64 is supported.
 #endif
 #include "../../core/unix/include/syscall.h"
 #ifndef HAVE_RSEQ


### PR DESCRIPTION
Ports the linux.rseq test and its extensive inline assembly to
AArch64.  We use compiler-acquired C variable addresses prior to the
assembly sequences for simplicity.  This should be fine as there are
plenty of GPR's and DR handles inputs.

Tested natively and with forthcoming DR rseq mangling changes;
separated to keep diffs smaller.  These tests will be enabled in the
PR that adds DR handling.

Issue: #4316