### PR TITLE
i#4953 ubuntu20: Fix issues on common.decode test in x86-32

### DIFF
--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -55,7 +55,7 @@ defaults:
 jobs:
   # 32-bit Linux build with gcc and run tests:
   x86-32:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     # When checking out the repository that triggered a workflow, actions/checkout@v2
     # defaults to the reference or SHA for that event. See documentation for ref at

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -55,7 +55,7 @@ defaults:
 jobs:
   # 32-bit Linux build with gcc and run tests:
   x86-32:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-16.04
 
     # When checking out the repository that triggered a workflow, actions/checkout@v2
     # defaults to the reference or SHA for that event. See documentation for ref at

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -1991,6 +1991,7 @@ monitor_cache_enter(dcontext_t *dcontext, fragment_t *f)
                      * to last_copy, must re-clear!
                      */
                     md->last_fragment = NULL;
+                    KSTOP(trace_building);
                     return f;
                 }
                 f = md->last_fragment;

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -174,7 +174,6 @@ main(int argc, char *argv[])
     buf = allocate_mem(7 * 256 + 1, ALLOW_READ | ALLOW_WRITE | ALLOW_EXEC);
     assert(buf != NULL);
     print("Start\n");
-
 #    ifndef X64
     print("Jumping to a sequence of every addr16 modrm byte\n");
     for (j = 0; j < 256; j++) {
@@ -315,6 +314,10 @@ GLOBAL_LABEL(FUNCNAME:)
         mov      REG_XAX, ARG1
         PUSH_CALLEE_SAVED_REGS()
         PUSH_NONCALLEE_SEH(REG_XAX)
+        /* As xsp will be clobbered by the routine below, we want to
+         * preserve it now and restore later.
+         */
+        mov      REG_XSP, sp_slot
         END_PROLOG
         mov      ax, 4
         mov      bx, 8
@@ -324,6 +327,7 @@ GLOBAL_LABEL(FUNCNAME:)
         mov      di, 8
         mov      bp, 8
         CALLC0(PTRSZ [REG_XSP] /* ARG1 */)
+        mov      sp_slot, REG_XSP
         pop      REG_XAX /* arg1 */
         add      REG_XSP, 0 /* make a legal SEH64 epilog */
         POP_CALLEE_SAVED_REGS()
@@ -381,6 +385,9 @@ GLOBAL_LABEL(FUNCNAME:)
         DECLARE_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
         mov    REG_XAX, ARG1
+        PUSH_CALLEE_SAVED_REGS()
+        END_PROLOG
+
         RAW(c5) RAW(f8) RAW(90) RAW(c8)                 /* kmovw  %k0,%k1 */
         RAW(c5) RAW(f9) RAW(90) RAW(da)                 /* kmovb  %k2,%k3 */
         RAW(c4) RAW(e1) RAW(f8) RAW(90) RAW(ec)         /* kmovq  %k4,%k5 */
@@ -448,6 +455,8 @@ GLOBAL_LABEL(FUNCNAME:)
         RAW(c4) RAW(e3) RAW(79) RAW(30) RAW(da) RAW(65) /* kshiftrb $0x65,%k2,%k3 */
         RAW(c4) RAW(e3) RAW(f9) RAW(31) RAW(ec) RAW(05) /* kshiftrq $0x5,%k4,%k5 */
         RAW(c4) RAW(e3) RAW(79) RAW(31) RAW(fe) RAW(2f) /* kshiftrd $0x2f,%k6,%k7 */
+
+        POP_CALLEE_SAVED_REGS();
         ret
         END_FUNC(FUNCNAME)
 #undef FUNCNAME
@@ -829,7 +838,10 @@ jecxz_zero:
         add      REG_XSP, 0 /* make a legal SEH64 epilog */
         ret
         END_FUNC(FUNCNAME)
-
+#undef FUNCNAME
+START_DATA
+    /* Allocate enough size to hold sp reg on 32- and 64-bit. */
+    BYTES_ARR(sp_slot, 8)
 END_FILE
 /* clang-format on */
 #endif /* ASM_CODE_ONLY */


### PR DESCRIPTION
Fixes some issues related to preservation of clobbered regs in the
common.decode test, seen on the x86-32 bit suite on latest Ubuntu versions.

Preserves stack reg in a separate data var on the test_modrm16 test.

Preserves callee saved regs in the test_avx512_vex test.

Issue: #4953