### PR TITLE
i#3348 sym conflicts: Rename set_cache_size to proc_set_cache_size

### DIFF
--- a/core/arch/proc.h
+++ b/core/arch/proc.h
@@ -102,7 +102,7 @@ void
 proc_init_arch(void);
 
 void
-set_cache_size(uint val, uint *dst);
+proc_set_cache_size(uint val, uint *dst);
 
 #ifdef AARCHXX
 uint

--- a/core/arch/proc_shared.c
+++ b/core/arch/proc_shared.c
@@ -78,7 +78,7 @@ cpu_info_t cpu_info = { VENDOR_UNKNOWN,
                         { 0x6e6b6e75, 0x006e776f } };
 
 void
-set_cache_size(uint val, uint *dst)
+proc_set_cache_size(uint val, uint *dst)
 {
     CLIENT_ASSERT(dst != NULL, "invalid internal param");
     switch (val) {

--- a/core/arch/x86/proc.c
+++ b/core/arch/x86/proc.c
@@ -90,13 +90,13 @@ get_cache_sizes_amd(uint max_ext_val)
 
     if (max_ext_val >= 0x80000005) {
         our_cpuid((int *)cpuid_res_local, 0x80000005, 0);
-        set_cache_size((cpuid_res_local[2] /*ecx*/ >> 24), &cpu_info.L1_icache_size);
-        set_cache_size((cpuid_res_local[3] /*edx*/ >> 24), &cpu_info.L1_dcache_size);
+        proc_set_cache_size((cpuid_res_local[2] /*ecx*/ >> 24), &cpu_info.L1_icache_size);
+        proc_set_cache_size((cpuid_res_local[3] /*edx*/ >> 24), &cpu_info.L1_dcache_size);
     }
 
     if (max_ext_val >= 0x80000006) {
         our_cpuid((int *)cpuid_res_local, 0x80000006, 0);
-        set_cache_size((cpuid_res_local[2] /*ecx*/ >> 16), &cpu_info.L2_cache_size);
+        proc_set_cache_size((cpuid_res_local[2] /*ecx*/ >> 16), &cpu_info.L2_cache_size);
     }
 }
 


### PR DESCRIPTION
Fixes a symbol conflict with a python package PyTables that is hit
when statically linking with certain toolchains where non-exported
symbol hiding is not available.  The fix is to rename set_cache_size()
to proc_set_cache_size().  This also matches the proc_ prefix for
related functions, so we do not resort to the d_r_ prefix.

Issue: #3348