### PR TITLE
i#4274 kernel pc: Export version number in final trace

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -224,6 +224,7 @@ Further non-compatibility-affecting changes include:
    event callback(s) via the #dr_restore_state_info_t arg.
  - Added the source context for restartable sequence aborts (#DR_XFER_RSEQ_ABORT)
    which was previously missing.
+ - Added a #TRACE_MARKER_TYPE_VERSION entry to drmemtrace traces.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -53,7 +53,14 @@
 
 typedef uintptr_t addr_t; /**< The type of a memory address. */
 
-#define TRACE_ENTRY_VERSION 2 /**< The version of the trace format. */
+/**
+ * The version number of the trace format.
+ * This is presented to analysis tools as a marker of type
+ * #TRACE_MARKER_TYPE_VERSION.
+ */
+typedef enum {
+    TRACE_ENTRY_VERSION = 2 /**< The latest version of the trace format. */
+} trace_version_t;
 
 /** The type of a trace entry in a #memref_t structure. */
 // The type identifier for trace entries in the raw trace_entry_t passed to
@@ -286,6 +293,13 @@ typedef enum {
      * present in online-cache-filtered traces and is placed at thread exit.
      */
     TRACE_MARKER_TYPE_INSTRUCTION_COUNT,
+
+    /**
+     * The marker value contains the version of the trace format: a value
+     * of type #trace_version_t.  The marker is present in the first few entries
+     * of a trace file.
+     */
+    TRACE_MARKER_TYPE_VERSION,
 
     // ...
     // These values are reserved for future built-in marker types.

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -205,6 +205,7 @@ reader_t::operator++()
             have_memref = true;
             cur_ref_.marker.type = (trace_type_t)input_entry_->type;
             assert((cur_tid_ != 0 && cur_pid_ != 0) ||
+                   input_entry_->size == TRACE_MARKER_TYPE_VERSION ||
                    input_entry_->size == TRACE_MARKER_TYPE_FILETYPE);
             cur_ref_.marker.pid = cur_pid_;
             cur_ref_.marker.tid = cur_tid_;

--- a/clients/drcachesim/tests/offline-delay-func.templatex
+++ b/clients/drcachesim/tests/offline-delay-func.templatex
@@ -16,5 +16,5 @@ Total counts:
            0 total function return address markers
            0 total function argument markers
            0 total function return value markers
-           2 total other markers
+           3 total other markers
 .*

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -59,6 +59,7 @@ view_t::view_t(const std::string &module_file_path, uint64_t skip_refs, uint64_t
                const std::string &alt_module_dir)
     : module_file_path_(module_file_path)
     , knob_verbose_(verbose)
+    , trace_version_(-1)
     , instr_count_(0)
     , knob_skip_refs_(skip_refs)
     , knob_sim_refs_(sim_refs)
@@ -100,18 +101,6 @@ view_t::initialize()
 bool
 view_t::process_memref(const memref_t &memref)
 {
-    if (memref.marker.type == TRACE_TYPE_MARKER &&
-        memref.marker.marker_type == TRACE_MARKER_TYPE_FILETYPE) {
-        if (TESTANY(OFFLINE_FILE_TYPE_ARCH_ALL, memref.marker.marker_value) &&
-            !TESTANY(build_target_arch_type(), memref.marker.marker_value)) {
-            error_string_ = std::string("Architecture mismatch: trace recorded on ") +
-                trace_arch_string(static_cast<offline_file_type_t>(
-                    memref.marker.marker_value)) +
-                " but tool built for " + trace_arch_string(build_target_arch_type());
-            return false;
-        }
-    }
-
     if (instr_count_ < knob_skip_refs_ ||
         instr_count_ >= (knob_skip_refs_ + knob_sim_refs_)) {
         if (type_is_instr(memref.instr.type) ||
@@ -122,6 +111,27 @@ view_t::process_memref(const memref_t &memref)
 
     if (memref.marker.type == TRACE_TYPE_MARKER) {
         switch (memref.marker.marker_type) {
+        case TRACE_MARKER_TYPE_VERSION:
+            std::cerr << "<marker: version " << memref.marker.marker_value << ">\n";
+            if (trace_version_ == -1)
+                trace_version_ = memref.marker.marker_value;
+            else if (trace_version_ != static_cast<int>(memref.marker.marker_value)) {
+                error_string_ = std::string("Version mismatch across files");
+                return false;
+            }
+            break;
+        case TRACE_MARKER_TYPE_FILETYPE:
+            std::cerr << "<marker: filetype 0x" << std::hex << memref.marker.marker_value
+                      << std::dec << ">\n";
+            if (TESTANY(OFFLINE_FILE_TYPE_ARCH_ALL, memref.marker.marker_value) &&
+                !TESTANY(build_target_arch_type(), memref.marker.marker_value)) {
+                error_string_ = std::string("Architecture mismatch: trace recorded on ") +
+                    trace_arch_string(static_cast<offline_file_type_t>(
+                        memref.marker.marker_value)) +
+                    " but tool built for " + trace_arch_string(build_target_arch_type());
+                return false;
+            }
+            break;
         case TRACE_MARKER_TYPE_TIMESTAMP:
             std::cerr << "<marker: timestamp " << memref.marker.marker_value << ">\n";
             break;
@@ -142,9 +152,6 @@ view_t::process_memref(const memref_t &memref)
         case TRACE_MARKER_TYPE_INSTRUCTION_COUNT:
             std::cerr << "<marker: instruction count " << memref.marker.marker_value
                       << ">\n";
-            break;
-        case TRACE_MARKER_TYPE_FILETYPE:
-            std::cerr << "<marker: filetype " << memref.marker.marker_value << ">\n";
             break;
         case TRACE_MARKER_TYPE_CACHE_LINE_SIZE:
             std::cerr << "<marker: cache line size " << memref.marker.marker_value

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -114,7 +114,7 @@ view_t::process_memref(const memref_t &memref)
         case TRACE_MARKER_TYPE_VERSION:
             std::cerr << "<marker: version " << memref.marker.marker_value << ">\n";
             if (trace_version_ == -1)
-                trace_version_ = memref.marker.marker_value;
+                trace_version_ = static_cast<int>(memref.marker.marker_value);
             else if (trace_version_ != static_cast<int>(memref.marker.marker_value)) {
                 error_string_ = std::string("Version mismatch across files");
                 return false;

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -71,6 +71,7 @@ protected:
     std::unique_ptr<module_mapper_t> module_mapper_;
     raw2trace_directory_t directory_;
     unsigned int knob_verbose_;
+    int trace_version_;
     uint64_t instr_count_;
     static const std::string TOOL_NAME;
     uint64_t knob_skip_refs_;

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -145,6 +145,7 @@ online_instru_t::append_thread_header(byte *buf_ptr, thread_id_t tid,
     new_buf += append_tid(new_buf, tid);
     new_buf += append_pid(new_buf, dr_get_process_id());
 
+    new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION);
     new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_FILETYPE, file_type);
     new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_CACHE_LINE_SIZE,
                              proc_get_cache_line_size());

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -507,10 +507,11 @@ module_mapper_t::write_module_data(char *buf, size_t buf_size,
 std::string
 raw2trace_t::process_header(raw2trace_thread_data_t *tdata)
 {
+    int version = TRACE_ENTRY_VERSION;
     trace_entry_t entry;
     entry.type = TRACE_TYPE_HEADER;
     entry.size = 0;
-    entry.addr = TRACE_ENTRY_VERSION;
+    entry.addr = version;
     if (!tdata->out_file->write((char *)&entry, sizeof(entry)))
         return "Failed to write header to output file";
 
@@ -530,7 +531,8 @@ raw2trace_t::process_header(raw2trace_thread_data_t *tdata)
     DR_ASSERT(pid != (process_id_t)INVALID_PROCESS_ID);
     byte *buf_base = reinterpret_cast<byte *>(get_write_buffer(tdata));
     byte *buf = buf_base;
-    // Write the arch and other type flags.
+    // Write the version, arch, and other type flags.
+    buf += instru.append_marker(buf, TRACE_MARKER_TYPE_VERSION, version);
     buf += instru.append_marker(buf, TRACE_MARKER_TYPE_FILETYPE, tdata->file_type);
     // Write out the tid, pid, and timestamp.
     buf += trace_metadata_writer_t::write_tid(buf, tid);


### PR DESCRIPTION
The version number in a drmemtrace trace is currently hidden in a
header that the reader hides from analysis tools.  Here we add a new
marker type that exports the version number so that analysis tools can
handle legacy traces.

Adds version awareness to the view tool.

Tested by manually running the view tool:
  $ bin64/drrun -t drcachesim -verbose 3 -- suite/tests/bin/allasm_repstr
  ::4152878.4152878:: marker type 12 value 2
  ::4152878.4152878:: marker type 9 value 64
  ::4152878.4152878:: marker type 10 value 64
  ...
  $ bin64/drrun -t drcachesim -offline -- suite/tests/bin/allasm_repstr
  $ bin64/drrun -t drcachesim -simulator_type view -indir drmemtrace.allasm_repstr.*.dir
  <marker: version 2>
  <marker: filetype 40>
  <marker: cache line size 64>
  <marker: timestamp 13269494545173426>
  <marker: tid 4152931 on core 2>
    0x0000000000401000  48 83 e4 f0          and    $0xf0, %rsp
  ...

Issue: #4274