### PR TITLE
i#5054: Hide Linux attach until it is fixed

### DIFF
--- a/api/docs/deployment.dox
+++ b/api/docs/deployment.dox
@@ -215,7 +215,8 @@ bin32/drrun.exe -c samples/bin32/bbsize.dll -- notepad
 \endcode
 
 Alternatively, you can first run \c notepad.exe, and then use \c drrun
-to attach to it:
+to attach to it, but please note that attaching is an experimental
+feature and is not yet as well-supported as launching a new process:
 \code
 bin32/drrun.exe -attach <notepad_pid> -c samples/bin32/bbsize.dll
 \endcode
@@ -314,11 +315,14 @@ under DynamoRIO with the bbsize sample client:
 % bin32/drrun -c samples/bin32/libbbsize.so -- ls
 \endcode
 
+\if DISABLED_UNTIL_BUG_5054_IS_FIXED
 Alternatively, you can first run the target, and then use \c drrun
-to attach to it:
+to attach to it, but please note that attaching is an experimental
+feature and is not yet as well-supported as launching a new process:
 \code
 % bin32/drrun -attach <target_pid> -c samples/bin32/libbbsize.so
 \endcode
+\endif
 
 Run \c drrun with no options to get a list of the options and
 environment variable shortcuts it supports.  To disable following across

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -244,7 +244,8 @@ Further non-compatibility-affecting changes include:
    and exhaustive machine state comparisons across instrumentation sequences.
  - Added drmodtrack_lookup_segment().
  - Added a new drrun option \p -attach for attaching to a running process.
-   This is currently an experimental option.
+   This is currently an experimental option and is not yet as well-supported
+   as launching a new process.
  - Added \ref page_drcallstack Extension for walking application callstacks, with
    an initial Linux-only implementation.
  - Added new #dr_cleancall_save_t flags which are required for proper interaction

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -299,22 +299,27 @@ const char *options_list_str =
     "       -logdir <dir>      Logfiles will be stored in this directory.\n"
 #    endif
 #    ifdef UNIX
+#        if DISABLED_UNTIL_BUG_5054_IS_FIXED /* Code is there, just not advertised. */
     "       -attach <pid>      Attach to the process with the given pid.\n"
-    "                          If attach to a process which is in middle of blocking\n"
-    "                          system call, dynamorio will wait until it returns.\n"
-#        ifdef X86
+    "                          Attaching is an experimental feature and is not yet\n"
+    "                          as well-supported as launching a new process.\n"
+    "                          When attaching to a process in the middle of a blocking\n"
+    "                          system call, DynamoRIO will wait until it returns.\n"
+#            ifdef X86
     "                          Can be used with -skip_syscall.\n"
     "       -skip_syscall      (Experimental)\n"
-    "                          Only work with -attach.\n"
+    "                          Only works with -attach.\n"
     "                          Attaching to a process will force blocking system calls\n"
     "                          to fail with EINTR.\n"
-#        endif
+#            endif
+#        endif /* DISABLED_UNTIL_BUG_5054_IS_FIXED */
 #    endif
 #    ifdef WINDOWS
-    "       -attach <pid>      (Experimental)\n"
-    "                          Attach to the process with the given pid.\n"
-    "                          If attach to a process which is in middle of blocking\n"
-    "                          system call, attach could fail.\n"
+    "       -attach <pid>      Attach to the process with the given pid.\n"
+    "                          Attaching is an experimental feature and is not yet\n"
+    "                          as well-supported as launching a new process.\n"
+    "                          Attaching to a process in the middle of a blocking\n"
+    "                          system call could fail.\n"
     "                          Try takeover_sleep and larger takeovers to increase\n"
     "                          the chances of success:\n"
     "       -takeover_sleep    Sleep 1 millisecond between takeover attempts.\n"


### PR DESCRIPTION
Hides the -attach flag from the drrun -help output.
Hides the -attach example in the documentation.

Once #5054 is fixed we can re-enable these, but for now it is just too
broken and advertising it causes more confusion than good.

Issue: #5145, #5054