### PR TITLE
i#2985 scatter-gather: Fix spill/restore of scratch xmm reg.

### DIFF
--- a/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
@@ -3,8 +3,8 @@ Hello world!
 ---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
-          87 total \(fetched\) instructions
-          87 total unique \(fetched\) instructions
+          96 total \(fetched\) instructions
+          96 total unique \(fetched\) instructions
            0 total non-fetched instructions
            0 total prefetches
            6 total data loads
@@ -20,8 +20,8 @@ Total counts:
      .* total function return value markers
      .* total other markers
 Thread .* counts:
-          87 \(fetched\) instructions
-          87 unique \(fetched\) instructions
+          96 \(fetched\) instructions
+          96 unique \(fetched\) instructions
            0 non-fetched instructions
            0 prefetches
            6 data loads

--- a/clients/drcachesim/tests/allasm_scattergather.asm
+++ b/clients/drcachesim/tests/allasm_scattergather.asm
@@ -31,10 +31,12 @@
  */
 
 /* This is a statically-linked app.
- * XXX i#2985, i#3844: We intentionally use high-numbered xmm registers here,
- * to avoid conflict with the xmm spill reg selection logic which is very naive
- * as of today. Maybe replace with lower-numbered xmm registers when drreg
- * support for xmm spills is complete.
+ * XXX i#3107: Pure-asm apps like this are difficult to maintain; things like
+ * setting up zmm or comparing mm regs are more easily done in a C+asm app. We
+ * need this to be pure-asm so that we can verify exact instruction, load and
+ * store counts for the emulated scatter/gather sequence. With support for
+ * #3107, we can use annotations to mark app phases and compute those counts
+ * for only the intended parts in the C+asm app.
  */
 .text
 .globl _start

--- a/clients/drcachesim/tests/allasm_scattergather.asm
+++ b/clients/drcachesim/tests/allasm_scattergather.asm
@@ -44,20 +44,52 @@ _start:
         // Align stack pointer to cache line.
         and      rsp, -16
 
-        // Load data into xmm0.
+        // Load data into ymm0/zmm0.
         // drx_expand_scatter_gather picks as scratch the lowest-numbered
         // xmm reg not being used by the scatter/gather instr being expanded.
-        // This will be xmm0 in this app. We want to test that xmm0 is indeed
-        // restored to its app value after the expansion.
-        mov      eax, 0x0123
-        vpinsrd  xmm0, xmm0, eax, 0x00
-        mov      eax, 0x4567
-        vpinsrd  xmm0, xmm0, eax, 0x01
-        mov      eax, 0x89ab
-        vpinsrd  xmm0, xmm0, eax, 0x02
-        mov      eax, 0xcdef
-        vpinsrd  xmm0, xmm0, eax, 0x03
-        vmovdqu  save_xmm0, xmm0
+        // This will be xmm0 in this app. We want to test that ymm0/zmm0 is
+        // indeed restored to its app value after the expansion.
+#ifdef __AVX512F__
+        mov      rax, 0x0123456701234567
+        vpinsrq  xmm3, xmm3, rax, 0x00
+        mov      rax, 0x89abcdef89abcdef
+        vpinsrq  xmm3, xmm3, rax, 0x01
+        vinserti64x2 zmm0, zmm0, xmm3, 0
+
+        mov      rax, 0x02468ace02468ace
+        vpinsrq  xmm3, xmm3, rax, 0x00
+        mov      rax, 0x13579bdf13579bdf
+        vpinsrq  xmm3, xmm3, rax, 0x01
+        vinserti64x2 zmm0, zmm0, xmm3, 1
+
+        mov      rax, 0x1111222211112222
+        vpinsrq  xmm3, xmm3, rax, 0x00
+        mov      rax, 0x3333444433334444
+        vpinsrq  xmm3, xmm3, rax, 0x01
+        vinserti64x2 zmm0, zmm0, xmm3, 2
+
+        mov      rax, 0x5555666655556666
+        vpinsrq  xmm3, xmm3, rax, 0x00
+        mov      rax, 0x7777888877778888
+        vpinsrq  xmm3, xmm3, rax, 0x01
+        vinserti64x2 zmm0, zmm0, xmm3, 3
+
+        vmovups  save_mm0, zmm0
+#else
+        mov      rax, 0x0123456701234567
+        vpinsrq  xmm3, xmm3, rax, 0x00
+        mov      rax, 0x89abcdef89abcdef
+        vpinsrq  xmm3, xmm3, rax, 0x01
+        vinserti128 ymm0, ymm0, xmm3, 0
+
+        mov      rax, 0x02468ace02468ace
+        vpinsrq  xmm3, xmm3, rax, 0x00
+        mov      rax, 0x13579bdf13579bdf
+        vpinsrq  xmm3, xmm3, rax, 0x01
+        vinserti128 ymm0, ymm0, xmm3, 1
+
+        vmovups  save_mm0, ymm0
+#endif
 
         // Load data into xmm10.
         // We embed data in instrs to avoid adding extra loads.
@@ -115,17 +147,33 @@ _start:
         cmp      eax, 0xffffffff
         jne      incorrect
 
-
         // Test 2: Verify that the scratch reg (here, xmm0) was restored to its
         // original app value.
-        vmovdqu  xmm1, save_xmm0
-        pcmpeqq  xmm1, xmm0
+#ifdef __AVX512F__
+        vmovups  zmm3, save_mm0
+        vpcmpeqq k1, zmm0, zmm3
+        kmovw    ebx, k1
+        cmp      ebx, 0xff
+        jne      incorrect_scratch
+#else
+        vmovups  ymm3, save_mm0
+        vpcmpeqq ymm2, ymm0, ymm3
+        /* Verify equality for each of the 4 qwords individually. */
+        vextracti128 xmm1, ymm2, 0
         vpextrd  eax, xmm1, 0
         cmp      eax, 0xffffffff
         jne      incorrect_scratch
         vpextrd  eax, xmm1, 2
         cmp      eax, 0xffffffff
         jne      incorrect_scratch
+        vextracti128 xmm1, ymm2, 1
+        vpextrd  eax, xmm1, 0
+        cmp      eax, 0xffffffff
+        jne      incorrect_scratch
+        vpextrd  eax, xmm1, 2
+        cmp      eax, 0xffffffff
+        jne      incorrect_scratch
+#endif
 
         // Test 3: Verify that negative indices are sign extended.
         mov      eax, -0x01
@@ -140,7 +188,6 @@ _start:
         // Emulate scatter instr if not available.
         mov      dword ptr [arr_neg], 0xdead
         // Match instr count in the #if block above.
-        nop
         nop
 #endif
         mov      ebx, dword ptr [arr_neg]
@@ -210,5 +257,5 @@ arr_neg:
         .zero    4
 arr:
         .zero    16
-save_xmm0:
-        .zero    16
+save_mm0:
+        .zero    64

--- a/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
@@ -2,8 +2,8 @@ Correct
 Hello world!
 Basic counts tool results:
 Total counts:
-          87 total \(fetched\) instructions
-          87 total unique \(fetched\) instructions
+          96 total \(fetched\) instructions
+          96 total unique \(fetched\) instructions
            0 total non-fetched instructions
            0 total prefetches
            6 total data loads
@@ -19,8 +19,8 @@ Total counts:
      .* total function return value markers
      .* total other markers
 Thread .* counts:
