### PR TITLE
i#3823 multi-phase drreg: Delay slot id label

### DIFF
--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -312,7 +312,7 @@ restore_reg(void *drcontext, per_thread_t *pt, reg_id_t reg, uint slot,
         }
         instr_set_note(spill_slot_data_label,
                        (void *)get_drreg_note_val(DRREG_NOTE_SPILL_SLOT_ID));
-        /* This must immediately precede the restore instrs inserted below. */
+        /* This must immediately follow the restore instrs inserted above. */
         PRE(ilist, where, spill_slot_data_label);
     }
 }

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -206,7 +206,7 @@ has_pending_slot_usage_by_prior_pass(per_thread_t *pt, instrlist_t *ilist, instr
         return false;
     for (instr_t *in = where; in != NULL; in = instr_get_next(in)) {
         /* We store data about spill slot usage in the data area of a label instr
-         * immediately preceding the usage.
+         * immediately following the usage.
          */
         if (instr_is_label(in) &&
             instr_get_note(in) == (void *)get_drreg_note_val(DRREG_NOTE_SPILL_SLOT_ID)) {
@@ -254,6 +254,13 @@ spill_reg(void *drcontext, per_thread_t *pt, reg_id_t reg, uint slot, instrlist_
     if (slot == AFLAGS_SLOT)
         pt->aflags.ever_spilled = true;
     pt->slot_use[slot] = reg;
+    if (slot < ops.num_spill_slots) {
+        dr_insert_write_raw_tls(drcontext, ilist, where, tls_seg,
+                                tls_slot_offs + slot * sizeof(reg_t), reg);
+    } else {
+        dr_spill_slot_t DR_slot = (dr_spill_slot_t)(slot - ops.num_spill_slots);
+        dr_save_reg(drcontext, ilist, where, reg, DR_slot);
+    }
     instr_t *spill_slot_data_label = INSTR_CREATE_label(drcontext);
     dr_instr_label_data_t *data = instr_get_label_data_area(spill_slot_data_label);
     ASSERT(data != NULL, "failed to find label's data area");
@@ -264,15 +271,8 @@ spill_reg(void *drcontext, per_thread_t *pt, reg_id_t reg, uint slot, instrlist_
     }
     instr_set_note(spill_slot_data_label,
                    (void *)get_drreg_note_val(DRREG_NOTE_SPILL_SLOT_ID));
-    /* This must immediately precede the spill instrs inserted below. */
+    /* This must immediately follow the spill instrs inserted above. */
     PRE(ilist, where, spill_slot_data_label);
-    if (slot < ops.num_spill_slots) {
-        dr_insert_write_raw_tls(drcontext, ilist, where, tls_seg,
-                                tls_slot_offs + slot * sizeof(reg_t), reg);
-    } else {
-        dr_spill_slot_t DR_slot = (dr_spill_slot_t)(slot - ops.num_spill_slots);
-        dr_save_reg(drcontext, ilist, where, reg, DR_slot);
-    }
 
 #ifdef DEBUG
     if (slot > stats_max_slot)
@@ -293,6 +293,15 @@ restore_reg(void *drcontext, per_thread_t *pt, reg_id_t reg, uint slot,
            "internal tracking error");
     if (release) {
         pt->slot_use[slot] = DR_REG_NULL;
+    }
+    if (slot < ops.num_spill_slots) {
+        dr_insert_read_raw_tls(drcontext, ilist, where, tls_seg,
+                               tls_slot_offs + slot * sizeof(reg_t), reg);
+    } else {
+        dr_spill_slot_t DR_slot = (dr_spill_slot_t)(slot - ops.num_spill_slots);
+        dr_restore_reg(drcontext, ilist, where, reg, DR_slot);
+    }
+    if (release) {
         instr_t *spill_slot_data_label = INSTR_CREATE_label(drcontext);
         dr_instr_label_data_t *data = instr_get_label_data_area(spill_slot_data_label);
         ASSERT(data != NULL, "failed to find label's data area");
@@ -305,13 +314,6 @@ restore_reg(void *drcontext, per_thread_t *pt, reg_id_t reg, uint slot,
                        (void *)get_drreg_note_val(DRREG_NOTE_SPILL_SLOT_ID));
         /* This must immediately precede the restore instrs inserted below. */
         PRE(ilist, where, spill_slot_data_label);
-    }
-    if (slot < ops.num_spill_slots) {
-        dr_insert_read_raw_tls(drcontext, ilist, where, tls_seg,
-                               tls_slot_offs + slot * sizeof(reg_t), reg);
-    } else {
-        dr_spill_slot_t DR_slot = (dr_spill_slot_t)(slot - ops.num_spill_slots);
-        dr_restore_reg(drcontext, ilist, where, reg, DR_slot);
     }
 }
 
@@ -700,12 +702,23 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
                     }
                     spill_reg(drcontext, pt, reg, tmp_slot, bb, inst);
                 }
-                spill_reg(drcontext, pt, reg, pt->reg[GPR_IDX(reg)].slot, bb,
-                          /* If reads and writes, make sure tool-restore and app-spill
-                           * are in the proper order.
-                           */
-                          restored_for_read[GPR_IDX(reg)] ? instr_get_prev(next)
-                                                          : next /*after*/);
+                /* If reads and writes, make sure tool-restore and app-spill
+                 * are in the proper order.
+                 */
+                if (restored_for_read[GPR_IDX(reg)]) {
+                    ASSERT(instr_get_prev(next) != NULL &&
+                               instr_is_label(instr_get_prev(next)) &&
+                               instr_get_note(instr_get_prev(next)) ==
+                                   (void *)get_drreg_note_val(DRREG_NOTE_SPILL_SLOT_ID),
+                           "instr before 'next' should be a label with spill slot id");
+                    ASSERT(instr_get_prev(instr_get_prev(next)) != NULL,
+                           "missing reg restore after app read");
+                    spill_reg(drcontext, pt, reg, pt->reg[GPR_IDX(reg)].slot, bb,
+                              instr_get_prev(instr_get_prev(next)));
+                } else {
+                    spill_reg(drcontext, pt, reg, pt->reg[GPR_IDX(reg)].slot, bb,
+                              next /*after*/);
+                }
                 pt->reg[GPR_IDX(reg)].ever_spilled = true;
                 if (!restored_for_read[GPR_IDX(reg)])
                     restore_reg(drcontext, pt, reg, tmp_slot, bb, next /*after*/, true);

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -702,8 +702,11 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
                     }
                     spill_reg(drcontext, pt, reg, tmp_slot, bb, inst);
                 }
