### PR TITLE
i#4736 loglevel: Fix high-loglevel rseq rank order

### DIFF
--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -751,7 +751,8 @@ print_vm_area(vm_area_vector_t *v, vm_area_t *area, file_t outf, const char *pre
             /* avoid rank order violation */
             IF_NO_MEMQUERY(v == all_memory_areas ? NULL :)
             /* i#1649: avoid rank order for dynamo_areas and for other vectors. */
-            ((v == dynamo_areas || v == fcache_unit_areas || v == loaded_module_areas)
+            ((v == dynamo_areas || v == fcache_unit_areas || v == loaded_module_areas ||
+              v == d_r_rseq_areas)
                  ? NULL
                  : get_module_base(area->start));
         if (modbase != NULL &&

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -751,8 +751,8 @@ print_vm_area(vm_area_vector_t *v, vm_area_t *area, file_t outf, const char *pre
             /* avoid rank order violation */
             IF_NO_MEMQUERY(v == all_memory_areas ? NULL :)
             /* i#1649: avoid rank order for dynamo_areas and for other vectors. */
-            ((v == dynamo_areas || v == fcache_unit_areas || v == loaded_module_areas ||
-              v == d_r_rseq_areas)
+            ((v == dynamo_areas || v == fcache_unit_areas ||
+              v == loaded_module_areas IF_LINUX(|| v == d_r_rseq_areas))
                  ? NULL
                  : get_module_base(area->start));
         if (modbase != NULL &&


### PR DESCRIPTION
Fixes a rank order violation at -loglevel 5 with rseq.
It is the same vmarea diagnostic issue seen with other vmarea lists.
It does not seem worth the complexity of adding rseq to the existing
high-loglevel test or adding a new one; tested manually on the
linux.rseq test.

Issue: #4736, #4316