### PR TITLE
i#4865 emulate: Add new emulation instrumentation API

### DIFF
--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -52,7 +52,7 @@ operating system (Windows, Linux, or Android) and commodity IA-32, AMD64,
 ARM, and AArch64 hardware.  See \ref sec_limit_platforms for details of
 which platform combinations are fully supported.
 
-This document describes the DynamoRIO system and the various API's that it
+This document describes the DynamoRIO system and the various APIs that it
 exports for building custom tools.  It is divided into the following
 sections:
 

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -166,7 +166,7 @@ compatibility changes:
    and includes the rest of the block; and #DR_EMULATE_INSTR_ONLY, indicating
    an emulation for which instrumentation should still examine the
    emulation sequence for observing data operations.  A third value is set by
-   drmgr_in_emulation_region(): #DR_EMULATE_FIRST_INSTR.  This flags addition preserves
+   drmgr_in_emulation_region(): #DR_EMULATE_IS_FIRST_INSTR.  This flag addition preserves
    binary compatibility, but source code that did not zero the structure could end
    up with an uninitialized flags field when calling drmgr_insert_emulation_start().
 
@@ -217,7 +217,7 @@ Further non-compatibility-affecting changes include:
  - Added #DRREG_HANDLE_MULTI_PHASE_SLOT_RESERVATIONS to #drreg_bb_properties_t to
    enable logic that avoids conflicts in spill slots when drreg is used to reserve
    registers in multiple phases.
