### PR TITLE
i#1807 long failures: List 8 long suite tests as flaky

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -49,6 +49,7 @@ use File::Basename;
 my $mydir = dirname(abs_path($0));
 my $is_CI = 0;
 my $is_aarchxx = $Config{archname} =~ /(aarch64)|(arm)/;
+my $is_long = $ENV{'CI_TRIGGER'} eq 'push' && $ENV{'CI_BRANCH'} eq 'refs/heads/master';
 
 # Forward args to runsuite.cmake:
 my $args = '';
@@ -263,7 +264,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'code_api|win32.x86_to_x64' => 1, # i#4617
                 'code_api|win32.x86_to_x64_ibl_opt' => 1, # i#4617
                 # These are from earlier runs on Appveyor:
-                'code_api|common.floatpc_xl8all' => 1,
+                'code_api|common.floatpc_xl8all' => 1, # i#2267
                 'code_api|win32.reload-newaddr' => 1,
                 'code_api|client.loader' => 1,
                 'code_api|client.drmgr-test' => 1, # i#1369
@@ -293,7 +294,15 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'checklevel|common.nativeexec' => 1, # i#1807
                 'finite_shared_bb_cache,cache_shared_bb_regen|common.nativeexec' => 1, # i#1807
                 'finite_shared_trace_cache,cache_shared_trace_regen|common.nativeexec' => 1, # i#1807
+                # We list this without any "options|" which will match all variations.
+                'common.floatpc_xl8all' => 1, # i#2267
                 );
+            if ($is_long) {
+                # These are important tests so we only ignore in the long suite,
+                # in an attempt to still detect fails-every-time breakage until we
+                # can reproduce and fix these failures while keeping merges green.
+                $ignore_failures_64{'code_api|tool.drcachesim.simple-config-file'} = 1; # i#1807
+            }
             $issue_no = "#2145";
         } elsif ($is_aarchxx) {
             # FIXME i#2416: fix flaky AArch32 tests
@@ -349,8 +358,9 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'code_api|linux.clone-reset' => 1, # i#4604
                 # These are from the long suite.
                 'common.decode-stress' => 1, # i#1807 Ignored for all options.
+                'code_api,opt_speed|common.fib' => 1, # i#1807: Undiagnosed timeout.
+                'prof_pcs|common.nativeexec_exe_opt' => 1, # i#2052
                 );
-            # FIXME i#2941: fix flaky threadfilter test
             %ignore_failures_64 = (
                 'code_api|tool.drcacheoff.burst_threadfilter' => 1, # i#2941
                 # These are from the long suite.
@@ -361,7 +371,16 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'common.nativeexec_retakeover_opt' => 1, # i#5010 Ignored for all options.
                 'common.nativeexec_exe' => 1, # i#5010 Ignored for all options.
                 'common.nativeexec_bindnow' => 1, # i#5010 Ignored for all options.
+                'code_api,opt_speed|common.floatpc_xl8all' => 1, # i#1807
                 );
+            if ($is_long) {
+                # These are important tests so we only ignore in the long suite,
+                # in an attempt to still detect fails-every-time breakage until we
+                # can reproduce and fix these failures while keeping merges green.
+                $ignore_failures_32{'code_api|api.startstop'} = 1; # i#4604
+                $ignore_failures_64{'code_api|api.detach_state'} = 1; # i#5123
+                $ignore_failures_64{'code_api|client.cleancallsig'} = 1; # i#1807
+            }
             $issue_no = "#2941";
         }
 


### PR DESCRIPTION
Adds the following tests to the ignore list in order to keep the long
suite on master merges greener:

+ win64 'common.floatpc_xl8all' #2267
+ win64 'code_api|tool.drcachesim.simple-config-file' #1807
+ lin32 'code_api,opt_speed|common.fib' #1807
+ lin32 'prof_pcs|common.nativeexec_exe_opt' #2052
+ lin64 'code_api,opt_speed|common.floatpc_xl8all' #1807

Only ignored in the long suite since these are tests we don't want to
completely break:

+ lin32 'code_api|api.startstop' #4604
+ lin64 'code_api|api.detach_state' #5123
+ lin64 'code_api|client.cleancallsig' #1807

Issue: #1807, #2267, #2052, #4604, #5123