### PR TITLE
i#2626: AArch64 v8.0 decode: Add FMOV, MOVI, CMHI, FCMGT and UDF

### DIFF
--- a/clients/drdisas/test_simple.template
+++ b/clients/drdisas/test_simple.template
@@ -1,5 +1,5 @@
 #if defined(AARCH64)
- 00000000   xx     $0x00000000 %x0 %x0 %x0 %x0 -> %x0 %x0 %x0 %x0
+ 00000000   udf    $0x0000
  f94017a0   ldr    +0x28(%x29)[8byte] -> %x0
  a9be7bfd   stp    %x29 %x30 %sp $0xffffffffffffffe0 -> -0x20(%sp)[16byte] %sp
 disassembly failed: invalid instruction: not enough bytes: 0x88

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -167,6 +167,23 @@ highest_bit_set(uint enc, int pos, int len, int *highest_bit)
     return false;
 }
 
+static inline uint
+get_reg_offset(reg_t reg, uint *offset)
+{
+    if (reg >= DR_REG_D0 && reg <= DR_REG_D31)
+        *offset = 3;
+    else if (reg >= DR_REG_S0 && reg <= DR_REG_S31)
+        *offset = 2;
+    else if (reg >= DR_REG_H0 && reg <= DR_REG_H31)
+        *offset = 1;
+    else if (reg >= DR_REG_B0 && reg <= DR_REG_B31)
+        *offset = 0;
+    else
+        return false;
+
+    return true;
+}
+
 static inline bool
 try_encode_int(OUT uint *bits, int len, int scale, ptr_int_t val)
 {
@@ -265,9 +282,9 @@ encode_sysreg(OUT uint *imm15, opnd_t opnd)
 static inline reg_id_t
 decode_reg(uint n, bool is_x, bool is_sp)
 {
-    return (n < 31 ? (is_x ? DR_REG_X0 : DR_REG_W0) + n
-                   : is_sp ? (is_x ? DR_REG_XSP : DR_REG_WSP)
-                           : (is_x ? DR_REG_XZR : DR_REG_WZR));
+    return (n < 31      ? (is_x ? DR_REG_X0 : DR_REG_W0) + n
+                : is_sp ? (is_x ? DR_REG_XSP : DR_REG_WSP)
+                        : (is_x ? DR_REG_XZR : DR_REG_WZR));
 }
 
 /* Encode integer register. */
@@ -1000,6 +1017,9 @@ decode_opnd_h_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 static inline bool
 encode_opnd_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
+    if (!opnd_is_immed_int(opnd))
+        return false;
+
     if (opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_HALF)
         return true;
     return false;
@@ -1017,6 +1037,9 @@ decode_opnd_b_const_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 static inline bool
 encode_opnd_b_const_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
+    if (!opnd_is_immed_int(opnd))
+        return false;
+
     if (opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_BYTE)
         return true;
     return false;
@@ -1034,7 +1057,50 @@ decode_opnd_s_const_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 static inline bool
 encode_opnd_s_const_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
+    if (!opnd_is_immed_int(opnd))
+        return false;
+
     if (opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_SINGLE)
+        return true;
+    return false;
+}
+
+/* d_const_sz: Operand size for double elements
+ */
+static inline bool
+decode_opnd_d_const_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_immed_int(VECTOR_ELEM_WIDTH_DOUBLE, OPSZ_2b);
+    return true;
+}
+
+static inline bool
+encode_opnd_d_const_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_immed_int(opnd))
+        return false;
+
+    if (opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_DOUBLE)
+        return true;
+    return false;
+}
+
+/* vindex_D1: implicit index, always 1 */
+
+static inline bool
+decode_opnd_vindex_D1(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_immed_int(1, OPSZ_2b);
+    return true;
+}
+
+static inline bool
+encode_opnd_vindex_D1(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_immed_int(opnd))
+        return false;
+
+    if (opnd_get_immed_int(opnd) == 1)
         return true;
     return false;
 }
@@ -1888,6 +1954,31 @@ encode_opnd_scale(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out
     return true;
 }
 
+static inline bool
+decode_opnd_imm16_0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    uint value = extract_uint(enc, 0, 16);
+    *opnd = opnd_create_immed_int(value, OPSZ_2);
+    return true;
+}
+
+static inline bool
+encode_opnd_imm16_0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    uint value;
+
+    if (!opnd_is_immed_int(opnd))
+        return false;
+
+    value = opnd_get_immed_int(opnd);
+
+    opnd = opnd_create_immed_uint(value, OPSZ_2);
+    uint enc_value;
+    encode_opnd_int(0, 16, false, false, 0, opnd, &enc_value);
+    *enc_out = enc_value;
+    return true;
+}
+
 /* op1: 3-bit immediate from bits 16-18 */
 
 static inline bool
