### PR TITLE
i#5076 trace invariants, part 6: Count memrefs in view tool

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -556,6 +556,16 @@ if (BUILD_TESTS)
     add_test(NAME tool.drcachesim.invariant_checker_test
              COMMAND tool.drcachesim.invariant_checker_test)
 
+    add_executable(tool.drcacheoff.view_test tests/view_test.cpp)
+    configure_DynamoRIO_standalone(tool.drcacheoff.view_test)
+    add_win32_flags(tool.drcacheoff.view_test)
+    target_link_libraries(tool.drcacheoff.view_test drmemtrace_view drmemtrace_raw2trace)
+    use_DynamoRIO_extension(tool.drcacheoff.view_test drreg_static)
+    use_DynamoRIO_extension(tool.drcacheoff.view_test drcovlib_static)
+    use_DynamoRIO_extension(tool.drcacheoff.view_test drdecode)
+    add_test(NAME tool.drcacheoff.view_test
+      COMMAND tool.drcacheoff.view_test)
+
     add_executable(tool.drcacheoff.burst_static tests/burst_static.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_static)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_static drmemtrace_static)

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -41,6 +41,7 @@
 
 #include "../tools/invariant_checker.h"
 #include "../common/memref.h"
+#include "memref_gen.h"
 
 namespace {
 
@@ -60,49 +61,6 @@ protected:
             errors.push_back(message);
     }
 };
-
-memref_t
-gen_instr_type(trace_type_t type, memref_tid_t tid, addr_t pc)
-{
-    memref_t memref = {};
-    memref.instr.type = type;
-    memref.instr.tid = tid;
-    memref.instr.addr = pc;
-    memref.instr.size = 1;
-    return memref;
-}
-
-memref_t
-gen_instr(memref_tid_t tid, addr_t pc)
-{
-    return gen_instr_type(TRACE_TYPE_INSTR, tid, pc);
-}
-
-memref_t
-gen_branch(memref_tid_t tid, addr_t pc)
-{
-    return gen_instr_type(TRACE_TYPE_INSTR_CONDITIONAL_JUMP, tid, pc);
-}
-
-memref_t
-gen_marker(memref_tid_t tid, trace_marker_type_t type, uintptr_t val)
-{
-    memref_t memref = {};
-    memref.marker.type = TRACE_TYPE_MARKER;
-    memref.marker.tid = tid;
-    memref.marker.marker_type = type;
-    memref.marker.marker_value = val;
-    return memref;
-}
-
-memref_t
-gen_exit(memref_tid_t tid)
-{
-    memref_t memref = {};
-    memref.instr.type = TRACE_TYPE_THREAD_EXIT;
-    memref.instr.tid = tid;
-    return memref;
-}
 
 /* Assumes there are at most 3 threads with tids 1, 2, and 3 in memrefs. */
 bool

