### PR TITLE
i#5076 trace invariants, part 1: Generalize error reporting

### DIFF
--- a/clients/drcachesim/tests/trace_invariants.cpp
+++ b/clients/drcachesim/tests/trace_invariants.cpp
@@ -31,7 +31,6 @@
  */
 
 #include "trace_invariants.h"
-#include <assert.h>
 #include <iostream>
 #include <string.h>
 
@@ -47,6 +46,15 @@ trace_invariants_t::trace_invariants_t(bool offline, unsigned int verbose,
 
 trace_invariants_t::~trace_invariants_t()
 {
+}
+
+void
+trace_invariants_t::report_if_false(bool condition, const std::string &message)
+{
+    if (!condition) {
+        std::cerr << "Trace invariant failure: " << message << "\n";
+        abort();
+    }
 }
 
 bool
@@ -72,37 +80,44 @@ trace_invariants_t::process_memref(const memref_t &memref)
          memrefs_until_interrupt_[memref.data.tid] == 0) ||
         (instrs_until_interrupt_[memref.data.tid] == 0 &&
          memrefs_until_interrupt_[memref.data.tid] == 0)) {
-        assert((memref.marker.type == TRACE_TYPE_MARKER &&
-                memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) ||
-               // TODO i#3937: Online instr bundles currently violate this.
-               !knob_offline_);
+        report_if_false((memref.marker.type == TRACE_TYPE_MARKER &&
+                         memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) ||
+                            // TODO i#3937: Online instr bundles currently violate this.
+                            !knob_offline_,
+                        "Interruption marker mis-placed");
         instrs_until_interrupt_[memref.data.tid] = -1;
         memrefs_until_interrupt_[memref.data.tid] = -1;
     }
     if (memrefs_until_interrupt_[memref.data.tid] >= 0 &&
         (memref.data.type == TRACE_TYPE_READ || memref.data.type == TRACE_TYPE_WRITE)) {
-        assert(memrefs_until_interrupt_[memref.data.tid] != 0);
+        report_if_false(memrefs_until_interrupt_[memref.data.tid] != 0,
+                        "Interruption marker too late");
         --memrefs_until_interrupt_[memref.data.tid];
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         prev_entry_[memref.data.tid].marker.type == TRACE_TYPE_MARKER &&
         prev_entry_[memref.data.tid].marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT) {
         // The rseq marker must be immediately prior to the kernel event marker.
-        assert(memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT);
+        report_if_false(memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT,
+                        "Rseq marker not immediately prior to kernel marker");
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT) {
         // Check that the rseq final instruction was not executed: that raw2trace
         // rolled it back.
-        assert(memref.marker.marker_value != prev_instr_[memref.data.tid].instr.addr);
+        report_if_false(memref.marker.marker_value !=
+                            prev_instr_[memref.data.tid].instr.addr,
+                        "Rseq post-abort instruction not rolled back");
     }
     // Check that the signal delivery marker is immediately followed by the
     // app's signal handler, which we have annotated with "prefetcht0 [1]".
     if (memref.data.type == TRACE_TYPE_PREFETCHT0 && memref.data.addr == 1) {
-        assert(type_is_instr(prev_entry_[memref.data.tid].instr.type) &&
-               prev_prev_entry_[memref.data.tid].marker.type == TRACE_TYPE_MARKER &&
-               prev_xfer_marker_[memref.data.tid].marker.marker_type ==
-                   TRACE_MARKER_TYPE_KERNEL_EVENT);
+        report_if_false(type_is_instr(prev_entry_[memref.data.tid].instr.type) &&
+                            prev_prev_entry_[memref.data.tid].marker.type ==
+                                TRACE_TYPE_MARKER &&
+                            prev_xfer_marker_[memref.data.tid].marker.marker_type ==
+                                TRACE_MARKER_TYPE_KERNEL_EVENT,
+                        "Signal handler not immediately after signal marker");
         app_handler_pc_ = prev_entry_[memref.data.tid].instr.addr;
     }
 #endif
