### PR TITLE
i#4848: AArch64 GPR Decode: Add UCVTF and SCVTF

### DIFF
--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -1160,31 +1160,51 @@ x001111000111000000000xxxxxxxxxx     fcvtzs    wx0 : s5
 x001111001111000000000xxxxxxxxxx     fcvtzs    wx0 : d5
 x001111000111001000000xxxxxxxxxx     fcvtzu    wx0 : s5
 x001111001111001000000xxxxxxxxxx     fcvtzu    wx0 : d5
+x001111000100011000000xxxxxxxxxx     ucvtf     s0 : wx5
+x001111001100011000000xxxxxxxxxx     ucvtf     d0 : wx5
+x001111000100010000000xxxxxxxxxx     scvtf     s0 : wx5
+x001111001100010000000xxxxxxxxxx     scvtf     d0 : wx5
 
-# Floating-point convert (vector, integer) (vector single-precision and double-precision)
+# Floating-point convert (vector, integer) (scalar single-precision and double-precision)
 0101111010100001101110xxxxxxxxxx     fcvtzs    s0 : s5
 0101111011100001101110xxxxxxxxxx     fcvtzs    d0 : d5
 0111111010100001101110xxxxxxxxxx     fcvtzu    s0 : s5
 0111111011100001101110xxxxxxxxxx     fcvtzu    d0 : d5
+0111111000100001110110xxxxxxxxxx     ucvtf     s0  : s5
+0111111001100001110110xxxxxxxxxx     ucvtf     d0  : d5
+0101111000100001110110xxxxxxxxxx     scvtf     s0  : s5
+0101111001100001110110xxxxxxxxxx     scvtf     d0  : d5
 
-# Floating-point convert (vector, integer) (scalar single-precision and double-precision)
+# Floating-point convert (vector, integer) (vector single-precision and double-precision)
 0x0011101x100001101110xxxxxxxxxx     fcvtzs    dq0 : dq5 sd_sz
 0x1011101x100001101110xxxxxxxxxx     fcvtzu    dq0 : dq5 sd_sz
+0x1011100x100001110110xxxxxxxxxx     ucvtf     dq0 : dq5 sd_sz
+0x0011100x100001110110xxxxxxxxxx     scvtf     dq0 : dq5 sd_sz
 
 # Floating-point convert (scalar, fixed-point)
 x001111000011000xxxxxxxxxxxxxxxx     fcvtzs    wx0 : s5 scale
 x001111001011000xxxxxxxxxxxxxxxx     fcvtzs    wx0 : d5 scale
 x001111000011001xxxxxxxxxxxxxxxx     fcvtzu    wx0 : s5 scale
 x001111001011001xxxxxxxxxxxxxxxx     fcvtzu    wx0 : d5 scale
+x001111000000011xxxxxxxxxxxxxxxx     ucvtf     s0 : wx5 scale
+x001111001000011xxxxxxxxxxxxxxxx     ucvtf     d0 : wx5 scale
+x001111000000010xxxxxxxxxxxxxxxx     scvtf     s0 : wx5 scale
+x001111001000010xxxxxxxxxxxxxxxx     scvtf     d0 : wx5 scale
 
 # Floating-point convert (vector, fixed-point) (scalar)
 0101111100xxxxxx111111xxxxxxxxxx     fcvtzs    s0 : s5 immhb
 0101111101xxxxxx111111xxxxxxxxxx     fcvtzs    d0 : d5 immhb
 0111111100xxxxxx111111xxxxxxxxxx     fcvtzu    s0 : s5 immhb
 0111111101xxxxxx111111xxxxxxxxxx     fcvtzu    d0 : d5 immhb
+0111111000xxxxxx111001xxxxxxxxxx     ucvtf     s0 : s5 immhb
+0111111001xxxxxx111001xxxxxxxxxx     ucvtf     d0 : d5 immhb
+0101111100xxxxxx111001xxxxxxxxxx     scvtf     s0 : s5 immhb
+0101111101xxxxxx111001xxxxxxxxxx     scvtf     d0 : d5 immhb
 
 # Floating-point convert (vector, fixed-point) (vector)
 0x1011110xxxxxxx111111xxxxxxxxxx     fcvtzu    dq0 : dq5 sd_sz immhb
