### PR TITLE
i#4532: aarch64 decode: remove incorrect clrex todo

### DIFF
--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -844,8 +844,9 @@
  * Creates a CLREX instruction.
  * \param dc   The void * dcontext used to allocate memory for the instr_t.
  */
-/* TODO i#4532: Remove this superfluous operand. */
-#define INSTR_CREATE_clrex(dc) instr_create_0dst_1src(dc, OP_clrex, OPND_CREATE_INT(0))
+#define INSTR_CREATE_clrex(dc) instr_create_0dst_1src(dc, OP_clrex, OPND_CREATE_INT(15))
+#define INSTR_CREATE_clrex_imm(dc, imm) instr_create_0dst_1src(dc, OP_clrex, OPND_CREATE_INT(imm))
+
 
 /* FIXME i#1569: these two should perhaps not be provided */
 #define INSTR_CREATE_add_shimm(dc, rd, rn, rm_or_imm, sht, sha) \

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -845,8 +845,8 @@
  * \param dc   The void * dcontext used to allocate memory for the instr_t.
  */
 #define INSTR_CREATE_clrex(dc) instr_create_0dst_1src(dc, OP_clrex, OPND_CREATE_INT(15))
-#define INSTR_CREATE_clrex_imm(dc, imm) instr_create_0dst_1src(dc, OP_clrex, OPND_CREATE_INT(imm))
-
+#define INSTR_CREATE_clrex_imm(dc, imm) \
+    instr_create_0dst_1src(dc, OP_clrex, OPND_CREATE_INT(imm))
 
 /* FIXME i#1569: these two should perhaps not be provided */
 #define INSTR_CREATE_add_shimm(dc, rd, rn, rm_or_imm, sht, sha) \

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -5515,6 +5515,10 @@ test_exclusive_memops(void *dc)
     instr = INSTR_CREATE_clrex(dc);
     ASSERT(!instr_is_exclusive_store(instr) && !instr_is_exclusive_load(instr));
     test_instr_encoding(dc, OP_clrex, instr);
+
+    instr = INSTR_CREATE_clrex_imm(dc, 2);
+    ASSERT(!instr_is_exclusive_store(instr) && !instr_is_exclusive_load(instr));
+    test_instr_encoding(dc, OP_clrex, instr);
 }
 
 static void

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -1142,7 +1142,8 @@ stlxr  %x0 -> (%x1)[8byte] %w2
 stlxrb %w0 -> (%x1)[1byte] %w2
 stlxrh %w0 -> (%x1)[2byte] %w2
 stlxp  %w0 %w1 -> (%x2)[8byte] %w3
-clrex  $0x0000000000000000
+clrex  $0x000000000000000f
+clrex  $0x0000000000000002
 test_exclusive_memops complete
 ldp    (%x2)[8byte] -> %w0 %w1
 stp    %w0 %w1 -> (%x2)[8byte]


### PR DESCRIPTION
This patch removes the TODO note for clrex which stated it had a superfluous
operand. The spec states that it is a real operand but is ignored and defaults
to a value of 15. The instr_create.h macros have been updated to reflect this.

Fixes: #4532 