### PR TITLE
i#4865 emul: Refactor drmgr callback list management

### DIFF
--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -101,6 +101,7 @@ typedef struct _cb_entry_t {
     priority_event_entry_t pri;
     void *registration_user_data; /* user data passed at registration time */
     bool has_quartet;
+    bool has_pair;
     bool is_opcode_insertion;
     union {
         drmgr_xform_cb_t xform_cb;
@@ -884,6 +885,7 @@ drmgr_bb_event_do_insertion_per_instr(void *drcontext, void *tag, instrlist_t *b
                                                  translating, quartet_data[quartet_idx]);
             quartet_idx++;
         } else {
+            ASSERT(e->has_pair, "internal pair-vs-quartet state is wrong");
             if (e->cb.pair.insertion_cb != NULL) {
                 res |= (*e->cb.pair.insertion_cb)(drcontext, tag, bb, inst, for_trace,
                                                   translating, pair_data[pair_idx]);
@@ -940,6 +942,7 @@ drmgr_bb_event_do_instrum_phases(void *drcontext, void *tag, instrlist_t *bb,
                 drcontext, tag, bb, for_trace, translating, quartet_data[quartet_idx]);
             quartet_idx++;
         } else {
+            ASSERT(e->has_pair, "internal pair-vs-quartet state is wrong");
             if (e->cb.pair.analysis_cb == NULL) {
                 pair_data[pair_idx] = NULL;
             } else {
@@ -1298,36 +1301,13 @@ priority_event_add(cb_list_t *list, drmgr_priority_t *new_pri)
 }
 
 static bool
-drmgr_bb_cb_add(cb_list_t *list, drmgr_xform_cb_t xform_func,
-                drmgr_analysis_cb_t analysis_func, drmgr_insertion_cb_t insertion_func,
-                /* for quartet (also uses insertion_func) */
-                drmgr_app2app_ex_cb_t app2app_ex_func,
-                drmgr_ilist_ex_cb_t analysis_ex_func,
-                drmgr_ilist_ex_cb_t instru2instru_ex_func,
-                drmgr_opcode_insertion_cb_t opcode_instrum_fuc,
-                drmgr_priority_t *priority, void *user_data /*passed at registration */)
+drmgr_bb_cb_add(cb_list_t *list, void *func1, void *func2, drmgr_priority_t *priority,
+                void *user_data, /*passed at registration */
+                void (*set_cb_fields)(cb_entry_t *e, void *f1, void *f2))
 {
     int idx;
     bool res = false;
-    ASSERT(list != NULL, "invalid internal params");
-    ASSERT(((xform_func != NULL && analysis_func == NULL && insertion_func == NULL &&
-             app2app_ex_func == NULL && analysis_ex_func == NULL &&
-             instru2instru_ex_func == NULL && opcode_instrum_fuc == NULL) ||
-            (xform_func == NULL && (analysis_func != NULL || insertion_func != NULL) &&
-             app2app_ex_func == NULL && analysis_ex_func == NULL &&
-             instru2instru_ex_func == NULL && opcode_instrum_fuc == NULL) ||
-            (xform_func == NULL && analysis_func == NULL && insertion_func == NULL &&
-             app2app_ex_func != NULL && analysis_ex_func == NULL &&
-             instru2instru_ex_func == NULL && opcode_instrum_fuc == NULL) ||
-            (xform_func == NULL && analysis_func == NULL && insertion_func != NULL &&
-             app2app_ex_func == NULL && analysis_ex_func != NULL &&
-             instru2instru_ex_func == NULL && opcode_instrum_fuc == NULL) ||
-            (xform_func == NULL && analysis_func == NULL && insertion_func == NULL &&
-             app2app_ex_func == NULL && analysis_ex_func == NULL &&
-             instru2instru_ex_func != NULL && opcode_instrum_fuc == NULL) ||
-            (xform_func == NULL && analysis_func == NULL && insertion_func == NULL &&
-             app2app_ex_func == NULL && analysis_ex_func == NULL &&
-             instru2instru_ex_func == NULL && opcode_instrum_fuc != NULL)),
+    ASSERT(list != NULL && (func1 != NULL || func2 != NULL) && set_cb_fields != NULL,
            "invalid internal params");
 
     dr_rwlock_write_lock(bb_cb_lock);
@@ -1335,46 +1315,28 @@ drmgr_bb_cb_add(cb_list_t *list, drmgr_xform_cb_t xform_func,
     if (idx >= 0) {
         cb_entry_t *new_e = &list->cbs.bb[idx];
         new_e->registration_user_data = user_data;
-        if (app2app_ex_func != NULL) {
-            new_e->has_quartet = true;
-            new_e->is_opcode_insertion = false;
-            new_e->cb.app2app_ex_cb = app2app_ex_func;
-        } else if (analysis_ex_func != NULL) {
-            new_e->has_quartet = true;
-            new_e->is_opcode_insertion = false;
-            new_e->cb.pair_ex.analysis_ex_cb = analysis_ex_func;
-            new_e->cb.pair_ex.insertion_ex_cb = insertion_func;
-        } else if (instru2instru_ex_func != NULL) {
-            new_e->has_quartet = true;
-            new_e->is_opcode_insertion = false;
-            new_e->cb.instru2instru_ex_cb = instru2instru_ex_func;
-        } else if (opcode_instrum_fuc != NULL) {
-            new_e->has_quartet = false;
-            new_e->is_opcode_insertion = true;
-            new_e->cb.opcode_insertion_cb = opcode_instrum_fuc;
-            /* set the flag b/c we encountered the registration of an opcode event */
-            was_opcode_instrum_registered = true;
-        } else {
-            new_e->has_quartet = false;
-            new_e->is_opcode_insertion = false;
-            if (xform_func != NULL) {
-                new_e->cb.xform_cb = xform_func;
-            } else {
-                new_e->cb.pair.analysis_cb = analysis_func;
-                new_e->cb.pair.insertion_cb = insertion_func;
-            }
-        }
+        new_e->has_quartet = false;
+        new_e->has_pair = false;
+        new_e->is_opcode_insertion = false;
+        set_cb_fields(new_e, func1, func2);
         if (bb_event_count == 0)
             dr_register_bb_event(drmgr_bb_event);
         bb_event_count++;
         if (new_e->has_quartet)
             quartet_count++;
-        else if (xform_func == NULL)
+        else if (new_e->has_pair)
             pair_count++;
         res = true;
     }
     dr_rwlock_write_unlock(bb_cb_lock);
     return res;
+}
+
+static void
+cb_entry_set_fields_xform(cb_entry_t *new_e, void *func1, void *func2)
+{
+    ASSERT(func2 == NULL, "invalid internal params");
+    new_e->cb.xform_cb = (drmgr_xform_cb_t)func1;
 }
 
 DR_EXPORT
@@ -1383,8 +1345,16 @@ drmgr_register_bb_app2app_event(drmgr_xform_cb_t func, drmgr_priority_t *priorit
 {
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_add(&cblist_app2app, func, NULL, NULL, NULL, NULL, NULL, NULL,
-                           priority, NULL /* no user data */);
+    return drmgr_bb_cb_add(&cblist_app2app, func, NULL, priority, NULL /* no user data */,
+                           cb_entry_set_fields_xform);
+}
+
+static void
+cb_entry_set_fields_instrumentation(cb_entry_t *new_e, void *func1, void *func2)
+{
+    new_e->has_pair = true;
+    new_e->cb.pair.analysis_cb = (drmgr_analysis_cb_t)func1;
+    new_e->cb.pair.insertion_cb = (drmgr_insertion_cb_t)func2;
 }
 
 DR_EXPORT
@@ -1395,8 +1365,9 @@ drmgr_register_bb_instrumentation_event(drmgr_analysis_cb_t analysis_func,
 {
     if (analysis_func == NULL && insertion_func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_add(&cblist_instrumentation, NULL, analysis_func, insertion_func,
-                           NULL, NULL, NULL, NULL, priority, NULL /* no user data */);
+    return drmgr_bb_cb_add(&cblist_instrumentation, analysis_func, insertion_func,
+                           priority, NULL /* no user data */,
+                           cb_entry_set_fields_instrumentation);
 }
 
 DR_EXPORT
@@ -1405,8 +1376,32 @@ drmgr_register_bb_instru2instru_event(drmgr_xform_cb_t func, drmgr_priority_t *p
 {
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_add(&cblist_instru2instru, func, NULL, NULL, NULL, NULL, NULL,
-                           NULL, priority, NULL /* no user data */);
+    return drmgr_bb_cb_add(&cblist_instru2instru, func, NULL, priority,
+                           NULL /* no user data */, cb_entry_set_fields_xform);
+}
+
+static void
+cb_entry_set_fields_app2app_ex(cb_entry_t *new_e, void *func1, void *func2)
+{
+    ASSERT(func2 == NULL, "invalid internal params");
+    new_e->has_quartet = true;
+    new_e->cb.app2app_ex_cb = (drmgr_app2app_ex_cb_t)func1;
+}
+
+static void
+cb_entry_set_fields_insertion_ex(cb_entry_t *new_e, void *func1, void *func2)
+{
+    new_e->has_quartet = true;
+    new_e->cb.pair_ex.analysis_ex_cb = (drmgr_ilist_ex_cb_t)func1;
+    new_e->cb.pair_ex.insertion_ex_cb = (drmgr_insertion_cb_t)func2;
+}
+
+static void
+cb_entry_set_fields_instru2instru_ex(cb_entry_t *new_e, void *func1, void *func2)
+{
+    ASSERT(func2 == NULL, "invalid internal params");
+    new_e->has_quartet = true;
+    new_e->cb.instru2instru_ex_cb = (drmgr_ilist_ex_cb_t)func1;
 }
 
 DR_EXPORT
@@ -1424,68 +1419,40 @@ drmgr_register_bb_instrumentation_ex_event(drmgr_app2app_ex_cb_t app2app_func,
         (analysis_func == NULL && insertion_func != NULL))
         return false; /* invalid params */
     if (app2app_func != NULL) {
-        ok = drmgr_bb_cb_add(&cblist_app2app, NULL, NULL, NULL, app2app_func, NULL, NULL,
-                             NULL, priority, NULL /* no user data */) &&
+        ok = drmgr_bb_cb_add(&cblist_app2app, app2app_func, NULL, priority,
+                             NULL /* no user data */, cb_entry_set_fields_app2app_ex) &&
             ok;
     }
     if (analysis_func != NULL) {
-        ok = drmgr_bb_cb_add(&cblist_instrumentation, NULL, NULL, insertion_func, NULL,
-                             analysis_func, NULL, NULL, priority,
-                             NULL /* no user data */) &&
+        ok = drmgr_bb_cb_add(&cblist_instrumentation, analysis_func, insertion_func,
+                             priority, NULL /* no user data */,
+                             cb_entry_set_fields_insertion_ex) &&
             ok;
     }
     if (instru2instru_func != NULL) {
-        ok = drmgr_bb_cb_add(&cblist_instru2instru, NULL, NULL, NULL, NULL, NULL,
-                             instru2instru_func, NULL, priority,
-                             NULL /* no user data */) &&
+        ok = drmgr_bb_cb_add(&cblist_instru2instru, instru2instru_func, NULL, priority,
+                             NULL /* no user data */,
+                             cb_entry_set_fields_instru2instru_ex) &&
             ok;
     }
     return ok;
 }
 
 static bool
-drmgr_bb_cb_remove(cb_list_t *list, drmgr_xform_cb_t xform_func,
-                   drmgr_analysis_cb_t analysis_func, drmgr_insertion_cb_t insertion_func,
-                   /* for quartet */
-                   drmgr_app2app_ex_cb_t app2app_ex_func,
-                   drmgr_ilist_ex_cb_t analysis_ex_func,
-                   drmgr_ilist_ex_cb_t instru2instru_ex_func,
-                   /* for opcode instrumentation */
-                   drmgr_opcode_insertion_cb_t opcode_insertion_func)
+drmgr_bb_cb_remove(cb_list_t *list, void *func,
+                   bool (*matches_func)(cb_entry_t *e, void *f))
 {
     bool res = false;
     uint i;
-    ASSERT(list != NULL, "invalid internal params");
-    ASSERT(
-        (xform_func != NULL && analysis_func == NULL && opcode_insertion_func == NULL) ||
-            (xform_func == NULL && analysis_func != NULL &&
-             opcode_insertion_func == NULL) ||
-            (xform_func == NULL && analysis_func == NULL && insertion_func != NULL &&
-             opcode_insertion_func == NULL) ||
-            (xform_func == NULL && analysis_func == NULL &&
-             opcode_insertion_func == NULL &&
-             (app2app_ex_func != NULL || analysis_ex_func != NULL ||
-              instru2instru_ex_func != NULL)) ||
-            (xform_func == NULL && analysis_func == NULL && app2app_ex_func == NULL &&
-             analysis_ex_func == NULL && instru2instru_ex_func == NULL &&
-             opcode_insertion_func != NULL),
-        "invalid internal params");
+    ASSERT(list != NULL && func != NULL && matches_func != NULL,
+           "invalid internal params");
 
     dr_rwlock_write_lock(bb_cb_lock);
     for (i = 0; i < list->num_def; i++) {
         cb_entry_t *e = &list->cbs.bb[i];
         if (!e->pri.valid)
             continue;
-        if ((xform_func != NULL && xform_func == e->cb.xform_cb) ||
-            (analysis_func != NULL && analysis_func == e->cb.pair.analysis_cb) ||
-            (insertion_func != NULL && insertion_func == e->cb.pair.insertion_cb) ||
-            (app2app_ex_func != NULL && app2app_ex_func == e->cb.app2app_ex_cb) ||
-            (analysis_ex_func != NULL &&
-             analysis_ex_func == e->cb.pair_ex.analysis_ex_cb) ||
-            (instru2instru_ex_func != NULL &&
-             instru2instru_ex_func == e->cb.instru2instru_ex_cb) ||
-            (opcode_insertion_func != NULL &&
-             opcode_insertion_func == e->cb.opcode_insertion_cb)) {
+        if (matches_func(e, func)) {
             res = true;
             e->pri.valid = false;
             ASSERT(list->num_valid > 0, "invalid num_valid");
@@ -1496,7 +1463,7 @@ drmgr_bb_cb_remove(cb_list_t *list, drmgr_xform_cb_t xform_func,
                 list->num_def--;
             if (e->has_quartet)
                 quartet_count--;
-            else if (xform_func == NULL)
+            else if (e->has_pair)
                 pair_count--;
             bb_event_count--;
             if (bb_event_count == 0)
@@ -1528,13 +1495,25 @@ drmgr_bb_exit(void)
     cblist_delete(&cblist_instru2instru);
 }
 
+static bool
+cb_entry_matches_xform(cb_entry_t *e, void *func)
+{
+    return e->cb.xform_cb == func;
+}
+
 DR_EXPORT
 bool
 drmgr_unregister_bb_app2app_event(drmgr_xform_cb_t func)
 {
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_remove(&cblist_app2app, func, NULL, NULL, NULL, NULL, NULL, NULL);
+    return drmgr_bb_cb_remove(&cblist_app2app, func, cb_entry_matches_xform);
+}
+
+static bool
+cb_entry_matches_analysis(cb_entry_t *e, void *func)
+{
+    return e->cb.pair.analysis_cb == func;
 }
 
 DR_EXPORT
@@ -1543,8 +1522,13 @@ drmgr_unregister_bb_instrumentation_event(drmgr_analysis_cb_t func)
 {
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_remove(&cblist_instrumentation, NULL, func, NULL, NULL, NULL, NULL,
-                              NULL);
+    return drmgr_bb_cb_remove(&cblist_instrumentation, func, cb_entry_matches_analysis);
+}
+
+static bool
+cb_entry_matches_insertion(cb_entry_t *e, void *func)
+{
+    return e->cb.pair.insertion_cb == func;
 }
 
 DR_EXPORT
@@ -1553,8 +1537,7 @@ drmgr_unregister_bb_insertion_event(drmgr_insertion_cb_t func)
 {
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_remove(&cblist_instrumentation, NULL, NULL, func, NULL, NULL, NULL,
-                              NULL);
+    return drmgr_bb_cb_remove(&cblist_instrumentation, func, cb_entry_matches_insertion);
 }
 
 DR_EXPORT
@@ -1563,8 +1546,25 @@ drmgr_unregister_bb_instru2instru_event(drmgr_xform_cb_t func)
 {
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_remove(&cblist_instru2instru, func, NULL, NULL, NULL, NULL, NULL,
-                              NULL);
+    return drmgr_bb_cb_remove(&cblist_instru2instru, func, cb_entry_matches_xform);
+}
+
+static bool
+cb_entry_matches_app2app_ex(cb_entry_t *e, void *func)
+{
+    return e->cb.app2app_ex_cb == func;
+}
+
+static bool
+cb_entry_matches_analysis_ex(cb_entry_t *e, void *func)
+{
+    return e->cb.pair_ex.analysis_ex_cb == func;
+}
+
+static bool
+cb_entry_matches_instru2instru_ex(cb_entry_t *e, void *func)
+{
+    return e->cb.instru2instru_ex_cb == func;
 }
 
 DR_EXPORT
@@ -1581,25 +1581,35 @@ drmgr_unregister_bb_instrumentation_ex_event(drmgr_app2app_ex_cb_t app2app_func,
         (analysis_func == NULL && insertion_func != NULL))
         return false; /* invalid params */
     if (app2app_func != NULL) {
-        ok = drmgr_bb_cb_remove(&cblist_app2app, NULL, NULL, NULL, app2app_func, NULL,
-                                NULL, NULL) &&
+        ok = drmgr_bb_cb_remove(&cblist_app2app, app2app_func,
+                                cb_entry_matches_app2app_ex) &&
             ok;
     }
     if (analysis_func != NULL) {
         /* Although analysis_func and insertion_func are registered together in
          * drmgr_register_bb_instrumentation_ex_event, drmgr_bb_cb_remove only
-         * checks analysis_func, so we pass NULL instead of insertion_func here.
+         * checks one, so we only look for analysis_func.
          */
-        ok = drmgr_bb_cb_remove(&cblist_instrumentation, NULL, NULL, NULL, NULL,
-                                analysis_func, NULL, NULL) &&
+        ok = drmgr_bb_cb_remove(&cblist_instrumentation, analysis_func,
+                                cb_entry_matches_analysis_ex) &&
             ok;
     }
     if (instru2instru_func != NULL) {
-        ok = drmgr_bb_cb_remove(&cblist_instru2instru, NULL, NULL, NULL, NULL, NULL,
-                                instru2instru_func, NULL) &&
+        ok = drmgr_bb_cb_remove(&cblist_instru2instru, instru2instru_func,
+                                cb_entry_matches_instru2instru_ex) &&
             ok;
     }
     return ok;
+}
+
+static void
+cb_entry_set_fields_opcode(cb_entry_t *new_e, void *func1, void *func2)
+{
+    ASSERT(func2 == NULL, "invalid internal params");
+    new_e->is_opcode_insertion = true;
+    new_e->cb.opcode_insertion_cb = (drmgr_opcode_insertion_cb_t)func1;
+    /* set the flag b/c we encountered the registration of an opcode event */
+    was_opcode_instrum_registered = true;
 }
 
 DR_EXPORT
@@ -1622,8 +1632,14 @@ drmgr_register_opcode_instrumentation_event(drmgr_opcode_insertion_cb_t func, in
     }
     dr_rwlock_write_unlock(opcode_table_lock);
 
-    return drmgr_bb_cb_add(opcode_cb_list, NULL, NULL, NULL, NULL, NULL, NULL, func,
-                           priority, user_data);
+    return drmgr_bb_cb_add(opcode_cb_list, func, NULL, priority, user_data,
+                           cb_entry_set_fields_opcode);
+}
+
+static bool
+cb_entry_matches_opcode(cb_entry_t *e, void *func)
+{
+    return e->cb.opcode_insertion_cb == func;
 }
 
 DR_EXPORT
@@ -1641,7 +1657,7 @@ drmgr_unregister_opcode_instrumentation_event(drmgr_opcode_insertion_cb_t func,
         return false; /* there should be a cb list present in the table */
     dr_rwlock_write_unlock(opcode_table_lock);
 
-    return drmgr_bb_cb_remove(opcode_cb_list, NULL, NULL, NULL, NULL, NULL, NULL, func);
+    return drmgr_bb_cb_remove(opcode_cb_list, func, cb_entry_matches_opcode);
 }
 
 DR_EXPORT
@@ -2725,7 +2741,8 @@ drmgr_cls_stack_push(void)
 static bool
 drmgr_cls_stack_pop(void)
 {
-    /* Our callback enter is AFTER DR's, but our callback exit is BEFORE. */
+    /* Our callback enter is AFTER DR's, but our callback exit is
+     * BEFORE. */
     generic_event_entry_t local[EVENTS_STACK_SZ];
     cb_list_t iter;
     uint i;
@@ -2803,9 +2820,10 @@ drmgr_cls_stack_exit(void *drcontext)
  * Returns -1 on error.
  * FIXME: does not handle somebody hooking the wrapper.
  */
-/* XXX: exporting this so drwrap can use it but I might prefer to have
- * this in drutil or the upcoming drsys, especially since drmgr no longer
- * uses this now that DR provides a kernel xfer event.
+/* XXX: exporting this so drwrap can use it but I might prefer to
+ * have this in drutil or the upcoming drsys, especially since
+ * drmgr no longer uses this now that DR provides a kernel xfer
+ * event.
  */
 DR_EXPORT
 int
@@ -2843,9 +2861,10 @@ drmgr_decode_sysnum_from_wrapper(app_pc entry)
 static void
 drmgr_kernel_xfer_event(void *drcontext, const dr_kernel_xfer_info_t *info)
 {
-    /* We used to watch KiUserCallbackDispatcher, identify NtCallbackReturn's number,
-     * and watch int 0x2b ourselves, but now DR provides us with an event that
-     * operates at the last moment before the kernel action, making our lives much
+    /* We used to watch KiUserCallbackDispatcher, identify
+     * NtCallbackReturn's number, and watch int 0x2b ourselves, but
+     * now DR provides us with an event that operates at the last
+     * moment before the kernel action, making our lives much
      * easier: we just have to order all other xfer events vs ours.
      */
     generic_event_entry_t local[EVENTS_STACK_SZ];
@@ -2857,7 +2876,8 @@ drmgr_kernel_xfer_event(void *drcontext, const dr_kernel_xfer_info_t *info)
     dr_rwlock_read_unlock(kernel_xfer_event_lock);
 
     if (info->type == DR_XFER_CALLBACK_DISPATCHER) {
-        /* We want to go first for callback entry so clients have a new context. */
+        /* We want to go first for callback entry so clients have a
+         * new context. */
         drmgr_cls_stack_push();
     }
 
@@ -2868,8 +2888,9 @@ drmgr_kernel_xfer_event(void *drcontext, const dr_kernel_xfer_info_t *info)
     }
 
     if (info->type == DR_XFER_CALLBACK_RETURN) {
-        /* We want to go last for cbret to swap contexts at the last possible moment,
-         * to ensure there are no references to cls data before we swap it.
+        /* We want to go last for cbret to swap contexts at the
+         * last possible moment, to ensure there are no references
+         * to cls data before we swap it.
          */
         drmgr_cls_stack_pop();
     }
@@ -3107,7 +3128,8 @@ enum {
 
 static ptr_uint_t note_next = DRMGR_NOTE_FIRST_FREE;
 
-/* un-reserving is not supported (would require interval tree to impl) */
+/* un-reserving is not supported (would require interval tree to
+ * impl) */
 DR_EXPORT
 ptr_uint_t
 drmgr_reserve_note_range(size_t size)
@@ -3141,11 +3163,12 @@ drmgr_disable_auto_predication(void *drcontext, instrlist_t *ilist)
 
 /*
  * Constants used when accessing emulated instruction data with the
- * drmgr_get_emulated_instr_data() function. Each constant refers to an element
- * of the emulated_instr_t struct.
+ * drmgr_get_emulated_instr_data() function. Each constant refers
+ * to an element of the emulated_instr_t struct.
  */
 typedef enum {
-    DRMGR_EMUL_INSTR_PC, /* The PC address of the emulated instruction. */
+    DRMGR_EMUL_INSTR_PC, /* The PC address of the emulated
+                            instruction. */
     DRMGR_EMUL_INSTR,    /* The emulated instruction. */
     DRMGR_EMUL_FLAGS,    /* Flags controlling emulation. */
 } emulated_instr_data_t;
@@ -3155,7 +3178,8 @@ static void
 drmgr_emulation_init(void)
 {
     ASSERT(sizeof(emulated_instr_t) <= sizeof(dr_instr_label_data_t),
-           "label data area is not large enough to store emulation data");
+           "label data area is not large enough to store "
+           "emulation data");
 
     note_base_emul = drmgr_reserve_note_range(DRMGR_NOTE_EMUL_COUNT);
     ASSERT(note_base_emul != DRMGR_NOTE_NONE, "failed to reserve emulation note space");
@@ -3192,8 +3216,8 @@ get_emul_label_data(instr_t *label, int type)
     return label_data->data[type];
 }
 
-/* A callback function to free the emulated instruction represented by the label.
- * This will be called when the label is freed.
+/* A callback function to free the emulated instruction represented
+ * by the label. This will be called when the label is freed.
  */
 static void
 free_einstr(void *drcontext, instr_t *label)
@@ -3348,8 +3372,9 @@ drmgr_register_bbdup_pre_event(drmgr_xform_cb_t func, drmgr_priority_t *priority
 
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_add(&cblist_pre_bbdup, func, NULL, NULL, NULL, NULL, NULL, NULL,
-                           priority, NULL /* no user data */);
+
+    return drmgr_bb_cb_add(&cblist_pre_bbdup, func, NULL, priority, NULL,
+                           cb_entry_set_fields_xform);
 }
 
 bool
@@ -3360,6 +3385,5 @@ drmgr_unregister_bbdup_pre_event(drmgr_xform_cb_t func)
 
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_remove(&cblist_pre_bbdup, func, NULL, NULL, NULL, NULL, NULL,
-                              NULL);
+    return drmgr_bb_cb_remove(&cblist_pre_bbdup, func, cb_entry_matches_xform);
 }

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -1345,8 +1345,8 @@ drmgr_register_bb_app2app_event(drmgr_xform_cb_t func, drmgr_priority_t *priorit
 {
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_add(&cblist_app2app, func, NULL, priority, NULL /* no user data */,
-                           cb_entry_set_fields_xform);
+    return drmgr_bb_cb_add(&cblist_app2app, (void *)func, NULL, priority,
+                           NULL /* no user data */, cb_entry_set_fields_xform);
 }
 
 static void
@@ -1365,8 +1365,8 @@ drmgr_register_bb_instrumentation_event(drmgr_analysis_cb_t analysis_func,
 {
     if (analysis_func == NULL && insertion_func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_add(&cblist_instrumentation, analysis_func, insertion_func,
-                           priority, NULL /* no user data */,
+    return drmgr_bb_cb_add(&cblist_instrumentation, (void *)analysis_func,
+                           (void *)insertion_func, priority, NULL /* no user data */,
                            cb_entry_set_fields_instrumentation);
 }
 
@@ -1376,7 +1376,7 @@ drmgr_register_bb_instru2instru_event(drmgr_xform_cb_t func, drmgr_priority_t *p
 {
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_add(&cblist_instru2instru, func, NULL, priority,
+    return drmgr_bb_cb_add(&cblist_instru2instru, (void *)func, NULL, priority,
                            NULL /* no user data */, cb_entry_set_fields_xform);
 }
 
@@ -1419,19 +1419,19 @@ drmgr_register_bb_instrumentation_ex_event(drmgr_app2app_ex_cb_t app2app_func,
         (analysis_func == NULL && insertion_func != NULL))
         return false; /* invalid params */
     if (app2app_func != NULL) {
-        ok = drmgr_bb_cb_add(&cblist_app2app, app2app_func, NULL, priority,
+        ok = drmgr_bb_cb_add(&cblist_app2app, (void *)app2app_func, NULL, priority,
                              NULL /* no user data */, cb_entry_set_fields_app2app_ex) &&
             ok;
     }
     if (analysis_func != NULL) {
-        ok = drmgr_bb_cb_add(&cblist_instrumentation, analysis_func, insertion_func,
-                             priority, NULL /* no user data */,
+        ok = drmgr_bb_cb_add(&cblist_instrumentation, (void *)analysis_func,
+                             (void *)insertion_func, priority, NULL /* no user data */,
                              cb_entry_set_fields_insertion_ex) &&
             ok;
     }
     if (instru2instru_func != NULL) {
-        ok = drmgr_bb_cb_add(&cblist_instru2instru, instru2instru_func, NULL, priority,
-                             NULL /* no user data */,
+        ok = drmgr_bb_cb_add(&cblist_instru2instru, (void *)instru2instru_func, NULL,
+                             priority, NULL /* no user data */,
                              cb_entry_set_fields_instru2instru_ex) &&
             ok;
     }
@@ -1507,7 +1507,7 @@ drmgr_unregister_bb_app2app_event(drmgr_xform_cb_t func)
 {
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_remove(&cblist_app2app, func, cb_entry_matches_xform);
+    return drmgr_bb_cb_remove(&cblist_app2app, (void *)func, cb_entry_matches_xform);
 }
 
 static bool
@@ -1522,7 +1522,8 @@ drmgr_unregister_bb_instrumentation_event(drmgr_analysis_cb_t func)
 {
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_remove(&cblist_instrumentation, func, cb_entry_matches_analysis);
+    return drmgr_bb_cb_remove(&cblist_instrumentation, (void *)func,
+                              cb_entry_matches_analysis);
 }
 
 static bool
@@ -1537,7 +1538,8 @@ drmgr_unregister_bb_insertion_event(drmgr_insertion_cb_t func)
 {
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_remove(&cblist_instrumentation, func, cb_entry_matches_insertion);
+    return drmgr_bb_cb_remove(&cblist_instrumentation, (void *)func,
+                              cb_entry_matches_insertion);
 }
 
 DR_EXPORT
@@ -1546,7 +1548,8 @@ drmgr_unregister_bb_instru2instru_event(drmgr_xform_cb_t func)
 {
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_remove(&cblist_instru2instru, func, cb_entry_matches_xform);
+    return drmgr_bb_cb_remove(&cblist_instru2instru, (void *)func,
+                              cb_entry_matches_xform);
 }
 
 static bool
@@ -1581,7 +1584,7 @@ drmgr_unregister_bb_instrumentation_ex_event(drmgr_app2app_ex_cb_t app2app_func,
         (analysis_func == NULL && insertion_func != NULL))
         return false; /* invalid params */
     if (app2app_func != NULL) {
-        ok = drmgr_bb_cb_remove(&cblist_app2app, app2app_func,
+        ok = drmgr_bb_cb_remove(&cblist_app2app, (void *)app2app_func,
                                 cb_entry_matches_app2app_ex) &&
             ok;
     }
@@ -1590,12 +1593,12 @@ drmgr_unregister_bb_instrumentation_ex_event(drmgr_app2app_ex_cb_t app2app_func,
          * drmgr_register_bb_instrumentation_ex_event, drmgr_bb_cb_remove only
          * checks one, so we only look for analysis_func.
          */
-        ok = drmgr_bb_cb_remove(&cblist_instrumentation, analysis_func,
+        ok = drmgr_bb_cb_remove(&cblist_instrumentation, (void *)analysis_func,
                                 cb_entry_matches_analysis_ex) &&
             ok;
     }
     if (instru2instru_func != NULL) {
-        ok = drmgr_bb_cb_remove(&cblist_instru2instru, instru2instru_func,
+        ok = drmgr_bb_cb_remove(&cblist_instru2instru, (void *)instru2instru_func,
                                 cb_entry_matches_instru2instru_ex) &&
             ok;
     }
@@ -1632,7 +1635,7 @@ drmgr_register_opcode_instrumentation_event(drmgr_opcode_insertion_cb_t func, in
     }
     dr_rwlock_write_unlock(opcode_table_lock);
 
-    return drmgr_bb_cb_add(opcode_cb_list, func, NULL, priority, user_data,
+    return drmgr_bb_cb_add(opcode_cb_list, (void *)func, NULL, priority, user_data,
                            cb_entry_set_fields_opcode);
 }
 
@@ -1657,7 +1660,7 @@ drmgr_unregister_opcode_instrumentation_event(drmgr_opcode_insertion_cb_t func,
         return false; /* there should be a cb list present in the table */
     dr_rwlock_write_unlock(opcode_table_lock);
 
-    return drmgr_bb_cb_remove(opcode_cb_list, func, cb_entry_matches_opcode);
+    return drmgr_bb_cb_remove(opcode_cb_list, (void *)func, cb_entry_matches_opcode);
 }
 
 DR_EXPORT
@@ -3373,7 +3376,7 @@ drmgr_register_bbdup_pre_event(drmgr_xform_cb_t func, drmgr_priority_t *priority
     if (func == NULL)
         return false; /* invalid params */
 
-    return drmgr_bb_cb_add(&cblist_pre_bbdup, func, NULL, priority, NULL,
+    return drmgr_bb_cb_add(&cblist_pre_bbdup, (void *)func, NULL, priority, NULL,
                            cb_entry_set_fields_xform);
 }
 
@@ -3385,5 +3388,5 @@ drmgr_unregister_bbdup_pre_event(drmgr_xform_cb_t func)
 
     if (func == NULL)
         return false; /* invalid params */
-    return drmgr_bb_cb_remove(&cblist_pre_bbdup, func, cb_entry_matches_xform);
+    return drmgr_bb_cb_remove(&cblist_pre_bbdup, (void *)func, cb_entry_matches_xform);
 }


### PR DESCRIPTION
The drmgr_bb_cb_add() and drmgr_bb_cb_remove() functions had become
unwieldy over time, with very long lists of parameters and complex
conditionals.  This makes it difficult to add new callbacks.  Here we
refactor them to take in helpers to set key fields while sharing all
of the other code.

A new has_pair field is also added.  This fixes a bug where
drmgr_register_opcode_instrumentation_event() incorrectly increased
the pair count.

Issue: #4865