### PR TITLE
Fix quoting mishap in build-from-source docs

### DIFF
--- a/api/docs/building.dox
+++ b/api/docs/building.dox
@@ -821,7 +821,7 @@ Here is a sample bash function to make building easier within Cygwin:
 
 ```
 function build {
-    config=`grep ^CMAKE_CONFIGURATION_TYPES:S CMakeCache.txt | sed 's/^.*=//'`
+    config=$(grep ^CMAKE_CONFIGURATION_TYPES:S CMakeCache.txt | sed 's/^.*=//')
     /usr/bin/time cmake --build . --config $config -- /m
 }
 ```
@@ -886,7 +886,7 @@ than two cores we have seen some strange build errors that may be pdb
 creation races.  We recommend using the Visual Studio generator instead if
 you are hitting these problems.
 
-## Building the Qt DrGUI extension
+\section sec_drgui Building the Qt DrGUI extension
 
 Simply install Qt 5.x and ensure that the architecture and compiler match what you will be using to build DynamoRIO.  E.g., on Fedora:
 ```


### PR DESCRIPTION
Apparently Doxygen's markdown parser cannot handle a single backtic
inside a triple-backtic quote block.  This was causing a messed-up
sequence of what is quoted and what is not and a missed final section
on the build-from-source web page.  We fix it here by switching to $()
instead of backtics in a bash function; we also add a named link to
the DrGUI build directions since Dr. Memory links to them.