### PR TITLE
i#4848 AArch64 Decoder: Add FCVT instructions

### DIFF
--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -1119,18 +1119,59 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0001111011100010010000xxxxxxxxxx     fcvt      s0 : h5
 0001111011100010110000xxxxxxxxxx     fcvt      d0 : h5
 
-# FCVTZU (scalar, integer) FP to GPR reg
+# Floating-point convert (scalar)
+0001111000100100000000xxxxxxxxxx     fcvtas    w0 : s5
+1001111000100100000000xxxxxxxxxx     fcvtas    x0 : s5
+0001111001100100000000xxxxxxxxxx     fcvtas    w0 : d5
+1001111001100100000000xxxxxxxxxx     fcvtas    x0 : d5
+0001111000100000000000xxxxxxxxxx     fcvtns    w0 : s5
+1001111000100000000000xxxxxxxxxx     fcvtns    x0 : s5
+0001111001100000000000xxxxxxxxxx     fcvtns    w0 : d5
+1001111001100000000000xxxxxxxxxx     fcvtns    x0 : d5
+0001111000101000000000xxxxxxxxxx     fcvtps    w0 : s5
+1001111000101000000000xxxxxxxxxx     fcvtps    x0 : s5
+0001111001101000000000xxxxxxxxxx     fcvtps    w0 : d5
+1001111001101000000000xxxxxxxxxx     fcvtps    x0 : d5
+0001111000101001000000xxxxxxxxxx     fcvtpu    w0 : s5
+1001111000101001000000xxxxxxxxxx     fcvtpu    x0 : s5
+0001111001101001000000xxxxxxxxxx     fcvtpu    w0 : d5
+1001111001101001000000xxxxxxxxxx     fcvtpu    x0 : d5
+
+# Floating-point convert (vector) (scalar single-precision and double-precision)
+0101111000100001110010xxxxxxxxxx     fcvtas    s0 : s5
+0101111001100001110010xxxxxxxxxx     fcvtas    d0 : d5
+0101111000100001101010xxxxxxxxxx     fcvtns    s0 : s5
+0101111001100001101010xxxxxxxxxx     fcvtns    d0 : d5
+0101111010100001101010xxxxxxxxxx     fcvtps    s0 : s5
+0101111011100001101010xxxxxxxxxx     fcvtps    d0 : d5
+0111111010100001101010xxxxxxxxxx     fcvtpu    s0 : s5
+0111111011100001101010xxxxxxxxxx     fcvtpu    d0 : d5
+
+# Floating-point convert (vector) (vector single-precision and double-precision)
+0x0011100x100001110010xxxxxxxxxx     fcvtas    dq0 : dq5 sd_sz
+0x0011100x100001101010xxxxxxxxxx     fcvtns    dq0 : dq5 sd_sz
+0x0011101x100001101010xxxxxxxxxx     fcvtps    dq0 : dq5 sd_sz
+0x1011101x100001101010xxxxxxxxxx     fcvtpu    dq0 : dq5 sd_sz
+
+# Floating-point convert (scalar, integer)
+0001111000111000000000xxxxxxxxxx     fcvtzs    w0 : s5
+1001111000111000000000xxxxxxxxxx     fcvtzs    x0 : s5
+0001111001111000000000xxxxxxxxxx     fcvtzs    w0 : d5
+1001111001111000000000xxxxxxxxxx     fcvtzs    x0 : d5
 0001111000111001000000xxxxxxxxxx     fcvtzu    w0 : s5
 1001111000111001000000xxxxxxxxxx     fcvtzu    x0 : s5
 0001111001111001000000xxxxxxxxxx     fcvtzu    w0 : d5
 1001111001111001000000xxxxxxxxxx     fcvtzu    x0 : d5
 
-# FCVTZU (vector, integer)
-0x1011101x100001101110xxxxxxxxxx     fcvtzu    dq0 : dq5 sd_sz
-
-# FCVTZU (Scalar single precision and double-precision)
+# Floating-point convert (vector, integer) (vector single-precision and double-precision)
+0101111010100001101110xxxxxxxxxx     fcvtzs    s0 : s5
+0101111011100001101110xxxxxxxxxx     fcvtzs    d0 : d5
 0111111010100001101110xxxxxxxxxx     fcvtzu    s0 : s5
 0111111011100001101110xxxxxxxxxx     fcvtzu    d0 : d5
