### PR TITLE
i#5131 new linux syscalls: Fix aarch64 dup3 and close_range handling

### DIFF
--- a/core/unix/include/syscall_linux_uapi.h
+++ b/core/unix/include/syscall_linux_uapi.h
@@ -2864,6 +2864,16 @@
 #    define SYS_writev __NR_writev
 #endif
 
+/* The following SYS_* constants are defined manually for some of the above
+ * __NR_* constants that do not have a corresponding SYS_* constant defined
+ * in the header files yet. This is so that we can add support for the
+ * corresponding syscall. These entries should be deleted when the above
+ * list is updated with a newer header file that contains them already.
+ */
+#ifdef __NR_close_range
+#    define SYS_close_range __NR_close_range
+#endif
+
 /* Added separately as it was present earlier. */
 #ifdef __NR_fstatat
 #    define SYS_fstatat __NR_fstatat

--- a/core/unix/include/syscall_linux_uapi.h
+++ b/core/unix/include/syscall_linux_uapi.h
@@ -334,9 +334,14 @@
 #define __NR_fspick 433
 #define __NR_pidfd_open 434
 #define __NR_clone3 435
+#define __NR_close_range 436
+#define __NR_openat2 437
+#define __NR_pidfd_getfd 438
+#define __NR_faccessat2 439
+#define __NR_process_madvise 440
 
 #undef __NR_syscalls
-#define __NR_syscalls 436
+#define __NR_syscalls 441
 
 /*
  * 32 bit systems traditionally used different

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7679,8 +7679,10 @@ pre_system_call(dcontext_t *dcontext)
 #endif
         break;
     }
-#if defined(SYS_dup2) || defined(LINUX)
-        IF_LINUX(case SYS_dup3:)
+#if defined(SYS_dup2) || defined(SYS_dup3)
+#    ifdef SYS_dup3
+    case SYS_dup3:
+#    endif
 #    ifdef SYS_dup2
     case SYS_dup2:
 #    endif

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4961,9 +4961,7 @@ ignorable_system_call_normalized(int num)
 #ifdef MACOS
     case SYS_close_nocancel:
 #endif
-#ifdef SYS_close_range
     case SYS_close_range:
-#endif
     case SYS_close:
 #ifdef SYS_dup2
     case SYS_dup2:
@@ -6157,13 +6155,11 @@ handle_close_pre(dcontext_t *dcontext)
                                     true /*set_return_val*/);
 }
 
-#ifdef SYS_close_range
 static bool
 handle_close_range_pre(dcontext_t *dcontext, file_t fd)
 {
     return handle_close_generic_pre(dcontext, fd, false /*set_return_val*/);
 }
-#endif
 
 /***************************************************************************/
 
@@ -7602,7 +7598,6 @@ pre_system_call(dcontext_t *dcontext)
 #ifdef MACOS
     case SYS_close_nocancel:
 #endif
-#ifdef SYS_close_range
     case SYS_close_range: {
         /* client.file_io indeed tests this for all arch, but it hasn't yet been
          * run on a machine that has close_range available.
@@ -7670,7 +7665,6 @@ pre_system_call(dcontext_t *dcontext)
         }
         break;
     }
-#endif
     case SYS_close: {
         execute_syscall = handle_close_pre(dcontext);
 #ifdef LINUX

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7605,7 +7605,7 @@ pre_system_call(dcontext_t *dcontext)
 #ifdef SYS_close_range
     case SYS_close_range: {
         /* client.file_io indeed tests this for all arch, but it hasn't yet been
-         * run on a machine that has close_range available.
+         * run on an AArchXX machine that has close_range available.
          */
         IF_AARCHXX(ASSERT_NOT_TESTED());
         uint first_fd = sys_param(dcontext, 0), last_fd = sys_param(dcontext, 1);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7604,6 +7604,10 @@ pre_system_call(dcontext_t *dcontext)
 #endif
 #ifdef SYS_close_range
     case SYS_close_range: {
+        /* client.file_io indeed tests this for all arch, but it hasn't yet been
+         * run on a machine that has close_range available.
+         */
+        IF_AARCHXX(ASSERT_NOT_TESTED());
         uint first_fd = sys_param(dcontext, 0), last_fd = sys_param(dcontext, 1);
         uint flags = sys_param(dcontext, 2);
         bool is_cloexec = TEST(CLOSE_RANGE_CLOEXEC, flags);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4961,7 +4961,9 @@ ignorable_system_call_normalized(int num)
 #ifdef MACOS
     case SYS_close_nocancel:
 #endif
+#ifdef SYS_close_range
     case SYS_close_range:
+#endif
     case SYS_close:
 #ifdef SYS_dup2
     case SYS_dup2:
@@ -6155,11 +6157,13 @@ handle_close_pre(dcontext_t *dcontext)
                                     true /*set_return_val*/);
 }
 
