### PR TITLE
i#4847 AArch64 v8.0 Memory decode: Add Encoding and Decoding tests

### DIFF
--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -2226,18 +2226,17 @@ enum {
 
 /* Advanced SIMD (NEON) memory instructions */
 
-#define INSTR_CREATE_ld2_multi(dc, Vt1, Vt2, Xn, index) instr_create_2dst_2src(dc, OP_ld2, Vt1, Vt2, Xn, index)
+#define INSTR_CREATE_ld2_multi(dc, Vt1, Vt2, Xn, index) \
+    instr_create_2dst_2src(dc, OP_ld2, Vt1, Vt2, Xn, index)
 
 /**
  * Creates an Advanced SIMD (NEON) LD2 instruction to load multiple 2-element
- * structures to two vector registers with post-indexing, e.g. LD2 {V0.4H, V1.4H}, [X0], #32.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Vt1     The destination vector register operand.
- * \param Vt2     The second destination vector register operand.
- * \param Xn      The stack-pointer or GPR to load into Vt1 and Vt2.
- * \param disp    The disposition of Xn.
- * \param index   The element index of the vectors.
- * \param offset  The post-index offset.
+ * structures to two vector registers with post-indexing, e.g. LD2 {V0.4H, V1.4H}, [X0],
+ * #32. \param dc      The void * dcontext used to allocate memory for the instr_t. \param
+ * Vt1     The destination vector register operand. \param Vt2     The second destination
+ * vector register operand. \param Xn      The stack-pointer or GPR to load into Vt1 and
+ * Vt2. \param disp    The disposition of Xn. \param index   The element index of the
+ * vectors. \param offset  The post-index offset.
  */
 #define INSTR_CREATE_ld2_multi_2(dc, Vt1, Vt2, Xn, disp, index, offset) \
     instr_create_3dst_4src(dc, OP_ld2, Vt1, Vt2, Xn, disp, index, Xn, offset)
@@ -2327,8 +2326,8 @@ enum {
 
 /**
  * Creates an Advanced SIMD (NEON) LD3 instruction to load a single 3-element
- * structure to the index of three vector registers, e.g. LD3 {V0.4H, V1.4H, V2.4H}[15], [X0].
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * structure to the index of three vector registers, e.g. LD3 {V0.4H, V1.4H, V2.4H}[15],
+ * [X0]. \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Vt1     The first destination vector register operand.
  * \param Vt2     The second destination vector register operand.
  * \param Vt3     The third destination vector register operand.
@@ -2351,33 +2350,31 @@ enum {
  * \param index   The index of the vectors.
  * \param offset  The immediate or GPR post-index offset.
  */
-#define INSTR_CREATE_ld3_2(dc, Vt1, Vt2, Vt3, Xn, Xnd, index, offset) \
-    instr_create_4dst_7src(dc, OP_ld3, Vt1, Vt2, Vt3, Xn, Vt1, Vt2, Vt3, Xnd, index, Xn, offset)
+#define INSTR_CREATE_ld3_2(dc, Vt1, Vt2, Vt3, Xn, Xnd, index, offset)                    \
+    instr_create_4dst_7src(dc, OP_ld3, Vt1, Vt2, Vt3, Xn, Vt1, Vt2, Vt3, Xnd, index, Xn, \
+                           offset)
 
 /**
- * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single 3-element
- * structure to the index of three vector registers,
- * e.g. LD3 {V0.4H, V1.4H, V2.4H}[15], [X0].
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Vt1     The first destination vector register operand.
- * \param Vt2     The second destination vector register operand.
- * \param Vt3     The third destination vector register operand.
- * \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and Vt3.
+ * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single
+ * 3-element structure to the index of three vector registers, e.g. LD3 {V0.4H, V1.4H,
+ * V2.4H}[15], [X0]. \param dc      The void * dcontext used to allocate memory for the
+ * instr_t. \param Vt1     The first destination vector register operand. \param Vt2 The
+ * second destination vector register operand. \param Vt3     The third destination vector
+ * register operand. \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and
+ * Vt3.
  */
 #define INSTR_CREATE_ld3r(dc, Vt1, Vt2, Vt3, Xn) \
     instr_create_3dst_1src(dc, OP_ld3r, Vt1, Vt2, Vt3, Xn)
 
 /**
- * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single 3-element
- * structure to the index of three vector registers with post-index offset,
- * e.g. LD3 {V0.4H, V1.4H, V2.4H}[15], [X0], X1.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Vt1     The first destination vector register operand.
- * \param Vt2     The second destination vector register operand.
- * \param Vt3     The third destination vector register operand.
- * \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and Vt3.
- * \param Xnd     The disposition of Xn.
- * \param offset  The immediate or GPR post-index offset
+ * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single
+ * 3-element structure to the index of three vector registers with post-index offset, e.g.
+ * LD3 {V0.4H, V1.4H, V2.4H}[15], [X0], X1. \param dc      The void * dcontext used to
+ * allocate memory for the instr_t. \param Vt1     The first destination vector register
+ * operand. \param Vt2     The second destination vector register operand. \param Vt3 The
+ * third destination vector register operand. \param Xn      The stack-pointer or GPR to
+ * load into Vt1, Vt2 and Vt3. \param Xnd     The disposition of Xn. \param offset  The
+ * immediate or GPR post-index offset
  */
 #define INSTR_CREATE_ld3r_2(dc, Vt1, Vt2, Vt3, Xn, Xnd, offset) \
     instr_create_4dst_3src(dc, OP_ld3r, Vt1, Vt2, Vt3, Xn, Xnd, Xn, offset)
@@ -2398,16 +2395,14 @@ enum {
 
 /**
  * Creates an Advanced SIMD (NEON) LD4 instruction to load multiple 4-element
- * structures to four vector registers with post-index, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Vt1     The first destination vector register operand.
- * \param Vt2     The second destination vector register operand.
- * \param Vt3     The third destination vector register operand.
- * \param Vt4     The fourth destination vector register operand.
- * \param Xn      The stack-pointer or GPR to load into the destination vectors
- * \param Xnd     The disposition of Xn
- * \param index   The index of the vectors.
- * \param offset  The post-index offset.
+ * structures to four vector registers with post-index, e.g. LD4 {V0.4H, V1.4H, V2.4H,
+ * V3.4H}, [X0], X1. \param dc      The void * dcontext used to allocate memory for the
+ * instr_t. \param Vt1     The first destination vector register operand. \param Vt2 The
+ * second destination vector register operand. \param Vt3     The third destination vector
+ * register operand. \param Vt4     The fourth destination vector register operand. \param
+ * Xn      The stack-pointer or GPR to load into the destination vectors \param Xnd The
+ * disposition of Xn \param index   The index of the vectors. \param offset  The
+ * post-index offset.
  */
 #define INSTR_CREATE_ld4_multi_2(dc, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, index, offset) \
     instr_create_5dst_4src(dc, OP_ld4, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, index, Xn, offset)
@@ -2428,25 +2423,23 @@ enum {
 
 /**
  * Creates an Advanced SIMD (NEON) LD4 instruction to load a single 4-element
- * structures to four vector registers with post-index, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Vt1     The first destination vector register operand.
- * \param Vt2     The second destination vector register operand.
- * \param Vt3     The third destination vector register operand.
- * \param Vt4     The fourth destination vector register operand.
- * \param Xn      The stack-pointer or GPR to load into the destination vectors.
- * \param Xn      The register to load into Vt and Vt2.
- * \param Xnd     The disposition of Xn.
- * \param index   The index of the vectors
- * \param offset  The post-index offset.
+ * structures to four vector registers with post-index, e.g. LD4 {V0.4H, V1.4H, V2.4H,
+ * V3.4H}, [X0], X1. \param dc      The void * dcontext used to allocate memory for the
+ * instr_t. \param Vt1     The first destination vector register operand. \param Vt2 The
+ * second destination vector register operand. \param Vt3     The third destination vector
+ * register operand. \param Vt4     The fourth destination vector register operand. \param
+ * Xn      The stack-pointer or GPR to load into the destination vectors. \param Xn The
+ * register to load into Vt and Vt2. \param Xnd     The disposition of Xn. \param index
+ * The index of the vectors \param offset  The post-index offset.
  */
-#define INSTR_CREATE_ld4_2(dc, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, index, offset) \
-    instr_create_5dst_8src(dc, OP_ld4, Vt1, Vt2, Vt3, Vt4, Xn, Vt1, Vt2, Vt3, Vt4, Xnd, index, Xn, offset)
+#define INSTR_CREATE_ld4_2(dc, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, index, offset)              \
+    instr_create_5dst_8src(dc, OP_ld4, Vt1, Vt2, Vt3, Vt4, Xn, Vt1, Vt2, Vt3, Vt4, Xnd, \
+                           index, Xn, offset)
 
 /**
- * Creates an Advanced SIMD (NEON) LD4R instruction to load and replicate a single 4-element
- * structure to four vector registers, e.g. LD4R {V0.4H, V1.4H, V2.4H, V3.4H}, [X0].
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an Advanced SIMD (NEON) LD4R instruction to load and replicate a single
+ * 4-element structure to four vector registers, e.g. LD4R {V0.4H, V1.4H, V2.4H, V3.4H},
+ * [X0]. \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Vt1     The first destination vector register operand.
  * \param Vt2     The second destination vector register operand.
  * \param Vt3     The third destination vector register operand.
@@ -2457,10 +2450,10 @@ enum {
     instr_create_4dst_1src(dc, OP_ld4r, Vt1, Vt2, Vt3, Vt4, Xn)
 
 /**
- * Creates an Advanced SIMD (NEON) LD4R instruction to load and replicate a single 4-element
- * structure to four vector registers with post-indexing, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Vt1     The first destination vector register operand.
+ * Creates an Advanced SIMD (NEON) LD4R instruction to load and replicate a single
+ * 4-element structure to four vector registers with post-indexing, e.g. LD4 {V0.4H,
+ * V1.4H, V2.4H, V3.4H}, [X0], X1. \param dc      The void * dcontext used to allocate
+ * memory for the instr_t. \param Vt1     The first destination vector register operand.
  * \param Vt2     The second destination vector register operand.
  * \param Vt3     The third destination vector register operand.
  * \param Vt4     The fourth destination vector register operand.

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -2434,7 +2434,6 @@ enum {
  * \param Vt3     The third destination vector register operand.
  * \param Vt4     The fourth destination vector register operand.
  * \param Xn      The stack-pointer or GPR to load into the destination vectors.
- * \param Xn      The register to load into Vt and Vt2.
  * \param Xnd     The disposition of Xn.
  * \param index   The index of the vectors
  * \param offset  The post-index offset.

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -2355,26 +2355,29 @@ enum {
                            offset)
 
 /**
- * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single
- * 3-element structure to the index of three vector registers, e.g. LD3 {V0.4H, V1.4H,
- * V2.4H}[15], [X0]. \param dc      The void * dcontext used to allocate memory for the
- * instr_t. \param Vt1     The first destination vector register operand. \param Vt2 The
- * second destination vector register operand. \param Vt3     The third destination vector
- * register operand. \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and
- * Vt3.
+ * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single 3-element
+ * structure to the index of three vector registers,
+ * e.g. LD3 {V0.4H, V1.4H, V2.4H}[15], [X0].
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and Vt3.
  */
 #define INSTR_CREATE_ld3r(dc, Vt1, Vt2, Vt3, Xn) \
     instr_create_3dst_1src(dc, OP_ld3r, Vt1, Vt2, Vt3, Xn)
 
 /**
- * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single
- * 3-element structure to the index of three vector registers with post-index offset, e.g.
- * LD3 {V0.4H, V1.4H, V2.4H}[15], [X0], X1. \param dc      The void * dcontext used to
- * allocate memory for the instr_t. \param Vt1     The first destination vector register
- * operand. \param Vt2     The second destination vector register operand. \param Vt3 The
- * third destination vector register operand. \param Xn      The stack-pointer or GPR to
- * load into Vt1, Vt2 and Vt3. \param Xnd     The disposition of Xn. \param offset  The
- * immediate or GPR post-index offset
+ * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single 3-element
+ * structure to the index of three vector registers with post-index offset,
+ * e.g. LD3 {V0.4H, V1.4H, V2.4H}[15], [X0], X1.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and Vt3.
+ * \param Xnd     The disposition of Xn.
+ * \param offset  The immediate or GPR post-index offset
  */
 #define INSTR_CREATE_ld3r_2(dc, Vt1, Vt2, Vt3, Xn, Xnd, offset) \
     instr_create_4dst_3src(dc, OP_ld3r, Vt1, Vt2, Vt3, Xn, Xnd, Xn, offset)
@@ -2395,14 +2398,16 @@ enum {
 
 /**
  * Creates an Advanced SIMD (NEON) LD4 instruction to load multiple 4-element
- * structures to four vector registers with post-index, e.g. LD4 {V0.4H, V1.4H, V2.4H,
- * V3.4H}, [X0], X1. \param dc      The void * dcontext used to allocate memory for the
- * instr_t. \param Vt1     The first destination vector register operand. \param Vt2 The
- * second destination vector register operand. \param Vt3     The third destination vector
- * register operand. \param Vt4     The fourth destination vector register operand. \param
- * Xn      The stack-pointer or GPR to load into the destination vectors \param Xnd The
- * disposition of Xn \param index   The index of the vectors. \param offset  The
- * post-index offset.
+ * structures to four vector registers with post-index, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Vt4     The fourth destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into the destination vectors
+ * \param Xnd     The disposition of Xn
+ * \param index   The index of the vectors.
+ * \param offset  The post-index offset.
  */
 #define INSTR_CREATE_ld4_multi_2(dc, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, index, offset) \
     instr_create_5dst_4src(dc, OP_ld4, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, index, Xn, offset)
@@ -2423,23 +2428,26 @@ enum {
 
 /**
  * Creates an Advanced SIMD (NEON) LD4 instruction to load a single 4-element
- * structures to four vector registers with post-index, e.g. LD4 {V0.4H, V1.4H, V2.4H,
- * V3.4H}, [X0], X1. \param dc      The void * dcontext used to allocate memory for the
- * instr_t. \param Vt1     The first destination vector register operand. \param Vt2 The
- * second destination vector register operand. \param Vt3     The third destination vector
- * register operand. \param Vt4     The fourth destination vector register operand. \param
- * Xn      The stack-pointer or GPR to load into the destination vectors. \param Xn The
- * register to load into Vt and Vt2. \param Xnd     The disposition of Xn. \param index
- * The index of the vectors \param offset  The post-index offset.
+ * structures to four vector registers with post-index, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Vt4     The fourth destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into the destination vectors.
+ * \param Xn      The register to load into Vt and Vt2.
+ * \param Xnd     The disposition of Xn.
+ * \param index   The index of the vectors
+ * \param offset  The post-index offset.
  */
 #define INSTR_CREATE_ld4_2(dc, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, index, offset)              \
     instr_create_5dst_8src(dc, OP_ld4, Vt1, Vt2, Vt3, Vt4, Xn, Vt1, Vt2, Vt3, Vt4, Xnd, \
                            index, Xn, offset)
 
 /**
- * Creates an Advanced SIMD (NEON) LD4R instruction to load and replicate a single
- * 4-element structure to four vector registers, e.g. LD4R {V0.4H, V1.4H, V2.4H, V3.4H},
- * [X0]. \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * Creates an Advanced SIMD (NEON) LD4R instruction to load and replicate a single 4-element
+ * structure to four vector registers, e.g. LD4R {V0.4H, V1.4H, V2.4H, V3.4H}, [X0].
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Vt1     The first destination vector register operand.
  * \param Vt2     The second destination vector register operand.
  * \param Vt3     The third destination vector register operand.
@@ -2450,10 +2458,10 @@ enum {
     instr_create_4dst_1src(dc, OP_ld4r, Vt1, Vt2, Vt3, Vt4, Xn)
 
 /**
- * Creates an Advanced SIMD (NEON) LD4R instruction to load and replicate a single
- * 4-element structure to four vector registers with post-indexing, e.g. LD4 {V0.4H,
- * V1.4H, V2.4H, V3.4H}, [X0], X1. \param dc      The void * dcontext used to allocate
- * memory for the instr_t. \param Vt1     The first destination vector register operand.
+ * Creates an Advanced SIMD (NEON) LD4R instruction to load and replicate a single 4-element
+ * structure to four vector registers with post-indexing, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
  * \param Vt2     The second destination vector register operand.
  * \param Vt3     The third destination vector register operand.
  * \param Vt4     The fourth destination vector register operand.

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -2063,6 +2063,29 @@ enum {
 #define INSTR_CREATE_frinti_scalar(dc, Rd, Rm) \
     instr_create_1dst_1src(dc, OP_frinti, Rd, Rm)
 
+/**
+ * Creates a LDPSW floating point instruction.
+ * \param dc    The void * dcontext used to allocate memory for the instr_t.
+ * \param Xt1   The first GPR output register.
+ * \param Xt2   The second GPR output register.
+ * \param Xn    The input Stack-pointer or GPR register.
+ * \param Xr    The disposition of the input Stack-pointer or GPR register.
+ * \param imm   The immediate integer offset.
+ */
+
+#define INSTR_CREATE_ldpsw(dc, Xt1, Xt2, Xn, Xr, imm) \
+    instr_create_3dst_3src(dc, OP_ldpsw, Xt1, Xt2, Xn, Xr, Xn, imm)
+
+/**
+ * Creates a LDPSW floating point instruction.
+ * \param dc    dc
+ * \param Xt1   The first GPR output register.
+ * \param Xt2   The second GPR output register.
+ * \param Xn    The disposition of the input register.
+ */
+#define INSTR_CREATE_ldpsw_2(dc, Xt1, Xt2, Xn) \
+    instr_create_2dst_1src(dc, OP_ldpsw, Xt1, Xt2, Xn)
+
 /* -------- Floating-point data-processing (2 source) ------------------ */
 
 /**
@@ -2202,6 +2225,260 @@ enum {
     instr_create_1dst_3src(dc, OP_fnmsub, Rd, Rm, Rn, Ra)
 
 /* Advanced SIMD (NEON) memory instructions */
+
+#define INSTR_CREATE_ld2_multi(dc, Vt1, Vt2, Xn, index) instr_create_2dst_2src(dc, OP_ld2, Vt1, Vt2, Xn, index)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD2 instruction to load multiple 2-element
+ * structures to two vector registers with post-indexing, e.g. LD2 {V0.4H, V1.4H}, [X0], #32.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into Vt1 and Vt2.
+ * \param disp    The disposition of Xn.
+ * \param index   The element index of the vectors.
+ * \param offset  The post-index offset.
+ */
+#define INSTR_CREATE_ld2_multi_2(dc, Vt1, Vt2, Xn, disp, index, offset) \
+    instr_create_3dst_4src(dc, OP_ld2, Vt1, Vt2, Xn, disp, index, Xn, offset)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD2 instruction to load a 2-element
+ * structure to the index of two vector registers, e.g. LD2 {V0.4H, V1.4H}[5], [X0].
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into Vt1 and Vt2.
+ * \param index   The vector element index.
+ */
+#define INSTR_CREATE_ld2(dc, Vt1, Vt2, Xn, index) \
+    instr_create_2dst_2src(dc, OP_ld2, Vt1, Vt2, Xn, index)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD2 instruction to load a 2-element
+ * structure to the index of two vector registers with post-indexing,
+ * e.g. LD2 {V0.4H, V1.4H}[5], [X0], X1.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Xn      The stack-pointer or register to load into Vt and Vt2.
+ * \param Xnd     The disposition of Xn.
+ * \param index   The index of the destination vectors.
+ * \param offset  The post-index offset.
+ */
+#define INSTR_CREATE_ld2_2(dc, Vt1, Vt2, Xn, Xnd, index, offset) \
+    instr_create_3dst_6src(dc, OP_ld2, Vt1, Vt2, Xn, Vt1, Vt2, Xnd, index, Xn, offset)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD2R instruction to load and replicate a
+ * single 2-element structure to all lanes of two vector registers,
+ * e.g. LD2R {V0.4H, V1.4H}, [X0].
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into Vt1 and Vt2.
+ */
+#define INSTR_CREATE_ld2r(dc, Vt1, Vt2, Xn) \
+    instr_create_2dst_1src(dc, OP_ld2r, Vt1, Vt2, Xn)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD2R instruction to load and replicate a
+ * single 2-element structure to all lanes of two vector registers with post-indexing
+ * , e.g. LD2R {V0.4H, V1.4H}, [X0], X1.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into Vt and Vt2.
+ * \param Xnd     Disposition of Xn.
+ * \param Xm      The post-index offset.
+ */
+#define INSTR_CREATE_ld2r_2(dc, Vt1, Vt2, Xn, Xnd, Xm) \
+    instr_create_3dst_3src(dc, OP_ld2r, Vt1, Vt2, Xn, Xnd, Xn, Xm)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD3 instruction to load multiple 3-element
+ * structures from memory to three vector register,
+ * e.g. LD3 {V0.4H, V1.4H, V2.4H}, [X0].
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and Vt3.
+ * \param index   The index of the vectors.
+ */
+#define INSTR_CREATE_ld3_multi(dc, Vt1, Vt2, Vt3, Xn, index) \
+    instr_create_3dst_2src(dc, OP_ld3, Vt1, Vt2, Vt3, Xn, index)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD3 instruction to load multiple 3-element
+ * structures from memory to the index of three vector registers with
+ * post-index offset, e.g. LD3 {V0.4H, V1.4H, V2.4H}, [X0], X1.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and Vt3.
+ * \param Xnd     The disposition of Xn.
+ * \param index   The index of the vectors.
+ * \param Xm      The post-index offset.
+ */
+#define INSTR_CREATE_ld3_multi_2(dc, Vt1, Vt2, Vt3, Xn, Xnd, index, Xm) \
+    instr_create_4dst_4src(dc, OP_ld3, Vt1, Vt2, Vt3, Xn, Xnd, index, Xn, Xm)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD3 instruction to load a single 3-element
+ * structure to the index of three vector registers, e.g. LD3 {V0.4H, V1.4H, V2.4H}[15], [X0].
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Xn      The GPR to load into Vt1, Vt2 and Vt3.
+ * \param index   The index of the vectors.
+ */
+#define INSTR_CREATE_ld3(dc, Vt1, Vt2, Vt3, Xn, index) \
+    instr_create_3dst_2src(dc, OP_ld3, Vt1, Vt2, Vt3, Xn, index)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD3 instruction to load a single 3-element
+ * structure to the index of three vector registers with post-index offset,
+ * e.g. LD3 {V0.4H, V1.4H, V2.4H}[15], [X0], X1.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Xn      The register to load into Vt, Vt2 and Vt3.
+ * \param Xnd     The disposition of Xn.
+ * \param index   The index of the vectors.
+ * \param offset  The immediate or GPR post-index offset.
+ */
+#define INSTR_CREATE_ld3_2(dc, Vt1, Vt2, Vt3, Xn, Xnd, index, offset) \
+    instr_create_4dst_7src(dc, OP_ld3, Vt1, Vt2, Vt3, Xn, Vt1, Vt2, Vt3, Xnd, index, Xn, offset)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single 3-element
+ * structure to the index of three vector registers,
+ * e.g. LD3 {V0.4H, V1.4H, V2.4H}[15], [X0].
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and Vt3.
+ */
+#define INSTR_CREATE_ld3r(dc, Vt1, Vt2, Vt3, Xn) \
+    instr_create_3dst_1src(dc, OP_ld3r, Vt1, Vt2, Vt3, Xn)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single 3-element
+ * structure to the index of three vector registers with post-index offset,
+ * e.g. LD3 {V0.4H, V1.4H, V2.4H}[15], [X0], X1.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and Vt3.
+ * \param Xnd     The disposition of Xn.
+ * \param offset  The immediate or GPR post-index offset
+ */
+#define INSTR_CREATE_ld3r_2(dc, Vt1, Vt2, Vt3, Xn, Xnd, offset) \
+    instr_create_4dst_3src(dc, OP_ld3r, Vt1, Vt2, Vt3, Xn, Xnd, Xn, offset)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD4 instruction to load single or multiple 4-element
+ * structures to four vector registers, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0].
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Vt4     The fourth destination vector register operand.
+ * \param Xn      The stack-pointer or register to load into the destination vectors.
+ * \param index   The immediate or GPR post-index offset.
+ */
+#define INSTR_CREATE_ld4_multi(dc, Vt1, Vt2, Vt3, Vt4, Xn, index) \
+    instr_create_4dst_2src(dc, OP_ld4, Vt1, Vt2, Vt3, Vt4, Xn, index)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD4 instruction to load multiple 4-element
+ * structures to four vector registers with post-index, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Vt4     The fourth destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into the destination vectors
+ * \param Xnd     The disposition of Xn
+ * \param index   The index of the vectors.
+ * \param offset  The post-index offset.
+ */
+#define INSTR_CREATE_ld4_multi_2(dc, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, index, offset) \
+    instr_create_5dst_4src(dc, OP_ld4, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, index, Xn, offset)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD4 instruction to load single or multiple 4-element
+ * structures to four vector registers, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0].
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Vt4     The fourth destination vector register operand.
+ * \param Xn      The stack-pointer or register to load into the destination vectors.
+ * \param index   The immediate or GPR post-index offset.
+ */
+#define INSTR_CREATE_ld4(dc, Vt1, Vt2, Vt3, Vt4, Xn, index) \
+    instr_create_4dst_2src(dc, OP_ld4, Vt1, Vt2, Vt3, Vt4, Xn, index)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD4 instruction to load a single 4-element
+ * structures to four vector registers with post-index, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Vt4     The fourth destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into the destination vectors.
+ * \param Xn      The register to load into Vt and Vt2.
+ * \param Xnd     The disposition of Xn.
+ * \param index   The index of the vectors
+ * \param offset  The post-index offset.
+ */
+#define INSTR_CREATE_ld4_2(dc, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, index, offset) \
+    instr_create_5dst_8src(dc, OP_ld4, Vt1, Vt2, Vt3, Vt4, Xn, Vt1, Vt2, Vt3, Vt4, Xnd, index, Xn, offset)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD4R instruction to load and replicate a single 4-element
+ * structure to four vector registers, e.g. LD4R {V0.4H, V1.4H, V2.4H, V3.4H}, [X0].
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Vt4     The fourth destination vector register operand.
+ * \param Xn      The stack-pointer or GPR to load into the destination vectors.
+ */
+#define INSTR_CREATE_ld4r(dc, Vt1, Vt2, Vt3, Vt4, Xn) \
+    instr_create_4dst_1src(dc, OP_ld4r, Vt1, Vt2, Vt3, Vt4, Xn)
+
+/**
+ * Creates an Advanced SIMD (NEON) LD4R instruction to load and replicate a single 4-element
+ * structure to four vector registers with post-indexing, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Vt1     The first destination vector register operand.
+ * \param Vt2     The second destination vector register operand.
+ * \param Vt3     The third destination vector register operand.
+ * \param Vt4     The fourth destination vector register operand.
+ * \param Xn      The stack-pointer or register to load into the destination vectors.
+ * \param Xnd     The disposition of Xn.
+ * \param offset  The post-index offset.
+ */
+#define INSTR_CREATE_ld4r_2(dc, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, offset) \
+    instr_create_5dst_3src(dc, OP_ld4r, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, Xn, offset)
+
+/**
+ * Creates an Advanced SIMD (NEON) ST1 instruction to store multiple
+ * single element structures from one vector register, e.g. ST1 {V1.2S},[X1].
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param r       The destination memory operand.
+ * \param q       The source vector register operand.
+ * \param s       The size of the vector element.
+ */
 
 /**
  * Creates an Advanced SIMD (NEON) LD1 instruction to load multiple

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -2355,29 +2355,26 @@ enum {
                            offset)
 
 /**
- * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single 3-element
- * structure to the index of three vector registers,
- * e.g. LD3 {V0.4H, V1.4H, V2.4H}[15], [X0].
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Vt1     The first destination vector register operand.
- * \param Vt2     The second destination vector register operand.
- * \param Vt3     The third destination vector register operand.
- * \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and Vt3.
+ * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single
+ * 3-element structure to the index of three vector registers, e.g. LD3 {V0.4H, V1.4H,
+ * V2.4H}[15], [X0]. \param dc      The void * dcontext used to allocate memory for the
+ * instr_t. \param Vt1     The first destination vector register operand. \param Vt2 The
+ * second destination vector register operand. \param Vt3     The third destination vector
+ * register operand. \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and
+ * Vt3.
  */
 #define INSTR_CREATE_ld3r(dc, Vt1, Vt2, Vt3, Xn) \
     instr_create_3dst_1src(dc, OP_ld3r, Vt1, Vt2, Vt3, Xn)
 
 /**
- * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single 3-element
- * structure to the index of three vector registers with post-index offset,
- * e.g. LD3 {V0.4H, V1.4H, V2.4H}[15], [X0], X1.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Vt1     The first destination vector register operand.
- * \param Vt2     The second destination vector register operand.
- * \param Vt3     The third destination vector register operand.
- * \param Xn      The stack-pointer or GPR to load into Vt1, Vt2 and Vt3.
- * \param Xnd     The disposition of Xn.
- * \param offset  The immediate or GPR post-index offset
+ * Creates an Advanced SIMD (NEON) LD3 instruction to load and replicate a single
+ * 3-element structure to the index of three vector registers with post-index offset, e.g.
+ * LD3 {V0.4H, V1.4H, V2.4H}[15], [X0], X1. \param dc      The void * dcontext used to
+ * allocate memory for the instr_t. \param Vt1     The first destination vector register
+ * operand. \param Vt2     The second destination vector register operand. \param Vt3 The
+ * third destination vector register operand. \param Xn      The stack-pointer or GPR to
+ * load into Vt1, Vt2 and Vt3. \param Xnd     The disposition of Xn. \param offset  The
+ * immediate or GPR post-index offset
  */
 #define INSTR_CREATE_ld3r_2(dc, Vt1, Vt2, Vt3, Xn, Xnd, offset) \
     instr_create_4dst_3src(dc, OP_ld3r, Vt1, Vt2, Vt3, Xn, Xnd, Xn, offset)
@@ -2398,7 +2395,8 @@ enum {
 
 /**
  * Creates an Advanced SIMD (NEON) LD4 instruction to load multiple 4-element
- * structures to four vector registers with post-index, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
+ * structures to four vector registers with post-index,
+ * e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
  * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Vt1     The first destination vector register operand.
  * \param Vt2     The second destination vector register operand.
@@ -2428,7 +2426,8 @@ enum {
 
 /**
  * Creates an Advanced SIMD (NEON) LD4 instruction to load a single 4-element
- * structures to four vector registers with post-index, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
+ * structures to four vector registers with post-index,
+ * e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
  * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Vt1     The first destination vector register operand.
  * \param Vt2     The second destination vector register operand.
@@ -2445,8 +2444,9 @@ enum {
                            index, Xn, offset)
 
 /**
- * Creates an Advanced SIMD (NEON) LD4R instruction to load and replicate a single 4-element
- * structure to four vector registers, e.g. LD4R {V0.4H, V1.4H, V2.4H, V3.4H}, [X0].
+ * Creates an Advanced SIMD (NEON) LD4R instruction to load
+ * and replicate a single 4-element structure to four vector registers,
+ * e.g. LD4R {V0.4H, V1.4H, V2.4H, V3.4H}, [X0].
  * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Vt1     The first destination vector register operand.
  * \param Vt2     The second destination vector register operand.
@@ -2458,8 +2458,9 @@ enum {
     instr_create_4dst_1src(dc, OP_ld4r, Vt1, Vt2, Vt3, Vt4, Xn)
 
 /**
- * Creates an Advanced SIMD (NEON) LD4R instruction to load and replicate a single 4-element
- * structure to four vector registers with post-indexing, e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
+ * Creates an Advanced SIMD (NEON) LD4R instruction to load and
+ * replicate a single 4-element structure to four vector registers with post-indexing,
+ * e.g. LD4 {V0.4H, V1.4H, V2.4H, V3.4H}, [X0], X1.
  * \param dc      The void * dcontext used to allocate memory for the instr_t.
  * \param Vt1     The first destination vector register operand.
  * \param Vt2     The second destination vector register operand.

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -2465,15 +2465,6 @@ enum {
     instr_create_5dst_3src(dc, OP_ld4r, Vt1, Vt2, Vt3, Vt4, Xn, Xnd, Xn, offset)
 
 /**
- * Creates an Advanced SIMD (NEON) ST1 instruction to store multiple
- * single element structures from one vector register, e.g. ST1 {V1.2S},[X1].
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param r       The destination memory operand.
- * \param q       The source vector register operand.
- * \param s       The size of the vector element.
- */
-
-/**
  * Creates an Advanced SIMD (NEON) LD1 instruction to load multiple
  * single element structures to one vector register, e.g. LD1 {V0.4H},[X0].
  * \param dc      The void * dcontext used to allocate memory for the instr_t.
@@ -2492,12 +2483,6 @@ enum {
  * \param s       The size of the vector element.
  */
 #define INSTR_CREATE_st1_multi_1(dc, r, q, s) instr_create_1dst_2src(dc, OP_st1, r, q, s)
-
-/* TODO i#2626: Remaining advanced SIMD (NEON) memory instructions:
- * #define INSTR_CREATE_ld2/3/4_multi_2/3/4()
- * #define INSTR_CREATE_ld1/2/3/4_single()
- * and st1 equivalents including post-index variants.
- */
 
 /* -------- SVE bitwise logical operations (predicated) ---------------- */
 

--- a/core/ir/instr_api.h
+++ b/core/ir/instr_api.h
@@ -2205,7 +2205,8 @@ DR_API
  */
 instr_t *
 instr_create_3dst_6src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
-                       opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4, opnd_t src5, opnd_t src6);
+                       opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4, opnd_t src5,
+                       opnd_t src6);
 
 DR_API
 /**
@@ -2281,7 +2282,8 @@ DR_API
  */
 instr_t *
 instr_create_5dst_4src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
-                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4);
+                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3,
+                       opnd_t src4);
 
 DR_API
 /**
@@ -2292,8 +2294,8 @@ DR_API
  */
 instr_t *
 instr_create_5dst_8src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
-                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4,
-                       opnd_t src5, opnd_t src6, opnd_t src7, opnd_t src8);
+                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3,
+                       opnd_t src4, opnd_t src5, opnd_t src6, opnd_t src7, opnd_t src8);
 
 DR_API
 /**

--- a/core/ir/instr_api.h
+++ b/core/ir/instr_api.h
@@ -2145,6 +2145,17 @@ DR_API
 /**
  * Convenience routine that returns an initialized instr_t allocated
  * on the thread-local heap with opcode \p opcode, three destinations
+ *  * (\p dst1, \p dst2, \p dst3) and one source
+ * (\p src1).
+ */
+instr_t *
+instr_create_3dst_1src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t src1);
+
+DR_API
+/**
+ * Convenience routine that returns an initialized instr_t allocated
+ * on the thread-local heap with opcode \p opcode, three destinations
  * (\p dst1, \p dst2, \p dst3) and two sources
  * (\p src1, \p src2).
  */