@@ -2068,6 +2159,70 @@ encode_opnd_imm8(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     uint enc_bottom = 0;
     opnd = opnd_create_immed_uint(eight_bits & 0b11111, OPSZ_5b);
     encode_opnd_int(5, 5, false, false, 0, opnd, &enc_bottom);
+
+    *enc_out = enc_top | enc_bottom;
+    return true;
+}
+
+/* exp_imm8 Encode and decode functions for the expanded imm format
+   The expanded imm format takes the bits from 16-18 and 5-9 and expands
+   them to a 64bit int.
+
+   It does this by taking each bit in turn and repeating it 8 times so,
+   abcdefgh
+   becomes
+   aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeefffffffgggggggghhhhhhh
+*/
+
+static inline bool
+decode_opnd_exp_imm8(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    const uint repeats = 8;
+    uint upper_bits = extract_uint(enc, 16, 3);
+    uint lower_bits = extract_uint(enc, 5, 5);
+    uint bit_value = (upper_bits << 5) | lower_bits;
+    uint64 value = 0;
+    for (uint i = 0; i < repeats; i++) {
+        uint64 bit = (bit_value & (1 << i)) >> i;
+        if (bit == 1) /* bit = 0 is already set, don't do unnecessary work*/
+            for (uint j = 0; j < repeats; j++)
+                value |= bit << (i * repeats + j);
+    }
+    *opnd = opnd_create_immed_uint(value, OPSZ_8);
+    return true;
+}
+
+static inline bool
+encode_opnd_exp_imm8(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_immed_int(opnd))
+        return false;
+    uint64 value = opnd_get_immed_int(opnd);
+
+    const uint first_top_bit = 5;
+    const uint num_top_bits = 3;
+    const uint first_bottom_bit = 0;
+    const uint num_bottom_bits = 5;
+
+    /*
+    The below code recompresses the repeated bits by selecting the first
+    bit of the group &(1 << (i * 8)) and then shifts it back to its
+    original position (i *7 + offset)
+    */
+
+    uint top_bits = 0;
+    uint enc_top = 0;
+    for (uint i = first_top_bit; i < first_top_bit + num_top_bits; i++)
+        top_bits |= (value & (uint64)1 << (i * 8)) >> (i * 7 + first_top_bit);
+    opnd = opnd_create_immed_uint(top_bits, OPSZ_3b);
+    encode_opnd_int(16, num_top_bits, false, false, 0, opnd, &enc_top);
+
+    uint bottom_bits = 0;
+    uint enc_bottom = 0;
+    for (uint i = first_bottom_bit; i < first_bottom_bit + num_bottom_bits; i++)
+        bottom_bits |= (value & (uint64)1 << (i * 8)) >> (i * 7 + first_bottom_bit);
+    opnd = opnd_create_immed_uint(bottom_bits, OPSZ_5b);
+    encode_opnd_int(5, num_bottom_bits, false, false, 0, opnd, &enc_bottom);
 
     *enc_out = enc_top | enc_bottom;
     return true;
@@ -2731,14 +2886,13 @@ encode_hsd_immh_regx(int rpos, uint enc, int opcode, byte *pc, opnd_t opnd,
     if (!opnd_is_reg(opnd))
         return false;
     reg_t reg = opnd_get_reg(opnd);
-    if (reg >= DR_REG_D0 && reg <= DR_REG_D31)
-        return encode_opnd_vector_reg(rpos, 3, opnd, enc_out);
-    else if (reg >= DR_REG_S0 && reg <= DR_REG_S31)
-        return encode_opnd_vector_reg(rpos, 2, opnd, enc_out);
-    else if (reg >= DR_REG_H0 && reg <= DR_REG_H31)
-        return encode_opnd_vector_reg(rpos, 1, opnd, enc_out);
-    else
+    uint offset;
+    if (!get_reg_offset(reg, &offset))
         return false;
+    if (offset == 0)
+        return false;
+
+    return encode_opnd_vector_reg(rpos, offset, opnd, enc_out);
 }
 
 static inline bool
@@ -2761,16 +2915,11 @@ encode_bhsd_immh_regx(int rpos, uint enc, int opcode, byte *pc, opnd_t opnd,
     if (!opnd_is_reg(opnd))
         return false;
     reg_t reg = opnd_get_reg(opnd);
-    if (reg >= DR_REG_D0 && reg <= DR_REG_D31)
-        return encode_opnd_vector_reg(rpos, 3, opnd, enc_out);
-    else if (reg >= DR_REG_S0 && reg <= DR_REG_S31)
-        return encode_opnd_vector_reg(rpos, 2, opnd, enc_out);
-    else if (reg >= DR_REG_H0 && reg <= DR_REG_H31)
-        return encode_opnd_vector_reg(rpos, 1, opnd, enc_out);
-    else if (reg >= DR_REG_B0 && reg <= DR_REG_B31)
-        return encode_opnd_vector_reg(rpos, 0, opnd, enc_out);
-    else
+    uint offset;
+    if (!get_reg_offset(reg, &offset))
         return false;
+
+    return encode_opnd_vector_reg(rpos, offset, opnd, enc_out);
 }
 
 static inline bool
@@ -2913,6 +3062,9 @@ decode_opnd_sd_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 static inline bool
 encode_opnd_sd_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
