### PR TITLE
i#5026 icount perf: Avoid flags for arm drmemtrace

### DIFF
--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1467,8 +1467,8 @@ enable_delay_instrumentation()
         DR_ASSERT(false);
     schedule_tracing_lock = dr_mutex_create();
 #if defined(AARCH64) && defined(DELAYED_CHECK_INLINED)
-    /* By counting down we can avoid clobbering aflags in our comparison. */
-    instr_count = op_trace_after_instrs.get_value();
+    /* By counting down to < 0, we can avoid clobbering aflags in our comparison. */
+    instr_count = op_trace_after_instrs.get_value() - 1;
 #endif
 }
 

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1466,6 +1466,10 @@ enable_delay_instrumentation()
             event_delay_bb_analysis, event_delay_app_instruction, &memtrace_pri))
         DR_ASSERT(false);
     schedule_tracing_lock = dr_mutex_create();
+#if defined(AARCH64) && defined(DELAYED_CHECK_INLINED)
+    /* By counting down we can avoid clobbering aflags in our comparison. */
+    instr_count = op_trace_after_instrs.get_value();
+#endif
 }
 
 static void
@@ -1593,10 +1597,11 @@ event_delay_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t
     }
     MINSERT(bb, instr, INSTR_CREATE_jcc(drcontext, OP_jl, opnd_create_instr(skip_call)));
 #        elif defined(AARCH64)
+    /* We're counting down for an aflags-free comparison. */
     if (!drx_insert_counter_update(drcontext, bb, instr,
                                    (dr_spill_slot_t)(SPILL_SLOT_MAX + 1) /*use drmgr*/,
                                    (dr_spill_slot_t)(SPILL_SLOT_MAX + 1), &instr_count,
-                                   num_instrs, DRX_COUNTER_64BIT | DRX_COUNTER_REL_ACQ))
+                                   -num_instrs, DRX_COUNTER_64BIT | DRX_COUNTER_REL_ACQ))
         DR_ASSERT(false);
 
     reg_id_t scratch1, scratch2;
@@ -1604,21 +1609,16 @@ event_delay_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t
         FATAL("Fatal error: failed to reserve scratch register");
     if (drreg_reserve_register(drcontext, bb, instr, NULL, &scratch2) != DRREG_SUCCESS)
         FATAL("Fatal error: failed to reserve scratch register");
-    if (drreg_reserve_aflags(drcontext, bb, instr) != DRREG_SUCCESS)
-        FATAL("Fatal error: failed to reserve aflags");
 
     instrlist_insert_mov_immed_ptrsz(drcontext, (ptr_int_t)&instr_count,
                                      opnd_create_reg(scratch1), bb, instr, NULL, NULL);
     MINSERT(bb, instr,
             XINST_CREATE_load(drcontext, opnd_create_reg(scratch2),
                               OPND_CREATE_MEMPTR(scratch1, 0)));
-    instrlist_insert_mov_immed_ptrsz(drcontext, op_trace_after_instrs.get_value(),
-                                     opnd_create_reg(scratch1), bb, instr, NULL, NULL);
     MINSERT(bb, instr,
-            XINST_CREATE_cmp(drcontext, opnd_create_reg(scratch2),
-                             opnd_create_reg(scratch1)));
-    MINSERT(bb, instr,
-            XINST_CREATE_jump_cond(drcontext, DR_PRED_LT, opnd_create_instr(skip_call)));
+            INSTR_CREATE_tbz(drcontext, opnd_create_instr(skip_call),
+                             /* If the top bit is still zero, skip the call. */
+                             opnd_create_reg(scratch2), OPND_CREATE_INT(63)));
 #        endif
 
     /* hit_instr_count_threshold does not always return. Restore scratch registers and
@@ -1643,8 +1643,6 @@ event_delay_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t
                                         NULL);
     drreg_statelessly_restore_app_value(drcontext, bb, scratch2, instr, instr, NULL,
                                         NULL);
-    drreg_statelessly_restore_app_value(drcontext, bb, DR_REG_NULL, instr, instr, NULL,
-                                        NULL);
 #        endif
     dr_insert_clean_call(drcontext, bb, instr, (void *)hit_instr_count_threshold,
                          false /*fpstate */, 1,
