### PR TITLE
i#2414 drcallstack: Guard drcallstack test label

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4809,7 +4809,6 @@ if (NOT ANDROID AND AARCHXX)
     code_api|client.call-retarget
     code_api|client.crashmsg
     code_api|client.destructor
-    code_api|client.drcallstack-test
     code_api|client.drcontainers-test
     code_api|client.drmodtrack-test
     code_api|client.drsyms-test
@@ -4840,6 +4839,11 @@ if (NOT ANDROID AND AARCHXX)
     set_tests_properties(
       code_api|common.logstderr
       code_api|common.loglevel
+      PROPERTIES LABELS RUNS_ON_QEMU)
+  endif ()
+  if (HAVE_LIBUNWIND_H)
+    set_tests_properties(
+      code_api|client.drcallstack-test
       PROPERTIES LABELS RUNS_ON_QEMU)
   endif ()
   if (AARCH64)


### PR DESCRIPTION
Puts the drcallstack test label RUNS_ON_QEMU under a guard for
HAVE_LIBUNWIND_H, since local builds may not have libunwind installed
for cross-compilation.

Issue: #2414