### PR TITLE
i#4963 burst_thread failure: Use tmate to debug on GA VM

### DIFF
--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -63,12 +63,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Cancel any prior runs for a PR (but do not cancel master branch runs).
-    - uses: n1hility/cancel-previous-runs@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ github.event_name == 'pull_request' }}
-
     # We also need origin/master for pre-commit source file checks in runsuite.cmake.
     # But fetching multiple branches isn't supported yet: actions/checkout#214
     # Pending PR that adds this support actions/checkout#155

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -97,6 +97,9 @@ jobs:
         CI_TRIGGER: ${{ github.event_name }}
         CI_BRANCH: ${{ github.ref }}
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
     - name: Send failure mail to dynamorio-devs
       if: failure() && github.ref == 'refs/heads/master'
       uses: dawidd6/action-send-mail@v2

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -129,12 +129,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Cancel any prior runs for a PR (but do not cancel master branch runs).
-    - uses: n1hility/cancel-previous-runs@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ github.event_name == 'pull_request' }}
-
     - run: git fetch --no-tags --depth=1 origin master
 
     # Install multilib for non-cross-compiling Linux build.

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -97,7 +97,11 @@ jobs:
         CI_TRIGGER: ${{ github.event_name }}
         CI_BRANCH: ${{ github.ref }}
 
-    - name: Setup tmate session
+    - name: Setup tmate session if failure
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
+
+    - name: Setup tmate session anyway
       uses: mxschmitt/action-tmate@v3
 
     - name: Send failure mail to dynamorio-devs


### PR DESCRIPTION
Set up tmate session on GA runner to debugging some flakiness on drcachesim.burst_threads test. This is not to be checked-in.

Issue: #4963