### PR TITLE
i#3068: API for accessing cache model metrics

### DIFF
--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -607,7 +607,7 @@ cache_simulator_t::get_l1_dcache_name(unsigned int core) const
 }
 
 const caching_device_stats_t *
-cache_simulator_t::get_cache_stats(const std::string& cache_type) const
+cache_simulator_t::get_cache_stats(const std::string &cache_type) const
 {
     auto pos = all_caches_.find(cache_type);
 

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -595,17 +595,16 @@ cache_simulator_t::print_results()
 }
 
 int_least64_t
-cache_simulator_t::get_cache_metric(unsigned level, metric_name_t metric, unsigned core,
+cache_simulator_t::get_cache_metric(metric_name_t metric, unsigned level, unsigned core,
                                     cache_split_t split) const
 {
     caching_device_t *curr_cache;
 
     if (core >= knobs_.num_cores) {
-        ERRMSG("Wrong core number: %u.\n", core);
-        return 0;
+        return STATS_ERROR_WRONG_CORE_NUMBER;
     }
 
-    if (split == DATA) {
+    if (split == cache_split_t::DATA) {
         curr_cache = l1_dcaches_[core];
     } else {
         curr_cache = l1_icaches_[core];
@@ -615,16 +614,14 @@ cache_simulator_t::get_cache_metric(unsigned level, metric_name_t metric, unsign
         caching_device_t *parent = curr_cache->get_parent();
 
         if (parent == NULL) {
-            ERRMSG("Wrong cache level: %u.\n", core);
-            return 0;
+            return STATS_ERROR_WRONG_CACHE_LEVEL;
         }
         curr_cache = parent;
     }
     caching_device_stats_t *stats = curr_cache->get_stats();
 
     if (stats == NULL) {
-        ERRMSG("Cache doesn't support statistics counting.");
-        return 0;
+        return STATS_ERROR_NO_CACHE_STATS;
     }
 
     return stats->get_metric(metric);

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -594,6 +594,91 @@ cache_simulator_t::print_results()
     return true;
 }
 
+inline std::string
+cache_simulator_t::get_l1_icache_name(unsigned int core) const {
+    return "L1_I_Cache_" + std::to_string(core);
+}
+
+inline std::string
+cache_simulator_t::get_l1_dcache_name(unsigned int core)  const {
+    return "L1_D_Cache_" + std::to_string(core);
+}
+
+const caching_device_stats_t *
+cache_simulator_t::get_cache_stats(const std::string& cache_type) const {
+    auto pos = all_caches_.find(cache_type);
+
+    if (pos != all_caches_.end()) {
+        return pos->second->get_stats();
+    } else {
+        ERRMSG("Couldn't get statistics. Wrong cache type.\n");
+        return nullptr;
+    }
+}
+
+int_least64_t
+cache_simulator_t::get_l1i_metric(metric_name_t metric, unsigned int core) const
+{
+    if (core >= knobs_.num_cores) {
+        ERRMSG("Wrong core number: %u.\n", core);
+        return 0;
+    }
+
+    const auto *stats = get_cache_stats(get_l1_icache_name(core));
+
+    if (!stats) {
+        return 0;
+    }
+
+    return stats->get_metric(metric);
+}
+
+int_least64_t
+cache_simulator_t::get_l1d_metric(metric_name_t metric, unsigned int core) const
+{
+    if (core >= knobs_.num_cores) {
+        ERRMSG("Wrong core number: %u.\n", core);
+        return 0;
+    }
+
+    const auto *stats = get_cache_stats(get_l1_dcache_name(core));
+
+    if (!stats) {
+        return 0;
+    }
+
+    return stats->get_metric(metric);
+}
+
+int_least64_t
+cache_simulator_t::get_ll_metric(metric_name_t metric) const
+{
+    const auto *stats = get_cache_stats(ll_cache_name);
+
+    if (!stats) {
+        return 0;
+    }
+
+    return stats->get_metric(metric);
+}
+
+unsigned int
+cache_simulator_t::get_core_num() const {
+    return knobs_.num_cores;
+}
+
+bool
+cache_simulator_t::is_prefetcher_used() const
+{
+    return knobs_.data_prefetcher != PREFETCH_POLICY_NONE;
+}
+
+bool
+cache_simulator_t::is_cache_coherent() const
+{
+    return knobs_.model_coherence;
+}
+
 cache_t *
 cache_simulator_t::create_cache(const std::string &policy)
 {

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -595,17 +595,20 @@ cache_simulator_t::print_results()
 }
 
 inline std::string
-cache_simulator_t::get_l1_icache_name(unsigned int core) const {
+cache_simulator_t::get_l1_icache_name(unsigned int core) const
+{
     return "L1_I_Cache_" + std::to_string(core);
 }
 
 inline std::string
-cache_simulator_t::get_l1_dcache_name(unsigned int core)  const {
+cache_simulator_t::get_l1_dcache_name(unsigned int core) const
+{
     return "L1_D_Cache_" + std::to_string(core);
 }
 
 const caching_device_stats_t *
-cache_simulator_t::get_cache_stats(const std::string& cache_type) const {
+cache_simulator_t::get_cache_stats(const std::string& cache_type) const
+{
     auto pos = all_caches_.find(cache_type);
 
     if (pos != all_caches_.end()) {
@@ -663,7 +666,8 @@ cache_simulator_t::get_ll_metric(metric_name_t metric) const
 }
 
 unsigned int
-cache_simulator_t::get_core_num() const {
+cache_simulator_t::get_core_num() const
+{
     return knobs_.num_cores;
 }
 

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -595,8 +595,8 @@ cache_simulator_t::print_results()
 }
 
 int_least64_t
-cache_simulator_t::get_cache_metric(unsigned level, metric_name_t metric,
-                                    unsigned core, cache_split_t split) const
+cache_simulator_t::get_cache_metric(unsigned level, metric_name_t metric, unsigned core,
+                                    cache_split_t split) const
 {
     caching_device_t *curr_cache;
 
@@ -631,7 +631,8 @@ cache_simulator_t::get_cache_metric(unsigned level, metric_name_t metric,
 }
 
 const cache_simulator_knobs_t &
-cache_simulator_t::get_knobs() const {
+cache_simulator_t::get_knobs() const
+{
     return knobs_;
 }
 

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -594,93 +594,45 @@ cache_simulator_t::print_results()
     return true;
 }
 
-inline std::string
-cache_simulator_t::get_l1_icache_name(unsigned int core) const
+int_least64_t
+cache_simulator_t::get_cache_metric(unsigned level, metric_name_t metric,
+                                    unsigned core, cache_split_t split) const
 {
-    return "L1_I_Cache_" + std::to_string(core);
-}
+    caching_device_t *curr_cache;
 
-inline std::string
-cache_simulator_t::get_l1_dcache_name(unsigned int core) const
-{
-    return "L1_D_Cache_" + std::to_string(core);
-}
+    if (core >= knobs_.num_cores) {
+        ERRMSG("Wrong core number: %u.\n", core);
+        return 0;
+    }
 
-const caching_device_stats_t *
-cache_simulator_t::get_cache_stats(const std::string &cache_type) const
-{
-    auto pos = all_caches_.find(cache_type);
-
-    if (pos != all_caches_.end()) {
-        return pos->second->get_stats();
+    if (split == DATA) {
+        curr_cache = l1_dcaches_[core];
     } else {
-        ERRMSG("Couldn't get statistics. Wrong cache type.\n");
-        return nullptr;
-    }
-}
-
-int_least64_t
-cache_simulator_t::get_l1i_metric(metric_name_t metric, unsigned int core) const
-{
-    if (core >= knobs_.num_cores) {
-        ERRMSG("Wrong core number: %u.\n", core);
-        return 0;
+        curr_cache = l1_icaches_[core];
     }
 
-    const auto *stats = get_cache_stats(get_l1_icache_name(core));
+    for (size_t i = 1; i < level; i++) {
+        caching_device_t *parent = curr_cache->get_parent();
 
-    if (!stats) {
-        return 0;
+        if (parent == NULL) {
+            ERRMSG("Wrong cache level: %u.\n", core);
+            return 0;
+        }
+        curr_cache = parent;
     }
+    caching_device_stats_t *stats = curr_cache->get_stats();
 
-    return stats->get_metric(metric);
-}
-
-int_least64_t
-cache_simulator_t::get_l1d_metric(metric_name_t metric, unsigned int core) const
-{
-    if (core >= knobs_.num_cores) {
-        ERRMSG("Wrong core number: %u.\n", core);
-        return 0;
-    }
-
-    const auto *stats = get_cache_stats(get_l1_dcache_name(core));
-
-    if (!stats) {
+    if (stats == NULL) {
+        ERRMSG("Cache doesn't support statistics counting.");
         return 0;
     }
 
     return stats->get_metric(metric);
 }
 
-int_least64_t
-cache_simulator_t::get_ll_metric(metric_name_t metric) const
-{
-    const auto *stats = get_cache_stats(ll_cache_name);
-
-    if (!stats) {
-        return 0;
-    }
-
-    return stats->get_metric(metric);
-}
-
-unsigned int
-cache_simulator_t::get_core_num() const
-{
-    return knobs_.num_cores;
-}
-
-bool
-cache_simulator_t::is_prefetcher_used() const
-{
-    return knobs_.data_prefetcher != PREFETCH_POLICY_NONE;
-}
-
-bool
-cache_simulator_t::is_cache_coherent() const
-{
-    return knobs_.model_coherence;
+const cache_simulator_knobs_t &
+cache_simulator_t::get_knobs() const {
+    return knobs_;
 }
 
 cache_t *

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -594,6 +594,8 @@ cache_simulator_t::print_results()
     return true;
 }
 
+// All valid metrics are returned as a positive number.
+// Negative return value is an error and is of type stats_error_t.
 int_least64_t
 cache_simulator_t::get_cache_metric(metric_name_t metric, unsigned level, unsigned core,
                                     cache_split_t split) const

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -111,7 +111,7 @@ private:
     std::string
     get_l1_dcache_name(unsigned int core) const;
     const caching_device_stats_t *
-    get_cache_stats(const std::string& cache_type) const;
+    get_cache_stats(const std::string &cache_type) const;
 
     const std::string ll_cache_name = "LL";
     bool is_warmed_up_;

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -60,11 +60,25 @@ public:
     bool
     print_results() override;
 
+    int_least64_t
+    get_l1i_metric(metric_name_t metric, unsigned int core) const;
+    int_least64_t
+    get_l1d_metric(metric_name_t metric, unsigned int core) const;
+    int_least64_t
+    get_ll_metric(metric_name_t metric) const;
+
     // Exposed to make it easy to test
     bool
     check_warmed_up();
     uint64_t
     remaining_sim_refs() const;
+
+    unsigned int
+    get_core_num() const;
+    bool
+    is_prefetcher_used() const;
+    bool
+    is_cache_coherent() const;
 
 protected:
     // Create a cache_t object with a specific replacement policy.
@@ -92,6 +106,14 @@ protected:
     snoop_filter_t *snoop_filter_ = nullptr;
 
 private:
+    std::string
+    get_l1_icache_name(unsigned int core) const;
+    std::string
+    get_l1_dcache_name(unsigned int core) const;
+    const caching_device_stats_t *
+    get_cache_stats(const std::string& cache_type) const;
+
+    const std::string ll_cache_name = "LL";
     bool is_warmed_up_;
 };
 

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -43,10 +43,7 @@
 #include "cache.h"
 #include "snoop_filter.h"
 
-enum cache_split_t {
-    DATA,
-    INSTRUCTION
-};
+enum cache_split_t { DATA, INSTRUCTION };
 
 class cache_simulator_t : public simulator_t {
 public:

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -42,8 +42,20 @@
 #include "cache_stats.h"
 #include "cache.h"
 #include "snoop_filter.h"
+#include <limits.h>
 
-enum cache_split_t { DATA, INSTRUCTION };
+enum class cache_split_t { DATA, INSTRUCTION };
+
+// Error codes returned when passing wrong parameters to the function for
+// accessing cache statistics.
+typedef enum {
+    // Core number is larger then congifured number of cores.
+    STATS_ERROR_WRONG_CORE_NUMBER = INT_MIN,
+    // Cache level is larger then configured number of levels.
+    STATS_ERROR_WRONG_CACHE_LEVEL,
+    // Given cache doesn't support counting statistics.
+    STATS_ERROR_NO_CACHE_STATS,
+} stats_error_t;
 
 class cache_simulator_t : public simulator_t {
 public:
@@ -63,8 +75,8 @@ public:
     print_results() override;
 
     int_least64_t
-    get_cache_metric(unsigned level, metric_name_t metric, unsigned core = 0,
-                     cache_split_t split = DATA) const;
+    get_cache_metric(metric_name_t metric, unsigned level, unsigned core = 0,
+                     cache_split_t split = cache_split_t::DATA) const;
 
     // Exposed to make it easy to test
     bool

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -43,6 +43,11 @@
 #include "cache.h"
 #include "snoop_filter.h"
 
+enum cache_split_t {
+    DATA,
+    INSTRUCTION
+};
+
 class cache_simulator_t : public simulator_t {
 public:
     // This constructor is used when the cache hierarchy is configured
@@ -61,11 +66,8 @@ public:
     print_results() override;
 
     int_least64_t
-    get_l1i_metric(metric_name_t metric, unsigned int core) const;
-    int_least64_t
-    get_l1d_metric(metric_name_t metric, unsigned int core) const;
-    int_least64_t
-    get_ll_metric(metric_name_t metric) const;
+    get_cache_metric(unsigned level, metric_name_t metric, unsigned core = 0,
+                     cache_split_t split = DATA) const;
 
     // Exposed to make it easy to test
     bool
@@ -73,12 +75,8 @@ public:
     uint64_t
     remaining_sim_refs() const;
 
-    unsigned int
-    get_core_num() const;
-    bool
-    is_prefetcher_used() const;
-    bool
-    is_cache_coherent() const;
+    const cache_simulator_knobs_t &
+    get_knobs() const;
 
 protected:
     // Create a cache_t object with a specific replacement policy.
@@ -106,14 +104,6 @@ protected:
     snoop_filter_t *snoop_filter_ = nullptr;
 
 private:
-    std::string
-    get_l1_icache_name(unsigned int core) const;
-    std::string
-    get_l1_dcache_name(unsigned int core) const;
-    const caching_device_stats_t *
-    get_cache_stats(const std::string &cache_type) const;
-
-    const std::string ll_cache_name = "LL";
     bool is_warmed_up_;
 };
 

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -46,8 +46,8 @@
 
 enum class cache_split_t { DATA, INSTRUCTION };
 
-// Error codes returned when passing wrong parameters to the function for
-// accessing cache statistics.
+// Error codes returned when passing wrong parameters to the
+// get_cache_metric function.
 typedef enum {
     // Core number is larger then congifured number of cores.
     STATS_ERROR_WRONG_CORE_NUMBER = INT_MIN,

--- a/clients/drcachesim/simulator/cache_stats.cpp
+++ b/clients/drcachesim/simulator/cache_stats.cpp
@@ -41,6 +41,9 @@ cache_stats_t::cache_stats_t(const std::string &miss_file, bool warmup_enabled,
     , num_prefetch_hits_(0)
     , num_prefetch_misses_(0)
 {
+    stats_map_.emplace(FLUSHES, num_flushes_);
+    stats_map_.emplace(PREFETCH_HITS, num_prefetch_hits_);
+    stats_map_.emplace(PREFETCH_MISSES, num_prefetch_misses_);
 }
 
 void

--- a/clients/drcachesim/simulator/cache_stats.cpp
+++ b/clients/drcachesim/simulator/cache_stats.cpp
@@ -41,9 +41,9 @@ cache_stats_t::cache_stats_t(const std::string &miss_file, bool warmup_enabled,
     , num_prefetch_hits_(0)
     , num_prefetch_misses_(0)
 {
-    stats_map_.emplace(FLUSHES, num_flushes_);
-    stats_map_.emplace(PREFETCH_HITS, num_prefetch_hits_);
-    stats_map_.emplace(PREFETCH_MISSES, num_prefetch_misses_);
+    stats_map_.emplace(metric_name_t::FLUSHES, num_flushes_);
+    stats_map_.emplace(metric_name_t::PREFETCH_HITS, num_prefetch_hits_);
+    stats_map_.emplace(metric_name_t::PREFETCH_MISSES, num_prefetch_misses_);
 }
 
 void

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -65,14 +65,14 @@ caching_device_stats_t::caching_device_stats_t(const std::string &miss_file,
             dump_misses_ = true;
     }
 
-    stats_map_.emplace(HITS, num_hits_);
-    stats_map_.emplace(MISSES, num_misses_);
-    stats_map_.emplace(HITS_AT_RESET, num_hits_at_reset_);
-    stats_map_.emplace(MISSES_AT_RESET, num_misses_at_reset_);
-    stats_map_.emplace(CHILD_HITS_AT_RESET, num_child_hits_at_reset_);
-    stats_map_.emplace(CHILD_HITS, num_child_hits_);
-    stats_map_.emplace(INCLUSIVE_INVALIDATES, num_inclusive_invalidates_);
-    stats_map_.emplace(COHERENCE_INVALIDATES, num_coherence_invalidates_);
+    stats_map_.emplace(metric_name_t::HITS, num_hits_);
+    stats_map_.emplace(metric_name_t::MISSES, num_misses_);
+    stats_map_.emplace(metric_name_t::HITS_AT_RESET, num_hits_at_reset_);
+    stats_map_.emplace(metric_name_t::MISSES_AT_RESET, num_misses_at_reset_);
+    stats_map_.emplace(metric_name_t::CHILD_HITS_AT_RESET, num_child_hits_at_reset_);
+    stats_map_.emplace(metric_name_t::CHILD_HITS, num_child_hits_);
+    stats_map_.emplace(metric_name_t::INCLUSIVE_INVALIDATES, num_inclusive_invalidates_);
+    stats_map_.emplace(metric_name_t::COHERENCE_INVALIDATES, num_coherence_invalidates_);
 }
 
 caching_device_stats_t::~caching_device_stats_t()

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -64,6 +64,15 @@ caching_device_stats_t::caching_device_stats_t(const std::string &miss_file,
         } else
             dump_misses_ = true;
     }
+
+    stats_map_.emplace(HITS, num_hits_);
+    stats_map_.emplace(MISSES, num_misses_);
+    stats_map_.emplace(HITS_AT_RESET, num_hits_at_reset_);
+    stats_map_.emplace(MISSES_AT_RESET, num_misses_at_reset_);
+    stats_map_.emplace(CHILD_HITS_AT_RESET, num_child_hits_at_reset_);
+    stats_map_.emplace(CHILD_HITS, num_child_hits_);
+    stats_map_.emplace(INCLUSIVE_INVALIDATES, num_inclusive_invalidates_);
+    stats_map_.emplace(COHERENCE_INVALIDATES, num_coherence_invalidates_);
 }
 
 caching_device_stats_t::~caching_device_stats_t()

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -50,7 +50,7 @@ enum invalidation_type_t {
     INVALIDATION_COHERENCE,
 };
 
-enum metric_name_t {
+enum class metric_name_t {
     HITS,
     MISSES,
     HITS_AT_RESET,

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -38,6 +38,7 @@
 
 #include "caching_device_block.h"
 #include <string>
+#include <map>
 #include <stdint.h>
 #ifdef HAS_ZLIB
 #    include <zlib.h>
@@ -47,6 +48,20 @@
 enum invalidation_type_t {
     INVALIDATION_INCLUSIVE,
     INVALIDATION_COHERENCE,
+};
+
+enum metric_name_t {
+    HITS,
+    MISSES,
+    HITS_AT_RESET,
+    MISSES_AT_RESET,
+    CHILD_HITS,
+    CHILD_HITS_AT_RESET,
+    INCLUSIVE_INVALIDATES,
+    COHERENCE_INVALIDATES,
+    PREFETCH_HITS,
+    PREFETCH_MISSES,
+    FLUSHES
 };
 
 class caching_device_stats_t {
@@ -81,6 +96,16 @@ public:
     virtual void
     invalidate(invalidation_type_t invalidation_type);
 
+    int_least64_t
+    get_metric(metric_name_t metric) const {
+        if (stats_map_.find(metric) != stats_map_.end()) {
+            return stats_map_.at(metric);
+        } else {
+            ERRMSG("Wrong metric name.\n");
+            return 0;
+        }
+    }
+
 protected:
     bool success_;
 
@@ -114,6 +139,10 @@ protected:
 
     // Print out write invalidations if cache is coherent.
     bool is_coherent_;
+
+    // References to the properties with statistics are held in the map with the
+    // statistic name as the key. Sample map element: {HITS, num_hits_}
+    std::map<metric_name_t, int_least64_t&> stats_map_;
 
     // We provide a feature of dumping misses to a file.
     bool dump_misses_;

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -97,7 +97,8 @@ public:
     invalidate(invalidation_type_t invalidation_type);
 
     int_least64_t
-    get_metric(metric_name_t metric) const {
+    get_metric(metric_name_t metric) const
+    {
         if (stats_map_.find(metric) != stats_map_.end()) {
             return stats_map_.at(metric);
         } else {
@@ -142,7 +143,7 @@ protected:
 
     // References to the properties with statistics are held in the map with the
     // statistic name as the key. Sample map element: {HITS, num_hits_}
-    std::map<metric_name_t, int_least64_t&> stats_map_;
+    std::map<metric_name_t, int_least64_t &> stats_map_;
 
     // We provide a feature of dumping misses to a file.
     bool dump_misses_;

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -157,10 +157,10 @@ unit_test_metrics_API()
             exit(1);
         }
     }
-    assert(cache_sim.get_cache_metric(metric_name_t::MISSES, 1, 0,
-                                      cache_split_t::DATA) == 1);
-    assert(cache_sim.get_cache_metric(metric_name_t::HITS, 1, 0,
-                                      cache_split_t::DATA) == 3);
+    assert(cache_sim.get_cache_metric(metric_name_t::MISSES, 1, 0, cache_split_t::DATA) ==
+           1);
+    assert(cache_sim.get_cache_metric(metric_name_t::HITS, 1, 0, cache_split_t::DATA) ==
+           3);
 
     ref.data.type = TRACE_TYPE_INSTR;
 

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -147,6 +147,9 @@ unit_test_metrics_API()
     ref.data.addr = 0;
     ref.data.size = 8;
 
+    // Currently invalidates are not counted properly in the configuration of
+    // cache_simulator_t with cache_simulator_knobs_t.
+    // TODO i#5031: Test invalidates metric when the issue is solved.
     for (int i = 0; i < 4; i++) {
         if (!cache_sim.process_memref(ref)) {
             std::cerr << "drcachesim unit_test_metrics_API failed: "

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -157,8 +157,10 @@ unit_test_metrics_API()
             exit(1);
         }
     }
-    assert(cache_sim.get_cache_metric(1, MISSES, 0, DATA) == 1);
-    assert(cache_sim.get_cache_metric(1, HITS, 0, DATA) == 3);
+    assert(cache_sim.get_cache_metric(metric_name_t::MISSES, 1, 0,
+                                      cache_split_t::DATA) == 1);
+    assert(cache_sim.get_cache_metric(metric_name_t::HITS, 1, 0,
+                                      cache_split_t::DATA) == 3);
 
     ref.data.type = TRACE_TYPE_INSTR;
 
@@ -169,11 +171,13 @@ unit_test_metrics_API()
             exit(1);
         }
     }
-    assert(cache_sim.get_cache_metric(1, MISSES, 0, INSTRUCTION) == 1);
-    assert(cache_sim.get_cache_metric(1, HITS, 0, INSTRUCTION) == 3);
+    assert(cache_sim.get_cache_metric(metric_name_t::MISSES, 1, 0,
+                                      cache_split_t::INSTRUCTION) == 1);
+    assert(cache_sim.get_cache_metric(metric_name_t::HITS, 1, 0,
+                                      cache_split_t::INSTRUCTION) == 3);
 
-    assert(cache_sim.get_cache_metric(2, MISSES) == 1);
-    assert(cache_sim.get_cache_metric(2, HITS) == 1);
+    assert(cache_sim.get_cache_metric(metric_name_t::MISSES, 2) == 1);
+    assert(cache_sim.get_cache_metric(metric_name_t::HITS, 2) == 1);
 
     ref.data.type = TRACE_TYPE_PREFETCH;
     ref.data.addr += 64;
@@ -185,8 +189,10 @@ unit_test_metrics_API()
             exit(1);
         }
     }
-    assert(cache_sim.get_cache_metric(1, PREFETCH_MISSES, 0, DATA) == 1);
-    assert(cache_sim.get_cache_metric(1, PREFETCH_HITS, 0, DATA) == 3);
+    assert(cache_sim.get_cache_metric(metric_name_t::PREFETCH_MISSES, 1, 0,
+                                      cache_split_t::DATA) == 1);
+    assert(cache_sim.get_cache_metric(metric_name_t::PREFETCH_HITS, 1, 0,
+                                      cache_split_t::DATA) == 3);
 
     ref.data.type = TRACE_TYPE_DATA_FLUSH;
 
@@ -197,7 +203,7 @@ unit_test_metrics_API()
             exit(1);
         }
     }
-    assert(cache_sim.get_cache_metric(2, FLUSHES) == 4);
+    assert(cache_sim.get_cache_metric(metric_name_t::FLUSHES, 2) == 4);
 }
 
 int


### PR DESCRIPTION
This patch contains implementation of the API for accessing separate
metrics gathered during the simulation.

Functions for accessing metrics were added for all caches in the
default configuration: L1I, L1D and LL. Also additional functions
for getting configuration options of the cache_simulator_t.

Issue: #3068