### PR TITLE
i#4678: AArch64 fuzz app for drstatecmp.

### DIFF
--- a/clients/drcachesim/tests/drstatecmp-fuzz.templatex
+++ b/clients/drcachesim/tests/drstatecmp-fuzz.templatex
@@ -1,0 +1,6 @@
+Generate code
+Hit delay threshold: enabling tracing.
+Execute generated code
+All done
+---- <application exited with code 0> ----
+.*

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -2118,7 +2118,6 @@ get_imm5_offset(int val)
             return i;
         }
     }
-    ASSERT(false);
     return -1;
 }
 

--- a/core/ir/aarch64/codec.py
+++ b/core/ir/aarch64/codec.py
@@ -115,15 +115,15 @@ def generate_decoder(patterns, opndsettab, opndtab, opc_props):
     # Recursive function to generate nested conditionals in main decoder.
     def gen(c, pats, depth):
         def reorder_key(t):
-            f, v, m, t = t
-            return (m, t, f, v)
+            f, v, m, t, p = t
+            return (m, t, f, v, p)
 
         def indent_append(text):
             c.append('{}{}'.format("    " * depth, text))
 
         if len(pats) < 4:
             else_str = ""
-            for opcode_bits, opnd_bits, m, t in sorted(pats, key=reorder_key):
+            for opcode_bits, opnd_bits, m, t, p in sorted(pats, key=reorder_key):
 
                 not_zero_mask = 0
                 try:
@@ -180,7 +180,7 @@ def generate_decoder(patterns, opndsettab, opndtab, opc_props):
         for b in range(N):
             x0 = 0
             x1 = 0
-            for (f, v, _, _) in pats:
+            for (f, v, _, _, _) in pats:
                 if (1 << b) & (~f | v):
                     x0 += 1
                 if (1 << b) & (f | v):
@@ -193,7 +193,7 @@ def generate_decoder(patterns, opndsettab, opndtab, opc_props):
         pats0 = []
         pats1 = []
         for p in pats:
-            (f, v, _, _) = p
+            (f, v, _, _, _) = p
             if (1 << best_b) & (~f | v):
                 pats0.append(p)
             if (1 << best_b) & (f | v):
@@ -284,7 +284,7 @@ def generate_encoder(patterns, opndsettab, opndtab):
         c.append('')
     case = dict()
     for p in patterns:
-        (b, m, mn, f) = p
+        (b, m, mn, f, _) = p
         if not mn in case:
             case[mn] = []
         case[mn].append(p)
@@ -296,19 +296,19 @@ def generate_encoder(patterns, opndsettab, opndtab):
           '    switch (instr->opcode) {']
 
     def reorder_key(t):
-        b, m, mn, f = t
-        return (mn, f, b, m)
+        b, m, mn, f, p = t
+        return (mn, f, b, m, p)
 
     for mn in sorted(case):
         c.append('    case OP_%s:' % mn)
         pats = sorted(case[mn], key = reorder_key)
         pat1 = pats.pop()
         for p in pats:
-            (b, m, mn, f) = p
+            (b, m, mn, f, _) = p
             c.append('        enc = encode_opnds%s(pc, instr, 0x%08x, di);' % (f, b))
             c.append('        if (enc != ENCFAIL)')
             c.append('            return enc;')
-        (b, m, mn, f) = pat1
+        (b, m, mn, f, _) = pat1
         c.append('        return encode_opnds%s(pc, instr, 0x%08x, di);' % (f, b))
     c += ['    }',
           '    return ENCFAIL;',
@@ -390,6 +390,42 @@ def generate_opcode_names(patterns):
           '#endif /* OPCODE_NAMES_H */']
     return '\n'.join(c) + '\n'
 