- - Added drmgr_in_emulation_region(), drmgr_orig_app_instr_for_fetch(, and
+ - Added drmgr_in_emulation_region(), drmgr_orig_app_instr_for_fetch(), and
    drmgr_orig_app_instr_for_operands() for more conveniently handling emulation.
  - Added the reconstructed #instrlist_t when available for the faulting fragment
    to #dr_fault_fragment_info_t. This makes it available to the restore state

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -217,7 +217,8 @@ Further non-compatibility-affecting changes include:
  - Added #DRREG_HANDLE_MULTI_PHASE_SLOT_RESERVATIONS to #drreg_bb_properties_t to
    enable logic that avoids conflicts in spill slots when drreg is used to reserve
    registers in multiple phases.
- - Added drmgr_in_emulation_region() for more conveniently handling emulation.
+ - Added drmgr_in_emulation_region(), drmgr_orig_app_instr_for_fetch(, and
+   drmgr_orig_app_instr_for_operands() for more conveniently handling emulation.
  - Added the reconstructed #instrlist_t when available for the faulting fragment
    to #dr_fault_fragment_info_t. This makes it available to the restore state
    event callback(s) via the #dr_restore_state_info_t arg.

--- a/api/samples/memtrace_simple.c
+++ b/api/samples/memtrace_simple.c
@@ -61,6 +61,7 @@
 
 #include <stdio.h>
 #include <stddef.h> /* for offsetof */
+#include <string.h>
 #include "dr_api.h"
 #include "drmgr.h"
 #include "drreg.h"
@@ -100,8 +101,9 @@ typedef struct {
 } per_thread_t;
 
 static client_id_t client_id;
-static void *mutex;     /* for multithread support */
-static uint64 num_refs; /* keep a global memory reference count */
+static void *mutex;        /* for multithread support */
+static uint64 num_refs;    /* keep a global memory reference count */
+static bool log_to_stderr; /* for testing */
 
 /* Allocated TLS slot offsets */
 enum {
@@ -226,7 +228,7 @@ insert_save_addr(void *drcontext, instrlist_t *ilist, instr_t *where, opnd_t ref
 
 /* insert inline code to add an instruction entry into the buffer */
 static void
-instrument_instr(void *drcontext, instrlist_t *ilist, instr_t *where)
+instrument_instr(void *drcontext, instrlist_t *ilist, instr_t *where, instr_t *instr)
 {
     /* We need two scratch registers */
     reg_id_t reg_ptr, reg_tmp;
@@ -241,10 +243,10 @@ instrument_instr(void *drcontext, instrlist_t *ilist, instr_t *where)
     }
     insert_load_buf_ptr(drcontext, ilist, where, reg_ptr);
     insert_save_type(drcontext, ilist, where, reg_ptr, reg_tmp,
-                     (ushort)instr_get_opcode(where));
+                     (ushort)instr_get_opcode(instr));
     insert_save_size(drcontext, ilist, where, reg_ptr, reg_tmp,
-                     (ushort)instr_length(drcontext, where));
-    insert_save_pc(drcontext, ilist, where, reg_ptr, reg_tmp, instr_get_app_pc(where));
+                     (ushort)instr_length(drcontext, instr));
+    insert_save_pc(drcontext, ilist, where, reg_ptr, reg_tmp, instr_get_app_pc(instr));
     insert_update_buf_ptr(drcontext, ilist, where, reg_ptr, sizeof(mem_ref_t));
     /* Restore scratch registers */
     if (drreg_unreserve_register(drcontext, ilist, where, reg_ptr) != DRREG_SUCCESS ||
@@ -284,28 +286,38 @@ instrument_mem(void *drcontext, instrlist_t *ilist, instr_t *where, opnd_t ref,
  * with an instruction entry and memory reference entries.
  */
 static dr_emit_flags_t
-event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
+event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *where,
                       bool for_trace, bool translating, void *user_data)
 {
     int i;
 
-    if (!instr_is_app(instr))
-        return DR_EMIT_DEFAULT;
-    if (!instr_reads_memory(instr) && !instr_writes_memory(instr))
-        return DR_EMIT_DEFAULT;
-
-    /* insert code to add an entry for app instruction */
-    instrument_instr(drcontext, bb, instr);
-
-    /* insert code to add an entry for each memory reference opnd */
-    for (i = 0; i < instr_num_srcs(instr); i++) {
-        if (opnd_is_memory_reference(instr_get_src(instr, i)))
-            instrument_mem(drcontext, bb, instr, instr_get_src(instr, i), false);
+    /* Insert code to add an entry for each app instruction. */
+    /* Use the drmgr_orig_app_instr_* interface to properly handle our own use
+     * of drutil_expand_rep_string() and drx_expand_scatter_gather() (as well
+     * as another client/library emulating the instruction stream).
+     */
+    instr_t *instr_fetch = drmgr_orig_app_instr_for_fetch(drcontext);
+    if (instr_fetch != NULL &&
+        (instr_reads_memory(instr_fetch) || instr_writes_memory(instr_fetch))) {
+        DR_ASSERT(instr_is_app(instr_fetch));
+        instrument_instr(drcontext, bb, where, instr_fetch);
     }
 
-    for (i = 0; i < instr_num_dsts(instr); i++) {
-        if (opnd_is_memory_reference(instr_get_dst(instr, i)))
-            instrument_mem(drcontext, bb, instr, instr_get_dst(instr, i), true);
+    /* Insert code to add an entry for each memory reference opnd. */
+    instr_t *instr_operands = drmgr_orig_app_instr_for_operands(drcontext);
+    if (instr_operands == NULL ||
+        (!instr_reads_memory(instr_operands) && !instr_writes_memory(instr_operands)))
+        return DR_EMIT_DEFAULT;
+    DR_ASSERT(instr_is_app(instr_operands));
+
+    for (i = 0; i < instr_num_srcs(instr_operands); i++) {
+        if (opnd_is_memory_reference(instr_get_src(instr_operands, i)))
+            instrument_mem(drcontext, bb, where, instr_get_src(instr_operands, i), false);
+    }
+
+    for (i = 0; i < instr_num_dsts(instr_operands); i++) {
+        if (opnd_is_memory_reference(instr_get_dst(instr_operands, i)))
+            instrument_mem(drcontext, bb, where, instr_get_dst(instr_operands, i), true);
     }
 
     /* insert code to call clean_call for processing the buffer */
@@ -319,8 +331,8 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
          * Using a fault to handle a full buffer should be more robust, and the
          * forthcoming buffer filling API (i#513) will provide that.
          */
-        IF_AARCHXX_ELSE(!instr_is_exclusive_store(instr), true))
-        dr_insert_clean_call(drcontext, bb, instr, (void *)clean_call, false, 0);
+        IF_AARCHXX_ELSE(!instr_is_exclusive_store(instr_operands), true))
+        dr_insert_clean_call(drcontext, bb, where, (void *)clean_call, false, 0);
 
     return DR_EMIT_DEFAULT;
 }
@@ -361,18 +373,22 @@ event_thread_init(void *drcontext)
 
     data->num_refs = 0;
 
-    /* We're going to dump our data to a per-thread file.
-     * On Windows we need an absolute path so we place it in
-     * the same directory as our library. We could also pass
-     * in a path as a client argument.
-     */
-    data->log =
-        log_file_open(client_id, drcontext, NULL /* using client lib path */, "memtrace",
+    if (log_to_stderr) {
+        data->logf = stderr;
+    } else {
+        /* We're going to dump our data to a per-thread file.
+         * On Windows we need an absolute path so we place it in
+         * the same directory as our library. We could also pass
+         * in a path as a client argument.
+         */
+        data->log = log_file_open(client_id, drcontext, NULL /* using client lib path */,
+                                  "memtrace",
 #ifndef WINDOWS
-                      DR_FILE_CLOSE_ON_FORK |
+                                  DR_FILE_CLOSE_ON_FORK |
 #endif
-                          DR_FILE_ALLOW_LARGE);
-    data->logf = log_stream_from_file(data->log);
+                                      DR_FILE_ALLOW_LARGE);
+        data->logf = log_stream_from_file(data->log);
+    }
     fprintf(data->logf, "Format: <data address>: <data size>, <(r)ead/(w)rite/opcode>\n");
 }
 
@@ -385,7 +401,8 @@ event_thread_exit(void *drcontext)
     dr_mutex_lock(mutex);
     num_refs += data->num_refs;
     dr_mutex_unlock(mutex);
-    log_stream_close(data->logf); /* closes fd too */
+    if (!log_to_stderr)
+        log_stream_close(data->logf); /* closes fd too */
     dr_raw_mem_free(data->buf_base, MEM_BUF_SIZE);
     dr_thread_free(drcontext, data, sizeof(per_thread_t));
 }
@@ -418,6 +435,19 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     drreg_options_t ops = { sizeof(ops), 3, false };
     dr_set_client_name("DynamoRIO Sample Client 'memtrace'",
                        "http://dynamorio.org/issues");
+
+    const char *client_ops = dr_get_options(id);
+    if (client_ops != NULL && client_ops[0] != '\0') {
+        if (strcmp(client_ops, "-log_to_stderr") == 0)
+            log_to_stderr = true;
+        else {
+            dr_fprintf(STDERR,
+                       "Error: unknown options |%s|: only -log_to_stderr is supported\n",
+                       client_ops);
+            dr_abort();
+        }
+    }
+
     if (!drmgr_init() || drreg_init(&ops) != DRREG_SUCCESS || !drutil_init() ||
         !drx_init())
         DR_ASSERT(false);

--- a/api/samples/memtrace_simple.c
+++ b/api/samples/memtrace_simple.c
@@ -437,12 +437,11 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
                        "http://dynamorio.org/issues");
 
     if (argc > 1) {
-        if (strcmp(argv[1], "-log_to_stderr") == 0)
+        if (argc == 2 && strcmp(argv[1], "-log_to_stderr") == 0)
             log_to_stderr = true;
         else {
             dr_fprintf(STDERR,
-                       "Error: unknown options |%s|: only -log_to_stderr is supported\n",
-                       client_ops);
+                       "Error: unknown options: only -log_to_stderr is supported\n");
             dr_abort();
         }
     }

