### PR TITLE
i#4905: Add thread id to assert message

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -179,13 +179,14 @@ d_r_internal_error(const char *file, int line, const char *expr)
     report_dynamorio_problem(NULL, DUMPCORE_ASSERTION, NULL, NULL,
                              PRODUCT_NAME " debug check failure: %s:%d %s"
 #    if defined(DEBUG) && defined(INTERNAL)
-                                          "\n(Error occurred @%d frags)"
+                                          "\n(Error occurred @%d frags in tid " TIDFMT ")"
 #    endif
                              ,
                              file, line, expr
 #    if defined(DEBUG) && defined(INTERNAL)
                              ,
-                             d_r_stats == NULL ? -1 : GLOBAL_STAT(num_fragments)
+                             d_r_stats == NULL ? -1 : GLOBAL_STAT(num_fragments),
+                             IF_UNIX_ELSE(get_sys_thread_id(), d_r_get_thread_id())
 #    endif
     );
 


### PR DESCRIPTION
In debug build, prints out the thread id in the assert message, to
make it easier to debug.

Tested by temporarily inserting an assert:

  <Application .../simple_app (3642802).  Internal Error: DynamoRIO debug check failure: .../src/core/dynamo.c:763 false
  (Error occurred @0 frags in tid 3642802)

Fixes #4905