### PR TITLE
i#5101 pcache: Fix incorrect shift bounds

### DIFF
--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -683,8 +683,8 @@ entrance_stub_target_tag(cache_pc stub, coarse_info_t *info)
      */
     if (info == NULL)
         info = get_stub_coarse_info(stub);
-    if (info->mod_shift != 0 && tag >= info->persist_base &&
-        tag < info->persist_base + (info->end_pc - info->base_pc))
+    if (info->mod_shift != 0 && tag >= info->base_pc + info->mod_shift &&
+        tag < info->end_pc + info->mod_shift)
         tag -= info->mod_shift;
     return tag;
 }

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -867,10 +867,12 @@ dispatch_enter_dynamorio(dcontext_t *dcontext)
                     coarse_info_t *info = dcontext->coarse_exit.dir_exit;
                     ASSERT(info != NULL);
                     if (info->mod_shift != 0 &&
-                        dcontext->next_tag >= info->persist_base &&
-                        dcontext->next_tag <
-                            info->persist_base + (info->end_pc - info->base_pc))
+                        dcontext->next_tag >= info->base_pc + info->mod_shift &&
+                        dcontext->next_tag < info->end_pc + info->mod_shift) {
                         dcontext->next_tag -= info->mod_shift;
+                        LOG(THREAD, LOG_INTERP, 3, "adjusted shifted-coarse tag to %p\n",
+                            dcontext->next_tag);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix a bug where the coarse base shift is not applied due to checking
the module base plus region size, instead of the persisted-region
base, which when the text segment is not at the module base is not the
same thing.

Tested on the pcache-use test, which raises an application crash on
recent Linux distros without this fix.

Fixes #5101