### PR TITLE
Add alias support to droption

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -129,7 +129,7 @@ changes:
  - (Nothing so far: this is a placeholder.)
 
 Further non-compatibility-affecting changes include:
- - (Nothing so far: this is a placeholder.)
+ - Added alias support to droption.
 
 The changes between version 9.0.0 and 8.0.0 include the following compatibility
 changes:

--- a/ext/droption/droption.dox
+++ b/ext/droption/droption.dox
@@ -182,7 +182,9 @@ reports) listed first, like this:
 \code
 droption_t<std::string> op_blocklist(
     // We support the legacy name as an alias for compatibility.
-    DROPTION_SCOPE_CLIENT, { std::string("blocklist"), std::string("blacklist") },
+    // We explicitly specity the vector type to avoid ambiguity with iterators
+    // when we have just 2 elements in the list.
+    DROPTION_SCOPE_CLIENT, std::vector<std::string>({ "blocklist", "blacklist" }),
     IF_WINDOWS_ELSE("ntdll.dll", ""), ":-separated list of libs to ignore.",
     "The blocklist is a :-separated list of library names for which violations "
     "should not be reported.");

--- a/ext/droption/droption.dox
+++ b/ext/droption/droption.dox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.   All rights reserved.
+ * Copyright (c) 2015-2022 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -42,6 +42,7 @@ declaration and parsing for both clients and standalone programs.
  - \ref sec_droption_usage
  - \ref sec_droption_types
  - \ref sec_droption_html
+ - \ref sec_droption_aliases
 
 \section sec_droption_setup Setup
 
@@ -171,5 +172,20 @@ main(int argc, const char *argv[])
 This program can be built and run at documentation generation time to
 produce HTML that can then be embedded into Doxygen or other
 documentation.
+
+\section sec_droption_aliases Aliases
+
+To support multiple strings to trigger the same option, pass a vector
+of strings as the name, with the primary name (the one used in usage
+reports) listed first, like this:
+
+\code
+droption_t<std::string> op_blocklist(
+    // We support the legacy name as an alias for compatibility.
+    DROPTION_SCOPE_CLIENT, { std::string("blocklist"), std::string("blacklist") },
+    IF_WINDOWS_ELSE("ntdll.dll", ""), ":-separated list of libs to ignore.",
+    "The blocklist is a :-separated list of library names for which violations "
+    "should not be reported.");
+\endcode
 
 */

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -141,7 +141,23 @@ public:
     droption_parser_t(unsigned int scope, std::string name, std::string desc_short,
                       std::string desc_long, unsigned int flags)
         : scope_(scope)
-        , name_(name)
+        , names_(std::vector<std::string>(1, name))
+        , is_specified_(false)
+        , desc_short_(desc_short)
+        , desc_long_(desc_long)
+        , flags_(flags)
+    {
+        // We assume no synch is needed as this is a static initializer.
+        // XXX: any way to check/assert on that?
+        allops().push_back(this);
+        if (TESTANY(DROPTION_FLAG_SWEEP, flags_))
+            sweeper() = this;
+    }
+
+    droption_parser_t(unsigned int scope, std::vector<std::string> names,
+                      std::string desc_short, std::string desc_long, unsigned int flags)
+        : scope_(scope)
+        , names_(names)
         , is_specified_(false)
         , desc_short_(desc_short)
         , desc_long_(desc_long)
@@ -214,7 +230,8 @@ public:
                             ++i;
                         if (i == argc) {
                             if (error_msg != NULL)
-                                *error_msg = "Option " + op->name_ + " missing value";
+                                *error_msg =
+                                    "Option " + op->get_name() + " missing value";
                             res = false;
                             goto parse_finished;
                         }
