### PR TITLE
i2626: AArch64 v8.0 decode: Add ADDV, MLA, MLS

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -2459,6 +2459,51 @@ encode_opnd_fpimm13(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_o
     return true;
 }
 
+/* index_lhm: imm3 from bits 21, 20 and 11 */
+
+static inline bool
+decode_opnd_index_lhm(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    uint h = extract_uint(enc, 11, 1);
+    uint l = extract_uint(enc, 21, 1);
+    uint value = (h << 1) | l;
+    opnd_size_t opsz = OPSZ_2b;
+
+    uint sz = extract_uint(enc, 22, 2);
+    if(sz < 0b01 || sz > 0b11)
+        return false;
+    if(sz == 0b01){
+        uint m = extract_uint(enc, 20, 1);
+        value = (value << 1) | m;
+        opsz = OPSZ_3b;
+    }
+
+    *opnd = opnd_create_immed_uint(value, opsz);
+    return true;
+}
+
+static inline bool
+encode_opnd_index_lhm(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    uint sz = extract_uint(enc, 22, 2);
+    if(sz < 0b01 || sz > 0b11)
+        return false;
+    if(!opnd_is_immed_int(opnd))
+        return false;
+    uint val = opnd_get_immed_int(opnd);
+    if (sz == 0b10)
+        val <<= 1;
+
+    *enc_out = 0;
+    if (val & (1 << 2))
+        *enc_out |= (1 << 11);
+    if (val & (1 << 1))
+        *enc_out |= (1 << 21);
+    if (val & 1)
+        *enc_out |= (1 << 20);
+    return true;
+}
+
 /* b_sz: Vector element width for SIMD instructions. */
 
 static inline bool

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -251,9 +251,9 @@ encode_sysreg(OUT uint *imm15, opnd_t opnd)
 static inline reg_id_t
 decode_reg(uint n, bool is_x, bool is_sp)
 {
-    return (n < 31 ? (is_x ? DR_REG_X0 : DR_REG_W0) + n
-                   : is_sp ? (is_x ? DR_REG_XSP : DR_REG_WSP)
-                           : (is_x ? DR_REG_XZR : DR_REG_WZR));
+    return (n < 31      ? (is_x ? DR_REG_X0 : DR_REG_W0) + n
+                : is_sp ? (is_x ? DR_REG_XSP : DR_REG_WSP)
+                        : (is_x ? DR_REG_XZR : DR_REG_WZR));
 }
 
 /* Encode integer register. */
