### PR TITLE
i5033: Fix intermittent crash in api.drdecode aarch64 test

### DIFF
--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -82,6 +82,8 @@ test_mov_instr_addr(void)
     instrlist_encode(GD, ilist, generated_code, true);
     protect_mem(generated_code, gencode_max_size, ALLOW_EXEC | ALLOW_READ);
 
+    __builtin___clear_cache(generated_code, generated_code + gencode_max_size);
+
     uint written = ((uint(*)(void))generated_code)();
     ASSERT(written == 0xdeadbeef);
 

--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -82,7 +82,7 @@ test_mov_instr_addr(void)
     instrlist_encode(GD, ilist, generated_code, true);
     protect_mem(generated_code, gencode_max_size, ALLOW_EXEC | ALLOW_READ);
 
-    // Make sure to flush the cache so v8.0 versions of aarch64 avoid stale icache
+    // Make sure to flush the cache to avoid stale icache
     // values which can lead to SEGFAULTs or SIGILLS on the subsequent attempted
     // execution (i#5033)
     __builtin___clear_cache(generated_code, generated_code + gencode_max_size);

--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -82,6 +82,9 @@ test_mov_instr_addr(void)
     instrlist_encode(GD, ilist, generated_code, true);
     protect_mem(generated_code, gencode_max_size, ALLOW_EXEC | ALLOW_READ);
 
+    // Make sure to flush the cache so v8.0 versions of aarch64 avoid stale icache
+    // values which can lead to SEGFAULTs or SIGILLS on the subsequent attempted
+    // execution (i#5033)
     __builtin___clear_cache(generated_code, generated_code + gencode_max_size);
 
     uint written = ((uint(*)(void))generated_code)();

--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -82,9 +82,10 @@ test_mov_instr_addr(void)
     instrlist_encode(GD, ilist, generated_code, true);
     protect_mem(generated_code, gencode_max_size, ALLOW_EXEC | ALLOW_READ);
 
-    // Make sure to flush the cache to avoid stale icache
-    // values which can lead to SEGFAULTs or SIGILLS on the subsequent attempted
-    // execution (i#5033)
+    /* Make sure to flush the cache to avoid stale icache values which
+     * can lead to SEGFAULTs or SIGILLS on the subsequent attempted
+     * execution (i#5033)
+     */
     __builtin___clear_cache(generated_code, generated_code + gencode_max_size);
 
     uint written = ((uint(*)(void))generated_code)();


### PR DESCRIPTION
This patch fixes an intermittent issue when the CI tests are run on AArch64 V8.0 machines. Depending on the compiler used to build the tests, SIGILLs or SEGFAULTS are triggered when generated code is run before the generated code is flushed from the cache. 

This change adds an explicit cache flush in the test that has been exhibiting this flaky behaviour.

Fixes #5033