### PR TITLE
i#4924: Enable drcachesim -test_mode in release builds

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -144,11 +144,8 @@ set(drcachesim_srcs
   simulator/analyzer_interface.cpp
   tracer/instru.cpp
   tracer/instru_online.cpp
-  )
-if (DEBUG)
-  # We include the invariants analyzer for testing.
-  set(drcachesim_srcs ${drcachesim_srcs} tools/invariant_checker.cpp)
-endif ()
+  # We include the invariants analyzer for sanity checks.
+  tools/invariant_checker.cpp)
 add_executable(drcachesim ${drcachesim_srcs})
 # In order to embed raw2trace we need to be standalone:
 configure_DynamoRIO_standalone(drcachesim)

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -43,9 +43,7 @@
 #    include "reader/compressed_file_reader.h"
 #endif
 #include "reader/ipc_reader.h"
-#ifdef DEBUG
-#    include "tools/invariant_checker.h"
-#endif
+#include "tools/invariant_checker.h"
 
 analyzer_multi_t::analyzer_multi_t()
 {
@@ -172,7 +170,6 @@ analyzer_multi_t::create_analysis_tools()
         return false;
     }
     num_tools_ = 1;
-#ifdef DEBUG
     if (op_test_mode.get_value()) {
         tools_[1] =
             new invariant_checker_t(op_offline.get_value(), op_verbose.get_value(),
@@ -189,7 +186,6 @@ analyzer_multi_t::create_analysis_tools()
         }
         num_tools_ = 2;
     }
-#endif
     return true;
 }
 

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -331,13 +331,11 @@ droption_t<bool>
                        "Show every traced call in the func_trace tool",
                        "In the func_trace tool, this controls whether every traced call "
                        "is shown or instead only aggregate statistics are shown.");
-#ifdef DEBUG
 droption_t<bool> op_test_mode(DROPTION_SCOPE_ALL, "test_mode", false, "Run sanity tests",
                               "Run extra analyses for sanity checks on the trace.");
 droption_t<std::string> op_test_mode_name(
     DROPTION_SCOPE_ALL, "test_mode_name", "", "Run custom sanity tests",
     "Run extra analyses for specific sanity checks by name on the trace.");
-#endif
 droption_t<bool> op_disable_optimizations(
     DROPTION_SCOPE_ALL, "disable_optimizations", false,
     "Disable offline trace optimizations for testing",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -104,10 +104,8 @@ extern droption_t<std::string> op_simulator_type;
 extern droption_t<unsigned int> op_verbose;
 extern droption_t<bool> op_show_func_trace;
 extern droption_t<int> op_jobs;
-#ifdef DEBUG
 extern droption_t<bool> op_test_mode;
 extern droption_t<std::string> op_test_mode_name;
-#endif
 extern droption_t<bool> op_disable_optimizations;
 extern droption_t<std::string> op_dr_root;
 extern droption_t<bool> op_dr_debug;

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -315,7 +315,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'code_api|linux.fib-conflict-early' => 1,
                                    'code_api|linux.mangle_asynch' => 1,
                                    'code_api|tool.drcachesim.phys' => 1, # i#4922
-                                   'code_api|tool.drcacheoff.rseq' => 1, # i#4924
                                    'code_api|api.rseq' => 1, # i#4923
                                    'code_api|tool.drcachesim.TLB-threads' => 1, # i#4928
                                    'code_api|tool.drcachesim.threads' => 1, # i#4928

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3199,9 +3199,6 @@ if (BUILD_CLIENTS)
     endif ()
 
     set(test_mode_flag "-test_mode")
-    if (NOT DEBUG)
-      set(test_mode_flag "")
-    endif ()
     torunonly_drcachesim(filter-simple ${ci_shared_app}
       "-L0_filter ${test_mode_flag}" "")
     if (DEBUG AND DR_HOST_X86 AND DR_HOST_X64 AND LINUX)


### PR DESCRIPTION
Makes the -test_mode option, which runs the invariant_checker tool,
available in release builds.  This fixes the drcacheoff.rseq test
failures on GA CI when rseq is actually available in our upgrade to
Ubuntu 20.04.

Removes the test failure ignore rule for Jenkins as this also fixes
the AArch64 failure for the same test.

Fixes #4924
Issue: #4924, #4953