+#ifdef SYS_close_range
 static bool
 handle_close_range_pre(dcontext_t *dcontext, file_t fd)
 {
     return handle_close_generic_pre(dcontext, fd, false /*set_return_val*/);
 }
+#endif
 
 /***************************************************************************/
 
@@ -7598,6 +7602,7 @@ pre_system_call(dcontext_t *dcontext)
 #ifdef MACOS
     case SYS_close_nocancel:
 #endif
+#ifdef SYS_close_range
     case SYS_close_range: {
         /* client.file_io indeed tests this for all arch, but it hasn't yet been
          * run on a machine that has close_range available.
@@ -7665,6 +7670,7 @@ pre_system_call(dcontext_t *dcontext)
         }
         break;
     }
+#endif
     case SYS_close: {
         execute_syscall = handle_close_pre(dcontext);
 #ifdef LINUX

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2441,9 +2441,9 @@ else (UNIX)
 
   tobuild_ci(client.winxfer client-interface/winxfer.c "" "" "")
 endif (UNIX)
+tobuild_ci(client.file_io client-interface/file_io.c
+  "${CMAKE_CURRENT_SOURCE_DIR}/client-interface/file_io_data.txt" "" "")
 if (X86) # FIXME i#1551, i#1569: port asm to ARM and AArch64
-  tobuild_ci(client.file_io client-interface/file_io.c
-    "${CMAKE_CURRENT_SOURCE_DIR}/client-interface/file_io_data.txt" "" "")
   if (DEBUG) # FIXME i#1806: fails in release; also in OSX list below.
     # we add custom option to flush test based on dr ops in torun_ci()
     tobuild_ci(client.flush client-interface/flush.c "" "" "")

--- a/suite/tests/client-interface/file_io.c
+++ b/suite/tests/client-interface/file_io.c
@@ -134,6 +134,7 @@ main()
     }
 
 #    ifdef __NR_close_range
+    fprintf(stderr, "AAA close_range available on this system\n");
     /* Test close_range. First open some FDs. */
     for (int i = rlimit.rlim_max - 1; i >= rlimit.rlim_max - 10; i--) {
         if (i % 2 == 0) {
@@ -147,12 +148,14 @@ main()
     /* Mark one FD as close-on-exec. */
     assert(!TEST(FD_CLOEXEC, fcntl(rlimit.rlim_max - 1, F_GETFD)));
 #        ifdef CLOSE_RANGE_CLOEXEC
+    fprintf(stderr, "AAA CLOSE_RANGE_CLOEXEC available on this system\n");
     /* CLOSE_RANGE_CLOEXEC is available only on kernel version >= 5.11 */
     if (syscall(__NR_close_range, rlimit.rlim_max - 1, rlimit.rlim_max - 1,
                 CLOSE_RANGE_CLOEXEC) == -1) {
         perror("close_range mark as close-on-exec failed");
     }
 #        else
+    fprintf(stderr, "AAA CLOSE_RANGE_CLOEXEC NOT available on this system\n");
     assert(fcntl(rlimit.rlim_max - 1, F_SETFD,
                  fcntl(rlimit.rlim_max - 1, F_GETFD) | FD_CLOEXEC) == 0);
 #        endif
@@ -178,6 +181,8 @@ main()
     /* Test EINVAL. */
     if (syscall(__NR_close_range, 3, 2, 0) != -1 || errno != EINVAL)
         fprintf(stderr, "expected EINVAL from close_range");
+#    else
+    fprintf(stderr, "AAA close_range NOT available on this system\n");
 #    endif
     struct rlimit new_rlimit;
     /* setrlimit with lower soft value */
@@ -298,6 +303,7 @@ main()
     _control87(_MCW_EM & (~_EM_ZERODIVIDE), _MCW_EM);
 #else
     if (feenableexcept(FE_DIVBYZERO) == -1) {
+        perror("AAA feenableexcept failed");
 #    ifdef AARCH64
         /* This call may return EPERM on AArch64.
          * https://code.woboq.org/userspace/glibc/sysdeps/aarch64/fpu/feenablxcpt.c.html#37
@@ -308,6 +314,7 @@ main()
         fprintf(stderr, "feenableexcept failed\n");
 #    endif
     } else {
+        fprintf(stderr, "AAA feenableexcept succeeded\n");
         if (!(fegetexcept() & FE_DIVBYZERO))
             fprintf(stderr, "feenableexcept was successful yet FE_DIVBYZERO not set\n");
     }

--- a/suite/tests/client-interface/file_io.c
+++ b/suite/tests/client-interface/file_io.c
@@ -117,6 +117,7 @@ main()
         }
 #    ifdef LINUX
         else {
+            /* Not available on MacOS. */
             if (dup3(0, i, 0) != -1 || errno != EBADF)
                 fprintf(stderr, "Expected dup3 to return EBADF for stolen FD %d\n", i);
         }

--- a/suite/tests/client-interface/file_io.c
+++ b/suite/tests/client-interface/file_io.c
@@ -134,7 +134,6 @@ main()
     }
 
 #    ifdef __NR_close_range
-    fprintf(stderr, "AAA close_range available on this system\n");
     /* Test close_range. First open some FDs. */
     for (int i = rlimit.rlim_max - 1; i >= rlimit.rlim_max - 10; i--) {
         if (i % 2 == 0) {
@@ -148,14 +147,12 @@ main()
     /* Mark one FD as close-on-exec. */
     assert(!TEST(FD_CLOEXEC, fcntl(rlimit.rlim_max - 1, F_GETFD)));
 #        ifdef CLOSE_RANGE_CLOEXEC
-    fprintf(stderr, "AAA CLOSE_RANGE_CLOEXEC available on this system\n");
     /* CLOSE_RANGE_CLOEXEC is available only on kernel version >= 5.11 */
     if (syscall(__NR_close_range, rlimit.rlim_max - 1, rlimit.rlim_max - 1,
                 CLOSE_RANGE_CLOEXEC) == -1) {
         perror("close_range mark as close-on-exec failed");
     }
 #        else
-    fprintf(stderr, "AAA CLOSE_RANGE_CLOEXEC NOT available on this system\n");
     assert(fcntl(rlimit.rlim_max - 1, F_SETFD,
                  fcntl(rlimit.rlim_max - 1, F_GETFD) | FD_CLOEXEC) == 0);
 #        endif
@@ -181,8 +178,6 @@ main()
     /* Test EINVAL. */
     if (syscall(__NR_close_range, 3, 2, 0) != -1 || errno != EINVAL)
         fprintf(stderr, "expected EINVAL from close_range");
-#    else
-    fprintf(stderr, "AAA close_range NOT available on this system\n");
 #    endif
     struct rlimit new_rlimit;
     /* setrlimit with lower soft value */
@@ -303,7 +298,6 @@ main()
     _control87(_MCW_EM & (~_EM_ZERODIVIDE), _MCW_EM);
 #else
     if (feenableexcept(FE_DIVBYZERO) == -1) {
-        perror("AAA feenableexcept failed");
 #    ifdef AARCH64
         /* This call may return EPERM on AArch64.
          * https://code.woboq.org/userspace/glibc/sysdeps/aarch64/fpu/feenablxcpt.c.html#37
@@ -314,7 +308,6 @@ main()
         fprintf(stderr, "feenableexcept failed\n");
 #    endif
     } else {
-        fprintf(stderr, "AAA feenableexcept succeeded\n");
         if (!(fegetexcept() & FE_DIVBYZERO))
             fprintf(stderr, "feenableexcept was successful yet FE_DIVBYZERO not set\n");
     }

--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -245,10 +245,6 @@ make_clone3_syscall(struct clone_args *clone_args, uint clone_args_size,
 #        endif
 #    elif defined(AARCH64)
     uint64 clone_args_size_64 = (uint64)clone_args_size;
-    /* Do not add code between above declarations and their use below.
-     * This is to ensure that those registers continue to have the
-     * same data.
-     */
     asm volatile("mov x8, #%[sys_clone3]\n\t"
                  "ldr x0, %[clone_args]\n\t"
                  "ldr x1, %[clone_args_size]\n\t"


### PR DESCRIPTION
Fixes an existing bug in dup3 handling on AArch64. As SYS_dup2 is not
available on AArch64, SYS_dup3 was not being included in the switch in
pre-syscall handling due to a misplaced conditional compile statement. Note
that on AArch64 dup2 automatically uses dup3 internally, so the bug affected
also the dup2 calls in the client.file_io test.

Fixes close_range handling on AArch64 by updating the syscall defines from a
newer header file that does define __NR_close_range. Defines the
SYS_close_range constant for AArch64.

Enables the client.file_io test on AArchXX. Replaces the inline asm code to
unmask divide-by-zero exceptions, with a glibc wrapper. Also adds a test for
dup3. The clone_range part of this test is enabled on AArchXX but hasn't been
run yet, because our CI machine does not have kernel >= 5.9.

Also, on AArch64, unmasking of float-point exceptions in the setup of the
client.file_io test may be ignored as trapping exceptions is optional.
https://code.woboq.org/userspace/glibc/sysdeps/aarch64/fpu/feenablxcpt.c.html#37

Issue: #5131