+# Generates pairs of opcodes and masks for their operands for all the
+# side-effect-free and non-branch instructions suppported by the decoder.
+# The generated file is used by the drstatecmp-fuzz-app.
+def generate_opcode_opnd_pairs(patterns):
+    c = ['#ifndef OPCODE_OPND_PAIRS_H',
+         '#define OPCODE_OPND_PAIRS_H 1',
+         '',
+         '#include <stdint.h>',
+         '',
+         'typedef struct {',
+         '  uint32_t opcode;',
+         '  uint32_t opnd;',
+         '} opcode_opnd_pair_t;',
+         '',
+         'const opcode_opnd_pair_t fuzz_opcode_opnd_pairs[] = {']
+    # Exclude instructions with side-effects and branch instructions.
+    # Particularly,  exclude: i) Load/Stores (opcode: x1x0);
+    # ii) Branches, Exception Generating and System instructions (opcode: 101x);
+    # iii) SVE memory (opcode: 0010 and 1 for the most significant bit).
+    # The allowed instructions include all the Data Processing instructions (including
+    # the FP and SIMD ones) and the non-memory SVE instructions.
+    excluded_opcodes = re.compile('....1.0|...101.|1..0010')
+    cnt = 0;
+    for p in patterns:
+        pattern = p[4]
+        if excluded_opcodes.match(pattern):
+            continue;
+        cnt += 1;
+        c.append('/* %s */ {%s, %s},' % (p[2], bin(p[0]), bin(p[1])))
+    c += ['};',
+          '']
+    c.append('#define FUZZ_INST_CNT %d' % (cnt))
+    c += ['',
+          '#endif /* OPCODE_OPND_PAIRS_H */']
+    return '\n'.join(c) + '\n'
+
 def write_if_changed(file, data):
     try:
         if open(file, 'r').read() == data:
@@ -424,7 +460,7 @@ def read_file(path):
             (pattern, nzcv_rw_flag, opcode, dsts) = (words[0], words[1], words[2], words[3:])
             opcode_bits = int(re.sub("x", "0", pattern), 2)
             opnd_bits = int(re.sub("x", "1", re.sub("1", "0", pattern)), 2)
-            patterns.append((opcode_bits, opnd_bits, opcode, (dsts, srcs)))
+            patterns.append((opcode_bits, opnd_bits, opcode, (dsts, srcs), pattern))
             opc_props[opcode] = nzcv_rw_flag
             continue
         if re.match("^[01x]{32} +[n|r|w|rw|wr|er|ew]+ +[a-zA-Z_0-9]+ +[a-zA-Z_0-9]+", line):
@@ -432,13 +468,13 @@ def read_file(path):
             (pattern, nzcv_rw_flag, opcode, opndset) = line.split()
             opcode_bits = int(re.sub("x", "0", pattern), 2)
             opnd_bits = int(re.sub("x", "1", re.sub("1", "0", pattern)), 2)
-            patterns.append((opcode_bits, opnd_bits, opcode, opndset))
+            patterns.append((opcode_bits, opnd_bits, opcode, opndset, pattern))
             opc_props[opcode] = nzcv_rw_flag
             continue
         raise Exception('Cannot parse line: %s' % line)
     return (patterns, opndtab, opc_props)
 
-def pattern_to_str(opcode_bits, opnd_bits, opcode, opndset):
+def pattern_to_str(opcode_bits, opnd_bits, opcode, opndset, _):
     p = ''
     for i in range(N - 1, -1, -1):
         p += 'x' if (opnd_bits >> i & 1) else '%d' % (opcode_bits >> i & 1)
@@ -450,7 +486,7 @@ def pattern_to_str(opcode_bits, opnd_bits, opcode, opndset):
 
 def consistency_check(patterns, opndtab):
     for p in patterns:
-        (opcode_bits, opnd_bits, opcode, opndset) = p
+        (opcode_bits, opnd_bits, opcode, opndset, _) = p
         if not type(opndset) is str:
             (dsts, srcs) = opndset
             bits = opnd_bits
@@ -471,7 +507,7 @@ def consistency_check(patterns, opndtab):
         for j in range(i):
             if ((patterns[j][0] ^ patterns[i][0]) &
                 ~patterns[j][1] & ~patterns[i][1] == 0):
-                opcode_bits_i, opnd_bits_i, opcode_i, opndset_i = patterns[i]
+                opcode_bits_i, opnd_bits_i, opcode_i, opndset_i, _ = patterns[i]
                 print('Overlap found between:\n%s\nand\n%s' %
                       (pattern_to_str(*patterns[j]),
                       pattern_to_str(*patterns[i])))
@@ -509,7 +545,7 @@ def reorder_opnds(fixed, dsts, srcs, opndtab):
 # smallest matching instruction word.
 def opndset_naming(patterns, opndtab):
     opndsets = dict() # maps (dst, src, opnd_bits) to smallest pattern seen so far
-    for (opcode_bits, opnd_bits, opcode, opndset) in patterns:
+    for (opcode_bits, opnd_bits, opcode, opndset, _) in patterns:
         if not type(opndset) is str:
             (dsts, srcs) = opndset
             h = (' '.join(dsts), ' '.join(srcs), opnd_bits)