--- a/api/samples/memtrace_simple.c
+++ b/api/samples/memtrace_simple.c
@@ -436,9 +436,8 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     dr_set_client_name("DynamoRIO Sample Client 'memtrace'",
                        "http://dynamorio.org/issues");
 
-    const char *client_ops = dr_get_options(id);
-    if (client_ops != NULL && client_ops[0] != '\0') {
-        if (strcmp(client_ops, "-log_to_stderr") == 0)
+    if (argc > 1) {
+        if (strcmp(argv[1], "-log_to_stderr") == 0)
             log_to_stderr = true;
         else {
             dr_fprintf(STDERR,

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -209,7 +209,7 @@ typedef struct _per_thread_t {
     emulated_instr_t emulation_info;
     bool in_emulation_region;
     /* This field stores the current insertion event instruction so that
-     * separate query API's don't need to take in the instruction.
+     * separate query APIs don't need to take in the instruction.
      */
     instr_t *insertion_instr;
 } per_thread_t;

--- a/ext/drmgr/drmgr.dox
+++ b/ext/drmgr/drmgr.dox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2015 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2021 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -46,6 +46,7 @@ composed and combined.
  - \ref sec_drmgr_setup
  - \ref sec_drmgr_events
  - \ref sec_drmgr_stages
+ - \ref sec_drmgr_emulation
  - \ref sec_drmgr_tls
  - \ref sec_drmgr_notes
 
@@ -103,6 +104,37 @@ actions.  The instrumentation insertion is performed in one forward pass:
 for each instruction, each registered component is invoked.  This simplifies
 register allocation (register allocation is provided by a separate
 Extension \p drreg).
+
+\subsection sec_drmgr_emulation Emulation-Aware Instrumentation
+
+Support for one client library emulating or refactoring application code
+while another observes application behavior is provided through emulation
+marking and reading support.
+
+An emulation-creating library uses drmgr_insert_emulation_start() and
+drmgr_insert_emulation_end() to mark the emulation region and make a copy
+of the original instruction being replaced.
+
+An emulation-aware observational client then wants to instrument the
+original copy, rather than the emulation sequence present in the
+instruction list.  This is most easily done using the application
+instruction and data events, which split the third stage, insertion, into
+two parts, and ignores non-application instructions (i.e., labels and meta
+instructions added as part of emulation in the app2app phase is all hidden
+from these two events).  Use drmgr_register_bb_app_observation_event() to
+register these events.
+
+Another method for an observational client is to use the regular insertion
+event and manually determine which instruction to examine, using
+drmgr_in_emulation_region() and the recommended code sequence in the
+documentation for that function.
+
+The refactoring of application code for simpler instrumentation performed
+by drutil_expand_rep_string() and drx_expand_scatter_gather() is also
+marked as emulation, but only for instructions, not data: i.e.,
+#DR_EMULATE_INSTR_ONLY is set for these refactorings.  These are typically
+used in address tracing clients, and we recommend that such clients also
+use the emulation-aware instrumentation approaches outlined here.
 
 \subsection sec_drmgr_ordering Ordering
 

--- a/ext/drmgr/drmgr.dox
+++ b/ext/drmgr/drmgr.dox
@@ -107,9 +107,9 @@ Extension \p drreg).
 
 \subsection sec_drmgr_emulation Emulation-Aware Instrumentation
 
-Support for one client library emulating or refactoring application code
-while another observes application behavior is provided through emulation
-marking and reading support.
+Support for one client library or component emulating or refactoring
+application code while another observes application behavior is
+provided through emulation marking and reading support.
 
 An emulation-creating library uses drmgr_insert_emulation_start() and
 drmgr_insert_emulation_end() to mark the emulation region and make a copy
@@ -117,24 +117,26 @@ of the original instruction being replaced.
 
 An emulation-aware observational client then wants to instrument the
 original copy, rather than the emulation sequence present in the
-instruction list.  This is most easily done using the application
-instruction and data events, which split the third stage, insertion, into
-two parts, and ignores non-application instructions (i.e., labels and meta
-instructions added as part of emulation in the app2app phase is all hidden
-from these two events).  Use drmgr_register_bb_app_observation_event() to
-register these events.
-
-Another method for an observational client is to use the regular insertion
-event and manually determine which instruction to examine, using
-drmgr_in_emulation_region() and the recommended code sequence in the
-documentation for that function.
+instruction list.  The client should use the
+drmgr_orig_app_instr_for_fetch() and
+drmgr_orig_app_instr_for_operands() routines inside the insertion
+event to determine the instruction to observe, ignoring the
+instruction passed to the insertion event except as a placeholder in
+the instruction list for where to place added instructions for
+instrumentation.
 
 The refactoring of application code for simpler instrumentation performed
 by drutil_expand_rep_string() and drx_expand_scatter_gather() is also
 marked as emulation, but only for instructions, not data: i.e.,
 #DR_EMULATE_INSTR_ONLY is set for these refactorings.  These are typically
 used in address tracing clients, and we recommend that such clients also
-use the emulation-aware instrumentation approaches outlined here.
+use the emulation-aware instrumentation approach just outlined.
+
+If expansions or true emulation is present and a client is not
+emulation-aware, it may not accurately observe the application's
+behavior.  For example, an opcode recording client might record the
+opcodes for the expansion sequence emulating a scatter instruction,
+rather than the original scatter opcode.
 
 \subsection sec_drmgr_ordering Ordering
 

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -947,25 +947,109 @@ drmgr_get_emulated_instr_data(instr_t *instr, OUT emulated_instr_t *emulated);
  * This is the recommended usage for observational clients in the insertion event,
  * highlighting the different paths for instruction versus data instrumentation:
  *
- *    const emulated_instr_t *emulation;
- *    if (drmgr_in_emulation_region(drcontext, &emulation)) {
- *        if (TEST(DR_EMULATE_FIRST_INSTR, emulation->flags)) {
- *            record_instr_fetch(emulation->instr);
- *            if (!TEST(DR_EMULATE_INSTR_ONLY, emulation->flags))
- *                record_data_addresses(emulation->instr);
- *        } // Else skip further instr fetches until outside emulation region.
- *        if (instr_is_app(exec_instr) && TEST(DR_EMULATE_INSTR_ONLY, emulation->flags))
- *            record_data_addresses(exec_instr);
- *    } else if (instr_is_app(exec_instr)) {
- *        record_instr_fetch(exec_instr);
- *        record_data_addresses(exec_instr);
- *    }
+ * dr_emit_flags_t
+ * event_insertion(void *drcontext, void *tag, instrlist_t *bb, instr_t *insert_instr,
+ *                 bool for_trace, bool translating, void *user_data) {
+ *     const emulated_instr_t *emulation;
+ *     if (drmgr_in_emulation_region(drcontext, &emulation)) {
+ *         if (TEST(DR_EMULATE_FIRST_INSTR, emulation->flags)) {
+ *             record_instr_fetch(emulation->instr);
+ *             if (!TEST(DR_EMULATE_INSTR_ONLY, emulation->flags))
+ *                 record_data_addresses(emulation->instr);
+ *         } // Else skip further instr fetches until outside emulation region.
+ *         if (instr_is_app(insert_instr) &&
+ *             TEST(DR_EMULATE_INSTR_ONLY, emulation->flags))
+ *             record_data_addresses(insert_instr);
+ *     } else if (instr_is_app(insert_instr)) {
+ *         record_instr_fetch(insert_instr);
+ *         record_data_addresses(insert_instr);
+ *     }
+ *     return DR_EMIT_DEFAULT;
+ * }
+ *
+ * An alternative, simpler usage model is to instead use the two routines
+ * drmgr_orig_app_instr_for_fetch() and drmgr_orig_app_instr_for_operands():
+ *
+ * dr_emit_flags_t
+ * event_insertion(void *drcontext, void *tag, instrlist_t *bb, instr_t *insert_instr,
+ *                 bool for_trace, bool translating, void *user_data) {
+ *     instr_t *instr_fetch = drmgr_orig_app_instr_for_fetch(drcontext);
+ *     if (instr_fetch != NULL)
+ *         record_instr_fetch(instr_fetch);
+ *     instr_t *instr_operands = drmgr_orig_app_instr_for_operands(drcontext);
+ *     if (instr_operands_valid != NULL)
+ *         record_data_addresses(instr_operands);
+ *     return DR_EMIT_DEFAULT;
+ * }
  *
  * \return false if the caller's \p emulated_instr_t is not compatible, true otherwise.
  */
 DR_EXPORT
 bool
 drmgr_in_emulation_region(void *drcontext, OUT const emulated_instr_t **emulation_info);
+
+DR_EXPORT
+/**
+ * Must be called during drmgr's insertion phase.
+ *
+ * Returns the instruction to consider as the current application
+ * instruction for observational clients with respect to which
+ * instruction executed, taking into account emulation.  This may be
+ * different from the current instruction list instruction passed to
+ * the insertion event.
+ *
+ * Returns NULL if observational clients should skip the current instruction
+ * list instruction.
+ *
+ * This is a convenience routine.  It follows the logic of the recommended usage
+ * for drmgr_in_emulation_region() laid out in the documentation for that method,
+ * repeated here for instruction fetch only:
+ *
+ *    const emulated_instr_t *emulation;
+ *    if (drmgr_in_emulation_region(drcontext, &emulation)) {
+ *        if (TEST(DR_EMULATE_FIRST_INSTR, emulation->flags)) {
+ *            return emulation->instr;
+ *        } // Else skip further instr fetches until outside emulation region.
+ *    } else if (instr_is_app(insert_instr)) {
+ *        return insert_instr;
+ *    }
+ *    return NULL;
+ */
+instr_t *
+drmgr_orig_app_instr_for_fetch(void *drcontext);
+
+DR_EXPORT
+/**
+ * Must be called during drmgr's insertion phase.
+ *
+ * Returns the instruction to consider as the current application
+ * instruction for observational clients with respect to the operands
+ * of the instruction, taking into account emulation.  This may be
+ * different from the current instruction list instruction passed to
+ * the insertion event.
+ *
+ * Returns NULL if observational clients should skip the current instruction
+ * list instruction.
+ *
+ * This is a convenience routine.  It follows the logic of the recommended usage
+ * for drmgr_in_emulation_region() laid out in the documentation for that method,
+ * repeated here for operands only:
+ *
+ *    const emulated_instr_t *emulation;
+ *    if (drmgr_in_emulation_region(drcontext, &emulation)) {
+ *        if (TEST(DR_EMULATE_FIRST_INSTR, emulation->flags) &&
+ *            !TEST(DR_EMULATE_INSTR_ONLY, emulation->flags))
+ *            return emulation->instr;
+ *        if (instr_is_app(insert_instr) &&
+ *            TEST(DR_EMULATE_INSTR_ONLY, emulation->flags))
+ *            return insert_instr;
+ *    } else if (instr_is_app(insert_instr)) {
+ *        return insert_instr;
+ *    }
+ *    return NULL;
+ */
+instr_t *
+drmgr_orig_app_instr_for_operands(void *drcontext);
 
 /***************************************************************************
  * UTILITIES

--- a/ext/drutil/drutil.c
+++ b/ext/drutil/drutil.c
@@ -691,11 +691,6 @@ drutil_expand_rep_string_ex(void *drcontext, instrlist_t *bb, bool *expanded OUT
         ASSERT(opnd_uses_reg(xcx, DR_REG_XCX), "rep string opnd order mismatch");
         ASSERT(inst == instrlist_last(bb), "repstr not alone in bb");
 
-        /* XXX i#4865: This is a different type of emulation where we want
-         * observational clients to look at the original instruction for instruction
-         * fetch info but the emulation sequence for data load/store info.  We need
-         * some kind of flag in emulated_instr_t to indicate this.
-         */
         emulated_instr_t emulated_instr;
         emulated_instr.size = sizeof(emulated_instr);
         emulated_instr.pc = xl8;
@@ -706,7 +701,11 @@ drutil_expand_rep_string_ex(void *drcontext, instrlist_t *bb, bool *expanded OUT
          * use the flag to mark the whole block as emulated.
          */
         emulated_instr.flags = DR_EMULATE_REST_OF_BLOCK |
-            /* Tools should instrument the data operations in the sequence. */
+            /* This is a different type of emulation where we want
+             * observational clients to look at the original instruction for instruction
+             * fetch info but the emulation sequence for data load/store info.  We use
+             * this flag in emulated_instr_t to indicate this.
+             */
             DR_EMULATE_INSTR_ONLY;
         drmgr_insert_emulation_start(drcontext, bb, inst, &emulated_instr);
 

--- a/ext/drutil/drutil.h
+++ b/ext/drutil/drutil.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2021 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /* drutil: DynamoRIO Instrumentation Utilities
@@ -143,6 +143,11 @@ DR_EXPORT
  * (by truncating the prior block before the loop, and truncating
  * instructions after the loop) and then exanding it into a
  * multi-instruction loop.
+ *
+ * Clients applying this expansion are encouraged to use emulation-aware
+ * instrumentation via drmgr_orig_app_instr_for_fetch() and
+ * drmgr_orig_app_instr_for_operands() in order to observe the original
+ * string loop opcode with the expanded memory operands.
  *
  * WARNING: The added multi-instruction loop contains several
  * control-transfer instructions and is not straight-line code, which

--- a/ext/drx/drx.h
+++ b/ext/drx/drx.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2017 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2021 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -509,7 +509,10 @@ DR_EXPORT
  * equivalent scalar load and stores, mask register bit tests, and mask register bit
  * updates.
  *
- * \warning This function is not fully supported yet. Do not use.
+ * Clients applying this expansion are encouraged to use emulation-aware
+ * instrumentation via drmgr_orig_app_instr_for_fetch() and
+ * drmgr_orig_app_instr_for_operands() in order to observe the original
+ * opcode with the expanded memory operands.
  *
  * \warning The added multi-instruction sequence contains several control-transfer
  * instructions and is not straight-line code, which can complicate subsequent analysis

--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2020 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2021 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -64,7 +64,7 @@
 #  add_executable(myapp myapp.c)
 #  configure_DynamoRIO_standalone(myapp)
 #
-# If using the drconfig (dr_config.h) and/or drinject (dr_inject.h) API's,
+# If using the drconfig (dr_config.h) and/or drinject (dr_inject.h) APIs,
 # you also need to explicitly link with those libraries:
 #
 #  target_link_libraries(myapp drinjectlib drconfiglib)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3053,7 +3053,7 @@ if (BUILD_SAMPLES)
     get_property(sample_list GLOBAL PROPERTY DynamoRIO_sample_list)
     foreach (sample ${sample_list})
       # FIXME i#4392: Remove sanity checks and replace with functioning tests like
-      # that done for the opcode_count sample.
+      # that done for the opcode_count and memtrace_simple samples.
       torunonly_ci(sample.${sample} common.${control_flags}
         ${sample} common/${control_flags}.c "" "" "")
       if (sample STREQUAL "inscount")
@@ -3097,7 +3097,12 @@ if (BUILD_SAMPLES)
 
           torunonly_ci(sample.${sample} sample.opcode_count-test ${sample}_test
             samples/opcode_count-test.asm "-opcode 5" "" "")
-        endif(X86 AND (NOT X64) AND UNIX)
+        endif (X86 AND (NOT X64) AND UNIX)
+      elseif (sample STREQUAL "memtrace_simple")
+        if (X86 AND X64 AND UNIX)
+          torunonly_ci(sample.${sample}_repstr allasm_repstr ${sample}_test
+            samples/${sample}_repstr "-log_to_stderr" "" "")
+        endif ()
       endif()
     endforeach ()
   endif (NOT ANDROID)

--- a/suite/tests/client-interface/emulation_api_simple.dll.c
+++ b/suite/tests/client-interface/emulation_api_simple.dll.c
@@ -432,15 +432,31 @@ event_insertion(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
     const emulated_instr_t *emulation;
     if (drmgr_in_emulation_region(drcontext, &emulation)) {
         if (TEST(DR_EMULATE_FIRST_INSTR, emulation->flags)) {
+            DR_ASSERT(drmgr_orig_app_instr_for_fetch(drcontext) == emulation->instr);
             record_instr_fetch_orig(emulation->instr);
-            if (!TEST(DR_EMULATE_INSTR_ONLY, emulation->flags))
+            if (!TEST(DR_EMULATE_INSTR_ONLY, emulation->flags)) {
+                DR_ASSERT(drmgr_orig_app_instr_for_fetch(drcontext) == emulation->instr);
                 record_data_addresses_orig(emulation->instr);
-        } /* Else skip further instr fetches until outside emulation region. */
-        if (instr_is_app(inst) && TEST(DR_EMULATE_INSTR_ONLY, emulation->flags))
+            }
+        } else {
+            /* Else skip further instr fetches until outside emulation region. */
+            DR_ASSERT(drmgr_orig_app_instr_for_fetch(drcontext) == NULL);
+        }
+        if (instr_is_app(inst) && TEST(DR_EMULATE_INSTR_ONLY, emulation->flags)) {
+            DR_ASSERT(drmgr_orig_app_instr_for_operands(drcontext) == inst);
             record_data_addresses_derived(inst);
+        } else if (!TEST(DR_EMULATE_FIRST_INSTR, emulation->flags) ||
+                   TEST(DR_EMULATE_INSTR_ONLY, emulation->flags)) {
+            DR_ASSERT(drmgr_orig_app_instr_for_operands(drcontext) == NULL);
+        }
     } else if (instr_is_app(inst)) {
+        DR_ASSERT(drmgr_orig_app_instr_for_fetch(drcontext) == inst);
         record_instr_fetch_unchanged(inst);
+        DR_ASSERT(drmgr_orig_app_instr_for_operands(drcontext) == inst);
         record_data_addresses_unchanged(inst);
+    } else {
+        DR_ASSERT(drmgr_orig_app_instr_for_fetch(drcontext) == NULL);
+        DR_ASSERT(drmgr_orig_app_instr_for_operands(drcontext) == NULL);
     }
     return DR_EMIT_DEFAULT;
 }

