### PR TITLE
i#2985 scatter-gather: Preserve scratch xmm.

### DIFF
--- a/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
@@ -3,12 +3,12 @@ Hello world!
 ---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
-          43 total \(fetched\) instructions
-          43 total unique \(fetched\) instructions
+          59 total \(fetched\) instructions
+          59 total unique \(fetched\) instructions
            0 total non-fetched instructions
            0 total prefetches
-           3 total data loads
-           3 total data stores
+           4 total data loads
+           4 total data stores
            0 total icache flushes
            0 total dcache flushes
            1 total threads
@@ -20,12 +20,12 @@ Total counts:
      .* total function return value markers
      .* total other markers
 Thread .* counts:
-          43 \(fetched\) instructions
-          43 unique \(fetched\) instructions
+          59 \(fetched\) instructions
+          59 unique \(fetched\) instructions
            0 non-fetched instructions
            0 prefetches
-           3 data loads
-           3 data stores
+           4 data loads
+           4 data stores
            0 icache flushes
            0 dcache flushes
      .* scheduling markers

--- a/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
@@ -2,12 +2,12 @@ Correct
 Hello world!
 Basic counts tool results:
 Total counts:
-          43 total \(fetched\) instructions
-          43 total unique \(fetched\) instructions
+          59 total \(fetched\) instructions
+          59 total unique \(fetched\) instructions
            0 total non-fetched instructions
            0 total prefetches
-           3 total data loads
-           3 total data stores
+           4 total data loads
+           4 total data stores
            0 total icache flushes
            0 total dcache flushes
            1 total threads
@@ -19,12 +19,12 @@ Total counts:
      .* total function return value markers
      .* total other markers
 Thread .* counts:
-          43 \(fetched\) instructions
-          43 unique \(fetched\) instructions
+          59 \(fetched\) instructions
+          59 unique \(fetched\) instructions
            0 non-fetched instructions
            0 prefetches
-           3 data loads
-           3 data stores
+           4 data loads
+           4 data stores
            0 icache flushes
            0 dcache flushes
      .* scheduling markers

--- a/clients/drcachesim/tests/scattergather.templatex
+++ b/clients/drcachesim/tests/scattergather.templatex
@@ -133,12 +133,15 @@ AVX2 gather ok
 #ifdef __AVX512F__
 Test restoring the AVX-512 gather scratch mask register upon a fault
 Test restoring the AVX-512 scatter scratch mask register upon a fault
+Test restoring the AVX-512 gather scratch xmm register upon a fault
+Test restoring the AVX-512 scatter scratch xmm register upon a fault
 Test restoring the AVX-512 gather mask register upon translation events
 Test restoring the AVX-512 scatter mask register upon translation events
 Test updating the AVX-512 gather mask register upon translation events
 Test updating the AVX-512 scatter mask register upon translation events
 #endif
 Test updating the AVX2 gather mask register upon translation events
