### PR TITLE
i#2658: Core-File-L2 is in kernel32 on Win7

### DIFF
--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -1637,7 +1637,6 @@ map_api_set_dll(const char *name, privmod_t *dependent)
              str_case_prefix(name, "API-MS-Win-Core-Comm-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-Console-L2-1") ||
              str_case_prefix(name, "API-MS-Win-Core-CRT-L2-1") ||
-             str_case_prefix(name, "API-MS-Win-Core-File-L2-1") ||
              str_case_prefix(name, "API-MS-Win-Core-Job-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Core-Localization-L2-1") ||
              str_case_prefix(name, "API-MS-Win-Core-Localization-Private-L1-1") ||
@@ -1660,7 +1659,13 @@ map_api_set_dll(const char *name, privmod_t *dependent)
              str_case_prefix(name, "API-MS-Win-Security-Appcontainer-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Security-Base-Private-L1-1"))
         return "kernelbase.dll";
-    else if (str_case_prefix(name, "API-MS-Win-Core-Heap-Obsolete-L1-1"))
+    else if (str_case_prefix(name, "API-MS-Win-Core-File-L2-1")) {
+        /* i#2658: In kernel32 on win7 but kernelbase on win8+. */
+        if (get_os_version() <= WINDOWS_VERSION_7)
+            return "kernel32.dll";
+        else
+            return "kernelbase.dll";
+    } else if (str_case_prefix(name, "API-MS-Win-Core-Heap-Obsolete-L1-1"))
         return "kernel32.dll";
     else if (str_case_prefix(name, "API-MS-Win-Service-Private-L1-1") ||
              str_case_prefix(name, "API-MS-Win-Security-Audit-L1-1") ||


### PR DESCRIPTION
The API-MS-Win-Core-File-L2-1 pseudo-dll is provided by kernel32.dll
on Windows 7, instead of kernelbase.dll as it is on all later
versions.

Issue: #2658