+    if (!opnd_is_immed_int(opnd))
+        return false;
+
     if (opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_SINGLE) {
         *enc_out = 0;
         return true;
@@ -3318,62 +3470,60 @@ encode_opnd_shift4(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_ou
 }
 
 static inline bool
-decode_hsd_size_regx(int rpos, uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+decode_scalar_size_regx(uint size_offset, int rpos, uint enc, int opcode, byte *pc,
+                        OUT opnd_t *opnd)
 {
     uint size = extract_uint(enc, 22, 2);
 
-    if (size < 0 || size > 2)
+    if (size < 0 || size > (3 - size_offset))
         return false;
 
-    return decode_opnd_vector_reg(rpos, size + 1, enc, opnd);
+    return decode_opnd_vector_reg(rpos, size + size_offset, enc, opnd);
+}
+
+static inline bool
+encode_scalar_size_regx(uint size_offset, int rpos, uint enc, int opcode, byte *pc,
+                        opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_reg(opnd))
+        return false;
+
+    reg_t reg = opnd_get_reg(opnd);
+
+    uint offset = 0;
+    if (!get_reg_offset(reg, &offset)) {
+        return false;
+    }
+    bool reg_written = encode_opnd_vector_reg(rpos, offset, opnd, enc_out);
+    *enc_out |= (offset - size_offset) << 22;
+
+    return reg_written;
+}
+
+static inline bool
+decode_hsd_size_regx(int rpos, uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_scalar_size_regx(1, rpos, enc, opcode, pc, opnd);
 }
 
 static inline bool
 encode_hsd_size_regx(int rpos, uint enc, int opcode, byte *pc, opnd_t opnd,
                      OUT uint *enc_out)
 {
-    if (!opnd_is_reg(opnd))
-        return false;
-
-    reg_t reg = opnd_get_reg(opnd);
-    if (reg >= DR_REG_D0 && reg <= DR_REG_D31)
-        return encode_opnd_vector_reg(rpos, 3, opnd, enc_out);
-    else if (reg >= DR_REG_S0 && reg <= DR_REG_S31)
-        return encode_opnd_vector_reg(rpos, 2, opnd, enc_out);
-    else if (reg >= DR_REG_H0 && reg <= DR_REG_H31)
-        return encode_opnd_vector_reg(rpos, 1, opnd, enc_out);
-    else
-        return false;
+    return encode_scalar_size_regx(1, rpos, enc, opcode, pc, opnd, enc_out);
 }
 
 static inline bool
 decode_bhsd_size_regx(int rpos, uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    uint size = extract_uint(enc, 22, 2);
-
-    if (size < 0 || size > 3)
-        return false;
-
-    return decode_opnd_vector_reg(rpos, size, enc, opnd);
+    return decode_scalar_size_regx(0, rpos, enc, opcode, pc, opnd);
 }
 
 static inline bool
 encode_bhsd_size_regx(int rpos, uint enc, int opcode, byte *pc, opnd_t opnd,
                       OUT uint *enc_out)
 {
-    if (!opnd_is_reg(opnd))
-        return false;
-    reg_t reg = opnd_get_reg(opnd);
-    if (reg >= DR_REG_D0 && reg <= DR_REG_D31)
-        return encode_opnd_vector_reg(rpos, 3, opnd, enc_out);
-    else if (reg >= DR_REG_S0 && reg <= DR_REG_S31)
-        return encode_opnd_vector_reg(rpos, 2, opnd, enc_out);
-    else if (reg >= DR_REG_H0 && reg <= DR_REG_H31)
-        return encode_opnd_vector_reg(rpos, 1, opnd, enc_out);
-    else if (reg >= DR_REG_B0 && reg <= DR_REG_B31)
-        return encode_opnd_vector_reg(rpos, 0, opnd, enc_out);
-    else
-        return false;
+    return encode_scalar_size_regx(0, rpos, enc, opcode, pc, opnd, enc_out);
 }
 
 static inline bool

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -282,9 +282,9 @@ encode_sysreg(OUT uint *imm15, opnd_t opnd)
 static inline reg_id_t
 decode_reg(uint n, bool is_x, bool is_sp)
 {
-    return (n < 31      ? (is_x ? DR_REG_X0 : DR_REG_W0) + n
-                : is_sp ? (is_x ? DR_REG_XSP : DR_REG_WSP)
-                        : (is_x ? DR_REG_XZR : DR_REG_WZR));
+    return (n < 31 ? (is_x ? DR_REG_X0 : DR_REG_W0) + n
+                   : is_sp ? (is_x ? DR_REG_XSP : DR_REG_WSP)
+                           : (is_x ? DR_REG_XZR : DR_REG_WZR));
 }
 
 /* Encode integer register. */

--- a/core/ir/aarch64/codec.h
+++ b/core/ir/aarch64/codec.h
@@ -35,7 +35,7 @@
 
 #include "decode_private.h"
 
-#define ENCFAIL (uint)0 /* a value that is not a valid instruction */
+#define ENCFAIL (uint)0xFFFFFFFF /* a value that is not a valid instruction */
 
 byte *
 decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr);

--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -68,6 +68,8 @@
                                              # distinguish FP16 and float/double encs
 --------------------------------  b_const_sz # as above, but for byte width
 --------------------------------  s_const_sz # as above, but for single width
