### PR TITLE
i#5198: Preserve actual inject hook page protections

### DIFF
--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -9077,10 +9077,10 @@ earliest_inject_init(byte *arg_ptr)
          * should we just silently go native?
          */
     } else {
-        /* Restore +rx to hook location before DR init scans it */
+        /* Restore the prior protections to the hook location before DR init scans it. */
         uint old_prot;
         if (!bootstrap_protect_virtual_memory((byte *)(ptr_int_t)args->hook_location,
-                                              EARLY_INJECT_HOOK_SIZE, PAGE_EXECUTE_READ,
+                                              EARLY_INJECT_HOOK_SIZE, args->hook_prot,
                                               &old_prot)) {
             /* XXX: again, how handle failure? */
         }

--- a/core/win32/os_private.h
+++ b/core/win32/os_private.h
@@ -75,6 +75,7 @@ typedef struct {
     uint64 ntdll_base;
     uint64 tofree_base;
     uint64 hook_location;
+    uint hook_prot;
     bool late_injection;
     char dynamorio_lib_path[MAX_PATH];
 } earliest_args_t;


### PR DESCRIPTION
Instead of blindly marking the inject hook page as +rx, we remember
its actual prior protections and restore those.  This avoids crashes
in cases where the app's initial code is actually writable.

Tested manually by the filer of #5198.  It is difficult to create an
automated test.

Fixes #5198