### PR TITLE
i#5076 trace invariants: Print ref count prefix in view tool

### DIFF
--- a/clients/drcachesim/tests/offline-view.templatex
+++ b/clients/drcachesim/tests/offline-view.templatex
@@ -1,7 +1,7 @@
 Hello, world!
 .*
-T[0-9]* <marker: timestamp.*
-T[0-9]* <marker: tid [0-9]* on core [0-9]*>
+ *[0-9]*: T[0-9]* <marker: timestamp.*
+ *[0-9]*: T[0-9]* <marker: tid [0-9]* on core [0-9]*>
 .*
 View tool results:
     *[0-9]* : total disassembled instructions

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -134,6 +134,13 @@ test_no_limit(void *drcontext, instrlist_t &ilist, const std::vector<memref_t> &
         std::cerr << "Incorrect line count\n";
         return false;
     }
+    std::stringstream ss(res);
+    int prefix;
+    ss >> prefix;
+    if (prefix != 1) {
+        std::cerr << "Expect 1-based line prefixes\n";
+        return false;
+    }
     return true;
 }
 
@@ -188,6 +195,14 @@ test_skip_memrefs(void *drcontext, instrlist_t &ilist,
     }
     if (found_markers != marker_count) {
         std::cerr << "Failed to skip proper number of markers\n";
+        return false;
+    }
+    std::stringstream ss(res);
+    int prefix;
+    ss >> prefix;
+    if (prefix != 1 + skip_memrefs) {
+        std::cerr << "Expect to start after skip count " << skip_memrefs << " but found "
+                  << prefix << "\n";
         return false;
     }
     return true;

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -33,6 +33,8 @@
 #ifndef _VIEW_H_
 #define _VIEW_H_ 1
 
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -77,6 +79,15 @@ protected:
     bool
     should_skip();
 
+    inline void
+    print_prefix(const memref_t &memref, std::ostream &stream = std::cerr)
+    {
+        if (prev_tid_ != -1 && prev_tid_ != memref.instr.tid)
+            stream << "------------------------------------------------------------\n";
+        prev_tid_ = memref.instr.tid;
+        stream << std::setw(9) << num_refs_ << ": T" << memref.marker.tid << " ";
+    }
+
     /* We make this the first field so that dr_standalone_exit() is called after
      * destroying the other fields which may use DR heap.
      */
@@ -100,6 +111,7 @@ protected:
     memref_tid_t prev_tid_;
     intptr_t filetype_;
     std::unordered_set<memref_tid_t> printed_header_;
+    uint64_t num_refs_;
 };
 
 #endif /* _VIEW_H_ */


### PR DESCRIPTION
Adds a memref count prefix to every line output by the view tool to
make it easier to use the -skip_refs and -sim_refs options, including
for visualizing errors reported by the trace_invariants tool.

Tested manually.  Here is an example showing a thread change and a
multi-line disassembly with the same prefix for both lines:
```
  $ clients/bin64/drcachesim -indir drmemtrace.threadsig.*.dir -simulator_type view -sim_refs 25 -skip_refs 3016012
    3016013: T327766   0x00007fe61d582a4a  b8 38 00 00 00       mov    $0x00000038, %eax
    3016014: T327766   0x00007fe61d582a4f  0f 05                syscall
  ------------------------------------------------------------
    3016015: T327767 <marker: timestamp 13280020226777973>
    3016016: T327767 <marker: tid 327767 on core 8>
    3016017: T327767   0x00007fe61d582a51  48 85 c0             test   %rax, %rax
    3016018: T327767   0x00007fe61d582a54  7c 13                jl     $0x00007fe61d582a69
    3016019: T327767   0x00007fe61d582a56  74 01                jz     $0x00007fe61d582a59
    3016020: T327767   0x00007fe61d582a59  31 ed                xor    %ebp, %ebp
    3016021: T327767   0x00007fe61d582a5b  58                   pop    %rax
    3016022: T327767     read  8 byte(s) @ 0x7fe61d483ef0
    3016023: T327767   0x00007fe61d582a5c  5f                   pop    %rdi
    3016024: T327767     read  8 byte(s) @ 0x7fe61d483ef8
    3016025: T327767   0x00007fe61d582a5d  ff d0                call   %rax
    3016026: T327767     write 8 byte(s) @ 0x7fe61d483ef8
    3016027: T327767   0x00007fe61d9bddd0  41 54                push   %r12
    3016028: T327767     write 8 byte(s) @ 0x7fe61d483ef0
    3016029: T327767   0x00007fe61d9bddd2  48 8d 97 b8 06 00 00 lea    0x000006b8(%rdi), %rdx
    3016030: T327767   0x00007fe61d9bddd9  55                   push   %rbp
    3016031: T327767     write 8 byte(s) @ 0x7fe61d483ee8
    3016032: T327767   0x00007fe61d9bddda  53                   push   %rbx
    3016033: T327767     write 8 byte(s) @ 0x7fe61d483ee0
    3016034: T327767   0x00007fe61d9bdddb  48 89 fb             mov    %rdi, %rbx
    3016035: T327767   0x00007fe61d9bddde  48 83 c4 80          add    $0x80, %rsp
    3016036: T327767   0x00007fe61d9bdde2  64 48 8b 04 25 28 00 mov    %fs:0x28, %rax
    3016036: T327767                       00 00
    3016037: T327767     read  8 byte(s) @ 0x7fe61d484668
```

Issue: #5076