@@ -518,7 +554,7 @@ def opndset_naming(patterns, opndtab):
 
     opndsettab = dict() # maps generated name to original opndsets
     new_patterns = []
-    for (opcode_bits, opnd_bits, opcode, opndset) in patterns:
+    for (opcode_bits, opnd_bits, opcode, opndset, pat) in patterns:
         if type(opndset) is str:
             new_opndset = '_' + opndset
         else:
@@ -528,7 +564,7 @@ def opndset_naming(patterns, opndtab):
             reordered = reorder_opnds(ONES & ~opnd_bits, dsts, srcs, opndtab)
             if not new_opndset in opndsettab:
                 opndsettab[new_opndset] = reordered
-        new_patterns.append((opcode_bits, opnd_bits, opcode, new_opndset))
+        new_patterns.append((opcode_bits, opnd_bits, opcode, new_opndset, pat))
         enc_key = fallthrough_instr_id(opcode, opcode_bits, opnd_bits)
         if enc_key in FALLTHROUGH:
             FALLTHROUGH[enc_key].opndset = new_opndset
@@ -550,6 +586,8 @@ def main():
                      header + generate_opcodes(patterns))
     write_if_changed(os.path.join(sys.argv[2], 'opcode_names.h'),
                      header + generate_opcode_names(patterns))
+    write_if_changed(os.path.join(sys.argv[2], 'opcode_opnd_pairs.h'),
+                     header + generate_opcode_opnd_pairs(patterns))
 
 if __name__ == "__main__":
     main()

--- a/core/ir/aarch64/codec.py
+++ b/core/ir/aarch64/codec.py
@@ -394,17 +394,17 @@ def generate_opcode_names(patterns):
 # side-effect-free and non-branch instructions suppported by the decoder.
 # The generated file is used by the drstatecmp-fuzz-app.
 def generate_opcode_opnd_pairs(patterns):
-    c = ['#ifndef OPCODE_OPND_PAIRS_H',
-         '#define OPCODE_OPND_PAIRS_H 1',
+    c = ['#ifndef DR_OPCODE_OPND_PAIRS_H',
+         '#define DR_OPCODE_OPND_PAIRS_H 1',
          '',
          '#include <stdint.h>',
          '',
          'typedef struct {',
          '  uint32_t opcode;',
          '  uint32_t opnd;',
-         '} opcode_opnd_pair_t;',
+         '} dr_opcode_opnd_pair_t;',
          '',
-         'const opcode_opnd_pair_t fuzz_opcode_opnd_pairs[] = {']
+         'const dr_opcode_opnd_pair_t dr_fuzz_opcode_opnd_pairs[] = {']
     # Exclude instructions with side-effects and branch instructions.
     # Particularly,  exclude: i) Load/Stores (opcode: x1x0);
     # ii) Branches, Exception Generating and System instructions (opcode: 101x);
@@ -421,9 +421,9 @@ def generate_opcode_opnd_pairs(patterns):
         c.append('/* %s */ {%s, %s},' % (p[2], bin(p[0]), bin(p[1])))
     c += ['};',
           '']
-    c.append('#define FUZZ_INST_CNT %d' % (cnt))
+    c.append('#define DR_FUZZ_INST_CNT %d' % (cnt))
     c += ['',
-          '#endif /* OPCODE_OPND_PAIRS_H */']
+          '#endif /* DR_OPCODE_OPND_PAIRS_H */']
     return '\n'.join(c) + '\n'
 
 def write_if_changed(file, data):

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2679,6 +2679,11 @@ if (NOT AARCHXX) # TODO i#1578: Hanging on AArch64.
   endif ()
 endif ()
 
+if (AARCH64)
+  # Create a fuzzing application for stress-testing via drstatecmp.
+  add_api_exe(drstatecmp-fuzz-app client-interface/drstatecmp-fuzz-app.c ON OFF)
+endif ()
+
 # We rely on dbghelp >= 6.0 for our drsyms and sample.instrcalls tests,
 # but the system dbghelp pre-Vista is too old, so we copy one from VS.
 if ("${CMAKE_SYSTEM_VERSION}" STRLESS "6.0")
@@ -3319,6 +3324,10 @@ if (BUILD_CLIENTS)
         "-simulator_type miss_analyzer -miss_count_threshold 5000 -miss_frac_threshold 0.25" "")
     endif ()
 