--- a/clients/drcachesim/tests/memref_gen.h
+++ b/clients/drcachesim/tests/memref_gen.h
@@ -1,0 +1,96 @@
+/* **********************************************************
+ * Copyright (c) 2021 Google, LLC  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, LLC OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef _MEMREF_GEN_
+#define _MEMREF_GEN_ 1
+
+#include "../common/memref.h"
+
+namespace {
+
+inline memref_t
+gen_data(memref_tid_t tid, bool load, addr_t addr, size_t size)
+{
+    memref_t memref = {};
+    memref.instr.type = load ? TRACE_TYPE_READ : TRACE_TYPE_WRITE;
+    memref.instr.tid = tid;
+    memref.instr.addr = addr;
+    memref.instr.size = size;
+    return memref;
+}
+
+inline memref_t
+gen_instr_type(trace_type_t type, memref_tid_t tid, addr_t pc)
+{
+    memref_t memref = {};
+    memref.instr.type = type;
+    memref.instr.tid = tid;
+    memref.instr.addr = pc;
+    memref.instr.size = 1;
+    return memref;
+}
+
+inline memref_t
+gen_instr(memref_tid_t tid, addr_t pc)
+{
+    return gen_instr_type(TRACE_TYPE_INSTR, tid, pc);
+}
+
+inline memref_t
+gen_branch(memref_tid_t tid, addr_t pc)
+{
+    return gen_instr_type(TRACE_TYPE_INSTR_CONDITIONAL_JUMP, tid, pc);
+}
+
+inline memref_t
+gen_marker(memref_tid_t tid, trace_marker_type_t type, uintptr_t val)
+{
+    memref_t memref = {};
+    memref.marker.type = TRACE_TYPE_MARKER;
+    memref.marker.tid = tid;
+    memref.marker.marker_type = type;
+    memref.marker.marker_value = val;
+    return memref;
+}
+
+inline memref_t
+gen_exit(memref_tid_t tid)
+{
+    memref_t memref = {};
+    memref.instr.type = TRACE_TYPE_THREAD_EXIT;
+    memref.instr.tid = tid;
+    return memref;
+}
+
+} // namespace
+
+#endif /* _MEMREF_GEN_ */

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -1,0 +1,263 @@
+/* **********************************************************
+ * Copyright (c) 2021 Google, LLC  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, LLC OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Unit tests for the view_t tool. */
+
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+#include "../tools/view.h"
+#include "../common/memref.h"
+#include "../tracer/raw2trace.h"
+
+#define ASSERT(cond, msg, ...)        \
+    do {                              \
+        if (!(cond)) {                \
+            std::cerr << msg << "\n"; \
+            abort();                  \
+        }                             \
+    } while (0)
+
+#define CHECK(cond, msg, ...)         \
+    do {                              \
+        if (!(cond)) {                \
+            std::cerr << msg << "\n"; \
+            return false;             \
+        }                             \
+    } while (0)
+
+namespace {
+
+// Subclasses module_mapper_t and replaces the module loading with a buffer
+// of encoded instr_t.
+class module_mapper_test_t : public module_mapper_t {
+public:
+    module_mapper_test_t(instrlist_t &instrs, void *drcontext)
+        : module_mapper_t(nullptr)
+    {
+        byte *pc = instrlist_encode(drcontext, &instrs, decode_buf_, true);
+        ASSERT(pc - decode_buf_ < MAX_DECODE_SIZE, "decode buffer overflow");
+        // Clear do_module_parsing error; we can't cleanly make virtual b/c it's
+        // called from the constructor.
+        last_error_ = "";
+    }
+
+protected:
+    void
+    read_and_map_modules(void) override
+    {
+        modvec_.push_back(module_t("fake_exe", 0, decode_buf_, 0, MAX_DECODE_SIZE,
+                                   MAX_DECODE_SIZE, true));
+    }
+
+private:
+    static const int MAX_DECODE_SIZE = 1024;
+    byte decode_buf_[MAX_DECODE_SIZE];
+};
+
+class view_test_t : public view_t {
+public:
+    view_test_t(instrlist_t &instrs, void *drcontext, uint64_t skip_refs,
+                uint64_t sim_refs)
+        : view_t("", skip_refs, sim_refs, "", 0)
+    {
+        module_mapper_ =
+            std::unique_ptr<module_mapper_t>(new module_mapper_test_t(instrs, drcontext));
+    }
+
+    std::string
+    initialize() override
+    {
+        module_mapper_->get_loaded_modules();
+        dr_disasm_flags_t flags =
+            IF_X86_ELSE(DR_DISASM_ATT, IF_AARCH64_ELSE(DR_DISASM_DR, DR_DISASM_ARM));
+        disassemble_set_syntax(flags);
+        return "";
+    }
+};
+
+memref_t
+gen_data(memref_tid_t tid, bool load, addr_t addr, size_t size)
+{
+    memref_t memref = {};
+    memref.instr.type = load ? TRACE_TYPE_READ : TRACE_TYPE_WRITE;
+    memref.instr.tid = tid;
+    memref.instr.addr = addr;
+    memref.instr.size = size;
+    return memref;
+}
+
+memref_t
+gen_instr_type(trace_type_t type, memref_tid_t tid, addr_t pc)
+{
+    memref_t memref = {};
+    memref.instr.type = type;
+    memref.instr.tid = tid;
+    memref.instr.addr = pc;
+    memref.instr.size = 1;
+    return memref;
+}
+
+memref_t
+gen_instr(memref_tid_t tid, addr_t pc)
+{
+    return gen_instr_type(TRACE_TYPE_INSTR, tid, pc);
+}
+
+memref_t
+gen_branch(memref_tid_t tid, addr_t pc)
+{
+    return gen_instr_type(TRACE_TYPE_INSTR_CONDITIONAL_JUMP, tid, pc);
+}
+
+memref_t
+gen_marker(memref_tid_t tid, trace_marker_type_t type, uintptr_t val)
+{
+    memref_t memref = {};
+    memref.marker.type = TRACE_TYPE_MARKER;
+    memref.marker.tid = tid;
+    memref.marker.marker_type = type;
+    memref.marker.marker_value = val;
+    return memref;
+}
+
+std::string
+run_test_helper(view_test_t &view, const std::vector<memref_t> &memrefs)
+{
+    view.initialize();
+    // Capture cerr.
+    std::stringstream capture;
+    std::streambuf *prior = std::cerr.rdbuf(capture.rdbuf());
+    // Run the tool.
+    for (const auto &memref : memrefs) {
+        if (!view.process_memref(memref))
+            std::cout << "Hit error: " << view.get_error_string() << "\n";
+    }
+    // Return the result.
+    std::string res = capture.str();
+    std::cerr.rdbuf(prior);
+    return res;
+}
+
+bool
+test_no_limit(instrlist_t &ilist, const std::vector<memref_t> &memrefs, void *drcontext)
+{
+    view_test_t view(ilist, drcontext, 0, 0);
+    std::string res = run_test_helper(view, memrefs);
+    if (std::count(res.begin(), res.end(), '\n') != static_cast<int>(memrefs.size())) {
+        std::cerr << "Incorrect line count\n";
+        return false;
+    }
+    return true;
+}
+
+bool
+test_num_memrefs(instrlist_t &ilist, const std::vector<memref_t> &memrefs,
+                 void *drcontext)
+{
+    const int num_memrefs = 3;
+    ASSERT(num_memrefs < memrefs.size(), "need more memrefs to limit");
+    view_test_t view(ilist, drcontext, num_memrefs, 0);
+    std::string res = run_test_helper(view, memrefs);
+    if (std::count(res.begin(), res.end(), '\n') != num_memrefs) {
+        std::cerr << "Incorrect num_memrefs count\n";
+        return false;
+    }
+    return true;
+}
+
+bool
+test_skip_memrefs(instrlist_t &ilist, const std::vector<memref_t> &memrefs,
+                  void *drcontext)
+{
+    const int skip_memrefs = 2;
+    const int num_memrefs = 2;
+    ASSERT(num_memrefs + skip_memrefs <= memrefs.size(), "need more memrefs to skip");
+    view_test_t view(ilist, drcontext, num_memrefs, skip_memrefs);
+    std::string res = run_test_helper(view, memrefs);
+    if (std::count(res.begin(), res.end(), '\n') != num_memrefs) {
+        std::cerr << "Incorrect skipped num_memrefs count\n";
+        return false;
+    }
+    return true;
+}
+
+bool
+run_limit_tests(void *drcontext)
+{
+    bool res = true;
+
+    instrlist_t *ilist = instrlist_create(drcontext);
+    // raw2trace doesn't like offsets of 0 so we shift with a nop.
+    instr_t *nop1 = XINST_CREATE_nop(drcontext);
+    instr_t *nop2 = XINST_CREATE_nop(drcontext);
+    instr_t *jcc = XINST_CREATE_jump_cond(drcontext, DR_PRED_EQ, opnd_create_instr(nop2));
+    instrlist_append(ilist, nop1);
+    instrlist_append(ilist, jcc);
+    instrlist_append(ilist, nop2);
+    size_t offs_nop1 = 0;
+    size_t offs_jz = offs_nop1 + instr_length(drcontext, nop1);
+    size_t offs_nop2 = offs_jz + instr_length(drcontext, jcc);
+
+    const memref_tid_t t1 = 3;
+    std::vector<memref_t> memrefs = {
+        gen_marker(t1, TRACE_MARKER_TYPE_VERSION, 3),
+        gen_marker(t1, TRACE_MARKER_TYPE_FILETYPE, 0),
+        gen_marker(t1, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+        gen_instr(t1, offs_nop1),
+        gen_data(t1, true, 0x42, 4),
+        gen_branch(t1, offs_jz),
+        gen_branch(t1, offs_nop2),
+        gen_data(t1, true, 0x42, 4),
+    };
+
+    res = test_no_limit(*ilist, memrefs, drcontext) && res;
+    res = test_num_memrefs(*ilist, memrefs, drcontext) && res;
+    res = test_skip_memrefs(*ilist, memrefs, drcontext) && res;
+
+    instrlist_clear_and_destroy(drcontext, ilist);
+    return res;
+}
+} // namespace
+
+int
+main(int argc, const char *argv[])
+{
+    void *drcontext = dr_standalone_init();
+    if (run_limit_tests(drcontext)) {
+        std::cerr << "view_test passed\n";
+        return 0;
+    }
+    std::cerr << "view_test FAILED\n";
+    exit(1);
+}

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -223,11 +223,11 @@ run_limit_tests(void *drcontext)
     };
 
     res = test_no_limit(drcontext, *ilist, memrefs) && res;
