### PR TITLE
i#2985 scatter-gather: Fix drcachesim and raw2trace issues.

### DIFF
--- a/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
@@ -4,6 +4,7 @@ Basic counts tool results:
 Total counts:
           14 total \(fetched\) instructions
           14 total unique \(fetched\) instructions
+/* One for each movs after the first one. */
            4 total non-fetched instructions
            0 total prefetches
            5 total data loads

--- a/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
@@ -1,14 +1,14 @@
-Correct
-Hello world!
+Adios world!
+---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
-          43 total \(fetched\) instructions
-          43 total unique \(fetched\) instructions
-/* One for each store/load in expanded scatter/gather seq. */
-           6 total non-fetched instructions
+          14 total \(fetched\) instructions
+          14 total unique \(fetched\) instructions
+/* One for each movs after the first one */
+           4 total non-fetched instructions
            0 total prefetches
-           3 total data loads
-           3 total data stores
+           5 total data loads
+           5 total data stores
            0 total icache flushes
            0 total dcache flushes
            1 total threads
@@ -20,12 +20,12 @@ Total counts:
      .* total function return value markers
      .* total other markers
 Thread .* counts:
-          43 \(fetched\) instructions
-          43 unique \(fetched\) instructions
-           6 non-fetched instructions
+          14 \(fetched\) instructions
+          14 unique \(fetched\) instructions
+           4 non-fetched instructions
            0 prefetches
-           3 data loads
-           3 data stores
+           5 data loads
+           5 data stores
            0 icache flushes
            0 dcache flushes
      .* scheduling markers

--- a/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
@@ -4,8 +4,7 @@ Basic counts tool results:
 Total counts:
           14 total \(fetched\) instructions
           14 total unique \(fetched\) instructions
-/* One for each movs after the first one */
-           4 total non-fetched instructions
+           0 total non-fetched instructions
            0 total prefetches
            5 total data loads
            5 total data stores
@@ -22,7 +21,7 @@ Total counts:
 Thread .* counts:
           14 \(fetched\) instructions
           14 unique \(fetched\) instructions
-           4 non-fetched instructions
+           0 non-fetched instructions
            0 prefetches
            5 data loads
            5 data stores

--- a/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
@@ -4,7 +4,7 @@ Basic counts tool results:
 Total counts:
           14 total \(fetched\) instructions
           14 total unique \(fetched\) instructions
-           0 total non-fetched instructions
+           4 total non-fetched instructions
            0 total prefetches
            5 total data loads
            5 total data stores
@@ -21,7 +21,7 @@ Total counts:
 Thread .* counts:
           14 \(fetched\) instructions
           14 unique \(fetched\) instructions
-           0 non-fetched instructions
+           4 non-fetched instructions
            0 prefetches
            5 data loads
            5 data stores

--- a/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
@@ -1,5 +1,6 @@
 Correct
 Hello world!
+---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
           43 total \(fetched\) instructions

--- a/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
@@ -6,7 +6,11 @@ Total counts:
           43 total \(fetched\) instructions
           43 total unique \(fetched\) instructions
 /* One for each store/load in expanded scatter/gather seq. */
+#ifdef __AVX512F__
            6 total non-fetched instructions
+#else
+           3 total non-fetched instructions
+#endif
            0 total prefetches
            3 total data loads
            3 total data stores
@@ -23,7 +27,11 @@ Total counts:
 Thread .* counts:
           43 \(fetched\) instructions
           43 unique \(fetched\) instructions
+#ifdef __AVX512F__
            6 non-fetched instructions
+#else
+           3 non-fetched instructions
+#endif
            0 prefetches
            3 data loads
            3 data stores

--- a/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
@@ -5,12 +5,7 @@ Basic counts tool results:
 Total counts:
           43 total \(fetched\) instructions
           43 total unique \(fetched\) instructions
-/* One for each store/load in expanded scatter/gather seq. */
-#ifdef __AVX512F__
-           6 total non-fetched instructions
-#else
-           3 total non-fetched instructions
-#endif
+           0 total non-fetched instructions
            0 total prefetches
            3 total data loads
            3 total data stores
@@ -27,11 +22,7 @@ Total counts:
 Thread .* counts:
           43 \(fetched\) instructions
           43 unique \(fetched\) instructions
-#ifdef __AVX512F__
-           6 non-fetched instructions
-#else
-           3 non-fetched instructions
-#endif
+           0 non-fetched instructions
            0 prefetches
            3 data loads
            3 data stores

--- a/clients/drcachesim/tests/allasm_repstr.asm
+++ b/clients/drcachesim/tests/allasm_repstr.asm
@@ -56,6 +56,7 @@ _start:
         mov      rdi, 0           // exit code
         mov      eax, 231         // SYS_exit_group
         syscall
+
         .data
         .align   8
 hello_str:

--- a/clients/drcachesim/tests/allasm_repstr.asm
+++ b/clients/drcachesim/tests/allasm_repstr.asm
@@ -1,0 +1,64 @@
+ /* **********************************************************
+ * Copyright (c) 2021 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* This is a statically-linked app. */
+.text
+.globl _start
+.type _start, @function
+        .align   8
+_start:
+        // Align stack pointer to cache line.
+        and      rsp, -16
+
+        mov      ecx, 5
+        lea      esi, bye_str
+        lea      edi, hello_str
+        cld
+        rep      movsb
+
+        // Print end message.
+        mov      rdi, 1           // stdout
+        lea      rsi, hello_str
+        mov      rdx, 13          // sizeof(hello_str)
+        mov      eax, 1           // SYS_write
+        syscall
+
+        // Exit.
+        mov      rdi, 0           // exit code
+        mov      eax, 231         // SYS_exit_group
+        syscall
+        .data
+        .align   8
+hello_str:
+        .string  "Hello world!\n"
+bye_str:
+        .string  "Adios\n"

--- a/clients/drcachesim/tests/allasm_scattergather.asm
+++ b/clients/drcachesim/tests/allasm_scattergather.asm
@@ -115,6 +115,7 @@ done_cmp:
         mov      rdi, 0           // exit code
         mov      eax, 231         // SYS_exit_group
         syscall
+
         .data
         .align   8
 hello_str:

--- a/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
@@ -3,6 +3,7 @@ Basic counts tool results:
 Total counts:
           14 total \(fetched\) instructions
           14 total unique \(fetched\) instructions
+/* One for each movs after the first one. */
            4 total non-fetched instructions
            0 total prefetches
            5 total data loads

--- a/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
@@ -3,7 +3,7 @@ Basic counts tool results:
 Total counts:
           14 total \(fetched\) instructions
           14 total unique \(fetched\) instructions
-           0 total non-fetched instructions
+           4 total non-fetched instructions
            0 total prefetches
            5 total data loads
            5 total data stores
@@ -20,7 +20,7 @@ Total counts:
 Thread .* counts:
           14 \(fetched\) instructions
           14 unique \(fetched\) instructions
-           0 non-fetched instructions
+           4 non-fetched instructions
            0 prefetches
            5 data loads
            5 data stores

--- a/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
@@ -3,8 +3,7 @@ Basic counts tool results:
 Total counts:
           14 total \(fetched\) instructions
           14 total unique \(fetched\) instructions
-/* One for each movs after the first one */
-           4 total non-fetched instructions
+           0 total non-fetched instructions
            0 total prefetches
            5 total data loads
            5 total data stores
@@ -21,7 +20,7 @@ Total counts:
 Thread .* counts:
           14 \(fetched\) instructions
           14 unique \(fetched\) instructions
-           4 non-fetched instructions
+           0 non-fetched instructions
            0 prefetches
            5 data loads
            5 data stores

--- a/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
@@ -1,14 +1,13 @@
-Correct
-Hello world!
+Adios world!
 Basic counts tool results:
 Total counts:
-          43 total \(fetched\) instructions
-          43 total unique \(fetched\) instructions
-/* One for each store/load in expanded scatter/gather seq. */
-           6 total non-fetched instructions
+          14 total \(fetched\) instructions
+          14 total unique \(fetched\) instructions
+/* One for each movs after the first one */
+           4 total non-fetched instructions
            0 total prefetches
-           3 total data loads
-           3 total data stores
+           5 total data loads
+           5 total data stores
            0 total icache flushes
            0 total dcache flushes
            1 total threads
@@ -20,12 +19,12 @@ Total counts:
      .* total function return value markers
      .* total other markers
 Thread .* counts:
-          43 \(fetched\) instructions
-          43 unique \(fetched\) instructions
-           6 non-fetched instructions
+          14 \(fetched\) instructions
+          14 unique \(fetched\) instructions
+           4 non-fetched instructions
            0 prefetches
-           3 data loads
-           3 data stores
+           5 data loads
+           5 data stores
            0 icache flushes
            0 dcache flushes
      .* scheduling markers

--- a/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
@@ -4,12 +4,7 @@ Basic counts tool results:
 Total counts:
           43 total \(fetched\) instructions
           43 total unique \(fetched\) instructions
-/* One for each store/load in expanded scatter/gather seq. */
-#ifdef __AVX512F__
-           6 total non-fetched instructions
-#else
-           3 total non-fetched instructions
-#endif
+           0 total non-fetched instructions
            0 total prefetches
            3 total data loads
            3 total data stores
@@ -26,11 +21,7 @@ Total counts:
 Thread .* counts:
           43 \(fetched\) instructions
           43 unique \(fetched\) instructions
-#ifdef __AVX512F__
-           6 non-fetched instructions
-#else
-           3 non-fetched instructions
-#endif
+           0 non-fetched instructions
            0 prefetches
            3 data loads
            3 data stores

--- a/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
@@ -5,7 +5,11 @@ Total counts:
           43 total \(fetched\) instructions
           43 total unique \(fetched\) instructions
 /* One for each store/load in expanded scatter/gather seq. */
+#ifdef __AVX512F__
            6 total non-fetched instructions
+#else
+           3 total non-fetched instructions
+#endif
            0 total prefetches
            3 total data loads
            3 total data stores
@@ -22,7 +26,11 @@ Total counts:
 Thread .* counts:
           43 \(fetched\) instructions
           43 unique \(fetched\) instructions
+#ifdef __AVX512F__
            6 non-fetched instructions
+#else
+           3 non-fetched instructions
+#endif
            0 prefetches
            3 data loads
            3 data stores

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -70,10 +70,13 @@ instru_t::instr_to_instr_type(instr_t *instr, bool repstr_expanded)
         return TRACE_TYPE_INSTR_SYSENTER;
 #endif
     // i#2051: to satisfy both cache and core simulators we mark subsequent iters
-    // of string loops as TRACE_TYPE_INSTR_NO_FETCH, converted from this
+    // of string loops and writes/reads of expanded scatter/gather instrs as
+    // TRACE_TYPE_INSTR_NO_FETCH, converted from this
     // TRACE_TYPE_INSTR_MAYBE_FETCH by reader_t (since online traces would need
-    // extra insru to distinguish the 1st and subsequent iters).
+    // extra instru to distinguish the 1st and subsequent iters).
     if (instr_is_rep_string_op(instr) || (repstr_expanded && instr_is_string_op(instr)))
+        return TRACE_TYPE_INSTR_MAYBE_FETCH;
+    if (instr_is_scatter(instr) || instr_is_gather(instr))
         return TRACE_TYPE_INSTR_MAYBE_FETCH;
     return TRACE_TYPE_INSTR;
 }

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -76,8 +76,11 @@ instru_t::instr_to_instr_type(instr_t *instr, bool repstr_expanded)
     // extra instru to distinguish the 1st and subsequent iters).
     if (instr_is_rep_string_op(instr) || (repstr_expanded && instr_is_string_op(instr)))
         return TRACE_TYPE_INSTR_MAYBE_FETCH;
+#ifdef X86
+    // TODO: NYI on ARM.
     if (instr_is_scatter(instr) || instr_is_gather(instr))
         return TRACE_TYPE_INSTR_MAYBE_FETCH;
+#endif
     return TRACE_TYPE_INSTR;
 }
 

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -70,17 +70,11 @@ instru_t::instr_to_instr_type(instr_t *instr, bool repstr_expanded)
         return TRACE_TYPE_INSTR_SYSENTER;
 #endif
     // i#2051: to satisfy both cache and core simulators we mark subsequent iters
-    // of string loops and writes/reads of expanded scatter/gather instrs as
-    // TRACE_TYPE_INSTR_NO_FETCH, converted from this
+    // of string loops as TRACE_TYPE_INSTR_NO_FETCH, converted from this
     // TRACE_TYPE_INSTR_MAYBE_FETCH by reader_t (since online traces would need
     // extra instru to distinguish the 1st and subsequent iters).
     if (instr_is_rep_string_op(instr) || (repstr_expanded && instr_is_string_op(instr)))
         return TRACE_TYPE_INSTR_MAYBE_FETCH;
-#ifdef X86
-    // TODO: NYI on ARM.
-    if (instr_is_scatter(instr) || instr_is_gather(instr))
-        return TRACE_TYPE_INSTR_MAYBE_FETCH;
-#endif
     return TRACE_TYPE_INSTR;
 }
 

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -234,7 +234,7 @@ public:
 
     virtual void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                bool repstr_expanded) = 0;
+                bool repstr_expanded, bool scatter_gather_expanded) = 0;
 
     // Utilities.
 #ifdef AARCH64
@@ -331,7 +331,7 @@ public:
 
     void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                bool repstr_expanded) override;
+                bool repstr_expanded, bool scatter_gather_expanded) override;
 
 private:
     void
@@ -398,7 +398,7 @@ public:
 
     void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                bool repstr_expanded) override;
+                bool repstr_expanded, bool scatter_gather_expanded) override;
 
     static bool
     custom_module_data(void *(*load_cb)(module_data_t *module, int seg_idx),
@@ -413,7 +413,8 @@ public:
     // Inserts labels marking elidable addresses. label_marks_elidable() identifies them.
     // "version" is an OFFLINE_FILE_VERSION* constant.
     void
-    identify_elidable_addresses(void *drcontext, instrlist_t *ilist, int version);
+    identify_elidable_addresses(void *drcontext, instrlist_t *ilist, int version,
+                                bool has_scatter_gather_instr);
     bool
     label_marks_elidable(instr_t *instr, OUT int *opnd_index, OUT int *memopnd_index,
                          OUT bool *is_write, OUT bool *needs_base);

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -226,7 +226,8 @@ public:
                       int ref_index, bool write, dr_pred_type_t pred) = 0;
     virtual int
     instrument_instr(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app) = 0;
+                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app,
+                     bool scatter_gather_expanded, bool repstr_expanded) = 0;
     virtual int
     instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t *where,
                        reg_id_t reg_ptr, int adjust, instr_t **delay_instrs,
@@ -323,7 +324,8 @@ public:
                       int ref_index, bool write, dr_pred_type_t pred) override;
     int
     instrument_instr(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app) override;
+                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app,
+                     bool scatter_gather_expanded, bool repstr_expanded) override;
     int
     instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t *where,
                        reg_id_t reg_ptr, int adjust, instr_t **delay_instrs,
@@ -390,7 +392,8 @@ public:
                       int ref_index, bool write, dr_pred_type_t pred) override;
     int
     instrument_instr(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app) override;
