### PR TITLE
i#2626: AArch64 v8.0 decode: Add SHA- instructions to codec

### DIFF
--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -1433,3 +1433,14 @@ x001111001000010xxxxxxxxxxxxxxxx     scvtf     d0 : wx5 scale
 0x001110xx100000001010xxxxxxxxxx     saddlp    dq0 : dq5 bhsd_sz
 0000111100xxxxxx101001xxxxxxxxxx     sshll      d0 : d5 immhb
 0100111100xxxxxx101001xxxxxxxxxx     sshll2     q0 : q5 immhb
+
+01011110000xxxxx000000xxxxxxxxxx     sha1c     q0 : s5 d16
+0101111000101000000010xxxxxxxxxx     sha1h     s0 : s5
+01011110000xxxxx001000xxxxxxxxxx     sha1m     q0 : s5 d16
+01011110000xxxxx000100xxxxxxxxxx     sha1p     q0 : s5 d16
+01011110000xxxxx001100xxxxxxxxxx     sha1su0   d0 : d5 d16
+0101111000101000000110xxxxxxxxxx     sha1su1   d0 : d5
+01011110000xxxxx010000xxxxxxxxxx     sha256h   q0 : q5 d16
+01011110000xxxxx010100xxxxxxxxxx     sha256h2  q0 : q5 d16
+0101111000101000001010xxxxxxxxxx     sha256su0 d0 : d5
+01011110000xxxxx011000xxxxxxxxxx     sha256su1 d0 : d5 d16

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -3704,6 +3704,86 @@ d503209f : sev                            : sev
 
 d50320bf : sevl                           : sevl
 
