### PR TITLE
i#4984 view tool: Fix stale prefix on 2-line-disasm bug

### DIFF
--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -248,14 +248,14 @@ view_t::process_memref(const memref_t &memref)
             return false;
         }
         disasm = buf;
-        // Put our prefix on raw byte spillover.
-        auto newline = disasm.find('\n');
-        if (newline != std::string::npos && newline < disasm.size() - 1) {
-            std::stringstream prefix;
-            prefix << "T" << memref.instr.tid << " ";
-            disasm.insert(newline + 1, prefix.str());
-        }
         disasm_cache_.insert({ mapped_pc, disasm });
+    }
+    // Put our prefix on raw byte spillover.
+    auto newline = disasm.find('\n');
+    if (newline != std::string::npos && newline < disasm.size() - 1) {
+        std::stringstream prefix;
+        prefix << "T" << memref.instr.tid << " ";
+        disasm.insert(newline + 1, prefix.str());
     }
     std::cerr << disasm;
     ++num_disasm_instrs_;


### PR DESCRIPTION
Moves the TID prefix outside of the cached disassembly to avoid a
stale prefix in drcachesim's view tool.

Tested manually:
```
  --------------------------------------------------
  $ bin64/drrun -t drcachesim -offline -- suite/tests/bin/drmemtrace.signal_invariants
  $ bin64/drrun -t drcachesim -indir drmemtrace.drm*[0-9]*.dir -simulator_type view 2>&1 | less
  --------------------------------------------------
```
Before:
```
  --------------------------------------------------
  T480221   0x00007ff86d0c4648  48 89 94 24 50 02 00 mov    %rdx, 0x00000250(%rsp)
  T480218                       00
  T480221     write 8 byte(s) @ 0x7ff86c96fd50
  T480221   0x00007ff86d0c4650  48 89 94 24 58 02 00 mov    %rdx, 0x00000258(%rsp)
  T480218                       00
  T480221     write 8 byte(s) @ 0x7ff86c96fd58
  T480221   0x00007ff86d0c4658  48 89 94 24 60 02 00 mov    %rdx, 0x00000260(%rsp)
  T480218                       00
  T480221     write 8 byte(s) @ 0x7ff86c96fd60
  T480221   0x00007ff86d0c4660  48 89 94 24 68 02 00 mov    %rdx, 0x00000268(%rsp)
  T480218                       00
  T480221     write 8 byte(s) @ 0x7ff86c96fd68
  --------------------------------------------------
```
After:
```
  --------------------------------------------------
  T480221   0x00007ff86d0c4648  48 89 94 24 50 02 00 mov    %rdx, 0x00000250(%rsp)
  T480221                       00
  T480221     write 8 byte(s) @ 0x7ff86c96fd50
  T480221   0x00007ff86d0c4650  48 89 94 24 58 02 00 mov    %rdx, 0x00000258(%rsp)
  T480221                       00
  T480221     write 8 byte(s) @ 0x7ff86c96fd58
  T480221   0x00007ff86d0c4658  48 89 94 24 60 02 00 mov    %rdx, 0x00000260(%rsp)
  T480221                       00
  T480221     write 8 byte(s) @ 0x7ff86c96fd60
  T480221   0x00007ff86d0c4660  48 89 94 24 68 02 00 mov    %rdx, 0x00000268(%rsp)
  T480221                       00
  T480221     write 8 byte(s) @ 0x7ff86c96fd68
  --------------------------------------------------
```

Issue: #4984