+--------------------------------  d_const_sz # as above, but for double width
+--------------------------------  vindex_D1  # An implicit index, at index 1
 ----------------------------xxxx  nzcv       # flag bit specifier for CCMN, CCMP
 ---------------------------xxxxx  w0         # W register (or WZR)
 ---------------------------xxxxx  w0p0       # even-numbered W register (or WZR)
@@ -117,9 +119,11 @@
 ----------------xxxx------------  crn        # 4 bit immediate from 12-15
 ----------------xxxx------------  cond       # condition for CCMN, CCMP
 ----------------xxxxxx----------  scale      # encoding of #fbits value in scale field
+----------------xxxxxxxxxxxxxxxx  imm16_0    # imm16 at position 0
 -------------xxx----------------  op1        # 3 bit immediate from 16-18
 -------------xxx------xxxxx-----  fpimm8     # floating-point immediate for vector fmov
 -------------xxx------xxxxx-----  imm8       # immediate from 16:18 and 5:9
+-------------xxx------xxxxx-----  exp_imm8   # expanded immediate from 16:18 and 5:9
 -------------xxxxxxxxxxxxxx-----  sysops     # immediate operands for SYS
 ------------xxxxxxxxxxxxxxx-----  sysreg     # operand of MRS
 -----------?????------xxxxx-----  wx5_imm5   # reg 5-9 d or q is inferred from bits 16:20
@@ -364,6 +368,7 @@ x101101011000000000100xxxxxxxxxx  n   60         clz            wx0 : wx5
 0101111011100000100010xxxxxxxxxx  n   63        cmgt             d0 : d5
 01011110111xxxxx001101xxxxxxxxxx  n   63        cmgt             d0 : d5 d16
 0x101110xx1xxxxx001101xxxxxxxxxx  n   64        cmhi            dq0 : dq5 dq16 bhsd_sz
+01111110111xxxxx001101xxxxxxxxxx  n   64        cmhi             d0 : d5 d16
 0x101110xx1xxxxx001111xxxxxxxxxx  n   65        cmhs            dq0 : dq5 dq16 bhsd_sz
 0111111011100000100110xxxxxxxxxx  n   66        cmle             d0 : d5
 0x101110xx100000100110xxxxxxxxxx  n   66        cmle            dq0 : dq5 bhsd_sz
@@ -445,6 +450,7 @@ x1001010xx0xxxxxxxxxxxxxxxxxxxxx  n   90         eor            wx0 : wx5 wx16 s
 0101111010100000110010xxxxxxxxxx  n   104      fcmgt             s0 : s5
 0101111011100000110010xxxxxxxxxx  n   104      fcmgt             d0 : d5
 0101111011111000110010xxxxxxxxxx  n   104      fcmgt             h0 : h5
+011111101x1xxxxx111001xxxxxxxxxx  n   104      fcmgt  bhsd_size_reg0 : bhsd_size_reg5 bhsd_size_reg16
 0111111011111000110110xxxxxxxxxx  n   105      fcmle             h0 : h5
 0111111010100000110110xxxxxxxxxx  n   105      fcmle             s0 : s5
 0111111011100000110110xxxxxxxxxx  n   105      fcmle             d0 : d5
@@ -608,6 +614,9 @@ x001111001011001xxxxxxxxxxxxxxxx  n   126     fcvtzu            wx0 : d5 scale
 1001111001100110000000xxxxxxxxxx  n   147       fmov             x0 : d5
 0x00111100000xxx111111xxxxxxxxxx  n   147       fmov            dq0 : fpimm8 h_sz # Armv8.2
 00011110xx100000010000xxxxxxxxxx  n   147       fmov     float_reg0 : float_reg5
+0x00111100000xxx111101xxxxxxxxxx  n   147       fmov            dq0 : fpimm8 s_const_sz
+1001111010101110000000xxxxxxxxxx  n   147       fmov             x0 : q5 vindex_D1 d_const_sz
+0110111100000xxx111101xxxxxxxxxx  n   147       fmov             q0 : fpimm8 d_const_sz
 00011111xx0xxxxx1xxxxxxxxxxxxxxx  n   148      fmsub     float_reg0 : float_reg5 float_reg16 float_reg10
 0x0011111xxxxxxx1001x0xxxxxxxxxx  n   149       fmul            dq0 : dq5 dq16 vindex_SD sd_sz
 0x00111100xxxxxx1001x0xxxxxxxxxx  n   149       fmul            dq0 : dq5 dq16_h_sz vindex_H h_sz
@@ -980,6 +989,8 @@ x0011011000xxxxx0xxxxxxxxxxxxxxx  n   311       madd            wx0 : wx5 wx16 w
 0x00111100000xxx10x001xxxxxxxxxx  n   314       movi            dq0 : imm8 cmode_h_sz
 0x00111100000xxx0xx001xxxxxxxxxx  n   314       movi            dq0 : imm8 cmode_s_sz
 0x00111100000xxx110x01xxxxxxxxxx  n   314       movi            dq0 : imm8 cmode4_s_sz_msl
