### PR TITLE
i#5166: test if random inst is decodeable before fully decoding in drstatecmp-fuzz test

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -4510,6 +4510,13 @@ encode_opnds_tbz(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
 
 /******************************************************************************/
 
+bool
+decode_supported(dcontext_t *dcontext, byte *pc, instr_t *instr)
+{
+    uint enc = *(uint *)pc;
+    return decoder(enc, dcontext, pc, instr);
+}
+
 byte *
 decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
 {

--- a/core/ir/aarch64/codec.h
+++ b/core/ir/aarch64/codec.h
@@ -37,6 +37,9 @@
 
 #define ENCFAIL (uint)0xFFFFFFFF /* a value that is not a valid instruction */
 
+bool
+decode_supported(dcontext_t *dcontext, byte *pc, instr_t *instr);
+
 byte *
 decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr);
 uint

--- a/core/ir/aarch64/decode.c
+++ b/core/ir/aarch64/decode.c
@@ -85,6 +85,17 @@ decode_opcode(dcontext_t *dcontext, byte *pc, instr_t *instr)
     return NULL;
 }
 
+bool
+decode_supported_op(void *drcontext, byte *pc)
+{
+    dcontext_t *dcontext = (dcontext_t *)drcontext;
+    instr_t instr;
+    instr_init(dcontext, &instr);
+    bool supported = decode_supported(dcontext, pc, instr);
+    instr_free(dcontext, &instr);
+    return supported;
+}
+
 byte *
 decode(void *drcontext, byte *pc, instr_t *instr)
 {

--- a/core/ir/decode_api.h
+++ b/core/ir/decode_api.h
@@ -57,6 +57,16 @@ DR_API
 byte *
 decode_eflags_usage(void *drcontext, byte *pc, uint *usage, dr_opnd_query_flags_t flags);
 
+#ifdef AARCH64
+DR_API
+/**
+ * Attempts to decode the instruction at address \p pc to determine if the
+ * instruction is supported by the decoder.
+ * Returns false on decoding an invalid or unsupported instruction.
+ */
+decode_supported_op(void *drcontext, byte *pc);
+#endif /* AARCH64 */
+
 DR_API
 /**
  * Decodes the instruction at address \p pc into \p instr, filling in the


### PR DESCRIPTION
Fixes a raised assertion in drstatecmp-fuzz test when an invalid register
is passed to opnd_create_reg. The solution is to avoid fully decoding the
random instruction but first test whether it is valid and supported by
the decoder.

Fixes: #5166