+
+# Floating-point convert (vector, integer) (scalar single-precision and double-precision)
+0x0011101x100001101110xxxxxxxxxx     fcvtzs    dq0 : dq5 sd_sz
+0x1011101x100001101110xxxxxxxxxx     fcvtzu    dq0 : dq5 sd_sz
 
 # Floating-point data-processing (2 source)
 00011110xx1xxxxx000010xxxxxxxxxx     fmul      float_reg0 : float_reg5 float_reg16

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1694,61 +1694,61 @@ enum {
     instr_create_1dst_2src(dc, OP_bif, Rd, Rm, Rn)
 
 /**
- * Creates a FCVTAS vector instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an FCVTAS vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param width   The input element vector width.
+ * \param Rm      The input vector register.
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fcvtas_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtas, Rd, Rm, width)
 
 /**
- * Creates a FCVTNS vector instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an FCVTNS vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
- * \param width   The input element vector width.
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fcvtns_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtns, Rd, Rm, width)
 
 /**
- * Creates a FCVTPS vector instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an FCVTPS vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
- * \param width   The input element vector width.
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fcvtps_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtps, Rd, Rm, width)
 
 /**
- * Creates a FCVTPU vector instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an FCVTPU vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
- * \param width   The input element vector width.
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fcvtpu_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtpu, Rd, Rm, width)
 
 /**
- * Creates a FCVTZS vector instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an FCVTZS vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
- * \param width   The input element vector width.
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fcvtzs_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtzs, Rd, Rm, width)
 
 /**
- * Creates a FCVTZU vector instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an FCVTZU vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
- * \param width   The input element vector width.
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fcvtzu_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtzu, Rd, Rm, width)
@@ -1788,16 +1788,16 @@ enum {
 #define INSTR_CREATE_fsqrt_scalar(dc, Rd, Rm) instr_create_1dst_1src(dc, OP_fsqrt, Rd, Rm)
 
 /**
- * Creates a FCVT floating point instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
+ * Creates an FCVT floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      Floating-point or integer output register.
+ * \param Rm      Floating-point input register.
  */
 #define INSTR_CREATE_fcvt_scalar(dc, Rd, Rm) instr_create_1dst_1src(dc, OP_fcvt, Rd, Rm)
 
 /**
- * Creates a FCVTAS floating point instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an FCVTAS floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      Floating-point or integer output register.
  * \param Rm      Floating-point input register.
  */
@@ -1805,8 +1805,8 @@ enum {
     instr_create_1dst_1src(dc, OP_fcvtas, Rd, Rm)
 
 /**
- * Creates a FCVTNS floating point instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an FCVTNS floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      Floating-point or integer output register.
  * \param Rm      Floating-point input register.
  */
@@ -1814,8 +1814,8 @@ enum {
     instr_create_1dst_1src(dc, OP_fcvtns, Rd, Rm)
 
 /**
- * Creates a FCVTPS floating point instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an FCVTPS floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      Floating-point or integer output register.
  * \param Rm      Floating-point input register.
  */
@@ -1823,8 +1823,8 @@ enum {
     instr_create_1dst_1src(dc, OP_fcvtps, Rd, Rm)
 
 /**
- * Creates a FCVTPU floating point instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an FCVTPU floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      Floating-point or integer output register.
  * \param Rm      Floating-point input register.
  */
@@ -1832,8 +1832,8 @@ enum {
     instr_create_1dst_1src(dc, OP_fcvtpu, Rd, Rm)
 
 /**
- * Creates a FCVTZS floating point instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an FCVTZS floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      Floating-point or integer output register.
  * \param Rm      Floating-point input register.
  */
@@ -1841,8 +1841,8 @@ enum {
     instr_create_1dst_1src(dc, OP_fcvtzs, Rd, Rm)
 
 /**
- * Creates a FCVTZU floating point instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an FCVTZU floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      Floating-point or integer output register.
  * \param Rm      Floating-point input register.
  */

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1698,7 +1698,8 @@ enum {
  * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
  * \param Rm      The input vector register.
- * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE()
+ * or #OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fcvtas_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtas, Rd, Rm, width)
@@ -1708,7 +1709,8 @@ enum {
  * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
- * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE()
+ * or #OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fcvtns_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtns, Rd, Rm, width)
@@ -1718,7 +1720,8 @@ enum {
  * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
- * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE()
+ * or #OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fcvtps_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtps, Rd, Rm, width)
@@ -1728,7 +1731,8 @@ enum {
  * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
- * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE()
+ * or #OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fcvtpu_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtpu, Rd, Rm, width)
@@ -1738,7 +1742,8 @@ enum {
  * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
- * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE()
+ * or #OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fcvtzs_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtzs, Rd, Rm, width)
@@ -1748,7 +1753,8 @@ enum {
  * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
  * \param Rm      The first input register.
- * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE()
+ * or #OPND_CREATE_DOUBLE().
  */
 #define INSTR_CREATE_fcvtzu_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtzu, Rd, Rm, width)

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1694,6 +1694,56 @@ enum {
     instr_create_1dst_2src(dc, OP_bif, Rd, Rm, Rn)
 
 /**
+ * Creates a FCVTAS vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param width   The input element vector width.
+ */
+#define INSTR_CREATE_fcvtas_vector(dc, Rd, Rm, width) \
+    instr_create_1dst_2src(dc, OP_fcvtas, Rd, Rm, width)
+
+/**
+ * Creates a FCVTNS vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param width   The input element vector width.
+ */
+#define INSTR_CREATE_fcvtns_vector(dc, Rd, Rm, width) \
+    instr_create_1dst_2src(dc, OP_fcvtns, Rd, Rm, width)
+
+/**
+ * Creates a FCVTPS vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param width   The input element vector width.
+ */
+#define INSTR_CREATE_fcvtps_vector(dc, Rd, Rm, width) \
+    instr_create_1dst_2src(dc, OP_fcvtps, Rd, Rm, width)
+
+/**
+ * Creates a FCVTPU vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param width   The input element vector width.
+ */
+#define INSTR_CREATE_fcvtpu_vector(dc, Rd, Rm, width) \
+    instr_create_1dst_2src(dc, OP_fcvtpu, Rd, Rm, width)
+
+/**
+ * Creates a FCVTZS vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param width   The input element vector width.
+ */
+#define INSTR_CREATE_fcvtzs_vector(dc, Rd, Rm, width) \
+    instr_create_1dst_2src(dc, OP_fcvtzs, Rd, Rm, width)
+
+/**
  * Creates a FCVTZU vector instruction.
  * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Rd      The output register.
@@ -1744,6 +1794,51 @@ enum {
  * \param Rm      The first input register.
  */
 #define INSTR_CREATE_fcvt_scalar(dc, Rd, Rm) instr_create_1dst_1src(dc, OP_fcvt, Rd, Rm)
+
+/**
+ * Creates a FCVTAS floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      Floating-point or integer output register.
+ * \param Rm      Floating-point input register.
+ */
+#define INSTR_CREATE_fcvtas_scalar(dc, Rd, Rm) \
+    instr_create_1dst_1src(dc, OP_fcvtas, Rd, Rm)
+
+/**
+ * Creates a FCVTNS floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      Floating-point or integer output register.
+ * \param Rm      Floating-point input register.
+ */
+#define INSTR_CREATE_fcvtns_scalar(dc, Rd, Rm) \
+    instr_create_1dst_1src(dc, OP_fcvtns, Rd, Rm)
+
+/**
+ * Creates a FCVTPS floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      Floating-point or integer output register.
+ * \param Rm      Floating-point input register.
+ */
+#define INSTR_CREATE_fcvtps_scalar(dc, Rd, Rm) \
+    instr_create_1dst_1src(dc, OP_fcvtps, Rd, Rm)
+
+/**
+ * Creates a FCVTPU floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      Floating-point or integer output register.
+ * \param Rm      Floating-point input register.
+ */
+#define INSTR_CREATE_fcvtpu_scalar(dc, Rd, Rm) \
+    instr_create_1dst_1src(dc, OP_fcvtpu, Rd, Rm)
+
+/**
+ * Creates a FCVTZS floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      Floating-point or integer output register.
+ * \param Rm      Floating-point input register.
+ */
+#define INSTR_CREATE_fcvtzs_scalar(dc, Rd, Rm) \
+    instr_create_1dst_1src(dc, OP_fcvtzs, Rd, Rm)
 
 /**
  * Creates a FCVTZU floating point instruction.

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -2095,19 +2095,6 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 1e67c26b : frinti d11, d19                          : frinti %d19 -> %d11
 1e27c26b : frinti s11, s19                          : frinti %s19 -> %s11
 1ee7c26b : frinti h11, h19                          : frinti %h19 -> %h11
-1e624117 : fcvt s23, d8                             : fcvt   %d8 -> %s23
-1e63c1fd : fcvt h29, d15                            : fcvt   %d15 -> %h29
-1ee2431c : fcvt s28, h24                            : fcvt   %h24 -> %s28
-1ee2c002 : fcvt d2, h0                              : fcvt   %h0 -> %d2
-1e390121 : fcvtzu w1, s9                            : fcvtzu %s9 -> %w1
-9e39012b : fcvtzu x11, s9                           : fcvtzu %s9 -> %x11
-1e7901a7 : fcvtzu w7, d13                           : fcvtzu %d13 -> %w7
-9e790055 : fcvtzu x21, d2                           : fcvtzu %d2 -> %x21
-2ea1b829 : fcvtzu v9.2s, v1.2s                      : fcvtzu %d1 $0x02 -> %d9
-6ea1b910 : fcvtzu v16.4s, v8.4s                     : fcvtzu %q8 $0x02 -> %q16
-6ee1b803 : fcvtzu v3.2d, v0.2d                      : fcvtzu %q0 $0x03 -> %q3
-7ea1b929 : fcvtzu s9, s9                            : fcvtzu %s9 -> %s9
-7ee1b841 : fcvtzu d1, d2                            : fcvtzu %d2 -> %d1
 
 # Floating-point data-processing (2 source)
 1e7e0b62 : fmul d2, d27, d30                        : fmul   %d27 %d30 -> %d2
@@ -2151,6 +2138,66 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 1f7789e4 : fnmsub d4, d15, d23, d2                  : fnmsub %d15 %d23 %d2 -> %d4
 1f3789e4 : fnmsub s4, s15, s23, s2                  : fnmsub %s15 %s23 %s2 -> %s4
 1ff789e4 : fnmsub h4, h15, h23, h2                  : fnmsub %h15 %h23 %h2 -> %h4
+
+# Floating-point conversion
+1e624117 : fcvt s23, d8                             : fcvt   %d8 -> %s23
+1e63c1fd : fcvt h29, d15                            : fcvt   %d15 -> %h29
+1ee2431c : fcvt s28, h24                            : fcvt   %h24 -> %s28
+1ee2c002 : fcvt d2, h0                              : fcvt   %h0 -> %d2
+1e240034 : fcvtas w20, s1                           : fcvtas %s1 -> %w20
+9e240067 : fcvtas x7, s3                            : fcvtas %s3 -> %x7
+1e6402c0 : fcvtas w0, d22                           : fcvtas %d22 -> %w0
+9e640015 : fcvtas x21, d0                           : fcvtas %d0 -> %x21
+0e21c827 : fcvtas v7.2s, v1.2s                      : fcvtas %d1 $0x02 -> %d7
+4e21c920 : fcvtas v0.4s, v9.4s                      : fcvtas %q9 $0x02 -> %q0
+4e61cba5 : fcvtas v5.2d, v29.2d                     : fcvtas %q29 $0x03 -> %q5
+5e21cbde : fcvtas s30, s30                          : fcvtas %s30 -> %s30
+5e61c987 : fcvtas d7, d12                           : fcvtas %d12 -> %d7
+1e200115 : fcvtns w21, s8                           : fcvtns %s8 -> %w21
+9e2002ae : fcvtns x14, s21                          : fcvtns %s21 -> %x14
+1e6003a7 : fcvtns w7, d29                           : fcvtns %d29 -> %w7
+9e600229 : fcvtns x9, d17                           : fcvtns %d17 -> %x9
+0e21a925 : fcvtns v5.2s, v9.2s                      : fcvtns %d9 $0x02 -> %d5
+4e21aa61 : fcvtns v1.4s, v19.4s                     : fcvtns %q19 $0x02 -> %q1
+4e61a971 : fcvtns v17.2d, v11.2d                    : fcvtns %q11 $0x03 -> %q17
+5e21a849 : fcvtns s9, s2                            : fcvtns %s2 -> %s9
+5e61a8f1 : fcvtns d17, d7                           : fcvtns %d7 -> %d17
+1e2800f3 : fcvtps w19, s7                           : fcvtps %s7 -> %w19
+9e280085 : fcvtps x5, s4                            : fcvtps %s4 -> %x5
+1e680148 : fcvtps w8, d10                           : fcvtps %d10 -> %w8
+9e680249 : fcvtps x9, d18                           : fcvtps %d18 -> %x9
+0ea1a926 : fcvtps v6.2s, v9.2s                      : fcvtps %d9 $0x02 -> %d6
+4ea1aa84 : fcvtps v4.4s, v20.4s                     : fcvtps %q20 $0x02 -> %q4
+4ee1a80f : fcvtps v15.2d, v0.2d                     : fcvtps %q0 $0x03 -> %q15
+5ea1a89d : fcvtps s29, s4                           : fcvtps %s4 -> %s29
+5ee1aa0c : fcvtps d12, d16                          : fcvtps %d16 -> %d12
+1e290041 : fcvtpu w1, s2                            : fcvtpu %s2 -> %w1
+9e29016e : fcvtpu x14, s11                          : fcvtpu %s11 -> %x14
+1e690044 : fcvtpu w4, d2                            : fcvtpu %d2 -> %w4
+9e690029 : fcvtpu x9, d1                            : fcvtpu %d1 -> %x9
+2ea1ab01 : fcvtpu v1.2s, v24.2s                     : fcvtpu %d24 $0x02 -> %d1
+6ea1aab6 : fcvtpu v22.4s, v21.4s                    : fcvtpu %q21 $0x02 -> %q22
+6ee1a96b : fcvtpu v11.2d, v11.2d                    : fcvtpu %q11 $0x03 -> %q11
+7ea1aabb : fcvtpu s27, s21                          : fcvtpu %s21 -> %s27
+7ee1aa4c : fcvtpu d12 -> d18                        : fcvtpu %d18 -> %d12
+1e38010b : fcvtzs w11, s8                           : fcvtzs %s8 -> %w11
+9e38006e : fcvtzs x14, s3                           : fcvtzs %s3 -> %x14
+1e780380 : fcvtzs w0, d28                           : fcvtzs %d28 -> %w0
+9e780029 : fcvtzs x9, d1                            : fcvtzs %d1 -> %x9
+0ea1b903 : fcvtzs v3.2s, v8.2s                      : fcvtzs %d8 $0x02 -> %d3
+4ea1baa9 : fcvtzs v9.4s, v21.4s                     : fcvtzs %q21 $0x02 -> %q9
+4ee1b84b : fcvtzs v11.2d, v2.2d                     : fcvtzs %q2 $0x03 -> %q11
+5ea1b863 : fcvtzs s3, s3                            : fcvtzs %s3 -> %s3
+5ee1b8f1 : fcvtzs d17, d7                           : fcvtzs %d7 -> %d17
+1e390121 : fcvtzu w1, s9                            : fcvtzu %s9 -> %w1
+9e39012b : fcvtzu x11, s9                           : fcvtzu %s9 -> %x11
+1e7901a7 : fcvtzu w7, d13                           : fcvtzu %d13 -> %w7
+9e790055 : fcvtzu x21, d2                           : fcvtzu %d2 -> %x21
+2ea1b829 : fcvtzu v9.2s, v1.2s                      : fcvtzu %d1 $0x02 -> %d9
+6ea1b910 : fcvtzu v16.4s, v8.4s                     : fcvtzu %q8 $0x02 -> %q16
+6ee1b803 : fcvtzu v3.2d, v0.2d                      : fcvtzu %q0 $0x03 -> %q3
+7ea1b929 : fcvtzu s9, s9                            : fcvtzu %s9 -> %s9
+7ee1b841 : fcvtzu d1, d2                            : fcvtzu %d2 -> %d1
 
 # SVE bitwise logical operations (predicated)
 04181da2 : orr z2.b, p7/m, z2.b, z13.b              : orr    %p7 %z2 %z13 $0x00 -> %z2

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -4940,17 +4940,17 @@ test_fcvtzu_vector(void *dc)
     instr_t *instr;
 
     /* FCVTZU <Vd>.<T>, <Vn>.<T> */
-    /* FCVTAS <Vd>.2S, <Vn>.2S */
+    /* FCVTZU <Vd>.2S, <Vn>.2S */
     instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(DR_REG_D7),
                                        opnd_create_reg(DR_REG_D9), OPND_CREATE_SINGLE());
     test_instr_encoding(dc, OP_fcvtzu, instr);
 
-    /* FCVTAS <Vd>.4S, <Vn>.4S */
+    /* FCVTZU <Vd>.4S, <Vn>.4S */
     instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(DR_REG_Q1),
                                        opnd_create_reg(DR_REG_Q24), OPND_CREATE_SINGLE());
     test_instr_encoding(dc, OP_fcvtzu, instr);
 
-    /* FCVTAS <Vd>.2D, <Vn>.2D */
+    /* FCVTZU <Vd>.2D, <Vn>.2D */
     instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(DR_REG_Q5),
                                        opnd_create_reg(DR_REG_Q18), OPND_CREATE_DOUBLE());
     test_instr_encoding(dc, OP_fcvtzu, instr);

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -4617,6 +4617,299 @@ test_mov_instr_addr(void *dc)
 }
 
 static void
+test_fcvtas_scalar(void *dc)
+{
+    instr_t *instr;
+    /* FCVTAS <Wd>, <Sn> */
+    instr = INSTR_CREATE_fcvtas_scalar(dc, opnd_create_reg(DR_REG_W20),
+                                       opnd_create_reg(DR_REG_S1));
+    test_instr_encoding(dc, OP_fcvtas, instr);
+
+    /* FCVTAS <Xd>, <Sn> */
+    instr = INSTR_CREATE_fcvtas_scalar(dc, opnd_create_reg(DR_REG_X7),
+                                       opnd_create_reg(DR_REG_S3));
+    test_instr_encoding(dc, OP_fcvtas, instr);
+
+    /* FCVTAS <Wd>, <Dn> */
+    instr = INSTR_CREATE_fcvtas_scalar(dc, opnd_create_reg(DR_REG_W0),
+                                       opnd_create_reg(DR_REG_D22));
+    test_instr_encoding(dc, OP_fcvtas, instr);
+
+    /* FCVTAS <Xd>, <Dn> */
+    instr = INSTR_CREATE_fcvtas_scalar(dc, opnd_create_reg(DR_REG_X21),
+                                       opnd_create_reg(DR_REG_D0));
+    test_instr_encoding(dc, OP_fcvtas, instr);
+}
+
+static void
+test_fcvtas_vector(void *dc)
+{
+    instr_t *instr;
+
+    /* FCVTAS <Vd>.<T>, <Vn>.<T> */
+    /* FCVTAS <Vd>.2S, <Vn>.2S */
+    instr = INSTR_CREATE_fcvtas_vector(dc, opnd_create_reg(DR_REG_D7),
+                                       opnd_create_reg(DR_REG_D1), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcvtas, instr);
+
+    /* FCVTAS <Vd>.4S, <Vn>.4S */
+    instr = INSTR_CREATE_fcvtas_vector(dc, opnd_create_reg(DR_REG_Q0),
+                                       opnd_create_reg(DR_REG_Q9), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcvtas, instr);
+
+    /* FCVTAS <Vd>.2D, <Vn>.2D */
+    instr = INSTR_CREATE_fcvtas_vector(dc, opnd_create_reg(DR_REG_Q5),
+                                       opnd_create_reg(DR_REG_Q29), OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fcvtas, instr);
+
+    /* FCVTAS <V><d>, <V><n> */
+    /* FCVTAS <V>S, <V>S */
+    instr = INSTR_CREATE_fcvtas_scalar(dc, opnd_create_reg(DR_REG_S30),
+                                       opnd_create_reg(DR_REG_S30));
+    test_instr_encoding(dc, OP_fcvtas, instr);
+
+    /* FCVTAS <V>D, <V>D */
+    instr = INSTR_CREATE_fcvtas_scalar(dc, opnd_create_reg(DR_REG_D7),
+                                       opnd_create_reg(DR_REG_D12));
+    test_instr_encoding(dc, OP_fcvtas, instr);
+}
+
+static void
+test_fcvtns_scalar(void *dc)
+{
+    instr_t *instr;
+
+    /* FCVTNS <Wd>, <Sn> */
+    instr = INSTR_CREATE_fcvtns_scalar(dc, opnd_create_reg(DR_REG_W21),
+                                       opnd_create_reg(DR_REG_S8));
+    test_instr_encoding(dc, OP_fcvtns, instr);
+
+    /* FCVTNS <Xd>, <Sn> */
+    instr = INSTR_CREATE_fcvtns_scalar(dc, opnd_create_reg(DR_REG_X14),
+                                       opnd_create_reg(DR_REG_S21));
+    test_instr_encoding(dc, OP_fcvtns, instr);
+
+    /* FCVTNS <Wd>, <Dn> */
+    instr = INSTR_CREATE_fcvtns_scalar(dc, opnd_create_reg(DR_REG_W7),
+                                       opnd_create_reg(DR_REG_D29));
+    test_instr_encoding(dc, OP_fcvtns, instr);
+
+    /* FCVTNS <Xd>, <Dn> */
+    instr = INSTR_CREATE_fcvtns_scalar(dc, opnd_create_reg(DR_REG_X9),
+                                       opnd_create_reg(DR_REG_D17));
+    test_instr_encoding(dc, OP_fcvtns, instr);
+}
+
+static void
+test_fcvtns_vector(void *dc)
+{
+    instr_t *instr;
+
+    /* FCVTNS <Vd>.<T>, <Vn>.<T> */
+    /* FCVTNS <Vd>.2S, <Vn>.2S */
+    instr = INSTR_CREATE_fcvtns_vector(dc, opnd_create_reg(DR_REG_D5),
+                                       opnd_create_reg(DR_REG_D9), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcvtns, instr);
+
+    /* FCVTNS <Vd>.4S, <Vn>.4S */
+    instr = INSTR_CREATE_fcvtns_vector(dc, opnd_create_reg(DR_REG_Q1),
+                                       opnd_create_reg(DR_REG_Q19), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcvtns, instr);
+
+    /* FCVTNS <Vd>.2D, <Vn>.2D */
+    instr = INSTR_CREATE_fcvtns_vector(dc, opnd_create_reg(DR_REG_Q17),
+                                       opnd_create_reg(DR_REG_Q11), OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fcvtns, instr);
+
+    /* FCVTNS <V><d>, <V><n> */
+    /* FCVTNS <V>S, <V>S */
+    instr = INSTR_CREATE_fcvtns_scalar(dc, opnd_create_reg(DR_REG_S9),
+                                       opnd_create_reg(DR_REG_S2));
+    test_instr_encoding(dc, OP_fcvtns, instr);
+
+    /* FCVTNS <V>D, <V>D */
+    instr = INSTR_CREATE_fcvtns_scalar(dc, opnd_create_reg(DR_REG_D17),
+                                       opnd_create_reg(DR_REG_D7));
+    test_instr_encoding(dc, OP_fcvtns, instr);
+}
+
+static void
+test_fcvtps_scalar(void *dc)
+{
+    instr_t *instr;
+
+    /* FCVTPS <Wd>, <Sn> */
+    instr = INSTR_CREATE_fcvtps_scalar(dc, opnd_create_reg(DR_REG_W19),
+                                       opnd_create_reg(DR_REG_S7));
+    test_instr_encoding(dc, OP_fcvtps, instr);
+
+    /* FCVTPS <Xd>, <Sn> */
+    instr = INSTR_CREATE_fcvtps_scalar(dc, opnd_create_reg(DR_REG_X5),
+                                       opnd_create_reg(DR_REG_S4));
+    test_instr_encoding(dc, OP_fcvtps, instr);
+
+    /* FCVTPS <Wd>, <Dn> */
+    instr = INSTR_CREATE_fcvtps_scalar(dc, opnd_create_reg(DR_REG_W8),
+                                       opnd_create_reg(DR_REG_D10));
+    test_instr_encoding(dc, OP_fcvtps, instr);
+
+    /* FCVTPS <Xd>, <Dn> */
+    instr = INSTR_CREATE_fcvtps_scalar(dc, opnd_create_reg(DR_REG_X9),
+                                       opnd_create_reg(DR_REG_D18));
+    test_instr_encoding(dc, OP_fcvtps, instr);
+}
+
+static void
+test_fcvtps_vector(void *dc)
+{
+    instr_t *instr;
+
+    /* FCVTPS <Vd>.<T>, <Vn>.<T> */
+    /* FCVTPS <Vd>.2S, <Vn>.2S */
+    instr = INSTR_CREATE_fcvtps_vector(dc, opnd_create_reg(DR_REG_D6),
+                                       opnd_create_reg(DR_REG_D9), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcvtps, instr);
+
+    /* FCVTPS <Vd>.4S, <Vn>.4S */
+    instr = INSTR_CREATE_fcvtps_vector(dc, opnd_create_reg(DR_REG_Q4),
+                                       opnd_create_reg(DR_REG_Q20), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcvtps, instr);
+
+    /* FCVTPS <Vd>.2D, <Vn>.2D */
+    instr = INSTR_CREATE_fcvtps_vector(dc, opnd_create_reg(DR_REG_Q15),
+                                       opnd_create_reg(DR_REG_Q0), OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fcvtps, instr);
+
+    /* FCVTPS <V><d>, <V><n> */
+    /* FCVTPS <V>S, <V>S */
+    instr = INSTR_CREATE_fcvtps_scalar(dc, opnd_create_reg(DR_REG_S29),
+                                       opnd_create_reg(DR_REG_S4));
+    test_instr_encoding(dc, OP_fcvtps, instr);
+
+    /* FCVTPS <V>D, <V>D */
+    instr = INSTR_CREATE_fcvtps_scalar(dc, opnd_create_reg(DR_REG_D12),
+                                       opnd_create_reg(DR_REG_D16));
+    test_instr_encoding(dc, OP_fcvtps, instr);
+}
+
+static void
+test_fcvtpu_scalar(void *dc)
+{
+    instr_t *instr;
+
+    /* FCVTPU <Wd>, <Sn> */
+    instr = INSTR_CREATE_fcvtpu_scalar(dc, opnd_create_reg(DR_REG_W1),
+                                       opnd_create_reg(DR_REG_S2));
+    test_instr_encoding(dc, OP_fcvtpu, instr);
+
+    /* FCVTPU <Xd>, <Sn> */
+    instr = INSTR_CREATE_fcvtpu_scalar(dc, opnd_create_reg(DR_REG_X14),
+                                       opnd_create_reg(DR_REG_S14));
+    test_instr_encoding(dc, OP_fcvtpu, instr);
+
+    /* FCVTPU <Wd>, <Dn> */
+    instr = INSTR_CREATE_fcvtpu_scalar(dc, opnd_create_reg(DR_REG_W4),
+                                       opnd_create_reg(DR_REG_D2));
+    test_instr_encoding(dc, OP_fcvtpu, instr);
+
+    /* FCVTPU <Xd>, <Dn> */
+    instr = INSTR_CREATE_fcvtpu_scalar(dc, opnd_create_reg(DR_REG_X9),
+                                       opnd_create_reg(DR_REG_D1));
+    test_instr_encoding(dc, OP_fcvtpu, instr);
+}
+
+static void
+test_fcvtpu_vector(void *dc)
+{
+    instr_t *instr;
+
+    /* FCVTPU <Vd>.<T>, <Vn>.<T> */
+    /* FCVTPU <Vd>.2S, <Vn>.2S */
+    instr = INSTR_CREATE_fcvtpu_vector(dc, opnd_create_reg(DR_REG_D1),
+                                       opnd_create_reg(DR_REG_D24), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcvtpu, instr);
+
+    /* FCVTPU <Vd>.4S, <Vn>.4S */
+    instr = INSTR_CREATE_fcvtpu_vector(dc, opnd_create_reg(DR_REG_Q22),
+                                       opnd_create_reg(DR_REG_Q21), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcvtpu, instr);
+
+    /* FCVTPU <Vd>.2D, <Vn>.2D */
+    instr = INSTR_CREATE_fcvtpu_vector(dc, opnd_create_reg(DR_REG_Q11),
+                                       opnd_create_reg(DR_REG_Q11), OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fcvtpu, instr);
+
+    /* FCVTPU <V><d>, <V><n> */
+    /* FCVTPU <V>S, <V>S */
+    instr = INSTR_CREATE_fcvtpu_scalar(dc, opnd_create_reg(DR_REG_S27),
+                                       opnd_create_reg(DR_REG_S21));
+    test_instr_encoding(dc, OP_fcvtpu, instr);
+
+    /* FCVTPU <V>D, <V>D */
+    instr = INSTR_CREATE_fcvtpu_scalar(dc, opnd_create_reg(DR_REG_D12),
+                                       opnd_create_reg(DR_REG_D18));
+    test_instr_encoding(dc, OP_fcvtpu, instr);
+}
+
+static void
+test_fcvtzs_scalar(void *dc)
+{
+    instr_t *instr;
+    /* FCVTZS <Wd>, <Sn> */
+    instr = INSTR_CREATE_fcvtzs_scalar(dc, opnd_create_reg(DR_REG_W11),
+                                       opnd_create_reg(DR_REG_S8));
+    test_instr_encoding(dc, OP_fcvtzs, instr);
+
+    /* FCVTZS <Xd>, <Sn> */
+    instr = INSTR_CREATE_fcvtzs_scalar(dc, opnd_create_reg(DR_REG_X14),
+                                       opnd_create_reg(DR_REG_S3));
+    test_instr_encoding(dc, OP_fcvtzs, instr);
+
+    /* FCVTZS <Wd>, <Dn> */
+    instr = INSTR_CREATE_fcvtzs_scalar(dc, opnd_create_reg(DR_REG_W0),
+                                       opnd_create_reg(DR_REG_D28));
+    test_instr_encoding(dc, OP_fcvtzs, instr);
+
+    /* FCVTZS <Xd>, <Dn> */
+    instr = INSTR_CREATE_fcvtzs_scalar(dc, opnd_create_reg(DR_REG_X9),
+                                       opnd_create_reg(DR_REG_D1));
+    test_instr_encoding(dc, OP_fcvtzs, instr);
+}
+
+static void
+test_fcvtzs_vector(void *dc)
+{
+    instr_t *instr;
+
+    /* FCVTZS <Vd>.<T>, <Vn>.<T> */
+    /* FCVTZS <Vd>.2S, <Vn>.2S */
+    instr = INSTR_CREATE_fcvtzs_vector(dc, opnd_create_reg(DR_REG_D3),
+                                       opnd_create_reg(DR_REG_D8), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcvtzs, instr);
+
+    /* FCVTZS <Vd>.4S, <Vn>.4S */
+    instr = INSTR_CREATE_fcvtzs_vector(dc, opnd_create_reg(DR_REG_Q9),
+                                       opnd_create_reg(DR_REG_Q21), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_fcvtzs, instr);
+
+    /* FCVTZS <Vd>.2D, <Vn>.2D */
+    instr = INSTR_CREATE_fcvtzs_vector(dc, opnd_create_reg(DR_REG_Q11),
+                                       opnd_create_reg(DR_REG_Q2), OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_fcvtzs, instr);
+
+    /* FCVTZS <V><d>, <V><n> */
+    /* FCVTZS <V>S, <V>S */
+    instr = INSTR_CREATE_fcvtzs_scalar(dc, opnd_create_reg(DR_REG_S3),
+                                       opnd_create_reg(DR_REG_S3));
+    test_instr_encoding(dc, OP_fcvtzs, instr);
+
+    /* FCVTZS <V>D, <V>D */
+    instr = INSTR_CREATE_fcvtzs_scalar(dc, opnd_create_reg(DR_REG_D17),
+                                       opnd_create_reg(DR_REG_D7));
+    test_instr_encoding(dc, OP_fcvtzs, instr);
+}
+
+static void
 test_fcvtzu_scalar(void *dc)
 {
     instr_t *instr;
@@ -4645,22 +4938,30 @@ static void
 test_fcvtzu_vector(void *dc)
 {
     instr_t *instr;
+
     /* FCVTZU <Vd>.<T>, <Vn>.<T> */
+    /* FCVTAS <Vd>.2S, <Vn>.2S */
     instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(DR_REG_D7),
                                        opnd_create_reg(DR_REG_D9), OPND_CREATE_SINGLE());
     test_instr_encoding(dc, OP_fcvtzu, instr);
+
+    /* FCVTAS <Vd>.4S, <Vn>.4S */
     instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(DR_REG_Q1),
                                        opnd_create_reg(DR_REG_Q24), OPND_CREATE_SINGLE());
     test_instr_encoding(dc, OP_fcvtzu, instr);
+
+    /* FCVTAS <Vd>.2D, <Vn>.2D */
     instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(DR_REG_Q5),
                                        opnd_create_reg(DR_REG_Q18), OPND_CREATE_DOUBLE());
     test_instr_encoding(dc, OP_fcvtzu, instr);
 
     /* FCVTZU <V><d>, <V><n> */
+    /* FCVTZU <V>S, <V>S */
     instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_S9),
                                        opnd_create_reg(DR_REG_S10));
     test_instr_encoding(dc, OP_fcvtzu, instr);
 
+    /* FCVTZU <V>D, <V>D */
     instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(DR_REG_D11),
                                        opnd_create_reg(DR_REG_D0));
     test_instr_encoding(dc, OP_fcvtzu, instr);
@@ -4740,6 +5041,36 @@ main(int argc, char *argv[])
 
     test_mov_instr_addr(dcontext);
     print("test_mov_instr_addr complete\n");
+
+    test_fcvtas_scalar(dcontext);
+    print("test_fcvtas_scalar complete\n");
+
+    test_fcvtas_vector(dcontext);
+    print("test_fcvtas_vector complete\n");
+
+    test_fcvtns_scalar(dcontext);
+    print("test_fcvtns_scalar complete\n");
+
+    test_fcvtns_vector(dcontext);
+    print("test_fcvtns_vector complete\n");
+
+    test_fcvtps_scalar(dcontext);
+    print("test_fcvtps_scalar complete\n");
+
+    test_fcvtps_vector(dcontext);
+    print("test_fcvtps_vector complete\n");
+
+    test_fcvtpu_scalar(dcontext);
+    print("test_fcvtpu_scalar complete\n");
+
+    test_fcvtpu_vector(dcontext);
+    print("test_fcvtpu_vector complete\n");
+
+    test_fcvtzs_scalar(dcontext);
+    print("test_fcvtzs_scalar complete\n");
+
+    test_fcvtzs_vector(dcontext);
+    print("test_fcvtzs_vector complete\n");
 
     test_fcvtzu_scalar(dcontext);
     print("test_fcvtzu_scalar complete\n");

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -865,6 +865,61 @@ blr    %x5 -> %x30
 test_xinst complete
 test_opnd complete
 test_mov_instr_addr complete
+fcvtas %s1 -> %w20
+fcvtas %s3 -> %x7
+fcvtas %d22 -> %w0
+fcvtas %d0 -> %x21
+test_fcvtas_scalar complete
+fcvtas %d1 $0x02 -> %d7
+fcvtas %q9 $0x02 -> %q0
+fcvtas %q29 $0x03 -> %q5
+fcvtas %s30 -> %s30
+fcvtas %d12 -> %d7
+test_fcvtas_vector complete
+fcvtns %s8 -> %w21
+fcvtns %s21 -> %x14
+fcvtns %d29 -> %w7
+fcvtns %d17 -> %x9
+test_fcvtns_scalar complete
+fcvtns %d9 $0x02 -> %d5
+fcvtns %q19 $0x02 -> %q1
+fcvtns %q11 $0x03 -> %q17
+fcvtns %s2 -> %s9
+fcvtns %d7 -> %d17
+test_fcvtns_vector complete
+fcvtps %s7 -> %w19
+fcvtps %s4 -> %x5
+fcvtps %d10 -> %w8
+fcvtps %d18 -> %x9
+test_fcvtps_scalar complete
+fcvtps %d9 $0x02 -> %d6
+fcvtps %q20 $0x02 -> %q4
+fcvtps %q0 $0x03 -> %q15
+fcvtps %s4 -> %s29
+fcvtps %d16 -> %d12
+test_fcvtps_vector complete
+fcvtpu %s2 -> %w1
+fcvtpu %s14 -> %x14
+fcvtpu %d2 -> %w4
+fcvtpu %d1 -> %x9
+test_fcvtpu_scalar complete
+fcvtpu %d24 $0x02 -> %d1
+fcvtpu %q21 $0x02 -> %q22
+fcvtpu %q11 $0x03 -> %q11
+fcvtpu %s21 -> %s27
+fcvtpu %d18 -> %d12
+test_fcvtpu_vector complete
+fcvtzs %s8 -> %w11
+fcvtzs %s3 -> %x14
+fcvtzs %d28 -> %w0
+fcvtzs %d1 -> %x9
+test_fcvtzs_scalar complete
+fcvtzs %d8 $0x02 -> %d3
+fcvtzs %q21 $0x02 -> %q9
+fcvtzs %q2 $0x03 -> %q11
+fcvtzs %s3 -> %s3
+fcvtzs %d7 -> %d17
+test_fcvtzs_vector complete
 fcvtzu %s8 -> %w7
 fcvtzu %s21 -> %x13
 fcvtzu %d9 -> %w0


### PR DESCRIPTION
 i#4848 AArch64 GPR Decode: Add FCVT instructions (#4855)

This implements:
- Scalar floating-point
- Vector floating-point
- Scalar floating-point to GPR

for FCVTAS, FCVTNS, FCVTPS, FCVTPU, and FCVTZS.

Issue: #4848, #2626