### PR TITLE
i#5076 trace invariants, part 3: Add simulator_type

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -314,13 +314,15 @@ droption_t<std::string>
                           "Specifies the replacement policy for TLBs. "
                           "Supported policies: LFU (Least Frequently Used).");
 
-droption_t<std::string> op_simulator_type(
-    DROPTION_SCOPE_FRONTEND, "simulator_type", CPU_CACHE,
-    "Simulator type (" CPU_CACHE ", " MISS_ANALYZER ", " TLB ", " REUSE_DIST
-    ", " REUSE_TIME ", " HISTOGRAM ", " VIEW ", " FUNC_VIEW ", or " BASIC_COUNTS ").",
-    "Specifies the type of the simulator. "
-    "Supported types: " CPU_CACHE ", " MISS_ANALYZER ", " TLB ", " REUSE_DIST
-    ", " REUSE_TIME ", " HISTOGRAM "or " BASIC_COUNTS ".");
+droption_t<std::string>
+    op_simulator_type(DROPTION_SCOPE_FRONTEND, "simulator_type", CPU_CACHE,
+                      "Simulator type (" CPU_CACHE ", " MISS_ANALYZER ", " TLB
+                      ", " REUSE_DIST ", " REUSE_TIME ", " HISTOGRAM ", " VIEW
+                      ", " FUNC_VIEW ", " BASIC_COUNTS ", or " INVARIANT_CHECKER ").",
+                      "Specifies the type of the simulator. "
+                      "Supported types: " CPU_CACHE ", " MISS_ANALYZER ", " TLB
+                      ", " REUSE_DIST ", " REUSE_TIME ", " HISTOGRAM ", " BASIC_COUNTS
+                      ", or " INVARIANT_CHECKER ".");
 
 droption_t<unsigned int> op_verbose(DROPTION_SCOPE_ALL, "verbose", 0, 0, 64,
                                     "Verbosity level",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -51,6 +51,7 @@
 #define OPCODE_MIX "opcode_mix"
 #define VIEW "view"
 #define FUNC_VIEW "func_view"
+#define INVARIANT_CHECKER "invariant_checker"
 #define CACHE_TYPE_INSTRUCTION "instruction"
 #define CACHE_TYPE_DATA "data"
 #define CACHE_TYPE_UNIFIED "unified"

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -164,6 +164,8 @@ tools can also be created, as described in \ref sec_drcachesim_newtool.
 - \ref sec_tool_opcode_mix
 - \ref sec_tool_view
 - \ref sec_tool_func_view
+- \ref sec_tool_histogram
+- \ref sec_tool_invariant_checker
 
 \section sec_tool_cache_sim Cache Simulator
 
@@ -680,6 +682,8 @@ Function id=0: common.fib!fib
        15 returns
 \endcode
 
+\section sec_tool_histogram Cache Line Histogram
+
 The top referenced cache lines are displayed by the \p histogram tool:
 
 \code
@@ -712,6 +716,15 @@ dcache top 10
     0x7facdb6625c0: 2016
     0x7ffcc35e7e40: 1997
 \endcode
+
+\section sec_tool_invariant_checker Invariant Checker
+
+The invariant_checker tool performs sanity checks on a trace, focusing
+on program counter continuity and guarantees around kernel control
+transfer interruptions.  It optionally checks for restricted behavior
+that technically is legal but is not expected to happen in the target
+trace, helping to identify tracing problems and suitability for use of
+a trace for core simulation.
 
 ****************************************************************************
 \page sec_drcachesim_config_file Configuration File

--- a/clients/drcachesim/simulator/analyzer_interface.cpp
+++ b/clients/drcachesim/simulator/analyzer_interface.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -47,6 +47,7 @@
 #include "../tools/opcode_mix_create.h"
 #include "../tools/view_create.h"
 #include "../tools/func_view_create.h"
+#include "../tools/invariant_checker_create.h"
 #include "../tracer/raw2trace.h"
 #include <fstream>
 
@@ -199,6 +200,8 @@ drmemtrace_analysis_tool_create()
         }
         return func_view_tool_create(funclist_file_path, op_show_func_trace.get_value(),
                                      op_verbose.get_value());
+    } else if (op_simulator_type.get_value() == INVARIANT_CHECKER) {
+        return invariant_checker_create(op_offline.get_value(), op_verbose.get_value());
     } else {
         ERRMSG("Usage error: unsupported analyzer type. "
                "Please choose " CPU_CACHE ", " MISS_ANALYZER ", " TLB ", " HISTOGRAM

--- a/clients/drcachesim/tests/offline-invariant_checker.expect
+++ b/clients/drcachesim/tests/offline-invariant_checker.expect
@@ -1,0 +1,2 @@
+Hello, world!
+Trace invariant checks passed

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -31,8 +31,15 @@
  */
 
 #include "invariant_checker.h"
+#include "invariant_checker_create.h"
 #include <iostream>
 #include <string.h>
+
+analysis_tool_t *
+invariant_checker_create(bool offline, unsigned int verbose)
+{
+    return new invariant_checker_t(offline, verbose, "");
+}
 
 invariant_checker_t::invariant_checker_t(bool offline, unsigned int verbose,
                                          std::string test_name)

--- a/clients/drcachesim/tools/invariant_checker_create.h
+++ b/clients/drcachesim/tools/invariant_checker_create.h
@@ -1,0 +1,51 @@
+/* **********************************************************
+ * Copyright (c) 2021 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef _INVARIANT_CHECKER_CREATE_H_
+#define _INVARIANT_CHECKER_CREATE_H_ 1
+
+#include "analysis_tool.h"
+
+/**
+ * @file drmemtrace/invariant_checker_create.h
+ * @brief DrMemtrace trace invariant checker tool creation.
+ */
+
+/**
+ * Creates an analysis tool which performs sanity checks on a trace,
+ * focusing on program counter continuity and guarantees around kernel
+ * control transfer interruptions.
+ */
+analysis_tool_t *
+invariant_checker_create(bool offline, unsigned int verbose = 0);
+
+#endif /* _INVARIANT_CHECKER_CREATE_H_ */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3699,6 +3699,9 @@ if (BUILD_CLIENTS)
       unset(tool.drcachesim.allasm-repstr-basic-counts_rawtemp) # use preprocessor
     endif (UNIX AND X86 AND X64)
 
+    torunonly_drcacheoff(invariant_checker ${ci_shared_app}
+      "" "@-simulator_type@invariant_checker" "")
+
     # Test the standalone histogram tool.
     # ${ci_shared_app} is already used for an offline test, so we run other apps
     # for variety and to include threads and signals for invariant_checker.


### PR DESCRIPTION
Adds a new -simulator_type invariant_checker to support a user
launching the checker explicitly on a target trace.

Adds documentation on the new top-level tool.

Adds a simple sanity test of the new flag.  (The -test_mode versions
of existing tests are already stressing the actual invariant checks.)

Issue: #5076