+    # Stress-test drcachesim with drstatecmp checks.
+    if (AARCH64)
+      torunonly_drcachesim(drstatecmp-fuzz drstatecmp-fuzz-app "-trace_after_instrs 10M -enable_drstatecmp" "" "")
+    endif ()
     if (NOT WIN32)
       torunonly_drcachesim(drstatecmp-delay-simple ${ci_shared_app} "-trace_after_instrs 20000 -exit_after_tracing 10000 -enable_drstatecmp" "")
     endif (NOT WIN32)

--- a/suite/tests/client-interface/drstatecmp-fuzz-app.c
+++ b/suite/tests/client-interface/drstatecmp-fuzz-app.c
@@ -1,0 +1,238 @@
+/* **********************************************************
+ * Copyright (c) 2021 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Fuzzing application to stress-test DR with the drstatecmp library.
+ * Only AArch64 is currently supported.
+ */
+
+#include "configure.h"
+#include "dr_api.h"
+/* The opcode_opnd_pairs.h is generated for this fuzzer by codec.py from codec.txt. */
+#include "opcode_opnd_pairs.h"
+#include "tools.h"
+#include <assert.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+
+#define NUM_INSTS 10000
+
+#define VERBOSE 0
+
+#ifdef AARCH64
+
+static byte *generated_code;
+static size_t code_size;
+
+static jmp_buf mark;
+static sigjmp_buf sig_mark;
+
+void
+sig_segv_fpe_handler(int signal)
+{
+    siglongjmp(sig_mark, 1);
+    DR_ASSERT_MSG(false, "Shouldn't be reached");
+}
+
+void
+sigill_handler(int signal, siginfo_t *siginfo, void *uctx)
+{
+    ucontext_t *context = (ucontext_t *)uctx;
+    /* Skip illegal instructions. */
+    context->uc_mcontext.pc += 4;
+}
+
+static void
+print_instr_pc(instr_t *instr, byte *encode_pc)
+{
+    fprintf(stderr, "%p: ", encode_pc);
+    instr_disassemble(GLOBAL_DCONTEXT, instr, STDERR);
+    fprintf(stderr, "\n");
+}
+
+static byte *
+append_instr(instr_t *instr, byte *encode_pc)
+{
+#    if VERBOSE > 0
+    print_instr_pc(instr, encode_pc);
+#    endif
+    byte *nxt_pc = instr_encode(GLOBAL_DCONTEXT, instr, encode_pc);
+    assert(nxt_pc);
+    instr_destroy(GLOBAL_DCONTEXT, instr);
+    return nxt_pc;
+}
+
+static uint32_t
+rand_32b(void)
+{
+    uint32_t r = rand() & 0xff;
+    r |= (rand() & 0xff) << 8;
+    r |= (rand() & 0xff) << 16;
+    r |= (rand() & 0xff) << 24;
+    return r;
+}
+
+static uint32_t
+generate_encoded_inst(void)
+{
+    /* Pick one of the available (side-effect-free and non-branch) opcodes
+     * and randomize the non-fixed bits.
+     */
+    uint32_t opcode_pick = rand() % FUZZ_INST_CNT;
+    const opcode_opnd_pair_t opcode_opnd_pair = fuzz_opcode_opnd_pairs[opcode_pick];
+
+    uint32_t opnd_mask = opcode_opnd_pair.opnd;
+    /* Avoid registers 16-31 for Rd (special registers and callee-saved registers) to
+     * avoid causing segmentation faults and skipping checks.
+     * XXX: Could relax this constraint by pushing all callee-saved registers in a new
+     * preceding basic block and popping them in a succeeding basic block (need
+     * to be separate basic blocks since drstatecmp does not support memory operations).
+     * Encoding for register 31 for Rd should still be avoided since this encoding is used
+     * for special purposes and sometimes refers to the stack pointer or the zero
+     * register.
+     */
+    opnd_mask &= 0b01111;
+    /* Fuzz the operand bits. */
+    uint32_t fuzzed_opnd = rand_32b() & opnd_mask;
+
+    uint32_t encoded_inst = opcode_opnd_pair.opcode | fuzzed_opnd;
+    return encoded_inst;
+}
+
+static int
+check_decoded_inst(instr_t *decoded_inst)
+{
+    return instr_valid(decoded_inst) && instr_get_opcode(decoded_inst) != OP_xx &&
+        instr_raw_bits_valid(decoded_inst) && instr_operands_valid(decoded_inst);
+}
+
+static byte *
+generate_inst(byte *encode_pc)
+{
+    /* Pick a random side-effect-free and non-branch instruction. */
+    uint32_t encoded_inst = generate_encoded_inst();
+    byte encoded_inst_bytes[4];
+    for (int i = 0; i < 4; ++i, encoded_inst >>= 8)
+        encoded_inst_bytes[i] = (byte)(encoded_inst & 0xff);
+
+    /* Try to decode the randomized encoding. */
+    instr_t *decoded_inst = instr_create(GLOBAL_DCONTEXT);
+    byte *nxt_pc = decode(GLOBAL_DCONTEXT, encoded_inst_bytes, decoded_inst);
+    /* XXX: Ideally the decoder would report as erroneous any encoding leading to SIGILL.
+     * Currently, several valid decodings are illegal instructions.
+     */
+    if (nxt_pc != NULL && check_decoded_inst(decoded_inst))
+        encode_pc = append_instr(decoded_inst, encode_pc);
+    else
+        instr_destroy(GLOBAL_DCONTEXT, decoded_inst);
+
+    return encode_pc;
+}
+
+static void
+generate_code()
+{
+    /* Account for the generated insts and the final return. */
+    code_size = (NUM_INSTS + 1) * 4;
+    generated_code =
+        (byte *)allocate_mem(code_size, ALLOW_EXEC | ALLOW_READ | ALLOW_WRITE);
+    assert(generated_code != NULL);
+
+    /* Synthesize code which includes a lot of side-effect-free instructions. Only one
+     * basic block is created (linear control flow). To test clobbering of arithmetic
+     * flags conditionally-executed instructions are included.
+     */
+    byte *encode_pc = generated_code;
+    for (int i = 0; i < NUM_INSTS; ++i) {
+        encode_pc = generate_inst(encode_pc);
+    }
+
+    /* The outer level is a function. */
+    encode_pc = append_instr(XINST_CREATE_return(GLOBAL_DCONTEXT), encode_pc);
+    assert(encode_pc && encode_pc <= generated_code + code_size);
+    protect_mem(generated_code, code_size, ALLOW_EXEC | ALLOW_READ);
+}
+
+int
+main(void)
+{
+    /* XXX: this app should take in the rand seed as a parameter and print it
+     * out on an error to allow reproducibility of the exact same instruction
+     * sequence in subsequent runs.
+     */
+    srand(time(NULL));
+    /* Produce fuzzing application code. */
+    fprintf(stderr, "Generate code\n");
+    generate_code();
+
+    /* Handle execution of illegal instructions that were decodable.
+     * (fairly common).
+     */
+    struct sigaction act_ill;
+    memset(&act_ill, 0, sizeof(act_ill));
+    act_ill.sa_sigaction = (void (*)(int, siginfo_t *, void *))sigill_handler;
+    act_ill.sa_flags = SA_SIGINFO;
+    sigaction(SIGILL, &act_ill, NULL);
+
+    /* Handle seg faults and floating-point exceptions caused by the fuzzed insts
+     * (rarely occur).
+     */
+    struct sigaction act_segv_fpe;
+    memset(&act_segv_fpe, 0, sizeof(act_segv_fpe));
+    act_segv_fpe.sa_sigaction = (void (*)(int, siginfo_t *, void *))sig_segv_fpe_handler;
+    act_segv_fpe.sa_flags = SA_SIGINFO;
+    sigaction(SIGSEGV, &act_segv_fpe, NULL);
+    sigaction(SIGFPE, &act_segv_fpe, NULL);
+
+    /* Execute generated code. */
+    int executed = setjmp(mark);
+    int sig_segv_fpe_received = sigsetjmp(sig_mark, 1);
+    if (!executed && !sig_segv_fpe_received) {
+        fprintf(stderr, "Execute generated code\n");
+        ((void (*)(void))generated_code)();
+        /* Restore the environment before the execution of the generated code. */
+        longjmp(mark, 1);
+    }
+
+    /* Cleanup generated code. */
+    free_mem((char *)generated_code, code_size);
+    fprintf(stderr, "All done\n");
+    return 0;
+}
+
+#else
+/* XXX: only AArch64 supported. */
+#    error NYI
+#endif


### PR DESCRIPTION
Adds a fuzzing app for AArch64 that automatically generates from the decoding
files a random sequence of side-effect-free and non-branch instructions with 
fuzzed operands for stress-testing clients with drstatecmp. 
This enables automatic testing of even newly inserted instructions in the decoder.

Adds a drcachesim test with delayed tracing for the fuzzing app. 
Testing with an older DR version showed that this test would have eventually 
automatically detected #5023 (instrumentation-clobbering of aflags).

Originally part of #4938. 

Issue: #4678