### PR TITLE
i#5076 trace invariants, part 2: Rename to invariant_checker

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -147,7 +147,7 @@ set(drcachesim_srcs
   )
 if (DEBUG)
   # We include the invariants analyzer for testing.
-  set(drcachesim_srcs ${drcachesim_srcs} tests/trace_invariants.cpp)
+  set(drcachesim_srcs ${drcachesim_srcs} tools/invariant_checker.cpp)
 endif ()
 add_executable(drcachesim ${drcachesim_srcs})
 # In order to embed raw2trace we need to be standalone:
@@ -211,10 +211,10 @@ install_client_nonDR_header(drmemtrace tracer/raw2trace.h)
 
 # We show one example of how to create a standalone analyzer of trace
 # files that does not need to link with DR.
-# We also use this to link in our trace_invariants sanity checker.
+# We also use this to link in our invariant_checker sanity checker.
 add_executable(histogram_launcher
   tools/histogram_launcher.cpp
-  tests/trace_invariants.cpp
+  tools/invariant_checker.cpp
   )
 target_link_libraries(histogram_launcher drmemtrace_analyzer drmemtrace_histogram
   drfrontendlib)

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -44,7 +44,7 @@
 #endif
 #include "reader/ipc_reader.h"
 #ifdef DEBUG
-#    include "tests/trace_invariants.h"
+#    include "tools/invariant_checker.h"
 #endif
 
 analyzer_multi_t::analyzer_multi_t()
