### PR TITLE
i#5079: Avoid skipping get_pc_thunk after redirect.

### DIFF
--- a/suite/tests/client-interface/signal.c
+++ b/suite/tests/client-interface/signal.c
@@ -57,13 +57,31 @@ static void
 }
 
 static void
-redirect_target(void)
+long_jump_to_mark(void)
+{
+    print("Redirected\n");
+    SIGLONGJMP(mark, 1);
+}
+
+static void
+hook_and_long_jump(void)
 {
     /* use 2 NOPs + call so client can locate this spot */
     NOP_NOP_CALL(foo);
 
-    print("Redirected\n");
-    SIGLONGJMP(mark, 1);
+    /* We perform the print and the long-jump in a separate routine
+     * (long_jump_to_mark) because we need to avoid accessing global
+     * objects such as 'mark' or string constants in
+     * hook_and_long_jump. This is because we use DR_SIGNAL_REDIRECT
+     * to redirect control to the start of the above nop-nop-call
+     * sequence; this ends up skipping the call to __x86.get_pc_thunk
+     * at the beginning of this routine. That call is required before
+     * global object accesses in PIC, so that they can be accessed
+     * using a fixed offset from code. We avoid skipping that
+     * required call by moving the global variable accesses to the
+     * following routine that we do execute from the beginning.
+     */
+    long_jump_to_mark();
 }
 
 static void
@@ -120,7 +138,7 @@ main(int argc, char **argv)
 
     if (SIGSETJMP(mark) == 0) {
         /* execute so that client sees the spot */
-        redirect_target();
+        hook_and_long_jump();
     }
     if (SIGSETJMP(mark) == 0) {
         print("Sending SIGUSR2\n");


### PR DESCRIPTION
Moves accesses to global variables and string constants to a separate method
that we always execute from the beginning.

Jumping to the middle of a routine using DR_SIGNAL_REDIRECT causes us to skip the
__x86.get_pc_thunk.x calls that are required before accesses to global variables
in PIC. This call allows accessing them using a fixed offset from code, by
loading the pc of code in a register. Skipping this call may cause the program
to crash due to a bad address.

This fixes the client.signal test on x86 32-bit, which would otherwise keep crashing
in an infinite loop (the crash loop is due to other setup in this test).

Issue: #5079