### PR TITLE
i#5190: drcachesim child stats include all lower levels

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -172,6 +172,8 @@ compatibility changes:
  - drcov's output now uses a module segment offset, rather than a module base offset.
    This better supports modules with code beyond the first segment and with
    gaps between segments.
+ - drcachesim's child cache statistics now include all lower levels and
+   not just the immediately lower level child caches.
 
 Further non-compatibility-affecting changes include:
 

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -1001,7 +1001,9 @@ sec_drcachesim_extend.
 For L2 caching devices, the L1 caching devices are considered its _children_.
 Two separate miss rates are computed, one (the "Local miss rate") considering
 just requests that reach L2 while the other (the "Total miss rate")
-includes the child hits.
+includes the child hits.  This generalizes to deeper hierarchies:
+lower level caches are children and reported child hits are cumulative
+across all lower levels.
 
 For memory requests that cross blocks, each block touched is
 considered separately, resulting in separate hit and miss statistics.  This

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -140,9 +140,7 @@ caching_device_t::request(const memref_t &memref_in)
         caching_device_block_t *cache_block =
             &get_caching_device_block(last_block_idx_, last_way_);
         assert(tag != TAG_INVALID && tag == cache_block->tag_);
-        stats_->access(memref_in, true /*hit*/, cache_block);
-        for (caching_device_t *up = parent_; up != nullptr; up = up->parent_)
-            up->stats_->child_access(memref_in, true, cache_block);
+        record_access_stats(memref_in, true /*hit*/, cache_block);
         access_update(last_block_idx_, last_way_);
         return;
     }
@@ -161,9 +159,7 @@ caching_device_t::request(const memref_t &memref_in)
             // Access is a hit.
             caching_device_block_t *cache_block = block_way.first;
             way = block_way.second;
-            stats_->access(memref, true /*hit*/, cache_block);
-            for (caching_device_t *up = parent_; up != nullptr; up = up->parent_)
-                up->stats_->child_access(memref, true, cache_block);
+            record_access_stats(memref, true /*hit*/, cache_block);
             if (coherent_cache_ && memref.data.type == TRACE_TYPE_WRITE) {
                 // On a hit, we must notify the snoop filter of the write or propagate
                 // the write to a snooped cache.
@@ -181,14 +177,11 @@ caching_device_t::request(const memref_t &memref_in)
             caching_device_block_t *cache_block =
                 &get_caching_device_block(block_idx, way);
 
-            stats_->access(memref, false /*miss*/, cache_block);
+            record_access_stats(memref, false /*miss*/, cache_block);
             missed = true;
             // If no parent we assume we get the data from main memory
-            if (parent_ != NULL) {
-                for (caching_device_t *up = parent_; up != nullptr; up = up->parent_)
-                    up->stats_->child_access(memref, false, cache_block);
+            if (parent_ != NULL)
                 parent_->request(memref);
-            }
             if (snoop_filter_ != NULL) {
                 // Update snoop filter, other private caches invalidated on write.
                 snoop_filter_->snoop(tag, id_, (memref.data.type == TRACE_TYPE_WRITE));
@@ -378,4 +371,18 @@ caching_device_t::propagate_write(addr_t tag, const caching_device_t *requester)
     } else if (parent_ != NULL) {
         parent_->propagate_write(tag, this);
     }
+}
+
+void
+caching_device_t::record_access_stats(const memref_t &memref, bool hit,
+                                      caching_device_block_t *cache_block)
+{
+    stats_->access(memref, hit, cache_block);
+    // We propagate hits all the way up the hierachy.
+    // But to avoid over-counting we only propagate misses one level up.
+    if (hit) {
+        for (caching_device_t *up = parent_; up != nullptr; up = up->parent_)
+            up->stats_->child_access(memref, hit, cache_block);
+    } else if (parent_ != nullptr)
+        parent_->stats_->child_access(memref, hit, cache_block);
 }

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -121,6 +121,9 @@ protected:
     access_update(int block_idx, int way);
     virtual int
     replace_which_way(int block_idx);
+    virtual void
+    record_access_stats(const memref_t &memref, bool hit,
+                        caching_device_block_t *cache_block);
 
     inline addr_t
     compute_tag(addr_t addr)

--- a/clients/drcachesim/simulator/tlb.cpp
+++ b/clients/drcachesim/simulator/tlb.cpp
@@ -71,9 +71,7 @@ tlb_t::request(const memref_t &memref_in)
             &get_caching_device_block(last_block_idx_, last_way_);
         assert(tag != TAG_INVALID && tag == tlb_entry->tag_ &&
                pid == ((tlb_entry_t *)tlb_entry)->pid_);
-        stats_->access(memref_in, true /*hit*/, tlb_entry);
-        for (caching_device_t *up = parent_; up != nullptr; up = up->get_parent())
-            up->get_stats()->child_access(memref_in, true, tlb_entry);
+        record_access_stats(memref_in, true /*hit*/, tlb_entry);
         access_update(last_block_idx_, last_way_);
         return;
     }
@@ -89,9 +87,7 @@ tlb_t::request(const memref_t &memref_in)
         for (way = 0; way < associativity_; ++way) {
             caching_device_block_t *tlb_entry = &get_caching_device_block(block_idx, way);
             if (tlb_entry->tag_ == tag && ((tlb_entry_t *)tlb_entry)->pid_ == pid) {
-                stats_->access(memref, true /*hit*/, tlb_entry);
-                for (caching_device_t *up = parent_; up != nullptr; up = up->get_parent())
-                    up->get_stats()->child_access(memref, true, tlb_entry);
+                record_access_stats(memref, true /*hit*/, tlb_entry);
                 break;
             }
         }