+                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app,
+                     bool scatter_gather_expanded, bool repstr_expanded) override;
     int
     instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t *where,
                        reg_id_t reg_ptr, int adjust, instr_t **delay_instrs,

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -226,8 +226,7 @@ public:
                       int ref_index, bool write, dr_pred_type_t pred) = 0;
     virtual int
     instrument_instr(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app,
-                     bool scatter_gather_expanded, bool repstr_expanded) = 0;
+                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app) = 0;
     virtual int
     instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t *where,
                        reg_id_t reg_ptr, int adjust, instr_t **delay_instrs,
@@ -324,8 +323,7 @@ public:
                       int ref_index, bool write, dr_pred_type_t pred) override;
     int
     instrument_instr(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app,
-                     bool scatter_gather_expanded, bool repstr_expanded) override;
+                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app) override;
     int
     instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t *where,
                        reg_id_t reg_ptr, int adjust, instr_t **delay_instrs,
@@ -392,8 +390,7 @@ public:
                       int ref_index, bool write, dr_pred_type_t pred) override;
     int
     instrument_instr(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app,
-                     bool scatter_gather_expanded, bool repstr_expanded) override;
+                     instr_t *where, reg_id_t reg_ptr, int adjust, instr_t *app) override;
     int
     instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t *where,
                        reg_id_t reg_ptr, int adjust, instr_t **delay_instrs,

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -234,7 +234,7 @@ public:
 
     virtual void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                bool repstr_expanded, bool scatter_gather_expanded) = 0;
+                bool repstr_expanded) = 0;
 
     // Utilities.
 #ifdef AARCH64
@@ -331,7 +331,7 @@ public:
 
     void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                bool repstr_expanded, bool scatter_gather_expanded) override;
+                bool repstr_expanded) override;
 
 private:
     void
@@ -398,7 +398,7 @@ public:
 
     void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
-                bool repstr_expanded, bool scatter_gather_expanded) override;
+                bool repstr_expanded) override;
 
     static bool
     custom_module_data(void *(*load_cb)(module_data_t *module, int seg_idx),
@@ -413,8 +413,7 @@ public:
     // Inserts labels marking elidable addresses. label_marks_elidable() identifies them.
     // "version" is an OFFLINE_FILE_VERSION* constant.
     void
-    identify_elidable_addresses(void *drcontext, instrlist_t *ilist, int version,
-                                bool has_scatter_gather_instr);
+    identify_elidable_addresses(void *drcontext, instrlist_t *ilist, int version);
     bool
     label_marks_elidable(instr_t *instr, OUT int *opnd_index, OUT int *memopnd_index,
                          OUT bool *is_write, OUT bool *needs_base);

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -757,13 +757,11 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
         // identifying elision opportunities. We can possibly provide a consistent
         // view by expanding the instr in raw2trace (e.g. using
         // drx_expand_scatter_gather) when building the ilist.
-#ifdef X86
-        // TODO i#3837: Scatter/gather support NYI on ARM/AArch64.
-        if (drutil_instr_is_stringop_loop(instr) ||
-            (instr_is_scatter(instr) || instr_is_gather(instr))) {
+        if (drutil_instr_is_stringop_loop(instr)
+            // TODO i#3837: Scatter/gather support NYI on ARM/AArch64.
+            IF_X86(|| instr_is_scatter(instr) || instr_is_gather(instr))) {
             return;
         }
-#endif
         if (drmgr_is_emulation_start(instr) || drmgr_is_emulation_end(instr)) {
             return;
         }

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -587,8 +587,7 @@ offline_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t
 int
 offline_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
                                    instrlist_t *ilist, instr_t *where, reg_id_t reg_ptr,
-                                   int adjust, instr_t *app, bool scatter_gather_expanded,
-                                   bool repstr_expanded)
+                                   int adjust, instr_t *app)
 {
     app_pc pc;
     reg_id_t reg_tmp;
@@ -600,7 +599,10 @@ offline_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
     } else {
         // This routine is called for the first instr in the expanded scatter/gather
         // sequence, which turns out to be a non-app instr which doesn't have an app pc.
+        // To verify this, we have an assert in tracer.cpp where we have info on whether
+        // the current bb has an expanded scatter/gather instr.
         // XXX: For repstr do we want tag insted of skipping rep prefix?
+        bool scatter_gather_expanded = !instr_is_app(where);
         pc = scatter_gather_expanded ? dr_fragment_app_pc(tag) : instr_get_app_pc(app);
     }
     drreg_status_t res =

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -599,11 +599,11 @@ offline_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
     } else {
         // This routine is called for the first instr in the expanded scatter/gather
         // sequence, which turns out to be a non-app instr which doesn't have an app pc.
-        // To verify this, we have an assert in tracer.cpp where we have info on whether
-        // the current bb has an expanded scatter/gather instr.
+        // XXX i#4865: Refactor tracer so that the first expanded scatter/gather
+        // sequence instr that we instrument doesn't need to be a non-app instr.
         // XXX: For repstr do we want tag insted of skipping rep prefix?
-        bool scatter_gather_expanded = !instr_is_app(where);
-        pc = scatter_gather_expanded ? dr_fragment_app_pc(tag) : instr_get_app_pc(app);
+        DR_ASSERT(instr_is_app(where) || drmgr_is_first_nonlabel_instr(drcontext, where));
+        pc = instr_is_app(where) ? instr_get_app_pc(app) : dr_fragment_app_pc(tag);
     }
     drreg_status_t res =
         drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_tmp);

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -757,11 +757,13 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
         // identifying elision opportunities. We can possibly provide a consistent
         // view by expanding the instr in raw2trace (e.g. using
         // drx_expand_scatter_gather) when building the ilist.
-        if (drutil_instr_is_stringop_loop(instr)
-            // TODO i#3837: Scatter/gather support NYI on ARM/AArch64.
-            IF_X86(|| instr_is_scatter(instr) || instr_is_gather(instr))) {
+#ifdef X86
+        // TODO i#3837: Scatter/gather support NYI on ARM/AArch64.
+        if (drutil_instr_is_stringop_loop(instr) ||
+            (instr_is_scatter(instr) || instr_is_gather(instr))) {
             return;
         }
+#endif
         if (drmgr_is_emulation_start(instr) || drmgr_is_emulation_end(instr)) {
             return;
         }

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -587,7 +587,8 @@ offline_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t
 int
 offline_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
                                    instrlist_t *ilist, instr_t *where, reg_id_t reg_ptr,
-                                   int adjust, instr_t *app)
+                                   int adjust, instr_t *app, bool scatter_gather_expanded,
+                                   bool repstr_expanded)
 {
     app_pc pc;
     reg_id_t reg_tmp;
@@ -597,8 +598,10 @@ offline_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
             return adjust;
         pc = dr_fragment_app_pc(tag);
     } else {
+        // This routine is called for the first instr in the expanded scatter/gather
+        // sequence, which turns out to be a non-app instr which doesn't have an app pc.
         // XXX: For repstr do we want tag insted of skipping rep prefix?
-        pc = instr_get_app_pc(app);
+        pc = scatter_gather_expanded ? dr_fragment_app_pc(tag) : instr_get_app_pc(app);
     }
     drreg_status_t res =
         drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_tmp);

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -318,7 +318,7 @@ online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
 {
     // We cannot rely on the given instr's app_pc in case of expanded repstr and
     // scatter/gather sequences. In both cases, this routine is called for the instr
-    // at the top of the bb.
+    // at the top of the expanded sequence (which has its own separate bb).
     // - in the repstr expansion, this is a jrcxz instr with a fake app pc.
     // - in the scatter/gather expansion, this is a non-app reg spill instr, which
     // doesn't have an app_pc set.
@@ -331,8 +331,8 @@ online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
     // For expanded repstr and scatter/gather sequences, we also need to hardcode
     // the type and size. As mentioned above, we cannot rely on the passed `app`
     // instr, as it is not the original instr. These instrs are expanded such that
-    // the resulting bb contains only that instr. So we can use the tag to get the
-    // original instr's details.
+    // the resulting bb contains only that instr's expansion. So we can use the
+    // tag to get the original app instr's details.
     ushort type;
     if (repstr_expanded)
         type = TRACE_TYPE_INSTR_MAYBE_FETCH;

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -316,11 +316,6 @@ online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
                                   int adjust, instr_t *app)
 {
     bool repstr_expanded = *bb_field != 0; // Avoid cl warning C4800.
-    // This routine is called for the first instr in the expanded scatter/gather
-    // sequence, which turns out to be a non-app instr which doesn't have an app pc.
-    // To verify this, we have an assert in tracer.cpp where we have info on
-    // whether the current bb has an expanded scatter/gather instr.
-    bool scatter_gather_expanded = !instr_is_app(where);
 
     // We cannot rely on the given instr's app_pc in case of expanded repstr and
     // scatter/gather sequences. In both cases, this routine is called for the instr
@@ -328,25 +323,23 @@ online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
     // - in the repstr expansion, this is a jrcxz instr with a fake app pc.
     // - in the scatter/gather expansion, this is a non-app reg spill instr, which
     // doesn't have an app_pc set.
-    app_pc pc = (repstr_expanded || scatter_gather_expanded) ? dr_fragment_app_pc(tag)
-                                                             : instr_get_app_pc(app);
+    // XXX i#4865: Refactor tracer so that the first expanded scatter/gather
+    // sequence instr that we instrument doesn't need to be a non-app instr.
+    DR_ASSERT(instr_is_app(where) || drmgr_is_first_nonlabel_instr(drcontext, where));
+    app_pc pc = (repstr_expanded || !instr_is_app(where)) ? dr_fragment_app_pc(tag)
+                                                          : instr_get_app_pc(app);
     reg_id_t reg_tmp;
     drreg_status_t res =
         drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_tmp);
     DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
