### PR TITLE
i#5067: Do not skip version in view tool

### DIFF
--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -82,7 +82,7 @@ protected:
     uint64_t num_disasm_instrs_;
     std::unordered_map<app_pc, std::string> disasm_cache_;
     memref_tid_t prev_tid_;
-    uintptr_t prev_filetype_;
+    intptr_t filetype_;
     std::unordered_set<memref_tid_t> printed_header_;
 };
 


### PR DESCRIPTION
When -skip_refs is passed, the view tool still needs to look at the
initial metadata to obtain the trace version and file type.

Tested:
Before:
  $ bin64/drrun -t drcachesim -offline -- suite/tests/bin/linux.signest
  $ bin64/drrun -t drcachesim -simulator_type view -skip_refs 100 -indir drmemtrace.linux.signest.*.dir/ 2>&1 | egrep 'version|kernel xfer'
  T1602962 <marker: version -1>
  T1602964 <marker: version -1>
  T1602964 <marker: kernel xfer from module offset +0x7fc58e2bd212 to handler>
  T1602964 <marker: kernel xfer from module offset +0x7fc58e2bd212 to handler>
  T1602964 <marker: kernel xfer from module offset +0x7fc58e2bd212 to handler>
  T1602964 <marker: kernel xfer from module offset +0x7fc58e2b87b2 to handler>
After:
  $ bin64/drrun -t drcachesim -simulator_type view -skip_refs 100 -indir drmemtrace.linux.signest.*.dir/ 2>&1 | egrep 'version|kernel xfer'
  T1602962 <marker: version 3>
  T1602964 <marker: version 3>
  T1602964 <marker: kernel xfer from 0x7fc58e2bd212 to handler>
  T1602964 <marker: kernel xfer from 0x7fc58e2bd212 to handler>
  T1602964 <marker: kernel xfer from 0x7fc58e2bd212 to handler>
  T1602964 <marker: kernel xfer from 0x7fc58e2b87b2 to handler>

Fixes #5067