### PR TITLE
i#4857 icount: Include instr count in filtered trace unit header

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -167,7 +167,8 @@ droption_t<bool> op_L0_filter(
     "that miss in this initial cache.  This cache is direct-mapped with sizes equal to "
     "-L0I_size and -L0D_size.  It uses virtual addresses regardless of -use_physical. "
     "The dynamic (pre-filtered) per-thread instruction count is tracked and supplied "
-    "via a #TRACE_MARKER_TYPE_INSTRUCTION_COUNT marker at thread exit.");
+    "via a #TRACE_MARKER_TYPE_INSTRUCTION_COUNT marker at thread buffer boundaries "
+    "and at thread exit.");
 
 droption_t<bytesize_t> op_L0I_size(
     DROPTION_SCOPE_CLIENT, "L0I_size", 32 * 1024U,

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -1012,7 +1012,7 @@ flow such as signal handler entry and exit.
 
 Filtered traces (filtered via -L0_filter) include the dynamic (pre-filtered)
 per-thread instruction count in a #TRACE_MARKER_TYPE_INSTRUCTION_COUNT marker at
-thread exit.
+each thread buffer boundary and at thread exit.
 
 A final feature that aids core simulators is the pair of interfaces
 module_mapper_t::get_loaded_modules() and

--- a/clients/drcachesim/tests/trace_invariants.cpp
+++ b/clients/drcachesim/tests/trace_invariants.cpp
@@ -92,12 +92,8 @@ trace_invariants_t::process_memref(const memref_t &memref)
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_INSTRUCTION_COUNT) {
         found_instr_count_marker_[memref.marker.tid] = true;
-        if (knob_test_name_ == "filter_asm_instr_count") {
-#ifndef NDEBUG
-            static constexpr int ASM_INSTR_COUNT = 133;
-#endif
-            assert(memref.marker.marker_value == ASM_INSTR_COUNT);
-        }
+        assert(memref.marker.marker_value >= last_instr_count_marker_[memref.marker.tid]);
+        last_instr_count_marker_[memref.marker.tid] = memref.marker.marker_value;
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_CACHE_LINE_SIZE) {
@@ -108,6 +104,12 @@ trace_invariants_t::process_memref(const memref_t &memref)
         assert(!TESTALL(OFFLINE_FILE_TYPE_FILTERED, file_type_) ||
                found_instr_count_marker_[memref.exit.tid]);
         assert(found_cache_line_size_marker_[memref.exit.tid]);
+        if (knob_test_name_ == "filter_asm_instr_count") {
+#ifndef NDEBUG
+            static constexpr int ASM_INSTR_COUNT = 133;
+#endif
+            assert(last_instr_count_marker_[memref.exit.tid] == ASM_INSTR_COUNT);
+        }
         thread_exited_[memref.exit.tid] = true;
     }
     if (type_is_instr(memref.instr.type) ||

--- a/clients/drcachesim/tests/trace_invariants.h
+++ b/clients/drcachesim/tests/trace_invariants.h
@@ -66,6 +66,7 @@ protected:
     std::unordered_map<memref_tid_t, bool> thread_exited_;
     std::unordered_map<memref_tid_t, bool> found_cache_line_size_marker_;
     std::unordered_map<memref_tid_t, bool> found_instr_count_marker_;
+    std::unordered_map<memref_tid_t, uint64_t> last_instr_count_marker_;
 };
 
 #endif /* _TRACE_INVARIANTS_H_ */

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -139,8 +139,20 @@ view_t::process_memref(const memref_t &memref)
         case TRACE_MARKER_TYPE_KERNEL_XFER:
             std::cerr << "<marker: syscall xfer>\n";
             break;
+        case TRACE_MARKER_TYPE_INSTRUCTION_COUNT:
+            std::cerr << "<marker: instruction count " << memref.marker.marker_value
+                      << ">\n";
+            break;
+        case TRACE_MARKER_TYPE_FILETYPE:
+            std::cerr << "<marker: filetype " << memref.marker.marker_value << ">\n";
+            break;
+        case TRACE_MARKER_TYPE_CACHE_LINE_SIZE:
+            std::cerr << "<marker: cache line size " << memref.marker.marker_value
+                      << ">\n";
+            break;
         default:
-            // We ignore other markers such as call/ret profiling for now.
+            std::cerr << "<marker: type " << memref.marker.marker_type << "; value "
+                      << memref.marker.marker_value << ">\n";
             break;
         }
         return true;


### PR DESCRIPTION
Adds the instruction count to the buffer header for drcachesim
filtered traces, instead of just at thread exit, to aid in correlating
filtered and unfiltered traces.

Updates the documentation and the trace_invariants test.

Augments the view tool to print out these markers.
Further verified manually on a larger trace with the view tool:

    <marker: filetype 65>
    <marker: cache line size 64>
    <marker: timestamp 13268850698443940>
    <marker: tid 2539348 on core 1>
    <marker: instruction count 33326>
      0x00007f6f64314090  48 89 e7             mov    %rsp, %rdi
      0x00007f6f6432dce0  b8 0c 00 00 00       mov    $0x0000000c, %eax
    <marker: timestamp 13268850698727951>
    <marker: tid 2539348 on core 1>
    <marker: instruction count 40130>
      0x00007f6f6432c906  c7 44 24 3c 00 00 00 movl   $0x00000000, 0x3c(%rsp)
    <...>
      0x00007f6f63cc3670  4c 8b 05 f9 27 0f 00 mov    <rel> 0x00007f6f63db5e70, %r8
    <marker: timestamp 13268850699555438>
    <marker: tid 2539348 on core 1>
    <marker: instruction count 126115>

Fixes #4857