-          87 \(fetched\) instructions
-          87 unique \(fetched\) instructions
+          96 \(fetched\) instructions
+          96 unique \(fetched\) instructions
            0 non-fetched instructions
            0 prefetches
            6 data loads

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2482,6 +2482,7 @@ drx_expand_scatter_gather(void *drcontext, instrlist_t *bb, OUT bool *expanded)
             instr_create_1dst_2src(drcontext, mov_scratch_mm_opcode,
                                    opnd_create_base_disp(scratch_reg0, DR_REG_NULL, 0, 0,
                                                          mov_scratch_mm_opnd_sz),
+                                   /* k0 denotes unmasked operation. */
                                    opnd_create_reg(DR_REG_K0),
                                    opnd_create_reg(scratch_mm)));
     } else {

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -36,6 +36,7 @@
 #include "drx.h"
 #include "hashtable.h"
 #include "../ext_utils.h"
+#include <stddef.h> /* for offsetof */
 #include <string.h>
 
 /* We use drmgr but only internally.  A user of drx will end up loading in
@@ -66,7 +67,7 @@
 
 #define XMM_REG_SIZE 16
 #define YMM_REG_SIZE 32
-#define XMM_ALIGNMENT 32
+#define ZMM_REG_SIZE 64
 
 #define MAX(x, y) ((x) >= (y) ? (x) : (y))
 
@@ -103,7 +104,7 @@ static bool soft_kills_enabled;
 #ifdef PLATFORM_SUPPORTS_SCATTER_GATHER
 static int tls_idx;
 typedef struct _per_thread_t {
-    void *scratch_xmm_spill_slot;
+    void *scratch_mm_spill_slot;
 } per_thread_t;
 
 static per_thread_t *
@@ -140,6 +141,10 @@ drx_event_restore_state(void *drcontext, bool restore_memory,
                         dr_restore_state_info_t *info);
 #endif
 
+/***************************************************************************
+ * INIT
+ */
+
 #ifdef PLATFORM_SUPPORTS_SCATTER_GATHER
 static per_thread_t *
 get_tls_data(void *drcontext)
@@ -150,19 +155,36 @@ get_tls_data(void *drcontext)
         return &init_pt;
     return pt;
 }
-#endif
 
-/***************************************************************************
- * INIT
- */
+static void
+get_mov_scratch_mm_opcode_and_size(uint *opcode_out, opnd_size_t *opnd_size_out)
+{
+    uint opcode;
+    opnd_size_t opnd_size;
+    /* We use same opcodes as used by fcache enter/return. */
+    if (proc_avx512_enabled()) {
+        /* ZMM enabled. */
+        opcode = OP_vmovups;
+        opnd_size = OPSZ_64;
+    } else {
+        /* YMM enabled. */
+        ASSERT(proc_avx_enabled(), "Scatter/gather instrs not available");
+        opcode = OP_vmovdqu;
+        opnd_size = OPSZ_32;
+    }
+    if (opcode_out != NULL)
+        *opcode_out = opcode;
+    if (opnd_size_out != NULL)
+        *opnd_size_out = opnd_size;
+}
 
-#ifdef PLATFORM_SUPPORTS_SCATTER_GATHER
 static void
 drx_thread_init(void *drcontext)
 {
     per_thread_t *pt = (per_thread_t *)dr_thread_alloc(drcontext, sizeof(*pt));
-    pt->scratch_xmm_spill_slot =
-        dr_thread_alloc(drcontext, XMM_REG_SIZE + (XMM_ALIGNMENT - 1));
+    opnd_size_t mm_opsz;
+    get_mov_scratch_mm_opcode_and_size(NULL, &mm_opsz);
+    pt->scratch_mm_spill_slot = dr_thread_alloc(drcontext, opnd_size_in_bytes(mm_opsz));
     drmgr_set_tls_field(drcontext, tls_idx, (void *)pt);
 }
 
@@ -170,8 +192,9 @@ static void
 drx_thread_exit(void *drcontext)
 {
     per_thread_t *pt = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
-    dr_thread_free(drcontext, pt->scratch_xmm_spill_slot,
-                   XMM_REG_SIZE + (XMM_ALIGNMENT - 1));
+    opnd_size_t mm_opsz;
+    get_mov_scratch_mm_opcode_and_size(NULL, &mm_opsz);
+    dr_thread_free(drcontext, pt->scratch_mm_spill_slot, opnd_size_in_bytes(mm_opsz));
     dr_thread_free(drcontext, pt, sizeof(*pt));
 }
 #endif
@@ -220,11 +243,11 @@ drx_init(void)
     if (!drmgr_register_restore_state_ex_event_ex(drx_event_restore_state,
                                                   &fault_priority))
         return false;
-    if (!drmgr_register_thread_init_event(drx_thread_init) ||
-        !drmgr_register_thread_exit_event(drx_thread_exit))
-        return false;
     tls_idx = drmgr_register_tls_field();
     if (tls_idx == -1)
+        return false;
+    if (!drmgr_register_thread_init_event(drx_thread_init) ||
+        !drmgr_register_thread_exit_event(drx_thread_exit))
         return false;
 #endif
 
@@ -2128,14 +2151,6 @@ expand_gather_load_scalar_value(void *drcontext, instrlist_t *bb, instr_t *sg_in
     }
     return true;
 }
-
-uint
-mov_xmm_aligned32_opcode()
-{
-    ASSERT(proc_avx_enabled(), "running on unsupported processor");
-    return OP_vmovdqa;
-}
-
 #endif
 
 /*****************************************************************************************
@@ -2439,22 +2454,45 @@ drx_expand_scatter_gather(void *drcontext, instrlist_t *bb, OUT bool *expanded)
             scratch_xmm != reg_resize_to_opsz(sg_info.gather_dst_reg, OPSZ_16))
             break;
     }
-    /* Spill the scratch xmm.
-     * TODO i#3844: drreg does not support spilling xmm regs yet, so we do it ourselves.
+    /* Spill the scratch mm reg. We spill the largest reg corresponding to scratch_xmm
+     * support by the system. This is required because writing a part of a ymm/zmm reg
+     * zeroes the remaining automatically. So we need to save the complete ymm/zmm reg
+     * and not just the lower xmm bits.
+     * TODO i#3844: drreg does not support spilling mm regs yet, so we do it ourselves.
      * When that support is available, replace the following with the required drreg API
      * calls.
      */