@@ -2188,6 +2199,17 @@ instr_create_3dst_5src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, op
 DR_API
 /**
  * Convenience routine that returns an initialized instr_t allocated
+ * on the thread-local heap with opcode \p opcode, three destinations
+ * (\p dst1, \p dst2, \p dst3) and six sources
+ * (\p src1, \p src2, \p src3, \p src4, \p src5, \p src6).
+ */
+instr_t *
+instr_create_3dst_6src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4, opnd_t src5, opnd_t src6);
+
+DR_API
+/**
+ * Convenience routine that returns an initialized instr_t allocated
  * on the thread-local heap with opcode \p opcode, four destinations
  * (\p dst1, \p dst2, \p dst3, \p dst4) and 1 source (\p src).
  */
@@ -2209,12 +2231,69 @@ DR_API
 /**
  * Convenience routine that returns an initialized instr_t allocated
  * on the thread-local heap with opcode \p opcode, four destinations
+ * (\p dst1, \p dst2, \p dst3, \p dst4) and 3 sources
+ * (\p src1, \p src2 and \p src3).
+ */
+instr_t *
+instr_create_4dst_3src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t dst4, opnd_t src1, opnd_t src2, opnd_t src3);
+
+DR_API
+/**
+ * Convenience routine that returns an initialized instr_t allocated
+ * on the thread-local heap with opcode \p opcode, four destinations
  * (\p dst1, \p dst2, \p dst3, \p dst4) and four sources
  * (\p src1, \p src2, \p src3, \p src4).
  */
 instr_t *
 instr_create_4dst_4src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
                        opnd_t dst4, opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4);
