### PR TITLE
i#2626: AArch64 v8.0 decode: Add CLS, CMGE, CMHS, CMTST

### DIFF
--- a/core/ir/aarch64/codec.txt
+++ b/core/ir/aarch64/codec.txt
@@ -354,6 +354,7 @@ x1111010010xxxxxxxxx00xxxxx0xxxx  rw  57        ccmp                : wx5 wx16 n
 x1111010010xxxxxxxxx10xxxxx0xxxx  rw  57        ccmp                : wx5 imm5 nzcv cond
 11010101000000110011xxxx01011111  n   58       clrex                : imm4
 x101101011000000000101xxxxxxxxxx  n   59         cls            wx0 : wx5
+0x001110xx100000010010xxxxxxxxxx  n   59         cls            dq0 : dq5 bhs_sz
 x101101011000000000100xxxxxxxxxx  n   60         clz            wx0 : wx5
 0x101110xx100000010010xxxxxxxxxx  n   60         clz            dq0 : dq5 bhs_sz
 0x101110xx1xxxxx100011xxxxxxxxxx  n   61        cmeq            dq0 : dq5 dq16 bhsd_sz
@@ -363,6 +364,7 @@ x101101011000000000100xxxxxxxxxx  n   60         clz            wx0 : wx5
 0x001110xx1xxxxx001111xxxxxxxxxx  n   62        cmge            dq0 : dq5 dq16 bhsd_sz
 0x101110xx100000100010xxxxxxxxxx  n   62        cmge            dq0 : dq5 bhsd_sz
 0111111011100000100010xxxxxxxxxx  n   62        cmge             d0 : d5
+01011110111xxxxx001111xxxxxxxxxx  n   62        cmge             d0 : d5 d16
 0x001110xx1xxxxx001101xxxxxxxxxx  n   63        cmgt            dq0 : dq5 dq16 bhsd_sz
 0x001110xx100000100010xxxxxxxxxx  n   63        cmgt            dq0 : dq5 bhsd_sz
 0101111011100000100010xxxxxxxxxx  n   63        cmgt             d0 : d5
@@ -370,11 +372,13 @@ x101101011000000000100xxxxxxxxxx  n   60         clz            wx0 : wx5
 0x101110xx1xxxxx001101xxxxxxxxxx  n   64        cmhi            dq0 : dq5 dq16 bhsd_sz
 01111110111xxxxx001101xxxxxxxxxx  n   64        cmhi             d0 : d5 d16
 0x101110xx1xxxxx001111xxxxxxxxxx  n   65        cmhs            dq0 : dq5 dq16 bhsd_sz
+01111110111xxxxx001111xxxxxxxxxx  n   65        cmhs             d0 : d5 d16
 0111111011100000100110xxxxxxxxxx  n   66        cmle             d0 : d5
 0x101110xx100000100110xxxxxxxxxx  n   66        cmle            dq0 : dq5 bhsd_sz
 0x001110xx100000101010xxxxxxxxxx  n   67        cmlt            dq0 : dq5 bhsd_sz
 0101111011100000101010xxxxxxxxxx  n   67        cmlt             d0 : d5
 0x001110xx1xxxxx100011xxxxxxxxxx  n   68       cmtst            dq0 : dq5 dq16 bhsd_sz
+01011110111xxxxx100011xxxxxxxxxx  n   68       cmtst             d0 : d5 d16
 0x00111000100000010110xxxxxxxxxx  n   69         cnt            dq0 : dq5
 00011010110xxxxx010000xxxxxxxxxx  n   70      crc32b             w0 : w5 w16
 00011010110xxxxx010100xxxxxxxxxx  n   71     crc32cb             w0 : w5 w16

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -15061,3 +15061,155 @@ d503203f : yield                          : yield
 6f03f799 : fmov v25.2d, #1.75                        : fmov   $1.750000 $0x03 -> %q25
 6f03f7bb : fmov v27.2d, #1.8125                      : fmov   $1.812500 $0x03 -> %q27
 6f03f7ff : fmov v31.2d, #1.9375                      : fmov   $1.937500 $0x03 -> %q31
