### PR TITLE
i#4865: Add emulation instr-only and convenience features

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -165,7 +165,8 @@ compatibility changes:
    #DR_EMULATE_REST_OF_BLOCK, indicating an emulation sequence that has no end label
    and includes the rest of the block; and #DR_EMULATE_INSTR_ONLY, indicating
    an emulation for which instrumentation should still examine the
-   emulation sequence for observing data operations.  This change preserves
+   emulation sequence for observing data operations.  A third value is set by
+   drmgr_in_emulation_region(): #DR_EMULATE_FIRST_INSTR.  This flags addition preserves
    binary compatibility, but source code that did not zero the structure could end
    up with an uninitialized flags field when calling drmgr_insert_emulation_start().
 

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -161,6 +161,13 @@ compatibility changes:
    dr_api.h includes the new files, so users including dr_api.h are unaffected.
  - The routines dr_insert_save_fpstate(), dr_insert_restore_fpstate(),
    and dr_insert_get_seg_base() moved from dr_proc.h to dr_ir_utils.h.
+ - Added a flags field to #emulated_instr_t and two emulator-set flags values:
+   #DR_EMULATE_REST_OF_BLOCK, indicating an emulation sequence that has no end label
+   and includes the rest of the block; and #DR_EMULATE_INSTR_ONLY, indicating
+   an emulation for which instrumentation should still examine the
+   emulation sequence for observing data operations.  This change preserves
+   binary compatibility, but source code that did not zero the structure could end
+   up with an uninitialized flags field when calling drmgr_insert_emulation_start().
 
 Further non-compatibility-affecting changes include:
 
@@ -206,12 +213,10 @@ Further non-compatibility-affecting changes include:
  - Added instr_zeroes_zmmh() that returns true if an instruction clears the
    upper bits of a ZMM register with zeros.
  - Added instr_clear_label_callback().
- - Added a flags field to #emulated_instr_t and a flags value
-   #DR_EMULATE_REST_OF_BLOCK, indicating an emulation sequence that has no end label
-   and includes the rest of the block.
  - Added #DRREG_HANDLE_MULTI_PHASE_SLOT_RESERVATIONS to #drreg_bb_properties_t to
    enable logic that avoids conflicts in spill slots when drreg is used to reserve
    registers in multiple phases.
