### PR TITLE
i#4274 kernel pc: Provide rseq abort interrupted pc

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -222,6 +222,8 @@ Further non-compatibility-affecting changes include:
  - Added the reconstructed #instrlist_t when available for the faulting fragment
    to #dr_fault_fragment_info_t. This makes it available to the restore state
    event callback(s) via the #dr_restore_state_info_t arg.
+ - Added the source context for restartable sequence aborts (#DR_XFER_RSEQ_ABORT)
+   which was previously missing.
 
 **************************************************
 <hr>

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1364,6 +1364,7 @@ mangle_rseq(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
                 "Rseq sequences must fall through their endpoints");
             ASSERT_NOT_REACHED();
         }
+        rseq_set_final_instr_pc(start, pc);
         mangle_rseq_insert_native_sequence(dcontext, ilist, instr, next_instr, flags,
                                            start, end, handler, scratch_reg, reg_written,
                                            reg_written_count);

--- a/core/lib/dr_events.h
+++ b/core/lib/dr_events.h
@@ -946,9 +946,12 @@ typedef struct _dr_kernel_xfer_info_t {
     dr_kernel_xfer_type_t type;
     /**
      * The source machine context which is about to be changed.  This may be NULL
-     * if it is unknown, which is the case for #DR_XFER_CALLBACK_DISPATCHER and
-     * #DR_XFER_RSEQ_ABORT (where the PC is not known but the rest of the state
-     * matches the current state).
+     * if it is unknown, which is the case for #DR_XFER_CALLBACK_DISPATCHER.
+     * For #DR_XFER_RSEQ_ABORT, due to the constraints of handling restartable
+     * sequences, the abort PC will point prior to the committing store, while
+     * that store already executed during instrumentation.  We recommend that
+     * clients treat the store as never-executed in that situation, if possible,
+     * to produce a more-representative sequence.
      */
     const dr_mcontext_t *source_mcontext;
     /**

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -545,6 +545,9 @@ extern vm_area_vector_t *d_r_rseq_areas;
 bool
 rseq_get_region_info(app_pc pc, app_pc *start OUT, app_pc *end OUT, app_pc *handler OUT,
                      bool **reg_written OUT, int *reg_written_size OUT);
+
+bool
+rseq_set_final_instr_pc(app_pc start, app_pc final_instr_pc);
 
 int
 rseq_get_tls_ptr_offset(void);

--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -933,10 +933,12 @@ kernel_xfer_event(void *drcontext, const dr_kernel_xfer_info_t *info)
 #    else
 #        error Unsupported arch
 #    endif
+#    ifdef DEBUG /* See above: special code in core/ is DEBUG-only> */
         /* Check that the interrupted PC for the true abort case is *prior* to the
          * committing store.
          */
         assert(info->source_mcontext->pc == (app_pc)test_rseq_native_abort_pre_commit);
+#    endif
     }
 }
 


### PR DESCRIPTION
Adds source context information to the kernel xfer event for rseq
aborts, which was previously missing.  To provide the interrupted rseq
abort PC as the PC of the final committing store, adds logic inside DR
to record that PC when it is discovered during block creation.

Updates the rseq test to check the new information.

Issue: #4274