@@ -225,8 +242,8 @@ public:
                                  !op->convert_from_string(argv[i - 1], argv[i])) ||
                                 !op->clamp_value()) {
                                 if (error_msg != NULL) {
-                                    *error_msg =
-                                        "Option " + op->name_ + " value out of range";
+                                    *error_msg = "Option " + op->get_name() +
+                                        " value out of range";
                                 }
                                 res = false;
                                 goto parse_finished;
@@ -239,8 +256,8 @@ public:
                                  !sweeper()->convert_from_string(argv[i - 1], argv[i])) ||
                                 !sweeper()->clamp_value()) {
                                 if (error_msg != NULL) {
-                                    *error_msg =
-                                        "Option " + op->name_ + " value out of range";
+                                    *error_msg = "Option " + op->get_name() +
+                                        " value out of range";
                                 }
                                 res = false;
                                 goto parse_finished;
@@ -277,7 +294,7 @@ public:
             droption_parser_t *op = *opi;
             if (!TESTALL(DROPTION_FLAG_INTERNAL, op->flags_) &&
                 TESTANY(scope, op->scope_)) {
-                oss << " -" << std::setw(20) << std::left << op->name_ << "["
+                oss << " -" << std::setw(20) << std::left << op->get_name() << "["
                     << std::setw(6) << std::right << op->default_as_string() << "]"
                     << "  " << std::left << op->desc_short_ << std::endl;
             }
@@ -303,7 +320,7 @@ public:
             // XXX: we should also add the min and max values
             if (!TESTALL(DROPTION_FLAG_INTERNAL, op->flags_) &&
                 TESTANY(scope, op->scope_)) {
-                oss << pre_name << "-" << op->name_ << post_name << pre_value
+                oss << pre_name << "-" << op->get_name() << post_name << pre_value
                     << "default value: " << op->default_as_string() << post_value
                     << pre_desc << op->desc_long_ << post_desc << std::endl;
             }
@@ -321,7 +338,7 @@ public:
     std::string
     get_name()
     {
-        return name_;
+        return names_[0];
     }
 
 protected:
@@ -355,7 +372,7 @@ protected:
     }
 
     unsigned int scope_; // made up of droption_scope_t bitfields
-    std::string name_;
+    std::vector<std::string> names_;
     bool is_specified_;
     std::string desc_short_;
     std::string desc_long_;
@@ -416,6 +433,68 @@ public:
     droption_t(unsigned int scope, std::string name, T defval, T minval, T maxval,
                std::string desc_short, std::string desc_long)
         : droption_parser_t(scope, name, desc_short, desc_long, 0)
+        , value_(defval)
+        , defval_(defval)
+        , valsep_(DROPTION_DEFAULT_VALUE_SEP)
+        , has_range_(true)
+        , minval_(minval)
+        , maxval_(maxval)
+    {
+    }
+
+    /**
+     * Declares a new option of type T with the given scope, list of alternative names,
+     * default value, and description in short and long forms.
+     */
+    droption_t(unsigned int scope, std::vector<std::string> names, T defval,
+               std::string desc_short, std::string desc_long)
+        : droption_parser_t(scope, names, desc_short, desc_long, 0)
+        , value_(defval)
+        , defval_(defval)
+        , valsep_(DROPTION_DEFAULT_VALUE_SEP)
+        , has_range_(false)
+    {
+    }
+
+    /**
+     * Declares a new option of type T with the given scope, list of alternative names,
+     * behavior flags, default value, and description in short and long forms.
+     */
+    droption_t(unsigned int scope, std::vector<std::string> names, unsigned int flags,
+               T defval, std::string desc_short, std::string desc_long)
+        : droption_parser_t(scope, names, desc_short, desc_long, flags)
+        , value_(defval)
+        , defval_(defval)
+        , valsep_(DROPTION_DEFAULT_VALUE_SEP)
+        , has_range_(false)
+    {
+    }
+
+    /**
+     * Declares a new option of type T with the given scope, list of alternative names,
+     * behavior flags,
+     * accumulated value separator (see #DROPTION_FLAG_ACCUMULATE), default value, and
+     * description in short and long forms. The first listed name is considered the
+     * primary name; the others are aliases.
+     */
+    droption_t(unsigned int scope, std::vector<std::string> names, unsigned int flags,
+               std::string valsep, T defval, std::string desc_short,
+               std::string desc_long)
+        : droption_parser_t(scope, names, desc_short, desc_long, 0)
+        , value_(defval)
+        , defval_(defval)
+        , valsep_(DROPTION_DEFAULT_VALUE_SEP)
+        , has_range_(false)
+    {
+    }
+
+    /**
+     * Declares a new option of type T with the given scope, list of alternative names,
+     * default value, minimum and maximum values, and description in short and long forms.
+     */
+    droption_t(unsigned int scope, std::vector<std::string> names, T defval, T minval,
+               T maxval, std::string desc_short, std::string desc_long)
+        : droption_parser_t(scope, names, desc_short, desc_long, 0)
         , value_(defval)
         , defval_(defval)
         , valsep_(DROPTION_DEFAULT_VALUE_SEP)
