### PR TITLE
i#5127: Avoid client aux lib query to avoid rank order

### DIFF
--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -899,14 +899,22 @@ is_in_client_lib(app_pc addr)
      * clients. If we add a callback on that event we'll have to be
      * sure to deliver it only to the right client.
      */
+    if (is_in_client_lib_ignore_aux(addr))
+        return true;
+    if (client_aux_libs != NULL && vmvector_overlap(client_aux_libs, addr, addr + 1))
+        return true;
+    return false;
+}
+
+bool
+is_in_client_lib_ignore_aux(app_pc addr)
+{
     size_t i;
     for (i = 0; i < num_client_libs; i++) {
         if ((addr >= (app_pc)client_libs[i].start) && (addr < client_libs[i].end)) {
             return true;
         }
     }
-    if (client_aux_libs != NULL && vmvector_overlap(client_aux_libs, addr, addr + 1))
-        return true;
     return false;
 }
 

--- a/core/lib/instrument.h
+++ b/core/lib/instrument.h
@@ -71,6 +71,12 @@ void
 instrument_exit(void);
 bool
 is_in_client_lib(app_pc addr);
+/* Does not consider auxiliary client libraries, avoiding a lock acquisition along
+ * the way (making this more suitable for diagnostics in sensitive locations at
+ * the downside of missing aux libs).
+ */
+bool
+is_in_client_lib_ignore_aux(app_pc addr);
 bool
 get_client_bounds(client_id_t client_id, app_pc *start /*OUT*/, app_pc *end /*OUT*/);
 const char *

--- a/core/unix/memcache.c
+++ b/core/unix/memcache.c
@@ -404,8 +404,12 @@ memcache_query_memory(const byte *pc, OUT dr_mem_info_t *out_info)
                  * r--, where /proc/maps lists it as r-x.  Infact, all regions listed in
                  * /proc/maps are executable, even guard pages --x (see case 8821)
                  */
-                /* we add the whole client lib as a single entry */
-                if (!is_in_client_lib(start) || !is_in_client_lib(end - 1)) {
+                /* We add the whole client lib as a single entry.  Unfortunately we
+                 * can't safely ask about aux client libs so we have to ignore them here
+                 * (else we hit a rank order violation: i#5127).
+                 */
+                if (!is_in_client_lib_ignore_aux(start) ||
+                    !is_in_client_lib_ignore_aux(end - 1)) {
                     SYSLOG_INTERNAL_WARNING_ONCE(
                         "get_memory_info mismatch! "
                         "(can happen if os combines entries in /proc/pid/maps)\n"


### PR DESCRIPTION
Removes the query about client aux libs from diagnostics while holding
the all_all_memory_areas lock, avoiding a rank order violation (at the
cost of a potentially spurious warnings).

Fixes #5127