### PR TITLE
i4489 drcachesim: support any associativity

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -129,24 +129,24 @@ droption_t<bytesize_t>
                 "Specifies the total size of each L1 data cache.  Must be a power of 2 "
                 "and a multiple of -line_size.");
 
-droption_t<unsigned int> op_L1I_assoc(
-    DROPTION_SCOPE_FRONTEND, "L1I_assoc", 8, "Instruction cache associativity",
-    "Specifies the associativity of each L1 instruction cache.  Must be a power of 2.");
+droption_t<unsigned int>
+    op_L1I_assoc(DROPTION_SCOPE_FRONTEND, "L1I_assoc", 8,
+                 "Instruction cache associativity",
+                 "Specifies the associativity of each L1 instruction cache.");
 
-droption_t<unsigned int> op_L1D_assoc(
-    DROPTION_SCOPE_FRONTEND, "L1D_assoc", 8, "Data cache associativity",
-    "Specifies the associativity of each L1 data cache.  Must be a power of 2.");
+droption_t<unsigned int>
+    op_L1D_assoc(DROPTION_SCOPE_FRONTEND, "L1D_assoc", 8, "Data cache associativity",
+                 "Specifies the associativity of each L1 data cache.");
 
 droption_t<bytesize_t> op_LL_size(DROPTION_SCOPE_FRONTEND, "LL_size", 8 * 1024 * 1024,
                                   "Last-level cache total size",
                                   "Specifies the total size of the unified last-level "
-                                  "(L2) cache.  Must be a power of 2 "
+                                  "(L2) cache.  Must be a multiple of associativity "
                                   "and a multiple of -line_size.");
 
 droption_t<unsigned int>
     op_LL_assoc(DROPTION_SCOPE_FRONTEND, "LL_assoc", 16, "Last-level cache associativity",
-                "Specifies the associativity of the unified last-level (L2) cache.  "
-                "Must be a power of 2.");
+                "Specifies the associativity of the unified last-level (L2) cache.");
 
 droption_t<std::string> op_LL_miss_file(
     DROPTION_SCOPE_FRONTEND, "LL_miss_file", "",
@@ -286,21 +286,23 @@ droption_t<unsigned int> op_TLB_L1D_entries(
     DROPTION_SCOPE_FRONTEND, "TLB_L1D_entries", 32, "Number of entries in data TLB",
     "Specifies the number of entries in each L1 data TLB.  Must be a power of 2.");
 
-droption_t<unsigned int> op_TLB_L1I_assoc(
-    DROPTION_SCOPE_FRONTEND, "TLB_L1I_assoc", 32, "Instruction TLB associativity",
-    "Specifies the associativity of each L1 instruction TLB.  Must be a power of 2.");
+droption_t<unsigned int>
+    op_TLB_L1I_assoc(DROPTION_SCOPE_FRONTEND, "TLB_L1I_assoc", 32,
+                     "Instruction TLB associativity",
+                     "Specifies the associativity of each L1 instruction TLB.");
 
-droption_t<unsigned int> op_TLB_L1D_assoc(
-    DROPTION_SCOPE_FRONTEND, "TLB_L1D_assoc", 32, "Data TLB associativity",
-    "Specifies the associativity of each L1 data TLB.  Must be a power of 2.");
+droption_t<unsigned int>
+    op_TLB_L1D_assoc(DROPTION_SCOPE_FRONTEND, "TLB_L1D_assoc", 32,
+                     "Data TLB associativity",
+                     "Specifies the associativity of each L1 data TLB.");
 
 droption_t<unsigned int> op_TLB_L2_entries(
     DROPTION_SCOPE_FRONTEND, "TLB_L2_entries", 1024, "Number of entries in L2 TLB",
     "Specifies the number of entries in each unified L2 TLB.  Must be a power of 2.");
 
-droption_t<unsigned int> op_TLB_L2_assoc(
-    DROPTION_SCOPE_FRONTEND, "TLB_L2_assoc", 4, "L2 TLB associativity",
-    "Specifies the associativity of each unified L2 TLB.  Must be a power of 2.");
+droption_t<unsigned int>
+    op_TLB_L2_assoc(DROPTION_SCOPE_FRONTEND, "TLB_L2_assoc", 4, "L2 TLB associativity",
+                    "Specifies the associativity of each unified L2 TLB.");
 
 droption_t<std::string>
     op_TLB_replace_policy(DROPTION_SCOPE_FRONTEND, "TLB_replace_policy",

--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -234,15 +234,14 @@ config_reader_t::configure_cache(cache_params_t &cache)
                 return false;
             }
         } else if (param == "assoc") {
-            // Cache associativity_. Must be a power of 2.
+            // Cache associativity_.
             if (!(*fin_ >> cache.assoc)) {
                 ERRMSG("Error reading cache assoc from "
                        "the configuration file\n");
                 return false;
             }
-            if (cache.assoc <= 0 || !IS_POWER_OF_2(cache.assoc)) {
-                ERRMSG("Cache associativity (%u) must be >0 and a power of 2\n",
-                       cache.assoc);
+            if (cache.assoc <= 0) {
+                ERRMSG("Cache associativity (%u) must be >0\n", cache.assoc);
                 return false;
             }
         } else if (param == "inclusive") {

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -71,7 +71,7 @@ struct cache_params_t {
     int core;
     // Cache size in bytes.
     uint64_t size;
-    // Cache associativity. Must be a power of 2.
+    // Cache associativity.
     unsigned int assoc;
     // Is the cache inclusive of its children.
     bool inclusive;

--- a/clients/drcachesim/simulator/cache_fifo.cpp
+++ b/clients/drcachesim/simulator/cache_fifo.cpp
@@ -56,8 +56,8 @@ cache_fifo_t::init(int associativity, int block_size, int total_size,
 
     // Create a replacement pointer for each set, and
     // initialize it to point to the first block.
-    for (int i = 0; i < blocks_per_set_; i++) {
-        get_caching_device_block(i << assoc_bits_, 0).counter_ = 1;
+    for (int i = 0; i < blocks_per_way_; i++) {
+        get_caching_device_block_scaled(i, 0).counter_ = 1;
     }
     return true;
 }
@@ -79,8 +79,8 @@ cache_fifo_t::replace_which_way(int block_idx)
             // clear the counter of the victim block
             get_caching_device_block(block_idx, i).counter_ = 0;
             // set the next block as victim
-            get_caching_device_block(block_idx, (i + 1) & (associativity_ - 1)).counter_ =
-                1;
+            unsigned int next_way = ((i + 1) < associativity_) ? (i + 1) : 0;
+            get_caching_device_block(block_idx, next_way).counter_ = 1;
             return i;
         }
     }

--- a/clients/drcachesim/simulator/cache_lru.cpp
+++ b/clients/drcachesim/simulator/cache_lru.cpp
@@ -54,9 +54,9 @@ cache_lru_t::init(int associativity, int block_size, int total_size,
         return false;
 
     // Initialize line counters with 0, 1, 2, ..., associativity - 1.
-    for (int i = 0; i < blocks_per_set_; i++) {
+    for (int i = 0; i < blocks_per_way_; i++) {
         for (int way = 0; way < associativity_; ++way) {
-            get_caching_device_block(i << assoc_bits_, way).counter_ = way;
+            get_caching_device_block_scaled(i, way).counter_ = way;
         }
     }
     return true;

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -107,9 +107,9 @@ cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs)
     if (!llc->init(knobs_.LL_assoc, (int)knobs_.line_size, (int)knobs_.LL_size, NULL,
                    new cache_stats_t(knobs_.LL_miss_file, warmup_enabled_))) {
         error_string_ =
-            "Usage error: failed to initialize LL cache.  Ensure sizes and "
-            "associativity are powers of 2, that the total size is a multiple "
-            "of the line size, and that any miss file path is writable.";
+            "Usage error: failed to initialize LL cache.  Ensure line size is "
+            "a multiple of 2, that the total size is a multiple of line size "
+            "and associativity, and that any miss file path is writable.";
         success_ = false;
         return;
     }

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -65,8 +65,7 @@ caching_device_t::init(int associativity, int block_size, int num_blocks,
                        int id, snoop_filter_t *snoop_filter,
                        const std::vector<caching_device_t *> &children)
 {
-    if (!IS_POWER_OF_2(associativity) || !IS_POWER_OF_2(block_size) ||
-        !IS_POWER_OF_2(num_blocks) ||
+    if (!IS_POWER_OF_2(block_size) || !((num_blocks % associativity) == 0) ||
         // Assuming caching device block size is at least 4 bytes
         block_size < 4)
         return false;
@@ -78,11 +77,10 @@ caching_device_t::init(int associativity, int block_size, int num_blocks,
     block_size_ = block_size;
     num_blocks_ = num_blocks;
     loaded_blocks_ = 0;
-    blocks_per_set_ = num_blocks_ / associativity;
-    assoc_bits_ = compute_log2(associativity_);
+    blocks_per_way_ = num_blocks_ / associativity;
     block_size_bits_ = compute_log2(block_size);
-    blocks_per_set_mask_ = blocks_per_set_ - 1;
-    if (assoc_bits_ == -1 || block_size_bits_ == -1 || !IS_POWER_OF_2(blocks_per_set_))
+    blocks_per_way_mask_ = blocks_per_way_ - 1;
+    if (block_size_bits_ == -1 || !IS_POWER_OF_2(blocks_per_way_))
         return false;
     parent_ = parent;
     stats_ = stats;

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -130,12 +130,17 @@ protected:
     inline int
     compute_block_idx(addr_t tag)
     {
-        return (tag & blocks_per_set_mask_) << assoc_bits_;
+        return (tag & blocks_per_way_mask_) * associativity_;
     }
     inline caching_device_block_t &
     get_caching_device_block(int block_idx, int way)
     {
         return *(blocks_[block_idx + way]);
+    }
+    inline caching_device_block_t &
+    get_caching_device_block_scaled(int block_num, int way)
+    {
+        return get_caching_device_block(block_num * associativity_, way);
     }
 
     inline void
@@ -191,10 +196,9 @@ protected:
     // an extended block class which has its own member variables cannot be indexed
     // correctly by base class pointers.
     caching_device_block_t **blocks_;
-    int blocks_per_set_;
+    int blocks_per_way_;
     // Optimization fields for fast bit operations
-    int blocks_per_set_mask_;
-    int assoc_bits_;
+    int blocks_per_way_mask_;
     int block_size_bits_;
 
     caching_device_stats_t *stats_;

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -91,8 +91,8 @@ tlb_simulator_t::tlb_simulator_t(const tlb_simulator_knobs_t &knobs)
             !lltlbs_[i]->init(knobs_.TLB_L2_assoc, (int)knobs_.page_size,
                               knobs_.TLB_L2_entries, NULL, new tlb_stats_t)) {
             error_string_ =
-                "Usage error: failed to initialize TLbs_. Ensure entry number, "
-                "page size and associativity are powers of 2.";
+                "Usage error: failed to initialize TLbs_. Ensure entry number and "
+                "page size are powers of 2.";
             success_ = false;
             return;
         }


### PR DESCRIPTION
drcachesim used to support only power-of-2 associativity even though it's not uncommon for L1 caches to be 3-way, 5-way, or sometimes 24-way for larger caches. Most changes were in option validation and related messages. The use of assoc_bits_ was removed. Shifts and masks were replaced by multiplication (as cheap as shifting, on modern CPUs) and a test. There are no division or modulo operators on the speed path.

This also seemed like a good opportunity to change the misnamed blocks_per_set_ variable to blocks_per_way_ (blocks per set is the same as associativity).

Reworked pull request to fix clang-format issues.