### PR TITLE
i#4719 qemu: Fix bad ARM encodings for BLX, BX, BXJ

### DIFF
--- a/core/ir/arm/table_a32_pred.c
+++ b/core/ir/arm/table_a32_pred.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -714,9 +714,9 @@ const instr_info_t A32_ext_opc4[][16] = {
     {OP_strd,    0x010000f0, "strd",   MNRq, xx, RBEw, RB2w, xx, pred, x, top4[3][0x0f]},/*PUW=100*/
   }, { /* 1 */
     {EXT_BIT9,   0x01200000, "(ext bit9 2)", xx, xx, xx, xx, xx, no, x, 2},
-    {OP_bx,      0x01200010, "bx",     xx, xx, RDw, xx, xx, pred, x, END_LIST},
-    {OP_bxj,     0x01200020, "bxj",    xx, xx, RDw, xx, xx, pred, x, END_LIST},
-    {OP_blx_ind, 0x01200030, "blx",    LRw, xx, RDw, xx, xx, pred, x, END_LIST},
+    {OP_bx,      0x012fff10, "bx",     xx, xx, RDw, xx, xx, pred, x, END_LIST},
+    {OP_bxj,     0x012fff20, "bxj",    xx, xx, RDw, xx, xx, pred, x, END_LIST},
+    {OP_blx_ind, 0x012fff30, "blx",    LRw, xx, RDw, xx, xx, pred, x, END_LIST},
     {EXT_BIT9,   0x01200040, "(ext bit9 3)", xx, xx, xx, xx, xx, no, x, 3},
     {OP_qsub,    0x01200050, "qsub",   RBw, xx, RDw, RAw, xx, pred, x, END_LIST},
     {INVALID,    0x01200060, "(bad)",  xx, xx, xx, xx, xx, no, x, NA},


### PR DESCRIPTION
Adds missing required-1 bits in the ARM encoding table entries for
OP_blx, OP_bx, and OP_bxj.  Without the bits, some hardware still
accepts the instructions (which is why we did not notice the problem
before), but they are technically unsound, and QEMU thinks they are
invalid, breaking some of our tests under QEMU.

Tested on QEMU with the forthcoming #2414 drwrap-drreg-test,
and directly with several other decoders:
  Prior encoding for "blx r11":
    <stdin>:1:1: warning: invalid instruction encoding
    0x3b 0x00 0x20 0xe1
    ^
    llvm-mc:   e120003b
    capstone:  e120003b <INVALID: errcode 0>
    bfd:       e120003b ; <UNDEFINED> instruction: 0xe120003b
  New encoding:
    $ disasm_a32 e12fff3b
    llvm-mc:   e12fff3b blx r11
    capstone:  e12fff3b blx r11
    bfd:       e12fff3b blx fp

Setting up more external-decoder testing is beyond the scope of this
fix: #1686 covers that.

Issue: #4719, #1686, #2414