@@ -2470,9 +2470,9 @@ decode_opnd_index_lhm(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
     opnd_size_t opsz = OPSZ_2b;
 
     uint sz = extract_uint(enc, 22, 2);
-    if(sz < 0b01 || sz > 0b11)
+    if (sz < 0b01 || sz > 0b11)
         return false;
-    if(sz == 0b01){
+    if (sz == 0b01) {
         uint m = extract_uint(enc, 20, 1);
         value = (value << 1) | m;
         opsz = OPSZ_3b;
@@ -2486,9 +2486,9 @@ static inline bool
 encode_opnd_index_lhm(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     uint sz = extract_uint(enc, 22, 2);
-    if(sz < 0b01 || sz > 0b11)
+    if (sz < 0b01 || sz > 0b11)
         return false;
-    if(!opnd_is_immed_int(opnd))
+    if (!opnd_is_immed_int(opnd))
         return false;
     uint val = opnd_get_immed_int(opnd);
     if (sz == 0b10)

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -251,9 +251,9 @@ encode_sysreg(OUT uint *imm15, opnd_t opnd)
 static inline reg_id_t
 decode_reg(uint n, bool is_x, bool is_sp)
 {
-    return (n < 31      ? (is_x ? DR_REG_X0 : DR_REG_W0) + n
-                : is_sp ? (is_x ? DR_REG_XSP : DR_REG_WSP)
-                        : (is_x ? DR_REG_XZR : DR_REG_WZR));
+    return (n < 31 ? (is_x ? DR_REG_X0 : DR_REG_W0) + n
+                   : is_sp ? (is_x ? DR_REG_XSP : DR_REG_WSP)
+                           : (is_x ? DR_REG_XZR : DR_REG_WZR));
 }
 
 /* Encode integer register. */

--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -131,6 +131,7 @@
                                              # elements, depending on bit 22 (sz)
 ---------x----------------------  sd_sz      # element width of FP vector reg for single
 --------??-xxxxxxxx-------------  fpimm13    # floating-point immediate for scalar fmov
+--------??xx--------x-----------  index_lhm  # imm3 from bits 11, 21 and/or 20 inferred from sz
 --------xx----------------------  b_sz       # element width of a vector (8<<b_sz)
 --------xx----------------------  hs_sz      # element width of a vector (8<<hs_sz)
 --------xx----------------------  bhs_sz     # element width of a vector (8<<bhs_sz)
@@ -1037,6 +1038,7 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0x001110xx1xxxxx100001xxxxxxxxxx     add       dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx100011xxxxxxxxxx     cmtst     dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx100101xxxxxxxxxx     mla       dq0 : dq0 dq5 dq16 bhs_sz
+0x101111xxxxxxxx0000x0xxxxxxxxxx     mla       dq0 : dq5 dq16_h_sz bhsd_sz index_lhm
 0x001110xx1xxxxx100111xxxxxxxxxx     mul       dq0 : dq5 dq16 bhs_sz
 0x001111xxxxxxxx1000x0xxxxxxxxxx     mul       dq0 : dq5 dq16_h_sz vindex_H hs_sz
 0x001110xx1xxxxx101001xxxxxxxxxx     smaxp     dq0 : dq5 dq16 bhs_sz
@@ -1080,6 +1082,7 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0x101110xx1xxxxx100001xxxxxxxxxx     sub       dq0 : dq5 dq16 bhsd_sz
 0x101110xx1xxxxx100011xxxxxxxxxx     cmeq      dq0 : dq5 dq16 bhsd_sz
 0x101110xx1xxxxx100101xxxxxxxxxx     mls       dq0 : dq0 dq5 dq16 bhs_sz
+0x101111xxxxxxxx0100x0xxxxxxxxxx     mls       dq0 : dq5 dq16_h_sz bhsd_sz index_lhm
 0x101110xx1xxxxx100111xxxxxxxxxx     pmul      dq0 : dq5 dq16 b_sz
 0x101110xx1xxxxx101001xxxxxxxxxx     umaxp     dq0 : dq5 dq16 bhs_sz
 0x101110xx1xxxxx101011xxxxxxxxxx     uminp     dq0 : dq5 dq16 bhs_sz
@@ -1333,3 +1336,5 @@ x001111001000010xxxxxxxxxxxxxxxx     scvtf     d0 : wx5 scale
 
 00001110000xxxxx001011xxxxxxxxxx     smov      w0 : d5 imm5
 01001110000xxxxx001011xxxxxxxxxx     smov      x0 : q5 imm5
+
+0x001110xx110001101110xxxxxxxxxx     addv      dq0 : dq5 bhsd_sz

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -83,6 +83,37 @@ ba030041 : adcs   x1, x2, x3              : adcs   %x2 %x3 -> %x1
 4eafbf9a : addp v26.4s, v28.4s, v15.4s              : addp   %q28 %q15 $0x02 -> %q26
 4eefbf9a : addp v26.2d, v28.2d, v15.2d              : addp   %q28 %q15 $0x03 -> %q26
 
+# ADDV <V><d>, <Vn>.<T>
+# ADDV b<d>, <Vn>.8b
+0e31b820 : addv b0, v1.8b                   : addv   %d1 $0x00 -> %d0
+0e31b96a : addv b10, v11.8b                 : addv   %d11 $0x00 -> %d10
+0e31bab4 : addv b20, v21.8b                 : addv   %d21 $0x00 -> %d20
+0e31bbbe : addv b30, v29.8b                 : addv   %d29 $0x00 -> %d30
+
+# ADDV b<d>, <Vn>.16b
+4e31b820 : addv b0, v1.16b                  : addv   %q1 $0x00 -> %q0
+4e31b96a : addv b10, v11.16b                : addv   %q11 $0x00 -> %q10
+4e31bab4 : addv b20, v21.16b                : addv   %q21 $0x00 -> %q20
+4e31bbbe : addv b30, v29.16b                : addv   %q29 $0x00 -> %q30
+
+# ADDV h<d>, <Vn>.4h
+0e71b820 : addv h0, v1.4h                   : addv   %d1 $0x01 -> %d0
+0e71b96a : addv h10, v11.4h                 : addv   %d11 $0x01 -> %d10
+0e71bab4 : addv h20, v21.4h                 : addv   %d21 $0x01 -> %d20
+0e71bbbe : addv h30, v29.4h                 : addv   %d29 $0x01 -> %d30
+
+# ADDV h<d>, <Vn>.8h
+4e71b820 : addv h0, v1.8h                   : addv   %q1 $0x01 -> %q0
+4e71b96a : addv h10, v11.8h                 : addv   %q11 $0x01 -> %q10
+4e71bab4 : addv h20, v21.8h                 : addv   %q21 $0x01 -> %q20
+4e71bbbe : addv h30, v29.8h                 : addv   %q29 $0x01 -> %q30
+
+# ADDV s<d>, <Vn>.4s
+4eb1b820 : addv s0, v1.4s                   : addv   %q1 $0x02 -> %q0
+4eb1b96a : addv s10, v11.4s                 : addv   %q11 $0x02 -> %q10
+4eb1bab4 : addv s20, v21.4s                 : addv   %q21 $0x02 -> %q20
+4eb1bbbe : addv s30, v29.4s                 : addv   %q29 $0x02 -> %q30
+
 2b031041 : adds   w1, w2, w3, lsl #4      : adds   %w2 %w3 lsl $0x04 -> %w1
 31000c41 : adds   w1, w2, #0x3            : adds   %w2 $0x0003 lsl $0x00 -> %w1
 ab431041 : adds   x1, x2, x3, lsr #4      : adds   %x2 %x3 lsr $0x04 -> %x1
@@ -2241,12 +2272,94 @@ d37fffff : lsr    xzr, xzr, #63           : ubfm   %xzr $0x3f $0x3f -> %xzr
 0ea49662 : mla v2.2s, v19.2s, v4.2s                 : mla    %d2 %d19 %d4 $0x02 -> %d2
 4ea49662 : mla v2.4s, v19.4s, v4.4s                 : mla    %q2 %q19 %q4 $0x02 -> %q2
 
+# MLA <Vd>.<T>, <Vn>.<T>, <Vm>.<Ts>[<index>]
+# MLA <Vd>.4h, <Vn>.4h, <Vm>.h[<index>]
+2f420020 : mla v0.4h, v1.4h, v2.h[0]                : mla    %d1 %d2 $0x01 $0x00 -> %d0
+2f520020 : mla v0.4h, v1.4h, v2.h[1]                : mla    %d1 %d2 $0x01 $0x01 -> %d0
+2f620020 : mla v0.4h, v1.4h, v2.h[2]                : mla    %d1 %d2 $0x01 $0x02 -> %d0
+2f720020 : mla v0.4h, v1.4h, v2.h[3]                : mla    %d1 %d2 $0x01 $0x03 -> %d0
+2f420820 : mla v0.4h, v1.4h, v2.h[4]                : mla    %d1 %d2 $0x01 $0x04 -> %d0
+2f520820 : mla v0.4h, v1.4h, v2.h[5]                : mla    %d1 %d2 $0x01 $0x05 -> %d0
+2f620820 : mla v0.4h, v1.4h, v2.h[6]                : mla    %d1 %d2 $0x01 $0x06 -> %d0
+2f720820 : mla v0.4h, v1.4h, v2.h[7]                : mla    %d1 %d2 $0x01 $0x07 -> %d0
+2f79090a : mla v10.4h, v8.4h, v9.h[7]               : mla    %d8 %d9 $0x01 $0x07 -> %d10
+2f7e09af : mla v15.4h, v13.4h, v14.h[7]             : mla    %d13 %d14 $0x01 $0x07 -> %d15
+
+# MLA <Vd>.8h, <Vn>.8h, <Vm>.h[<index>]
+6f420020 : mla v0.8h, v1.8h, v2.h[0]                : mla    %q1 %q2 $0x01 $0x00 -> %q0
+6f520020 : mla v0.8h, v1.8h, v2.h[1]                : mla    %q1 %q2 $0x01 $0x01 -> %q0
+6f620020 : mla v0.8h, v1.8h, v2.h[2]                : mla    %q1 %q2 $0x01 $0x02 -> %q0
+6f720020 : mla v0.8h, v1.8h, v2.h[3]                : mla    %q1 %q2 $0x01 $0x03 -> %q0
+6f420820 : mla v0.8h, v1.8h, v2.h[4]                : mla    %q1 %q2 $0x01 $0x04 -> %q0
+6f520820 : mla v0.8h, v1.8h, v2.h[5]                : mla    %q1 %q2 $0x01 $0x05 -> %q0
+6f620820 : mla v0.8h, v1.8h, v2.h[6]                : mla    %q1 %q2 $0x01 $0x06 -> %q0
+6f720820 : mla v0.8h, v1.8h, v2.h[7]                : mla    %q1 %q2 $0x01 $0x07 -> %q0
+6f79090a : mla v10.8h, v8.8h, v9.h[7]               : mla    %q8 %q9 $0x01 $0x07 -> %q10
+6f7e09af : mla v15.8h, v13.8h, v14.h[7]             : mla    %q13 %q14 $0x01 $0x07 -> %q15
+
+# MLA <Vd>.2s, <Vn>.2s, <Vm>.s[<index>]
+2f820020 : mla v0.2s, v1.2s, v2.s[0]                : mla    %d1 %d2 $0x02 $0x00 -> %d0
+2fa20020 : mla v0.2s, v1.2s, v2.s[1]                : mla    %d1 %d2 $0x02 $0x01 -> %d0
+2f820820 : mla v0.2s, v1.2s, v2.s[2]                : mla    %d1 %d2 $0x02 $0x02 -> %d0
+2fa20820 : mla v0.2s, v1.2s, v2.s[3]                : mla    %d1 %d2 $0x02 $0x03 -> %d0
+2fa9090a : mla v10.2s, v8.2s, v9.s[3]               : mla    %d8 %d9 $0x02 $0x03 -> %d10
+2fae09af : mla v15.2s, v13.2s, v14.s[3]             : mla    %d13 %d14 $0x02 $0x03 -> %d15
+
+# MLA <Vd>.4s, <Vn>.4s, <Vm>.s[<index>]
+6f820020 : mla v0.4s, v1.4s, v2.s[0]                : mla    %q1 %q2 $0x02 $0x00 -> %q0
+6fa20020 : mla v0.4s, v1.4s, v2.s[1]                : mla    %q1 %q2 $0x02 $0x01 -> %q0
+6f820820 : mla v0.4s, v1.4s, v2.s[2]                : mla    %q1 %q2 $0x02 $0x02 -> %q0
+6fa20820 : mla v0.4s, v1.4s, v2.s[3]                : mla    %q1 %q2 $0x02 $0x03 -> %q0
+6fa9090a : mla v10.4s, v8.4s, v9.s[3]               : mla    %q8 %q9 $0x02 $0x03 -> %q10
+6fae09af : mla v15.4s, v13.4s, v14.s[3]             : mla    %q13 %q14 $0x02 $0x03 -> %q15
+
 2e3b95a7 : mls v7.8b, v13.8b, v27.8b                : mls    %d7 %d13 %d27 $0x00 -> %d7
 6e3b95a7 : mls v7.16b, v13.16b, v27.16b             : mls    %q7 %q13 %q27 $0x00 -> %q7
 2e7b95a7 : mls v7.4h, v13.4h, v27.4h                : mls    %d7 %d13 %d27 $0x01 -> %d7
 6e7b95a7 : mls v7.8h, v13.8h, v27.8h                : mls    %q7 %q13 %q27 $0x01 -> %q7
 2ebb95a7 : mls v7.2s, v13.2s, v27.2s                : mls    %d7 %d13 %d27 $0x02 -> %d7
 6ebb95a7 : mls v7.4s, v13.4s, v27.4s                : mls    %q7 %q13 %q27 $0x02 -> %q7
+
+# MLS <Vd>.<T>, <Vn>.<T>, <Vm>.<Ts>[<index>]
+# MLS <Vd>.4h, <Vn>.4h, <Vm>.h[<index>]
+2f424020 : mls v0.4h, v1.4h, v2.h[0]                : mls    %d1 %d2 $0x01 $0x00 -> %d0
+2f524020 : mls v0.4h, v1.4h, v2.h[1]                : mls    %d1 %d2 $0x01 $0x01 -> %d0
+2f624020 : mls v0.4h, v1.4h, v2.h[2]                : mls    %d1 %d2 $0x01 $0x02 -> %d0
+2f724020 : mls v0.4h, v1.4h, v2.h[3]                : mls    %d1 %d2 $0x01 $0x03 -> %d0
+2f424820 : mls v0.4h, v1.4h, v2.h[4]                : mls    %d1 %d2 $0x01 $0x04 -> %d0
+2f524820 : mls v0.4h, v1.4h, v2.h[5]                : mls    %d1 %d2 $0x01 $0x05 -> %d0
+2f624820 : mls v0.4h, v1.4h, v2.h[6]                : mls    %d1 %d2 $0x01 $0x06 -> %d0
+2f724820 : mls v0.4h, v1.4h, v2.h[7]                : mls    %d1 %d2 $0x01 $0x07 -> %d0
+2f79490a : mls v10.4h, v8.4h, v9.h[7]               : mls    %d8 %d9 $0x01 $0x07 -> %d10
+2f7e49af : mls v15.4h, v13.4h, v14.h[7]             : mls    %d13 %d14 $0x01 $0x07 -> %d15
+
+# MLS <Vd>.8h, <Vn>.8h, <Vm>.h[<index>]
+6f424020 : mls v0.8h, v1.8h, v2.h[0]                : mls    %q1 %q2 $0x01 $0x00 -> %q0
+6f524020 : mls v0.8h, v1.8h, v2.h[1]                : mls    %q1 %q2 $0x01 $0x01 -> %q0
+6f624020 : mls v0.8h, v1.8h, v2.h[2]                : mls    %q1 %q2 $0x01 $0x02 -> %q0
+6f724020 : mls v0.8h, v1.8h, v2.h[3]                : mls    %q1 %q2 $0x01 $0x03 -> %q0
+6f424820 : mls v0.8h, v1.8h, v2.h[4]                : mls    %q1 %q2 $0x01 $0x04 -> %q0
+6f524820 : mls v0.8h, v1.8h, v2.h[5]                : mls    %q1 %q2 $0x01 $0x05 -> %q0
+6f624820 : mls v0.8h, v1.8h, v2.h[6]                : mls    %q1 %q2 $0x01 $0x06 -> %q0
+6f724820 : mls v0.8h, v1.8h, v2.h[7]                : mls    %q1 %q2 $0x01 $0x07 -> %q0
+6f79490a : mls v10.8h, v8.8h, v9.h[7]               : mls    %q8 %q9 $0x01 $0x07 -> %q10
+6f7e49af : mls v15.8h, v13.8h, v14.h[7]             : mls    %q13 %q14 $0x01 $0x07 -> %q15
+
+# MLS <Vd>.2s, <Vn>.2s, <Vm>.s[<index>]
+2f824020 : mls v0.2s, v1.2s, v2.s[0]                : mls    %d1 %d2 $0x02 $0x00 -> %d0
+2fa24020 : mls v0.2s, v1.2s, v2.s[1]                : mls    %d1 %d2 $0x02 $0x01 -> %d0
+2f824820 : mls v0.2s, v1.2s, v2.s[2]                : mls    %d1 %d2 $0x02 $0x02 -> %d0
+2fa24820 : mls v0.2s, v1.2s, v2.s[3]                : mls    %d1 %d2 $0x02 $0x03 -> %d0
+2fa9490a : mls v10.2s, v8.2s, v9.s[3]               : mls    %d8 %d9 $0x02 $0x03 -> %d10
+2fae49af : mls v15.2s, v13.2s, v14.s[3]             : mls    %d13 %d14 $0x02 $0x03 -> %d15
+
+# MLS <Vd>.4s, <Vn>.4s, <Vm>.s[<index>]
+6f824020 : mls v0.4s, v1.4s, v2.s[0]                : mls    %q1 %q2 $0x02 $0x00 -> %q0
+6fa24020 : mls v0.4s, v1.4s, v2.s[1]                : mls    %q1 %q2 $0x02 $0x01 -> %q0
+6f824820 : mls v0.4s, v1.4s, v2.s[2]                : mls    %q1 %q2 $0x02 $0x02 -> %q0
+6fa24820 : mls v0.4s, v1.4s, v2.s[3]                : mls    %q1 %q2 $0x02 $0x03 -> %q0
+6fa9490a : mls v10.4s, v8.4s, v9.s[3]               : mls    %q8 %q9 $0x02 $0x03 -> %q10
+6fae49af : mls v15.4s, v13.4s, v14.s[3]             : mls    %q13 %q14 $0x02 $0x03 -> %q15
 
 1b03fc41 : mneg   w1, w2, w3              : msub   %w2 %w3 %wzr -> %w1
 


### PR DESCRIPTION
Adds the following instructions to the codec:
- ADDV
- MLA (by element)
- MLS (by element)

Issue: #2626