### PR TITLE
i#4878 signals_pending: Clean up bool-vs-int usage

### DIFF
--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -714,7 +714,7 @@ dispatch_enter_native(dcontext_t *dcontext)
          * be an alarm signal so we drop it as the simplest solution.
          */
         ASSERT(dcontext->signals_pending);
-        dcontext->signals_pending = false;
+        dcontext->signals_pending = 0;
     } while (true);
 #else
     (*go_native)(dcontext);

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -1798,7 +1798,7 @@ initialize_dynamo_context(dcontext_t *dcontext)
 #endif
 
 #ifdef UNIX
-    dcontext->signals_pending = false;
+    dcontext->signals_pending = 0;
 #endif
 
     /* all thread-private fields are initialized in dynamo_thread_init


### PR DESCRIPTION
Fixes two legacy stores treating signals_pending as a boolean,
discovered while debugging the signals_pending corruption.

Issue: #4878