### PR TITLE
i#4896: Consider 32-bit-reg writes to cover AArch64 reg

### DIFF
--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -413,10 +413,12 @@ drreg_event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_tr
                 value = REG_LIVE;
             /* make sure we don't consider writes to sub-regs */
             else if (instr_writes_to_exact_reg(inst, reg, DR_QUERY_INCLUDE_COND_SRCS)
-                     /* a write to a 32-bit reg for amd64 zeroes the top 32 bits */
-                     IF_X86_64(||
-                               instr_writes_to_exact_reg(inst, reg_64_to_32(reg),
-                                                         DR_QUERY_INCLUDE_COND_SRCS)))
+                     /* A write to a 32-bit reg zeroes the top 32 bits for x86_64 and
+                      * aarch64.
+                      */
+                     IF_X64(||
+                            instr_writes_to_exact_reg(inst, reg_64_to_32(reg),
+                                                      DR_QUERY_INCLUDE_COND_SRCS)))
                 value = REG_DEAD;
             else if (xfer)
                 value = REG_LIVE;
@@ -795,10 +797,12 @@ drreg_forward_analysis(void *drcontext, instr_t *start)
                 value = REG_LIVE;
             /* make sure we don't consider writes to sub-regs */
             else if (instr_writes_to_exact_reg(inst, reg, DR_QUERY_INCLUDE_COND_SRCS)
-                     /* a write to a 32-bit reg for amd64 zeroes the top 32 bits */
-                     IF_X86_64(||
-                               instr_writes_to_exact_reg(inst, reg_64_to_32(reg),
-                                                         DR_QUERY_INCLUDE_COND_SRCS)))
+                     /* A write to a 32-bit reg zeroes the top 32 bits for x86_64 and
+                      * aarch64.
+                      */
+                     IF_X64(||
+                            instr_writes_to_exact_reg(inst, reg_64_to_32(reg),
+                                                      DR_QUERY_INCLUDE_COND_SRCS)))
                 value = REG_DEAD;
             if (value != REG_UNKNOWN)
                 drvector_set_entry(&pt->reg[GPR_IDX(reg)].live, 0, value);


### PR DESCRIPTION
AArch64 behaves like x86 with respect to writing to a 32-bit register:
the top 32 bits are zeroed.  Thus, drreg can consider such a write to
make the whole register dead.

Tested on a large proprietary application where drreg liveness errors
recently caused various problems (#4898).

Fixes #4896