### PR TITLE
i#4865 emulate: Use new API in memval_simple + memtrace_x86

### DIFF
--- a/api/samples/memtrace_x86.c
+++ b/api/samples/memtrace_x86.c
@@ -100,6 +100,11 @@ typedef struct {
     uint64 num_refs;
 } per_thread_t;
 
+/* Cross-instrumentation-phase data. */
+typedef struct {
+    app_pc last_pc;
+} instru_data_t;
+
 static size_t page_size;
 static client_id_t client_id;
 static app_pc code_cache;
@@ -116,7 +121,9 @@ event_thread_exit(void *drcontext);
 static dr_emit_flags_t
 event_bb_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                  bool translating);
-
+static dr_emit_flags_t
+event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
+                  bool translating, void **user_data);
 static dr_emit_flags_t
 event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
                 bool for_trace, bool translating, void *user_data);
@@ -130,7 +137,8 @@ code_cache_init(void);
 static void
 code_cache_exit(void);
 static void
-instrument_mem(void *drcontext, instrlist_t *ilist, instr_t *where, int pos, bool write);
+instrument_mem(void *drcontext, instrlist_t *ilist, instr_t *where, app_pc pc,
+               instr_t *memref_instr, int pos, bool write);
 
 DR_EXPORT void
 dr_client_main(client_id_t id, int argc, const char *argv[])
@@ -154,7 +162,8 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     if (!drmgr_register_thread_init_event(event_thread_init) ||
         !drmgr_register_thread_exit_event(event_thread_exit) ||
         !drmgr_register_bb_app2app_event(event_bb_app2app, &priority) ||
-        !drmgr_register_bb_instrumentation_event(NULL, event_bb_insert, &priority) ||
+        !drmgr_register_bb_instrumentation_event(event_bb_analysis, event_bb_insert,
+                                                 &priority) ||
         drreg_init(&ops) != DRREG_SUCCESS || !drx_init()) {
         /* something is wrong: can't continue */
         DR_ASSERT(false);
@@ -280,27 +289,54 @@ event_bb_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     return DR_EMIT_DEFAULT;
 }
 
+static dr_emit_flags_t
+event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
+                  bool translating, void **user_data)
+{
+    instru_data_t *data = (instru_data_t *)dr_thread_alloc(drcontext, sizeof(*data));
+    data->last_pc = NULL;
+    *user_data = (void *)data;
+    return DR_EMIT_DEFAULT;
+}
+
 /* event_bb_insert calls instrument_mem to instrument every
  * application memory reference.
  */
 static dr_emit_flags_t
