### PR TITLE
i#2626: AArch64 v8.0 Decode: Add missing instructions, part 5

### DIFF
--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -1478,3 +1478,8 @@ x001111001100001000000xxxxxxxxxx     fcvtnu   wx0 : d5
 0101111011100000101010xxxxxxxxxx     cmlt      d0 : d5
 0x001110xx100000101010xxxxxxxxxx     cmlt     dq0 : dq5 bhsd_sz
 1101010100101xxxxxxxxxxxxxxxxxxx     sysl      x0 : op1 crn imm4 op2
+11010100101xxxxxxxxxxxxxxxx00001     dcps1        : imm16
+11010100101xxxxxxxxxxxxxxxx00010     dcps2        : imm16
+11010100101xxxxxxxxxxxxxxxx00011     dcps3        : imm16
+11010110101111110000001111100000     drps         :
+11010110100111110000001111100000     eret         :

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -671,6 +671,30 @@ f16003ff : cmp    sp, #0x800, lsl #12     : subs   %sp $0x0800 lsl $0x10 -> %xzr
 4e205b19 : cnt v25.16b, v24.16b           : cnt    %q24 -> %q25
 4e205bbe : cnt v30.16b, v29.16b           : cnt    %q29 -> %q30
 
+# DCPS1 {#<imm>}
+d4a00001 : dcps1 #0                       : dcps1  $0x0000
+d4aaaaa1 : dcps1 #21845                   : dcps1  $0x5555
+d4b55541 : dcps1 #43690                   : dcps1  $0xaaaa
+d4bfffe1 : dcps1 #65535                   : dcps1  $0xffff
+
+# DCPS2 {#<imm>}
+d4a00002 : dcps2 #0                       : dcps2  $0x0000
+d4aaaaa2 : dcps2 #21845                   : dcps2  $0x5555
+d4b55542 : dcps2 #43690                   : dcps2  $0xaaaa
+d4bfffe2 : dcps2 #65535                   : dcps2  $0xffff
+
+# DCPS3 {#<imm>}
+d4a00003 : dcps3 #0                       : dcps3  $0x0000
+d4aaaaa3 : dcps3 #21845                   : dcps3  $0x5555
+d4b55543 : dcps3 #43690                   : dcps3  $0xaaaa
+d4bfffe3 : dcps3 #65535                   : dcps3  $0xffff
+
+# DRPS
+d6bf03e0 : drps                           : drps
+
+# ERET
+d69f03e0 : eret                           : eret
+
 # EXT <Vd>.<T>, <Vn>.<T>, <Vm>.<T>, #<index>
 2e040065 : ext v5.8b, v3.8b, v4.8b, #0        : ext    %d3 %d4 $0x00 -> %d5
 2e09010a : ext v10.8b, v8.8b, v9.8b, #0       : ext    %d8 %d9 $0x00 -> %d10


### PR DESCRIPTION
Adds the following instructions to the codec
- DCPS1
- DCPS2
- DCPS3
- DRPS
- ERET

Issue: #2626