+
+# CMHS    <Dd>, <Dn>, <Dm>
+7ee23c20 : cmhs d0, d1, d2                           : cmhs   %d1 %d2 -> %d0
+7ee43c62 : cmhs d2, d3, d4                           : cmhs   %d3 %d4 -> %d2
+7ee63ca4 : cmhs d4, d5, d6                           : cmhs   %d5 %d6 -> %d4
+7ee83ce6 : cmhs d6, d7, d8                           : cmhs   %d7 %d8 -> %d6
+7eea3d28 : cmhs d8, d9, d10                          : cmhs   %d9 %d10 -> %d8
+7eec3d6a : cmhs d10, d11, d12                        : cmhs   %d11 %d12 -> %d10
+7eee3dac : cmhs d12, d13, d14                        : cmhs   %d13 %d14 -> %d12
+7ef03dee : cmhs d14, d15, d16                        : cmhs   %d15 %d16 -> %d14
+7ef23e30 : cmhs d16, d17, d18                        : cmhs   %d17 %d18 -> %d16
+7ef33e51 : cmhs d17, d18, d19                        : cmhs   %d18 %d19 -> %d17
+7ef53e93 : cmhs d19, d20, d21                        : cmhs   %d20 %d21 -> %d19
+7ef73ed5 : cmhs d21, d22, d23                        : cmhs   %d22 %d23 -> %d21
+7ef93f17 : cmhs d23, d24, d25                        : cmhs   %d24 %d25 -> %d23
+7efb3f59 : cmhs d25, d26, d27                        : cmhs   %d26 %d27 -> %d25
+7efd3f9b : cmhs d27, d28, d29                        : cmhs   %d28 %d29 -> %d27
+7ee13c1f : cmhs d31, d0, d1                          : cmhs   %d0 %d1 -> %d31
+
+# CMGE    <Dd>, <Dn>, <Dm>
+5ee23c20 : cmge d0, d1, d2                           : cmge   %d1 %d2 -> %d0
+5ee43c62 : cmge d2, d3, d4                           : cmge   %d3 %d4 -> %d2
+5ee63ca4 : cmge d4, d5, d6                           : cmge   %d5 %d6 -> %d4
+5ee83ce6 : cmge d6, d7, d8                           : cmge   %d7 %d8 -> %d6
+5eea3d28 : cmge d8, d9, d10                          : cmge   %d9 %d10 -> %d8
+5eec3d6a : cmge d10, d11, d12                        : cmge   %d11 %d12 -> %d10
+5eee3dac : cmge d12, d13, d14                        : cmge   %d13 %d14 -> %d12
+5ef03dee : cmge d14, d15, d16                        : cmge   %d15 %d16 -> %d14
+5ef23e30 : cmge d16, d17, d18                        : cmge   %d17 %d18 -> %d16
+5ef33e51 : cmge d17, d18, d19                        : cmge   %d18 %d19 -> %d17
+5ef53e93 : cmge d19, d20, d21                        : cmge   %d20 %d21 -> %d19
+5ef73ed5 : cmge d21, d22, d23                        : cmge   %d22 %d23 -> %d21
+5ef93f17 : cmge d23, d24, d25                        : cmge   %d24 %d25 -> %d23
+5efb3f59 : cmge d25, d26, d27                        : cmge   %d26 %d27 -> %d25
+5efd3f9b : cmge d27, d28, d29                        : cmge   %d28 %d29 -> %d27
+5ee13c1f : cmge d31, d0, d1                          : cmge   %d0 %d1 -> %d31
+
+# CMTST   <Dd>, <Dn>, <Dm>
+5ee28c20 : cmtst d0, d1, d2                          : cmtst  %d1 %d2 -> %d0
+5ee48c62 : cmtst d2, d3, d4                          : cmtst  %d3 %d4 -> %d2
+5ee68ca4 : cmtst d4, d5, d6                          : cmtst  %d5 %d6 -> %d4
+5ee88ce6 : cmtst d6, d7, d8                          : cmtst  %d7 %d8 -> %d6
+5eea8d28 : cmtst d8, d9, d10                         : cmtst  %d9 %d10 -> %d8
+5eec8d6a : cmtst d10, d11, d12                       : cmtst  %d11 %d12 -> %d10
+5eee8dac : cmtst d12, d13, d14                       : cmtst  %d13 %d14 -> %d12
+5ef08dee : cmtst d14, d15, d16                       : cmtst  %d15 %d16 -> %d14
+5ef28e30 : cmtst d16, d17, d18                       : cmtst  %d17 %d18 -> %d16
+5ef38e51 : cmtst d17, d18, d19                       : cmtst  %d18 %d19 -> %d17
+5ef58e93 : cmtst d19, d20, d21                       : cmtst  %d20 %d21 -> %d19
+5ef78ed5 : cmtst d21, d22, d23                       : cmtst  %d22 %d23 -> %d21
+5ef98f17 : cmtst d23, d24, d25                       : cmtst  %d24 %d25 -> %d23
+5efb8f59 : cmtst d25, d26, d27                       : cmtst  %d26 %d27 -> %d25
+5efd8f9b : cmtst d27, d28, d29                       : cmtst  %d28 %d29 -> %d27
+5ee18c1f : cmtst d31, d0, d1                         : cmtst  %d0 %d1 -> %d31
+
+# CLS     <Vd>.<T>, <Vn>.<T>
+0e204820 : cls v0.8b, v1.8b                          : cls    %d1 $0x00 -> %d0
+0e204862 : cls v2.8b, v3.8b                          : cls    %d3 $0x00 -> %d2
+0e2048a4 : cls v4.8b, v5.8b                          : cls    %d5 $0x00 -> %d4
+0e2048e6 : cls v6.8b, v7.8b                          : cls    %d7 $0x00 -> %d6
+0e204928 : cls v8.8b, v9.8b                          : cls    %d9 $0x00 -> %d8
+0e20496a : cls v10.8b, v11.8b                        : cls    %d11 $0x00 -> %d10
+0e2049ac : cls v12.8b, v13.8b                        : cls    %d13 $0x00 -> %d12
+0e2049ee : cls v14.8b, v15.8b                        : cls    %d15 $0x00 -> %d14
+0e204a30 : cls v16.8b, v17.8b                        : cls    %d17 $0x00 -> %d16
+0e204a51 : cls v17.8b, v18.8b                        : cls    %d18 $0x00 -> %d17
+0e204a93 : cls v19.8b, v20.8b                        : cls    %d20 $0x00 -> %d19
+0e204ad5 : cls v21.8b, v22.8b                        : cls    %d22 $0x00 -> %d21
+0e204b17 : cls v23.8b, v24.8b                        : cls    %d24 $0x00 -> %d23
+0e204b59 : cls v25.8b, v26.8b                        : cls    %d26 $0x00 -> %d25
+0e204b9b : cls v27.8b, v28.8b                        : cls    %d28 $0x00 -> %d27
+0e20481f : cls v31.8b, v0.8b                         : cls    %d0 $0x00 -> %d31
+0e604820 : cls v0.4h, v1.4h                          : cls    %d1 $0x01 -> %d0
+0e604862 : cls v2.4h, v3.4h                          : cls    %d3 $0x01 -> %d2
+0e6048a4 : cls v4.4h, v5.4h                          : cls    %d5 $0x01 -> %d4
+0e6048e6 : cls v6.4h, v7.4h                          : cls    %d7 $0x01 -> %d6
+0e604928 : cls v8.4h, v9.4h                          : cls    %d9 $0x01 -> %d8
+0e60496a : cls v10.4h, v11.4h                        : cls    %d11 $0x01 -> %d10
+0e6049ac : cls v12.4h, v13.4h                        : cls    %d13 $0x01 -> %d12
+0e6049ee : cls v14.4h, v15.4h                        : cls    %d15 $0x01 -> %d14
+0e604a30 : cls v16.4h, v17.4h                        : cls    %d17 $0x01 -> %d16
+0e604a51 : cls v17.4h, v18.4h                        : cls    %d18 $0x01 -> %d17
+0e604a93 : cls v19.4h, v20.4h                        : cls    %d20 $0x01 -> %d19
+0e604ad5 : cls v21.4h, v22.4h                        : cls    %d22 $0x01 -> %d21
+0e604b17 : cls v23.4h, v24.4h                        : cls    %d24 $0x01 -> %d23
+0e604b59 : cls v25.4h, v26.4h                        : cls    %d26 $0x01 -> %d25
+0e604b9b : cls v27.4h, v28.4h                        : cls    %d28 $0x01 -> %d27
+0e60481f : cls v31.4h, v0.4h                         : cls    %d0 $0x01 -> %d31
+0ea04820 : cls v0.2s, v1.2s                          : cls    %d1 $0x02 -> %d0
+0ea04862 : cls v2.2s, v3.2s                          : cls    %d3 $0x02 -> %d2
+0ea048a4 : cls v4.2s, v5.2s                          : cls    %d5 $0x02 -> %d4
+0ea048e6 : cls v6.2s, v7.2s                          : cls    %d7 $0x02 -> %d6
+0ea04928 : cls v8.2s, v9.2s                          : cls    %d9 $0x02 -> %d8
+0ea0496a : cls v10.2s, v11.2s                        : cls    %d11 $0x02 -> %d10
+0ea049ac : cls v12.2s, v13.2s                        : cls    %d13 $0x02 -> %d12
+0ea049ee : cls v14.2s, v15.2s                        : cls    %d15 $0x02 -> %d14
+0ea04a30 : cls v16.2s, v17.2s                        : cls    %d17 $0x02 -> %d16
+0ea04a51 : cls v17.2s, v18.2s                        : cls    %d18 $0x02 -> %d17
+0ea04a93 : cls v19.2s, v20.2s                        : cls    %d20 $0x02 -> %d19
+0ea04ad5 : cls v21.2s, v22.2s                        : cls    %d22 $0x02 -> %d21
+0ea04b17 : cls v23.2s, v24.2s                        : cls    %d24 $0x02 -> %d23
+0ea04b59 : cls v25.2s, v26.2s                        : cls    %d26 $0x02 -> %d25
+0ea04b9b : cls v27.2s, v28.2s                        : cls    %d28 $0x02 -> %d27
+0ea0481f : cls v31.2s, v0.2s                         : cls    %d0 $0x02 -> %d31
+4e204820 : cls v0.16b, v1.16b                        : cls    %q1 $0x00 -> %q0
+4e204862 : cls v2.16b, v3.16b                        : cls    %q3 $0x00 -> %q2
+4e2048a4 : cls v4.16b, v5.16b                        : cls    %q5 $0x00 -> %q4
+4e2048e6 : cls v6.16b, v7.16b                        : cls    %q7 $0x00 -> %q6
+4e204928 : cls v8.16b, v9.16b                        : cls    %q9 $0x00 -> %q8
+4e20496a : cls v10.16b, v11.16b                      : cls    %q11 $0x00 -> %q10
+4e2049ac : cls v12.16b, v13.16b                      : cls    %q13 $0x00 -> %q12
+4e2049ee : cls v14.16b, v15.16b                      : cls    %q15 $0x00 -> %q14
+4e204a30 : cls v16.16b, v17.16b                      : cls    %q17 $0x00 -> %q16
+4e204a51 : cls v17.16b, v18.16b                      : cls    %q18 $0x00 -> %q17
+4e204a93 : cls v19.16b, v20.16b                      : cls    %q20 $0x00 -> %q19
+4e204ad5 : cls v21.16b, v22.16b                      : cls    %q22 $0x00 -> %q21
+4e204b17 : cls v23.16b, v24.16b                      : cls    %q24 $0x00 -> %q23
+4e204b59 : cls v25.16b, v26.16b                      : cls    %q26 $0x00 -> %q25
+4e204b9b : cls v27.16b, v28.16b                      : cls    %q28 $0x00 -> %q27
+4e20481f : cls v31.16b, v0.16b                       : cls    %q0 $0x00 -> %q31
+4e604820 : cls v0.8h, v1.8h                          : cls    %q1 $0x01 -> %q0
+4e604862 : cls v2.8h, v3.8h                          : cls    %q3 $0x01 -> %q2
+4e6048a4 : cls v4.8h, v5.8h                          : cls    %q5 $0x01 -> %q4
+4e6048e6 : cls v6.8h, v7.8h                          : cls    %q7 $0x01 -> %q6
+4e604928 : cls v8.8h, v9.8h                          : cls    %q9 $0x01 -> %q8
+4e60496a : cls v10.8h, v11.8h                        : cls    %q11 $0x01 -> %q10
+4e6049ac : cls v12.8h, v13.8h                        : cls    %q13 $0x01 -> %q12
+4e6049ee : cls v14.8h, v15.8h                        : cls    %q15 $0x01 -> %q14
+4e604a30 : cls v16.8h, v17.8h                        : cls    %q17 $0x01 -> %q16
+4e604a51 : cls v17.8h, v18.8h                        : cls    %q18 $0x01 -> %q17
+4e604a93 : cls v19.8h, v20.8h                        : cls    %q20 $0x01 -> %q19
+4e604ad5 : cls v21.8h, v22.8h                        : cls    %q22 $0x01 -> %q21
+4e604b17 : cls v23.8h, v24.8h                        : cls    %q24 $0x01 -> %q23
+4e604b59 : cls v25.8h, v26.8h                        : cls    %q26 $0x01 -> %q25
+4e604b9b : cls v27.8h, v28.8h                        : cls    %q28 $0x01 -> %q27
+4e60481f : cls v31.8h, v0.8h                         : cls    %q0 $0x01 -> %q31
+4ea04820 : cls v0.4s, v1.4s                          : cls    %q1 $0x02 -> %q0
+4ea04862 : cls v2.4s, v3.4s                          : cls    %q3 $0x02 -> %q2
+4ea048a4 : cls v4.4s, v5.4s                          : cls    %q5 $0x02 -> %q4
+4ea048e6 : cls v6.4s, v7.4s                          : cls    %q7 $0x02 -> %q6
+4ea04928 : cls v8.4s, v9.4s                          : cls    %q9 $0x02 -> %q8
+4ea0496a : cls v10.4s, v11.4s                        : cls    %q11 $0x02 -> %q10
+4ea049ac : cls v12.4s, v13.4s                        : cls    %q13 $0x02 -> %q12
+4ea049ee : cls v14.4s, v15.4s                        : cls    %q15 $0x02 -> %q14
+4ea04a30 : cls v16.4s, v17.4s                        : cls    %q17 $0x02 -> %q16
+4ea04a51 : cls v17.4s, v18.4s                        : cls    %q18 $0x02 -> %q17
+4ea04a93 : cls v19.4s, v20.4s                        : cls    %q20 $0x02 -> %q19
+4ea04ad5 : cls v21.4s, v22.4s                        : cls    %q22 $0x02 -> %q21
+4ea04b17 : cls v23.4s, v24.4s                        : cls    %q24 $0x02 -> %q23
+4ea04b59 : cls v25.4s, v26.4s                        : cls    %q26 $0x02 -> %q25
+4ea04b9b : cls v27.4s, v28.4s                        : cls    %q28 $0x02 -> %q27
+4ea0481f : cls v31.4s, v0.4s                         : cls    %q0 $0x02 -> %q31


### PR DESCRIPTION
This patch adds:
`CMHS    <Dd>, <Dn>, <Dm>`
`CMGE    <Dd>, <Dn>, <Dm>`
`CMTST   <Dd>, <Dn>, <Dm>`
`CLS     <Vd>.<T>, <Vn>.<T>`

Issues: #2626