### PR TITLE
i#5026 icount perf: Use per-thread counters

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -241,8 +241,14 @@ droption_t<bytesize_t> op_trace_after_instrs(
     "Do not start tracing until N instructions",
     "If non-zero, this causes tracing to be suppressed until this many dynamic "
     "instruction "
-    "executions are observed.  At that point, regular tracing is put into place.  Use "
-    "-max_trace_size to set a limit on the subsequent trace length.");
+    "executions are observed.  At that point, regular tracing is put into place. "
+    "The threshold should be considered approximate, especially for larger values. "
+    "Switching to regular tracing takes some amount of time during which other "
+    "threads than the one that triggered the switch can continue to execute, "
+    "resulting in a larger count of executed instructions before tracing actually "
+    "starts than this given threshold. "
+    "Use -max_trace_size or -max_global_trace_refs to set a limit on the subsequent "
+    "trace length.");
 
 droption_t<bytesize_t> op_exit_after_tracing(
     DROPTION_SCOPE_CLIENT, "exit_after_tracing", 0,

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3477,6 +3477,8 @@ if (BUILD_CLIENTS)
     torunonly_drcacheoff(delay-func ${ci_shared_app}
       # Delay enough that zero data should be logged to test that function
       # tracing is delayed (i#4893).
+      # This is also large enough to test the (non-triggering portion of) the
+      # per-thread counter feature (i#5026).
       "-trace_after_instrs 200M -record_heap"
       "@-simulator_type@basic_counts" "")
 


### PR DESCRIPTION
For drmemtrace -trace_after_instrs, if the threshold is large (>10M),
we use per-thread counters and only check the global value every 10K
instructions in each thread.  The approximate result is fine for these
use cases.

Tested on the original app where the global counter contention results
in a 20x slowdown over plain DR.  The new scheme has a 14% slowdown
over plain DR on this app, a massive speedup.

Fixes #5026