+
+DR_API
+/**
+ * Convenience routine that returns an initialized instr_t allocated
+ * on the thread-local heap with opcode \p opcode, four destinations
+ * (\p dst1, \p dst2, \p dst3, \p dst4) and seven sources
+ * (\p src1, \p src2, \p src3, \p src4, \p src5, \p src6, \p src7).
+ */
+instr_t *
+instr_create_4dst_7src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t dst4, opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4,
+                       opnd_t src5, opnd_t src6, opnd_t src7);
+
+DR_API
+/**
+ * Convenience routine that returns an initialized instr_t allocated
+ * on the thread-local heap with opcode \p opcode, five destinations
+ * (\p dst1, \p dst2, \p dst3, \p dst4, \p dst5) and five sources
+ * (\p src1, \p src2, \p src3).
+ */
+instr_t *
+instr_create_5dst_3src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3);
+
+DR_API
+/**
+ * Convenience routine that returns an initialized instr_t allocated
+ * on the thread-local heap with opcode \p opcode, five destinations
+ * (\p dst1, \p dst2, \p dst3, \p dst4, \p dst5) and five sources
+ * (\p src1, \p src2, \p src3, \p src4).
+ */
+instr_t *
+instr_create_5dst_4src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4);
+
+DR_API
+/**
+ * Convenience routine that returns an initialized instr_t allocated
+ * on the thread-local heap with opcode \p opcode, five destinations
+ * (\p dst1, \p dst2, \p dst3, \p dst4, \p dst5) and eight sources
+ * (\p src1, \p src2, \p src3, \p src4, \p src5, \p src6, \p src7, \p src8).
+ */
+instr_t *
+instr_create_5dst_8src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4,
+                       opnd_t src5, opnd_t src6, opnd_t src7, opnd_t src8);
 
 DR_API
 /**

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -3053,7 +3053,8 @@ instr_create_3dst_5src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, op
 instr_t *
 
 instr_create_3dst_6src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
-                       opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4, opnd_t src5, opnd_t src6)
+                       opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4, opnd_t src5,
+                       opnd_t src6)
 {
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     instr_t *in = instr_build(dcontext, opcode, 3, 6);
@@ -3171,7 +3172,8 @@ instr_create_5dst_3src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, op
 
 instr_t *
 instr_create_5dst_4src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
-                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4)
+                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3,
+                       opnd_t src4)
 {
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     instr_t *in = instr_build(dcontext, opcode, 5, 4);
@@ -3189,8 +3191,8 @@ instr_create_5dst_4src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, op
 
 instr_t *
 instr_create_5dst_8src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
-                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4,
-                       opnd_t src5, opnd_t src6, opnd_t src7, opnd_t src8)
+                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3,
+                       opnd_t src4, opnd_t src5, opnd_t src6, opnd_t src7, opnd_t src8)
 {
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     instr_t *in = instr_build(dcontext, opcode, 5, 8);

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -2976,6 +2976,19 @@ instr_create_3dst_0src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, op
 }
 
 instr_t *
+instr_create_3dst_1src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t src1)
+{
+    dcontext_t *dcontext = (dcontext_t *)drcontext;
+    instr_t *in = instr_build(dcontext, opcode, 3, 1);
+    instr_set_dst(in, 0, dst1);
+    instr_set_dst(in, 1, dst2);
+    instr_set_dst(in, 2, dst3);
+    instr_set_src(in, 0, src1);
+    return in;
+}
+
+instr_t *
 instr_create_3dst_2src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
                        opnd_t src1, opnd_t src2)
 {
@@ -3038,6 +3051,25 @@ instr_create_3dst_5src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, op
 }
 
 instr_t *
+
+instr_create_3dst_6src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4, opnd_t src5, opnd_t src6)
+{
+    dcontext_t *dcontext = (dcontext_t *)drcontext;
+    instr_t *in = instr_build(dcontext, opcode, 3, 6);
+    instr_set_dst(in, 0, dst1);
+    instr_set_dst(in, 1, dst2);
+    instr_set_dst(in, 2, dst3);
+    instr_set_src(in, 0, src1);
+    instr_set_src(in, 1, src2);
+    instr_set_src(in, 2, src3);
+    instr_set_src(in, 3, src4);
+    instr_set_src(in, 4, src5);
+    instr_set_src(in, 5, src6);
+    return in;
+}
+
+instr_t *
 instr_create_4dst_1src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
                        opnd_t dst4, opnd_t src)
 {
@@ -3067,6 +3099,22 @@ instr_create_4dst_2src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, op
 }
 
 instr_t *
+instr_create_4dst_3src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t dst4, opnd_t src1, opnd_t src2, opnd_t src3)
+{
+    dcontext_t *dcontext = (dcontext_t *)drcontext;
+    instr_t *in = instr_build(dcontext, opcode, 4, 3);
+    instr_set_dst(in, 0, dst1);
+    instr_set_dst(in, 1, dst2);
+    instr_set_dst(in, 2, dst3);
+    instr_set_dst(in, 3, dst4);
+    instr_set_src(in, 0, src1);
+    instr_set_src(in, 1, src2);
+    instr_set_src(in, 2, src3);
+    return in;
+}
+
+instr_t *
 instr_create_4dst_4src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
                        opnd_t dst4, opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4)
 {
@@ -3080,6 +3128,85 @@ instr_create_4dst_4src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, op
     instr_set_src(in, 1, src2);
     instr_set_src(in, 2, src3);
     instr_set_src(in, 3, src4);
+    return in;
+}
+
+instr_t *
+instr_create_4dst_7src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t dst4, opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4,
+                       opnd_t src5, opnd_t src6, opnd_t src7)
+{
+    dcontext_t *dcontext = (dcontext_t *)drcontext;
+    instr_t *in = instr_build(dcontext, opcode, 4, 7);
+    instr_set_dst(in, 0, dst1);
+    instr_set_dst(in, 1, dst2);
+    instr_set_dst(in, 2, dst3);
+    instr_set_dst(in, 3, dst4);
+    instr_set_src(in, 0, src1);
+    instr_set_src(in, 1, src2);
+    instr_set_src(in, 2, src3);
+    instr_set_src(in, 3, src4);
+    instr_set_src(in, 4, src5);
+    instr_set_src(in, 5, src6);
+    instr_set_src(in, 6, src7);
+    return in;
+}
+
+instr_t *
+instr_create_5dst_3src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3)
+{
+    dcontext_t *dcontext = (dcontext_t *)drcontext;
+    instr_t *in = instr_build(dcontext, opcode, 5, 3);
+    instr_set_dst(in, 0, dst1);
+    instr_set_dst(in, 1, dst2);
+    instr_set_dst(in, 2, dst3);
+    instr_set_dst(in, 3, dst4);
+    instr_set_dst(in, 4, dst5);
+    instr_set_src(in, 0, src1);
+    instr_set_src(in, 1, src2);
+    instr_set_src(in, 2, src3);
+    return in;
+}
+
+instr_t *
+instr_create_5dst_4src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4)
+{
+    dcontext_t *dcontext = (dcontext_t *)drcontext;
+    instr_t *in = instr_build(dcontext, opcode, 5, 4);
+    instr_set_dst(in, 0, dst1);
+    instr_set_dst(in, 1, dst2);
+    instr_set_dst(in, 2, dst3);
+    instr_set_dst(in, 3, dst4);
+    instr_set_dst(in, 4, dst5);
+    instr_set_src(in, 0, src1);
+    instr_set_src(in, 1, src2);
+    instr_set_src(in, 2, src3);
+    instr_set_src(in, 3, src4);
+    return in;
+}
+
+instr_t *
+instr_create_5dst_8src(void *drcontext, int opcode, opnd_t dst1, opnd_t dst2, opnd_t dst3,
+                       opnd_t dst4, opnd_t dst5, opnd_t src1, opnd_t src2, opnd_t src3, opnd_t src4,
+                       opnd_t src5, opnd_t src6, opnd_t src7, opnd_t src8)
+{
+    dcontext_t *dcontext = (dcontext_t *)drcontext;
+    instr_t *in = instr_build(dcontext, opcode, 5, 8);
+    instr_set_dst(in, 0, dst1);
+    instr_set_dst(in, 1, dst2);
+    instr_set_dst(in, 2, dst3);
+    instr_set_dst(in, 3, dst4);
+    instr_set_dst(in, 4, dst5);
+    instr_set_src(in, 0, src1);
+    instr_set_src(in, 1, src2);
+    instr_set_src(in, 2, src3);
+    instr_set_src(in, 3, src4);
+    instr_set_src(in, 4, src5);
+    instr_set_src(in, 5, src6);
+    instr_set_src(in, 6, src7);
+    instr_set_src(in, 7, src8);
     return in;
 }
 

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -244,39 +244,42 @@ test_add(void *dc)
 }
 
 static void
-adr(void* dc){
-    instr_t *instr = INSTR_CREATE_adr(dc,
-        opnd_create_reg(DR_REG_X1),
-        OPND_CREATE_ABSMEM((void*)0x0000000010010208, OPSZ_0));
+adr(void *dc)
+{
+    instr_t *instr =
+        INSTR_CREATE_adr(dc, opnd_create_reg(DR_REG_X1),
+                         OPND_CREATE_ABSMEM((void *)0x0000000010010208, OPSZ_0));
     test_instr_encoding(dc, OP_adr, instr);
 
     print("adr complete\n");
 }
 
 static void
-adrp(void* dc){
-    instr_t *instr = INSTR_CREATE_adrp(dc,
-        opnd_create_reg(DR_REG_X1),
-        OPND_CREATE_ABSMEM((void*)0x0000000020208000, OPSZ_0));
+adrp(void *dc)
+{
+    instr_t *instr =
+        INSTR_CREATE_adrp(dc, opnd_create_reg(DR_REG_X1),
+                          OPND_CREATE_ABSMEM((void *)0x0000000020208000, OPSZ_0));
     test_instr_encoding(dc, OP_adrp, instr);
 
     print("adrp complete\n");
 }
 
 static void
-ldpsw_base_post_index(void* dc){
+ldpsw_base_post_index(void *dc)
+{
     int dst_reg_0[] = { DR_REG_X1, DR_REG_X15, DR_REG_X29 };
     int dst_reg_1[] = { DR_REG_X2, DR_REG_X16, DR_REG_X30 };
     int src_reg[] = { DR_REG_X0, DR_REG_X14, DR_REG_X28 };
-    int value[] = { 0, 4, 252, -256};
+    int value[] = { 0, 4, 252, -256 };
 
-    for(int i = 0; i < 3; i++){
-        for(int ii = 0; ii < 4; ii++){
-            instr_t* instr = INSTR_CREATE_ldpsw(dc,
-                opnd_create_reg(dst_reg_0[i]),
-                opnd_create_reg(dst_reg_1[i]),
+    for (int i = 0; i < 3; i++) {
+        for (int ii = 0; ii < 4; ii++) {
+            instr_t *instr = INSTR_CREATE_ldpsw(
+                dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
                 opnd_create_reg(src_reg[i]),
-                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_8),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                              OPSZ_8),
                 OPND_CREATE_INT(value[ii]));
             test_instr_encoding(dc, OP_ldpsw, instr);
         }
@@ -285,19 +288,20 @@ ldpsw_base_post_index(void* dc){
 }
 
 static void
-ldpsw_base_pre_index(void* dc){
+ldpsw_base_pre_index(void *dc)
+{
     int dst_reg_0[] = { DR_REG_X1, DR_REG_X15, DR_REG_X29 };
     int dst_reg_1[] = { DR_REG_X2, DR_REG_X16, DR_REG_X30 };
     int src_reg[] = { DR_REG_X0, DR_REG_X14, DR_REG_X28 };
-    int value[] = { 0, 4, 252, -256};
+    int value[] = { 0, 4, 252, -256 };
 
-    for(int i = 0; i < 3; i++){
-        for(int ii = 0; ii < 4; ii++){
-            instr_t* instr = INSTR_CREATE_ldpsw(dc,
-                opnd_create_reg(dst_reg_0[i]),
-                opnd_create_reg(dst_reg_1[i]),
+    for (int i = 0; i < 3; i++) {
+        for (int ii = 0; ii < 4; ii++) {
+            instr_t *instr = INSTR_CREATE_ldpsw(
+                dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
                 opnd_create_reg(src_reg[i]),
-                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, value[ii], 0, OPSZ_8),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false,
+                                              value[ii], 0, OPSZ_8),
                 OPND_CREATE_INT(value[ii]));
             test_instr_encoding(dc, OP_ldpsw, instr);
         }
@@ -306,18 +310,19 @@ ldpsw_base_pre_index(void* dc){
 }
 
 static void
-ldpsw_base_signed_offset(void* dc){
+ldpsw_base_signed_offset(void *dc)
+{
     int dst_reg_0[] = { DR_REG_X1, DR_REG_X15, DR_REG_X29 };
     int dst_reg_1[] = { DR_REG_X2, DR_REG_X16, DR_REG_X30 };
     int src_reg[] = { DR_REG_X0, DR_REG_X14, DR_REG_X28 };
-    int value[] = { 8, 4, 252, -256};
+    int value[] = { 8, 4, 252, -256 };
 
-    for(int i = 0; i < 3; i++){
-        for(int ii = 0; ii < 4; ii++){
-            instr_t* instr = INSTR_CREATE_ldpsw_2(dc,
-                opnd_create_reg(dst_reg_0[i]),
-                opnd_create_reg(dst_reg_1[i]),
-                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, value[ii], 0, OPSZ_8));
+    for (int i = 0; i < 3; i++) {
+        for (int ii = 0; ii < 4; ii++) {
+            instr_t *instr = INSTR_CREATE_ldpsw_2(
+                dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false,
+                                              value[ii], 0, OPSZ_8));
             test_instr_encoding(dc, OP_ldpsw, instr);
         }
     }
@@ -325,7 +330,8 @@ ldpsw_base_signed_offset(void* dc){
 }
 
 static void
-ldpsw(void* dc){
+ldpsw(void *dc)
+{
     ldpsw_base_post_index(dc);
     ldpsw_base_pre_index(dc);
     ldpsw_base_signed_offset(dc);
@@ -364,18 +370,19 @@ test_ldar(void *dc)
 }
 
 static void
-ld2_simdfp_multiple_structures_no_offset(void* dc){
+ld2_simdfp_multiple_structures_no_offset(void *dc)
+{
     const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q14, DR_REG_Q28 };
     const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q15, DR_REG_Q29 };
     const int src_reg[] = { DR_REG_X2, DR_REG_X16, DR_REG_X30 };
     const int index[] = { 0x00 };
 
-    for(int i = 0; i < 3; i++){
-        for(int ii = 0; ii < 1; ii++){
-            instr_t *instr = INSTR_CREATE_ld2_multi(dc,
-                opnd_create_reg(dst_reg_0[i]),
-                opnd_create_reg(dst_reg_1[i]),
-                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_16),
+    for (int i = 0; i < 3; i++) {
+        for (int ii = 0; ii < 1; ii++) {
+            instr_t *instr = INSTR_CREATE_ld2_multi(
+                dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                              OPSZ_16),
                 opnd_create_immed_uint(index[ii], OPSZ_1));
             test_instr_encoding(dc, OP_ld2, instr);
         }
@@ -384,20 +391,20 @@ ld2_simdfp_multiple_structures_no_offset(void* dc){
 }
 
 static void
-ld2_simdfp_multiple_structures_post_index(void* dc){
+ld2_simdfp_multiple_structures_post_index(void *dc)
+{
     const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q29 };
     const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q30 };
     const int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
     const int offset_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
 
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld2_multi_2(dc,
-                opnd_create_reg(dst_reg_0[i]),
-                opnd_create_reg(dst_reg_1[i]),
-                opnd_create_reg(src_reg[i]),
-                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_32),
-                opnd_create_immed_uint(0x00, OPSZ_1),
-                opnd_create_reg(offset_reg[i]));
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld2_multi_2(
+            dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(src_reg[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                          OPSZ_32),
+            opnd_create_immed_uint(0x00, OPSZ_1), opnd_create_reg(offset_reg[i]));
         test_instr_encoding(dc, OP_ld2, instr);
     }
 
@@ -406,25 +413,24 @@ ld2_simdfp_multiple_structures_post_index(void* dc){
     const int imm[] = { 0x10, 0x20 };
     const int opsz[] = { OPSZ_16, OPSZ_32 };
 
-    for(int i = 0; i < 2; i++){
-        instr_t *instr = INSTR_CREATE_ld2_multi_2(dc,
-            opnd_create_reg(dst_reg_post_index_0[i]),
-            opnd_create_reg(dst_reg_post_index_1[i]),
-            opnd_create_reg(src_reg[0]),
-            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0, opsz[i]),
-            opnd_create_immed_uint(0x00, OPSZ_1),
-            opnd_create_immed_uint(imm[i], OPSZ_1));
+    for (int i = 0; i < 2; i++) {
+        instr_t *instr = INSTR_CREATE_ld2_multi_2(
+            dc, opnd_create_reg(dst_reg_post_index_0[i]),
+            opnd_create_reg(dst_reg_post_index_1[i]), opnd_create_reg(src_reg[0]),
+            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0,
+                                          opsz[i]),
+            opnd_create_immed_uint(0x00, OPSZ_1), opnd_create_immed_uint(imm[i], OPSZ_1));
         test_instr_encoding(dc, OP_ld2, instr);
     }
     print("ld2 simdfp multiple structures post-index complete\n");
 }
 
 static void
-ld2_simdfp_single_structure_no_offset(void* dc){
-    for(int index = 0; index < 16; index++){
-        instr_t *instr = INSTR_CREATE_ld2(dc,
-            opnd_create_reg(DR_REG_Q0),
-            opnd_create_reg(DR_REG_Q1),
+ld2_simdfp_single_structure_no_offset(void *dc)
+{
+    for (int index = 0; index < 16; index++) {
+        instr_t *instr = INSTR_CREATE_ld2(
+            dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1),
             opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, OPSZ_2),
             opnd_create_immed_uint(index, OPSZ_1));
         test_instr_encoding(dc, OP_ld2, instr);
@@ -433,11 +439,11 @@ ld2_simdfp_single_structure_no_offset(void* dc){
     const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q29 };
     const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q30 };
     const int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld2(dc,
-            opnd_create_reg(dst_reg_0[i]),
-            opnd_create_reg(dst_reg_1[i]),
-            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_2),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld2(
+            dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                          OPSZ_2),
             opnd_create_immed_uint(0x01, OPSZ_1));
         test_instr_encoding(dc, OP_ld2, instr);
     }
@@ -446,54 +452,48 @@ ld2_simdfp_single_structure_no_offset(void* dc){
 }
 
 static void
-ld2_simdfp_single_structure_post_index(void* dc){
-    for(int index = 1; index < 16; index++){
-        instr_t *instr = INSTR_CREATE_ld2_2(dc,
-            opnd_create_reg(DR_REG_Q0),
-            opnd_create_reg(DR_REG_Q1),
+ld2_simdfp_single_structure_post_index(void *dc)
+{
+    for (int index = 1; index < 16; index++) {
+        instr_t *instr = INSTR_CREATE_ld2_2(
+            dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1),
             opnd_create_reg(DR_REG_X0),
             opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, OPSZ_2),
-            opnd_create_immed_uint(index, OPSZ_1),
-            opnd_create_immed_uint(0x02, OPSZ_1));
+            opnd_create_immed_uint(index, OPSZ_1), opnd_create_immed_uint(0x02, OPSZ_1));
         test_instr_encoding(dc, OP_ld2, instr);
     }
 
     const int dst_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q29 };
     const int dst_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q30 };
     const int src[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld2_2(dc,
-            opnd_create_reg(dst_0[i]),
-            opnd_create_reg(dst_1[i]),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld2_2(
+            dc, opnd_create_reg(dst_0[i]), opnd_create_reg(dst_1[i]),
             opnd_create_reg(src[i]),
             opnd_create_base_disp_aarch64(src[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_2),
-            opnd_create_immed_uint(0x01, OPSZ_1),
-            opnd_create_immed_uint(0x02, OPSZ_1));
+            opnd_create_immed_uint(0x01, OPSZ_1), opnd_create_immed_uint(0x02, OPSZ_1));
         test_instr_encoding(dc, OP_ld2, instr);
     }
 
     const int opsz[] = { OPSZ_2, OPSZ_4, OPSZ_8, OPSZ_16 };
     const int imm[] = { 2, 4, 8, 16 };
-    for(int i = 0; i < 4; i++){
-        instr_t *instr = INSTR_CREATE_ld2_2(dc,
-            opnd_create_reg(DR_REG_Q0),
-            opnd_create_reg(DR_REG_Q1),
+    for (int i = 0; i < 4; i++) {
+        instr_t *instr = INSTR_CREATE_ld2_2(
+            dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1),
             opnd_create_reg(DR_REG_X0),
-            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, opsz[i]),
-            opnd_create_immed_uint(0x01, OPSZ_1),
-            opnd_create_immed_uint(imm[i], OPSZ_1));
+            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0,
+                                          opsz[i]),
+            opnd_create_immed_uint(0x01, OPSZ_1), opnd_create_immed_uint(imm[i], OPSZ_1));
         test_instr_encoding(dc, OP_ld2, instr);
     }
 
     const int offset_reg[] = { DR_REG_X1, DR_REG_X16, DR_REG_X29 };
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld2_2(dc,
-            opnd_create_reg(dst_0[i]),
-            opnd_create_reg(dst_1[i]),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld2_2(
+            dc, opnd_create_reg(dst_0[i]), opnd_create_reg(dst_1[i]),
             opnd_create_reg(src[i]),
             opnd_create_base_disp_aarch64(src[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_2),
-            opnd_create_immed_uint(0x01, OPSZ_1),
-            opnd_create_reg(offset_reg[i]));
+            opnd_create_immed_uint(0x01, OPSZ_1), opnd_create_reg(offset_reg[i]));
         test_instr_encoding(dc, OP_ld2, instr);
     }
 
@@ -501,7 +501,8 @@ ld2_simdfp_single_structure_post_index(void* dc){
 }
 
 static void
-ld2(void* dc){
+ld2(void *dc)
+{
     ld2_simdfp_multiple_structures_no_offset(dc);
     ld2_simdfp_multiple_structures_post_index(dc);
     ld2_simdfp_single_structure_no_offset(dc);
@@ -510,22 +511,22 @@ ld2(void* dc){
     print("ld2 complete\n");
 }
 
-
 static void
-ld3_simdfp_multiple_structures_no_offset(void* dc){
+ld3_simdfp_multiple_structures_no_offset(void *dc)
+{
     const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q14, DR_REG_Q28 };
     const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q15, DR_REG_Q29 };
     const int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q16, DR_REG_Q30 };
     const int src_reg[] = { DR_REG_X2, DR_REG_X16, DR_REG_X30 };
     const int index[] = { 0x00 };
 
-    for(int i = 0; i < 3; i++){
-        for(int ii = 0; ii < 1; ii++){
-            instr_t *instr = INSTR_CREATE_ld3_multi(dc,
-                opnd_create_reg(dst_reg_0[i]),
-                opnd_create_reg(dst_reg_1[i]),
+    for (int i = 0; i < 3; i++) {
+        for (int ii = 0; ii < 1; ii++) {
+            instr_t *instr = INSTR_CREATE_ld3_multi(
+                dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
                 opnd_create_reg(dst_reg_2[i]),
-                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_24),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                              OPSZ_24),
                 opnd_create_immed_uint(index[ii], OPSZ_1));
             test_instr_encoding(dc, OP_ld3, instr);
         }
@@ -534,22 +535,21 @@ ld3_simdfp_multiple_structures_no_offset(void* dc){
 }
 
 static void
-ld3_simdfp_multiple_structures_post_index(void* dc){
+ld3_simdfp_multiple_structures_post_index(void *dc)
+{
     const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q28 };
     const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q29 };
     const int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q30 };
     const int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
     const int offset_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
 
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld3_multi_2(dc,
-                opnd_create_reg(dst_reg_0[i]),
-                opnd_create_reg(dst_reg_1[i]),
-                opnd_create_reg(dst_reg_2[i]),
-                opnd_create_reg(src_reg[i]),
-                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_48),
-                opnd_create_immed_uint(0x00, OPSZ_1),
-                opnd_create_reg(offset_reg[i]));
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld3_multi_2(
+            dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]), opnd_create_reg(src_reg[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                          OPSZ_48),
+            opnd_create_immed_uint(0x00, OPSZ_1), opnd_create_reg(offset_reg[i]));
         test_instr_encoding(dc, OP_ld3, instr);
     }
 
@@ -559,26 +559,25 @@ ld3_simdfp_multiple_structures_post_index(void* dc){
     const int imm[] = { 0x18, 0x30 };
     const int opsz[] = { OPSZ_24, OPSZ_48 };
 
-    for(int i = 0; i < 2; i++){
-        instr_t *instr = INSTR_CREATE_ld3_multi_2(dc,
-            opnd_create_reg(dst_reg_post_index_0[i]),
+    for (int i = 0; i < 2; i++) {
+        instr_t *instr = INSTR_CREATE_ld3_multi_2(
+            dc, opnd_create_reg(dst_reg_post_index_0[i]),
             opnd_create_reg(dst_reg_post_index_1[i]),
-            opnd_create_reg(dst_reg_post_index_2[i]),
-            opnd_create_reg(src_reg[0]),
-            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0, opsz[i]),
-            opnd_create_immed_uint(0x00, OPSZ_1),
-            opnd_create_immed_uint(imm[i], OPSZ_1));
+            opnd_create_reg(dst_reg_post_index_2[i]), opnd_create_reg(src_reg[0]),
+            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0,
+                                          opsz[i]),
+            opnd_create_immed_uint(0x00, OPSZ_1), opnd_create_immed_uint(imm[i], OPSZ_1));
         test_instr_encoding(dc, OP_ld3, instr);
     }
     print("ld3 simdfp multiple structures post-index complete\n");
 }
 
 static void
-ld3_simdfp_single_structure_no_offset(void* dc){
-    for(int index = 0; index < 16; index++){
-        instr_t *instr = INSTR_CREATE_ld3(dc,
-            opnd_create_reg(DR_REG_Q0),
-            opnd_create_reg(DR_REG_Q1),
+ld3_simdfp_single_structure_no_offset(void *dc)
+{
+    for (int index = 0; index < 16; index++) {
+        instr_t *instr = INSTR_CREATE_ld3(
+            dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1),
             opnd_create_reg(DR_REG_Q2),
             opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, OPSZ_3),
             opnd_create_immed_uint(index, OPSZ_1));
@@ -589,29 +588,27 @@ ld3_simdfp_single_structure_no_offset(void* dc){
     const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q29 };
     const int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q30 };
     const int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld3(dc,
-            opnd_create_reg(dst_reg_0[i]),
-            opnd_create_reg(dst_reg_1[i]),
-            opnd_create_reg(dst_reg_2[i]),
-            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_3),
-            opnd_create_immed_uint(0x01, OPSZ_1));
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr =
+            INSTR_CREATE_ld3(dc, opnd_create_reg(dst_reg_0[i]),
+                             opnd_create_reg(dst_reg_1[i]), opnd_create_reg(dst_reg_2[i]),
+                             opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0,
+                                                           false, 0, 0, OPSZ_3),
+                             opnd_create_immed_uint(0x01, OPSZ_1));
         test_instr_encoding(dc, OP_ld3, instr);
     }
     print("ld3 simdfp single structure no offset complete\n");
 }
 
 static void
-ld3_simdfp_single_structure_post_index(void* dc){
-    for(int index = 0; index < 16; index++){
-        instr_t *instr = INSTR_CREATE_ld3_2(dc,
-            opnd_create_reg(DR_REG_Q0),
-            opnd_create_reg(DR_REG_Q1),
-            opnd_create_reg(DR_REG_Q2),
-            opnd_create_reg(DR_REG_X0),
+ld3_simdfp_single_structure_post_index(void *dc)
+{
+    for (int index = 0; index < 16; index++) {
+        instr_t *instr = INSTR_CREATE_ld3_2(
+            dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_Q2), opnd_create_reg(DR_REG_X0),
             opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, OPSZ_3),
-            opnd_create_immed_uint(index, OPSZ_1),
-            opnd_create_immed_uint(0x03, OPSZ_1));
+            opnd_create_immed_uint(index, OPSZ_1), opnd_create_immed_uint(0x03, OPSZ_1));
         test_instr_encoding(dc, OP_ld3, instr);
     }
 
@@ -619,49 +616,42 @@ ld3_simdfp_single_structure_post_index(void* dc){
     const int dst_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q29 };
     const int dst_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q30 };
     const int src[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld3_2(dc,
-            opnd_create_reg(dst_0[i]),
-            opnd_create_reg(dst_1[i]),
-            opnd_create_reg(dst_2[i]),
-            opnd_create_reg(src[i]),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld3_2(
+            dc, opnd_create_reg(dst_0[i]), opnd_create_reg(dst_1[i]),
+            opnd_create_reg(dst_2[i]), opnd_create_reg(src[i]),
             opnd_create_base_disp_aarch64(src[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_3),
-            opnd_create_immed_uint(0x01, OPSZ_1),
-            opnd_create_immed_uint(0x03, OPSZ_1));
+            opnd_create_immed_uint(0x01, OPSZ_1), opnd_create_immed_uint(0x03, OPSZ_1));
         test_instr_encoding(dc, OP_ld3, instr);
     }
 
     const int opsz[] = { OPSZ_3, OPSZ_6, OPSZ_12, OPSZ_24 };
     const int imm[] = { 3, 6, 12, 24 };
-    for(int i = 0; i < 4; i++){
-        instr_t *instr = INSTR_CREATE_ld3_2(dc,
-            opnd_create_reg(DR_REG_Q0),
-            opnd_create_reg(DR_REG_Q1),
-            opnd_create_reg(DR_REG_Q2),
-            opnd_create_reg(DR_REG_X0),
-            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, opsz[i]),
-            opnd_create_immed_uint(0x01, OPSZ_1),
-            opnd_create_immed_uint(imm[i], OPSZ_1));
+    for (int i = 0; i < 4; i++) {
+        instr_t *instr = INSTR_CREATE_ld3_2(
+            dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_Q2), opnd_create_reg(DR_REG_X0),
+            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0,
+                                          opsz[i]),
+            opnd_create_immed_uint(0x01, OPSZ_1), opnd_create_immed_uint(imm[i], OPSZ_1));
         test_instr_encoding(dc, OP_ld3, instr);
     }
 
     const int offset_reg[] = { DR_REG_X1, DR_REG_X16, DR_REG_X29 };
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld3_2(dc,
-            opnd_create_reg(dst_0[i]),
-            opnd_create_reg(dst_1[i]),
-            opnd_create_reg(dst_2[i]),
-            opnd_create_reg(src[i]),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld3_2(
+            dc, opnd_create_reg(dst_0[i]), opnd_create_reg(dst_1[i]),
+            opnd_create_reg(dst_2[i]), opnd_create_reg(src[i]),
             opnd_create_base_disp_aarch64(src[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_3),
-            opnd_create_immed_uint(0x01, OPSZ_1),
-            opnd_create_reg(offset_reg[i]));
+            opnd_create_immed_uint(0x01, OPSZ_1), opnd_create_reg(offset_reg[i]));
         test_instr_encoding(dc, OP_ld3, instr);
     }
     print("ld3 simdfp single structure post-index complete\n");
 }
 
 static void
-ld3(void* dc){
+ld3(void *dc)
+{
     ld3_simdfp_multiple_structures_no_offset(dc);
     ld3_simdfp_multiple_structures_post_index(dc);
     ld3_simdfp_single_structure_no_offset(dc);
@@ -671,20 +661,20 @@ ld3(void* dc){
 }
 
 static void
-ld4_simdfp_multiple_structures_no_offset(void* dc){
+ld4_simdfp_multiple_structures_no_offset(void *dc)
+{
     const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q14, DR_REG_Q27 };
     const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q15, DR_REG_Q28 };
     const int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q16, DR_REG_Q29 };
     const int dst_reg_3[] = { DR_REG_Q3, DR_REG_Q17, DR_REG_Q30 };
     const int src_reg[] = { DR_REG_X2, DR_REG_X16, DR_REG_X30 };
 
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld4_multi(dc,
-            opnd_create_reg(dst_reg_0[i]),
-            opnd_create_reg(dst_reg_1[i]),
-            opnd_create_reg(dst_reg_2[i]),
-            opnd_create_reg(dst_reg_3[i]),
-            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_64),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld4_multi(
+            dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]), opnd_create_reg(dst_reg_3[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                          OPSZ_64),
             opnd_create_immed_uint(0x00, OPSZ_1));
         test_instr_encoding(dc, OP_ld4, instr);
     }
@@ -692,7 +682,8 @@ ld4_simdfp_multiple_structures_no_offset(void* dc){
 }
 
 static void
-ld4_simdfp_multiple_structures_post_index(void* dc){
+ld4_simdfp_multiple_structures_post_index(void *dc)
+{
     const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q27 };
     const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q28 };
     const int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q29 };
@@ -700,16 +691,14 @@ ld4_simdfp_multiple_structures_post_index(void* dc){
     const int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
     const int offset_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
 
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld4_multi_2(dc,
-                opnd_create_reg(dst_reg_0[i]),
-                opnd_create_reg(dst_reg_1[i]),
-                opnd_create_reg(dst_reg_2[i]),
-                opnd_create_reg(dst_reg_3[i]),
-                opnd_create_reg(src_reg[i]),
-                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_64),
-                opnd_create_immed_uint(0x00, OPSZ_1),
-                opnd_create_reg(offset_reg[i]));
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld4_multi_2(
+            dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]), opnd_create_reg(dst_reg_3[i]),
+            opnd_create_reg(src_reg[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                          OPSZ_64),
+            opnd_create_immed_uint(0x00, OPSZ_1), opnd_create_reg(offset_reg[i]));
         test_instr_encoding(dc, OP_ld4, instr);
     }
 
@@ -720,29 +709,27 @@ ld4_simdfp_multiple_structures_post_index(void* dc){
     const int imm[] = { 0x20, 0x40 };
     const int opsz[] = { OPSZ_32, OPSZ_64 };
 
-    for(int i = 0; i < 2; i++){
-        instr_t *instr = INSTR_CREATE_ld4_multi_2(dc,
-            opnd_create_reg(dst_reg_post_index_0[i]),
+    for (int i = 0; i < 2; i++) {
+        instr_t *instr = INSTR_CREATE_ld4_multi_2(
+            dc, opnd_create_reg(dst_reg_post_index_0[i]),
             opnd_create_reg(dst_reg_post_index_1[i]),
             opnd_create_reg(dst_reg_post_index_2[i]),
-            opnd_create_reg(dst_reg_post_index_3[i]),
-            opnd_create_reg(src_reg[0]),
-            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0, opsz[i]),
-            opnd_create_immed_uint(0x00, OPSZ_1),
-            opnd_create_immed_uint(imm[i], OPSZ_1));
+            opnd_create_reg(dst_reg_post_index_3[i]), opnd_create_reg(src_reg[0]),
+            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0,
+                                          opsz[i]),
+            opnd_create_immed_uint(0x00, OPSZ_1), opnd_create_immed_uint(imm[i], OPSZ_1));
         test_instr_encoding(dc, OP_ld4, instr);
     }
     print("ld4 simdfp multiple structures post-index complete\n");
 }
 
 static void
-ld4_simdfp_single_structure_no_offset(void* dc){
-    for(int index = 0; index < 16; index++){
-        instr_t *instr = INSTR_CREATE_ld4(dc,
-            opnd_create_reg(DR_REG_Q0),
-            opnd_create_reg(DR_REG_Q1),
-            opnd_create_reg(DR_REG_Q2),
-            opnd_create_reg(DR_REG_Q3),
+ld4_simdfp_single_structure_no_offset(void *dc)
+{
+    for (int index = 0; index < 16; index++) {
+        instr_t *instr = INSTR_CREATE_ld4(
+            dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_Q2), opnd_create_reg(DR_REG_Q3),
             opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, OPSZ_4),
             opnd_create_immed_uint(index, OPSZ_1));
         test_instr_encoding(dc, OP_ld4, instr);
@@ -753,13 +740,12 @@ ld4_simdfp_single_structure_no_offset(void* dc){
     const int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q29 };
     const int dst_reg_3[] = { DR_REG_Q3, DR_REG_Q18, DR_REG_Q30 };
     const int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld4(dc,
-            opnd_create_reg(dst_reg_0[i]),
-            opnd_create_reg(dst_reg_1[i]),
-            opnd_create_reg(dst_reg_2[i]),
-            opnd_create_reg(dst_reg_3[i]),
-            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_4),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld4(
+            dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]), opnd_create_reg(dst_reg_3[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                          OPSZ_4),
             opnd_create_immed_uint(0x01, OPSZ_1));
         test_instr_encoding(dc, OP_ld4, instr);
     }
@@ -767,17 +753,15 @@ ld4_simdfp_single_structure_no_offset(void* dc){
 }
 
 static void
-ld4_simdfp_single_structure_post_index(void* dc){
-    for(int index = 0; index < 16; index++){
-        instr_t *instr = INSTR_CREATE_ld4_2(dc,
-            opnd_create_reg(DR_REG_Q0),
-            opnd_create_reg(DR_REG_Q1),
-            opnd_create_reg(DR_REG_Q2),
-            opnd_create_reg(DR_REG_Q3),
+ld4_simdfp_single_structure_post_index(void *dc)
+{
+    for (int index = 0; index < 16; index++) {
+        instr_t *instr = INSTR_CREATE_ld4_2(
+            dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_Q2), opnd_create_reg(DR_REG_Q3),
             opnd_create_reg(DR_REG_X0),
             opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, OPSZ_4),
-            opnd_create_immed_uint(index, OPSZ_1),
-            opnd_create_immed_uint(0x04, OPSZ_1));
+            opnd_create_immed_uint(index, OPSZ_1), opnd_create_immed_uint(0x04, OPSZ_1));
         test_instr_encoding(dc, OP_ld4, instr);
     }
 
@@ -786,45 +770,35 @@ ld4_simdfp_single_structure_post_index(void* dc){
     const int dst_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q29 };
     const int dst_3[] = { DR_REG_Q3, DR_REG_Q18, DR_REG_Q30 };
     const int src[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld4_2(dc,
-            opnd_create_reg(dst_0[i]),
-            opnd_create_reg(dst_1[i]),
-            opnd_create_reg(dst_2[i]),
-            opnd_create_reg(dst_3[i]),
-            opnd_create_reg(src[i]),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld4_2(
+            dc, opnd_create_reg(dst_0[i]), opnd_create_reg(dst_1[i]),
+            opnd_create_reg(dst_2[i]), opnd_create_reg(dst_3[i]), opnd_create_reg(src[i]),
             opnd_create_base_disp_aarch64(src[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_4),
-            opnd_create_immed_uint(0x01, OPSZ_1),
-            opnd_create_immed_uint(0x04, OPSZ_1));
+            opnd_create_immed_uint(0x01, OPSZ_1), opnd_create_immed_uint(0x04, OPSZ_1));
         test_instr_encoding(dc, OP_ld4, instr);
     }
 
     const int opsz[] = { OPSZ_4, OPSZ_8, OPSZ_16, OPSZ_32 };
     const int imm[] = { 4, 8, 16, 32 };
-    for(int i = 0; i < 4; i++){
-        instr_t *instr = INSTR_CREATE_ld4_2(dc,
-            opnd_create_reg(DR_REG_Q0),
-            opnd_create_reg(DR_REG_Q1),
-            opnd_create_reg(DR_REG_Q2),
-            opnd_create_reg(DR_REG_Q3),
+    for (int i = 0; i < 4; i++) {
+        instr_t *instr = INSTR_CREATE_ld4_2(
+            dc, opnd_create_reg(DR_REG_Q0), opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_Q2), opnd_create_reg(DR_REG_Q3),
             opnd_create_reg(DR_REG_X0),
-            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, opsz[i]),
-            opnd_create_immed_uint(0x01, OPSZ_1),
-            opnd_create_immed_uint(imm[i], OPSZ_1));
+            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0,
+                                          opsz[i]),
+            opnd_create_immed_uint(0x01, OPSZ_1), opnd_create_immed_uint(imm[i], OPSZ_1));
         test_instr_encoding(dc, OP_ld4, instr);
     }
 
     const int offset_reg[] = { DR_REG_X1, DR_REG_X16, DR_REG_X29 };
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld4_2(dc,
-            opnd_create_reg(dst_0[i]),
-            opnd_create_reg(dst_1[i]),
-            opnd_create_reg(dst_2[i]),
-            opnd_create_reg(dst_3[i]),
-            opnd_create_reg(src[i]),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld4_2(
+            dc, opnd_create_reg(dst_0[i]), opnd_create_reg(dst_1[i]),
+            opnd_create_reg(dst_2[i]), opnd_create_reg(dst_3[i]), opnd_create_reg(src[i]),
             opnd_create_base_disp_aarch64(src[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_4),
-            opnd_create_immed_uint(0x01, OPSZ_1),
-            opnd_create_reg(offset_reg[i]));
+            opnd_create_immed_uint(0x01, OPSZ_1), opnd_create_reg(offset_reg[i]));
         test_instr_encoding(dc, OP_ld4, instr);
     }
 
@@ -832,7 +806,8 @@ ld4_simdfp_single_structure_post_index(void* dc){
 }
 
 static void
-ld4(void* dc){
+ld4(void *dc)
+{
     ld4_simdfp_multiple_structures_no_offset(dc);
     ld4_simdfp_multiple_structures_post_index(dc);
     ld4_simdfp_single_structure_no_offset(dc);
@@ -842,46 +817,48 @@ ld4(void* dc){
 }
 
 static void
-ld2r_simdfp_no_offset(void* dc){
+ld2r_simdfp_no_offset(void *dc)
+{
     int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q29 };
     int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q30 };
     int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X16 };
 
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld2r(dc,
-            opnd_create_reg(dst_reg_0[i]),
-            opnd_create_reg(dst_reg_1[i]),
-            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_16));
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld2r(
+            dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                          OPSZ_16));
         test_instr_encoding(dc, OP_ld2r, instr);
     }
     print("ld2r simdfp no offset complete\n");
 }
 
 static void
-ld2r_simdfp_post_index(void* dc){
+ld2r_simdfp_post_index(void *dc)
+{
     int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q29 };
     int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q30 };
     int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X29 };
     int offset_reg[] = { DR_REG_X1, DR_REG_X16, DR_REG_X30 };
 
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld2r_2(dc,
-            opnd_create_reg(dst_reg_0[i]),
-            opnd_create_reg(dst_reg_1[i]),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld2r_2(
+            dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
             opnd_create_reg(src_reg[i]),
-            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_8),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                          OPSZ_8),
             opnd_create_reg(offset_reg[i]));
         test_instr_encoding(dc, OP_ld2r, instr);
     }
 
     int opsz[] = { OPSZ_2, OPSZ_4, OPSZ_8, OPSZ_16 };
     int imm[] = { 2, 4, 8, 16 };
-    for(int i = 0; i < 4; i++){
-        instr_t *instr = INSTR_CREATE_ld2r_2(dc,
-            opnd_create_reg(dst_reg_0[0]),
-            opnd_create_reg(dst_reg_1[0]),
+    for (int i = 0; i < 4; i++) {
+        instr_t *instr = INSTR_CREATE_ld2r_2(
+            dc, opnd_create_reg(dst_reg_0[0]), opnd_create_reg(dst_reg_1[0]),
             opnd_create_reg(src_reg[0]),
-            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0, opsz[i]),
+            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0,
+                                          opsz[i]),
             opnd_create_immed_uint(imm[i], OPSZ_1));
         test_instr_encoding(dc, OP_ld2r, instr);
     }
@@ -889,7 +866,8 @@ ld2r_simdfp_post_index(void* dc){
 }
 
 static void
-ld2r(void* dc){
+ld2r(void *dc)
+{
     ld2r_simdfp_no_offset(dc);
     ld2r_simdfp_post_index(dc);
 
@@ -897,51 +875,51 @@ ld2r(void* dc){
 }
 
 static void
-ld3r_simdfp_no_offset(void* dc){
+ld3r_simdfp_no_offset(void *dc)
+{
     int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q28 };
     int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q29 };
     int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q30 };
     int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
 
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld3r(dc,
-            opnd_create_reg(dst_reg_0[i]),
-            opnd_create_reg(dst_reg_1[i]),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld3r(
+            dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
             opnd_create_reg(dst_reg_2[i]),
-            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_24));
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                          OPSZ_24));
         test_instr_encoding(dc, OP_ld3r, instr);
     }
     print("ld3r simdfp no offset complete\n");
 }
 
 static void
-ld3r_simdfp_post_index(void* dc){
+ld3r_simdfp_post_index(void *dc)
+{
     int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q28 };
     int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q29 };
     int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q30 };
     int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X29 };
     int offset_reg[] = { DR_REG_X1, DR_REG_X16, DR_REG_X30 };
 
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld3r_2(dc,
-            opnd_create_reg(dst_reg_0[i]),
-            opnd_create_reg(dst_reg_1[i]),
-            opnd_create_reg(dst_reg_2[i]),
-            opnd_create_reg(src_reg[i]),
-            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_24),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld3r_2(
+            dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]), opnd_create_reg(src_reg[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                          OPSZ_24),
             opnd_create_reg(offset_reg[i]));
         test_instr_encoding(dc, OP_ld3r, instr);
     }
 
     int opsz[] = { OPSZ_3, OPSZ_6, OPSZ_12, OPSZ_24 };
     int imm[] = { 3, 6, 12, 24 };
-    for(int i = 0; i < 4; i++){
-        instr_t *instr = INSTR_CREATE_ld3r_2(dc,
-            opnd_create_reg(dst_reg_0[0]),
-            opnd_create_reg(dst_reg_1[0]),
-            opnd_create_reg(dst_reg_2[0]),
-            opnd_create_reg(src_reg[0]),
-            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0, opsz[i]),
+    for (int i = 0; i < 4; i++) {
+        instr_t *instr = INSTR_CREATE_ld3r_2(
+            dc, opnd_create_reg(dst_reg_0[0]), opnd_create_reg(dst_reg_1[0]),
+            opnd_create_reg(dst_reg_2[0]), opnd_create_reg(src_reg[0]),
+            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0,
+                                          opsz[i]),
             opnd_create_immed_uint(imm[i], OPSZ_1));
         test_instr_encoding(dc, OP_ld3r, instr);
     }
@@ -949,7 +927,8 @@ ld3r_simdfp_post_index(void* dc){
 }
 
 static void
-ld3r(void* dc){
+ld3r(void *dc)
+{
     ld3r_simdfp_no_offset(dc);
     ld3r_simdfp_post_index(dc);
 
@@ -957,27 +936,28 @@ ld3r(void* dc){
 }
 
 static void
-ld4r_simdfp_no_offset(void* dc){
+ld4r_simdfp_no_offset(void *dc)
+{
     int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q27 };
     int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q28 };
     int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q29 };
     int dst_reg_3[] = { DR_REG_Q3, DR_REG_Q18, DR_REG_Q30 };
     int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
 
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld4r(dc,
-            opnd_create_reg(dst_reg_0[i]),
-            opnd_create_reg(dst_reg_1[i]),
-            opnd_create_reg(dst_reg_2[i]),
-            opnd_create_reg(dst_reg_3[i]),
-            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_32));
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld4r(
+            dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]), opnd_create_reg(dst_reg_3[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                          OPSZ_32));
         test_instr_encoding(dc, OP_ld4r, instr);
     }
     print("ld4r simdfp no offset complete\n");
 }
 
 static void
-ld4r_simdfp_post_index(void* dc){
+ld4r_simdfp_post_index(void *dc)
+{
     int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q27 };
     int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q28 };
     int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q29 };
@@ -985,28 +965,26 @@ ld4r_simdfp_post_index(void* dc){
     int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X29 };
     int offset_reg[] = { DR_REG_X1, DR_REG_X16, DR_REG_X30 };
 
-    for(int i = 0; i < 3; i++){
-        instr_t *instr = INSTR_CREATE_ld4r_2(dc,
-            opnd_create_reg(dst_reg_0[i]),
-            opnd_create_reg(dst_reg_1[i]),
-            opnd_create_reg(dst_reg_2[i]),
-            opnd_create_reg(dst_reg_3[i]),
+    for (int i = 0; i < 3; i++) {
+        instr_t *instr = INSTR_CREATE_ld4r_2(
+            dc, opnd_create_reg(dst_reg_0[i]), opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]), opnd_create_reg(dst_reg_3[i]),
             opnd_create_reg(src_reg[i]),
-            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_32),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0,
+                                          OPSZ_32),
             opnd_create_reg(offset_reg[i]));
         test_instr_encoding(dc, OP_ld4r, instr);
     }
 
     int opsz[] = { OPSZ_4, OPSZ_8, OPSZ_16, OPSZ_32 };
     int imm[] = { 4, 8, 16, 32 };
-    for(int i = 0; i < 4; i++){
-        instr_t *instr = INSTR_CREATE_ld4r_2(dc,
-            opnd_create_reg(dst_reg_0[0]),
-            opnd_create_reg(dst_reg_1[0]),
-            opnd_create_reg(dst_reg_2[0]),
-            opnd_create_reg(dst_reg_3[0]),
+    for (int i = 0; i < 4; i++) {
+        instr_t *instr = INSTR_CREATE_ld4r_2(
+            dc, opnd_create_reg(dst_reg_0[0]), opnd_create_reg(dst_reg_1[0]),
+            opnd_create_reg(dst_reg_2[0]), opnd_create_reg(dst_reg_3[0]),
             opnd_create_reg(src_reg[0]),
-            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0, opsz[i]),
+            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0,
+                                          opsz[i]),
             opnd_create_immed_uint(imm[i], OPSZ_1));
         test_instr_encoding(dc, OP_ld4r, instr);
     }
@@ -1014,7 +992,8 @@ ld4r_simdfp_post_index(void* dc){
 }
 
 static void
-ld4r(void* dc){
+ld4r(void *dc)
+{
     ld4r_simdfp_no_offset(dc);
     ld4r_simdfp_post_index(dc);
 
@@ -7198,9 +7177,9 @@ main(int argc, char *argv[])
     ldr(dcontext);
     str(dcontext);
 
-    #if 0 /* TODO i#4847: address memory touching instructions that fail to encode */
+#if 0 /* TODO i#4847: address memory touching instructions that fail to encode */
         adr(dcontext);
