### PR TITLE
i#4953: Upgrade some AArchXX CI jobs to use Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -160,7 +160,7 @@ jobs:
 
   # Android ARM cross-compile with gcc, no tests:
   android-arm-cross-compile:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -224,7 +224,7 @@ jobs:
 
   # AArch64 drdecode and drmemtrace on x86:
   a64-on-x86:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Upgrades Ubuntu version in android-arm-cross-compile and a64-on-x86 CI jobs on Github to 20.04. We currently use 16.04 which is going to be deprecated on Github next week.

Issue: #4953