### PR TITLE
i#4953 ubuntu20: Fix issues on common.decode test in x86-32.

### DIFF
--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -234,14 +234,14 @@ ASSUME fs:_DATA @N@\
         ADD_STACK_ALIGNMENT_NOSEH @N@\
         .allocstack FRAME_ALIGNMENT - ARG_SZ
 #  define END_PROLOG .endprolog
-#  define DECL_REG_SPILL_SLOT(sym) sym dword 0
+#  define DECL_REG_SPILL_SLOT(sym) sym qword 0
 # else
 #  define DECLARE_FUNC_SEH(symbol) DECLARE_FUNC(symbol)
 #  define PUSH_SEH(reg) push reg @N@ /* add a line to match x64 line count */
 #  define PUSH_NONCALLEE_SEH(reg) push reg @N@ /* add a line to match x64 line count */
 #  define ADD_STACK_ALIGNMENT ADD_STACK_ALIGNMENT_NOSEH
 #  define END_PROLOG /* nothing */
-#  define DECL_REG_SPILL_SLOT(sym) sym word 0
+#  define DECL_REG_SPILL_SLOT(sym) sym dword 0
 # endif
 /****************************************************/
 #elif defined(ASSEMBLE_WITH_NASM)

--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -128,8 +128,10 @@
 #  ifdef X64
 /* w/o the rip, gas won't use rip-rel and adds relocs that ld trips over */
 #   define SYMREF(sym) [rip + sym]
+#   define DECL_REG_SPILL_SLOT(sym) sym: .quad 0
 #  else
 #   define SYMREF(sym) [sym]
+#   define DECL_REG_SPILL_SLOT(sym) sym: .word 0
 #  endif
 # elif defined(AARCHXX)
 #  define BYTE /* nothing */
@@ -232,12 +234,14 @@ ASSUME fs:_DATA @N@\
         ADD_STACK_ALIGNMENT_NOSEH @N@\
         .allocstack FRAME_ALIGNMENT - ARG_SZ
 #  define END_PROLOG .endprolog
+#  define DECL_REG_SPILL_SLOT(sym) sym dword 0
 # else
 #  define DECLARE_FUNC_SEH(symbol) DECLARE_FUNC(symbol)
 #  define PUSH_SEH(reg) push reg @N@ /* add a line to match x64 line count */
 #  define PUSH_NONCALLEE_SEH(reg) push reg @N@ /* add a line to match x64 line count */
 #  define ADD_STACK_ALIGNMENT ADD_STACK_ALIGNMENT_NOSEH
 #  define END_PROLOG /* nothing */
+#  define DECL_REG_SPILL_SLOT(sym) sym word 0
 # endif
 /****************************************************/
 #elif defined(ASSEMBLE_WITH_NASM)
@@ -263,8 +267,10 @@ ASSUME fs:_DATA @N@\
 # define ZMMWORD zword
 # ifdef X64
 #  define SYMREF(sym) [rel GLOBAL_REF(sym)]
+#  define DECL_REG_SPILL_SLOT(sym) sym: dq 0
 # else
 #  define SYMREF(sym) [GLOBAL_REF(sym)]
+#  define DECL_REG_SPILL_SLOT(sym) sym: dd 0
 # endif
 # define HEX(n) 0x##n
 # define SEGMEM(seg,mem) [seg:mem]

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -345,7 +345,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'code_api|client.drwrap-test-detach' => 1, # i#4593
                 'code_api|linux.thread-reset' => 1, # i#4604
                 'code_api|linux.clone-reset' => 1, # i#4604
-                'code_api|common.decode' => 1, # i#4953
                 # These are from the long suite.
                 'common.decode-stress' => 1, # i#1807 Ignored for all options.
                 );

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1924,6 +1924,8 @@ if (X86) # TODO i#1551, i#1569: port asm to ARM and AArch64
   if (proc_supports_avx512)
     set_target_properties(common.decode PROPERTIES COMPILE_FLAGS "${CFLAGS_AVX512}")
   endif ()
+  # Cannot create PIE if we have a .data section in asm code.
+  append_link_flags(common.decode "-no-pie")
 endif (X86)
 if (X86)
   torunonly(common.decode-stress common.decode common/decode.c

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -841,7 +841,7 @@ jecxz_zero:
         END_FUNC(FUNCNAME)
 #undef FUNCNAME
 START_DATA
-    BYTES_ARR(sp_slot, IF_X64_ELSE(8, 4))
+    DECL_REG_SPILL_SLOT(sp_slot)
 END_FILE
 /* clang-format on */
 #endif /* ASM_CODE_ONLY */

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -841,8 +841,7 @@ jecxz_zero:
         END_FUNC(FUNCNAME)
 #undef FUNCNAME
 START_DATA
-    /* Allocate enough size to hold sp reg on 32- and 64-bit. */
-    BYTES_ARR(sp_slot, 8)
+    BYTES_ARR(sp_slot, IF_X64_ELSE(8, 4))
 END_FILE
 /* clang-format on */
 #endif /* ASM_CODE_ONLY */

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -318,7 +318,7 @@ GLOBAL_LABEL(FUNCNAME:)
         /* As xsp will be clobbered by the routine below, we want to
          * preserve it now and restore later.
          */
-        mov      REG_XSP, sp_slot
+        mov      REG_XSP, [sp_slot]
         END_PROLOG
         mov      ax, 4
         mov      bx, 8
@@ -328,7 +328,7 @@ GLOBAL_LABEL(FUNCNAME:)
         mov      di, 8
         mov      bp, 8
         CALLC0(PTRSZ [REG_XSP] /* ARG1 */)
-        mov      sp_slot, REG_XSP
+        mov      [sp_slot], REG_XSP
         pop      REG_XAX /* arg1 */
         add      REG_XSP, 0 /* make a legal SEH64 epilog */
         POP_CALLEE_SAVED_REGS()

--- a/suite/tests/common/decode.c
+++ b/suite/tests/common/decode.c
@@ -315,11 +315,11 @@ GLOBAL_LABEL(FUNCNAME:)
         mov      REG_XAX, ARG1
         PUSH_CALLEE_SAVED_REGS()
         PUSH_NONCALLEE_SEH(REG_XAX)
+        END_PROLOG
         /* As xsp will be clobbered by the routine below, we want to
          * preserve it now and restore later.
          */
         mov      REG_XSP, [sp_slot]
-        END_PROLOG
         mov      ax, 4
         mov      bx, 8
         mov      cx, 4


### PR DESCRIPTION
Fixes some issues related to preservation of regs in the common.decode
test, seen on the x86-32 bit suite on latest Ubuntu versions.

Preserves stack reg in a separate data var on the test_modrm16 test.

Preserves callee saved regs in the test_avx512_vex test.

Removes common.decode from ignore list. Verified locally that there was no
failure in 1000 runs.

Issue: #4953