### PR TITLE
i#5054: Fix attach crash and other problems

### DIFF
--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -92,6 +92,7 @@ jobs:
         sudo rsync -av ../extract/usr/lib/i386-linux-gnu/ /usr/lib/i386-linux-gnu/
         sudo rsync -av ../extract/lib/i386-linux-gnu/ /usr/lib/i386-linux-gnu/
         sudo rsync -av ../extract/usr/include/i386-linux-gnu/ /usr/include/
+        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
 
     # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
     - name: Setup newer cmake
@@ -152,6 +153,7 @@ jobs:
         sudo apt update
         sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
           g++-multilib libunwind-dev
+        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
 
     # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
     - name: Setup newer cmake

--- a/api/docs/deployment.dox
+++ b/api/docs/deployment.dox
@@ -325,6 +325,12 @@ the syscall, additionally pass -skip_syscall.
 % bin32/drrun -attach <target_pid> -c samples/bin32/libbbsize.so
 \endcode
 
+This attach feature requires ptrace capabilities, which can be enabled
+with this command:
+\code
+% echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+\endcode
+
 Run \c drrun with no options to get a list of the options and
 environment variable shortcuts it supports.  To disable following across
 child execve calls, use the \ref op_children "-no_follow_children" runtime

--- a/api/docs/deployment.dox
+++ b/api/docs/deployment.dox
@@ -315,14 +315,15 @@ under DynamoRIO with the bbsize sample client:
 % bin32/drrun -c samples/bin32/libbbsize.so -- ls
 \endcode
 
-\if DISABLED_UNTIL_BUG_5054_IS_FIXED
 Alternatively, you can first run the target, and then use \c drrun
 to attach to it, but please note that attaching is an experimental
-feature and is not yet as well-supported as launching a new process:
+feature and is not yet as well-supported as launching a new process.
+In particular, if the application is in the middle of a blocking syscall,
+DynamoRIO will wait for that to finish.  To instead force interruption of
+the syscall, additionally pass -skip_syscall.
 \code
 % bin32/drrun -attach <target_pid> -c samples/bin32/libbbsize.so
 \endcode
-\endif
 
 Run \c drrun with no options to get a list of the options and
 environment variable shortcuts it supports.  To disable following across

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -245,7 +245,7 @@ Further non-compatibility-affecting changes include:
  - Added drmodtrack_lookup_segment().
  - Added a new drrun option \p -attach for attaching to a running process.
    This is currently an experimental option and is not yet as well-supported
-   as launching a new process.
+   as launching a new process.  It is only supported on x86 at this time.
  - Added \ref page_drcallstack Extension for walking application callstacks, with
    an initial Linux-only implementation.
  - Added new #dr_cleancall_save_t flags which are required for proper interaction

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -522,9 +522,9 @@ privload_map_and_relocate(const char *filename, size_t *size OUT, modload_flags_
         }
         return NULL;
     }
-    base =
-        elf_loader_map_phdrs(&loader, false /* fixed */, map_func, unmap_func, prot_func,
-                             privload_check_new_map_bounds, privload_map_flags(flags));
+    base = elf_loader_map_phdrs(&loader, false /* fixed */, map_func, unmap_func,
+                                prot_func, privload_check_new_map_bounds, memset,
+                                privload_map_flags(flags));
     if (base != NULL) {
         if (size != NULL)
             *size = loader.image_size;
@@ -1897,7 +1897,7 @@ reload_dynamorio(void **init_sp, app_pc conflict_start, app_pc conflict_end)
     /* Now load the 2nd libdynamorio.so */
     dr_map = elf_loader_map_phdrs(&dr_ld, false /*!fixed*/, os_map_file, os_unmap_file,
                                   os_set_protection, privload_check_new_map_bounds,
-                                  privload_map_flags(0 /*!reachable*/));
+                                  memset, privload_map_flags(0 /*!reachable*/));
     ASSERT(dr_map != NULL);
     ASSERT(is_elf_so_header(dr_map, 0));
 
@@ -2054,7 +2054,7 @@ privload_early_inject(void **sp, byte *old_libdr_base, size_t old_libdr_size)
                                    true,
                                    /* ensure there's space for the brk */
                                    map_exe_file_and_brk, os_unmap_file, os_set_protection,