-    for (size_t i = 1; i < memrefs.size(); ++i) {
+    for (int i = 1; i < static_cast<int>(memrefs.size()); ++i) {
         res = test_num_memrefs(drcontext, *ilist, memrefs, i) && res;
     }
     // We primarily test skipping the initial markers.
-    for (size_t i = 1; i < 6; ++i) {
+    for (int i = 1; i < 6; ++i) {
         res = test_skip_memrefs(drcontext, *ilist, memrefs, i) && res;
     }
 

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -60,9 +60,9 @@ view_t::view_t(const std::string &module_file_path, uint64_t skip_refs, uint64_t
     : module_file_path_(module_file_path)
     , knob_verbose_(verbose)
     , trace_version_(-1)
-    , instr_count_(0)
     , knob_skip_refs_(skip_refs)
     , knob_sim_refs_(sim_refs)
+    , refs_limited_(knob_sim_refs_ > 0)
     , knob_syntax_(syntax)
     , knob_alt_module_dir_(alt_module_dir)
     , num_disasm_instrs_(0)
@@ -114,7 +114,7 @@ view_t::process_memref(const memref_t &memref)
                 error_string_ = std::string("Version mismatch across files");
                 return false;
             }
-            break;
+            return true; // Do not count toward -sim_refs yet b/c we don't have tid.
         case TRACE_MARKER_TYPE_FILETYPE:
             // We delay printing until we know the tid.
             if (filetype_ == -1)
@@ -131,17 +131,22 @@ view_t::process_memref(const memref_t &memref)
                     " but tool built for " + trace_arch_string(build_target_arch_type());
                 return false;
             }
-            break;
+            return true; // Do not count toward -sim_refs yet b/c we don't have tid.
         default: break;
         }
     }
 