+0010111100000xxx111001xxxxxxxxxx  n   314       movi             d0 : exp_imm8
+0110111100000xxx111001xxxxxxxxxx  n   314       movi             q0 : exp_imm8 d_const_sz
 011100101xxxxxxxxxxxxxxxxxxxxxxx  n   315       movk             w0 : w0 imm16 lsl imm16sh
 111100101xxxxxxxxxxxxxxxxxxxxxxx  n   315       movk             x0 : x0 imm16 lsl imm16sh
 000100101xxxxxxxxxxxxxxxxxxxxxxx  n   316       movn             w0 : imm16 lsl imm16sh
@@ -1403,6 +1414,7 @@ x001111000000011xxxxxxxxxxxxxxxx  n   510      ucvtf             s0 : wx5 scale
 x001111001000011xxxxxxxxxxxxxxxx  n   510      ucvtf             d0 : wx5 scale
 011111110xxxxxxx111001xxxxxxxxxx  n   510      ucvtf  bhsd_immh_reg0 : bhsd_immh_reg5 immhb_fxp
 0x1011110xxxxxxx111001xxxxxxxxxx  n   510      ucvtf            dq0 : dq5 bhsd_immh_sz immhb_fxp
+0000000000000000xxxxxxxxxxxxxxxx  n   567        udf                : imm16_0
 x0011010110xxxxx000010xxxxxxxxxx  n   511       udiv            wx0 : wx5 wx16
 0x101110100xxxxx100101xxxxxxxxxx  n   512       udot            dq0 : dq5 dq16 s_const_sz b_const_sz # v8.2
 0x101110xx1xxxxx000001xxxxxxxxxx  n   513      uhadd            dq0 : dq5 dq16 bhs_sz

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -14890,3 +14890,174 @@ d503203f : yield                          : yield
 4ec9790a : zip2 v10.2d, v8.2d, v9.2d                   : zip2   %q8 %q9 $0x03 -> %q10
 4ed37a54 : zip2 v20.2d, v18.2d, v19.2d                 : zip2   %q18 %q19 $0x03 -> %q20
 4edd7b9e : zip2 v30.2d, v28.2d, v29.2d                 : zip2   %q28 %q29 $0x03 -> %q30
