### PR TITLE
i#3823 multi-phase drreg: Remove slot id labels.

### DIFF
--- a/ext/drreg/drreg.dox
+++ b/ext/drreg/drreg.dox
@@ -53,6 +53,11 @@ less available in future phases; the current logic skips over a slot if
 there's a usage found anywhere later in the bb added by any previous phase.
 So it requires additional spill slots as well.
 
+Note that DR provides APIs to directly access TLS slots: like
+\p dr_insert_write_raw_tls(), \p dr_insert_write_tls_field(). These are
+also used by drreg internally. It is unsafe to mix usages of drreg and
+these direct APIs as it may cause conflicts in slot usages.
+
 CAUTION: this extension is still a work in progress.  Not all pieces are
 implemented yet, and the interface may be in flux until the details are
 finalized.

--- a/ext/drreg/drreg.dox
+++ b/ext/drreg/drreg.dox
@@ -53,14 +53,16 @@ less available in future phases; the current logic skips over a slot if
 there's a usage found anywhere later in the bb added by any previous phase.
 So it requires additional spill slots as well.
 
-Note that DR provides APIs to directly access TLS slots: like
-\p dr_insert_write_raw_tls(), \p dr_insert_write_tls_field(). These are
-also used by drreg internally. It is unsafe to mix usages of drreg and
-these direct APIs as it may cause conflicts in slot usages.
-
-CAUTION: this extension is still a work in progress.  Not all pieces are
-implemented yet, and the interface may be in flux until the details are
-finalized.
+Note that DR provides other APIs to save or restore regs, like \p
+dr_save_reg() and \p dr_restore_reg(), and the corresponding \p
+dr_read_saved_reg() and \p dr_write_saved_reg(). They use DR spill slots.
+drreg may also use DR spill slots if not given enough dedicated slots via
+#drreg_options_t.num_spill_slots. It is unsafe to mix usages of drreg and
+these direct APIs as it may cause conflicts in slot usages within the same
+client or with other clients/libraries. Therefore, all cooperating client
+components should use drreg. Also, clients should make sure to request
+sufficient dedicated slots from drreg. See documentation of
+#drreg_options_t.num_spill_slots for more details.
 
  - \ref sec_drreg_setup
  - \ref sec_drreg_usage

--- a/ext/drreg/drreg.h
+++ b/ext/drreg/drreg.h
@@ -117,7 +117,10 @@ typedef struct _drreg_options_t {
      * requested from DR via dr_raw_tls_calloc().  Any slots needed beyond
      * this number will use DR's base slots, which are not allowed to be
      * used across application instructions.  DR's slots are also more
-     * expensive to access (beyond the first few).
+     * expensive to access (beyond the first few). DR's base slots may
+     * also be used by core DR or other clients, which may cause
+     * correctness issues if there's some slot usage conflict. Therefore,
+     * clients should make sure to request sufficient slots.
      * This number should be computed as one plus the number of
      * simultaneously used general-purpose register spill slots, as
      * drreg reserves one of the requested slots for arithmetic flag

--- a/ext/drreg/drreg.h
+++ b/ext/drreg/drreg.h
@@ -120,9 +120,9 @@ typedef struct _drreg_options_t {
      * expensive to access (beyond the first few). DR's base slots may
      * also be used by core DR or other clients, which may cause
      * correctness issues if there's some slot usage conflict. Therefore,
-     * clients should make sure to request sufficient slots.
-     * This number should be computed as one plus the number of
-     * simultaneously used general-purpose register spill slots, as
+     * clients should make sure to request sufficient dedicated slots
+     * from drreg. This number should be computed as one plus the number
+     * of simultaneously used general-purpose register spill slots, as
      * drreg reserves one of the requested slots for arithmetic flag
      * preservation.
      *

--- a/ext/drreg/drreg.h
+++ b/ext/drreg/drreg.h
@@ -117,12 +117,15 @@ typedef struct _drreg_options_t {
      * requested from DR via dr_raw_tls_calloc().  Any slots needed beyond
      * this number will use DR's base slots, which are not allowed to be
      * used across application instructions.  DR's slots are also more
-     * expensive to access (beyond the first few). DR's base slots may
-     * also be used by core DR or other clients, which may cause
-     * correctness issues if there's some slot usage conflict. Therefore,
-     * clients should make sure to request sufficient dedicated slots
-     * from drreg. This number should be computed as one plus the number
-     * of simultaneously used general-purpose register spill slots, as
+     * expensive to access (beyond the first few).  DR's base slots may
+     * also be used by APIs like dr_save_reg()/dr_restore_reg() (and the
+     * corresponding dr_read_saved_reg()/dr_write_saved_reg()), which may
+     * cause correctness issues if there's some slot usage conflict within
+     * the same client or with other clients/libraries.  Therefore, all
+     * cooperating client components should use drreg.  Also, clients
+     * should make sure to request sufficient dedicated slots from drreg.
+     * This number should be computed as one plus the number of
+     * simultaneously used general-purpose register spill slots, as
      * drreg reserves one of the requested slots for arithmetic flag
      * preservation.
      *


### PR DESCRIPTION
Modifies free spill slot selection logic to use is_our_spill_or_restore instead
of the labels with spill slot use information added for this purpose. We do not
need the extra information in the latter and can simply use the former routine.

Removes the extra spill slot use metadata added in form of labels from the
instrlist.

Also adds documentation about possibility of DR slot conflicts if DR APIs are
mixed with drreg ones.

Issue: #3823