### PR TITLE
i#5245: Handle exclusive loads into the zero register

### DIFF
--- a/api/docs/ldstex.dox
+++ b/api/docs/ldstex.dox
@@ -183,7 +183,7 @@ One complication is multiple different load-exclusive opcodes pairing with a sin
 - Storing the load opcode into its own TLS slot, but we do not know what to compare it with when we reach the store-exclusive, especially for cases like dr_prepopulate_cache().
 - Just always using the acquire version for the store-exclusive size.  Since the size must match, this is the only variation, and it should not affect correctness to add the barriers even when they are not needed.  This is the solution that we choose.
 
-There are other complexities, such as saving and comparing a second value in another TLS slot for pair opcodes.  32-bit ARM raises even more issues, such as requiring saving the flags, requiring consecutive registers for pair opcodes, and predication, all of which add further complexity.
+There are other complexities, such as saving and comparing a second value in another TLS slot for pair opcodes, and handling a load-exclusive that discards a result by targeting the zero register.  32-bit ARM raises even more issues, such as requiring saving the flags, requiring consecutive registers for pair opcodes, and predication, all of which add further complexity.
 
 This solution should also act on a `clrex` instruction, clearing the stored monitor values in order to avoid incorrect success in a load-exclusive, `clrex`, store-exclusive sequence.
 

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -3253,8 +3253,11 @@ mangle_exclusive_load(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         if (instr_writes_to_reg(in, value_reg, DR_QUERY_INCLUDE_ALL) ||
             (value2_reg != DR_REG_NULL &&
              instr_writes_to_reg(in, value2_reg, DR_QUERY_INCLUDE_ALL)) ||
-            instr_writes_to_reg(in, base_reg, DR_QUERY_INCLUDE_ALL))
+            instr_writes_to_reg(in, base_reg, DR_QUERY_INCLUDE_ALL)) {
+            LOG(THREAD, LOG_INTERP, 4,
+                "Value clobbered => not using same-block ldex-stex mangling\n");
             break;
+        }
     }
     /* If the ldex uses the stolen reg, we do not swap around it as we normally do,
      * since we have a bunch of TLS refs inside that would then have a non-standard
@@ -3272,8 +3275,8 @@ mangle_exclusive_load(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
              */
             stex_in_same_block = false;
         }