+ - Added drmgr_in_emulation_region() for more conveniently handling emulation.
 
 **************************************************
 <hr>

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -3282,6 +3282,9 @@ drmgr_in_emulation_region(void *drcontext, OUT emulated_instr_t *emulation_info)
     if (!pt->in_emulation_region)
         return false;
     if (emulation_info != NULL) {
+        /* The size field supplies compatibility so we copy just the fields the
+         * caller has allocated.
+         */
         size_t size = emulation_info->size;
         if (size > pt->emulation_info.size)
             size = pt->emulation_info.size;

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -3274,22 +3274,15 @@ drmgr_get_emulated_instr_data(instr_t *instr, emulated_instr_t *emulated)
 
 DR_EXPORT
 bool
-drmgr_in_emulation_region(void *drcontext, OUT emulated_instr_t *emulation_info)
+drmgr_in_emulation_region(void *drcontext, OUT const emulated_instr_t **emulation_info)
 {
     per_thread_t *pt = (per_thread_t *)drmgr_get_tls_field(drcontext, our_tls_idx);
     if (drmgr_current_bb_phase(drcontext) != DRMGR_PHASE_INSERTION)
         return false;
     if (!pt->in_emulation_region)
         return false;
-    if (emulation_info != NULL) {
-        /* The size field supplies compatibility so we copy just the fields the
-         * caller has allocated.
-         */
-        size_t size = emulation_info->size;
-        if (size > pt->emulation_info.size)
-            size = pt->emulation_info.size;
-        memcpy(emulation_info, &pt->emulation_info, size);
-    }
+    if (emulation_info != NULL)
+        *emulation_info = &pt->emulation_info;
     return true;
 }
 

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -79,8 +79,10 @@
  */
 #ifdef DEBUG
 #    define ASSERT(x, msg) DR_ASSERT_MSG(x, msg)
+#    define IF_DEBUG(x) x
 #else
 #    define ASSERT(x, msg) /* nothing */
+#    define IF_DEBUG(x)    /* nothing */
 #endif
 
 /***************************************************************************
@@ -203,6 +205,8 @@ typedef struct _per_thread_t {
     instr_t *first_instr;
     instr_t *first_nonlabel_instr;
     instr_t *last_instr;
+    emulated_instr_t emulation_info;
+    bool in_emulation_region;
 } per_thread_t;
 
 /* Emulation note types */
@@ -952,6 +956,7 @@ drmgr_bb_event_do_instrum_phases(void *drcontext, void *tag, instrlist_t *bb,
     pt->first_instr = instrlist_first(bb);
     pt->first_nonlabel_instr = instrlist_first_nonlabel(bb);
     pt->last_instr = instrlist_last(bb);
+    pt->in_emulation_region = false; /* Just to be safe. */
 
     /* For opcode instrumentation:
      * We need to create a local copy of the opcode map.
@@ -970,6 +975,12 @@ drmgr_bb_event_do_instrum_phases(void *drcontext, void *tag, instrlist_t *bb,
     /* Main pass for instrumentation. */
     for (inst = instrlist_first(bb); inst != NULL; inst = next_inst) {
         next_inst = instr_get_next(inst);
+        if (!pt->in_emulation_region && drmgr_is_emulation_start(inst)) {
+            IF_DEBUG(bool ok =) drmgr_get_emulated_instr_data(inst, &pt->emulation_info);
+            ASSERT(ok, "should be at emulation start label");
+            pt->in_emulation_region = true;
+            pt->emulation_info.flags |= DR_EMULATE_FIRST_INSTR;
+        }
         if (is_opcode_instrum_applicable && instr_opcode_valid(inst)) {
             opcode = instr_get_opcode(inst);
             local_info->iter_opcode_insert =
@@ -984,6 +995,13 @@ drmgr_bb_event_do_instrum_phases(void *drcontext, void *tag, instrlist_t *bb,
         res |= drmgr_bb_event_do_insertion_per_instr(
             drcontext, tag, bb, inst, for_trace, translating, &local_info->iter_insert,
             pair_data, quartet_data);
+        if (pt->in_emulation_region) {
+            pt->emulation_info.flags &= ~DR_EMULATE_FIRST_INSTR;
+            if (drmgr_is_emulation_end(inst) ||
+                (TEST(DR_EMULATE_REST_OF_BLOCK, pt->emulation_info.flags) &&
+                 drmgr_is_last_instr(drcontext, inst)))
+                pt->in_emulation_region = false;
+        }
     }
 
     /* Pass 4: final */
@@ -1670,6 +1688,7 @@ our_thread_init_event(void *drcontext)
 {
     per_thread_t *pt = (per_thread_t *)dr_thread_alloc(drcontext, sizeof(*pt));
     memset(pt, 0, sizeof(*pt));
+    pt->emulation_info.size = sizeof(pt->emulation_info);
     drmgr_set_tls_field(drcontext, our_tls_idx, (void *)pt);
 }
 
@@ -3250,6 +3269,24 @@ drmgr_get_emulated_instr_data(instr_t *instr, emulated_instr_t *emulated)
             (dr_emulate_options_t)get_emul_label_data(instr, DRMGR_EMUL_FLAGS);
     }
 
+    return true;
+}
+
+DR_EXPORT
+bool
+drmgr_in_emulation_region(void *drcontext, OUT emulated_instr_t *emulation_info)
+{
+    per_thread_t *pt = (per_thread_t *)drmgr_get_tls_field(drcontext, our_tls_idx);
+    if (drmgr_current_bb_phase(drcontext) != DRMGR_PHASE_INSERTION)
+        return false;
+    if (!pt->in_emulation_region)
+        return false;
+    if (emulation_info != NULL) {
+        size_t size = emulation_info->size;
+        if (size > pt->emulation_info.size)
+            size = pt->emulation_info.size;
+        memcpy(emulation_info, &pt->emulation_info, size);
+    }
     return true;
 }
 

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -815,6 +815,29 @@ typedef enum {
      * block in any case.
      */
     DR_EMULATE_REST_OF_BLOCK = 0x0001,
+    /**
+     * When used with drmgr_in_emulation_region(), indicates that the current
+     * instruction is the first instruction of the emulation region.  This allows
+     * a client to act on the original instruction just once, despite multiple
+     * emulation instructions.
+     */
+    DR_EMULATE_FIRST_INSTR = 0x0002,
+    /**
+     * Indicates that only the instruction fetch is being emulated differently.
+     * The operation of the instruction remains the same.
+     * Observational instrumentation should examine the original instruction
+     * (in #emulated_instr_t.instr) for instruction fetch purposes, but should
+     * examine the emulation sequence for data accesses (e.g., loads and stores for
+     * a memory address tracing tool).  If this flag is not set, instrumentation
+     * should instrument the original instruction in every way and ignore the
+     * emulation sequence.
+     *
+     * This flag is used for instruction refactorings that simplify instrumentation:
+     * e.g., drutil_expand_rep_string() and drx_expand_scatter_gather().  It is not
+     * used for true emulation of an instruction that is not supported by the current
+     * hardware with an alternative sequence of instructions.
+     */
+    DR_EMULATE_INSTR_ONLY = 0x0004,
 } dr_emulate_options_t;
 
 /**
@@ -909,6 +932,41 @@ drmgr_is_emulation_end(instr_t *instr);
 DR_EXPORT
 bool
 drmgr_get_emulated_instr_data(instr_t *instr, OUT emulated_instr_t *emulated);
+
+/**
+ * Must be called during drmgr's insertion phase.  Returns whether the current
+ * instruction in the phase is inside an emulation region.  If it returns true,
+ * \p emulation_info is filled in with information about the emulation.
+ *
+ * This is a convenience routine that records the state for the
+ * drmgr_is_emulation_start() and drmgr_is_emulation_end() labels and the
+ * #DR_EMULATE_REST_OF_BLOCK flag to prevent the client having to store state.
+ *
+ * When calling this function, the \p size field of \p emulation_info should be set
+ * using sizeof(). This allows the API to check for compatibility.
+ *
+ * This is the recommended usage for observational clients in the insertion event,
+ * highlighting the different paths for instruction versus data instrumentation:
+ *
+ *    emulated_instr_t emulation;
+ *    if (drmgr_in_emulation_region(drcontext, &emulation)) {
+ *        if (TEST(DR_EMULATE_FIRST_INSTR, emulation.flags)) {
+ *            record_instr_fetch(emulation.instr);
+ *            if (!TEST(DR_EMULATE_INSTR_ONLY, emulation.flags))
+ *                record_data_addresses(emulation.instr);
+ *        } // Else skip further instr fetches until outside emulation region.
+ *        if (instr_is_app(exec_instr) && TEST(DR_EMULATE_INSTR_ONLY, emulation.flags))
+ *            record_data_addresses(exec_instr);
+ *    } else if (instr_is_app(exec_instr)) {
+ *        record_instr_fetch(exec_instr);
+ *        record_data_addresses(exec_instr);
+ *    }
+ *
+ * \return false if the caller's \p emulated_instr_t is not compatible, true otherwise.
+ */
+DR_EXPORT
+bool
+drmgr_in_emulation_region(void *drcontext, OUT emulated_instr_t *emulation_info);
 
 /***************************************************************************
  * UTILITIES

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -834,8 +834,9 @@ typedef enum {
      *
      * This flag is used for instruction refactorings that simplify instrumentation:
      * e.g., drutil_expand_rep_string() and drx_expand_scatter_gather().  It is not
-     * used for true emulation of an instruction that is not supported by the current
-     * hardware with an alternative sequence of instructions.
+     * used for true emulation of an instruction, for example, for replacing an
+     * instruction that is not supported by the current hardware with
+     * an alternative sequence of instructions.
      */
     DR_EMULATE_INSTR_ONLY = 0x0004,
 } dr_emulate_options_t;

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -937,26 +937,24 @@ drmgr_get_emulated_instr_data(instr_t *instr, OUT emulated_instr_t *emulated);
 /**
  * Must be called during drmgr's insertion phase.  Returns whether the current
  * instruction in the phase is inside an emulation region.  If it returns true,
- * \p emulation_info is filled in with information about the emulation.
+ * \p emulation_info is written with a pointer to information about the emulation.
+ * The pointed-at information's lifetime is the full range of the emulation region.
  *
  * This is a convenience routine that records the state for the
  * drmgr_is_emulation_start() and drmgr_is_emulation_end() labels and the
  * #DR_EMULATE_REST_OF_BLOCK flag to prevent the client having to store state.
  *
- * When calling this function, the \p size field of \p emulation_info should be set
- * using sizeof(). This allows the API to check for compatibility.
- *
  * This is the recommended usage for observational clients in the insertion event,
  * highlighting the different paths for instruction versus data instrumentation:
  *
- *    emulated_instr_t emulation;
+ *    const emulated_instr_t *emulation;
  *    if (drmgr_in_emulation_region(drcontext, &emulation)) {
- *        if (TEST(DR_EMULATE_FIRST_INSTR, emulation.flags)) {
- *            record_instr_fetch(emulation.instr);
- *            if (!TEST(DR_EMULATE_INSTR_ONLY, emulation.flags))
- *                record_data_addresses(emulation.instr);
+ *        if (TEST(DR_EMULATE_FIRST_INSTR, emulation->flags)) {
+ *            record_instr_fetch(emulation->instr);
+ *            if (!TEST(DR_EMULATE_INSTR_ONLY, emulation->flags))
+ *                record_data_addresses(emulation->instr);
  *        } // Else skip further instr fetches until outside emulation region.
- *        if (instr_is_app(exec_instr) && TEST(DR_EMULATE_INSTR_ONLY, emulation.flags))
+ *        if (instr_is_app(exec_instr) && TEST(DR_EMULATE_INSTR_ONLY, emulation->flags))
  *            record_data_addresses(exec_instr);
  *    } else if (instr_is_app(exec_instr)) {
  *        record_instr_fetch(exec_instr);
@@ -967,7 +965,7 @@ drmgr_get_emulated_instr_data(instr_t *instr, OUT emulated_instr_t *emulated);
  */
 DR_EXPORT
 bool
-drmgr_in_emulation_region(void *drcontext, OUT emulated_instr_t *emulation_info);
+drmgr_in_emulation_region(void *drcontext, OUT const emulated_instr_t **emulation_info);
 
 /***************************************************************************
  * UTILITIES

--- a/ext/drutil/drutil.c
+++ b/ext/drutil/drutil.c
@@ -705,7 +705,9 @@ drutil_expand_rep_string_ex(void *drcontext, instrlist_t *bb, bool *expanded OUT
          * many complexities that were not worth further work), so we instead
          * use the flag to mark the whole block as emulated.
          */
-        emulated_instr.flags = DR_EMULATE_REST_OF_BLOCK;
+        emulated_instr.flags = DR_EMULATE_REST_OF_BLOCK |
+            /* Tools should instrument the data operations in the sequence. */
+            DR_EMULATE_INSTR_ONLY;
         drmgr_insert_emulation_start(drcontext, bb, inst, &emulated_instr);
 
         pre_loop = INSTR_CREATE_label(drcontext);

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2366,6 +2366,8 @@ drx_expand_scatter_gather(void *drcontext, instrlist_t *bb, OUT bool *expanded)
     emulated_instr.size = sizeof(emulated_instr);
     emulated_instr.pc = instr_get_app_pc(sg_instr);
     emulated_instr.instr = sg_instr;
+    /* Tools should instrument the data operations in the sequence. */
+    emulated_instr.flags = DR_EMULATE_INSTR_ONLY;
     drmgr_insert_emulation_start(drcontext, bb, sg_instr, &emulated_instr);
 
     if (sg_info.is_evex) {

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2384,10 +2384,11 @@ if (UNIX)
     tobuild_ci(client.cbr-retarget client-interface/cbr-retarget.c "" "" "")
   endif (X86)
   tobuild_ci(client.cleancallsig client-interface/cleancallsig.c "" "" "")
-  if (AARCH64) # XXX i#3173 Improve testing of emulation API functions
-    tobuild_ci(client.emulation_api_simple client-interface/emulation_api_simple.c "" "" "")
+  if (X64) # XXX i#3173 Improve testing of emulation API functions
+    tobuild_ci(client.emulation_api_simple client-interface/emulation_api_simple.c
+      "" "" "")
     use_DynamoRIO_extension(client.emulation_api_simple.dll drmgr)
-  endif (AARCH64)
+  endif ()
 else (UNIX)
   tobuild_ci(client.events client-interface/events.c
     "" "" "${events_appdll_path}")

--- a/suite/tests/client-interface/drutil-test.dll.c
+++ b/suite/tests/client-interface/drutil-test.dll.c
@@ -169,9 +169,6 @@ event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
             continue;
         }
         CHECK(!drmgr_is_emulation_end(instr), "no end marker expected");
-        CHECK((in_emulation && drmgr_in_emulation_region(drcontext, NULL)) ||
-                  (!in_emulation && !drmgr_in_emulation_region(drcontext, NULL)),
-              "emulation labels do not agree with drmgr_in_emulation_region");
         if (!in_emulation && instr_is_app(instr)) {
             ++num_app_instrs;
             CHECK(!instr_is_stringop_loop(instr), "string loop still here");

--- a/suite/tests/client-interface/drutil-test.dll.c
+++ b/suite/tests/client-interface/drutil-test.dll.c
@@ -169,6 +169,9 @@ event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
             continue;
         }
         CHECK(!drmgr_is_emulation_end(instr), "no end marker expected");
+        CHECK((in_emulation && drmgr_in_emulation_region(drcontext, NULL)) ||
+                  (!in_emulation && !drmgr_in_emulation_region(drcontext, NULL)),
+              "emulation labels do not agree with drmgr_in_emulation_region");
         if (!in_emulation && instr_is_app(instr)) {
             ++num_app_instrs;
             CHECK(!instr_is_stringop_loop(instr), "string loop still here");

--- a/suite/tests/client-interface/emulation_api_simple.dll.c
+++ b/suite/tests/client-interface/emulation_api_simple.dll.c
@@ -132,7 +132,7 @@ should_fully_emulate_instr(instr_t *instr)
     return true;
 }
 
-static dr_emit_flags_t
+static void
 emulate_fully(void *drcontext, instrlist_t *bb, instr_t *instr)
 {
 
@@ -264,7 +264,7 @@ should_partly_emulate_instr(instr_t *instr)
     return true;
 }
 
-static dr_emit_flags_t
+static void
 emulate_partly(void *drcontext, instrlist_t *bb, instr_t *instr)
 {
     dr_atomic_add32_return_sum(&count_emulated_partly, 1);

--- a/suite/tests/client-interface/emulation_api_simple.dll.c
+++ b/suite/tests/client-interface/emulation_api_simple.dll.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2021 Google, Inc.   All rights reserved.
  * Copyright (c) 2018 ARM Limited. All rights reserved.
  * **********************************************************
  *
@@ -30,29 +31,52 @@
  *
  */
 
-/* A simple AArch64 client replacing 'dst = src0 & src1' with
+/* A simple client replacing 'dst = src0 & src1' with
  * 'dst = !(!src0 | !src1)' to sanity test two core emulation API functions:
  * - drmgr_insert_emulation_start()
  * - drmgr_insert_emulation_end()
  *
- * Note this emulation client is for AArch64 only:
+ * Note: This emulation client is for AArch64 and x86_64 only:
  * XXX i#3173 Improve testing of emulation API functions
  */
 
 #include "dr_api.h"
 #include "drmgr.h"
+#include "client_tools.h"
 #include <limits.h>
 #include <stdint.h>
 #include <string.h>
 #include <unistd.h>
 
-/* Events handlers */
+#define CHECK(x, msg)                                                                \
+    do {                                                                             \
+        if (!(x)) {                                                                  \
+            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
+            dr_log(dr_get_current_drcontext(), DR_LOG_ALL, 1,                        \
+                   "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg);             \
+            /* NOCHECK dr_abort(); */                                                \
+        }                                                                            \
+    } while (0);
+
+static int count_emulated_fully;
+static int count_emulated_partly;
+
+static ptr_uint_t derived_marker;
+
+/* Event handlers. */
 static void
 event_exit(void);
 
 static dr_emit_flags_t
 event_instruction_change(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                          bool translating);
+static dr_emit_flags_t
+event_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
+               bool translating, OUT void **user_data);
+
+static dr_emit_flags_t
+event_insertion(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
+                bool for_trace, bool translating, void *user_data);
 
 DR_EXPORT void
 dr_client_main(client_id_t id, int argc, const char *argv[])
@@ -64,14 +88,237 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 
     if (!drmgr_register_bb_app2app_event(event_instruction_change, NULL))
         DR_ASSERT(false);
+    if (!drmgr_register_bb_instrumentation_event(event_analysis, event_insertion, NULL))
+        DR_ASSERT(false);
+    derived_marker = drmgr_reserve_note_range(1);
+    DR_ASSERT(derived_marker != DRMGR_NOTE_NONE);
 }
 
 static void
 event_exit(void)
 {
-    if (!drmgr_unregister_bb_app2app_event(event_instruction_change))
+#if VERBOSE
+    dr_fprintf(STDERR, "Found and emulated %d instructions fully, %d partly\n",
+               dr_atomic_load32(&count_emulated_fully),
+               dr_atomic_load32(&count_emulated_partly));
+#endif
+    if (!drmgr_unregister_bb_app2app_event(event_instruction_change) ||
+        !drmgr_unregister_bb_instrumentation_event(event_analysis))
         DR_ASSERT(false);
     drmgr_exit();
+}
+
+static bool
+should_fully_emulate_instr(instr_t *instr)
+{
+    /* We replace 'dst = src0 & src1' with 'dst = !(!src0 | !src1)'. We only
+     * transform AND instructions with unshifted, 64 bit register operands.
+     */
+    if (instr_get_opcode(instr) != OP_and)
+        return false;
+    opnd_t src0 = instr_get_src(instr, 0);
+#ifdef AARCH64
+    if (instr_num_srcs(instr) != 4 || opnd_get_size(src0) != OPSZ_8 ||
+        opnd_get_immed_int(instr_get_src(instr, 3)) != 0)
+        return false;
+#elif defined(X86_64)
+    opnd_t dst = instr_get_dst(instr, 0);
+    opnd_t src1 = instr_get_src(instr, 1);
+    if (!opnd_same(src1, dst) || !opnd_is_reg(src0) || opnd_get_size(src0) != OPSZ_8)
+        return false;
+#else
+#    error Architecture not supported.
+#endif
+    return true;
+}
+
+static dr_emit_flags_t
+emulate_fully(void *drcontext, instrlist_t *bb, instr_t *instr)
+{
+
+    dr_atomic_add32_return_sum(&count_emulated_fully, 1);
+
+    opnd_t dst = instr_get_dst(instr, 0);
+    opnd_t src0 = instr_get_src(instr, 0);
+    opnd_t src1 = instr_get_src(instr, 1);
+    app_pc raw_instr_pc = instr_get_app_pc(instr);
+
+    /* Insert emulation label to signal start of emulation code sequence. The
+     * label is loaded with data about the instruction being emulated for use by
+     * an observational client.
+     */
+    emulated_instr_t emulated_instr;
+    emulated_instr.size = sizeof(emulated_instr);
+    emulated_instr.pc = raw_instr_pc;
+    emulated_instr.instr = instr;
+    emulated_instr.flags = 0;
+    drmgr_insert_emulation_start(drcontext, bb, instr, &emulated_instr);
+    instr_t *start_derived = INSTR_CREATE_label(drcontext);
+    instrlist_meta_preinsert(bb, instr, start_derived);
+
+#ifdef AARCH64
+    dr_save_reg(drcontext, bb, instr, DR_REG_X26, SPILL_SLOT_1);
+    dr_save_reg(drcontext, bb, instr, DR_REG_X27, SPILL_SLOT_2);
+
+    opnd_t scratch0 = opnd_create_reg(DR_REG_X26);
+    opnd_t scratch1 = opnd_create_reg(DR_REG_X27);
+
+    /* scratch0 = !src0
+     * XXX i#2440 AArch64 missing INSTR_CREATE macros (INSTR_CREATE_orn)
+     */
+    instr_t *not0 =
+        instr_create_1dst_4src(drcontext, OP_orn, scratch0, opnd_create_reg(DR_REG_XZR),
+                               src0, OPND_CREATE_LSL(), OPND_CREATE_INT(0));
+    instrlist_preinsert(bb, instr, instr_set_translation(not0, raw_instr_pc));
+
+    /* scratch1 = !src1
+     * XXX i#2440 AArch64 missing INSTR_CREATE macros (INSTR_CREATE_orn)
+     */
+    instr_t *not1 =
+        instr_create_1dst_4src(drcontext, OP_orn, scratch1, opnd_create_reg(DR_REG_XZR),
+                               src1, OPND_CREATE_LSL(), OPND_CREATE_INT(0));
+    instrlist_preinsert(bb, instr, instr_set_translation(not1, raw_instr_pc));
+
+    /* scratch0 = scratch0 | scratch1
+     * XXX i#2440 AArch64 missing INSTR_CREATE macros (INSTR_CREATE_orr)
+     */
+    instr_t *or_i =
+        instr_create_1dst_4src(drcontext, OP_orr, scratch0, scratch0, scratch1,
+                               OPND_CREATE_LSL(), OPND_CREATE_INT(0));
+    instrlist_preinsert(bb, instr, instr_set_translation(or_i, raw_instr_pc));
+
+    /* dst = !scratch0
+     * XXX i#2440 AArch64 missing INSTR_CREATE macros (INSTR_CREATE_orn)
+     */
+    instr_t *not2 =
+        instr_create_1dst_4src(drcontext, OP_orn, dst, opnd_create_reg(DR_REG_XZR),
+                               scratch0, OPND_CREATE_LSL(), OPND_CREATE_INT(0));
+    instrlist_preinsert(bb, instr, instr_set_translation(not2, raw_instr_pc));
+
+    dr_restore_reg(drcontext, bb, instr, DR_REG_X26, SPILL_SLOT_1);
+    dr_restore_reg(drcontext, bb, instr, DR_REG_X27, SPILL_SLOT_2);
+#elif defined(X86_64)
+#    define PRE instrlist_preinsert
+    /*  and rax, rdx
+     * =>
+     *  not rax
+     *  <spill rdx>
+     *  not rdx
+     *  or rax, rdx
+     *  <restore rdx>
+     *  not rax
+     *  test rax, rax   (to set SF,ZF,PF and clear OF,CF)
+     */
+    PRE(bb, instr, INSTR_XL8(INSTR_CREATE_not(drcontext, dst), raw_instr_pc));
+    dr_save_reg(drcontext, bb, instr, opnd_get_reg(src0), SPILL_SLOT_1);
+    PRE(bb, instr, INSTR_XL8(INSTR_CREATE_not(drcontext, src0), raw_instr_pc));
+    PRE(bb, instr, INSTR_XL8(INSTR_CREATE_or(drcontext, dst, src0), raw_instr_pc));
+    dr_restore_reg(drcontext, bb, instr, opnd_get_reg(src0), SPILL_SLOT_1);
+    PRE(bb, instr, INSTR_XL8(INSTR_CREATE_not(drcontext, dst), raw_instr_pc));
+    PRE(bb, instr, INSTR_XL8(INSTR_CREATE_test(drcontext, dst, dst), raw_instr_pc));
+#else
+#    error Architecture not supported.
+#endif
+    for (instr_t *added = start_derived; added != instr; added = instr_get_next(added)) {
+        instr_set_note(added, (void *)derived_marker);
+    }
+
+    /* Insert emulation label to signal end of emulation code sequence and
+     * remove the instruction being emulated from the basic block.
+     */
+    drmgr_insert_emulation_end(drcontext, bb, instr);
+    instrlist_remove(bb, instr);
+}
+
+/* We perform same-data different-instr emulation to test DR_EMULATE_INSTR_ONLY. */
+static bool
+should_partly_emulate_instr(instr_t *instr)
+{
+#ifdef AARCH64
+    /* We replace "ldr reg, [base]" with "ldr reg, [base, XZR, LSL #3]". */
+    if (instr_get_opcode(instr) != OP_ldr || instr_num_srcs(instr) != 1 ||
+        instr_num_dsts(instr) != 1)
+        return false;
+    opnd_t dst = instr_get_dst(instr, 0);
+    opnd_t src = instr_get_src(instr, 0);
+    if (!opnd_is_reg(dst) || !opnd_is_near_base_disp(src))
+        return false;
+    if (opnd_get_base(src) == DR_REG_NULL || opnd_get_index(src) != DR_REG_NULL ||
+        opnd_get_base(src) == DR_REG_XSP || opnd_get_disp(src) != 0)
+        return false;
+#elif defined(X86_64)
+    /* We replace "mov reg, disp(base)" with "mov reg, disp(,index,1)". */
+    if (instr_get_opcode(instr) != OP_mov_ld || instr_num_srcs(instr) != 1 ||
+        instr_num_dsts(instr) != 1)
+        return false;
+    opnd_t dst = instr_get_dst(instr, 0);
+    opnd_t src = instr_get_src(instr, 0);
+    if (!opnd_is_reg(dst) || !opnd_is_near_base_disp(src))
+        return false;
+    if (opnd_get_base(src) == DR_REG_NULL || opnd_get_index(src) != DR_REG_NULL ||
+        opnd_get_base(src) == DR_REG_XSP)
+        return false;
+#else
+#    error Architecture not supported.
+#endif
+    return true;
+}
+
+static dr_emit_flags_t
+emulate_partly(void *drcontext, instrlist_t *bb, instr_t *instr)
+{
+    dr_atomic_add32_return_sum(&count_emulated_partly, 1);
+
+    app_pc raw_instr_pc = instr_get_app_pc(instr);
+
+    emulated_instr_t emulated_instr;
+    emulated_instr.size = sizeof(emulated_instr);
+    emulated_instr.pc = raw_instr_pc;
+    emulated_instr.instr = instr;
+    emulated_instr.flags = DR_EMULATE_INSTR_ONLY;
+    drmgr_insert_emulation_start(drcontext, bb, instr, &emulated_instr);
+    instr_t *start_derived = INSTR_CREATE_label(drcontext);
+    instrlist_meta_preinsert(bb, instr, start_derived);
+
+#define PRE instrlist_preinsert
+#ifdef AARCH64
+    /*  ldr reg, [base]
+     * =>
+     *  ldr reg, [base, XZR, LSL #3]
+     */
+    opnd_t dst = instr_get_dst(instr, 0);
+    opnd_t src = instr_get_src(instr, 0);
+    PRE(bb, instr,
+        INSTR_XL8(INSTR_CREATE_ldr(drcontext, dst,
+                                   opnd_create_base_disp_aarch64(
+                                       opnd_get_base(src), DR_REG_XZR, DR_EXTEND_UXTX,
+                                       true, opnd_get_disp(src), 0, opnd_get_size(src))),
+                  raw_instr_pc));
+#elif defined(X86_64)
+    /*  mov reg, disp(base)
+     * =>
+     *  mov reg, disp(,index,1)
+     */
+    opnd_t dst = instr_get_dst(instr, 0);
+    opnd_t src = instr_get_src(instr, 0);
+    PRE(bb, instr,
+        INSTR_XL8(INSTR_CREATE_mov_ld(
+                      drcontext, dst,
+                      opnd_create_base_disp(DR_REG_NULL, opnd_get_base(src), 1,
+                                            opnd_get_disp(src), opnd_get_size(src))),
+                  raw_instr_pc));
+#else
+#    error Architecture not supported.
+#endif
+    for (instr_t *added = start_derived; added != instr; added = instr_get_next(added)) {
+        instr_set_note(added, (void *)derived_marker);
+    }
+
+    /* Insert emulation label to signal end of emulation code sequence and
+     * remove the instruction being emulated from the basic block.
+     */
+    drmgr_insert_emulation_end(drcontext, bb, instr);
+    instrlist_remove(bb, instr);
 }
 
 static dr_emit_flags_t
@@ -84,77 +331,95 @@ event_instruction_change(void *drcontext, void *tag, instrlist_t *bb, bool for_t
         /* We're deleting some instrs, so get the next first. */
         next_instr = instr_get_next_app(instr);
 
-        /* We replace 'dst = src0 & src1' with 'dst = !(!src0 | !src1)'. We only
-         * transform AND instructions with unshifted, 64 bit register operands. */
-        if (instr_get_opcode(instr) != OP_and)
-            continue;
-        opnd_t dst = instr_get_dst(instr, 0);
-        opnd_t src0 = instr_get_src(instr, 0);
-        opnd_t src1 = instr_get_src(instr, 1);
-
-        if (instr_num_srcs(instr) != 4 || opnd_get_size(src0) != OPSZ_8 ||
-            opnd_get_immed_int(instr_get_src(instr, 3)) != 0)
-            continue;
-
-        app_pc raw_instr_pc = instr_get_app_pc(instr);
-
-        /* Insert emulation label to signal start of emulation code sequence. The
-         * label is loaded with data about the instruction being emulated for use by
-         * an observational client.
-         */
-        emulated_instr_t emulated_instr;
-        emulated_instr.size = sizeof(emulated_instr);
-        emulated_instr.pc = raw_instr_pc;
-        emulated_instr.instr = instr;
-        drmgr_insert_emulation_start(drcontext, bb, instr, &emulated_instr);
-
-        dr_save_reg(drcontext, bb, instr, DR_REG_X26, SPILL_SLOT_1);
-        dr_save_reg(drcontext, bb, instr, DR_REG_X27, SPILL_SLOT_2);
-
-        opnd_t scratch0 = opnd_create_reg(DR_REG_X26);
-        opnd_t scratch1 = opnd_create_reg(DR_REG_X27);
-
-        /* scratch0 = !src0
-         * XXX i#2440 AArch64 missing INSTR_CREATE macros (INSTR_CREATE_orn)
-         */
-        instr_t *not0 = instr_create_1dst_4src(drcontext, OP_orn, scratch0,
-                                               opnd_create_reg(DR_REG_XZR), src0,
-                                               OPND_CREATE_LSL(), OPND_CREATE_INT(0));
-        instrlist_preinsert(bb, instr, instr_set_translation(not0, raw_instr_pc));
-
-        /* scratch1 = !src1
-         * XXX i#2440 AArch64 missing INSTR_CREATE macros (INSTR_CREATE_orn)
-         */
-        instr_t *not1 = instr_create_1dst_4src(drcontext, OP_orn, scratch1,
-                                               opnd_create_reg(DR_REG_XZR), src1,
-                                               OPND_CREATE_LSL(), OPND_CREATE_INT(0));
-        instrlist_preinsert(bb, instr, instr_set_translation(not1, raw_instr_pc));
-
-        /* scratch0 = scratch0 | scratch1
-         * XXX i#2440 AArch64 missing INSTR_CREATE macros (INSTR_CREATE_orr)
-         */
-        instr_t *or_i =
-            instr_create_1dst_4src(drcontext, OP_orr, scratch0, scratch0, scratch1,
-                                   OPND_CREATE_LSL(), OPND_CREATE_INT(0));
-        instrlist_preinsert(bb, instr, instr_set_translation(or_i, raw_instr_pc));
-
-        /* dst = !scratch0
-         * XXX i#2440 AArch64 missing INSTR_CREATE macros (INSTR_CREATE_orn)
-         */
-        instr_t *not2 =
-            instr_create_1dst_4src(drcontext, OP_orn, dst, opnd_create_reg(DR_REG_XZR),
-                                   scratch0, OPND_CREATE_LSL(), OPND_CREATE_INT(0));
-        instrlist_preinsert(bb, instr, instr_set_translation(not2, raw_instr_pc));
-
-        dr_restore_reg(drcontext, bb, instr, DR_REG_X26, SPILL_SLOT_1);
-        dr_restore_reg(drcontext, bb, instr, DR_REG_X27, SPILL_SLOT_2);
-
-        /* Insert emulation label to signal end of emulation code sequence and
-         * remove the instruction being emulated from the basic block.
-         */
-        drmgr_insert_emulation_end(drcontext, bb, instr);
-        instrlist_remove(bb, instr);
+        if (should_fully_emulate_instr(instr))
+            emulate_fully(drcontext, bb, instr);
+        if (should_partly_emulate_instr(instr))
+            emulate_partly(drcontext, bb, instr);
     }
 
+    return DR_EMIT_DEFAULT;
+}
+
+static dr_emit_flags_t
+event_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
+               bool translating, OUT void **user_data)
+{
+    bool in_emulation = false;
+    for (instr_t *instr = instrlist_first(bb); instr != NULL;
+         instr = instr_get_next(instr)) {
+        if (drmgr_is_emulation_start(instr)) {
+            emulated_instr_t emulated_instr = {
+                0,
+            };
+            emulated_instr.size = sizeof(emulated_instr);
+            CHECK(drmgr_get_emulated_instr_data(instr, &emulated_instr),
+                  "drmgr_get_emulated_instr_data() failed");
+            in_emulation = true;
+            continue;
+        }
+        /* drmgr_in_emulation_region() only works in the insertion phase so we
+         * can't compare here.
+         */
+        if (drmgr_is_emulation_end(instr)) {
+            in_emulation = false;
+        }
+    }
+    return DR_EMIT_DEFAULT;
+}
+
+static void
+record_instr_fetch_orig(instr_t *instr)
+{
+    DR_ASSERT(should_fully_emulate_instr(instr) || should_partly_emulate_instr(instr));
+    DR_ASSERT((ptr_uint_t)instr_get_note(instr) != derived_marker);
+}
+
+static void
+record_instr_fetch_unchanged(instr_t *instr)
+{
+    DR_ASSERT(!should_partly_emulate_instr(instr) && !should_fully_emulate_instr(instr));
+    DR_ASSERT((ptr_uint_t)instr_get_note(instr) != derived_marker);
+}
+
+static void
+record_data_addresses_orig(instr_t *instr)
+{
+    DR_ASSERT(should_fully_emulate_instr(instr));
+    DR_ASSERT(!should_partly_emulate_instr(instr));
+    DR_ASSERT((ptr_uint_t)instr_get_note(instr) != derived_marker);
+}
+
+static void
+record_data_addresses_derived(instr_t *instr)
+{
+    DR_ASSERT(!should_partly_emulate_instr(instr) && !should_fully_emulate_instr(instr));
+    DR_ASSERT((ptr_uint_t)instr_get_note(instr) == derived_marker);
+}
+
+static void
+record_data_addresses_unchanged(instr_t *instr)
+{
+    DR_ASSERT(!should_partly_emulate_instr(instr) && !should_fully_emulate_instr(instr));
+    DR_ASSERT((ptr_uint_t)instr_get_note(instr) != derived_marker);
+}
+
+static dr_emit_flags_t
+event_insertion(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
+                bool for_trace, bool translating, void *user_data)
+{
+    /* Use the recommended emulation instrumentation code pattern: */
+    emulated_instr_t emulation;
+    if (drmgr_in_emulation_region(drcontext, &emulation)) {
+        if (TEST(DR_EMULATE_FIRST_INSTR, emulation.flags)) {
+            record_instr_fetch_orig(emulation.instr);
+            if (!TEST(DR_EMULATE_INSTR_ONLY, emulation.flags))
+                record_data_addresses_orig(emulation.instr);
+        } /* Else skip further instr fetches until outside emulation region. */
+        if (instr_is_app(inst) && TEST(DR_EMULATE_INSTR_ONLY, emulation.flags))
+            record_data_addresses_derived(inst);
+    } else if (instr_is_app(inst)) {
+        record_instr_fetch_unchanged(inst);
+        record_data_addresses_unchanged(inst);
+    }
     return DR_EMIT_DEFAULT;
 }


### PR DESCRIPTION
Adds a convenience routine drmgr_in_emulation_region() and flag
DR_EMULATE_FIRST_INSTR to make it easier to query emulation markers.

Adds a new flag DR_EMULATE_INSTR_ONLY for expansions where the
sequence being executed should be examined for data references
and only instruction observation should look at the original
instruction.  Sets the flag for drutil_expand_rep_string*() and
drx_expand_scatter_gather().

Clarifies that the flags field added in PR #4877 is a source
compatibility break if source code was not zeroing the full struct.

Ports the emulation_api_simple test to x86_64.  Augments the test to
perform a partial DR_EMULATE_INSTR_ONLY emulation as well for both
platforms.  Adds checks for various invariants in the test.

Future work will add emulation awareness to tracing clients.

Issue: #4866, #4865
Fixes #4865