### PR TITLE
i#2243 drcov segments: Increase drov output format version

### DIFF
--- a/clients/drcov/postprocess/drcov2lcov.cpp
+++ b/clients/drcov/postprocess/drcov2lcov.cpp
@@ -882,7 +882,7 @@ read_file_header(const char *buf)
         return NULL;
     }
     if (version != DRCOV_VERSION) {
-        if (version == 2) {
+        if (version == DRCOV_VERSION_MODULE_OFFSETS) {
             WARN(1,
                  "File is in legacy version 2 format: only code in the first "
                  "segment of each module will be reported\n");

--- a/clients/drcov/postprocess/drcov2lcov.cpp
+++ b/clients/drcov/postprocess/drcov2lcov.cpp
@@ -774,7 +774,7 @@ read_module_list(const char *buf, module_table_t ***tables, uint *num_mods)
     /* module table header */
     if (drmodtrack_offline_read(INVALID_FILE, buf, &buf, &handle, num_mods) !=
         DRCOVLIB_SUCCESS) {
-        WARN(2, "Failed to read module table");
+        WARN(1, "Failed to read module table");
         return NULL;
     }
 
@@ -878,24 +878,30 @@ read_file_header(const char *buf)
      */
     PRINT(4, "Reading version number\n");
     if (dr_sscanf(buf, "DRCOV VERSION: %u\n", &version) != 1) {
-        WARN(2, "Failed to read version number");
+        WARN(1, "Failed to read version number");
         return NULL;
     }
     if (version != DRCOV_VERSION) {
-        WARN(2, "Version mismatch: file version %d vs tool version %d\n", version,
-             DRCOV_VERSION);
-        return NULL;
+        if (version == 2) {
+            WARN(1,
+                 "File is in legacy version 2 format: only code in the first "
+                 "segment of each module will be reported\n");
+        } else {
+            WARN(1, "Version mismatch: file version %d vs tool version %d\n", version,
+                 DRCOV_VERSION);
+            return NULL;
+        }
     }
     buf = move_to_next_line(buf);
 
     /* flavor */
     PRINT(4, "Reading flavor\n");
     if (dr_sscanf(buf, "DRCOV FLAVOR: %[^\n\r]\n", str) != 1) {
-        WARN(2, "Failed to read version number");
+        WARN(1, "Failed to read version number");
         return NULL;
     }
     if (strcmp(str, DRCOV_FLAVOR) != 0) {
-        WARN(2, "Fatal file mismatch: file %s vs tool %s\n", str, DRCOV_FLAVOR);
+        WARN(1, "Fatal file mismatch: file %s vs tool %s\n", str, DRCOV_FLAVOR);
         return NULL;
     }
     buf = move_to_next_line(buf);
@@ -914,23 +920,23 @@ open_input_file(const char *fname, const char **map_out OUT, size_t *map_size OU
     ASSERT(map_out != NULL && map_size != NULL, "map_out must not be NULL");
     f = dr_open_file(fname, DR_FILE_READ | DR_FILE_ALLOW_LARGE);
     if (f == INVALID_FILE) {
-        WARN(2, "Failed to open file %s\n", fname);
+        WARN(1, "Failed to open file %s\n", fname);
         return INVALID_FILE;
     }
     if (!dr_file_size(f, &file_size)) {
-        WARN(2, "Failed to get input file size for %s\n", fname);
+        WARN(1, "Failed to get input file size for %s\n", fname);
         dr_close_file(f);
         return INVALID_FILE;
     }
     if (file_size <= MIN_LOG_FILE_SIZE) {
-        WARN(2, "File size is 0 for %s\n", fname);
+        WARN(1, "File size is 0 for %s\n", fname);
         dr_close_file(f);
         return INVALID_FILE;
     }
     *map_size = (size_t)file_size;
     map = (char *)dr_map_file(f, map_size, 0, NULL, DR_MEMPROT_READ, 0);
     if (map == NULL || (size_t)file_size > *map_size) {
-        WARN(2, "Failed to map file %s\n", fname);
+        WARN(1, "Failed to map file %s\n", fname);
         dr_close_file(f);
         return INVALID_FILE;
     }

--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -113,8 +113,11 @@ typedef struct _drcovlib_options_t {
  * make drcovlib usable in standalone mode.
  */
 
-/* file format version */
-#define DRCOV_VERSION 2
+/* File format version. */
+/* Version 3 changes module offsets to be offsets from the module segment,
+ * rather than the whole module base as in version 2.
+ */
+#define DRCOV_VERSION 3
 
 /* i#1532: drsyms can't mix arch for ELF */
 #ifdef LINUX

--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -114,10 +114,12 @@ typedef struct _drcovlib_options_t {
  */
 
 /* File format version. */
+#define DRCOV_VERSION_MODULE_OFFSETS 2
 /* Version 3 changes module offsets to be offsets from the module segment,
  * rather than the whole module base as in version 2.
  */
-#define DRCOV_VERSION 3
+#define DRCOV_VERSION_SEGMENT_OFFSETS 3
+#define DRCOV_VERSION DRCOV_VERSION_SEGMENT_OFFSETS
 
 /* i#1532: drsyms can't mix arch for ELF */
 #ifdef LINUX


### PR DESCRIPTION
PR #5094 added support for non-first-segment-code in drcov by changing
the drcov output format.  It should have bumped its file format
version; we do that here.

drcov2lcov prints a warning but continues if passed the prior version,
as we expect it to work for cases that worked before: code in the
first segment.  An old build of drcov2lcov would have failed on the
different module table format in any case; now it gives a better error
message about a version change.

Reduces the warning level to 1 for the fatal warnings opening files to
make them more visible.

Tested on a version 2 file from an 8.0 run on a +rx-first-segment application:
    $ clients/bin64/drcov2lcov -input ~/dr/releases/DynamoRIO-Linux-8.0.0-1/drcov*.log && grep -A 5 hello coverage.info
    [6/6] Generating embed/html/index.html
    [DRCOV2LCOV] WARNING(1): No output file name specified: using default coverage.info
    [DRCOV2LCOV] INFO(1):    Reading input files...
    [DRCOV2LCOV] WARNING(1): File is in legacy version 2 format: only code in the first segment of each module will be reported
    [DRCOV2LCOV] INFO(1):    Enumerating line info...
    [DRCOV2LCOV] WARNING(1): Failed to enumerate lines for [vdso]
    [DRCOV2LCOV] WARNING(1): Failed to enumerate lines for [vdso]
    [DRCOV2LCOV] INFO(1):    Writing output file...
    SF:/home/derek/hello.c
    DA:4,1
    DA:5,1
    DA:6,1
    DA:7,1
    DA:8,1

Issue: #2243