+5e020020 : sha1c q0, s1, v2.4s                      : sha1c  %s1 %d2 -> %q0
+5e040065 : sha1c q5, s3, v4.4s                      : sha1c  %s3 %d4 -> %q5
+5e09010a : sha1c q10, s8, v9.4s                     : sha1c  %s8 %d9 -> %q10
+5e0e01af : sha1c q15, s13, v14.4s                   : sha1c  %s13 %d14 -> %q15
+5e130254 : sha1c q20, s18, v19.4s                   : sha1c  %s18 %d19 -> %q20
+5e1802f9 : sha1c q25, s23, v24.4s                   : sha1c  %s23 %d24 -> %q25
+5e1d039e : sha1c q30, s28, v29.4s                   : sha1c  %s28 %d29 -> %q30
+
+5e280820 : sha1h s0, s1                             : sha1h  %s1 -> %s0
+5e280885 : sha1h s5, s4                             : sha1h  %s4 -> %s5
+5e28092a : sha1h s10, s9                            : sha1h  %s9 -> %s10
+5e2809cf : sha1h s15, s14                           : sha1h  %s14 -> %s15
+5e280a74 : sha1h s20, s19                           : sha1h  %s19 -> %s20
+5e280b19 : sha1h s25, s24                           : sha1h  %s24 -> %s25
+5e280bbe : sha1h s30, s29                           : sha1h  %s29 -> %s30
+
+5e022020 : sha1m q0, s1, v2.4s                      : sha1m  %s1 %d2 -> %q0
+5e042065 : sha1m q5, s3, v4.4s                      : sha1m  %s3 %d4 -> %q5
+5e09210a : sha1m q10, s8, v9.4s                     : sha1m  %s8 %d9 -> %q10
+5e0e21af : sha1m q15, s13, v14.4s                   : sha1m  %s13 %d14 -> %q15
+5e132254 : sha1m q20, s18, v19.4s                   : sha1m  %s18 %d19 -> %q20
+5e1822f9 : sha1m q25, s23, v24.4s                   : sha1m  %s23 %d24 -> %q25
+5e1d239e : sha1m q30, s28, v29.4s                   : sha1m  %s28 %d29 -> %q30
+
+5e021020 : sha1p q0, s1, v2.4s                      : sha1p  %s1 %d2 -> %q0
+5e041065 : sha1p q5, s3, v4.4s                      : sha1p  %s3 %d4 -> %q5
+5e09110a : sha1p q10, s8, v9.4s                     : sha1p  %s8 %d9 -> %q10
+5e0e11af : sha1p q15, s13, v14.4s                   : sha1p  %s13 %d14 -> %q15
+5e131254 : sha1p q20, s18, v19.4s                   : sha1p  %s18 %d19 -> %q20
+5e1812f9 : sha1p q25, s23, v24.4s                   : sha1p  %s23 %d24 -> %q25
+5e1d139e : sha1p q30, s28, v29.4s                   : sha1p  %s28 %d29 -> %q30
+
+5e023020 : sha1su0 v0.4s, v1.4s, v2.4s              : sha1su0 %d1 %d2 -> %d0
+5e043065 : sha1su0 v5.4s, v3.4s, v4.4s              : sha1su0 %d3 %d4 -> %d5
+5e09310a : sha1su0 v10.4s, v8.4s, v9.4s             : sha1su0 %d8 %d9 -> %d10
+5e0e31af : sha1su0 v15.4s, v13.4s, v14.4s           : sha1su0 %d13 %d14 -> %d15
+5e133254 : sha1su0 v20.4s, v18.4s, v19.4s           : sha1su0 %d18 %d19 -> %d20
+5e1832f9 : sha1su0 v25.4s, v23.4s, v24.4s           : sha1su0 %d23 %d24 -> %d25
+5e1d339e : sha1su0 v30.4s, v28.4s, v29.4s           : sha1su0 %d28 %d29 -> %d30
+
+5e281820 : sha1su1 v0.4s, v1.4s                     : sha1su1 %d1 -> %d0
+5e281885 : sha1su1 v5.4s, v4.4s                     : sha1su1 %d4 -> %d5
+5e28192a : sha1su1 v10.4s, v9.4s                    : sha1su1 %d9 -> %d10
+5e2819cf : sha1su1 v15.4s, v14.4s                   : sha1su1 %d14 -> %d15
+5e281a74 : sha1su1 v20.4s, v19.4s                   : sha1su1 %d19 -> %d20
+5e281b19 : sha1su1 v25.4s, v24.4s                   : sha1su1 %d24 -> %d25
+5e281bbe : sha1su1 v30.4s, v29.4s                   : sha1su1 %d29 -> %d30
+
+5e024020 : sha256h q0, q1, v2.4s                    : sha256h %q1 %d2 -> %q0
+5e044065 : sha256h q5, q3, v4.4s                    : sha256h %q3 %d4 -> %q5
+5e09410a : sha256h q10, q8, v9.4s                   : sha256h %q8 %d9 -> %q10
+5e0e41af : sha256h q15, q13, v14.4s                 : sha256h %q13 %d14 -> %q15
+5e134254 : sha256h q20, q18, v19.4s                 : sha256h %q18 %d19 -> %q20
+5e1842f9 : sha256h q25, q23, v24.4s                 : sha256h %q23 %d24 -> %q25
+5e1d439e : sha256h q30, q28, v29.4s                 : sha256h %q28 %d29 -> %q30
+
+5e025020 : sha256h2 q0, q1, v2.4s                   : sha256h2 %q1 %d2 -> %q0
+5e045065 : sha256h2 q5, q3, v4.4s                   : sha256h2 %q3 %d4 -> %q5
+5e09510a : sha256h2 q10, q8, v9.4s                  : sha256h2 %q8 %d9 -> %q10
+5e0e51af : sha256h2 q15, q13, v14.4s                : sha256h2 %q13 %d14 -> %q15
+5e135254 : sha256h2 q20, q18, v19.4s                : sha256h2 %q18 %d19 -> %q20
+5e1852f9 : sha256h2 q25, q23, v24.4s                : sha256h2 %q23 %d24 -> %q25
+5e1d539e : sha256h2 q30, q28, v29.4s                : sha256h2 %q28 %d29 -> %q30
+
+5e282820 : sha256su0 v0.4s, v1.4s                   : sha256su0 %d1 -> %d0
+5e282885 : sha256su0 v5.4s, v4.4s                   : sha256su0 %d4 -> %d5
+5e28292a : sha256su0 v10.4s, v9.4s                  : sha256su0 %d9 -> %d10
+5e2829cf : sha256su0 v15.4s, v14.4s                 : sha256su0 %d14 -> %d15
+5e282a74 : sha256su0 v20.4s, v19.4s                 : sha256su0 %d19 -> %d20
+5e282b19 : sha256su0 v25.4s, v24.4s                 : sha256su0 %d24 -> %d25
+5e282bbe : sha256su0 v30.4s, v29.4s                 : sha256su0 %d29 -> %d30
+
+5e026020 : sha256su1 v0.4s, v1.4s, v2.4s            : sha256su1 %d1 %d2 -> %d0
+5e046065 : sha256su1 v5.4s, v3.4s, v4.4s            : sha256su1 %d3 %d4 -> %d5
+5e09610a : sha256su1 v10.4s, v8.4s, v9.4s           : sha256su1 %d8 %d9 -> %d10
+5e0e61af : sha256su1 v15.4s, v13.4s, v14.4s         : sha256su1 %d13 %d14 -> %d15
+5e136254 : sha256su1 v20.4s, v18.4s, v19.4s         : sha256su1 %d18 %d19 -> %d20
+5e1862f9 : sha256su1 v25.4s, v23.4s, v24.4s         : sha256su1 %d23 %d24 -> %d25
+5e1d639e : sha256su1 v30.4s, v28.4s, v29.4s         : sha256su1 %d28 %d29 -> %d30
+
 0e3e0762 : shadd v2.8b, v27.8b, v30.8b              : shadd  %d27 %d30 $0x00 -> %d2
 4e3e0762 : shadd v2.16b, v27.16b, v30.16b           : shadd  %q27 %q30 $0x00 -> %q2
 0e7e0762 : shadd v2.4h, v27.4h, v30.4h              : shadd  %d27 %d30 $0x01 -> %d2


### PR DESCRIPTION
Adds the following instructions to the codec:
- sha1c
- sha1h
- sha1m
- sha1p
- sha1su0
- sha1su1
- sha256h
- sha256h2
- sha256su0
- sha256su1

Issue: #2626