--- a/suite/tests/client-interface/emulation_api_simple.dll.c
+++ b/suite/tests/client-interface/emulation_api_simple.dll.c
@@ -431,11 +431,12 @@ event_insertion(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
     /* Use the recommended emulation instrumentation code pattern: */
     const emulated_instr_t *emulation;
     if (drmgr_in_emulation_region(drcontext, &emulation)) {
-        if (TEST(DR_EMULATE_FIRST_INSTR, emulation->flags)) {
+        if (TEST(DR_EMULATE_IS_FIRST_INSTR, emulation->flags)) {
             DR_ASSERT(drmgr_orig_app_instr_for_fetch(drcontext) == emulation->instr);
             record_instr_fetch_orig(emulation->instr);
             if (!TEST(DR_EMULATE_INSTR_ONLY, emulation->flags)) {
-                DR_ASSERT(drmgr_orig_app_instr_for_fetch(drcontext) == emulation->instr);
+                DR_ASSERT(drmgr_orig_app_instr_for_operands(drcontext) ==
+                          emulation->instr);
                 record_data_addresses_orig(emulation->instr);
             }
         } else {
@@ -445,7 +446,7 @@ event_insertion(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
         if (instr_is_app(inst) && TEST(DR_EMULATE_INSTR_ONLY, emulation->flags)) {
             DR_ASSERT(drmgr_orig_app_instr_for_operands(drcontext) == inst);
             record_data_addresses_derived(inst);
-        } else if (!TEST(DR_EMULATE_FIRST_INSTR, emulation->flags) ||
+        } else if (!TEST(DR_EMULATE_IS_FIRST_INSTR, emulation->flags) ||
                    TEST(DR_EMULATE_INSTR_ONLY, emulation->flags)) {
             DR_ASSERT(drmgr_orig_app_instr_for_operands(drcontext) == NULL);
         }

--- a/suite/tests/samples/memtrace_simple_repstr.templatex
+++ b/suite/tests/samples/memtrace_simple_repstr.templatex
@@ -1,0 +1,18 @@
+// Without emulation awareness, this will print "1, movs" instead of "2, rep movs".
+Format: <data address>: <data size>, <\(r\)ead/\(w\)rite/opcode>
+0x[0-9a-f]*:  2, rep movs
+0x[0-9a-f]*:  1, r
+0x[0-9a-f]*:  1, w
+0x[0-9a-f]*:  2, rep movs
+0x[0-9a-f]*:  1, r
+0x[0-9a-f]*:  1, w
+0x[0-9a-f]*:  2, rep movs
+0x[0-9a-f]*:  1, r
+0x[0-9a-f]*:  1, w
+0x[0-9a-f]*:  2, rep movs
+0x[0-9a-f]*:  1, r
+0x[0-9a-f]*:  1, w
+0x[0-9a-f]*:  2, rep movs
+0x[0-9a-f]*:  1, r
+0x[0-9a-f]*:  1, w
+Adios world!


### PR DESCRIPTION
Adds a new emulation instrumentation interface with simpler
convenience routines for identifying the original application
instruction fetch and operands.

Uses the new interface in memtrace_simple.  Separate commits will
update memval_simple, memtrace_x86, and drmemtrace.

Adds an x86 test that runs the memtrace_simple sample on the
allasm_repstr app and ensures we see 2-byte "rep movs" instructions
instead of the 1-byte "movs" that the existing sample client records
due to not being emulation-aware.  Adds a -log_to_stderr flag to the
sample to make the test simpler and not have to deal with log files.

Adding new events is separated into #4947 which we may attempt in the
future.  Removing rep string non-fetched instructions is #4948.

--------------------------------------------------
Testing:

memtrace_simple before:
    $ bin64/drrun -c api/bin/libmemtrace_simple.so -- suite/tests/bin/allasm_repstr && cat `ls -1td api/bin/*.log|head -1`
    Format: <data address>: <data size>, <(r)ead/(w)rite/opcode>
    0x401018:  1, movs
    0x40200e:  1, r
    0x402000:  1, w
    0x401018:  1, movs
    0x40200f:  1, r
    0x402001:  1, w
    0x401018:  1, movs
    0x402010:  1, r
    0x402002:  1, w
    0x401018:  1, movs
    0x402011:  1, r
    0x402003:  1, w
    0x401018:  1, movs
    0x402012:  1, r
    0x402004:  1, w
After:
    Format: <data address>: <data size>, <(r)ead/(w)rite/opcode>
    0x401018:  2, rep movs
    0x40200e:  1, r
    0x402000:  1, w
    0x401018:  2, rep movs
    0x40200f:  1, r
    0x402001:  1, w
    0x401018:  2, rep movs
    0x402010:  1, r
    0x402002:  1, w
    0x401018:  2, rep movs
    0x402011:  1, r
    0x402003:  1, w
    0x401018:  2, rep movs
    0x402012:  1, r
    0x402004:  1, w

memtrace_simple on a gather expansion:
    $ ninja && bin64/drrun -c api/bin/libmemtrace_simple.so -log_to_stderr -- suite/tests/bin/allasm_scattergather
    Format: <data address>: <data size>, <(r)ead/(w)rite/opcode>
    0x40105c: 11, mov
    0x402022:  4, w
    0x401067: 11, mov
    0x402026:  4, w
    0x401072: 11, mov
    0x40202a:  4, w
    0x40108a:  7, mov
    0x402026:  4, r
    0x40108a:  7, mov
    0x40202e:  4, r
    0x40108a:  7, mov
    0x40202a:  4, r
  =>
    Format: <data address>: <data size>, <(r)ead/(w)rite/opcode>
    0x40105c: 11, mov
    0x402022:  4, w
    0x401067: 11, mov
    0x402026:  4, w
    0x401072: 11, mov
    0x40202a:  4, w
    0x40108a: 10, vpgatherdd
    0x402026:  4, r
    0x40202e:  4, r
    0x40202a:  4, r
--------------------------------------------------

Issue: #4865