### PR TITLE
i#2985 scatter-gather: sign-extend double word index.

### DIFF
--- a/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
@@ -3,12 +3,12 @@ Hello world!
 ---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
-          59 total \(fetched\) instructions
-          59 total unique \(fetched\) instructions
+          87 total \(fetched\) instructions
+          87 total unique \(fetched\) instructions
            0 total non-fetched instructions
            0 total prefetches
-           4 total data loads
-           4 total data stores
+           6 total data loads
+           5 total data stores
            0 total icache flushes
            0 total dcache flushes
            1 total threads
@@ -20,12 +20,12 @@ Total counts:
      .* total function return value markers
      .* total other markers
 Thread .* counts:
-          59 \(fetched\) instructions
-          59 unique \(fetched\) instructions
+          87 \(fetched\) instructions
+          87 unique \(fetched\) instructions
            0 non-fetched instructions
            0 prefetches
-           4 data loads
-           4 data stores
+           6 data loads
+           5 data stores
            0 icache flushes
            0 dcache flushes
      .* scheduling markers

--- a/clients/drcachesim/tests/allasm_scattergather.asm
+++ b/clients/drcachesim/tests/allasm_scattergather.asm
@@ -106,6 +106,7 @@ _start:
         mov      eax, 0x00
         vpinsrd  xmm10, xmm10, eax, 0x01
         vpinsrd  xmm10, xmm10, eax, 0x02
+        // Compare the two 64-bit quad-words that make up an xmm reg.
         pcmpeqq  xmm12, xmm10
         vpextrd  eax, xmm12, 0
         cmp      eax, 0xffffffff

--- a/clients/drcachesim/tests/allasm_scattergather.asm
+++ b/clients/drcachesim/tests/allasm_scattergather.asm
@@ -96,9 +96,9 @@ _start:
 
         // Gather arr data into xmm12, skipping index 2 at xmm12,
         // using same indices as scatter.
-        pcmpeqd    xmm13, xmm13
-        xor        eax, eax
-        vpinsrd    xmm13, xmm13, eax, 0x02
+        pcmpeqd  xmm13, xmm13
+        xor      eax, eax
+        vpinsrd  xmm13, xmm13, eax, 0x02
         vpgatherdd xmm12, [arr + xmm11*4], xmm13
 
         // Compare xmm10 and xmm12.
@@ -149,10 +149,10 @@ _start:
 
         // Gather the element at arr-4 into xmm14, using a negative index
         // same as above scatter.
-        pcmpgtd    xmm13, xmm13
-        xor        eax, eax
-        not        eax
-        vpinsrd    xmm13, xmm13, eax, 0x00
+        pcmpgtd  xmm13, xmm13
+        xor      eax, eax
+        not      eax
+        vpinsrd  xmm13, xmm13, eax, 0x00
         vpgatherdd xmm14, [arr + xmm11*4], xmm13
 
         // Compare xmm10 and xmm14.

--- a/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
@@ -2,12 +2,12 @@ Correct
 Hello world!
 Basic counts tool results:
 Total counts:
-          59 total \(fetched\) instructions
-          59 total unique \(fetched\) instructions
+          87 total \(fetched\) instructions
+          87 total unique \(fetched\) instructions
            0 total non-fetched instructions
            0 total prefetches
-           4 total data loads
-           4 total data stores
+           6 total data loads
+           5 total data stores
            0 total icache flushes
            0 total dcache flushes
            1 total threads
@@ -19,12 +19,12 @@ Total counts:
      .* total function return value markers
      .* total other markers
 Thread .* counts:
-          59 \(fetched\) instructions
-          59 unique \(fetched\) instructions
+          87 \(fetched\) instructions
+          87 unique \(fetched\) instructions
            0 non-fetched instructions
            0 prefetches
-           4 data loads
-           4 data stores
+           6 data loads
+           5 data stores
            0 icache flushes
            0 dcache flushes
      .* scheduling markers

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2045,6 +2045,15 @@ expand_avx512_scatter_store_scalar_value(void *drcontext, instrlist_t *bb,
         drreg_get_app_value(drcontext, bb, sg_instr, sg_info->base_reg,
                             sg_info->base_reg);
     }
+#    ifdef X64
+    if (sg_info->scalar_index_size == OPSZ_4) {
+        PREXL8(bb, sg_instr,
+               INSTR_XL8(
+                   INSTR_CREATE_movsxd(drcontext, opnd_create_reg(scalar_index_reg),
+                                       opnd_create_reg(reg_64_to_32(scalar_index_reg))),
+                   orig_app_pc));
+    }
+#    endif
     if (sg_info->scalar_value_size == OPSZ_4) {
         PREXL8(bb, sg_instr,
                INSTR_XL8(INSTR_CREATE_mov_st(
@@ -2085,6 +2094,15 @@ expand_gather_load_scalar_value(void *drcontext, instrlist_t *bb, instr_t *sg_in
         drreg_get_app_value(drcontext, bb, sg_instr, sg_info->base_reg,
                             sg_info->base_reg);
     }
+#    ifdef X64
+    if (sg_info->scalar_index_size == OPSZ_4) {
+        PREXL8(bb, sg_instr,
+               INSTR_XL8(
+                   INSTR_CREATE_movsxd(drcontext, opnd_create_reg(scalar_index_reg),
+                                       opnd_create_reg(reg_64_to_32(scalar_index_reg))),
+                   orig_app_pc));
+    }
+#    endif
     if (sg_info->scalar_value_size == OPSZ_4) {
         PREXL8(
             bb, sg_instr,


### PR DESCRIPTION
Fixes a crash in the expanded scatter gather sequence when
a double word index is negative and needs to be sign-extended.
Without sign extension, the computed address may be invalid
(e.g. base + 0xffffffff, instead of base - 1). Double indices are
always signed in scatter/gather instrs; they are already loaded
in 32-bit registers in the expansion.

Also adds test for the same. Fixes some asm test code to use
pcmpeqq for xmm comparisons; vcmpeqss does it only for the
low 32-bits.

Issue: #2985