### PR TITLE
i#5233: Fix arm-vs-thumb signal transitions

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -3665,7 +3665,6 @@ transfer_from_sig_handler_to_fcache_return(dcontext_t *dcontext, kernel_ucontext
         sc_interrupted->SC_XIP = official_xl8;
     }
     dcontext->next_tag = canonicalize_pc_target(dcontext, next_pc);
-    IF_ARM(dr_set_isa_mode(dcontext, get_pc_mode_from_cpsr(sc), NULL));
 
     /* Set our sigreturn context to point to fcache_return!
      * Then we'll go back through kernel, appear in fcache_return,
@@ -5713,10 +5712,6 @@ execute_handler_from_cache(dcontext_t *dcontext, int sig, sigframe_rt_t *our_fra
         sc->SC_LR = (reg_t)info->app_sigaction[sig]->restorer;
     else
         sc->SC_LR = (reg_t)dynamorio_sigreturn;
-#    ifndef AARCH64
-    /* We're going to our fcache_return gencode which uses DEFAULT_ISA_MODE */
-    set_pc_mode_in_cpsr(sc, DEFAULT_ISA_MODE);
-#    endif
 #endif
     /* Set our sigreturn context (NOT for the app: we already copied the
      * translated context to the app stack) to point to fcache_return!

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4916,6 +4916,22 @@ if (NOT ANDROID AND AARCHXX)
       code_api|linux.alarm
       code_api|linux.fork-sleep
       code_api|linux.signal_race
+      code_api|linux.signal0000
+      code_api|linux.signal0001
+      code_api|linux.signal0010
+      code_api|linux.signal0011
+      code_api|linux.signal0100
+      code_api|linux.signal0101
+      code_api|linux.signal0110
+      code_api|linux.signal0111
+      code_api|linux.signal1000
+      code_api|linux.signal1001
+      code_api|linux.signal1010
+      code_api|linux.signal1011
+      code_api|linux.signal1100
+      code_api|linux.signal1101
+      code_api|linux.signal1110
+      code_api|linux.signal1111
       code_api|linux.sigplain000
       code_api|linux.sigplain001
       code_api|linux.sigplain010


### PR DESCRIPTION
Removes a too-early-and-thus-incorrect call to set_pc_mode_in_cpsr()
in execute_handler_from_cache()
(transfer_from_sig_handler_to_fcache_return() does this for us at the
right time).

Removes an incorrect call to dr_set_isa_mode from the cpsr in
transfer_from_sig_handler_to_fcache_return(): we want to only set the
mode from the target, not the interruption point.

Works around QEMU bugs with signals 63 and 64 by using 62 instead in
the linux.signalNNNN tests.  This allows adding them to the list of
tests that work under QEMU.

Augments the linux.signalNNNN tests to vary whether the main code and
the signal handler are arm or thumb, helping to catch and test signal
transition issues.

Issue: #4719, #5233
Fixes #5233