### PR TITLE
i#4316 a64 rseq: Nop writeback stores

### DIFF
--- a/api/docs/bt.dox
+++ b/api/docs/bt.dox
@@ -1327,6 +1327,8 @@ This run-twice approach is subject to the following limitations:
   effects: it must only write to memory and not to any registers.
   For example, a push instruction which both writes to memory and the
   stack pointer register is not supported.
+  An exception is a pre-indexed or post-indexed writeback store, which is
+  supported.
 - Each rseq region's code must end with a fall-through (non-control-flow)
   instruction.
 - Indirect branches that do not exit the rseq region are not allowed.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4716,6 +4716,7 @@ if (NOT ANDROID AND AARCHXX)
       code_api|sample.opcodes
       PROPERTIES LABELS RUNS_ON_QEMU)
     if (LINUX AND X64 AND HAVE_RSEQ)
+      # QEMU just returns ENOSYS, but still this is testing that.
       set_tests_properties(
         code_api|linux.rseq
         code_api|linux.rseq_table


### PR DESCRIPTION
Adds nop-ing of writeback stores inside rseq regions by replacing them
with adds to preserve the GPR changes but throw away the memory changes.

Updates the documentation.
Adds a test case.

Fixes #4316