### PR TITLE
i#5145 v9.0: Post-release documentation updates

### DIFF
--- a/api/docs/download.dox
+++ b/api/docs/download.dox
@@ -50,7 +50,19 @@ The source code is available:
 
 For the very latest changes since the last official release, you can download \ref page_weekly_builds.
 
-The [8.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_8.0.0-1):
+The [9.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_9.0.0):
+
+  - [DynamoRIO-Windows-9.0.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.0/DynamoRIO-Windows-9.0.0.zip)
+
+  - [DynamoRIO-Linux-9.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.0/DynamoRIO-Linux-9.0.0.tar.gz)
+
+  - [DynamoRIO-ARM-Linux-EABIHF-9.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.0/DynamoRIO-ARM-Linux-EABIHF-9.0.0.tar.gz)
+
+  - [DynamoRIO-ARM-Android-EABI-9.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.0/DynamoRIO-ARM-Android-EABI-9.0.0.tar.gz)
+
+  - [DynamoRIO-AArch64-Linux-9.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.0/DynamoRIO-AArch64-Linux-9.0.0.tar.gz)
+
+The prior [8.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_8.0.0-1):
 
   - [DynamoRIO-Windows-8.0.0-1.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_8.0.0-1/DynamoRIO-Windows-8.0.0-1.zip)
 
@@ -75,18 +87,6 @@ The prior [7.1.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/re
   - [DynamoRIO-ARM-Android-EABI-7.1.0-1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_7.1.0/DynamoRIO-ARM-Android-EABI-7.1.0-1.tar.gz)
 
   - [DynamoRIO-AArch64-Linux-7.1.0-1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_7.1.0/DynamoRIO-AArch64-Linux-7.1.0-1.tar.gz)
-
-The prior [7.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_7_0_0_rc1):
-
-  - [DynamoRIO-Windows-7.0.0-RC1.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_7_0_0_rc1/DynamoRIO-Windows-7.0.0-RC1.zip)
-
-  - [DynamoRIO-Linux-7.0.0-RC1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_7_0_0_rc1/DynamoRIO-Linux-7.0.0-RC1.tar.gz)
-
-  - [DynamoRIO-ARM-Linux-EABIHF-7.0.0-RC1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_7_0_0_rc1/DynamoRIO-ARM-Linux-EABIHF-7.0.0-RC1.tar.gz)
-
-  - [DynamoRIO-ARM-Android-EABI-7.0.0-RC1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_7_0_0_rc1/DynamoRIO-ARM-Android-EABI-7.0.0-RC1.tar.gz)
-
-  - [DynamoRIO-AArch64-Linux-7.0.0-RC1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_7_0_0_rc1/DynamoRIO-AArch64-Linux-7.0.0-RC1.tar.gz)
 
 
 ***************************************************************************

--- a/api/docs/new_release.dox
+++ b/api/docs/new_release.dox
@@ -68,13 +68,13 @@ To create a new build:
 2. Click on "ci-package" on the list of workflows on the left.
 3. Click on "Run workflow" on the right.
 4. Select the branch.
-5. Fill in the version number.  For a test build or periodic build (i.e., not an official new-version-number release), use the current version major.minor and the date-based patchlevel.  The patchlevel can be found from CMake's configuration output by running `cmake .`:
+5. Fill in the version number.  For an official release, use three digits (e.g., '9.0.0'). For a test build or periodic build (i.e., not an official new-version-number release), use the current version major.minor and the date-based patchlevel.  The patchlevel can be found from CMake's configuration output by running `cmake .`:
 ```
 -- Version number: 8.0.18611
 ```
 For the build number, start at 0 for any given version number and add 1 for each attempt to produce a successful build.  If the build number is 0 it is not appended to the version number.
 
-Wait for the workflow to finish.  It should create a new tag, a new Release, upload 4 binary packages to the Release, and update the online documentation.
+Wait for the workflow to finish.  It should create a new tag, a new Release, and upload 5 binary packages to the Release.
 
 ## Update the Release Description
 
@@ -89,6 +89,16 @@ We generally edit the title to simplify it: e.g., from `release_8.0.0-1` to just
 ## Update api/docs/download.dox
 
 Make a new list of direct links for the new version at \ref page_releases.
+
+## Trigger a Docs Update
+
+1. Go to the Actions tab for the DynamoRIO/dynamorio repository.
+2. Click on "ci-docs" on the list of workflows on the left.
+3. Click on "Run workflow" on the right.
+4. Select the branch.
+5. Fill in the version number and build number to match that used for the package build.
+
+Wait for the workflow to finish.  It should update the online docs.
 
 ## Verify Package and Documentation Uploads
 

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -124,6 +124,13 @@ Dr. Memory Framework (DRMF) in the same package as DynamoRIO.  DRMF
 provides the umbra, drsyscall, and drsymcache Extensions for use by
 clients.
 
+The changes between version \DR_VERSION and 9.0.0 include the following compatibility
+changes:
+ - (Nothing so far: this is a placeholder.)
+
+Further non-compatibility-affecting changes include:
+ - (Nothing so far: this is a placeholder.)
+
 The changes between version \DR_VERSION and 8.0.0 include the following compatibility
 changes:
 

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -131,7 +131,7 @@ changes:
 Further non-compatibility-affecting changes include:
  - (Nothing so far: this is a placeholder.)
 
-The changes between version \DR_VERSION and 8.0.0 include the following compatibility
+The changes between version 9.0.0 and 8.0.0 include the following compatibility
 changes:
 
  - The AArch64 opcode enum ordering changed.


### PR DESCRIPTION
Updates the Download page to list the new 9.0.0 release.

Prepares the changelog for new post-9.0 changes.

Updates the New Release instructions for a separate docs step.

Fixes #5145