### PR TITLE
i#2062: Increased severity of logs for JITted code

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1018,7 +1018,7 @@ private:
             // Once that support is in we can remove the bool return value and handle
             // the memrefs up here.
             impl()->log(
-                3, "Skipping ifetch for %u instrs not in a module (idx %d, +" PIFX ")\n",
+                1, "Skipping ifetch for %u instrs not in a module (idx %d, +" PIFX ")\n",
                 instr_count, in_entry->pc.modidx, in_entry->pc.modoffs);
             *handled = false;
             return "";


### PR DESCRIPTION
Currently offline traces do not support code that is not in a library
(e.g. JIT compiled code). Increased the log severity from 3 to 1 so that
it is more easily noticeable.

Issue: #2062 