### PR TITLE
Fix clang-tidy and python linter warnings

### DIFF
--- a/core/ir/aarch64/codec.py
+++ b/core/ir/aarch64/codec.py
@@ -118,7 +118,7 @@ def generate_decoder(patterns, opndsettab, opndtab, opc_props):
                     elif opc_props[m] in ["rw", "wr"]:
                         indent_append('    instr->eflags |= (EFLAGS_READ_NZCV | EFLAGS_WRITE_NZCV);')
                     elif opc_props[m] in ["er", "ew"]:
-                        indent_append('    // instr->eflags handling for %s is manually handled in codec.c\'s decode_common().' % (m))
+                        indent_append('    // instr->eflags handling for %s is manually handled in codec.c\'s decode_common().' % (m,))
                     else:
                         indent_append('    ASSERT(0);')
                 indent_append('    return decode_opnds%s(enc, dc, pc, instr, OP_%s);' %
@@ -141,7 +141,7 @@ def generate_decoder(patterns, opndsettab, opndtab, opc_props):
             if x < best_x:
                 best_b = b
                 best_x = x
-        indent_append('if ((enc >> %d & 1) == 0) {' % (best_b))
+        indent_append('if ((enc >> %d & 1) == 0) {' % (best_b,))
         pats0 = []
         pats1 = []
         for p in pats:

--- a/core/ir/instr.h
+++ b/core/ir/instr.h
@@ -251,7 +251,7 @@ typedef enum _dr_tuple_type_t {
 #define PREFIX_PRED_BITS 5
 #define PREFIX_PRED_BITPOS (32 - PREFIX_PRED_BITS)
 #define PREFIX_PRED_MASK \
-    (((1 << PREFIX_PRED_BITS) - 1) << PREFIX_PRED_BITPOS) /*0xf8000000 */
+    (((1U << PREFIX_PRED_BITS) - 1) << PREFIX_PRED_BITPOS) /*0xf8000000 */
 
 bool
 instr_branch_is_padded(instr_t *instr);

--- a/core/lib/dr_inject.h
+++ b/core/lib/dr_inject.h
@@ -153,7 +153,7 @@ DR_EXPORT
  *
  * \param[in]   wait_syscall   Syscall handling mode in inject stage.
  *                             If true, will wait for completion of ongoing syscall.
- *                             Else start inject immidiately.
+ *                             Else start inject immediately.
  *
  * \param[out]  data           An opaque pointer that should be passed to
  *                             subsequent dr_inject_* routines to refer to


### PR DESCRIPTION
Fixes a signed shift issue in instr_set_predicate().
Fixes a typo in dr_inject.h.
Fixes singleton-tuple warnings in codec.py.