### PR TITLE
i#2891 docs: Fix drx doc typo

### DIFF
--- a/ext/drx/drx.dox
+++ b/ext/drx/drx.dox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2016 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2021 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -71,7 +71,7 @@ parent to simply skip its own termination request.  The nudge handler
 should normally handle multiple requests, as it is not uncommon for the
 parent to kill each child process through multiple mechanisms.
 
-\section sec_drx_buf \p Buffer Filling API
+\section sec_drx_buf Buffer Filling API
 
 The \p drx library also demonstrates a minimalistic buffer API. Its API is
 currently in flux. These buffers may contain traces of data gathered during


### PR DESCRIPTION
Removes a misplaced \p marker in the drx docs.

Fixes #2891