@@ -114,7 +129,9 @@ trace_invariants_t::process_memref(const memref_t &memref)
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_INSTRUCTION_COUNT) {
         found_instr_count_marker_[memref.marker.tid] = true;
-        assert(memref.marker.marker_value >= last_instr_count_marker_[memref.marker.tid]);
+        report_if_false(memref.marker.marker_value >=
+                            last_instr_count_marker_[memref.marker.tid],
+                        "Instr count markers not increasing");
         last_instr_count_marker_[memref.marker.tid] = memref.marker.marker_value;
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
@@ -123,14 +140,15 @@ trace_invariants_t::process_memref(const memref_t &memref)
     }
 
     if (memref.exit.type == TRACE_TYPE_THREAD_EXIT) {
-        assert(!TESTALL(OFFLINE_FILE_TYPE_FILTERED, file_type_) ||
-               found_instr_count_marker_[memref.exit.tid]);
-        assert(found_cache_line_size_marker_[memref.exit.tid]);
+        report_if_false(!TESTALL(OFFLINE_FILE_TYPE_FILTERED, file_type_) ||
+                            found_instr_count_marker_[memref.exit.tid],
+                        "Missing instr count markers");
+        report_if_false(found_cache_line_size_marker_[memref.exit.tid],
+                        "Missing cache line marker");
         if (knob_test_name_ == "filter_asm_instr_count") {
-#ifndef NDEBUG
             static constexpr int ASM_INSTR_COUNT = 133;
-#endif
-            assert(last_instr_count_marker_[memref.exit.tid] == ASM_INSTR_COUNT);
+            report_if_false(last_instr_count_marker_[memref.exit.tid] == ASM_INSTR_COUNT,
+                            "Incorrect instr count marker value");
         }
         thread_exited_[memref.exit.tid] = true;
     }
@@ -146,24 +164,27 @@ trace_invariants_t::process_memref(const memref_t &memref)
                       << " instr x" << memref.instr.size << "\n";
         }
 #ifdef UNIX
-        assert(instrs_until_interrupt_[memref.data.tid] != 0);
+        report_if_false(instrs_until_interrupt_[memref.data.tid] != 0,
+                        "Interruption marker too late");
         if (instrs_until_interrupt_[memref.data.tid] > 0)
             --instrs_until_interrupt_[memref.data.tid];
 #endif
         // Invariant: offline traces guarantee that a branch target must immediately
         // follow the branch w/ no intervening thread switch.
         if (knob_offline_ && type_is_instr_branch(prev_interleaved_instr_.instr.type)) {
-            assert(prev_interleaved_instr_.instr.tid == memref.instr.tid ||
-                   // For limited-window traces a thread might exit after a branch.
-                   thread_exited_[prev_interleaved_instr_.instr.tid] ||
-                   // The invariant is relaxed for a signal.
-                   // prev_xfer_marker_ is cleared on an instr, so if set to
-                   // non-zero it means it is immediately prior, in between
-                   // prev_interleaved_instr_ and memref.
-                   (prev_xfer_marker_[prev_interleaved_instr_.instr.tid].instr.tid ==
-                        prev_interleaved_instr_.instr.tid &&
-                    prev_xfer_marker_[prev_interleaved_instr_.instr.tid]
-                            .marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT));
+            report_if_false(
+                prev_interleaved_instr_.instr.tid == memref.instr.tid ||
+                    // For limited-window traces a thread might exit after a branch.
+                    thread_exited_[prev_interleaved_instr_.instr.tid] ||
+                    // The invariant is relaxed for a signal.
+                    // prev_xfer_marker_ is cleared on an instr, so if set to
+                    // non-zero it means it is immediately prior, in between
+                    // prev_interleaved_instr_ and memref.
+                    (prev_xfer_marker_[prev_interleaved_instr_.instr.tid].instr.tid ==
+                         prev_interleaved_instr_.instr.tid &&
+                     prev_xfer_marker_[prev_interleaved_instr_.instr.tid]
+                             .marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT),
+                "Branch target not immediately after branch");
         }
         // Invariant: non-explicit control flow (i.e., kernel-mediated) is indicated
         // by markers.
