### PR TITLE
i#5076 trace invariants, part 7: View single threads

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -374,6 +374,12 @@ droption_t<std::string> op_tracer_ops(
     "(For internal use: sweeps up tracer options)",
     "This is an internal option that sweeps up other options to pass to the tracer.");
 
+droption_t<int>
+    op_only_thread(DROPTION_SCOPE_FRONTEND, "only_thread", 0,
+                   "Only analyze this thread (0 means all)",
+                   "For simulator types that support it, limits analyis to the single "
+                   "thread with the given identifier.  0 enables all threads.");
+
 droption_t<bytesize_t>
     op_skip_refs(DROPTION_SCOPE_FRONTEND, "skip_refs", 0,
                  "Number of memory references to skip",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -114,6 +114,7 @@ extern droption_t<std::string> op_dr_ops;
 extern droption_t<std::string> op_tracer;
 extern droption_t<std::string> op_tracer_alt;
 extern droption_t<std::string> op_tracer_ops;
+extern droption_t<int> op_only_thread;
 extern droption_t<bytesize_t> op_skip_refs;
 extern droption_t<bytesize_t> op_warmup_refs;
 extern droption_t<double> op_warmup_fraction;

--- a/clients/drcachesim/simulator/analyzer_interface.cpp
+++ b/clients/drcachesim/simulator/analyzer_interface.cpp
@@ -188,9 +188,10 @@ drmemtrace_analysis_tool_create()
             ERRMSG("Usage error: the view tool requires offline traces.\n");
             return nullptr;
         }
-        return view_tool_create(module_file_path, op_skip_refs.get_value(),
-                                op_sim_refs.get_value(), op_view_syntax.get_value(),
-                                op_verbose.get_value(), op_alt_module_dir.get_value());
+        return view_tool_create(module_file_path, op_only_thread.get_value(),
+                                op_skip_refs.get_value(), op_sim_refs.get_value(),
+                                op_view_syntax.get_value(), op_verbose.get_value(),
+                                op_alt_module_dir.get_value());
     } else if (op_simulator_type.get_value() == FUNC_VIEW) {
         std::string funclist_file_path = get_aux_file_path(
             op_funclist_file.get_value(), DRMEMTRACE_FUNCTION_LIST_FILENAME);

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -43,11 +43,21 @@
 
 class view_t : public analysis_tool_t {
 public:
-    view_t(const std::string &module_file_path, uint64_t skip_refs, uint64_t sim_refs,
-           const std::string &syntax, unsigned int verbose,
+    view_t(const std::string &module_file_path, memref_tid_t thread, uint64_t skip_refs,
+           uint64_t sim_refs, const std::string &syntax, unsigned int verbose,
            const std::string &alt_module_dir = "");
     std::string
     initialize() override;
+    bool
+    parallel_shard_supported() override;
+    void *
+    parallel_shard_init(int shard_index, void *worker_data) override;
+    bool
+    parallel_shard_exit(void *shard_data) override;
+    bool
+    parallel_shard_memref(void *shard_data, const memref_t &memref) override;
+    std::string
+    parallel_shard_error(void *shard_data) override;
     bool
     process_memref(const memref_t &memref) override;
     bool
@@ -77,6 +87,7 @@ protected:
     unsigned int knob_verbose_;
     int trace_version_;
     static const std::string TOOL_NAME;
+    memref_tid_t knob_thread_;
     uint64_t knob_skip_refs_;
     uint64_t skip_refs_left_;
     uint64_t knob_sim_refs_;

--- a/clients/drcachesim/tools/view_create.h
+++ b/clients/drcachesim/tools/view_create.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,8 +49,8 @@
  * It does not support online analysis.
  */
 analysis_tool_t *
-view_tool_create(const std::string &module_file_path, uint64_t skip_refs,
-                 uint64_t sim_refs, const std::string &syntax, unsigned int verbose = 0,
-                 const std::string &alt_module_dir = "");
+view_tool_create(const std::string &module_file_path, memref_tid_t thread,
+                 uint64_t skip_refs, uint64_t sim_refs, const std::string &syntax,
+                 unsigned int verbose = 0, const std::string &alt_module_dir = "");
 
 #endif /* _OPCODE_MIX_CREATE_H_ */


### PR DESCRIPTION
Augments the view tool to show a single thread when the new option
"-only_thread <tid>" is passed.  This is done in parallel mode for
efficiency.

Updates the view test with a simple thread filter test.

Issue: #5076