-                /* If reads and writes, make sure tool-restore and app-spill
-                 * are in the proper order.
+                /* If the instr reads and writes both, make sure that the app-spill
+                 * instr is added **before** the tool-restore instrs added by
+                 * drreg_insert_restore_all called earlier in this routine. Note
+                 * that the tool-restore instrs consists of the actual reg restore and
+                 * a following label (which has some data about spill slot usage).
                  */
                 if (restored_for_read[GPR_IDX(reg)]) {
                     ASSERT(instr_get_prev(next) != NULL &&

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -705,7 +705,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
                 /* If the instr reads and writes both, make sure that the app-spill
                  * instr is added **before** the tool-restore instrs added by
                  * drreg_insert_restore_all called earlier in this routine. Note
-                 * that the tool-restore instrs consists of the actual reg restore and
+                 * that the tool-restore instrs consist of the actual reg restore and
                  * a following label (which has some data about spill slot usage).
                  */
                 if (restored_for_read[GPR_IDX(reg)]) {

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -712,7 +712,7 @@ drreg_event_bb_insert_late(void *drcontext, void *tag, instrlist_t *bb, instr_t 
                                    (void *)get_drreg_note_val(DRREG_NOTE_SPILL_SLOT_ID),
                            "instr before 'next' should be a label with spill slot id");
                     ASSERT(instr_get_prev(instr_get_prev(next)) != NULL,
-                           "missing reg restore after app read");
+                           "missing tool value restore after app read");
                     spill_reg(drcontext, pt, reg, pt->reg[GPR_IDX(reg)].slot, bb,
                               instr_get_prev(instr_get_prev(next)));
                 } else {

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4804,6 +4804,7 @@ if (NOT ANDROID AND AARCHXX)
   endif ()
   if (ARM)
     set_tests_properties(
+      code_api|client.drreg-test
       code_api|common.allasm_arm
       code_api|common.allasm_thumb
       code_api|common.broadfun-stress

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4804,7 +4804,6 @@ if (NOT ANDROID AND AARCHXX)
   endif ()
   if (ARM)
     set_tests_properties(
-      code_api|client.drreg-test
       code_api|common.allasm_arm
       code_api|common.allasm_thumb
       code_api|common.broadfun-stress

--- a/suite/tests/client-interface/drreg-test-shared.h
+++ b/suite/tests/client-interface/drreg-test-shared.h
@@ -66,7 +66,7 @@
  * specific tests in the client.
  * We limit to 16 bits to work on ARM.
  */
-#define DRREG_TEST_CONST(num) f1f##num
+#define DRREG_TEST_CONST(num) f1##num
 
 #ifdef X86
 /* Set SF,ZF,AF,PF,CF, and bit 1 is always 1 => 0xd7 */
@@ -127,3 +127,6 @@
 
 #define DRREG_TEST_13_ASM MAKE_HEX_ASM(DRREG_TEST_CONST(13))
 #define DRREG_TEST_13_C MAKE_HEX_C(DRREG_TEST_CONST(13))
+
+#define DRREG_TEST_14_ASM MAKE_HEX_ASM(DRREG_TEST_CONST(14))
+#define DRREG_TEST_14_C MAKE_HEX_C(DRREG_TEST_CONST(14))

--- a/suite/tests/client-interface/drreg-test-shared.h
+++ b/suite/tests/client-interface/drreg-test-shared.h
@@ -68,6 +68,9 @@
  */
 #define DRREG_TEST_CONST(num) f1##num
 
+/* PC we jump to when the test fails. */
+#define TEST_INVALID_PC 0
+
 #ifdef X86
 /* Set SF,ZF,AF,PF,CF, and bit 1 is always 1 => 0xd7 */
 #    define DRREG_TEST_AFLAGS_ASM MAKE_HEX_ASM(d7)

--- a/suite/tests/client-interface/drreg-test-shared.h
+++ b/suite/tests/client-interface/drreg-test-shared.h
@@ -68,9 +68,6 @@
  */
 #define DRREG_TEST_CONST(num) f1##num
 
-/* PC we jump to when the test fails. */
-#define TEST_INVALID_PC 0
-
 #ifdef X86
 /* Set SF,ZF,AF,PF,CF, and bit 1 is always 1 => 0xd7 */
 #    define DRREG_TEST_AFLAGS_ASM MAKE_HEX_ASM(d7)

--- a/suite/tests/client-interface/drreg-test.c
+++ b/suite/tests/client-interface/drreg-test.c
@@ -351,8 +351,10 @@ GLOBAL_LABEL(FUNCNAME:)
      test13_done:
         /* Fail if reg was not restored correctly. */
         cmp      TEST_REG_ASM, DRREG_TEST_13_ASM
-        jne      0
-        jmp      epilog
+        je       epilog
+        /* Cannot jump to an immediate address on Windows. */
+        mov      TEST_REG_ASM, TEST_INVALID_PC
+        jmp      TEST_REG_ASM
 
      epilog:
         add      REG_XSP, FRAME_PADDING /* make a legal SEH64 epilog */
@@ -387,14 +389,15 @@ GLOBAL_LABEL(FUNCNAME:)
         b        test13
         /* Test 13: Multi-phase reg spill slot conflicts. */
      test13:
-        mov      TEST_REG_ASM, DRREG_TEST_13_ASM
-        mov      TEST_REG_ASM, DRREG_TEST_13_ASM
+        movw     TEST_REG_ASM, DRREG_TEST_13_ASM
+        movw     TEST_REG_ASM, DRREG_TEST_13_ASM
         nop
         b        test13_done
      test13_done:
         /* Fail if reg was not restored correctly. */
-        cmp      TEST_REG_ASM, DRREG_TEST_13_ASM
-        bne      0
+        movw     TEST_REG2_ASM, DRREG_TEST_13_ASM
+        cmp      TEST_REG_ASM, TEST_REG2_ASM
+        bne      TEST_INVALID_PC
 
         b        epilog
     epilog:
@@ -436,7 +439,7 @@ GLOBAL_LABEL(FUNCNAME:)
         /* Fail if reg was not restored correctly. */
         movz     TEST_REG2_ASM, DRREG_TEST_13_ASM
         cmp      TEST_REG_ASM, TEST_REG2_ASM
-        bne      0
+        bne      TEST_INVALID_PC
 
         b        epilog
     epilog:

--- a/suite/tests/client-interface/drreg-test.c
+++ b/suite/tests/client-interface/drreg-test.c
@@ -181,16 +181,16 @@ handle_exception5(struct _EXCEPTION_POINTERS *ep)
 int
 main(int argc, const char *argv[])
 {
+    print("drreg-test running\n");
+
+    test_asm();
+
 #    if defined(UNIX)
     intercept_signal(SIGSEGV, (handler_3_t)&handle_signal, false);
     intercept_signal(SIGILL, (handler_3_t)&handle_signal, false);
 #    elif defined(WINDOWS)
     SetUnhandledExceptionFilter(&handle_exception);
 #    endif
-
-    print("drreg-test running\n");
-
-    test_asm();
 
     /* Test fault reg restore */
     if (SIGSETJMP(mark) == 0) {

--- a/suite/tests/client-interface/drreg-test.dll.c
+++ b/suite/tests/client-interface/drreg-test.dll.c
@@ -128,8 +128,8 @@ event_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
             } else if (inst == instrlist_last(bb)) {
                 /* Make sure that TEST_REG isn't dead after its app2app spill.
                  * If it is dead, its next spill will only reserve a slot, but not
-                 * actually write to it. To test the nested restore scenario in
-                 * test13, we need it to actually write.
+                 * actually write to it. To test restore in the multi-phase nested
+                 * spill case (test #13, #14), we need it to actually write.
                  */
                 instrlist_meta_preinsert(bb, inst,
                                          XINST_CREATE_add(drcontext,

--- a/suite/tests/client-interface/drreg-test.dll.c
+++ b/suite/tests/client-interface/drreg-test.dll.c
@@ -49,26 +49,41 @@
 
 #define MAGIC_VAL 0xabcd
 
+static ptr_uint_t note_base;
+#define NOTE_VAL(enum_val) ((void *)(ptr_int_t)(note_base + (enum_val)))
+
+/* Enum describing the different types of notes in drreg-test. */
+enum { DRREG_TEST_LABEL_MARKER, DRREG_TEST_NOTE_COUNT };
+
 uint tls_offs_app2app_spilled_reg;
 
+static bool
+is_drreg_test_label_marker(instr_t *inst)
+{
+    if (instr_is_label(inst) && instr_get_note(inst) == NOTE_VAL(DRREG_TEST_LABEL_MARKER))
+        return true;
+    return false;
+}
+
 static uint
-spill_some_reg_to_slot(void *drcontext, instrlist_t *bb, instr_t *inst)
+spill_test_reg_to_slot(void *drcontext, instrlist_t *bb, instr_t *inst,
+                       drvector_t *allowed)
 {
     uint tls_offs;
-    /* Loop until some register is spilled to a slot. */
-    do {
-        reg_id_t reg;
-        CHECK(drreg_reserve_register(drcontext, bb, inst, NULL, &reg) == DRREG_SUCCESS,
-              "unable to reserve register");
-        CHECK(drreg_reservation_info(drcontext, reg, NULL, NULL, &tls_offs) ==
-                  DRREG_SUCCESS,
-              "unable to get reservation info");
-        CHECK(drreg_unreserve_register(drcontext, bb, instr_get_next_app(inst), reg) ==
-                  DRREG_SUCCESS,
-              "cannot unreserve register");
-    } while (tls_offs == -1);
+    reg_id_t reg;
+    CHECK(drreg_reserve_register(drcontext, bb, inst, allowed, &reg) == DRREG_SUCCESS,
+          "unable to reserve register");
+    ASSERT(reg == TEST_REG);
+    /* Load with some value so that we need to restore it later. */
+    instrlist_meta_preinsert(bb, inst,
+                             XINST_CREATE_load_int(drcontext, opnd_create_reg(reg),
+                                                   OPND_CREATE_INT32(MAGIC_VAL)));
+    CHECK(drreg_reservation_info(drcontext, reg, NULL, NULL, &tls_offs) == DRREG_SUCCESS,
+          "unable to get reservation info");
+    ASSERT(tls_offs != -1);
     return tls_offs;
 }
+
 static dr_emit_flags_t
 event_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
               bool translating, OUT void **user_data)
@@ -76,6 +91,10 @@ event_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     instr_t *inst;
     bool prev_was_mov_const = false;
     ptr_int_t val1, val2;
+    drvector_t allowed;
+    drreg_init_and_fill_vector(&allowed, false);
+    drreg_set_vector_entry(&allowed, TEST_REG, true);
+
     *user_data = NULL;
     /* Look for duplicate mov immediates telling us which subtest we're in */
     for (inst = instrlist_first_app(bb); inst != NULL; inst = instr_get_next_app(inst)) {
@@ -85,28 +104,44 @@ event_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                 opnd_is_reg(instr_get_dst(inst, 0)) &&
                 opnd_get_reg(instr_get_dst(inst, 0)) == TEST_REG) {
                 *user_data = (void *)val1;
-                instrlist_meta_postinsert(bb, inst, INSTR_CREATE_label(drcontext));
+                instr_t *label = INSTR_CREATE_label(drcontext);
+                instr_set_note(label, NOTE_VAL(DRREG_TEST_LABEL_MARKER));
+                instrlist_meta_postinsert(bb, inst, label);
             } else
                 prev_was_mov_const = true;
         } else
             prev_was_mov_const = false;
     }
-    if (*((ptr_int_t *)user_data) == DRREG_TEST_13_C) {
+    if (*((ptr_int_t *)user_data) == DRREG_TEST_13_C ||
+        *((ptr_int_t *)user_data) == DRREG_TEST_14_C) {
         CHECK(drreg_set_bb_properties(
                   drcontext, DRREG_HANDLE_MULTI_PHASE_SLOT_RESERVATIONS) == DRREG_SUCCESS,
               "unable to set bb properties");
         /* Reset for this bb. */
         tls_offs_app2app_spilled_reg = -1;
-        dr_log(drcontext, DR_LOG_ALL, 1, "drreg test #13: app2app phase\n");
+        dr_log(drcontext, DR_LOG_ALL, 1, "drreg test #13/#14: app2app phase\n");
         for (inst = instrlist_first_app(bb); inst != NULL;
              inst = instr_get_next_app(inst)) {
             if (instr_is_nop(inst)) {
                 tls_offs_app2app_spilled_reg =
-                    spill_some_reg_to_slot(drcontext, bb, inst);
-                break;
+                    spill_test_reg_to_slot(drcontext, bb, inst, &allowed);
+            } else if (inst == instrlist_last(bb)) {
+                /* Make sure that TEST_REG isn't dead after its app2app spill.
+                 * If it is dead, its next spill will only reserve a slot, but not
+                 * actually write to it. To test the nested restore scenario in
+                 * test13, we need it to actually write.
+                 */
+                instrlist_meta_preinsert(bb, inst,
+                                         XINST_CREATE_add(drcontext,
+                                                          opnd_create_reg(TEST_REG),
+                                                          OPND_CREATE_INT32(1)));
+                CHECK(drreg_unreserve_register(drcontext, bb, inst, TEST_REG) ==
+                          DRREG_SUCCESS,
+                      "cannot unreserve register");
             }
         }
     }
+    drvector_delete(&allowed);
     return DR_EMIT_DEFAULT;
 }
 
@@ -281,7 +316,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
                subtest == DRREG_TEST_3_C) {
         /* Cross-app-instr tests */
         dr_log(drcontext, DR_LOG_ALL, 1, "drreg test #1/2/3\n");
-        if (instr_is_label(inst)) {
+        if (is_drreg_test_label_marker(inst)) {
             res = drreg_reserve_register(drcontext, bb, inst, &allowed, &reg);
             CHECK(res == DRREG_SUCCESS, "reserve of test reg should work");
             instrlist_meta_preinsert(bb, inst,
@@ -297,7 +332,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     } else if (subtest == DRREG_TEST_4_C || subtest == DRREG_TEST_5_C) {
         /* Cross-app-instr aflags test */
         dr_log(drcontext, DR_LOG_ALL, 1, "drreg test #4/5\n");
-        if (instr_is_label(inst)) {
+        if (is_drreg_test_label_marker(inst)) {
             res = drreg_reserve_aflags(drcontext, bb, inst);
             CHECK(res == DRREG_SUCCESS, "reserve of aflags should work");
         } else if (instr_is_nop(inst) IF_ARM(
@@ -319,7 +354,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
          * the xl8 point in this test.
          */
         dr_log(drcontext, DR_LOG_ALL, 1, "drreg test #6\n");
-        if (instr_is_label(inst)) {
+        if (is_drreg_test_label_marker(inst)) {
             dr_save_reg(drcontext, bb, inst, TEST_REG, 2);
         } else if (drmgr_is_last_instr(drcontext, inst)) {
             dr_restore_reg(drcontext, bb, inst, TEST_REG, 2);
@@ -350,14 +385,18 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         res = drreg_unreserve_aflags(drcontext, bb, inst);
         CHECK(res == DRREG_SUCCESS, "unreserve of aflags");
 #endif
-    } else if (subtest == DRREG_TEST_13_C) {
-        dr_log(drcontext, DR_LOG_ALL, 1, "drreg test #13: insertion phase\n");
+    } else if (subtest == DRREG_TEST_13_C || subtest == DRREG_TEST_14_C) {
+        dr_log(drcontext, DR_LOG_ALL, 1, "drreg test #13/14: insertion phase\n");
         if (instr_is_nop(inst)) {
             CHECK(tls_offs_app2app_spilled_reg != -1,
                   "unable to use any spill slot in app2app phase.");
-            uint tls_offs = spill_some_reg_to_slot(drcontext, bb, inst);
+            uint tls_offs = spill_test_reg_to_slot(drcontext, bb, inst, &allowed);
             CHECK(tls_offs_app2app_spilled_reg != tls_offs,
                   "found conflict in use of spill slots across multiple phases");
+        } else if (drmgr_is_last_instr(drcontext, inst)) {
+            CHECK(drreg_unreserve_register(drcontext, bb, inst, TEST_REG) ==
+                      DRREG_SUCCESS,
+                  "cannot unreserve register");
         }
     }
 
@@ -460,6 +499,9 @@ dr_init(client_id_t id)
     drreg_options_t ops = { sizeof(ops), 2 /*max slots needed*/, false };
     if (!drmgr_init() || drreg_init(&ops) != DRREG_SUCCESS)
         CHECK(false, "init failed");
+
+    note_base = drmgr_reserve_note_range(DRREG_TEST_NOTE_COUNT);
+    ASSERT(note_base != DRMGR_NOTE_NONE);
 
     /* register events */
     dr_register_exit_event(event_exit);


### PR DESCRIPTION
Moves label that contains slot id for register spill/restore instrs to after the instr instead of
before. The free spill slot selection logic that makes use of these labels scans instrs *after*
the given one, so we may miss the label if it is placed before.

Fixes order of app val spill and tool val restore instrs after an instr that reads and writes a
spilled reg. This was to take into account the label which is now after the tool restore instr.

Adds test to verify restoration of reg that was reserved in multiple phases on a fault, for
X86 and AARCHXX.

Also adds AARCHXX variant of the multi-phase slot conflict test, and extends it to also
check proper restoration of app val (under normal operation, as opposed to under a
fault which is done by the above test). The existing test only verified whether the slot
used in different phases was different.

Adds a note to the label instrs added by drreg-test to mark instrumentation locations. This
is to avoid conflicts with other label instrs.

Issue: #3823, #2985