### PR TITLE
i#2350 rseq: Clarify docs on rseq limitations

### DIFF
--- a/api/docs/bt.dox
+++ b/api/docs/bt.dox
@@ -1340,8 +1340,10 @@ This run-twice approach is subject to the following limitations:
   region whose values are then read afterward, must be general-purpose registers.
 - The instrumented execution of the rseq region may not perfectly reflect
   the native behavior of the application.  The instrumentation will never see
-  the abort handler called, and memory addresses may be wrong if they are based on
-  the underlying cpuid and a migration occurred mid-region.  These are minor and
+  an abort anywhere but just prior to the committing store.
+  Additionally, memory addresses may be wrong if they are based on
+  the live (as opposed to cached at the rseq region entrance) underlying cpuid
+  and a migration occurred mid-region.  These are minor and
   acceptable for most tools (especially given that there is no better alternative).
 
 Some of these limitations are explicitly checked, and DR will exit with an error

--- a/api/docs/rseq.dox
+++ b/api/docs/rseq.dox
@@ -268,7 +268,7 @@ We do not yet perfectly handle a midpoint exit during the instrumentation execut
 
 We do not yet handle indirect branch exits out of a sequence.
 
-We are currently ignoring the flags which indicate which triggers (out of preempt, signal, and migrate) should cause the abort handler to be called.  We blindly run a second time even the preempt and migrate bits are not set, which the application may not expect without a signal arriving or may expect to only happen in a fatal error condition.
+We are currently ignoring the flags which indicate which triggers (out of preempt, signal, and migrate) should cause the abort handler to be called.  We blindly run a second time even if the preempt and migrate bits are not set, which the application may not expect without a signal arriving or may expect to only happen in a fatal error condition.
 
 # Limitations
 


### PR DESCRIPTION
Clarifies when instrumentation will see an rseq abort.
Fixes a typo.

Issue: #2350