### PR TITLE
i#2417: Add drcachesim.coherence to the aarch64 flaky list

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -321,6 +321,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'code_api|tool.drcachesim.threads' => 1, # i#4928
                                    'code_api,tracedump_text,tracedump_origins,syntax_intel|common.loglevel' => 1, # i#1807
                                    'code_api|tool.drcachesim.threads-with-config-file' => 1, # i#4954
+                                   'code_api|tool.drcachesim.coherence' => 1, # i#2417
                                    );
             if ($is_32) {
                 $issue_no = "#2416";


### PR DESCRIPTION
This test always fails on certain types of aarch64 hardware.