### PR TITLE
Udpate transparency docs to reflect modern support

### DIFF
--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -572,7 +572,8 @@ on Windows (see \ref sec_alertable).  While most non-graphical
 non-alertable Windows API routines are supported, native threading libraries
 such as \p libpthread.so on Linux are known to cause problems.
 
-Currently we provide a private loader for both Windows and Linux.
+Currently we provide a private loader for both Windows and Linux which
+supplies support for client external library use.
 Clients must either link statically to all libraries or load them using
 our private loader, which will happen automatically for shared libraries
 loaded in a typical manner.

--- a/api/docs/transp.dox
+++ b/api/docs/transp.dox
@@ -94,8 +94,11 @@ API.  We do not recommend that a client invoke its own system calls as
 this bypasses DynamoRIO's monitoring of changes to the process address
 space and changes to threads or control flow.
 
-We provide limited support to assist in using statically linked libraries
-in a client: see \ref sec_extlibs.
+DynamoRIO does have its own loader and through it support is provided
+to clients to use external libraries while isolating them from the
+libraries used by the application: see \ref sec_extlibs.  This support
+is limited, however, and there are libraries that are not supported
+today.
 
 In addition to Library Transparency, several other types of transparency
 are of concern to a client:
@@ -110,7 +113,9 @@ Transparency: see below) or with application memory bugs (Error
 Transparency: see below).  DynamoRIO obtains its memory directly from
 system calls and parcels it out internally with a custom memory manager.
 It exports its heap allocation routines through its API to ensure that
-clients maintain Heap Transparency (see \ref sec_utils).
+clients maintain Heap Transparency (see \ref sec_utils).  Calls to malloc in
+external libraries used by clients are also redirected to DynamoRIO's internal
+heap.
 
 \par Input/Output Transparency
 


### PR DESCRIPTION
Updates the docs on transparency to reflect that we have a private
loader and do support many typical uses of clients using external
libraries.