### PR TITLE
i#4958: Take over at app context, not DR return

### DIFF
--- a/core/arch/x86/x86.asm
+++ b/core/arch/x86/x86.asm
@@ -2674,7 +2674,12 @@ inv64_return_to_32:
  */
         DECLARE_EXPORTED_FUNC(dynamorio_earliest_init_takeover)
 GLOBAL_LABEL(dynamorio_earliest_init_takeover:)
-        PUSHGPR
+        push     REG_XAX /* Save xax (PUSH_PRIV_MCXT clobbers it) and align x64 stack. */
+# ifndef X64
+        lea      REG_XSP, [REG_XSP - 2*ARG_SZ] /* Align 32-bit stack. */
+# endif
+        PUSH_PRIV_MCXT(PTRSZ [FRAME_ALIGNMENT - ARG_SZ + REG_XSP -\
+                       PUSH_PRIV_MCXT_PRE_PC_SHIFT]) /* Return address as pc. */
 # ifdef EARLIEST_INIT_DEBUGBREAK
         /* giant loop so can attach debugger, then change ebx to 1
          * to step through rest of code */
@@ -2689,16 +2694,23 @@ dynamorio_earliest_init_repeatme:
         cmp      ebx, 0
         jg       dynamorio_earliest_init_repeat_outer
 # endif
+        lea      REG_XDX, [REG_XSP] /* Pointer to priv_mcontext_t. */
+        /* Load passed-in xax which points to the arg struct. */
+        mov      REG_XAX, PTRSZ [REG_XSP + PRIV_MCXT_SIZE + FRAME_ALIGNMENT - 2*ARG_SZ]
         /* Load earliest_args_t.app_xax, written by our gencode. */
         mov      REG_XCX, PTRSZ [REG_XAX]
         /* Store into xax slot on stack. */
-        mov      PTRSZ [PUSHGPR_XAX_OFFS + REG_XSP], REG_XCX
-        /* Args are pointed at by xax. */
-        CALLC1(GLOBAL_REF(dynamorio_earliest_init_takeover_C), REG_XAX)
+        mov      PTRSZ [MCONTEXT_XAX_OFFS + REG_XSP], REG_XCX
+        CALLC2(GLOBAL_REF(dynamorio_earliest_init_takeover_C), REG_XAX, REG_XDX)
         /* We will either be under DR control or running natively at this point. */
 
         /* Restore. */
-        POPGPR
+        POP_PRIV_MCXT_GPRS()
+# ifdef X64
+        lea      REG_XSP, [REG_XSP + ARG_SZ] /* Undo push. */
+# else
+        lea      REG_XSP, [REG_XSP + 3*ARG_SZ] /* Undo alignment. */
+# endif
         ret
         END_FUNC(dynamorio_earliest_init_takeover)
 #endif /* WINDOWS */

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -3021,7 +3021,7 @@ dynamorio_app_init_and_early_takeover(uint inject_location, void *restore_code)
 /* Called with DR library mapped in but without its imports processed.
  */
 void
-dynamorio_earliest_init_takeover_C(byte *arg_ptr)
+dynamorio_earliest_init_takeover_C(byte *arg_ptr, priv_mcontext_t *mc)
 {
     int res;
     bool earliest_inject;
@@ -3044,21 +3044,7 @@ dynamorio_earliest_init_takeover_C(byte *arg_ptr)
      * confusing the exec areas scan
      */
 
-    /* Take over at retaddr
-     *
-     * XXX i#626: app_takeover sets preinjected for rct (should prob. rename)
-     * which needs to be done whenever we takeover not at the bottom of the
-     * callstack.  For earliest won't need to set this if we takeover
-     * in such a way as to handle the return back to our hook code without a
-     * violation -- though currently we will see 3 rets (return from
-     * dynamorio_app_take_over(), return from here, and return from
-     * dynamorio_earliest_init_takeover() to app hook code).
-     * Should we have dynamorio_earliest_init_takeover() set up an
-     * mcontext that we can go to directly instead of interpreting
-     * the returns in our own code?  That would make tools that shadow
-     * callstacks simpler too.
-     */
-    dynamorio_app_take_over();
+    dynamorio_app_take_over_helper(mc);
 }
 #endif /* WINDOWS */
 

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -2962,7 +2962,7 @@ dynamorio_app_take_over_helper(priv_mcontext_t *mc)
         control_all_threads = automatic_startup;
         SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
 
-        if (!dr_earliest_injected && !dr_early_injected) {
+        if (IF_WINDOWS_ELSE(!dr_earliest_injected && !dr_early_injected, true)) {
             /* Adjust the app stack to account for the return address + alignment.
              * See dynamorio_app_take_over in x86.asm.
              */

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -2962,10 +2962,12 @@ dynamorio_app_take_over_helper(priv_mcontext_t *mc)
         control_all_threads = automatic_startup;
         SELF_PROTECT_DATASEC(DATASEC_RARELY_PROT);
 
-        /* Adjust the app stack to account for the return address + alignment.
-         * See dynamorio_app_take_over in x86.asm.
-         */
-        mc->xsp += DYNAMO_START_XSP_ADJUST;
+        if (!dr_earliest_injected && !dr_early_injected) {
+            /* Adjust the app stack to account for the return address + alignment.
+             * See dynamorio_app_take_over in x86.asm.
+             */
+            mc->xsp += DYNAMO_START_XSP_ADJUST;
+        }
 
         /* For hotp_only and thin_client, the app should run native, except
          * for our hooks.


### PR DESCRIPTION
Switches Windows default map injection to record an app mcontext and
take over there, rather than taking over on the return path out of DR
functions and confusing clients with two initial blocks in the DR
library.

Tested by observing the block sequence in the log file.
Without the fix:
```
  Fragment 1, tag 0x000000001502643b, flags 0x1000630, shared, size 19:
          [dynamorio.dll~dynamorio_app_init_and_early_takeover+0x37b,~dr_persist_start-0x
  Fragment 2, tag 0x0000000015349c23, flags 0x1000030, shared, size 44:
          [dynamorio.dll~dynamorio_earliest_init_takeover+0x2d,~dr_virtual_query-0x24dfd]
  Fragment 3, tag 0x00007fff20502630, flags 0x9000630, shared, size 34:
          [ntdll.dll!RtlUserThreadStart]
```
With the fix:
```
  Fragment 1, tag 0x00007ffc25822630, flags 0x9000630, shared, size 34:
          [ntdll.dll!RtlUserThreadStart]
```

Issue: #4958, #626
Fixes #4958
Fixes #626