-    #endif
+#endif
     adrp(dcontext);
     ldpsw(dcontext);
     ld2(dcontext);

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -244,16 +244,92 @@ test_add(void *dc)
 }
 
 static void
-test_pc_addr(void *dc)
-{
-    byte *pc;
-    instr_t *instr;
-
-#if 0 /* TODO: implement OPSZ_21b */
-    instr = INSTR_CREATE_adr(dc, opnd_create_reg(DR_REG_X0),
-                                 opnd_create_immed_int(0, OPSZ_21b));
+adr(void* dc){
+    instr_t *instr = INSTR_CREATE_adr(dc,
+        opnd_create_reg(DR_REG_X1),
+        OPND_CREATE_ABSMEM((void*)0x0000000010010208, OPSZ_0));
     test_instr_encoding(dc, OP_adr, instr);
-#endif
+
+    print("adr complete\n");
+}
+
+static void
+adrp(void* dc){
+    instr_t *instr = INSTR_CREATE_adrp(dc,
+        opnd_create_reg(DR_REG_X1),
+        OPND_CREATE_ABSMEM((void*)0x0000000020208000, OPSZ_0));
+    test_instr_encoding(dc, OP_adrp, instr);
+
+    print("adrp complete\n");
+}
+
+static void
+ldpsw_base_post_index(void* dc){
+    int dst_reg_0[] = { DR_REG_X1, DR_REG_X15, DR_REG_X29 };
+    int dst_reg_1[] = { DR_REG_X2, DR_REG_X16, DR_REG_X30 };
+    int src_reg[] = { DR_REG_X0, DR_REG_X14, DR_REG_X28 };
+    int value[] = { 0, 4, 252, -256};
+
+    for(int i = 0; i < 3; i++){
+        for(int ii = 0; ii < 4; ii++){
+            instr_t* instr = INSTR_CREATE_ldpsw(dc,
+                opnd_create_reg(dst_reg_0[i]),
+                opnd_create_reg(dst_reg_1[i]),
+                opnd_create_reg(src_reg[i]),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_8),
+                OPND_CREATE_INT(value[ii]));
+            test_instr_encoding(dc, OP_ldpsw, instr);
+        }
+    }
+    print("ldpsw base post-index complete\n");
+}
+
+static void
+ldpsw_base_pre_index(void* dc){
+    int dst_reg_0[] = { DR_REG_X1, DR_REG_X15, DR_REG_X29 };
+    int dst_reg_1[] = { DR_REG_X2, DR_REG_X16, DR_REG_X30 };
+    int src_reg[] = { DR_REG_X0, DR_REG_X14, DR_REG_X28 };
+    int value[] = { 0, 4, 252, -256};
+
+    for(int i = 0; i < 3; i++){
+        for(int ii = 0; ii < 4; ii++){
+            instr_t* instr = INSTR_CREATE_ldpsw(dc,
+                opnd_create_reg(dst_reg_0[i]),
+                opnd_create_reg(dst_reg_1[i]),
+                opnd_create_reg(src_reg[i]),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, value[ii], 0, OPSZ_8),
+                OPND_CREATE_INT(value[ii]));
+            test_instr_encoding(dc, OP_ldpsw, instr);
+        }
+    }
+    print("ldpsw base pre-index complete\n");
+}
+
+static void
+ldpsw_base_signed_offset(void* dc){
+    int dst_reg_0[] = { DR_REG_X1, DR_REG_X15, DR_REG_X29 };
+    int dst_reg_1[] = { DR_REG_X2, DR_REG_X16, DR_REG_X30 };
+    int src_reg[] = { DR_REG_X0, DR_REG_X14, DR_REG_X28 };
+    int value[] = { 8, 4, 252, -256};
+
+    for(int i = 0; i < 3; i++){
+        for(int ii = 0; ii < 4; ii++){
+            instr_t* instr = INSTR_CREATE_ldpsw_2(dc,
+                opnd_create_reg(dst_reg_0[i]),
+                opnd_create_reg(dst_reg_1[i]),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, value[ii], 0, OPSZ_8));
+            test_instr_encoding(dc, OP_ldpsw, instr);
+        }
+    }
+    print("ldpsw base signed offset complete\n");
+}
+
+static void
+ldpsw(void* dc){
+    ldpsw_base_post_index(dc);
+    ldpsw_base_pre_index(dc);
+    ldpsw_base_signed_offset(dc);
+    print("ldpsw complete\n");
 }
 
 static void