-    // For expanded repstr and scatter/gather sequences, we also need to hardcode
-    // the type and size. As mentioned above, we cannot rely on the passed `app`
-    // instr, as it is not the original instr. These instrs are expanded such that
-    // the resulting bb contains only that instr's expansion. So we can use the
-    // tag to get the original app instr's details.
+
     ushort type;
     if (repstr_expanded)
         type = TRACE_TYPE_INSTR_MAYBE_FETCH;
-    else if (scatter_gather_expanded)
-        type = TRACE_TYPE_INSTR;
     else
         type = instr_to_instr_type(app, repstr_expanded);
-    ushort size = (repstr_expanded || scatter_gather_expanded)
+    // We decode to get instr size for repstr and scatter/gather.
+    ushort size = (repstr_expanded || !instr_is_app(where))
         ? (ushort)decode_sizeof(drcontext, pc, NULL _IF_X86_64(NULL))
         : (ushort)instr_length(drcontext, app);
     insert_save_type_and_size(drcontext, ilist, where, reg_ptr, reg_tmp, type, size,

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -313,9 +313,15 @@ online_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t 
 int
 online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
                                   instrlist_t *ilist, instr_t *where, reg_id_t reg_ptr,
-                                  int adjust, instr_t *app, bool scatter_gather_expanded,
-                                  bool repstr_expanded)
+                                  int adjust, instr_t *app)
 {
+    bool repstr_expanded = *bb_field != 0; // Avoid cl warning C4800.
+    // This routine is called for the first instr in the expanded scatter/gather
+    // sequence, which turns out to be a non-app instr which doesn't have an app pc.
+    // To verify this, we have an assert in tracer.cpp where we have info on
+    // whether the current bb has an expanded scatter/gather instr.
+    bool scatter_gather_expanded = !instr_is_app(where);
+
     // We cannot rely on the given instr's app_pc in case of expanded repstr and
     // scatter/gather sequences. In both cases, this routine is called for the instr
     // at the top of the expanded sequence (which has its own separate bb).
@@ -387,4 +393,5 @@ void
 online_instru_t::bb_analysis(void *drcontext, void *tag, void **bb_field,
                              instrlist_t *ilist, bool repstr_expanded)
 {
+    *bb_field = (void *)repstr_expanded;
 }

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -383,7 +383,8 @@ online_instru_t::instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t
 
 void
 online_instru_t::bb_analysis(void *drcontext, void *tag, void **bb_field,
-                             instrlist_t *ilist, bool repstr_expanded)
+                             instrlist_t *ilist, bool repstr_expanded,
+                             bool scatter_gather_expanded)
 {
     *bb_field = (void *)repstr_expanded;
 }

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -383,8 +383,7 @@ online_instru_t::instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t
 
 void
 online_instru_t::bb_analysis(void *drcontext, void *tag, void **bb_field,
-                             instrlist_t *ilist, bool repstr_expanded,
-                             bool scatter_gather_expanded)
+                             instrlist_t *ilist, bool repstr_expanded)
 {
     *bb_field = (void *)repstr_expanded;
 }

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -332,12 +332,11 @@ online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
     drreg_status_t res =
         drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_tmp);
     DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
-
-    ushort type;
-    if (repstr_expanded)
-        type = TRACE_TYPE_INSTR_MAYBE_FETCH;
-    else
-        type = instr_to_instr_type(app, repstr_expanded);
+    // To handle zero-iter repstr loops this routine is called at the top of the bb
+    // where "app" is jecxz so we have to hardcode the rep str type and get length
+    // from the tag.
+    ushort type = repstr_expanded ? TRACE_TYPE_INSTR_MAYBE_FETCH
+                                  : instr_to_instr_type(app, repstr_expanded);
     // We decode to get instr size for repstr and scatter/gather.
     ushort size = (repstr_expanded || !instr_is_app(where))
         ? (ushort)decode_sizeof(drcontext, pc, NULL _IF_X86_64(NULL))

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -888,6 +888,10 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, INOUT app_pc *pc,
         desc->packed_ |= kIsAarch64DcZvaMask;
 #endif
 
