### PR TITLE
i#3805 msvc2019: add support for Microsoft Visual Studio 2019 and Tools for Visual Studio 2019

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -40,7 +40,7 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, reopened, synchroni]
+    types: [opened, reopened, synchronize]
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -40,7 +40,7 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchroni]
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:
@@ -246,7 +246,7 @@ jobs:
         from: Github Action CI
 
   ###########################################################################
-  # 32-bit and 64-bit VS2019 release builds:
+  # 32-bit and 64-bit VS2019 debug builds:
   vs2019-builds:
     runs-on: windows-2019
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -244,3 +244,68 @@ jobs:
           See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
         to: dynamorio-devs@googlegroups.com
         from: Github Action CI
+
+  ###########################################################################
+  # 32-bit and 64-bit VS2019 release builds:
+  vs2019-builds:
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
+
+    - name: Fetch Sources
+      run: git fetch --no-tags --depth=1 origin master
+
+    - name: Download Packages
+      shell: powershell
+      run: |
+        md c:\projects\install
+        (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip", "c:\projects\install\ninja.zip")
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
+
+    - name: Run Suite
+      working-directory: ${{ github.workspace }}
+      run: |
+        echo ------ Setting up paths ------
+        7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
+        set PATH=c:\projects\install\ninja;%PATH%
+        7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
+        set PATH=c:\projects\install\doxygen;%PATH%
+        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        echo ------ Running suite ------
+        echo PATH is "%PATH%"
+        echo Running in directory "%CD%"
+        perl suite/runsuite_wrapper.pl automated_ci use_ninja debug_only build_only
+      env:
+        CI_TRIGGER: ${{ github.event_name }}
+        CI_BRANCH: ${{ github.ref }}
+
+    - name: Send failure mail to dynamorio-devs
+      if: failure() && github.ref == 'refs/heads/master'
+      uses: dawidd6/action-send-mail@v2
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+        subject: |
+          [${{github.repository}}] ${{github.workflow}} FAILED
+          on ${{github.event_name}} at ${{github.ref}}
+        body: |
+          Github Actions CI workflow run FAILED!
+          Workflow: ${{github.workflow}}/vs2017-builds
+          Repository: ${{github.repository}}
+          Branch ref: ${{github.ref}}
+          SHA: ${{github.sha}}
+          Triggering actor: ${{github.actor}}
+          Triggering event: ${{github.event_name}}
+          Run Id: ${{github.run_id}}
+          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+        to: dynamorio-devs@googlegroups.com
+        from: Github Action CI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,29 +649,7 @@ else (UNIX)
     message(FATAL_ERROR "cl (Microsoft C++ compiler) is required to build")
   endif (NOT ${COMPILER_BASE_NAME} STREQUAL "cl")
 
-  # CMake older than 2.6.3 does not automatically look for ml or ml64
-  if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
-    # CMAKE_C_COMPILER doesn't have full path, unless user has in PATH
-    if (MSVC10)
-      get_filename_component(vc_dir [HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\10.0\\Setup\\VC;ProductDir] REALPATH)
-    elseif (MSVC90)
-      get_filename_component(vc_dir [HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\9.0\\Setup\\VC;ProductDir] REALPATH)
-    elseif (MSVC80)
-      get_filename_component(vc_dir [HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\8.0\\Setup\\VC;ProductDir] REALPATH)
-    endif()
-    if (X64)
-      set(cl_path "${vc_dir}/bin/amd64")
-    else (X64)
-      set(cl_path "${vc_dir}/bin")
-    endif (X64)
-    # while we can get the cl path, we can't run cl b/c mspdb80.dll must
-    # be on the PATH: so even w/ VS generators we require PATH to be set.
-    if ("${CMAKE_C_COMPILER}" STREQUAL "cl")
-      set(CMAKE_C_COMPILER "${cl_path}/${CMAKE_C_COMPILER}")
-    endif ()
-  else ()
-    get_filename_component(cl_path ${CMAKE_C_COMPILER} PATH)
-  endif ()
+  get_filename_component(cl_path ${CMAKE_C_COMPILER} PATH)
 
   # cmake has CMAKE_RC_COMPILER, but no message compiler
   if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,6 +596,16 @@ if (UNIX)
   check_avx512_processor_and_compiler_support(proc_supports_avx512)
 endif ()
 
+# Ensure that _AMD64_ or _X86_ are defined on Microsoft Windows, as otherwise
+# um/winnt.h provided since Windows 10.0.22000 will error.
+if (NOT UNIX)
+  if (X64)
+    add_definitions(-D_AMD64_)
+  else (X64)
+    add_definitions(-D_X86_)
+  endif (X64)
+endif (NOT UNIX)
+
 # Set up assembly support and CMAKE_CPP.
 # Note that in cmake < 2.6.4, I had to fix a bug in
 # /usr/share/cmake/Modules/CMakeASMInformation.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -653,14 +653,25 @@ else (UNIX)
 
   # cmake has CMAKE_RC_COMPILER, but no message compiler
   if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
-    # this path is only present for 2008+, but we currently require PATH to
-    # be set up anyway
-    get_filename_component(sdk_dir "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows;CurrentInstallFolder]" REALPATH)
-    if (X64)
-      set(sdk_bindir "${sdk_dir}/bin/x64")
-    else (X64)
-      set(sdk_bindir "${sdk_dir}/bin")
-    endif (X64)
+    # First checks for the Windows SDK through Windows Kits.
+    get_filename_component(kits_dir "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]" REALPATH)
+
+    if (EXISTS ${kits_dir})
+      if (X64)
+        set(sdk_bindir "${kits_dir}/bin/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/x64")
+      else (X64)
+        set(sdk_bindir "${kits_dir}/bin/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/x86")
+      endif (X64)
+    else (EXISTS ${kits_dir})
+      # this path is only present for 2008+, but we currently require PATH to
+      # be set up anyway
+      get_filename_component(sdk_dir "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows;CurrentInstallFolder]" REALPATH)
+      if (X64)
+        set(sdk_bindir "${sdk_dir}/bin/x64")
+      else (X64)
+        set(sdk_bindir "${sdk_dir}/bin")
+      endif (X64)
+    endif (EXISTS ${kits_dir})
   endif ()
   if (NOT ("${CMAKE_GENERATOR}" MATCHES "MSYS Makefiles"))
     # For MinGW (MSYS Makefiles) we do not have a message compiler.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -602,6 +602,10 @@ endif ()
 # where @VAR@ expansion was used, which only works for configure_file()
 #   now fixed in CMake/Modules/CMakeASMInformation.cmake:1.5
 # See top of top-level CMakeLists.txt for our workaround.
+if (NOT UNIX)
+  get_filename_component(cl_path ${CMAKE_C_COMPILER} PATH)
+endif (NOT UNIX)
+
 set(cpp2asm_newline_script_path "${PROJECT_SOURCE_DIR}/make/CMake_asm.cmake")
 include(make/cpp2asm_support.cmake)
 if (UNIX)
@@ -648,8 +652,6 @@ else (UNIX)
     # we use cl pragmas and intrinsics
     message(FATAL_ERROR "cl (Microsoft C++ compiler) is required to build")
   endif (NOT ${COMPILER_BASE_NAME} STREQUAL "cl")
-
-  get_filename_component(cl_path ${CMAKE_C_COMPILER} PATH)
 
   # cmake has CMAKE_RC_COMPILER, but no message compiler
   if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -757,7 +757,7 @@ else (UNIX)
   set_target_properties(dynamorio PROPERTIES LINK_FLAGS "${dynamorio_link_flags}")
 
   # ensure there are no dependencies other than ntdll
-  find_program(DUMPBIN_EXECUTABLE dumpbin.exe DOC "path to dumpbin.exe")
+  find_program(DUMPBIN_EXECUTABLE dumpbin.exe HINTS "${cl_path}" DOC "path to dumpbin.exe")
   if (DUMPBIN_EXECUTABLE)
     add_custom_command(TARGET dynamorio
       POST_BUILD

--- a/ext/drsyms/CMakeLists.txt
+++ b/ext/drsyms/CMakeLists.txt
@@ -70,7 +70,7 @@ set(DynamoRIO_USE_LIBC ON)
 if (WIN32)
   # XXX: if we add any more of these .lib files we should share this code
   # (currently we have make/ntdll_imports.cmake and here).
-  find_program(LIB_EXECUTABLE lib.exe DOC "path to lib.exe")
+  find_program(LIB_EXECUTABLE lib.exe HINTS "${cl_path}" DOC "path to lib.exe")
   if (NOT LIB_EXECUTABLE)
     message(FATAL_ERROR "Cannot find lib.exe")
   endif (NOT LIB_EXECUTABLE)

--- a/tools/DRstats/CMakeLists.txt
+++ b/tools/DRstats/CMakeLists.txt
@@ -105,16 +105,10 @@ add_executable(DRstats WIN32
 # somehow VS2010 doesn't find its own SDK uuid.lib
 find_library(uuid_lib uuid)
 if (NOT uuid_lib)
-  # VS2012 doesn't either; nor does find_library find it
-  # XXX: put in more general solution
   if (X64)
-    set(uuid_lib "c:/Program Files (x86)/Windows Kits/8.0/Lib/win8/um/x64/Uuid.Lib")
+    set(uuid_lib "${kits_dir}/Lib/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/um/x64/Uuid.Lib")
   else (X64)
-    set(uuid_lib "c:/Program Files (x86)/Windows Kits/8.0/Lib/win8/um/x86/Uuid.Lib")
-    if (NOT EXISTS ${uuid_lib})
-      # Probably we are in 32-bit Windows which doesn't have "Program Files (x86)" folder
-      set(uuid_lib "c:/Program Files/Windows Kits/8.0/Lib/win8/um/x86/Uuid.Lib")
-    endif ()
+    set(uuid_lib "${kits_dir}/Lib/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/um/x86/Uuid.Lib")
   endif (X64)
   if (NOT EXISTS ${uuid_lib})
     message(FATAL_ERROR "uuid.lib not found")


### PR DESCRIPTION
This addresses issue #3805 as follows:

- Remove old detection code for CMake versions older than 2.6.3 to detect `cl_path`. This was hindering CMake from finding the correct `cl_path`.
- Ensure `cl_path` is defined before `cpp2asm_support.cmake` gets included, such that `ml.exe` and `ml64.exe` for x86 and x64 respectively are found in the correct path.
- Specify `cl_path` as a hint when trying to find `lib.exe` and `dumpbin.exe`.
- The Windows SDK that is being used may be installed into `C:\Program Files (x86)\Windows Kits\10`, of which the installation path is covered by a different registry key, namely `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows Kits\Installed Roots\KitsRoot10`. Check if the registry key points to an existing path, and use it as `kits_dir` if it does and then use that to derive the correct `sdk_bindir`. Otherwise fall back to the old method of detecting `sdk_bin` and `sdk_bindir`.
- When MFC is installed, this will try building drstats. Since drstats has hardcoded paths to `Uuid.Lib`, we now simply use `kits_dir` to specify the correct path to `Uuid.Lib`.

I have tested this with Tools for Visual Studio 2019 as follows:

```
git clone https://github.com/StephanvanSchaik/dynamorio -b i3805-msvc2019
cd dynamorio
mkdir build
cd build
cmake ..
cmd.exe
call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" amd64
msbuild.exe DynamoRIO.sln
```

This builds everything successfully. However, do note that you should not have Windows 11 SDK (version 10.0.22000.0) installed. Trying to build DynamoRIO against the Windows 11 SDK will fail with rc.exe emitting error RC2188 due to line 253 in `C:\Program Files (x86)\Windows Kits\10\Include\10.0.22000.0\um\winnt.h`. See also: https://bugs.python.org/issue45220 (EDIT: the fix for this is to ensure `_AMD64_` or `_X86_` are defined when building).