@@ -1660,8 +1658,7 @@ event_delay_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t
     }
 #        elif defined(AARCH64)
     if (drreg_unreserve_register(drcontext, bb, instr, scratch1) != DRREG_SUCCESS ||
-        drreg_unreserve_register(drcontext, bb, instr, scratch2) != DRREG_SUCCESS ||
-        drreg_unreserve_aflags(drcontext, bb, instr) != DRREG_SUCCESS)
+        drreg_unreserve_register(drcontext, bb, instr, scratch2) != DRREG_SUCCESS)
         DR_ASSERT(false);
 #        endif
 #    else

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -589,6 +589,10 @@ enum {
 #define INSTR_CREATE_brk(dc, imm) instr_create_0dst_1src((dc), OP_brk, (imm))
 #define INSTR_CREATE_cbnz(dc, pc, reg) instr_create_0dst_2src((dc), OP_cbnz, (pc), (reg))
 #define INSTR_CREATE_cbz(dc, pc, reg) instr_create_0dst_2src((dc), OP_cbz, (pc), (reg))
+#define INSTR_CREATE_tbz(dc, pc, reg, imm) \
+    instr_create_0dst_3src((dc), OP_tbz, (pc), (reg), (imm))
+#define INSTR_CREATE_tbnz(dc, pc, reg, imm) \
+    instr_create_0dst_3src((dc), OP_tbnz, (pc), (reg), (imm))
 #define INSTR_CREATE_cmp(dc, rn, rm_or_imm) \
     INSTR_CREATE_subs(dc, OPND_CREATE_ZR(rn), rn, rm_or_imm)
 #define INSTR_CREATE_ldp(dc, rt1, rt2, mem) \

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -563,9 +563,15 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
         MINSERT(ilist, where,
                 INSTR_CREATE_ldar(drcontext, opnd_create_reg(reg2),
                                   OPND_CREATE_MEMPTR(reg1, 0)));
-        MINSERT(
-            ilist, where,
-            XINST_CREATE_add(drcontext, opnd_create_reg(reg2), OPND_CREATE_INT(value)));
+        if (value >= 0) {
+            MINSERT(ilist, where,
+                    XINST_CREATE_add(drcontext, opnd_create_reg(reg2),
+                                     OPND_CREATE_INT(value)));
+        } else {
+            MINSERT(ilist, where,
+                    XINST_CREATE_sub(drcontext, opnd_create_reg(reg2),
+                                     OPND_CREATE_INT(-value)));
+        }
         MINSERT(ilist, where,
                 INST_CREATE_stlr(drcontext, OPND_CREATE_MEMPTR(reg1, 0),
                                  opnd_create_reg(reg2)));
@@ -575,9 +581,15 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
                 XINST_CREATE_load(drcontext, opnd_create_reg(reg2),
                                   OPND_CREATE_MEMPTR(reg1, 0)));
         MINSERT(ilist, where, INSTR_CREATE_dmb(drcontext, OPND_CREATE_INT(DR_DMB_ISH)));
-        MINSERT(
-            ilist, where,
-            XINST_CREATE_add(drcontext, opnd_create_reg(reg2), OPND_CREATE_INT(value)));
+        if (value >= 0) {
+            MINSERT(ilist, where,
+                    XINST_CREATE_add(drcontext, opnd_create_reg(reg2),
+                                     OPND_CREATE_INT(value)));
+        } else {
+            MINSERT(ilist, where,
+                    XINST_CREATE_add(drcontext, opnd_create_reg(reg2),
+                                     OPND_CREATE_INT(-value)));
+        }
         MINSERT(ilist, where, INSTR_CREATE_dmb(drcontext, OPND_CREATE_INT(DR_DMB_ISH)));
         MINSERT(ilist, where,
                 XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(reg1, 0),
@@ -587,9 +599,15 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
         MINSERT(ilist, where,
                 XINST_CREATE_load(drcontext, opnd_create_reg(reg2),
                                   OPND_CREATE_MEMPTR(reg1, 0)));
-        MINSERT(
-            ilist, where,
-            XINST_CREATE_add(drcontext, opnd_create_reg(reg2), OPND_CREATE_INT(value)));
+        if (value >= 0) {
+            MINSERT(ilist, where,
+                    XINST_CREATE_add(drcontext, opnd_create_reg(reg2),
+                                     OPND_CREATE_INT(value)));
+        } else {
+            MINSERT(ilist, where,
+                    XINST_CREATE_sub(drcontext, opnd_create_reg(reg2),
+                                     OPND_CREATE_INT(-value)));
+        }
         MINSERT(ilist, where,
                 XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(reg1, 0),
                                    opnd_create_reg(reg2)));

--- a/suite/tests/client-interface/drx-test.dll.c
+++ b/suite/tests/client-interface/drx-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -112,7 +112,11 @@ event_basic_block(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                               /* DRX_COUNTER_LOCK is not yet supported on ARM */
                               IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
     drx_insert_counter_update(drcontext, bb, first, SPILL_SLOT_1,
-                              IF_NOT_X86_(SPILL_SLOT_2) & counterB, 2,
+                              IF_NOT_X86_(SPILL_SLOT_2) & counterB, 3,
+                              IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
+    /* Ensure subtraction works. */
+    drx_insert_counter_update(drcontext, bb, first, SPILL_SLOT_1,
+                              IF_NOT_X86_(SPILL_SLOT_2) & counterB, -1,
                               IF_X86_ELSE(DRX_COUNTER_LOCK, 0));
     instrlist_meta_preinsert(bb, first, INSTR_CREATE_label(drcontext));
 #if defined(ARM)


### PR DESCRIPTION
Switches the instruction counting inlined code for AArch64
drmemtrace's delayed-by-instruction-count feature to count down and
use TBZ, avoiding use of the arithmetic flags.

Adds INSTR_CREATE_ support for TBZ and TBNZ.

Fixes missing support for subtracting in drx_insert_counter_update()
for AArch64 (fatal encoder errors are raised without this).
Adds a drx test for subtracting.

Issue: #5026