### PR TITLE
i#5023: Mark FCSEL, FC*MP* as reading/writing aflags

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -3816,20 +3816,15 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
          opnd_get_reg(instr_get_src(instr, 0)) == DR_REG_NZCV) ||
         opc == OP_bcond || opc == OP_adc || opc == OP_adcs || opc == OP_sbc ||
         opc == OP_sbcs || opc == OP_csel || opc == OP_csinc || opc == OP_csinv ||
-        opc == OP_csneg || opc == OP_ccmn || opc == OP_ccmp) {
-        /* FIXME i#2626: When handled by decoder, add:
-         * opc == OP_fcsel
-         */
+        opc == OP_csneg || opc == OP_ccmn || opc == OP_ccmp || opc == OP_fcsel) {
         eflags |= EFLAGS_READ_NZCV;
     }
     if ((opc == OP_msr && instr_num_dsts(instr) == 1 &&
          opnd_is_reg(instr_get_dst(instr, 0)) &&
          opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_NZCV) ||
         opc == OP_adcs || opc == OP_adds || opc == OP_sbcs || opc == OP_subs ||
-        opc == OP_ands || opc == OP_bics || opc == OP_ccmn || opc == OP_ccmp) {
-        /* FIXME i#2626: When handled by decoder, add:
-         * opc == OP_fccmp || opc == OP_fccmpe || opc == OP_fcmp || opc == OP_fcmpe
-         */
+        opc == OP_ands || opc == OP_bics || opc == OP_ccmn || opc == OP_ccmp ||
+        opc == OP_fccmp || opc == OP_fccmpe || opc == OP_fcmp || opc == OP_fcmpe) {
         eflags |= EFLAGS_WRITE_NZCV;
     }
 


### PR DESCRIPTION
Fixes a regression from PR #4966 and PR #5012 where FCSEL and FC*MP*
opcodes were added to the decoder but the flag reading/writing code
was not updated for them, meaning they no longer went into the OP_xx
workaround, resulting in incorrect aflags attributes and resulting
instrumentation bugs.

Tested on the large application where app crashes were first seen.
It's not clear how to easily add a regression test for this kind of
thing for all opcodes.

Fixes #5023