### PR TITLE
i#2417 suite: Fix regression from bad tool.drcacheoff.rseq cmdline

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3542,7 +3542,7 @@ if (BUILD_CLIENTS)
     endif ()
 
     if (LINUX AND X64 AND HAVE_RSEQ)
-      torunonly_drcacheoff(rseq linux.rseq "" "${test_mode_flag}" "")
+      torunonly_drcacheoff(rseq linux.rseq "" "@${test_mode_flag}" "")
     endif ()
 
     if (AARCH64)


### PR DESCRIPTION
Fixes a bug in the tool.drcacheoff.rseq test command line where the
glob for the output directory was run up against the -test_mode
parameter.  The bug was introduced in PR #4929.

Issue: #2417