### PR TITLE
Fix broken paper links

### DIFF
--- a/api/docs/publications.dox
+++ b/api/docs/publications.dox
@@ -41,13 +41,13 @@
  to Halide DSL Code</b>.
  2015 Conference on Programming Language Design and Implementation (PLDI-15).
 
--  [[pdf](http://www.burningcutlery.com/derek/docs/dgc-CGO15.pdf)]
+-  [[pdf](https://www.burningcutlery.com/derek/docs/dgc-CGO15.pdf)]
  Byron Hawkins, Brian Demsky, Derek Bruening, and Qin Zhao.
  <b>Optimizing Binary Translation for Dynamically Generated Code</b>.
  [2015 International Symposium on Code Generation
  and Optimization (CGO-15)](http://www.cgo.org/cgo2015/), February 2015, San Francisco, CA.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/instant-profiling-CGO13.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/instant-profiling-CGO13.pdf)]
  Hyoun Kyu Cho, Tipp Moseley, Richard Hank, Derek Bruening, and Scott Mahlke.
  <b>Instant Profiling: Instrumentation Sampling for Profiling Datacenter
  Applications</b>.
@@ -62,117 +62,117 @@
  and Operating Systems (ASPLOS-12)](http://research.microsoft.com/en-us/um/cambridge/events/asplos_2012/), March 2012,
  London, UK.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/transparency-VEE12.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/transparency-VEE12.pdf)]
  Derek Bruening, Qin Zhao, and Saman Amarasinghe.
  <b>Transparent Dynamic Instrumentation</b>.
  [International
  Conference on Virtual Execution Environments (VEE-12)](http://www.cl.cam.ac.uk/research/srg/netos/vee_2012/), March 2012,
  London, UK.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/drmem-CGO11.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/drmem-CGO11.pdf)]
  Derek Bruening and Qin Zhao.
  <b>Practical Memory Checking with Dr. Memory</b>.
  [International
  Symposium on Code Generation and Optimization (CGO-11)](http://www.cgo.org), April 2011,
  Chamonix, France.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/cache-contention-vee11.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/cache-contention-vee11.pdf)]
  Qin Zhao, David Koh, Syed Raza, Derek Bruening, Saman Amarasinghe, and Weng-Fai Wong.
  <b>Dynamic Cache Contention Detection in Multi-threaded Applications</b>.
  [International
  Conference on Virtual Execution Environments (VEE-11)](http://www.cs.technion.ac.il/~erez/vee11/VEE_2011/Home_Page.html), March 2011,
  Newport Beach, CA.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/ems64-ISMM10.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/ems64-ISMM10.pdf)]
  Qin Zhao, Derek Bruening, and Saman Amarasinghe.
  <b>Efficient Memory Shadowing for 64-bit Architectures</b>.
  [International Symposium
  on Memory Management (ISMM-10)](http://www.cs.purdue.edu/ISMM10/), June 2010.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/umbra-CGO10.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/umbra-CGO10.pdf)]
  Qin Zhao, Derek Bruening, and Saman Amarasinghe.
  <b>Umbra: Efficient and Scalable Memory Shadowing</b>.
  [International
  Symposium on Code Generation and Optimization (CGO-10)](http://www.cgo.org), April 2010.
 
-- [[pdf](pubs/zhao-million-watchpoints-CC08.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/zhao-million-watchpoints-CC08.pdf)]
  Qin Zhao, Rodric M. Rabbah, Saman Amarasinghe, Larry Rudolph, and Weng-Fai Wong.
  <b>How to Do a Million Watchpoints: Efficient Debugging Using Dynamic
  Instrumentation</b>.
  International Conference on Compiler Construction (CC 2008), March 2008.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/procshared-VEE08.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/procshared-VEE08.pdf)]
  Derek Bruening and Vladimir Kiriansky.
  <b>Process-Shared and Persistent Code Caches</b>.
  [International
  Conference on Virtual Execution Environments (VEE-08)](http://vee08.cs.tcd.ie/), March 2008.
 
-- [[pdf](pubs/PiPA-pipelined-profiling-cgo08.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/PiPA-pipelined-profiling-cgo08.pdf)]
  Qin Zhao, Ioana Cutcutache, and Weng-Fai Wong.
  <b>PiPA: Pipelined Profiling and Analysis on Multi-Core Systems</b>.
  [International
  Symposium on Code Generation and Optimization (CGO-08)](http://www.cgo.org), March 2008.
 
-- [[pdf](pubs/zhao-introspection-cgo07.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/zhao-introspection-cgo07.pdf)]
  Qin Zhao, Rodric M. Rabbah, Saman P. Amarasinghe, Larry Rudolph, and Weng-Fai Wong.
  <b>Ubiquitous Memory Introspection.</b>.
  [International
  Symposium on Code Generation and Optimization (CGO-07)](http://www.cgo.org), March 2007.
 
-- [[pdf](pubs/zhao-DEP-pact06.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/zhao-DEP-pact06.pdf)]
  Qin Zhao, Joon Edward Sim, Weng-Fai Wong, and Larry Rudolph.
  <b>DEP: Detailed Execution Profile</b>.
  International Conference on Parallel Architectures and Compilation
  Techniques (PACT-06)</a>, September 2006.
 
-- [[pdf](pubs/tainttrace-iscc06.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/tainttrace-iscc06.pdf)]
  Winnie Cheng, Qin Zhao, Bei Yu, and Scott Hiroshige.
  <b>TaintTrace: Efficient Flow Tracing with Dynamic Binary Rewriting</b>.
  IEEE Symposium on Computers and Communications (ISCC '06), June 2006.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/threadshared-CGO06.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/threadshared-CGO06.pdf)]
  Derek Bruening, Vladimir Kiriansky, Timothy Garnett, and Sanjeev Banerji.
  <b>Thread-Shared Software Code Caches</b>.
  [International
  Symposium on Code Generation and Optimization (CGO-06)](http://www.cgo.org), March 2006.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/cacheconscap-CGO05.pdf)]
-   [[ps.gz](http://www.burningcutlery.com/derek/docs/cacheconscap-CGO05.ps.gz)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/cacheconscap-CGO05.pdf)]
+   [[ps.gz](https://www.burningcutlery.com/derek/docs/cacheconscap-CGO05.ps.gz)]
  Derek Bruening and Saman Amarasinghe.
  <b>Maintaining Consistency and Bounding Capacity of Software Code Caches</b>.
  [International
  Symposium on Code Generation and Optimization (CGO-05)](http://www.cgo.org), March 2005.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/phd.pdf)]
-   [[ps.gz](http://www.burningcutlery.com/derek/docs/phd.ps.gz)]
-   [[defense](http://www.burningcutlery.com/derek/phd.html)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/phd.pdf)]
+   [[ps.gz](https://www.burningcutlery.com/derek/docs/phd.ps.gz)]
+   [[defense](https://www.burningcutlery.com/derek/phd.html)]
  Derek Bruening.
  <b>Efficient, Transparent, and Comprehensive Runtime Code Manipulation</b>.
  Ph.D. Thesis, MIT, September 2004.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/IVME03.pdf)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/IVME03.pdf)]
      Gregory Sullivan, Derek Bruening, Iris Baron, Timothy Garnett, and
  Saman Amarasinghe.
  <b>Dynamic Native Optimization of Interpreters</b>.
  [ACM Workshop on
  Interpreters, Virtual Machines and Emulators (IVME-03)](http://www.cs.tcd.ie/David.Gregg/ivme03/), June 2003.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/adaptive-CGO03.pdf)]
-   [[ps.gz](http://www.burningcutlery.com/derek/docs/adaptive-CGO03.ps.gz)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/adaptive-CGO03.pdf)]
+   [[ps.gz](https://www.burningcutlery.com/derek/docs/adaptive-CGO03.ps.gz)]
      Derek Bruening, Timothy Garnett, and Saman Amarasinghe.
  <b>An Infrastructure for Adaptive Dynamic Optimization</b>.
  [International
  Symposium on Code Generation and Optimization (CGO-03)](http://www.cgo.org), March 2003.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/security-usenix.pdf)]
-   [[ps.gz](http://www.burningcutlery.com/derek/docs/security-usenix.ps.gz)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/security-usenix.pdf)]
+   [[ps.gz](https://www.burningcutlery.com/derek/docs/security-usenix.ps.gz)]
  Vladimir Kiriansky, Derek Bruening, and Saman Amarasinghe.
  <b>Secure Execution Via Program Shepherding</b>.
  [11th USENIX Security
  Symposium](http://www.usenix.org/events/sec02/), August 2002.
 
-- [[pdf](http://www.burningcutlery.com/derek/docs/win32-FDDO.pdf)]
-   [[ps.gz](http://www.burningcutlery.com/derek/docs/win32-FDDO.ps.gz)]
+- [[pdf](https://www.burningcutlery.com/derek/docs/win32-FDDO.pdf)]
+   [[ps.gz](https://www.burningcutlery.com/derek/docs/win32-FDDO.ps.gz)]
      Derek Bruening, Evelyn Duesterwald, and Saman Amarasinghe.
  <b>Design and Implementation of a Dynamic Optimization Framework for
  Windows</b>.


### PR DESCRIPTION
The move from the old dynamorio.org to the new Github Pages-hosted
site did not bring over 5 academic papers, whose links were broken.
We fix that here by pointing at copies on burningcutlery.com.

Also updates from http to https for burningcutlery.com.