-                                   privload_check_new_map_bounds,
+                                   privload_check_new_map_bounds, memset,
                                    privload_map_flags(MODLOAD_IS_APP /*!reachable*/));
     apicheck(exe_map != NULL,
              "Failed to load application.  "
@@ -2114,7 +2114,7 @@ privload_early_inject(void **sp, byte *old_libdr_base, size_t old_libdr_size)
         apicheck(success, "Failed to read ELF interpreter headers.");
         interp_map = elf_loader_map_phdrs(
             &interp_ld, false /* fixed */, os_map_file, os_unmap_file, os_set_protection,
-            privload_check_new_map_bounds,
+            privload_check_new_map_bounds, memset,
             privload_map_flags(MODLOAD_IS_APP /*!reachable*/));
         apicheck(interp_map != NULL && is_elf_so_header(interp_map, 0),
                  "Failed to map ELF interpreter.");

--- a/core/unix/module_elf.h
+++ b/core/unix/module_elf.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -268,6 +268,7 @@ typedef byte *(*map_fn_t)(file_t f, size_t *size INOUT, uint64 offs, app_pc addr
 typedef bool (*unmap_fn_t)(byte *map, size_t size);
 typedef bool (*prot_fn_t)(byte *map, size_t size, uint prot /*MEMPROT_*/);
 typedef void (*check_bounds_fn_t)(elf_loader_t *elf, byte *start, byte *end);
+typedef void *(*memset_fn_t)(void *dst, int val, size_t size);
 
 /* Initialized an ELF loader for use with the given file. */
 bool
@@ -308,7 +309,8 @@ elf_loader_map_file(elf_loader_t *elf, bool reachable);
 app_pc
 elf_loader_map_phdrs(elf_loader_t *elf, bool fixed, map_fn_t map_func,
                      unmap_fn_t unmap_func, prot_fn_t prot_func,
-                     check_bounds_fn_t check_bounds_func, modload_flags_t flags);
+                     check_bounds_fn_t check_bounds_func, memset_fn_t memset_func,
+                     modload_flags_t flags);
 
 /* Iterate program headers of a mapped ELF image and find the string that
  * PT_INTERP points to.  Typically this comes early in the file and is always

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1307,6 +1307,11 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out)
     if (UNIX)
       # We always run infloop.
       get_target_path_for_execution(app_path linux.infloop "${location_suffix}")
+      if ("${runall}" MATCHES "<attach>")
+        # Add a starting message with -v, and avoid mprotect for now (i#38: mprotect
+        # is failing).
+        set(exe_ops "${exe_ops};-v;-attach")
+      endif ()
     else ()
       if ("${runall}" MATCHES "<attach>")
         # For attach we use attachee, which is identical to infloop, aside for writing
@@ -2369,6 +2374,8 @@ if (ANNOTATIONS AND NOT ARM)
       client-interface/vg-annot.c "truncate@2" "" "")
   endif (UNIX OR NOT X64)
 endif (ANNOTATIONS AND NOT ARM)
+# TODO i#38: Add targeted Linux tests of attaching during a blocking syscall.
+tobuild_ci(client.attach_test client-interface/attach_test.runall "" "" "")
 if (UNIX)
   if (NOT ARM) # FIXME i#1551: fix bugs on ARM
     if (AARCH64)
@@ -2409,7 +2416,6 @@ if (UNIX)
     use_DynamoRIO_extension(client.emulation_api_simple.dll drmgr)
   endif ()
 else (UNIX)
-  tobuild_ci(client.attach_test client-interface/attach_test.runall "" "" "")
   tobuild_ci(client.events client-interface/events.c
     "" "" "${events_appdll_path}")
   tobuild_ci(client.events_cpp client-interface/events_cpp.cpp

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2374,8 +2374,14 @@ if (ANNOTATIONS AND NOT ARM)
       client-interface/vg-annot.c "truncate@2" "" "")
   endif (UNIX OR NOT X64)
 endif (ANNOTATIONS AND NOT ARM)
-# TODO i#38: Add targeted Linux tests of attaching during a blocking syscall.
-tobuild_ci(client.attach_test client-interface/attach_test.runall "" "" "")
+
+if (NOT ANDROID) # TODO i#38: Port test to Android.
+  if (X86) # TODO i#38,i#1550: Port injector.c attach gencode to AArchXX.
+    # TODO i#38: Add targeted Linux tests of attaching during a blocking syscall.
+    tobuild_ci(client.attach_test client-interface/attach_test.runall "" "" "")
+  endif ()
+endif ()
+
 if (UNIX)
   if (NOT ARM) # FIXME i#1551: fix bugs on ARM
     if (AARCH64)

--- a/suite/tests/client-interface/attach_test.template
+++ b/suite/tests/client-interface/attach_test.template
@@ -1,4 +1,8 @@
+#ifdef WINDOWS
 starting attachee
+#else
+starting
+#endif
 thank you for testing attach
 thread init
 #ifdef WINDOWS

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -1920,8 +1920,7 @@ done_with_options:
     if (inject && !dr_inject_process_inject(inject_data, force_injection, drlib_path)) {
 #    ifdef DRRUN
         if (attach_pid != 0) {
-            error("unable to attach to %d; check pid and system ptrace permissions",
-                  attach_pid);
+            error("unable to attach; check pid and system ptrace permissions");
             goto error;
         }
         error("unable to inject: exec of |%s| failed", drlib_path);

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -299,20 +299,18 @@ const char *options_list_str =
     "       -logdir <dir>      Logfiles will be stored in this directory.\n"
 #    endif
 #    ifdef UNIX
-#        if DISABLED_UNTIL_BUG_5054_IS_FIXED /* Code is there, just not advertised. */
     "       -attach <pid>      Attach to the process with the given pid.\n"
     "                          Attaching is an experimental feature and is not yet\n"
     "                          as well-supported as launching a new process.\n"
     "                          When attaching to a process in the middle of a blocking\n"
     "                          system call, DynamoRIO will wait until it returns.\n"
-#            ifdef X86
-    "                          Can be used with -skip_syscall.\n"
+#        ifdef X86
+    "                          Use -skip_syscall to force interruption.\n"
     "       -skip_syscall      (Experimental)\n"
     "                          Only works with -attach.\n"
     "                          Attaching to a process will force blocking system calls\n"
     "                          to fail with EINTR.\n"
-#            endif
-#        endif /* DISABLED_UNTIL_BUG_5054_IS_FIXED */
+#        endif
 #    endif
 #    ifdef WINDOWS
     "       -attach <pid>      Attach to the process with the given pid.\n"
@@ -1282,12 +1280,14 @@ _tmain(int argc, TCHAR *targv[])
         }
 #    endif
         else if (strcmp(argv[i], "-attach") == 0) {
+            if (i + 1 >= argc)
+                usage(false, "attach requires a process id");
             const char *pid_str = argv[++i];
             process_id_t pid = strtoul(pid_str, NULL, 10);
             if (pid == ULONG_MAX)
-                usage(false, "attach expects an integer pid");
+                usage(false, "attach expects an integer pid: '%s'", pid_str);
             if (pid == 0) {
-                usage(false, "attach to invalid pid");
+                usage(false, "attach passed an invalid pid: '%s'", pid_str);
             }
             attach_pid = pid;
 #    ifdef UNIX
@@ -1903,6 +1903,8 @@ done_with_options:
             goto error;
         } else {
             info("using ptrace to inject");
+            if (wait_syscall)
+                warn("using experimental attach feature; if it hangs, try -skip_syscall");
         }
     }
     if (kill_group) {
@@ -1917,6 +1919,11 @@ done_with_options:
 
     if (inject && !dr_inject_process_inject(inject_data, force_injection, drlib_path)) {
 #    ifdef DRRUN
+        if (attach_pid != 0) {
+            error("unable to attach to %d; check pid and system ptrace permissions",
+                  attach_pid);
+            goto error;
+        }
         error("unable to inject: exec of |%s| failed", drlib_path);
 #    else
         error("unable to inject: did you forget to run drconfig first?");
@@ -1957,7 +1964,8 @@ done_with_options:
         success = true; /* Don't kill the child if we're not waiting. */
     }
 
-    exitcode = dr_inject_process_exit(inject_data, !success /*kill process*/);
+    exitcode = dr_inject_process_exit(
+        inject_data, attach_pid != 0 ? false : !success /*kill process*/);
 
     if (limit < 0)
         exitcode = 0; /* Return success if we didn't wait. */
@@ -1970,8 +1978,10 @@ error:
     /* we created the process suspended so if we later had an error be sure
      * to kill it instead of leaving it hanging
      */
-    if (inject_data != NULL)
-        dr_inject_process_exit(inject_data, true /*kill process*/);
+    if (inject_data != NULL) {
+        dr_inject_process_exit(inject_data,
+                               attach_pid != 0 ? false : true /*kill process*/);
+    }
 #    ifdef DRRUN
     if (tofree != NULL)
         free(tofree);


### PR DESCRIPTION
Fixes a number of issues with Linux attach:

+ Set xdi to zero for x86 _start relocation of libdynamorio.

+ Implement remote memset for .bss zeroing in elf_loader_map_phdrs(),
  fixing a crash in some builds such as Ubuntu20 release build.

+ Don't kill target if attach fails.

+ Fix crash if no pid passed.

+ Adds a useful error message on failure to look at ptrace permissions.

+ Adds a warning to use -skip_syscall if attach hangs.

+ Adds a test by porting the Windows client.attach test to Linux.
  Disables the mprotect syscall due to weird failures which need to be
  examined.
  Further tests of blocking syscalls and -skip_syscall are needed.

Re-enables the attach help message for drrun and the deployment docs.

Tested release build on Ubuntu20 where the .bss crash reproduced every
run and is now gone.

Tested "ctest --repeat-until-fail 100 -V -R client.attach" on Ubuntu20
and on a Debian-ish system: no failures.

Issue: #38, #5054
Fixes #5054