### PR TITLE
i#4998: Fix incorrectly nested signals

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2367,6 +2367,28 @@ handle_sigsuspend(dcontext_t *dcontext, kernel_sigset_t *set, size_t sigsetsize)
 #endif
 }
 
+static void
+terminate_sigsuspend(dcontext_t *dcontext, thread_sig_info_t *info,
+                     kernel_ucontext_t *ucxt)
+{
+    ASSERT(info->in_sigsuspend);
+    /* Sigsuspend ends when a signal is received, so restore the
+     * old blocked set.
+     */
+    info->app_sigblocked = info->app_sigblocked_save;
+    info->in_sigsuspend = false;
+    /* Update the set to restore to post-signal-delivery. */
+#ifdef MACOS
+    ucxt->uc_sigmask = *(__darwin_sigset_t *)&info->app_sigblocked;
+#else
+    ucxt->uc_sigmask = info->app_sigblocked;
+#endif
+    DOLOG(3, LOG_ASYNCH, {
+        LOG(THREAD, LOG_ASYNCH, 3, "after sigsuspend, blocked signals are now:\n");
+        dump_sigset(dcontext, &info->app_sigblocked);
+    });
+}
+
 /**** utility routines ***********************************************/
 #ifdef DEBUG
 static void
@@ -4295,26 +4317,6 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
     if (kernel_sigismember(&info->app_sigblocked, sig))
         blocked = true;
 
-    if (info->in_sigsuspend) {
-        /* sigsuspend ends when a signal is received, so restore the
-         * old blocked set
-         */
-        info->app_sigblocked = info->app_sigblocked_save;
-        info->in_sigsuspend = false;
-        /* update the set to restore to post-signal-delivery */
-#ifdef MACOS
-        ucxt->uc_sigmask = *(__darwin_sigset_t *)&info->app_sigblocked;
-#else
-        ucxt->uc_sigmask = info->app_sigblocked;
-#endif
-#ifdef DEBUG
-        if (d_r_stats->loglevel >= 3 && (d_r_stats->logmask & LOG_ASYNCH) != 0) {
-            LOG(THREAD, LOG_ASYNCH, 3, "after sigsuspend, blocked signals are now:\n");
-            dump_sigset(dcontext, &info->app_sigblocked);
-        }
-#endif
-    }
-
     if (get_at_syscall(dcontext))
         syslen = syscall_instr_length(dr_get_isa_mode(dcontext));
 
@@ -4662,7 +4664,6 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
 
             pend->next = info->sigpending[sig];
             info->sigpending[sig] = pend;
-            pend->unblocked = !blocked;
 
             /* FIXME: note that for asynchronous signals we don't need to
              *  bother to record exact machine context, even entire frame,
@@ -5576,6 +5577,9 @@ execute_handler_from_cache(dcontext_t *dcontext, int sig, sigframe_rt_t *our_fra
 
     LOG(THREAD, LOG_ASYNCH, 3, "\txsp is " PFX "\n", xsp);
 
+    if (info->in_sigsuspend)
+        terminate_sigsuspend(dcontext, info, uc);
+
     /* copy frame to appropriate stack and convert to non-rt if necessary */
     copy_frame_to_stack(dcontext, info, sig, our_frame, (void *)xsp, false /*!pending*/);
     LOG(THREAD, LOG_ASYNCH, 3, "\tcopied frame from " PFX " to " PFX "\n", our_frame,
@@ -5789,6 +5793,9 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
         return true;
     }
     CLIENT_ASSERT(action == DR_SIGNAL_DELIVER, "invalid signal event return value");
