### PR TITLE
i#2626 AArch64 Decode: Add Saturating SIMD instructions

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -150,6 +150,7 @@ extract_int(uint enc, int pos, int len)
 static inline ptr_uint_t
 extract_uint(uint enc, int pos, int len)
 {
+    /* pos starts at bit 0 and len includes pos bit as part of its length. */
     return enc >> pos & (((uint)1 << len) - 1);
 }
 

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1297,6 +1297,19 @@ encode_opnd_x5sp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     return encode_opnd_wxn(true, true, 5, opnd, enc_out);
 }
 
+/* b5: B register at bit position 5 */
+static inline bool
+decode_opnd_b5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_vector_reg(5, 0, enc, opnd);
+}
+
+static inline bool
+encode_opnd_b5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_vector_reg(5, 0, opnd, enc_out);
+}
+
 /* h5: H register at bit position 5 */
 
 static inline bool
@@ -1809,6 +1822,21 @@ encode_opnd_sysops(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_ou
     return encode_opnd_int(5, 14, false, 0, 0, opnd, enc_out);
 }
 
+/* wx5_imm5: bits 5-9 is a GPR whos width is dependent on information in
+   an imm5 from bits 16-20
+*/
+static inline bool
+decode_opnd_imm4_16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_int(16, 4, false, 0, OPSZ_4b, 0, enc, opnd);
+}
+
+static inline bool
+encode_opnd_imm4_16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_int(16, 4, false, 0, 0, opnd, enc_out);
+}
+
 /* sysreg: system register, operand of MRS/MSR */
 
 static inline bool
@@ -2022,6 +2050,48 @@ static inline bool
 encode_opnd_z16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_z(16, opnd, enc_out);
+}
+
+/* b16: B register at bit position 16. */
+
+static inline bool
+decode_opnd_b16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_vector_reg(16, 0, enc, opnd);
+}
+
+static inline bool
+encode_opnd_b16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_vector_reg(16, 0, opnd, enc_out);
+}
+
+/* h16: H register at bit position 16. */
+
+static inline bool
+decode_opnd_h16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_vector_reg(16, 1, enc, opnd);
+}
+
+static inline bool
+encode_opnd_h16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_vector_reg(16, 1, opnd, enc_out);
+}
+
+/* s16: S register at bit position 16. */
+
+static inline bool
+decode_opnd_s16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_vector_reg(16, 2, enc, opnd);
+}
+
+static inline bool
+encode_opnd_s16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_vector_reg(16, 2, opnd, enc_out);
 }
 
 /* mem9off: just the 9-bit offset from mem9 */