-    per_thread_t *pt = get_tls_data(drcontext);
-    instrlist_insert_mov_immed_ptrsz(
-        drcontext, ALIGN_FORWARD(pt->scratch_xmm_spill_slot, XMM_ALIGNMENT),
-        opnd_create_reg(scratch_reg0), bb, sg_instr, NULL, NULL);
-    uint mov_xmm_opcode = mov_xmm_aligned32_opcode();
+    uint mov_scratch_mm_opcode;
+    opnd_size_t mov_scratch_mm_opnd_sz;
+    reg_id_t scratch_mm;
+    get_mov_scratch_mm_opcode_and_size(&mov_scratch_mm_opcode, &mov_scratch_mm_opnd_sz);
+    scratch_mm = reg_resize_to_opsz(scratch_xmm, mov_scratch_mm_opnd_sz);
+
+    drmgr_insert_read_tls_field(drcontext, tls_idx, bb, sg_instr, scratch_reg0);
     instrlist_meta_preinsert(
         bb, sg_instr,
-        instr_create_1dst_1src(
-            drcontext, mov_xmm_opcode,
-            opnd_create_base_disp(scratch_reg0, DR_REG_NULL, 0, 0, OPSZ_16),
-            opnd_create_reg(scratch_xmm)));
+        INSTR_CREATE_mov_ld(
+            drcontext, opnd_create_reg(scratch_reg0),
+            OPND_CREATE_MEMPTR(scratch_reg0,
+                               offsetof(per_thread_t, scratch_mm_spill_slot))));
+
+    if (mov_scratch_mm_opnd_sz == OPSZ_64) {
+        instrlist_meta_preinsert(
+            bb, sg_instr,
+            instr_create_1dst_2src(drcontext, mov_scratch_mm_opcode,
+                                   opnd_create_base_disp(scratch_reg0, DR_REG_NULL, 0, 0,
+                                                         mov_scratch_mm_opnd_sz),
+                                   opnd_create_reg(DR_REG_K0),
+                                   opnd_create_reg(scratch_mm)));
+    } else {
+        instrlist_meta_preinsert(
+            bb, sg_instr,
+            instr_create_1dst_1src(drcontext, mov_scratch_mm_opcode,
+                                   opnd_create_base_disp(scratch_reg0, DR_REG_NULL, 0, 0,
+                                                         mov_scratch_mm_opnd_sz),
+                                   opnd_create_reg(scratch_mm)));
+    }
+
     emulated_instr_t emulated_instr;
     emulated_instr.size = sizeof(emulated_instr);
     emulated_instr.pc = instr_get_app_pc(sg_instr);
@@ -2567,14 +2605,29 @@ drx_expand_scatter_gather(void *drcontext, instrlist_t *bb, OUT bool *expanded)
                          orig_app_pc));
     }
     /* Restore the scratch xmm. */