+
+# UDF   #<imm>
+00000000 : udf #0x0000                               : udf    $0x0000
+0000119a : udf #0x119a                               : udf    $0x119a
+00003333 : udf #0x3333                               : udf    $0x3333
+00004ccd : udf #0x4ccd                               : udf    $0x4ccd
+00006666 : udf #0x6666                               : udf    $0x6666
+00008000 : udf #0x8000                               : udf    $0x8000
+00009999 : udf #0x9999                               : udf    $0x9999
+0000b333 : udf #0xb333                               : udf    $0xb333
+0000cccc : udf #0xcccc                               : udf    $0xcccc
+0000ffff : udf #0xffff                               : udf    $0xffff
+
+
+# MOVI    <Dd>, #<imm>
+2f00e400 : movi d0, #0x0                             : movi   $0x0000000000000000 -> %d0
+2f00e602 : movi d2, #0xff00000000                    : movi   $0x000000ff00000000 -> %d2
+2f01e404 : movi d4, #0xff0000000000                  : movi   $0x0000ff0000000000 -> %d4
+2f01e606 : movi d6, #0xffff00000000                  : movi   $0x0000ffff00000000 -> %d6
+2f02e408 : movi d8, #0xff000000000000                : movi   $0x00ff000000000000 -> %d8
+2f02e60a : movi d10, #0xff00ff00000000               : movi   $0x00ff00ff00000000 -> %d10
+2f03e40c : movi d12, #0xffff0000000000               : movi   $0x00ffff0000000000 -> %d12
+2f03e60e : movi d14, #0xffffff00000000               : movi   $0x00ffffff00000000 -> %d14
+2f04e410 : movi d16, #0xff00000000000000             : movi   $0xff00000000000000 -> %d16
+2f04e5f1 : movi d17, #0xff000000ffffffff             : movi   $0xff000000ffffffff -> %d17
+2f04e7f3 : movi d19, #0xff0000ffffffffff             : movi   $0xff0000ffffffffff -> %d19
+2f05e5f5 : movi d21, #0xff00ff00ffffffff             : movi   $0xff00ff00ffffffff -> %d21
+2f05e7f7 : movi d23, #0xff00ffffffffffff             : movi   $0xff00ffffffffffff -> %d23
+2f06e5f9 : movi d25, #0xffff0000ffffffff             : movi   $0xffff0000ffffffff -> %d25
+2f06e7fb : movi d27, #0xffff00ffffffffff             : movi   $0xffff00ffffffffff -> %d27
+2f07e7ff : movi d31, #0xffffffffffffffff             : movi   $0xffffffffffffffff -> %d31
+
+# CMHI    <Dd>, <Dn>, <Dm>
+7ee23420 : cmhi d0, d1, d2                           : cmhi   %d1 %d2 -> %d0
+7ee43462 : cmhi d2, d3, d4                           : cmhi   %d3 %d4 -> %d2
+7ee634a4 : cmhi d4, d5, d6                           : cmhi   %d5 %d6 -> %d4
+7ee834e6 : cmhi d6, d7, d8                           : cmhi   %d7 %d8 -> %d6
+7eea3528 : cmhi d8, d9, d10                          : cmhi   %d9 %d10 -> %d8
+7eec356a : cmhi d10, d11, d12                        : cmhi   %d11 %d12 -> %d10
+7eee35ac : cmhi d12, d13, d14                        : cmhi   %d13 %d14 -> %d12
+7ef035ee : cmhi d14, d15, d16                        : cmhi   %d15 %d16 -> %d14
+7ef23630 : cmhi d16, d17, d18                        : cmhi   %d17 %d18 -> %d16
+7ef33651 : cmhi d17, d18, d19                        : cmhi   %d18 %d19 -> %d17
+7ef53693 : cmhi d19, d20, d21                        : cmhi   %d20 %d21 -> %d19
+7ef736d5 : cmhi d21, d22, d23                        : cmhi   %d22 %d23 -> %d21
+7ef93717 : cmhi d23, d24, d25                        : cmhi   %d24 %d25 -> %d23
+7efb3759 : cmhi d25, d26, d27                        : cmhi   %d26 %d27 -> %d25
+7efd379b : cmhi d27, d28, d29                        : cmhi   %d28 %d29 -> %d27
+7ee1341f : cmhi d31, d0, d1                          : cmhi   %d0 %d1 -> %d31
+
+# FCMGT   <V><d>, <V><n>, <V><m>
+7ea2e420 : fcmgt s0, s1, s2                          : fcmgt  %s1 %s2 -> %s0
+7ea4e462 : fcmgt s2, s3, s4                          : fcmgt  %s3 %s4 -> %s2
+7ea6e4a4 : fcmgt s4, s5, s6                          : fcmgt  %s5 %s6 -> %s4
+7ea8e4e6 : fcmgt s6, s7, s8                          : fcmgt  %s7 %s8 -> %s6
+7eaae528 : fcmgt s8, s9, s10                         : fcmgt  %s9 %s10 -> %s8
+7eace56a : fcmgt s10, s11, s12                       : fcmgt  %s11 %s12 -> %s10
+7eaee5ac : fcmgt s12, s13, s14                       : fcmgt  %s13 %s14 -> %s12
+7eb0e5ee : fcmgt s14, s15, s16                       : fcmgt  %s15 %s16 -> %s14
+7eb2e630 : fcmgt s16, s17, s18                       : fcmgt  %s17 %s18 -> %s16
+7eb3e651 : fcmgt s17, s18, s19                       : fcmgt  %s18 %s19 -> %s17
+7eb5e693 : fcmgt s19, s20, s21                       : fcmgt  %s20 %s21 -> %s19
+7eb7e6d5 : fcmgt s21, s22, s23                       : fcmgt  %s22 %s23 -> %s21
+7eb9e717 : fcmgt s23, s24, s25                       : fcmgt  %s24 %s25 -> %s23
+7ebbe759 : fcmgt s25, s26, s27                       : fcmgt  %s26 %s27 -> %s25
+7ebde79b : fcmgt s27, s28, s29                       : fcmgt  %s28 %s29 -> %s27
+7ea1e41f : fcmgt s31, s0, s1                         : fcmgt  %s0 %s1 -> %s31
+7ee2e420 : fcmgt d0, d1, d2                          : fcmgt  %d1 %d2 -> %d0
+7ee4e462 : fcmgt d2, d3, d4                          : fcmgt  %d3 %d4 -> %d2
+7ee6e4a4 : fcmgt d4, d5, d6                          : fcmgt  %d5 %d6 -> %d4
+7ee8e4e6 : fcmgt d6, d7, d8                          : fcmgt  %d7 %d8 -> %d6
+7eeae528 : fcmgt d8, d9, d10                         : fcmgt  %d9 %d10 -> %d8
+7eece56a : fcmgt d10, d11, d12                       : fcmgt  %d11 %d12 -> %d10
+7eeee5ac : fcmgt d12, d13, d14                       : fcmgt  %d13 %d14 -> %d12
+7ef0e5ee : fcmgt d14, d15, d16                       : fcmgt  %d15 %d16 -> %d14
+7ef2e630 : fcmgt d16, d17, d18                       : fcmgt  %d17 %d18 -> %d16
+7ef3e651 : fcmgt d17, d18, d19                       : fcmgt  %d18 %d19 -> %d17
+7ef5e693 : fcmgt d19, d20, d21                       : fcmgt  %d20 %d21 -> %d19
+7ef7e6d5 : fcmgt d21, d22, d23                       : fcmgt  %d22 %d23 -> %d21
+7ef9e717 : fcmgt d23, d24, d25                       : fcmgt  %d24 %d25 -> %d23
+7efbe759 : fcmgt d25, d26, d27                       : fcmgt  %d26 %d27 -> %d25
+7efde79b : fcmgt d27, d28, d29                       : fcmgt  %d28 %d29 -> %d27
+7ee1e41f : fcmgt d31, d0, d1                         : fcmgt  %d0 %d1 -> %d31
+
+# MOVI    <Vd>.2D, #<imm>
+6f00e400 : movi v0.2d, #0x0                          : movi   $0x0000000000000000 $0x03 -> %q0
+6f00e602 : movi v2.2d, #0xff00000000                 : movi   $0x000000ff00000000 $0x03 -> %q2
+6f01e404 : movi v4.2d, #0xff0000000000               : movi   $0x0000ff0000000000 $0x03 -> %q4
+6f01e606 : movi v6.2d, #0xffff00000000               : movi   $0x0000ffff00000000 $0x03 -> %q6
+6f02e408 : movi v8.2d, #0xff000000000000             : movi   $0x00ff000000000000 $0x03 -> %q8
+6f02e60a : movi v10.2d, #0xff00ff00000000            : movi   $0x00ff00ff00000000 $0x03 -> %q10
+6f03e40c : movi v12.2d, #0xffff0000000000            : movi   $0x00ffff0000000000 $0x03 -> %q12
+6f03e60e : movi v14.2d, #0xffffff00000000            : movi   $0x00ffffff00000000 $0x03 -> %q14
+6f04e410 : movi v16.2d, #0xff00000000000000          : movi   $0xff00000000000000 $0x03 -> %q16
+6f04e5f1 : movi v17.2d, #0xff000000ffffffff          : movi   $0xff000000ffffffff $0x03 -> %q17
+6f04e7f3 : movi v19.2d, #0xff0000ffffffffff          : movi   $0xff0000ffffffffff $0x03 -> %q19
+6f05e5f5 : movi v21.2d, #0xff00ff00ffffffff          : movi   $0xff00ff00ffffffff $0x03 -> %q21
+6f05e7f7 : movi v23.2d, #0xff00ffffffffffff          : movi   $0xff00ffffffffffff $0x03 -> %q23
+6f06e5f9 : movi v25.2d, #0xffff0000ffffffff          : movi   $0xffff0000ffffffff $0x03 -> %q25
+6f06e7fb : movi v27.2d, #0xffff00ffffffffff          : movi   $0xffff00ffffffffff $0x03 -> %q27
+6f07e7ff : movi v31.2d, #0xffffffffffffffff          : movi   $0xffffffffffffffff $0x03 -> %q31
+
+# FMOV    <Vd>.<T>, #<imm>
+0f00f400 : fmov v0.2s, #2.0                          : fmov   $2.000000 $0x02 -> %d0
+0f00f422 : fmov v2.2s, #2.125                        : fmov   $2.125000 $0x02 -> %d2
+0f00f444 : fmov v4.2s, #2.25                         : fmov   $2.250000 $0x02 -> %d4
+0f00f466 : fmov v6.2s, #2.375                        : fmov   $2.375000 $0x02 -> %d6
+0f00f488 : fmov v8.2s, #2.5                          : fmov   $2.500000 $0x02 -> %d8
+0f00f4aa : fmov v10.2s, #2.625                       : fmov   $2.625000 $0x02 -> %d10
+0f00f4cc : fmov v12.2s, #2.75                        : fmov   $2.750000 $0x02 -> %d12
+0f00f4ee : fmov v14.2s, #2.875                       : fmov   $2.875000 $0x02 -> %d14
+0f00f510 : fmov v16.2s, #3.0                         : fmov   $3.000000 $0x02 -> %d16
+0f03f711 : fmov v17.2s, #1.5                         : fmov   $1.500000 $0x02 -> %d17
+0f03f733 : fmov v19.2s, #1.5625                      : fmov   $1.562500 $0x02 -> %d19
+0f03f755 : fmov v21.2s, #1.625                       : fmov   $1.625000 $0x02 -> %d21
+0f03f777 : fmov v23.2s, #1.6875                      : fmov   $1.687500 $0x02 -> %d23
+0f03f799 : fmov v25.2s, #1.75                        : fmov   $1.750000 $0x02 -> %d25
+0f03f7bb : fmov v27.2s, #1.8125                      : fmov   $1.812500 $0x02 -> %d27
+0f03f7ff : fmov v31.2s, #1.9375                      : fmov   $1.937500 $0x02 -> %d31
+4f00f400 : fmov v0.4s, #2.0                          : fmov   $2.000000 $0x02 -> %q0
+4f00f422 : fmov v2.4s, #2.125                        : fmov   $2.125000 $0x02 -> %q2
+4f00f444 : fmov v4.4s, #2.25                         : fmov   $2.250000 $0x02 -> %q4
+4f00f466 : fmov v6.4s, #2.375                        : fmov   $2.375000 $0x02 -> %q6
+4f00f488 : fmov v8.4s, #2.5                          : fmov   $2.500000 $0x02 -> %q8
+4f00f4aa : fmov v10.4s, #2.625                       : fmov   $2.625000 $0x02 -> %q10
+4f00f4cc : fmov v12.4s, #2.75                        : fmov   $2.750000 $0x02 -> %q12
+4f00f4ee : fmov v14.4s, #2.875                       : fmov   $2.875000 $0x02 -> %q14
+4f00f510 : fmov v16.4s, #3.0                         : fmov   $3.000000 $0x02 -> %q16
+4f03f711 : fmov v17.4s, #1.5                         : fmov   $1.500000 $0x02 -> %q17
+4f03f733 : fmov v19.4s, #1.5625                      : fmov   $1.562500 $0x02 -> %q19
+4f03f755 : fmov v21.4s, #1.625                       : fmov   $1.625000 $0x02 -> %q21
+4f03f777 : fmov v23.4s, #1.6875                      : fmov   $1.687500 $0x02 -> %q23
+4f03f799 : fmov v25.4s, #1.75                        : fmov   $1.750000 $0x02 -> %q25
+4f03f7bb : fmov v27.4s, #1.8125                      : fmov   $1.812500 $0x02 -> %q27
+4f03f7ff : fmov v31.4s, #1.9375                      : fmov   $1.937500 $0x02 -> %q31
+
+# FMOV    <Xd>, <Dn>.1D[1]
+9eae0020 : fmov x0, v1.d[1]                          : fmov   %q1 $0x01 $0x03 -> %x0
+9eae0062 : fmov x2, v3.d[1]                          : fmov   %q3 $0x01 $0x03 -> %x2
+9eae00a4 : fmov x4, v5.d[1]                          : fmov   %q5 $0x01 $0x03 -> %x4
+9eae00e6 : fmov x6, v7.d[1]                          : fmov   %q7 $0x01 $0x03 -> %x6
+9eae0128 : fmov x8, v9.d[1]                          : fmov   %q9 $0x01 $0x03 -> %x8
+9eae0169 : fmov x9, v11.d[1]                         : fmov   %q11 $0x01 $0x03 -> %x9
+9eae01ab : fmov x11, v13.d[1]                        : fmov   %q13 $0x01 $0x03 -> %x11
+9eae01ed : fmov x13, v15.d[1]                        : fmov   %q15 $0x01 $0x03 -> %x13
+9eae022f : fmov x15, v17.d[1]                        : fmov   %q17 $0x01 $0x03 -> %x15
+9eae0251 : fmov x17, v18.d[1]                        : fmov   %q18 $0x01 $0x03 -> %x17
+9eae0293 : fmov x19, v20.d[1]                        : fmov   %q20 $0x01 $0x03 -> %x19
+9eae02d5 : fmov x21, v22.d[1]                        : fmov   %q22 $0x01 $0x03 -> %x21
+9eae0317 : fmov x23, v24.d[1]                        : fmov   %q24 $0x01 $0x03 -> %x23
+9eae0358 : fmov x24, v26.d[1]                        : fmov   %q26 $0x01 $0x03 -> %x24
+9eae039a : fmov x26, v28.d[1]                        : fmov   %q28 $0x01 $0x03 -> %x26
+9eae001e : fmov x30, v0.d[1]                         : fmov   %q0 $0x01 $0x03 -> %x30
+
+# FMOV    <Vd>.2D, #<imm>
+6f00f400 : fmov v0.2d, #2.0                          : fmov   $2.000000 $0x03 -> %q0
+6f00f422 : fmov v2.2d, #2.125                        : fmov   $2.125000 $0x03 -> %q2
+6f00f444 : fmov v4.2d, #2.25                         : fmov   $2.250000 $0x03 -> %q4
+6f00f466 : fmov v6.2d, #2.375                        : fmov   $2.375000 $0x03 -> %q6
+6f00f488 : fmov v8.2d, #2.5                          : fmov   $2.500000 $0x03 -> %q8
+6f00f4aa : fmov v10.2d, #2.625                       : fmov   $2.625000 $0x03 -> %q10
+6f00f4cc : fmov v12.2d, #2.75                        : fmov   $2.750000 $0x03 -> %q12
+6f00f4ee : fmov v14.2d, #2.875                       : fmov   $2.875000 $0x03 -> %q14
+6f00f510 : fmov v16.2d, #3.0                         : fmov   $3.000000 $0x03 -> %q16
+6f03f711 : fmov v17.2d, #1.5                         : fmov   $1.500000 $0x03 -> %q17
+6f03f733 : fmov v19.2d, #1.5625                      : fmov   $1.562500 $0x03 -> %q19
+6f03f755 : fmov v21.2d, #1.625                       : fmov   $1.625000 $0x03 -> %q21
+6f03f777 : fmov v23.2d, #1.6875                      : fmov   $1.687500 $0x03 -> %q23
+6f03f799 : fmov v25.2d, #1.75                        : fmov   $1.750000 $0x03 -> %q25
+6f03f7bb : fmov v27.2d, #1.8125                      : fmov   $1.812500 $0x03 -> %q27
+6f03f7ff : fmov v31.2d, #1.9375                      : fmov   $1.937500 $0x03 -> %q31


### PR DESCRIPTION
This patch implements the instructions:
`FMOV <Vd>.<T>, #<imm>`
`FMOV <Vd>.2D, #<imm>`
`FMOV <Xd>, <Dn>.1D[1]`
`MOVI <Dd>, #<imm>`
`MOVI <Vd>.2D, #<imm>`
`CMHI <V><d>, <V><n>, <V><m>`
`FCMGT <V><d>, <V><n>, <V><m>`
`UDF #<imm>`

and their appropriate en/decode functions.

The encoder currently uses ENCFAIL, with a value
of 0 to determine if an encoding has passed or failed.
Unfortunately, this turned out to be a bad assumption of
an invalid value as UDF can be decoded from an encoding of 0.
This patch changes it to 0xFFFFFFF which is currently unused.
A longer term solution would be to return true/false and write
the encoded value to a variable rather than returning it.