@@ -100,13 +96,10 @@ tlb_t::request(const memref_t &memref_in)
             way = replace_which_way(block_idx);
             caching_device_block_t *tlb_entry = &get_caching_device_block(block_idx, way);
 
-            stats_->access(memref, false /*miss*/, tlb_entry);
+            record_access_stats(memref, false /*miss*/, tlb_entry);
             // If no parent we assume we get the data from main memory
-            if (parent_ != NULL) {
-                for (caching_device_t *up = parent_; up != nullptr; up = up->get_parent())
-                    up->get_stats()->child_access(memref, false, tlb_entry);
+            if (parent_ != NULL)
                 parent_->request(memref);
-            }
 
             // XXX: do we need to handle TLB coherency?
 

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -280,6 +280,7 @@ LLC {
     ref.data.type = TRACE_TYPE_READ;
     ref.data.size = 1;
 
+    // We perform a bunch of accesses to the same cache line to ensure they hit.
     const int num_accesses = 16;
     for (int i = 0; i < num_accesses; i++) {
         ref.data.addr = 64 + i;
@@ -289,6 +290,16 @@ LLC {
             exit(1);
         }
     }
+    assert(cache_sim.get_cache_metric(metric_name_t::CHILD_HITS, 1, 0,
+                                      cache_split_t::DATA) == 0);
+    assert(cache_sim.get_cache_metric(metric_name_t::MISSES, 1, 0, cache_split_t::DATA) ==
+           1);
+    assert(cache_sim.get_cache_metric(metric_name_t::HITS, 1, 0, cache_split_t::DATA) ==
+           num_accesses - 1);
+    assert(cache_sim.get_cache_metric(metric_name_t::MISSES, 2, 0) == 1);
+    assert(cache_sim.get_cache_metric(metric_name_t::HITS, 2, 0) == 0);
+    assert(cache_sim.get_cache_metric(metric_name_t::CHILD_HITS, 2, 0) ==
+           num_accesses - 1);
     assert(cache_sim.get_cache_metric(metric_name_t::CHILD_HITS, 3, 0) ==
            num_accesses - 1);
 }

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -36,6 +36,8 @@
 #include <assert.h>
 #include "simulator/cache_simulator.h"
 #include "../common/memref.h"
+
+#define ALIGN_BACKWARD(x, alignment) (((uintptr_t)x) & (~((uintptr_t)(alignment)-1)))
 
 static cache_simulator_knobs_t
 make_test_knobs()
@@ -235,6 +237,64 @@ unit_test_compulsory_misses()
                                       cache_split_t::INSTRUCTION) == 6);
 }
 
+void
+unit_test_child_hits()
+{
+    // Ensure child hits include all lower levels.
+    std::string config = R"MYCONFIG(// 3-level simple config.
+num_cores       1
+line_size       64
+L1I {
+  type            instruction
+  core            0
+  size            256
+  assoc           4
+  prefetcher      none
+  parent          L2
+}
+L1D {
+  type            data
+  core            0
+  size            256
+  assoc           4
+  prefetcher      none
+  parent          L2
+}
+L2 {
+  size            8K
+  assoc           8
+  inclusive       true
+  prefetcher      none
+  parent          LLC
+}
+LLC {
+  size            1M
+  assoc           8
+  inclusive       true
+  prefetcher      none
+  parent          memory
+}
+)MYCONFIG";
+    std::istringstream config_in(config);
+    cache_simulator_t cache_sim(&config_in);
+
+    memref_t ref;
+    ref.data.type = TRACE_TYPE_READ;
+    ref.data.size = 1;
+
+    const int num_accesses = 16;
+    for (int i = 0; i < num_accesses; i++) {
+        ref.data.addr = 64 + i;
+        if (!cache_sim.process_memref(ref)) {
+            std::cerr << "drcachesim unit_test_child_hits failed: "
+                      << cache_sim.get_error_string() << "\n";
+            exit(1);
+        }
+    }
+    assert(cache_sim.get_cache_metric(metric_name_t::CHILD_HITS, 3, 0) ==
+           num_accesses - 1);
+}
+
 int
 main(int argc, const char *argv[])
 {
@@ -243,5 +303,6 @@ main(int argc, const char *argv[])
     unit_test_warmup_fraction();
     unit_test_warmup_refs();
     unit_test_sim_refs();
+    unit_test_child_hits();
     return 0;
 }

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -37,8 +37,6 @@
 #include "simulator/cache_simulator.h"
 #include "../common/memref.h"
 
-#define ALIGN_BACKWARD(x, alignment) (((uintptr_t)x) & (~((uintptr_t)(alignment)-1)))
-
 static cache_simulator_knobs_t
 make_test_knobs()
 {


### PR DESCRIPTION
The child (==lower level) cache stats in drcachesim today are only for
the immediately lower level. This is a holdover from the original
implementation which didn't support other than 2 levels. For multiple
levels, one would expect the child stats to include the sum of all the
lower levels.  We fix that here and add a unit test.

The difference is clear in the config file test:
  LLC stats:
     Child hits:                        147
=>
  LLC stats:
     Child hits:                    174,695

But to avoid flakiness we do not update its regex and rely on the unit
test.

Fixes #5190