+Test restoring the AVX2 gather scratch xmm register upon a fault
 #endif
 AVX2/AVX-512 scatter/gather checks ok
 ---- <application exited with code 0> ----

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2832,7 +2832,7 @@ restore_spilled_xmm_value(drx_state_machine_params_t *params)
     ASSERT(params->spilled_xmm_slot_addr != NULL,
            "No spill address recorded for the app xmm value");
     ASSERT(params->spilled_xmm != DR_REG_NULL && reg_is_strictly_xmm(params->spilled_xmm),
-           "no spilled xmm recorded");
+           "No spilled xmm reg recorded");
     void *spilled_xmm_val = params->spilled_xmm_slot_addr;
     for (int i = 0; i < XMM_REG_SIZE; i++) {
         xmm_val[i] = *((byte *)spilled_xmm_val + i);
@@ -2900,9 +2900,8 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
     switch (params->detect_state) {
     /* First we detect the spill address for the scratch xmm reg. */
     case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0: {
-        ASSERT(params->spilled_xmm_slot_addr == NULL &&
-                   params->spilled_xmm_slot_addr_reg == DR_REG_NULL,
-               "Spill address for xmm must be undetermined yet");
+        params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
+        params->spilled_xmm_slot_addr = NULL;
         ptr_int_t spilled_xmm_slot_addr;
         if (instr_is_mov_constant(&params->inst, &spilled_xmm_slot_addr) &&
             opnd_is_reg(instr_get_dst(&params->inst, 0)) &&
@@ -2931,8 +2930,6 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
             advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
             break;
         }
-        params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
-        params->spilled_xmm_slot_addr = NULL;
         skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
         break;
     /* We come back to DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2 for each
@@ -2952,9 +2949,7 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                 break;
             }
         }
-        /* We don't need to ignore any instructions here, because we are already in
-         * DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2.
-         */
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
         break;
     case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
@@ -3189,9 +3184,8 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
     switch (params->detect_state) {
     /* First we detect the spill address for the scratch xmm reg. */
     case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0: {
-        ASSERT(params->spilled_xmm_slot_addr == NULL &&
-                   params->spilled_xmm_slot_addr_reg == DR_REG_NULL,
-               "Spill address for xmm must be undetermined yet");
+        params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
+        params->spilled_xmm_slot_addr = NULL;
         ptr_int_t spilled_xmm_slot_addr;
         if (instr_is_mov_constant(&params->inst, &spilled_xmm_slot_addr) &&
             opnd_is_reg(instr_get_dst(&params->inst, 0)) &&
@@ -3220,8 +3214,6 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
             advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
             break;
         }
-        params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
-        params->spilled_xmm_slot_addr = NULL;
         skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
         break;
     /* We come back to DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2 for each
@@ -3241,9 +3233,7 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                 break;
             }
         }
-        /* We don't need to ignore any instructions here, because we are already in
-         * DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2.
-         */
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
         break;
     case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_3:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
@@ -3484,9 +3474,8 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
     switch (params->detect_state) {
     /* First we detect the spill address for the scratch xmm reg. */
     case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0: {
-        ASSERT(params->spilled_xmm_slot_addr == NULL &&
-                   params->spilled_xmm_slot_addr_reg == DR_REG_NULL,
-               "Spill address for xmm must be undetermined yet");
+        params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
+        params->spilled_xmm_slot_addr = NULL;
         ptr_int_t spilled_xmm_slot_addr;
         if (instr_is_mov_constant(&params->inst, &spilled_xmm_slot_addr) &&
             opnd_is_reg(instr_get_dst(&params->inst, 0)) &&
@@ -3515,8 +3504,6 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
             advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
             break;
         }
-        params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
-        params->spilled_xmm_slot_addr = NULL;
         skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
         break;
     /* We come back to DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2 for each
@@ -3536,9 +3523,7 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                 break;
             }
         }
-        /* We don't need to ignore any instructions here, because we are already in
-         * DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2.
-         */
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
         break;
     case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2407,7 +2407,9 @@ drx_expand_scatter_gather(void *drcontext, instrlist_t *bb, OUT bool *expanded)
     }
     app_pc orig_app_pc = instr_get_app_pc(sg_instr);
     reg_id_t scratch_xmm;
-    /* Search the instruction for an unused xmm register we will use as a temp. */
+    /* Search the instruction for an unused xmm register we will use as a temp.
+     * Modify scatter-gather tests if the criteria for picking the scratch xmm changes.
+     */
     for (scratch_xmm = DR_REG_START_XMM; scratch_xmm <= DR_REG_STOP_XMM; ++scratch_xmm) {
         if ((sg_info.is_evex ||
              scratch_xmm != reg_resize_to_opsz(sg_info.mask_reg, OPSZ_16)) &&
@@ -2627,28 +2629,32 @@ drx_expand_scatter_gather_exit:
  * AVX-512 gather sequence detection example:
  *
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0
- *         vextracti32x4 {%k0} $0x00 %zmm1 -> %xmm2
+ *         mov           <xmm_spill_addr> -> %ecx
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1
- *         vpextrd       %xmm2 $0x00 -> %ecx
+ *         vmovdqa       %xmm2 -> (%ecx)[16byte]
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2
- *         mov           (%rax,%rcx,4)[4byte] -> %ecx
+ *         vextracti32x4 {%k0} $0x00 %zmm1 -> %xmm2
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3
- * (a)     vextracti32x4 {%k0} $0x00 %zmm0 -> %xmm2
+ *         vpextrd       %xmm2 $0x00 -> %ecx
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4
- * (a)     vpinsrd       %xmm2 %ecx $0x00 -> %xmm2
+ *         mov           (%rax,%rcx,4)[4byte] -> %ecx
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5
- * (a)     vinserti32x4  {%k0} $0x00 %zmm0 %xmm2 -> %zmm0
+ * (a)     vextracti32x4 {%k0} $0x00 %zmm0 -> %xmm2
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6
- * (a)     mov           $0x00000001 -> %ecx
+ * (a)     vpinsrd       %xmm2 %ecx $0x00 -> %xmm2
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7
- * (a)     kmovw         %k0 -> %edx
+ * (a)     vinserti32x4  {%k0} $0x00 %zmm0 %xmm2 -> %zmm0
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8
- * (a)     kmovw         %ecx -> %k0
+ * (a)     mov           $0x00000001 -> %ecx
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9
- * (a) (b) kandnw        %k0 %k1 -> %k1
+ * (a)     kmovw         %k0 -> %edx
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10
+ * (a)     kmovw         %ecx -> %k0
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_11
+ * (a) (b) kandnw        %k0 %k1 -> %k1
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_12
  *     (b) kmovw         %edx -> %k0
- *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2
  *
  * (a): The instruction window where the destination mask state hadn't been updated yet.
  * (b): The instruction window where the scratch mask is clobbered w/o support by drreg.
@@ -2656,26 +2662,30 @@ drx_expand_scatter_gather_exit:
  * AVX-512 scatter sequence detection example:
  *
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0
- *         vextracti32x4 {%k0} $0x00 %zmm1 -> %xmm2
+ *         mov           <xmm_spill_addr> -> %edx
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1
- *         vpextrd       %xmm2 $0x00 -> %edx
+ *         vmovdqa       %xmm2 -> (%edx)[16byte]
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2
- *         vextracti32x4 {%k0} $0x00 %zmm0 -> %xmm2
+ *         vextracti32x4 {%k0} $0x00 %zmm1 -> %xmm2
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_3
- *         vpextrd       %xmm2 $0x00 -> %ebx
+ *         vpextrd       %xmm2 $0x00 -> %edx
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_4
- *         mov           %ebx -> (%rcx,%rdx,4)[4byte]
+ *         vextracti32x4 {%k0} $0x00 %zmm0 -> %xmm2
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_5
- * (a)     mov           $0x00000001 -> %edx
+ *         vpextrd       %xmm2 $0x00 -> %ebx
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_6
- * (a)     kmovw         %k0 -> %ebp
+ *         mov           %ebx -> (%rcx,%rdx,4)[4byte]
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_7
- * (a)     kmovw         %edx -> %k0
+ * (a)     mov           $0x00000001 -> %edx
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8
- * (a) (b) kandnw        %k0 %k1 -> %k1
+ * (a)     kmovw         %k0 -> %ebp
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9
+ * (a)     kmovw         %edx -> %k0
+ *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_10
+ * (a) (b) kandnw        %k0 %k1 -> %k1
+ *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_11
  *     (b) kmovw         %ebp -> %k0
- *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0
+ *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2
  *
  * (a): The instruction window where the destination mask state hadn't been updated yet.
  * (b): The instruction window where the scratch mask is clobbered w/o support by drreg.
@@ -2683,26 +2693,30 @@ drx_expand_scatter_gather_exit:
  * AVX2 gather sequence detection example:
  *
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0
- *         vextracti128  %ymm2 $0x00 -> %xmm3
+ *         mov           <xmm_spill_addr> -> %ecx
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1
- *         vpextrd       %xmm3 $0x00 -> %ecx
+ *         vmovdqa       %xmm2 -> (%ecx)[16byte]
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2
- *         mov           (%rax,%rcx,4)[4byte] -> %ecx
+ *         vextracti128  %ymm2 $0x00 -> %xmm3
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3
- * (a)     vextracti128  %ymm0 $0x00 -> %xmm3
+ *         vpextrd       %xmm3 $0x00 -> %ecx
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4
- * (a)     vpinsrd       %xmm3 %ecx $0x00 -> %xmm3
+ *         mov           (%rax,%rcx,4)[4byte] -> %ecx
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5
- * (a)     vinserti128   %ymm0 %xmm3 $0x00 -> %ymm0
+ * (a)     vextracti128  %ymm0 $0x00 -> %xmm3
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6
- * (a)     xor           %ecx %ecx -> %ecx
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7
- * (a)     vextracti128  %ymm2 $0x00 -> %xmm3
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8
  * (a)     vpinsrd       %xmm3 %ecx $0x00 -> %xmm3
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7
+ * (a)     vinserti128   %ymm0 %xmm3 $0x00 -> %ymm0
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8
+ * (a)     xor           %ecx %ecx -> %ecx
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9
+ * (a)     vextracti128  %ymm2 $0x00 -> %xmm3
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_10
+ * (a)     vpinsrd       %xmm3 %ecx $0x00 -> %xmm3
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_11
  * (a)     vinserti128   %ymm2 %xmm3 $0x00 -> %ymm2
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2
  *
  * (a): The instruction window where the destination mask state hadn't been updated yet.
  *
@@ -2722,6 +2736,8 @@ drx_expand_scatter_gather_exit:
 #    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8 8
 #    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9 9
 #    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10 10
+#    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_11 11
+#    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_12 12
 
 /* States of the AVX-512 scatter detection state machine. */
 #    define DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0 0
@@ -2734,6 +2750,8 @@ drx_expand_scatter_gather_exit:
 #    define DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_7 7
 #    define DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8 8
 #    define DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9 9
+#    define DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_10 10
+#    define DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_11 11
 
 /* States of the AVX2 gather detection state machine. */
 #    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0 0
@@ -2746,6 +2764,8 @@ drx_expand_scatter_gather_exit:
 #    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7 7
 #    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8 8
 #    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9 9
+#    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_10 10
+#    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_11 11
 
 typedef struct _drx_state_machine_params_t {
     byte *pc;
@@ -2758,6 +2778,18 @@ typedef struct _drx_state_machine_params_t {
     byte *restore_scratch_mask_start_pc;
     /* counter to allow for skipping unknown instructions */
     int skip_unknown_instr_count;
+    /* The spilled xmm register. When the_scratch_xmm in set,
+     * it is expected to be equal to this.
+     */
+    reg_id_t spilled_xmm;
+    /* The address where the spilled xmm reg's app value is
+     * stored.
+     */
+    void *spilled_xmm_slot_addr;
+    /* The reg with spilled_xmm_slot_addr, so that we can use it
+     * in the actual spill instr.
+     */
+    reg_id_t spilled_xmm_slot_addr_reg;
     /* detected scratch xmm register for mask update */
     reg_id_t the_scratch_xmm;
     /* detected gpr register that holds the mask update immediate */
@@ -2791,6 +2823,21 @@ skip_unknown_instr_inc(int reset_state, drx_state_machine_params_t *params)
     }
 }
 
+static void
+restore_spilled_xmm_value(drx_state_machine_params_t *params)
+{
+    byte xmm_val[XMM_REG_SIZE];
+    ASSERT(params->spilled_xmm_slot_addr != NULL,
+           "No spill address recorded for the app xmm value");
+    ASSERT(params->spilled_xmm != DR_REG_NULL && reg_is_strictly_xmm(params->spilled_xmm),
+           "no spilled xmm recorded");
+    void *spilled_xmm_val = params->spilled_xmm_slot_addr;
+    for (int i = 0; i < XMM_REG_SIZE; i++) {
+        xmm_val[i] = *((byte *)spilled_xmm_val + i);
+    }
+    reg_set_value_ex(params->spilled_xmm, params->info->mcontext, xmm_val);
+}
+
 /* Run the state machines and decode the code cache. The state machines will search the
  * code for whether the translation pc is in one of the instruction windows that need
  * additional handling by drx in order to restore specific state of the application's mask
@@ -2807,6 +2854,9 @@ drx_restore_state_scatter_gather(
     params.detect_state = 0;
     params.skip_unknown_instr_count = 0;
     params.the_scratch_xmm = DR_REG_NULL;
+    params.spilled_xmm = DR_REG_NULL;
+    params.spilled_xmm_slot_addr = NULL;
+    params.spilled_xmm_slot_addr_reg = DR_REG_NULL;
     params.gpr_bit_mask = DR_REG_NULL;
     params.gpr_save_scratch_mask = DR_REG_NULL;
     params.scalar_mask_update_no = 0;
@@ -2846,23 +2896,65 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                                        drx_state_machine_params_t *params)
 {
     switch (params->detect_state) {
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0:
+    /* First we detect the spill address for the scratch xmm reg. */
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0: {
+        ASSERT(params->spilled_xmm_slot_addr == NULL &&
+                   params->spilled_xmm_slot_addr_reg == DR_REG_NULL,
+               "Spill address for xmm must be undetermined yet");
+        ptr_int_t spilled_xmm_slot_addr;
+        if (instr_is_mov_constant(&params->inst, &spilled_xmm_slot_addr) &&
+            opnd_is_reg(instr_get_dst(&params->inst, 0)) &&
+            reg_is_gpr(opnd_get_reg(instr_get_dst(&params->inst, 0)))) {
+            params->spilled_xmm_slot_addr = (void *)spilled_xmm_slot_addr;
+            params->spilled_xmm_slot_addr_reg =
+                opnd_get_reg(instr_get_dst(&params->inst, 0));
+            advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
+        }
+        break;
+    }
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1:
+        ASSERT(params->spilled_xmm == DR_REG_NULL,
+               "Spilled xmm reg must be undetermined yet");
+        ASSERT(params->spilled_xmm_slot_addr != NULL &&
+                   params->spilled_xmm_slot_addr_reg != DR_REG_NULL,
+               "xmm spill address must be determined already");
+        if (instr_get_opcode(&params->inst) == OP_vmovdqa &&
+            opnd_is_memory_reference(instr_get_dst(&params->inst, 0)) &&
+            opnd_get_base(instr_get_dst(&params->inst, 0)) ==
+                params->spilled_xmm_slot_addr_reg &&
+            opnd_is_reg(instr_get_src(&params->inst, 0)) &&
+            reg_is_strictly_xmm(opnd_get_reg(instr_get_src(&params->inst, 0)))) {
+            params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
+            params->spilled_xmm = opnd_get_reg(instr_get_src(&params->inst, 0));
+            advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+            break;
+        }
+        params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
+        params->spilled_xmm_slot_addr = NULL;
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        break;
+    /* We come back to DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2 for each
+     * scalar load sequence of the expanded gather instr.
+     */
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2:
         if (instr_get_opcode(&params->inst) == OP_vextracti128) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0)) {
                 reg_id_t tmp_reg = opnd_get_reg(dst0);
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
+                ASSERT(params->spilled_xmm == tmp_reg,
+                       "Only the spilled xmm should be used as scratch");
                 params->the_scratch_xmm = tmp_reg;
-                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
+                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3, params);
                 break;
             }
         }
         /* We don't need to ignore any instructions here, because we are already in
-         * DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0.
+         * DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2.
          */
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -2878,15 +2970,15 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                 if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
                     params->the_scratch_xmm = DR_REG_NULL;
                     params->gpr_scratch_index = opnd_get_reg(dst0);
-                    advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+                    advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4, params);
                     break;
                 }
             }
         }
         /* Intentionally not else if */
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4:
         if (!instr_is_reg_spill_or_restore(drcontext, &params->inst, NULL, NULL, NULL,
                                            NULL)) {
             if (instr_reads_memory(&params->inst)) {
@@ -2896,7 +2988,7 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                         opnd_t dst0 = instr_get_dst(&params->inst, 0);
                         if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
                             params->restore_dest_mask_start_pc = params->pc;
-                            advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3,
+                            advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5,
                                           params);
                             break;
                         }