@@ -173,27 +194,28 @@ trace_invariants_t::process_memref(const memref_t &memref)
             : &prev_instr_[memref.data.tid];
         if (prev_instr_ptr->instr.addr != 0 /*first*/ &&
             !type_is_instr_branch(prev_instr_ptr->instr.type)) {
-            assert( // Filtered.
+            report_if_false( // Filtered.
                 TESTALL(OFFLINE_FILE_TYPE_FILTERED, file_type_) ||
-                // Regular fall-through.
-                (prev_instr_ptr->instr.addr + prev_instr_ptr->instr.size ==
-                 memref.instr.addr) ||
-                // String loop.
-                (prev_instr_ptr->instr.addr == memref.instr.addr &&
-                 (memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH ||
-                  // Online incorrectly marks the 1st string instr across a thread
-                  // switch as fetched.
-                  // TODO i#4915, #4948: Eliminate non-fetched and remove the underlying
-                  // instrs altogether, which would fix this for us.
-                  (!knob_offline_ &&
-                   prev_interleaved_instr_.instr.tid != memref.instr.tid))) ||
-                // Kernel-mediated, but we can't tell if we had a thread swap.
-                (prev_xfer_marker_[memref.data.tid].instr.tid != 0 &&
-                 (prev_xfer_marker_[memref.data.tid].marker.marker_type ==
-                      TRACE_MARKER_TYPE_KERNEL_EVENT ||
-                  prev_xfer_marker_[memref.data.tid].marker.marker_type ==
-                      TRACE_MARKER_TYPE_KERNEL_XFER)) ||
-                prev_instr_ptr->instr.type == TRACE_TYPE_INSTR_SYSENTER);
+                    // Regular fall-through.
+                    (prev_instr_ptr->instr.addr + prev_instr_ptr->instr.size ==
+                     memref.instr.addr) ||
+                    // String loop.
+                    (prev_instr_ptr->instr.addr == memref.instr.addr &&
+                     (memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH ||
+                      // Online incorrectly marks the 1st string instr across a thread
+                      // switch as fetched.
+                      // TODO i#4915, #4948: Eliminate non-fetched and remove the
+                      // underlying instrs altogether, which would fix this for us.
+                      (!knob_offline_ &&
+                       prev_interleaved_instr_.instr.tid != memref.instr.tid))) ||
+                    // Kernel-mediated, but we can't tell if we had a thread swap.
+                    (prev_xfer_marker_[memref.data.tid].instr.tid != 0 &&
+                     (prev_xfer_marker_[memref.data.tid].marker.marker_type ==
+                          TRACE_MARKER_TYPE_KERNEL_EVENT ||
+                      prev_xfer_marker_[memref.data.tid].marker.marker_type ==
+                          TRACE_MARKER_TYPE_KERNEL_XFER)) ||
+                    prev_instr_ptr->instr.type == TRACE_TYPE_INSTR_SYSENTER,
+                "Non-explicit control flow has no marker");
             // XXX: If we had instr decoding we could check direct branch targets
             // and look for gaps after branches.
         }
