### PR TITLE
i#4256: prevent triggered assertion for duplicated elf_headers on AArch64

### DIFF
--- a/core/unix/module.h
+++ b/core/unix/module.h
@@ -60,6 +60,10 @@ typedef struct _os_module_data_t {
      * address references within the file.
      */
     app_pc base_address;
+    /* XXX: All segments are expected to have the same alignment, even though that it is
+     * not a requirement for ELF. To allow a different alignment for each segment we will
+     * need to move this field in the module_segment_t struct.
+     */
     size_t alignment; /* the alignment between segments */
 
     /* Fields for pcaches (PR 295534) */

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7827,35 +7827,24 @@ mmap_check_for_module_overlap(app_pc base, size_t size, bool readable, uint64 in
                  * disk space, e.g. /usr/lib/httpd/modules/mod_auth_anon.so.  When
                  * such a module is mapped in, the os maps the same disk page twice,
                  * one readonly and one copy-on-write (see pg.  96, Sec 4.4 from
-                 * Linkers and Loaders by John R.  Levine).  This makes the data
-                 * section also satisfy the elf_header check above.  So, if the new
-                 * mmap overlaps an elf_area and it is also a header, then make sure
-                 * the previous page (correcting for alignment) is also a elf_header.
-                 * Note, if it is a header of a different module, then we'll not have
-                 * an overlap, so we will not hit this case.
+                 * Linkers and Loaders by John R.  Levine). It also possible for
+                 * such small modules to have multiple LOAD data segments. Since all
+                 * these segments are mapped from a single disk page they will all have a
+                 * elf_header satisfying the check above. So, if the new mmap overlaps an
+                 * elf_area and it is also a header, then make sure the current segment's
+                 * offset (from the beginning of the backing file) is within the page
+                 * size. Note, if it is a header of a different module, then we'll not
+                 * have an overlap, so we will not hit this case.
                  */
-#ifdef AARCH64
-                /* For AArch64 systems with 64K pages it is possible for small modules
-                 * (less than 1 page of disk space) to have multiple RW LOADable data
-                 * segments. Since these segments are mapped from a single disk space they
-                 * will all have a elf_header satisfying the check above.
-                 */
-                if (ma->os_data.alignment == 65536) {
-                    size_t offset = base - ma->start;
-                    size_t seg_id = offset / ma->os_data.alignment;
-                    ASSERT_CURIOSITY(seg_id < ma->os_data.num_segments &&
-                                     ma->os_data.segments[seg_id].start == base &&
-                                     ma->os_data.segments[seg_id].prot ==
-                                         (MEMPROT_READ | MEMPROT_WRITE));
-                } else
-#endif
-                    ASSERT_CURIOSITY(
-                        ma->start + ma->os_data.alignment ==
-                        base
-                            /* On Mac we walk the dyld module list before the
-                             * address space, so we often hit modules we already
-                             * know about. */
-                            IF_MACOS(|| !dynamo_initialized && ma->start == base));
+                size_t aligned_offset = base - ma->start;
+                size_t seg_id = aligned_offset / ma->os_data.alignment;
+                ASSERT_CURIOSITY((seg_id < ma->os_data.num_segments &&
+                                  ma->os_data.segments[seg_id].start == base &&
+                                  ma->os_data.segments[seg_id].offset < PAGE_SIZE)
+                                 /* On Mac we walk the dyld module list before the
+                                  * address space, so we often hit modules we already
+                                  * know about. */
+                                 IF_MACOS(|| !dynamo_initialized && ma->start == base));
             }
         });
     }

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7829,22 +7829,28 @@ mmap_check_for_module_overlap(app_pc base, size_t size, bool readable, uint64 in
                  * one readonly and one copy-on-write (see pg.  96, Sec 4.4 from
                  * Linkers and Loaders by John R.  Levine). It also possible for
                  * such small modules to have multiple LOAD data segments. Since all
-                 * these segments are mapped from a single disk page they will all have a
+                 * these segments are mapped from a single disk page they will all have an
                  * elf_header satisfying the check above. So, if the new mmap overlaps an
-                 * elf_area and it is also a header, then make sure the current segment's
-                 * offset (from the beginning of the backing file) is within the page
-                 * size. Note, if it is a header of a different module, then we'll not
-                 * have an overlap, so we will not hit this case.
+                 * elf_area and it is also a header, then make sure the offsets (from the
+                 * beginning of the backing file) of all the segments up to the currect
+                 * one are within the page size. Note, if it is a header of a different
+                 * module, then we'll not have an overlap, so we will not hit this case.
                  */
-                size_t aligned_offset = base - ma->start;
-                size_t seg_id = aligned_offset / ma->os_data.alignment;
-                ASSERT_CURIOSITY((seg_id < ma->os_data.num_segments &&
-                                  ma->os_data.segments[seg_id].start == base &&
-                                  ma->os_data.segments[seg_id].offset < PAGE_SIZE)
-                                 /* On Mac we walk the dyld module list before the
-                                  * address space, so we often hit modules we already
-                                  * know about. */
-                                 IF_MACOS(|| !dynamo_initialized && ma->start == base));
+                bool cur_seg_found = false;
+                int seg_id = 0;
+                while (seg_id < ma->os_data.num_segments &&
+                       ma->os_data.segments[seg_id].start <= base) {
+                    cur_seg_found = ma->os_data.segments[seg_id].start == base;
+                    ASSERT_CURIOSITY(
+                        ma->os_data.segments[seg_id].offset <
+                        PAGE_SIZE
+                            /* On Mac we walk the dyld module list before the
+                             * address space, so we often hit modules we already
+                             * know about. */
+                            IF_MACOS(|| !dynamo_initialized && ma->start == base));
+                    ++seg_id;
+                }
+                ASSERT_CURIOSITY(cur_seg_found);
             }
         });
     }


### PR DESCRIPTION
Prevents triggering an ASSERT_CURIOSITY for duplicated elf headers for debug DR builds 
on AArch64 systems. It is possible for small modules (less than 1 page of disk space) to 
have multiple LOAD data segments. Since these segments are mapped from a single disk 
page they will all have an elf header. The triggered assertion assumed that there can only 
be one data segment. Extends this assertion check to accommodate for more than one 
data segments.

Fixes: #4256