### PR TITLE
Fix typo in the example config in the drcachesim doc.

### DIFF
--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -807,7 +807,7 @@ LLC {                          // LLC
   size            1M
   assoc           16
   inclusive       true
-  parent          mem
+  parent          memory
   replace_policy  LRU
   miss_file       misses.txt
 }


### PR DESCRIPTION
Replaces 'mem' with 'memory'. The former causes tool init to fail.
The configs in various tests are already fine.