### PR TITLE
i#5076 trace invariants: Fix concurrent thread writes

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -94,6 +94,11 @@ protected:
         // Track the location of errors.
         memref_tid_t tid = -1;
         uint64_t ref_count = 0;
+        // We do not expect these to vary by thread but it is simpler to keep
+        // separate values per thread as we discover their values during parallel
+        // operation.
+        addr_t app_handler_pc_ = 0;
+        offline_file_type_t file_type_ = OFFLINE_FILE_TYPE_DEFAULT;
     };
 
     // We provide this for subclasses to run these invariants with custom
@@ -111,8 +116,6 @@ protected:
     unsigned int knob_verbose_;
     std::string knob_test_name_;
     bool has_annotations_ = false;
-    addr_t app_handler_pc_;
-    offline_file_type_t file_type_ = OFFLINE_FILE_TYPE_DEFAULT;
 };
 
 #endif /* _INVARIANT_CHECKER_H_ */


### PR DESCRIPTION
Moves two invariant_checker_t data fields that are written
concurrently (though we expect their values to be constant across
threads) into per-thread data to avoid data race tools complaining.

Tested under ThreadSanitizer.

Issue: #5076