-    instrlist_insert_mov_immed_ptrsz(
-        drcontext, ALIGN_FORWARD(pt->scratch_xmm_spill_slot, XMM_ALIGNMENT),
-        opnd_create_reg(scratch_reg0), bb, sg_instr, NULL, NULL);
+    drmgr_insert_read_tls_field(drcontext, tls_idx, bb, sg_instr, scratch_reg0);
     instrlist_meta_preinsert(
         bb, sg_instr,
-        instr_create_1dst_1src(
-            drcontext, mov_xmm_opcode, opnd_create_reg(scratch_xmm),
-            opnd_create_base_disp(scratch_reg0, DR_REG_NULL, 0, 0, OPSZ_16)));
+        INSTR_CREATE_mov_ld(
+            drcontext, opnd_create_reg(scratch_reg0),
+            OPND_CREATE_MEMPTR(scratch_reg0,
+                               offsetof(per_thread_t, scratch_mm_spill_slot))));
+    if (mov_scratch_mm_opnd_sz == OPSZ_64) {
+        instrlist_meta_preinsert(
+            bb, sg_instr,
+            instr_create_1dst_2src(drcontext, mov_scratch_mm_opcode,
+                                   opnd_create_reg(scratch_mm),
+                                   opnd_create_reg(DR_REG_K0),
+                                   opnd_create_base_disp(scratch_reg0, DR_REG_NULL, 0, 0,
+                                                         mov_scratch_mm_opnd_sz)));
+    } else {
+        instrlist_meta_preinsert(
+            bb, sg_instr,
+            instr_create_1dst_1src(drcontext, mov_scratch_mm_opcode,
+                                   opnd_create_reg(scratch_mm),
+                                   opnd_create_base_disp(scratch_reg0, DR_REG_NULL, 0, 0,
+                                                         mov_scratch_mm_opnd_sz)));
+    }
     ASSERT(scratch_reg0 != scratch_reg1,
            "Internal error: scratch registers must be different");
     if (drreg_unreserve_register(drcontext, bb, sg_instr, scratch_reg0) !=
@@ -2650,32 +2703,30 @@ drx_expand_scatter_gather_exit:
  * AVX-512 gather sequence detection example:
  *
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0
- *         mov           <xmm_spill_addr> -> %ecx
+ *         vmovups       {%k0} %zmm2 -> (%rcx)[64byte]
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1
- *         vmovdqa       %xmm2 -> (%ecx)[16byte]
- *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2
  *         vextracti32x4 {%k0} $0x00 %zmm1 -> %xmm2
- *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3
- *         vpextrd       %xmm2 $0x00 -> %ecx
- *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4
- *         mov           (%rax,%rcx,4)[4byte] -> %ecx
- *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5
- * (a)     vextracti32x4 {%k0} $0x00 %zmm0 -> %xmm2
- *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6
- * (a)     vpinsrd       %xmm2 %ecx $0x00 -> %xmm2
- *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7
- * (a)     vinserti32x4  {%k0} $0x00 %zmm0 %xmm2 -> %zmm0
- *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8
- * (a)     mov           $0x00000001 -> %ecx
- *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9
- * (a)     kmovw         %k0 -> %edx
- *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10
- * (a)     kmovw         %ecx -> %k0
- *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_11
- * (a) (b) kandnw        %k0 %k1 -> %k1
- *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_12
- *     (b) kmovw         %edx -> %k0
  *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2
+ *         vpextrd       %xmm2 $0x00 -> %ecx
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3
+ *         mov           (%rax,%rcx,4)[4byte] -> %ecx
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4
+ * (a)     vextracti32x4 {%k0} $0x00 %zmm0 -> %xmm2
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5
+ * (a)     vpinsrd       %xmm2 %ecx $0x00 -> %xmm2
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6
+ * (a)     vinserti32x4  {%k0} $0x00 %zmm0 %xmm2 -> %zmm0
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7
+ * (a)     mov           $0x00000001 -> %ecx
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8
+ * (a)     kmovw         %k0 -> %edx
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9
+ * (a)     kmovw         %ecx -> %k0
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10
+ * (a) (b) kandnw        %k0 %k1 -> %k1
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_11
+ *     (b) kmovw         %edx -> %k0
+ *         DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1
  *
  * (a): The instruction window where the destination mask state hadn't been updated yet.
  * (b): The instruction window where the scratch mask is clobbered w/o support by drreg.
@@ -2683,30 +2734,28 @@ drx_expand_scatter_gather_exit:
  * AVX-512 scatter sequence detection example:
  *
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0
- *         mov           <xmm_spill_addr> -> %edx
+ *         vmovups       {%k0} %zmm2 -> (%rcx)[64byte]
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1
- *         vmovdqa       %xmm2 -> (%edx)[16byte]
- *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2
  *         vextracti32x4 {%k0} $0x00 %zmm1 -> %xmm2
- *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_3
- *         vpextrd       %xmm2 $0x00 -> %edx
- *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_4
- *         vextracti32x4 {%k0} $0x00 %zmm0 -> %xmm2
- *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_5
- *         vpextrd       %xmm2 $0x00 -> %ebx
- *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_6
- *         mov           %ebx -> (%rcx,%rdx,4)[4byte]
- *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_7
- * (a)     mov           $0x00000001 -> %edx
- *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8
- * (a)     kmovw         %k0 -> %ebp
- *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9
- * (a)     kmovw         %edx -> %k0
- *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_10
- * (a) (b) kandnw        %k0 %k1 -> %k1
- *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_11
- *     (b) kmovw         %ebp -> %k0
  *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2
+ *         vpextrd       %xmm2 $0x00 -> %edx
+ *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_3
+ *         vextracti32x4 {%k0} $0x00 %zmm0 -> %xmm2
+ *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_4
+ *         vpextrd       %xmm2 $0x00 -> %ebx
+ *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_5
+ *         mov           %ebx -> (%rcx,%rdx,4)[4byte]
+ *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_6
+ * (a)     mov           $0x00000001 -> %edx
+ *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_7
+ * (a)     kmovw         %k0 -> %ebp
+ *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8
+ * (a)     kmovw         %edx -> %k0
+ *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9
+ * (a) (b) kandnw        %k0 %k1 -> %k1
+ *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_10
+ *     (b) kmovw         %ebp -> %k0
+ *         DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1
  *
  * (a): The instruction window where the destination mask state hadn't been updated yet.
  * (b): The instruction window where the scratch mask is clobbered w/o support by drreg.
@@ -2714,30 +2763,28 @@ drx_expand_scatter_gather_exit:
  * AVX2 gather sequence detection example:
  *
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0
- *         mov           <xmm_spill_addr> -> %ecx
+ *         vmovups       {%k0} %zmm3 -> (%rcx)[64byte]
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1
- *         vmovdqa       %xmm3 -> (%ecx)[16byte]
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2
  *         vextracti128  %ymm2 $0x00 -> %xmm3
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3
- *         vpextrd       %xmm3 $0x00 -> %ecx
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4
- *         mov           (%rax,%rcx,4)[4byte] -> %ecx
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5
- * (a)     vextracti128  %ymm0 $0x00 -> %xmm3
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6
- * (a)     vpinsrd       %xmm3 %ecx $0x00 -> %xmm3
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7
- * (a)     vinserti128   %ymm0 %xmm3 $0x00 -> %ymm0
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8
- * (a)     xor           %ecx %ecx -> %ecx
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9
- * (a)     vextracti128  %ymm2 $0x00 -> %xmm3
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_10
- * (a)     vpinsrd       %xmm3 %ecx $0x00 -> %xmm3
- *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_11
- * (a)     vinserti128   %ymm2 %xmm3 $0x00 -> %ymm2
  *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2
+ *         vpextrd       %xmm3 $0x00 -> %ecx
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3
+ *         mov           (%rax,%rcx,4)[4byte] -> %ecx
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4
+ * (a)     vextracti128  %ymm0 $0x00 -> %xmm3
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5
+ * (a)     vpinsrd       %xmm3 %ecx $0x00 -> %xmm3
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6
+ * (a)     vinserti128   %ymm0 %xmm3 $0x00 -> %ymm0
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7
+ * (a)     xor           %ecx %ecx -> %ecx
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8
+ * (a)     vextracti128  %ymm2 $0x00 -> %xmm3
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9
+ * (a)     vpinsrd       %xmm3 %ecx $0x00 -> %xmm3
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_10
+ * (a)     vinserti128   %ymm2 %xmm3 $0x00 -> %ymm2
+ *         DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1
  *
  * (a): The instruction window where the destination mask state hadn't been updated yet.
  *
@@ -2758,7 +2805,6 @@ drx_expand_scatter_gather_exit:
 #    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9 9
 #    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10 10
 #    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_11 11
-#    define DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_12 12
 
 /* States of the AVX-512 scatter detection state machine. */
 #    define DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0 0
@@ -2772,7 +2818,6 @@ drx_expand_scatter_gather_exit:
 #    define DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8 8
 #    define DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9 9
 #    define DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_10 10
-#    define DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_11 11
 
 /* States of the AVX2 gather detection state machine. */
 #    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0 0
@@ -2786,7 +2831,6 @@ drx_expand_scatter_gather_exit:
 #    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8 8
 #    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9 9
 #    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_10 10
-#    define DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_11 11
 
 typedef struct _drx_state_machine_params_t {
     byte *pc;
@@ -2799,18 +2843,10 @@ typedef struct _drx_state_machine_params_t {
     byte *restore_scratch_mask_start_pc;
     /* counter to allow for skipping unknown instructions */
     int skip_unknown_instr_count;
-    /* The spilled xmm register. When the_scratch_xmm is set,
-     * it is expected to be equal to this.
+    /* The spilled ymm/zmm register. When the_scratch_xmm is set,
+     * it is expected to correspond to this.
      */
-    reg_id_t spilled_xmm;
-    /* The address where the spilled xmm reg's app value is
-     * stored.
-     */
-    void *spilled_xmm_slot_addr;
-    /* The reg with spilled_xmm_slot_addr, so that we can use it
-     * in the actual spill instr.
-     */
-    reg_id_t spilled_xmm_slot_addr_reg;
+    reg_id_t spilled_mm;
     /* detected scratch xmm register for mask update */
     reg_id_t the_scratch_xmm;
     /* detected gpr register that holds the mask update immediate */
@@ -2845,15 +2881,16 @@ skip_unknown_instr_inc(int reset_state, drx_state_machine_params_t *params)
 }
 
 static void
-restore_spilled_xmm_value(drx_state_machine_params_t *params)
+restore_spilled_mm_value(void *drcontext, drx_state_machine_params_t *params)
 {
-    byte xmm_val[XMM_REG_SIZE];
-    ASSERT(params->spilled_xmm_slot_addr != NULL,
-           "No spill address recorded for the app xmm value");
-    ASSERT(params->spilled_xmm != DR_REG_NULL && reg_is_strictly_xmm(params->spilled_xmm),
-           "No spilled xmm reg recorded");
-    memcpy(xmm_val, params->spilled_xmm_slot_addr, XMM_REG_SIZE);
-    reg_set_value_ex(params->spilled_xmm, params->info->mcontext, xmm_val);
+    byte mm_val[ZMM_REG_SIZE];
+    ASSERT(params->spilled_mm != DR_REG_NULL &&
+               (reg_is_strictly_ymm(params->spilled_mm) ||
+                reg_is_strictly_zmm(params->spilled_mm)),
+           "No spilled ymm/zmm reg recorded");
+    memcpy(mm_val, get_tls_data(drcontext)->scratch_mm_spill_slot,
+           reg_is_strictly_ymm(params->spilled_mm) ? YMM_REG_SIZE : ZMM_REG_SIZE);
+    reg_set_value_ex(params->spilled_mm, params->info->mcontext, mm_val);
 }
 
 /* Run the state machines and decode the code cache. The state machines will search the
@@ -2872,9 +2909,7 @@ drx_restore_state_scatter_gather(
     params.detect_state = 0;
     params.skip_unknown_instr_count = 0;
     params.the_scratch_xmm = DR_REG_NULL;
-    params.spilled_xmm = DR_REG_NULL;
-    params.spilled_xmm_slot_addr = NULL;
-    params.spilled_xmm_slot_addr_reg = DR_REG_NULL;
+    params.spilled_mm = DR_REG_NULL;
     params.gpr_bit_mask = DR_REG_NULL;
     params.gpr_save_scratch_mask = DR_REG_NULL;
     params.scalar_mask_update_no = 0;
@@ -2913,61 +2948,46 @@ static bool
 drx_avx2_gather_sequence_state_machine(void *drcontext,
                                        drx_state_machine_params_t *params)
 {
+    uint mov_scratch_mm_opcode;
+    opnd_size_t mov_scratch_mm_opnd_sz;
+    get_mov_scratch_mm_opcode_and_size(&mov_scratch_mm_opcode, &mov_scratch_mm_opnd_sz);
+    uint mov_scratch_mm_opnd_pos = (mov_scratch_mm_opnd_sz == OPSZ_64 ? 1 : 0);
     switch (params->detect_state) {
-    /* First we detect the spill address for the scratch xmm reg. */
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0: {
-        params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
-        params->spilled_xmm_slot_addr = NULL;
-        ptr_int_t spilled_xmm_slot_addr;
-        if (instr_is_mov_constant(&params->inst, &spilled_xmm_slot_addr) &&
-            opnd_is_reg(instr_get_dst(&params->inst, 0)) &&
-            reg_is_gpr(opnd_get_reg(instr_get_dst(&params->inst, 0)))) {
-            params->spilled_xmm_slot_addr = (void *)spilled_xmm_slot_addr;
-            params->spilled_xmm_slot_addr_reg =
-                opnd_get_reg(instr_get_dst(&params->inst, 0));
-            advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
-        }
-        break;
-    }
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1:
-        ASSERT(params->spilled_xmm == DR_REG_NULL,
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0:
+        ASSERT(params->spilled_mm == DR_REG_NULL,
                "Spilled xmm reg must be undetermined yet");
-        ASSERT(params->spilled_xmm_slot_addr != NULL &&
-                   params->spilled_xmm_slot_addr_reg != DR_REG_NULL,
-               "xmm spill address must be determined already");
-        if (instr_get_opcode(&params->inst) == OP_vmovdqa &&
-            opnd_is_base_disp(instr_get_dst(&params->inst, 0)) &&
-            opnd_get_base(instr_get_dst(&params->inst, 0)) ==
-                params->spilled_xmm_slot_addr_reg &&
-            opnd_is_reg(instr_get_src(&params->inst, 0)) &&
-            reg_is_strictly_xmm(opnd_get_reg(instr_get_src(&params->inst, 0)))) {
-            params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
-            params->spilled_xmm = opnd_get_reg(instr_get_src(&params->inst, 0));
-            advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+        if (instr_get_opcode(&params->inst) == mov_scratch_mm_opcode &&
+            opnd_is_reg(instr_get_src(&params->inst, mov_scratch_mm_opnd_pos)) &&
+            (reg_is_strictly_ymm(
+                 opnd_get_reg(instr_get_src(&params->inst, mov_scratch_mm_opnd_pos))) ||
+             reg_is_strictly_zmm(
+                 opnd_get_reg(instr_get_src(&params->inst, mov_scratch_mm_opnd_pos))))) {
+            params->spilled_mm =
+                opnd_get_reg(instr_get_src(&params->inst, mov_scratch_mm_opnd_pos));
+            advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
             break;
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
         break;
-    /* We come back to DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2 for each
+    /* We come back to DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1 for each
      * scalar load sequence of the expanded gather instr.
      */
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1:
         if (instr_get_opcode(&params->inst) == OP_vextracti128) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0)) {
                 reg_id_t tmp_reg = opnd_get_reg(dst0);
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
-                ASSERT(params->spilled_xmm == tmp_reg,
+                ASSERT(reg_resize_to_opsz(params->spilled_mm, OPSZ_16) == tmp_reg,
                        "Only the spilled xmm should be used as scratch");
                 params->the_scratch_xmm = tmp_reg;
-                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3, params);
+                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -2983,15 +3003,15 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                 if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
                     params->the_scratch_xmm = DR_REG_NULL;
                     params->gpr_scratch_index = opnd_get_reg(dst0);
-                    advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4, params);
+                    advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3, params);
                     break;
                 }
             }
         }
         /* Intentionally not else if */
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_3:
         if (!instr_is_reg_spill_or_restore(drcontext, &params->inst, NULL, NULL, NULL,
                                            NULL)) {
             if (instr_reads_memory(&params->inst)) {
@@ -3001,7 +3021,7 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                         opnd_t dst0 = instr_get_dst(&params->inst, 0);
                         if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
                             params->restore_dest_mask_start_pc = params->pc;
-                            advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5,
+                            advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4,
                                           params);
                             break;
                         }