@@ -2576,35 +2646,16 @@ decode_opnd_index_lhm(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
     uint h = extract_uint(enc, 11, 1);
     uint l = extract_uint(enc, 21, 1);
-    uint value = (h << 1) | l;
-    opnd_size_t opsz = OPSZ_2b;
-
-    uint sz = extract_uint(enc, 22, 2);
-    if (sz < 0b01 || sz > 0b11)
-        return false;
-    if (sz == 0b01) {
-        uint m = extract_uint(enc, 20, 1);
-        value = (value << 1) | m;
-        opsz = OPSZ_3b;
-    }
-
-    *opnd = opnd_create_immed_uint(value, opsz);
+    uint m = extract_uint(enc, 20, 1);
+    uint value = (h << 2) | (l << 1) | m;
+    *opnd = opnd_create_immed_uint(value, OPSZ_3b);
     return true;
 }
 
 static inline bool
 encode_opnd_index_lhm(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
-    uint sz = extract_uint(enc, 22, 2);
-    if (sz < 0b01 || sz > 0b11)
-        return false;
-    if (!opnd_is_immed_int(opnd))
-        return false;
     uint val = opnd_get_immed_int(opnd);
-    if (sz == 0b10)
-        val <<= 1;
-
-    *enc_out = 0;
     if (val & (1 << 2))
         *enc_out |= (1 << 11);
     if (val & (1 << 1))

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -2347,6 +2347,32 @@ encode_opnd_vindex_H(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_
     return true;
 }
 
+/* index_lhm: imm3 from bits 21, 20 and 11 */
+
+static inline bool
+decode_opnd_index_lhm(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    uint h = extract_uint(enc, 11, 1);
+    uint l = extract_uint(enc, 21, 1);
+    uint m = extract_uint(enc, 20, 1);
+    uint value = (h << 2) | (l << 1) | m;
+    *opnd = opnd_create_immed_uint(value, OPSZ_3b);
+    return true;
+}
+
+static inline bool
+encode_opnd_index_lhm(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    uint val = opnd_get_immed_int(opnd);
+    if (val & (1 << 2))
+        *enc_out |= (1 << 11);
+    if (val & (1 << 1))
+        *enc_out |= (1 << 21);
+    if (val & 1)
+        *enc_out |= (1 << 20);
+    return true;
+}
+
 /* immhb: The vector encoding of #fbits operand. This is the number of bits
  * after the decimal point for fixed-point values.
  */
@@ -2634,32 +2660,6 @@ encode_opnd_fpimm13(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_o
     } else
         return false;
 
-    return true;
-}
-
-/* index_lhm: imm3 from bits 21, 20 and 11 */
-
-static inline bool
-decode_opnd_index_lhm(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
-{
-    uint h = extract_uint(enc, 11, 1);
-    uint l = extract_uint(enc, 21, 1);
-    uint m = extract_uint(enc, 20, 1);
-    uint value = (h << 2) | (l << 1) | m;
-    *opnd = opnd_create_immed_uint(value, OPSZ_3b);
-    return true;
-}
-
-static inline bool
-encode_opnd_index_lhm(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
-{
-    uint val = opnd_get_immed_int(opnd);
-    if (val & (1 << 2))
-        *enc_out |= (1 << 11);
-    if (val & (1 << 1))
-        *enc_out |= (1 << 21);
-    if (val & 1)
-        *enc_out |= (1 << 20);
     return true;
 }
 

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1822,15 +1822,15 @@ encode_opnd_sysops(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_ou
     return encode_opnd_int(5, 14, false, 0, 0, opnd, enc_out);
 }
 
-/* imm4_16: imm4 from bits 16-20 */
+/* dq16_idx_lhm: imm4 from bits 16-20, the lower 4 bits of register Rm with idx_lhm */
 static inline bool
-decode_opnd_imm4_16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+decode_opnd_dq16_idx_lhm(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
     return decode_opnd_int(16, 4, false, 0, OPSZ_4b, 0, enc, opnd);
 }
 
 static inline bool
-encode_opnd_imm4_16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+encode_opnd_dq16_idx_lhm(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_int(16, 4, false, 0, 0, opnd, enc_out);
 }
@@ -2347,10 +2347,10 @@ encode_opnd_vindex_H(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_
     return true;
 }
 
-/* index_lhm: imm3 from bits 21, 20 and 11 */
+/* idx_lhm: imm3 from bits 21, 20 and 11 */
 
 static inline bool
-decode_opnd_index_lhm(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+decode_opnd_idx_lhm(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
     uint h = extract_uint(enc, 11, 1);
     uint l = extract_uint(enc, 21, 1);
@@ -2361,7 +2361,7 @@ decode_opnd_index_lhm(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 }
 
 static inline bool
-encode_opnd_index_lhm(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+encode_opnd_idx_lhm(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     uint val = opnd_get_immed_int(opnd);
     if (val & (1 << 2))

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1822,9 +1822,7 @@ encode_opnd_sysops(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_ou
     return encode_opnd_int(5, 14, false, 0, 0, opnd, enc_out);
 }
 
-/* wx5_imm5: bits 5-9 is a GPR whos width is dependent on information in
-   an imm5 from bits 16-20
-*/
+/* imm4_16: imm4 from bits 16-20 */
 static inline bool
 decode_opnd_imm4_16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {

--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -939,6 +939,7 @@ x0011010100xxxxxxxxx00xxxxxxxxxx  csel   wx0 : wx5 wx16 cond
 x0011010100xxxxxxxxx01xxxxxxxxxx  csinc  wx0 : wx5 wx16 cond
 x1011010100xxxxxxxxx00xxxxxxxxxx  csinv  wx0 : wx5 wx16 cond
 x1011010100xxxxxxxxx01xxxxxxxxxx  csneg  wx0 : wx5 wx16 cond
+00011110xx1xxxxxxxxx11xxxxxxxxxx  fcsel  float_reg0 : float_reg5 float_reg16 cond
 
 # Data-processing (3 source)
 
@@ -1143,6 +1144,14 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0001111001100011110000xxxxxxxxxx     fcvt      h0 : d5
 0001111011100010010000xxxxxxxxxx     fcvt      s0 : h5
 0001111011100010110000xxxxxxxxxx     fcvt      d0 : h5
+00011110xx1xxxxx001000xxxxx00000     fcmp      float_reg5 : float_reg16
+00011110xx100000001000xxxxx01000     fcmp      float_reg5 : bhsd_sz
+00011110xx1xxxxxxxxx01xxxxx0xxxx     fccmp     float_reg5 : float_reg16 cond nzcv
+00011110xx1xxxxxxxxx01xxxxx1xxxx     fccmpe    float_reg5 : float_reg16 cond nzcv
+0x10111000110000111110xxxxxxxxxx     fmaxv     s0 : dq5
+0x00111000110000111110xxxxxxxxxx     fmaxv     h0 : dq5
+0x10111010110000111110xxxxxxxxxx     fminv     s0 : dq5
+0x00111010110000111110xxxxxxxxxx     fminv     h0 : dq5
 
 # Floating-point convert (scalar)
 0001111000100100000000xxxxxxxxxx     fcvtas    w0 : s5

--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -131,6 +131,7 @@
 ----------?xxxxx--?-??----------  x16immvr   # computes immed from 21, 13 and 11:10
 ----------?xxxxx???-??----------  x16immvs   # computes immed from 21, 15:13 and 11:10
 ----------xx--------x-----------  vindex_H   # Index for vector with half elements (0-7)
+----------xx--------x-----------  index_lhm  # imm3 from bits 11, 21 and/or 20 inferred from sz
 ----------xxxxxx----------------  immhb      # encoding of #fbits value in immh:immb fields
 ----------xxxxxxxxxxxx----------  imm12      # immediate for ADD/SUB
 ----------xxxxxxxxxxxxxxxxx-----  mem12q     # size is 16 bytes
@@ -140,7 +141,6 @@
                                              # elements, depending on bit 22 (sz)
 ---------x----------------------  sd_sz      # element width of FP vector reg for single
 --------??-xxxxxxxx-------------  fpimm13    # floating-point immediate for scalar fmov
-----------xx--------x-----------  index_lhm  # imm3 from bits 11, 21 and/or 20 inferred from sz
 --------xx----------------------  b_sz       # element width of a vector (8<<b_sz)
 --------xx----------------------  hs_sz      # element width of a vector (8<<hs_sz)
 --------xx----------------------  bhs_sz     # element width of a vector (8<<bhs_sz)

--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -103,7 +103,7 @@
 -------------xxx------xxxxx-----  fpimm8     # floating-point immediate for vector fmov
 -------------xxx------xxxxx-----  imm8       # immediate from 16:18 and 5:10
 -------------xxxxxxxxxxxxxx-----  sysops     # immediate operands for SYS
-------------xxxx----------------  imm4_16    # imm4 from bits 16-20
+------------xxxx----------------  dq16_idx_lhm # lower 4 bits of Rm with idx_lhm
 ------------xxxxxxxxxxxxxxx-----  sysreg     # operand of MRS
 -----------?????------xxxxx-----  wx5_imm5   # reg 5-9 d or q is inferred from bits 16:20
 -----------xxxxx----------------  ign16      # ignored reg field in load/store exclusive
@@ -131,7 +131,7 @@
 ----------?xxxxx--?-??----------  x16immvr   # computes immed from 21, 13 and 11:10
 ----------?xxxxx???-??----------  x16immvs   # computes immed from 21, 15:13 and 11:10
 ----------xx--------x-----------  vindex_H   # Index for vector with half elements (0-7)
-----------xx--------x-----------  index_lhm  # imm3 from bits 11, 21 and/or 20 inferred from sz
+----------xx--------x-----------  idx_lhm    # imm3 from bits 11, 21 and/or 20 inferred from sz
 ----------xxxxxx----------------  immhb      # encoding of #fbits value in immh:immb fields
 ----------xxxxxxxxxxxx----------  imm12      # immediate for ADD/SUB
 ----------xxxxxxxxxxxxxxxxx-----  mem12q     # size is 16 bytes
@@ -1068,7 +1068,7 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0x001110xx1xxxxx100001xxxxxxxxxx     add       dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx100011xxxxxxxxxx     cmtst     dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx100101xxxxxxxxxx     mla       dq0 : dq0 dq5 dq16 bhs_sz
-0x101111xxxxxxxx0000x0xxxxxxxxxx     mla       dq0 : dq5 imm4_16 bhsd_sz index_lhm
+0x101111xxxxxxxx0000x0xxxxxxxxxx     mla       dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
 0x001110xx1xxxxx100111xxxxxxxxxx     mul       dq0 : dq5 dq16 bhs_sz
 0x001111xxxxxxxx1000x0xxxxxxxxxx     mul       dq0 : dq5 dq16_h_sz vindex_H hs_sz
 0x001110xx1xxxxx101001xxxxxxxxxx     smaxp     dq0 : dq5 dq16 bhs_sz
@@ -1076,12 +1076,12 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0x001110xx1xxxxx101101xxxxxxxxxx     sqdmulh   dq0 : dq5 dq16 hs_sz
 01011110011xxxxx101101xxxxxxxxxx     sqdmulh    h0 : h5 h16
 01011110101xxxxx101101xxxxxxxxxx     sqdmulh    s0 : s5 s16
-0x001111xxxxxxxx1100x0xxxxxxxxxx     sqdmulh   dq0 : dq5 imm4_16 bhsd_sz index_lhm
-0101111101xxxxxx1100x0xxxxxxxxxx     sqdmulh    h0 : h5 imm4_16 index_lhm
-0101111110xxxxxx1100x0xxxxxxxxxx     sqdmulh    s0 : s5 imm4_16 index_lhm
-0x101111xxxxxxxx1101x0xxxxxxxxxx     sqrdmlah  dq0 : dq5 imm4_16 bhsd_sz index_lhm
-0111111101xxxxxx1101x0xxxxxxxxxx     sqrdmlah   h0 : h5 imm4_16 index_lhm
-0111111110xxxxxx1101x0xxxxxxxxxx     sqrdmlah   s0 : s5 imm4_16 index_lhm
+0x001111xxxxxxxx1100x0xxxxxxxxxx     sqdmulh   dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
+0101111101xxxxxx1100x0xxxxxxxxxx     sqdmulh    h0 : h5 dq16_idx_lhm idx_lhm
+0101111110xxxxxx1100x0xxxxxxxxxx     sqdmulh    s0 : s5 dq16_idx_lhm idx_lhm
+0x101111xxxxxxxx1101x0xxxxxxxxxx     sqrdmlah  dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
+0111111101xxxxxx1101x0xxxxxxxxxx     sqrdmlah   h0 : h5 dq16_idx_lhm idx_lhm
+0111111110xxxxxx1101x0xxxxxxxxxx     sqrdmlah   s0 : s5 dq16_idx_lhm idx_lhm
 0x101110xx0xxxxx100001xxxxxxxxxx     sqrdmlah  dq0 : dq5 dq16 hs_sz
 01111110010xxxxx100001xxxxxxxxxx     sqrdmlah   h0 : h5 h16
 01111110100xxxxx100001xxxxxxxxxx     sqrdmlah   s0 : s5 s16
@@ -1139,16 +1139,16 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0x101110xx1xxxxx100001xxxxxxxxxx     sub       dq0 : dq5 dq16 bhsd_sz
 0x101110xx1xxxxx100011xxxxxxxxxx     cmeq      dq0 : dq5 dq16 bhsd_sz
 0x101110xx1xxxxx100101xxxxxxxxxx     mls       dq0 : dq0 dq5 dq16 bhs_sz
-0x101111xxxxxxxx0100x0xxxxxxxxxx     mls       dq0 : dq5 imm4_16 bhsd_sz index_lhm
+0x101111xxxxxxxx0100x0xxxxxxxxxx     mls       dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
 0x101110xx1xxxxx100111xxxxxxxxxx     pmul      dq0 : dq5 dq16 b_sz
 0x101110xx1xxxxx101001xxxxxxxxxx     umaxp     dq0 : dq5 dq16 bhs_sz
 0x101110xx1xxxxx101011xxxxxxxxxx     uminp     dq0 : dq5 dq16 bhs_sz
 01111110011xxxxx101101xxxxxxxxxx     sqrdmulh  h0 : h5 h16
 01111110101xxxxx101101xxxxxxxxxx     sqrdmulh  s0 : s5 s16
 0x101110xx1xxxxx101101xxxxxxxxxx     sqrdmulh  dq0 : dq5 dq16 hs_sz
-0x001111xxxxxxxx1101x0xxxxxxxxxx     sqrdmulh  dq0 : dq5 imm4_16 bhsd_sz index_lhm
-0101111101xxxxxx1101x0xxxxxxxxxx     sqrdmulh  h0 : h5 imm4_16 index_lhm
-0101111110xxxxxx1101x0xxxxxxxxxx     sqrdmulh  s0 : s5 imm4_16 index_lhm
+0x001111xxxxxxxx1101x0xxxxxxxxxx     sqrdmulh  dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
+0101111101xxxxxx1101x0xxxxxxxxxx     sqrdmulh  h0 : h5 dq16_idx_lhm idx_lhm
+0101111110xxxxxx1101x0xxxxxxxxxx     sqrdmulh  s0 : s5 dq16_idx_lhm idx_lhm
 0x1011100x1xxxxx110001xxxxxxxxxx     fmaxnmp   dq0 : dq5 dq16 sd_sz
 0x101110001xxxxx110011xxxxxxxxxx     fmlal2    dq0 : dq0 dq5 dq16
 0x1011100x1xxxxx110101xxxxxxxxxx     faddp     dq0 : dq5 dq16 sd_sz

--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -78,6 +78,7 @@
 ----------------------xxxxx-----  w5         # W register (or WZR)
 ----------------------xxxxx-----  x5         # X register (or XZR)
 ----------------------xxxxx-----  x5sp       # X register or XSP
+----------------------xxxxx-----  b5         # B register
 ----------------------xxxxx-----  h5         # H register
 ----------------------xxxxx-----  s5         # S register
 ----------------------xxxxx-----  d5         # D register
@@ -102,6 +103,7 @@
 -------------xxx------xxxxx-----  fpimm8     # floating-point immediate for vector fmov
 -------------xxx------xxxxx-----  imm8       # immediate from 16:18 and 5:10
 -------------xxxxxxxxxxxxxx-----  sysops     # immediate operands for SYS
+------------xxxx----------------  imm4_16    # Q register (0-15) if bit 30 is set, else D
 ------------xxxxxxxxxxxxxxx-----  sysreg     # operand of MRS
 -----------?????------xxxxx-----  wx5_imm5   # reg 5-9 d or q is inferred from bits 16:20
 -----------xxxxx----------------  ign16      # ignored reg field in load/store exclusive
@@ -115,6 +117,9 @@
 -----------xxxxx----------------  d16        # D register
 -----------xxxxx----------------  q16        # Q register
 -----------xxxxx----------------  z16        # Z register
+-----------xxxxx----------------  b16        # B register
+-----------xxxxx----------------  h16        # H register
+-----------xxxxx----------------  s16        # S register
 -----------xxxxxxxxx------------  mem9off    # immed offset for mem9/mem9post
 -----------xxxxxxxxx--xxxxx-----  mem9q      # size is 16 bytes
 -----------xxxxxxxxx--xxxxx-----  prf9       # size is 0 bytes (prefetch variant of mem9)
@@ -1048,6 +1053,12 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0x001110xx1xxxxx001111xxxxxxxxxx     cmge      dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx010001xxxxxxxxxx     sshl      dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx010011xxxxxxxxxx     sqshl     dq0 : dq5 dq16 bhsd_sz
+01011110001xxxxx010011xxxxxxxxxx     sqshl     b0 : b5 b16
+01011110011xxxxx010011xxxxxxxxxx     sqshl     h0 : h5 h16
+01011110101xxxxx010011xxxxxxxxxx     sqshl     s0 : s5 s16
+01011110111xxxxx010011xxxxxxxxxx     sqshl     d0 : d5 d16
+0101111100xxxxxx011101xxxxxxxxxx     sqshl     s0 : s5 immhb
+0101111101xxxxxx011101xxxxxxxxxx     sqshl     d0 : d5 immhb
 0x001110xx1xxxxx010101xxxxxxxxxx     srshl     dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx010111xxxxxxxxxx     sqrshl    dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx011001xxxxxxxxxx     smax      dq0 : dq5 dq16 bhs_sz
@@ -1057,12 +1068,38 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0x001110xx1xxxxx100001xxxxxxxxxx     add       dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx100011xxxxxxxxxx     cmtst     dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx100101xxxxxxxxxx     mla       dq0 : dq0 dq5 dq16 bhs_sz
-0x101111xxxxxxxx0000x0xxxxxxxxxx     mla       dq0 : dq5 dq16_h_sz bhsd_sz index_lhm
+0x101111xxxxxxxx0000x0xxxxxxxxxx     mla       dq0 : dq5 imm4_16 bhsd_sz index_lhm
 0x001110xx1xxxxx100111xxxxxxxxxx     mul       dq0 : dq5 dq16 bhs_sz
 0x001111xxxxxxxx1000x0xxxxxxxxxx     mul       dq0 : dq5 dq16_h_sz vindex_H hs_sz
 0x001110xx1xxxxx101001xxxxxxxxxx     smaxp     dq0 : dq5 dq16 bhs_sz
 0x001110xx1xxxxx101011xxxxxxxxxx     sminp     dq0 : dq5 dq16 bhs_sz
 0x001110xx1xxxxx101101xxxxxxxxxx     sqdmulh   dq0 : dq5 dq16 hs_sz
+01011110011xxxxx101101xxxxxxxxxx     sqdmulh   h0 : h5 h16
+01011110101xxxxx101101xxxxxxxxxx     sqdmulh   s0 : s5 s16
+0x001111xxxxxxxx1100x0xxxxxxxxxx     sqdmulh   dq0 : dq5 imm4_16 bhsd_sz index_lhm
+0101111101xxxxxx1100x0xxxxxxxxxx     sqdmulh   h0 : h5 imm4_16 index_lhm
+0101111110xxxxxx1100x0xxxxxxxxxx     sqdmulh   s0 : s5 imm4_16 index_lhm
+0x101111xxxxxxxx1101x0xxxxxxxxxx     sqrdmlah  dq0 : dq5 imm4_16 bhsd_sz index_lhm
+0111111101xxxxxx1101x0xxxxxxxxxx     sqrdmlah  h0 : h5 imm4_16 index_lhm
+0111111110xxxxxx1101x0xxxxxxxxxx     sqrdmlah  s0 : s5 imm4_16 index_lhm
+0x101110xx0xxxxx100001xxxxxxxxxx     sqrdmlah  dq0 : dq5 dq16 hs_sz
+01111110010xxxxx100001xxxxxxxxxx     sqrdmlah  h0 : h5 h16
+01111110100xxxxx100001xxxxxxxxxx     sqrdmlah  s0 : s5 s16
+0101111000100001010010xxxxxxxxxx     sqxtn     b0 : h5
+0101111001100001010010xxxxxxxxxx     sqxtn     h0 : s5
+0101111010100001010010xxxxxxxxxx     sqxtn     s0 : d5
+00001110xx100001010010xxxxxxxxxx     sqxtn     d0 : d5 bhs_sz
+01001110xx100001010010xxxxxxxxxx     sqxtn2    q0 : q5 bhs_sz
+0111111000100001001010xxxxxxxxxx     sqxtun    b0 : h5
+0111111001100001001010xxxxxxxxxx     sqxtun    h0 : s5
+0111111010100001001010xxxxxxxxxx     sqxtun    s0 : d5
+00101110xx100001001010xxxxxxxxxx     sqxtun    d0 : d5 bhs_sz
+01101110xx100001001010xxxxxxxxxx     sqxtun2   q0 : q5 bhs_sz
+0111111000100001010010xxxxxxxxxx     uqxtn     b0 : h5
+0111111001100001010010xxxxxxxxxx     uqxtn     h0 : s5
+0111111010100001010010xxxxxxxxxx     uqxtn     s0 : d5
+00101110xx100001010010xxxxxxxxxx     uqxtn     d0 : d5 bhs_sz
+01101110xx100001010010xxxxxxxxxx     uqxtn2    q0 : q5 bhs_sz
 0x001110xx1xxxxx101111xxxxxxxxxx     addp      dq0 : dq5 dq16 bhsd_sz
 0x0011100x1xxxxx110001xxxxxxxxxx     fmaxnm    dq0 : dq5 dq16 sd_sz
 0x0011100x1xxxxx110011xxxxxxxxxx     fmla      dq0 : dq0 dq5 dq16 sd_sz
@@ -1102,11 +1139,16 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0x101110xx1xxxxx100001xxxxxxxxxx     sub       dq0 : dq5 dq16 bhsd_sz
 0x101110xx1xxxxx100011xxxxxxxxxx     cmeq      dq0 : dq5 dq16 bhsd_sz
 0x101110xx1xxxxx100101xxxxxxxxxx     mls       dq0 : dq0 dq5 dq16 bhs_sz
-0x101111xxxxxxxx0100x0xxxxxxxxxx     mls       dq0 : dq5 dq16_h_sz bhsd_sz index_lhm
+0x101111xxxxxxxx0100x0xxxxxxxxxx     mls       dq0 : dq5 imm4_16 bhsd_sz index_lhm
 0x101110xx1xxxxx100111xxxxxxxxxx     pmul      dq0 : dq5 dq16 b_sz
 0x101110xx1xxxxx101001xxxxxxxxxx     umaxp     dq0 : dq5 dq16 bhs_sz
 0x101110xx1xxxxx101011xxxxxxxxxx     uminp     dq0 : dq5 dq16 bhs_sz
+01111110011xxxxx101101xxxxxxxxxx     sqrdmulh  h0 : h5 h16
+01111110101xxxxx101101xxxxxxxxxx     sqrdmulh  s0 : s5 s16
 0x101110xx1xxxxx101101xxxxxxxxxx     sqrdmulh  dq0 : dq5 dq16 hs_sz
+0x001111xxxxxxxx1101x0xxxxxxxxxx     sqrdmulh  dq0 : dq5 imm4_16 bhsd_sz index_lhm
+0101111101xxxxxx1101x0xxxxxxxxxx     sqrdmulh  h0 : h5 imm4_16 index_lhm
+0101111110xxxxxx1101x0xxxxxxxxxx     sqrdmulh  s0 : s5 imm4_16 index_lhm
 0x1011100x1xxxxx110001xxxxxxxxxx     fmaxnmp   dq0 : dq5 dq16 sd_sz
 0x101110001xxxxx110011xxxxxxxxxx     fmlal2    dq0 : dq0 dq5 dq16
 0x1011100x1xxxxx110101xxxxxxxxxx     faddp     dq0 : dq5 dq16 sd_sz

--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -103,7 +103,7 @@
 -------------xxx------xxxxx-----  fpimm8     # floating-point immediate for vector fmov
 -------------xxx------xxxxx-----  imm8       # immediate from 16:18 and 5:10
 -------------xxxxxxxxxxxxxx-----  sysops     # immediate operands for SYS
-------------xxxx----------------  imm4_16    # Q register (0-15) if bit 30 is set, else D
+------------xxxx----------------  imm4_16    # imm4 from bits 16-20
 ------------xxxxxxxxxxxxxxx-----  sysreg     # operand of MRS
 -----------?????------xxxxx-----  wx5_imm5   # reg 5-9 d or q is inferred from bits 16:20
 -----------xxxxx----------------  ign16      # ignored reg field in load/store exclusive
@@ -140,7 +140,7 @@
                                              # elements, depending on bit 22 (sz)
 ---------x----------------------  sd_sz      # element width of FP vector reg for single
 --------??-xxxxxxxx-------------  fpimm13    # floating-point immediate for scalar fmov
---------??xx--------x-----------  index_lhm  # imm3 from bits 11, 21 and/or 20 inferred from sz
+----------xx--------x-----------  index_lhm  # imm3 from bits 11, 21 and/or 20 inferred from sz
 --------xx----------------------  b_sz       # element width of a vector (8<<b_sz)
 --------xx----------------------  hs_sz      # element width of a vector (8<<hs_sz)
 --------xx----------------------  bhs_sz     # element width of a vector (8<<bhs_sz)
@@ -1053,12 +1053,12 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0x001110xx1xxxxx001111xxxxxxxxxx     cmge      dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx010001xxxxxxxxxx     sshl      dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx010011xxxxxxxxxx     sqshl     dq0 : dq5 dq16 bhsd_sz
-01011110001xxxxx010011xxxxxxxxxx     sqshl     b0 : b5 b16
-01011110011xxxxx010011xxxxxxxxxx     sqshl     h0 : h5 h16
-01011110101xxxxx010011xxxxxxxxxx     sqshl     s0 : s5 s16
-01011110111xxxxx010011xxxxxxxxxx     sqshl     d0 : d5 d16
-0101111100xxxxxx011101xxxxxxxxxx     sqshl     s0 : s5 immhb
-0101111101xxxxxx011101xxxxxxxxxx     sqshl     d0 : d5 immhb
+01011110001xxxxx010011xxxxxxxxxx     sqshl      b0 : b5 b16
+01011110011xxxxx010011xxxxxxxxxx     sqshl      h0 : h5 h16
+01011110101xxxxx010011xxxxxxxxxx     sqshl      s0 : s5 s16
+01011110111xxxxx010011xxxxxxxxxx     sqshl      d0 : d5 d16
+0101111100xxxxxx011101xxxxxxxxxx     sqshl      s0 : s5 immhb
+0101111101xxxxxx011101xxxxxxxxxx     sqshl      d0 : d5 immhb
 0x001110xx1xxxxx010101xxxxxxxxxx     srshl     dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx010111xxxxxxxxxx     sqrshl    dq0 : dq5 dq16 bhsd_sz
 0x001110xx1xxxxx011001xxxxxxxxxx     smax      dq0 : dq5 dq16 bhs_sz
@@ -1074,32 +1074,32 @@ x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
 0x001110xx1xxxxx101001xxxxxxxxxx     smaxp     dq0 : dq5 dq16 bhs_sz
 0x001110xx1xxxxx101011xxxxxxxxxx     sminp     dq0 : dq5 dq16 bhs_sz
 0x001110xx1xxxxx101101xxxxxxxxxx     sqdmulh   dq0 : dq5 dq16 hs_sz
-01011110011xxxxx101101xxxxxxxxxx     sqdmulh   h0 : h5 h16
-01011110101xxxxx101101xxxxxxxxxx     sqdmulh   s0 : s5 s16
+01011110011xxxxx101101xxxxxxxxxx     sqdmulh    h0 : h5 h16
+01011110101xxxxx101101xxxxxxxxxx     sqdmulh    s0 : s5 s16
 0x001111xxxxxxxx1100x0xxxxxxxxxx     sqdmulh   dq0 : dq5 imm4_16 bhsd_sz index_lhm
-0101111101xxxxxx1100x0xxxxxxxxxx     sqdmulh   h0 : h5 imm4_16 index_lhm
-0101111110xxxxxx1100x0xxxxxxxxxx     sqdmulh   s0 : s5 imm4_16 index_lhm
+0101111101xxxxxx1100x0xxxxxxxxxx     sqdmulh    h0 : h5 imm4_16 index_lhm
+0101111110xxxxxx1100x0xxxxxxxxxx     sqdmulh    s0 : s5 imm4_16 index_lhm
 0x101111xxxxxxxx1101x0xxxxxxxxxx     sqrdmlah  dq0 : dq5 imm4_16 bhsd_sz index_lhm
-0111111101xxxxxx1101x0xxxxxxxxxx     sqrdmlah  h0 : h5 imm4_16 index_lhm
-0111111110xxxxxx1101x0xxxxxxxxxx     sqrdmlah  s0 : s5 imm4_16 index_lhm
+0111111101xxxxxx1101x0xxxxxxxxxx     sqrdmlah   h0 : h5 imm4_16 index_lhm
+0111111110xxxxxx1101x0xxxxxxxxxx     sqrdmlah   s0 : s5 imm4_16 index_lhm
 0x101110xx0xxxxx100001xxxxxxxxxx     sqrdmlah  dq0 : dq5 dq16 hs_sz
-01111110010xxxxx100001xxxxxxxxxx     sqrdmlah  h0 : h5 h16
-01111110100xxxxx100001xxxxxxxxxx     sqrdmlah  s0 : s5 s16
-0101111000100001010010xxxxxxxxxx     sqxtn     b0 : h5
-0101111001100001010010xxxxxxxxxx     sqxtn     h0 : s5
-0101111010100001010010xxxxxxxxxx     sqxtn     s0 : d5
-00001110xx100001010010xxxxxxxxxx     sqxtn     d0 : d5 bhs_sz
-01001110xx100001010010xxxxxxxxxx     sqxtn2    q0 : q5 bhs_sz
-0111111000100001001010xxxxxxxxxx     sqxtun    b0 : h5
-0111111001100001001010xxxxxxxxxx     sqxtun    h0 : s5
-0111111010100001001010xxxxxxxxxx     sqxtun    s0 : d5
-00101110xx100001001010xxxxxxxxxx     sqxtun    d0 : d5 bhs_sz
-01101110xx100001001010xxxxxxxxxx     sqxtun2   q0 : q5 bhs_sz
-0111111000100001010010xxxxxxxxxx     uqxtn     b0 : h5
-0111111001100001010010xxxxxxxxxx     uqxtn     h0 : s5
-0111111010100001010010xxxxxxxxxx     uqxtn     s0 : d5
-00101110xx100001010010xxxxxxxxxx     uqxtn     d0 : d5 bhs_sz
-01101110xx100001010010xxxxxxxxxx     uqxtn2    q0 : q5 bhs_sz
+01111110010xxxxx100001xxxxxxxxxx     sqrdmlah   h0 : h5 h16
+01111110100xxxxx100001xxxxxxxxxx     sqrdmlah   s0 : s5 s16
+0101111000100001010010xxxxxxxxxx     sqxtn      b0 : h5
+0101111001100001010010xxxxxxxxxx     sqxtn      h0 : s5
+0101111010100001010010xxxxxxxxxx     sqxtn      s0 : d5
+00001110xx100001010010xxxxxxxxxx     sqxtn      d0 : d5 bhs_sz
+01001110xx100001010010xxxxxxxxxx     sqxtn2     q0 : q5 bhs_sz
+0111111000100001001010xxxxxxxxxx     sqxtun     b0 : h5
+0111111001100001001010xxxxxxxxxx     sqxtun     h0 : s5
+0111111010100001001010xxxxxxxxxx     sqxtun     s0 : d5
+00101110xx100001001010xxxxxxxxxx     sqxtun     d0 : d5 bhs_sz
+01101110xx100001001010xxxxxxxxxx     sqxtun2    q0 : q5 bhs_sz
+0111111000100001010010xxxxxxxxxx     uqxtn      b0 : h5
+0111111001100001010010xxxxxxxxxx     uqxtn      h0 : s5
+0111111010100001010010xxxxxxxxxx     uqxtn      s0 : d5
+00101110xx100001010010xxxxxxxxxx     uqxtn      d0 : d5 bhs_sz
+01101110xx100001010010xxxxxxxxxx     uqxtn2     q0 : q5 bhs_sz
 0x001110xx1xxxxx101111xxxxxxxxxx     addp      dq0 : dq5 dq16 bhsd_sz
 0x0011100x1xxxxx110001xxxxxxxxxx     fmaxnm    dq0 : dq5 dq16 sd_sz
 0x0011100x1xxxxx110011xxxxxxxxxx     fmla      dq0 : dq0 dq5 dq16 sd_sz

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -441,6 +441,147 @@ eb3fe3ff : cmp    sp, xzr, sxtx           : subs   %sp %xzr sxtx $0x00 -> %xzr
 f1000fff : cmp    sp, #0x3                : subs   %sp $0x0003 lsl $0x00 -> %xzr
 f16003ff : cmp    sp, #0x800, lsl #12     : subs   %sp $0x0800 lsl $0x10 -> %xzr
 
+# FCMP <Hn>, <Hm>
+# FCMP <Hn>, #0.0
+1ee12000 : fcmp   h0, h1                  : fcmp   %h1 -> %h0
+1ee02008 : fcmp   h0, #0.0                : fcmp   $0x03 -> %h0
+1eeb2140 : fcmp   h10, h11                : fcmp   %h11 -> %h10
+1ee02188 : fcmp   h12, #0.0               : fcmp   $0x03 -> %h12
+1ef52280 : fcmp   h20, h21                : fcmp   %h21 -> %h20
+1ee022c8 : fcmp   h22, #0.0               : fcmp   $0x03 -> %h22
+1efd23c0 : fcmp   h30, h29                : fcmp   %h29 -> %h30
+1ee02388 : fcmp   h28, #0.0               : fcmp   $0x03 -> %h28
+
+# FCMP <Sn>, <Sm>
+# FCMP <Sn>, #0.0
+1e212000 : fcmp   s0, s1                  : fcmp   %s1 -> %s0
+1e202008 : fcmp   s0, #0.0                : fcmp   $0x00 -> %s0
+1e2b2140 : fcmp   s10, s11                : fcmp   %s11 -> %s10
+1e202188 : fcmp   s12, #0.0               : fcmp   $0x00 -> %s12
+1e352280 : fcmp   s20, s21                : fcmp   %s21 -> %s20
+1e2022c8 : fcmp   s22, #0.0               : fcmp   $0x00 -> %s22
+1e3d23c0 : fcmp   s30, s29                : fcmp   %s29 -> %s30
+1e202388 : fcmp   s28, #0.0               : fcmp   $0x00 -> %s28
+
+# FCMP <Dn>, <Dm>
+# FCMP <Dn>, #0.0
+1e612000 : fcmp   d0, d1                  : fcmp   %d1 -> %d0
+1e602008 : fcmp   d0, #0.0                : fcmp   $0x01 -> %d0
+1e6b2140 : fcmp   d10, d11                : fcmp   %d11 -> %d10
+1e602188 : fcmp   d12, #0.0               : fcmp   $0x01 -> %d12
+1e752280 : fcmp   d20, d21                : fcmp   %d21 -> %d20
+1e6022c8 : fcmp   d22, #0.0               : fcmp   $0x01 -> %d22
+1e7d23c0 : fcmp   d30, d29                : fcmp   %d29 -> %d30
+1e602388 : fcmp   d28, #0.0               : fcmp   $0x01 -> %d28
+
+# FCCMP <Hn>, <Hm>, #<nzcv>, <cond>
+1ee10400 : fccmp  h0, h1, #0x0, eq        : fccmp  %h1 eq $0x00 -> %h0
+1ee31441 : fccmp  h2, h3, #0x1, ne        : fccmp  %h3 ne $0x01 -> %h2
+1ee52482 : fccmp  h4, h5, #0x2, cs        : fccmp  %h5 cs $0x02 -> %h4
+1ee734c4 : fccmp  h6, h7, #0x4, cc        : fccmp  %h7 cc $0x04 -> %h6
+1ee94508 : fccmp  h8, h9, #0x8, mi        : fccmp  %h9 mi $0x08 -> %h8
+1eeb5540 : fccmp  h10, h11, #0x0, pl      : fccmp  %h11 pl $0x00 -> %h10
+1eed6581 : fccmp  h12, h13, #0x1, vs      : fccmp  %h13 vs $0x01 -> %h12
+1eef75c2 : fccmp  h14, h15, #0x2, vc      : fccmp  %h15 vc $0x02 -> %h14
+1ef18604 : fccmp  h16, h17, #0x4, hi      : fccmp  %h17 hi $0x04 -> %h16
+1ef39648 : fccmp  h18, h19, #0x8, ls      : fccmp  %h19 ls $0x08 -> %h18
+1ef5a680 : fccmp  h20, h21, #0x0, ge      : fccmp  %h21 ge $0x00 -> %h20
+1ef7b6c1 : fccmp  h22, h23, #0x1, lt      : fccmp  %h23 lt $0x01 -> %h22
+1ef9c702 : fccmp  h24, h25, #0x2, gt      : fccmp  %h25 gt $0x02 -> %h24
+1efbd744 : fccmp  h26, h27, #0x4, le      : fccmp  %h27 le $0x04 -> %h26
+1efde788 : fccmp  h28, h29, #0x8, al      : fccmp  %h29 al $0x08 -> %h28
+1ee1f400 : fccmp  h0, h1, #0x0, nv        : fccmp  %h1 nv $0x00 -> %h0
+
+# FCCMP <Sn>, <Sm>, #<nzcv>, <cond>
+1e230441 : fccmp  s2, s3, #0x1, eq        : fccmp  %s3 eq $0x01 -> %s2
+1e251482 : fccmp  s4, s5, #0x2, ne        : fccmp  %s5 ne $0x02 -> %s4
+1e2724c4 : fccmp  s6, s7, #0x4, cs        : fccmp  %s7 cs $0x04 -> %s6
+1e293508 : fccmp  s8, s9, #0x8, cc        : fccmp  %s9 cc $0x08 -> %s8
+1e2b4540 : fccmp  s10, s11, #0x0, mi      : fccmp  %s11 mi $0x00 -> %s10
+1e2d5581 : fccmp  s12, s13, #0x1, pl      : fccmp  %s13 pl $0x01 -> %s12
+1e2f65c2 : fccmp  s14, s15, #0x2, vs      : fccmp  %s15 vs $0x02 -> %s14
+1e317604 : fccmp  s16, s17, #0x4, vc      : fccmp  %s17 vc $0x04 -> %s16
+1e338648 : fccmp  s18, s19, #0x8, hi      : fccmp  %s19 hi $0x08 -> %s18
+1e359680 : fccmp  s20, s21, #0x0, ls      : fccmp  %s21 ls $0x00 -> %s20
+1e37a6c1 : fccmp  s22, s23, #0x1, ge      : fccmp  %s23 ge $0x01 -> %s22
+1e39b702 : fccmp  s24, s25, #0x2, lt      : fccmp  %s25 lt $0x02 -> %s24
+1e3bc744 : fccmp  s26, s27, #0x4, gt      : fccmp  %s27 gt $0x04 -> %s26
+1e3dd788 : fccmp  s28, s29, #0x8, le      : fccmp  %s29 le $0x08 -> %s28
+1e21e400 : fccmp  s0, s1, #0x0, al        : fccmp  %s1 al $0x00 -> %s0
+1e23f441 : fccmp  s2, s3, #0x1, nv        : fccmp  %s3 nv $0x01 -> %s2
+
+# FCCMP <Dn>, <Dm>, #<nzcv>, <cond>
+1e650482 : fccmp  d4, d5, #0x2, eq        : fccmp  %d5 eq $0x02 -> %d4
+1e6714c4 : fccmp  d6, d7, #0x4, ne        : fccmp  %d7 ne $0x04 -> %d6
+1e692508 : fccmp  d8, d9, #0x8, cs        : fccmp  %d9 cs $0x08 -> %d8
+1e6b3540 : fccmp  d10, d11, #0x0, cc      : fccmp  %d11 cc $0x00 -> %d10
+1e6d4581 : fccmp  d12, d13, #0x1, mi      : fccmp  %d13 mi $0x01 -> %d12
+1e6f55c2 : fccmp  d14, d15, #0x2, pl      : fccmp  %d15 pl $0x02 -> %d14
+1e716604 : fccmp  d16, d17, #0x4, vs      : fccmp  %d17 vs $0x04 -> %d16
+1e737648 : fccmp  d18, d19, #0x8, vc      : fccmp  %d19 vc $0x08 -> %d18
+1e758680 : fccmp  d20, d21, #0x0, hi      : fccmp  %d21 hi $0x00 -> %d20
+1e7796c1 : fccmp  d22, d23, #0x1, ls      : fccmp  %d23 ls $0x01 -> %d22
+1e79a702 : fccmp  d24, d25, #0x2, ge      : fccmp  %d25 ge $0x02 -> %d24
+1e7bb744 : fccmp  d26, d27, #0x4, lt      : fccmp  %d27 lt $0x04 -> %d26
+1e7dc788 : fccmp  d28, d29, #0x8, gt      : fccmp  %d29 gt $0x08 -> %d28
+1e61d400 : fccmp  d0, d1, #0x0, le        : fccmp  %d1 le $0x00 -> %d0
+1e63e441 : fccmp  d2, d3, #0x1, al        : fccmp  %d3 al $0x01 -> %d2
+1e65f482 : fccmp  d4, d5, #0x2, nv        : fccmp  %d5 nv $0x02 -> %d4
+
+# FCCMPE <Hn>, <Hm>, #<nzcv>, <cond
+1ee10410 : fccmpe  h0, h1, #0x0, eq       : fccmpe %h1 eq $0x00 -> %h0
+1ee31451 : fccmpe  h2, h3, #0x1, ne       : fccmpe %h3 ne $0x01 -> %h2
+1ee52492 : fccmpe  h4, h5, #0x2, cs       : fccmpe %h5 cs $0x02 -> %h4
+1ee734d4 : fccmpe  h6, h7, #0x4, cc       : fccmpe %h7 cc $0x04 -> %h6
+1ee94518 : fccmpe  h8, h9, #0x8, mi       : fccmpe %h9 mi $0x08 -> %h8
+1eeb5550 : fccmpe  h10, h11, #0x0, pl     : fccmpe %h11 pl $0x00 -> %h10
+1eed6591 : fccmpe  h12, h13, #0x1, vs     : fccmpe %h13 vs $0x01 -> %h12
+1eef75d2 : fccmpe  h14, h15, #0x2, vc     : fccmpe %h15 vc $0x02 -> %h14
+1ef18614 : fccmpe  h16, h17, #0x4, hi     : fccmpe %h17 hi $0x04 -> %h16
+1ef39658 : fccmpe  h18, h19, #0x8, ls     : fccmpe %h19 ls $0x08 -> %h18
+1ef5a690 : fccmpe  h20, h21, #0x0, ge     : fccmpe %h21 ge $0x00 -> %h20
+1ef7b6d1 : fccmpe  h22, h23, #0x1, lt     : fccmpe %h23 lt $0x01 -> %h22
+1ef9c712 : fccmpe  h24, h25, #0x2, gt     : fccmpe %h25 gt $0x02 -> %h24
+1efbd754 : fccmpe  h26, h27, #0x4, le     : fccmpe %h27 le $0x04 -> %h26
+1efde798 : fccmpe  h28, h29, #0x8, al     : fccmpe %h29 al $0x08 -> %h28
+1ee1f410 : fccmpe  h0, h1, #0x0, nv       : fccmpe %h1 nv $0x00 -> %h0
+
+# FCCMPE <Sn>, <Sm>, #<nzcv>, <cond>
+1e230451 : fccmpe  s2, s3, #0x1, eq       : fccmpe %s3 eq $0x01 -> %s2
+1e251492 : fccmpe  s4, s5, #0x2, ne       : fccmpe %s5 ne $0x02 -> %s4
+1e2724d4 : fccmpe  s6, s7, #0x4, cs       : fccmpe %s7 cs $0x04 -> %s6
+1e293518 : fccmpe  s8, s9, #0x8, cc       : fccmpe %s9 cc $0x08 -> %s8
+1e2b4550 : fccmpe  s10, s11, #0x0, mi     : fccmpe %s11 mi $0x00 -> %s10
+1e2d5591 : fccmpe  s12, s13, #0x1, pl     : fccmpe %s13 pl $0x01 -> %s12
+1e2f65d2 : fccmpe  s14, s15, #0x2, vs     : fccmpe %s15 vs $0x02 -> %s14
+1e317614 : fccmpe  s16, s17, #0x4, vc     : fccmpe %s17 vc $0x04 -> %s16
+1e338658 : fccmpe  s18, s19, #0x8, hi     : fccmpe %s19 hi $0x08 -> %s18
+1e359690 : fccmpe  s20, s21, #0x0, ls     : fccmpe %s21 ls $0x00 -> %s20
+1e37a6d1 : fccmpe  s22, s23, #0x1, ge     : fccmpe %s23 ge $0x01 -> %s22
+1e39b712 : fccmpe  s24, s25, #0x2, lt     : fccmpe %s25 lt $0x02 -> %s24
+1e3bc754 : fccmpe  s26, s27, #0x4, gt     : fccmpe %s27 gt $0x04 -> %s26
+1e3dd798 : fccmpe  s28, s29, #0x8, le     : fccmpe %s29 le $0x08 -> %s28
+1e21e410 : fccmpe  s0, s1, #0x0, al       : fccmpe %s1 al $0x00 -> %s0
+1e23f451 : fccmpe  s2, s3, #0x1, nv       : fccmpe %s3 nv $0x01 -> %s2
+
+# FCCMPE <Dn>, <Dm>, #<nzcv>, <cond>
+1e650492 : fccmpe  d4, d5, #0x2, eq       : fccmpe %d5 eq $0x02 -> %d4
+1e6714d4 : fccmpe  d6, d7, #0x4, ne       : fccmpe %d7 ne $0x04 -> %d6
+1e692518 : fccmpe  d8, d9, #0x8, cs       : fccmpe %d9 cs $0x08 -> %d8
+1e6b3550 : fccmpe  d10, d11, #0x0, cc     : fccmpe %d11 cc $0x00 -> %d10
+1e6d4591 : fccmpe  d12, d13, #0x1, mi     : fccmpe %d13 mi $0x01 -> %d12
+1e6f55d2 : fccmpe  d14, d15, #0x2, pl     : fccmpe %d15 pl $0x02 -> %d14
+1e716614 : fccmpe  d16, d17, #0x4, vs     : fccmpe %d17 vs $0x04 -> %d16
+1e737658 : fccmpe  d18, d19, #0x8, vc     : fccmpe %d19 vc $0x08 -> %d18
+1e758690 : fccmpe  d20, d21, #0x0, hi     : fccmpe %d21 hi $0x00 -> %d20
+1e7796d1 : fccmpe  d22, d23, #0x1, ls     : fccmpe %d23 ls $0x01 -> %d22
+1e79a712 : fccmpe  d24, d25, #0x2, ge     : fccmpe %d25 ge $0x02 -> %d24
+1e7bb754 : fccmpe  d26, d27, #0x4, lt     : fccmpe %d27 lt $0x04 -> %d26
+1e7dc798 : fccmpe  d28, d29, #0x8, gt     : fccmpe %d29 gt $0x08 -> %d28
+1e61d410 : fccmpe  d0, d1, #0x0, le       : fccmpe %d1 le $0x00 -> %d0
+1e63e451 : fccmpe  d2, d3, #0x1, al       : fccmpe %d3 al $0x01 -> %d2
+1e65f492 : fccmpe  d4, d5, #0x2, nv       : fccmpe %d5 nv $0x02 -> %d4
+
 0e228dfa : cmtst v26.8b, v15.8b, v2.8b              : cmtst  %d15 %d2 $0x00 -> %d26
 4e228dfa : cmtst v26.16b, v15.16b, v2.16b           : cmtst  %q15 %q2 $0x00 -> %q26
 0e628dfa : cmtst v26.4h, v15.4h, v2.4h              : cmtst  %d15 %d2 $0x01 -> %d26
@@ -466,6 +607,99 @@ f16003ff : cmp    sp, #0x800, lsl #12     : subs   %sp $0x0800 lsl $0x10 -> %xzr
 9ac34c41 : crc32x w1, w2, x3              : crc32x %w2 %x3 -> %w1
 
 9a830041 : csel   x1, x2, x3, eq          : csel   %x2 %x3 eq -> %x1
+
+# FCSEL <Hd>, <Hn>, <Hm>, <cond>
+1ee20c20 : fcsel  h0, h1, h2, eq          : fcsel  %h1 %h2 eq -> %h0
+1ee31c41 : fcsel  h1, h2, h3, ne          : fcsel  %h2 %h3 ne -> %h1
+1ee42c62 : fcsel  h2, h3, h4, cs          : fcsel  %h3 %h4 cs -> %h2
+1ee53c83 : fcsel  h3, h4, h5, cc          : fcsel  %h4 %h5 cc -> %h3
+1ee64ca4 : fcsel  h4, h5, h6, mi          : fcsel  %h5 %h6 mi -> %h4
+1ee75cc5 : fcsel  h5, h6, h7, pl          : fcsel  %h6 %h7 pl -> %h5
+1ee86ce6 : fcsel  h6, h7, h8, vs          : fcsel  %h7 %h8 vs -> %h6
+1ee97d07 : fcsel  h7, h8, h9, vc          : fcsel  %h8 %h9 vc -> %h7
+1eea8d28 : fcsel  h8, h9, h10, hi         : fcsel  %h9 %h10 hi -> %h8
+1eeb9d49 : fcsel  h9, h10, h11, ls        : fcsel  %h10 %h11 ls -> %h9
+1eecad6a : fcsel  h10, h11, h12, ge       : fcsel  %h11 %h12 ge -> %h10
+1eedbd8b : fcsel  h11, h12, h13, lt       : fcsel  %h12 %h13 lt -> %h11
+1eeecdac : fcsel  h12, h13, h14, gt       : fcsel  %h13 %h14 gt -> %h12
+1eefddcd : fcsel  h13, h14, h15, le       : fcsel  %h14 %h15 le -> %h13
+1ef0edee : fcsel  h14, h15, h16, al       : fcsel  %h15 %h16 al -> %h14
+1ef1fe0f : fcsel  h15, h16, h17, nv       : fcsel  %h16 %h17 nv -> %h15
+1ef20e30 : fcsel  h16, h17, h18, eq       : fcsel  %h17 %h18 eq -> %h16
+1ef31e51 : fcsel  h17, h18, h19, ne       : fcsel  %h18 %h19 ne -> %h17
+1ef42e72 : fcsel  h18, h19, h20, cs       : fcsel  %h19 %h20 cs -> %h18
+1ef53e93 : fcsel  h19, h20, h21, cc       : fcsel  %h20 %h21 cc -> %h19
+1ef64eb4 : fcsel  h20, h21, h22, mi       : fcsel  %h21 %h22 mi -> %h20
+1ef75ed5 : fcsel  h21, h22, h23, pl       : fcsel  %h22 %h23 pl -> %h21
+1ef86ef6 : fcsel  h22, h23, h24, vs       : fcsel  %h23 %h24 vs -> %h22
+1ef97f17 : fcsel  h23, h24, h25, vc       : fcsel  %h24 %h25 vc -> %h23
+1efa8f38 : fcsel  h24, h25, h26, hi       : fcsel  %h25 %h26 hi -> %h24
+1efb9f59 : fcsel  h25, h26, h27, ls       : fcsel  %h26 %h27 ls -> %h25
+1efcaf7a : fcsel  h26, h27, h28, ge       : fcsel  %h27 %h28 ge -> %h26
+1efdbf9b : fcsel  h27, h28, h29, lt       : fcsel  %h28 %h29 lt -> %h27
+1efecfbc : fcsel  h28, h29, h30, gt       : fcsel  %h29 %h30 gt -> %h28
+
+# FCSEL <Sd>, <Sn>, <Sm>, <cond>
+1e220c20 : fcsel  s0, s1, s2, eq          : fcsel  %s1 %s2 eq -> %s0
+1e231c41 : fcsel  s1, s2, s3, ne          : fcsel  %s2 %s3 ne -> %s1
+1e242c62 : fcsel  s2, s3, s4, cs          : fcsel  %s3 %s4 cs -> %s2
+1e253c83 : fcsel  s3, s4, s5, cc          : fcsel  %s4 %s5 cc -> %s3
+1e264ca4 : fcsel  s4, s5, s6, mi          : fcsel  %s5 %s6 mi -> %s4
+1e275cc5 : fcsel  s5, s6, s7, pl          : fcsel  %s6 %s7 pl -> %s5
+1e286ce6 : fcsel  s6, s7, s8, vs          : fcsel  %s7 %s8 vs -> %s6
+1e297d07 : fcsel  s7, s8, s9, vc          : fcsel  %s8 %s9 vc -> %s7
+1e2a8d28 : fcsel  s8, s9, s10, hi         : fcsel  %s9 %s10 hi -> %s8
+1e2b9d49 : fcsel  s9, s10, s11, ls        : fcsel  %s10 %s11 ls -> %s9
+1e2cad6a : fcsel  s10, s11, s12, ge       : fcsel  %s11 %s12 ge -> %s10
+1e2dbd8b : fcsel  s11, s12, s13, lt       : fcsel  %s12 %s13 lt -> %s11
+1e2ecdac : fcsel  s12, s13, s14, gt       : fcsel  %s13 %s14 gt -> %s12
+1e2fddcd : fcsel  s13, s14, s15, le       : fcsel  %s14 %s15 le -> %s13
+1e30edee : fcsel  s14, s15, s16, al       : fcsel  %s15 %s16 al -> %s14
+1e31fe0f : fcsel  s15, s16, s17, nv       : fcsel  %s16 %s17 nv -> %s15
+1e320e30 : fcsel  s16, s17, s18, eq       : fcsel  %s17 %s18 eq -> %s16
+1e331e51 : fcsel  s17, s18, s19, ne       : fcsel  %s18 %s19 ne -> %s17
+1e342e72 : fcsel  s18, s19, s20, cs       : fcsel  %s19 %s20 cs -> %s18
+1e353e93 : fcsel  s19, s20, s21, cc       : fcsel  %s20 %s21 cc -> %s19
+1e364eb4 : fcsel  s20, s21, s22, mi       : fcsel  %s21 %s22 mi -> %s20
+1e375ed5 : fcsel  s21, s22, s23, pl       : fcsel  %s22 %s23 pl -> %s21
+1e386ef6 : fcsel  s22, s23, s24, vs       : fcsel  %s23 %s24 vs -> %s22
+1e397f17 : fcsel  s23, s24, s25, vc       : fcsel  %s24 %s25 vc -> %s23
+1e3a8f38 : fcsel  s24, s25, s26, hi       : fcsel  %s25 %s26 hi -> %s24
+1e3b9f59 : fcsel  s25, s26, s27, ls       : fcsel  %s26 %s27 ls -> %s25
+1e3caf7a : fcsel  s26, s27, s28, ge       : fcsel  %s27 %s28 ge -> %s26
+1e3dbf9b : fcsel  s27, s28, s29, lt       : fcsel  %s28 %s29 lt -> %s27
+1e3ecfbc : fcsel  s28, s29, s30, gt       : fcsel  %s29 %s30 gt -> %s28
+
+# FCSEL <Dd>, <Dn>, <Dm>, <cond>
+1e620c20 : fcsel  d0, d1, d2, eq          : fcsel  %d1 %d2 eq -> %d0
+1e631c41 : fcsel  d1, d2, d3, ne          : fcsel  %d2 %d3 ne -> %d1
+1e642c62 : fcsel  d2, d3, d4, cs          : fcsel  %d3 %d4 cs -> %d2
+1e653c83 : fcsel  d3, d4, d5, cc          : fcsel  %d4 %d5 cc -> %d3
+1e664ca4 : fcsel  d4, d5, d6, mi          : fcsel  %d5 %d6 mi -> %d4
+1e675cc5 : fcsel  d5, d6, d7, pl          : fcsel  %d6 %d7 pl -> %d5
+1e686ce6 : fcsel  d6, d7, d8, vs          : fcsel  %d7 %d8 vs -> %d6
+1e697d07 : fcsel  d7, d8, d9, vc          : fcsel  %d8 %d9 vc -> %d7
+1e6a8d28 : fcsel  d8, d9, d10, hi         : fcsel  %d9 %d10 hi -> %d8
+1e6b9d49 : fcsel  d9, d10, d11, ls        : fcsel  %d10 %d11 ls -> %d9
+1e6cad6a : fcsel  d10, d11, d12, ge       : fcsel  %d11 %d12 ge -> %d10
+1e6dbd8b : fcsel  d11, d12, d13, lt       : fcsel  %d12 %d13 lt -> %d11
+1e6ecdac : fcsel  d12, d13, d14, gt       : fcsel  %d13 %d14 gt -> %d12
+1e6fddcd : fcsel  d13, d14, d15, le       : fcsel  %d14 %d15 le -> %d13
+1e70edee : fcsel  d14, d15, d16, al       : fcsel  %d15 %d16 al -> %d14
+1e71fe0f : fcsel  d15, d16, d17, nv       : fcsel  %d16 %d17 nv -> %d15
+1e720e30 : fcsel  d16, d17, d18, eq       : fcsel  %d17 %d18 eq -> %d16
+1e731e51 : fcsel  d17, d18, d19, ne       : fcsel  %d18 %d19 ne -> %d17
+1e742e72 : fcsel  d18, d19, d20, cs       : fcsel  %d19 %d20 cs -> %d18
+1e753e93 : fcsel  d19, d20, d21, cc       : fcsel  %d20 %d21 cc -> %d19
+1e764eb4 : fcsel  d20, d21, d22, mi       : fcsel  %d21 %d22 mi -> %d20
+1e775ed5 : fcsel  d21, d22, d23, pl       : fcsel  %d22 %d23 pl -> %d21
+1e786ef6 : fcsel  d22, d23, d24, vs       : fcsel  %d23 %d24 vs -> %d22
+1e797f17 : fcsel  d23, d24, d25, vc       : fcsel  %d24 %d25 vc -> %d23
+1e7a8f38 : fcsel  d24, d25, d26, hi       : fcsel  %d25 %d26 hi -> %d24
+1e7b9f59 : fcsel  d25, d26, d27, ls       : fcsel  %d26 %d27 ls -> %d25
+1e7caf7a : fcsel  d26, d27, d28, ge       : fcsel  %d27 %d28 ge -> %d26
+1e7dbf9b : fcsel  d27, d28, d29, lt       : fcsel  %d28 %d29 lt -> %d27
+1e7ecfbc : fcsel  d28, d29, d30, gt       : fcsel  %d29 %d30 gt -> %d28
 
 1a9f7441 : csinc  w1, w2, wzr, vc         : csinc  %w2 %wzr vc -> %w1
 
@@ -1189,6 +1423,22 @@ d2400441 : eor    x1, x2, #0x3            : eor    %x2 $0x0000000000000003 -> %x
 6e39f6e5 : fmaxp v5.4s, v23.4s, v25.4s              : fmaxp  %q23 %q25 $0x02 -> %q5
 6e79f6e5 : fmaxp v5.2d, v23.2d, v25.2d              : fmaxp  %q23 %q25 $0x03 -> %q5
 
+# FMAXV <V><d>, <Vn>.<T>
+6e30f820 : fmaxv s0, v1.4s                          : fmaxv  %q1 -> %s0
+6e30f96a : fmaxv s10, v11.4s                        : fmaxv  %q11 -> %s10
+6e30fab4 : fmaxv s20, v21.4s                        : fmaxv  %q21 -> %s20
+6e30fbdd : fmaxv s29, v30.4s                        : fmaxv  %q30 -> %s29
+
+0e30f820 : fmaxv h0, v1.4h                          : fmaxv  %d1 -> %h0
+0e30f96a : fmaxv h10, v11.4h                        : fmaxv  %d11 -> %h10
+0e30fab4 : fmaxv h20, v21.4h                        : fmaxv  %d21 -> %h20
+0e30fbdd : fmaxv h29, v30.4h                        : fmaxv  %d30 -> %h29
+
+4e30f841 : fmaxv h1, v2.8h                          : fmaxv  %q2 -> %h1
+4e30f98b : fmaxv h11, v12.8h                        : fmaxv  %q12 -> %h11
+4e30fad5 : fmaxv h21, v22.8h                        : fmaxv  %q22 -> %h21
+4e30fb9b : fmaxv h27, v28.8h                        : fmaxv  %q28 -> %h27
+
 0ecf3402 : fmin v2.4h, v0.4h, v15.4h                : fmin   %d0 %d15 $0x01 -> %d2
 4ecf3402 : fmin v2.8h, v0.8h, v15.8h                : fmin   %q0 %q15 $0x01 -> %q2
 0ebff716 : fmin v22.2s, v24.2s, v31.2s              : fmin   %d24 %d31 $0x02 -> %d22
@@ -1218,6 +1468,22 @@ d2400441 : eor    x1, x2, #0x3            : eor    %x2 $0x0000000000000003 -> %x
 2eb9f43c : fminp v28.2s, v1.2s, v25.2s              : fminp  %d1 %d25 $0x02 -> %d28
 6eb9f43c : fminp v28.4s, v1.4s, v25.4s              : fminp  %q1 %q25 $0x02 -> %q28
 6ef9f43c : fminp v28.2d, v1.2d, v25.2d              : fminp  %q1 %q25 $0x03 -> %q28
+
+# FMINV <V><d>, <Vn>.<T>
+6eb0f820 : fminv s0, v1.4s                          : fminv  %q1 -> %s0
+6eb0f96a : fminv s10, v11.4s                        : fminv  %q11 -> %s10
+6eb0fab4 : fminv s20, v21.4s                        : fminv  %q21 -> %s20
+6eb0fbdd : fminv s29, v30.4s                        : fminv  %q30 -> %s29
+
+0eb0f820 : fminv h0, v1.4h                          : fminv  %d1 -> %h0
+0eb0f96a : fminv h10, v11.4h                        : fminv  %d11 -> %h10
+0eb0fab4 : fminv h20, v21.4h                        : fminv  %d21 -> %h20
+0eb0fbdd : fminv h29, v30.4h                        : fminv  %d30 -> %h29
+
+4eb0f841 : fminv h1, v2.8h                          : fminv  %q2 -> %h1
+4eb0f98b : fminv h11, v12.8h                        : fminv  %q12 -> %h11
+4eb0fad5 : fminv h21, v22.8h                        : fminv  %q22 -> %h21
+4eb0fb9b : fminv h27, v28.8h                        : fminv  %q28 -> %h27
 
 0e5f0fa0 : fmla v0.4h, v29.4h, v31.4h               : fmla   %d0 %d29 %d31 $0x01 -> %d0
 4e5f0fa0 : fmla v0.8h, v29.8h, v31.8h               : fmla   %q0 %q29 %q31 $0x01 -> %q0

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -2594,44 +2594,50 @@ d37fffff : lsr    xzr, xzr, #63           : ubfm   %xzr $0x3f $0x3f -> %xzr
 
 # MLA <Vd>.<T>, <Vn>.<T>, <Vm>.<Ts>[<index>]
 # MLA <Vd>.4h, <Vn>.4h, <Vm>.h[<index>]
-2f420020 : mla v0.4h, v1.4h, v2.h[0]                : mla    %d1 %d2 $0x01 $0x00 -> %d0
-2f520020 : mla v0.4h, v1.4h, v2.h[1]                : mla    %d1 %d2 $0x01 $0x01 -> %d0
-2f620020 : mla v0.4h, v1.4h, v2.h[2]                : mla    %d1 %d2 $0x01 $0x02 -> %d0
-2f720020 : mla v0.4h, v1.4h, v2.h[3]                : mla    %d1 %d2 $0x01 $0x03 -> %d0
-2f420820 : mla v0.4h, v1.4h, v2.h[4]                : mla    %d1 %d2 $0x01 $0x04 -> %d0
-2f520820 : mla v0.4h, v1.4h, v2.h[5]                : mla    %d1 %d2 $0x01 $0x05 -> %d0
-2f620820 : mla v0.4h, v1.4h, v2.h[6]                : mla    %d1 %d2 $0x01 $0x06 -> %d0
-2f720820 : mla v0.4h, v1.4h, v2.h[7]                : mla    %d1 %d2 $0x01 $0x07 -> %d0
-2f79090a : mla v10.4h, v8.4h, v9.h[7]               : mla    %d8 %d9 $0x01 $0x07 -> %d10
-2f7e09af : mla v15.4h, v13.4h, v14.h[7]             : mla    %d13 %d14 $0x01 $0x07 -> %d15
+2f420020 : mla v0.4h, v1.4h, v2.h[0]                : mla    %d1 $0x02 $0x01 $0x00 -> %d0
+2f520020 : mla v0.4h, v1.4h, v2.h[1]                : mla    %d1 $0x02 $0x01 $0x01 -> %d0
+2f620020 : mla v0.4h, v1.4h, v2.h[2]                : mla    %d1 $0x02 $0x01 $0x02 -> %d0
+2f720020 : mla v0.4h, v1.4h, v2.h[3]                : mla    %d1 $0x02 $0x01 $0x03 -> %d0
+2f420820 : mla v0.4h, v1.4h, v2.h[4]                : mla    %d1 $0x02 $0x01 $0x04 -> %d0
+2f520820 : mla v0.4h, v1.4h, v2.h[5]                : mla    %d1 $0x02 $0x01 $0x05 -> %d0
+2f620820 : mla v0.4h, v1.4h, v2.h[6]                : mla    %d1 $0x02 $0x01 $0x06 -> %d0
+2f720820 : mla v0.4h, v1.4h, v2.h[7]                : mla    %d1 $0x02 $0x01 $0x07 -> %d0
+2f79090a : mla v10.4h, v8.4h, v9.h[7]               : mla    %d8 $0x09 $0x01 $0x07 -> %d10
+2f7e09af : mla v15.4h, v13.4h, v14.h[7]             : mla    %d13 $0x0e $0x01 $0x07 -> %d15
 
 # MLA <Vd>.8h, <Vn>.8h, <Vm>.h[<index>]
-6f420020 : mla v0.8h, v1.8h, v2.h[0]                : mla    %q1 %q2 $0x01 $0x00 -> %q0
-6f520020 : mla v0.8h, v1.8h, v2.h[1]                : mla    %q1 %q2 $0x01 $0x01 -> %q0
-6f620020 : mla v0.8h, v1.8h, v2.h[2]                : mla    %q1 %q2 $0x01 $0x02 -> %q0
-6f720020 : mla v0.8h, v1.8h, v2.h[3]                : mla    %q1 %q2 $0x01 $0x03 -> %q0
-6f420820 : mla v0.8h, v1.8h, v2.h[4]                : mla    %q1 %q2 $0x01 $0x04 -> %q0
-6f520820 : mla v0.8h, v1.8h, v2.h[5]                : mla    %q1 %q2 $0x01 $0x05 -> %q0
-6f620820 : mla v0.8h, v1.8h, v2.h[6]                : mla    %q1 %q2 $0x01 $0x06 -> %q0
-6f720820 : mla v0.8h, v1.8h, v2.h[7]                : mla    %q1 %q2 $0x01 $0x07 -> %q0
-6f79090a : mla v10.8h, v8.8h, v9.h[7]               : mla    %q8 %q9 $0x01 $0x07 -> %q10
-6f7e09af : mla v15.8h, v13.8h, v14.h[7]             : mla    %q13 %q14 $0x01 $0x07 -> %q15
+6f420020 : mla v0.8h, v1.8h, v2.h[0]                : mla    %q1 $0x02 $0x01 $0x00 -> %q0
+6f520020 : mla v0.8h, v1.8h, v2.h[1]                : mla    %q1 $0x02 $0x01 $0x01 -> %q0
+6f620020 : mla v0.8h, v1.8h, v2.h[2]                : mla    %q1 $0x02 $0x01 $0x02 -> %q0
+6f720020 : mla v0.8h, v1.8h, v2.h[3]                : mla    %q1 $0x02 $0x01 $0x03 -> %q0
+6f420820 : mla v0.8h, v1.8h, v2.h[4]                : mla    %q1 $0x02 $0x01 $0x04 -> %q0
+6f520820 : mla v0.8h, v1.8h, v2.h[5]                : mla    %q1 $0x02 $0x01 $0x05 -> %q0
+6f620820 : mla v0.8h, v1.8h, v2.h[6]                : mla    %q1 $0x02 $0x01 $0x06 -> %q0
+6f720820 : mla v0.8h, v1.8h, v2.h[7]                : mla    %q1 $0x02 $0x01 $0x07 -> %q0
+6f79090a : mla v10.8h, v8.8h, v9.h[7]               : mla    %q8 $0x09 $0x01 $0x07 -> %q10
+6f7e09af : mla v15.8h, v13.8h, v14.h[7]             : mla    %q13 $0x0e $0x01 $0x07 -> %q15
 
 # MLA <Vd>.2s, <Vn>.2s, <Vm>.s[<index>]
-2f820020 : mla v0.2s, v1.2s, v2.s[0]                : mla    %d1 %d2 $0x02 $0x00 -> %d0
-2fa20020 : mla v0.2s, v1.2s, v2.s[1]                : mla    %d1 %d2 $0x02 $0x01 -> %d0
-2f820820 : mla v0.2s, v1.2s, v2.s[2]                : mla    %d1 %d2 $0x02 $0x02 -> %d0
-2fa20820 : mla v0.2s, v1.2s, v2.s[3]                : mla    %d1 %d2 $0x02 $0x03 -> %d0
-2fa9090a : mla v10.2s, v8.2s, v9.s[3]               : mla    %d8 %d9 $0x02 $0x03 -> %d10
-2fae09af : mla v15.2s, v13.2s, v14.s[3]             : mla    %d13 %d14 $0x02 $0x03 -> %d15
+2f820020 : mla v0.2s, v1.2s, v2.s[0]                : mla    %d1 $0x02 $0x02 $0x00 -> %d0
+2fa20020 : mla v0.2s, v1.2s, v2.s[1]                : mla    %d1 $0x02 $0x02 $0x02 -> %d0
+2f820820 : mla v0.2s, v1.2s, v2.s[2]                : mla    %d1 $0x02 $0x02 $0x04 -> %d0
+2fa20820 : mla v0.2s, v1.2s, v2.s[3]                : mla    %d1 $0x02 $0x02 $0x06 -> %d0
+2fa9090a : mla v10.2s, v8.2s, v9.s[3]               : mla    %d8 $0x09 $0x02 $0x06 -> %d10
+2fae09af : mla v15.2s, v13.2s, v14.s[3]             : mla    %d13 $0x0e $0x02 $0x06 -> %d15
+2fb30a54 : mla v20.2s, v18.2s, v19.s[3]             : mla    %d18 $0x03 $0x02 $0x07 -> %d20
+2fb80af9 : mla v25.2s, v23.2s, v24.s[3]             : mla    %d23 $0x08 $0x02 $0x07 -> %d25
+2fbd0b9e : mla v30.2s, v28.2s, v29.s[3]             : mla    %d28 $0x0d $0x02 $0x07 -> %d30
 
 # MLA <Vd>.4s, <Vn>.4s, <Vm>.s[<index>]
-6f820020 : mla v0.4s, v1.4s, v2.s[0]                : mla    %q1 %q2 $0x02 $0x00 -> %q0
-6fa20020 : mla v0.4s, v1.4s, v2.s[1]                : mla    %q1 %q2 $0x02 $0x01 -> %q0
-6f820820 : mla v0.4s, v1.4s, v2.s[2]                : mla    %q1 %q2 $0x02 $0x02 -> %q0
-6fa20820 : mla v0.4s, v1.4s, v2.s[3]                : mla    %q1 %q2 $0x02 $0x03 -> %q0
-6fa9090a : mla v10.4s, v8.4s, v9.s[3]               : mla    %q8 %q9 $0x02 $0x03 -> %q10
-6fae09af : mla v15.4s, v13.4s, v14.s[3]             : mla    %q13 %q14 $0x02 $0x03 -> %q15
+6f820020 : mla v0.4s, v1.4s, v2.s[0]                : mla    %q1 $0x02 $0x02 $0x00 -> %q0
+6fa20020 : mla v0.4s, v1.4s, v2.s[1]                : mla    %q1 $0x02 $0x02 $0x02 -> %q0
+6f820820 : mla v0.4s, v1.4s, v2.s[2]                : mla    %q1 $0x02 $0x02 $0x04 -> %q0
+6fa20820 : mla v0.4s, v1.4s, v2.s[3]                : mla    %q1 $0x02 $0x02 $0x06 -> %q0
+6fa9090a : mla v10.4s, v8.4s, v9.s[3]               : mla    %q8 $0x09 $0x02 $0x06 -> %q10
+6fae09af : mla v15.4s, v13.4s, v14.s[3]             : mla    %q13 $0x0e $0x02 $0x06 -> %q15
+6fb30a54 : mla v20.4s, v18.4s, v19.s[3]             : mla    %q18 $0x03 $0x02 $0x07 -> %q20
+6fb80af9 : mla v25.4s, v23.4s, v24.s[3]             : mla    %q23 $0x08 $0x02 $0x07 -> %q25
+6fbd0b9e : mla v30.4s, v28.4s, v29.s[3]             : mla    %q28 $0x0d $0x02 $0x07 -> %q30
 
 2e3b95a7 : mls v7.8b, v13.8b, v27.8b                : mls    %d7 %d13 %d27 $0x00 -> %d7
 6e3b95a7 : mls v7.16b, v13.16b, v27.16b             : mls    %q7 %q13 %q27 $0x00 -> %q7
@@ -2642,44 +2648,50 @@ d37fffff : lsr    xzr, xzr, #63           : ubfm   %xzr $0x3f $0x3f -> %xzr
 
 # MLS <Vd>.<T>, <Vn>.<T>, <Vm>.<Ts>[<index>]
 # MLS <Vd>.4h, <Vn>.4h, <Vm>.h[<index>]
-2f424020 : mls v0.4h, v1.4h, v2.h[0]                : mls    %d1 %d2 $0x01 $0x00 -> %d0
-2f524020 : mls v0.4h, v1.4h, v2.h[1]                : mls    %d1 %d2 $0x01 $0x01 -> %d0
-2f624020 : mls v0.4h, v1.4h, v2.h[2]                : mls    %d1 %d2 $0x01 $0x02 -> %d0
-2f724020 : mls v0.4h, v1.4h, v2.h[3]                : mls    %d1 %d2 $0x01 $0x03 -> %d0
-2f424820 : mls v0.4h, v1.4h, v2.h[4]                : mls    %d1 %d2 $0x01 $0x04 -> %d0
-2f524820 : mls v0.4h, v1.4h, v2.h[5]                : mls    %d1 %d2 $0x01 $0x05 -> %d0
-2f624820 : mls v0.4h, v1.4h, v2.h[6]                : mls    %d1 %d2 $0x01 $0x06 -> %d0
-2f724820 : mls v0.4h, v1.4h, v2.h[7]                : mls    %d1 %d2 $0x01 $0x07 -> %d0
-2f79490a : mls v10.4h, v8.4h, v9.h[7]               : mls    %d8 %d9 $0x01 $0x07 -> %d10
-2f7e49af : mls v15.4h, v13.4h, v14.h[7]             : mls    %d13 %d14 $0x01 $0x07 -> %d15
+2f424020 : mls v0.4h, v1.4h, v2.h[0]                : mls    %d1 $0x02 $0x01 $0x00 -> %d0
+2f524020 : mls v0.4h, v1.4h, v2.h[1]                : mls    %d1 $0x02 $0x01 $0x01 -> %d0
+2f624020 : mls v0.4h, v1.4h, v2.h[2]                : mls    %d1 $0x02 $0x01 $0x02 -> %d0
+2f724020 : mls v0.4h, v1.4h, v2.h[3]                : mls    %d1 $0x02 $0x01 $0x03 -> %d0
+2f424820 : mls v0.4h, v1.4h, v2.h[4]                : mls    %d1 $0x02 $0x01 $0x04 -> %d0
+2f524820 : mls v0.4h, v1.4h, v2.h[5]                : mls    %d1 $0x02 $0x01 $0x05 -> %d0
+2f624820 : mls v0.4h, v1.4h, v2.h[6]                : mls    %d1 $0x02 $0x01 $0x06 -> %d0
+2f724820 : mls v0.4h, v1.4h, v2.h[7]                : mls    %d1 $0x02 $0x01 $0x07 -> %d0
+2f79490a : mls v10.4h, v8.4h, v9.h[7]               : mls    %d8 $0x09 $0x01 $0x07 -> %d10
+2f7e49af : mls v15.4h, v13.4h, v14.h[7]             : mls    %d13 $0x0e $0x01 $0x07 -> %d15
 
-# MLS <Vd>.8h, <Vn>.8h, <Vm>.h[<index>]
-6f424020 : mls v0.8h, v1.8h, v2.h[0]                : mls    %q1 %q2 $0x01 $0x00 -> %q0
-6f524020 : mls v0.8h, v1.8h, v2.h[1]                : mls    %q1 %q2 $0x01 $0x01 -> %q0
-6f624020 : mls v0.8h, v1.8h, v2.h[2]                : mls    %q1 %q2 $0x01 $0x02 -> %q0
-6f724020 : mls v0.8h, v1.8h, v2.h[3]                : mls    %q1 %q2 $0x01 $0x03 -> %q0
-6f424820 : mls v0.8h, v1.8h, v2.h[4]                : mls    %q1 %q2 $0x01 $0x04 -> %q0
-6f524820 : mls v0.8h, v1.8h, v2.h[5]                : mls    %q1 %q2 $0x01 $0x05 -> %q0
-6f624820 : mls v0.8h, v1.8h, v2.h[6]                : mls    %q1 %q2 $0x01 $0x06 -> %q0
-6f724820 : mls v0.8h, v1.8h, v2.h[7]                : mls    %q1 %q2 $0x01 $0x07 -> %q0
-6f79490a : mls v10.8h, v8.8h, v9.h[7]               : mls    %q8 %q9 $0x01 $0x07 -> %q10
-6f7e49af : mls v15.8h, v13.8h, v14.h[7]             : mls    %q13 %q14 $0x01 $0x07 -> %q15
+## MLS <Vd>.8h, <Vn>.8h, <Vm>.h[<index>]
+6f424020 : mls v0.8h, v1.8h, v2.h[0]                : mls    %q1 $0x02 $0x01 $0x00 -> %q0
+6f524020 : mls v0.8h, v1.8h, v2.h[1]                : mls    %q1 $0x02 $0x01 $0x01 -> %q0
+6f624020 : mls v0.8h, v1.8h, v2.h[2]                : mls    %q1 $0x02 $0x01 $0x02 -> %q0
+6f724020 : mls v0.8h, v1.8h, v2.h[3]                : mls    %q1 $0x02 $0x01 $0x03 -> %q0
+6f424820 : mls v0.8h, v1.8h, v2.h[4]                : mls    %q1 $0x02 $0x01 $0x04 -> %q0
+6f524820 : mls v0.8h, v1.8h, v2.h[5]                : mls    %q1 $0x02 $0x01 $0x05 -> %q0
+6f624820 : mls v0.8h, v1.8h, v2.h[6]                : mls    %q1 $0x02 $0x01 $0x06 -> %q0
+6f724820 : mls v0.8h, v1.8h, v2.h[7]                : mls    %q1 $0x02 $0x01 $0x07 -> %q0
+6f79490a : mls v10.8h, v8.8h, v9.h[7]               : mls    %q8 $0x09 $0x01 $0x07 -> %q10
+6f7e49af : mls v15.8h, v13.8h, v14.h[7]             : mls    %q13 $0x0e $0x01 $0x07 -> %q15
 
 # MLS <Vd>.2s, <Vn>.2s, <Vm>.s[<index>]
-2f824020 : mls v0.2s, v1.2s, v2.s[0]                : mls    %d1 %d2 $0x02 $0x00 -> %d0
-2fa24020 : mls v0.2s, v1.2s, v2.s[1]                : mls    %d1 %d2 $0x02 $0x01 -> %d0
-2f824820 : mls v0.2s, v1.2s, v2.s[2]                : mls    %d1 %d2 $0x02 $0x02 -> %d0
-2fa24820 : mls v0.2s, v1.2s, v2.s[3]                : mls    %d1 %d2 $0x02 $0x03 -> %d0
-2fa9490a : mls v10.2s, v8.2s, v9.s[3]               : mls    %d8 %d9 $0x02 $0x03 -> %d10
-2fae49af : mls v15.2s, v13.2s, v14.s[3]             : mls    %d13 %d14 $0x02 $0x03 -> %d15
+2f824020 : mls v0.2s, v1.2s, v2.s[0]                : mls    %d1 $0x02 $0x02 $0x00 -> %d0
+2fa24020 : mls v0.2s, v1.2s, v2.s[1]                : mls    %d1 $0x02 $0x02 $0x02 -> %d0
+2f824820 : mls v0.2s, v1.2s, v2.s[2]                : mls    %d1 $0x02 $0x02 $0x04 -> %d0
+2fa24820 : mls v0.2s, v1.2s, v2.s[3]                : mls    %d1 $0x02 $0x02 $0x06 -> %d0
+2fa9490a : mls v10.2s, v8.2s, v9.s[3]               : mls    %d8 $0x09 $0x02 $0x06 -> %d10
+2fae49af : mls v15.2s, v13.2s, v14.s[3]             : mls    %d13 $0x0e $0x02 $0x06 -> %d15
+2fb34a54 : mls v20.2s, v18.2s, v19.s[3]             : mls    %d18 $0x03 $0x02 $0x07 -> %d20
+2fb84af9 : mls v25.2s, v23.2s, v24.s[3]             : mls    %d23 $0x08 $0x02 $0x07 -> %d25
+2fbd4b9e : mls v30.2s, v28.2s, v29.s[3]             : mls    %d28 $0x0d $0x02 $0x07 -> %d30
 
 # MLS <Vd>.4s, <Vn>.4s, <Vm>.s[<index>]
-6f824020 : mls v0.4s, v1.4s, v2.s[0]                : mls    %q1 %q2 $0x02 $0x00 -> %q0
-6fa24020 : mls v0.4s, v1.4s, v2.s[1]                : mls    %q1 %q2 $0x02 $0x01 -> %q0
-6f824820 : mls v0.4s, v1.4s, v2.s[2]                : mls    %q1 %q2 $0x02 $0x02 -> %q0
-6fa24820 : mls v0.4s, v1.4s, v2.s[3]                : mls    %q1 %q2 $0x02 $0x03 -> %q0
-6fa9490a : mls v10.4s, v8.4s, v9.s[3]               : mls    %q8 %q9 $0x02 $0x03 -> %q10
-6fae49af : mls v15.4s, v13.4s, v14.s[3]             : mls    %q13 %q14 $0x02 $0x03 -> %q15
+6f824020 : mls v0.4s, v1.4s, v2.s[0]                : mls    %q1 $0x02 $0x02 $0x00 -> %q0
+6fa24020 : mls v0.4s, v1.4s, v2.s[1]                : mls    %q1 $0x02 $0x02 $0x02 -> %q0
+6f824820 : mls v0.4s, v1.4s, v2.s[2]                : mls    %q1 $0x02 $0x02 $0x04 -> %q0
+6fa24820 : mls v0.4s, v1.4s, v2.s[3]                : mls    %q1 $0x02 $0x02 $0x06 -> %q0
+6fa9490a : mls v10.4s, v8.4s, v9.s[3]               : mls    %q8 $0x09 $0x02 $0x06 -> %q10
+6fae49af : mls v15.4s, v13.4s, v14.s[3]             : mls    %q13 $0x0e $0x02 $0x06 -> %q15
+6fb34a54 : mls v20.4s, v18.4s, v19.s[3]             : mls    %q18 $0x03 $0x02 $0x07 -> %q20
+6fb84af9 : mls v25.4s, v23.4s, v24.s[3]             : mls    %q23 $0x08 $0x02 $0x07 -> %q25
+6fbd4b9e : mls v30.4s, v28.4s, v29.s[3]             : mls    %q28 $0x0d $0x02 $0x07 -> %q30
 
 1b03fc41 : mneg   w1, w2, w3              : msub   %w2 %w3 %wzr -> %w1
 
@@ -3541,10 +3553,76 @@ d41fffe3 : smc    #0xffff                 : smc    $0xffff
 4e6fb31a : sqdmlsl2 v26.4s, v24.8h, v15.8h          : sqdmlsl2 %q24 %q15 $0x01 -> %q26
 4eafb31a : sqdmlsl2 v26.2d, v24.4s, v15.4s          : sqdmlsl2 %q24 %q15 $0x02 -> %q26
 
+# SQDMULH <V><d>, <V><n>, <V><m>
+5e62b420 : sqdmulh h0, h1, h2                       : sqdmulh %h1 %h2 -> %h0
+5e64b465 : sqdmulh h5, h3, h4                       : sqdmulh %h3 %h4 -> %h5
+5e69b50a : sqdmulh h10, h8, h9                      : sqdmulh %h8 %h9 -> %h10
+5e6eb5af : sqdmulh h15, h13, h14                    : sqdmulh %h13 %h14 -> %h15
+5e73b654 : sqdmulh h20, h18, h19                    : sqdmulh %h18 %h19 -> %h20
+5e78b6f9 : sqdmulh h25, h23, h24                    : sqdmulh %h23 %h24 -> %h25
+5e7db79e : sqdmulh h30, h28, h29                    : sqdmulh %h28 %h29 -> %h30
+5ea2b420 : sqdmulh s0, s1, s2                       : sqdmulh %s1 %s2 -> %s0
+5ea4b465 : sqdmulh s5, s3, s4                       : sqdmulh %s3 %s4 -> %s5
+5ea9b50a : sqdmulh s10, s8, s9                      : sqdmulh %s8 %s9 -> %s10
+5eaeb5af : sqdmulh s15, s13, s14                    : sqdmulh %s13 %s14 -> %s15
+5eb3b654 : sqdmulh s20, s18, s19                    : sqdmulh %s18 %s19 -> %s20
+5eb8b6f9 : sqdmulh s25, s23, s24                    : sqdmulh %s23 %s24 -> %s25
+5ebdb79e : sqdmulh s30, s28, s29                    : sqdmulh %s28 %s29 -> %s30
+
 0e7bb6cc : sqdmulh v12.4h, v22.4h, v27.4h           : sqdmulh %d22 %d27 $0x01 -> %d12
 4e7bb6cc : sqdmulh v12.8h, v22.8h, v27.8h           : sqdmulh %q22 %q27 $0x01 -> %q12
 0ebbb6cc : sqdmulh v12.2s, v22.2s, v27.2s           : sqdmulh %d22 %d27 $0x02 -> %d12
 4ebbb6cc : sqdmulh v12.4s, v22.4s, v27.4s           : sqdmulh %q22 %q27 $0x02 -> %q12
+
+# SQDMULH <Vd>.<T>, <Vn>.<T>, <Vm>.<Ts>[<index>]
+0f42c020 : sqdmulh v0.4h, v1.4h, v2.h[0]             : sqdmulh %d1 $0x02 $0x01 $0x00 -> %d0
+0f52c020 : sqdmulh v0.4h, v1.4h, v2.h[1]             : sqdmulh %d1 $0x02 $0x01 $0x01 -> %d0
+0f62c020 : sqdmulh v0.4h, v1.4h, v2.h[2]             : sqdmulh %d1 $0x02 $0x01 $0x02 -> %d0
+0f72c020 : sqdmulh v0.4h, v1.4h, v2.h[3]             : sqdmulh %d1 $0x02 $0x01 $0x03 -> %d0
+0f42c820 : sqdmulh v0.4h, v1.4h, v2.h[4]             : sqdmulh %d1 $0x02 $0x01 $0x04 -> %d0
+0f52c820 : sqdmulh v0.4h, v1.4h, v2.h[5]             : sqdmulh %d1 $0x02 $0x01 $0x05 -> %d0
+0f62c820 : sqdmulh v0.4h, v1.4h, v2.h[6]             : sqdmulh %d1 $0x02 $0x01 $0x06 -> %d0
+0f72c820 : sqdmulh v0.4h, v1.4h, v2.h[7]             : sqdmulh %d1 $0x02 $0x01 $0x07 -> %d0
+0f79c90a : sqdmulh v10.4h, v8.4h, v9.h[7]            : sqdmulh %d8 $0x09 $0x01 $0x07 -> %d10
+0f7ec9af : sqdmulh v15.4h, v13.4h, v14.h[7]          : sqdmulh %d13 $0x0e $0x01 $0x07 -> %d15
+4f42c020 : sqdmulh v0.8h, v1.8h, v2.h[0]             : sqdmulh %q1 $0x02 $0x01 $0x00 -> %q0
+4f52c020 : sqdmulh v0.8h, v1.8h, v2.h[1]             : sqdmulh %q1 $0x02 $0x01 $0x01 -> %q0
+4f62c020 : sqdmulh v0.8h, v1.8h, v2.h[2]             : sqdmulh %q1 $0x02 $0x01 $0x02 -> %q0
+4f72c020 : sqdmulh v0.8h, v1.8h, v2.h[3]             : sqdmulh %q1 $0x02 $0x01 $0x03 -> %q0
+4f42c820 : sqdmulh v0.8h, v1.8h, v2.h[4]             : sqdmulh %q1 $0x02 $0x01 $0x04 -> %q0
+4f52c820 : sqdmulh v0.8h, v1.8h, v2.h[5]             : sqdmulh %q1 $0x02 $0x01 $0x05 -> %q0
+4f62c820 : sqdmulh v0.8h, v1.8h, v2.h[6]             : sqdmulh %q1 $0x02 $0x01 $0x06 -> %q0
+4f72c820 : sqdmulh v0.8h, v1.8h, v2.h[7]             : sqdmulh %q1 $0x02 $0x01 $0x07 -> %q0
+4f79c90a : sqdmulh v10.8h, v8.8h, v9.h[7]            : sqdmulh %q8 $0x09 $0x01 $0x07 -> %q10
+4f7ec9af : sqdmulh v15.8h, v13.8h, v14.h[7]          : sqdmulh %q13 $0x0e $0x01 $0x07 -> %q15
+0f82c020 : sqdmulh v0.2s, v1.2s, v2.s[0]             : sqdmulh %d1 $0x02 $0x02 $0x00 -> %d0
+0fa2c020 : sqdmulh v0.2s, v1.2s, v2.s[1]             : sqdmulh %d1 $0x02 $0x02 $0x02 -> %d0
+0f82c820 : sqdmulh v0.2s, v1.2s, v2.s[2]             : sqdmulh %d1 $0x02 $0x02 $0x04 -> %d0
+0fa2c820 : sqdmulh v0.2s, v1.2s, v2.s[3]             : sqdmulh %d1 $0x02 $0x02 $0x06 -> %d0
+0fa9c90a : sqdmulh v10.2s, v8.2s, v9.s[3]            : sqdmulh %d8 $0x09 $0x02 $0x06 -> %d10
+0fb3ca54 : sqdmulh v20.2s, v18.2s, v19.s[3]          : sqdmulh %d18 $0x03 $0x02 $0x07 -> %d20
+0fbdcb9e : sqdmulh v30.2s, v28.2s, v29.s[3]          : sqdmulh %d28 $0x0d $0x02 $0x07 -> %d30
+4f82c020 : sqdmulh v0.4s, v1.4s, v2.s[0]             : sqdmulh %q1 $0x02 $0x02 $0x00 -> %q0
+4fa2c020 : sqdmulh v0.4s, v1.4s, v2.s[1]             : sqdmulh %q1 $0x02 $0x02 $0x02 -> %q0
+4f82c820 : sqdmulh v0.4s, v1.4s, v2.s[2]             : sqdmulh %q1 $0x02 $0x02 $0x04 -> %q0
+4fa2c820 : sqdmulh v0.4s, v1.4s, v2.s[3]             : sqdmulh %q1 $0x02 $0x02 $0x06 -> %q0
+4fa9c90a : sqdmulh v10.4s, v8.4s, v9.s[3]            : sqdmulh %q8 $0x09 $0x02 $0x06 -> %q10
+4fb3ca54 : sqdmulh v20.4s, v18.4s, v19.s[3]          : sqdmulh %q18 $0x03 $0x02 $0x07 -> %q20
+4fbdcb9e : sqdmulh v30.4s, v28.4s, v29.s[3]          : sqdmulh %q28 $0x0d $0x02 $0x07 -> %q30
+
+# SQDMULH <V><d>, <V><n>, <Vm>.<Ts>[<index>]
+5f42c020 : sqdmulh h0, h1, v2.h[0]                   : sqdmulh %h1 $0x02 $0x00 -> %h0
+5f52c020 : sqdmulh h0, h1, v2.h[1]                   : sqdmulh %h1 $0x02 $0x01 -> %h0
+5f62c020 : sqdmulh h0, h1, v2.h[2]                   : sqdmulh %h1 $0x02 $0x02 -> %h0
+5f72c020 : sqdmulh h0, h1, v2.h[3]                   : sqdmulh %h1 $0x02 $0x03 -> %h0
+5f42c820 : sqdmulh h0, h1, v2.h[4]                   : sqdmulh %h1 $0x02 $0x04 -> %h0
+5f52c820 : sqdmulh h0, h1, v2.h[5]                   : sqdmulh %h1 $0x02 $0x05 -> %h0
+5f62c820 : sqdmulh h0, h1, v2.h[6]                   : sqdmulh %h1 $0x02 $0x06 -> %h0
+5f72c820 : sqdmulh h0, h1, v2.h[7]                   : sqdmulh %h1 $0x02 $0x07 -> %h0
+5f82c020 : sqdmulh s0, s1, v2.s[0]                   : sqdmulh %s1 $0x02 $0x00 -> %s0
+5fa2c020 : sqdmulh s0, s1, v2.s[1]                   : sqdmulh %s1 $0x02 $0x02 -> %s0
+5f82c820 : sqdmulh s0, s1, v2.s[2]                   : sqdmulh %s1 $0x02 $0x04 -> %s0
+5fa2c820 : sqdmulh s0, s1, v2.s[3]                   : sqdmulh %s1 $0x02 $0x06 -> %s0
 
 0e72d1c2 : sqdmull v2.4s, v14.4h, v18.4h            : sqdmull %d14 %d18 $0x01 -> %q2
 0eb2d1c2 : sqdmull v2.2d, v14.2s, v18.2s            : sqdmull %d14 %d18 $0x02 -> %q2
@@ -3552,10 +3630,172 @@ d41fffe3 : smc    #0xffff                 : smc    $0xffff
 4e75d36c : sqdmull2 v12.4s, v27.8h, v21.8h          : sqdmull2 %q27 %q21 $0x01 -> %q12
 4eb5d36c : sqdmull2 v12.2d, v27.4s, v21.4s          : sqdmull2 %q27 %q21 $0x02 -> %q12
 
+# SQRDMULH <V><d>, <V><n>, <V><m>
+7e62b420 : sqrdmulh h0, h1, h2                       : sqrdmulh %h1 %h2 -> %h0
+7e64b465 : sqrdmulh h5, h3, h4                       : sqrdmulh %h3 %h4 -> %h5
+7e69b50a : sqrdmulh h10, h8, h9                      : sqrdmulh %h8 %h9 -> %h10
+7e6eb5af : sqrdmulh h15, h13, h14                    : sqrdmulh %h13 %h14 -> %h15
+7e73b654 : sqrdmulh h20, h18, h19                    : sqrdmulh %h18 %h19 -> %h20
+7e78b6f9 : sqrdmulh h25, h23, h24                    : sqrdmulh %h23 %h24 -> %h25
+7e7db79e : sqrdmulh h30, h28, h29                    : sqrdmulh %h28 %h29 -> %h30
+7ea2b420 : sqrdmulh s0, s1, s2                       : sqrdmulh %s1 %s2 -> %s0
+7ea4b465 : sqrdmulh s5, s3, s4                       : sqrdmulh %s3 %s4 -> %s5
+7ea9b50a : sqrdmulh s10, s8, s9                      : sqrdmulh %s8 %s9 -> %s10
+7eaeb5af : sqrdmulh s15, s13, s14                    : sqrdmulh %s13 %s14 -> %s15
+7eb3b654 : sqrdmulh s20, s18, s19                    : sqrdmulh %s18 %s19 -> %s20
+7eb8b6f9 : sqrdmulh s25, s23, s24                    : sqrdmulh %s23 %s24 -> %s25
+7ebdb79e : sqrdmulh s30, s28, s29                    : sqrdmulh %s28 %s29 -> %s30
+
 2e7bb7b7 : sqrdmulh v23.4h, v29.4h, v27.4h          : sqrdmulh %d29 %d27 $0x01 -> %d23
 6e7bb7b7 : sqrdmulh v23.8h, v29.8h, v27.8h          : sqrdmulh %q29 %q27 $0x01 -> %q23
 2ebbb7b7 : sqrdmulh v23.2s, v29.2s, v27.2s          : sqrdmulh %d29 %d27 $0x02 -> %d23
 6ebbb7b7 : sqrdmulh v23.4s, v29.4s, v27.4s          : sqrdmulh %q29 %q27 $0x02 -> %q23
+
+# SQRDMULH <V><d>, <V><n>, <Vm>.<Ts>[<index>]
+5f42d020 : sqrdmulh h0, h1, v2.h[0]                  : sqrdmulh %h1 $0x02 $0x00 -> %h0
+5f52d020 : sqrdmulh h0, h1, v2.h[1]                  : sqrdmulh %h1 $0x02 $0x01 -> %h0
+5f62d020 : sqrdmulh h0, h1, v2.h[2]                  : sqrdmulh %h1 $0x02 $0x02 -> %h0
+5f72d020 : sqrdmulh h0, h1, v2.h[3]                  : sqrdmulh %h1 $0x02 $0x03 -> %h0
+5f42d820 : sqrdmulh h0, h1, v2.h[4]                  : sqrdmulh %h1 $0x02 $0x04 -> %h0
+5f52d820 : sqrdmulh h0, h1, v2.h[5]                  : sqrdmulh %h1 $0x02 $0x05 -> %h0
+5f62d820 : sqrdmulh h0, h1, v2.h[6]                  : sqrdmulh %h1 $0x02 $0x06 -> %h0
+5f72d820 : sqrdmulh h0, h1, v2.h[7]                  : sqrdmulh %h1 $0x02 $0x07 -> %h0
+5f82d020 : sqrdmulh s0, s1, v2.s[0]                  : sqrdmulh %s1 $0x02 $0x00 -> %s0
+5fa2d020 : sqrdmulh s0, s1, v2.s[1]                  : sqrdmulh %s1 $0x02 $0x02 -> %s0
+5f82d820 : sqrdmulh s0, s1, v2.s[2]                  : sqrdmulh %s1 $0x02 $0x04 -> %s0
+5fa2d820 : sqrdmulh s0, s1, v2.s[3]                  : sqrdmulh %s1 $0x02 $0x06 -> %s0
+
+# SQRDMULH <Vd>.<T>, <Vn>.<T>, <Vm>.<Ts>[<index>]
+0f42d020 : sqrdmulh v0.4h, v1.4h, v2.h[0]            : sqrdmulh %d1 $0x02 $0x01 $0x00 -> %d0
+0f52d020 : sqrdmulh v0.4h, v1.4h, v2.h[1]            : sqrdmulh %d1 $0x02 $0x01 $0x01 -> %d0
+0f62d020 : sqrdmulh v0.4h, v1.4h, v2.h[2]            : sqrdmulh %d1 $0x02 $0x01 $0x02 -> %d0
+0f72d020 : sqrdmulh v0.4h, v1.4h, v2.h[3]            : sqrdmulh %d1 $0x02 $0x01 $0x03 -> %d0
+0f42d820 : sqrdmulh v0.4h, v1.4h, v2.h[4]            : sqrdmulh %d1 $0x02 $0x01 $0x04 -> %d0
+0f52d820 : sqrdmulh v0.4h, v1.4h, v2.h[5]            : sqrdmulh %d1 $0x02 $0x01 $0x05 -> %d0
+0f62d820 : sqrdmulh v0.4h, v1.4h, v2.h[6]            : sqrdmulh %d1 $0x02 $0x01 $0x06 -> %d0
+0f72d820 : sqrdmulh v0.4h, v1.4h, v2.h[7]            : sqrdmulh %d1 $0x02 $0x01 $0x07 -> %d0
+0f79d90a : sqrdmulh v10.4h, v8.4h, v9.h[7]           : sqrdmulh %d8 $0x09 $0x01 $0x07 -> %d10
+0f7ed9af : sqrdmulh v15.4h, v13.4h, v14.h[7]         : sqrdmulh %d13 $0x0e $0x01 $0x07 -> %d15
+4f42d020 : sqrdmulh v0.8h, v1.8h, v2.h[0]            : sqrdmulh %q1 $0x02 $0x01 $0x00 -> %q0
+4f52d020 : sqrdmulh v0.8h, v1.8h, v2.h[1]            : sqrdmulh %q1 $0x02 $0x01 $0x01 -> %q0
+4f62d020 : sqrdmulh v0.8h, v1.8h, v2.h[2]            : sqrdmulh %q1 $0x02 $0x01 $0x02 -> %q0
+4f72d020 : sqrdmulh v0.8h, v1.8h, v2.h[3]            : sqrdmulh %q1 $0x02 $0x01 $0x03 -> %q0
+4f42d820 : sqrdmulh v0.8h, v1.8h, v2.h[4]            : sqrdmulh %q1 $0x02 $0x01 $0x04 -> %q0
+4f52d820 : sqrdmulh v0.8h, v1.8h, v2.h[5]            : sqrdmulh %q1 $0x02 $0x01 $0x05 -> %q0
+4f62d820 : sqrdmulh v0.8h, v1.8h, v2.h[6]            : sqrdmulh %q1 $0x02 $0x01 $0x06 -> %q0
+4f72d820 : sqrdmulh v0.8h, v1.8h, v2.h[7]            : sqrdmulh %q1 $0x02 $0x01 $0x07 -> %q0
+4f79d90a : sqrdmulh v10.8h, v8.8h, v9.h[7]           : sqrdmulh %q8 $0x09 $0x01 $0x07 -> %q10
+4f7ed9af : sqrdmulh v15.8h, v13.8h, v14.h[7]         : sqrdmulh %q13 $0x0e $0x01 $0x07 -> %q15
+0f82d020 : sqrdmulh v0.2s, v1.2s, v2.s[0]            : sqrdmulh %d1 $0x02 $0x02 $0x00 -> %d0
+0fa2d020 : sqrdmulh v0.2s, v1.2s, v2.s[1]            : sqrdmulh %d1 $0x02 $0x02 $0x02 -> %d0
+0f82d820 : sqrdmulh v0.2s, v1.2s, v2.s[2]            : sqrdmulh %d1 $0x02 $0x02 $0x04 -> %d0
+0fa2d820 : sqrdmulh v0.2s, v1.2s, v2.s[3]            : sqrdmulh %d1 $0x02 $0x02 $0x06 -> %d0
+0fa9d90a : sqrdmulh v10.2s, v8.2s, v9.s[3]           : sqrdmulh %d8 $0x09 $0x02 $0x06 -> %d10
+0fb3da54 : sqrdmulh v20.2s, v18.2s, v19.s[3]         : sqrdmulh %d18 $0x03 $0x02 $0x07 -> %d20
+0fbddb9e : sqrdmulh v30.2s, v28.2s, v29.s[3]         : sqrdmulh %d28 $0x0d $0x02 $0x07 -> %d30
+4f82d020 : sqrdmulh v0.4s, v1.4s, v2.s[0]            : sqrdmulh %q1 $0x02 $0x02 $0x00 -> %q0
+4fa2d020 : sqrdmulh v0.4s, v1.4s, v2.s[1]            : sqrdmulh %q1 $0x02 $0x02 $0x02 -> %q0
+4f82d820 : sqrdmulh v0.4s, v1.4s, v2.s[2]            : sqrdmulh %q1 $0x02 $0x02 $0x04 -> %q0
+4fa2d820 : sqrdmulh v0.4s, v1.4s, v2.s[3]            : sqrdmulh %q1 $0x02 $0x02 $0x06 -> %q0
+4fa9d90a : sqrdmulh v10.4s, v8.4s, v9.s[3]           : sqrdmulh %q8 $0x09 $0x02 $0x06 -> %q10
+4fb3da54 : sqrdmulh v20.4s, v18.4s, v19.s[3]         : sqrdmulh %q18 $0x03 $0x02 $0x07 -> %q20
+4fbddb9e : sqrdmulh v30.4s, v28.4s, v29.s[3]         : sqrdmulh %q28 $0x0d $0x02 $0x07 -> %q30
+
+# SQRDMLAH <V><d>, <V><n>, <V><m>
+7e428420 : sqrdmlah h0, h1, h2                       : sqrdmlah %h1 %h2 -> %h0
+7e448465 : sqrdmlah h5, h3, h4                       : sqrdmlah %h3 %h4 -> %h5
+7e49850a : sqrdmlah h10, h8, h9                      : sqrdmlah %h8 %h9 -> %h10
+7e4e85af : sqrdmlah h15, h13, h14                    : sqrdmlah %h13 %h14 -> %h15
+7e538654 : sqrdmlah h20, h18, h19                    : sqrdmlah %h18 %h19 -> %h20
+7e5886f9 : sqrdmlah h25, h23, h24                    : sqrdmlah %h23 %h24 -> %h25
+7e5d879e : sqrdmlah h30, h28, h29                    : sqrdmlah %h28 %h29 -> %h30
+7e828420 : sqrdmlah s0, s1, s2                       : sqrdmlah %s1 %s2 -> %s0
+7e848465 : sqrdmlah s5, s3, s4                       : sqrdmlah %s3 %s4 -> %s5
+7e89850a : sqrdmlah s10, s8, s9                      : sqrdmlah %s8 %s9 -> %s10
+7e8e85af : sqrdmlah s15, s13, s14                    : sqrdmlah %s13 %s14 -> %s15
+7e938654 : sqrdmlah s20, s18, s19                    : sqrdmlah %s18 %s19 -> %s20
+7e9886f9 : sqrdmlah s25, s23, s24                    : sqrdmlah %s23 %s24 -> %s25
+7e9d879e : sqrdmlah s30, s28, s29                    : sqrdmlah %s28 %s29 -> %s30
+
+# SQRDMLAH <Vd>.<T>, <Vn>.<T>, <Vm>.<T>
+2e428420 : sqrdmlah v0.4h, v1.4h, v2.4h              : sqrdmlah %d1 %d2 $0x01 -> %d0
+2e448465 : sqrdmlah v5.4h, v3.4h, v4.4h              : sqrdmlah %d3 %d4 $0x01 -> %d5
+2e49850a : sqrdmlah v10.4h, v8.4h, v9.4h             : sqrdmlah %d8 %d9 $0x01 -> %d10
+2e4e85af : sqrdmlah v15.4h, v13.4h, v14.4h           : sqrdmlah %d13 %d14 $0x01 -> %d15
+2e538654 : sqrdmlah v20.4h, v18.4h, v19.4h           : sqrdmlah %d18 %d19 $0x01 -> %d20
+2e5886f9 : sqrdmlah v25.4h, v23.4h, v24.4h           : sqrdmlah %d23 %d24 $0x01 -> %d25
+2e5d879e : sqrdmlah v30.4h, v28.4h, v29.4h           : sqrdmlah %d28 %d29 $0x01 -> %d30
+6e428420 : sqrdmlah v0.8h, v1.8h, v2.8h              : sqrdmlah %q1 %q2 $0x01 -> %q0
+6e448465 : sqrdmlah v5.8h, v3.8h, v4.8h              : sqrdmlah %q3 %q4 $0x01 -> %q5
+6e49850a : sqrdmlah v10.8h, v8.8h, v9.8h             : sqrdmlah %q8 %q9 $0x01 -> %q10
+6e4e85af : sqrdmlah v15.8h, v13.8h, v14.8h           : sqrdmlah %q13 %q14 $0x01 -> %q15
+6e538654 : sqrdmlah v20.8h, v18.8h, v19.8h           : sqrdmlah %q18 %q19 $0x01 -> %q20
+6e5886f9 : sqrdmlah v25.8h, v23.8h, v24.8h           : sqrdmlah %q23 %q24 $0x01 -> %q25
+6e5d879e : sqrdmlah v30.8h, v28.8h, v29.8h           : sqrdmlah %q28 %q29 $0x01 -> %q30
+2e828420 : sqrdmlah v0.2s, v1.2s, v2.2s              : sqrdmlah %d1 %d2 $0x02 -> %d0
+2e848465 : sqrdmlah v5.2s, v3.2s, v4.2s              : sqrdmlah %d3 %d4 $0x02 -> %d5
+2e89850a : sqrdmlah v10.2s, v8.2s, v9.2s             : sqrdmlah %d8 %d9 $0x02 -> %d10
+2e8e85af : sqrdmlah v15.2s, v13.2s, v14.2s           : sqrdmlah %d13 %d14 $0x02 -> %d15
+2e938654 : sqrdmlah v20.2s, v18.2s, v19.2s           : sqrdmlah %d18 %d19 $0x02 -> %d20
+2e9886f9 : sqrdmlah v25.2s, v23.2s, v24.2s           : sqrdmlah %d23 %d24 $0x02 -> %d25
+2e9d879e : sqrdmlah v30.2s, v28.2s, v29.2s           : sqrdmlah %d28 %d29 $0x02 -> %d30
+6e828420 : sqrdmlah v0.4s, v1.4s, v2.4s              : sqrdmlah %q1 %q2 $0x02 -> %q0
+6e848465 : sqrdmlah v5.4s, v3.4s, v4.4s              : sqrdmlah %q3 %q4 $0x02 -> %q5
+6e89850a : sqrdmlah v10.4s, v8.4s, v9.4s             : sqrdmlah %q8 %q9 $0x02 -> %q10
+6e8e85af : sqrdmlah v15.4s, v13.4s, v14.4s           : sqrdmlah %q13 %q14 $0x02 -> %q15
+6e938654 : sqrdmlah v20.4s, v18.4s, v19.4s           : sqrdmlah %q18 %q19 $0x02 -> %q20
+6e9886f9 : sqrdmlah v25.4s, v23.4s, v24.4s           : sqrdmlah %q23 %q24 $0x02 -> %q25
+6e9d879e : sqrdmlah v30.4s, v28.4s, v29.4s           : sqrdmlah %q28 %q29 $0x02 -> %q30
+
+# SQRDMLAH <V><d>, <V><n>, <Vm>.<Ts>[<index>]
+7f42d020 : sqrdmlah h0, h1, v2.h[0]                  : sqrdmlah %h1 $0x02 $0x00 -> %h0
+7f52d020 : sqrdmlah h0, h1, v2.h[1]                  : sqrdmlah %h1 $0x02 $0x01 -> %h0
+7f62d020 : sqrdmlah h0, h1, v2.h[2]                  : sqrdmlah %h1 $0x02 $0x02 -> %h0
+7f72d020 : sqrdmlah h0, h1, v2.h[3]                  : sqrdmlah %h1 $0x02 $0x03 -> %h0
+7f42d820 : sqrdmlah h0, h1, v2.h[4]                  : sqrdmlah %h1 $0x02 $0x04 -> %h0
+7f52d820 : sqrdmlah h0, h1, v2.h[5]                  : sqrdmlah %h1 $0x02 $0x05 -> %h0
+7f62d820 : sqrdmlah h0, h1, v2.h[6]                  : sqrdmlah %h1 $0x02 $0x06 -> %h0
+7f72d820 : sqrdmlah h0, h1, v2.h[7]                  : sqrdmlah %h1 $0x02 $0x07 -> %h0
+7f82d020 : sqrdmlah s0, s1, v2.s[0]                  : sqrdmlah %s1 $0x02 $0x00 -> %s0
+7fa2d020 : sqrdmlah s0, s1, v2.s[1]                  : sqrdmlah %s1 $0x02 $0x02 -> %s0
+7f82d820 : sqrdmlah s0, s1, v2.s[2]                  : sqrdmlah %s1 $0x02 $0x04 -> %s0
+7fa2d820 : sqrdmlah s0, s1, v2.s[3]                  : sqrdmlah %s1 $0x02 $0x06 -> %s0
+
+# SQRDMLAH <Vd>.<T>, <Vn>.<T>, <Vm>.<Ts>[<index>]
+2f42d020 : sqrdmlah v0.4h, v1.4h, v2.h[0]            : sqrdmlah %d1 $0x02 $0x01 $0x00 -> %d0
+2f52d020 : sqrdmlah v0.4h, v1.4h, v2.h[1]            : sqrdmlah %d1 $0x02 $0x01 $0x01 -> %d0
+2f62d020 : sqrdmlah v0.4h, v1.4h, v2.h[2]            : sqrdmlah %d1 $0x02 $0x01 $0x02 -> %d0
+2f72d020 : sqrdmlah v0.4h, v1.4h, v2.h[3]            : sqrdmlah %d1 $0x02 $0x01 $0x03 -> %d0
+2f42d820 : sqrdmlah v0.4h, v1.4h, v2.h[4]            : sqrdmlah %d1 $0x02 $0x01 $0x04 -> %d0
+2f52d820 : sqrdmlah v0.4h, v1.4h, v2.h[5]            : sqrdmlah %d1 $0x02 $0x01 $0x05 -> %d0
+2f62d820 : sqrdmlah v0.4h, v1.4h, v2.h[6]            : sqrdmlah %d1 $0x02 $0x01 $0x06 -> %d0
+2f72d820 : sqrdmlah v0.4h, v1.4h, v2.h[7]            : sqrdmlah %d1 $0x02 $0x01 $0x07 -> %d0
+2f79d90a : sqrdmlah v10.4h, v8.4h, v9.h[7]           : sqrdmlah %d8 $0x09 $0x01 $0x07 -> %d10
+2f7ed9af : sqrdmlah v15.4h, v13.4h, v14.h[7]         : sqrdmlah %d13 $0x0e $0x01 $0x07 -> %d15
+6f42d020 : sqrdmlah v0.8h, v1.8h, v2.h[0]            : sqrdmlah %q1 $0x02 $0x01 $0x00 -> %q0
+6f52d020 : sqrdmlah v0.8h, v1.8h, v2.h[1]            : sqrdmlah %q1 $0x02 $0x01 $0x01 -> %q0
+6f62d020 : sqrdmlah v0.8h, v1.8h, v2.h[2]            : sqrdmlah %q1 $0x02 $0x01 $0x02 -> %q0
+6f72d020 : sqrdmlah v0.8h, v1.8h, v2.h[3]            : sqrdmlah %q1 $0x02 $0x01 $0x03 -> %q0
+6f42d820 : sqrdmlah v0.8h, v1.8h, v2.h[4]            : sqrdmlah %q1 $0x02 $0x01 $0x04 -> %q0
+6f52d820 : sqrdmlah v0.8h, v1.8h, v2.h[5]            : sqrdmlah %q1 $0x02 $0x01 $0x05 -> %q0
+6f62d820 : sqrdmlah v0.8h, v1.8h, v2.h[6]            : sqrdmlah %q1 $0x02 $0x01 $0x06 -> %q0
+6f72d820 : sqrdmlah v0.8h, v1.8h, v2.h[7]            : sqrdmlah %q1 $0x02 $0x01 $0x07 -> %q0
+6f79d90a : sqrdmlah v10.8h, v8.8h, v9.h[7]           : sqrdmlah %q8 $0x09 $0x01 $0x07 -> %q10
+6f7ed9af : sqrdmlah v15.8h, v13.8h, v14.h[7]         : sqrdmlah %q13 $0x0e $0x01 $0x07 -> %q15
+2f82d020 : sqrdmlah v0.2s, v1.2s, v2.s[0]            : sqrdmlah %d1 $0x02 $0x02 $0x00 -> %d0
+2fa2d020 : sqrdmlah v0.2s, v1.2s, v2.s[1]            : sqrdmlah %d1 $0x02 $0x02 $0x02 -> %d0
+2f82d820 : sqrdmlah v0.2s, v1.2s, v2.s[2]            : sqrdmlah %d1 $0x02 $0x02 $0x04 -> %d0
+2fa2d820 : sqrdmlah v0.2s, v1.2s, v2.s[3]            : sqrdmlah %d1 $0x02 $0x02 $0x06 -> %d0
+2fa9d90a : sqrdmlah v10.2s, v8.2s, v9.s[3]           : sqrdmlah %d8 $0x09 $0x02 $0x06 -> %d10
+2fb3da54 : sqrdmlah v20.2s, v18.2s, v19.s[3]         : sqrdmlah %d18 $0x03 $0x02 $0x07 -> %d20
+2fbddb9e : sqrdmlah v30.2s, v28.2s, v29.s[3]         : sqrdmlah %d28 $0x0d $0x02 $0x07 -> %d30
+6f82d020 : sqrdmlah v0.4s, v1.4s, v2.s[0]            : sqrdmlah %q1 $0x02 $0x02 $0x00 -> %q0
+6fa2d020 : sqrdmlah v0.4s, v1.4s, v2.s[1]            : sqrdmlah %q1 $0x02 $0x02 $0x02 -> %q0
+6f82d820 : sqrdmlah v0.4s, v1.4s, v2.s[2]            : sqrdmlah %q1 $0x02 $0x02 $0x04 -> %q0
+6fa2d820 : sqrdmlah v0.4s, v1.4s, v2.s[3]            : sqrdmlah %q1 $0x02 $0x02 $0x06 -> %q0
+6fa9d90a : sqrdmlah v10.4s, v8.4s, v9.s[3]           : sqrdmlah %q8 $0x09 $0x02 $0x06 -> %q10
+6fb3da54 : sqrdmlah v20.4s, v18.4s, v19.s[3]         : sqrdmlah %q18 $0x03 $0x02 $0x07 -> %q20
+6fbddb9e : sqrdmlah v30.4s, v28.4s, v29.s[3]         : sqrdmlah %q28 $0x0d $0x02 $0x07 -> %q30
 
 # SMOV <Wd>, <Vn>.<B>[<index>]
 0e012c00 : smov w0, v0.b[0]              : smov   %d0 $0x01 -> %w0
@@ -3731,6 +3971,37 @@ d41fffe3 : smc    #0xffff                 : smc    $0xffff
 4ea25f1c : sqrshl v28.4s, v24.4s, v2.4s             : sqrshl %q24 %q2 $0x02 -> %q28
 4ee25f1c : sqrshl v28.2d, v24.2d, v2.2d             : sqrshl %q24 %q2 $0x03 -> %q28
 
+# SQSHL <V><d>, <V><n>, <V><m>
+5e224c20 : sqshl b0, b1, b2                         : sqshl  %b1 %b2 -> %b0
+5e244c65 : sqshl b5, b3, b4                         : sqshl  %b3 %b4 -> %b5
+5e294d0a : sqshl b10, b8, b9                        : sqshl  %b8 %b9 -> %b10
+5e2e4daf : sqshl b15, b13, b14                      : sqshl  %b13 %b14 -> %b15
+5e334e54 : sqshl b20, b18, b19                      : sqshl  %b18 %b19 -> %b20
+5e384ef9 : sqshl b25, b23, b24                      : sqshl  %b23 %b24 -> %b25
+5e3d4f9e : sqshl b30, b28, b29                      : sqshl  %b28 %b29 -> %b30
+5e624c20 : sqshl h0, h1, h2                         : sqshl  %h1 %h2 -> %h0
+5e644c65 : sqshl h5, h3, h4                         : sqshl  %h3 %h4 -> %h5
+5e694d0a : sqshl h10, h8, h9                        : sqshl  %h8 %h9 -> %h10
+5e6e4daf : sqshl h15, h13, h14                      : sqshl  %h13 %h14 -> %h15
+5e734e54 : sqshl h20, h18, h19                      : sqshl  %h18 %h19 -> %h20
+5e784ef9 : sqshl h25, h23, h24                      : sqshl  %h23 %h24 -> %h25
+5e7d4f9e : sqshl h30, h28, h29                      : sqshl  %h28 %h29 -> %h30
+5ea24c20 : sqshl s0, s1, s2                         : sqshl  %s1 %s2 -> %s0
+5ea44c65 : sqshl s5, s3, s4                         : sqshl  %s3 %s4 -> %s5
+5ea94d0a : sqshl s10, s8, s9                        : sqshl  %s8 %s9 -> %s10
+5eae4daf : sqshl s15, s13, s14                      : sqshl  %s13 %s14 -> %s15
+5eb34e54 : sqshl s20, s18, s19                      : sqshl  %s18 %s19 -> %s20
+5eb84ef9 : sqshl s25, s23, s24                      : sqshl  %s23 %s24 -> %s25
+5ebd4f9e : sqshl s30, s28, s29                      : sqshl  %s28 %s29 -> %s30
+5ee24c20 : sqshl d0, d1, d2                         : sqshl  %d1 %d2 -> %d0
+5ee44c65 : sqshl d5, d3, d4                         : sqshl  %d3 %d4 -> %d5
+5ee94d0a : sqshl d10, d8, d9                        : sqshl  %d8 %d9 -> %d10
+5eee4daf : sqshl d15, d13, d14                      : sqshl  %d13 %d14 -> %d15
+5ef34e54 : sqshl d20, d18, d19                      : sqshl  %d18 %d19 -> %d20
+5ef84ef9 : sqshl d25, d23, d24                      : sqshl  %d23 %d24 -> %d25
+5efd4f9e : sqshl d30, d28, d29                      : sqshl  %d28 %d29 -> %d30
+
+# SQSHL <Vd>.<T>, <Vn>.<T>, <Vm>.<T>
 0e374e6b : sqshl v11.8b, v19.8b, v23.8b             : sqshl  %d19 %d23 $0x00 -> %d11
 4e374e6b : sqshl v11.16b, v19.16b, v23.16b          : sqshl  %q19 %q23 $0x00 -> %q11
 0e774e6b : sqshl v11.4h, v19.4h, v23.4h             : sqshl  %d19 %d23 $0x01 -> %d11
@@ -3738,6 +4009,68 @@ d41fffe3 : smc    #0xffff                 : smc    $0xffff
 0eb74e6b : sqshl v11.2s, v19.2s, v23.2s             : sqshl  %d19 %d23 $0x02 -> %d11
 4eb74e6b : sqshl v11.4s, v19.4s, v23.4s             : sqshl  %q19 %q23 $0x02 -> %q11
 4ef74e6b : sqshl v11.2d, v19.2d, v23.2d             : sqshl  %q19 %q23 $0x03 -> %q11
+
+# SQSHL <V><d>, <V><n>, #<shift>
+5f087420 : sqshl b0, b1, #0                         : sqshl  %s1 $0x38 -> %s0
+5f097420 : sqshl b0, b1, #1                         : sqshl  %s1 $0x37 -> %s0
+5f0a7420 : sqshl b0, b1, #2                         : sqshl  %s1 $0x36 -> %s0
+5f0b7420 : sqshl b0, b1, #3                         : sqshl  %s1 $0x35 -> %s0
+5f0c7420 : sqshl b0, b1, #4                         : sqshl  %s1 $0x34 -> %s0
+5f0d7420 : sqshl b0, b1, #5                         : sqshl  %s1 $0x33 -> %s0
+5f0e7420 : sqshl b0, b1, #6                         : sqshl  %s1 $0x32 -> %s0
+5f0f7420 : sqshl b0, b1, #7                         : sqshl  %s1 $0x31 -> %s0
+5f107420 : sqshl h0, h1, #0                         : sqshl  %s1 $0x30 -> %s0
+5f117420 : sqshl h0, h1, #1                         : sqshl  %s1 $0x2f -> %s0
+5f127420 : sqshl h0, h1, #2                         : sqshl  %s1 $0x2e -> %s0
+5f137420 : sqshl h0, h1, #3                         : sqshl  %s1 $0x2d -> %s0
+5f147420 : sqshl h0, h1, #4                         : sqshl  %s1 $0x2c -> %s0
+5f157420 : sqshl h0, h1, #5                         : sqshl  %s1 $0x2b -> %s0
+5f167420 : sqshl h0, h1, #6                         : sqshl  %s1 $0x2a -> %s0
+5f177420 : sqshl h0, h1, #7                         : sqshl  %s1 $0x29 -> %s0
+5f187420 : sqshl h0, h1, #8                         : sqshl  %s1 $0x28 -> %s0
+5f197420 : sqshl h0, h1, #9                         : sqshl  %s1 $0x27 -> %s0
+5f1a7420 : sqshl h0, h1, #10                        : sqshl  %s1 $0x26 -> %s0
+5f1b7420 : sqshl h0, h1, #11                        : sqshl  %s1 $0x25 -> %s0
+5f1c7420 : sqshl h0, h1, #12                        : sqshl  %s1 $0x24 -> %s0
+5f1d7420 : sqshl h0, h1, #13                        : sqshl  %s1 $0x23 -> %s0
+5f1e7420 : sqshl h0, h1, #14                        : sqshl  %s1 $0x22 -> %s0
+5f1f7420 : sqshl h0, h1, #15                        : sqshl  %s1 $0x21 -> %s0
+5f207420 : sqshl s0, s1, #0                         : sqshl  %s1 $0x20 -> %s0
+5f217420 : sqshl s0, s1, #1                         : sqshl  %s1 $0x1f -> %s0
+5f227420 : sqshl s0, s1, #2                         : sqshl  %s1 $0x1e -> %s0
+5f237420 : sqshl s0, s1, #3                         : sqshl  %s1 $0x1d -> %s0
+5f247420 : sqshl s0, s1, #4                         : sqshl  %s1 $0x1c -> %s0
+5f257420 : sqshl s0, s1, #5                         : sqshl  %s1 $0x1b -> %s0
+5f267420 : sqshl s0, s1, #6                         : sqshl  %s1 $0x1a -> %s0
+5f277420 : sqshl s0, s1, #7                         : sqshl  %s1 $0x19 -> %s0
+5f287420 : sqshl s0, s1, #8                         : sqshl  %s1 $0x18 -> %s0
+5f297420 : sqshl s0, s1, #9                         : sqshl  %s1 $0x17 -> %s0
+5f2a7420 : sqshl s0, s1, #10                        : sqshl  %s1 $0x16 -> %s0
+5f2b7420 : sqshl s0, s1, #11                        : sqshl  %s1 $0x15 -> %s0
+5f2c7420 : sqshl s0, s1, #12                        : sqshl  %s1 $0x14 -> %s0
+5f2d7420 : sqshl s0, s1, #13                        : sqshl  %s1 $0x13 -> %s0
+5f2e7420 : sqshl s0, s1, #14                        : sqshl  %s1 $0x12 -> %s0
+5f2f7420 : sqshl s0, s1, #15                        : sqshl  %s1 $0x11 -> %s0
+5f307420 : sqshl s0, s1, #16                        : sqshl  %s1 $0x10 -> %s0
+5f317420 : sqshl s0, s1, #17                        : sqshl  %s1 $0x0f -> %s0
+5f327420 : sqshl s0, s1, #18                        : sqshl  %s1 $0x0e -> %s0
+5f337420 : sqshl s0, s1, #19                        : sqshl  %s1 $0x0d -> %s0
+5f347420 : sqshl s0, s1, #20                        : sqshl  %s1 $0x0c -> %s0
+5f357420 : sqshl s0, s1, #21                        : sqshl  %s1 $0x0b -> %s0
+5f367420 : sqshl s0, s1, #22                        : sqshl  %s1 $0x0a -> %s0
+5f377420 : sqshl s0, s1, #23                        : sqshl  %s1 $0x09 -> %s0
+5f387420 : sqshl s0, s1, #24                        : sqshl  %s1 $0x08 -> %s0
+5f397420 : sqshl s0, s1, #25                        : sqshl  %s1 $0x07 -> %s0
+5f3a7420 : sqshl s0, s1, #26                        : sqshl  %s1 $0x06 -> %s0
+5f3b7420 : sqshl s0, s1, #27                        : sqshl  %s1 $0x05 -> %s0
+5f3c7420 : sqshl s0, s1, #28                        : sqshl  %s1 $0x04 -> %s0
+5f3d7420 : sqshl s0, s1, #29                        : sqshl  %s1 $0x03 -> %s0
+5f3e7420 : sqshl s0, s1, #30                        : sqshl  %s1 $0x02 -> %s0
+5f3f7420 : sqshl s0, s1, #31                        : sqshl  %s1 $0x01 -> %s0
+5f407420 : sqshl d0, d1, #0                         : sqshl  %d1 $0x40 -> %d0
+5f6a7420 : sqshl d0, d1, #42                        : sqshl  %d1 $0x16 -> %d0
+5f757420 : sqshl d0, d1, #53                        : sqshl  %d1 $0x0b -> %d0
+5f7f7420 : sqshl d0, d1, #63                        : sqshl  %d1 $0x01 -> %d0
 
 0e372de4 : sqsub v4.8b, v15.8b, v23.8b              : sqsub  %d15 %d23 $0x00 -> %d4
 4e372de4 : sqsub v4.16b, v15.16b, v23.16b           : sqsub  %q15 %q23 $0x00 -> %q4
@@ -3750,6 +4083,213 @@ d41fffe3 : smc    #0xffff                 : smc    $0xffff
 047719e4 : sqsub z4.h, z15.h, z23.h                 : sqsub  %z15 %z23 $0x01 -> %z4
 04b719e4 : sqsub z4.s, z15.s, z23.s                 : sqsub  %z15 %z23 $0x02 -> %z4
 04f719e4 : sqsub z4.d, z15.d, z23.d                 : sqsub  %z15 %z23 $0x03 -> %z4
+
+# SQXTN <Vb><d>, <Va><n>
+5e214820 : sqxtn b0, h1                             : sqxtn  %h1 -> %b0
+5e214885 : sqxtn b5, h4                             : sqxtn  %h4 -> %b5
+5e21492a : sqxtn b10, h9                            : sqxtn  %h9 -> %b10
+5e2149cf : sqxtn b15, h14                           : sqxtn  %h14 -> %b15
+5e214a74 : sqxtn b20, h19                           : sqxtn  %h19 -> %b20
+5e214b19 : sqxtn b25, h24                           : sqxtn  %h24 -> %b25
+5e214bbe : sqxtn b30, h29                           : sqxtn  %h29 -> %b30
+5e614820 : sqxtn h0, s1                             : sqxtn  %s1 -> %h0
+5e614885 : sqxtn h5, s4                             : sqxtn  %s4 -> %h5
+5e61492a : sqxtn h10, s9                            : sqxtn  %s9 -> %h10
+5e6149cf : sqxtn h15, s14                           : sqxtn  %s14 -> %h15
+5e614a74 : sqxtn h20, s19                           : sqxtn  %s19 -> %h20
+5e614b19 : sqxtn h25, s24                           : sqxtn  %s24 -> %h25
+5e614bbe : sqxtn h30, s29                           : sqxtn  %s29 -> %h30
+5ea14820 : sqxtn s0, d1                             : sqxtn  %d1 -> %s0
+5ea14885 : sqxtn s5, d4                             : sqxtn  %d4 -> %s5
+5ea1492a : sqxtn s10, d9                            : sqxtn  %d9 -> %s10
+5ea149cf : sqxtn s15, d14                           : sqxtn  %d14 -> %s15
+5ea14a74 : sqxtn s20, d19                           : sqxtn  %d19 -> %s20
+5ea14b19 : sqxtn s25, d24                           : sqxtn  %d24 -> %s25
+5ea14bbe : sqxtn s30, d29                           : sqxtn  %d29 -> %s30
+
+# SQXTN <Vd>.<Tb>, <Vn>.<Ta>
+0e214820 : sqxtn v0.8b, v1.8h                       : sqxtn  %d1 $0x00 -> %d0
+0e214885 : sqxtn v5.8b, v4.8h                       : sqxtn  %d4 $0x00 -> %d5
+0e21492a : sqxtn v10.8b, v9.8h                      : sqxtn  %d9 $0x00 -> %d10
+0e2149cf : sqxtn v15.8b, v14.8h                     : sqxtn  %d14 $0x00 -> %d15
+0e214a74 : sqxtn v20.8b, v19.8h                     : sqxtn  %d19 $0x00 -> %d20
+0e214b19 : sqxtn v25.8b, v24.8h                     : sqxtn  %d24 $0x00 -> %d25
+0e214bbe : sqxtn v30.8b, v29.8h                     : sqxtn  %d29 $0x00 -> %d30
+0e614820 : sqxtn v0.4h, v1.4s                       : sqxtn  %d1 $0x01 -> %d0
+0e614885 : sqxtn v5.4h, v4.4s                       : sqxtn  %d4 $0x01 -> %d5
+0e61492a : sqxtn v10.4h, v9.4s                      : sqxtn  %d9 $0x01 -> %d10
+0e6149cf : sqxtn v15.4h, v14.4s                     : sqxtn  %d14 $0x01 -> %d15
+0e614a74 : sqxtn v20.4h, v19.4s                     : sqxtn  %d19 $0x01 -> %d20
+0e614b19 : sqxtn v25.4h, v24.4s                     : sqxtn  %d24 $0x01 -> %d25
+0e614bbe : sqxtn v30.4h, v29.4s                     : sqxtn  %d29 $0x01 -> %d30
+0ea14820 : sqxtn v0.2s, v1.2d                       : sqxtn  %d1 $0x02 -> %d0
+0ea14885 : sqxtn v5.2s, v4.2d                       : sqxtn  %d4 $0x02 -> %d5
+0ea1492a : sqxtn v10.2s, v9.2d                      : sqxtn  %d9 $0x02 -> %d10
+0ea149cf : sqxtn v15.2s, v14.2d                     : sqxtn  %d14 $0x02 -> %d15
+0ea14a74 : sqxtn v20.2s, v19.2d                     : sqxtn  %d19 $0x02 -> %d20
+0ea14b19 : sqxtn v25.2s, v24.2d                     : sqxtn  %d24 $0x02 -> %d25
+0ea14bbe : sqxtn v30.2s, v29.2d                     : sqxtn  %d29 $0x02 -> %d30
+
+# SQXTN2 <Vd>.<Tb>, <Vn>.<Ta>
+4e214820 : sqxtn2 v0.16b, v1.8h                     : sqxtn2 %q1 $0x00 -> %q0
+4e214885 : sqxtn2 v5.16b, v4.8h                     : sqxtn2 %q4 $0x00 -> %q5
+4e21492a : sqxtn2 v10.16b, v9.8h                    : sqxtn2 %q9 $0x00 -> %q10
+4e2149cf : sqxtn2 v15.16b, v14.8h                   : sqxtn2 %q14 $0x00 -> %q15
+4e214a74 : sqxtn2 v20.16b, v19.8h                   : sqxtn2 %q19 $0x00 -> %q20
+4e214b19 : sqxtn2 v25.16b, v24.8h                   : sqxtn2 %q24 $0x00 -> %q25
+4e214bbe : sqxtn2 v30.16b, v29.8h                   : sqxtn2 %q29 $0x00 -> %q30
+4e614820 : sqxtn2 v0.8h, v1.4s                      : sqxtn2 %q1 $0x01 -> %q0
+4e614885 : sqxtn2 v5.8h, v4.4s                      : sqxtn2 %q4 $0x01 -> %q5
+4e61492a : sqxtn2 v10.8h, v9.4s                     : sqxtn2 %q9 $0x01 -> %q10
+4e6149cf : sqxtn2 v15.8h, v14.4s                    : sqxtn2 %q14 $0x01 -> %q15
+4e614a74 : sqxtn2 v20.8h, v19.4s                    : sqxtn2 %q19 $0x01 -> %q20
+4e614b19 : sqxtn2 v25.8h, v24.4s                    : sqxtn2 %q24 $0x01 -> %q25
+4e614bbe : sqxtn2 v30.8h, v29.4s                    : sqxtn2 %q29 $0x01 -> %q30
+4ea14820 : sqxtn2 v0.4s, v1.2d                      : sqxtn2 %q1 $0x02 -> %q0
+4ea14885 : sqxtn2 v5.4s, v4.2d                      : sqxtn2 %q4 $0x02 -> %q5
+4ea1492a : sqxtn2 v10.4s, v9.2d                     : sqxtn2 %q9 $0x02 -> %q10
+4ea149cf : sqxtn2 v15.4s, v14.2d                    : sqxtn2 %q14 $0x02 -> %q15
+4ea14a74 : sqxtn2 v20.4s, v19.2d                    : sqxtn2 %q19 $0x02 -> %q20
+4ea14b19 : sqxtn2 v25.4s, v24.2d                    : sqxtn2 %q24 $0x02 -> %q25
+4ea14bbe : sqxtn2 v30.4s, v29.2d                    : sqxtn2 %q29 $0x02 -> %q30
+
+# SQXTUN <Vb><d>, <Va><n>
+7e212820 : sqxtun b0, h1                            : sqxtun %h1 -> %b0
+7e212885 : sqxtun b5, h4                            : sqxtun %h4 -> %b5
+7e21292a : sqxtun b10, h9                           : sqxtun %h9 -> %b10
+7e2129cf : sqxtun b15, h14                          : sqxtun %h14 -> %b15
+7e212a74 : sqxtun b20, h19                          : sqxtun %h19 -> %b20
+7e212b19 : sqxtun b25, h24                          : sqxtun %h24 -> %b25
+7e212bbe : sqxtun b30, h29                          : sqxtun %h29 -> %b30
+7e612820 : sqxtun h0, s1                            : sqxtun %s1 -> %h0
+7e612885 : sqxtun h5, s4                            : sqxtun %s4 -> %h5
+7e61292a : sqxtun h10, s9                           : sqxtun %s9 -> %h10
+7e6129cf : sqxtun h15, s14                          : sqxtun %s14 -> %h15
+7e612a74 : sqxtun h20, s19                          : sqxtun %s19 -> %h20
+7e612b19 : sqxtun h25, s24                          : sqxtun %s24 -> %h25
+7e612bbe : sqxtun h30, s29                          : sqxtun %s29 -> %h30
+7ea12820 : sqxtun s0, d1                            : sqxtun %d1 -> %s0
+7ea12885 : sqxtun s5, d4                            : sqxtun %d4 -> %s5
+7ea1292a : sqxtun s10, d9                           : sqxtun %d9 -> %s10
+7ea129cf : sqxtun s15, d14                          : sqxtun %d14 -> %s15
+7ea12a74 : sqxtun s20, d19                          : sqxtun %d19 -> %s20
+7ea12b19 : sqxtun s25, d24                          : sqxtun %d24 -> %s25
+7ea12bbe : sqxtun s30, d29                          : sqxtun %d29 -> %s30
+
+# SQXTUN <Vd>.<Tb>, <Vn>.<Ta>
+2e212820 : sqxtun v0.8b, v1.8h                      : sqxtun %d1 $0x00 -> %d0
+2e212885 : sqxtun v5.8b, v4.8h                      : sqxtun %d4 $0x00 -> %d5
+2e21292a : sqxtun v10.8b, v9.8h                     : sqxtun %d9 $0x00 -> %d10
+2e2129cf : sqxtun v15.8b, v14.8h                    : sqxtun %d14 $0x00 -> %d15
+2e212a74 : sqxtun v20.8b, v19.8h                    : sqxtun %d19 $0x00 -> %d20
+2e212b19 : sqxtun v25.8b, v24.8h                    : sqxtun %d24 $0x00 -> %d25
+2e212bbe : sqxtun v30.8b, v29.8h                    : sqxtun %d29 $0x00 -> %d30
+2e612820 : sqxtun v0.4h, v1.4s                      : sqxtun %d1 $0x01 -> %d0
+2e612885 : sqxtun v5.4h, v4.4s                      : sqxtun %d4 $0x01 -> %d5
+2e61292a : sqxtun v10.4h, v9.4s                     : sqxtun %d9 $0x01 -> %d10
+2e6129cf : sqxtun v15.4h, v14.4s                    : sqxtun %d14 $0x01 -> %d15
+2e612a74 : sqxtun v20.4h, v19.4s                    : sqxtun %d19 $0x01 -> %d20
+2e612b19 : sqxtun v25.4h, v24.4s                    : sqxtun %d24 $0x01 -> %d25
+2e612bbe : sqxtun v30.4h, v29.4s                    : sqxtun %d29 $0x01 -> %d30
+2ea12820 : sqxtun v0.2s, v1.2d                      : sqxtun %d1 $0x02 -> %d0
+2ea12885 : sqxtun v5.2s, v4.2d                      : sqxtun %d4 $0x02 -> %d5
+2ea1292a : sqxtun v10.2s, v9.2d                     : sqxtun %d9 $0x02 -> %d10
+2ea129cf : sqxtun v15.2s, v14.2d                    : sqxtun %d14 $0x02 -> %d15
+2ea12a74 : sqxtun v20.2s, v19.2d                    : sqxtun %d19 $0x02 -> %d20
+2ea12b19 : sqxtun v25.2s, v24.2d                    : sqxtun %d24 $0x02 -> %d25
+2ea12bbe : sqxtun v30.2s, v29.2d                    : sqxtun %d29 $0x02 -> %d30
+
+# SQXTUN2 <Vd>.<Tb>, <Vn>.<Ta>
+6e212820 : sqxtun2 v0.16b, v1.8h                    : sqxtun2 %q1 $0x00 -> %q0
+6e212885 : sqxtun2 v5.16b, v4.8h                    : sqxtun2 %q4 $0x00 -> %q5
+6e21292a : sqxtun2 v10.16b, v9.8h                   : sqxtun2 %q9 $0x00 -> %q10
+6e2129cf : sqxtun2 v15.16b, v14.8h                  : sqxtun2 %q14 $0x00 -> %q15
+6e212a74 : sqxtun2 v20.16b, v19.8h                  : sqxtun2 %q19 $0x00 -> %q20
+6e212b19 : sqxtun2 v25.16b, v24.8h                  : sqxtun2 %q24 $0x00 -> %q25
+6e212bbe : sqxtun2 v30.16b, v29.8h                  : sqxtun2 %q29 $0x00 -> %q30
+6e612820 : sqxtun2 v0.8h, v1.4s                     : sqxtun2 %q1 $0x01 -> %q0
+6e612885 : sqxtun2 v5.8h, v4.4s                     : sqxtun2 %q4 $0x01 -> %q5
+6e61292a : sqxtun2 v10.8h, v9.4s                    : sqxtun2 %q9 $0x01 -> %q10
+6e6129cf : sqxtun2 v15.8h, v14.4s                   : sqxtun2 %q14 $0x01 -> %q15
+6e612a74 : sqxtun2 v20.8h, v19.4s                   : sqxtun2 %q19 $0x01 -> %q20
+6e612b19 : sqxtun2 v25.8h, v24.4s                   : sqxtun2 %q24 $0x01 -> %q25
+6e612bbe : sqxtun2 v30.8h, v29.4s                   : sqxtun2 %q29 $0x01 -> %q30
+6ea12820 : sqxtun2 v0.4s, v1.2d                     : sqxtun2 %q1 $0x02 -> %q0
+6ea12885 : sqxtun2 v5.4s, v4.2d                     : sqxtun2 %q4 $0x02 -> %q5
+6ea1292a : sqxtun2 v10.4s, v9.2d                    : sqxtun2 %q9 $0x02 -> %q10
+6ea129cf : sqxtun2 v15.4s, v14.2d                   : sqxtun2 %q14 $0x02 -> %q15
+6ea12a74 : sqxtun2 v20.4s, v19.2d                   : sqxtun2 %q19 $0x02 -> %q20
+6ea12b19 : sqxtun2 v25.4s, v24.2d                   : sqxtun2 %q24 $0x02 -> %q25
+6ea12bbe : sqxtun2 v30.4s, v29.2d                   : sqxtun2 %q29 $0x02 -> %q30
+
+# UQXTN <Vb><d>, <Va><n>
+7e214820 : uqxtn b0, h1                             : uqxtn  %h1 -> %b0
+7e214885 : uqxtn b5, h4                             : uqxtn  %h4 -> %b5
+7e21492a : uqxtn b10, h9                            : uqxtn  %h9 -> %b10
+7e2149cf : uqxtn b15, h14                           : uqxtn  %h14 -> %b15
+7e214a74 : uqxtn b20, h19                           : uqxtn  %h19 -> %b20
+7e214b19 : uqxtn b25, h24                           : uqxtn  %h24 -> %b25
+7e214bbe : uqxtn b30, h29                           : uqxtn  %h29 -> %b30
+7e614820 : uqxtn h0, s1                             : uqxtn  %s1 -> %h0
+7e614885 : uqxtn h5, s4                             : uqxtn  %s4 -> %h5
+7e61492a : uqxtn h10, s9                            : uqxtn  %s9 -> %h10
+7e6149cf : uqxtn h15, s14                           : uqxtn  %s14 -> %h15
+7e614a74 : uqxtn h20, s19                           : uqxtn  %s19 -> %h20
+7e614b19 : uqxtn h25, s24                           : uqxtn  %s24 -> %h25
+7e614bbe : uqxtn h30, s29                           : uqxtn  %s29 -> %h30
+7ea14820 : uqxtn s0, d1                             : uqxtn  %d1 -> %s0
+7ea14885 : uqxtn s5, d4                             : uqxtn  %d4 -> %s5
+7ea1492a : uqxtn s10, d9                            : uqxtn  %d9 -> %s10
+7ea149cf : uqxtn s15, d14                           : uqxtn  %d14 -> %s15
+7ea14a74 : uqxtn s20, d19                           : uqxtn  %d19 -> %s20
+7ea14b19 : uqxtn s25, d24                           : uqxtn  %d24 -> %s25
+7ea14bbe : uqxtn s30, d29                           : uqxtn  %d29 -> %s30
+
+# UQXTN <Vd>.<Tb>, <Vn>.<Ta>
+2e214820 : uqxtn v0.8b, v1.8h                       : uqxtn  %d1 $0x00 -> %d0
+2e214885 : uqxtn v5.8b, v4.8h                       : uqxtn  %d4 $0x00 -> %d5
+2e21492a : uqxtn v10.8b, v9.8h                      : uqxtn  %d9 $0x00 -> %d10
+2e2149cf : uqxtn v15.8b, v14.8h                     : uqxtn  %d14 $0x00 -> %d15
+2e214a74 : uqxtn v20.8b, v19.8h                     : uqxtn  %d19 $0x00 -> %d20
+2e214b19 : uqxtn v25.8b, v24.8h                     : uqxtn  %d24 $0x00 -> %d25
+2e214bbe : uqxtn v30.8b, v29.8h                     : uqxtn  %d29 $0x00 -> %d30
+2e614820 : uqxtn v0.4h, v1.4s                       : uqxtn  %d1 $0x01 -> %d0
+2e614885 : uqxtn v5.4h, v4.4s                       : uqxtn  %d4 $0x01 -> %d5
+2e61492a : uqxtn v10.4h, v9.4s                      : uqxtn  %d9 $0x01 -> %d10
+2e6149cf : uqxtn v15.4h, v14.4s                     : uqxtn  %d14 $0x01 -> %d15
+2e614a74 : uqxtn v20.4h, v19.4s                     : uqxtn  %d19 $0x01 -> %d20
+2e614b19 : uqxtn v25.4h, v24.4s                     : uqxtn  %d24 $0x01 -> %d25
+2e614bbe : uqxtn v30.4h, v29.4s                     : uqxtn  %d29 $0x01 -> %d30
+2ea14820 : uqxtn v0.2s, v1.2d                       : uqxtn  %d1 $0x02 -> %d0
+2ea14885 : uqxtn v5.2s, v4.2d                       : uqxtn  %d4 $0x02 -> %d5
+2ea1492a : uqxtn v10.2s, v9.2d                      : uqxtn  %d9 $0x02 -> %d10
+2ea149cf : uqxtn v15.2s, v14.2d                     : uqxtn  %d14 $0x02 -> %d15
+2ea14a74 : uqxtn v20.2s, v19.2d                     : uqxtn  %d19 $0x02 -> %d20
+2ea14b19 : uqxtn v25.2s, v24.2d                     : uqxtn  %d24 $0x02 -> %d25
+2ea14bbe : uqxtn v30.2s, v29.2d                     : uqxtn  %d29 $0x02 -> %d30
+
+# UQXTN2 <Vd>.<Tb>, <Vn>.<Ta>
+6e214820 : uqxtn2 v0.16b, v1.8h                     : uqxtn2 %q1 $0x00 -> %q0
+6e214885 : uqxtn2 v5.16b, v4.8h                     : uqxtn2 %q4 $0x00 -> %q5
+6e21492a : uqxtn2 v10.16b, v9.8h                    : uqxtn2 %q9 $0x00 -> %q10
+6e2149cf : uqxtn2 v15.16b, v14.8h                   : uqxtn2 %q14 $0x00 -> %q15
+6e214a74 : uqxtn2 v20.16b, v19.8h                   : uqxtn2 %q19 $0x00 -> %q20
+6e214b19 : uqxtn2 v25.16b, v24.8h                   : uqxtn2 %q24 $0x00 -> %q25
+6e214bbe : uqxtn2 v30.16b, v29.8h                   : uqxtn2 %q29 $0x00 -> %q30
+6e614820 : uqxtn2 v0.8h, v1.4s                      : uqxtn2 %q1 $0x01 -> %q0
+6e614885 : uqxtn2 v5.8h, v4.4s                      : uqxtn2 %q4 $0x01 -> %q5
+6e61492a : uqxtn2 v10.8h, v9.4s                     : uqxtn2 %q9 $0x01 -> %q10
+6e6149cf : uqxtn2 v15.8h, v14.4s                    : uqxtn2 %q14 $0x01 -> %q15
+6e614a74 : uqxtn2 v20.8h, v19.4s                    : uqxtn2 %q19 $0x01 -> %q20
+6e614b19 : uqxtn2 v25.8h, v24.4s                    : uqxtn2 %q24 $0x01 -> %q25
+6e614bbe : uqxtn2 v30.8h, v29.4s                    : uqxtn2 %q29 $0x01 -> %q30
+6ea14820 : uqxtn2 v0.4s, v1.2d                      : uqxtn2 %q1 $0x02 -> %q0
+6ea14885 : uqxtn2 v5.4s, v4.2d                      : uqxtn2 %q4 $0x02 -> %q5
+6ea1492a : uqxtn2 v10.4s, v9.2d                     : uqxtn2 %q9 $0x02 -> %q10
+6ea149cf : uqxtn2 v15.4s, v14.2d                    : uqxtn2 %q14 $0x02 -> %q15
+6ea14a74 : uqxtn2 v20.4s, v19.2d                    : uqxtn2 %q19 $0x02 -> %q20
+6ea14b19 : uqxtn2 v25.4s, v24.2d                    : uqxtn2 %q24 $0x02 -> %q25
+6ea14bbe : uqxtn2 v30.4s, v29.2d                    : uqxtn2 %q29 $0x02 -> %q30
 
 0e2a163f : srhadd v31.8b, v17.8b, v10.8b            : srhadd %d17 %d10 $0x00 -> %d31
 4e2a163f : srhadd v31.16b, v17.16b, v10.16b         : srhadd %q17 %q10 $0x00 -> %q31


### PR DESCRIPTION
Adds the following instructions to the codec
- SQRDMULH (by element scalar, by element vector, vector scalar)
- SQRDMLAH (by element scalar, by element vector, vector scalar)
- SQRDMULH (by element scalar, by element vector, vector scalar)
- SQSHL    (immediate scalar, register scalar, register vector)
- SQXTN    (scalar, vector)
- SQXTN2   (vector)
- SQXTUN   (scalar, vector)
- SQXTUN2  (vector)
- UQXTN    (scalar, vector)
- UQXTN2   (vector)

Issue: #2626