### PR TITLE
i#2417 Suppress regressions caused by CI migration

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -313,6 +313,11 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'code_api|linux.fib-conflict' => 1,
                                    'code_api|linux.fib-conflict-early' => 1,
                                    'code_api|linux.mangle_asynch' => 1,
+                                   'code_api|tool.drcachesim.phys' => 1, # i#4922
+                                   'code_api|tool.drcacheoff.rseq' => 1, # i#4924
+                                   'code_api|api.rseq' => 1, # i#4923
+                                   'code_api|tool.drcachesim.TLB-threads' => 1, # i#4928
+                                   'code_api|tool.drcachesim.threads' => 1, # i#4928
                                    'code_api,tracedump_text,tracedump_origins,syntax_intel|common.loglevel' => 1, # i#1807
                                    );
             if ($is_32) {

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3542,7 +3542,7 @@ if (BUILD_CLIENTS)
     endif ()
 
     if (LINUX AND X64 AND HAVE_RSEQ)
-      torunonly_drcacheoff(rseq linux.rseq "" "@-test_mode" "")
+      torunonly_drcacheoff(rseq linux.rseq "" "${test_mode_flag}" "")
     endif ()
 
     if (AARCH64)


### PR DESCRIPTION
The following tests fail on the new Jenkins CI host, an Ampere Altra:
code_api|tool.drcachesim.phys            i4922
code_api|tool.drcacheoff.rseq            i4924
code_api|api.rseq                        i4923
code_api|tool.drcachesim.threads         i4928
code_api|tool.drcachesim.TLB-threads     i4928

This patch adds them to the 'ignore' list for now.
Issues have been raised to track fixes:

Issue: #2417