### PR TITLE
i#4965: Add SVG data path modification.

### DIFF
--- a/api/docs/CMake_rundoxygen.cmake
+++ b/api/docs/CMake_rundoxygen.cmake
@@ -181,6 +181,10 @@ if (embeddable)
       string "${string}")
     # Our images are in an images/ subdir.
     string(REGEX REPLACE "<img src=\"" "<img src=\"/images/" string "${string}")
+    string(REGEX REPLACE
+        "<object type=\"image/svg\\+xml\" data=\""
+        "<object type=\"image/svg+xml\" data=\"/images/"
+        string "${string}")
 
     # Collect type info for keyword searches with direct anchor links (else the
     # search finds the page but the user then has to manually search within the long


### PR DESCRIPTION
Adds a regex command for docs to find SVG data in /images.

Fixes: #4965