@@ -515,23 +594,31 @@ template <typename T>
 inline bool
 droption_t<T>::name_match(const char *arg)
 {
-    return (std::string("-").append(name_) == arg ||
-            std::string("--").append(name_) == arg);
+    for (const auto &name : names_) {
+        if (std::string("-").append(name) == arg || std::string("--").append(name) == arg)
+            return true;
+    }
+    return false;
 }
 template <>
 inline bool
 droption_t<bool>::name_match(const char *arg)
 {
-    if (std::string("-").append(name_) == arg || std::string("--").append(name_) == arg) {
-        value_ = true;
-        return true;
+    for (const auto &name : names_) {
+        if (std::string("-").append(name) == arg ||
+            std::string("--").append(name) == arg) {
+            value_ = true;
+            return true;
+        }
     }
-    if (std::string("-no").append(name_) == arg ||
-        std::string("-no_").append(name_) == arg ||
-        std::string("--no").append(name_) == arg ||
-        std::string("--no_").append(name_) == arg) {
-        value_ = false;
-        return true;
+    for (const auto &name : names_) {
+        if (std::string("-no").append(name) == arg ||
+            std::string("-no_").append(name) == arg ||
+            std::string("--no").append(name) == arg ||
+            std::string("--no_").append(name) == arg) {
+            value_ = false;
+            return true;
+        }
     }
     return false;
 }

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -229,9 +229,10 @@ public:
                         if (op->option_takes_2args() && i < argc)
                             ++i;
                         if (i == argc) {
-                            if (error_msg != NULL)
+                            if (error_msg != NULL) {
                                 *error_msg =
                                     "Option " + op->get_name() + " missing value";
+                            }
                             res = false;
                             goto parse_finished;
                         }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2021 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2022 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # Copyright (c) 2016      ARM Limited.    All rights reserved.
 # **********************************************************

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2532,7 +2532,7 @@ torunonly_ci(client.blackbox ${ci_shared_app} client.blackbox.dll.A
   "" "" "")
 
 tobuild_ci(client.option_parse client-interface/option_parse.cpp
-  "-l;-4;-ll;-3220721071790640321;-ul;4;-ull;1384772493926445887;-x;4;-y;quoted string;-z;first;-z;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-no_flag;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4;-large_bytesize;9999999999"
+  "-l;-4;-ll;-3220721071790640321;-ul;4;-ull;1384772493926445887;-x;3;-x_alias;4;-y;quoted string;-z;first;-z_alias;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-no_flag;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4;-large_bytesize;9999999999"
   "" "")
 use_DynamoRIO_extension(client.option_parse.dll droption)
 set(client.option_parse_client_ops_islist ON)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2532,7 +2532,7 @@ torunonly_ci(client.blackbox ${ci_shared_app} client.blackbox.dll.A
   "" "" "")
 
 tobuild_ci(client.option_parse client-interface/option_parse.cpp
-  "-l;-4;-ll;-3220721071790640321;-ul;4;-ull;1384772493926445887;-x;3;-x_alias;4;-y;quoted string;-z;first;-z_alias;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-no_flag;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4;-large_bytesize;9999999999"
+  "-l;-4;-ll;-3220721071790640321;-ul;4;-ull;1384772493926445887;-x;3;-x_alias;4;-y;quoted string;-z;first;-z_alias;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-flag;-flag_alias1;-no_flag_alias2;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4;-large_bytesize;9999999999"
   "" "")
 use_DynamoRIO_extension(client.option_parse.dll droption)
 set(client.option_parse_client_ops_islist ON)

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -47,13 +47,13 @@ static droption_t<unsigned long> op_ul(DROPTION_SCOPE_CLIENT, "ul", 0UL, 0, 64,
 static droption_t<unsigned long long> op_ull(DROPTION_SCOPE_CLIENT, "ull", 0ULL,
                                              "Some param", "Longer desc of some param.");
 static droption_t<unsigned int> op_x(DROPTION_SCOPE_CLIENT,
-                                     { std::string("x"), std::string("x_alias") }, 0, 0,
+                                     std::vector<std::string>({ "x", "x_alias" }), 0, 0,
                                      64, "Some param", "Longer desc of some param.");
 static droption_t<std::string> op_y(DROPTION_SCOPE_CLIENT, "y", DROPTION_FLAG_ACCUMULATE,
                                     "<default>", "Another param",
                                     "Longer desc of another param.");
 static droption_t<std::string> op_z(DROPTION_SCOPE_CLIENT,
-                                    { std::string("z"), std::string("z_alias") }, "",
+                                    std::vector<std::string>({ "z", "z_alias" }), "",
                                     "Yet another param",
                                     "Longer desc of yet another param.");
 static droption_t<int> op_foo(DROPTION_SCOPE_CLIENT, "foo", 8, "Missing param",

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -61,8 +61,9 @@ static droption_t<int> op_foo(DROPTION_SCOPE_CLIENT, "foo", 8, "Missing param",
 static droption_t<std::string> op_bar(DROPTION_SCOPE_CLIENT, "bar",
                                       "some string with spaces", "Missing string param",
                                       "Longer desc of missing string param.");
-static droption_t<bool> op_flag(DROPTION_SCOPE_CLIENT, "flag", true, "Bool param",
-                                "Longer desc of bool param.");
+static droption_t<bool> op_flag(DROPTION_SCOPE_CLIENT,
+                                { "flag", "flag_alias1", "flag_alias2" }, true,
+                                "Bool param", "Longer desc of bool param.");
 static droption_t<std::string> op_sweep(DROPTION_SCOPE_CLIENT, "sweep",
                                         DROPTION_FLAG_SWEEP | DROPTION_FLAG_ACCUMULATE,
                                         "", "All the unknown params",
@@ -94,7 +95,7 @@ static droption_t<bytesize_t>
 static void
 test_argv(int argc, const char *argv[])
 {
-    ASSERT(argc == 44);
+    ASSERT(argc == 46);
 
     int i = 1;
     ASSERT(strcmp(argv[i++], "-l") == 0);
@@ -121,7 +122,9 @@ test_argv(int argc, const char *argv[])
     ASSERT(strcmp(argv[i++], "accum") == 0);
     ASSERT(strcmp(argv[i++], "-front2") == 0);
     ASSERT(strcmp(argv[i++], "value2") == 0);
-    ASSERT(strcmp(argv[i++], "-no_flag") == 0);
+    ASSERT(strcmp(argv[i++], "-flag") == 0);
+    ASSERT(strcmp(argv[i++], "-flag_alias1") == 0);
+    ASSERT(strcmp(argv[i++], "-no_flag_alias2") == 0);
     ASSERT(strcmp(argv[i++], "-takes2") == 0);
     ASSERT(strcmp(argv[i++], "1_of_4") == 0);
     ASSERT(strcmp(argv[i++], "2_of_4") == 0);

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -46,8 +46,9 @@ static droption_t<unsigned long> op_ul(DROPTION_SCOPE_CLIENT, "ul", 0UL, 0, 64,
                                        "Some param", "Longer desc of some param.");
 static droption_t<unsigned long long> op_ull(DROPTION_SCOPE_CLIENT, "ull", 0ULL,
                                              "Some param", "Longer desc of some param.");
-static droption_t<unsigned int> op_x(DROPTION_SCOPE_CLIENT, "x", 0, 0, 64, "Some param",
-                                     "Longer desc of some param.");
+static droption_t<unsigned int> op_x(DROPTION_SCOPE_CLIENT,
+                                     { std::string("x"), std::string("x_alias") }, 0, 0,
+                                     64, "Some param", "Longer desc of some param.");
 static droption_t<std::string> op_y(DROPTION_SCOPE_CLIENT, "y", DROPTION_FLAG_ACCUMULATE,
                                     "<default>", "Another param",
                                     "Longer desc of another param.");

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -51,7 +51,9 @@ static droption_t<unsigned int> op_x(DROPTION_SCOPE_CLIENT, "x", 0, 0, 64, "Some
 static droption_t<std::string> op_y(DROPTION_SCOPE_CLIENT, "y", DROPTION_FLAG_ACCUMULATE,
                                     "<default>", "Another param",
                                     "Longer desc of another param.");
-static droption_t<std::string> op_z(DROPTION_SCOPE_CLIENT, "z", "", "Yet another param",
+static droption_t<std::string> op_z(DROPTION_SCOPE_CLIENT,
+                                    { std::string("z"), std::string("z_alias") }, "",
+                                    "Yet another param",
                                     "Longer desc of yet another param.");
 static droption_t<int> op_foo(DROPTION_SCOPE_CLIENT, "foo", 8, "Missing param",
                               "Longer desc of missing param.");
@@ -91,49 +93,52 @@ static droption_t<bytesize_t>
 static void
 test_argv(int argc, const char *argv[])
 {
-    ASSERT(argc == 42);
+    ASSERT(argc == 44);
 
-    ASSERT(strcmp(argv[1], "-l") == 0);
-    ASSERT(strcmp(argv[2], "-4") == 0);
-    ASSERT(strcmp(argv[3], "-ll") == 0);
-    ASSERT(strcmp(argv[4], "-3220721071790640321") == 0);
-    ASSERT(strcmp(argv[5], "-ul") == 0);
-    ASSERT(strcmp(argv[6], "4") == 0);
-    ASSERT(strcmp(argv[7], "-ull") == 0);
-    ASSERT(strcmp(argv[8], "1384772493926445887") == 0);
-    ASSERT(strcmp(argv[9], "-x") == 0);
-    ASSERT(strcmp(argv[10], "4") == 0);
-    ASSERT(strcmp(argv[11], "-y") == 0);
-    ASSERT(strcmp(argv[12], "quoted string") == 0);
-    ASSERT(strcmp(argv[13], "-z") == 0);
-    ASSERT(strcmp(argv[14], "first") == 0);
-    ASSERT(strcmp(argv[15], "-z") == 0);
-    ASSERT(strcmp(argv[16], "single quotes -dash --dashes") == 0);
-    ASSERT(strcmp(argv[17], "-front") == 0);
-    ASSERT(strcmp(argv[18], "value") == 0);
-    ASSERT(strcmp(argv[19], "-y") == 0);
-    ASSERT(strcmp(argv[20], "accum") == 0);
-    ASSERT(strcmp(argv[21], "-front2") == 0);
-    ASSERT(strcmp(argv[22], "value2") == 0);
-    ASSERT(strcmp(argv[23], "-no_flag") == 0);
-    ASSERT(strcmp(argv[24], "-takes2") == 0);
-    ASSERT(strcmp(argv[25], "1_of_4") == 0);
-    ASSERT(strcmp(argv[26], "2_of_4") == 0);
-    ASSERT(strcmp(argv[27], "-takes2") == 0);
-    ASSERT(strcmp(argv[28], "3_of_4") == 0);
-    ASSERT(strcmp(argv[29], "4_of_4") == 0);
-    ASSERT(strcmp(argv[30], "-val_sep") == 0);
-    ASSERT(strcmp(argv[31], "v1.1 v1.2") == 0);
-    ASSERT(strcmp(argv[32], "-val_sep") == 0);
-    ASSERT(strcmp(argv[33], "v2.1 v2.2") == 0);
-    ASSERT(strcmp(argv[34], "-val_sep2") == 0);
-    ASSERT(strcmp(argv[35], "v1") == 0);
-    ASSERT(strcmp(argv[36], "v2") == 0);
-    ASSERT(strcmp(argv[37], "-val_sep2") == 0);
-    ASSERT(strcmp(argv[38], "v3") == 0);
-    ASSERT(strcmp(argv[39], "v4") == 0);
-    ASSERT(strcmp(argv[40], "-large_bytesize") == 0);
-    ASSERT(strcmp(argv[41], "9999999999") == 0);
+    int i = 1;
+    ASSERT(strcmp(argv[i++], "-l") == 0);
+    ASSERT(strcmp(argv[i++], "-4") == 0);
+    ASSERT(strcmp(argv[i++], "-ll") == 0);
+    ASSERT(strcmp(argv[i++], "-3220721071790640321") == 0);
+    ASSERT(strcmp(argv[i++], "-ul") == 0);
+    ASSERT(strcmp(argv[i++], "4") == 0);
+    ASSERT(strcmp(argv[i++], "-ull") == 0);
+    ASSERT(strcmp(argv[i++], "1384772493926445887") == 0);
+    ASSERT(strcmp(argv[i++], "-x") == 0);
+    ASSERT(strcmp(argv[i++], "3") == 0);
+    ASSERT(strcmp(argv[i++], "-x_alias") == 0);
+    ASSERT(strcmp(argv[i++], "4") == 0);
+    ASSERT(strcmp(argv[i++], "-y") == 0);
+    ASSERT(strcmp(argv[i++], "quoted string") == 0);
+    ASSERT(strcmp(argv[i++], "-z") == 0);
+    ASSERT(strcmp(argv[i++], "first") == 0);
+    ASSERT(strcmp(argv[i++], "-z_alias") == 0);
+    ASSERT(strcmp(argv[i++], "single quotes -dash --dashes") == 0);
+    ASSERT(strcmp(argv[i++], "-front") == 0);
+    ASSERT(strcmp(argv[i++], "value") == 0);
+    ASSERT(strcmp(argv[i++], "-y") == 0);
+    ASSERT(strcmp(argv[i++], "accum") == 0);
+    ASSERT(strcmp(argv[i++], "-front2") == 0);
+    ASSERT(strcmp(argv[i++], "value2") == 0);
+    ASSERT(strcmp(argv[i++], "-no_flag") == 0);
+    ASSERT(strcmp(argv[i++], "-takes2") == 0);
+    ASSERT(strcmp(argv[i++], "1_of_4") == 0);
+    ASSERT(strcmp(argv[i++], "2_of_4") == 0);
+    ASSERT(strcmp(argv[i++], "-takes2") == 0);
+    ASSERT(strcmp(argv[i++], "3_of_4") == 0);
+    ASSERT(strcmp(argv[i++], "4_of_4") == 0);
+    ASSERT(strcmp(argv[i++], "-val_sep") == 0);
+    ASSERT(strcmp(argv[i++], "v1.1 v1.2") == 0);
+    ASSERT(strcmp(argv[i++], "-val_sep") == 0);
+    ASSERT(strcmp(argv[i++], "v2.1 v2.2") == 0);
+    ASSERT(strcmp(argv[i++], "-val_sep2") == 0);
+    ASSERT(strcmp(argv[i++], "v1") == 0);
+    ASSERT(strcmp(argv[i++], "v2") == 0);
+    ASSERT(strcmp(argv[i++], "-val_sep2") == 0);
+    ASSERT(strcmp(argv[i++], "v3") == 0);
+    ASSERT(strcmp(argv[i++], "v4") == 0);
+    ASSERT(strcmp(argv[i++], "-large_bytesize") == 0);
+    ASSERT(strcmp(argv[i++], "9999999999") == 0);
 }
 
 DR_EXPORT void


### PR DESCRIPTION
Adds support for multiple names for one option.
Adds a simple test.

This is needed for renaming a drcpusim option while keeping legacy
support for #4366.

Issue: #4366