-    if (instr_count_ < knob_skip_refs_ ||
-        instr_count_ >= (knob_skip_refs_ + knob_sim_refs_)) {
-        if (type_is_instr(memref.instr.type) ||
-            memref.data.type == TRACE_TYPE_INSTR_NO_FETCH)
-            ++instr_count_;
+    if (knob_skip_refs_ > 0) {
+        knob_skip_refs_--;
+        // I considered printing the version and filetype even when skipped but
+        // it adds more confusion from the memref counting than it removes.
+        // A user can do two views, one without a skip, to see the headers.
         return true;
+    }
+    if (refs_limited_) {
+        if (knob_sim_refs_ == 0)
+            return true;
+        knob_sim_refs_--;
     }
 
     if (memref.instr.tid != 0) {
@@ -151,19 +156,17 @@ view_t::process_memref(const memref_t &memref)
         std::cerr << "T" << memref.instr.tid << " ";
     }
 
-    if (memref.marker.type == TRACE_TYPE_MARKER ||
-        // When skipping there may not be a marker and we want to print out the version.
-        // We keep the marker
-        (knob_sim_refs_ > 0 && instr_count_ == knob_skip_refs_)) {
-        if (memref.marker.tid != 0 &&
-            printed_header_.find(memref.marker.tid) == printed_header_.end()) {
-            printed_header_.insert(memref.marker.tid);
-            std::cerr << "<marker: version " << trace_version_ << ">\n";
-            std::cerr << "T" << memref.marker.tid << " ";
-            std::cerr << "<marker: filetype 0x" << std::hex << filetype_ << std::dec
-                      << ">\n";
-            std::cerr << "T" << memref.marker.tid << " ";
-        }
+    if (memref.marker.type == TRACE_TYPE_MARKER && memref.marker.tid != 0 &&
+        printed_header_.find(memref.marker.tid) == printed_header_.end()) {
+        if (knob_sim_refs_ <= 2)
+            knob_sim_refs_ = 0;
+        else
+            knob_sim_refs_ -= 2;
+        printed_header_.insert(memref.marker.tid);
+        std::cerr << "<marker: version " << trace_version_ << ">\n";
+        std::cerr << "T" << memref.marker.tid << " ";
+        std::cerr << "<marker: filetype 0x" << std::hex << filetype_ << std::dec << ">\n";
+        std::cerr << "T" << memref.marker.tid << " ";
     }
 
     if (memref.marker.type == TRACE_TYPE_MARKER) {
@@ -243,8 +246,6 @@ view_t::process_memref(const memref_t &memref)
         }
         return true;
     }
-
-    ++instr_count_;
 
     app_pc mapped_pc;
     app_pc orig_pc = (app_pc)memref.instr.addr;

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -61,8 +61,9 @@ view_t::view_t(const std::string &module_file_path, uint64_t skip_refs, uint64_t
     , knob_verbose_(verbose)
     , trace_version_(-1)
     , knob_skip_refs_(skip_refs)
+    , skip_refs_left_(knob_skip_refs_)
     , knob_sim_refs_(sim_refs)
-    , refs_limited_(knob_sim_refs_ > 0)
+    , sim_refs_left_(knob_sim_refs_)
     , knob_syntax_(syntax)
     , knob_alt_module_dir_(alt_module_dir)
     , num_disasm_instrs_(0)
@@ -101,6 +102,24 @@ view_t::initialize()
 }
 
 bool
+view_t::should_skip()
+{
+    if (skip_refs_left_ > 0) {
+        skip_refs_left_--;
+        // I considered printing the version and filetype even when skipped but
+        // it adds more confusion from the memref counting than it removes.
+        // A user can do two views, one without a skip, to see the headers.
+        return true;
+    }
+    if (knob_sim_refs_ > 0) {
+        if (sim_refs_left_ == 0)
+            return true;
+        sim_refs_left_--;
+    }
+    return false;
+}
+
+bool
 view_t::process_memref(const memref_t &memref)
 {
     // Even for -skip_refs we need to process the up-front version and type.
@@ -136,37 +155,35 @@ view_t::process_memref(const memref_t &memref)
         }
     }
 
