### PR TITLE
i#5076 trace invariants, part 5: Parallelize over shards

### DIFF
--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -78,6 +78,9 @@ droption_t<unsigned int> op_verbose(DROPTION_SCOPE_ALL, "verbose", 0, 0, 64,
 // For test simplicity we use this same launcher to run some extra tests.
 droption_t<bool> op_test_mode(DROPTION_SCOPE_ALL, "test_mode", false, "Run tests",
                               "Run extra analyses for testing.");
+droption_t<std::string> op_test_mode_name(DROPTION_SCOPE_ALL, "test_mode_name", "",
+                                          "Test name",
+                                          "Name of extra analyses for testing.");
 
 int
 _tmain(int argc, const TCHAR *targv[])
@@ -100,7 +103,8 @@ _tmain(int argc, const TCHAR *targv[])
         op_line_size.get_value(), op_report_top.get_value(), op_verbose.get_value());
     std::vector<analysis_tool_t *> tools;
     tools.push_back(tool1);
-    invariant_checker_t tool2(true /*offline*/, op_verbose.get_value());
+    invariant_checker_t tool2(true /*offline*/, op_verbose.get_value(),
+                              op_test_mode_name.get_value());
     if (op_test_mode.get_value()) {
         // We use this launcher to run tests as well:
         tools.push_back(&tool2);

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -48,7 +48,8 @@ invariant_checker_t::invariant_checker_t(bool offline, unsigned int verbose,
     , knob_test_name_(test_name)
     , app_handler_pc_(0)
 {
-    memset(&prev_interleaved_instr_, 0, sizeof(prev_interleaved_instr_));
+    if (knob_test_name_ == "kernel_xfer_app" || knob_test_name_ == "rseq_app")
+        has_annotations_ = true;
 }
 
 invariant_checker_t::~invariant_checker_t()
@@ -65,45 +66,89 @@ invariant_checker_t::report_if_false(bool condition, const std::string &message)
 }
 
 bool
-invariant_checker_t::process_memref(const memref_t &memref)
+invariant_checker_t::parallel_shard_supported()
 {
-    if (prev_instr_.find(memref.data.tid) == prev_instr_.end()) {
+    return true;
+}
+
+void *
+invariant_checker_t::parallel_shard_init(int shard_index, void *worker_data)
+{
+    auto per_shard = std::unique_ptr<per_shard_t>(new per_shard_t);
+    void *res = reinterpret_cast<void *>(per_shard.get());
+    std::lock_guard<std::mutex> guard(shard_map_mutex_);
+    shard_map_[shard_index] = std::move(per_shard);
+    return res;
+}
+
+bool
+invariant_checker_t::parallel_shard_exit(void *shard_data)
+{
+    return true;
+}
+
+std::string
+invariant_checker_t::parallel_shard_error(void *shard_data)
+{
+    per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
+    return shard->error;
+}
+
+bool
+invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
+{
+    per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
 #ifdef UNIX
-        instrs_until_interrupt_[memref.data.tid] = -1;
-        memrefs_until_interrupt_[memref.data.tid] = -1;
-        prev_entry_[memref.data.tid] = {};
-        prev_prev_entry_[memref.data.tid] = {};
-#endif
-        prev_instr_[memref.data.tid] = {};
-        prev_xfer_marker_[memref.data.tid] = {};
-    }
-#ifdef UNIX
-    // Check conditions specific to the signal_invariants app, where it
-    // has annotations in prefetch instructions telling us how many instrs
-    // and/or memrefs until a signal should arrive.
-    if ((instrs_until_interrupt_[memref.data.tid] == 0 &&
-         memrefs_until_interrupt_[memref.data.tid] == -1) ||
-        (instrs_until_interrupt_[memref.data.tid] == -1 &&
-         memrefs_until_interrupt_[memref.data.tid] == 0) ||
-        (instrs_until_interrupt_[memref.data.tid] == 0 &&
-         memrefs_until_interrupt_[memref.data.tid] == 0)) {
-        report_if_false((memref.marker.type == TRACE_TYPE_MARKER &&
-                         memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) ||
-                            // TODO i#3937: Online instr bundles currently violate this.
-                            !knob_offline_,
-                        "Interruption marker mis-placed");
-        instrs_until_interrupt_[memref.data.tid] = -1;
-        memrefs_until_interrupt_[memref.data.tid] = -1;
-    }
-    if (memrefs_until_interrupt_[memref.data.tid] >= 0 &&
-        (memref.data.type == TRACE_TYPE_READ || memref.data.type == TRACE_TYPE_WRITE)) {
-        report_if_false(memrefs_until_interrupt_[memref.data.tid] != 0,
-                        "Interruption marker too late");
-        --memrefs_until_interrupt_[memref.data.tid];
+    if (has_annotations_) {
+        // Check conditions specific to the signal_invariants app, where it
+        // has annotations in prefetch instructions telling us how many instrs
+        // and/or memrefs until a signal should arrive.
+        if ((shard->instrs_until_interrupt_ == 0 &&
+             shard->memrefs_until_interrupt_ == -1) ||
+            (shard->instrs_until_interrupt_ == -1 &&
+             shard->memrefs_until_interrupt_ == 0) ||
+            (shard->instrs_until_interrupt_ == 0 &&
+             shard->memrefs_until_interrupt_ == 0)) {
+            report_if_false(
+                (memref.marker.type == TRACE_TYPE_MARKER &&
+                 memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) ||
+                    // TODO i#3937: Online instr bundles currently violate this.
+                    !knob_offline_,
+                "Interruption marker mis-placed");
+            shard->instrs_until_interrupt_ = -1;
+            shard->memrefs_until_interrupt_ = -1;
+        }
+        if (shard->memrefs_until_interrupt_ >= 0 &&
+            (memref.data.type == TRACE_TYPE_READ ||
+             memref.data.type == TRACE_TYPE_WRITE)) {
+            report_if_false(shard->memrefs_until_interrupt_ != 0,
+                            "Interruption marker too late");
+            --shard->memrefs_until_interrupt_;
+        }
+        // Check that the signal delivery marker is immediately followed by the
+        // app's signal handler, which we have annotated with "prefetcht0 [1]".
+        if (memref.data.type == TRACE_TYPE_PREFETCHT0 && memref.data.addr == 1) {
+            report_if_false(type_is_instr(shard->prev_entry_.instr.type) &&
+                                shard->prev_prev_entry_.marker.type ==
+                                    TRACE_TYPE_MARKER &&
+                                shard->prev_xfer_marker_.marker.marker_type ==
+                                    TRACE_MARKER_TYPE_KERNEL_EVENT,
+                            "Signal handler not immediately after signal marker");
+            app_handler_pc_ = shard->prev_entry_.instr.addr;
+        }
+        // Look for annotations where signal_invariants.c and rseq.c pass info to us on
+        // what to check for.  We assume the app does not have prefetch instrs w/ low
+        // addresses.
+        if (memref.data.type == TRACE_TYPE_PREFETCHT2 && memref.data.addr < 1024) {
+            shard->instrs_until_interrupt_ = static_cast<int>(memref.data.addr);
+        }
+        if (memref.data.type == TRACE_TYPE_PREFETCHT1 && memref.data.addr < 1024) {
+            shard->memrefs_until_interrupt_ = static_cast<int>(memref.data.addr);
+        }
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
-        prev_entry_[memref.data.tid].marker.type == TRACE_TYPE_MARKER &&
-        prev_entry_[memref.data.tid].marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT) {
+        shard->prev_entry_.marker.type == TRACE_TYPE_MARKER &&
+        shard->prev_entry_.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT) {
         // The rseq marker must be immediately prior to the kernel event marker.
         report_if_false(memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT,
                         "Rseq marker not immediately prior to kernel marker");
@@ -112,20 +157,8 @@ invariant_checker_t::process_memref(const memref_t &memref)
         memref.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT) {
         // Check that the rseq final instruction was not executed: that raw2trace
         // rolled it back.
-        report_if_false(memref.marker.marker_value !=
-                            prev_instr_[memref.data.tid].instr.addr,
+        report_if_false(memref.marker.marker_value != shard->prev_instr_.instr.addr,
                         "Rseq post-abort instruction not rolled back");
-    }
-    // Check that the signal delivery marker is immediately followed by the
-    // app's signal handler, which we have annotated with "prefetcht0 [1]".
-    if (memref.data.type == TRACE_TYPE_PREFETCHT0 && memref.data.addr == 1) {
-        report_if_false(type_is_instr(prev_entry_[memref.data.tid].instr.type) &&
-                            prev_prev_entry_[memref.data.tid].marker.type ==
-                                TRACE_TYPE_MARKER &&
-                            prev_xfer_marker_[memref.data.tid].marker.marker_type ==
-                                TRACE_MARKER_TYPE_KERNEL_EVENT,
-                        "Signal handler not immediately after signal marker");
-        app_handler_pc_ = prev_entry_[memref.data.tid].instr.addr;
     }
 #endif
 
@@ -135,29 +168,27 @@ invariant_checker_t::process_memref(const memref_t &memref)
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_INSTRUCTION_COUNT) {
-        found_instr_count_marker_[memref.marker.tid] = true;
-        report_if_false(memref.marker.marker_value >=
-                            last_instr_count_marker_[memref.marker.tid],
+        shard->found_instr_count_marker_ = true;
+        report_if_false(memref.marker.marker_value >= shard->last_instr_count_marker_,
                         "Instr count markers not increasing");
-        last_instr_count_marker_[memref.marker.tid] = memref.marker.marker_value;
+        shard->last_instr_count_marker_ = memref.marker.marker_value;
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_CACHE_LINE_SIZE) {
-        found_cache_line_size_marker_[memref.marker.tid] = true;
+        shard->found_cache_line_size_marker_ = true;
     }
 
     if (memref.exit.type == TRACE_TYPE_THREAD_EXIT) {
         report_if_false(!TESTALL(OFFLINE_FILE_TYPE_FILTERED, file_type_) ||
-                            found_instr_count_marker_[memref.exit.tid],
+                            shard->found_instr_count_marker_,
                         "Missing instr count markers");
-        report_if_false(found_cache_line_size_marker_[memref.exit.tid],
+        report_if_false(shard->found_cache_line_size_marker_,
                         "Missing cache line marker");
         if (knob_test_name_ == "filter_asm_instr_count") {
             static constexpr int ASM_INSTR_COUNT = 133;
-            report_if_false(last_instr_count_marker_[memref.exit.tid] == ASM_INSTR_COUNT,
+            report_if_false(shard->last_instr_count_marker_ == ASM_INSTR_COUNT,
                             "Incorrect instr count marker value");
         }
-        thread_exited_[memref.exit.tid] = true;
     }
     if (type_is_instr(memref.instr.type) ||
         memref.instr.type == TRACE_TYPE_PREFETCH_INSTR ||
@@ -171,85 +202,76 @@ invariant_checker_t::process_memref(const memref_t &memref)
                       << " instr x" << memref.instr.size << "\n";
         }
 #ifdef UNIX
-        report_if_false(instrs_until_interrupt_[memref.data.tid] != 0,
+        report_if_false(shard->instrs_until_interrupt_ != 0,
                         "Interruption marker too late");
-        if (instrs_until_interrupt_[memref.data.tid] > 0)
-            --instrs_until_interrupt_[memref.data.tid];
+        if (shard->instrs_until_interrupt_ > 0)
+            --shard->instrs_until_interrupt_;
 #endif
         // Invariant: offline traces guarantee that a branch target must immediately
         // follow the branch w/ no intervening thread switch.
-        if (knob_offline_ && type_is_instr_branch(prev_interleaved_instr_.instr.type)) {
-            report_if_false(
-                prev_interleaved_instr_.instr.tid == memref.instr.tid ||
-                    // For limited-window traces a thread might exit after a branch.
-                    thread_exited_[prev_interleaved_instr_.instr.tid] ||
-                    // The invariant is relaxed for a signal.
-                    // prev_xfer_marker_ is cleared on an instr, so if set to
-                    // non-zero it means it is immediately prior, in between
-                    // prev_interleaved_instr_ and memref.
-                    (prev_xfer_marker_[prev_interleaved_instr_.instr.tid].instr.tid ==
-                         prev_interleaved_instr_.instr.tid &&
-                     prev_xfer_marker_[prev_interleaved_instr_.instr.tid]
-                             .marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT),
-                "Branch target not immediately after branch");
+        // If we did serial analyses only, we'd just track the previous instr in the
+        // interleaved stream.  Here we look for headers indicating where an interleaved
+        // stream *could* switch threads, so we're stricter than necessary.
+        if (knob_offline_ && type_is_instr_branch(shard->prev_instr_.instr.type)) {
+            report_if_false(!shard->saw_timestamp_but_no_instr_ ||
+                                // The invariant is relaxed for a signal.
+                                // prev_xfer_marker_ is cleared on an instr, so if set to
+                                // non-zero it means it is immediately prior, in between
+                                // prev_instr_ and memref.
+                                shard->prev_xfer_marker_.marker.marker_type ==
+                                    TRACE_MARKER_TYPE_KERNEL_EVENT,
+                            "Branch target not immediately after branch");
         }
         // Invariant: non-explicit control flow (i.e., kernel-mediated) is indicated
         // by markers.
-        // We cache the prev_instr_ hash lookup to avoid large slowdowns on Windows.
-        memref_t *prev_instr_ptr = prev_interleaved_instr_.instr.tid == memref.instr.tid
-            ? &prev_interleaved_instr_
-            : &prev_instr_[memref.data.tid];
-        if (prev_instr_ptr->instr.addr != 0 /*first*/ &&
-            !type_is_instr_branch(prev_instr_ptr->instr.type)) {
+        if (shard->prev_instr_.instr.addr != 0 /*first*/ &&
+            !type_is_instr_branch(shard->prev_instr_.instr.type)) {
             report_if_false( // Filtered.
                 TESTALL(OFFLINE_FILE_TYPE_FILTERED, file_type_) ||
                     // Regular fall-through.
-                    (prev_instr_ptr->instr.addr + prev_instr_ptr->instr.size ==
+                    (shard->prev_instr_.instr.addr + shard->prev_instr_.instr.size ==
                      memref.instr.addr) ||
                     // String loop.
-                    (prev_instr_ptr->instr.addr == memref.instr.addr &&
+                    (shard->prev_instr_.instr.addr == memref.instr.addr &&
                      (memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH ||
                       // Online incorrectly marks the 1st string instr across a thread
                       // switch as fetched.
                       // TODO i#4915, #4948: Eliminate non-fetched and remove the
                       // underlying instrs altogether, which would fix this for us.
-                      (!knob_offline_ &&
-                       prev_interleaved_instr_.instr.tid != memref.instr.tid))) ||
+                      (!knob_offline_ && shard->saw_timestamp_but_no_instr_))) ||
                     // Kernel-mediated, but we can't tell if we had a thread swap.
-                    (prev_xfer_marker_[memref.data.tid].instr.tid != 0 &&
-                     (prev_xfer_marker_[memref.data.tid].marker.marker_type ==
+                    (shard->prev_xfer_marker_.instr.tid != 0 &&
+                     (shard->prev_xfer_marker_.marker.marker_type ==
                           TRACE_MARKER_TYPE_KERNEL_EVENT ||
-                      prev_xfer_marker_[memref.data.tid].marker.marker_type ==
+                      shard->prev_xfer_marker_.marker.marker_type ==
                           TRACE_MARKER_TYPE_KERNEL_XFER)) ||
-                    prev_instr_ptr->instr.type == TRACE_TYPE_INSTR_SYSENTER,
+                    shard->prev_instr_.instr.type == TRACE_TYPE_INSTR_SYSENTER,
                 "Non-explicit control flow has no marker");
             // XXX: If we had instr decoding we could check direct branch targets
             // and look for gaps after branches.
         }
 #ifdef UNIX
         // Ensure signal handlers return to the interruption point.
-        if (prev_xfer_marker_[memref.data.tid].marker.marker_type ==
+        if (shard->prev_xfer_marker_.marker.marker_type ==
             TRACE_MARKER_TYPE_KERNEL_XFER) {
             report_if_false(
-                ((memref.instr.addr == prev_xfer_int_pc_[memref.data.tid].top() ||
+                ((memref.instr.addr == shard->prev_xfer_int_pc_.top() ||
                   // DR hands us a different address for sysenter than the
                   // resumption point.
-                  pre_signal_instr_[memref.data.tid].top().instr.type ==
+                  shard->pre_signal_instr_.top().instr.type ==
                       TRACE_TYPE_INSTR_SYSENTER) &&
-                 (memref.instr.addr ==
-                      pre_signal_instr_[memref.data.tid].top().instr.addr ||
+                 (memref.instr.addr == shard->pre_signal_instr_.top().instr.addr ||
                   // Asynch will go to the subsequent instr.
                   memref.instr.addr ==
-                      pre_signal_instr_[memref.data.tid].top().instr.addr +
-                          pre_signal_instr_[memref.data.tid].top().instr.size ||
+                      shard->pre_signal_instr_.top().instr.addr +
+                          shard->pre_signal_instr_.top().instr.size ||
                   // Too hard to figure out branch targets.  We have the
                   // prev_xfer_int_pc_ though.
-                  type_is_instr_branch(
-                      pre_signal_instr_[memref.data.tid].top().instr.type) ||
-                  pre_signal_instr_[memref.data.tid].top().instr.type ==
+                  type_is_instr_branch(shard->pre_signal_instr_.top().instr.type) ||
+                  shard->pre_signal_instr_.top().instr.type ==
                       TRACE_TYPE_INSTR_SYSENTER)) ||
                     // Nested signal.  XXX: This only works for our annotated test
-                    // signal_invariants.
+                    // signal_invariants where we know app_handler_pc_.
                     memref.instr.addr == app_handler_pc_ ||
                     // Marker for rseq abort handler.  Not as unique as a prefetch, but
                     // we need an instruction and not a data type.
@@ -257,19 +279,23 @@ invariant_checker_t::process_memref(const memref_t &memref)
                 "Signal handler return point incorrect");
             // We assume paired signal entry-exit (so no longjmp and no rseq
             // inside signal handlers).
-            prev_xfer_int_pc_[memref.data.tid].pop();
-            pre_signal_instr_[memref.data.tid].pop();
+            shard->prev_xfer_int_pc_.pop();
+            shard->pre_signal_instr_.pop();
         }
 #endif
-        prev_interleaved_instr_ = memref;
         // These 2 hash assignments cause a 2.5x slowdown for this test on Windows.
         // We have as many other hash lookups as we can under UNIX.
         // We could try to only update on a tid change to further reduce overhead.
-        prev_instr_[memref.data.tid] = memref;
+        shard->prev_instr_ = memref;
         // Clear prev_xfer_marker_ on an instr (not a memref which could come between an
         // instr and a kernel-mediated far-away instr) to ensure it's *immediately*
         // prior (i#3937).
-        prev_xfer_marker_[memref.data.tid] = {};
+        shard->prev_xfer_marker_.marker.marker_type = TRACE_MARKER_TYPE_VERSION;
+        shard->saw_timestamp_but_no_instr_ = false;
+    }
+    if (memref.marker.type == TRACE_TYPE_MARKER &&
+        memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP) {
+        shard->saw_timestamp_but_no_instr_ = true;
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         // Ignore timestamp, etc. markers which show up a signal delivery boundaries
@@ -283,32 +309,40 @@ invariant_checker_t::process_memref(const memref_t &memref)
         }
 #ifdef UNIX
         if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT)
-            prev_xfer_int_pc_[memref.data.tid].push(memref.marker.marker_value);
+            shard->prev_xfer_int_pc_.push(memref.marker.marker_value);
         report_if_false(memref.marker.marker_value != 0,
                         "Kernel event marker value missing");
         if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT &&
             // Give up on back-to-back signals.
-            prev_xfer_marker_[memref.data.tid].marker.marker_type !=
-                TRACE_MARKER_TYPE_KERNEL_XFER)
-            pre_signal_instr_[memref.data.tid].push(prev_instr_[memref.data.tid]);
+            shard->prev_xfer_marker_.marker.marker_type != TRACE_MARKER_TYPE_KERNEL_XFER)
+            shard->pre_signal_instr_.push(shard->prev_instr_);
 #endif
-        prev_xfer_marker_[memref.data.tid] = memref;
+        shard->prev_xfer_marker_ = memref;
     }
 
 #ifdef UNIX
-    // Look for annotations where signal_invariants.c and rseq.c pass info to us on what
-    // to check for.  We assume the app does not have prefetch instrs w/ low addresses.
-    if (memref.data.type == TRACE_TYPE_PREFETCHT2 && memref.data.addr < 1024) {
-        instrs_until_interrupt_[memref.data.tid] = static_cast<int>(memref.data.addr);
-    }
-    if (memref.data.type == TRACE_TYPE_PREFETCHT1 && memref.data.addr < 1024) {
-        memrefs_until_interrupt_[memref.data.tid] = static_cast<int>(memref.data.addr);
-    }
-
-    prev_prev_entry_[memref.data.tid] = prev_entry_[memref.data.tid];
-    prev_entry_[memref.data.tid] = memref;
+    shard->prev_prev_entry_ = shard->prev_entry_;
+    shard->prev_entry_ = memref;
 #endif
 
+    return true;
+}
+
+bool
+invariant_checker_t::process_memref(const memref_t &memref)
+{
+    per_shard_t *per_shard;
+    const auto &lookup = shard_map_.find(memref.data.tid);
+    if (lookup == shard_map_.end()) {
+        auto per_shard_unique = std::unique_ptr<per_shard_t>(new per_shard_t);
+        per_shard = per_shard_unique.get();
+        shard_map_[memref.data.tid] = std::move(per_shard_unique);
+    } else
+        per_shard = lookup->second.get();
+    if (!parallel_shard_memref(reinterpret_cast<void *>(per_shard), memref)) {
+        error_string_ = per_shard->error;
+        return false;
+    }
     return true;
 }
 

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -38,6 +38,7 @@
 
 #include "analysis_tool.h"
 #include "memref.h"
+#include <mutex>
 #include <stack>
 #include <unordered_map>
 
@@ -50,35 +51,63 @@ public:
     process_memref(const memref_t &memref) override;
     bool
     print_results() override;
+    bool
+    parallel_shard_supported() override;
+    void *
+    parallel_shard_init(int shard_index, void *worker_data) override;
+    bool
+    parallel_shard_exit(void *shard_data) override;
+    bool
+    parallel_shard_memref(void *shard_data, const memref_t &memref) override;
+    std::string
+    parallel_shard_error(void *shard_data) override;
 
 protected:
+    // For performance we support parallel analysis.
+    // Most checks are thread-local; for thread switch checks we rely
+    // on identifying thread switch points via timestamp entries.
+    struct per_shard_t {
+        per_shard_t()
+        {
+            // We need a sentinel different from type 0.
+            prev_xfer_marker_.marker.marker_type = TRACE_MARKER_TYPE_VERSION;
+        }
+        memref_t prev_instr_ = {};
+        memref_t prev_xfer_marker_ = {};
+#ifdef UNIX
+        // We only support sigreturn-using handlers so we have pairing: no longjmp.
+        std::stack<addr_t> prev_xfer_int_pc_;
+        memref_t prev_entry_ = {};
+        memref_t prev_prev_entry_ = {};
+        std::stack<memref_t> pre_signal_instr_;
+        // These are only available via annotations in signal_invariants.cpp.
+        int instrs_until_interrupt_ = -1;
+        int memrefs_until_interrupt_ = -1;
+#endif
+        bool saw_timestamp_but_no_instr_ = false;
+        bool found_cache_line_size_marker_ = false;
+        bool found_instr_count_marker_ = false;
+        uint64_t last_instr_count_marker_ = 0;
+        std::string error;
+    };
+
     // We provide this for subclasses to run these invariants with custom
     // failure reporting.
     virtual void
     report_if_false(bool condition, const std::string &message);
 
+    // The keys here are int for parallel, tid for serial.
+    std::unordered_map<memref_tid_t, std::unique_ptr<per_shard_t>> shard_map_;
+    // This mutex is only needed in parallel_shard_init.  In all other accesses to
+    // shard_map (process_memref, print_results) we are single-threaded.
+    std::mutex shard_map_mutex_;
+
     bool knob_offline_;
     unsigned int knob_verbose_;
     std::string knob_test_name_;
-    memref_t prev_interleaved_instr_;
-    std::unordered_map<memref_tid_t, memref_t> prev_instr_;
-    std::unordered_map<memref_tid_t, memref_t> prev_xfer_marker_;
-#ifdef UNIX
-    // We only support sigreturn-using handlers so we have pairing: no longjmp.
-    std::unordered_map<memref_tid_t, std::stack<addr_t>> prev_xfer_int_pc_;
-    std::unordered_map<memref_tid_t, memref_t> prev_entry_;
-    std::unordered_map<memref_tid_t, memref_t> prev_prev_entry_;
-    std::unordered_map<memref_tid_t, std::stack<memref_t>> pre_signal_instr_;
-    // These are only available via annotations in signal_invariants.cpp.
-    std::unordered_map<memref_tid_t, int> instrs_until_interrupt_;
-    std::unordered_map<memref_tid_t, int> memrefs_until_interrupt_;
-#endif
+    bool has_annotations_ = false;
     addr_t app_handler_pc_;
     offline_file_type_t file_type_ = OFFLINE_FILE_TYPE_DEFAULT;
-    std::unordered_map<memref_tid_t, bool> thread_exited_;
-    std::unordered_map<memref_tid_t, bool> found_cache_line_size_marker_;
-    std::unordered_map<memref_tid_t, bool> found_instr_count_marker_;
-    std::unordered_map<memref_tid_t, uint64_t> last_instr_count_marker_;
 };
 
 #endif /* _INVARIANT_CHECKER_H_ */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3391,7 +3391,8 @@ if (BUILD_CLIENTS)
       set(kernel_xfer_app client.winxfer) # We want threads and xfers.
     endif()
     if (DEBUG) # for -test_mode
-      torunonly_drcachesim(invariants ${kernel_xfer_app} "-test_mode" "")
+      torunonly_drcachesim(invariants ${kernel_xfer_app}
+        "-test_mode -test_mode_name kernel_xfer_app" "")
       # This is slow on Windows.  I tried reducing the tracing window but
       # it seems to vary too much across machines, and if we delay too far
       # we start in the middle of a callback.
@@ -3584,7 +3585,8 @@ if (BUILD_CLIENTS)
     endif ()
 
     if (LINUX AND X64 AND HAVE_RSEQ)
-      torunonly_drcacheoff(rseq linux.rseq "" "@${test_mode_flag}" "")
+      torunonly_drcacheoff(rseq linux.rseq ""
+        "@${test_mode_flag}@-test_mode_name@rseq_app" "")
     endif ()
 
     if (AARCH64)
@@ -3736,7 +3738,7 @@ if (BUILD_CLIENTS)
     set(${testname_full}_postcmd
       "${drcachesim_path}@-indir@${testname_full}.*.dir")
     set(${testname_full}_postcmd2
-      "${histo_path}@-test_mode@-trace_dir@${testname_full}.*.dir/trace")
+      "${histo_path}@-test_mode@-test_mode_name@kernel_xfer_app@-trace_dir@${testname_full}.*.dir/trace")
 
     if (AARCH64)
       set(testname_full "tool.drcacheoff.allasm-aarch64-prefetch-counts")
@@ -3780,7 +3782,7 @@ if (BUILD_CLIENTS)
       set(${testname_full}_postcmd2
         "${GZIP}@${testname_full}.*.dir/trace/*")
       set(${testname_full}_postcmd3
-        "${histo_path}@-test_mode@-trace_dir@${testname_full}.*.dir/trace")
+        "${histo_path}@-test_mode@-test_mode_name@kernel_xfer_app@-trace_dir@${testname_full}.*.dir/trace")
     elseif (UNIX)
       message(STATUS "gzip or zlib not found: disabling ${testname_full} test")
     endif ()


### PR DESCRIPTION
Refactors the trace invariants checker tool to operate in parallel
over the sharded threads of the trace.  The branch target check across
thread switches instead looks for branch targets across possible
switch points indicated by timestamps.

Adds a test name parameter to isolate the targeted-app portions of the
invariants checks.

Refactors the invariant_checker_test to run the tool in both serial
and parallel mode.

Fixes a bug found in initializing per_shard_t.prev_xfer_marker_ which
caused false negatives in certain cases.

Issue: #5076