### PR TITLE
i#4575: Track threads and nesting in trace_invariants test

### DIFF
--- a/clients/drcachesim/tests/trace_invariants.cpp
+++ b/clients/drcachesim/tests/trace_invariants.cpp
@@ -216,11 +216,13 @@ trace_invariants_t::process_memref(const memref_t &memref)
                       << "marker type " << memref.marker.marker_type << " value "
                       << memref.marker.marker_value << "\n";
         }
+#ifdef UNIX
         if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT &&
             // Give up on back-to-back signals.
             prev_xfer_marker_[memref.data.tid].marker.marker_type !=
                 TRACE_MARKER_TYPE_KERNEL_XFER)
             pre_signal_instr_[memref.data.tid].push(prev_instr_[memref.data.tid]);
+#endif
         prev_xfer_marker_[memref.data.tid] = memref;
     }
 

--- a/clients/drcachesim/tests/trace_invariants.h
+++ b/clients/drcachesim/tests/trace_invariants.h
@@ -38,6 +38,7 @@
 
 #include "../analysis_tool.h"
 #include "../common/memref.h"
+#include <stack>
 #include <unordered_map>
 
 class trace_invariants_t : public analysis_tool_t {
@@ -54,13 +55,13 @@ protected:
     bool knob_offline_;
     unsigned int knob_verbose_;
     std::string knob_test_name_;
-    memref_t prev_instr_;
-    memref_t prev_xfer_marker_;
-    memref_t prev_entry_;
-    memref_t prev_prev_entry_;
-    memref_t pre_signal_instr_;
-    int instrs_until_interrupt_;
-    int memrefs_until_interrupt_;
+    std::unordered_map<memref_tid_t, memref_t> prev_instr_;
+    std::unordered_map<memref_tid_t, memref_t> prev_xfer_marker_;
+    std::unordered_map<memref_tid_t, memref_t> prev_entry_;
+    std::unordered_map<memref_tid_t, memref_t> prev_prev_entry_;
+    std::unordered_map<memref_tid_t, std::stack<memref_t>> pre_signal_instr_;
+    std::unordered_map<memref_tid_t, int> instrs_until_interrupt_;
+    std::unordered_map<memref_tid_t, int> memrefs_until_interrupt_;
     addr_t app_handler_pc_;
     offline_file_type_t file_type_ = OFFLINE_FILE_TYPE_DEFAULT;
     std::unordered_map<memref_tid_t, bool> thread_exited_;

--- a/clients/drcachesim/tests/trace_invariants.h
+++ b/clients/drcachesim/tests/trace_invariants.h
@@ -58,9 +58,9 @@ protected:
     memref_t prev_interleaved_instr_;
     std::unordered_map<memref_tid_t, memref_t> prev_instr_;
     std::unordered_map<memref_tid_t, memref_t> prev_xfer_marker_;
+#ifdef UNIX
     std::unordered_map<memref_tid_t, memref_t> prev_entry_;
     std::unordered_map<memref_tid_t, memref_t> prev_prev_entry_;
-#ifdef UNIX
     std::unordered_map<memref_tid_t, std::stack<memref_t>> pre_signal_instr_;
     // These are only available via annotations in signal_invariants.cpp.
     std::unordered_map<memref_tid_t, int> instrs_until_interrupt_;

--- a/clients/drcachesim/tests/trace_invariants.h
+++ b/clients/drcachesim/tests/trace_invariants.h
@@ -60,9 +60,12 @@ protected:
     std::unordered_map<memref_tid_t, memref_t> prev_xfer_marker_;
     std::unordered_map<memref_tid_t, memref_t> prev_entry_;
     std::unordered_map<memref_tid_t, memref_t> prev_prev_entry_;
+#ifdef UNIX
     std::unordered_map<memref_tid_t, std::stack<memref_t>> pre_signal_instr_;
+    // These are only available via annotations in signal_invariants.cpp.
     std::unordered_map<memref_tid_t, int> instrs_until_interrupt_;
     std::unordered_map<memref_tid_t, int> memrefs_until_interrupt_;
+#endif
     addr_t app_handler_pc_;
     offline_file_type_t file_type_ = OFFLINE_FILE_TYPE_DEFAULT;
     std::unordered_map<memref_tid_t, bool> thread_exited_;

--- a/clients/drcachesim/tests/trace_invariants.h
+++ b/clients/drcachesim/tests/trace_invariants.h
@@ -55,6 +55,7 @@ protected:
     bool knob_offline_;
     unsigned int knob_verbose_;
     std::string knob_test_name_;
+    memref_t prev_interleaved_instr_;
     std::unordered_map<memref_tid_t, memref_t> prev_instr_;
     std::unordered_map<memref_tid_t, memref_t> prev_xfer_marker_;
     std::unordered_map<memref_tid_t, memref_t> prev_entry_;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3360,16 +3360,10 @@ if (BUILD_CLIENTS)
       set(kernel_xfer_app client.winxfer) # We want threads and xfers.
     endif()
     if (DEBUG) # for -test_mode
-      if (WIN32)
-        # Just like for tool.histogram.offline, this is slow on Windows, so
-        # we narrow the tracing window a little.  If we delay too far we start
-        # in the middle of a callback and hit asserts though.
-        set(invariants_ops "-trace_after_instrs 5M")
-      else ()
-        set(invariants_ops "")
-      endif ()
-      torunonly_drcachesim(invariants ${kernel_xfer_app}
-        "-test_mode ${invariants_ops}" "")
+      torunonly_drcachesim(invariants ${kernel_xfer_app} "-test_mode" "")
+      # This is slow on Windows.  I tried reducing the tracing window but
+      # it seems to vary too much across machines, and if we delay too far
+      # we start in the middle of a callback.
       set(tool.drcachesim.invariants_timeout 180)
     endif ()
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3362,8 +3362,9 @@ if (BUILD_CLIENTS)
     if (DEBUG) # for -test_mode
       if (WIN32)
         # Just like for tool.histogram.offline, this is slow on Windows, so
-        # we narrow the tracing window.
-        set(invariants_ops "-trace_after_instrs 20M")
+        # we narrow the tracing window a little.  If we delay too far we start
+        # in the middle of a callback and hit asserts though.
+        set(invariants_ops "-trace_after_instrs 5M")
       else ()
         set(invariants_ops "")
       endif ()

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3360,7 +3360,16 @@ if (BUILD_CLIENTS)
       set(kernel_xfer_app client.winxfer) # We want threads and xfers.
     endif()
     if (DEBUG) # for -test_mode
-      torunonly_drcachesim(invariants ${kernel_xfer_app} "-test_mode" "")
+      if (WIN32)
+        # Just like for tool.histogram.offline, this is slow on Windows, so
+        # we narrow the tracing window.
+        set(invariants_ops "-trace_after_instrs 20M")
+      else ()
+        set(invariants_ops "")
+      endif ()
+      torunonly_drcachesim(invariants ${kernel_xfer_app}
+        "-test_mode ${invariants_ops}" "")
+      set(tool.drcachesim.invariants_timeout 180)
     endif ()
 
     if (NOT MACOS AND X86)


### PR DESCRIPTION
Improves the robustness of the trace_invariants test by shifting the
various tracked state to be per-thread and per-nested-signal, avoiding
incorrect results from thread interleavings or nested signals.
This presumably explains past flakiness like #4575.

Fixes #4575