@@ -174,8 +174,9 @@ analyzer_multi_t::create_analysis_tools()
     num_tools_ = 1;
 #ifdef DEBUG
     if (op_test_mode.get_value()) {
-        tools_[1] = new trace_invariants_t(op_offline.get_value(), op_verbose.get_value(),
-                                           op_test_mode_name.get_value());
+        tools_[1] =
+            new invariant_checker_t(op_offline.get_value(), op_verbose.get_value(),
+                                    op_test_mode_name.get_value());
         if (tools_[1] == NULL)
             return false;
         if (!!*tools_[1])

--- a/clients/drcachesim/tests/signal_invariants.c
+++ b/clients/drcachesim/tests/signal_invariants.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -32,7 +32,7 @@
  */
 
 /* Adapted from suite/tests/pthreads/ptsig.c, with extra cases added.
- * This is a test of signal corner cases.  It partners with trace_invariants.cpp,
+ * This is a test of signal corner cases.  It partners with invariant_checker.cpp,
  * passing annotations to indicate places to check.
  */
 

--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,7 +43,7 @@
 #include "dr_frontend.h"
 #include "analyzer.h"
 #include "histogram_create.h"
-#include "../tests/trace_invariants.h"
+#include "../tools/invariant_checker.h"
 
 #define FATAL_ERROR(msg, ...)                               \
     do {                                                    \
@@ -100,7 +100,7 @@ _tmain(int argc, const TCHAR *targv[])
         op_line_size.get_value(), op_report_top.get_value(), op_verbose.get_value());
     std::vector<analysis_tool_t *> tools;
     tools.push_back(tool1);
-    trace_invariants_t tool2(true /*offline*/, op_verbose.get_value());
+    invariant_checker_t tool2(true /*offline*/, op_verbose.get_value());
     if (op_test_mode.get_value()) {
         // We use this launcher to run tests as well:
         tools.push_back(&tool2);

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -30,12 +30,12 @@
  * DAMAGE.
  */
 
-#include "trace_invariants.h"
+#include "invariant_checker.h"
 #include <iostream>
 #include <string.h>
 
-trace_invariants_t::trace_invariants_t(bool offline, unsigned int verbose,
-                                       std::string test_name)
+invariant_checker_t::invariant_checker_t(bool offline, unsigned int verbose,
+                                         std::string test_name)
     : knob_offline_(offline)
     , knob_verbose_(verbose)
     , knob_test_name_(test_name)
@@ -44,12 +44,12 @@ trace_invariants_t::trace_invariants_t(bool offline, unsigned int verbose,
     memset(&prev_interleaved_instr_, 0, sizeof(prev_interleaved_instr_));
 }
 
-trace_invariants_t::~trace_invariants_t()
+invariant_checker_t::~invariant_checker_t()
 {
 }
 
 void
-trace_invariants_t::report_if_false(bool condition, const std::string &message)
+invariant_checker_t::report_if_false(bool condition, const std::string &message)
 {
     if (!condition) {
         std::cerr << "Trace invariant failure: " << message << "\n";
@@ -58,7 +58,7 @@ trace_invariants_t::report_if_false(bool condition, const std::string &message)
 }
 
 bool
-trace_invariants_t::process_memref(const memref_t &memref)
+invariant_checker_t::process_memref(const memref_t &memref)
 {
     if (prev_instr_.find(memref.data.tid) == prev_instr_.end()) {
 #ifdef UNIX
@@ -306,7 +306,7 @@ trace_invariants_t::process_memref(const memref_t &memref)
 }
 
 bool
-trace_invariants_t::print_results()
+invariant_checker_t::print_results()
 {
     std::cerr << "Trace invariant checks passed\n";
     return true;

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -30,22 +30,22 @@
  * DAMAGE.
  */
 
-/* trace_invariants: a memory trace invariants checker.
+/* invariant_checker: a memory trace invariants checker.
  */
 
-#ifndef _TRACE_INVARIANTS_H_
-#define _TRACE_INVARIANTS_H_ 1
+#ifndef _INVARIANT_CHECKER_H_
+#define _INVARIANT_CHECKER_H_ 1
 
 #include "analysis_tool.h"
 #include "memref.h"
 #include <stack>
 #include <unordered_map>
 
-class trace_invariants_t : public analysis_tool_t {
+class invariant_checker_t : public analysis_tool_t {
 public:
-    trace_invariants_t(bool offline = true, unsigned int verbose = 0,
-                       std::string test_name = "");
-    virtual ~trace_invariants_t();
+    invariant_checker_t(bool offline = true, unsigned int verbose = 0,
+                        std::string test_name = "");
+    virtual ~invariant_checker_t();
     bool
     process_memref(const memref_t &memref) override;
     bool
@@ -81,4 +81,4 @@ protected:
     std::unordered_map<memref_tid_t, uint64_t> last_instr_count_marker_;
 };
 
-#endif /* _TRACE_INVARIANTS_H_ */
+#endif /* _INVARIANT_CHECKER_H_ */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3344,7 +3344,7 @@ if (BUILD_CLIENTS)
       endif ()
     endif ()
 
-    # We run an app w/ kernel xfers to test trace_invariants online.
+    # We run an app w/ kernel xfers to test invariant_checker online.
     # Offline invariants are tested in the tool.histogram.offline test below.
     if (UNIX)
       # The signal_invariants asm is x86-only.  The extra checks are cross-arch
@@ -3671,7 +3671,7 @@ if (BUILD_CLIENTS)
 
     # Test the standalone histogram tool.
     # ${ci_shared_app} is already used for an offline test, so we run other apps
-    # for variety and to include threads and signals for trace_invariants.
+    # for variety and to include threads and signals for invariant_checker.
     set(histo_app ${kernel_xfer_app})
     if (WIN32)
       # winxfer produces a 500M+ trace and test taking >3mins so we narrow

--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -153,8 +153,8 @@ test_rseq_call_once(bool force_restart_in, int *completions_out, int *restarts_o
         /* Test a restart in the middle of the sequence via ud2a SIGILL. */
         "cmpb $0, %[force_restart]\n\t"
         "jz 7f\n\t"
-        /* For -test_mode trace_invariants: expect a signal after ud2a.
-         * (An alternative is to add decoding to trace_invariants but with
+        /* For -test_mode invariant_checker: expect a signal after ud2a.
+         * (An alternative is to add decoding to invariant_checker but with
          * i#2007 and other problems that liimts the test.)
          */
         "prefetcht2 1\n\t"
@@ -170,7 +170,7 @@ test_rseq_call_once(bool force_restart_in, int *completions_out, int *restarts_o
         /* clang-format off */ /* (avoid indenting next few lines) */
         ".long " STRINGIFY(RSEQ_SIG) "\n\t"
         "4:\n\t"
-        /* Start with jmp to avoid trace_invariants assert on return to u2da. */
+        /* Start with jmp to avoid invariant_checker assert on return to u2da. */
         "jmp 42f\n\t"
         "42:\n\t"
         "addl $1, %[restarts]\n\t"
@@ -218,7 +218,7 @@ test_rseq_call_once(bool force_restart_in, int *completions_out, int *restarts_o
         "ldrb w0, %[force_restart]\n\t"
         "cbz x0, 7f\n\t"
         "mov x0, #1\n\t"
-        "prfm pldl3keep, [x0]\n\t" /* See above: annotation for trace_invariants. */
+        "prfm pldl3keep, [x0]\n\t" /* See above: annotation for invariant_checker. */
         ".word 0\n\t"              /* udf */
         "7:\n\t"
         "ldr x1, %[completions]\n\t"
@@ -233,7 +233,7 @@ test_rseq_call_once(bool force_restart_in, int *completions_out, int *restarts_o
         /* clang-format off */ /* (avoid indenting next few lines) */
         ".long " STRINGIFY(RSEQ_SIG) "\n\t"
         "4:\n\t"
-        /* Start with jmp to avoid trace_invariants assert on return to udf. */
+        /* Start with jmp to avoid invariant_checker assert on return to udf. */
         "b 42f\n\t"
         "42:\n\t"
         "ldr x1, %[restarts]\n\t"
@@ -312,7 +312,7 @@ test_rseq_branches_once(bool force_restart, int *completions_out, int *restarts_
         /* Test a restart via ud2a SIGILL. */
         "cmpb $0, %[force_restart]\n\t"
         "jz 7f\n\t"
-        "prefetcht2 1\n\t" /* See above: annotation for trace_invariants. */
+        "prefetcht2 1\n\t" /* See above: annotation for invariant_checker. */
         "ud2a\n\t"
         "7:\n\t"
         "addl $1, %[completions]\n\t"
@@ -325,7 +325,7 @@ test_rseq_branches_once(bool force_restart, int *completions_out, int *restarts_
         /* clang-format off */ /* (avoid indenting next few lines) */
         ".long " STRINGIFY(RSEQ_SIG) "\n\t"
         "4:\n\t"
-        /* Start with jmp to avoid trace_invariants assert on return to u2da. */
+        /* Start with jmp to avoid invariant_checker assert on return to u2da. */
         "jmp 42f\n\t"
         "42:\n\t"
         "addl $1, %[restarts]\n\t"
@@ -378,7 +378,7 @@ test_rseq_branches_once(bool force_restart, int *completions_out, int *restarts_
         "ldrb w0, %[force_restart]\n\t"
         "cbz x0, 7f\n\t"
         "mov x0, #1\n\t"
-        "prfm pldl3keep, [x0]\n\t" /* See above: annotation for trace_invariants. */
+        "prfm pldl3keep, [x0]\n\t" /* See above: annotation for invariant_checker. */
         ".word 0\n\t"              /* udf */
         "7:\n\t"
         "ldr x1, %[completions]\n\t"
@@ -393,7 +393,7 @@ test_rseq_branches_once(bool force_restart, int *completions_out, int *restarts_
         /* clang-format off */ /* (avoid indenting next few lines) */
         ".long " STRINGIFY(RSEQ_SIG) "\n\t"
         "4:\n\t"
-        /* Start with jmp to avoid trace_invariants assert on return to udf. */
+        /* Start with jmp to avoid invariant_checker assert on return to udf. */
         "b 42f\n\t"
         "42:\n\t"
         "ldr x1, %[restarts]\n\t"
@@ -481,7 +481,7 @@ test_rseq_native_fault(void)
         /* clang-format off */ /* (avoid indenting next few lines) */
         ".long " STRINGIFY(RSEQ_SIG) "\n\t"
         "4:\n\t"
-        /* Start with jmp to avoid trace_invariants assert on return to u2da. */
+        /* Start with jmp to avoid invariant_checker assert on return to u2da. */
         "jmp 42f\n\t"
         "42:\n\t"
         "addl $1, %[restarts]\n\t"
@@ -533,7 +533,7 @@ test_rseq_native_fault(void)
         /* clang-format off */ /* (avoid indenting next few lines) */
         ".long " STRINGIFY(RSEQ_SIG) "\n\t"
         "4:\n\t"
-        /* Start with jmp to avoid trace_invariants assert on return to u2da. */
+        /* Start with jmp to avoid invariant_checker assert on return to u2da. */
         "b 42f\n\t"
         "42:\n\t"
         "ldr x1, %[restarts]\n\t"


### PR DESCRIPTION
Moves tests/trace_invariants.* to tools/invariant_checker.*.
Renames trace_invariants_t to invariant_checker_t.

Issue: #5076