@@ -285,6 +361,664 @@ test_ldar(void *dc)
         dc, opnd_create_reg(DR_REG_W0),
         opnd_create_base_disp_aarch64(DR_REG_X1, DR_REG_NULL, 0, false, 0, 0, OPSZ_2));
     test_instr_encoding(dc, OP_ldarh, instr);
+}
+
+static void
+ld2_simdfp_multiple_structures_no_offset(void* dc){
+    const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q14, DR_REG_Q28 };
+    const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q15, DR_REG_Q29 };
+    const int src_reg[] = { DR_REG_X2, DR_REG_X16, DR_REG_X30 };
+    const int index[] = { 0x00 };
+
+    for(int i = 0; i < 3; i++){
+        for(int ii = 0; ii < 1; ii++){
+            instr_t *instr = INSTR_CREATE_ld2_multi(dc,
+                opnd_create_reg(dst_reg_0[i]),
+                opnd_create_reg(dst_reg_1[i]),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_16),
+                opnd_create_immed_uint(index[ii], OPSZ_1));
+            test_instr_encoding(dc, OP_ld2, instr);
+        }
+    }
+    print("ld2 simdfp multiple structures no offset complete\n");
+}
+
+static void
+ld2_simdfp_multiple_structures_post_index(void* dc){
+    const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q29 };
+    const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q30 };
+    const int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+    const int offset_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld2_multi_2(dc,
+                opnd_create_reg(dst_reg_0[i]),
+                opnd_create_reg(dst_reg_1[i]),
+                opnd_create_reg(src_reg[i]),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_32),
+                opnd_create_immed_uint(0x00, OPSZ_1),
+                opnd_create_reg(offset_reg[i]));
+        test_instr_encoding(dc, OP_ld2, instr);
+    }
+
+    const int dst_reg_post_index_0[] = { DR_REG_D0, DR_REG_Q0 };
+    const int dst_reg_post_index_1[] = { DR_REG_D1, DR_REG_Q1 };
+    const int imm[] = { 0x10, 0x20 };
+    const int opsz[] = { OPSZ_16, OPSZ_32 };
+
+    for(int i = 0; i < 2; i++){
+        instr_t *instr = INSTR_CREATE_ld2_multi_2(dc,
+            opnd_create_reg(dst_reg_post_index_0[i]),
+            opnd_create_reg(dst_reg_post_index_1[i]),
+            opnd_create_reg(src_reg[0]),
+            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0, opsz[i]),
+            opnd_create_immed_uint(0x00, OPSZ_1),
+            opnd_create_immed_uint(imm[i], OPSZ_1));
+        test_instr_encoding(dc, OP_ld2, instr);
+    }
+    print("ld2 simdfp multiple structures post-index complete\n");
+}
+
+static void
+ld2_simdfp_single_structure_no_offset(void* dc){
+    for(int index = 0; index < 16; index++){
+        instr_t *instr = INSTR_CREATE_ld2(dc,
+            opnd_create_reg(DR_REG_Q0),
+            opnd_create_reg(DR_REG_Q1),
+            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, OPSZ_2),
+            opnd_create_immed_uint(index, OPSZ_1));
+        test_instr_encoding(dc, OP_ld2, instr);
+    }
+
+    const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q29 };
+    const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q30 };
+    const int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld2(dc,
+            opnd_create_reg(dst_reg_0[i]),
+            opnd_create_reg(dst_reg_1[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_2),
+            opnd_create_immed_uint(0x01, OPSZ_1));
+        test_instr_encoding(dc, OP_ld2, instr);
+    }
+
+    print("ld2 simdfp single structure no offset complete\n");
+}
+
+static void
+ld2_simdfp_single_structure_post_index(void* dc){
+    for(int index = 1; index < 16; index++){
+        instr_t *instr = INSTR_CREATE_ld2_2(dc,
+            opnd_create_reg(DR_REG_Q0),
+            opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_X0),
+            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, OPSZ_2),
+            opnd_create_immed_uint(index, OPSZ_1),
+            opnd_create_immed_uint(0x02, OPSZ_1));
+        test_instr_encoding(dc, OP_ld2, instr);
+    }
+
+    const int dst_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q29 };
+    const int dst_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q30 };
+    const int src[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld2_2(dc,
+            opnd_create_reg(dst_0[i]),
+            opnd_create_reg(dst_1[i]),
+            opnd_create_reg(src[i]),
+            opnd_create_base_disp_aarch64(src[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_2),
+            opnd_create_immed_uint(0x01, OPSZ_1),
+            opnd_create_immed_uint(0x02, OPSZ_1));
+        test_instr_encoding(dc, OP_ld2, instr);
+    }
+
+    const int opsz[] = { OPSZ_2, OPSZ_4, OPSZ_8, OPSZ_16 };
+    const int imm[] = { 2, 4, 8, 16 };
+    for(int i = 0; i < 4; i++){
+        instr_t *instr = INSTR_CREATE_ld2_2(dc,
+            opnd_create_reg(DR_REG_Q0),
+            opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_X0),
+            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, opsz[i]),
+            opnd_create_immed_uint(0x01, OPSZ_1),
+            opnd_create_immed_uint(imm[i], OPSZ_1));
+        test_instr_encoding(dc, OP_ld2, instr);
+    }
+
+    const int offset_reg[] = { DR_REG_X1, DR_REG_X16, DR_REG_X29 };
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld2_2(dc,
+            opnd_create_reg(dst_0[i]),
+            opnd_create_reg(dst_1[i]),
+            opnd_create_reg(src[i]),
+            opnd_create_base_disp_aarch64(src[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_2),
+            opnd_create_immed_uint(0x01, OPSZ_1),
+            opnd_create_reg(offset_reg[i]));
+        test_instr_encoding(dc, OP_ld2, instr);
+    }
+
+    print("ld2 simdfp single structure post-index complete\n");
+}
+
+static void
+ld2(void* dc){
+    ld2_simdfp_multiple_structures_no_offset(dc);
+    ld2_simdfp_multiple_structures_post_index(dc);
+    ld2_simdfp_single_structure_no_offset(dc);
+    ld2_simdfp_single_structure_post_index(dc);
+
+    print("ld2 complete\n");
+}
+
+
+static void
+ld3_simdfp_multiple_structures_no_offset(void* dc){
+    const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q14, DR_REG_Q28 };
+    const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q15, DR_REG_Q29 };
+    const int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q16, DR_REG_Q30 };
+    const int src_reg[] = { DR_REG_X2, DR_REG_X16, DR_REG_X30 };
+    const int index[] = { 0x00 };
+
+    for(int i = 0; i < 3; i++){
+        for(int ii = 0; ii < 1; ii++){
+            instr_t *instr = INSTR_CREATE_ld3_multi(dc,
+                opnd_create_reg(dst_reg_0[i]),
+                opnd_create_reg(dst_reg_1[i]),
+                opnd_create_reg(dst_reg_2[i]),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_24),
+                opnd_create_immed_uint(index[ii], OPSZ_1));
+            test_instr_encoding(dc, OP_ld3, instr);
+        }
+    }
+    print("ld3 simdfp multiple structures no offset complete\n");
+}
+
+static void
+ld3_simdfp_multiple_structures_post_index(void* dc){
+    const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q28 };
+    const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q29 };
+    const int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q30 };
+    const int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+    const int offset_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld3_multi_2(dc,
+                opnd_create_reg(dst_reg_0[i]),
+                opnd_create_reg(dst_reg_1[i]),
+                opnd_create_reg(dst_reg_2[i]),
+                opnd_create_reg(src_reg[i]),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_48),
+                opnd_create_immed_uint(0x00, OPSZ_1),
+                opnd_create_reg(offset_reg[i]));
+        test_instr_encoding(dc, OP_ld3, instr);
+    }
+
+    const int dst_reg_post_index_0[] = { DR_REG_D0, DR_REG_Q0 };
+    const int dst_reg_post_index_1[] = { DR_REG_D1, DR_REG_Q1 };
+    const int dst_reg_post_index_2[] = { DR_REG_D2, DR_REG_Q2 };
+    const int imm[] = { 0x18, 0x30 };
+    const int opsz[] = { OPSZ_24, OPSZ_48 };
+
+    for(int i = 0; i < 2; i++){
+        instr_t *instr = INSTR_CREATE_ld3_multi_2(dc,
+            opnd_create_reg(dst_reg_post_index_0[i]),
+            opnd_create_reg(dst_reg_post_index_1[i]),
+            opnd_create_reg(dst_reg_post_index_2[i]),
+            opnd_create_reg(src_reg[0]),
+            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0, opsz[i]),
+            opnd_create_immed_uint(0x00, OPSZ_1),
+            opnd_create_immed_uint(imm[i], OPSZ_1));
+        test_instr_encoding(dc, OP_ld3, instr);
+    }
+    print("ld3 simdfp multiple structures post-index complete\n");
+}
+
+static void
+ld3_simdfp_single_structure_no_offset(void* dc){
+    for(int index = 0; index < 16; index++){
+        instr_t *instr = INSTR_CREATE_ld3(dc,
+            opnd_create_reg(DR_REG_Q0),
+            opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_Q2),
+            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, OPSZ_3),
+            opnd_create_immed_uint(index, OPSZ_1));
+        test_instr_encoding(dc, OP_ld3, instr);
+    }
+
+    const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q28 };
+    const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q29 };
+    const int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q30 };
+    const int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld3(dc,
+            opnd_create_reg(dst_reg_0[i]),
+            opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_3),
+            opnd_create_immed_uint(0x01, OPSZ_1));
+        test_instr_encoding(dc, OP_ld3, instr);
+    }
+    print("ld3 simdfp single structure no offset complete\n");
+}
+
+static void
+ld3_simdfp_single_structure_post_index(void* dc){
+    for(int index = 0; index < 16; index++){
+        instr_t *instr = INSTR_CREATE_ld3_2(dc,
+            opnd_create_reg(DR_REG_Q0),
+            opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_Q2),
+            opnd_create_reg(DR_REG_X0),
+            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, OPSZ_3),
+            opnd_create_immed_uint(index, OPSZ_1),
+            opnd_create_immed_uint(0x03, OPSZ_1));
+        test_instr_encoding(dc, OP_ld3, instr);
+    }
+
+    const int dst_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q28 };
+    const int dst_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q29 };
+    const int dst_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q30 };
+    const int src[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld3_2(dc,
+            opnd_create_reg(dst_0[i]),
+            opnd_create_reg(dst_1[i]),
+            opnd_create_reg(dst_2[i]),
+            opnd_create_reg(src[i]),
+            opnd_create_base_disp_aarch64(src[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_3),
+            opnd_create_immed_uint(0x01, OPSZ_1),
+            opnd_create_immed_uint(0x03, OPSZ_1));
+        test_instr_encoding(dc, OP_ld3, instr);
+    }
+
+    const int opsz[] = { OPSZ_3, OPSZ_6, OPSZ_12, OPSZ_24 };
+    const int imm[] = { 3, 6, 12, 24 };
+    for(int i = 0; i < 4; i++){
+        instr_t *instr = INSTR_CREATE_ld3_2(dc,
+            opnd_create_reg(DR_REG_Q0),
+            opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_Q2),
+            opnd_create_reg(DR_REG_X0),
+            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, opsz[i]),
+            opnd_create_immed_uint(0x01, OPSZ_1),
+            opnd_create_immed_uint(imm[i], OPSZ_1));
+        test_instr_encoding(dc, OP_ld3, instr);
+    }
+
+    const int offset_reg[] = { DR_REG_X1, DR_REG_X16, DR_REG_X29 };
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld3_2(dc,
+            opnd_create_reg(dst_0[i]),
+            opnd_create_reg(dst_1[i]),
+            opnd_create_reg(dst_2[i]),
+            opnd_create_reg(src[i]),
+            opnd_create_base_disp_aarch64(src[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_3),
+            opnd_create_immed_uint(0x01, OPSZ_1),
+            opnd_create_reg(offset_reg[i]));
+        test_instr_encoding(dc, OP_ld3, instr);
+    }
+    print("ld3 simdfp single structure post-index complete\n");
+}
+
+static void
+ld3(void* dc){
+    ld3_simdfp_multiple_structures_no_offset(dc);
+    ld3_simdfp_multiple_structures_post_index(dc);
+    ld3_simdfp_single_structure_no_offset(dc);
+    ld3_simdfp_single_structure_post_index(dc);
+
+    print("ld3 complete\n");
+}
+
+static void
+ld4_simdfp_multiple_structures_no_offset(void* dc){
+    const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q14, DR_REG_Q27 };
+    const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q15, DR_REG_Q28 };
+    const int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q16, DR_REG_Q29 };
+    const int dst_reg_3[] = { DR_REG_Q3, DR_REG_Q17, DR_REG_Q30 };
+    const int src_reg[] = { DR_REG_X2, DR_REG_X16, DR_REG_X30 };
+
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld4_multi(dc,
+            opnd_create_reg(dst_reg_0[i]),
+            opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]),
+            opnd_create_reg(dst_reg_3[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_64),
+            opnd_create_immed_uint(0x00, OPSZ_1));
+        test_instr_encoding(dc, OP_ld4, instr);
+    }
+    print("ld4 simdfp multiple structures no offset complete\n");
+}
+
+static void
+ld4_simdfp_multiple_structures_post_index(void* dc){
+    const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q27 };
+    const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q28 };
+    const int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q29 };
+    const int dst_reg_3[] = { DR_REG_Q3, DR_REG_Q18, DR_REG_Q30 };
+    const int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+    const int offset_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld4_multi_2(dc,
+                opnd_create_reg(dst_reg_0[i]),
+                opnd_create_reg(dst_reg_1[i]),
+                opnd_create_reg(dst_reg_2[i]),
+                opnd_create_reg(dst_reg_3[i]),
+                opnd_create_reg(src_reg[i]),
+                opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_64),
+                opnd_create_immed_uint(0x00, OPSZ_1),
+                opnd_create_reg(offset_reg[i]));
+        test_instr_encoding(dc, OP_ld4, instr);
+    }
+
+    const int dst_reg_post_index_0[] = { DR_REG_D0, DR_REG_Q0 };
+    const int dst_reg_post_index_1[] = { DR_REG_D1, DR_REG_Q1 };
+    const int dst_reg_post_index_2[] = { DR_REG_D2, DR_REG_Q2 };
+    const int dst_reg_post_index_3[] = { DR_REG_D3, DR_REG_Q3 };
+    const int imm[] = { 0x20, 0x40 };
+    const int opsz[] = { OPSZ_32, OPSZ_64 };
+
+    for(int i = 0; i < 2; i++){
+        instr_t *instr = INSTR_CREATE_ld4_multi_2(dc,
+            opnd_create_reg(dst_reg_post_index_0[i]),
+            opnd_create_reg(dst_reg_post_index_1[i]),
+            opnd_create_reg(dst_reg_post_index_2[i]),
+            opnd_create_reg(dst_reg_post_index_3[i]),
+            opnd_create_reg(src_reg[0]),
+            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0, opsz[i]),
+            opnd_create_immed_uint(0x00, OPSZ_1),
+            opnd_create_immed_uint(imm[i], OPSZ_1));
+        test_instr_encoding(dc, OP_ld4, instr);
+    }
+    print("ld4 simdfp multiple structures post-index complete\n");
+}
+
+static void
+ld4_simdfp_single_structure_no_offset(void* dc){
+    for(int index = 0; index < 16; index++){
+        instr_t *instr = INSTR_CREATE_ld4(dc,
+            opnd_create_reg(DR_REG_Q0),
+            opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_Q2),
+            opnd_create_reg(DR_REG_Q3),
+            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, OPSZ_4),
+            opnd_create_immed_uint(index, OPSZ_1));
+        test_instr_encoding(dc, OP_ld4, instr);
+    }
+
+    const int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q27 };
+    const int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q28 };
+    const int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q29 };
+    const int dst_reg_3[] = { DR_REG_Q3, DR_REG_Q18, DR_REG_Q30 };
+    const int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld4(dc,
+            opnd_create_reg(dst_reg_0[i]),
+            opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]),
+            opnd_create_reg(dst_reg_3[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_4),
+            opnd_create_immed_uint(0x01, OPSZ_1));
+        test_instr_encoding(dc, OP_ld4, instr);
+    }
+    print("ld4 simdfp single structure no offset complete\n");
+}
+
+static void
+ld4_simdfp_single_structure_post_index(void* dc){
+    for(int index = 0; index < 16; index++){
+        instr_t *instr = INSTR_CREATE_ld4_2(dc,
+            opnd_create_reg(DR_REG_Q0),
+            opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_Q2),
+            opnd_create_reg(DR_REG_Q3),
+            opnd_create_reg(DR_REG_X0),
+            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, OPSZ_4),
+            opnd_create_immed_uint(index, OPSZ_1),
+            opnd_create_immed_uint(0x04, OPSZ_1));
+        test_instr_encoding(dc, OP_ld4, instr);
+    }
+
+    const int dst_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q27 };
+    const int dst_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q28 };
+    const int dst_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q29 };
+    const int dst_3[] = { DR_REG_Q3, DR_REG_Q18, DR_REG_Q30 };
+    const int src[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld4_2(dc,
+            opnd_create_reg(dst_0[i]),
+            opnd_create_reg(dst_1[i]),
+            opnd_create_reg(dst_2[i]),
+            opnd_create_reg(dst_3[i]),
+            opnd_create_reg(src[i]),
+            opnd_create_base_disp_aarch64(src[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_4),
+            opnd_create_immed_uint(0x01, OPSZ_1),
+            opnd_create_immed_uint(0x04, OPSZ_1));
+        test_instr_encoding(dc, OP_ld4, instr);
+    }
+
+    const int opsz[] = { OPSZ_4, OPSZ_8, OPSZ_16, OPSZ_32 };
+    const int imm[] = { 4, 8, 16, 32 };
+    for(int i = 0; i < 4; i++){
+        instr_t *instr = INSTR_CREATE_ld4_2(dc,
+            opnd_create_reg(DR_REG_Q0),
+            opnd_create_reg(DR_REG_Q1),
+            opnd_create_reg(DR_REG_Q2),
+            opnd_create_reg(DR_REG_Q3),
+            opnd_create_reg(DR_REG_X0),
+            opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, 0, false, 0, 0, opsz[i]),
+            opnd_create_immed_uint(0x01, OPSZ_1),
+            opnd_create_immed_uint(imm[i], OPSZ_1));
+        test_instr_encoding(dc, OP_ld4, instr);
+    }
+
+    const int offset_reg[] = { DR_REG_X1, DR_REG_X16, DR_REG_X29 };
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld4_2(dc,
+            opnd_create_reg(dst_0[i]),
+            opnd_create_reg(dst_1[i]),
+            opnd_create_reg(dst_2[i]),
+            opnd_create_reg(dst_3[i]),
+            opnd_create_reg(src[i]),
+            opnd_create_base_disp_aarch64(src[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_4),
+            opnd_create_immed_uint(0x01, OPSZ_1),
+            opnd_create_reg(offset_reg[i]));
+        test_instr_encoding(dc, OP_ld4, instr);
+    }
+
+    print("ld4 simdfp single structure post-index complete\n");
+}
+
+static void
+ld4(void* dc){
+    ld4_simdfp_multiple_structures_no_offset(dc);
+    ld4_simdfp_multiple_structures_post_index(dc);
+    ld4_simdfp_single_structure_no_offset(dc);
+    ld4_simdfp_single_structure_post_index(dc);
+
+    print("ld4 complete\n");
+}
+
+static void
+ld2r_simdfp_no_offset(void* dc){
+    int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q29 };
+    int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q30 };
+    int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X16 };
+
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld2r(dc,
+            opnd_create_reg(dst_reg_0[i]),
+            opnd_create_reg(dst_reg_1[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_16));
+        test_instr_encoding(dc, OP_ld2r, instr);
+    }
+    print("ld2r simdfp no offset complete\n");
+}
+
+static void
+ld2r_simdfp_post_index(void* dc){
+    int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q29 };
+    int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q30 };
+    int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X29 };
+    int offset_reg[] = { DR_REG_X1, DR_REG_X16, DR_REG_X30 };
+
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld2r_2(dc,
+            opnd_create_reg(dst_reg_0[i]),
+            opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(src_reg[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_8),
+            opnd_create_reg(offset_reg[i]));
+        test_instr_encoding(dc, OP_ld2r, instr);
+    }
+
+    int opsz[] = { OPSZ_2, OPSZ_4, OPSZ_8, OPSZ_16 };
+    int imm[] = { 2, 4, 8, 16 };
+    for(int i = 0; i < 4; i++){
+        instr_t *instr = INSTR_CREATE_ld2r_2(dc,
+            opnd_create_reg(dst_reg_0[0]),
+            opnd_create_reg(dst_reg_1[0]),
+            opnd_create_reg(src_reg[0]),
+            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0, opsz[i]),
+            opnd_create_immed_uint(imm[i], OPSZ_1));
+        test_instr_encoding(dc, OP_ld2r, instr);
+    }
+    print("ld2r simdfp post-index complete\n");
+}
+
+static void
+ld2r(void* dc){
+    ld2r_simdfp_no_offset(dc);
+    ld2r_simdfp_post_index(dc);
+
+    print("ld2r complete\n");
+}
+
+static void
+ld3r_simdfp_no_offset(void* dc){
+    int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q28 };
+    int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q29 };
+    int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q30 };
+    int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld3r(dc,
+            opnd_create_reg(dst_reg_0[i]),
+            opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_24));
+        test_instr_encoding(dc, OP_ld3r, instr);
+    }
+    print("ld3r simdfp no offset complete\n");
+}
+
+static void
+ld3r_simdfp_post_index(void* dc){
+    int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q28 };
+    int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q29 };
+    int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q30 };
+    int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X29 };
+    int offset_reg[] = { DR_REG_X1, DR_REG_X16, DR_REG_X30 };
+
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld3r_2(dc,
+            opnd_create_reg(dst_reg_0[i]),
+            opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]),
+            opnd_create_reg(src_reg[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_24),
+            opnd_create_reg(offset_reg[i]));
+        test_instr_encoding(dc, OP_ld3r, instr);
+    }
+
+    int opsz[] = { OPSZ_3, OPSZ_6, OPSZ_12, OPSZ_24 };
+    int imm[] = { 3, 6, 12, 24 };
+    for(int i = 0; i < 4; i++){
+        instr_t *instr = INSTR_CREATE_ld3r_2(dc,
+            opnd_create_reg(dst_reg_0[0]),
+            opnd_create_reg(dst_reg_1[0]),
+            opnd_create_reg(dst_reg_2[0]),
+            opnd_create_reg(src_reg[0]),
+            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0, opsz[i]),
+            opnd_create_immed_uint(imm[i], OPSZ_1));
+        test_instr_encoding(dc, OP_ld3r, instr);
+    }
+    print("ld3r simdfp post-index complete\n");
+}
+
+static void
+ld3r(void* dc){
+    ld3r_simdfp_no_offset(dc);
+    ld3r_simdfp_post_index(dc);
+
+    print("ld3r complete\n");
+}
+
+static void
+ld4r_simdfp_no_offset(void* dc){
+    int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q27 };
+    int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q28 };
+    int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q29 };
+    int dst_reg_3[] = { DR_REG_Q3, DR_REG_Q18, DR_REG_Q30 };
+    int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X30 };
+
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld4r(dc,
+            opnd_create_reg(dst_reg_0[i]),
+            opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]),
+            opnd_create_reg(dst_reg_3[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_32));
+        test_instr_encoding(dc, OP_ld4r, instr);
+    }
+    print("ld4r simdfp no offset complete\n");
+}
+
+static void
+ld4r_simdfp_post_index(void* dc){
+    int dst_reg_0[] = { DR_REG_Q0, DR_REG_Q15, DR_REG_Q27 };
+    int dst_reg_1[] = { DR_REG_Q1, DR_REG_Q16, DR_REG_Q28 };
+    int dst_reg_2[] = { DR_REG_Q2, DR_REG_Q17, DR_REG_Q29 };
+    int dst_reg_3[] = { DR_REG_Q3, DR_REG_Q18, DR_REG_Q30 };
+    int src_reg[] = { DR_REG_X0, DR_REG_X15, DR_REG_X29 };
+    int offset_reg[] = { DR_REG_X1, DR_REG_X16, DR_REG_X30 };
+
+    for(int i = 0; i < 3; i++){
+        instr_t *instr = INSTR_CREATE_ld4r_2(dc,
+            opnd_create_reg(dst_reg_0[i]),
+            opnd_create_reg(dst_reg_1[i]),
+            opnd_create_reg(dst_reg_2[i]),
+            opnd_create_reg(dst_reg_3[i]),
+            opnd_create_reg(src_reg[i]),
+            opnd_create_base_disp_aarch64(src_reg[i], DR_REG_NULL, 0, false, 0, 0, OPSZ_32),
+            opnd_create_reg(offset_reg[i]));
+        test_instr_encoding(dc, OP_ld4r, instr);
+    }
+
+    int opsz[] = { OPSZ_4, OPSZ_8, OPSZ_16, OPSZ_32 };
+    int imm[] = { 4, 8, 16, 32 };
+    for(int i = 0; i < 4; i++){
+        instr_t *instr = INSTR_CREATE_ld4r_2(dc,
+            opnd_create_reg(dst_reg_0[0]),
+            opnd_create_reg(dst_reg_1[0]),
+            opnd_create_reg(dst_reg_2[0]),
+            opnd_create_reg(dst_reg_3[0]),
+            opnd_create_reg(src_reg[0]),
+            opnd_create_base_disp_aarch64(src_reg[0], DR_REG_NULL, 0, false, 0, 0, opsz[i]),
+            opnd_create_immed_uint(imm[i], OPSZ_1));
+        test_instr_encoding(dc, OP_ld4r, instr);
+    }
+    print("ld4r simdfp post index complete\n");
+}
+
+static void
+ld4r(void* dc){
+    ld4r_simdfp_no_offset(dc);
+    ld4r_simdfp_post_index(dc);
+
+    print("ld4r complete\n");
 }
 
 static void