-    if (knob_skip_refs_ > 0) {
-        knob_skip_refs_--;
-        // I considered printing the version and filetype even when skipped but
-        // it adds more confusion from the memref counting than it removes.
-        // A user can do two views, one without a skip, to see the headers.
+    // We delay the initial markers until we know the tid.
+    // There are always at least 2 markers (timestamp+cpu) immediately after the
+    // first two, and on newer versions there is a 3rd (line size).
+    if (memref.marker.type == TRACE_TYPE_MARKER && memref.marker.tid != 0 &&
+        printed_header_.find(memref.marker.tid) == printed_header_.end()) {
+        printed_header_.insert(memref.marker.tid);
+        if (trace_version_ != -1) { // Old versions may not have a version marker.
+            if (!should_skip()) {
+                std::cerr << "T" << memref.marker.tid << " "
+                          << "<marker: version " << trace_version_ << ">\n";
+            }
+        }
+        if (filetype_ != -1) { // Handle old/malformed versions.
+            if (!should_skip()) {
+                std::cerr << "T" << memref.marker.tid << " "
+                          << "<marker: filetype 0x" << std::hex << filetype_ << std::dec
+                          << ">\n";
+            }
+        }
+    }
+
+    if (should_skip())
         return true;
-    }
-    if (refs_limited_) {
-        if (knob_sim_refs_ == 0)
-            return true;
-        knob_sim_refs_--;
-    }
 
     if (memref.instr.tid != 0) {
         if (prev_tid_ != -1 && prev_tid_ != memref.instr.tid)
             std::cerr << "------------------------------------------------------------\n";
         prev_tid_ = memref.instr.tid;
         std::cerr << "T" << memref.instr.tid << " ";
-    }
-
-    if (memref.marker.type == TRACE_TYPE_MARKER && memref.marker.tid != 0 &&
-        printed_header_.find(memref.marker.tid) == printed_header_.end()) {
-        if (knob_sim_refs_ <= 2)
-            knob_sim_refs_ = 0;
-        else
-            knob_sim_refs_ -= 2;
-        printed_header_.insert(memref.marker.tid);
-        std::cerr << "<marker: version " << trace_version_ << ">\n";
-        std::cerr << "T" << memref.marker.tid << " ";
-        std::cerr << "<marker: filetype 0x" << std::hex << filetype_ << std::dec << ">\n";
-        std::cerr << "T" << memref.marker.tid << " ";
     }
 
     if (memref.marker.type == TRACE_TYPE_MARKER) {

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -64,6 +64,9 @@ protected:
         void *dcontext = nullptr;
     };
 
