### PR TITLE
i#4892: Update basename pointer when path buffer changes

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -995,16 +995,6 @@ get_application_pid()
     return get_application_pid_helper(false);
 }
 
-/* i#907: Called during early injection before data section protection to avoid
- * issues with /proc/self/exe.
- */
-void
-set_executable_path(const char *exe_path)
-{
-    strncpy(executable_path, exe_path, BUFFER_SIZE_ELEMENTS(executable_path));
-    NULL_TERMINATE_BUFFER(executable_path);
-}
-
 /* The OSX kernel used to place the bare executable path above envp.
  * On recent XNU versions, the kernel now prefixes the executable path
  * with the string executable_path= so it can be parsed getenv style.
@@ -1083,6 +1073,18 @@ char *
 get_application_name(void)
 {
     return get_application_name_helper(false, true /* full path */);
+}
+
+/* i#907: Called during early injection before data section protection to avoid
+ * issues with /proc/self/exe.
+ */
+void
+set_executable_path(const char *exe_path)
+{
+    strncpy(executable_path, exe_path, BUFFER_SIZE_ELEMENTS(executable_path));
+    NULL_TERMINATE_BUFFER(executable_path);
+    /* Re-compute the basename in case the full path changed. */
+    get_application_name_helper(true /* re-compute */, false /* basename */);
 }
 
 /* Note: this is exported so that libdrpreload.so (preload.c) can use it to

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3877,12 +3877,15 @@ if (UNIX)
         # We can't get the depends property right b/c execve32 has no prefix,
         # so we do this one directly too.
         add_exe(linux.execve64 linux/execve.c)
+        # Use a relative path for the child's execve to stress i#1660, i#4892.
+        file(RELATIVE_PATH relative_sub32 "${CMAKE_CURRENT_BINARY_DIR}"
+          "${32dir}/${test_bindir}/linux.execve-sub32")
         add_test(linux.execve64 ${drrun_path} ${dr_test_ops}
           # We test the "-c32 -c64" syntax for the other direction.
           -c32 ${client32_path} -paramA foo -paramB bar --
           -c64 ${client64_path} -paramA foo -paramB bar --
           ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/linux.execve64
-          "${32dir}/${test_bindir}/linux.execve-sub32")
+          "${relative_sub32}")
         set_tests_properties(linux.execve64 PROPERTIES DEPENDS linux.execve32
           PASS_REGULAR_EXPRESSION "^${expect}$")
       endif ()

--- a/suite/tests/client-interface/large_options.dll.c
+++ b/suite/tests/client-interface/large_options.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,6 +40,9 @@
  */
 
 #include "dr_api.h"
+#ifdef UNIX
+#    include <string.h>
+#endif
 
 static void
 event_exit(void)
@@ -51,6 +54,12 @@ DR_EXPORT void
 dr_init(client_id_t client_id)
 {
     const char *opts = dr_get_options(client_id);
+#ifdef UNIX
+    /* Test i#4892. */
+    if (strchr(dr_get_application_name(), '/')) {
+        dr_fprintf(STDERR, "dr_get_application_name() has slashes!\n");
+    }
+#endif
     dr_fprintf(STDERR, "large_options passed: %s\n", opts);
     dr_register_exit_event(event_exit);
 }


### PR DESCRIPTION
Fixes a regression from the #1660 fix which changes the
executable_path buffer after most initialization, yet fails to update
the executable_basename pointer into that same buffer.

Adds a test by changing the linux.execve64 test to use a relative path
for the sub-path, and having that client check for slashes in
dr_get_application_name().  Confirmed the new test fails without this fix.

Issue: #1660, #4892
Fixes #4892