-        swap_reg = pick_scratch_reg(dcontext, instr, false, DR_REG_NULL, DR_REG_NULL,
-                                    DR_REG_NULL, &swap_slot, &swap_restore);
+        swap_reg = pick_scratch_reg(dcontext, instr, DR_REG_NULL, DR_REG_NULL,
+                                    DR_REG_NULL, false, &swap_slot, &swap_restore);
         insert_save_to_tls_if_necessary(dcontext, ilist, instr, swap_reg, swap_slot);
         if (instr_reads_from_reg(instr, dr_reg_stolen, DR_QUERY_DEFAULT)) {
             PRE(ilist, instr,
@@ -3286,6 +3289,39 @@ mangle_exclusive_load(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
             value2_reg = reg_to_pointer_sized(opnd_get_reg(instr_get_dst(instr, 1)));
         base_reg = opnd_get_base(instr_get_src(instr, 0));
     }
+    ushort xzr_slot = 0, xzr2_slot = 0;
+    bool xzr_restore = false, xzr2_restore = false;
+    reg_id_t xzr_repl = DR_REG_NULL, xzr2_repl = DR_REG_NULL;
+#ifdef AARCH64
+    /* If the ldex loads into the zero register, we need to instead get the real
+     * value so our compare at the stex will succeed (otherwise we will loop
+     * forever: i#5245).  For same-block we statically skip the compare.
+     */
+    if (!stex_in_same_block && value_reg == DR_REG_XZR) {
+        xzr_repl = pick_scratch_reg(dcontext, instr, swap_reg, DR_REG_NULL, DR_REG_NULL,
+                                    true, &xzr_slot, &xzr_restore);
+        insert_save_to_tls_if_necessary(dcontext, ilist, instr, xzr_repl, xzr_slot);
+        opnd_t value_op = instr_get_dst(instr, 0);
+        opnd_replace_reg_resize(&value_op, opnd_get_reg(value_op), xzr_repl);
+        instr_set_dst(instr, 0, value_op);
+        value_reg = xzr_repl;
+    }
+    if (!stex_in_same_block && value2_reg == DR_REG_XZR) {
+        if (value_reg == DR_REG_XZR) {
+            /* LDAXP with dest1==dest2 has undefined behavior, but we try to handle it.
+             * XXX: I tried to test this but it raises SIGILL on my hardware.
+             */
+            ASSERT_NOT_TESTED();
+        }
+        xzr2_repl = pick_scratch_reg(dcontext, instr, swap_reg, xzr_repl, DR_REG_NULL,
+                                     true, &xzr2_slot, &xzr2_restore);
+        insert_save_to_tls_if_necessary(dcontext, ilist, instr, xzr2_repl, xzr2_slot);
+        opnd_t value2_op = instr_get_dst(instr, 1);
+        opnd_replace_reg_resize(&value2_op, opnd_get_reg(value2_op), xzr2_repl);
+        instr_set_dst(instr, 1, value2_op);
+        value2_reg = xzr2_repl;
+    }
+#endif
     instr_t *where = instr_get_next(instr);
     if (stex_in_same_block) {
         /* Insert a label so subsequent stex mangling knows the ldex was here. */
@@ -3302,8 +3338,8 @@ mangle_exclusive_load(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         /* We need a scratch register. */
         ushort slot;
         bool should_restore;
-        reg_id_t scratch = pick_scratch_reg(dcontext, instr, swap_reg, DR_REG_NULL,
-                                            DR_REG_NULL, true, &slot, &should_restore);
+        reg_id_t scratch = pick_scratch_reg(dcontext, instr, swap_reg, xzr_repl,
+                                            xzr2_repl, true, &slot, &should_restore);
         insert_save_to_tls_if_necessary(dcontext, ilist, where, scratch, slot);
         /* Write the address and value to TLS. */
         /* Pair store requires consecutive register numbers for 32-bit. */
@@ -3391,6 +3427,10 @@ mangle_exclusive_load(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
                 instr_create_restore_from_tls(dcontext, swap_reg, swap_slot));
         }
     }
+    if (xzr_restore)
+        PRE(ilist, where, instr_create_restore_from_tls(dcontext, xzr_repl, xzr_slot));
+    if (xzr2_restore)
+        PRE(ilist, where, instr_create_restore_from_tls(dcontext, xzr2_repl, xzr2_slot));
     instrlist_remove(ilist, instr);
     instr_destroy(dcontext, instr);
     return next_instr;
@@ -3566,10 +3606,16 @@ mangle_exclusive_store(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         create_ldax_from_stex(dcontext, instr, &reg_new_ld_val, reg_new_ld_val2,
                               !is_pair));
     reg_new_ld_val = reg_to_pointer_sized(reg_new_ld_val);
-    insert_compare_and_jump_not_equal(dcontext, ilist, instr, op_res,
-                                      opnd_create_reg(reg_new_ld_val),
-                                      opnd_create_reg(reg_orig_ld_val), no_match);
-    if (is_pair) {
+    /* Skip the value comparison if the load discarded via XZR.
+     * This is not an optimization, but required to avoid an infinite loop (i#5245).
+     * (For !ldex_in_same_block, we handle this when mangling the load.)
+     */
+    if (IF_AARCH64_ELSE(!ldex_in_same_block || reg_orig_ld_val != DR_REG_XZR, true)) {
+        insert_compare_and_jump_not_equal(dcontext, ilist, instr, op_res,
+                                          opnd_create_reg(reg_new_ld_val),
+                                          opnd_create_reg(reg_orig_ld_val), no_match);
+    }
+    if (is_pair IF_AARCH64(&&(!ldex_in_same_block || reg_orig_ld_val2 != DR_REG_XZR))) {
         insert_compare_and_jump_not_equal(dcontext, ilist, instr, op_res,
                                           opnd_create_reg(reg_new_ld_val2),
                                           opnd_create_reg(reg_orig_ld_val2), no_match);

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -3277,7 +3277,8 @@ mangle_exclusive_load(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         }
         swap_reg = pick_scratch_reg(dcontext, instr, DR_REG_NULL, DR_REG_NULL,
                                     DR_REG_NULL, false, &swap_slot, &swap_restore);
-        insert_save_to_tls_if_necessary(dcontext, ilist, instr, swap_reg, swap_slot);
+        if (swap_restore)
+            insert_save_to_tls_if_necessary(dcontext, ilist, instr, swap_reg, swap_slot);
         if (instr_reads_from_reg(instr, dr_reg_stolen, DR_QUERY_DEFAULT)) {
             PRE(ilist, instr,
                 instr_create_restore_from_tls(dcontext, swap_reg, TLS_REG_STOLEN_SLOT));
@@ -3300,7 +3301,8 @@ mangle_exclusive_load(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     if (!stex_in_same_block && value_reg == DR_REG_XZR) {
         xzr_repl = pick_scratch_reg(dcontext, instr, swap_reg, DR_REG_NULL, DR_REG_NULL,
                                     true, &xzr_slot, &xzr_restore);
-        insert_save_to_tls_if_necessary(dcontext, ilist, instr, xzr_repl, xzr_slot);
+        if (xzr_restore)
+            insert_save_to_tls_if_necessary(dcontext, ilist, instr, xzr_repl, xzr_slot);
         opnd_t value_op = instr_get_dst(instr, 0);
         opnd_replace_reg_resize(&value_op, opnd_get_reg(value_op), xzr_repl);
         instr_set_dst(instr, 0, value_op);
@@ -3315,7 +3317,8 @@ mangle_exclusive_load(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         }
         xzr2_repl = pick_scratch_reg(dcontext, instr, swap_reg, xzr_repl, DR_REG_NULL,
                                      true, &xzr2_slot, &xzr2_restore);
-        insert_save_to_tls_if_necessary(dcontext, ilist, instr, xzr2_repl, xzr2_slot);
+        if (xzr2_restore)
+            insert_save_to_tls_if_necessary(dcontext, ilist, instr, xzr2_repl, xzr2_slot);
         opnd_t value2_op = instr_get_dst(instr, 1);
         opnd_replace_reg_resize(&value2_op, opnd_get_reg(value2_op), xzr2_repl);
         instr_set_dst(instr, 1, value2_op);
@@ -3340,7 +3343,8 @@ mangle_exclusive_load(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         bool should_restore;
         reg_id_t scratch = pick_scratch_reg(dcontext, instr, swap_reg, xzr_repl,
                                             xzr2_repl, true, &slot, &should_restore);
-        insert_save_to_tls_if_necessary(dcontext, ilist, where, scratch, slot);
+        if (should_restore)
+            insert_save_to_tls_if_necessary(dcontext, ilist, where, scratch, slot);
         /* Write the address and value to TLS. */
         /* Pair store requires consecutive register numbers for 32-bit. */
         bool use_pair = IF_AARCH64_ELSE(base_reg != DR_REG_SP, false);
@@ -3495,7 +3499,8 @@ mangle_exclusive_store(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
          */
         swap_reg = pick_scratch_reg(dcontext, instr, reg_orig_ld_val, reg_orig_ld_val2,
                                     DR_REG_NULL, false, &swap_slot, &swap_restore);
-        insert_save_to_tls_if_necessary(dcontext, ilist, instr, swap_reg, swap_slot);
+        if (swap_restore)
+            insert_save_to_tls_if_necessary(dcontext, ilist, instr, swap_reg, swap_slot);
         if (instr_reads_from_reg(instr, dr_reg_stolen, DR_QUERY_DEFAULT)) {
             PRE(ilist, instr,
                 instr_create_restore_from_tls(dcontext, swap_reg, TLS_REG_STOLEN_SLOT));
@@ -3532,7 +3537,8 @@ mangle_exclusive_store(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
             scratch3 = pick_scratch_reg(dcontext, instr, swap_reg, reg_orig_ld_val,
                                         reg_orig_ld_val2,
                                         /*dead_reg_ok=*/false, &slot3, &should_restore3);
-            insert_save_to_tls_if_necessary(dcontext, ilist, instr, scratch3, slot3);
+            if (should_restore3)
+                insert_save_to_tls_if_necessary(dcontext, ilist, instr, scratch3, slot3);
         }
     } else {
         ASSERT(reg_orig_ld_val == DR_REG_NULL &&
@@ -3540,7 +3546,8 @@ mangle_exclusive_store(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         /* We pass false to avoid the status reg, which we ourselves use. */
         scratch = pick_scratch_reg(dcontext, instr, swap_reg, DR_REG_NULL, DR_REG_NULL,
                                    false, &slot, &should_restore);
-        insert_save_to_tls_if_necessary(dcontext, ilist, instr, scratch, slot);
+        if (should_restore)
+            insert_save_to_tls_if_necessary(dcontext, ilist, instr, scratch, slot);
 #ifdef ARM
         if (!is_cbnz_available(dcontext, reg_res)) {
             /* We have no CBNZ so we need to preserve the flags. */
@@ -3554,8 +3561,10 @@ mangle_exclusive_store(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
                                         /*dead_reg_ok=*/false, &slot2, &should_restore2);
             scratch3 = pick_scratch_reg(dcontext, instr, swap_reg, scratch, scratch2,
                                         /*dead_reg_ok=*/false, &slot3, &should_restore3);
-            insert_save_to_tls_if_necessary(dcontext, ilist, instr, scratch2, slot2);
-            insert_save_to_tls_if_necessary(dcontext, ilist, instr, scratch3, slot3);
+            if (should_restore2)
+                insert_save_to_tls_if_necessary(dcontext, ilist, instr, scratch2, slot2);
+            if (should_restore3)
+                insert_save_to_tls_if_necessary(dcontext, ilist, instr, scratch3, slot3);
         }
         /* Compare address, arranging op_res to show failure on mismatch (though
          * now that we have a stex after no_match for fault fidelity it will set
@@ -3704,7 +3713,8 @@ mangle_exclusive_monitor_op(dcontext_t *dcontext, instrlist_t *ilist, instr_t *i
         bool should_restore;
         reg_id_t scratch = pick_scratch_reg(dcontext, instr, DR_REG_NULL, DR_REG_NULL,
                                             DR_REG_NULL, true, &slot, &should_restore);
-        insert_save_to_tls_if_necessary(dcontext, ilist, instr, scratch, slot);
+        if (should_restore)
+            insert_save_to_tls_if_necessary(dcontext, ilist, instr, scratch, slot);
         PRE(ilist, instr,
             XINST_CREATE_load_int(dcontext, opnd_create_reg(scratch),
                                   OPND_CREATE_INT(0)));

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -4479,8 +4479,11 @@ mangle_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
     }
 #endif /* X86 */
 
-    DOLOG(4, LOG_INTERP, {
-        LOG(THREAD, LOG_INTERP, 4, "bb ilist before mangling:\n");
+    /* We make "before mangling" level 5 b/c there's not much there (just final jmp)
+     * beyond "after instrumentation".
+     */
+    DOLOG(5, LOG_INTERP, {
+        LOG(THREAD, LOG_INTERP, 5, "bb ilist before mangling:\n");
         instrlist_disassemble(dcontext, bb->start_pc, bb->ilist, THREAD);
     });
     d_r_mangle(dcontext, bb->ilist, &bb->flags, true, bb->record_translation);

--- a/suite/tests/client-interface/ldstex.c
+++ b/suite/tests/client-interface/ldstex.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -110,6 +110,10 @@ typedef struct {
     int counter1, counter2;
 } __attribute__((__aligned__(IF_ARM_ELSE(8, 16)))) two_counters_t;
 
+typedef struct {
+    long counter1, counter2;
+} __attribute__((__aligned__(IF_ARM_ELSE(8, 16)))) two_counters64_t;
+
 int
 ldstex_inc_pair(two_counters_t *counters);
 int
@@ -118,6 +122,13 @@ int
 ldstex_inc_byte(char *counter);
 int
 ldstex_inc_shapes(int *counter);
+
+#    ifdef AARCH64
+int
+ldstex_inc32_with_xzr(two_counters_t *counters);
+int
+ldstex_inc64_with_xzr(two_counters64_t *counters);
+#    endif
 
 static void
 test_shapes(void)
@@ -140,6 +151,18 @@ test_shapes(void)
     added = ldstex_inc_shapes(&ctr);
     if (ctr != 42 + added)
         print("Error in ldstex_inc_shapes: %d\n", ctr);
+
+#    ifdef AARCH64
+    my_var.counter2 = 117;
+    added = ldstex_inc32_with_xzr(&my_var);
+    /* We zero both and only the 2nd's add sticks. */
+    if (my_var.counter2 != added)
+        print("Error in ldstex_inc32_with_xzr: %d\n", my_var.counter2);
+    two_counters64_t my_var64 = { 42, 117 };
+    added = ldstex_inc64_with_xzr(&my_var64);
+    if (my_var64.counter2 != added)
+        print("Error in ldstex_inc64_with_xzr: %ld\n", my_var64.counter2);
+#    endif
 }
 
 /***************************************************************************
@@ -221,11 +244,26 @@ test_clrex(void)
 int
 main(int argc, const char *argv[])
 {
-    test_atomic_incdec();
-    test_stolen_reg();
-    test_shapes();
-    test_faults();
-    test_clrex();
+    /* Run twice: on the first run, the client will insert clean calls, which will test
+     * that we're avoiding infinite loops (from all the inserted memory operations) as
+     * well as often thwarting same-block optimizations due to register writes in the
+     * clean calls.  So we run a second time where the client avoids inserting anything
+     * (the client flushes in between to obtain new blocks) to test the same-block
+     * optimization path.
+     */
+    for (int i = 0; i < 2; i++) {
+        test_atomic_incdec();
+        test_stolen_reg();
+        test_shapes();
+        test_faults();
+        test_clrex();
+        /* Notify client to flush and change modes. */
+        NOP;
+        NOP;
+        NOP;
+        NOP;
+        count = 0; /* Reset for test_faults(). */
+    }
     print("Test finished\n");
     return 0;
 }
@@ -842,6 +880,64 @@ GLOBAL_LABEL(FUNCNAME:)
 #endif
         END_FUNC(FUNCNAME)
 #undef FUNCNAME
+
+#ifdef AARCH64
+/* int ldstex_inc32_with_xzr(two_counters_t *counter)
+ */
+#define FUNCNAME ldstex_inc32_with_xzr
+        DECLARE_FUNC_SEH(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+      1:
+        ldaxr    wzr, [x0]
+        stlxr    w3, wzr, [x0]
+        cbnz     w3, 1b
+        str      x0, [x0] /* Ensure we'd loop forever w/o i#5245 on next test. */
+      2:
+        ldaxrh   wzr, [x0]
+        stlxrh   w3, wzr, [x0]
+        cbnz     w3, 2b
+        str      x0, [x0] /* Ensure we'd loop forever w/o i#5245 on next test. */
+      3:
+        ldaxrb   wzr, [x0]
+        stlxrb   w3, wzr, [x0]
+        cbnz     w3, 3b
+        str      x0, [x0] /* Ensure we'd loop forever w/o i#5245 on next test. */
+        /* Test each LDAXP dest being xzr (both raises SIGILL). */
+      4:
+        ldaxp    w1, wzr, [x0]
+        add      w2, w1, #0x1
+        stlxp    w3, w2, wzr, [x0]
+        cbnz     w3, 4b
+      5:
+        ldaxp    wzr, w1, [x0]
+        add      w2, w1, #0x1
+        stlxp    w3, wzr, w2, [x0]
+        cbnz     w3, 5b
+        mov      w0, #1
+        ret
+        END_FUNC(FUNCNAME)
+#undef FUNCNAME
+/* int ldstex_inc64_with_xzr(two_counters64_t *counter)
+ */
+#define FUNCNAME ldstex_inc64_with_xzr
+        DECLARE_FUNC_SEH(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        /* Test each LDAXP dest being xzr (both raises SIGILL). */
+      1:
+        ldaxp    x1, xzr, [x0]
+        add      x2, x1, #0x1
+        stlxp    w3, x2, xzr, [x0]
+        cbnz     w3, 1b
+      2:
+        ldaxp    xzr, x1, [x0]
+        add      x2, x1, #0x1
+        stlxp    w3, xzr, x2, [x0]
+        cbnz     w3, 2b
+        mov      w0, #1
+        ret
+        END_FUNC(FUNCNAME)
+#undef FUNCNAME
+#endif
 
 END_FILE
 

--- a/suite/tests/client-interface/ldstex.c
+++ b/suite/tests/client-interface/ldstex.c
@@ -156,12 +156,16 @@ test_shapes(void)
     my_var.counter2 = 117;
     added = ldstex_inc32_with_xzr(&my_var);
     /* We zero both and only the 2nd's add sticks. */
-    if (my_var.counter2 != added)
-        print("Error in ldstex_inc32_with_xzr: %d\n", my_var.counter2);
+    if (my_var.counter1 != 0 || my_var.counter2 != added) {
+        print("Error in ldstex_inc32_with_xzr: %d %d\n", my_var.counter1,
+              my_var.counter2);
+    }
     two_counters64_t my_var64 = { 42, 117 };
     added = ldstex_inc64_with_xzr(&my_var64);
-    if (my_var64.counter2 != added)
-        print("Error in ldstex_inc64_with_xzr: %ld\n", my_var64.counter2);
+    if (my_var64.counter1 != 0 || my_var64.counter2 != added) {
+        print("Error in ldstex_inc64_with_xzr: %ld %ld\n", my_var64.counter1,
+              my_var64.counter2);
+    }
 #    endif
 }
 
@@ -887,6 +891,10 @@ GLOBAL_LABEL(FUNCNAME:)
 #define FUNCNAME ldstex_inc32_with_xzr
         DECLARE_FUNC_SEH(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
+        /* The clean call version thwarts the single-block optimized mangling,
+         * so we do not need to make separate-block versions of these as we
+         * have tests of both the fastpath and slowpath.
+         */
       1:
         ldaxr    wzr, [x0]
         stlxr    w3, wzr, [x0]

--- a/suite/tests/client-interface/ldstex.expect
+++ b/suite/tests/client-interface/ldstex.expect
@@ -3,4 +3,9 @@ Got signal 11; count 1
 Got signal 11; count 2
 Got signal 11; count 3
 Got signal 4; count 4
+Got signal 11; count 0
+Got signal 11; count 1
+Got signal 11; count 2
+Got signal 11; count 3
+Got signal 4; count 4
 Test finished


### PR DESCRIPTION
Adds handling for AArch64 exclusive loads that discard a value by
targeting the zero register.  Without this fix, we loop forever in the
store since we load the real value and compare it to the zero we
recorded.  Our fix is to replace the zero register with a scratch
register so that we record the actual value at load time.  For the
same-block optimized case, we instead simply skip the value comparison
check at the store.

Adds a test of every size and destination zero variant.  This test
spins (at multiple points) without the fix.

Fixes #5245