### PR TITLE
i#2626 AArch64 Decode: Fix imm5 decode bits

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1888,7 +1888,7 @@ encode_opnd_ign16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out
 static inline bool
 decode_opnd_imm5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    return decode_opnd_int(16, 5, false, 0, OPSZ_6b, 0, enc, opnd);
+    return decode_opnd_int(16, 5, false, 0, OPSZ_5b, 0, enc, opnd);
 }
 
 static inline bool


### PR DESCRIPTION
Change imm5 bitsize from 6 to 5

Issue: #2626