+0x1011110xxxxxxx111001xxxxxxxxxx     ucvtf     dq0 : dq5 sd_sz immhb
+0x0011110xxxxxxx111001xxxxxxxxxx     scvtf     dq0 : dq5 sd_sz immhb
 
 # Floating-point data-processing (2 source)
 00011110xx1xxxxx000010xxxxxxxxxx     fmul      float_reg0 : float_reg5 float_reg16

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1772,6 +1772,54 @@ enum {
 #define INSTR_CREATE_fcvtzu_vector_fixed(dc, Rd, Rm, width, fbits) \
     instr_create_1dst_3src(dc, OP_fcvtzu, Rd, Rm, width, fbits)
 
+/**
+ * Creates a UCVTF vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE()
+ * or #OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_ucvtf_vector(dc, Rd, Rm, width) \
+    instr_create_1dst_2src(dc, OP_ucvtf, Rd, Rm, width)
+
+/**
+ * Creates a UCVTF vector floating-point to fixed-point convert instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The input register.
+ * \param width   The vector element width. Must be #OPND_CREATE_SINGLE() or
+ *                #OPND_CREATE_DOUBLE().
+ * \param fbits   The number of bits after the binary point in the fixed-point
+ *                destination element.
+ */
+#define INSTR_CREATE_ucvtf_vector_fixed(dc, Rd, Rm, width, fbits) \
+    instr_create_1dst_3src(dc, OP_ucvtf, Rd, Rm, width, fbits)
+
+/**
+ * Creates an SCVTF vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE()
+ * or #OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_scvtf_vector(dc, Rd, Rm, width) \
+    instr_create_1dst_2src(dc, OP_scvtf, Rd, Rm, width)
+
+/**
+ * Creates an SCVTF vector floating-point to fixed-point convert instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The input register.
+ * \param width   The vector element width. Must be #OPND_CREATE_SINGLE() or
+ *                #OPND_CREATE_DOUBLE().
+ * \param fbits   The number of bits after the binary point in the fixed-point
+ *                destination element.
+ */
+#define INSTR_CREATE_scvtf_vector_fixed(dc, Rd, Rm, width, fbits) \
+    instr_create_1dst_3src(dc, OP_scvtf, Rd, Rm, width, fbits)
+
 /* -------- Floating-point data-processing (1 source) ------------------ */
 
 /**
@@ -1889,6 +1937,44 @@ enum {
  */
 #define INSTR_CREATE_fcvtzu_scalar_fixed(dc, Rd, Rm, fbits) \
     instr_create_1dst_2src(dc, OP_fcvtzu, Rd, Rm, fbits)
+
+/**
+ * Creates a UCVTF floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      Floating-point output register.
+ * \param Rm      Integer input register.
+ */
+#define INSTR_CREATE_ucvtf_scalar(dc, Rd, Rm) instr_create_1dst_1src(dc, OP_ucvtf, Rd, Rm)
+
+/**
+ * Creates a UCVTF scalar floating-point to fixed-point convert instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      Floating-point output register.
+ * \param Rm      Integer input register.
+ * \param fbits   The number of bits after the binary point in the fixed-point
+ *                input.
+ */
+#define INSTR_CREATE_ucvtf_scalar_fixed(dc, Rd, Rm, fbits) \
+    instr_create_1dst_2src(dc, OP_ucvtf, Rd, Rm, fbits)
+
+/**
+ * Creates an SCVTF floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      Floating-point output register.
+ * \param Rm      Integer input register.
+ */
+#define INSTR_CREATE_scvtf_scalar(dc, Rd, Rm) instr_create_1dst_1src(dc, OP_scvtf, Rd, Rm)
+
+/**
+ * Creates an SCVTF scalar floating-point to fixed-point convert instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      Floating-point output register.
+ * \param Rm      Integer input register.
+ * \param fbits   The number of bits after the binary point in the fixed-point
+ *                input.
+ */
+#define INSTR_CREATE_scvtf_scalar_fixed(dc, Rd, Rm, fbits) \
+    instr_create_1dst_2src(dc, OP_scvtf, Rd, Rm, fbits)
 
 /**
  * Creates a FRINTN floating point instruction.

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -2220,7 +2220,6 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 5f40fdac : fcvtzs d12, d13, #64                     : fcvtzs %d13 $0x40 -> %d12
 5f6bffbc : fcvtzs d28, d29, #21                     : fcvtzs %d29 $0x15 -> %d28
 5f56fffe : fcvtzs d30, d31, #42                     : fcvtzs %d31 $0x2a -> %d30
-
 1e19f107 : fcvtzu w7, s8, #4                        : fcvtzu %s8 $0x04 -> %w7
 9e19c2ad : fcvtzu x13, s21, #16                     : fcvtzu %s21 $0x10 -> %x13
 1e59813e : fcvtzu w30, d9, #32                      : fcvtzu %d9 $0x20 -> %w30
@@ -2266,6 +2265,98 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 2f20fd6a : fcvtzu v10.2s, v11.2s, #32               : fcvtzu %d11 $0x02 $0x20 -> %d10
 2f2bffbc : fcvtzu v28.2s, v29.2s, #21               : fcvtzu %d29 $0x02 $0x15 -> %d28
 2f21fffe : fcvtzu v30.2s, v31.2s, #31               : fcvtzu %d31 $0x02 $0x1f -> %d30
+1e03f105 : ucvtf s5, w8, #4                         : ucvtf  %w8 $0x04 -> %s5
+9e03c0ed : ucvtf s13, x7, #16                       : ucvtf  %x7 $0x10 -> %s13
+1e438011 : ucvtf d17, w0, #32                       : ucvtf  %w0 $0x20 -> %d17
+9e43016d : ucvtf d13, x11, #64                      : ucvtf  %x11 $0x40 -> %d13
+7e3fe509 : ucvtf s9, s8, #1                         : ucvtf  %s8 $0x01 -> %s9
+7e3ee495 : ucvtf s21, s4, #2                        : ucvtf  %s4 $0x02 -> %s21
+7e3ce674 : ucvtf s20, s19, #4                       : ucvtf  %s19 $0x04 -> %s20
+7e38e4e6 : ucvtf s6, s7, #8                         : ucvtf  %s7 $0x08 -> %s6
+7e30e7cc : ucvtf s12, s30, #16                      : ucvtf  %s30 $0x10 -> %s12
+7e20e532 : ucvtf s18, s9, #32                       : ucvtf  %s9 $0x20 -> %s18
+7e2be6b6 : ucvtf s22, s21, #21                      : ucvtf  %s21 $0x15 -> %s22
+7e21e66b : ucvtf s11, s19, #31                      : ucvtf  %s19 $0x1f -> %s11
+7e7fe56d : ucvtf d13, d11, #1                       : ucvtf  %d11 $0x01 -> %d13
+2e21d843 : ucvtf d3, d2, #2                         : ucvtf  %d2 $0x02 -> %d3
+7e7ce633 : ucvtf d19, d17, #4                       : ucvtf  %d17 $0x04 -> %d19
+7e78e53e : ucvtf d30, d9, #8                        : ucvtf  %d9 $0x08 -> %d30
+7e70e571 : ucvtf d17, d11, #16                      : ucvtf  %d11 $0x10 -> %d17
+7e60e488 : ucvtf d8, d4, #32                        : ucvtf  %d4 $0x20 -> %d8
+7e40e6bd : ucvtf d29, d21, #64                      : ucvtf  %d21 $0x40 -> %d29
+7e6be7be : ucvtf d30, d29, #21                      : ucvtf  %d29 $0x15 -> %d30
+7e56e5b1 : ucvtf d17, d13, #42                      : ucvtf  %d13 $0x2a -> %d17
+6f3fe420 : ucvtf v0.4s, v1.4s, #1                   : ucvtf  %q1 $0x02 $0x01 -> %q0
+6f3ee462 : ucvtf v2.4s, v3.4s, #2                   : ucvtf  %q3 $0x02 $0x02 -> %q2
+6f3ce4a4 : ucvtf v4.4s, v5.4s, #4                   : ucvtf  %q5 $0x02 $0x04 -> %q4
+6f38e4e6 : ucvtf v6.4s, v7.4s, #8                   : ucvtf  %q7 $0x02 $0x08 -> %q6
+6f30e528 : ucvtf v8.4s, v9.4s, #16                  : ucvtf  %q9 $0x02 $0x10 -> %q8
+6f20e56a : ucvtf v10.4s, v11.4s, #32                : ucvtf  %q11 $0x02 $0x20 -> %q10
+6f2be7bc : ucvtf v28.4s, v29.4s, #21                : ucvtf  %q29 $0x02 $0x15 -> %q28
+6f21e7fe : ucvtf v30.4s, v31.4s, #31                : ucvtf  %q31 $0x02 $0x1f -> %q30
+6f7fe420 : ucvtf v0.2d, v1.2d, #1                   : ucvtf  %q1 $0x03 $0x01 -> %q0
+6f7ee462 : ucvtf v2.2d, v3.2d, #2                   : ucvtf  %q3 $0x03 $0x02 -> %q2
+6f7ce4a4 : ucvtf v4.2d, v5.2d, #4                   : ucvtf  %q5 $0x03 $0x04 -> %q4
+6f78e4e6 : ucvtf v6.2d, v7.2d, #8                   : ucvtf  %q7 $0x03 $0x08 -> %q6
+6f70e528 : ucvtf v8.2d, v9.2d, #16                  : ucvtf  %q9 $0x03 $0x10 -> %q8
+6f60e56a : ucvtf v10.2d, v11.2d, #32                : ucvtf  %q11 $0x03 $0x20 -> %q10
+6f40e5ac : ucvtf v12.2d, v13.2d, #64                : ucvtf  %q13 $0x03 $0x40 -> %q12
+6f6be7bc : ucvtf v28.2d, v29.2d, #21                : ucvtf  %q29 $0x03 $0x15 -> %q28
+6f56e7fe : ucvtf v30.2d, v31.2d, #42                : ucvtf  %q31 $0x03 $0x2a -> %q30
+2f3fe420 : ucvtf v0.2s, v1.2s, #1                   : ucvtf  %d1 $0x02 $0x01 -> %d0
+2f3ee462 : ucvtf v2.2s, v3.2s, #2                   : ucvtf  %d3 $0x02 $0x02 -> %d2
+2f3ce4a4 : ucvtf v4.2s, v5.2s, #4                   : ucvtf  %d5 $0x02 $0x04 -> %d4
+2f38e4e6 : ucvtf v6.2s, v7.2s, #8                   : ucvtf  %d7 $0x02 $0x08 -> %d6
+2f30e528 : ucvtf v8.2s, v9.2s, #16                  : ucvtf  %d9 $0x02 $0x10 -> %d8
+2f20e56a : ucvtf v10.2s, v11.2s, #32                : ucvtf  %d11 $0x02 $0x20 -> %d10
+2f2be7bc : ucvtf v28.2s, v29.2s, #21                : ucvtf  %d29 $0x02 $0x15 -> %d28
+2f21e7fe : ucvtf v30.2s, v31.2s, #31                : ucvtf  %d31 $0x02 $0x1f -> %d30
+1e02f105 : scvtf s5, w8, #4                         : scvtf  %w8 $0x04 -> %s5
+9e02c0ed : scvtf s13, x7, #16                       : scvtf  %x7 $0x10 -> %s13
+1e428011 : scvtf d17, w0, #32                       : scvtf  %w0 $0x20 -> %d17
+9e42016d : scvtf d13, x11, #64                      : scvtf  %x11 $0x40 -> %d13
+5f3fe509 : scvtf s9, s8, #1                         : scvtf  %s8 $0x01 -> %s9
+5f3ee495 : scvtf s21, s4, #2                        : scvtf  %s4 $0x02 -> %s21
+5f3ce674 : scvtf s20, s19, #4                       : scvtf  %s19 $0x04 -> %s20
+5f38e4e6 : scvtf s6, s7, #8                         : scvtf  %s7 $0x08 -> %s6
+5f30e7cc : scvtf s12, s30, #16                      : scvtf  %s30 $0x10 -> %s12
+5f20e532 : scvtf s18, s9, #32                       : scvtf  %s9 $0x20 -> %s18
+5f2be6b6 : scvtf s22, s21, #21                      : scvtf  %s21 $0x15 -> %s22
+5f21e66b : scvtf s11, s19, #31                      : scvtf  %s19 $0x1f -> %s11
+5f7fe56d : scvtf d13, d11, #1                       : scvtf  %d11 $0x01 -> %d13
+0e21d843 : scvtf d3, d2, #2                         : scvtf  %d2 $0x02 -> %d3
+5f7ce633 : scvtf d19, d17, #4                       : scvtf  %d17 $0x04 -> %d19
+5f78e53e : scvtf d30, d9, #8                        : scvtf  %d9 $0x08 -> %d30
+5f70e571 : scvtf d17, d11, #16                      : scvtf  %d11 $0x10 -> %d17
+5f60e488 : scvtf d8, d4, #32                        : scvtf  %d4 $0x20 -> %d8
+5f40e6bd : scvtf d29, d21, #64                      : scvtf  %d21 $0x40 -> %d29
+5f6be7be : scvtf d30, d29, #21                      : scvtf  %d29 $0x15 -> %d30
+5f56e5b1 : scvtf d17, d13, #42                      : scvtf  %d13 $0x2a -> %d17
+4f3fe420 : scvtf v0.4s, v1.4s, #1                   : scvtf  %q1 $0x02 $0x01 -> %q0
+4f3ee462 : scvtf v2.4s, v3.4s, #2                   : scvtf  %q3 $0x02 $0x02 -> %q2
+4f3ce4a4 : scvtf v4.4s, v5.4s, #4                   : scvtf  %q5 $0x02 $0x04 -> %q4
+4f38e4e6 : scvtf v6.4s, v7.4s, #8                   : scvtf  %q7 $0x02 $0x08 -> %q6
+4f30e528 : scvtf v8.4s, v9.4s, #16                  : scvtf  %q9 $0x02 $0x10 -> %q8
+4f20e56a : scvtf v10.4s, v11.4s, #32                : scvtf  %q11 $0x02 $0x20 -> %q10
+4f2be7bc : scvtf v28.4s, v29.4s, #21                : scvtf  %q29 $0x02 $0x15 -> %q28
+4f21e7fe : scvtf v30.4s, v31.4s, #31                : scvtf  %q31 $0x02 $0x1f -> %q30
+4f7fe420 : scvtf v0.2d, v1.2d, #1                   : scvtf  %q1 $0x03 $0x01 -> %q0
+4f7ee462 : scvtf v2.2d, v3.2d, #2                   : scvtf  %q3 $0x03 $0x02 -> %q2
+4f7ce4a4 : scvtf v4.2d, v5.2d, #4                   : scvtf  %q5 $0x03 $0x04 -> %q4
+4f78e4e6 : scvtf v6.2d, v7.2d, #8                   : scvtf  %q7 $0x03 $0x08 -> %q6
+4f70e528 : scvtf v8.2d, v9.2d, #16                  : scvtf  %q9 $0x03 $0x10 -> %q8
+4f60e56a : scvtf v10.2d, v11.2d, #32                : scvtf  %q11 $0x03 $0x20 -> %q10
+4f40e5ac : scvtf v12.2d, v13.2d, #64                : scvtf  %q13 $0x03 $0x40 -> %q12
+4f6be7bc : scvtf v28.2d, v29.2d, #21                : scvtf  %q29 $0x03 $0x15 -> %q28
+4f56e7fe : scvtf v30.2d, v31.2d, #42                : scvtf  %q31 $0x03 $0x2a -> %q30
+0f3fe420 : scvtf v0.2s, v1.2s, #1                   : scvtf  %d1 $0x02 $0x01 -> %d0
+0f3ee462 : scvtf v2.2s, v3.2s, #2                   : scvtf  %d3 $0x02 $0x02 -> %d2
+0f3ce4a4 : scvtf v4.2s, v5.2s, #4                   : scvtf  %d5 $0x02 $0x04 -> %d4
+0f38e4e6 : scvtf v6.2s, v7.2s, #8                   : scvtf  %d7 $0x02 $0x08 -> %d6
+0f30e528 : scvtf v8.2s, v9.2s, #16                  : scvtf  %d9 $0x02 $0x10 -> %d8
+0f20e56a : scvtf v10.2s, v11.2s, #32                : scvtf  %d11 $0x02 $0x20 -> %d10
+0f2be7bc : scvtf v28.2s, v29.2s, #21                : scvtf  %d29 $0x02 $0x15 -> %d28
+0f21e7fe : scvtf v30.2s, v31.2s, #31                : scvtf  %d31 $0x02 $0x1f -> %d30
 
 # SVE bitwise logical operations (predicated)
 04181da2 : orr z2.b, p7/m, z2.b, z13.b              : orr    %p7 %z2 %z13 $0x00 -> %z2

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -5349,6 +5349,632 @@ test_fcvtzu_vector_fixed(void *dc)
     test_instr_encoding(dc, OP_fcvtzu, instr);
 }
 
+static void
+test_ucvtf_scalar(void *dc)
+{
+    instr_t *instr;
+    instr = INSTR_CREATE_ucvtf_scalar(dc, opnd_create_reg(DR_REG_S4),
+                                      opnd_create_reg(DR_REG_W9));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar(dc, opnd_create_reg(DR_REG_D11),
+                                      opnd_create_reg(DR_REG_W28));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar(dc, opnd_create_reg(DR_REG_S1),
+                                      opnd_create_reg(DR_REG_X21));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar(dc, opnd_create_reg(DR_REG_D3),
+                                      opnd_create_reg(DR_REG_X2));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+}
+
+static void
+test_ucvtf_vector(void *dc)
+{
+    instr_t *instr;
+
+    /* UCVTF <Vd>.<T>, <Vn>.<T> */
+    /* UCVTF <Vd>.2S, <Vn>.2S */
+    instr = INSTR_CREATE_ucvtf_vector(dc, opnd_create_reg(DR_REG_D13),
+                                      opnd_create_reg(DR_REG_D7), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    /* UCVTF <Vd>.4S, <Vn>.4S */
+    instr = INSTR_CREATE_ucvtf_vector(dc, opnd_create_reg(DR_REG_Q12),
+                                      opnd_create_reg(DR_REG_Q24), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    /* UCVTF <Vd>.2D, <Vn>.2D */
+    instr = INSTR_CREATE_ucvtf_vector(dc, opnd_create_reg(DR_REG_Q9),
+                                      opnd_create_reg(DR_REG_Q1), OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    /* UCVTF <V><d>, <V><n> */
+    /* UCVTF <V>S, <V>S */
+    instr = INSTR_CREATE_ucvtf_scalar(dc, opnd_create_reg(DR_REG_S17),
+                                      opnd_create_reg(DR_REG_S20));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    /* UCVTF <V>D, <V>D */
+    instr = INSTR_CREATE_ucvtf_scalar(dc, opnd_create_reg(DR_REG_D14),
+                                      opnd_create_reg(DR_REG_D14));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+}
+
+static void
+test_ucvtf_scalar_fixed_gpr(void *dc)
+{
+    instr_t *instr;
+
+    /* UCVTF <Sd>, <Wn>, #<fbits> */
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S5),
+                                            opnd_create_reg(DR_REG_W8),
+                                            opnd_create_immed_int(4, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    /* UCVTF <Sd>, <Xn>, #<fbits> */
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S13),
+                                            opnd_create_reg(DR_REG_X7),
+                                            opnd_create_immed_int(16, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    /* UCVTF <Dd>, <Sn>, #<fbits> */
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D17),
+                                            opnd_create_reg(DR_REG_W0),
+                                            opnd_create_immed_int(32, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    /* UCVTF <Dd>, <Xn>, #<fbits> */
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D13),
+                                            opnd_create_reg(DR_REG_X11),
+                                            opnd_create_immed_int(64, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+}
+
+static void
+test_ucvtf_scalar_fixed(void *dc)
+{
+    instr_t *instr;
+
+    /* UCVTF <Sd>, <Sn>, #<fbits> */
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S9),
+                                            opnd_create_reg(DR_REG_S8),
+                                            opnd_create_immed_int(1, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S21),
+                                            opnd_create_reg(DR_REG_S4),
+                                            opnd_create_immed_int(2, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S20),
+                                            opnd_create_reg(DR_REG_S19),
+                                            opnd_create_immed_int(4, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S6),
+                                            opnd_create_reg(DR_REG_S7),
+                                            opnd_create_immed_int(8, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S12),
+                                            opnd_create_reg(DR_REG_S30),
+                                            opnd_create_immed_int(16, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S18),
+                                            opnd_create_reg(DR_REG_S9),
+                                            opnd_create_immed_int(32, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S22),
+                                            opnd_create_reg(DR_REG_S21),
+                                            opnd_create_immed_int(21, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S11),
+                                            opnd_create_reg(DR_REG_S19),
+                                            opnd_create_immed_int(31, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    /* UCVTF <Dd>, <Dn>, #<fbits> */
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D13),
+                                            opnd_create_reg(DR_REG_D11),
+                                            opnd_create_immed_int(1, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D2),
+                                            opnd_create_reg(DR_REG_D3),
+                                            opnd_create_immed_int(2, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D19),
+                                            opnd_create_reg(DR_REG_D17),
+                                            opnd_create_immed_int(4, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D30),
+                                            opnd_create_reg(DR_REG_D9),
+                                            opnd_create_immed_int(8, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D17),
+                                            opnd_create_reg(DR_REG_D11),
+                                            opnd_create_immed_int(16, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D8),
+                                            opnd_create_reg(DR_REG_D4),
+                                            opnd_create_immed_int(32, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D29),
+                                            opnd_create_reg(DR_REG_D21),
+                                            opnd_create_immed_int(64, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D30),
+                                            opnd_create_reg(DR_REG_D29),
+                                            opnd_create_immed_int(21, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D17),
+                                            opnd_create_reg(DR_REG_D13),
+                                            opnd_create_immed_int(42, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+}
+
+static void
+test_ucvtf_vector_fixed(void *dc)
+{
+    instr_t *instr;
+
+    /* UCVTF <Vd>.<T>, <Vn>.<T>, #<fbits> */
+
+    /* UCVTF <Vd>.4s, <Vn>.4s, #<fbits> */
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(1, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q2), opnd_create_reg(DR_REG_Q3), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(2, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q4), opnd_create_reg(DR_REG_Q5), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(4, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q6), opnd_create_reg(DR_REG_Q7), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(8, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q8), opnd_create_reg(DR_REG_Q9), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(16, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q10), opnd_create_reg(DR_REG_Q11),
+        OPND_CREATE_SINGLE(), opnd_create_immed_int(32, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q28), opnd_create_reg(DR_REG_Q29),
+        OPND_CREATE_SINGLE(), opnd_create_immed_int(21, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q30), opnd_create_reg(DR_REG_Q31),
+        OPND_CREATE_SINGLE(), opnd_create_immed_int(31, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    /* UCVTF <Vd>.2d, <Vn>.2d, #<fbits> */
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1), OPND_CREATE_DOUBLE(),
+        opnd_create_immed_int(1, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q2), opnd_create_reg(DR_REG_Q3), OPND_CREATE_DOUBLE(),
+        opnd_create_immed_int(2, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q4), opnd_create_reg(DR_REG_Q5), OPND_CREATE_DOUBLE(),
+        opnd_create_immed_int(4, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q6), opnd_create_reg(DR_REG_Q7), OPND_CREATE_DOUBLE(),
+        opnd_create_immed_int(8, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q8), opnd_create_reg(DR_REG_Q9), OPND_CREATE_DOUBLE(),
+        opnd_create_immed_int(16, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q10), opnd_create_reg(DR_REG_Q11),
+        OPND_CREATE_DOUBLE(), opnd_create_immed_int(32, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q12), opnd_create_reg(DR_REG_Q13),
+        OPND_CREATE_DOUBLE(), opnd_create_immed_int(64, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q28), opnd_create_reg(DR_REG_Q29),
+        OPND_CREATE_DOUBLE(), opnd_create_immed_int(21, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q30), opnd_create_reg(DR_REG_Q31),
+        OPND_CREATE_DOUBLE(), opnd_create_immed_int(42, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    /* UCVTF <Vd>.2s, <Vn>.2s, #<fbits> */
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D0), opnd_create_reg(DR_REG_D1), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(1, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D2), opnd_create_reg(DR_REG_D3), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(2, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D4), opnd_create_reg(DR_REG_D5), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(4, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D6), opnd_create_reg(DR_REG_D7), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(8, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D8), opnd_create_reg(DR_REG_D9), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(16, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D10), opnd_create_reg(DR_REG_D11),
+        OPND_CREATE_SINGLE(), opnd_create_immed_int(32, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D28), opnd_create_reg(DR_REG_D29),
+        OPND_CREATE_SINGLE(), opnd_create_immed_int(21, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+
+    instr = INSTR_CREATE_ucvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D30), opnd_create_reg(DR_REG_D31),
+        OPND_CREATE_SINGLE(), opnd_create_immed_int(31, OPSZ_6b));
+    test_instr_encoding(dc, OP_ucvtf, instr);
+}
+
+static void
+test_scvtf_scalar(void *dc)
+{
+    instr_t *instr;
+    instr = INSTR_CREATE_scvtf_scalar(dc, opnd_create_reg(DR_REG_S4),
+                                      opnd_create_reg(DR_REG_W9));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar(dc, opnd_create_reg(DR_REG_D11),
+                                      opnd_create_reg(DR_REG_W28));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar(dc, opnd_create_reg(DR_REG_S1),
+                                      opnd_create_reg(DR_REG_X21));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar(dc, opnd_create_reg(DR_REG_D3),
+                                      opnd_create_reg(DR_REG_X2));
+    test_instr_encoding(dc, OP_scvtf, instr);
+}
+
+static void
+test_scvtf_vector(void *dc)
+{
+    instr_t *instr;
+
+    /* SCVTF <Vd>.<T>, <Vn>.<T> */
+    /* SCVTF <Vd>.2S, <Vn>.2S */
+    instr = INSTR_CREATE_scvtf_vector(dc, opnd_create_reg(DR_REG_D13),
+                                      opnd_create_reg(DR_REG_D7), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    /* SCVTF <Vd>.4S, <Vn>.4S */
+    instr = INSTR_CREATE_scvtf_vector(dc, opnd_create_reg(DR_REG_Q12),
+                                      opnd_create_reg(DR_REG_Q24), OPND_CREATE_SINGLE());
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    /* SCVTF <Vd>.2D, <Vn>.2D */
+    instr = INSTR_CREATE_scvtf_vector(dc, opnd_create_reg(DR_REG_Q9),
+                                      opnd_create_reg(DR_REG_Q1), OPND_CREATE_DOUBLE());
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    /* SCVTF <V><d>, <V><n> */
+    /* SCVTF <V>S, <V>S */
+    instr = INSTR_CREATE_scvtf_scalar(dc, opnd_create_reg(DR_REG_S17),
+                                      opnd_create_reg(DR_REG_S20));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    /* SCVTF <V>D, <V>D */
+    instr = INSTR_CREATE_scvtf_scalar(dc, opnd_create_reg(DR_REG_D14),
+                                      opnd_create_reg(DR_REG_D14));
+    test_instr_encoding(dc, OP_scvtf, instr);
+}
+
+static void
+test_scvtf_scalar_fixed_gpr(void *dc)
+{
+    instr_t *instr;
+
+    /* SCVTF <Sd>, <Wn>, #<fbits> */
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S5),
+                                            opnd_create_reg(DR_REG_W8),
+                                            opnd_create_immed_int(4, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    /* SCVTF <Sd>, <Xn>, #<fbits> */
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S13),
+                                            opnd_create_reg(DR_REG_X7),
+                                            opnd_create_immed_int(16, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    /* SCVTF <Dd>, <Sn>, #<fbits> */
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D17),
+                                            opnd_create_reg(DR_REG_W0),
+                                            opnd_create_immed_int(32, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    /* SCVTF <Dd>, <Xn>, #<fbits> */
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D13),
+                                            opnd_create_reg(DR_REG_X11),
+                                            opnd_create_immed_int(64, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+}
+
+static void
+test_scvtf_scalar_fixed(void *dc)
+{
+    instr_t *instr;
+
+    /* SCVTF <Sd>, <Sn>, #<fbits> */
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S9),
+                                            opnd_create_reg(DR_REG_S8),
+                                            opnd_create_immed_int(1, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S21),
+                                            opnd_create_reg(DR_REG_S4),
+                                            opnd_create_immed_int(2, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S20),
+                                            opnd_create_reg(DR_REG_S19),
+                                            opnd_create_immed_int(4, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S6),
+                                            opnd_create_reg(DR_REG_S7),
+                                            opnd_create_immed_int(8, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S12),
+                                            opnd_create_reg(DR_REG_S30),
+                                            opnd_create_immed_int(16, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S18),
+                                            opnd_create_reg(DR_REG_S9),
+                                            opnd_create_immed_int(32, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S22),
+                                            opnd_create_reg(DR_REG_S21),
+                                            opnd_create_immed_int(21, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_S11),
+                                            opnd_create_reg(DR_REG_S19),
+                                            opnd_create_immed_int(31, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    /* SCVTF <Dd>, <Dn>, #<fbits> */
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D13),
+                                            opnd_create_reg(DR_REG_D11),
+                                            opnd_create_immed_int(1, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D2),
+                                            opnd_create_reg(DR_REG_D3),
+                                            opnd_create_immed_int(2, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D19),
+                                            opnd_create_reg(DR_REG_D17),
+                                            opnd_create_immed_int(4, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D30),
+                                            opnd_create_reg(DR_REG_D9),
+                                            opnd_create_immed_int(8, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D17),
+                                            opnd_create_reg(DR_REG_D11),
+                                            opnd_create_immed_int(16, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D8),
+                                            opnd_create_reg(DR_REG_D4),
+                                            opnd_create_immed_int(32, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D29),
+                                            opnd_create_reg(DR_REG_D21),
+                                            opnd_create_immed_int(64, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D30),
+                                            opnd_create_reg(DR_REG_D29),
+                                            opnd_create_immed_int(21, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(DR_REG_D17),
+                                            opnd_create_reg(DR_REG_D13),
+                                            opnd_create_immed_int(42, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+}
+
+static void
+test_scvtf_vector_fixed(void *dc)
+{
+    instr_t *instr;
+
+    /* SCVTF <Vd>.<T>, <Vn>.<T>, #<fbits> */
+
+    /* SCVTF <Vd>.4s, <Vn>.4s, #<fbits> */
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(1, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q2), opnd_create_reg(DR_REG_Q3), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(2, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q4), opnd_create_reg(DR_REG_Q5), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(4, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q6), opnd_create_reg(DR_REG_Q7), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(8, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q8), opnd_create_reg(DR_REG_Q9), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(16, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q10), opnd_create_reg(DR_REG_Q11),
+        OPND_CREATE_SINGLE(), opnd_create_immed_int(32, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q28), opnd_create_reg(DR_REG_Q29),
+        OPND_CREATE_SINGLE(), opnd_create_immed_int(21, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q30), opnd_create_reg(DR_REG_Q31),
+        OPND_CREATE_SINGLE(), opnd_create_immed_int(31, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    /* SCVTF <Vd>.2d, <Vn>.2d, #<fbits> */
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1), OPND_CREATE_DOUBLE(),
+        opnd_create_immed_int(1, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q2), opnd_create_reg(DR_REG_Q3), OPND_CREATE_DOUBLE(),
+        opnd_create_immed_int(2, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q4), opnd_create_reg(DR_REG_Q5), OPND_CREATE_DOUBLE(),
+        opnd_create_immed_int(4, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q6), opnd_create_reg(DR_REG_Q7), OPND_CREATE_DOUBLE(),
+        opnd_create_immed_int(8, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q8), opnd_create_reg(DR_REG_Q9), OPND_CREATE_DOUBLE(),
+        opnd_create_immed_int(16, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q10), opnd_create_reg(DR_REG_Q11),
+        OPND_CREATE_DOUBLE(), opnd_create_immed_int(32, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q12), opnd_create_reg(DR_REG_Q13),
+        OPND_CREATE_DOUBLE(), opnd_create_immed_int(64, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q28), opnd_create_reg(DR_REG_Q29),
+        OPND_CREATE_DOUBLE(), opnd_create_immed_int(21, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_Q30), opnd_create_reg(DR_REG_Q31),
+        OPND_CREATE_DOUBLE(), opnd_create_immed_int(42, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    /* SCVTF <Vd>.2s, <Vn>.2s, #<fbits> */
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D0), opnd_create_reg(DR_REG_D1), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(1, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D2), opnd_create_reg(DR_REG_D3), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(2, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D4), opnd_create_reg(DR_REG_D5), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(4, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D6), opnd_create_reg(DR_REG_D7), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(8, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D8), opnd_create_reg(DR_REG_D9), OPND_CREATE_SINGLE(),
+        opnd_create_immed_int(16, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D10), opnd_create_reg(DR_REG_D11),
+        OPND_CREATE_SINGLE(), opnd_create_immed_int(32, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D28), opnd_create_reg(DR_REG_D29),
+        OPND_CREATE_SINGLE(), opnd_create_immed_int(21, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+
+    instr = INSTR_CREATE_scvtf_vector_fixed(
+        dc, opnd_create_reg(DR_REG_D30), opnd_create_reg(DR_REG_D31),
+        OPND_CREATE_SINGLE(), opnd_create_immed_int(31, OPSZ_6b));
+    test_instr_encoding(dc, OP_scvtf, instr);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -5474,6 +6100,36 @@ main(int argc, char *argv[])
 
     test_fcvtzu_vector_fixed(dcontext);
     print("test_fcvtzu_vector_fixed complete\n");
+
+    test_ucvtf_scalar(dcontext);
+    print("test_ucvtf_scalar complete\n");
+
+    test_ucvtf_vector(dcontext);
+    print("test_ucvtf_vector complete\n");
+
+    test_ucvtf_scalar_fixed_gpr(dcontext);
+    print("test_ucvtf_scalar_fixed_gpr complete\n");
+
+    test_ucvtf_scalar_fixed(dcontext);
+    print("test_ucvtf_scalar_fixed complete\n");
+
+    test_ucvtf_vector_fixed(dcontext);
+    print("test_ucvtf_vector_fixed complete\n");
+
+    test_scvtf_scalar(dcontext);
+    print("test_scvtf_scalar complete\n");
+
+    test_scvtf_vector(dcontext);
+    print("test_scvtf_vector complete\n");
+
+    test_scvtf_scalar_fixed_gpr(dcontext);
+    print("test_scvtf_scalar_fixed_gpr complete\n");
+
+    test_scvtf_scalar_fixed(dcontext);
+    print("test_scvtf_scalar_fixed complete\n");
+
+    test_scvtf_vector_fixed(dcontext);
+    print("test_scvtf_vector_fixed complete\n");
 
     print("All tests complete\n");
 #ifndef STANDALONE_DECODER

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -1003,4 +1003,124 @@ fcvtzu %d11 $0x02 $0x20 -> %d10
 fcvtzu %d29 $0x02 $0x15 -> %d28
 fcvtzu %d31 $0x02 $0x1f -> %d30
 test_fcvtzu_vector_fixed complete
+ucvtf  %w9 -> %s4
+ucvtf  %w28 -> %d11
+ucvtf  %x21 -> %s1
+ucvtf  %x2 -> %d3
+test_ucvtf_scalar complete
+ucvtf  %d7 $0x02 -> %d13
+ucvtf  %q24 $0x02 -> %q12
+ucvtf  %q1 $0x03 -> %q9
+ucvtf  %s20 -> %s17
+ucvtf  %d14 -> %d14
+test_ucvtf_vector complete
+ucvtf  %w8 $0x04 -> %s5
+ucvtf  %x7 $0x10 -> %s13
+ucvtf  %w0 $0x20 -> %d17
+ucvtf  %x11 $0x40 -> %d13
+test_ucvtf_scalar_fixed_gpr complete
+ucvtf  %s8 $0x01 -> %s9
+ucvtf  %s4 $0x02 -> %s21
+ucvtf  %s19 $0x04 -> %s20
+ucvtf  %s7 $0x08 -> %s6
+ucvtf  %s30 $0x10 -> %s12
+ucvtf  %s9 $0x20 -> %s18
+ucvtf  %s21 $0x15 -> %s22
+ucvtf  %s19 $0x1f -> %s11
+ucvtf  %d11 $0x01 -> %d13
+ucvtf  %d3 $0x02 -> %d2
+ucvtf  %d17 $0x04 -> %d19
+ucvtf  %d9 $0x08 -> %d30
+ucvtf  %d11 $0x10 -> %d17
+ucvtf  %d4 $0x20 -> %d8
+ucvtf  %d21 $0x40 -> %d29
+ucvtf  %d29 $0x15 -> %d30
+ucvtf  %d13 $0x2a -> %d17
+test_ucvtf_scalar_fixed complete
+ucvtf  %q1 $0x02 $0x01 -> %q0
+ucvtf  %q3 $0x02 $0x02 -> %q2
+ucvtf  %q5 $0x02 $0x04 -> %q4
+ucvtf  %q7 $0x02 $0x08 -> %q6
+ucvtf  %q9 $0x02 $0x10 -> %q8
+ucvtf  %q11 $0x02 $0x20 -> %q10
+ucvtf  %q29 $0x02 $0x15 -> %q28
+ucvtf  %q31 $0x02 $0x1f -> %q30
+ucvtf  %q1 $0x03 $0x01 -> %q0
+ucvtf  %q3 $0x03 $0x02 -> %q2
+ucvtf  %q5 $0x03 $0x04 -> %q4
+ucvtf  %q7 $0x03 $0x08 -> %q6
+ucvtf  %q9 $0x03 $0x10 -> %q8
+ucvtf  %q11 $0x03 $0x20 -> %q10
+ucvtf  %q13 $0x03 $0x40 -> %q12
+ucvtf  %q29 $0x03 $0x15 -> %q28
+ucvtf  %q31 $0x03 $0x2a -> %q30
+ucvtf  %d1 $0x02 $0x01 -> %d0
+ucvtf  %d3 $0x02 $0x02 -> %d2
+ucvtf  %d5 $0x02 $0x04 -> %d4
+ucvtf  %d7 $0x02 $0x08 -> %d6
+ucvtf  %d9 $0x02 $0x10 -> %d8
+ucvtf  %d11 $0x02 $0x20 -> %d10
+ucvtf  %d29 $0x02 $0x15 -> %d28
+ucvtf  %d31 $0x02 $0x1f -> %d30
+test_ucvtf_vector_fixed complete
+scvtf  %w9 -> %s4
+scvtf  %w28 -> %d11
+scvtf  %x21 -> %s1
+scvtf  %x2 -> %d3
+test_scvtf_scalar complete
+scvtf  %d7 $0x02 -> %d13
+scvtf  %q24 $0x02 -> %q12
+scvtf  %q1 $0x03 -> %q9
+scvtf  %s20 -> %s17
+scvtf  %d14 -> %d14
+test_scvtf_vector complete
+scvtf  %w8 $0x04 -> %s5
+scvtf  %x7 $0x10 -> %s13
+scvtf  %w0 $0x20 -> %d17
+scvtf  %x11 $0x40 -> %d13
+test_scvtf_scalar_fixed_gpr complete
+scvtf  %s8 $0x01 -> %s9
+scvtf  %s4 $0x02 -> %s21
+scvtf  %s19 $0x04 -> %s20
+scvtf  %s7 $0x08 -> %s6
+scvtf  %s30 $0x10 -> %s12
+scvtf  %s9 $0x20 -> %s18
+scvtf  %s21 $0x15 -> %s22
+scvtf  %s19 $0x1f -> %s11
+scvtf  %d11 $0x01 -> %d13
+scvtf  %d3 $0x02 -> %d2
+scvtf  %d17 $0x04 -> %d19
+scvtf  %d9 $0x08 -> %d30
+scvtf  %d11 $0x10 -> %d17
+scvtf  %d4 $0x20 -> %d8
+scvtf  %d21 $0x40 -> %d29
+scvtf  %d29 $0x15 -> %d30
+scvtf  %d13 $0x2a -> %d17
+test_scvtf_scalar_fixed complete
+scvtf  %q1 $0x02 $0x01 -> %q0
+scvtf  %q3 $0x02 $0x02 -> %q2
+scvtf  %q5 $0x02 $0x04 -> %q4
+scvtf  %q7 $0x02 $0x08 -> %q6
+scvtf  %q9 $0x02 $0x10 -> %q8
+scvtf  %q11 $0x02 $0x20 -> %q10
+scvtf  %q29 $0x02 $0x15 -> %q28
+scvtf  %q31 $0x02 $0x1f -> %q30
+scvtf  %q1 $0x03 $0x01 -> %q0
+scvtf  %q3 $0x03 $0x02 -> %q2
+scvtf  %q5 $0x03 $0x04 -> %q4
+scvtf  %q7 $0x03 $0x08 -> %q6
+scvtf  %q9 $0x03 $0x10 -> %q8
+scvtf  %q11 $0x03 $0x20 -> %q10
+scvtf  %q13 $0x03 $0x40 -> %q12
+scvtf  %q29 $0x03 $0x15 -> %q28
+scvtf  %q31 $0x03 $0x2a -> %q30
+scvtf  %d1 $0x02 $0x01 -> %d0
+scvtf  %d3 $0x02 $0x02 -> %d2
+scvtf  %d5 $0x02 $0x04 -> %d4
+scvtf  %d7 $0x02 $0x08 -> %d6
+scvtf  %d9 $0x02 $0x10 -> %d8
+scvtf  %d11 $0x02 $0x20 -> %d10
+scvtf  %d29 $0x02 $0x15 -> %d28
+scvtf  %d31 $0x02 $0x1f -> %d30
+test_scvtf_vector_fixed complete
 All tests complete


### PR DESCRIPTION
Add handling of:
- scalar, integer
- vector, integer
- scalar, fixed-point
- vector, fixed-point

for instructions UCVTF and SCVTF

Issue: #2626, #4848