@@ -6463,6 +7197,18 @@ main(int argc, char *argv[])
 
     ldr(dcontext);
     str(dcontext);
+
+    #if 0 /* TODO i#4847: address memory touching instructions that fail to encode */
+        adr(dcontext);
+    #endif
+    adrp(dcontext);
+    ldpsw(dcontext);
+    ld2(dcontext);
+    ld3(dcontext);
+    ld4(dcontext);
+    ld2r(dcontext);
+    ld3r(dcontext);
+    ld4r(dcontext);
 
     print("All tests complete\n");
 #ifndef STANDALONE_DECODER

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -7177,10 +7177,10 @@ main(int argc, char *argv[])
     ldr(dcontext);
     str(dcontext);
 
-#if 0 /* TODO i#4847: address memory touching instructions that fail to encode */
+#if 0 /* TODO i#4847: add memory touching instructions */
         adr(dcontext);
+        adrp(dcontext);
 #endif
-    adrp(dcontext);
     ldpsw(dcontext);
     ld2(dcontext);
     ld3(dcontext);

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -1459,4 +1459,258 @@ str    %w30 -> (%x29,%x30,sxtx #2)[4byte]
 str    %x30 -> (%x29,%x30,sxtx #3)[8byte]
 str base register extend complete
 str complete
+adrp   <rel> 0x0000000020208000 -> %x1
+adrp complete
+ldpsw  (%x0)[8byte] %x0 $0x0000000000000000 -> %x1 %x2 %x0
+ldpsw  (%x0)[8byte] %x0 $0x0000000000000004 -> %x1 %x2 %x0
+ldpsw  (%x0)[8byte] %x0 $0x00000000000000fc -> %x1 %x2 %x0
+ldpsw  (%x0)[8byte] %x0 $0xffffffffffffff00 -> %x1 %x2 %x0
+ldpsw  (%x14)[8byte] %x14 $0x0000000000000000 -> %x15 %x16 %x14
+ldpsw  (%x14)[8byte] %x14 $0x0000000000000004 -> %x15 %x16 %x14
+ldpsw  (%x14)[8byte] %x14 $0x00000000000000fc -> %x15 %x16 %x14
+ldpsw  (%x14)[8byte] %x14 $0xffffffffffffff00 -> %x15 %x16 %x14
+ldpsw  (%x28)[8byte] %x28 $0x0000000000000000 -> %x29 %x30 %x28
+ldpsw  (%x28)[8byte] %x28 $0x0000000000000004 -> %x29 %x30 %x28
+ldpsw  (%x28)[8byte] %x28 $0x00000000000000fc -> %x29 %x30 %x28
+ldpsw  (%x28)[8byte] %x28 $0xffffffffffffff00 -> %x29 %x30 %x28
+ldpsw base post-index complete
+ldpsw  (%x0)[8byte] %x0 $0x0000000000000000 -> %x1 %x2 %x0
+ldpsw  +0x04(%x0)[8byte] %x0 $0x0000000000000004 -> %x1 %x2 %x0
+ldpsw  +0xfc(%x0)[8byte] %x0 $0x00000000000000fc -> %x1 %x2 %x0
+ldpsw  -0x0100(%x0)[8byte] %x0 $0xffffffffffffff00 -> %x1 %x2 %x0
+ldpsw  (%x14)[8byte] %x14 $0x0000000000000000 -> %x15 %x16 %x14
+ldpsw  +0x04(%x14)[8byte] %x14 $0x0000000000000004 -> %x15 %x16 %x14
+ldpsw  +0xfc(%x14)[8byte] %x14 $0x00000000000000fc -> %x15 %x16 %x14
+ldpsw  -0x0100(%x14)[8byte] %x14 $0xffffffffffffff00 -> %x15 %x16 %x14
+ldpsw  (%x28)[8byte] %x28 $0x0000000000000000 -> %x29 %x30 %x28
+ldpsw  +0x04(%x28)[8byte] %x28 $0x0000000000000004 -> %x29 %x30 %x28
+ldpsw  +0xfc(%x28)[8byte] %x28 $0x00000000000000fc -> %x29 %x30 %x28
+ldpsw  -0x0100(%x28)[8byte] %x28 $0xffffffffffffff00 -> %x29 %x30 %x28
+ldpsw base pre-index complete
+ldpsw  +0x08(%x0)[8byte] -> %x1 %x2
+ldpsw  +0x04(%x0)[8byte] -> %x1 %x2
+ldpsw  +0xfc(%x0)[8byte] -> %x1 %x2
+ldpsw  -0x0100(%x0)[8byte] -> %x1 %x2
+ldpsw  +0x08(%x14)[8byte] -> %x15 %x16
+ldpsw  +0x04(%x14)[8byte] -> %x15 %x16
+ldpsw  +0xfc(%x14)[8byte] -> %x15 %x16
+ldpsw  -0x0100(%x14)[8byte] -> %x15 %x16
+ldpsw  +0x08(%x28)[8byte] -> %x29 %x30
+ldpsw  +0x04(%x28)[8byte] -> %x29 %x30
+ldpsw  +0xfc(%x28)[8byte] -> %x29 %x30
+ldpsw  -0x0100(%x28)[8byte] -> %x29 %x30
+ldpsw base signed offset complete
+ldpsw complete
+ld2    (%x2)[16byte] $0x00 -> %q0 %q1
+ld2    (%x16)[16byte] $0x00 -> %q14 %q15
+ld2    (%x30)[16byte] $0x00 -> %q28 %q29
+ld2 simdfp multiple structures no offset complete
+ld2    (%x0)[32byte] $0x00 %x0 %x0 -> %q0 %q1 %x0
+ld2    (%x15)[32byte] $0x00 %x15 %x15 -> %q15 %q16 %x15
+ld2    (%x30)[32byte] $0x00 %x30 %x30 -> %q29 %q30 %x30
+ld2    (%x0)[16byte] $0x00 %x0 $0x10 -> %d0 %d1 %x0
+ld2    (%x0)[32byte] $0x00 %x0 $0x20 -> %q0 %q1 %x0
+ld2 simdfp multiple structures post-index complete
+ld2    (%x0)[2byte] $0x00 -> %q0 %q1
+ld2    (%x0)[2byte] $0x01 -> %q0 %q1
+ld2    (%x0)[2byte] $0x02 -> %q0 %q1
+ld2    (%x0)[2byte] $0x03 -> %q0 %q1
+ld2    (%x0)[2byte] $0x04 -> %q0 %q1
+ld2    (%x0)[2byte] $0x05 -> %q0 %q1
+ld2    (%x0)[2byte] $0x06 -> %q0 %q1
+ld2    (%x0)[2byte] $0x07 -> %q0 %q1
+ld2    (%x0)[2byte] $0x08 -> %q0 %q1
+ld2    (%x0)[2byte] $0x09 -> %q0 %q1
+ld2    (%x0)[2byte] $0x0a -> %q0 %q1
+ld2    (%x0)[2byte] $0x0b -> %q0 %q1
+ld2    (%x0)[2byte] $0x0c -> %q0 %q1
+ld2    (%x0)[2byte] $0x0d -> %q0 %q1
+ld2    (%x0)[2byte] $0x0e -> %q0 %q1
+ld2    (%x0)[2byte] $0x0f -> %q0 %q1
+ld2    (%x0)[2byte] $0x01 -> %q0 %q1
+ld2    (%x15)[2byte] $0x01 -> %q15 %q16
+ld2    (%x30)[2byte] $0x01 -> %q29 %q30
+ld2 simdfp single structure no offset complete
+ld2    %q0 %q1 (%x0)[2byte] $0x01 %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x02 %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x03 %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x04 %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x05 %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x06 %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x07 %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x08 %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x09 %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x0a %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x0b %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x0c %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x0d %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x0e %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x0f %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x01 %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q15 %q16 (%x15)[2byte] $0x01 %x15 $0x02 -> %q15 %q16 %x15
+ld2    %q29 %q30 (%x30)[2byte] $0x01 %x30 $0x02 -> %q29 %q30 %x30
+ld2    %q0 %q1 (%x0)[2byte] $0x01 %x0 $0x02 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[4byte] $0x01 %x0 $0x04 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[8byte] $0x01 %x0 $0x08 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[16byte] $0x01 %x0 $0x10 -> %q0 %q1 %x0
+ld2    %q0 %q1 (%x0)[2byte] $0x01 %x0 %x1 -> %q0 %q1 %x0
+ld2    %q15 %q16 (%x15)[2byte] $0x01 %x15 %x16 -> %q15 %q16 %x15
+ld2    %q29 %q30 (%x30)[2byte] $0x01 %x30 %x29 -> %q29 %q30 %x30
+ld2 simdfp single structure post-index complete
+ld2 complete
+ld3    (%x2)[24byte] $0x00 -> %q0 %q1 %q2
+ld3    (%x16)[24byte] $0x00 -> %q14 %q15 %q16
+ld3    (%x30)[24byte] $0x00 -> %q28 %q29 %q30
+ld3 simdfp multiple structures no offset complete
+ld3    (%x0)[48byte] $0x00 %x0 %x0 -> %q0 %q1 %q2 %x0
+ld3    (%x15)[48byte] $0x00 %x15 %x15 -> %q15 %q16 %q17 %x15
+ld3    (%x30)[48byte] $0x00 %x30 %x30 -> %q28 %q29 %q30 %x30
+ld3    (%x0)[24byte] $0x00 %x0 $0x18 -> %d0 %d1 %d2 %x0
+ld3    (%x0)[48byte] $0x00 %x0 $0x30 -> %q0 %q1 %q2 %x0
+ld3 simdfp multiple structures post-index complete
+ld3    (%x0)[3byte] $0x00 -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x01 -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x02 -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x03 -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x04 -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x05 -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x06 -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x07 -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x08 -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x09 -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x0a -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x0b -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x0c -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x0d -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x0e -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x0f -> %q0 %q1 %q2
+ld3    (%x0)[3byte] $0x01 -> %q0 %q1 %q2
+ld3    (%x15)[3byte] $0x01 -> %q15 %q16 %q17
+ld3    (%x30)[3byte] $0x01 -> %q28 %q29 %q30
+ld3 simdfp single structure no offset complete
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x00 %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x01 %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x02 %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x03 %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x04 %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x05 %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x06 %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x07 %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x08 %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x09 %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x0a %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x0b %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x0c %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x0d %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x0e %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x0f %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x01 %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q15 %q16 %q17 (%x15)[3byte] $0x01 %x15 $0x03 -> %q15 %q16 %q17 %x15
+ld3    %q28 %q29 %q30 (%x30)[3byte] $0x01 %x30 $0x03 -> %q28 %q29 %q30 %x30
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x01 %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[6byte] $0x01 %x0 $0x06 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[12byte] $0x01 %x0 $0x0c -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[24byte] $0x01 %x0 $0x18 -> %q0 %q1 %q2 %x0
+ld3    %q0 %q1 %q2 (%x0)[3byte] $0x01 %x0 %x1 -> %q0 %q1 %q2 %x0
+ld3    %q15 %q16 %q17 (%x15)[3byte] $0x01 %x15 %x16 -> %q15 %q16 %q17 %x15
+ld3    %q28 %q29 %q30 (%x30)[3byte] $0x01 %x30 %x29 -> %q28 %q29 %q30 %x30
+ld3 simdfp single structure post-index complete
+ld3 complete
+ld4    (%x2)[64byte] $0x00 -> %q0 %q1 %q2 %q3
+ld4    (%x16)[64byte] $0x00 -> %q14 %q15 %q16 %q17
+ld4    (%x30)[64byte] $0x00 -> %q27 %q28 %q29 %q30
+ld4 simdfp multiple structures no offset complete
+ld4    (%x0)[64byte] $0x00 %x0 %x0 -> %q0 %q1 %q2 %q3 %x0
+ld4    (%x15)[64byte] $0x00 %x15 %x15 -> %q15 %q16 %q17 %q18 %x15
+ld4    (%x30)[64byte] $0x00 %x30 %x30 -> %q27 %q28 %q29 %q30 %x30
+ld4    (%x0)[32byte] $0x00 %x0 $0x20 -> %d0 %d1 %d2 %d3 %x0
+ld4    (%x0)[64byte] $0x00 %x0 $0x40 -> %q0 %q1 %q2 %q3 %x0
+ld4 simdfp multiple structures post-index complete
+ld4    (%x0)[4byte] $0x00 -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x01 -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x02 -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x03 -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x04 -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x05 -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x06 -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x07 -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x08 -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x09 -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x0a -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x0b -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x0c -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x0d -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x0e -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x0f -> %q0 %q1 %q2 %q3
+ld4    (%x0)[4byte] $0x01 -> %q0 %q1 %q2 %q3
+ld4    (%x15)[4byte] $0x01 -> %q15 %q16 %q17 %q18
+ld4    (%x30)[4byte] $0x01 -> %q27 %q28 %q29 %q30
+ld4 simdfp single structure no offset complete
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x00 %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x01 %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x02 %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x03 %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x04 %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x05 %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x06 %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x07 %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x08 %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x09 %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x0a %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x0b %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x0c %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x0d %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x0e %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x0f %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x01 %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q15 %q16 %q17 %q18 (%x15)[4byte] $0x01 %x15 $0x04 -> %q15 %q16 %q17 %q18 %x15
+ld4    %q27 %q28 %q29 %q30 (%x30)[4byte] $0x01 %x30 $0x04 -> %q27 %q28 %q29 %q30 %x30
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x01 %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[8byte] $0x01 %x0 $0x08 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[16byte] $0x01 %x0 $0x10 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[32byte] $0x01 %x0 $0x20 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q0 %q1 %q2 %q3 (%x0)[4byte] $0x01 %x0 %x1 -> %q0 %q1 %q2 %q3 %x0
+ld4    %q15 %q16 %q17 %q18 (%x15)[4byte] $0x01 %x15 %x16 -> %q15 %q16 %q17 %q18 %x15
+ld4    %q27 %q28 %q29 %q30 (%x30)[4byte] $0x01 %x30 %x29 -> %q27 %q28 %q29 %q30 %x30
+ld4 simdfp single structure post-index complete
+ld4 complete
+ld2r   (%x0)[16byte] -> %q0 %q1
+ld2r   (%x15)[16byte] -> %q15 %q16
+ld2r   (%x16)[16byte] -> %q29 %q30
+ld2r simdfp no offset complete
+ld2r   (%x0)[8byte] %x0 %x1 -> %q0 %q1 %x0
+ld2r   (%x15)[8byte] %x15 %x16 -> %q15 %q16 %x15
+ld2r   (%x29)[8byte] %x29 %x30 -> %q29 %q30 %x29
+ld2r   (%x0)[2byte] %x0 $0x02 -> %q0 %q1 %x0
+ld2r   (%x0)[4byte] %x0 $0x04 -> %q0 %q1 %x0
+ld2r   (%x0)[8byte] %x0 $0x08 -> %q0 %q1 %x0
+ld2r   (%x0)[16byte] %x0 $0x10 -> %q0 %q1 %x0
+ld2r simdfp post-index complete
+ld2r complete
+ld3r   (%x0)[24byte] -> %q0 %q1 %q2
+ld3r   (%x15)[24byte] -> %q15 %q16 %q17
+ld3r   (%x30)[24byte] -> %q28 %q29 %q30
+ld3r simdfp no offset complete
+ld3r   (%x0)[24byte] %x0 %x1 -> %q0 %q1 %q2 %x0
+ld3r   (%x15)[24byte] %x15 %x16 -> %q15 %q16 %q17 %x15
+ld3r   (%x29)[24byte] %x29 %x30 -> %q28 %q29 %q30 %x29
+ld3r   (%x0)[3byte] %x0 $0x03 -> %q0 %q1 %q2 %x0
+ld3r   (%x0)[6byte] %x0 $0x06 -> %q0 %q1 %q2 %x0
+ld3r   (%x0)[12byte] %x0 $0x0c -> %q0 %q1 %q2 %x0
+ld3r   (%x0)[24byte] %x0 $0x18 -> %q0 %q1 %q2 %x0
+ld3r simdfp post-index complete
+ld3r complete
+ld4r   (%x0)[32byte] -> %q0 %q1 %q2 %q3
+ld4r   (%x15)[32byte] -> %q15 %q16 %q17 %q18
+ld4r   (%x30)[32byte] -> %q27 %q28 %q29 %q30
+ld4r simdfp no offset complete
+ld4r   (%x0)[32byte] %x0 %x1 -> %q0 %q1 %q2 %q3 %x0
+ld4r   (%x15)[32byte] %x15 %x16 -> %q15 %q16 %q17 %q18 %x15
+ld4r   (%x29)[32byte] %x29 %x30 -> %q27 %q28 %q29 %q30 %x29
+ld4r   (%x0)[4byte] %x0 $0x04 -> %q0 %q1 %q2 %q3 %x0
+ld4r   (%x0)[8byte] %x0 $0x08 -> %q0 %q1 %q2 %q3 %x0
+ld4r   (%x0)[16byte] %x0 $0x10 -> %q0 %q1 %q2 %q3 %x0
+ld4r   (%x0)[32byte] %x0 $0x20 -> %q0 %q1 %q2 %q3 %x0
+ld4r simdfp post index complete
+ld4r complete
 All tests complete

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -1459,8 +1459,6 @@ str    %w30 -> (%x29,%x30,sxtx #2)[4byte]
 str    %x30 -> (%x29,%x30,sxtx #3)[8byte]
 str base register extend complete
 str complete
-adrp   <rel> 0x0000000020208000 -> %x1
-adrp complete
 ldpsw  (%x0)[8byte] %x0 $0x0000000000000000 -> %x1 %x2 %x0
 ldpsw  (%x0)[8byte] %x0 $0x0000000000000004 -> %x1 %x2 %x0
 ldpsw  (%x0)[8byte] %x0 $0x00000000000000fc -> %x1 %x2 %x0


### PR DESCRIPTION
Add encoding and decoding IR tests for:
- adrp, ldpsw, ld2, ld3, ld4, ld2r, ld3r, ld4r

Issue #4847, #2626