### PR TITLE
i#2626 AArch64 v8.0 Decode: Order dis-a64.txt alphabetically

### DIFF
--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -36,1703 +36,25 @@
 # Field 2: Disassembly produced by objdump (not used for testing).
 # Field 3: Disassembly produced by DynamoRIO.
 
-08081041 : stxrb  w8, w1, [x2]            : stxrb  %w1 $0x04 -> (%x2)[1byte] %w8
-08089041 : stlxrb w8, w1, [x2]            : stlxrb %w1 $0x04 -> (%x2)[1byte] %w8
-081f7fff : stxrb  wzr, wzr, [sp]          : stxrb  %wzr $0x1f -> (%sp)[1byte] %wzr
-081fffff : stlxrb wzr, wzr, [sp]          : stlxrb %wzr $0x1f -> (%sp)[1byte] %wzr
-08287c40 : casp   w8, w9, w0, w1, [x2]    : casp   %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
-0828fc40 : caspl  w8, w9, w0, w1, [x2]    : caspl  %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
-083e7ffe : casp   w30, wzr, w30, wzr, [sp]: casp   %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
-083efffe : caspl  w30, wzr, w30, wzr, [sp]: caspl  %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
-08481041 : ldxrb  w1, [x2]                : ldxrb  (%x2)[1byte] $0x04 $0x08 -> %w1
-08489041 : ldaxrb w1, [x2]                : ldaxrb (%x2)[1byte] $0x04 $0x08 -> %w1
-085f7fff : ldxrb  wzr, [sp]               : ldxrb  (%sp)[1byte] $0x1f $0x1f -> %wzr
-085fffff : ldaxrb wzr, [sp]               : ldaxrb (%sp)[1byte] $0x1f $0x1f -> %wzr
-08687c40 : caspa  w8, w9, w0, w1, [x2]    : caspa  %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
-0868fc40 : caspal w8, w9, w0, w1, [x2]    : caspal %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
-087e7ffe : caspa  w30, wzr, w30, wzr, [sp]: caspa  %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
-087efffe : caspal w30, wzr, w30, wzr, [sp]: caspal %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
-08889041 : stlrb  w1, [x2]                : stlrb  %w1 $0x04 $0x08 -> (%x2)[1byte]
-089fffff : stlrb  wzr, [sp]               : stlrb  %wzr $0x1f $0x1f -> (%sp)[1byte]
-08a87c41 : casb   w8, w1, [x2]            : casb   %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
-08a8fc41 : caslb  w8, w1, [x2]            : caslb  %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
-08bf7fff : casb   wzr, wzr, [sp]          : casb   %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-08bfffff : caslb  wzr, wzr, [sp]          : caslb  %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-08dfffff : ldarb  wzr, [sp]               : ldarb  (%sp)[1byte] -> %wzr
-08e87c41 : casab  w8, w1, [x2]            : casab  %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
-08e8fc41 : casalb w8, w1, [x2]            : casalb %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
-08ff7fff : casab  wzr, wzr, [sp]          : casab  %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-08ffffff : casalb wzr, wzr, [sp]          : casalb %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-0a031041 : and    w1, w2, w3, lsl #4      : and    %w2 %w3 lsl $0x04 -> %w1
-0a231041 : bic    w1, w2, w3, lsl #4      : bic    %w2 %w3 lsl $0x04 -> %w1
-0a7f7fff : bic    wzr, wzr, wzr, lsr #31  : bic    %wzr %wzr lsr $0x1f -> %wzr
-0a9f13ff : and    wzr, wzr, wzr, asr #4   : and    %wzr %wzr asr $0x04 -> %wzr
-0abf13ff : bic    wzr, wzr, wzr, asr #4   : bic    %wzr %wzr asr $0x04 -> %wzr
+1a030041 : adc    w1, w2, w3              : adc    %w2 %w3 -> %w1
+9a1f03ff : adc    xzr, xzr, xzr           : adc    %xzr %xzr -> %xzr
+
+3a1f03ff : adcs   wzr, wzr, wzr           : adcs   %wzr %wzr -> %wzr
+ba030041 : adcs   x1, x2, x3              : adcs   %x2 %x3 -> %x1
+
 0b031041 : add    w1, w2, w3, lsl #4      : add    %w2 %w3 lsl $0x04 -> %w1
 0b1f7fff : add    wzr, wzr, wzr, lsl #31  : add    %wzr %wzr lsl $0x1f -> %wzr
 0b3008a0 : add    w0, w5, w16, uxtb #2    : add    %w5 %w16 uxtb $0x02 -> %w0
 0b9f13ff : add    wzr, wzr, wzr, asr #4   : add    %wzr %wzr asr $0x04 -> %wzr
-0c0007ff : st4    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp]: st4    $0x01 %d31 %d0 %d1 %d2 -> (%sp)[32byte]
-0c0067ff : st1    {v31.4h, v0.4h, v1.4h}, [sp]: st1    $0x01 %d31 %d0 %d1 -> (%sp)[24byte]
-0c0077ff : st1    {v31.4h}, [sp]          : st1    %d31 $0x01 -> (%sp)[8byte]
-0c00a7ff : st1    {v31.4h, v0.4h}, [sp]   : st1    $0x01 %d31 %d0 -> (%sp)[16byte]
-0c4027ff : ld1    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp]: ld1    (%sp)[32byte] $0x01 -> %d31 %d0 %d1 %d2
-0c4047ff : ld3    {v31.4h, v0.4h, v1.4h}, [sp]: ld3    (%sp)[24byte] $0x01 -> %d31 %d0 %d1
-0c4087ff : ld2    {v31.4h, v0.4h}, [sp]   : ld2    (%sp)[16byte] $0x01 -> %d31 %d0
-0c9f27ff : st1    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp], #32: st1    $0x01 %d31 %d0 %d1 %d2 %sp $0x20 -> (%sp)[32byte] %sp
-0c9f47ff : st3    {v31.4h, v0.4h, v1.4h}, [sp], #24: st3    $0x01 %d31 %d0 %d1 %sp $0x18 -> (%sp)[24byte] %sp
-0c9f87ff : st2    {v31.4h, v0.4h}, [sp], #16: st2    $0x01 %d31 %d0 %sp $0x10 -> (%sp)[16byte] %sp
-0cd5a7ff : ld1    {v31.4h, v0.4h}, [sp], x21: ld1    (%sp)[16byte] $0x01 %sp %x21 -> %d31 %d0 %sp
-0cdf07ff : ld4    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp], #32: ld4    (%sp)[32byte] $0x01 %sp $0x20 -> %d31 %d0 %d1 %d2 %sp
-0cdf67ff : ld1    {v31.4h, v0.4h, v1.4h}, [sp], #24: ld1    (%sp)[24byte] $0x01 %sp $0x18 -> %d31 %d0 %d1 %sp
-0cdf77ff : ld1    {v31.4h}, [sp], #8      : ld1    (%sp)[8byte] $0x01 %sp $0x08 -> %d31 %sp
-0cdfa7ff : ld1    {v31.4h, v0.4h}, [sp], #16: ld1    (%sp)[16byte] $0x01 %sp $0x10 -> %d31 %d0 %sp
-0d40e7ff : ld3r   {v31.4h, v0.4h, v1.4h}, [sp]: ld3r   (%sp)[6byte] -> %d31 %d0 %d1
-0d60cbff : ld2r   {v31.2s, v0.2s}, [sp]   : ld2r   (%sp)[8byte] -> %d31 %d0
-0dc1e7ff : ld3r   {v31.4h, v0.4h, v1.4h}, [sp], x1: ld3r   (%sp)[6byte] %sp %x1 -> %d31 %d0 %d1 %sp
-0ddfe7ff : ld3r   {v31.4h, v0.4h, v1.4h}, [sp], #6: ld3r   (%sp)[6byte] %sp $0x06 -> %d31 %d0 %d1 %sp
-0de2cbff : ld2r   {v31.2s, v0.2s}, [sp], x2: ld2r   (%sp)[8byte] %sp %x2 -> %d31 %d0 %sp
-0dffcbff : ld2r   {v31.2s, v0.2s}, [sp], #8: ld2r   (%sp)[8byte] %sp $0x08 -> %d31 %d0 %sp
-10081041 : adr    x1, 10010208            : adr    <rel> 0x0000000010010208 -> %x1
-10800000 : adr    x0, ff00000             : adr    <rel> 0x000000000ff00000 -> %x0
 11000c41 : add    w1, w2, #0x3            : add    %w2 $0x0003 lsl $0x00 -> %w1
 11000fff : add    wsp, wsp, #0x3          : add    %wsp $0x0003 lsl $0x00 -> %wsp
 117fffff : add    wsp, wsp, #0xfff, lsl #12: add    %wsp $0x0fff lsl $0x10 -> %wsp
-12000441 : and    w1, w2, #0x3            : and    %w2 $0x00000003 -> %w1
-12881041 : mov    w1, #0xffffbf7d         : movn   $0x4082 lsl $0x00 -> %w1
-13031041 : sbfx   w1, w2, #3, #2          : sbfm   %w2 $0x03 $0x04 -> %w1
-131f7fff : asr    wzr, wzr, #31           : sbfm   %wzr $0x1f $0x1f -> %wzr
-13831041 : extr   w1, w2, w3, #4          : extr   %w2 %w3 $0x04 -> %w1
-139f7fff : ror    wzr, wzr, #31           : extr   %wzr %wzr $0x1f -> %wzr
-14081041 : b      10204104                : b      $0x0000000010204104
-15ffffff : b      17fffffc                : b      $0x0000000017fffffc
-17ffffff : b      ffffffc                 : b      $0x000000000ffffffc
-18081041 : ldr    w1, 10010208            : ldr    <rel> 0x0000000010010208[4byte] -> %w1
-187fffff : ldr    wzr, 100ffffc           : ldr    <rel> 0x00000000100ffffc[4byte] -> %wzr
-18800000 : ldr    w0, ff00000             : ldr    <rel> 0x000000000ff00000[4byte] -> %w0
-1a030041 : adc    w1, w2, w3              : adc    %w2 %w3 -> %w1
-1a9f7441 : csinc  w1, w2, wzr, vc         : csinc  %w2 %wzr vc -> %w1
-1ac30c5f : sdiv   wzr, w2, w3             : sdiv   %w2 %w3 -> %wzr
-1ac323e1 : lsl    w1, wzr, w3             : lslv   %wzr %w3 -> %w1
-1ac32c41 : ror    w1, w2, w3              : rorv   %w2 %w3 -> %w1
-1ac34041 : crc32b w1, w2, w3              : crc32b %w2 %w3 -> %w1
-1ac34441 : crc32h w1, w2, w3              : crc32h %w2 %w3 -> %w1
-1ac353e1 : crc32cb w1, wzr, w3            : crc32cb %wzr %w3 -> %w1
-1ac3545f : crc32ch wzr, w2, w3            : crc32ch %w2 %w3 -> %wzr
-1ac35841 : crc32cw w1, w2, w3             : crc32cw %w2 %w3 -> %w1
-1adf4841 : crc32w w1, w2, wzr             : crc32w %w2 %wzr -> %w1
-1b03fc41 : mneg   w1, w2, w3              : msub   %w2 %w3 %wzr -> %w1
-1b1f1041 : madd   w1, w2, wzr, w4         : madd   %w2 %wzr %w4 -> %w1
-1c081041 : ldr    s1, 10010208            : ldr    <rel> 0x0000000010010208[4byte] -> %s1
-1c7fffff : ldr    s31, 100ffffc           : ldr    <rel> 0x00000000100ffffc[4byte] -> %s31
-1c800000 : ldr    s0, ff00000             : ldr    <rel> 0x000000000ff00000[4byte] -> %s0
-28000000 : stnp   w0, w0, [x0]            : stnp   %w0 %w0 -> (%x0)[8byte]
-283fffff : stnp   wzr, wzr, [sp,#-4]      : stnp   %wzr %wzr -> -0x04(%sp)[8byte]
-28400000 : ldnp   w0, w0, [x0]            : ldnp   (%x0)[8byte] -> %w0 %w0
-287fffff : ldnp   wzr, wzr, [sp,#-4]      : ldnp   -0x04(%sp)[8byte] -> %wzr %wzr
-28800000 : stp    w0, w0, [x0],#0         : stp    %w0 %w0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
-28bfffff : stp    wzr, wzr, [sp],#-4      : stp    %wzr %wzr %sp $0xfffffffffffffffc -> (%sp)[8byte] %sp
-28c00000 : ldp    w0, w0, [x0],#0         : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %w0 %w0 %x0
-28ffffff : ldp    wzr, wzr, [sp],#-4      : ldp    (%sp)[8byte] %sp $0xfffffffffffffffc -> %wzr %wzr %sp
-29000000 : stp    w0, w0, [x0]            : stp    %w0 %w0 -> (%x0)[8byte]
-293fffff : stp    wzr, wzr, [sp,#-4]      : stp    %wzr %wzr -> -0x04(%sp)[8byte]
-29400000 : ldp    w0, w0, [x0]            : ldp    (%x0)[8byte] -> %w0 %w0
-297fffff : ldp    wzr, wzr, [sp,#-4]      : ldp    -0x04(%sp)[8byte] -> %wzr %wzr
-29800000 : stp    w0, w0, [x0,#0]!        : stp    %w0 %w0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
-29bfffff : stp    wzr, wzr, [sp,#-4]!     : stp    %wzr %wzr %sp $0xfffffffffffffffc -> -0x04(%sp)[8byte] %sp
-29c00000 : ldp    w0, w0, [x0,#0]!        : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %w0 %w0 %x0
-29ffffff : ldp    wzr, wzr, [sp,#-4]!     : ldp    -0x04(%sp)[8byte] %sp $0xfffffffffffffffc -> %wzr %wzr %sp
-2a031041 : orr    w1, w2, w3, lsl #4      : orr    %w2 %w3 lsl $0x04 -> %w1
-2a231041 : orn    w1, w2, w3, lsl #4      : orn    %w2 %w3 lsl $0x04 -> %w1
-2a9f13ff : mov    wzr, wzr                : orr    %wzr %wzr asr $0x04 -> %wzr
-2a9f7fff : mov    wzr, wzr                : orr    %wzr %wzr asr $0x1f -> %wzr
-2abf13ff : mvn    wzr, wzr, asr #4        : orn    %wzr %wzr asr $0x04 -> %wzr
-2b031041 : adds   w1, w2, w3, lsl #4      : adds   %w2 %w3 lsl $0x04 -> %w1
-2b3f43ff : cmn    wsp, wzr                : adds   %wsp %wzr uxtw $0x00 -> %wzr
-2b5f7fff : cmn    wzr, wzr, lsr #31       : adds   %wzr %wzr lsr $0x1f -> %wzr
-2b9f13ff : cmn    wzr, wzr, asr #4        : adds   %wzr %wzr asr $0x04 -> %wzr
-2c000000 : stnp   s0, s0, [x0]            : stnp   %s0 %s0 -> (%x0)[8byte]
-2c3fffff : stnp   s31, s31, [sp,#-4]      : stnp   %s31 %s31 -> -0x04(%sp)[8byte]
-2c400000 : ldnp   s0, s0, [x0]            : ldnp   (%x0)[8byte] -> %s0 %s0
-2c7fffff : ldnp   s31, s31, [sp,#-4]      : ldnp   -0x04(%sp)[8byte] -> %s31 %s31
-2c800000 : stp    s0, s0, [x0],#0         : stp    %s0 %s0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
-2cbfffff : stp    s31, s31, [sp],#-4      : stp    %s31 %s31 %sp $0xfffffffffffffffc -> (%sp)[8byte] %sp
-2cc00000 : ldp    s0, s0, [x0],#0         : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %s0 %s0 %x0
-2cffffff : ldp    s31, s31, [sp],#-4      : ldp    (%sp)[8byte] %sp $0xfffffffffffffffc -> %s31 %s31 %sp
-2d000000 : stp    s0, s0, [x0]            : stp    %s0 %s0 -> (%x0)[8byte]
-2d3fffff : stp    s31, s31, [sp,#-4]      : stp    %s31 %s31 -> -0x04(%sp)[8byte]
-2d400000 : ldp    s0, s0, [x0]            : ldp    (%x0)[8byte] -> %s0 %s0
-2d7fffff : ldp    s31, s31, [sp,#-4]      : ldp    -0x04(%sp)[8byte] -> %s31 %s31
-2d800000 : stp    s0, s0, [x0,#0]!        : stp    %s0 %s0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
-2dbfffff : stp    s31, s31, [sp,#-4]!     : stp    %s31 %s31 %sp $0xfffffffffffffffc -> -0x04(%sp)[8byte] %sp
-2dc00000 : ldp    s0, s0, [x0,#0]!        : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %s0 %s0 %x0
-2dffffff : ldp    s31, s31, [sp,#-4]!     : ldp    -0x04(%sp)[8byte] %sp $0xfffffffffffffffc -> %s31 %s31 %sp
-310003ff : cmn    wsp, #0x0               : adds   %wsp $0x0000 lsl $0x00 -> %wzr
-31000c41 : adds   w1, w2, #0x3            : adds   %w2 $0x0003 lsl $0x00 -> %w1
-31000fff : cmn    wsp, #0x3               : adds   %wsp $0x0003 lsl $0x00 -> %wzr
-32000441 : orr    w1, w2, #0x3            : orr    %w2 $0x00000003 -> %w1
-33031041 : bfxil  w1, w2, #3, #2          : bfm    %w1 %w2 $0x03 $0x04 -> %w1
-331f7fff : bfxil  wzr, wzr, #31, #1       : bfm    %wzr %wzr $0x1f $0x1f -> %wzr
-34081041 : cbz    w1, 10010208            : cbz    $0x0000000010010208 %w1
-347fffff : cbz    wzr, 100ffffc           : cbz    $0x00000000100ffffc %wzr
-35081041 : cbnz   w1, 10010208            : cbnz   $0x0000000010010208 %w1
-3603ffff : tbz    wzr, #0, 10007ffc       : tbz    $0x0000000010007ffc %xzr $0x00
-36081041 : tbz    w1, #1, 10000208        : tbz    $0x0000000010000208 %x1 $0x01
-37081041 : tbnz   w1, #1, 10000208        : tbnz   $0x0000000010000208 %x1 $0x01
-38000400 : strb   w0, [x0],#0             : strb   %w0 %x0 $0x0000000000000000 -> (%x0)[1byte] %x0
-38000c00 : strb   w0, [x0,#0]!            : strb   %w0 %x0 $0x0000000000000000 -> (%x0)[1byte] %x0
-38081041 : sturb  w1, [x2,#129]           : sturb  %w1 -> +0x81(%x2)[1byte]
-38081441 : strb   w1, [x2],#129           : strb   %w1 %x2 $0x0000000000000081 -> (%x2)[1byte] %x2
-38081841 : sttrb  w1, [x2,#129]           : sttrb  %w1 -> +0x81(%x2)[1byte]
-38081c41 : strb   w1, [x2,#129]!          : strb   %w1 %x2 $0x0000000000000081 -> +0x81(%x2)[1byte] %x2
-381ff3ff : sturb  wzr, [sp,#-1]           : sturb  %wzr -> -0x01(%sp)[1byte]
-381ff7ff : strb   wzr, [sp],#-1           : strb   %wzr %sp $0xffffffffffffffff -> (%sp)[1byte] %sp
-381ffbff : sttrb  wzr, [sp,#-1]           : sttrb  %wzr -> -0x01(%sp)[1byte]
-381fffff : strb   wzr, [sp,#-1]!          : strb   %wzr %sp $0xffffffffffffffff -> -0x01(%sp)[1byte] %sp
-38234841 : strb   w1, [x2,w3,uxtw]        : strb   %w1 -> (%x2,%x3,uxtw)[1byte]
-38235841 : strb   w1, [x2,w3,uxtw #0]     : strb   %w1 -> (%x2,%x3,uxtw #0)[1byte]
-38236841 : strb   w1, [x2,x3]             : strb   %w1 -> (%x2,%x3)[1byte]
-38237841 : strb   w1, [x2,x3,lsl #0]      : strb   %w1 -> (%x2,%x3,uxtx #0)[1byte]
-3823c841 : strb   w1, [x2,w3,sxtw]        : strb   %w1 -> (%x2,%x3,sxtw)[1byte]
-3823d841 : strb   w1, [x2,w3,sxtw #0]     : strb   %w1 -> (%x2,%x3,sxtw #0)[1byte]
-3823e841 : strb   w1, [x2,x3,sxtx]        : strb   %w1 -> (%x2,%x3,sxtx)[1byte]
-3823f841 : strb   w1, [x2,x3,sxtx #0]     : strb   %w1 -> (%x2,%x3,sxtx #0)[1byte]
-38280041 : ldaddb w8, w1, [x2]            : ldaddb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38281041 : ldclrb w8, w1, [x2]            : ldclrb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38282041 : ldeorb w8, w1, [x2]            : ldeorb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38283041 : ldsetb w8, w1, [x2]            : ldsetb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38284041 : ldsmaxb w8, w1, [x2]           : ldsmaxb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38285041 : ldsminb w8, w1, [x2]           : ldsminb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38286041 : ldumaxb w8, w1, [x2]           : ldumaxb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38287041 : lduminb w8, w1, [x2]           : lduminb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38288041 : swpb   w8, w1, [x2]            : swpb   %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-383f03ff : staddb wzr, [sp]               : ldaddb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-383f13ff : stclrb wzr, [sp]               : ldclrb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-383f23ff : steorb wzr, [sp]               : ldeorb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-383f33ff : stsetb wzr, [sp]               : ldsetb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-383f43ff : stsmaxb wzr, [sp]              : ldsmaxb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-383f4bff : strb   wzr, [sp,wzr,uxtw]      : strb   %wzr -> (%sp,%xzr,uxtw)[1byte]
-383f53ff : stsminb wzr, [sp]              : ldsminb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-383f5bff : strb   wzr, [sp,wzr,uxtw #0]   : strb   %wzr -> (%sp,%xzr,uxtw #0)[1byte]
-383f63ff : stumaxb wzr, [sp]              : ldumaxb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-383f6bff : strb   wzr, [sp,xzr]           : strb   %wzr -> (%sp,%xzr)[1byte]
-383f73ff : stuminb wzr, [sp]              : lduminb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-383f7bff : strb   wzr, [sp,xzr,lsl #0]    : strb   %wzr -> (%sp,%xzr,uxtx #0)[1byte]
-383f83ff : swpb   wzr, wzr, [sp]          : swpb   %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-383fcbff : strb   wzr, [sp,wzr,sxtw]      : strb   %wzr -> (%sp,%xzr,sxtw)[1byte]
-383fdbff : strb   wzr, [sp,wzr,sxtw #0]   : strb   %wzr -> (%sp,%xzr,sxtw #0)[1byte]
-383febff : strb   wzr, [sp,xzr,sxtx]      : strb   %wzr -> (%sp,%xzr,sxtx)[1byte]
-383ffbff : strb   wzr, [sp,xzr,sxtx #0]   : strb   %wzr -> (%sp,%xzr,sxtx #0)[1byte]
-38400400 : ldrb   w0, [x0],#0             : ldrb   (%x0)[1byte] %x0 $0x0000000000000000 -> %w0 %x0
-38400c00 : ldrb   w0, [x0,#0]!            : ldrb   (%x0)[1byte] %x0 $0x0000000000000000 -> %w0 %x0
-38481041 : ldurb  w1, [x2,#129]           : ldurb  +0x81(%x2)[1byte] -> %w1
-3c400000 : ldur   b0, [x0]                : ldur   (%x0)[1byte] -> %b0
-3c4ff021 : ldur   b1, [x1, #255]          : ldur   +0xff(%x1)[1byte] -> %b1
-7c400042 : ldur   h2, [x2]                : ldur   (%x2)[2byte] -> %h2
-7c500063 : ldur   h3, [x3, #-256]         : ldur   -0x0100(%x3)[2byte] -> %h3
-bc400084 : ldur   s4, [x4]                : ldur   (%x4)[4byte] -> %s4
-bc5000a5 : ldur   s5, [x5, #-256]         : ldur   -0x0100(%x5)[4byte] -> %s5
-fc4000c6 : ldur   d6, [x6]                : ldur   (%x6)[8byte] -> %d6
-fc5000e7 : ldur   d7, [x7, #-256]         : ldur   -0x0100(%x7)[8byte] -> %d7
-3cc00108 : ldur   q8, [x8]                : ldur   (%x8)[16byte] -> %q8
-3cd00129 : ldur   q9, [x9, #-256]         : ldur   -0x0100(%x9)[16byte] -> %q9
-3c00014a : stur   b10, [x10]              : stur   %b10 -> (%x10)[1byte]
-3c0ff16b : stur   b11, [x11, #255]        : stur   %b11 -> +0xff(%x11)[1byte]
-7c00018c : stur   h12, [x12]              : stur   %h12 -> (%x12)[2byte]
-7c0ff1ad : stur   h13, [x13, #255]        : stur   %h13 -> +0xff(%x13)[2byte]
-bc0001ce : stur   s14, [x14]              : stur   %s14 -> (%x14)[4byte]
-bc1001ef : stur   s15, [x15, #-256]       : stur   %s15 -> -0x0100(%x15)[4byte]
-fc000210 : stur   d16, [x16]              : stur   %d16 -> (%x16)[8byte]
-fc100231 : stur   d17, [x17, #-256]       : stur   %d17 -> -0x0100(%x17)[8byte]
-3c800252 : stur   q18, [x18]              : stur   %q18 -> (%x18)[16byte]
-3c900273 : stur   q19, [x19, #-256]       : stur   %q19 -> -0x0100(%x19)[16byte]
-38481441 : ldrb   w1, [x2],#129           : ldrb   (%x2)[1byte] %x2 $0x0000000000000081 -> %w1 %x2
-38481841 : ldtrb  w1, [x2,#129]           : ldtrb  +0x81(%x2)[1byte] -> %w1
-38481c41 : ldrb   w1, [x2,#129]!          : ldrb   +0x81(%x2)[1byte] %x2 $0x0000000000000081 -> %w1 %x2
-385ff3ff : ldurb  wzr, [sp,#-1]           : ldurb  -0x01(%sp)[1byte] -> %wzr
-385ff7ff : ldrb   wzr, [sp],#-1           : ldrb   (%sp)[1byte] %sp $0xffffffffffffffff -> %wzr %sp
-385ffbff : ldtrb  wzr, [sp,#-1]           : ldtrb  -0x01(%sp)[1byte] -> %wzr
-385fffff : ldrb   wzr, [sp,#-1]!          : ldrb   -0x01(%sp)[1byte] %sp $0xffffffffffffffff -> %wzr %sp
-38634841 : ldrb   w1, [x2,w3,uxtw]        : ldrb   (%x2,%x3,uxtw)[1byte] -> %w1
-38635841 : ldrb   w1, [x2,w3,uxtw #0]     : ldrb   (%x2,%x3,uxtw #0)[1byte] -> %w1
-38636841 : ldrb   w1, [x2,x3]             : ldrb   (%x2,%x3)[1byte] -> %w1
-38637841 : ldrb   w1, [x2,x3,lsl #0]      : ldrb   (%x2,%x3,uxtx #0)[1byte] -> %w1
-3863c841 : ldrb   w1, [x2,w3,sxtw]        : ldrb   (%x2,%x3,sxtw)[1byte] -> %w1
-3863d841 : ldrb   w1, [x2,w3,sxtw #0]     : ldrb   (%x2,%x3,sxtw #0)[1byte] -> %w1
-3863e841 : ldrb   w1, [x2,x3,sxtx]        : ldrb   (%x2,%x3,sxtx)[1byte] -> %w1
-3863f841 : ldrb   w1, [x2,x3,sxtx #0]     : ldrb   (%x2,%x3,sxtx #0)[1byte] -> %w1
-38680041 : ldaddlb w8, w1, [x2]           : ldaddlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38681041 : ldclrlb w8, w1, [x2]           : ldclrlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38682041 : ldeorlb w8, w1, [x2]           : ldeorlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38683041 : ldsetlb w8, w1, [x2]           : ldsetlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38684041 : ldsmaxlb w8, w1, [x2]          : ldsmaxlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38685041 : ldsminlb w8, w1, [x2]          : ldsminlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38686041 : ldumaxlb w8, w1, [x2]          : ldumaxlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38687041 : lduminlb w8, w1, [x2]          : lduminlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38688041 : swplb  w8, w1, [x2]            : swplb  %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-387f03ff : staddlb wzr, [sp]              : ldaddlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-387f13ff : stclrlb wzr, [sp]              : ldclrlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-387f23ff : steorlb wzr, [sp]              : ldeorlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-387f33ff : stsetlb wzr, [sp]              : ldsetlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-387f43ff : stsmaxlb wzr, [sp]             : ldsmaxlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-387f4bff : ldrb   wzr, [sp,wzr,uxtw]      : ldrb   (%sp,%xzr,uxtw)[1byte] -> %wzr
-387f53ff : stsminlb wzr, [sp]             : ldsminlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-387f5bff : ldrb   wzr, [sp,wzr,uxtw #0]   : ldrb   (%sp,%xzr,uxtw #0)[1byte] -> %wzr
-387f63ff : stumaxlb wzr, [sp]             : ldumaxlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-387f6bff : ldrb   wzr, [sp,xzr]           : ldrb   (%sp,%xzr)[1byte] -> %wzr
-387f73ff : stuminlb wzr, [sp]             : lduminlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-387f7bff : ldrb   wzr, [sp,xzr,lsl #0]    : ldrb   (%sp,%xzr,uxtx #0)[1byte] -> %wzr
-387f83ff : swplb  wzr, wzr, [sp]          : swplb  %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-387fcbff : ldrb   wzr, [sp,wzr,sxtw]      : ldrb   (%sp,%xzr,sxtw)[1byte] -> %wzr
-387fdbff : ldrb   wzr, [sp,wzr,sxtw #0]   : ldrb   (%sp,%xzr,sxtw #0)[1byte] -> %wzr
-387febff : ldrb   wzr, [sp,xzr,sxtx]      : ldrb   (%sp,%xzr,sxtx)[1byte] -> %wzr
-387ffbff : ldrb   wzr, [sp,xzr,sxtx #0]   : ldrb   (%sp,%xzr,sxtx #0)[1byte] -> %wzr
-38800400 : ldrsb  x0, [x0],#0             : ldrsb  (%x0)[1byte] %x0 $0x0000000000000000 -> %x0 %x0
-38800c00 : ldrsb  x0, [x0,#0]!            : ldrsb  (%x0)[1byte] %x0 $0x0000000000000000 -> %x0 %x0
-38881041 : ldursb x1, [x2,#129]           : ldursb +0x81(%x2)[1byte] -> %x1
-38881441 : ldrsb  x1, [x2],#129           : ldrsb  (%x2)[1byte] %x2 $0x0000000000000081 -> %x1 %x2
-38881841 : ldtrsb x1, [x2,#129]           : ldtrsb +0x81(%x2)[1byte] -> %x1
-38881c41 : ldrsb  x1, [x2,#129]!          : ldrsb  +0x81(%x2)[1byte] %x2 $0x0000000000000081 -> %x1 %x2
-389ff3ff : ldursb xzr, [sp,#-1]           : ldursb -0x01(%sp)[1byte] -> %xzr
-389ff7ff : ldrsb  xzr, [sp],#-1           : ldrsb  (%sp)[1byte] %sp $0xffffffffffffffff -> %xzr %sp
-389ffbff : ldtrsb xzr, [sp,#-1]           : ldtrsb -0x01(%sp)[1byte] -> %xzr
-389fffff : ldrsb  xzr, [sp,#-1]!          : ldrsb  -0x01(%sp)[1byte] %sp $0xffffffffffffffff -> %xzr %sp
-38a34841 : ldrsb  x1, [x2,w3,uxtw]        : ldrsb  (%x2,%x3,uxtw)[1byte] -> %x1
-38a35841 : ldrsb  x1, [x2,w3,uxtw #0]     : ldrsb  (%x2,%x3,uxtw #0)[1byte] -> %x1
-38a36841 : ldrsb  x1, [x2,x3]             : ldrsb  (%x2,%x3)[1byte] -> %x1
-38a37841 : ldrsb  x1, [x2,x3,lsl #0]      : ldrsb  (%x2,%x3,uxtx #0)[1byte] -> %x1
-38a3c841 : ldrsb  x1, [x2,w3,sxtw]        : ldrsb  (%x2,%x3,sxtw)[1byte] -> %x1
-38a3d841 : ldrsb  x1, [x2,w3,sxtw #0]     : ldrsb  (%x2,%x3,sxtw #0)[1byte] -> %x1
-38a3e841 : ldrsb  x1, [x2,x3,sxtx]        : ldrsb  (%x2,%x3,sxtx)[1byte] -> %x1
-38a3f841 : ldrsb  x1, [x2,x3,sxtx #0]     : ldrsb  (%x2,%x3,sxtx #0)[1byte] -> %x1
-38a80041 : ldaddab w8, w1, [x2]           : ldaddab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38a81041 : ldclrab w8, w1, [x2]           : ldclrab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38a82041 : ldeorab w8, w1, [x2]           : ldeorab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38a83041 : ldsetab w8, w1, [x2]           : ldsetab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38a84041 : ldsmaxab w8, w1, [x2]          : ldsmaxab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38a85041 : ldsminab w8, w1, [x2]          : ldsminab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38a86041 : ldumaxab w8, w1, [x2]          : ldumaxab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38a87041 : lduminab w8, w1, [x2]          : lduminab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38a88041 : swpab  w8, w1, [x2]            : swpab  %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38bf03ff : ldaddab wzr, wzr, [sp]         : ldaddab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38bf13ff : ldclrab wzr, wzr, [sp]         : ldclrab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38bf23ff : ldeorab wzr, wzr, [sp]         : ldeorab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38bf33ff : ldsetab wzr, wzr, [sp]         : ldsetab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38bf43ff : ldsmaxab wzr, wzr, [sp]        : ldsmaxab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38bf4bff : ldrsb  xzr, [sp,wzr,uxtw]      : ldrsb  (%sp,%xzr,uxtw)[1byte] -> %xzr
-38bf53ff : ldsminab wzr, wzr, [sp]        : ldsminab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38bf5bff : ldrsb  xzr, [sp,wzr,uxtw #0]   : ldrsb  (%sp,%xzr,uxtw #0)[1byte] -> %xzr
-38bf63ff : ldumaxab wzr, wzr, [sp]        : ldumaxab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38bf6bff : ldrsb  xzr, [sp,xzr]           : ldrsb  (%sp,%xzr)[1byte] -> %xzr
-38bf73ff : lduminab wzr, wzr, [sp]        : lduminab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38bf7bff : ldrsb  xzr, [sp,xzr,lsl #0]    : ldrsb  (%sp,%xzr,uxtx #0)[1byte] -> %xzr
-38bf83ff : swpab  wzr, wzr, [sp]          : swpab  %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38bfcbff : ldrsb  xzr, [sp,wzr,sxtw]      : ldrsb  (%sp,%xzr,sxtw)[1byte] -> %xzr
-38bfdbff : ldrsb  xzr, [sp,wzr,sxtw #0]   : ldrsb  (%sp,%xzr,sxtw #0)[1byte] -> %xzr
-38bfebff : ldrsb  xzr, [sp,xzr,sxtx]      : ldrsb  (%sp,%xzr,sxtx)[1byte] -> %xzr
-38bffbff : ldrsb  xzr, [sp,xzr,sxtx #0]   : ldrsb  (%sp,%xzr,sxtx #0)[1byte] -> %xzr
-38c00400 : ldrsb  w0, [x0],#0             : ldrsb  (%x0)[1byte] %x0 $0x0000000000000000 -> %w0 %x0
-38c00c00 : ldrsb  w0, [x0,#0]!            : ldrsb  (%x0)[1byte] %x0 $0x0000000000000000 -> %w0 %x0
-38c81041 : ldursb w1, [x2,#129]           : ldursb +0x81(%x2)[1byte] -> %w1
-38c81441 : ldrsb  w1, [x2],#129           : ldrsb  (%x2)[1byte] %x2 $0x0000000000000081 -> %w1 %x2
-38c81841 : ldtrsb w1, [x2,#129]           : ldtrsb +0x81(%x2)[1byte] -> %w1
-38c81c41 : ldrsb  w1, [x2,#129]!          : ldrsb  +0x81(%x2)[1byte] %x2 $0x0000000000000081 -> %w1 %x2
-38dff3ff : ldursb wzr, [sp,#-1]           : ldursb -0x01(%sp)[1byte] -> %wzr
-38dff7ff : ldrsb  wzr, [sp],#-1           : ldrsb  (%sp)[1byte] %sp $0xffffffffffffffff -> %wzr %sp
-38dffbff : ldtrsb wzr, [sp,#-1]           : ldtrsb -0x01(%sp)[1byte] -> %wzr
-38dfffff : ldrsb  wzr, [sp,#-1]!          : ldrsb  -0x01(%sp)[1byte] %sp $0xffffffffffffffff -> %wzr %sp
-38e34841 : ldrsb  w1, [x2,w3,uxtw]        : ldrsb  (%x2,%x3,uxtw)[1byte] -> %w1
-38e35841 : ldrsb  w1, [x2,w3,uxtw #0]     : ldrsb  (%x2,%x3,uxtw #0)[1byte] -> %w1
-38e36841 : ldrsb  w1, [x2,x3]             : ldrsb  (%x2,%x3)[1byte] -> %w1
-38e37841 : ldrsb  w1, [x2,x3,lsl #0]      : ldrsb  (%x2,%x3,uxtx #0)[1byte] -> %w1
-38e3c841 : ldrsb  w1, [x2,w3,sxtw]        : ldrsb  (%x2,%x3,sxtw)[1byte] -> %w1
-38e3d841 : ldrsb  w1, [x2,w3,sxtw #0]     : ldrsb  (%x2,%x3,sxtw #0)[1byte] -> %w1
-38e3e841 : ldrsb  w1, [x2,x3,sxtx]        : ldrsb  (%x2,%x3,sxtx)[1byte] -> %w1
-38e3f841 : ldrsb  w1, [x2,x3,sxtx #0]     : ldrsb  (%x2,%x3,sxtx #0)[1byte] -> %w1
-38e80041 : ldaddalb w8, w1, [x2]          : ldaddalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38e81041 : ldclralb w8, w1, [x2]          : ldclralb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38e82041 : ldeoralb w8, w1, [x2]          : ldeoralb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38e83041 : ldsetalb w8, w1, [x2]          : ldsetalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38e84041 : ldsmaxalb w8, w1, [x2]         : ldsmaxalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38e85041 : ldsminalb w8, w1, [x2]         : ldsminalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38e86041 : ldumaxalb w8, w1, [x2]         : ldumaxalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38e87041 : lduminalb w8, w1, [x2]         : lduminalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38e88041 : swpalb w8, w1, [x2]            : swpalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
-38ff03ff : ldaddalb wzr, wzr, [sp]        : ldaddalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38ff13ff : ldclralb wzr, wzr, [sp]        : ldclralb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38ff23ff : ldeoralb wzr, wzr, [sp]        : ldeoralb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38ff33ff : ldsetalb wzr, wzr, [sp]        : ldsetalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38ff43ff : ldsmaxalb wzr, wzr, [sp]       : ldsmaxalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38ff4bff : ldrsb  wzr, [sp,wzr,uxtw]      : ldrsb  (%sp,%xzr,uxtw)[1byte] -> %wzr
-38ff53ff : ldsminalb wzr, wzr, [sp]       : ldsminalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38ff5bff : ldrsb  wzr, [sp,wzr,uxtw #0]   : ldrsb  (%sp,%xzr,uxtw #0)[1byte] -> %wzr
-38ff63ff : ldumaxalb wzr, wzr, [sp]       : ldumaxalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38ff6bff : ldrsb  wzr, [sp,xzr]           : ldrsb  (%sp,%xzr)[1byte] -> %wzr
-38ff73ff : lduminalb wzr, wzr, [sp]       : lduminalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38ff7bff : ldrsb  wzr, [sp,xzr,lsl #0]    : ldrsb  (%sp,%xzr,uxtx #0)[1byte] -> %wzr
-38ff83ff : swpalb wzr, wzr, [sp]          : swpalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
-38ffcbff : ldrsb  wzr, [sp,wzr,sxtw]      : ldrsb  (%sp,%xzr,sxtw)[1byte] -> %wzr
-38ffdbff : ldrsb  wzr, [sp,wzr,sxtw #0]   : ldrsb  (%sp,%xzr,sxtw #0)[1byte] -> %wzr
-38ffebff : ldrsb  wzr, [sp,xzr,sxtx]      : ldrsb  (%sp,%xzr,sxtx)[1byte] -> %wzr
-38fffbff : ldrsb  wzr, [sp,xzr,sxtx #0]   : ldrsb  (%sp,%xzr,sxtx #0)[1byte] -> %wzr
-39081041 : strb   w1, [x2,#516]           : strb   %w1 -> +0x0204(%x2)[1byte]
-393fffff : strb   wzr, [sp,#4095]         : strb   %wzr -> +0x0fff(%sp)[1byte]
-39481041 : ldrb   w1, [x2,#516]           : ldrb   +0x0204(%x2)[1byte] -> %w1
-397fffff : ldrb   wzr, [sp,#4095]         : ldrb   +0x0fff(%sp)[1byte] -> %wzr
-39881041 : ldrsb  x1, [x2,#516]           : ldrsb  +0x0204(%x2)[1byte] -> %x1
-39bfffff : ldrsb  xzr, [sp,#4095]         : ldrsb  +0x0fff(%sp)[1byte] -> %xzr
-39c81041 : ldrsb  w1, [x2,#516]           : ldrsb  +0x0204(%x2)[1byte] -> %w1
-39ffffff : ldrsb  wzr, [sp,#4095]         : ldrsb  +0x0fff(%sp)[1byte] -> %wzr
-3a1f03ff : adcs   wzr, wzr, wzr           : adcs   %wzr %wzr -> %wzr
-3a40f820 : ccmn   w1, #0x0, #0x0, nv      : ccmn   %w1 $0x00 $0x00 nv
-3a42f020 : ccmn   w1, w2, #0x0, nv        : ccmn   %w1 %w2 $0x00 nv
-3c000400 : str    b0, [x0],#0             : str    %b0 %x0 $0x0000000000000000 -> (%x0)[1byte] %x0
-3c000c00 : str    b0, [x0,#0]!            : str    %b0 %x0 $0x0000000000000000 -> (%x0)[1byte] %x0
-3c081041 : stur   b1, [x2,#129]           : stur   %b1 -> +0x81(%x2)[1byte]
-3c081441 : str    b1, [x2],#129           : str    %b1 %x2 $0x0000000000000081 -> (%x2)[1byte] %x2
-3c081c41 : str    b1, [x2,#129]!          : str    %b1 %x2 $0x0000000000000081 -> +0x81(%x2)[1byte] %x2
-3c1ff3ff : stur   b31, [sp,#-1]           : stur   %b31 -> -0x01(%sp)[1byte]
-3c1ff7ff : str    b31, [sp],#-1           : str    %b31 %sp $0xffffffffffffffff -> (%sp)[1byte] %sp
-3c1fffff : str    b31, [sp,#-1]!          : str    %b31 %sp $0xffffffffffffffff -> -0x01(%sp)[1byte] %sp
-3c234841 : str    b1, [x2,w3,uxtw]        : str    %b1 -> (%x2,%x3,uxtw)[1byte]
-3c235841 : str    b1, [x2,w3,uxtw #0]     : str    %b1 -> (%x2,%x3,uxtw #0)[1byte]
-3c236841 : str    b1, [x2,x3]             : str    %b1 -> (%x2,%x3)[1byte]
-3c237841 : str    b1, [x2,x3,lsl #0]      : str    %b1 -> (%x2,%x3,uxtx #0)[1byte]
-3c23c841 : str    b1, [x2,w3,sxtw]        : str    %b1 -> (%x2,%x3,sxtw)[1byte]
-3c23d841 : str    b1, [x2,w3,sxtw #0]     : str    %b1 -> (%x2,%x3,sxtw #0)[1byte]
-3c23e841 : str    b1, [x2,x3,sxtx]        : str    %b1 -> (%x2,%x3,sxtx)[1byte]
-3c23f841 : str    b1, [x2,x3,sxtx #0]     : str    %b1 -> (%x2,%x3,sxtx #0)[1byte]
-3c3f4bff : str    b31, [sp,wzr,uxtw]      : str    %b31 -> (%sp,%xzr,uxtw)[1byte]
-3c3f5bff : str    b31, [sp,wzr,uxtw #0]   : str    %b31 -> (%sp,%xzr,uxtw #0)[1byte]
-3c3f6bff : str    b31, [sp,xzr]           : str    %b31 -> (%sp,%xzr)[1byte]
-3c3f7bff : str    b31, [sp,xzr,lsl #0]    : str    %b31 -> (%sp,%xzr,uxtx #0)[1byte]
-3c3fcbff : str    b31, [sp,wzr,sxtw]      : str    %b31 -> (%sp,%xzr,sxtw)[1byte]
-3c3fdbff : str    b31, [sp,wzr,sxtw #0]   : str    %b31 -> (%sp,%xzr,sxtw #0)[1byte]
-3c3febff : str    b31, [sp,xzr,sxtx]      : str    %b31 -> (%sp,%xzr,sxtx)[1byte]
-3c3ffbff : str    b31, [sp,xzr,sxtx #0]   : str    %b31 -> (%sp,%xzr,sxtx #0)[1byte]
-3c400400 : ldr    b0, [x0],#0             : ldr    (%x0)[1byte] %x0 $0x0000000000000000 -> %b0 %x0
-3c400c00 : ldr    b0, [x0,#0]!            : ldr    (%x0)[1byte] %x0 $0x0000000000000000 -> %b0 %x0
-3c481041 : ldur   b1, [x2,#129]           : ldur   +0x81(%x2)[1byte] -> %b1
-3c481441 : ldr    b1, [x2],#129           : ldr    (%x2)[1byte] %x2 $0x0000000000000081 -> %b1 %x2
-3c481c41 : ldr    b1, [x2,#129]!          : ldr    +0x81(%x2)[1byte] %x2 $0x0000000000000081 -> %b1 %x2
-3c5ff3ff : ldur   b31, [sp,#-1]           : ldur   -0x01(%sp)[1byte] -> %b31
-3c5ff7ff : ldr    b31, [sp],#-1           : ldr    (%sp)[1byte] %sp $0xffffffffffffffff -> %b31 %sp
-3c5fffff : ldr    b31, [sp,#-1]!          : ldr    -0x01(%sp)[1byte] %sp $0xffffffffffffffff -> %b31 %sp
-3c634841 : ldr    b1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[1byte] -> %b1
-3c635841 : ldr    b1, [x2,w3,uxtw #0]     : ldr    (%x2,%x3,uxtw #0)[1byte] -> %b1
-3c636841 : ldr    b1, [x2,x3]             : ldr    (%x2,%x3)[1byte] -> %b1
-3c637841 : ldr    b1, [x2,x3,lsl #0]      : ldr    (%x2,%x3,uxtx #0)[1byte] -> %b1
-3c63c841 : ldr    b1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[1byte] -> %b1
-3c63d841 : ldr    b1, [x2,w3,sxtw #0]     : ldr    (%x2,%x3,sxtw #0)[1byte] -> %b1
-3c63e841 : ldr    b1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[1byte] -> %b1
-3c63f841 : ldr    b1, [x2,x3,sxtx #0]     : ldr    (%x2,%x3,sxtx #0)[1byte] -> %b1
-3c7f4bff : ldr    b31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[1byte] -> %b31
-3c7f5bff : ldr    b31, [sp,wzr,uxtw #0]   : ldr    (%sp,%xzr,uxtw #0)[1byte] -> %b31
-3c7f6bff : ldr    b31, [sp,xzr]           : ldr    (%sp,%xzr)[1byte] -> %b31
-3c7f7bff : ldr    b31, [sp,xzr,lsl #0]    : ldr    (%sp,%xzr,uxtx #0)[1byte] -> %b31
-3c7fcbff : ldr    b31, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[1byte] -> %b31
-3c7fdbff : ldr    b31, [sp,wzr,sxtw #0]   : ldr    (%sp,%xzr,sxtw #0)[1byte] -> %b31
-3c7febff : ldr    b31, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[1byte] -> %b31
-3c7ffbff : ldr    b31, [sp,xzr,sxtx #0]   : ldr    (%sp,%xzr,sxtx #0)[1byte] -> %b31
-3c800400 : str    q0, [x0],#0             : str    %q0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
-3c800c00 : str    q0, [x0,#0]!            : str    %q0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
-3c881041 : stur   q1, [x2,#129]           : stur   %q1 -> +0x81(%x2)[16byte]
-3c881441 : str    q1, [x2],#129           : str    %q1 %x2 $0x0000000000000081 -> (%x2)[16byte] %x2
-3c881c41 : str    q1, [x2,#129]!          : str    %q1 %x2 $0x0000000000000081 -> +0x81(%x2)[16byte] %x2
-3c9ff3ff : stur   q31, [sp,#-1]           : stur   %q31 -> -0x01(%sp)[16byte]
-3c9ff7ff : str    q31, [sp],#-1           : str    %q31 %sp $0xffffffffffffffff -> (%sp)[16byte] %sp
-3c9fffff : str    q31, [sp,#-1]!          : str    %q31 %sp $0xffffffffffffffff -> -0x01(%sp)[16byte] %sp
-3ca34841 : str    q1, [x2,w3,uxtw]        : str    %b1 -> (%x2,%x3,uxtw)[16byte]
-3ca35841 : str    q1, [x2,w3,uxtw #4]     : str    %b1 -> (%x2,%x3,uxtw #4)[16byte]
-3ca36841 : str    q1, [x2,x3]             : str    %b1 -> (%x2,%x3)[16byte]
-3ca37841 : str    q1, [x2,x3,lsl #4]      : str    %b1 -> (%x2,%x3,uxtx #4)[16byte]
-3ca3c841 : str    q1, [x2,w3,sxtw]        : str    %b1 -> (%x2,%x3,sxtw)[16byte]
-3ca3d841 : str    q1, [x2,w3,sxtw #4]     : str    %b1 -> (%x2,%x3,sxtw #4)[16byte]
-3ca3e841 : str    q1, [x2,x3,sxtx]        : str    %b1 -> (%x2,%x3,sxtx)[16byte]
-3ca3f841 : str    q1, [x2,x3,sxtx #4]     : str    %b1 -> (%x2,%x3,sxtx #4)[16byte]
-3cbf4bff : str    q31, [sp,wzr,uxtw]      : str    %b31 -> (%sp,%xzr,uxtw)[16byte]
-3cbf5bff : str    q31, [sp,wzr,uxtw #4]   : str    %b31 -> (%sp,%xzr,uxtw #4)[16byte]
-3cbf6bff : str    q31, [sp,xzr]           : str    %b31 -> (%sp,%xzr)[16byte]
-3cbf7bff : str    q31, [sp,xzr,lsl #4]    : str    %b31 -> (%sp,%xzr,uxtx #4)[16byte]
-3cbfcbff : str    q31, [sp,wzr,sxtw]      : str    %b31 -> (%sp,%xzr,sxtw)[16byte]
-3cbfdbff : str    q31, [sp,wzr,sxtw #4]   : str    %b31 -> (%sp,%xzr,sxtw #4)[16byte]
-3cbfebff : str    q31, [sp,xzr,sxtx]      : str    %b31 -> (%sp,%xzr,sxtx)[16byte]
-3cbffbff : str    q31, [sp,xzr,sxtx #4]   : str    %b31 -> (%sp,%xzr,sxtx #4)[16byte]
-3cc00400 : ldr    q0, [x0],#0             : ldr    (%x0)[16byte] %x0 $0x0000000000000000 -> %q0 %x0
-3cc00c00 : ldr    q0, [x0,#0]!            : ldr    (%x0)[16byte] %x0 $0x0000000000000000 -> %q0 %x0
-3cc81041 : ldur   q1, [x2,#129]           : ldur   +0x81(%x2)[16byte] -> %q1
-3cc81441 : ldr    q1, [x2],#129           : ldr    (%x2)[16byte] %x2 $0x0000000000000081 -> %q1 %x2
-3cc81c41 : ldr    q1, [x2,#129]!          : ldr    +0x81(%x2)[16byte] %x2 $0x0000000000000081 -> %q1 %x2
-3cdff3ff : ldur   q31, [sp,#-1]           : ldur   -0x01(%sp)[16byte] -> %q31
-3cdff7ff : ldr    q31, [sp],#-1           : ldr    (%sp)[16byte] %sp $0xffffffffffffffff -> %q31 %sp
-3cdfffff : ldr    q31, [sp,#-1]!          : ldr    -0x01(%sp)[16byte] %sp $0xffffffffffffffff -> %q31 %sp
-3ce34841 : ldr    q1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[16byte] -> %q1
-3ce35841 : ldr    q1, [x2,w3,uxtw #4]     : ldr    (%x2,%x3,uxtw #4)[16byte] -> %q1
-3ce36841 : ldr    q1, [x2,x3]             : ldr    (%x2,%x3)[16byte] -> %q1
-3ce37841 : ldr    q1, [x2,x3,lsl #4]      : ldr    (%x2,%x3,uxtx #4)[16byte] -> %q1
-3ce3c841 : ldr    q1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[16byte] -> %q1
-3ce3d841 : ldr    q1, [x2,w3,sxtw #4]     : ldr    (%x2,%x3,sxtw #4)[16byte] -> %q1
-3ce3e841 : ldr    q1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[16byte] -> %q1
-3ce3f841 : ldr    q1, [x2,x3,sxtx #4]     : ldr    (%x2,%x3,sxtx #4)[16byte] -> %q1
-3cff4bff : ldr    q31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[16byte] -> %q31
-3cff5bff : ldr    q31, [sp,wzr,uxtw #4]   : ldr    (%sp,%xzr,uxtw #4)[16byte] -> %q31
-3cff6bff : ldr    q31, [sp,xzr]           : ldr    (%sp,%xzr)[16byte] -> %q31
-3cff7bff : ldr    q31, [sp,xzr,lsl #4]    : ldr    (%sp,%xzr,uxtx #4)[16byte] -> %q31
-3cffcbff : ldr    q31, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[16byte] -> %q31
-3cffdbff : ldr    q31, [sp,wzr,sxtw #4]   : ldr    (%sp,%xzr,sxtw #4)[16byte] -> %q31
-3cffebff : ldr    q31, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[16byte] -> %q31
-3cfffbff : ldr    q31, [sp,xzr,sxtx #4]   : ldr    (%sp,%xzr,sxtx #4)[16byte] -> %q31
-3d081041 : str    b1, [x2,#516]           : str    %b1 -> +0x0204(%x2)[1byte]
-3d3fffff : str    b31, [sp,#4095]         : str    %b31 -> +0x0fff(%sp)[1byte]
-3d481041 : ldr    b1, [x2,#516]           : ldr    +0x0204(%x2)[1byte] -> %b1
-3d7fffff : ldr    b31, [sp,#4095]         : ldr    +0x0fff(%sp)[1byte] -> %b31
-3d881041 : str    q1, [x2,#8256]          : str    %q1 -> +0x2040(%x2)[16byte]
-3dbfffff : str    q31, [sp,#65520]        : str    %q31 -> +0xfff0(%sp)[16byte]
-3dc81041 : ldr    q1, [x2,#8256]          : ldr    +0x2040(%x2)[16byte] -> %q1
-3dffffff : ldr    q31, [sp,#65520]        : ldr    +0xfff0(%sp)[16byte] -> %q31
-48081041 : stxrh  w8, w1, [x2]            : stxrh  %w1 $0x04 -> (%x2)[2byte] %w8
-48089041 : stlxrh w8, w1, [x2]            : stlxrh %w1 $0x04 -> (%x2)[2byte] %w8
-481f7fff : stxrh  wzr, wzr, [sp]          : stxrh  %wzr $0x1f -> (%sp)[2byte] %wzr
-481fffff : stlxrh wzr, wzr, [sp]          : stlxrh %wzr $0x1f -> (%sp)[2byte] %wzr
-48287c40 : casp   x8, x9, x0, x1, [x2]    : casp   %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
-4828fc40 : caspl  x8, x9, x0, x1, [x2]    : caspl  %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
-483e7ffe : casp   x30, xzr, x30, xzr, [sp]: casp   %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
-483efffe : caspl  x30, xzr, x30, xzr, [sp]: caspl  %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
-48481041 : ldxrh  w1, [x2]                : ldxrh  (%x2)[2byte] $0x04 $0x08 -> %w1
-48489041 : ldaxrh w1, [x2]                : ldaxrh (%x2)[2byte] $0x04 $0x08 -> %w1
-485f7fff : ldxrh  wzr, [sp]               : ldxrh  (%sp)[2byte] $0x1f $0x1f -> %wzr
-485fffff : ldaxrh wzr, [sp]               : ldaxrh (%sp)[2byte] $0x1f $0x1f -> %wzr
-48687c40 : caspa  x8, x9, x0, x1, [x2]    : caspa  %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
-4868fc40 : caspal x8, x9, x0, x1, [x2]    : caspal %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
-487e7ffe : caspa  x30, xzr, x30, xzr, [sp]: caspa  %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
-487efffe : caspal x30, xzr, x30, xzr, [sp]: caspal %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
-48889041 : stlrh  w1, [x2]                : stlrh  %w1 $0x04 $0x08 -> (%x2)[2byte]
-489fffff : stlrh  wzr, [sp]               : stlrh  %wzr $0x1f $0x1f -> (%sp)[2byte]
-48a87c41 : cash   w8, w1, [x2]            : cash   %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
-48a8fc41 : caslh  w8, w1, [x2]            : caslh  %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
-48bf7fff : cash   wzr, wzr, [sp]          : cash   %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-48bfffff : caslh  wzr, wzr, [sp]          : caslh  %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-48dfffff : ldarh  wzr, [sp]               : ldarh  (%sp)[2byte] -> %wzr
-48e87c41 : casah  w8, w1, [x2]            : casah  %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
-48e8fc41 : casalh w8, w1, [x2]            : casalh %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
-48ff7fff : casah  wzr, wzr, [sp]          : casah  %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-48ffffff : casalh wzr, wzr, [sp]          : casalh %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-4a031041 : eor    w1, w2, w3, lsl #4      : eor    %w2 %w3 lsl $0x04 -> %w1
-4a231041 : eon    w1, w2, w3, lsl #4      : eon    %w2 %w3 lsl $0x04 -> %w1
-4a9f13ff : eor    wzr, wzr, wzr, asr #4   : eor    %wzr %wzr asr $0x04 -> %wzr
-4abf13ff : eon    wzr, wzr, wzr, asr #4   : eon    %wzr %wzr asr $0x04 -> %wzr
-4b031041 : sub    w1, w2, w3, lsl #4      : sub    %w2 %w3 lsl $0x04 -> %w1
-4b9f13ff : neg    wzr, wzr, asr #4        : sub    %wzr %wzr asr $0x04 -> %wzr
-4b9f7fff : neg    wzr, wzr, asr #31       : sub    %wzr %wzr asr $0x1f -> %wzr
-4c0027ff : st1    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp]: st1    $0x01 %q31 %q0 %q1 %q2 -> (%sp)[64byte]
-4c0047ff : st3    {v31.8h, v0.8h, v1.8h}, [sp]: st3    $0x01 %q31 %q0 %q1 -> (%sp)[48byte]
-4c0087ff : st2    {v31.8h, v0.8h}, [sp]   : st2    $0x01 %q31 %q0 -> (%sp)[32byte]
-4c4007ff : ld4    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp]: ld4    (%sp)[64byte] $0x01 -> %q31 %q0 %q1 %q2
-4c4067ff : ld1    {v31.8h, v0.8h, v1.8h}, [sp]: ld1    (%sp)[48byte] $0x01 -> %q31 %q0 %q1
-4c4077ff : ld1    {v31.8h}, [sp]          : ld1    (%sp)[16byte] $0x01 -> %q31
-4c40a7ff : ld1    {v31.8h, v0.8h}, [sp]   : ld1    (%sp)[32byte] $0x01 -> %q31 %q0
-4c800000 : st4    {v0.16b-v3.16b}, [x0], x0: st4    $0x00 %q0 %q1 %q2 %q3 %x0 %x0 -> (%x0)[64byte] %x0
-4c9f07ff : st4    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp], #64: st4    $0x01 %q31 %q0 %q1 %q2 %sp $0x40 -> (%sp)[64byte] %sp
-4c9f67ff : st1    {v31.8h, v0.8h, v1.8h}, [sp], #48: st1    $0x01 %q31 %q0 %q1 %sp $0x30 -> (%sp)[48byte] %sp
-4c9f77ff : st1    {v31.8h}, [sp], #16     : st1    $0x01 %q31 %sp $0x10 -> (%sp)[16byte] %sp
-4c9fa7ff : st1    {v31.8h, v0.8h}, [sp], #32: st1    $0x01 %q31 %q0 %sp $0x20 -> (%sp)[32byte] %sp
-4cdf27ff : ld1    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp], #64: ld1    (%sp)[64byte] $0x01 %sp $0x40 -> %q31 %q0 %q1 %q2 %sp
-4cdf47ff : ld3    {v31.8h, v0.8h, v1.8h}, [sp], #48: ld3    (%sp)[48byte] $0x01 %sp $0x30 -> %q31 %q0 %q1 %sp
-4cdf87ff : ld2    {v31.8h, v0.8h}, [sp], #32: ld2    (%sp)[32byte] $0x01 %sp $0x20 -> %q31 %q0 %sp
-4d001fff : st1    {v31.b}[15], [sp]       : st1    %q31 $0x0f -> (%sp)[1byte]
-4d003fff : st3    {v31.b, v0.b, v1.b}[15], [sp]: st3    %q31 %q0 %q1 $0x0f -> (%sp)[3byte]
-4d005bff : st1    {v31.h}[7], [sp]        : st1    %q31 $0x07 -> (%sp)[2byte]
-4d007bff : st3    {v31.h, v0.h, v1.h}[7], [sp]: st3    %q31 %q0 %q1 $0x07 -> (%sp)[6byte]
-4d0087ff : st1    {v31.d}[1], [sp]        : st1    %q31 $0x01 -> (%sp)[8byte]
-4d0093ff : st1    {v31.s}[3], [sp]        : st1    %q31 $0x03 -> (%sp)[4byte]
-4d00a7ff : st3    {v31.d, v0.d, v1.d}[1], [sp]: st3    %q31 %q0 %q1 $0x01 -> (%sp)[24byte]
-4d00b3ff : st3    {v31.s, v0.s, v1.s}[3], [sp]: st3    %q31 %q0 %q1 $0x03 -> (%sp)[12byte]
-4d201fff : st2    {v31.b, v0.b}[15], [sp] : st2    %q31 %q0 $0x0f -> (%sp)[2byte]
-4d203fff : st4    {v31.b, v0.b, v1.b, v2.b}[15], [sp]: st4    %q31 %q0 %q1 %q2 $0x0f -> (%sp)[4byte]
-4d205bff : st2    {v31.h, v0.h}[7], [sp]  : st2    %q31 %q0 $0x07 -> (%sp)[4byte]
-4d207bff : st4    {v31.h, v0.h, v1.h, v2.h}[7], [sp]: st4    %q31 %q0 %q1 %q2 $0x07 -> (%sp)[8byte]
-4d2087ff : st2    {v31.d, v0.d}[1], [sp]  : st2    %q31 %q0 $0x01 -> (%sp)[16byte]
-4d2093ff : st2    {v31.s, v0.s}[3], [sp]  : st2    %q31 %q0 $0x03 -> (%sp)[8byte]
-4d20a7ff : st4    {v31.d, v0.d, v1.d, v2.d}[1], [sp]: st4    %q31 %q0 %q1 %q2 $0x01 -> (%sp)[32byte]
-4d20b3ff : st4    {v31.s, v0.s, v1.s, v2.s}[3], [sp]: st4    %q31 %q0 %q1 %q2 $0x03 -> (%sp)[16byte]
-4d401fff : ld1    {v31.b}[15], [sp]       : ld1    (%sp)[1byte] $0x0f -> %q31
-4d403fff : ld3    {v31.b, v0.b, v1.b}[15], [sp]: ld3    (%sp)[3byte] $0x0f -> %q31 %q0 %q1
-4d405bff : ld1    {v31.h}[7], [sp]        : ld1    (%sp)[2byte] $0x07 -> %q31
-4d407bff : ld3    {v31.h, v0.h, v1.h}[7], [sp]: ld3    (%sp)[6byte] $0x07 -> %q31 %q0 %q1
-4d4087ff : ld1    {v31.d}[1], [sp]        : ld1    (%sp)[8byte] $0x01 -> %q31
-4d4093ff : ld1    {v31.s}[3], [sp]        : ld1    (%sp)[4byte] $0x03 -> %q31
-4d40a7ff : ld3    {v31.d, v0.d, v1.d}[1], [sp]: ld3    (%sp)[24byte] $0x01 -> %q31 %q0 %q1
-4d40b3ff : ld3    {v31.s, v0.s, v1.s}[3], [sp]: ld3    (%sp)[12byte] $0x03 -> %q31 %q0 %q1
-4d40c3ff : ld1r   {v31.16b}, [sp]         : ld1r   (%sp)[1byte] -> %q31
-4d601fff : ld2    {v31.b, v0.b}[15], [sp] : ld2    (%sp)[2byte] $0x0f -> %q31 %q0
-4d603fff : ld4    {v31.b, v0.b, v1.b, v2.b}[15], [sp]: ld4    (%sp)[4byte] $0x0f -> %q31 %q0 %q1 %q2
-4d605bff : ld2    {v31.h, v0.h}[7], [sp]  : ld2    (%sp)[4byte] $0x07 -> %q31 %q0
-4d607bff : ld4    {v31.h, v0.h, v1.h, v2.h}[7], [sp]: ld4    (%sp)[8byte] $0x07 -> %q31 %q0 %q1 %q2
-4d6087ff : ld2    {v31.d, v0.d}[1], [sp]  : ld2    (%sp)[16byte] $0x01 -> %q31 %q0
-4d6093ff : ld2    {v31.s, v0.s}[3], [sp]  : ld2    (%sp)[8byte] $0x03 -> %q31 %q0
-4d60a7ff : ld4    {v31.d, v0.d, v1.d, v2.d}[1], [sp]: ld4    (%sp)[32byte] $0x01 -> %q31 %q0 %q1 %q2
-4d60b3ff : ld4    {v31.s, v0.s, v1.s, v2.s}[3], [sp]: ld4    (%sp)[16byte] $0x03 -> %q31 %q0 %q1 %q2
-4d60efff : ld4r   {v31.2d, v0.2d, v1.2d, v2.2d}, [sp]: ld4r   (%sp)[32byte] -> %q31 %q0 %q1 %q2
-4d9f1fff : st1    {v31.b}[15], [sp], #1   : st1    %q31 $0x0f %sp $0x01 -> (%sp)[1byte] %sp
-4d9f3fff : st3    {v31.b, v0.b, v1.b}[15], [sp], #3: st3    %q31 %q0 %q1 $0x0f %sp $0x03 -> (%sp)[3byte] %sp
-4d9f5bff : st1    {v31.h}[7], [sp], #2    : st1    %q31 $0x07 %sp $0x02 -> (%sp)[2byte] %sp
-4d9f7bff : st3    {v31.h, v0.h, v1.h}[7], [sp], #6: st3    %q31 %q0 %q1 $0x07 %sp $0x06 -> (%sp)[6byte] %sp
-4d9f87ff : st1    {v31.d}[1], [sp], #8    : st1    %q31 $0x01 %sp $0x08 -> (%sp)[8byte] %sp
-4d9f93ff : st1    {v31.s}[3], [sp], #4    : st1    %q31 $0x03 %sp $0x04 -> (%sp)[4byte] %sp
-4d9fa7ff : st3    {v31.d, v0.d, v1.d}[1], [sp], #24: st3    %q31 %q0 %q1 $0x01 %sp $0x18 -> (%sp)[24byte] %sp
-4d9fb3ff : st3    {v31.s, v0.s, v1.s}[3], [sp], #12: st3    %q31 %q0 %q1 $0x03 %sp $0x0c -> (%sp)[12byte] %sp
-4dbf1fff : st2    {v31.b, v0.b}[15], [sp], #2: st2    %q31 %q0 $0x0f %sp $0x02 -> (%sp)[2byte] %sp
-4dbf3fff : st4    {v31.b, v0.b, v1.b, v2.b}[15], [sp], #4: st4    %q31 %q0 %q1 %q2 $0x0f %sp $0x04 -> (%sp)[4byte] %sp
-4dbf5bff : st2    {v31.h, v0.h}[7], [sp], #4: st2    %q31 %q0 $0x07 %sp $0x04 -> (%sp)[4byte] %sp
-4dbf7bff : st4    {v31.h, v0.h, v1.h, v2.h}[7], [sp], #8: st4    %q31 %q0 %q1 %q2 $0x07 %sp $0x08 -> (%sp)[8byte] %sp
-4dbf87ff : st2    {v31.d, v0.d}[1], [sp], #16: st2    %q31 %q0 $0x01 %sp $0x10 -> (%sp)[16byte] %sp
-4dbf93ff : st2    {v31.s, v0.s}[3], [sp], #8: st2    %q31 %q0 $0x03 %sp $0x08 -> (%sp)[8byte] %sp
-4dbfa7ff : st4    {v31.d, v0.d, v1.d, v2.d}[1], [sp], #32: st4    %q31 %q0 %q1 %q2 $0x01 %sp $0x20 -> (%sp)[32byte] %sp
-4dbfb3ff : st4    {v31.s, v0.s, v1.s, v2.s}[3], [sp], #16: st4    %q31 %q0 %q1 %q2 $0x03 %sp $0x10 -> (%sp)[16byte] %sp
-4dc4c3ff : ld1r   {v31.16b}, [sp], x4     : ld1r   (%sp)[1byte] %sp %x4 -> %q31 %sp
-4ddf1fff : ld1    {v31.b}[15], [sp], #1   : ld1    %q31 (%sp)[1byte] $0x0f %sp $0x01 -> %q31 %sp
-4ddf3fff : ld3    {v31.b, v0.b, v1.b}[15], [sp], #3: ld3    %q31 %q0 %q1 (%sp)[3byte] $0x0f %sp $0x03 -> %q31 %q0 %q1 %sp
-4ddf5bff : ld1    {v31.h}[7], [sp], #2    : ld1    %q31 (%sp)[2byte] $0x07 %sp $0x02 -> %q31 %sp
-4ddf7bff : ld3    {v31.h, v0.h, v1.h}[7], [sp], #6: ld3    %q31 %q0 %q1 (%sp)[6byte] $0x07 %sp $0x06 -> %q31 %q0 %q1 %sp
-4ddf87ff : ld1    {v31.d}[1], [sp], #8    : ld1    %q31 (%sp)[8byte] $0x01 %sp $0x08 -> %q31 %sp
-4ddf93ff : ld1    {v31.s}[3], [sp], #4    : ld1    %q31 (%sp)[4byte] $0x03 %sp $0x04 -> %q31 %sp
-4ddfa7ff : ld3    {v31.d, v0.d, v1.d}[1], [sp], #24: ld3    %q31 %q0 %q1 (%sp)[24byte] $0x01 %sp $0x18 -> %q31 %q0 %q1 %sp
-4ddfb3ff : ld3    {v31.s, v0.s, v1.s}[3], [sp], #12: ld3    %q31 %q0 %q1 (%sp)[12byte] $0x03 %sp $0x0c -> %q31 %q0 %q1 %sp
-4ddfc3ff : ld1r   {v31.16b}, [sp], #1     : ld1r   (%sp)[1byte] %sp $0x01 -> %q31 %sp
-4df0efff : ld4r   {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], x16: ld4r   (%sp)[32byte] %sp %x16 -> %q31 %q0 %q1 %q2 %sp
-4dff1fff : ld2    {v31.b, v0.b}[15], [sp], #2: ld2    %q31 %q0 (%sp)[2byte] $0x0f %sp $0x02 -> %q31 %q0 %sp
-4dff3fff : ld4    {v31.b, v0.b, v1.b, v2.b}[15], [sp], #4: ld4    %q31 %q0 %q1 %q2 (%sp)[4byte] $0x0f %sp $0x04 -> %q31 %q0 %q1 %q2 %sp
-4dff5bff : ld2    {v31.h, v0.h}[7], [sp], #4: ld2    %q31 %q0 (%sp)[4byte] $0x07 %sp $0x04 -> %q31 %q0 %sp
-4dff7bff : ld4    {v31.h, v0.h, v1.h, v2.h}[7], [sp], #8: ld4    %q31 %q0 %q1 %q2 (%sp)[8byte] $0x07 %sp $0x08 -> %q31 %q0 %q1 %q2 %sp
-4dff87ff : ld2    {v31.d, v0.d}[1], [sp], #16: ld2    %q31 %q0 (%sp)[16byte] $0x01 %sp $0x10 -> %q31 %q0 %sp
-4dff93ff : ld2    {v31.s, v0.s}[3], [sp], #8: ld2    %q31 %q0 (%sp)[8byte] $0x03 %sp $0x08 -> %q31 %q0 %sp
-4dffa7ff : ld4    {v31.d, v0.d, v1.d, v2.d}[1], [sp], #32: ld4    %q31 %q0 %q1 %q2 (%sp)[32byte] $0x01 %sp $0x20 -> %q31 %q0 %q1 %q2 %sp
-4dffb3ff : ld4    {v31.s, v0.s, v1.s, v2.s}[3], [sp], #16: ld4    %q31 %q0 %q1 %q2 (%sp)[16byte] $0x03 %sp $0x10 -> %q31 %q0 %q1 %q2 %sp
-4dffefff : ld4r   {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], #32: ld4r   (%sp)[32byte] %sp $0x20 -> %q31 %q0 %q1 %q2 %sp
-51000c41 : sub    w1, w2, #0x3            : sub    %w2 $0x0003 lsl $0x00 -> %w1
-51000fff : sub    wsp, wsp, #0x3          : sub    %wsp $0x0003 lsl $0x00 -> %wsp
-52000441 : eor    w1, w2, #0x3            : eor    %w2 $0x00000003 -> %w1
-52881041 : mov    w1, #0x4082             : movz   $0x4082 lsl $0x00 -> %w1
-53031041 : ubfx   w1, w2, #3, #2          : ubfm   %w2 $0x03 $0x04 -> %w1
-531f7fff : lsr    wzr, wzr, #31           : ubfm   %wzr $0x1f $0x1f -> %wzr
-54000000 : b.eq   10000000                : b.eq   $0x0000000010000000
-54000001 : b.ne   10000000                : b.ne   $0x0000000010000000
-54000002 : b.cs   10000000                : b.cs   $0x0000000010000000
-54000003 : b.cc   10000000                : b.cc   $0x0000000010000000
-54000004 : b.mi   10000000                : b.mi   $0x0000000010000000
-54000005 : b.pl   10000000                : b.pl   $0x0000000010000000
-54000006 : b.vs   10000000                : b.vs   $0x0000000010000000
-54000007 : b.vc   10000000                : b.vc   $0x0000000010000000
-54000008 : b.hi   10000000                : b.hi   $0x0000000010000000
-54000009 : b.ls   10000000                : b.ls   $0x0000000010000000
-5400000a : b.ge   10000000                : b.ge   $0x0000000010000000
-5400000b : b.lt   10000000                : b.lt   $0x0000000010000000
-5400002c : b.gt   10000004                : b.gt   $0x0000000010000004
-547fffed : b.le   100ffffc                : b.le   $0x00000000100ffffc
-547fffef : b.nv   100ffffc                : b.nv   $0x00000000100ffffc
-5480000e : b.al   ff00000                 : b.al   $0x000000000ff00000
-54ffffef : b.nv   ffffffc                 : b.nv   $0x000000000ffffffc
-587fffff : ldr    xzr, 100ffffc           : ldr    <rel> 0x00000000100ffffc[8byte] -> %xzr
-58800000 : ldr    x0, ff00000             : ldr    <rel> 0x000000000ff00000[8byte] -> %x0
-58ffffff : ldr    xzr, ffffffc            : ldr    <rel> 0x000000000ffffffc[8byte] -> %xzr
-5a1f03ff : ngc    wzr, wzr                : sbc    %wzr %wzr -> %wzr
-5a8383e1 : csinv  w1, wzr, w3, hi         : csinv  %wzr %w3 hi -> %w1
-5ac00041 : rbit   w1, w2                  : rbit   %w2 -> %w1
-5ac00441 : rev16  w1, w2                  : rev16  %w2 -> %w1
-5ac00841 : rev    w1, w2                  : rev    %w2 -> %w1
-5ac01041 : clz    w1, w2                  : clz    %w2 -> %w1
-5ac01441 : cls    w1, w2                  : cls    %w2 -> %w1
-5c7fffff : ldr    d31, 100ffffc           : ldr    <rel> 0x00000000100ffffc[8byte] -> %d31
-5c800000 : ldr    d0, ff00000             : ldr    <rel> 0x000000000ff00000[8byte] -> %d0
-68c00000 : ldpsw  x0, x0, [x0],#0         : ldpsw  (%x0)[8byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
-68ffffff : ldpsw  xzr, xzr, [sp],#-4      : ldpsw  (%sp)[8byte] %sp $0xfffffffffffffffc -> %xzr %xzr %sp
-69400000 : ldpsw  x0, x0, [x0]            : ldpsw  (%x0)[8byte] -> %x0 %x0
-697fffff : ldpsw  xzr, xzr, [sp,#-4]      : ldpsw  -0x04(%sp)[8byte] -> %xzr %xzr
-69c00000 : ldpsw  x0, x0, [x0,#0]!        : ldpsw  (%x0)[8byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
-69ffffff : ldpsw  xzr, xzr, [sp,#-4]!     : ldpsw  -0x04(%sp)[8byte] %sp $0xfffffffffffffffc -> %xzr %xzr %sp
-6a031041 : ands   w1, w2, w3, lsl #4      : ands   %w2 %w3 lsl $0x04 -> %w1
-6a231041 : bics   w1, w2, w3, lsl #4      : bics   %w2 %w3 lsl $0x04 -> %w1
-6a9f13ff : tst    wzr, wzr, asr #4        : ands   %wzr %wzr asr $0x04 -> %wzr
-6abf13ff : bics   wzr, wzr, wzr, asr #4   : bics   %wzr %wzr asr $0x04 -> %wzr
-6aff7fff : bics   wzr, wzr, wzr, ror #31  : bics   %wzr %wzr ror $0x1f -> %wzr
-6b031041 : subs   w1, w2, w3, lsl #4      : subs   %w2 %w3 lsl $0x04 -> %w1
-6b1f7fff : negs   wzr, wzr, lsl #31       : subs   %wzr %wzr lsl $0x1f -> %wzr
-6b3f8fff : cmp    wsp, wzr, sxtb #3       : subs   %wsp %wzr sxtb $0x03 -> %wzr
-6b3fc7ff : cmp    wsp, wzr, sxtw #1       : subs   %wsp %wzr sxtw $0x01 -> %wzr
-6b9f13ff : negs   wzr, wzr, asr #4        : subs   %wzr %wzr asr $0x04 -> %wzr
-6c000000 : stnp   d0, d0, [x0]            : stnp   %d0 %d0 -> (%x0)[16byte]
-6c3fffff : stnp   d31, d31, [sp,#-8]      : stnp   %d31 %d31 -> -0x08(%sp)[16byte]
-6c400000 : ldnp   d0, d0, [x0]            : ldnp   (%x0)[16byte] -> %d0 %d0
-6c7fffff : ldnp   d31, d31, [sp,#-8]      : ldnp   -0x08(%sp)[16byte] -> %d31 %d31
-6c800000 : stp    d0, d0, [x0],#0         : stp    %d0 %d0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
-6cbfffff : stp    d31, d31, [sp],#-8      : stp    %d31 %d31 %sp $0xfffffffffffffff8 -> (%sp)[16byte] %sp
-6cc00000 : ldp    d0, d0, [x0],#0         : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %d0 %d0 %x0
-6cffffff : ldp    d31, d31, [sp],#-8      : ldp    (%sp)[16byte] %sp $0xfffffffffffffff8 -> %d31 %d31 %sp
-6d000000 : stp    d0, d0, [x0]            : stp    %d0 %d0 -> (%x0)[16byte]
-6d3fffff : stp    d31, d31, [sp,#-8]      : stp    %d31 %d31 -> -0x08(%sp)[16byte]
-6d400000 : ldp    d0, d0, [x0]            : ldp    (%x0)[16byte] -> %d0 %d0
-6d7fffff : ldp    d31, d31, [sp,#-8]      : ldp    -0x08(%sp)[16byte] -> %d31 %d31
-6d800000 : stp    d0, d0, [x0,#0]!        : stp    %d0 %d0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
-6dbfffff : stp    d31, d31, [sp,#-8]!     : stp    %d31 %d31 %sp $0xfffffffffffffff8 -> -0x08(%sp)[16byte] %sp
-6dc00000 : ldp    d0, d0, [x0,#0]!        : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %d0 %d0 %x0
-6dffffff : ldp    d31, d31, [sp,#-8]!     : ldp    -0x08(%sp)[16byte] %sp $0xfffffffffffffff8 -> %d31 %d31 %sp
-707fffff : adr    xzr, 100fffff           : adr    <rel> 0x00000000100fffff -> %xzr
-70ffffff : adr    xzr, fffffff            : adr    <rel> 0x000000000fffffff -> %xzr
-71000c41 : subs   w1, w2, #0x3            : subs   %w2 $0x0003 lsl $0x00 -> %w1
-71000fff : cmp    wsp, #0x3               : subs   %wsp $0x0003 lsl $0x00 -> %wzr
-72000441 : ands   w1, w2, #0x3            : ands   %w2 $0x00000003 -> %w1
-72881041 : movk   w1, #0x4082             : movk   %w1 $0x4082 lsl $0x00 -> %w1
-78000400 : strh   w0, [x0],#0             : strh   %w0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
-78000c00 : strh   w0, [x0,#0]!            : strh   %w0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
-78081041 : sturh  w1, [x2,#129]           : sturh  %w1 -> +0x81(%x2)[2byte]
-78081441 : strh   w1, [x2],#129           : strh   %w1 %x2 $0x0000000000000081 -> (%x2)[2byte] %x2
-78081841 : sttrh  w1, [x2,#129]           : sttrh  %w1 -> +0x81(%x2)[2byte]
-78081c41 : strh   w1, [x2,#129]!          : strh   %w1 %x2 $0x0000000000000081 -> +0x81(%x2)[2byte] %x2
-781ff3ff : sturh  wzr, [sp,#-1]           : sturh  %wzr -> -0x01(%sp)[2byte]
-781ff7ff : strh   wzr, [sp],#-1           : strh   %wzr %sp $0xffffffffffffffff -> (%sp)[2byte] %sp
-781ffbff : sttrh  wzr, [sp,#-1]           : sttrh  %wzr -> -0x01(%sp)[2byte]
-781fffff : strh   wzr, [sp,#-1]!          : strh   %wzr %sp $0xffffffffffffffff -> -0x01(%sp)[2byte] %sp
-78234841 : strh   w1, [x2,w3,uxtw]        : strh   %w1 -> (%x2,%x3,uxtw)[2byte]
-78235841 : strh   w1, [x2,w3,uxtw #1]     : strh   %w1 -> (%x2,%x3,uxtw #1)[2byte]
-78236841 : strh   w1, [x2,x3]             : strh   %w1 -> (%x2,%x3)[2byte]
-78237841 : strh   w1, [x2,x3,lsl #1]      : strh   %w1 -> (%x2,%x3,uxtx #1)[2byte]
-7823c841 : strh   w1, [x2,w3,sxtw]        : strh   %w1 -> (%x2,%x3,sxtw)[2byte]
-7823d841 : strh   w1, [x2,w3,sxtw #1]     : strh   %w1 -> (%x2,%x3,sxtw #1)[2byte]
-7823e841 : strh   w1, [x2,x3,sxtx]        : strh   %w1 -> (%x2,%x3,sxtx)[2byte]
-7823f841 : strh   w1, [x2,x3,sxtx #1]     : strh   %w1 -> (%x2,%x3,sxtx #1)[2byte]
-78280041 : ldaddh w8, w1, [x2]            : ldaddh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78281041 : ldclrh w8, w1, [x2]            : ldclrh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78282041 : ldeorh w8, w1, [x2]            : ldeorh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78283041 : ldseth w8, w1, [x2]            : ldseth %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78284041 : ldsmaxh w8, w1, [x2]           : ldsmaxh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78285041 : ldsminh w8, w1, [x2]           : ldsminh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78286041 : ldumaxh w8, w1, [x2]           : ldumaxh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78287041 : lduminh w8, w1, [x2]           : lduminh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78288041 : swph   w8, w1, [x2]            : swph   %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-783f03ff : staddh wzr, [sp]               : ldaddh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-783f13ff : stclrh wzr, [sp]               : ldclrh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-783f23ff : steorh wzr, [sp]               : ldeorh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-783f33ff : stseth wzr, [sp]               : ldseth %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-783f43ff : stsmaxh wzr, [sp]              : ldsmaxh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-783f4bff : strh   wzr, [sp,wzr,uxtw]      : strh   %wzr -> (%sp,%xzr,uxtw)[2byte]
-783f53ff : stsminh wzr, [sp]              : ldsminh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-783f5bff : strh   wzr, [sp,wzr,uxtw #1]   : strh   %wzr -> (%sp,%xzr,uxtw #1)[2byte]
-783f63ff : stumaxh wzr, [sp]              : ldumaxh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-783f6bff : strh   wzr, [sp,xzr]           : strh   %wzr -> (%sp,%xzr)[2byte]
-783f73ff : stuminh wzr, [sp]              : lduminh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-783f7bff : strh   wzr, [sp,xzr,lsl #1]    : strh   %wzr -> (%sp,%xzr,uxtx #1)[2byte]
-783f83ff : swph   wzr, wzr, [sp]          : swph   %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-783fcbff : strh   wzr, [sp,wzr,sxtw]      : strh   %wzr -> (%sp,%xzr,sxtw)[2byte]
-783fdbff : strh   wzr, [sp,wzr,sxtw #1]   : strh   %wzr -> (%sp,%xzr,sxtw #1)[2byte]
-783febff : strh   wzr, [sp,xzr,sxtx]      : strh   %wzr -> (%sp,%xzr,sxtx)[2byte]
-783ffbff : strh   wzr, [sp,xzr,sxtx #1]   : strh   %wzr -> (%sp,%xzr,sxtx #1)[2byte]
-78400400 : ldrh   w0, [x0],#0             : ldrh   (%x0)[2byte] %x0 $0x0000000000000000 -> %w0 %x0
-78400c00 : ldrh   w0, [x0,#0]!            : ldrh   (%x0)[2byte] %x0 $0x0000000000000000 -> %w0 %x0
-78481041 : ldurh  w1, [x2,#129]           : ldurh  +0x81(%x2)[2byte] -> %w1
-78481441 : ldrh   w1, [x2],#129           : ldrh   (%x2)[2byte] %x2 $0x0000000000000081 -> %w1 %x2
-78481841 : ldtrh  w1, [x2,#129]           : ldtrh  +0x81(%x2)[2byte] -> %w1
-78481c41 : ldrh   w1, [x2,#129]!          : ldrh   +0x81(%x2)[2byte] %x2 $0x0000000000000081 -> %w1 %x2
-785ff3ff : ldurh  wzr, [sp,#-1]           : ldurh  -0x01(%sp)[2byte] -> %wzr
-785ff7ff : ldrh   wzr, [sp],#-1           : ldrh   (%sp)[2byte] %sp $0xffffffffffffffff -> %wzr %sp
-785ffbff : ldtrh  wzr, [sp,#-1]           : ldtrh  -0x01(%sp)[2byte] -> %wzr
-785fffff : ldrh   wzr, [sp,#-1]!          : ldrh   -0x01(%sp)[2byte] %sp $0xffffffffffffffff -> %wzr %sp
-78634841 : ldrh   w1, [x2,w3,uxtw]        : ldrh   (%x2,%x3,uxtw)[2byte] -> %w1
-78635841 : ldrh   w1, [x2,w3,uxtw #1]     : ldrh   (%x2,%x3,uxtw #1)[2byte] -> %w1
-78636841 : ldrh   w1, [x2,x3]             : ldrh   (%x2,%x3)[2byte] -> %w1
-78637841 : ldrh   w1, [x2,x3,lsl #1]      : ldrh   (%x2,%x3,uxtx #1)[2byte] -> %w1
-7863c841 : ldrh   w1, [x2,w3,sxtw]        : ldrh   (%x2,%x3,sxtw)[2byte] -> %w1
-7863d841 : ldrh   w1, [x2,w3,sxtw #1]     : ldrh   (%x2,%x3,sxtw #1)[2byte] -> %w1
-7863e841 : ldrh   w1, [x2,x3,sxtx]        : ldrh   (%x2,%x3,sxtx)[2byte] -> %w1
-7863f841 : ldrh   w1, [x2,x3,sxtx #1]     : ldrh   (%x2,%x3,sxtx #1)[2byte] -> %w1
-78680041 : ldaddlh w8, w1, [x2]           : ldaddlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78681041 : ldclrlh w8, w1, [x2]           : ldclrlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78682041 : ldeorlh w8, w1, [x2]           : ldeorlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78683041 : ldsetlh w8, w1, [x2]           : ldsetlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78684041 : ldsmaxlh w8, w1, [x2]          : ldsmaxlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78685041 : ldsminlh w8, w1, [x2]          : ldsminlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78686041 : ldumaxlh w8, w1, [x2]          : ldumaxlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78687041 : lduminlh w8, w1, [x2]          : lduminlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78688041 : swplh  w8, w1, [x2]            : swplh  %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-787f03ff : staddlh wzr, [sp]              : ldaddlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-787f13ff : stclrlh wzr, [sp]              : ldclrlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-787f23ff : steorlh wzr, [sp]              : ldeorlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-787f33ff : stsetlh wzr, [sp]              : ldsetlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-787f43ff : stsmaxlh wzr, [sp]             : ldsmaxlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-787f4bff : ldrh   wzr, [sp,wzr,uxtw]      : ldrh   (%sp,%xzr,uxtw)[2byte] -> %wzr
-787f53ff : stsminlh wzr, [sp]             : ldsminlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-787f5bff : ldrh   wzr, [sp,wzr,uxtw #1]   : ldrh   (%sp,%xzr,uxtw #1)[2byte] -> %wzr
-787f63ff : stumaxlh wzr, [sp]             : ldumaxlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-787f6bff : ldrh   wzr, [sp,xzr]           : ldrh   (%sp,%xzr)[2byte] -> %wzr
-787f73ff : stuminlh wzr, [sp]             : lduminlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-787f7bff : ldrh   wzr, [sp,xzr,lsl #1]    : ldrh   (%sp,%xzr,uxtx #1)[2byte] -> %wzr
-787f83ff : swplh  wzr, wzr, [sp]          : swplh  %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-787fcbff : ldrh   wzr, [sp,wzr,sxtw]      : ldrh   (%sp,%xzr,sxtw)[2byte] -> %wzr
-787fdbff : ldrh   wzr, [sp,wzr,sxtw #1]   : ldrh   (%sp,%xzr,sxtw #1)[2byte] -> %wzr
-787febff : ldrh   wzr, [sp,xzr,sxtx]      : ldrh   (%sp,%xzr,sxtx)[2byte] -> %wzr
-787ffbff : ldrh   wzr, [sp,xzr,sxtx #1]   : ldrh   (%sp,%xzr,sxtx #1)[2byte] -> %wzr
-78800400 : ldrsh  x0, [x0],#0             : ldrsh  (%x0)[2byte] %x0 $0x0000000000000000 -> %x0 %x0
-78800c00 : ldrsh  x0, [x0,#0]!            : ldrsh  (%x0)[2byte] %x0 $0x0000000000000000 -> %x0 %x0
-78881041 : ldursh x1, [x2,#129]           : ldursh +0x81(%x2)[2byte] -> %x1
-78881441 : ldrsh  x1, [x2],#129           : ldrsh  (%x2)[2byte] %x2 $0x0000000000000081 -> %x1 %x2
-78881841 : ldtrsh x1, [x2,#129]           : ldtrsh +0x81(%x2)[2byte] -> %x1
-78881c41 : ldrsh  x1, [x2,#129]!          : ldrsh  +0x81(%x2)[2byte] %x2 $0x0000000000000081 -> %x1 %x2
-789ff3ff : ldursh xzr, [sp,#-1]           : ldursh -0x01(%sp)[2byte] -> %xzr
-789ff7ff : ldrsh  xzr, [sp],#-1           : ldrsh  (%sp)[2byte] %sp $0xffffffffffffffff -> %xzr %sp
-789ffbff : ldtrsh xzr, [sp,#-1]           : ldtrsh -0x01(%sp)[2byte] -> %xzr
-789fffff : ldrsh  xzr, [sp,#-1]!          : ldrsh  -0x01(%sp)[2byte] %sp $0xffffffffffffffff -> %xzr %sp
-78a34841 : ldrsh  x1, [x2,w3,uxtw]        : ldrsh  (%x2,%x3,uxtw)[2byte] -> %x1
-78a35841 : ldrsh  x1, [x2,w3,uxtw #1]     : ldrsh  (%x2,%x3,uxtw #1)[2byte] -> %x1
-78a36841 : ldrsh  x1, [x2,x3]             : ldrsh  (%x2,%x3)[2byte] -> %x1
-78a37841 : ldrsh  x1, [x2,x3,lsl #1]      : ldrsh  (%x2,%x3,uxtx #1)[2byte] -> %x1
-78a3c841 : ldrsh  x1, [x2,w3,sxtw]        : ldrsh  (%x2,%x3,sxtw)[2byte] -> %x1
-78a3d841 : ldrsh  x1, [x2,w3,sxtw #1]     : ldrsh  (%x2,%x3,sxtw #1)[2byte] -> %x1
-78a3e841 : ldrsh  x1, [x2,x3,sxtx]        : ldrsh  (%x2,%x3,sxtx)[2byte] -> %x1
-78a3f841 : ldrsh  x1, [x2,x3,sxtx #1]     : ldrsh  (%x2,%x3,sxtx #1)[2byte] -> %x1
-78a80041 : ldaddah w8, w1, [x2]           : ldaddah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78a81041 : ldclrah w8, w1, [x2]           : ldclrah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78a82041 : ldeorah w8, w1, [x2]           : ldeorah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78a83041 : ldsetah w8, w1, [x2]           : ldsetah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78a84041 : ldsmaxah w8, w1, [x2]          : ldsmaxah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78a85041 : ldsminah w8, w1, [x2]          : ldsminah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78a86041 : ldumaxah w8, w1, [x2]          : ldumaxah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78a87041 : lduminah w8, w1, [x2]          : lduminah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78a88041 : swpah  w8, w1, [x2]            : swpah  %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78bf03ff : ldaddah wzr, wzr, [sp]         : ldaddah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78bf13ff : ldclrah wzr, wzr, [sp]         : ldclrah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78bf23ff : ldeorah wzr, wzr, [sp]         : ldeorah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78bf33ff : ldsetah wzr, wzr, [sp]         : ldsetah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78bf43ff : ldsmaxah wzr, wzr, [sp]        : ldsmaxah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78bf4bff : ldrsh  xzr, [sp,wzr,uxtw]      : ldrsh  (%sp,%xzr,uxtw)[2byte] -> %xzr
-78bf53ff : ldsminah wzr, wzr, [sp]        : ldsminah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78bf5bff : ldrsh  xzr, [sp,wzr,uxtw #1]   : ldrsh  (%sp,%xzr,uxtw #1)[2byte] -> %xzr
-78bf63ff : ldumaxah wzr, wzr, [sp]        : ldumaxah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78bf6bff : ldrsh  xzr, [sp,xzr]           : ldrsh  (%sp,%xzr)[2byte] -> %xzr
-78bf73ff : lduminah wzr, wzr, [sp]        : lduminah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78bf7bff : ldrsh  xzr, [sp,xzr,lsl #1]    : ldrsh  (%sp,%xzr,uxtx #1)[2byte] -> %xzr
-78bf83ff : swpah  wzr, wzr, [sp]          : swpah  %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78bfcbff : ldrsh  xzr, [sp,wzr,sxtw]      : ldrsh  (%sp,%xzr,sxtw)[2byte] -> %xzr
-78bfdbff : ldrsh  xzr, [sp,wzr,sxtw #1]   : ldrsh  (%sp,%xzr,sxtw #1)[2byte] -> %xzr
-78bfebff : ldrsh  xzr, [sp,xzr,sxtx]      : ldrsh  (%sp,%xzr,sxtx)[2byte] -> %xzr
-78bffbff : ldrsh  xzr, [sp,xzr,sxtx #1]   : ldrsh  (%sp,%xzr,sxtx #1)[2byte] -> %xzr
-78c00400 : ldrsh  w0, [x0],#0             : ldrsh  (%x0)[2byte] %x0 $0x0000000000000000 -> %w0 %x0
-78c00c00 : ldrsh  w0, [x0,#0]!            : ldrsh  (%x0)[2byte] %x0 $0x0000000000000000 -> %w0 %x0
-78c81041 : ldursh w1, [x2,#129]           : ldursh +0x81(%x2)[2byte] -> %w1
-78c81441 : ldrsh  w1, [x2],#129           : ldrsh  (%x2)[2byte] %x2 $0x0000000000000081 -> %w1 %x2
-78c81841 : ldtrsh w1, [x2,#129]           : ldtrsh +0x81(%x2)[2byte] -> %w1
-78c81c41 : ldrsh  w1, [x2,#129]!          : ldrsh  +0x81(%x2)[2byte] %x2 $0x0000000000000081 -> %w1 %x2
-78dff3ff : ldursh wzr, [sp,#-1]           : ldursh -0x01(%sp)[2byte] -> %wzr
-78dff7ff : ldrsh  wzr, [sp],#-1           : ldrsh  (%sp)[2byte] %sp $0xffffffffffffffff -> %wzr %sp
-78dffbff : ldtrsh wzr, [sp,#-1]           : ldtrsh -0x01(%sp)[2byte] -> %wzr
-78dfffff : ldrsh  wzr, [sp,#-1]!          : ldrsh  -0x01(%sp)[2byte] %sp $0xffffffffffffffff -> %wzr %sp
-78e34841 : ldrsh  w1, [x2,w3,uxtw]        : ldrsh  (%x2,%x3,uxtw)[2byte] -> %w1
-78e35841 : ldrsh  w1, [x2,w3,uxtw #1]     : ldrsh  (%x2,%x3,uxtw #1)[2byte] -> %w1
-78e36841 : ldrsh  w1, [x2,x3]             : ldrsh  (%x2,%x3)[2byte] -> %w1
-78e37841 : ldrsh  w1, [x2,x3,lsl #1]      : ldrsh  (%x2,%x3,uxtx #1)[2byte] -> %w1
-78e3c841 : ldrsh  w1, [x2,w3,sxtw]        : ldrsh  (%x2,%x3,sxtw)[2byte] -> %w1
-78e3d841 : ldrsh  w1, [x2,w3,sxtw #1]     : ldrsh  (%x2,%x3,sxtw #1)[2byte] -> %w1
-78e3e841 : ldrsh  w1, [x2,x3,sxtx]        : ldrsh  (%x2,%x3,sxtx)[2byte] -> %w1
-78e3f841 : ldrsh  w1, [x2,x3,sxtx #1]     : ldrsh  (%x2,%x3,sxtx #1)[2byte] -> %w1
-78e80041 : ldaddalh w8, w1, [x2]          : ldaddalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78e81041 : ldclralh w8, w1, [x2]          : ldclralh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78e82041 : ldeoralh w8, w1, [x2]          : ldeoralh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78e83041 : ldsetalh w8, w1, [x2]          : ldsetalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78e84041 : ldsmaxalh w8, w1, [x2]         : ldsmaxalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78e85041 : ldsminalh w8, w1, [x2]         : ldsminalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78e86041 : ldumaxalh w8, w1, [x2]         : ldumaxalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78e87041 : lduminalh w8, w1, [x2]         : lduminalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78e88041 : swpalh w8, w1, [x2]            : swpalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
-78ff03ff : ldaddalh wzr, wzr, [sp]        : ldaddalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78ff13ff : ldclralh wzr, wzr, [sp]        : ldclralh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78ff23ff : ldeoralh wzr, wzr, [sp]        : ldeoralh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78ff33ff : ldsetalh wzr, wzr, [sp]        : ldsetalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78ff43ff : ldsmaxalh wzr, wzr, [sp]       : ldsmaxalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78ff4bff : ldrsh  wzr, [sp,wzr,uxtw]      : ldrsh  (%sp,%xzr,uxtw)[2byte] -> %wzr
-78ff53ff : ldsminalh wzr, wzr, [sp]       : ldsminalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78ff5bff : ldrsh  wzr, [sp,wzr,uxtw #1]   : ldrsh  (%sp,%xzr,uxtw #1)[2byte] -> %wzr
-78ff63ff : ldumaxalh wzr, wzr, [sp]       : ldumaxalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78ff6bff : ldrsh  wzr, [sp,xzr]           : ldrsh  (%sp,%xzr)[2byte] -> %wzr
-78ff73ff : lduminalh wzr, wzr, [sp]       : lduminalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78ff7bff : ldrsh  wzr, [sp,xzr,lsl #1]    : ldrsh  (%sp,%xzr,uxtx #1)[2byte] -> %wzr
-78ff83ff : swpalh wzr, wzr, [sp]          : swpalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
-78ffcbff : ldrsh  wzr, [sp,wzr,sxtw]      : ldrsh  (%sp,%xzr,sxtw)[2byte] -> %wzr
-78ffdbff : ldrsh  wzr, [sp,wzr,sxtw #1]   : ldrsh  (%sp,%xzr,sxtw #1)[2byte] -> %wzr
-78ffebff : ldrsh  wzr, [sp,xzr,sxtx]      : ldrsh  (%sp,%xzr,sxtx)[2byte] -> %wzr
-78fffbff : ldrsh  wzr, [sp,xzr,sxtx #1]   : ldrsh  (%sp,%xzr,sxtx #1)[2byte] -> %wzr
-79081041 : strh   w1, [x2,#1032]          : strh   %w1 -> +0x0408(%x2)[2byte]
-793fffff : strh   wzr, [sp,#8190]         : strh   %wzr -> +0x1ffe(%sp)[2byte]
-79481041 : ldrh   w1, [x2,#1032]          : ldrh   +0x0408(%x2)[2byte] -> %w1
-797fffff : ldrh   wzr, [sp,#8190]         : ldrh   +0x1ffe(%sp)[2byte] -> %wzr
-79881041 : ldrsh  x1, [x2,#1032]          : ldrsh  +0x0408(%x2)[2byte] -> %x1
-79bfffff : ldrsh  xzr, [sp,#8190]         : ldrsh  +0x1ffe(%sp)[2byte] -> %xzr
-79c81041 : ldrsh  w1, [x2,#1032]          : ldrsh  +0x0408(%x2)[2byte] -> %w1
-79ffffff : ldrsh  wzr, [sp,#8190]         : ldrsh  +0x1ffe(%sp)[2byte] -> %wzr
-7a030041 : sbcs   w1, w2, w3              : sbcs   %w2 %w3 -> %w1
-7a42e3e1 : ccmp   wzr, w2, #0x1, al       : ccmp   %wzr %w2 $0x01 al
-7a4aebe1 : ccmp   wzr, #0xa, #0x1, al     : ccmp   %wzr $0x0a $0x01 al
-7c000400 : str    h0, [x0],#0             : str    %h0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
-7c000c00 : str    h0, [x0,#0]!            : str    %h0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
-7c081041 : stur   h1, [x2,#129]           : stur   %h1 -> +0x81(%x2)[2byte]
-7c081441 : str    h1, [x2],#129           : str    %h1 %x2 $0x0000000000000081 -> (%x2)[2byte] %x2
-7c081c41 : str    h1, [x2,#129]!          : str    %h1 %x2 $0x0000000000000081 -> +0x81(%x2)[2byte] %x2
-7c1ff3ff : stur   h31, [sp,#-1]           : stur   %h31 -> -0x01(%sp)[2byte]
-7c1ff7ff : str    h31, [sp],#-1           : str    %h31 %sp $0xffffffffffffffff -> (%sp)[2byte] %sp
-7c1fffff : str    h31, [sp,#-1]!          : str    %h31 %sp $0xffffffffffffffff -> -0x01(%sp)[2byte] %sp
-7c234841 : str    h1, [x2,w3,uxtw]        : str    %h1 -> (%x2,%x3,uxtw)[2byte]
-7c235841 : str    h1, [x2,w3,uxtw #1]     : str    %h1 -> (%x2,%x3,uxtw #1)[2byte]
-7c236841 : str    h1, [x2,x3]             : str    %h1 -> (%x2,%x3)[2byte]
-7c237841 : str    h1, [x2,x3,lsl #1]      : str    %h1 -> (%x2,%x3,uxtx #1)[2byte]
-7c23c841 : str    h1, [x2,w3,sxtw]        : str    %h1 -> (%x2,%x3,sxtw)[2byte]
-7c23d841 : str    h1, [x2,w3,sxtw #1]     : str    %h1 -> (%x2,%x3,sxtw #1)[2byte]
-7c23e841 : str    h1, [x2,x3,sxtx]        : str    %h1 -> (%x2,%x3,sxtx)[2byte]
-7c23f841 : str    h1, [x2,x3,sxtx #1]     : str    %h1 -> (%x2,%x3,sxtx #1)[2byte]
-7c3f4bff : str    h31, [sp,wzr,uxtw]      : str    %h31 -> (%sp,%xzr,uxtw)[2byte]
-7c3f5bff : str    h31, [sp,wzr,uxtw #1]   : str    %h31 -> (%sp,%xzr,uxtw #1)[2byte]
-7c3f6bff : str    h31, [sp,xzr]           : str    %h31 -> (%sp,%xzr)[2byte]
-7c3f7bff : str    h31, [sp,xzr,lsl #1]    : str    %h31 -> (%sp,%xzr,uxtx #1)[2byte]
-7c3fcbff : str    h31, [sp,wzr,sxtw]      : str    %h31 -> (%sp,%xzr,sxtw)[2byte]
-7c3fdbff : str    h31, [sp,wzr,sxtw #1]   : str    %h31 -> (%sp,%xzr,sxtw #1)[2byte]
-7c3febff : str    h31, [sp,xzr,sxtx]      : str    %h31 -> (%sp,%xzr,sxtx)[2byte]
-7c3ffbff : str    h31, [sp,xzr,sxtx #1]   : str    %h31 -> (%sp,%xzr,sxtx #1)[2byte]
-7c400400 : ldr    h0, [x0],#0             : ldr    (%x0)[2byte] %x0 $0x0000000000000000 -> %h0 %x0
-7c400c00 : ldr    h0, [x0,#0]!            : ldr    (%x0)[2byte] %x0 $0x0000000000000000 -> %h0 %x0
-7c481041 : ldur   h1, [x2,#129]           : ldur   +0x81(%x2)[2byte] -> %h1
-7c481441 : ldr    h1, [x2],#129           : ldr    (%x2)[2byte] %x2 $0x0000000000000081 -> %h1 %x2
-7c481c41 : ldr    h1, [x2,#129]!          : ldr    +0x81(%x2)[2byte] %x2 $0x0000000000000081 -> %h1 %x2
-7c5ff3ff : ldur   h31, [sp,#-1]           : ldur   -0x01(%sp)[2byte] -> %h31
-7c5ff7ff : ldr    h31, [sp],#-1           : ldr    (%sp)[2byte] %sp $0xffffffffffffffff -> %h31 %sp
-7c5fffff : ldr    h31, [sp,#-1]!          : ldr    -0x01(%sp)[2byte] %sp $0xffffffffffffffff -> %h31 %sp
-7c634841 : ldr    h1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[2byte] -> %h1
-7c635841 : ldr    h1, [x2,w3,uxtw #1]     : ldr    (%x2,%x3,uxtw #1)[2byte] -> %h1
-7c636841 : ldr    h1, [x2,x3]             : ldr    (%x2,%x3)[2byte] -> %h1
-7c637841 : ldr    h1, [x2,x3,lsl #1]      : ldr    (%x2,%x3,uxtx #1)[2byte] -> %h1
-7c63c841 : ldr    h1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[2byte] -> %h1
-7c63d841 : ldr    h1, [x2,w3,sxtw #1]     : ldr    (%x2,%x3,sxtw #1)[2byte] -> %h1
-7c63e841 : ldr    h1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[2byte] -> %h1
-7c63f841 : ldr    h1, [x2,x3,sxtx #1]     : ldr    (%x2,%x3,sxtx #1)[2byte] -> %h1
-7c7f4bff : ldr    h31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[2byte] -> %h31
-7c7f5bff : ldr    h31, [sp,wzr,uxtw #1]   : ldr    (%sp,%xzr,uxtw #1)[2byte] -> %h31
-7c7f6bff : ldr    h31, [sp,xzr]           : ldr    (%sp,%xzr)[2byte] -> %h31
-7c7f7bff : ldr    h31, [sp,xzr,lsl #1]    : ldr    (%sp,%xzr,uxtx #1)[2byte] -> %h31
-7c7fcbff : ldr    h31, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[2byte] -> %h31
-7c7fdbff : ldr    h31, [sp,wzr,sxtw #1]   : ldr    (%sp,%xzr,sxtw #1)[2byte] -> %h31
-7c7febff : ldr    h31, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[2byte] -> %h31
-7c7ffbff : ldr    h31, [sp,xzr,sxtx #1]   : ldr    (%sp,%xzr,sxtx #1)[2byte] -> %h31
-7d081041 : str    h1, [x2,#1032]          : str    %h1 -> +0x0408(%x2)[2byte]
-7d3fffff : str    h31, [sp,#8190]         : str    %h31 -> +0x1ffe(%sp)[2byte]
-7d481041 : ldr    h1, [x2,#1032]          : ldr    +0x0408(%x2)[2byte] -> %h1
-7d7fffff : ldr    h31, [sp,#8190]         : ldr    +0x1ffe(%sp)[2byte] -> %h31
-88081041 : stxr   w8, w1, [x2]            : stxr   %w1 $0x04 -> (%x2)[4byte] %w8
-88089041 : stlxr  w8, w1, [x2]            : stlxr  %w1 $0x04 -> (%x2)[4byte] %w8
-881f7fff : stxr   wzr, wzr, [sp]          : stxr   %wzr $0x1f -> (%sp)[4byte] %wzr
-881fffff : stlxr  wzr, wzr, [sp]          : stlxr  %wzr $0x1f -> (%sp)[4byte] %wzr
-88281041 : stxp   w8, w1, w4, [x2]        : stxp   %w1 %w4 -> (%x2)[8byte] %w8
-88289041 : stlxp  w8, w1, w4, [x2]        : stlxp  %w1 %w4 -> (%x2)[8byte] %w8
-883f7fff : stxp   wzr, wzr, wzr, [sp]     : stxp   %wzr %wzr -> (%sp)[8byte] %wzr
-883fffff : stlxp  wzr, wzr, wzr, [sp]     : stlxp  %wzr %wzr -> (%sp)[8byte] %wzr
-88481041 : ldxr   w1, [x2]                : ldxr   (%x2)[4byte] $0x04 $0x08 -> %w1
-88489041 : ldaxr  w1, [x2]                : ldaxr  (%x2)[4byte] $0x04 $0x08 -> %w1
-885f7fff : ldxr   wzr, [sp]               : ldxr   (%sp)[4byte] $0x1f $0x1f -> %wzr
-885fffff : ldaxr  wzr, [sp]               : ldaxr  (%sp)[4byte] $0x1f $0x1f -> %wzr
-88681041 : ldxp   w1, w4, [x2]            : ldxp   (%x2)[8byte] $0x08 -> %w1 %w4
-88689041 : ldaxp  w1, w4, [x2]            : ldaxp  (%x2)[8byte] $0x08 -> %w1 %w4
-887f7fff : ldxp   wzr, wzr, [sp]          : ldxp   (%sp)[8byte] $0x1f -> %wzr %wzr
-887fffff : ldaxp  wzr, wzr, [sp]          : ldaxp  (%sp)[8byte] $0x1f -> %wzr %wzr
-88889041 : stlr   w1, [x2]                : stlr   %w1 $0x04 $0x08 -> (%x2)[4byte]
-889fffff : stlr   wzr, [sp]               : stlr   %wzr $0x1f $0x1f -> (%sp)[4byte]
-88a87c41 : cas    w8, w1, [x2]            : cas    %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
-88a8fc41 : casl   w8, w1, [x2]            : casl   %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
-88bf7fff : cas    wzr, wzr, [sp]          : cas    %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-88bfffff : casl   wzr, wzr, [sp]          : casl   %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-88dfffff : ldar   wzr, [sp]               : ldar   (%sp)[4byte] -> %wzr
-88e87c41 : casa   w8, w1, [x2]            : casa   %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
-88e8fc41 : casal  w8, w1, [x2]            : casal  %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
-88ff7fff : casa   wzr, wzr, [sp]          : casa   %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-88ffffff : casal  wzr, wzr, [sp]          : casal  %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-8a1fffff : and    xzr, xzr, xzr, lsl #63  : and    %xzr %xzr lsl $0x3f -> %xzr
-8a431041 : and    x1, x2, x3, lsr #4      : and    %x2 %x3 lsr $0x04 -> %x1
-8a631041 : bic    x1, x2, x3, lsr #4      : bic    %x2 %x3 lsr $0x04 -> %x1
-8adf13ff : and    xzr, xzr, xzr, ror #4   : and    %xzr %xzr ror $0x04 -> %xzr
-8aff13ff : bic    xzr, xzr, xzr, ror #4   : bic    %xzr %xzr ror $0x04 -> %xzr
 8b3f27ff : add    sp, sp, wzr, uxth #1    : add    %sp %xzr uxth $0x01 -> %sp
 8b431041 : add    x1, x2, x3, lsr #4      : add    %x2 %x3 lsr $0x04 -> %x1
 8b5fffff : add    xzr, xzr, xzr, lsr #63  : add    %xzr %xzr lsr $0x3f -> %xzr
 8b9f13ff : add    xzr, xzr, xzr, asr #4   : add    %xzr %xzr asr $0x04 -> %xzr
-90081041 : adrp   x1, 20208000            : adrp   <rel> 0x0000000020208000 -> %x1
-90800000 : adrp   x0, ffffffff10000000    : adrp   <rel> 0xffffffff10000000 -> %x0
 91000c41 : add    x1, x2, #0x3            : add    %x2 $0x0003 lsl $0x00 -> %x1
 91000fff : add    sp, sp, #0x3            : add    %sp $0x0003 lsl $0x00 -> %sp
-9201f041 : and    x1, x2, #0xaaaaaaaaaaaaaaaa: and    %x2 $0xaaaaaaaaaaaaaaaa -> %x1
-923ff041 : and    x1, x2, #0xaaaaaaaaaaaaaaaa: and    %x2 $0xaaaaaaaaaaaaaaaa $0x0ffc -> %x1
-92400441 : and    x1, x2, #0x3            : and    %x2 $0x0000000000000003 -> %x1
-92ffffff : mov    xzr, #0xffffffffffff    : movn   $0xffff lsl $0x30 -> %xzr
-93431041 : sbfx   x1, x2, #3, #2          : sbfm   %x2 $0x03 $0x04 -> %x1
-937fffff : asr    xzr, xzr, #63           : sbfm   %xzr $0x3f $0x3f -> %xzr
-93c31041 : extr   x1, x2, x3, #4          : extr   %x2 %x3 $0x04 -> %x1
-93dfffff : ror    xzr, xzr, #63           : extr   %xzr %xzr $0x3f -> %xzr
-94081041 : bl     10204104                : bl     $0x0000000010204104 -> %x30
-96000000 : bl     8000000                 : bl     $0x0000000008000000 -> %x30
-97ffffff : bl     ffffffc                 : bl     $0x000000000ffffffc -> %x30
-98081041 : ldrsw  x1, 10010208            : ldrsw  <rel> 0x0000000010010208[4byte] -> %x1
-987fffff : ldrsw  xzr, 100ffffc           : ldrsw  <rel> 0x00000000100ffffc[4byte] -> %xzr
-98800000 : ldrsw  x0, ff00000             : ldrsw  <rel> 0x000000000ff00000[4byte] -> %x0
-98ffffff : ldrsw  xzr, ffffffc            : ldrsw  <rel> 0x000000000ffffffc[4byte] -> %xzr
-9a1f03ff : adc    xzr, xzr, xzr           : adc    %xzr %xzr -> %xzr
-9a830041 : csel   x1, x2, x3, eq          : csel   %x2 %x3 eq -> %x1
-9ac30841 : udiv   x1, x2, x3              : udiv   %x2 %x3 -> %x1
-9ac32841 : asr    x1, x2, x3              : asrv   %x2 %x3 -> %x1
-9ac34c41 : crc32x w1, w2, x3              : crc32x %w2 %x3 -> %w1
-9ac35c41 : crc32cx w1, w2, x3             : crc32cx %w2 %x3 -> %w1
-9adf2441 : lsr    x1, x2, xzr             : lsrv   %x2 %xzr -> %x1
-9b0313e1 : madd   x1, xzr, x3, x4         : madd   %xzr %x3 %x4 -> %x1
-9b03905f : msub   xzr, x2, x3, x4         : msub   %x2 %x3 %x4 -> %xzr
-9b23fc41 : smnegl x1, w2, w3              : smsubl %w2 %w3 %xzr -> %x1
-9b3f1041 : smaddl x1, w2, wzr, x4         : smaddl %w2 %wzr %x4 -> %x1
-9b4313e1 : smulh  x1, xzr, x3             : smulh  %xzr %x3 $0x04 -> %x1
-9ba3105f : umaddl xzr, w2, w3, x4         : umaddl %w2 %w3 %x4 -> %xzr
-9ba39041 : umsubl x1, w2, w3, x4          : umsubl %w2 %w3 %x4 -> %x1
-9bc31041 : umulh  x1, x2, x3              : umulh  %x2 %x3 $0x04 -> %x1
-9c7fffff : ldr    q31, 100ffffc           : ldr    <rel> 0x00000000100ffffc[16byte] -> %q31
-9c800000 : ldr    q0, ff00000             : ldr    <rel> 0x000000000ff00000[16byte] -> %q0
-a8000000 : stnp   x0, x0, [x0]            : stnp   %x0 %x0 -> (%x0)[16byte]
-a83fffff : stnp   xzr, xzr, [sp,#-8]      : stnp   %xzr %xzr -> -0x08(%sp)[16byte]
-a8400000 : ldnp   x0, x0, [x0]            : ldnp   (%x0)[16byte] -> %x0 %x0
-a87fffff : ldnp   xzr, xzr, [sp,#-8]      : ldnp   -0x08(%sp)[16byte] -> %xzr %xzr
-a8800000 : stp    x0, x0, [x0],#0         : stp    %x0 %x0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
-a8bfffff : stp    xzr, xzr, [sp],#-8      : stp    %xzr %xzr %sp $0xfffffffffffffff8 -> (%sp)[16byte] %sp
-a8c00000 : ldp    x0, x0, [x0],#0         : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
-a8ffffff : ldp    xzr, xzr, [sp],#-8      : ldp    (%sp)[16byte] %sp $0xfffffffffffffff8 -> %xzr %xzr %sp
-a9000000 : stp    x0, x0, [x0]            : stp    %x0 %x0 -> (%x0)[16byte]
-a93fffff : stp    xzr, xzr, [sp,#-8]      : stp    %xzr %xzr -> -0x08(%sp)[16byte]
-a9400000 : ldp    x0, x0, [x0]            : ldp    (%x0)[16byte] -> %x0 %x0
-a97fffff : ldp    xzr, xzr, [sp,#-8]      : ldp    -0x08(%sp)[16byte] -> %xzr %xzr
-a9800000 : stp    x0, x0, [x0,#0]!        : stp    %x0 %x0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
-a9bfffff : stp    xzr, xzr, [sp,#-8]!     : stp    %xzr %xzr %sp $0xfffffffffffffff8 -> -0x08(%sp)[16byte] %sp
-a9c00000 : ldp    x0, x0, [x0,#0]!        : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
-a9ffffff : ldp    xzr, xzr, [sp,#-8]!     : ldp    -0x08(%sp)[16byte] %sp $0xfffffffffffffff8 -> %xzr %xzr %sp
-aa431041 : orr    x1, x2, x3, lsr #4      : orr    %x2 %x3 lsr $0x04 -> %x1
-aa631041 : orn    x1, x2, x3, lsr #4      : orn    %x2 %x3 lsr $0x04 -> %x1
-aadf13ff : mov    xzr, xzr                : orr    %xzr %xzr ror $0x04 -> %xzr
-aaff13ff : mvn    xzr, xzr, ror #4        : orn    %xzr %xzr ror $0x04 -> %xzr
-aaffffff : mvn    xzr, xzr, ror #63       : orn    %xzr %xzr ror $0x3f -> %xzr
-ab431041 : adds   x1, x2, x3, lsr #4      : adds   %x2 %x3 lsr $0x04 -> %x1
-ab9f13ff : cmn    xzr, xzr, asr #4        : adds   %xzr %xzr asr $0x04 -> %xzr
-ab9fffff : cmn    xzr, xzr, asr #63       : adds   %xzr %xzr asr $0x3f -> %xzr
-ac000000 : stnp   q0, q0, [x0]            : stnp   %q0 %q0 -> (%x0)[32byte]
-ac3fffff : stnp   q31, q31, [sp,#-16]     : stnp   %q31 %q31 -> -0x10(%sp)[32byte]
-ac400000 : ldnp   q0, q0, [x0]            : ldnp   (%x0)[32byte] -> %q0 %q0
-ac7fffff : ldnp   q31, q31, [sp,#-16]     : ldnp   -0x10(%sp)[32byte] -> %q31 %q31
-ac800000 : stp    q0, q0, [x0],#0         : stp    %q0 %q0 %x0 $0x0000000000000000 -> (%x0)[32byte] %x0
-acbfffff : stp    q31, q31, [sp],#-16     : stp    %q31 %q31 %sp $0xfffffffffffffff0 -> (%sp)[32byte] %sp
-acc00000 : ldp    q0, q0, [x0],#0         : ldp    (%x0)[32byte] %x0 $0x0000000000000000 -> %q0 %q0 %x0
-acffffff : ldp    q31, q31, [sp],#-16     : ldp    (%sp)[32byte] %sp $0xfffffffffffffff0 -> %q31 %q31 %sp
-ad000000 : stp    q0, q0, [x0]            : stp    %q0 %q0 -> (%x0)[32byte]
-ad3fffff : stp    q31, q31, [sp,#-16]     : stp    %q31 %q31 -> -0x10(%sp)[32byte]
-ad400000 : ldp    q0, q0, [x0]            : ldp    (%x0)[32byte] -> %q0 %q0
-ad7fffff : ldp    q31, q31, [sp,#-16]     : ldp    -0x10(%sp)[32byte] -> %q31 %q31
-ad800000 : stp    q0, q0, [x0,#0]!        : stp    %q0 %q0 %x0 $0x0000000000000000 -> (%x0)[32byte] %x0
-adbfffff : stp    q31, q31, [sp,#-16]!    : stp    %q31 %q31 %sp $0xfffffffffffffff0 -> -0x10(%sp)[32byte] %sp
-adc00000 : ldp    q0, q0, [x0,#0]!        : ldp    (%x0)[32byte] %x0 $0x0000000000000000 -> %q0 %q0 %x0
-adffffff : ldp    q31, q31, [sp,#-16]!    : ldp    -0x10(%sp)[32byte] %sp $0xfffffffffffffff0 -> %q31 %q31 %sp
-b1000c41 : adds   x1, x2, #0x3            : adds   %x2 $0x0003 lsl $0x00 -> %x1
-b1000fff : cmn    sp, #0x3                : adds   %sp $0x0003 lsl $0x00 -> %xzr
-b2400441 : orr    x1, x2, #0x3            : orr    %x2 $0x0000000000000003 -> %x1
-b3431041 : bfxil  x1, x2, #3, #2          : bfm    %x1 %x2 $0x03 $0x04 -> %x1
-b37fffff : bfxil  xzr, xzr, #63, #1       : bfm    %xzr %xzr $0x3f $0x3f -> %xzr
-b4ffffff : cbz    xzr, ffffffc            : cbz    $0x000000000ffffffc %xzr
-b5800000 : cbnz   x0, ff00000             : cbnz   $0x000000000ff00000 %x0
-b5ffffff : cbnz   xzr, ffffffc            : cbnz   $0x000000000ffffffc %xzr
-b6ffffff : tbz    xzr, #63, ffffffc       : tbz    $0x000000000ffffffc %xzr $0x3f
-b7fc0000 : tbnz   x0, #63, fff8000        : tbnz   $0x000000000fff8000 %x0 $0x3f
-b7ffffff : tbnz   xzr, #63, ffffffc       : tbnz   $0x000000000ffffffc %xzr $0x3f
-b8000400 : str    w0, [x0],#0             : str    %w0 %x0 $0x0000000000000000 -> (%x0)[4byte] %x0
-b8000c00 : str    w0, [x0,#0]!            : str    %w0 %x0 $0x0000000000000000 -> (%x0)[4byte] %x0
-b8081041 : stur   w1, [x2,#129]           : stur   %w1 -> +0x81(%x2)[4byte]
-b8081441 : str    w1, [x2],#129           : str    %w1 %x2 $0x0000000000000081 -> (%x2)[4byte] %x2
-b8081841 : sttr   w1, [x2,#129]           : sttr   %w1 -> +0x81(%x2)[4byte]
-b8081c41 : str    w1, [x2,#129]!          : str    %w1 %x2 $0x0000000000000081 -> +0x81(%x2)[4byte] %x2
-b81ff3ff : stur   wzr, [sp,#-1]           : stur   %wzr -> -0x01(%sp)[4byte]
-b81ff7ff : str    wzr, [sp],#-1           : str    %wzr %sp $0xffffffffffffffff -> (%sp)[4byte] %sp
-b81ffbff : sttr   wzr, [sp,#-1]           : sttr   %wzr -> -0x01(%sp)[4byte]
-b81fffff : str    wzr, [sp,#-1]!          : str    %wzr %sp $0xffffffffffffffff -> -0x01(%sp)[4byte] %sp
-b8234841 : str    w1, [x2,w3,uxtw]        : str    %w1 -> (%x2,%x3,uxtw)[4byte]
-b8235841 : str    w1, [x2,w3,uxtw #2]     : str    %w1 -> (%x2,%x3,uxtw #2)[4byte]
-b8236841 : str    w1, [x2,x3]             : str    %w1 -> (%x2,%x3)[4byte]
-b8237841 : str    w1, [x2,x3,lsl #2]      : str    %w1 -> (%x2,%x3,uxtx #2)[4byte]
-b823c841 : str    w1, [x2,w3,sxtw]        : str    %w1 -> (%x2,%x3,sxtw)[4byte]
-b823d841 : str    w1, [x2,w3,sxtw #2]     : str    %w1 -> (%x2,%x3,sxtw #2)[4byte]
-b823e841 : str    w1, [x2,x3,sxtx]        : str    %w1 -> (%x2,%x3,sxtx)[4byte]
-b823f841 : str    w1, [x2,x3,sxtx #2]     : str    %w1 -> (%x2,%x3,sxtx #2)[4byte]
-b8280041 : ldadd  w8, w1, [x2]            : ldadd  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8281041 : ldclr  w8, w1, [x2]            : ldclr  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8282041 : ldeor  w8, w1, [x2]            : ldeor  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8283041 : ldset  w8, w1, [x2]            : ldset  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8284041 : ldsmax w8, w1, [x2]            : ldsmax %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8285041 : ldsmin w8, w1, [x2]            : ldsmin %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8286041 : ldumax w8, w1, [x2]            : ldumax %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8287041 : ldumin w8, w1, [x2]            : ldumin %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8288041 : swp    w8, w1, [x2]            : swp    %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b83f03ff : stadd  wzr, [sp]               : ldadd  %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b83f13ff : stclr  wzr, [sp]               : ldclr  %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b83f23ff : steor  wzr, [sp]               : ldeor  %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b83f33ff : stset  wzr, [sp]               : ldset  %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b83f43ff : stsmax wzr, [sp]               : ldsmax %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b83f4bff : str    wzr, [sp,wzr,uxtw]      : str    %wzr -> (%sp,%xzr,uxtw)[4byte]
-b83f53ff : stsmin wzr, [sp]               : ldsmin %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b83f5bff : str    wzr, [sp,wzr,uxtw #2]   : str    %wzr -> (%sp,%xzr,uxtw #2)[4byte]
-b83f63ff : stumax wzr, [sp]               : ldumax %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b83f6bff : str    wzr, [sp,xzr]           : str    %wzr -> (%sp,%xzr)[4byte]
-b83f73ff : stumin wzr, [sp]               : ldumin %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b83f7bff : str    wzr, [sp,xzr,lsl #2]    : str    %wzr -> (%sp,%xzr,uxtx #2)[4byte]
-b83f83ff : swp    wzr, wzr, [sp]          : swp    %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b83fcbff : str    wzr, [sp,wzr,sxtw]      : str    %wzr -> (%sp,%xzr,sxtw)[4byte]
-b83fdbff : str    wzr, [sp,wzr,sxtw #2]   : str    %wzr -> (%sp,%xzr,sxtw #2)[4byte]
-b83febff : str    wzr, [sp,xzr,sxtx]      : str    %wzr -> (%sp,%xzr,sxtx)[4byte]
-b83ffbff : str    wzr, [sp,xzr,sxtx #2]   : str    %wzr -> (%sp,%xzr,sxtx #2)[4byte]
-b8400400 : ldr    w0, [x0],#0             : ldr    (%x0)[4byte] %x0 $0x0000000000000000 -> %w0 %x0
-b8400c00 : ldr    w0, [x0,#0]!            : ldr    (%x0)[4byte] %x0 $0x0000000000000000 -> %w0 %x0
-b8481041 : ldur   w1, [x2,#129]           : ldur   +0x81(%x2)[4byte] -> %w1
-b8481441 : ldr    w1, [x2],#129           : ldr    (%x2)[4byte] %x2 $0x0000000000000081 -> %w1 %x2
-b8481841 : ldtr   w1, [x2,#129]           : ldtr   +0x81(%x2)[4byte] -> %w1
-b8481c41 : ldr    w1, [x2,#129]!          : ldr    +0x81(%x2)[4byte] %x2 $0x0000000000000081 -> %w1 %x2
-b85ff3ff : ldur   wzr, [sp,#-1]           : ldur   -0x01(%sp)[4byte] -> %wzr
-b85ff7ff : ldr    wzr, [sp],#-1           : ldr    (%sp)[4byte] %sp $0xffffffffffffffff -> %wzr %sp
-b85ffbff : ldtr   wzr, [sp,#-1]           : ldtr   -0x01(%sp)[4byte] -> %wzr
-b85fffff : ldr    wzr, [sp,#-1]!          : ldr    -0x01(%sp)[4byte] %sp $0xffffffffffffffff -> %wzr %sp
-b8634841 : ldr    w1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[4byte] -> %w1
-b8635841 : ldr    w1, [x2,w3,uxtw #2]     : ldr    (%x2,%x3,uxtw #2)[4byte] -> %w1
-b8636841 : ldr    w1, [x2,x3]             : ldr    (%x2,%x3)[4byte] -> %w1
-b8637841 : ldr    w1, [x2,x3,lsl #2]      : ldr    (%x2,%x3,uxtx #2)[4byte] -> %w1
-b863c841 : ldr    w1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[4byte] -> %w1
-b863d841 : ldr    w1, [x2,w3,sxtw #2]     : ldr    (%x2,%x3,sxtw #2)[4byte] -> %w1
-b863e841 : ldr    w1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[4byte] -> %w1
-b863f841 : ldr    w1, [x2,x3,sxtx #2]     : ldr    (%x2,%x3,sxtx #2)[4byte] -> %w1
-b8680041 : ldaddl w8, w1, [x2]            : ldaddl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8681041 : ldclrl w8, w1, [x2]            : ldclrl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8682041 : ldeorl w8, w1, [x2]            : ldeorl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8683041 : ldsetl w8, w1, [x2]            : ldsetl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8684041 : ldsmaxl w8, w1, [x2]           : ldsmaxl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8685041 : ldsminl w8, w1, [x2]           : ldsminl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8686041 : ldumaxl w8, w1, [x2]           : ldumaxl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8687041 : lduminl w8, w1, [x2]           : lduminl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8688041 : swpl   w8, w1, [x2]            : swpl   %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b87f03ff : staddl wzr, [sp]               : ldaddl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b87f13ff : stclrl wzr, [sp]               : ldclrl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b87f23ff : steorl wzr, [sp]               : ldeorl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b87f33ff : stsetl wzr, [sp]               : ldsetl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b87f43ff : stsmaxl wzr, [sp]              : ldsmaxl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b87f4bff : ldr    wzr, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[4byte] -> %wzr
-b87f53ff : stsminl wzr, [sp]              : ldsminl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b87f5bff : ldr    wzr, [sp,wzr,uxtw #2]   : ldr    (%sp,%xzr,uxtw #2)[4byte] -> %wzr
-b87f63ff : stumaxl wzr, [sp]              : ldumaxl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b87f6bff : ldr    wzr, [sp,xzr]           : ldr    (%sp,%xzr)[4byte] -> %wzr
-b87f73ff : stuminl wzr, [sp]              : lduminl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b87f7bff : ldr    wzr, [sp,xzr,lsl #2]    : ldr    (%sp,%xzr,uxtx #2)[4byte] -> %wzr
-b87f83ff : swpl   wzr, wzr, [sp]          : swpl   %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b87fcbff : ldr    wzr, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[4byte] -> %wzr
-b87fdbff : ldr    wzr, [sp,wzr,sxtw #2]   : ldr    (%sp,%xzr,sxtw #2)[4byte] -> %wzr
-b87febff : ldr    wzr, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[4byte] -> %wzr
-b87ffbff : ldr    wzr, [sp,xzr,sxtx #2]   : ldr    (%sp,%xzr,sxtx #2)[4byte] -> %wzr
-b8800400 : ldrsw  x0, [x0],#0             : ldrsw  (%x0)[4byte] %x0 $0x0000000000000000 -> %x0 %x0
-b8800c00 : ldrsw  x0, [x0,#0]!            : ldrsw  (%x0)[4byte] %x0 $0x0000000000000000 -> %x0 %x0
-b8881041 : ldursw x1, [x2,#129]           : ldursw +0x81(%x2)[4byte] -> %x1
-b8881441 : ldrsw  x1, [x2],#129           : ldrsw  (%x2)[4byte] %x2 $0x0000000000000081 -> %x1 %x2
-b8881841 : ldtrsw x1, [x2,#129]           : ldtrsw +0x81(%x2)[4byte] -> %x1
-b8881c41 : ldrsw  x1, [x2,#129]!          : ldrsw  +0x81(%x2)[4byte] %x2 $0x0000000000000081 -> %x1 %x2
-b89ff3ff : ldursw xzr, [sp,#-1]           : ldursw -0x01(%sp)[4byte] -> %xzr
-b89ff7ff : ldrsw  xzr, [sp],#-1           : ldrsw  (%sp)[4byte] %sp $0xffffffffffffffff -> %xzr %sp
-b89ffbff : ldtrsw xzr, [sp,#-1]           : ldtrsw -0x01(%sp)[4byte] -> %xzr
-b89fffff : ldrsw  xzr, [sp,#-1]!          : ldrsw  -0x01(%sp)[4byte] %sp $0xffffffffffffffff -> %xzr %sp
-b8a34841 : ldrsw  x1, [x2,w3,uxtw]        : ldrsw  (%x2,%x3,uxtw)[4byte] -> %x1
-b8a35841 : ldrsw  x1, [x2,w3,uxtw #2]     : ldrsw  (%x2,%x3,uxtw #2)[4byte] -> %x1
-b8a36841 : ldrsw  x1, [x2,x3]             : ldrsw  (%x2,%x3)[4byte] -> %x1
-b8a37841 : ldrsw  x1, [x2,x3,lsl #2]      : ldrsw  (%x2,%x3,uxtx #2)[4byte] -> %x1
-b8a3c841 : ldrsw  x1, [x2,w3,sxtw]        : ldrsw  (%x2,%x3,sxtw)[4byte] -> %x1
-b8a3d841 : ldrsw  x1, [x2,w3,sxtw #2]     : ldrsw  (%x2,%x3,sxtw #2)[4byte] -> %x1
-b8a3e841 : ldrsw  x1, [x2,x3,sxtx]        : ldrsw  (%x2,%x3,sxtx)[4byte] -> %x1
-b8a3f841 : ldrsw  x1, [x2,x3,sxtx #2]     : ldrsw  (%x2,%x3,sxtx #2)[4byte] -> %x1
-b8a80041 : ldadda w8, w1, [x2]            : ldadda %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8a81041 : ldclra w8, w1, [x2]            : ldclra %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8a82041 : ldeora w8, w1, [x2]            : ldeora %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8a83041 : ldseta w8, w1, [x2]            : ldseta %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8a84041 : ldsmaxa w8, w1, [x2]           : ldsmaxa %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8a85041 : ldsmina w8, w1, [x2]           : ldsmina %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8a86041 : ldumaxa w8, w1, [x2]           : ldumaxa %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8a87041 : ldumina w8, w1, [x2]           : ldumina %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8a88041 : swpa   w8, w1, [x2]            : swpa   %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8bf03ff : ldadda wzr, wzr, [sp]          : ldadda %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8bf13ff : ldclra wzr, wzr, [sp]          : ldclra %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8bf23ff : ldeora wzr, wzr, [sp]          : ldeora %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8bf33ff : ldseta wzr, wzr, [sp]          : ldseta %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8bf43ff : ldsmaxa wzr, wzr, [sp]         : ldsmaxa %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8bf4bff : ldrsw  xzr, [sp,wzr,uxtw]      : ldrsw  (%sp,%xzr,uxtw)[4byte] -> %xzr
-b8bf53ff : ldsmina wzr, wzr, [sp]         : ldsmina %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8bf5bff : ldrsw  xzr, [sp,wzr,uxtw #2]   : ldrsw  (%sp,%xzr,uxtw #2)[4byte] -> %xzr
-b8bf63ff : ldumaxa wzr, wzr, [sp]         : ldumaxa %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8bf6bff : ldrsw  xzr, [sp,xzr]           : ldrsw  (%sp,%xzr)[4byte] -> %xzr
-b8bf73ff : ldumina wzr, wzr, [sp]         : ldumina %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8bf7bff : ldrsw  xzr, [sp,xzr,lsl #2]    : ldrsw  (%sp,%xzr,uxtx #2)[4byte] -> %xzr
-b8bf83ff : swpa   wzr, wzr, [sp]          : swpa   %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8bfcbff : ldrsw  xzr, [sp,wzr,sxtw]      : ldrsw  (%sp,%xzr,sxtw)[4byte] -> %xzr
-b8bfdbff : ldrsw  xzr, [sp,wzr,sxtw #2]   : ldrsw  (%sp,%xzr,sxtw #2)[4byte] -> %xzr
-b8bfebff : ldrsw  xzr, [sp,xzr,sxtx]      : ldrsw  (%sp,%xzr,sxtx)[4byte] -> %xzr
-b8bffbff : ldrsw  xzr, [sp,xzr,sxtx #2]   : ldrsw  (%sp,%xzr,sxtx #2)[4byte] -> %xzr
-b8e80041 : ldaddal w8, w1, [x2]           : ldaddal %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8e81041 : ldclral w8, w1, [x2]           : ldclral %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8e82041 : ldeoral w8, w1, [x2]           : ldeoral %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8e83041 : ldsetal w8, w1, [x2]           : ldsetal %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8e84041 : ldsmaxal w8, w1, [x2]          : ldsmaxal %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8e85041 : ldsminal w8, w1, [x2]          : ldsminal %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8e86041 : ldumaxal w8, w1, [x2]          : ldumaxal %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8e87041 : lduminal w8, w1, [x2]          : lduminal %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8e88041 : swpal  w8, w1, [x2]            : swpal  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
-b8ff03ff : ldaddal wzr, wzr, [sp]         : ldaddal %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8ff13ff : ldclral wzr, wzr, [sp]         : ldclral %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8ff23ff : ldeoral wzr, wzr, [sp]         : ldeoral %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8ff33ff : ldsetal wzr, wzr, [sp]         : ldsetal %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8ff43ff : ldsmaxal wzr, wzr, [sp]        : ldsmaxal %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8ff53ff : ldsminal wzr, wzr, [sp]        : ldsminal %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8ff63ff : ldumaxal wzr, wzr, [sp]        : ldumaxal %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8ff73ff : lduminal wzr, wzr, [sp]        : lduminal %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b8ff83ff : swpal  wzr, wzr, [sp]          : swpal  %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
-b9081041 : str    w1, [x2,#2064]          : str    %w1 -> +0x0810(%x2)[4byte]
-b93fffff : str    wzr, [sp,#16380]        : str    %wzr -> +0x3ffc(%sp)[4byte]
-b9481041 : ldr    w1, [x2,#2064]          : ldr    +0x0810(%x2)[4byte] -> %w1
-b97fffff : ldr    wzr, [sp,#16380]        : ldr    +0x3ffc(%sp)[4byte] -> %wzr
-b9881041 : ldrsw  x1, [x2,#2064]          : ldrsw  +0x0810(%x2)[4byte] -> %x1
-b9bfffff : ldrsw  xzr, [sp,#16380]        : ldrsw  +0x3ffc(%sp)[4byte] -> %xzr
-ba030041 : adcs   x1, x2, x3              : adcs   %x2 %x3 -> %x1
-ba55d822 : ccmn   x1, #0x15, #0x2, le     : ccmn   %x1 $0x15 $0x02 le
-ba5fd022 : ccmn   x1, xzr, #0x2, le       : ccmn   %x1 %xzr $0x02 le
-bc000400 : str    s0, [x0],#0             : str    %s0 %x0 $0x0000000000000000 -> (%x0)[4byte] %x0
-bc000c00 : str    s0, [x0,#0]!            : str    %s0 %x0 $0x0000000000000000 -> (%x0)[4byte] %x0
-bc081041 : stur   s1, [x2,#129]           : stur   %s1 -> +0x81(%x2)[4byte]
-bc081441 : str    s1, [x2],#129           : str    %s1 %x2 $0x0000000000000081 -> (%x2)[4byte] %x2
-bc081c41 : str    s1, [x2,#129]!          : str    %s1 %x2 $0x0000000000000081 -> +0x81(%x2)[4byte] %x2
-bc1ff3ff : stur   s31, [sp,#-1]           : stur   %s31 -> -0x01(%sp)[4byte]
-bc1ff7ff : str    s31, [sp],#-1           : str    %s31 %sp $0xffffffffffffffff -> (%sp)[4byte] %sp
-bc1fffff : str    s31, [sp,#-1]!          : str    %s31 %sp $0xffffffffffffffff -> -0x01(%sp)[4byte] %sp
-bc234841 : str    s1, [x2,w3,uxtw]        : str    %s1 -> (%x2,%x3,uxtw)[4byte]
-bc235841 : str    s1, [x2,w3,uxtw #2]     : str    %s1 -> (%x2,%x3,uxtw #2)[4byte]
-bc236841 : str    s1, [x2,x3]             : str    %s1 -> (%x2,%x3)[4byte]
-bc237841 : str    s1, [x2,x3,lsl #2]      : str    %s1 -> (%x2,%x3,uxtx #2)[4byte]
-bc23c841 : str    s1, [x2,w3,sxtw]        : str    %s1 -> (%x2,%x3,sxtw)[4byte]
-bc23d841 : str    s1, [x2,w3,sxtw #2]     : str    %s1 -> (%x2,%x3,sxtw #2)[4byte]
-bc23e841 : str    s1, [x2,x3,sxtx]        : str    %s1 -> (%x2,%x3,sxtx)[4byte]
-bc23f841 : str    s1, [x2,x3,sxtx #2]     : str    %s1 -> (%x2,%x3,sxtx #2)[4byte]
-bc3f4bff : str    s31, [sp,wzr,uxtw]      : str    %s31 -> (%sp,%xzr,uxtw)[4byte]
-bc3f5bff : str    s31, [sp,wzr,uxtw #2]   : str    %s31 -> (%sp,%xzr,uxtw #2)[4byte]
-bc3f6bff : str    s31, [sp,xzr]           : str    %s31 -> (%sp,%xzr)[4byte]
-bc3f7bff : str    s31, [sp,xzr,lsl #2]    : str    %s31 -> (%sp,%xzr,uxtx #2)[4byte]
-bc3fcbff : str    s31, [sp,wzr,sxtw]      : str    %s31 -> (%sp,%xzr,sxtw)[4byte]
-bc3fdbff : str    s31, [sp,wzr,sxtw #2]   : str    %s31 -> (%sp,%xzr,sxtw #2)[4byte]
-bc3febff : str    s31, [sp,xzr,sxtx]      : str    %s31 -> (%sp,%xzr,sxtx)[4byte]
-bc3ffbff : str    s31, [sp,xzr,sxtx #2]   : str    %s31 -> (%sp,%xzr,sxtx #2)[4byte]
-bc400400 : ldr    s0, [x0],#0             : ldr    (%x0)[4byte] %x0 $0x0000000000000000 -> %s0 %x0
-bc400c00 : ldr    s0, [x0,#0]!            : ldr    (%x0)[4byte] %x0 $0x0000000000000000 -> %s0 %x0
-bc481041 : ldur   s1, [x2,#129]           : ldur   +0x81(%x2)[4byte] -> %s1
-bc481441 : ldr    s1, [x2],#129           : ldr    (%x2)[4byte] %x2 $0x0000000000000081 -> %s1 %x2
-bc481c41 : ldr    s1, [x2,#129]!          : ldr    +0x81(%x2)[4byte] %x2 $0x0000000000000081 -> %s1 %x2
-bc5ff3ff : ldur   s31, [sp,#-1]           : ldur   -0x01(%sp)[4byte] -> %s31
-bc5ff7ff : ldr    s31, [sp],#-1           : ldr    (%sp)[4byte] %sp $0xffffffffffffffff -> %s31 %sp
-bc5fffff : ldr    s31, [sp,#-1]!          : ldr    -0x01(%sp)[4byte] %sp $0xffffffffffffffff -> %s31 %sp
-bc634841 : ldr    s1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[4byte] -> %s1
-bc635841 : ldr    s1, [x2,w3,uxtw #2]     : ldr    (%x2,%x3,uxtw #2)[4byte] -> %s1
-bc636841 : ldr    s1, [x2,x3]             : ldr    (%x2,%x3)[4byte] -> %s1
-bc637841 : ldr    s1, [x2,x3,lsl #2]      : ldr    (%x2,%x3,uxtx #2)[4byte] -> %s1
-bc63c841 : ldr    s1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[4byte] -> %s1
-bc63d841 : ldr    s1, [x2,w3,sxtw #2]     : ldr    (%x2,%x3,sxtw #2)[4byte] -> %s1
-bc63e841 : ldr    s1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[4byte] -> %s1
-bc63f841 : ldr    s1, [x2,x3,sxtx #2]     : ldr    (%x2,%x3,sxtx #2)[4byte] -> %s1
-bc7f4bff : ldr    s31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[4byte] -> %s31
-bc7f5bff : ldr    s31, [sp,wzr,uxtw #2]   : ldr    (%sp,%xzr,uxtw #2)[4byte] -> %s31
-bc7f6bff : ldr    s31, [sp,xzr]           : ldr    (%sp,%xzr)[4byte] -> %s31
-bc7f7bff : ldr    s31, [sp,xzr,lsl #2]    : ldr    (%sp,%xzr,uxtx #2)[4byte] -> %s31
-bc7fcbff : ldr    s31, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[4byte] -> %s31
-bc7fdbff : ldr    s31, [sp,wzr,sxtw #2]   : ldr    (%sp,%xzr,sxtw #2)[4byte] -> %s31
-bc7febff : ldr    s31, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[4byte] -> %s31
-bc7ffbff : ldr    s31, [sp,xzr,sxtx #2]   : ldr    (%sp,%xzr,sxtx #2)[4byte] -> %s31
-bd081041 : str    s1, [x2,#2064]          : str    %s1 -> +0x0810(%x2)[4byte]
-bd3fffff : str    s31, [sp,#16380]        : str    %s31 -> +0x3ffc(%sp)[4byte]
-bd481041 : ldr    s1, [x2,#2064]          : ldr    +0x0810(%x2)[4byte] -> %s1
-bd7fffff : ldr    s31, [sp,#16380]        : ldr    +0x3ffc(%sp)[4byte] -> %s31
-c8081041 : stxr   w8, x1, [x2]            : stxr   %x1 $0x04 -> (%x2)[8byte] %w8
-c8089041 : stlxr  w8, x1, [x2]            : stlxr  %x1 $0x04 -> (%x2)[8byte] %w8
-c81f7fff : stxr   wzr, xzr, [sp]          : stxr   %xzr $0x1f -> (%sp)[8byte] %wzr
-c81fffff : stlxr  wzr, xzr, [sp]          : stlxr  %xzr $0x1f -> (%sp)[8byte] %wzr
-c8281041 : stxp   w8, x1, x4, [x2]        : stxp   %x1 %x4 -> (%x2)[16byte] %w8
-c8289041 : stlxp  w8, x1, x4, [x2]        : stlxp  %x1 %x4 -> (%x2)[16byte] %w8
-c83f7fff : stxp   wzr, xzr, xzr, [sp]     : stxp   %xzr %xzr -> (%sp)[16byte] %wzr
-c83fffff : stlxp  wzr, xzr, xzr, [sp]     : stlxp  %xzr %xzr -> (%sp)[16byte] %wzr
-c8481041 : ldxr   x1, [x2]                : ldxr   (%x2)[8byte] $0x04 $0x08 -> %x1
-c8489041 : ldaxr  x1, [x2]                : ldaxr  (%x2)[8byte] $0x04 $0x08 -> %x1
-c85f7fff : ldxr   xzr, [sp]               : ldxr   (%sp)[8byte] $0x1f $0x1f -> %xzr
-c85fffff : ldaxr  xzr, [sp]               : ldaxr  (%sp)[8byte] $0x1f $0x1f -> %xzr
-c8681041 : ldxp   x1, x4, [x2]            : ldxp   (%x2)[16byte] $0x08 -> %x1 %x4
-c8689041 : ldaxp  x1, x4, [x2]            : ldaxp  (%x2)[16byte] $0x08 -> %x1 %x4
-c87f7fff : ldxp   xzr, xzr, [sp]          : ldxp   (%sp)[16byte] $0x1f -> %xzr %xzr
-c87fffff : ldaxp  xzr, xzr, [sp]          : ldaxp  (%sp)[16byte] $0x1f -> %xzr %xzr
-c8889041 : stlr   x1, [x2]                : stlr   %x1 $0x04 $0x08 -> (%x2)[8byte]
-c89fffff : stlr   xzr, [sp]               : stlr   %xzr $0x1f $0x1f -> (%sp)[8byte]
-c8a87c41 : cas    x8, x1, [x2]            : cas    %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
-c8a8fc41 : casl   x8, x1, [x2]            : casl   %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
-c8bf7fff : cas    xzr, xzr, [sp]          : cas    %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-c8bfffff : casl   xzr, xzr, [sp]          : casl   %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-c8dfffff : ldar   xzr, [sp]               : ldar   (%sp)[8byte] -> %xzr
-c8e87c41 : casa   x8, x1, [x2]            : casa   %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
-c8e8fc41 : casal  x8, x1, [x2]            : casal  %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
-c8ff7fff : casa   xzr, xzr, [sp]          : casa   %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-c8ffffff : casal  xzr, xzr, [sp]          : casal  %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-ca431041 : eor    x1, x2, x3, lsr #4      : eor    %x2 %x3 lsr $0x04 -> %x1
-ca631041 : eon    x1, x2, x3, lsr #4      : eon    %x2 %x3 lsr $0x04 -> %x1
-ca7f7fff : eon    xzr, xzr, xzr, lsr #31  : eon    %xzr %xzr lsr $0x1f -> %xzr
-cadf13ff : eor    xzr, xzr, xzr, ror #4   : eor    %xzr %xzr ror $0x04 -> %xzr
-caff13ff : eon    xzr, xzr, xzr, ror #4   : eon    %xzr %xzr ror $0x04 -> %xzr
-cb031041 : sub    x1, x2, x3, lsl #4      : sub    %x2 %x3 lsl $0x04 -> %x1
-cb3f73ff : sub    sp, sp, xzr, lsl #4     : sub    %sp %xzr uxtx $0x04 -> %sp
-cb431041 : sub    x1, x2, x3, lsr #4      : sub    %x2 %x3 lsr $0x04 -> %x1
-cb9f13ff : neg    xzr, xzr, asr #4        : sub    %xzr %xzr asr $0x04 -> %xzr
-d1000c41 : sub    x1, x2, #0x3            : sub    %x2 $0x0003 lsl $0x00 -> %x1
-d1000fff : sub    sp, sp, #0x3            : sub    %sp $0x0003 lsl $0x00 -> %sp
-d13fffff : sub    sp, sp, #0xfff          : sub    %sp $0x0fff lsl $0x00 -> %sp
-d2400441 : eor    x1, x2, #0x3            : eor    %x2 $0x0000000000000003 -> %x1
-d2ffffff : mov    xzr, #0xffff000000000000: movz   $0xffff lsl $0x30 -> %xzr
-d3431041 : ubfx   x1, x2, #3, #2          : ubfm   %x2 $0x03 $0x04 -> %x1
-d37fffff : lsr    xzr, xzr, #63           : ubfm   %xzr $0x3f $0x3f -> %xzr
-d4000001 : svc    #0x0                    : svc    $0x0000
-d4000002 : hvc    #0x0                    : hvc    $0x0000
-d4000003 : smc    #0x0                    : smc    $0x0000
-d4081041 : svc    #0x4082                 : svc    $0x4082
-d41fffe1 : svc    #0xffff                 : svc    $0xffff
-d41fffe2 : hvc    #0xffff                 : hvc    $0xffff
-d41fffe3 : smc    #0xffff                 : smc    $0xffff
-d4200000 : brk    #0x0                    : brk    $0x0000
-d4281040 : brk    #0x4082                 : brk    $0x4082
-d43fffe0 : brk    #0xffff                 : brk    $0xffff
-d4400000 : hlt    #0x0                    : hlt    $0x0000
-d45fffe0 : hlt    #0xffff                 : hlt    $0xffff
-d503201f : nop                            : nop
-d503203f : yield                          : yield
-d503205f : wfe                            : wfe
-d503207f : wfi                            : wfi
-d503209f : sev                            : sev
-d50320bf : sevl                           : sevl
-d503305f : clrex  #0x0                    : clrex  $0x00
-d503309f : dsb    #0x00                   : dsb    $0x00
-d50330bf : dmb    #0x00                   : dmb    $0x00
-d50330df : isb    #0x0                    : isb    $0x00
-d5033f5f : clrex                          : clrex  $0x0f
-d5033f9f : dsb    sy                      : dsb    $0x0f
-d5033fbf : dmb    sy                      : dmb    $0x0f
-d5033fdf : isb                            : isb    $0x0f
-d5080000 : sys    #0, C0, C0, #0, x0      : sys    $0x0000 (%x0)[1byte]
-d50fffff : sys    #7, C15, C15, #7        : sys    $0x3fff (%xzr)[1byte]
-d50b7420 : sys    #3,  C7,  C4, #1, x0    : sys    $0x1ba1 (%x0)[1byte]
-d50b7a21 : sys    #3,  C7,  C10, #1, x1   : sys    $0x1bd1 (%x1)[1byte]
-d50b7b21 : sys    #3,  C7,  C11, #1, x1   : sys    $0x1bd9 (%x1)[1byte]
-d50b7e21 : sys    #3,  C7,  C14, #1, x1   : sys    $0x1bf1 (%x1)[1byte]
-d50b7521 : sys    #3,  C7,  C5,  #1, x1   : sys    $0x1ba9 (%x1)[1byte]
-d5100000 : msr    s2_0_c0_c0_0, x0        : msr    %x0 $0x0000
-d51b4201 : msr    nzcv, x1                : msr    %x1 -> %nzcv
-d51b4402 : msr    fpcr, x2                : msr    %x2 -> %fpcr
-d51b4423 : msr    fpsr, x3                : msr    %x3 -> %fpsr
-d51bd044 : msr    tpidr_el0, x4           : msr    %x4 -> %tpidr_el0
-d51fffff : msr    s3_7_c15_c15_7, xzr     : msr    %xzr $0x7fff
-d5300000 : mrs    x0, s2_0_c0_c0_0        : mrs    $0x0000 -> %x0
-d53b4201 : mrs    x1, nzcv                : mrs    %nzcv -> %x1
-d53b4402 : mrs    x2, fpcr                : mrs    %fpcr -> %x2
-d53b4423 : mrs    x3, fpsr                : mrs    %fpsr -> %x3
-d53bd044 : mrs    x4, tpidr_el0           : mrs    %tpidr_el0 -> %x4
-d53fffff : mrs    xzr, s3_7_c15_c15_7     : mrs    $0x7fff -> %xzr
-d61f0000 : br     x0                      : br     %x0
-d61f0040 : br     x2                      : br     %x2
-d61f03e0 : br     xzr                     : br     %xzr
-d63f0000 : blr    x0                      : blr    %x0 -> %x30
-d63f0040 : blr    x2                      : blr    %x2 -> %x30
-d63f03e0 : blr    xzr                     : blr    %xzr -> %x30
-d65f0000 : ret    x0                      : ret    %x0
-d65f0040 : ret    x2                      : ret    %x2
-d65f03e0 : ret    xzr                     : ret    %xzr
-d87fffff : prfm   #0x1f, 100ffffc         : prfm   $0x1f <rel> 0x00000000100ffffc
-d8800000 : prfm   pldl1keep, ff00000      : prfm   $0x00 <rel> 0x000000000ff00000
-da030041 : sbc    x1, x2, x3              : sbc    %x2 %x3 -> %x1
-da83f45f : csneg  xzr, x2, x3, nv         : csneg  %x2 %x3 nv -> %xzr
-dac00041 : rbit   x1, x2                  : rbit   %x2 -> %x1
-dac00441 : rev16  x1, x2                  : rev16  %x2 -> %x1
-dac00841 : rev32  x1, x2                  : rev32  %x2 -> %x1
-dac00c41 : rev    x1, x2                  : rev    %x2 -> %x1
-dac01041 : clz    x1, x2                  : clz    %x2 -> %x1
-dac01441 : cls    x1, x2                  : cls    %x2 -> %x1
-ea431041 : ands   x1, x2, x3, lsr #4      : ands   %x2 %x3 lsr $0x04 -> %x1
-ea631041 : bics   x1, x2, x3, lsr #4      : bics   %x2 %x3 lsr $0x04 -> %x1
-ea9fffff : tst    xzr, xzr, asr #63       : ands   %xzr %xzr asr $0x3f -> %xzr
-eadf13ff : tst    xzr, xzr, ror #4        : ands   %xzr %xzr ror $0x04 -> %xzr
-eaff13ff : bics   xzr, xzr, xzr, ror #4   : bics   %xzr %xzr ror $0x04 -> %xzr
-eb3fabff : cmp    sp, wzr, sxth #2        : subs   %sp %xzr sxth $0x02 -> %xzr
-eb3fe3ff : cmp    sp, xzr, sxtx           : subs   %sp %xzr sxtx $0x00 -> %xzr
-eb431041 : subs   x1, x2, x3, lsr #4      : subs   %x2 %x3 lsr $0x04 -> %x1
-eb5fffff : negs   xzr, xzr, lsr #63       : subs   %xzr %xzr lsr $0x3f -> %xzr
-eb9f13ff : negs   xzr, xzr, asr #4        : subs   %xzr %xzr asr $0x04 -> %xzr
-f07fffff : adrp   xzr, 10ffff000          : adrp   <rel> 0x000000010ffff000 -> %xzr
-f0ffffff : adrp   xzr, ffff000            : adrp   <rel> 0x000000000ffff000 -> %xzr
-f1000c41 : subs   x1, x2, #0x3            : subs   %x2 $0x0003 lsl $0x00 -> %x1
-f1000fff : cmp    sp, #0x3                : subs   %sp $0x0003 lsl $0x00 -> %xzr
-f16003ff : cmp    sp, #0x800, lsl #12     : subs   %sp $0x0800 lsl $0x10 -> %xzr
-f2400441 : ands   x1, x2, #0x3            : ands   %x2 $0x0000000000000003 -> %x1
-f2ffffff : movk   xzr, #0xffff, lsl #48   : movk   %xzr $0xffff lsl $0x30 -> %xzr
-f8000400 : str    x0, [x0],#0             : str    %x0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
-f8000c00 : str    x0, [x0,#0]!            : str    %x0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
-f8081041 : stur   x1, [x2,#129]           : stur   %x1 -> +0x81(%x2)[8byte]
-f8081441 : str    x1, [x2],#129           : str    %x1 %x2 $0x0000000000000081 -> (%x2)[8byte] %x2
-f8081841 : sttr   x1, [x2,#129]           : sttr   %x1 -> +0x81(%x2)[8byte]
-f8081c41 : str    x1, [x2,#129]!          : str    %x1 %x2 $0x0000000000000081 -> +0x81(%x2)[8byte] %x2
-f81ff3ff : stur   xzr, [sp,#-1]           : stur   %xzr -> -0x01(%sp)[8byte]
-f81ff7ff : str    xzr, [sp],#-1           : str    %xzr %sp $0xffffffffffffffff -> (%sp)[8byte] %sp
-f81ffbff : sttr   xzr, [sp,#-1]           : sttr   %xzr -> -0x01(%sp)[8byte]
-f81fffff : str    xzr, [sp,#-1]!          : str    %xzr %sp $0xffffffffffffffff -> -0x01(%sp)[8byte] %sp
-f8234841 : str    x1, [x2,w3,uxtw]        : str    %x1 -> (%x2,%x3,uxtw)[8byte]
-f8235841 : str    x1, [x2,w3,uxtw #3]     : str    %x1 -> (%x2,%x3,uxtw #3)[8byte]
-f8236841 : str    x1, [x2,x3]             : str    %x1 -> (%x2,%x3)[8byte]
-f8237841 : str    x1, [x2,x3,lsl #3]      : str    %x1 -> (%x2,%x3,uxtx #3)[8byte]
-f823c841 : str    x1, [x2,w3,sxtw]        : str    %x1 -> (%x2,%x3,sxtw)[8byte]
-f823d841 : str    x1, [x2,w3,sxtw #3]     : str    %x1 -> (%x2,%x3,sxtw #3)[8byte]
-f823e841 : str    x1, [x2,x3,sxtx]        : str    %x1 -> (%x2,%x3,sxtx)[8byte]
-f823f841 : str    x1, [x2,x3,sxtx #3]     : str    %x1 -> (%x2,%x3,sxtx #3)[8byte]
-f8280041 : ldadd  x8, x1, [x2]            : ldadd  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8281041 : ldclr  x8, x1, [x2]            : ldclr  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8282041 : ldeor  x8, x1, [x2]            : ldeor  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8283041 : ldset  x8, x1, [x2]            : ldset  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8284041 : ldsmax x8, x1, [x2]            : ldsmax %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8285041 : ldsmin x8, x1, [x2]            : ldsmin %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8286041 : ldumax x8, x1, [x2]            : ldumax %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8287041 : ldumin x8, x1, [x2]            : ldumin %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8288041 : swp    x8, x1, [x2]            : swp    %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f83f03ff : stadd  xzr, [sp]               : ldadd  %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f83f13ff : stclr  xzr, [sp]               : ldclr  %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f83f23ff : steor  xzr, [sp]               : ldeor  %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f83f33ff : stset  xzr, [sp]               : ldset  %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f83f43ff : stsmax xzr, [sp]               : ldsmax %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f83f4bff : str    xzr, [sp,wzr,uxtw]      : str    %xzr -> (%sp,%xzr,uxtw)[8byte]
-f83f53ff : stsmin xzr, [sp]               : ldsmin %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f83f5bff : str    xzr, [sp,wzr,uxtw #3]   : str    %xzr -> (%sp,%xzr,uxtw #3)[8byte]
-f83f63ff : stumax xzr, [sp]               : ldumax %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f83f6bff : str    xzr, [sp,xzr]           : str    %xzr -> (%sp,%xzr)[8byte]
-f83f73ff : stumin xzr, [sp]               : ldumin %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f83f7bff : str    xzr, [sp,xzr,lsl #3]    : str    %xzr -> (%sp,%xzr,uxtx #3)[8byte]
-f83f83ff : swp    xzr, xzr, [sp]          : swp    %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f83fcbff : str    xzr, [sp,wzr,sxtw]      : str    %xzr -> (%sp,%xzr,sxtw)[8byte]
-f83fdbff : str    xzr, [sp,wzr,sxtw #3]   : str    %xzr -> (%sp,%xzr,sxtw #3)[8byte]
-f83febff : str    xzr, [sp,xzr,sxtx]      : str    %xzr -> (%sp,%xzr,sxtx)[8byte]
-f83ffbff : str    xzr, [sp,xzr,sxtx #3]   : str    %xzr -> (%sp,%xzr,sxtx #3)[8byte]
-f8400400 : ldr    x0, [x0],#0             : ldr    (%x0)[8byte] %x0 $0x0000000000000000 -> %x0 %x0
-f8400c00 : ldr    x0, [x0,#0]!            : ldr    (%x0)[8byte] %x0 $0x0000000000000000 -> %x0 %x0
-f8481041 : ldur   x1, [x2,#129]           : ldur   +0x81(%x2)[8byte] -> %x1
-f8481441 : ldr    x1, [x2],#129           : ldr    (%x2)[8byte] %x2 $0x0000000000000081 -> %x1 %x2
-f8481841 : ldtr   x1, [x2,#129]           : ldtr   +0x81(%x2)[8byte] -> %x1
-f8481c41 : ldr    x1, [x2,#129]!          : ldr    +0x81(%x2)[8byte] %x2 $0x0000000000000081 -> %x1 %x2
-f85ff3ff : ldur   xzr, [sp,#-1]           : ldur   -0x01(%sp)[8byte] -> %xzr
-f85ff7ff : ldr    xzr, [sp],#-1           : ldr    (%sp)[8byte] %sp $0xffffffffffffffff -> %xzr %sp
-f85ffbff : ldtr   xzr, [sp,#-1]           : ldtr   -0x01(%sp)[8byte] -> %xzr
-f85fffff : ldr    xzr, [sp,#-1]!          : ldr    -0x01(%sp)[8byte] %sp $0xffffffffffffffff -> %xzr %sp
-f8634841 : ldr    x1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[8byte] -> %x1
-f8635841 : ldr    x1, [x2,w3,uxtw #3]     : ldr    (%x2,%x3,uxtw #3)[8byte] -> %x1
-f8636841 : ldr    x1, [x2,x3]             : ldr    (%x2,%x3)[8byte] -> %x1
-f8637841 : ldr    x1, [x2,x3,lsl #3]      : ldr    (%x2,%x3,uxtx #3)[8byte] -> %x1
-f863c841 : ldr    x1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[8byte] -> %x1
-f863d841 : ldr    x1, [x2,w3,sxtw #3]     : ldr    (%x2,%x3,sxtw #3)[8byte] -> %x1
-f863e841 : ldr    x1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[8byte] -> %x1
-f863f841 : ldr    x1, [x2,x3,sxtx #3]     : ldr    (%x2,%x3,sxtx #3)[8byte] -> %x1
-f8680041 : ldaddl x8, x1, [x2]            : ldaddl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8681041 : ldclrl x8, x1, [x2]            : ldclrl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8682041 : ldeorl x8, x1, [x2]            : ldeorl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8683041 : ldsetl x8, x1, [x2]            : ldsetl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8684041 : ldsmaxl x8, x1, [x2]           : ldsmaxl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8685041 : ldsminl x8, x1, [x2]           : ldsminl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8686041 : ldumaxl x8, x1, [x2]           : ldumaxl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8687041 : lduminl x8, x1, [x2]           : lduminl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8688041 : swpl   x8, x1, [x2]            : swpl   %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f87f03ff : staddl xzr, [sp]               : ldaddl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f87f13ff : stclrl xzr, [sp]               : ldclrl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f87f23ff : steorl xzr, [sp]               : ldeorl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f87f33ff : stsetl xzr, [sp]               : ldsetl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f87f43ff : stsmaxl xzr, [sp]              : ldsmaxl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f87f4bff : ldr    xzr, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[8byte] -> %xzr
-f87f53ff : stsminl xzr, [sp]              : ldsminl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f87f5bff : ldr    xzr, [sp,wzr,uxtw #3]   : ldr    (%sp,%xzr,uxtw #3)[8byte] -> %xzr
-f87f63ff : stumaxl xzr, [sp]              : ldumaxl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f87f6bff : ldr    xzr, [sp,xzr]           : ldr    (%sp,%xzr)[8byte] -> %xzr
-f87f73ff : stuminl xzr, [sp]              : lduminl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f87f7bff : ldr    xzr, [sp,xzr,lsl #3]    : ldr    (%sp,%xzr,uxtx #3)[8byte] -> %xzr
-f87f83ff : swpl   xzr, xzr, [sp]          : swpl   %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f87fcbff : ldr    xzr, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[8byte] -> %xzr
-f87fdbff : ldr    xzr, [sp,wzr,sxtw #3]   : ldr    (%sp,%xzr,sxtw #3)[8byte] -> %xzr
-f87febff : ldr    xzr, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[8byte] -> %xzr
-f87ffbff : ldr    xzr, [sp,xzr,sxtx #3]   : ldr    (%sp,%xzr,sxtx #3)[8byte] -> %xzr
-f8800000 : prfum  pldl1keep, [x0]         : prfum  $0x00 (%x0)
-f8881041 : prfum  pldl1strm, [x2,#129]    : prfum  $0x01 +0x81(%x2)
-f89ff3ff : prfum  #0x1f, [sp,#-1]         : prfum  $0x1f -0x01(%sp)
-f8a34841 : prfm   pldl1strm, [x2,w3,uxtw] : prfm   $0x01 (%x2,%x3,uxtw)
-f8a35841 : prfm   pldl1strm, [x2,w3,uxtw #3]: prfm   $0x01 (%x2,%x3,uxtw #3)
-f8a36841 : prfm   pldl1strm, [x2,x3]      : prfm   $0x01 (%x2,%x3)
-f8a37841 : prfm   pldl1strm, [x2,x3,lsl #3]: prfm   $0x01 (%x2,%x3,uxtx #3)
-f8a3c841 : prfm   pldl1strm, [x2,w3,sxtw] : prfm   $0x01 (%x2,%x3,sxtw)
-f8a3d841 : prfm   pldl1strm, [x2,w3,sxtw #3]: prfm   $0x01 (%x2,%x3,sxtw #3)
-f8a3e841 : prfm   pldl1strm, [x2,x3,sxtx] : prfm   $0x01 (%x2,%x3,sxtx)
-f8a3f841 : prfm   pldl1strm, [x2,x3,sxtx #3]: prfm   $0x01 (%x2,%x3,sxtx #3)
-f8a80041 : ldadda x8, x1, [x2]            : ldadda %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8a81041 : ldclra x8, x1, [x2]            : ldclra %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8a82041 : ldeora x8, x1, [x2]            : ldeora %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8a83041 : ldseta x8, x1, [x2]            : ldseta %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8a84041 : ldsmaxa x8, x1, [x2]           : ldsmaxa %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8a85041 : ldsmina x8, x1, [x2]           : ldsmina %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8a86041 : ldumaxa x8, x1, [x2]           : ldumaxa %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8a87041 : ldumina x8, x1, [x2]           : ldumina %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8a88041 : swpa   x8, x1, [x2]            : swpa   %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8bf03ff : ldadda xzr, xzr, [sp]          : ldadda %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8bf13ff : ldclra xzr, xzr, [sp]          : ldclra %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8bf23ff : ldeora xzr, xzr, [sp]          : ldeora %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8bf33ff : ldseta xzr, xzr, [sp]          : ldseta %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8bf43ff : ldsmaxa xzr, xzr, [sp]         : ldsmaxa %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8bf4bff : prfm   #0x1f, [sp,wzr,uxtw]    : prfm   $0x1f (%sp,%xzr,uxtw)
-f8bf53ff : ldsmina xzr, xzr, [sp]         : ldsmina %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8bf5bff : prfm   #0x1f, [sp,wzr,uxtw #3] : prfm   $0x1f (%sp,%xzr,uxtw #3)
-f8bf63ff : ldumaxa xzr, xzr, [sp]         : ldumaxa %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8bf6bff : prfm   #0x1f, [sp,xzr]         : prfm   $0x1f (%sp,%xzr)
-f8bf73ff : ldumina xzr, xzr, [sp]         : ldumina %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8bf7bff : prfm   #0x1f, [sp,xzr,lsl #3]  : prfm   $0x1f (%sp,%xzr,uxtx #3)
-f8bf83ff : swpa   xzr, xzr, [sp]          : swpa   %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8bfcbff : prfm   #0x1f, [sp,wzr,sxtw]    : prfm   $0x1f (%sp,%xzr,sxtw)
-f8bfdbff : prfm   #0x1f, [sp,wzr,sxtw #3] : prfm   $0x1f (%sp,%xzr,sxtw #3)
-f8bfebff : prfm   #0x1f, [sp,xzr,sxtx]    : prfm   $0x1f (%sp,%xzr,sxtx)
-f8bffbff : prfm   #0x1f, [sp,xzr,sxtx #3] : prfm   $0x1f (%sp,%xzr,sxtx #3)
-f8e80041 : ldaddal x8, x1, [x2]           : ldaddal %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8e81041 : ldclral x8, x1, [x2]           : ldclral %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8e82041 : ldeoral x8, x1, [x2]           : ldeoral %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8e83041 : ldsetal x8, x1, [x2]           : ldsetal %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8e84041 : ldsmaxal x8, x1, [x2]          : ldsmaxal %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8e85041 : ldsminal x8, x1, [x2]          : ldsminal %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8e86041 : ldumaxal x8, x1, [x2]          : ldumaxal %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8e87041 : lduminal x8, x1, [x2]          : lduminal %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8e88041 : swpal  x8, x1, [x2]            : swpal  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
-f8ff03ff : ldaddal xzr, xzr, [sp]         : ldaddal %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8ff13ff : ldclral xzr, xzr, [sp]         : ldclral %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8ff23ff : ldeoral xzr, xzr, [sp]         : ldeoral %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8ff33ff : ldsetal xzr, xzr, [sp]         : ldsetal %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8ff43ff : ldsmaxal xzr, xzr, [sp]        : ldsmaxal %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8ff53ff : ldsminal xzr, xzr, [sp]        : ldsminal %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8ff63ff : ldumaxal xzr, xzr, [sp]        : ldumaxal %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8ff73ff : lduminal xzr, xzr, [sp]        : lduminal %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f8ff83ff : swpal  xzr, xzr, [sp]          : swpal  %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
-f9081041 : str    x1, [x2,#4128]          : str    %x1 -> +0x1020(%x2)[8byte]
-f93fffff : str    xzr, [sp,#32760]        : str    %xzr -> +0x7ff8(%sp)[8byte]
-f9481041 : ldr    x1, [x2,#4128]          : ldr    +0x1020(%x2)[8byte] -> %x1
-f97fffff : ldr    xzr, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %xzr
-f9881041 : prfm   pldl1strm, [x2,#4128]   : prfm   $0x01 +0x1020(%x2)
-f9bfffff : prfm   #0x1f, [sp,#32760]      : prfm   $0x1f +0x7ff8(%sp)
-fa1f03ff : ngcs   xzr, xzr                : sbcs   %xzr %xzr -> %xzr
-fa42c023 : ccmp   x1, x2, #0x3, gt        : ccmp   %x1 %x2 $0x03 gt
-fa5fc823 : ccmp   x1, #0x1f, #0x3, gt     : ccmp   %x1 $0x1f $0x03 gt
-fc000400 : str    d0, [x0],#0             : str    %d0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
-fc000c00 : str    d0, [x0,#0]!            : str    %d0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
-fc081041 : stur   d1, [x2,#129]           : stur   %d1 -> +0x81(%x2)[8byte]
-fc081441 : str    d1, [x2],#129           : str    %d1 %x2 $0x0000000000000081 -> (%x2)[8byte] %x2
-fc081c41 : str    d1, [x2,#129]!          : str    %d1 %x2 $0x0000000000000081 -> +0x81(%x2)[8byte] %x2
-fc1ff3ff : stur   d31, [sp,#-1]           : stur   %d31 -> -0x01(%sp)[8byte]
-fc1ff7ff : str    d31, [sp],#-1           : str    %d31 %sp $0xffffffffffffffff -> (%sp)[8byte] %sp
-fc1fffff : str    d31, [sp,#-1]!          : str    %d31 %sp $0xffffffffffffffff -> -0x01(%sp)[8byte] %sp
-fc234841 : str    d1, [x2,w3,uxtw]        : str    %d1 -> (%x2,%x3,uxtw)[8byte]
-fc235841 : str    d1, [x2,w3,uxtw #3]     : str    %d1 -> (%x2,%x3,uxtw #3)[8byte]
-fc236841 : str    d1, [x2,x3]             : str    %d1 -> (%x2,%x3)[8byte]
-fc237841 : str    d1, [x2,x3,lsl #3]      : str    %d1 -> (%x2,%x3,uxtx #3)[8byte]
-fc23c841 : str    d1, [x2,w3,sxtw]        : str    %d1 -> (%x2,%x3,sxtw)[8byte]
-fc23d841 : str    d1, [x2,w3,sxtw #3]     : str    %d1 -> (%x2,%x3,sxtw #3)[8byte]
-fc23e841 : str    d1, [x2,x3,sxtx]        : str    %d1 -> (%x2,%x3,sxtx)[8byte]
-fc23f841 : str    d1, [x2,x3,sxtx #3]     : str    %d1 -> (%x2,%x3,sxtx #3)[8byte]
-fc3f4bff : str    d31, [sp,wzr,uxtw]      : str    %d31 -> (%sp,%xzr,uxtw)[8byte]
-fc3f5bff : str    d31, [sp,wzr,uxtw #3]   : str    %d31 -> (%sp,%xzr,uxtw #3)[8byte]
-fc3f6bff : str    d31, [sp,xzr]           : str    %d31 -> (%sp,%xzr)[8byte]
-fc3f7bff : str    d31, [sp,xzr,lsl #3]    : str    %d31 -> (%sp,%xzr,uxtx #3)[8byte]
-fc3fcbff : str    d31, [sp,wzr,sxtw]      : str    %d31 -> (%sp,%xzr,sxtw)[8byte]
-fc3fdbff : str    d31, [sp,wzr,sxtw #3]   : str    %d31 -> (%sp,%xzr,sxtw #3)[8byte]
-fc3febff : str    d31, [sp,xzr,sxtx]      : str    %d31 -> (%sp,%xzr,sxtx)[8byte]
-fc3ffbff : str    d31, [sp,xzr,sxtx #3]   : str    %d31 -> (%sp,%xzr,sxtx #3)[8byte]
-fc400400 : ldr    d0, [x0],#0             : ldr    (%x0)[8byte] %x0 $0x0000000000000000 -> %d0 %x0
-fc400c00 : ldr    d0, [x0,#0]!            : ldr    (%x0)[8byte] %x0 $0x0000000000000000 -> %d0 %x0
-fc481041 : ldur   d1, [x2,#129]           : ldur   +0x81(%x2)[8byte] -> %d1
-fc481441 : ldr    d1, [x2],#129           : ldr    (%x2)[8byte] %x2 $0x0000000000000081 -> %d1 %x2
-fc481c41 : ldr    d1, [x2,#129]!          : ldr    +0x81(%x2)[8byte] %x2 $0x0000000000000081 -> %d1 %x2
-fc5ff3ff : ldur   d31, [sp,#-1]           : ldur   -0x01(%sp)[8byte] -> %d31
-fc5ff7ff : ldr    d31, [sp],#-1           : ldr    (%sp)[8byte] %sp $0xffffffffffffffff -> %d31 %sp
-fc5fffff : ldr    d31, [sp,#-1]!          : ldr    -0x01(%sp)[8byte] %sp $0xffffffffffffffff -> %d31 %sp
-fc634841 : ldr    d1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[8byte] -> %d1
-fc635841 : ldr    d1, [x2,w3,uxtw #3]     : ldr    (%x2,%x3,uxtw #3)[8byte] -> %d1
-fc636841 : ldr    d1, [x2,x3]             : ldr    (%x2,%x3)[8byte] -> %d1
-fc637841 : ldr    d1, [x2,x3,lsl #3]      : ldr    (%x2,%x3,uxtx #3)[8byte] -> %d1
-fc63c841 : ldr    d1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[8byte] -> %d1
-fc63d841 : ldr    d1, [x2,w3,sxtw #3]     : ldr    (%x2,%x3,sxtw #3)[8byte] -> %d1
-fc63e841 : ldr    d1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[8byte] -> %d1
-fc63f841 : ldr    d1, [x2,x3,sxtx #3]     : ldr    (%x2,%x3,sxtx #3)[8byte] -> %d1
-fc7f4bff : ldr    d31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[8byte] -> %d31
-fc7f5bff : ldr    d31, [sp,wzr,uxtw #3]   : ldr    (%sp,%xzr,uxtw #3)[8byte] -> %d31
-fc7f6bff : ldr    d31, [sp,xzr]           : ldr    (%sp,%xzr)[8byte] -> %d31
-fc7f7bff : ldr    d31, [sp,xzr,lsl #3]    : ldr    (%sp,%xzr,uxtx #3)[8byte] -> %d31
-fc7fcbff : ldr    d31, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[8byte] -> %d31
-fc7fdbff : ldr    d31, [sp,wzr,sxtw #3]   : ldr    (%sp,%xzr,sxtw #3)[8byte] -> %d31
-fc7febff : ldr    d31, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[8byte] -> %d31
-fc7ffbff : ldr    d31, [sp,xzr,sxtx #3]   : ldr    (%sp,%xzr,sxtx #3)[8byte] -> %d31
-fd081041 : str    d1, [x2,#4128]          : str    %d1 -> +0x1020(%x2)[8byte]
-fd3fffff : str    d31, [sp,#32760]        : str    %d31 -> +0x7ff8(%sp)[8byte]
-fd481041 : ldr    d1, [x2,#4128]          : ldr    +0x1020(%x2)[8byte] -> %d1
-fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
-
-# Advanced SIMD three same (FP16)
-0e5e0762 : fmaxnm v2.4h, v27.4h, v30.4h             : fmaxnm %d27 %d30 $0x01 -> %d2
-4e5e0762 : fmaxnm v2.8h, v27.8h, v30.8h             : fmaxnm %q27 %q30 $0x01 -> %q2
-0e5f0fa0 : fmla v0.4h, v29.4h, v31.4h               : fmla   %d0 %d29 %d31 $0x01 -> %d0
-4e5f0fa0 : fmla v0.8h, v29.8h, v31.8h               : fmla   %q0 %q29 %q31 $0x01 -> %q0
-0e421551 : fadd v17.4h, v10.4h, v2.4h               : fadd   %d10 %d2 $0x01 -> %d17
-4e421551 : fadd v17.8h, v10.8h, v2.8h               : fadd   %q10 %q2 $0x01 -> %q17
-0e441e9f : fmulx v31.4h, v20.4h, v4.4h              : fmulx  %d20 %d4 $0x01 -> %d31
-4e441e9f : fmulx v31.8h, v20.8h, v4.8h              : fmulx  %q20 %q4 $0x01 -> %q31
-0e4226ef : fcmeq v15.4h, v23.4h, v2.4h              : fcmeq  %d23 %d2 $0x01 -> %d15
-4e4226ef : fcmeq v15.8h, v23.8h, v2.8h              : fcmeq  %q23 %q2 $0x01 -> %q15
-0e56351a : fmax v26.4h, v8.4h, v22.4h               : fmax   %d8 %d22 $0x01 -> %d26
-4e56351a : fmax v26.8h, v8.8h, v22.8h               : fmax   %q8 %q22 $0x01 -> %q26
-0e523f58 : frecps v24.4h, v26.4h, v18.4h            : frecps %d26 %d18 $0x01 -> %d24
-4e523f58 : frecps v24.8h, v26.8h, v18.8h            : frecps %q26 %q18 $0x01 -> %q24
-0ecb07b0 : fminnm v16.4h, v29.4h, v11.4h            : fminnm %d29 %d11 $0x01 -> %d16
-4ecb07b0 : fminnm v16.8h, v29.8h, v11.8h            : fminnm %q29 %q11 $0x01 -> %q16
-0edd0d13 : fmls v19.4h, v8.4h, v29.4h               : fmls   %d19 %d8 %d29 $0x01 -> %d19
-4edd0d13 : fmls v19.8h, v8.8h, v29.8h               : fmls   %q19 %q8 %q29 $0x01 -> %q19
-0ed8178f : fsub v15.4h, v28.4h, v24.4h              : fsub   %d28 %d24 $0x01 -> %d15
-4ed8178f : fsub v15.8h, v28.8h, v24.8h              : fsub   %q28 %q24 $0x01 -> %q15
-0ecf3402 : fmin v2.4h, v0.4h, v15.4h                : fmin   %d0 %d15 $0x01 -> %d2
-4ecf3402 : fmin v2.8h, v0.8h, v15.8h                : fmin   %q0 %q15 $0x01 -> %q2
-0ed33d88 : frsqrts v8.4h, v12.4h, v19.4h            : frsqrts %d12 %d19 $0x01 -> %d8
-4ed33d88 : frsqrts v8.8h, v12.8h, v19.8h            : frsqrts %q12 %q19 $0x01 -> %q8
-2e5405f7 : fmaxnmp v23.4h, v15.4h, v20.4h           : fmaxnmp %d15 %d20 $0x01 -> %d23
-6e5405f7 : fmaxnmp v23.8h, v15.8h, v20.8h           : fmaxnmp %q15 %q20 $0x01 -> %q23
-2e5e177c : faddp v28.4h, v27.4h, v30.4h             : faddp  %d27 %d30 $0x01 -> %d28
-6e5e177c : faddp v28.8h, v27.8h, v30.8h             : faddp  %q27 %q30 $0x01 -> %q28
-2e4a1e84 : fmul v4.4h, v20.4h, v10.4h               : fmul   %d20 %d10 $0x01 -> %d4
-6e4a1e84 : fmul v4.8h, v20.8h, v10.8h               : fmul   %q20 %q10 $0x01 -> %q4
-2e4f274e : fcmge v14.4h, v26.4h, v15.4h             : fcmge  %d26 %d15 $0x01 -> %d14
-6e4f274e : fcmge v14.8h, v26.8h, v15.8h             : fcmge  %q26 %q15 $0x01 -> %q14
-2e5f2c42 : facge v2.4h, v2.4h, v31.4h               : facge  %d2 %d31 $0x01 -> %d2
-6e5f2c42 : facge v2.8h, v2.8h, v31.8h               : facge  %q2 %q31 $0x01 -> %q2
-2e453493 : fmaxp v19.4h, v4.4h, v5.4h               : fmaxp  %d4 %d5 $0x01 -> %d19
-6e453493 : fmaxp v19.8h, v4.8h, v5.8h               : fmaxp  %q4 %q5 $0x01 -> %q19
-2e573f09 : fdiv v9.4h, v24.4h, v23.4h               : fdiv   %d24 %d23 $0x01 -> %d9
-6e573f09 : fdiv v9.8h, v24.8h, v23.8h               : fdiv   %q24 %q23 $0x01 -> %q9
-2ec604e9 : fminnmp v9.4h, v7.4h, v6.4h              : fminnmp %d7 %d6 $0x01 -> %d9
-6ec604e9 : fminnmp v9.8h, v7.8h, v6.8h              : fminnmp %q7 %q6 $0x01 -> %q9
-2ecc155c : fabd v28.4h, v10.4h, v12.4h              : fabd   %d10 %d12 $0x01 -> %d28
-6ecc155c : fabd v28.8h, v10.8h, v12.8h              : fabd   %q10 %q12 $0x01 -> %q28
-2eda2776 : fcmgt v22.4h, v27.4h, v26.4h             : fcmgt  %d27 %d26 $0x01 -> %d22
-6eda2776 : fcmgt v22.8h, v27.8h, v26.8h             : fcmgt  %q27 %q26 $0x01 -> %q22
-2ed12dfc : facgt v28.4h, v15.4h, v17.4h             : facgt  %d15 %d17 $0x01 -> %d28
-6ed12dfc : facgt v28.8h, v15.8h, v17.8h             : facgt  %q15 %q17 $0x01 -> %q28
-2ec73569 : fminp v9.4h, v11.4h, v7.4h               : fminp  %d11 %d7 $0x01 -> %d9
-6ec73569 : fminp v9.8h, v11.8h, v7.8h               : fminp  %q11 %q7 $0x01 -> %q9
-
-# Advanced SIMD three same
-0e3e0762 : shadd v2.8b, v27.8b, v30.8b              : shadd  %d27 %d30 $0x00 -> %d2
-4e3e0762 : shadd v2.16b, v27.16b, v30.16b           : shadd  %q27 %q30 $0x00 -> %q2
-0e7e0762 : shadd v2.4h, v27.4h, v30.4h              : shadd  %d27 %d30 $0x01 -> %d2
-4e7e0762 : shadd v2.8h, v27.8h, v30.8h              : shadd  %q27 %q30 $0x01 -> %q2
-0ebe0762 : shadd v2.2s, v27.2s, v30.2s              : shadd  %d27 %d30 $0x02 -> %d2
-4ebe0762 : shadd v2.4s, v27.4s, v30.4s              : shadd  %q27 %q30 $0x02 -> %q2
-0e3d0da0 : sqadd v0.8b, v13.8b, v29.8b              : sqadd  %d13 %d29 $0x00 -> %d0
-4e3d0da0 : sqadd v0.16b, v13.16b, v29.16b           : sqadd  %q13 %q29 $0x00 -> %q0
-0e7d0da0 : sqadd v0.4h, v13.4h, v29.4h              : sqadd  %d13 %d29 $0x01 -> %d0
-4e7d0da0 : sqadd v0.8h, v13.8h, v29.8h              : sqadd  %q13 %q29 $0x01 -> %q0
-0ebd0da0 : sqadd v0.2s, v13.2s, v29.2s              : sqadd  %d13 %d29 $0x02 -> %d0
-4ebd0da0 : sqadd v0.4s, v13.4s, v29.4s              : sqadd  %q13 %q29 $0x02 -> %q0
-4efd0da0 : sqadd v0.2d, v13.2d, v29.2d              : sqadd  %q13 %q29 $0x03 -> %q0
-0e2a163f : srhadd v31.8b, v17.8b, v10.8b            : srhadd %d17 %d10 $0x00 -> %d31
-4e2a163f : srhadd v31.16b, v17.16b, v10.16b         : srhadd %q17 %q10 $0x00 -> %q31
-0e6a163f : srhadd v31.4h, v17.4h, v10.4h            : srhadd %d17 %d10 $0x01 -> %d31
-4e6a163f : srhadd v31.8h, v17.8h, v10.8h            : srhadd %q17 %q10 $0x01 -> %q31
-0eaa163f : srhadd v31.2s, v17.2s, v10.2s            : srhadd %d17 %d10 $0x02 -> %d31
-4eaa163f : srhadd v31.4s, v17.4s, v10.4s            : srhadd %q17 %q10 $0x02 -> %q31
-0e3427e2 : shsub v2.8b, v31.8b, v20.8b              : shsub  %d31 %d20 $0x00 -> %d2
-4e3427e2 : shsub v2.16b, v31.16b, v20.16b           : shsub  %q31 %q20 $0x00 -> %q2
-0e7427e2 : shsub v2.4h, v31.4h, v20.4h              : shsub  %d31 %d20 $0x01 -> %d2
-4e7427e2 : shsub v2.8h, v31.8h, v20.8h              : shsub  %q31 %q20 $0x01 -> %q2
-0eb427e2 : shsub v2.2s, v31.2s, v20.2s              : shsub  %d31 %d20 $0x02 -> %d2
-4eb427e2 : shsub v2.4s, v31.4s, v20.4s              : shsub  %q31 %q20 $0x02 -> %q2
-0e372de4 : sqsub v4.8b, v15.8b, v23.8b              : sqsub  %d15 %d23 $0x00 -> %d4
-4e372de4 : sqsub v4.16b, v15.16b, v23.16b           : sqsub  %q15 %q23 $0x00 -> %q4
-0e772de4 : sqsub v4.4h, v15.4h, v23.4h              : sqsub  %d15 %d23 $0x01 -> %d4
-4e772de4 : sqsub v4.8h, v15.8h, v23.8h              : sqsub  %q15 %q23 $0x01 -> %q4
-0eb72de4 : sqsub v4.2s, v15.2s, v23.2s              : sqsub  %d15 %d23 $0x02 -> %d4
-4eb72de4 : sqsub v4.4s, v15.4s, v23.4s              : sqsub  %q15 %q23 $0x02 -> %q4
-4ef72de4 : sqsub v4.2d, v15.2d, v23.2d              : sqsub  %q15 %q23 $0x03 -> %q4
-0e283742 : cmgt v2.8b, v26.8b, v8.8b                : cmgt   %d26 %d8 $0x00 -> %d2
-4e283742 : cmgt v2.16b, v26.16b, v8.16b             : cmgt   %q26 %q8 $0x00 -> %q2
-0e683742 : cmgt v2.4h, v26.4h, v8.4h                : cmgt   %d26 %d8 $0x01 -> %d2
-4e683742 : cmgt v2.8h, v26.8h, v8.8h                : cmgt   %q26 %q8 $0x01 -> %q2
-0ea83742 : cmgt v2.2s, v26.2s, v8.2s                : cmgt   %d26 %d8 $0x02 -> %d2
-4ea83742 : cmgt v2.4s, v26.4s, v8.4s                : cmgt   %q26 %q8 $0x02 -> %q2
-4ee83742 : cmgt v2.2d, v26.2d, v8.2d                : cmgt   %q26 %q8 $0x03 -> %q2
-0e3a3f16 : cmge v22.8b, v24.8b, v26.8b              : cmge   %d24 %d26 $0x00 -> %d22
-4e3a3f16 : cmge v22.16b, v24.16b, v26.16b           : cmge   %q24 %q26 $0x00 -> %q22
-0e7a3f16 : cmge v22.4h, v24.4h, v26.4h              : cmge   %d24 %d26 $0x01 -> %d22
-4e7a3f16 : cmge v22.8h, v24.8h, v26.8h              : cmge   %q24 %q26 $0x01 -> %q22
-0eba3f16 : cmge v22.2s, v24.2s, v26.2s              : cmge   %d24 %d26 $0x02 -> %d22
-4eba3f16 : cmge v22.4s, v24.4s, v26.4s              : cmge   %q24 %q26 $0x02 -> %q22
-4efa3f16 : cmge v22.2d, v24.2d, v26.2d              : cmge   %q24 %q26 $0x03 -> %q22
-0e3d4612 : sshl v18.8b, v16.8b, v29.8b              : sshl   %d16 %d29 $0x00 -> %d18
-4e3d4612 : sshl v18.16b, v16.16b, v29.16b           : sshl   %q16 %q29 $0x00 -> %q18
-0e7d4612 : sshl v18.4h, v16.4h, v29.4h              : sshl   %d16 %d29 $0x01 -> %d18
-4e7d4612 : sshl v18.8h, v16.8h, v29.8h              : sshl   %q16 %q29 $0x01 -> %q18
-0ebd4612 : sshl v18.2s, v16.2s, v29.2s              : sshl   %d16 %d29 $0x02 -> %d18
-4ebd4612 : sshl v18.4s, v16.4s, v29.4s              : sshl   %q16 %q29 $0x02 -> %q18
-4efd4612 : sshl v18.2d, v16.2d, v29.2d              : sshl   %q16 %q29 $0x03 -> %q18
-0e374e6b : sqshl v11.8b, v19.8b, v23.8b             : sqshl  %d19 %d23 $0x00 -> %d11
-4e374e6b : sqshl v11.16b, v19.16b, v23.16b          : sqshl  %q19 %q23 $0x00 -> %q11
-0e774e6b : sqshl v11.4h, v19.4h, v23.4h             : sqshl  %d19 %d23 $0x01 -> %d11
-4e774e6b : sqshl v11.8h, v19.8h, v23.8h             : sqshl  %q19 %q23 $0x01 -> %q11
-0eb74e6b : sqshl v11.2s, v19.2s, v23.2s             : sqshl  %d19 %d23 $0x02 -> %d11
-4eb74e6b : sqshl v11.4s, v19.4s, v23.4s             : sqshl  %q19 %q23 $0x02 -> %q11
-4ef74e6b : sqshl v11.2d, v19.2d, v23.2d             : sqshl  %q19 %q23 $0x03 -> %q11
-0e2f57a8 : srshl v8.8b, v29.8b, v15.8b              : srshl  %d29 %d15 $0x00 -> %d8
-4e2f57a8 : srshl v8.16b, v29.16b, v15.16b           : srshl  %q29 %q15 $0x00 -> %q8
-0e6f57a8 : srshl v8.4h, v29.4h, v15.4h              : srshl  %d29 %d15 $0x01 -> %d8
-4e6f57a8 : srshl v8.8h, v29.8h, v15.8h              : srshl  %q29 %q15 $0x01 -> %q8
-0eaf57a8 : srshl v8.2s, v29.2s, v15.2s              : srshl  %d29 %d15 $0x02 -> %d8
-4eaf57a8 : srshl v8.4s, v29.4s, v15.4s              : srshl  %q29 %q15 $0x02 -> %q8
-4eef57a8 : srshl v8.2d, v29.2d, v15.2d              : srshl  %q29 %q15 $0x03 -> %q8
-0e225f1c : sqrshl v28.8b, v24.8b, v2.8b             : sqrshl %d24 %d2 $0x00 -> %d28
-4e225f1c : sqrshl v28.16b, v24.16b, v2.16b          : sqrshl %q24 %q2 $0x00 -> %q28
-0e625f1c : sqrshl v28.4h, v24.4h, v2.4h             : sqrshl %d24 %d2 $0x01 -> %d28
-4e625f1c : sqrshl v28.8h, v24.8h, v2.8h             : sqrshl %q24 %q2 $0x01 -> %q28
-0ea25f1c : sqrshl v28.2s, v24.2s, v2.2s             : sqrshl %d24 %d2 $0x02 -> %d28
-4ea25f1c : sqrshl v28.4s, v24.4s, v2.4s             : sqrshl %q24 %q2 $0x02 -> %q28
-4ee25f1c : sqrshl v28.2d, v24.2d, v2.2d             : sqrshl %q24 %q2 $0x03 -> %q28
-0e2865e0 : smax v0.8b, v15.8b, v8.8b                : smax   %d15 %d8 $0x00 -> %d0
-4e2865e0 : smax v0.16b, v15.16b, v8.16b             : smax   %q15 %q8 $0x00 -> %q0
-0e6865e0 : smax v0.4h, v15.4h, v8.4h                : smax   %d15 %d8 $0x01 -> %d0
-4e6865e0 : smax v0.8h, v15.8h, v8.8h                : smax   %q15 %q8 $0x01 -> %q0
-0ea865e0 : smax v0.2s, v15.2s, v8.2s                : smax   %d15 %d8 $0x02 -> %d0
-4ea865e0 : smax v0.4s, v15.4s, v8.4s                : smax   %q15 %q8 $0x02 -> %q0
-0e376e6c : smin v12.8b, v19.8b, v23.8b              : smin   %d19 %d23 $0x00 -> %d12
-4e376e6c : smin v12.16b, v19.16b, v23.16b           : smin   %q19 %q23 $0x00 -> %q12
-0e776e6c : smin v12.4h, v19.4h, v23.4h              : smin   %d19 %d23 $0x01 -> %d12
-4e776e6c : smin v12.8h, v19.8h, v23.8h              : smin   %q19 %q23 $0x01 -> %q12
-0eb76e6c : smin v12.2s, v19.2s, v23.2s              : smin   %d19 %d23 $0x02 -> %d12
-4eb76e6c : smin v12.4s, v19.4s, v23.4s              : smin   %q19 %q23 $0x02 -> %q12
-0e3c768f : sabd v15.8b, v20.8b, v28.8b              : sabd   %d20 %d28 $0x00 -> %d15
-4e3c768f : sabd v15.16b, v20.16b, v28.16b           : sabd   %q20 %q28 $0x00 -> %q15
-0e7c768f : sabd v15.4h, v20.4h, v28.4h              : sabd   %d20 %d28 $0x01 -> %d15
-4e7c768f : sabd v15.8h, v20.8h, v28.8h              : sabd   %q20 %q28 $0x01 -> %q15
-0ebc768f : sabd v15.2s, v20.2s, v28.2s              : sabd   %d20 %d28 $0x02 -> %d15
-4ebc768f : sabd v15.4s, v20.4s, v28.4s              : sabd   %q20 %q28 $0x02 -> %q15
-0e247fdb : saba v27.8b, v30.8b, v4.8b               : saba   %d30 %d4 $0x00 -> %d27
-4e247fdb : saba v27.16b, v30.16b, v4.16b            : saba   %q30 %q4 $0x00 -> %q27
-0e647fdb : saba v27.4h, v30.4h, v4.4h               : saba   %d30 %d4 $0x01 -> %d27
-4e647fdb : saba v27.8h, v30.8h, v4.8h               : saba   %q30 %q4 $0x01 -> %q27
-0ea47fdb : saba v27.2s, v30.2s, v4.2s               : saba   %d30 %d4 $0x02 -> %d27
-4ea47fdb : saba v27.4s, v30.4s, v4.4s               : saba   %q30 %q4 $0x02 -> %q27
 0e2e8554 : add v20.8b, v10.8b, v14.8b               : add    %d10 %d14 $0x00 -> %d20
 4e2e8554 : add v20.16b, v10.16b, v14.16b            : add    %q10 %q14 $0x00 -> %q20
 0e6e8554 : add v20.4h, v10.4h, v14.4h               : add    %d10 %d14 $0x01 -> %d20
@@ -1740,41 +62,19 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 0eae8554 : add v20.2s, v10.2s, v14.2s               : add    %d10 %d14 $0x02 -> %d20
 4eae8554 : add v20.4s, v10.4s, v14.4s               : add    %q10 %q14 $0x02 -> %q20
 4eee8554 : add v20.2d, v10.2d, v14.2d               : add    %q10 %q14 $0x03 -> %q20
-0e228dfa : cmtst v26.8b, v15.8b, v2.8b              : cmtst  %d15 %d2 $0x00 -> %d26
-4e228dfa : cmtst v26.16b, v15.16b, v2.16b           : cmtst  %q15 %q2 $0x00 -> %q26
-0e628dfa : cmtst v26.4h, v15.4h, v2.4h              : cmtst  %d15 %d2 $0x01 -> %d26
-4e628dfa : cmtst v26.8h, v15.8h, v2.8h              : cmtst  %q15 %q2 $0x01 -> %q26
-0ea28dfa : cmtst v26.2s, v15.2s, v2.2s              : cmtst  %d15 %d2 $0x02 -> %d26
-4ea28dfa : cmtst v26.4s, v15.4s, v2.4s              : cmtst  %q15 %q2 $0x02 -> %q26
-4ee28dfa : cmtst v26.2d, v15.2d, v2.2d              : cmtst  %q15 %q2 $0x03 -> %q26
-0e249662 : mla v2.8b, v19.8b, v4.8b                 : mla    %d2 %d19 %d4 $0x00 -> %d2
-4e249662 : mla v2.16b, v19.16b, v4.16b              : mla    %q2 %q19 %q4 $0x00 -> %q2
-0e649662 : mla v2.4h, v19.4h, v4.4h                 : mla    %d2 %d19 %d4 $0x01 -> %d2
-4e649662 : mla v2.8h, v19.8h, v4.8h                 : mla    %q2 %q19 %q4 $0x01 -> %q2
-0ea49662 : mla v2.2s, v19.2s, v4.2s                 : mla    %d2 %d19 %d4 $0x02 -> %d2
-4ea49662 : mla v2.4s, v19.4s, v4.4s                 : mla    %q2 %q19 %q4 $0x02 -> %q2
-0e389d25 : mul v5.8b, v9.8b, v24.8b                 : mul    %d9 %d24 $0x00 -> %d5
-4e389d25 : mul v5.16b, v9.16b, v24.16b              : mul    %q9 %q24 $0x00 -> %q5
-0e789d25 : mul v5.4h, v9.4h, v24.4h                 : mul    %d9 %d24 $0x01 -> %d5
-4e789d25 : mul v5.8h, v9.8h, v24.8h                 : mul    %q9 %q24 $0x01 -> %q5
-0eb89d25 : mul v5.2s, v9.2s, v24.2s                 : mul    %d9 %d24 $0x02 -> %d5
-4eb89d25 : mul v5.4s, v9.4s, v24.4s                 : mul    %q9 %q24 $0x02 -> %q5
-0e27a537 : smaxp v23.8b, v9.8b, v7.8b               : smaxp  %d9 %d7 $0x00 -> %d23
-4e27a537 : smaxp v23.16b, v9.16b, v7.16b            : smaxp  %q9 %q7 $0x00 -> %q23
-0e67a537 : smaxp v23.4h, v9.4h, v7.4h               : smaxp  %d9 %d7 $0x01 -> %d23
-4e67a537 : smaxp v23.8h, v9.8h, v7.8h               : smaxp  %q9 %q7 $0x01 -> %q23
-0ea7a537 : smaxp v23.2s, v9.2s, v7.2s               : smaxp  %d9 %d7 $0x02 -> %d23
-4ea7a537 : smaxp v23.4s, v9.4s, v7.4s               : smaxp  %q9 %q7 $0x02 -> %q23
-0e2aaf86 : sminp v6.8b, v28.8b, v10.8b              : sminp  %d28 %d10 $0x00 -> %d6
-4e2aaf86 : sminp v6.16b, v28.16b, v10.16b           : sminp  %q28 %q10 $0x00 -> %q6
-0e6aaf86 : sminp v6.4h, v28.4h, v10.4h              : sminp  %d28 %d10 $0x01 -> %d6
-4e6aaf86 : sminp v6.8h, v28.8h, v10.8h              : sminp  %q28 %q10 $0x01 -> %q6
-0eaaaf86 : sminp v6.2s, v28.2s, v10.2s              : sminp  %d28 %d10 $0x02 -> %d6
-4eaaaf86 : sminp v6.4s, v28.4s, v10.4s              : sminp  %q28 %q10 $0x02 -> %q6
-0e7bb6cc : sqdmulh v12.4h, v22.4h, v27.4h           : sqdmulh %d22 %d27 $0x01 -> %d12
-4e7bb6cc : sqdmulh v12.8h, v22.8h, v27.8h           : sqdmulh %q22 %q27 $0x01 -> %q12
-0ebbb6cc : sqdmulh v12.2s, v22.2s, v27.2s           : sqdmulh %d22 %d27 $0x02 -> %d12
-4ebbb6cc : sqdmulh v12.4s, v22.4s, v27.4s           : sqdmulh %q22 %q27 $0x02 -> %q12
+043e0362 : add z2.b, z27.b, z30.b                   : add    %z27 %z30 $0x00 -> %z2
+047e0362 : add z2.h, z27.h, z30.h                   : add    %z27 %z30 $0x01 -> %z2
+04be0362 : add z2.s, z27.s, z30.s                   : add    %z27 %z30 $0x02 -> %z2
+04fe0362 : add z2.d, z27.d, z30.d                   : add    %z27 %z30 $0x03 -> %z2
+
+0e3343ff : addhn v31.8b, v31.8h, v19.8h             : addhn  %q31 %q19 $0x00 -> %d31
+0e7343ff : addhn v31.4h, v31.4s, v19.4s             : addhn  %q31 %q19 $0x01 -> %d31
+0eb343ff : addhn v31.2s, v31.2d, v19.2d             : addhn  %q31 %q19 $0x02 -> %d31
+
+4e244001 : addhn2 v1.16b, v0.8h, v4.8h              : addhn2 %q0 %q4 $0x00 -> %q1
+4e644001 : addhn2 v1.8h, v0.4s, v4.4s               : addhn2 %q0 %q4 $0x01 -> %q1
+4ea44001 : addhn2 v1.4s, v0.2d, v4.2d               : addhn2 %q0 %q4 $0x02 -> %q1
+
 0e2fbf9a : addp v26.8b, v28.8b, v15.8b              : addp   %d28 %d15 $0x00 -> %d26
 4e2fbf9a : addp v26.16b, v28.16b, v15.16b           : addp   %q28 %q15 $0x00 -> %q26
 0e6fbf9a : addp v26.4h, v28.4h, v15.4h              : addp   %d28 %d15 $0x01 -> %d26
@@ -1782,165 +82,223 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 0eafbf9a : addp v26.2s, v28.2s, v15.2s              : addp   %d28 %d15 $0x02 -> %d26
 4eafbf9a : addp v26.4s, v28.4s, v15.4s              : addp   %q28 %q15 $0x02 -> %q26
 4eefbf9a : addp v26.2d, v28.2d, v15.2d              : addp   %q28 %q15 $0x03 -> %q26
-0e2bc531 : fmaxnm v17.2s, v9.2s, v11.2s             : fmaxnm %d9 %d11 $0x02 -> %d17
-4e2bc531 : fmaxnm v17.4s, v9.4s, v11.4s             : fmaxnm %q9 %q11 $0x02 -> %q17
-4e6bc531 : fmaxnm v17.2d, v9.2d, v11.2d             : fmaxnm %q9 %q11 $0x03 -> %q17
-0e33cfa7 : fmla v7.2s, v29.2s, v19.2s               : fmla   %d7 %d29 %d19 $0x02 -> %d7
-4e33cfa7 : fmla v7.4s, v29.4s, v19.4s               : fmla   %q7 %q29 %q19 $0x02 -> %q7
-4e73cfa7 : fmla v7.2d, v29.2d, v19.2d               : fmla   %q7 %q29 %q19 $0x03 -> %q7
-4fd11240 : fmla v0.2d, v18.2d, v17.d[0]             : fmla   %q0 %q18 %q17 $0x00 $0x03 -> %q0
-4fc4180b : fmla v11.2d, v0.2d, v4.d[1]              : fmla   %q11 %q0 %q4 $0x01 $0x03 -> %q11
-4f981382 : fmla v2.4s, v28.4s, v24.s[0]             : fmla   %q2 %q28 %q24 $0x00 $0x02 -> %q2
-4fb81343 : fmla v3.4s, v26.4s, v24.s[1]             : fmla   %q3 %q26 %q24 $0x01 $0x02 -> %q3
-4f981b88 : fmla v8.4s, v28.4s, v24.s[2]             : fmla   %q8 %q28 %q24 $0x02 $0x02 -> %q8
-4fb81b49 : fmla v9.4s, v26.4s, v24.s[3]             : fmla   %q9 %q26 %q24 $0x03 $0x02 -> %q9
-0e2bd56a : fadd v10.2s, v11.2s, v11.2s              : fadd   %d11 %d11 $0x02 -> %d10
-4e2bd56a : fadd v10.4s, v11.4s, v11.4s              : fadd   %q11 %q11 $0x02 -> %q10
-4e6bd56a : fadd v10.2d, v11.2d, v11.2d              : fadd   %q11 %q11 $0x03 -> %q10
-0e34dede : fmulx v30.2s, v22.2s, v20.2s             : fmulx  %d22 %d20 $0x02 -> %d30
-4e34dede : fmulx v30.4s, v22.4s, v20.4s             : fmulx  %q22 %q20 $0x02 -> %q30
-4e74dede : fmulx v30.2d, v22.2d, v20.2d             : fmulx  %q22 %q20 $0x03 -> %q30
-0e20e5db : fcmeq v27.2s, v14.2s, v0.2s              : fcmeq  %d14 %d0 $0x02 -> %d27
-4e20e5db : fcmeq v27.4s, v14.4s, v0.4s              : fcmeq  %q14 %q0 $0x02 -> %q27
-4e60e5db : fcmeq v27.2d, v14.2d, v0.2d              : fcmeq  %q14 %q0 $0x03 -> %q27
-0e20ed42 : fmlal v2.2s, v10.2h, v0.2h               : fmlal  %d2 %d10 %d0 -> %d2
-4e20ed42 : fmlal v2.4s, v10.4h, v0.4h               : fmlal  %q2 %q10 %q0 -> %q2
-0e34f6a2 : fmax v2.2s, v21.2s, v20.2s               : fmax   %d21 %d20 $0x02 -> %d2
-4e34f6a2 : fmax v2.4s, v21.4s, v20.4s               : fmax   %q21 %q20 $0x02 -> %q2
-4e74f6a2 : fmax v2.2d, v21.2d, v20.2d               : fmax   %q21 %q20 $0x03 -> %q2
-0e30fcaf : frecps v15.2s, v5.2s, v16.2s             : frecps %d5 %d16 $0x02 -> %d15
-4e30fcaf : frecps v15.4s, v5.4s, v16.4s             : frecps %q5 %q16 $0x02 -> %q15
-4e70fcaf : frecps v15.2d, v5.2d, v16.2d             : frecps %q5 %q16 $0x03 -> %q15
+
+2b031041 : adds   w1, w2, w3, lsl #4      : adds   %w2 %w3 lsl $0x04 -> %w1
+31000c41 : adds   w1, w2, #0x3            : adds   %w2 $0x0003 lsl $0x00 -> %w1
+ab431041 : adds   x1, x2, x3, lsr #4      : adds   %x2 %x3 lsr $0x04 -> %x1
+b1000c41 : adds   x1, x2, #0x3            : adds   %x2 $0x0003 lsl $0x00 -> %x1
+
+10081041 : adr    x1, 10010208            : adr    <rel> 0x0000000010010208 -> %x1
+10800000 : adr    x0, ff00000             : adr    <rel> 0x000000000ff00000 -> %x0
+707fffff : adr    xzr, 100fffff           : adr    <rel> 0x00000000100fffff -> %xzr
+70ffffff : adr    xzr, fffffff            : adr    <rel> 0x000000000fffffff -> %xzr
+
+90081041 : adrp   x1, 20208000            : adrp   <rel> 0x0000000020208000 -> %x1
+90800000 : adrp   x0, ffffffff10000000    : adrp   <rel> 0xffffffff10000000 -> %x0
+f07fffff : adrp   xzr, 10ffff000          : adrp   <rel> 0x000000010ffff000 -> %xzr
+f0ffffff : adrp   xzr, ffff000            : adrp   <rel> 0x000000000ffff000 -> %xzr
+
+0a031041 : and    w1, w2, w3, lsl #4      : and    %w2 %w3 lsl $0x04 -> %w1
+0a9f13ff : and    wzr, wzr, wzr, asr #4   : and    %wzr %wzr asr $0x04 -> %wzr
+12000441 : and    w1, w2, #0x3            : and    %w2 $0x00000003 -> %w1
+8a1fffff : and    xzr, xzr, xzr, lsl #63  : and    %xzr %xzr lsl $0x3f -> %xzr
+8a431041 : and    x1, x2, x3, lsr #4      : and    %x2 %x3 lsr $0x04 -> %x1
+8adf13ff : and    xzr, xzr, xzr, ror #4   : and    %xzr %xzr ror $0x04 -> %xzr
+9201f041 : and    x1, x2, #0xaaaaaaaaaaaaaaaa: and    %x2 $0xaaaaaaaaaaaaaaaa -> %x1
+923ff041 : and    x1, x2, #0xaaaaaaaaaaaaaaaa: and    %x2 $0xaaaaaaaaaaaaaaaa $0x0ffc -> %x1
+92400441 : and    x1, x2, #0x3            : and    %x2 $0x0000000000000003 -> %x1
 0e2a1f3c : and v28.8b, v25.8b, v10.8b               : and    %d25 %d10 -> %d28
 4e2a1f3c : and v28.16b, v25.16b, v10.16b            : and    %q25 %q10 -> %q28
+041a06ff : and z31.b, p1/m, z31.b, z23.b            : and    %p1 %z31 %z23 $0x00 -> %z31
+045a06ff : and z31.h, p1/m, z31.h, z23.h            : and    %p1 %z31 %z23 $0x01 -> %z31
+049a06ff : and z31.s, p1/m, z31.s, z23.s            : and    %p1 %z31 %z23 $0x02 -> %z31
+04da06ff : and z31.d, p1/m, z31.d, z23.d            : and    %p1 %z31 %z23 $0x03 -> %z31
+
+6a031041 : ands   w1, w2, w3, lsl #4      : ands   %w2 %w3 lsl $0x04 -> %w1
+72000441 : ands   w1, w2, #0x3            : ands   %w2 $0x00000003 -> %w1
+ea431041 : ands   x1, x2, x3, lsr #4      : ands   %x2 %x3 lsr $0x04 -> %x1
+f2400441 : ands   x1, x2, #0x3            : ands   %x2 $0x0000000000000003 -> %x1
+
+131f7fff : asr    wzr, wzr, #31           : sbfm   %wzr $0x1f $0x1f -> %wzr
+937fffff : asr    xzr, xzr, #63           : sbfm   %xzr $0x3f $0x3f -> %xzr
+9ac32841 : asr    x1, x2, x3              : asrv   %x2 %x3 -> %x1
+
+14081041 : b      10204104                : b      $0x0000000010204104
+15ffffff : b      17fffffc                : b      $0x0000000017fffffc
+17ffffff : b      ffffffc                 : b      $0x000000000ffffffc
+
+5480000e : b.al   ff00000                 : b.al   $0x000000000ff00000
+
+54000003 : b.cc   10000000                : b.cc   $0x0000000010000000
+
+54000002 : b.cs   10000000                : b.cs   $0x0000000010000000
+
+54000000 : b.eq   10000000                : b.eq   $0x0000000010000000
+
+5400000a : b.ge   10000000                : b.ge   $0x0000000010000000
+
+5400002c : b.gt   10000004                : b.gt   $0x0000000010000004
+
+54000008 : b.hi   10000000                : b.hi   $0x0000000010000000
+
+547fffed : b.le   100ffffc                : b.le   $0x00000000100ffffc
+
+54000009 : b.ls   10000000                : b.ls   $0x0000000010000000
+
+5400000b : b.lt   10000000                : b.lt   $0x0000000010000000
+
+54000004 : b.mi   10000000                : b.mi   $0x0000000010000000
+
+54000001 : b.ne   10000000                : b.ne   $0x0000000010000000
+
+547fffef : b.nv   100ffffc                : b.nv   $0x00000000100ffffc
+54ffffef : b.nv   ffffffc                 : b.nv   $0x000000000ffffffc
+
+54000005 : b.pl   10000000                : b.pl   $0x0000000010000000
+
+54000007 : b.vc   10000000                : b.vc   $0x0000000010000000
+
+54000006 : b.vs   10000000                : b.vs   $0x0000000010000000
+
+33031041 : bfxil  w1, w2, #3, #2          : bfm    %w1 %w2 $0x03 $0x04 -> %w1
+331f7fff : bfxil  wzr, wzr, #31, #1       : bfm    %wzr %wzr $0x1f $0x1f -> %wzr
+b3431041 : bfxil  x1, x2, #3, #2          : bfm    %x1 %x2 $0x03 $0x04 -> %x1
+b37fffff : bfxil  xzr, xzr, #63, #1       : bfm    %xzr %xzr $0x3f $0x3f -> %xzr
+
+0a231041 : bic    w1, w2, w3, lsl #4      : bic    %w2 %w3 lsl $0x04 -> %w1
+0a7f7fff : bic    wzr, wzr, wzr, lsr #31  : bic    %wzr %wzr lsr $0x1f -> %wzr
+0abf13ff : bic    wzr, wzr, wzr, asr #4   : bic    %wzr %wzr asr $0x04 -> %wzr
+8a631041 : bic    x1, x2, x3, lsr #4      : bic    %x2 %x3 lsr $0x04 -> %x1
+8aff13ff : bic    xzr, xzr, xzr, ror #4   : bic    %xzr %xzr ror $0x04 -> %xzr
 0e6f1ff8 : bic v24.8b, v31.8b, v15.8b               : bic    %d31 %d15 -> %d24
 4e6f1ff8 : bic v24.16b, v31.16b, v15.16b            : bic    %q31 %q15 -> %q24
-0ebfc7d1 : fminnm v17.2s, v30.2s, v31.2s            : fminnm %d30 %d31 $0x02 -> %d17
-4ebfc7d1 : fminnm v17.4s, v30.4s, v31.4s            : fminnm %q30 %q31 $0x02 -> %q17
-4effc7d1 : fminnm v17.2d, v30.2d, v31.2d            : fminnm %q30 %q31 $0x03 -> %q17
-0ebdcfe4 : fmls v4.2s, v31.2s, v29.2s               : fmls   %d4 %d31 %d29 $0x02 -> %d4
-4ebdcfe4 : fmls v4.4s, v31.4s, v29.4s               : fmls   %q4 %q31 %q29 $0x02 -> %q4
-4efdcfe4 : fmls v4.2d, v31.2d, v29.2d               : fmls   %q4 %q31 %q29 $0x03 -> %q4
-0ebad519 : fsub v25.2s, v8.2s, v26.2s               : fsub   %d8 %d26 $0x02 -> %d25
-4ebad519 : fsub v25.4s, v8.4s, v26.4s               : fsub   %q8 %q26 $0x02 -> %q25
-4efad519 : fsub v25.2d, v8.2d, v26.2d               : fsub   %q8 %q26 $0x03 -> %q25
-0ea0ed42 : fmlsl v2.2s, v10.2h, v0.2h               : fmlsl  %d2 %d10 %d0 -> %d2
-4ea0ed42 : fmlsl v2.4s, v10.4h, v0.4h               : fmlsl  %q2 %q10 %q0 -> %q2
-0ebff716 : fmin v22.2s, v24.2s, v31.2s              : fmin   %d24 %d31 $0x02 -> %d22
-4ebff716 : fmin v22.4s, v24.4s, v31.4s              : fmin   %q24 %q31 $0x02 -> %q22
-4efff716 : fmin v22.2d, v24.2d, v31.2d              : fmin   %q24 %q31 $0x03 -> %q22
-0ea6ff8a : frsqrts v10.2s, v28.2s, v6.2s            : frsqrts %d28 %d6 $0x02 -> %d10
-4ea6ff8a : frsqrts v10.4s, v28.4s, v6.4s            : frsqrts %q28 %q6 $0x02 -> %q10
-4ee6ff8a : frsqrts v10.2d, v28.2d, v6.2d            : frsqrts %q28 %q6 $0x03 -> %q10
-0ea01c5a : orr v26.8b, v2.8b, v0.8b                 : orr    %d2 %d0 -> %d26
-4ea01c5a : orr v26.16b, v2.16b, v0.16b              : orr    %q2 %q0 -> %q26
-0ee31c9c : orn v28.8b, v4.8b, v3.8b                 : orn    %d4 %d3 -> %d28
-4ee31c9c : orn v28.16b, v4.16b, v3.16b              : orn    %q4 %q3 -> %q28
-2e2904b6 : uhadd v22.8b, v5.8b, v9.8b               : uhadd  %d5 %d9 $0x00 -> %d22
-6e2904b6 : uhadd v22.16b, v5.16b, v9.16b            : uhadd  %q5 %q9 $0x00 -> %q22
-2e6904b6 : uhadd v22.4h, v5.4h, v9.4h               : uhadd  %d5 %d9 $0x01 -> %d22
-6e6904b6 : uhadd v22.8h, v5.8h, v9.8h               : uhadd  %q5 %q9 $0x01 -> %q22
-2ea904b6 : uhadd v22.2s, v5.2s, v9.2s               : uhadd  %d5 %d9 $0x02 -> %d22
-6ea904b6 : uhadd v22.4s, v5.4s, v9.4s               : uhadd  %q5 %q9 $0x02 -> %q22
-2e3f0fa6 : uqadd v6.8b, v29.8b, v31.8b              : uqadd  %d29 %d31 $0x00 -> %d6
-6e3f0fa6 : uqadd v6.16b, v29.16b, v31.16b           : uqadd  %q29 %q31 $0x00 -> %q6
-2e7f0fa6 : uqadd v6.4h, v29.4h, v31.4h              : uqadd  %d29 %d31 $0x01 -> %d6
-6e7f0fa6 : uqadd v6.8h, v29.8h, v31.8h              : uqadd  %q29 %q31 $0x01 -> %q6
-2ebf0fa6 : uqadd v6.2s, v29.2s, v31.2s              : uqadd  %d29 %d31 $0x02 -> %d6
-6ebf0fa6 : uqadd v6.4s, v29.4s, v31.4s              : uqadd  %q29 %q31 $0x02 -> %q6
-6eff0fa6 : uqadd v6.2d, v29.2d, v31.2d              : uqadd  %q29 %q31 $0x03 -> %q6
-2e3b17a8 : urhadd v8.8b, v29.8b, v27.8b             : urhadd %d29 %d27 $0x00 -> %d8
-6e3b17a8 : urhadd v8.16b, v29.16b, v27.16b          : urhadd %q29 %q27 $0x00 -> %q8
-2e7b17a8 : urhadd v8.4h, v29.4h, v27.4h             : urhadd %d29 %d27 $0x01 -> %d8
-6e7b17a8 : urhadd v8.8h, v29.8h, v27.8h             : urhadd %q29 %q27 $0x01 -> %q8
-2ebb17a8 : urhadd v8.2s, v29.2s, v27.2s             : urhadd %d29 %d27 $0x02 -> %d8
-6ebb17a8 : urhadd v8.4s, v29.4s, v27.4s             : urhadd %q29 %q27 $0x02 -> %q8
-2e3026bc : uhsub v28.8b, v21.8b, v16.8b             : uhsub  %d21 %d16 $0x00 -> %d28
-6e3026bc : uhsub v28.16b, v21.16b, v16.16b          : uhsub  %q21 %q16 $0x00 -> %q28
-2e7026bc : uhsub v28.4h, v21.4h, v16.4h             : uhsub  %d21 %d16 $0x01 -> %d28
-6e7026bc : uhsub v28.8h, v21.8h, v16.8h             : uhsub  %q21 %q16 $0x01 -> %q28
-2eb026bc : uhsub v28.2s, v21.2s, v16.2s             : uhsub  %d21 %d16 $0x02 -> %d28
-6eb026bc : uhsub v28.4s, v21.4s, v16.4s             : uhsub  %q21 %q16 $0x02 -> %q28
-2e352f7d : uqsub v29.8b, v27.8b, v21.8b             : uqsub  %d27 %d21 $0x00 -> %d29
-6e352f7d : uqsub v29.16b, v27.16b, v21.16b          : uqsub  %q27 %q21 $0x00 -> %q29
-2e752f7d : uqsub v29.4h, v27.4h, v21.4h             : uqsub  %d27 %d21 $0x01 -> %d29
-6e752f7d : uqsub v29.8h, v27.8h, v21.8h             : uqsub  %q27 %q21 $0x01 -> %q29
-2eb52f7d : uqsub v29.2s, v27.2s, v21.2s             : uqsub  %d27 %d21 $0x02 -> %d29
-6eb52f7d : uqsub v29.4s, v27.4s, v21.4s             : uqsub  %q27 %q21 $0x02 -> %q29
-6ef52f7d : uqsub v29.2d, v27.2d, v21.2d             : uqsub  %q27 %q21 $0x03 -> %q29
-2e3435e9 : cmhi v9.8b, v15.8b, v20.8b               : cmhi   %d15 %d20 $0x00 -> %d9
-6e3435e9 : cmhi v9.16b, v15.16b, v20.16b            : cmhi   %q15 %q20 $0x00 -> %q9
-2e7435e9 : cmhi v9.4h, v15.4h, v20.4h               : cmhi   %d15 %d20 $0x01 -> %d9
-6e7435e9 : cmhi v9.8h, v15.8h, v20.8h               : cmhi   %q15 %q20 $0x01 -> %q9
-2eb435e9 : cmhi v9.2s, v15.2s, v20.2s               : cmhi   %d15 %d20 $0x02 -> %d9
-6eb435e9 : cmhi v9.4s, v15.4s, v20.4s               : cmhi   %q15 %q20 $0x02 -> %q9
-6ef435e9 : cmhi v9.2d, v15.2d, v20.2d               : cmhi   %q15 %q20 $0x03 -> %q9
-2e3e3d82 : cmhs v2.8b, v12.8b, v30.8b               : cmhs   %d12 %d30 $0x00 -> %d2
-6e3e3d82 : cmhs v2.16b, v12.16b, v30.16b            : cmhs   %q12 %q30 $0x00 -> %q2
-2e7e3d82 : cmhs v2.4h, v12.4h, v30.4h               : cmhs   %d12 %d30 $0x01 -> %d2
-6e7e3d82 : cmhs v2.8h, v12.8h, v30.8h               : cmhs   %q12 %q30 $0x01 -> %q2
-2ebe3d82 : cmhs v2.2s, v12.2s, v30.2s               : cmhs   %d12 %d30 $0x02 -> %d2
-6ebe3d82 : cmhs v2.4s, v12.4s, v30.4s               : cmhs   %q12 %q30 $0x02 -> %q2
-6efe3d82 : cmhs v2.2d, v12.2d, v30.2d               : cmhs   %q12 %q30 $0x03 -> %q2
-2e3244e1 : ushl v1.8b, v7.8b, v18.8b                : ushl   %d7 %d18 $0x00 -> %d1
-6e3244e1 : ushl v1.16b, v7.16b, v18.16b             : ushl   %q7 %q18 $0x00 -> %q1
-2e7244e1 : ushl v1.4h, v7.4h, v18.4h                : ushl   %d7 %d18 $0x01 -> %d1
-6e7244e1 : ushl v1.8h, v7.8h, v18.8h                : ushl   %q7 %q18 $0x01 -> %q1
-2eb244e1 : ushl v1.2s, v7.2s, v18.2s                : ushl   %d7 %d18 $0x02 -> %d1
-6eb244e1 : ushl v1.4s, v7.4s, v18.4s                : ushl   %q7 %q18 $0x02 -> %q1
-6ef244e1 : ushl v1.2d, v7.2d, v18.2d                : ushl   %q7 %q18 $0x03 -> %q1
-2e324dfb : uqshl v27.8b, v15.8b, v18.8b             : uqshl  %d15 %d18 $0x00 -> %d27
-6e324dfb : uqshl v27.16b, v15.16b, v18.16b          : uqshl  %q15 %q18 $0x00 -> %q27
-2e724dfb : uqshl v27.4h, v15.4h, v18.4h             : uqshl  %d15 %d18 $0x01 -> %d27
-6e724dfb : uqshl v27.8h, v15.8h, v18.8h             : uqshl  %q15 %q18 $0x01 -> %q27
-2eb24dfb : uqshl v27.2s, v15.2s, v18.2s             : uqshl  %d15 %d18 $0x02 -> %d27
-6eb24dfb : uqshl v27.4s, v15.4s, v18.4s             : uqshl  %q15 %q18 $0x02 -> %q27
-6ef24dfb : uqshl v27.2d, v15.2d, v18.2d             : uqshl  %q15 %q18 $0x03 -> %q27
-2e265445 : urshl v5.8b, v2.8b, v6.8b                : urshl  %d2 %d6 $0x00 -> %d5
-6e265445 : urshl v5.16b, v2.16b, v6.16b             : urshl  %q2 %q6 $0x00 -> %q5
-2e665445 : urshl v5.4h, v2.4h, v6.4h                : urshl  %d2 %d6 $0x01 -> %d5
-6e665445 : urshl v5.8h, v2.8h, v6.8h                : urshl  %q2 %q6 $0x01 -> %q5
-2ea65445 : urshl v5.2s, v2.2s, v6.2s                : urshl  %d2 %d6 $0x02 -> %d5
-6ea65445 : urshl v5.4s, v2.4s, v6.4s                : urshl  %q2 %q6 $0x02 -> %q5
-6ee65445 : urshl v5.2d, v2.2d, v6.2d                : urshl  %q2 %q6 $0x03 -> %q5
-2e3e5d52 : uqrshl v18.8b, v10.8b, v30.8b            : uqrshl %d10 %d30 $0x00 -> %d18
-6e3e5d52 : uqrshl v18.16b, v10.16b, v30.16b         : uqrshl %q10 %q30 $0x00 -> %q18
-2e7e5d52 : uqrshl v18.4h, v10.4h, v30.4h            : uqrshl %d10 %d30 $0x01 -> %d18
-6e7e5d52 : uqrshl v18.8h, v10.8h, v30.8h            : uqrshl %q10 %q30 $0x01 -> %q18
-2ebe5d52 : uqrshl v18.2s, v10.2s, v30.2s            : uqrshl %d10 %d30 $0x02 -> %d18
-6ebe5d52 : uqrshl v18.4s, v10.4s, v30.4s            : uqrshl %q10 %q30 $0x02 -> %q18
-6efe5d52 : uqrshl v18.2d, v10.2d, v30.2d            : uqrshl %q10 %q30 $0x03 -> %q18
-2e3966e9 : umax v9.8b, v23.8b, v25.8b               : umax   %d23 %d25 $0x00 -> %d9
-6e3966e9 : umax v9.16b, v23.16b, v25.16b            : umax   %q23 %q25 $0x00 -> %q9
-2e7966e9 : umax v9.4h, v23.4h, v25.4h               : umax   %d23 %d25 $0x01 -> %d9
-6e7966e9 : umax v9.8h, v23.8h, v25.8h               : umax   %q23 %q25 $0x01 -> %q9
-2eb966e9 : umax v9.2s, v23.2s, v25.2s               : umax   %d23 %d25 $0x02 -> %d9
-6eb966e9 : umax v9.4s, v23.4s, v25.4s               : umax   %q23 %q25 $0x02 -> %q9
-2e2b6ecc : umin v12.8b, v22.8b, v11.8b              : umin   %d22 %d11 $0x00 -> %d12
-6e2b6ecc : umin v12.16b, v22.16b, v11.16b           : umin   %q22 %q11 $0x00 -> %q12
-2e6b6ecc : umin v12.4h, v22.4h, v11.4h              : umin   %d22 %d11 $0x01 -> %d12
-6e6b6ecc : umin v12.8h, v22.8h, v11.8h              : umin   %q22 %q11 $0x01 -> %q12
-2eab6ecc : umin v12.2s, v22.2s, v11.2s              : umin   %d22 %d11 $0x02 -> %d12
-6eab6ecc : umin v12.4s, v22.4s, v11.4s              : umin   %q22 %q11 $0x02 -> %q12
-2e3b7585 : uabd v5.8b, v12.8b, v27.8b               : uabd   %d12 %d27 $0x00 -> %d5
-6e3b7585 : uabd v5.16b, v12.16b, v27.16b            : uabd   %q12 %q27 $0x00 -> %q5
-2e7b7585 : uabd v5.4h, v12.4h, v27.4h               : uabd   %d12 %d27 $0x01 -> %d5
-6e7b7585 : uabd v5.8h, v12.8h, v27.8h               : uabd   %q12 %q27 $0x01 -> %q5
-2ebb7585 : uabd v5.2s, v12.2s, v27.2s               : uabd   %d12 %d27 $0x02 -> %d5
-6ebb7585 : uabd v5.4s, v12.4s, v27.4s               : uabd   %q12 %q27 $0x02 -> %q5
-2e337ccd : uaba v13.8b, v6.8b, v19.8b               : uaba   %d6 %d19 $0x00 -> %d13
-6e337ccd : uaba v13.16b, v6.16b, v19.16b            : uaba   %q6 %q19 $0x00 -> %q13
-2e737ccd : uaba v13.4h, v6.4h, v19.4h               : uaba   %d6 %d19 $0x01 -> %d13
-6e737ccd : uaba v13.8h, v6.8h, v19.8h               : uaba   %q6 %q19 $0x01 -> %q13
-2eb37ccd : uaba v13.2s, v6.2s, v19.2s               : uaba   %d6 %d19 $0x02 -> %d13
-6eb37ccd : uaba v13.4s, v6.4s, v19.4s               : uaba   %q6 %q19 $0x02 -> %q13
-2e3c877d : sub v29.8b, v27.8b, v28.8b               : sub    %d27 %d28 $0x00 -> %d29
-6e3c877d : sub v29.16b, v27.16b, v28.16b            : sub    %q27 %q28 $0x00 -> %q29
-2e7c877d : sub v29.4h, v27.4h, v28.4h               : sub    %d27 %d28 $0x01 -> %d29
-6e7c877d : sub v29.8h, v27.8h, v28.8h               : sub    %q27 %q28 $0x01 -> %q29
-2ebc877d : sub v29.2s, v27.2s, v28.2s               : sub    %d27 %d28 $0x02 -> %d29
-6ebc877d : sub v29.4s, v27.4s, v28.4s               : sub    %q27 %q28 $0x02 -> %q29
-6efc877d : sub v29.2d, v27.2d, v28.2d               : sub    %q27 %q28 $0x03 -> %q29
+041b0b02 : bic z2.b, p2/m, z2.b, z24.b              : bic    %p2 %z2 %z24 $0x00 -> %z2
+045b0b02 : bic z2.h, p2/m, z2.h, z24.h              : bic    %p2 %z2 %z24 $0x01 -> %z2
+049b0b02 : bic z2.s, p2/m, z2.s, z24.s              : bic    %p2 %z2 %z24 $0x02 -> %z2
+04db0b02 : bic z2.d, p2/m, z2.d, z24.d              : bic    %p2 %z2 %z24 $0x03 -> %z2
+
+6a231041 : bics   w1, w2, w3, lsl #4      : bics   %w2 %w3 lsl $0x04 -> %w1
+6abf13ff : bics   wzr, wzr, wzr, asr #4   : bics   %wzr %wzr asr $0x04 -> %wzr
+6aff7fff : bics   wzr, wzr, wzr, ror #31  : bics   %wzr %wzr ror $0x1f -> %wzr
+ea631041 : bics   x1, x2, x3, lsr #4      : bics   %x2 %x3 lsr $0x04 -> %x1
+eaff13ff : bics   xzr, xzr, xzr, ror #4   : bics   %xzr %xzr ror $0x04 -> %xzr
+
+2ee31c74 : bif v20.8b, v3.8b, v3.8b                 : bif    %d3 %d3 -> %d20
+6ee31c74 : bif v20.16b, v3.16b, v3.16b              : bif    %q3 %q3 -> %q20
+
+2eac1eac : bit v12.8b, v21.8b, v12.8b               : bit    %d21 %d12 -> %d12
+6eac1eac : bit v12.16b, v21.16b, v12.16b            : bit    %q21 %q12 -> %q12
+
+94081041 : bl     10204104                : bl     $0x0000000010204104 -> %x30
+96000000 : bl     8000000                 : bl     $0x0000000008000000 -> %x30
+97ffffff : bl     ffffffc                 : bl     $0x000000000ffffffc -> %x30
+
+d63f0000 : blr    x0                      : blr    %x0 -> %x30
+d63f0040 : blr    x2                      : blr    %x2 -> %x30
+d63f03e0 : blr    xzr                     : blr    %xzr -> %x30
+
+d61f0000 : br     x0                      : br     %x0
+d61f0040 : br     x2                      : br     %x2
+d61f03e0 : br     xzr                     : br     %xzr
+
+d4200000 : brk    #0x0                    : brk    $0x0000
+d4281040 : brk    #0x4082                 : brk    $0x4082
+d43fffe0 : brk    #0xffff                 : brk    $0xffff
+
+2e791c94 : bsl v20.8b, v4.8b, v25.8b                : bsl    %d4 %d25 -> %d20
+6e791c94 : bsl v20.16b, v4.16b, v25.16b             : bsl    %q4 %q25 -> %q20
+
+88a87c41 : cas    w8, w1, [x2]            : cas    %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
+88bf7fff : cas    wzr, wzr, [sp]          : cas    %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+c8a87c41 : cas    x8, x1, [x2]            : cas    %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
+c8bf7fff : cas    xzr, xzr, [sp]          : cas    %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+88e87c41 : casa   w8, w1, [x2]            : casa   %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
+88ff7fff : casa   wzr, wzr, [sp]          : casa   %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+c8e87c41 : casa   x8, x1, [x2]            : casa   %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
+c8ff7fff : casa   xzr, xzr, [sp]          : casa   %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+08e87c41 : casab  w8, w1, [x2]            : casab  %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
+08ff7fff : casab  wzr, wzr, [sp]          : casab  %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+48e87c41 : casah  w8, w1, [x2]            : casah  %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
+48ff7fff : casah  wzr, wzr, [sp]          : casah  %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+88e8fc41 : casal  w8, w1, [x2]            : casal  %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
+88ffffff : casal  wzr, wzr, [sp]          : casal  %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+c8e8fc41 : casal  x8, x1, [x2]            : casal  %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
+c8ffffff : casal  xzr, xzr, [sp]          : casal  %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+08e8fc41 : casalb w8, w1, [x2]            : casalb %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
+08ffffff : casalb wzr, wzr, [sp]          : casalb %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+48e8fc41 : casalh w8, w1, [x2]            : casalh %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
+48ffffff : casalh wzr, wzr, [sp]          : casalh %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+08a87c41 : casb   w8, w1, [x2]            : casb   %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
+08bf7fff : casb   wzr, wzr, [sp]          : casb   %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+48a87c41 : cash   w8, w1, [x2]            : cash   %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
+48bf7fff : cash   wzr, wzr, [sp]          : cash   %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+88a8fc41 : casl   w8, w1, [x2]            : casl   %w8 %w1 (%x2)[4byte] -> %w8 (%x2)[4byte]
+88bfffff : casl   wzr, wzr, [sp]          : casl   %wzr %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+c8a8fc41 : casl   x8, x1, [x2]            : casl   %x8 %x1 (%x2)[8byte] -> %x8 (%x2)[8byte]
+c8bfffff : casl   xzr, xzr, [sp]          : casl   %xzr %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+08a8fc41 : caslb  w8, w1, [x2]            : caslb  %w8 %w1 (%x2)[1byte] -> %w8 (%x2)[1byte]
+08bfffff : caslb  wzr, wzr, [sp]          : caslb  %wzr %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+48a8fc41 : caslh  w8, w1, [x2]            : caslh  %w8 %w1 (%x2)[2byte] -> %w8 (%x2)[2byte]
+48bfffff : caslh  wzr, wzr, [sp]          : caslh  %wzr %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+08287c40 : casp   w8, w9, w0, w1, [x2]    : casp   %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
+083e7ffe : casp   w30, wzr, w30, wzr, [sp]: casp   %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
+48287c40 : casp   x8, x9, x0, x1, [x2]    : casp   %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
+483e7ffe : casp   x30, xzr, x30, xzr, [sp]: casp   %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
+
+08687c40 : caspa  w8, w9, w0, w1, [x2]    : caspa  %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
+087e7ffe : caspa  w30, wzr, w30, wzr, [sp]: caspa  %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
+48687c40 : caspa  x8, x9, x0, x1, [x2]    : caspa  %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
+487e7ffe : caspa  x30, xzr, x30, xzr, [sp]: caspa  %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
+
+0868fc40 : caspal w8, w9, w0, w1, [x2]    : caspal %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
+087efffe : caspal w30, wzr, w30, wzr, [sp]: caspal %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
+4868fc40 : caspal x8, x9, x0, x1, [x2]    : caspal %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
+487efffe : caspal x30, xzr, x30, xzr, [sp]: caspal %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
+
+0828fc40 : caspl  w8, w9, w0, w1, [x2]    : caspl  %w8 %w9 %w0 %w1 (%x2)[8byte] -> %w8 %w9 (%x2)[8byte]
+083efffe : caspl  w30, wzr, w30, wzr, [sp]: caspl  %w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr (%sp)[8byte]
+4828fc40 : caspl  x8, x9, x0, x1, [x2]    : caspl  %x8 %x9 %x0 %x1 (%x2)[16byte] -> %x8 %x9 (%x2)[16byte]
+483efffe : caspl  x30, xzr, x30, xzr, [sp]: caspl  %x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr (%sp)[16byte]
+
+35081041 : cbnz   w1, 10010208            : cbnz   $0x0000000010010208 %w1
+b5800000 : cbnz   x0, ff00000             : cbnz   $0x000000000ff00000 %x0
+b5ffffff : cbnz   xzr, ffffffc            : cbnz   $0x000000000ffffffc %xzr
+
+34081041 : cbz    w1, 10010208            : cbz    $0x0000000010010208 %w1
+347fffff : cbz    wzr, 100ffffc           : cbz    $0x00000000100ffffc %wzr
+b4ffffff : cbz    xzr, ffffffc            : cbz    $0x000000000ffffffc %xzr
+
+3a40f820 : ccmn   w1, #0x0, #0x0, nv      : ccmn   %w1 $0x00 $0x00 nv
+3a42f020 : ccmn   w1, w2, #0x0, nv        : ccmn   %w1 %w2 $0x00 nv
+ba55d822 : ccmn   x1, #0x15, #0x2, le     : ccmn   %x1 $0x15 $0x02 le
+ba5fd022 : ccmn   x1, xzr, #0x2, le       : ccmn   %x1 %xzr $0x02 le
+
+7a42e3e1 : ccmp   wzr, w2, #0x1, al       : ccmp   %wzr %w2 $0x01 al
+7a4aebe1 : ccmp   wzr, #0xa, #0x1, al     : ccmp   %wzr $0x0a $0x01 al
+fa42c023 : ccmp   x1, x2, #0x3, gt        : ccmp   %x1 %x2 $0x03 gt
+fa5fc823 : ccmp   x1, #0x1f, #0x3, gt     : ccmp   %x1 $0x1f $0x03 gt
+
+d503305f : clrex  #0x0                    : clrex  $0x00
+d5033f5f : clrex                          : clrex  $0x0f
+
+5ac01441 : cls    w1, w2                  : cls    %w2 -> %w1
+dac01441 : cls    x1, x2                  : cls    %x2 -> %x1
+
+5ac01041 : clz    w1, w2                  : clz    %w2 -> %w1
+dac01041 : clz    x1, x2                  : clz    %x2 -> %x1
+
 2e378e2d : cmeq v13.8b, v17.8b, v23.8b              : cmeq   %d17 %d23 $0x00 -> %d13
 6e378e2d : cmeq v13.16b, v17.16b, v23.16b           : cmeq   %q17 %q23 $0x00 -> %q13
 2e778e2d : cmeq v13.4h, v17.4h, v23.4h              : cmeq   %d17 %d23 $0x01 -> %d13
@@ -1948,202 +306,178 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 2eb78e2d : cmeq v13.2s, v17.2s, v23.2s              : cmeq   %d17 %d23 $0x02 -> %d13
 6eb78e2d : cmeq v13.4s, v17.4s, v23.4s              : cmeq   %q17 %q23 $0x02 -> %q13
 6ef78e2d : cmeq v13.2d, v17.2d, v23.2d              : cmeq   %q17 %q23 $0x03 -> %q13
-2e3b95a7 : mls v7.8b, v13.8b, v27.8b                : mls    %d7 %d13 %d27 $0x00 -> %d7
-6e3b95a7 : mls v7.16b, v13.16b, v27.16b             : mls    %q7 %q13 %q27 $0x00 -> %q7
-2e7b95a7 : mls v7.4h, v13.4h, v27.4h                : mls    %d7 %d13 %d27 $0x01 -> %d7
-6e7b95a7 : mls v7.8h, v13.8h, v27.8h                : mls    %q7 %q13 %q27 $0x01 -> %q7
-2ebb95a7 : mls v7.2s, v13.2s, v27.2s                : mls    %d7 %d13 %d27 $0x02 -> %d7
-6ebb95a7 : mls v7.4s, v13.4s, v27.4s                : mls    %q7 %q13 %q27 $0x02 -> %q7
-2e2c9f1a : pmul v26.8b, v24.8b, v12.8b              : pmul   %d24 %d12 $0x00 -> %d26
-6e2c9f1a : pmul v26.16b, v24.16b, v12.16b           : pmul   %q24 %q12 $0x00 -> %q26
-2e25a764 : umaxp v4.8b, v27.8b, v5.8b               : umaxp  %d27 %d5 $0x00 -> %d4
-6e25a764 : umaxp v4.16b, v27.16b, v5.16b            : umaxp  %q27 %q5 $0x00 -> %q4
-2e65a764 : umaxp v4.4h, v27.4h, v5.4h               : umaxp  %d27 %d5 $0x01 -> %d4
-6e65a764 : umaxp v4.8h, v27.8h, v5.8h               : umaxp  %q27 %q5 $0x01 -> %q4
-2ea5a764 : umaxp v4.2s, v27.2s, v5.2s               : umaxp  %d27 %d5 $0x02 -> %d4
-6ea5a764 : umaxp v4.4s, v27.4s, v5.4s               : umaxp  %q27 %q5 $0x02 -> %q4
-2e30aec3 : uminp v3.8b, v22.8b, v16.8b              : uminp  %d22 %d16 $0x00 -> %d3
-6e30aec3 : uminp v3.16b, v22.16b, v16.16b           : uminp  %q22 %q16 $0x00 -> %q3
-2e70aec3 : uminp v3.4h, v22.4h, v16.4h              : uminp  %d22 %d16 $0x01 -> %d3
-6e70aec3 : uminp v3.8h, v22.8h, v16.8h              : uminp  %q22 %q16 $0x01 -> %q3
-2eb0aec3 : uminp v3.2s, v22.2s, v16.2s              : uminp  %d22 %d16 $0x02 -> %d3
-6eb0aec3 : uminp v3.4s, v22.4s, v16.4s              : uminp  %q22 %q16 $0x02 -> %q3
-2e7bb7b7 : sqrdmulh v23.4h, v29.4h, v27.4h          : sqrdmulh %d29 %d27 $0x01 -> %d23
-6e7bb7b7 : sqrdmulh v23.8h, v29.8h, v27.8h          : sqrdmulh %q29 %q27 $0x01 -> %q23
-2ebbb7b7 : sqrdmulh v23.2s, v29.2s, v27.2s          : sqrdmulh %d29 %d27 $0x02 -> %d23
-6ebbb7b7 : sqrdmulh v23.4s, v29.4s, v27.4s          : sqrdmulh %q29 %q27 $0x02 -> %q23
-2e3dc64c : fmaxnmp v12.2s, v18.2s, v29.2s           : fmaxnmp %d18 %d29 $0x02 -> %d12
-6e3dc64c : fmaxnmp v12.4s, v18.4s, v29.4s           : fmaxnmp %q18 %q29 $0x02 -> %q12
-6e7dc64c : fmaxnmp v12.2d, v18.2d, v29.2d           : fmaxnmp %q18 %q29 $0x03 -> %q12
-2e20cd42 : fmlal2 v2.2s, v10.2h, v0.2h              : fmlal2 %d2 %d10 %d0 -> %d2
-6e20cd42 : fmlal2 v2.4s, v10.4h, v0.4h              : fmlal2 %q2 %q10 %q0 -> %q2
-2e30d7f2 : faddp v18.2s, v31.2s, v16.2s             : faddp  %d31 %d16 $0x02 -> %d18
-6e30d7f2 : faddp v18.4s, v31.4s, v16.4s             : faddp  %q31 %q16 $0x02 -> %q18
-6e70d7f2 : faddp v18.2d, v31.2d, v16.2d             : faddp  %q31 %q16 $0x03 -> %q18
-2e35df99 : fmul v25.2s, v28.2s, v21.2s              : fmul   %d28 %d21 $0x02 -> %d25
-6e35df99 : fmul v25.4s, v28.4s, v21.4s              : fmul   %q28 %q21 $0x02 -> %q25
-6e75df99 : fmul v25.2d, v28.2d, v21.2d              : fmul   %q28 %q21 $0x03 -> %q25
-2e3ee636 : fcmge v22.2s, v17.2s, v30.2s             : fcmge  %d17 %d30 $0x02 -> %d22
-6e3ee636 : fcmge v22.4s, v17.4s, v30.4s             : fcmge  %q17 %q30 $0x02 -> %q22
-6e7ee636 : fcmge v22.2d, v17.2d, v30.2d             : fcmge  %q17 %q30 $0x03 -> %q22
-2e3eefdc : facge v28.2s, v30.2s, v30.2s             : facge  %d30 %d30 $0x02 -> %d28
-6e3eefdc : facge v28.4s, v30.4s, v30.4s             : facge  %q30 %q30 $0x02 -> %q28
-6e7eefdc : facge v28.2d, v30.2d, v30.2d             : facge  %q30 %q30 $0x03 -> %q28
-2e39f6e5 : fmaxp v5.2s, v23.2s, v25.2s              : fmaxp  %d23 %d25 $0x02 -> %d5
-6e39f6e5 : fmaxp v5.4s, v23.4s, v25.4s              : fmaxp  %q23 %q25 $0x02 -> %q5
-6e79f6e5 : fmaxp v5.2d, v23.2d, v25.2d              : fmaxp  %q23 %q25 $0x03 -> %q5
-2e24ff4a : fdiv v10.2s, v26.2s, v4.2s               : fdiv   %d26 %d4 $0x02 -> %d10
-6e24ff4a : fdiv v10.4s, v26.4s, v4.4s               : fdiv   %q26 %q4 $0x02 -> %q10
-6e64ff4a : fdiv v10.2d, v26.2d, v4.2d               : fdiv   %q26 %q4 $0x03 -> %q10
+
+0e3a3f16 : cmge v22.8b, v24.8b, v26.8b              : cmge   %d24 %d26 $0x00 -> %d22
+4e3a3f16 : cmge v22.16b, v24.16b, v26.16b           : cmge   %q24 %q26 $0x00 -> %q22
+0e7a3f16 : cmge v22.4h, v24.4h, v26.4h              : cmge   %d24 %d26 $0x01 -> %d22
+4e7a3f16 : cmge v22.8h, v24.8h, v26.8h              : cmge   %q24 %q26 $0x01 -> %q22
+0eba3f16 : cmge v22.2s, v24.2s, v26.2s              : cmge   %d24 %d26 $0x02 -> %d22
+4eba3f16 : cmge v22.4s, v24.4s, v26.4s              : cmge   %q24 %q26 $0x02 -> %q22
+4efa3f16 : cmge v22.2d, v24.2d, v26.2d              : cmge   %q24 %q26 $0x03 -> %q22
+
+0e283742 : cmgt v2.8b, v26.8b, v8.8b                : cmgt   %d26 %d8 $0x00 -> %d2
+4e283742 : cmgt v2.16b, v26.16b, v8.16b             : cmgt   %q26 %q8 $0x00 -> %q2
+0e683742 : cmgt v2.4h, v26.4h, v8.4h                : cmgt   %d26 %d8 $0x01 -> %d2
+4e683742 : cmgt v2.8h, v26.8h, v8.8h                : cmgt   %q26 %q8 $0x01 -> %q2
+0ea83742 : cmgt v2.2s, v26.2s, v8.2s                : cmgt   %d26 %d8 $0x02 -> %d2
+4ea83742 : cmgt v2.4s, v26.4s, v8.4s                : cmgt   %q26 %q8 $0x02 -> %q2
+4ee83742 : cmgt v2.2d, v26.2d, v8.2d                : cmgt   %q26 %q8 $0x03 -> %q2
+
+2e3435e9 : cmhi v9.8b, v15.8b, v20.8b               : cmhi   %d15 %d20 $0x00 -> %d9
+6e3435e9 : cmhi v9.16b, v15.16b, v20.16b            : cmhi   %q15 %q20 $0x00 -> %q9
+2e7435e9 : cmhi v9.4h, v15.4h, v20.4h               : cmhi   %d15 %d20 $0x01 -> %d9
+6e7435e9 : cmhi v9.8h, v15.8h, v20.8h               : cmhi   %q15 %q20 $0x01 -> %q9
+2eb435e9 : cmhi v9.2s, v15.2s, v20.2s               : cmhi   %d15 %d20 $0x02 -> %d9
+6eb435e9 : cmhi v9.4s, v15.4s, v20.4s               : cmhi   %q15 %q20 $0x02 -> %q9
+6ef435e9 : cmhi v9.2d, v15.2d, v20.2d               : cmhi   %q15 %q20 $0x03 -> %q9
+
+2e3e3d82 : cmhs v2.8b, v12.8b, v30.8b               : cmhs   %d12 %d30 $0x00 -> %d2
+6e3e3d82 : cmhs v2.16b, v12.16b, v30.16b            : cmhs   %q12 %q30 $0x00 -> %q2
+2e7e3d82 : cmhs v2.4h, v12.4h, v30.4h               : cmhs   %d12 %d30 $0x01 -> %d2
+6e7e3d82 : cmhs v2.8h, v12.8h, v30.8h               : cmhs   %q12 %q30 $0x01 -> %q2
+2ebe3d82 : cmhs v2.2s, v12.2s, v30.2s               : cmhs   %d12 %d30 $0x02 -> %d2
+6ebe3d82 : cmhs v2.4s, v12.4s, v30.4s               : cmhs   %q12 %q30 $0x02 -> %q2
+6efe3d82 : cmhs v2.2d, v12.2d, v30.2d               : cmhs   %q12 %q30 $0x03 -> %q2
+
+2b3f43ff : cmn    wsp, wzr                : adds   %wsp %wzr uxtw $0x00 -> %wzr
+2b5f7fff : cmn    wzr, wzr, lsr #31       : adds   %wzr %wzr lsr $0x1f -> %wzr
+2b9f13ff : cmn    wzr, wzr, asr #4        : adds   %wzr %wzr asr $0x04 -> %wzr
+310003ff : cmn    wsp, #0x0               : adds   %wsp $0x0000 lsl $0x00 -> %wzr
+31000fff : cmn    wsp, #0x3               : adds   %wsp $0x0003 lsl $0x00 -> %wzr
+ab9f13ff : cmn    xzr, xzr, asr #4        : adds   %xzr %xzr asr $0x04 -> %xzr
+ab9fffff : cmn    xzr, xzr, asr #63       : adds   %xzr %xzr asr $0x3f -> %xzr
+b1000fff : cmn    sp, #0x3                : adds   %sp $0x0003 lsl $0x00 -> %xzr
+
+6b3f8fff : cmp    wsp, wzr, sxtb #3       : subs   %wsp %wzr sxtb $0x03 -> %wzr
+6b3fc7ff : cmp    wsp, wzr, sxtw #1       : subs   %wsp %wzr sxtw $0x01 -> %wzr
+71000fff : cmp    wsp, #0x3               : subs   %wsp $0x0003 lsl $0x00 -> %wzr
+eb3fabff : cmp    sp, wzr, sxth #2        : subs   %sp %xzr sxth $0x02 -> %xzr
+eb3fe3ff : cmp    sp, xzr, sxtx           : subs   %sp %xzr sxtx $0x00 -> %xzr
+f1000fff : cmp    sp, #0x3                : subs   %sp $0x0003 lsl $0x00 -> %xzr
+f16003ff : cmp    sp, #0x800, lsl #12     : subs   %sp $0x0800 lsl $0x10 -> %xzr
+
+0e228dfa : cmtst v26.8b, v15.8b, v2.8b              : cmtst  %d15 %d2 $0x00 -> %d26
+4e228dfa : cmtst v26.16b, v15.16b, v2.16b           : cmtst  %q15 %q2 $0x00 -> %q26
+0e628dfa : cmtst v26.4h, v15.4h, v2.4h              : cmtst  %d15 %d2 $0x01 -> %d26
+4e628dfa : cmtst v26.8h, v15.8h, v2.8h              : cmtst  %q15 %q2 $0x01 -> %q26
+0ea28dfa : cmtst v26.2s, v15.2s, v2.2s              : cmtst  %d15 %d2 $0x02 -> %d26
+4ea28dfa : cmtst v26.4s, v15.4s, v2.4s              : cmtst  %q15 %q2 $0x02 -> %q26
+4ee28dfa : cmtst v26.2d, v15.2d, v2.2d              : cmtst  %q15 %q2 $0x03 -> %q26
+
+1ac34041 : crc32b w1, w2, w3              : crc32b %w2 %w3 -> %w1
+
+1ac353e1 : crc32cb w1, wzr, w3            : crc32cb %wzr %w3 -> %w1
+
+1ac3545f : crc32ch wzr, w2, w3            : crc32ch %w2 %w3 -> %wzr
+
+1ac35841 : crc32cw w1, w2, w3             : crc32cw %w2 %w3 -> %w1
+
+9ac35c41 : crc32cx w1, w2, x3             : crc32cx %w2 %x3 -> %w1
+
+1ac34441 : crc32h w1, w2, w3              : crc32h %w2 %w3 -> %w1
+
+1adf4841 : crc32w w1, w2, wzr             : crc32w %w2 %wzr -> %w1
+
+9ac34c41 : crc32x w1, w2, x3              : crc32x %w2 %x3 -> %w1
+
+9a830041 : csel   x1, x2, x3, eq          : csel   %x2 %x3 eq -> %x1
+
+1a9f7441 : csinc  w1, w2, wzr, vc         : csinc  %w2 %wzr vc -> %w1
+
+5a8383e1 : csinv  w1, wzr, w3, hi         : csinv  %wzr %w3 hi -> %w1
+
+da83f45f : csneg  xzr, x2, x3, nv         : csneg  %x2 %x3 nv -> %xzr
+
+d50330bf : dmb    #0x00                   : dmb    $0x00
+d5033fbf : dmb    sy                      : dmb    $0x0f
+
+d503309f : dsb    #0x00                   : dsb    $0x00
+d5033f9f : dsb    sy                      : dsb    $0x0f
+
+4a231041 : eon    w1, w2, w3, lsl #4      : eon    %w2 %w3 lsl $0x04 -> %w1
+4abf13ff : eon    wzr, wzr, wzr, asr #4   : eon    %wzr %wzr asr $0x04 -> %wzr
+ca631041 : eon    x1, x2, x3, lsr #4      : eon    %x2 %x3 lsr $0x04 -> %x1
+ca7f7fff : eon    xzr, xzr, xzr, lsr #31  : eon    %xzr %xzr lsr $0x1f -> %xzr
+caff13ff : eon    xzr, xzr, xzr, ror #4   : eon    %xzr %xzr ror $0x04 -> %xzr
+
+4a031041 : eor    w1, w2, w3, lsl #4      : eor    %w2 %w3 lsl $0x04 -> %w1
+4a9f13ff : eor    wzr, wzr, wzr, asr #4   : eor    %wzr %wzr asr $0x04 -> %wzr
+52000441 : eor    w1, w2, #0x3            : eor    %w2 $0x00000003 -> %w1
+ca431041 : eor    x1, x2, x3, lsr #4      : eor    %x2 %x3 lsr $0x04 -> %x1
+cadf13ff : eor    xzr, xzr, xzr, ror #4   : eor    %xzr %xzr ror $0x04 -> %xzr
+d2400441 : eor    x1, x2, #0x3            : eor    %x2 $0x0000000000000003 -> %x1
 2e341c33 : eor v19.8b, v1.8b, v20.8b                : eor    %d1 %d20 -> %d19
 6e341c33 : eor v19.16b, v1.16b, v20.16b             : eor    %q1 %q20 -> %q19
-2e791c94 : bsl v20.8b, v4.8b, v25.8b                : bsl    %d4 %d25 -> %d20
-6e791c94 : bsl v20.16b, v4.16b, v25.16b             : bsl    %q4 %q25 -> %q20
-2eabc657 : fminnmp v23.2s, v18.2s, v11.2s           : fminnmp %d18 %d11 $0x02 -> %d23
-6eabc657 : fminnmp v23.4s, v18.4s, v11.4s           : fminnmp %q18 %q11 $0x02 -> %q23
-6eebc657 : fminnmp v23.2d, v18.2d, v11.2d           : fminnmp %q18 %q11 $0x03 -> %q23
-2ea0cd42 : fmlsl2 v2.2s, v10.2h, v0.2h              : fmlsl2 %d2 %d10 %d0 -> %d2
-6ea0cd42 : fmlsl2 v2.4s, v10.4h, v0.4h              : fmlsl2 %q2 %q10 %q0 -> %q2
+0419105d : eor z29.b, p4/m, z29.b, z2.b             : eor    %p4 %z29 %z2 $0x00 -> %z29
+0459105d : eor z29.h, p4/m, z29.h, z2.h             : eor    %p4 %z29 %z2 $0x01 -> %z29
+0499105d : eor z29.s, p4/m, z29.s, z2.s             : eor    %p4 %z29 %z2 $0x02 -> %z29
+04d9105d : eor z29.d, p4/m, z29.d, z2.d             : eor    %p4 %z29 %z2 $0x03 -> %z29
+
+13831041 : extr   w1, w2, w3, #4          : extr   %w2 %w3 $0x04 -> %w1
+93c31041 : extr   x1, x2, x3, #4          : extr   %x2 %x3 $0x04 -> %x1
+
+2ecc155c : fabd v28.4h, v10.4h, v12.4h              : fabd   %d10 %d12 $0x01 -> %d28
+6ecc155c : fabd v28.8h, v10.8h, v12.8h              : fabd   %q10 %q12 $0x01 -> %q28
 2eb3d54f : fabd v15.2s, v10.2s, v19.2s              : fabd   %d10 %d19 $0x02 -> %d15
 6eb3d54f : fabd v15.4s, v10.4s, v19.4s              : fabd   %q10 %q19 $0x02 -> %q15
 6ef3d54f : fabd v15.2d, v10.2d, v19.2d              : fabd   %q10 %q19 $0x03 -> %q15
-2eaee466 : fcmgt v6.2s, v3.2s, v14.2s               : fcmgt  %d3 %d14 $0x02 -> %d6
-6eaee466 : fcmgt v6.4s, v3.4s, v14.4s               : fcmgt  %q3 %q14 $0x02 -> %q6
-6eeee466 : fcmgt v6.2d, v3.2d, v14.2d               : fcmgt  %q3 %q14 $0x03 -> %q6
-2eacef44 : facgt v4.2s, v26.2s, v12.2s              : facgt  %d26 %d12 $0x02 -> %d4
-6eacef44 : facgt v4.4s, v26.4s, v12.4s              : facgt  %q26 %q12 $0x02 -> %q4
-6eecef44 : facgt v4.2d, v26.2d, v12.2d              : facgt  %q26 %q12 $0x03 -> %q4
-2eb9f43c : fminp v28.2s, v1.2s, v25.2s              : fminp  %d1 %d25 $0x02 -> %d28
-6eb9f43c : fminp v28.4s, v1.4s, v25.4s              : fminp  %q1 %q25 $0x02 -> %q28
-6ef9f43c : fminp v28.2d, v1.2d, v25.2d              : fminp  %q1 %q25 $0x03 -> %q28
-2eac1eac : bit v12.8b, v21.8b, v12.8b               : bit    %d21 %d12 -> %d12
-6eac1eac : bit v12.16b, v21.16b, v12.16b            : bit    %q21 %q12 -> %q12
-2ee31c74 : bif v20.8b, v3.8b, v3.8b                 : bif    %d3 %d3 -> %d20
-6ee31c74 : bif v20.16b, v3.16b, v3.16b              : bif    %q3 %q3 -> %q20
 
-# Floating-point data-processing (1 source)
-1e604362 : fmov d2, d27                             : fmov   %d27 -> %d2
-1e204362 : fmov s2, s27                             : fmov   %s27 -> %s2
-1ee04362 : fmov h2, h27                             : fmov   %h27 -> %h2
-4f03fe10 : fmov v1.8h, #1.00000000                  : fmov   $1.000000 $0x01 -> %q16
-4f00fc01 : fmov v1.8h, #2.00000000                  : fmov   $2.000000 $0x01 -> %q1
-4f07fe02 : fmov v2.8h, #-1.0000000                  : fmov   $-1.000000 $0x01 -> %q2
-4f04fc03 : fmov v3.8h, #-2.0000000                  : fmov   $-2.000000 $0x01 -> %q3
-4f00fd84 : fmov v4.8h, #3.50000000                  : fmov   $3.500000 $0x01 -> %q4
-4f00fe25 : fmov v5.8h, #4.25000000                  : fmov   $4.250000 $0x01 -> %q5
-4f03fe46 : fmov v6.8h, #1.12500000                  : fmov   $1.125000 $0x01 -> %q6
-4f06fe07 : fmov v7.8h, #-0.2500000                  : fmov   $-0.250000 $0x01 -> %q7
-4f00ff88 : fmov v8.8h, #7.00000000                  : fmov   $7.000000 $0x01 -> %q8
-4f03ffe9 : fmov v9.8h, #1.93750000                  : fmov   $1.937500 $0x01 -> %q9
-4f02fd6a : fmov v10.8h, #0.210937                   : fmov   $0.210937 $0x01 -> %q10
-4f01ffff : fmov v31.8h, #31.0000000                 : fmov   $31.000000 $0x01 -> %q31
-1e2e1000 : fmov s0, #1.00000000                     : fmov   $1.000000 -> %s0
-1e201001 : fmov s1, #2.00000000                     : fmov   $2.000000 -> %s1
-1e211002 : fmov s2, #3.00000000                     : fmov   $3.000000 -> %s2
-1e3e1003 : fmov s3, #-1.0000000                     : fmov   $-1.000000 -> %s3
-1e301004 : fmov s4, #-2.0000000                     : fmov   $-2.000000 -> %s4
-1e219005 : fmov s5, #3.50000000                     : fmov   $3.500000 -> %s5
-1e223006 : fmov s6, #4.25000000                     : fmov   $4.250000 -> %s6
-1e2e5007 : fmov s7, #1.12500000                     : fmov   $1.125000 -> %s7
-1e3a1008 : fmov s8, #-0.2500000                     : fmov   $-0.250000 -> %s8
-1e239009 : fmov s9, #7.00000000                     : fmov   $7.000000 -> %s9
-1e2ff00a : fmov s10, #1.9375000                     : fmov   $1.937500 -> %s10
-1e29701e : fmov s30, #0.2109375                     : fmov   $0.210937 -> %s30
-1e27f01f : fmov s31, #31.0000000                    : fmov   $31.000000 -> %s31
-1e603000 : fmov d0, #2.1250000                      : fmov   $2.125000 -> %d0
-1e6a9001 : fmov d1, #0.3125000                      : fmov   $0.312500 -> %d1
-1e65f002 : fmov d2, #15.5000000                     : fmov   $15.500000 -> %d2
-1e703003 : fmov d3, #-2.1250000                     : fmov   $-2.125000 -> %d3
-1e7a9004 : fmov d4, #-0.3125000                     : fmov   $-0.312500 -> %d4
-1e75f005 : fmov d5, #-15.5000000                    : fmov   $-15.500000 -> %d5
-1e649006 : fmov d6, #10.0000000                     : fmov   $10.000000 -> %d6
-1e64b007 : fmov d7, #10.5000000                     : fmov   $10.500000 -> %d7
-1e64d008 : fmov d8, #11.0000000                     : fmov   $11.000000 -> %d8
-1e64f009 : fmov d9, #11.5000000                     : fmov   $11.500000 -> %d9
-1e75100a : fmov d10, #-12.0000000                   : fmov   $-12.000000 -> %d10
-1e75301e : fmov d30, #-12.5000000                   : fmov   $-12.500000 -> %d30
-1e61301f : fmov d31, #3.125000000                   : fmov   $3.125000 -> %d31
 1e60c01e : fabs d30, d0                             : fabs   %d0 -> %d30
 1e20c01e : fabs s30, s0                             : fabs   %s0 -> %s30
 1ee0c01e : fabs h30, h0                             : fabs   %h0 -> %h30
-1e6143ad : fneg d13, d29                            : fneg   %d29 -> %d13
-1e2143ad : fneg s13, s29                            : fneg   %s29 -> %s13
-1ee143ad : fneg h13, h29                            : fneg   %h29 -> %h13
-1e61c23f : fsqrt d31, d17                           : fsqrt  %d17 -> %d31
-1e21c23f : fsqrt s31, s17                           : fsqrt  %s17 -> %s31
-1ee1c23f : fsqrt h31, h17                           : fsqrt  %h17 -> %h31
-1e22c04a : fcvt d10, s2                             : fcvt   %s2 -> %d10
-1e23c29f : fcvt h31, s20                            : fcvt   %s20 -> %h31
-1e6441e4 : frintn d4, d15                           : frintn %d15 -> %d4
-1e2441e4 : frintn s4, s15                           : frintn %s15 -> %s4
-1ee441e4 : frintn h4, h15                           : frintn %h15 -> %h4
-1e64c057 : frintp d23, d2                           : frintp %d2 -> %d23
-1e24c057 : frintp s23, s2                           : frintp %s2 -> %s23
-1ee4c057 : frintp h23, h2                           : frintp %h2 -> %h23
-1e65411a : frintm d26, d8                           : frintm %d8 -> %d26
-1e25411a : frintm s26, s8                           : frintm %s8 -> %s26
-1ee5411a : frintm h26, h8                           : frintm %h8 -> %h26
-1e65c316 : frintz d22, d24                          : frintz %d24 -> %d22
-1e25c316 : frintz s22, s24                          : frintz %s24 -> %s22
-1ee5c316 : frintz h22, h24                          : frintz %h24 -> %h22
-1e66425a : frinta d26, d18                          : frinta %d18 -> %d26
-1e26425a : frinta s26, s18                          : frinta %s18 -> %s26
-1ee6425a : frinta h26, h18                          : frinta %h18 -> %h26
-1e6743b0 : frintx d16, d29                          : frintx %d29 -> %d16
-1e2743b0 : frintx s16, s29                          : frintx %s29 -> %s16
-1ee743b0 : frintx h16, h29                          : frintx %h29 -> %h16
-1e67c26b : frinti d11, d19                          : frinti %d19 -> %d11
-1e27c26b : frinti s11, s19                          : frinti %s19 -> %s11
-1ee7c26b : frinti h11, h19                          : frinti %h19 -> %h11
 
-# Floating-point data-processing (2 source)
-1e7e0b62 : fmul d2, d27, d30                        : fmul   %d27 %d30 -> %d2
-1e3e0b62 : fmul s2, s27, s30                        : fmul   %s27 %s30 -> %s2
-1efe0b62 : fmul h2, h27, h30                        : fmul   %h27 %h30 -> %h2
-1e7d19a0 : fdiv d0, d13, d29                        : fdiv   %d13 %d29 -> %d0
-1e3d19a0 : fdiv s0, s13, s29                        : fdiv   %s13 %s29 -> %s0
-1efd19a0 : fdiv h0, h13, h29                        : fdiv   %h13 %h29 -> %h0
+2e5f2c42 : facge v2.4h, v2.4h, v31.4h               : facge  %d2 %d31 $0x01 -> %d2
+6e5f2c42 : facge v2.8h, v2.8h, v31.8h               : facge  %q2 %q31 $0x01 -> %q2
+2e3eefdc : facge v28.2s, v30.2s, v30.2s             : facge  %d30 %d30 $0x02 -> %d28
+6e3eefdc : facge v28.4s, v30.4s, v30.4s             : facge  %q30 %q30 $0x02 -> %q28
+6e7eefdc : facge v28.2d, v30.2d, v30.2d             : facge  %q30 %q30 $0x03 -> %q28
+
+2ed12dfc : facgt v28.4h, v15.4h, v17.4h             : facgt  %d15 %d17 $0x01 -> %d28
+6ed12dfc : facgt v28.8h, v15.8h, v17.8h             : facgt  %q15 %q17 $0x01 -> %q28
+2eacef44 : facgt v4.2s, v26.2s, v12.2s              : facgt  %d26 %d12 $0x02 -> %d4
+6eacef44 : facgt v4.4s, v26.4s, v12.4s              : facgt  %q26 %q12 $0x02 -> %q4
+6eecef44 : facgt v4.2d, v26.2d, v12.2d              : facgt  %q26 %q12 $0x03 -> %q4
+
+0e421551 : fadd v17.4h, v10.4h, v2.4h               : fadd   %d10 %d2 $0x01 -> %d17
+4e421551 : fadd v17.8h, v10.8h, v2.8h               : fadd   %q10 %q2 $0x01 -> %q17
+0e2bd56a : fadd v10.2s, v11.2s, v11.2s              : fadd   %d11 %d11 $0x02 -> %d10
+4e2bd56a : fadd v10.4s, v11.4s, v11.4s              : fadd   %q11 %q11 $0x02 -> %q10
+4e6bd56a : fadd v10.2d, v11.2d, v11.2d              : fadd   %q11 %q11 $0x03 -> %q10
 1e6a2a3f : fadd d31, d17, d10                       : fadd   %d17 %d10 -> %d31
 1e2a2a3f : fadd s31, s17, s10                       : fadd   %s17 %s10 -> %s31
 1eea2a3f : fadd h31, h17, h10                       : fadd   %h17 %h10 -> %h31
-1e743be2 : fsub d2, d31, d20                        : fsub   %d31 %d20 -> %d2
-1e343be2 : fsub s2, s31, s20                        : fsub   %s31 %s20 -> %s2
-1ef43be2 : fsub h2, h31, h20                        : fsub   %h31 %h20 -> %h2
-1e7749e4 : fmax d4, d15, d23                        : fmax   %d15 %d23 -> %d4
-1e3749e4 : fmax s4, s15, s23                        : fmax   %s15 %s23 -> %s4
-1ef749e4 : fmax h4, h15, h23                        : fmax   %h15 %h23 -> %h4
-1e685b42 : fmin d2, d26, d8                         : fmin   %d26 %d8 -> %d2
-1e285b42 : fmin s2, s26, s8                         : fmin   %s26 %s8 -> %s2
-1ee85b42 : fmin h2, h26, h8                         : fmin   %h26 %h8 -> %h2
-1e7a6b16 : fmaxnm d22, d24, d26                     : fmaxnm %d24 %d26 -> %d22
-1e3a6b16 : fmaxnm s22, s24, s26                     : fmaxnm %s24 %s26 -> %s22
-1efa6b16 : fmaxnm h22, h24, h26                     : fmaxnm %h24 %h26 -> %h22
-1e7d7a12 : fminnm d18, d16, d29                     : fminnm %d16 %d29 -> %d18
-1e3d7a12 : fminnm s18, s16, s29                     : fminnm %s16 %s29 -> %s18
-1efd7a12 : fminnm h18, h16, h29                     : fminnm %h16 %h29 -> %h18
-1e778a6b : fnmul d11, d19, d23                      : fnmul  %d19 %d23 -> %d11
-1e378a6b : fnmul s11, s19, s23                      : fnmul  %s19 %s23 -> %s11
-1ef78a6b : fnmul h11, h19, h23                      : fnmul  %h19 %h23 -> %h11
 
-# Floating-point data-processing (3 source)
-1f5e0362 : fmadd d2, d27, d30, d0                   : fmadd  %d27 %d30 %d0 -> %d2
-1f1e0362 : fmadd s2, s27, s30, s0                   : fmadd  %s27 %s30 %s0 -> %s2
-1fde0362 : fmadd h2, h27, h30, h0                   : fmadd  %h27 %h30 %h0 -> %h2
-1f5fc7ad : fmsub d13, d29, d31, d17                 : fmsub  %d29 %d31 %d17 -> %d13
-1f1fc7ad : fmsub s13, s29, s31, s17                 : fmsub  %s29 %s31 %s17 -> %s13
-1fdfc7ad : fmsub h13, h29, h31, h17                 : fmsub  %h29 %h31 %h17 -> %h13
-1f7f504a : fnmadd d10, d2, d31, d20                 : fnmadd %d2 %d31 %d20 -> %d10
-1f3f504a : fnmadd s10, s2, s31, s20                 : fnmadd %s2 %s31 %s20 -> %s10
-1fff504a : fnmadd h10, h2, h31, h20                 : fnmadd %h2 %h31 %h20 -> %h10
-1f7789e4 : fnmsub d4, d15, d23, d2                  : fnmsub %d15 %d23 %d2 -> %d4
-1f3789e4 : fnmsub s4, s15, s23, s2                  : fnmsub %s15 %s23 %s2 -> %s4
-1ff789e4 : fnmsub h4, h15, h23, h2                  : fnmsub %h15 %h23 %h2 -> %h4
+2e5e177c : faddp v28.4h, v27.4h, v30.4h             : faddp  %d27 %d30 $0x01 -> %d28
+6e5e177c : faddp v28.8h, v27.8h, v30.8h             : faddp  %q27 %q30 $0x01 -> %q28
+2e30d7f2 : faddp v18.2s, v31.2s, v16.2s             : faddp  %d31 %d16 $0x02 -> %d18
+6e30d7f2 : faddp v18.4s, v31.4s, v16.4s             : faddp  %q31 %q16 $0x02 -> %q18
+6e70d7f2 : faddp v18.2d, v31.2d, v16.2d             : faddp  %q31 %q16 $0x03 -> %q18
 
-# Floating-point conversion
+0e4226ef : fcmeq v15.4h, v23.4h, v2.4h              : fcmeq  %d23 %d2 $0x01 -> %d15
+4e4226ef : fcmeq v15.8h, v23.8h, v2.8h              : fcmeq  %q23 %q2 $0x01 -> %q15
+0e20e5db : fcmeq v27.2s, v14.2s, v0.2s              : fcmeq  %d14 %d0 $0x02 -> %d27
+4e20e5db : fcmeq v27.4s, v14.4s, v0.4s              : fcmeq  %q14 %q0 $0x02 -> %q27
+4e60e5db : fcmeq v27.2d, v14.2d, v0.2d              : fcmeq  %q14 %q0 $0x03 -> %q27
+
+2e4f274e : fcmge v14.4h, v26.4h, v15.4h             : fcmge  %d26 %d15 $0x01 -> %d14
+6e4f274e : fcmge v14.8h, v26.8h, v15.8h             : fcmge  %q26 %q15 $0x01 -> %q14
+2e3ee636 : fcmge v22.2s, v17.2s, v30.2s             : fcmge  %d17 %d30 $0x02 -> %d22
+6e3ee636 : fcmge v22.4s, v17.4s, v30.4s             : fcmge  %q17 %q30 $0x02 -> %q22
+6e7ee636 : fcmge v22.2d, v17.2d, v30.2d             : fcmge  %q17 %q30 $0x03 -> %q22
+
+2eda2776 : fcmgt v22.4h, v27.4h, v26.4h             : fcmgt  %d27 %d26 $0x01 -> %d22
+6eda2776 : fcmgt v22.8h, v27.8h, v26.8h             : fcmgt  %q27 %q26 $0x01 -> %q22
+2eaee466 : fcmgt v6.2s, v3.2s, v14.2s               : fcmgt  %d3 %d14 $0x02 -> %d6
+6eaee466 : fcmgt v6.4s, v3.4s, v14.4s               : fcmgt  %q3 %q14 $0x02 -> %q6
+6eeee466 : fcmgt v6.2d, v3.2d, v14.2d               : fcmgt  %q3 %q14 $0x03 -> %q6
+
+1e22c04a : fcvt d10, s2                             : fcvt   %s2 -> %d10
+1e23c29f : fcvt h31, s20                            : fcvt   %s20 -> %h31
 1e624117 : fcvt s23, d8                             : fcvt   %d8 -> %s23
 1e63c1fd : fcvt h29, d15                            : fcvt   %d15 -> %h29
 1ee2431c : fcvt s28, h24                            : fcvt   %h24 -> %s28
 1ee2c002 : fcvt d2, h0                              : fcvt   %h0 -> %d2
+
 1e240034 : fcvtas w20, s1                           : fcvtas %s1 -> %w20
 9e240067 : fcvtas x7, s3                            : fcvtas %s3 -> %x7
 1e6402c0 : fcvtas w0, d22                           : fcvtas %d22 -> %w0
@@ -2153,6 +487,7 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 4e61cba5 : fcvtas v5.2d, v29.2d                     : fcvtas %q29 $0x03 -> %q5
 5e21cbde : fcvtas s30, s30                          : fcvtas %s30 -> %s30
 5e61c987 : fcvtas d7, d12                           : fcvtas %d12 -> %d7
+
 1e200115 : fcvtns w21, s8                           : fcvtns %s8 -> %w21
 9e2002ae : fcvtns x14, s21                          : fcvtns %s21 -> %x14
 1e6003a7 : fcvtns w7, d29                           : fcvtns %d29 -> %w7
@@ -2162,6 +497,7 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 4e61a971 : fcvtns v17.2d, v11.2d                    : fcvtns %q11 $0x03 -> %q17
 5e21a849 : fcvtns s9, s2                            : fcvtns %s2 -> %s9
 5e61a8f1 : fcvtns d17, d7                           : fcvtns %d7 -> %d17
+
 1e2800f3 : fcvtps w19, s7                           : fcvtps %s7 -> %w19
 9e280085 : fcvtps x5, s4                            : fcvtps %s4 -> %x5
 1e680148 : fcvtps w8, d10                           : fcvtps %d10 -> %w8
@@ -2171,6 +507,7 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 4ee1a80f : fcvtps v15.2d, v0.2d                     : fcvtps %q0 $0x03 -> %q15
 5ea1a89d : fcvtps s29, s4                           : fcvtps %s4 -> %s29
 5ee1aa0c : fcvtps d12, d16                          : fcvtps %d16 -> %d12
+
 1e290041 : fcvtpu w1, s2                            : fcvtpu %s2 -> %w1
 9e29016e : fcvtpu x14, s11                          : fcvtpu %s11 -> %x14
 1e690044 : fcvtpu w4, d2                            : fcvtpu %d2 -> %w4
@@ -2180,6 +517,7 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 6ee1a96b : fcvtpu v11.2d, v11.2d                    : fcvtpu %q11 $0x03 -> %q11
 7ea1aabb : fcvtpu s27, s21                          : fcvtpu %s21 -> %s27
 7ee1aa4c : fcvtpu d12 -> d18                        : fcvtpu %d18 -> %d12
+
 1e38010b : fcvtzs w11, s8                           : fcvtzs %s8 -> %w11
 9e38006e : fcvtzs x14, s3                           : fcvtzs %s3 -> %x14
 1e780380 : fcvtzs w0, d28                           : fcvtzs %d28 -> %w0
@@ -2189,17 +527,6 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 4ee1b84b : fcvtzs v11.2d, v2.2d                     : fcvtzs %q2 $0x03 -> %q11
 5ea1b863 : fcvtzs s3, s3                            : fcvtzs %s3 -> %s3
 5ee1b8f1 : fcvtzs d17, d7                           : fcvtzs %d7 -> %d17
-1e390121 : fcvtzu w1, s9                            : fcvtzu %s9 -> %w1
-9e39012b : fcvtzu x11, s9                           : fcvtzu %s9 -> %x11
-1e7901a7 : fcvtzu w7, d13                           : fcvtzu %d13 -> %w7
-9e790055 : fcvtzu x21, d2                           : fcvtzu %d2 -> %x21
-2ea1b829 : fcvtzu v9.2s, v1.2s                      : fcvtzu %d1 $0x02 -> %d9
-6ea1b910 : fcvtzu v16.4s, v8.4s                     : fcvtzu %q8 $0x02 -> %q16
-6ee1b803 : fcvtzu v3.2d, v0.2d                      : fcvtzu %q0 $0x03 -> %q3
-7ea1b929 : fcvtzu s9, s9                            : fcvtzu %s9 -> %s9
-7ee1b841 : fcvtzu d1, d2                            : fcvtzu %d2 -> %d1
-
-# Floating-point/fixed-point conversion
 1e18f107 : fcvtzs w7, s8, #4                        : fcvtzs %s8 $0x04 -> %w7
 9e18c2ad : fcvtzs x13, s21, #16                     : fcvtzs %s21 $0x10 -> %x13
 1e58813e : fcvtzs w30, d9, #32                      : fcvtzs %d9 $0x20 -> %w30
@@ -2220,6 +547,16 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 5f40fdac : fcvtzs d12, d13, #64                     : fcvtzs %d13 $0x40 -> %d12
 5f6bffbc : fcvtzs d28, d29, #21                     : fcvtzs %d29 $0x15 -> %d28
 5f56fffe : fcvtzs d30, d31, #42                     : fcvtzs %d31 $0x2a -> %d30
+
+1e390121 : fcvtzu w1, s9                            : fcvtzu %s9 -> %w1
+9e39012b : fcvtzu x11, s9                           : fcvtzu %s9 -> %x11
+1e7901a7 : fcvtzu w7, d13                           : fcvtzu %d13 -> %w7
+9e790055 : fcvtzu x21, d2                           : fcvtzu %d2 -> %x21
+2ea1b829 : fcvtzu v9.2s, v1.2s                      : fcvtzu %d1 $0x02 -> %d9
+6ea1b910 : fcvtzu v16.4s, v8.4s                     : fcvtzu %q8 $0x02 -> %q16
+6ee1b803 : fcvtzu v3.2d, v0.2d                      : fcvtzu %q0 $0x03 -> %q3
+7ea1b929 : fcvtzu s9, s9                            : fcvtzu %s9 -> %s9
+7ee1b841 : fcvtzu d1, d2                            : fcvtzu %d2 -> %d1
 1e19f107 : fcvtzu w7, s8, #4                        : fcvtzu %s8 $0x04 -> %w7
 9e19c2ad : fcvtzu x13, s21, #16                     : fcvtzu %s21 $0x10 -> %x13
 1e59813e : fcvtzu w30, d9, #32                      : fcvtzu %d9 $0x20 -> %w30
@@ -2265,52 +602,1335 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 2f20fd6a : fcvtzu v10.2s, v11.2s, #32               : fcvtzu %d11 $0x02 $0x20 -> %d10
 2f2bffbc : fcvtzu v28.2s, v29.2s, #21               : fcvtzu %d29 $0x02 $0x15 -> %d28
 2f21fffe : fcvtzu v30.2s, v31.2s, #31               : fcvtzu %d31 $0x02 $0x1f -> %d30
-1e03f105 : ucvtf s5, w8, #4                         : ucvtf  %w8 $0x04 -> %s5
-9e03c0ed : ucvtf s13, x7, #16                       : ucvtf  %x7 $0x10 -> %s13
-1e438011 : ucvtf d17, w0, #32                       : ucvtf  %w0 $0x20 -> %d17
-9e43016d : ucvtf d13, x11, #64                      : ucvtf  %x11 $0x40 -> %d13
-7e3fe509 : ucvtf s9, s8, #1                         : ucvtf  %s8 $0x01 -> %s9
-7e3ee495 : ucvtf s21, s4, #2                        : ucvtf  %s4 $0x02 -> %s21
-7e3ce674 : ucvtf s20, s19, #4                       : ucvtf  %s19 $0x04 -> %s20
-7e38e4e6 : ucvtf s6, s7, #8                         : ucvtf  %s7 $0x08 -> %s6
-7e30e7cc : ucvtf s12, s30, #16                      : ucvtf  %s30 $0x10 -> %s12
-7e20e532 : ucvtf s18, s9, #32                       : ucvtf  %s9 $0x20 -> %s18
-7e2be6b6 : ucvtf s22, s21, #21                      : ucvtf  %s21 $0x15 -> %s22
-7e21e66b : ucvtf s11, s19, #31                      : ucvtf  %s19 $0x1f -> %s11
-7e7fe56d : ucvtf d13, d11, #1                       : ucvtf  %d11 $0x01 -> %d13
-2e21d843 : ucvtf d3, d2, #2                         : ucvtf  %d2 $0x02 -> %d3
-7e7ce633 : ucvtf d19, d17, #4                       : ucvtf  %d17 $0x04 -> %d19
-7e78e53e : ucvtf d30, d9, #8                        : ucvtf  %d9 $0x08 -> %d30
-7e70e571 : ucvtf d17, d11, #16                      : ucvtf  %d11 $0x10 -> %d17
-7e60e488 : ucvtf d8, d4, #32                        : ucvtf  %d4 $0x20 -> %d8
-7e40e6bd : ucvtf d29, d21, #64                      : ucvtf  %d21 $0x40 -> %d29
-7e6be7be : ucvtf d30, d29, #21                      : ucvtf  %d29 $0x15 -> %d30
-7e56e5b1 : ucvtf d17, d13, #42                      : ucvtf  %d13 $0x2a -> %d17
-6f3fe420 : ucvtf v0.4s, v1.4s, #1                   : ucvtf  %q1 $0x02 $0x01 -> %q0
-6f3ee462 : ucvtf v2.4s, v3.4s, #2                   : ucvtf  %q3 $0x02 $0x02 -> %q2
-6f3ce4a4 : ucvtf v4.4s, v5.4s, #4                   : ucvtf  %q5 $0x02 $0x04 -> %q4
-6f38e4e6 : ucvtf v6.4s, v7.4s, #8                   : ucvtf  %q7 $0x02 $0x08 -> %q6
-6f30e528 : ucvtf v8.4s, v9.4s, #16                  : ucvtf  %q9 $0x02 $0x10 -> %q8
-6f20e56a : ucvtf v10.4s, v11.4s, #32                : ucvtf  %q11 $0x02 $0x20 -> %q10
-6f2be7bc : ucvtf v28.4s, v29.4s, #21                : ucvtf  %q29 $0x02 $0x15 -> %q28
-6f21e7fe : ucvtf v30.4s, v31.4s, #31                : ucvtf  %q31 $0x02 $0x1f -> %q30
-6f7fe420 : ucvtf v0.2d, v1.2d, #1                   : ucvtf  %q1 $0x03 $0x01 -> %q0
-6f7ee462 : ucvtf v2.2d, v3.2d, #2                   : ucvtf  %q3 $0x03 $0x02 -> %q2
-6f7ce4a4 : ucvtf v4.2d, v5.2d, #4                   : ucvtf  %q5 $0x03 $0x04 -> %q4
-6f78e4e6 : ucvtf v6.2d, v7.2d, #8                   : ucvtf  %q7 $0x03 $0x08 -> %q6
-6f70e528 : ucvtf v8.2d, v9.2d, #16                  : ucvtf  %q9 $0x03 $0x10 -> %q8
-6f60e56a : ucvtf v10.2d, v11.2d, #32                : ucvtf  %q11 $0x03 $0x20 -> %q10
-6f40e5ac : ucvtf v12.2d, v13.2d, #64                : ucvtf  %q13 $0x03 $0x40 -> %q12
-6f6be7bc : ucvtf v28.2d, v29.2d, #21                : ucvtf  %q29 $0x03 $0x15 -> %q28
-6f56e7fe : ucvtf v30.2d, v31.2d, #42                : ucvtf  %q31 $0x03 $0x2a -> %q30
-2f3fe420 : ucvtf v0.2s, v1.2s, #1                   : ucvtf  %d1 $0x02 $0x01 -> %d0
-2f3ee462 : ucvtf v2.2s, v3.2s, #2                   : ucvtf  %d3 $0x02 $0x02 -> %d2
-2f3ce4a4 : ucvtf v4.2s, v5.2s, #4                   : ucvtf  %d5 $0x02 $0x04 -> %d4
-2f38e4e6 : ucvtf v6.2s, v7.2s, #8                   : ucvtf  %d7 $0x02 $0x08 -> %d6
-2f30e528 : ucvtf v8.2s, v9.2s, #16                  : ucvtf  %d9 $0x02 $0x10 -> %d8
-2f20e56a : ucvtf v10.2s, v11.2s, #32                : ucvtf  %d11 $0x02 $0x20 -> %d10
-2f2be7bc : ucvtf v28.2s, v29.2s, #21                : ucvtf  %d29 $0x02 $0x15 -> %d28
-2f21e7fe : ucvtf v30.2s, v31.2s, #31                : ucvtf  %d31 $0x02 $0x1f -> %d30
+
+2e573f09 : fdiv v9.4h, v24.4h, v23.4h               : fdiv   %d24 %d23 $0x01 -> %d9
+6e573f09 : fdiv v9.8h, v24.8h, v23.8h               : fdiv   %q24 %q23 $0x01 -> %q9
+2e24ff4a : fdiv v10.2s, v26.2s, v4.2s               : fdiv   %d26 %d4 $0x02 -> %d10
+6e24ff4a : fdiv v10.4s, v26.4s, v4.4s               : fdiv   %q26 %q4 $0x02 -> %q10
+6e64ff4a : fdiv v10.2d, v26.2d, v4.2d               : fdiv   %q26 %q4 $0x03 -> %q10
+1e7d19a0 : fdiv d0, d13, d29                        : fdiv   %d13 %d29 -> %d0
+1e3d19a0 : fdiv s0, s13, s29                        : fdiv   %s13 %s29 -> %s0
+1efd19a0 : fdiv h0, h13, h29                        : fdiv   %h13 %h29 -> %h0
+
+1f5e0362 : fmadd d2, d27, d30, d0                   : fmadd  %d27 %d30 %d0 -> %d2
+1f1e0362 : fmadd s2, s27, s30, s0                   : fmadd  %s27 %s30 %s0 -> %s2
+1fde0362 : fmadd h2, h27, h30, h0                   : fmadd  %h27 %h30 %h0 -> %h2
+
+0e56351a : fmax v26.4h, v8.4h, v22.4h               : fmax   %d8 %d22 $0x01 -> %d26
+4e56351a : fmax v26.8h, v8.8h, v22.8h               : fmax   %q8 %q22 $0x01 -> %q26
+0e34f6a2 : fmax v2.2s, v21.2s, v20.2s               : fmax   %d21 %d20 $0x02 -> %d2
+4e34f6a2 : fmax v2.4s, v21.4s, v20.4s               : fmax   %q21 %q20 $0x02 -> %q2
+4e74f6a2 : fmax v2.2d, v21.2d, v20.2d               : fmax   %q21 %q20 $0x03 -> %q2
+1e7749e4 : fmax d4, d15, d23                        : fmax   %d15 %d23 -> %d4
+1e3749e4 : fmax s4, s15, s23                        : fmax   %s15 %s23 -> %s4
+1ef749e4 : fmax h4, h15, h23                        : fmax   %h15 %h23 -> %h4
+
+0e5e0762 : fmaxnm v2.4h, v27.4h, v30.4h             : fmaxnm %d27 %d30 $0x01 -> %d2
+4e5e0762 : fmaxnm v2.8h, v27.8h, v30.8h             : fmaxnm %q27 %q30 $0x01 -> %q2
+0e2bc531 : fmaxnm v17.2s, v9.2s, v11.2s             : fmaxnm %d9 %d11 $0x02 -> %d17
+4e2bc531 : fmaxnm v17.4s, v9.4s, v11.4s             : fmaxnm %q9 %q11 $0x02 -> %q17
+4e6bc531 : fmaxnm v17.2d, v9.2d, v11.2d             : fmaxnm %q9 %q11 $0x03 -> %q17
+1e7a6b16 : fmaxnm d22, d24, d26                     : fmaxnm %d24 %d26 -> %d22
+1e3a6b16 : fmaxnm s22, s24, s26                     : fmaxnm %s24 %s26 -> %s22
+1efa6b16 : fmaxnm h22, h24, h26                     : fmaxnm %h24 %h26 -> %h22
+
+2e5405f7 : fmaxnmp v23.4h, v15.4h, v20.4h           : fmaxnmp %d15 %d20 $0x01 -> %d23
+6e5405f7 : fmaxnmp v23.8h, v15.8h, v20.8h           : fmaxnmp %q15 %q20 $0x01 -> %q23
+2e3dc64c : fmaxnmp v12.2s, v18.2s, v29.2s           : fmaxnmp %d18 %d29 $0x02 -> %d12
+6e3dc64c : fmaxnmp v12.4s, v18.4s, v29.4s           : fmaxnmp %q18 %q29 $0x02 -> %q12
+6e7dc64c : fmaxnmp v12.2d, v18.2d, v29.2d           : fmaxnmp %q18 %q29 $0x03 -> %q12
+
+2e453493 : fmaxp v19.4h, v4.4h, v5.4h               : fmaxp  %d4 %d5 $0x01 -> %d19
+6e453493 : fmaxp v19.8h, v4.8h, v5.8h               : fmaxp  %q4 %q5 $0x01 -> %q19
+2e39f6e5 : fmaxp v5.2s, v23.2s, v25.2s              : fmaxp  %d23 %d25 $0x02 -> %d5
+6e39f6e5 : fmaxp v5.4s, v23.4s, v25.4s              : fmaxp  %q23 %q25 $0x02 -> %q5
+6e79f6e5 : fmaxp v5.2d, v23.2d, v25.2d              : fmaxp  %q23 %q25 $0x03 -> %q5
+
+0ecf3402 : fmin v2.4h, v0.4h, v15.4h                : fmin   %d0 %d15 $0x01 -> %d2
+4ecf3402 : fmin v2.8h, v0.8h, v15.8h                : fmin   %q0 %q15 $0x01 -> %q2
+0ebff716 : fmin v22.2s, v24.2s, v31.2s              : fmin   %d24 %d31 $0x02 -> %d22
+4ebff716 : fmin v22.4s, v24.4s, v31.4s              : fmin   %q24 %q31 $0x02 -> %q22
+4efff716 : fmin v22.2d, v24.2d, v31.2d              : fmin   %q24 %q31 $0x03 -> %q22
+1e685b42 : fmin d2, d26, d8                         : fmin   %d26 %d8 -> %d2
+1e285b42 : fmin s2, s26, s8                         : fmin   %s26 %s8 -> %s2
+1ee85b42 : fmin h2, h26, h8                         : fmin   %h26 %h8 -> %h2
+
+0ecb07b0 : fminnm v16.4h, v29.4h, v11.4h            : fminnm %d29 %d11 $0x01 -> %d16
+4ecb07b0 : fminnm v16.8h, v29.8h, v11.8h            : fminnm %q29 %q11 $0x01 -> %q16
+0ebfc7d1 : fminnm v17.2s, v30.2s, v31.2s            : fminnm %d30 %d31 $0x02 -> %d17
+4ebfc7d1 : fminnm v17.4s, v30.4s, v31.4s            : fminnm %q30 %q31 $0x02 -> %q17
+4effc7d1 : fminnm v17.2d, v30.2d, v31.2d            : fminnm %q30 %q31 $0x03 -> %q17
+1e7d7a12 : fminnm d18, d16, d29                     : fminnm %d16 %d29 -> %d18
+1e3d7a12 : fminnm s18, s16, s29                     : fminnm %s16 %s29 -> %s18
+1efd7a12 : fminnm h18, h16, h29                     : fminnm %h16 %h29 -> %h18
+
+2ec604e9 : fminnmp v9.4h, v7.4h, v6.4h              : fminnmp %d7 %d6 $0x01 -> %d9
+6ec604e9 : fminnmp v9.8h, v7.8h, v6.8h              : fminnmp %q7 %q6 $0x01 -> %q9
+2eabc657 : fminnmp v23.2s, v18.2s, v11.2s           : fminnmp %d18 %d11 $0x02 -> %d23
+6eabc657 : fminnmp v23.4s, v18.4s, v11.4s           : fminnmp %q18 %q11 $0x02 -> %q23
+6eebc657 : fminnmp v23.2d, v18.2d, v11.2d           : fminnmp %q18 %q11 $0x03 -> %q23
+
+2ec73569 : fminp v9.4h, v11.4h, v7.4h               : fminp  %d11 %d7 $0x01 -> %d9
+6ec73569 : fminp v9.8h, v11.8h, v7.8h               : fminp  %q11 %q7 $0x01 -> %q9
+2eb9f43c : fminp v28.2s, v1.2s, v25.2s              : fminp  %d1 %d25 $0x02 -> %d28
+6eb9f43c : fminp v28.4s, v1.4s, v25.4s              : fminp  %q1 %q25 $0x02 -> %q28
+6ef9f43c : fminp v28.2d, v1.2d, v25.2d              : fminp  %q1 %q25 $0x03 -> %q28
+
+0e5f0fa0 : fmla v0.4h, v29.4h, v31.4h               : fmla   %d0 %d29 %d31 $0x01 -> %d0
+4e5f0fa0 : fmla v0.8h, v29.8h, v31.8h               : fmla   %q0 %q29 %q31 $0x01 -> %q0
+0e33cfa7 : fmla v7.2s, v29.2s, v19.2s               : fmla   %d7 %d29 %d19 $0x02 -> %d7
+4e33cfa7 : fmla v7.4s, v29.4s, v19.4s               : fmla   %q7 %q29 %q19 $0x02 -> %q7
+4e73cfa7 : fmla v7.2d, v29.2d, v19.2d               : fmla   %q7 %q29 %q19 $0x03 -> %q7
+4fd11240 : fmla v0.2d, v18.2d, v17.d[0]             : fmla   %q0 %q18 %q17 $0x00 $0x03 -> %q0
+4fc4180b : fmla v11.2d, v0.2d, v4.d[1]              : fmla   %q11 %q0 %q4 $0x01 $0x03 -> %q11
+4f981382 : fmla v2.4s, v28.4s, v24.s[0]             : fmla   %q2 %q28 %q24 $0x00 $0x02 -> %q2
+4fb81343 : fmla v3.4s, v26.4s, v24.s[1]             : fmla   %q3 %q26 %q24 $0x01 $0x02 -> %q3
+4f981b88 : fmla v8.4s, v28.4s, v24.s[2]             : fmla   %q8 %q28 %q24 $0x02 $0x02 -> %q8
+4fb81b49 : fmla v9.4s, v26.4s, v24.s[3]             : fmla   %q9 %q26 %q24 $0x03 $0x02 -> %q9
+
+0e20ed42 : fmlal v2.2s, v10.2h, v0.2h               : fmlal  %d2 %d10 %d0 -> %d2
+4e20ed42 : fmlal v2.4s, v10.4h, v0.4h               : fmlal  %q2 %q10 %q0 -> %q2
+
+2e20cd42 : fmlal2 v2.2s, v10.2h, v0.2h              : fmlal2 %d2 %d10 %d0 -> %d2
+6e20cd42 : fmlal2 v2.4s, v10.4h, v0.4h              : fmlal2 %q2 %q10 %q0 -> %q2
+
+0edd0d13 : fmls v19.4h, v8.4h, v29.4h               : fmls   %d19 %d8 %d29 $0x01 -> %d19
+4edd0d13 : fmls v19.8h, v8.8h, v29.8h               : fmls   %q19 %q8 %q29 $0x01 -> %q19
+0ebdcfe4 : fmls v4.2s, v31.2s, v29.2s               : fmls   %d4 %d31 %d29 $0x02 -> %d4
+4ebdcfe4 : fmls v4.4s, v31.4s, v29.4s               : fmls   %q4 %q31 %q29 $0x02 -> %q4
+4efdcfe4 : fmls v4.2d, v31.2d, v29.2d               : fmls   %q4 %q31 %q29 $0x03 -> %q4
+
+0ea0ed42 : fmlsl v2.2s, v10.2h, v0.2h               : fmlsl  %d2 %d10 %d0 -> %d2
+4ea0ed42 : fmlsl v2.4s, v10.4h, v0.4h               : fmlsl  %q2 %q10 %q0 -> %q2
+
+2ea0cd42 : fmlsl2 v2.2s, v10.2h, v0.2h              : fmlsl2 %d2 %d10 %d0 -> %d2
+6ea0cd42 : fmlsl2 v2.4s, v10.4h, v0.4h              : fmlsl2 %q2 %q10 %q0 -> %q2
+
+1e604362 : fmov d2, d27                             : fmov   %d27 -> %d2
+1e204362 : fmov s2, s27                             : fmov   %s27 -> %s2
+1ee04362 : fmov h2, h27                             : fmov   %h27 -> %h2
+4f03fe10 : fmov v1.8h, #1.00000000                  : fmov   $1.000000 $0x01 -> %q16
+4f00fc01 : fmov v1.8h, #2.00000000                  : fmov   $2.000000 $0x01 -> %q1
+4f07fe02 : fmov v2.8h, #-1.0000000                  : fmov   $-1.000000 $0x01 -> %q2
+4f04fc03 : fmov v3.8h, #-2.0000000                  : fmov   $-2.000000 $0x01 -> %q3
+4f00fd84 : fmov v4.8h, #3.50000000                  : fmov   $3.500000 $0x01 -> %q4
+4f00fe25 : fmov v5.8h, #4.25000000                  : fmov   $4.250000 $0x01 -> %q5
+4f03fe46 : fmov v6.8h, #1.12500000                  : fmov   $1.125000 $0x01 -> %q6
+4f06fe07 : fmov v7.8h, #-0.2500000                  : fmov   $-0.250000 $0x01 -> %q7
+4f00ff88 : fmov v8.8h, #7.00000000                  : fmov   $7.000000 $0x01 -> %q8
+4f03ffe9 : fmov v9.8h, #1.93750000                  : fmov   $1.937500 $0x01 -> %q9
+4f02fd6a : fmov v10.8h, #0.210937                   : fmov   $0.210937 $0x01 -> %q10
+4f01ffff : fmov v31.8h, #31.0000000                 : fmov   $31.000000 $0x01 -> %q31
+1e2e1000 : fmov s0, #1.00000000                     : fmov   $1.000000 -> %s0
+1e201001 : fmov s1, #2.00000000                     : fmov   $2.000000 -> %s1
+1e211002 : fmov s2, #3.00000000                     : fmov   $3.000000 -> %s2
+1e3e1003 : fmov s3, #-1.0000000                     : fmov   $-1.000000 -> %s3
+1e301004 : fmov s4, #-2.0000000                     : fmov   $-2.000000 -> %s4
+1e219005 : fmov s5, #3.50000000                     : fmov   $3.500000 -> %s5
+1e223006 : fmov s6, #4.25000000                     : fmov   $4.250000 -> %s6
+1e2e5007 : fmov s7, #1.12500000                     : fmov   $1.125000 -> %s7
+1e3a1008 : fmov s8, #-0.2500000                     : fmov   $-0.250000 -> %s8
+1e239009 : fmov s9, #7.00000000                     : fmov   $7.000000 -> %s9
+1e2ff00a : fmov s10, #1.9375000                     : fmov   $1.937500 -> %s10
+1e29701e : fmov s30, #0.2109375                     : fmov   $0.210937 -> %s30
+1e27f01f : fmov s31, #31.0000000                    : fmov   $31.000000 -> %s31
+1e603000 : fmov d0, #2.1250000                      : fmov   $2.125000 -> %d0
+1e6a9001 : fmov d1, #0.3125000                      : fmov   $0.312500 -> %d1
+1e65f002 : fmov d2, #15.5000000                     : fmov   $15.500000 -> %d2
+1e703003 : fmov d3, #-2.1250000                     : fmov   $-2.125000 -> %d3
+1e7a9004 : fmov d4, #-0.3125000                     : fmov   $-0.312500 -> %d4
+1e75f005 : fmov d5, #-15.5000000                    : fmov   $-15.500000 -> %d5
+1e649006 : fmov d6, #10.0000000                     : fmov   $10.000000 -> %d6
+1e64b007 : fmov d7, #10.5000000                     : fmov   $10.500000 -> %d7
+1e64d008 : fmov d8, #11.0000000                     : fmov   $11.000000 -> %d8
+1e64f009 : fmov d9, #11.5000000                     : fmov   $11.500000 -> %d9
+1e75100a : fmov d10, #-12.0000000                   : fmov   $-12.000000 -> %d10
+1e75301e : fmov d30, #-12.5000000                   : fmov   $-12.500000 -> %d30
+1e61301f : fmov d31, #3.125000000                   : fmov   $3.125000 -> %d31
+
+1f5fc7ad : fmsub d13, d29, d31, d17                 : fmsub  %d29 %d31 %d17 -> %d13
+1f1fc7ad : fmsub s13, s29, s31, s17                 : fmsub  %s29 %s31 %s17 -> %s13
+1fdfc7ad : fmsub h13, h29, h31, h17                 : fmsub  %h29 %h31 %h17 -> %h13
+
+2e4a1e84 : fmul v4.4h, v20.4h, v10.4h               : fmul   %d20 %d10 $0x01 -> %d4
+6e4a1e84 : fmul v4.8h, v20.8h, v10.8h               : fmul   %q20 %q10 $0x01 -> %q4
+2e35df99 : fmul v25.2s, v28.2s, v21.2s              : fmul   %d28 %d21 $0x02 -> %d25
+6e35df99 : fmul v25.4s, v28.4s, v21.4s              : fmul   %q28 %q21 $0x02 -> %q25
+6e75df99 : fmul v25.2d, v28.2d, v21.2d              : fmul   %q28 %q21 $0x03 -> %q25
+1e7e0b62 : fmul d2, d27, d30                        : fmul   %d27 %d30 -> %d2
+1e3e0b62 : fmul s2, s27, s30                        : fmul   %s27 %s30 -> %s2
+1efe0b62 : fmul h2, h27, h30                        : fmul   %h27 %h30 -> %h2
+
+0e441e9f : fmulx v31.4h, v20.4h, v4.4h              : fmulx  %d20 %d4 $0x01 -> %d31
+4e441e9f : fmulx v31.8h, v20.8h, v4.8h              : fmulx  %q20 %q4 $0x01 -> %q31
+0e34dede : fmulx v30.2s, v22.2s, v20.2s             : fmulx  %d22 %d20 $0x02 -> %d30
+4e34dede : fmulx v30.4s, v22.4s, v20.4s             : fmulx  %q22 %q20 $0x02 -> %q30
+4e74dede : fmulx v30.2d, v22.2d, v20.2d             : fmulx  %q22 %q20 $0x03 -> %q30
+
+1e6143ad : fneg d13, d29                            : fneg   %d29 -> %d13
+1e2143ad : fneg s13, s29                            : fneg   %s29 -> %s13
+1ee143ad : fneg h13, h29                            : fneg   %h29 -> %h13
+
+1f7f504a : fnmadd d10, d2, d31, d20                 : fnmadd %d2 %d31 %d20 -> %d10
+1f3f504a : fnmadd s10, s2, s31, s20                 : fnmadd %s2 %s31 %s20 -> %s10
+1fff504a : fnmadd h10, h2, h31, h20                 : fnmadd %h2 %h31 %h20 -> %h10
+
+1f7789e4 : fnmsub d4, d15, d23, d2                  : fnmsub %d15 %d23 %d2 -> %d4
+1f3789e4 : fnmsub s4, s15, s23, s2                  : fnmsub %s15 %s23 %s2 -> %s4
+1ff789e4 : fnmsub h4, h15, h23, h2                  : fnmsub %h15 %h23 %h2 -> %h4
+
+1e778a6b : fnmul d11, d19, d23                      : fnmul  %d19 %d23 -> %d11
+1e378a6b : fnmul s11, s19, s23                      : fnmul  %s19 %s23 -> %s11
+1ef78a6b : fnmul h11, h19, h23                      : fnmul  %h19 %h23 -> %h11
+
+0e523f58 : frecps v24.4h, v26.4h, v18.4h            : frecps %d26 %d18 $0x01 -> %d24
+4e523f58 : frecps v24.8h, v26.8h, v18.8h            : frecps %q26 %q18 $0x01 -> %q24
+0e30fcaf : frecps v15.2s, v5.2s, v16.2s             : frecps %d5 %d16 $0x02 -> %d15
+4e30fcaf : frecps v15.4s, v5.4s, v16.4s             : frecps %q5 %q16 $0x02 -> %q15
+4e70fcaf : frecps v15.2d, v5.2d, v16.2d             : frecps %q5 %q16 $0x03 -> %q15
+
+1e66425a : frinta d26, d18                          : frinta %d18 -> %d26
+1e26425a : frinta s26, s18                          : frinta %s18 -> %s26
+1ee6425a : frinta h26, h18                          : frinta %h18 -> %h26
+
+1e67c26b : frinti d11, d19                          : frinti %d19 -> %d11
+1e27c26b : frinti s11, s19                          : frinti %s19 -> %s11
+1ee7c26b : frinti h11, h19                          : frinti %h19 -> %h11
+
+1e65411a : frintm d26, d8                           : frintm %d8 -> %d26
+1e25411a : frintm s26, s8                           : frintm %s8 -> %s26
+1ee5411a : frintm h26, h8                           : frintm %h8 -> %h26
+
+1e6441e4 : frintn d4, d15                           : frintn %d15 -> %d4
+1e2441e4 : frintn s4, s15                           : frintn %s15 -> %s4
+1ee441e4 : frintn h4, h15                           : frintn %h15 -> %h4
+
+1e64c057 : frintp d23, d2                           : frintp %d2 -> %d23
+1e24c057 : frintp s23, s2                           : frintp %s2 -> %s23
+1ee4c057 : frintp h23, h2                           : frintp %h2 -> %h23
+
+1e6743b0 : frintx d16, d29                          : frintx %d29 -> %d16
+1e2743b0 : frintx s16, s29                          : frintx %s29 -> %s16
+1ee743b0 : frintx h16, h29                          : frintx %h29 -> %h16
+
+1e65c316 : frintz d22, d24                          : frintz %d24 -> %d22
+1e25c316 : frintz s22, s24                          : frintz %s24 -> %s22
+1ee5c316 : frintz h22, h24                          : frintz %h24 -> %h22
+
+0ed33d88 : frsqrts v8.4h, v12.4h, v19.4h            : frsqrts %d12 %d19 $0x01 -> %d8
+4ed33d88 : frsqrts v8.8h, v12.8h, v19.8h            : frsqrts %q12 %q19 $0x01 -> %q8
+0ea6ff8a : frsqrts v10.2s, v28.2s, v6.2s            : frsqrts %d28 %d6 $0x02 -> %d10
+4ea6ff8a : frsqrts v10.4s, v28.4s, v6.4s            : frsqrts %q28 %q6 $0x02 -> %q10
+4ee6ff8a : frsqrts v10.2d, v28.2d, v6.2d            : frsqrts %q28 %q6 $0x03 -> %q10
+
+1e61c23f : fsqrt d31, d17                           : fsqrt  %d17 -> %d31
+1e21c23f : fsqrt s31, s17                           : fsqrt  %s17 -> %s31
+1ee1c23f : fsqrt h31, h17                           : fsqrt  %h17 -> %h31
+
+0ed8178f : fsub v15.4h, v28.4h, v24.4h              : fsub   %d28 %d24 $0x01 -> %d15
+4ed8178f : fsub v15.8h, v28.8h, v24.8h              : fsub   %q28 %q24 $0x01 -> %q15
+0ebad519 : fsub v25.2s, v8.2s, v26.2s               : fsub   %d8 %d26 $0x02 -> %d25
+4ebad519 : fsub v25.4s, v8.4s, v26.4s               : fsub   %q8 %q26 $0x02 -> %q25
+4efad519 : fsub v25.2d, v8.2d, v26.2d               : fsub   %q8 %q26 $0x03 -> %q25
+1e743be2 : fsub d2, d31, d20                        : fsub   %d31 %d20 -> %d2
+1e343be2 : fsub s2, s31, s20                        : fsub   %s31 %s20 -> %s2
+1ef43be2 : fsub h2, h31, h20                        : fsub   %h31 %h20 -> %h2
+
+d4400000 : hlt    #0x0                    : hlt    $0x0000
+d45fffe0 : hlt    #0xffff                 : hlt    $0xffff
+
+d4000002 : hvc    #0x0                    : hvc    $0x0000
+d41fffe2 : hvc    #0xffff                 : hvc    $0xffff
+
+d50330df : isb    #0x0                    : isb    $0x00
+d5033fdf : isb                            : isb    $0x0f
+
+0c4027ff : ld1    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp]: ld1    (%sp)[32byte] $0x01 -> %d31 %d0 %d1 %d2
+0cd5a7ff : ld1    {v31.4h, v0.4h}, [sp], x21: ld1    (%sp)[16byte] $0x01 %sp %x21 -> %d31 %d0 %sp
+0cdf67ff : ld1    {v31.4h, v0.4h, v1.4h}, [sp], #24: ld1    (%sp)[24byte] $0x01 %sp $0x18 -> %d31 %d0 %d1 %sp
+0cdf77ff : ld1    {v31.4h}, [sp], #8      : ld1    (%sp)[8byte] $0x01 %sp $0x08 -> %d31 %sp
+0cdfa7ff : ld1    {v31.4h, v0.4h}, [sp], #16: ld1    (%sp)[16byte] $0x01 %sp $0x10 -> %d31 %d0 %sp
+4c4067ff : ld1    {v31.8h, v0.8h, v1.8h}, [sp]: ld1    (%sp)[48byte] $0x01 -> %q31 %q0 %q1
+4c4077ff : ld1    {v31.8h}, [sp]          : ld1    (%sp)[16byte] $0x01 -> %q31
+4c40a7ff : ld1    {v31.8h, v0.8h}, [sp]   : ld1    (%sp)[32byte] $0x01 -> %q31 %q0
+4cdf27ff : ld1    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp], #64: ld1    (%sp)[64byte] $0x01 %sp $0x40 -> %q31 %q0 %q1 %q2 %sp
+4d401fff : ld1    {v31.b}[15], [sp]       : ld1    (%sp)[1byte] $0x0f -> %q31
+4d405bff : ld1    {v31.h}[7], [sp]        : ld1    (%sp)[2byte] $0x07 -> %q31
+4d4087ff : ld1    {v31.d}[1], [sp]        : ld1    (%sp)[8byte] $0x01 -> %q31
+4d4093ff : ld1    {v31.s}[3], [sp]        : ld1    (%sp)[4byte] $0x03 -> %q31
+4ddf1fff : ld1    {v31.b}[15], [sp], #1   : ld1    %q31 (%sp)[1byte] $0x0f %sp $0x01 -> %q31 %sp
+4ddf5bff : ld1    {v31.h}[7], [sp], #2    : ld1    %q31 (%sp)[2byte] $0x07 %sp $0x02 -> %q31 %sp
+4ddf87ff : ld1    {v31.d}[1], [sp], #8    : ld1    %q31 (%sp)[8byte] $0x01 %sp $0x08 -> %q31 %sp
+4ddf93ff : ld1    {v31.s}[3], [sp], #4    : ld1    %q31 (%sp)[4byte] $0x03 %sp $0x04 -> %q31 %sp
+
+4d40c3ff : ld1r   {v31.16b}, [sp]         : ld1r   (%sp)[1byte] -> %q31
+4dc4c3ff : ld1r   {v31.16b}, [sp], x4     : ld1r   (%sp)[1byte] %sp %x4 -> %q31 %sp
+4ddfc3ff : ld1r   {v31.16b}, [sp], #1     : ld1r   (%sp)[1byte] %sp $0x01 -> %q31 %sp
+
+0c4087ff : ld2    {v31.4h, v0.4h}, [sp]   : ld2    (%sp)[16byte] $0x01 -> %d31 %d0
+4cdf87ff : ld2    {v31.8h, v0.8h}, [sp], #32: ld2    (%sp)[32byte] $0x01 %sp $0x20 -> %q31 %q0 %sp
+4d601fff : ld2    {v31.b, v0.b}[15], [sp] : ld2    (%sp)[2byte] $0x0f -> %q31 %q0
+4d605bff : ld2    {v31.h, v0.h}[7], [sp]  : ld2    (%sp)[4byte] $0x07 -> %q31 %q0
+4d6087ff : ld2    {v31.d, v0.d}[1], [sp]  : ld2    (%sp)[16byte] $0x01 -> %q31 %q0
+4d6093ff : ld2    {v31.s, v0.s}[3], [sp]  : ld2    (%sp)[8byte] $0x03 -> %q31 %q0
+4dff1fff : ld2    {v31.b, v0.b}[15], [sp], #2: ld2    %q31 %q0 (%sp)[2byte] $0x0f %sp $0x02 -> %q31 %q0 %sp
+4dff5bff : ld2    {v31.h, v0.h}[7], [sp], #4: ld2    %q31 %q0 (%sp)[4byte] $0x07 %sp $0x04 -> %q31 %q0 %sp
+4dff87ff : ld2    {v31.d, v0.d}[1], [sp], #16: ld2    %q31 %q0 (%sp)[16byte] $0x01 %sp $0x10 -> %q31 %q0 %sp
+4dff93ff : ld2    {v31.s, v0.s}[3], [sp], #8: ld2    %q31 %q0 (%sp)[8byte] $0x03 %sp $0x08 -> %q31 %q0 %sp
+
+0d60cbff : ld2r   {v31.2s, v0.2s}, [sp]   : ld2r   (%sp)[8byte] -> %d31 %d0
+0de2cbff : ld2r   {v31.2s, v0.2s}, [sp], x2: ld2r   (%sp)[8byte] %sp %x2 -> %d31 %d0 %sp
+0dffcbff : ld2r   {v31.2s, v0.2s}, [sp], #8: ld2r   (%sp)[8byte] %sp $0x08 -> %d31 %d0 %sp
+
+0c4047ff : ld3    {v31.4h, v0.4h, v1.4h}, [sp]: ld3    (%sp)[24byte] $0x01 -> %d31 %d0 %d1
+4cdf47ff : ld3    {v31.8h, v0.8h, v1.8h}, [sp], #48: ld3    (%sp)[48byte] $0x01 %sp $0x30 -> %q31 %q0 %q1 %sp
+4d403fff : ld3    {v31.b, v0.b, v1.b}[15], [sp]: ld3    (%sp)[3byte] $0x0f -> %q31 %q0 %q1
+4d407bff : ld3    {v31.h, v0.h, v1.h}[7], [sp]: ld3    (%sp)[6byte] $0x07 -> %q31 %q0 %q1
+4d40a7ff : ld3    {v31.d, v0.d, v1.d}[1], [sp]: ld3    (%sp)[24byte] $0x01 -> %q31 %q0 %q1
+4d40b3ff : ld3    {v31.s, v0.s, v1.s}[3], [sp]: ld3    (%sp)[12byte] $0x03 -> %q31 %q0 %q1
+4ddf3fff : ld3    {v31.b, v0.b, v1.b}[15], [sp], #3: ld3    %q31 %q0 %q1 (%sp)[3byte] $0x0f %sp $0x03 -> %q31 %q0 %q1 %sp
+4ddf7bff : ld3    {v31.h, v0.h, v1.h}[7], [sp], #6: ld3    %q31 %q0 %q1 (%sp)[6byte] $0x07 %sp $0x06 -> %q31 %q0 %q1 %sp
+4ddfa7ff : ld3    {v31.d, v0.d, v1.d}[1], [sp], #24: ld3    %q31 %q0 %q1 (%sp)[24byte] $0x01 %sp $0x18 -> %q31 %q0 %q1 %sp
+4ddfb3ff : ld3    {v31.s, v0.s, v1.s}[3], [sp], #12: ld3    %q31 %q0 %q1 (%sp)[12byte] $0x03 %sp $0x0c -> %q31 %q0 %q1 %sp
+
+0d40e7ff : ld3r   {v31.4h, v0.4h, v1.4h}, [sp]: ld3r   (%sp)[6byte] -> %d31 %d0 %d1
+0dc1e7ff : ld3r   {v31.4h, v0.4h, v1.4h}, [sp], x1: ld3r   (%sp)[6byte] %sp %x1 -> %d31 %d0 %d1 %sp
+0ddfe7ff : ld3r   {v31.4h, v0.4h, v1.4h}, [sp], #6: ld3r   (%sp)[6byte] %sp $0x06 -> %d31 %d0 %d1 %sp
+
+0cdf07ff : ld4    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp], #32: ld4    (%sp)[32byte] $0x01 %sp $0x20 -> %d31 %d0 %d1 %d2 %sp
+4c4007ff : ld4    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp]: ld4    (%sp)[64byte] $0x01 -> %q31 %q0 %q1 %q2
+4d603fff : ld4    {v31.b, v0.b, v1.b, v2.b}[15], [sp]: ld4    (%sp)[4byte] $0x0f -> %q31 %q0 %q1 %q2
+4d607bff : ld4    {v31.h, v0.h, v1.h, v2.h}[7], [sp]: ld4    (%sp)[8byte] $0x07 -> %q31 %q0 %q1 %q2
+4d60a7ff : ld4    {v31.d, v0.d, v1.d, v2.d}[1], [sp]: ld4    (%sp)[32byte] $0x01 -> %q31 %q0 %q1 %q2
+4d60b3ff : ld4    {v31.s, v0.s, v1.s, v2.s}[3], [sp]: ld4    (%sp)[16byte] $0x03 -> %q31 %q0 %q1 %q2
+4dff3fff : ld4    {v31.b, v0.b, v1.b, v2.b}[15], [sp], #4: ld4    %q31 %q0 %q1 %q2 (%sp)[4byte] $0x0f %sp $0x04 -> %q31 %q0 %q1 %q2 %sp
+4dff7bff : ld4    {v31.h, v0.h, v1.h, v2.h}[7], [sp], #8: ld4    %q31 %q0 %q1 %q2 (%sp)[8byte] $0x07 %sp $0x08 -> %q31 %q0 %q1 %q2 %sp
+4dffa7ff : ld4    {v31.d, v0.d, v1.d, v2.d}[1], [sp], #32: ld4    %q31 %q0 %q1 %q2 (%sp)[32byte] $0x01 %sp $0x20 -> %q31 %q0 %q1 %q2 %sp
+4dffb3ff : ld4    {v31.s, v0.s, v1.s, v2.s}[3], [sp], #16: ld4    %q31 %q0 %q1 %q2 (%sp)[16byte] $0x03 %sp $0x10 -> %q31 %q0 %q1 %q2 %sp
+
+4d60efff : ld4r   {v31.2d, v0.2d, v1.2d, v2.2d}, [sp]: ld4r   (%sp)[32byte] -> %q31 %q0 %q1 %q2
+4df0efff : ld4r   {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], x16: ld4r   (%sp)[32byte] %sp %x16 -> %q31 %q0 %q1 %q2 %sp
+4dffefff : ld4r   {v31.2d, v0.2d, v1.2d, v2.2d}, [sp], #32: ld4r   (%sp)[32byte] %sp $0x20 -> %q31 %q0 %q1 %q2 %sp
+
+b8280041 : ldadd  w8, w1, [x2]            : ldadd  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8280041 : ldadd  x8, x1, [x2]            : ldadd  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+b8a80041 : ldadda w8, w1, [x2]            : ldadda %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8bf03ff : ldadda wzr, wzr, [sp]          : ldadda %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8a80041 : ldadda x8, x1, [x2]            : ldadda %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8bf03ff : ldadda xzr, xzr, [sp]          : ldadda %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38a80041 : ldaddab w8, w1, [x2]           : ldaddab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38bf03ff : ldaddab wzr, wzr, [sp]         : ldaddab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78a80041 : ldaddah w8, w1, [x2]           : ldaddah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78bf03ff : ldaddah wzr, wzr, [sp]         : ldaddah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b8e80041 : ldaddal w8, w1, [x2]           : ldaddal %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8ff03ff : ldaddal wzr, wzr, [sp]         : ldaddal %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8e80041 : ldaddal x8, x1, [x2]           : ldaddal %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8ff03ff : ldaddal xzr, xzr, [sp]         : ldaddal %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38e80041 : ldaddalb w8, w1, [x2]          : ldaddalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38ff03ff : ldaddalb wzr, wzr, [sp]        : ldaddalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78e80041 : ldaddalh w8, w1, [x2]          : ldaddalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78ff03ff : ldaddalh wzr, wzr, [sp]        : ldaddalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+38280041 : ldaddb w8, w1, [x2]            : ldaddb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78280041 : ldaddh w8, w1, [x2]            : ldaddh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8680041 : ldaddl w8, w1, [x2]            : ldaddl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8680041 : ldaddl x8, x1, [x2]            : ldaddl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+38680041 : ldaddlb w8, w1, [x2]           : ldaddlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78680041 : ldaddlh w8, w1, [x2]           : ldaddlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+88dfffff : ldar   wzr, [sp]               : ldar   (%sp)[4byte] -> %wzr
+c8dfffff : ldar   xzr, [sp]               : ldar   (%sp)[8byte] -> %xzr
+
+08dfffff : ldarb  wzr, [sp]               : ldarb  (%sp)[1byte] -> %wzr
+
+48dfffff : ldarh  wzr, [sp]               : ldarh  (%sp)[2byte] -> %wzr
+
+88689041 : ldaxp  w1, w4, [x2]            : ldaxp  (%x2)[8byte] $0x08 -> %w1 %w4
+887fffff : ldaxp  wzr, wzr, [sp]          : ldaxp  (%sp)[8byte] $0x1f -> %wzr %wzr
+c8689041 : ldaxp  x1, x4, [x2]            : ldaxp  (%x2)[16byte] $0x08 -> %x1 %x4
+c87fffff : ldaxp  xzr, xzr, [sp]          : ldaxp  (%sp)[16byte] $0x1f -> %xzr %xzr
+
+88489041 : ldaxr  w1, [x2]                : ldaxr  (%x2)[4byte] $0x04 $0x08 -> %w1
+885fffff : ldaxr  wzr, [sp]               : ldaxr  (%sp)[4byte] $0x1f $0x1f -> %wzr
+c8489041 : ldaxr  x1, [x2]                : ldaxr  (%x2)[8byte] $0x04 $0x08 -> %x1
+c85fffff : ldaxr  xzr, [sp]               : ldaxr  (%sp)[8byte] $0x1f $0x1f -> %xzr
+
+08489041 : ldaxrb w1, [x2]                : ldaxrb (%x2)[1byte] $0x04 $0x08 -> %w1
+085fffff : ldaxrb wzr, [sp]               : ldaxrb (%sp)[1byte] $0x1f $0x1f -> %wzr
+
+48489041 : ldaxrh w1, [x2]                : ldaxrh (%x2)[2byte] $0x04 $0x08 -> %w1
+485fffff : ldaxrh wzr, [sp]               : ldaxrh (%sp)[2byte] $0x1f $0x1f -> %wzr
+
+b8281041 : ldclr  w8, w1, [x2]            : ldclr  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8281041 : ldclr  x8, x1, [x2]            : ldclr  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+b8a81041 : ldclra w8, w1, [x2]            : ldclra %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8bf13ff : ldclra wzr, wzr, [sp]          : ldclra %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8a81041 : ldclra x8, x1, [x2]            : ldclra %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8bf13ff : ldclra xzr, xzr, [sp]          : ldclra %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38a81041 : ldclrab w8, w1, [x2]           : ldclrab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38bf13ff : ldclrab wzr, wzr, [sp]         : ldclrab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78a81041 : ldclrah w8, w1, [x2]           : ldclrah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78bf13ff : ldclrah wzr, wzr, [sp]         : ldclrah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b8e81041 : ldclral w8, w1, [x2]           : ldclral %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8ff13ff : ldclral wzr, wzr, [sp]         : ldclral %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8e81041 : ldclral x8, x1, [x2]           : ldclral %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8ff13ff : ldclral xzr, xzr, [sp]         : ldclral %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38e81041 : ldclralb w8, w1, [x2]          : ldclralb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38ff13ff : ldclralb wzr, wzr, [sp]        : ldclralb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78e81041 : ldclralh w8, w1, [x2]          : ldclralh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78ff13ff : ldclralh wzr, wzr, [sp]        : ldclralh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+38281041 : ldclrb w8, w1, [x2]            : ldclrb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78281041 : ldclrh w8, w1, [x2]            : ldclrh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8681041 : ldclrl w8, w1, [x2]            : ldclrl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8681041 : ldclrl x8, x1, [x2]            : ldclrl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+38681041 : ldclrlb w8, w1, [x2]           : ldclrlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78681041 : ldclrlh w8, w1, [x2]           : ldclrlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8282041 : ldeor  w8, w1, [x2]            : ldeor  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8282041 : ldeor  x8, x1, [x2]            : ldeor  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+b8a82041 : ldeora w8, w1, [x2]            : ldeora %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8bf23ff : ldeora wzr, wzr, [sp]          : ldeora %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8a82041 : ldeora x8, x1, [x2]            : ldeora %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8bf23ff : ldeora xzr, xzr, [sp]          : ldeora %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38a82041 : ldeorab w8, w1, [x2]           : ldeorab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38bf23ff : ldeorab wzr, wzr, [sp]         : ldeorab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78a82041 : ldeorah w8, w1, [x2]           : ldeorah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78bf23ff : ldeorah wzr, wzr, [sp]         : ldeorah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b8e82041 : ldeoral w8, w1, [x2]           : ldeoral %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8ff23ff : ldeoral wzr, wzr, [sp]         : ldeoral %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8e82041 : ldeoral x8, x1, [x2]           : ldeoral %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8ff23ff : ldeoral xzr, xzr, [sp]         : ldeoral %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38e82041 : ldeoralb w8, w1, [x2]          : ldeoralb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38ff23ff : ldeoralb wzr, wzr, [sp]        : ldeoralb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78e82041 : ldeoralh w8, w1, [x2]          : ldeoralh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78ff23ff : ldeoralh wzr, wzr, [sp]        : ldeoralh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+38282041 : ldeorb w8, w1, [x2]            : ldeorb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78282041 : ldeorh w8, w1, [x2]            : ldeorh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8682041 : ldeorl w8, w1, [x2]            : ldeorl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8682041 : ldeorl x8, x1, [x2]            : ldeorl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+38682041 : ldeorlb w8, w1, [x2]           : ldeorlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78682041 : ldeorlh w8, w1, [x2]           : ldeorlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+28400000 : ldnp   w0, w0, [x0]            : ldnp   (%x0)[8byte] -> %w0 %w0
+287fffff : ldnp   wzr, wzr, [sp,#-4]      : ldnp   -0x04(%sp)[8byte] -> %wzr %wzr
+2c400000 : ldnp   s0, s0, [x0]            : ldnp   (%x0)[8byte] -> %s0 %s0
+2c7fffff : ldnp   s31, s31, [sp,#-4]      : ldnp   -0x04(%sp)[8byte] -> %s31 %s31
+6c400000 : ldnp   d0, d0, [x0]            : ldnp   (%x0)[16byte] -> %d0 %d0
+6c7fffff : ldnp   d31, d31, [sp,#-8]      : ldnp   -0x08(%sp)[16byte] -> %d31 %d31
+a8400000 : ldnp   x0, x0, [x0]            : ldnp   (%x0)[16byte] -> %x0 %x0
+a87fffff : ldnp   xzr, xzr, [sp,#-8]      : ldnp   -0x08(%sp)[16byte] -> %xzr %xzr
+ac400000 : ldnp   q0, q0, [x0]            : ldnp   (%x0)[32byte] -> %q0 %q0
+ac7fffff : ldnp   q31, q31, [sp,#-16]     : ldnp   -0x10(%sp)[32byte] -> %q31 %q31
+
+28c00000 : ldp    w0, w0, [x0],#0         : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %w0 %w0 %x0
+28ffffff : ldp    wzr, wzr, [sp],#-4      : ldp    (%sp)[8byte] %sp $0xfffffffffffffffc -> %wzr %wzr %sp
+29400000 : ldp    w0, w0, [x0]            : ldp    (%x0)[8byte] -> %w0 %w0
+297fffff : ldp    wzr, wzr, [sp,#-4]      : ldp    -0x04(%sp)[8byte] -> %wzr %wzr
+29c00000 : ldp    w0, w0, [x0,#0]!        : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %w0 %w0 %x0
+29ffffff : ldp    wzr, wzr, [sp,#-4]!     : ldp    -0x04(%sp)[8byte] %sp $0xfffffffffffffffc -> %wzr %wzr %sp
+2cc00000 : ldp    s0, s0, [x0],#0         : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %s0 %s0 %x0
+2cffffff : ldp    s31, s31, [sp],#-4      : ldp    (%sp)[8byte] %sp $0xfffffffffffffffc -> %s31 %s31 %sp
+2d400000 : ldp    s0, s0, [x0]            : ldp    (%x0)[8byte] -> %s0 %s0
+2d7fffff : ldp    s31, s31, [sp,#-4]      : ldp    -0x04(%sp)[8byte] -> %s31 %s31
+2dc00000 : ldp    s0, s0, [x0,#0]!        : ldp    (%x0)[8byte] %x0 $0x0000000000000000 -> %s0 %s0 %x0
+2dffffff : ldp    s31, s31, [sp,#-4]!     : ldp    -0x04(%sp)[8byte] %sp $0xfffffffffffffffc -> %s31 %s31 %sp
+6cc00000 : ldp    d0, d0, [x0],#0         : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %d0 %d0 %x0
+6cffffff : ldp    d31, d31, [sp],#-8      : ldp    (%sp)[16byte] %sp $0xfffffffffffffff8 -> %d31 %d31 %sp
+6d400000 : ldp    d0, d0, [x0]            : ldp    (%x0)[16byte] -> %d0 %d0
+6d7fffff : ldp    d31, d31, [sp,#-8]      : ldp    -0x08(%sp)[16byte] -> %d31 %d31
+6dc00000 : ldp    d0, d0, [x0,#0]!        : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %d0 %d0 %x0
+6dffffff : ldp    d31, d31, [sp,#-8]!     : ldp    -0x08(%sp)[16byte] %sp $0xfffffffffffffff8 -> %d31 %d31 %sp
+a8c00000 : ldp    x0, x0, [x0],#0         : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
+a8ffffff : ldp    xzr, xzr, [sp],#-8      : ldp    (%sp)[16byte] %sp $0xfffffffffffffff8 -> %xzr %xzr %sp
+a9400000 : ldp    x0, x0, [x0]            : ldp    (%x0)[16byte] -> %x0 %x0
+a97fffff : ldp    xzr, xzr, [sp,#-8]      : ldp    -0x08(%sp)[16byte] -> %xzr %xzr
+a9c00000 : ldp    x0, x0, [x0,#0]!        : ldp    (%x0)[16byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
+a9ffffff : ldp    xzr, xzr, [sp,#-8]!     : ldp    -0x08(%sp)[16byte] %sp $0xfffffffffffffff8 -> %xzr %xzr %sp
+acc00000 : ldp    q0, q0, [x0],#0         : ldp    (%x0)[32byte] %x0 $0x0000000000000000 -> %q0 %q0 %x0
+acffffff : ldp    q31, q31, [sp],#-16     : ldp    (%sp)[32byte] %sp $0xfffffffffffffff0 -> %q31 %q31 %sp
+ad400000 : ldp    q0, q0, [x0]            : ldp    (%x0)[32byte] -> %q0 %q0
+ad7fffff : ldp    q31, q31, [sp,#-16]     : ldp    -0x10(%sp)[32byte] -> %q31 %q31
+adc00000 : ldp    q0, q0, [x0,#0]!        : ldp    (%x0)[32byte] %x0 $0x0000000000000000 -> %q0 %q0 %x0
+adffffff : ldp    q31, q31, [sp,#-16]!    : ldp    -0x10(%sp)[32byte] %sp $0xfffffffffffffff0 -> %q31 %q31 %sp
+
+68c00000 : ldpsw  x0, x0, [x0],#0         : ldpsw  (%x0)[8byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
+68ffffff : ldpsw  xzr, xzr, [sp],#-4      : ldpsw  (%sp)[8byte] %sp $0xfffffffffffffffc -> %xzr %xzr %sp
+69400000 : ldpsw  x0, x0, [x0]            : ldpsw  (%x0)[8byte] -> %x0 %x0
+697fffff : ldpsw  xzr, xzr, [sp,#-4]      : ldpsw  -0x04(%sp)[8byte] -> %xzr %xzr
+69c00000 : ldpsw  x0, x0, [x0,#0]!        : ldpsw  (%x0)[8byte] %x0 $0x0000000000000000 -> %x0 %x0 %x0
+69ffffff : ldpsw  xzr, xzr, [sp,#-4]!     : ldpsw  -0x04(%sp)[8byte] %sp $0xfffffffffffffffc -> %xzr %xzr %sp
+
+18081041 : ldr    w1, 10010208            : ldr    <rel> 0x0000000010010208[4byte] -> %w1
+187fffff : ldr    wzr, 100ffffc           : ldr    <rel> 0x00000000100ffffc[4byte] -> %wzr
+18800000 : ldr    w0, ff00000             : ldr    <rel> 0x000000000ff00000[4byte] -> %w0
+1c081041 : ldr    s1, 10010208            : ldr    <rel> 0x0000000010010208[4byte] -> %s1
+1c7fffff : ldr    s31, 100ffffc           : ldr    <rel> 0x00000000100ffffc[4byte] -> %s31
+1c800000 : ldr    s0, ff00000             : ldr    <rel> 0x000000000ff00000[4byte] -> %s0
+3c400400 : ldr    b0, [x0],#0             : ldr    (%x0)[1byte] %x0 $0x0000000000000000 -> %b0 %x0
+3c400c00 : ldr    b0, [x0,#0]!            : ldr    (%x0)[1byte] %x0 $0x0000000000000000 -> %b0 %x0
+3c481441 : ldr    b1, [x2],#129           : ldr    (%x2)[1byte] %x2 $0x0000000000000081 -> %b1 %x2
+3c481c41 : ldr    b1, [x2,#129]!          : ldr    +0x81(%x2)[1byte] %x2 $0x0000000000000081 -> %b1 %x2
+3c5ff7ff : ldr    b31, [sp],#-1           : ldr    (%sp)[1byte] %sp $0xffffffffffffffff -> %b31 %sp
+3c5fffff : ldr    b31, [sp,#-1]!          : ldr    -0x01(%sp)[1byte] %sp $0xffffffffffffffff -> %b31 %sp
+3c634841 : ldr    b1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[1byte] -> %b1
+3c635841 : ldr    b1, [x2,w3,uxtw #0]     : ldr    (%x2,%x3,uxtw #0)[1byte] -> %b1
+3c636841 : ldr    b1, [x2,x3]             : ldr    (%x2,%x3)[1byte] -> %b1
+3c637841 : ldr    b1, [x2,x3,lsl #0]      : ldr    (%x2,%x3,uxtx #0)[1byte] -> %b1
+3c63c841 : ldr    b1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[1byte] -> %b1
+3c63d841 : ldr    b1, [x2,w3,sxtw #0]     : ldr    (%x2,%x3,sxtw #0)[1byte] -> %b1
+3c63e841 : ldr    b1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[1byte] -> %b1
+3c63f841 : ldr    b1, [x2,x3,sxtx #0]     : ldr    (%x2,%x3,sxtx #0)[1byte] -> %b1
+3c7f4bff : ldr    b31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[1byte] -> %b31
+3c7f5bff : ldr    b31, [sp,wzr,uxtw #0]   : ldr    (%sp,%xzr,uxtw #0)[1byte] -> %b31
+3c7f6bff : ldr    b31, [sp,xzr]           : ldr    (%sp,%xzr)[1byte] -> %b31
+3c7f7bff : ldr    b31, [sp,xzr,lsl #0]    : ldr    (%sp,%xzr,uxtx #0)[1byte] -> %b31
+3c7fcbff : ldr    b31, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[1byte] -> %b31
+3c7fdbff : ldr    b31, [sp,wzr,sxtw #0]   : ldr    (%sp,%xzr,sxtw #0)[1byte] -> %b31
+3c7febff : ldr    b31, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[1byte] -> %b31
+3c7ffbff : ldr    b31, [sp,xzr,sxtx #0]   : ldr    (%sp,%xzr,sxtx #0)[1byte] -> %b31
+3cc00400 : ldr    q0, [x0],#0             : ldr    (%x0)[16byte] %x0 $0x0000000000000000 -> %q0 %x0
+3cc00c00 : ldr    q0, [x0,#0]!            : ldr    (%x0)[16byte] %x0 $0x0000000000000000 -> %q0 %x0
+3cc81441 : ldr    q1, [x2],#129           : ldr    (%x2)[16byte] %x2 $0x0000000000000081 -> %q1 %x2
+3cc81c41 : ldr    q1, [x2,#129]!          : ldr    +0x81(%x2)[16byte] %x2 $0x0000000000000081 -> %q1 %x2
+3cdff7ff : ldr    q31, [sp],#-1           : ldr    (%sp)[16byte] %sp $0xffffffffffffffff -> %q31 %sp
+3cdfffff : ldr    q31, [sp,#-1]!          : ldr    -0x01(%sp)[16byte] %sp $0xffffffffffffffff -> %q31 %sp
+3ce34841 : ldr    q1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[16byte] -> %q1
+3ce35841 : ldr    q1, [x2,w3,uxtw #4]     : ldr    (%x2,%x3,uxtw #4)[16byte] -> %q1
+3ce36841 : ldr    q1, [x2,x3]             : ldr    (%x2,%x3)[16byte] -> %q1
+3ce37841 : ldr    q1, [x2,x3,lsl #4]      : ldr    (%x2,%x3,uxtx #4)[16byte] -> %q1
+3ce3c841 : ldr    q1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[16byte] -> %q1
+3ce3d841 : ldr    q1, [x2,w3,sxtw #4]     : ldr    (%x2,%x3,sxtw #4)[16byte] -> %q1
+3ce3e841 : ldr    q1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[16byte] -> %q1
+3ce3f841 : ldr    q1, [x2,x3,sxtx #4]     : ldr    (%x2,%x3,sxtx #4)[16byte] -> %q1
+3cff4bff : ldr    q31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[16byte] -> %q31
+3cff5bff : ldr    q31, [sp,wzr,uxtw #4]   : ldr    (%sp,%xzr,uxtw #4)[16byte] -> %q31
+3cff6bff : ldr    q31, [sp,xzr]           : ldr    (%sp,%xzr)[16byte] -> %q31
+3cff7bff : ldr    q31, [sp,xzr,lsl #4]    : ldr    (%sp,%xzr,uxtx #4)[16byte] -> %q31
+3cffcbff : ldr    q31, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[16byte] -> %q31
+3cffdbff : ldr    q31, [sp,wzr,sxtw #4]   : ldr    (%sp,%xzr,sxtw #4)[16byte] -> %q31
+3cffebff : ldr    q31, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[16byte] -> %q31
+3cfffbff : ldr    q31, [sp,xzr,sxtx #4]   : ldr    (%sp,%xzr,sxtx #4)[16byte] -> %q31
+3d481041 : ldr    b1, [x2,#516]           : ldr    +0x0204(%x2)[1byte] -> %b1
+3d7fffff : ldr    b31, [sp,#4095]         : ldr    +0x0fff(%sp)[1byte] -> %b31
+3dc81041 : ldr    q1, [x2,#8256]          : ldr    +0x2040(%x2)[16byte] -> %q1
+3dffffff : ldr    q31, [sp,#65520]        : ldr    +0xfff0(%sp)[16byte] -> %q31
+587fffff : ldr    xzr, 100ffffc           : ldr    <rel> 0x00000000100ffffc[8byte] -> %xzr
+58800000 : ldr    x0, ff00000             : ldr    <rel> 0x000000000ff00000[8byte] -> %x0
+58ffffff : ldr    xzr, ffffffc            : ldr    <rel> 0x000000000ffffffc[8byte] -> %xzr
+5c7fffff : ldr    d31, 100ffffc           : ldr    <rel> 0x00000000100ffffc[8byte] -> %d31
+5c800000 : ldr    d0, ff00000             : ldr    <rel> 0x000000000ff00000[8byte] -> %d0
+7c400400 : ldr    h0, [x0],#0             : ldr    (%x0)[2byte] %x0 $0x0000000000000000 -> %h0 %x0
+7c400c00 : ldr    h0, [x0,#0]!            : ldr    (%x0)[2byte] %x0 $0x0000000000000000 -> %h0 %x0
+7c481441 : ldr    h1, [x2],#129           : ldr    (%x2)[2byte] %x2 $0x0000000000000081 -> %h1 %x2
+7c481c41 : ldr    h1, [x2,#129]!          : ldr    +0x81(%x2)[2byte] %x2 $0x0000000000000081 -> %h1 %x2
+7c5ff7ff : ldr    h31, [sp],#-1           : ldr    (%sp)[2byte] %sp $0xffffffffffffffff -> %h31 %sp
+7c5fffff : ldr    h31, [sp,#-1]!          : ldr    -0x01(%sp)[2byte] %sp $0xffffffffffffffff -> %h31 %sp
+7c634841 : ldr    h1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[2byte] -> %h1
+7c635841 : ldr    h1, [x2,w3,uxtw #1]     : ldr    (%x2,%x3,uxtw #1)[2byte] -> %h1
+7c636841 : ldr    h1, [x2,x3]             : ldr    (%x2,%x3)[2byte] -> %h1
+7c637841 : ldr    h1, [x2,x3,lsl #1]      : ldr    (%x2,%x3,uxtx #1)[2byte] -> %h1
+7c63c841 : ldr    h1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[2byte] -> %h1
+7c63d841 : ldr    h1, [x2,w3,sxtw #1]     : ldr    (%x2,%x3,sxtw #1)[2byte] -> %h1
+7c63e841 : ldr    h1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[2byte] -> %h1
+7c63f841 : ldr    h1, [x2,x3,sxtx #1]     : ldr    (%x2,%x3,sxtx #1)[2byte] -> %h1
+7c7f4bff : ldr    h31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[2byte] -> %h31
+7c7f5bff : ldr    h31, [sp,wzr,uxtw #1]   : ldr    (%sp,%xzr,uxtw #1)[2byte] -> %h31
+7c7f6bff : ldr    h31, [sp,xzr]           : ldr    (%sp,%xzr)[2byte] -> %h31
+7c7f7bff : ldr    h31, [sp,xzr,lsl #1]    : ldr    (%sp,%xzr,uxtx #1)[2byte] -> %h31
+7c7fcbff : ldr    h31, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[2byte] -> %h31
+7c7fdbff : ldr    h31, [sp,wzr,sxtw #1]   : ldr    (%sp,%xzr,sxtw #1)[2byte] -> %h31
+7c7febff : ldr    h31, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[2byte] -> %h31
+7c7ffbff : ldr    h31, [sp,xzr,sxtx #1]   : ldr    (%sp,%xzr,sxtx #1)[2byte] -> %h31
+7d481041 : ldr    h1, [x2,#1032]          : ldr    +0x0408(%x2)[2byte] -> %h1
+7d7fffff : ldr    h31, [sp,#8190]         : ldr    +0x1ffe(%sp)[2byte] -> %h31
+9c7fffff : ldr    q31, 100ffffc           : ldr    <rel> 0x00000000100ffffc[16byte] -> %q31
+9c800000 : ldr    q0, ff00000             : ldr    <rel> 0x000000000ff00000[16byte] -> %q0
+b8400400 : ldr    w0, [x0],#0             : ldr    (%x0)[4byte] %x0 $0x0000000000000000 -> %w0 %x0
+b8400c00 : ldr    w0, [x0,#0]!            : ldr    (%x0)[4byte] %x0 $0x0000000000000000 -> %w0 %x0
+b8481441 : ldr    w1, [x2],#129           : ldr    (%x2)[4byte] %x2 $0x0000000000000081 -> %w1 %x2
+b8481c41 : ldr    w1, [x2,#129]!          : ldr    +0x81(%x2)[4byte] %x2 $0x0000000000000081 -> %w1 %x2
+b85ff7ff : ldr    wzr, [sp],#-1           : ldr    (%sp)[4byte] %sp $0xffffffffffffffff -> %wzr %sp
+b85fffff : ldr    wzr, [sp,#-1]!          : ldr    -0x01(%sp)[4byte] %sp $0xffffffffffffffff -> %wzr %sp
+b8634841 : ldr    w1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[4byte] -> %w1
+b8635841 : ldr    w1, [x2,w3,uxtw #2]     : ldr    (%x2,%x3,uxtw #2)[4byte] -> %w1
+b8636841 : ldr    w1, [x2,x3]             : ldr    (%x2,%x3)[4byte] -> %w1
+b8637841 : ldr    w1, [x2,x3,lsl #2]      : ldr    (%x2,%x3,uxtx #2)[4byte] -> %w1
+b863c841 : ldr    w1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[4byte] -> %w1
+b863d841 : ldr    w1, [x2,w3,sxtw #2]     : ldr    (%x2,%x3,sxtw #2)[4byte] -> %w1
+b863e841 : ldr    w1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[4byte] -> %w1
+b863f841 : ldr    w1, [x2,x3,sxtx #2]     : ldr    (%x2,%x3,sxtx #2)[4byte] -> %w1
+b87f4bff : ldr    wzr, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[4byte] -> %wzr
+b87f5bff : ldr    wzr, [sp,wzr,uxtw #2]   : ldr    (%sp,%xzr,uxtw #2)[4byte] -> %wzr
+b87f6bff : ldr    wzr, [sp,xzr]           : ldr    (%sp,%xzr)[4byte] -> %wzr
+b87f7bff : ldr    wzr, [sp,xzr,lsl #2]    : ldr    (%sp,%xzr,uxtx #2)[4byte] -> %wzr
+b87fcbff : ldr    wzr, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[4byte] -> %wzr
+b87fdbff : ldr    wzr, [sp,wzr,sxtw #2]   : ldr    (%sp,%xzr,sxtw #2)[4byte] -> %wzr
+b87febff : ldr    wzr, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[4byte] -> %wzr
+b87ffbff : ldr    wzr, [sp,xzr,sxtx #2]   : ldr    (%sp,%xzr,sxtx #2)[4byte] -> %wzr
+b9481041 : ldr    w1, [x2,#2064]          : ldr    +0x0810(%x2)[4byte] -> %w1
+b97fffff : ldr    wzr, [sp,#16380]        : ldr    +0x3ffc(%sp)[4byte] -> %wzr
+bc400400 : ldr    s0, [x0],#0             : ldr    (%x0)[4byte] %x0 $0x0000000000000000 -> %s0 %x0
+bc400c00 : ldr    s0, [x0,#0]!            : ldr    (%x0)[4byte] %x0 $0x0000000000000000 -> %s0 %x0
+bc481441 : ldr    s1, [x2],#129           : ldr    (%x2)[4byte] %x2 $0x0000000000000081 -> %s1 %x2
+bc481c41 : ldr    s1, [x2,#129]!          : ldr    +0x81(%x2)[4byte] %x2 $0x0000000000000081 -> %s1 %x2
+bc5ff7ff : ldr    s31, [sp],#-1           : ldr    (%sp)[4byte] %sp $0xffffffffffffffff -> %s31 %sp
+bc5fffff : ldr    s31, [sp,#-1]!          : ldr    -0x01(%sp)[4byte] %sp $0xffffffffffffffff -> %s31 %sp
+bc634841 : ldr    s1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[4byte] -> %s1
+bc635841 : ldr    s1, [x2,w3,uxtw #2]     : ldr    (%x2,%x3,uxtw #2)[4byte] -> %s1
+bc636841 : ldr    s1, [x2,x3]             : ldr    (%x2,%x3)[4byte] -> %s1
+bc637841 : ldr    s1, [x2,x3,lsl #2]      : ldr    (%x2,%x3,uxtx #2)[4byte] -> %s1
+bc63c841 : ldr    s1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[4byte] -> %s1
+bc63d841 : ldr    s1, [x2,w3,sxtw #2]     : ldr    (%x2,%x3,sxtw #2)[4byte] -> %s1
+bc63e841 : ldr    s1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[4byte] -> %s1
+bc63f841 : ldr    s1, [x2,x3,sxtx #2]     : ldr    (%x2,%x3,sxtx #2)[4byte] -> %s1
+bc7f4bff : ldr    s31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[4byte] -> %s31
+bc7f5bff : ldr    s31, [sp,wzr,uxtw #2]   : ldr    (%sp,%xzr,uxtw #2)[4byte] -> %s31
+bc7f6bff : ldr    s31, [sp,xzr]           : ldr    (%sp,%xzr)[4byte] -> %s31
+bc7f7bff : ldr    s31, [sp,xzr,lsl #2]    : ldr    (%sp,%xzr,uxtx #2)[4byte] -> %s31
+bc7fcbff : ldr    s31, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[4byte] -> %s31
+bc7fdbff : ldr    s31, [sp,wzr,sxtw #2]   : ldr    (%sp,%xzr,sxtw #2)[4byte] -> %s31
+bc7febff : ldr    s31, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[4byte] -> %s31
+bc7ffbff : ldr    s31, [sp,xzr,sxtx #2]   : ldr    (%sp,%xzr,sxtx #2)[4byte] -> %s31
+bd481041 : ldr    s1, [x2,#2064]          : ldr    +0x0810(%x2)[4byte] -> %s1
+bd7fffff : ldr    s31, [sp,#16380]        : ldr    +0x3ffc(%sp)[4byte] -> %s31
+f8400400 : ldr    x0, [x0],#0             : ldr    (%x0)[8byte] %x0 $0x0000000000000000 -> %x0 %x0
+f8400c00 : ldr    x0, [x0,#0]!            : ldr    (%x0)[8byte] %x0 $0x0000000000000000 -> %x0 %x0
+f8481441 : ldr    x1, [x2],#129           : ldr    (%x2)[8byte] %x2 $0x0000000000000081 -> %x1 %x2
+f8481c41 : ldr    x1, [x2,#129]!          : ldr    +0x81(%x2)[8byte] %x2 $0x0000000000000081 -> %x1 %x2
+f85ff7ff : ldr    xzr, [sp],#-1           : ldr    (%sp)[8byte] %sp $0xffffffffffffffff -> %xzr %sp
+f85fffff : ldr    xzr, [sp,#-1]!          : ldr    -0x01(%sp)[8byte] %sp $0xffffffffffffffff -> %xzr %sp
+f8634841 : ldr    x1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[8byte] -> %x1
+f8635841 : ldr    x1, [x2,w3,uxtw #3]     : ldr    (%x2,%x3,uxtw #3)[8byte] -> %x1
+f8636841 : ldr    x1, [x2,x3]             : ldr    (%x2,%x3)[8byte] -> %x1
+f8637841 : ldr    x1, [x2,x3,lsl #3]      : ldr    (%x2,%x3,uxtx #3)[8byte] -> %x1
+f863c841 : ldr    x1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[8byte] -> %x1
+f863d841 : ldr    x1, [x2,w3,sxtw #3]     : ldr    (%x2,%x3,sxtw #3)[8byte] -> %x1
+f863e841 : ldr    x1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[8byte] -> %x1
+f863f841 : ldr    x1, [x2,x3,sxtx #3]     : ldr    (%x2,%x3,sxtx #3)[8byte] -> %x1
+f87f4bff : ldr    xzr, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[8byte] -> %xzr
+f87f5bff : ldr    xzr, [sp,wzr,uxtw #3]   : ldr    (%sp,%xzr,uxtw #3)[8byte] -> %xzr
+f87f6bff : ldr    xzr, [sp,xzr]           : ldr    (%sp,%xzr)[8byte] -> %xzr
+f87f7bff : ldr    xzr, [sp,xzr,lsl #3]    : ldr    (%sp,%xzr,uxtx #3)[8byte] -> %xzr
+f87fcbff : ldr    xzr, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[8byte] -> %xzr
+f87fdbff : ldr    xzr, [sp,wzr,sxtw #3]   : ldr    (%sp,%xzr,sxtw #3)[8byte] -> %xzr
+f87febff : ldr    xzr, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[8byte] -> %xzr
+f87ffbff : ldr    xzr, [sp,xzr,sxtx #3]   : ldr    (%sp,%xzr,sxtx #3)[8byte] -> %xzr
+f9481041 : ldr    x1, [x2,#4128]          : ldr    +0x1020(%x2)[8byte] -> %x1
+f97fffff : ldr    xzr, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %xzr
+fc400400 : ldr    d0, [x0],#0             : ldr    (%x0)[8byte] %x0 $0x0000000000000000 -> %d0 %x0
+fc400c00 : ldr    d0, [x0,#0]!            : ldr    (%x0)[8byte] %x0 $0x0000000000000000 -> %d0 %x0
+fc481441 : ldr    d1, [x2],#129           : ldr    (%x2)[8byte] %x2 $0x0000000000000081 -> %d1 %x2
+fc481c41 : ldr    d1, [x2,#129]!          : ldr    +0x81(%x2)[8byte] %x2 $0x0000000000000081 -> %d1 %x2
+fc5ff7ff : ldr    d31, [sp],#-1           : ldr    (%sp)[8byte] %sp $0xffffffffffffffff -> %d31 %sp
+fc5fffff : ldr    d31, [sp,#-1]!          : ldr    -0x01(%sp)[8byte] %sp $0xffffffffffffffff -> %d31 %sp
+fc634841 : ldr    d1, [x2,w3,uxtw]        : ldr    (%x2,%x3,uxtw)[8byte] -> %d1
+fc635841 : ldr    d1, [x2,w3,uxtw #3]     : ldr    (%x2,%x3,uxtw #3)[8byte] -> %d1
+fc636841 : ldr    d1, [x2,x3]             : ldr    (%x2,%x3)[8byte] -> %d1
+fc637841 : ldr    d1, [x2,x3,lsl #3]      : ldr    (%x2,%x3,uxtx #3)[8byte] -> %d1
+fc63c841 : ldr    d1, [x2,w3,sxtw]        : ldr    (%x2,%x3,sxtw)[8byte] -> %d1
+fc63d841 : ldr    d1, [x2,w3,sxtw #3]     : ldr    (%x2,%x3,sxtw #3)[8byte] -> %d1
+fc63e841 : ldr    d1, [x2,x3,sxtx]        : ldr    (%x2,%x3,sxtx)[8byte] -> %d1
+fc63f841 : ldr    d1, [x2,x3,sxtx #3]     : ldr    (%x2,%x3,sxtx #3)[8byte] -> %d1
+fc7f4bff : ldr    d31, [sp,wzr,uxtw]      : ldr    (%sp,%xzr,uxtw)[8byte] -> %d31
+fc7f5bff : ldr    d31, [sp,wzr,uxtw #3]   : ldr    (%sp,%xzr,uxtw #3)[8byte] -> %d31
+fc7f6bff : ldr    d31, [sp,xzr]           : ldr    (%sp,%xzr)[8byte] -> %d31
+fc7f7bff : ldr    d31, [sp,xzr,lsl #3]    : ldr    (%sp,%xzr,uxtx #3)[8byte] -> %d31
+fc7fcbff : ldr    d31, [sp,wzr,sxtw]      : ldr    (%sp,%xzr,sxtw)[8byte] -> %d31
+fc7fdbff : ldr    d31, [sp,wzr,sxtw #3]   : ldr    (%sp,%xzr,sxtw #3)[8byte] -> %d31
+fc7febff : ldr    d31, [sp,xzr,sxtx]      : ldr    (%sp,%xzr,sxtx)[8byte] -> %d31
+fc7ffbff : ldr    d31, [sp,xzr,sxtx #3]   : ldr    (%sp,%xzr,sxtx #3)[8byte] -> %d31
+fd481041 : ldr    d1, [x2,#4128]          : ldr    +0x1020(%x2)[8byte] -> %d1
+fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
+
+38400400 : ldrb   w0, [x0],#0             : ldrb   (%x0)[1byte] %x0 $0x0000000000000000 -> %w0 %x0
+38400c00 : ldrb   w0, [x0,#0]!            : ldrb   (%x0)[1byte] %x0 $0x0000000000000000 -> %w0 %x0
+38481441 : ldrb   w1, [x2],#129           : ldrb   (%x2)[1byte] %x2 $0x0000000000000081 -> %w1 %x2
+38481c41 : ldrb   w1, [x2,#129]!          : ldrb   +0x81(%x2)[1byte] %x2 $0x0000000000000081 -> %w1 %x2
+385ff7ff : ldrb   wzr, [sp],#-1           : ldrb   (%sp)[1byte] %sp $0xffffffffffffffff -> %wzr %sp
+385fffff : ldrb   wzr, [sp,#-1]!          : ldrb   -0x01(%sp)[1byte] %sp $0xffffffffffffffff -> %wzr %sp
+38634841 : ldrb   w1, [x2,w3,uxtw]        : ldrb   (%x2,%x3,uxtw)[1byte] -> %w1
+38635841 : ldrb   w1, [x2,w3,uxtw #0]     : ldrb   (%x2,%x3,uxtw #0)[1byte] -> %w1
+38636841 : ldrb   w1, [x2,x3]             : ldrb   (%x2,%x3)[1byte] -> %w1
+38637841 : ldrb   w1, [x2,x3,lsl #0]      : ldrb   (%x2,%x3,uxtx #0)[1byte] -> %w1
+3863c841 : ldrb   w1, [x2,w3,sxtw]        : ldrb   (%x2,%x3,sxtw)[1byte] -> %w1
+3863d841 : ldrb   w1, [x2,w3,sxtw #0]     : ldrb   (%x2,%x3,sxtw #0)[1byte] -> %w1
+3863e841 : ldrb   w1, [x2,x3,sxtx]        : ldrb   (%x2,%x3,sxtx)[1byte] -> %w1
+3863f841 : ldrb   w1, [x2,x3,sxtx #0]     : ldrb   (%x2,%x3,sxtx #0)[1byte] -> %w1
+387f4bff : ldrb   wzr, [sp,wzr,uxtw]      : ldrb   (%sp,%xzr,uxtw)[1byte] -> %wzr
+387f5bff : ldrb   wzr, [sp,wzr,uxtw #0]   : ldrb   (%sp,%xzr,uxtw #0)[1byte] -> %wzr
+387f6bff : ldrb   wzr, [sp,xzr]           : ldrb   (%sp,%xzr)[1byte] -> %wzr
+387f7bff : ldrb   wzr, [sp,xzr,lsl #0]    : ldrb   (%sp,%xzr,uxtx #0)[1byte] -> %wzr
+387fcbff : ldrb   wzr, [sp,wzr,sxtw]      : ldrb   (%sp,%xzr,sxtw)[1byte] -> %wzr
+387fdbff : ldrb   wzr, [sp,wzr,sxtw #0]   : ldrb   (%sp,%xzr,sxtw #0)[1byte] -> %wzr
+387febff : ldrb   wzr, [sp,xzr,sxtx]      : ldrb   (%sp,%xzr,sxtx)[1byte] -> %wzr
+387ffbff : ldrb   wzr, [sp,xzr,sxtx #0]   : ldrb   (%sp,%xzr,sxtx #0)[1byte] -> %wzr
+39481041 : ldrb   w1, [x2,#516]           : ldrb   +0x0204(%x2)[1byte] -> %w1
+397fffff : ldrb   wzr, [sp,#4095]         : ldrb   +0x0fff(%sp)[1byte] -> %wzr
+
+78400400 : ldrh   w0, [x0],#0             : ldrh   (%x0)[2byte] %x0 $0x0000000000000000 -> %w0 %x0
+78400c00 : ldrh   w0, [x0,#0]!            : ldrh   (%x0)[2byte] %x0 $0x0000000000000000 -> %w0 %x0
+78481441 : ldrh   w1, [x2],#129           : ldrh   (%x2)[2byte] %x2 $0x0000000000000081 -> %w1 %x2
+78481c41 : ldrh   w1, [x2,#129]!          : ldrh   +0x81(%x2)[2byte] %x2 $0x0000000000000081 -> %w1 %x2
+785ff7ff : ldrh   wzr, [sp],#-1           : ldrh   (%sp)[2byte] %sp $0xffffffffffffffff -> %wzr %sp
+785fffff : ldrh   wzr, [sp,#-1]!          : ldrh   -0x01(%sp)[2byte] %sp $0xffffffffffffffff -> %wzr %sp
+78634841 : ldrh   w1, [x2,w3,uxtw]        : ldrh   (%x2,%x3,uxtw)[2byte] -> %w1
+78635841 : ldrh   w1, [x2,w3,uxtw #1]     : ldrh   (%x2,%x3,uxtw #1)[2byte] -> %w1
+78636841 : ldrh   w1, [x2,x3]             : ldrh   (%x2,%x3)[2byte] -> %w1
+78637841 : ldrh   w1, [x2,x3,lsl #1]      : ldrh   (%x2,%x3,uxtx #1)[2byte] -> %w1
+7863c841 : ldrh   w1, [x2,w3,sxtw]        : ldrh   (%x2,%x3,sxtw)[2byte] -> %w1
+7863d841 : ldrh   w1, [x2,w3,sxtw #1]     : ldrh   (%x2,%x3,sxtw #1)[2byte] -> %w1
+7863e841 : ldrh   w1, [x2,x3,sxtx]        : ldrh   (%x2,%x3,sxtx)[2byte] -> %w1
+7863f841 : ldrh   w1, [x2,x3,sxtx #1]     : ldrh   (%x2,%x3,sxtx #1)[2byte] -> %w1
+787f4bff : ldrh   wzr, [sp,wzr,uxtw]      : ldrh   (%sp,%xzr,uxtw)[2byte] -> %wzr
+787f5bff : ldrh   wzr, [sp,wzr,uxtw #1]   : ldrh   (%sp,%xzr,uxtw #1)[2byte] -> %wzr
+787f6bff : ldrh   wzr, [sp,xzr]           : ldrh   (%sp,%xzr)[2byte] -> %wzr
+787f7bff : ldrh   wzr, [sp,xzr,lsl #1]    : ldrh   (%sp,%xzr,uxtx #1)[2byte] -> %wzr
+787fcbff : ldrh   wzr, [sp,wzr,sxtw]      : ldrh   (%sp,%xzr,sxtw)[2byte] -> %wzr
+787fdbff : ldrh   wzr, [sp,wzr,sxtw #1]   : ldrh   (%sp,%xzr,sxtw #1)[2byte] -> %wzr
+787febff : ldrh   wzr, [sp,xzr,sxtx]      : ldrh   (%sp,%xzr,sxtx)[2byte] -> %wzr
+787ffbff : ldrh   wzr, [sp,xzr,sxtx #1]   : ldrh   (%sp,%xzr,sxtx #1)[2byte] -> %wzr
+79481041 : ldrh   w1, [x2,#1032]          : ldrh   +0x0408(%x2)[2byte] -> %w1
+797fffff : ldrh   wzr, [sp,#8190]         : ldrh   +0x1ffe(%sp)[2byte] -> %wzr
+
+38800400 : ldrsb  x0, [x0],#0             : ldrsb  (%x0)[1byte] %x0 $0x0000000000000000 -> %x0 %x0
+38800c00 : ldrsb  x0, [x0,#0]!            : ldrsb  (%x0)[1byte] %x0 $0x0000000000000000 -> %x0 %x0
+38881441 : ldrsb  x1, [x2],#129           : ldrsb  (%x2)[1byte] %x2 $0x0000000000000081 -> %x1 %x2
+38881c41 : ldrsb  x1, [x2,#129]!          : ldrsb  +0x81(%x2)[1byte] %x2 $0x0000000000000081 -> %x1 %x2
+389ff7ff : ldrsb  xzr, [sp],#-1           : ldrsb  (%sp)[1byte] %sp $0xffffffffffffffff -> %xzr %sp
+389fffff : ldrsb  xzr, [sp,#-1]!          : ldrsb  -0x01(%sp)[1byte] %sp $0xffffffffffffffff -> %xzr %sp
+38a34841 : ldrsb  x1, [x2,w3,uxtw]        : ldrsb  (%x2,%x3,uxtw)[1byte] -> %x1
+38a35841 : ldrsb  x1, [x2,w3,uxtw #0]     : ldrsb  (%x2,%x3,uxtw #0)[1byte] -> %x1
+38a36841 : ldrsb  x1, [x2,x3]             : ldrsb  (%x2,%x3)[1byte] -> %x1
+38a37841 : ldrsb  x1, [x2,x3,lsl #0]      : ldrsb  (%x2,%x3,uxtx #0)[1byte] -> %x1
+38a3c841 : ldrsb  x1, [x2,w3,sxtw]        : ldrsb  (%x2,%x3,sxtw)[1byte] -> %x1
+38a3d841 : ldrsb  x1, [x2,w3,sxtw #0]     : ldrsb  (%x2,%x3,sxtw #0)[1byte] -> %x1
+38a3e841 : ldrsb  x1, [x2,x3,sxtx]        : ldrsb  (%x2,%x3,sxtx)[1byte] -> %x1
+38a3f841 : ldrsb  x1, [x2,x3,sxtx #0]     : ldrsb  (%x2,%x3,sxtx #0)[1byte] -> %x1
+38bf4bff : ldrsb  xzr, [sp,wzr,uxtw]      : ldrsb  (%sp,%xzr,uxtw)[1byte] -> %xzr
+38bf5bff : ldrsb  xzr, [sp,wzr,uxtw #0]   : ldrsb  (%sp,%xzr,uxtw #0)[1byte] -> %xzr
+38bf6bff : ldrsb  xzr, [sp,xzr]           : ldrsb  (%sp,%xzr)[1byte] -> %xzr
+38bf7bff : ldrsb  xzr, [sp,xzr,lsl #0]    : ldrsb  (%sp,%xzr,uxtx #0)[1byte] -> %xzr
+38bfcbff : ldrsb  xzr, [sp,wzr,sxtw]      : ldrsb  (%sp,%xzr,sxtw)[1byte] -> %xzr
+38bfdbff : ldrsb  xzr, [sp,wzr,sxtw #0]   : ldrsb  (%sp,%xzr,sxtw #0)[1byte] -> %xzr
+38bfebff : ldrsb  xzr, [sp,xzr,sxtx]      : ldrsb  (%sp,%xzr,sxtx)[1byte] -> %xzr
+38bffbff : ldrsb  xzr, [sp,xzr,sxtx #0]   : ldrsb  (%sp,%xzr,sxtx #0)[1byte] -> %xzr
+38c00400 : ldrsb  w0, [x0],#0             : ldrsb  (%x0)[1byte] %x0 $0x0000000000000000 -> %w0 %x0
+38c00c00 : ldrsb  w0, [x0,#0]!            : ldrsb  (%x0)[1byte] %x0 $0x0000000000000000 -> %w0 %x0
+38c81441 : ldrsb  w1, [x2],#129           : ldrsb  (%x2)[1byte] %x2 $0x0000000000000081 -> %w1 %x2
+38c81c41 : ldrsb  w1, [x2,#129]!          : ldrsb  +0x81(%x2)[1byte] %x2 $0x0000000000000081 -> %w1 %x2
+38dff7ff : ldrsb  wzr, [sp],#-1           : ldrsb  (%sp)[1byte] %sp $0xffffffffffffffff -> %wzr %sp
+38dfffff : ldrsb  wzr, [sp,#-1]!          : ldrsb  -0x01(%sp)[1byte] %sp $0xffffffffffffffff -> %wzr %sp
+38e34841 : ldrsb  w1, [x2,w3,uxtw]        : ldrsb  (%x2,%x3,uxtw)[1byte] -> %w1
+38e35841 : ldrsb  w1, [x2,w3,uxtw #0]     : ldrsb  (%x2,%x3,uxtw #0)[1byte] -> %w1
+38e36841 : ldrsb  w1, [x2,x3]             : ldrsb  (%x2,%x3)[1byte] -> %w1
+38e37841 : ldrsb  w1, [x2,x3,lsl #0]      : ldrsb  (%x2,%x3,uxtx #0)[1byte] -> %w1
+38e3c841 : ldrsb  w1, [x2,w3,sxtw]        : ldrsb  (%x2,%x3,sxtw)[1byte] -> %w1
+38e3d841 : ldrsb  w1, [x2,w3,sxtw #0]     : ldrsb  (%x2,%x3,sxtw #0)[1byte] -> %w1
+38e3e841 : ldrsb  w1, [x2,x3,sxtx]        : ldrsb  (%x2,%x3,sxtx)[1byte] -> %w1
+38e3f841 : ldrsb  w1, [x2,x3,sxtx #0]     : ldrsb  (%x2,%x3,sxtx #0)[1byte] -> %w1
+38ff4bff : ldrsb  wzr, [sp,wzr,uxtw]      : ldrsb  (%sp,%xzr,uxtw)[1byte] -> %wzr
+38ff5bff : ldrsb  wzr, [sp,wzr,uxtw #0]   : ldrsb  (%sp,%xzr,uxtw #0)[1byte] -> %wzr
+38ff6bff : ldrsb  wzr, [sp,xzr]           : ldrsb  (%sp,%xzr)[1byte] -> %wzr
+38ff7bff : ldrsb  wzr, [sp,xzr,lsl #0]    : ldrsb  (%sp,%xzr,uxtx #0)[1byte] -> %wzr
+38ffcbff : ldrsb  wzr, [sp,wzr,sxtw]      : ldrsb  (%sp,%xzr,sxtw)[1byte] -> %wzr
+38ffdbff : ldrsb  wzr, [sp,wzr,sxtw #0]   : ldrsb  (%sp,%xzr,sxtw #0)[1byte] -> %wzr
+38ffebff : ldrsb  wzr, [sp,xzr,sxtx]      : ldrsb  (%sp,%xzr,sxtx)[1byte] -> %wzr
+38fffbff : ldrsb  wzr, [sp,xzr,sxtx #0]   : ldrsb  (%sp,%xzr,sxtx #0)[1byte] -> %wzr
+39881041 : ldrsb  x1, [x2,#516]           : ldrsb  +0x0204(%x2)[1byte] -> %x1
+39bfffff : ldrsb  xzr, [sp,#4095]         : ldrsb  +0x0fff(%sp)[1byte] -> %xzr
+39c81041 : ldrsb  w1, [x2,#516]           : ldrsb  +0x0204(%x2)[1byte] -> %w1
+39ffffff : ldrsb  wzr, [sp,#4095]         : ldrsb  +0x0fff(%sp)[1byte] -> %wzr
+
+78800400 : ldrsh  x0, [x0],#0             : ldrsh  (%x0)[2byte] %x0 $0x0000000000000000 -> %x0 %x0
+78800c00 : ldrsh  x0, [x0,#0]!            : ldrsh  (%x0)[2byte] %x0 $0x0000000000000000 -> %x0 %x0
+78881441 : ldrsh  x1, [x2],#129           : ldrsh  (%x2)[2byte] %x2 $0x0000000000000081 -> %x1 %x2
+78881c41 : ldrsh  x1, [x2,#129]!          : ldrsh  +0x81(%x2)[2byte] %x2 $0x0000000000000081 -> %x1 %x2
+789ff7ff : ldrsh  xzr, [sp],#-1           : ldrsh  (%sp)[2byte] %sp $0xffffffffffffffff -> %xzr %sp
+789fffff : ldrsh  xzr, [sp,#-1]!          : ldrsh  -0x01(%sp)[2byte] %sp $0xffffffffffffffff -> %xzr %sp
+78a34841 : ldrsh  x1, [x2,w3,uxtw]        : ldrsh  (%x2,%x3,uxtw)[2byte] -> %x1
+78a35841 : ldrsh  x1, [x2,w3,uxtw #1]     : ldrsh  (%x2,%x3,uxtw #1)[2byte] -> %x1
+78a36841 : ldrsh  x1, [x2,x3]             : ldrsh  (%x2,%x3)[2byte] -> %x1
+78a37841 : ldrsh  x1, [x2,x3,lsl #1]      : ldrsh  (%x2,%x3,uxtx #1)[2byte] -> %x1
+78a3c841 : ldrsh  x1, [x2,w3,sxtw]        : ldrsh  (%x2,%x3,sxtw)[2byte] -> %x1
+78a3d841 : ldrsh  x1, [x2,w3,sxtw #1]     : ldrsh  (%x2,%x3,sxtw #1)[2byte] -> %x1
+78a3e841 : ldrsh  x1, [x2,x3,sxtx]        : ldrsh  (%x2,%x3,sxtx)[2byte] -> %x1
+78a3f841 : ldrsh  x1, [x2,x3,sxtx #1]     : ldrsh  (%x2,%x3,sxtx #1)[2byte] -> %x1
+78bf4bff : ldrsh  xzr, [sp,wzr,uxtw]      : ldrsh  (%sp,%xzr,uxtw)[2byte] -> %xzr
+78bf5bff : ldrsh  xzr, [sp,wzr,uxtw #1]   : ldrsh  (%sp,%xzr,uxtw #1)[2byte] -> %xzr
+78bf6bff : ldrsh  xzr, [sp,xzr]           : ldrsh  (%sp,%xzr)[2byte] -> %xzr
+78bf7bff : ldrsh  xzr, [sp,xzr,lsl #1]    : ldrsh  (%sp,%xzr,uxtx #1)[2byte] -> %xzr
+78bfcbff : ldrsh  xzr, [sp,wzr,sxtw]      : ldrsh  (%sp,%xzr,sxtw)[2byte] -> %xzr
+78bfdbff : ldrsh  xzr, [sp,wzr,sxtw #1]   : ldrsh  (%sp,%xzr,sxtw #1)[2byte] -> %xzr
+78bfebff : ldrsh  xzr, [sp,xzr,sxtx]      : ldrsh  (%sp,%xzr,sxtx)[2byte] -> %xzr
+78bffbff : ldrsh  xzr, [sp,xzr,sxtx #1]   : ldrsh  (%sp,%xzr,sxtx #1)[2byte] -> %xzr
+78c00400 : ldrsh  w0, [x0],#0             : ldrsh  (%x0)[2byte] %x0 $0x0000000000000000 -> %w0 %x0
+78c00c00 : ldrsh  w0, [x0,#0]!            : ldrsh  (%x0)[2byte] %x0 $0x0000000000000000 -> %w0 %x0
+78c81441 : ldrsh  w1, [x2],#129           : ldrsh  (%x2)[2byte] %x2 $0x0000000000000081 -> %w1 %x2
+78c81c41 : ldrsh  w1, [x2,#129]!          : ldrsh  +0x81(%x2)[2byte] %x2 $0x0000000000000081 -> %w1 %x2
+78dff7ff : ldrsh  wzr, [sp],#-1           : ldrsh  (%sp)[2byte] %sp $0xffffffffffffffff -> %wzr %sp
+78dfffff : ldrsh  wzr, [sp,#-1]!          : ldrsh  -0x01(%sp)[2byte] %sp $0xffffffffffffffff -> %wzr %sp
+78e34841 : ldrsh  w1, [x2,w3,uxtw]        : ldrsh  (%x2,%x3,uxtw)[2byte] -> %w1
+78e35841 : ldrsh  w1, [x2,w3,uxtw #1]     : ldrsh  (%x2,%x3,uxtw #1)[2byte] -> %w1
+78e36841 : ldrsh  w1, [x2,x3]             : ldrsh  (%x2,%x3)[2byte] -> %w1
+78e37841 : ldrsh  w1, [x2,x3,lsl #1]      : ldrsh  (%x2,%x3,uxtx #1)[2byte] -> %w1
+78e3c841 : ldrsh  w1, [x2,w3,sxtw]        : ldrsh  (%x2,%x3,sxtw)[2byte] -> %w1
+78e3d841 : ldrsh  w1, [x2,w3,sxtw #1]     : ldrsh  (%x2,%x3,sxtw #1)[2byte] -> %w1
+78e3e841 : ldrsh  w1, [x2,x3,sxtx]        : ldrsh  (%x2,%x3,sxtx)[2byte] -> %w1
+78e3f841 : ldrsh  w1, [x2,x3,sxtx #1]     : ldrsh  (%x2,%x3,sxtx #1)[2byte] -> %w1
+78ff4bff : ldrsh  wzr, [sp,wzr,uxtw]      : ldrsh  (%sp,%xzr,uxtw)[2byte] -> %wzr
+78ff5bff : ldrsh  wzr, [sp,wzr,uxtw #1]   : ldrsh  (%sp,%xzr,uxtw #1)[2byte] -> %wzr
+78ff6bff : ldrsh  wzr, [sp,xzr]           : ldrsh  (%sp,%xzr)[2byte] -> %wzr
+78ff7bff : ldrsh  wzr, [sp,xzr,lsl #1]    : ldrsh  (%sp,%xzr,uxtx #1)[2byte] -> %wzr
+78ffcbff : ldrsh  wzr, [sp,wzr,sxtw]      : ldrsh  (%sp,%xzr,sxtw)[2byte] -> %wzr
+78ffdbff : ldrsh  wzr, [sp,wzr,sxtw #1]   : ldrsh  (%sp,%xzr,sxtw #1)[2byte] -> %wzr
+78ffebff : ldrsh  wzr, [sp,xzr,sxtx]      : ldrsh  (%sp,%xzr,sxtx)[2byte] -> %wzr
+78fffbff : ldrsh  wzr, [sp,xzr,sxtx #1]   : ldrsh  (%sp,%xzr,sxtx #1)[2byte] -> %wzr
+79881041 : ldrsh  x1, [x2,#1032]          : ldrsh  +0x0408(%x2)[2byte] -> %x1
+79bfffff : ldrsh  xzr, [sp,#8190]         : ldrsh  +0x1ffe(%sp)[2byte] -> %xzr
+79c81041 : ldrsh  w1, [x2,#1032]          : ldrsh  +0x0408(%x2)[2byte] -> %w1
+79ffffff : ldrsh  wzr, [sp,#8190]         : ldrsh  +0x1ffe(%sp)[2byte] -> %wzr
+
+98081041 : ldrsw  x1, 10010208            : ldrsw  <rel> 0x0000000010010208[4byte] -> %x1
+987fffff : ldrsw  xzr, 100ffffc           : ldrsw  <rel> 0x00000000100ffffc[4byte] -> %xzr
+98800000 : ldrsw  x0, ff00000             : ldrsw  <rel> 0x000000000ff00000[4byte] -> %x0
+98ffffff : ldrsw  xzr, ffffffc            : ldrsw  <rel> 0x000000000ffffffc[4byte] -> %xzr
+b8800400 : ldrsw  x0, [x0],#0             : ldrsw  (%x0)[4byte] %x0 $0x0000000000000000 -> %x0 %x0
+b8800c00 : ldrsw  x0, [x0,#0]!            : ldrsw  (%x0)[4byte] %x0 $0x0000000000000000 -> %x0 %x0
+b8881441 : ldrsw  x1, [x2],#129           : ldrsw  (%x2)[4byte] %x2 $0x0000000000000081 -> %x1 %x2
+b8881c41 : ldrsw  x1, [x2,#129]!          : ldrsw  +0x81(%x2)[4byte] %x2 $0x0000000000000081 -> %x1 %x2
+b89ff7ff : ldrsw  xzr, [sp],#-1           : ldrsw  (%sp)[4byte] %sp $0xffffffffffffffff -> %xzr %sp
+b89fffff : ldrsw  xzr, [sp,#-1]!          : ldrsw  -0x01(%sp)[4byte] %sp $0xffffffffffffffff -> %xzr %sp
+b8a34841 : ldrsw  x1, [x2,w3,uxtw]        : ldrsw  (%x2,%x3,uxtw)[4byte] -> %x1
+b8a35841 : ldrsw  x1, [x2,w3,uxtw #2]     : ldrsw  (%x2,%x3,uxtw #2)[4byte] -> %x1
+b8a36841 : ldrsw  x1, [x2,x3]             : ldrsw  (%x2,%x3)[4byte] -> %x1
+b8a37841 : ldrsw  x1, [x2,x3,lsl #2]      : ldrsw  (%x2,%x3,uxtx #2)[4byte] -> %x1
+b8a3c841 : ldrsw  x1, [x2,w3,sxtw]        : ldrsw  (%x2,%x3,sxtw)[4byte] -> %x1
+b8a3d841 : ldrsw  x1, [x2,w3,sxtw #2]     : ldrsw  (%x2,%x3,sxtw #2)[4byte] -> %x1
+b8a3e841 : ldrsw  x1, [x2,x3,sxtx]        : ldrsw  (%x2,%x3,sxtx)[4byte] -> %x1
+b8a3f841 : ldrsw  x1, [x2,x3,sxtx #2]     : ldrsw  (%x2,%x3,sxtx #2)[4byte] -> %x1
+b8bf4bff : ldrsw  xzr, [sp,wzr,uxtw]      : ldrsw  (%sp,%xzr,uxtw)[4byte] -> %xzr
+b8bf5bff : ldrsw  xzr, [sp,wzr,uxtw #2]   : ldrsw  (%sp,%xzr,uxtw #2)[4byte] -> %xzr
+b8bf6bff : ldrsw  xzr, [sp,xzr]           : ldrsw  (%sp,%xzr)[4byte] -> %xzr
+b8bf7bff : ldrsw  xzr, [sp,xzr,lsl #2]    : ldrsw  (%sp,%xzr,uxtx #2)[4byte] -> %xzr
+b8bfcbff : ldrsw  xzr, [sp,wzr,sxtw]      : ldrsw  (%sp,%xzr,sxtw)[4byte] -> %xzr
+b8bfdbff : ldrsw  xzr, [sp,wzr,sxtw #2]   : ldrsw  (%sp,%xzr,sxtw #2)[4byte] -> %xzr
+b8bfebff : ldrsw  xzr, [sp,xzr,sxtx]      : ldrsw  (%sp,%xzr,sxtx)[4byte] -> %xzr
+b8bffbff : ldrsw  xzr, [sp,xzr,sxtx #2]   : ldrsw  (%sp,%xzr,sxtx #2)[4byte] -> %xzr
+b9881041 : ldrsw  x1, [x2,#2064]          : ldrsw  +0x0810(%x2)[4byte] -> %x1
+b9bfffff : ldrsw  xzr, [sp,#16380]        : ldrsw  +0x3ffc(%sp)[4byte] -> %xzr
+
+b8283041 : ldset  w8, w1, [x2]            : ldset  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8283041 : ldset  x8, x1, [x2]            : ldset  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+b8a83041 : ldseta w8, w1, [x2]            : ldseta %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8bf33ff : ldseta wzr, wzr, [sp]          : ldseta %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8a83041 : ldseta x8, x1, [x2]            : ldseta %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8bf33ff : ldseta xzr, xzr, [sp]          : ldseta %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38a83041 : ldsetab w8, w1, [x2]           : ldsetab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38bf33ff : ldsetab wzr, wzr, [sp]         : ldsetab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78a83041 : ldsetah w8, w1, [x2]           : ldsetah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78bf33ff : ldsetah wzr, wzr, [sp]         : ldsetah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b8e83041 : ldsetal w8, w1, [x2]           : ldsetal %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8ff33ff : ldsetal wzr, wzr, [sp]         : ldsetal %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8e83041 : ldsetal x8, x1, [x2]           : ldsetal %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8ff33ff : ldsetal xzr, xzr, [sp]         : ldsetal %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38e83041 : ldsetalb w8, w1, [x2]          : ldsetalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38ff33ff : ldsetalb wzr, wzr, [sp]        : ldsetalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78e83041 : ldsetalh w8, w1, [x2]          : ldsetalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78ff33ff : ldsetalh wzr, wzr, [sp]        : ldsetalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+38283041 : ldsetb w8, w1, [x2]            : ldsetb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78283041 : ldseth w8, w1, [x2]            : ldseth %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8683041 : ldsetl w8, w1, [x2]            : ldsetl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8683041 : ldsetl x8, x1, [x2]            : ldsetl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+38683041 : ldsetlb w8, w1, [x2]           : ldsetlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78683041 : ldsetlh w8, w1, [x2]           : ldsetlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8284041 : ldsmax w8, w1, [x2]            : ldsmax %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8284041 : ldsmax x8, x1, [x2]            : ldsmax %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+b8a84041 : ldsmaxa w8, w1, [x2]           : ldsmaxa %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8bf43ff : ldsmaxa wzr, wzr, [sp]         : ldsmaxa %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8a84041 : ldsmaxa x8, x1, [x2]           : ldsmaxa %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8bf43ff : ldsmaxa xzr, xzr, [sp]         : ldsmaxa %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38a84041 : ldsmaxab w8, w1, [x2]          : ldsmaxab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38bf43ff : ldsmaxab wzr, wzr, [sp]        : ldsmaxab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78a84041 : ldsmaxah w8, w1, [x2]          : ldsmaxah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78bf43ff : ldsmaxah wzr, wzr, [sp]        : ldsmaxah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b8e84041 : ldsmaxal w8, w1, [x2]          : ldsmaxal %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8ff43ff : ldsmaxal wzr, wzr, [sp]        : ldsmaxal %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8e84041 : ldsmaxal x8, x1, [x2]          : ldsmaxal %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8ff43ff : ldsmaxal xzr, xzr, [sp]        : ldsmaxal %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38e84041 : ldsmaxalb w8, w1, [x2]         : ldsmaxalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38ff43ff : ldsmaxalb wzr, wzr, [sp]       : ldsmaxalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78e84041 : ldsmaxalh w8, w1, [x2]         : ldsmaxalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78ff43ff : ldsmaxalh wzr, wzr, [sp]       : ldsmaxalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+38284041 : ldsmaxb w8, w1, [x2]           : ldsmaxb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78284041 : ldsmaxh w8, w1, [x2]           : ldsmaxh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8684041 : ldsmaxl w8, w1, [x2]           : ldsmaxl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8684041 : ldsmaxl x8, x1, [x2]           : ldsmaxl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+38684041 : ldsmaxlb w8, w1, [x2]          : ldsmaxlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78684041 : ldsmaxlh w8, w1, [x2]          : ldsmaxlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8285041 : ldsmin w8, w1, [x2]            : ldsmin %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8285041 : ldsmin x8, x1, [x2]            : ldsmin %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+b8a85041 : ldsmina w8, w1, [x2]           : ldsmina %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8bf53ff : ldsmina wzr, wzr, [sp]         : ldsmina %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8a85041 : ldsmina x8, x1, [x2]           : ldsmina %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8bf53ff : ldsmina xzr, xzr, [sp]         : ldsmina %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38a85041 : ldsminab w8, w1, [x2]          : ldsminab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38bf53ff : ldsminab wzr, wzr, [sp]        : ldsminab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78a85041 : ldsminah w8, w1, [x2]          : ldsminah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78bf53ff : ldsminah wzr, wzr, [sp]        : ldsminah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b8e85041 : ldsminal w8, w1, [x2]          : ldsminal %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8ff53ff : ldsminal wzr, wzr, [sp]        : ldsminal %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8e85041 : ldsminal x8, x1, [x2]          : ldsminal %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8ff53ff : ldsminal xzr, xzr, [sp]        : ldsminal %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38e85041 : ldsminalb w8, w1, [x2]         : ldsminalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38ff53ff : ldsminalb wzr, wzr, [sp]       : ldsminalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78e85041 : ldsminalh w8, w1, [x2]         : ldsminalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78ff53ff : ldsminalh wzr, wzr, [sp]       : ldsminalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+38285041 : ldsminb w8, w1, [x2]           : ldsminb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78285041 : ldsminh w8, w1, [x2]           : ldsminh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8685041 : ldsminl w8, w1, [x2]           : ldsminl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8685041 : ldsminl x8, x1, [x2]           : ldsminl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+38685041 : ldsminlb w8, w1, [x2]          : ldsminlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78685041 : ldsminlh w8, w1, [x2]          : ldsminlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8481841 : ldtr   w1, [x2,#129]           : ldtr   +0x81(%x2)[4byte] -> %w1
+b85ffbff : ldtr   wzr, [sp,#-1]           : ldtr   -0x01(%sp)[4byte] -> %wzr
+f8481841 : ldtr   x1, [x2,#129]           : ldtr   +0x81(%x2)[8byte] -> %x1
+f85ffbff : ldtr   xzr, [sp,#-1]           : ldtr   -0x01(%sp)[8byte] -> %xzr
+
+38481841 : ldtrb  w1, [x2,#129]           : ldtrb  +0x81(%x2)[1byte] -> %w1
+385ffbff : ldtrb  wzr, [sp,#-1]           : ldtrb  -0x01(%sp)[1byte] -> %wzr
+
+78481841 : ldtrh  w1, [x2,#129]           : ldtrh  +0x81(%x2)[2byte] -> %w1
+785ffbff : ldtrh  wzr, [sp,#-1]           : ldtrh  -0x01(%sp)[2byte] -> %wzr
+
+38881841 : ldtrsb x1, [x2,#129]           : ldtrsb +0x81(%x2)[1byte] -> %x1
+389ffbff : ldtrsb xzr, [sp,#-1]           : ldtrsb -0x01(%sp)[1byte] -> %xzr
+38c81841 : ldtrsb w1, [x2,#129]           : ldtrsb +0x81(%x2)[1byte] -> %w1
+38dffbff : ldtrsb wzr, [sp,#-1]           : ldtrsb -0x01(%sp)[1byte] -> %wzr
+
+78881841 : ldtrsh x1, [x2,#129]           : ldtrsh +0x81(%x2)[2byte] -> %x1
+789ffbff : ldtrsh xzr, [sp,#-1]           : ldtrsh -0x01(%sp)[2byte] -> %xzr
+78c81841 : ldtrsh w1, [x2,#129]           : ldtrsh +0x81(%x2)[2byte] -> %w1
+78dffbff : ldtrsh wzr, [sp,#-1]           : ldtrsh -0x01(%sp)[2byte] -> %wzr
+
+b8881841 : ldtrsw x1, [x2,#129]           : ldtrsw +0x81(%x2)[4byte] -> %x1
+b89ffbff : ldtrsw xzr, [sp,#-1]           : ldtrsw -0x01(%sp)[4byte] -> %xzr
+
+b8286041 : ldumax w8, w1, [x2]            : ldumax %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8286041 : ldumax x8, x1, [x2]            : ldumax %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+b8a86041 : ldumaxa w8, w1, [x2]           : ldumaxa %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8bf63ff : ldumaxa wzr, wzr, [sp]         : ldumaxa %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8a86041 : ldumaxa x8, x1, [x2]           : ldumaxa %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8bf63ff : ldumaxa xzr, xzr, [sp]         : ldumaxa %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38a86041 : ldumaxab w8, w1, [x2]          : ldumaxab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38bf63ff : ldumaxab wzr, wzr, [sp]        : ldumaxab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78a86041 : ldumaxah w8, w1, [x2]          : ldumaxah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78bf63ff : ldumaxah wzr, wzr, [sp]        : ldumaxah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b8e86041 : ldumaxal w8, w1, [x2]          : ldumaxal %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8ff63ff : ldumaxal wzr, wzr, [sp]        : ldumaxal %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8e86041 : ldumaxal x8, x1, [x2]          : ldumaxal %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8ff63ff : ldumaxal xzr, xzr, [sp]        : ldumaxal %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38e86041 : ldumaxalb w8, w1, [x2]         : ldumaxalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38ff63ff : ldumaxalb wzr, wzr, [sp]       : ldumaxalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78e86041 : ldumaxalh w8, w1, [x2]         : ldumaxalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78ff63ff : ldumaxalh wzr, wzr, [sp]       : ldumaxalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+38286041 : ldumaxb w8, w1, [x2]           : ldumaxb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78286041 : ldumaxh w8, w1, [x2]           : ldumaxh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8686041 : ldumaxl w8, w1, [x2]           : ldumaxl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8686041 : ldumaxl x8, x1, [x2]           : ldumaxl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+38686041 : ldumaxlb w8, w1, [x2]          : ldumaxlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78686041 : ldumaxlh w8, w1, [x2]          : ldumaxlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8287041 : ldumin w8, w1, [x2]            : ldumin %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8287041 : ldumin x8, x1, [x2]            : ldumin %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+b8a87041 : ldumina w8, w1, [x2]           : ldumina %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8bf73ff : ldumina wzr, wzr, [sp]         : ldumina %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8a87041 : ldumina x8, x1, [x2]           : ldumina %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8bf73ff : ldumina xzr, xzr, [sp]         : ldumina %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38a87041 : lduminab w8, w1, [x2]          : lduminab %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38bf73ff : lduminab wzr, wzr, [sp]        : lduminab %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78a87041 : lduminah w8, w1, [x2]          : lduminah %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78bf73ff : lduminah wzr, wzr, [sp]        : lduminah %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b8e87041 : lduminal w8, w1, [x2]          : lduminal %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8ff73ff : lduminal wzr, wzr, [sp]        : lduminal %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8e87041 : lduminal x8, x1, [x2]          : lduminal %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8ff73ff : lduminal xzr, xzr, [sp]        : lduminal %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38e87041 : lduminalb w8, w1, [x2]         : lduminalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38ff73ff : lduminalb wzr, wzr, [sp]       : lduminalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78e87041 : lduminalh w8, w1, [x2]         : lduminalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78ff73ff : lduminalh wzr, wzr, [sp]       : lduminalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+38287041 : lduminb w8, w1, [x2]           : lduminb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78287041 : lduminh w8, w1, [x2]           : lduminh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+b8687041 : lduminl w8, w1, [x2]           : lduminl %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+f8687041 : lduminl x8, x1, [x2]           : lduminl %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+
+38687041 : lduminlb w8, w1, [x2]          : lduminlb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+
+78687041 : lduminlh w8, w1, [x2]          : lduminlh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+
+3c400000 : ldur   b0, [x0]                : ldur   (%x0)[1byte] -> %b0
+3c4ff021 : ldur   b1, [x1, #255]          : ldur   +0xff(%x1)[1byte] -> %b1
+7c400042 : ldur   h2, [x2]                : ldur   (%x2)[2byte] -> %h2
+7c500063 : ldur   h3, [x3, #-256]         : ldur   -0x0100(%x3)[2byte] -> %h3
+bc400084 : ldur   s4, [x4]                : ldur   (%x4)[4byte] -> %s4
+bc5000a5 : ldur   s5, [x5, #-256]         : ldur   -0x0100(%x5)[4byte] -> %s5
+fc4000c6 : ldur   d6, [x6]                : ldur   (%x6)[8byte] -> %d6
+fc5000e7 : ldur   d7, [x7, #-256]         : ldur   -0x0100(%x7)[8byte] -> %d7
+3cc00108 : ldur   q8, [x8]                : ldur   (%x8)[16byte] -> %q8
+3cd00129 : ldur   q9, [x9, #-256]         : ldur   -0x0100(%x9)[16byte] -> %q9
+3c481041 : ldur   b1, [x2,#129]           : ldur   +0x81(%x2)[1byte] -> %b1
+3c5ff3ff : ldur   b31, [sp,#-1]           : ldur   -0x01(%sp)[1byte] -> %b31
+3cc81041 : ldur   q1, [x2,#129]           : ldur   +0x81(%x2)[16byte] -> %q1
+3cdff3ff : ldur   q31, [sp,#-1]           : ldur   -0x01(%sp)[16byte] -> %q31
+7c481041 : ldur   h1, [x2,#129]           : ldur   +0x81(%x2)[2byte] -> %h1
+7c5ff3ff : ldur   h31, [sp,#-1]           : ldur   -0x01(%sp)[2byte] -> %h31
+b8481041 : ldur   w1, [x2,#129]           : ldur   +0x81(%x2)[4byte] -> %w1
+b85ff3ff : ldur   wzr, [sp,#-1]           : ldur   -0x01(%sp)[4byte] -> %wzr
+bc481041 : ldur   s1, [x2,#129]           : ldur   +0x81(%x2)[4byte] -> %s1
+bc5ff3ff : ldur   s31, [sp,#-1]           : ldur   -0x01(%sp)[4byte] -> %s31
+f8481041 : ldur   x1, [x2,#129]           : ldur   +0x81(%x2)[8byte] -> %x1
+f85ff3ff : ldur   xzr, [sp,#-1]           : ldur   -0x01(%sp)[8byte] -> %xzr
+fc481041 : ldur   d1, [x2,#129]           : ldur   +0x81(%x2)[8byte] -> %d1
+fc5ff3ff : ldur   d31, [sp,#-1]           : ldur   -0x01(%sp)[8byte] -> %d31
+
+38481041 : ldurb  w1, [x2,#129]           : ldurb  +0x81(%x2)[1byte] -> %w1
+385ff3ff : ldurb  wzr, [sp,#-1]           : ldurb  -0x01(%sp)[1byte] -> %wzr
+
+78481041 : ldurh  w1, [x2,#129]           : ldurh  +0x81(%x2)[2byte] -> %w1
+785ff3ff : ldurh  wzr, [sp,#-1]           : ldurh  -0x01(%sp)[2byte] -> %wzr
+
+38881041 : ldursb x1, [x2,#129]           : ldursb +0x81(%x2)[1byte] -> %x1
+389ff3ff : ldursb xzr, [sp,#-1]           : ldursb -0x01(%sp)[1byte] -> %xzr
+38c81041 : ldursb w1, [x2,#129]           : ldursb +0x81(%x2)[1byte] -> %w1
+38dff3ff : ldursb wzr, [sp,#-1]           : ldursb -0x01(%sp)[1byte] -> %wzr
+
+78881041 : ldursh x1, [x2,#129]           : ldursh +0x81(%x2)[2byte] -> %x1
+789ff3ff : ldursh xzr, [sp,#-1]           : ldursh -0x01(%sp)[2byte] -> %xzr
+78c81041 : ldursh w1, [x2,#129]           : ldursh +0x81(%x2)[2byte] -> %w1
+78dff3ff : ldursh wzr, [sp,#-1]           : ldursh -0x01(%sp)[2byte] -> %wzr
+
+b8881041 : ldursw x1, [x2,#129]           : ldursw +0x81(%x2)[4byte] -> %x1
+b89ff3ff : ldursw xzr, [sp,#-1]           : ldursw -0x01(%sp)[4byte] -> %xzr
+
+88681041 : ldxp   w1, w4, [x2]            : ldxp   (%x2)[8byte] $0x08 -> %w1 %w4
+887f7fff : ldxp   wzr, wzr, [sp]          : ldxp   (%sp)[8byte] $0x1f -> %wzr %wzr
+c8681041 : ldxp   x1, x4, [x2]            : ldxp   (%x2)[16byte] $0x08 -> %x1 %x4
+c87f7fff : ldxp   xzr, xzr, [sp]          : ldxp   (%sp)[16byte] $0x1f -> %xzr %xzr
+
+88481041 : ldxr   w1, [x2]                : ldxr   (%x2)[4byte] $0x04 $0x08 -> %w1
+885f7fff : ldxr   wzr, [sp]               : ldxr   (%sp)[4byte] $0x1f $0x1f -> %wzr
+c8481041 : ldxr   x1, [x2]                : ldxr   (%x2)[8byte] $0x04 $0x08 -> %x1
+c85f7fff : ldxr   xzr, [sp]               : ldxr   (%sp)[8byte] $0x1f $0x1f -> %xzr
+
+08481041 : ldxrb  w1, [x2]                : ldxrb  (%x2)[1byte] $0x04 $0x08 -> %w1
+085f7fff : ldxrb  wzr, [sp]               : ldxrb  (%sp)[1byte] $0x1f $0x1f -> %wzr
+
+48481041 : ldxrh  w1, [x2]                : ldxrh  (%x2)[2byte] $0x04 $0x08 -> %w1
+485f7fff : ldxrh  wzr, [sp]               : ldxrh  (%sp)[2byte] $0x1f $0x1f -> %wzr
+
+1ac323e1 : lsl    w1, wzr, w3             : lslv   %wzr %w3 -> %w1
+
+531f7fff : lsr    wzr, wzr, #31           : ubfm   %wzr $0x1f $0x1f -> %wzr
+9adf2441 : lsr    x1, x2, xzr             : lsrv   %x2 %xzr -> %x1
+d37fffff : lsr    xzr, xzr, #63           : ubfm   %xzr $0x3f $0x3f -> %xzr
+
+1b1f1041 : madd   w1, w2, wzr, w4         : madd   %w2 %wzr %w4 -> %w1
+9b0313e1 : madd   x1, xzr, x3, x4         : madd   %xzr %x3 %x4 -> %x1
+
+0e249662 : mla v2.8b, v19.8b, v4.8b                 : mla    %d2 %d19 %d4 $0x00 -> %d2
+4e249662 : mla v2.16b, v19.16b, v4.16b              : mla    %q2 %q19 %q4 $0x00 -> %q2
+0e649662 : mla v2.4h, v19.4h, v4.4h                 : mla    %d2 %d19 %d4 $0x01 -> %d2
+4e649662 : mla v2.8h, v19.8h, v4.8h                 : mla    %q2 %q19 %q4 $0x01 -> %q2
+0ea49662 : mla v2.2s, v19.2s, v4.2s                 : mla    %d2 %d19 %d4 $0x02 -> %d2
+4ea49662 : mla v2.4s, v19.4s, v4.4s                 : mla    %q2 %q19 %q4 $0x02 -> %q2
+
+2e3b95a7 : mls v7.8b, v13.8b, v27.8b                : mls    %d7 %d13 %d27 $0x00 -> %d7
+6e3b95a7 : mls v7.16b, v13.16b, v27.16b             : mls    %q7 %q13 %q27 $0x00 -> %q7
+2e7b95a7 : mls v7.4h, v13.4h, v27.4h                : mls    %d7 %d13 %d27 $0x01 -> %d7
+6e7b95a7 : mls v7.8h, v13.8h, v27.8h                : mls    %q7 %q13 %q27 $0x01 -> %q7
+2ebb95a7 : mls v7.2s, v13.2s, v27.2s                : mls    %d7 %d13 %d27 $0x02 -> %d7
+6ebb95a7 : mls v7.4s, v13.4s, v27.4s                : mls    %q7 %q13 %q27 $0x02 -> %q7
+
+1b03fc41 : mneg   w1, w2, w3              : msub   %w2 %w3 %wzr -> %w1
+
+12881041 : mov    w1, #0xffffbf7d         : movn   $0x4082 lsl $0x00 -> %w1
+2a9f13ff : mov    wzr, wzr                : orr    %wzr %wzr asr $0x04 -> %wzr
+2a9f7fff : mov    wzr, wzr                : orr    %wzr %wzr asr $0x1f -> %wzr
+52881041 : mov    w1, #0x4082             : movz   $0x4082 lsl $0x00 -> %w1
+92ffffff : mov    xzr, #0xffffffffffff    : movn   $0xffff lsl $0x30 -> %xzr
+aadf13ff : mov    xzr, xzr                : orr    %xzr %xzr ror $0x04 -> %xzr
+d2ffffff : mov    xzr, #0xffff000000000000: movz   $0xffff lsl $0x30 -> %xzr
+
+72881041 : movk   w1, #0x4082             : movk   %w1 $0x4082 lsl $0x00 -> %w1
+f2ffffff : movk   xzr, #0xffff, lsl #48   : movk   %xzr $0xffff lsl $0x30 -> %xzr
+
+d5300000 : mrs    x0, s2_0_c0_c0_0        : mrs    $0x0000 -> %x0
+d53b4201 : mrs    x1, nzcv                : mrs    %nzcv -> %x1
+d53b4402 : mrs    x2, fpcr                : mrs    %fpcr -> %x2
+d53b4423 : mrs    x3, fpsr                : mrs    %fpsr -> %x3
+d53bd044 : mrs    x4, tpidr_el0           : mrs    %tpidr_el0 -> %x4
+d53fffff : mrs    xzr, s3_7_c15_c15_7     : mrs    $0x7fff -> %xzr
+
+d5100000 : msr    s2_0_c0_c0_0, x0        : msr    %x0 $0x0000
+d51b4201 : msr    nzcv, x1                : msr    %x1 -> %nzcv
+d51b4402 : msr    fpcr, x2                : msr    %x2 -> %fpcr
+d51b4423 : msr    fpsr, x3                : msr    %x3 -> %fpsr
+d51bd044 : msr    tpidr_el0, x4           : msr    %x4 -> %tpidr_el0
+d51fffff : msr    s3_7_c15_c15_7, xzr     : msr    %xzr $0x7fff
+
+9b03905f : msub   xzr, x2, x3, x4         : msub   %x2 %x3 %x4 -> %xzr
+
+0e389d25 : mul v5.8b, v9.8b, v24.8b                 : mul    %d9 %d24 $0x00 -> %d5
+4e389d25 : mul v5.16b, v9.16b, v24.16b              : mul    %q9 %q24 $0x00 -> %q5
+0e789d25 : mul v5.4h, v9.4h, v24.4h                 : mul    %d9 %d24 $0x01 -> %d5
+4e789d25 : mul v5.8h, v9.8h, v24.8h                 : mul    %q9 %q24 $0x01 -> %q5
+0eb89d25 : mul v5.2s, v9.2s, v24.2s                 : mul    %d9 %d24 $0x02 -> %d5
+4eb89d25 : mul v5.4s, v9.4s, v24.4s                 : mul    %q9 %q24 $0x02 -> %q5
+
+2abf13ff : mvn    wzr, wzr, asr #4        : orn    %wzr %wzr asr $0x04 -> %wzr
+aaff13ff : mvn    xzr, xzr, ror #4        : orn    %xzr %xzr ror $0x04 -> %xzr
+aaffffff : mvn    xzr, xzr, ror #63       : orn    %xzr %xzr ror $0x3f -> %xzr
+
+4b9f13ff : neg    wzr, wzr, asr #4        : sub    %wzr %wzr asr $0x04 -> %wzr
+4b9f7fff : neg    wzr, wzr, asr #31       : sub    %wzr %wzr asr $0x1f -> %wzr
+cb9f13ff : neg    xzr, xzr, asr #4        : sub    %xzr %xzr asr $0x04 -> %xzr
+
+6b1f7fff : negs   wzr, wzr, lsl #31       : subs   %wzr %wzr lsl $0x1f -> %wzr
+6b9f13ff : negs   wzr, wzr, asr #4        : subs   %wzr %wzr asr $0x04 -> %wzr
+eb5fffff : negs   xzr, xzr, lsr #63       : subs   %xzr %xzr lsr $0x3f -> %xzr
+eb9f13ff : negs   xzr, xzr, asr #4        : subs   %xzr %xzr asr $0x04 -> %xzr
+
+5a1f03ff : ngc    wzr, wzr                : sbc    %wzr %wzr -> %wzr
+
+fa1f03ff : ngcs   xzr, xzr                : sbcs   %xzr %xzr -> %xzr
+
+d503201f : nop                            : nop
+
+2a231041 : orn    w1, w2, w3, lsl #4      : orn    %w2 %w3 lsl $0x04 -> %w1
+aa631041 : orn    x1, x2, x3, lsr #4      : orn    %x2 %x3 lsr $0x04 -> %x1
+0ee31c9c : orn v28.8b, v4.8b, v3.8b                 : orn    %d4 %d3 -> %d28
+4ee31c9c : orn v28.16b, v4.16b, v3.16b              : orn    %q4 %q3 -> %q28
+
+2a031041 : orr    w1, w2, w3, lsl #4      : orr    %w2 %w3 lsl $0x04 -> %w1
+32000441 : orr    w1, w2, #0x3            : orr    %w2 $0x00000003 -> %w1
+aa431041 : orr    x1, x2, x3, lsr #4      : orr    %x2 %x3 lsr $0x04 -> %x1
+b2400441 : orr    x1, x2, #0x3            : orr    %x2 $0x0000000000000003 -> %x1
+0ea01c5a : orr v26.8b, v2.8b, v0.8b                 : orr    %d2 %d0 -> %d26
+4ea01c5a : orr v26.16b, v2.16b, v0.16b              : orr    %q2 %q0 -> %q26
+04181da2 : orr z2.b, p7/m, z2.b, z13.b              : orr    %p7 %z2 %z13 $0x00 -> %z2
+04581da2 : orr z2.h, p7/m, z2.h, z13.h              : orr    %p7 %z2 %z13 $0x01 -> %z2
+04981da2 : orr z2.s, p7/m, z2.s, z13.s              : orr    %p7 %z2 %z13 $0x02 -> %z2
+04d81da2 : orr z2.d, p7/m, z2.d, z13.d              : orr    %p7 %z2 %z13 $0x03 -> %z2
+
+2e2c9f1a : pmul v26.8b, v24.8b, v12.8b              : pmul   %d24 %d12 $0x00 -> %d26
+6e2c9f1a : pmul v26.16b, v24.16b, v12.16b           : pmul   %q24 %q12 $0x00 -> %q26
+
+0e22e270 : pmull v16.8h, v19.8b, v2.8b              : pmull  %d19 %d2 $0x00 -> %q16
+0ee2e270 : pmull v16.1q, v19.1d, v2.1d              : pmull  %d19 %d2 $0x03 -> %q16
+
+4e22e270 : pmull2 v16.8h, v19.16b, v2.16b           : pmull2 %q19 %q2 $0x00 -> %q16
+4ee2e270 : pmull2 v16.1q, v19.2d, v2.2d             : pmull2 %q19 %q2 $0x03 -> %q16
+
+d87fffff : prfm   #0x1f, 100ffffc         : prfm   $0x1f <rel> 0x00000000100ffffc
+d8800000 : prfm   pldl1keep, ff00000      : prfm   $0x00 <rel> 0x000000000ff00000
+f8a34841 : prfm   pldl1strm, [x2,w3,uxtw] : prfm   $0x01 (%x2,%x3,uxtw)
+f8a35841 : prfm   pldl1strm, [x2,w3,uxtw #3]: prfm   $0x01 (%x2,%x3,uxtw #3)
+f8a36841 : prfm   pldl1strm, [x2,x3]      : prfm   $0x01 (%x2,%x3)
+f8a37841 : prfm   pldl1strm, [x2,x3,lsl #3]: prfm   $0x01 (%x2,%x3,uxtx #3)
+f8a3c841 : prfm   pldl1strm, [x2,w3,sxtw] : prfm   $0x01 (%x2,%x3,sxtw)
+f8a3d841 : prfm   pldl1strm, [x2,w3,sxtw #3]: prfm   $0x01 (%x2,%x3,sxtw #3)
+f8a3e841 : prfm   pldl1strm, [x2,x3,sxtx] : prfm   $0x01 (%x2,%x3,sxtx)
+f8a3f841 : prfm   pldl1strm, [x2,x3,sxtx #3]: prfm   $0x01 (%x2,%x3,sxtx #3)
+f8bf4bff : prfm   #0x1f, [sp,wzr,uxtw]    : prfm   $0x1f (%sp,%xzr,uxtw)
+f8bf5bff : prfm   #0x1f, [sp,wzr,uxtw #3] : prfm   $0x1f (%sp,%xzr,uxtw #3)
+f8bf6bff : prfm   #0x1f, [sp,xzr]         : prfm   $0x1f (%sp,%xzr)
+f8bf7bff : prfm   #0x1f, [sp,xzr,lsl #3]  : prfm   $0x1f (%sp,%xzr,uxtx #3)
+f8bfcbff : prfm   #0x1f, [sp,wzr,sxtw]    : prfm   $0x1f (%sp,%xzr,sxtw)
+f8bfdbff : prfm   #0x1f, [sp,wzr,sxtw #3] : prfm   $0x1f (%sp,%xzr,sxtw #3)
+f8bfebff : prfm   #0x1f, [sp,xzr,sxtx]    : prfm   $0x1f (%sp,%xzr,sxtx)
+f8bffbff : prfm   #0x1f, [sp,xzr,sxtx #3] : prfm   $0x1f (%sp,%xzr,sxtx #3)
+f9881041 : prfm   pldl1strm, [x2,#4128]   : prfm   $0x01 +0x1020(%x2)
+f9bfffff : prfm   #0x1f, [sp,#32760]      : prfm   $0x1f +0x7ff8(%sp)
+
+f8800000 : prfum  pldl1keep, [x0]         : prfum  $0x00 (%x0)
+f8881041 : prfum  pldl1strm, [x2,#129]    : prfum  $0x01 +0x81(%x2)
+f89ff3ff : prfum  #0x1f, [sp,#-1]         : prfum  $0x1f -0x01(%sp)
+
+2e2e41ff : raddhn v31.8b, v15.8h, v14.8h            : raddhn %q15 %q14 $0x00 -> %d31
+2e6e41ff : raddhn v31.4h, v15.4s, v14.4s            : raddhn %q15 %q14 $0x01 -> %d31
+2eae41ff : raddhn v31.2s, v15.2d, v14.2d            : raddhn %q15 %q14 $0x02 -> %d31
+
+6e2e420d : raddhn2 v13.16b, v16.8h, v14.8h          : raddhn2 %q16 %q14 $0x00 -> %q13
+6e6e420d : raddhn2 v13.8h, v16.4s, v14.4s           : raddhn2 %q16 %q14 $0x01 -> %q13
+6eae420d : raddhn2 v13.4s, v16.2d, v14.2d           : raddhn2 %q16 %q14 $0x02 -> %q13
+
+5ac00041 : rbit   w1, w2                  : rbit   %w2 -> %w1
+dac00041 : rbit   x1, x2                  : rbit   %x2 -> %x1
+
+d65f0000 : ret    x0                      : ret    %x0
+d65f0040 : ret    x2                      : ret    %x2
+d65f03e0 : ret    xzr                     : ret    %xzr
+
+5ac00841 : rev    w1, w2                  : rev    %w2 -> %w1
+dac00c41 : rev    x1, x2                  : rev    %x2 -> %x1
+
+5ac00441 : rev16  w1, w2                  : rev16  %w2 -> %w1
+dac00441 : rev16  x1, x2                  : rev16  %x2 -> %x1
+
+dac00841 : rev32  x1, x2                  : rev32  %x2 -> %x1
+
+139f7fff : ror    wzr, wzr, #31           : extr   %wzr %wzr $0x1f -> %wzr
+1ac32c41 : ror    w1, w2, w3              : rorv   %w2 %w3 -> %w1
+93dfffff : ror    xzr, xzr, #63           : extr   %xzr %xzr $0x3f -> %xzr
+
+2e3360e4 : rsubhn v4.8b, v7.8h, v19.8h              : rsubhn %q7 %q19 $0x00 -> %d4
+2e7360e4 : rsubhn v4.4h, v7.4s, v19.4s              : rsubhn %q7 %q19 $0x01 -> %d4
+2eb360e4 : rsubhn v4.2s, v7.2d, v19.2d              : rsubhn %q7 %q19 $0x02 -> %d4
+
+6e326295 : rsubhn2 v21.16b, v20.8h, v18.8h          : rsubhn2 %q20 %q18 $0x00 -> %q21
+6e726295 : rsubhn2 v21.8h, v20.4s, v18.4s           : rsubhn2 %q20 %q18 $0x01 -> %q21
+6eb26295 : rsubhn2 v21.4s, v20.2d, v18.2d           : rsubhn2 %q20 %q18 $0x02 -> %q21
+
+0e247fdb : saba v27.8b, v30.8b, v4.8b               : saba   %d30 %d4 $0x00 -> %d27
+4e247fdb : saba v27.16b, v30.16b, v4.16b            : saba   %q30 %q4 $0x00 -> %q27
+0e647fdb : saba v27.4h, v30.4h, v4.4h               : saba   %d30 %d4 $0x01 -> %d27
+4e647fdb : saba v27.8h, v30.8h, v4.8h               : saba   %q30 %q4 $0x01 -> %q27
+0ea47fdb : saba v27.2s, v30.2s, v4.2s               : saba   %d30 %d4 $0x02 -> %d27
+4ea47fdb : saba v27.4s, v30.4s, v4.4s               : saba   %q30 %q4 $0x02 -> %q27
+
+0e2b513e : sabal v30.8h, v9.8b, v11.8b              : sabal  %d9 %d11 $0x00 -> %q30
+0e6b513e : sabal v30.4s, v9.4h, v11.4h              : sabal  %d9 %d11 $0x01 -> %q30
+0eab513e : sabal v30.2d, v9.2s, v11.2s              : sabal  %d9 %d11 $0x02 -> %q30
+
+4e31515c : sabal2 v28.8h, v10.16b, v17.16b          : sabal2 %q10 %q17 $0x00 -> %q28
+4e71515c : sabal2 v28.4s, v10.8h, v17.8h            : sabal2 %q10 %q17 $0x01 -> %q28
+4eb1515c : sabal2 v28.2d, v10.4s, v17.4s            : sabal2 %q10 %q17 $0x02 -> %q28
+
+0e3c768f : sabd v15.8b, v20.8b, v28.8b              : sabd   %d20 %d28 $0x00 -> %d15
+4e3c768f : sabd v15.16b, v20.16b, v28.16b           : sabd   %q20 %q28 $0x00 -> %q15
+0e7c768f : sabd v15.4h, v20.4h, v28.4h              : sabd   %d20 %d28 $0x01 -> %d15
+4e7c768f : sabd v15.8h, v20.8h, v28.8h              : sabd   %q20 %q28 $0x01 -> %q15
+0ebc768f : sabd v15.2s, v20.2s, v28.2s              : sabd   %d20 %d28 $0x02 -> %d15
+4ebc768f : sabd v15.4s, v20.4s, v28.4s              : sabd   %q20 %q28 $0x02 -> %q15
+
+0e2f702d : sabdl v13.8h, v1.8b, v15.8b              : sabdl  %d1 %d15 $0x00 -> %q13
+0e6f702d : sabdl v13.4s, v1.4h, v15.4h              : sabdl  %d1 %d15 $0x01 -> %q13
+0eaf702d : sabdl v13.2d, v1.2s, v15.2s              : sabdl  %d1 %d15 $0x02 -> %q13
+
+4e3172ba : sabdl2 v26.8h, v21.16b, v17.16b          : sabdl2 %q21 %q17 $0x00 -> %q26
+4e7172ba : sabdl2 v26.4s, v21.8h, v17.8h            : sabdl2 %q21 %q17 $0x01 -> %q26
+4eb172ba : sabdl2 v26.2d, v21.4s, v17.4s            : sabdl2 %q21 %q17 $0x02 -> %q26
+
+0e3201b2 : saddl v18.8h, v13.8b, v18.8b             : saddl  %d13 %d18 $0x00 -> %q18
+0e7201b2 : saddl v18.4s, v13.4h, v18.4h             : saddl  %d13 %d18 $0x01 -> %q18
+0eb201b2 : saddl v18.2d, v13.2s, v18.2s             : saddl  %d13 %d18 $0x02 -> %q18
+
+4e3a0346 : saddl2 v6.8h, v26.16b, v26.16b           : saddl2 %q26 %q26 $0x00 -> %q6
+4e7a0346 : saddl2 v6.4s, v26.8h, v26.8h             : saddl2 %q26 %q26 $0x01 -> %q6
+4eba0346 : saddl2 v6.2d, v26.4s, v26.4s             : saddl2 %q26 %q26 $0x02 -> %q6
+
+0e3010b4 : saddw v20.8h, v5.8h, v16.8b              : saddw  %q5 %d16 $0x00 -> %q20
+0e7010b4 : saddw v20.4s, v5.4s, v16.4h              : saddw  %q5 %d16 $0x01 -> %q20
+0eb010b4 : saddw v20.2d, v5.2d, v16.2s              : saddw  %q5 %d16 $0x02 -> %q20
+
+4e3e10ea : saddw2 v10.8h, v7.8h, v30.16b            : saddw2 %q7 %q30 $0x00 -> %q10
+4e7e10ea : saddw2 v10.4s, v7.4s, v30.8h             : saddw2 %q7 %q30 $0x01 -> %q10
+4ebe10ea : saddw2 v10.2d, v7.2d, v30.4s             : saddw2 %q7 %q30 $0x02 -> %q10
+
+da030041 : sbc    x1, x2, x3              : sbc    %x2 %x3 -> %x1
+
+7a030041 : sbcs   w1, w2, w3              : sbcs   %w2 %w3 -> %w1
+
+13031041 : sbfx   w1, w2, #3, #2          : sbfm   %w2 $0x03 $0x04 -> %w1
+93431041 : sbfx   x1, x2, #3, #2          : sbfm   %x2 $0x03 $0x04 -> %x1
+
 1e02f105 : scvtf s5, w8, #4                         : scvtf  %w8 $0x04 -> %s5
 9e02c0ed : scvtf s13, x7, #16                       : scvtf  %x7 $0x10 -> %s13
 1e428011 : scvtf d17, w0, #32                       : scvtf  %w0 $0x20 -> %d17
@@ -2358,196 +1978,1056 @@ fd7fffff : ldr    d31, [sp,#32760]        : ldr    +0x7ff8(%sp)[8byte] -> %d31
 0f2be7bc : scvtf v28.2s, v29.2s, #21                : scvtf  %d29 $0x02 $0x15 -> %d28
 0f21e7fe : scvtf v30.2s, v31.2s, #31                : scvtf  %d31 $0x02 $0x1f -> %d30
 
-# SVE bitwise logical operations (predicated)
-04181da2 : orr z2.b, p7/m, z2.b, z13.b              : orr    %p7 %z2 %z13 $0x00 -> %z2
-04581da2 : orr z2.h, p7/m, z2.h, z13.h              : orr    %p7 %z2 %z13 $0x01 -> %z2
-04981da2 : orr z2.s, p7/m, z2.s, z13.s              : orr    %p7 %z2 %z13 $0x02 -> %z2
-04d81da2 : orr z2.d, p7/m, z2.d, z13.d              : orr    %p7 %z2 %z13 $0x03 -> %z2
-0419105d : eor z29.b, p4/m, z29.b, z2.b             : eor    %p4 %z29 %z2 $0x00 -> %z29
-0459105d : eor z29.h, p4/m, z29.h, z2.h             : eor    %p4 %z29 %z2 $0x01 -> %z29
-0499105d : eor z29.s, p4/m, z29.s, z2.s             : eor    %p4 %z29 %z2 $0x02 -> %z29
-04d9105d : eor z29.d, p4/m, z29.d, z2.d             : eor    %p4 %z29 %z2 $0x03 -> %z29
-041a06ff : and z31.b, p1/m, z31.b, z23.b            : and    %p1 %z31 %z23 $0x00 -> %z31
-045a06ff : and z31.h, p1/m, z31.h, z23.h            : and    %p1 %z31 %z23 $0x01 -> %z31
-049a06ff : and z31.s, p1/m, z31.s, z23.s            : and    %p1 %z31 %z23 $0x02 -> %z31
-04da06ff : and z31.d, p1/m, z31.d, z23.d            : and    %p1 %z31 %z23 $0x03 -> %z31
-041b0b02 : bic z2.b, p2/m, z2.b, z24.b              : bic    %p2 %z2 %z24 $0x00 -> %z2
-045b0b02 : bic z2.h, p2/m, z2.h, z24.h              : bic    %p2 %z2 %z24 $0x01 -> %z2
-049b0b02 : bic z2.s, p2/m, z2.s, z24.s              : bic    %p2 %z2 %z24 $0x02 -> %z2
-04db0b02 : bic z2.d, p2/m, z2.d, z24.d              : bic    %p2 %z2 %z24 $0x03 -> %z2
+1ac30c5f : sdiv   wzr, w2, w3             : sdiv   %w2 %w3 -> %wzr
 
-# SVE integer add/subtract vectors (unpredicated)
-043e0362 : add z2.b, z27.b, z30.b                   : add    %z27 %z30 $0x00 -> %z2
-047e0362 : add z2.h, z27.h, z30.h                   : add    %z27 %z30 $0x01 -> %z2
-04be0362 : add z2.s, z27.s, z30.s                   : add    %z27 %z30 $0x02 -> %z2
-04fe0362 : add z2.d, z27.d, z30.d                   : add    %z27 %z30 $0x03 -> %z2
-043d05a0 : sub z0.b, z13.b, z29.b                   : sub    %z13 %z29 $0x00 -> %z0
-047d05a0 : sub z0.h, z13.h, z29.h                   : sub    %z13 %z29 $0x01 -> %z0
-04bd05a0 : sub z0.s, z13.s, z29.s                   : sub    %z13 %z29 $0x02 -> %z0
-04fd05a0 : sub z0.d, z13.d, z29.d                   : sub    %z13 %z29 $0x03 -> %z0
+d503209f : sev                            : sev
+
+d50320bf : sevl                           : sevl
+
+0e3e0762 : shadd v2.8b, v27.8b, v30.8b              : shadd  %d27 %d30 $0x00 -> %d2
+4e3e0762 : shadd v2.16b, v27.16b, v30.16b           : shadd  %q27 %q30 $0x00 -> %q2
+0e7e0762 : shadd v2.4h, v27.4h, v30.4h              : shadd  %d27 %d30 $0x01 -> %d2
+4e7e0762 : shadd v2.8h, v27.8h, v30.8h              : shadd  %q27 %q30 $0x01 -> %q2
+0ebe0762 : shadd v2.2s, v27.2s, v30.2s              : shadd  %d27 %d30 $0x02 -> %d2
+4ebe0762 : shadd v2.4s, v27.4s, v30.4s              : shadd  %q27 %q30 $0x02 -> %q2
+
+0e3427e2 : shsub v2.8b, v31.8b, v20.8b              : shsub  %d31 %d20 $0x00 -> %d2
+4e3427e2 : shsub v2.16b, v31.16b, v20.16b           : shsub  %q31 %q20 $0x00 -> %q2
+0e7427e2 : shsub v2.4h, v31.4h, v20.4h              : shsub  %d31 %d20 $0x01 -> %d2
+4e7427e2 : shsub v2.8h, v31.8h, v20.8h              : shsub  %q31 %q20 $0x01 -> %q2
+0eb427e2 : shsub v2.2s, v31.2s, v20.2s              : shsub  %d31 %d20 $0x02 -> %d2
+4eb427e2 : shsub v2.4s, v31.4s, v20.4s              : shsub  %q31 %q20 $0x02 -> %q2
+
+9b3f1041 : smaddl x1, w2, wzr, x4         : smaddl %w2 %wzr %x4 -> %x1
+
+0e2865e0 : smax v0.8b, v15.8b, v8.8b                : smax   %d15 %d8 $0x00 -> %d0
+4e2865e0 : smax v0.16b, v15.16b, v8.16b             : smax   %q15 %q8 $0x00 -> %q0
+0e6865e0 : smax v0.4h, v15.4h, v8.4h                : smax   %d15 %d8 $0x01 -> %d0
+4e6865e0 : smax v0.8h, v15.8h, v8.8h                : smax   %q15 %q8 $0x01 -> %q0
+0ea865e0 : smax v0.2s, v15.2s, v8.2s                : smax   %d15 %d8 $0x02 -> %d0
+4ea865e0 : smax v0.4s, v15.4s, v8.4s                : smax   %q15 %q8 $0x02 -> %q0
+
+0e27a537 : smaxp v23.8b, v9.8b, v7.8b               : smaxp  %d9 %d7 $0x00 -> %d23
+4e27a537 : smaxp v23.16b, v9.16b, v7.16b            : smaxp  %q9 %q7 $0x00 -> %q23
+0e67a537 : smaxp v23.4h, v9.4h, v7.4h               : smaxp  %d9 %d7 $0x01 -> %d23
+4e67a537 : smaxp v23.8h, v9.8h, v7.8h               : smaxp  %q9 %q7 $0x01 -> %q23
+0ea7a537 : smaxp v23.2s, v9.2s, v7.2s               : smaxp  %d9 %d7 $0x02 -> %d23
+4ea7a537 : smaxp v23.4s, v9.4s, v7.4s               : smaxp  %q9 %q7 $0x02 -> %q23
+
+d4000003 : smc    #0x0                    : smc    $0x0000
+d41fffe3 : smc    #0xffff                 : smc    $0xffff
+
+0e376e6c : smin v12.8b, v19.8b, v23.8b              : smin   %d19 %d23 $0x00 -> %d12
+4e376e6c : smin v12.16b, v19.16b, v23.16b           : smin   %q19 %q23 $0x00 -> %q12
+0e776e6c : smin v12.4h, v19.4h, v23.4h              : smin   %d19 %d23 $0x01 -> %d12
+4e776e6c : smin v12.8h, v19.8h, v23.8h              : smin   %q19 %q23 $0x01 -> %q12
+0eb76e6c : smin v12.2s, v19.2s, v23.2s              : smin   %d19 %d23 $0x02 -> %d12
+4eb76e6c : smin v12.4s, v19.4s, v23.4s              : smin   %q19 %q23 $0x02 -> %q12
+
+0e2aaf86 : sminp v6.8b, v28.8b, v10.8b              : sminp  %d28 %d10 $0x00 -> %d6
+4e2aaf86 : sminp v6.16b, v28.16b, v10.16b           : sminp  %q28 %q10 $0x00 -> %q6
+0e6aaf86 : sminp v6.4h, v28.4h, v10.4h              : sminp  %d28 %d10 $0x01 -> %d6
+4e6aaf86 : sminp v6.8h, v28.8h, v10.8h              : sminp  %q28 %q10 $0x01 -> %q6
+0eaaaf86 : sminp v6.2s, v28.2s, v10.2s              : sminp  %d28 %d10 $0x02 -> %d6
+4eaaaf86 : sminp v6.4s, v28.4s, v10.4s              : sminp  %q28 %q10 $0x02 -> %q6
+
+0e32809b : smlal v27.8h, v4.8b, v18.8b              : smlal  %d4 %d18 $0x00 -> %q27
+0e72809b : smlal v27.4s, v4.4h, v18.4h              : smlal  %d4 %d18 $0x01 -> %q27
+0eb2809b : smlal v27.2d, v4.2s, v18.2s              : smlal  %d4 %d18 $0x02 -> %q27
+
+4e23826b : smlal2 v11.8h, v19.16b, v3.16b           : smlal2 %q19 %q3 $0x00 -> %q11
+4e63826b : smlal2 v11.4s, v19.8h, v3.8h             : smlal2 %q19 %q3 $0x01 -> %q11
+4ea3826b : smlal2 v11.2d, v19.4s, v3.4s             : smlal2 %q19 %q3 $0x02 -> %q11
+
+0e28a0ed : smlsl v13.8h, v7.8b, v8.8b               : smlsl  %d7 %d8 $0x00 -> %q13
+0e68a0ed : smlsl v13.4s, v7.4h, v8.4h               : smlsl  %d7 %d8 $0x01 -> %q13
+0ea8a0ed : smlsl v13.2d, v7.2s, v8.2s               : smlsl  %d7 %d8 $0x02 -> %q13
+
+4e23a0b3 : smlsl2 v19.8h, v5.16b, v3.16b            : smlsl2 %q5 %q3 $0x00 -> %q19
+4e63a0b3 : smlsl2 v19.4s, v5.8h, v3.8h              : smlsl2 %q5 %q3 $0x01 -> %q19
+4ea3a0b3 : smlsl2 v19.2d, v5.4s, v3.4s              : smlsl2 %q5 %q3 $0x02 -> %q19
+
+9b23fc41 : smnegl x1, w2, w3              : smsubl %w2 %w3 %xzr -> %x1
+
+9b4313e1 : smulh  x1, xzr, x3             : smulh  %xzr %x3 $0x04 -> %x1
+
+0e20c1ab : smull v11.8h, v13.8b, v0.8b              : smull  %d13 %d0 $0x00 -> %q11
+0e60c1ab : smull v11.4s, v13.4h, v0.4h              : smull  %d13 %d0 $0x01 -> %q11
+0ea0c1ab : smull v11.2d, v13.2s, v0.2s              : smull  %d13 %d0 $0x02 -> %q11
+
+4e2ac156 : smull2 v22.8h, v10.16b, v10.16b          : smull2 %q10 %q10 $0x00 -> %q22
+4e6ac156 : smull2 v22.4s, v10.8h, v10.8h            : smull2 %q10 %q10 $0x01 -> %q22
+4eaac156 : smull2 v22.2d, v10.4s, v10.4s            : smull2 %q10 %q10 $0x02 -> %q22
+
+0e3d0da0 : sqadd v0.8b, v13.8b, v29.8b              : sqadd  %d13 %d29 $0x00 -> %d0
+4e3d0da0 : sqadd v0.16b, v13.16b, v29.16b           : sqadd  %q13 %q29 $0x00 -> %q0
+0e7d0da0 : sqadd v0.4h, v13.4h, v29.4h              : sqadd  %d13 %d29 $0x01 -> %d0
+4e7d0da0 : sqadd v0.8h, v13.8h, v29.8h              : sqadd  %q13 %q29 $0x01 -> %q0
+0ebd0da0 : sqadd v0.2s, v13.2s, v29.2s              : sqadd  %d13 %d29 $0x02 -> %d0
+4ebd0da0 : sqadd v0.4s, v13.4s, v29.4s              : sqadd  %q13 %q29 $0x02 -> %q0
+4efd0da0 : sqadd v0.2d, v13.2d, v29.2d              : sqadd  %q13 %q29 $0x03 -> %q0
 042a123f : sqadd z31.b, z17.b, z10.b                : sqadd  %z17 %z10 $0x00 -> %z31
 046a123f : sqadd z31.h, z17.h, z10.h                : sqadd  %z17 %z10 $0x01 -> %z31
 04aa123f : sqadd z31.s, z17.s, z10.s                : sqadd  %z17 %z10 $0x02 -> %z31
 04ea123f : sqadd z31.d, z17.d, z10.d                : sqadd  %z17 %z10 $0x03 -> %z31
-043417e2 : uqadd z2.b, z31.b, z20.b                 : uqadd  %z31 %z20 $0x00 -> %z2
-047417e2 : uqadd z2.h, z31.h, z20.h                 : uqadd  %z31 %z20 $0x01 -> %z2
-04b417e2 : uqadd z2.s, z31.s, z20.s                 : uqadd  %z31 %z20 $0x02 -> %z2
-04f417e2 : uqadd z2.d, z31.d, z20.d                 : uqadd  %z31 %z20 $0x03 -> %z2
+
+0e659078 : sqdmlal v24.4s, v3.4h, v5.4h             : sqdmlal %d3 %d5 $0x01 -> %q24
+0ea59078 : sqdmlal v24.2d, v3.2s, v5.2s             : sqdmlal %d3 %d5 $0x02 -> %q24
+
+4e6d93d9 : sqdmlal2 v25.4s, v30.8h, v13.8h          : sqdmlal2 %q30 %q13 $0x01 -> %q25
+4ead93d9 : sqdmlal2 v25.2d, v30.4s, v13.4s          : sqdmlal2 %q30 %q13 $0x02 -> %q25
+
+0e74b0ae : sqdmlsl v14.4s, v5.4h, v20.4h            : sqdmlsl %d5 %d20 $0x01 -> %q14
+0eb4b0ae : sqdmlsl v14.2d, v5.2s, v20.2s            : sqdmlsl %d5 %d20 $0x02 -> %q14
+
+4e6fb31a : sqdmlsl2 v26.4s, v24.8h, v15.8h          : sqdmlsl2 %q24 %q15 $0x01 -> %q26
+4eafb31a : sqdmlsl2 v26.2d, v24.4s, v15.4s          : sqdmlsl2 %q24 %q15 $0x02 -> %q26
+
+0e7bb6cc : sqdmulh v12.4h, v22.4h, v27.4h           : sqdmulh %d22 %d27 $0x01 -> %d12
+4e7bb6cc : sqdmulh v12.8h, v22.8h, v27.8h           : sqdmulh %q22 %q27 $0x01 -> %q12
+0ebbb6cc : sqdmulh v12.2s, v22.2s, v27.2s           : sqdmulh %d22 %d27 $0x02 -> %d12
+4ebbb6cc : sqdmulh v12.4s, v22.4s, v27.4s           : sqdmulh %q22 %q27 $0x02 -> %q12
+
+0e72d1c2 : sqdmull v2.4s, v14.4h, v18.4h            : sqdmull %d14 %d18 $0x01 -> %q2
+0eb2d1c2 : sqdmull v2.2d, v14.2s, v18.2s            : sqdmull %d14 %d18 $0x02 -> %q2
+
+4e75d36c : sqdmull2 v12.4s, v27.8h, v21.8h          : sqdmull2 %q27 %q21 $0x01 -> %q12
+4eb5d36c : sqdmull2 v12.2d, v27.4s, v21.4s          : sqdmull2 %q27 %q21 $0x02 -> %q12
+
+2e7bb7b7 : sqrdmulh v23.4h, v29.4h, v27.4h          : sqrdmulh %d29 %d27 $0x01 -> %d23
+6e7bb7b7 : sqrdmulh v23.8h, v29.8h, v27.8h          : sqrdmulh %q29 %q27 $0x01 -> %q23
+2ebbb7b7 : sqrdmulh v23.2s, v29.2s, v27.2s          : sqrdmulh %d29 %d27 $0x02 -> %d23
+6ebbb7b7 : sqrdmulh v23.4s, v29.4s, v27.4s          : sqrdmulh %q29 %q27 $0x02 -> %q23
+
+0e225f1c : sqrshl v28.8b, v24.8b, v2.8b             : sqrshl %d24 %d2 $0x00 -> %d28
+4e225f1c : sqrshl v28.16b, v24.16b, v2.16b          : sqrshl %q24 %q2 $0x00 -> %q28
+0e625f1c : sqrshl v28.4h, v24.4h, v2.4h             : sqrshl %d24 %d2 $0x01 -> %d28
+4e625f1c : sqrshl v28.8h, v24.8h, v2.8h             : sqrshl %q24 %q2 $0x01 -> %q28
+0ea25f1c : sqrshl v28.2s, v24.2s, v2.2s             : sqrshl %d24 %d2 $0x02 -> %d28
+4ea25f1c : sqrshl v28.4s, v24.4s, v2.4s             : sqrshl %q24 %q2 $0x02 -> %q28
+4ee25f1c : sqrshl v28.2d, v24.2d, v2.2d             : sqrshl %q24 %q2 $0x03 -> %q28
+
+0e374e6b : sqshl v11.8b, v19.8b, v23.8b             : sqshl  %d19 %d23 $0x00 -> %d11
+4e374e6b : sqshl v11.16b, v19.16b, v23.16b          : sqshl  %q19 %q23 $0x00 -> %q11
+0e774e6b : sqshl v11.4h, v19.4h, v23.4h             : sqshl  %d19 %d23 $0x01 -> %d11
+4e774e6b : sqshl v11.8h, v19.8h, v23.8h             : sqshl  %q19 %q23 $0x01 -> %q11
+0eb74e6b : sqshl v11.2s, v19.2s, v23.2s             : sqshl  %d19 %d23 $0x02 -> %d11
+4eb74e6b : sqshl v11.4s, v19.4s, v23.4s             : sqshl  %q19 %q23 $0x02 -> %q11
+4ef74e6b : sqshl v11.2d, v19.2d, v23.2d             : sqshl  %q19 %q23 $0x03 -> %q11
+
+0e372de4 : sqsub v4.8b, v15.8b, v23.8b              : sqsub  %d15 %d23 $0x00 -> %d4
+4e372de4 : sqsub v4.16b, v15.16b, v23.16b           : sqsub  %q15 %q23 $0x00 -> %q4
+0e772de4 : sqsub v4.4h, v15.4h, v23.4h              : sqsub  %d15 %d23 $0x01 -> %d4
+4e772de4 : sqsub v4.8h, v15.8h, v23.8h              : sqsub  %q15 %q23 $0x01 -> %q4
+0eb72de4 : sqsub v4.2s, v15.2s, v23.2s              : sqsub  %d15 %d23 $0x02 -> %d4
+4eb72de4 : sqsub v4.4s, v15.4s, v23.4s              : sqsub  %q15 %q23 $0x02 -> %q4
+4ef72de4 : sqsub v4.2d, v15.2d, v23.2d              : sqsub  %q15 %q23 $0x03 -> %q4
 043719e4 : sqsub z4.b, z15.b, z23.b                 : sqsub  %z15 %z23 $0x00 -> %z4
 047719e4 : sqsub z4.h, z15.h, z23.h                 : sqsub  %z15 %z23 $0x01 -> %z4
 04b719e4 : sqsub z4.s, z15.s, z23.s                 : sqsub  %z15 %z23 $0x02 -> %z4
 04f719e4 : sqsub z4.d, z15.d, z23.d                 : sqsub  %z15 %z23 $0x03 -> %z4
+
+0e2a163f : srhadd v31.8b, v17.8b, v10.8b            : srhadd %d17 %d10 $0x00 -> %d31
+4e2a163f : srhadd v31.16b, v17.16b, v10.16b         : srhadd %q17 %q10 $0x00 -> %q31
+0e6a163f : srhadd v31.4h, v17.4h, v10.4h            : srhadd %d17 %d10 $0x01 -> %d31
+4e6a163f : srhadd v31.8h, v17.8h, v10.8h            : srhadd %q17 %q10 $0x01 -> %q31
+0eaa163f : srhadd v31.2s, v17.2s, v10.2s            : srhadd %d17 %d10 $0x02 -> %d31
+4eaa163f : srhadd v31.4s, v17.4s, v10.4s            : srhadd %q17 %q10 $0x02 -> %q31
+
+0e2f57a8 : srshl v8.8b, v29.8b, v15.8b              : srshl  %d29 %d15 $0x00 -> %d8
+4e2f57a8 : srshl v8.16b, v29.16b, v15.16b           : srshl  %q29 %q15 $0x00 -> %q8
+0e6f57a8 : srshl v8.4h, v29.4h, v15.4h              : srshl  %d29 %d15 $0x01 -> %d8
+4e6f57a8 : srshl v8.8h, v29.8h, v15.8h              : srshl  %q29 %q15 $0x01 -> %q8
+0eaf57a8 : srshl v8.2s, v29.2s, v15.2s              : srshl  %d29 %d15 $0x02 -> %d8
+4eaf57a8 : srshl v8.4s, v29.4s, v15.4s              : srshl  %q29 %q15 $0x02 -> %q8
+4eef57a8 : srshl v8.2d, v29.2d, v15.2d              : srshl  %q29 %q15 $0x03 -> %q8
+
+0e3d4612 : sshl v18.8b, v16.8b, v29.8b              : sshl   %d16 %d29 $0x00 -> %d18
+4e3d4612 : sshl v18.16b, v16.16b, v29.16b           : sshl   %q16 %q29 $0x00 -> %q18
+0e7d4612 : sshl v18.4h, v16.4h, v29.4h              : sshl   %d16 %d29 $0x01 -> %d18
+4e7d4612 : sshl v18.8h, v16.8h, v29.8h              : sshl   %q16 %q29 $0x01 -> %q18
+0ebd4612 : sshl v18.2s, v16.2s, v29.2s              : sshl   %d16 %d29 $0x02 -> %d18
+4ebd4612 : sshl v18.4s, v16.4s, v29.4s              : sshl   %q16 %q29 $0x02 -> %q18
+4efd4612 : sshl v18.2d, v16.2d, v29.2d              : sshl   %q16 %q29 $0x03 -> %q18
+
+0e3b203f : ssubl v31.8h, v1.8b, v27.8b              : ssubl  %d1 %d27 $0x00 -> %q31
+0e7b203f : ssubl v31.4s, v1.4h, v27.4h              : ssubl  %d1 %d27 $0x01 -> %q31
+0ebb203f : ssubl v31.2d, v1.2s, v27.2s              : ssubl  %d1 %d27 $0x02 -> %q31
+
+4e292193 : ssubl2 v19.8h, v12.16b, v9.16b           : ssubl2 %q12 %q9 $0x00 -> %q19
+4e692193 : ssubl2 v19.4s, v12.8h, v9.8h             : ssubl2 %q12 %q9 $0x01 -> %q19
+4ea92193 : ssubl2 v19.2d, v12.4s, v9.4s             : ssubl2 %q12 %q9 $0x02 -> %q19
+
+0e3531d5 : ssubw v21.8h, v14.8h, v21.8b             : ssubw  %q14 %d21 $0x00 -> %q21
+0e7531d5 : ssubw v21.4s, v14.4s, v21.4h             : ssubw  %q14 %d21 $0x01 -> %q21
+0eb531d5 : ssubw v21.2d, v14.2d, v21.2s             : ssubw  %q14 %d21 $0x02 -> %q21
+
+4e383095 : ssubw2 v21.8h, v4.8h, v24.16b            : ssubw2 %q4 %q24 $0x00 -> %q21
+4e783095 : ssubw2 v21.4s, v4.4s, v24.8h             : ssubw2 %q4 %q24 $0x01 -> %q21
+4eb83095 : ssubw2 v21.2d, v4.2d, v24.4s             : ssubw2 %q4 %q24 $0x02 -> %q21
+
+0c0067ff : st1    {v31.4h, v0.4h, v1.4h}, [sp]: st1    $0x01 %d31 %d0 %d1 -> (%sp)[24byte]
+0c0077ff : st1    {v31.4h}, [sp]          : st1    %d31 $0x01 -> (%sp)[8byte]
+0c00a7ff : st1    {v31.4h, v0.4h}, [sp]   : st1    $0x01 %d31 %d0 -> (%sp)[16byte]
+0c9f27ff : st1    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp], #32: st1    $0x01 %d31 %d0 %d1 %d2 %sp $0x20 -> (%sp)[32byte] %sp
+4c0027ff : st1    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp]: st1    $0x01 %q31 %q0 %q1 %q2 -> (%sp)[64byte]
+4c9f67ff : st1    {v31.8h, v0.8h, v1.8h}, [sp], #48: st1    $0x01 %q31 %q0 %q1 %sp $0x30 -> (%sp)[48byte] %sp
+4c9f77ff : st1    {v31.8h}, [sp], #16     : st1    $0x01 %q31 %sp $0x10 -> (%sp)[16byte] %sp
+4c9fa7ff : st1    {v31.8h, v0.8h}, [sp], #32: st1    $0x01 %q31 %q0 %sp $0x20 -> (%sp)[32byte] %sp
+4d001fff : st1    {v31.b}[15], [sp]       : st1    %q31 $0x0f -> (%sp)[1byte]
+4d005bff : st1    {v31.h}[7], [sp]        : st1    %q31 $0x07 -> (%sp)[2byte]
+4d0087ff : st1    {v31.d}[1], [sp]        : st1    %q31 $0x01 -> (%sp)[8byte]
+4d0093ff : st1    {v31.s}[3], [sp]        : st1    %q31 $0x03 -> (%sp)[4byte]
+4d9f1fff : st1    {v31.b}[15], [sp], #1   : st1    %q31 $0x0f %sp $0x01 -> (%sp)[1byte] %sp
+4d9f5bff : st1    {v31.h}[7], [sp], #2    : st1    %q31 $0x07 %sp $0x02 -> (%sp)[2byte] %sp
+4d9f87ff : st1    {v31.d}[1], [sp], #8    : st1    %q31 $0x01 %sp $0x08 -> (%sp)[8byte] %sp
+4d9f93ff : st1    {v31.s}[3], [sp], #4    : st1    %q31 $0x03 %sp $0x04 -> (%sp)[4byte] %sp
+
+0c9f87ff : st2    {v31.4h, v0.4h}, [sp], #16: st2    $0x01 %d31 %d0 %sp $0x10 -> (%sp)[16byte] %sp
+4c0087ff : st2    {v31.8h, v0.8h}, [sp]   : st2    $0x01 %q31 %q0 -> (%sp)[32byte]
+4d201fff : st2    {v31.b, v0.b}[15], [sp] : st2    %q31 %q0 $0x0f -> (%sp)[2byte]
+4d205bff : st2    {v31.h, v0.h}[7], [sp]  : st2    %q31 %q0 $0x07 -> (%sp)[4byte]
+4d2087ff : st2    {v31.d, v0.d}[1], [sp]  : st2    %q31 %q0 $0x01 -> (%sp)[16byte]
+4d2093ff : st2    {v31.s, v0.s}[3], [sp]  : st2    %q31 %q0 $0x03 -> (%sp)[8byte]
+4dbf1fff : st2    {v31.b, v0.b}[15], [sp], #2: st2    %q31 %q0 $0x0f %sp $0x02 -> (%sp)[2byte] %sp
+4dbf5bff : st2    {v31.h, v0.h}[7], [sp], #4: st2    %q31 %q0 $0x07 %sp $0x04 -> (%sp)[4byte] %sp
+4dbf87ff : st2    {v31.d, v0.d}[1], [sp], #16: st2    %q31 %q0 $0x01 %sp $0x10 -> (%sp)[16byte] %sp
+4dbf93ff : st2    {v31.s, v0.s}[3], [sp], #8: st2    %q31 %q0 $0x03 %sp $0x08 -> (%sp)[8byte] %sp
+
+0c9f47ff : st3    {v31.4h, v0.4h, v1.4h}, [sp], #24: st3    $0x01 %d31 %d0 %d1 %sp $0x18 -> (%sp)[24byte] %sp
+4c0047ff : st3    {v31.8h, v0.8h, v1.8h}, [sp]: st3    $0x01 %q31 %q0 %q1 -> (%sp)[48byte]
+4d003fff : st3    {v31.b, v0.b, v1.b}[15], [sp]: st3    %q31 %q0 %q1 $0x0f -> (%sp)[3byte]
+4d007bff : st3    {v31.h, v0.h, v1.h}[7], [sp]: st3    %q31 %q0 %q1 $0x07 -> (%sp)[6byte]
+4d00a7ff : st3    {v31.d, v0.d, v1.d}[1], [sp]: st3    %q31 %q0 %q1 $0x01 -> (%sp)[24byte]
+4d00b3ff : st3    {v31.s, v0.s, v1.s}[3], [sp]: st3    %q31 %q0 %q1 $0x03 -> (%sp)[12byte]
+4d9f3fff : st3    {v31.b, v0.b, v1.b}[15], [sp], #3: st3    %q31 %q0 %q1 $0x0f %sp $0x03 -> (%sp)[3byte] %sp
+4d9f7bff : st3    {v31.h, v0.h, v1.h}[7], [sp], #6: st3    %q31 %q0 %q1 $0x07 %sp $0x06 -> (%sp)[6byte] %sp
+4d9fa7ff : st3    {v31.d, v0.d, v1.d}[1], [sp], #24: st3    %q31 %q0 %q1 $0x01 %sp $0x18 -> (%sp)[24byte] %sp
+4d9fb3ff : st3    {v31.s, v0.s, v1.s}[3], [sp], #12: st3    %q31 %q0 %q1 $0x03 %sp $0x0c -> (%sp)[12byte] %sp
+
+0c0007ff : st4    {v31.4h, v0.4h, v1.4h, v2.4h}, [sp]: st4    $0x01 %d31 %d0 %d1 %d2 -> (%sp)[32byte]
+4c800000 : st4    {v0.16b-v3.16b}, [x0], x0: st4    $0x00 %q0 %q1 %q2 %q3 %x0 %x0 -> (%x0)[64byte] %x0
+4c9f07ff : st4    {v31.8h, v0.8h, v1.8h, v2.8h}, [sp], #64: st4    $0x01 %q31 %q0 %q1 %q2 %sp $0x40 -> (%sp)[64byte] %sp
+4d203fff : st4    {v31.b, v0.b, v1.b, v2.b}[15], [sp]: st4    %q31 %q0 %q1 %q2 $0x0f -> (%sp)[4byte]
+4d207bff : st4    {v31.h, v0.h, v1.h, v2.h}[7], [sp]: st4    %q31 %q0 %q1 %q2 $0x07 -> (%sp)[8byte]
+4d20a7ff : st4    {v31.d, v0.d, v1.d, v2.d}[1], [sp]: st4    %q31 %q0 %q1 %q2 $0x01 -> (%sp)[32byte]
+4d20b3ff : st4    {v31.s, v0.s, v1.s, v2.s}[3], [sp]: st4    %q31 %q0 %q1 %q2 $0x03 -> (%sp)[16byte]
+4dbf3fff : st4    {v31.b, v0.b, v1.b, v2.b}[15], [sp], #4: st4    %q31 %q0 %q1 %q2 $0x0f %sp $0x04 -> (%sp)[4byte] %sp
+4dbf7bff : st4    {v31.h, v0.h, v1.h, v2.h}[7], [sp], #8: st4    %q31 %q0 %q1 %q2 $0x07 %sp $0x08 -> (%sp)[8byte] %sp
+4dbfa7ff : st4    {v31.d, v0.d, v1.d, v2.d}[1], [sp], #32: st4    %q31 %q0 %q1 %q2 $0x01 %sp $0x20 -> (%sp)[32byte] %sp
+4dbfb3ff : st4    {v31.s, v0.s, v1.s, v2.s}[3], [sp], #16: st4    %q31 %q0 %q1 %q2 $0x03 %sp $0x10 -> (%sp)[16byte] %sp
+
+b83f03ff : stadd  wzr, [sp]               : ldadd  %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f83f03ff : stadd  xzr, [sp]               : ldadd  %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+383f03ff : staddb wzr, [sp]               : ldaddb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+783f03ff : staddh wzr, [sp]               : ldaddh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b87f03ff : staddl wzr, [sp]               : ldaddl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f87f03ff : staddl xzr, [sp]               : ldaddl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+387f03ff : staddlb wzr, [sp]              : ldaddlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+787f03ff : staddlh wzr, [sp]              : ldaddlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b83f13ff : stclr  wzr, [sp]               : ldclr  %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f83f13ff : stclr  xzr, [sp]               : ldclr  %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+383f13ff : stclrb wzr, [sp]               : ldclrb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+783f13ff : stclrh wzr, [sp]               : ldclrh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b87f13ff : stclrl wzr, [sp]               : ldclrl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f87f13ff : stclrl xzr, [sp]               : ldclrl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+387f13ff : stclrlb wzr, [sp]              : ldclrlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+787f13ff : stclrlh wzr, [sp]              : ldclrlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b83f23ff : steor  wzr, [sp]               : ldeor  %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f83f23ff : steor  xzr, [sp]               : ldeor  %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+383f23ff : steorb wzr, [sp]               : ldeorb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+783f23ff : steorh wzr, [sp]               : ldeorh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b87f23ff : steorl wzr, [sp]               : ldeorl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f87f23ff : steorl xzr, [sp]               : ldeorl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+387f23ff : steorlb wzr, [sp]              : ldeorlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+787f23ff : steorlh wzr, [sp]              : ldeorlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+88889041 : stlr   w1, [x2]                : stlr   %w1 $0x04 $0x08 -> (%x2)[4byte]
+889fffff : stlr   wzr, [sp]               : stlr   %wzr $0x1f $0x1f -> (%sp)[4byte]
+c8889041 : stlr   x1, [x2]                : stlr   %x1 $0x04 $0x08 -> (%x2)[8byte]
+c89fffff : stlr   xzr, [sp]               : stlr   %xzr $0x1f $0x1f -> (%sp)[8byte]
+
+08889041 : stlrb  w1, [x2]                : stlrb  %w1 $0x04 $0x08 -> (%x2)[1byte]
+089fffff : stlrb  wzr, [sp]               : stlrb  %wzr $0x1f $0x1f -> (%sp)[1byte]
+
+48889041 : stlrh  w1, [x2]                : stlrh  %w1 $0x04 $0x08 -> (%x2)[2byte]
+489fffff : stlrh  wzr, [sp]               : stlrh  %wzr $0x1f $0x1f -> (%sp)[2byte]
+
+88289041 : stlxp  w8, w1, w4, [x2]        : stlxp  %w1 %w4 -> (%x2)[8byte] %w8
+883fffff : stlxp  wzr, wzr, wzr, [sp]     : stlxp  %wzr %wzr -> (%sp)[8byte] %wzr
+c8289041 : stlxp  w8, x1, x4, [x2]        : stlxp  %x1 %x4 -> (%x2)[16byte] %w8
+c83fffff : stlxp  wzr, xzr, xzr, [sp]     : stlxp  %xzr %xzr -> (%sp)[16byte] %wzr
+
+88089041 : stlxr  w8, w1, [x2]            : stlxr  %w1 $0x04 -> (%x2)[4byte] %w8
+881fffff : stlxr  wzr, wzr, [sp]          : stlxr  %wzr $0x1f -> (%sp)[4byte] %wzr
+c8089041 : stlxr  w8, x1, [x2]            : stlxr  %x1 $0x04 -> (%x2)[8byte] %w8
+c81fffff : stlxr  wzr, xzr, [sp]          : stlxr  %xzr $0x1f -> (%sp)[8byte] %wzr
+
+08089041 : stlxrb w8, w1, [x2]            : stlxrb %w1 $0x04 -> (%x2)[1byte] %w8
+081fffff : stlxrb wzr, wzr, [sp]          : stlxrb %wzr $0x1f -> (%sp)[1byte] %wzr
+
+48089041 : stlxrh w8, w1, [x2]            : stlxrh %w1 $0x04 -> (%x2)[2byte] %w8
+481fffff : stlxrh wzr, wzr, [sp]          : stlxrh %wzr $0x1f -> (%sp)[2byte] %wzr
+
+28000000 : stnp   w0, w0, [x0]            : stnp   %w0 %w0 -> (%x0)[8byte]
+283fffff : stnp   wzr, wzr, [sp,#-4]      : stnp   %wzr %wzr -> -0x04(%sp)[8byte]
+2c000000 : stnp   s0, s0, [x0]            : stnp   %s0 %s0 -> (%x0)[8byte]
+2c3fffff : stnp   s31, s31, [sp,#-4]      : stnp   %s31 %s31 -> -0x04(%sp)[8byte]
+6c000000 : stnp   d0, d0, [x0]            : stnp   %d0 %d0 -> (%x0)[16byte]
+6c3fffff : stnp   d31, d31, [sp,#-8]      : stnp   %d31 %d31 -> -0x08(%sp)[16byte]
+a8000000 : stnp   x0, x0, [x0]            : stnp   %x0 %x0 -> (%x0)[16byte]
+a83fffff : stnp   xzr, xzr, [sp,#-8]      : stnp   %xzr %xzr -> -0x08(%sp)[16byte]
+ac000000 : stnp   q0, q0, [x0]            : stnp   %q0 %q0 -> (%x0)[32byte]
+ac3fffff : stnp   q31, q31, [sp,#-16]     : stnp   %q31 %q31 -> -0x10(%sp)[32byte]
+
+28800000 : stp    w0, w0, [x0],#0         : stp    %w0 %w0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
+28bfffff : stp    wzr, wzr, [sp],#-4      : stp    %wzr %wzr %sp $0xfffffffffffffffc -> (%sp)[8byte] %sp
+29000000 : stp    w0, w0, [x0]            : stp    %w0 %w0 -> (%x0)[8byte]
+293fffff : stp    wzr, wzr, [sp,#-4]      : stp    %wzr %wzr -> -0x04(%sp)[8byte]
+29800000 : stp    w0, w0, [x0,#0]!        : stp    %w0 %w0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
+29bfffff : stp    wzr, wzr, [sp,#-4]!     : stp    %wzr %wzr %sp $0xfffffffffffffffc -> -0x04(%sp)[8byte] %sp
+2c800000 : stp    s0, s0, [x0],#0         : stp    %s0 %s0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
+2cbfffff : stp    s31, s31, [sp],#-4      : stp    %s31 %s31 %sp $0xfffffffffffffffc -> (%sp)[8byte] %sp
+2d000000 : stp    s0, s0, [x0]            : stp    %s0 %s0 -> (%x0)[8byte]
+2d3fffff : stp    s31, s31, [sp,#-4]      : stp    %s31 %s31 -> -0x04(%sp)[8byte]
+2d800000 : stp    s0, s0, [x0,#0]!        : stp    %s0 %s0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
+2dbfffff : stp    s31, s31, [sp,#-4]!     : stp    %s31 %s31 %sp $0xfffffffffffffffc -> -0x04(%sp)[8byte] %sp
+6c800000 : stp    d0, d0, [x0],#0         : stp    %d0 %d0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
+6cbfffff : stp    d31, d31, [sp],#-8      : stp    %d31 %d31 %sp $0xfffffffffffffff8 -> (%sp)[16byte] %sp
+6d000000 : stp    d0, d0, [x0]            : stp    %d0 %d0 -> (%x0)[16byte]
+6d3fffff : stp    d31, d31, [sp,#-8]      : stp    %d31 %d31 -> -0x08(%sp)[16byte]
+6d800000 : stp    d0, d0, [x0,#0]!        : stp    %d0 %d0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
+6dbfffff : stp    d31, d31, [sp,#-8]!     : stp    %d31 %d31 %sp $0xfffffffffffffff8 -> -0x08(%sp)[16byte] %sp
+a8800000 : stp    x0, x0, [x0],#0         : stp    %x0 %x0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
+a8bfffff : stp    xzr, xzr, [sp],#-8      : stp    %xzr %xzr %sp $0xfffffffffffffff8 -> (%sp)[16byte] %sp
+a9000000 : stp    x0, x0, [x0]            : stp    %x0 %x0 -> (%x0)[16byte]
+a93fffff : stp    xzr, xzr, [sp,#-8]      : stp    %xzr %xzr -> -0x08(%sp)[16byte]
+a9800000 : stp    x0, x0, [x0,#0]!        : stp    %x0 %x0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
+a9bfffff : stp    xzr, xzr, [sp,#-8]!     : stp    %xzr %xzr %sp $0xfffffffffffffff8 -> -0x08(%sp)[16byte] %sp
+ac800000 : stp    q0, q0, [x0],#0         : stp    %q0 %q0 %x0 $0x0000000000000000 -> (%x0)[32byte] %x0
+acbfffff : stp    q31, q31, [sp],#-16     : stp    %q31 %q31 %sp $0xfffffffffffffff0 -> (%sp)[32byte] %sp
+ad000000 : stp    q0, q0, [x0]            : stp    %q0 %q0 -> (%x0)[32byte]
+ad3fffff : stp    q31, q31, [sp,#-16]     : stp    %q31 %q31 -> -0x10(%sp)[32byte]
+ad800000 : stp    q0, q0, [x0,#0]!        : stp    %q0 %q0 %x0 $0x0000000000000000 -> (%x0)[32byte] %x0
+adbfffff : stp    q31, q31, [sp,#-16]!    : stp    %q31 %q31 %sp $0xfffffffffffffff0 -> -0x10(%sp)[32byte] %sp
+
+3c000400 : str    b0, [x0],#0             : str    %b0 %x0 $0x0000000000000000 -> (%x0)[1byte] %x0
+3c000c00 : str    b0, [x0,#0]!            : str    %b0 %x0 $0x0000000000000000 -> (%x0)[1byte] %x0
+3c081441 : str    b1, [x2],#129           : str    %b1 %x2 $0x0000000000000081 -> (%x2)[1byte] %x2
+3c081c41 : str    b1, [x2,#129]!          : str    %b1 %x2 $0x0000000000000081 -> +0x81(%x2)[1byte] %x2
+3c1ff7ff : str    b31, [sp],#-1           : str    %b31 %sp $0xffffffffffffffff -> (%sp)[1byte] %sp
+3c1fffff : str    b31, [sp,#-1]!          : str    %b31 %sp $0xffffffffffffffff -> -0x01(%sp)[1byte] %sp
+3c234841 : str    b1, [x2,w3,uxtw]        : str    %b1 -> (%x2,%x3,uxtw)[1byte]
+3c235841 : str    b1, [x2,w3,uxtw #0]     : str    %b1 -> (%x2,%x3,uxtw #0)[1byte]
+3c236841 : str    b1, [x2,x3]             : str    %b1 -> (%x2,%x3)[1byte]
+3c237841 : str    b1, [x2,x3,lsl #0]      : str    %b1 -> (%x2,%x3,uxtx #0)[1byte]
+3c23c841 : str    b1, [x2,w3,sxtw]        : str    %b1 -> (%x2,%x3,sxtw)[1byte]
+3c23d841 : str    b1, [x2,w3,sxtw #0]     : str    %b1 -> (%x2,%x3,sxtw #0)[1byte]
+3c23e841 : str    b1, [x2,x3,sxtx]        : str    %b1 -> (%x2,%x3,sxtx)[1byte]
+3c23f841 : str    b1, [x2,x3,sxtx #0]     : str    %b1 -> (%x2,%x3,sxtx #0)[1byte]
+3c3f4bff : str    b31, [sp,wzr,uxtw]      : str    %b31 -> (%sp,%xzr,uxtw)[1byte]
+3c3f5bff : str    b31, [sp,wzr,uxtw #0]   : str    %b31 -> (%sp,%xzr,uxtw #0)[1byte]
+3c3f6bff : str    b31, [sp,xzr]           : str    %b31 -> (%sp,%xzr)[1byte]
+3c3f7bff : str    b31, [sp,xzr,lsl #0]    : str    %b31 -> (%sp,%xzr,uxtx #0)[1byte]
+3c3fcbff : str    b31, [sp,wzr,sxtw]      : str    %b31 -> (%sp,%xzr,sxtw)[1byte]
+3c3fdbff : str    b31, [sp,wzr,sxtw #0]   : str    %b31 -> (%sp,%xzr,sxtw #0)[1byte]
+3c3febff : str    b31, [sp,xzr,sxtx]      : str    %b31 -> (%sp,%xzr,sxtx)[1byte]
+3c3ffbff : str    b31, [sp,xzr,sxtx #0]   : str    %b31 -> (%sp,%xzr,sxtx #0)[1byte]
+3c800400 : str    q0, [x0],#0             : str    %q0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
+3c800c00 : str    q0, [x0,#0]!            : str    %q0 %x0 $0x0000000000000000 -> (%x0)[16byte] %x0
+3c881441 : str    q1, [x2],#129           : str    %q1 %x2 $0x0000000000000081 -> (%x2)[16byte] %x2
+3c881c41 : str    q1, [x2,#129]!          : str    %q1 %x2 $0x0000000000000081 -> +0x81(%x2)[16byte] %x2
+3c9ff7ff : str    q31, [sp],#-1           : str    %q31 %sp $0xffffffffffffffff -> (%sp)[16byte] %sp
+3c9fffff : str    q31, [sp,#-1]!          : str    %q31 %sp $0xffffffffffffffff -> -0x01(%sp)[16byte] %sp
+3ca34841 : str    q1, [x2,w3,uxtw]        : str    %b1 -> (%x2,%x3,uxtw)[16byte]
+3ca35841 : str    q1, [x2,w3,uxtw #4]     : str    %b1 -> (%x2,%x3,uxtw #4)[16byte]
+3ca36841 : str    q1, [x2,x3]             : str    %b1 -> (%x2,%x3)[16byte]
+3ca37841 : str    q1, [x2,x3,lsl #4]      : str    %b1 -> (%x2,%x3,uxtx #4)[16byte]
+3ca3c841 : str    q1, [x2,w3,sxtw]        : str    %b1 -> (%x2,%x3,sxtw)[16byte]
+3ca3d841 : str    q1, [x2,w3,sxtw #4]     : str    %b1 -> (%x2,%x3,sxtw #4)[16byte]
+3ca3e841 : str    q1, [x2,x3,sxtx]        : str    %b1 -> (%x2,%x3,sxtx)[16byte]
+3ca3f841 : str    q1, [x2,x3,sxtx #4]     : str    %b1 -> (%x2,%x3,sxtx #4)[16byte]
+3cbf4bff : str    q31, [sp,wzr,uxtw]      : str    %b31 -> (%sp,%xzr,uxtw)[16byte]
+3cbf5bff : str    q31, [sp,wzr,uxtw #4]   : str    %b31 -> (%sp,%xzr,uxtw #4)[16byte]
+3cbf6bff : str    q31, [sp,xzr]           : str    %b31 -> (%sp,%xzr)[16byte]
+3cbf7bff : str    q31, [sp,xzr,lsl #4]    : str    %b31 -> (%sp,%xzr,uxtx #4)[16byte]
+3cbfcbff : str    q31, [sp,wzr,sxtw]      : str    %b31 -> (%sp,%xzr,sxtw)[16byte]
+3cbfdbff : str    q31, [sp,wzr,sxtw #4]   : str    %b31 -> (%sp,%xzr,sxtw #4)[16byte]
+3cbfebff : str    q31, [sp,xzr,sxtx]      : str    %b31 -> (%sp,%xzr,sxtx)[16byte]
+3cbffbff : str    q31, [sp,xzr,sxtx #4]   : str    %b31 -> (%sp,%xzr,sxtx #4)[16byte]
+3d081041 : str    b1, [x2,#516]           : str    %b1 -> +0x0204(%x2)[1byte]
+3d3fffff : str    b31, [sp,#4095]         : str    %b31 -> +0x0fff(%sp)[1byte]
+3d881041 : str    q1, [x2,#8256]          : str    %q1 -> +0x2040(%x2)[16byte]
+3dbfffff : str    q31, [sp,#65520]        : str    %q31 -> +0xfff0(%sp)[16byte]
+7c000400 : str    h0, [x0],#0             : str    %h0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
+7c000c00 : str    h0, [x0,#0]!            : str    %h0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
+7c081441 : str    h1, [x2],#129           : str    %h1 %x2 $0x0000000000000081 -> (%x2)[2byte] %x2
+7c081c41 : str    h1, [x2,#129]!          : str    %h1 %x2 $0x0000000000000081 -> +0x81(%x2)[2byte] %x2
+7c1ff7ff : str    h31, [sp],#-1           : str    %h31 %sp $0xffffffffffffffff -> (%sp)[2byte] %sp
+7c1fffff : str    h31, [sp,#-1]!          : str    %h31 %sp $0xffffffffffffffff -> -0x01(%sp)[2byte] %sp
+7c234841 : str    h1, [x2,w3,uxtw]        : str    %h1 -> (%x2,%x3,uxtw)[2byte]
+7c235841 : str    h1, [x2,w3,uxtw #1]     : str    %h1 -> (%x2,%x3,uxtw #1)[2byte]
+7c236841 : str    h1, [x2,x3]             : str    %h1 -> (%x2,%x3)[2byte]
+7c237841 : str    h1, [x2,x3,lsl #1]      : str    %h1 -> (%x2,%x3,uxtx #1)[2byte]
+7c23c841 : str    h1, [x2,w3,sxtw]        : str    %h1 -> (%x2,%x3,sxtw)[2byte]
+7c23d841 : str    h1, [x2,w3,sxtw #1]     : str    %h1 -> (%x2,%x3,sxtw #1)[2byte]
+7c23e841 : str    h1, [x2,x3,sxtx]        : str    %h1 -> (%x2,%x3,sxtx)[2byte]
+7c23f841 : str    h1, [x2,x3,sxtx #1]     : str    %h1 -> (%x2,%x3,sxtx #1)[2byte]
+7c3f4bff : str    h31, [sp,wzr,uxtw]      : str    %h31 -> (%sp,%xzr,uxtw)[2byte]
+7c3f5bff : str    h31, [sp,wzr,uxtw #1]   : str    %h31 -> (%sp,%xzr,uxtw #1)[2byte]
+7c3f6bff : str    h31, [sp,xzr]           : str    %h31 -> (%sp,%xzr)[2byte]
+7c3f7bff : str    h31, [sp,xzr,lsl #1]    : str    %h31 -> (%sp,%xzr,uxtx #1)[2byte]
+7c3fcbff : str    h31, [sp,wzr,sxtw]      : str    %h31 -> (%sp,%xzr,sxtw)[2byte]
+7c3fdbff : str    h31, [sp,wzr,sxtw #1]   : str    %h31 -> (%sp,%xzr,sxtw #1)[2byte]
+7c3febff : str    h31, [sp,xzr,sxtx]      : str    %h31 -> (%sp,%xzr,sxtx)[2byte]
+7c3ffbff : str    h31, [sp,xzr,sxtx #1]   : str    %h31 -> (%sp,%xzr,sxtx #1)[2byte]
+7d081041 : str    h1, [x2,#1032]          : str    %h1 -> +0x0408(%x2)[2byte]
+7d3fffff : str    h31, [sp,#8190]         : str    %h31 -> +0x1ffe(%sp)[2byte]
+b8000400 : str    w0, [x0],#0             : str    %w0 %x0 $0x0000000000000000 -> (%x0)[4byte] %x0
+b8000c00 : str    w0, [x0,#0]!            : str    %w0 %x0 $0x0000000000000000 -> (%x0)[4byte] %x0
+b8081441 : str    w1, [x2],#129           : str    %w1 %x2 $0x0000000000000081 -> (%x2)[4byte] %x2
+b8081c41 : str    w1, [x2,#129]!          : str    %w1 %x2 $0x0000000000000081 -> +0x81(%x2)[4byte] %x2
+b81ff7ff : str    wzr, [sp],#-1           : str    %wzr %sp $0xffffffffffffffff -> (%sp)[4byte] %sp
+b81fffff : str    wzr, [sp,#-1]!          : str    %wzr %sp $0xffffffffffffffff -> -0x01(%sp)[4byte] %sp
+b8234841 : str    w1, [x2,w3,uxtw]        : str    %w1 -> (%x2,%x3,uxtw)[4byte]
+b8235841 : str    w1, [x2,w3,uxtw #2]     : str    %w1 -> (%x2,%x3,uxtw #2)[4byte]
+b8236841 : str    w1, [x2,x3]             : str    %w1 -> (%x2,%x3)[4byte]
+b8237841 : str    w1, [x2,x3,lsl #2]      : str    %w1 -> (%x2,%x3,uxtx #2)[4byte]
+b823c841 : str    w1, [x2,w3,sxtw]        : str    %w1 -> (%x2,%x3,sxtw)[4byte]
+b823d841 : str    w1, [x2,w3,sxtw #2]     : str    %w1 -> (%x2,%x3,sxtw #2)[4byte]
+b823e841 : str    w1, [x2,x3,sxtx]        : str    %w1 -> (%x2,%x3,sxtx)[4byte]
+b823f841 : str    w1, [x2,x3,sxtx #2]     : str    %w1 -> (%x2,%x3,sxtx #2)[4byte]
+b83f4bff : str    wzr, [sp,wzr,uxtw]      : str    %wzr -> (%sp,%xzr,uxtw)[4byte]
+b83f5bff : str    wzr, [sp,wzr,uxtw #2]   : str    %wzr -> (%sp,%xzr,uxtw #2)[4byte]
+b83f6bff : str    wzr, [sp,xzr]           : str    %wzr -> (%sp,%xzr)[4byte]
+b83f7bff : str    wzr, [sp,xzr,lsl #2]    : str    %wzr -> (%sp,%xzr,uxtx #2)[4byte]
+b83fcbff : str    wzr, [sp,wzr,sxtw]      : str    %wzr -> (%sp,%xzr,sxtw)[4byte]
+b83fdbff : str    wzr, [sp,wzr,sxtw #2]   : str    %wzr -> (%sp,%xzr,sxtw #2)[4byte]
+b83febff : str    wzr, [sp,xzr,sxtx]      : str    %wzr -> (%sp,%xzr,sxtx)[4byte]
+b83ffbff : str    wzr, [sp,xzr,sxtx #2]   : str    %wzr -> (%sp,%xzr,sxtx #2)[4byte]
+b9081041 : str    w1, [x2,#2064]          : str    %w1 -> +0x0810(%x2)[4byte]
+b93fffff : str    wzr, [sp,#16380]        : str    %wzr -> +0x3ffc(%sp)[4byte]
+bc000400 : str    s0, [x0],#0             : str    %s0 %x0 $0x0000000000000000 -> (%x0)[4byte] %x0
+bc000c00 : str    s0, [x0,#0]!            : str    %s0 %x0 $0x0000000000000000 -> (%x0)[4byte] %x0
+bc081441 : str    s1, [x2],#129           : str    %s1 %x2 $0x0000000000000081 -> (%x2)[4byte] %x2
+bc081c41 : str    s1, [x2,#129]!          : str    %s1 %x2 $0x0000000000000081 -> +0x81(%x2)[4byte] %x2
+bc1ff7ff : str    s31, [sp],#-1           : str    %s31 %sp $0xffffffffffffffff -> (%sp)[4byte] %sp
+bc1fffff : str    s31, [sp,#-1]!          : str    %s31 %sp $0xffffffffffffffff -> -0x01(%sp)[4byte] %sp
+bc234841 : str    s1, [x2,w3,uxtw]        : str    %s1 -> (%x2,%x3,uxtw)[4byte]
+bc235841 : str    s1, [x2,w3,uxtw #2]     : str    %s1 -> (%x2,%x3,uxtw #2)[4byte]
+bc236841 : str    s1, [x2,x3]             : str    %s1 -> (%x2,%x3)[4byte]
+bc237841 : str    s1, [x2,x3,lsl #2]      : str    %s1 -> (%x2,%x3,uxtx #2)[4byte]
+bc23c841 : str    s1, [x2,w3,sxtw]        : str    %s1 -> (%x2,%x3,sxtw)[4byte]
+bc23d841 : str    s1, [x2,w3,sxtw #2]     : str    %s1 -> (%x2,%x3,sxtw #2)[4byte]
+bc23e841 : str    s1, [x2,x3,sxtx]        : str    %s1 -> (%x2,%x3,sxtx)[4byte]
+bc23f841 : str    s1, [x2,x3,sxtx #2]     : str    %s1 -> (%x2,%x3,sxtx #2)[4byte]
+bc3f4bff : str    s31, [sp,wzr,uxtw]      : str    %s31 -> (%sp,%xzr,uxtw)[4byte]
+bc3f5bff : str    s31, [sp,wzr,uxtw #2]   : str    %s31 -> (%sp,%xzr,uxtw #2)[4byte]
+bc3f6bff : str    s31, [sp,xzr]           : str    %s31 -> (%sp,%xzr)[4byte]
+bc3f7bff : str    s31, [sp,xzr,lsl #2]    : str    %s31 -> (%sp,%xzr,uxtx #2)[4byte]
+bc3fcbff : str    s31, [sp,wzr,sxtw]      : str    %s31 -> (%sp,%xzr,sxtw)[4byte]
+bc3fdbff : str    s31, [sp,wzr,sxtw #2]   : str    %s31 -> (%sp,%xzr,sxtw #2)[4byte]
+bc3febff : str    s31, [sp,xzr,sxtx]      : str    %s31 -> (%sp,%xzr,sxtx)[4byte]
+bc3ffbff : str    s31, [sp,xzr,sxtx #2]   : str    %s31 -> (%sp,%xzr,sxtx #2)[4byte]
+bd081041 : str    s1, [x2,#2064]          : str    %s1 -> +0x0810(%x2)[4byte]
+bd3fffff : str    s31, [sp,#16380]        : str    %s31 -> +0x3ffc(%sp)[4byte]
+f8000400 : str    x0, [x0],#0             : str    %x0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
+f8000c00 : str    x0, [x0,#0]!            : str    %x0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
+f8081441 : str    x1, [x2],#129           : str    %x1 %x2 $0x0000000000000081 -> (%x2)[8byte] %x2
+f8081c41 : str    x1, [x2,#129]!          : str    %x1 %x2 $0x0000000000000081 -> +0x81(%x2)[8byte] %x2
+f81ff7ff : str    xzr, [sp],#-1           : str    %xzr %sp $0xffffffffffffffff -> (%sp)[8byte] %sp
+f81fffff : str    xzr, [sp,#-1]!          : str    %xzr %sp $0xffffffffffffffff -> -0x01(%sp)[8byte] %sp
+f8234841 : str    x1, [x2,w3,uxtw]        : str    %x1 -> (%x2,%x3,uxtw)[8byte]
+f8235841 : str    x1, [x2,w3,uxtw #3]     : str    %x1 -> (%x2,%x3,uxtw #3)[8byte]
+f8236841 : str    x1, [x2,x3]             : str    %x1 -> (%x2,%x3)[8byte]
+f8237841 : str    x1, [x2,x3,lsl #3]      : str    %x1 -> (%x2,%x3,uxtx #3)[8byte]
+f823c841 : str    x1, [x2,w3,sxtw]        : str    %x1 -> (%x2,%x3,sxtw)[8byte]
+f823d841 : str    x1, [x2,w3,sxtw #3]     : str    %x1 -> (%x2,%x3,sxtw #3)[8byte]
+f823e841 : str    x1, [x2,x3,sxtx]        : str    %x1 -> (%x2,%x3,sxtx)[8byte]
+f823f841 : str    x1, [x2,x3,sxtx #3]     : str    %x1 -> (%x2,%x3,sxtx #3)[8byte]
+f83f4bff : str    xzr, [sp,wzr,uxtw]      : str    %xzr -> (%sp,%xzr,uxtw)[8byte]
+f83f5bff : str    xzr, [sp,wzr,uxtw #3]   : str    %xzr -> (%sp,%xzr,uxtw #3)[8byte]
+f83f6bff : str    xzr, [sp,xzr]           : str    %xzr -> (%sp,%xzr)[8byte]
+f83f7bff : str    xzr, [sp,xzr,lsl #3]    : str    %xzr -> (%sp,%xzr,uxtx #3)[8byte]
+f83fcbff : str    xzr, [sp,wzr,sxtw]      : str    %xzr -> (%sp,%xzr,sxtw)[8byte]
+f83fdbff : str    xzr, [sp,wzr,sxtw #3]   : str    %xzr -> (%sp,%xzr,sxtw #3)[8byte]
+f83febff : str    xzr, [sp,xzr,sxtx]      : str    %xzr -> (%sp,%xzr,sxtx)[8byte]
+f83ffbff : str    xzr, [sp,xzr,sxtx #3]   : str    %xzr -> (%sp,%xzr,sxtx #3)[8byte]
+f9081041 : str    x1, [x2,#4128]          : str    %x1 -> +0x1020(%x2)[8byte]
+f93fffff : str    xzr, [sp,#32760]        : str    %xzr -> +0x7ff8(%sp)[8byte]
+fc000400 : str    d0, [x0],#0             : str    %d0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
+fc000c00 : str    d0, [x0,#0]!            : str    %d0 %x0 $0x0000000000000000 -> (%x0)[8byte] %x0
+fc081441 : str    d1, [x2],#129           : str    %d1 %x2 $0x0000000000000081 -> (%x2)[8byte] %x2
+fc081c41 : str    d1, [x2,#129]!          : str    %d1 %x2 $0x0000000000000081 -> +0x81(%x2)[8byte] %x2
+fc1ff7ff : str    d31, [sp],#-1           : str    %d31 %sp $0xffffffffffffffff -> (%sp)[8byte] %sp
+fc1fffff : str    d31, [sp,#-1]!          : str    %d31 %sp $0xffffffffffffffff -> -0x01(%sp)[8byte] %sp
+fc234841 : str    d1, [x2,w3,uxtw]        : str    %d1 -> (%x2,%x3,uxtw)[8byte]
+fc235841 : str    d1, [x2,w3,uxtw #3]     : str    %d1 -> (%x2,%x3,uxtw #3)[8byte]
+fc236841 : str    d1, [x2,x3]             : str    %d1 -> (%x2,%x3)[8byte]
+fc237841 : str    d1, [x2,x3,lsl #3]      : str    %d1 -> (%x2,%x3,uxtx #3)[8byte]
+fc23c841 : str    d1, [x2,w3,sxtw]        : str    %d1 -> (%x2,%x3,sxtw)[8byte]
+fc23d841 : str    d1, [x2,w3,sxtw #3]     : str    %d1 -> (%x2,%x3,sxtw #3)[8byte]
+fc23e841 : str    d1, [x2,x3,sxtx]        : str    %d1 -> (%x2,%x3,sxtx)[8byte]
+fc23f841 : str    d1, [x2,x3,sxtx #3]     : str    %d1 -> (%x2,%x3,sxtx #3)[8byte]
+fc3f4bff : str    d31, [sp,wzr,uxtw]      : str    %d31 -> (%sp,%xzr,uxtw)[8byte]
+fc3f5bff : str    d31, [sp,wzr,uxtw #3]   : str    %d31 -> (%sp,%xzr,uxtw #3)[8byte]
+fc3f6bff : str    d31, [sp,xzr]           : str    %d31 -> (%sp,%xzr)[8byte]
+fc3f7bff : str    d31, [sp,xzr,lsl #3]    : str    %d31 -> (%sp,%xzr,uxtx #3)[8byte]
+fc3fcbff : str    d31, [sp,wzr,sxtw]      : str    %d31 -> (%sp,%xzr,sxtw)[8byte]
+fc3fdbff : str    d31, [sp,wzr,sxtw #3]   : str    %d31 -> (%sp,%xzr,sxtw #3)[8byte]
+fc3febff : str    d31, [sp,xzr,sxtx]      : str    %d31 -> (%sp,%xzr,sxtx)[8byte]
+fc3ffbff : str    d31, [sp,xzr,sxtx #3]   : str    %d31 -> (%sp,%xzr,sxtx #3)[8byte]
+fd081041 : str    d1, [x2,#4128]          : str    %d1 -> +0x1020(%x2)[8byte]
+fd3fffff : str    d31, [sp,#32760]        : str    %d31 -> +0x7ff8(%sp)[8byte]
+
+38000400 : strb   w0, [x0],#0             : strb   %w0 %x0 $0x0000000000000000 -> (%x0)[1byte] %x0
+38000c00 : strb   w0, [x0,#0]!            : strb   %w0 %x0 $0x0000000000000000 -> (%x0)[1byte] %x0
+38081441 : strb   w1, [x2],#129           : strb   %w1 %x2 $0x0000000000000081 -> (%x2)[1byte] %x2
+38081c41 : strb   w1, [x2,#129]!          : strb   %w1 %x2 $0x0000000000000081 -> +0x81(%x2)[1byte] %x2
+381ff7ff : strb   wzr, [sp],#-1           : strb   %wzr %sp $0xffffffffffffffff -> (%sp)[1byte] %sp
+381fffff : strb   wzr, [sp,#-1]!          : strb   %wzr %sp $0xffffffffffffffff -> -0x01(%sp)[1byte] %sp
+38234841 : strb   w1, [x2,w3,uxtw]        : strb   %w1 -> (%x2,%x3,uxtw)[1byte]
+38235841 : strb   w1, [x2,w3,uxtw #0]     : strb   %w1 -> (%x2,%x3,uxtw #0)[1byte]
+38236841 : strb   w1, [x2,x3]             : strb   %w1 -> (%x2,%x3)[1byte]
+38237841 : strb   w1, [x2,x3,lsl #0]      : strb   %w1 -> (%x2,%x3,uxtx #0)[1byte]
+3823c841 : strb   w1, [x2,w3,sxtw]        : strb   %w1 -> (%x2,%x3,sxtw)[1byte]
+3823d841 : strb   w1, [x2,w3,sxtw #0]     : strb   %w1 -> (%x2,%x3,sxtw #0)[1byte]
+3823e841 : strb   w1, [x2,x3,sxtx]        : strb   %w1 -> (%x2,%x3,sxtx)[1byte]
+3823f841 : strb   w1, [x2,x3,sxtx #0]     : strb   %w1 -> (%x2,%x3,sxtx #0)[1byte]
+383f4bff : strb   wzr, [sp,wzr,uxtw]      : strb   %wzr -> (%sp,%xzr,uxtw)[1byte]
+383f5bff : strb   wzr, [sp,wzr,uxtw #0]   : strb   %wzr -> (%sp,%xzr,uxtw #0)[1byte]
+383f6bff : strb   wzr, [sp,xzr]           : strb   %wzr -> (%sp,%xzr)[1byte]
+383f7bff : strb   wzr, [sp,xzr,lsl #0]    : strb   %wzr -> (%sp,%xzr,uxtx #0)[1byte]
+383fcbff : strb   wzr, [sp,wzr,sxtw]      : strb   %wzr -> (%sp,%xzr,sxtw)[1byte]
+383fdbff : strb   wzr, [sp,wzr,sxtw #0]   : strb   %wzr -> (%sp,%xzr,sxtw #0)[1byte]
+383febff : strb   wzr, [sp,xzr,sxtx]      : strb   %wzr -> (%sp,%xzr,sxtx)[1byte]
+383ffbff : strb   wzr, [sp,xzr,sxtx #0]   : strb   %wzr -> (%sp,%xzr,sxtx #0)[1byte]
+39081041 : strb   w1, [x2,#516]           : strb   %w1 -> +0x0204(%x2)[1byte]
+393fffff : strb   wzr, [sp,#4095]         : strb   %wzr -> +0x0fff(%sp)[1byte]
+
+78000400 : strh   w0, [x0],#0             : strh   %w0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
+78000c00 : strh   w0, [x0,#0]!            : strh   %w0 %x0 $0x0000000000000000 -> (%x0)[2byte] %x0
+78081441 : strh   w1, [x2],#129           : strh   %w1 %x2 $0x0000000000000081 -> (%x2)[2byte] %x2
+78081c41 : strh   w1, [x2,#129]!          : strh   %w1 %x2 $0x0000000000000081 -> +0x81(%x2)[2byte] %x2
+781ff7ff : strh   wzr, [sp],#-1           : strh   %wzr %sp $0xffffffffffffffff -> (%sp)[2byte] %sp
+781fffff : strh   wzr, [sp,#-1]!          : strh   %wzr %sp $0xffffffffffffffff -> -0x01(%sp)[2byte] %sp
+78234841 : strh   w1, [x2,w3,uxtw]        : strh   %w1 -> (%x2,%x3,uxtw)[2byte]
+78235841 : strh   w1, [x2,w3,uxtw #1]     : strh   %w1 -> (%x2,%x3,uxtw #1)[2byte]
+78236841 : strh   w1, [x2,x3]             : strh   %w1 -> (%x2,%x3)[2byte]
+78237841 : strh   w1, [x2,x3,lsl #1]      : strh   %w1 -> (%x2,%x3,uxtx #1)[2byte]
+7823c841 : strh   w1, [x2,w3,sxtw]        : strh   %w1 -> (%x2,%x3,sxtw)[2byte]
+7823d841 : strh   w1, [x2,w3,sxtw #1]     : strh   %w1 -> (%x2,%x3,sxtw #1)[2byte]
+7823e841 : strh   w1, [x2,x3,sxtx]        : strh   %w1 -> (%x2,%x3,sxtx)[2byte]
+7823f841 : strh   w1, [x2,x3,sxtx #1]     : strh   %w1 -> (%x2,%x3,sxtx #1)[2byte]
+783f4bff : strh   wzr, [sp,wzr,uxtw]      : strh   %wzr -> (%sp,%xzr,uxtw)[2byte]
+783f5bff : strh   wzr, [sp,wzr,uxtw #1]   : strh   %wzr -> (%sp,%xzr,uxtw #1)[2byte]
+783f6bff : strh   wzr, [sp,xzr]           : strh   %wzr -> (%sp,%xzr)[2byte]
+783f7bff : strh   wzr, [sp,xzr,lsl #1]    : strh   %wzr -> (%sp,%xzr,uxtx #1)[2byte]
+783fcbff : strh   wzr, [sp,wzr,sxtw]      : strh   %wzr -> (%sp,%xzr,sxtw)[2byte]
+783fdbff : strh   wzr, [sp,wzr,sxtw #1]   : strh   %wzr -> (%sp,%xzr,sxtw #1)[2byte]
+783febff : strh   wzr, [sp,xzr,sxtx]      : strh   %wzr -> (%sp,%xzr,sxtx)[2byte]
+783ffbff : strh   wzr, [sp,xzr,sxtx #1]   : strh   %wzr -> (%sp,%xzr,sxtx #1)[2byte]
+79081041 : strh   w1, [x2,#1032]          : strh   %w1 -> +0x0408(%x2)[2byte]
+793fffff : strh   wzr, [sp,#8190]         : strh   %wzr -> +0x1ffe(%sp)[2byte]
+
+b83f33ff : stset  wzr, [sp]               : ldset  %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f83f33ff : stset  xzr, [sp]               : ldset  %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+383f33ff : stsetb wzr, [sp]               : ldsetb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+783f33ff : stseth wzr, [sp]               : ldseth %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b87f33ff : stsetl wzr, [sp]               : ldsetl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f87f33ff : stsetl xzr, [sp]               : ldsetl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+387f33ff : stsetlb wzr, [sp]              : ldsetlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+787f33ff : stsetlh wzr, [sp]              : ldsetlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b83f43ff : stsmax wzr, [sp]               : ldsmax %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f83f43ff : stsmax xzr, [sp]               : ldsmax %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+383f43ff : stsmaxb wzr, [sp]              : ldsmaxb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+783f43ff : stsmaxh wzr, [sp]              : ldsmaxh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b87f43ff : stsmaxl wzr, [sp]              : ldsmaxl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f87f43ff : stsmaxl xzr, [sp]              : ldsmaxl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+387f43ff : stsmaxlb wzr, [sp]             : ldsmaxlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+787f43ff : stsmaxlh wzr, [sp]             : ldsmaxlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b83f53ff : stsmin wzr, [sp]               : ldsmin %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f83f53ff : stsmin xzr, [sp]               : ldsmin %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+383f53ff : stsminb wzr, [sp]              : ldsminb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+783f53ff : stsminh wzr, [sp]              : ldsminh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b87f53ff : stsminl wzr, [sp]              : ldsminl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f87f53ff : stsminl xzr, [sp]              : ldsminl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+387f53ff : stsminlb wzr, [sp]             : ldsminlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+787f53ff : stsminlh wzr, [sp]             : ldsminlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b8081841 : sttr   w1, [x2,#129]           : sttr   %w1 -> +0x81(%x2)[4byte]
+b81ffbff : sttr   wzr, [sp,#-1]           : sttr   %wzr -> -0x01(%sp)[4byte]
+f8081841 : sttr   x1, [x2,#129]           : sttr   %x1 -> +0x81(%x2)[8byte]
+f81ffbff : sttr   xzr, [sp,#-1]           : sttr   %xzr -> -0x01(%sp)[8byte]
+
+38081841 : sttrb  w1, [x2,#129]           : sttrb  %w1 -> +0x81(%x2)[1byte]
+381ffbff : sttrb  wzr, [sp,#-1]           : sttrb  %wzr -> -0x01(%sp)[1byte]
+
+78081841 : sttrh  w1, [x2,#129]           : sttrh  %w1 -> +0x81(%x2)[2byte]
+781ffbff : sttrh  wzr, [sp,#-1]           : sttrh  %wzr -> -0x01(%sp)[2byte]
+
+b83f63ff : stumax wzr, [sp]               : ldumax %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f83f63ff : stumax xzr, [sp]               : ldumax %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+383f63ff : stumaxb wzr, [sp]              : ldumaxb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+783f63ff : stumaxh wzr, [sp]              : ldumaxh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b87f63ff : stumaxl wzr, [sp]              : ldumaxl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f87f63ff : stumaxl xzr, [sp]              : ldumaxl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+387f63ff : stumaxlb wzr, [sp]             : ldumaxlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+787f63ff : stumaxlh wzr, [sp]             : ldumaxlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b83f73ff : stumin wzr, [sp]               : ldumin %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f83f73ff : stumin xzr, [sp]               : ldumin %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+383f73ff : stuminb wzr, [sp]              : lduminb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+783f73ff : stuminh wzr, [sp]              : lduminh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b87f73ff : stuminl wzr, [sp]              : lduminl %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f87f73ff : stuminl xzr, [sp]              : lduminl %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+387f73ff : stuminlb wzr, [sp]             : lduminlb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+787f73ff : stuminlh wzr, [sp]             : lduminlh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+3c00014a : stur   b10, [x10]              : stur   %b10 -> (%x10)[1byte]
+3c0ff16b : stur   b11, [x11, #255]        : stur   %b11 -> +0xff(%x11)[1byte]
+7c00018c : stur   h12, [x12]              : stur   %h12 -> (%x12)[2byte]
+7c0ff1ad : stur   h13, [x13, #255]        : stur   %h13 -> +0xff(%x13)[2byte]
+bc0001ce : stur   s14, [x14]              : stur   %s14 -> (%x14)[4byte]
+bc1001ef : stur   s15, [x15, #-256]       : stur   %s15 -> -0x0100(%x15)[4byte]
+fc000210 : stur   d16, [x16]              : stur   %d16 -> (%x16)[8byte]
+fc100231 : stur   d17, [x17, #-256]       : stur   %d17 -> -0x0100(%x17)[8byte]
+3c800252 : stur   q18, [x18]              : stur   %q18 -> (%x18)[16byte]
+3c900273 : stur   q19, [x19, #-256]       : stur   %q19 -> -0x0100(%x19)[16byte]
+3c081041 : stur   b1, [x2,#129]           : stur   %b1 -> +0x81(%x2)[1byte]
+3c1ff3ff : stur   b31, [sp,#-1]           : stur   %b31 -> -0x01(%sp)[1byte]
+3c881041 : stur   q1, [x2,#129]           : stur   %q1 -> +0x81(%x2)[16byte]
+3c9ff3ff : stur   q31, [sp,#-1]           : stur   %q31 -> -0x01(%sp)[16byte]
+7c081041 : stur   h1, [x2,#129]           : stur   %h1 -> +0x81(%x2)[2byte]
+7c1ff3ff : stur   h31, [sp,#-1]           : stur   %h31 -> -0x01(%sp)[2byte]
+b8081041 : stur   w1, [x2,#129]           : stur   %w1 -> +0x81(%x2)[4byte]
+b81ff3ff : stur   wzr, [sp,#-1]           : stur   %wzr -> -0x01(%sp)[4byte]
+bc081041 : stur   s1, [x2,#129]           : stur   %s1 -> +0x81(%x2)[4byte]
+bc1ff3ff : stur   s31, [sp,#-1]           : stur   %s31 -> -0x01(%sp)[4byte]
+f8081041 : stur   x1, [x2,#129]           : stur   %x1 -> +0x81(%x2)[8byte]
+f81ff3ff : stur   xzr, [sp,#-1]           : stur   %xzr -> -0x01(%sp)[8byte]
+fc081041 : stur   d1, [x2,#129]           : stur   %d1 -> +0x81(%x2)[8byte]
+fc1ff3ff : stur   d31, [sp,#-1]           : stur   %d31 -> -0x01(%sp)[8byte]
+
+38081041 : sturb  w1, [x2,#129]           : sturb  %w1 -> +0x81(%x2)[1byte]
+381ff3ff : sturb  wzr, [sp,#-1]           : sturb  %wzr -> -0x01(%sp)[1byte]
+
+78081041 : sturh  w1, [x2,#129]           : sturh  %w1 -> +0x81(%x2)[2byte]
+781ff3ff : sturh  wzr, [sp,#-1]           : sturh  %wzr -> -0x01(%sp)[2byte]
+
+88281041 : stxp   w8, w1, w4, [x2]        : stxp   %w1 %w4 -> (%x2)[8byte] %w8
+883f7fff : stxp   wzr, wzr, wzr, [sp]     : stxp   %wzr %wzr -> (%sp)[8byte] %wzr
+c8281041 : stxp   w8, x1, x4, [x2]        : stxp   %x1 %x4 -> (%x2)[16byte] %w8
+c83f7fff : stxp   wzr, xzr, xzr, [sp]     : stxp   %xzr %xzr -> (%sp)[16byte] %wzr
+
+88081041 : stxr   w8, w1, [x2]            : stxr   %w1 $0x04 -> (%x2)[4byte] %w8
+881f7fff : stxr   wzr, wzr, [sp]          : stxr   %wzr $0x1f -> (%sp)[4byte] %wzr
+c8081041 : stxr   w8, x1, [x2]            : stxr   %x1 $0x04 -> (%x2)[8byte] %w8
+c81f7fff : stxr   wzr, xzr, [sp]          : stxr   %xzr $0x1f -> (%sp)[8byte] %wzr
+
+08081041 : stxrb  w8, w1, [x2]            : stxrb  %w1 $0x04 -> (%x2)[1byte] %w8
+081f7fff : stxrb  wzr, wzr, [sp]          : stxrb  %wzr $0x1f -> (%sp)[1byte] %wzr
+
+48081041 : stxrh  w8, w1, [x2]            : stxrh  %w1 $0x04 -> (%x2)[2byte] %w8
+481f7fff : stxrh  wzr, wzr, [sp]          : stxrh  %wzr $0x1f -> (%sp)[2byte] %wzr
+
+4b031041 : sub    w1, w2, w3, lsl #4      : sub    %w2 %w3 lsl $0x04 -> %w1
+51000c41 : sub    w1, w2, #0x3            : sub    %w2 $0x0003 lsl $0x00 -> %w1
+51000fff : sub    wsp, wsp, #0x3          : sub    %wsp $0x0003 lsl $0x00 -> %wsp
+cb031041 : sub    x1, x2, x3, lsl #4      : sub    %x2 %x3 lsl $0x04 -> %x1
+cb3f73ff : sub    sp, sp, xzr, lsl #4     : sub    %sp %xzr uxtx $0x04 -> %sp
+cb431041 : sub    x1, x2, x3, lsr #4      : sub    %x2 %x3 lsr $0x04 -> %x1
+d1000c41 : sub    x1, x2, #0x3            : sub    %x2 $0x0003 lsl $0x00 -> %x1
+d1000fff : sub    sp, sp, #0x3            : sub    %sp $0x0003 lsl $0x00 -> %sp
+d13fffff : sub    sp, sp, #0xfff          : sub    %sp $0x0fff lsl $0x00 -> %sp
+2e3c877d : sub v29.8b, v27.8b, v28.8b               : sub    %d27 %d28 $0x00 -> %d29
+6e3c877d : sub v29.16b, v27.16b, v28.16b            : sub    %q27 %q28 $0x00 -> %q29
+2e7c877d : sub v29.4h, v27.4h, v28.4h               : sub    %d27 %d28 $0x01 -> %d29
+6e7c877d : sub v29.8h, v27.8h, v28.8h               : sub    %q27 %q28 $0x01 -> %q29
+2ebc877d : sub v29.2s, v27.2s, v28.2s               : sub    %d27 %d28 $0x02 -> %d29
+6ebc877d : sub v29.4s, v27.4s, v28.4s               : sub    %q27 %q28 $0x02 -> %q29
+6efc877d : sub v29.2d, v27.2d, v28.2d               : sub    %q27 %q28 $0x03 -> %q29
+043d05a0 : sub z0.b, z13.b, z29.b                   : sub    %z13 %z29 $0x00 -> %z0
+047d05a0 : sub z0.h, z13.h, z29.h                   : sub    %z13 %z29 $0x01 -> %z0
+04bd05a0 : sub z0.s, z13.s, z29.s                   : sub    %z13 %z29 $0x02 -> %z0
+04fd05a0 : sub z0.d, z13.d, z29.d                   : sub    %z13 %z29 $0x03 -> %z0
+
+0e32604d : subhn v13.8b, v2.8h, v18.8h              : subhn  %q2 %q18 $0x00 -> %d13
+0e72604d : subhn v13.4h, v2.4s, v18.4s              : subhn  %q2 %q18 $0x01 -> %d13
+0eb2604d : subhn v13.2s, v2.2d, v18.2d              : subhn  %q2 %q18 $0x02 -> %d13
+
+4e2760bb : subhn2 v27.16b, v5.8h, v7.8h             : subhn2 %q5 %q7 $0x00 -> %q27
+4e6760bb : subhn2 v27.8h, v5.4s, v7.4s              : subhn2 %q5 %q7 $0x01 -> %q27
+4ea760bb : subhn2 v27.4s, v5.2d, v7.2d              : subhn2 %q5 %q7 $0x02 -> %q27
+
+6b031041 : subs   w1, w2, w3, lsl #4      : subs   %w2 %w3 lsl $0x04 -> %w1
+71000c41 : subs   w1, w2, #0x3            : subs   %w2 $0x0003 lsl $0x00 -> %w1
+eb431041 : subs   x1, x2, x3, lsr #4      : subs   %x2 %x3 lsr $0x04 -> %x1
+f1000c41 : subs   x1, x2, #0x3            : subs   %x2 $0x0003 lsl $0x00 -> %x1
+
+d4000001 : svc    #0x0                    : svc    $0x0000
+d4081041 : svc    #0x4082                 : svc    $0x4082
+d41fffe1 : svc    #0xffff                 : svc    $0xffff
+
+b8288041 : swp    w8, w1, [x2]            : swp    %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b83f83ff : swp    wzr, wzr, [sp]          : swp    %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8288041 : swp    x8, x1, [x2]            : swp    %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f83f83ff : swp    xzr, xzr, [sp]          : swp    %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+b8a88041 : swpa   w8, w1, [x2]            : swpa   %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8bf83ff : swpa   wzr, wzr, [sp]          : swpa   %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8a88041 : swpa   x8, x1, [x2]            : swpa   %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8bf83ff : swpa   xzr, xzr, [sp]          : swpa   %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38a88041 : swpab  w8, w1, [x2]            : swpab  %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38bf83ff : swpab  wzr, wzr, [sp]          : swpab  %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78a88041 : swpah  w8, w1, [x2]            : swpah  %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78bf83ff : swpah  wzr, wzr, [sp]          : swpah  %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b8e88041 : swpal  w8, w1, [x2]            : swpal  %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b8ff83ff : swpal  wzr, wzr, [sp]          : swpal  %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8e88041 : swpal  x8, x1, [x2]            : swpal  %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f8ff83ff : swpal  xzr, xzr, [sp]          : swpal  %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38e88041 : swpalb w8, w1, [x2]            : swpalb %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+38ff83ff : swpalb wzr, wzr, [sp]          : swpalb %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78e88041 : swpalh w8, w1, [x2]            : swpalh %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+78ff83ff : swpalh wzr, wzr, [sp]          : swpalh %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+38288041 : swpb   w8, w1, [x2]            : swpb   %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+383f83ff : swpb   wzr, wzr, [sp]          : swpb   %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78288041 : swph   w8, w1, [x2]            : swph   %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+783f83ff : swph   wzr, wzr, [sp]          : swph   %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+b8688041 : swpl   w8, w1, [x2]            : swpl   %w8 (%x2)[4byte] -> %w1 (%x2)[4byte]
+b87f83ff : swpl   wzr, wzr, [sp]          : swpl   %wzr (%sp)[4byte] -> %wzr (%sp)[4byte]
+f8688041 : swpl   x8, x1, [x2]            : swpl   %x8 (%x2)[8byte] -> %x1 (%x2)[8byte]
+f87f83ff : swpl   xzr, xzr, [sp]          : swpl   %xzr (%sp)[8byte] -> %xzr (%sp)[8byte]
+
+38688041 : swplb  w8, w1, [x2]            : swplb  %w8 (%x2)[1byte] -> %w1 (%x2)[1byte]
+387f83ff : swplb  wzr, wzr, [sp]          : swplb  %wzr (%sp)[1byte] -> %wzr (%sp)[1byte]
+
+78688041 : swplh  w8, w1, [x2]            : swplh  %w8 (%x2)[2byte] -> %w1 (%x2)[2byte]
+787f83ff : swplh  wzr, wzr, [sp]          : swplh  %wzr (%sp)[2byte] -> %wzr (%sp)[2byte]
+
+d5080000 : sys    #0, C0, C0, #0, x0      : sys    $0x0000 (%x0)[1byte]
+d50fffff : sys    #7, C15, C15, #7        : sys    $0x3fff (%xzr)[1byte]
+d50b7420 : sys    #3,  C7,  C4, #1, x0    : sys    $0x1ba1 (%x0)[1byte]
+d50b7a21 : sys    #3,  C7,  C10, #1, x1   : sys    $0x1bd1 (%x1)[1byte]
+d50b7b21 : sys    #3,  C7,  C11, #1, x1   : sys    $0x1bd9 (%x1)[1byte]
+d50b7e21 : sys    #3,  C7,  C14, #1, x1   : sys    $0x1bf1 (%x1)[1byte]
+d50b7521 : sys    #3,  C7,  C5,  #1, x1   : sys    $0x1ba9 (%x1)[1byte]
+
+37081041 : tbnz   w1, #1, 10000208        : tbnz   $0x0000000010000208 %x1 $0x01
+b7fc0000 : tbnz   x0, #63, fff8000        : tbnz   $0x000000000fff8000 %x0 $0x3f
+b7ffffff : tbnz   xzr, #63, ffffffc       : tbnz   $0x000000000ffffffc %xzr $0x3f
+
+3603ffff : tbz    wzr, #0, 10007ffc       : tbz    $0x0000000010007ffc %xzr $0x00
+36081041 : tbz    w1, #1, 10000208        : tbz    $0x0000000010000208 %x1 $0x01
+b6ffffff : tbz    xzr, #63, ffffffc       : tbz    $0x000000000ffffffc %xzr $0x3f
+
+6a9f13ff : tst    wzr, wzr, asr #4        : ands   %wzr %wzr asr $0x04 -> %wzr
+ea9fffff : tst    xzr, xzr, asr #63       : ands   %xzr %xzr asr $0x3f -> %xzr
+eadf13ff : tst    xzr, xzr, ror #4        : ands   %xzr %xzr ror $0x04 -> %xzr
+
+2e337ccd : uaba v13.8b, v6.8b, v19.8b               : uaba   %d6 %d19 $0x00 -> %d13
+6e337ccd : uaba v13.16b, v6.16b, v19.16b            : uaba   %q6 %q19 $0x00 -> %q13
+2e737ccd : uaba v13.4h, v6.4h, v19.4h               : uaba   %d6 %d19 $0x01 -> %d13
+6e737ccd : uaba v13.8h, v6.8h, v19.8h               : uaba   %q6 %q19 $0x01 -> %q13
+2eb37ccd : uaba v13.2s, v6.2s, v19.2s               : uaba   %d6 %d19 $0x02 -> %d13
+6eb37ccd : uaba v13.4s, v6.4s, v19.4s               : uaba   %q6 %q19 $0x02 -> %q13
+
+2e365397 : uabal v23.8h, v28.8b, v22.8b             : uabal  %d28 %d22 $0x00 -> %q23
+2e765397 : uabal v23.4s, v28.4h, v22.4h             : uabal  %d28 %d22 $0x01 -> %q23
+2eb65397 : uabal v23.2d, v28.2s, v22.2s             : uabal  %d28 %d22 $0x02 -> %q23
+
+6e3d528d : uabal2 v13.8h, v20.16b, v29.16b          : uabal2 %q20 %q29 $0x00 -> %q13
+6e7d528d : uabal2 v13.4s, v20.8h, v29.8h            : uabal2 %q20 %q29 $0x01 -> %q13
+6ebd528d : uabal2 v13.2d, v20.4s, v29.4s            : uabal2 %q20 %q29 $0x02 -> %q13
+
+2e3b7585 : uabd v5.8b, v12.8b, v27.8b               : uabd   %d12 %d27 $0x00 -> %d5
+6e3b7585 : uabd v5.16b, v12.16b, v27.16b            : uabd   %q12 %q27 $0x00 -> %q5
+2e7b7585 : uabd v5.4h, v12.4h, v27.4h               : uabd   %d12 %d27 $0x01 -> %d5
+6e7b7585 : uabd v5.8h, v12.8h, v27.8h               : uabd   %q12 %q27 $0x01 -> %q5
+2ebb7585 : uabd v5.2s, v12.2s, v27.2s               : uabd   %d12 %d27 $0x02 -> %d5
+6ebb7585 : uabd v5.4s, v12.4s, v27.4s               : uabd   %q12 %q27 $0x02 -> %q5
+
+2e3971fa : uabdl v26.8h, v15.8b, v25.8b             : uabdl  %d15 %d25 $0x00 -> %q26
+2e7971fa : uabdl v26.4s, v15.4h, v25.4h             : uabdl  %d15 %d25 $0x01 -> %q26
+2eb971fa : uabdl v26.2d, v15.2s, v25.2s             : uabdl  %d15 %d25 $0x02 -> %q26
+
+6e3b71be : uabdl2 v30.8h, v13.16b, v27.16b          : uabdl2 %q13 %q27 $0x00 -> %q30
+6e7b71be : uabdl2 v30.4s, v13.8h, v27.8h            : uabdl2 %q13 %q27 $0x01 -> %q30
+6ebb71be : uabdl2 v30.2d, v13.4s, v27.4s            : uabdl2 %q13 %q27 $0x02 -> %q30
+
+2e3d0207 : uaddl v7.8h, v16.8b, v29.8b              : uaddl  %d16 %d29 $0x00 -> %q7
+2e7d0207 : uaddl v7.4s, v16.4h, v29.4h              : uaddl  %d16 %d29 $0x01 -> %q7
+2ebd0207 : uaddl v7.2d, v16.2s, v29.2s              : uaddl  %d16 %d29 $0x02 -> %q7
+
+6e220270 : uaddl2 v16.8h, v19.16b, v2.16b           : uaddl2 %q19 %q2 $0x00 -> %q16
+6e620270 : uaddl2 v16.4s, v19.8h, v2.8h             : uaddl2 %q19 %q2 $0x01 -> %q16
+6ea20270 : uaddl2 v16.2d, v19.4s, v2.4s             : uaddl2 %q19 %q2 $0x02 -> %q16
+
+2e2c11cf : uaddw v15.8h, v14.8h, v12.8b             : uaddw  %q14 %d12 $0x00 -> %q15
+2e6c11cf : uaddw v15.4s, v14.4s, v12.4h             : uaddw  %q14 %d12 $0x01 -> %q15
+2eac11cf : uaddw v15.2d, v14.2d, v12.2s             : uaddw  %q14 %d12 $0x02 -> %q15
+
+6e31124d : uaddw2 v13.8h, v18.8h, v17.16b           : uaddw2 %q18 %q17 $0x00 -> %q13
+6e71124d : uaddw2 v13.4s, v18.4s, v17.8h            : uaddw2 %q18 %q17 $0x01 -> %q13
+6eb1124d : uaddw2 v13.2d, v18.2d, v17.4s            : uaddw2 %q18 %q17 $0x02 -> %q13
+
+53031041 : ubfx   w1, w2, #3, #2          : ubfm   %w2 $0x03 $0x04 -> %w1
+d3431041 : ubfx   x1, x2, #3, #2          : ubfm   %x2 $0x03 $0x04 -> %x1
+
+1e03f105 : ucvtf s5, w8, #4                         : ucvtf  %w8 $0x04 -> %s5
+9e03c0ed : ucvtf s13, x7, #16                       : ucvtf  %x7 $0x10 -> %s13
+1e438011 : ucvtf d17, w0, #32                       : ucvtf  %w0 $0x20 -> %d17
+9e43016d : ucvtf d13, x11, #64                      : ucvtf  %x11 $0x40 -> %d13
+7e3fe509 : ucvtf s9, s8, #1                         : ucvtf  %s8 $0x01 -> %s9
+7e3ee495 : ucvtf s21, s4, #2                        : ucvtf  %s4 $0x02 -> %s21
+7e3ce674 : ucvtf s20, s19, #4                       : ucvtf  %s19 $0x04 -> %s20
+7e38e4e6 : ucvtf s6, s7, #8                         : ucvtf  %s7 $0x08 -> %s6
+7e30e7cc : ucvtf s12, s30, #16                      : ucvtf  %s30 $0x10 -> %s12
+7e20e532 : ucvtf s18, s9, #32                       : ucvtf  %s9 $0x20 -> %s18
+7e2be6b6 : ucvtf s22, s21, #21                      : ucvtf  %s21 $0x15 -> %s22
+7e21e66b : ucvtf s11, s19, #31                      : ucvtf  %s19 $0x1f -> %s11
+7e7fe56d : ucvtf d13, d11, #1                       : ucvtf  %d11 $0x01 -> %d13
+2e21d843 : ucvtf d3, d2, #2                         : ucvtf  %d2 $0x02 -> %d3
+7e7ce633 : ucvtf d19, d17, #4                       : ucvtf  %d17 $0x04 -> %d19
+7e78e53e : ucvtf d30, d9, #8                        : ucvtf  %d9 $0x08 -> %d30
+7e70e571 : ucvtf d17, d11, #16                      : ucvtf  %d11 $0x10 -> %d17
+7e60e488 : ucvtf d8, d4, #32                        : ucvtf  %d4 $0x20 -> %d8
+7e40e6bd : ucvtf d29, d21, #64                      : ucvtf  %d21 $0x40 -> %d29
+7e6be7be : ucvtf d30, d29, #21                      : ucvtf  %d29 $0x15 -> %d30
+7e56e5b1 : ucvtf d17, d13, #42                      : ucvtf  %d13 $0x2a -> %d17
+6f3fe420 : ucvtf v0.4s, v1.4s, #1                   : ucvtf  %q1 $0x02 $0x01 -> %q0
+6f3ee462 : ucvtf v2.4s, v3.4s, #2                   : ucvtf  %q3 $0x02 $0x02 -> %q2
+6f3ce4a4 : ucvtf v4.4s, v5.4s, #4                   : ucvtf  %q5 $0x02 $0x04 -> %q4
+6f38e4e6 : ucvtf v6.4s, v7.4s, #8                   : ucvtf  %q7 $0x02 $0x08 -> %q6
+6f30e528 : ucvtf v8.4s, v9.4s, #16                  : ucvtf  %q9 $0x02 $0x10 -> %q8
+6f20e56a : ucvtf v10.4s, v11.4s, #32                : ucvtf  %q11 $0x02 $0x20 -> %q10
+6f2be7bc : ucvtf v28.4s, v29.4s, #21                : ucvtf  %q29 $0x02 $0x15 -> %q28
+6f21e7fe : ucvtf v30.4s, v31.4s, #31                : ucvtf  %q31 $0x02 $0x1f -> %q30
+6f7fe420 : ucvtf v0.2d, v1.2d, #1                   : ucvtf  %q1 $0x03 $0x01 -> %q0
+6f7ee462 : ucvtf v2.2d, v3.2d, #2                   : ucvtf  %q3 $0x03 $0x02 -> %q2
+6f7ce4a4 : ucvtf v4.2d, v5.2d, #4                   : ucvtf  %q5 $0x03 $0x04 -> %q4
+6f78e4e6 : ucvtf v6.2d, v7.2d, #8                   : ucvtf  %q7 $0x03 $0x08 -> %q6
+6f70e528 : ucvtf v8.2d, v9.2d, #16                  : ucvtf  %q9 $0x03 $0x10 -> %q8
+6f60e56a : ucvtf v10.2d, v11.2d, #32                : ucvtf  %q11 $0x03 $0x20 -> %q10
+6f40e5ac : ucvtf v12.2d, v13.2d, #64                : ucvtf  %q13 $0x03 $0x40 -> %q12
+6f6be7bc : ucvtf v28.2d, v29.2d, #21                : ucvtf  %q29 $0x03 $0x15 -> %q28
+6f56e7fe : ucvtf v30.2d, v31.2d, #42                : ucvtf  %q31 $0x03 $0x2a -> %q30
+2f3fe420 : ucvtf v0.2s, v1.2s, #1                   : ucvtf  %d1 $0x02 $0x01 -> %d0
+2f3ee462 : ucvtf v2.2s, v3.2s, #2                   : ucvtf  %d3 $0x02 $0x02 -> %d2
+2f3ce4a4 : ucvtf v4.2s, v5.2s, #4                   : ucvtf  %d5 $0x02 $0x04 -> %d4
+2f38e4e6 : ucvtf v6.2s, v7.2s, #8                   : ucvtf  %d7 $0x02 $0x08 -> %d6
+2f30e528 : ucvtf v8.2s, v9.2s, #16                  : ucvtf  %d9 $0x02 $0x10 -> %d8
+2f20e56a : ucvtf v10.2s, v11.2s, #32                : ucvtf  %d11 $0x02 $0x20 -> %d10
+2f2be7bc : ucvtf v28.2s, v29.2s, #21                : ucvtf  %d29 $0x02 $0x15 -> %d28
+2f21e7fe : ucvtf v30.2s, v31.2s, #31                : ucvtf  %d31 $0x02 $0x1f -> %d30
+
+9ac30841 : udiv   x1, x2, x3              : udiv   %x2 %x3 -> %x1
+
+2e2904b6 : uhadd v22.8b, v5.8b, v9.8b               : uhadd  %d5 %d9 $0x00 -> %d22
+6e2904b6 : uhadd v22.16b, v5.16b, v9.16b            : uhadd  %q5 %q9 $0x00 -> %q22
+2e6904b6 : uhadd v22.4h, v5.4h, v9.4h               : uhadd  %d5 %d9 $0x01 -> %d22
+6e6904b6 : uhadd v22.8h, v5.8h, v9.8h               : uhadd  %q5 %q9 $0x01 -> %q22
+2ea904b6 : uhadd v22.2s, v5.2s, v9.2s               : uhadd  %d5 %d9 $0x02 -> %d22
+6ea904b6 : uhadd v22.4s, v5.4s, v9.4s               : uhadd  %q5 %q9 $0x02 -> %q22
+
+2e3026bc : uhsub v28.8b, v21.8b, v16.8b             : uhsub  %d21 %d16 $0x00 -> %d28
+6e3026bc : uhsub v28.16b, v21.16b, v16.16b          : uhsub  %q21 %q16 $0x00 -> %q28
+2e7026bc : uhsub v28.4h, v21.4h, v16.4h             : uhsub  %d21 %d16 $0x01 -> %d28
+6e7026bc : uhsub v28.8h, v21.8h, v16.8h             : uhsub  %q21 %q16 $0x01 -> %q28
+2eb026bc : uhsub v28.2s, v21.2s, v16.2s             : uhsub  %d21 %d16 $0x02 -> %d28
+6eb026bc : uhsub v28.4s, v21.4s, v16.4s             : uhsub  %q21 %q16 $0x02 -> %q28
+
+9ba3105f : umaddl xzr, w2, w3, x4         : umaddl %w2 %w3 %x4 -> %xzr
+
+2e3966e9 : umax v9.8b, v23.8b, v25.8b               : umax   %d23 %d25 $0x00 -> %d9
+6e3966e9 : umax v9.16b, v23.16b, v25.16b            : umax   %q23 %q25 $0x00 -> %q9
+2e7966e9 : umax v9.4h, v23.4h, v25.4h               : umax   %d23 %d25 $0x01 -> %d9
+6e7966e9 : umax v9.8h, v23.8h, v25.8h               : umax   %q23 %q25 $0x01 -> %q9
+2eb966e9 : umax v9.2s, v23.2s, v25.2s               : umax   %d23 %d25 $0x02 -> %d9
+6eb966e9 : umax v9.4s, v23.4s, v25.4s               : umax   %q23 %q25 $0x02 -> %q9
+
+2e25a764 : umaxp v4.8b, v27.8b, v5.8b               : umaxp  %d27 %d5 $0x00 -> %d4
+6e25a764 : umaxp v4.16b, v27.16b, v5.16b            : umaxp  %q27 %q5 $0x00 -> %q4
+2e65a764 : umaxp v4.4h, v27.4h, v5.4h               : umaxp  %d27 %d5 $0x01 -> %d4
+6e65a764 : umaxp v4.8h, v27.8h, v5.8h               : umaxp  %q27 %q5 $0x01 -> %q4
+2ea5a764 : umaxp v4.2s, v27.2s, v5.2s               : umaxp  %d27 %d5 $0x02 -> %d4
+6ea5a764 : umaxp v4.4s, v27.4s, v5.4s               : umaxp  %q27 %q5 $0x02 -> %q4
+
+2e2b6ecc : umin v12.8b, v22.8b, v11.8b              : umin   %d22 %d11 $0x00 -> %d12
+6e2b6ecc : umin v12.16b, v22.16b, v11.16b           : umin   %q22 %q11 $0x00 -> %q12
+2e6b6ecc : umin v12.4h, v22.4h, v11.4h              : umin   %d22 %d11 $0x01 -> %d12
+6e6b6ecc : umin v12.8h, v22.8h, v11.8h              : umin   %q22 %q11 $0x01 -> %q12
+2eab6ecc : umin v12.2s, v22.2s, v11.2s              : umin   %d22 %d11 $0x02 -> %d12
+6eab6ecc : umin v12.4s, v22.4s, v11.4s              : umin   %q22 %q11 $0x02 -> %q12
+
+2e30aec3 : uminp v3.8b, v22.8b, v16.8b              : uminp  %d22 %d16 $0x00 -> %d3
+6e30aec3 : uminp v3.16b, v22.16b, v16.16b           : uminp  %q22 %q16 $0x00 -> %q3
+2e70aec3 : uminp v3.4h, v22.4h, v16.4h              : uminp  %d22 %d16 $0x01 -> %d3
+6e70aec3 : uminp v3.8h, v22.8h, v16.8h              : uminp  %q22 %q16 $0x01 -> %q3
+2eb0aec3 : uminp v3.2s, v22.2s, v16.2s              : uminp  %d22 %d16 $0x02 -> %d3
+6eb0aec3 : uminp v3.4s, v22.4s, v16.4s              : uminp  %q22 %q16 $0x02 -> %q3
+
+2e218396 : umlal v22.8h, v28.8b, v1.8b              : umlal  %d28 %d1 $0x00 -> %q22
+2e618396 : umlal v22.4s, v28.4h, v1.4h              : umlal  %d28 %d1 $0x01 -> %q22
+2ea18396 : umlal v22.2d, v28.2s, v1.2s              : umlal  %d28 %d1 $0x02 -> %q22
+
+6e3e831d : umlal2 v29.8h, v24.16b, v30.16b          : umlal2 %q24 %q30 $0x00 -> %q29
+6e7e831d : umlal2 v29.4s, v24.8h, v30.8h            : umlal2 %q24 %q30 $0x01 -> %q29
+6ebe831d : umlal2 v29.2d, v24.4s, v30.4s            : umlal2 %q24 %q30 $0x02 -> %q29
+
+2e35a13f : umlsl v31.8h, v9.8b, v21.8b              : umlsl  %d9 %d21 $0x00 -> %q31
+2e75a13f : umlsl v31.4s, v9.4h, v21.4h              : umlsl  %d9 %d21 $0x01 -> %q31
+2eb5a13f : umlsl v31.2d, v9.2s, v21.2s              : umlsl  %d9 %d21 $0x02 -> %q31
+
+6e3da264 : umlsl2 v4.8h, v19.16b, v29.16b           : umlsl2 %q19 %q29 $0x00 -> %q4
+6e7da264 : umlsl2 v4.4s, v19.8h, v29.8h             : umlsl2 %q19 %q29 $0x01 -> %q4
+6ebda264 : umlsl2 v4.2d, v19.4s, v29.4s             : umlsl2 %q19 %q29 $0x02 -> %q4
+
+9ba39041 : umsubl x1, w2, w3, x4          : umsubl %w2 %w3 %x4 -> %x1
+
+9bc31041 : umulh  x1, x2, x3              : umulh  %x2 %x3 $0x04 -> %x1
+
+2e22c166 : umull v6.8h, v11.8b, v2.8b               : umull  %d11 %d2 $0x00 -> %q6
+2e62c166 : umull v6.4s, v11.4h, v2.4h               : umull  %d11 %d2 $0x01 -> %q6
+2ea2c166 : umull v6.2d, v11.2s, v2.2s               : umull  %d11 %d2 $0x02 -> %q6
+
+6e23c0c6 : umull2 v6.8h, v6.16b, v3.16b             : umull2 %q6 %q3 $0x00 -> %q6
+6e63c0c6 : umull2 v6.4s, v6.8h, v3.8h               : umull2 %q6 %q3 $0x01 -> %q6
+6ea3c0c6 : umull2 v6.2d, v6.4s, v3.4s               : umull2 %q6 %q3 $0x02 -> %q6
+
+2e3f0fa6 : uqadd v6.8b, v29.8b, v31.8b              : uqadd  %d29 %d31 $0x00 -> %d6
+6e3f0fa6 : uqadd v6.16b, v29.16b, v31.16b           : uqadd  %q29 %q31 $0x00 -> %q6
+2e7f0fa6 : uqadd v6.4h, v29.4h, v31.4h              : uqadd  %d29 %d31 $0x01 -> %d6
+6e7f0fa6 : uqadd v6.8h, v29.8h, v31.8h              : uqadd  %q29 %q31 $0x01 -> %q6
+2ebf0fa6 : uqadd v6.2s, v29.2s, v31.2s              : uqadd  %d29 %d31 $0x02 -> %d6
+6ebf0fa6 : uqadd v6.4s, v29.4s, v31.4s              : uqadd  %q29 %q31 $0x02 -> %q6
+6eff0fa6 : uqadd v6.2d, v29.2d, v31.2d              : uqadd  %q29 %q31 $0x03 -> %q6
+043417e2 : uqadd z2.b, z31.b, z20.b                 : uqadd  %z31 %z20 $0x00 -> %z2
+047417e2 : uqadd z2.h, z31.h, z20.h                 : uqadd  %z31 %z20 $0x01 -> %z2
+04b417e2 : uqadd z2.s, z31.s, z20.s                 : uqadd  %z31 %z20 $0x02 -> %z2
+04f417e2 : uqadd z2.d, z31.d, z20.d                 : uqadd  %z31 %z20 $0x03 -> %z2
+
+2e3e5d52 : uqrshl v18.8b, v10.8b, v30.8b            : uqrshl %d10 %d30 $0x00 -> %d18
+6e3e5d52 : uqrshl v18.16b, v10.16b, v30.16b         : uqrshl %q10 %q30 $0x00 -> %q18
+2e7e5d52 : uqrshl v18.4h, v10.4h, v30.4h            : uqrshl %d10 %d30 $0x01 -> %d18
+6e7e5d52 : uqrshl v18.8h, v10.8h, v30.8h            : uqrshl %q10 %q30 $0x01 -> %q18
+2ebe5d52 : uqrshl v18.2s, v10.2s, v30.2s            : uqrshl %d10 %d30 $0x02 -> %d18
+6ebe5d52 : uqrshl v18.4s, v10.4s, v30.4s            : uqrshl %q10 %q30 $0x02 -> %q18
+6efe5d52 : uqrshl v18.2d, v10.2d, v30.2d            : uqrshl %q10 %q30 $0x03 -> %q18
+
+2e324dfb : uqshl v27.8b, v15.8b, v18.8b             : uqshl  %d15 %d18 $0x00 -> %d27
+6e324dfb : uqshl v27.16b, v15.16b, v18.16b          : uqshl  %q15 %q18 $0x00 -> %q27
+2e724dfb : uqshl v27.4h, v15.4h, v18.4h             : uqshl  %d15 %d18 $0x01 -> %d27
+6e724dfb : uqshl v27.8h, v15.8h, v18.8h             : uqshl  %q15 %q18 $0x01 -> %q27
+2eb24dfb : uqshl v27.2s, v15.2s, v18.2s             : uqshl  %d15 %d18 $0x02 -> %d27
+6eb24dfb : uqshl v27.4s, v15.4s, v18.4s             : uqshl  %q15 %q18 $0x02 -> %q27
+6ef24dfb : uqshl v27.2d, v15.2d, v18.2d             : uqshl  %q15 %q18 $0x03 -> %q27
+
+2e352f7d : uqsub v29.8b, v27.8b, v21.8b             : uqsub  %d27 %d21 $0x00 -> %d29
+6e352f7d : uqsub v29.16b, v27.16b, v21.16b          : uqsub  %q27 %q21 $0x00 -> %q29
+2e752f7d : uqsub v29.4h, v27.4h, v21.4h             : uqsub  %d27 %d21 $0x01 -> %d29
+6e752f7d : uqsub v29.8h, v27.8h, v21.8h             : uqsub  %q27 %q21 $0x01 -> %q29
+2eb52f7d : uqsub v29.2s, v27.2s, v21.2s             : uqsub  %d27 %d21 $0x02 -> %d29
+6eb52f7d : uqsub v29.4s, v27.4s, v21.4s             : uqsub  %q27 %q21 $0x02 -> %q29
+6ef52f7d : uqsub v29.2d, v27.2d, v21.2d             : uqsub  %q27 %q21 $0x03 -> %q29
 04281f42 : uqsub z2.b, z26.b, z8.b                  : uqsub  %z26 %z8 $0x00 -> %z2
 04681f42 : uqsub z2.h, z26.h, z8.h                  : uqsub  %z26 %z8 $0x01 -> %z2
 04a81f42 : uqsub z2.s, z26.s, z8.s                  : uqsub  %z26 %z8 $0x02 -> %z2
 04e81f42 : uqsub z2.d, z26.d, z8.d                  : uqsub  %z26 %z8 $0x03 -> %z2
 
-# Advanced SIMD three different
-0e3201b2 : saddl v18.8h, v13.8b, v18.8b             : saddl  %d13 %d18 $0x00 -> %q18
-0e7201b2 : saddl v18.4s, v13.4h, v18.4h             : saddl  %d13 %d18 $0x01 -> %q18
-0eb201b2 : saddl v18.2d, v13.2s, v18.2s             : saddl  %d13 %d18 $0x02 -> %q18
-4e3a0346 : saddl2 v6.8h, v26.16b, v26.16b           : saddl2 %q26 %q26 $0x00 -> %q6
-4e7a0346 : saddl2 v6.4s, v26.8h, v26.8h             : saddl2 %q26 %q26 $0x01 -> %q6
-4eba0346 : saddl2 v6.2d, v26.4s, v26.4s             : saddl2 %q26 %q26 $0x02 -> %q6
-0e3010b4 : saddw v20.8h, v5.8h, v16.8b              : saddw  %q5 %d16 $0x00 -> %q20
-0e7010b4 : saddw v20.4s, v5.4s, v16.4h              : saddw  %q5 %d16 $0x01 -> %q20
-0eb010b4 : saddw v20.2d, v5.2d, v16.2s              : saddw  %q5 %d16 $0x02 -> %q20
-4e3e10ea : saddw2 v10.8h, v7.8h, v30.16b            : saddw2 %q7 %q30 $0x00 -> %q10
-4e7e10ea : saddw2 v10.4s, v7.4s, v30.8h             : saddw2 %q7 %q30 $0x01 -> %q10
-4ebe10ea : saddw2 v10.2d, v7.2d, v30.4s             : saddw2 %q7 %q30 $0x02 -> %q10
-0e3b203f : ssubl v31.8h, v1.8b, v27.8b              : ssubl  %d1 %d27 $0x00 -> %q31
-0e7b203f : ssubl v31.4s, v1.4h, v27.4h              : ssubl  %d1 %d27 $0x01 -> %q31
-0ebb203f : ssubl v31.2d, v1.2s, v27.2s              : ssubl  %d1 %d27 $0x02 -> %q31
-4e292193 : ssubl2 v19.8h, v12.16b, v9.16b           : ssubl2 %q12 %q9 $0x00 -> %q19
-4e692193 : ssubl2 v19.4s, v12.8h, v9.8h             : ssubl2 %q12 %q9 $0x01 -> %q19
-4ea92193 : ssubl2 v19.2d, v12.4s, v9.4s             : ssubl2 %q12 %q9 $0x02 -> %q19
-0e3531d5 : ssubw v21.8h, v14.8h, v21.8b             : ssubw  %q14 %d21 $0x00 -> %q21
-0e7531d5 : ssubw v21.4s, v14.4s, v21.4h             : ssubw  %q14 %d21 $0x01 -> %q21
-0eb531d5 : ssubw v21.2d, v14.2d, v21.2s             : ssubw  %q14 %d21 $0x02 -> %q21
-4e383095 : ssubw2 v21.8h, v4.8h, v24.16b            : ssubw2 %q4 %q24 $0x00 -> %q21
-4e783095 : ssubw2 v21.4s, v4.4s, v24.8h             : ssubw2 %q4 %q24 $0x01 -> %q21
-4eb83095 : ssubw2 v21.2d, v4.2d, v24.4s             : ssubw2 %q4 %q24 $0x02 -> %q21
-0e3343ff : addhn v31.8b, v31.8h, v19.8h             : addhn  %q31 %q19 $0x00 -> %d31
-0e7343ff : addhn v31.4h, v31.4s, v19.4s             : addhn  %q31 %q19 $0x01 -> %d31
-0eb343ff : addhn v31.2s, v31.2d, v19.2d             : addhn  %q31 %q19 $0x02 -> %d31
-4e244001 : addhn2 v1.16b, v0.8h, v4.8h              : addhn2 %q0 %q4 $0x00 -> %q1
-4e644001 : addhn2 v1.8h, v0.4s, v4.4s               : addhn2 %q0 %q4 $0x01 -> %q1
-4ea44001 : addhn2 v1.4s, v0.2d, v4.2d               : addhn2 %q0 %q4 $0x02 -> %q1
-0e2b513e : sabal v30.8h, v9.8b, v11.8b              : sabal  %d9 %d11 $0x00 -> %q30
-0e6b513e : sabal v30.4s, v9.4h, v11.4h              : sabal  %d9 %d11 $0x01 -> %q30
-0eab513e : sabal v30.2d, v9.2s, v11.2s              : sabal  %d9 %d11 $0x02 -> %q30
-4e31515c : sabal2 v28.8h, v10.16b, v17.16b          : sabal2 %q10 %q17 $0x00 -> %q28
-4e71515c : sabal2 v28.4s, v10.8h, v17.8h            : sabal2 %q10 %q17 $0x01 -> %q28
-4eb1515c : sabal2 v28.2d, v10.4s, v17.4s            : sabal2 %q10 %q17 $0x02 -> %q28
-0e32604d : subhn v13.8b, v2.8h, v18.8h              : subhn  %q2 %q18 $0x00 -> %d13
-0e72604d : subhn v13.4h, v2.4s, v18.4s              : subhn  %q2 %q18 $0x01 -> %d13
-0eb2604d : subhn v13.2s, v2.2d, v18.2d              : subhn  %q2 %q18 $0x02 -> %d13
-4e2760bb : subhn2 v27.16b, v5.8h, v7.8h             : subhn2 %q5 %q7 $0x00 -> %q27
-4e6760bb : subhn2 v27.8h, v5.4s, v7.4s              : subhn2 %q5 %q7 $0x01 -> %q27
-4ea760bb : subhn2 v27.4s, v5.2d, v7.2d              : subhn2 %q5 %q7 $0x02 -> %q27
-0e2f702d : sabdl v13.8h, v1.8b, v15.8b              : sabdl  %d1 %d15 $0x00 -> %q13
-0e6f702d : sabdl v13.4s, v1.4h, v15.4h              : sabdl  %d1 %d15 $0x01 -> %q13
-0eaf702d : sabdl v13.2d, v1.2s, v15.2s              : sabdl  %d1 %d15 $0x02 -> %q13
-4e3172ba : sabdl2 v26.8h, v21.16b, v17.16b          : sabdl2 %q21 %q17 $0x00 -> %q26
-4e7172ba : sabdl2 v26.4s, v21.8h, v17.8h            : sabdl2 %q21 %q17 $0x01 -> %q26
-4eb172ba : sabdl2 v26.2d, v21.4s, v17.4s            : sabdl2 %q21 %q17 $0x02 -> %q26
-0e32809b : smlal v27.8h, v4.8b, v18.8b              : smlal  %d4 %d18 $0x00 -> %q27
-0e72809b : smlal v27.4s, v4.4h, v18.4h              : smlal  %d4 %d18 $0x01 -> %q27
-0eb2809b : smlal v27.2d, v4.2s, v18.2s              : smlal  %d4 %d18 $0x02 -> %q27
-4e23826b : smlal2 v11.8h, v19.16b, v3.16b           : smlal2 %q19 %q3 $0x00 -> %q11
-4e63826b : smlal2 v11.4s, v19.8h, v3.8h             : smlal2 %q19 %q3 $0x01 -> %q11
-4ea3826b : smlal2 v11.2d, v19.4s, v3.4s             : smlal2 %q19 %q3 $0x02 -> %q11
-0e659078 : sqdmlal v24.4s, v3.4h, v5.4h             : sqdmlal %d3 %d5 $0x01 -> %q24
-0ea59078 : sqdmlal v24.2d, v3.2s, v5.2s             : sqdmlal %d3 %d5 $0x02 -> %q24
-4e6d93d9 : sqdmlal2 v25.4s, v30.8h, v13.8h          : sqdmlal2 %q30 %q13 $0x01 -> %q25
-4ead93d9 : sqdmlal2 v25.2d, v30.4s, v13.4s          : sqdmlal2 %q30 %q13 $0x02 -> %q25
-0e28a0ed : smlsl v13.8h, v7.8b, v8.8b               : smlsl  %d7 %d8 $0x00 -> %q13
-0e68a0ed : smlsl v13.4s, v7.4h, v8.4h               : smlsl  %d7 %d8 $0x01 -> %q13
-0ea8a0ed : smlsl v13.2d, v7.2s, v8.2s               : smlsl  %d7 %d8 $0x02 -> %q13
-4e23a0b3 : smlsl2 v19.8h, v5.16b, v3.16b            : smlsl2 %q5 %q3 $0x00 -> %q19
-4e63a0b3 : smlsl2 v19.4s, v5.8h, v3.8h              : smlsl2 %q5 %q3 $0x01 -> %q19
-4ea3a0b3 : smlsl2 v19.2d, v5.4s, v3.4s              : smlsl2 %q5 %q3 $0x02 -> %q19
-0e74b0ae : sqdmlsl v14.4s, v5.4h, v20.4h            : sqdmlsl %d5 %d20 $0x01 -> %q14
-0eb4b0ae : sqdmlsl v14.2d, v5.2s, v20.2s            : sqdmlsl %d5 %d20 $0x02 -> %q14
-4e6fb31a : sqdmlsl2 v26.4s, v24.8h, v15.8h          : sqdmlsl2 %q24 %q15 $0x01 -> %q26
-4eafb31a : sqdmlsl2 v26.2d, v24.4s, v15.4s          : sqdmlsl2 %q24 %q15 $0x02 -> %q26
-0e20c1ab : smull v11.8h, v13.8b, v0.8b              : smull  %d13 %d0 $0x00 -> %q11
-0e60c1ab : smull v11.4s, v13.4h, v0.4h              : smull  %d13 %d0 $0x01 -> %q11
-0ea0c1ab : smull v11.2d, v13.2s, v0.2s              : smull  %d13 %d0 $0x02 -> %q11
-4e2ac156 : smull2 v22.8h, v10.16b, v10.16b          : smull2 %q10 %q10 $0x00 -> %q22
-4e6ac156 : smull2 v22.4s, v10.8h, v10.8h            : smull2 %q10 %q10 $0x01 -> %q22
-4eaac156 : smull2 v22.2d, v10.4s, v10.4s            : smull2 %q10 %q10 $0x02 -> %q22
-0e72d1c2 : sqdmull v2.4s, v14.4h, v18.4h            : sqdmull %d14 %d18 $0x01 -> %q2
-0eb2d1c2 : sqdmull v2.2d, v14.2s, v18.2s            : sqdmull %d14 %d18 $0x02 -> %q2
-4e75d36c : sqdmull2 v12.4s, v27.8h, v21.8h          : sqdmull2 %q27 %q21 $0x01 -> %q12
-4eb5d36c : sqdmull2 v12.2d, v27.4s, v21.4s          : sqdmull2 %q27 %q21 $0x02 -> %q12
-0e22e270 : pmull v16.8h, v19.8b, v2.8b              : pmull  %d19 %d2 $0x00 -> %q16
-0ee2e270 : pmull v16.1q, v19.1d, v2.1d              : pmull  %d19 %d2 $0x03 -> %q16
-4e22e270 : pmull2 v16.8h, v19.16b, v2.16b           : pmull2 %q19 %q2 $0x00 -> %q16
-4ee2e270 : pmull2 v16.1q, v19.2d, v2.2d             : pmull2 %q19 %q2 $0x03 -> %q16
-2e3d0207 : uaddl v7.8h, v16.8b, v29.8b              : uaddl  %d16 %d29 $0x00 -> %q7
-2e7d0207 : uaddl v7.4s, v16.4h, v29.4h              : uaddl  %d16 %d29 $0x01 -> %q7
-2ebd0207 : uaddl v7.2d, v16.2s, v29.2s              : uaddl  %d16 %d29 $0x02 -> %q7
-6e220270 : uaddl2 v16.8h, v19.16b, v2.16b           : uaddl2 %q19 %q2 $0x00 -> %q16
-6e620270 : uaddl2 v16.4s, v19.8h, v2.8h             : uaddl2 %q19 %q2 $0x01 -> %q16
-6ea20270 : uaddl2 v16.2d, v19.4s, v2.4s             : uaddl2 %q19 %q2 $0x02 -> %q16
-2e2c11cf : uaddw v15.8h, v14.8h, v12.8b             : uaddw  %q14 %d12 $0x00 -> %q15
-2e6c11cf : uaddw v15.4s, v14.4s, v12.4h             : uaddw  %q14 %d12 $0x01 -> %q15
-2eac11cf : uaddw v15.2d, v14.2d, v12.2s             : uaddw  %q14 %d12 $0x02 -> %q15
-6e31124d : uaddw2 v13.8h, v18.8h, v17.16b           : uaddw2 %q18 %q17 $0x00 -> %q13
-6e71124d : uaddw2 v13.4s, v18.4s, v17.8h            : uaddw2 %q18 %q17 $0x01 -> %q13
-6eb1124d : uaddw2 v13.2d, v18.2d, v17.4s            : uaddw2 %q18 %q17 $0x02 -> %q13
+2e3b17a8 : urhadd v8.8b, v29.8b, v27.8b             : urhadd %d29 %d27 $0x00 -> %d8
+6e3b17a8 : urhadd v8.16b, v29.16b, v27.16b          : urhadd %q29 %q27 $0x00 -> %q8
+2e7b17a8 : urhadd v8.4h, v29.4h, v27.4h             : urhadd %d29 %d27 $0x01 -> %d8
+6e7b17a8 : urhadd v8.8h, v29.8h, v27.8h             : urhadd %q29 %q27 $0x01 -> %q8
+2ebb17a8 : urhadd v8.2s, v29.2s, v27.2s             : urhadd %d29 %d27 $0x02 -> %d8
+6ebb17a8 : urhadd v8.4s, v29.4s, v27.4s             : urhadd %q29 %q27 $0x02 -> %q8
+
+2e265445 : urshl v5.8b, v2.8b, v6.8b                : urshl  %d2 %d6 $0x00 -> %d5
+6e265445 : urshl v5.16b, v2.16b, v6.16b             : urshl  %q2 %q6 $0x00 -> %q5
+2e665445 : urshl v5.4h, v2.4h, v6.4h                : urshl  %d2 %d6 $0x01 -> %d5
+6e665445 : urshl v5.8h, v2.8h, v6.8h                : urshl  %q2 %q6 $0x01 -> %q5
+2ea65445 : urshl v5.2s, v2.2s, v6.2s                : urshl  %d2 %d6 $0x02 -> %d5
+6ea65445 : urshl v5.4s, v2.4s, v6.4s                : urshl  %q2 %q6 $0x02 -> %q5
+6ee65445 : urshl v5.2d, v2.2d, v6.2d                : urshl  %q2 %q6 $0x03 -> %q5
+
+2e3244e1 : ushl v1.8b, v7.8b, v18.8b                : ushl   %d7 %d18 $0x00 -> %d1
+6e3244e1 : ushl v1.16b, v7.16b, v18.16b             : ushl   %q7 %q18 $0x00 -> %q1
+2e7244e1 : ushl v1.4h, v7.4h, v18.4h                : ushl   %d7 %d18 $0x01 -> %d1
+6e7244e1 : ushl v1.8h, v7.8h, v18.8h                : ushl   %q7 %q18 $0x01 -> %q1
+2eb244e1 : ushl v1.2s, v7.2s, v18.2s                : ushl   %d7 %d18 $0x02 -> %d1
+6eb244e1 : ushl v1.4s, v7.4s, v18.4s                : ushl   %q7 %q18 $0x02 -> %q1
+6ef244e1 : ushl v1.2d, v7.2d, v18.2d                : ushl   %q7 %q18 $0x03 -> %q1
+
 2e2e20af : usubl v15.8h, v5.8b, v14.8b              : usubl  %d5 %d14 $0x00 -> %q15
 2e6e20af : usubl v15.4s, v5.4h, v14.4h              : usubl  %d5 %d14 $0x01 -> %q15
 2eae20af : usubl v15.2d, v5.2s, v14.2s              : usubl  %d5 %d14 $0x02 -> %q15
+
 6e2121be : usubl2 v30.8h, v13.16b, v1.16b           : usubl2 %q13 %q1 $0x00 -> %q30
 6e6121be : usubl2 v30.4s, v13.8h, v1.8h             : usubl2 %q13 %q1 $0x01 -> %q30
 6ea121be : usubl2 v30.2d, v13.4s, v1.4s             : usubl2 %q13 %q1 $0x02 -> %q30
+
 2e213220 : usubw v0.8h, v17.8h, v1.8b               : usubw  %q17 %d1 $0x00 -> %q0
 2e613220 : usubw v0.4s, v17.4s, v1.4h               : usubw  %q17 %d1 $0x01 -> %q0
 2ea13220 : usubw v0.2d, v17.2d, v1.2s               : usubw  %q17 %d1 $0x02 -> %q0
+
 6e2e3062 : usubw2 v2.8h, v3.8h, v14.16b             : usubw2 %q3 %q14 $0x00 -> %q2
 6e6e3062 : usubw2 v2.4s, v3.4s, v14.8h              : usubw2 %q3 %q14 $0x01 -> %q2
 6eae3062 : usubw2 v2.2d, v3.2d, v14.4s              : usubw2 %q3 %q14 $0x02 -> %q2
-2e2e41ff : raddhn v31.8b, v15.8h, v14.8h            : raddhn %q15 %q14 $0x00 -> %d31
-2e6e41ff : raddhn v31.4h, v15.4s, v14.4s            : raddhn %q15 %q14 $0x01 -> %d31
-2eae41ff : raddhn v31.2s, v15.2d, v14.2d            : raddhn %q15 %q14 $0x02 -> %d31
-6e2e420d : raddhn2 v13.16b, v16.8h, v14.8h          : raddhn2 %q16 %q14 $0x00 -> %q13
-6e6e420d : raddhn2 v13.8h, v16.4s, v14.4s           : raddhn2 %q16 %q14 $0x01 -> %q13
-6eae420d : raddhn2 v13.4s, v16.2d, v14.2d           : raddhn2 %q16 %q14 $0x02 -> %q13
-2e365397 : uabal v23.8h, v28.8b, v22.8b             : uabal  %d28 %d22 $0x00 -> %q23
-2e765397 : uabal v23.4s, v28.4h, v22.4h             : uabal  %d28 %d22 $0x01 -> %q23
-2eb65397 : uabal v23.2d, v28.2s, v22.2s             : uabal  %d28 %d22 $0x02 -> %q23
-6e3d528d : uabal2 v13.8h, v20.16b, v29.16b          : uabal2 %q20 %q29 $0x00 -> %q13
-6e7d528d : uabal2 v13.4s, v20.8h, v29.8h            : uabal2 %q20 %q29 $0x01 -> %q13
-6ebd528d : uabal2 v13.2d, v20.4s, v29.4s            : uabal2 %q20 %q29 $0x02 -> %q13
-2e3360e4 : rsubhn v4.8b, v7.8h, v19.8h              : rsubhn %q7 %q19 $0x00 -> %d4
-2e7360e4 : rsubhn v4.4h, v7.4s, v19.4s              : rsubhn %q7 %q19 $0x01 -> %d4
-2eb360e4 : rsubhn v4.2s, v7.2d, v19.2d              : rsubhn %q7 %q19 $0x02 -> %d4
-6e326295 : rsubhn2 v21.16b, v20.8h, v18.8h          : rsubhn2 %q20 %q18 $0x00 -> %q21
-6e726295 : rsubhn2 v21.8h, v20.4s, v18.4s           : rsubhn2 %q20 %q18 $0x01 -> %q21
-6eb26295 : rsubhn2 v21.4s, v20.2d, v18.2d           : rsubhn2 %q20 %q18 $0x02 -> %q21
-2e3971fa : uabdl v26.8h, v15.8b, v25.8b             : uabdl  %d15 %d25 $0x00 -> %q26
-2e7971fa : uabdl v26.4s, v15.4h, v25.4h             : uabdl  %d15 %d25 $0x01 -> %q26
-2eb971fa : uabdl v26.2d, v15.2s, v25.2s             : uabdl  %d15 %d25 $0x02 -> %q26
-6e3b71be : uabdl2 v30.8h, v13.16b, v27.16b          : uabdl2 %q13 %q27 $0x00 -> %q30
-6e7b71be : uabdl2 v30.4s, v13.8h, v27.8h            : uabdl2 %q13 %q27 $0x01 -> %q30
-6ebb71be : uabdl2 v30.2d, v13.4s, v27.4s            : uabdl2 %q13 %q27 $0x02 -> %q30
-2e218396 : umlal v22.8h, v28.8b, v1.8b              : umlal  %d28 %d1 $0x00 -> %q22
-2e618396 : umlal v22.4s, v28.4h, v1.4h              : umlal  %d28 %d1 $0x01 -> %q22
-2ea18396 : umlal v22.2d, v28.2s, v1.2s              : umlal  %d28 %d1 $0x02 -> %q22
-6e3e831d : umlal2 v29.8h, v24.16b, v30.16b          : umlal2 %q24 %q30 $0x00 -> %q29
-6e7e831d : umlal2 v29.4s, v24.8h, v30.8h            : umlal2 %q24 %q30 $0x01 -> %q29
-6ebe831d : umlal2 v29.2d, v24.4s, v30.4s            : umlal2 %q24 %q30 $0x02 -> %q29
-2e35a13f : umlsl v31.8h, v9.8b, v21.8b              : umlsl  %d9 %d21 $0x00 -> %q31
-2e75a13f : umlsl v31.4s, v9.4h, v21.4h              : umlsl  %d9 %d21 $0x01 -> %q31
-2eb5a13f : umlsl v31.2d, v9.2s, v21.2s              : umlsl  %d9 %d21 $0x02 -> %q31
-6e3da264 : umlsl2 v4.8h, v19.16b, v29.16b           : umlsl2 %q19 %q29 $0x00 -> %q4
-6e7da264 : umlsl2 v4.4s, v19.8h, v29.8h             : umlsl2 %q19 %q29 $0x01 -> %q4
-6ebda264 : umlsl2 v4.2d, v19.4s, v29.4s             : umlsl2 %q19 %q29 $0x02 -> %q4
-2e22c166 : umull v6.8h, v11.8b, v2.8b               : umull  %d11 %d2 $0x00 -> %q6
-2e62c166 : umull v6.4s, v11.4h, v2.4h               : umull  %d11 %d2 $0x01 -> %q6
-2ea2c166 : umull v6.2d, v11.2s, v2.2s               : umull  %d11 %d2 $0x02 -> %q6
-6e23c0c6 : umull2 v6.8h, v6.16b, v3.16b             : umull2 %q6 %q3 $0x00 -> %q6
-6e63c0c6 : umull2 v6.4s, v6.8h, v3.8h               : umull2 %q6 %q3 $0x01 -> %q6
-6ea3c0c6 : umull2 v6.2d, v6.4s, v3.4s               : umull2 %q6 %q3 $0x02 -> %q6
+
+d503205f : wfe                            : wfe
+
+d503207f : wfi                            : wfi
+
+d503203f : yield                          : yield


### PR DESCRIPTION
Ordering dis-a64.txt alphabetically by instruction name will make it
much easier to navigate and detect missing or erroneous tests.

Issue: #2626, #4847, #4848, #4849