### PR TITLE
i#4953: Add missing KSTOP in trace building.

### DIFF
--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -55,7 +55,7 @@ defaults:
 jobs:
   # 32-bit Linux build with gcc and run tests:
   x86-32:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     # When checking out the repository that triggered a workflow, actions/checkout@v2
     # defaults to the reference or SHA for that event. See documentation for ref at

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -55,7 +55,7 @@ defaults:
 jobs:
   # 32-bit Linux build with gcc and run tests:
   x86-32:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-16.04
 
     # When checking out the repository that triggered a workflow, actions/checkout@v2
     # defaults to the reference or SHA for that event. See documentation for ref at

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -1991,6 +1991,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
                      * to last_copy, must re-clear!
                      */
                     md->last_fragment = NULL;
+                    KSTOP(trace_building);
                     return f;
                 }
                 f = md->last_fragment;


### PR DESCRIPTION
Adds a missing KSTOP in monitor_cache_enter for the case when we abort
trace building.

This was causing an assert failure in core/stats.c:361 'stop not matching TOS'
in the code_api,opt_memory|client.events test, on Ubuntu 18.04 in Github CI.

Issue: #4953