### PR TITLE
i#5076 trace invariants: Report parallel view error

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -172,6 +172,9 @@ compatibility changes:
  - drcov's output now uses a module segment offset, rather than a module base offset.
    This better supports modules with code beyond the first segment and with
    gaps between segments.
+ - Changed the drcachesim view tool's behavior to count all trace entries, rather
+   than just instructions, with respect to the -skip_refs and -sim_refs flags.
+   This matches the cache and TLB simulator behavior.
 
 Further non-compatibility-affecting changes include:
 

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -125,7 +125,9 @@ view_t::parallel_shard_exit(void *shard_data)
 std::string
 view_t::parallel_shard_error(void *shard_data)
 {
-    return "";
+    // Our parallel operation ignores all but one thread, so we need just
+    // the one global error string.
+    return error_string_;
 }
 
 bool


### PR DESCRIPTION
Fixes an omission from part 7 (PR #5185) where the view tools runs in
parallel but fails to report error strings for that mode.

Tested manually on a wrong-archtecture trace.

Issue: #5076