@@ -3009,26 +3029,26 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_4:
         if (instr_get_opcode(&params->inst) == OP_vextracti128) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0)) {
                 reg_id_t tmp_reg = opnd_get_reg(dst0);
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
-                ASSERT(params->spilled_xmm == tmp_reg,
+                ASSERT(reg_resize_to_opsz(params->spilled_mm, OPSZ_16) == tmp_reg,
                        "Only the spilled xmm should be used as scratch");
                 params->the_scratch_xmm = tmp_reg;
-                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6, params);
+                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5, params);
                 break;
             }
         }
         /* Intentionally not else if */
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_5:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -3041,25 +3061,25 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
             reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
             if (tmp_reg == params->the_scratch_xmm) {
                 params->the_scratch_xmm = DR_REG_NULL;
-                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7, params);
+                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_6:
         if (instr_get_opcode(&params->inst) == OP_vinserti128) {
             ASSERT(opnd_is_reg(instr_get_dst(&params->inst, 0)),
                    "internal error: unexpected instruction format");
             reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
             if (tmp_reg == params->sg_info->gather_dst_reg) {
-                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8, params);
+                advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_7:
         if (instr_get_opcode(&params->inst) == OP_xor) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             opnd_t src0 = instr_get_src(&params->inst, 0);
@@ -3073,13 +3093,13 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                        "internal error: unexpected instruction format");
                 if (reg_dst0 == reg_src0 && reg_src0 == reg_src1) {
                     params->gpr_bit_mask = reg_dst0;
-                    advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9, params);
+                    advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8, params);
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_8:
         if (instr_get_opcode(&params->inst) == OP_vextracti128) {
             opnd_t src0 = instr_get_src(&params->inst, 0);
             if (opnd_is_reg(src0)) {
@@ -3089,19 +3109,19 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                         reg_id_t tmp_reg = opnd_get_reg(dst0);
                         if (!reg_is_strictly_xmm(tmp_reg))
                             break;
-                        ASSERT(params->spilled_xmm == tmp_reg,
+                        ASSERT(reg_resize_to_opsz(params->spilled_mm, OPSZ_16) == tmp_reg,
                                "Only the spilled xmm should be used as scratch");
                         params->the_scratch_xmm = tmp_reg;
-                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_10,
+                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_10:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_9:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -3116,16 +3136,16 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                            "internal error: unexpected instruction format");
                     reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
                     if (tmp_reg == params->the_scratch_xmm) {
-                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_11,
+                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_10,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_11:
+    case DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_10:
         if (instr_get_opcode(&params->inst) == OP_vinserti128) {
             ASSERT(opnd_is_reg(instr_get_dst(&params->inst, 0)) &&
                        opnd_is_reg(instr_get_src(&params->inst, 0)) &&
@@ -3163,7 +3183,7 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                                 reg_set_value_ex(params->sg_info->mask_reg,
                                                  params->info->mcontext, val);
                             }
-                            restore_spilled_xmm_value(params);
+                            restore_spilled_mm_value(drcontext, params);
                             /* We are done. */
                             return true;
                         }
@@ -3178,14 +3198,14 @@ drx_avx2_gather_sequence_state_machine(void *drcontext,
                              */
                             return true;
                         }
-                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2,
+                        advance_state(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX2_GATHER_EVENT_STATE_1, params);
         break;
     default: ASSERT(false, "internal error: invalid state.");
     }
@@ -3197,61 +3217,46 @@ static bool
 drx_avx512_scatter_sequence_state_machine(void *drcontext,
                                           drx_state_machine_params_t *params)
 {
+    uint mov_scratch_mm_opcode;
+    opnd_size_t mov_scratch_mm_opnd_sz;
+    get_mov_scratch_mm_opcode_and_size(&mov_scratch_mm_opcode, &mov_scratch_mm_opnd_sz);
+    uint mov_scratch_mm_opnd_pos = (mov_scratch_mm_opnd_sz == OPSZ_64 ? 1 : 0);
     switch (params->detect_state) {
-    /* First we detect the spill address for the scratch xmm reg. */
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0: {
-        params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
-        params->spilled_xmm_slot_addr = NULL;
-        ptr_int_t spilled_xmm_slot_addr;
-        if (instr_is_mov_constant(&params->inst, &spilled_xmm_slot_addr) &&
-            opnd_is_reg(instr_get_dst(&params->inst, 0)) &&
-            reg_is_gpr(opnd_get_reg(instr_get_dst(&params->inst, 0)))) {
-            params->spilled_xmm_slot_addr = (void *)spilled_xmm_slot_addr;
-            params->spilled_xmm_slot_addr_reg =
-                opnd_get_reg(instr_get_dst(&params->inst, 0));
-            advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
-        }
-        break;
-    }
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1:
-        ASSERT(params->spilled_xmm == DR_REG_NULL,
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0:
+        ASSERT(params->spilled_mm == DR_REG_NULL,
                "Spilled xmm reg must be undetermined yet");
-        ASSERT(params->spilled_xmm_slot_addr != NULL &&
-                   params->spilled_xmm_slot_addr_reg != DR_REG_NULL,
-               "xmm spill address must be determined already");
-        if (instr_get_opcode(&params->inst) == OP_vmovdqa &&
-            opnd_is_base_disp(instr_get_dst(&params->inst, 0)) &&
-            opnd_get_base(instr_get_dst(&params->inst, 0)) ==
-                params->spilled_xmm_slot_addr_reg &&
-            opnd_is_reg(instr_get_src(&params->inst, 0)) &&
-            reg_is_strictly_xmm(opnd_get_reg(instr_get_src(&params->inst, 0)))) {
-            params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
-            params->spilled_xmm = opnd_get_reg(instr_get_src(&params->inst, 0));
-            advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
+        if (instr_get_opcode(&params->inst) == mov_scratch_mm_opcode &&
+            opnd_is_reg(instr_get_src(&params->inst, mov_scratch_mm_opnd_pos)) &&
+            (reg_is_strictly_ymm(
+                 opnd_get_reg(instr_get_src(&params->inst, mov_scratch_mm_opnd_pos))) ||
+             reg_is_strictly_zmm(
+                 opnd_get_reg(instr_get_src(&params->inst, mov_scratch_mm_opnd_pos))))) {
+            params->spilled_mm =
+                opnd_get_reg(instr_get_src(&params->inst, mov_scratch_mm_opnd_pos));
+            advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
             break;
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
         break;
-    /* We come back to DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2 for each
+    /* We come back to DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1 for each
      * scalar store sequence of the expanded scatter instr.
      */
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1:
         if (instr_get_opcode(&params->inst) == OP_vextracti32x4) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0)) {
                 reg_id_t tmp_reg = opnd_get_reg(dst0);
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
-                ASSERT(params->spilled_xmm == tmp_reg,
+                ASSERT(reg_resize_to_opsz(params->spilled_mm, OPSZ_16) == tmp_reg,
                        "Only the spilled xmm should be used as scratch");
                 params->the_scratch_xmm = tmp_reg;
-                advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_3, params);
+                advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_3:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -3267,33 +3272,33 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                 if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
                     params->the_scratch_xmm = DR_REG_NULL;
                     params->gpr_scratch_index = opnd_get_reg(dst0);
-                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_4,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_3,
                                   params);
                     break;
                 }
             }
         }
         /* Intentionally not else if */
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_4:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_3:
         if (instr_get_opcode(&params->inst) == OP_vextracti32x4) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0)) {
                 reg_id_t tmp_reg = opnd_get_reg(dst0);
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
-                ASSERT(params->spilled_xmm == tmp_reg,
+                ASSERT(reg_resize_to_opsz(params->spilled_mm, OPSZ_16) == tmp_reg,
                        "Only the spilled xmm should be used as scratch");
                 params->the_scratch_xmm = tmp_reg;
-                advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_5, params);
+                advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_4, params);
                 break;
             }
         }
         /* Intentionally not else if */
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_5:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_4:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -3309,15 +3314,15 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                 if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
                     params->the_scratch_xmm = DR_REG_NULL;
                     params->gpr_scratch_value = opnd_get_reg(dst0);
