### PR TITLE
i#4953 ubuntu20: Explicily invoke python2 for clang-format-diff

### DIFF
--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -77,6 +77,7 @@ jobs:
       run: ./suite/runsuite_wrapper.pl automated_ci 64_only require_format
       env:
         DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: no
+        DYNAMORIO_CLANG: yes
         CI_TRIGGER: ${{ github.event_name }}
         CI_BRANCH: ${{ github.ref }}
 

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -54,7 +54,7 @@ jobs:
   # the CI resources: 64-bit hits most clang-only warnings and 64-bit
   # is the primary target these days.
   clang-format:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -77,8 +77,6 @@ jobs:
       run: ./suite/runsuite_wrapper.pl automated_ci 64_only require_format
       env:
         DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: no
-        CC: clang-9
-        CXX: clang++-9
         CI_TRIGGER: ${{ github.event_name }}
         CI_BRANCH: ${{ github.ref }}
 

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -2274,8 +2274,7 @@ handle_callback_return(dcontext_t *dcontext)
  * caller must set up mcontext with proper system call number and arguments
  */
 void
-issue_last_system_call_from_app(dcontext_t *dcontext)
-{
+issue_last_system_call_from_app(dcontext_t *dcontext){
     LOG(THREAD, LOG_SYSCALLS, 2, "issue_last_system_call_from_app(" PIFX ")\n",
         MCXT_SYSNUM_REG(get_mcontext(dcontext)));
 

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -2274,7 +2274,8 @@ handle_callback_return(dcontext_t *dcontext)
  * caller must set up mcontext with proper system call number and arguments
  */
 void
-issue_last_system_call_from_app(dcontext_t *dcontext){
+issue_last_system_call_from_app(dcontext_t *dcontext)
+{
     LOG(THREAD, LOG_SYSCALLS, 2, "issue_last_system_call_from_app(" PIFX ")\n",
         MCXT_SYSNUM_REG(get_mcontext(dcontext)));
 

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -82,7 +82,7 @@ set(build_tests "BUILD_TESTS:BOOL=ON")
 if (arg_automated_ci)
   # XXX i#1801, i#1962: under clang we have several failing tests.  Until those are
   # fixed, our CI clang suite only builds and does not run tests.
-  if (UNIX AND NOT APPLE AND "$ENV{CC}" MATCHES "clang")
+  if (UNIX AND NOT APPLE AND "$ENV{DYNAMORIO_CLANG}" MATCHES "yes")
     set(run_tests OFF)
     message("Detected a CI clang suite: disabling running of tests")
   endif ()

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -225,11 +225,12 @@ endif ()
 if (NOT CLANG_FORMAT_DIFF)
   find_program(CLANG_FORMAT_DIFF clang-format-diff.py DOC "clang-format-diff")
 endif ()
-if (CLANG_FORMAT_DIFF)
+find_package(Python2)
+if (CLANG_FORMAT_DIFF AND Python2_FOUND)
   get_filename_component(CUR_DIR "." ABSOLUTE)
   set(diff_file "${CUR_DIR}/runsuite_diff.patch")
   file(WRITE ${diff_file} "${diff_contents}")
-  execute_process(COMMAND ${CLANG_FORMAT_DIFF} -p1
+  execute_process(COMMAND ${Python2_EXECUTABLE} ${CLANG_FORMAT_DIFF} -p1
     WORKING_DIRECTORY "${CTEST_SOURCE_DIRECTORY}"
     INPUT_FILE ${diff_file}
     RESULT_VARIABLE format_result


### PR DESCRIPTION
Locates python2 and uses it to invoke clang-format-diff for 6.0, to
support running that old version on Ubuntu 20.

Issue: #4953