### PR TITLE
i#1312: Adds instr_zeroes_zmmh()

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -203,6 +203,8 @@ Further non-compatibility-affecting changes include:
    runtime option which locates guest system libraries and enables workarounds for
    problems with QEMU's threads.
  - Added dr_is_detaching(), an API to query whether detach is in progress.
+ - Added instr_zeroes_zmmh() that returns true if an instruction clears the
+   upper bits of a ZMM register with zeros.
 
 **************************************************
 <hr>

--- a/core/ir/instr_api.h
+++ b/core/ir/instr_api.h
@@ -1439,11 +1439,18 @@ DR_API
  * the top half while others zero it when writing to the bottom half).
  * This zeroing will occur even if \p instr is predicated (see instr_is_predicated()).
  */
-/* XXX i#1312: For AVX-512, we will want a instr_zeroes_zmmh function as well that also
- * includes the vzeroupper instruction.
- */
 bool
 instr_zeroes_ymmh(instr_t *instr);
+
+DR_API
+/**
+ * Returns true iff \p instr writes to an xmm or ymm register and zeroes the top half
+ * of the corresponding zmm register as a result (some instructions preserve
+ * the top half while others zero it when writing to the bottom half).
+ * This zeroing will occur even if \p instr is predicated (see instr_is_predicated()).
+ */
+bool
+instr_zeroes_zmmh(instr_t *instr);
 
 DR_API
 /** Returns true if \p instr's opcode is #OP_xsave32, #OP_xsaveopt32, #OP_xsave64,

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -2015,6 +2015,7 @@ instr_writes_memory(instr_t *instr)
 }
 
 #ifdef X86
+
 bool
 instr_zeroes_ymmh(instr_t *instr)
 {
@@ -2022,13 +2023,35 @@ instr_zeroes_ymmh(instr_t *instr)
     const instr_info_t *info = get_encoding_info(instr);
     if (info == NULL)
         return false;
-    /* legacy instrs always preserve top half of ymm */
-    if (!TEST(REQUIRES_VEX, info->flags))
+    /* Legacy (SSE) instructions always preserve top half of YMM.
+     * Moreover, EVEX encoded instructions clear upper ZMM bits, but also
+     * YMM bits if an XMM reg is used.
+     */
+    if (!TEST(REQUIRES_VEX, info->flags) && !TEST(REQUIRES_EVEX, info->flags))
         return false;
     for (i = 0; i < instr_num_dsts(instr); i++) {
         opnd_t opnd = instr_get_dst(instr, i);
-        if (opnd_is_reg(opnd) && reg_is_xmm(opnd_get_reg(opnd)) &&
-            !reg_is_ymm(opnd_get_reg(opnd)))
+        if (opnd_is_reg(opnd) && reg_is_vector_simd(opnd_get_reg(opnd)) &&
+            reg_is_strictly_xmm(opnd_get_reg(opnd)))
+            return true;
+    }
+    return false;
+}
+
+bool
+instr_zeroes_zmmh(instr_t *instr)
+{
+    int i;
+    const instr_info_t *info = get_encoding_info(instr);
+    if (info == NULL)
+        return false;
+    if (!TEST(REQUIRES_VEX, info->flags) && !TEST(REQUIRES_EVEX, info->flags))
+        return false;
+    for (i = 0; i < instr_num_dsts(instr); i++) {
+        opnd_t opnd = instr_get_dst(instr, i);
+        if (opnd_is_reg(opnd) && reg_is_vector_simd(opnd_get_reg(opnd)) &&
+            (reg_is_strictly_xmm(opnd_get_reg(opnd)) ||
+             reg_is_strictly_ymm(opnd_get_reg(opnd))))
             return true;
     }
     return false;

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -2029,6 +2029,11 @@ instr_zeroes_ymmh(instr_t *instr)
      */
     if (!TEST(REQUIRES_VEX, info->flags) && !TEST(REQUIRES_EVEX, info->flags))
         return false;
+
+    /* Handle zeroall special case. */
+    if (instr->opcode == OP_vzeroall)
+        return true;
+
     for (i = 0; i < instr_num_dsts(instr); i++) {
         opnd_t opnd = instr_get_dst(instr, i);
         if (opnd_is_reg(opnd) && reg_is_vector_simd(opnd_get_reg(opnd)) &&
@@ -2047,6 +2052,13 @@ instr_zeroes_zmmh(instr_t *instr)
         return false;
     if (!TEST(REQUIRES_VEX, info->flags) && !TEST(REQUIRES_EVEX, info->flags))
         return false;
+    /* Handle special cases, namely zeroupper and zeroall. */
+    /* XXX: DR ir should actually have these two instructions have all SIMD vector regs
+     * as operand even though they are implicit.
+     */
+    if (instr->opcode == OP_vzeroall || instr->opcode == OP_vzeroupper)
+        return true;
+
     for (i = 0; i < instr_num_dsts(instr); i++) {
         opnd_t opnd = instr_get_dst(instr, i);
         if (opnd_is_reg(opnd) && reg_is_vector_simd(opnd_get_reg(opnd)) &&

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -2428,6 +2428,16 @@ test_simd_zeroes_upper(void *dc)
     ASSERT(!instr_zeroes_ymmh(instr));
     ASSERT(!instr_zeroes_zmmh(instr));
     instr_destroy(dc, instr);
+
+    instr = INSTR_CREATE_vzeroupper(dc);
+    ASSERT(!instr_zeroes_ymmh(instr));
+    ASSERT(instr_zeroes_zmmh(instr));
+    instr_destroy(dc, instr);
+
+    instr = INSTR_CREATE_vzeroall(dc);
+    ASSERT(instr_zeroes_ymmh(instr));
+    ASSERT(instr_zeroes_zmmh(instr));
+    instr_destroy(dc, instr);
 }
 
 int

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -2397,6 +2397,39 @@ test_opnd(void *dc)
     /* XXX: test other routines like opnd_defines_use() */
 }
 
+static void
+test_simd_zeroes_upper(void *dc)
+{
+    instr_t *instr;
+
+    instr =
+        INSTR_CREATE_pxor(dc, opnd_create_reg(DR_REG_XMM0), opnd_create_reg(DR_REG_XMM0));
+    ASSERT(!instr_zeroes_ymmh(instr));
+    ASSERT(!instr_zeroes_zmmh(instr));
+    instr_destroy(dc, instr);
+
+    instr =
+        INSTR_CREATE_vpxor(dc, opnd_create_reg(DR_REG_XMM0), opnd_create_reg(DR_REG_XMM0),
+                           opnd_create_reg(DR_REG_XMM0));
+    ASSERT(instr_zeroes_ymmh(instr));
+    ASSERT(instr_zeroes_zmmh(instr));
+    instr_destroy(dc, instr);
+
+    instr =
+        INSTR_CREATE_vpxor(dc, opnd_create_reg(DR_REG_YMM0), opnd_create_reg(DR_REG_YMM0),
+                           opnd_create_reg(DR_REG_YMM0));
+    ASSERT(!instr_zeroes_ymmh(instr));
+    ASSERT(instr_zeroes_zmmh(instr));
+    instr_destroy(dc, instr);
+
+    instr =
+        INSTR_CREATE_vpxor(dc, opnd_create_reg(DR_REG_ZMM0), opnd_create_reg(DR_REG_ZMM0),
+                           opnd_create_reg(DR_REG_ZMM0));
+    ASSERT(!instr_zeroes_ymmh(instr));
+    ASSERT(!instr_zeroes_zmmh(instr));
+    instr_destroy(dc, instr);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -2471,6 +2504,8 @@ main(int argc, char *argv[])
     test_noalloc(dcontext);
 
     test_opnd(dcontext);
+
+    test_simd_zeroes_upper(dcontext);
 
 #ifndef STANDALONE_DECODER /* speed up compilation */
     test_all_opcodes_2_avx512_vex(dcontext);


### PR DESCRIPTION
Adds instr_zeroes_zmmh(), which returns true if the instruction clears the upper bits of a ZMM register with zeros.

Updates instr_zeroes_ymmh() to take into account EVEX instructions.

Tests for the above are also included.

Issue: #1312