+#ifdef X86
+    if (instr_is_scatter(instr) || instr_is_gather(instr))
+        desc->packed_ |= kIsScatterOrGatherMask;
+#endif
     desc->type_ = instru_t::instr_to_instr_type(instr);
     desc->prefetch_type_ = is_prefetch ? instru_t::instr_to_prefetch_type(instr) : 0;
     desc->flush_type_ = is_flush ? instru_t::instr_to_flush_type(instr) : 0;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1082,7 +1082,7 @@ private:
                 !is_instr_only_trace) {
                 if (instr->is_scatter_or_gather()) {
                     // The instr should either load or store, but not both. Also,
-                    // should have a single src or dest.
+                    // it should have a single src or dest operand.
                     DR_ASSERT(instr->num_mem_srcs() + instr->num_mem_dests() == 1);
                     bool is_scatter = instr->num_mem_dests() == 1;
                     bool reached_end_of_memrefs = false;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1104,11 +1104,16 @@ private:
                     // For expanded scatter/gather instrs, we do not have prior knowledge
                     // of the number of store/load memrefs that will be present. So we
                     // continue reading entries until we find a non-memref entry.
+                    // This works only because drx_expand_scatter_gather ensures that the
+                    // expansion has its own basic block, with no other app instr in it.
                     while (!reached_end_of_memrefs) {
                         // XXX: Add sanity check for max count of store/load memrefs
                         // possible for a given scatter/gather instr.
                         error = process_memref(
                             tls, &buf, instr,
+                            // We reuse the 0th dest/src for all memrefs. This should be
+                            // okay because all memrefs in the scatter/gather actually
+                            // have the same instr/opnd.
                             is_scatter ? instr->mem_dest_at(0) : instr->mem_src_at(0),
                             is_scatter, reg_vals, cur_modoffs, instrs_are_separate,
                             &reached_end_of_memrefs, &interrupted);

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -867,9 +867,12 @@ private:
         for (uint count = 0; count < instr_count; ++count) {
             instr_t *inst = instr_create(dcontext_);
             app_pc next_pc = decode(dcontext_, pc, inst);
+#ifdef X86
+            // NYI on ARM/AArch64.
             if (instr_is_scatter(inst) || instr_is_gather(inst)) {
                 has_scatter_gather_instr = true;
             }
+#endif
             DR_ASSERT(next_pc != NULL);
             instr_set_translation(inst, pc);
             instr_set_note(inst, reinterpret_cast<void *>(static_cast<ptr_int_t>(count)));

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -109,7 +109,12 @@ struct module_t {
  * conversion from decoded instructions.
  */
 struct instr_summary_t final {
-    /** Caches information about a single memory reference. */
+    /**
+     * Caches information about a single memory reference.
+     * Note that we reuse the same memref_summary_t object for all memrefs of a
+     * scatter/gather instr. This should be okay as they all share the same instr
+     * and the src/dest operand.
+     */
     struct memref_summary_t {
         memref_summary_t(opnd_t opnd)
             : opnd(opnd)

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -863,16 +863,9 @@ private:
         // state needed to reconstruct elided addresses.
         instrlist_t *ilist = instrlist_create(dcontext_);
         app_pc pc = start_pc;
-        bool has_scatter_gather_instr = false;
         for (uint count = 0; count < instr_count; ++count) {
             instr_t *inst = instr_create(dcontext_);
             app_pc next_pc = decode(dcontext_, pc, inst);
-#ifdef X86
-            // NYI on ARM/AArch64.
-            if (instr_is_scatter(inst) || instr_is_gather(inst)) {
-                has_scatter_gather_instr = true;
-            }
-#endif
             DR_ASSERT(next_pc != NULL);
             instr_set_translation(inst, pc);
             instr_set_note(inst, reinterpret_cast<void *>(static_cast<ptr_int_t>(count)));
@@ -880,8 +873,7 @@ private:
             instrlist_append(ilist, inst);
         }
 
-        instru_offline_.identify_elidable_addresses(dcontext_, ilist, version,
-                                                    has_scatter_gather_instr);
+        instru_offline_.identify_elidable_addresses(dcontext_, ilist, version);
 
         for (instr_t *inst = instrlist_first(ilist); inst != nullptr;
              inst = instr_get_next(inst)) {
@@ -997,6 +989,7 @@ private:
             tls, buf_in, cur_modoffs, instr->length(), instrs_are_separate, interrupted);
         return error;
     }
+
     std::string
     append_bb_entries(void *tls, const offline_entry_t *in_entry, OUT bool *handled)
     {

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1305,8 +1305,9 @@ private:
             // XXX i#2015: if there are multiple predicated memrefs, our instr vs
             // data stream may not be in the correct order here.
             impl()->log(4,
-                        "Missing memref from predication, 0-iter repstr, or filter "
-                        "(next type is 0x" ZHEX64_FORMAT_STRING ")\n",
+                        "Missing memref from predication, 0-iter repstr, filter, "
+                        "masked write/read in scatter/gather, or first instr in expanded "
+                        "scatter/gather seq (next type is 0x" ZHEX64_FORMAT_STRING ")\n",
                         in_entry == nullptr ? 0 : in_entry->combined_value);
             if (in_entry != nullptr) {
                 impl()->unread_last_entry(tls);

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1216,12 +1216,11 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     }
     ud->last_app_pc = instr_get_app_pc(instr);
 
-    // For the scatter/gather expansion, the first instr is a non-app memref (a reg
-    // spill). So, we reach here for a non-app instruction, but we
+    // For the scatter/gather expansion, the first instr turns out to be a non-app
+    // memref (a reg spill). So, we reach here for a non-app instruction and we
     // don't want to add a memref for that.
     bool is_first_instr_in_scatter_gather_expansion =
         ud->scatter_gather && drmgr_is_first_nonlabel_instr(drcontext, instr);
-    DR_ASSERT(!is_first_instr_in_scatter_gather_expansion || !instr_is_app(instr));
     if (is_memref && !is_first_instr_in_scatter_gather_expansion) {
         if (pred != DR_PRED_NONE && adjust != 0) {
             // Update buffer ptr and reset adjust to 0, because

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1212,7 +1212,8 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         // figure out whether the current bb has an expanded scatter/gather instr.
         // XXX i#4865: Refactor tracer so that the first expanded scatter/gather
         // sequence instr that we instrument doesn't need to be a non-app instr.
-        DR_ASSERT(!ud->scatter_gather || !instr_is_app(instr));
+        DR_ASSERT((ud->scatter_gather && !instr_is_app(instr)) ||
+                  (!ud->scatter_gather && instr_is_app(instr)));
         adjust = instrument_instr(drcontext, tag, ud, bb, instr, reg_ptr, adjust, instr);
     }
     ud->last_app_pc = instr_get_app_pc(instr);

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1214,8 +1214,11 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     // For the scatter/gather expansion, the first instr turns out to be a non-app
     // memref (a reg spill). So, we reach here for a non-app instruction and we
     // don't want to add a memref for that.
+    // XXX i#4865: Refactor tracer so that the first expanded scatter/gather
+    // sequence instr that we instrument doesn't need to be a non-app instr.
     bool is_first_instr_in_scatter_gather_expansion =
         ud->scatter_gather && drmgr_is_first_nonlabel_instr(drcontext, instr);
+    // Verify that we're not skipping an app memref.
     DR_ASSERT(!is_first_instr_in_scatter_gather_expansion || !instr_is_app(instr));
     if (is_memref && !is_first_instr_in_scatter_gather_expansion) {
         if (pred != DR_PRED_NONE && adjust != 0) {

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1295,7 +1295,8 @@ event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                   bool translating, void *user_data)
 {
     user_data_t *ud = (user_data_t *)user_data;
-    instru->bb_analysis(drcontext, tag, &ud->instru_field, bb, ud->repstr);
+    instru->bb_analysis(drcontext, tag, &ud->instru_field, bb, ud->repstr,
+                        ud->scatter_gather);
     // As elsewhere in this code, we want the single-instr original and not
     // the expanded 6 labeled-app instrs for repstr loops (i#2011).
     if (ud->repstr || ud->scatter_gather)

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1216,6 +1216,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     // don't want to add a memref for that.
     bool is_first_instr_in_scatter_gather_expansion =
         ud->scatter_gather && drmgr_is_first_nonlabel_instr(drcontext, instr);
+    DR_ASSERT(!is_first_instr_in_scatter_gather_expansion || !instr_is_app(instr));
     if (is_memref && !is_first_instr_in_scatter_gather_expansion) {
         if (pred != DR_PRED_NONE && adjust != 0) {
             // Update buffer ptr and reset adjust to 0, because
@@ -1295,8 +1296,7 @@ event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                   bool translating, void *user_data)
 {
     user_data_t *ud = (user_data_t *)user_data;
-    instru->bb_analysis(drcontext, tag, &ud->instru_field, bb, ud->repstr,
-                        ud->scatter_gather);
+    instru->bb_analysis(drcontext, tag, &ud->instru_field, bb, ud->repstr);
     // As elsewhere in this code, we want the single-instr original and not
     // the expanded 6 labeled-app instrs for repstr loops (i#2011).
     if (ud->repstr || ud->scatter_gather)

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1205,13 +1205,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     // ifetch and not any of the expansion instrs.  We instrument the first
     // one to handle a zero-iter loop.  For offline, we just record the pc; for
     // online we have to ignore "instr" here in instru_online::instrument_instr().
-    //
-    // For scatter/gather expansion, we do not have a loop like repstr. So we
-    // need to instrument each mov so that it adds a pc entry before the memrefs.
-    // In addition, we also need to add a pc entry for the first non-label instr,
-    // for cases where the scatter/gather operation is fully supressed by the
-    // mask.
-    if (!(ud->repstr || (ud->scatter_gather && !is_memref)) ||
+    if (!(ud->repstr || ud->scatter_gather) ||
         drmgr_is_first_nonlabel_instr(drcontext, instr)) {
         // TODO PR#_: Seems a bit hacky. Find an alternative.
         if (ud->scatter_gather && is_memref) {

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -141,6 +141,7 @@ typedef struct {
     int num_delay_instrs;
     instr_t *delay_instrs[MAX_NUM_DELAY_INSTRS];
     bool repstr;
+    bool scatter_gather;
     void *instru_field; /* for use by instru_t */
     int bb_instr_count;
 } user_data_t;
@@ -1078,10 +1079,19 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
 
     if ((!instr_is_app(instr) ||
          /* Skip identical app pc, which happens with rep str expansion.
+          * Note that all instrs except the stringop have a fake app pc. So
+          * the stringop memref will not get skipped because it has a different
+          * app pc.
           * XXX: the expansion means our instr fetch trace is not perfect,
           * but we live with having the wrong instr length for online traces.
+          *
+          * Note that we will have identical app pcs also for scatter/gather
+          * expansion. However, in that case, all instrs have the same app pc,
+          * including all individual scalar mov instrs. Unlike rep str expansion
+          * these are not in a loop and we do need to record memrefs for those
+          * instrs, so we don't skip.
           */
-         ud->last_app_pc == instr_get_app_pc(instr)) &&
+         (ud->last_app_pc == instr_get_app_pc(instr) && ud->repstr)) &&
         ud->strex == NULL &&
         // Ensure we have an instr entry for the start of the bb.
         !drmgr_is_first_nonlabel_instr(drcontext, instr))
@@ -1118,6 +1128,8 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         ud->strex == NULL &&
         // Don't bundle the zero-rep-string-iter instr.
         (!ud->repstr || !drmgr_is_first_nonlabel_instr(drcontext, instr)) &&
+        // Don't bundle scatter/gather instr.
+        !ud->scatter_gather &&
         // We can't bundle with a filter.
         !op_L0_filter.get_value() &&
         // The delay instr buffer is not full.
@@ -1193,12 +1205,29 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     // ifetch and not any of the expansion instrs.  We instrument the first
     // one to handle a zero-iter loop.  For offline, we just record the pc; for
     // online we have to ignore "instr" here in instru_online::instrument_instr().
-    if (!ud->repstr || drmgr_is_first_nonlabel_instr(drcontext, instr)) {
+    //
+    // For scatter/gather expansion, we do not have a loop like repstr. So we
+    // need to instrument each mov so that it adds a pc entry before the memrefs.
+    // In addition, we also need to add a pc entry for the first non-label instr,
+    // for cases where the scatter/gather operation is fully supressed by the
+    // mask.
+    if (!(ud->repstr || (ud->scatter_gather && !is_memref)) ||
+        drmgr_is_first_nonlabel_instr(drcontext, instr)) {
+        // TODO PR#_: Seems a bit hacky. Find an alternative.
+        if (ud->scatter_gather && is_memref) {
+            ud->instru_field = (void *)1;
+        }
         adjust = instrument_instr(drcontext, tag, ud, bb, instr, reg_ptr, adjust, instr);
     }
     ud->last_app_pc = instr_get_app_pc(instr);
 
-    if (is_memref) {
+    // For the scatter/gather expansion, the first instr is a non-app memref (a reg
+    // spill). So, we reach here for a non-app instruction, but we
+    // don't want to add a memref for that.
+    bool is_first_instr_in_scatter_gather_expansion =
+        ud->scatter_gather && drmgr_is_first_nonlabel_instr(drcontext, instr);
+    DR_ASSERT(!is_first_instr_in_scatter_gather_expansion || !instr_is_app(instr));
+    if (is_memref && !is_first_instr_in_scatter_gather_expansion) {
         if (pred != DR_PRED_NONE && adjust != 0) {
             // Update buffer ptr and reset adjust to 0, because
             // we may not execute the inserted code below.
@@ -1266,7 +1295,7 @@ event_bb_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     /* XXX i#4865: Online traces will have incorrect instr counts, because
      * scatter/gather instrs are emulated by a sequence of scalar stores/loads.
      */
-    if (!drx_expand_scatter_gather(drcontext, bb, NULL)) {
+    if (!drx_expand_scatter_gather(drcontext, bb, &data->scatter_gather)) {
         DR_ASSERT(false);
     }
     return DR_EMIT_DEFAULT;
@@ -1280,7 +1309,7 @@ event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     instru->bb_analysis(drcontext, tag, &ud->instru_field, bb, ud->repstr);
     // As elsewhere in this code, we want the single-instr original and not
     // the expanded 6 labeled-app instrs for repstr loops (i#2011).
-    if (ud->repstr)
+    if (ud->repstr || ud->scatter_gather)
         ud->bb_instr_count = 1;
     else {
         for (instr_t *app = instrlist_first_app(bb); app != NULL;

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1207,13 +1207,6 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     // online we have to ignore "instr" here in instru_online::instrument_instr().
     if (!(ud->repstr || ud->scatter_gather) ||
         drmgr_is_first_nonlabel_instr(drcontext, instr)) {
-        // For the expanded scatter gather sequence, the first instr turns out to
-        // be a non-app reg spill instr.  In instrument_instr, we rely on this to
-        // figure out whether the current bb has an expanded scatter/gather instr.
-        // XXX i#4865: Refactor tracer so that the first expanded scatter/gather
-        // sequence instr that we instrument doesn't need to be a non-app instr.
-        DR_ASSERT((ud->scatter_gather && !instr_is_app(instr)) ||
-                  (!ud->scatter_gather && instr_is_app(instr)));
         adjust = instrument_instr(drcontext, tag, ud, bb, instr, reg_ptr, adjust, instr);
     }
     ud->last_app_pc = instr_get_app_pc(instr);

--- a/ext/drutil/drutil.c
+++ b/ext/drutil/drutil.c
@@ -527,6 +527,16 @@ opc_is_stringop_loop(uint opc)
             opc == OP_repne_cmps || opc == OP_rep_scas || opc == OP_repne_scas);
 }
 
+DR_EXPORT
+bool
+drutil_instr_is_stringop_loop(instr_t *inst)
+{
+#    ifdef X86
+    return opc_is_stringop_loop(instr_get_opcode(inst));
+#    endif
+    return false;
+}
+
 static instr_t *
 create_nonloop_stringop(void *drcontext, instr_t *inst)
 {

--- a/ext/drutil/drutil.c
+++ b/ext/drutil/drutil.c
@@ -527,16 +527,6 @@ opc_is_stringop_loop(uint opc)
             opc == OP_repne_cmps || opc == OP_rep_scas || opc == OP_repne_scas);
 }
 
-DR_EXPORT
-bool
-drutil_instr_is_stringop_loop(instr_t *inst)
-{
-#    ifdef X86
-    return opc_is_stringop_loop(instr_get_opcode(inst));
-#    endif
-    return false;
-}
-
 static instr_t *
 create_nonloop_stringop(void *drcontext, instr_t *inst)
 {
@@ -601,6 +591,17 @@ create_nonloop_stringop(void *drcontext, instr_t *inst)
     return res;
 }
 #endif /* X86 */
+
+DR_EXPORT
+bool
+drutil_instr_is_stringop_loop(instr_t *inst)
+{
+#ifdef X86
+    return opc_is_stringop_loop(instr_get_opcode(inst));
+#else
+    return false;
+#endif
+}
 
 DR_EXPORT
 bool

--- a/ext/drutil/drutil.h
+++ b/ext/drutil/drutil.h
@@ -185,6 +185,17 @@ bool
 drutil_expand_rep_string_ex(void *drcontext, instrlist_t *bb, OUT bool *expanded,
                             OUT instr_t **stringop);
 
+DR_EXPORT
+/**
+ * Returns whether the given instr is a stringop loop.
+ *
+ * @param[in]  inst        The instr to inspect.
+ *
+ * \return whether given instr is a stringop loop.
+ */
+bool
+drutil_instr_is_stringop_loop(instr_t *inst);
+
 /**@}*/ /* end doxygen group */
 
 #ifdef __cplusplus

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2624,7 +2624,7 @@ if (X86)
       set(client.drx-scattergather_runavx 1)
     endif ()
 
-    if (X64)
+    if (X64 AND UNIX)
       if (proc_supports_avx)
         add_exe(allasm_scattergather
           ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_scattergather.asm
@@ -2652,7 +2652,7 @@ if (X86)
         # with some tool chains (such as SUSE GCC 6.2) results in an executable that
         # is not properly static. Adding --no-export-dynamic avoids the problem.
         "-Wl,--no-export-dynamic")
-    endif (X64)
+    endif (X64 AND UNIX)
   endif()
 endif ()
 
@@ -3656,19 +3656,21 @@ if (BUILD_CLIENTS)
       endif ()
     endif ()
 
-    if (NOT MACOS AND X86 AND X64 AND proc_supports_avx)
-      torunonly_drcacheoff(allasm-scattergather-basic-counts allasm_scattergather
-        "" "@-simulator_type@basic_counts" "")
-      unset(tool.drcacheoff.allasm-scattergather-basic-counts_rawtemp) # use preprocessor
-      if (proc_supports_avx512)
-        set(tool.drcacheoff.allasm-scattergather-basic-counts_runavx512 1)
-      endif (proc_supports_avx512)
-      torunonly_drcachesim(allasm-scattergather-basic-counts allasm_scattergather
-        "-simulator_type basic_counts" "")
-      unset(tool.drcachesim.allasm-scattergather-basic-counts_rawtemp) # use preprocessor
-      if (proc_supports_avx512)
-        set(tool.drcachesim.allasm-scattergather-basic-counts_runavx512 1)
-      endif (proc_supports_avx512)
+    if (UNIX AND X86 AND X64)
+      if (proc_supports_avx)
+        torunonly_drcacheoff(allasm-scattergather-basic-counts allasm_scattergather
+          "" "@-simulator_type@basic_counts" "")
+        unset(tool.drcacheoff.allasm-scattergather-basic-counts_rawtemp) # use preprocessor
+        if (proc_supports_avx512)
+          set(tool.drcacheoff.allasm-scattergather-basic-counts_runavx512 1)
+        endif (proc_supports_avx512)
+        torunonly_drcachesim(allasm-scattergather-basic-counts allasm_scattergather
+          "-simulator_type basic_counts" "")
+        unset(tool.drcachesim.allasm-scattergather-basic-counts_rawtemp) # use preprocessor
+        if (proc_supports_avx512)
+          set(tool.drcachesim.allasm-scattergather-basic-counts_runavx512 1)
+        endif (proc_supports_avx512)
+      endif (proc_supports_avx)
 
       torunonly_drcacheoff(allasm-repstr-basic-counts allasm_repstr
         "" "@-simulator_type@basic_counts" "")
@@ -3676,7 +3678,7 @@ if (BUILD_CLIENTS)
       torunonly_drcachesim(allasm-repstr-basic-counts allasm_repstr
         "-simulator_type basic_counts" "")
       unset(tool.drcachesim.allasm-repstr-basic-counts_rawtemp) # use preprocessor
-    endif (NOT MACOS AND X86 AND X64 AND proc_supports_avx)
+    endif (UNIX AND X86 AND X64)
 
     # Test the standalone histogram tool.
     # ${ci_shared_app} is already used for an offline test, so we run other apps

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2624,23 +2624,35 @@ if (X86)
       set(client.drx-scattergather_runavx 1)
     endif ()
 
-    if (proc_supports_avx AND X64)
-      add_exe(allasm_scattergather
-        ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_scattergather.asm
+    if (X64)
+      if (proc_supports_avx)
+        add_exe(allasm_scattergather
+          ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_scattergather.asm
+          "-early_inject" "")
+        set_target_properties(allasm_scattergather PROPERTIES LINKER_LANGUAGE C)
+        append_link_flags(allasm_scattergather
+          "-nostartfiles -nodefaultlibs -static")
+        append_property_string(TARGET allasm_scattergather LINK_FLAGS
+          # The default value of CMAKE_SHARED_LIBRARY_LINK_C_FLAGS has -rdynamic, which
+          # with some tool chains (such as SUSE GCC 6.2) results in an executable that
+          # is not properly static. Adding --no-export-dynamic avoids the problem.
+          "-Wl,--no-export-dynamic")
+        if (proc_supports_avx512)
+          append_property_string(TARGET allasm_scattergather COMPILE_FLAGS "${CFLAGS_AVX512}")
+          set(allasm_scattergather_runavx512 1)
+        endif (proc_supports_avx512)
+      endif (proc_supports_avx)
+      add_exe(allasm_repstr
+        ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_repstr.asm
         "-early_inject" "")
-      set_target_properties(allasm_scattergather PROPERTIES LINKER_LANGUAGE C)
-      append_link_flags(allasm_scattergather
-        "-nostartfiles -nodefaultlibs -static")
-      append_property_string(TARGET allasm_scattergather LINK_FLAGS
+      set_target_properties(allasm_repstr PROPERTIES LINKER_LANGUAGE C)
+      append_link_flags(allasm_repstr "-nostartfiles -nodefaultlibs -static")
+      append_property_string(TARGET allasm_repstr LINK_FLAGS
         # The default value of CMAKE_SHARED_LIBRARY_LINK_C_FLAGS has -rdynamic, which
         # with some tool chains (such as SUSE GCC 6.2) results in an executable that
         # is not properly static. Adding --no-export-dynamic avoids the problem.
         "-Wl,--no-export-dynamic")
-      if (proc_supports_avx512)
-        append_property_string(TARGET allasm_scattergather COMPILE_FLAGS "${CFLAGS_AVX512}")
-        set(allasm_scattergather_runavx512 1)
-      endif ()
-    endif ()
+    endif (X64)
   endif()
 endif ()
 
@@ -3650,8 +3662,21 @@ if (BUILD_CLIENTS)
       unset(tool.drcacheoff.allasm-scattergather-basic-counts_rawtemp) # use preprocessor
       if (proc_supports_avx512)
         set(tool.drcacheoff.allasm-scattergather-basic-counts_runavx512 1)
-      endif ()
-    endif ()
+      endif (proc_supports_avx512)
+      torunonly_drcachesim(allasm-scattergather-basic-counts allasm_scattergather
+        "-simulator_type basic_counts" "")
+      unset(tool.drcachesim.allasm-scattergather-basic-counts_rawtemp) # use preprocessor
+      if (proc_supports_avx512)
+        set(tool.drcachesim.allasm-scattergather-basic-counts_runavx512 1)
+      endif (proc_supports_avx512)
+
+      torunonly_drcacheoff(allasm-repstr-basic-counts allasm_repstr
+        "" "@-simulator_type@basic_counts" "")
+      unset(tool.drcacheoff.allasm-repstr-basic-counts_rawtemp) # use preprocessor
+      torunonly_drcachesim(allasm-repstr-basic-counts allasm_repstr
+        "-simulator_type basic_counts" "")
+      unset(tool.drcachesim.allasm-repstr-basic-counts_rawtemp) # use preprocessor
+    endif (NOT MACOS AND X86 AND X64 AND proc_supports_avx)
 
     # Test the standalone histogram tool.
     # ${ci_shared_app} is already used for an offline test, so we run other apps

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -902,6 +902,16 @@ macro(tobuild_csharp test source)
   endif ()
 endmacro(tobuild_csharp)
 
+macro(append_pure_asm_app_link_flags target)
+  set_target_properties(${target} PROPERTIES LINKER_LANGUAGE C)
+  append_link_flags(${target} "-nostartfiles -nodefaultlibs -static")
+  append_property_string(TARGET ${target} LINK_FLAGS
+    # The default value of CMAKE_SHARED_LIBRARY_LINK_C_FLAGS has -rdynamic, which
+    # with some tool chains (such as SUSE GCC 6.2) results in an executable that
+    # is not properly static. Adding --no-export-dynamic avoids the problem.
+    "-Wl,--no-export-dynamic")
+endmacro(append_pure_asm_app_link_flags)
+
 function(tobind target)
   if (BIND_EXECUTABLE)
     add_custom_command(TARGET ${target}
@@ -2033,37 +2043,16 @@ if (DR_HOST_AARCH64)
 
   tobuild_ops(common.allasm_aarch64_cache common/allasm_aarch64_cache.asm
     "-early_inject" "")
-  set_target_properties(common.allasm_aarch64_cache PROPERTIES LINKER_LANGUAGE C)
-  append_link_flags(common.allasm_aarch64_cache
-    "-nostartfiles -nodefaultlibs -static")
-  append_property_string(TARGET common.allasm_aarch64_cache LINK_FLAGS
-    # The default value of CMAKE_SHARED_LIBRARY_LINK_C_FLAGS has -rdynamic, which
-    # with some tool chains (such as SUSE GCC 6.2) results in an executable that
-    # is not properly static. Adding --no-export-dynamic avoids the problem.
-    "-Wl,--no-export-dynamic")
+  append_pure_asm_app_link_flags(common.allasm_aarch64_cache)
 
   add_exe(allasm_aarch64_prefetch
     ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_aarch64_prefetch.asm
     "-early_inject" "")
-  set_target_properties(allasm_aarch64_prefetch PROPERTIES LINKER_LANGUAGE C)
-  append_link_flags(allasm_aarch64_prefetch
-    "-nostartfiles -nodefaultlibs -static")
-  append_property_string(TARGET allasm_aarch64_prefetch LINK_FLAGS
-    # The default value of CMAKE_SHARED_LIBRARY_LINK_C_FLAGS has -rdynamic, which
-    # with some tool chains (such as SUSE GCC 6.2) results in an executable that
-    # is not properly static. Adding --no-export-dynamic avoids the problem.
-    "-Wl,--no-export-dynamic")
+  append_pure_asm_app_link_flags(allasm_aarch64_prefetch)
 
   add_exe(allasm_aarch64_flush
     ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_aarch64_flush.asm "" "")
-  set_target_properties(allasm_aarch64_flush PROPERTIES LINKER_LANGUAGE C)
-  append_link_flags(allasm_aarch64_flush
-    "-nostartfiles -nodefaultlibs -static")
-  append_property_string(TARGET allasm_aarch64_flush LINK_FLAGS
-    # The default value of CMAKE_SHARED_LIBRARY_LINK_C_FLAGS has -rdynamic, which
-    # with some tool chains (such as SUSE GCC 6.2) results in an executable that
-    # is not properly static. Adding --no-export-dynamic avoids the problem.
-    "-Wl,--no-export-dynamic")
+  append_pure_asm_app_link_flags(allasm_aarch64_flush)
 endif ()
 
 if (DEBUG)
@@ -2629,14 +2618,7 @@ if (X86)
         add_exe(allasm_scattergather
           ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_scattergather.asm
           "-early_inject" "")
-        set_target_properties(allasm_scattergather PROPERTIES LINKER_LANGUAGE C)
-        append_link_flags(allasm_scattergather
-          "-nostartfiles -nodefaultlibs -static")
-        append_property_string(TARGET allasm_scattergather LINK_FLAGS
-          # The default value of CMAKE_SHARED_LIBRARY_LINK_C_FLAGS has -rdynamic, which
-          # with some tool chains (such as SUSE GCC 6.2) results in an executable that
-          # is not properly static. Adding --no-export-dynamic avoids the problem.
-          "-Wl,--no-export-dynamic")
+	append_pure_asm_app_link_flags(allasm_scattergather)
         if (proc_supports_avx512)
           append_property_string(TARGET allasm_scattergather COMPILE_FLAGS "${CFLAGS_AVX512}")
           set(allasm_scattergather_runavx512 1)
@@ -2645,13 +2627,7 @@ if (X86)
       add_exe(allasm_repstr
         ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_repstr.asm
         "-early_inject" "")
-      set_target_properties(allasm_repstr PROPERTIES LINKER_LANGUAGE C)
-      append_link_flags(allasm_repstr "-nostartfiles -nodefaultlibs -static")
-      append_property_string(TARGET allasm_repstr LINK_FLAGS
-        # The default value of CMAKE_SHARED_LIBRARY_LINK_C_FLAGS has -rdynamic, which
-        # with some tool chains (such as SUSE GCC 6.2) results in an executable that
-        # is not properly static. Adding --no-export-dynamic avoids the problem.
-        "-Wl,--no-export-dynamic")
+      append_pure_asm_app_link_flags(allasm_repstr)
     endif (X64 AND UNIX)
   endif()
 endif ()

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2618,7 +2618,7 @@ if (X86)
         add_exe(allasm_scattergather
           ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_scattergather.asm
           "-early_inject" "")
-	append_pure_asm_app_link_flags(allasm_scattergather)
+        append_pure_asm_app_link_flags(allasm_scattergather)
         if (proc_supports_avx512)
           append_property_string(TARGET allasm_scattergather COMPILE_FLAGS "${CFLAGS_AVX512}")
           set(allasm_scattergather_runavx512 1)


### PR DESCRIPTION
Fixes issues in drcachesim and raw2trace because of which some
instructions and memrefs in the scatter/gather expansion were
not being instrumented. This led to lower than expected
basic_counts for data loads and stores.

In the scatter/gather expansion, all instrs have the same app
pc (this is unlike rep str expansion where the stringop has
the original app pc, and others have a fake one). So we need
to continue instrumenting even if we see an instr with app pc
same as the last one we saw.

Modifies raw2trace to properly detect scatter/gather memrefs:
when we see a scatter/gather instr, we keep reading entries
until we encounter a non-memref entry. The alternative to this
was to add a pc entry for each mov instr (to fulfil raw2trace's
requirement of always having a preceding pc entry for each
memref), but that may have higher overhead.

Another tricky behavior of scatter/gather expansion is that
the first non-label instruction in the expansion is a non-
app memref, which needs to be instrumented to output pc entry
(for scatter/gather completely suppressed due to  mask, we
still want a pc entry). But as we don't want a memref entry for
that, had to add a special check for it.

Figures out pc for scatter/gather instr using fragment tag,
instead of the passed instr. As the first instr in the expanded
scatter/gather is a non-app instr, we cannot use that to
get the app pc. 

Hard-codes type and length for scatter/gather instrs in
online traces. Type and length cannot be found out using
the passed-in instr (which is from the expansion), so we
use the original instr at given pc to get those details.

Disables instr bundling for scatter/gather expansions, so
that we can choose to not output a duplicate pc entry for
some instrs in the online trace.

Adds drcachesim online test for allasm scatter gather app.

Adds an allasm app that uses repstr, and a drcachesim offline
and online test for this.

Issue: #2985