### PR TITLE
i#4953 ubuntu20: Fix bad cast in raw2trace

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1030,8 +1030,9 @@ private:
             TESTANY(OFFLINE_FILE_TYPE_FILTERED, impl()->get_file_type(tls));
         bool is_instr_only_trace =
             TESTANY(OFFLINE_FILE_TYPE_INSTRUCTION_ONLY, impl()->get_file_type(tls));
-        uint64_t cur_pc =
-            reinterpret_cast<uint64_t>(modvec_()[in_entry->pc.modidx].orig_seg_base) +
+        // Cast to unsigned pointer-sized int first to avoid sign-extending.
+        uint64_t cur_pc = static_cast<uint64_t>(reinterpret_cast<ptr_uint_t>(
+                              modvec_()[in_entry->pc.modidx].orig_seg_base)) +
             (in_entry->pc.modoffs - modvec_()[in_entry->pc.modidx].seg_offs);
         // Legacy traces need the offset, not the pc.
         uint64_t cur_offs = in_entry->pc.modoffs;
@@ -1252,7 +1253,9 @@ private:
                     // assert or check that here or in the tracer.)
                     rseq_rollback = true;
                 }
-                impl()->log(4, "Checking whether reached signal/exception %p vs cur %p\n",
+                impl()->log(4,
+                            "Checking whether reached signal/exception %p vs "
+                            "cur 0x" HEX64_FORMAT_STRING "\n",
                             marker_val, cur_pc);
                 if (marker_val == 0 || at_interrupted_pc || rseq_rollback) {
                     impl()->log(4, "Signal/exception interrupted the bb @ %p\n", cur_pc);

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -345,7 +345,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'code_api|client.drwrap-test-detach' => 1, # i#4593
                 'code_api|linux.thread-reset' => 1, # i#4604
                 'code_api|linux.clone-reset' => 1, # i#4604
-                'code_api|tool.histogram.offline' => 1, # i#4953
                 'code_api|common.decode' => 1, # i#4953
                 # These are from the long suite.
                 'common.decode-stress' => 1, # i#1807 Ignored for all options.


### PR DESCRIPTION
Fixes a raw2trace cast from 32-bit app_pc to 64-bit int that was
incorrectly sign-extending, to fix the histogram test's invariant
check failure.

Issue: #4953