### PR TITLE
i#4953 ubuntu20: Update package building to use Ubuntu 20

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -55,7 +55,7 @@ jobs:
   ###########################################################################
   # Linux x86 tarball with 64-bit and 32-bit builds:
   linux-x86:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -146,7 +146,7 @@ jobs:
   ###########################################################################
   # Linux AArch64 tarball:
   linux-aarch64:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -222,7 +222,7 @@ jobs:
   ###########################################################################
   # Linux ARM tarball (package.cmake does not support same job as AArch64):
   linux-arm:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -298,7 +298,7 @@ jobs:
   ###########################################################################
   # Android ARM tarball:
   android-arm:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -481,7 +481,7 @@ jobs:
 
   create_release:
     needs: [linux-x86, linux-aarch64, linux-arm, android-arm, windows]
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
       # We need a checkout to run git log for the version.


### PR DESCRIPTION
Upgrades the VM's used for package building from Ubuntu 16.04 to
Ubuntu 20.04.

Issue: #4953