### PR TITLE
i#5023: AArch64 decode: generate condition flags register r/w marking

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -3806,25 +3806,22 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
         instr->dsts[3] = opnd_create_reg(DR_REG_X0 + (enc >> 16 & 31));
     }
 
-    /* XXX i#2374: This determination of flag usage should be separate from the decoding
-     * of operands. Also, we should perhaps add flag information in codec.txt instead of
-     * listing all the opcodes, although the list is short and unlikely to change.
+    /* XXX i#2374: This determination of flag usage should be separate from the
+     * decoding of operands.
+     *
+     * Apart from explicit read/write from/to flags register using MRS and MSR,
+     * a field in codec.txt specifies whether instructions read/write from/to
+     * flags register.
      */
     opc = instr_get_opcode(instr);
-    if ((opc == OP_mrs && instr_num_srcs(instr) == 1 &&
-         opnd_is_reg(instr_get_src(instr, 0)) &&
-         opnd_get_reg(instr_get_src(instr, 0)) == DR_REG_NZCV) ||
-        opc == OP_bcond || opc == OP_adc || opc == OP_adcs || opc == OP_sbc ||
-        opc == OP_sbcs || opc == OP_csel || opc == OP_csinc || opc == OP_csinv ||
-        opc == OP_csneg || opc == OP_ccmn || opc == OP_ccmp || opc == OP_fcsel) {
+    if (opc == OP_mrs && instr_num_srcs(instr) == 1 &&
+        opnd_is_reg(instr_get_src(instr, 0)) &&
+        opnd_get_reg(instr_get_src(instr, 0)) == DR_REG_NZCV) {
         eflags |= EFLAGS_READ_NZCV;
     }
-    if ((opc == OP_msr && instr_num_dsts(instr) == 1 &&
-         opnd_is_reg(instr_get_dst(instr, 0)) &&
-         opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_NZCV) ||
-        opc == OP_adcs || opc == OP_adds || opc == OP_sbcs || opc == OP_subs ||
-        opc == OP_ands || opc == OP_bics || opc == OP_ccmn || opc == OP_ccmp ||
-        opc == OP_fccmp || opc == OP_fccmpe || opc == OP_fcmp || opc == OP_fcmpe) {
+    if (opc == OP_msr && instr_num_dsts(instr) == 1 &&
+        opnd_is_reg(instr_get_dst(instr, 0)) &&
+        opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_NZCV) {
         eflags |= EFLAGS_WRITE_NZCV;
     }
 
@@ -3837,7 +3834,7 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
         eflags |= EFLAGS_WRITE_ARITH;
     }
 
-    instr->eflags = eflags;
+    instr->eflags |= eflags;
     instr_set_eflags_valid(instr, true);
 
     instr_set_operands_valid(instr, true);

--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -198,7 +198,7 @@ x----------xxxxx----------------  wx16       # W/X register (or WZR/XZR)
 
 # Instruction patterns
 
-# The syntax here is: pattern opcode opndtype* : opndtype*
+# The syntax here is: pattern nzcv_flag opcode opndtype* : opndtype*
 
 # Each pattern consists of '0', '1' and 'x'. Patterns must not overlap.
 # The opndtypes before/after the ':' correspond to destination/source operands.
@@ -212,1135 +212,1153 @@ x----------xxxxx----------------  wx16       # W/X register (or WZR/XZR)
 # {de,en}code_opnds_OPNDSET in "codec.c", that handles all the operands together.
 # This is used, for example, when the number of operands varies.
 
+################################################################################
+
+# Condition register access field: nzcv_flag.
+
+# This field tells the decode genarator to set NZCV flag register usage for the
+# instruction, i.e. whether the instruction can read from the register, write
+# to the register or both.
+
+# There are 6 states for nzcv_flag. The field should appear between the
+# instruction pattern and the opcode as shown above. The flag states are:
+# n No read or write
+# r Read only
+# w Write only
+# rw or wr Read and write
+# er Explicit/direct read (currently only MRS instruction)
+# ew Explicit/direct write (currently only MSR instruction)
+
+
 # Data Processing - Immediate
 
 ## PC-relative addressing
 
-0xx10000xxxxxxxxxxxxxxxxxxxxxxxx  adr    adr
-1xx10000xxxxxxxxxxxxxxxxxxxxxxxx  adrp   adr
+0xx10000xxxxxxxxxxxxxxxxxxxxxxxx  n  adr    adr
+1xx10000xxxxxxxxxxxxxxxxxxxxxxxx  n  adrp   adr
 
 ## Add/subtract (immediate)
 
-x00100010xxxxxxxxxxxxxxxxxxxxxxx  add    wx0sp : wx5sp imm12 lsl imm12sh
-x01100010xxxxxxxxxxxxxxxxxxxxxxx  adds   wx0   : wx5sp imm12 lsl imm12sh
-x10100010xxxxxxxxxxxxxxxxxxxxxxx  sub    wx0sp : wx5sp imm12 lsl imm12sh
-x11100010xxxxxxxxxxxxxxxxxxxxxxx  subs   wx0   : wx5sp imm12 lsl imm12sh
+x00100010xxxxxxxxxxxxxxxxxxxxxxx  n  add    wx0sp : wx5sp imm12 lsl imm12sh
+x01100010xxxxxxxxxxxxxxxxxxxxxxx  w  adds   wx0   : wx5sp imm12 lsl imm12sh
+x10100010xxxxxxxxxxxxxxxxxxxxxxx  n  sub    wx0sp : wx5sp imm12 lsl imm12sh
+x11100010xxxxxxxxxxxxxxxxxxxxxxx  w  subs   wx0   : wx5sp imm12 lsl imm12sh
 
 ## Logical (immediate)
 
-x00100100xxxxxxxxxxxxxxxxxxxxxxx  and    logic_imm
-x01100100xxxxxxxxxxxxxxxxxxxxxxx  orr    logic_imm
-x10100100xxxxxxxxxxxxxxxxxxxxxxx  eor    logic_imm
-x11100100xxxxxxxxxxxxxxxxxxxxxxx  ands   logic_imm
+x00100100xxxxxxxxxxxxxxxxxxxxxxx  n  and    logic_imm
+x01100100xxxxxxxxxxxxxxxxxxxxxxx  n  orr    logic_imm
+x10100100xxxxxxxxxxxxxxxxxxxxxxx  n  eor    logic_imm
+x11100100xxxxxxxxxxxxxxxxxxxxxxx  w  ands   logic_imm
 
 ## Move wide (immediate)
 
-000100101xxxxxxxxxxxxxxxxxxxxxxx  movn   w0 : imm16 lsl imm16sh
-010100101xxxxxxxxxxxxxxxxxxxxxxx  movz   w0 : imm16 lsl imm16sh
-011100101xxxxxxxxxxxxxxxxxxxxxxx  movk   w0 : w0 imm16 lsl imm16sh
-100100101xxxxxxxxxxxxxxxxxxxxxxx  movn   x0 : imm16 lsl imm16sh
-110100101xxxxxxxxxxxxxxxxxxxxxxx  movz   x0 : imm16 lsl imm16sh
-111100101xxxxxxxxxxxxxxxxxxxxxxx  movk   x0 : x0 imm16 lsl imm16sh
+000100101xxxxxxxxxxxxxxxxxxxxxxx  n  movn   w0 : imm16 lsl imm16sh
+010100101xxxxxxxxxxxxxxxxxxxxxxx  n  movz   w0 : imm16 lsl imm16sh
+011100101xxxxxxxxxxxxxxxxxxxxxxx  n  movk   w0 : w0 imm16 lsl imm16sh
+100100101xxxxxxxxxxxxxxxxxxxxxxx  n  movn   x0 : imm16 lsl imm16sh
+110100101xxxxxxxxxxxxxxxxxxxxxxx  n  movz   x0 : imm16 lsl imm16sh
+111100101xxxxxxxxxxxxxxxxxxxxxxx  n  movk   x0 : x0 imm16 lsl imm16sh
 
 ## Bitfield
 
-0001001100xxxxxxxxxxxxxxxxxxxxxx  sbfm   w0 : w5 immr imms
-0011001100xxxxxxxxxxxxxxxxxxxxxx  bfm    w0 : w0 w5 immr imms
-0101001100xxxxxxxxxxxxxxxxxxxxxx  ubfm   w0 : w5 immr imms
-1001001101xxxxxxxxxxxxxxxxxxxxxx  sbfm   x0 : x5 immr imms
-1011001101xxxxxxxxxxxxxxxxxxxxxx  bfm    x0 : x0 x5 immr imms
-1101001101xxxxxxxxxxxxxxxxxxxxxx  ubfm   x0 : x5 immr imms
+0001001100xxxxxxxxxxxxxxxxxxxxxx  n  sbfm   w0 : w5 immr imms
+0011001100xxxxxxxxxxxxxxxxxxxxxx  n  bfm    w0 : w0 w5 immr imms
+0101001100xxxxxxxxxxxxxxxxxxxxxx  n  ubfm   w0 : w5 immr imms
+1001001101xxxxxxxxxxxxxxxxxxxxxx  n  sbfm   x0 : x5 immr imms
+1011001101xxxxxxxxxxxxxxxxxxxxxx  n  bfm    x0 : x0 x5 immr imms
+1101001101xxxxxxxxxxxxxxxxxxxxxx  n  ubfm   x0 : x5 immr imms
 
 ## Extract
 
-00010011100xxxxxxxxxxxxxxxxxxxxx  extr   w0 : w5 w16 imms
-10010011110xxxxxxxxxxxxxxxxxxxxx  extr   x0 : x5 x16 imms
+00010011100xxxxxxxxxxxxxxxxxxxxx  n  extr   w0 : w5 w16 imms
+10010011110xxxxxxxxxxxxxxxxxxxxx  n  extr   x0 : x5 x16 imms
 
 # Branches, Exception Generating and System instructions
 
 ## Unconditional branch (immediate)
 
-000101xxxxxxxxxxxxxxxxxxxxxxxxxx  b      b
-100101xxxxxxxxxxxxxxxxxxxxxxxxxx  bl     b
+000101xxxxxxxxxxxxxxxxxxxxxxxxxx  n  b      b
+100101xxxxxxxxxxxxxxxxxxxxxxxxxx  n  bl     b
 
 ## Compare and branch (immediate)
 
-x0110100xxxxxxxxxxxxxxxxxxxxxxxx  cbz    cbz
-x0110101xxxxxxxxxxxxxxxxxxxxxxxx  cbnz   cbz
+x0110100xxxxxxxxxxxxxxxxxxxxxxxx  n  cbz    cbz
+x0110101xxxxxxxxxxxxxxxxxxxxxxxx  n  cbnz   cbz
 
 ## Test and branch (immediate)
 
-x0110110xxxxxxxxxxxxxxxxxxxxxxxx  tbz    tbz
-x0110111xxxxxxxxxxxxxxxxxxxxxxxx  tbnz   tbz
+x0110110xxxxxxxxxxxxxxxxxxxxxxxx  n  tbz    tbz
+x0110111xxxxxxxxxxxxxxxxxxxxxxxx  n  tbnz   tbz
 
 ## Conditional branch (immediate)
 
-01010100xxxxxxxxxxxxxxxxxxx0xxxx  bcond  bcond
+01010100xxxxxxxxxxxxxxxxxxx0xxxx  r  bcond  bcond
 
 ## Exception generation
 
-11010100000xxxxxxxxxxxxxxxx00001  svc    : imm16
-11010100000xxxxxxxxxxxxxxxx00010  hvc    : imm16
-11010100000xxxxxxxxxxxxxxxx00011  smc    : imm16
-11010100001xxxxxxxxxxxxxxxx00000  brk    : imm16
-11010100010xxxxxxxxxxxxxxxx00000  hlt    : imm16
+11010100000xxxxxxxxxxxxxxxx00001  n  svc    : imm16
+11010100000xxxxxxxxxxxxxxxx00010  n  hvc    : imm16
+11010100000xxxxxxxxxxxxxxxx00011  n  smc    : imm16
+11010100001xxxxxxxxxxxxxxxx00000  n  brk    : imm16
+11010100010xxxxxxxxxxxxxxxx00000  n  hlt    : imm16
 
 ## System
 
 # FIXME i#1569: Add: MSR (immediate), HINT
-11010101000000110010000000011111  nop    :
-11010101000000110010000000111111  yield  :
-11010101000000110010000001011111  wfe    :
-11010101000000110010000001111111  wfi    :
-11010101000000110010000010011111  sev    :
-11010101000000110010000010111111  sevl   :
-11010101000000110011xxxx01011111  clrex  : imm4
-11010101000000110011xxxx10011111  dsb    : imm4
-11010101000000110011xxxx10111111  dmb    : imm4
-11010101000000110011xxxx11011111  isb    : imm4
-1101010100001xxxxxxxxxxxxxxxxxxx  sys    : sysops memx0
-110101010001xxxxxxxxxxxxxxxxxxxx  msr    msr
+11010101000000110010000000011111  n  nop    :
+11010101000000110010000000111111  n  yield  :
+11010101000000110010000001011111  n  wfe    :
+11010101000000110010000001111111  n  wfi    :
+11010101000000110010000010011111  n  sev    :
+11010101000000110010000010111111  n  sevl   :
+11010101000000110011xxxx01011111  n  clrex  : imm4
+11010101000000110011xxxx10011111  n  dsb    : imm4
+11010101000000110011xxxx10111111  n  dmb    : imm4
+11010101000000110011xxxx11011111  n  isb    : imm4
+1101010100001xxxxxxxxxxxxxxxxxxx  n  sys    : sysops memx0
+110101010001xxxxxxxxxxxxxxxxxxxx  ew msr    msr
 # FIXME i#1569: Add: SYSL
-110101010011xxxxxxxxxxxxxxxxxxxx  mrs    x0 : sysreg
+110101010011xxxxxxxxxxxxxxxxxxxx  er mrs    x0 : sysreg
 
 ## Unconditional branch (register)
 
-1101011000011111000000xxxxx00000  br     : x5
-1101011000111111000000xxxxx00000  blr    impx30 : x5
-1101011001011111000000xxxxx00000  ret    : x5
+1101011000011111000000xxxxx00000  n  br     : x5
+1101011000111111000000xxxxx00000  n  blr    impx30 : x5
+1101011001011111000000xxxxx00000  n  ret    : x5
 
 # Loads and Stores
 
 ## Load/store exclusive
 
-00001000000xxxxx0xxxxxxxxxxxxxxx  stxrb  mem0 w16 : w0 ign10
-00001000000xxxxx1xxxxxxxxxxxxxxx  stlxrb mem0 w16 : w0 ign10
-00001000010xxxxx0xxxxxxxxxxxxxxx  ldxrb  w0 : mem0 ign10 ign16
-00001000010xxxxx1xxxxxxxxxxxxxxx  ldaxrb w0 : mem0 ign10 ign16
-00001000100xxxxx1xxxxxxxxxxxxxxx  stlrb  mem0 : w0 ign10 ign16
-0000100011011111111111xxxxxxxxxx  ldarb  w0 : mem0
+00001000000xxxxx0xxxxxxxxxxxxxxx  n  stxrb  mem0 w16 : w0 ign10
+00001000000xxxxx1xxxxxxxxxxxxxxx  n  stlxrb mem0 w16 : w0 ign10
+00001000010xxxxx0xxxxxxxxxxxxxxx  n  ldxrb  w0 : mem0 ign10 ign16
+00001000010xxxxx1xxxxxxxxxxxxxxx  n  ldaxrb w0 : mem0 ign10 ign16
+00001000100xxxxx1xxxxxxxxxxxxxxx  n  stlrb  mem0 : w0 ign10 ign16
+0000100011011111111111xxxxxxxxxx  n  ldarb  w0 : mem0
 
-01001000000xxxxx0xxxxxxxxxxxxxxx  stxrh  mem0 w16 : w0 ign10
-01001000000xxxxx1xxxxxxxxxxxxxxx  stlxrh mem0 w16 : w0 ign10
-01001000010xxxxx0xxxxxxxxxxxxxxx  ldxrh  w0 : mem0 ign10 ign16
-01001000010xxxxx1xxxxxxxxxxxxxxx  ldaxrh w0 : mem0 ign10 ign16
-01001000100xxxxx1xxxxxxxxxxxxxxx  stlrh  mem0 : w0 ign10 ign16
-0100100011011111111111xxxxxxxxxx  ldarh  w0 : mem0
+01001000000xxxxx0xxxxxxxxxxxxxxx  n  stxrh  mem0 w16 : w0 ign10
+01001000000xxxxx1xxxxxxxxxxxxxxx  n  stlxrh mem0 w16 : w0 ign10
+01001000010xxxxx0xxxxxxxxxxxxxxx  n  ldxrh  w0 : mem0 ign10 ign16
+01001000010xxxxx1xxxxxxxxxxxxxxx  n  ldaxrh w0 : mem0 ign10 ign16
+01001000100xxxxx1xxxxxxxxxxxxxxx  n  stlrh  mem0 : w0 ign10 ign16
+0100100011011111111111xxxxxxxxxx  n  ldarh  w0 : mem0
 
-10001000000xxxxx0xxxxxxxxxxxxxxx  stxr   mem0 w16 : w0 ign10
-10001000000xxxxx1xxxxxxxxxxxxxxx  stlxr  mem0 w16 : w0 ign10
-10001000001xxxxx0xxxxxxxxxxxxxxx  stxp   mem0p w16 : w0 w10
-10001000001xxxxx1xxxxxxxxxxxxxxx  stlxp  mem0p w16 : w0 w10
-10001000010xxxxx0xxxxxxxxxxxxxxx  ldxr   w0 : mem0 ign10 ign16
-10001000010xxxxx1xxxxxxxxxxxxxxx  ldaxr  w0 : mem0 ign10 ign16
-10001000011xxxxx0xxxxxxxxxxxxxxx  ldxp   w0 w10 : mem0p ign16
-10001000011xxxxx1xxxxxxxxxxxxxxx  ldaxp  w0 w10 : mem0p ign16
-10001000100xxxxx1xxxxxxxxxxxxxxx  stlr   mem0 : w0 ign10 ign16
-1000100011011111111111xxxxxxxxxx  ldar   w0 : mem0
+10001000000xxxxx0xxxxxxxxxxxxxxx  n  stxr   mem0 w16 : w0 ign10
+10001000000xxxxx1xxxxxxxxxxxxxxx  n  stlxr  mem0 w16 : w0 ign10
+10001000001xxxxx0xxxxxxxxxxxxxxx  n  stxp   mem0p w16 : w0 w10
+10001000001xxxxx1xxxxxxxxxxxxxxx  n  stlxp  mem0p w16 : w0 w10
+10001000010xxxxx0xxxxxxxxxxxxxxx  n  ldxr   w0 : mem0 ign10 ign16
+10001000010xxxxx1xxxxxxxxxxxxxxx  n  ldaxr  w0 : mem0 ign10 ign16
+10001000011xxxxx0xxxxxxxxxxxxxxx  n  ldxp   w0 w10 : mem0p ign16
+10001000011xxxxx1xxxxxxxxxxxxxxx  n  ldaxp  w0 w10 : mem0p ign16
+10001000100xxxxx1xxxxxxxxxxxxxxx  n  stlr   mem0 : w0 ign10 ign16
+1000100011011111111111xxxxxxxxxx  n  ldar   w0 : mem0
 
-11001000000xxxxx0xxxxxxxxxxxxxxx  stxr   mem0 w16 : x0 ign10
-11001000000xxxxx1xxxxxxxxxxxxxxx  stlxr  mem0 w16 : x0 ign10
-11001000001xxxxx0xxxxxxxxxxxxxxx  stxp   mem0p w16 : x0 x10
-11001000001xxxxx1xxxxxxxxxxxxxxx  stlxp  mem0p w16 : x0 x10
-11001000010xxxxx0xxxxxxxxxxxxxxx  ldxr   x0 : mem0 ign10 ign16
-11001000010xxxxx1xxxxxxxxxxxxxxx  ldaxr  x0 : mem0 ign10 ign16
-11001000011xxxxx0xxxxxxxxxxxxxxx  ldxp   x0 x10 : mem0p ign16
-11001000011xxxxx1xxxxxxxxxxxxxxx  ldaxp  x0 x10 : mem0p ign16
-11001000100xxxxx1xxxxxxxxxxxxxxx  stlr   mem0 : x0 ign10 ign16
-1100100011011111111111xxxxxxxxxx  ldar   x0 : mem0
+11001000000xxxxx0xxxxxxxxxxxxxxx  n  stxr   mem0 w16 : x0 ign10
+11001000000xxxxx1xxxxxxxxxxxxxxx  n  stlxr  mem0 w16 : x0 ign10
+11001000001xxxxx0xxxxxxxxxxxxxxx  n  stxp   mem0p w16 : x0 x10
+11001000001xxxxx1xxxxxxxxxxxxxxx  n  stlxp  mem0p w16 : x0 x10
+11001000010xxxxx0xxxxxxxxxxxxxxx  n  ldxr   x0 : mem0 ign10 ign16
+11001000010xxxxx1xxxxxxxxxxxxxxx  n  ldaxr  x0 : mem0 ign10 ign16
+11001000011xxxxx0xxxxxxxxxxxxxxx  n  ldxp   x0 x10 : mem0p ign16
+11001000011xxxxx1xxxxxxxxxxxxxxx  n  ldaxp  x0 x10 : mem0p ign16
+11001000100xxxxx1xxxxxxxxxxxxxxx  n  stlr   mem0 : x0 ign10 ign16
+1100100011011111111111xxxxxxxxxx  n  ldar   x0 : mem0
 
 ### ARMv8.1 atomic instructions
 
-00001000101xxxxx011111xxxxxxxxxx  casb    w16 mem0 : w16 w0 mem0
-00001000101xxxxx111111xxxxxxxxxx  caslb   w16 mem0 : w16 w0 mem0
-00001000111xxxxx011111xxxxxxxxxx  casab   w16 mem0 : w16 w0 mem0
-00001000111xxxxx111111xxxxxxxxxx  casalb  w16 mem0 : w16 w0 mem0
-01001000101xxxxx011111xxxxxxxxxx  cash    w16 mem0 : w16 w0 mem0
-01001000101xxxxx111111xxxxxxxxxx  caslh   w16 mem0 : w16 w0 mem0
-01001000111xxxxx011111xxxxxxxxxx  casah   w16 mem0 : w16 w0 mem0
-01001000111xxxxx111111xxxxxxxxxx  casalh  w16 mem0 : w16 w0 mem0
-10001000101xxxxx011111xxxxxxxxxx  cas     w16 mem0 : w16 w0 mem0
-10001000101xxxxx111111xxxxxxxxxx  casl    w16 mem0 : w16 w0 mem0
-10001000111xxxxx011111xxxxxxxxxx  casa    w16 mem0 : w16 w0 mem0
-10001000111xxxxx111111xxxxxxxxxx  casal   w16 mem0 : w16 w0 mem0
-11001000101xxxxx011111xxxxxxxxxx  cas     x16 mem0 : x16 x0 mem0
-11001000101xxxxx111111xxxxxxxxxx  casl    x16 mem0 : x16 x0 mem0
-11001000111xxxxx011111xxxxxxxxxx  casa    x16 mem0 : x16 x0 mem0
-11001000111xxxxx111111xxxxxxxxxx  casal   x16 mem0 : x16 x0 mem0
+00001000101xxxxx011111xxxxxxxxxx  n  casb    w16 mem0 : w16 w0 mem0
+00001000101xxxxx111111xxxxxxxxxx  n  caslb   w16 mem0 : w16 w0 mem0
+00001000111xxxxx011111xxxxxxxxxx  n  casab   w16 mem0 : w16 w0 mem0
+00001000111xxxxx111111xxxxxxxxxx  n  casalb  w16 mem0 : w16 w0 mem0
+01001000101xxxxx011111xxxxxxxxxx  n  cash    w16 mem0 : w16 w0 mem0
+01001000101xxxxx111111xxxxxxxxxx  n  caslh   w16 mem0 : w16 w0 mem0
+01001000111xxxxx011111xxxxxxxxxx  n  casah   w16 mem0 : w16 w0 mem0
+01001000111xxxxx111111xxxxxxxxxx  n  casalh  w16 mem0 : w16 w0 mem0
+10001000101xxxxx011111xxxxxxxxxx  n  cas     w16 mem0 : w16 w0 mem0
+10001000101xxxxx111111xxxxxxxxxx  n  casl    w16 mem0 : w16 w0 mem0
+10001000111xxxxx011111xxxxxxxxxx  n  casa    w16 mem0 : w16 w0 mem0
+10001000111xxxxx111111xxxxxxxxxx  n  casal   w16 mem0 : w16 w0 mem0
+11001000101xxxxx011111xxxxxxxxxx  n  cas     x16 mem0 : x16 x0 mem0
+11001000101xxxxx111111xxxxxxxxxx  n  casl    x16 mem0 : x16 x0 mem0
+11001000111xxxxx011111xxxxxxxxxx  n  casa    x16 mem0 : x16 x0 mem0
+11001000111xxxxx111111xxxxxxxxxx  n  casal   x16 mem0 : x16 x0 mem0
 
-00001000001xxxxx011111xxxxxxxxxx  casp    w16p0 w16p1 mem0p : w16p0 w16p1 w0p0 w0p1 mem0p
-00001000001xxxxx111111xxxxxxxxxx  caspl   w16p0 w16p1 mem0p : w16p0 w16p1 w0p0 w0p1 mem0p
-00001000011xxxxx011111xxxxxxxxxx  caspa   w16p0 w16p1 mem0p : w16p0 w16p1 w0p0 w0p1 mem0p
-00001000011xxxxx111111xxxxxxxxxx  caspal  w16p0 w16p1 mem0p : w16p0 w16p1 w0p0 w0p1 mem0p
-01001000001xxxxx011111xxxxxxxxxx  casp    x16p0 x16p1 mem0p : x16p0 x16p1 x0p0 x0p1 mem0p
-01001000001xxxxx111111xxxxxxxxxx  caspl   x16p0 x16p1 mem0p : x16p0 x16p1 x0p0 x0p1 mem0p
-01001000011xxxxx011111xxxxxxxxxx  caspa   x16p0 x16p1 mem0p : x16p0 x16p1 x0p0 x0p1 mem0p
-01001000011xxxxx111111xxxxxxxxxx  caspal  x16p0 x16p1 mem0p : x16p0 x16p1 x0p0 x0p1 mem0p
+00001000001xxxxx011111xxxxxxxxxx  n  casp    w16p0 w16p1 mem0p : w16p0 w16p1 w0p0 w0p1 mem0p
+00001000001xxxxx111111xxxxxxxxxx  n  caspl   w16p0 w16p1 mem0p : w16p0 w16p1 w0p0 w0p1 mem0p
+00001000011xxxxx011111xxxxxxxxxx  n  caspa   w16p0 w16p1 mem0p : w16p0 w16p1 w0p0 w0p1 mem0p
+00001000011xxxxx111111xxxxxxxxxx  n  caspal  w16p0 w16p1 mem0p : w16p0 w16p1 w0p0 w0p1 mem0p
+01001000001xxxxx011111xxxxxxxxxx  n  casp    x16p0 x16p1 mem0p : x16p0 x16p1 x0p0 x0p1 mem0p
+01001000001xxxxx111111xxxxxxxxxx  n  caspl   x16p0 x16p1 mem0p : x16p0 x16p1 x0p0 x0p1 mem0p
+01001000011xxxxx011111xxxxxxxxxx  n  caspa   x16p0 x16p1 mem0p : x16p0 x16p1 x0p0 x0p1 mem0p
+01001000011xxxxx111111xxxxxxxxxx  n  caspal  x16p0 x16p1 mem0p : x16p0 x16p1 x0p0 x0p1 mem0p
 
 ## Load register (literal)
 
-00011000xxxxxxxxxxxxxxxxxxxxxxxx  ldr    w0 : memlit
-00011100xxxxxxxxxxxxxxxxxxxxxxxx  ldr    s0 : memlit
-01011000xxxxxxxxxxxxxxxxxxxxxxxx  ldr    x0 : memlit
-01011100xxxxxxxxxxxxxxxxxxxxxxxx  ldr    d0 : memlit
-10011000xxxxxxxxxxxxxxxxxxxxxxxx  ldrsw  x0 : memlit
-10011100xxxxxxxxxxxxxxxxxxxxxxxx  ldr    q0 : memlit
-11011000xxxxxxxxxxxxxxxxxxxxxxxx  prfm   : prfop memlit
+00011000xxxxxxxxxxxxxxxxxxxxxxxx  n  ldr    w0 : memlit
+00011100xxxxxxxxxxxxxxxxxxxxxxxx  n  ldr    s0 : memlit
+01011000xxxxxxxxxxxxxxxxxxxxxxxx  n  ldr    x0 : memlit
+01011100xxxxxxxxxxxxxxxxxxxxxxxx  n  ldr    d0 : memlit
+10011000xxxxxxxxxxxxxxxxxxxxxxxx  n  ldrsw  x0 : memlit
+10011100xxxxxxxxxxxxxxxxxxxxxxxx  n  ldr    q0 : memlit
+11011000xxxxxxxxxxxxxxxxxxxxxxxx  n  prfm   : prfop memlit
 
 ## Load/store no-allocate pair (offset)
 
-0010100000xxxxxxxxxxxxxxxxxxxxxx  stnp   mem7 : w0 w10
-0010100001xxxxxxxxxxxxxxxxxxxxxx  ldnp   w0 w10 : mem7
-0010110000xxxxxxxxxxxxxxxxxxxxxx  stnp   mem7 : s0 s10
-0010110001xxxxxxxxxxxxxxxxxxxxxx  ldnp   s0 s10 : mem7
-0110110000xxxxxxxxxxxxxxxxxxxxxx  stnp   mem7 : d0 d10
-0110110001xxxxxxxxxxxxxxxxxxxxxx  ldnp   d0 d10 : mem7
-1010100000xxxxxxxxxxxxxxxxxxxxxx  stnp   mem7 : x0 x10
-1010100001xxxxxxxxxxxxxxxxxxxxxx  ldnp   x0 x10 : mem7
-1010110000xxxxxxxxxxxxxxxxxxxxxx  stnp   mem7 : q0 q10
-1010110001xxxxxxxxxxxxxxxxxxxxxx  ldnp   q0 q10 : mem7
+0010100000xxxxxxxxxxxxxxxxxxxxxx  n  stnp   mem7 : w0 w10
+0010100001xxxxxxxxxxxxxxxxxxxxxx  n  ldnp   w0 w10 : mem7
+0010110000xxxxxxxxxxxxxxxxxxxxxx  n  stnp   mem7 : s0 s10
+0010110001xxxxxxxxxxxxxxxxxxxxxx  n  ldnp   s0 s10 : mem7
+0110110000xxxxxxxxxxxxxxxxxxxxxx  n  stnp   mem7 : d0 d10
+0110110001xxxxxxxxxxxxxxxxxxxxxx  n  ldnp   d0 d10 : mem7
+1010100000xxxxxxxxxxxxxxxxxxxxxx  n  stnp   mem7 : x0 x10
+1010100001xxxxxxxxxxxxxxxxxxxxxx  n  ldnp   x0 x10 : mem7
+1010110000xxxxxxxxxxxxxxxxxxxxxx  n  stnp   mem7 : q0 q10
+1010110001xxxxxxxxxxxxxxxxxxxxxx  n  ldnp   q0 q10 : mem7
 
 ## Load/store register pair (post-indexed)
 
-0010100010xxxxxxxxxxxxxxxxxxxxxx  stp    mem7post x5sp : w0 w10 x5sp mem7off
-0010100011xxxxxxxxxxxxxxxxxxxxxx  ldp    w0 w10 x5sp : mem7post x5sp mem7off
-0010110010xxxxxxxxxxxxxxxxxxxxxx  stp    mem7post x5sp : s0 s10 x5sp mem7off
-0010110011xxxxxxxxxxxxxxxxxxxxxx  ldp    s0 s10 x5sp : mem7post x5sp mem7off
-0110100011xxxxxxxxxxxxxxxxxxxxxx  ldpsw  x0 x10 x5sp : mem7post x5sp mem7off
-0110110010xxxxxxxxxxxxxxxxxxxxxx  stp    mem7post x5sp : d0 d10 x5sp mem7off
-0110110011xxxxxxxxxxxxxxxxxxxxxx  ldp    d0 d10 x5sp : mem7post x5sp mem7off
-1010100010xxxxxxxxxxxxxxxxxxxxxx  stp    mem7post x5sp : x0 x10 x5sp mem7off
-1010100011xxxxxxxxxxxxxxxxxxxxxx  ldp    x0 x10 x5sp : mem7post x5sp mem7off
-1010110010xxxxxxxxxxxxxxxxxxxxxx  stp    mem7post x5sp : q0 q10 x5sp mem7off
-1010110011xxxxxxxxxxxxxxxxxxxxxx  ldp    q0 q10 x5sp : mem7post x5sp mem7off
+0010100010xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7post x5sp : w0 w10 x5sp mem7off
+0010100011xxxxxxxxxxxxxxxxxxxxxx  n  ldp    w0 w10 x5sp : mem7post x5sp mem7off
+0010110010xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7post x5sp : s0 s10 x5sp mem7off
+0010110011xxxxxxxxxxxxxxxxxxxxxx  n  ldp    s0 s10 x5sp : mem7post x5sp mem7off
+0110100011xxxxxxxxxxxxxxxxxxxxxx  n  ldpsw  x0 x10 x5sp : mem7post x5sp mem7off
+0110110010xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7post x5sp : d0 d10 x5sp mem7off
+0110110011xxxxxxxxxxxxxxxxxxxxxx  n  ldp    d0 d10 x5sp : mem7post x5sp mem7off
+1010100010xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7post x5sp : x0 x10 x5sp mem7off
+1010100011xxxxxxxxxxxxxxxxxxxxxx  n  ldp    x0 x10 x5sp : mem7post x5sp mem7off
+1010110010xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7post x5sp : q0 q10 x5sp mem7off
+1010110011xxxxxxxxxxxxxxxxxxxxxx  n  ldp    q0 q10 x5sp : mem7post x5sp mem7off
 
 ## Load/store register pair (offset)
 
-0010100100xxxxxxxxxxxxxxxxxxxxxx  stp    mem7 : w0 w10
-0010100101xxxxxxxxxxxxxxxxxxxxxx  ldp    w0 w10 : mem7
-0010110100xxxxxxxxxxxxxxxxxxxxxx  stp    mem7 : s0 s10
-0010110101xxxxxxxxxxxxxxxxxxxxxx  ldp    s0 s10 : mem7
-0110100101xxxxxxxxxxxxxxxxxxxxxx  ldpsw  x0 x10 : mem7
-0110110100xxxxxxxxxxxxxxxxxxxxxx  stp    mem7 : d0 d10
-0110110101xxxxxxxxxxxxxxxxxxxxxx  ldp    d0 d10 : mem7
-1010100100xxxxxxxxxxxxxxxxxxxxxx  stp    mem7 : x0 x10
-1010100101xxxxxxxxxxxxxxxxxxxxxx  ldp    x0 x10 : mem7
-1010110100xxxxxxxxxxxxxxxxxxxxxx  stp    mem7 : q0 q10
-1010110101xxxxxxxxxxxxxxxxxxxxxx  ldp    q0 q10 : mem7
+0010100100xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7 : w0 w10
+0010100101xxxxxxxxxxxxxxxxxxxxxx  n  ldp    w0 w10 : mem7
+0010110100xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7 : s0 s10
+0010110101xxxxxxxxxxxxxxxxxxxxxx  n  ldp    s0 s10 : mem7
+0110100101xxxxxxxxxxxxxxxxxxxxxx  n  ldpsw  x0 x10 : mem7
+0110110100xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7 : d0 d10
+0110110101xxxxxxxxxxxxxxxxxxxxxx  n  ldp    d0 d10 : mem7
+1010100100xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7 : x0 x10
+1010100101xxxxxxxxxxxxxxxxxxxxxx  n  ldp    x0 x10 : mem7
+1010110100xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7 : q0 q10
+1010110101xxxxxxxxxxxxxxxxxxxxxx  n  ldp    q0 q10 : mem7
 
 ## Load/store register pair (pre-indexed)
 
-0010100110xxxxxxxxxxxxxxxxxxxxxx  stp    mem7 x5sp : w0 w10 x5sp mem7off
-0010100111xxxxxxxxxxxxxxxxxxxxxx  ldp    w0 w10 x5sp : mem7 x5sp mem7off
-0010110110xxxxxxxxxxxxxxxxxxxxxx  stp    mem7 x5sp : s0 s10 x5sp mem7off
-0010110111xxxxxxxxxxxxxxxxxxxxxx  ldp    s0 s10 x5sp : mem7 x5sp mem7off
-0110100111xxxxxxxxxxxxxxxxxxxxxx  ldpsw  x0 x10 x5sp : mem7 x5sp mem7off
-0110110110xxxxxxxxxxxxxxxxxxxxxx  stp    mem7 x5sp : d0 d10 x5sp mem7off
-0110110111xxxxxxxxxxxxxxxxxxxxxx  ldp    d0 d10 x5sp : mem7 x5sp mem7off
-1010100110xxxxxxxxxxxxxxxxxxxxxx  stp    mem7 x5sp : x0 x10 x5sp mem7off
-1010100111xxxxxxxxxxxxxxxxxxxxxx  ldp    x0 x10 x5sp : mem7 x5sp mem7off
-1010110110xxxxxxxxxxxxxxxxxxxxxx  stp    mem7 x5sp : q0 q10 x5sp mem7off
-1010110111xxxxxxxxxxxxxxxxxxxxxx  ldp    q0 q10 x5sp : mem7 x5sp mem7off
+0010100110xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7 x5sp : w0 w10 x5sp mem7off
+0010100111xxxxxxxxxxxxxxxxxxxxxx  n  ldp    w0 w10 x5sp : mem7 x5sp mem7off
+0010110110xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7 x5sp : s0 s10 x5sp mem7off
+0010110111xxxxxxxxxxxxxxxxxxxxxx  n  ldp    s0 s10 x5sp : mem7 x5sp mem7off
+0110100111xxxxxxxxxxxxxxxxxxxxxx  n  ldpsw  x0 x10 x5sp : mem7 x5sp mem7off
+0110110110xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7 x5sp : d0 d10 x5sp mem7off
+0110110111xxxxxxxxxxxxxxxxxxxxxx  n  ldp    d0 d10 x5sp : mem7 x5sp mem7off
+1010100110xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7 x5sp : x0 x10 x5sp mem7off
+1010100111xxxxxxxxxxxxxxxxxxxxxx  n  ldp    x0 x10 x5sp : mem7 x5sp mem7off
+1010110110xxxxxxxxxxxxxxxxxxxxxx  n  stp    mem7 x5sp : q0 q10 x5sp mem7off
+1010110111xxxxxxxxxxxxxxxxxxxxxx  n  ldp    q0 q10 x5sp : mem7 x5sp mem7off
 
 ## Load/store register (unscaled immediate)
 
 # Base
-10111000000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : w0
-11111000000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : x0
-00111000000xxxxxxxxx00xxxxxxxxxx  sturb  mem9 : w0
-01111000000xxxxxxxxx00xxxxxxxxxx  sturh  mem9 : w0
+10111000000xxxxxxxxx00xxxxxxxxxx  n  stur   mem9 : w0
+11111000000xxxxxxxxx00xxxxxxxxxx  n  stur   mem9 : x0
+00111000000xxxxxxxxx00xxxxxxxxxx  n  sturb  mem9 : w0
+01111000000xxxxxxxxx00xxxxxxxxxx  n  sturh  mem9 : w0
 
 # SIMD
-00111100000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : b0
-01111100000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : h0
-10111100000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : s0
-11111100000xxxxxxxxx00xxxxxxxxxx  stur   mem9 : d0
-00111100100xxxxxxxxx00xxxxxxxxxx  stur   mem9q : q0
+00111100000xxxxxxxxx00xxxxxxxxxx  n  stur   mem9 : b0
+01111100000xxxxxxxxx00xxxxxxxxxx  n  stur   mem9 : h0
+10111100000xxxxxxxxx00xxxxxxxxxx  n  stur   mem9 : s0
+11111100000xxxxxxxxx00xxxxxxxxxx  n  stur   mem9 : d0
+00111100100xxxxxxxxx00xxxxxxxxxx  n  stur   mem9q : q0
 
 # Base
-10111000010xxxxxxxxx00xxxxxxxxxx  ldur   w0 : mem9
-11111000010xxxxxxxxx00xxxxxxxxxx  ldur   x0 : mem9
-00111000010xxxxxxxxx00xxxxxxxxxx  ldurb  w0 : mem9
-01111000010xxxxxxxxx00xxxxxxxxxx  ldurh  w0 : mem9
-00111000100xxxxxxxxx00xxxxxxxxxx  ldursb x0 : mem9
-00111000110xxxxxxxxx00xxxxxxxxxx  ldursb w0 : mem9
-01111000100xxxxxxxxx00xxxxxxxxxx  ldursh x0 : mem9
-01111000110xxxxxxxxx00xxxxxxxxxx  ldursh w0 : mem9
-10111000100xxxxxxxxx00xxxxxxxxxx  ldursw x0 : mem9
+10111000010xxxxxxxxx00xxxxxxxxxx  n  ldur   w0 : mem9
+11111000010xxxxxxxxx00xxxxxxxxxx  n  ldur   x0 : mem9
+00111000010xxxxxxxxx00xxxxxxxxxx  n  ldurb  w0 : mem9
+01111000010xxxxxxxxx00xxxxxxxxxx  n  ldurh  w0 : mem9
+00111000100xxxxxxxxx00xxxxxxxxxx  n  ldursb x0 : mem9
+00111000110xxxxxxxxx00xxxxxxxxxx  n  ldursb w0 : mem9
+01111000100xxxxxxxxx00xxxxxxxxxx  n  ldursh x0 : mem9
+01111000110xxxxxxxxx00xxxxxxxxxx  n  ldursh w0 : mem9
+10111000100xxxxxxxxx00xxxxxxxxxx  n  ldursw x0 : mem9
 
 # SIMD
-00111100010xxxxxxxxx00xxxxxxxxxx  ldur   b0 : mem9
-01111100010xxxxxxxxx00xxxxxxxxxx  ldur   h0 : mem9
-10111100010xxxxxxxxx00xxxxxxxxxx  ldur   s0 : mem9
-11111100010xxxxxxxxx00xxxxxxxxxx  ldur   d0 : mem9
-00111100110xxxxxxxxx00xxxxxxxxxx  ldur   q0 : mem9q
+00111100010xxxxxxxxx00xxxxxxxxxx  n  ldur   b0 : mem9
+01111100010xxxxxxxxx00xxxxxxxxxx  n  ldur   h0 : mem9
+10111100010xxxxxxxxx00xxxxxxxxxx  n  ldur   s0 : mem9
+11111100010xxxxxxxxx00xxxxxxxxxx  n  ldur   d0 : mem9
+00111100110xxxxxxxxx00xxxxxxxxxx  n  ldur   q0 : mem9q
 
-11111000100xxxxxxxxx00xxxxxxxxxx  prfum  : prfop prf9  # PRFUM #imm5,[Xn,#simm]
+11111000100xxxxxxxxx00xxxxxxxxxx  n  prfum  : prfop prf9  # PRFUM #imm5,[Xn,#simm]
 
 ## Load/store register (immediate post-indexed)
 
-00111000000xxxxxxxxx01xxxxxxxxxx  strb  mem9post x5sp : w0 x5sp mem9off  # STRB Wt,[Xn],#simm
-00111000010xxxxxxxxx01xxxxxxxxxx  ldrb  w0 x5sp : mem9post x5sp mem9off
-00111000100xxxxxxxxx01xxxxxxxxxx  ldrsb x0 x5sp : mem9post x5sp mem9off
-00111000110xxxxxxxxx01xxxxxxxxxx  ldrsb w0 x5sp : mem9post x5sp mem9off
-00111100000xxxxxxxxx01xxxxxxxxxx  str   mem9post x5sp : b0 x5sp mem9off
-00111100010xxxxxxxxx01xxxxxxxxxx  ldr   b0 x5sp : mem9post x5sp mem9off
-00111100100xxxxxxxxx01xxxxxxxxxx  str   mem9qpost x5sp : q0 x5sp mem9off
-00111100110xxxxxxxxx01xxxxxxxxxx  ldr   q0 x5sp : mem9qpost x5sp mem9off
+00111000000xxxxxxxxx01xxxxxxxxxx  n  strb  mem9post x5sp : w0 x5sp mem9off  # STRB Wt,[Xn],#simm
+00111000010xxxxxxxxx01xxxxxxxxxx  n  ldrb  w0 x5sp : mem9post x5sp mem9off
+00111000100xxxxxxxxx01xxxxxxxxxx  n  ldrsb x0 x5sp : mem9post x5sp mem9off
+00111000110xxxxxxxxx01xxxxxxxxxx  n  ldrsb w0 x5sp : mem9post x5sp mem9off
+00111100000xxxxxxxxx01xxxxxxxxxx  n  str   mem9post x5sp : b0 x5sp mem9off
+00111100010xxxxxxxxx01xxxxxxxxxx  n  ldr   b0 x5sp : mem9post x5sp mem9off
+00111100100xxxxxxxxx01xxxxxxxxxx  n  str   mem9qpost x5sp : q0 x5sp mem9off
+00111100110xxxxxxxxx01xxxxxxxxxx  n  ldr   q0 x5sp : mem9qpost x5sp mem9off
 
-01111000000xxxxxxxxx01xxxxxxxxxx  strh  mem9post x5sp : w0 x5sp mem9off
-01111000010xxxxxxxxx01xxxxxxxxxx  ldrh  w0 x5sp : mem9post x5sp mem9off
-01111000100xxxxxxxxx01xxxxxxxxxx  ldrsh x0 x5sp : mem9post x5sp mem9off
-01111000110xxxxxxxxx01xxxxxxxxxx  ldrsh w0 x5sp : mem9post x5sp mem9off
-01111100000xxxxxxxxx01xxxxxxxxxx  str   mem9post x5sp : h0 x5sp mem9off
-01111100010xxxxxxxxx01xxxxxxxxxx  ldr   h0 x5sp : mem9post x5sp mem9off
+01111000000xxxxxxxxx01xxxxxxxxxx  n  strh  mem9post x5sp : w0 x5sp mem9off
+01111000010xxxxxxxxx01xxxxxxxxxx  n  ldrh  w0 x5sp : mem9post x5sp mem9off
+01111000100xxxxxxxxx01xxxxxxxxxx  n  ldrsh x0 x5sp : mem9post x5sp mem9off
+01111000110xxxxxxxxx01xxxxxxxxxx  n  ldrsh w0 x5sp : mem9post x5sp mem9off
+01111100000xxxxxxxxx01xxxxxxxxxx  n  str   mem9post x5sp : h0 x5sp mem9off
+01111100010xxxxxxxxx01xxxxxxxxxx  n  ldr   h0 x5sp : mem9post x5sp mem9off
 
-10111000000xxxxxxxxx01xxxxxxxxxx  str   mem9post x5sp : w0 x5sp mem9off
-10111000010xxxxxxxxx01xxxxxxxxxx  ldr   w0 x5sp : mem9post x5sp mem9off
-10111000100xxxxxxxxx01xxxxxxxxxx  ldrsw x0 x5sp : mem9post x5sp mem9off
-10111100000xxxxxxxxx01xxxxxxxxxx  str   mem9post x5sp : s0 x5sp mem9off
-10111100010xxxxxxxxx01xxxxxxxxxx  ldr   s0 x5sp : mem9post x5sp mem9off
+10111000000xxxxxxxxx01xxxxxxxxxx  n  str   mem9post x5sp : w0 x5sp mem9off
+10111000010xxxxxxxxx01xxxxxxxxxx  n  ldr   w0 x5sp : mem9post x5sp mem9off
+10111000100xxxxxxxxx01xxxxxxxxxx  n  ldrsw x0 x5sp : mem9post x5sp mem9off
+10111100000xxxxxxxxx01xxxxxxxxxx  n  str   mem9post x5sp : s0 x5sp mem9off
+10111100010xxxxxxxxx01xxxxxxxxxx  n  ldr   s0 x5sp : mem9post x5sp mem9off
 
-11111000000xxxxxxxxx01xxxxxxxxxx  str   mem9post x5sp : x0 x5sp mem9off
-11111000010xxxxxxxxx01xxxxxxxxxx  ldr   x0 x5sp : mem9post x5sp mem9off
-11111100000xxxxxxxxx01xxxxxxxxxx  str   mem9post x5sp : d0 x5sp mem9off
-11111100010xxxxxxxxx01xxxxxxxxxx  ldr   d0 x5sp : mem9post x5sp mem9off
+11111000000xxxxxxxxx01xxxxxxxxxx  n  str   mem9post x5sp : x0 x5sp mem9off
+11111000010xxxxxxxxx01xxxxxxxxxx  n  ldr   x0 x5sp : mem9post x5sp mem9off
+11111100000xxxxxxxxx01xxxxxxxxxx  n  str   mem9post x5sp : d0 x5sp mem9off
+11111100010xxxxxxxxx01xxxxxxxxxx  n  ldr   d0 x5sp : mem9post x5sp mem9off
 
 ## Load/store register (unprivileged)
 
-00111000000xxxxxxxxx10xxxxxxxxxx  sttrb  mem9 : w0
-00111000010xxxxxxxxx10xxxxxxxxxx  ldtrb  w0 : mem9
-00111000100xxxxxxxxx10xxxxxxxxxx  ldtrsb x0 : mem9
-00111000110xxxxxxxxx10xxxxxxxxxx  ldtrsb w0 : mem9
-01111000000xxxxxxxxx10xxxxxxxxxx  sttrh  mem9 : w0
-01111000010xxxxxxxxx10xxxxxxxxxx  ldtrh  w0 : mem9
-01111000100xxxxxxxxx10xxxxxxxxxx  ldtrsh x0 : mem9
-01111000110xxxxxxxxx10xxxxxxxxxx  ldtrsh w0 : mem9
-10111000000xxxxxxxxx10xxxxxxxxxx  sttr   mem9 : w0
-10111000010xxxxxxxxx10xxxxxxxxxx  ldtr   w0 : mem9
-10111000100xxxxxxxxx10xxxxxxxxxx  ldtrsw x0 : mem9
-11111000000xxxxxxxxx10xxxxxxxxxx  sttr   mem9 : x0
-11111000010xxxxxxxxx10xxxxxxxxxx  ldtr   x0 : mem9
+00111000000xxxxxxxxx10xxxxxxxxxx  n  sttrb  mem9 : w0
+00111000010xxxxxxxxx10xxxxxxxxxx  n  ldtrb  w0 : mem9
+00111000100xxxxxxxxx10xxxxxxxxxx  n  ldtrsb x0 : mem9
+00111000110xxxxxxxxx10xxxxxxxxxx  n  ldtrsb w0 : mem9
+01111000000xxxxxxxxx10xxxxxxxxxx  n  sttrh  mem9 : w0
+01111000010xxxxxxxxx10xxxxxxxxxx  n  ldtrh  w0 : mem9
+01111000100xxxxxxxxx10xxxxxxxxxx  n  ldtrsh x0 : mem9
+01111000110xxxxxxxxx10xxxxxxxxxx  n  ldtrsh w0 : mem9
+10111000000xxxxxxxxx10xxxxxxxxxx  n  sttr   mem9 : w0
+10111000010xxxxxxxxx10xxxxxxxxxx  n  ldtr   w0 : mem9
+10111000100xxxxxxxxx10xxxxxxxxxx  n  ldtrsw x0 : mem9
+11111000000xxxxxxxxx10xxxxxxxxxx  n  sttr   mem9 : x0
+11111000010xxxxxxxxx10xxxxxxxxxx  n  ldtr   x0 : mem9
 
 ## Load/store register (immediate pre-indexed)
 
-00111000000xxxxxxxxx11xxxxxxxxxx  strb   mem9 x5sp : w0 x5sp mem9off  # STRB Wt,[Xn,#simm]!
-00111000010xxxxxxxxx11xxxxxxxxxx  ldrb   w0 x5sp : mem9 x5sp mem9off
-00111000100xxxxxxxxx11xxxxxxxxxx  ldrsb  x0 x5sp : mem9 x5sp mem9off
-00111000110xxxxxxxxx11xxxxxxxxxx  ldrsb  w0 x5sp : mem9 x5sp mem9off
-00111100000xxxxxxxxx11xxxxxxxxxx  str    mem9 x5sp : b0 x5sp mem9off
-00111100010xxxxxxxxx11xxxxxxxxxx  ldr    b0 x5sp : mem9 x5sp mem9off
-00111100100xxxxxxxxx11xxxxxxxxxx  str    mem9q x5sp : q0 x5sp mem9off
-00111100110xxxxxxxxx11xxxxxxxxxx  ldr    q0 x5sp : mem9q x5sp mem9off
+00111000000xxxxxxxxx11xxxxxxxxxx  n  strb   mem9 x5sp : w0 x5sp mem9off  # STRB Wt,[Xn,#simm]!
+00111000010xxxxxxxxx11xxxxxxxxxx  n  ldrb   w0 x5sp : mem9 x5sp mem9off
+00111000100xxxxxxxxx11xxxxxxxxxx  n  ldrsb  x0 x5sp : mem9 x5sp mem9off
+00111000110xxxxxxxxx11xxxxxxxxxx  n  ldrsb  w0 x5sp : mem9 x5sp mem9off
+00111100000xxxxxxxxx11xxxxxxxxxx  n  str    mem9 x5sp : b0 x5sp mem9off
+00111100010xxxxxxxxx11xxxxxxxxxx  n  ldr    b0 x5sp : mem9 x5sp mem9off
+00111100100xxxxxxxxx11xxxxxxxxxx  n  str    mem9q x5sp : q0 x5sp mem9off
+00111100110xxxxxxxxx11xxxxxxxxxx  n  ldr    q0 x5sp : mem9q x5sp mem9off
 
-01111000000xxxxxxxxx11xxxxxxxxxx  strh   mem9 x5sp : w0 x5sp mem9off
-01111000010xxxxxxxxx11xxxxxxxxxx  ldrh   w0 x5sp : mem9 x5sp mem9off
-01111000100xxxxxxxxx11xxxxxxxxxx  ldrsh  x0 x5sp : mem9 x5sp mem9off
-01111000110xxxxxxxxx11xxxxxxxxxx  ldrsh  w0 x5sp : mem9 x5sp mem9off
-01111100000xxxxxxxxx11xxxxxxxxxx  str    mem9 x5sp : h0 x5sp mem9off
-01111100010xxxxxxxxx11xxxxxxxxxx  ldr    h0 x5sp : mem9 x5sp mem9off
+01111000000xxxxxxxxx11xxxxxxxxxx  n  strh   mem9 x5sp : w0 x5sp mem9off
+01111000010xxxxxxxxx11xxxxxxxxxx  n  ldrh   w0 x5sp : mem9 x5sp mem9off
+01111000100xxxxxxxxx11xxxxxxxxxx  n  ldrsh  x0 x5sp : mem9 x5sp mem9off
+01111000110xxxxxxxxx11xxxxxxxxxx  n  ldrsh  w0 x5sp : mem9 x5sp mem9off
+01111100000xxxxxxxxx11xxxxxxxxxx  n  str    mem9 x5sp : h0 x5sp mem9off
+01111100010xxxxxxxxx11xxxxxxxxxx  n  ldr    h0 x5sp : mem9 x5sp mem9off
 
-10111000000xxxxxxxxx11xxxxxxxxxx  str    mem9 x5sp : w0 x5sp mem9off
-10111000010xxxxxxxxx11xxxxxxxxxx  ldr    w0 x5sp : mem9 x5sp mem9off
-10111000100xxxxxxxxx11xxxxxxxxxx  ldrsw  x0 x5sp : mem9 x5sp mem9off
-10111100000xxxxxxxxx11xxxxxxxxxx  str    mem9 x5sp : s0 x5sp mem9off
-10111100010xxxxxxxxx11xxxxxxxxxx  ldr    s0 x5sp : mem9 x5sp mem9off
+10111000000xxxxxxxxx11xxxxxxxxxx  n  str    mem9 x5sp : w0 x5sp mem9off
+10111000010xxxxxxxxx11xxxxxxxxxx  n  ldr    w0 x5sp : mem9 x5sp mem9off
+10111000100xxxxxxxxx11xxxxxxxxxx  n  ldrsw  x0 x5sp : mem9 x5sp mem9off
+10111100000xxxxxxxxx11xxxxxxxxxx  n  str    mem9 x5sp : s0 x5sp mem9off
+10111100010xxxxxxxxx11xxxxxxxxxx  n  ldr    s0 x5sp : mem9 x5sp mem9off
 
-11111000000xxxxxxxxx11xxxxxxxxxx  str    mem9 x5sp : x0 x5sp mem9off
-11111000010xxxxxxxxx11xxxxxxxxxx  ldr    x0 x5sp : mem9 x5sp mem9off
-11111100000xxxxxxxxx11xxxxxxxxxx  str    mem9 x5sp : d0 x5sp mem9off
-11111100010xxxxxxxxx11xxxxxxxxxx  ldr    d0 x5sp : mem9 x5sp mem9off
+11111000000xxxxxxxxx11xxxxxxxxxx  n  str    mem9 x5sp : x0 x5sp mem9off
+11111000010xxxxxxxxx11xxxxxxxxxx  n  ldr    x0 x5sp : mem9 x5sp mem9off
+11111100000xxxxxxxxx11xxxxxxxxxx  n  str    mem9 x5sp : d0 x5sp mem9off
+11111100010xxxxxxxxx11xxxxxxxxxx  n  ldr    d0 x5sp : mem9 x5sp mem9off
 
 ## Atomic memory operations (ARMv8.1)
 
-00111000001xxxxx000000xxxxxxxxxx  ldaddb    w0 mem0 : w16 mem0
-00111000001xxxxx000100xxxxxxxxxx  ldclrb    w0 mem0 : w16 mem0
-00111000001xxxxx001000xxxxxxxxxx  ldeorb    w0 mem0 : w16 mem0
-00111000001xxxxx001100xxxxxxxxxx  ldsetb    w0 mem0 : w16 mem0
-00111000001xxxxx010000xxxxxxxxxx  ldsmaxb   w0 mem0 : w16 mem0
-00111000001xxxxx010100xxxxxxxxxx  ldsminb   w0 mem0 : w16 mem0
-00111000001xxxxx011000xxxxxxxxxx  ldumaxb   w0 mem0 : w16 mem0
-00111000001xxxxx011100xxxxxxxxxx  lduminb   w0 mem0 : w16 mem0
+00111000001xxxxx000000xxxxxxxxxx  n  ldaddb    w0 mem0 : w16 mem0
+00111000001xxxxx000100xxxxxxxxxx  n  ldclrb    w0 mem0 : w16 mem0
+00111000001xxxxx001000xxxxxxxxxx  n  ldeorb    w0 mem0 : w16 mem0
+00111000001xxxxx001100xxxxxxxxxx  n  ldsetb    w0 mem0 : w16 mem0
+00111000001xxxxx010000xxxxxxxxxx  n  ldsmaxb   w0 mem0 : w16 mem0
+00111000001xxxxx010100xxxxxxxxxx  n  ldsminb   w0 mem0 : w16 mem0
+00111000001xxxxx011000xxxxxxxxxx  n  ldumaxb   w0 mem0 : w16 mem0
+00111000001xxxxx011100xxxxxxxxxx  n  lduminb   w0 mem0 : w16 mem0
 
-00111000011xxxxx000000xxxxxxxxxx  ldaddlb   w0 mem0 : w16 mem0
-00111000011xxxxx000100xxxxxxxxxx  ldclrlb   w0 mem0 : w16 mem0
-00111000011xxxxx001000xxxxxxxxxx  ldeorlb   w0 mem0 : w16 mem0
-00111000011xxxxx001100xxxxxxxxxx  ldsetlb   w0 mem0 : w16 mem0
-00111000011xxxxx010000xxxxxxxxxx  ldsmaxlb  w0 mem0 : w16 mem0
-00111000011xxxxx010100xxxxxxxxxx  ldsminlb  w0 mem0 : w16 mem0
-00111000011xxxxx011000xxxxxxxxxx  ldumaxlb  w0 mem0 : w16 mem0
-00111000011xxxxx011100xxxxxxxxxx  lduminlb  w0 mem0 : w16 mem0
+00111000011xxxxx000000xxxxxxxxxx  n  ldaddlb   w0 mem0 : w16 mem0
+00111000011xxxxx000100xxxxxxxxxx  n  ldclrlb   w0 mem0 : w16 mem0
+00111000011xxxxx001000xxxxxxxxxx  n  ldeorlb   w0 mem0 : w16 mem0
+00111000011xxxxx001100xxxxxxxxxx  n  ldsetlb   w0 mem0 : w16 mem0
+00111000011xxxxx010000xxxxxxxxxx  n  ldsmaxlb  w0 mem0 : w16 mem0
+00111000011xxxxx010100xxxxxxxxxx  n  ldsminlb  w0 mem0 : w16 mem0
+00111000011xxxxx011000xxxxxxxxxx  n  ldumaxlb  w0 mem0 : w16 mem0
+00111000011xxxxx011100xxxxxxxxxx  n  lduminlb  w0 mem0 : w16 mem0
 
-00111000101xxxxx000000xxxxxxxxxx  ldaddab   w0 mem0 : w16 mem0
-00111000101xxxxx000100xxxxxxxxxx  ldclrab   w0 mem0 : w16 mem0
-00111000101xxxxx001000xxxxxxxxxx  ldeorab   w0 mem0 : w16 mem0
-00111000101xxxxx001100xxxxxxxxxx  ldsetab   w0 mem0 : w16 mem0
-00111000101xxxxx010000xxxxxxxxxx  ldsmaxab  w0 mem0 : w16 mem0
-00111000101xxxxx010100xxxxxxxxxx  ldsminab  w0 mem0 : w16 mem0
-00111000101xxxxx011000xxxxxxxxxx  ldumaxab  w0 mem0 : w16 mem0
-00111000101xxxxx011100xxxxxxxxxx  lduminab  w0 mem0 : w16 mem0
+00111000101xxxxx000000xxxxxxxxxx  n  ldaddab   w0 mem0 : w16 mem0
+00111000101xxxxx000100xxxxxxxxxx  n  ldclrab   w0 mem0 : w16 mem0
+00111000101xxxxx001000xxxxxxxxxx  n  ldeorab   w0 mem0 : w16 mem0
+00111000101xxxxx001100xxxxxxxxxx  n  ldsetab   w0 mem0 : w16 mem0
+00111000101xxxxx010000xxxxxxxxxx  n  ldsmaxab  w0 mem0 : w16 mem0
+00111000101xxxxx010100xxxxxxxxxx  n  ldsminab  w0 mem0 : w16 mem0
+00111000101xxxxx011000xxxxxxxxxx  n  ldumaxab  w0 mem0 : w16 mem0
+00111000101xxxxx011100xxxxxxxxxx  n  lduminab  w0 mem0 : w16 mem0
 
-00111000111xxxxx000000xxxxxxxxxx  ldaddalb  w0 mem0 : w16 mem0
-00111000111xxxxx000100xxxxxxxxxx  ldclralb  w0 mem0 : w16 mem0
-00111000111xxxxx001000xxxxxxxxxx  ldeoralb  w0 mem0 : w16 mem0
-00111000111xxxxx001100xxxxxxxxxx  ldsetalb  w0 mem0 : w16 mem0
-00111000111xxxxx010000xxxxxxxxxx  ldsmaxalb w0 mem0 : w16 mem0
-00111000111xxxxx010100xxxxxxxxxx  ldsminalb w0 mem0 : w16 mem0
-00111000111xxxxx011000xxxxxxxxxx  ldumaxalb w0 mem0 : w16 mem0
-00111000111xxxxx011100xxxxxxxxxx  lduminalb w0 mem0 : w16 mem0
+00111000111xxxxx000000xxxxxxxxxx  n  ldaddalb  w0 mem0 : w16 mem0
+00111000111xxxxx000100xxxxxxxxxx  n  ldclralb  w0 mem0 : w16 mem0
+00111000111xxxxx001000xxxxxxxxxx  n  ldeoralb  w0 mem0 : w16 mem0
+00111000111xxxxx001100xxxxxxxxxx  n  ldsetalb  w0 mem0 : w16 mem0
+00111000111xxxxx010000xxxxxxxxxx  n  ldsmaxalb w0 mem0 : w16 mem0
+00111000111xxxxx010100xxxxxxxxxx  n  ldsminalb w0 mem0 : w16 mem0
+00111000111xxxxx011000xxxxxxxxxx  n  ldumaxalb w0 mem0 : w16 mem0
+00111000111xxxxx011100xxxxxxxxxx  n  lduminalb w0 mem0 : w16 mem0
 
-01111000001xxxxx000000xxxxxxxxxx  ldaddh    w0 mem0 : w16 mem0
-01111000001xxxxx000100xxxxxxxxxx  ldclrh    w0 mem0 : w16 mem0
-01111000001xxxxx001000xxxxxxxxxx  ldeorh    w0 mem0 : w16 mem0
-01111000001xxxxx001100xxxxxxxxxx  ldseth    w0 mem0 : w16 mem0
-01111000001xxxxx010000xxxxxxxxxx  ldsmaxh   w0 mem0 : w16 mem0
-01111000001xxxxx010100xxxxxxxxxx  ldsminh   w0 mem0 : w16 mem0
-01111000001xxxxx011000xxxxxxxxxx  ldumaxh   w0 mem0 : w16 mem0
-01111000001xxxxx011100xxxxxxxxxx  lduminh   w0 mem0 : w16 mem0
+01111000001xxxxx000000xxxxxxxxxx  n  ldaddh    w0 mem0 : w16 mem0
+01111000001xxxxx000100xxxxxxxxxx  n  ldclrh    w0 mem0 : w16 mem0
+01111000001xxxxx001000xxxxxxxxxx  n  ldeorh    w0 mem0 : w16 mem0
+01111000001xxxxx001100xxxxxxxxxx  n  ldseth    w0 mem0 : w16 mem0
+01111000001xxxxx010000xxxxxxxxxx  n  ldsmaxh   w0 mem0 : w16 mem0
+01111000001xxxxx010100xxxxxxxxxx  n  ldsminh   w0 mem0 : w16 mem0
+01111000001xxxxx011000xxxxxxxxxx  n  ldumaxh   w0 mem0 : w16 mem0
+01111000001xxxxx011100xxxxxxxxxx  n  lduminh   w0 mem0 : w16 mem0
 
-01111000011xxxxx000000xxxxxxxxxx  ldaddlh   w0 mem0 : w16 mem0
-01111000011xxxxx000100xxxxxxxxxx  ldclrlh   w0 mem0 : w16 mem0
-01111000011xxxxx001000xxxxxxxxxx  ldeorlh   w0 mem0 : w16 mem0
-01111000011xxxxx001100xxxxxxxxxx  ldsetlh   w0 mem0 : w16 mem0
-01111000011xxxxx010000xxxxxxxxxx  ldsmaxlh  w0 mem0 : w16 mem0
-01111000011xxxxx010100xxxxxxxxxx  ldsminlh  w0 mem0 : w16 mem0
-01111000011xxxxx011000xxxxxxxxxx  ldumaxlh  w0 mem0 : w16 mem0
-01111000011xxxxx011100xxxxxxxxxx  lduminlh  w0 mem0 : w16 mem0
+01111000011xxxxx000000xxxxxxxxxx  n  ldaddlh   w0 mem0 : w16 mem0
+01111000011xxxxx000100xxxxxxxxxx  n  ldclrlh   w0 mem0 : w16 mem0
+01111000011xxxxx001000xxxxxxxxxx  n  ldeorlh   w0 mem0 : w16 mem0
+01111000011xxxxx001100xxxxxxxxxx  n  ldsetlh   w0 mem0 : w16 mem0
+01111000011xxxxx010000xxxxxxxxxx  n  ldsmaxlh  w0 mem0 : w16 mem0
+01111000011xxxxx010100xxxxxxxxxx  n  ldsminlh  w0 mem0 : w16 mem0
+01111000011xxxxx011000xxxxxxxxxx  n  ldumaxlh  w0 mem0 : w16 mem0
+01111000011xxxxx011100xxxxxxxxxx  n  lduminlh  w0 mem0 : w16 mem0
 
-01111000101xxxxx000000xxxxxxxxxx  ldaddah   w0 mem0 : w16 mem0
-01111000101xxxxx000100xxxxxxxxxx  ldclrah   w0 mem0 : w16 mem0
-01111000101xxxxx001000xxxxxxxxxx  ldeorah   w0 mem0 : w16 mem0
-01111000101xxxxx001100xxxxxxxxxx  ldsetah   w0 mem0 : w16 mem0
-01111000101xxxxx010000xxxxxxxxxx  ldsmaxah  w0 mem0 : w16 mem0
-01111000101xxxxx010100xxxxxxxxxx  ldsminah  w0 mem0 : w16 mem0
-01111000101xxxxx011000xxxxxxxxxx  ldumaxah  w0 mem0 : w16 mem0
-01111000101xxxxx011100xxxxxxxxxx  lduminah  w0 mem0 : w16 mem0
+01111000101xxxxx000000xxxxxxxxxx  n  ldaddah   w0 mem0 : w16 mem0
+01111000101xxxxx000100xxxxxxxxxx  n  ldclrah   w0 mem0 : w16 mem0
+01111000101xxxxx001000xxxxxxxxxx  n  ldeorah   w0 mem0 : w16 mem0
+01111000101xxxxx001100xxxxxxxxxx  n  ldsetah   w0 mem0 : w16 mem0
+01111000101xxxxx010000xxxxxxxxxx  n  ldsmaxah  w0 mem0 : w16 mem0
+01111000101xxxxx010100xxxxxxxxxx  n  ldsminah  w0 mem0 : w16 mem0
+01111000101xxxxx011000xxxxxxxxxx  n  ldumaxah  w0 mem0 : w16 mem0
+01111000101xxxxx011100xxxxxxxxxx  n  lduminah  w0 mem0 : w16 mem0
 
-01111000111xxxxx000000xxxxxxxxxx  ldaddalh  w0 mem0 : w16 mem0
-01111000111xxxxx000100xxxxxxxxxx  ldclralh  w0 mem0 : w16 mem0
-01111000111xxxxx001000xxxxxxxxxx  ldeoralh  w0 mem0 : w16 mem0
-01111000111xxxxx001100xxxxxxxxxx  ldsetalh  w0 mem0 : w16 mem0
-01111000111xxxxx010000xxxxxxxxxx  ldsmaxalh w0 mem0 : w16 mem0
-01111000111xxxxx010100xxxxxxxxxx  ldsminalh w0 mem0 : w16 mem0
-01111000111xxxxx011000xxxxxxxxxx  ldumaxalh w0 mem0 : w16 mem0
-01111000111xxxxx011100xxxxxxxxxx  lduminalh w0 mem0 : w16 mem0
+01111000111xxxxx000000xxxxxxxxxx  n  ldaddalh  w0 mem0 : w16 mem0
+01111000111xxxxx000100xxxxxxxxxx  n  ldclralh  w0 mem0 : w16 mem0
+01111000111xxxxx001000xxxxxxxxxx  n  ldeoralh  w0 mem0 : w16 mem0
+01111000111xxxxx001100xxxxxxxxxx  n  ldsetalh  w0 mem0 : w16 mem0
+01111000111xxxxx010000xxxxxxxxxx  n  ldsmaxalh w0 mem0 : w16 mem0
+01111000111xxxxx010100xxxxxxxxxx  n  ldsminalh w0 mem0 : w16 mem0
+01111000111xxxxx011000xxxxxxxxxx  n  ldumaxalh w0 mem0 : w16 mem0
+01111000111xxxxx011100xxxxxxxxxx  n  lduminalh w0 mem0 : w16 mem0
 
-10111000001xxxxx000000xxxxxxxxxx  ldadd     w0 mem0 : w16 mem0
-10111000001xxxxx000100xxxxxxxxxx  ldclr     w0 mem0 : w16 mem0
-10111000001xxxxx001000xxxxxxxxxx  ldeor     w0 mem0 : w16 mem0
-10111000001xxxxx001100xxxxxxxxxx  ldset     w0 mem0 : w16 mem0
-10111000001xxxxx010000xxxxxxxxxx  ldsmax    w0 mem0 : w16 mem0
-10111000001xxxxx010100xxxxxxxxxx  ldsmin    w0 mem0 : w16 mem0
-10111000001xxxxx011000xxxxxxxxxx  ldumax    w0 mem0 : w16 mem0
-10111000001xxxxx011100xxxxxxxxxx  ldumin    w0 mem0 : w16 mem0
+10111000001xxxxx000000xxxxxxxxxx  n  ldadd     w0 mem0 : w16 mem0
+10111000001xxxxx000100xxxxxxxxxx  n  ldclr     w0 mem0 : w16 mem0
+10111000001xxxxx001000xxxxxxxxxx  n  ldeor     w0 mem0 : w16 mem0
+10111000001xxxxx001100xxxxxxxxxx  n  ldset     w0 mem0 : w16 mem0
+10111000001xxxxx010000xxxxxxxxxx  n  ldsmax    w0 mem0 : w16 mem0
+10111000001xxxxx010100xxxxxxxxxx  n  ldsmin    w0 mem0 : w16 mem0
+10111000001xxxxx011000xxxxxxxxxx  n  ldumax    w0 mem0 : w16 mem0
+10111000001xxxxx011100xxxxxxxxxx  n  ldumin    w0 mem0 : w16 mem0
 
-10111000011xxxxx000000xxxxxxxxxx  ldaddl    w0 mem0 : w16 mem0
-10111000011xxxxx000100xxxxxxxxxx  ldclrl    w0 mem0 : w16 mem0
-10111000011xxxxx001000xxxxxxxxxx  ldeorl    w0 mem0 : w16 mem0
-10111000011xxxxx001100xxxxxxxxxx  ldsetl    w0 mem0 : w16 mem0
-10111000011xxxxx010000xxxxxxxxxx  ldsmaxl   w0 mem0 : w16 mem0
-10111000011xxxxx010100xxxxxxxxxx  ldsminl   w0 mem0 : w16 mem0
-10111000011xxxxx011000xxxxxxxxxx  ldumaxl   w0 mem0 : w16 mem0
-10111000011xxxxx011100xxxxxxxxxx  lduminl   w0 mem0 : w16 mem0
+10111000011xxxxx000000xxxxxxxxxx  n  ldaddl    w0 mem0 : w16 mem0
+10111000011xxxxx000100xxxxxxxxxx  n  ldclrl    w0 mem0 : w16 mem0
+10111000011xxxxx001000xxxxxxxxxx  n  ldeorl    w0 mem0 : w16 mem0
+10111000011xxxxx001100xxxxxxxxxx  n  ldsetl    w0 mem0 : w16 mem0
+10111000011xxxxx010000xxxxxxxxxx  n  ldsmaxl   w0 mem0 : w16 mem0
+10111000011xxxxx010100xxxxxxxxxx  n  ldsminl   w0 mem0 : w16 mem0
+10111000011xxxxx011000xxxxxxxxxx  n  ldumaxl   w0 mem0 : w16 mem0
+10111000011xxxxx011100xxxxxxxxxx  n  lduminl   w0 mem0 : w16 mem0
 
-10111000101xxxxx000000xxxxxxxxxx  ldadda    w0 mem0 : w16 mem0
-10111000101xxxxx000100xxxxxxxxxx  ldclra    w0 mem0 : w16 mem0
-10111000101xxxxx001000xxxxxxxxxx  ldeora    w0 mem0 : w16 mem0
-10111000101xxxxx001100xxxxxxxxxx  ldseta    w0 mem0 : w16 mem0
-10111000101xxxxx010000xxxxxxxxxx  ldsmaxa   w0 mem0 : w16 mem0
-10111000101xxxxx010100xxxxxxxxxx  ldsmina   w0 mem0 : w16 mem0
-10111000101xxxxx011000xxxxxxxxxx  ldumaxa   w0 mem0 : w16 mem0
-10111000101xxxxx011100xxxxxxxxxx  ldumina   w0 mem0 : w16 mem0
+10111000101xxxxx000000xxxxxxxxxx  n  ldadda    w0 mem0 : w16 mem0
+10111000101xxxxx000100xxxxxxxxxx  n  ldclra    w0 mem0 : w16 mem0
+10111000101xxxxx001000xxxxxxxxxx  n  ldeora    w0 mem0 : w16 mem0
+10111000101xxxxx001100xxxxxxxxxx  n  ldseta    w0 mem0 : w16 mem0
+10111000101xxxxx010000xxxxxxxxxx  n  ldsmaxa   w0 mem0 : w16 mem0
+10111000101xxxxx010100xxxxxxxxxx  n  ldsmina   w0 mem0 : w16 mem0
+10111000101xxxxx011000xxxxxxxxxx  n  ldumaxa   w0 mem0 : w16 mem0
+10111000101xxxxx011100xxxxxxxxxx  n  ldumina   w0 mem0 : w16 mem0
 
-10111000111xxxxx000000xxxxxxxxxx  ldaddal   w0 mem0 : w16 mem0
-10111000111xxxxx000100xxxxxxxxxx  ldclral   w0 mem0 : w16 mem0
-10111000111xxxxx001000xxxxxxxxxx  ldeoral   w0 mem0 : w16 mem0
-10111000111xxxxx001100xxxxxxxxxx  ldsetal   w0 mem0 : w16 mem0
-10111000111xxxxx010000xxxxxxxxxx  ldsmaxal  w0 mem0 : w16 mem0
-10111000111xxxxx010100xxxxxxxxxx  ldsminal  w0 mem0 : w16 mem0
-10111000111xxxxx011000xxxxxxxxxx  ldumaxal  w0 mem0 : w16 mem0
-10111000111xxxxx011100xxxxxxxxxx  lduminal  w0 mem0 : w16 mem0
+10111000111xxxxx000000xxxxxxxxxx  n  ldaddal   w0 mem0 : w16 mem0
+10111000111xxxxx000100xxxxxxxxxx  n  ldclral   w0 mem0 : w16 mem0
+10111000111xxxxx001000xxxxxxxxxx  n  ldeoral   w0 mem0 : w16 mem0
+10111000111xxxxx001100xxxxxxxxxx  n  ldsetal   w0 mem0 : w16 mem0
+10111000111xxxxx010000xxxxxxxxxx  n  ldsmaxal  w0 mem0 : w16 mem0
+10111000111xxxxx010100xxxxxxxxxx  n  ldsminal  w0 mem0 : w16 mem0
+10111000111xxxxx011000xxxxxxxxxx  n  ldumaxal  w0 mem0 : w16 mem0
+10111000111xxxxx011100xxxxxxxxxx  n  lduminal  w0 mem0 : w16 mem0
 
-11111000001xxxxx000000xxxxxxxxxx  ldadd     x0 mem0 : x16 mem0
-11111000001xxxxx000100xxxxxxxxxx  ldclr     x0 mem0 : x16 mem0
-11111000001xxxxx001000xxxxxxxxxx  ldeor     x0 mem0 : x16 mem0
-11111000001xxxxx001100xxxxxxxxxx  ldset     x0 mem0 : x16 mem0
-11111000001xxxxx010000xxxxxxxxxx  ldsmax    x0 mem0 : x16 mem0
-11111000001xxxxx010100xxxxxxxxxx  ldsmin    x0 mem0 : x16 mem0
-11111000001xxxxx011000xxxxxxxxxx  ldumax    x0 mem0 : x16 mem0
-11111000001xxxxx011100xxxxxxxxxx  ldumin    x0 mem0 : x16 mem0
+11111000001xxxxx000000xxxxxxxxxx  n  ldadd     x0 mem0 : x16 mem0
+11111000001xxxxx000100xxxxxxxxxx  n  ldclr     x0 mem0 : x16 mem0
+11111000001xxxxx001000xxxxxxxxxx  n  ldeor     x0 mem0 : x16 mem0
+11111000001xxxxx001100xxxxxxxxxx  n  ldset     x0 mem0 : x16 mem0
+11111000001xxxxx010000xxxxxxxxxx  n  ldsmax    x0 mem0 : x16 mem0
+11111000001xxxxx010100xxxxxxxxxx  n  ldsmin    x0 mem0 : x16 mem0
+11111000001xxxxx011000xxxxxxxxxx  n  ldumax    x0 mem0 : x16 mem0
+11111000001xxxxx011100xxxxxxxxxx  n  ldumin    x0 mem0 : x16 mem0
 
-11111000011xxxxx000000xxxxxxxxxx  ldaddl    x0 mem0 : x16 mem0
-11111000011xxxxx000100xxxxxxxxxx  ldclrl    x0 mem0 : x16 mem0
-11111000011xxxxx001000xxxxxxxxxx  ldeorl    x0 mem0 : x16 mem0
-11111000011xxxxx001100xxxxxxxxxx  ldsetl    x0 mem0 : x16 mem0
-11111000011xxxxx010000xxxxxxxxxx  ldsmaxl   x0 mem0 : x16 mem0
-11111000011xxxxx010100xxxxxxxxxx  ldsminl   x0 mem0 : x16 mem0
-11111000011xxxxx011000xxxxxxxxxx  ldumaxl   x0 mem0 : x16 mem0
-11111000011xxxxx011100xxxxxxxxxx  lduminl   x0 mem0 : x16 mem0
+11111000011xxxxx000000xxxxxxxxxx  n  ldaddl    x0 mem0 : x16 mem0
+11111000011xxxxx000100xxxxxxxxxx  n  ldclrl    x0 mem0 : x16 mem0
+11111000011xxxxx001000xxxxxxxxxx  n  ldeorl    x0 mem0 : x16 mem0
+11111000011xxxxx001100xxxxxxxxxx  n  ldsetl    x0 mem0 : x16 mem0
+11111000011xxxxx010000xxxxxxxxxx  n  ldsmaxl   x0 mem0 : x16 mem0
+11111000011xxxxx010100xxxxxxxxxx  n  ldsminl   x0 mem0 : x16 mem0
+11111000011xxxxx011000xxxxxxxxxx  n  ldumaxl   x0 mem0 : x16 mem0
+11111000011xxxxx011100xxxxxxxxxx  n  lduminl   x0 mem0 : x16 mem0
 
-11111000101xxxxx000000xxxxxxxxxx  ldadda    x0 mem0 : x16 mem0
-11111000101xxxxx000100xxxxxxxxxx  ldclra    x0 mem0 : x16 mem0
-11111000101xxxxx001000xxxxxxxxxx  ldeora    x0 mem0 : x16 mem0
-11111000101xxxxx001100xxxxxxxxxx  ldseta    x0 mem0 : x16 mem0
-11111000101xxxxx010000xxxxxxxxxx  ldsmaxa   x0 mem0 : x16 mem0
-11111000101xxxxx010100xxxxxxxxxx  ldsmina   x0 mem0 : x16 mem0
-11111000101xxxxx011000xxxxxxxxxx  ldumaxa   x0 mem0 : x16 mem0
-11111000101xxxxx011100xxxxxxxxxx  ldumina   x0 mem0 : x16 mem0
+11111000101xxxxx000000xxxxxxxxxx  n  ldadda    x0 mem0 : x16 mem0
+11111000101xxxxx000100xxxxxxxxxx  n  ldclra    x0 mem0 : x16 mem0
+11111000101xxxxx001000xxxxxxxxxx  n  ldeora    x0 mem0 : x16 mem0
+11111000101xxxxx001100xxxxxxxxxx  n  ldseta    x0 mem0 : x16 mem0
+11111000101xxxxx010000xxxxxxxxxx  n  ldsmaxa   x0 mem0 : x16 mem0
+11111000101xxxxx010100xxxxxxxxxx  n  ldsmina   x0 mem0 : x16 mem0
+11111000101xxxxx011000xxxxxxxxxx  n  ldumaxa   x0 mem0 : x16 mem0
+11111000101xxxxx011100xxxxxxxxxx  n  ldumina   x0 mem0 : x16 mem0
 
-11111000111xxxxx000000xxxxxxxxxx  ldaddal   x0 mem0 : x16 mem0
-11111000111xxxxx000100xxxxxxxxxx  ldclral   x0 mem0 : x16 mem0
-11111000111xxxxx001000xxxxxxxxxx  ldeoral   x0 mem0 : x16 mem0
-11111000111xxxxx001100xxxxxxxxxx  ldsetal   x0 mem0 : x16 mem0
-11111000111xxxxx010000xxxxxxxxxx  ldsmaxal  x0 mem0 : x16 mem0
-11111000111xxxxx010100xxxxxxxxxx  ldsminal  x0 mem0 : x16 mem0
-11111000111xxxxx011000xxxxxxxxxx  ldumaxal  x0 mem0 : x16 mem0
-11111000111xxxxx011100xxxxxxxxxx  lduminal  x0 mem0 : x16 mem0
+11111000111xxxxx000000xxxxxxxxxx  n  ldaddal   x0 mem0 : x16 mem0
+11111000111xxxxx000100xxxxxxxxxx  n  ldclral   x0 mem0 : x16 mem0
+11111000111xxxxx001000xxxxxxxxxx  n  ldeoral   x0 mem0 : x16 mem0
+11111000111xxxxx001100xxxxxxxxxx  n  ldsetal   x0 mem0 : x16 mem0
+11111000111xxxxx010000xxxxxxxxxx  n  ldsmaxal  x0 mem0 : x16 mem0
+11111000111xxxxx010100xxxxxxxxxx  n  ldsminal  x0 mem0 : x16 mem0
+11111000111xxxxx011000xxxxxxxxxx  n  ldumaxal  x0 mem0 : x16 mem0
+11111000111xxxxx011100xxxxxxxxxx  n  lduminal  x0 mem0 : x16 mem0
 
-00111000001xxxxx100000xxxxxxxxxx  swpb   w0 mem0 : w16 mem0
-00111000011xxxxx100000xxxxxxxxxx  swplb  w0 mem0 : w16 mem0
-00111000101xxxxx100000xxxxxxxxxx  swpab  w0 mem0 : w16 mem0
-00111000111xxxxx100000xxxxxxxxxx  swpalb w0 mem0 : w16 mem0
-01111000001xxxxx100000xxxxxxxxxx  swph   w0 mem0 : w16 mem0
-01111000011xxxxx100000xxxxxxxxxx  swplh  w0 mem0 : w16 mem0
-01111000101xxxxx100000xxxxxxxxxx  swpah  w0 mem0 : w16 mem0
-01111000111xxxxx100000xxxxxxxxxx  swpalh w0 mem0 : w16 mem0
-10111000001xxxxx100000xxxxxxxxxx  swp    w0 mem0 : w16 mem0
-10111000011xxxxx100000xxxxxxxxxx  swpl   w0 mem0 : w16 mem0
-10111000101xxxxx100000xxxxxxxxxx  swpa   w0 mem0 : w16 mem0
-10111000111xxxxx100000xxxxxxxxxx  swpal  w0 mem0 : w16 mem0
-11111000001xxxxx100000xxxxxxxxxx  swp    x0 mem0 : x16 mem0
-11111000011xxxxx100000xxxxxxxxxx  swpl   x0 mem0 : x16 mem0
-11111000101xxxxx100000xxxxxxxxxx  swpa   x0 mem0 : x16 mem0
-11111000111xxxxx100000xxxxxxxxxx  swpal  x0 mem0 : x16 mem0
+00111000001xxxxx100000xxxxxxxxxx  n  swpb   w0 mem0 : w16 mem0
+00111000011xxxxx100000xxxxxxxxxx  n  swplb  w0 mem0 : w16 mem0
+00111000101xxxxx100000xxxxxxxxxx  n  swpab  w0 mem0 : w16 mem0
+00111000111xxxxx100000xxxxxxxxxx  n  swpalb w0 mem0 : w16 mem0
+01111000001xxxxx100000xxxxxxxxxx  n  swph   w0 mem0 : w16 mem0
+01111000011xxxxx100000xxxxxxxxxx  n  swplh  w0 mem0 : w16 mem0
+01111000101xxxxx100000xxxxxxxxxx  n  swpah  w0 mem0 : w16 mem0
+01111000111xxxxx100000xxxxxxxxxx  n  swpalh w0 mem0 : w16 mem0
+10111000001xxxxx100000xxxxxxxxxx  n  swp    w0 mem0 : w16 mem0
+10111000011xxxxx100000xxxxxxxxxx  n  swpl   w0 mem0 : w16 mem0
+10111000101xxxxx100000xxxxxxxxxx  n  swpa   w0 mem0 : w16 mem0
+10111000111xxxxx100000xxxxxxxxxx  n  swpal  w0 mem0 : w16 mem0
+11111000001xxxxx100000xxxxxxxxxx  n  swp    x0 mem0 : x16 mem0
+11111000011xxxxx100000xxxxxxxxxx  n  swpl   x0 mem0 : x16 mem0
+11111000101xxxxx100000xxxxxxxxxx  n  swpa   x0 mem0 : x16 mem0
+11111000111xxxxx100000xxxxxxxxxx  n  swpal  x0 mem0 : x16 mem0
 
 ## Load/store register (register offset)
 
-00111000001xxxxxxxxx10xxxxxxxxxx  strb   memreg : w0
-00111000011xxxxxxxxx10xxxxxxxxxx  ldrb   w0 : memreg
-00111000101xxxxxxxxx10xxxxxxxxxx  ldrsb  x0 : memreg
-00111000111xxxxxxxxx10xxxxxxxxxx  ldrsb  w0 : memreg
-00111100001xxxxxxxxx10xxxxxxxxxx  str    memreg : b0
-00111100011xxxxxxxxx10xxxxxxxxxx  ldr    b0 : memreg
-00111100101xxxxxxxxx10xxxxxxxxxx  str    memregq : b0
-00111100111xxxxxxxxx10xxxxxxxxxx  ldr    q0 : memregq
+00111000001xxxxxxxxx10xxxxxxxxxx  n  strb   memreg : w0
+00111000011xxxxxxxxx10xxxxxxxxxx  n  ldrb   w0 : memreg
+00111000101xxxxxxxxx10xxxxxxxxxx  n  ldrsb  x0 : memreg
+00111000111xxxxxxxxx10xxxxxxxxxx  n  ldrsb  w0 : memreg
+00111100001xxxxxxxxx10xxxxxxxxxx  n  str    memreg : b0
+00111100011xxxxxxxxx10xxxxxxxxxx  n  ldr    b0 : memreg
+00111100101xxxxxxxxx10xxxxxxxxxx  n  str    memregq : b0
+00111100111xxxxxxxxx10xxxxxxxxxx  n  ldr    q0 : memregq
 
-01111000001xxxxxxxxx10xxxxxxxxxx  strh   memreg : w0
-01111000011xxxxxxxxx10xxxxxxxxxx  ldrh   w0 : memreg
-01111000101xxxxxxxxx10xxxxxxxxxx  ldrsh  x0 : memreg
-01111000111xxxxxxxxx10xxxxxxxxxx  ldrsh  w0 : memreg
-01111100001xxxxxxxxx10xxxxxxxxxx  str    memreg : h0
-01111100011xxxxxxxxx10xxxxxxxxxx  ldr    h0 : memreg
+01111000001xxxxxxxxx10xxxxxxxxxx  n  strh   memreg : w0
+01111000011xxxxxxxxx10xxxxxxxxxx  n  ldrh   w0 : memreg
+01111000101xxxxxxxxx10xxxxxxxxxx  n  ldrsh  x0 : memreg
+01111000111xxxxxxxxx10xxxxxxxxxx  n  ldrsh  w0 : memreg
+01111100001xxxxxxxxx10xxxxxxxxxx  n  str    memreg : h0
+01111100011xxxxxxxxx10xxxxxxxxxx  n  ldr    h0 : memreg
 
-10111000001xxxxxxxxx10xxxxxxxxxx  str    memreg : w0
-10111000011xxxxxxxxx10xxxxxxxxxx  ldr    w0 : memreg
-10111000101xxxxxxxxx10xxxxxxxxxx  ldrsw  x0 : memreg
-10111100001xxxxxxxxx10xxxxxxxxxx  str    memreg : s0
-10111100011xxxxxxxxx10xxxxxxxxxx  ldr    s0 : memreg
+10111000001xxxxxxxxx10xxxxxxxxxx  n  str    memreg : w0
+10111000011xxxxxxxxx10xxxxxxxxxx  n  ldr    w0 : memreg
+10111000101xxxxxxxxx10xxxxxxxxxx  n  ldrsw  x0 : memreg
+10111100001xxxxxxxxx10xxxxxxxxxx  n  str    memreg : s0
+10111100011xxxxxxxxx10xxxxxxxxxx  n  ldr    s0 : memreg
 
-11111000001xxxxxxxxx10xxxxxxxxxx  str    memreg : x0
-11111000011xxxxxxxxx10xxxxxxxxxx  ldr    x0 : memreg
-11111000101xxxxxxxxx10xxxxxxxxxx  prfm   : prfop prfreg
-11111100001xxxxxxxxx10xxxxxxxxxx  str    memreg : d0
-11111100011xxxxxxxxx10xxxxxxxxxx  ldr    d0 : memreg
+11111000001xxxxxxxxx10xxxxxxxxxx  n  str    memreg : x0
+11111000011xxxxxxxxx10xxxxxxxxxx  n  ldr    x0 : memreg
+11111000101xxxxxxxxx10xxxxxxxxxx  n  prfm   : prfop prfreg
+11111100001xxxxxxxxx10xxxxxxxxxx  n  str    memreg : d0
+11111100011xxxxxxxxx10xxxxxxxxxx  n  ldr    d0 : memreg
 
 ## Load/store register (unsigned immediate)
 
-0011100100xxxxxxxxxxxxxxxxxxxxxx  strb   mem12 : w0  # STRB Wt,[Xn,#simm]
-0011100101xxxxxxxxxxxxxxxxxxxxxx  ldrb   w0 : mem12
-0011100110xxxxxxxxxxxxxxxxxxxxxx  ldrsb  x0 : mem12
-0011100111xxxxxxxxxxxxxxxxxxxxxx  ldrsb  w0 : mem12
-0011110100xxxxxxxxxxxxxxxxxxxxxx  str    mem12 : b0
-0011110101xxxxxxxxxxxxxxxxxxxxxx  ldr    b0 : mem12
-0011110110xxxxxxxxxxxxxxxxxxxxxx  str    mem12q : q0
-0011110111xxxxxxxxxxxxxxxxxxxxxx  ldr    q0 : mem12q
+0011100100xxxxxxxxxxxxxxxxxxxxxx  n  strb   mem12 : w0  # STRB Wt,[Xn,#simm]
+0011100101xxxxxxxxxxxxxxxxxxxxxx  n  ldrb   w0 : mem12
+0011100110xxxxxxxxxxxxxxxxxxxxxx  n  ldrsb  x0 : mem12
+0011100111xxxxxxxxxxxxxxxxxxxxxx  n  ldrsb  w0 : mem12
+0011110100xxxxxxxxxxxxxxxxxxxxxx  n  str    mem12 : b0
+0011110101xxxxxxxxxxxxxxxxxxxxxx  n  ldr    b0 : mem12
+0011110110xxxxxxxxxxxxxxxxxxxxxx  n  str    mem12q : q0
+0011110111xxxxxxxxxxxxxxxxxxxxxx  n  ldr    q0 : mem12q
 
-0111100100xxxxxxxxxxxxxxxxxxxxxx  strh   mem12 : w0
-0111100101xxxxxxxxxxxxxxxxxxxxxx  ldrh   w0 : mem12
-0111100110xxxxxxxxxxxxxxxxxxxxxx  ldrsh  x0 : mem12
-0111100111xxxxxxxxxxxxxxxxxxxxxx  ldrsh  w0 : mem12
-0111110100xxxxxxxxxxxxxxxxxxxxxx  str    mem12 : h0
-0111110101xxxxxxxxxxxxxxxxxxxxxx  ldr    h0 : mem12
+0111100100xxxxxxxxxxxxxxxxxxxxxx  n  strh   mem12 : w0
+0111100101xxxxxxxxxxxxxxxxxxxxxx  n  ldrh   w0 : mem12
+0111100110xxxxxxxxxxxxxxxxxxxxxx  n  ldrsh  x0 : mem12
+0111100111xxxxxxxxxxxxxxxxxxxxxx  n  ldrsh  w0 : mem12
+0111110100xxxxxxxxxxxxxxxxxxxxxx  n  str    mem12 : h0
+0111110101xxxxxxxxxxxxxxxxxxxxxx  n  ldr    h0 : mem12
 
-1011100100xxxxxxxxxxxxxxxxxxxxxx  str    mem12 : w0
-1011100101xxxxxxxxxxxxxxxxxxxxxx  ldr    w0 : mem12
-1011100110xxxxxxxxxxxxxxxxxxxxxx  ldrsw  x0 : mem12
-1011110100xxxxxxxxxxxxxxxxxxxxxx  str    mem12 : s0
-1011110101xxxxxxxxxxxxxxxxxxxxxx  ldr    s0 : mem12
+1011100100xxxxxxxxxxxxxxxxxxxxxx  n  str    mem12 : w0
+1011100101xxxxxxxxxxxxxxxxxxxxxx  n  ldr    w0 : mem12
+1011100110xxxxxxxxxxxxxxxxxxxxxx  n  ldrsw  x0 : mem12
+1011110100xxxxxxxxxxxxxxxxxxxxxx  n  str    mem12 : s0
+1011110101xxxxxxxxxxxxxxxxxxxxxx  n  ldr    s0 : mem12
 
-1111100100xxxxxxxxxxxxxxxxxxxxxx  str    mem12 : x0
-1111100101xxxxxxxxxxxxxxxxxxxxxx  ldr    x0 : mem12
-1111100110xxxxxxxxxxxxxxxxxxxxxx  prfm   : prfop prf12  # PRFM #imm5,[Xn,#simm]
-1111110100xxxxxxxxxxxxxxxxxxxxxx  str    mem12 : d0
-1111110101xxxxxxxxxxxxxxxxxxxxxx  ldr    d0 : mem12
+1111100100xxxxxxxxxxxxxxxxxxxxxx  n  str    mem12 : x0
+1111100101xxxxxxxxxxxxxxxxxxxxxx  n  ldr    x0 : mem12
+1111100110xxxxxxxxxxxxxxxxxxxxxx  n  prfm   : prfop prf12  # PRFM #imm5,[Xn,#simm]
+1111110100xxxxxxxxxxxxxxxxxxxxxx  n  str    mem12 : d0
+1111110101xxxxxxxxxxxxxxxxxxxxxx  n  ldr    d0 : mem12
 
 ## Advanced SIMD load/store multiple structures
 
-0x001100000000000000xxxxxxxxxxxx  st4    memvm : vmsz vt0 vt1 vt2 vt3
-0x001100000000000010xxxxxxxxxxxx  st1    memvm : vmsz vt0 vt1 vt2 vt3
-0x001100000000000100xxxxxxxxxxxx  st3    memvm : vmsz vt0 vt1 vt2
-0x001100000000000110xxxxxxxxxxxx  st1    memvm : vmsz vt0 vt1 vt2
-0x001100000000000111xxxxxxxxxxxx  st1    memvm : vt0 vmsz
-0x001100000000001000xxxxxxxxxxxx  st2    memvm : vmsz vt0 vt1
-0x001100000000001010xxxxxxxxxxxx  st1    memvm : vmsz vt0 vt1
+0x001100000000000000xxxxxxxxxxxx  n  st4    memvm : vmsz vt0 vt1 vt2 vt3
+0x001100000000000010xxxxxxxxxxxx  n  st1    memvm : vmsz vt0 vt1 vt2 vt3
+0x001100000000000100xxxxxxxxxxxx  n  st3    memvm : vmsz vt0 vt1 vt2
+0x001100000000000110xxxxxxxxxxxx  n  st1    memvm : vmsz vt0 vt1 vt2
+0x001100000000000111xxxxxxxxxxxx  n  st1    memvm : vt0 vmsz
+0x001100000000001000xxxxxxxxxxxx  n  st2    memvm : vmsz vt0 vt1
+0x001100000000001010xxxxxxxxxxxx  n  st1    memvm : vmsz vt0 vt1
 
-0x001100010000000000xxxxxxxxxxxx  ld4    vt0 vt1 vt2 vt3 : memvm vmsz
-0x001100010000000010xxxxxxxxxxxx  ld1    vt0 vt1 vt2 vt3 : memvm vmsz
-0x001100010000000100xxxxxxxxxxxx  ld3    vt0 vt1 vt2 : memvm vmsz
-0x001100010000000110xxxxxxxxxxxx  ld1    vt0 vt1 vt2 : memvm vmsz
-0x001100010000000111xxxxxxxxxxxx  ld1    vt0 : memvm vmsz
-0x001100010000001000xxxxxxxxxxxx  ld2    vt0 vt1 : memvm vmsz
-0x001100010000001010xxxxxxxxxxxx  ld1    vt0 vt1 : memvm vmsz
+0x001100010000000000xxxxxxxxxxxx  n  ld4    vt0 vt1 vt2 vt3 : memvm vmsz
+0x001100010000000010xxxxxxxxxxxx  n  ld1    vt0 vt1 vt2 vt3 : memvm vmsz
+0x001100010000000100xxxxxxxxxxxx  n  ld3    vt0 vt1 vt2 : memvm vmsz
+0x001100010000000110xxxxxxxxxxxx  n  ld1    vt0 vt1 vt2 : memvm vmsz
+0x001100010000000111xxxxxxxxxxxx  n  ld1    vt0 : memvm vmsz
+0x001100010000001000xxxxxxxxxxxx  n  ld2    vt0 vt1 : memvm vmsz
+0x001100010000001010xxxxxxxxxxxx  n  ld1    vt0 vt1 : memvm vmsz
 
 ## Advanced SIMD load/store multiple structures (post-indexed)
 
-0x001100100xxxxx0000xxxxxxxxxxxx  st4    memvm x5sp : vmsz vt0 vt1 vt2 vt3 x5sp x16imm
-0x001100100xxxxx0010xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 vt1 vt2 vt3 x5sp x16imm
-0x001100100xxxxx0100xxxxxxxxxxxx  st3    memvm x5sp : vmsz vt0 vt1 vt2 x5sp x16imm
-0x001100100xxxxx0110xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 vt1 vt2 x5sp x16imm
-0x001100100xxxxx0111xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 x5sp x16imm
-0x001100100xxxxx1000xxxxxxxxxxxx  st2    memvm x5sp : vmsz vt0 vt1 x5sp x16imm
-0x001100100xxxxx1010xxxxxxxxxxxx  st1    memvm x5sp : vmsz vt0 vt1 x5sp x16imm
+0x001100100xxxxx0000xxxxxxxxxxxx  n  st4    memvm x5sp : vmsz vt0 vt1 vt2 vt3 x5sp x16imm
+0x001100100xxxxx0010xxxxxxxxxxxx  n  st1    memvm x5sp : vmsz vt0 vt1 vt2 vt3 x5sp x16imm
+0x001100100xxxxx0100xxxxxxxxxxxx  n  st3    memvm x5sp : vmsz vt0 vt1 vt2 x5sp x16imm
+0x001100100xxxxx0110xxxxxxxxxxxx  n  st1    memvm x5sp : vmsz vt0 vt1 vt2 x5sp x16imm
+0x001100100xxxxx0111xxxxxxxxxxxx  n  st1    memvm x5sp : vmsz vt0 x5sp x16imm
+0x001100100xxxxx1000xxxxxxxxxxxx  n  st2    memvm x5sp : vmsz vt0 vt1 x5sp x16imm
+0x001100100xxxxx1010xxxxxxxxxxxx  n  st1    memvm x5sp : vmsz vt0 vt1 x5sp x16imm
 
-0x001100110xxxxx0000xxxxxxxxxxxx  ld4    vt0 vt1 vt2 vt3 x5sp : memvm vmsz x5sp x16imm
-0x001100110xxxxx0010xxxxxxxxxxxx  ld1    vt0 vt1 vt2 vt3 x5sp : memvm vmsz x5sp x16imm
-0x001100110xxxxx0100xxxxxxxxxxxx  ld3    vt0 vt1 vt2 x5sp : memvm vmsz x5sp x16imm
-0x001100110xxxxx0110xxxxxxxxxxxx  ld1    vt0 vt1 vt2 x5sp : memvm vmsz x5sp x16imm
-0x001100110xxxxx0111xxxxxxxxxxxx  ld1    vt0 x5sp : memvm vmsz x5sp x16imm
-0x001100110xxxxx1000xxxxxxxxxxxx  ld2    vt0 vt1 x5sp : memvm vmsz x5sp x16imm
-0x001100110xxxxx1010xxxxxxxxxxxx  ld1    vt0 vt1 x5sp : memvm vmsz x5sp x16imm
+0x001100110xxxxx0000xxxxxxxxxxxx  n  ld4    vt0 vt1 vt2 vt3 x5sp : memvm vmsz x5sp x16imm
+0x001100110xxxxx0010xxxxxxxxxxxx  n  ld1    vt0 vt1 vt2 vt3 x5sp : memvm vmsz x5sp x16imm
+0x001100110xxxxx0100xxxxxxxxxxxx  n  ld3    vt0 vt1 vt2 x5sp : memvm vmsz x5sp x16imm
+0x001100110xxxxx0110xxxxxxxxxxxx  n  ld1    vt0 vt1 vt2 x5sp : memvm vmsz x5sp x16imm
+0x001100110xxxxx0111xxxxxxxxxxxx  n  ld1    vt0 x5sp : memvm vmsz x5sp x16imm
+0x001100110xxxxx1000xxxxxxxxxxxx  n  ld2    vt0 vt1 x5sp : memvm vmsz x5sp x16imm
+0x001100110xxxxx1010xxxxxxxxxxxx  n  ld1    vt0 vt1 x5sp : memvm vmsz x5sp x16imm
 
 ## Advanced SIMD load/store single structure
 
-0x00110100000000000xxxxxxxxxxxxx  st1    memvs : q0 index0
-0x00110100000000001xxxxxxxxxxxxx  st3    memvs : q0 q0p1 q0p2 index0
-0x00110100000000010xx0xxxxxxxxxx  st1    memvs : q0 index1
-0x00110100000000011xx0xxxxxxxxxx  st3    memvs : q0 q0p1 q0p2 index1
-0x00110100000000100x00xxxxxxxxxx  st1    memvs : q0 index2
-0x00110100000000100001xxxxxxxxxx  st1    memvs : q0 index3
-0x00110100000000101x00xxxxxxxxxx  st3    memvs : q0 q0p1 q0p2 index2
-0x00110100000000101001xxxxxxxxxx  st3    memvs : q0 q0p1 q0p2 index3
+0x00110100000000000xxxxxxxxxxxxx  n  st1    memvs : q0 index0
+0x00110100000000001xxxxxxxxxxxxx  n  st3    memvs : q0 q0p1 q0p2 index0
+0x00110100000000010xx0xxxxxxxxxx  n  st1    memvs : q0 index1
+0x00110100000000011xx0xxxxxxxxxx  n  st3    memvs : q0 q0p1 q0p2 index1
+0x00110100000000100x00xxxxxxxxxx  n  st1    memvs : q0 index2
+0x00110100000000100001xxxxxxxxxx  n  st1    memvs : q0 index3
+0x00110100000000101x00xxxxxxxxxx  n  st3    memvs : q0 q0p1 q0p2 index2
+0x00110100000000101001xxxxxxxxxx  n  st3    memvs : q0 q0p1 q0p2 index3
 
-0x00110100100000000xxxxxxxxxxxxx  st2    memvs : q0 q0p1 index0
-0x00110100100000001xxxxxxxxxxxxx  st4    memvs : q0 q0p1 q0p2 q0p3 index0
-0x00110100100000010xx0xxxxxxxxxx  st2    memvs : q0 q0p1 index1
-0x00110100100000011xx0xxxxxxxxxx  st4    memvs : q0 q0p1 q0p2 q0p3 index1
-0x00110100100000100x00xxxxxxxxxx  st2    memvs : q0 q0p1 index2
-0x00110100100000100001xxxxxxxxxx  st2    memvs : q0 q0p1 index3
-0x00110100100000101x00xxxxxxxxxx  st4    memvs : q0 q0p1 q0p2 q0p3 index2
-0x00110100100000101001xxxxxxxxxx  st4    memvs : q0 q0p1 q0p2 q0p3 index3
+0x00110100100000000xxxxxxxxxxxxx  n  st2    memvs : q0 q0p1 index0
+0x00110100100000001xxxxxxxxxxxxx  n  st4    memvs : q0 q0p1 q0p2 q0p3 index0
+0x00110100100000010xx0xxxxxxxxxx  n  st2    memvs : q0 q0p1 index1
+0x00110100100000011xx0xxxxxxxxxx  n  st4    memvs : q0 q0p1 q0p2 q0p3 index1
+0x00110100100000100x00xxxxxxxxxx  n  st2    memvs : q0 q0p1 index2
+0x00110100100000100001xxxxxxxxxx  n  st2    memvs : q0 q0p1 index3
+0x00110100100000101x00xxxxxxxxxx  n  st4    memvs : q0 q0p1 q0p2 q0p3 index2
+0x00110100100000101001xxxxxxxxxx  n  st4    memvs : q0 q0p1 q0p2 q0p3 index3
 
-0x00110101000000000xxxxxxxxxxxxx  ld1    q0 : memvs index0
-0x00110101000000001xxxxxxxxxxxxx  ld3    q0 q0p1 q0p2 : memvs index0
-0x00110101000000010xx0xxxxxxxxxx  ld1    q0 : memvs index1
-0x00110101000000011xx0xxxxxxxxxx  ld3    q0 q0p1 q0p2 : memvs index1
-0x00110101000000100x00xxxxxxxxxx  ld1    q0 : memvs index2
-0x00110101000000100001xxxxxxxxxx  ld1    q0 : memvs index3
-0x00110101000000101x00xxxxxxxxxx  ld3    q0 q0p1 q0p2 : memvs index2
-0x00110101000000101001xxxxxxxxxx  ld3    q0 q0p1 q0p2 : memvs index3
+0x00110101000000000xxxxxxxxxxxxx  n  ld1    q0 : memvs index0
+0x00110101000000001xxxxxxxxxxxxx  n  ld3    q0 q0p1 q0p2 : memvs index0
+0x00110101000000010xx0xxxxxxxxxx  n  ld1    q0 : memvs index1
+0x00110101000000011xx0xxxxxxxxxx  n  ld3    q0 q0p1 q0p2 : memvs index1
+0x00110101000000100x00xxxxxxxxxx  n  ld1    q0 : memvs index2
+0x00110101000000100001xxxxxxxxxx  n  ld1    q0 : memvs index3
+0x00110101000000101x00xxxxxxxxxx  n  ld3    q0 q0p1 q0p2 : memvs index2
+0x00110101000000101001xxxxxxxxxx  n  ld3    q0 q0p1 q0p2 : memvs index3
 
-0x001101010000001100xxxxxxxxxxxx  ld1r   dq0 : memvr
-0x001101010000001110xxxxxxxxxxxx  ld3r   dq0 dq0p1 dq0p2 : memvr
+0x001101010000001100xxxxxxxxxxxx  n  ld1r   dq0 : memvr
+0x001101010000001110xxxxxxxxxxxx  n  ld3r   dq0 dq0p1 dq0p2 : memvr
 
-0x00110101100000000xxxxxxxxxxxxx  ld2    q0 q0p1 : memvs index0
-0x00110101100000001xxxxxxxxxxxxx  ld4    q0 q0p1 q0p2 q0p3 : memvs index0
-0x00110101100000010xx0xxxxxxxxxx  ld2    q0 q0p1 : memvs index1
-0x00110101100000011xx0xxxxxxxxxx  ld4    q0 q0p1 q0p2 q0p3 : memvs index1
-0x00110101100000100x00xxxxxxxxxx  ld2    q0 q0p1 : memvs index2
-0x00110101100000100001xxxxxxxxxx  ld2    q0 q0p1 : memvs index3
-0x00110101100000101x00xxxxxxxxxx  ld4    q0 q0p1 q0p2 q0p3 : memvs index2
-0x00110101100000101001xxxxxxxxxx  ld4    q0 q0p1 q0p2 q0p3 : memvs index3
+0x00110101100000000xxxxxxxxxxxxx  n  ld2    q0 q0p1 : memvs index0
+0x00110101100000001xxxxxxxxxxxxx  n  ld4    q0 q0p1 q0p2 q0p3 : memvs index0
+0x00110101100000010xx0xxxxxxxxxx  n  ld2    q0 q0p1 : memvs index1
+0x00110101100000011xx0xxxxxxxxxx  n  ld4    q0 q0p1 q0p2 q0p3 : memvs index1
+0x00110101100000100x00xxxxxxxxxx  n  ld2    q0 q0p1 : memvs index2
+0x00110101100000100001xxxxxxxxxx  n  ld2    q0 q0p1 : memvs index3
+0x00110101100000101x00xxxxxxxxxx  n  ld4    q0 q0p1 q0p2 q0p3 : memvs index2
+0x00110101100000101001xxxxxxxxxx  n  ld4    q0 q0p1 q0p2 q0p3 : memvs index3
 
-0x001101011000001100xxxxxxxxxxxx  ld2r   dq0 dq0p1 : memvr
-0x001101011000001110xxxxxxxxxxxx  ld4r   dq0 dq0p1 dq0p2 dq0p3 : memvr
+0x001101011000001100xxxxxxxxxxxx  n  ld2r   dq0 dq0p1 : memvr
+0x001101011000001110xxxxxxxxxxxx  n  ld4r   dq0 dq0p1 dq0p2 dq0p3 : memvr
 
 ## Advanced SIMD load/store single structure (post-indexed)
 
-0x001101100xxxxx000xxxxxxxxxxxxx  st1    memvs x5sp : q0 index0 x5sp x16immvs
-0x001101100xxxxx001xxxxxxxxxxxxx  st3    memvs x5sp : q0 q0p1 q0p2 index0 x5sp x16immvs
-0x001101100xxxxx010xx0xxxxxxxxxx  st1    memvs x5sp : q0 index1 x5sp x16immvs
-0x001101100xxxxx011xx0xxxxxxxxxx  st3    memvs x5sp : q0 q0p1 q0p2 index1 x5sp x16immvs
-0x001101100xxxxx100x00xxxxxxxxxx  st1    memvs x5sp : q0 index2 x5sp x16immvs
-0x001101100xxxxx100001xxxxxxxxxx  st1    memvs x5sp : q0 index3 x5sp x16immvs
-0x001101100xxxxx101x00xxxxxxxxxx  st3    memvs x5sp : q0 q0p1 q0p2 index2 x5sp x16immvs
-0x001101100xxxxx101001xxxxxxxxxx  st3    memvs x5sp : q0 q0p1 q0p2 index3 x5sp x16immvs
+0x001101100xxxxx000xxxxxxxxxxxxx  n  st1    memvs x5sp : q0 index0 x5sp x16immvs
+0x001101100xxxxx001xxxxxxxxxxxxx  n  st3    memvs x5sp : q0 q0p1 q0p2 index0 x5sp x16immvs
+0x001101100xxxxx010xx0xxxxxxxxxx  n  st1    memvs x5sp : q0 index1 x5sp x16immvs
+0x001101100xxxxx011xx0xxxxxxxxxx  n  st3    memvs x5sp : q0 q0p1 q0p2 index1 x5sp x16immvs
+0x001101100xxxxx100x00xxxxxxxxxx  n  st1    memvs x5sp : q0 index2 x5sp x16immvs
+0x001101100xxxxx100001xxxxxxxxxx  n  st1    memvs x5sp : q0 index3 x5sp x16immvs
+0x001101100xxxxx101x00xxxxxxxxxx  n  st3    memvs x5sp : q0 q0p1 q0p2 index2 x5sp x16immvs
+0x001101100xxxxx101001xxxxxxxxxx  n  st3    memvs x5sp : q0 q0p1 q0p2 index3 x5sp x16immvs
 
-0x001101101xxxxx000xxxxxxxxxxxxx  st2    memvs x5sp : q0 q0p1 index0 x5sp x16immvs
-0x001101101xxxxx001xxxxxxxxxxxxx  st4    memvs x5sp : q0 q0p1 q0p2 q0p3 index0 x5sp x16immvs
-0x001101101xxxxx010xx0xxxxxxxxxx  st2    memvs x5sp : q0 q0p1 index1 x5sp x16immvs
-0x001101101xxxxx011xx0xxxxxxxxxx  st4    memvs x5sp : q0 q0p1 q0p2 q0p3 index1 x5sp x16immvs
-0x001101101xxxxx100x00xxxxxxxxxx  st2    memvs x5sp : q0 q0p1 index2 x5sp x16immvs
-0x001101101xxxxx100001xxxxxxxxxx  st2    memvs x5sp : q0 q0p1 index3 x5sp x16immvs
-0x001101101xxxxx101x00xxxxxxxxxx  st4    memvs x5sp : q0 q0p1 q0p2 q0p3 index2 x5sp x16immvs
-0x001101101xxxxx101001xxxxxxxxxx  st4    memvs x5sp : q0 q0p1 q0p2 q0p3 index3 x5sp x16immvs
+0x001101101xxxxx000xxxxxxxxxxxxx  n  st2    memvs x5sp : q0 q0p1 index0 x5sp x16immvs
+0x001101101xxxxx001xxxxxxxxxxxxx  n  st4    memvs x5sp : q0 q0p1 q0p2 q0p3 index0 x5sp x16immvs
+0x001101101xxxxx010xx0xxxxxxxxxx  n  st2    memvs x5sp : q0 q0p1 index1 x5sp x16immvs
+0x001101101xxxxx011xx0xxxxxxxxxx  n  st4    memvs x5sp : q0 q0p1 q0p2 q0p3 index1 x5sp x16immvs
+0x001101101xxxxx100x00xxxxxxxxxx  n  st2    memvs x5sp : q0 q0p1 index2 x5sp x16immvs
+0x001101101xxxxx100001xxxxxxxxxx  n  st2    memvs x5sp : q0 q0p1 index3 x5sp x16immvs
+0x001101101xxxxx101x00xxxxxxxxxx  n  st4    memvs x5sp : q0 q0p1 q0p2 q0p3 index2 x5sp x16immvs
+0x001101101xxxxx101001xxxxxxxxxx  n  st4    memvs x5sp : q0 q0p1 q0p2 q0p3 index3 x5sp x16immvs
 
-0x001101110xxxxx000xxxxxxxxxxxxx  ld1    q0 x5sp : q0 memvs index0 x5sp x16immvs
-0x001101110xxxxx001xxxxxxxxxxxxx  ld3    q0 q0p1 q0p2 x5sp : q0 q0p1 q0p2 memvs index0 x5sp x16immvs
-0x001101110xxxxx010xx0xxxxxxxxxx  ld1    q0 x5sp : q0 memvs index1 x5sp x16immvs
-0x001101110xxxxx011xx0xxxxxxxxxx  ld3    q0 q0p1 q0p2 x5sp : q0 q0p1 q0p2 memvs index1 x5sp x16immvs
-0x001101110xxxxx100x00xxxxxxxxxx  ld1    q0 x5sp : q0 memvs index2 x5sp x16immvs
-0x001101110xxxxx100001xxxxxxxxxx  ld1    q0 x5sp : q0 memvs index3 x5sp x16immvs
-0x001101110xxxxx101x00xxxxxxxxxx  ld3    q0 q0p1 q0p2 x5sp : q0 q0p1 q0p2 memvs index2 x5sp x16immvs
-0x001101110xxxxx101001xxxxxxxxxx  ld3    q0 q0p1 q0p2 x5sp : q0 q0p1 q0p2 memvs index3 x5sp x16immvs
+0x001101110xxxxx000xxxxxxxxxxxxx  n  ld1    q0 x5sp : q0 memvs index0 x5sp x16immvs
+0x001101110xxxxx001xxxxxxxxxxxxx  n  ld3    q0 q0p1 q0p2 x5sp : q0 q0p1 q0p2 memvs index0 x5sp x16immvs
+0x001101110xxxxx010xx0xxxxxxxxxx  n  ld1    q0 x5sp : q0 memvs index1 x5sp x16immvs
+0x001101110xxxxx011xx0xxxxxxxxxx  n  ld3    q0 q0p1 q0p2 x5sp : q0 q0p1 q0p2 memvs index1 x5sp x16immvs
+0x001101110xxxxx100x00xxxxxxxxxx  n  ld1    q0 x5sp : q0 memvs index2 x5sp x16immvs
+0x001101110xxxxx100001xxxxxxxxxx  n  ld1    q0 x5sp : q0 memvs index3 x5sp x16immvs
+0x001101110xxxxx101x00xxxxxxxxxx  n  ld3    q0 q0p1 q0p2 x5sp : q0 q0p1 q0p2 memvs index2 x5sp x16immvs
+0x001101110xxxxx101001xxxxxxxxxx  n  ld3    q0 q0p1 q0p2 x5sp : q0 q0p1 q0p2 memvs index3 x5sp x16immvs
 
-0x001101110xxxxx1100xxxxxxxxxxxx  ld1r   dq0 x5sp : memvr x5sp x16immvr
-0x001101110xxxxx1110xxxxxxxxxxxx  ld3r   dq0 dq0p1 dq0p2 x5sp : memvr x5sp x16immvr
+0x001101110xxxxx1100xxxxxxxxxxxx  n  ld1r   dq0 x5sp : memvr x5sp x16immvr
+0x001101110xxxxx1110xxxxxxxxxxxx  n  ld3r   dq0 dq0p1 dq0p2 x5sp : memvr x5sp x16immvr
 
-0x001101111xxxxx000xxxxxxxxxxxxx  ld2    q0 q0p1 x5sp : q0 q0p1 memvs index0 x5sp x16immvs
-0x001101111xxxxx001xxxxxxxxxxxxx  ld4    q0 q0p1 q0p2 q0p3 x5sp : q0 q0p1 q0p2 q0p3 memvs index0 x5sp x16immvs
-0x001101111xxxxx010xx0xxxxxxxxxx  ld2    q0 q0p1 x5sp : q0 q0p1 memvs index1 x5sp x16immvs
-0x001101111xxxxx011xx0xxxxxxxxxx  ld4    q0 q0p1 q0p2 q0p3 x5sp : q0 q0p1 q0p2 q0p3 memvs index1 x5sp x16immvs
-0x001101111xxxxx100x00xxxxxxxxxx  ld2    q0 q0p1 x5sp : q0 q0p1 memvs index2 x5sp x16immvs
-0x001101111xxxxx100001xxxxxxxxxx  ld2    q0 q0p1 x5sp : q0 q0p1 memvs index3 x5sp x16immvs
-0x001101111xxxxx101x00xxxxxxxxxx  ld4    q0 q0p1 q0p2 q0p3 x5sp : q0 q0p1 q0p2 q0p3 memvs index2 x5sp x16immvs
-0x001101111xxxxx101001xxxxxxxxxx  ld4    q0 q0p1 q0p2 q0p3 x5sp : q0 q0p1 q0p2 q0p3 memvs index3 x5sp x16immvs
+0x001101111xxxxx000xxxxxxxxxxxxx  n  ld2    q0 q0p1 x5sp : q0 q0p1 memvs index0 x5sp x16immvs
+0x001101111xxxxx001xxxxxxxxxxxxx  n  ld4    q0 q0p1 q0p2 q0p3 x5sp : q0 q0p1 q0p2 q0p3 memvs index0 x5sp x16immvs
+0x001101111xxxxx010xx0xxxxxxxxxx  n  ld2    q0 q0p1 x5sp : q0 q0p1 memvs index1 x5sp x16immvs
+0x001101111xxxxx011xx0xxxxxxxxxx  n  ld4    q0 q0p1 q0p2 q0p3 x5sp : q0 q0p1 q0p2 q0p3 memvs index1 x5sp x16immvs
+0x001101111xxxxx100x00xxxxxxxxxx  n  ld2    q0 q0p1 x5sp : q0 q0p1 memvs index2 x5sp x16immvs
+0x001101111xxxxx100001xxxxxxxxxx  n  ld2    q0 q0p1 x5sp : q0 q0p1 memvs index3 x5sp x16immvs
+0x001101111xxxxx101x00xxxxxxxxxx  n  ld4    q0 q0p1 q0p2 q0p3 x5sp : q0 q0p1 q0p2 q0p3 memvs index2 x5sp x16immvs
+0x001101111xxxxx101001xxxxxxxxxx  n  ld4    q0 q0p1 q0p2 q0p3 x5sp : q0 q0p1 q0p2 q0p3 memvs index3 x5sp x16immvs
 
-0x001101111xxxxx1100xxxxxxxxxxxx  ld2r   dq0 dq0p1 x5sp : memvr x5sp x16immvr
-0x001101111xxxxx1110xxxxxxxxxxxx  ld4r   dq0 dq0p1 dq0p2 dq0p3 x5sp : memvr x5sp x16immvr
+0x001101111xxxxx1100xxxxxxxxxxxx  n  ld2r   dq0 dq0p1 x5sp : memvr x5sp x16immvr
+0x001101111xxxxx1110xxxxxxxxxxxx  n  ld4r   dq0 dq0p1 dq0p2 dq0p3 x5sp : memvr x5sp x16immvr
 
 # Data Processing - Register
 
 ## Logical (shifted register)
 
-x0001010xx0xxxxxxxxxxxxxxxxxxxxx  and    wx0 : wx5 wx16 shift4 imm6
-x0001010xx1xxxxxxxxxxxxxxxxxxxxx  bic    wx0 : wx5 wx16 shift4 imm6
-x0101010xx0xxxxxxxxxxxxxxxxxxxxx  orr    wx0 : wx5 wx16 shift4 imm6
-x0101010xx1xxxxxxxxxxxxxxxxxxxxx  orn    wx0 : wx5 wx16 shift4 imm6
-x1001010xx0xxxxxxxxxxxxxxxxxxxxx  eor    wx0 : wx5 wx16 shift4 imm6
-x1001010xx1xxxxxxxxxxxxxxxxxxxxx  eon    wx0 : wx5 wx16 shift4 imm6
-x1101010xx0xxxxxxxxxxxxxxxxxxxxx  ands   wx0 : wx5 wx16 shift4 imm6
-x1101010xx1xxxxxxxxxxxxxxxxxxxxx  bics   wx0 : wx5 wx16 shift4 imm6
+x0001010xx0xxxxxxxxxxxxxxxxxxxxx  n  and    wx0 : wx5 wx16 shift4 imm6
+x0001010xx1xxxxxxxxxxxxxxxxxxxxx  n  bic    wx0 : wx5 wx16 shift4 imm6
+x0101010xx0xxxxxxxxxxxxxxxxxxxxx  n  orr    wx0 : wx5 wx16 shift4 imm6
+x0101010xx1xxxxxxxxxxxxxxxxxxxxx  n  orn    wx0 : wx5 wx16 shift4 imm6
+x1001010xx0xxxxxxxxxxxxxxxxxxxxx  n  eor    wx0 : wx5 wx16 shift4 imm6
+x1001010xx1xxxxxxxxxxxxxxxxxxxxx  n  eon    wx0 : wx5 wx16 shift4 imm6
+x1101010xx0xxxxxxxxxxxxxxxxxxxxx  w  ands   wx0 : wx5 wx16 shift4 imm6
+x1101010xx1xxxxxxxxxxxxxxxxxxxxx  w  bics   wx0 : wx5 wx16 shift4 imm6
 
 ## Add/subtract (shifted register)
 
-x0001011xx0xxxxxxxxxxxxxxxxxxxxx  add    wx0 : wx5 wx16 shift3 imm6
-x0101011xx0xxxxxxxxxxxxxxxxxxxxx  adds   wx0 : wx5 wx16 shift3 imm6
-x1001011xx0xxxxxxxxxxxxxxxxxxxxx  sub    wx0 : wx5 wx16 shift3 imm6
-x1101011xx0xxxxxxxxxxxxxxxxxxxxx  subs   wx0 : wx5 wx16 shift3 imm6
+x0001011xx0xxxxxxxxxxxxxxxxxxxxx  n  add    wx0 : wx5 wx16 shift3 imm6
+x0101011xx0xxxxxxxxxxxxxxxxxxxxx  w  adds   wx0 : wx5 wx16 shift3 imm6
+x1001011xx0xxxxxxxxxxxxxxxxxxxxx  n  sub    wx0 : wx5 wx16 shift3 imm6
+x1101011xx0xxxxxxxxxxxxxxxxxxxxx  w  subs   wx0 : wx5 wx16 shift3 imm6
 
 ## Add/subtract (extended register)
 
-x0001011001xxxxxxxxxxxxxxxxxxxxx  add    wx0sp : wx5sp wx16 ext extam
-x0101011001xxxxxxxxxxxxxxxxxxxxx  adds   wx0   : wx5sp wx16 ext extam
-x1001011001xxxxxxxxxxxxxxxxxxxxx  sub    wx0sp : wx5sp wx16 ext extam
-x1101011001xxxxxxxxxxxxxxxxxxxxx  subs   wx0   : wx5sp wx16 ext extam
+x0001011001xxxxxxxxxxxxxxxxxxxxx  n  add    wx0sp : wx5sp wx16 ext extam
+x0101011001xxxxxxxxxxxxxxxxxxxxx  w  adds   wx0   : wx5sp wx16 ext extam
+x1001011001xxxxxxxxxxxxxxxxxxxxx  n  sub    wx0sp : wx5sp wx16 ext extam
+x1101011001xxxxxxxxxxxxxxxxxxxxx  w  subs   wx0   : wx5sp wx16 ext extam
 
 ## Add/subtract (with carry)
 
-x0011010000xxxxx000000xxxxxxxxxx  adc    wx0 : wx5 wx16
-x0111010000xxxxx000000xxxxxxxxxx  adcs   wx0 : wx5 wx16
-x1011010000xxxxx000000xxxxxxxxxx  sbc    wx0 : wx5 wx16
-x1111010000xxxxx000000xxxxxxxxxx  sbcs   wx0 : wx5 wx16
+x0011010000xxxxx000000xxxxxxxxxx  r  adc    wx0 : wx5 wx16
+x0111010000xxxxx000000xxxxxxxxxx  rw adcs   wx0 : wx5 wx16
+x1011010000xxxxx000000xxxxxxxxxx  r  sbc    wx0 : wx5 wx16
+x1111010000xxxxx000000xxxxxxxxxx  rw sbcs   wx0 : wx5 wx16
 
 ## Conditional compare (register)
 
-x0111010010xxxxxxxxx00xxxxx0xxxx  ccmn   : wx5 wx16 nzcv cond
-x1111010010xxxxxxxxx00xxxxx0xxxx  ccmp   : wx5 wx16 nzcv cond
+x0111010010xxxxxxxxx00xxxxx0xxxx  rw ccmn   : wx5 wx16 nzcv cond
+x1111010010xxxxxxxxx00xxxxx0xxxx  rw ccmp   : wx5 wx16 nzcv cond
 
 ## Conditional compare (immediate)
 
-x0111010010xxxxxxxxx10xxxxx0xxxx  ccmn   : wx5 imm5 nzcv cond
-x1111010010xxxxxxxxx10xxxxx0xxxx  ccmp   : wx5 imm5 nzcv cond
+x0111010010xxxxxxxxx10xxxxx0xxxx  rw ccmn   : wx5 imm5 nzcv cond
+x1111010010xxxxxxxxx10xxxxx0xxxx  rw ccmp   : wx5 imm5 nzcv cond
 
 ## Conditional select
 
-x0011010100xxxxxxxxx00xxxxxxxxxx  csel   wx0 : wx5 wx16 cond
-x0011010100xxxxxxxxx01xxxxxxxxxx  csinc  wx0 : wx5 wx16 cond
-x1011010100xxxxxxxxx00xxxxxxxxxx  csinv  wx0 : wx5 wx16 cond
-x1011010100xxxxxxxxx01xxxxxxxxxx  csneg  wx0 : wx5 wx16 cond
-00011110xx1xxxxxxxxx11xxxxxxxxxx  fcsel  float_reg0 : float_reg5 float_reg16 cond
+x0011010100xxxxxxxxx00xxxxxxxxxx  r  csel   wx0 : wx5 wx16 cond
+x0011010100xxxxxxxxx01xxxxxxxxxx  r  csinc  wx0 : wx5 wx16 cond
+x1011010100xxxxxxxxx00xxxxxxxxxx  r  csinv  wx0 : wx5 wx16 cond
+x1011010100xxxxxxxxx01xxxxxxxxxx  r  csneg  wx0 : wx5 wx16 cond
+00011110xx1xxxxxxxxx11xxxxxxxxxx  r  fcsel  float_reg0 : float_reg5 float_reg16 cond
 
 # Data-processing (3 source)
 
-x0011011000xxxxx0xxxxxxxxxxxxxxx  madd   wx0 : wx5 wx16 wx10
-x0011011000xxxxx1xxxxxxxxxxxxxxx  msub   wx0 : wx5 wx16 wx10
+x0011011000xxxxx0xxxxxxxxxxxxxxx  n  madd   wx0 : wx5 wx16 wx10
+x0011011000xxxxx1xxxxxxxxxxxxxxx  n  msub   wx0 : wx5 wx16 wx10
 
-10011011001xxxxx0xxxxxxxxxxxxxxx  smaddl x0 : w5 w16 x10
-10011011001xxxxx1xxxxxxxxxxxxxxx  smsubl x0 : w5 w16 x10
-10011011010xxxxx0xxxxxxxxxxxxxxx  smulh  x0 : x5 x16 ign10
-10011011101xxxxx0xxxxxxxxxxxxxxx  umaddl x0 : w5 w16 x10
-10011011101xxxxx1xxxxxxxxxxxxxxx  umsubl x0 : w5 w16 x10
-10011011110xxxxx0xxxxxxxxxxxxxxx  umulh  x0 : x5 x16 ign10
+10011011001xxxxx0xxxxxxxxxxxxxxx  n  smaddl x0 : w5 w16 x10
+10011011001xxxxx1xxxxxxxxxxxxxxx  n  smsubl x0 : w5 w16 x10
+10011011010xxxxx0xxxxxxxxxxxxxxx  n  smulh  x0 : x5 x16 ign10
+10011011101xxxxx0xxxxxxxxxxxxxxx  n  umaddl x0 : w5 w16 x10
+10011011101xxxxx1xxxxxxxxxxxxxxx  n  umsubl x0 : w5 w16 x10
+10011011110xxxxx0xxxxxxxxxxxxxxx  n  umulh  x0 : x5 x16 ign10
 
 # Data-processing (2 source)
 
-x0011010110xxxxx000010xxxxxxxxxx  udiv   wx0 : wx5 wx16
-x0011010110xxxxx000011xxxxxxxxxx  sdiv   wx0 : wx5 wx16
-x0011010110xxxxx001000xxxxxxxxxx  lslv   wx0 : wx5 wx16
-x0011010110xxxxx001001xxxxxxxxxx  lsrv   wx0 : wx5 wx16
-x0011010110xxxxx001010xxxxxxxxxx  asrv   wx0 : wx5 wx16
-x0011010110xxxxx001011xxxxxxxxxx  rorv   wx0 : wx5 wx16
+x0011010110xxxxx000010xxxxxxxxxx  n  udiv   wx0 : wx5 wx16
+x0011010110xxxxx000011xxxxxxxxxx  n  sdiv   wx0 : wx5 wx16
+x0011010110xxxxx001000xxxxxxxxxx  n  lslv   wx0 : wx5 wx16
+x0011010110xxxxx001001xxxxxxxxxx  n  lsrv   wx0 : wx5 wx16
+x0011010110xxxxx001010xxxxxxxxxx  n  asrv   wx0 : wx5 wx16
+x0011010110xxxxx001011xxxxxxxxxx  n  rorv   wx0 : wx5 wx16
 
-00011010110xxxxx010000xxxxxxxxxx  crc32b  w0 : w5 w16
-00011010110xxxxx010001xxxxxxxxxx  crc32h  w0 : w5 w16
-00011010110xxxxx010010xxxxxxxxxx  crc32w  w0 : w5 w16
-00011010110xxxxx010100xxxxxxxxxx  crc32cb w0 : w5 w16
-00011010110xxxxx010101xxxxxxxxxx  crc32ch w0 : w5 w16
-00011010110xxxxx010110xxxxxxxxxx  crc32cw w0 : w5 w16
-10011010110xxxxx010011xxxxxxxxxx  crc32x  w0 : w5 x16
-10011010110xxxxx010111xxxxxxxxxx  crc32cx w0 : w5 x16
+00011010110xxxxx010000xxxxxxxxxx  n  crc32b  w0 : w5 w16
+00011010110xxxxx010001xxxxxxxxxx  n  crc32h  w0 : w5 w16
+00011010110xxxxx010010xxxxxxxxxx  n  crc32w  w0 : w5 w16
+00011010110xxxxx010100xxxxxxxxxx  n  crc32cb w0 : w5 w16
+00011010110xxxxx010101xxxxxxxxxx  n  crc32ch w0 : w5 w16
+00011010110xxxxx010110xxxxxxxxxx  n  crc32cw w0 : w5 w16
+10011010110xxxxx010011xxxxxxxxxx  n  crc32x  w0 : w5 x16
+10011010110xxxxx010111xxxxxxxxxx  n  crc32cx w0 : w5 x16
 
 # Data-processing (1 source)
 
-x101101011000000000000xxxxxxxxxx  rbit    wx0 : wx5
-x101101011000000000001xxxxxxxxxx  rev16   wx0 : wx5
-0101101011000000000010xxxxxxxxxx  rev     w0  : w5
-x101101011000000000100xxxxxxxxxx  clz     wx0 : wx5
-0x101110xx100000010010xxxxxxxxxx  clz     dq0 : dq5 bhs_sz
-x101101011000000000101xxxxxxxxxx  cls     wx0 : wx5
-1101101011000000000010xxxxxxxxxx  rev32   x0 : x5
-1101101011000000000011xxxxxxxxxx  rev     x0 : x5
+x101101011000000000000xxxxxxxxxx  n  rbit    wx0 : wx5
+x101101011000000000001xxxxxxxxxx  n  rev16   wx0 : wx5
+0101101011000000000010xxxxxxxxxx  n  rev     w0  : w5
+x101101011000000000100xxxxxxxxxx  n  clz     wx0 : wx5
+0x101110xx100000010010xxxxxxxxxx  n  clz     dq0 : dq5 bhs_sz
+x101101011000000000101xxxxxxxxxx  n  cls     wx0 : wx5
+1101101011000000000010xxxxxxxxxx  n  rev32   x0 : x5
+1101101011000000000011xxxxxxxxxx  n  rev     x0 : x5
 
 # Data Processing - Scalar Floating-Point and Advanced SIMD
 
 
 # FMOV immediate to scalar FP reg
-00011110111xxxxxxxx10000000xxxxx     fmov h0 : fpimm13 # Armv8.2
-00011110001xxxxxxxx10000000xxxxx     fmov s0 : fpimm13
-00011110011xxxxxxxx10000000xxxxx     fmov d0 : fpimm13
+00011110111xxxxxxxx10000000xxxxx  n     fmov h0 : fpimm13 # Armv8.2
+00011110001xxxxxxxx10000000xxxxx  n     fmov s0 : fpimm13
+00011110011xxxxxxxx10000000xxxxx  n     fmov d0 : fpimm13
 
 # FMOV (general) GPR to FP reg
-0001111011100111000000xxxxxxxxxx     fmov h0 : w5 # Armv8.2
-0001111000100111000000xxxxxxxxxx     fmov s0 : w5
-1001111011100111000000xxxxxxxxxx     fmov h0 : x5 # Armv8.2
-1001111001100111000000xxxxxxxxxx     fmov d0 : x5
-1001111010101111000000xxxxxxxxxx     fmov q0 : x5 # only sets the bit top half of q0
+0001111011100111000000xxxxxxxxxx  n     fmov h0 : w5 # Armv8.2
+0001111000100111000000xxxxxxxxxx  n     fmov s0 : w5
+1001111011100111000000xxxxxxxxxx  n     fmov h0 : x5 # Armv8.2
+1001111001100111000000xxxxxxxxxx  n     fmov d0 : x5
+1001111010101111000000xxxxxxxxxx  n     fmov q0 : x5 # only sets the bit top half of q0
 
 # FMOV immediate to vector reg
-0x00111100000xxx111111xxxxxxxxxx     fmov dq0 : fpimm8 h_sz # Armv8.2
+0x00111100000xxx111111xxxxxxxxxx  n     fmov dq0 : fpimm8 h_sz # Armv8.2
 
 # SMOV
-00001110000xxxxx001011xxxxxxxxxx     smov      w0 : d5 imm5
-01001110000xxxxx001011xxxxxxxxxx     smov      x0 : q5 imm5
+00001110000xxxxx001011xxxxxxxxxx  n     smov      w0 : d5 imm5
+01001110000xxxxx001011xxxxxxxxxx  n     smov      x0 : q5 imm5
 
 # UMOV
-0x001110000xxxxx001111xxxxxxxxxx     umov      wx0_imm5_q : q5 imm5
+0x001110000xxxxx001111xxxxxxxxxx  n     umov      wx0_imm5_q : q5 imm5
 
 # INS (element)
-01101110000xxxxx0xxxx1xxxxxxxxxx     ins       q0 imm5 : q5 imm4idx
+01101110000xxxxx0xxxx1xxxxxxxxxx  n     ins       q0 imm5 : q5 imm4idx
 
 # INS (general)
-01001110000xxxxx000111xxxxxxxxxx     ins       q0 imm5 : wx5_imm5
+01001110000xxxxx000111xxxxxxxxxx  n     ins       q0 imm5 : wx5_imm5
 
 # Advanced SIMD three same (FP16)
-0x001110010xxxxx000001xxxxxxxxxx     fmaxnm    dq0 : dq5 dq16 h_sz
-0x001110010xxxxx000011xxxxxxxxxx     fmla      dq0 : dq0 dq5 dq16 h_sz
-0x001110010xxxxx000101xxxxxxxxxx     fadd      dq0 : dq5 dq16 h_sz
-0x001110010xxxxx000111xxxxxxxxxx     fmulx     dq0 : dq5 dq16 h_sz
-0x001110010xxxxx001001xxxxxxxxxx     fcmeq     dq0 : dq5 dq16 h_sz
-0x001110010xxxxx001101xxxxxxxxxx     fmax      dq0 : dq5 dq16 h_sz
-0x001110010xxxxx001111xxxxxxxxxx     frecps    dq0 : dq5 dq16 h_sz
-0x001110110xxxxx000001xxxxxxxxxx     fminnm    dq0 : dq5 dq16 h_sz
-0x001110110xxxxx000011xxxxxxxxxx     fmls      dq0 : dq0 dq5 dq16 h_sz
-0x001110110xxxxx000101xxxxxxxxxx     fsub      dq0 : dq5 dq16 h_sz
-0x001110110xxxxx001101xxxxxxxxxx     fmin      dq0 : dq5 dq16 h_sz
-0x001110110xxxxx001111xxxxxxxxxx     frsqrts   dq0 : dq5 dq16 h_sz
-0x101110010xxxxx000001xxxxxxxxxx     fmaxnmp   dq0 : dq5 dq16 h_sz
-0x101110010xxxxx000101xxxxxxxxxx     faddp     dq0 : dq5 dq16 h_sz
-0x101110010xxxxx000111xxxxxxxxxx     fmul      dq0 : dq5 dq16 h_sz
-0x101110010xxxxx001001xxxxxxxxxx     fcmge     dq0 : dq5 dq16 h_sz
-0x101110010xxxxx001011xxxxxxxxxx     facge     dq0 : dq5 dq16 h_sz
-0x101110010xxxxx001101xxxxxxxxxx     fmaxp     dq0 : dq5 dq16 h_sz
-0x101110010xxxxx001111xxxxxxxxxx     fdiv      dq0 : dq5 dq16 h_sz
-0x101110110xxxxx000001xxxxxxxxxx     fminnmp   dq0 : dq5 dq16 h_sz
-0x101110110xxxxx000101xxxxxxxxxx     fabd      dq0 : dq5 dq16 h_sz
-0x101110110xxxxx001001xxxxxxxxxx     fcmgt     dq0 : dq5 dq16 h_sz
-0x101110110xxxxx001011xxxxxxxxxx     facgt     dq0 : dq5 dq16 h_sz
-0x101110110xxxxx001101xxxxxxxxxx     fminp     dq0 : dq5 dq16 h_sz
+0x001110010xxxxx000001xxxxxxxxxx  n     fmaxnm    dq0 : dq5 dq16 h_sz
+0x001110010xxxxx000011xxxxxxxxxx  n     fmla      dq0 : dq0 dq5 dq16 h_sz
+0x001110010xxxxx000101xxxxxxxxxx  n     fadd      dq0 : dq5 dq16 h_sz
+0x001110010xxxxx000111xxxxxxxxxx  n     fmulx     dq0 : dq5 dq16 h_sz
+0x001110010xxxxx001001xxxxxxxxxx  n     fcmeq     dq0 : dq5 dq16 h_sz
+0x001110010xxxxx001101xxxxxxxxxx  n     fmax      dq0 : dq5 dq16 h_sz
+0x001110010xxxxx001111xxxxxxxxxx  n     frecps    dq0 : dq5 dq16 h_sz
+0x001110110xxxxx000001xxxxxxxxxx  n     fminnm    dq0 : dq5 dq16 h_sz
+0x001110110xxxxx000011xxxxxxxxxx  n     fmls      dq0 : dq0 dq5 dq16 h_sz
+0x001110110xxxxx000101xxxxxxxxxx  n     fsub      dq0 : dq5 dq16 h_sz
+0x001110110xxxxx001101xxxxxxxxxx  n     fmin      dq0 : dq5 dq16 h_sz
+0x001110110xxxxx001111xxxxxxxxxx  n     frsqrts   dq0 : dq5 dq16 h_sz
+0x101110010xxxxx000001xxxxxxxxxx  n     fmaxnmp   dq0 : dq5 dq16 h_sz
+0x101110010xxxxx000101xxxxxxxxxx  n     faddp     dq0 : dq5 dq16 h_sz
+0x101110010xxxxx000111xxxxxxxxxx  n     fmul      dq0 : dq5 dq16 h_sz
+0x101110010xxxxx001001xxxxxxxxxx  n     fcmge     dq0 : dq5 dq16 h_sz
+0x101110010xxxxx001011xxxxxxxxxx  n     facge     dq0 : dq5 dq16 h_sz
+0x101110010xxxxx001101xxxxxxxxxx  n     fmaxp     dq0 : dq5 dq16 h_sz
+0x101110010xxxxx001111xxxxxxxxxx  n     fdiv      dq0 : dq5 dq16 h_sz
+0x101110110xxxxx000001xxxxxxxxxx  n     fminnmp   dq0 : dq5 dq16 h_sz
+0x101110110xxxxx000101xxxxxxxxxx  n     fabd      dq0 : dq5 dq16 h_sz
+0x101110110xxxxx001001xxxxxxxxxx  n     fcmgt     dq0 : dq5 dq16 h_sz
+0x101110110xxxxx001011xxxxxxxxxx  n     facgt     dq0 : dq5 dq16 h_sz
+0x101110110xxxxx001101xxxxxxxxxx  n     fminp     dq0 : dq5 dq16 h_sz
 # Advanced SIMD three same
-0x001110xx1xxxxx000001xxxxxxxxxx     shadd     dq0 : dq5 dq16 bhs_sz
-0x001110xx1xxxxx000011xxxxxxxxxx     sqadd     dq0 : dq5 dq16 bhsd_sz
-0x001110xx1xxxxx000101xxxxxxxxxx     srhadd    dq0 : dq5 dq16 bhs_sz
-0x001110xx1xxxxx001001xxxxxxxxxx     shsub     dq0 : dq5 dq16 bhs_sz
-0x001110xx1xxxxx001011xxxxxxxxxx     sqsub     dq0 : dq5 dq16 bhsd_sz
-0x001110xx1xxxxx001101xxxxxxxxxx     cmgt      dq0 : dq5 dq16 bhsd_sz
-0x001110xx100000100010xxxxxxxxxx     cmgt      dq0 : dq5 bhsd_sz
-0101111011100000100010xxxxxxxxxx     cmgt       d0 : d5
-0x001110xx1xxxxx001111xxxxxxxxxx     cmge      dq0 : dq5 dq16 bhsd_sz
-0x101110xx100000100010xxxxxxxxxx     cmge      dq0 : dq5 bhsd_sz
-0111111011100000100010xxxxxxxxxx     cmge       d0 : d5
-0x001110xx100000101010xxxxxxxxxx     cmlt      dq0 : dq5 bhsd_sz
-0101111011100000101010xxxxxxxxxx     cmlt       d0 : d5
-0x001110xx1xxxxx010001xxxxxxxxxx     sshl      dq0 : dq5 dq16 bhsd_sz
-0x001110xx1xxxxx010011xxxxxxxxxx     sqshl     dq0 : dq5 dq16 bhsd_sz
-01011110001xxxxx010011xxxxxxxxxx     sqshl      b0 : b5 b16
-01011110011xxxxx010011xxxxxxxxxx     sqshl      h0 : h5 h16
-01011110101xxxxx010011xxxxxxxxxx     sqshl      s0 : s5 s16
-01011110111xxxxx010011xxxxxxxxxx     sqshl      d0 : d5 d16
-0101111100xxxxxx011101xxxxxxxxxx     sqshl      s0 : s5 immhb
-0101111101xxxxxx011101xxxxxxxxxx     sqshl      d0 : d5 immhb
-0x001110xx1xxxxx010101xxxxxxxxxx     srshl     dq0 : dq5 dq16 bhsd_sz
-0x001110xx1xxxxx010111xxxxxxxxxx     sqrshl    dq0 : dq5 dq16 bhsd_sz
-0x001110xx1xxxxx011001xxxxxxxxxx     smax      dq0 : dq5 dq16 bhs_sz
-0x001110xx1xxxxx011011xxxxxxxxxx     smin      dq0 : dq5 dq16 bhs_sz
-0x001110xx1xxxxx011101xxxxxxxxxx     sabd      dq0 : dq5 dq16 bhs_sz
-0x001110xx1xxxxx011111xxxxxxxxxx     saba      dq0 : dq5 dq16 bhs_sz
-0x001110xx1xxxxx100001xxxxxxxxxx     add       dq0 : dq5 dq16 bhsd_sz
-0x001110xx1xxxxx100011xxxxxxxxxx     cmtst     dq0 : dq5 dq16 bhsd_sz
-0x001110xx1xxxxx100101xxxxxxxxxx     mla       dq0 : dq0 dq5 dq16 bhs_sz
-0x101111xxxxxxxx0000x0xxxxxxxxxx     mla       dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
-0x001110xx1xxxxx100111xxxxxxxxxx     mul       dq0 : dq5 dq16 bhs_sz
-0x001111xxxxxxxx1000x0xxxxxxxxxx     mul       dq0 : dq5 dq16_h_sz vindex_H hs_sz
-0x001110xx1xxxxx101001xxxxxxxxxx     smaxp     dq0 : dq5 dq16 bhs_sz
-0x001110xx1xxxxx101011xxxxxxxxxx     sminp     dq0 : dq5 dq16 bhs_sz
-0x001110xx1xxxxx101101xxxxxxxxxx     sqdmulh   dq0 : dq5 dq16 hs_sz
-01011110011xxxxx101101xxxxxxxxxx     sqdmulh    h0 : h5 h16
-01011110101xxxxx101101xxxxxxxxxx     sqdmulh    s0 : s5 s16
-0x001111xxxxxxxx1100x0xxxxxxxxxx     sqdmulh   dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
-0101111101xxxxxx1100x0xxxxxxxxxx     sqdmulh    h0 : h5 dq16_idx_lhm idx_lhm
-0101111110xxxxxx1100x0xxxxxxxxxx     sqdmulh    s0 : s5 dq16_idx_lhm idx_lhm
-0x101111xxxxxxxx1101x0xxxxxxxxxx     sqrdmlah  dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
-0111111101xxxxxx1101x0xxxxxxxxxx     sqrdmlah   h0 : h5 dq16_idx_lhm idx_lhm
-0111111110xxxxxx1101x0xxxxxxxxxx     sqrdmlah   s0 : s5 dq16_idx_lhm idx_lhm
-0x101110xx0xxxxx100001xxxxxxxxxx     sqrdmlah  dq0 : dq5 dq16 hs_sz
-01111110010xxxxx100001xxxxxxxxxx     sqrdmlah   h0 : h5 h16
-01111110100xxxxx100001xxxxxxxxxx     sqrdmlah   s0 : s5 s16
-0101111000100001010010xxxxxxxxxx     sqxtn      b0 : h5
-0101111001100001010010xxxxxxxxxx     sqxtn      h0 : s5
-0101111010100001010010xxxxxxxxxx     sqxtn      s0 : d5
-00001110xx100001010010xxxxxxxxxx     sqxtn      d0 : d5 bhs_sz
-01001110xx100001010010xxxxxxxxxx     sqxtn2     q0 : q5 bhs_sz
-0111111000100001001010xxxxxxxxxx     sqxtun     b0 : h5
-0111111001100001001010xxxxxxxxxx     sqxtun     h0 : s5
-0111111010100001001010xxxxxxxxxx     sqxtun     s0 : d5
-00101110xx100001001010xxxxxxxxxx     sqxtun     d0 : d5 bhs_sz
-01101110xx100001001010xxxxxxxxxx     sqxtun2    q0 : q5 bhs_sz
-0111111000100001010010xxxxxxxxxx     uqxtn      b0 : h5
-0111111001100001010010xxxxxxxxxx     uqxtn      h0 : s5
-0111111010100001010010xxxxxxxxxx     uqxtn      s0 : d5
-00101110xx100001010010xxxxxxxxxx     uqxtn      d0 : d5 bhs_sz
-01101110xx100001010010xxxxxxxxxx     uqxtn2     q0 : q5 bhs_sz
-0x001110xx1xxxxx101111xxxxxxxxxx     addp      dq0 : dq5 dq16 bhsd_sz
-0x0011100x1xxxxx110001xxxxxxxxxx     fmaxnm    dq0 : dq5 dq16 sd_sz
-0x0011100x1xxxxx110011xxxxxxxxxx     fmla      dq0 : dq0 dq5 dq16 sd_sz
-0x0011111xxxxxxx0001x0xxxxxxxxxx     fmla      dq0 : dq0 dq5 dq16 vindex_SD sd_sz
-0x0011100x1xxxxx110101xxxxxxxxxx     fadd      dq0 : dq5 dq16 sd_sz
-0x0011100x1xxxxx110111xxxxxxxxxx     fmulx     dq0 : dq5 dq16 sd_sz
-0x0011100x1xxxxx111001xxxxxxxxxx     fcmeq     dq0 : dq5 dq16 sd_sz
-0x001110001xxxxx111011xxxxxxxxxx     fmlal     dq0 : dq0 dq5 dq16
-0x0011100x1xxxxx111101xxxxxxxxxx     fmax      dq0 : dq5 dq16 sd_sz
-0x0011100x1xxxxx111111xxxxxxxxxx     frecps    dq0 : dq5 dq16 sd_sz
-0x001110001xxxxx000111xxxxxxxxxx     and       dq0 : dq5 dq16
-0x001110011xxxxx000111xxxxxxxxxx     bic       dq0 : dq5 dq16
-0x0011101x1xxxxx110001xxxxxxxxxx     fminnm    dq0 : dq5 dq16 sd_sz
-0x0011101x1xxxxx110011xxxxxxxxxx     fmls      dq0 : dq0 dq5 dq16 sd_sz
-0x0011101x1xxxxx110101xxxxxxxxxx     fsub      dq0 : dq5 dq16 sd_sz
-0x001110101xxxxx111011xxxxxxxxxx     fmlsl     dq0 : dq0 dq5 dq16
-0x0011101x1xxxxx111101xxxxxxxxxx     fmin      dq0 : dq5 dq16 sd_sz
-0x0011101x1xxxxx111111xxxxxxxxxx     frsqrts   dq0 : dq5 dq16 sd_sz
-0x001110101xxxxx000111xxxxxxxxxx     orr       dq0 : dq5 dq16
-0x00111100000xxxxxx101xxxxxxxxxx     orr       dq0 : imm8 cmode3
-0x001110111xxxxx000111xxxxxxxxxx     orn       dq0 : dq5 dq16
-0x101110xx1xxxxx000001xxxxxxxxxx     uhadd     dq0 : dq5 dq16 bhs_sz
-0x101110xx1xxxxx000011xxxxxxxxxx     uqadd     dq0 : dq5 dq16 bhsd_sz
-0x101110xx1xxxxx000101xxxxxxxxxx     urhadd    dq0 : dq5 dq16 bhs_sz
-0x101110xx1xxxxx001001xxxxxxxxxx     uhsub     dq0 : dq5 dq16 bhs_sz
-0x101110xx1xxxxx001011xxxxxxxxxx     uqsub     dq0 : dq5 dq16 bhsd_sz
-0x101110xx1xxxxx001101xxxxxxxxxx     cmhi      dq0 : dq5 dq16 bhsd_sz
-0x101110xx1xxxxx001111xxxxxxxxxx     cmhs      dq0 : dq5 dq16 bhsd_sz
-0x101110xx1xxxxx010001xxxxxxxxxx     ushl      dq0 : dq5 dq16 bhsd_sz
-0x101110xx1xxxxx010011xxxxxxxxxx     uqshl     dq0 : dq5 dq16 bhsd_sz
-0x101110xx1xxxxx010101xxxxxxxxxx     urshl     dq0 : dq5 dq16 bhsd_sz
-0x101110xx1xxxxx010111xxxxxxxxxx     uqrshl    dq0 : dq5 dq16 bhsd_sz
-0x101110xx1xxxxx011001xxxxxxxxxx     umax      dq0 : dq5 dq16 bhs_sz
-0x101110xx1xxxxx011011xxxxxxxxxx     umin      dq0 : dq5 dq16 bhs_sz
-0x101110xx1xxxxx011101xxxxxxxxxx     uabd      dq0 : dq5 dq16 bhs_sz
-0x101110xx1xxxxx011111xxxxxxxxxx     uaba      dq0 : dq5 dq16 bhs_sz
-0x101110xx1xxxxx100001xxxxxxxxxx     sub       dq0 : dq5 dq16 bhsd_sz
-0x101110xx1xxxxx100011xxxxxxxxxx     cmeq      dq0 : dq5 dq16 bhsd_sz
-0x001110xx100000100110xxxxxxxxxx     cmeq      dq0 : dq5 bhsd_sz
-0101111011100000100110xxxxxxxxxx     cmeq       d0 : d5
+0x001110xx1xxxxx000001xxxxxxxxxx  n     shadd     dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx000011xxxxxxxxxx  n     sqadd     dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx000101xxxxxxxxxx  n     srhadd    dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx001001xxxxxxxxxx  n     shsub     dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx001011xxxxxxxxxx  n     sqsub     dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx001101xxxxxxxxxx  n     cmgt      dq0 : dq5 dq16 bhsd_sz
+0x001110xx100000100010xxxxxxxxxx  n     cmgt      dq0 : dq5 bhsd_sz
+0101111011100000100010xxxxxxxxxx  n     cmgt       d0 : d5
+0x001110xx1xxxxx001111xxxxxxxxxx  n     cmge      dq0 : dq5 dq16 bhsd_sz
+0x101110xx100000100010xxxxxxxxxx  n     cmge      dq0 : dq5 bhsd_sz
+0111111011100000100010xxxxxxxxxx  n     cmge       d0 : d5
+0x001110xx100000101010xxxxxxxxxx  n     cmlt      dq0 : dq5 bhsd_sz
+0101111011100000101010xxxxxxxxxx  n     cmlt       d0 : d5
+0x001110xx1xxxxx010001xxxxxxxxxx  n     sshl      dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx010011xxxxxxxxxx  n     sqshl     dq0 : dq5 dq16 bhsd_sz
+01011110001xxxxx010011xxxxxxxxxx  n     sqshl      b0 : b5 b16
+01011110011xxxxx010011xxxxxxxxxx  n     sqshl      h0 : h5 h16
+01011110101xxxxx010011xxxxxxxxxx  n     sqshl      s0 : s5 s16
+01011110111xxxxx010011xxxxxxxxxx  n     sqshl      d0 : d5 d16
+0101111100xxxxxx011101xxxxxxxxxx  n     sqshl      s0 : s5 immhb
+0101111101xxxxxx011101xxxxxxxxxx  n     sqshl      d0 : d5 immhb
+0x001110xx1xxxxx010101xxxxxxxxxx  n     srshl     dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx010111xxxxxxxxxx  n     sqrshl    dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx011001xxxxxxxxxx  n     smax      dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx011011xxxxxxxxxx  n     smin      dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx011101xxxxxxxxxx  n     sabd      dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx011111xxxxxxxxxx  n     saba      dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx100001xxxxxxxxxx  n     add       dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx100011xxxxxxxxxx  n     cmtst     dq0 : dq5 dq16 bhsd_sz
+0x001110xx1xxxxx100101xxxxxxxxxx  n     mla       dq0 : dq0 dq5 dq16 bhs_sz
+0x101111xxxxxxxx0000x0xxxxxxxxxx  n     mla       dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
+0x001110xx1xxxxx100111xxxxxxxxxx  n     mul       dq0 : dq5 dq16 bhs_sz
+0x001111xxxxxxxx1000x0xxxxxxxxxx  n     mul       dq0 : dq5 dq16_h_sz vindex_H hs_sz
+0x001110xx1xxxxx101001xxxxxxxxxx  n     smaxp     dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx101011xxxxxxxxxx  n     sminp     dq0 : dq5 dq16 bhs_sz
+0x001110xx1xxxxx101101xxxxxxxxxx  n     sqdmulh   dq0 : dq5 dq16 hs_sz
+01011110011xxxxx101101xxxxxxxxxx  n     sqdmulh    h0 : h5 h16
+01011110101xxxxx101101xxxxxxxxxx  n     sqdmulh    s0 : s5 s16
+0x001111xxxxxxxx1100x0xxxxxxxxxx  n     sqdmulh   dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
+0101111101xxxxxx1100x0xxxxxxxxxx  n     sqdmulh    h0 : h5 dq16_idx_lhm idx_lhm
+0101111110xxxxxx1100x0xxxxxxxxxx  n     sqdmulh    s0 : s5 dq16_idx_lhm idx_lhm
+0x101111xxxxxxxx1101x0xxxxxxxxxx  n     sqrdmlah  dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
+0111111101xxxxxx1101x0xxxxxxxxxx  n     sqrdmlah   h0 : h5 dq16_idx_lhm idx_lhm
+0111111110xxxxxx1101x0xxxxxxxxxx  n     sqrdmlah   s0 : s5 dq16_idx_lhm idx_lhm
+0x101110xx0xxxxx100001xxxxxxxxxx  n     sqrdmlah  dq0 : dq5 dq16 hs_sz
+01111110010xxxxx100001xxxxxxxxxx  n     sqrdmlah   h0 : h5 h16
+01111110100xxxxx100001xxxxxxxxxx  n     sqrdmlah   s0 : s5 s16
+0101111000100001010010xxxxxxxxxx  n     sqxtn      b0 : h5
+0101111001100001010010xxxxxxxxxx  n     sqxtn      h0 : s5
+0101111010100001010010xxxxxxxxxx  n     sqxtn      s0 : d5
+00001110xx100001010010xxxxxxxxxx  n     sqxtn      d0 : d5 bhs_sz
+01001110xx100001010010xxxxxxxxxx  n     sqxtn2     q0 : q5 bhs_sz
+0111111000100001001010xxxxxxxxxx  n     sqxtun     b0 : h5
+0111111001100001001010xxxxxxxxxx  n     sqxtun     h0 : s5
+0111111010100001001010xxxxxxxxxx  n     sqxtun     s0 : d5
+00101110xx100001001010xxxxxxxxxx  n     sqxtun     d0 : d5 bhs_sz
+01101110xx100001001010xxxxxxxxxx  n     sqxtun2    q0 : q5 bhs_sz
+0111111000100001010010xxxxxxxxxx  n     uqxtn      b0 : h5
+0111111001100001010010xxxxxxxxxx  n     uqxtn      h0 : s5
+0111111010100001010010xxxxxxxxxx  n     uqxtn      s0 : d5
+00101110xx100001010010xxxxxxxxxx  n     uqxtn      d0 : d5 bhs_sz
+01101110xx100001010010xxxxxxxxxx  n     uqxtn2     q0 : q5 bhs_sz
+0x001110xx1xxxxx101111xxxxxxxxxx  n     addp      dq0 : dq5 dq16 bhsd_sz
+0x0011100x1xxxxx110001xxxxxxxxxx  n     fmaxnm    dq0 : dq5 dq16 sd_sz
+0x0011100x1xxxxx110011xxxxxxxxxx  n     fmla      dq0 : dq0 dq5 dq16 sd_sz
+0x0011111xxxxxxx0001x0xxxxxxxxxx  n     fmla      dq0 : dq0 dq5 dq16 vindex_SD sd_sz
+0x0011100x1xxxxx110101xxxxxxxxxx  n     fadd      dq0 : dq5 dq16 sd_sz
+0x0011100x1xxxxx110111xxxxxxxxxx  n     fmulx     dq0 : dq5 dq16 sd_sz
+0x0011100x1xxxxx111001xxxxxxxxxx  n     fcmeq     dq0 : dq5 dq16 sd_sz
+0x001110001xxxxx111011xxxxxxxxxx  n     fmlal     dq0 : dq0 dq5 dq16
+0x0011100x1xxxxx111101xxxxxxxxxx  n     fmax      dq0 : dq5 dq16 sd_sz
+0x0011100x1xxxxx111111xxxxxxxxxx  n     frecps    dq0 : dq5 dq16 sd_sz
+0x001110001xxxxx000111xxxxxxxxxx  n     and       dq0 : dq5 dq16
+0x001110011xxxxx000111xxxxxxxxxx  n     bic       dq0 : dq5 dq16
+0x0011101x1xxxxx110001xxxxxxxxxx  n     fminnm    dq0 : dq5 dq16 sd_sz
+0x0011101x1xxxxx110011xxxxxxxxxx  n     fmls      dq0 : dq0 dq5 dq16 sd_sz
+0x0011101x1xxxxx110101xxxxxxxxxx  n     fsub      dq0 : dq5 dq16 sd_sz
+0x001110101xxxxx111011xxxxxxxxxx  n     fmlsl     dq0 : dq0 dq5 dq16
+0x0011101x1xxxxx111101xxxxxxxxxx  n     fmin      dq0 : dq5 dq16 sd_sz
+0x0011101x1xxxxx111111xxxxxxxxxx  n     frsqrts   dq0 : dq5 dq16 sd_sz
+0x001110101xxxxx000111xxxxxxxxxx  n     orr       dq0 : dq5 dq16
+0x00111100000xxxxxx101xxxxxxxxxx  n     orr       dq0 : imm8 cmode3
+0x001110111xxxxx000111xxxxxxxxxx  n     orn       dq0 : dq5 dq16
+0x101110xx1xxxxx000001xxxxxxxxxx  n     uhadd     dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx000011xxxxxxxxxx  n     uqadd     dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx000101xxxxxxxxxx  n     urhadd    dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx001001xxxxxxxxxx  n     uhsub     dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx001011xxxxxxxxxx  n     uqsub     dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx001101xxxxxxxxxx  n     cmhi      dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx001111xxxxxxxxxx  n     cmhs      dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx010001xxxxxxxxxx  n     ushl      dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx010011xxxxxxxxxx  n     uqshl     dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx010101xxxxxxxxxx  n     urshl     dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx010111xxxxxxxxxx  n     uqrshl    dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx011001xxxxxxxxxx  n     umax      dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx011011xxxxxxxxxx  n     umin      dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx011101xxxxxxxxxx  n     uabd      dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx011111xxxxxxxxxx  n     uaba      dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx100001xxxxxxxxxx  n     sub       dq0 : dq5 dq16 bhsd_sz
+0x101110xx1xxxxx100011xxxxxxxxxx  n     cmeq      dq0 : dq5 dq16 bhsd_sz
+0x001110xx100000100110xxxxxxxxxx  n     cmeq      dq0 : dq5 bhsd_sz
+0101111011100000100110xxxxxxxxxx  n     cmeq       d0 : d5
 
-0x101110xx1xxxxx100101xxxxxxxxxx     mls       dq0 : dq0 dq5 dq16 bhs_sz
-0x101111xxxxxxxx0100x0xxxxxxxxxx     mls       dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
-0x101110xx1xxxxx100111xxxxxxxxxx     pmul      dq0 : dq5 dq16 b_sz
-0x101110xx1xxxxx101001xxxxxxxxxx     umaxp     dq0 : dq5 dq16 bhs_sz
-0x101110xx1xxxxx101011xxxxxxxxxx     uminp     dq0 : dq5 dq16 bhs_sz
-01111110011xxxxx101101xxxxxxxxxx     sqrdmulh  h0 : h5 h16
-01111110101xxxxx101101xxxxxxxxxx     sqrdmulh  s0 : s5 s16
-0x101110xx1xxxxx101101xxxxxxxxxx     sqrdmulh  dq0 : dq5 dq16 hs_sz
-0x001111xxxxxxxx1101x0xxxxxxxxxx     sqrdmulh  dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
-0101111101xxxxxx1101x0xxxxxxxxxx     sqrdmulh  h0 : h5 dq16_idx_lhm idx_lhm
-0101111110xxxxxx1101x0xxxxxxxxxx     sqrdmulh  s0 : s5 dq16_idx_lhm idx_lhm
-0x1011100x1xxxxx110001xxxxxxxxxx     fmaxnmp   dq0 : dq5 dq16 sd_sz
-0x101110001xxxxx110011xxxxxxxxxx     fmlal2    dq0 : dq0 dq5 dq16
-0x1011100x1xxxxx110101xxxxxxxxxx     faddp     dq0 : dq5 dq16 sd_sz
-0x1011100x1xxxxx110111xxxxxxxxxx     fmul      dq0 : dq5 dq16 sd_sz
-0x1011100x1xxxxx111001xxxxxxxxxx     fcmge     dq0 : dq5 dq16 sd_sz
-0x1011100x1xxxxx111011xxxxxxxxxx     facge     dq0 : dq5 dq16 sd_sz
-0x1011100x1xxxxx111101xxxxxxxxxx     fmaxp     dq0 : dq5 dq16 sd_sz
-0x1011100x1xxxxx111111xxxxxxxxxx     fdiv      dq0 : dq5 dq16 sd_sz
-0x101110001xxxxx000111xxxxxxxxxx     eor       dq0 : dq5 dq16
-0x101110011xxxxx000111xxxxxxxxxx     bsl       dq0 : dq5 dq16
-0x1011101x1xxxxx110001xxxxxxxxxx     fminnmp   dq0 : dq5 dq16 sd_sz
-0x101110101xxxxx110011xxxxxxxxxx     fmlsl2    dq0 : dq0 dq5 dq16
-0x1011101x1xxxxx110101xxxxxxxxxx     fabd      dq0 : dq5 dq16 sd_sz
-0x1011101x1xxxxx111001xxxxxxxxxx     fcmgt     dq0 : dq5 dq16 sd_sz
-0x1011101x1xxxxx111011xxxxxxxxxx     facgt     dq0 : dq5 dq16 sd_sz
-0x1011101x1xxxxx111101xxxxxxxxxx     fminp     dq0 : dq5 dq16 sd_sz
-0x101110101xxxxx000111xxxxxxxxxx     bit       dq0 : dq5 dq16
-0x101110111xxxxx000111xxxxxxxxxx     bif       dq0 : dq5 dq16
+0x101110xx1xxxxx100101xxxxxxxxxx  n     mls       dq0 : dq0 dq5 dq16 bhs_sz
+0x101111xxxxxxxx0100x0xxxxxxxxxx  n     mls       dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
+0x101110xx1xxxxx100111xxxxxxxxxx  n     pmul      dq0 : dq5 dq16 b_sz
+0x101110xx1xxxxx101001xxxxxxxxxx  n     umaxp     dq0 : dq5 dq16 bhs_sz
+0x101110xx1xxxxx101011xxxxxxxxxx  n     uminp     dq0 : dq5 dq16 bhs_sz
+01111110011xxxxx101101xxxxxxxxxx  n     sqrdmulh  h0 : h5 h16
+01111110101xxxxx101101xxxxxxxxxx  n     sqrdmulh  s0 : s5 s16
+0x101110xx1xxxxx101101xxxxxxxxxx  n     sqrdmulh  dq0 : dq5 dq16 hs_sz
+0x001111xxxxxxxx1101x0xxxxxxxxxx  n     sqrdmulh  dq0 : dq5 dq16_idx_lhm bhsd_sz idx_lhm
+0101111101xxxxxx1101x0xxxxxxxxxx  n     sqrdmulh  h0 : h5 dq16_idx_lhm idx_lhm
+0101111110xxxxxx1101x0xxxxxxxxxx  n     sqrdmulh  s0 : s5 dq16_idx_lhm idx_lhm
+0x1011100x1xxxxx110001xxxxxxxxxx  n     fmaxnmp   dq0 : dq5 dq16 sd_sz
+0x101110001xxxxx110011xxxxxxxxxx  n     fmlal2    dq0 : dq0 dq5 dq16
+0x1011100x1xxxxx110101xxxxxxxxxx  n     faddp     dq0 : dq5 dq16 sd_sz
+0x1011100x1xxxxx110111xxxxxxxxxx  n     fmul      dq0 : dq5 dq16 sd_sz
+0x1011100x1xxxxx111001xxxxxxxxxx  n     fcmge     dq0 : dq5 dq16 sd_sz
+0x1011100x1xxxxx111011xxxxxxxxxx  n     facge     dq0 : dq5 dq16 sd_sz
+0x1011100x1xxxxx111101xxxxxxxxxx  n     fmaxp     dq0 : dq5 dq16 sd_sz
+0x1011100x1xxxxx111111xxxxxxxxxx  n     fdiv      dq0 : dq5 dq16 sd_sz
+0x101110001xxxxx000111xxxxxxxxxx  n     eor       dq0 : dq5 dq16
+0x101110011xxxxx000111xxxxxxxxxx  n     bsl       dq0 : dq5 dq16
+0x1011101x1xxxxx110001xxxxxxxxxx  n     fminnmp   dq0 : dq5 dq16 sd_sz
+0x101110101xxxxx110011xxxxxxxxxx  n     fmlsl2    dq0 : dq0 dq5 dq16
+0x1011101x1xxxxx110101xxxxxxxxxx  n     fabd      dq0 : dq5 dq16 sd_sz
+0x1011101x1xxxxx111001xxxxxxxxxx  n     fcmgt     dq0 : dq5 dq16 sd_sz
+0x1011101x1xxxxx111011xxxxxxxxxx  n     facgt     dq0 : dq5 dq16 sd_sz
+0x1011101x1xxxxx111101xxxxxxxxxx  n     fminp     dq0 : dq5 dq16 sd_sz
+0x101110101xxxxx000111xxxxxxxxxx  n     bit       dq0 : dq5 dq16
+0x101110111xxxxx000111xxxxxxxxxx  n     bif       dq0 : dq5 dq16
 
 # Floating-point data-processing (1 source)
-00011110xx100000010000xxxxxxxxxx     fmov      float_reg0 : float_reg5
-00011110xx100000110000xxxxxxxxxx     fabs      float_reg0 : float_reg5
-00011110xx100001010000xxxxxxxxxx     fneg      float_reg0 : float_reg5
-00011110xx100001110000xxxxxxxxxx     fsqrt     float_reg0 : float_reg5
-0001111000100010110000xxxxxxxxxx     fcvt      d0 : s5
-0001111000100011110000xxxxxxxxxx     fcvt      h0 : s5
-00011110xx100100010000xxxxxxxxxx     frintn    float_reg0 : float_reg5
-00011110xx100100110000xxxxxxxxxx     frintp    float_reg0 : float_reg5
-00011110xx100101010000xxxxxxxxxx     frintm    float_reg0 : float_reg5
-00011110xx100101110000xxxxxxxxxx     frintz    float_reg0 : float_reg5
-00011110xx100110010000xxxxxxxxxx     frinta    float_reg0 : float_reg5
-00011110xx100111010000xxxxxxxxxx     frintx    float_reg0 : float_reg5
-00011110xx100111110000xxxxxxxxxx     frinti    float_reg0 : float_reg5
-0001111001100010010000xxxxxxxxxx     fcvt      s0 : d5
-0001111001100011110000xxxxxxxxxx     fcvt      h0 : d5
-0001111011100010010000xxxxxxxxxx     fcvt      s0 : h5
-0001111011100010110000xxxxxxxxxx     fcvt      d0 : h5
-00011110xx1xxxxx001000xxxxx00000     fcmp      float_reg5 : float_reg16
-00011110xx100000001000xxxxx01000     fcmp      float_reg5 : bhsd_sz
-00011110xx1xxxxxxxxx01xxxxx0xxxx     fccmp     float_reg5 : float_reg16 cond nzcv
-00011110xx1xxxxxxxxx01xxxxx1xxxx     fccmpe    float_reg5 : float_reg16 cond nzcv
-0x10111000110000111110xxxxxxxxxx     fmaxv     s0 : dq5
-0x00111000110000111110xxxxxxxxxx     fmaxv     h0 : dq5
-0x10111010110000111110xxxxxxxxxx     fminv     s0 : dq5
-0x00111010110000111110xxxxxxxxxx     fminv     h0 : dq5
+00011110xx100000010000xxxxxxxxxx  n     fmov      float_reg0 : float_reg5
+00011110xx100000110000xxxxxxxxxx  n     fabs      float_reg0 : float_reg5
+00011110xx100001010000xxxxxxxxxx  n     fneg      float_reg0 : float_reg5
+00011110xx100001110000xxxxxxxxxx  n     fsqrt     float_reg0 : float_reg5
+0001111000100010110000xxxxxxxxxx  n     fcvt      d0 : s5
+0001111000100011110000xxxxxxxxxx  n     fcvt      h0 : s5
+00011110xx100100010000xxxxxxxxxx  n     frintn    float_reg0 : float_reg5
+00011110xx100100110000xxxxxxxxxx  n     frintp    float_reg0 : float_reg5
+00011110xx100101010000xxxxxxxxxx  n     frintm    float_reg0 : float_reg5
+00011110xx100101110000xxxxxxxxxx  n     frintz    float_reg0 : float_reg5
+00011110xx100110010000xxxxxxxxxx  n     frinta    float_reg0 : float_reg5
+00011110xx100111010000xxxxxxxxxx  n     frintx    float_reg0 : float_reg5
+00011110xx100111110000xxxxxxxxxx  n     frinti    float_reg0 : float_reg5
+0001111001100010010000xxxxxxxxxx  n     fcvt      s0 : d5
+0001111001100011110000xxxxxxxxxx  n     fcvt      h0 : d5
+0001111011100010010000xxxxxxxxxx  n     fcvt      s0 : h5
+0001111011100010110000xxxxxxxxxx  n     fcvt      d0 : h5
+00011110xx1xxxxx001000xxxxx00000  w     fcmp      float_reg5 : float_reg16
+00011110xx100000001000xxxxx01000  w     fcmp      float_reg5 : bhsd_sz
+00011110xx1xxxxxxxxx01xxxxx0xxxx  w     fccmp     float_reg5 : float_reg16 cond nzcv
+00011110xx1xxxxxxxxx01xxxxx1xxxx  w     fccmpe    float_reg5 : float_reg16 cond nzcv
+0x10111000110000111110xxxxxxxxxx  n     fmaxv     s0 : dq5
+0x00111000110000111110xxxxxxxxxx  n     fmaxv     h0 : dq5
+0x10111010110000111110xxxxxxxxxx  n     fminv     s0 : dq5
+0x00111010110000111110xxxxxxxxxx  n     fminv     h0 : dq5
 
 # Floating-point convert (scalar)
-0001111000100100000000xxxxxxxxxx     fcvtas    w0 : s5
-1001111000100100000000xxxxxxxxxx     fcvtas    x0 : s5
-0001111001100100000000xxxxxxxxxx     fcvtas    w0 : d5
-1001111001100100000000xxxxxxxxxx     fcvtas    x0 : d5
-0001111000100101000000xxxxxxxxxx     fcvtau    w0 : s5
-1001111000100101000000xxxxxxxxxx     fcvtau    x0 : s5
-0001111001100101000000xxxxxxxxxx     fcvtau    w0 : d5
-1001111001100101000000xxxxxxxxxx     fcvtau    x0 : d5
-0001111000110000000000xxxxxxxxxx     fcvtms    w0 : s5
-1001111000110000000000xxxxxxxxxx     fcvtms    x0 : s5
-0001111001110000000000xxxxxxxxxx     fcvtms    w0 : d5
-1001111001110000000000xxxxxxxxxx     fcvtms    x0 : d5
-0001111000100000000000xxxxxxxxxx     fcvtns    w0 : s5
-1001111000100000000000xxxxxxxxxx     fcvtns    x0 : s5
-0001111001100000000000xxxxxxxxxx     fcvtns    w0 : d5
-1001111001100000000000xxxxxxxxxx     fcvtns    x0 : d5
-0001111000101000000000xxxxxxxxxx     fcvtps    w0 : s5
-1001111000101000000000xxxxxxxxxx     fcvtps    x0 : s5
-0001111001101000000000xxxxxxxxxx     fcvtps    w0 : d5
-1001111001101000000000xxxxxxxxxx     fcvtps    x0 : d5
-0001111000101001000000xxxxxxxxxx     fcvtpu    w0 : s5
-1001111000101001000000xxxxxxxxxx     fcvtpu    x0 : s5
-0001111001101001000000xxxxxxxxxx     fcvtpu    w0 : d5
-1001111001101001000000xxxxxxxxxx     fcvtpu    x0 : d5
+0001111000100100000000xxxxxxxxxx  n     fcvtas    w0 : s5
+1001111000100100000000xxxxxxxxxx  n     fcvtas    x0 : s5
+0001111001100100000000xxxxxxxxxx  n     fcvtas    w0 : d5
+1001111001100100000000xxxxxxxxxx  n     fcvtas    x0 : d5
+0001111000100101000000xxxxxxxxxx  n     fcvtau    w0 : s5
+1001111000100101000000xxxxxxxxxx  n     fcvtau    x0 : s5
+0001111001100101000000xxxxxxxxxx  n     fcvtau    w0 : d5
+1001111001100101000000xxxxxxxxxx  n     fcvtau    x0 : d5
+0001111000110000000000xxxxxxxxxx  n     fcvtms    w0 : s5
+1001111000110000000000xxxxxxxxxx  n     fcvtms    x0 : s5
+0001111001110000000000xxxxxxxxxx  n     fcvtms    w0 : d5
+1001111001110000000000xxxxxxxxxx  n     fcvtms    x0 : d5
+0001111000100000000000xxxxxxxxxx  n     fcvtns    w0 : s5
+1001111000100000000000xxxxxxxxxx  n     fcvtns    x0 : s5
+0001111001100000000000xxxxxxxxxx  n     fcvtns    w0 : d5
+1001111001100000000000xxxxxxxxxx  n     fcvtns    x0 : d5
+0001111000101000000000xxxxxxxxxx  n     fcvtps    w0 : s5
+1001111000101000000000xxxxxxxxxx  n     fcvtps    x0 : s5
+0001111001101000000000xxxxxxxxxx  n     fcvtps    w0 : d5
+1001111001101000000000xxxxxxxxxx  n     fcvtps    x0 : d5
+0001111000101001000000xxxxxxxxxx  n     fcvtpu    w0 : s5
+1001111000101001000000xxxxxxxxxx  n     fcvtpu    x0 : s5
+0001111001101001000000xxxxxxxxxx  n     fcvtpu    w0 : d5
+1001111001101001000000xxxxxxxxxx  n     fcvtpu    x0 : d5
 
 # Floating-point convert (vector) (scalar single-precision and double-precision)
-0101111000100001110010xxxxxxxxxx     fcvtas    s0 : s5
-0101111001100001110010xxxxxxxxxx     fcvtas    d0 : d5
-0111111000100001110010xxxxxxxxxx     fcvtau    s0 : s5
-0111111001100001110010xxxxxxxxxx     fcvtau    d0 : d5
-0101111000100001101110xxxxxxxxxx     fcvtms    s0 : s5
-0101111001100001101110xxxxxxxxxx     fcvtms    d0 : d5
-0101111000100001101010xxxxxxxxxx     fcvtns    s0 : s5
-0101111001100001101010xxxxxxxxxx     fcvtns    d0 : d5
-0101111010100001101010xxxxxxxxxx     fcvtps    s0 : s5
-0101111011100001101010xxxxxxxxxx     fcvtps    d0 : d5
-0111111010100001101010xxxxxxxxxx     fcvtpu    s0 : s5
-0111111011100001101010xxxxxxxxxx     fcvtpu    d0 : d5
+0101111000100001110010xxxxxxxxxx  n     fcvtas    s0 : s5
+0101111001100001110010xxxxxxxxxx  n     fcvtas    d0 : d5
+0111111000100001110010xxxxxxxxxx  n     fcvtau    s0 : s5
+0111111001100001110010xxxxxxxxxx  n     fcvtau    d0 : d5
+0101111000100001101110xxxxxxxxxx  n     fcvtms    s0 : s5
+0101111001100001101110xxxxxxxxxx  n     fcvtms    d0 : d5
+0101111000100001101010xxxxxxxxxx  n     fcvtns    s0 : s5
+0101111001100001101010xxxxxxxxxx  n     fcvtns    d0 : d5
+0101111010100001101010xxxxxxxxxx  n     fcvtps    s0 : s5
+0101111011100001101010xxxxxxxxxx  n     fcvtps    d0 : d5
+0111111010100001101010xxxxxxxxxx  n     fcvtpu    s0 : s5
+0111111011100001101010xxxxxxxxxx  n     fcvtpu    d0 : d5
 
 # Floating-point convert (vector) (vector single-precision and double-precision)
-0x0011100x100001110010xxxxxxxxxx     fcvtas    dq0 : dq5 sd_sz
-0x1011100x100001110010xxxxxxxxxx     fcvtau    dq0 : dq5 sd_sz
-0x0011100x100001101110xxxxxxxxxx     fcvtms    dq0 : dq5 sd_sz
-0x0011100x100001101010xxxxxxxxxx     fcvtns    dq0 : dq5 sd_sz
-0x0011101x100001101010xxxxxxxxxx     fcvtps    dq0 : dq5 sd_sz
-0x1011101x100001101010xxxxxxxxxx     fcvtpu    dq0 : dq5 sd_sz
-000011100x100001011110xxxxxxxxxx     fcvtl     dq0 : dq5 sd_sz
-010011100x100001011110xxxxxxxxxx     fcvtl2    dq0 : dq5 sd_sz
-000011100x100001011010xxxxxxxxxx     fcvtn     dq0 : dq5 sd_sz
-010011100x100001011010xxxxxxxxxx     fcvtn2    dq0 : dq5 sd_sz
+0x0011100x100001110010xxxxxxxxxx  n     fcvtas    dq0 : dq5 sd_sz
+0x1011100x100001110010xxxxxxxxxx  n     fcvtau    dq0 : dq5 sd_sz
+0x0011100x100001101110xxxxxxxxxx  n     fcvtms    dq0 : dq5 sd_sz
+0x0011100x100001101010xxxxxxxxxx  n     fcvtns    dq0 : dq5 sd_sz
+0x0011101x100001101010xxxxxxxxxx  n     fcvtps    dq0 : dq5 sd_sz
+0x1011101x100001101010xxxxxxxxxx  n     fcvtpu    dq0 : dq5 sd_sz
+000011100x100001011110xxxxxxxxxx  n     fcvtl     dq0 : dq5 sd_sz
+010011100x100001011110xxxxxxxxxx  n     fcvtl2    dq0 : dq5 sd_sz
+000011100x100001011010xxxxxxxxxx  n     fcvtn     dq0 : dq5 sd_sz
+010011100x100001011010xxxxxxxxxx  n     fcvtn2    dq0 : dq5 sd_sz
 
 # Floating-point convert (scalar, integer)
-x001111000111000000000xxxxxxxxxx     fcvtzs    wx0 : s5
-x001111001111000000000xxxxxxxxxx     fcvtzs    wx0 : d5
-x001111000111001000000xxxxxxxxxx     fcvtzu    wx0 : s5
-x001111001111001000000xxxxxxxxxx     fcvtzu    wx0 : d5
-x001111000100011000000xxxxxxxxxx     ucvtf     s0 : wx5
-x001111001100011000000xxxxxxxxxx     ucvtf     d0 : wx5
-x001111000100010000000xxxxxxxxxx     scvtf     s0 : wx5
-x001111001100010000000xxxxxxxxxx     scvtf     d0 : wx5
+x001111000111000000000xxxxxxxxxx  n     fcvtzs    wx0 : s5
+x001111001111000000000xxxxxxxxxx  n     fcvtzs    wx0 : d5
+x001111000111001000000xxxxxxxxxx  n     fcvtzu    wx0 : s5
+x001111001111001000000xxxxxxxxxx  n     fcvtzu    wx0 : d5
+x001111000100011000000xxxxxxxxxx  n     ucvtf     s0 : wx5
+x001111001100011000000xxxxxxxxxx  n     ucvtf     d0 : wx5
+x001111000100010000000xxxxxxxxxx  n     scvtf     s0 : wx5
+x001111001100010000000xxxxxxxxxx  n     scvtf     d0 : wx5
 
 # Floating-point convert (vector, integer) (scalar single-precision and double-precision)
-0101111010100001101110xxxxxxxxxx     fcvtzs    s0 : s5
-0101111011100001101110xxxxxxxxxx     fcvtzs    d0 : d5
-0111111010100001101110xxxxxxxxxx     fcvtzu    s0 : s5
-0111111011100001101110xxxxxxxxxx     fcvtzu    d0 : d5
-0111111000100001110110xxxxxxxxxx     ucvtf     s0  : s5
-0111111001100001110110xxxxxxxxxx     ucvtf     d0  : d5
-0101111000100001110110xxxxxxxxxx     scvtf     s0  : s5
-0101111001100001110110xxxxxxxxxx     scvtf     d0  : d5
+0101111010100001101110xxxxxxxxxx  n     fcvtzs    s0 : s5
+0101111011100001101110xxxxxxxxxx  n     fcvtzs    d0 : d5
+0111111010100001101110xxxxxxxxxx  n     fcvtzu    s0 : s5
+0111111011100001101110xxxxxxxxxx  n     fcvtzu    d0 : d5
+0111111000100001110110xxxxxxxxxx  n     ucvtf     s0  : s5
+0111111001100001110110xxxxxxxxxx  n     ucvtf     d0  : d5
+0101111000100001110110xxxxxxxxxx  n     scvtf     s0  : s5
+0101111001100001110110xxxxxxxxxx  n     scvtf     d0  : d5
 
 # Floating-point convert (vector, integer) (vector single-precision and double-precision)
-0x0011101x100001101110xxxxxxxxxx     fcvtzs    dq0 : dq5 sd_sz
-0x1011101x100001101110xxxxxxxxxx     fcvtzu    dq0 : dq5 sd_sz
-0x1011100x100001110110xxxxxxxxxx     ucvtf     dq0 : dq5 sd_sz
-0x0011100x100001110110xxxxxxxxxx     scvtf     dq0 : dq5 sd_sz
+0x0011101x100001101110xxxxxxxxxx  n     fcvtzs    dq0 : dq5 sd_sz
+0x1011101x100001101110xxxxxxxxxx  n     fcvtzu    dq0 : dq5 sd_sz
+0x1011100x100001110110xxxxxxxxxx  n     ucvtf     dq0 : dq5 sd_sz
+0x0011100x100001110110xxxxxxxxxx  n     scvtf     dq0 : dq5 sd_sz
 
 # Floating-point convert (scalar, fixed-point)
-x001111000011000xxxxxxxxxxxxxxxx     fcvtzs    wx0 : s5 scale
-x001111001011000xxxxxxxxxxxxxxxx     fcvtzs    wx0 : d5 scale
-x001111000011001xxxxxxxxxxxxxxxx     fcvtzu    wx0 : s5 scale
-x001111001011001xxxxxxxxxxxxxxxx     fcvtzu    wx0 : d5 scale
-x001111000000011xxxxxxxxxxxxxxxx     ucvtf     s0 : wx5 scale
-x001111001000011xxxxxxxxxxxxxxxx     ucvtf     d0 : wx5 scale
-x001111000000010xxxxxxxxxxxxxxxx     scvtf     s0 : wx5 scale
-x001111001000010xxxxxxxxxxxxxxxx     scvtf     d0 : wx5 scale
+x001111000011000xxxxxxxxxxxxxxxx  n     fcvtzs    wx0 : s5 scale
+x001111001011000xxxxxxxxxxxxxxxx  n     fcvtzs    wx0 : d5 scale
+x001111000011001xxxxxxxxxxxxxxxx  n     fcvtzu    wx0 : s5 scale
+x001111001011001xxxxxxxxxxxxxxxx  n     fcvtzu    wx0 : d5 scale
+x001111000000011xxxxxxxxxxxxxxxx  n     ucvtf     s0 : wx5 scale
+x001111001000011xxxxxxxxxxxxxxxx  n     ucvtf     d0 : wx5 scale
+x001111000000010xxxxxxxxxxxxxxxx  n     scvtf     s0 : wx5 scale
+x001111001000010xxxxxxxxxxxxxxxx  n     scvtf     d0 : wx5 scale
 
 # Floating-point convert (vector, fixed-point) (scalar)
-0101111100xxxxxx111111xxxxxxxxxx     fcvtzs    s0 : s5 immhb
-0101111101xxxxxx111111xxxxxxxxxx     fcvtzs    d0 : d5 immhb
-0111111100xxxxxx111111xxxxxxxxxx     fcvtzu    s0 : s5 immhb
-0111111101xxxxxx111111xxxxxxxxxx     fcvtzu    d0 : d5 immhb
-0111111000xxxxxx111001xxxxxxxxxx     ucvtf     s0 : s5 immhb
-0111111001xxxxxx111001xxxxxxxxxx     ucvtf     d0 : d5 immhb
-0101111100xxxxxx111001xxxxxxxxxx     scvtf     s0 : s5 immhb
-0101111101xxxxxx111001xxxxxxxxxx     scvtf     d0 : d5 immhb
+0101111100xxxxxx111111xxxxxxxxxx  n     fcvtzs    s0 : s5 immhb
+0101111101xxxxxx111111xxxxxxxxxx  n     fcvtzs    d0 : d5 immhb
+0111111100xxxxxx111111xxxxxxxxxx  n     fcvtzu    s0 : s5 immhb
+0111111101xxxxxx111111xxxxxxxxxx  n     fcvtzu    d0 : d5 immhb
+0111111000xxxxxx111001xxxxxxxxxx  n     ucvtf     s0 : s5 immhb
+0111111001xxxxxx111001xxxxxxxxxx  n     ucvtf     d0 : d5 immhb
+0101111100xxxxxx111001xxxxxxxxxx  n     scvtf     s0 : s5 immhb
+0101111101xxxxxx111001xxxxxxxxxx  n     scvtf     d0 : d5 immhb
 
 # Floating-point convert (vector, fixed-point) (vector)
-0x1011110xxxxxxx111111xxxxxxxxxx     fcvtzu    dq0 : dq5 sd_sz immhb
-0x1011110xxxxxxx111001xxxxxxxxxx     ucvtf     dq0 : dq5 sd_sz immhb
-0x0011110xxxxxxx111001xxxxxxxxxx     scvtf     dq0 : dq5 sd_sz immhb
+0x1011110xxxxxxx111111xxxxxxxxxx  n     fcvtzu    dq0 : dq5 sd_sz immhb
+0x1011110xxxxxxx111001xxxxxxxxxx  n     ucvtf     dq0 : dq5 sd_sz immhb
+0x0011110xxxxxxx111001xxxxxxxxxx  n     scvtf     dq0 : dq5 sd_sz immhb
 
 # Floating-point data-processing (2 source)
-00011110xx1xxxxx000010xxxxxxxxxx     fmul      float_reg0 : float_reg5 float_reg16
-00011110xx1xxxxx000110xxxxxxxxxx     fdiv      float_reg0 : float_reg5 float_reg16
-00011110xx1xxxxx001010xxxxxxxxxx     fadd      float_reg0 : float_reg5 float_reg16
-00011110xx1xxxxx001110xxxxxxxxxx     fsub      float_reg0 : float_reg5 float_reg16
-00011110xx1xxxxx010010xxxxxxxxxx     fmax      float_reg0 : float_reg5 float_reg16
-00011110xx1xxxxx010110xxxxxxxxxx     fmin      float_reg0 : float_reg5 float_reg16
-00011110xx1xxxxx011010xxxxxxxxxx     fmaxnm    float_reg0 : float_reg5 float_reg16
-00011110xx1xxxxx011110xxxxxxxxxx     fminnm    float_reg0 : float_reg5 float_reg16
-00011110xx1xxxxx100010xxxxxxxxxx     fnmul     float_reg0 : float_reg5 float_reg16
+00011110xx1xxxxx000010xxxxxxxxxx  n     fmul      float_reg0 : float_reg5 float_reg16
+00011110xx1xxxxx000110xxxxxxxxxx  n     fdiv      float_reg0 : float_reg5 float_reg16
+00011110xx1xxxxx001010xxxxxxxxxx  n     fadd      float_reg0 : float_reg5 float_reg16
+00011110xx1xxxxx001110xxxxxxxxxx  n     fsub      float_reg0 : float_reg5 float_reg16
+00011110xx1xxxxx010010xxxxxxxxxx  n     fmax      float_reg0 : float_reg5 float_reg16
+00011110xx1xxxxx010110xxxxxxxxxx  n     fmin      float_reg0 : float_reg5 float_reg16
+00011110xx1xxxxx011010xxxxxxxxxx  n     fmaxnm    float_reg0 : float_reg5 float_reg16
+00011110xx1xxxxx011110xxxxxxxxxx  n     fminnm    float_reg0 : float_reg5 float_reg16
+00011110xx1xxxxx100010xxxxxxxxxx  n     fnmul     float_reg0 : float_reg5 float_reg16
 
 # Floating-point data-processing (3 source)
-00011111xx0xxxxx0xxxxxxxxxxxxxxx     fmadd     float_reg0 : float_reg5 float_reg16 float_reg10
-00011111xx0xxxxx1xxxxxxxxxxxxxxx     fmsub     float_reg0 : float_reg5 float_reg16 float_reg10
-00011111xx1xxxxx0xxxxxxxxxxxxxxx     fnmadd    float_reg0 : float_reg5 float_reg16 float_reg10
-00011111xx1xxxxx1xxxxxxxxxxxxxxx     fnmsub    float_reg0 : float_reg5 float_reg16 float_reg10
+00011111xx0xxxxx0xxxxxxxxxxxxxxx  n     fmadd     float_reg0 : float_reg5 float_reg16 float_reg10
+00011111xx0xxxxx1xxxxxxxxxxxxxxx  n     fmsub     float_reg0 : float_reg5 float_reg16 float_reg10
+00011111xx1xxxxx0xxxxxxxxxxxxxxx  n     fnmadd    float_reg0 : float_reg5 float_reg16 float_reg10
+00011111xx1xxxxx1xxxxxxxxxxxxxxx  n     fnmsub    float_reg0 : float_reg5 float_reg16 float_reg10
 
 # SVE bitwise logical operations (predicated)
-00000100xx011000000xxxxxxxxxxxxx     orr       z0 : p10_low z0 z5 bhsd_sz
-00000100xx011001000xxxxxxxxxxxxx     eor       z0 : p10_low z0 z5 bhsd_sz
-00000100xx011010000xxxxxxxxxxxxx     and       z0 : p10_low z0 z5 bhsd_sz
-00000100xx011011000xxxxxxxxxxxxx     bic       z0 : p10_low z0 z5 bhsd_sz
+00000100xx011000000xxxxxxxxxxxxx  n     orr       z0 : p10_low z0 z5 bhsd_sz
+00000100xx011001000xxxxxxxxxxxxx  n     eor       z0 : p10_low z0 z5 bhsd_sz
+00000100xx011010000xxxxxxxxxxxxx  n     and       z0 : p10_low z0 z5 bhsd_sz
+00000100xx011011000xxxxxxxxxxxxx  n     bic       z0 : p10_low z0 z5 bhsd_sz
 
 # SVE integer add/subtract vectors (unpredicated)
-00000100xx1xxxxx000000xxxxxxxxxx     add       z0 : z5 z16 bhsd_sz
-00000100xx1xxxxx000001xxxxxxxxxx     sub       z0 : z5 z16 bhsd_sz
-00000100xx1xxxxx000100xxxxxxxxxx     sqadd     z0 : z5 z16 bhsd_sz
-00000100xx1xxxxx000101xxxxxxxxxx     uqadd     z0 : z5 z16 bhsd_sz
-00000100xx1xxxxx000110xxxxxxxxxx     sqsub     z0 : z5 z16 bhsd_sz
-00000100xx1xxxxx000111xxxxxxxxxx     uqsub     z0 : z5 z16 bhsd_sz
+00000100xx1xxxxx000000xxxxxxxxxx  n     add       z0 : z5 z16 bhsd_sz
+00000100xx1xxxxx000001xxxxxxxxxx  n     sub       z0 : z5 z16 bhsd_sz
+00000100xx1xxxxx000100xxxxxxxxxx  n     sqadd     z0 : z5 z16 bhsd_sz
+00000100xx1xxxxx000101xxxxxxxxxx  n     uqadd     z0 : z5 z16 bhsd_sz
+00000100xx1xxxxx000110xxxxxxxxxx  n     sqsub     z0 : z5 z16 bhsd_sz
+00000100xx1xxxxx000111xxxxxxxxxx  n     uqsub     z0 : z5 z16 bhsd_sz
 
 # Advanced SIMD three different
 
@@ -1350,232 +1368,232 @@ x001111001000010xxxxxxxxxxxxxxxx     scvtf     d0 : wx5 scale
 # input width can by byte, half, and single, which will produce outputs
 # of size half, single, and double, respectively.
 
-00001110xx1xxxxx000000xxxxxxxxxx     saddl     q0 : d5 d16 bhs_sz
-01001110xx1xxxxx000000xxxxxxxxxx     saddl2    q0 : q5 q16 bhs_sz
-00001110xx1xxxxx000100xxxxxxxxxx     saddw     q0 : q5 d16 bhs_sz
-01001110xx1xxxxx000100xxxxxxxxxx     saddw2    q0 : q5 q16 bhs_sz
-00001110xx1xxxxx001000xxxxxxxxxx     ssubl     q0 : d5 d16 bhs_sz
-01001110xx1xxxxx001000xxxxxxxxxx     ssubl2    q0 : q5 q16 bhs_sz
-00001110xx1xxxxx001100xxxxxxxxxx     ssubw     q0 : q5 d16 bhs_sz
-01001110xx1xxxxx001100xxxxxxxxxx     ssubw2    q0 : q5 q16 bhs_sz
-00001110xx1xxxxx010000xxxxxxxxxx     addhn     d0 : q5 q16 bhs_sz
-01001110xx1xxxxx010000xxxxxxxxxx     addhn2    q0 : q5 q16 bhs_sz
-00001110xx1xxxxx010100xxxxxxxxxx     sabal     q0 : d5 d16 bhs_sz
-01001110xx1xxxxx010100xxxxxxxxxx     sabal2    q0 : q5 q16 bhs_sz
-00001110xx1xxxxx011000xxxxxxxxxx     subhn     d0 : q5 q16 bhs_sz
-01001110xx1xxxxx011000xxxxxxxxxx     subhn2    q0 : q5 q16 bhs_sz
-00001110xx1xxxxx011100xxxxxxxxxx     sabdl     q0 : d5 d16 bhs_sz
-01001110xx1xxxxx011100xxxxxxxxxx     sabdl2    q0 : q5 q16 bhs_sz
-00001110xx1xxxxx100000xxxxxxxxxx     smlal     q0 : d5 d16 bhs_sz
-00001111xxxxxxxx0010x0xxxxxxxxxx     smlal     d0 : d5 dq16_idx_lhm bhsd_sz idx_lhm
-01001110xx1xxxxx100000xxxxxxxxxx     smlal2    q0 : q5 q16 bhs_sz
-01001111xxxxxxxx0010x0xxxxxxxxxx     smlal2    q0 : q5 dq16_idx_lhm bhsd_sz idx_lhm
-00001110xx1xxxxx100100xxxxxxxxxx     sqdmlal   q0 : d5 d16 hs_sz
-01001110xx1xxxxx100100xxxxxxxxxx     sqdmlal2  q0 : q5 q16 hs_sz
-00001110xx1xxxxx101000xxxxxxxxxx     smlsl     q0 : d5 d16 bhs_sz
-01001110xx1xxxxx101000xxxxxxxxxx     smlsl2    q0 : q5 q16 bhs_sz
-00001110xx1xxxxx101100xxxxxxxxxx     sqdmlsl   q0 : d5 d16 hs_sz
-01001110xx1xxxxx101100xxxxxxxxxx     sqdmlsl2  q0 : q5 q16 hs_sz
-00001110xx1xxxxx110000xxxxxxxxxx     smull     q0 : d5 d16 bhs_sz
-01001110xx1xxxxx110000xxxxxxxxxx     smull2    q0 : q5 q16 bhs_sz
-00001110xx1xxxxx110100xxxxxxxxxx     sqdmull   q0 : d5 d16 hs_sz
-01001110xx1xxxxx110100xxxxxxxxxx     sqdmull2  q0 : q5 q16 hs_sz
-00001110xx1xxxxx111000xxxxxxxxxx     pmull     q0 : d5 d16 bd_sz
-01001110xx1xxxxx111000xxxxxxxxxx     pmull2    q0 : q5 q16 bd_sz
-00101110xx1xxxxx000000xxxxxxxxxx     uaddl     q0 : d5 d16 bhs_sz
-01101110xx1xxxxx000000xxxxxxxxxx     uaddl2    q0 : q5 q16 bhs_sz
-00101110xx1xxxxx000100xxxxxxxxxx     uaddw     q0 : q5 d16 bhs_sz
-01101110xx1xxxxx000100xxxxxxxxxx     uaddw2    q0 : q5 q16 bhs_sz
-00101110xx1xxxxx001000xxxxxxxxxx     usubl     q0 : d5 d16 bhs_sz
-01101110xx1xxxxx001000xxxxxxxxxx     usubl2    q0 : q5 q16 bhs_sz
-00101110xx1xxxxx001100xxxxxxxxxx     usubw     q0 : q5 d16 bhs_sz
-01101110xx1xxxxx001100xxxxxxxxxx     usubw2    q0 : q5 q16 bhs_sz
-00101110xx1xxxxx010000xxxxxxxxxx     raddhn    d0 : q5 q16 bhs_sz
-01101110xx1xxxxx010000xxxxxxxxxx     raddhn2   q0 : q5 q16 bhs_sz
-00101110xx1xxxxx010100xxxxxxxxxx     uabal     q0 : d5 d16 bhs_sz
-01101110xx1xxxxx010100xxxxxxxxxx     uabal2    q0 : q5 q16 bhs_sz
-00101110xx1xxxxx011000xxxxxxxxxx     rsubhn    d0 : q5 q16 bhs_sz
-01101110xx1xxxxx011000xxxxxxxxxx     rsubhn2   q0 : q5 q16 bhs_sz
-00101110xx1xxxxx011100xxxxxxxxxx     uabdl     q0 : d5 d16 bhs_sz
-01101110xx1xxxxx011100xxxxxxxxxx     uabdl2    q0 : q5 q16 bhs_sz
-00101110xx1xxxxx100000xxxxxxxxxx     umlal     q0 : d5 d16 bhs_sz
-01101110xx1xxxxx100000xxxxxxxxxx     umlal2    q0 : q5 q16 bhs_sz
-00101110xx1xxxxx101000xxxxxxxxxx     umlsl     q0 : d5 d16 bhs_sz
-01101110xx1xxxxx101000xxxxxxxxxx     umlsl2    q0 : q5 q16 bhs_sz
-00101110xx1xxxxx110000xxxxxxxxxx     umull     q0 : d5 d16 bhs_sz
-01101110xx1xxxxx110000xxxxxxxxxx     umull2    q0 : q5 q16 bhs_sz
+00001110xx1xxxxx000000xxxxxxxxxx  n     saddl     q0 : d5 d16 bhs_sz
+01001110xx1xxxxx000000xxxxxxxxxx  n     saddl2    q0 : q5 q16 bhs_sz
+00001110xx1xxxxx000100xxxxxxxxxx  n     saddw     q0 : q5 d16 bhs_sz
+01001110xx1xxxxx000100xxxxxxxxxx  n     saddw2    q0 : q5 q16 bhs_sz
+00001110xx1xxxxx001000xxxxxxxxxx  n     ssubl     q0 : d5 d16 bhs_sz
+01001110xx1xxxxx001000xxxxxxxxxx  n     ssubl2    q0 : q5 q16 bhs_sz
+00001110xx1xxxxx001100xxxxxxxxxx  n     ssubw     q0 : q5 d16 bhs_sz
+01001110xx1xxxxx001100xxxxxxxxxx  n     ssubw2    q0 : q5 q16 bhs_sz
+00001110xx1xxxxx010000xxxxxxxxxx  n     addhn     d0 : q5 q16 bhs_sz
+01001110xx1xxxxx010000xxxxxxxxxx  n     addhn2    q0 : q5 q16 bhs_sz
+00001110xx1xxxxx010100xxxxxxxxxx  n     sabal     q0 : d5 d16 bhs_sz
+01001110xx1xxxxx010100xxxxxxxxxx  n     sabal2    q0 : q5 q16 bhs_sz
+00001110xx1xxxxx011000xxxxxxxxxx  n     subhn     d0 : q5 q16 bhs_sz
+01001110xx1xxxxx011000xxxxxxxxxx  n     subhn2    q0 : q5 q16 bhs_sz
+00001110xx1xxxxx011100xxxxxxxxxx  n     sabdl     q0 : d5 d16 bhs_sz
+01001110xx1xxxxx011100xxxxxxxxxx  n     sabdl2    q0 : q5 q16 bhs_sz
+00001110xx1xxxxx100000xxxxxxxxxx  n     smlal     q0 : d5 d16 bhs_sz
+00001111xxxxxxxx0010x0xxxxxxxxxx  n     smlal     d0 : d5 dq16_idx_lhm bhsd_sz idx_lhm
+01001110xx1xxxxx100000xxxxxxxxxx  n     smlal2    q0 : q5 q16 bhs_sz
+01001111xxxxxxxx0010x0xxxxxxxxxx  n     smlal2    q0 : q5 dq16_idx_lhm bhsd_sz idx_lhm
+00001110xx1xxxxx100100xxxxxxxxxx  n     sqdmlal   q0 : d5 d16 hs_sz
+01001110xx1xxxxx100100xxxxxxxxxx  n     sqdmlal2  q0 : q5 q16 hs_sz
+00001110xx1xxxxx101000xxxxxxxxxx  n     smlsl     q0 : d5 d16 bhs_sz
+01001110xx1xxxxx101000xxxxxxxxxx  n     smlsl2    q0 : q5 q16 bhs_sz
+00001110xx1xxxxx101100xxxxxxxxxx  n     sqdmlsl   q0 : d5 d16 hs_sz
+01001110xx1xxxxx101100xxxxxxxxxx  n     sqdmlsl2  q0 : q5 q16 hs_sz
+00001110xx1xxxxx110000xxxxxxxxxx  n     smull     q0 : d5 d16 bhs_sz
+01001110xx1xxxxx110000xxxxxxxxxx  n     smull2    q0 : q5 q16 bhs_sz
+00001110xx1xxxxx110100xxxxxxxxxx  n     sqdmull   q0 : d5 d16 hs_sz
+01001110xx1xxxxx110100xxxxxxxxxx  n     sqdmull2  q0 : q5 q16 hs_sz
+00001110xx1xxxxx111000xxxxxxxxxx  n     pmull     q0 : d5 d16 bd_sz
+01001110xx1xxxxx111000xxxxxxxxxx  n     pmull2    q0 : q5 q16 bd_sz
+00101110xx1xxxxx000000xxxxxxxxxx  n     uaddl     q0 : d5 d16 bhs_sz
+01101110xx1xxxxx000000xxxxxxxxxx  n     uaddl2    q0 : q5 q16 bhs_sz
+00101110xx1xxxxx000100xxxxxxxxxx  n     uaddw     q0 : q5 d16 bhs_sz
+01101110xx1xxxxx000100xxxxxxxxxx  n     uaddw2    q0 : q5 q16 bhs_sz
+00101110xx1xxxxx001000xxxxxxxxxx  n     usubl     q0 : d5 d16 bhs_sz
+01101110xx1xxxxx001000xxxxxxxxxx  n     usubl2    q0 : q5 q16 bhs_sz
+00101110xx1xxxxx001100xxxxxxxxxx  n     usubw     q0 : q5 d16 bhs_sz
+01101110xx1xxxxx001100xxxxxxxxxx  n     usubw2    q0 : q5 q16 bhs_sz
+00101110xx1xxxxx010000xxxxxxxxxx  n     raddhn    d0 : q5 q16 bhs_sz
+01101110xx1xxxxx010000xxxxxxxxxx  n     raddhn2   q0 : q5 q16 bhs_sz
+00101110xx1xxxxx010100xxxxxxxxxx  n     uabal     q0 : d5 d16 bhs_sz
+01101110xx1xxxxx010100xxxxxxxxxx  n     uabal2    q0 : q5 q16 bhs_sz
+00101110xx1xxxxx011000xxxxxxxxxx  n     rsubhn    d0 : q5 q16 bhs_sz
+01101110xx1xxxxx011000xxxxxxxxxx  n     rsubhn2   q0 : q5 q16 bhs_sz
+00101110xx1xxxxx011100xxxxxxxxxx  n     uabdl     q0 : d5 d16 bhs_sz
+01101110xx1xxxxx011100xxxxxxxxxx  n     uabdl2    q0 : q5 q16 bhs_sz
+00101110xx1xxxxx100000xxxxxxxxxx  n     umlal     q0 : d5 d16 bhs_sz
+01101110xx1xxxxx100000xxxxxxxxxx  n     umlal2    q0 : q5 q16 bhs_sz
+00101110xx1xxxxx101000xxxxxxxxxx  n     umlsl     q0 : d5 d16 bhs_sz
+01101110xx1xxxxx101000xxxxxxxxxx  n     umlsl2    q0 : q5 q16 bhs_sz
+00101110xx1xxxxx110000xxxxxxxxxx  n     umull     q0 : d5 d16 bhs_sz
+01101110xx1xxxxx110000xxxxxxxxxx  n     umull2    q0 : q5 q16 bhs_sz
 
-0x101110xx100000000010xxxxxxxxxx     rev32     dq0 : dq5 bhs_sz
-0x001110xx100000000010xxxxxxxxxx     rev64     dq0 : dq5 bhs_sz
+0x101110xx100000000010xxxxxxxxxx  n     rev32     dq0 : dq5 bhs_sz
+0x001110xx100000000010xxxxxxxxxx  n     rev64     dq0 : dq5 bhs_sz
 
 # DUP (element) Scalar
-01011110000xxxxx000001xxxxxxxxxx     dup       dq0 : dq5 imm5
+01011110000xxxxx000001xxxxxxxxxx  n     dup       dq0 : dq5 imm5
 
 # DUP (element) Vector
-00001110000xxxxx000001xxxxxxxxxx     dup       d0 : d5 imm5
-01001110000xxxxx000001xxxxxxxxxx     dup       q0 : q5 imm5
+00001110000xxxxx000001xxxxxxxxxx  n     dup       d0 : d5 imm5
+01001110000xxxxx000001xxxxxxxxxx  n     dup       q0 : q5 imm5
 
 # DUP (general)
-00001110000xxxxx000011xxxxxxxxxx     dup       d0 : w5 imm5
-01001110000xxxxx000011xxxxxxxxxx     dup       q0 : x5 imm5
+00001110000xxxxx000011xxxxxxxxxx  n     dup       d0 : w5 imm5
+01001110000xxxxx000011xxxxxxxxxx  n     dup       q0 : x5 imm5
 
-0x001110xx110001101110xxxxxxxxxx     addv      dq0 : dq5 bhsd_sz
-0111111011100000101110xxxxxxxxxx     neg        q0 : q5
-0x101110xx100000101110xxxxxxxxxx     neg       dq0 : dq5 bhsd_sz
+0x001110xx110001101110xxxxxxxxxx  n     addv      dq0 : dq5 bhsd_sz
+0111111011100000101110xxxxxxxxxx  n     neg        q0 : q5
+0x101110xx100000101110xxxxxxxxxx  n     neg       dq0 : dq5 bhsd_sz
 
-0101111011100000101110xxxxxxxxxx     abs        d0 : d5
-0x001110xx100000101110xxxxxxxxxx     abs       dq0 : dq5 bhsd_sz
-0101111011110001101110xxxxxxxxxx     addp       d0 : q5
-0x001110xx110000101010xxxxxxxxxx     smaxv     dq0 : dq5 bhsd_sz
-0x001110xx110001101010xxxxxxxxxx     sminv     dq0 : dq5 bhsd_sz
-0x001110xx0xxxxx001110xxxxxxxxxx     zip1      dq0 : dq5 dq16 bhsd_sz
-0x001110xx0xxxxx011110xxxxxxxxxx     zip2      dq0 : dq5 dq16 bhsd_sz
-11010101000000110010000110011111     autia1716 :
-11010101000000110010000111011111     autib1716 :
-11010101000000110010000011111111     xpaclri   :
-0x10111000100000010110xxxxxxxxxx     not       dq0 : dq5
-0x001110000xxxxx0xx000xxxxxxxxxx     tbl       dq0 : dq5 dq16 len
-0x10111100000xxxxxx101xxxxxxxxxx     bic       dq0 : imm8 cmode3
-0x101110xx100000011010xxxxxxxxxx     uadalp    dq0 : dq5 bhsd_sz
-0x101110xx100000001010xxxxxxxxxx     uaddlp    dq0 : dq5 bhsd_sz
-0x101110xx110000001110xxxxxxxxxx     uaddlv    dq0 : dq5 bhsd_sz
-0x101110xx110000101010xxxxxxxxxx     umaxv     dq0 : dq5 bhsd_sz
-0x101110xx110001101010xxxxxxxxxx     uminv     dq0 : dq5 bhsd_sz
-0x001110xx100000011010xxxxxxxxxx     sadalp    dq0 : dq5 bhsd_sz
-0x001110xx100000001010xxxxxxxxxx     saddlp    dq0 : dq5 bhsd_sz
-0000111100xxxxxx101001xxxxxxxxxx     sshll      d0 : d5 immhb
-0100111100xxxxxx101001xxxxxxxxxx     sshll2     q0 : q5 immhb
-01011110000xxxxx000000xxxxxxxxxx     sha1c     q0 : s5 d16
-0101111000101000000010xxxxxxxxxx     sha1h     s0 : s5
-01011110000xxxxx001000xxxxxxxxxx     sha1m     q0 : s5 d16
-01011110000xxxxx000100xxxxxxxxxx     sha1p     q0 : s5 d16
-01011110000xxxxx001100xxxxxxxxxx     sha1su0   d0 : d5 d16
-0101111000101000000110xxxxxxxxxx     sha1su1   d0 : d5
-01011110000xxxxx010000xxxxxxxxxx     sha256h   q0 : q5 d16
-01011110000xxxxx010100xxxxxxxxxx     sha256h2  q0 : q5 d16
-0101111000101000001010xxxxxxxxxx     sha256su0 d0 : d5
-01011110000xxxxx011000xxxxxxxxxx     sha256su1 d0 : d5 d16
-0100111000101000010110xxxxxxxxxx     aesd      q0 : q5
-0100111000101000010010xxxxxxxxxx     aese      q0 : q5
-0100111000101000011110xxxxxxxxxx     aesimc    q0 : q5
-0100111000101000011010xxxxxxxxxx     aesmc     q0 : q5
-0x00111000100000010110xxxxxxxxxx     cnt      dq0 : dq5
-0x101110000xxxxx0xxxx0xxxxxxxxxx     ext      dq0 : dq5 dq16 imm4idx
-0x001110xx0xxxxx001010xxxxxxxxxx     trn1     dq0 : dq5 dq16 bhsd_sz
-0x001110xx0xxxxx011010xxxxxxxxxx     trn2     dq0 : dq5 dq16 bhsd_sz
-0010111100xxxxxx101001xxxxxxxxxx     ushll    d0  : d5 immhb
-0110111100xxxxxx101001xxxxxxxxxx     ushll2   q0  : q5 immhb
-0x001110xx0xxxxx000110xxxxxxxxxx     uzp1     dq0 : dq5 dq16 bhsd_sz
-0x001110xx0xxxxx010110xxxxxxxxxx     uzp2     dq0 : dq5 dq16 bhsd_sz
-00001110xx100001001010xxxxxxxxxx     xtn       d0 : d5 bhsd_sz
-01001110xx100001001010xxxxxxxxxx     xtn2      q0 : q5 bhsd_sz
-0101111101xxxxxx001001xxxxxxxxxx     srshr      d0 : d5 immhb
-0x0011110xxxxxxx001001xxxxxxxxxx     srshr     dq0 : dq5 sd_sz immhb
-0101111101xxxxxx001101xxxxxxxxxx     srsra      d0 : d5 immhb
-0101111101xxxxxx000001xxxxxxxxxx     sshr       d0 : d5 immhb
-0x0011110xxxxxxx000001xxxxxxxxxx     sshr      dq0 : dq5 sd_sz immhb
-0101111101xxxxxx000101xxxxxxxxxx     ssra       d0 : d5 immhb
-0101111101xxxxxx010101xxxxxxxxxx     shl        d0 : d5 immhb
-0111111101xxxxxx010101xxxxxxxxxx     sli        d0 : d5 immhb
-0111111101xxxxxx000001xxxxxxxxxx     ushr       d0 : d5 immhb
-0x1011110xxxxxxx000001xxxxxxxxxx     ushr      dq0 : dq5 sd_sz immhb
-0111111101xxxxxx000101xxxxxxxxxx     usra       d0 : d5 immhb
-0000111100xxxxxx100001xxxxxxxxxx     shrn       d0 : d5 immhb
-0100111100xxxxxx100001xxxxxxxxxx     shrn2      q0 : q5 immhb
-00101110xx100001001110xxxxxxxxxx     shll       d0 : d5 bhs_sz
-01101110xx100001001110xxxxxxxxxx     shll2      q0 : q5 bhs_sz
-x001111011110001000000xxxxxxxxxx     fcvtmu   wx0 : h5
-x001111000110001000000xxxxxxxxxx     fcvtmu   wx0 : s5
-x001111001110001000000xxxxxxxxxx     fcvtmu   wx0 : d5
-0111111001111001101110xxxxxxxxxx     fcvtmu    h0 : h5
-0111111000100001101110xxxxxxxxxx     fcvtmu    s0 : s5
-0111111001100001101110xxxxxxxxxx     fcvtmu    d0 : d5
-0x1011100x100001101110xxxxxxxxxx     fcvtmu   dq0 : dq5 sd_sz
-x001111011100001000000xxxxxxxxxx     fcvtnu   wx0 : h5
-x001111000100001000000xxxxxxxxxx     fcvtnu   wx0 : s5
-x001111001100001000000xxxxxxxxxx     fcvtnu   wx0 : d5
-0111111001111001101010xxxxxxxxxx     fcvtnu    h0 : h5
-0111111000100001101010xxxxxxxxxx     fcvtnu    s0 : s5
-0111111001100001101010xxxxxxxxxx     fcvtnu    d0 : d5
-0x1011100x100001101010xxxxxxxxxx     fcvtnu   dq0 : dq5 sd_sz
-1101010100101xxxxxxxxxxxxxxxxxxx     sysl      x0 : op1 crn imm4 op2
-11010100101xxxxxxxxxxxxxxxx00001     dcps1        : imm16
-11010100101xxxxxxxxxxxxxxxx00010     dcps2        : imm16
-11010100101xxxxxxxxxxxxxxxx00011     dcps3        : imm16
-11010110101111110000001111100000     drps         :
-11010110100111110000001111100000     eret         :
-0101111000100000001110xxxxxxxxxx     suqadd    b0 : b5
-0101111001100000001110xxxxxxxxxx     suqadd    h0 : h5
-0101111010100000001110xxxxxxxxxx     suqadd    s0 : s5
-0101111011100000001110xxxxxxxxxx     suqadd    d0 : d5
-0x001110xx100000001110xxxxxxxxxx     suqadd   dq0 : dq5 bhsd_sz
-0x001110000xxxxx0xx100xxxxxxxxxx     tbx      dq0 : dq5 dq16 len
-0010111100xxxxxx100111xxxxxxxxxx     uqrshrn   d0 : d5 immhb
-0110111100xxxxxx100111xxxxxxxxxx     uqrshrn2  q0 : q5 immhb
-0x0011101x100001110010xxxxxxxxxx     urecpe   dq0 : dq5 sd_sz
-0111111101xxxxxx001101xxxxxxxxxx     ursra     d0 : d5 immhb
-0111111000100000001110xxxxxxxxxx     usqadd    b0 : b5
-0111111001100000001110xxxxxxxxxx     usqadd    h0 : h5
-0111111010100000001110xxxxxxxxxx     usqadd    s0 : s5
-0111111011100000001110xxxxxxxxxx     usqadd    d0 : d5
-0x101110xx100000001110xxxxxxxxxx     usqadd   dq0 : dq5 bhsd_sz
-0111111000100000011110xxxxxxxxxx     sqneg     b0 : b5
-0111111001100000011110xxxxxxxxxx     sqneg     h0 : h5
-0111111010100000011110xxxxxxxxxx     sqneg     s0 : s5
-0111111011100000011110xxxxxxxxxx     sqneg     d0 : d5
-0x101110xx100000011110xxxxxxxxxx     sqneg    dq0 : dq5 bhsd_sz
-0000111100xxxxxx100111xxxxxxxxxx     sqrshrn   d0 : d5 immhb
-0100111100xxxxxx100111xxxxxxxxxx     sqrshrn2  q0 : q5 immhb
-0010111100xxxxxx100011xxxxxxxxxx     sqrshrun  d0 : d5 immhb
-0110111100xxxxxx100011xxxxxxxxxx     sqrshrun2 q0 : q5 immhb
-0111111100xxxxxx011001xxxxxxxxxx     sqshlu    s0 : s5 immhb
-0111111101xxxxxx011001xxxxxxxxxx     sqshlu    d0 : d5 immhb
-0x1011110xxxxxxx011001xxxxxxxxxx     sqshlu   dq0 : dq5 sd_sz immhb
-0010111100xxxxxx100001xxxxxxxxxx     sqshrun   d0 : d5 immhb
-0110111100xxxxxx100001xxxxxxxxxx     sqshrun2  q0 : q5 immhb
-0111111101xxxxxx010001xxxxxxxxxx     sri       d0 : d5 immhb
-0x1011110xxxxxxx010001xxxxxxxxxx     sri      dq0 : dq5 sd_sz immhb
-0000111000110000110010xxxxxxxxxx     fmaxnmv   h0 : d5
-0100111000110000110010xxxxxxxxxx     fmaxnmv   h0 : q5
-0110111000110000110010xxxxxxxxxx     fmaxnmv   s0 : q5
-0000111010110000110010xxxxxxxxxx     fminnmv   h0 : d5
-0100111010110000110010xxxxxxxxxx     fminnmv   h0 : q5
-0110111010110000110010xxxxxxxxxx     fminnmv   s0 : q5
-0101111011111001110110xxxxxxxxxx     frecpe     h0 : h5
-0101111010100001110110xxxxxxxxxx     frecpe     s0 : s5
-0101111011100001110110xxxxxxxxxx     frecpe     d0 : d5
-0x0011101x100001110110xxxxxxxxxx     frecpe    dq0 : dq5 bd_sz
-0101111011111001111110xxxxxxxxxx     frecpx     h0 : h5
-0101111010100001111110xxxxxxxxxx     frecpx     s0 : s5
-0101111011100001111110xxxxxxxxxx     frecpx     d0 : d5
-0111111011111001110110xxxxxxxxxx     frsqrte    h0 : h5
-0111111010100001110110xxxxxxxxxx     frsqrte    s0 : s5
-0111111011100001110110xxxxxxxxxx     frsqrte    d0 : d5
-0x1011101x100001110110xxxxxxxxxx     frsqrte   dq0 : dq5 bd_sz
-0000111100xxxxxx100011xxxxxxxxxx     rshrn      d0 : d5 immhb
-0100111100xxxxxx100011xxxxxxxxxx     rshrn2     q0 : q5 immhb
-0x001110xx110000001110xxxxxxxxxx     saddlv    dq0 : dq5 bhsd_sz
-0101111000100000011110xxxxxxxxxx     sqabs     b0 : b5
-0101111001100000011110xxxxxxxxxx     sqabs     h0 : h5
-0101111010100000011110xxxxxxxxxx     sqabs     s0 : s5
-0101111011100000011110xxxxxxxxxx     sqabs     d0 : d5
-0x001110xx100000011110xxxxxxxxxx     sqabs     dq0 : dq5 bhsd_sz
-0111111011100000100110xxxxxxxxxx     cmle       d0 : d5
-0x101110xx100000100110xxxxxxxxxx     cmle      dq0 : dq5 bhsd_sz
-0111111011111000110110xxxxxxxxxx     fcmle      h0 : h5
-0111111010100000110110xxxxxxxxxx     fcmle      s0 : s5
-0111111011100000110110xxxxxxxxxx     fcmle      d0 : d5
-0x1011101x100000110110xxxxxxxxxx     fcmle     dq0 : dq5 sd_sz
-0101111011111000111010xxxxxxxxxx     fcmlt      h0 : h5
-0101111010100000111010xxxxxxxxxx     fcmlt      s0 : s5
-0101111011100000111010xxxxxxxxxx     fcmlt      d0 : d5
-0x0011101x100000111010xxxxxxxxxx     fcmlt     dq0 : dq5 sd_sz
-00011110111xxxxx001000xxxxx10000     fcmpe         : h5 h16
-0001111011100000001000xxxxx11000     fcmpe         : h5
-00011110001xxxxx001000xxxxx10000     fcmpe         : s5 s16
-0001111000100000001000xxxxx11000     fcmpe         : s5
-00011110011xxxxx001000xxxxx10000     fcmpe         : d5 d16
-0001111001100000001000xxxxx11000     fcmpe         : d5
-0111111001100001011010xxxxxxxxxx     fcvtxn     s0 : d5
-0010111001100001011010xxxxxxxxxx     fcvtxn     d0 : q5
-0110111001100001011010xxxxxxxxxx     fcvtxn2    q0 : q5
+0101111011100000101110xxxxxxxxxx  n     abs        d0 : d5
+0x001110xx100000101110xxxxxxxxxx  n     abs       dq0 : dq5 bhsd_sz
+0101111011110001101110xxxxxxxxxx  n     addp       d0 : q5
+0x001110xx110000101010xxxxxxxxxx  n     smaxv     dq0 : dq5 bhsd_sz
+0x001110xx110001101010xxxxxxxxxx  n     sminv     dq0 : dq5 bhsd_sz
+0x001110xx0xxxxx001110xxxxxxxxxx  n     zip1      dq0 : dq5 dq16 bhsd_sz
+0x001110xx0xxxxx011110xxxxxxxxxx  n     zip2      dq0 : dq5 dq16 bhsd_sz
+11010101000000110010000110011111  n     autia1716 :
+11010101000000110010000111011111  n     autib1716 :
+11010101000000110010000011111111  n     xpaclri   :
+0x10111000100000010110xxxxxxxxxx  n     not       dq0 : dq5
+0x001110000xxxxx0xx000xxxxxxxxxx  n     tbl       dq0 : dq5 dq16 len
+0x10111100000xxxxxx101xxxxxxxxxx  n     bic       dq0 : imm8 cmode3
+0x101110xx100000011010xxxxxxxxxx  n     uadalp    dq0 : dq5 bhsd_sz
+0x101110xx100000001010xxxxxxxxxx  n     uaddlp    dq0 : dq5 bhsd_sz
+0x101110xx110000001110xxxxxxxxxx  n     uaddlv    dq0 : dq5 bhsd_sz
+0x101110xx110000101010xxxxxxxxxx  n     umaxv     dq0 : dq5 bhsd_sz
+0x101110xx110001101010xxxxxxxxxx  n     uminv     dq0 : dq5 bhsd_sz
+0x001110xx100000011010xxxxxxxxxx  n     sadalp    dq0 : dq5 bhsd_sz
+0x001110xx100000001010xxxxxxxxxx  n     saddlp    dq0 : dq5 bhsd_sz
+0000111100xxxxxx101001xxxxxxxxxx  n     sshll      d0 : d5 immhb
+0100111100xxxxxx101001xxxxxxxxxx  n     sshll2     q0 : q5 immhb
+01011110000xxxxx000000xxxxxxxxxx  n     sha1c     q0 : s5 d16
+0101111000101000000010xxxxxxxxxx  n     sha1h     s0 : s5
+01011110000xxxxx001000xxxxxxxxxx  n     sha1m     q0 : s5 d16
+01011110000xxxxx000100xxxxxxxxxx  n     sha1p     q0 : s5 d16
+01011110000xxxxx001100xxxxxxxxxx  n     sha1su0   d0 : d5 d16
+0101111000101000000110xxxxxxxxxx  n     sha1su1   d0 : d5
+01011110000xxxxx010000xxxxxxxxxx  n     sha256h   q0 : q5 d16
+01011110000xxxxx010100xxxxxxxxxx  n     sha256h2  q0 : q5 d16
+0101111000101000001010xxxxxxxxxx  n     sha256su0 d0 : d5
+01011110000xxxxx011000xxxxxxxxxx  n     sha256su1 d0 : d5 d16
+0100111000101000010110xxxxxxxxxx  n     aesd      q0 : q5
+0100111000101000010010xxxxxxxxxx  n     aese      q0 : q5
+0100111000101000011110xxxxxxxxxx  n     aesimc    q0 : q5
+0100111000101000011010xxxxxxxxxx  n     aesmc     q0 : q5
+0x00111000100000010110xxxxxxxxxx  n     cnt      dq0 : dq5
+0x101110000xxxxx0xxxx0xxxxxxxxxx  n     ext      dq0 : dq5 dq16 imm4idx
+0x001110xx0xxxxx001010xxxxxxxxxx  n     trn1     dq0 : dq5 dq16 bhsd_sz
+0x001110xx0xxxxx011010xxxxxxxxxx  n     trn2     dq0 : dq5 dq16 bhsd_sz
+0010111100xxxxxx101001xxxxxxxxxx  n     ushll    d0  : d5 immhb
+0110111100xxxxxx101001xxxxxxxxxx  n     ushll2   q0  : q5 immhb
+0x001110xx0xxxxx000110xxxxxxxxxx  n     uzp1     dq0 : dq5 dq16 bhsd_sz
+0x001110xx0xxxxx010110xxxxxxxxxx  n     uzp2     dq0 : dq5 dq16 bhsd_sz
+00001110xx100001001010xxxxxxxxxx  n     xtn       d0 : d5 bhsd_sz
+01001110xx100001001010xxxxxxxxxx  n     xtn2      q0 : q5 bhsd_sz
+0101111101xxxxxx001001xxxxxxxxxx  n     srshr      d0 : d5 immhb
+0x0011110xxxxxxx001001xxxxxxxxxx  n     srshr     dq0 : dq5 sd_sz immhb
+0101111101xxxxxx001101xxxxxxxxxx  n     srsra      d0 : d5 immhb
+0101111101xxxxxx000001xxxxxxxxxx  n     sshr       d0 : d5 immhb
+0x0011110xxxxxxx000001xxxxxxxxxx  n     sshr      dq0 : dq5 sd_sz immhb
+0101111101xxxxxx000101xxxxxxxxxx  n     ssra       d0 : d5 immhb
+0101111101xxxxxx010101xxxxxxxxxx  n     shl        d0 : d5 immhb
+0111111101xxxxxx010101xxxxxxxxxx  n     sli        d0 : d5 immhb
+0111111101xxxxxx000001xxxxxxxxxx  n     ushr       d0 : d5 immhb
+0x1011110xxxxxxx000001xxxxxxxxxx  n     ushr      dq0 : dq5 sd_sz immhb
+0111111101xxxxxx000101xxxxxxxxxx  n     usra       d0 : d5 immhb
+0000111100xxxxxx100001xxxxxxxxxx  n     shrn       d0 : d5 immhb
+0100111100xxxxxx100001xxxxxxxxxx  n     shrn2      q0 : q5 immhb
+00101110xx100001001110xxxxxxxxxx  n     shll       d0 : d5 bhs_sz
+01101110xx100001001110xxxxxxxxxx  n     shll2      q0 : q5 bhs_sz
+x001111011110001000000xxxxxxxxxx  n     fcvtmu   wx0 : h5
+x001111000110001000000xxxxxxxxxx  n     fcvtmu   wx0 : s5
+x001111001110001000000xxxxxxxxxx  n     fcvtmu   wx0 : d5
+0111111001111001101110xxxxxxxxxx  n     fcvtmu    h0 : h5
+0111111000100001101110xxxxxxxxxx  n     fcvtmu    s0 : s5
+0111111001100001101110xxxxxxxxxx  n     fcvtmu    d0 : d5
+0x1011100x100001101110xxxxxxxxxx  n     fcvtmu   dq0 : dq5 sd_sz
+x001111011100001000000xxxxxxxxxx  n     fcvtnu   wx0 : h5
+x001111000100001000000xxxxxxxxxx  n     fcvtnu   wx0 : s5
+x001111001100001000000xxxxxxxxxx  n     fcvtnu   wx0 : d5
+0111111001111001101010xxxxxxxxxx  n     fcvtnu    h0 : h5
+0111111000100001101010xxxxxxxxxx  n     fcvtnu    s0 : s5
+0111111001100001101010xxxxxxxxxx  n     fcvtnu    d0 : d5
+0x1011100x100001101010xxxxxxxxxx  n     fcvtnu   dq0 : dq5 sd_sz
+1101010100101xxxxxxxxxxxxxxxxxxx  n     sysl      x0 : op1 crn imm4 op2
+11010100101xxxxxxxxxxxxxxxx00001  n     dcps1        : imm16
+11010100101xxxxxxxxxxxxxxxx00010  n     dcps2        : imm16
+11010100101xxxxxxxxxxxxxxxx00011  n     dcps3        : imm16
+11010110101111110000001111100000  n     drps         :
+11010110100111110000001111100000  n     eret         :
+0101111000100000001110xxxxxxxxxx  n     suqadd    b0 : b5
+0101111001100000001110xxxxxxxxxx  n     suqadd    h0 : h5
+0101111010100000001110xxxxxxxxxx  n     suqadd    s0 : s5
+0101111011100000001110xxxxxxxxxx  n     suqadd    d0 : d5
+0x001110xx100000001110xxxxxxxxxx  n     suqadd   dq0 : dq5 bhsd_sz
+0x001110000xxxxx0xx100xxxxxxxxxx  n     tbx      dq0 : dq5 dq16 len
+0010111100xxxxxx100111xxxxxxxxxx  n     uqrshrn   d0 : d5 immhb
+0110111100xxxxxx100111xxxxxxxxxx  n     uqrshrn2  q0 : q5 immhb
+0x0011101x100001110010xxxxxxxxxx  n     urecpe   dq0 : dq5 sd_sz
+0111111101xxxxxx001101xxxxxxxxxx  n     ursra     d0 : d5 immhb
+0111111000100000001110xxxxxxxxxx  n     usqadd    b0 : b5
+0111111001100000001110xxxxxxxxxx  n     usqadd    h0 : h5
+0111111010100000001110xxxxxxxxxx  n     usqadd    s0 : s5
+0111111011100000001110xxxxxxxxxx  n     usqadd    d0 : d5
+0x101110xx100000001110xxxxxxxxxx  n     usqadd   dq0 : dq5 bhsd_sz
+0111111000100000011110xxxxxxxxxx  n     sqneg     b0 : b5
+0111111001100000011110xxxxxxxxxx  n     sqneg     h0 : h5
+0111111010100000011110xxxxxxxxxx  n     sqneg     s0 : s5
+0111111011100000011110xxxxxxxxxx  n     sqneg     d0 : d5
+0x101110xx100000011110xxxxxxxxxx  n     sqneg    dq0 : dq5 bhsd_sz
+0000111100xxxxxx100111xxxxxxxxxx  n     sqrshrn   d0 : d5 immhb
+0100111100xxxxxx100111xxxxxxxxxx  n     sqrshrn2  q0 : q5 immhb
+0010111100xxxxxx100011xxxxxxxxxx  n     sqrshrun  d0 : d5 immhb
+0110111100xxxxxx100011xxxxxxxxxx  n     sqrshrun2 q0 : q5 immhb
+0111111100xxxxxx011001xxxxxxxxxx  n     sqshlu    s0 : s5 immhb
+0111111101xxxxxx011001xxxxxxxxxx  n     sqshlu    d0 : d5 immhb
+0x1011110xxxxxxx011001xxxxxxxxxx  n     sqshlu   dq0 : dq5 sd_sz immhb
+0010111100xxxxxx100001xxxxxxxxxx  n     sqshrun   d0 : d5 immhb
+0110111100xxxxxx100001xxxxxxxxxx  n     sqshrun2  q0 : q5 immhb
+0111111101xxxxxx010001xxxxxxxxxx  n     sri       d0 : d5 immhb
+0x1011110xxxxxxx010001xxxxxxxxxx  n     sri      dq0 : dq5 sd_sz immhb
+0000111000110000110010xxxxxxxxxx  n     fmaxnmv   h0 : d5
+0100111000110000110010xxxxxxxxxx  n     fmaxnmv   h0 : q5
+0110111000110000110010xxxxxxxxxx  n     fmaxnmv   s0 : q5
+0000111010110000110010xxxxxxxxxx  n     fminnmv   h0 : d5
+0100111010110000110010xxxxxxxxxx  n     fminnmv   h0 : q5
+0110111010110000110010xxxxxxxxxx  n     fminnmv   s0 : q5
+0101111011111001110110xxxxxxxxxx  n     frecpe     h0 : h5
+0101111010100001110110xxxxxxxxxx  n     frecpe     s0 : s5
+0101111011100001110110xxxxxxxxxx  n     frecpe     d0 : d5
+0x0011101x100001110110xxxxxxxxxx  n     frecpe    dq0 : dq5 bd_sz
+0101111011111001111110xxxxxxxxxx  n     frecpx     h0 : h5
+0101111010100001111110xxxxxxxxxx  n     frecpx     s0 : s5
+0101111011100001111110xxxxxxxxxx  n     frecpx     d0 : d5
+0111111011111001110110xxxxxxxxxx  n     frsqrte    h0 : h5
+0111111010100001110110xxxxxxxxxx  n     frsqrte    s0 : s5
+0111111011100001110110xxxxxxxxxx  n     frsqrte    d0 : d5
+0x1011101x100001110110xxxxxxxxxx  n     frsqrte   dq0 : dq5 bd_sz
+0000111100xxxxxx100011xxxxxxxxxx  n     rshrn      d0 : d5 immhb
+0100111100xxxxxx100011xxxxxxxxxx  n     rshrn2     q0 : q5 immhb
+0x001110xx110000001110xxxxxxxxxx  n     saddlv    dq0 : dq5 bhsd_sz
+0101111000100000011110xxxxxxxxxx  n     sqabs     b0 : b5
+0101111001100000011110xxxxxxxxxx  n     sqabs     h0 : h5
+0101111010100000011110xxxxxxxxxx  n     sqabs     s0 : s5
+0101111011100000011110xxxxxxxxxx  n     sqabs     d0 : d5
+0x001110xx100000011110xxxxxxxxxx  n     sqabs     dq0 : dq5 bhsd_sz
+0111111011100000100110xxxxxxxxxx  n     cmle       d0 : d5
+0x101110xx100000100110xxxxxxxxxx  n     cmle      dq0 : dq5 bhsd_sz
+0111111011111000110110xxxxxxxxxx  n     fcmle      h0 : h5
+0111111010100000110110xxxxxxxxxx  n     fcmle      s0 : s5
+0111111011100000110110xxxxxxxxxx  n     fcmle      d0 : d5
+0x1011101x100000110110xxxxxxxxxx  n     fcmle     dq0 : dq5 sd_sz
+0101111011111000111010xxxxxxxxxx  n     fcmlt      h0 : h5
+0101111010100000111010xxxxxxxxxx  n     fcmlt      s0 : s5
+0101111011100000111010xxxxxxxxxx  n     fcmlt      d0 : d5
+0x0011101x100000111010xxxxxxxxxx  n     fcmlt     dq0 : dq5 sd_sz
+00011110111xxxxx001000xxxxx10000  w     fcmpe         : h5 h16
+0001111011100000001000xxxxx11000  w     fcmpe         : h5
+00011110001xxxxx001000xxxxx10000  w     fcmpe         : s5 s16
+0001111000100000001000xxxxx11000  w     fcmpe         : s5
+00011110011xxxxx001000xxxxx10000  w     fcmpe         : d5 d16
+0001111001100000001000xxxxx11000  w     fcmpe         : d5
+0111111001100001011010xxxxxxxxxx  n     fcvtxn     s0 : d5
+0010111001100001011010xxxxxxxxxx  n     fcvtxn     d0 : q5
+0110111001100001011010xxxxxxxxxx  n     fcvtxn2    q0 : q5

--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -228,7 +228,8 @@ x----------xxxxx----------------  wx16       # W/X register (or WZR/XZR)
 # rw or wr Read and write
 # er Explicit/direct read (currently only MRS instruction)
 # ew Explicit/direct write (currently only MSR instruction)
-
+#    Note that currently explicit/direct reads and writes to instr_t.eflags are
+#    handled in codec.c's decode_common() function.
 
 # Data Processing - Immediate
 


### PR DESCRIPTION
This patch adds a new field to codec.txt to make developers
explicitly specify whether an instruction touches the condition
code register.

For v8.0:
```
Read only      Write only      Read and write
adc            adds            adcs
bcond          ands            ccmn
csel           bics            ccmp
csinc          fccmp           sbcs
csinv          fccmpe
csneg          fcmp
fcsel          fcmpe
sbc            subs
mrs            msr
```

Issues: #5023, #5025