-                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_6,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_5,
                                   params);
                     break;
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_6: {
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_5: {
         if (!instr_is_reg_spill_or_restore(drcontext, &params->inst, NULL, NULL, NULL,
                                            NULL)) {
             if (instr_writes_memory(&params->inst)) {
@@ -3328,17 +3333,17 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                         opnd_uses_reg(src0, params->gpr_scratch_value) &&
                         opnd_uses_reg(dst0, params->gpr_scratch_index)) {
                         params->restore_dest_mask_start_pc = params->pc;
-                        advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_7,
+                        advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_6,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
         break;
     }
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_7: {
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_6: {
         ptr_int_t val;
         if (instr_is_mov_constant(&params->inst, &val)) {
             /* If more than one bit is set, this is not what we're looking for. */
@@ -3349,16 +3354,16 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                 reg_id_t tmp_gpr = opnd_get_reg(dst0);
                 if (reg_is_gpr(tmp_gpr)) {
                     params->gpr_bit_mask = tmp_gpr;
-                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_7,
                                   params);
                     break;
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
         break;
     }
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_7:
         if (instr_get_opcode(&params->inst) == OP_kmovw) {
             opnd_t src0 = instr_get_src(&params->inst, 0);
             if (opnd_is_reg(src0) && opnd_get_reg(src0) == DR_REG_K0) {
@@ -3367,16 +3372,16 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                     reg_id_t tmp_gpr = opnd_get_reg(dst0);
                     if (reg_is_gpr(tmp_gpr)) {
                         params->gpr_save_scratch_mask = tmp_gpr;
-                        advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9,
+                        advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_8:
         ASSERT(params->gpr_bit_mask != DR_REG_NULL,
                "internal error: expected gpr register to be recorded in state "
                "machine.");
@@ -3386,15 +3391,15 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                 opnd_t dst0 = instr_get_dst(&params->inst, 0);
                 if (opnd_is_reg(dst0) && opnd_get_reg(dst0) == DR_REG_K0) {
                     params->restore_scratch_mask_start_pc = params->pc;
-                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_10,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9,
                                   params);
                     break;
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_10:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_9:
         if (instr_get_opcode(&params->inst) == OP_kandnw) {
             opnd_t src0 = instr_get_src(&params->inst, 0);
             opnd_t src1 = instr_get_src(&params->inst, 1);
@@ -3432,15 +3437,15 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                          */
                         return true;
                     }
-                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_11,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_10,
                                   params);
                     break;
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_11:
+    case DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_10:
         if (instr_get_opcode(&params->inst) == OP_kmovw) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0) && opnd_get_reg(dst0) == DR_REG_K0) {
@@ -3464,18 +3469,18 @@ drx_avx512_scatter_sequence_state_machine(void *drcontext,
                                               params->info->raw_mcontext) &
                                 0xffff;
                         }
-                        restore_spilled_xmm_value(params);
+                        restore_spilled_mm_value(drcontext, params);
                         /* We are done. If we did fix up the scatter's destination
                          * mask, this already has happened.
                          */
                         return true;
                     }
-                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1,
                                   params);
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_SCATTER_EVENT_STATE_1, params);
         break;
     default: ASSERT(false, "internal error: invalid state.");
     }
@@ -3487,61 +3492,46 @@ static bool
 drx_avx512_gather_sequence_state_machine(void *drcontext,
                                          drx_state_machine_params_t *params)
 {
+    uint mov_scratch_mm_opcode;
+    opnd_size_t mov_scratch_mm_opnd_sz;
+    get_mov_scratch_mm_opcode_and_size(&mov_scratch_mm_opcode, &mov_scratch_mm_opnd_sz);
+    uint mov_scratch_mm_opnd_pos = (mov_scratch_mm_opnd_sz == OPSZ_64 ? 1 : 0);
     switch (params->detect_state) {
-    /* First we detect the spill address for the scratch xmm reg. */
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0: {
-        params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
-        params->spilled_xmm_slot_addr = NULL;
-        ptr_int_t spilled_xmm_slot_addr;
-        if (instr_is_mov_constant(&params->inst, &spilled_xmm_slot_addr) &&
-            opnd_is_reg(instr_get_dst(&params->inst, 0)) &&
-            reg_is_gpr(opnd_get_reg(instr_get_dst(&params->inst, 0)))) {
-            params->spilled_xmm_slot_addr = (void *)spilled_xmm_slot_addr;
-            params->spilled_xmm_slot_addr_reg =
-                opnd_get_reg(instr_get_dst(&params->inst, 0));
-            advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
-        }
-        break;
-    }
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1:
-        ASSERT(params->spilled_xmm == DR_REG_NULL,
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0:
+        ASSERT(params->spilled_mm == DR_REG_NULL,
                "Spilled xmm reg must be undetermined yet");
-        ASSERT(params->spilled_xmm_slot_addr != NULL &&
-                   params->spilled_xmm_slot_addr_reg != DR_REG_NULL,
-               "xmm spill address must be determined already");
-        if (instr_get_opcode(&params->inst) == OP_vmovdqa &&
-            opnd_is_base_disp(instr_get_dst(&params->inst, 0)) &&
-            opnd_get_base(instr_get_dst(&params->inst, 0)) ==
-                params->spilled_xmm_slot_addr_reg &&
-            opnd_is_reg(instr_get_src(&params->inst, 0)) &&
-            reg_is_strictly_xmm(opnd_get_reg(instr_get_src(&params->inst, 0)))) {
-            params->spilled_xmm_slot_addr_reg = DR_REG_NULL;
-            params->spilled_xmm = opnd_get_reg(instr_get_src(&params->inst, 0));
-            advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+        if (instr_get_opcode(&params->inst) == mov_scratch_mm_opcode &&
+            opnd_is_reg(instr_get_src(&params->inst, mov_scratch_mm_opnd_pos)) &&
+            (reg_is_strictly_ymm(
+                 opnd_get_reg(instr_get_src(&params->inst, mov_scratch_mm_opnd_pos))) ||
+             reg_is_strictly_zmm(
+                 opnd_get_reg(instr_get_src(&params->inst, mov_scratch_mm_opnd_pos))))) {
+            params->spilled_mm =
+                opnd_get_reg(instr_get_src(&params->inst, mov_scratch_mm_opnd_pos));
+            advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
             break;
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
         break;
-    /* We come back to DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2 for each
+    /* We come back to DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1 for each
      * scalar load sequence of the expanded gather instr.
      */
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1:
         if (instr_get_opcode(&params->inst) == OP_vextracti32x4) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0)) {
                 reg_id_t tmp_reg = opnd_get_reg(dst0);
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
-                ASSERT(params->spilled_xmm == tmp_reg,
+                ASSERT(reg_resize_to_opsz(params->spilled_mm, OPSZ_16) == tmp_reg,
                        "Only the spilled xmm should be used as scratch");
                 params->the_scratch_xmm = tmp_reg;
-                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3, params);
+                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_0, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -3557,15 +3547,15 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                 if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
                     params->the_scratch_xmm = DR_REG_NULL;
                     params->gpr_scratch_index = opnd_get_reg(dst0);
-                    advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4, params);
+                    advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3, params);
                     break;
                 }
             }
         }
         /* Intentionally not else if */
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_3:
         if (!instr_is_reg_spill_or_restore(drcontext, &params->inst, NULL, NULL, NULL,
                                            NULL)) {
             if (instr_reads_memory(&params->inst)) {
@@ -3575,32 +3565,32 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                     opnd_t dst0 = instr_get_dst(&params->inst, 0);
                     if (opnd_is_reg(dst0) && reg_is_gpr(opnd_get_reg(dst0))) {
                         params->restore_dest_mask_start_pc = params->pc;
-                        advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5,
+                        advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_4:
         if (instr_get_opcode(&params->inst) == OP_vextracti32x4) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0)) {
                 reg_id_t tmp_reg = opnd_get_reg(dst0);
                 if (!reg_is_strictly_xmm(tmp_reg))
                     break;
-                ASSERT(params->spilled_xmm == tmp_reg,
+                ASSERT(reg_resize_to_opsz(params->spilled_mm, OPSZ_16) == tmp_reg,
                        "Only the spilled xmm should be used as scratch");
                 params->the_scratch_xmm = tmp_reg;
-                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6, params);
+                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_5:
         ASSERT(params->the_scratch_xmm != DR_REG_NULL,
                "internal error: expected xmm register to be recorded in state "
                "machine.");
@@ -3612,25 +3602,25 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                    "internal error: unexpected instruction format");
             reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
             if (tmp_reg == params->the_scratch_xmm) {
-                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7, params);
+                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_6:
         if (instr_get_opcode(&params->inst) == OP_vinserti32x4) {
             ASSERT(opnd_is_reg(instr_get_dst(&params->inst, 0)),
                    "internal error: unexpected instruction format");
             reg_id_t tmp_reg = opnd_get_reg(instr_get_dst(&params->inst, 0));
             if (tmp_reg == params->sg_info->gather_dst_reg) {
-                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8, params);
+                advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7, params);
                 break;
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8: {
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_7: {
         ptr_int_t val;
         if (instr_is_mov_constant(&params->inst, &val)) {
             /* If more than one bit is set, this is not what we're looking for. */
@@ -3641,15 +3631,15 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                 reg_id_t tmp_gpr = opnd_get_reg(dst0);
                 if (reg_is_gpr(tmp_gpr)) {
                     params->gpr_bit_mask = tmp_gpr;
-                    advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9, params);
+                    advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8, params);
                     break;
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
         break;
     }
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_8:
         if (instr_get_opcode(&params->inst) == OP_kmovw) {
             opnd_t src0 = instr_get_src(&params->inst, 0);
             if (opnd_is_reg(src0) && opnd_get_reg(src0) == DR_REG_K0) {
@@ -3658,16 +3648,16 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                     reg_id_t tmp_gpr = opnd_get_reg(dst0);
                     if (reg_is_gpr(tmp_gpr)) {
                         params->gpr_save_scratch_mask = tmp_gpr;
-                        advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10,
+                        advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_9:
         ASSERT(params->gpr_bit_mask != DR_REG_NULL,
                "internal error: expected gpr register to be recorded in state "
                "machine.");
@@ -3677,15 +3667,15 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                 opnd_t dst0 = instr_get_dst(&params->inst, 0);
                 if (opnd_is_reg(dst0) && opnd_get_reg(dst0) == DR_REG_K0) {
                     params->restore_scratch_mask_start_pc = params->pc;
-                    advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_11,
+                    advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10,
                                   params);
                     break;
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_11:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_10:
         if (instr_get_opcode(&params->inst) == OP_kandnw) {
             opnd_t src0 = instr_get_src(&params->inst, 0);
             opnd_t src1 = instr_get_src(&params->inst, 1);
@@ -3723,16 +3713,16 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                              */
                             return true;
                         }
-                        advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_12,
+                        advance_state(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_11,
                                       params);
                         break;
                     }
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
         break;
-    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_12:
+    case DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_11:
         if (instr_get_opcode(&params->inst) == OP_kmovw) {
             opnd_t dst0 = instr_get_dst(&params->inst, 0);
             if (opnd_is_reg(dst0) && opnd_get_reg(dst0) == DR_REG_K0) {
@@ -3757,7 +3747,7 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                                                   params->info->raw_mcontext) &
                                     0xffff;
                             }
-                            restore_spilled_xmm_value(params);
+                            restore_spilled_mm_value(drcontext, params);
                             /* We are done. If we did fix up the gather's destination
                              * mask, this already has happened.
                              */
@@ -3767,7 +3757,7 @@ drx_avx512_gather_sequence_state_machine(void *drcontext,
                 }
             }
         }
-        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_2, params);
+        skip_unknown_instr_inc(DRX_DETECT_RESTORE_AVX512_GATHER_EVENT_STATE_1, params);
         break;
     default: ASSERT(false, "internal error: invalid state.");
     }

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2455,9 +2455,9 @@ drx_expand_scatter_gather(void *drcontext, instrlist_t *bb, OUT bool *expanded)
             break;
     }
     /* Spill the scratch mm reg. We spill the largest reg corresponding to scratch_xmm
-     * support by the system. This is required because writing a part of a ymm/zmm reg
-     * zeroes the remaining automatically. So we need to save the complete ymm/zmm reg
-     * and not just the lower xmm bits.
+     * that is supported by the system. This is required because writing a part of a
+     * ymm/zmm reg zeroes the remaining automatically. So we need to save the complete
+     * ymm/zmm reg and not just the lower xmm bits.
      * TODO i#3844: drreg does not support spilling mm regs yet, so we do it ourselves.
      * When that support is available, replace the following with the required drreg API
      * calls.
@@ -2948,7 +2948,7 @@ static bool
 drx_avx2_gather_sequence_state_machine(void *drcontext,
                                        drx_state_machine_params_t *params)
 {
-    uint mov_scratch_mm_opcode;
+    int mov_scratch_mm_opcode;
     opnd_size_t mov_scratch_mm_opnd_sz;
     get_mov_scratch_mm_opcode_and_size(&mov_scratch_mm_opcode, &mov_scratch_mm_opnd_sz);
     uint mov_scratch_mm_opnd_pos = (mov_scratch_mm_opnd_sz == OPSZ_64 ? 1 : 0);
@@ -3217,7 +3217,7 @@ static bool
 drx_avx512_scatter_sequence_state_machine(void *drcontext,
                                           drx_state_machine_params_t *params)
 {
-    uint mov_scratch_mm_opcode;
+    int mov_scratch_mm_opcode;
     opnd_size_t mov_scratch_mm_opnd_sz;
     get_mov_scratch_mm_opcode_and_size(&mov_scratch_mm_opcode, &mov_scratch_mm_opnd_sz);
     uint mov_scratch_mm_opnd_pos = (mov_scratch_mm_opnd_sz == OPSZ_64 ? 1 : 0);
@@ -3492,7 +3492,7 @@ static bool
 drx_avx512_gather_sequence_state_machine(void *drcontext,
                                          drx_state_machine_params_t *params)
 {
-    uint mov_scratch_mm_opcode;
+    int mov_scratch_mm_opcode;
     opnd_size_t mov_scratch_mm_opnd_sz;
     get_mov_scratch_mm_opcode_and_size(&mov_scratch_mm_opcode, &mov_scratch_mm_opnd_sz);
     uint mov_scratch_mm_opnd_pos = (mov_scratch_mm_opnd_sz == OPSZ_64 ? 1 : 0);

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -157,7 +157,7 @@ get_tls_data(void *drcontext)
 }
 
 static void
-get_mov_scratch_mm_opcode_and_size(uint *opcode_out, opnd_size_t *opnd_size_out)
+get_mov_scratch_mm_opcode_and_size(int *opcode_out, opnd_size_t *opnd_size_out)
 {
     uint opcode;
     opnd_size_t opnd_size;
@@ -2462,7 +2462,7 @@ drx_expand_scatter_gather(void *drcontext, instrlist_t *bb, OUT bool *expanded)
      * When that support is available, replace the following with the required drreg API
      * calls.
      */