-event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
+event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *where,
                 bool for_trace, bool translating, void *user_data)
 {
     int i;
-    if (instr_get_app_pc(instr) == NULL)
+    instru_data_t *data = (instru_data_t *)user_data;
+    /* Use the drmgr_orig_app_instr_* interface to properly handle our own use
+     * of drutil_expand_rep_string() and drx_expand_scatter_gather() (as well
+     * as another client/library emulating the instruction stream).
+     */
+    instr_t *instr_fetch = drmgr_orig_app_instr_for_fetch(drcontext);
+    if (instr_fetch != NULL)
+        data->last_pc = instr_get_app_pc(instr_fetch);
+    app_pc last_pc = data->last_pc;
+    if (drmgr_is_last_instr(drcontext, where))
+        dr_thread_free(drcontext, data, sizeof(*data));
+
+    instr_t *instr_operands = drmgr_orig_app_instr_for_operands(drcontext);
+    if (instr_operands == NULL ||
+        (!instr_writes_memory(instr_operands) && !instr_reads_memory(instr_operands)))
         return DR_EMIT_DEFAULT;
-    if (instr_reads_memory(instr)) {
-        for (i = 0; i < instr_num_srcs(instr); i++) {
-            if (opnd_is_memory_reference(instr_get_src(instr, i))) {
-                instrument_mem(drcontext, bb, instr, i, false);
+    DR_ASSERT(instr_is_app(instr_operands));
+    DR_ASSERT(last_pc != NULL);
+
+    if (instr_reads_memory(instr_operands)) {
+        for (i = 0; i < instr_num_srcs(instr_operands); i++) {
+            if (opnd_is_memory_reference(instr_get_src(instr_operands, i))) {
+                instrument_mem(drcontext, bb, where, last_pc, instr_operands, i, false);
             }
         }
     }
-    if (instr_writes_memory(instr)) {
-        for (i = 0; i < instr_num_dsts(instr); i++) {
-            if (opnd_is_memory_reference(instr_get_dst(instr, i))) {
-                instrument_mem(drcontext, bb, instr, i, true);
+    if (instr_writes_memory(instr_operands)) {
+        for (i = 0; i < instr_num_dsts(instr_operands); i++) {
+            if (opnd_is_memory_reference(instr_get_dst(instr_operands, i))) {
+                instrument_mem(drcontext, bb, where, last_pc, instr_operands, i, true);
             }
         }
     }
@@ -388,14 +424,14 @@ code_cache_exit(void)
  * and jump to our own code cache to call the clean_call when the buffer is full.
  */
 static void
-instrument_mem(void *drcontext, instrlist_t *ilist, instr_t *where, int pos, bool write)
+instrument_mem(void *drcontext, instrlist_t *ilist, instr_t *where, app_pc pc,
+               instr_t *memref_instr, int pos, bool write)
 {
     instr_t *instr, *call, *restore;
     opnd_t ref, opnd1, opnd2;
     reg_id_t reg1, reg2;
     drvector_t allowed;
     per_thread_t *data;
-    app_pc pc;
 
     data = drmgr_get_tls_field(drcontext, tls_index);
 
@@ -414,9 +450,9 @@ instrument_mem(void *drcontext, instrlist_t *ilist, instr_t *where, int pos, boo
     drvector_delete(&allowed);
 
     if (write)
-        ref = instr_get_dst(where, pos);
+        ref = instr_get_dst(memref_instr, pos);
     else
-        ref = instr_get_src(where, pos);
+        ref = instr_get_src(memref_instr, pos);
 
     /* use drutil to get mem address */
     drutil_insert_get_mem_addr(drcontext, ilist, where, ref, reg1, reg2);
@@ -452,12 +488,11 @@ instrument_mem(void *drcontext, instrlist_t *ilist, instr_t *where, int pos, boo
     /* Store size in memory ref */
     opnd1 = OPND_CREATE_MEMPTR(reg2, offsetof(mem_ref_t, size));
     /* drutil_opnd_mem_size_in_bytes handles OP_enter */
-    opnd2 = OPND_CREATE_INT32(drutil_opnd_mem_size_in_bytes(ref, where));
+    opnd2 = OPND_CREATE_INT32(drutil_opnd_mem_size_in_bytes(ref, memref_instr));
     instr = INSTR_CREATE_mov_st(drcontext, opnd1, opnd2);
     instrlist_meta_preinsert(ilist, where, instr);
 
     /* Store pc in memory ref */
-    pc = instr_get_app_pc(where);
     /* For 64-bit, we can't use a 64-bit immediate so we split pc into two halves.
      * We could alternatively load it into reg1 and then store reg1.
      * We use a convenience routine that does the two-step store for us.

--- a/api/samples/memval_simple.c
+++ b/api/samples/memval_simple.c
@@ -87,12 +87,17 @@ typedef struct _mem_ref_t {
 
 #define MINSERT instrlist_meta_preinsert
 
-/* thread private log file and across-app-inst register */
+/* Thread-private log file. */
 typedef struct {
     file_t log;
     FILE *logf;
-    reg_id_t reg_addr;
 } per_thread_t;
+
+/* Cross-instrumentation-phase data. */
+typedef struct {
+    reg_id_t reg_addr;
+    int last_opcode;
+} instru_data_t;
 
 static client_id_t client_id;
 static int tls_idx;
@@ -155,7 +160,8 @@ trace_fault(void *drcontext, void *buf_base, size_t size)
 }
 
 static reg_id_t
-instrument_pre_write(void *drcontext, instrlist_t *ilist, instr_t *where, opnd_t ref)
+instrument_pre_write(void *drcontext, instrlist_t *ilist, instr_t *where, int opcode,
+                     instr_t *instr_operands, opnd_t ref)
 {
     reg_id_t reg_ptr, reg_tmp, reg_addr;
     ushort type, size;
@@ -212,11 +218,11 @@ instrument_pre_write(void *drcontext, instrlist_t *ilist, instr_t *where, opnd_t
                                   opnd_create_reg(reg_tmp)));
     }
     /* Inserts type. */
-    type = (ushort)instr_get_opcode(where);
+    type = (ushort)opcode;
     drx_buf_insert_buf_store(drcontext, trace_buffer, ilist, where, reg_ptr, reg_tmp,
                              OPND_CREATE_INT16(type), OPSZ_2, offsetof(mem_ref_t, type));
     /* Inserts size. */
-    size = (ushort)drutil_opnd_mem_size_in_bytes(ref, where);
+    size = (ushort)drutil_opnd_mem_size_in_bytes(ref, instr_operands);
     drx_buf_insert_buf_store(drcontext, trace_buffer, ilist, where, reg_ptr, reg_tmp,
                              OPND_CREATE_INT16(size), OPSZ_2, offsetof(mem_ref_t, size));
     /* If the app write segfaults, we will be unable to write to the write_buffer, which
@@ -226,7 +232,7 @@ instrument_pre_write(void *drcontext, instrlist_t *ilist, instr_t *where, opnd_t
      * the trace_buffer entry will not be committed.
      */
 
-    if (instr_is_call(where)) {
+    if (instr_is_call(instr_operands)) {
         app_pc pc;
 
         /* Note that on ARM the call instruction writes only to the link register, so
@@ -237,7 +243,7 @@ instrument_pre_write(void *drcontext, instrlist_t *ilist, instr_t *where, opnd_t
          * to the written buffer, since we can't do this after the call has happened.
          */
         drx_buf_insert_load_buf_ptr(drcontext, write_buffer, ilist, where, reg_ptr);
-        pc = decode_next_pc(drcontext, instr_get_app_pc(where));
+        pc = decode_next_pc(drcontext, instr_get_app_pc(instr_operands));
         /* note that for a circular buffer, we don't need to specify a scratch register */
         drx_buf_insert_buf_store(drcontext, trace_buffer, ilist, where, reg_ptr,
                                  DR_REG_NULL, OPND_CREATE_INTPTR((ptr_int_t)pc), OPSZ_PTR,
@@ -332,14 +338,10 @@ static dr_emit_flags_t
 event_app_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                    bool translating, void **user_data)
 {
-    per_thread_t *data = drmgr_get_tls_field(drcontext, tls_idx);
-
-    *user_data = (void *)&data->reg_addr;
-    /* If we have an outstanding write, that means we did not correctly handle a case
-     * where there was a write but no fall-through NOP or terminating instruction in
-     * the previous basic block.
-     */
-    DR_ASSERT(data->reg_addr == DR_REG_NULL);
+    instru_data_t *data = (instru_data_t *)dr_thread_alloc(drcontext, sizeof(*data));
+    data->reg_addr = DR_REG_NULL;
+    data->last_opcode = OP_INVALID;
+    *user_data = (void *)data;
     return DR_EMIT_DEFAULT;
 }
 
@@ -347,34 +349,47 @@ event_app_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
  * with an instruction entry and memory reference entries.
  */
 static dr_emit_flags_t
-event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
+event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *where,
                       bool for_trace, bool translating, void *user_data)
 {
     int i;
-    reg_id_t *reg_next = (reg_id_t *)user_data;
     bool seen_memref = false;
+    instru_data_t *data = (instru_data_t *)user_data;
 
     /* If the previous instruction was a write, we should handle it. */
-    if (*reg_next != DR_REG_NULL)
-        handle_post_write(drcontext, bb, instr, *reg_next);
-    *reg_next = DR_REG_NULL;
+    if (data->reg_addr != DR_REG_NULL)
+        handle_post_write(drcontext, bb, where, data->reg_addr);
+    data->reg_addr = DR_REG_NULL;
 
-    if (!instr_is_app(instr))
+    /* Use the drmgr_orig_app_instr_* interface to properly handle our own use
+     * of drutil_expand_rep_string() and drx_expand_scatter_gather() (as well
+     * as another client/library emulating the instruction stream).
+     */
+    instr_t *instr_fetch = drmgr_orig_app_instr_for_fetch(drcontext);
+    if (instr_fetch != NULL)
+        data->last_opcode = instr_get_opcode(instr_fetch);
+    int last_opcode = data->last_opcode;
+    if (drmgr_is_last_instr(drcontext, where))
+        dr_thread_free(drcontext, data, sizeof(*data));
+
+    instr_t *instr_operands = drmgr_orig_app_instr_for_operands(drcontext);
+    if (instr_operands == NULL || !instr_writes_memory(instr_operands))
         return DR_EMIT_DEFAULT;
-    if (!instr_writes_memory(instr))
-        return DR_EMIT_DEFAULT;
+    DR_ASSERT(instr_is_app(instr_operands));
+    DR_ASSERT(last_opcode != 0);
 
     /* XXX: See above, in handle_post_write(). To simplify the handling of registers, we
      * assume no instruction has multiple distinct memory destination operands.
      */
-    for (i = 0; i < instr_num_dsts(instr); ++i) {
-        if (opnd_is_memory_reference(instr_get_dst(instr, i))) {
+    for (i = 0; i < instr_num_dsts(instr_operands); ++i) {
+        if (opnd_is_memory_reference(instr_get_dst(instr_operands, i))) {
             if (seen_memref) {
                 DR_ASSERT_MSG(false, "Found inst with multiple memory destinations");
                 break;
             }
-            *reg_next =
-                instrument_pre_write(drcontext, bb, instr, instr_get_dst(instr, i));
+            data->reg_addr =
+                instrument_pre_write(drcontext, bb, where, last_opcode, instr_operands,
+                                     instr_get_dst(instr_operands, i));
             seen_memref = true;
         }
     }
@@ -404,7 +419,6 @@ event_thread_init(void *drcontext)
 {
     per_thread_t *data = dr_thread_alloc(drcontext, sizeof(per_thread_t));
     DR_ASSERT(data != NULL);
-    data->reg_addr = DR_REG_NULL;
     drmgr_set_tls_field(drcontext, tls_idx, data);
 
     /* We're going to dump our data to a per-thread file.


### PR DESCRIPTION
Uses the new emulation instrumentation interface in the memval_simple
and memtrace_x86 samples.

Here's the output of memval_simple before:
    $ bin64/drrun -c api/bin/libmemval_simple.so -- suite/tests/bin/allasm_repstr && cat `ls -1td api/bin/*.log|head -1`
    0x402000: movs  1 41
    0x402001: movs  1 64
    0x402002: movs  1 69
    0x402003: movs  1 6f
    0x402004: movs  1 73
And after:
    0x402000: rep movs  1 41
    0x402001: rep movs  1 64
    0x402002: rep movs  1 69
    0x402003: rep movs  1 6f
    0x402004: rep movs  1 73

Issue: #4865