@@ -201,29 +223,31 @@ trace_invariants_t::process_memref(const memref_t &memref)
         // Ensure signal handlers return to the interruption point.
         if (prev_xfer_marker_[memref.data.tid].marker.marker_type ==
             TRACE_MARKER_TYPE_KERNEL_XFER) {
-            assert(((memref.instr.addr == prev_xfer_int_pc_[memref.data.tid].top() ||
-                     // DR hands us a different address for sysenter than the
-                     // resumption point.
-                     pre_signal_instr_[memref.data.tid].top().instr.type ==
-                         TRACE_TYPE_INSTR_SYSENTER) &&
-                    (memref.instr.addr ==
-                         pre_signal_instr_[memref.data.tid].top().instr.addr ||
-                     // Asynch will go to the subsequent instr.
-                     memref.instr.addr ==
-                         pre_signal_instr_[memref.data.tid].top().instr.addr +
-                             pre_signal_instr_[memref.data.tid].top().instr.size ||
-                     // Too hard to figure out branch targets.  We have the
-                     // prev_xfer_int_pc_ though.
-                     type_is_instr_branch(
-                         pre_signal_instr_[memref.data.tid].top().instr.type) ||
-                     pre_signal_instr_[memref.data.tid].top().instr.type ==
-                         TRACE_TYPE_INSTR_SYSENTER)) ||
-                   // Nested signal.  XXX: This only works for our annotated test
-                   // signal_invariants.
-                   memref.instr.addr == app_handler_pc_ ||
-                   // Marker for rseq abort handler.  Not as unique as a prefetch, but
-                   // we need an instruction and not a data type.
-                   memref.instr.type == TRACE_TYPE_INSTR_DIRECT_JUMP);
+            report_if_false(
+                ((memref.instr.addr == prev_xfer_int_pc_[memref.data.tid].top() ||
+                  // DR hands us a different address for sysenter than the
+                  // resumption point.
+                  pre_signal_instr_[memref.data.tid].top().instr.type ==
+                      TRACE_TYPE_INSTR_SYSENTER) &&
+                 (memref.instr.addr ==
+                      pre_signal_instr_[memref.data.tid].top().instr.addr ||
+                  // Asynch will go to the subsequent instr.
+                  memref.instr.addr ==
+                      pre_signal_instr_[memref.data.tid].top().instr.addr +
+                          pre_signal_instr_[memref.data.tid].top().instr.size ||
+                  // Too hard to figure out branch targets.  We have the
+                  // prev_xfer_int_pc_ though.
+                  type_is_instr_branch(
+                      pre_signal_instr_[memref.data.tid].top().instr.type) ||
+                  pre_signal_instr_[memref.data.tid].top().instr.type ==
+                      TRACE_TYPE_INSTR_SYSENTER)) ||
+                    // Nested signal.  XXX: This only works for our annotated test
+                    // signal_invariants.
+                    memref.instr.addr == app_handler_pc_ ||
+                    // Marker for rseq abort handler.  Not as unique as a prefetch, but
+                    // we need an instruction and not a data type.
+                    memref.instr.type == TRACE_TYPE_INSTR_DIRECT_JUMP,
+                "Signal handler return point incorrect");
             // We assume paired signal entry-exit (so no longjmp and no rseq
             // inside signal handlers).
             prev_xfer_int_pc_[memref.data.tid].pop();
@@ -253,7 +277,8 @@ trace_invariants_t::process_memref(const memref_t &memref)
 #ifdef UNIX
         if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT)
             prev_xfer_int_pc_[memref.data.tid].push(memref.marker.marker_value);
-        assert(memref.marker.marker_value != 0);
+        report_if_false(memref.marker.marker_value != 0,
+                        "Kernel event marker value missing");
         if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT &&
             // Give up on back-to-back signals.
             prev_xfer_marker_[memref.data.tid].marker.marker_type !=

--- a/clients/drcachesim/tests/trace_invariants.h
+++ b/clients/drcachesim/tests/trace_invariants.h
@@ -36,8 +36,8 @@
 #ifndef _TRACE_INVARIANTS_H_
 #define _TRACE_INVARIANTS_H_ 1
 
-#include "../analysis_tool.h"
-#include "../common/memref.h"
+#include "analysis_tool.h"
+#include "memref.h"
 #include <stack>
 #include <unordered_map>
 
@@ -52,6 +52,11 @@ public:
     print_results() override;
 
 protected:
+    // We provide this for subclasses to run these invariants with custom
+    // failure reporting.
+    virtual void
+    report_if_false(bool condition, const std::string &message);
+
     bool knob_offline_;
     unsigned int knob_verbose_;
     std::string knob_test_name_;


### PR DESCRIPTION
Replaces the use of assert() with a virtual function report_if_false()
so that subclasses can set up custom reporting.

Generalizes the includes for easier use in other build frameworks.

Issue: #5076