-    uint mov_scratch_mm_opcode;
+    int mov_scratch_mm_opcode;
     opnd_size_t mov_scratch_mm_opnd_sz;
     reg_id_t scratch_mm;
     get_mov_scratch_mm_opcode_and_size(&mov_scratch_mm_opcode, &mov_scratch_mm_opnd_sz);

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -2455,7 +2455,7 @@ drx_expand_scatter_gather(void *drcontext, instrlist_t *bb, OUT bool *expanded)
             break;
     }
     /* Spill the scratch mm reg. We spill the largest reg corresponding to scratch_xmm
-     * that is supported by the system. This is required because writing a part of a
+     * that is supported by the system. This is required because mov-ing a part of a
      * ymm/zmm reg zeroes the remaining automatically. So we need to save the complete
      * ymm/zmm reg and not just the lower xmm bits.
      * TODO i#3844: drreg does not support spilling mm regs yet, so we do it ourselves.


### PR DESCRIPTION
Fixes spill and restore for the scratch xmm reg. Mov-ing to the lower
xmm bits zeroes the upper bits of the corresponding ymm and zmm
reg. So we need to spill and restore the entire ymm or zmm reg,
whichever is the largest one reg supported by the system, and not
just the xmm part of it.

Also adjusts the state restoration machine to expect the new spill
instrs.

Replaces the linear address of spill slot in instrumentation with an
address computed online using the TLS reg.

Extends the allasm-scattergather test to verify the whole zmm reg
after the scatter/gather expansion. On systems without AVX512, we
verify ymm. This test fails without the fix.

Issue: #2985