### PR TITLE
i#5021: Set frozen timestamp at drmemtrace max size

### DIFF
--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -218,6 +218,11 @@ public:
     // This is a per-buffer-writeout header.
     virtual int
     append_unit_header(byte *buf_ptr, thread_id_t tid) = 0;
+    virtual void
+    set_frozen_timestamp(uint64 timestamp)
+    {
+        frozen_timestamp_ = timestamp;
+    }
 
     // These insert inlined code to add an entry into the trace buffer.
     virtual int
@@ -277,6 +282,7 @@ protected:
     bool memref_needs_full_info_;
     drvector_t *reg_vector_;
     bool disable_optimizations_;
+    uint64 frozen_timestamp_ = 0;
 
 private:
     instru_t()

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -282,6 +282,8 @@ protected:
     bool memref_needs_full_info_;
     drvector_t *reg_vector_;
     bool disable_optimizations_;
+    // Stores a timestamp to use for all future unit headers.  This is meant for
+    // avoiding time gaps for max-limit scenarios (i#5021).
     uint64 frozen_timestamp_ = 0;
 
 private:

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -349,7 +349,8 @@ offline_instru_t::append_unit_header(byte *buf_ptr, thread_id_t tid)
     byte *new_buf = buf_ptr;
     offline_entry_t *entry = (offline_entry_t *)new_buf;
     entry->timestamp.type = OFFLINE_TYPE_TIMESTAMP;
-    entry->timestamp.usec = instru_t::get_timestamp();
+    entry->timestamp.usec =
+        frozen_timestamp_ != 0 ? frozen_timestamp_ : instru_t::get_timestamp();
     new_buf += sizeof(*entry);
     new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_CPU_ID, instru_t::get_cpu_id());
     return (int)(new_buf - buf_ptr);

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -165,7 +165,9 @@ online_instru_t::append_unit_header(byte *buf_ptr, thread_id_t tid)
     new_buf += append_tid(new_buf, tid);
     new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_TIMESTAMP,
                              // Truncated to 32 bits for 32-bit: we live with it.
-                             (uintptr_t)instru_t::get_timestamp());
+                             static_cast<uintptr_t>(frozen_timestamp_ != 0
+                                                        ? frozen_timestamp_
+                                                        : instru_t::get_timestamp()));
     new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_CPU_ID, instru_t::get_cpu_id());
     return (int)(new_buf - buf_ptr);
 }

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1578,6 +1578,9 @@ hit_instr_count_threshold(app_pc next_pc)
 static void
 check_instr_count_threshold(uint incby, app_pc next_pc)
 {
+    /* XXX i#5030: This is racy.  We could make std::atomic, or, better, go and
+     * implement the inlining and i#5026's thread-private counting.
+     */
     instr_count += incby;
     if (instr_count > op_trace_after_instrs.get_value())
         hit_instr_count_threshold(next_pc);

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -480,6 +480,13 @@ memtrace(void *drcontext, bool skip_size_cap)
                 int count = dr_atomic_add32_return_sum(&notify_beyond_global_max_once, 1);
                 if (count == 1) {
                     NOTIFY(0, "Hit -max_global_trace_refs: disabling tracing.\n");
+                    // We're not detaching, so the app keeps running and we don't flush
+                    // thread buffers or emit thread exits until the app exits.  To avoid
+                    // huge time gaps we use the current timestamp for all future
+                    // entries.  (An alternative would be a suspsend-the-world now and
+                    // flush-and-exit all threads; a better solution for most use cases
+                    // is probably i#5022: -detach_after_tracing.)
+                    instru->set_frozen_timestamp(instru_t::get_timestamp());
                 }
             }
         }


### PR DESCRIPTION
Adds a new drmemtrace mechanism to set a frozen timestamp for all
future entries, to avoid huge time gaps when -max_global_trace_refs is
reached but existing thread buffers and exits are not emitted until
much later when the app exits.

Adding a small regression test seems difficult without flakiness as
this involved real-time gaps.  Tested manually:

Pre-fix we see a 2s gap before the thread exit:

    $ ninja && ctest -V -R max-global
    $ bin64/drrun -t drcachesim -simulator_type view -indir suite/tests/tool.drcacheoff.max-global*.dir 2>&1 | grep timestamp
    T3427537 <marker: timestamp 13271354817417504>
    T3427537 <marker: timestamp 13271354817418955>
    T3427537 <marker: timestamp 13271354817624561>
    T3427537 <marker: timestamp 13271354817657186>
    T3427537 <marker: timestamp 13271354817659466>
    T3427537 <marker: timestamp 13271354817664998>
    T3427537 <marker: timestamp 13271354817667972>
    T3427537 <marker: timestamp 13271354817701187>
    T3427537 <marker: timestamp 13271354819175717>

After adding a frozen timestamp:

    $ bin64/drrun -t drcachesim -simulator_type view -indir suite/tests/tool.drcacheoff.max-global*.dir 2>&1 | grep timestamp
    T3429223 <marker: timestamp 13271355614195474>
    T3429223 <marker: timestamp 13271355614196983>
    T3429223 <marker: timestamp 13271355614399149>
    T3429223 <marker: timestamp 13271355614432167>
    T3429223 <marker: timestamp 13271355614434675>
    T3429223 <marker: timestamp 13271355614438892>
    T3429223 <marker: timestamp 13271355614441260>
    T3429223 <marker: timestamp 13271355614474587>
    T3429223 <marker: timestamp 13271355614475843>

Fixes #5021