@@ -2904,24 +2996,26 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5:
         if (instr_get_opcode(&params->inst) == OP_vextracti128) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0)) {
                 reg_id_t tmp_reg = opnd_get_reg(dst0);
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
+                ASSERT(params->spilled_xmm == tmp_reg,
+                       "Only the spilled xmm should be used as scratch");
                 params->the_scratch_xmm = tmp_reg;
-                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4, params);
+                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6, params);
                 break;
             }
         }
         /* Intentionally not else if */
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -2934,25 +3028,25 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
             reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
             if (tmp_reg == params->the_scratch_xmm) {
                 params->the_scratch_xmm = DR_REG_NULL;
-                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5, params);
+                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7:
         if (instr_get_opcode(&params->inst) == OP_vinserti128) {
             ASSERT(opnd_is_reg(instr_get_dst(&params->inst, 0)),
                    "internal error: unexpected instruction format");
             reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
             if (tmp_reg == params->sg_info->gather_dst_reg) {
-                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6, params);
+                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8:
         if (instr_get_opcode(&params->inst) == OP_xor) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             opnd_t src0 = instr_get_src(&params->inst, 0);
@@ -2966,13 +3060,13 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                        "internal error: unexpected instruction format");
                 if (reg_dst0 == reg_src0 && reg_src0 == reg_src1) {
                     params->gpr_bit_mask = reg_dst0;
-                    advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7, params);
+                    advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9, params);
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9:
         if (instr_get_opcode(&params->inst) == OP_vextracti128) {
             opnd_t src0 = instr_get_src(&params->inst, 0);
             if (opnd_is_reg(src0)) {
@@ -2982,17 +3076,19 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                         reg_id_t tmp_reg = opnd_get_reg(dst0);
                         if (!reg_is_strictly_xmm(tmp_reg))
                             break;
+                        ASSERT(params->spilled_xmm == tmp_reg,
+                               "Only the spilled xmm should be used as scratch");
                         params->the_scratch_xmm = tmp_reg;
-                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8,
+                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_10,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_10:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -3007,16 +3103,16 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                            "internal error: unexpected instruction format");
                     reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
                     if (tmp_reg == params->the_scratch_xmm) {
-                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9,
+                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_11,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_11:
         if (instr_get_opcode(&params->inst) == OP_vinserti128) {
             ASSERT(opnd_is_reg(instr_get_dst(&params->inst, 0)) &&
                        opnd_is_reg(instr_get_src(&params->inst, 0)) &&
@@ -3028,30 +3124,33 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
             if (src1 == params->the_scratch_xmm) {
                 if (src0 == params->sg_info->mask_reg) {
                     if (dst0 == params->sg_info->mask_reg) {
-                        if (params->restore_dest_mask_start_pc <=
-                                params->info->raw_mcontext->pc &&
-                            params->info->raw_mcontext->pc <= params->prev_pc) {
-                            /* Fix the gather's destination mask here and zero out
-                             * the bit that the emulation sequence hadn't done
-                             * before the fault hit.
-                             */
-                            ASSERT(reg_is_strictly_xmm(params->sg_info->mask_reg) ||
-                                       reg_is_strictly_ymm(params->sg_info->mask_reg),
-                                   "internal error: unexpected instruction format");
-                            byte val[YMM_REG_SIZE];
-                            if (!reg_get_value_ex(params->sg_info->mask_reg,
-                                                  params->info->raw_mcontext, val)) {
-                                ASSERT(
-                                    false,
-                                    "internal error: can't read mcontext's mask value");
+                        /* Check if we are already past the fault point. */
+                        if (params->info->raw_mcontext->pc <= params->prev_pc) {
+                            if (params->restore_dest_mask_start_pc <=
+                                params->info->raw_mcontext->pc) {
+                                /* Fix the gather's destination mask here and zero out
+                                 * the bit that the emulation sequence hadn't done
+                                 * before the fault hit.
+                                 */
+                                ASSERT(reg_is_strictly_xmm(params->sg_info->mask_reg) ||
+                                           reg_is_strictly_ymm(params->sg_info->mask_reg),
+                                       "internal error: unexpected instruction format");
+                                byte val[YMM_REG_SIZE];
+                                if (!reg_get_value_ex(params->sg_info->mask_reg,
+                                                      params->info->raw_mcontext, val)) {
+                                    ASSERT(false,
+                                           "internal error: can't read mcontext's mask "
+                                           "value");
+                                }
+                                uint mask_byte = opnd_size_in_bytes(
+                                                     params->sg_info->scalar_index_size) *
+                                        (params->scalar_mask_update_no + 1) -
+                                    1;
+                                val[mask_byte] &= ~(byte)128;
+                                reg_set_value_ex(params->sg_info->mask_reg,
+                                                 params->info->mcontext, val);
                             }
-                            uint mask_byte =
-                                opnd_size_in_bytes(params->sg_info->scalar_index_size) *
-                                    (params->scalar_mask_update_no + 1) -
-                                1;
-                            val[mask_byte] &= ~(byte)128;
-                            reg_set_value_ex(params->sg_info->mask_reg,
-                                             params->info->mcontext, val);
+                            restore_spilled_xmm_value(params);
                             /* We are done. */
                             return true;
                         }
@@ -3066,14 +3165,14 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                              */
                             return true;
                         }
-                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0,
+                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
         break;
     default: ASSERT(false, "internal error: invalid state.");
     }
@@ -3086,23 +3185,65 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                                           drx_state_machine_params_t *params)
 {
     switch (params->detect_state) {
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0:
+    /* First we detect the spill address for the scratch xmm reg. */
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0: {
+        ASSERT(params->spilled_xmm_slot_addr == NULL &&
+                   params->spilled_xmm_slot_addr_reg == DR_REG_NULL,
+               "Spill address for xmm must be undetermined yet");
+        ptr_int_t spilled_xmm_slot_addr;
+        if (instr_is_mov_constant(&params->inst, &spilled_xmm_slot_addr) &&
+            opnd_is_reg(instr_get_dst(&params->inst, 0)) &&
+            reg_is_gpr(opnd_get_reg(instr_get_dst(&params->inst, 0)))) {
+            params->spilled_xmm_slot_addr = (void *)spilled_xmm_slot_addr;
+            params->spilled_xmm_slot_addr_reg =
+                opnd_get_reg(instr_get_dst(&params->inst, 0));
+            advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
+        }
+        break;
+    }
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1:
+        ASSERT(params->spilled_xmm == DR_REG_NULL,
+               "Spilled xmm reg must be undetermined yet");
+        ASSERT(params->spilled_xmm_slot_addr != NULL &&
+                   params->spilled_xmm_slot_addr_reg != DR_REG_NULL,
+               "xmm spill address must be determined already");
+        if (instr_get_opcode(&params->inst) == OP_vmovdqa &&
+            opnd_is_memory_reference(instr_get_dst(&params->inst, 0)) &&
+            opnd_get_base(instr_get_dst(&params->inst, 0)) ==
+                params->spilled_xmm_slot_addr_reg &&
+            opnd_is_reg(instr_get_src(&params->inst, 0)) &&
+            reg_is_strictly_xmm(opnd_get_reg(instr_get_src(&params->inst, 0)))) {
+            params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
+            params->spilled_xmm = opnd_get_reg(instr_get_src(&params->inst, 0));
+            advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
+            break;
+        }
+        params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
+        params->spilled_xmm_slot_addr = NULL;
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
+        break;
+    /* We come back to DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2 for each
+     * scalar store sequence of the expanded scatter instr.
+     */
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2:
         if (instr_get_opcode(&params->inst) == OP_vextracti32x4) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0)) {
                 reg_id_t tmp_reg = opnd_get_reg(dst0);
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
+                ASSERT(params->spilled_xmm == tmp_reg,
+                       "Only the spilled xmm should be used as scratch");
                 params->the_scratch_xmm = tmp_reg;
-                advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
+                advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_3, params);
                 break;
             }
         }
         /* We don't need to ignore any instructions here, because we are already in
-         * DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0.
+         * DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2.
          */
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_3:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -3118,31 +3259,33 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                 if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
                     params->the_scratch_xmm = DR_REG_NULL;
                     params->gpr_scratch_index = opnd_get_reg(dst0);
-                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_4,
                                   params);
                     break;
                 }
             }
         }
         /* Intentionally not else if */
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_4:
         if (instr_get_opcode(&params->inst) == OP_vextracti32x4) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0)) {
                 reg_id_t tmp_reg = opnd_get_reg(dst0);
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
+                ASSERT(params->spilled_xmm == tmp_reg,
+                       "Only the spilled xmm should be used as scratch");
                 params->the_scratch_xmm = tmp_reg;
-                advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_3, params);
+                advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_5, params);
                 break;
             }
         }
         /* Intentionally not else if */
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_3:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_5:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -3158,15 +3301,15 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                 if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
                     params->the_scratch_xmm = DR_REG_NULL;
                     params->gpr_scratch_value = opnd_get_reg(dst0);