+
+    if (info->in_sigsuspend)
+        terminate_sigsuspend(dcontext, info, uc);
 
     /* now that we've made all our changes and given the client a
      * chance to make changes, copy the frame to the appropriate stack
@@ -6387,11 +6394,7 @@ receive_pending_signal(dcontext_t *dcontext)
     for (sig = 1; sig <= MAX_SIGNUM; sig++) {
         if (info->sigpending[sig] != NULL) {
             bool executing = true;
-            /* We do not re-check whether blocked if it was unblocked at
-             * receive time, to properly handle sigsuspend (i#1340).
-             */
-            if (!info->sigpending[sig]->unblocked &&
-                kernel_sigismember(&info->app_sigblocked, sig)) {
+            if (kernel_sigismember(&info->app_sigblocked, sig)) {
                 LOG(THREAD, LOG_ASYNCH, 3, "\tsignal %d is blocked!\n", sig);
                 continue;
             }

--- a/core/unix/signal_linux.c
+++ b/core/unix/signal_linux.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -380,6 +380,10 @@ handle_post_extended_syscall_sigmasks(dcontext_t *dcontext, bool success)
 {
     thread_sig_info_t *info = (thread_sig_info_t *)dcontext->signal_field;
     ASSERT(info->pre_syscall_app_sigprocmask_valid);
+    /* We restore the mask here *before* we make it back to dispatch for
+     * receive_pending_signal().  We rely on sigpending_t.unblocked_at_receipt
+     * to deliver the signal ignoring the now-restored mask.
+     */
     info->pre_syscall_app_sigprocmask_valid = false;
     signal_set_mask(dcontext, &info->pre_syscall_app_sigprocmask);
 }

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -321,6 +321,8 @@ typedef struct _sigpending_t {
     byte *access_address;
     /* use the sigcontext, not the mcontext (used to restart syscalls for i#1145) */
     bool use_sigcontext;
+    /* Was this unblocked at receive time? */
+    bool unblocked_at_receipt;
     struct _sigpending_t *next;
 #if defined(LINUX) && defined(X86)
     /* fpstate is no longer kept inside the frame, and is not always present.

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -321,8 +321,6 @@ typedef struct _sigpending_t {
     byte *access_address;
     /* use the sigcontext, not the mcontext (used to restart syscalls for i#1145) */
     bool use_sigcontext;
-    /* was this unblocked at receive time? */
-    bool unblocked;
     struct _sigpending_t *next;
 #if defined(LINUX) && defined(X86)
     /* fpstate is no longer kept inside the frame, and is not always present.

--- a/suite/tests/linux/signest.c
+++ b/suite/tests/linux/signest.c
@@ -119,6 +119,7 @@ thread_routine(void *arg)
         rc = sigaction(SIG_NEST, NULL, &act);
         ASSERT_NOERR(rc);
     }
+    return NULL;
 }
 
 int

--- a/suite/tests/linux/signest.c
+++ b/suite/tests/linux/signest.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -41,28 +41,56 @@
 #include <string.h>
 #include <signal.h>
 #include <stdlib.h>
-#include <pthread.h>
+#include "condvar.h"
 
-static pthread_cond_t condvar;
-static bool child_ready;
-static pthread_mutex_t lock;
-static int num_received;
+static void *child_started;
+static void *received_nonest_signal;
+static void *received_nest_signal;
+static void *sent_nest_signal2;
+static volatile int in_handler;
+static volatile bool saw_nest;
+static volatile bool sideline_exit;
 
-#define OURSIG 42 /* a real-time signal */
+#define SIG_NONEST SIGUSR1
+#define SIG_NEST SIGUSR2
 
 static void
-handler(int sig, siginfo_t *info, void *ucxt)
+handler_nonest(int sig, siginfo_t *info, void *ucxt)
 {
-    print("in handler %d\n", sig);
-    if (sig == OURSIG) {
-        num_received++;
-        if (num_received >= 2)
-            pthread_exit(NULL);
-        else {
-            /* take up some time to try and ensure we get a nested signal */
-            sleep(1);
-        }
+    /* Increment in the 1st block so we'll go back to DR for code discovery,
+     * hitting the i#4998 issue.
+     */
+    ++in_handler;
+    if (sig != SIG_NONEST)
+        print("invalid signal for nonest handler\n");
+    if (in_handler > 1)
+        print("incorrectly nested signal!\n");
+    signal_cond_var(received_nonest_signal);
+    /* Return to DR again to further test i#4998. */
+    struct sigaction act;
+    int rc = sigaction(SIG_NEST, NULL, &act);
+    ASSERT_NOERR(rc);
+    --in_handler;
+}
+
+static void
+handler_nest(int sig, siginfo_t *info, void *ucxt)
+{
+    /* Similarly to handler_nonest: increment first to better detect nesting. */
+    ++in_handler;
+    if (sig != SIG_NEST)
+        print("invalid signal for nest handler\n");
+    if (in_handler > 1)
+        saw_nest = true;
+    else {
+        signal_cond_var(received_nest_signal);
+        wait_cond_var(sent_nest_signal2);
     }
+    /* Return to DR to check pending signals. */
+    struct sigaction act;
+    int rc = sigaction(SIG_NEST, NULL, &act);
+    ASSERT_NOERR(rc);
+    --in_handler;
 }
 
 static void *
@@ -70,21 +98,27 @@ thread_routine(void *arg)
 {
     int rc;
     struct sigaction act;
-    act.sa_sigaction = (void (*)(int, siginfo_t *, void *))handler;
-    rc = sigemptyset(&act.sa_mask); /* do not block signals within handler */
+    act.sa_sigaction = (void (*)(int, siginfo_t *, void *))handler_nonest;
+    rc = sigfillset(&act.sa_mask); /* Block all other signals. */
     ASSERT_NOERR(rc);
-    act.sa_flags = SA_SIGINFO;
-    rc = sigaction(OURSIG, &act, NULL);
+    act.sa_flags = SA_SIGINFO; /* *Do* block the same signal (no SA_NODEFER). */
+    rc = sigaction(SIG_NONEST, &act, NULL);
     ASSERT_NOERR(rc);
 
-    pthread_mutex_lock(&lock);
-    child_ready = true;
-    pthread_cond_signal(&condvar);
-    pthread_mutex_unlock(&lock);
+    rc = sigdelset(&act.sa_mask, SIG_NEST);
+    ASSERT_NOERR(rc);
+    act.sa_sigaction = (void (*)(int, siginfo_t *, void *))handler_nest;
+    act.sa_flags = SA_SIGINFO | SA_NODEFER; /* Do *not* block the same signal. */
+    rc = sigaction(SIG_NEST, &act, NULL);
+    ASSERT_NOERR(rc);
 
-    /* wait for parent to send us SIGTERM */
-    while (true)
-        sleep(10);
+    signal_cond_var(child_started);
+
+    while (!sideline_exit) {
+        /* Spend as much time in DR as possible so signals will accumulate. */
+        rc = sigaction(SIG_NEST, NULL, &act);
+        ASSERT_NOERR(rc);
+    }
 }
 
 int
@@ -94,35 +128,44 @@ main(int argc, char **argv)
     void *retval;
     struct timespec sleeptime;
 
-    pthread_mutex_init(&lock, NULL);
-    pthread_cond_init(&condvar, NULL);
+    child_started = create_cond_var();
+    received_nonest_signal = create_cond_var();
+    received_nest_signal = create_cond_var();
+    sent_nest_signal2 = create_cond_var();
 
     if (pthread_create(&thread, NULL, thread_routine, NULL) != 0) {
         perror("failed to create thread");
         exit(1);
     }
 
-    pthread_mutex_lock(&lock);
-    while (!child_ready)
-        pthread_cond_wait(&condvar, &lock);
-    pthread_mutex_unlock(&lock);
+    wait_cond_var(child_started);
 
-    print("sending 2 signals\n");
-    pthread_kill(thread, OURSIG);
-    /* XXX i#1803: DR may incorrectly drop the signal if more than one are delivered
-     * together.  We delay sending the second signal until the first one is delivered
-     * as a temporary workaround.
+    /* Send multiple signals and try to get at least 2 to queue up while the thread
+     * is in DR, replicating i#4998.
      */
-    if (num_received == 0)
-        sched_yield();
-    pthread_kill(thread, OURSIG);
+    print("sending no-nest signals\n");
+    for (int i = 0; i < 5; i++)
+        pthread_kill(thread, SIG_NONEST);
 
+    wait_cond_var(received_nonest_signal);
+
+    /* Use cond vars to deliver a signal while the thread is inside its handler. */
+    print("sending nestable signals\n");
+    pthread_kill(thread, SIG_NEST);
+    wait_cond_var(received_nest_signal);
+    pthread_kill(thread, SIG_NEST);
+    signal_cond_var(sent_nest_signal2);
+
+    sideline_exit = true;
     if (pthread_join(thread, &retval) != 0)
         perror("failed to join thread");
 
-    pthread_cond_destroy(&condvar);
-    pthread_mutex_destroy(&lock);
+    destroy_cond_var(child_started);
+    destroy_cond_var(received_nonest_signal);
+    destroy_cond_var(received_nest_signal);
+    destroy_cond_var(sent_nest_signal2);
 
+    print("saw %snesting\n", saw_nest ? "" : "no ");
     print("all done\n");
 
     return 0;

--- a/suite/tests/linux/signest.expect
+++ b/suite/tests/linux/signest.expect
@@ -1,4 +1,4 @@
-sending 2 signals
-in handler 42
-in handler 42
+sending no-nest signals
+sending nestable signals
+saw nesting
 all done


### PR DESCRIPTION
Fixes a bug where DR delivers a signal while an app is inside its
signal handler for that same signal and has blocked such self-nesting.
The fix is to undo some of the sigsuspend-handling changes that cause
this regression by moving the sigsuspend state restore to actual
delivery rather than at pending signal time.

Improves the linux.signest test to reproduce the original bug and
verify the fix.  Also adds a test case to ensure that signals are
nested when not blocked.

Fixes #4998