+    bool
+    should_skip();
+
     /* We make this the first field so that dr_standalone_exit() is called after
      * destroying the other fields which may use DR heap.
      */
@@ -75,7 +78,9 @@ protected:
     int trace_version_;
     static const std::string TOOL_NAME;
     uint64_t knob_skip_refs_;
+    uint64_t skip_refs_left_;
     uint64_t knob_sim_refs_;
+    uint64_t sim_refs_left_;
     bool refs_limited_;
     std::string knob_syntax_;
     std::string knob_alt_module_dir_;

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -73,10 +73,10 @@ protected:
     raw2trace_directory_t directory_;
     unsigned int knob_verbose_;
     int trace_version_;
-    uint64_t instr_count_;
     static const std::string TOOL_NAME;
     uint64_t knob_skip_refs_;
     uint64_t knob_sim_refs_;
+    bool refs_limited_;
     std::string knob_syntax_;
     std::string knob_alt_module_dir_;
     uint64_t num_disasm_instrs_;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -444,8 +444,8 @@ app_pc
 module_mapper_t::find_mapped_trace_bounds(app_pc trace_address, OUT app_pc *module_start,
                                           OUT size_t *module_size)
 {
-    if (modhandle_ == nullptr || modlist_.empty()) {
-        last_error_ = "Failed to call get_module_list() first";
+    if (modvec_.empty()) {
+        last_error_ = "Failed to call get_loaded_modules() first";
         return nullptr;
     }
 

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -350,7 +350,7 @@ struct trace_metadata_reader_t {
  * Using it assumes a dr_context has already been setup.
  * This class is not thread-safe.
  */
-class module_mapper_t final {
+class module_mapper_t {
 public:
     /**
      * Parses and iterates over the list of modules.  This is provided to give the user a
@@ -398,7 +398,7 @@ public:
      * get_last_error() to ensure no error has occurred, or get the applicable error
      * message.
      */
-    const std::vector<module_t> &
+    virtual const std::vector<module_t> &
     get_loaded_modules()
     {
         if (last_error_.empty() && modvec_.empty())
@@ -444,7 +444,7 @@ public:
                       int (*print_cb)(void *data, char *dst, size_t max_len),
                       OUT size_t *wrote);
 
-private:
+protected:
     module_mapper_t(const char *module_map,
                     const char *(*parse_cb)(const char *src, OUT void **data) = nullptr,
                     std::string (*process_cb)(drmodtrack_info_t *info, void *data,
@@ -452,6 +452,7 @@ private:
                     void *process_cb_user_data = nullptr,
                     void (*free_cb)(void *data) = nullptr, uint verbosity = 0,
                     const std::string &alt_module_dir = "");
+
     module_mapper_t(const module_mapper_t &) = delete;
     module_mapper_t &
     operator=(const module_mapper_t &) = delete;
@@ -468,7 +469,7 @@ private:
         void *user_data;
     };
 
-    void
+    virtual void
     read_and_map_modules(void);
 
     std::string

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -430,7 +430,7 @@ public:
     /**
      * Unload modules loaded with read_and_map_modules(), freeing associated resources.
      */
-    ~module_mapper_t();
+    virtual ~module_mapper_t();
 
     /**
      * Writes out the module list to \p buf, whose capacity is \p buf_size.


### PR DESCRIPTION
Changes the view tool's -skip_refs and -sim_refs behavior to count
memrefs rather than instructions, for consistency with other tools.
It was only counting instructions at all because until recently when
it was augmented to print data and markers it only printed
instructions.

Removes the feature of printing the version and filetype for
-skip_refs as the usefulness is outweighed by messing up the reference
count (not an issue with the instruction count).

Adds a new unit test for the view tool which mocks the module mapping
and tests the skip_refs and num_refs options.

Issue: #5076