-                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_4,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_6,
                                   params);
                     break;
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_4: {
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_6: {
         if (!instr_is_reg_spill_or_restore(drcontext, &params->inst, NULL, NULL, NULL,
                                            NULL)) {
             if (instr_writes_memory(&params->inst)) {
@@ -3177,17 +3320,17 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                         opnd_uses_reg(src0, params->gpr_scratch_value) &&
                         opnd_uses_reg(dst0, params->gpr_scratch_index)) {
                         params->restore_dest_mask_start_pc = params->pc;
-                        advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_5,
+                        advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_7,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
         break;
     }
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_5: {
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_7: {
         ptr_int_t val;
         if (instr_is_mov_constant(&params->inst, &val)) {
             /* If more than one bit is set, this is not what we're looking for. */
@@ -3198,16 +3341,16 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                 reg_id_t tmp_gpr = opnd_get_reg(dst0);
                 if (reg_is_gpr(tmp_gpr)) {
                     params->gpr_bit_mask = tmp_gpr;
-                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_6,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8,
                                   params);
                     break;
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
         break;
     }
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_6:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8:
         if (instr_get_opcode(&params->inst) == OP_kmovw) {
             opnd_t src0 = instr_get_src(&params->inst, 0);
             if (opnd_is_reg(src0) && opnd_get_reg(src0) == DR_REG_K0) {
@@ -3216,16 +3359,16 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                     reg_id_t tmp_gpr = opnd_get_reg(dst0);
                     if (reg_is_gpr(tmp_gpr)) {
                         params->gpr_save_scratch_mask = tmp_gpr;
-                        advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_7,
+                        advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_7:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9:
         ASSERT(params->gpr_bit_mask != DR_REG_NULL,
                "internal error: expected gpr register to be recorded in state "
                "machine.");
@@ -3235,15 +3378,15 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                 opnd_t dst0 = instr_get_dst(&params->inst, 0);
                 if (opnd_is_reg(dst0) && opnd_get_reg(dst0) == DR_REG_K0) {
                     params->restore_scratch_mask_start_pc = params->pc;
-                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_10,
                                   params);
                     break;
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_10:
         if (instr_get_opcode(&params->inst) == OP_kandnw) {
             opnd_t src0 = instr_get_src(&params->inst, 0);
             opnd_t src1 = instr_get_src(&params->inst, 1);
@@ -3281,47 +3424,50 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                          */
                         return true;
                     }
-                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_11,
                                   params);
                     break;
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_11:
         if (instr_get_opcode(&params->inst) == OP_kmovw) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0) && opnd_get_reg(dst0) == DR_REG_K0) {
                 opnd_t src0 = instr_get_src(&params->inst, 0);
                 if (opnd_is_reg(src0)) {
                     if (reg_is_gpr(opnd_get_reg(src0)) &&
-                        params->restore_scratch_mask_start_pc <=
-                            params->info->raw_mcontext->pc &&
+                        /* Check if we are already past the fault point. */
                         params->info->raw_mcontext->pc <= params->prev_pc) {
-                        /* The scratch mask is always k0. This is hard-coded
-                         * in drx. We carefully only update the lowest 16 bits
-                         * because the mask was saved with kmovw.
-                         */
-                        ASSERT(sizeof(params->info->mcontext->opmask[0]) ==
-                                   sizeof(long long),
-                               "internal error: unexpected opmask slot size");
-                        params->info->mcontext->opmask[0] &= ~0xffffLL;
-                        params->info->mcontext->opmask[0] |=
-                            reg_get_value(params->gpr_save_scratch_mask,
-                                          params->info->raw_mcontext) &
-                            0xffff;
+                        if (params->restore_scratch_mask_start_pc <=
+                            params->info->raw_mcontext->pc) {
+                            /* The scratch mask is always k0. This is hard-coded
+                             * in drx. We carefully only update the lowest 16 bits
+                             * because the mask was saved with kmovw.
+                             */
+                            ASSERT(sizeof(params->info->mcontext->opmask[0]) ==
+                                       sizeof(long long),
+                                   "internal error: unexpected opmask slot size");
+                            params->info->mcontext->opmask[0] &= ~0xffffLL;
+                            params->info->mcontext->opmask[0] |=
+                                reg_get_value(params->gpr_save_scratch_mask,
+                                              params->info->raw_mcontext) &
+                                0xffff;
+                        }
+                        restore_spilled_xmm_value(params);
                         /* We are done. If we did fix up the scatter's destination
                          * mask, this already has happened.
                          */
                         return true;
                     }
-                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2,
                                   params);
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
         break;
     default: ASSERT(false, "internal error: invalid state.");
     }
@@ -3334,23 +3480,65 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                                          drx_state_machine_params_t *params)
 {
     switch (params->detect_state) {
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0:
+    /* First we detect the spill address for the scratch xmm reg. */
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0: {
+        ASSERT(params->spilled_xmm_slot_addr == NULL &&
+                   params->spilled_xmm_slot_addr_reg == DR_REG_NULL,
+               "Spill address for xmm must be undetermined yet");
+        ptr_int_t spilled_xmm_slot_addr;
+        if (instr_is_mov_constant(&params->inst, &spilled_xmm_slot_addr) &&
+            opnd_is_reg(instr_get_dst(&params->inst, 0)) &&
+            reg_is_gpr(opnd_get_reg(instr_get_dst(&params->inst, 0)))) {
+            params->spilled_xmm_slot_addr = (void *)spilled_xmm_slot_addr;
+            params->spilled_xmm_slot_addr_reg =
+                opnd_get_reg(instr_get_dst(&params->inst, 0));
+            advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
+        }
+        break;
+    }
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1:
+        ASSERT(params->spilled_xmm == DR_REG_NULL,
+               "Spilled xmm reg must be undetermined yet");
+        ASSERT(params->spilled_xmm_slot_addr != NULL &&
+                   params->spilled_xmm_slot_addr_reg != DR_REG_NULL,
+               "xmm spill address must be determined already");
+        if (instr_get_opcode(&params->inst) == OP_vmovdqa &&
+            opnd_is_memory_reference(instr_get_dst(&params->inst, 0)) &&
+            opnd_get_base(instr_get_dst(&params->inst, 0)) ==
+                params->spilled_xmm_slot_addr_reg &&
+            opnd_is_reg(instr_get_src(&params->inst, 0)) &&
+            reg_is_strictly_xmm(opnd_get_reg(instr_get_src(&params->inst, 0)))) {
+            params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
+            params->spilled_xmm = opnd_get_reg(instr_get_src(&params->inst, 0));
+            advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+            break;
+        }
+        params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
+        params->spilled_xmm_slot_addr = NULL;
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        break;
+    /* We come back to DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2 for each
+     * scalar load sequence of the expanded gather instr.
+     */
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2:
         if (instr_get_opcode(&params->inst) == OP_vextracti32x4) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0)) {
                 reg_id_t tmp_reg = opnd_get_reg(dst0);
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
+                ASSERT(params->spilled_xmm == tmp_reg,
+                       "Only the spilled xmm should be used as scratch");
                 params->the_scratch_xmm = tmp_reg;
-                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
+                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3, params);
                 break;
             }
         }
         /* We don't need to ignore any instructions here, because we are already in
-         * DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0.
+         * DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2.
          */
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -3366,15 +3554,15 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                 if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
                     params->the_scratch_xmm = DR_REG_NULL;
                     params->gpr_scratch_index = opnd_get_reg(dst0);
-                    advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+                    advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4, params);
                     break;
                 }
             }
         }
         /* Intentionally not else if */
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4:
         if (!instr_is_reg_spill_or_restore(drcontext, &params->inst, NULL, NULL, NULL,
                                            NULL)) {
             if (instr_reads_memory(&params->inst)) {
@@ -3384,30 +3572,32 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                     opnd_t dst0 = instr_get_dst(&params->inst, 0);
                     if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
                         params->restore_dest_mask_start_pc = params->pc;
-                        advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3,
+                        advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5:
         if (instr_get_opcode(&params->inst) == OP_vextracti32x4) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0)) {
                 reg_id_t tmp_reg = opnd_get_reg(dst0);
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
+                ASSERT(params->spilled_xmm == tmp_reg,
+                       "Only the spilled xmm should be used as scratch");
                 params->the_scratch_xmm = tmp_reg;
-                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4, params);
+                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -3419,25 +3609,25 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                    "internal error: unexpected instruction format");
             reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
             if (tmp_reg == params->the_scratch_xmm) {
-                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5, params);
+                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7:
         if (instr_get_opcode(&params->inst) == OP_vinserti32x4) {
             ASSERT(opnd_is_reg(instr_get_dst(&params->inst, 0)),
                    "internal error: unexpected instruction format");
             reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
             if (tmp_reg == params->sg_info->gather_dst_reg) {
-                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6, params);
+                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6: {
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8: {
         ptr_int_t val;
         if (instr_is_mov_constant(&params->inst, &val)) {
             /* If more than one bit is set, this is not what we're looking for. */
@@ -3448,15 +3638,15 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                 reg_id_t tmp_gpr = opnd_get_reg(dst0);
                 if (reg_is_gpr(tmp_gpr)) {
                     params->gpr_bit_mask = tmp_gpr;
-                    advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7, params);
+                    advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9, params);
                     break;
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
         break;
     }
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9:
         if (instr_get_opcode(&params->inst) == OP_kmovw) {
             opnd_t src0 = instr_get_src(&params->inst, 0);
             if (opnd_is_reg(src0) && opnd_get_reg(src0) == DR_REG_K0) {
@@ -3465,16 +3655,16 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                     reg_id_t tmp_gpr = opnd_get_reg(dst0);
                     if (reg_is_gpr(tmp_gpr)) {
                         params->gpr_save_scratch_mask = tmp_gpr;
-                        advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8,
+                        advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10:
         ASSERT(params->gpr_bit_mask != DR_REG_NULL,
                "internal error: expected gpr register to be recorded in state "
                "machine.");
@@ -3484,14 +3674,15 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                 opnd_t dst0 = instr_get_dst(&params->inst, 0);
                 if (opnd_is_reg(dst0) && opnd_get_reg(dst0) == DR_REG_K0) {
                     params->restore_scratch_mask_start_pc = params->pc;
-                    advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9, params);
+                    advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_11,
+                                  params);
                     break;
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_11:
         if (instr_get_opcode(&params->inst) == OP_kandnw) {
             opnd_t src0 = instr_get_src(&params->inst, 0);
             opnd_t src1 = instr_get_src(&params->inst, 1);
@@ -3529,16 +3720,16 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                              */
                             return true;
                         }
-                        advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10,
+                        advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_12,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_12:
         if (instr_get_opcode(&params->inst) == OP_kmovw) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0) && opnd_get_reg(dst0) == DR_REG_K0) {
@@ -3546,21 +3737,24 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                 if (opnd_is_reg(src0)) {
                     reg_id_t tmp_gpr = opnd_get_reg(src0);
                     if (reg_is_gpr(tmp_gpr)) {
-                        if (params->restore_scratch_mask_start_pc <=
-                                params->info->raw_mcontext->pc &&
-                            params->info->raw_mcontext->pc <= params->prev_pc) {
-                            /* The scratch mask is always k0. This is hard-coded
-                             * in drx. We carefully only update the lowest 16 bits
-                             * because the mask was saved with kmovw.
-                             */
-                            ASSERT(sizeof(params->info->mcontext->opmask[0]) ==
-                                       sizeof(long long),
-                                   "internal error: unexpected opmask slot size");
-                            params->info->mcontext->opmask[0] &= ~0xffffLL;
-                            params->info->mcontext->opmask[0] |=
-                                reg_get_value(params->gpr_save_scratch_mask,
-                                              params->info->raw_mcontext) &
-                                0xffff;
+                        /* Check if we are already past the fault point. */
+                        if (params->info->raw_mcontext->pc <= params->prev_pc) {
+                            if (params->restore_scratch_mask_start_pc <=
+                                params->info->raw_mcontext->pc) {
+                                /* The scratch mask is always k0. This is hard-coded
+                                 * in drx. We carefully only update the lowest 16 bits
+                                 * because the mask was saved with kmovw.
+                                 */
+                                ASSERT(sizeof(params->info->mcontext->opmask[0]) ==
+                                           sizeof(long long),
+                                       "internal error: unexpected opmask slot size");
+                                params->info->mcontext->opmask[0] &= ~0xffffLL;
+                                params->info->mcontext->opmask[0] |=
+                                    reg_get_value(params->gpr_save_scratch_mask,
+                                                  params->info->raw_mcontext) &
+                                    0xffff;
+                            }
+                            restore_spilled_xmm_value(params);
                             /* We are done. If we did fix up the gather's destination
                              * mask, this already has happened.
                              */
@@ -3570,7 +3764,7 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
         break;
     default: ASSERT(false, "internal error: invalid state.");
     }

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -153,7 +153,6 @@ get_tls_data(void *drcontext)
  * INIT
  */
 
-static int drx_init_count;
 #ifdef PLATFORM_SUPPORTS_SCATTER_GATHER
 static void
 drx_thread_init(void *drcontext)
@@ -173,6 +172,8 @@ drx_thread_exit(void *drcontext)
     dr_thread_free(drcontext, pt, sizeof(*pt));
 }
 #endif
+
+static int drx_init_count;
 
 DR_EXPORT
 bool

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2698,7 +2698,7 @@ drx_expand_scatter_gather_exit:
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0
  *         mov           <xmm_spill_addr> -> %ecx
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1
- *         vmovdqa       %xmm2 -> (%ecx)[16byte]
+ *         vmovdqa       %xmm3 -> (%ecx)[16byte]
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2
  *         vextracti128  %ymm2 $0x00 -> %xmm3
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3

--- a/suite/tests/client-interface/drx-scattergather.c
+++ b/suite/tests/client-interface/drx-scattergather.c
@@ -156,6 +156,11 @@ test_avx512_restore_gather_mask_fault(uint32_t *ref_sparse_test_buf,
                                       uint32_t *test_idx32_vec);
 /* See comment above. */
 void
+test_avx512_restore_gather_scratch_xmm_fault(uint32_t *ref_sparse_test_buf,
+                                             uint32_t *test_idx32_vec,
+                                             uint32_t *scratch_xmm_val);
+/* See comment above. */
+void
 test_avx512_restore_gather_mask_clobber(uint32_t *ref_sparse_test_buf,
                                         uint32_t *test_idx32_vec);
 /* See comment above. */
@@ -166,6 +171,12 @@ test_avx512_restore_gather_mask_update(uint32_t *ref_sparse_test_buf,
 void
 test_avx512_restore_scatter_mask_fault(uint32_t *xmm_ymm_zmm, uint32_t *test_idx32_vec,
                                        uint32_t *output_sparse_test_buf OUT);
+/* See comment above. */
+void
+test_avx512_restore_scatter_scratch_xmm_fault(uint32_t *xmm_ymm_zmm,
+                                              uint32_t *test_idx32_vec,
+                                              uint32_t *output_sparse_test_buf OUT,
+                                              uint32_t *scratch_xmm_fault);
 /* See comment above. */
 void
 test_avx512_restore_scatter_mask_clobber(uint32_t *xmm_ymm_zmm, uint32_t *test_idx32_vec,
@@ -180,6 +191,11 @@ test_avx512_restore_scatter_mask_update(uint32_t *xmm_ymm_zmm, uint32_t *test_id
 void
 test_avx2_restore_gather_mask_update(uint32_t *ref_sparse_test_buf,
                                      uint32_t *test_idx32_vec);
+/* See comment above. */
+void
+test_avx2_restore_gather_scratch_xmm_fault(uint32_t *ref_sparse_test_buf,
+                                           uint32_t *test_idx32_vec,
+                                           uint32_t *scratch_xmm_val);
 #    endif
 
 #    define SPARSE_FACTOR 4
@@ -195,7 +211,7 @@ test_avx2_restore_gather_mask_update(uint32_t *ref_sparse_test_buf,
 
 #    ifdef UNIX
 static SIGJMP_BUF mark;
-
+static uint32_t scratch_xmm_val[] = { 0xdead, 0xbeef, 0x8bad, 0xf00d };
 static int
 get_xstate_area_offs(int xstate_component)
 {
@@ -218,6 +234,39 @@ signal_handler_check_k0(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
      * 32-bit mode by the kernel.
      */
 #        endif
+    SIGLONGJMP(mark, 1);
+}
+
+static bool
+check_scratch_xmm_val(ucontext_t *ucxt, int xmm_reg_id)
+{
+    kernel_fpstate_t *fp = (kernel_fpstate_t *)ucxt->uc_mcontext.fpregs;
+#        ifdef X64
+    return fp->xmm_space[xmm_reg_id * 4] == scratch_xmm_val[0] &&
+        fp->xmm_space[xmm_reg_id * 4 + 1] == scratch_xmm_val[1] &&
+        fp->xmm_space[xmm_reg_id * 4 + 2] == scratch_xmm_val[2] &&
+        fp->xmm_space[xmm_reg_id * 4 + 3] == scratch_xmm_val[3];
+#        else
+    return fp->_xmm[xmm_reg_id].element[0] == scratch_xmm_val[0] &&
+        fp->_xmm[xmm_reg_id].element[1] == scratch_xmm_val[1] &&
+        fp->_xmm[xmm_reg_id].element[2] == scratch_xmm_val[2] &&
+        fp->_xmm[xmm_reg_id].element[3] == scratch_xmm_val[3];
+#        endif
+}
+
+static void
+signal_handler_check_xmm2(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
+{
+    if (!check_scratch_xmm_val(ucxt, 2))
+        print("Scratch xmm2 not restored\n");
+    SIGLONGJMP(mark, 1);
+}
+
+static void
+signal_handler_check_xmm3(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
+{
+    if (!check_scratch_xmm_val(ucxt, 3))
+        print("Scratch xmm3 not restored\n");
     SIGLONGJMP(mark, 1);
 }
 
@@ -562,12 +611,30 @@ test_avx2_avx512_scatter_gather(void)
     /* This index will cause a fault. The index number is arbitrary.*/
     test_idx32_vec[9] = 0xefffffff;
     print("Test restoring the AVX-512 gather scratch mask register upon a fault\n");
-    if (SIGSETJMP(mark) == 0)
+    if (SIGSETJMP(mark) == 0) {
         test_avx512_restore_gather_mask_fault(ref_sparse_test_buf, test_idx32_vec);
+        print("ERROR: Expected a fault\n");
+    }
     print("Test restoring the AVX-512 scatter scratch mask register upon a fault\n");
     if (SIGSETJMP(mark) == 0) {
         test_avx512_restore_scatter_mask_fault(ref_idx32_val32_xmm_ymm_zmm,
                                                test_idx32_vec, output_sparse_test_buf);
+        print("ERROR: Expected a fault\n");
+    }
+
+    intercept_signal(SIGSEGV, (handler_3_t)&signal_handler_check_xmm2, false);
+    print("Test restoring the AVX-512 gather scratch xmm register upon a fault\n");
+    if (SIGSETJMP(mark) == 0) {
+        test_avx512_restore_gather_scratch_xmm_fault(ref_sparse_test_buf, test_idx32_vec,
+                                                     scratch_xmm_val);
+        print("ERROR: Expected a fault\n");
+    }
+    print("Test restoring the AVX-512 scatter scratch xmm register upon a fault\n");
+    if (SIGSETJMP(mark) == 0) {
+        test_avx512_restore_scatter_scratch_xmm_fault(
+            ref_idx32_val32_xmm_ymm_zmm, test_idx32_vec, output_sparse_test_buf,
+            scratch_xmm_val);
+        print("ERROR: Expected a fault\n");
     }
     /* We will get the SIGILL from a ud2 instruction that the client will insert. */
     intercept_signal(SIGILL, (handler_3_t)&signal_handler_check_k0, false);
@@ -604,6 +671,14 @@ test_avx2_avx512_scatter_gather(void)
     print("Test updating the AVX2 gather mask register upon translation events\n");
     if (SIGSETJMP(mark) == 0)
         test_avx2_restore_gather_mask_update(ref_idx32_val32_xmm_ymm_zmm, test_idx32_vec);
+    print("Test restoring the AVX2 gather scratch xmm register upon a fault\n");
+    intercept_signal(SIGSEGV, (handler_3_t)&signal_handler_check_xmm3, false);
+    test_idx32_vec[1] = 0xefffffff;
+    if (SIGSETJMP(mark) == 0) {
+        test_avx2_restore_gather_scratch_xmm_fault(ref_idx32_val32_xmm_ymm_zmm,
+                                                   test_idx32_vec, scratch_xmm_val);
+        print("ERROR: Expected a fault\n");
+    }
 #    endif
     return true;
 }
@@ -896,11 +971,14 @@ DECLARE_FUNC_SEH(FUNCNAME(name))                            @N@\
   GLOBAL_LABEL(FUNCNAME(name):)                             @N@\
         /* uint32_t *ref_sparse_test_buf */                 @N@\
         mov        REG_XAX, ARG1                            @N@\
+        /* uint32_t *scratch_xmm_val */                     @N@\
+        mov        REG_XCX, ARG3                            @N@\
         /* uint32_t *test_idx32_vec */                      @N@\
         mov        REG_XDX, ARG2                            @N@\
         PUSH_CALLEE_SAVED_REGS()                            @N@\
         sub        REG_XSP, FRAME_PADDING                   @N@\
         END_PROLOG                                          @N@\
+        vmovdqu32  xmm2, [REG_XCX]                          @N@\
         mov        REG_XCX, marker                          @N@\
         mov        REG_XCX, marker                          @N@\
         vmovdqu32  zmm1, [REG_XDX]                          @N@\
@@ -918,13 +996,16 @@ DECLARE_FUNC_SEH(FUNCNAME(name))                             @N@\
   GLOBAL_LABEL(FUNCNAME(name):)                              @N@\
         /* uint32_t *xmm_ymm_zmm */                          @N@\
         mov         REG_XAX, ARG1                            @N@\
+        /* uint32_t *scratch_xmm_val */                      @N@\
+        mov         REG_XDI, ARG4                            @N@\
         /* uint32_t *output_sparse_test_buf OUT */           @N@\
-        mov        REG_XCX, ARG3                             @N@\
+        mov         REG_XCX, ARG3                            @N@\
         /* uint32_t *test_idx32_vec */                       @N@\
         mov         REG_XDX, ARG2                            @N@\
         PUSH_CALLEE_SAVED_REGS()                             @N@\
         sub         REG_XSP, FRAME_PADDING                   @N@\
         END_PROLOG                                           @N@\
+        vmovdqu32   xmm2, [REG_XDI]                          @N@\
         vmovdqu32   zmm0, [REG_XAX + 48]                     @N@\
         mov         REG_XAX, marker                          @N@\
         mov         REG_XAX, marker                          @N@\
@@ -941,6 +1022,8 @@ DECLARE_FUNC_SEH(FUNCNAME(name))                             @N@\
 /* No marker is needed for the fault test. */
 TEST_AVX512_GATHER_MASK_RESTORE_EVENT(restore_gather_mask_fault, 0x0)
 TEST_AVX512_SCATTER_MASK_RESTORE_EVENT(restore_scatter_mask_fault, 0x0)
+TEST_AVX512_GATHER_MASK_RESTORE_EVENT(restore_gather_scratch_xmm_fault, 0x0)
+TEST_AVX512_SCATTER_MASK_RESTORE_EVENT(restore_scatter_scratch_xmm_fault, 0x0)
 /* These tests depend on markers being present. */
 TEST_AVX512_GATHER_MASK_RESTORE_EVENT(restore_gather_mask_clobber,
                                       TEST_AVX512_GATHER_MASK_CLOBBER_MARKER)
@@ -1074,11 +1157,14 @@ DECLARE_FUNC_SEH(FUNCNAME(name))                          @N@\
   GLOBAL_LABEL(FUNCNAME(name):)                           @N@\
         /* uint32_t *ref_sparse_test_buf */               @N@\
         mov           REG_XAX, ARG1                       @N@\
+        /* uint32_t *scratch_xmm_val */                   @N@\
+        mov           REG_XCX, ARG3                       @N@\
         /* uint32_t *test_idx32_vec */                    @N@\
         mov           REG_XDX, ARG2                       @N@\
         PUSH_CALLEE_SAVED_REGS()                          @N@\
         sub           REG_XSP, FRAME_PADDING              @N@\
         END_PROLOG                                        @N@\
+        vmovdqu       xmm3, [REG_XCX]                     @N@\
         mov           REG_XCX, marker                     @N@\
         mov           REG_XCX, marker                     @N@\
         vmovdqu       ymm1, [REG_XDX]                     @N@\
@@ -1094,6 +1180,7 @@ DECLARE_FUNC_SEH(FUNCNAME(name))                          @N@\
  */
 TEST_AVX2_GATHER_MASK_RESTORE_EVENT(restore_gather_mask_update,
                                     TEST_AVX2_GATHER_MASK_UPDATE_MARKER)
+TEST_AVX2_GATHER_MASK_RESTORE_EVENT(restore_gather_scratch_xmm_fault, 0x0)
 
 #endif /* __AVX__ */
 

--- a/suite/tests/client-interface/drx-scattergather.c
+++ b/suite/tests/client-interface/drx-scattergather.c
@@ -1040,6 +1040,8 @@ DECLARE_FUNC_SEH(FUNCNAME(name))                            @N@\
         END_PROLOG                                          @N@\
         vmovdqu32  xmm2, [REG_XCX]                          @N@\
         vmovdqu32  zmm1, [REG_XDX]                          @N@\
+        movw       dx, 0xffff                               @N@\
+        kmovw      k1, edx                                  @N@\
         vpgatherdd zmm0 {k1}, [REG_XAX + zmm1 * 4]          @N@\
         add        REG_XSP, FRAME_PADDING                   @N@\
         POP_CALLEE_SAVED_REGS()                             @N@\
@@ -1063,6 +1065,8 @@ DECLARE_FUNC_SEH(FUNCNAME(name))                             @N@\
         vmovdqu32   xmm2, [REG_XDI]                          @N@\
         vmovdqu32   zmm0, [REG_XAX + 48]                     @N@\
         vmovdqu32   zmm1, [REG_XDX]                          @N@\
+        movw        dx, 0xffff                               @N@\
+        kmovw       k1, edx                                  @N@\
         vpscatterdd [REG_XCX + zmm1 * 4] {k1}, zmm0          @N@\
         add         REG_XSP, FRAME_PADDING                   @N@\
         POP_CALLEE_SAVED_REGS()                              @N@\

--- a/suite/tests/client-interface/drx-scattergather.templatex
+++ b/suite/tests/client-interface/drx-scattergather.templatex
@@ -133,6 +133,8 @@ AVX2 gather ok
 #ifdef __AVX512F__
 Test restoring the AVX-512 gather scratch mask register upon a fault
 Test restoring the AVX-512 scatter scratch mask register upon a fault
+Test restoring the AVX-512 gather scratch xmm register upon a fault
+Test restoring the AVX-512 scatter scratch xmm register upon a fault
 Test restoring the AVX-512 gather mask register upon translation events
 /* FIXME i2985: remove all errors below once restore event has been implemented in drx. */
 Test restoring the AVX-512 scatter mask register upon translation events
@@ -140,22 +142,23 @@ Test updating the AVX-512 gather mask register upon translation events
 Test updating the AVX-512 scatter mask register upon translation events
 #endif
 Test updating the AVX2 gather mask register upon translation events
+Test restoring the AVX2 gather scratch xmm register upon a fault
 #endif
 AVX2/AVX-512 scatter/gather checks ok
 #ifndef TEST_SAMPLE_CLIENT
 #ifdef X64
 #ifdef __AVX512F__
-event_exit, 269 scatter/gather instructions
+event_exit, 272 scatter/gather instructions
 #elif defined(__AVX__)
-event_exit, 215 scatter/gather instructions
+event_exit, 216 scatter/gather instructions
 #else
 event_exit, 0 scatter/gather instructions
 #endif
 #else
 #ifdef __AVX512F__
-event_exit, 221 scatter/gather instructions
+event_exit, 224 scatter/gather instructions
 #elif defined(__AVX__)
-event_exit, 203 scatter/gather instructions
+event_exit, 204 scatter/gather instructions
 #else
 event_exit, 0 scatter/gather instructions
 #endif


### PR DESCRIPTION
Preserves the scratch xmm register by spilling it before the scatter/gather
instr expansion, and restoring it after. We use memory obtained from the
thread-private heap, using dr_thread_alloc, as the spill slot.

Reserves TLS slot for every thread in drx, to store the allocated pointer to the
xmm spill slot.

Extends drx's state restore to also restore the app value of the spilled xmm
register.

An alternate approach was to extend drreg to make it capable of spilling xmm
regs too, but that was overkill as the scatter/gather expansion requires only
a small subset of that functionality that is very easily implemented as a set of
manual spill and restore. When that support is available in drreg (#3844) we
can use it here too; added a TODO.

Also extends the pure-asm scatter/gather test to verify that the scratch reg
(which is xmm0 in the test, given that we always select the lowest-numbered
available xmm reg as scratch) value is preserved across the scatter/gather
instrs.

Also fixes an issue with comparison of xmm regs in the test. `cmpss` writes
the result of comparison to the first reg, not the aflags. (We had replaced
`vpcmpud` with `cmpss` in 106bf952d9c7aca020d52a03e2f3adc33cb208b7 due to some `SIGILL` issues.)

Issues: #2985