### PR TITLE
i#2626: AArch64 v8 decode: Add validating tests for GPR instructions

### DIFF
--- a/suite/tests/api/dis-a64.c
+++ b/suite/tests/api/dis-a64.c
@@ -195,7 +195,10 @@ do_line(void *dc, const char *line, size_t len, bool verbose, bool *failed)
 int
 run_test(void *dc, const char *file, bool verbose)
 {
+    bool test_failed = false;
     bool failed = false;
+    int failures = 0;
+    int lines = 0;
     byte *map_base;
     size_t map_size;
     byte *s, *end;
@@ -208,10 +211,19 @@ run_test(void *dc, const char *file, bool verbose)
     s = map_base;
     end = map_base + map_size;
     while (s < end) {
+        lines++;
+        test_failed = false;
         byte *t = memchr(s, '\n', end - s);
-        do_line(dc, (const char *)s, (t == NULL ? end : t) - s, verbose, &failed);
+        do_line(dc, (const char *)s, (t == NULL ? end : t) - s, verbose, &test_failed);
         s = (t == NULL ? end : t + 1);
+        if (test_failed) {
+            failures++;
+            failed = true;
+        }
     }
+
+    if (failures > 0)
+        dr_printf("%i out of %i tests failed\n", failures, lines);
 
     if (failed) {
         dr_printf("FAIL\n");

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -18290,3 +18290,7708 @@ d3431041 : ubfx   x1, x2, #3, #2          : ubfm   %x2 $0x03 $0x04 -> %x1
 7efb4f59 : uqshl d25, d26, d27                       : uqshl  %d26 %d27 -> %d25
 7efd4f9b : uqshl d27, d28, d29                       : uqshl  %d28 %d29 -> %d27
 7ee14c1f : uqshl d31, d0, d1                         : uqshl  %d0 %d1 -> %d31
+
+# CSINV   <Xd>, <Xn>, <Xm>, <cond> (CSINV-R.RR-64_condsel)
+da820020 : csinv x0, x1, x2, EQ                      : csinv  %x1 %x2 eq -> %x0
+da840062 : csinv x2, x3, x4, EQ                      : csinv  %x3 %x4 eq -> %x2
+da8600a4 : csinv x4, x5, x6, EQ                      : csinv  %x5 %x6 eq -> %x4
+da8800e6 : csinv x6, x7, x8, EQ                      : csinv  %x7 %x8 eq -> %x6
+da8a0128 : csinv x8, x9, x10, EQ                     : csinv  %x9 %x10 eq -> %x8
+da8b0149 : csinv x9, x10, x11, EQ                    : csinv  %x10 %x11 eq -> %x9
+da8d018b : csinv x11, x12, x13, EQ                   : csinv  %x12 %x13 eq -> %x11
+da8f01cd : csinv x13, x14, x15, EQ                   : csinv  %x14 %x15 eq -> %x13
+da91020f : csinv x15, x16, x17, EQ                   : csinv  %x16 %x17 eq -> %x15
+da930251 : csinv x17, x18, x19, EQ                   : csinv  %x18 %x19 eq -> %x17
+da950293 : csinv x19, x20, x21, EQ                   : csinv  %x20 %x21 eq -> %x19
+da9702d5 : csinv x21, x22, x23, EQ                   : csinv  %x22 %x23 eq -> %x21
+da9802f6 : csinv x22, x23, x24, EQ                   : csinv  %x23 %x24 eq -> %x22
+da9a0338 : csinv x24, x25, x26, EQ                   : csinv  %x25 %x26 eq -> %x24
+da9c037a : csinv x26, x27, x28, EQ                   : csinv  %x27 %x28 eq -> %x26
+da81001e : csinv x30, x0, x1, EQ                     : csinv  %x0 %x1 eq -> %x30
+da821020 : csinv x0, x1, x2, NE                      : csinv  %x1 %x2 ne -> %x0
+da841062 : csinv x2, x3, x4, NE                      : csinv  %x3 %x4 ne -> %x2
+da8610a4 : csinv x4, x5, x6, NE                      : csinv  %x5 %x6 ne -> %x4
+da8810e6 : csinv x6, x7, x8, NE                      : csinv  %x7 %x8 ne -> %x6
+da8a1128 : csinv x8, x9, x10, NE                     : csinv  %x9 %x10 ne -> %x8
+da8b1149 : csinv x9, x10, x11, NE                    : csinv  %x10 %x11 ne -> %x9
+da8d118b : csinv x11, x12, x13, NE                   : csinv  %x12 %x13 ne -> %x11
+da8f11cd : csinv x13, x14, x15, NE                   : csinv  %x14 %x15 ne -> %x13
+da91120f : csinv x15, x16, x17, NE                   : csinv  %x16 %x17 ne -> %x15
+da931251 : csinv x17, x18, x19, NE                   : csinv  %x18 %x19 ne -> %x17
+da951293 : csinv x19, x20, x21, NE                   : csinv  %x20 %x21 ne -> %x19
+da9712d5 : csinv x21, x22, x23, NE                   : csinv  %x22 %x23 ne -> %x21
+da9812f6 : csinv x22, x23, x24, NE                   : csinv  %x23 %x24 ne -> %x22
+da9a1338 : csinv x24, x25, x26, NE                   : csinv  %x25 %x26 ne -> %x24
+da9c137a : csinv x26, x27, x28, NE                   : csinv  %x27 %x28 ne -> %x26
+da81101e : csinv x30, x0, x1, NE                     : csinv  %x0 %x1 ne -> %x30
+da822020 : csinv x0, x1, x2, CS                      : csinv  %x1 %x2 cs -> %x0
+da842062 : csinv x2, x3, x4, CS                      : csinv  %x3 %x4 cs -> %x2
+da8620a4 : csinv x4, x5, x6, CS                      : csinv  %x5 %x6 cs -> %x4
+da8820e6 : csinv x6, x7, x8, CS                      : csinv  %x7 %x8 cs -> %x6
+da8a2128 : csinv x8, x9, x10, CS                     : csinv  %x9 %x10 cs -> %x8
+da8b2149 : csinv x9, x10, x11, CS                    : csinv  %x10 %x11 cs -> %x9
+da8d218b : csinv x11, x12, x13, CS                   : csinv  %x12 %x13 cs -> %x11
+da8f21cd : csinv x13, x14, x15, CS                   : csinv  %x14 %x15 cs -> %x13
+da91220f : csinv x15, x16, x17, CS                   : csinv  %x16 %x17 cs -> %x15
+da932251 : csinv x17, x18, x19, CS                   : csinv  %x18 %x19 cs -> %x17
+da952293 : csinv x19, x20, x21, CS                   : csinv  %x20 %x21 cs -> %x19
+da9722d5 : csinv x21, x22, x23, CS                   : csinv  %x22 %x23 cs -> %x21
+da9822f6 : csinv x22, x23, x24, CS                   : csinv  %x23 %x24 cs -> %x22
+da9a2338 : csinv x24, x25, x26, CS                   : csinv  %x25 %x26 cs -> %x24
+da9c237a : csinv x26, x27, x28, CS                   : csinv  %x27 %x28 cs -> %x26
+da81201e : csinv x30, x0, x1, CS                     : csinv  %x0 %x1 cs -> %x30
+da823020 : csinv x0, x1, x2, CC                      : csinv  %x1 %x2 cc -> %x0
+da843062 : csinv x2, x3, x4, CC                      : csinv  %x3 %x4 cc -> %x2
+da8630a4 : csinv x4, x5, x6, CC                      : csinv  %x5 %x6 cc -> %x4
+da8830e6 : csinv x6, x7, x8, CC                      : csinv  %x7 %x8 cc -> %x6
+da8a3128 : csinv x8, x9, x10, CC                     : csinv  %x9 %x10 cc -> %x8
+da8b3149 : csinv x9, x10, x11, CC                    : csinv  %x10 %x11 cc -> %x9
+da8d318b : csinv x11, x12, x13, CC                   : csinv  %x12 %x13 cc -> %x11
+da8f31cd : csinv x13, x14, x15, CC                   : csinv  %x14 %x15 cc -> %x13
+da91320f : csinv x15, x16, x17, CC                   : csinv  %x16 %x17 cc -> %x15
+da933251 : csinv x17, x18, x19, CC                   : csinv  %x18 %x19 cc -> %x17
+da953293 : csinv x19, x20, x21, CC                   : csinv  %x20 %x21 cc -> %x19
+da9732d5 : csinv x21, x22, x23, CC                   : csinv  %x22 %x23 cc -> %x21
+da9832f6 : csinv x22, x23, x24, CC                   : csinv  %x23 %x24 cc -> %x22
+da9a3338 : csinv x24, x25, x26, CC                   : csinv  %x25 %x26 cc -> %x24
+da9c337a : csinv x26, x27, x28, CC                   : csinv  %x27 %x28 cc -> %x26
+da81301e : csinv x30, x0, x1, CC                     : csinv  %x0 %x1 cc -> %x30
+da824020 : csinv x0, x1, x2, MI                      : csinv  %x1 %x2 mi -> %x0
+da844062 : csinv x2, x3, x4, MI                      : csinv  %x3 %x4 mi -> %x2
+da8640a4 : csinv x4, x5, x6, MI                      : csinv  %x5 %x6 mi -> %x4
+da8840e6 : csinv x6, x7, x8, MI                      : csinv  %x7 %x8 mi -> %x6
+da8a4128 : csinv x8, x9, x10, MI                     : csinv  %x9 %x10 mi -> %x8
+da8b4149 : csinv x9, x10, x11, MI                    : csinv  %x10 %x11 mi -> %x9
+da8d418b : csinv x11, x12, x13, MI                   : csinv  %x12 %x13 mi -> %x11
+da8f41cd : csinv x13, x14, x15, MI                   : csinv  %x14 %x15 mi -> %x13
+da91420f : csinv x15, x16, x17, MI                   : csinv  %x16 %x17 mi -> %x15
+da934251 : csinv x17, x18, x19, MI                   : csinv  %x18 %x19 mi -> %x17
+da954293 : csinv x19, x20, x21, MI                   : csinv  %x20 %x21 mi -> %x19
+da9742d5 : csinv x21, x22, x23, MI                   : csinv  %x22 %x23 mi -> %x21
+da9842f6 : csinv x22, x23, x24, MI                   : csinv  %x23 %x24 mi -> %x22
+da9a4338 : csinv x24, x25, x26, MI                   : csinv  %x25 %x26 mi -> %x24
+da9c437a : csinv x26, x27, x28, MI                   : csinv  %x27 %x28 mi -> %x26
+da81401e : csinv x30, x0, x1, MI                     : csinv  %x0 %x1 mi -> %x30
+da825020 : csinv x0, x1, x2, PL                      : csinv  %x1 %x2 pl -> %x0
+da845062 : csinv x2, x3, x4, PL                      : csinv  %x3 %x4 pl -> %x2
+da8650a4 : csinv x4, x5, x6, PL                      : csinv  %x5 %x6 pl -> %x4
+da8850e6 : csinv x6, x7, x8, PL                      : csinv  %x7 %x8 pl -> %x6
+da8a5128 : csinv x8, x9, x10, PL                     : csinv  %x9 %x10 pl -> %x8
+da8b5149 : csinv x9, x10, x11, PL                    : csinv  %x10 %x11 pl -> %x9
+da8d518b : csinv x11, x12, x13, PL                   : csinv  %x12 %x13 pl -> %x11
+da8f51cd : csinv x13, x14, x15, PL                   : csinv  %x14 %x15 pl -> %x13
+da91520f : csinv x15, x16, x17, PL                   : csinv  %x16 %x17 pl -> %x15
+da935251 : csinv x17, x18, x19, PL                   : csinv  %x18 %x19 pl -> %x17
+da955293 : csinv x19, x20, x21, PL                   : csinv  %x20 %x21 pl -> %x19
+da9752d5 : csinv x21, x22, x23, PL                   : csinv  %x22 %x23 pl -> %x21
+da9852f6 : csinv x22, x23, x24, PL                   : csinv  %x23 %x24 pl -> %x22
+da9a5338 : csinv x24, x25, x26, PL                   : csinv  %x25 %x26 pl -> %x24
+da9c537a : csinv x26, x27, x28, PL                   : csinv  %x27 %x28 pl -> %x26
+da81501e : csinv x30, x0, x1, PL                     : csinv  %x0 %x1 pl -> %x30
+da826020 : csinv x0, x1, x2, VS                      : csinv  %x1 %x2 vs -> %x0
+da846062 : csinv x2, x3, x4, VS                      : csinv  %x3 %x4 vs -> %x2
+da8660a4 : csinv x4, x5, x6, VS                      : csinv  %x5 %x6 vs -> %x4
+da8860e6 : csinv x6, x7, x8, VS                      : csinv  %x7 %x8 vs -> %x6
+da8a6128 : csinv x8, x9, x10, VS                     : csinv  %x9 %x10 vs -> %x8
+da8b6149 : csinv x9, x10, x11, VS                    : csinv  %x10 %x11 vs -> %x9
+da8d618b : csinv x11, x12, x13, VS                   : csinv  %x12 %x13 vs -> %x11
+da8f61cd : csinv x13, x14, x15, VS                   : csinv  %x14 %x15 vs -> %x13
+da91620f : csinv x15, x16, x17, VS                   : csinv  %x16 %x17 vs -> %x15
+da936251 : csinv x17, x18, x19, VS                   : csinv  %x18 %x19 vs -> %x17
+da956293 : csinv x19, x20, x21, VS                   : csinv  %x20 %x21 vs -> %x19
+da9762d5 : csinv x21, x22, x23, VS                   : csinv  %x22 %x23 vs -> %x21
+da9862f6 : csinv x22, x23, x24, VS                   : csinv  %x23 %x24 vs -> %x22
+da9a6338 : csinv x24, x25, x26, VS                   : csinv  %x25 %x26 vs -> %x24
+da9c637a : csinv x26, x27, x28, VS                   : csinv  %x27 %x28 vs -> %x26
+da81601e : csinv x30, x0, x1, VS                     : csinv  %x0 %x1 vs -> %x30
+da827020 : csinv x0, x1, x2, VC                      : csinv  %x1 %x2 vc -> %x0
+da847062 : csinv x2, x3, x4, VC                      : csinv  %x3 %x4 vc -> %x2
+da8670a4 : csinv x4, x5, x6, VC                      : csinv  %x5 %x6 vc -> %x4
+da8870e6 : csinv x6, x7, x8, VC                      : csinv  %x7 %x8 vc -> %x6
+da8a7128 : csinv x8, x9, x10, VC                     : csinv  %x9 %x10 vc -> %x8
+da8b7149 : csinv x9, x10, x11, VC                    : csinv  %x10 %x11 vc -> %x9
+da8d718b : csinv x11, x12, x13, VC                   : csinv  %x12 %x13 vc -> %x11
+da8f71cd : csinv x13, x14, x15, VC                   : csinv  %x14 %x15 vc -> %x13
+da91720f : csinv x15, x16, x17, VC                   : csinv  %x16 %x17 vc -> %x15
+da937251 : csinv x17, x18, x19, VC                   : csinv  %x18 %x19 vc -> %x17
+da957293 : csinv x19, x20, x21, VC                   : csinv  %x20 %x21 vc -> %x19
+da9772d5 : csinv x21, x22, x23, VC                   : csinv  %x22 %x23 vc -> %x21
+da9872f6 : csinv x22, x23, x24, VC                   : csinv  %x23 %x24 vc -> %x22
+da9a7338 : csinv x24, x25, x26, VC                   : csinv  %x25 %x26 vc -> %x24
+da9c737a : csinv x26, x27, x28, VC                   : csinv  %x27 %x28 vc -> %x26
+da81701e : csinv x30, x0, x1, VC                     : csinv  %x0 %x1 vc -> %x30
+da828020 : csinv x0, x1, x2, HI                      : csinv  %x1 %x2 hi -> %x0
+da848062 : csinv x2, x3, x4, HI                      : csinv  %x3 %x4 hi -> %x2
+da8680a4 : csinv x4, x5, x6, HI                      : csinv  %x5 %x6 hi -> %x4
+da8880e6 : csinv x6, x7, x8, HI                      : csinv  %x7 %x8 hi -> %x6
+da8a8128 : csinv x8, x9, x10, HI                     : csinv  %x9 %x10 hi -> %x8
+da8b8149 : csinv x9, x10, x11, HI                    : csinv  %x10 %x11 hi -> %x9
+da8d818b : csinv x11, x12, x13, HI                   : csinv  %x12 %x13 hi -> %x11
+da8f81cd : csinv x13, x14, x15, HI                   : csinv  %x14 %x15 hi -> %x13
+da91820f : csinv x15, x16, x17, HI                   : csinv  %x16 %x17 hi -> %x15
+da938251 : csinv x17, x18, x19, HI                   : csinv  %x18 %x19 hi -> %x17
+da958293 : csinv x19, x20, x21, HI                   : csinv  %x20 %x21 hi -> %x19
+da9782d5 : csinv x21, x22, x23, HI                   : csinv  %x22 %x23 hi -> %x21
+da9882f6 : csinv x22, x23, x24, HI                   : csinv  %x23 %x24 hi -> %x22
+da9a8338 : csinv x24, x25, x26, HI                   : csinv  %x25 %x26 hi -> %x24
+da9c837a : csinv x26, x27, x28, HI                   : csinv  %x27 %x28 hi -> %x26
+da81801e : csinv x30, x0, x1, HI                     : csinv  %x0 %x1 hi -> %x30
+da829020 : csinv x0, x1, x2, LS                      : csinv  %x1 %x2 ls -> %x0
+da849062 : csinv x2, x3, x4, LS                      : csinv  %x3 %x4 ls -> %x2
+da8690a4 : csinv x4, x5, x6, LS                      : csinv  %x5 %x6 ls -> %x4
+da8890e6 : csinv x6, x7, x8, LS                      : csinv  %x7 %x8 ls -> %x6
+da8a9128 : csinv x8, x9, x10, LS                     : csinv  %x9 %x10 ls -> %x8
+da8b9149 : csinv x9, x10, x11, LS                    : csinv  %x10 %x11 ls -> %x9
+da8d918b : csinv x11, x12, x13, LS                   : csinv  %x12 %x13 ls -> %x11
+da8f91cd : csinv x13, x14, x15, LS                   : csinv  %x14 %x15 ls -> %x13
+da91920f : csinv x15, x16, x17, LS                   : csinv  %x16 %x17 ls -> %x15
+da939251 : csinv x17, x18, x19, LS                   : csinv  %x18 %x19 ls -> %x17
+da959293 : csinv x19, x20, x21, LS                   : csinv  %x20 %x21 ls -> %x19
+da9792d5 : csinv x21, x22, x23, LS                   : csinv  %x22 %x23 ls -> %x21
+da9892f6 : csinv x22, x23, x24, LS                   : csinv  %x23 %x24 ls -> %x22
+da9a9338 : csinv x24, x25, x26, LS                   : csinv  %x25 %x26 ls -> %x24
+da9c937a : csinv x26, x27, x28, LS                   : csinv  %x27 %x28 ls -> %x26
+da81901e : csinv x30, x0, x1, LS                     : csinv  %x0 %x1 ls -> %x30
+da82a020 : csinv x0, x1, x2, GE                      : csinv  %x1 %x2 ge -> %x0
+da84a062 : csinv x2, x3, x4, GE                      : csinv  %x3 %x4 ge -> %x2
+da86a0a4 : csinv x4, x5, x6, GE                      : csinv  %x5 %x6 ge -> %x4
+da88a0e6 : csinv x6, x7, x8, GE                      : csinv  %x7 %x8 ge -> %x6
+da8aa128 : csinv x8, x9, x10, GE                     : csinv  %x9 %x10 ge -> %x8
+da8ba149 : csinv x9, x10, x11, GE                    : csinv  %x10 %x11 ge -> %x9
+da8da18b : csinv x11, x12, x13, GE                   : csinv  %x12 %x13 ge -> %x11
+da8fa1cd : csinv x13, x14, x15, GE                   : csinv  %x14 %x15 ge -> %x13
+da91a20f : csinv x15, x16, x17, GE                   : csinv  %x16 %x17 ge -> %x15
+da93a251 : csinv x17, x18, x19, GE                   : csinv  %x18 %x19 ge -> %x17
+da95a293 : csinv x19, x20, x21, GE                   : csinv  %x20 %x21 ge -> %x19
+da97a2d5 : csinv x21, x22, x23, GE                   : csinv  %x22 %x23 ge -> %x21
+da98a2f6 : csinv x22, x23, x24, GE                   : csinv  %x23 %x24 ge -> %x22
+da9aa338 : csinv x24, x25, x26, GE                   : csinv  %x25 %x26 ge -> %x24
+da9ca37a : csinv x26, x27, x28, GE                   : csinv  %x27 %x28 ge -> %x26
+da81a01e : csinv x30, x0, x1, GE                     : csinv  %x0 %x1 ge -> %x30
+da82b020 : csinv x0, x1, x2, LT                      : csinv  %x1 %x2 lt -> %x0
+da84b062 : csinv x2, x3, x4, LT                      : csinv  %x3 %x4 lt -> %x2
+da86b0a4 : csinv x4, x5, x6, LT                      : csinv  %x5 %x6 lt -> %x4
+da88b0e6 : csinv x6, x7, x8, LT                      : csinv  %x7 %x8 lt -> %x6
+da8ab128 : csinv x8, x9, x10, LT                     : csinv  %x9 %x10 lt -> %x8
+da8bb149 : csinv x9, x10, x11, LT                    : csinv  %x10 %x11 lt -> %x9
+da8db18b : csinv x11, x12, x13, LT                   : csinv  %x12 %x13 lt -> %x11
+da8fb1cd : csinv x13, x14, x15, LT                   : csinv  %x14 %x15 lt -> %x13
+da91b20f : csinv x15, x16, x17, LT                   : csinv  %x16 %x17 lt -> %x15
+da93b251 : csinv x17, x18, x19, LT                   : csinv  %x18 %x19 lt -> %x17
+da95b293 : csinv x19, x20, x21, LT                   : csinv  %x20 %x21 lt -> %x19
+da97b2d5 : csinv x21, x22, x23, LT                   : csinv  %x22 %x23 lt -> %x21
+da98b2f6 : csinv x22, x23, x24, LT                   : csinv  %x23 %x24 lt -> %x22
+da9ab338 : csinv x24, x25, x26, LT                   : csinv  %x25 %x26 lt -> %x24
+da9cb37a : csinv x26, x27, x28, LT                   : csinv  %x27 %x28 lt -> %x26
+da81b01e : csinv x30, x0, x1, LT                     : csinv  %x0 %x1 lt -> %x30
+da82c020 : csinv x0, x1, x2, GT                      : csinv  %x1 %x2 gt -> %x0
+da84c062 : csinv x2, x3, x4, GT                      : csinv  %x3 %x4 gt -> %x2
+da86c0a4 : csinv x4, x5, x6, GT                      : csinv  %x5 %x6 gt -> %x4
+da88c0e6 : csinv x6, x7, x8, GT                      : csinv  %x7 %x8 gt -> %x6
+da8ac128 : csinv x8, x9, x10, GT                     : csinv  %x9 %x10 gt -> %x8
+da8bc149 : csinv x9, x10, x11, GT                    : csinv  %x10 %x11 gt -> %x9
+da8dc18b : csinv x11, x12, x13, GT                   : csinv  %x12 %x13 gt -> %x11
+da8fc1cd : csinv x13, x14, x15, GT                   : csinv  %x14 %x15 gt -> %x13
+da91c20f : csinv x15, x16, x17, GT                   : csinv  %x16 %x17 gt -> %x15
+da93c251 : csinv x17, x18, x19, GT                   : csinv  %x18 %x19 gt -> %x17
+da95c293 : csinv x19, x20, x21, GT                   : csinv  %x20 %x21 gt -> %x19
+da97c2d5 : csinv x21, x22, x23, GT                   : csinv  %x22 %x23 gt -> %x21
+da98c2f6 : csinv x22, x23, x24, GT                   : csinv  %x23 %x24 gt -> %x22
+da9ac338 : csinv x24, x25, x26, GT                   : csinv  %x25 %x26 gt -> %x24
+da9cc37a : csinv x26, x27, x28, GT                   : csinv  %x27 %x28 gt -> %x26
+da81c01e : csinv x30, x0, x1, GT                     : csinv  %x0 %x1 gt -> %x30
+da82d020 : csinv x0, x1, x2, LE                      : csinv  %x1 %x2 le -> %x0
+da84d062 : csinv x2, x3, x4, LE                      : csinv  %x3 %x4 le -> %x2
+da86d0a4 : csinv x4, x5, x6, LE                      : csinv  %x5 %x6 le -> %x4
+da88d0e6 : csinv x6, x7, x8, LE                      : csinv  %x7 %x8 le -> %x6
+da8ad128 : csinv x8, x9, x10, LE                     : csinv  %x9 %x10 le -> %x8
+da8bd149 : csinv x9, x10, x11, LE                    : csinv  %x10 %x11 le -> %x9
+da8dd18b : csinv x11, x12, x13, LE                   : csinv  %x12 %x13 le -> %x11
+da8fd1cd : csinv x13, x14, x15, LE                   : csinv  %x14 %x15 le -> %x13
+da91d20f : csinv x15, x16, x17, LE                   : csinv  %x16 %x17 le -> %x15
+da93d251 : csinv x17, x18, x19, LE                   : csinv  %x18 %x19 le -> %x17
+da95d293 : csinv x19, x20, x21, LE                   : csinv  %x20 %x21 le -> %x19
+da97d2d5 : csinv x21, x22, x23, LE                   : csinv  %x22 %x23 le -> %x21
+da98d2f6 : csinv x22, x23, x24, LE                   : csinv  %x23 %x24 le -> %x22
+da9ad338 : csinv x24, x25, x26, LE                   : csinv  %x25 %x26 le -> %x24
+da9cd37a : csinv x26, x27, x28, LE                   : csinv  %x27 %x28 le -> %x26
+da81d01e : csinv x30, x0, x1, LE                     : csinv  %x0 %x1 le -> %x30
+da82e020 : csinv x0, x1, x2, AL                      : csinv  %x1 %x2 al -> %x0
+da84e062 : csinv x2, x3, x4, AL                      : csinv  %x3 %x4 al -> %x2
+da86e0a4 : csinv x4, x5, x6, AL                      : csinv  %x5 %x6 al -> %x4
+da88e0e6 : csinv x6, x7, x8, AL                      : csinv  %x7 %x8 al -> %x6
+da8ae128 : csinv x8, x9, x10, AL                     : csinv  %x9 %x10 al -> %x8
+da8be149 : csinv x9, x10, x11, AL                    : csinv  %x10 %x11 al -> %x9
+da8de18b : csinv x11, x12, x13, AL                   : csinv  %x12 %x13 al -> %x11
+da8fe1cd : csinv x13, x14, x15, AL                   : csinv  %x14 %x15 al -> %x13
+da91e20f : csinv x15, x16, x17, AL                   : csinv  %x16 %x17 al -> %x15
+da93e251 : csinv x17, x18, x19, AL                   : csinv  %x18 %x19 al -> %x17
+da95e293 : csinv x19, x20, x21, AL                   : csinv  %x20 %x21 al -> %x19
+da97e2d5 : csinv x21, x22, x23, AL                   : csinv  %x22 %x23 al -> %x21
+da98e2f6 : csinv x22, x23, x24, AL                   : csinv  %x23 %x24 al -> %x22
+da9ae338 : csinv x24, x25, x26, AL                   : csinv  %x25 %x26 al -> %x24
+da9ce37a : csinv x26, x27, x28, AL                   : csinv  %x27 %x28 al -> %x26
+da81e01e : csinv x30, x0, x1, AL                     : csinv  %x0 %x1 al -> %x30
+da82f020 : csinv x0, x1, x2, NV                      : csinv  %x1 %x2 nv -> %x0
+da84f062 : csinv x2, x3, x4, NV                      : csinv  %x3 %x4 nv -> %x2
+da86f0a4 : csinv x4, x5, x6, NV                      : csinv  %x5 %x6 nv -> %x4
+da88f0e6 : csinv x6, x7, x8, NV                      : csinv  %x7 %x8 nv -> %x6
+da8af128 : csinv x8, x9, x10, NV                     : csinv  %x9 %x10 nv -> %x8
+da8bf149 : csinv x9, x10, x11, NV                    : csinv  %x10 %x11 nv -> %x9
+da8df18b : csinv x11, x12, x13, NV                   : csinv  %x12 %x13 nv -> %x11
+da8ff1cd : csinv x13, x14, x15, NV                   : csinv  %x14 %x15 nv -> %x13
+da91f20f : csinv x15, x16, x17, NV                   : csinv  %x16 %x17 nv -> %x15
+da93f251 : csinv x17, x18, x19, NV                   : csinv  %x18 %x19 nv -> %x17
+da95f293 : csinv x19, x20, x21, NV                   : csinv  %x20 %x21 nv -> %x19
+da97f2d5 : csinv x21, x22, x23, NV                   : csinv  %x22 %x23 nv -> %x21
+da98f2f6 : csinv x22, x23, x24, NV                   : csinv  %x23 %x24 nv -> %x22
+da9af338 : csinv x24, x25, x26, NV                   : csinv  %x25 %x26 nv -> %x24
+da9cf37a : csinv x26, x27, x28, NV                   : csinv  %x27 %x28 nv -> %x26
+da81f01e : csinv x30, x0, x1, NV                     : csinv  %x0 %x1 nv -> %x30
+
+# CRC32X  <Wd>, <Wn>, <Xm> (CRC32X-R.RR-64C_dp_2src)
+9ac24c20 : crc32x w0, w1, x2                         : crc32x %w1 %x2 -> %w0
+9ac44c62 : crc32x w2, w3, x4                         : crc32x %w3 %x4 -> %w2
+9ac64ca4 : crc32x w4, w5, x6                         : crc32x %w5 %x6 -> %w4
+9ac84ce6 : crc32x w6, w7, x8                         : crc32x %w7 %x8 -> %w6
+9aca4d28 : crc32x w8, w9, x10                        : crc32x %w9 %x10 -> %w8
+9acb4d49 : crc32x w9, w10, x11                       : crc32x %w10 %x11 -> %w9
+9acd4d8b : crc32x w11, w12, x13                      : crc32x %w12 %x13 -> %w11
+9acf4dcd : crc32x w13, w14, x15                      : crc32x %w14 %x15 -> %w13
+9ad14e0f : crc32x w15, w16, x17                      : crc32x %w16 %x17 -> %w15
+9ad34e51 : crc32x w17, w18, x19                      : crc32x %w18 %x19 -> %w17
+9ad54e93 : crc32x w19, w20, x21                      : crc32x %w20 %x21 -> %w19
+9ad74ed5 : crc32x w21, w22, x23                      : crc32x %w22 %x23 -> %w21
+9ad84ef6 : crc32x w22, w23, x24                      : crc32x %w23 %x24 -> %w22
+9ada4f38 : crc32x w24, w25, x26                      : crc32x %w25 %x26 -> %w24
+9adc4f7a : crc32x w26, w27, x28                      : crc32x %w27 %x28 -> %w26
+9ac14c1e : crc32x w30, w0, x1                        : crc32x %w0 %x1 -> %w30
+
+# BFM     <Wd>, <Wn>, #<imm1>, #<imm2> (BFM-R.RII-32M_bitfield)
+33000020 : bfm w0, w1, #0x0, #0x0                    : bfm    %w0 %w1 $0x00 $0x00 -> %w0
+33020862 : bfm w2, w3, #0x2, #0x2                    : bfm    %w2 %w3 $0x02 $0x02 -> %w2
+330410a4 : bfm w4, w5, #0x4, #0x4                    : bfm    %w4 %w5 $0x04 $0x04 -> %w4
+330618e6 : bfm w6, w7, #0x6, #0x6                    : bfm    %w6 %w7 $0x06 $0x06 -> %w6
+33082128 : bfm w8, w9, #0x8, #0x8                    : bfm    %w8 %w9 $0x08 $0x08 -> %w8
+330a2949 : bfm w9, w10, #0xa, #0xa                   : bfm    %w9 %w10 $0x0a $0x0a -> %w9
+330c318b : bfm w11, w12, #0xc, #0xc                  : bfm    %w11 %w12 $0x0c $0x0c -> %w11
+330e39cd : bfm w13, w14, #0xe, #0xe                  : bfm    %w13 %w14 $0x0e $0x0e -> %w13
+3310420f : bfm w15, w16, #0x10, #0x10                : bfm    %w15 %w16 $0x10 $0x10 -> %w15
+33114651 : bfm w17, w18, #0x11, #0x11                : bfm    %w17 %w18 $0x11 $0x11 -> %w17
+33134e93 : bfm w19, w20, #0x13, #0x13                : bfm    %w19 %w20 $0x13 $0x13 -> %w19
+331556d5 : bfm w21, w22, #0x15, #0x15                : bfm    %w21 %w22 $0x15 $0x15 -> %w21
+33175ef6 : bfm w22, w23, #0x17, #0x17                : bfm    %w22 %w23 $0x17 $0x17 -> %w22
+33196738 : bfm w24, w25, #0x19, #0x19                : bfm    %w24 %w25 $0x19 $0x19 -> %w24
+331b6f7a : bfm w26, w27, #0x1b, #0x1b                : bfm    %w26 %w27 $0x1b $0x1b -> %w26
+331f7c1e : bfm w30, w0, #0x1f, #0x1f                 : bfm    %w30 %w0 $0x1f $0x1f -> %w30
+
+# LSLV    <Xd>, <Xn>, <Xm> (LSLV-R.RR-64_dp_2src)
+9ac22020 : lslv x0, x1, x2                           : lslv   %x1 %x2 -> %x0
+9ac42062 : lslv x2, x3, x4                           : lslv   %x3 %x4 -> %x2
+9ac620a4 : lslv x4, x5, x6                           : lslv   %x5 %x6 -> %x4
+9ac820e6 : lslv x6, x7, x8                           : lslv   %x7 %x8 -> %x6
+9aca2128 : lslv x8, x9, x10                          : lslv   %x9 %x10 -> %x8
+9acb2149 : lslv x9, x10, x11                         : lslv   %x10 %x11 -> %x9
+9acd218b : lslv x11, x12, x13                        : lslv   %x12 %x13 -> %x11
+9acf21cd : lslv x13, x14, x15                        : lslv   %x14 %x15 -> %x13
+9ad1220f : lslv x15, x16, x17                        : lslv   %x16 %x17 -> %x15
+9ad32251 : lslv x17, x18, x19                        : lslv   %x18 %x19 -> %x17
+9ad52293 : lslv x19, x20, x21                        : lslv   %x20 %x21 -> %x19
+9ad722d5 : lslv x21, x22, x23                        : lslv   %x22 %x23 -> %x21
+9ad822f6 : lslv x22, x23, x24                        : lslv   %x23 %x24 -> %x22
+9ada2338 : lslv x24, x25, x26                        : lslv   %x25 %x26 -> %x24
+9adc237a : lslv x26, x27, x28                        : lslv   %x27 %x28 -> %x26
+9ac1201e : lslv x30, x0, x1                          : lslv   %x0 %x1 -> %x30
+
+# SUBS    <Xd>, <Xn>, <Xm>, <extend> #<imm> (SUBS-R.RRI-64_addsub_shift)
+eb020020 : subs x0, x1, x2, LSL #0                   : subs   %x1 %x2 lsl $0x00 -> %x0
+eb040862 : subs x2, x3, x4, LSL #2                   : subs   %x3 %x4 lsl $0x02 -> %x2
+eb0610a4 : subs x4, x5, x6, LSL #4                   : subs   %x5 %x6 lsl $0x04 -> %x4
+eb0818e6 : subs x6, x7, x8, LSL #6                   : subs   %x7 %x8 lsl $0x06 -> %x6
+eb0a2128 : subs x8, x9, x10, LSL #8                  : subs   %x9 %x10 lsl $0x08 -> %x8
+eb0b2949 : subs x9, x10, x11, LSL #10                : subs   %x10 %x11 lsl $0x0a -> %x9
+eb0d318b : subs x11, x12, x13, LSL #12               : subs   %x12 %x13 lsl $0x0c -> %x11
+eb0f39cd : subs x13, x14, x15, LSL #14               : subs   %x14 %x15 lsl $0x0e -> %x13
+eb11420f : subs x15, x16, x17, LSL #16               : subs   %x16 %x17 lsl $0x10 -> %x15
+eb134651 : subs x17, x18, x19, LSL #17               : subs   %x18 %x19 lsl $0x11 -> %x17
+eb154e93 : subs x19, x20, x21, LSL #19               : subs   %x20 %x21 lsl $0x13 -> %x19
+eb1756d5 : subs x21, x22, x23, LSL #21               : subs   %x22 %x23 lsl $0x15 -> %x21
+eb185ef6 : subs x22, x23, x24, LSL #23               : subs   %x23 %x24 lsl $0x17 -> %x22
+eb1a6738 : subs x24, x25, x26, LSL #25               : subs   %x25 %x26 lsl $0x19 -> %x24
+eb1c6f7a : subs x26, x27, x28, LSL #27               : subs   %x27 %x28 lsl $0x1b -> %x26
+eb017c1e : subs x30, x0, x1, LSL #31                 : subs   %x0 %x1 lsl $0x1f -> %x30
+eb420020 : subs x0, x1, x2, LSR #0                   : subs   %x1 %x2 lsr $0x00 -> %x0
+eb440862 : subs x2, x3, x4, LSR #2                   : subs   %x3 %x4 lsr $0x02 -> %x2
+eb4610a4 : subs x4, x5, x6, LSR #4                   : subs   %x5 %x6 lsr $0x04 -> %x4
+eb4818e6 : subs x6, x7, x8, LSR #6                   : subs   %x7 %x8 lsr $0x06 -> %x6
+eb4a2128 : subs x8, x9, x10, LSR #8                  : subs   %x9 %x10 lsr $0x08 -> %x8
+eb4b2949 : subs x9, x10, x11, LSR #10                : subs   %x10 %x11 lsr $0x0a -> %x9
+eb4d318b : subs x11, x12, x13, LSR #12               : subs   %x12 %x13 lsr $0x0c -> %x11
+eb4f39cd : subs x13, x14, x15, LSR #14               : subs   %x14 %x15 lsr $0x0e -> %x13
+eb51420f : subs x15, x16, x17, LSR #16               : subs   %x16 %x17 lsr $0x10 -> %x15
+eb534651 : subs x17, x18, x19, LSR #17               : subs   %x18 %x19 lsr $0x11 -> %x17
+eb554e93 : subs x19, x20, x21, LSR #19               : subs   %x20 %x21 lsr $0x13 -> %x19
+eb5756d5 : subs x21, x22, x23, LSR #21               : subs   %x22 %x23 lsr $0x15 -> %x21
+eb585ef6 : subs x22, x23, x24, LSR #23               : subs   %x23 %x24 lsr $0x17 -> %x22
+eb5a6738 : subs x24, x25, x26, LSR #25               : subs   %x25 %x26 lsr $0x19 -> %x24
+eb5c6f7a : subs x26, x27, x28, LSR #27               : subs   %x27 %x28 lsr $0x1b -> %x26
+eb417c1e : subs x30, x0, x1, LSR #31                 : subs   %x0 %x1 lsr $0x1f -> %x30
+eb820020 : subs x0, x1, x2, ASR #0                   : subs   %x1 %x2 asr $0x00 -> %x0
+eb840862 : subs x2, x3, x4, ASR #2                   : subs   %x3 %x4 asr $0x02 -> %x2
+eb8610a4 : subs x4, x5, x6, ASR #4                   : subs   %x5 %x6 asr $0x04 -> %x4
+eb8818e6 : subs x6, x7, x8, ASR #6                   : subs   %x7 %x8 asr $0x06 -> %x6
+eb8a2128 : subs x8, x9, x10, ASR #8                  : subs   %x9 %x10 asr $0x08 -> %x8
+eb8b2949 : subs x9, x10, x11, ASR #10                : subs   %x10 %x11 asr $0x0a -> %x9
+eb8d318b : subs x11, x12, x13, ASR #12               : subs   %x12 %x13 asr $0x0c -> %x11
+eb8f39cd : subs x13, x14, x15, ASR #14               : subs   %x14 %x15 asr $0x0e -> %x13
+eb91420f : subs x15, x16, x17, ASR #16               : subs   %x16 %x17 asr $0x10 -> %x15
+eb934651 : subs x17, x18, x19, ASR #17               : subs   %x18 %x19 asr $0x11 -> %x17
+eb954e93 : subs x19, x20, x21, ASR #19               : subs   %x20 %x21 asr $0x13 -> %x19
+eb9756d5 : subs x21, x22, x23, ASR #21               : subs   %x22 %x23 asr $0x15 -> %x21
+eb985ef6 : subs x22, x23, x24, ASR #23               : subs   %x23 %x24 asr $0x17 -> %x22
+eb9a6738 : subs x24, x25, x26, ASR #25               : subs   %x25 %x26 asr $0x19 -> %x24
+eb9c6f7a : subs x26, x27, x28, ASR #27               : subs   %x27 %x28 asr $0x1b -> %x26
+eb817c1e : subs x30, x0, x1, ASR #31                 : subs   %x0 %x1 asr $0x1f -> %x30
+
+# CRC32W  <Wd>, <Wn>, <Wm> (CRC32W-R.RR-32C_dp_2src)
+1ac24820 : crc32w w0, w1, w2                         : crc32w %w1 %w2 -> %w0
+1ac44862 : crc32w w2, w3, w4                         : crc32w %w3 %w4 -> %w2
+1ac648a4 : crc32w w4, w5, w6                         : crc32w %w5 %w6 -> %w4
+1ac848e6 : crc32w w6, w7, w8                         : crc32w %w7 %w8 -> %w6
+1aca4928 : crc32w w8, w9, w10                        : crc32w %w9 %w10 -> %w8
+1acb4949 : crc32w w9, w10, w11                       : crc32w %w10 %w11 -> %w9
+1acd498b : crc32w w11, w12, w13                      : crc32w %w12 %w13 -> %w11
+1acf49cd : crc32w w13, w14, w15                      : crc32w %w14 %w15 -> %w13
+1ad14a0f : crc32w w15, w16, w17                      : crc32w %w16 %w17 -> %w15
+1ad34a51 : crc32w w17, w18, w19                      : crc32w %w18 %w19 -> %w17
+1ad54a93 : crc32w w19, w20, w21                      : crc32w %w20 %w21 -> %w19
+1ad74ad5 : crc32w w21, w22, w23                      : crc32w %w22 %w23 -> %w21
+1ad84af6 : crc32w w22, w23, w24                      : crc32w %w23 %w24 -> %w22
+1ada4b38 : crc32w w24, w25, w26                      : crc32w %w25 %w26 -> %w24
+1adc4b7a : crc32w w26, w27, w28                      : crc32w %w27 %w28 -> %w26
+1ac1481e : crc32w w30, w0, w1                        : crc32w %w0 %w1 -> %w30
+
+# CLZ     <Xd>, <Xn> (CLZ-R.R-64_dp_1src)
+dac01020 : clz x0, x1                                : clz    %x1 -> %x0
+dac01062 : clz x2, x3                                : clz    %x3 -> %x2
+dac010a4 : clz x4, x5                                : clz    %x5 -> %x4
+dac010e6 : clz x6, x7                                : clz    %x7 -> %x6
+dac01128 : clz x8, x9                                : clz    %x9 -> %x8
+dac01149 : clz x9, x10                               : clz    %x10 -> %x9
+dac0118b : clz x11, x12                              : clz    %x12 -> %x11
+dac011cd : clz x13, x14                              : clz    %x14 -> %x13
+dac0120f : clz x15, x16                              : clz    %x16 -> %x15
+dac01251 : clz x17, x18                              : clz    %x18 -> %x17
+dac01293 : clz x19, x20                              : clz    %x20 -> %x19
+dac012d5 : clz x21, x22                              : clz    %x22 -> %x21
+dac012f6 : clz x22, x23                              : clz    %x23 -> %x22
+dac01338 : clz x24, x25                              : clz    %x25 -> %x24
+dac0137a : clz x26, x27                              : clz    %x27 -> %x26
+dac0101e : clz x30, x0                               : clz    %x0 -> %x30
+
+# SMADDL  <Xd>, <Wn>, <Wm>, <Xa> (SMADDL-R.RRR-64WA_dp_3src)
+9b220c20 : smaddl x0, w1, w2, x3                     : smaddl %w1 %w2 %x3 -> %x0
+9b241462 : smaddl x2, w3, w4, x5                     : smaddl %w3 %w4 %x5 -> %x2
+9b261ca4 : smaddl x4, w5, w6, x7                     : smaddl %w5 %w6 %x7 -> %x4
+9b2824e6 : smaddl x6, w7, w8, x9                     : smaddl %w7 %w8 %x9 -> %x6
+9b2a2d28 : smaddl x8, w9, w10, x11                   : smaddl %w9 %w10 %x11 -> %x8
+9b2b3149 : smaddl x9, w10, w11, x12                  : smaddl %w10 %w11 %x12 -> %x9
+9b2d398b : smaddl x11, w12, w13, x14                 : smaddl %w12 %w13 %x14 -> %x11
+9b2f41cd : smaddl x13, w14, w15, x16                 : smaddl %w14 %w15 %x16 -> %x13
+9b314a0f : smaddl x15, w16, w17, x18                 : smaddl %w16 %w17 %x18 -> %x15
+9b335251 : smaddl x17, w18, w19, x20                 : smaddl %w18 %w19 %x20 -> %x17
+9b355a93 : smaddl x19, w20, w21, x22                 : smaddl %w20 %w21 %x22 -> %x19
+9b3762d5 : smaddl x21, w22, w23, x24                 : smaddl %w22 %w23 %x24 -> %x21
+9b3866f6 : smaddl x22, w23, w24, x25                 : smaddl %w23 %w24 %x25 -> %x22
+9b3a6f38 : smaddl x24, w25, w26, x27                 : smaddl %w25 %w26 %x27 -> %x24
+9b3c777a : smaddl x26, w27, w28, x29                 : smaddl %w27 %w28 %x29 -> %x26
+9b21081e : smaddl x30, w0, w1, x2                    : smaddl %w0 %w1 %x2 -> %x30
+
+# SBC     <Xd>, <Xn>, <Xm> (SBC-R.RR-64_addsub_carry)
+da020020 : sbc x0, x1, x2                            : sbc    %x1 %x2 -> %x0
+da040062 : sbc x2, x3, x4                            : sbc    %x3 %x4 -> %x2
+da0600a4 : sbc x4, x5, x6                            : sbc    %x5 %x6 -> %x4
+da0800e6 : sbc x6, x7, x8                            : sbc    %x7 %x8 -> %x6
+da0a0128 : sbc x8, x9, x10                           : sbc    %x9 %x10 -> %x8
+da0b0149 : sbc x9, x10, x11                          : sbc    %x10 %x11 -> %x9
+da0d018b : sbc x11, x12, x13                         : sbc    %x12 %x13 -> %x11
+da0f01cd : sbc x13, x14, x15                         : sbc    %x14 %x15 -> %x13
+da11020f : sbc x15, x16, x17                         : sbc    %x16 %x17 -> %x15
+da130251 : sbc x17, x18, x19                         : sbc    %x18 %x19 -> %x17
+da150293 : sbc x19, x20, x21                         : sbc    %x20 %x21 -> %x19
+da1702d5 : sbc x21, x22, x23                         : sbc    %x22 %x23 -> %x21
+da1802f6 : sbc x22, x23, x24                         : sbc    %x23 %x24 -> %x22
+da1a0338 : sbc x24, x25, x26                         : sbc    %x25 %x26 -> %x24
+da1c037a : sbc x26, x27, x28                         : sbc    %x27 %x28 -> %x26
+da01001e : sbc x30, x0, x1                           : sbc    %x0 %x1 -> %x30
+
+# BIC     <Wd>, <Wn>, <Wm>, <extend> #<imm> (BIC-R.RRI-32_log_shift)
+0a220020 : bic w0, w1, w2, LSL #0                    : bic    %w1 %w2 lsl $0x00 -> %w0
+0a240862 : bic w2, w3, w4, LSL #2                    : bic    %w3 %w4 lsl $0x02 -> %w2
+0a2610a4 : bic w4, w5, w6, LSL #4                    : bic    %w5 %w6 lsl $0x04 -> %w4
+0a2818e6 : bic w6, w7, w8, LSL #6                    : bic    %w7 %w8 lsl $0x06 -> %w6
+0a2a2128 : bic w8, w9, w10, LSL #8                   : bic    %w9 %w10 lsl $0x08 -> %w8
+0a2b2949 : bic w9, w10, w11, LSL #10                 : bic    %w10 %w11 lsl $0x0a -> %w9
+0a2d318b : bic w11, w12, w13, LSL #12                : bic    %w12 %w13 lsl $0x0c -> %w11
+0a2f39cd : bic w13, w14, w15, LSL #14                : bic    %w14 %w15 lsl $0x0e -> %w13
+0a31420f : bic w15, w16, w17, LSL #16                : bic    %w16 %w17 lsl $0x10 -> %w15
+0a334651 : bic w17, w18, w19, LSL #17                : bic    %w18 %w19 lsl $0x11 -> %w17
+0a354e93 : bic w19, w20, w21, LSL #19                : bic    %w20 %w21 lsl $0x13 -> %w19
+0a3756d5 : bic w21, w22, w23, LSL #21                : bic    %w22 %w23 lsl $0x15 -> %w21
+0a385ef6 : bic w22, w23, w24, LSL #23                : bic    %w23 %w24 lsl $0x17 -> %w22
+0a3a6738 : bic w24, w25, w26, LSL #25                : bic    %w25 %w26 lsl $0x19 -> %w24
+0a3c6f7a : bic w26, w27, w28, LSL #27                : bic    %w27 %w28 lsl $0x1b -> %w26
+0a217c1e : bic w30, w0, w1, LSL #31                  : bic    %w0 %w1 lsl $0x1f -> %w30
+0a620020 : bic w0, w1, w2, LSR #0                    : bic    %w1 %w2 lsr $0x00 -> %w0
+0a640862 : bic w2, w3, w4, LSR #2                    : bic    %w3 %w4 lsr $0x02 -> %w2
+0a6610a4 : bic w4, w5, w6, LSR #4                    : bic    %w5 %w6 lsr $0x04 -> %w4
+0a6818e6 : bic w6, w7, w8, LSR #6                    : bic    %w7 %w8 lsr $0x06 -> %w6
+0a6a2128 : bic w8, w9, w10, LSR #8                   : bic    %w9 %w10 lsr $0x08 -> %w8
+0a6b2949 : bic w9, w10, w11, LSR #10                 : bic    %w10 %w11 lsr $0x0a -> %w9
+0a6d318b : bic w11, w12, w13, LSR #12                : bic    %w12 %w13 lsr $0x0c -> %w11
+0a6f39cd : bic w13, w14, w15, LSR #14                : bic    %w14 %w15 lsr $0x0e -> %w13
+0a71420f : bic w15, w16, w17, LSR #16                : bic    %w16 %w17 lsr $0x10 -> %w15
+0a734651 : bic w17, w18, w19, LSR #17                : bic    %w18 %w19 lsr $0x11 -> %w17
+0a754e93 : bic w19, w20, w21, LSR #19                : bic    %w20 %w21 lsr $0x13 -> %w19
+0a7756d5 : bic w21, w22, w23, LSR #21                : bic    %w22 %w23 lsr $0x15 -> %w21
+0a785ef6 : bic w22, w23, w24, LSR #23                : bic    %w23 %w24 lsr $0x17 -> %w22
+0a7a6738 : bic w24, w25, w26, LSR #25                : bic    %w25 %w26 lsr $0x19 -> %w24
+0a7c6f7a : bic w26, w27, w28, LSR #27                : bic    %w27 %w28 lsr $0x1b -> %w26
+0a617c1e : bic w30, w0, w1, LSR #31                  : bic    %w0 %w1 lsr $0x1f -> %w30
+0aa20020 : bic w0, w1, w2, ASR #0                    : bic    %w1 %w2 asr $0x00 -> %w0
+0aa40862 : bic w2, w3, w4, ASR #2                    : bic    %w3 %w4 asr $0x02 -> %w2
+0aa610a4 : bic w4, w5, w6, ASR #4                    : bic    %w5 %w6 asr $0x04 -> %w4
+0aa818e6 : bic w6, w7, w8, ASR #6                    : bic    %w7 %w8 asr $0x06 -> %w6
+0aaa2128 : bic w8, w9, w10, ASR #8                   : bic    %w9 %w10 asr $0x08 -> %w8
+0aab2949 : bic w9, w10, w11, ASR #10                 : bic    %w10 %w11 asr $0x0a -> %w9
+0aad318b : bic w11, w12, w13, ASR #12                : bic    %w12 %w13 asr $0x0c -> %w11
+0aaf39cd : bic w13, w14, w15, ASR #14                : bic    %w14 %w15 asr $0x0e -> %w13
+0ab1420f : bic w15, w16, w17, ASR #16                : bic    %w16 %w17 asr $0x10 -> %w15
+0ab34651 : bic w17, w18, w19, ASR #17                : bic    %w18 %w19 asr $0x11 -> %w17
+0ab54e93 : bic w19, w20, w21, ASR #19                : bic    %w20 %w21 asr $0x13 -> %w19
+0ab756d5 : bic w21, w22, w23, ASR #21                : bic    %w22 %w23 asr $0x15 -> %w21
+0ab85ef6 : bic w22, w23, w24, ASR #23                : bic    %w23 %w24 asr $0x17 -> %w22
+0aba6738 : bic w24, w25, w26, ASR #25                : bic    %w25 %w26 asr $0x19 -> %w24
+0abc6f7a : bic w26, w27, w28, ASR #27                : bic    %w27 %w28 asr $0x1b -> %w26
+0aa17c1e : bic w30, w0, w1, ASR #31                  : bic    %w0 %w1 asr $0x1f -> %w30
+0ae20020 : bic w0, w1, w2, ROR #0                    : bic    %w1 %w2 ror $0x00 -> %w0
+0ae40862 : bic w2, w3, w4, ROR #2                    : bic    %w3 %w4 ror $0x02 -> %w2
+0ae610a4 : bic w4, w5, w6, ROR #4                    : bic    %w5 %w6 ror $0x04 -> %w4
+0ae818e6 : bic w6, w7, w8, ROR #6                    : bic    %w7 %w8 ror $0x06 -> %w6
+0aea2128 : bic w8, w9, w10, ROR #8                   : bic    %w9 %w10 ror $0x08 -> %w8
+0aeb2949 : bic w9, w10, w11, ROR #10                 : bic    %w10 %w11 ror $0x0a -> %w9
+0aed318b : bic w11, w12, w13, ROR #12                : bic    %w12 %w13 ror $0x0c -> %w11
+0aef39cd : bic w13, w14, w15, ROR #14                : bic    %w14 %w15 ror $0x0e -> %w13
+0af1420f : bic w15, w16, w17, ROR #16                : bic    %w16 %w17 ror $0x10 -> %w15
+0af34651 : bic w17, w18, w19, ROR #17                : bic    %w18 %w19 ror $0x11 -> %w17
+0af54e93 : bic w19, w20, w21, ROR #19                : bic    %w20 %w21 ror $0x13 -> %w19
+0af756d5 : bic w21, w22, w23, ROR #21                : bic    %w22 %w23 ror $0x15 -> %w21
+0af85ef6 : bic w22, w23, w24, ROR #23                : bic    %w23 %w24 ror $0x17 -> %w22
+0afa6738 : bic w24, w25, w26, ROR #25                : bic    %w25 %w26 ror $0x19 -> %w24
+0afc6f7a : bic w26, w27, w28, ROR #27                : bic    %w27 %w28 ror $0x1b -> %w26
+0ae17c1e : bic w30, w0, w1, ROR #31                  : bic    %w0 %w1 ror $0x1f -> %w30
+
+# ADR     <Xd>, #<imm> (ADR-R.I-only_pcreladdr)
+10800000 : adr x0, #-0x100000                        : adr    <rel> 0x000000000ff00000 -> %x0
+10900002 : adr x2, #-0xe0000                         : adr    <rel> 0x000000000ff20000 -> %x2
+10a00004 : adr x4, #-0xc0000                         : adr    <rel> 0x000000000ff40000 -> %x4
+10b00006 : adr x6, #-0xa0000                         : adr    <rel> 0x000000000ff60000 -> %x6
+10c00008 : adr x8, #-0x80000                         : adr    <rel> 0x000000000ff80000 -> %x8
+10d00009 : adr x9, #-0x60000                         : adr    <rel> 0x000000000ffa0000 -> %x9
+10e0000b : adr x11, #-0x40000                        : adr    <rel> 0x000000000ffc0000 -> %x11
+10f0000d : adr x13, #-0x20000                        : adr    <rel> 0x000000000ffe0000 -> %x13
+1000000f : adr x15, #0x0                             : adr    <rel> 0x0000000010000000 -> %x15
+700ffff1 : adr x17, #0x1ffff                         : adr    <rel> 0x000000001001ffff -> %x17
+701ffff3 : adr x19, #0x3ffff                         : adr    <rel> 0x000000001003ffff -> %x19
+702ffff5 : adr x21, #0x5ffff                         : adr    <rel> 0x000000001005ffff -> %x21
+703ffff6 : adr x22, #0x7ffff                         : adr    <rel> 0x000000001007ffff -> %x22
+704ffff8 : adr x24, #0x9ffff                         : adr    <rel> 0x000000001009ffff -> %x24
+705ffffa : adr x26, #0xbffff                         : adr    <rel> 0x00000000100bffff -> %x26
+707ffffe : adr x30, #0xfffff                         : adr    <rel> 0x00000000100fffff -> %x30
+
+# CSINC   <Wd>, <Wn>, <Wm>, <cond> (CSINC-R.RR-32_condsel)
+1a820420 : csinc w0, w1, w2, EQ                      : csinc  %w1 %w2 eq -> %w0
+1a840462 : csinc w2, w3, w4, EQ                      : csinc  %w3 %w4 eq -> %w2
+1a8604a4 : csinc w4, w5, w6, EQ                      : csinc  %w5 %w6 eq -> %w4
+1a8804e6 : csinc w6, w7, w8, EQ                      : csinc  %w7 %w8 eq -> %w6
+1a8a0528 : csinc w8, w9, w10, EQ                     : csinc  %w9 %w10 eq -> %w8
+1a8b0549 : csinc w9, w10, w11, EQ                    : csinc  %w10 %w11 eq -> %w9
+1a8d058b : csinc w11, w12, w13, EQ                   : csinc  %w12 %w13 eq -> %w11
+1a8f05cd : csinc w13, w14, w15, EQ                   : csinc  %w14 %w15 eq -> %w13
+1a91060f : csinc w15, w16, w17, EQ                   : csinc  %w16 %w17 eq -> %w15
+1a930651 : csinc w17, w18, w19, EQ                   : csinc  %w18 %w19 eq -> %w17
+1a950693 : csinc w19, w20, w21, EQ                   : csinc  %w20 %w21 eq -> %w19
+1a9706d5 : csinc w21, w22, w23, EQ                   : csinc  %w22 %w23 eq -> %w21
+1a9806f6 : csinc w22, w23, w24, EQ                   : csinc  %w23 %w24 eq -> %w22
+1a9a0738 : csinc w24, w25, w26, EQ                   : csinc  %w25 %w26 eq -> %w24
+1a9c077a : csinc w26, w27, w28, EQ                   : csinc  %w27 %w28 eq -> %w26
+1a81041e : csinc w30, w0, w1, EQ                     : csinc  %w0 %w1 eq -> %w30
+1a821420 : csinc w0, w1, w2, NE                      : csinc  %w1 %w2 ne -> %w0
+1a841462 : csinc w2, w3, w4, NE                      : csinc  %w3 %w4 ne -> %w2
+1a8614a4 : csinc w4, w5, w6, NE                      : csinc  %w5 %w6 ne -> %w4
+1a8814e6 : csinc w6, w7, w8, NE                      : csinc  %w7 %w8 ne -> %w6
+1a8a1528 : csinc w8, w9, w10, NE                     : csinc  %w9 %w10 ne -> %w8
+1a8b1549 : csinc w9, w10, w11, NE                    : csinc  %w10 %w11 ne -> %w9
+1a8d158b : csinc w11, w12, w13, NE                   : csinc  %w12 %w13 ne -> %w11
+1a8f15cd : csinc w13, w14, w15, NE                   : csinc  %w14 %w15 ne -> %w13
+1a91160f : csinc w15, w16, w17, NE                   : csinc  %w16 %w17 ne -> %w15
+1a931651 : csinc w17, w18, w19, NE                   : csinc  %w18 %w19 ne -> %w17
+1a951693 : csinc w19, w20, w21, NE                   : csinc  %w20 %w21 ne -> %w19
+1a9716d5 : csinc w21, w22, w23, NE                   : csinc  %w22 %w23 ne -> %w21
+1a9816f6 : csinc w22, w23, w24, NE                   : csinc  %w23 %w24 ne -> %w22
+1a9a1738 : csinc w24, w25, w26, NE                   : csinc  %w25 %w26 ne -> %w24
+1a9c177a : csinc w26, w27, w28, NE                   : csinc  %w27 %w28 ne -> %w26
+1a81141e : csinc w30, w0, w1, NE                     : csinc  %w0 %w1 ne -> %w30
+1a822420 : csinc w0, w1, w2, CS                      : csinc  %w1 %w2 cs -> %w0
+1a842462 : csinc w2, w3, w4, CS                      : csinc  %w3 %w4 cs -> %w2
+1a8624a4 : csinc w4, w5, w6, CS                      : csinc  %w5 %w6 cs -> %w4
+1a8824e6 : csinc w6, w7, w8, CS                      : csinc  %w7 %w8 cs -> %w6
+1a8a2528 : csinc w8, w9, w10, CS                     : csinc  %w9 %w10 cs -> %w8
+1a8b2549 : csinc w9, w10, w11, CS                    : csinc  %w10 %w11 cs -> %w9
+1a8d258b : csinc w11, w12, w13, CS                   : csinc  %w12 %w13 cs -> %w11
+1a8f25cd : csinc w13, w14, w15, CS                   : csinc  %w14 %w15 cs -> %w13
+1a91260f : csinc w15, w16, w17, CS                   : csinc  %w16 %w17 cs -> %w15
+1a932651 : csinc w17, w18, w19, CS                   : csinc  %w18 %w19 cs -> %w17
+1a952693 : csinc w19, w20, w21, CS                   : csinc  %w20 %w21 cs -> %w19
+1a9726d5 : csinc w21, w22, w23, CS                   : csinc  %w22 %w23 cs -> %w21
+1a9826f6 : csinc w22, w23, w24, CS                   : csinc  %w23 %w24 cs -> %w22
+1a9a2738 : csinc w24, w25, w26, CS                   : csinc  %w25 %w26 cs -> %w24
+1a9c277a : csinc w26, w27, w28, CS                   : csinc  %w27 %w28 cs -> %w26
+1a81241e : csinc w30, w0, w1, CS                     : csinc  %w0 %w1 cs -> %w30
+1a823420 : csinc w0, w1, w2, CC                      : csinc  %w1 %w2 cc -> %w0
+1a843462 : csinc w2, w3, w4, CC                      : csinc  %w3 %w4 cc -> %w2
+1a8634a4 : csinc w4, w5, w6, CC                      : csinc  %w5 %w6 cc -> %w4
+1a8834e6 : csinc w6, w7, w8, CC                      : csinc  %w7 %w8 cc -> %w6
+1a8a3528 : csinc w8, w9, w10, CC                     : csinc  %w9 %w10 cc -> %w8
+1a8b3549 : csinc w9, w10, w11, CC                    : csinc  %w10 %w11 cc -> %w9
+1a8d358b : csinc w11, w12, w13, CC                   : csinc  %w12 %w13 cc -> %w11
+1a8f35cd : csinc w13, w14, w15, CC                   : csinc  %w14 %w15 cc -> %w13
+1a91360f : csinc w15, w16, w17, CC                   : csinc  %w16 %w17 cc -> %w15
+1a933651 : csinc w17, w18, w19, CC                   : csinc  %w18 %w19 cc -> %w17
+1a953693 : csinc w19, w20, w21, CC                   : csinc  %w20 %w21 cc -> %w19
+1a9736d5 : csinc w21, w22, w23, CC                   : csinc  %w22 %w23 cc -> %w21
+1a9836f6 : csinc w22, w23, w24, CC                   : csinc  %w23 %w24 cc -> %w22
+1a9a3738 : csinc w24, w25, w26, CC                   : csinc  %w25 %w26 cc -> %w24
+1a9c377a : csinc w26, w27, w28, CC                   : csinc  %w27 %w28 cc -> %w26
+1a81341e : csinc w30, w0, w1, CC                     : csinc  %w0 %w1 cc -> %w30
+1a824420 : csinc w0, w1, w2, MI                      : csinc  %w1 %w2 mi -> %w0
+1a844462 : csinc w2, w3, w4, MI                      : csinc  %w3 %w4 mi -> %w2
+1a8644a4 : csinc w4, w5, w6, MI                      : csinc  %w5 %w6 mi -> %w4
+1a8844e6 : csinc w6, w7, w8, MI                      : csinc  %w7 %w8 mi -> %w6
+1a8a4528 : csinc w8, w9, w10, MI                     : csinc  %w9 %w10 mi -> %w8
+1a8b4549 : csinc w9, w10, w11, MI                    : csinc  %w10 %w11 mi -> %w9
+1a8d458b : csinc w11, w12, w13, MI                   : csinc  %w12 %w13 mi -> %w11
+1a8f45cd : csinc w13, w14, w15, MI                   : csinc  %w14 %w15 mi -> %w13
+1a91460f : csinc w15, w16, w17, MI                   : csinc  %w16 %w17 mi -> %w15
+1a934651 : csinc w17, w18, w19, MI                   : csinc  %w18 %w19 mi -> %w17
+1a954693 : csinc w19, w20, w21, MI                   : csinc  %w20 %w21 mi -> %w19
+1a9746d5 : csinc w21, w22, w23, MI                   : csinc  %w22 %w23 mi -> %w21
+1a9846f6 : csinc w22, w23, w24, MI                   : csinc  %w23 %w24 mi -> %w22
+1a9a4738 : csinc w24, w25, w26, MI                   : csinc  %w25 %w26 mi -> %w24
+1a9c477a : csinc w26, w27, w28, MI                   : csinc  %w27 %w28 mi -> %w26
+1a81441e : csinc w30, w0, w1, MI                     : csinc  %w0 %w1 mi -> %w30
+1a825420 : csinc w0, w1, w2, PL                      : csinc  %w1 %w2 pl -> %w0
+1a845462 : csinc w2, w3, w4, PL                      : csinc  %w3 %w4 pl -> %w2
+1a8654a4 : csinc w4, w5, w6, PL                      : csinc  %w5 %w6 pl -> %w4
+1a8854e6 : csinc w6, w7, w8, PL                      : csinc  %w7 %w8 pl -> %w6
+1a8a5528 : csinc w8, w9, w10, PL                     : csinc  %w9 %w10 pl -> %w8
+1a8b5549 : csinc w9, w10, w11, PL                    : csinc  %w10 %w11 pl -> %w9
+1a8d558b : csinc w11, w12, w13, PL                   : csinc  %w12 %w13 pl -> %w11
+1a8f55cd : csinc w13, w14, w15, PL                   : csinc  %w14 %w15 pl -> %w13
+1a91560f : csinc w15, w16, w17, PL                   : csinc  %w16 %w17 pl -> %w15
+1a935651 : csinc w17, w18, w19, PL                   : csinc  %w18 %w19 pl -> %w17
+1a955693 : csinc w19, w20, w21, PL                   : csinc  %w20 %w21 pl -> %w19
+1a9756d5 : csinc w21, w22, w23, PL                   : csinc  %w22 %w23 pl -> %w21
+1a9856f6 : csinc w22, w23, w24, PL                   : csinc  %w23 %w24 pl -> %w22
+1a9a5738 : csinc w24, w25, w26, PL                   : csinc  %w25 %w26 pl -> %w24
+1a9c577a : csinc w26, w27, w28, PL                   : csinc  %w27 %w28 pl -> %w26
+1a81541e : csinc w30, w0, w1, PL                     : csinc  %w0 %w1 pl -> %w30
+1a826420 : csinc w0, w1, w2, VS                      : csinc  %w1 %w2 vs -> %w0
+1a846462 : csinc w2, w3, w4, VS                      : csinc  %w3 %w4 vs -> %w2
+1a8664a4 : csinc w4, w5, w6, VS                      : csinc  %w5 %w6 vs -> %w4
+1a8864e6 : csinc w6, w7, w8, VS                      : csinc  %w7 %w8 vs -> %w6
+1a8a6528 : csinc w8, w9, w10, VS                     : csinc  %w9 %w10 vs -> %w8
+1a8b6549 : csinc w9, w10, w11, VS                    : csinc  %w10 %w11 vs -> %w9
+1a8d658b : csinc w11, w12, w13, VS                   : csinc  %w12 %w13 vs -> %w11
+1a8f65cd : csinc w13, w14, w15, VS                   : csinc  %w14 %w15 vs -> %w13
+1a91660f : csinc w15, w16, w17, VS                   : csinc  %w16 %w17 vs -> %w15
+1a936651 : csinc w17, w18, w19, VS                   : csinc  %w18 %w19 vs -> %w17
+1a956693 : csinc w19, w20, w21, VS                   : csinc  %w20 %w21 vs -> %w19
+1a9766d5 : csinc w21, w22, w23, VS                   : csinc  %w22 %w23 vs -> %w21
+1a9866f6 : csinc w22, w23, w24, VS                   : csinc  %w23 %w24 vs -> %w22
+1a9a6738 : csinc w24, w25, w26, VS                   : csinc  %w25 %w26 vs -> %w24
+1a9c677a : csinc w26, w27, w28, VS                   : csinc  %w27 %w28 vs -> %w26
+1a81641e : csinc w30, w0, w1, VS                     : csinc  %w0 %w1 vs -> %w30
+1a827420 : csinc w0, w1, w2, VC                      : csinc  %w1 %w2 vc -> %w0
+1a847462 : csinc w2, w3, w4, VC                      : csinc  %w3 %w4 vc -> %w2
+1a8674a4 : csinc w4, w5, w6, VC                      : csinc  %w5 %w6 vc -> %w4
+1a8874e6 : csinc w6, w7, w8, VC                      : csinc  %w7 %w8 vc -> %w6
+1a8a7528 : csinc w8, w9, w10, VC                     : csinc  %w9 %w10 vc -> %w8
+1a8b7549 : csinc w9, w10, w11, VC                    : csinc  %w10 %w11 vc -> %w9
+1a8d758b : csinc w11, w12, w13, VC                   : csinc  %w12 %w13 vc -> %w11
+1a8f75cd : csinc w13, w14, w15, VC                   : csinc  %w14 %w15 vc -> %w13
+1a91760f : csinc w15, w16, w17, VC                   : csinc  %w16 %w17 vc -> %w15
+1a937651 : csinc w17, w18, w19, VC                   : csinc  %w18 %w19 vc -> %w17
+1a957693 : csinc w19, w20, w21, VC                   : csinc  %w20 %w21 vc -> %w19
+1a9776d5 : csinc w21, w22, w23, VC                   : csinc  %w22 %w23 vc -> %w21
+1a9876f6 : csinc w22, w23, w24, VC                   : csinc  %w23 %w24 vc -> %w22
+1a9a7738 : csinc w24, w25, w26, VC                   : csinc  %w25 %w26 vc -> %w24
+1a9c777a : csinc w26, w27, w28, VC                   : csinc  %w27 %w28 vc -> %w26
+1a81741e : csinc w30, w0, w1, VC                     : csinc  %w0 %w1 vc -> %w30
+1a828420 : csinc w0, w1, w2, HI                      : csinc  %w1 %w2 hi -> %w0
+1a848462 : csinc w2, w3, w4, HI                      : csinc  %w3 %w4 hi -> %w2
+1a8684a4 : csinc w4, w5, w6, HI                      : csinc  %w5 %w6 hi -> %w4
+1a8884e6 : csinc w6, w7, w8, HI                      : csinc  %w7 %w8 hi -> %w6
+1a8a8528 : csinc w8, w9, w10, HI                     : csinc  %w9 %w10 hi -> %w8
+1a8b8549 : csinc w9, w10, w11, HI                    : csinc  %w10 %w11 hi -> %w9
+1a8d858b : csinc w11, w12, w13, HI                   : csinc  %w12 %w13 hi -> %w11
+1a8f85cd : csinc w13, w14, w15, HI                   : csinc  %w14 %w15 hi -> %w13
+1a91860f : csinc w15, w16, w17, HI                   : csinc  %w16 %w17 hi -> %w15
+1a938651 : csinc w17, w18, w19, HI                   : csinc  %w18 %w19 hi -> %w17
+1a958693 : csinc w19, w20, w21, HI                   : csinc  %w20 %w21 hi -> %w19
+1a9786d5 : csinc w21, w22, w23, HI                   : csinc  %w22 %w23 hi -> %w21
+1a9886f6 : csinc w22, w23, w24, HI                   : csinc  %w23 %w24 hi -> %w22
+1a9a8738 : csinc w24, w25, w26, HI                   : csinc  %w25 %w26 hi -> %w24
+1a9c877a : csinc w26, w27, w28, HI                   : csinc  %w27 %w28 hi -> %w26
+1a81841e : csinc w30, w0, w1, HI                     : csinc  %w0 %w1 hi -> %w30
+1a829420 : csinc w0, w1, w2, LS                      : csinc  %w1 %w2 ls -> %w0
+1a849462 : csinc w2, w3, w4, LS                      : csinc  %w3 %w4 ls -> %w2
+1a8694a4 : csinc w4, w5, w6, LS                      : csinc  %w5 %w6 ls -> %w4
+1a8894e6 : csinc w6, w7, w8, LS                      : csinc  %w7 %w8 ls -> %w6
+1a8a9528 : csinc w8, w9, w10, LS                     : csinc  %w9 %w10 ls -> %w8
+1a8b9549 : csinc w9, w10, w11, LS                    : csinc  %w10 %w11 ls -> %w9
+1a8d958b : csinc w11, w12, w13, LS                   : csinc  %w12 %w13 ls -> %w11
+1a8f95cd : csinc w13, w14, w15, LS                   : csinc  %w14 %w15 ls -> %w13
+1a91960f : csinc w15, w16, w17, LS                   : csinc  %w16 %w17 ls -> %w15
+1a939651 : csinc w17, w18, w19, LS                   : csinc  %w18 %w19 ls -> %w17
+1a959693 : csinc w19, w20, w21, LS                   : csinc  %w20 %w21 ls -> %w19
+1a9796d5 : csinc w21, w22, w23, LS                   : csinc  %w22 %w23 ls -> %w21
+1a9896f6 : csinc w22, w23, w24, LS                   : csinc  %w23 %w24 ls -> %w22
+1a9a9738 : csinc w24, w25, w26, LS                   : csinc  %w25 %w26 ls -> %w24
+1a9c977a : csinc w26, w27, w28, LS                   : csinc  %w27 %w28 ls -> %w26
+1a81941e : csinc w30, w0, w1, LS                     : csinc  %w0 %w1 ls -> %w30
+1a82a420 : csinc w0, w1, w2, GE                      : csinc  %w1 %w2 ge -> %w0
+1a84a462 : csinc w2, w3, w4, GE                      : csinc  %w3 %w4 ge -> %w2
+1a86a4a4 : csinc w4, w5, w6, GE                      : csinc  %w5 %w6 ge -> %w4
+1a88a4e6 : csinc w6, w7, w8, GE                      : csinc  %w7 %w8 ge -> %w6
+1a8aa528 : csinc w8, w9, w10, GE                     : csinc  %w9 %w10 ge -> %w8
+1a8ba549 : csinc w9, w10, w11, GE                    : csinc  %w10 %w11 ge -> %w9
+1a8da58b : csinc w11, w12, w13, GE                   : csinc  %w12 %w13 ge -> %w11
+1a8fa5cd : csinc w13, w14, w15, GE                   : csinc  %w14 %w15 ge -> %w13
+1a91a60f : csinc w15, w16, w17, GE                   : csinc  %w16 %w17 ge -> %w15
+1a93a651 : csinc w17, w18, w19, GE                   : csinc  %w18 %w19 ge -> %w17
+1a95a693 : csinc w19, w20, w21, GE                   : csinc  %w20 %w21 ge -> %w19
+1a97a6d5 : csinc w21, w22, w23, GE                   : csinc  %w22 %w23 ge -> %w21
+1a98a6f6 : csinc w22, w23, w24, GE                   : csinc  %w23 %w24 ge -> %w22
+1a9aa738 : csinc w24, w25, w26, GE                   : csinc  %w25 %w26 ge -> %w24
+1a9ca77a : csinc w26, w27, w28, GE                   : csinc  %w27 %w28 ge -> %w26
+1a81a41e : csinc w30, w0, w1, GE                     : csinc  %w0 %w1 ge -> %w30
+1a82b420 : csinc w0, w1, w2, LT                      : csinc  %w1 %w2 lt -> %w0
+1a84b462 : csinc w2, w3, w4, LT                      : csinc  %w3 %w4 lt -> %w2
+1a86b4a4 : csinc w4, w5, w6, LT                      : csinc  %w5 %w6 lt -> %w4
+1a88b4e6 : csinc w6, w7, w8, LT                      : csinc  %w7 %w8 lt -> %w6
+1a8ab528 : csinc w8, w9, w10, LT                     : csinc  %w9 %w10 lt -> %w8
+1a8bb549 : csinc w9, w10, w11, LT                    : csinc  %w10 %w11 lt -> %w9
+1a8db58b : csinc w11, w12, w13, LT                   : csinc  %w12 %w13 lt -> %w11
+1a8fb5cd : csinc w13, w14, w15, LT                   : csinc  %w14 %w15 lt -> %w13
+1a91b60f : csinc w15, w16, w17, LT                   : csinc  %w16 %w17 lt -> %w15
+1a93b651 : csinc w17, w18, w19, LT                   : csinc  %w18 %w19 lt -> %w17
+1a95b693 : csinc w19, w20, w21, LT                   : csinc  %w20 %w21 lt -> %w19
+1a97b6d5 : csinc w21, w22, w23, LT                   : csinc  %w22 %w23 lt -> %w21
+1a98b6f6 : csinc w22, w23, w24, LT                   : csinc  %w23 %w24 lt -> %w22
+1a9ab738 : csinc w24, w25, w26, LT                   : csinc  %w25 %w26 lt -> %w24
+1a9cb77a : csinc w26, w27, w28, LT                   : csinc  %w27 %w28 lt -> %w26
+1a81b41e : csinc w30, w0, w1, LT                     : csinc  %w0 %w1 lt -> %w30
+1a82c420 : csinc w0, w1, w2, GT                      : csinc  %w1 %w2 gt -> %w0
+1a84c462 : csinc w2, w3, w4, GT                      : csinc  %w3 %w4 gt -> %w2
+1a86c4a4 : csinc w4, w5, w6, GT                      : csinc  %w5 %w6 gt -> %w4
+1a88c4e6 : csinc w6, w7, w8, GT                      : csinc  %w7 %w8 gt -> %w6
+1a8ac528 : csinc w8, w9, w10, GT                     : csinc  %w9 %w10 gt -> %w8
+1a8bc549 : csinc w9, w10, w11, GT                    : csinc  %w10 %w11 gt -> %w9
+1a8dc58b : csinc w11, w12, w13, GT                   : csinc  %w12 %w13 gt -> %w11
+1a8fc5cd : csinc w13, w14, w15, GT                   : csinc  %w14 %w15 gt -> %w13
+1a91c60f : csinc w15, w16, w17, GT                   : csinc  %w16 %w17 gt -> %w15
+1a93c651 : csinc w17, w18, w19, GT                   : csinc  %w18 %w19 gt -> %w17
+1a95c693 : csinc w19, w20, w21, GT                   : csinc  %w20 %w21 gt -> %w19
+1a97c6d5 : csinc w21, w22, w23, GT                   : csinc  %w22 %w23 gt -> %w21
+1a98c6f6 : csinc w22, w23, w24, GT                   : csinc  %w23 %w24 gt -> %w22
+1a9ac738 : csinc w24, w25, w26, GT                   : csinc  %w25 %w26 gt -> %w24
+1a9cc77a : csinc w26, w27, w28, GT                   : csinc  %w27 %w28 gt -> %w26
+1a81c41e : csinc w30, w0, w1, GT                     : csinc  %w0 %w1 gt -> %w30
+1a82d420 : csinc w0, w1, w2, LE                      : csinc  %w1 %w2 le -> %w0
+1a84d462 : csinc w2, w3, w4, LE                      : csinc  %w3 %w4 le -> %w2
+1a86d4a4 : csinc w4, w5, w6, LE                      : csinc  %w5 %w6 le -> %w4
+1a88d4e6 : csinc w6, w7, w8, LE                      : csinc  %w7 %w8 le -> %w6
+1a8ad528 : csinc w8, w9, w10, LE                     : csinc  %w9 %w10 le -> %w8
+1a8bd549 : csinc w9, w10, w11, LE                    : csinc  %w10 %w11 le -> %w9
+1a8dd58b : csinc w11, w12, w13, LE                   : csinc  %w12 %w13 le -> %w11
+1a8fd5cd : csinc w13, w14, w15, LE                   : csinc  %w14 %w15 le -> %w13
+1a91d60f : csinc w15, w16, w17, LE                   : csinc  %w16 %w17 le -> %w15
+1a93d651 : csinc w17, w18, w19, LE                   : csinc  %w18 %w19 le -> %w17
+1a95d693 : csinc w19, w20, w21, LE                   : csinc  %w20 %w21 le -> %w19
+1a97d6d5 : csinc w21, w22, w23, LE                   : csinc  %w22 %w23 le -> %w21
+1a98d6f6 : csinc w22, w23, w24, LE                   : csinc  %w23 %w24 le -> %w22
+1a9ad738 : csinc w24, w25, w26, LE                   : csinc  %w25 %w26 le -> %w24
+1a9cd77a : csinc w26, w27, w28, LE                   : csinc  %w27 %w28 le -> %w26
+1a81d41e : csinc w30, w0, w1, LE                     : csinc  %w0 %w1 le -> %w30
+1a82e420 : csinc w0, w1, w2, AL                      : csinc  %w1 %w2 al -> %w0
+1a84e462 : csinc w2, w3, w4, AL                      : csinc  %w3 %w4 al -> %w2
+1a86e4a4 : csinc w4, w5, w6, AL                      : csinc  %w5 %w6 al -> %w4
+1a88e4e6 : csinc w6, w7, w8, AL                      : csinc  %w7 %w8 al -> %w6
+1a8ae528 : csinc w8, w9, w10, AL                     : csinc  %w9 %w10 al -> %w8
+1a8be549 : csinc w9, w10, w11, AL                    : csinc  %w10 %w11 al -> %w9
+1a8de58b : csinc w11, w12, w13, AL                   : csinc  %w12 %w13 al -> %w11
+1a8fe5cd : csinc w13, w14, w15, AL                   : csinc  %w14 %w15 al -> %w13
+1a91e60f : csinc w15, w16, w17, AL                   : csinc  %w16 %w17 al -> %w15
+1a93e651 : csinc w17, w18, w19, AL                   : csinc  %w18 %w19 al -> %w17
+1a95e693 : csinc w19, w20, w21, AL                   : csinc  %w20 %w21 al -> %w19
+1a97e6d5 : csinc w21, w22, w23, AL                   : csinc  %w22 %w23 al -> %w21
+1a98e6f6 : csinc w22, w23, w24, AL                   : csinc  %w23 %w24 al -> %w22
+1a9ae738 : csinc w24, w25, w26, AL                   : csinc  %w25 %w26 al -> %w24
+1a9ce77a : csinc w26, w27, w28, AL                   : csinc  %w27 %w28 al -> %w26
+1a81e41e : csinc w30, w0, w1, AL                     : csinc  %w0 %w1 al -> %w30
+1a82f420 : csinc w0, w1, w2, NV                      : csinc  %w1 %w2 nv -> %w0
+1a84f462 : csinc w2, w3, w4, NV                      : csinc  %w3 %w4 nv -> %w2
+1a86f4a4 : csinc w4, w5, w6, NV                      : csinc  %w5 %w6 nv -> %w4
+1a88f4e6 : csinc w6, w7, w8, NV                      : csinc  %w7 %w8 nv -> %w6
+1a8af528 : csinc w8, w9, w10, NV                     : csinc  %w9 %w10 nv -> %w8
+1a8bf549 : csinc w9, w10, w11, NV                    : csinc  %w10 %w11 nv -> %w9
+1a8df58b : csinc w11, w12, w13, NV                   : csinc  %w12 %w13 nv -> %w11
+1a8ff5cd : csinc w13, w14, w15, NV                   : csinc  %w14 %w15 nv -> %w13
+1a91f60f : csinc w15, w16, w17, NV                   : csinc  %w16 %w17 nv -> %w15
+1a93f651 : csinc w17, w18, w19, NV                   : csinc  %w18 %w19 nv -> %w17
+1a95f693 : csinc w19, w20, w21, NV                   : csinc  %w20 %w21 nv -> %w19
+1a97f6d5 : csinc w21, w22, w23, NV                   : csinc  %w22 %w23 nv -> %w21
+1a98f6f6 : csinc w22, w23, w24, NV                   : csinc  %w23 %w24 nv -> %w22
+1a9af738 : csinc w24, w25, w26, NV                   : csinc  %w25 %w26 nv -> %w24
+1a9cf77a : csinc w26, w27, w28, NV                   : csinc  %w27 %w28 nv -> %w26
+1a81f41e : csinc w30, w0, w1, NV                     : csinc  %w0 %w1 nv -> %w30
+
+# CLS     <Wd>, <Wn> (CLS-R.R-32_dp_1src)
+5ac01420 : cls w0, w1                                : cls    %w1 -> %w0
+5ac01462 : cls w2, w3                                : cls    %w3 -> %w2
+5ac014a4 : cls w4, w5                                : cls    %w5 -> %w4
+5ac014e6 : cls w6, w7                                : cls    %w7 -> %w6
+5ac01528 : cls w8, w9                                : cls    %w9 -> %w8
+5ac01549 : cls w9, w10                               : cls    %w10 -> %w9
+5ac0158b : cls w11, w12                              : cls    %w12 -> %w11
+5ac015cd : cls w13, w14                              : cls    %w14 -> %w13
+5ac0160f : cls w15, w16                              : cls    %w16 -> %w15
+5ac01651 : cls w17, w18                              : cls    %w18 -> %w17
+5ac01693 : cls w19, w20                              : cls    %w20 -> %w19
+5ac016d5 : cls w21, w22                              : cls    %w22 -> %w21
+5ac016f6 : cls w22, w23                              : cls    %w23 -> %w22
+5ac01738 : cls w24, w25                              : cls    %w25 -> %w24
+5ac0177a : cls w26, w27                              : cls    %w27 -> %w26
+5ac0141e : cls w30, w0                               : cls    %w0 -> %w30
+
+# AND     <Xd>, <Xn>, <Xm>, <extend> #<imm> (AND-R.RRI-64_log_shift)
+8a020020 : and x0, x1, x2, LSL #0                    : and    %x1 %x2 lsl $0x00 -> %x0
+8a040862 : and x2, x3, x4, LSL #2                    : and    %x3 %x4 lsl $0x02 -> %x2
+8a0610a4 : and x4, x5, x6, LSL #4                    : and    %x5 %x6 lsl $0x04 -> %x4
+8a0818e6 : and x6, x7, x8, LSL #6                    : and    %x7 %x8 lsl $0x06 -> %x6
+8a0a2128 : and x8, x9, x10, LSL #8                   : and    %x9 %x10 lsl $0x08 -> %x8
+8a0b2949 : and x9, x10, x11, LSL #10                 : and    %x10 %x11 lsl $0x0a -> %x9
+8a0d318b : and x11, x12, x13, LSL #12                : and    %x12 %x13 lsl $0x0c -> %x11
+8a0f39cd : and x13, x14, x15, LSL #14                : and    %x14 %x15 lsl $0x0e -> %x13
+8a11420f : and x15, x16, x17, LSL #16                : and    %x16 %x17 lsl $0x10 -> %x15
+8a134651 : and x17, x18, x19, LSL #17                : and    %x18 %x19 lsl $0x11 -> %x17
+8a154e93 : and x19, x20, x21, LSL #19                : and    %x20 %x21 lsl $0x13 -> %x19
+8a1756d5 : and x21, x22, x23, LSL #21                : and    %x22 %x23 lsl $0x15 -> %x21
+8a185ef6 : and x22, x23, x24, LSL #23                : and    %x23 %x24 lsl $0x17 -> %x22
+8a1a6738 : and x24, x25, x26, LSL #25                : and    %x25 %x26 lsl $0x19 -> %x24
+8a1c6f7a : and x26, x27, x28, LSL #27                : and    %x27 %x28 lsl $0x1b -> %x26
+8a017c1e : and x30, x0, x1, LSL #31                  : and    %x0 %x1 lsl $0x1f -> %x30
+8a420020 : and x0, x1, x2, LSR #0                    : and    %x1 %x2 lsr $0x00 -> %x0
+8a440862 : and x2, x3, x4, LSR #2                    : and    %x3 %x4 lsr $0x02 -> %x2
+8a4610a4 : and x4, x5, x6, LSR #4                    : and    %x5 %x6 lsr $0x04 -> %x4
+8a4818e6 : and x6, x7, x8, LSR #6                    : and    %x7 %x8 lsr $0x06 -> %x6
+8a4a2128 : and x8, x9, x10, LSR #8                   : and    %x9 %x10 lsr $0x08 -> %x8
+8a4b2949 : and x9, x10, x11, LSR #10                 : and    %x10 %x11 lsr $0x0a -> %x9
+8a4d318b : and x11, x12, x13, LSR #12                : and    %x12 %x13 lsr $0x0c -> %x11
+8a4f39cd : and x13, x14, x15, LSR #14                : and    %x14 %x15 lsr $0x0e -> %x13
+8a51420f : and x15, x16, x17, LSR #16                : and    %x16 %x17 lsr $0x10 -> %x15
+8a534651 : and x17, x18, x19, LSR #17                : and    %x18 %x19 lsr $0x11 -> %x17
+8a554e93 : and x19, x20, x21, LSR #19                : and    %x20 %x21 lsr $0x13 -> %x19
+8a5756d5 : and x21, x22, x23, LSR #21                : and    %x22 %x23 lsr $0x15 -> %x21
+8a585ef6 : and x22, x23, x24, LSR #23                : and    %x23 %x24 lsr $0x17 -> %x22
+8a5a6738 : and x24, x25, x26, LSR #25                : and    %x25 %x26 lsr $0x19 -> %x24
+8a5c6f7a : and x26, x27, x28, LSR #27                : and    %x27 %x28 lsr $0x1b -> %x26
+8a417c1e : and x30, x0, x1, LSR #31                  : and    %x0 %x1 lsr $0x1f -> %x30
+8a820020 : and x0, x1, x2, ASR #0                    : and    %x1 %x2 asr $0x00 -> %x0
+8a840862 : and x2, x3, x4, ASR #2                    : and    %x3 %x4 asr $0x02 -> %x2
+8a8610a4 : and x4, x5, x6, ASR #4                    : and    %x5 %x6 asr $0x04 -> %x4
+8a8818e6 : and x6, x7, x8, ASR #6                    : and    %x7 %x8 asr $0x06 -> %x6
+8a8a2128 : and x8, x9, x10, ASR #8                   : and    %x9 %x10 asr $0x08 -> %x8
+8a8b2949 : and x9, x10, x11, ASR #10                 : and    %x10 %x11 asr $0x0a -> %x9
+8a8d318b : and x11, x12, x13, ASR #12                : and    %x12 %x13 asr $0x0c -> %x11
+8a8f39cd : and x13, x14, x15, ASR #14                : and    %x14 %x15 asr $0x0e -> %x13
+8a91420f : and x15, x16, x17, ASR #16                : and    %x16 %x17 asr $0x10 -> %x15
+8a934651 : and x17, x18, x19, ASR #17                : and    %x18 %x19 asr $0x11 -> %x17
+8a954e93 : and x19, x20, x21, ASR #19                : and    %x20 %x21 asr $0x13 -> %x19
+8a9756d5 : and x21, x22, x23, ASR #21                : and    %x22 %x23 asr $0x15 -> %x21
+8a985ef6 : and x22, x23, x24, ASR #23                : and    %x23 %x24 asr $0x17 -> %x22
+8a9a6738 : and x24, x25, x26, ASR #25                : and    %x25 %x26 asr $0x19 -> %x24
+8a9c6f7a : and x26, x27, x28, ASR #27                : and    %x27 %x28 asr $0x1b -> %x26
+8a817c1e : and x30, x0, x1, ASR #31                  : and    %x0 %x1 asr $0x1f -> %x30
+8ac20020 : and x0, x1, x2, ROR #0                    : and    %x1 %x2 ror $0x00 -> %x0
+8ac40862 : and x2, x3, x4, ROR #2                    : and    %x3 %x4 ror $0x02 -> %x2
+8ac610a4 : and x4, x5, x6, ROR #4                    : and    %x5 %x6 ror $0x04 -> %x4
+8ac818e6 : and x6, x7, x8, ROR #6                    : and    %x7 %x8 ror $0x06 -> %x6
+8aca2128 : and x8, x9, x10, ROR #8                   : and    %x9 %x10 ror $0x08 -> %x8
+8acb2949 : and x9, x10, x11, ROR #10                 : and    %x10 %x11 ror $0x0a -> %x9
+8acd318b : and x11, x12, x13, ROR #12                : and    %x12 %x13 ror $0x0c -> %x11
+8acf39cd : and x13, x14, x15, ROR #14                : and    %x14 %x15 ror $0x0e -> %x13
+8ad1420f : and x15, x16, x17, ROR #16                : and    %x16 %x17 ror $0x10 -> %x15
+8ad34651 : and x17, x18, x19, ROR #17                : and    %x18 %x19 ror $0x11 -> %x17
+8ad54e93 : and x19, x20, x21, ROR #19                : and    %x20 %x21 ror $0x13 -> %x19
+8ad756d5 : and x21, x22, x23, ROR #21                : and    %x22 %x23 ror $0x15 -> %x21
+8ad85ef6 : and x22, x23, x24, ROR #23                : and    %x23 %x24 ror $0x17 -> %x22
+8ada6738 : and x24, x25, x26, ROR #25                : and    %x25 %x26 ror $0x19 -> %x24
+8adc6f7a : and x26, x27, x28, ROR #27                : and    %x27 %x28 ror $0x1b -> %x26
+8ac17c1e : and x30, x0, x1, ROR #31                  : and    %x0 %x1 ror $0x1f -> %x30
+
+# EOR     <Wd>, <Wn>, <Wm>, <extend> #<imm> (EOR-R.RRI-32_log_shift)
+4a020020 : eor w0, w1, w2, LSL #0                    : eor    %w1 %w2 lsl $0x00 -> %w0
+4a040862 : eor w2, w3, w4, LSL #2                    : eor    %w3 %w4 lsl $0x02 -> %w2
+4a0610a4 : eor w4, w5, w6, LSL #4                    : eor    %w5 %w6 lsl $0x04 -> %w4
+4a0818e6 : eor w6, w7, w8, LSL #6                    : eor    %w7 %w8 lsl $0x06 -> %w6
+4a0a2128 : eor w8, w9, w10, LSL #8                   : eor    %w9 %w10 lsl $0x08 -> %w8
+4a0b2949 : eor w9, w10, w11, LSL #10                 : eor    %w10 %w11 lsl $0x0a -> %w9
+4a0d318b : eor w11, w12, w13, LSL #12                : eor    %w12 %w13 lsl $0x0c -> %w11
+4a0f39cd : eor w13, w14, w15, LSL #14                : eor    %w14 %w15 lsl $0x0e -> %w13
+4a11420f : eor w15, w16, w17, LSL #16                : eor    %w16 %w17 lsl $0x10 -> %w15
+4a134651 : eor w17, w18, w19, LSL #17                : eor    %w18 %w19 lsl $0x11 -> %w17
+4a154e93 : eor w19, w20, w21, LSL #19                : eor    %w20 %w21 lsl $0x13 -> %w19
+4a1756d5 : eor w21, w22, w23, LSL #21                : eor    %w22 %w23 lsl $0x15 -> %w21
+4a185ef6 : eor w22, w23, w24, LSL #23                : eor    %w23 %w24 lsl $0x17 -> %w22
+4a1a6738 : eor w24, w25, w26, LSL #25                : eor    %w25 %w26 lsl $0x19 -> %w24
+4a1c6f7a : eor w26, w27, w28, LSL #27                : eor    %w27 %w28 lsl $0x1b -> %w26
+4a017c1e : eor w30, w0, w1, LSL #31                  : eor    %w0 %w1 lsl $0x1f -> %w30
+4a420020 : eor w0, w1, w2, LSR #0                    : eor    %w1 %w2 lsr $0x00 -> %w0
+4a440862 : eor w2, w3, w4, LSR #2                    : eor    %w3 %w4 lsr $0x02 -> %w2
+4a4610a4 : eor w4, w5, w6, LSR #4                    : eor    %w5 %w6 lsr $0x04 -> %w4
+4a4818e6 : eor w6, w7, w8, LSR #6                    : eor    %w7 %w8 lsr $0x06 -> %w6
+4a4a2128 : eor w8, w9, w10, LSR #8                   : eor    %w9 %w10 lsr $0x08 -> %w8
+4a4b2949 : eor w9, w10, w11, LSR #10                 : eor    %w10 %w11 lsr $0x0a -> %w9
+4a4d318b : eor w11, w12, w13, LSR #12                : eor    %w12 %w13 lsr $0x0c -> %w11
+4a4f39cd : eor w13, w14, w15, LSR #14                : eor    %w14 %w15 lsr $0x0e -> %w13
+4a51420f : eor w15, w16, w17, LSR #16                : eor    %w16 %w17 lsr $0x10 -> %w15
+4a534651 : eor w17, w18, w19, LSR #17                : eor    %w18 %w19 lsr $0x11 -> %w17
+4a554e93 : eor w19, w20, w21, LSR #19                : eor    %w20 %w21 lsr $0x13 -> %w19
+4a5756d5 : eor w21, w22, w23, LSR #21                : eor    %w22 %w23 lsr $0x15 -> %w21
+4a585ef6 : eor w22, w23, w24, LSR #23                : eor    %w23 %w24 lsr $0x17 -> %w22
+4a5a6738 : eor w24, w25, w26, LSR #25                : eor    %w25 %w26 lsr $0x19 -> %w24
+4a5c6f7a : eor w26, w27, w28, LSR #27                : eor    %w27 %w28 lsr $0x1b -> %w26
+4a417c1e : eor w30, w0, w1, LSR #31                  : eor    %w0 %w1 lsr $0x1f -> %w30
+4a820020 : eor w0, w1, w2, ASR #0                    : eor    %w1 %w2 asr $0x00 -> %w0
+4a840862 : eor w2, w3, w4, ASR #2                    : eor    %w3 %w4 asr $0x02 -> %w2
+4a8610a4 : eor w4, w5, w6, ASR #4                    : eor    %w5 %w6 asr $0x04 -> %w4
+4a8818e6 : eor w6, w7, w8, ASR #6                    : eor    %w7 %w8 asr $0x06 -> %w6
+4a8a2128 : eor w8, w9, w10, ASR #8                   : eor    %w9 %w10 asr $0x08 -> %w8
+4a8b2949 : eor w9, w10, w11, ASR #10                 : eor    %w10 %w11 asr $0x0a -> %w9
+4a8d318b : eor w11, w12, w13, ASR #12                : eor    %w12 %w13 asr $0x0c -> %w11
+4a8f39cd : eor w13, w14, w15, ASR #14                : eor    %w14 %w15 asr $0x0e -> %w13
+4a91420f : eor w15, w16, w17, ASR #16                : eor    %w16 %w17 asr $0x10 -> %w15
+4a934651 : eor w17, w18, w19, ASR #17                : eor    %w18 %w19 asr $0x11 -> %w17
+4a954e93 : eor w19, w20, w21, ASR #19                : eor    %w20 %w21 asr $0x13 -> %w19
+4a9756d5 : eor w21, w22, w23, ASR #21                : eor    %w22 %w23 asr $0x15 -> %w21
+4a985ef6 : eor w22, w23, w24, ASR #23                : eor    %w23 %w24 asr $0x17 -> %w22
+4a9a6738 : eor w24, w25, w26, ASR #25                : eor    %w25 %w26 asr $0x19 -> %w24
+4a9c6f7a : eor w26, w27, w28, ASR #27                : eor    %w27 %w28 asr $0x1b -> %w26
+4a817c1e : eor w30, w0, w1, ASR #31                  : eor    %w0 %w1 asr $0x1f -> %w30
+4ac20020 : eor w0, w1, w2, ROR #0                    : eor    %w1 %w2 ror $0x00 -> %w0
+4ac40862 : eor w2, w3, w4, ROR #2                    : eor    %w3 %w4 ror $0x02 -> %w2
+4ac610a4 : eor w4, w5, w6, ROR #4                    : eor    %w5 %w6 ror $0x04 -> %w4
+4ac818e6 : eor w6, w7, w8, ROR #6                    : eor    %w7 %w8 ror $0x06 -> %w6
+4aca2128 : eor w8, w9, w10, ROR #8                   : eor    %w9 %w10 ror $0x08 -> %w8
+4acb2949 : eor w9, w10, w11, ROR #10                 : eor    %w10 %w11 ror $0x0a -> %w9
+4acd318b : eor w11, w12, w13, ROR #12                : eor    %w12 %w13 ror $0x0c -> %w11
+4acf39cd : eor w13, w14, w15, ROR #14                : eor    %w14 %w15 ror $0x0e -> %w13
+4ad1420f : eor w15, w16, w17, ROR #16                : eor    %w16 %w17 ror $0x10 -> %w15
+4ad34651 : eor w17, w18, w19, ROR #17                : eor    %w18 %w19 ror $0x11 -> %w17
+4ad54e93 : eor w19, w20, w21, ROR #19                : eor    %w20 %w21 ror $0x13 -> %w19
+4ad756d5 : eor w21, w22, w23, ROR #21                : eor    %w22 %w23 ror $0x15 -> %w21
+4ad85ef6 : eor w22, w23, w24, ROR #23                : eor    %w23 %w24 ror $0x17 -> %w22
+4ada6738 : eor w24, w25, w26, ROR #25                : eor    %w25 %w26 ror $0x19 -> %w24
+4adc6f7a : eor w26, w27, w28, ROR #27                : eor    %w27 %w28 ror $0x1b -> %w26
+4ac17c1e : eor w30, w0, w1, ROR #31                  : eor    %w0 %w1 ror $0x1f -> %w30
+
+# ADRP    <Xd>, #<imm> (ADRP-R.I-only_pcreladdr)
+90800000 : adrp x0, ( . + -0x100000000)              : adrp   <rel> 0xffffffff10000000 -> %x0
+90900002 : adrp x2, ( . + -0xe0000000)               : adrp   <rel> 0xffffffff30000000 -> %x2
+90a00004 : adrp x4, ( . + -0xc0000000)               : adrp   <rel> 0xffffffff50000000 -> %x4
+90b00006 : adrp x6, ( . + -0xa0000000)               : adrp   <rel> 0xffffffff70000000 -> %x6
+90c00008 : adrp x8, ( . + -0x80000000)               : adrp   <rel> 0xffffffff90000000 -> %x8
+90d00009 : adrp x9, ( . + -0x60000000)               : adrp   <rel> 0xffffffffb0000000 -> %x9
+90e0000b : adrp x11, ( . + -0x40000000)              : adrp   <rel> 0xffffffffd0000000 -> %x11
+90f0000d : adrp x13, ( . + -0x20000000)              : adrp   <rel> 0xfffffffff0000000 -> %x13
+9000000f : adrp x15, ( . + 0x0)                      : adrp   <rel> 0x0000000010000000 -> %x15
+f00ffff1 : adrp x17, ( . + 0x1ffff000)               : adrp   <rel> 0x000000002ffff000 -> %x17
+f01ffff3 : adrp x19, ( . + 0x3ffff000)               : adrp   <rel> 0x000000004ffff000 -> %x19
+f02ffff5 : adrp x21, ( . + 0x5ffff000)               : adrp   <rel> 0x000000006ffff000 -> %x21
+f03ffff6 : adrp x22, ( . + 0x7ffff000)               : adrp   <rel> 0x000000008ffff000 -> %x22
+f04ffff8 : adrp x24, ( . + 0x9ffff000)               : adrp   <rel> 0x00000000affff000 -> %x24
+f05ffffa : adrp x26, ( . + 0xbffff000)               : adrp   <rel> 0x00000000cffff000 -> %x26
+f07ffffe : adrp x30, ( . + 0xfffff000)               : adrp   <rel> 0x000000010ffff000 -> %x30
+
+# CLS     <Xd>, <Xn> (CLS-R.R-64_dp_1src)
+dac01420 : cls x0, x1                                : cls    %x1 -> %x0
+dac01462 : cls x2, x3                                : cls    %x3 -> %x2
+dac014a4 : cls x4, x5                                : cls    %x5 -> %x4
+dac014e6 : cls x6, x7                                : cls    %x7 -> %x6
+dac01528 : cls x8, x9                                : cls    %x9 -> %x8
+dac01549 : cls x9, x10                               : cls    %x10 -> %x9
+dac0158b : cls x11, x12                              : cls    %x12 -> %x11
+dac015cd : cls x13, x14                              : cls    %x14 -> %x13
+dac0160f : cls x15, x16                              : cls    %x16 -> %x15
+dac01651 : cls x17, x18                              : cls    %x18 -> %x17
+dac01693 : cls x19, x20                              : cls    %x20 -> %x19
+dac016d5 : cls x21, x22                              : cls    %x22 -> %x21
+dac016f6 : cls x22, x23                              : cls    %x23 -> %x22
+dac01738 : cls x24, x25                              : cls    %x25 -> %x24
+dac0177a : cls x26, x27                              : cls    %x27 -> %x26
+dac0141e : cls x30, x0                               : cls    %x0 -> %x30
+
+# CSEL    <Xd>, <Xn>, <Xm>, <cond> (CSEL-R.RR-64_condsel)
+9a820020 : csel x0, x1, x2, EQ                       : csel   %x1 %x2 eq -> %x0
+9a840062 : csel x2, x3, x4, EQ                       : csel   %x3 %x4 eq -> %x2
+9a8600a4 : csel x4, x5, x6, EQ                       : csel   %x5 %x6 eq -> %x4
+9a8800e6 : csel x6, x7, x8, EQ                       : csel   %x7 %x8 eq -> %x6
+9a8a0128 : csel x8, x9, x10, EQ                      : csel   %x9 %x10 eq -> %x8
+9a8b0149 : csel x9, x10, x11, EQ                     : csel   %x10 %x11 eq -> %x9
+9a8d018b : csel x11, x12, x13, EQ                    : csel   %x12 %x13 eq -> %x11
+9a8f01cd : csel x13, x14, x15, EQ                    : csel   %x14 %x15 eq -> %x13
+9a91020f : csel x15, x16, x17, EQ                    : csel   %x16 %x17 eq -> %x15
+9a930251 : csel x17, x18, x19, EQ                    : csel   %x18 %x19 eq -> %x17
+9a950293 : csel x19, x20, x21, EQ                    : csel   %x20 %x21 eq -> %x19
+9a9702d5 : csel x21, x22, x23, EQ                    : csel   %x22 %x23 eq -> %x21
+9a9802f6 : csel x22, x23, x24, EQ                    : csel   %x23 %x24 eq -> %x22
+9a9a0338 : csel x24, x25, x26, EQ                    : csel   %x25 %x26 eq -> %x24
+9a9c037a : csel x26, x27, x28, EQ                    : csel   %x27 %x28 eq -> %x26
+9a81001e : csel x30, x0, x1, EQ                      : csel   %x0 %x1 eq -> %x30
+9a821020 : csel x0, x1, x2, NE                       : csel   %x1 %x2 ne -> %x0
+9a841062 : csel x2, x3, x4, NE                       : csel   %x3 %x4 ne -> %x2
+9a8610a4 : csel x4, x5, x6, NE                       : csel   %x5 %x6 ne -> %x4
+9a8810e6 : csel x6, x7, x8, NE                       : csel   %x7 %x8 ne -> %x6
+9a8a1128 : csel x8, x9, x10, NE                      : csel   %x9 %x10 ne -> %x8
+9a8b1149 : csel x9, x10, x11, NE                     : csel   %x10 %x11 ne -> %x9
+9a8d118b : csel x11, x12, x13, NE                    : csel   %x12 %x13 ne -> %x11
+9a8f11cd : csel x13, x14, x15, NE                    : csel   %x14 %x15 ne -> %x13
+9a91120f : csel x15, x16, x17, NE                    : csel   %x16 %x17 ne -> %x15
+9a931251 : csel x17, x18, x19, NE                    : csel   %x18 %x19 ne -> %x17
+9a951293 : csel x19, x20, x21, NE                    : csel   %x20 %x21 ne -> %x19
+9a9712d5 : csel x21, x22, x23, NE                    : csel   %x22 %x23 ne -> %x21
+9a9812f6 : csel x22, x23, x24, NE                    : csel   %x23 %x24 ne -> %x22
+9a9a1338 : csel x24, x25, x26, NE                    : csel   %x25 %x26 ne -> %x24
+9a9c137a : csel x26, x27, x28, NE                    : csel   %x27 %x28 ne -> %x26
+9a81101e : csel x30, x0, x1, NE                      : csel   %x0 %x1 ne -> %x30
+9a822020 : csel x0, x1, x2, CS                       : csel   %x1 %x2 cs -> %x0
+9a842062 : csel x2, x3, x4, CS                       : csel   %x3 %x4 cs -> %x2
+9a8620a4 : csel x4, x5, x6, CS                       : csel   %x5 %x6 cs -> %x4
+9a8820e6 : csel x6, x7, x8, CS                       : csel   %x7 %x8 cs -> %x6
+9a8a2128 : csel x8, x9, x10, CS                      : csel   %x9 %x10 cs -> %x8
+9a8b2149 : csel x9, x10, x11, CS                     : csel   %x10 %x11 cs -> %x9
+9a8d218b : csel x11, x12, x13, CS                    : csel   %x12 %x13 cs -> %x11
+9a8f21cd : csel x13, x14, x15, CS                    : csel   %x14 %x15 cs -> %x13
+9a91220f : csel x15, x16, x17, CS                    : csel   %x16 %x17 cs -> %x15
+9a932251 : csel x17, x18, x19, CS                    : csel   %x18 %x19 cs -> %x17
+9a952293 : csel x19, x20, x21, CS                    : csel   %x20 %x21 cs -> %x19
+9a9722d5 : csel x21, x22, x23, CS                    : csel   %x22 %x23 cs -> %x21
+9a9822f6 : csel x22, x23, x24, CS                    : csel   %x23 %x24 cs -> %x22
+9a9a2338 : csel x24, x25, x26, CS                    : csel   %x25 %x26 cs -> %x24
+9a9c237a : csel x26, x27, x28, CS                    : csel   %x27 %x28 cs -> %x26
+9a81201e : csel x30, x0, x1, CS                      : csel   %x0 %x1 cs -> %x30
+9a823020 : csel x0, x1, x2, CC                       : csel   %x1 %x2 cc -> %x0
+9a843062 : csel x2, x3, x4, CC                       : csel   %x3 %x4 cc -> %x2
+9a8630a4 : csel x4, x5, x6, CC                       : csel   %x5 %x6 cc -> %x4
+9a8830e6 : csel x6, x7, x8, CC                       : csel   %x7 %x8 cc -> %x6
+9a8a3128 : csel x8, x9, x10, CC                      : csel   %x9 %x10 cc -> %x8
+9a8b3149 : csel x9, x10, x11, CC                     : csel   %x10 %x11 cc -> %x9
+9a8d318b : csel x11, x12, x13, CC                    : csel   %x12 %x13 cc -> %x11
+9a8f31cd : csel x13, x14, x15, CC                    : csel   %x14 %x15 cc -> %x13
+9a91320f : csel x15, x16, x17, CC                    : csel   %x16 %x17 cc -> %x15
+9a933251 : csel x17, x18, x19, CC                    : csel   %x18 %x19 cc -> %x17
+9a953293 : csel x19, x20, x21, CC                    : csel   %x20 %x21 cc -> %x19
+9a9732d5 : csel x21, x22, x23, CC                    : csel   %x22 %x23 cc -> %x21
+9a9832f6 : csel x22, x23, x24, CC                    : csel   %x23 %x24 cc -> %x22
+9a9a3338 : csel x24, x25, x26, CC                    : csel   %x25 %x26 cc -> %x24
+9a9c337a : csel x26, x27, x28, CC                    : csel   %x27 %x28 cc -> %x26
+9a81301e : csel x30, x0, x1, CC                      : csel   %x0 %x1 cc -> %x30
+9a824020 : csel x0, x1, x2, MI                       : csel   %x1 %x2 mi -> %x0
+9a844062 : csel x2, x3, x4, MI                       : csel   %x3 %x4 mi -> %x2
+9a8640a4 : csel x4, x5, x6, MI                       : csel   %x5 %x6 mi -> %x4
+9a8840e6 : csel x6, x7, x8, MI                       : csel   %x7 %x8 mi -> %x6
+9a8a4128 : csel x8, x9, x10, MI                      : csel   %x9 %x10 mi -> %x8
+9a8b4149 : csel x9, x10, x11, MI                     : csel   %x10 %x11 mi -> %x9
+9a8d418b : csel x11, x12, x13, MI                    : csel   %x12 %x13 mi -> %x11
+9a8f41cd : csel x13, x14, x15, MI                    : csel   %x14 %x15 mi -> %x13
+9a91420f : csel x15, x16, x17, MI                    : csel   %x16 %x17 mi -> %x15
+9a934251 : csel x17, x18, x19, MI                    : csel   %x18 %x19 mi -> %x17
+9a954293 : csel x19, x20, x21, MI                    : csel   %x20 %x21 mi -> %x19
+9a9742d5 : csel x21, x22, x23, MI                    : csel   %x22 %x23 mi -> %x21
+9a9842f6 : csel x22, x23, x24, MI                    : csel   %x23 %x24 mi -> %x22
+9a9a4338 : csel x24, x25, x26, MI                    : csel   %x25 %x26 mi -> %x24
+9a9c437a : csel x26, x27, x28, MI                    : csel   %x27 %x28 mi -> %x26
+9a81401e : csel x30, x0, x1, MI                      : csel   %x0 %x1 mi -> %x30
+9a825020 : csel x0, x1, x2, PL                       : csel   %x1 %x2 pl -> %x0
+9a845062 : csel x2, x3, x4, PL                       : csel   %x3 %x4 pl -> %x2
+9a8650a4 : csel x4, x5, x6, PL                       : csel   %x5 %x6 pl -> %x4
+9a8850e6 : csel x6, x7, x8, PL                       : csel   %x7 %x8 pl -> %x6
+9a8a5128 : csel x8, x9, x10, PL                      : csel   %x9 %x10 pl -> %x8
+9a8b5149 : csel x9, x10, x11, PL                     : csel   %x10 %x11 pl -> %x9
+9a8d518b : csel x11, x12, x13, PL                    : csel   %x12 %x13 pl -> %x11
+9a8f51cd : csel x13, x14, x15, PL                    : csel   %x14 %x15 pl -> %x13
+9a91520f : csel x15, x16, x17, PL                    : csel   %x16 %x17 pl -> %x15
+9a935251 : csel x17, x18, x19, PL                    : csel   %x18 %x19 pl -> %x17
+9a955293 : csel x19, x20, x21, PL                    : csel   %x20 %x21 pl -> %x19
+9a9752d5 : csel x21, x22, x23, PL                    : csel   %x22 %x23 pl -> %x21
+9a9852f6 : csel x22, x23, x24, PL                    : csel   %x23 %x24 pl -> %x22
+9a9a5338 : csel x24, x25, x26, PL                    : csel   %x25 %x26 pl -> %x24
+9a9c537a : csel x26, x27, x28, PL                    : csel   %x27 %x28 pl -> %x26
+9a81501e : csel x30, x0, x1, PL                      : csel   %x0 %x1 pl -> %x30
+9a826020 : csel x0, x1, x2, VS                       : csel   %x1 %x2 vs -> %x0
+9a846062 : csel x2, x3, x4, VS                       : csel   %x3 %x4 vs -> %x2
+9a8660a4 : csel x4, x5, x6, VS                       : csel   %x5 %x6 vs -> %x4
+9a8860e6 : csel x6, x7, x8, VS                       : csel   %x7 %x8 vs -> %x6
+9a8a6128 : csel x8, x9, x10, VS                      : csel   %x9 %x10 vs -> %x8
+9a8b6149 : csel x9, x10, x11, VS                     : csel   %x10 %x11 vs -> %x9
+9a8d618b : csel x11, x12, x13, VS                    : csel   %x12 %x13 vs -> %x11
+9a8f61cd : csel x13, x14, x15, VS                    : csel   %x14 %x15 vs -> %x13
+9a91620f : csel x15, x16, x17, VS                    : csel   %x16 %x17 vs -> %x15
+9a936251 : csel x17, x18, x19, VS                    : csel   %x18 %x19 vs -> %x17
+9a956293 : csel x19, x20, x21, VS                    : csel   %x20 %x21 vs -> %x19
+9a9762d5 : csel x21, x22, x23, VS                    : csel   %x22 %x23 vs -> %x21
+9a9862f6 : csel x22, x23, x24, VS                    : csel   %x23 %x24 vs -> %x22
+9a9a6338 : csel x24, x25, x26, VS                    : csel   %x25 %x26 vs -> %x24
+9a9c637a : csel x26, x27, x28, VS                    : csel   %x27 %x28 vs -> %x26
+9a81601e : csel x30, x0, x1, VS                      : csel   %x0 %x1 vs -> %x30
+9a827020 : csel x0, x1, x2, VC                       : csel   %x1 %x2 vc -> %x0
+9a847062 : csel x2, x3, x4, VC                       : csel   %x3 %x4 vc -> %x2
+9a8670a4 : csel x4, x5, x6, VC                       : csel   %x5 %x6 vc -> %x4
+9a8870e6 : csel x6, x7, x8, VC                       : csel   %x7 %x8 vc -> %x6
+9a8a7128 : csel x8, x9, x10, VC                      : csel   %x9 %x10 vc -> %x8
+9a8b7149 : csel x9, x10, x11, VC                     : csel   %x10 %x11 vc -> %x9
+9a8d718b : csel x11, x12, x13, VC                    : csel   %x12 %x13 vc -> %x11
+9a8f71cd : csel x13, x14, x15, VC                    : csel   %x14 %x15 vc -> %x13
+9a91720f : csel x15, x16, x17, VC                    : csel   %x16 %x17 vc -> %x15
+9a937251 : csel x17, x18, x19, VC                    : csel   %x18 %x19 vc -> %x17
+9a957293 : csel x19, x20, x21, VC                    : csel   %x20 %x21 vc -> %x19
+9a9772d5 : csel x21, x22, x23, VC                    : csel   %x22 %x23 vc -> %x21
+9a9872f6 : csel x22, x23, x24, VC                    : csel   %x23 %x24 vc -> %x22
+9a9a7338 : csel x24, x25, x26, VC                    : csel   %x25 %x26 vc -> %x24
+9a9c737a : csel x26, x27, x28, VC                    : csel   %x27 %x28 vc -> %x26
+9a81701e : csel x30, x0, x1, VC                      : csel   %x0 %x1 vc -> %x30
+9a828020 : csel x0, x1, x2, HI                       : csel   %x1 %x2 hi -> %x0
+9a848062 : csel x2, x3, x4, HI                       : csel   %x3 %x4 hi -> %x2
+9a8680a4 : csel x4, x5, x6, HI                       : csel   %x5 %x6 hi -> %x4
+9a8880e6 : csel x6, x7, x8, HI                       : csel   %x7 %x8 hi -> %x6
+9a8a8128 : csel x8, x9, x10, HI                      : csel   %x9 %x10 hi -> %x8
+9a8b8149 : csel x9, x10, x11, HI                     : csel   %x10 %x11 hi -> %x9
+9a8d818b : csel x11, x12, x13, HI                    : csel   %x12 %x13 hi -> %x11
+9a8f81cd : csel x13, x14, x15, HI                    : csel   %x14 %x15 hi -> %x13
+9a91820f : csel x15, x16, x17, HI                    : csel   %x16 %x17 hi -> %x15
+9a938251 : csel x17, x18, x19, HI                    : csel   %x18 %x19 hi -> %x17
+9a958293 : csel x19, x20, x21, HI                    : csel   %x20 %x21 hi -> %x19
+9a9782d5 : csel x21, x22, x23, HI                    : csel   %x22 %x23 hi -> %x21
+9a9882f6 : csel x22, x23, x24, HI                    : csel   %x23 %x24 hi -> %x22
+9a9a8338 : csel x24, x25, x26, HI                    : csel   %x25 %x26 hi -> %x24
+9a9c837a : csel x26, x27, x28, HI                    : csel   %x27 %x28 hi -> %x26
+9a81801e : csel x30, x0, x1, HI                      : csel   %x0 %x1 hi -> %x30
+9a829020 : csel x0, x1, x2, LS                       : csel   %x1 %x2 ls -> %x0
+9a849062 : csel x2, x3, x4, LS                       : csel   %x3 %x4 ls -> %x2
+9a8690a4 : csel x4, x5, x6, LS                       : csel   %x5 %x6 ls -> %x4
+9a8890e6 : csel x6, x7, x8, LS                       : csel   %x7 %x8 ls -> %x6
+9a8a9128 : csel x8, x9, x10, LS                      : csel   %x9 %x10 ls -> %x8
+9a8b9149 : csel x9, x10, x11, LS                     : csel   %x10 %x11 ls -> %x9
+9a8d918b : csel x11, x12, x13, LS                    : csel   %x12 %x13 ls -> %x11
+9a8f91cd : csel x13, x14, x15, LS                    : csel   %x14 %x15 ls -> %x13
+9a91920f : csel x15, x16, x17, LS                    : csel   %x16 %x17 ls -> %x15
+9a939251 : csel x17, x18, x19, LS                    : csel   %x18 %x19 ls -> %x17
+9a959293 : csel x19, x20, x21, LS                    : csel   %x20 %x21 ls -> %x19
+9a9792d5 : csel x21, x22, x23, LS                    : csel   %x22 %x23 ls -> %x21
+9a9892f6 : csel x22, x23, x24, LS                    : csel   %x23 %x24 ls -> %x22
+9a9a9338 : csel x24, x25, x26, LS                    : csel   %x25 %x26 ls -> %x24
+9a9c937a : csel x26, x27, x28, LS                    : csel   %x27 %x28 ls -> %x26
+9a81901e : csel x30, x0, x1, LS                      : csel   %x0 %x1 ls -> %x30
+9a82a020 : csel x0, x1, x2, GE                       : csel   %x1 %x2 ge -> %x0
+9a84a062 : csel x2, x3, x4, GE                       : csel   %x3 %x4 ge -> %x2
+9a86a0a4 : csel x4, x5, x6, GE                       : csel   %x5 %x6 ge -> %x4
+9a88a0e6 : csel x6, x7, x8, GE                       : csel   %x7 %x8 ge -> %x6
+9a8aa128 : csel x8, x9, x10, GE                      : csel   %x9 %x10 ge -> %x8
+9a8ba149 : csel x9, x10, x11, GE                     : csel   %x10 %x11 ge -> %x9
+9a8da18b : csel x11, x12, x13, GE                    : csel   %x12 %x13 ge -> %x11
+9a8fa1cd : csel x13, x14, x15, GE                    : csel   %x14 %x15 ge -> %x13
+9a91a20f : csel x15, x16, x17, GE                    : csel   %x16 %x17 ge -> %x15
+9a93a251 : csel x17, x18, x19, GE                    : csel   %x18 %x19 ge -> %x17
+9a95a293 : csel x19, x20, x21, GE                    : csel   %x20 %x21 ge -> %x19
+9a97a2d5 : csel x21, x22, x23, GE                    : csel   %x22 %x23 ge -> %x21
+9a98a2f6 : csel x22, x23, x24, GE                    : csel   %x23 %x24 ge -> %x22
+9a9aa338 : csel x24, x25, x26, GE                    : csel   %x25 %x26 ge -> %x24
+9a9ca37a : csel x26, x27, x28, GE                    : csel   %x27 %x28 ge -> %x26
+9a81a01e : csel x30, x0, x1, GE                      : csel   %x0 %x1 ge -> %x30
+9a82b020 : csel x0, x1, x2, LT                       : csel   %x1 %x2 lt -> %x0
+9a84b062 : csel x2, x3, x4, LT                       : csel   %x3 %x4 lt -> %x2
+9a86b0a4 : csel x4, x5, x6, LT                       : csel   %x5 %x6 lt -> %x4
+9a88b0e6 : csel x6, x7, x8, LT                       : csel   %x7 %x8 lt -> %x6
+9a8ab128 : csel x8, x9, x10, LT                      : csel   %x9 %x10 lt -> %x8
+9a8bb149 : csel x9, x10, x11, LT                     : csel   %x10 %x11 lt -> %x9
+9a8db18b : csel x11, x12, x13, LT                    : csel   %x12 %x13 lt -> %x11
+9a8fb1cd : csel x13, x14, x15, LT                    : csel   %x14 %x15 lt -> %x13
+9a91b20f : csel x15, x16, x17, LT                    : csel   %x16 %x17 lt -> %x15
+9a93b251 : csel x17, x18, x19, LT                    : csel   %x18 %x19 lt -> %x17
+9a95b293 : csel x19, x20, x21, LT                    : csel   %x20 %x21 lt -> %x19
+9a97b2d5 : csel x21, x22, x23, LT                    : csel   %x22 %x23 lt -> %x21
+9a98b2f6 : csel x22, x23, x24, LT                    : csel   %x23 %x24 lt -> %x22
+9a9ab338 : csel x24, x25, x26, LT                    : csel   %x25 %x26 lt -> %x24
+9a9cb37a : csel x26, x27, x28, LT                    : csel   %x27 %x28 lt -> %x26
+9a81b01e : csel x30, x0, x1, LT                      : csel   %x0 %x1 lt -> %x30
+9a82c020 : csel x0, x1, x2, GT                       : csel   %x1 %x2 gt -> %x0
+9a84c062 : csel x2, x3, x4, GT                       : csel   %x3 %x4 gt -> %x2
+9a86c0a4 : csel x4, x5, x6, GT                       : csel   %x5 %x6 gt -> %x4
+9a88c0e6 : csel x6, x7, x8, GT                       : csel   %x7 %x8 gt -> %x6
+9a8ac128 : csel x8, x9, x10, GT                      : csel   %x9 %x10 gt -> %x8
+9a8bc149 : csel x9, x10, x11, GT                     : csel   %x10 %x11 gt -> %x9
+9a8dc18b : csel x11, x12, x13, GT                    : csel   %x12 %x13 gt -> %x11
+9a8fc1cd : csel x13, x14, x15, GT                    : csel   %x14 %x15 gt -> %x13
+9a91c20f : csel x15, x16, x17, GT                    : csel   %x16 %x17 gt -> %x15
+9a93c251 : csel x17, x18, x19, GT                    : csel   %x18 %x19 gt -> %x17
+9a95c293 : csel x19, x20, x21, GT                    : csel   %x20 %x21 gt -> %x19
+9a97c2d5 : csel x21, x22, x23, GT                    : csel   %x22 %x23 gt -> %x21
+9a98c2f6 : csel x22, x23, x24, GT                    : csel   %x23 %x24 gt -> %x22
+9a9ac338 : csel x24, x25, x26, GT                    : csel   %x25 %x26 gt -> %x24
+9a9cc37a : csel x26, x27, x28, GT                    : csel   %x27 %x28 gt -> %x26
+9a81c01e : csel x30, x0, x1, GT                      : csel   %x0 %x1 gt -> %x30
+9a82d020 : csel x0, x1, x2, LE                       : csel   %x1 %x2 le -> %x0
+9a84d062 : csel x2, x3, x4, LE                       : csel   %x3 %x4 le -> %x2
+9a86d0a4 : csel x4, x5, x6, LE                       : csel   %x5 %x6 le -> %x4
+9a88d0e6 : csel x6, x7, x8, LE                       : csel   %x7 %x8 le -> %x6
+9a8ad128 : csel x8, x9, x10, LE                      : csel   %x9 %x10 le -> %x8
+9a8bd149 : csel x9, x10, x11, LE                     : csel   %x10 %x11 le -> %x9
+9a8dd18b : csel x11, x12, x13, LE                    : csel   %x12 %x13 le -> %x11
+9a8fd1cd : csel x13, x14, x15, LE                    : csel   %x14 %x15 le -> %x13
+9a91d20f : csel x15, x16, x17, LE                    : csel   %x16 %x17 le -> %x15
+9a93d251 : csel x17, x18, x19, LE                    : csel   %x18 %x19 le -> %x17
+9a95d293 : csel x19, x20, x21, LE                    : csel   %x20 %x21 le -> %x19
+9a97d2d5 : csel x21, x22, x23, LE                    : csel   %x22 %x23 le -> %x21
+9a98d2f6 : csel x22, x23, x24, LE                    : csel   %x23 %x24 le -> %x22
+9a9ad338 : csel x24, x25, x26, LE                    : csel   %x25 %x26 le -> %x24
+9a9cd37a : csel x26, x27, x28, LE                    : csel   %x27 %x28 le -> %x26
+9a81d01e : csel x30, x0, x1, LE                      : csel   %x0 %x1 le -> %x30
+9a82e020 : csel x0, x1, x2, AL                       : csel   %x1 %x2 al -> %x0
+9a84e062 : csel x2, x3, x4, AL                       : csel   %x3 %x4 al -> %x2
+9a86e0a4 : csel x4, x5, x6, AL                       : csel   %x5 %x6 al -> %x4
+9a88e0e6 : csel x6, x7, x8, AL                       : csel   %x7 %x8 al -> %x6
+9a8ae128 : csel x8, x9, x10, AL                      : csel   %x9 %x10 al -> %x8
+9a8be149 : csel x9, x10, x11, AL                     : csel   %x10 %x11 al -> %x9
+9a8de18b : csel x11, x12, x13, AL                    : csel   %x12 %x13 al -> %x11
+9a8fe1cd : csel x13, x14, x15, AL                    : csel   %x14 %x15 al -> %x13
+9a91e20f : csel x15, x16, x17, AL                    : csel   %x16 %x17 al -> %x15
+9a93e251 : csel x17, x18, x19, AL                    : csel   %x18 %x19 al -> %x17
+9a95e293 : csel x19, x20, x21, AL                    : csel   %x20 %x21 al -> %x19
+9a97e2d5 : csel x21, x22, x23, AL                    : csel   %x22 %x23 al -> %x21
+9a98e2f6 : csel x22, x23, x24, AL                    : csel   %x23 %x24 al -> %x22
+9a9ae338 : csel x24, x25, x26, AL                    : csel   %x25 %x26 al -> %x24
+9a9ce37a : csel x26, x27, x28, AL                    : csel   %x27 %x28 al -> %x26
+9a81e01e : csel x30, x0, x1, AL                      : csel   %x0 %x1 al -> %x30
+9a82f020 : csel x0, x1, x2, NV                       : csel   %x1 %x2 nv -> %x0
+9a84f062 : csel x2, x3, x4, NV                       : csel   %x3 %x4 nv -> %x2
+9a86f0a4 : csel x4, x5, x6, NV                       : csel   %x5 %x6 nv -> %x4
+9a88f0e6 : csel x6, x7, x8, NV                       : csel   %x7 %x8 nv -> %x6
+9a8af128 : csel x8, x9, x10, NV                      : csel   %x9 %x10 nv -> %x8
+9a8bf149 : csel x9, x10, x11, NV                     : csel   %x10 %x11 nv -> %x9
+9a8df18b : csel x11, x12, x13, NV                    : csel   %x12 %x13 nv -> %x11
+9a8ff1cd : csel x13, x14, x15, NV                    : csel   %x14 %x15 nv -> %x13
+9a91f20f : csel x15, x16, x17, NV                    : csel   %x16 %x17 nv -> %x15
+9a93f251 : csel x17, x18, x19, NV                    : csel   %x18 %x19 nv -> %x17
+9a95f293 : csel x19, x20, x21, NV                    : csel   %x20 %x21 nv -> %x19
+9a97f2d5 : csel x21, x22, x23, NV                    : csel   %x22 %x23 nv -> %x21
+9a98f2f6 : csel x22, x23, x24, NV                    : csel   %x23 %x24 nv -> %x22
+9a9af338 : csel x24, x25, x26, NV                    : csel   %x25 %x26 nv -> %x24
+9a9cf37a : csel x26, x27, x28, NV                    : csel   %x27 %x28 nv -> %x26
+9a81f01e : csel x30, x0, x1, NV                      : csel   %x0 %x1 nv -> %x30
+
+# MADD    <Wd>, <Wn>, <Wm>, <Wa> (MADD-R.RRR-32A_dp_3src)
+1b020c20 : madd w0, w1, w2, w3                       : madd   %w1 %w2 %w3 -> %w0
+1b041462 : madd w2, w3, w4, w5                       : madd   %w3 %w4 %w5 -> %w2
+1b061ca4 : madd w4, w5, w6, w7                       : madd   %w5 %w6 %w7 -> %w4
+1b0824e6 : madd w6, w7, w8, w9                       : madd   %w7 %w8 %w9 -> %w6
+1b0a2d28 : madd w8, w9, w10, w11                     : madd   %w9 %w10 %w11 -> %w8
+1b0b3149 : madd w9, w10, w11, w12                    : madd   %w10 %w11 %w12 -> %w9
+1b0d398b : madd w11, w12, w13, w14                   : madd   %w12 %w13 %w14 -> %w11
+1b0f41cd : madd w13, w14, w15, w16                   : madd   %w14 %w15 %w16 -> %w13
+1b114a0f : madd w15, w16, w17, w18                   : madd   %w16 %w17 %w18 -> %w15
+1b135251 : madd w17, w18, w19, w20                   : madd   %w18 %w19 %w20 -> %w17
+1b155a93 : madd w19, w20, w21, w22                   : madd   %w20 %w21 %w22 -> %w19
+1b1762d5 : madd w21, w22, w23, w24                   : madd   %w22 %w23 %w24 -> %w21
+1b1866f6 : madd w22, w23, w24, w25                   : madd   %w23 %w24 %w25 -> %w22
+1b1a6f38 : madd w24, w25, w26, w27                   : madd   %w25 %w26 %w27 -> %w24
+1b1c777a : madd w26, w27, w28, w29                   : madd   %w27 %w28 %w29 -> %w26
+1b01081e : madd w30, w0, w1, w2                      : madd   %w0 %w1 %w2 -> %w30
+
+# CRC32CX <Wd>, <Wn>, <Xm> (CRC32CX-R.RR-64C_dp_2src)
+9ac25c20 : crc32cx w0, w1, x2                        : crc32cx %w1 %x2 -> %w0
+9ac45c62 : crc32cx w2, w3, x4                        : crc32cx %w3 %x4 -> %w2
+9ac65ca4 : crc32cx w4, w5, x6                        : crc32cx %w5 %x6 -> %w4
+9ac85ce6 : crc32cx w6, w7, x8                        : crc32cx %w7 %x8 -> %w6
+9aca5d28 : crc32cx w8, w9, x10                       : crc32cx %w9 %x10 -> %w8
+9acb5d49 : crc32cx w9, w10, x11                      : crc32cx %w10 %x11 -> %w9
+9acd5d8b : crc32cx w11, w12, x13                     : crc32cx %w12 %x13 -> %w11
+9acf5dcd : crc32cx w13, w14, x15                     : crc32cx %w14 %x15 -> %w13
+9ad15e0f : crc32cx w15, w16, x17                     : crc32cx %w16 %x17 -> %w15
+9ad35e51 : crc32cx w17, w18, x19                     : crc32cx %w18 %x19 -> %w17
+9ad55e93 : crc32cx w19, w20, x21                     : crc32cx %w20 %x21 -> %w19
+9ad75ed5 : crc32cx w21, w22, x23                     : crc32cx %w22 %x23 -> %w21
+9ad85ef6 : crc32cx w22, w23, x24                     : crc32cx %w23 %x24 -> %w22
+9ada5f38 : crc32cx w24, w25, x26                     : crc32cx %w25 %x26 -> %w24
+9adc5f7a : crc32cx w26, w27, x28                     : crc32cx %w27 %x28 -> %w26
+9ac15c1e : crc32cx w30, w0, x1                       : crc32cx %w0 %x1 -> %w30
+
+# EOR     <Xd|SP>, <Xn>, #<imm> (EOR-R.RI-64_log_imm)
+d2000020 : eor x0, x1, #0x100000001                  : eor    %x1 $0x0000000100000001 -> %x0
+d2040062 : eor x2, x3, #0x1000000010000000           : eor    %x3 $0x1000000010000000 -> %x2
+d20800a4 : eor x4, x5, #0x100000001000000            : eor    %x5 $0x0100000001000000 -> %x4
+d20c00e6 : eor x6, x7, #0x10000000100000             : eor    %x7 $0x0010000000100000 -> %x6
+d2100128 : eor x8, x9, #0x1000000010000              : eor    %x9 $0x0001000000010000 -> %x8
+d2140149 : eor x9, x10, #0x100000001000              : eor    %x10 $0x0000100000001000 -> %x9
+d218018b : eor x11, x12, #0x10000000100              : eor    %x12 $0x0000010000000100 -> %x11
+d21c01cd : eor x13, x14, #0x1000000010               : eor    %x14 $0x0000001000000010 -> %x13
+d200020f : eor x15, x16, #0x100000001                : eor    %x16 $0x0000000100000001 -> %x15
+d203ea51 : eor x17, x18, #0xeeeeeeeeeeeeeeee         : eor    %x18 $0xeeeeeeeeeeeeeeee -> %x17
+d203ea93 : eor x19, x20, #0xeeeeeeeeeeeeeeee         : eor    %x20 $0xeeeeeeeeeeeeeeee -> %x19
+d203ead5 : eor x21, x22, #0xeeeeeeeeeeeeeeee         : eor    %x22 $0xeeeeeeeeeeeeeeee -> %x21
+d203eaf6 : eor x22, x23, #0xeeeeeeeeeeeeeeee         : eor    %x23 $0xeeeeeeeeeeeeeeee -> %x22
+d203eb38 : eor x24, x25, #0xeeeeeeeeeeeeeeee         : eor    %x25 $0xeeeeeeeeeeeeeeee -> %x24
+d203eb7a : eor x26, x27, #0xeeeeeeeeeeeeeeee         : eor    %x27 $0xeeeeeeeeeeeeeeee -> %x26
+d203e81f : eor sp, x0, #0xeeeeeeeeeeeeeeee           : eor    %x0 $0xeeeeeeeeeeeeeeee -> %sp
+
+# CRC32H  <Wd>, <Wn>, <Wm> (CRC32H-R.RR-32C_dp_2src)
+1ac24420 : crc32h w0, w1, w2                         : crc32h %w1 %w2 -> %w0
+1ac44462 : crc32h w2, w3, w4                         : crc32h %w3 %w4 -> %w2
+1ac644a4 : crc32h w4, w5, w6                         : crc32h %w5 %w6 -> %w4
+1ac844e6 : crc32h w6, w7, w8                         : crc32h %w7 %w8 -> %w6
+1aca4528 : crc32h w8, w9, w10                        : crc32h %w9 %w10 -> %w8
+1acb4549 : crc32h w9, w10, w11                       : crc32h %w10 %w11 -> %w9
+1acd458b : crc32h w11, w12, w13                      : crc32h %w12 %w13 -> %w11
+1acf45cd : crc32h w13, w14, w15                      : crc32h %w14 %w15 -> %w13
+1ad1460f : crc32h w15, w16, w17                      : crc32h %w16 %w17 -> %w15
+1ad34651 : crc32h w17, w18, w19                      : crc32h %w18 %w19 -> %w17
+1ad54693 : crc32h w19, w20, w21                      : crc32h %w20 %w21 -> %w19
+1ad746d5 : crc32h w21, w22, w23                      : crc32h %w22 %w23 -> %w21
+1ad846f6 : crc32h w22, w23, w24                      : crc32h %w23 %w24 -> %w22
+1ada4738 : crc32h w24, w25, w26                      : crc32h %w25 %w26 -> %w24
+1adc477a : crc32h w26, w27, w28                      : crc32h %w27 %w28 -> %w26
+1ac1441e : crc32h w30, w0, w1                        : crc32h %w0 %w1 -> %w30
+
+# ORR     <Wd>, <Wn>, <Wm>, <extend> #<imm> (ORR-R.RRI-32_log_shift)
+2a020020 : orr w0, w1, w2, LSL #0                    : orr    %w1 %w2 lsl $0x00 -> %w0
+2a040862 : orr w2, w3, w4, LSL #2                    : orr    %w3 %w4 lsl $0x02 -> %w2
+2a0610a4 : orr w4, w5, w6, LSL #4                    : orr    %w5 %w6 lsl $0x04 -> %w4
+2a0818e6 : orr w6, w7, w8, LSL #6                    : orr    %w7 %w8 lsl $0x06 -> %w6
+2a0a2128 : orr w8, w9, w10, LSL #8                   : orr    %w9 %w10 lsl $0x08 -> %w8
+2a0b2949 : orr w9, w10, w11, LSL #10                 : orr    %w10 %w11 lsl $0x0a -> %w9
+2a0d318b : orr w11, w12, w13, LSL #12                : orr    %w12 %w13 lsl $0x0c -> %w11
+2a0f39cd : orr w13, w14, w15, LSL #14                : orr    %w14 %w15 lsl $0x0e -> %w13
+2a11420f : orr w15, w16, w17, LSL #16                : orr    %w16 %w17 lsl $0x10 -> %w15
+2a134651 : orr w17, w18, w19, LSL #17                : orr    %w18 %w19 lsl $0x11 -> %w17
+2a154e93 : orr w19, w20, w21, LSL #19                : orr    %w20 %w21 lsl $0x13 -> %w19
+2a1756d5 : orr w21, w22, w23, LSL #21                : orr    %w22 %w23 lsl $0x15 -> %w21
+2a185ef6 : orr w22, w23, w24, LSL #23                : orr    %w23 %w24 lsl $0x17 -> %w22
+2a1a6738 : orr w24, w25, w26, LSL #25                : orr    %w25 %w26 lsl $0x19 -> %w24
+2a1c6f7a : orr w26, w27, w28, LSL #27                : orr    %w27 %w28 lsl $0x1b -> %w26
+2a017c1e : orr w30, w0, w1, LSL #31                  : orr    %w0 %w1 lsl $0x1f -> %w30
+2a420020 : orr w0, w1, w2, LSR #0                    : orr    %w1 %w2 lsr $0x00 -> %w0
+2a440862 : orr w2, w3, w4, LSR #2                    : orr    %w3 %w4 lsr $0x02 -> %w2
+2a4610a4 : orr w4, w5, w6, LSR #4                    : orr    %w5 %w6 lsr $0x04 -> %w4
+2a4818e6 : orr w6, w7, w8, LSR #6                    : orr    %w7 %w8 lsr $0x06 -> %w6
+2a4a2128 : orr w8, w9, w10, LSR #8                   : orr    %w9 %w10 lsr $0x08 -> %w8
+2a4b2949 : orr w9, w10, w11, LSR #10                 : orr    %w10 %w11 lsr $0x0a -> %w9
+2a4d318b : orr w11, w12, w13, LSR #12                : orr    %w12 %w13 lsr $0x0c -> %w11
+2a4f39cd : orr w13, w14, w15, LSR #14                : orr    %w14 %w15 lsr $0x0e -> %w13
+2a51420f : orr w15, w16, w17, LSR #16                : orr    %w16 %w17 lsr $0x10 -> %w15
+2a534651 : orr w17, w18, w19, LSR #17                : orr    %w18 %w19 lsr $0x11 -> %w17
+2a554e93 : orr w19, w20, w21, LSR #19                : orr    %w20 %w21 lsr $0x13 -> %w19
+2a5756d5 : orr w21, w22, w23, LSR #21                : orr    %w22 %w23 lsr $0x15 -> %w21
+2a585ef6 : orr w22, w23, w24, LSR #23                : orr    %w23 %w24 lsr $0x17 -> %w22
+2a5a6738 : orr w24, w25, w26, LSR #25                : orr    %w25 %w26 lsr $0x19 -> %w24
+2a5c6f7a : orr w26, w27, w28, LSR #27                : orr    %w27 %w28 lsr $0x1b -> %w26
+2a417c1e : orr w30, w0, w1, LSR #31                  : orr    %w0 %w1 lsr $0x1f -> %w30
+2a820020 : orr w0, w1, w2, ASR #0                    : orr    %w1 %w2 asr $0x00 -> %w0
+2a840862 : orr w2, w3, w4, ASR #2                    : orr    %w3 %w4 asr $0x02 -> %w2
+2a8610a4 : orr w4, w5, w6, ASR #4                    : orr    %w5 %w6 asr $0x04 -> %w4
+2a8818e6 : orr w6, w7, w8, ASR #6                    : orr    %w7 %w8 asr $0x06 -> %w6
+2a8a2128 : orr w8, w9, w10, ASR #8                   : orr    %w9 %w10 asr $0x08 -> %w8
+2a8b2949 : orr w9, w10, w11, ASR #10                 : orr    %w10 %w11 asr $0x0a -> %w9
+2a8d318b : orr w11, w12, w13, ASR #12                : orr    %w12 %w13 asr $0x0c -> %w11
+2a8f39cd : orr w13, w14, w15, ASR #14                : orr    %w14 %w15 asr $0x0e -> %w13
+2a91420f : orr w15, w16, w17, ASR #16                : orr    %w16 %w17 asr $0x10 -> %w15
+2a934651 : orr w17, w18, w19, ASR #17                : orr    %w18 %w19 asr $0x11 -> %w17
+2a954e93 : orr w19, w20, w21, ASR #19                : orr    %w20 %w21 asr $0x13 -> %w19
+2a9756d5 : orr w21, w22, w23, ASR #21                : orr    %w22 %w23 asr $0x15 -> %w21
+2a985ef6 : orr w22, w23, w24, ASR #23                : orr    %w23 %w24 asr $0x17 -> %w22
+2a9a6738 : orr w24, w25, w26, ASR #25                : orr    %w25 %w26 asr $0x19 -> %w24
+2a9c6f7a : orr w26, w27, w28, ASR #27                : orr    %w27 %w28 asr $0x1b -> %w26
+2a817c1e : orr w30, w0, w1, ASR #31                  : orr    %w0 %w1 asr $0x1f -> %w30
+2ac20020 : orr w0, w1, w2, ROR #0                    : orr    %w1 %w2 ror $0x00 -> %w0
+2ac40862 : orr w2, w3, w4, ROR #2                    : orr    %w3 %w4 ror $0x02 -> %w2
+2ac610a4 : orr w4, w5, w6, ROR #4                    : orr    %w5 %w6 ror $0x04 -> %w4
+2ac818e6 : orr w6, w7, w8, ROR #6                    : orr    %w7 %w8 ror $0x06 -> %w6
+2aca2128 : orr w8, w9, w10, ROR #8                   : orr    %w9 %w10 ror $0x08 -> %w8
+2acb2949 : orr w9, w10, w11, ROR #10                 : orr    %w10 %w11 ror $0x0a -> %w9
+2acd318b : orr w11, w12, w13, ROR #12                : orr    %w12 %w13 ror $0x0c -> %w11
+2acf39cd : orr w13, w14, w15, ROR #14                : orr    %w14 %w15 ror $0x0e -> %w13
+2ad1420f : orr w15, w16, w17, ROR #16                : orr    %w16 %w17 ror $0x10 -> %w15
+2ad34651 : orr w17, w18, w19, ROR #17                : orr    %w18 %w19 ror $0x11 -> %w17
+2ad54e93 : orr w19, w20, w21, ROR #19                : orr    %w20 %w21 ror $0x13 -> %w19
+2ad756d5 : orr w21, w22, w23, ROR #21                : orr    %w22 %w23 ror $0x15 -> %w21
+2ad85ef6 : orr w22, w23, w24, ROR #23                : orr    %w23 %w24 ror $0x17 -> %w22
+2ada6738 : orr w24, w25, w26, ROR #25                : orr    %w25 %w26 ror $0x19 -> %w24
+2adc6f7a : orr w26, w27, w28, ROR #27                : orr    %w27 %w28 ror $0x1b -> %w26
+2ac17c1e : orr w30, w0, w1, ROR #31                  : orr    %w0 %w1 ror $0x1f -> %w30
+
+# REV32   <Xd>, <Xn> (REV32-R.R-64_dp_1src)
+dac00820 : rev32 x0, x1                              : rev32  %x1 -> %x0
+dac00862 : rev32 x2, x3                              : rev32  %x3 -> %x2
+dac008a4 : rev32 x4, x5                              : rev32  %x5 -> %x4
+dac008e6 : rev32 x6, x7                              : rev32  %x7 -> %x6
+dac00928 : rev32 x8, x9                              : rev32  %x9 -> %x8
+dac00949 : rev32 x9, x10                             : rev32  %x10 -> %x9
+dac0098b : rev32 x11, x12                            : rev32  %x12 -> %x11
+dac009cd : rev32 x13, x14                            : rev32  %x14 -> %x13
+dac00a0f : rev32 x15, x16                            : rev32  %x16 -> %x15
+dac00a51 : rev32 x17, x18                            : rev32  %x18 -> %x17
+dac00a93 : rev32 x19, x20                            : rev32  %x20 -> %x19
+dac00ad5 : rev32 x21, x22                            : rev32  %x22 -> %x21
+dac00af6 : rev32 x22, x23                            : rev32  %x23 -> %x22
+dac00b38 : rev32 x24, x25                            : rev32  %x25 -> %x24
+dac00b7a : rev32 x26, x27                            : rev32  %x27 -> %x26
+dac0081e : rev32 x30, x0                             : rev32  %x0 -> %x30
+
+# CSNEG   <Xd>, <Xn>, <Xm>, <cond> (CSNEG-R.RR-64_condsel)
+da820420 : csneg x0, x1, x2, EQ                      : csneg  %x1 %x2 eq -> %x0
+da840462 : csneg x2, x3, x4, EQ                      : csneg  %x3 %x4 eq -> %x2
+da8604a4 : csneg x4, x5, x6, EQ                      : csneg  %x5 %x6 eq -> %x4
+da8804e6 : csneg x6, x7, x8, EQ                      : csneg  %x7 %x8 eq -> %x6
+da8a0528 : csneg x8, x9, x10, EQ                     : csneg  %x9 %x10 eq -> %x8
+da8b0549 : csneg x9, x10, x11, EQ                    : csneg  %x10 %x11 eq -> %x9
+da8d058b : csneg x11, x12, x13, EQ                   : csneg  %x12 %x13 eq -> %x11
+da8f05cd : csneg x13, x14, x15, EQ                   : csneg  %x14 %x15 eq -> %x13
+da91060f : csneg x15, x16, x17, EQ                   : csneg  %x16 %x17 eq -> %x15
+da930651 : csneg x17, x18, x19, EQ                   : csneg  %x18 %x19 eq -> %x17
+da950693 : csneg x19, x20, x21, EQ                   : csneg  %x20 %x21 eq -> %x19
+da9706d5 : csneg x21, x22, x23, EQ                   : csneg  %x22 %x23 eq -> %x21
+da9806f6 : csneg x22, x23, x24, EQ                   : csneg  %x23 %x24 eq -> %x22
+da9a0738 : csneg x24, x25, x26, EQ                   : csneg  %x25 %x26 eq -> %x24
+da9c077a : csneg x26, x27, x28, EQ                   : csneg  %x27 %x28 eq -> %x26
+da81041e : csneg x30, x0, x1, EQ                     : csneg  %x0 %x1 eq -> %x30
+da821420 : csneg x0, x1, x2, NE                      : csneg  %x1 %x2 ne -> %x0
+da841462 : csneg x2, x3, x4, NE                      : csneg  %x3 %x4 ne -> %x2
+da8614a4 : csneg x4, x5, x6, NE                      : csneg  %x5 %x6 ne -> %x4
+da8814e6 : csneg x6, x7, x8, NE                      : csneg  %x7 %x8 ne -> %x6
+da8a1528 : csneg x8, x9, x10, NE                     : csneg  %x9 %x10 ne -> %x8
+da8b1549 : csneg x9, x10, x11, NE                    : csneg  %x10 %x11 ne -> %x9
+da8d158b : csneg x11, x12, x13, NE                   : csneg  %x12 %x13 ne -> %x11
+da8f15cd : csneg x13, x14, x15, NE                   : csneg  %x14 %x15 ne -> %x13
+da91160f : csneg x15, x16, x17, NE                   : csneg  %x16 %x17 ne -> %x15
+da931651 : csneg x17, x18, x19, NE                   : csneg  %x18 %x19 ne -> %x17
+da951693 : csneg x19, x20, x21, NE                   : csneg  %x20 %x21 ne -> %x19
+da9716d5 : csneg x21, x22, x23, NE                   : csneg  %x22 %x23 ne -> %x21
+da9816f6 : csneg x22, x23, x24, NE                   : csneg  %x23 %x24 ne -> %x22
+da9a1738 : csneg x24, x25, x26, NE                   : csneg  %x25 %x26 ne -> %x24
+da9c177a : csneg x26, x27, x28, NE                   : csneg  %x27 %x28 ne -> %x26
+da81141e : csneg x30, x0, x1, NE                     : csneg  %x0 %x1 ne -> %x30
+da822420 : csneg x0, x1, x2, CS                      : csneg  %x1 %x2 cs -> %x0
+da842462 : csneg x2, x3, x4, CS                      : csneg  %x3 %x4 cs -> %x2
+da8624a4 : csneg x4, x5, x6, CS                      : csneg  %x5 %x6 cs -> %x4
+da8824e6 : csneg x6, x7, x8, CS                      : csneg  %x7 %x8 cs -> %x6
+da8a2528 : csneg x8, x9, x10, CS                     : csneg  %x9 %x10 cs -> %x8
+da8b2549 : csneg x9, x10, x11, CS                    : csneg  %x10 %x11 cs -> %x9
+da8d258b : csneg x11, x12, x13, CS                   : csneg  %x12 %x13 cs -> %x11
+da8f25cd : csneg x13, x14, x15, CS                   : csneg  %x14 %x15 cs -> %x13
+da91260f : csneg x15, x16, x17, CS                   : csneg  %x16 %x17 cs -> %x15
+da932651 : csneg x17, x18, x19, CS                   : csneg  %x18 %x19 cs -> %x17
+da952693 : csneg x19, x20, x21, CS                   : csneg  %x20 %x21 cs -> %x19
+da9726d5 : csneg x21, x22, x23, CS                   : csneg  %x22 %x23 cs -> %x21
+da9826f6 : csneg x22, x23, x24, CS                   : csneg  %x23 %x24 cs -> %x22
+da9a2738 : csneg x24, x25, x26, CS                   : csneg  %x25 %x26 cs -> %x24
+da9c277a : csneg x26, x27, x28, CS                   : csneg  %x27 %x28 cs -> %x26
+da81241e : csneg x30, x0, x1, CS                     : csneg  %x0 %x1 cs -> %x30
+da823420 : csneg x0, x1, x2, CC                      : csneg  %x1 %x2 cc -> %x0
+da843462 : csneg x2, x3, x4, CC                      : csneg  %x3 %x4 cc -> %x2
+da8634a4 : csneg x4, x5, x6, CC                      : csneg  %x5 %x6 cc -> %x4
+da8834e6 : csneg x6, x7, x8, CC                      : csneg  %x7 %x8 cc -> %x6
+da8a3528 : csneg x8, x9, x10, CC                     : csneg  %x9 %x10 cc -> %x8
+da8b3549 : csneg x9, x10, x11, CC                    : csneg  %x10 %x11 cc -> %x9
+da8d358b : csneg x11, x12, x13, CC                   : csneg  %x12 %x13 cc -> %x11
+da8f35cd : csneg x13, x14, x15, CC                   : csneg  %x14 %x15 cc -> %x13
+da91360f : csneg x15, x16, x17, CC                   : csneg  %x16 %x17 cc -> %x15
+da933651 : csneg x17, x18, x19, CC                   : csneg  %x18 %x19 cc -> %x17
+da953693 : csneg x19, x20, x21, CC                   : csneg  %x20 %x21 cc -> %x19
+da9736d5 : csneg x21, x22, x23, CC                   : csneg  %x22 %x23 cc -> %x21
+da9836f6 : csneg x22, x23, x24, CC                   : csneg  %x23 %x24 cc -> %x22
+da9a3738 : csneg x24, x25, x26, CC                   : csneg  %x25 %x26 cc -> %x24
+da9c377a : csneg x26, x27, x28, CC                   : csneg  %x27 %x28 cc -> %x26
+da81341e : csneg x30, x0, x1, CC                     : csneg  %x0 %x1 cc -> %x30
+da824420 : csneg x0, x1, x2, MI                      : csneg  %x1 %x2 mi -> %x0
+da844462 : csneg x2, x3, x4, MI                      : csneg  %x3 %x4 mi -> %x2
+da8644a4 : csneg x4, x5, x6, MI                      : csneg  %x5 %x6 mi -> %x4
+da8844e6 : csneg x6, x7, x8, MI                      : csneg  %x7 %x8 mi -> %x6
+da8a4528 : csneg x8, x9, x10, MI                     : csneg  %x9 %x10 mi -> %x8
+da8b4549 : csneg x9, x10, x11, MI                    : csneg  %x10 %x11 mi -> %x9
+da8d458b : csneg x11, x12, x13, MI                   : csneg  %x12 %x13 mi -> %x11
+da8f45cd : csneg x13, x14, x15, MI                   : csneg  %x14 %x15 mi -> %x13
+da91460f : csneg x15, x16, x17, MI                   : csneg  %x16 %x17 mi -> %x15
+da934651 : csneg x17, x18, x19, MI                   : csneg  %x18 %x19 mi -> %x17
+da954693 : csneg x19, x20, x21, MI                   : csneg  %x20 %x21 mi -> %x19
+da9746d5 : csneg x21, x22, x23, MI                   : csneg  %x22 %x23 mi -> %x21
+da9846f6 : csneg x22, x23, x24, MI                   : csneg  %x23 %x24 mi -> %x22
+da9a4738 : csneg x24, x25, x26, MI                   : csneg  %x25 %x26 mi -> %x24
+da9c477a : csneg x26, x27, x28, MI                   : csneg  %x27 %x28 mi -> %x26
+da81441e : csneg x30, x0, x1, MI                     : csneg  %x0 %x1 mi -> %x30
+da825420 : csneg x0, x1, x2, PL                      : csneg  %x1 %x2 pl -> %x0
+da845462 : csneg x2, x3, x4, PL                      : csneg  %x3 %x4 pl -> %x2
+da8654a4 : csneg x4, x5, x6, PL                      : csneg  %x5 %x6 pl -> %x4
+da8854e6 : csneg x6, x7, x8, PL                      : csneg  %x7 %x8 pl -> %x6
+da8a5528 : csneg x8, x9, x10, PL                     : csneg  %x9 %x10 pl -> %x8
+da8b5549 : csneg x9, x10, x11, PL                    : csneg  %x10 %x11 pl -> %x9
+da8d558b : csneg x11, x12, x13, PL                   : csneg  %x12 %x13 pl -> %x11
+da8f55cd : csneg x13, x14, x15, PL                   : csneg  %x14 %x15 pl -> %x13
+da91560f : csneg x15, x16, x17, PL                   : csneg  %x16 %x17 pl -> %x15
+da935651 : csneg x17, x18, x19, PL                   : csneg  %x18 %x19 pl -> %x17
+da955693 : csneg x19, x20, x21, PL                   : csneg  %x20 %x21 pl -> %x19
+da9756d5 : csneg x21, x22, x23, PL                   : csneg  %x22 %x23 pl -> %x21
+da9856f6 : csneg x22, x23, x24, PL                   : csneg  %x23 %x24 pl -> %x22
+da9a5738 : csneg x24, x25, x26, PL                   : csneg  %x25 %x26 pl -> %x24
+da9c577a : csneg x26, x27, x28, PL                   : csneg  %x27 %x28 pl -> %x26
+da81541e : csneg x30, x0, x1, PL                     : csneg  %x0 %x1 pl -> %x30
+da826420 : csneg x0, x1, x2, VS                      : csneg  %x1 %x2 vs -> %x0
+da846462 : csneg x2, x3, x4, VS                      : csneg  %x3 %x4 vs -> %x2
+da8664a4 : csneg x4, x5, x6, VS                      : csneg  %x5 %x6 vs -> %x4
+da8864e6 : csneg x6, x7, x8, VS                      : csneg  %x7 %x8 vs -> %x6
+da8a6528 : csneg x8, x9, x10, VS                     : csneg  %x9 %x10 vs -> %x8
+da8b6549 : csneg x9, x10, x11, VS                    : csneg  %x10 %x11 vs -> %x9
+da8d658b : csneg x11, x12, x13, VS                   : csneg  %x12 %x13 vs -> %x11
+da8f65cd : csneg x13, x14, x15, VS                   : csneg  %x14 %x15 vs -> %x13
+da91660f : csneg x15, x16, x17, VS                   : csneg  %x16 %x17 vs -> %x15
+da936651 : csneg x17, x18, x19, VS                   : csneg  %x18 %x19 vs -> %x17
+da956693 : csneg x19, x20, x21, VS                   : csneg  %x20 %x21 vs -> %x19
+da9766d5 : csneg x21, x22, x23, VS                   : csneg  %x22 %x23 vs -> %x21
+da9866f6 : csneg x22, x23, x24, VS                   : csneg  %x23 %x24 vs -> %x22
+da9a6738 : csneg x24, x25, x26, VS                   : csneg  %x25 %x26 vs -> %x24
+da9c677a : csneg x26, x27, x28, VS                   : csneg  %x27 %x28 vs -> %x26
+da81641e : csneg x30, x0, x1, VS                     : csneg  %x0 %x1 vs -> %x30
+da827420 : csneg x0, x1, x2, VC                      : csneg  %x1 %x2 vc -> %x0
+da847462 : csneg x2, x3, x4, VC                      : csneg  %x3 %x4 vc -> %x2
+da8674a4 : csneg x4, x5, x6, VC                      : csneg  %x5 %x6 vc -> %x4
+da8874e6 : csneg x6, x7, x8, VC                      : csneg  %x7 %x8 vc -> %x6
+da8a7528 : csneg x8, x9, x10, VC                     : csneg  %x9 %x10 vc -> %x8
+da8b7549 : csneg x9, x10, x11, VC                    : csneg  %x10 %x11 vc -> %x9
+da8d758b : csneg x11, x12, x13, VC                   : csneg  %x12 %x13 vc -> %x11
+da8f75cd : csneg x13, x14, x15, VC                   : csneg  %x14 %x15 vc -> %x13
+da91760f : csneg x15, x16, x17, VC                   : csneg  %x16 %x17 vc -> %x15
+da937651 : csneg x17, x18, x19, VC                   : csneg  %x18 %x19 vc -> %x17
+da957693 : csneg x19, x20, x21, VC                   : csneg  %x20 %x21 vc -> %x19
+da9776d5 : csneg x21, x22, x23, VC                   : csneg  %x22 %x23 vc -> %x21
+da9876f6 : csneg x22, x23, x24, VC                   : csneg  %x23 %x24 vc -> %x22
+da9a7738 : csneg x24, x25, x26, VC                   : csneg  %x25 %x26 vc -> %x24
+da9c777a : csneg x26, x27, x28, VC                   : csneg  %x27 %x28 vc -> %x26
+da81741e : csneg x30, x0, x1, VC                     : csneg  %x0 %x1 vc -> %x30
+da828420 : csneg x0, x1, x2, HI                      : csneg  %x1 %x2 hi -> %x0
+da848462 : csneg x2, x3, x4, HI                      : csneg  %x3 %x4 hi -> %x2
+da8684a4 : csneg x4, x5, x6, HI                      : csneg  %x5 %x6 hi -> %x4
+da8884e6 : csneg x6, x7, x8, HI                      : csneg  %x7 %x8 hi -> %x6
+da8a8528 : csneg x8, x9, x10, HI                     : csneg  %x9 %x10 hi -> %x8
+da8b8549 : csneg x9, x10, x11, HI                    : csneg  %x10 %x11 hi -> %x9
+da8d858b : csneg x11, x12, x13, HI                   : csneg  %x12 %x13 hi -> %x11
+da8f85cd : csneg x13, x14, x15, HI                   : csneg  %x14 %x15 hi -> %x13
+da91860f : csneg x15, x16, x17, HI                   : csneg  %x16 %x17 hi -> %x15
+da938651 : csneg x17, x18, x19, HI                   : csneg  %x18 %x19 hi -> %x17
+da958693 : csneg x19, x20, x21, HI                   : csneg  %x20 %x21 hi -> %x19
+da9786d5 : csneg x21, x22, x23, HI                   : csneg  %x22 %x23 hi -> %x21
+da9886f6 : csneg x22, x23, x24, HI                   : csneg  %x23 %x24 hi -> %x22
+da9a8738 : csneg x24, x25, x26, HI                   : csneg  %x25 %x26 hi -> %x24
+da9c877a : csneg x26, x27, x28, HI                   : csneg  %x27 %x28 hi -> %x26
+da81841e : csneg x30, x0, x1, HI                     : csneg  %x0 %x1 hi -> %x30
+da829420 : csneg x0, x1, x2, LS                      : csneg  %x1 %x2 ls -> %x0
+da849462 : csneg x2, x3, x4, LS                      : csneg  %x3 %x4 ls -> %x2
+da8694a4 : csneg x4, x5, x6, LS                      : csneg  %x5 %x6 ls -> %x4
+da8894e6 : csneg x6, x7, x8, LS                      : csneg  %x7 %x8 ls -> %x6
+da8a9528 : csneg x8, x9, x10, LS                     : csneg  %x9 %x10 ls -> %x8
+da8b9549 : csneg x9, x10, x11, LS                    : csneg  %x10 %x11 ls -> %x9
+da8d958b : csneg x11, x12, x13, LS                   : csneg  %x12 %x13 ls -> %x11
+da8f95cd : csneg x13, x14, x15, LS                   : csneg  %x14 %x15 ls -> %x13
+da91960f : csneg x15, x16, x17, LS                   : csneg  %x16 %x17 ls -> %x15
+da939651 : csneg x17, x18, x19, LS                   : csneg  %x18 %x19 ls -> %x17
+da959693 : csneg x19, x20, x21, LS                   : csneg  %x20 %x21 ls -> %x19
+da9796d5 : csneg x21, x22, x23, LS                   : csneg  %x22 %x23 ls -> %x21
+da9896f6 : csneg x22, x23, x24, LS                   : csneg  %x23 %x24 ls -> %x22
+da9a9738 : csneg x24, x25, x26, LS                   : csneg  %x25 %x26 ls -> %x24
+da9c977a : csneg x26, x27, x28, LS                   : csneg  %x27 %x28 ls -> %x26
+da81941e : csneg x30, x0, x1, LS                     : csneg  %x0 %x1 ls -> %x30
+da82a420 : csneg x0, x1, x2, GE                      : csneg  %x1 %x2 ge -> %x0
+da84a462 : csneg x2, x3, x4, GE                      : csneg  %x3 %x4 ge -> %x2
+da86a4a4 : csneg x4, x5, x6, GE                      : csneg  %x5 %x6 ge -> %x4
+da88a4e6 : csneg x6, x7, x8, GE                      : csneg  %x7 %x8 ge -> %x6
+da8aa528 : csneg x8, x9, x10, GE                     : csneg  %x9 %x10 ge -> %x8
+da8ba549 : csneg x9, x10, x11, GE                    : csneg  %x10 %x11 ge -> %x9
+da8da58b : csneg x11, x12, x13, GE                   : csneg  %x12 %x13 ge -> %x11
+da8fa5cd : csneg x13, x14, x15, GE                   : csneg  %x14 %x15 ge -> %x13
+da91a60f : csneg x15, x16, x17, GE                   : csneg  %x16 %x17 ge -> %x15
+da93a651 : csneg x17, x18, x19, GE                   : csneg  %x18 %x19 ge -> %x17
+da95a693 : csneg x19, x20, x21, GE                   : csneg  %x20 %x21 ge -> %x19
+da97a6d5 : csneg x21, x22, x23, GE                   : csneg  %x22 %x23 ge -> %x21
+da98a6f6 : csneg x22, x23, x24, GE                   : csneg  %x23 %x24 ge -> %x22
+da9aa738 : csneg x24, x25, x26, GE                   : csneg  %x25 %x26 ge -> %x24
+da9ca77a : csneg x26, x27, x28, GE                   : csneg  %x27 %x28 ge -> %x26
+da81a41e : csneg x30, x0, x1, GE                     : csneg  %x0 %x1 ge -> %x30
+da82b420 : csneg x0, x1, x2, LT                      : csneg  %x1 %x2 lt -> %x0
+da84b462 : csneg x2, x3, x4, LT                      : csneg  %x3 %x4 lt -> %x2
+da86b4a4 : csneg x4, x5, x6, LT                      : csneg  %x5 %x6 lt -> %x4
+da88b4e6 : csneg x6, x7, x8, LT                      : csneg  %x7 %x8 lt -> %x6
+da8ab528 : csneg x8, x9, x10, LT                     : csneg  %x9 %x10 lt -> %x8
+da8bb549 : csneg x9, x10, x11, LT                    : csneg  %x10 %x11 lt -> %x9
+da8db58b : csneg x11, x12, x13, LT                   : csneg  %x12 %x13 lt -> %x11
+da8fb5cd : csneg x13, x14, x15, LT                   : csneg  %x14 %x15 lt -> %x13
+da91b60f : csneg x15, x16, x17, LT                   : csneg  %x16 %x17 lt -> %x15
+da93b651 : csneg x17, x18, x19, LT                   : csneg  %x18 %x19 lt -> %x17
+da95b693 : csneg x19, x20, x21, LT                   : csneg  %x20 %x21 lt -> %x19
+da97b6d5 : csneg x21, x22, x23, LT                   : csneg  %x22 %x23 lt -> %x21
+da98b6f6 : csneg x22, x23, x24, LT                   : csneg  %x23 %x24 lt -> %x22
+da9ab738 : csneg x24, x25, x26, LT                   : csneg  %x25 %x26 lt -> %x24
+da9cb77a : csneg x26, x27, x28, LT                   : csneg  %x27 %x28 lt -> %x26
+da81b41e : csneg x30, x0, x1, LT                     : csneg  %x0 %x1 lt -> %x30
+da82c420 : csneg x0, x1, x2, GT                      : csneg  %x1 %x2 gt -> %x0
+da84c462 : csneg x2, x3, x4, GT                      : csneg  %x3 %x4 gt -> %x2
+da86c4a4 : csneg x4, x5, x6, GT                      : csneg  %x5 %x6 gt -> %x4
+da88c4e6 : csneg x6, x7, x8, GT                      : csneg  %x7 %x8 gt -> %x6
+da8ac528 : csneg x8, x9, x10, GT                     : csneg  %x9 %x10 gt -> %x8
+da8bc549 : csneg x9, x10, x11, GT                    : csneg  %x10 %x11 gt -> %x9
+da8dc58b : csneg x11, x12, x13, GT                   : csneg  %x12 %x13 gt -> %x11
+da8fc5cd : csneg x13, x14, x15, GT                   : csneg  %x14 %x15 gt -> %x13
+da91c60f : csneg x15, x16, x17, GT                   : csneg  %x16 %x17 gt -> %x15
+da93c651 : csneg x17, x18, x19, GT                   : csneg  %x18 %x19 gt -> %x17
+da95c693 : csneg x19, x20, x21, GT                   : csneg  %x20 %x21 gt -> %x19
+da97c6d5 : csneg x21, x22, x23, GT                   : csneg  %x22 %x23 gt -> %x21
+da98c6f6 : csneg x22, x23, x24, GT                   : csneg  %x23 %x24 gt -> %x22
+da9ac738 : csneg x24, x25, x26, GT                   : csneg  %x25 %x26 gt -> %x24
+da9cc77a : csneg x26, x27, x28, GT                   : csneg  %x27 %x28 gt -> %x26
+da81c41e : csneg x30, x0, x1, GT                     : csneg  %x0 %x1 gt -> %x30
+da82d420 : csneg x0, x1, x2, LE                      : csneg  %x1 %x2 le -> %x0
+da84d462 : csneg x2, x3, x4, LE                      : csneg  %x3 %x4 le -> %x2
+da86d4a4 : csneg x4, x5, x6, LE                      : csneg  %x5 %x6 le -> %x4
+da88d4e6 : csneg x6, x7, x8, LE                      : csneg  %x7 %x8 le -> %x6
+da8ad528 : csneg x8, x9, x10, LE                     : csneg  %x9 %x10 le -> %x8
+da8bd549 : csneg x9, x10, x11, LE                    : csneg  %x10 %x11 le -> %x9
+da8dd58b : csneg x11, x12, x13, LE                   : csneg  %x12 %x13 le -> %x11
+da8fd5cd : csneg x13, x14, x15, LE                   : csneg  %x14 %x15 le -> %x13
+da91d60f : csneg x15, x16, x17, LE                   : csneg  %x16 %x17 le -> %x15
+da93d651 : csneg x17, x18, x19, LE                   : csneg  %x18 %x19 le -> %x17
+da95d693 : csneg x19, x20, x21, LE                   : csneg  %x20 %x21 le -> %x19
+da97d6d5 : csneg x21, x22, x23, LE                   : csneg  %x22 %x23 le -> %x21
+da98d6f6 : csneg x22, x23, x24, LE                   : csneg  %x23 %x24 le -> %x22
+da9ad738 : csneg x24, x25, x26, LE                   : csneg  %x25 %x26 le -> %x24
+da9cd77a : csneg x26, x27, x28, LE                   : csneg  %x27 %x28 le -> %x26
+da81d41e : csneg x30, x0, x1, LE                     : csneg  %x0 %x1 le -> %x30
+da82e420 : csneg x0, x1, x2, AL                      : csneg  %x1 %x2 al -> %x0
+da84e462 : csneg x2, x3, x4, AL                      : csneg  %x3 %x4 al -> %x2
+da86e4a4 : csneg x4, x5, x6, AL                      : csneg  %x5 %x6 al -> %x4
+da88e4e6 : csneg x6, x7, x8, AL                      : csneg  %x7 %x8 al -> %x6
+da8ae528 : csneg x8, x9, x10, AL                     : csneg  %x9 %x10 al -> %x8
+da8be549 : csneg x9, x10, x11, AL                    : csneg  %x10 %x11 al -> %x9
+da8de58b : csneg x11, x12, x13, AL                   : csneg  %x12 %x13 al -> %x11
+da8fe5cd : csneg x13, x14, x15, AL                   : csneg  %x14 %x15 al -> %x13
+da91e60f : csneg x15, x16, x17, AL                   : csneg  %x16 %x17 al -> %x15
+da93e651 : csneg x17, x18, x19, AL                   : csneg  %x18 %x19 al -> %x17
+da95e693 : csneg x19, x20, x21, AL                   : csneg  %x20 %x21 al -> %x19
+da97e6d5 : csneg x21, x22, x23, AL                   : csneg  %x22 %x23 al -> %x21
+da98e6f6 : csneg x22, x23, x24, AL                   : csneg  %x23 %x24 al -> %x22
+da9ae738 : csneg x24, x25, x26, AL                   : csneg  %x25 %x26 al -> %x24
+da9ce77a : csneg x26, x27, x28, AL                   : csneg  %x27 %x28 al -> %x26
+da81e41e : csneg x30, x0, x1, AL                     : csneg  %x0 %x1 al -> %x30
+da82f420 : csneg x0, x1, x2, NV                      : csneg  %x1 %x2 nv -> %x0
+da84f462 : csneg x2, x3, x4, NV                      : csneg  %x3 %x4 nv -> %x2
+da86f4a4 : csneg x4, x5, x6, NV                      : csneg  %x5 %x6 nv -> %x4
+da88f4e6 : csneg x6, x7, x8, NV                      : csneg  %x7 %x8 nv -> %x6
+da8af528 : csneg x8, x9, x10, NV                     : csneg  %x9 %x10 nv -> %x8
+da8bf549 : csneg x9, x10, x11, NV                    : csneg  %x10 %x11 nv -> %x9
+da8df58b : csneg x11, x12, x13, NV                   : csneg  %x12 %x13 nv -> %x11
+da8ff5cd : csneg x13, x14, x15, NV                   : csneg  %x14 %x15 nv -> %x13
+da91f60f : csneg x15, x16, x17, NV                   : csneg  %x16 %x17 nv -> %x15
+da93f651 : csneg x17, x18, x19, NV                   : csneg  %x18 %x19 nv -> %x17
+da95f693 : csneg x19, x20, x21, NV                   : csneg  %x20 %x21 nv -> %x19
+da97f6d5 : csneg x21, x22, x23, NV                   : csneg  %x22 %x23 nv -> %x21
+da98f6f6 : csneg x22, x23, x24, NV                   : csneg  %x23 %x24 nv -> %x22
+da9af738 : csneg x24, x25, x26, NV                   : csneg  %x25 %x26 nv -> %x24
+da9cf77a : csneg x26, x27, x28, NV                   : csneg  %x27 %x28 nv -> %x26
+da81f41e : csneg x30, x0, x1, NV                     : csneg  %x0 %x1 nv -> %x30
+
+# BICS    <Wd>, <Wn>, <Wm>, <extend> #<imm> (BICS-R.RRI-32_log_shift)
+6a220020 : bics w0, w1, w2, LSL #0                   : bics   %w1 %w2 lsl $0x00 -> %w0
+6a240862 : bics w2, w3, w4, LSL #2                   : bics   %w3 %w4 lsl $0x02 -> %w2
+6a2610a4 : bics w4, w5, w6, LSL #4                   : bics   %w5 %w6 lsl $0x04 -> %w4
+6a2818e6 : bics w6, w7, w8, LSL #6                   : bics   %w7 %w8 lsl $0x06 -> %w6
+6a2a2128 : bics w8, w9, w10, LSL #8                  : bics   %w9 %w10 lsl $0x08 -> %w8
+6a2b2949 : bics w9, w10, w11, LSL #10                : bics   %w10 %w11 lsl $0x0a -> %w9
+6a2d318b : bics w11, w12, w13, LSL #12               : bics   %w12 %w13 lsl $0x0c -> %w11
+6a2f39cd : bics w13, w14, w15, LSL #14               : bics   %w14 %w15 lsl $0x0e -> %w13
+6a31420f : bics w15, w16, w17, LSL #16               : bics   %w16 %w17 lsl $0x10 -> %w15
+6a334651 : bics w17, w18, w19, LSL #17               : bics   %w18 %w19 lsl $0x11 -> %w17
+6a354e93 : bics w19, w20, w21, LSL #19               : bics   %w20 %w21 lsl $0x13 -> %w19
+6a3756d5 : bics w21, w22, w23, LSL #21               : bics   %w22 %w23 lsl $0x15 -> %w21
+6a385ef6 : bics w22, w23, w24, LSL #23               : bics   %w23 %w24 lsl $0x17 -> %w22
+6a3a6738 : bics w24, w25, w26, LSL #25               : bics   %w25 %w26 lsl $0x19 -> %w24
+6a3c6f7a : bics w26, w27, w28, LSL #27               : bics   %w27 %w28 lsl $0x1b -> %w26
+6a217c1e : bics w30, w0, w1, LSL #31                 : bics   %w0 %w1 lsl $0x1f -> %w30
+6a620020 : bics w0, w1, w2, LSR #0                   : bics   %w1 %w2 lsr $0x00 -> %w0
+6a640862 : bics w2, w3, w4, LSR #2                   : bics   %w3 %w4 lsr $0x02 -> %w2
+6a6610a4 : bics w4, w5, w6, LSR #4                   : bics   %w5 %w6 lsr $0x04 -> %w4
+6a6818e6 : bics w6, w7, w8, LSR #6                   : bics   %w7 %w8 lsr $0x06 -> %w6
+6a6a2128 : bics w8, w9, w10, LSR #8                  : bics   %w9 %w10 lsr $0x08 -> %w8
+6a6b2949 : bics w9, w10, w11, LSR #10                : bics   %w10 %w11 lsr $0x0a -> %w9
+6a6d318b : bics w11, w12, w13, LSR #12               : bics   %w12 %w13 lsr $0x0c -> %w11
+6a6f39cd : bics w13, w14, w15, LSR #14               : bics   %w14 %w15 lsr $0x0e -> %w13
+6a71420f : bics w15, w16, w17, LSR #16               : bics   %w16 %w17 lsr $0x10 -> %w15
+6a734651 : bics w17, w18, w19, LSR #17               : bics   %w18 %w19 lsr $0x11 -> %w17
+6a754e93 : bics w19, w20, w21, LSR #19               : bics   %w20 %w21 lsr $0x13 -> %w19
+6a7756d5 : bics w21, w22, w23, LSR #21               : bics   %w22 %w23 lsr $0x15 -> %w21
+6a785ef6 : bics w22, w23, w24, LSR #23               : bics   %w23 %w24 lsr $0x17 -> %w22
+6a7a6738 : bics w24, w25, w26, LSR #25               : bics   %w25 %w26 lsr $0x19 -> %w24
+6a7c6f7a : bics w26, w27, w28, LSR #27               : bics   %w27 %w28 lsr $0x1b -> %w26
+6a617c1e : bics w30, w0, w1, LSR #31                 : bics   %w0 %w1 lsr $0x1f -> %w30
+6aa20020 : bics w0, w1, w2, ASR #0                   : bics   %w1 %w2 asr $0x00 -> %w0
+6aa40862 : bics w2, w3, w4, ASR #2                   : bics   %w3 %w4 asr $0x02 -> %w2
+6aa610a4 : bics w4, w5, w6, ASR #4                   : bics   %w5 %w6 asr $0x04 -> %w4
+6aa818e6 : bics w6, w7, w8, ASR #6                   : bics   %w7 %w8 asr $0x06 -> %w6
+6aaa2128 : bics w8, w9, w10, ASR #8                  : bics   %w9 %w10 asr $0x08 -> %w8
+6aab2949 : bics w9, w10, w11, ASR #10                : bics   %w10 %w11 asr $0x0a -> %w9
+6aad318b : bics w11, w12, w13, ASR #12               : bics   %w12 %w13 asr $0x0c -> %w11
+6aaf39cd : bics w13, w14, w15, ASR #14               : bics   %w14 %w15 asr $0x0e -> %w13
+6ab1420f : bics w15, w16, w17, ASR #16               : bics   %w16 %w17 asr $0x10 -> %w15
+6ab34651 : bics w17, w18, w19, ASR #17               : bics   %w18 %w19 asr $0x11 -> %w17
+6ab54e93 : bics w19, w20, w21, ASR #19               : bics   %w20 %w21 asr $0x13 -> %w19
+6ab756d5 : bics w21, w22, w23, ASR #21               : bics   %w22 %w23 asr $0x15 -> %w21
+6ab85ef6 : bics w22, w23, w24, ASR #23               : bics   %w23 %w24 asr $0x17 -> %w22
+6aba6738 : bics w24, w25, w26, ASR #25               : bics   %w25 %w26 asr $0x19 -> %w24
+6abc6f7a : bics w26, w27, w28, ASR #27               : bics   %w27 %w28 asr $0x1b -> %w26
+6aa17c1e : bics w30, w0, w1, ASR #31                 : bics   %w0 %w1 asr $0x1f -> %w30
+6ae20020 : bics w0, w1, w2, ROR #0                   : bics   %w1 %w2 ror $0x00 -> %w0
+6ae40862 : bics w2, w3, w4, ROR #2                   : bics   %w3 %w4 ror $0x02 -> %w2
+6ae610a4 : bics w4, w5, w6, ROR #4                   : bics   %w5 %w6 ror $0x04 -> %w4
+6ae818e6 : bics w6, w7, w8, ROR #6                   : bics   %w7 %w8 ror $0x06 -> %w6
+6aea2128 : bics w8, w9, w10, ROR #8                  : bics   %w9 %w10 ror $0x08 -> %w8
+6aeb2949 : bics w9, w10, w11, ROR #10                : bics   %w10 %w11 ror $0x0a -> %w9
+6aed318b : bics w11, w12, w13, ROR #12               : bics   %w12 %w13 ror $0x0c -> %w11
+6aef39cd : bics w13, w14, w15, ROR #14               : bics   %w14 %w15 ror $0x0e -> %w13
+6af1420f : bics w15, w16, w17, ROR #16               : bics   %w16 %w17 ror $0x10 -> %w15
+6af34651 : bics w17, w18, w19, ROR #17               : bics   %w18 %w19 ror $0x11 -> %w17
+6af54e93 : bics w19, w20, w21, ROR #19               : bics   %w20 %w21 ror $0x13 -> %w19
+6af756d5 : bics w21, w22, w23, ROR #21               : bics   %w22 %w23 ror $0x15 -> %w21
+6af85ef6 : bics w22, w23, w24, ROR #23               : bics   %w23 %w24 ror $0x17 -> %w22
+6afa6738 : bics w24, w25, w26, ROR #25               : bics   %w25 %w26 ror $0x19 -> %w24
+6afc6f7a : bics w26, w27, w28, ROR #27               : bics   %w27 %w28 ror $0x1b -> %w26
+6ae17c1e : bics w30, w0, w1, ROR #31                 : bics   %w0 %w1 ror $0x1f -> %w30
+
+# SDIV    <Wd>, <Wn>, <Wm> (SDIV-R.RR-32_dp_2src)
+1ac20c20 : sdiv w0, w1, w2                           : sdiv   %w1 %w2 -> %w0
+1ac40c62 : sdiv w2, w3, w4                           : sdiv   %w3 %w4 -> %w2
+1ac60ca4 : sdiv w4, w5, w6                           : sdiv   %w5 %w6 -> %w4
+1ac80ce6 : sdiv w6, w7, w8                           : sdiv   %w7 %w8 -> %w6
+1aca0d28 : sdiv w8, w9, w10                          : sdiv   %w9 %w10 -> %w8
+1acb0d49 : sdiv w9, w10, w11                         : sdiv   %w10 %w11 -> %w9
+1acd0d8b : sdiv w11, w12, w13                        : sdiv   %w12 %w13 -> %w11
+1acf0dcd : sdiv w13, w14, w15                        : sdiv   %w14 %w15 -> %w13
+1ad10e0f : sdiv w15, w16, w17                        : sdiv   %w16 %w17 -> %w15
+1ad30e51 : sdiv w17, w18, w19                        : sdiv   %w18 %w19 -> %w17
+1ad50e93 : sdiv w19, w20, w21                        : sdiv   %w20 %w21 -> %w19
+1ad70ed5 : sdiv w21, w22, w23                        : sdiv   %w22 %w23 -> %w21
+1ad80ef6 : sdiv w22, w23, w24                        : sdiv   %w23 %w24 -> %w22
+1ada0f38 : sdiv w24, w25, w26                        : sdiv   %w25 %w26 -> %w24
+1adc0f7a : sdiv w26, w27, w28                        : sdiv   %w27 %w28 -> %w26
+1ac10c1e : sdiv w30, w0, w1                          : sdiv   %w0 %w1 -> %w30
+
+# RET     <Xn> (RET-R-64R_branch_reg)
+d65f0000 : ret x0                                    : ret    %x0
+d65f0040 : ret x2                                    : ret    %x2
+d65f0080 : ret x4                                    : ret    %x4
+d65f00c0 : ret x6                                    : ret    %x6
+d65f0100 : ret x8                                    : ret    %x8
+d65f0120 : ret x9                                    : ret    %x9
+d65f0160 : ret x11                                   : ret    %x11
+d65f01a0 : ret x13                                   : ret    %x13
+d65f01e0 : ret x15                                   : ret    %x15
+d65f0220 : ret x17                                   : ret    %x17
+d65f0260 : ret x19                                   : ret    %x19
+d65f02a0 : ret x21                                   : ret    %x21
+d65f02c0 : ret x22                                   : ret    %x22
+d65f0300 : ret x24                                   : ret    %x24
+d65f0340 : ret x26                                   : ret    %x26
+d65f03c0 : ret x30                                   : ret    %x30
+
+# EXTR    <Wd>, <Wn>, <Wm>, #<imm> (EXTR-R.RRI-32_extract)
+13820020 : extr w0, w1, w2, #0x0                     : extr   %w1 %w2 $0x00 -> %w0
+13840862 : extr w2, w3, w4, #0x2                     : extr   %w3 %w4 $0x02 -> %w2
+138610a4 : extr w4, w5, w6, #0x4                     : extr   %w5 %w6 $0x04 -> %w4
+138818e6 : extr w6, w7, w8, #0x6                     : extr   %w7 %w8 $0x06 -> %w6
+138a2128 : extr w8, w9, w10, #0x8                    : extr   %w9 %w10 $0x08 -> %w8
+138b2949 : extr w9, w10, w11, #0xa                   : extr   %w10 %w11 $0x0a -> %w9
+138d318b : extr w11, w12, w13, #0xc                  : extr   %w12 %w13 $0x0c -> %w11
+138f39cd : extr w13, w14, w15, #0xe                  : extr   %w14 %w15 $0x0e -> %w13
+1391420f : extr w15, w16, w17, #0x10                 : extr   %w16 %w17 $0x10 -> %w15
+13934651 : extr w17, w18, w19, #0x11                 : extr   %w18 %w19 $0x11 -> %w17
+13954e93 : extr w19, w20, w21, #0x13                 : extr   %w20 %w21 $0x13 -> %w19
+139756d5 : extr w21, w22, w23, #0x15                 : extr   %w22 %w23 $0x15 -> %w21
+13985ef6 : extr w22, w23, w24, #0x17                 : extr   %w23 %w24 $0x17 -> %w22
+139a6738 : extr w24, w25, w26, #0x19                 : extr   %w25 %w26 $0x19 -> %w24
+139c6f7a : extr w26, w27, w28, #0x1b                 : extr   %w27 %w28 $0x1b -> %w26
+13817c1e : extr w30, w0, w1, #0x1f                   : extr   %w0 %w1 $0x1f -> %w30
+
+# EON     <Wd>, <Wn>, <Wm>, <extend> #<imm> (EON-R.RRI-32_log_shift)
+4a220020 : eon w0, w1, w2, LSL #0                    : eon    %w1 %w2 lsl $0x00 -> %w0
+4a240862 : eon w2, w3, w4, LSL #2                    : eon    %w3 %w4 lsl $0x02 -> %w2
+4a2610a4 : eon w4, w5, w6, LSL #4                    : eon    %w5 %w6 lsl $0x04 -> %w4
+4a2818e6 : eon w6, w7, w8, LSL #6                    : eon    %w7 %w8 lsl $0x06 -> %w6
+4a2a2128 : eon w8, w9, w10, LSL #8                   : eon    %w9 %w10 lsl $0x08 -> %w8
+4a2b2949 : eon w9, w10, w11, LSL #10                 : eon    %w10 %w11 lsl $0x0a -> %w9
+4a2d318b : eon w11, w12, w13, LSL #12                : eon    %w12 %w13 lsl $0x0c -> %w11
+4a2f39cd : eon w13, w14, w15, LSL #14                : eon    %w14 %w15 lsl $0x0e -> %w13
+4a31420f : eon w15, w16, w17, LSL #16                : eon    %w16 %w17 lsl $0x10 -> %w15
+4a334651 : eon w17, w18, w19, LSL #17                : eon    %w18 %w19 lsl $0x11 -> %w17
+4a354e93 : eon w19, w20, w21, LSL #19                : eon    %w20 %w21 lsl $0x13 -> %w19
+4a3756d5 : eon w21, w22, w23, LSL #21                : eon    %w22 %w23 lsl $0x15 -> %w21
+4a385ef6 : eon w22, w23, w24, LSL #23                : eon    %w23 %w24 lsl $0x17 -> %w22
+4a3a6738 : eon w24, w25, w26, LSL #25                : eon    %w25 %w26 lsl $0x19 -> %w24
+4a3c6f7a : eon w26, w27, w28, LSL #27                : eon    %w27 %w28 lsl $0x1b -> %w26
+4a217c1e : eon w30, w0, w1, LSL #31                  : eon    %w0 %w1 lsl $0x1f -> %w30
+4a620020 : eon w0, w1, w2, LSR #0                    : eon    %w1 %w2 lsr $0x00 -> %w0
+4a640862 : eon w2, w3, w4, LSR #2                    : eon    %w3 %w4 lsr $0x02 -> %w2
+4a6610a4 : eon w4, w5, w6, LSR #4                    : eon    %w5 %w6 lsr $0x04 -> %w4
+4a6818e6 : eon w6, w7, w8, LSR #6                    : eon    %w7 %w8 lsr $0x06 -> %w6
+4a6a2128 : eon w8, w9, w10, LSR #8                   : eon    %w9 %w10 lsr $0x08 -> %w8
+4a6b2949 : eon w9, w10, w11, LSR #10                 : eon    %w10 %w11 lsr $0x0a -> %w9
+4a6d318b : eon w11, w12, w13, LSR #12                : eon    %w12 %w13 lsr $0x0c -> %w11
+4a6f39cd : eon w13, w14, w15, LSR #14                : eon    %w14 %w15 lsr $0x0e -> %w13
+4a71420f : eon w15, w16, w17, LSR #16                : eon    %w16 %w17 lsr $0x10 -> %w15
+4a734651 : eon w17, w18, w19, LSR #17                : eon    %w18 %w19 lsr $0x11 -> %w17
+4a754e93 : eon w19, w20, w21, LSR #19                : eon    %w20 %w21 lsr $0x13 -> %w19
+4a7756d5 : eon w21, w22, w23, LSR #21                : eon    %w22 %w23 lsr $0x15 -> %w21
+4a785ef6 : eon w22, w23, w24, LSR #23                : eon    %w23 %w24 lsr $0x17 -> %w22
+4a7a6738 : eon w24, w25, w26, LSR #25                : eon    %w25 %w26 lsr $0x19 -> %w24
+4a7c6f7a : eon w26, w27, w28, LSR #27                : eon    %w27 %w28 lsr $0x1b -> %w26
+4a617c1e : eon w30, w0, w1, LSR #31                  : eon    %w0 %w1 lsr $0x1f -> %w30
+4aa20020 : eon w0, w1, w2, ASR #0                    : eon    %w1 %w2 asr $0x00 -> %w0
+4aa40862 : eon w2, w3, w4, ASR #2                    : eon    %w3 %w4 asr $0x02 -> %w2
+4aa610a4 : eon w4, w5, w6, ASR #4                    : eon    %w5 %w6 asr $0x04 -> %w4
+4aa818e6 : eon w6, w7, w8, ASR #6                    : eon    %w7 %w8 asr $0x06 -> %w6
+4aaa2128 : eon w8, w9, w10, ASR #8                   : eon    %w9 %w10 asr $0x08 -> %w8
+4aab2949 : eon w9, w10, w11, ASR #10                 : eon    %w10 %w11 asr $0x0a -> %w9
+4aad318b : eon w11, w12, w13, ASR #12                : eon    %w12 %w13 asr $0x0c -> %w11
+4aaf39cd : eon w13, w14, w15, ASR #14                : eon    %w14 %w15 asr $0x0e -> %w13
+4ab1420f : eon w15, w16, w17, ASR #16                : eon    %w16 %w17 asr $0x10 -> %w15
+4ab34651 : eon w17, w18, w19, ASR #17                : eon    %w18 %w19 asr $0x11 -> %w17
+4ab54e93 : eon w19, w20, w21, ASR #19                : eon    %w20 %w21 asr $0x13 -> %w19
+4ab756d5 : eon w21, w22, w23, ASR #21                : eon    %w22 %w23 asr $0x15 -> %w21
+4ab85ef6 : eon w22, w23, w24, ASR #23                : eon    %w23 %w24 asr $0x17 -> %w22
+4aba6738 : eon w24, w25, w26, ASR #25                : eon    %w25 %w26 asr $0x19 -> %w24
+4abc6f7a : eon w26, w27, w28, ASR #27                : eon    %w27 %w28 asr $0x1b -> %w26
+4aa17c1e : eon w30, w0, w1, ASR #31                  : eon    %w0 %w1 asr $0x1f -> %w30
+4ae20020 : eon w0, w1, w2, ROR #0                    : eon    %w1 %w2 ror $0x00 -> %w0
+4ae40862 : eon w2, w3, w4, ROR #2                    : eon    %w3 %w4 ror $0x02 -> %w2
+4ae610a4 : eon w4, w5, w6, ROR #4                    : eon    %w5 %w6 ror $0x04 -> %w4
+4ae818e6 : eon w6, w7, w8, ROR #6                    : eon    %w7 %w8 ror $0x06 -> %w6
+4aea2128 : eon w8, w9, w10, ROR #8                   : eon    %w9 %w10 ror $0x08 -> %w8
+4aeb2949 : eon w9, w10, w11, ROR #10                 : eon    %w10 %w11 ror $0x0a -> %w9
+4aed318b : eon w11, w12, w13, ROR #12                : eon    %w12 %w13 ror $0x0c -> %w11
+4aef39cd : eon w13, w14, w15, ROR #14                : eon    %w14 %w15 ror $0x0e -> %w13
+4af1420f : eon w15, w16, w17, ROR #16                : eon    %w16 %w17 ror $0x10 -> %w15
+4af34651 : eon w17, w18, w19, ROR #17                : eon    %w18 %w19 ror $0x11 -> %w17
+4af54e93 : eon w19, w20, w21, ROR #19                : eon    %w20 %w21 ror $0x13 -> %w19
+4af756d5 : eon w21, w22, w23, ROR #21                : eon    %w22 %w23 ror $0x15 -> %w21
+4af85ef6 : eon w22, w23, w24, ROR #23                : eon    %w23 %w24 ror $0x17 -> %w22
+4afa6738 : eon w24, w25, w26, ROR #25                : eon    %w25 %w26 ror $0x19 -> %w24
+4afc6f7a : eon w26, w27, w28, ROR #27                : eon    %w27 %w28 ror $0x1b -> %w26
+4ae17c1e : eon w30, w0, w1, ROR #31                  : eon    %w0 %w1 ror $0x1f -> %w30
+
+# CCMN    <Xn>, <Xm>, #<imm>, <cond> (CCMN-R.RI-64_condcmp_reg)
+ba410000 : ccmn x0, x1, #0x0, EQ                     : ccmn.eq %x0 %x1 $0x00
+ba430041 : ccmn x2, x3, #0x1, EQ                     : ccmn.eq %x2 %x3 $0x01
+ba450082 : ccmn x4, x5, #0x2, EQ                     : ccmn.eq %x4 %x5 $0x02
+ba4700c3 : ccmn x6, x7, #0x3, EQ                     : ccmn.eq %x6 %x7 $0x03
+ba490104 : ccmn x8, x9, #0x4, EQ                     : ccmn.eq %x8 %x9 $0x04
+ba4a0125 : ccmn x9, x10, #0x5, EQ                    : ccmn.eq %x9 %x10 $0x05
+ba4c0166 : ccmn x11, x12, #0x6, EQ                   : ccmn.eq %x11 %x12 $0x06
+ba4e01a7 : ccmn x13, x14, #0x7, EQ                   : ccmn.eq %x13 %x14 $0x07
+ba5001e8 : ccmn x15, x16, #0x8, EQ                   : ccmn.eq %x15 %x16 $0x08
+ba520228 : ccmn x17, x18, #0x8, EQ                   : ccmn.eq %x17 %x18 $0x08
+ba540269 : ccmn x19, x20, #0x9, EQ                   : ccmn.eq %x19 %x20 $0x09
+ba5602aa : ccmn x21, x22, #0xa, EQ                   : ccmn.eq %x21 %x22 $0x0a
+ba5702cb : ccmn x22, x23, #0xb, EQ                   : ccmn.eq %x22 %x23 $0x0b
+ba59030c : ccmn x24, x25, #0xc, EQ                   : ccmn.eq %x24 %x25 $0x0c
+ba5b034d : ccmn x26, x27, #0xd, EQ                   : ccmn.eq %x26 %x27 $0x0d
+ba4003cf : ccmn x30, x0, #0xf, EQ                    : ccmn.eq %x30 %x0 $0x0f
+ba411000 : ccmn x0, x1, #0x0, NE                     : ccmn.ne %x0 %x1 $0x00
+ba431041 : ccmn x2, x3, #0x1, NE                     : ccmn.ne %x2 %x3 $0x01
+ba451082 : ccmn x4, x5, #0x2, NE                     : ccmn.ne %x4 %x5 $0x02
+ba4710c3 : ccmn x6, x7, #0x3, NE                     : ccmn.ne %x6 %x7 $0x03
+ba491104 : ccmn x8, x9, #0x4, NE                     : ccmn.ne %x8 %x9 $0x04
+ba4a1125 : ccmn x9, x10, #0x5, NE                    : ccmn.ne %x9 %x10 $0x05
+ba4c1166 : ccmn x11, x12, #0x6, NE                   : ccmn.ne %x11 %x12 $0x06
+ba4e11a7 : ccmn x13, x14, #0x7, NE                   : ccmn.ne %x13 %x14 $0x07
+ba5011e8 : ccmn x15, x16, #0x8, NE                   : ccmn.ne %x15 %x16 $0x08
+ba521228 : ccmn x17, x18, #0x8, NE                   : ccmn.ne %x17 %x18 $0x08
+ba541269 : ccmn x19, x20, #0x9, NE                   : ccmn.ne %x19 %x20 $0x09
+ba5612aa : ccmn x21, x22, #0xa, NE                   : ccmn.ne %x21 %x22 $0x0a
+ba5712cb : ccmn x22, x23, #0xb, NE                   : ccmn.ne %x22 %x23 $0x0b
+ba59130c : ccmn x24, x25, #0xc, NE                   : ccmn.ne %x24 %x25 $0x0c
+ba5b134d : ccmn x26, x27, #0xd, NE                   : ccmn.ne %x26 %x27 $0x0d
+ba4013cf : ccmn x30, x0, #0xf, NE                    : ccmn.ne %x30 %x0 $0x0f
+ba412000 : ccmn x0, x1, #0x0, CS                     : ccmn.cs %x0 %x1 $0x00
+ba432041 : ccmn x2, x3, #0x1, CS                     : ccmn.cs %x2 %x3 $0x01
+ba452082 : ccmn x4, x5, #0x2, CS                     : ccmn.cs %x4 %x5 $0x02
+ba4720c3 : ccmn x6, x7, #0x3, CS                     : ccmn.cs %x6 %x7 $0x03
+ba492104 : ccmn x8, x9, #0x4, CS                     : ccmn.cs %x8 %x9 $0x04
+ba4a2125 : ccmn x9, x10, #0x5, CS                    : ccmn.cs %x9 %x10 $0x05
+ba4c2166 : ccmn x11, x12, #0x6, CS                   : ccmn.cs %x11 %x12 $0x06
+ba4e21a7 : ccmn x13, x14, #0x7, CS                   : ccmn.cs %x13 %x14 $0x07
+ba5021e8 : ccmn x15, x16, #0x8, CS                   : ccmn.cs %x15 %x16 $0x08
+ba522228 : ccmn x17, x18, #0x8, CS                   : ccmn.cs %x17 %x18 $0x08
+ba542269 : ccmn x19, x20, #0x9, CS                   : ccmn.cs %x19 %x20 $0x09
+ba5622aa : ccmn x21, x22, #0xa, CS                   : ccmn.cs %x21 %x22 $0x0a
+ba5722cb : ccmn x22, x23, #0xb, CS                   : ccmn.cs %x22 %x23 $0x0b
+ba59230c : ccmn x24, x25, #0xc, CS                   : ccmn.cs %x24 %x25 $0x0c
+ba5b234d : ccmn x26, x27, #0xd, CS                   : ccmn.cs %x26 %x27 $0x0d
+ba4023cf : ccmn x30, x0, #0xf, CS                    : ccmn.cs %x30 %x0 $0x0f
+ba413000 : ccmn x0, x1, #0x0, CC                     : ccmn.cc %x0 %x1 $0x00
+ba433041 : ccmn x2, x3, #0x1, CC                     : ccmn.cc %x2 %x3 $0x01
+ba453082 : ccmn x4, x5, #0x2, CC                     : ccmn.cc %x4 %x5 $0x02
+ba4730c3 : ccmn x6, x7, #0x3, CC                     : ccmn.cc %x6 %x7 $0x03
+ba493104 : ccmn x8, x9, #0x4, CC                     : ccmn.cc %x8 %x9 $0x04
+ba4a3125 : ccmn x9, x10, #0x5, CC                    : ccmn.cc %x9 %x10 $0x05
+ba4c3166 : ccmn x11, x12, #0x6, CC                   : ccmn.cc %x11 %x12 $0x06
+ba4e31a7 : ccmn x13, x14, #0x7, CC                   : ccmn.cc %x13 %x14 $0x07
+ba5031e8 : ccmn x15, x16, #0x8, CC                   : ccmn.cc %x15 %x16 $0x08
+ba523228 : ccmn x17, x18, #0x8, CC                   : ccmn.cc %x17 %x18 $0x08
+ba543269 : ccmn x19, x20, #0x9, CC                   : ccmn.cc %x19 %x20 $0x09
+ba5632aa : ccmn x21, x22, #0xa, CC                   : ccmn.cc %x21 %x22 $0x0a
+ba5732cb : ccmn x22, x23, #0xb, CC                   : ccmn.cc %x22 %x23 $0x0b
+ba59330c : ccmn x24, x25, #0xc, CC                   : ccmn.cc %x24 %x25 $0x0c
+ba5b334d : ccmn x26, x27, #0xd, CC                   : ccmn.cc %x26 %x27 $0x0d
+ba4033cf : ccmn x30, x0, #0xf, CC                    : ccmn.cc %x30 %x0 $0x0f
+ba414000 : ccmn x0, x1, #0x0, MI                     : ccmn.mi %x0 %x1 $0x00
+ba434041 : ccmn x2, x3, #0x1, MI                     : ccmn.mi %x2 %x3 $0x01
+ba454082 : ccmn x4, x5, #0x2, MI                     : ccmn.mi %x4 %x5 $0x02
+ba4740c3 : ccmn x6, x7, #0x3, MI                     : ccmn.mi %x6 %x7 $0x03
+ba494104 : ccmn x8, x9, #0x4, MI                     : ccmn.mi %x8 %x9 $0x04
+ba4a4125 : ccmn x9, x10, #0x5, MI                    : ccmn.mi %x9 %x10 $0x05
+ba4c4166 : ccmn x11, x12, #0x6, MI                   : ccmn.mi %x11 %x12 $0x06
+ba4e41a7 : ccmn x13, x14, #0x7, MI                   : ccmn.mi %x13 %x14 $0x07
+ba5041e8 : ccmn x15, x16, #0x8, MI                   : ccmn.mi %x15 %x16 $0x08
+ba524228 : ccmn x17, x18, #0x8, MI                   : ccmn.mi %x17 %x18 $0x08
+ba544269 : ccmn x19, x20, #0x9, MI                   : ccmn.mi %x19 %x20 $0x09
+ba5642aa : ccmn x21, x22, #0xa, MI                   : ccmn.mi %x21 %x22 $0x0a
+ba5742cb : ccmn x22, x23, #0xb, MI                   : ccmn.mi %x22 %x23 $0x0b
+ba59430c : ccmn x24, x25, #0xc, MI                   : ccmn.mi %x24 %x25 $0x0c
+ba5b434d : ccmn x26, x27, #0xd, MI                   : ccmn.mi %x26 %x27 $0x0d
+ba4043cf : ccmn x30, x0, #0xf, MI                    : ccmn.mi %x30 %x0 $0x0f
+ba415000 : ccmn x0, x1, #0x0, PL                     : ccmn.pl %x0 %x1 $0x00
+ba435041 : ccmn x2, x3, #0x1, PL                     : ccmn.pl %x2 %x3 $0x01
+ba455082 : ccmn x4, x5, #0x2, PL                     : ccmn.pl %x4 %x5 $0x02
+ba4750c3 : ccmn x6, x7, #0x3, PL                     : ccmn.pl %x6 %x7 $0x03
+ba495104 : ccmn x8, x9, #0x4, PL                     : ccmn.pl %x8 %x9 $0x04
+ba4a5125 : ccmn x9, x10, #0x5, PL                    : ccmn.pl %x9 %x10 $0x05
+ba4c5166 : ccmn x11, x12, #0x6, PL                   : ccmn.pl %x11 %x12 $0x06
+ba4e51a7 : ccmn x13, x14, #0x7, PL                   : ccmn.pl %x13 %x14 $0x07
+ba5051e8 : ccmn x15, x16, #0x8, PL                   : ccmn.pl %x15 %x16 $0x08
+ba525228 : ccmn x17, x18, #0x8, PL                   : ccmn.pl %x17 %x18 $0x08
+ba545269 : ccmn x19, x20, #0x9, PL                   : ccmn.pl %x19 %x20 $0x09
+ba5652aa : ccmn x21, x22, #0xa, PL                   : ccmn.pl %x21 %x22 $0x0a
+ba5752cb : ccmn x22, x23, #0xb, PL                   : ccmn.pl %x22 %x23 $0x0b
+ba59530c : ccmn x24, x25, #0xc, PL                   : ccmn.pl %x24 %x25 $0x0c
+ba5b534d : ccmn x26, x27, #0xd, PL                   : ccmn.pl %x26 %x27 $0x0d
+ba4053cf : ccmn x30, x0, #0xf, PL                    : ccmn.pl %x30 %x0 $0x0f
+ba416000 : ccmn x0, x1, #0x0, VS                     : ccmn.vs %x0 %x1 $0x00
+ba436041 : ccmn x2, x3, #0x1, VS                     : ccmn.vs %x2 %x3 $0x01
+ba456082 : ccmn x4, x5, #0x2, VS                     : ccmn.vs %x4 %x5 $0x02
+ba4760c3 : ccmn x6, x7, #0x3, VS                     : ccmn.vs %x6 %x7 $0x03
+ba496104 : ccmn x8, x9, #0x4, VS                     : ccmn.vs %x8 %x9 $0x04
+ba4a6125 : ccmn x9, x10, #0x5, VS                    : ccmn.vs %x9 %x10 $0x05
+ba4c6166 : ccmn x11, x12, #0x6, VS                   : ccmn.vs %x11 %x12 $0x06
+ba4e61a7 : ccmn x13, x14, #0x7, VS                   : ccmn.vs %x13 %x14 $0x07
+ba5061e8 : ccmn x15, x16, #0x8, VS                   : ccmn.vs %x15 %x16 $0x08
+ba526228 : ccmn x17, x18, #0x8, VS                   : ccmn.vs %x17 %x18 $0x08
+ba546269 : ccmn x19, x20, #0x9, VS                   : ccmn.vs %x19 %x20 $0x09
+ba5662aa : ccmn x21, x22, #0xa, VS                   : ccmn.vs %x21 %x22 $0x0a
+ba5762cb : ccmn x22, x23, #0xb, VS                   : ccmn.vs %x22 %x23 $0x0b
+ba59630c : ccmn x24, x25, #0xc, VS                   : ccmn.vs %x24 %x25 $0x0c
+ba5b634d : ccmn x26, x27, #0xd, VS                   : ccmn.vs %x26 %x27 $0x0d
+ba4063cf : ccmn x30, x0, #0xf, VS                    : ccmn.vs %x30 %x0 $0x0f
+ba417000 : ccmn x0, x1, #0x0, VC                     : ccmn.vc %x0 %x1 $0x00
+ba437041 : ccmn x2, x3, #0x1, VC                     : ccmn.vc %x2 %x3 $0x01
+ba457082 : ccmn x4, x5, #0x2, VC                     : ccmn.vc %x4 %x5 $0x02
+ba4770c3 : ccmn x6, x7, #0x3, VC                     : ccmn.vc %x6 %x7 $0x03
+ba497104 : ccmn x8, x9, #0x4, VC                     : ccmn.vc %x8 %x9 $0x04
+ba4a7125 : ccmn x9, x10, #0x5, VC                    : ccmn.vc %x9 %x10 $0x05
+ba4c7166 : ccmn x11, x12, #0x6, VC                   : ccmn.vc %x11 %x12 $0x06
+ba4e71a7 : ccmn x13, x14, #0x7, VC                   : ccmn.vc %x13 %x14 $0x07
+ba5071e8 : ccmn x15, x16, #0x8, VC                   : ccmn.vc %x15 %x16 $0x08
+ba527228 : ccmn x17, x18, #0x8, VC                   : ccmn.vc %x17 %x18 $0x08
+ba547269 : ccmn x19, x20, #0x9, VC                   : ccmn.vc %x19 %x20 $0x09
+ba5672aa : ccmn x21, x22, #0xa, VC                   : ccmn.vc %x21 %x22 $0x0a
+ba5772cb : ccmn x22, x23, #0xb, VC                   : ccmn.vc %x22 %x23 $0x0b
+ba59730c : ccmn x24, x25, #0xc, VC                   : ccmn.vc %x24 %x25 $0x0c
+ba5b734d : ccmn x26, x27, #0xd, VC                   : ccmn.vc %x26 %x27 $0x0d
+ba4073cf : ccmn x30, x0, #0xf, VC                    : ccmn.vc %x30 %x0 $0x0f
+ba418000 : ccmn x0, x1, #0x0, HI                     : ccmn.hi %x0 %x1 $0x00
+ba438041 : ccmn x2, x3, #0x1, HI                     : ccmn.hi %x2 %x3 $0x01
+ba458082 : ccmn x4, x5, #0x2, HI                     : ccmn.hi %x4 %x5 $0x02
+ba4780c3 : ccmn x6, x7, #0x3, HI                     : ccmn.hi %x6 %x7 $0x03
+ba498104 : ccmn x8, x9, #0x4, HI                     : ccmn.hi %x8 %x9 $0x04
+ba4a8125 : ccmn x9, x10, #0x5, HI                    : ccmn.hi %x9 %x10 $0x05
+ba4c8166 : ccmn x11, x12, #0x6, HI                   : ccmn.hi %x11 %x12 $0x06
+ba4e81a7 : ccmn x13, x14, #0x7, HI                   : ccmn.hi %x13 %x14 $0x07
+ba5081e8 : ccmn x15, x16, #0x8, HI                   : ccmn.hi %x15 %x16 $0x08
+ba528228 : ccmn x17, x18, #0x8, HI                   : ccmn.hi %x17 %x18 $0x08
+ba548269 : ccmn x19, x20, #0x9, HI                   : ccmn.hi %x19 %x20 $0x09
+ba5682aa : ccmn x21, x22, #0xa, HI                   : ccmn.hi %x21 %x22 $0x0a
+ba5782cb : ccmn x22, x23, #0xb, HI                   : ccmn.hi %x22 %x23 $0x0b
+ba59830c : ccmn x24, x25, #0xc, HI                   : ccmn.hi %x24 %x25 $0x0c
+ba5b834d : ccmn x26, x27, #0xd, HI                   : ccmn.hi %x26 %x27 $0x0d
+ba4083cf : ccmn x30, x0, #0xf, HI                    : ccmn.hi %x30 %x0 $0x0f
+ba419000 : ccmn x0, x1, #0x0, LS                     : ccmn.ls %x0 %x1 $0x00
+ba439041 : ccmn x2, x3, #0x1, LS                     : ccmn.ls %x2 %x3 $0x01
+ba459082 : ccmn x4, x5, #0x2, LS                     : ccmn.ls %x4 %x5 $0x02
+ba4790c3 : ccmn x6, x7, #0x3, LS                     : ccmn.ls %x6 %x7 $0x03
+ba499104 : ccmn x8, x9, #0x4, LS                     : ccmn.ls %x8 %x9 $0x04
+ba4a9125 : ccmn x9, x10, #0x5, LS                    : ccmn.ls %x9 %x10 $0x05
+ba4c9166 : ccmn x11, x12, #0x6, LS                   : ccmn.ls %x11 %x12 $0x06
+ba4e91a7 : ccmn x13, x14, #0x7, LS                   : ccmn.ls %x13 %x14 $0x07
+ba5091e8 : ccmn x15, x16, #0x8, LS                   : ccmn.ls %x15 %x16 $0x08
+ba529228 : ccmn x17, x18, #0x8, LS                   : ccmn.ls %x17 %x18 $0x08
+ba549269 : ccmn x19, x20, #0x9, LS                   : ccmn.ls %x19 %x20 $0x09
+ba5692aa : ccmn x21, x22, #0xa, LS                   : ccmn.ls %x21 %x22 $0x0a
+ba5792cb : ccmn x22, x23, #0xb, LS                   : ccmn.ls %x22 %x23 $0x0b
+ba59930c : ccmn x24, x25, #0xc, LS                   : ccmn.ls %x24 %x25 $0x0c
+ba5b934d : ccmn x26, x27, #0xd, LS                   : ccmn.ls %x26 %x27 $0x0d
+ba4093cf : ccmn x30, x0, #0xf, LS                    : ccmn.ls %x30 %x0 $0x0f
+ba41a000 : ccmn x0, x1, #0x0, GE                     : ccmn.ge %x0 %x1 $0x00
+ba43a041 : ccmn x2, x3, #0x1, GE                     : ccmn.ge %x2 %x3 $0x01
+ba45a082 : ccmn x4, x5, #0x2, GE                     : ccmn.ge %x4 %x5 $0x02
+ba47a0c3 : ccmn x6, x7, #0x3, GE                     : ccmn.ge %x6 %x7 $0x03
+ba49a104 : ccmn x8, x9, #0x4, GE                     : ccmn.ge %x8 %x9 $0x04
+ba4aa125 : ccmn x9, x10, #0x5, GE                    : ccmn.ge %x9 %x10 $0x05
+ba4ca166 : ccmn x11, x12, #0x6, GE                   : ccmn.ge %x11 %x12 $0x06
+ba4ea1a7 : ccmn x13, x14, #0x7, GE                   : ccmn.ge %x13 %x14 $0x07
+ba50a1e8 : ccmn x15, x16, #0x8, GE                   : ccmn.ge %x15 %x16 $0x08
+ba52a228 : ccmn x17, x18, #0x8, GE                   : ccmn.ge %x17 %x18 $0x08
+ba54a269 : ccmn x19, x20, #0x9, GE                   : ccmn.ge %x19 %x20 $0x09
+ba56a2aa : ccmn x21, x22, #0xa, GE                   : ccmn.ge %x21 %x22 $0x0a
+ba57a2cb : ccmn x22, x23, #0xb, GE                   : ccmn.ge %x22 %x23 $0x0b
+ba59a30c : ccmn x24, x25, #0xc, GE                   : ccmn.ge %x24 %x25 $0x0c
+ba5ba34d : ccmn x26, x27, #0xd, GE                   : ccmn.ge %x26 %x27 $0x0d
+ba40a3cf : ccmn x30, x0, #0xf, GE                    : ccmn.ge %x30 %x0 $0x0f
+ba41b000 : ccmn x0, x1, #0x0, LT                     : ccmn.lt %x0 %x1 $0x00
+ba43b041 : ccmn x2, x3, #0x1, LT                     : ccmn.lt %x2 %x3 $0x01
+ba45b082 : ccmn x4, x5, #0x2, LT                     : ccmn.lt %x4 %x5 $0x02
+ba47b0c3 : ccmn x6, x7, #0x3, LT                     : ccmn.lt %x6 %x7 $0x03
+ba49b104 : ccmn x8, x9, #0x4, LT                     : ccmn.lt %x8 %x9 $0x04
+ba4ab125 : ccmn x9, x10, #0x5, LT                    : ccmn.lt %x9 %x10 $0x05
+ba4cb166 : ccmn x11, x12, #0x6, LT                   : ccmn.lt %x11 %x12 $0x06
+ba4eb1a7 : ccmn x13, x14, #0x7, LT                   : ccmn.lt %x13 %x14 $0x07
+ba50b1e8 : ccmn x15, x16, #0x8, LT                   : ccmn.lt %x15 %x16 $0x08
+ba52b228 : ccmn x17, x18, #0x8, LT                   : ccmn.lt %x17 %x18 $0x08
+ba54b269 : ccmn x19, x20, #0x9, LT                   : ccmn.lt %x19 %x20 $0x09
+ba56b2aa : ccmn x21, x22, #0xa, LT                   : ccmn.lt %x21 %x22 $0x0a
+ba57b2cb : ccmn x22, x23, #0xb, LT                   : ccmn.lt %x22 %x23 $0x0b
+ba59b30c : ccmn x24, x25, #0xc, LT                   : ccmn.lt %x24 %x25 $0x0c
+ba5bb34d : ccmn x26, x27, #0xd, LT                   : ccmn.lt %x26 %x27 $0x0d
+ba40b3cf : ccmn x30, x0, #0xf, LT                    : ccmn.lt %x30 %x0 $0x0f
+ba41c000 : ccmn x0, x1, #0x0, GT                     : ccmn.gt %x0 %x1 $0x00
+ba43c041 : ccmn x2, x3, #0x1, GT                     : ccmn.gt %x2 %x3 $0x01
+ba45c082 : ccmn x4, x5, #0x2, GT                     : ccmn.gt %x4 %x5 $0x02
+ba47c0c3 : ccmn x6, x7, #0x3, GT                     : ccmn.gt %x6 %x7 $0x03
+ba49c104 : ccmn x8, x9, #0x4, GT                     : ccmn.gt %x8 %x9 $0x04
+ba4ac125 : ccmn x9, x10, #0x5, GT                    : ccmn.gt %x9 %x10 $0x05
+ba4cc166 : ccmn x11, x12, #0x6, GT                   : ccmn.gt %x11 %x12 $0x06
+ba4ec1a7 : ccmn x13, x14, #0x7, GT                   : ccmn.gt %x13 %x14 $0x07
+ba50c1e8 : ccmn x15, x16, #0x8, GT                   : ccmn.gt %x15 %x16 $0x08
+ba52c228 : ccmn x17, x18, #0x8, GT                   : ccmn.gt %x17 %x18 $0x08
+ba54c269 : ccmn x19, x20, #0x9, GT                   : ccmn.gt %x19 %x20 $0x09
+ba56c2aa : ccmn x21, x22, #0xa, GT                   : ccmn.gt %x21 %x22 $0x0a
+ba57c2cb : ccmn x22, x23, #0xb, GT                   : ccmn.gt %x22 %x23 $0x0b
+ba59c30c : ccmn x24, x25, #0xc, GT                   : ccmn.gt %x24 %x25 $0x0c
+ba5bc34d : ccmn x26, x27, #0xd, GT                   : ccmn.gt %x26 %x27 $0x0d
+ba40c3cf : ccmn x30, x0, #0xf, GT                    : ccmn.gt %x30 %x0 $0x0f
+ba41d000 : ccmn x0, x1, #0x0, LE                     : ccmn.le %x0 %x1 $0x00
+ba43d041 : ccmn x2, x3, #0x1, LE                     : ccmn.le %x2 %x3 $0x01
+ba45d082 : ccmn x4, x5, #0x2, LE                     : ccmn.le %x4 %x5 $0x02
+ba47d0c3 : ccmn x6, x7, #0x3, LE                     : ccmn.le %x6 %x7 $0x03
+ba49d104 : ccmn x8, x9, #0x4, LE                     : ccmn.le %x8 %x9 $0x04
+ba4ad125 : ccmn x9, x10, #0x5, LE                    : ccmn.le %x9 %x10 $0x05
+ba4cd166 : ccmn x11, x12, #0x6, LE                   : ccmn.le %x11 %x12 $0x06
+ba4ed1a7 : ccmn x13, x14, #0x7, LE                   : ccmn.le %x13 %x14 $0x07
+ba50d1e8 : ccmn x15, x16, #0x8, LE                   : ccmn.le %x15 %x16 $0x08
+ba52d228 : ccmn x17, x18, #0x8, LE                   : ccmn.le %x17 %x18 $0x08
+ba54d269 : ccmn x19, x20, #0x9, LE                   : ccmn.le %x19 %x20 $0x09
+ba56d2aa : ccmn x21, x22, #0xa, LE                   : ccmn.le %x21 %x22 $0x0a
+ba57d2cb : ccmn x22, x23, #0xb, LE                   : ccmn.le %x22 %x23 $0x0b
+ba59d30c : ccmn x24, x25, #0xc, LE                   : ccmn.le %x24 %x25 $0x0c
+ba5bd34d : ccmn x26, x27, #0xd, LE                   : ccmn.le %x26 %x27 $0x0d
+ba40d3cf : ccmn x30, x0, #0xf, LE                    : ccmn.le %x30 %x0 $0x0f
+ba41e000 : ccmn x0, x1, #0x0, AL                     : ccmn.al %x0 %x1 $0x00
+ba43e041 : ccmn x2, x3, #0x1, AL                     : ccmn.al %x2 %x3 $0x01
+ba45e082 : ccmn x4, x5, #0x2, AL                     : ccmn.al %x4 %x5 $0x02
+ba47e0c3 : ccmn x6, x7, #0x3, AL                     : ccmn.al %x6 %x7 $0x03
+ba49e104 : ccmn x8, x9, #0x4, AL                     : ccmn.al %x8 %x9 $0x04
+ba4ae125 : ccmn x9, x10, #0x5, AL                    : ccmn.al %x9 %x10 $0x05
+ba4ce166 : ccmn x11, x12, #0x6, AL                   : ccmn.al %x11 %x12 $0x06
+ba4ee1a7 : ccmn x13, x14, #0x7, AL                   : ccmn.al %x13 %x14 $0x07
+ba50e1e8 : ccmn x15, x16, #0x8, AL                   : ccmn.al %x15 %x16 $0x08
+ba52e228 : ccmn x17, x18, #0x8, AL                   : ccmn.al %x17 %x18 $0x08
+ba54e269 : ccmn x19, x20, #0x9, AL                   : ccmn.al %x19 %x20 $0x09
+ba56e2aa : ccmn x21, x22, #0xa, AL                   : ccmn.al %x21 %x22 $0x0a
+ba57e2cb : ccmn x22, x23, #0xb, AL                   : ccmn.al %x22 %x23 $0x0b
+ba59e30c : ccmn x24, x25, #0xc, AL                   : ccmn.al %x24 %x25 $0x0c
+ba5be34d : ccmn x26, x27, #0xd, AL                   : ccmn.al %x26 %x27 $0x0d
+ba40e3cf : ccmn x30, x0, #0xf, AL                    : ccmn.al %x30 %x0 $0x0f
+ba41f000 : ccmn x0, x1, #0x0, NV                     : ccmn.nv %x0 %x1 $0x00
+ba43f041 : ccmn x2, x3, #0x1, NV                     : ccmn.nv %x2 %x3 $0x01
+ba45f082 : ccmn x4, x5, #0x2, NV                     : ccmn.nv %x4 %x5 $0x02
+ba47f0c3 : ccmn x6, x7, #0x3, NV                     : ccmn.nv %x6 %x7 $0x03
+ba49f104 : ccmn x8, x9, #0x4, NV                     : ccmn.nv %x8 %x9 $0x04
+ba4af125 : ccmn x9, x10, #0x5, NV                    : ccmn.nv %x9 %x10 $0x05
+ba4cf166 : ccmn x11, x12, #0x6, NV                   : ccmn.nv %x11 %x12 $0x06
+ba4ef1a7 : ccmn x13, x14, #0x7, NV                   : ccmn.nv %x13 %x14 $0x07
+ba50f1e8 : ccmn x15, x16, #0x8, NV                   : ccmn.nv %x15 %x16 $0x08
+ba52f228 : ccmn x17, x18, #0x8, NV                   : ccmn.nv %x17 %x18 $0x08
+ba54f269 : ccmn x19, x20, #0x9, NV                   : ccmn.nv %x19 %x20 $0x09
+ba56f2aa : ccmn x21, x22, #0xa, NV                   : ccmn.nv %x21 %x22 $0x0a
+ba57f2cb : ccmn x22, x23, #0xb, NV                   : ccmn.nv %x22 %x23 $0x0b
+ba59f30c : ccmn x24, x25, #0xc, NV                   : ccmn.nv %x24 %x25 $0x0c
+ba5bf34d : ccmn x26, x27, #0xd, NV                   : ccmn.nv %x26 %x27 $0x0d
+ba40f3cf : ccmn x30, x0, #0xf, NV                    : ccmn.nv %x30 %x0 $0x0f
+
+# ADDS    <Wd>, <Wn|SP>, <Wm>, <extend> #<imm> (ADDS-R.RRI-32S_addsub_ext)
+2b220020 : adds w0, w1, w2, UXTB #0                  : adds   %w1 %w2 uxtb $0x00 -> %w0
+2b240062 : adds w2, w3, w4, UXTB #0                  : adds   %w3 %w4 uxtb $0x00 -> %w2
+2b2600a4 : adds w4, w5, w6, UXTB #0                  : adds   %w5 %w6 uxtb $0x00 -> %w4
+2b2804e6 : adds w6, w7, w8, UXTB #1                  : adds   %w7 %w8 uxtb $0x01 -> %w6
+2b2a0528 : adds w8, w9, w10, UXTB #1                 : adds   %w9 %w10 uxtb $0x01 -> %w8
+2b2b0549 : adds w9, w10, w11, UXTB #1                : adds   %w10 %w11 uxtb $0x01 -> %w9
+2b2d098b : adds w11, w12, w13, UXTB #2               : adds   %w12 %w13 uxtb $0x02 -> %w11
+2b2f09cd : adds w13, w14, w15, UXTB #2               : adds   %w14 %w15 uxtb $0x02 -> %w13
+2b310a0f : adds w15, w16, w17, UXTB #2               : adds   %w16 %w17 uxtb $0x02 -> %w15
+2b330a51 : adds w17, w18, w19, UXTB #2               : adds   %w18 %w19 uxtb $0x02 -> %w17
+2b350a93 : adds w19, w20, w21, UXTB #2               : adds   %w20 %w21 uxtb $0x02 -> %w19
+2b370ed5 : adds w21, w22, w23, UXTB #3               : adds   %w22 %w23 uxtb $0x03 -> %w21
+2b380ef6 : adds w22, w23, w24, UXTB #3               : adds   %w23 %w24 uxtb $0x03 -> %w22
+2b3a0f38 : adds w24, w25, w26, UXTB #3               : adds   %w25 %w26 uxtb $0x03 -> %w24
+2b3c137a : adds w26, w27, w28, UXTB #4               : adds   %w27 %w28 uxtb $0x04 -> %w26
+2b21101e : adds w30, w0, w1, UXTB #4                 : adds   %w0 %w1 uxtb $0x04 -> %w30
+2b222020 : adds w0, w1, w2, UXTH #0                  : adds   %w1 %w2 uxth $0x00 -> %w0
+2b242062 : adds w2, w3, w4, UXTH #0                  : adds   %w3 %w4 uxth $0x00 -> %w2
+2b2620a4 : adds w4, w5, w6, UXTH #0                  : adds   %w5 %w6 uxth $0x00 -> %w4
+2b2824e6 : adds w6, w7, w8, UXTH #1                  : adds   %w7 %w8 uxth $0x01 -> %w6
+2b2a2528 : adds w8, w9, w10, UXTH #1                 : adds   %w9 %w10 uxth $0x01 -> %w8
+2b2b2549 : adds w9, w10, w11, UXTH #1                : adds   %w10 %w11 uxth $0x01 -> %w9
+2b2d298b : adds w11, w12, w13, UXTH #2               : adds   %w12 %w13 uxth $0x02 -> %w11
+2b2f29cd : adds w13, w14, w15, UXTH #2               : adds   %w14 %w15 uxth $0x02 -> %w13
+2b312a0f : adds w15, w16, w17, UXTH #2               : adds   %w16 %w17 uxth $0x02 -> %w15
+2b332a51 : adds w17, w18, w19, UXTH #2               : adds   %w18 %w19 uxth $0x02 -> %w17
+2b352a93 : adds w19, w20, w21, UXTH #2               : adds   %w20 %w21 uxth $0x02 -> %w19
+2b372ed5 : adds w21, w22, w23, UXTH #3               : adds   %w22 %w23 uxth $0x03 -> %w21
+2b382ef6 : adds w22, w23, w24, UXTH #3               : adds   %w23 %w24 uxth $0x03 -> %w22
+2b3a2f38 : adds w24, w25, w26, UXTH #3               : adds   %w25 %w26 uxth $0x03 -> %w24
+2b3c337a : adds w26, w27, w28, UXTH #4               : adds   %w27 %w28 uxth $0x04 -> %w26
+2b21301e : adds w30, w0, w1, UXTH #4                 : adds   %w0 %w1 uxth $0x04 -> %w30
+2b224020 : adds w0, w1, w2, UXTW #0                  : adds   %w1 %w2 uxtw $0x00 -> %w0
+2b244062 : adds w2, w3, w4, UXTW #0                  : adds   %w3 %w4 uxtw $0x00 -> %w2
+2b2640a4 : adds w4, w5, w6, UXTW #0                  : adds   %w5 %w6 uxtw $0x00 -> %w4
+2b2844e6 : adds w6, w7, w8, UXTW #1                  : adds   %w7 %w8 uxtw $0x01 -> %w6
+2b2a4528 : adds w8, w9, w10, UXTW #1                 : adds   %w9 %w10 uxtw $0x01 -> %w8
+2b2b4549 : adds w9, w10, w11, UXTW #1                : adds   %w10 %w11 uxtw $0x01 -> %w9
+2b2d498b : adds w11, w12, w13, UXTW #2               : adds   %w12 %w13 uxtw $0x02 -> %w11
+2b2f49cd : adds w13, w14, w15, UXTW #2               : adds   %w14 %w15 uxtw $0x02 -> %w13
+2b314a0f : adds w15, w16, w17, UXTW #2               : adds   %w16 %w17 uxtw $0x02 -> %w15
+2b334a51 : adds w17, w18, w19, UXTW #2               : adds   %w18 %w19 uxtw $0x02 -> %w17
+2b354a93 : adds w19, w20, w21, UXTW #2               : adds   %w20 %w21 uxtw $0x02 -> %w19
+2b374ed5 : adds w21, w22, w23, UXTW #3               : adds   %w22 %w23 uxtw $0x03 -> %w21
+2b384ef6 : adds w22, w23, w24, UXTW #3               : adds   %w23 %w24 uxtw $0x03 -> %w22
+2b3a4f38 : adds w24, w25, w26, UXTW #3               : adds   %w25 %w26 uxtw $0x03 -> %w24
+2b3c537a : adds w26, w27, w28, UXTW #4               : adds   %w27 %w28 uxtw $0x04 -> %w26
+2b21501e : adds w30, w0, w1, UXTW #4                 : adds   %w0 %w1 uxtw $0x04 -> %w30
+2b226020 : adds w0, w1, w2, UXTX #0                  : adds   %w1 %w2 uxtx $0x00 -> %w0
+2b246062 : adds w2, w3, w4, UXTX #0                  : adds   %w3 %w4 uxtx $0x00 -> %w2
+2b2660a4 : adds w4, w5, w6, UXTX #0                  : adds   %w5 %w6 uxtx $0x00 -> %w4
+2b2864e6 : adds w6, w7, w8, UXTX #1                  : adds   %w7 %w8 uxtx $0x01 -> %w6
+2b2a6528 : adds w8, w9, w10, UXTX #1                 : adds   %w9 %w10 uxtx $0x01 -> %w8
+2b2b6549 : adds w9, w10, w11, UXTX #1                : adds   %w10 %w11 uxtx $0x01 -> %w9
+2b2d698b : adds w11, w12, w13, UXTX #2               : adds   %w12 %w13 uxtx $0x02 -> %w11
+2b2f69cd : adds w13, w14, w15, UXTX #2               : adds   %w14 %w15 uxtx $0x02 -> %w13
+2b316a0f : adds w15, w16, w17, UXTX #2               : adds   %w16 %w17 uxtx $0x02 -> %w15
+2b336a51 : adds w17, w18, w19, UXTX #2               : adds   %w18 %w19 uxtx $0x02 -> %w17
+2b356a93 : adds w19, w20, w21, UXTX #2               : adds   %w20 %w21 uxtx $0x02 -> %w19
+2b376ed5 : adds w21, w22, w23, UXTX #3               : adds   %w22 %w23 uxtx $0x03 -> %w21
+2b386ef6 : adds w22, w23, w24, UXTX #3               : adds   %w23 %w24 uxtx $0x03 -> %w22
+2b3a6f38 : adds w24, w25, w26, UXTX #3               : adds   %w25 %w26 uxtx $0x03 -> %w24
+2b3c737a : adds w26, w27, w28, UXTX #4               : adds   %w27 %w28 uxtx $0x04 -> %w26
+2b21701e : adds w30, w0, w1, UXTX #4                 : adds   %w0 %w1 uxtx $0x04 -> %w30
+2b228020 : adds w0, w1, w2, SXTB #0                  : adds   %w1 %w2 sxtb $0x00 -> %w0
+2b248062 : adds w2, w3, w4, SXTB #0                  : adds   %w3 %w4 sxtb $0x00 -> %w2
+2b2680a4 : adds w4, w5, w6, SXTB #0                  : adds   %w5 %w6 sxtb $0x00 -> %w4
+2b2884e6 : adds w6, w7, w8, SXTB #1                  : adds   %w7 %w8 sxtb $0x01 -> %w6
+2b2a8528 : adds w8, w9, w10, SXTB #1                 : adds   %w9 %w10 sxtb $0x01 -> %w8
+2b2b8549 : adds w9, w10, w11, SXTB #1                : adds   %w10 %w11 sxtb $0x01 -> %w9
+2b2d898b : adds w11, w12, w13, SXTB #2               : adds   %w12 %w13 sxtb $0x02 -> %w11
+2b2f89cd : adds w13, w14, w15, SXTB #2               : adds   %w14 %w15 sxtb $0x02 -> %w13
+2b318a0f : adds w15, w16, w17, SXTB #2               : adds   %w16 %w17 sxtb $0x02 -> %w15
+2b338a51 : adds w17, w18, w19, SXTB #2               : adds   %w18 %w19 sxtb $0x02 -> %w17
+2b358a93 : adds w19, w20, w21, SXTB #2               : adds   %w20 %w21 sxtb $0x02 -> %w19
+2b378ed5 : adds w21, w22, w23, SXTB #3               : adds   %w22 %w23 sxtb $0x03 -> %w21
+2b388ef6 : adds w22, w23, w24, SXTB #3               : adds   %w23 %w24 sxtb $0x03 -> %w22
+2b3a8f38 : adds w24, w25, w26, SXTB #3               : adds   %w25 %w26 sxtb $0x03 -> %w24
+2b3c937a : adds w26, w27, w28, SXTB #4               : adds   %w27 %w28 sxtb $0x04 -> %w26
+2b21901e : adds w30, w0, w1, SXTB #4                 : adds   %w0 %w1 sxtb $0x04 -> %w30
+2b22a020 : adds w0, w1, w2, SXTH #0                  : adds   %w1 %w2 sxth $0x00 -> %w0
+2b24a062 : adds w2, w3, w4, SXTH #0                  : adds   %w3 %w4 sxth $0x00 -> %w2
+2b26a0a4 : adds w4, w5, w6, SXTH #0                  : adds   %w5 %w6 sxth $0x00 -> %w4
+2b28a4e6 : adds w6, w7, w8, SXTH #1                  : adds   %w7 %w8 sxth $0x01 -> %w6
+2b2aa528 : adds w8, w9, w10, SXTH #1                 : adds   %w9 %w10 sxth $0x01 -> %w8
+2b2ba549 : adds w9, w10, w11, SXTH #1                : adds   %w10 %w11 sxth $0x01 -> %w9
+2b2da98b : adds w11, w12, w13, SXTH #2               : adds   %w12 %w13 sxth $0x02 -> %w11
+2b2fa9cd : adds w13, w14, w15, SXTH #2               : adds   %w14 %w15 sxth $0x02 -> %w13
+2b31aa0f : adds w15, w16, w17, SXTH #2               : adds   %w16 %w17 sxth $0x02 -> %w15
+2b33aa51 : adds w17, w18, w19, SXTH #2               : adds   %w18 %w19 sxth $0x02 -> %w17
+2b35aa93 : adds w19, w20, w21, SXTH #2               : adds   %w20 %w21 sxth $0x02 -> %w19
+2b37aed5 : adds w21, w22, w23, SXTH #3               : adds   %w22 %w23 sxth $0x03 -> %w21
+2b38aef6 : adds w22, w23, w24, SXTH #3               : adds   %w23 %w24 sxth $0x03 -> %w22
+2b3aaf38 : adds w24, w25, w26, SXTH #3               : adds   %w25 %w26 sxth $0x03 -> %w24
+2b3cb37a : adds w26, w27, w28, SXTH #4               : adds   %w27 %w28 sxth $0x04 -> %w26
+2b21b01e : adds w30, w0, w1, SXTH #4                 : adds   %w0 %w1 sxth $0x04 -> %w30
+2b22c020 : adds w0, w1, w2, SXTW #0                  : adds   %w1 %w2 sxtw $0x00 -> %w0
+2b24c062 : adds w2, w3, w4, SXTW #0                  : adds   %w3 %w4 sxtw $0x00 -> %w2
+2b26c0a4 : adds w4, w5, w6, SXTW #0                  : adds   %w5 %w6 sxtw $0x00 -> %w4
+2b28c4e6 : adds w6, w7, w8, SXTW #1                  : adds   %w7 %w8 sxtw $0x01 -> %w6
+2b2ac528 : adds w8, w9, w10, SXTW #1                 : adds   %w9 %w10 sxtw $0x01 -> %w8
+2b2bc549 : adds w9, w10, w11, SXTW #1                : adds   %w10 %w11 sxtw $0x01 -> %w9
+2b2dc98b : adds w11, w12, w13, SXTW #2               : adds   %w12 %w13 sxtw $0x02 -> %w11
+2b2fc9cd : adds w13, w14, w15, SXTW #2               : adds   %w14 %w15 sxtw $0x02 -> %w13
+2b31ca0f : adds w15, w16, w17, SXTW #2               : adds   %w16 %w17 sxtw $0x02 -> %w15
+2b33ca51 : adds w17, w18, w19, SXTW #2               : adds   %w18 %w19 sxtw $0x02 -> %w17
+2b35ca93 : adds w19, w20, w21, SXTW #2               : adds   %w20 %w21 sxtw $0x02 -> %w19
+2b37ced5 : adds w21, w22, w23, SXTW #3               : adds   %w22 %w23 sxtw $0x03 -> %w21
+2b38cef6 : adds w22, w23, w24, SXTW #3               : adds   %w23 %w24 sxtw $0x03 -> %w22
+2b3acf38 : adds w24, w25, w26, SXTW #3               : adds   %w25 %w26 sxtw $0x03 -> %w24
+2b3cd37a : adds w26, w27, w28, SXTW #4               : adds   %w27 %w28 sxtw $0x04 -> %w26
+2b21d01e : adds w30, w0, w1, SXTW #4                 : adds   %w0 %w1 sxtw $0x04 -> %w30
+2b22e020 : adds w0, w1, w2, SXTX #0                  : adds   %w1 %w2 sxtx $0x00 -> %w0
+2b24e062 : adds w2, w3, w4, SXTX #0                  : adds   %w3 %w4 sxtx $0x00 -> %w2
+2b26e0a4 : adds w4, w5, w6, SXTX #0                  : adds   %w5 %w6 sxtx $0x00 -> %w4
+2b28e4e6 : adds w6, w7, w8, SXTX #1                  : adds   %w7 %w8 sxtx $0x01 -> %w6
+2b2ae528 : adds w8, w9, w10, SXTX #1                 : adds   %w9 %w10 sxtx $0x01 -> %w8
+2b2be549 : adds w9, w10, w11, SXTX #1                : adds   %w10 %w11 sxtx $0x01 -> %w9
+2b2de98b : adds w11, w12, w13, SXTX #2               : adds   %w12 %w13 sxtx $0x02 -> %w11
+2b2fe9cd : adds w13, w14, w15, SXTX #2               : adds   %w14 %w15 sxtx $0x02 -> %w13
+2b31ea0f : adds w15, w16, w17, SXTX #2               : adds   %w16 %w17 sxtx $0x02 -> %w15
+2b33ea51 : adds w17, w18, w19, SXTX #2               : adds   %w18 %w19 sxtx $0x02 -> %w17
+2b35ea93 : adds w19, w20, w21, SXTX #2               : adds   %w20 %w21 sxtx $0x02 -> %w19
+2b37eed5 : adds w21, w22, w23, SXTX #3               : adds   %w22 %w23 sxtx $0x03 -> %w21
+2b38eef6 : adds w22, w23, w24, SXTX #3               : adds   %w23 %w24 sxtx $0x03 -> %w22
+2b3aef38 : adds w24, w25, w26, SXTX #3               : adds   %w25 %w26 sxtx $0x03 -> %w24
+2b3cf37a : adds w26, w27, w28, SXTX #4               : adds   %w27 %w28 sxtx $0x04 -> %w26
+2b21f01e : adds w30, w0, w1, SXTX #4                 : adds   %w0 %w1 sxtx $0x04 -> %w30
+
+# MOVN    <Wd>, #<imm>{, LSL <amount>} (MOVN-R.I-32_movewide)
+12800000 : movn w0, #0x0, LSL #0                     : movn   $0x0000 lsl $0x00 -> %w0
+12820002 : movn w2, #0x1000, LSL #0                  : movn   $0x1000 lsl $0x00 -> %w2
+12840004 : movn w4, #0x2000, LSL #0                  : movn   $0x2000 lsl $0x00 -> %w4
+12860006 : movn w6, #0x3000, LSL #0                  : movn   $0x3000 lsl $0x00 -> %w6
+12880008 : movn w8, #0x4000, LSL #0                  : movn   $0x4000 lsl $0x00 -> %w8
+128a0009 : movn w9, #0x5000, LSL #0                  : movn   $0x5000 lsl $0x00 -> %w9
+128c000b : movn w11, #0x6000, LSL #0                 : movn   $0x6000 lsl $0x00 -> %w11
+128e000d : movn w13, #0x7000, LSL #0                 : movn   $0x7000 lsl $0x00 -> %w13
+1290000f : movn w15, #0x8000, LSL #0                 : movn   $0x8000 lsl $0x00 -> %w15
+1291fff1 : movn w17, #0x8fff, LSL #0                 : movn   $0x8fff lsl $0x00 -> %w17
+1293fff3 : movn w19, #0x9fff, LSL #0                 : movn   $0x9fff lsl $0x00 -> %w19
+1295fff5 : movn w21, #0xafff, LSL #0                 : movn   $0xafff lsl $0x00 -> %w21
+1297fff6 : movn w22, #0xbfff, LSL #0                 : movn   $0xbfff lsl $0x00 -> %w22
+1299fff8 : movn w24, #0xcfff, LSL #0                 : movn   $0xcfff lsl $0x00 -> %w24
+129bfffa : movn w26, #0xdfff, LSL #0                 : movn   $0xdfff lsl $0x00 -> %w26
+129ffffe : movn w30, #0xffff, LSL #0                 : movn   $0xffff lsl $0x00 -> %w30
+12a00000 : movn w0, #0x0, LSL #16                    : movn   $0x0000 lsl $0x10 -> %w0
+12a20002 : movn w2, #0x1000, LSL #16                 : movn   $0x1000 lsl $0x10 -> %w2
+12a40004 : movn w4, #0x2000, LSL #16                 : movn   $0x2000 lsl $0x10 -> %w4
+12a60006 : movn w6, #0x3000, LSL #16                 : movn   $0x3000 lsl $0x10 -> %w6
+12a80008 : movn w8, #0x4000, LSL #16                 : movn   $0x4000 lsl $0x10 -> %w8
+12aa0009 : movn w9, #0x5000, LSL #16                 : movn   $0x5000 lsl $0x10 -> %w9
+12ac000b : movn w11, #0x6000, LSL #16                : movn   $0x6000 lsl $0x10 -> %w11
+12ae000d : movn w13, #0x7000, LSL #16                : movn   $0x7000 lsl $0x10 -> %w13
+12b0000f : movn w15, #0x8000, LSL #16                : movn   $0x8000 lsl $0x10 -> %w15
+12b1fff1 : movn w17, #0x8fff, LSL #16                : movn   $0x8fff lsl $0x10 -> %w17
+12b3fff3 : movn w19, #0x9fff, LSL #16                : movn   $0x9fff lsl $0x10 -> %w19
+12b5fff5 : movn w21, #0xafff, LSL #16                : movn   $0xafff lsl $0x10 -> %w21
+12b7fff6 : movn w22, #0xbfff, LSL #16                : movn   $0xbfff lsl $0x10 -> %w22
+12b9fff8 : movn w24, #0xcfff, LSL #16                : movn   $0xcfff lsl $0x10 -> %w24
+12bbfffa : movn w26, #0xdfff, LSL #16                : movn   $0xdfff lsl $0x10 -> %w26
+12bffffe : movn w30, #0xffff, LSL #16                : movn   $0xffff lsl $0x10 -> %w30
+
+# UMULH   <Xd>, <Xn>, <Xm> (UMULH-R.RR-64_dp_3src)
+9bc27c20 : umulh x0, x1, x2                          : umulh  %x1 %x2 -> %x0
+9bc47c62 : umulh x2, x3, x4                          : umulh  %x3 %x4 -> %x2
+9bc67ca4 : umulh x4, x5, x6                          : umulh  %x5 %x6 -> %x4
+9bc87ce6 : umulh x6, x7, x8                          : umulh  %x7 %x8 -> %x6
+9bca7d28 : umulh x8, x9, x10                         : umulh  %x9 %x10 -> %x8
+9bcb7d49 : umulh x9, x10, x11                        : umulh  %x10 %x11 -> %x9
+9bcd7d8b : umulh x11, x12, x13                       : umulh  %x12 %x13 -> %x11
+9bcf7dcd : umulh x13, x14, x15                       : umulh  %x14 %x15 -> %x13
+9bd17e0f : umulh x15, x16, x17                       : umulh  %x16 %x17 -> %x15
+9bd37e51 : umulh x17, x18, x19                       : umulh  %x18 %x19 -> %x17
+9bd57e93 : umulh x19, x20, x21                       : umulh  %x20 %x21 -> %x19
+9bd77ed5 : umulh x21, x22, x23                       : umulh  %x22 %x23 -> %x21
+9bd87ef6 : umulh x22, x23, x24                       : umulh  %x23 %x24 -> %x22
+9bda7f38 : umulh x24, x25, x26                       : umulh  %x25 %x26 -> %x24
+9bdc7f7a : umulh x26, x27, x28                       : umulh  %x27 %x28 -> %x26
+9bc17c1e : umulh x30, x0, x1                         : umulh  %x0 %x1 -> %x30
+
+# CCMP    <Xn>, #<imm1>, #<imm2>, <cond> (CCMP-R.II-64_condcmp_imm)
+fa400800 : ccmp x0, #0x0, #0x0, EQ                   : ccmp.eq %x0 $0x00 $0x00
+fa420841 : ccmp x2, #0x2, #0x1, EQ                   : ccmp.eq %x2 $0x02 $0x01
+fa440882 : ccmp x4, #0x4, #0x2, EQ                   : ccmp.eq %x4 $0x04 $0x02
+fa4608c3 : ccmp x6, #0x6, #0x3, EQ                   : ccmp.eq %x6 $0x06 $0x03
+fa480904 : ccmp x8, #0x8, #0x4, EQ                   : ccmp.eq %x8 $0x08 $0x04
+fa4a0925 : ccmp x9, #0xa, #0x5, EQ                   : ccmp.eq %x9 $0x0a $0x05
+fa4c0966 : ccmp x11, #0xc, #0x6, EQ                  : ccmp.eq %x11 $0x0c $0x06
+fa4e09a7 : ccmp x13, #0xe, #0x7, EQ                  : ccmp.eq %x13 $0x0e $0x07
+fa5009e8 : ccmp x15, #0x10, #0x8, EQ                 : ccmp.eq %x15 $0x10 $0x08
+fa510a28 : ccmp x17, #0x11, #0x8, EQ                 : ccmp.eq %x17 $0x11 $0x08
+fa530a69 : ccmp x19, #0x13, #0x9, EQ                 : ccmp.eq %x19 $0x13 $0x09
+fa550aaa : ccmp x21, #0x15, #0xa, EQ                 : ccmp.eq %x21 $0x15 $0x0a
+fa570acb : ccmp x22, #0x17, #0xb, EQ                 : ccmp.eq %x22 $0x17 $0x0b
+fa590b0c : ccmp x24, #0x19, #0xc, EQ                 : ccmp.eq %x24 $0x19 $0x0c
+fa5b0b4d : ccmp x26, #0x1b, #0xd, EQ                 : ccmp.eq %x26 $0x1b $0x0d
+fa5f0bcf : ccmp x30, #0x1f, #0xf, EQ                 : ccmp.eq %x30 $0x1f $0x0f
+fa401800 : ccmp x0, #0x0, #0x0, NE                   : ccmp.ne %x0 $0x00 $0x00
+fa421841 : ccmp x2, #0x2, #0x1, NE                   : ccmp.ne %x2 $0x02 $0x01
+fa441882 : ccmp x4, #0x4, #0x2, NE                   : ccmp.ne %x4 $0x04 $0x02
+fa4618c3 : ccmp x6, #0x6, #0x3, NE                   : ccmp.ne %x6 $0x06 $0x03
+fa481904 : ccmp x8, #0x8, #0x4, NE                   : ccmp.ne %x8 $0x08 $0x04
+fa4a1925 : ccmp x9, #0xa, #0x5, NE                   : ccmp.ne %x9 $0x0a $0x05
+fa4c1966 : ccmp x11, #0xc, #0x6, NE                  : ccmp.ne %x11 $0x0c $0x06
+fa4e19a7 : ccmp x13, #0xe, #0x7, NE                  : ccmp.ne %x13 $0x0e $0x07
+fa5019e8 : ccmp x15, #0x10, #0x8, NE                 : ccmp.ne %x15 $0x10 $0x08
+fa511a28 : ccmp x17, #0x11, #0x8, NE                 : ccmp.ne %x17 $0x11 $0x08
+fa531a69 : ccmp x19, #0x13, #0x9, NE                 : ccmp.ne %x19 $0x13 $0x09
+fa551aaa : ccmp x21, #0x15, #0xa, NE                 : ccmp.ne %x21 $0x15 $0x0a
+fa571acb : ccmp x22, #0x17, #0xb, NE                 : ccmp.ne %x22 $0x17 $0x0b
+fa591b0c : ccmp x24, #0x19, #0xc, NE                 : ccmp.ne %x24 $0x19 $0x0c
+fa5b1b4d : ccmp x26, #0x1b, #0xd, NE                 : ccmp.ne %x26 $0x1b $0x0d
+fa5f1bcf : ccmp x30, #0x1f, #0xf, NE                 : ccmp.ne %x30 $0x1f $0x0f
+fa402800 : ccmp x0, #0x0, #0x0, CS                   : ccmp.cs %x0 $0x00 $0x00
+fa422841 : ccmp x2, #0x2, #0x1, CS                   : ccmp.cs %x2 $0x02 $0x01
+fa442882 : ccmp x4, #0x4, #0x2, CS                   : ccmp.cs %x4 $0x04 $0x02
+fa4628c3 : ccmp x6, #0x6, #0x3, CS                   : ccmp.cs %x6 $0x06 $0x03
+fa482904 : ccmp x8, #0x8, #0x4, CS                   : ccmp.cs %x8 $0x08 $0x04
+fa4a2925 : ccmp x9, #0xa, #0x5, CS                   : ccmp.cs %x9 $0x0a $0x05
+fa4c2966 : ccmp x11, #0xc, #0x6, CS                  : ccmp.cs %x11 $0x0c $0x06
+fa4e29a7 : ccmp x13, #0xe, #0x7, CS                  : ccmp.cs %x13 $0x0e $0x07
+fa5029e8 : ccmp x15, #0x10, #0x8, CS                 : ccmp.cs %x15 $0x10 $0x08
+fa512a28 : ccmp x17, #0x11, #0x8, CS                 : ccmp.cs %x17 $0x11 $0x08
+fa532a69 : ccmp x19, #0x13, #0x9, CS                 : ccmp.cs %x19 $0x13 $0x09
+fa552aaa : ccmp x21, #0x15, #0xa, CS                 : ccmp.cs %x21 $0x15 $0x0a
+fa572acb : ccmp x22, #0x17, #0xb, CS                 : ccmp.cs %x22 $0x17 $0x0b
+fa592b0c : ccmp x24, #0x19, #0xc, CS                 : ccmp.cs %x24 $0x19 $0x0c
+fa5b2b4d : ccmp x26, #0x1b, #0xd, CS                 : ccmp.cs %x26 $0x1b $0x0d
+fa5f2bcf : ccmp x30, #0x1f, #0xf, CS                 : ccmp.cs %x30 $0x1f $0x0f
+fa403800 : ccmp x0, #0x0, #0x0, CC                   : ccmp.cc %x0 $0x00 $0x00
+fa423841 : ccmp x2, #0x2, #0x1, CC                   : ccmp.cc %x2 $0x02 $0x01
+fa443882 : ccmp x4, #0x4, #0x2, CC                   : ccmp.cc %x4 $0x04 $0x02
+fa4638c3 : ccmp x6, #0x6, #0x3, CC                   : ccmp.cc %x6 $0x06 $0x03
+fa483904 : ccmp x8, #0x8, #0x4, CC                   : ccmp.cc %x8 $0x08 $0x04
+fa4a3925 : ccmp x9, #0xa, #0x5, CC                   : ccmp.cc %x9 $0x0a $0x05
+fa4c3966 : ccmp x11, #0xc, #0x6, CC                  : ccmp.cc %x11 $0x0c $0x06
+fa4e39a7 : ccmp x13, #0xe, #0x7, CC                  : ccmp.cc %x13 $0x0e $0x07
+fa5039e8 : ccmp x15, #0x10, #0x8, CC                 : ccmp.cc %x15 $0x10 $0x08
+fa513a28 : ccmp x17, #0x11, #0x8, CC                 : ccmp.cc %x17 $0x11 $0x08
+fa533a69 : ccmp x19, #0x13, #0x9, CC                 : ccmp.cc %x19 $0x13 $0x09
+fa553aaa : ccmp x21, #0x15, #0xa, CC                 : ccmp.cc %x21 $0x15 $0x0a
+fa573acb : ccmp x22, #0x17, #0xb, CC                 : ccmp.cc %x22 $0x17 $0x0b
+fa593b0c : ccmp x24, #0x19, #0xc, CC                 : ccmp.cc %x24 $0x19 $0x0c
+fa5b3b4d : ccmp x26, #0x1b, #0xd, CC                 : ccmp.cc %x26 $0x1b $0x0d
+fa5f3bcf : ccmp x30, #0x1f, #0xf, CC                 : ccmp.cc %x30 $0x1f $0x0f
+fa404800 : ccmp x0, #0x0, #0x0, MI                   : ccmp.mi %x0 $0x00 $0x00
+fa424841 : ccmp x2, #0x2, #0x1, MI                   : ccmp.mi %x2 $0x02 $0x01
+fa444882 : ccmp x4, #0x4, #0x2, MI                   : ccmp.mi %x4 $0x04 $0x02
+fa4648c3 : ccmp x6, #0x6, #0x3, MI                   : ccmp.mi %x6 $0x06 $0x03
+fa484904 : ccmp x8, #0x8, #0x4, MI                   : ccmp.mi %x8 $0x08 $0x04
+fa4a4925 : ccmp x9, #0xa, #0x5, MI                   : ccmp.mi %x9 $0x0a $0x05
+fa4c4966 : ccmp x11, #0xc, #0x6, MI                  : ccmp.mi %x11 $0x0c $0x06
+fa4e49a7 : ccmp x13, #0xe, #0x7, MI                  : ccmp.mi %x13 $0x0e $0x07
+fa5049e8 : ccmp x15, #0x10, #0x8, MI                 : ccmp.mi %x15 $0x10 $0x08
+fa514a28 : ccmp x17, #0x11, #0x8, MI                 : ccmp.mi %x17 $0x11 $0x08
+fa534a69 : ccmp x19, #0x13, #0x9, MI                 : ccmp.mi %x19 $0x13 $0x09
+fa554aaa : ccmp x21, #0x15, #0xa, MI                 : ccmp.mi %x21 $0x15 $0x0a
+fa574acb : ccmp x22, #0x17, #0xb, MI                 : ccmp.mi %x22 $0x17 $0x0b
+fa594b0c : ccmp x24, #0x19, #0xc, MI                 : ccmp.mi %x24 $0x19 $0x0c
+fa5b4b4d : ccmp x26, #0x1b, #0xd, MI                 : ccmp.mi %x26 $0x1b $0x0d
+fa5f4bcf : ccmp x30, #0x1f, #0xf, MI                 : ccmp.mi %x30 $0x1f $0x0f
+fa405800 : ccmp x0, #0x0, #0x0, PL                   : ccmp.pl %x0 $0x00 $0x00
+fa425841 : ccmp x2, #0x2, #0x1, PL                   : ccmp.pl %x2 $0x02 $0x01
+fa445882 : ccmp x4, #0x4, #0x2, PL                   : ccmp.pl %x4 $0x04 $0x02
+fa4658c3 : ccmp x6, #0x6, #0x3, PL                   : ccmp.pl %x6 $0x06 $0x03
+fa485904 : ccmp x8, #0x8, #0x4, PL                   : ccmp.pl %x8 $0x08 $0x04
+fa4a5925 : ccmp x9, #0xa, #0x5, PL                   : ccmp.pl %x9 $0x0a $0x05
+fa4c5966 : ccmp x11, #0xc, #0x6, PL                  : ccmp.pl %x11 $0x0c $0x06
+fa4e59a7 : ccmp x13, #0xe, #0x7, PL                  : ccmp.pl %x13 $0x0e $0x07
+fa5059e8 : ccmp x15, #0x10, #0x8, PL                 : ccmp.pl %x15 $0x10 $0x08
+fa515a28 : ccmp x17, #0x11, #0x8, PL                 : ccmp.pl %x17 $0x11 $0x08
+fa535a69 : ccmp x19, #0x13, #0x9, PL                 : ccmp.pl %x19 $0x13 $0x09
+fa555aaa : ccmp x21, #0x15, #0xa, PL                 : ccmp.pl %x21 $0x15 $0x0a
+fa575acb : ccmp x22, #0x17, #0xb, PL                 : ccmp.pl %x22 $0x17 $0x0b
+fa595b0c : ccmp x24, #0x19, #0xc, PL                 : ccmp.pl %x24 $0x19 $0x0c
+fa5b5b4d : ccmp x26, #0x1b, #0xd, PL                 : ccmp.pl %x26 $0x1b $0x0d
+fa5f5bcf : ccmp x30, #0x1f, #0xf, PL                 : ccmp.pl %x30 $0x1f $0x0f
+fa406800 : ccmp x0, #0x0, #0x0, VS                   : ccmp.vs %x0 $0x00 $0x00
+fa426841 : ccmp x2, #0x2, #0x1, VS                   : ccmp.vs %x2 $0x02 $0x01
+fa446882 : ccmp x4, #0x4, #0x2, VS                   : ccmp.vs %x4 $0x04 $0x02
+fa4668c3 : ccmp x6, #0x6, #0x3, VS                   : ccmp.vs %x6 $0x06 $0x03
+fa486904 : ccmp x8, #0x8, #0x4, VS                   : ccmp.vs %x8 $0x08 $0x04
+fa4a6925 : ccmp x9, #0xa, #0x5, VS                   : ccmp.vs %x9 $0x0a $0x05
+fa4c6966 : ccmp x11, #0xc, #0x6, VS                  : ccmp.vs %x11 $0x0c $0x06
+fa4e69a7 : ccmp x13, #0xe, #0x7, VS                  : ccmp.vs %x13 $0x0e $0x07
+fa5069e8 : ccmp x15, #0x10, #0x8, VS                 : ccmp.vs %x15 $0x10 $0x08
+fa516a28 : ccmp x17, #0x11, #0x8, VS                 : ccmp.vs %x17 $0x11 $0x08
+fa536a69 : ccmp x19, #0x13, #0x9, VS                 : ccmp.vs %x19 $0x13 $0x09
+fa556aaa : ccmp x21, #0x15, #0xa, VS                 : ccmp.vs %x21 $0x15 $0x0a
+fa576acb : ccmp x22, #0x17, #0xb, VS                 : ccmp.vs %x22 $0x17 $0x0b
+fa596b0c : ccmp x24, #0x19, #0xc, VS                 : ccmp.vs %x24 $0x19 $0x0c
+fa5b6b4d : ccmp x26, #0x1b, #0xd, VS                 : ccmp.vs %x26 $0x1b $0x0d
+fa5f6bcf : ccmp x30, #0x1f, #0xf, VS                 : ccmp.vs %x30 $0x1f $0x0f
+fa407800 : ccmp x0, #0x0, #0x0, VC                   : ccmp.vc %x0 $0x00 $0x00
+fa427841 : ccmp x2, #0x2, #0x1, VC                   : ccmp.vc %x2 $0x02 $0x01
+fa447882 : ccmp x4, #0x4, #0x2, VC                   : ccmp.vc %x4 $0x04 $0x02
+fa4678c3 : ccmp x6, #0x6, #0x3, VC                   : ccmp.vc %x6 $0x06 $0x03
+fa487904 : ccmp x8, #0x8, #0x4, VC                   : ccmp.vc %x8 $0x08 $0x04
+fa4a7925 : ccmp x9, #0xa, #0x5, VC                   : ccmp.vc %x9 $0x0a $0x05
+fa4c7966 : ccmp x11, #0xc, #0x6, VC                  : ccmp.vc %x11 $0x0c $0x06
+fa4e79a7 : ccmp x13, #0xe, #0x7, VC                  : ccmp.vc %x13 $0x0e $0x07
+fa5079e8 : ccmp x15, #0x10, #0x8, VC                 : ccmp.vc %x15 $0x10 $0x08
+fa517a28 : ccmp x17, #0x11, #0x8, VC                 : ccmp.vc %x17 $0x11 $0x08
+fa537a69 : ccmp x19, #0x13, #0x9, VC                 : ccmp.vc %x19 $0x13 $0x09
+fa557aaa : ccmp x21, #0x15, #0xa, VC                 : ccmp.vc %x21 $0x15 $0x0a
+fa577acb : ccmp x22, #0x17, #0xb, VC                 : ccmp.vc %x22 $0x17 $0x0b
+fa597b0c : ccmp x24, #0x19, #0xc, VC                 : ccmp.vc %x24 $0x19 $0x0c
+fa5b7b4d : ccmp x26, #0x1b, #0xd, VC                 : ccmp.vc %x26 $0x1b $0x0d
+fa5f7bcf : ccmp x30, #0x1f, #0xf, VC                 : ccmp.vc %x30 $0x1f $0x0f
+fa408800 : ccmp x0, #0x0, #0x0, HI                   : ccmp.hi %x0 $0x00 $0x00
+fa428841 : ccmp x2, #0x2, #0x1, HI                   : ccmp.hi %x2 $0x02 $0x01
+fa448882 : ccmp x4, #0x4, #0x2, HI                   : ccmp.hi %x4 $0x04 $0x02
+fa4688c3 : ccmp x6, #0x6, #0x3, HI                   : ccmp.hi %x6 $0x06 $0x03
+fa488904 : ccmp x8, #0x8, #0x4, HI                   : ccmp.hi %x8 $0x08 $0x04
+fa4a8925 : ccmp x9, #0xa, #0x5, HI                   : ccmp.hi %x9 $0x0a $0x05
+fa4c8966 : ccmp x11, #0xc, #0x6, HI                  : ccmp.hi %x11 $0x0c $0x06
+fa4e89a7 : ccmp x13, #0xe, #0x7, HI                  : ccmp.hi %x13 $0x0e $0x07
+fa5089e8 : ccmp x15, #0x10, #0x8, HI                 : ccmp.hi %x15 $0x10 $0x08
+fa518a28 : ccmp x17, #0x11, #0x8, HI                 : ccmp.hi %x17 $0x11 $0x08
+fa538a69 : ccmp x19, #0x13, #0x9, HI                 : ccmp.hi %x19 $0x13 $0x09
+fa558aaa : ccmp x21, #0x15, #0xa, HI                 : ccmp.hi %x21 $0x15 $0x0a
+fa578acb : ccmp x22, #0x17, #0xb, HI                 : ccmp.hi %x22 $0x17 $0x0b
+fa598b0c : ccmp x24, #0x19, #0xc, HI                 : ccmp.hi %x24 $0x19 $0x0c
+fa5b8b4d : ccmp x26, #0x1b, #0xd, HI                 : ccmp.hi %x26 $0x1b $0x0d
+fa5f8bcf : ccmp x30, #0x1f, #0xf, HI                 : ccmp.hi %x30 $0x1f $0x0f
+fa409800 : ccmp x0, #0x0, #0x0, LS                   : ccmp.ls %x0 $0x00 $0x00
+fa429841 : ccmp x2, #0x2, #0x1, LS                   : ccmp.ls %x2 $0x02 $0x01
+fa449882 : ccmp x4, #0x4, #0x2, LS                   : ccmp.ls %x4 $0x04 $0x02
+fa4698c3 : ccmp x6, #0x6, #0x3, LS                   : ccmp.ls %x6 $0x06 $0x03
+fa489904 : ccmp x8, #0x8, #0x4, LS                   : ccmp.ls %x8 $0x08 $0x04
+fa4a9925 : ccmp x9, #0xa, #0x5, LS                   : ccmp.ls %x9 $0x0a $0x05
+fa4c9966 : ccmp x11, #0xc, #0x6, LS                  : ccmp.ls %x11 $0x0c $0x06
+fa4e99a7 : ccmp x13, #0xe, #0x7, LS                  : ccmp.ls %x13 $0x0e $0x07
+fa5099e8 : ccmp x15, #0x10, #0x8, LS                 : ccmp.ls %x15 $0x10 $0x08
+fa519a28 : ccmp x17, #0x11, #0x8, LS                 : ccmp.ls %x17 $0x11 $0x08
+fa539a69 : ccmp x19, #0x13, #0x9, LS                 : ccmp.ls %x19 $0x13 $0x09
+fa559aaa : ccmp x21, #0x15, #0xa, LS                 : ccmp.ls %x21 $0x15 $0x0a
+fa579acb : ccmp x22, #0x17, #0xb, LS                 : ccmp.ls %x22 $0x17 $0x0b
+fa599b0c : ccmp x24, #0x19, #0xc, LS                 : ccmp.ls %x24 $0x19 $0x0c
+fa5b9b4d : ccmp x26, #0x1b, #0xd, LS                 : ccmp.ls %x26 $0x1b $0x0d
+fa5f9bcf : ccmp x30, #0x1f, #0xf, LS                 : ccmp.ls %x30 $0x1f $0x0f
+fa40a800 : ccmp x0, #0x0, #0x0, GE                   : ccmp.ge %x0 $0x00 $0x00
+fa42a841 : ccmp x2, #0x2, #0x1, GE                   : ccmp.ge %x2 $0x02 $0x01
+fa44a882 : ccmp x4, #0x4, #0x2, GE                   : ccmp.ge %x4 $0x04 $0x02
+fa46a8c3 : ccmp x6, #0x6, #0x3, GE                   : ccmp.ge %x6 $0x06 $0x03
+fa48a904 : ccmp x8, #0x8, #0x4, GE                   : ccmp.ge %x8 $0x08 $0x04
+fa4aa925 : ccmp x9, #0xa, #0x5, GE                   : ccmp.ge %x9 $0x0a $0x05
+fa4ca966 : ccmp x11, #0xc, #0x6, GE                  : ccmp.ge %x11 $0x0c $0x06
+fa4ea9a7 : ccmp x13, #0xe, #0x7, GE                  : ccmp.ge %x13 $0x0e $0x07
+fa50a9e8 : ccmp x15, #0x10, #0x8, GE                 : ccmp.ge %x15 $0x10 $0x08
+fa51aa28 : ccmp x17, #0x11, #0x8, GE                 : ccmp.ge %x17 $0x11 $0x08
+fa53aa69 : ccmp x19, #0x13, #0x9, GE                 : ccmp.ge %x19 $0x13 $0x09
+fa55aaaa : ccmp x21, #0x15, #0xa, GE                 : ccmp.ge %x21 $0x15 $0x0a
+fa57aacb : ccmp x22, #0x17, #0xb, GE                 : ccmp.ge %x22 $0x17 $0x0b
+fa59ab0c : ccmp x24, #0x19, #0xc, GE                 : ccmp.ge %x24 $0x19 $0x0c
+fa5bab4d : ccmp x26, #0x1b, #0xd, GE                 : ccmp.ge %x26 $0x1b $0x0d
+fa5fabcf : ccmp x30, #0x1f, #0xf, GE                 : ccmp.ge %x30 $0x1f $0x0f
+fa40b800 : ccmp x0, #0x0, #0x0, LT                   : ccmp.lt %x0 $0x00 $0x00
+fa42b841 : ccmp x2, #0x2, #0x1, LT                   : ccmp.lt %x2 $0x02 $0x01
+fa44b882 : ccmp x4, #0x4, #0x2, LT                   : ccmp.lt %x4 $0x04 $0x02
+fa46b8c3 : ccmp x6, #0x6, #0x3, LT                   : ccmp.lt %x6 $0x06 $0x03
+fa48b904 : ccmp x8, #0x8, #0x4, LT                   : ccmp.lt %x8 $0x08 $0x04
+fa4ab925 : ccmp x9, #0xa, #0x5, LT                   : ccmp.lt %x9 $0x0a $0x05
+fa4cb966 : ccmp x11, #0xc, #0x6, LT                  : ccmp.lt %x11 $0x0c $0x06
+fa4eb9a7 : ccmp x13, #0xe, #0x7, LT                  : ccmp.lt %x13 $0x0e $0x07
+fa50b9e8 : ccmp x15, #0x10, #0x8, LT                 : ccmp.lt %x15 $0x10 $0x08
+fa51ba28 : ccmp x17, #0x11, #0x8, LT                 : ccmp.lt %x17 $0x11 $0x08
+fa53ba69 : ccmp x19, #0x13, #0x9, LT                 : ccmp.lt %x19 $0x13 $0x09
+fa55baaa : ccmp x21, #0x15, #0xa, LT                 : ccmp.lt %x21 $0x15 $0x0a
+fa57bacb : ccmp x22, #0x17, #0xb, LT                 : ccmp.lt %x22 $0x17 $0x0b
+fa59bb0c : ccmp x24, #0x19, #0xc, LT                 : ccmp.lt %x24 $0x19 $0x0c
+fa5bbb4d : ccmp x26, #0x1b, #0xd, LT                 : ccmp.lt %x26 $0x1b $0x0d
+fa5fbbcf : ccmp x30, #0x1f, #0xf, LT                 : ccmp.lt %x30 $0x1f $0x0f
+fa40c800 : ccmp x0, #0x0, #0x0, GT                   : ccmp.gt %x0 $0x00 $0x00
+fa42c841 : ccmp x2, #0x2, #0x1, GT                   : ccmp.gt %x2 $0x02 $0x01
+fa44c882 : ccmp x4, #0x4, #0x2, GT                   : ccmp.gt %x4 $0x04 $0x02
+fa46c8c3 : ccmp x6, #0x6, #0x3, GT                   : ccmp.gt %x6 $0x06 $0x03
+fa48c904 : ccmp x8, #0x8, #0x4, GT                   : ccmp.gt %x8 $0x08 $0x04
+fa4ac925 : ccmp x9, #0xa, #0x5, GT                   : ccmp.gt %x9 $0x0a $0x05
+fa4cc966 : ccmp x11, #0xc, #0x6, GT                  : ccmp.gt %x11 $0x0c $0x06
+fa4ec9a7 : ccmp x13, #0xe, #0x7, GT                  : ccmp.gt %x13 $0x0e $0x07
+fa50c9e8 : ccmp x15, #0x10, #0x8, GT                 : ccmp.gt %x15 $0x10 $0x08
+fa51ca28 : ccmp x17, #0x11, #0x8, GT                 : ccmp.gt %x17 $0x11 $0x08
+fa53ca69 : ccmp x19, #0x13, #0x9, GT                 : ccmp.gt %x19 $0x13 $0x09
+fa55caaa : ccmp x21, #0x15, #0xa, GT                 : ccmp.gt %x21 $0x15 $0x0a
+fa57cacb : ccmp x22, #0x17, #0xb, GT                 : ccmp.gt %x22 $0x17 $0x0b
+fa59cb0c : ccmp x24, #0x19, #0xc, GT                 : ccmp.gt %x24 $0x19 $0x0c
+fa5bcb4d : ccmp x26, #0x1b, #0xd, GT                 : ccmp.gt %x26 $0x1b $0x0d
+fa5fcbcf : ccmp x30, #0x1f, #0xf, GT                 : ccmp.gt %x30 $0x1f $0x0f
+fa40d800 : ccmp x0, #0x0, #0x0, LE                   : ccmp.le %x0 $0x00 $0x00
+fa42d841 : ccmp x2, #0x2, #0x1, LE                   : ccmp.le %x2 $0x02 $0x01
+fa44d882 : ccmp x4, #0x4, #0x2, LE                   : ccmp.le %x4 $0x04 $0x02
+fa46d8c3 : ccmp x6, #0x6, #0x3, LE                   : ccmp.le %x6 $0x06 $0x03
+fa48d904 : ccmp x8, #0x8, #0x4, LE                   : ccmp.le %x8 $0x08 $0x04
+fa4ad925 : ccmp x9, #0xa, #0x5, LE                   : ccmp.le %x9 $0x0a $0x05
+fa4cd966 : ccmp x11, #0xc, #0x6, LE                  : ccmp.le %x11 $0x0c $0x06
+fa4ed9a7 : ccmp x13, #0xe, #0x7, LE                  : ccmp.le %x13 $0x0e $0x07
+fa50d9e8 : ccmp x15, #0x10, #0x8, LE                 : ccmp.le %x15 $0x10 $0x08
+fa51da28 : ccmp x17, #0x11, #0x8, LE                 : ccmp.le %x17 $0x11 $0x08
+fa53da69 : ccmp x19, #0x13, #0x9, LE                 : ccmp.le %x19 $0x13 $0x09
+fa55daaa : ccmp x21, #0x15, #0xa, LE                 : ccmp.le %x21 $0x15 $0x0a
+fa57dacb : ccmp x22, #0x17, #0xb, LE                 : ccmp.le %x22 $0x17 $0x0b
+fa59db0c : ccmp x24, #0x19, #0xc, LE                 : ccmp.le %x24 $0x19 $0x0c
+fa5bdb4d : ccmp x26, #0x1b, #0xd, LE                 : ccmp.le %x26 $0x1b $0x0d
+fa5fdbcf : ccmp x30, #0x1f, #0xf, LE                 : ccmp.le %x30 $0x1f $0x0f
+fa40e800 : ccmp x0, #0x0, #0x0, AL                   : ccmp.al %x0 $0x00 $0x00
+fa42e841 : ccmp x2, #0x2, #0x1, AL                   : ccmp.al %x2 $0x02 $0x01
+fa44e882 : ccmp x4, #0x4, #0x2, AL                   : ccmp.al %x4 $0x04 $0x02
+fa46e8c3 : ccmp x6, #0x6, #0x3, AL                   : ccmp.al %x6 $0x06 $0x03
+fa48e904 : ccmp x8, #0x8, #0x4, AL                   : ccmp.al %x8 $0x08 $0x04
+fa4ae925 : ccmp x9, #0xa, #0x5, AL                   : ccmp.al %x9 $0x0a $0x05
+fa4ce966 : ccmp x11, #0xc, #0x6, AL                  : ccmp.al %x11 $0x0c $0x06
+fa4ee9a7 : ccmp x13, #0xe, #0x7, AL                  : ccmp.al %x13 $0x0e $0x07
+fa50e9e8 : ccmp x15, #0x10, #0x8, AL                 : ccmp.al %x15 $0x10 $0x08
+fa51ea28 : ccmp x17, #0x11, #0x8, AL                 : ccmp.al %x17 $0x11 $0x08
+fa53ea69 : ccmp x19, #0x13, #0x9, AL                 : ccmp.al %x19 $0x13 $0x09
+fa55eaaa : ccmp x21, #0x15, #0xa, AL                 : ccmp.al %x21 $0x15 $0x0a
+fa57eacb : ccmp x22, #0x17, #0xb, AL                 : ccmp.al %x22 $0x17 $0x0b
+fa59eb0c : ccmp x24, #0x19, #0xc, AL                 : ccmp.al %x24 $0x19 $0x0c
+fa5beb4d : ccmp x26, #0x1b, #0xd, AL                 : ccmp.al %x26 $0x1b $0x0d
+fa5febcf : ccmp x30, #0x1f, #0xf, AL                 : ccmp.al %x30 $0x1f $0x0f
+fa40f800 : ccmp x0, #0x0, #0x0, NV                   : ccmp.nv %x0 $0x00 $0x00
+fa42f841 : ccmp x2, #0x2, #0x1, NV                   : ccmp.nv %x2 $0x02 $0x01
+fa44f882 : ccmp x4, #0x4, #0x2, NV                   : ccmp.nv %x4 $0x04 $0x02
+fa46f8c3 : ccmp x6, #0x6, #0x3, NV                   : ccmp.nv %x6 $0x06 $0x03
+fa48f904 : ccmp x8, #0x8, #0x4, NV                   : ccmp.nv %x8 $0x08 $0x04
+fa4af925 : ccmp x9, #0xa, #0x5, NV                   : ccmp.nv %x9 $0x0a $0x05
+fa4cf966 : ccmp x11, #0xc, #0x6, NV                  : ccmp.nv %x11 $0x0c $0x06
+fa4ef9a7 : ccmp x13, #0xe, #0x7, NV                  : ccmp.nv %x13 $0x0e $0x07
+fa50f9e8 : ccmp x15, #0x10, #0x8, NV                 : ccmp.nv %x15 $0x10 $0x08
+fa51fa28 : ccmp x17, #0x11, #0x8, NV                 : ccmp.nv %x17 $0x11 $0x08
+fa53fa69 : ccmp x19, #0x13, #0x9, NV                 : ccmp.nv %x19 $0x13 $0x09
+fa55faaa : ccmp x21, #0x15, #0xa, NV                 : ccmp.nv %x21 $0x15 $0x0a
+fa57facb : ccmp x22, #0x17, #0xb, NV                 : ccmp.nv %x22 $0x17 $0x0b
+fa59fb0c : ccmp x24, #0x19, #0xc, NV                 : ccmp.nv %x24 $0x19 $0x0c
+fa5bfb4d : ccmp x26, #0x1b, #0xd, NV                 : ccmp.nv %x26 $0x1b $0x0d
+fa5ffbcf : ccmp x30, #0x1f, #0xf, NV                 : ccmp.nv %x30 $0x1f $0x0f
+
+# SBC     <Wd>, <Wn>, <Wm> (SBC-R.RR-32_addsub_carry)
+5a020020 : sbc w0, w1, w2                            : sbc    %w1 %w2 -> %w0
+5a040062 : sbc w2, w3, w4                            : sbc    %w3 %w4 -> %w2
+5a0600a4 : sbc w4, w5, w6                            : sbc    %w5 %w6 -> %w4
+5a0800e6 : sbc w6, w7, w8                            : sbc    %w7 %w8 -> %w6
+5a0a0128 : sbc w8, w9, w10                           : sbc    %w9 %w10 -> %w8
+5a0b0149 : sbc w9, w10, w11                          : sbc    %w10 %w11 -> %w9
+5a0d018b : sbc w11, w12, w13                         : sbc    %w12 %w13 -> %w11
+5a0f01cd : sbc w13, w14, w15                         : sbc    %w14 %w15 -> %w13
+5a11020f : sbc w15, w16, w17                         : sbc    %w16 %w17 -> %w15
+5a130251 : sbc w17, w18, w19                         : sbc    %w18 %w19 -> %w17
+5a150293 : sbc w19, w20, w21                         : sbc    %w20 %w21 -> %w19
+5a1702d5 : sbc w21, w22, w23                         : sbc    %w22 %w23 -> %w21
+5a1802f6 : sbc w22, w23, w24                         : sbc    %w23 %w24 -> %w22
+5a1a0338 : sbc w24, w25, w26                         : sbc    %w25 %w26 -> %w24
+5a1c037a : sbc w26, w27, w28                         : sbc    %w27 %w28 -> %w26
+5a01001e : sbc w30, w0, w1                           : sbc    %w0 %w1 -> %w30
+
+# CSINC   <Xd>, <Xn>, <Xm>, <cond> (CSINC-R.RR-64_condsel)
+9a820420 : csinc x0, x1, x2, EQ                      : csinc  %x1 %x2 eq -> %x0
+9a840462 : csinc x2, x3, x4, EQ                      : csinc  %x3 %x4 eq -> %x2
+9a8604a4 : csinc x4, x5, x6, EQ                      : csinc  %x5 %x6 eq -> %x4
+9a8804e6 : csinc x6, x7, x8, EQ                      : csinc  %x7 %x8 eq -> %x6
+9a8a0528 : csinc x8, x9, x10, EQ                     : csinc  %x9 %x10 eq -> %x8
+9a8b0549 : csinc x9, x10, x11, EQ                    : csinc  %x10 %x11 eq -> %x9
+9a8d058b : csinc x11, x12, x13, EQ                   : csinc  %x12 %x13 eq -> %x11
+9a8f05cd : csinc x13, x14, x15, EQ                   : csinc  %x14 %x15 eq -> %x13
+9a91060f : csinc x15, x16, x17, EQ                   : csinc  %x16 %x17 eq -> %x15
+9a930651 : csinc x17, x18, x19, EQ                   : csinc  %x18 %x19 eq -> %x17
+9a950693 : csinc x19, x20, x21, EQ                   : csinc  %x20 %x21 eq -> %x19
+9a9706d5 : csinc x21, x22, x23, EQ                   : csinc  %x22 %x23 eq -> %x21
+9a9806f6 : csinc x22, x23, x24, EQ                   : csinc  %x23 %x24 eq -> %x22
+9a9a0738 : csinc x24, x25, x26, EQ                   : csinc  %x25 %x26 eq -> %x24
+9a9c077a : csinc x26, x27, x28, EQ                   : csinc  %x27 %x28 eq -> %x26
+9a81041e : csinc x30, x0, x1, EQ                     : csinc  %x0 %x1 eq -> %x30
+9a821420 : csinc x0, x1, x2, NE                      : csinc  %x1 %x2 ne -> %x0
+9a841462 : csinc x2, x3, x4, NE                      : csinc  %x3 %x4 ne -> %x2
+9a8614a4 : csinc x4, x5, x6, NE                      : csinc  %x5 %x6 ne -> %x4
+9a8814e6 : csinc x6, x7, x8, NE                      : csinc  %x7 %x8 ne -> %x6
+9a8a1528 : csinc x8, x9, x10, NE                     : csinc  %x9 %x10 ne -> %x8
+9a8b1549 : csinc x9, x10, x11, NE                    : csinc  %x10 %x11 ne -> %x9
+9a8d158b : csinc x11, x12, x13, NE                   : csinc  %x12 %x13 ne -> %x11
+9a8f15cd : csinc x13, x14, x15, NE                   : csinc  %x14 %x15 ne -> %x13
+9a91160f : csinc x15, x16, x17, NE                   : csinc  %x16 %x17 ne -> %x15
+9a931651 : csinc x17, x18, x19, NE                   : csinc  %x18 %x19 ne -> %x17
+9a951693 : csinc x19, x20, x21, NE                   : csinc  %x20 %x21 ne -> %x19
+9a9716d5 : csinc x21, x22, x23, NE                   : csinc  %x22 %x23 ne -> %x21
+9a9816f6 : csinc x22, x23, x24, NE                   : csinc  %x23 %x24 ne -> %x22
+9a9a1738 : csinc x24, x25, x26, NE                   : csinc  %x25 %x26 ne -> %x24
+9a9c177a : csinc x26, x27, x28, NE                   : csinc  %x27 %x28 ne -> %x26
+9a81141e : csinc x30, x0, x1, NE                     : csinc  %x0 %x1 ne -> %x30
+9a822420 : csinc x0, x1, x2, CS                      : csinc  %x1 %x2 cs -> %x0
+9a842462 : csinc x2, x3, x4, CS                      : csinc  %x3 %x4 cs -> %x2
+9a8624a4 : csinc x4, x5, x6, CS                      : csinc  %x5 %x6 cs -> %x4
+9a8824e6 : csinc x6, x7, x8, CS                      : csinc  %x7 %x8 cs -> %x6
+9a8a2528 : csinc x8, x9, x10, CS                     : csinc  %x9 %x10 cs -> %x8
+9a8b2549 : csinc x9, x10, x11, CS                    : csinc  %x10 %x11 cs -> %x9
+9a8d258b : csinc x11, x12, x13, CS                   : csinc  %x12 %x13 cs -> %x11
+9a8f25cd : csinc x13, x14, x15, CS                   : csinc  %x14 %x15 cs -> %x13
+9a91260f : csinc x15, x16, x17, CS                   : csinc  %x16 %x17 cs -> %x15
+9a932651 : csinc x17, x18, x19, CS                   : csinc  %x18 %x19 cs -> %x17
+9a952693 : csinc x19, x20, x21, CS                   : csinc  %x20 %x21 cs -> %x19
+9a9726d5 : csinc x21, x22, x23, CS                   : csinc  %x22 %x23 cs -> %x21
+9a9826f6 : csinc x22, x23, x24, CS                   : csinc  %x23 %x24 cs -> %x22
+9a9a2738 : csinc x24, x25, x26, CS                   : csinc  %x25 %x26 cs -> %x24
+9a9c277a : csinc x26, x27, x28, CS                   : csinc  %x27 %x28 cs -> %x26
+9a81241e : csinc x30, x0, x1, CS                     : csinc  %x0 %x1 cs -> %x30
+9a823420 : csinc x0, x1, x2, CC                      : csinc  %x1 %x2 cc -> %x0
+9a843462 : csinc x2, x3, x4, CC                      : csinc  %x3 %x4 cc -> %x2
+9a8634a4 : csinc x4, x5, x6, CC                      : csinc  %x5 %x6 cc -> %x4
+9a8834e6 : csinc x6, x7, x8, CC                      : csinc  %x7 %x8 cc -> %x6
+9a8a3528 : csinc x8, x9, x10, CC                     : csinc  %x9 %x10 cc -> %x8
+9a8b3549 : csinc x9, x10, x11, CC                    : csinc  %x10 %x11 cc -> %x9
+9a8d358b : csinc x11, x12, x13, CC                   : csinc  %x12 %x13 cc -> %x11
+9a8f35cd : csinc x13, x14, x15, CC                   : csinc  %x14 %x15 cc -> %x13
+9a91360f : csinc x15, x16, x17, CC                   : csinc  %x16 %x17 cc -> %x15
+9a933651 : csinc x17, x18, x19, CC                   : csinc  %x18 %x19 cc -> %x17
+9a953693 : csinc x19, x20, x21, CC                   : csinc  %x20 %x21 cc -> %x19
+9a9736d5 : csinc x21, x22, x23, CC                   : csinc  %x22 %x23 cc -> %x21
+9a9836f6 : csinc x22, x23, x24, CC                   : csinc  %x23 %x24 cc -> %x22
+9a9a3738 : csinc x24, x25, x26, CC                   : csinc  %x25 %x26 cc -> %x24
+9a9c377a : csinc x26, x27, x28, CC                   : csinc  %x27 %x28 cc -> %x26
+9a81341e : csinc x30, x0, x1, CC                     : csinc  %x0 %x1 cc -> %x30
+9a824420 : csinc x0, x1, x2, MI                      : csinc  %x1 %x2 mi -> %x0
+9a844462 : csinc x2, x3, x4, MI                      : csinc  %x3 %x4 mi -> %x2
+9a8644a4 : csinc x4, x5, x6, MI                      : csinc  %x5 %x6 mi -> %x4
+9a8844e6 : csinc x6, x7, x8, MI                      : csinc  %x7 %x8 mi -> %x6
+9a8a4528 : csinc x8, x9, x10, MI                     : csinc  %x9 %x10 mi -> %x8
+9a8b4549 : csinc x9, x10, x11, MI                    : csinc  %x10 %x11 mi -> %x9
+9a8d458b : csinc x11, x12, x13, MI                   : csinc  %x12 %x13 mi -> %x11
+9a8f45cd : csinc x13, x14, x15, MI                   : csinc  %x14 %x15 mi -> %x13
+9a91460f : csinc x15, x16, x17, MI                   : csinc  %x16 %x17 mi -> %x15
+9a934651 : csinc x17, x18, x19, MI                   : csinc  %x18 %x19 mi -> %x17
+9a954693 : csinc x19, x20, x21, MI                   : csinc  %x20 %x21 mi -> %x19
+9a9746d5 : csinc x21, x22, x23, MI                   : csinc  %x22 %x23 mi -> %x21
+9a9846f6 : csinc x22, x23, x24, MI                   : csinc  %x23 %x24 mi -> %x22
+9a9a4738 : csinc x24, x25, x26, MI                   : csinc  %x25 %x26 mi -> %x24
+9a9c477a : csinc x26, x27, x28, MI                   : csinc  %x27 %x28 mi -> %x26
+9a81441e : csinc x30, x0, x1, MI                     : csinc  %x0 %x1 mi -> %x30
+9a825420 : csinc x0, x1, x2, PL                      : csinc  %x1 %x2 pl -> %x0
+9a845462 : csinc x2, x3, x4, PL                      : csinc  %x3 %x4 pl -> %x2
+9a8654a4 : csinc x4, x5, x6, PL                      : csinc  %x5 %x6 pl -> %x4
+9a8854e6 : csinc x6, x7, x8, PL                      : csinc  %x7 %x8 pl -> %x6
+9a8a5528 : csinc x8, x9, x10, PL                     : csinc  %x9 %x10 pl -> %x8
+9a8b5549 : csinc x9, x10, x11, PL                    : csinc  %x10 %x11 pl -> %x9
+9a8d558b : csinc x11, x12, x13, PL                   : csinc  %x12 %x13 pl -> %x11
+9a8f55cd : csinc x13, x14, x15, PL                   : csinc  %x14 %x15 pl -> %x13
+9a91560f : csinc x15, x16, x17, PL                   : csinc  %x16 %x17 pl -> %x15
+9a935651 : csinc x17, x18, x19, PL                   : csinc  %x18 %x19 pl -> %x17
+9a955693 : csinc x19, x20, x21, PL                   : csinc  %x20 %x21 pl -> %x19
+9a9756d5 : csinc x21, x22, x23, PL                   : csinc  %x22 %x23 pl -> %x21
+9a9856f6 : csinc x22, x23, x24, PL                   : csinc  %x23 %x24 pl -> %x22
+9a9a5738 : csinc x24, x25, x26, PL                   : csinc  %x25 %x26 pl -> %x24
+9a9c577a : csinc x26, x27, x28, PL                   : csinc  %x27 %x28 pl -> %x26
+9a81541e : csinc x30, x0, x1, PL                     : csinc  %x0 %x1 pl -> %x30
+9a826420 : csinc x0, x1, x2, VS                      : csinc  %x1 %x2 vs -> %x0
+9a846462 : csinc x2, x3, x4, VS                      : csinc  %x3 %x4 vs -> %x2
+9a8664a4 : csinc x4, x5, x6, VS                      : csinc  %x5 %x6 vs -> %x4
+9a8864e6 : csinc x6, x7, x8, VS                      : csinc  %x7 %x8 vs -> %x6
+9a8a6528 : csinc x8, x9, x10, VS                     : csinc  %x9 %x10 vs -> %x8
+9a8b6549 : csinc x9, x10, x11, VS                    : csinc  %x10 %x11 vs -> %x9
+9a8d658b : csinc x11, x12, x13, VS                   : csinc  %x12 %x13 vs -> %x11
+9a8f65cd : csinc x13, x14, x15, VS                   : csinc  %x14 %x15 vs -> %x13
+9a91660f : csinc x15, x16, x17, VS                   : csinc  %x16 %x17 vs -> %x15
+9a936651 : csinc x17, x18, x19, VS                   : csinc  %x18 %x19 vs -> %x17
+9a956693 : csinc x19, x20, x21, VS                   : csinc  %x20 %x21 vs -> %x19
+9a9766d5 : csinc x21, x22, x23, VS                   : csinc  %x22 %x23 vs -> %x21
+9a9866f6 : csinc x22, x23, x24, VS                   : csinc  %x23 %x24 vs -> %x22
+9a9a6738 : csinc x24, x25, x26, VS                   : csinc  %x25 %x26 vs -> %x24
+9a9c677a : csinc x26, x27, x28, VS                   : csinc  %x27 %x28 vs -> %x26
+9a81641e : csinc x30, x0, x1, VS                     : csinc  %x0 %x1 vs -> %x30
+9a827420 : csinc x0, x1, x2, VC                      : csinc  %x1 %x2 vc -> %x0
+9a847462 : csinc x2, x3, x4, VC                      : csinc  %x3 %x4 vc -> %x2
+9a8674a4 : csinc x4, x5, x6, VC                      : csinc  %x5 %x6 vc -> %x4
+9a8874e6 : csinc x6, x7, x8, VC                      : csinc  %x7 %x8 vc -> %x6
+9a8a7528 : csinc x8, x9, x10, VC                     : csinc  %x9 %x10 vc -> %x8
+9a8b7549 : csinc x9, x10, x11, VC                    : csinc  %x10 %x11 vc -> %x9
+9a8d758b : csinc x11, x12, x13, VC                   : csinc  %x12 %x13 vc -> %x11
+9a8f75cd : csinc x13, x14, x15, VC                   : csinc  %x14 %x15 vc -> %x13
+9a91760f : csinc x15, x16, x17, VC                   : csinc  %x16 %x17 vc -> %x15
+9a937651 : csinc x17, x18, x19, VC                   : csinc  %x18 %x19 vc -> %x17
+9a957693 : csinc x19, x20, x21, VC                   : csinc  %x20 %x21 vc -> %x19
+9a9776d5 : csinc x21, x22, x23, VC                   : csinc  %x22 %x23 vc -> %x21
+9a9876f6 : csinc x22, x23, x24, VC                   : csinc  %x23 %x24 vc -> %x22
+9a9a7738 : csinc x24, x25, x26, VC                   : csinc  %x25 %x26 vc -> %x24
+9a9c777a : csinc x26, x27, x28, VC                   : csinc  %x27 %x28 vc -> %x26
+9a81741e : csinc x30, x0, x1, VC                     : csinc  %x0 %x1 vc -> %x30
+9a828420 : csinc x0, x1, x2, HI                      : csinc  %x1 %x2 hi -> %x0
+9a848462 : csinc x2, x3, x4, HI                      : csinc  %x3 %x4 hi -> %x2
+9a8684a4 : csinc x4, x5, x6, HI                      : csinc  %x5 %x6 hi -> %x4
+9a8884e6 : csinc x6, x7, x8, HI                      : csinc  %x7 %x8 hi -> %x6
+9a8a8528 : csinc x8, x9, x10, HI                     : csinc  %x9 %x10 hi -> %x8
+9a8b8549 : csinc x9, x10, x11, HI                    : csinc  %x10 %x11 hi -> %x9
+9a8d858b : csinc x11, x12, x13, HI                   : csinc  %x12 %x13 hi -> %x11
+9a8f85cd : csinc x13, x14, x15, HI                   : csinc  %x14 %x15 hi -> %x13
+9a91860f : csinc x15, x16, x17, HI                   : csinc  %x16 %x17 hi -> %x15
+9a938651 : csinc x17, x18, x19, HI                   : csinc  %x18 %x19 hi -> %x17
+9a958693 : csinc x19, x20, x21, HI                   : csinc  %x20 %x21 hi -> %x19
+9a9786d5 : csinc x21, x22, x23, HI                   : csinc  %x22 %x23 hi -> %x21
+9a9886f6 : csinc x22, x23, x24, HI                   : csinc  %x23 %x24 hi -> %x22
+9a9a8738 : csinc x24, x25, x26, HI                   : csinc  %x25 %x26 hi -> %x24
+9a9c877a : csinc x26, x27, x28, HI                   : csinc  %x27 %x28 hi -> %x26
+9a81841e : csinc x30, x0, x1, HI                     : csinc  %x0 %x1 hi -> %x30
+9a829420 : csinc x0, x1, x2, LS                      : csinc  %x1 %x2 ls -> %x0
+9a849462 : csinc x2, x3, x4, LS                      : csinc  %x3 %x4 ls -> %x2
+9a8694a4 : csinc x4, x5, x6, LS                      : csinc  %x5 %x6 ls -> %x4
+9a8894e6 : csinc x6, x7, x8, LS                      : csinc  %x7 %x8 ls -> %x6
+9a8a9528 : csinc x8, x9, x10, LS                     : csinc  %x9 %x10 ls -> %x8
+9a8b9549 : csinc x9, x10, x11, LS                    : csinc  %x10 %x11 ls -> %x9
+9a8d958b : csinc x11, x12, x13, LS                   : csinc  %x12 %x13 ls -> %x11
+9a8f95cd : csinc x13, x14, x15, LS                   : csinc  %x14 %x15 ls -> %x13
+9a91960f : csinc x15, x16, x17, LS                   : csinc  %x16 %x17 ls -> %x15
+9a939651 : csinc x17, x18, x19, LS                   : csinc  %x18 %x19 ls -> %x17
+9a959693 : csinc x19, x20, x21, LS                   : csinc  %x20 %x21 ls -> %x19
+9a9796d5 : csinc x21, x22, x23, LS                   : csinc  %x22 %x23 ls -> %x21
+9a9896f6 : csinc x22, x23, x24, LS                   : csinc  %x23 %x24 ls -> %x22
+9a9a9738 : csinc x24, x25, x26, LS                   : csinc  %x25 %x26 ls -> %x24
+9a9c977a : csinc x26, x27, x28, LS                   : csinc  %x27 %x28 ls -> %x26
+9a81941e : csinc x30, x0, x1, LS                     : csinc  %x0 %x1 ls -> %x30
+9a82a420 : csinc x0, x1, x2, GE                      : csinc  %x1 %x2 ge -> %x0
+9a84a462 : csinc x2, x3, x4, GE                      : csinc  %x3 %x4 ge -> %x2
+9a86a4a4 : csinc x4, x5, x6, GE                      : csinc  %x5 %x6 ge -> %x4
+9a88a4e6 : csinc x6, x7, x8, GE                      : csinc  %x7 %x8 ge -> %x6
+9a8aa528 : csinc x8, x9, x10, GE                     : csinc  %x9 %x10 ge -> %x8
+9a8ba549 : csinc x9, x10, x11, GE                    : csinc  %x10 %x11 ge -> %x9
+9a8da58b : csinc x11, x12, x13, GE                   : csinc  %x12 %x13 ge -> %x11
+9a8fa5cd : csinc x13, x14, x15, GE                   : csinc  %x14 %x15 ge -> %x13
+9a91a60f : csinc x15, x16, x17, GE                   : csinc  %x16 %x17 ge -> %x15
+9a93a651 : csinc x17, x18, x19, GE                   : csinc  %x18 %x19 ge -> %x17
+9a95a693 : csinc x19, x20, x21, GE                   : csinc  %x20 %x21 ge -> %x19
+9a97a6d5 : csinc x21, x22, x23, GE                   : csinc  %x22 %x23 ge -> %x21
+9a98a6f6 : csinc x22, x23, x24, GE                   : csinc  %x23 %x24 ge -> %x22
+9a9aa738 : csinc x24, x25, x26, GE                   : csinc  %x25 %x26 ge -> %x24
+9a9ca77a : csinc x26, x27, x28, GE                   : csinc  %x27 %x28 ge -> %x26
+9a81a41e : csinc x30, x0, x1, GE                     : csinc  %x0 %x1 ge -> %x30
+9a82b420 : csinc x0, x1, x2, LT                      : csinc  %x1 %x2 lt -> %x0
+9a84b462 : csinc x2, x3, x4, LT                      : csinc  %x3 %x4 lt -> %x2
+9a86b4a4 : csinc x4, x5, x6, LT                      : csinc  %x5 %x6 lt -> %x4
+9a88b4e6 : csinc x6, x7, x8, LT                      : csinc  %x7 %x8 lt -> %x6
+9a8ab528 : csinc x8, x9, x10, LT                     : csinc  %x9 %x10 lt -> %x8
+9a8bb549 : csinc x9, x10, x11, LT                    : csinc  %x10 %x11 lt -> %x9
+9a8db58b : csinc x11, x12, x13, LT                   : csinc  %x12 %x13 lt -> %x11
+9a8fb5cd : csinc x13, x14, x15, LT                   : csinc  %x14 %x15 lt -> %x13
+9a91b60f : csinc x15, x16, x17, LT                   : csinc  %x16 %x17 lt -> %x15
+9a93b651 : csinc x17, x18, x19, LT                   : csinc  %x18 %x19 lt -> %x17
+9a95b693 : csinc x19, x20, x21, LT                   : csinc  %x20 %x21 lt -> %x19
+9a97b6d5 : csinc x21, x22, x23, LT                   : csinc  %x22 %x23 lt -> %x21
+9a98b6f6 : csinc x22, x23, x24, LT                   : csinc  %x23 %x24 lt -> %x22
+9a9ab738 : csinc x24, x25, x26, LT                   : csinc  %x25 %x26 lt -> %x24
+9a9cb77a : csinc x26, x27, x28, LT                   : csinc  %x27 %x28 lt -> %x26
+9a81b41e : csinc x30, x0, x1, LT                     : csinc  %x0 %x1 lt -> %x30
+9a82c420 : csinc x0, x1, x2, GT                      : csinc  %x1 %x2 gt -> %x0
+9a84c462 : csinc x2, x3, x4, GT                      : csinc  %x3 %x4 gt -> %x2
+9a86c4a4 : csinc x4, x5, x6, GT                      : csinc  %x5 %x6 gt -> %x4
+9a88c4e6 : csinc x6, x7, x8, GT                      : csinc  %x7 %x8 gt -> %x6
+9a8ac528 : csinc x8, x9, x10, GT                     : csinc  %x9 %x10 gt -> %x8
+9a8bc549 : csinc x9, x10, x11, GT                    : csinc  %x10 %x11 gt -> %x9
+9a8dc58b : csinc x11, x12, x13, GT                   : csinc  %x12 %x13 gt -> %x11
+9a8fc5cd : csinc x13, x14, x15, GT                   : csinc  %x14 %x15 gt -> %x13
+9a91c60f : csinc x15, x16, x17, GT                   : csinc  %x16 %x17 gt -> %x15
+9a93c651 : csinc x17, x18, x19, GT                   : csinc  %x18 %x19 gt -> %x17
+9a95c693 : csinc x19, x20, x21, GT                   : csinc  %x20 %x21 gt -> %x19
+9a97c6d5 : csinc x21, x22, x23, GT                   : csinc  %x22 %x23 gt -> %x21
+9a98c6f6 : csinc x22, x23, x24, GT                   : csinc  %x23 %x24 gt -> %x22
+9a9ac738 : csinc x24, x25, x26, GT                   : csinc  %x25 %x26 gt -> %x24
+9a9cc77a : csinc x26, x27, x28, GT                   : csinc  %x27 %x28 gt -> %x26
+9a81c41e : csinc x30, x0, x1, GT                     : csinc  %x0 %x1 gt -> %x30
+9a82d420 : csinc x0, x1, x2, LE                      : csinc  %x1 %x2 le -> %x0
+9a84d462 : csinc x2, x3, x4, LE                      : csinc  %x3 %x4 le -> %x2
+9a86d4a4 : csinc x4, x5, x6, LE                      : csinc  %x5 %x6 le -> %x4
+9a88d4e6 : csinc x6, x7, x8, LE                      : csinc  %x7 %x8 le -> %x6
+9a8ad528 : csinc x8, x9, x10, LE                     : csinc  %x9 %x10 le -> %x8
+9a8bd549 : csinc x9, x10, x11, LE                    : csinc  %x10 %x11 le -> %x9
+9a8dd58b : csinc x11, x12, x13, LE                   : csinc  %x12 %x13 le -> %x11
+9a8fd5cd : csinc x13, x14, x15, LE                   : csinc  %x14 %x15 le -> %x13
+9a91d60f : csinc x15, x16, x17, LE                   : csinc  %x16 %x17 le -> %x15
+9a93d651 : csinc x17, x18, x19, LE                   : csinc  %x18 %x19 le -> %x17
+9a95d693 : csinc x19, x20, x21, LE                   : csinc  %x20 %x21 le -> %x19
+9a97d6d5 : csinc x21, x22, x23, LE                   : csinc  %x22 %x23 le -> %x21
+9a98d6f6 : csinc x22, x23, x24, LE                   : csinc  %x23 %x24 le -> %x22
+9a9ad738 : csinc x24, x25, x26, LE                   : csinc  %x25 %x26 le -> %x24
+9a9cd77a : csinc x26, x27, x28, LE                   : csinc  %x27 %x28 le -> %x26
+9a81d41e : csinc x30, x0, x1, LE                     : csinc  %x0 %x1 le -> %x30
+9a82e420 : csinc x0, x1, x2, AL                      : csinc  %x1 %x2 al -> %x0
+9a84e462 : csinc x2, x3, x4, AL                      : csinc  %x3 %x4 al -> %x2
+9a86e4a4 : csinc x4, x5, x6, AL                      : csinc  %x5 %x6 al -> %x4
+9a88e4e6 : csinc x6, x7, x8, AL                      : csinc  %x7 %x8 al -> %x6
+9a8ae528 : csinc x8, x9, x10, AL                     : csinc  %x9 %x10 al -> %x8
+9a8be549 : csinc x9, x10, x11, AL                    : csinc  %x10 %x11 al -> %x9
+9a8de58b : csinc x11, x12, x13, AL                   : csinc  %x12 %x13 al -> %x11
+9a8fe5cd : csinc x13, x14, x15, AL                   : csinc  %x14 %x15 al -> %x13
+9a91e60f : csinc x15, x16, x17, AL                   : csinc  %x16 %x17 al -> %x15
+9a93e651 : csinc x17, x18, x19, AL                   : csinc  %x18 %x19 al -> %x17
+9a95e693 : csinc x19, x20, x21, AL                   : csinc  %x20 %x21 al -> %x19
+9a97e6d5 : csinc x21, x22, x23, AL                   : csinc  %x22 %x23 al -> %x21
+9a98e6f6 : csinc x22, x23, x24, AL                   : csinc  %x23 %x24 al -> %x22
+9a9ae738 : csinc x24, x25, x26, AL                   : csinc  %x25 %x26 al -> %x24
+9a9ce77a : csinc x26, x27, x28, AL                   : csinc  %x27 %x28 al -> %x26
+9a81e41e : csinc x30, x0, x1, AL                     : csinc  %x0 %x1 al -> %x30
+9a82f420 : csinc x0, x1, x2, NV                      : csinc  %x1 %x2 nv -> %x0
+9a84f462 : csinc x2, x3, x4, NV                      : csinc  %x3 %x4 nv -> %x2
+9a86f4a4 : csinc x4, x5, x6, NV                      : csinc  %x5 %x6 nv -> %x4
+9a88f4e6 : csinc x6, x7, x8, NV                      : csinc  %x7 %x8 nv -> %x6
+9a8af528 : csinc x8, x9, x10, NV                     : csinc  %x9 %x10 nv -> %x8
+9a8bf549 : csinc x9, x10, x11, NV                    : csinc  %x10 %x11 nv -> %x9
+9a8df58b : csinc x11, x12, x13, NV                   : csinc  %x12 %x13 nv -> %x11
+9a8ff5cd : csinc x13, x14, x15, NV                   : csinc  %x14 %x15 nv -> %x13
+9a91f60f : csinc x15, x16, x17, NV                   : csinc  %x16 %x17 nv -> %x15
+9a93f651 : csinc x17, x18, x19, NV                   : csinc  %x18 %x19 nv -> %x17
+9a95f693 : csinc x19, x20, x21, NV                   : csinc  %x20 %x21 nv -> %x19
+9a97f6d5 : csinc x21, x22, x23, NV                   : csinc  %x22 %x23 nv -> %x21
+9a98f6f6 : csinc x22, x23, x24, NV                   : csinc  %x23 %x24 nv -> %x22
+9a9af738 : csinc x24, x25, x26, NV                   : csinc  %x25 %x26 nv -> %x24
+9a9cf77a : csinc x26, x27, x28, NV                   : csinc  %x27 %x28 nv -> %x26
+9a81f41e : csinc x30, x0, x1, NV                     : csinc  %x0 %x1 nv -> %x30
+
+# EOR     <Wd|SP>, <Wn>, #<imm> (EOR-R.RI-32_log_imm)
+52000020 : eor w0, w1, #0x1                          : eor    %w1 $0x00000001 -> %w0
+52040062 : eor w2, w3, #0x10000000                   : eor    %w3 $0x10000000 -> %w2
+520800a4 : eor w4, w5, #0x1000000                    : eor    %w5 $0x01000000 -> %w4
+520c00e6 : eor w6, w7, #0x100000                     : eor    %w7 $0x00100000 -> %w6
+52100128 : eor w8, w9, #0x10000                      : eor    %w9 $0x00010000 -> %w8
+52140149 : eor w9, w10, #0x1000                      : eor    %w10 $0x00001000 -> %w9
+5218018b : eor w11, w12, #0x100                      : eor    %w12 $0x00000100 -> %w11
+521c01cd : eor w13, w14, #0x10                       : eor    %w14 $0x00000010 -> %w13
+5200020f : eor w15, w16, #0x1                        : eor    %w16 $0x00000001 -> %w15
+5203ea51 : eor w17, w18, #0xeeeeeeee                 : eor    %w18 $0xeeeeeeee -> %w17
+5203ea93 : eor w19, w20, #0xeeeeeeee                 : eor    %w20 $0xeeeeeeee -> %w19
+5203ead5 : eor w21, w22, #0xeeeeeeee                 : eor    %w22 $0xeeeeeeee -> %w21
+5203eaf6 : eor w22, w23, #0xeeeeeeee                 : eor    %w23 $0xeeeeeeee -> %w22
+5203eb38 : eor w24, w25, #0xeeeeeeee                 : eor    %w25 $0xeeeeeeee -> %w24
+5203eb7a : eor w26, w27, #0xeeeeeeee                 : eor    %w27 $0xeeeeeeee -> %w26
+5203e81f : eor wsp, w0, #0xeeeeeeee                  : eor    %w0 $0xeeeeeeee -> %wsp
+
+# ANDS    <Wd>, <Wn>, #<imm> (ANDS-R.RI-32S_log_imm)
+72000020 : ands w0, w1, #0x1                         : ands   %w1 $0x00000001 -> %w0
+72040062 : ands w2, w3, #0x10000000                  : ands   %w3 $0x10000000 -> %w2
+720800a4 : ands w4, w5, #0x1000000                   : ands   %w5 $0x01000000 -> %w4
+720c00e6 : ands w6, w7, #0x100000                    : ands   %w7 $0x00100000 -> %w6
+72100128 : ands w8, w9, #0x10000                     : ands   %w9 $0x00010000 -> %w8
+72140149 : ands w9, w10, #0x1000                     : ands   %w10 $0x00001000 -> %w9
+7218018b : ands w11, w12, #0x100                     : ands   %w12 $0x00000100 -> %w11
+721c01cd : ands w13, w14, #0x10                      : ands   %w14 $0x00000010 -> %w13
+7200020f : ands w15, w16, #0x1                       : ands   %w16 $0x00000001 -> %w15
+7203ea51 : ands w17, w18, #0xeeeeeeee                : ands   %w18 $0xeeeeeeee -> %w17
+7203ea93 : ands w19, w20, #0xeeeeeeee                : ands   %w20 $0xeeeeeeee -> %w19
+7203ead5 : ands w21, w22, #0xeeeeeeee                : ands   %w22 $0xeeeeeeee -> %w21
+7203eaf6 : ands w22, w23, #0xeeeeeeee                : ands   %w23 $0xeeeeeeee -> %w22
+7203eb38 : ands w24, w25, #0xeeeeeeee                : ands   %w25 $0xeeeeeeee -> %w24
+7203eb7a : ands w26, w27, #0xeeeeeeee                : ands   %w27 $0xeeeeeeee -> %w26
+7203e81e : ands w30, w0, #0xeeeeeeee                 : ands   %w0 $0xeeeeeeee -> %w30
+
+# MOVK    <Xd>, #<imm>{, LSL <amount>} (MOVK-R.I-64_movewide)
+f2800000 : movk x0, #0x0, LSL #0                     : movk   %x0 $0x0000 lsl $0x00 -> %x0
+f2820002 : movk x2, #0x1000, LSL #0                  : movk   %x2 $0x1000 lsl $0x00 -> %x2
+f2840004 : movk x4, #0x2000, LSL #0                  : movk   %x4 $0x2000 lsl $0x00 -> %x4
+f2860006 : movk x6, #0x3000, LSL #0                  : movk   %x6 $0x3000 lsl $0x00 -> %x6
+f2880008 : movk x8, #0x4000, LSL #0                  : movk   %x8 $0x4000 lsl $0x00 -> %x8
+f28a0009 : movk x9, #0x5000, LSL #0                  : movk   %x9 $0x5000 lsl $0x00 -> %x9
+f28c000b : movk x11, #0x6000, LSL #0                 : movk   %x11 $0x6000 lsl $0x00 -> %x11
+f28e000d : movk x13, #0x7000, LSL #0                 : movk   %x13 $0x7000 lsl $0x00 -> %x13
+f290000f : movk x15, #0x8000, LSL #0                 : movk   %x15 $0x8000 lsl $0x00 -> %x15
+f291fff1 : movk x17, #0x8fff, LSL #0                 : movk   %x17 $0x8fff lsl $0x00 -> %x17
+f293fff3 : movk x19, #0x9fff, LSL #0                 : movk   %x19 $0x9fff lsl $0x00 -> %x19
+f295fff5 : movk x21, #0xafff, LSL #0                 : movk   %x21 $0xafff lsl $0x00 -> %x21
+f297fff6 : movk x22, #0xbfff, LSL #0                 : movk   %x22 $0xbfff lsl $0x00 -> %x22
+f299fff8 : movk x24, #0xcfff, LSL #0                 : movk   %x24 $0xcfff lsl $0x00 -> %x24
+f29bfffa : movk x26, #0xdfff, LSL #0                 : movk   %x26 $0xdfff lsl $0x00 -> %x26
+f29ffffe : movk x30, #0xffff, LSL #0                 : movk   %x30 $0xffff lsl $0x00 -> %x30
+f2a00000 : movk x0, #0x0, LSL #16                    : movk   %x0 $0x0000 lsl $0x10 -> %x0
+f2a20002 : movk x2, #0x1000, LSL #16                 : movk   %x2 $0x1000 lsl $0x10 -> %x2
+f2a40004 : movk x4, #0x2000, LSL #16                 : movk   %x4 $0x2000 lsl $0x10 -> %x4
+f2a60006 : movk x6, #0x3000, LSL #16                 : movk   %x6 $0x3000 lsl $0x10 -> %x6
+f2a80008 : movk x8, #0x4000, LSL #16                 : movk   %x8 $0x4000 lsl $0x10 -> %x8
+f2aa0009 : movk x9, #0x5000, LSL #16                 : movk   %x9 $0x5000 lsl $0x10 -> %x9
+f2ac000b : movk x11, #0x6000, LSL #16                : movk   %x11 $0x6000 lsl $0x10 -> %x11
+f2ae000d : movk x13, #0x7000, LSL #16                : movk   %x13 $0x7000 lsl $0x10 -> %x13
+f2b0000f : movk x15, #0x8000, LSL #16                : movk   %x15 $0x8000 lsl $0x10 -> %x15
+f2b1fff1 : movk x17, #0x8fff, LSL #16                : movk   %x17 $0x8fff lsl $0x10 -> %x17
+f2b3fff3 : movk x19, #0x9fff, LSL #16                : movk   %x19 $0x9fff lsl $0x10 -> %x19
+f2b5fff5 : movk x21, #0xafff, LSL #16                : movk   %x21 $0xafff lsl $0x10 -> %x21
+f2b7fff6 : movk x22, #0xbfff, LSL #16                : movk   %x22 $0xbfff lsl $0x10 -> %x22
+f2b9fff8 : movk x24, #0xcfff, LSL #16                : movk   %x24 $0xcfff lsl $0x10 -> %x24
+f2bbfffa : movk x26, #0xdfff, LSL #16                : movk   %x26 $0xdfff lsl $0x10 -> %x26
+f2bffffe : movk x30, #0xffff, LSL #16                : movk   %x30 $0xffff lsl $0x10 -> %x30
+f2c00000 : movk x0, #0x0, LSL #32                    : movk   %x0 $0x0000 lsl $0x20 -> %x0
+f2c20002 : movk x2, #0x1000, LSL #32                 : movk   %x2 $0x1000 lsl $0x20 -> %x2
+f2c40004 : movk x4, #0x2000, LSL #32                 : movk   %x4 $0x2000 lsl $0x20 -> %x4
+f2c60006 : movk x6, #0x3000, LSL #32                 : movk   %x6 $0x3000 lsl $0x20 -> %x6
+f2c80008 : movk x8, #0x4000, LSL #32                 : movk   %x8 $0x4000 lsl $0x20 -> %x8
+f2ca0009 : movk x9, #0x5000, LSL #32                 : movk   %x9 $0x5000 lsl $0x20 -> %x9
+f2cc000b : movk x11, #0x6000, LSL #32                : movk   %x11 $0x6000 lsl $0x20 -> %x11
+f2ce000d : movk x13, #0x7000, LSL #32                : movk   %x13 $0x7000 lsl $0x20 -> %x13
+f2d0000f : movk x15, #0x8000, LSL #32                : movk   %x15 $0x8000 lsl $0x20 -> %x15
+f2d1fff1 : movk x17, #0x8fff, LSL #32                : movk   %x17 $0x8fff lsl $0x20 -> %x17
+f2d3fff3 : movk x19, #0x9fff, LSL #32                : movk   %x19 $0x9fff lsl $0x20 -> %x19
+f2d5fff5 : movk x21, #0xafff, LSL #32                : movk   %x21 $0xafff lsl $0x20 -> %x21
+f2d7fff6 : movk x22, #0xbfff, LSL #32                : movk   %x22 $0xbfff lsl $0x20 -> %x22
+f2d9fff8 : movk x24, #0xcfff, LSL #32                : movk   %x24 $0xcfff lsl $0x20 -> %x24
+f2dbfffa : movk x26, #0xdfff, LSL #32                : movk   %x26 $0xdfff lsl $0x20 -> %x26
+f2dffffe : movk x30, #0xffff, LSL #32                : movk   %x30 $0xffff lsl $0x20 -> %x30
+f2e00000 : movk x0, #0x0, LSL #48                    : movk   %x0 $0x0000 lsl $0x30 -> %x0
+f2e20002 : movk x2, #0x1000, LSL #48                 : movk   %x2 $0x1000 lsl $0x30 -> %x2
+f2e40004 : movk x4, #0x2000, LSL #48                 : movk   %x4 $0x2000 lsl $0x30 -> %x4
+f2e60006 : movk x6, #0x3000, LSL #48                 : movk   %x6 $0x3000 lsl $0x30 -> %x6
+f2e80008 : movk x8, #0x4000, LSL #48                 : movk   %x8 $0x4000 lsl $0x30 -> %x8
+f2ea0009 : movk x9, #0x5000, LSL #48                 : movk   %x9 $0x5000 lsl $0x30 -> %x9
+f2ec000b : movk x11, #0x6000, LSL #48                : movk   %x11 $0x6000 lsl $0x30 -> %x11
+f2ee000d : movk x13, #0x7000, LSL #48                : movk   %x13 $0x7000 lsl $0x30 -> %x13
+f2f0000f : movk x15, #0x8000, LSL #48                : movk   %x15 $0x8000 lsl $0x30 -> %x15
+f2f1fff1 : movk x17, #0x8fff, LSL #48                : movk   %x17 $0x8fff lsl $0x30 -> %x17
+f2f3fff3 : movk x19, #0x9fff, LSL #48                : movk   %x19 $0x9fff lsl $0x30 -> %x19
+f2f5fff5 : movk x21, #0xafff, LSL #48                : movk   %x21 $0xafff lsl $0x30 -> %x21
+f2f7fff6 : movk x22, #0xbfff, LSL #48                : movk   %x22 $0xbfff lsl $0x30 -> %x22
+f2f9fff8 : movk x24, #0xcfff, LSL #48                : movk   %x24 $0xcfff lsl $0x30 -> %x24
+f2fbfffa : movk x26, #0xdfff, LSL #48                : movk   %x26 $0xdfff lsl $0x30 -> %x26
+f2fffffe : movk x30, #0xffff, LSL #48                : movk   %x30 $0xffff lsl $0x30 -> %x30
+
+# AND     <Wd|SP>, <Wn>, #<imm> (AND-R.RI-32_log_imm)
+12000020 : and w0, w1, #0x1                          : and    %w1 $0x00000001 -> %w0
+12040062 : and w2, w3, #0x10000000                   : and    %w3 $0x10000000 -> %w2
+120800a4 : and w4, w5, #0x1000000                    : and    %w5 $0x01000000 -> %w4
+120c00e6 : and w6, w7, #0x100000                     : and    %w7 $0x00100000 -> %w6
+12100128 : and w8, w9, #0x10000                      : and    %w9 $0x00010000 -> %w8
+12140149 : and w9, w10, #0x1000                      : and    %w10 $0x00001000 -> %w9
+1218018b : and w11, w12, #0x100                      : and    %w12 $0x00000100 -> %w11
+121c01cd : and w13, w14, #0x10                       : and    %w14 $0x00000010 -> %w13
+1200020f : and w15, w16, #0x1                        : and    %w16 $0x00000001 -> %w15
+1203ea51 : and w17, w18, #0xeeeeeeee                 : and    %w18 $0xeeeeeeee -> %w17
+1203ea93 : and w19, w20, #0xeeeeeeee                 : and    %w20 $0xeeeeeeee -> %w19
+1203ead5 : and w21, w22, #0xeeeeeeee                 : and    %w22 $0xeeeeeeee -> %w21
+1203eaf6 : and w22, w23, #0xeeeeeeee                 : and    %w23 $0xeeeeeeee -> %w22
+1203eb38 : and w24, w25, #0xeeeeeeee                 : and    %w25 $0xeeeeeeee -> %w24
+1203eb7a : and w26, w27, #0xeeeeeeee                 : and    %w27 $0xeeeeeeee -> %w26
+1203e81f : and wsp, w0, #0xeeeeeeee                  : and    %w0 $0xeeeeeeee -> %wsp
+
+# SMSUBL  <Xd>, <Wn>, <Wm>, <Xa> (SMSUBL-R.RRR-64WA_dp_3src)
+9b228c20 : smsubl x0, w1, w2, x3                     : smsubl %w1 %w2 %x3 -> %x0
+9b249462 : smsubl x2, w3, w4, x5                     : smsubl %w3 %w4 %x5 -> %x2
+9b269ca4 : smsubl x4, w5, w6, x7                     : smsubl %w5 %w6 %x7 -> %x4
+9b28a4e6 : smsubl x6, w7, w8, x9                     : smsubl %w7 %w8 %x9 -> %x6
+9b2aad28 : smsubl x8, w9, w10, x11                   : smsubl %w9 %w10 %x11 -> %x8
+9b2bb149 : smsubl x9, w10, w11, x12                  : smsubl %w10 %w11 %x12 -> %x9
+9b2db98b : smsubl x11, w12, w13, x14                 : smsubl %w12 %w13 %x14 -> %x11
+9b2fc1cd : smsubl x13, w14, w15, x16                 : smsubl %w14 %w15 %x16 -> %x13
+9b31ca0f : smsubl x15, w16, w17, x18                 : smsubl %w16 %w17 %x18 -> %x15
+9b33d251 : smsubl x17, w18, w19, x20                 : smsubl %w18 %w19 %x20 -> %x17
+9b35da93 : smsubl x19, w20, w21, x22                 : smsubl %w20 %w21 %x22 -> %x19
+9b37e2d5 : smsubl x21, w22, w23, x24                 : smsubl %w22 %w23 %x24 -> %x21
+9b38e6f6 : smsubl x22, w23, w24, x25                 : smsubl %w23 %w24 %x25 -> %x22
+9b3aef38 : smsubl x24, w25, w26, x27                 : smsubl %w25 %w26 %x27 -> %x24
+9b3cf77a : smsubl x26, w27, w28, x29                 : smsubl %w27 %w28 %x29 -> %x26
+9b21881e : smsubl x30, w0, w1, x2                    : smsubl %w0 %w1 %x2 -> %x30
+
+# AND     <Wd>, <Wn>, <Wm>, <extend> #<imm> (AND-R.RRI-32_log_shift)
+0a020020 : and w0, w1, w2, LSL #0                    : and    %w1 %w2 lsl $0x00 -> %w0
+0a040862 : and w2, w3, w4, LSL #2                    : and    %w3 %w4 lsl $0x02 -> %w2
+0a0610a4 : and w4, w5, w6, LSL #4                    : and    %w5 %w6 lsl $0x04 -> %w4
+0a0818e6 : and w6, w7, w8, LSL #6                    : and    %w7 %w8 lsl $0x06 -> %w6
+0a0a2128 : and w8, w9, w10, LSL #8                   : and    %w9 %w10 lsl $0x08 -> %w8
+0a0b2949 : and w9, w10, w11, LSL #10                 : and    %w10 %w11 lsl $0x0a -> %w9
+0a0d318b : and w11, w12, w13, LSL #12                : and    %w12 %w13 lsl $0x0c -> %w11
+0a0f39cd : and w13, w14, w15, LSL #14                : and    %w14 %w15 lsl $0x0e -> %w13
+0a11420f : and w15, w16, w17, LSL #16                : and    %w16 %w17 lsl $0x10 -> %w15
+0a134651 : and w17, w18, w19, LSL #17                : and    %w18 %w19 lsl $0x11 -> %w17
+0a154e93 : and w19, w20, w21, LSL #19                : and    %w20 %w21 lsl $0x13 -> %w19
+0a1756d5 : and w21, w22, w23, LSL #21                : and    %w22 %w23 lsl $0x15 -> %w21
+0a185ef6 : and w22, w23, w24, LSL #23                : and    %w23 %w24 lsl $0x17 -> %w22
+0a1a6738 : and w24, w25, w26, LSL #25                : and    %w25 %w26 lsl $0x19 -> %w24
+0a1c6f7a : and w26, w27, w28, LSL #27                : and    %w27 %w28 lsl $0x1b -> %w26
+0a017c1e : and w30, w0, w1, LSL #31                  : and    %w0 %w1 lsl $0x1f -> %w30
+0a420020 : and w0, w1, w2, LSR #0                    : and    %w1 %w2 lsr $0x00 -> %w0
+0a440862 : and w2, w3, w4, LSR #2                    : and    %w3 %w4 lsr $0x02 -> %w2
+0a4610a4 : and w4, w5, w6, LSR #4                    : and    %w5 %w6 lsr $0x04 -> %w4
+0a4818e6 : and w6, w7, w8, LSR #6                    : and    %w7 %w8 lsr $0x06 -> %w6
+0a4a2128 : and w8, w9, w10, LSR #8                   : and    %w9 %w10 lsr $0x08 -> %w8
+0a4b2949 : and w9, w10, w11, LSR #10                 : and    %w10 %w11 lsr $0x0a -> %w9
+0a4d318b : and w11, w12, w13, LSR #12                : and    %w12 %w13 lsr $0x0c -> %w11
+0a4f39cd : and w13, w14, w15, LSR #14                : and    %w14 %w15 lsr $0x0e -> %w13
+0a51420f : and w15, w16, w17, LSR #16                : and    %w16 %w17 lsr $0x10 -> %w15
+0a534651 : and w17, w18, w19, LSR #17                : and    %w18 %w19 lsr $0x11 -> %w17
+0a554e93 : and w19, w20, w21, LSR #19                : and    %w20 %w21 lsr $0x13 -> %w19
+0a5756d5 : and w21, w22, w23, LSR #21                : and    %w22 %w23 lsr $0x15 -> %w21
+0a585ef6 : and w22, w23, w24, LSR #23                : and    %w23 %w24 lsr $0x17 -> %w22
+0a5a6738 : and w24, w25, w26, LSR #25                : and    %w25 %w26 lsr $0x19 -> %w24
+0a5c6f7a : and w26, w27, w28, LSR #27                : and    %w27 %w28 lsr $0x1b -> %w26
+0a417c1e : and w30, w0, w1, LSR #31                  : and    %w0 %w1 lsr $0x1f -> %w30
+0a820020 : and w0, w1, w2, ASR #0                    : and    %w1 %w2 asr $0x00 -> %w0
+0a840862 : and w2, w3, w4, ASR #2                    : and    %w3 %w4 asr $0x02 -> %w2
+0a8610a4 : and w4, w5, w6, ASR #4                    : and    %w5 %w6 asr $0x04 -> %w4
+0a8818e6 : and w6, w7, w8, ASR #6                    : and    %w7 %w8 asr $0x06 -> %w6
+0a8a2128 : and w8, w9, w10, ASR #8                   : and    %w9 %w10 asr $0x08 -> %w8
+0a8b2949 : and w9, w10, w11, ASR #10                 : and    %w10 %w11 asr $0x0a -> %w9
+0a8d318b : and w11, w12, w13, ASR #12                : and    %w12 %w13 asr $0x0c -> %w11
+0a8f39cd : and w13, w14, w15, ASR #14                : and    %w14 %w15 asr $0x0e -> %w13
+0a91420f : and w15, w16, w17, ASR #16                : and    %w16 %w17 asr $0x10 -> %w15
+0a934651 : and w17, w18, w19, ASR #17                : and    %w18 %w19 asr $0x11 -> %w17
+0a954e93 : and w19, w20, w21, ASR #19                : and    %w20 %w21 asr $0x13 -> %w19
+0a9756d5 : and w21, w22, w23, ASR #21                : and    %w22 %w23 asr $0x15 -> %w21
+0a985ef6 : and w22, w23, w24, ASR #23                : and    %w23 %w24 asr $0x17 -> %w22
+0a9a6738 : and w24, w25, w26, ASR #25                : and    %w25 %w26 asr $0x19 -> %w24
+0a9c6f7a : and w26, w27, w28, ASR #27                : and    %w27 %w28 asr $0x1b -> %w26
+0a817c1e : and w30, w0, w1, ASR #31                  : and    %w0 %w1 asr $0x1f -> %w30
+0ac20020 : and w0, w1, w2, ROR #0                    : and    %w1 %w2 ror $0x00 -> %w0
+0ac40862 : and w2, w3, w4, ROR #2                    : and    %w3 %w4 ror $0x02 -> %w2
+0ac610a4 : and w4, w5, w6, ROR #4                    : and    %w5 %w6 ror $0x04 -> %w4
+0ac818e6 : and w6, w7, w8, ROR #6                    : and    %w7 %w8 ror $0x06 -> %w6
+0aca2128 : and w8, w9, w10, ROR #8                   : and    %w9 %w10 ror $0x08 -> %w8
+0acb2949 : and w9, w10, w11, ROR #10                 : and    %w10 %w11 ror $0x0a -> %w9
+0acd318b : and w11, w12, w13, ROR #12                : and    %w12 %w13 ror $0x0c -> %w11
+0acf39cd : and w13, w14, w15, ROR #14                : and    %w14 %w15 ror $0x0e -> %w13
+0ad1420f : and w15, w16, w17, ROR #16                : and    %w16 %w17 ror $0x10 -> %w15
+0ad34651 : and w17, w18, w19, ROR #17                : and    %w18 %w19 ror $0x11 -> %w17
+0ad54e93 : and w19, w20, w21, ROR #19                : and    %w20 %w21 ror $0x13 -> %w19
+0ad756d5 : and w21, w22, w23, ROR #21                : and    %w22 %w23 ror $0x15 -> %w21
+0ad85ef6 : and w22, w23, w24, ROR #23                : and    %w23 %w24 ror $0x17 -> %w22
+0ada6738 : and w24, w25, w26, ROR #25                : and    %w25 %w26 ror $0x19 -> %w24
+0adc6f7a : and w26, w27, w28, ROR #27                : and    %w27 %w28 ror $0x1b -> %w26
+0ac17c1e : and w30, w0, w1, ROR #31                  : and    %w0 %w1 ror $0x1f -> %w30
+
+# SBFM    <Xd>, <Xn>, #<imm1>, #<imm2> (SBFM-R.RII-64M_bitfield)
+93400020 : sbfm x0, x1, #0x0, #0x0                   : sbfm   %x1 $0x00 $0x00 -> %x0
+93420862 : sbfm x2, x3, #0x2, #0x2                   : sbfm   %x3 $0x02 $0x02 -> %x2
+934410a4 : sbfm x4, x5, #0x4, #0x4                   : sbfm   %x5 $0x04 $0x04 -> %x4
+934618e6 : sbfm x6, x7, #0x6, #0x6                   : sbfm   %x7 $0x06 $0x06 -> %x6
+93482128 : sbfm x8, x9, #0x8, #0x8                   : sbfm   %x9 $0x08 $0x08 -> %x8
+934a2949 : sbfm x9, x10, #0xa, #0xa                  : sbfm   %x10 $0x0a $0x0a -> %x9
+934c318b : sbfm x11, x12, #0xc, #0xc                 : sbfm   %x12 $0x0c $0x0c -> %x11
+934e39cd : sbfm x13, x14, #0xe, #0xe                 : sbfm   %x14 $0x0e $0x0e -> %x13
+9350420f : sbfm x15, x16, #0x10, #0x10               : sbfm   %x16 $0x10 $0x10 -> %x15
+93514651 : sbfm x17, x18, #0x11, #0x11               : sbfm   %x18 $0x11 $0x11 -> %x17
+93534e93 : sbfm x19, x20, #0x13, #0x13               : sbfm   %x20 $0x13 $0x13 -> %x19
+935556d5 : sbfm x21, x22, #0x15, #0x15               : sbfm   %x22 $0x15 $0x15 -> %x21
+93575ef6 : sbfm x22, x23, #0x17, #0x17               : sbfm   %x23 $0x17 $0x17 -> %x22
+93596738 : sbfm x24, x25, #0x19, #0x19               : sbfm   %x25 $0x19 $0x19 -> %x24
+935b6f7a : sbfm x26, x27, #0x1b, #0x1b               : sbfm   %x27 $0x1b $0x1b -> %x26
+935f7c1e : sbfm x30, x0, #0x1f, #0x1f                : sbfm   %x0 $0x1f $0x1f -> %x30
+
+# CRC32CH <Wd>, <Wn>, <Wm> (CRC32CH-R.RR-32C_dp_2src)
+1ac25420 : crc32ch w0, w1, w2                        : crc32ch %w1 %w2 -> %w0
+1ac45462 : crc32ch w2, w3, w4                        : crc32ch %w3 %w4 -> %w2
+1ac654a4 : crc32ch w4, w5, w6                        : crc32ch %w5 %w6 -> %w4
+1ac854e6 : crc32ch w6, w7, w8                        : crc32ch %w7 %w8 -> %w6
+1aca5528 : crc32ch w8, w9, w10                       : crc32ch %w9 %w10 -> %w8
+1acb5549 : crc32ch w9, w10, w11                      : crc32ch %w10 %w11 -> %w9
+1acd558b : crc32ch w11, w12, w13                     : crc32ch %w12 %w13 -> %w11
+1acf55cd : crc32ch w13, w14, w15                     : crc32ch %w14 %w15 -> %w13
+1ad1560f : crc32ch w15, w16, w17                     : crc32ch %w16 %w17 -> %w15
+1ad35651 : crc32ch w17, w18, w19                     : crc32ch %w18 %w19 -> %w17
+1ad55693 : crc32ch w19, w20, w21                     : crc32ch %w20 %w21 -> %w19
+1ad756d5 : crc32ch w21, w22, w23                     : crc32ch %w22 %w23 -> %w21
+1ad856f6 : crc32ch w22, w23, w24                     : crc32ch %w23 %w24 -> %w22
+1ada5738 : crc32ch w24, w25, w26                     : crc32ch %w25 %w26 -> %w24
+1adc577a : crc32ch w26, w27, w28                     : crc32ch %w27 %w28 -> %w26
+1ac1541e : crc32ch w30, w0, w1                       : crc32ch %w0 %w1 -> %w30
+
+# SYSL    <Xt>, #<imm1>, #<imm2>, #<imm3>, #<imm4> (SYSL-R.IIII-RC_system)
+d5280000 : sysl x0, #0x0, C0, C0, #0x0               : sysl   $0x00 $0x00 $0x00 $0x00 -> %x0
+d5281102 : sysl x2, #0x0, C1, C1, #0x0               : sysl   $0x00 $0x01 $0x01 $0x00 -> %x2
+d5292224 : sysl x4, #0x1, C2, C2, #0x1               : sysl   $0x01 $0x02 $0x02 $0x01 -> %x4
+d5293326 : sysl x6, #0x1, C3, C3, #0x1               : sysl   $0x01 $0x03 $0x03 $0x01 -> %x6
+d52a4448 : sysl x8, #0x2, C4, C4, #0x2               : sysl   $0x02 $0x04 $0x04 $0x02 -> %x8
+d52a5549 : sysl x9, #0x2, C5, C5, #0x2               : sysl   $0x02 $0x05 $0x05 $0x02 -> %x9
+d52b666b : sysl x11, #0x3, C6, C6, #0x3              : sysl   $0x03 $0x06 $0x06 $0x03 -> %x11
+d52b776d : sysl x13, #0x3, C7, C7, #0x3              : sysl   $0x03 $0x07 $0x07 $0x03 -> %x13
+d52c888f : sysl x15, #0x4, C8, C8, #0x4              : sysl   $0x04 $0x08 $0x08 $0x04 -> %x15
+d52c8891 : sysl x17, #0x4, C8, C8, #0x4              : sysl   $0x04 $0x08 $0x08 $0x04 -> %x17
+d52c9993 : sysl x19, #0x4, C9, C9, #0x4              : sysl   $0x04 $0x09 $0x09 $0x04 -> %x19
+d52daab5 : sysl x21, #0x5, C10, C10, #0x5            : sysl   $0x05 $0x0a $0x0a $0x05 -> %x21
+d52dbbb6 : sysl x22, #0x5, C11, C11, #0x5            : sysl   $0x05 $0x0b $0x0b $0x05 -> %x22
+d52eccd8 : sysl x24, #0x6, C12, C12, #0x6            : sysl   $0x06 $0x0c $0x0c $0x06 -> %x24
+d52eddda : sysl x26, #0x6, C13, C13, #0x6            : sysl   $0x06 $0x0d $0x0d $0x06 -> %x26
+d52ffffe : sysl x30, #0x7, C15, C15, #0x7            : sysl   $0x07 $0x0f $0x0f $0x07 -> %x30
+
+# ORN     <Wd>, <Wn>, <Wm>, <extend> #<imm> (ORN-R.RRI-32_log_shift)
+2a220020 : orn w0, w1, w2, LSL #0                    : orn    %w1 %w2 lsl $0x00 -> %w0
+2a240862 : orn w2, w3, w4, LSL #2                    : orn    %w3 %w4 lsl $0x02 -> %w2
+2a2610a4 : orn w4, w5, w6, LSL #4                    : orn    %w5 %w6 lsl $0x04 -> %w4
+2a2818e6 : orn w6, w7, w8, LSL #6                    : orn    %w7 %w8 lsl $0x06 -> %w6
+2a2a2128 : orn w8, w9, w10, LSL #8                   : orn    %w9 %w10 lsl $0x08 -> %w8
+2a2b2949 : orn w9, w10, w11, LSL #10                 : orn    %w10 %w11 lsl $0x0a -> %w9
+2a2d318b : orn w11, w12, w13, LSL #12                : orn    %w12 %w13 lsl $0x0c -> %w11
+2a2f39cd : orn w13, w14, w15, LSL #14                : orn    %w14 %w15 lsl $0x0e -> %w13
+2a31420f : orn w15, w16, w17, LSL #16                : orn    %w16 %w17 lsl $0x10 -> %w15
+2a334651 : orn w17, w18, w19, LSL #17                : orn    %w18 %w19 lsl $0x11 -> %w17
+2a354e93 : orn w19, w20, w21, LSL #19                : orn    %w20 %w21 lsl $0x13 -> %w19
+2a3756d5 : orn w21, w22, w23, LSL #21                : orn    %w22 %w23 lsl $0x15 -> %w21
+2a385ef6 : orn w22, w23, w24, LSL #23                : orn    %w23 %w24 lsl $0x17 -> %w22
+2a3a6738 : orn w24, w25, w26, LSL #25                : orn    %w25 %w26 lsl $0x19 -> %w24
+2a3c6f7a : orn w26, w27, w28, LSL #27                : orn    %w27 %w28 lsl $0x1b -> %w26
+2a217c1e : orn w30, w0, w1, LSL #31                  : orn    %w0 %w1 lsl $0x1f -> %w30
+2a620020 : orn w0, w1, w2, LSR #0                    : orn    %w1 %w2 lsr $0x00 -> %w0
+2a640862 : orn w2, w3, w4, LSR #2                    : orn    %w3 %w4 lsr $0x02 -> %w2
+2a6610a4 : orn w4, w5, w6, LSR #4                    : orn    %w5 %w6 lsr $0x04 -> %w4
+2a6818e6 : orn w6, w7, w8, LSR #6                    : orn    %w7 %w8 lsr $0x06 -> %w6
+2a6a2128 : orn w8, w9, w10, LSR #8                   : orn    %w9 %w10 lsr $0x08 -> %w8
+2a6b2949 : orn w9, w10, w11, LSR #10                 : orn    %w10 %w11 lsr $0x0a -> %w9
+2a6d318b : orn w11, w12, w13, LSR #12                : orn    %w12 %w13 lsr $0x0c -> %w11
+2a6f39cd : orn w13, w14, w15, LSR #14                : orn    %w14 %w15 lsr $0x0e -> %w13
+2a71420f : orn w15, w16, w17, LSR #16                : orn    %w16 %w17 lsr $0x10 -> %w15
+2a734651 : orn w17, w18, w19, LSR #17                : orn    %w18 %w19 lsr $0x11 -> %w17
+2a754e93 : orn w19, w20, w21, LSR #19                : orn    %w20 %w21 lsr $0x13 -> %w19
+2a7756d5 : orn w21, w22, w23, LSR #21                : orn    %w22 %w23 lsr $0x15 -> %w21
+2a785ef6 : orn w22, w23, w24, LSR #23                : orn    %w23 %w24 lsr $0x17 -> %w22
+2a7a6738 : orn w24, w25, w26, LSR #25                : orn    %w25 %w26 lsr $0x19 -> %w24
+2a7c6f7a : orn w26, w27, w28, LSR #27                : orn    %w27 %w28 lsr $0x1b -> %w26
+2a617c1e : orn w30, w0, w1, LSR #31                  : orn    %w0 %w1 lsr $0x1f -> %w30
+2aa20020 : orn w0, w1, w2, ASR #0                    : orn    %w1 %w2 asr $0x00 -> %w0
+2aa40862 : orn w2, w3, w4, ASR #2                    : orn    %w3 %w4 asr $0x02 -> %w2
+2aa610a4 : orn w4, w5, w6, ASR #4                    : orn    %w5 %w6 asr $0x04 -> %w4
+2aa818e6 : orn w6, w7, w8, ASR #6                    : orn    %w7 %w8 asr $0x06 -> %w6
+2aaa2128 : orn w8, w9, w10, ASR #8                   : orn    %w9 %w10 asr $0x08 -> %w8
+2aab2949 : orn w9, w10, w11, ASR #10                 : orn    %w10 %w11 asr $0x0a -> %w9
+2aad318b : orn w11, w12, w13, ASR #12                : orn    %w12 %w13 asr $0x0c -> %w11
+2aaf39cd : orn w13, w14, w15, ASR #14                : orn    %w14 %w15 asr $0x0e -> %w13
+2ab1420f : orn w15, w16, w17, ASR #16                : orn    %w16 %w17 asr $0x10 -> %w15
+2ab34651 : orn w17, w18, w19, ASR #17                : orn    %w18 %w19 asr $0x11 -> %w17
+2ab54e93 : orn w19, w20, w21, ASR #19                : orn    %w20 %w21 asr $0x13 -> %w19
+2ab756d5 : orn w21, w22, w23, ASR #21                : orn    %w22 %w23 asr $0x15 -> %w21
+2ab85ef6 : orn w22, w23, w24, ASR #23                : orn    %w23 %w24 asr $0x17 -> %w22
+2aba6738 : orn w24, w25, w26, ASR #25                : orn    %w25 %w26 asr $0x19 -> %w24
+2abc6f7a : orn w26, w27, w28, ASR #27                : orn    %w27 %w28 asr $0x1b -> %w26
+2aa17c1e : orn w30, w0, w1, ASR #31                  : orn    %w0 %w1 asr $0x1f -> %w30
+2ae20020 : orn w0, w1, w2, ROR #0                    : orn    %w1 %w2 ror $0x00 -> %w0
+2ae40862 : orn w2, w3, w4, ROR #2                    : orn    %w3 %w4 ror $0x02 -> %w2
+2ae610a4 : orn w4, w5, w6, ROR #4                    : orn    %w5 %w6 ror $0x04 -> %w4
+2ae818e6 : orn w6, w7, w8, ROR #6                    : orn    %w7 %w8 ror $0x06 -> %w6
+2aea2128 : orn w8, w9, w10, ROR #8                   : orn    %w9 %w10 ror $0x08 -> %w8
+2aeb2949 : orn w9, w10, w11, ROR #10                 : orn    %w10 %w11 ror $0x0a -> %w9
+2aed318b : orn w11, w12, w13, ROR #12                : orn    %w12 %w13 ror $0x0c -> %w11
+2aef39cd : orn w13, w14, w15, ROR #14                : orn    %w14 %w15 ror $0x0e -> %w13
+2af1420f : orn w15, w16, w17, ROR #16                : orn    %w16 %w17 ror $0x10 -> %w15
+2af34651 : orn w17, w18, w19, ROR #17                : orn    %w18 %w19 ror $0x11 -> %w17
+2af54e93 : orn w19, w20, w21, ROR #19                : orn    %w20 %w21 ror $0x13 -> %w19
+2af756d5 : orn w21, w22, w23, ROR #21                : orn    %w22 %w23 ror $0x15 -> %w21
+2af85ef6 : orn w22, w23, w24, ROR #23                : orn    %w23 %w24 ror $0x17 -> %w22
+2afa6738 : orn w24, w25, w26, ROR #25                : orn    %w25 %w26 ror $0x19 -> %w24
+2afc6f7a : orn w26, w27, w28, ROR #27                : orn    %w27 %w28 ror $0x1b -> %w26
+2ae17c1e : orn w30, w0, w1, ROR #31                  : orn    %w0 %w1 ror $0x1f -> %w30
+
+# CLZ     <Wd>, <Wn> (CLZ-R.R-32_dp_1src)
+5ac01020 : clz w0, w1                                : clz    %w1 -> %w0
+5ac01062 : clz w2, w3                                : clz    %w3 -> %w2
+5ac010a4 : clz w4, w5                                : clz    %w5 -> %w4
+5ac010e6 : clz w6, w7                                : clz    %w7 -> %w6
+5ac01128 : clz w8, w9                                : clz    %w9 -> %w8
+5ac01149 : clz w9, w10                               : clz    %w10 -> %w9
+5ac0118b : clz w11, w12                              : clz    %w12 -> %w11
+5ac011cd : clz w13, w14                              : clz    %w14 -> %w13
+5ac0120f : clz w15, w16                              : clz    %w16 -> %w15
+5ac01251 : clz w17, w18                              : clz    %w18 -> %w17
+5ac01293 : clz w19, w20                              : clz    %w20 -> %w19
+5ac012d5 : clz w21, w22                              : clz    %w22 -> %w21
+5ac012f6 : clz w22, w23                              : clz    %w23 -> %w22
+5ac01338 : clz w24, w25                              : clz    %w25 -> %w24
+5ac0137a : clz w26, w27                              : clz    %w27 -> %w26
+5ac0101e : clz w30, w0                               : clz    %w0 -> %w30
+
+# RORV    <Wd>, <Wn>, <Wm> (RORV-R.RR-32_dp_2src)
+1ac22c20 : rorv w0, w1, w2                           : rorv   %w1 %w2 -> %w0
+1ac42c62 : rorv w2, w3, w4                           : rorv   %w3 %w4 -> %w2
+1ac62ca4 : rorv w4, w5, w6                           : rorv   %w5 %w6 -> %w4
+1ac82ce6 : rorv w6, w7, w8                           : rorv   %w7 %w8 -> %w6
+1aca2d28 : rorv w8, w9, w10                          : rorv   %w9 %w10 -> %w8
+1acb2d49 : rorv w9, w10, w11                         : rorv   %w10 %w11 -> %w9
+1acd2d8b : rorv w11, w12, w13                        : rorv   %w12 %w13 -> %w11
+1acf2dcd : rorv w13, w14, w15                        : rorv   %w14 %w15 -> %w13
+1ad12e0f : rorv w15, w16, w17                        : rorv   %w16 %w17 -> %w15
+1ad32e51 : rorv w17, w18, w19                        : rorv   %w18 %w19 -> %w17
+1ad52e93 : rorv w19, w20, w21                        : rorv   %w20 %w21 -> %w19
+1ad72ed5 : rorv w21, w22, w23                        : rorv   %w22 %w23 -> %w21
+1ad82ef6 : rorv w22, w23, w24                        : rorv   %w23 %w24 -> %w22
+1ada2f38 : rorv w24, w25, w26                        : rorv   %w25 %w26 -> %w24
+1adc2f7a : rorv w26, w27, w28                        : rorv   %w27 %w28 -> %w26
+1ac12c1e : rorv w30, w0, w1                          : rorv   %w0 %w1 -> %w30
+
+# MOVZ    <Xd>, #<imm>{, LSL <amount>} (MOVZ-R.I-64_movewide)
+d2800000 : movz x0, #0x0, LSL #0                     : movz   $0x0000 lsl $0x00 -> %x0
+d2820002 : movz x2, #0x1000, LSL #0                  : movz   $0x1000 lsl $0x00 -> %x2
+d2840004 : movz x4, #0x2000, LSL #0                  : movz   $0x2000 lsl $0x00 -> %x4
+d2860006 : movz x6, #0x3000, LSL #0                  : movz   $0x3000 lsl $0x00 -> %x6
+d2880008 : movz x8, #0x4000, LSL #0                  : movz   $0x4000 lsl $0x00 -> %x8
+d28a0009 : movz x9, #0x5000, LSL #0                  : movz   $0x5000 lsl $0x00 -> %x9
+d28c000b : movz x11, #0x6000, LSL #0                 : movz   $0x6000 lsl $0x00 -> %x11
+d28e000d : movz x13, #0x7000, LSL #0                 : movz   $0x7000 lsl $0x00 -> %x13
+d290000f : movz x15, #0x8000, LSL #0                 : movz   $0x8000 lsl $0x00 -> %x15
+d291fff1 : movz x17, #0x8fff, LSL #0                 : movz   $0x8fff lsl $0x00 -> %x17
+d293fff3 : movz x19, #0x9fff, LSL #0                 : movz   $0x9fff lsl $0x00 -> %x19
+d295fff5 : movz x21, #0xafff, LSL #0                 : movz   $0xafff lsl $0x00 -> %x21
+d297fff6 : movz x22, #0xbfff, LSL #0                 : movz   $0xbfff lsl $0x00 -> %x22
+d299fff8 : movz x24, #0xcfff, LSL #0                 : movz   $0xcfff lsl $0x00 -> %x24
+d29bfffa : movz x26, #0xdfff, LSL #0                 : movz   $0xdfff lsl $0x00 -> %x26
+d29ffffe : movz x30, #0xffff, LSL #0                 : movz   $0xffff lsl $0x00 -> %x30
+d2a00000 : movz x0, #0x0, LSL #16                    : movz   $0x0000 lsl $0x10 -> %x0
+d2a20002 : movz x2, #0x1000, LSL #16                 : movz   $0x1000 lsl $0x10 -> %x2
+d2a40004 : movz x4, #0x2000, LSL #16                 : movz   $0x2000 lsl $0x10 -> %x4
+d2a60006 : movz x6, #0x3000, LSL #16                 : movz   $0x3000 lsl $0x10 -> %x6
+d2a80008 : movz x8, #0x4000, LSL #16                 : movz   $0x4000 lsl $0x10 -> %x8
+d2aa0009 : movz x9, #0x5000, LSL #16                 : movz   $0x5000 lsl $0x10 -> %x9
+d2ac000b : movz x11, #0x6000, LSL #16                : movz   $0x6000 lsl $0x10 -> %x11
+d2ae000d : movz x13, #0x7000, LSL #16                : movz   $0x7000 lsl $0x10 -> %x13
+d2b0000f : movz x15, #0x8000, LSL #16                : movz   $0x8000 lsl $0x10 -> %x15
+d2b1fff1 : movz x17, #0x8fff, LSL #16                : movz   $0x8fff lsl $0x10 -> %x17
+d2b3fff3 : movz x19, #0x9fff, LSL #16                : movz   $0x9fff lsl $0x10 -> %x19
+d2b5fff5 : movz x21, #0xafff, LSL #16                : movz   $0xafff lsl $0x10 -> %x21
+d2b7fff6 : movz x22, #0xbfff, LSL #16                : movz   $0xbfff lsl $0x10 -> %x22
+d2b9fff8 : movz x24, #0xcfff, LSL #16                : movz   $0xcfff lsl $0x10 -> %x24
+d2bbfffa : movz x26, #0xdfff, LSL #16                : movz   $0xdfff lsl $0x10 -> %x26
+d2bffffe : movz x30, #0xffff, LSL #16                : movz   $0xffff lsl $0x10 -> %x30
+d2c00000 : movz x0, #0x0, LSL #32                    : movz   $0x0000 lsl $0x20 -> %x0
+d2c20002 : movz x2, #0x1000, LSL #32                 : movz   $0x1000 lsl $0x20 -> %x2
+d2c40004 : movz x4, #0x2000, LSL #32                 : movz   $0x2000 lsl $0x20 -> %x4
+d2c60006 : movz x6, #0x3000, LSL #32                 : movz   $0x3000 lsl $0x20 -> %x6
+d2c80008 : movz x8, #0x4000, LSL #32                 : movz   $0x4000 lsl $0x20 -> %x8
+d2ca0009 : movz x9, #0x5000, LSL #32                 : movz   $0x5000 lsl $0x20 -> %x9
+d2cc000b : movz x11, #0x6000, LSL #32                : movz   $0x6000 lsl $0x20 -> %x11
+d2ce000d : movz x13, #0x7000, LSL #32                : movz   $0x7000 lsl $0x20 -> %x13
+d2d0000f : movz x15, #0x8000, LSL #32                : movz   $0x8000 lsl $0x20 -> %x15
+d2d1fff1 : movz x17, #0x8fff, LSL #32                : movz   $0x8fff lsl $0x20 -> %x17
+d2d3fff3 : movz x19, #0x9fff, LSL #32                : movz   $0x9fff lsl $0x20 -> %x19
+d2d5fff5 : movz x21, #0xafff, LSL #32                : movz   $0xafff lsl $0x20 -> %x21
+d2d7fff6 : movz x22, #0xbfff, LSL #32                : movz   $0xbfff lsl $0x20 -> %x22
+d2d9fff8 : movz x24, #0xcfff, LSL #32                : movz   $0xcfff lsl $0x20 -> %x24
+d2dbfffa : movz x26, #0xdfff, LSL #32                : movz   $0xdfff lsl $0x20 -> %x26
+d2dffffe : movz x30, #0xffff, LSL #32                : movz   $0xffff lsl $0x20 -> %x30
+d2e00000 : movz x0, #0x0, LSL #48                    : movz   $0x0000 lsl $0x30 -> %x0
+d2e20002 : movz x2, #0x1000, LSL #48                 : movz   $0x1000 lsl $0x30 -> %x2
+d2e40004 : movz x4, #0x2000, LSL #48                 : movz   $0x2000 lsl $0x30 -> %x4
+d2e60006 : movz x6, #0x3000, LSL #48                 : movz   $0x3000 lsl $0x30 -> %x6
+d2e80008 : movz x8, #0x4000, LSL #48                 : movz   $0x4000 lsl $0x30 -> %x8
+d2ea0009 : movz x9, #0x5000, LSL #48                 : movz   $0x5000 lsl $0x30 -> %x9
+d2ec000b : movz x11, #0x6000, LSL #48                : movz   $0x6000 lsl $0x30 -> %x11
+d2ee000d : movz x13, #0x7000, LSL #48                : movz   $0x7000 lsl $0x30 -> %x13
+d2f0000f : movz x15, #0x8000, LSL #48                : movz   $0x8000 lsl $0x30 -> %x15
+d2f1fff1 : movz x17, #0x8fff, LSL #48                : movz   $0x8fff lsl $0x30 -> %x17
+d2f3fff3 : movz x19, #0x9fff, LSL #48                : movz   $0x9fff lsl $0x30 -> %x19
+d2f5fff5 : movz x21, #0xafff, LSL #48                : movz   $0xafff lsl $0x30 -> %x21
+d2f7fff6 : movz x22, #0xbfff, LSL #48                : movz   $0xbfff lsl $0x30 -> %x22
+d2f9fff8 : movz x24, #0xcfff, LSL #48                : movz   $0xcfff lsl $0x30 -> %x24
+d2fbfffa : movz x26, #0xdfff, LSL #48                : movz   $0xdfff lsl $0x30 -> %x26
+d2fffffe : movz x30, #0xffff, LSL #48                : movz   $0xffff lsl $0x30 -> %x30
+
+
+# ADDS    <Xd>, <Xn>, <Xm>, <extend> #<imm> (ADDS-R.RRI-64_addsub_shift)
+ab020020 : adds x0, x1, x2, LSL #0                   : adds   %x1 %x2 lsl $0x00 -> %x0
+ab040862 : adds x2, x3, x4, LSL #2                   : adds   %x3 %x4 lsl $0x02 -> %x2
+ab0610a4 : adds x4, x5, x6, LSL #4                   : adds   %x5 %x6 lsl $0x04 -> %x4
+ab0818e6 : adds x6, x7, x8, LSL #6                   : adds   %x7 %x8 lsl $0x06 -> %x6
+ab0a2128 : adds x8, x9, x10, LSL #8                  : adds   %x9 %x10 lsl $0x08 -> %x8
+ab0b2949 : adds x9, x10, x11, LSL #10                : adds   %x10 %x11 lsl $0x0a -> %x9
+ab0d318b : adds x11, x12, x13, LSL #12               : adds   %x12 %x13 lsl $0x0c -> %x11
+ab0f39cd : adds x13, x14, x15, LSL #14               : adds   %x14 %x15 lsl $0x0e -> %x13
+ab11420f : adds x15, x16, x17, LSL #16               : adds   %x16 %x17 lsl $0x10 -> %x15
+ab134651 : adds x17, x18, x19, LSL #17               : adds   %x18 %x19 lsl $0x11 -> %x17
+ab154e93 : adds x19, x20, x21, LSL #19               : adds   %x20 %x21 lsl $0x13 -> %x19
+ab1756d5 : adds x21, x22, x23, LSL #21               : adds   %x22 %x23 lsl $0x15 -> %x21
+ab185ef6 : adds x22, x23, x24, LSL #23               : adds   %x23 %x24 lsl $0x17 -> %x22
+ab1a6738 : adds x24, x25, x26, LSL #25               : adds   %x25 %x26 lsl $0x19 -> %x24
+ab1c6f7a : adds x26, x27, x28, LSL #27               : adds   %x27 %x28 lsl $0x1b -> %x26
+ab017c1e : adds x30, x0, x1, LSL #31                 : adds   %x0 %x1 lsl $0x1f -> %x30
+ab420020 : adds x0, x1, x2, LSR #0                   : adds   %x1 %x2 lsr $0x00 -> %x0
+ab440862 : adds x2, x3, x4, LSR #2                   : adds   %x3 %x4 lsr $0x02 -> %x2
+ab4610a4 : adds x4, x5, x6, LSR #4                   : adds   %x5 %x6 lsr $0x04 -> %x4
+ab4818e6 : adds x6, x7, x8, LSR #6                   : adds   %x7 %x8 lsr $0x06 -> %x6
+ab4a2128 : adds x8, x9, x10, LSR #8                  : adds   %x9 %x10 lsr $0x08 -> %x8
+ab4b2949 : adds x9, x10, x11, LSR #10                : adds   %x10 %x11 lsr $0x0a -> %x9
+ab4d318b : adds x11, x12, x13, LSR #12               : adds   %x12 %x13 lsr $0x0c -> %x11
+ab4f39cd : adds x13, x14, x15, LSR #14               : adds   %x14 %x15 lsr $0x0e -> %x13
+ab51420f : adds x15, x16, x17, LSR #16               : adds   %x16 %x17 lsr $0x10 -> %x15
+ab534651 : adds x17, x18, x19, LSR #17               : adds   %x18 %x19 lsr $0x11 -> %x17
+ab554e93 : adds x19, x20, x21, LSR #19               : adds   %x20 %x21 lsr $0x13 -> %x19
+ab5756d5 : adds x21, x22, x23, LSR #21               : adds   %x22 %x23 lsr $0x15 -> %x21
+ab585ef6 : adds x22, x23, x24, LSR #23               : adds   %x23 %x24 lsr $0x17 -> %x22
+ab5a6738 : adds x24, x25, x26, LSR #25               : adds   %x25 %x26 lsr $0x19 -> %x24
+ab5c6f7a : adds x26, x27, x28, LSR #27               : adds   %x27 %x28 lsr $0x1b -> %x26
+ab417c1e : adds x30, x0, x1, LSR #31                 : adds   %x0 %x1 lsr $0x1f -> %x30
+ab820020 : adds x0, x1, x2, ASR #0                   : adds   %x1 %x2 asr $0x00 -> %x0
+ab840862 : adds x2, x3, x4, ASR #2                   : adds   %x3 %x4 asr $0x02 -> %x2
+ab8610a4 : adds x4, x5, x6, ASR #4                   : adds   %x5 %x6 asr $0x04 -> %x4
+ab8818e6 : adds x6, x7, x8, ASR #6                   : adds   %x7 %x8 asr $0x06 -> %x6
+ab8a2128 : adds x8, x9, x10, ASR #8                  : adds   %x9 %x10 asr $0x08 -> %x8
+ab8b2949 : adds x9, x10, x11, ASR #10                : adds   %x10 %x11 asr $0x0a -> %x9
+ab8d318b : adds x11, x12, x13, ASR #12               : adds   %x12 %x13 asr $0x0c -> %x11
+ab8f39cd : adds x13, x14, x15, ASR #14               : adds   %x14 %x15 asr $0x0e -> %x13
+ab91420f : adds x15, x16, x17, ASR #16               : adds   %x16 %x17 asr $0x10 -> %x15
+ab934651 : adds x17, x18, x19, ASR #17               : adds   %x18 %x19 asr $0x11 -> %x17
+ab954e93 : adds x19, x20, x21, ASR #19               : adds   %x20 %x21 asr $0x13 -> %x19
+ab9756d5 : adds x21, x22, x23, ASR #21               : adds   %x22 %x23 asr $0x15 -> %x21
+ab985ef6 : adds x22, x23, x24, ASR #23               : adds   %x23 %x24 asr $0x17 -> %x22
+ab9a6738 : adds x24, x25, x26, ASR #25               : adds   %x25 %x26 asr $0x19 -> %x24
+ab9c6f7a : adds x26, x27, x28, ASR #27               : adds   %x27 %x28 asr $0x1b -> %x26
+ab817c1e : adds x30, x0, x1, ASR #31                 : adds   %x0 %x1 asr $0x1f -> %x30
+
+# MOVZ    <Wd>, #<imm>{, LSL <amount>} (MOVZ-R.I-32_movewide)
+52800000 : movz w0, #0x0, LSL #0                     : movz   $0x0000 lsl $0x00 -> %w0
+52820002 : movz w2, #0x1000, LSL #0                  : movz   $0x1000 lsl $0x00 -> %w2
+52840004 : movz w4, #0x2000, LSL #0                  : movz   $0x2000 lsl $0x00 -> %w4
+52860006 : movz w6, #0x3000, LSL #0                  : movz   $0x3000 lsl $0x00 -> %w6
+52880008 : movz w8, #0x4000, LSL #0                  : movz   $0x4000 lsl $0x00 -> %w8
+528a0009 : movz w9, #0x5000, LSL #0                  : movz   $0x5000 lsl $0x00 -> %w9
+528c000b : movz w11, #0x6000, LSL #0                 : movz   $0x6000 lsl $0x00 -> %w11
+528e000d : movz w13, #0x7000, LSL #0                 : movz   $0x7000 lsl $0x00 -> %w13
+5290000f : movz w15, #0x8000, LSL #0                 : movz   $0x8000 lsl $0x00 -> %w15
+5291fff1 : movz w17, #0x8fff, LSL #0                 : movz   $0x8fff lsl $0x00 -> %w17
+5293fff3 : movz w19, #0x9fff, LSL #0                 : movz   $0x9fff lsl $0x00 -> %w19
+5295fff5 : movz w21, #0xafff, LSL #0                 : movz   $0xafff lsl $0x00 -> %w21
+5297fff6 : movz w22, #0xbfff, LSL #0                 : movz   $0xbfff lsl $0x00 -> %w22
+5299fff8 : movz w24, #0xcfff, LSL #0                 : movz   $0xcfff lsl $0x00 -> %w24
+529bfffa : movz w26, #0xdfff, LSL #0                 : movz   $0xdfff lsl $0x00 -> %w26
+529ffffe : movz w30, #0xffff, LSL #0                 : movz   $0xffff lsl $0x00 -> %w30
+52a00000 : movz w0, #0x0, LSL #16                    : movz   $0x0000 lsl $0x10 -> %w0
+52a20002 : movz w2, #0x1000, LSL #16                 : movz   $0x1000 lsl $0x10 -> %w2
+52a40004 : movz w4, #0x2000, LSL #16                 : movz   $0x2000 lsl $0x10 -> %w4
+52a60006 : movz w6, #0x3000, LSL #16                 : movz   $0x3000 lsl $0x10 -> %w6
+52a80008 : movz w8, #0x4000, LSL #16                 : movz   $0x4000 lsl $0x10 -> %w8
+52aa0009 : movz w9, #0x5000, LSL #16                 : movz   $0x5000 lsl $0x10 -> %w9
+52ac000b : movz w11, #0x6000, LSL #16                : movz   $0x6000 lsl $0x10 -> %w11
+52ae000d : movz w13, #0x7000, LSL #16                : movz   $0x7000 lsl $0x10 -> %w13
+52b0000f : movz w15, #0x8000, LSL #16                : movz   $0x8000 lsl $0x10 -> %w15
+52b1fff1 : movz w17, #0x8fff, LSL #16                : movz   $0x8fff lsl $0x10 -> %w17
+52b3fff3 : movz w19, #0x9fff, LSL #16                : movz   $0x9fff lsl $0x10 -> %w19
+52b5fff5 : movz w21, #0xafff, LSL #16                : movz   $0xafff lsl $0x10 -> %w21
+52b7fff6 : movz w22, #0xbfff, LSL #16                : movz   $0xbfff lsl $0x10 -> %w22
+52b9fff8 : movz w24, #0xcfff, LSL #16                : movz   $0xcfff lsl $0x10 -> %w24
+52bbfffa : movz w26, #0xdfff, LSL #16                : movz   $0xdfff lsl $0x10 -> %w26
+52bffffe : movz w30, #0xffff, LSL #16                : movz   $0xffff lsl $0x10 -> %w30
+
+# ADCS    <Wd>, <Wn>, <Wm> (ADCS-R.RR-32_addsub_carry)
+3a020020 : adcs w0, w1, w2                           : adcs   %w1 %w2 -> %w0
+3a040062 : adcs w2, w3, w4                           : adcs   %w3 %w4 -> %w2
+3a0600a4 : adcs w4, w5, w6                           : adcs   %w5 %w6 -> %w4
+3a0800e6 : adcs w6, w7, w8                           : adcs   %w7 %w8 -> %w6
+3a0a0128 : adcs w8, w9, w10                          : adcs   %w9 %w10 -> %w8
+3a0b0149 : adcs w9, w10, w11                         : adcs   %w10 %w11 -> %w9
+3a0d018b : adcs w11, w12, w13                        : adcs   %w12 %w13 -> %w11
+3a0f01cd : adcs w13, w14, w15                        : adcs   %w14 %w15 -> %w13
+3a11020f : adcs w15, w16, w17                        : adcs   %w16 %w17 -> %w15
+3a130251 : adcs w17, w18, w19                        : adcs   %w18 %w19 -> %w17
+3a150293 : adcs w19, w20, w21                        : adcs   %w20 %w21 -> %w19
+3a1702d5 : adcs w21, w22, w23                        : adcs   %w22 %w23 -> %w21
+3a1802f6 : adcs w22, w23, w24                        : adcs   %w23 %w24 -> %w22
+3a1a0338 : adcs w24, w25, w26                        : adcs   %w25 %w26 -> %w24
+3a1c037a : adcs w26, w27, w28                        : adcs   %w27 %w28 -> %w26
+3a01001e : adcs w30, w0, w1                          : adcs   %w0 %w1 -> %w30
+
+# SUBS    <Wd>, <Wn|SP>, <Wm>, <extend> #<imm> (SUBS-R.RRI-32S_addsub_ext)
+6b220020 : subs w0, w1, w2, UXTB #0                  : subs   %w1 %w2 uxtb $0x00 -> %w0
+6b240062 : subs w2, w3, w4, UXTB #0                  : subs   %w3 %w4 uxtb $0x00 -> %w2
+6b2600a4 : subs w4, w5, w6, UXTB #0                  : subs   %w5 %w6 uxtb $0x00 -> %w4
+6b2804e6 : subs w6, w7, w8, UXTB #1                  : subs   %w7 %w8 uxtb $0x01 -> %w6
+6b2a0528 : subs w8, w9, w10, UXTB #1                 : subs   %w9 %w10 uxtb $0x01 -> %w8
+6b2b0549 : subs w9, w10, w11, UXTB #1                : subs   %w10 %w11 uxtb $0x01 -> %w9
+6b2d098b : subs w11, w12, w13, UXTB #2               : subs   %w12 %w13 uxtb $0x02 -> %w11
+6b2f09cd : subs w13, w14, w15, UXTB #2               : subs   %w14 %w15 uxtb $0x02 -> %w13
+6b310a0f : subs w15, w16, w17, UXTB #2               : subs   %w16 %w17 uxtb $0x02 -> %w15
+6b330a51 : subs w17, w18, w19, UXTB #2               : subs   %w18 %w19 uxtb $0x02 -> %w17
+6b350a93 : subs w19, w20, w21, UXTB #2               : subs   %w20 %w21 uxtb $0x02 -> %w19
+6b370ed5 : subs w21, w22, w23, UXTB #3               : subs   %w22 %w23 uxtb $0x03 -> %w21
+6b380ef6 : subs w22, w23, w24, UXTB #3               : subs   %w23 %w24 uxtb $0x03 -> %w22
+6b3a0f38 : subs w24, w25, w26, UXTB #3               : subs   %w25 %w26 uxtb $0x03 -> %w24
+6b3c137a : subs w26, w27, w28, UXTB #4               : subs   %w27 %w28 uxtb $0x04 -> %w26
+6b21101e : subs w30, w0, w1, UXTB #4                 : subs   %w0 %w1 uxtb $0x04 -> %w30
+6b222020 : subs w0, w1, w2, UXTH #0                  : subs   %w1 %w2 uxth $0x00 -> %w0
+6b242062 : subs w2, w3, w4, UXTH #0                  : subs   %w3 %w4 uxth $0x00 -> %w2
+6b2620a4 : subs w4, w5, w6, UXTH #0                  : subs   %w5 %w6 uxth $0x00 -> %w4
+6b2824e6 : subs w6, w7, w8, UXTH #1                  : subs   %w7 %w8 uxth $0x01 -> %w6
+6b2a2528 : subs w8, w9, w10, UXTH #1                 : subs   %w9 %w10 uxth $0x01 -> %w8
+6b2b2549 : subs w9, w10, w11, UXTH #1                : subs   %w10 %w11 uxth $0x01 -> %w9
+6b2d298b : subs w11, w12, w13, UXTH #2               : subs   %w12 %w13 uxth $0x02 -> %w11
+6b2f29cd : subs w13, w14, w15, UXTH #2               : subs   %w14 %w15 uxth $0x02 -> %w13
+6b312a0f : subs w15, w16, w17, UXTH #2               : subs   %w16 %w17 uxth $0x02 -> %w15
+6b332a51 : subs w17, w18, w19, UXTH #2               : subs   %w18 %w19 uxth $0x02 -> %w17
+6b352a93 : subs w19, w20, w21, UXTH #2               : subs   %w20 %w21 uxth $0x02 -> %w19
+6b372ed5 : subs w21, w22, w23, UXTH #3               : subs   %w22 %w23 uxth $0x03 -> %w21
+6b382ef6 : subs w22, w23, w24, UXTH #3               : subs   %w23 %w24 uxth $0x03 -> %w22
+6b3a2f38 : subs w24, w25, w26, UXTH #3               : subs   %w25 %w26 uxth $0x03 -> %w24
+6b3c337a : subs w26, w27, w28, UXTH #4               : subs   %w27 %w28 uxth $0x04 -> %w26
+6b21301e : subs w30, w0, w1, UXTH #4                 : subs   %w0 %w1 uxth $0x04 -> %w30
+6b224020 : subs w0, w1, w2, UXTW #0                  : subs   %w1 %w2 uxtw $0x00 -> %w0
+6b244062 : subs w2, w3, w4, UXTW #0                  : subs   %w3 %w4 uxtw $0x00 -> %w2
+6b2640a4 : subs w4, w5, w6, UXTW #0                  : subs   %w5 %w6 uxtw $0x00 -> %w4
+6b2844e6 : subs w6, w7, w8, UXTW #1                  : subs   %w7 %w8 uxtw $0x01 -> %w6
+6b2a4528 : subs w8, w9, w10, UXTW #1                 : subs   %w9 %w10 uxtw $0x01 -> %w8
+6b2b4549 : subs w9, w10, w11, UXTW #1                : subs   %w10 %w11 uxtw $0x01 -> %w9
+6b2d498b : subs w11, w12, w13, UXTW #2               : subs   %w12 %w13 uxtw $0x02 -> %w11
+6b2f49cd : subs w13, w14, w15, UXTW #2               : subs   %w14 %w15 uxtw $0x02 -> %w13
+6b314a0f : subs w15, w16, w17, UXTW #2               : subs   %w16 %w17 uxtw $0x02 -> %w15
+6b334a51 : subs w17, w18, w19, UXTW #2               : subs   %w18 %w19 uxtw $0x02 -> %w17
+6b354a93 : subs w19, w20, w21, UXTW #2               : subs   %w20 %w21 uxtw $0x02 -> %w19
+6b374ed5 : subs w21, w22, w23, UXTW #3               : subs   %w22 %w23 uxtw $0x03 -> %w21
+6b384ef6 : subs w22, w23, w24, UXTW #3               : subs   %w23 %w24 uxtw $0x03 -> %w22
+6b3a4f38 : subs w24, w25, w26, UXTW #3               : subs   %w25 %w26 uxtw $0x03 -> %w24
+6b3c537a : subs w26, w27, w28, UXTW #4               : subs   %w27 %w28 uxtw $0x04 -> %w26
+6b21501e : subs w30, w0, w1, UXTW #4                 : subs   %w0 %w1 uxtw $0x04 -> %w30
+6b226020 : subs w0, w1, w2, UXTX #0                  : subs   %w1 %w2 uxtx $0x00 -> %w0
+6b246062 : subs w2, w3, w4, UXTX #0                  : subs   %w3 %w4 uxtx $0x00 -> %w2
+6b2660a4 : subs w4, w5, w6, UXTX #0                  : subs   %w5 %w6 uxtx $0x00 -> %w4
+6b2864e6 : subs w6, w7, w8, UXTX #1                  : subs   %w7 %w8 uxtx $0x01 -> %w6
+6b2a6528 : subs w8, w9, w10, UXTX #1                 : subs   %w9 %w10 uxtx $0x01 -> %w8
+6b2b6549 : subs w9, w10, w11, UXTX #1                : subs   %w10 %w11 uxtx $0x01 -> %w9
+6b2d698b : subs w11, w12, w13, UXTX #2               : subs   %w12 %w13 uxtx $0x02 -> %w11
+6b2f69cd : subs w13, w14, w15, UXTX #2               : subs   %w14 %w15 uxtx $0x02 -> %w13
+6b316a0f : subs w15, w16, w17, UXTX #2               : subs   %w16 %w17 uxtx $0x02 -> %w15
+6b336a51 : subs w17, w18, w19, UXTX #2               : subs   %w18 %w19 uxtx $0x02 -> %w17
+6b356a93 : subs w19, w20, w21, UXTX #2               : subs   %w20 %w21 uxtx $0x02 -> %w19
+6b376ed5 : subs w21, w22, w23, UXTX #3               : subs   %w22 %w23 uxtx $0x03 -> %w21
+6b386ef6 : subs w22, w23, w24, UXTX #3               : subs   %w23 %w24 uxtx $0x03 -> %w22
+6b3a6f38 : subs w24, w25, w26, UXTX #3               : subs   %w25 %w26 uxtx $0x03 -> %w24
+6b3c737a : subs w26, w27, w28, UXTX #4               : subs   %w27 %w28 uxtx $0x04 -> %w26
+6b21701e : subs w30, w0, w1, UXTX #4                 : subs   %w0 %w1 uxtx $0x04 -> %w30
+6b228020 : subs w0, w1, w2, SXTB #0                  : subs   %w1 %w2 sxtb $0x00 -> %w0
+6b248062 : subs w2, w3, w4, SXTB #0                  : subs   %w3 %w4 sxtb $0x00 -> %w2
+6b2680a4 : subs w4, w5, w6, SXTB #0                  : subs   %w5 %w6 sxtb $0x00 -> %w4
+6b2884e6 : subs w6, w7, w8, SXTB #1                  : subs   %w7 %w8 sxtb $0x01 -> %w6
+6b2a8528 : subs w8, w9, w10, SXTB #1                 : subs   %w9 %w10 sxtb $0x01 -> %w8
+6b2b8549 : subs w9, w10, w11, SXTB #1                : subs   %w10 %w11 sxtb $0x01 -> %w9
+6b2d898b : subs w11, w12, w13, SXTB #2               : subs   %w12 %w13 sxtb $0x02 -> %w11
+6b2f89cd : subs w13, w14, w15, SXTB #2               : subs   %w14 %w15 sxtb $0x02 -> %w13
+6b318a0f : subs w15, w16, w17, SXTB #2               : subs   %w16 %w17 sxtb $0x02 -> %w15
+6b338a51 : subs w17, w18, w19, SXTB #2               : subs   %w18 %w19 sxtb $0x02 -> %w17
+6b358a93 : subs w19, w20, w21, SXTB #2               : subs   %w20 %w21 sxtb $0x02 -> %w19
+6b378ed5 : subs w21, w22, w23, SXTB #3               : subs   %w22 %w23 sxtb $0x03 -> %w21
+6b388ef6 : subs w22, w23, w24, SXTB #3               : subs   %w23 %w24 sxtb $0x03 -> %w22
+6b3a8f38 : subs w24, w25, w26, SXTB #3               : subs   %w25 %w26 sxtb $0x03 -> %w24
+6b3c937a : subs w26, w27, w28, SXTB #4               : subs   %w27 %w28 sxtb $0x04 -> %w26
+6b21901e : subs w30, w0, w1, SXTB #4                 : subs   %w0 %w1 sxtb $0x04 -> %w30
+6b22a020 : subs w0, w1, w2, SXTH #0                  : subs   %w1 %w2 sxth $0x00 -> %w0
+6b24a062 : subs w2, w3, w4, SXTH #0                  : subs   %w3 %w4 sxth $0x00 -> %w2
+6b26a0a4 : subs w4, w5, w6, SXTH #0                  : subs   %w5 %w6 sxth $0x00 -> %w4
+6b28a4e6 : subs w6, w7, w8, SXTH #1                  : subs   %w7 %w8 sxth $0x01 -> %w6
+6b2aa528 : subs w8, w9, w10, SXTH #1                 : subs   %w9 %w10 sxth $0x01 -> %w8
+6b2ba549 : subs w9, w10, w11, SXTH #1                : subs   %w10 %w11 sxth $0x01 -> %w9
+6b2da98b : subs w11, w12, w13, SXTH #2               : subs   %w12 %w13 sxth $0x02 -> %w11
+6b2fa9cd : subs w13, w14, w15, SXTH #2               : subs   %w14 %w15 sxth $0x02 -> %w13
+6b31aa0f : subs w15, w16, w17, SXTH #2               : subs   %w16 %w17 sxth $0x02 -> %w15
+6b33aa51 : subs w17, w18, w19, SXTH #2               : subs   %w18 %w19 sxth $0x02 -> %w17
+6b35aa93 : subs w19, w20, w21, SXTH #2               : subs   %w20 %w21 sxth $0x02 -> %w19
+6b37aed5 : subs w21, w22, w23, SXTH #3               : subs   %w22 %w23 sxth $0x03 -> %w21
+6b38aef6 : subs w22, w23, w24, SXTH #3               : subs   %w23 %w24 sxth $0x03 -> %w22
+6b3aaf38 : subs w24, w25, w26, SXTH #3               : subs   %w25 %w26 sxth $0x03 -> %w24
+6b3cb37a : subs w26, w27, w28, SXTH #4               : subs   %w27 %w28 sxth $0x04 -> %w26
+6b21b01e : subs w30, w0, w1, SXTH #4                 : subs   %w0 %w1 sxth $0x04 -> %w30
+6b22c020 : subs w0, w1, w2, SXTW #0                  : subs   %w1 %w2 sxtw $0x00 -> %w0
+6b24c062 : subs w2, w3, w4, SXTW #0                  : subs   %w3 %w4 sxtw $0x00 -> %w2
+6b26c0a4 : subs w4, w5, w6, SXTW #0                  : subs   %w5 %w6 sxtw $0x00 -> %w4
+6b28c4e6 : subs w6, w7, w8, SXTW #1                  : subs   %w7 %w8 sxtw $0x01 -> %w6
+6b2ac528 : subs w8, w9, w10, SXTW #1                 : subs   %w9 %w10 sxtw $0x01 -> %w8
+6b2bc549 : subs w9, w10, w11, SXTW #1                : subs   %w10 %w11 sxtw $0x01 -> %w9
+6b2dc98b : subs w11, w12, w13, SXTW #2               : subs   %w12 %w13 sxtw $0x02 -> %w11
+6b2fc9cd : subs w13, w14, w15, SXTW #2               : subs   %w14 %w15 sxtw $0x02 -> %w13
+6b31ca0f : subs w15, w16, w17, SXTW #2               : subs   %w16 %w17 sxtw $0x02 -> %w15
+6b33ca51 : subs w17, w18, w19, SXTW #2               : subs   %w18 %w19 sxtw $0x02 -> %w17
+6b35ca93 : subs w19, w20, w21, SXTW #2               : subs   %w20 %w21 sxtw $0x02 -> %w19
+6b37ced5 : subs w21, w22, w23, SXTW #3               : subs   %w22 %w23 sxtw $0x03 -> %w21
+6b38cef6 : subs w22, w23, w24, SXTW #3               : subs   %w23 %w24 sxtw $0x03 -> %w22
+6b3acf38 : subs w24, w25, w26, SXTW #3               : subs   %w25 %w26 sxtw $0x03 -> %w24
+6b3cd37a : subs w26, w27, w28, SXTW #4               : subs   %w27 %w28 sxtw $0x04 -> %w26
+6b21d01e : subs w30, w0, w1, SXTW #4                 : subs   %w0 %w1 sxtw $0x04 -> %w30
+6b22e020 : subs w0, w1, w2, SXTX #0                  : subs   %w1 %w2 sxtx $0x00 -> %w0
+6b24e062 : subs w2, w3, w4, SXTX #0                  : subs   %w3 %w4 sxtx $0x00 -> %w2
+6b26e0a4 : subs w4, w5, w6, SXTX #0                  : subs   %w5 %w6 sxtx $0x00 -> %w4
+6b28e4e6 : subs w6, w7, w8, SXTX #1                  : subs   %w7 %w8 sxtx $0x01 -> %w6
+6b2ae528 : subs w8, w9, w10, SXTX #1                 : subs   %w9 %w10 sxtx $0x01 -> %w8
+6b2be549 : subs w9, w10, w11, SXTX #1                : subs   %w10 %w11 sxtx $0x01 -> %w9
+6b2de98b : subs w11, w12, w13, SXTX #2               : subs   %w12 %w13 sxtx $0x02 -> %w11
+6b2fe9cd : subs w13, w14, w15, SXTX #2               : subs   %w14 %w15 sxtx $0x02 -> %w13
+6b31ea0f : subs w15, w16, w17, SXTX #2               : subs   %w16 %w17 sxtx $0x02 -> %w15
+6b33ea51 : subs w17, w18, w19, SXTX #2               : subs   %w18 %w19 sxtx $0x02 -> %w17
+6b35ea93 : subs w19, w20, w21, SXTX #2               : subs   %w20 %w21 sxtx $0x02 -> %w19
+6b37eed5 : subs w21, w22, w23, SXTX #3               : subs   %w22 %w23 sxtx $0x03 -> %w21
+6b38eef6 : subs w22, w23, w24, SXTX #3               : subs   %w23 %w24 sxtx $0x03 -> %w22
+6b3aef38 : subs w24, w25, w26, SXTX #3               : subs   %w25 %w26 sxtx $0x03 -> %w24
+6b3cf37a : subs w26, w27, w28, SXTX #4               : subs   %w27 %w28 sxtx $0x04 -> %w26
+6b21f01e : subs w30, w0, w1, SXTX #4                 : subs   %w0 %w1 sxtx $0x04 -> %w30
+
+# ASRV    <Xd>, <Xn>, <Xm> (ASRV-R.RR-64_dp_2src)
+9ac22820 : asrv x0, x1, x2                           : asrv   %x1 %x2 -> %x0
+9ac42862 : asrv x2, x3, x4                           : asrv   %x3 %x4 -> %x2
+9ac628a4 : asrv x4, x5, x6                           : asrv   %x5 %x6 -> %x4
+9ac828e6 : asrv x6, x7, x8                           : asrv   %x7 %x8 -> %x6
+9aca2928 : asrv x8, x9, x10                          : asrv   %x9 %x10 -> %x8
+9acb2949 : asrv x9, x10, x11                         : asrv   %x10 %x11 -> %x9
+9acd298b : asrv x11, x12, x13                        : asrv   %x12 %x13 -> %x11
+9acf29cd : asrv x13, x14, x15                        : asrv   %x14 %x15 -> %x13
+9ad12a0f : asrv x15, x16, x17                        : asrv   %x16 %x17 -> %x15
+9ad32a51 : asrv x17, x18, x19                        : asrv   %x18 %x19 -> %x17
+9ad52a93 : asrv x19, x20, x21                        : asrv   %x20 %x21 -> %x19
+9ad72ad5 : asrv x21, x22, x23                        : asrv   %x22 %x23 -> %x21
+9ad82af6 : asrv x22, x23, x24                        : asrv   %x23 %x24 -> %x22
+9ada2b38 : asrv x24, x25, x26                        : asrv   %x25 %x26 -> %x24
+9adc2b7a : asrv x26, x27, x28                        : asrv   %x27 %x28 -> %x26
+9ac1281e : asrv x30, x0, x1                          : asrv   %x0 %x1 -> %x30
+
+# UBFM    <Xd>, <Xn>, #<imm1>, #<imm2> (UBFM-R.RII-64M_bitfield)
+d3400020 : ubfm x0, x1, #0x0, #0x0                   : ubfm   %x1 $0x00 $0x00 -> %x0
+d3420862 : ubfm x2, x3, #0x2, #0x2                   : ubfm   %x3 $0x02 $0x02 -> %x2
+d34410a4 : ubfm x4, x5, #0x4, #0x4                   : ubfm   %x5 $0x04 $0x04 -> %x4
+d34618e6 : ubfm x6, x7, #0x6, #0x6                   : ubfm   %x7 $0x06 $0x06 -> %x6
+d3482128 : ubfm x8, x9, #0x8, #0x8                   : ubfm   %x9 $0x08 $0x08 -> %x8
+d34a2949 : ubfm x9, x10, #0xa, #0xa                  : ubfm   %x10 $0x0a $0x0a -> %x9
+d34c318b : ubfm x11, x12, #0xc, #0xc                 : ubfm   %x12 $0x0c $0x0c -> %x11
+d34e39cd : ubfm x13, x14, #0xe, #0xe                 : ubfm   %x14 $0x0e $0x0e -> %x13
+d350420f : ubfm x15, x16, #0x10, #0x10               : ubfm   %x16 $0x10 $0x10 -> %x15
+d3514651 : ubfm x17, x18, #0x11, #0x11               : ubfm   %x18 $0x11 $0x11 -> %x17
+d3534e93 : ubfm x19, x20, #0x13, #0x13               : ubfm   %x20 $0x13 $0x13 -> %x19
+d35556d5 : ubfm x21, x22, #0x15, #0x15               : ubfm   %x22 $0x15 $0x15 -> %x21
+d3575ef6 : ubfm x22, x23, #0x17, #0x17               : ubfm   %x23 $0x17 $0x17 -> %x22
+d3596738 : ubfm x24, x25, #0x19, #0x19               : ubfm   %x25 $0x19 $0x19 -> %x24
+d35b6f7a : ubfm x26, x27, #0x1b, #0x1b               : ubfm   %x27 $0x1b $0x1b -> %x26
+d35f7c1e : ubfm x30, x0, #0x1f, #0x1f                : ubfm   %x0 $0x1f $0x1f -> %x30
+
+# BIC     <Xd>, <Xn>, <Xm>, <extend> #<imm> (BIC-R.RRI-64_log_shift)
+8a220020 : bic x0, x1, x2, LSL #0                    : bic    %x1 %x2 lsl $0x00 -> %x0
+8a240862 : bic x2, x3, x4, LSL #2                    : bic    %x3 %x4 lsl $0x02 -> %x2
+8a2610a4 : bic x4, x5, x6, LSL #4                    : bic    %x5 %x6 lsl $0x04 -> %x4
+8a2818e6 : bic x6, x7, x8, LSL #6                    : bic    %x7 %x8 lsl $0x06 -> %x6
+8a2a2128 : bic x8, x9, x10, LSL #8                   : bic    %x9 %x10 lsl $0x08 -> %x8
+8a2b2949 : bic x9, x10, x11, LSL #10                 : bic    %x10 %x11 lsl $0x0a -> %x9
+8a2d318b : bic x11, x12, x13, LSL #12                : bic    %x12 %x13 lsl $0x0c -> %x11
+8a2f39cd : bic x13, x14, x15, LSL #14                : bic    %x14 %x15 lsl $0x0e -> %x13
+8a31420f : bic x15, x16, x17, LSL #16                : bic    %x16 %x17 lsl $0x10 -> %x15
+8a334651 : bic x17, x18, x19, LSL #17                : bic    %x18 %x19 lsl $0x11 -> %x17
+8a354e93 : bic x19, x20, x21, LSL #19                : bic    %x20 %x21 lsl $0x13 -> %x19
+8a3756d5 : bic x21, x22, x23, LSL #21                : bic    %x22 %x23 lsl $0x15 -> %x21
+8a385ef6 : bic x22, x23, x24, LSL #23                : bic    %x23 %x24 lsl $0x17 -> %x22
+8a3a6738 : bic x24, x25, x26, LSL #25                : bic    %x25 %x26 lsl $0x19 -> %x24
+8a3c6f7a : bic x26, x27, x28, LSL #27                : bic    %x27 %x28 lsl $0x1b -> %x26
+8a217c1e : bic x30, x0, x1, LSL #31                  : bic    %x0 %x1 lsl $0x1f -> %x30
+8a620020 : bic x0, x1, x2, LSR #0                    : bic    %x1 %x2 lsr $0x00 -> %x0
+8a640862 : bic x2, x3, x4, LSR #2                    : bic    %x3 %x4 lsr $0x02 -> %x2
+8a6610a4 : bic x4, x5, x6, LSR #4                    : bic    %x5 %x6 lsr $0x04 -> %x4
+8a6818e6 : bic x6, x7, x8, LSR #6                    : bic    %x7 %x8 lsr $0x06 -> %x6
+8a6a2128 : bic x8, x9, x10, LSR #8                   : bic    %x9 %x10 lsr $0x08 -> %x8
+8a6b2949 : bic x9, x10, x11, LSR #10                 : bic    %x10 %x11 lsr $0x0a -> %x9
+8a6d318b : bic x11, x12, x13, LSR #12                : bic    %x12 %x13 lsr $0x0c -> %x11
+8a6f39cd : bic x13, x14, x15, LSR #14                : bic    %x14 %x15 lsr $0x0e -> %x13
+8a71420f : bic x15, x16, x17, LSR #16                : bic    %x16 %x17 lsr $0x10 -> %x15
+8a734651 : bic x17, x18, x19, LSR #17                : bic    %x18 %x19 lsr $0x11 -> %x17
+8a754e93 : bic x19, x20, x21, LSR #19                : bic    %x20 %x21 lsr $0x13 -> %x19
+8a7756d5 : bic x21, x22, x23, LSR #21                : bic    %x22 %x23 lsr $0x15 -> %x21
+8a785ef6 : bic x22, x23, x24, LSR #23                : bic    %x23 %x24 lsr $0x17 -> %x22
+8a7a6738 : bic x24, x25, x26, LSR #25                : bic    %x25 %x26 lsr $0x19 -> %x24
+8a7c6f7a : bic x26, x27, x28, LSR #27                : bic    %x27 %x28 lsr $0x1b -> %x26
+8a617c1e : bic x30, x0, x1, LSR #31                  : bic    %x0 %x1 lsr $0x1f -> %x30
+8aa20020 : bic x0, x1, x2, ASR #0                    : bic    %x1 %x2 asr $0x00 -> %x0
+8aa40862 : bic x2, x3, x4, ASR #2                    : bic    %x3 %x4 asr $0x02 -> %x2
+8aa610a4 : bic x4, x5, x6, ASR #4                    : bic    %x5 %x6 asr $0x04 -> %x4
+8aa818e6 : bic x6, x7, x8, ASR #6                    : bic    %x7 %x8 asr $0x06 -> %x6
+8aaa2128 : bic x8, x9, x10, ASR #8                   : bic    %x9 %x10 asr $0x08 -> %x8
+8aab2949 : bic x9, x10, x11, ASR #10                 : bic    %x10 %x11 asr $0x0a -> %x9
+8aad318b : bic x11, x12, x13, ASR #12                : bic    %x12 %x13 asr $0x0c -> %x11
+8aaf39cd : bic x13, x14, x15, ASR #14                : bic    %x14 %x15 asr $0x0e -> %x13
+8ab1420f : bic x15, x16, x17, ASR #16                : bic    %x16 %x17 asr $0x10 -> %x15
+8ab34651 : bic x17, x18, x19, ASR #17                : bic    %x18 %x19 asr $0x11 -> %x17
+8ab54e93 : bic x19, x20, x21, ASR #19                : bic    %x20 %x21 asr $0x13 -> %x19
+8ab756d5 : bic x21, x22, x23, ASR #21                : bic    %x22 %x23 asr $0x15 -> %x21
+8ab85ef6 : bic x22, x23, x24, ASR #23                : bic    %x23 %x24 asr $0x17 -> %x22
+8aba6738 : bic x24, x25, x26, ASR #25                : bic    %x25 %x26 asr $0x19 -> %x24
+8abc6f7a : bic x26, x27, x28, ASR #27                : bic    %x27 %x28 asr $0x1b -> %x26
+8aa17c1e : bic x30, x0, x1, ASR #31                  : bic    %x0 %x1 asr $0x1f -> %x30
+8ae20020 : bic x0, x1, x2, ROR #0                    : bic    %x1 %x2 ror $0x00 -> %x0
+8ae40862 : bic x2, x3, x4, ROR #2                    : bic    %x3 %x4 ror $0x02 -> %x2
+8ae610a4 : bic x4, x5, x6, ROR #4                    : bic    %x5 %x6 ror $0x04 -> %x4
+8ae818e6 : bic x6, x7, x8, ROR #6                    : bic    %x7 %x8 ror $0x06 -> %x6
+8aea2128 : bic x8, x9, x10, ROR #8                   : bic    %x9 %x10 ror $0x08 -> %x8
+8aeb2949 : bic x9, x10, x11, ROR #10                 : bic    %x10 %x11 ror $0x0a -> %x9
+8aed318b : bic x11, x12, x13, ROR #12                : bic    %x12 %x13 ror $0x0c -> %x11
+8aef39cd : bic x13, x14, x15, ROR #14                : bic    %x14 %x15 ror $0x0e -> %x13
+8af1420f : bic x15, x16, x17, ROR #16                : bic    %x16 %x17 ror $0x10 -> %x15
+8af34651 : bic x17, x18, x19, ROR #17                : bic    %x18 %x19 ror $0x11 -> %x17
+8af54e93 : bic x19, x20, x21, ROR #19                : bic    %x20 %x21 ror $0x13 -> %x19
+8af756d5 : bic x21, x22, x23, ROR #21                : bic    %x22 %x23 ror $0x15 -> %x21
+8af85ef6 : bic x22, x23, x24, ROR #23                : bic    %x23 %x24 ror $0x17 -> %x22
+8afa6738 : bic x24, x25, x26, ROR #25                : bic    %x25 %x26 ror $0x19 -> %x24
+8afc6f7a : bic x26, x27, x28, ROR #27                : bic    %x27 %x28 ror $0x1b -> %x26
+8ae17c1e : bic x30, x0, x1, ROR #31                  : bic    %x0 %x1 ror $0x1f -> %x30
+
+# CRC32CW <Wd>, <Wn>, <Wm> (CRC32CW-R.RR-32C_dp_2src)
+1ac25820 : crc32cw w0, w1, w2                        : crc32cw %w1 %w2 -> %w0
+1ac45862 : crc32cw w2, w3, w4                        : crc32cw %w3 %w4 -> %w2
+1ac658a4 : crc32cw w4, w5, w6                        : crc32cw %w5 %w6 -> %w4
+1ac858e6 : crc32cw w6, w7, w8                        : crc32cw %w7 %w8 -> %w6
+1aca5928 : crc32cw w8, w9, w10                       : crc32cw %w9 %w10 -> %w8
+1acb5949 : crc32cw w9, w10, w11                      : crc32cw %w10 %w11 -> %w9
+1acd598b : crc32cw w11, w12, w13                     : crc32cw %w12 %w13 -> %w11
+1acf59cd : crc32cw w13, w14, w15                     : crc32cw %w14 %w15 -> %w13
+1ad15a0f : crc32cw w15, w16, w17                     : crc32cw %w16 %w17 -> %w15
+1ad35a51 : crc32cw w17, w18, w19                     : crc32cw %w18 %w19 -> %w17
+1ad55a93 : crc32cw w19, w20, w21                     : crc32cw %w20 %w21 -> %w19
+1ad75ad5 : crc32cw w21, w22, w23                     : crc32cw %w22 %w23 -> %w21
+1ad85af6 : crc32cw w22, w23, w24                     : crc32cw %w23 %w24 -> %w22
+1ada5b38 : crc32cw w24, w25, w26                     : crc32cw %w25 %w26 -> %w24
+1adc5b7a : crc32cw w26, w27, w28                     : crc32cw %w27 %w28 -> %w26
+1ac1581e : crc32cw w30, w0, w1                       : crc32cw %w0 %w1 -> %w30
+
+# ORR     <Xd>, <Xn>, <Xm>, <extend> #<imm> (ORR-R.RRI-64_log_shift)
+aa020020 : orr x0, x1, x2, LSL #0                    : orr    %x1 %x2 lsl $0x00 -> %x0
+aa040862 : orr x2, x3, x4, LSL #2                    : orr    %x3 %x4 lsl $0x02 -> %x2
+aa0610a4 : orr x4, x5, x6, LSL #4                    : orr    %x5 %x6 lsl $0x04 -> %x4
+aa0818e6 : orr x6, x7, x8, LSL #6                    : orr    %x7 %x8 lsl $0x06 -> %x6
+aa0a2128 : orr x8, x9, x10, LSL #8                   : orr    %x9 %x10 lsl $0x08 -> %x8
+aa0b2949 : orr x9, x10, x11, LSL #10                 : orr    %x10 %x11 lsl $0x0a -> %x9
+aa0d318b : orr x11, x12, x13, LSL #12                : orr    %x12 %x13 lsl $0x0c -> %x11
+aa0f39cd : orr x13, x14, x15, LSL #14                : orr    %x14 %x15 lsl $0x0e -> %x13
+aa11420f : orr x15, x16, x17, LSL #16                : orr    %x16 %x17 lsl $0x10 -> %x15
+aa134651 : orr x17, x18, x19, LSL #17                : orr    %x18 %x19 lsl $0x11 -> %x17
+aa154e93 : orr x19, x20, x21, LSL #19                : orr    %x20 %x21 lsl $0x13 -> %x19
+aa1756d5 : orr x21, x22, x23, LSL #21                : orr    %x22 %x23 lsl $0x15 -> %x21
+aa185ef6 : orr x22, x23, x24, LSL #23                : orr    %x23 %x24 lsl $0x17 -> %x22
+aa1a6738 : orr x24, x25, x26, LSL #25                : orr    %x25 %x26 lsl $0x19 -> %x24
+aa1c6f7a : orr x26, x27, x28, LSL #27                : orr    %x27 %x28 lsl $0x1b -> %x26
+aa017c1e : orr x30, x0, x1, LSL #31                  : orr    %x0 %x1 lsl $0x1f -> %x30
+aa420020 : orr x0, x1, x2, LSR #0                    : orr    %x1 %x2 lsr $0x00 -> %x0
+aa440862 : orr x2, x3, x4, LSR #2                    : orr    %x3 %x4 lsr $0x02 -> %x2
+aa4610a4 : orr x4, x5, x6, LSR #4                    : orr    %x5 %x6 lsr $0x04 -> %x4
+aa4818e6 : orr x6, x7, x8, LSR #6                    : orr    %x7 %x8 lsr $0x06 -> %x6
+aa4a2128 : orr x8, x9, x10, LSR #8                   : orr    %x9 %x10 lsr $0x08 -> %x8
+aa4b2949 : orr x9, x10, x11, LSR #10                 : orr    %x10 %x11 lsr $0x0a -> %x9
+aa4d318b : orr x11, x12, x13, LSR #12                : orr    %x12 %x13 lsr $0x0c -> %x11
+aa4f39cd : orr x13, x14, x15, LSR #14                : orr    %x14 %x15 lsr $0x0e -> %x13
+aa51420f : orr x15, x16, x17, LSR #16                : orr    %x16 %x17 lsr $0x10 -> %x15
+aa534651 : orr x17, x18, x19, LSR #17                : orr    %x18 %x19 lsr $0x11 -> %x17
+aa554e93 : orr x19, x20, x21, LSR #19                : orr    %x20 %x21 lsr $0x13 -> %x19
+aa5756d5 : orr x21, x22, x23, LSR #21                : orr    %x22 %x23 lsr $0x15 -> %x21
+aa585ef6 : orr x22, x23, x24, LSR #23                : orr    %x23 %x24 lsr $0x17 -> %x22
+aa5a6738 : orr x24, x25, x26, LSR #25                : orr    %x25 %x26 lsr $0x19 -> %x24
+aa5c6f7a : orr x26, x27, x28, LSR #27                : orr    %x27 %x28 lsr $0x1b -> %x26
+aa417c1e : orr x30, x0, x1, LSR #31                  : orr    %x0 %x1 lsr $0x1f -> %x30
+aa820020 : orr x0, x1, x2, ASR #0                    : orr    %x1 %x2 asr $0x00 -> %x0
+aa840862 : orr x2, x3, x4, ASR #2                    : orr    %x3 %x4 asr $0x02 -> %x2
+aa8610a4 : orr x4, x5, x6, ASR #4                    : orr    %x5 %x6 asr $0x04 -> %x4
+aa8818e6 : orr x6, x7, x8, ASR #6                    : orr    %x7 %x8 asr $0x06 -> %x6
+aa8a2128 : orr x8, x9, x10, ASR #8                   : orr    %x9 %x10 asr $0x08 -> %x8
+aa8b2949 : orr x9, x10, x11, ASR #10                 : orr    %x10 %x11 asr $0x0a -> %x9
+aa8d318b : orr x11, x12, x13, ASR #12                : orr    %x12 %x13 asr $0x0c -> %x11
+aa8f39cd : orr x13, x14, x15, ASR #14                : orr    %x14 %x15 asr $0x0e -> %x13
+aa91420f : orr x15, x16, x17, ASR #16                : orr    %x16 %x17 asr $0x10 -> %x15
+aa934651 : orr x17, x18, x19, ASR #17                : orr    %x18 %x19 asr $0x11 -> %x17
+aa954e93 : orr x19, x20, x21, ASR #19                : orr    %x20 %x21 asr $0x13 -> %x19
+aa9756d5 : orr x21, x22, x23, ASR #21                : orr    %x22 %x23 asr $0x15 -> %x21
+aa985ef6 : orr x22, x23, x24, ASR #23                : orr    %x23 %x24 asr $0x17 -> %x22
+aa9a6738 : orr x24, x25, x26, ASR #25                : orr    %x25 %x26 asr $0x19 -> %x24
+aa9c6f7a : orr x26, x27, x28, ASR #27                : orr    %x27 %x28 asr $0x1b -> %x26
+aa817c1e : orr x30, x0, x1, ASR #31                  : orr    %x0 %x1 asr $0x1f -> %x30
+aac20020 : orr x0, x1, x2, ROR #0                    : orr    %x1 %x2 ror $0x00 -> %x0
+aac40862 : orr x2, x3, x4, ROR #2                    : orr    %x3 %x4 ror $0x02 -> %x2
+aac610a4 : orr x4, x5, x6, ROR #4                    : orr    %x5 %x6 ror $0x04 -> %x4
+aac818e6 : orr x6, x7, x8, ROR #6                    : orr    %x7 %x8 ror $0x06 -> %x6
+aaca2128 : orr x8, x9, x10, ROR #8                   : orr    %x9 %x10 ror $0x08 -> %x8
+aacb2949 : orr x9, x10, x11, ROR #10                 : orr    %x10 %x11 ror $0x0a -> %x9
+aacd318b : orr x11, x12, x13, ROR #12                : orr    %x12 %x13 ror $0x0c -> %x11
+aacf39cd : orr x13, x14, x15, ROR #14                : orr    %x14 %x15 ror $0x0e -> %x13
+aad1420f : orr x15, x16, x17, ROR #16                : orr    %x16 %x17 ror $0x10 -> %x15
+aad34651 : orr x17, x18, x19, ROR #17                : orr    %x18 %x19 ror $0x11 -> %x17
+aad54e93 : orr x19, x20, x21, ROR #19                : orr    %x20 %x21 ror $0x13 -> %x19
+aad756d5 : orr x21, x22, x23, ROR #21                : orr    %x22 %x23 ror $0x15 -> %x21
+aad85ef6 : orr x22, x23, x24, ROR #23                : orr    %x23 %x24 ror $0x17 -> %x22
+aada6738 : orr x24, x25, x26, ROR #25                : orr    %x25 %x26 ror $0x19 -> %x24
+aadc6f7a : orr x26, x27, x28, ROR #27                : orr    %x27 %x28 ror $0x1b -> %x26
+aac17c1e : orr x30, x0, x1, ROR #31                  : orr    %x0 %x1 ror $0x1f -> %x30
+
+# MSUB    <Wd>, <Wn>, <Wm>, <Wa> (MSUB-R.RRR-32A_dp_3src)
+1b028c20 : msub w0, w1, w2, w3                       : msub   %w1 %w2 %w3 -> %w0
+1b049462 : msub w2, w3, w4, w5                       : msub   %w3 %w4 %w5 -> %w2
+1b069ca4 : msub w4, w5, w6, w7                       : msub   %w5 %w6 %w7 -> %w4
+1b08a4e6 : msub w6, w7, w8, w9                       : msub   %w7 %w8 %w9 -> %w6
+1b0aad28 : msub w8, w9, w10, w11                     : msub   %w9 %w10 %w11 -> %w8
+1b0bb149 : msub w9, w10, w11, w12                    : msub   %w10 %w11 %w12 -> %w9
+1b0db98b : msub w11, w12, w13, w14                   : msub   %w12 %w13 %w14 -> %w11
+1b0fc1cd : msub w13, w14, w15, w16                   : msub   %w14 %w15 %w16 -> %w13
+1b11ca0f : msub w15, w16, w17, w18                   : msub   %w16 %w17 %w18 -> %w15
+1b13d251 : msub w17, w18, w19, w20                   : msub   %w18 %w19 %w20 -> %w17
+1b15da93 : msub w19, w20, w21, w22                   : msub   %w20 %w21 %w22 -> %w19
+1b17e2d5 : msub w21, w22, w23, w24                   : msub   %w22 %w23 %w24 -> %w21
+1b18e6f6 : msub w22, w23, w24, w25                   : msub   %w23 %w24 %w25 -> %w22
+1b1aef38 : msub w24, w25, w26, w27                   : msub   %w25 %w26 %w27 -> %w24
+1b1cf77a : msub w26, w27, w28, w29                   : msub   %w27 %w28 %w29 -> %w26
+1b01881e : msub w30, w0, w1, w2                      : msub   %w0 %w1 %w2 -> %w30
+
+# BICS    <Xd>, <Xn>, <Xm>, <extend> #<imm> (BICS-R.RRI-64_log_shift)
+ea220020 : bics x0, x1, x2, LSL #0                   : bics   %x1 %x2 lsl $0x00 -> %x0
+ea240862 : bics x2, x3, x4, LSL #2                   : bics   %x3 %x4 lsl $0x02 -> %x2
+ea2610a4 : bics x4, x5, x6, LSL #4                   : bics   %x5 %x6 lsl $0x04 -> %x4
+ea2818e6 : bics x6, x7, x8, LSL #6                   : bics   %x7 %x8 lsl $0x06 -> %x6
+ea2a2128 : bics x8, x9, x10, LSL #8                  : bics   %x9 %x10 lsl $0x08 -> %x8
+ea2b2949 : bics x9, x10, x11, LSL #10                : bics   %x10 %x11 lsl $0x0a -> %x9
+ea2d318b : bics x11, x12, x13, LSL #12               : bics   %x12 %x13 lsl $0x0c -> %x11
+ea2f39cd : bics x13, x14, x15, LSL #14               : bics   %x14 %x15 lsl $0x0e -> %x13
+ea31420f : bics x15, x16, x17, LSL #16               : bics   %x16 %x17 lsl $0x10 -> %x15
+ea334651 : bics x17, x18, x19, LSL #17               : bics   %x18 %x19 lsl $0x11 -> %x17
+ea354e93 : bics x19, x20, x21, LSL #19               : bics   %x20 %x21 lsl $0x13 -> %x19
+ea3756d5 : bics x21, x22, x23, LSL #21               : bics   %x22 %x23 lsl $0x15 -> %x21
+ea385ef6 : bics x22, x23, x24, LSL #23               : bics   %x23 %x24 lsl $0x17 -> %x22
+ea3a6738 : bics x24, x25, x26, LSL #25               : bics   %x25 %x26 lsl $0x19 -> %x24
+ea3c6f7a : bics x26, x27, x28, LSL #27               : bics   %x27 %x28 lsl $0x1b -> %x26
+ea217c1e : bics x30, x0, x1, LSL #31                 : bics   %x0 %x1 lsl $0x1f -> %x30
+ea620020 : bics x0, x1, x2, LSR #0                   : bics   %x1 %x2 lsr $0x00 -> %x0
+ea640862 : bics x2, x3, x4, LSR #2                   : bics   %x3 %x4 lsr $0x02 -> %x2
+ea6610a4 : bics x4, x5, x6, LSR #4                   : bics   %x5 %x6 lsr $0x04 -> %x4
+ea6818e6 : bics x6, x7, x8, LSR #6                   : bics   %x7 %x8 lsr $0x06 -> %x6
+ea6a2128 : bics x8, x9, x10, LSR #8                  : bics   %x9 %x10 lsr $0x08 -> %x8
+ea6b2949 : bics x9, x10, x11, LSR #10                : bics   %x10 %x11 lsr $0x0a -> %x9
+ea6d318b : bics x11, x12, x13, LSR #12               : bics   %x12 %x13 lsr $0x0c -> %x11
+ea6f39cd : bics x13, x14, x15, LSR #14               : bics   %x14 %x15 lsr $0x0e -> %x13
+ea71420f : bics x15, x16, x17, LSR #16               : bics   %x16 %x17 lsr $0x10 -> %x15
+ea734651 : bics x17, x18, x19, LSR #17               : bics   %x18 %x19 lsr $0x11 -> %x17
+ea754e93 : bics x19, x20, x21, LSR #19               : bics   %x20 %x21 lsr $0x13 -> %x19
+ea7756d5 : bics x21, x22, x23, LSR #21               : bics   %x22 %x23 lsr $0x15 -> %x21
+ea785ef6 : bics x22, x23, x24, LSR #23               : bics   %x23 %x24 lsr $0x17 -> %x22
+ea7a6738 : bics x24, x25, x26, LSR #25               : bics   %x25 %x26 lsr $0x19 -> %x24
+ea7c6f7a : bics x26, x27, x28, LSR #27               : bics   %x27 %x28 lsr $0x1b -> %x26
+ea617c1e : bics x30, x0, x1, LSR #31                 : bics   %x0 %x1 lsr $0x1f -> %x30
+eaa20020 : bics x0, x1, x2, ASR #0                   : bics   %x1 %x2 asr $0x00 -> %x0
+eaa40862 : bics x2, x3, x4, ASR #2                   : bics   %x3 %x4 asr $0x02 -> %x2
+eaa610a4 : bics x4, x5, x6, ASR #4                   : bics   %x5 %x6 asr $0x04 -> %x4
+eaa818e6 : bics x6, x7, x8, ASR #6                   : bics   %x7 %x8 asr $0x06 -> %x6
+eaaa2128 : bics x8, x9, x10, ASR #8                  : bics   %x9 %x10 asr $0x08 -> %x8
+eaab2949 : bics x9, x10, x11, ASR #10                : bics   %x10 %x11 asr $0x0a -> %x9
+eaad318b : bics x11, x12, x13, ASR #12               : bics   %x12 %x13 asr $0x0c -> %x11
+eaaf39cd : bics x13, x14, x15, ASR #14               : bics   %x14 %x15 asr $0x0e -> %x13
+eab1420f : bics x15, x16, x17, ASR #16               : bics   %x16 %x17 asr $0x10 -> %x15
+eab34651 : bics x17, x18, x19, ASR #17               : bics   %x18 %x19 asr $0x11 -> %x17
+eab54e93 : bics x19, x20, x21, ASR #19               : bics   %x20 %x21 asr $0x13 -> %x19
+eab756d5 : bics x21, x22, x23, ASR #21               : bics   %x22 %x23 asr $0x15 -> %x21
+eab85ef6 : bics x22, x23, x24, ASR #23               : bics   %x23 %x24 asr $0x17 -> %x22
+eaba6738 : bics x24, x25, x26, ASR #25               : bics   %x25 %x26 asr $0x19 -> %x24
+eabc6f7a : bics x26, x27, x28, ASR #27               : bics   %x27 %x28 asr $0x1b -> %x26
+eaa17c1e : bics x30, x0, x1, ASR #31                 : bics   %x0 %x1 asr $0x1f -> %x30
+eae20020 : bics x0, x1, x2, ROR #0                   : bics   %x1 %x2 ror $0x00 -> %x0
+eae40862 : bics x2, x3, x4, ROR #2                   : bics   %x3 %x4 ror $0x02 -> %x2
+eae610a4 : bics x4, x5, x6, ROR #4                   : bics   %x5 %x6 ror $0x04 -> %x4
+eae818e6 : bics x6, x7, x8, ROR #6                   : bics   %x7 %x8 ror $0x06 -> %x6
+eaea2128 : bics x8, x9, x10, ROR #8                  : bics   %x9 %x10 ror $0x08 -> %x8
+eaeb2949 : bics x9, x10, x11, ROR #10                : bics   %x10 %x11 ror $0x0a -> %x9
+eaed318b : bics x11, x12, x13, ROR #12               : bics   %x12 %x13 ror $0x0c -> %x11
+eaef39cd : bics x13, x14, x15, ROR #14               : bics   %x14 %x15 ror $0x0e -> %x13
+eaf1420f : bics x15, x16, x17, ROR #16               : bics   %x16 %x17 ror $0x10 -> %x15
+eaf34651 : bics x17, x18, x19, ROR #17               : bics   %x18 %x19 ror $0x11 -> %x17
+eaf54e93 : bics x19, x20, x21, ROR #19               : bics   %x20 %x21 ror $0x13 -> %x19
+eaf756d5 : bics x21, x22, x23, ROR #21               : bics   %x22 %x23 ror $0x15 -> %x21
+eaf85ef6 : bics x22, x23, x24, ROR #23               : bics   %x23 %x24 ror $0x17 -> %x22
+eafa6738 : bics x24, x25, x26, ROR #25               : bics   %x25 %x26 ror $0x19 -> %x24
+eafc6f7a : bics x26, x27, x28, ROR #27               : bics   %x27 %x28 ror $0x1b -> %x26
+eae17c1e : bics x30, x0, x1, ROR #31                 : bics   %x0 %x1 ror $0x1f -> %x30
+
+# SBFM    <Wd>, <Wn>, #<imm1>, #<imm2> (SBFM-R.RII-32M_bitfield)
+13000020 : sbfm w0, w1, #0x0, #0x0                   : sbfm   %w1 $0x00 $0x00 -> %w0
+13020862 : sbfm w2, w3, #0x2, #0x2                   : sbfm   %w3 $0x02 $0x02 -> %w2
+130410a4 : sbfm w4, w5, #0x4, #0x4                   : sbfm   %w5 $0x04 $0x04 -> %w4
+130618e6 : sbfm w6, w7, #0x6, #0x6                   : sbfm   %w7 $0x06 $0x06 -> %w6
+13082128 : sbfm w8, w9, #0x8, #0x8                   : sbfm   %w9 $0x08 $0x08 -> %w8
+130a2949 : sbfm w9, w10, #0xa, #0xa                  : sbfm   %w10 $0x0a $0x0a -> %w9
+130c318b : sbfm w11, w12, #0xc, #0xc                 : sbfm   %w12 $0x0c $0x0c -> %w11
+130e39cd : sbfm w13, w14, #0xe, #0xe                 : sbfm   %w14 $0x0e $0x0e -> %w13
+1310420f : sbfm w15, w16, #0x10, #0x10               : sbfm   %w16 $0x10 $0x10 -> %w15
+13114651 : sbfm w17, w18, #0x11, #0x11               : sbfm   %w18 $0x11 $0x11 -> %w17
+13134e93 : sbfm w19, w20, #0x13, #0x13               : sbfm   %w20 $0x13 $0x13 -> %w19
+131556d5 : sbfm w21, w22, #0x15, #0x15               : sbfm   %w22 $0x15 $0x15 -> %w21
+13175ef6 : sbfm w22, w23, #0x17, #0x17               : sbfm   %w23 $0x17 $0x17 -> %w22
+13196738 : sbfm w24, w25, #0x19, #0x19               : sbfm   %w25 $0x19 $0x19 -> %w24
+131b6f7a : sbfm w26, w27, #0x1b, #0x1b               : sbfm   %w27 $0x1b $0x1b -> %w26
+131f7c1e : sbfm w30, w0, #0x1f, #0x1f                : sbfm   %w0 $0x1f $0x1f -> %w30
+
+# SBCS    <Wd>, <Wn>, <Wm> (SBCS-R.RR-32_addsub_carry)
+7a020020 : sbcs w0, w1, w2                           : sbcs   %w1 %w2 -> %w0
+7a040062 : sbcs w2, w3, w4                           : sbcs   %w3 %w4 -> %w2
+7a0600a4 : sbcs w4, w5, w6                           : sbcs   %w5 %w6 -> %w4
+7a0800e6 : sbcs w6, w7, w8                           : sbcs   %w7 %w8 -> %w6
+7a0a0128 : sbcs w8, w9, w10                          : sbcs   %w9 %w10 -> %w8
+7a0b0149 : sbcs w9, w10, w11                         : sbcs   %w10 %w11 -> %w9
+7a0d018b : sbcs w11, w12, w13                        : sbcs   %w12 %w13 -> %w11
+7a0f01cd : sbcs w13, w14, w15                        : sbcs   %w14 %w15 -> %w13
+7a11020f : sbcs w15, w16, w17                        : sbcs   %w16 %w17 -> %w15
+7a130251 : sbcs w17, w18, w19                        : sbcs   %w18 %w19 -> %w17
+7a150293 : sbcs w19, w20, w21                        : sbcs   %w20 %w21 -> %w19
+7a1702d5 : sbcs w21, w22, w23                        : sbcs   %w22 %w23 -> %w21
+7a1802f6 : sbcs w22, w23, w24                        : sbcs   %w23 %w24 -> %w22
+7a1a0338 : sbcs w24, w25, w26                        : sbcs   %w25 %w26 -> %w24
+7a1c037a : sbcs w26, w27, w28                        : sbcs   %w27 %w28 -> %w26
+7a01001e : sbcs w30, w0, w1                          : sbcs   %w0 %w1 -> %w30
+
+# CCMP    <Wn>, #<imm1>, #<imm2>, <cond> (CCMP-R.II-32_condcmp_imm)
+7a400800 : ccmp w0, #0x0, #0x0, EQ                   : ccmp.eq %w0 $0x00 $0x00
+7a420841 : ccmp w2, #0x2, #0x1, EQ                   : ccmp.eq %w2 $0x02 $0x01
+7a440882 : ccmp w4, #0x4, #0x2, EQ                   : ccmp.eq %w4 $0x04 $0x02
+7a4608c3 : ccmp w6, #0x6, #0x3, EQ                   : ccmp.eq %w6 $0x06 $0x03
+7a480904 : ccmp w8, #0x8, #0x4, EQ                   : ccmp.eq %w8 $0x08 $0x04
+7a4a0925 : ccmp w9, #0xa, #0x5, EQ                   : ccmp.eq %w9 $0x0a $0x05
+7a4c0966 : ccmp w11, #0xc, #0x6, EQ                  : ccmp.eq %w11 $0x0c $0x06
+7a4e09a7 : ccmp w13, #0xe, #0x7, EQ                  : ccmp.eq %w13 $0x0e $0x07
+7a5009e8 : ccmp w15, #0x10, #0x8, EQ                 : ccmp.eq %w15 $0x10 $0x08
+7a510a28 : ccmp w17, #0x11, #0x8, EQ                 : ccmp.eq %w17 $0x11 $0x08
+7a530a69 : ccmp w19, #0x13, #0x9, EQ                 : ccmp.eq %w19 $0x13 $0x09
+7a550aaa : ccmp w21, #0x15, #0xa, EQ                 : ccmp.eq %w21 $0x15 $0x0a
+7a570acb : ccmp w22, #0x17, #0xb, EQ                 : ccmp.eq %w22 $0x17 $0x0b
+7a590b0c : ccmp w24, #0x19, #0xc, EQ                 : ccmp.eq %w24 $0x19 $0x0c
+7a5b0b4d : ccmp w26, #0x1b, #0xd, EQ                 : ccmp.eq %w26 $0x1b $0x0d
+7a5f0bcf : ccmp w30, #0x1f, #0xf, EQ                 : ccmp.eq %w30 $0x1f $0x0f
+7a401800 : ccmp w0, #0x0, #0x0, NE                   : ccmp.ne %w0 $0x00 $0x00
+7a421841 : ccmp w2, #0x2, #0x1, NE                   : ccmp.ne %w2 $0x02 $0x01
+7a441882 : ccmp w4, #0x4, #0x2, NE                   : ccmp.ne %w4 $0x04 $0x02
+7a4618c3 : ccmp w6, #0x6, #0x3, NE                   : ccmp.ne %w6 $0x06 $0x03
+7a481904 : ccmp w8, #0x8, #0x4, NE                   : ccmp.ne %w8 $0x08 $0x04
+7a4a1925 : ccmp w9, #0xa, #0x5, NE                   : ccmp.ne %w9 $0x0a $0x05
+7a4c1966 : ccmp w11, #0xc, #0x6, NE                  : ccmp.ne %w11 $0x0c $0x06
+7a4e19a7 : ccmp w13, #0xe, #0x7, NE                  : ccmp.ne %w13 $0x0e $0x07
+7a5019e8 : ccmp w15, #0x10, #0x8, NE                 : ccmp.ne %w15 $0x10 $0x08
+7a511a28 : ccmp w17, #0x11, #0x8, NE                 : ccmp.ne %w17 $0x11 $0x08
+7a531a69 : ccmp w19, #0x13, #0x9, NE                 : ccmp.ne %w19 $0x13 $0x09
+7a551aaa : ccmp w21, #0x15, #0xa, NE                 : ccmp.ne %w21 $0x15 $0x0a
+7a571acb : ccmp w22, #0x17, #0xb, NE                 : ccmp.ne %w22 $0x17 $0x0b
+7a591b0c : ccmp w24, #0x19, #0xc, NE                 : ccmp.ne %w24 $0x19 $0x0c
+7a5b1b4d : ccmp w26, #0x1b, #0xd, NE                 : ccmp.ne %w26 $0x1b $0x0d
+7a5f1bcf : ccmp w30, #0x1f, #0xf, NE                 : ccmp.ne %w30 $0x1f $0x0f
+7a402800 : ccmp w0, #0x0, #0x0, CS                   : ccmp.cs %w0 $0x00 $0x00
+7a422841 : ccmp w2, #0x2, #0x1, CS                   : ccmp.cs %w2 $0x02 $0x01
+7a442882 : ccmp w4, #0x4, #0x2, CS                   : ccmp.cs %w4 $0x04 $0x02
+7a4628c3 : ccmp w6, #0x6, #0x3, CS                   : ccmp.cs %w6 $0x06 $0x03
+7a482904 : ccmp w8, #0x8, #0x4, CS                   : ccmp.cs %w8 $0x08 $0x04
+7a4a2925 : ccmp w9, #0xa, #0x5, CS                   : ccmp.cs %w9 $0x0a $0x05
+7a4c2966 : ccmp w11, #0xc, #0x6, CS                  : ccmp.cs %w11 $0x0c $0x06
+7a4e29a7 : ccmp w13, #0xe, #0x7, CS                  : ccmp.cs %w13 $0x0e $0x07
+7a5029e8 : ccmp w15, #0x10, #0x8, CS                 : ccmp.cs %w15 $0x10 $0x08
+7a512a28 : ccmp w17, #0x11, #0x8, CS                 : ccmp.cs %w17 $0x11 $0x08
+7a532a69 : ccmp w19, #0x13, #0x9, CS                 : ccmp.cs %w19 $0x13 $0x09
+7a552aaa : ccmp w21, #0x15, #0xa, CS                 : ccmp.cs %w21 $0x15 $0x0a
+7a572acb : ccmp w22, #0x17, #0xb, CS                 : ccmp.cs %w22 $0x17 $0x0b
+7a592b0c : ccmp w24, #0x19, #0xc, CS                 : ccmp.cs %w24 $0x19 $0x0c
+7a5b2b4d : ccmp w26, #0x1b, #0xd, CS                 : ccmp.cs %w26 $0x1b $0x0d
+7a5f2bcf : ccmp w30, #0x1f, #0xf, CS                 : ccmp.cs %w30 $0x1f $0x0f
+7a403800 : ccmp w0, #0x0, #0x0, CC                   : ccmp.cc %w0 $0x00 $0x00
+7a423841 : ccmp w2, #0x2, #0x1, CC                   : ccmp.cc %w2 $0x02 $0x01
+7a443882 : ccmp w4, #0x4, #0x2, CC                   : ccmp.cc %w4 $0x04 $0x02
+7a4638c3 : ccmp w6, #0x6, #0x3, CC                   : ccmp.cc %w6 $0x06 $0x03
+7a483904 : ccmp w8, #0x8, #0x4, CC                   : ccmp.cc %w8 $0x08 $0x04
+7a4a3925 : ccmp w9, #0xa, #0x5, CC                   : ccmp.cc %w9 $0x0a $0x05
+7a4c3966 : ccmp w11, #0xc, #0x6, CC                  : ccmp.cc %w11 $0x0c $0x06
+7a4e39a7 : ccmp w13, #0xe, #0x7, CC                  : ccmp.cc %w13 $0x0e $0x07
+7a5039e8 : ccmp w15, #0x10, #0x8, CC                 : ccmp.cc %w15 $0x10 $0x08
+7a513a28 : ccmp w17, #0x11, #0x8, CC                 : ccmp.cc %w17 $0x11 $0x08
+7a533a69 : ccmp w19, #0x13, #0x9, CC                 : ccmp.cc %w19 $0x13 $0x09
+7a553aaa : ccmp w21, #0x15, #0xa, CC                 : ccmp.cc %w21 $0x15 $0x0a
+7a573acb : ccmp w22, #0x17, #0xb, CC                 : ccmp.cc %w22 $0x17 $0x0b
+7a593b0c : ccmp w24, #0x19, #0xc, CC                 : ccmp.cc %w24 $0x19 $0x0c
+7a5b3b4d : ccmp w26, #0x1b, #0xd, CC                 : ccmp.cc %w26 $0x1b $0x0d
+7a5f3bcf : ccmp w30, #0x1f, #0xf, CC                 : ccmp.cc %w30 $0x1f $0x0f
+7a404800 : ccmp w0, #0x0, #0x0, MI                   : ccmp.mi %w0 $0x00 $0x00
+7a424841 : ccmp w2, #0x2, #0x1, MI                   : ccmp.mi %w2 $0x02 $0x01
+7a444882 : ccmp w4, #0x4, #0x2, MI                   : ccmp.mi %w4 $0x04 $0x02
+7a4648c3 : ccmp w6, #0x6, #0x3, MI                   : ccmp.mi %w6 $0x06 $0x03
+7a484904 : ccmp w8, #0x8, #0x4, MI                   : ccmp.mi %w8 $0x08 $0x04
+7a4a4925 : ccmp w9, #0xa, #0x5, MI                   : ccmp.mi %w9 $0x0a $0x05
+7a4c4966 : ccmp w11, #0xc, #0x6, MI                  : ccmp.mi %w11 $0x0c $0x06
+7a4e49a7 : ccmp w13, #0xe, #0x7, MI                  : ccmp.mi %w13 $0x0e $0x07
+7a5049e8 : ccmp w15, #0x10, #0x8, MI                 : ccmp.mi %w15 $0x10 $0x08
+7a514a28 : ccmp w17, #0x11, #0x8, MI                 : ccmp.mi %w17 $0x11 $0x08
+7a534a69 : ccmp w19, #0x13, #0x9, MI                 : ccmp.mi %w19 $0x13 $0x09
+7a554aaa : ccmp w21, #0x15, #0xa, MI                 : ccmp.mi %w21 $0x15 $0x0a
+7a574acb : ccmp w22, #0x17, #0xb, MI                 : ccmp.mi %w22 $0x17 $0x0b
+7a594b0c : ccmp w24, #0x19, #0xc, MI                 : ccmp.mi %w24 $0x19 $0x0c
+7a5b4b4d : ccmp w26, #0x1b, #0xd, MI                 : ccmp.mi %w26 $0x1b $0x0d
+7a5f4bcf : ccmp w30, #0x1f, #0xf, MI                 : ccmp.mi %w30 $0x1f $0x0f
+7a405800 : ccmp w0, #0x0, #0x0, PL                   : ccmp.pl %w0 $0x00 $0x00
+7a425841 : ccmp w2, #0x2, #0x1, PL                   : ccmp.pl %w2 $0x02 $0x01
+7a445882 : ccmp w4, #0x4, #0x2, PL                   : ccmp.pl %w4 $0x04 $0x02
+7a4658c3 : ccmp w6, #0x6, #0x3, PL                   : ccmp.pl %w6 $0x06 $0x03
+7a485904 : ccmp w8, #0x8, #0x4, PL                   : ccmp.pl %w8 $0x08 $0x04
+7a4a5925 : ccmp w9, #0xa, #0x5, PL                   : ccmp.pl %w9 $0x0a $0x05
+7a4c5966 : ccmp w11, #0xc, #0x6, PL                  : ccmp.pl %w11 $0x0c $0x06
+7a4e59a7 : ccmp w13, #0xe, #0x7, PL                  : ccmp.pl %w13 $0x0e $0x07
+7a5059e8 : ccmp w15, #0x10, #0x8, PL                 : ccmp.pl %w15 $0x10 $0x08
+7a515a28 : ccmp w17, #0x11, #0x8, PL                 : ccmp.pl %w17 $0x11 $0x08
+7a535a69 : ccmp w19, #0x13, #0x9, PL                 : ccmp.pl %w19 $0x13 $0x09
+7a555aaa : ccmp w21, #0x15, #0xa, PL                 : ccmp.pl %w21 $0x15 $0x0a
+7a575acb : ccmp w22, #0x17, #0xb, PL                 : ccmp.pl %w22 $0x17 $0x0b
+7a595b0c : ccmp w24, #0x19, #0xc, PL                 : ccmp.pl %w24 $0x19 $0x0c
+7a5b5b4d : ccmp w26, #0x1b, #0xd, PL                 : ccmp.pl %w26 $0x1b $0x0d
+7a5f5bcf : ccmp w30, #0x1f, #0xf, PL                 : ccmp.pl %w30 $0x1f $0x0f
+7a406800 : ccmp w0, #0x0, #0x0, VS                   : ccmp.vs %w0 $0x00 $0x00
+7a426841 : ccmp w2, #0x2, #0x1, VS                   : ccmp.vs %w2 $0x02 $0x01
+7a446882 : ccmp w4, #0x4, #0x2, VS                   : ccmp.vs %w4 $0x04 $0x02
+7a4668c3 : ccmp w6, #0x6, #0x3, VS                   : ccmp.vs %w6 $0x06 $0x03
+7a486904 : ccmp w8, #0x8, #0x4, VS                   : ccmp.vs %w8 $0x08 $0x04
+7a4a6925 : ccmp w9, #0xa, #0x5, VS                   : ccmp.vs %w9 $0x0a $0x05
+7a4c6966 : ccmp w11, #0xc, #0x6, VS                  : ccmp.vs %w11 $0x0c $0x06
+7a4e69a7 : ccmp w13, #0xe, #0x7, VS                  : ccmp.vs %w13 $0x0e $0x07
+7a5069e8 : ccmp w15, #0x10, #0x8, VS                 : ccmp.vs %w15 $0x10 $0x08
+7a516a28 : ccmp w17, #0x11, #0x8, VS                 : ccmp.vs %w17 $0x11 $0x08
+7a536a69 : ccmp w19, #0x13, #0x9, VS                 : ccmp.vs %w19 $0x13 $0x09
+7a556aaa : ccmp w21, #0x15, #0xa, VS                 : ccmp.vs %w21 $0x15 $0x0a
+7a576acb : ccmp w22, #0x17, #0xb, VS                 : ccmp.vs %w22 $0x17 $0x0b
+7a596b0c : ccmp w24, #0x19, #0xc, VS                 : ccmp.vs %w24 $0x19 $0x0c
+7a5b6b4d : ccmp w26, #0x1b, #0xd, VS                 : ccmp.vs %w26 $0x1b $0x0d
+7a5f6bcf : ccmp w30, #0x1f, #0xf, VS                 : ccmp.vs %w30 $0x1f $0x0f
+7a407800 : ccmp w0, #0x0, #0x0, VC                   : ccmp.vc %w0 $0x00 $0x00
+7a427841 : ccmp w2, #0x2, #0x1, VC                   : ccmp.vc %w2 $0x02 $0x01
+7a447882 : ccmp w4, #0x4, #0x2, VC                   : ccmp.vc %w4 $0x04 $0x02
+7a4678c3 : ccmp w6, #0x6, #0x3, VC                   : ccmp.vc %w6 $0x06 $0x03
+7a487904 : ccmp w8, #0x8, #0x4, VC                   : ccmp.vc %w8 $0x08 $0x04
+7a4a7925 : ccmp w9, #0xa, #0x5, VC                   : ccmp.vc %w9 $0x0a $0x05
+7a4c7966 : ccmp w11, #0xc, #0x6, VC                  : ccmp.vc %w11 $0x0c $0x06
+7a4e79a7 : ccmp w13, #0xe, #0x7, VC                  : ccmp.vc %w13 $0x0e $0x07
+7a5079e8 : ccmp w15, #0x10, #0x8, VC                 : ccmp.vc %w15 $0x10 $0x08
+7a517a28 : ccmp w17, #0x11, #0x8, VC                 : ccmp.vc %w17 $0x11 $0x08
+7a537a69 : ccmp w19, #0x13, #0x9, VC                 : ccmp.vc %w19 $0x13 $0x09
+7a557aaa : ccmp w21, #0x15, #0xa, VC                 : ccmp.vc %w21 $0x15 $0x0a
+7a577acb : ccmp w22, #0x17, #0xb, VC                 : ccmp.vc %w22 $0x17 $0x0b
+7a597b0c : ccmp w24, #0x19, #0xc, VC                 : ccmp.vc %w24 $0x19 $0x0c
+7a5b7b4d : ccmp w26, #0x1b, #0xd, VC                 : ccmp.vc %w26 $0x1b $0x0d
+7a5f7bcf : ccmp w30, #0x1f, #0xf, VC                 : ccmp.vc %w30 $0x1f $0x0f
+7a408800 : ccmp w0, #0x0, #0x0, HI                   : ccmp.hi %w0 $0x00 $0x00
+7a428841 : ccmp w2, #0x2, #0x1, HI                   : ccmp.hi %w2 $0x02 $0x01
+7a448882 : ccmp w4, #0x4, #0x2, HI                   : ccmp.hi %w4 $0x04 $0x02
+7a4688c3 : ccmp w6, #0x6, #0x3, HI                   : ccmp.hi %w6 $0x06 $0x03
+7a488904 : ccmp w8, #0x8, #0x4, HI                   : ccmp.hi %w8 $0x08 $0x04
+7a4a8925 : ccmp w9, #0xa, #0x5, HI                   : ccmp.hi %w9 $0x0a $0x05
+7a4c8966 : ccmp w11, #0xc, #0x6, HI                  : ccmp.hi %w11 $0x0c $0x06
+7a4e89a7 : ccmp w13, #0xe, #0x7, HI                  : ccmp.hi %w13 $0x0e $0x07
+7a5089e8 : ccmp w15, #0x10, #0x8, HI                 : ccmp.hi %w15 $0x10 $0x08
+7a518a28 : ccmp w17, #0x11, #0x8, HI                 : ccmp.hi %w17 $0x11 $0x08
+7a538a69 : ccmp w19, #0x13, #0x9, HI                 : ccmp.hi %w19 $0x13 $0x09
+7a558aaa : ccmp w21, #0x15, #0xa, HI                 : ccmp.hi %w21 $0x15 $0x0a
+7a578acb : ccmp w22, #0x17, #0xb, HI                 : ccmp.hi %w22 $0x17 $0x0b
+7a598b0c : ccmp w24, #0x19, #0xc, HI                 : ccmp.hi %w24 $0x19 $0x0c
+7a5b8b4d : ccmp w26, #0x1b, #0xd, HI                 : ccmp.hi %w26 $0x1b $0x0d
+7a5f8bcf : ccmp w30, #0x1f, #0xf, HI                 : ccmp.hi %w30 $0x1f $0x0f
+7a409800 : ccmp w0, #0x0, #0x0, LS                   : ccmp.ls %w0 $0x00 $0x00
+7a429841 : ccmp w2, #0x2, #0x1, LS                   : ccmp.ls %w2 $0x02 $0x01
+7a449882 : ccmp w4, #0x4, #0x2, LS                   : ccmp.ls %w4 $0x04 $0x02
+7a4698c3 : ccmp w6, #0x6, #0x3, LS                   : ccmp.ls %w6 $0x06 $0x03
+7a489904 : ccmp w8, #0x8, #0x4, LS                   : ccmp.ls %w8 $0x08 $0x04
+7a4a9925 : ccmp w9, #0xa, #0x5, LS                   : ccmp.ls %w9 $0x0a $0x05
+7a4c9966 : ccmp w11, #0xc, #0x6, LS                  : ccmp.ls %w11 $0x0c $0x06
+7a4e99a7 : ccmp w13, #0xe, #0x7, LS                  : ccmp.ls %w13 $0x0e $0x07
+7a5099e8 : ccmp w15, #0x10, #0x8, LS                 : ccmp.ls %w15 $0x10 $0x08
+7a519a28 : ccmp w17, #0x11, #0x8, LS                 : ccmp.ls %w17 $0x11 $0x08
+7a539a69 : ccmp w19, #0x13, #0x9, LS                 : ccmp.ls %w19 $0x13 $0x09
+7a559aaa : ccmp w21, #0x15, #0xa, LS                 : ccmp.ls %w21 $0x15 $0x0a
+7a579acb : ccmp w22, #0x17, #0xb, LS                 : ccmp.ls %w22 $0x17 $0x0b
+7a599b0c : ccmp w24, #0x19, #0xc, LS                 : ccmp.ls %w24 $0x19 $0x0c
+7a5b9b4d : ccmp w26, #0x1b, #0xd, LS                 : ccmp.ls %w26 $0x1b $0x0d
+7a5f9bcf : ccmp w30, #0x1f, #0xf, LS                 : ccmp.ls %w30 $0x1f $0x0f
+7a40a800 : ccmp w0, #0x0, #0x0, GE                   : ccmp.ge %w0 $0x00 $0x00
+7a42a841 : ccmp w2, #0x2, #0x1, GE                   : ccmp.ge %w2 $0x02 $0x01
+7a44a882 : ccmp w4, #0x4, #0x2, GE                   : ccmp.ge %w4 $0x04 $0x02
+7a46a8c3 : ccmp w6, #0x6, #0x3, GE                   : ccmp.ge %w6 $0x06 $0x03
+7a48a904 : ccmp w8, #0x8, #0x4, GE                   : ccmp.ge %w8 $0x08 $0x04
+7a4aa925 : ccmp w9, #0xa, #0x5, GE                   : ccmp.ge %w9 $0x0a $0x05
+7a4ca966 : ccmp w11, #0xc, #0x6, GE                  : ccmp.ge %w11 $0x0c $0x06
+7a4ea9a7 : ccmp w13, #0xe, #0x7, GE                  : ccmp.ge %w13 $0x0e $0x07
+7a50a9e8 : ccmp w15, #0x10, #0x8, GE                 : ccmp.ge %w15 $0x10 $0x08
+7a51aa28 : ccmp w17, #0x11, #0x8, GE                 : ccmp.ge %w17 $0x11 $0x08
+7a53aa69 : ccmp w19, #0x13, #0x9, GE                 : ccmp.ge %w19 $0x13 $0x09
+7a55aaaa : ccmp w21, #0x15, #0xa, GE                 : ccmp.ge %w21 $0x15 $0x0a
+7a57aacb : ccmp w22, #0x17, #0xb, GE                 : ccmp.ge %w22 $0x17 $0x0b
+7a59ab0c : ccmp w24, #0x19, #0xc, GE                 : ccmp.ge %w24 $0x19 $0x0c
+7a5bab4d : ccmp w26, #0x1b, #0xd, GE                 : ccmp.ge %w26 $0x1b $0x0d
+7a5fabcf : ccmp w30, #0x1f, #0xf, GE                 : ccmp.ge %w30 $0x1f $0x0f
+7a40b800 : ccmp w0, #0x0, #0x0, LT                   : ccmp.lt %w0 $0x00 $0x00
+7a42b841 : ccmp w2, #0x2, #0x1, LT                   : ccmp.lt %w2 $0x02 $0x01
+7a44b882 : ccmp w4, #0x4, #0x2, LT                   : ccmp.lt %w4 $0x04 $0x02
+7a46b8c3 : ccmp w6, #0x6, #0x3, LT                   : ccmp.lt %w6 $0x06 $0x03
+7a48b904 : ccmp w8, #0x8, #0x4, LT                   : ccmp.lt %w8 $0x08 $0x04
+7a4ab925 : ccmp w9, #0xa, #0x5, LT                   : ccmp.lt %w9 $0x0a $0x05
+7a4cb966 : ccmp w11, #0xc, #0x6, LT                  : ccmp.lt %w11 $0x0c $0x06
+7a4eb9a7 : ccmp w13, #0xe, #0x7, LT                  : ccmp.lt %w13 $0x0e $0x07
+7a50b9e8 : ccmp w15, #0x10, #0x8, LT                 : ccmp.lt %w15 $0x10 $0x08
+7a51ba28 : ccmp w17, #0x11, #0x8, LT                 : ccmp.lt %w17 $0x11 $0x08
+7a53ba69 : ccmp w19, #0x13, #0x9, LT                 : ccmp.lt %w19 $0x13 $0x09
+7a55baaa : ccmp w21, #0x15, #0xa, LT                 : ccmp.lt %w21 $0x15 $0x0a
+7a57bacb : ccmp w22, #0x17, #0xb, LT                 : ccmp.lt %w22 $0x17 $0x0b
+7a59bb0c : ccmp w24, #0x19, #0xc, LT                 : ccmp.lt %w24 $0x19 $0x0c
+7a5bbb4d : ccmp w26, #0x1b, #0xd, LT                 : ccmp.lt %w26 $0x1b $0x0d
+7a5fbbcf : ccmp w30, #0x1f, #0xf, LT                 : ccmp.lt %w30 $0x1f $0x0f
+7a40c800 : ccmp w0, #0x0, #0x0, GT                   : ccmp.gt %w0 $0x00 $0x00
+7a42c841 : ccmp w2, #0x2, #0x1, GT                   : ccmp.gt %w2 $0x02 $0x01
+7a44c882 : ccmp w4, #0x4, #0x2, GT                   : ccmp.gt %w4 $0x04 $0x02
+7a46c8c3 : ccmp w6, #0x6, #0x3, GT                   : ccmp.gt %w6 $0x06 $0x03
+7a48c904 : ccmp w8, #0x8, #0x4, GT                   : ccmp.gt %w8 $0x08 $0x04
+7a4ac925 : ccmp w9, #0xa, #0x5, GT                   : ccmp.gt %w9 $0x0a $0x05
+7a4cc966 : ccmp w11, #0xc, #0x6, GT                  : ccmp.gt %w11 $0x0c $0x06
+7a4ec9a7 : ccmp w13, #0xe, #0x7, GT                  : ccmp.gt %w13 $0x0e $0x07
+7a50c9e8 : ccmp w15, #0x10, #0x8, GT                 : ccmp.gt %w15 $0x10 $0x08
+7a51ca28 : ccmp w17, #0x11, #0x8, GT                 : ccmp.gt %w17 $0x11 $0x08
+7a53ca69 : ccmp w19, #0x13, #0x9, GT                 : ccmp.gt %w19 $0x13 $0x09
+7a55caaa : ccmp w21, #0x15, #0xa, GT                 : ccmp.gt %w21 $0x15 $0x0a
+7a57cacb : ccmp w22, #0x17, #0xb, GT                 : ccmp.gt %w22 $0x17 $0x0b
+7a59cb0c : ccmp w24, #0x19, #0xc, GT                 : ccmp.gt %w24 $0x19 $0x0c
+7a5bcb4d : ccmp w26, #0x1b, #0xd, GT                 : ccmp.gt %w26 $0x1b $0x0d
+7a5fcbcf : ccmp w30, #0x1f, #0xf, GT                 : ccmp.gt %w30 $0x1f $0x0f
+7a40d800 : ccmp w0, #0x0, #0x0, LE                   : ccmp.le %w0 $0x00 $0x00
+7a42d841 : ccmp w2, #0x2, #0x1, LE                   : ccmp.le %w2 $0x02 $0x01
+7a44d882 : ccmp w4, #0x4, #0x2, LE                   : ccmp.le %w4 $0x04 $0x02
+7a46d8c3 : ccmp w6, #0x6, #0x3, LE                   : ccmp.le %w6 $0x06 $0x03
+7a48d904 : ccmp w8, #0x8, #0x4, LE                   : ccmp.le %w8 $0x08 $0x04
+7a4ad925 : ccmp w9, #0xa, #0x5, LE                   : ccmp.le %w9 $0x0a $0x05
+7a4cd966 : ccmp w11, #0xc, #0x6, LE                  : ccmp.le %w11 $0x0c $0x06
+7a4ed9a7 : ccmp w13, #0xe, #0x7, LE                  : ccmp.le %w13 $0x0e $0x07
+7a50d9e8 : ccmp w15, #0x10, #0x8, LE                 : ccmp.le %w15 $0x10 $0x08
+7a51da28 : ccmp w17, #0x11, #0x8, LE                 : ccmp.le %w17 $0x11 $0x08
+7a53da69 : ccmp w19, #0x13, #0x9, LE                 : ccmp.le %w19 $0x13 $0x09
+7a55daaa : ccmp w21, #0x15, #0xa, LE                 : ccmp.le %w21 $0x15 $0x0a
+7a57dacb : ccmp w22, #0x17, #0xb, LE                 : ccmp.le %w22 $0x17 $0x0b
+7a59db0c : ccmp w24, #0x19, #0xc, LE                 : ccmp.le %w24 $0x19 $0x0c
+7a5bdb4d : ccmp w26, #0x1b, #0xd, LE                 : ccmp.le %w26 $0x1b $0x0d
+7a5fdbcf : ccmp w30, #0x1f, #0xf, LE                 : ccmp.le %w30 $0x1f $0x0f
+7a40e800 : ccmp w0, #0x0, #0x0, AL                   : ccmp.al %w0 $0x00 $0x00
+7a42e841 : ccmp w2, #0x2, #0x1, AL                   : ccmp.al %w2 $0x02 $0x01
+7a44e882 : ccmp w4, #0x4, #0x2, AL                   : ccmp.al %w4 $0x04 $0x02
+7a46e8c3 : ccmp w6, #0x6, #0x3, AL                   : ccmp.al %w6 $0x06 $0x03
+7a48e904 : ccmp w8, #0x8, #0x4, AL                   : ccmp.al %w8 $0x08 $0x04
+7a4ae925 : ccmp w9, #0xa, #0x5, AL                   : ccmp.al %w9 $0x0a $0x05
+7a4ce966 : ccmp w11, #0xc, #0x6, AL                  : ccmp.al %w11 $0x0c $0x06
+7a4ee9a7 : ccmp w13, #0xe, #0x7, AL                  : ccmp.al %w13 $0x0e $0x07
+7a50e9e8 : ccmp w15, #0x10, #0x8, AL                 : ccmp.al %w15 $0x10 $0x08
+7a51ea28 : ccmp w17, #0x11, #0x8, AL                 : ccmp.al %w17 $0x11 $0x08
+7a53ea69 : ccmp w19, #0x13, #0x9, AL                 : ccmp.al %w19 $0x13 $0x09
+7a55eaaa : ccmp w21, #0x15, #0xa, AL                 : ccmp.al %w21 $0x15 $0x0a
+7a57eacb : ccmp w22, #0x17, #0xb, AL                 : ccmp.al %w22 $0x17 $0x0b
+7a59eb0c : ccmp w24, #0x19, #0xc, AL                 : ccmp.al %w24 $0x19 $0x0c
+7a5beb4d : ccmp w26, #0x1b, #0xd, AL                 : ccmp.al %w26 $0x1b $0x0d
+7a5febcf : ccmp w30, #0x1f, #0xf, AL                 : ccmp.al %w30 $0x1f $0x0f
+7a40f800 : ccmp w0, #0x0, #0x0, NV                   : ccmp.nv %w0 $0x00 $0x00
+7a42f841 : ccmp w2, #0x2, #0x1, NV                   : ccmp.nv %w2 $0x02 $0x01
+7a44f882 : ccmp w4, #0x4, #0x2, NV                   : ccmp.nv %w4 $0x04 $0x02
+7a46f8c3 : ccmp w6, #0x6, #0x3, NV                   : ccmp.nv %w6 $0x06 $0x03
+7a48f904 : ccmp w8, #0x8, #0x4, NV                   : ccmp.nv %w8 $0x08 $0x04
+7a4af925 : ccmp w9, #0xa, #0x5, NV                   : ccmp.nv %w9 $0x0a $0x05
+7a4cf966 : ccmp w11, #0xc, #0x6, NV                  : ccmp.nv %w11 $0x0c $0x06
+7a4ef9a7 : ccmp w13, #0xe, #0x7, NV                  : ccmp.nv %w13 $0x0e $0x07
+7a50f9e8 : ccmp w15, #0x10, #0x8, NV                 : ccmp.nv %w15 $0x10 $0x08
+7a51fa28 : ccmp w17, #0x11, #0x8, NV                 : ccmp.nv %w17 $0x11 $0x08
+7a53fa69 : ccmp w19, #0x13, #0x9, NV                 : ccmp.nv %w19 $0x13 $0x09
+7a55faaa : ccmp w21, #0x15, #0xa, NV                 : ccmp.nv %w21 $0x15 $0x0a
+7a57facb : ccmp w22, #0x17, #0xb, NV                 : ccmp.nv %w22 $0x17 $0x0b
+7a59fb0c : ccmp w24, #0x19, #0xc, NV                 : ccmp.nv %w24 $0x19 $0x0c
+7a5bfb4d : ccmp w26, #0x1b, #0xd, NV                 : ccmp.nv %w26 $0x1b $0x0d
+7a5ffbcf : ccmp w30, #0x1f, #0xf, NV                 : ccmp.nv %w30 $0x1f $0x0f
+
+# CCMN    <Xn>, #<imm1>, #<imm2>, <cond> (CCMN-R.II-64_condcmp_imm)
+ba400800 : ccmn x0, #0x0, #0x0, EQ                   : ccmn.eq %x0 $0x00 $0x00
+ba420841 : ccmn x2, #0x2, #0x1, EQ                   : ccmn.eq %x2 $0x02 $0x01
+ba440882 : ccmn x4, #0x4, #0x2, EQ                   : ccmn.eq %x4 $0x04 $0x02
+ba4608c3 : ccmn x6, #0x6, #0x3, EQ                   : ccmn.eq %x6 $0x06 $0x03
+ba480904 : ccmn x8, #0x8, #0x4, EQ                   : ccmn.eq %x8 $0x08 $0x04
+ba4a0925 : ccmn x9, #0xa, #0x5, EQ                   : ccmn.eq %x9 $0x0a $0x05
+ba4c0966 : ccmn x11, #0xc, #0x6, EQ                  : ccmn.eq %x11 $0x0c $0x06
+ba4e09a7 : ccmn x13, #0xe, #0x7, EQ                  : ccmn.eq %x13 $0x0e $0x07
+ba5009e8 : ccmn x15, #0x10, #0x8, EQ                 : ccmn.eq %x15 $0x10 $0x08
+ba510a28 : ccmn x17, #0x11, #0x8, EQ                 : ccmn.eq %x17 $0x11 $0x08
+ba530a69 : ccmn x19, #0x13, #0x9, EQ                 : ccmn.eq %x19 $0x13 $0x09
+ba550aaa : ccmn x21, #0x15, #0xa, EQ                 : ccmn.eq %x21 $0x15 $0x0a
+ba570acb : ccmn x22, #0x17, #0xb, EQ                 : ccmn.eq %x22 $0x17 $0x0b
+ba590b0c : ccmn x24, #0x19, #0xc, EQ                 : ccmn.eq %x24 $0x19 $0x0c
+ba5b0b4d : ccmn x26, #0x1b, #0xd, EQ                 : ccmn.eq %x26 $0x1b $0x0d
+ba5f0bcf : ccmn x30, #0x1f, #0xf, EQ                 : ccmn.eq %x30 $0x1f $0x0f
+ba401800 : ccmn x0, #0x0, #0x0, NE                   : ccmn.ne %x0 $0x00 $0x00
+ba421841 : ccmn x2, #0x2, #0x1, NE                   : ccmn.ne %x2 $0x02 $0x01
+ba441882 : ccmn x4, #0x4, #0x2, NE                   : ccmn.ne %x4 $0x04 $0x02
+ba4618c3 : ccmn x6, #0x6, #0x3, NE                   : ccmn.ne %x6 $0x06 $0x03
+ba481904 : ccmn x8, #0x8, #0x4, NE                   : ccmn.ne %x8 $0x08 $0x04
+ba4a1925 : ccmn x9, #0xa, #0x5, NE                   : ccmn.ne %x9 $0x0a $0x05
+ba4c1966 : ccmn x11, #0xc, #0x6, NE                  : ccmn.ne %x11 $0x0c $0x06
+ba4e19a7 : ccmn x13, #0xe, #0x7, NE                  : ccmn.ne %x13 $0x0e $0x07
+ba5019e8 : ccmn x15, #0x10, #0x8, NE                 : ccmn.ne %x15 $0x10 $0x08
+ba511a28 : ccmn x17, #0x11, #0x8, NE                 : ccmn.ne %x17 $0x11 $0x08
+ba531a69 : ccmn x19, #0x13, #0x9, NE                 : ccmn.ne %x19 $0x13 $0x09
+ba551aaa : ccmn x21, #0x15, #0xa, NE                 : ccmn.ne %x21 $0x15 $0x0a
+ba571acb : ccmn x22, #0x17, #0xb, NE                 : ccmn.ne %x22 $0x17 $0x0b
+ba591b0c : ccmn x24, #0x19, #0xc, NE                 : ccmn.ne %x24 $0x19 $0x0c
+ba5b1b4d : ccmn x26, #0x1b, #0xd, NE                 : ccmn.ne %x26 $0x1b $0x0d
+ba5f1bcf : ccmn x30, #0x1f, #0xf, NE                 : ccmn.ne %x30 $0x1f $0x0f
+ba402800 : ccmn x0, #0x0, #0x0, CS                   : ccmn.cs %x0 $0x00 $0x00
+ba422841 : ccmn x2, #0x2, #0x1, CS                   : ccmn.cs %x2 $0x02 $0x01
+ba442882 : ccmn x4, #0x4, #0x2, CS                   : ccmn.cs %x4 $0x04 $0x02
+ba4628c3 : ccmn x6, #0x6, #0x3, CS                   : ccmn.cs %x6 $0x06 $0x03
+ba482904 : ccmn x8, #0x8, #0x4, CS                   : ccmn.cs %x8 $0x08 $0x04
+ba4a2925 : ccmn x9, #0xa, #0x5, CS                   : ccmn.cs %x9 $0x0a $0x05
+ba4c2966 : ccmn x11, #0xc, #0x6, CS                  : ccmn.cs %x11 $0x0c $0x06
+ba4e29a7 : ccmn x13, #0xe, #0x7, CS                  : ccmn.cs %x13 $0x0e $0x07
+ba5029e8 : ccmn x15, #0x10, #0x8, CS                 : ccmn.cs %x15 $0x10 $0x08
+ba512a28 : ccmn x17, #0x11, #0x8, CS                 : ccmn.cs %x17 $0x11 $0x08
+ba532a69 : ccmn x19, #0x13, #0x9, CS                 : ccmn.cs %x19 $0x13 $0x09
+ba552aaa : ccmn x21, #0x15, #0xa, CS                 : ccmn.cs %x21 $0x15 $0x0a
+ba572acb : ccmn x22, #0x17, #0xb, CS                 : ccmn.cs %x22 $0x17 $0x0b
+ba592b0c : ccmn x24, #0x19, #0xc, CS                 : ccmn.cs %x24 $0x19 $0x0c
+ba5b2b4d : ccmn x26, #0x1b, #0xd, CS                 : ccmn.cs %x26 $0x1b $0x0d
+ba5f2bcf : ccmn x30, #0x1f, #0xf, CS                 : ccmn.cs %x30 $0x1f $0x0f
+ba403800 : ccmn x0, #0x0, #0x0, CC                   : ccmn.cc %x0 $0x00 $0x00
+ba423841 : ccmn x2, #0x2, #0x1, CC                   : ccmn.cc %x2 $0x02 $0x01
+ba443882 : ccmn x4, #0x4, #0x2, CC                   : ccmn.cc %x4 $0x04 $0x02
+ba4638c3 : ccmn x6, #0x6, #0x3, CC                   : ccmn.cc %x6 $0x06 $0x03
+ba483904 : ccmn x8, #0x8, #0x4, CC                   : ccmn.cc %x8 $0x08 $0x04
+ba4a3925 : ccmn x9, #0xa, #0x5, CC                   : ccmn.cc %x9 $0x0a $0x05
+ba4c3966 : ccmn x11, #0xc, #0x6, CC                  : ccmn.cc %x11 $0x0c $0x06
+ba4e39a7 : ccmn x13, #0xe, #0x7, CC                  : ccmn.cc %x13 $0x0e $0x07
+ba5039e8 : ccmn x15, #0x10, #0x8, CC                 : ccmn.cc %x15 $0x10 $0x08
+ba513a28 : ccmn x17, #0x11, #0x8, CC                 : ccmn.cc %x17 $0x11 $0x08
+ba533a69 : ccmn x19, #0x13, #0x9, CC                 : ccmn.cc %x19 $0x13 $0x09
+ba553aaa : ccmn x21, #0x15, #0xa, CC                 : ccmn.cc %x21 $0x15 $0x0a
+ba573acb : ccmn x22, #0x17, #0xb, CC                 : ccmn.cc %x22 $0x17 $0x0b
+ba593b0c : ccmn x24, #0x19, #0xc, CC                 : ccmn.cc %x24 $0x19 $0x0c
+ba5b3b4d : ccmn x26, #0x1b, #0xd, CC                 : ccmn.cc %x26 $0x1b $0x0d
+ba5f3bcf : ccmn x30, #0x1f, #0xf, CC                 : ccmn.cc %x30 $0x1f $0x0f
+ba404800 : ccmn x0, #0x0, #0x0, MI                   : ccmn.mi %x0 $0x00 $0x00
+ba424841 : ccmn x2, #0x2, #0x1, MI                   : ccmn.mi %x2 $0x02 $0x01
+ba444882 : ccmn x4, #0x4, #0x2, MI                   : ccmn.mi %x4 $0x04 $0x02
+ba4648c3 : ccmn x6, #0x6, #0x3, MI                   : ccmn.mi %x6 $0x06 $0x03
+ba484904 : ccmn x8, #0x8, #0x4, MI                   : ccmn.mi %x8 $0x08 $0x04
+ba4a4925 : ccmn x9, #0xa, #0x5, MI                   : ccmn.mi %x9 $0x0a $0x05
+ba4c4966 : ccmn x11, #0xc, #0x6, MI                  : ccmn.mi %x11 $0x0c $0x06
+ba4e49a7 : ccmn x13, #0xe, #0x7, MI                  : ccmn.mi %x13 $0x0e $0x07
+ba5049e8 : ccmn x15, #0x10, #0x8, MI                 : ccmn.mi %x15 $0x10 $0x08
+ba514a28 : ccmn x17, #0x11, #0x8, MI                 : ccmn.mi %x17 $0x11 $0x08
+ba534a69 : ccmn x19, #0x13, #0x9, MI                 : ccmn.mi %x19 $0x13 $0x09
+ba554aaa : ccmn x21, #0x15, #0xa, MI                 : ccmn.mi %x21 $0x15 $0x0a
+ba574acb : ccmn x22, #0x17, #0xb, MI                 : ccmn.mi %x22 $0x17 $0x0b
+ba594b0c : ccmn x24, #0x19, #0xc, MI                 : ccmn.mi %x24 $0x19 $0x0c
+ba5b4b4d : ccmn x26, #0x1b, #0xd, MI                 : ccmn.mi %x26 $0x1b $0x0d
+ba5f4bcf : ccmn x30, #0x1f, #0xf, MI                 : ccmn.mi %x30 $0x1f $0x0f
+ba405800 : ccmn x0, #0x0, #0x0, PL                   : ccmn.pl %x0 $0x00 $0x00
+ba425841 : ccmn x2, #0x2, #0x1, PL                   : ccmn.pl %x2 $0x02 $0x01
+ba445882 : ccmn x4, #0x4, #0x2, PL                   : ccmn.pl %x4 $0x04 $0x02
+ba4658c3 : ccmn x6, #0x6, #0x3, PL                   : ccmn.pl %x6 $0x06 $0x03
+ba485904 : ccmn x8, #0x8, #0x4, PL                   : ccmn.pl %x8 $0x08 $0x04
+ba4a5925 : ccmn x9, #0xa, #0x5, PL                   : ccmn.pl %x9 $0x0a $0x05
+ba4c5966 : ccmn x11, #0xc, #0x6, PL                  : ccmn.pl %x11 $0x0c $0x06
+ba4e59a7 : ccmn x13, #0xe, #0x7, PL                  : ccmn.pl %x13 $0x0e $0x07
+ba5059e8 : ccmn x15, #0x10, #0x8, PL                 : ccmn.pl %x15 $0x10 $0x08
+ba515a28 : ccmn x17, #0x11, #0x8, PL                 : ccmn.pl %x17 $0x11 $0x08
+ba535a69 : ccmn x19, #0x13, #0x9, PL                 : ccmn.pl %x19 $0x13 $0x09
+ba555aaa : ccmn x21, #0x15, #0xa, PL                 : ccmn.pl %x21 $0x15 $0x0a
+ba575acb : ccmn x22, #0x17, #0xb, PL                 : ccmn.pl %x22 $0x17 $0x0b
+ba595b0c : ccmn x24, #0x19, #0xc, PL                 : ccmn.pl %x24 $0x19 $0x0c
+ba5b5b4d : ccmn x26, #0x1b, #0xd, PL                 : ccmn.pl %x26 $0x1b $0x0d
+ba5f5bcf : ccmn x30, #0x1f, #0xf, PL                 : ccmn.pl %x30 $0x1f $0x0f
+ba406800 : ccmn x0, #0x0, #0x0, VS                   : ccmn.vs %x0 $0x00 $0x00
+ba426841 : ccmn x2, #0x2, #0x1, VS                   : ccmn.vs %x2 $0x02 $0x01
+ba446882 : ccmn x4, #0x4, #0x2, VS                   : ccmn.vs %x4 $0x04 $0x02
+ba4668c3 : ccmn x6, #0x6, #0x3, VS                   : ccmn.vs %x6 $0x06 $0x03
+ba486904 : ccmn x8, #0x8, #0x4, VS                   : ccmn.vs %x8 $0x08 $0x04
+ba4a6925 : ccmn x9, #0xa, #0x5, VS                   : ccmn.vs %x9 $0x0a $0x05
+ba4c6966 : ccmn x11, #0xc, #0x6, VS                  : ccmn.vs %x11 $0x0c $0x06
+ba4e69a7 : ccmn x13, #0xe, #0x7, VS                  : ccmn.vs %x13 $0x0e $0x07
+ba5069e8 : ccmn x15, #0x10, #0x8, VS                 : ccmn.vs %x15 $0x10 $0x08
+ba516a28 : ccmn x17, #0x11, #0x8, VS                 : ccmn.vs %x17 $0x11 $0x08
+ba536a69 : ccmn x19, #0x13, #0x9, VS                 : ccmn.vs %x19 $0x13 $0x09
+ba556aaa : ccmn x21, #0x15, #0xa, VS                 : ccmn.vs %x21 $0x15 $0x0a
+ba576acb : ccmn x22, #0x17, #0xb, VS                 : ccmn.vs %x22 $0x17 $0x0b
+ba596b0c : ccmn x24, #0x19, #0xc, VS                 : ccmn.vs %x24 $0x19 $0x0c
+ba5b6b4d : ccmn x26, #0x1b, #0xd, VS                 : ccmn.vs %x26 $0x1b $0x0d
+ba5f6bcf : ccmn x30, #0x1f, #0xf, VS                 : ccmn.vs %x30 $0x1f $0x0f
+ba407800 : ccmn x0, #0x0, #0x0, VC                   : ccmn.vc %x0 $0x00 $0x00
+ba427841 : ccmn x2, #0x2, #0x1, VC                   : ccmn.vc %x2 $0x02 $0x01
+ba447882 : ccmn x4, #0x4, #0x2, VC                   : ccmn.vc %x4 $0x04 $0x02
+ba4678c3 : ccmn x6, #0x6, #0x3, VC                   : ccmn.vc %x6 $0x06 $0x03
+ba487904 : ccmn x8, #0x8, #0x4, VC                   : ccmn.vc %x8 $0x08 $0x04
+ba4a7925 : ccmn x9, #0xa, #0x5, VC                   : ccmn.vc %x9 $0x0a $0x05
+ba4c7966 : ccmn x11, #0xc, #0x6, VC                  : ccmn.vc %x11 $0x0c $0x06
+ba4e79a7 : ccmn x13, #0xe, #0x7, VC                  : ccmn.vc %x13 $0x0e $0x07
+ba5079e8 : ccmn x15, #0x10, #0x8, VC                 : ccmn.vc %x15 $0x10 $0x08
+ba517a28 : ccmn x17, #0x11, #0x8, VC                 : ccmn.vc %x17 $0x11 $0x08
+ba537a69 : ccmn x19, #0x13, #0x9, VC                 : ccmn.vc %x19 $0x13 $0x09
+ba557aaa : ccmn x21, #0x15, #0xa, VC                 : ccmn.vc %x21 $0x15 $0x0a
+ba577acb : ccmn x22, #0x17, #0xb, VC                 : ccmn.vc %x22 $0x17 $0x0b
+ba597b0c : ccmn x24, #0x19, #0xc, VC                 : ccmn.vc %x24 $0x19 $0x0c
+ba5b7b4d : ccmn x26, #0x1b, #0xd, VC                 : ccmn.vc %x26 $0x1b $0x0d
+ba5f7bcf : ccmn x30, #0x1f, #0xf, VC                 : ccmn.vc %x30 $0x1f $0x0f
+ba408800 : ccmn x0, #0x0, #0x0, HI                   : ccmn.hi %x0 $0x00 $0x00
+ba428841 : ccmn x2, #0x2, #0x1, HI                   : ccmn.hi %x2 $0x02 $0x01
+ba448882 : ccmn x4, #0x4, #0x2, HI                   : ccmn.hi %x4 $0x04 $0x02
+ba4688c3 : ccmn x6, #0x6, #0x3, HI                   : ccmn.hi %x6 $0x06 $0x03
+ba488904 : ccmn x8, #0x8, #0x4, HI                   : ccmn.hi %x8 $0x08 $0x04
+ba4a8925 : ccmn x9, #0xa, #0x5, HI                   : ccmn.hi %x9 $0x0a $0x05
+ba4c8966 : ccmn x11, #0xc, #0x6, HI                  : ccmn.hi %x11 $0x0c $0x06
+ba4e89a7 : ccmn x13, #0xe, #0x7, HI                  : ccmn.hi %x13 $0x0e $0x07
+ba5089e8 : ccmn x15, #0x10, #0x8, HI                 : ccmn.hi %x15 $0x10 $0x08
+ba518a28 : ccmn x17, #0x11, #0x8, HI                 : ccmn.hi %x17 $0x11 $0x08
+ba538a69 : ccmn x19, #0x13, #0x9, HI                 : ccmn.hi %x19 $0x13 $0x09
+ba558aaa : ccmn x21, #0x15, #0xa, HI                 : ccmn.hi %x21 $0x15 $0x0a
+ba578acb : ccmn x22, #0x17, #0xb, HI                 : ccmn.hi %x22 $0x17 $0x0b
+ba598b0c : ccmn x24, #0x19, #0xc, HI                 : ccmn.hi %x24 $0x19 $0x0c
+ba5b8b4d : ccmn x26, #0x1b, #0xd, HI                 : ccmn.hi %x26 $0x1b $0x0d
+ba5f8bcf : ccmn x30, #0x1f, #0xf, HI                 : ccmn.hi %x30 $0x1f $0x0f
+ba409800 : ccmn x0, #0x0, #0x0, LS                   : ccmn.ls %x0 $0x00 $0x00
+ba429841 : ccmn x2, #0x2, #0x1, LS                   : ccmn.ls %x2 $0x02 $0x01
+ba449882 : ccmn x4, #0x4, #0x2, LS                   : ccmn.ls %x4 $0x04 $0x02
+ba4698c3 : ccmn x6, #0x6, #0x3, LS                   : ccmn.ls %x6 $0x06 $0x03
+ba489904 : ccmn x8, #0x8, #0x4, LS                   : ccmn.ls %x8 $0x08 $0x04
+ba4a9925 : ccmn x9, #0xa, #0x5, LS                   : ccmn.ls %x9 $0x0a $0x05
+ba4c9966 : ccmn x11, #0xc, #0x6, LS                  : ccmn.ls %x11 $0x0c $0x06
+ba4e99a7 : ccmn x13, #0xe, #0x7, LS                  : ccmn.ls %x13 $0x0e $0x07
+ba5099e8 : ccmn x15, #0x10, #0x8, LS                 : ccmn.ls %x15 $0x10 $0x08
+ba519a28 : ccmn x17, #0x11, #0x8, LS                 : ccmn.ls %x17 $0x11 $0x08
+ba539a69 : ccmn x19, #0x13, #0x9, LS                 : ccmn.ls %x19 $0x13 $0x09
+ba559aaa : ccmn x21, #0x15, #0xa, LS                 : ccmn.ls %x21 $0x15 $0x0a
+ba579acb : ccmn x22, #0x17, #0xb, LS                 : ccmn.ls %x22 $0x17 $0x0b
+ba599b0c : ccmn x24, #0x19, #0xc, LS                 : ccmn.ls %x24 $0x19 $0x0c
+ba5b9b4d : ccmn x26, #0x1b, #0xd, LS                 : ccmn.ls %x26 $0x1b $0x0d
+ba5f9bcf : ccmn x30, #0x1f, #0xf, LS                 : ccmn.ls %x30 $0x1f $0x0f
+ba40a800 : ccmn x0, #0x0, #0x0, GE                   : ccmn.ge %x0 $0x00 $0x00
+ba42a841 : ccmn x2, #0x2, #0x1, GE                   : ccmn.ge %x2 $0x02 $0x01
+ba44a882 : ccmn x4, #0x4, #0x2, GE                   : ccmn.ge %x4 $0x04 $0x02
+ba46a8c3 : ccmn x6, #0x6, #0x3, GE                   : ccmn.ge %x6 $0x06 $0x03
+ba48a904 : ccmn x8, #0x8, #0x4, GE                   : ccmn.ge %x8 $0x08 $0x04
+ba4aa925 : ccmn x9, #0xa, #0x5, GE                   : ccmn.ge %x9 $0x0a $0x05
+ba4ca966 : ccmn x11, #0xc, #0x6, GE                  : ccmn.ge %x11 $0x0c $0x06
+ba4ea9a7 : ccmn x13, #0xe, #0x7, GE                  : ccmn.ge %x13 $0x0e $0x07
+ba50a9e8 : ccmn x15, #0x10, #0x8, GE                 : ccmn.ge %x15 $0x10 $0x08
+ba51aa28 : ccmn x17, #0x11, #0x8, GE                 : ccmn.ge %x17 $0x11 $0x08
+ba53aa69 : ccmn x19, #0x13, #0x9, GE                 : ccmn.ge %x19 $0x13 $0x09
+ba55aaaa : ccmn x21, #0x15, #0xa, GE                 : ccmn.ge %x21 $0x15 $0x0a
+ba57aacb : ccmn x22, #0x17, #0xb, GE                 : ccmn.ge %x22 $0x17 $0x0b
+ba59ab0c : ccmn x24, #0x19, #0xc, GE                 : ccmn.ge %x24 $0x19 $0x0c
+ba5bab4d : ccmn x26, #0x1b, #0xd, GE                 : ccmn.ge %x26 $0x1b $0x0d
+ba5fabcf : ccmn x30, #0x1f, #0xf, GE                 : ccmn.ge %x30 $0x1f $0x0f
+ba40b800 : ccmn x0, #0x0, #0x0, LT                   : ccmn.lt %x0 $0x00 $0x00
+ba42b841 : ccmn x2, #0x2, #0x1, LT                   : ccmn.lt %x2 $0x02 $0x01
+ba44b882 : ccmn x4, #0x4, #0x2, LT                   : ccmn.lt %x4 $0x04 $0x02
+ba46b8c3 : ccmn x6, #0x6, #0x3, LT                   : ccmn.lt %x6 $0x06 $0x03
+ba48b904 : ccmn x8, #0x8, #0x4, LT                   : ccmn.lt %x8 $0x08 $0x04
+ba4ab925 : ccmn x9, #0xa, #0x5, LT                   : ccmn.lt %x9 $0x0a $0x05
+ba4cb966 : ccmn x11, #0xc, #0x6, LT                  : ccmn.lt %x11 $0x0c $0x06
+ba4eb9a7 : ccmn x13, #0xe, #0x7, LT                  : ccmn.lt %x13 $0x0e $0x07
+ba50b9e8 : ccmn x15, #0x10, #0x8, LT                 : ccmn.lt %x15 $0x10 $0x08
+ba51ba28 : ccmn x17, #0x11, #0x8, LT                 : ccmn.lt %x17 $0x11 $0x08
+ba53ba69 : ccmn x19, #0x13, #0x9, LT                 : ccmn.lt %x19 $0x13 $0x09
+ba55baaa : ccmn x21, #0x15, #0xa, LT                 : ccmn.lt %x21 $0x15 $0x0a
+ba57bacb : ccmn x22, #0x17, #0xb, LT                 : ccmn.lt %x22 $0x17 $0x0b
+ba59bb0c : ccmn x24, #0x19, #0xc, LT                 : ccmn.lt %x24 $0x19 $0x0c
+ba5bbb4d : ccmn x26, #0x1b, #0xd, LT                 : ccmn.lt %x26 $0x1b $0x0d
+ba5fbbcf : ccmn x30, #0x1f, #0xf, LT                 : ccmn.lt %x30 $0x1f $0x0f
+ba40c800 : ccmn x0, #0x0, #0x0, GT                   : ccmn.gt %x0 $0x00 $0x00
+ba42c841 : ccmn x2, #0x2, #0x1, GT                   : ccmn.gt %x2 $0x02 $0x01
+ba44c882 : ccmn x4, #0x4, #0x2, GT                   : ccmn.gt %x4 $0x04 $0x02
+ba46c8c3 : ccmn x6, #0x6, #0x3, GT                   : ccmn.gt %x6 $0x06 $0x03
+ba48c904 : ccmn x8, #0x8, #0x4, GT                   : ccmn.gt %x8 $0x08 $0x04
+ba4ac925 : ccmn x9, #0xa, #0x5, GT                   : ccmn.gt %x9 $0x0a $0x05
+ba4cc966 : ccmn x11, #0xc, #0x6, GT                  : ccmn.gt %x11 $0x0c $0x06
+ba4ec9a7 : ccmn x13, #0xe, #0x7, GT                  : ccmn.gt %x13 $0x0e $0x07
+ba50c9e8 : ccmn x15, #0x10, #0x8, GT                 : ccmn.gt %x15 $0x10 $0x08
+ba51ca28 : ccmn x17, #0x11, #0x8, GT                 : ccmn.gt %x17 $0x11 $0x08
+ba53ca69 : ccmn x19, #0x13, #0x9, GT                 : ccmn.gt %x19 $0x13 $0x09
+ba55caaa : ccmn x21, #0x15, #0xa, GT                 : ccmn.gt %x21 $0x15 $0x0a
+ba57cacb : ccmn x22, #0x17, #0xb, GT                 : ccmn.gt %x22 $0x17 $0x0b
+ba59cb0c : ccmn x24, #0x19, #0xc, GT                 : ccmn.gt %x24 $0x19 $0x0c
+ba5bcb4d : ccmn x26, #0x1b, #0xd, GT                 : ccmn.gt %x26 $0x1b $0x0d
+ba5fcbcf : ccmn x30, #0x1f, #0xf, GT                 : ccmn.gt %x30 $0x1f $0x0f
+ba40d800 : ccmn x0, #0x0, #0x0, LE                   : ccmn.le %x0 $0x00 $0x00
+ba42d841 : ccmn x2, #0x2, #0x1, LE                   : ccmn.le %x2 $0x02 $0x01
+ba44d882 : ccmn x4, #0x4, #0x2, LE                   : ccmn.le %x4 $0x04 $0x02
+ba46d8c3 : ccmn x6, #0x6, #0x3, LE                   : ccmn.le %x6 $0x06 $0x03
+ba48d904 : ccmn x8, #0x8, #0x4, LE                   : ccmn.le %x8 $0x08 $0x04
+ba4ad925 : ccmn x9, #0xa, #0x5, LE                   : ccmn.le %x9 $0x0a $0x05
+ba4cd966 : ccmn x11, #0xc, #0x6, LE                  : ccmn.le %x11 $0x0c $0x06
+ba4ed9a7 : ccmn x13, #0xe, #0x7, LE                  : ccmn.le %x13 $0x0e $0x07
+ba50d9e8 : ccmn x15, #0x10, #0x8, LE                 : ccmn.le %x15 $0x10 $0x08
+ba51da28 : ccmn x17, #0x11, #0x8, LE                 : ccmn.le %x17 $0x11 $0x08
+ba53da69 : ccmn x19, #0x13, #0x9, LE                 : ccmn.le %x19 $0x13 $0x09
+ba55daaa : ccmn x21, #0x15, #0xa, LE                 : ccmn.le %x21 $0x15 $0x0a
+ba57dacb : ccmn x22, #0x17, #0xb, LE                 : ccmn.le %x22 $0x17 $0x0b
+ba59db0c : ccmn x24, #0x19, #0xc, LE                 : ccmn.le %x24 $0x19 $0x0c
+ba5bdb4d : ccmn x26, #0x1b, #0xd, LE                 : ccmn.le %x26 $0x1b $0x0d
+ba5fdbcf : ccmn x30, #0x1f, #0xf, LE                 : ccmn.le %x30 $0x1f $0x0f
+ba40e800 : ccmn x0, #0x0, #0x0, AL                   : ccmn.al %x0 $0x00 $0x00
+ba42e841 : ccmn x2, #0x2, #0x1, AL                   : ccmn.al %x2 $0x02 $0x01
+ba44e882 : ccmn x4, #0x4, #0x2, AL                   : ccmn.al %x4 $0x04 $0x02
+ba46e8c3 : ccmn x6, #0x6, #0x3, AL                   : ccmn.al %x6 $0x06 $0x03
+ba48e904 : ccmn x8, #0x8, #0x4, AL                   : ccmn.al %x8 $0x08 $0x04
+ba4ae925 : ccmn x9, #0xa, #0x5, AL                   : ccmn.al %x9 $0x0a $0x05
+ba4ce966 : ccmn x11, #0xc, #0x6, AL                  : ccmn.al %x11 $0x0c $0x06
+ba4ee9a7 : ccmn x13, #0xe, #0x7, AL                  : ccmn.al %x13 $0x0e $0x07
+ba50e9e8 : ccmn x15, #0x10, #0x8, AL                 : ccmn.al %x15 $0x10 $0x08
+ba51ea28 : ccmn x17, #0x11, #0x8, AL                 : ccmn.al %x17 $0x11 $0x08
+ba53ea69 : ccmn x19, #0x13, #0x9, AL                 : ccmn.al %x19 $0x13 $0x09
+ba55eaaa : ccmn x21, #0x15, #0xa, AL                 : ccmn.al %x21 $0x15 $0x0a
+ba57eacb : ccmn x22, #0x17, #0xb, AL                 : ccmn.al %x22 $0x17 $0x0b
+ba59eb0c : ccmn x24, #0x19, #0xc, AL                 : ccmn.al %x24 $0x19 $0x0c
+ba5beb4d : ccmn x26, #0x1b, #0xd, AL                 : ccmn.al %x26 $0x1b $0x0d
+ba5febcf : ccmn x30, #0x1f, #0xf, AL                 : ccmn.al %x30 $0x1f $0x0f
+ba40f800 : ccmn x0, #0x0, #0x0, NV                   : ccmn.nv %x0 $0x00 $0x00
+ba42f841 : ccmn x2, #0x2, #0x1, NV                   : ccmn.nv %x2 $0x02 $0x01
+ba44f882 : ccmn x4, #0x4, #0x2, NV                   : ccmn.nv %x4 $0x04 $0x02
+ba46f8c3 : ccmn x6, #0x6, #0x3, NV                   : ccmn.nv %x6 $0x06 $0x03
+ba48f904 : ccmn x8, #0x8, #0x4, NV                   : ccmn.nv %x8 $0x08 $0x04
+ba4af925 : ccmn x9, #0xa, #0x5, NV                   : ccmn.nv %x9 $0x0a $0x05
+ba4cf966 : ccmn x11, #0xc, #0x6, NV                  : ccmn.nv %x11 $0x0c $0x06
+ba4ef9a7 : ccmn x13, #0xe, #0x7, NV                  : ccmn.nv %x13 $0x0e $0x07
+ba50f9e8 : ccmn x15, #0x10, #0x8, NV                 : ccmn.nv %x15 $0x10 $0x08
+ba51fa28 : ccmn x17, #0x11, #0x8, NV                 : ccmn.nv %x17 $0x11 $0x08
+ba53fa69 : ccmn x19, #0x13, #0x9, NV                 : ccmn.nv %x19 $0x13 $0x09
+ba55faaa : ccmn x21, #0x15, #0xa, NV                 : ccmn.nv %x21 $0x15 $0x0a
+ba57facb : ccmn x22, #0x17, #0xb, NV                 : ccmn.nv %x22 $0x17 $0x0b
+ba59fb0c : ccmn x24, #0x19, #0xc, NV                 : ccmn.nv %x24 $0x19 $0x0c
+ba5bfb4d : ccmn x26, #0x1b, #0xd, NV                 : ccmn.nv %x26 $0x1b $0x0d
+ba5ffbcf : ccmn x30, #0x1f, #0xf, NV                 : ccmn.nv %x30 $0x1f $0x0f
+
+# ANDS    <Wd>, <Wn>, <Wm>, <extend> #<imm> (ANDS-R.RRI-32_log_shift)
+6a020020 : ands w0, w1, w2, LSL #0                   : ands   %w1 %w2 lsl $0x00 -> %w0
+6a040862 : ands w2, w3, w4, LSL #2                   : ands   %w3 %w4 lsl $0x02 -> %w2
+6a0610a4 : ands w4, w5, w6, LSL #4                   : ands   %w5 %w6 lsl $0x04 -> %w4
+6a0818e6 : ands w6, w7, w8, LSL #6                   : ands   %w7 %w8 lsl $0x06 -> %w6
+6a0a2128 : ands w8, w9, w10, LSL #8                  : ands   %w9 %w10 lsl $0x08 -> %w8
+6a0b2949 : ands w9, w10, w11, LSL #10                : ands   %w10 %w11 lsl $0x0a -> %w9
+6a0d318b : ands w11, w12, w13, LSL #12               : ands   %w12 %w13 lsl $0x0c -> %w11
+6a0f39cd : ands w13, w14, w15, LSL #14               : ands   %w14 %w15 lsl $0x0e -> %w13
+6a11420f : ands w15, w16, w17, LSL #16               : ands   %w16 %w17 lsl $0x10 -> %w15
+6a134651 : ands w17, w18, w19, LSL #17               : ands   %w18 %w19 lsl $0x11 -> %w17
+6a154e93 : ands w19, w20, w21, LSL #19               : ands   %w20 %w21 lsl $0x13 -> %w19
+6a1756d5 : ands w21, w22, w23, LSL #21               : ands   %w22 %w23 lsl $0x15 -> %w21
+6a185ef6 : ands w22, w23, w24, LSL #23               : ands   %w23 %w24 lsl $0x17 -> %w22
+6a1a6738 : ands w24, w25, w26, LSL #25               : ands   %w25 %w26 lsl $0x19 -> %w24
+6a1c6f7a : ands w26, w27, w28, LSL #27               : ands   %w27 %w28 lsl $0x1b -> %w26
+6a017c1e : ands w30, w0, w1, LSL #31                 : ands   %w0 %w1 lsl $0x1f -> %w30
+6a420020 : ands w0, w1, w2, LSR #0                   : ands   %w1 %w2 lsr $0x00 -> %w0
+6a440862 : ands w2, w3, w4, LSR #2                   : ands   %w3 %w4 lsr $0x02 -> %w2
+6a4610a4 : ands w4, w5, w6, LSR #4                   : ands   %w5 %w6 lsr $0x04 -> %w4
+6a4818e6 : ands w6, w7, w8, LSR #6                   : ands   %w7 %w8 lsr $0x06 -> %w6
+6a4a2128 : ands w8, w9, w10, LSR #8                  : ands   %w9 %w10 lsr $0x08 -> %w8
+6a4b2949 : ands w9, w10, w11, LSR #10                : ands   %w10 %w11 lsr $0x0a -> %w9
+6a4d318b : ands w11, w12, w13, LSR #12               : ands   %w12 %w13 lsr $0x0c -> %w11
+6a4f39cd : ands w13, w14, w15, LSR #14               : ands   %w14 %w15 lsr $0x0e -> %w13
+6a51420f : ands w15, w16, w17, LSR #16               : ands   %w16 %w17 lsr $0x10 -> %w15
+6a534651 : ands w17, w18, w19, LSR #17               : ands   %w18 %w19 lsr $0x11 -> %w17
+6a554e93 : ands w19, w20, w21, LSR #19               : ands   %w20 %w21 lsr $0x13 -> %w19
+6a5756d5 : ands w21, w22, w23, LSR #21               : ands   %w22 %w23 lsr $0x15 -> %w21
+6a585ef6 : ands w22, w23, w24, LSR #23               : ands   %w23 %w24 lsr $0x17 -> %w22
+6a5a6738 : ands w24, w25, w26, LSR #25               : ands   %w25 %w26 lsr $0x19 -> %w24
+6a5c6f7a : ands w26, w27, w28, LSR #27               : ands   %w27 %w28 lsr $0x1b -> %w26
+6a417c1e : ands w30, w0, w1, LSR #31                 : ands   %w0 %w1 lsr $0x1f -> %w30
+6a820020 : ands w0, w1, w2, ASR #0                   : ands   %w1 %w2 asr $0x00 -> %w0
+6a840862 : ands w2, w3, w4, ASR #2                   : ands   %w3 %w4 asr $0x02 -> %w2
+6a8610a4 : ands w4, w5, w6, ASR #4                   : ands   %w5 %w6 asr $0x04 -> %w4
+6a8818e6 : ands w6, w7, w8, ASR #6                   : ands   %w7 %w8 asr $0x06 -> %w6
+6a8a2128 : ands w8, w9, w10, ASR #8                  : ands   %w9 %w10 asr $0x08 -> %w8
+6a8b2949 : ands w9, w10, w11, ASR #10                : ands   %w10 %w11 asr $0x0a -> %w9
+6a8d318b : ands w11, w12, w13, ASR #12               : ands   %w12 %w13 asr $0x0c -> %w11
+6a8f39cd : ands w13, w14, w15, ASR #14               : ands   %w14 %w15 asr $0x0e -> %w13
+6a91420f : ands w15, w16, w17, ASR #16               : ands   %w16 %w17 asr $0x10 -> %w15
+6a934651 : ands w17, w18, w19, ASR #17               : ands   %w18 %w19 asr $0x11 -> %w17
+6a954e93 : ands w19, w20, w21, ASR #19               : ands   %w20 %w21 asr $0x13 -> %w19
+6a9756d5 : ands w21, w22, w23, ASR #21               : ands   %w22 %w23 asr $0x15 -> %w21
+6a985ef6 : ands w22, w23, w24, ASR #23               : ands   %w23 %w24 asr $0x17 -> %w22
+6a9a6738 : ands w24, w25, w26, ASR #25               : ands   %w25 %w26 asr $0x19 -> %w24
+6a9c6f7a : ands w26, w27, w28, ASR #27               : ands   %w27 %w28 asr $0x1b -> %w26
+6a817c1e : ands w30, w0, w1, ASR #31                 : ands   %w0 %w1 asr $0x1f -> %w30
+6ac20020 : ands w0, w1, w2, ROR #0                   : ands   %w1 %w2 ror $0x00 -> %w0
+6ac40862 : ands w2, w3, w4, ROR #2                   : ands   %w3 %w4 ror $0x02 -> %w2
+6ac610a4 : ands w4, w5, w6, ROR #4                   : ands   %w5 %w6 ror $0x04 -> %w4
+6ac818e6 : ands w6, w7, w8, ROR #6                   : ands   %w7 %w8 ror $0x06 -> %w6
+6aca2128 : ands w8, w9, w10, ROR #8                  : ands   %w9 %w10 ror $0x08 -> %w8
+6acb2949 : ands w9, w10, w11, ROR #10                : ands   %w10 %w11 ror $0x0a -> %w9
+6acd318b : ands w11, w12, w13, ROR #12               : ands   %w12 %w13 ror $0x0c -> %w11
+6acf39cd : ands w13, w14, w15, ROR #14               : ands   %w14 %w15 ror $0x0e -> %w13
+6ad1420f : ands w15, w16, w17, ROR #16               : ands   %w16 %w17 ror $0x10 -> %w15
+6ad34651 : ands w17, w18, w19, ROR #17               : ands   %w18 %w19 ror $0x11 -> %w17
+6ad54e93 : ands w19, w20, w21, ROR #19               : ands   %w20 %w21 ror $0x13 -> %w19
+6ad756d5 : ands w21, w22, w23, ROR #21               : ands   %w22 %w23 ror $0x15 -> %w21
+6ad85ef6 : ands w22, w23, w24, ROR #23               : ands   %w23 %w24 ror $0x17 -> %w22
+6ada6738 : ands w24, w25, w26, ROR #25               : ands   %w25 %w26 ror $0x19 -> %w24
+6adc6f7a : ands w26, w27, w28, ROR #27               : ands   %w27 %w28 ror $0x1b -> %w26
+6ac17c1e : ands w30, w0, w1, ROR #31                 : ands   %w0 %w1 ror $0x1f -> %w30
+
+# ORR     <Xd|SP>, <Xn>, #<imm> (ORR-R.RI-64_log_imm)
+b2000020 : orr x0, x1, #0x100000001                  : orr    %x1 $0x0000000100000001 -> %x0
+b2040062 : orr x2, x3, #0x1000000010000000           : orr    %x3 $0x1000000010000000 -> %x2
+b20800a4 : orr x4, x5, #0x100000001000000            : orr    %x5 $0x0100000001000000 -> %x4
+b20c00e6 : orr x6, x7, #0x10000000100000             : orr    %x7 $0x0010000000100000 -> %x6
+b2100128 : orr x8, x9, #0x1000000010000              : orr    %x9 $0x0001000000010000 -> %x8
+b2140149 : orr x9, x10, #0x100000001000              : orr    %x10 $0x0000100000001000 -> %x9
+b218018b : orr x11, x12, #0x10000000100              : orr    %x12 $0x0000010000000100 -> %x11
+b21c01cd : orr x13, x14, #0x1000000010               : orr    %x14 $0x0000001000000010 -> %x13
+b200020f : orr x15, x16, #0x100000001                : orr    %x16 $0x0000000100000001 -> %x15
+b203ea51 : orr x17, x18, #0xeeeeeeeeeeeeeeee         : orr    %x18 $0xeeeeeeeeeeeeeeee -> %x17
+b203ea93 : orr x19, x20, #0xeeeeeeeeeeeeeeee         : orr    %x20 $0xeeeeeeeeeeeeeeee -> %x19
+b203ead5 : orr x21, x22, #0xeeeeeeeeeeeeeeee         : orr    %x22 $0xeeeeeeeeeeeeeeee -> %x21
+b203eaf6 : orr x22, x23, #0xeeeeeeeeeeeeeeee         : orr    %x23 $0xeeeeeeeeeeeeeeee -> %x22
+b203eb38 : orr x24, x25, #0xeeeeeeeeeeeeeeee         : orr    %x25 $0xeeeeeeeeeeeeeeee -> %x24
+b203eb7a : orr x26, x27, #0xeeeeeeeeeeeeeeee         : orr    %x27 $0xeeeeeeeeeeeeeeee -> %x26
+b203e81f : orr sp, x0, #0xeeeeeeeeeeeeeeee           : orr    %x0 $0xeeeeeeeeeeeeeeee -> %sp
+
+# CRC32CB <Wd>, <Wn>, <Wm> (CRC32CB-R.RR-32C_dp_2src)
+1ac25020 : crc32cb w0, w1, w2                        : crc32cb %w1 %w2 -> %w0
+1ac45062 : crc32cb w2, w3, w4                        : crc32cb %w3 %w4 -> %w2
+1ac650a4 : crc32cb w4, w5, w6                        : crc32cb %w5 %w6 -> %w4
+1ac850e6 : crc32cb w6, w7, w8                        : crc32cb %w7 %w8 -> %w6
+1aca5128 : crc32cb w8, w9, w10                       : crc32cb %w9 %w10 -> %w8
+1acb5149 : crc32cb w9, w10, w11                      : crc32cb %w10 %w11 -> %w9
+1acd518b : crc32cb w11, w12, w13                     : crc32cb %w12 %w13 -> %w11
+1acf51cd : crc32cb w13, w14, w15                     : crc32cb %w14 %w15 -> %w13
+1ad1520f : crc32cb w15, w16, w17                     : crc32cb %w16 %w17 -> %w15
+1ad35251 : crc32cb w17, w18, w19                     : crc32cb %w18 %w19 -> %w17
+1ad55293 : crc32cb w19, w20, w21                     : crc32cb %w20 %w21 -> %w19
+1ad752d5 : crc32cb w21, w22, w23                     : crc32cb %w22 %w23 -> %w21
+1ad852f6 : crc32cb w22, w23, w24                     : crc32cb %w23 %w24 -> %w22
+1ada5338 : crc32cb w24, w25, w26                     : crc32cb %w25 %w26 -> %w24
+1adc537a : crc32cb w26, w27, w28                     : crc32cb %w27 %w28 -> %w26
+1ac1501e : crc32cb w30, w0, w1                       : crc32cb %w0 %w1 -> %w30
+
+# ASRV    <Wd>, <Wn>, <Wm> (ASRV-R.RR-32_dp_2src)
+1ac22820 : asrv w0, w1, w2                           : asrv   %w1 %w2 -> %w0
+1ac42862 : asrv w2, w3, w4                           : asrv   %w3 %w4 -> %w2
+1ac628a4 : asrv w4, w5, w6                           : asrv   %w5 %w6 -> %w4
+1ac828e6 : asrv w6, w7, w8                           : asrv   %w7 %w8 -> %w6
+1aca2928 : asrv w8, w9, w10                          : asrv   %w9 %w10 -> %w8
+1acb2949 : asrv w9, w10, w11                         : asrv   %w10 %w11 -> %w9
+1acd298b : asrv w11, w12, w13                        : asrv   %w12 %w13 -> %w11
+1acf29cd : asrv w13, w14, w15                        : asrv   %w14 %w15 -> %w13
+1ad12a0f : asrv w15, w16, w17                        : asrv   %w16 %w17 -> %w15
+1ad32a51 : asrv w17, w18, w19                        : asrv   %w18 %w19 -> %w17
+1ad52a93 : asrv w19, w20, w21                        : asrv   %w20 %w21 -> %w19
+1ad72ad5 : asrv w21, w22, w23                        : asrv   %w22 %w23 -> %w21
+1ad82af6 : asrv w22, w23, w24                        : asrv   %w23 %w24 -> %w22
+1ada2b38 : asrv w24, w25, w26                        : asrv   %w25 %w26 -> %w24
+1adc2b7a : asrv w26, w27, w28                        : asrv   %w27 %w28 -> %w26
+1ac1281e : asrv w30, w0, w1                          : asrv   %w0 %w1 -> %w30
+
+# ADDS    <Wd>, <Wn>, <Wm>, <extend> #<imm> (ADDS-R.RRI-32_addsub_shift)
+2b020020 : adds w0, w1, w2, LSL #0                   : adds   %w1 %w2 lsl $0x00 -> %w0
+2b040862 : adds w2, w3, w4, LSL #2                   : adds   %w3 %w4 lsl $0x02 -> %w2
+2b0610a4 : adds w4, w5, w6, LSL #4                   : adds   %w5 %w6 lsl $0x04 -> %w4
+2b0818e6 : adds w6, w7, w8, LSL #6                   : adds   %w7 %w8 lsl $0x06 -> %w6
+2b0a2128 : adds w8, w9, w10, LSL #8                  : adds   %w9 %w10 lsl $0x08 -> %w8
+2b0b2949 : adds w9, w10, w11, LSL #10                : adds   %w10 %w11 lsl $0x0a -> %w9
+2b0d318b : adds w11, w12, w13, LSL #12               : adds   %w12 %w13 lsl $0x0c -> %w11
+2b0f39cd : adds w13, w14, w15, LSL #14               : adds   %w14 %w15 lsl $0x0e -> %w13
+2b11420f : adds w15, w16, w17, LSL #16               : adds   %w16 %w17 lsl $0x10 -> %w15
+2b134651 : adds w17, w18, w19, LSL #17               : adds   %w18 %w19 lsl $0x11 -> %w17
+2b154e93 : adds w19, w20, w21, LSL #19               : adds   %w20 %w21 lsl $0x13 -> %w19
+2b1756d5 : adds w21, w22, w23, LSL #21               : adds   %w22 %w23 lsl $0x15 -> %w21
+2b185ef6 : adds w22, w23, w24, LSL #23               : adds   %w23 %w24 lsl $0x17 -> %w22
+2b1a6738 : adds w24, w25, w26, LSL #25               : adds   %w25 %w26 lsl $0x19 -> %w24
+2b1c6f7a : adds w26, w27, w28, LSL #27               : adds   %w27 %w28 lsl $0x1b -> %w26
+2b017c1e : adds w30, w0, w1, LSL #31                 : adds   %w0 %w1 lsl $0x1f -> %w30
+2b420020 : adds w0, w1, w2, LSR #0                   : adds   %w1 %w2 lsr $0x00 -> %w0
+2b440862 : adds w2, w3, w4, LSR #2                   : adds   %w3 %w4 lsr $0x02 -> %w2
+2b4610a4 : adds w4, w5, w6, LSR #4                   : adds   %w5 %w6 lsr $0x04 -> %w4
+2b4818e6 : adds w6, w7, w8, LSR #6                   : adds   %w7 %w8 lsr $0x06 -> %w6
+2b4a2128 : adds w8, w9, w10, LSR #8                  : adds   %w9 %w10 lsr $0x08 -> %w8
+2b4b2949 : adds w9, w10, w11, LSR #10                : adds   %w10 %w11 lsr $0x0a -> %w9
+2b4d318b : adds w11, w12, w13, LSR #12               : adds   %w12 %w13 lsr $0x0c -> %w11
+2b4f39cd : adds w13, w14, w15, LSR #14               : adds   %w14 %w15 lsr $0x0e -> %w13
+2b51420f : adds w15, w16, w17, LSR #16               : adds   %w16 %w17 lsr $0x10 -> %w15
+2b534651 : adds w17, w18, w19, LSR #17               : adds   %w18 %w19 lsr $0x11 -> %w17
+2b554e93 : adds w19, w20, w21, LSR #19               : adds   %w20 %w21 lsr $0x13 -> %w19
+2b5756d5 : adds w21, w22, w23, LSR #21               : adds   %w22 %w23 lsr $0x15 -> %w21
+2b585ef6 : adds w22, w23, w24, LSR #23               : adds   %w23 %w24 lsr $0x17 -> %w22
+2b5a6738 : adds w24, w25, w26, LSR #25               : adds   %w25 %w26 lsr $0x19 -> %w24
+2b5c6f7a : adds w26, w27, w28, LSR #27               : adds   %w27 %w28 lsr $0x1b -> %w26
+2b417c1e : adds w30, w0, w1, LSR #31                 : adds   %w0 %w1 lsr $0x1f -> %w30
+2b820020 : adds w0, w1, w2, ASR #0                   : adds   %w1 %w2 asr $0x00 -> %w0
+2b840862 : adds w2, w3, w4, ASR #2                   : adds   %w3 %w4 asr $0x02 -> %w2
+2b8610a4 : adds w4, w5, w6, ASR #4                   : adds   %w5 %w6 asr $0x04 -> %w4
+2b8818e6 : adds w6, w7, w8, ASR #6                   : adds   %w7 %w8 asr $0x06 -> %w6
+2b8a2128 : adds w8, w9, w10, ASR #8                  : adds   %w9 %w10 asr $0x08 -> %w8
+2b8b2949 : adds w9, w10, w11, ASR #10                : adds   %w10 %w11 asr $0x0a -> %w9
+2b8d318b : adds w11, w12, w13, ASR #12               : adds   %w12 %w13 asr $0x0c -> %w11
+2b8f39cd : adds w13, w14, w15, ASR #14               : adds   %w14 %w15 asr $0x0e -> %w13
+2b91420f : adds w15, w16, w17, ASR #16               : adds   %w16 %w17 asr $0x10 -> %w15
+2b934651 : adds w17, w18, w19, ASR #17               : adds   %w18 %w19 asr $0x11 -> %w17
+2b954e93 : adds w19, w20, w21, ASR #19               : adds   %w20 %w21 asr $0x13 -> %w19
+2b9756d5 : adds w21, w22, w23, ASR #21               : adds   %w22 %w23 asr $0x15 -> %w21
+2b985ef6 : adds w22, w23, w24, ASR #23               : adds   %w23 %w24 asr $0x17 -> %w22
+2b9a6738 : adds w24, w25, w26, ASR #25               : adds   %w25 %w26 asr $0x19 -> %w24
+2b9c6f7a : adds w26, w27, w28, ASR #27               : adds   %w27 %w28 asr $0x1b -> %w26
+2b817c1e : adds w30, w0, w1, ASR #31                 : adds   %w0 %w1 asr $0x1f -> %w30
+
+# REV     <Wd>, <Wn> (REV-R.R-32_dp_1src)
+5ac00820 : rev w0, w1                                : rev    %w1 -> %w0
+5ac00862 : rev w2, w3                                : rev    %w3 -> %w2
+5ac008a4 : rev w4, w5                                : rev    %w5 -> %w4
+5ac008e6 : rev w6, w7                                : rev    %w7 -> %w6
+5ac00928 : rev w8, w9                                : rev    %w9 -> %w8
+5ac00949 : rev w9, w10                               : rev    %w10 -> %w9
+5ac0098b : rev w11, w12                              : rev    %w12 -> %w11
+5ac009cd : rev w13, w14                              : rev    %w14 -> %w13
+5ac00a0f : rev w15, w16                              : rev    %w16 -> %w15
+5ac00a51 : rev w17, w18                              : rev    %w18 -> %w17
+5ac00a93 : rev w19, w20                              : rev    %w20 -> %w19
+5ac00ad5 : rev w21, w22                              : rev    %w22 -> %w21
+5ac00af6 : rev w22, w23                              : rev    %w23 -> %w22
+5ac00b38 : rev w24, w25                              : rev    %w25 -> %w24
+5ac00b7a : rev w26, w27                              : rev    %w27 -> %w26
+5ac0081e : rev w30, w0                               : rev    %w0 -> %w30
+
+# SDIV    <Xd>, <Xn>, <Xm> (SDIV-R.RR-64_dp_2src)
+9ac20c20 : sdiv x0, x1, x2                           : sdiv   %x1 %x2 -> %x0
+9ac40c62 : sdiv x2, x3, x4                           : sdiv   %x3 %x4 -> %x2
+9ac60ca4 : sdiv x4, x5, x6                           : sdiv   %x5 %x6 -> %x4
+9ac80ce6 : sdiv x6, x7, x8                           : sdiv   %x7 %x8 -> %x6
+9aca0d28 : sdiv x8, x9, x10                          : sdiv   %x9 %x10 -> %x8
+9acb0d49 : sdiv x9, x10, x11                         : sdiv   %x10 %x11 -> %x9
+9acd0d8b : sdiv x11, x12, x13                        : sdiv   %x12 %x13 -> %x11
+9acf0dcd : sdiv x13, x14, x15                        : sdiv   %x14 %x15 -> %x13
+9ad10e0f : sdiv x15, x16, x17                        : sdiv   %x16 %x17 -> %x15
+9ad30e51 : sdiv x17, x18, x19                        : sdiv   %x18 %x19 -> %x17
+9ad50e93 : sdiv x19, x20, x21                        : sdiv   %x20 %x21 -> %x19
+9ad70ed5 : sdiv x21, x22, x23                        : sdiv   %x22 %x23 -> %x21
+9ad80ef6 : sdiv x22, x23, x24                        : sdiv   %x23 %x24 -> %x22
+9ada0f38 : sdiv x24, x25, x26                        : sdiv   %x25 %x26 -> %x24
+9adc0f7a : sdiv x26, x27, x28                        : sdiv   %x27 %x28 -> %x26
+9ac10c1e : sdiv x30, x0, x1                          : sdiv   %x0 %x1 -> %x30
+
+# BR      <Xn> (BR-R-64_branch_reg)
+d61f0000 : br x0                                     : br     %x0
+d61f0040 : br x2                                     : br     %x2
+d61f0080 : br x4                                     : br     %x4
+d61f00c0 : br x6                                     : br     %x6
+d61f0100 : br x8                                     : br     %x8
+d61f0120 : br x9                                     : br     %x9
+d61f0160 : br x11                                    : br     %x11
+d61f01a0 : br x13                                    : br     %x13
+d61f01e0 : br x15                                    : br     %x15
+d61f0220 : br x17                                    : br     %x17
+d61f0260 : br x19                                    : br     %x19
+d61f02a0 : br x21                                    : br     %x21
+d61f02c0 : br x22                                    : br     %x22
+d61f0300 : br x24                                    : br     %x24
+d61f0340 : br x26                                    : br     %x26
+d61f03c0 : br x30                                    : br     %x30
+
+# UDIV    <Xd>, <Xn>, <Xm> (UDIV-R.RR-64_dp_2src)
+9ac20820 : udiv x0, x1, x2                           : udiv   %x1 %x2 -> %x0
+9ac40862 : udiv x2, x3, x4                           : udiv   %x3 %x4 -> %x2
+9ac608a4 : udiv x4, x5, x6                           : udiv   %x5 %x6 -> %x4
+9ac808e6 : udiv x6, x7, x8                           : udiv   %x7 %x8 -> %x6
+9aca0928 : udiv x8, x9, x10                          : udiv   %x9 %x10 -> %x8
+9acb0949 : udiv x9, x10, x11                         : udiv   %x10 %x11 -> %x9
+9acd098b : udiv x11, x12, x13                        : udiv   %x12 %x13 -> %x11
+9acf09cd : udiv x13, x14, x15                        : udiv   %x14 %x15 -> %x13
+9ad10a0f : udiv x15, x16, x17                        : udiv   %x16 %x17 -> %x15
+9ad30a51 : udiv x17, x18, x19                        : udiv   %x18 %x19 -> %x17
+9ad50a93 : udiv x19, x20, x21                        : udiv   %x20 %x21 -> %x19
+9ad70ad5 : udiv x21, x22, x23                        : udiv   %x22 %x23 -> %x21
+9ad80af6 : udiv x22, x23, x24                        : udiv   %x23 %x24 -> %x22
+9ada0b38 : udiv x24, x25, x26                        : udiv   %x25 %x26 -> %x24
+9adc0b7a : udiv x26, x27, x28                        : udiv   %x27 %x28 -> %x26
+9ac1081e : udiv x30, x0, x1                          : udiv   %x0 %x1 -> %x30
+
+# BLR     <Xn> (BLR-R-64_branch_reg)
+d63f0000 : blr x0                                    : blr    %x0 -> %x30
+d63f0040 : blr x2                                    : blr    %x2 -> %x30
+d63f0080 : blr x4                                    : blr    %x4 -> %x30
+d63f00c0 : blr x6                                    : blr    %x6 -> %x30
+d63f0100 : blr x8                                    : blr    %x8 -> %x30
+d63f0120 : blr x9                                    : blr    %x9 -> %x30
+d63f0160 : blr x11                                   : blr    %x11 -> %x30
+d63f01a0 : blr x13                                   : blr    %x13 -> %x30
+d63f01e0 : blr x15                                   : blr    %x15 -> %x30
+d63f0220 : blr x17                                   : blr    %x17 -> %x30
+d63f0260 : blr x19                                   : blr    %x19 -> %x30
+d63f02a0 : blr x21                                   : blr    %x21 -> %x30
+d63f02c0 : blr x22                                   : blr    %x22 -> %x30
+d63f0300 : blr x24                                   : blr    %x24 -> %x30
+d63f0340 : blr x26                                   : blr    %x26 -> %x30
+d63f03c0 : blr x30                                   : blr    %x30 -> %x30
+
+# SUB     <Xd>, <Xn>, <Xm>, <extend> #<imm> (SUB-R.RRI-64_addsub_shift)
+cb020020 : sub x0, x1, x2, LSL #0                    : sub    %x1 %x2 lsl $0x00 -> %x0
+cb040862 : sub x2, x3, x4, LSL #2                    : sub    %x3 %x4 lsl $0x02 -> %x2
+cb0610a4 : sub x4, x5, x6, LSL #4                    : sub    %x5 %x6 lsl $0x04 -> %x4
+cb0818e6 : sub x6, x7, x8, LSL #6                    : sub    %x7 %x8 lsl $0x06 -> %x6
+cb0a2128 : sub x8, x9, x10, LSL #8                   : sub    %x9 %x10 lsl $0x08 -> %x8
+cb0b2949 : sub x9, x10, x11, LSL #10                 : sub    %x10 %x11 lsl $0x0a -> %x9
+cb0d318b : sub x11, x12, x13, LSL #12                : sub    %x12 %x13 lsl $0x0c -> %x11
+cb0f39cd : sub x13, x14, x15, LSL #14                : sub    %x14 %x15 lsl $0x0e -> %x13
+cb11420f : sub x15, x16, x17, LSL #16                : sub    %x16 %x17 lsl $0x10 -> %x15
+cb134651 : sub x17, x18, x19, LSL #17                : sub    %x18 %x19 lsl $0x11 -> %x17
+cb154e93 : sub x19, x20, x21, LSL #19                : sub    %x20 %x21 lsl $0x13 -> %x19
+cb1756d5 : sub x21, x22, x23, LSL #21                : sub    %x22 %x23 lsl $0x15 -> %x21
+cb185ef6 : sub x22, x23, x24, LSL #23                : sub    %x23 %x24 lsl $0x17 -> %x22
+cb1a6738 : sub x24, x25, x26, LSL #25                : sub    %x25 %x26 lsl $0x19 -> %x24
+cb1c6f7a : sub x26, x27, x28, LSL #27                : sub    %x27 %x28 lsl $0x1b -> %x26
+cb017c1e : sub x30, x0, x1, LSL #31                  : sub    %x0 %x1 lsl $0x1f -> %x30
+cb420020 : sub x0, x1, x2, LSR #0                    : sub    %x1 %x2 lsr $0x00 -> %x0
+cb440862 : sub x2, x3, x4, LSR #2                    : sub    %x3 %x4 lsr $0x02 -> %x2
+cb4610a4 : sub x4, x5, x6, LSR #4                    : sub    %x5 %x6 lsr $0x04 -> %x4
+cb4818e6 : sub x6, x7, x8, LSR #6                    : sub    %x7 %x8 lsr $0x06 -> %x6
+cb4a2128 : sub x8, x9, x10, LSR #8                   : sub    %x9 %x10 lsr $0x08 -> %x8
+cb4b2949 : sub x9, x10, x11, LSR #10                 : sub    %x10 %x11 lsr $0x0a -> %x9
+cb4d318b : sub x11, x12, x13, LSR #12                : sub    %x12 %x13 lsr $0x0c -> %x11
+cb4f39cd : sub x13, x14, x15, LSR #14                : sub    %x14 %x15 lsr $0x0e -> %x13
+cb51420f : sub x15, x16, x17, LSR #16                : sub    %x16 %x17 lsr $0x10 -> %x15
+cb534651 : sub x17, x18, x19, LSR #17                : sub    %x18 %x19 lsr $0x11 -> %x17
+cb554e93 : sub x19, x20, x21, LSR #19                : sub    %x20 %x21 lsr $0x13 -> %x19
+cb5756d5 : sub x21, x22, x23, LSR #21                : sub    %x22 %x23 lsr $0x15 -> %x21
+cb585ef6 : sub x22, x23, x24, LSR #23                : sub    %x23 %x24 lsr $0x17 -> %x22
+cb5a6738 : sub x24, x25, x26, LSR #25                : sub    %x25 %x26 lsr $0x19 -> %x24
+cb5c6f7a : sub x26, x27, x28, LSR #27                : sub    %x27 %x28 lsr $0x1b -> %x26
+cb417c1e : sub x30, x0, x1, LSR #31                  : sub    %x0 %x1 lsr $0x1f -> %x30
+cb820020 : sub x0, x1, x2, ASR #0                    : sub    %x1 %x2 asr $0x00 -> %x0
+cb840862 : sub x2, x3, x4, ASR #2                    : sub    %x3 %x4 asr $0x02 -> %x2
+cb8610a4 : sub x4, x5, x6, ASR #4                    : sub    %x5 %x6 asr $0x04 -> %x4
+cb8818e6 : sub x6, x7, x8, ASR #6                    : sub    %x7 %x8 asr $0x06 -> %x6
+cb8a2128 : sub x8, x9, x10, ASR #8                   : sub    %x9 %x10 asr $0x08 -> %x8
+cb8b2949 : sub x9, x10, x11, ASR #10                 : sub    %x10 %x11 asr $0x0a -> %x9
+cb8d318b : sub x11, x12, x13, ASR #12                : sub    %x12 %x13 asr $0x0c -> %x11
+cb8f39cd : sub x13, x14, x15, ASR #14                : sub    %x14 %x15 asr $0x0e -> %x13
+cb91420f : sub x15, x16, x17, ASR #16                : sub    %x16 %x17 asr $0x10 -> %x15
+cb934651 : sub x17, x18, x19, ASR #17                : sub    %x18 %x19 asr $0x11 -> %x17
+cb954e93 : sub x19, x20, x21, ASR #19                : sub    %x20 %x21 asr $0x13 -> %x19
+cb9756d5 : sub x21, x22, x23, ASR #21                : sub    %x22 %x23 asr $0x15 -> %x21
+cb985ef6 : sub x22, x23, x24, ASR #23                : sub    %x23 %x24 asr $0x17 -> %x22
+cb9a6738 : sub x24, x25, x26, ASR #25                : sub    %x25 %x26 asr $0x19 -> %x24
+cb9c6f7a : sub x26, x27, x28, ASR #27                : sub    %x27 %x28 asr $0x1b -> %x26
+cb817c1e : sub x30, x0, x1, ASR #31                  : sub    %x0 %x1 asr $0x1f -> %x30
+
+# RBIT    <Xd>, <Xn> (RBIT-R.R-64_dp_1src)
+dac00020 : rbit x0, x1                               : rbit   %x1 -> %x0
+dac00062 : rbit x2, x3                               : rbit   %x3 -> %x2
+dac000a4 : rbit x4, x5                               : rbit   %x5 -> %x4
+dac000e6 : rbit x6, x7                               : rbit   %x7 -> %x6
+dac00128 : rbit x8, x9                               : rbit   %x9 -> %x8
+dac00149 : rbit x9, x10                              : rbit   %x10 -> %x9
+dac0018b : rbit x11, x12                             : rbit   %x12 -> %x11
+dac001cd : rbit x13, x14                             : rbit   %x14 -> %x13
+dac0020f : rbit x15, x16                             : rbit   %x16 -> %x15
+dac00251 : rbit x17, x18                             : rbit   %x18 -> %x17
+dac00293 : rbit x19, x20                             : rbit   %x20 -> %x19
+dac002d5 : rbit x21, x22                             : rbit   %x22 -> %x21
+dac002f6 : rbit x22, x23                             : rbit   %x23 -> %x22
+dac00338 : rbit x24, x25                             : rbit   %x25 -> %x24
+dac0037a : rbit x26, x27                             : rbit   %x27 -> %x26
+dac0001e : rbit x30, x0                              : rbit   %x0 -> %x30
+
+# SMULH   <Xd>, <Xn>, <Xm> (SMULH-R.RR-64_dp_3src)
+9b427c20 : smulh x0, x1, x2                          : smulh  %x1 %x2 -> %x0
+9b447c62 : smulh x2, x3, x4                          : smulh  %x3 %x4 -> %x2
+9b467ca4 : smulh x4, x5, x6                          : smulh  %x5 %x6 -> %x4
+9b487ce6 : smulh x6, x7, x8                          : smulh  %x7 %x8 -> %x6
+9b4a7d28 : smulh x8, x9, x10                         : smulh  %x9 %x10 -> %x8
+9b4b7d49 : smulh x9, x10, x11                        : smulh  %x10 %x11 -> %x9
+9b4d7d8b : smulh x11, x12, x13                       : smulh  %x12 %x13 -> %x11
+9b4f7dcd : smulh x13, x14, x15                       : smulh  %x14 %x15 -> %x13
+9b517e0f : smulh x15, x16, x17                       : smulh  %x16 %x17 -> %x15
+9b537e51 : smulh x17, x18, x19                       : smulh  %x18 %x19 -> %x17
+9b557e93 : smulh x19, x20, x21                       : smulh  %x20 %x21 -> %x19
+9b577ed5 : smulh x21, x22, x23                       : smulh  %x22 %x23 -> %x21
+9b587ef6 : smulh x22, x23, x24                       : smulh  %x23 %x24 -> %x22
+9b5a7f38 : smulh x24, x25, x26                       : smulh  %x25 %x26 -> %x24
+9b5c7f7a : smulh x26, x27, x28                       : smulh  %x27 %x28 -> %x26
+9b417c1e : smulh x30, x0, x1                         : smulh  %x0 %x1 -> %x30
+
+# ADCS    <Xd>, <Xn>, <Xm> (ADCS-R.RR-64_addsub_carry)
+ba020020 : adcs x0, x1, x2                           : adcs   %x1 %x2 -> %x0
+ba040062 : adcs x2, x3, x4                           : adcs   %x3 %x4 -> %x2
+ba0600a4 : adcs x4, x5, x6                           : adcs   %x5 %x6 -> %x4
+ba0800e6 : adcs x6, x7, x8                           : adcs   %x7 %x8 -> %x6
+ba0a0128 : adcs x8, x9, x10                          : adcs   %x9 %x10 -> %x8
+ba0b0149 : adcs x9, x10, x11                         : adcs   %x10 %x11 -> %x9
+ba0d018b : adcs x11, x12, x13                        : adcs   %x12 %x13 -> %x11
+ba0f01cd : adcs x13, x14, x15                        : adcs   %x14 %x15 -> %x13
+ba11020f : adcs x15, x16, x17                        : adcs   %x16 %x17 -> %x15
+ba130251 : adcs x17, x18, x19                        : adcs   %x18 %x19 -> %x17
+ba150293 : adcs x19, x20, x21                        : adcs   %x20 %x21 -> %x19
+ba1702d5 : adcs x21, x22, x23                        : adcs   %x22 %x23 -> %x21
+ba1802f6 : adcs x22, x23, x24                        : adcs   %x23 %x24 -> %x22
+ba1a0338 : adcs x24, x25, x26                        : adcs   %x25 %x26 -> %x24
+ba1c037a : adcs x26, x27, x28                        : adcs   %x27 %x28 -> %x26
+ba01001e : adcs x30, x0, x1                          : adcs   %x0 %x1 -> %x30
+
+# CBZ     <Xt>, #<imm> (CBZ-R.I-64_compbranch)
+b4800000 : cbz x0, #-0x100000                        : cbz    $0x000000000ff00000 %x0
+b4900002 : cbz x2, #-0xe0000                         : cbz    $0x000000000ff20000 %x2
+b4a00004 : cbz x4, #-0xc0000                         : cbz    $0x000000000ff40000 %x4
+b4b00006 : cbz x6, #-0xa0000                         : cbz    $0x000000000ff60000 %x6
+b4c00008 : cbz x8, #-0x80000                         : cbz    $0x000000000ff80000 %x8
+b4d00009 : cbz x9, #-0x60000                         : cbz    $0x000000000ffa0000 %x9
+b4e0000b : cbz x11, #-0x40000                        : cbz    $0x000000000ffc0000 %x11
+b4f0000d : cbz x13, #-0x20000                        : cbz    $0x000000000ffe0000 %x13
+b400000f : cbz x15, #0x0                             : cbz    $0x0000000010000000 %x15
+b40ffff1 : cbz x17, #0x1fffc                         : cbz    $0x000000001001fffc %x17
+b41ffff3 : cbz x19, #0x3fffc                         : cbz    $0x000000001003fffc %x19
+b42ffff5 : cbz x21, #0x5fffc                         : cbz    $0x000000001005fffc %x21
+b43ffff6 : cbz x22, #0x7fffc                         : cbz    $0x000000001007fffc %x22
+b44ffff8 : cbz x24, #0x9fffc                         : cbz    $0x000000001009fffc %x24
+b45ffffa : cbz x26, #0xbfffc                         : cbz    $0x00000000100bfffc %x26
+b47ffffe : cbz x30, #0xffffc                         : cbz    $0x00000000100ffffc %x30
+
+# REV16   <Xd>, <Xn> (REV16-R.R-64_dp_1src)
+dac00420 : rev16 x0, x1                              : rev16  %x1 -> %x0
+dac00462 : rev16 x2, x3                              : rev16  %x3 -> %x2
+dac004a4 : rev16 x4, x5                              : rev16  %x5 -> %x4
+dac004e6 : rev16 x6, x7                              : rev16  %x7 -> %x6
+dac00528 : rev16 x8, x9                              : rev16  %x9 -> %x8
+dac00549 : rev16 x9, x10                             : rev16  %x10 -> %x9
+dac0058b : rev16 x11, x12                            : rev16  %x12 -> %x11
+dac005cd : rev16 x13, x14                            : rev16  %x14 -> %x13
+dac0060f : rev16 x15, x16                            : rev16  %x16 -> %x15
+dac00651 : rev16 x17, x18                            : rev16  %x18 -> %x17
+dac00693 : rev16 x19, x20                            : rev16  %x20 -> %x19
+dac006d5 : rev16 x21, x22                            : rev16  %x22 -> %x21
+dac006f6 : rev16 x22, x23                            : rev16  %x23 -> %x22
+dac00738 : rev16 x24, x25                            : rev16  %x25 -> %x24
+dac0077a : rev16 x26, x27                            : rev16  %x27 -> %x26
+dac0041e : rev16 x30, x0                             : rev16  %x0 -> %x30
+
+# CSINV   <Wd>, <Wn>, <Wm>, <cond> (CSINV-R.RR-32_condsel)
+5a820020 : csinv w0, w1, w2, EQ                      : csinv  %w1 %w2 eq -> %w0
+5a840062 : csinv w2, w3, w4, EQ                      : csinv  %w3 %w4 eq -> %w2
+5a8600a4 : csinv w4, w5, w6, EQ                      : csinv  %w5 %w6 eq -> %w4
+5a8800e6 : csinv w6, w7, w8, EQ                      : csinv  %w7 %w8 eq -> %w6
+5a8a0128 : csinv w8, w9, w10, EQ                     : csinv  %w9 %w10 eq -> %w8
+5a8b0149 : csinv w9, w10, w11, EQ                    : csinv  %w10 %w11 eq -> %w9
+5a8d018b : csinv w11, w12, w13, EQ                   : csinv  %w12 %w13 eq -> %w11
+5a8f01cd : csinv w13, w14, w15, EQ                   : csinv  %w14 %w15 eq -> %w13
+5a91020f : csinv w15, w16, w17, EQ                   : csinv  %w16 %w17 eq -> %w15
+5a930251 : csinv w17, w18, w19, EQ                   : csinv  %w18 %w19 eq -> %w17
+5a950293 : csinv w19, w20, w21, EQ                   : csinv  %w20 %w21 eq -> %w19
+5a9702d5 : csinv w21, w22, w23, EQ                   : csinv  %w22 %w23 eq -> %w21
+5a9802f6 : csinv w22, w23, w24, EQ                   : csinv  %w23 %w24 eq -> %w22
+5a9a0338 : csinv w24, w25, w26, EQ                   : csinv  %w25 %w26 eq -> %w24
+5a9c037a : csinv w26, w27, w28, EQ                   : csinv  %w27 %w28 eq -> %w26
+5a81001e : csinv w30, w0, w1, EQ                     : csinv  %w0 %w1 eq -> %w30
+5a821020 : csinv w0, w1, w2, NE                      : csinv  %w1 %w2 ne -> %w0
+5a841062 : csinv w2, w3, w4, NE                      : csinv  %w3 %w4 ne -> %w2
+5a8610a4 : csinv w4, w5, w6, NE                      : csinv  %w5 %w6 ne -> %w4
+5a8810e6 : csinv w6, w7, w8, NE                      : csinv  %w7 %w8 ne -> %w6
+5a8a1128 : csinv w8, w9, w10, NE                     : csinv  %w9 %w10 ne -> %w8
+5a8b1149 : csinv w9, w10, w11, NE                    : csinv  %w10 %w11 ne -> %w9
+5a8d118b : csinv w11, w12, w13, NE                   : csinv  %w12 %w13 ne -> %w11
+5a8f11cd : csinv w13, w14, w15, NE                   : csinv  %w14 %w15 ne -> %w13
+5a91120f : csinv w15, w16, w17, NE                   : csinv  %w16 %w17 ne -> %w15
+5a931251 : csinv w17, w18, w19, NE                   : csinv  %w18 %w19 ne -> %w17
+5a951293 : csinv w19, w20, w21, NE                   : csinv  %w20 %w21 ne -> %w19
+5a9712d5 : csinv w21, w22, w23, NE                   : csinv  %w22 %w23 ne -> %w21
+5a9812f6 : csinv w22, w23, w24, NE                   : csinv  %w23 %w24 ne -> %w22
+5a9a1338 : csinv w24, w25, w26, NE                   : csinv  %w25 %w26 ne -> %w24
+5a9c137a : csinv w26, w27, w28, NE                   : csinv  %w27 %w28 ne -> %w26
+5a81101e : csinv w30, w0, w1, NE                     : csinv  %w0 %w1 ne -> %w30
+5a822020 : csinv w0, w1, w2, CS                      : csinv  %w1 %w2 cs -> %w0
+5a842062 : csinv w2, w3, w4, CS                      : csinv  %w3 %w4 cs -> %w2
+5a8620a4 : csinv w4, w5, w6, CS                      : csinv  %w5 %w6 cs -> %w4
+5a8820e6 : csinv w6, w7, w8, CS                      : csinv  %w7 %w8 cs -> %w6
+5a8a2128 : csinv w8, w9, w10, CS                     : csinv  %w9 %w10 cs -> %w8
+5a8b2149 : csinv w9, w10, w11, CS                    : csinv  %w10 %w11 cs -> %w9
+5a8d218b : csinv w11, w12, w13, CS                   : csinv  %w12 %w13 cs -> %w11
+5a8f21cd : csinv w13, w14, w15, CS                   : csinv  %w14 %w15 cs -> %w13
+5a91220f : csinv w15, w16, w17, CS                   : csinv  %w16 %w17 cs -> %w15
+5a932251 : csinv w17, w18, w19, CS                   : csinv  %w18 %w19 cs -> %w17
+5a952293 : csinv w19, w20, w21, CS                   : csinv  %w20 %w21 cs -> %w19
+5a9722d5 : csinv w21, w22, w23, CS                   : csinv  %w22 %w23 cs -> %w21
+5a9822f6 : csinv w22, w23, w24, CS                   : csinv  %w23 %w24 cs -> %w22
+5a9a2338 : csinv w24, w25, w26, CS                   : csinv  %w25 %w26 cs -> %w24
+5a9c237a : csinv w26, w27, w28, CS                   : csinv  %w27 %w28 cs -> %w26
+5a81201e : csinv w30, w0, w1, CS                     : csinv  %w0 %w1 cs -> %w30
+5a823020 : csinv w0, w1, w2, CC                      : csinv  %w1 %w2 cc -> %w0
+5a843062 : csinv w2, w3, w4, CC                      : csinv  %w3 %w4 cc -> %w2
+5a8630a4 : csinv w4, w5, w6, CC                      : csinv  %w5 %w6 cc -> %w4
+5a8830e6 : csinv w6, w7, w8, CC                      : csinv  %w7 %w8 cc -> %w6
+5a8a3128 : csinv w8, w9, w10, CC                     : csinv  %w9 %w10 cc -> %w8
+5a8b3149 : csinv w9, w10, w11, CC                    : csinv  %w10 %w11 cc -> %w9
+5a8d318b : csinv w11, w12, w13, CC                   : csinv  %w12 %w13 cc -> %w11
+5a8f31cd : csinv w13, w14, w15, CC                   : csinv  %w14 %w15 cc -> %w13
+5a91320f : csinv w15, w16, w17, CC                   : csinv  %w16 %w17 cc -> %w15
+5a933251 : csinv w17, w18, w19, CC                   : csinv  %w18 %w19 cc -> %w17
+5a953293 : csinv w19, w20, w21, CC                   : csinv  %w20 %w21 cc -> %w19
+5a9732d5 : csinv w21, w22, w23, CC                   : csinv  %w22 %w23 cc -> %w21
+5a9832f6 : csinv w22, w23, w24, CC                   : csinv  %w23 %w24 cc -> %w22
+5a9a3338 : csinv w24, w25, w26, CC                   : csinv  %w25 %w26 cc -> %w24
+5a9c337a : csinv w26, w27, w28, CC                   : csinv  %w27 %w28 cc -> %w26
+5a81301e : csinv w30, w0, w1, CC                     : csinv  %w0 %w1 cc -> %w30
+5a824020 : csinv w0, w1, w2, MI                      : csinv  %w1 %w2 mi -> %w0
+5a844062 : csinv w2, w3, w4, MI                      : csinv  %w3 %w4 mi -> %w2
+5a8640a4 : csinv w4, w5, w6, MI                      : csinv  %w5 %w6 mi -> %w4
+5a8840e6 : csinv w6, w7, w8, MI                      : csinv  %w7 %w8 mi -> %w6
+5a8a4128 : csinv w8, w9, w10, MI                     : csinv  %w9 %w10 mi -> %w8
+5a8b4149 : csinv w9, w10, w11, MI                    : csinv  %w10 %w11 mi -> %w9
+5a8d418b : csinv w11, w12, w13, MI                   : csinv  %w12 %w13 mi -> %w11
+5a8f41cd : csinv w13, w14, w15, MI                   : csinv  %w14 %w15 mi -> %w13
+5a91420f : csinv w15, w16, w17, MI                   : csinv  %w16 %w17 mi -> %w15
+5a934251 : csinv w17, w18, w19, MI                   : csinv  %w18 %w19 mi -> %w17
+5a954293 : csinv w19, w20, w21, MI                   : csinv  %w20 %w21 mi -> %w19
+5a9742d5 : csinv w21, w22, w23, MI                   : csinv  %w22 %w23 mi -> %w21
+5a9842f6 : csinv w22, w23, w24, MI                   : csinv  %w23 %w24 mi -> %w22
+5a9a4338 : csinv w24, w25, w26, MI                   : csinv  %w25 %w26 mi -> %w24
+5a9c437a : csinv w26, w27, w28, MI                   : csinv  %w27 %w28 mi -> %w26
+5a81401e : csinv w30, w0, w1, MI                     : csinv  %w0 %w1 mi -> %w30
+5a825020 : csinv w0, w1, w2, PL                      : csinv  %w1 %w2 pl -> %w0
+5a845062 : csinv w2, w3, w4, PL                      : csinv  %w3 %w4 pl -> %w2
+5a8650a4 : csinv w4, w5, w6, PL                      : csinv  %w5 %w6 pl -> %w4
+5a8850e6 : csinv w6, w7, w8, PL                      : csinv  %w7 %w8 pl -> %w6
+5a8a5128 : csinv w8, w9, w10, PL                     : csinv  %w9 %w10 pl -> %w8
+5a8b5149 : csinv w9, w10, w11, PL                    : csinv  %w10 %w11 pl -> %w9
+5a8d518b : csinv w11, w12, w13, PL                   : csinv  %w12 %w13 pl -> %w11
+5a8f51cd : csinv w13, w14, w15, PL                   : csinv  %w14 %w15 pl -> %w13
+5a91520f : csinv w15, w16, w17, PL                   : csinv  %w16 %w17 pl -> %w15
+5a935251 : csinv w17, w18, w19, PL                   : csinv  %w18 %w19 pl -> %w17
+5a955293 : csinv w19, w20, w21, PL                   : csinv  %w20 %w21 pl -> %w19
+5a9752d5 : csinv w21, w22, w23, PL                   : csinv  %w22 %w23 pl -> %w21
+5a9852f6 : csinv w22, w23, w24, PL                   : csinv  %w23 %w24 pl -> %w22
+5a9a5338 : csinv w24, w25, w26, PL                   : csinv  %w25 %w26 pl -> %w24
+5a9c537a : csinv w26, w27, w28, PL                   : csinv  %w27 %w28 pl -> %w26
+5a81501e : csinv w30, w0, w1, PL                     : csinv  %w0 %w1 pl -> %w30
+5a826020 : csinv w0, w1, w2, VS                      : csinv  %w1 %w2 vs -> %w0
+5a846062 : csinv w2, w3, w4, VS                      : csinv  %w3 %w4 vs -> %w2
+5a8660a4 : csinv w4, w5, w6, VS                      : csinv  %w5 %w6 vs -> %w4
+5a8860e6 : csinv w6, w7, w8, VS                      : csinv  %w7 %w8 vs -> %w6
+5a8a6128 : csinv w8, w9, w10, VS                     : csinv  %w9 %w10 vs -> %w8
+5a8b6149 : csinv w9, w10, w11, VS                    : csinv  %w10 %w11 vs -> %w9
+5a8d618b : csinv w11, w12, w13, VS                   : csinv  %w12 %w13 vs -> %w11
+5a8f61cd : csinv w13, w14, w15, VS                   : csinv  %w14 %w15 vs -> %w13
+5a91620f : csinv w15, w16, w17, VS                   : csinv  %w16 %w17 vs -> %w15
+5a936251 : csinv w17, w18, w19, VS                   : csinv  %w18 %w19 vs -> %w17
+5a956293 : csinv w19, w20, w21, VS                   : csinv  %w20 %w21 vs -> %w19
+5a9762d5 : csinv w21, w22, w23, VS                   : csinv  %w22 %w23 vs -> %w21
+5a9862f6 : csinv w22, w23, w24, VS                   : csinv  %w23 %w24 vs -> %w22
+5a9a6338 : csinv w24, w25, w26, VS                   : csinv  %w25 %w26 vs -> %w24
+5a9c637a : csinv w26, w27, w28, VS                   : csinv  %w27 %w28 vs -> %w26
+5a81601e : csinv w30, w0, w1, VS                     : csinv  %w0 %w1 vs -> %w30
+5a827020 : csinv w0, w1, w2, VC                      : csinv  %w1 %w2 vc -> %w0
+5a847062 : csinv w2, w3, w4, VC                      : csinv  %w3 %w4 vc -> %w2
+5a8670a4 : csinv w4, w5, w6, VC                      : csinv  %w5 %w6 vc -> %w4
+5a8870e6 : csinv w6, w7, w8, VC                      : csinv  %w7 %w8 vc -> %w6
+5a8a7128 : csinv w8, w9, w10, VC                     : csinv  %w9 %w10 vc -> %w8
+5a8b7149 : csinv w9, w10, w11, VC                    : csinv  %w10 %w11 vc -> %w9
+5a8d718b : csinv w11, w12, w13, VC                   : csinv  %w12 %w13 vc -> %w11
+5a8f71cd : csinv w13, w14, w15, VC                   : csinv  %w14 %w15 vc -> %w13
+5a91720f : csinv w15, w16, w17, VC                   : csinv  %w16 %w17 vc -> %w15
+5a937251 : csinv w17, w18, w19, VC                   : csinv  %w18 %w19 vc -> %w17
+5a957293 : csinv w19, w20, w21, VC                   : csinv  %w20 %w21 vc -> %w19
+5a9772d5 : csinv w21, w22, w23, VC                   : csinv  %w22 %w23 vc -> %w21
+5a9872f6 : csinv w22, w23, w24, VC                   : csinv  %w23 %w24 vc -> %w22
+5a9a7338 : csinv w24, w25, w26, VC                   : csinv  %w25 %w26 vc -> %w24
+5a9c737a : csinv w26, w27, w28, VC                   : csinv  %w27 %w28 vc -> %w26
+5a81701e : csinv w30, w0, w1, VC                     : csinv  %w0 %w1 vc -> %w30
+5a828020 : csinv w0, w1, w2, HI                      : csinv  %w1 %w2 hi -> %w0
+5a848062 : csinv w2, w3, w4, HI                      : csinv  %w3 %w4 hi -> %w2
+5a8680a4 : csinv w4, w5, w6, HI                      : csinv  %w5 %w6 hi -> %w4
+5a8880e6 : csinv w6, w7, w8, HI                      : csinv  %w7 %w8 hi -> %w6
+5a8a8128 : csinv w8, w9, w10, HI                     : csinv  %w9 %w10 hi -> %w8
+5a8b8149 : csinv w9, w10, w11, HI                    : csinv  %w10 %w11 hi -> %w9
+5a8d818b : csinv w11, w12, w13, HI                   : csinv  %w12 %w13 hi -> %w11
+5a8f81cd : csinv w13, w14, w15, HI                   : csinv  %w14 %w15 hi -> %w13
+5a91820f : csinv w15, w16, w17, HI                   : csinv  %w16 %w17 hi -> %w15
+5a938251 : csinv w17, w18, w19, HI                   : csinv  %w18 %w19 hi -> %w17
+5a958293 : csinv w19, w20, w21, HI                   : csinv  %w20 %w21 hi -> %w19
+5a9782d5 : csinv w21, w22, w23, HI                   : csinv  %w22 %w23 hi -> %w21
+5a9882f6 : csinv w22, w23, w24, HI                   : csinv  %w23 %w24 hi -> %w22
+5a9a8338 : csinv w24, w25, w26, HI                   : csinv  %w25 %w26 hi -> %w24
+5a9c837a : csinv w26, w27, w28, HI                   : csinv  %w27 %w28 hi -> %w26
+5a81801e : csinv w30, w0, w1, HI                     : csinv  %w0 %w1 hi -> %w30
+5a829020 : csinv w0, w1, w2, LS                      : csinv  %w1 %w2 ls -> %w0
+5a849062 : csinv w2, w3, w4, LS                      : csinv  %w3 %w4 ls -> %w2
+5a8690a4 : csinv w4, w5, w6, LS                      : csinv  %w5 %w6 ls -> %w4
+5a8890e6 : csinv w6, w7, w8, LS                      : csinv  %w7 %w8 ls -> %w6
+5a8a9128 : csinv w8, w9, w10, LS                     : csinv  %w9 %w10 ls -> %w8
+5a8b9149 : csinv w9, w10, w11, LS                    : csinv  %w10 %w11 ls -> %w9
+5a8d918b : csinv w11, w12, w13, LS                   : csinv  %w12 %w13 ls -> %w11
+5a8f91cd : csinv w13, w14, w15, LS                   : csinv  %w14 %w15 ls -> %w13
+5a91920f : csinv w15, w16, w17, LS                   : csinv  %w16 %w17 ls -> %w15
+5a939251 : csinv w17, w18, w19, LS                   : csinv  %w18 %w19 ls -> %w17
+5a959293 : csinv w19, w20, w21, LS                   : csinv  %w20 %w21 ls -> %w19
+5a9792d5 : csinv w21, w22, w23, LS                   : csinv  %w22 %w23 ls -> %w21
+5a9892f6 : csinv w22, w23, w24, LS                   : csinv  %w23 %w24 ls -> %w22
+5a9a9338 : csinv w24, w25, w26, LS                   : csinv  %w25 %w26 ls -> %w24
+5a9c937a : csinv w26, w27, w28, LS                   : csinv  %w27 %w28 ls -> %w26
+5a81901e : csinv w30, w0, w1, LS                     : csinv  %w0 %w1 ls -> %w30
+5a82a020 : csinv w0, w1, w2, GE                      : csinv  %w1 %w2 ge -> %w0
+5a84a062 : csinv w2, w3, w4, GE                      : csinv  %w3 %w4 ge -> %w2
+5a86a0a4 : csinv w4, w5, w6, GE                      : csinv  %w5 %w6 ge -> %w4
+5a88a0e6 : csinv w6, w7, w8, GE                      : csinv  %w7 %w8 ge -> %w6
+5a8aa128 : csinv w8, w9, w10, GE                     : csinv  %w9 %w10 ge -> %w8
+5a8ba149 : csinv w9, w10, w11, GE                    : csinv  %w10 %w11 ge -> %w9
+5a8da18b : csinv w11, w12, w13, GE                   : csinv  %w12 %w13 ge -> %w11
+5a8fa1cd : csinv w13, w14, w15, GE                   : csinv  %w14 %w15 ge -> %w13
+5a91a20f : csinv w15, w16, w17, GE                   : csinv  %w16 %w17 ge -> %w15
+5a93a251 : csinv w17, w18, w19, GE                   : csinv  %w18 %w19 ge -> %w17
+5a95a293 : csinv w19, w20, w21, GE                   : csinv  %w20 %w21 ge -> %w19
+5a97a2d5 : csinv w21, w22, w23, GE                   : csinv  %w22 %w23 ge -> %w21
+5a98a2f6 : csinv w22, w23, w24, GE                   : csinv  %w23 %w24 ge -> %w22
+5a9aa338 : csinv w24, w25, w26, GE                   : csinv  %w25 %w26 ge -> %w24
+5a9ca37a : csinv w26, w27, w28, GE                   : csinv  %w27 %w28 ge -> %w26
+5a81a01e : csinv w30, w0, w1, GE                     : csinv  %w0 %w1 ge -> %w30
+5a82b020 : csinv w0, w1, w2, LT                      : csinv  %w1 %w2 lt -> %w0
+5a84b062 : csinv w2, w3, w4, LT                      : csinv  %w3 %w4 lt -> %w2
+5a86b0a4 : csinv w4, w5, w6, LT                      : csinv  %w5 %w6 lt -> %w4
+5a88b0e6 : csinv w6, w7, w8, LT                      : csinv  %w7 %w8 lt -> %w6
+5a8ab128 : csinv w8, w9, w10, LT                     : csinv  %w9 %w10 lt -> %w8
+5a8bb149 : csinv w9, w10, w11, LT                    : csinv  %w10 %w11 lt -> %w9
+5a8db18b : csinv w11, w12, w13, LT                   : csinv  %w12 %w13 lt -> %w11
+5a8fb1cd : csinv w13, w14, w15, LT                   : csinv  %w14 %w15 lt -> %w13
+5a91b20f : csinv w15, w16, w17, LT                   : csinv  %w16 %w17 lt -> %w15
+5a93b251 : csinv w17, w18, w19, LT                   : csinv  %w18 %w19 lt -> %w17
+5a95b293 : csinv w19, w20, w21, LT                   : csinv  %w20 %w21 lt -> %w19
+5a97b2d5 : csinv w21, w22, w23, LT                   : csinv  %w22 %w23 lt -> %w21
+5a98b2f6 : csinv w22, w23, w24, LT                   : csinv  %w23 %w24 lt -> %w22
+5a9ab338 : csinv w24, w25, w26, LT                   : csinv  %w25 %w26 lt -> %w24
+5a9cb37a : csinv w26, w27, w28, LT                   : csinv  %w27 %w28 lt -> %w26
+5a81b01e : csinv w30, w0, w1, LT                     : csinv  %w0 %w1 lt -> %w30
+5a82c020 : csinv w0, w1, w2, GT                      : csinv  %w1 %w2 gt -> %w0
+5a84c062 : csinv w2, w3, w4, GT                      : csinv  %w3 %w4 gt -> %w2
+5a86c0a4 : csinv w4, w5, w6, GT                      : csinv  %w5 %w6 gt -> %w4
+5a88c0e6 : csinv w6, w7, w8, GT                      : csinv  %w7 %w8 gt -> %w6
+5a8ac128 : csinv w8, w9, w10, GT                     : csinv  %w9 %w10 gt -> %w8
+5a8bc149 : csinv w9, w10, w11, GT                    : csinv  %w10 %w11 gt -> %w9
+5a8dc18b : csinv w11, w12, w13, GT                   : csinv  %w12 %w13 gt -> %w11
+5a8fc1cd : csinv w13, w14, w15, GT                   : csinv  %w14 %w15 gt -> %w13
+5a91c20f : csinv w15, w16, w17, GT                   : csinv  %w16 %w17 gt -> %w15
+5a93c251 : csinv w17, w18, w19, GT                   : csinv  %w18 %w19 gt -> %w17
+5a95c293 : csinv w19, w20, w21, GT                   : csinv  %w20 %w21 gt -> %w19
+5a97c2d5 : csinv w21, w22, w23, GT                   : csinv  %w22 %w23 gt -> %w21
+5a98c2f6 : csinv w22, w23, w24, GT                   : csinv  %w23 %w24 gt -> %w22
+5a9ac338 : csinv w24, w25, w26, GT                   : csinv  %w25 %w26 gt -> %w24
+5a9cc37a : csinv w26, w27, w28, GT                   : csinv  %w27 %w28 gt -> %w26
+5a81c01e : csinv w30, w0, w1, GT                     : csinv  %w0 %w1 gt -> %w30
+5a82d020 : csinv w0, w1, w2, LE                      : csinv  %w1 %w2 le -> %w0
+5a84d062 : csinv w2, w3, w4, LE                      : csinv  %w3 %w4 le -> %w2
+5a86d0a4 : csinv w4, w5, w6, LE                      : csinv  %w5 %w6 le -> %w4
+5a88d0e6 : csinv w6, w7, w8, LE                      : csinv  %w7 %w8 le -> %w6
+5a8ad128 : csinv w8, w9, w10, LE                     : csinv  %w9 %w10 le -> %w8
+5a8bd149 : csinv w9, w10, w11, LE                    : csinv  %w10 %w11 le -> %w9
+5a8dd18b : csinv w11, w12, w13, LE                   : csinv  %w12 %w13 le -> %w11
+5a8fd1cd : csinv w13, w14, w15, LE                   : csinv  %w14 %w15 le -> %w13
+5a91d20f : csinv w15, w16, w17, LE                   : csinv  %w16 %w17 le -> %w15
+5a93d251 : csinv w17, w18, w19, LE                   : csinv  %w18 %w19 le -> %w17
+5a95d293 : csinv w19, w20, w21, LE                   : csinv  %w20 %w21 le -> %w19
+5a97d2d5 : csinv w21, w22, w23, LE                   : csinv  %w22 %w23 le -> %w21
+5a98d2f6 : csinv w22, w23, w24, LE                   : csinv  %w23 %w24 le -> %w22
+5a9ad338 : csinv w24, w25, w26, LE                   : csinv  %w25 %w26 le -> %w24
+5a9cd37a : csinv w26, w27, w28, LE                   : csinv  %w27 %w28 le -> %w26
+5a81d01e : csinv w30, w0, w1, LE                     : csinv  %w0 %w1 le -> %w30
+5a82e020 : csinv w0, w1, w2, AL                      : csinv  %w1 %w2 al -> %w0
+5a84e062 : csinv w2, w3, w4, AL                      : csinv  %w3 %w4 al -> %w2
+5a86e0a4 : csinv w4, w5, w6, AL                      : csinv  %w5 %w6 al -> %w4
+5a88e0e6 : csinv w6, w7, w8, AL                      : csinv  %w7 %w8 al -> %w6
+5a8ae128 : csinv w8, w9, w10, AL                     : csinv  %w9 %w10 al -> %w8
+5a8be149 : csinv w9, w10, w11, AL                    : csinv  %w10 %w11 al -> %w9
+5a8de18b : csinv w11, w12, w13, AL                   : csinv  %w12 %w13 al -> %w11
+5a8fe1cd : csinv w13, w14, w15, AL                   : csinv  %w14 %w15 al -> %w13
+5a91e20f : csinv w15, w16, w17, AL                   : csinv  %w16 %w17 al -> %w15
+5a93e251 : csinv w17, w18, w19, AL                   : csinv  %w18 %w19 al -> %w17
+5a95e293 : csinv w19, w20, w21, AL                   : csinv  %w20 %w21 al -> %w19
+5a97e2d5 : csinv w21, w22, w23, AL                   : csinv  %w22 %w23 al -> %w21
+5a98e2f6 : csinv w22, w23, w24, AL                   : csinv  %w23 %w24 al -> %w22
+5a9ae338 : csinv w24, w25, w26, AL                   : csinv  %w25 %w26 al -> %w24
+5a9ce37a : csinv w26, w27, w28, AL                   : csinv  %w27 %w28 al -> %w26
+5a81e01e : csinv w30, w0, w1, AL                     : csinv  %w0 %w1 al -> %w30
+5a82f020 : csinv w0, w1, w2, NV                      : csinv  %w1 %w2 nv -> %w0
+5a84f062 : csinv w2, w3, w4, NV                      : csinv  %w3 %w4 nv -> %w2
+5a86f0a4 : csinv w4, w5, w6, NV                      : csinv  %w5 %w6 nv -> %w4
+5a88f0e6 : csinv w6, w7, w8, NV                      : csinv  %w7 %w8 nv -> %w6
+5a8af128 : csinv w8, w9, w10, NV                     : csinv  %w9 %w10 nv -> %w8
+5a8bf149 : csinv w9, w10, w11, NV                    : csinv  %w10 %w11 nv -> %w9
+5a8df18b : csinv w11, w12, w13, NV                   : csinv  %w12 %w13 nv -> %w11
+5a8ff1cd : csinv w13, w14, w15, NV                   : csinv  %w14 %w15 nv -> %w13
+5a91f20f : csinv w15, w16, w17, NV                   : csinv  %w16 %w17 nv -> %w15
+5a93f251 : csinv w17, w18, w19, NV                   : csinv  %w18 %w19 nv -> %w17
+5a95f293 : csinv w19, w20, w21, NV                   : csinv  %w20 %w21 nv -> %w19
+5a97f2d5 : csinv w21, w22, w23, NV                   : csinv  %w22 %w23 nv -> %w21
+5a98f2f6 : csinv w22, w23, w24, NV                   : csinv  %w23 %w24 nv -> %w22
+5a9af338 : csinv w24, w25, w26, NV                   : csinv  %w25 %w26 nv -> %w24
+5a9cf37a : csinv w26, w27, w28, NV                   : csinv  %w27 %w28 nv -> %w26
+5a81f01e : csinv w30, w0, w1, NV                     : csinv  %w0 %w1 nv -> %w30
+
+# SUBS    <Wd>, <Wn>, <Wm>, <extend> #<imm> (SUBS-R.RRI-32_addsub_shift)
+6b020020 : subs w0, w1, w2, LSL #0                   : subs   %w1 %w2 lsl $0x00 -> %w0
+6b040862 : subs w2, w3, w4, LSL #2                   : subs   %w3 %w4 lsl $0x02 -> %w2
+6b0610a4 : subs w4, w5, w6, LSL #4                   : subs   %w5 %w6 lsl $0x04 -> %w4
+6b0818e6 : subs w6, w7, w8, LSL #6                   : subs   %w7 %w8 lsl $0x06 -> %w6
+6b0a2128 : subs w8, w9, w10, LSL #8                  : subs   %w9 %w10 lsl $0x08 -> %w8
+6b0b2949 : subs w9, w10, w11, LSL #10                : subs   %w10 %w11 lsl $0x0a -> %w9
+6b0d318b : subs w11, w12, w13, LSL #12               : subs   %w12 %w13 lsl $0x0c -> %w11
+6b0f39cd : subs w13, w14, w15, LSL #14               : subs   %w14 %w15 lsl $0x0e -> %w13
+6b11420f : subs w15, w16, w17, LSL #16               : subs   %w16 %w17 lsl $0x10 -> %w15
+6b134651 : subs w17, w18, w19, LSL #17               : subs   %w18 %w19 lsl $0x11 -> %w17
+6b154e93 : subs w19, w20, w21, LSL #19               : subs   %w20 %w21 lsl $0x13 -> %w19
+6b1756d5 : subs w21, w22, w23, LSL #21               : subs   %w22 %w23 lsl $0x15 -> %w21
+6b185ef6 : subs w22, w23, w24, LSL #23               : subs   %w23 %w24 lsl $0x17 -> %w22
+6b1a6738 : subs w24, w25, w26, LSL #25               : subs   %w25 %w26 lsl $0x19 -> %w24
+6b1c6f7a : subs w26, w27, w28, LSL #27               : subs   %w27 %w28 lsl $0x1b -> %w26
+6b017c1e : subs w30, w0, w1, LSL #31                 : subs   %w0 %w1 lsl $0x1f -> %w30
+6b420020 : subs w0, w1, w2, LSR #0                   : subs   %w1 %w2 lsr $0x00 -> %w0
+6b440862 : subs w2, w3, w4, LSR #2                   : subs   %w3 %w4 lsr $0x02 -> %w2
+6b4610a4 : subs w4, w5, w6, LSR #4                   : subs   %w5 %w6 lsr $0x04 -> %w4
+6b4818e6 : subs w6, w7, w8, LSR #6                   : subs   %w7 %w8 lsr $0x06 -> %w6
+6b4a2128 : subs w8, w9, w10, LSR #8                  : subs   %w9 %w10 lsr $0x08 -> %w8
+6b4b2949 : subs w9, w10, w11, LSR #10                : subs   %w10 %w11 lsr $0x0a -> %w9
+6b4d318b : subs w11, w12, w13, LSR #12               : subs   %w12 %w13 lsr $0x0c -> %w11
+6b4f39cd : subs w13, w14, w15, LSR #14               : subs   %w14 %w15 lsr $0x0e -> %w13
+6b51420f : subs w15, w16, w17, LSR #16               : subs   %w16 %w17 lsr $0x10 -> %w15
+6b534651 : subs w17, w18, w19, LSR #17               : subs   %w18 %w19 lsr $0x11 -> %w17
+6b554e93 : subs w19, w20, w21, LSR #19               : subs   %w20 %w21 lsr $0x13 -> %w19
+6b5756d5 : subs w21, w22, w23, LSR #21               : subs   %w22 %w23 lsr $0x15 -> %w21
+6b585ef6 : subs w22, w23, w24, LSR #23               : subs   %w23 %w24 lsr $0x17 -> %w22
+6b5a6738 : subs w24, w25, w26, LSR #25               : subs   %w25 %w26 lsr $0x19 -> %w24
+6b5c6f7a : subs w26, w27, w28, LSR #27               : subs   %w27 %w28 lsr $0x1b -> %w26
+6b417c1e : subs w30, w0, w1, LSR #31                 : subs   %w0 %w1 lsr $0x1f -> %w30
+6b820020 : subs w0, w1, w2, ASR #0                   : subs   %w1 %w2 asr $0x00 -> %w0
+6b840862 : subs w2, w3, w4, ASR #2                   : subs   %w3 %w4 asr $0x02 -> %w2
+6b8610a4 : subs w4, w5, w6, ASR #4                   : subs   %w5 %w6 asr $0x04 -> %w4
+6b8818e6 : subs w6, w7, w8, ASR #6                   : subs   %w7 %w8 asr $0x06 -> %w6
+6b8a2128 : subs w8, w9, w10, ASR #8                  : subs   %w9 %w10 asr $0x08 -> %w8
+6b8b2949 : subs w9, w10, w11, ASR #10                : subs   %w10 %w11 asr $0x0a -> %w9
+6b8d318b : subs w11, w12, w13, ASR #12               : subs   %w12 %w13 asr $0x0c -> %w11
+6b8f39cd : subs w13, w14, w15, ASR #14               : subs   %w14 %w15 asr $0x0e -> %w13
+6b91420f : subs w15, w16, w17, ASR #16               : subs   %w16 %w17 asr $0x10 -> %w15
+6b934651 : subs w17, w18, w19, ASR #17               : subs   %w18 %w19 asr $0x11 -> %w17
+6b954e93 : subs w19, w20, w21, ASR #19               : subs   %w20 %w21 asr $0x13 -> %w19
+6b9756d5 : subs w21, w22, w23, ASR #21               : subs   %w22 %w23 asr $0x15 -> %w21
+6b985ef6 : subs w22, w23, w24, ASR #23               : subs   %w23 %w24 asr $0x17 -> %w22
+6b9a6738 : subs w24, w25, w26, ASR #25               : subs   %w25 %w26 asr $0x19 -> %w24
+6b9c6f7a : subs w26, w27, w28, ASR #27               : subs   %w27 %w28 asr $0x1b -> %w26
+6b817c1e : subs w30, w0, w1, ASR #31                 : subs   %w0 %w1 asr $0x1f -> %w30
+
+# ADD     <Wd|SP>, <Wn|SP>, <Wm>, <extend> #<imm> (ADD-R.RRI-32_addsub_ext)
+0b220020 : add w0, w1, w2, UXTB #0                   : add    %w1 %w2 uxtb $0x00 -> %w0
+0b240062 : add w2, w3, w4, UXTB #0                   : add    %w3 %w4 uxtb $0x00 -> %w2
+0b2600a4 : add w4, w5, w6, UXTB #0                   : add    %w5 %w6 uxtb $0x00 -> %w4
+0b2804e6 : add w6, w7, w8, UXTB #1                   : add    %w7 %w8 uxtb $0x01 -> %w6
+0b2a0528 : add w8, w9, w10, UXTB #1                  : add    %w9 %w10 uxtb $0x01 -> %w8
+0b2b0549 : add w9, w10, w11, UXTB #1                 : add    %w10 %w11 uxtb $0x01 -> %w9
+0b2d098b : add w11, w12, w13, UXTB #2                : add    %w12 %w13 uxtb $0x02 -> %w11
+0b2f09cd : add w13, w14, w15, UXTB #2                : add    %w14 %w15 uxtb $0x02 -> %w13
+0b310a0f : add w15, w16, w17, UXTB #2                : add    %w16 %w17 uxtb $0x02 -> %w15
+0b330a51 : add w17, w18, w19, UXTB #2                : add    %w18 %w19 uxtb $0x02 -> %w17
+0b350a93 : add w19, w20, w21, UXTB #2                : add    %w20 %w21 uxtb $0x02 -> %w19
+0b370ed5 : add w21, w22, w23, UXTB #3                : add    %w22 %w23 uxtb $0x03 -> %w21
+0b380ef6 : add w22, w23, w24, UXTB #3                : add    %w23 %w24 uxtb $0x03 -> %w22
+0b3a0f38 : add w24, w25, w26, UXTB #3                : add    %w25 %w26 uxtb $0x03 -> %w24
+0b3c137a : add w26, w27, w28, UXTB #4                : add    %w27 %w28 uxtb $0x04 -> %w26
+0b21101f : add wsp, w0, w1, UXTB #4                  : add    %w0 %w1 uxtb $0x04 -> %wsp
+0b222020 : add w0, w1, w2, UXTH #0                   : add    %w1 %w2 uxth $0x00 -> %w0
+0b242062 : add w2, w3, w4, UXTH #0                   : add    %w3 %w4 uxth $0x00 -> %w2
+0b2620a4 : add w4, w5, w6, UXTH #0                   : add    %w5 %w6 uxth $0x00 -> %w4
+0b2824e6 : add w6, w7, w8, UXTH #1                   : add    %w7 %w8 uxth $0x01 -> %w6
+0b2a2528 : add w8, w9, w10, UXTH #1                  : add    %w9 %w10 uxth $0x01 -> %w8
+0b2b2549 : add w9, w10, w11, UXTH #1                 : add    %w10 %w11 uxth $0x01 -> %w9
+0b2d298b : add w11, w12, w13, UXTH #2                : add    %w12 %w13 uxth $0x02 -> %w11
+0b2f29cd : add w13, w14, w15, UXTH #2                : add    %w14 %w15 uxth $0x02 -> %w13
+0b312a0f : add w15, w16, w17, UXTH #2                : add    %w16 %w17 uxth $0x02 -> %w15
+0b332a51 : add w17, w18, w19, UXTH #2                : add    %w18 %w19 uxth $0x02 -> %w17
+0b352a93 : add w19, w20, w21, UXTH #2                : add    %w20 %w21 uxth $0x02 -> %w19
+0b372ed5 : add w21, w22, w23, UXTH #3                : add    %w22 %w23 uxth $0x03 -> %w21
+0b382ef6 : add w22, w23, w24, UXTH #3                : add    %w23 %w24 uxth $0x03 -> %w22
+0b3a2f38 : add w24, w25, w26, UXTH #3                : add    %w25 %w26 uxth $0x03 -> %w24
+0b3c337a : add w26, w27, w28, UXTH #4                : add    %w27 %w28 uxth $0x04 -> %w26
+0b21301f : add wsp, w0, w1, UXTH #4                  : add    %w0 %w1 uxth $0x04 -> %wsp
+0b224020 : add w0, w1, w2, UXTW #0                   : add    %w1 %w2 uxtw $0x00 -> %w0
+0b244062 : add w2, w3, w4, UXTW #0                   : add    %w3 %w4 uxtw $0x00 -> %w2
+0b2640a4 : add w4, w5, w6, UXTW #0                   : add    %w5 %w6 uxtw $0x00 -> %w4
+0b2844e6 : add w6, w7, w8, UXTW #1                   : add    %w7 %w8 uxtw $0x01 -> %w6
+0b2a4528 : add w8, w9, w10, UXTW #1                  : add    %w9 %w10 uxtw $0x01 -> %w8
+0b2b4549 : add w9, w10, w11, UXTW #1                 : add    %w10 %w11 uxtw $0x01 -> %w9
+0b2d498b : add w11, w12, w13, UXTW #2                : add    %w12 %w13 uxtw $0x02 -> %w11
+0b2f49cd : add w13, w14, w15, UXTW #2                : add    %w14 %w15 uxtw $0x02 -> %w13
+0b314a0f : add w15, w16, w17, UXTW #2                : add    %w16 %w17 uxtw $0x02 -> %w15
+0b334a51 : add w17, w18, w19, UXTW #2                : add    %w18 %w19 uxtw $0x02 -> %w17
+0b354a93 : add w19, w20, w21, UXTW #2                : add    %w20 %w21 uxtw $0x02 -> %w19
+0b374ed5 : add w21, w22, w23, UXTW #3                : add    %w22 %w23 uxtw $0x03 -> %w21
+0b384ef6 : add w22, w23, w24, UXTW #3                : add    %w23 %w24 uxtw $0x03 -> %w22
+0b3a4f38 : add w24, w25, w26, UXTW #3                : add    %w25 %w26 uxtw $0x03 -> %w24
+0b3c537a : add w26, w27, w28, UXTW #4                : add    %w27 %w28 uxtw $0x04 -> %w26
+0b21501f : add wsp, w0, w1, UXTW #4                  : add    %w0 %w1 uxtw $0x04 -> %wsp
+0b226020 : add w0, w1, w2, UXTX #0                   : add    %w1 %w2 uxtx $0x00 -> %w0
+0b246062 : add w2, w3, w4, UXTX #0                   : add    %w3 %w4 uxtx $0x00 -> %w2
+0b2660a4 : add w4, w5, w6, UXTX #0                   : add    %w5 %w6 uxtx $0x00 -> %w4
+0b2864e6 : add w6, w7, w8, UXTX #1                   : add    %w7 %w8 uxtx $0x01 -> %w6
+0b2a6528 : add w8, w9, w10, UXTX #1                  : add    %w9 %w10 uxtx $0x01 -> %w8
+0b2b6549 : add w9, w10, w11, UXTX #1                 : add    %w10 %w11 uxtx $0x01 -> %w9
+0b2d698b : add w11, w12, w13, UXTX #2                : add    %w12 %w13 uxtx $0x02 -> %w11
+0b2f69cd : add w13, w14, w15, UXTX #2                : add    %w14 %w15 uxtx $0x02 -> %w13
+0b316a0f : add w15, w16, w17, UXTX #2                : add    %w16 %w17 uxtx $0x02 -> %w15
+0b336a51 : add w17, w18, w19, UXTX #2                : add    %w18 %w19 uxtx $0x02 -> %w17
+0b356a93 : add w19, w20, w21, UXTX #2                : add    %w20 %w21 uxtx $0x02 -> %w19
+0b376ed5 : add w21, w22, w23, UXTX #3                : add    %w22 %w23 uxtx $0x03 -> %w21
+0b386ef6 : add w22, w23, w24, UXTX #3                : add    %w23 %w24 uxtx $0x03 -> %w22
+0b3a6f38 : add w24, w25, w26, UXTX #3                : add    %w25 %w26 uxtx $0x03 -> %w24
+0b3c737a : add w26, w27, w28, UXTX #4                : add    %w27 %w28 uxtx $0x04 -> %w26
+0b21701f : add wsp, w0, w1, UXTX #4                  : add    %w0 %w1 uxtx $0x04 -> %wsp
+0b228020 : add w0, w1, w2, SXTB #0                   : add    %w1 %w2 sxtb $0x00 -> %w0
+0b248062 : add w2, w3, w4, SXTB #0                   : add    %w3 %w4 sxtb $0x00 -> %w2
+0b2680a4 : add w4, w5, w6, SXTB #0                   : add    %w5 %w6 sxtb $0x00 -> %w4
+0b2884e6 : add w6, w7, w8, SXTB #1                   : add    %w7 %w8 sxtb $0x01 -> %w6
+0b2a8528 : add w8, w9, w10, SXTB #1                  : add    %w9 %w10 sxtb $0x01 -> %w8
+0b2b8549 : add w9, w10, w11, SXTB #1                 : add    %w10 %w11 sxtb $0x01 -> %w9
+0b2d898b : add w11, w12, w13, SXTB #2                : add    %w12 %w13 sxtb $0x02 -> %w11
+0b2f89cd : add w13, w14, w15, SXTB #2                : add    %w14 %w15 sxtb $0x02 -> %w13
+0b318a0f : add w15, w16, w17, SXTB #2                : add    %w16 %w17 sxtb $0x02 -> %w15
+0b338a51 : add w17, w18, w19, SXTB #2                : add    %w18 %w19 sxtb $0x02 -> %w17
+0b358a93 : add w19, w20, w21, SXTB #2                : add    %w20 %w21 sxtb $0x02 -> %w19
+0b378ed5 : add w21, w22, w23, SXTB #3                : add    %w22 %w23 sxtb $0x03 -> %w21
+0b388ef6 : add w22, w23, w24, SXTB #3                : add    %w23 %w24 sxtb $0x03 -> %w22
+0b3a8f38 : add w24, w25, w26, SXTB #3                : add    %w25 %w26 sxtb $0x03 -> %w24
+0b3c937a : add w26, w27, w28, SXTB #4                : add    %w27 %w28 sxtb $0x04 -> %w26
+0b21901f : add wsp, w0, w1, SXTB #4                  : add    %w0 %w1 sxtb $0x04 -> %wsp
+0b22a020 : add w0, w1, w2, SXTH #0                   : add    %w1 %w2 sxth $0x00 -> %w0
+0b24a062 : add w2, w3, w4, SXTH #0                   : add    %w3 %w4 sxth $0x00 -> %w2
+0b26a0a4 : add w4, w5, w6, SXTH #0                   : add    %w5 %w6 sxth $0x00 -> %w4
+0b28a4e6 : add w6, w7, w8, SXTH #1                   : add    %w7 %w8 sxth $0x01 -> %w6
+0b2aa528 : add w8, w9, w10, SXTH #1                  : add    %w9 %w10 sxth $0x01 -> %w8
+0b2ba549 : add w9, w10, w11, SXTH #1                 : add    %w10 %w11 sxth $0x01 -> %w9
+0b2da98b : add w11, w12, w13, SXTH #2                : add    %w12 %w13 sxth $0x02 -> %w11
+0b2fa9cd : add w13, w14, w15, SXTH #2                : add    %w14 %w15 sxth $0x02 -> %w13
+0b31aa0f : add w15, w16, w17, SXTH #2                : add    %w16 %w17 sxth $0x02 -> %w15
+0b33aa51 : add w17, w18, w19, SXTH #2                : add    %w18 %w19 sxth $0x02 -> %w17
+0b35aa93 : add w19, w20, w21, SXTH #2                : add    %w20 %w21 sxth $0x02 -> %w19
+0b37aed5 : add w21, w22, w23, SXTH #3                : add    %w22 %w23 sxth $0x03 -> %w21
+0b38aef6 : add w22, w23, w24, SXTH #3                : add    %w23 %w24 sxth $0x03 -> %w22
+0b3aaf38 : add w24, w25, w26, SXTH #3                : add    %w25 %w26 sxth $0x03 -> %w24
+0b3cb37a : add w26, w27, w28, SXTH #4                : add    %w27 %w28 sxth $0x04 -> %w26
+0b21b01f : add wsp, w0, w1, SXTH #4                  : add    %w0 %w1 sxth $0x04 -> %wsp
+0b22c020 : add w0, w1, w2, SXTW #0                   : add    %w1 %w2 sxtw $0x00 -> %w0
+0b24c062 : add w2, w3, w4, SXTW #0                   : add    %w3 %w4 sxtw $0x00 -> %w2
+0b26c0a4 : add w4, w5, w6, SXTW #0                   : add    %w5 %w6 sxtw $0x00 -> %w4
+0b28c4e6 : add w6, w7, w8, SXTW #1                   : add    %w7 %w8 sxtw $0x01 -> %w6
+0b2ac528 : add w8, w9, w10, SXTW #1                  : add    %w9 %w10 sxtw $0x01 -> %w8
+0b2bc549 : add w9, w10, w11, SXTW #1                 : add    %w10 %w11 sxtw $0x01 -> %w9
+0b2dc98b : add w11, w12, w13, SXTW #2                : add    %w12 %w13 sxtw $0x02 -> %w11
+0b2fc9cd : add w13, w14, w15, SXTW #2                : add    %w14 %w15 sxtw $0x02 -> %w13
+0b31ca0f : add w15, w16, w17, SXTW #2                : add    %w16 %w17 sxtw $0x02 -> %w15
+0b33ca51 : add w17, w18, w19, SXTW #2                : add    %w18 %w19 sxtw $0x02 -> %w17
+0b35ca93 : add w19, w20, w21, SXTW #2                : add    %w20 %w21 sxtw $0x02 -> %w19
+0b37ced5 : add w21, w22, w23, SXTW #3                : add    %w22 %w23 sxtw $0x03 -> %w21
+0b38cef6 : add w22, w23, w24, SXTW #3                : add    %w23 %w24 sxtw $0x03 -> %w22
+0b3acf38 : add w24, w25, w26, SXTW #3                : add    %w25 %w26 sxtw $0x03 -> %w24
+0b3cd37a : add w26, w27, w28, SXTW #4                : add    %w27 %w28 sxtw $0x04 -> %w26
+0b21d01f : add wsp, w0, w1, SXTW #4                  : add    %w0 %w1 sxtw $0x04 -> %wsp
+0b22e020 : add w0, w1, w2, SXTX #0                   : add    %w1 %w2 sxtx $0x00 -> %w0
+0b24e062 : add w2, w3, w4, SXTX #0                   : add    %w3 %w4 sxtx $0x00 -> %w2
+0b26e0a4 : add w4, w5, w6, SXTX #0                   : add    %w5 %w6 sxtx $0x00 -> %w4
+0b28e4e6 : add w6, w7, w8, SXTX #1                   : add    %w7 %w8 sxtx $0x01 -> %w6
+0b2ae528 : add w8, w9, w10, SXTX #1                  : add    %w9 %w10 sxtx $0x01 -> %w8
+0b2be549 : add w9, w10, w11, SXTX #1                 : add    %w10 %w11 sxtx $0x01 -> %w9
+0b2de98b : add w11, w12, w13, SXTX #2                : add    %w12 %w13 sxtx $0x02 -> %w11
+0b2fe9cd : add w13, w14, w15, SXTX #2                : add    %w14 %w15 sxtx $0x02 -> %w13
+0b31ea0f : add w15, w16, w17, SXTX #2                : add    %w16 %w17 sxtx $0x02 -> %w15
+0b33ea51 : add w17, w18, w19, SXTX #2                : add    %w18 %w19 sxtx $0x02 -> %w17
+0b35ea93 : add w19, w20, w21, SXTX #2                : add    %w20 %w21 sxtx $0x02 -> %w19
+0b37eed5 : add w21, w22, w23, SXTX #3                : add    %w22 %w23 sxtx $0x03 -> %w21
+0b38eef6 : add w22, w23, w24, SXTX #3                : add    %w23 %w24 sxtx $0x03 -> %w22
+0b3aef38 : add w24, w25, w26, SXTX #3                : add    %w25 %w26 sxtx $0x03 -> %w24
+0b3cf37a : add w26, w27, w28, SXTX #4                : add    %w27 %w28 sxtx $0x04 -> %w26
+0b21f01f : add wsp, w0, w1, SXTX #4                  : add    %w0 %w1 sxtx $0x04 -> %wsp
+
+# UBFM    <Wd>, <Wn>, #<imm1>, #<imm2> (UBFM-R.RII-32M_bitfield)
+53000020 : ubfm w0, w1, #0x0, #0x0                   : ubfm   %w1 $0x00 $0x00 -> %w0
+53020862 : ubfm w2, w3, #0x2, #0x2                   : ubfm   %w3 $0x02 $0x02 -> %w2
+530410a4 : ubfm w4, w5, #0x4, #0x4                   : ubfm   %w5 $0x04 $0x04 -> %w4
+530618e6 : ubfm w6, w7, #0x6, #0x6                   : ubfm   %w7 $0x06 $0x06 -> %w6
+53082128 : ubfm w8, w9, #0x8, #0x8                   : ubfm   %w9 $0x08 $0x08 -> %w8
+530a2949 : ubfm w9, w10, #0xa, #0xa                  : ubfm   %w10 $0x0a $0x0a -> %w9
+530c318b : ubfm w11, w12, #0xc, #0xc                 : ubfm   %w12 $0x0c $0x0c -> %w11
+530e39cd : ubfm w13, w14, #0xe, #0xe                 : ubfm   %w14 $0x0e $0x0e -> %w13
+5310420f : ubfm w15, w16, #0x10, #0x10               : ubfm   %w16 $0x10 $0x10 -> %w15
+53114651 : ubfm w17, w18, #0x11, #0x11               : ubfm   %w18 $0x11 $0x11 -> %w17
+53134e93 : ubfm w19, w20, #0x13, #0x13               : ubfm   %w20 $0x13 $0x13 -> %w19
+531556d5 : ubfm w21, w22, #0x15, #0x15               : ubfm   %w22 $0x15 $0x15 -> %w21
+53175ef6 : ubfm w22, w23, #0x17, #0x17               : ubfm   %w23 $0x17 $0x17 -> %w22
+53196738 : ubfm w24, w25, #0x19, #0x19               : ubfm   %w25 $0x19 $0x19 -> %w24
+531b6f7a : ubfm w26, w27, #0x1b, #0x1b               : ubfm   %w27 $0x1b $0x1b -> %w26
+531f7c1e : ubfm w30, w0, #0x1f, #0x1f                : ubfm   %w0 $0x1f $0x1f -> %w30
+
+# ANDS    <Xd>, <Xn>, <Xm>, <extend> #<imm> (ANDS-R.RRI-64_log_shift)
+ea020020 : ands x0, x1, x2, LSL #0                   : ands   %x1 %x2 lsl $0x00 -> %x0
+ea040862 : ands x2, x3, x4, LSL #2                   : ands   %x3 %x4 lsl $0x02 -> %x2
+ea0610a4 : ands x4, x5, x6, LSL #4                   : ands   %x5 %x6 lsl $0x04 -> %x4
+ea0818e6 : ands x6, x7, x8, LSL #6                   : ands   %x7 %x8 lsl $0x06 -> %x6
+ea0a2128 : ands x8, x9, x10, LSL #8                  : ands   %x9 %x10 lsl $0x08 -> %x8
+ea0b2949 : ands x9, x10, x11, LSL #10                : ands   %x10 %x11 lsl $0x0a -> %x9
+ea0d318b : ands x11, x12, x13, LSL #12               : ands   %x12 %x13 lsl $0x0c -> %x11
+ea0f39cd : ands x13, x14, x15, LSL #14               : ands   %x14 %x15 lsl $0x0e -> %x13
+ea11420f : ands x15, x16, x17, LSL #16               : ands   %x16 %x17 lsl $0x10 -> %x15
+ea134651 : ands x17, x18, x19, LSL #17               : ands   %x18 %x19 lsl $0x11 -> %x17
+ea154e93 : ands x19, x20, x21, LSL #19               : ands   %x20 %x21 lsl $0x13 -> %x19
+ea1756d5 : ands x21, x22, x23, LSL #21               : ands   %x22 %x23 lsl $0x15 -> %x21
+ea185ef6 : ands x22, x23, x24, LSL #23               : ands   %x23 %x24 lsl $0x17 -> %x22
+ea1a6738 : ands x24, x25, x26, LSL #25               : ands   %x25 %x26 lsl $0x19 -> %x24
+ea1c6f7a : ands x26, x27, x28, LSL #27               : ands   %x27 %x28 lsl $0x1b -> %x26
+ea017c1e : ands x30, x0, x1, LSL #31                 : ands   %x0 %x1 lsl $0x1f -> %x30
+ea420020 : ands x0, x1, x2, LSR #0                   : ands   %x1 %x2 lsr $0x00 -> %x0
+ea440862 : ands x2, x3, x4, LSR #2                   : ands   %x3 %x4 lsr $0x02 -> %x2
+ea4610a4 : ands x4, x5, x6, LSR #4                   : ands   %x5 %x6 lsr $0x04 -> %x4
+ea4818e6 : ands x6, x7, x8, LSR #6                   : ands   %x7 %x8 lsr $0x06 -> %x6
+ea4a2128 : ands x8, x9, x10, LSR #8                  : ands   %x9 %x10 lsr $0x08 -> %x8
+ea4b2949 : ands x9, x10, x11, LSR #10                : ands   %x10 %x11 lsr $0x0a -> %x9
+ea4d318b : ands x11, x12, x13, LSR #12               : ands   %x12 %x13 lsr $0x0c -> %x11
+ea4f39cd : ands x13, x14, x15, LSR #14               : ands   %x14 %x15 lsr $0x0e -> %x13
+ea51420f : ands x15, x16, x17, LSR #16               : ands   %x16 %x17 lsr $0x10 -> %x15
+ea534651 : ands x17, x18, x19, LSR #17               : ands   %x18 %x19 lsr $0x11 -> %x17
+ea554e93 : ands x19, x20, x21, LSR #19               : ands   %x20 %x21 lsr $0x13 -> %x19
+ea5756d5 : ands x21, x22, x23, LSR #21               : ands   %x22 %x23 lsr $0x15 -> %x21
+ea585ef6 : ands x22, x23, x24, LSR #23               : ands   %x23 %x24 lsr $0x17 -> %x22
+ea5a6738 : ands x24, x25, x26, LSR #25               : ands   %x25 %x26 lsr $0x19 -> %x24
+ea5c6f7a : ands x26, x27, x28, LSR #27               : ands   %x27 %x28 lsr $0x1b -> %x26
+ea417c1e : ands x30, x0, x1, LSR #31                 : ands   %x0 %x1 lsr $0x1f -> %x30
+ea820020 : ands x0, x1, x2, ASR #0                   : ands   %x1 %x2 asr $0x00 -> %x0
+ea840862 : ands x2, x3, x4, ASR #2                   : ands   %x3 %x4 asr $0x02 -> %x2
+ea8610a4 : ands x4, x5, x6, ASR #4                   : ands   %x5 %x6 asr $0x04 -> %x4
+ea8818e6 : ands x6, x7, x8, ASR #6                   : ands   %x7 %x8 asr $0x06 -> %x6
+ea8a2128 : ands x8, x9, x10, ASR #8                  : ands   %x9 %x10 asr $0x08 -> %x8
+ea8b2949 : ands x9, x10, x11, ASR #10                : ands   %x10 %x11 asr $0x0a -> %x9
+ea8d318b : ands x11, x12, x13, ASR #12               : ands   %x12 %x13 asr $0x0c -> %x11
+ea8f39cd : ands x13, x14, x15, ASR #14               : ands   %x14 %x15 asr $0x0e -> %x13
+ea91420f : ands x15, x16, x17, ASR #16               : ands   %x16 %x17 asr $0x10 -> %x15
+ea934651 : ands x17, x18, x19, ASR #17               : ands   %x18 %x19 asr $0x11 -> %x17
+ea954e93 : ands x19, x20, x21, ASR #19               : ands   %x20 %x21 asr $0x13 -> %x19
+ea9756d5 : ands x21, x22, x23, ASR #21               : ands   %x22 %x23 asr $0x15 -> %x21
+ea985ef6 : ands x22, x23, x24, ASR #23               : ands   %x23 %x24 asr $0x17 -> %x22
+ea9a6738 : ands x24, x25, x26, ASR #25               : ands   %x25 %x26 asr $0x19 -> %x24
+ea9c6f7a : ands x26, x27, x28, ASR #27               : ands   %x27 %x28 asr $0x1b -> %x26
+ea817c1e : ands x30, x0, x1, ASR #31                 : ands   %x0 %x1 asr $0x1f -> %x30
+eac20020 : ands x0, x1, x2, ROR #0                   : ands   %x1 %x2 ror $0x00 -> %x0
+eac40862 : ands x2, x3, x4, ROR #2                   : ands   %x3 %x4 ror $0x02 -> %x2
+eac610a4 : ands x4, x5, x6, ROR #4                   : ands   %x5 %x6 ror $0x04 -> %x4
+eac818e6 : ands x6, x7, x8, ROR #6                   : ands   %x7 %x8 ror $0x06 -> %x6
+eaca2128 : ands x8, x9, x10, ROR #8                  : ands   %x9 %x10 ror $0x08 -> %x8
+eacb2949 : ands x9, x10, x11, ROR #10                : ands   %x10 %x11 ror $0x0a -> %x9
+eacd318b : ands x11, x12, x13, ROR #12               : ands   %x12 %x13 ror $0x0c -> %x11
+eacf39cd : ands x13, x14, x15, ROR #14               : ands   %x14 %x15 ror $0x0e -> %x13
+ead1420f : ands x15, x16, x17, ROR #16               : ands   %x16 %x17 ror $0x10 -> %x15
+ead34651 : ands x17, x18, x19, ROR #17               : ands   %x18 %x19 ror $0x11 -> %x17
+ead54e93 : ands x19, x20, x21, ROR #19               : ands   %x20 %x21 ror $0x13 -> %x19
+ead756d5 : ands x21, x22, x23, ROR #21               : ands   %x22 %x23 ror $0x15 -> %x21
+ead85ef6 : ands x22, x23, x24, ROR #23               : ands   %x23 %x24 ror $0x17 -> %x22
+eada6738 : ands x24, x25, x26, ROR #25               : ands   %x25 %x26 ror $0x19 -> %x24
+eadc6f7a : ands x26, x27, x28, ROR #27               : ands   %x27 %x28 ror $0x1b -> %x26
+eac17c1e : ands x30, x0, x1, ROR #31                 : ands   %x0 %x1 ror $0x1f -> %x30
+
+# RORV    <Xd>, <Xn>, <Xm> (RORV-R.RR-64_dp_2src)
+9ac22c20 : rorv x0, x1, x2                           : rorv   %x1 %x2 -> %x0
+9ac42c62 : rorv x2, x3, x4                           : rorv   %x3 %x4 -> %x2
+9ac62ca4 : rorv x4, x5, x6                           : rorv   %x5 %x6 -> %x4
+9ac82ce6 : rorv x6, x7, x8                           : rorv   %x7 %x8 -> %x6
+9aca2d28 : rorv x8, x9, x10                          : rorv   %x9 %x10 -> %x8
+9acb2d49 : rorv x9, x10, x11                         : rorv   %x10 %x11 -> %x9
+9acd2d8b : rorv x11, x12, x13                        : rorv   %x12 %x13 -> %x11
+9acf2dcd : rorv x13, x14, x15                        : rorv   %x14 %x15 -> %x13
+9ad12e0f : rorv x15, x16, x17                        : rorv   %x16 %x17 -> %x15
+9ad32e51 : rorv x17, x18, x19                        : rorv   %x18 %x19 -> %x17
+9ad52e93 : rorv x19, x20, x21                        : rorv   %x20 %x21 -> %x19
+9ad72ed5 : rorv x21, x22, x23                        : rorv   %x22 %x23 -> %x21
+9ad82ef6 : rorv x22, x23, x24                        : rorv   %x23 %x24 -> %x22
+9ada2f38 : rorv x24, x25, x26                        : rorv   %x25 %x26 -> %x24
+9adc2f7a : rorv x26, x27, x28                        : rorv   %x27 %x28 -> %x26
+9ac12c1e : rorv x30, x0, x1                          : rorv   %x0 %x1 -> %x30
+
+# UDIV    <Wd>, <Wn>, <Wm> (UDIV-R.RR-32_dp_2src)
+1ac20820 : udiv w0, w1, w2                           : udiv   %w1 %w2 -> %w0
+1ac40862 : udiv w2, w3, w4                           : udiv   %w3 %w4 -> %w2
+1ac608a4 : udiv w4, w5, w6                           : udiv   %w5 %w6 -> %w4
+1ac808e6 : udiv w6, w7, w8                           : udiv   %w7 %w8 -> %w6
+1aca0928 : udiv w8, w9, w10                          : udiv   %w9 %w10 -> %w8
+1acb0949 : udiv w9, w10, w11                         : udiv   %w10 %w11 -> %w9
+1acd098b : udiv w11, w12, w13                        : udiv   %w12 %w13 -> %w11
+1acf09cd : udiv w13, w14, w15                        : udiv   %w14 %w15 -> %w13
+1ad10a0f : udiv w15, w16, w17                        : udiv   %w16 %w17 -> %w15
+1ad30a51 : udiv w17, w18, w19                        : udiv   %w18 %w19 -> %w17
+1ad50a93 : udiv w19, w20, w21                        : udiv   %w20 %w21 -> %w19
+1ad70ad5 : udiv w21, w22, w23                        : udiv   %w22 %w23 -> %w21
+1ad80af6 : udiv w22, w23, w24                        : udiv   %w23 %w24 -> %w22
+1ada0b38 : udiv w24, w25, w26                        : udiv   %w25 %w26 -> %w24
+1adc0b7a : udiv w26, w27, w28                        : udiv   %w27 %w28 -> %w26
+1ac1081e : udiv w30, w0, w1                          : udiv   %w0 %w1 -> %w30
+
+# AND     <Xd|SP>, <Xn>, #<imm> (AND-R.RI-64_log_imm)
+92000020 : and x0, x1, #0x100000001                  : and    %x1 $0x0000000100000001 -> %x0
+92040062 : and x2, x3, #0x1000000010000000           : and    %x3 $0x1000000010000000 -> %x2
+920800a4 : and x4, x5, #0x100000001000000            : and    %x5 $0x0100000001000000 -> %x4
+920c00e6 : and x6, x7, #0x10000000100000             : and    %x7 $0x0010000000100000 -> %x6
+92100128 : and x8, x9, #0x1000000010000              : and    %x9 $0x0001000000010000 -> %x8
+92140149 : and x9, x10, #0x100000001000              : and    %x10 $0x0000100000001000 -> %x9
+9218018b : and x11, x12, #0x10000000100              : and    %x12 $0x0000010000000100 -> %x11
+921c01cd : and x13, x14, #0x1000000010               : and    %x14 $0x0000001000000010 -> %x13
+9200020f : and x15, x16, #0x100000001                : and    %x16 $0x0000000100000001 -> %x15
+9203ea51 : and x17, x18, #0xeeeeeeeeeeeeeeee         : and    %x18 $0xeeeeeeeeeeeeeeee -> %x17
+9203ea93 : and x19, x20, #0xeeeeeeeeeeeeeeee         : and    %x20 $0xeeeeeeeeeeeeeeee -> %x19
+9203ead5 : and x21, x22, #0xeeeeeeeeeeeeeeee         : and    %x22 $0xeeeeeeeeeeeeeeee -> %x21
+9203eaf6 : and x22, x23, #0xeeeeeeeeeeeeeeee         : and    %x23 $0xeeeeeeeeeeeeeeee -> %x22
+9203eb38 : and x24, x25, #0xeeeeeeeeeeeeeeee         : and    %x25 $0xeeeeeeeeeeeeeeee -> %x24
+9203eb7a : and x26, x27, #0xeeeeeeeeeeeeeeee         : and    %x27 $0xeeeeeeeeeeeeeeee -> %x26
+9203e81f : and sp, x0, #0xeeeeeeeeeeeeeeee           : and    %x0 $0xeeeeeeeeeeeeeeee -> %sp
+
+# ADD     <Wd>, <Wn>, <Wm>, <extend> #<imm> (ADD-R.RRI-32_addsub_shift)
+0b020020 : add w0, w1, w2, LSL #0                    : add    %w1 %w2 lsl $0x00 -> %w0
+0b040862 : add w2, w3, w4, LSL #2                    : add    %w3 %w4 lsl $0x02 -> %w2
+0b0610a4 : add w4, w5, w6, LSL #4                    : add    %w5 %w6 lsl $0x04 -> %w4
+0b0818e6 : add w6, w7, w8, LSL #6                    : add    %w7 %w8 lsl $0x06 -> %w6
+0b0a2128 : add w8, w9, w10, LSL #8                   : add    %w9 %w10 lsl $0x08 -> %w8
+0b0b2949 : add w9, w10, w11, LSL #10                 : add    %w10 %w11 lsl $0x0a -> %w9
+0b0d318b : add w11, w12, w13, LSL #12                : add    %w12 %w13 lsl $0x0c -> %w11
+0b0f39cd : add w13, w14, w15, LSL #14                : add    %w14 %w15 lsl $0x0e -> %w13
+0b11420f : add w15, w16, w17, LSL #16                : add    %w16 %w17 lsl $0x10 -> %w15
+0b134651 : add w17, w18, w19, LSL #17                : add    %w18 %w19 lsl $0x11 -> %w17
+0b154e93 : add w19, w20, w21, LSL #19                : add    %w20 %w21 lsl $0x13 -> %w19
+0b1756d5 : add w21, w22, w23, LSL #21                : add    %w22 %w23 lsl $0x15 -> %w21
+0b185ef6 : add w22, w23, w24, LSL #23                : add    %w23 %w24 lsl $0x17 -> %w22
+0b1a6738 : add w24, w25, w26, LSL #25                : add    %w25 %w26 lsl $0x19 -> %w24
+0b1c6f7a : add w26, w27, w28, LSL #27                : add    %w27 %w28 lsl $0x1b -> %w26
+0b017c1e : add w30, w0, w1, LSL #31                  : add    %w0 %w1 lsl $0x1f -> %w30
+0b420020 : add w0, w1, w2, LSR #0                    : add    %w1 %w2 lsr $0x00 -> %w0
+0b440862 : add w2, w3, w4, LSR #2                    : add    %w3 %w4 lsr $0x02 -> %w2
+0b4610a4 : add w4, w5, w6, LSR #4                    : add    %w5 %w6 lsr $0x04 -> %w4
+0b4818e6 : add w6, w7, w8, LSR #6                    : add    %w7 %w8 lsr $0x06 -> %w6
+0b4a2128 : add w8, w9, w10, LSR #8                   : add    %w9 %w10 lsr $0x08 -> %w8
+0b4b2949 : add w9, w10, w11, LSR #10                 : add    %w10 %w11 lsr $0x0a -> %w9
+0b4d318b : add w11, w12, w13, LSR #12                : add    %w12 %w13 lsr $0x0c -> %w11
+0b4f39cd : add w13, w14, w15, LSR #14                : add    %w14 %w15 lsr $0x0e -> %w13
+0b51420f : add w15, w16, w17, LSR #16                : add    %w16 %w17 lsr $0x10 -> %w15
+0b534651 : add w17, w18, w19, LSR #17                : add    %w18 %w19 lsr $0x11 -> %w17
+0b554e93 : add w19, w20, w21, LSR #19                : add    %w20 %w21 lsr $0x13 -> %w19
+0b5756d5 : add w21, w22, w23, LSR #21                : add    %w22 %w23 lsr $0x15 -> %w21
+0b585ef6 : add w22, w23, w24, LSR #23                : add    %w23 %w24 lsr $0x17 -> %w22
+0b5a6738 : add w24, w25, w26, LSR #25                : add    %w25 %w26 lsr $0x19 -> %w24
+0b5c6f7a : add w26, w27, w28, LSR #27                : add    %w27 %w28 lsr $0x1b -> %w26
+0b417c1e : add w30, w0, w1, LSR #31                  : add    %w0 %w1 lsr $0x1f -> %w30
+0b820020 : add w0, w1, w2, ASR #0                    : add    %w1 %w2 asr $0x00 -> %w0
+0b840862 : add w2, w3, w4, ASR #2                    : add    %w3 %w4 asr $0x02 -> %w2
+0b8610a4 : add w4, w5, w6, ASR #4                    : add    %w5 %w6 asr $0x04 -> %w4
+0b8818e6 : add w6, w7, w8, ASR #6                    : add    %w7 %w8 asr $0x06 -> %w6
+0b8a2128 : add w8, w9, w10, ASR #8                   : add    %w9 %w10 asr $0x08 -> %w8
+0b8b2949 : add w9, w10, w11, ASR #10                 : add    %w10 %w11 asr $0x0a -> %w9
+0b8d318b : add w11, w12, w13, ASR #12                : add    %w12 %w13 asr $0x0c -> %w11
+0b8f39cd : add w13, w14, w15, ASR #14                : add    %w14 %w15 asr $0x0e -> %w13
+0b91420f : add w15, w16, w17, ASR #16                : add    %w16 %w17 asr $0x10 -> %w15
+0b934651 : add w17, w18, w19, ASR #17                : add    %w18 %w19 asr $0x11 -> %w17
+0b954e93 : add w19, w20, w21, ASR #19                : add    %w20 %w21 asr $0x13 -> %w19
+0b9756d5 : add w21, w22, w23, ASR #21                : add    %w22 %w23 asr $0x15 -> %w21
+0b985ef6 : add w22, w23, w24, ASR #23                : add    %w23 %w24 asr $0x17 -> %w22
+0b9a6738 : add w24, w25, w26, ASR #25                : add    %w25 %w26 asr $0x19 -> %w24
+0b9c6f7a : add w26, w27, w28, ASR #27                : add    %w27 %w28 asr $0x1b -> %w26
+0b817c1e : add w30, w0, w1, ASR #31                  : add    %w0 %w1 asr $0x1f -> %w30
+
+# ADC     <Xd>, <Xn>, <Xm> (ADC-R.RR-64_addsub_carry)
+9a020020 : adc x0, x1, x2                            : adc    %x1 %x2 -> %x0
+9a040062 : adc x2, x3, x4                            : adc    %x3 %x4 -> %x2
+9a0600a4 : adc x4, x5, x6                            : adc    %x5 %x6 -> %x4
+9a0800e6 : adc x6, x7, x8                            : adc    %x7 %x8 -> %x6
+9a0a0128 : adc x8, x9, x10                           : adc    %x9 %x10 -> %x8
+9a0b0149 : adc x9, x10, x11                          : adc    %x10 %x11 -> %x9
+9a0d018b : adc x11, x12, x13                         : adc    %x12 %x13 -> %x11
+9a0f01cd : adc x13, x14, x15                         : adc    %x14 %x15 -> %x13
+9a11020f : adc x15, x16, x17                         : adc    %x16 %x17 -> %x15
+9a130251 : adc x17, x18, x19                         : adc    %x18 %x19 -> %x17
+9a150293 : adc x19, x20, x21                         : adc    %x20 %x21 -> %x19
+9a1702d5 : adc x21, x22, x23                         : adc    %x22 %x23 -> %x21
+9a1802f6 : adc x22, x23, x24                         : adc    %x23 %x24 -> %x22
+9a1a0338 : adc x24, x25, x26                         : adc    %x25 %x26 -> %x24
+9a1c037a : adc x26, x27, x28                         : adc    %x27 %x28 -> %x26
+9a01001e : adc x30, x0, x1                           : adc    %x0 %x1 -> %x30
+
+# EXTR    <Xd>, <Xn>, <Xm>, #<imm> (EXTR-R.RRI-64_extract)
+93c20020 : extr x0, x1, x2, #0x0                     : extr   %x1 %x2 $0x00 -> %x0
+93c40862 : extr x2, x3, x4, #0x2                     : extr   %x3 %x4 $0x02 -> %x2
+93c610a4 : extr x4, x5, x6, #0x4                     : extr   %x5 %x6 $0x04 -> %x4
+93c818e6 : extr x6, x7, x8, #0x6                     : extr   %x7 %x8 $0x06 -> %x6
+93ca2128 : extr x8, x9, x10, #0x8                    : extr   %x9 %x10 $0x08 -> %x8
+93cb2949 : extr x9, x10, x11, #0xa                   : extr   %x10 %x11 $0x0a -> %x9
+93cd318b : extr x11, x12, x13, #0xc                  : extr   %x12 %x13 $0x0c -> %x11
+93cf39cd : extr x13, x14, x15, #0xe                  : extr   %x14 %x15 $0x0e -> %x13
+93d1420f : extr x15, x16, x17, #0x10                 : extr   %x16 %x17 $0x10 -> %x15
+93d34651 : extr x17, x18, x19, #0x11                 : extr   %x18 %x19 $0x11 -> %x17
+93d54e93 : extr x19, x20, x21, #0x13                 : extr   %x20 %x21 $0x13 -> %x19
+93d756d5 : extr x21, x22, x23, #0x15                 : extr   %x22 %x23 $0x15 -> %x21
+93d85ef6 : extr x22, x23, x24, #0x17                 : extr   %x23 %x24 $0x17 -> %x22
+93da6738 : extr x24, x25, x26, #0x19                 : extr   %x25 %x26 $0x19 -> %x24
+93dc6f7a : extr x26, x27, x28, #0x1b                 : extr   %x27 %x28 $0x1b -> %x26
+93c17c1e : extr x30, x0, x1, #0x1f                   : extr   %x0 %x1 $0x1f -> %x30
+
+# EOR     <Xd>, <Xn>, <Xm>, <extend> #<imm> (EOR-R.RRI-64_log_shift)
+ca020020 : eor x0, x1, x2, LSL #0                    : eor    %x1 %x2 lsl $0x00 -> %x0
+ca040862 : eor x2, x3, x4, LSL #2                    : eor    %x3 %x4 lsl $0x02 -> %x2
+ca0610a4 : eor x4, x5, x6, LSL #4                    : eor    %x5 %x6 lsl $0x04 -> %x4
+ca0818e6 : eor x6, x7, x8, LSL #6                    : eor    %x7 %x8 lsl $0x06 -> %x6
+ca0a2128 : eor x8, x9, x10, LSL #8                   : eor    %x9 %x10 lsl $0x08 -> %x8
+ca0b2949 : eor x9, x10, x11, LSL #10                 : eor    %x10 %x11 lsl $0x0a -> %x9
+ca0d318b : eor x11, x12, x13, LSL #12                : eor    %x12 %x13 lsl $0x0c -> %x11
+ca0f39cd : eor x13, x14, x15, LSL #14                : eor    %x14 %x15 lsl $0x0e -> %x13
+ca11420f : eor x15, x16, x17, LSL #16                : eor    %x16 %x17 lsl $0x10 -> %x15
+ca134651 : eor x17, x18, x19, LSL #17                : eor    %x18 %x19 lsl $0x11 -> %x17
+ca154e93 : eor x19, x20, x21, LSL #19                : eor    %x20 %x21 lsl $0x13 -> %x19
+ca1756d5 : eor x21, x22, x23, LSL #21                : eor    %x22 %x23 lsl $0x15 -> %x21
+ca185ef6 : eor x22, x23, x24, LSL #23                : eor    %x23 %x24 lsl $0x17 -> %x22
+ca1a6738 : eor x24, x25, x26, LSL #25                : eor    %x25 %x26 lsl $0x19 -> %x24
+ca1c6f7a : eor x26, x27, x28, LSL #27                : eor    %x27 %x28 lsl $0x1b -> %x26
+ca017c1e : eor x30, x0, x1, LSL #31                  : eor    %x0 %x1 lsl $0x1f -> %x30
+ca420020 : eor x0, x1, x2, LSR #0                    : eor    %x1 %x2 lsr $0x00 -> %x0
+ca440862 : eor x2, x3, x4, LSR #2                    : eor    %x3 %x4 lsr $0x02 -> %x2
+ca4610a4 : eor x4, x5, x6, LSR #4                    : eor    %x5 %x6 lsr $0x04 -> %x4
+ca4818e6 : eor x6, x7, x8, LSR #6                    : eor    %x7 %x8 lsr $0x06 -> %x6
+ca4a2128 : eor x8, x9, x10, LSR #8                   : eor    %x9 %x10 lsr $0x08 -> %x8
+ca4b2949 : eor x9, x10, x11, LSR #10                 : eor    %x10 %x11 lsr $0x0a -> %x9
+ca4d318b : eor x11, x12, x13, LSR #12                : eor    %x12 %x13 lsr $0x0c -> %x11
+ca4f39cd : eor x13, x14, x15, LSR #14                : eor    %x14 %x15 lsr $0x0e -> %x13
+ca51420f : eor x15, x16, x17, LSR #16                : eor    %x16 %x17 lsr $0x10 -> %x15
+ca534651 : eor x17, x18, x19, LSR #17                : eor    %x18 %x19 lsr $0x11 -> %x17
+ca554e93 : eor x19, x20, x21, LSR #19                : eor    %x20 %x21 lsr $0x13 -> %x19
+ca5756d5 : eor x21, x22, x23, LSR #21                : eor    %x22 %x23 lsr $0x15 -> %x21
+ca585ef6 : eor x22, x23, x24, LSR #23                : eor    %x23 %x24 lsr $0x17 -> %x22
+ca5a6738 : eor x24, x25, x26, LSR #25                : eor    %x25 %x26 lsr $0x19 -> %x24
+ca5c6f7a : eor x26, x27, x28, LSR #27                : eor    %x27 %x28 lsr $0x1b -> %x26
+ca417c1e : eor x30, x0, x1, LSR #31                  : eor    %x0 %x1 lsr $0x1f -> %x30
+ca820020 : eor x0, x1, x2, ASR #0                    : eor    %x1 %x2 asr $0x00 -> %x0
+ca840862 : eor x2, x3, x4, ASR #2                    : eor    %x3 %x4 asr $0x02 -> %x2
+ca8610a4 : eor x4, x5, x6, ASR #4                    : eor    %x5 %x6 asr $0x04 -> %x4
+ca8818e6 : eor x6, x7, x8, ASR #6                    : eor    %x7 %x8 asr $0x06 -> %x6
+ca8a2128 : eor x8, x9, x10, ASR #8                   : eor    %x9 %x10 asr $0x08 -> %x8
+ca8b2949 : eor x9, x10, x11, ASR #10                 : eor    %x10 %x11 asr $0x0a -> %x9
+ca8d318b : eor x11, x12, x13, ASR #12                : eor    %x12 %x13 asr $0x0c -> %x11
+ca8f39cd : eor x13, x14, x15, ASR #14                : eor    %x14 %x15 asr $0x0e -> %x13
+ca91420f : eor x15, x16, x17, ASR #16                : eor    %x16 %x17 asr $0x10 -> %x15
+ca934651 : eor x17, x18, x19, ASR #17                : eor    %x18 %x19 asr $0x11 -> %x17
+ca954e93 : eor x19, x20, x21, ASR #19                : eor    %x20 %x21 asr $0x13 -> %x19
+ca9756d5 : eor x21, x22, x23, ASR #21                : eor    %x22 %x23 asr $0x15 -> %x21
+ca985ef6 : eor x22, x23, x24, ASR #23                : eor    %x23 %x24 asr $0x17 -> %x22
+ca9a6738 : eor x24, x25, x26, ASR #25                : eor    %x25 %x26 asr $0x19 -> %x24
+ca9c6f7a : eor x26, x27, x28, ASR #27                : eor    %x27 %x28 asr $0x1b -> %x26
+ca817c1e : eor x30, x0, x1, ASR #31                  : eor    %x0 %x1 asr $0x1f -> %x30
+cac20020 : eor x0, x1, x2, ROR #0                    : eor    %x1 %x2 ror $0x00 -> %x0
+cac40862 : eor x2, x3, x4, ROR #2                    : eor    %x3 %x4 ror $0x02 -> %x2
+cac610a4 : eor x4, x5, x6, ROR #4                    : eor    %x5 %x6 ror $0x04 -> %x4
+cac818e6 : eor x6, x7, x8, ROR #6                    : eor    %x7 %x8 ror $0x06 -> %x6
+caca2128 : eor x8, x9, x10, ROR #8                   : eor    %x9 %x10 ror $0x08 -> %x8
+cacb2949 : eor x9, x10, x11, ROR #10                 : eor    %x10 %x11 ror $0x0a -> %x9
+cacd318b : eor x11, x12, x13, ROR #12                : eor    %x12 %x13 ror $0x0c -> %x11
+cacf39cd : eor x13, x14, x15, ROR #14                : eor    %x14 %x15 ror $0x0e -> %x13
+cad1420f : eor x15, x16, x17, ROR #16                : eor    %x16 %x17 ror $0x10 -> %x15
+cad34651 : eor x17, x18, x19, ROR #17                : eor    %x18 %x19 ror $0x11 -> %x17
+cad54e93 : eor x19, x20, x21, ROR #19                : eor    %x20 %x21 ror $0x13 -> %x19
+cad756d5 : eor x21, x22, x23, ROR #21                : eor    %x22 %x23 ror $0x15 -> %x21
+cad85ef6 : eor x22, x23, x24, ROR #23                : eor    %x23 %x24 ror $0x17 -> %x22
+cada6738 : eor x24, x25, x26, ROR #25                : eor    %x25 %x26 ror $0x19 -> %x24
+cadc6f7a : eor x26, x27, x28, ROR #27                : eor    %x27 %x28 ror $0x1b -> %x26
+cac17c1e : eor x30, x0, x1, ROR #31                  : eor    %x0 %x1 ror $0x1f -> %x30
+
+# BFM     <Xd>, <Xn>, #<imm1>, #<imm2> (BFM-R.RII-64M_bitfield)
+b3400020 : bfm x0, x1, #0x0, #0x0                    : bfm    %x0 %x1 $0x00 $0x00 -> %x0
+b3420862 : bfm x2, x3, #0x2, #0x2                    : bfm    %x2 %x3 $0x02 $0x02 -> %x2
+b34410a4 : bfm x4, x5, #0x4, #0x4                    : bfm    %x4 %x5 $0x04 $0x04 -> %x4
+b34618e6 : bfm x6, x7, #0x6, #0x6                    : bfm    %x6 %x7 $0x06 $0x06 -> %x6
+b3482128 : bfm x8, x9, #0x8, #0x8                    : bfm    %x8 %x9 $0x08 $0x08 -> %x8
+b34a2949 : bfm x9, x10, #0xa, #0xa                   : bfm    %x9 %x10 $0x0a $0x0a -> %x9
+b34c318b : bfm x11, x12, #0xc, #0xc                  : bfm    %x11 %x12 $0x0c $0x0c -> %x11
+b34e39cd : bfm x13, x14, #0xe, #0xe                  : bfm    %x13 %x14 $0x0e $0x0e -> %x13
+b350420f : bfm x15, x16, #0x10, #0x10                : bfm    %x15 %x16 $0x10 $0x10 -> %x15
+b3514651 : bfm x17, x18, #0x11, #0x11                : bfm    %x17 %x18 $0x11 $0x11 -> %x17
+b3534e93 : bfm x19, x20, #0x13, #0x13                : bfm    %x19 %x20 $0x13 $0x13 -> %x19
+b35556d5 : bfm x21, x22, #0x15, #0x15                : bfm    %x21 %x22 $0x15 $0x15 -> %x21
+b3575ef6 : bfm x22, x23, #0x17, #0x17                : bfm    %x22 %x23 $0x17 $0x17 -> %x22
+b3596738 : bfm x24, x25, #0x19, #0x19                : bfm    %x24 %x25 $0x19 $0x19 -> %x24
+b35b6f7a : bfm x26, x27, #0x1b, #0x1b                : bfm    %x26 %x27 $0x1b $0x1b -> %x26
+b35f7c1e : bfm x30, x0, #0x1f, #0x1f                 : bfm    %x30 %x0 $0x1f $0x1f -> %x30
+
+# MOVK    <Wd>, #<imm>{, LSL <amount>} (MOVK-R.I-32_movewide)
+72800000 : movk w0, #0x0, LSL #0                     : movk   %w0 $0x0000 lsl $0x00 -> %w0
+72820002 : movk w2, #0x1000, LSL #0                  : movk   %w2 $0x1000 lsl $0x00 -> %w2
+72840004 : movk w4, #0x2000, LSL #0                  : movk   %w4 $0x2000 lsl $0x00 -> %w4
+72860006 : movk w6, #0x3000, LSL #0                  : movk   %w6 $0x3000 lsl $0x00 -> %w6
+72880008 : movk w8, #0x4000, LSL #0                  : movk   %w8 $0x4000 lsl $0x00 -> %w8
+728a0009 : movk w9, #0x5000, LSL #0                  : movk   %w9 $0x5000 lsl $0x00 -> %w9
+728c000b : movk w11, #0x6000, LSL #0                 : movk   %w11 $0x6000 lsl $0x00 -> %w11
+728e000d : movk w13, #0x7000, LSL #0                 : movk   %w13 $0x7000 lsl $0x00 -> %w13
+7290000f : movk w15, #0x8000, LSL #0                 : movk   %w15 $0x8000 lsl $0x00 -> %w15
+7291fff1 : movk w17, #0x8fff, LSL #0                 : movk   %w17 $0x8fff lsl $0x00 -> %w17
+7293fff3 : movk w19, #0x9fff, LSL #0                 : movk   %w19 $0x9fff lsl $0x00 -> %w19
+7295fff5 : movk w21, #0xafff, LSL #0                 : movk   %w21 $0xafff lsl $0x00 -> %w21
+7297fff6 : movk w22, #0xbfff, LSL #0                 : movk   %w22 $0xbfff lsl $0x00 -> %w22
+7299fff8 : movk w24, #0xcfff, LSL #0                 : movk   %w24 $0xcfff lsl $0x00 -> %w24
+729bfffa : movk w26, #0xdfff, LSL #0                 : movk   %w26 $0xdfff lsl $0x00 -> %w26
+729ffffe : movk w30, #0xffff, LSL #0                 : movk   %w30 $0xffff lsl $0x00 -> %w30
+72a00000 : movk w0, #0x0, LSL #16                    : movk   %w0 $0x0000 lsl $0x10 -> %w0
+72a20002 : movk w2, #0x1000, LSL #16                 : movk   %w2 $0x1000 lsl $0x10 -> %w2
+72a40004 : movk w4, #0x2000, LSL #16                 : movk   %w4 $0x2000 lsl $0x10 -> %w4
+72a60006 : movk w6, #0x3000, LSL #16                 : movk   %w6 $0x3000 lsl $0x10 -> %w6
+72a80008 : movk w8, #0x4000, LSL #16                 : movk   %w8 $0x4000 lsl $0x10 -> %w8
+72aa0009 : movk w9, #0x5000, LSL #16                 : movk   %w9 $0x5000 lsl $0x10 -> %w9
+72ac000b : movk w11, #0x6000, LSL #16                : movk   %w11 $0x6000 lsl $0x10 -> %w11
+72ae000d : movk w13, #0x7000, LSL #16                : movk   %w13 $0x7000 lsl $0x10 -> %w13
+72b0000f : movk w15, #0x8000, LSL #16                : movk   %w15 $0x8000 lsl $0x10 -> %w15
+72b1fff1 : movk w17, #0x8fff, LSL #16                : movk   %w17 $0x8fff lsl $0x10 -> %w17
+72b3fff3 : movk w19, #0x9fff, LSL #16                : movk   %w19 $0x9fff lsl $0x10 -> %w19
+72b5fff5 : movk w21, #0xafff, LSL #16                : movk   %w21 $0xafff lsl $0x10 -> %w21
+72b7fff6 : movk w22, #0xbfff, LSL #16                : movk   %w22 $0xbfff lsl $0x10 -> %w22
+72b9fff8 : movk w24, #0xcfff, LSL #16                : movk   %w24 $0xcfff lsl $0x10 -> %w24
+72bbfffa : movk w26, #0xdfff, LSL #16                : movk   %w26 $0xdfff lsl $0x10 -> %w26
+72bffffe : movk w30, #0xffff, LSL #16                : movk   %w30 $0xffff lsl $0x10 -> %w30
+
+# CSEL    <Wd>, <Wn>, <Wm>, <cond> (CSEL-R.RR-32_condsel)
+1a820020 : csel w0, w1, w2, EQ                       : csel   %w1 %w2 eq -> %w0
+1a840062 : csel w2, w3, w4, EQ                       : csel   %w3 %w4 eq -> %w2
+1a8600a4 : csel w4, w5, w6, EQ                       : csel   %w5 %w6 eq -> %w4
+1a8800e6 : csel w6, w7, w8, EQ                       : csel   %w7 %w8 eq -> %w6
+1a8a0128 : csel w8, w9, w10, EQ                      : csel   %w9 %w10 eq -> %w8
+1a8b0149 : csel w9, w10, w11, EQ                     : csel   %w10 %w11 eq -> %w9
+1a8d018b : csel w11, w12, w13, EQ                    : csel   %w12 %w13 eq -> %w11
+1a8f01cd : csel w13, w14, w15, EQ                    : csel   %w14 %w15 eq -> %w13
+1a91020f : csel w15, w16, w17, EQ                    : csel   %w16 %w17 eq -> %w15
+1a930251 : csel w17, w18, w19, EQ                    : csel   %w18 %w19 eq -> %w17
+1a950293 : csel w19, w20, w21, EQ                    : csel   %w20 %w21 eq -> %w19
+1a9702d5 : csel w21, w22, w23, EQ                    : csel   %w22 %w23 eq -> %w21
+1a9802f6 : csel w22, w23, w24, EQ                    : csel   %w23 %w24 eq -> %w22
+1a9a0338 : csel w24, w25, w26, EQ                    : csel   %w25 %w26 eq -> %w24
+1a9c037a : csel w26, w27, w28, EQ                    : csel   %w27 %w28 eq -> %w26
+1a81001e : csel w30, w0, w1, EQ                      : csel   %w0 %w1 eq -> %w30
+1a821020 : csel w0, w1, w2, NE                       : csel   %w1 %w2 ne -> %w0
+1a841062 : csel w2, w3, w4, NE                       : csel   %w3 %w4 ne -> %w2
+1a8610a4 : csel w4, w5, w6, NE                       : csel   %w5 %w6 ne -> %w4
+1a8810e6 : csel w6, w7, w8, NE                       : csel   %w7 %w8 ne -> %w6
+1a8a1128 : csel w8, w9, w10, NE                      : csel   %w9 %w10 ne -> %w8
+1a8b1149 : csel w9, w10, w11, NE                     : csel   %w10 %w11 ne -> %w9
+1a8d118b : csel w11, w12, w13, NE                    : csel   %w12 %w13 ne -> %w11
+1a8f11cd : csel w13, w14, w15, NE                    : csel   %w14 %w15 ne -> %w13
+1a91120f : csel w15, w16, w17, NE                    : csel   %w16 %w17 ne -> %w15
+1a931251 : csel w17, w18, w19, NE                    : csel   %w18 %w19 ne -> %w17
+1a951293 : csel w19, w20, w21, NE                    : csel   %w20 %w21 ne -> %w19
+1a9712d5 : csel w21, w22, w23, NE                    : csel   %w22 %w23 ne -> %w21
+1a9812f6 : csel w22, w23, w24, NE                    : csel   %w23 %w24 ne -> %w22
+1a9a1338 : csel w24, w25, w26, NE                    : csel   %w25 %w26 ne -> %w24
+1a9c137a : csel w26, w27, w28, NE                    : csel   %w27 %w28 ne -> %w26
+1a81101e : csel w30, w0, w1, NE                      : csel   %w0 %w1 ne -> %w30
+1a822020 : csel w0, w1, w2, CS                       : csel   %w1 %w2 cs -> %w0
+1a842062 : csel w2, w3, w4, CS                       : csel   %w3 %w4 cs -> %w2
+1a8620a4 : csel w4, w5, w6, CS                       : csel   %w5 %w6 cs -> %w4
+1a8820e6 : csel w6, w7, w8, CS                       : csel   %w7 %w8 cs -> %w6
+1a8a2128 : csel w8, w9, w10, CS                      : csel   %w9 %w10 cs -> %w8
+1a8b2149 : csel w9, w10, w11, CS                     : csel   %w10 %w11 cs -> %w9
+1a8d218b : csel w11, w12, w13, CS                    : csel   %w12 %w13 cs -> %w11
+1a8f21cd : csel w13, w14, w15, CS                    : csel   %w14 %w15 cs -> %w13
+1a91220f : csel w15, w16, w17, CS                    : csel   %w16 %w17 cs -> %w15
+1a932251 : csel w17, w18, w19, CS                    : csel   %w18 %w19 cs -> %w17
+1a952293 : csel w19, w20, w21, CS                    : csel   %w20 %w21 cs -> %w19
+1a9722d5 : csel w21, w22, w23, CS                    : csel   %w22 %w23 cs -> %w21
+1a9822f6 : csel w22, w23, w24, CS                    : csel   %w23 %w24 cs -> %w22
+1a9a2338 : csel w24, w25, w26, CS                    : csel   %w25 %w26 cs -> %w24
+1a9c237a : csel w26, w27, w28, CS                    : csel   %w27 %w28 cs -> %w26
+1a81201e : csel w30, w0, w1, CS                      : csel   %w0 %w1 cs -> %w30
+1a823020 : csel w0, w1, w2, CC                       : csel   %w1 %w2 cc -> %w0
+1a843062 : csel w2, w3, w4, CC                       : csel   %w3 %w4 cc -> %w2
+1a8630a4 : csel w4, w5, w6, CC                       : csel   %w5 %w6 cc -> %w4
+1a8830e6 : csel w6, w7, w8, CC                       : csel   %w7 %w8 cc -> %w6
+1a8a3128 : csel w8, w9, w10, CC                      : csel   %w9 %w10 cc -> %w8
+1a8b3149 : csel w9, w10, w11, CC                     : csel   %w10 %w11 cc -> %w9
+1a8d318b : csel w11, w12, w13, CC                    : csel   %w12 %w13 cc -> %w11
+1a8f31cd : csel w13, w14, w15, CC                    : csel   %w14 %w15 cc -> %w13
+1a91320f : csel w15, w16, w17, CC                    : csel   %w16 %w17 cc -> %w15
+1a933251 : csel w17, w18, w19, CC                    : csel   %w18 %w19 cc -> %w17
+1a953293 : csel w19, w20, w21, CC                    : csel   %w20 %w21 cc -> %w19
+1a9732d5 : csel w21, w22, w23, CC                    : csel   %w22 %w23 cc -> %w21
+1a9832f6 : csel w22, w23, w24, CC                    : csel   %w23 %w24 cc -> %w22
+1a9a3338 : csel w24, w25, w26, CC                    : csel   %w25 %w26 cc -> %w24
+1a9c337a : csel w26, w27, w28, CC                    : csel   %w27 %w28 cc -> %w26
+1a81301e : csel w30, w0, w1, CC                      : csel   %w0 %w1 cc -> %w30
+1a824020 : csel w0, w1, w2, MI                       : csel   %w1 %w2 mi -> %w0
+1a844062 : csel w2, w3, w4, MI                       : csel   %w3 %w4 mi -> %w2
+1a8640a4 : csel w4, w5, w6, MI                       : csel   %w5 %w6 mi -> %w4
+1a8840e6 : csel w6, w7, w8, MI                       : csel   %w7 %w8 mi -> %w6
+1a8a4128 : csel w8, w9, w10, MI                      : csel   %w9 %w10 mi -> %w8
+1a8b4149 : csel w9, w10, w11, MI                     : csel   %w10 %w11 mi -> %w9
+1a8d418b : csel w11, w12, w13, MI                    : csel   %w12 %w13 mi -> %w11
+1a8f41cd : csel w13, w14, w15, MI                    : csel   %w14 %w15 mi -> %w13
+1a91420f : csel w15, w16, w17, MI                    : csel   %w16 %w17 mi -> %w15
+1a934251 : csel w17, w18, w19, MI                    : csel   %w18 %w19 mi -> %w17
+1a954293 : csel w19, w20, w21, MI                    : csel   %w20 %w21 mi -> %w19
+1a9742d5 : csel w21, w22, w23, MI                    : csel   %w22 %w23 mi -> %w21
+1a9842f6 : csel w22, w23, w24, MI                    : csel   %w23 %w24 mi -> %w22
+1a9a4338 : csel w24, w25, w26, MI                    : csel   %w25 %w26 mi -> %w24
+1a9c437a : csel w26, w27, w28, MI                    : csel   %w27 %w28 mi -> %w26
+1a81401e : csel w30, w0, w1, MI                      : csel   %w0 %w1 mi -> %w30
+1a825020 : csel w0, w1, w2, PL                       : csel   %w1 %w2 pl -> %w0
+1a845062 : csel w2, w3, w4, PL                       : csel   %w3 %w4 pl -> %w2
+1a8650a4 : csel w4, w5, w6, PL                       : csel   %w5 %w6 pl -> %w4
+1a8850e6 : csel w6, w7, w8, PL                       : csel   %w7 %w8 pl -> %w6
+1a8a5128 : csel w8, w9, w10, PL                      : csel   %w9 %w10 pl -> %w8
+1a8b5149 : csel w9, w10, w11, PL                     : csel   %w10 %w11 pl -> %w9
+1a8d518b : csel w11, w12, w13, PL                    : csel   %w12 %w13 pl -> %w11
+1a8f51cd : csel w13, w14, w15, PL                    : csel   %w14 %w15 pl -> %w13
+1a91520f : csel w15, w16, w17, PL                    : csel   %w16 %w17 pl -> %w15
+1a935251 : csel w17, w18, w19, PL                    : csel   %w18 %w19 pl -> %w17
+1a955293 : csel w19, w20, w21, PL                    : csel   %w20 %w21 pl -> %w19
+1a9752d5 : csel w21, w22, w23, PL                    : csel   %w22 %w23 pl -> %w21
+1a9852f6 : csel w22, w23, w24, PL                    : csel   %w23 %w24 pl -> %w22
+1a9a5338 : csel w24, w25, w26, PL                    : csel   %w25 %w26 pl -> %w24
+1a9c537a : csel w26, w27, w28, PL                    : csel   %w27 %w28 pl -> %w26
+1a81501e : csel w30, w0, w1, PL                      : csel   %w0 %w1 pl -> %w30
+1a826020 : csel w0, w1, w2, VS                       : csel   %w1 %w2 vs -> %w0
+1a846062 : csel w2, w3, w4, VS                       : csel   %w3 %w4 vs -> %w2
+1a8660a4 : csel w4, w5, w6, VS                       : csel   %w5 %w6 vs -> %w4
+1a8860e6 : csel w6, w7, w8, VS                       : csel   %w7 %w8 vs -> %w6
+1a8a6128 : csel w8, w9, w10, VS                      : csel   %w9 %w10 vs -> %w8
+1a8b6149 : csel w9, w10, w11, VS                     : csel   %w10 %w11 vs -> %w9
+1a8d618b : csel w11, w12, w13, VS                    : csel   %w12 %w13 vs -> %w11
+1a8f61cd : csel w13, w14, w15, VS                    : csel   %w14 %w15 vs -> %w13
+1a91620f : csel w15, w16, w17, VS                    : csel   %w16 %w17 vs -> %w15
+1a936251 : csel w17, w18, w19, VS                    : csel   %w18 %w19 vs -> %w17
+1a956293 : csel w19, w20, w21, VS                    : csel   %w20 %w21 vs -> %w19
+1a9762d5 : csel w21, w22, w23, VS                    : csel   %w22 %w23 vs -> %w21
+1a9862f6 : csel w22, w23, w24, VS                    : csel   %w23 %w24 vs -> %w22
+1a9a6338 : csel w24, w25, w26, VS                    : csel   %w25 %w26 vs -> %w24
+1a9c637a : csel w26, w27, w28, VS                    : csel   %w27 %w28 vs -> %w26
+1a81601e : csel w30, w0, w1, VS                      : csel   %w0 %w1 vs -> %w30
+1a827020 : csel w0, w1, w2, VC                       : csel   %w1 %w2 vc -> %w0
+1a847062 : csel w2, w3, w4, VC                       : csel   %w3 %w4 vc -> %w2
+1a8670a4 : csel w4, w5, w6, VC                       : csel   %w5 %w6 vc -> %w4
+1a8870e6 : csel w6, w7, w8, VC                       : csel   %w7 %w8 vc -> %w6
+1a8a7128 : csel w8, w9, w10, VC                      : csel   %w9 %w10 vc -> %w8
+1a8b7149 : csel w9, w10, w11, VC                     : csel   %w10 %w11 vc -> %w9
+1a8d718b : csel w11, w12, w13, VC                    : csel   %w12 %w13 vc -> %w11
+1a8f71cd : csel w13, w14, w15, VC                    : csel   %w14 %w15 vc -> %w13
+1a91720f : csel w15, w16, w17, VC                    : csel   %w16 %w17 vc -> %w15
+1a937251 : csel w17, w18, w19, VC                    : csel   %w18 %w19 vc -> %w17
+1a957293 : csel w19, w20, w21, VC                    : csel   %w20 %w21 vc -> %w19
+1a9772d5 : csel w21, w22, w23, VC                    : csel   %w22 %w23 vc -> %w21
+1a9872f6 : csel w22, w23, w24, VC                    : csel   %w23 %w24 vc -> %w22
+1a9a7338 : csel w24, w25, w26, VC                    : csel   %w25 %w26 vc -> %w24
+1a9c737a : csel w26, w27, w28, VC                    : csel   %w27 %w28 vc -> %w26
+1a81701e : csel w30, w0, w1, VC                      : csel   %w0 %w1 vc -> %w30
+1a828020 : csel w0, w1, w2, HI                       : csel   %w1 %w2 hi -> %w0
+1a848062 : csel w2, w3, w4, HI                       : csel   %w3 %w4 hi -> %w2
+1a8680a4 : csel w4, w5, w6, HI                       : csel   %w5 %w6 hi -> %w4
+1a8880e6 : csel w6, w7, w8, HI                       : csel   %w7 %w8 hi -> %w6
+1a8a8128 : csel w8, w9, w10, HI                      : csel   %w9 %w10 hi -> %w8
+1a8b8149 : csel w9, w10, w11, HI                     : csel   %w10 %w11 hi -> %w9
+1a8d818b : csel w11, w12, w13, HI                    : csel   %w12 %w13 hi -> %w11
+1a8f81cd : csel w13, w14, w15, HI                    : csel   %w14 %w15 hi -> %w13
+1a91820f : csel w15, w16, w17, HI                    : csel   %w16 %w17 hi -> %w15
+1a938251 : csel w17, w18, w19, HI                    : csel   %w18 %w19 hi -> %w17
+1a958293 : csel w19, w20, w21, HI                    : csel   %w20 %w21 hi -> %w19
+1a9782d5 : csel w21, w22, w23, HI                    : csel   %w22 %w23 hi -> %w21
+1a9882f6 : csel w22, w23, w24, HI                    : csel   %w23 %w24 hi -> %w22
+1a9a8338 : csel w24, w25, w26, HI                    : csel   %w25 %w26 hi -> %w24
+1a9c837a : csel w26, w27, w28, HI                    : csel   %w27 %w28 hi -> %w26
+1a81801e : csel w30, w0, w1, HI                      : csel   %w0 %w1 hi -> %w30
+1a829020 : csel w0, w1, w2, LS                       : csel   %w1 %w2 ls -> %w0
+1a849062 : csel w2, w3, w4, LS                       : csel   %w3 %w4 ls -> %w2
+1a8690a4 : csel w4, w5, w6, LS                       : csel   %w5 %w6 ls -> %w4
+1a8890e6 : csel w6, w7, w8, LS                       : csel   %w7 %w8 ls -> %w6
+1a8a9128 : csel w8, w9, w10, LS                      : csel   %w9 %w10 ls -> %w8
+1a8b9149 : csel w9, w10, w11, LS                     : csel   %w10 %w11 ls -> %w9
+1a8d918b : csel w11, w12, w13, LS                    : csel   %w12 %w13 ls -> %w11
+1a8f91cd : csel w13, w14, w15, LS                    : csel   %w14 %w15 ls -> %w13
+1a91920f : csel w15, w16, w17, LS                    : csel   %w16 %w17 ls -> %w15
+1a939251 : csel w17, w18, w19, LS                    : csel   %w18 %w19 ls -> %w17
+1a959293 : csel w19, w20, w21, LS                    : csel   %w20 %w21 ls -> %w19
+1a9792d5 : csel w21, w22, w23, LS                    : csel   %w22 %w23 ls -> %w21
+1a9892f6 : csel w22, w23, w24, LS                    : csel   %w23 %w24 ls -> %w22
+1a9a9338 : csel w24, w25, w26, LS                    : csel   %w25 %w26 ls -> %w24
+1a9c937a : csel w26, w27, w28, LS                    : csel   %w27 %w28 ls -> %w26
+1a81901e : csel w30, w0, w1, LS                      : csel   %w0 %w1 ls -> %w30
+1a82a020 : csel w0, w1, w2, GE                       : csel   %w1 %w2 ge -> %w0
+1a84a062 : csel w2, w3, w4, GE                       : csel   %w3 %w4 ge -> %w2
+1a86a0a4 : csel w4, w5, w6, GE                       : csel   %w5 %w6 ge -> %w4
+1a88a0e6 : csel w6, w7, w8, GE                       : csel   %w7 %w8 ge -> %w6
+1a8aa128 : csel w8, w9, w10, GE                      : csel   %w9 %w10 ge -> %w8
+1a8ba149 : csel w9, w10, w11, GE                     : csel   %w10 %w11 ge -> %w9
+1a8da18b : csel w11, w12, w13, GE                    : csel   %w12 %w13 ge -> %w11
+1a8fa1cd : csel w13, w14, w15, GE                    : csel   %w14 %w15 ge -> %w13
+1a91a20f : csel w15, w16, w17, GE                    : csel   %w16 %w17 ge -> %w15
+1a93a251 : csel w17, w18, w19, GE                    : csel   %w18 %w19 ge -> %w17
+1a95a293 : csel w19, w20, w21, GE                    : csel   %w20 %w21 ge -> %w19
+1a97a2d5 : csel w21, w22, w23, GE                    : csel   %w22 %w23 ge -> %w21
+1a98a2f6 : csel w22, w23, w24, GE                    : csel   %w23 %w24 ge -> %w22
+1a9aa338 : csel w24, w25, w26, GE                    : csel   %w25 %w26 ge -> %w24
+1a9ca37a : csel w26, w27, w28, GE                    : csel   %w27 %w28 ge -> %w26
+1a81a01e : csel w30, w0, w1, GE                      : csel   %w0 %w1 ge -> %w30
+1a82b020 : csel w0, w1, w2, LT                       : csel   %w1 %w2 lt -> %w0
+1a84b062 : csel w2, w3, w4, LT                       : csel   %w3 %w4 lt -> %w2
+1a86b0a4 : csel w4, w5, w6, LT                       : csel   %w5 %w6 lt -> %w4
+1a88b0e6 : csel w6, w7, w8, LT                       : csel   %w7 %w8 lt -> %w6
+1a8ab128 : csel w8, w9, w10, LT                      : csel   %w9 %w10 lt -> %w8
+1a8bb149 : csel w9, w10, w11, LT                     : csel   %w10 %w11 lt -> %w9
+1a8db18b : csel w11, w12, w13, LT                    : csel   %w12 %w13 lt -> %w11
+1a8fb1cd : csel w13, w14, w15, LT                    : csel   %w14 %w15 lt -> %w13
+1a91b20f : csel w15, w16, w17, LT                    : csel   %w16 %w17 lt -> %w15
+1a93b251 : csel w17, w18, w19, LT                    : csel   %w18 %w19 lt -> %w17
+1a95b293 : csel w19, w20, w21, LT                    : csel   %w20 %w21 lt -> %w19
+1a97b2d5 : csel w21, w22, w23, LT                    : csel   %w22 %w23 lt -> %w21
+1a98b2f6 : csel w22, w23, w24, LT                    : csel   %w23 %w24 lt -> %w22
+1a9ab338 : csel w24, w25, w26, LT                    : csel   %w25 %w26 lt -> %w24
+1a9cb37a : csel w26, w27, w28, LT                    : csel   %w27 %w28 lt -> %w26
+1a81b01e : csel w30, w0, w1, LT                      : csel   %w0 %w1 lt -> %w30
+1a82c020 : csel w0, w1, w2, GT                       : csel   %w1 %w2 gt -> %w0
+1a84c062 : csel w2, w3, w4, GT                       : csel   %w3 %w4 gt -> %w2
+1a86c0a4 : csel w4, w5, w6, GT                       : csel   %w5 %w6 gt -> %w4
+1a88c0e6 : csel w6, w7, w8, GT                       : csel   %w7 %w8 gt -> %w6
+1a8ac128 : csel w8, w9, w10, GT                      : csel   %w9 %w10 gt -> %w8
+1a8bc149 : csel w9, w10, w11, GT                     : csel   %w10 %w11 gt -> %w9
+1a8dc18b : csel w11, w12, w13, GT                    : csel   %w12 %w13 gt -> %w11
+1a8fc1cd : csel w13, w14, w15, GT                    : csel   %w14 %w15 gt -> %w13
+1a91c20f : csel w15, w16, w17, GT                    : csel   %w16 %w17 gt -> %w15
+1a93c251 : csel w17, w18, w19, GT                    : csel   %w18 %w19 gt -> %w17
+1a95c293 : csel w19, w20, w21, GT                    : csel   %w20 %w21 gt -> %w19
+1a97c2d5 : csel w21, w22, w23, GT                    : csel   %w22 %w23 gt -> %w21
+1a98c2f6 : csel w22, w23, w24, GT                    : csel   %w23 %w24 gt -> %w22
+1a9ac338 : csel w24, w25, w26, GT                    : csel   %w25 %w26 gt -> %w24
+1a9cc37a : csel w26, w27, w28, GT                    : csel   %w27 %w28 gt -> %w26
+1a81c01e : csel w30, w0, w1, GT                      : csel   %w0 %w1 gt -> %w30
+1a82d020 : csel w0, w1, w2, LE                       : csel   %w1 %w2 le -> %w0
+1a84d062 : csel w2, w3, w4, LE                       : csel   %w3 %w4 le -> %w2
+1a86d0a4 : csel w4, w5, w6, LE                       : csel   %w5 %w6 le -> %w4
+1a88d0e6 : csel w6, w7, w8, LE                       : csel   %w7 %w8 le -> %w6
+1a8ad128 : csel w8, w9, w10, LE                      : csel   %w9 %w10 le -> %w8
+1a8bd149 : csel w9, w10, w11, LE                     : csel   %w10 %w11 le -> %w9
+1a8dd18b : csel w11, w12, w13, LE                    : csel   %w12 %w13 le -> %w11
+1a8fd1cd : csel w13, w14, w15, LE                    : csel   %w14 %w15 le -> %w13
+1a91d20f : csel w15, w16, w17, LE                    : csel   %w16 %w17 le -> %w15
+1a93d251 : csel w17, w18, w19, LE                    : csel   %w18 %w19 le -> %w17
+1a95d293 : csel w19, w20, w21, LE                    : csel   %w20 %w21 le -> %w19
+1a97d2d5 : csel w21, w22, w23, LE                    : csel   %w22 %w23 le -> %w21
+1a98d2f6 : csel w22, w23, w24, LE                    : csel   %w23 %w24 le -> %w22
+1a9ad338 : csel w24, w25, w26, LE                    : csel   %w25 %w26 le -> %w24
+1a9cd37a : csel w26, w27, w28, LE                    : csel   %w27 %w28 le -> %w26
+1a81d01e : csel w30, w0, w1, LE                      : csel   %w0 %w1 le -> %w30
+1a82e020 : csel w0, w1, w2, AL                       : csel   %w1 %w2 al -> %w0
+1a84e062 : csel w2, w3, w4, AL                       : csel   %w3 %w4 al -> %w2
+1a86e0a4 : csel w4, w5, w6, AL                       : csel   %w5 %w6 al -> %w4
+1a88e0e6 : csel w6, w7, w8, AL                       : csel   %w7 %w8 al -> %w6
+1a8ae128 : csel w8, w9, w10, AL                      : csel   %w9 %w10 al -> %w8
+1a8be149 : csel w9, w10, w11, AL                     : csel   %w10 %w11 al -> %w9
+1a8de18b : csel w11, w12, w13, AL                    : csel   %w12 %w13 al -> %w11
+1a8fe1cd : csel w13, w14, w15, AL                    : csel   %w14 %w15 al -> %w13
+1a91e20f : csel w15, w16, w17, AL                    : csel   %w16 %w17 al -> %w15
+1a93e251 : csel w17, w18, w19, AL                    : csel   %w18 %w19 al -> %w17
+1a95e293 : csel w19, w20, w21, AL                    : csel   %w20 %w21 al -> %w19
+1a97e2d5 : csel w21, w22, w23, AL                    : csel   %w22 %w23 al -> %w21
+1a98e2f6 : csel w22, w23, w24, AL                    : csel   %w23 %w24 al -> %w22
+1a9ae338 : csel w24, w25, w26, AL                    : csel   %w25 %w26 al -> %w24
+1a9ce37a : csel w26, w27, w28, AL                    : csel   %w27 %w28 al -> %w26
+1a81e01e : csel w30, w0, w1, AL                      : csel   %w0 %w1 al -> %w30
+1a82f020 : csel w0, w1, w2, NV                       : csel   %w1 %w2 nv -> %w0
+1a84f062 : csel w2, w3, w4, NV                       : csel   %w3 %w4 nv -> %w2
+1a86f0a4 : csel w4, w5, w6, NV                       : csel   %w5 %w6 nv -> %w4
+1a88f0e6 : csel w6, w7, w8, NV                       : csel   %w7 %w8 nv -> %w6
+1a8af128 : csel w8, w9, w10, NV                      : csel   %w9 %w10 nv -> %w8
+1a8bf149 : csel w9, w10, w11, NV                     : csel   %w10 %w11 nv -> %w9
+1a8df18b : csel w11, w12, w13, NV                    : csel   %w12 %w13 nv -> %w11
+1a8ff1cd : csel w13, w14, w15, NV                    : csel   %w14 %w15 nv -> %w13
+1a91f20f : csel w15, w16, w17, NV                    : csel   %w16 %w17 nv -> %w15
+1a93f251 : csel w17, w18, w19, NV                    : csel   %w18 %w19 nv -> %w17
+1a95f293 : csel w19, w20, w21, NV                    : csel   %w20 %w21 nv -> %w19
+1a97f2d5 : csel w21, w22, w23, NV                    : csel   %w22 %w23 nv -> %w21
+1a98f2f6 : csel w22, w23, w24, NV                    : csel   %w23 %w24 nv -> %w22
+1a9af338 : csel w24, w25, w26, NV                    : csel   %w25 %w26 nv -> %w24
+1a9cf37a : csel w26, w27, w28, NV                    : csel   %w27 %w28 nv -> %w26
+1a81f01e : csel w30, w0, w1, NV                      : csel   %w0 %w1 nv -> %w30
+
+# CBNZ    <Wt>, #<imm> (CBNZ-R.I-32_compbranch)
+35800000 : cbnz w0, #-0x100000                       : cbnz   $0x000000000ff00000 %w0
+35900002 : cbnz w2, #-0xe0000                        : cbnz   $0x000000000ff20000 %w2
+35a00004 : cbnz w4, #-0xc0000                        : cbnz   $0x000000000ff40000 %w4
+35b00006 : cbnz w6, #-0xa0000                        : cbnz   $0x000000000ff60000 %w6
+35c00008 : cbnz w8, #-0x80000                        : cbnz   $0x000000000ff80000 %w8
+35d00009 : cbnz w9, #-0x60000                        : cbnz   $0x000000000ffa0000 %w9
+35e0000b : cbnz w11, #-0x40000                       : cbnz   $0x000000000ffc0000 %w11
+35f0000d : cbnz w13, #-0x20000                       : cbnz   $0x000000000ffe0000 %w13
+3500000f : cbnz w15, #0x0                            : cbnz   $0x0000000010000000 %w15
+350ffff1 : cbnz w17, #0x1fffc                        : cbnz   $0x000000001001fffc %w17
+351ffff3 : cbnz w19, #0x3fffc                        : cbnz   $0x000000001003fffc %w19
+352ffff5 : cbnz w21, #0x5fffc                        : cbnz   $0x000000001005fffc %w21
+353ffff6 : cbnz w22, #0x7fffc                        : cbnz   $0x000000001007fffc %w22
+354ffff8 : cbnz w24, #0x9fffc                        : cbnz   $0x000000001009fffc %w24
+355ffffa : cbnz w26, #0xbfffc                        : cbnz   $0x00000000100bfffc %w26
+357ffffe : cbnz w30, #0xffffc                        : cbnz   $0x00000000100ffffc %w30
+
+# MOVN    <Xd>, #<imm>{, LSL <amount>} (MOVN-R.I-64_movewide)
+92800000 : movn x0, #0x0, LSL #0                     : movn   $0x0000 lsl $0x00 -> %x0
+92820002 : movn x2, #0x1000, LSL #0                  : movn   $0x1000 lsl $0x00 -> %x2
+92840004 : movn x4, #0x2000, LSL #0                  : movn   $0x2000 lsl $0x00 -> %x4
+92860006 : movn x6, #0x3000, LSL #0                  : movn   $0x3000 lsl $0x00 -> %x6
+92880008 : movn x8, #0x4000, LSL #0                  : movn   $0x4000 lsl $0x00 -> %x8
+928a0009 : movn x9, #0x5000, LSL #0                  : movn   $0x5000 lsl $0x00 -> %x9
+928c000b : movn x11, #0x6000, LSL #0                 : movn   $0x6000 lsl $0x00 -> %x11
+928e000d : movn x13, #0x7000, LSL #0                 : movn   $0x7000 lsl $0x00 -> %x13
+9290000f : movn x15, #0x8000, LSL #0                 : movn   $0x8000 lsl $0x00 -> %x15
+9291fff1 : movn x17, #0x8fff, LSL #0                 : movn   $0x8fff lsl $0x00 -> %x17
+9293fff3 : movn x19, #0x9fff, LSL #0                 : movn   $0x9fff lsl $0x00 -> %x19
+9295fff5 : movn x21, #0xafff, LSL #0                 : movn   $0xafff lsl $0x00 -> %x21
+9297fff6 : movn x22, #0xbfff, LSL #0                 : movn   $0xbfff lsl $0x00 -> %x22
+9299fff8 : movn x24, #0xcfff, LSL #0                 : movn   $0xcfff lsl $0x00 -> %x24
+929bfffa : movn x26, #0xdfff, LSL #0                 : movn   $0xdfff lsl $0x00 -> %x26
+929ffffe : movn x30, #0xffff, LSL #0                 : movn   $0xffff lsl $0x00 -> %x30
+92a00000 : movn x0, #0x0, LSL #16                    : movn   $0x0000 lsl $0x10 -> %x0
+92a20002 : movn x2, #0x1000, LSL #16                 : movn   $0x1000 lsl $0x10 -> %x2
+92a40004 : movn x4, #0x2000, LSL #16                 : movn   $0x2000 lsl $0x10 -> %x4
+92a60006 : movn x6, #0x3000, LSL #16                 : movn   $0x3000 lsl $0x10 -> %x6
+92a80008 : movn x8, #0x4000, LSL #16                 : movn   $0x4000 lsl $0x10 -> %x8
+92aa0009 : movn x9, #0x5000, LSL #16                 : movn   $0x5000 lsl $0x10 -> %x9
+92ac000b : movn x11, #0x6000, LSL #16                : movn   $0x6000 lsl $0x10 -> %x11
+92ae000d : movn x13, #0x7000, LSL #16                : movn   $0x7000 lsl $0x10 -> %x13
+92b0000f : movn x15, #0x8000, LSL #16                : movn   $0x8000 lsl $0x10 -> %x15
+92b1fff1 : movn x17, #0x8fff, LSL #16                : movn   $0x8fff lsl $0x10 -> %x17
+92b3fff3 : movn x19, #0x9fff, LSL #16                : movn   $0x9fff lsl $0x10 -> %x19
+92b5fff5 : movn x21, #0xafff, LSL #16                : movn   $0xafff lsl $0x10 -> %x21
+92b7fff6 : movn x22, #0xbfff, LSL #16                : movn   $0xbfff lsl $0x10 -> %x22
+92b9fff8 : movn x24, #0xcfff, LSL #16                : movn   $0xcfff lsl $0x10 -> %x24
+92bbfffa : movn x26, #0xdfff, LSL #16                : movn   $0xdfff lsl $0x10 -> %x26
+92bffffe : movn x30, #0xffff, LSL #16                : movn   $0xffff lsl $0x10 -> %x30
+92c00000 : movn x0, #0x0, LSL #32                    : movn   $0x0000 lsl $0x20 -> %x0
+92c20002 : movn x2, #0x1000, LSL #32                 : movn   $0x1000 lsl $0x20 -> %x2
+92c40004 : movn x4, #0x2000, LSL #32                 : movn   $0x2000 lsl $0x20 -> %x4
+92c60006 : movn x6, #0x3000, LSL #32                 : movn   $0x3000 lsl $0x20 -> %x6
+92c80008 : movn x8, #0x4000, LSL #32                 : movn   $0x4000 lsl $0x20 -> %x8
+92ca0009 : movn x9, #0x5000, LSL #32                 : movn   $0x5000 lsl $0x20 -> %x9
+92cc000b : movn x11, #0x6000, LSL #32                : movn   $0x6000 lsl $0x20 -> %x11
+92ce000d : movn x13, #0x7000, LSL #32                : movn   $0x7000 lsl $0x20 -> %x13
+92d0000f : movn x15, #0x8000, LSL #32                : movn   $0x8000 lsl $0x20 -> %x15
+92d1fff1 : movn x17, #0x8fff, LSL #32                : movn   $0x8fff lsl $0x20 -> %x17
+92d3fff3 : movn x19, #0x9fff, LSL #32                : movn   $0x9fff lsl $0x20 -> %x19
+92d5fff5 : movn x21, #0xafff, LSL #32                : movn   $0xafff lsl $0x20 -> %x21
+92d7fff6 : movn x22, #0xbfff, LSL #32                : movn   $0xbfff lsl $0x20 -> %x22
+92d9fff8 : movn x24, #0xcfff, LSL #32                : movn   $0xcfff lsl $0x20 -> %x24
+92dbfffa : movn x26, #0xdfff, LSL #32                : movn   $0xdfff lsl $0x20 -> %x26
+92dffffe : movn x30, #0xffff, LSL #32                : movn   $0xffff lsl $0x20 -> %x30
+92e00000 : movn x0, #0x0, LSL #48                    : movn   $0x0000 lsl $0x30 -> %x0
+92e20002 : movn x2, #0x1000, LSL #48                 : movn   $0x1000 lsl $0x30 -> %x2
+92e40004 : movn x4, #0x2000, LSL #48                 : movn   $0x2000 lsl $0x30 -> %x4
+92e60006 : movn x6, #0x3000, LSL #48                 : movn   $0x3000 lsl $0x30 -> %x6
+92e80008 : movn x8, #0x4000, LSL #48                 : movn   $0x4000 lsl $0x30 -> %x8
+92ea0009 : movn x9, #0x5000, LSL #48                 : movn   $0x5000 lsl $0x30 -> %x9
+92ec000b : movn x11, #0x6000, LSL #48                : movn   $0x6000 lsl $0x30 -> %x11
+92ee000d : movn x13, #0x7000, LSL #48                : movn   $0x7000 lsl $0x30 -> %x13
+92f0000f : movn x15, #0x8000, LSL #48                : movn   $0x8000 lsl $0x30 -> %x15
+92f1fff1 : movn x17, #0x8fff, LSL #48                : movn   $0x8fff lsl $0x30 -> %x17
+92f3fff3 : movn x19, #0x9fff, LSL #48                : movn   $0x9fff lsl $0x30 -> %x19
+92f5fff5 : movn x21, #0xafff, LSL #48                : movn   $0xafff lsl $0x30 -> %x21
+92f7fff6 : movn x22, #0xbfff, LSL #48                : movn   $0xbfff lsl $0x30 -> %x22
+92f9fff8 : movn x24, #0xcfff, LSL #48                : movn   $0xcfff lsl $0x30 -> %x24
+92fbfffa : movn x26, #0xdfff, LSL #48                : movn   $0xdfff lsl $0x30 -> %x26
+92fffffe : movn x30, #0xffff, LSL #48                : movn   $0xffff lsl $0x30 -> %x30
+
+# SUB     <Wd|SP>, <Wn|SP>, <Wm>, <extend> #<imm> (SUB-R.RRI-32_addsub_ext)
+4b220020 : sub w0, w1, w2, UXTB #0                   : sub    %w1 %w2 uxtb $0x00 -> %w0
+4b240062 : sub w2, w3, w4, UXTB #0                   : sub    %w3 %w4 uxtb $0x00 -> %w2
+4b2600a4 : sub w4, w5, w6, UXTB #0                   : sub    %w5 %w6 uxtb $0x00 -> %w4
+4b2804e6 : sub w6, w7, w8, UXTB #1                   : sub    %w7 %w8 uxtb $0x01 -> %w6
+4b2a0528 : sub w8, w9, w10, UXTB #1                  : sub    %w9 %w10 uxtb $0x01 -> %w8
+4b2b0549 : sub w9, w10, w11, UXTB #1                 : sub    %w10 %w11 uxtb $0x01 -> %w9
+4b2d098b : sub w11, w12, w13, UXTB #2                : sub    %w12 %w13 uxtb $0x02 -> %w11
+4b2f09cd : sub w13, w14, w15, UXTB #2                : sub    %w14 %w15 uxtb $0x02 -> %w13
+4b310a0f : sub w15, w16, w17, UXTB #2                : sub    %w16 %w17 uxtb $0x02 -> %w15
+4b330a51 : sub w17, w18, w19, UXTB #2                : sub    %w18 %w19 uxtb $0x02 -> %w17
+4b350a93 : sub w19, w20, w21, UXTB #2                : sub    %w20 %w21 uxtb $0x02 -> %w19
+4b370ed5 : sub w21, w22, w23, UXTB #3                : sub    %w22 %w23 uxtb $0x03 -> %w21
+4b380ef6 : sub w22, w23, w24, UXTB #3                : sub    %w23 %w24 uxtb $0x03 -> %w22
+4b3a0f38 : sub w24, w25, w26, UXTB #3                : sub    %w25 %w26 uxtb $0x03 -> %w24
+4b3c137a : sub w26, w27, w28, UXTB #4                : sub    %w27 %w28 uxtb $0x04 -> %w26
+4b21101f : sub wsp, w0, w1, UXTB #4                  : sub    %w0 %w1 uxtb $0x04 -> %wsp
+4b222020 : sub w0, w1, w2, UXTH #0                   : sub    %w1 %w2 uxth $0x00 -> %w0
+4b242062 : sub w2, w3, w4, UXTH #0                   : sub    %w3 %w4 uxth $0x00 -> %w2
+4b2620a4 : sub w4, w5, w6, UXTH #0                   : sub    %w5 %w6 uxth $0x00 -> %w4
+4b2824e6 : sub w6, w7, w8, UXTH #1                   : sub    %w7 %w8 uxth $0x01 -> %w6
+4b2a2528 : sub w8, w9, w10, UXTH #1                  : sub    %w9 %w10 uxth $0x01 -> %w8
+4b2b2549 : sub w9, w10, w11, UXTH #1                 : sub    %w10 %w11 uxth $0x01 -> %w9
+4b2d298b : sub w11, w12, w13, UXTH #2                : sub    %w12 %w13 uxth $0x02 -> %w11
+4b2f29cd : sub w13, w14, w15, UXTH #2                : sub    %w14 %w15 uxth $0x02 -> %w13
+4b312a0f : sub w15, w16, w17, UXTH #2                : sub    %w16 %w17 uxth $0x02 -> %w15
+4b332a51 : sub w17, w18, w19, UXTH #2                : sub    %w18 %w19 uxth $0x02 -> %w17
+4b352a93 : sub w19, w20, w21, UXTH #2                : sub    %w20 %w21 uxth $0x02 -> %w19
+4b372ed5 : sub w21, w22, w23, UXTH #3                : sub    %w22 %w23 uxth $0x03 -> %w21
+4b382ef6 : sub w22, w23, w24, UXTH #3                : sub    %w23 %w24 uxth $0x03 -> %w22
+4b3a2f38 : sub w24, w25, w26, UXTH #3                : sub    %w25 %w26 uxth $0x03 -> %w24
+4b3c337a : sub w26, w27, w28, UXTH #4                : sub    %w27 %w28 uxth $0x04 -> %w26
+4b21301f : sub wsp, w0, w1, UXTH #4                  : sub    %w0 %w1 uxth $0x04 -> %wsp
+4b224020 : sub w0, w1, w2, UXTW #0                   : sub    %w1 %w2 uxtw $0x00 -> %w0
+4b244062 : sub w2, w3, w4, UXTW #0                   : sub    %w3 %w4 uxtw $0x00 -> %w2
+4b2640a4 : sub w4, w5, w6, UXTW #0                   : sub    %w5 %w6 uxtw $0x00 -> %w4
+4b2844e6 : sub w6, w7, w8, UXTW #1                   : sub    %w7 %w8 uxtw $0x01 -> %w6
+4b2a4528 : sub w8, w9, w10, UXTW #1                  : sub    %w9 %w10 uxtw $0x01 -> %w8
+4b2b4549 : sub w9, w10, w11, UXTW #1                 : sub    %w10 %w11 uxtw $0x01 -> %w9
+4b2d498b : sub w11, w12, w13, UXTW #2                : sub    %w12 %w13 uxtw $0x02 -> %w11
+4b2f49cd : sub w13, w14, w15, UXTW #2                : sub    %w14 %w15 uxtw $0x02 -> %w13
+4b314a0f : sub w15, w16, w17, UXTW #2                : sub    %w16 %w17 uxtw $0x02 -> %w15
+4b334a51 : sub w17, w18, w19, UXTW #2                : sub    %w18 %w19 uxtw $0x02 -> %w17
+4b354a93 : sub w19, w20, w21, UXTW #2                : sub    %w20 %w21 uxtw $0x02 -> %w19
+4b374ed5 : sub w21, w22, w23, UXTW #3                : sub    %w22 %w23 uxtw $0x03 -> %w21
+4b384ef6 : sub w22, w23, w24, UXTW #3                : sub    %w23 %w24 uxtw $0x03 -> %w22
+4b3a4f38 : sub w24, w25, w26, UXTW #3                : sub    %w25 %w26 uxtw $0x03 -> %w24
+4b3c537a : sub w26, w27, w28, UXTW #4                : sub    %w27 %w28 uxtw $0x04 -> %w26
+4b21501f : sub wsp, w0, w1, UXTW #4                  : sub    %w0 %w1 uxtw $0x04 -> %wsp
+4b226020 : sub w0, w1, w2, UXTX #0                   : sub    %w1 %w2 uxtx $0x00 -> %w0
+4b246062 : sub w2, w3, w4, UXTX #0                   : sub    %w3 %w4 uxtx $0x00 -> %w2
+4b2660a4 : sub w4, w5, w6, UXTX #0                   : sub    %w5 %w6 uxtx $0x00 -> %w4
+4b2864e6 : sub w6, w7, w8, UXTX #1                   : sub    %w7 %w8 uxtx $0x01 -> %w6
+4b2a6528 : sub w8, w9, w10, UXTX #1                  : sub    %w9 %w10 uxtx $0x01 -> %w8
+4b2b6549 : sub w9, w10, w11, UXTX #1                 : sub    %w10 %w11 uxtx $0x01 -> %w9
+4b2d698b : sub w11, w12, w13, UXTX #2                : sub    %w12 %w13 uxtx $0x02 -> %w11
+4b2f69cd : sub w13, w14, w15, UXTX #2                : sub    %w14 %w15 uxtx $0x02 -> %w13
+4b316a0f : sub w15, w16, w17, UXTX #2                : sub    %w16 %w17 uxtx $0x02 -> %w15
+4b336a51 : sub w17, w18, w19, UXTX #2                : sub    %w18 %w19 uxtx $0x02 -> %w17
+4b356a93 : sub w19, w20, w21, UXTX #2                : sub    %w20 %w21 uxtx $0x02 -> %w19
+4b376ed5 : sub w21, w22, w23, UXTX #3                : sub    %w22 %w23 uxtx $0x03 -> %w21
+4b386ef6 : sub w22, w23, w24, UXTX #3                : sub    %w23 %w24 uxtx $0x03 -> %w22
+4b3a6f38 : sub w24, w25, w26, UXTX #3                : sub    %w25 %w26 uxtx $0x03 -> %w24
+4b3c737a : sub w26, w27, w28, UXTX #4                : sub    %w27 %w28 uxtx $0x04 -> %w26
+4b21701f : sub wsp, w0, w1, UXTX #4                  : sub    %w0 %w1 uxtx $0x04 -> %wsp
+4b228020 : sub w0, w1, w2, SXTB #0                   : sub    %w1 %w2 sxtb $0x00 -> %w0
+4b248062 : sub w2, w3, w4, SXTB #0                   : sub    %w3 %w4 sxtb $0x00 -> %w2
+4b2680a4 : sub w4, w5, w6, SXTB #0                   : sub    %w5 %w6 sxtb $0x00 -> %w4
+4b2884e6 : sub w6, w7, w8, SXTB #1                   : sub    %w7 %w8 sxtb $0x01 -> %w6
+4b2a8528 : sub w8, w9, w10, SXTB #1                  : sub    %w9 %w10 sxtb $0x01 -> %w8
+4b2b8549 : sub w9, w10, w11, SXTB #1                 : sub    %w10 %w11 sxtb $0x01 -> %w9
+4b2d898b : sub w11, w12, w13, SXTB #2                : sub    %w12 %w13 sxtb $0x02 -> %w11
+4b2f89cd : sub w13, w14, w15, SXTB #2                : sub    %w14 %w15 sxtb $0x02 -> %w13
+4b318a0f : sub w15, w16, w17, SXTB #2                : sub    %w16 %w17 sxtb $0x02 -> %w15
+4b338a51 : sub w17, w18, w19, SXTB #2                : sub    %w18 %w19 sxtb $0x02 -> %w17
+4b358a93 : sub w19, w20, w21, SXTB #2                : sub    %w20 %w21 sxtb $0x02 -> %w19
+4b378ed5 : sub w21, w22, w23, SXTB #3                : sub    %w22 %w23 sxtb $0x03 -> %w21
+4b388ef6 : sub w22, w23, w24, SXTB #3                : sub    %w23 %w24 sxtb $0x03 -> %w22
+4b3a8f38 : sub w24, w25, w26, SXTB #3                : sub    %w25 %w26 sxtb $0x03 -> %w24
+4b3c937a : sub w26, w27, w28, SXTB #4                : sub    %w27 %w28 sxtb $0x04 -> %w26
+4b21901f : sub wsp, w0, w1, SXTB #4                  : sub    %w0 %w1 sxtb $0x04 -> %wsp
+4b22a020 : sub w0, w1, w2, SXTH #0                   : sub    %w1 %w2 sxth $0x00 -> %w0
+4b24a062 : sub w2, w3, w4, SXTH #0                   : sub    %w3 %w4 sxth $0x00 -> %w2
+4b26a0a4 : sub w4, w5, w6, SXTH #0                   : sub    %w5 %w6 sxth $0x00 -> %w4
+4b28a4e6 : sub w6, w7, w8, SXTH #1                   : sub    %w7 %w8 sxth $0x01 -> %w6
+4b2aa528 : sub w8, w9, w10, SXTH #1                  : sub    %w9 %w10 sxth $0x01 -> %w8
+4b2ba549 : sub w9, w10, w11, SXTH #1                 : sub    %w10 %w11 sxth $0x01 -> %w9
+4b2da98b : sub w11, w12, w13, SXTH #2                : sub    %w12 %w13 sxth $0x02 -> %w11
+4b2fa9cd : sub w13, w14, w15, SXTH #2                : sub    %w14 %w15 sxth $0x02 -> %w13
+4b31aa0f : sub w15, w16, w17, SXTH #2                : sub    %w16 %w17 sxth $0x02 -> %w15
+4b33aa51 : sub w17, w18, w19, SXTH #2                : sub    %w18 %w19 sxth $0x02 -> %w17
+4b35aa93 : sub w19, w20, w21, SXTH #2                : sub    %w20 %w21 sxth $0x02 -> %w19
+4b37aed5 : sub w21, w22, w23, SXTH #3                : sub    %w22 %w23 sxth $0x03 -> %w21
+4b38aef6 : sub w22, w23, w24, SXTH #3                : sub    %w23 %w24 sxth $0x03 -> %w22
+4b3aaf38 : sub w24, w25, w26, SXTH #3                : sub    %w25 %w26 sxth $0x03 -> %w24
+4b3cb37a : sub w26, w27, w28, SXTH #4                : sub    %w27 %w28 sxth $0x04 -> %w26
+4b21b01f : sub wsp, w0, w1, SXTH #4                  : sub    %w0 %w1 sxth $0x04 -> %wsp
+4b22c020 : sub w0, w1, w2, SXTW #0                   : sub    %w1 %w2 sxtw $0x00 -> %w0
+4b24c062 : sub w2, w3, w4, SXTW #0                   : sub    %w3 %w4 sxtw $0x00 -> %w2
+4b26c0a4 : sub w4, w5, w6, SXTW #0                   : sub    %w5 %w6 sxtw $0x00 -> %w4
+4b28c4e6 : sub w6, w7, w8, SXTW #1                   : sub    %w7 %w8 sxtw $0x01 -> %w6
+4b2ac528 : sub w8, w9, w10, SXTW #1                  : sub    %w9 %w10 sxtw $0x01 -> %w8
+4b2bc549 : sub w9, w10, w11, SXTW #1                 : sub    %w10 %w11 sxtw $0x01 -> %w9
+4b2dc98b : sub w11, w12, w13, SXTW #2                : sub    %w12 %w13 sxtw $0x02 -> %w11
+4b2fc9cd : sub w13, w14, w15, SXTW #2                : sub    %w14 %w15 sxtw $0x02 -> %w13
+4b31ca0f : sub w15, w16, w17, SXTW #2                : sub    %w16 %w17 sxtw $0x02 -> %w15
+4b33ca51 : sub w17, w18, w19, SXTW #2                : sub    %w18 %w19 sxtw $0x02 -> %w17
+4b35ca93 : sub w19, w20, w21, SXTW #2                : sub    %w20 %w21 sxtw $0x02 -> %w19
+4b37ced5 : sub w21, w22, w23, SXTW #3                : sub    %w22 %w23 sxtw $0x03 -> %w21
+4b38cef6 : sub w22, w23, w24, SXTW #3                : sub    %w23 %w24 sxtw $0x03 -> %w22
+4b3acf38 : sub w24, w25, w26, SXTW #3                : sub    %w25 %w26 sxtw $0x03 -> %w24
+4b3cd37a : sub w26, w27, w28, SXTW #4                : sub    %w27 %w28 sxtw $0x04 -> %w26
+4b21d01f : sub wsp, w0, w1, SXTW #4                  : sub    %w0 %w1 sxtw $0x04 -> %wsp
+4b22e020 : sub w0, w1, w2, SXTX #0                   : sub    %w1 %w2 sxtx $0x00 -> %w0
+4b24e062 : sub w2, w3, w4, SXTX #0                   : sub    %w3 %w4 sxtx $0x00 -> %w2
+4b26e0a4 : sub w4, w5, w6, SXTX #0                   : sub    %w5 %w6 sxtx $0x00 -> %w4
+4b28e4e6 : sub w6, w7, w8, SXTX #1                   : sub    %w7 %w8 sxtx $0x01 -> %w6
+4b2ae528 : sub w8, w9, w10, SXTX #1                  : sub    %w9 %w10 sxtx $0x01 -> %w8
+4b2be549 : sub w9, w10, w11, SXTX #1                 : sub    %w10 %w11 sxtx $0x01 -> %w9
+4b2de98b : sub w11, w12, w13, SXTX #2                : sub    %w12 %w13 sxtx $0x02 -> %w11
+4b2fe9cd : sub w13, w14, w15, SXTX #2                : sub    %w14 %w15 sxtx $0x02 -> %w13
+4b31ea0f : sub w15, w16, w17, SXTX #2                : sub    %w16 %w17 sxtx $0x02 -> %w15
+4b33ea51 : sub w17, w18, w19, SXTX #2                : sub    %w18 %w19 sxtx $0x02 -> %w17
+4b35ea93 : sub w19, w20, w21, SXTX #2                : sub    %w20 %w21 sxtx $0x02 -> %w19
+4b37eed5 : sub w21, w22, w23, SXTX #3                : sub    %w22 %w23 sxtx $0x03 -> %w21
+4b38eef6 : sub w22, w23, w24, SXTX #3                : sub    %w23 %w24 sxtx $0x03 -> %w22
+4b3aef38 : sub w24, w25, w26, SXTX #3                : sub    %w25 %w26 sxtx $0x03 -> %w24
+4b3cf37a : sub w26, w27, w28, SXTX #4                : sub    %w27 %w28 sxtx $0x04 -> %w26
+4b21f01f : sub wsp, w0, w1, SXTX #4                  : sub    %w0 %w1 sxtx $0x04 -> %wsp
+
+# ADD     <Xd>, <Xn>, <Xm>, <extend> #<imm> (ADD-R.RRI-64_addsub_shift)
+8b020020 : add x0, x1, x2, LSL #0                    : add    %x1 %x2 lsl $0x00 -> %x0
+8b040862 : add x2, x3, x4, LSL #2                    : add    %x3 %x4 lsl $0x02 -> %x2
+8b0610a4 : add x4, x5, x6, LSL #4                    : add    %x5 %x6 lsl $0x04 -> %x4
+8b0818e6 : add x6, x7, x8, LSL #6                    : add    %x7 %x8 lsl $0x06 -> %x6
+8b0a2128 : add x8, x9, x10, LSL #8                   : add    %x9 %x10 lsl $0x08 -> %x8
+8b0b2949 : add x9, x10, x11, LSL #10                 : add    %x10 %x11 lsl $0x0a -> %x9
+8b0d318b : add x11, x12, x13, LSL #12                : add    %x12 %x13 lsl $0x0c -> %x11
+8b0f39cd : add x13, x14, x15, LSL #14                : add    %x14 %x15 lsl $0x0e -> %x13
+8b11420f : add x15, x16, x17, LSL #16                : add    %x16 %x17 lsl $0x10 -> %x15
+8b134651 : add x17, x18, x19, LSL #17                : add    %x18 %x19 lsl $0x11 -> %x17
+8b154e93 : add x19, x20, x21, LSL #19                : add    %x20 %x21 lsl $0x13 -> %x19
+8b1756d5 : add x21, x22, x23, LSL #21                : add    %x22 %x23 lsl $0x15 -> %x21
+8b185ef6 : add x22, x23, x24, LSL #23                : add    %x23 %x24 lsl $0x17 -> %x22
+8b1a6738 : add x24, x25, x26, LSL #25                : add    %x25 %x26 lsl $0x19 -> %x24
+8b1c6f7a : add x26, x27, x28, LSL #27                : add    %x27 %x28 lsl $0x1b -> %x26
+8b017c1e : add x30, x0, x1, LSL #31                  : add    %x0 %x1 lsl $0x1f -> %x30
+8b420020 : add x0, x1, x2, LSR #0                    : add    %x1 %x2 lsr $0x00 -> %x0
+8b440862 : add x2, x3, x4, LSR #2                    : add    %x3 %x4 lsr $0x02 -> %x2
+8b4610a4 : add x4, x5, x6, LSR #4                    : add    %x5 %x6 lsr $0x04 -> %x4
+8b4818e6 : add x6, x7, x8, LSR #6                    : add    %x7 %x8 lsr $0x06 -> %x6
+8b4a2128 : add x8, x9, x10, LSR #8                   : add    %x9 %x10 lsr $0x08 -> %x8
+8b4b2949 : add x9, x10, x11, LSR #10                 : add    %x10 %x11 lsr $0x0a -> %x9
+8b4d318b : add x11, x12, x13, LSR #12                : add    %x12 %x13 lsr $0x0c -> %x11
+8b4f39cd : add x13, x14, x15, LSR #14                : add    %x14 %x15 lsr $0x0e -> %x13
+8b51420f : add x15, x16, x17, LSR #16                : add    %x16 %x17 lsr $0x10 -> %x15
+8b534651 : add x17, x18, x19, LSR #17                : add    %x18 %x19 lsr $0x11 -> %x17
+8b554e93 : add x19, x20, x21, LSR #19                : add    %x20 %x21 lsr $0x13 -> %x19
+8b5756d5 : add x21, x22, x23, LSR #21                : add    %x22 %x23 lsr $0x15 -> %x21
+8b585ef6 : add x22, x23, x24, LSR #23                : add    %x23 %x24 lsr $0x17 -> %x22
+8b5a6738 : add x24, x25, x26, LSR #25                : add    %x25 %x26 lsr $0x19 -> %x24
+8b5c6f7a : add x26, x27, x28, LSR #27                : add    %x27 %x28 lsr $0x1b -> %x26
+8b417c1e : add x30, x0, x1, LSR #31                  : add    %x0 %x1 lsr $0x1f -> %x30
+8b820020 : add x0, x1, x2, ASR #0                    : add    %x1 %x2 asr $0x00 -> %x0
+8b840862 : add x2, x3, x4, ASR #2                    : add    %x3 %x4 asr $0x02 -> %x2
+8b8610a4 : add x4, x5, x6, ASR #4                    : add    %x5 %x6 asr $0x04 -> %x4
+8b8818e6 : add x6, x7, x8, ASR #6                    : add    %x7 %x8 asr $0x06 -> %x6
+8b8a2128 : add x8, x9, x10, ASR #8                   : add    %x9 %x10 asr $0x08 -> %x8
+8b8b2949 : add x9, x10, x11, ASR #10                 : add    %x10 %x11 asr $0x0a -> %x9
+8b8d318b : add x11, x12, x13, ASR #12                : add    %x12 %x13 asr $0x0c -> %x11
+8b8f39cd : add x13, x14, x15, ASR #14                : add    %x14 %x15 asr $0x0e -> %x13
+8b91420f : add x15, x16, x17, ASR #16                : add    %x16 %x17 asr $0x10 -> %x15
+8b934651 : add x17, x18, x19, ASR #17                : add    %x18 %x19 asr $0x11 -> %x17
+8b954e93 : add x19, x20, x21, ASR #19                : add    %x20 %x21 asr $0x13 -> %x19
+8b9756d5 : add x21, x22, x23, ASR #21                : add    %x22 %x23 asr $0x15 -> %x21
+8b985ef6 : add x22, x23, x24, ASR #23                : add    %x23 %x24 asr $0x17 -> %x22
+8b9a6738 : add x24, x25, x26, ASR #25                : add    %x25 %x26 asr $0x19 -> %x24
+8b9c6f7a : add x26, x27, x28, ASR #27                : add    %x27 %x28 asr $0x1b -> %x26
+8b817c1e : add x30, x0, x1, ASR #31                  : add    %x0 %x1 asr $0x1f -> %x30
+
+# CCMN    <Wn>, #<imm1>, #<imm2>, <cond> (CCMN-R.II-32_condcmp_imm)
+3a400800 : ccmn w0, #0x0, #0x0, EQ                   : ccmn.eq %w0 $0x00 $0x00
+3a420841 : ccmn w2, #0x2, #0x1, EQ                   : ccmn.eq %w2 $0x02 $0x01
+3a440882 : ccmn w4, #0x4, #0x2, EQ                   : ccmn.eq %w4 $0x04 $0x02
+3a4608c3 : ccmn w6, #0x6, #0x3, EQ                   : ccmn.eq %w6 $0x06 $0x03
+3a480904 : ccmn w8, #0x8, #0x4, EQ                   : ccmn.eq %w8 $0x08 $0x04
+3a4a0925 : ccmn w9, #0xa, #0x5, EQ                   : ccmn.eq %w9 $0x0a $0x05
+3a4c0966 : ccmn w11, #0xc, #0x6, EQ                  : ccmn.eq %w11 $0x0c $0x06
+3a4e09a7 : ccmn w13, #0xe, #0x7, EQ                  : ccmn.eq %w13 $0x0e $0x07
+3a5009e8 : ccmn w15, #0x10, #0x8, EQ                 : ccmn.eq %w15 $0x10 $0x08
+3a510a28 : ccmn w17, #0x11, #0x8, EQ                 : ccmn.eq %w17 $0x11 $0x08
+3a530a69 : ccmn w19, #0x13, #0x9, EQ                 : ccmn.eq %w19 $0x13 $0x09
+3a550aaa : ccmn w21, #0x15, #0xa, EQ                 : ccmn.eq %w21 $0x15 $0x0a
+3a570acb : ccmn w22, #0x17, #0xb, EQ                 : ccmn.eq %w22 $0x17 $0x0b
+3a590b0c : ccmn w24, #0x19, #0xc, EQ                 : ccmn.eq %w24 $0x19 $0x0c
+3a5b0b4d : ccmn w26, #0x1b, #0xd, EQ                 : ccmn.eq %w26 $0x1b $0x0d
+3a5f0bcf : ccmn w30, #0x1f, #0xf, EQ                 : ccmn.eq %w30 $0x1f $0x0f
+3a401800 : ccmn w0, #0x0, #0x0, NE                   : ccmn.ne %w0 $0x00 $0x00
+3a421841 : ccmn w2, #0x2, #0x1, NE                   : ccmn.ne %w2 $0x02 $0x01
+3a441882 : ccmn w4, #0x4, #0x2, NE                   : ccmn.ne %w4 $0x04 $0x02
+3a4618c3 : ccmn w6, #0x6, #0x3, NE                   : ccmn.ne %w6 $0x06 $0x03
+3a481904 : ccmn w8, #0x8, #0x4, NE                   : ccmn.ne %w8 $0x08 $0x04
+3a4a1925 : ccmn w9, #0xa, #0x5, NE                   : ccmn.ne %w9 $0x0a $0x05
+3a4c1966 : ccmn w11, #0xc, #0x6, NE                  : ccmn.ne %w11 $0x0c $0x06
+3a4e19a7 : ccmn w13, #0xe, #0x7, NE                  : ccmn.ne %w13 $0x0e $0x07
+3a5019e8 : ccmn w15, #0x10, #0x8, NE                 : ccmn.ne %w15 $0x10 $0x08
+3a511a28 : ccmn w17, #0x11, #0x8, NE                 : ccmn.ne %w17 $0x11 $0x08
+3a531a69 : ccmn w19, #0x13, #0x9, NE                 : ccmn.ne %w19 $0x13 $0x09
+3a551aaa : ccmn w21, #0x15, #0xa, NE                 : ccmn.ne %w21 $0x15 $0x0a
+3a571acb : ccmn w22, #0x17, #0xb, NE                 : ccmn.ne %w22 $0x17 $0x0b
+3a591b0c : ccmn w24, #0x19, #0xc, NE                 : ccmn.ne %w24 $0x19 $0x0c
+3a5b1b4d : ccmn w26, #0x1b, #0xd, NE                 : ccmn.ne %w26 $0x1b $0x0d
+3a5f1bcf : ccmn w30, #0x1f, #0xf, NE                 : ccmn.ne %w30 $0x1f $0x0f
+3a402800 : ccmn w0, #0x0, #0x0, CS                   : ccmn.cs %w0 $0x00 $0x00
+3a422841 : ccmn w2, #0x2, #0x1, CS                   : ccmn.cs %w2 $0x02 $0x01
+3a442882 : ccmn w4, #0x4, #0x2, CS                   : ccmn.cs %w4 $0x04 $0x02
+3a4628c3 : ccmn w6, #0x6, #0x3, CS                   : ccmn.cs %w6 $0x06 $0x03
+3a482904 : ccmn w8, #0x8, #0x4, CS                   : ccmn.cs %w8 $0x08 $0x04
+3a4a2925 : ccmn w9, #0xa, #0x5, CS                   : ccmn.cs %w9 $0x0a $0x05
+3a4c2966 : ccmn w11, #0xc, #0x6, CS                  : ccmn.cs %w11 $0x0c $0x06
+3a4e29a7 : ccmn w13, #0xe, #0x7, CS                  : ccmn.cs %w13 $0x0e $0x07
+3a5029e8 : ccmn w15, #0x10, #0x8, CS                 : ccmn.cs %w15 $0x10 $0x08
+3a512a28 : ccmn w17, #0x11, #0x8, CS                 : ccmn.cs %w17 $0x11 $0x08
+3a532a69 : ccmn w19, #0x13, #0x9, CS                 : ccmn.cs %w19 $0x13 $0x09
+3a552aaa : ccmn w21, #0x15, #0xa, CS                 : ccmn.cs %w21 $0x15 $0x0a
+3a572acb : ccmn w22, #0x17, #0xb, CS                 : ccmn.cs %w22 $0x17 $0x0b
+3a592b0c : ccmn w24, #0x19, #0xc, CS                 : ccmn.cs %w24 $0x19 $0x0c
+3a5b2b4d : ccmn w26, #0x1b, #0xd, CS                 : ccmn.cs %w26 $0x1b $0x0d
+3a5f2bcf : ccmn w30, #0x1f, #0xf, CS                 : ccmn.cs %w30 $0x1f $0x0f
+3a403800 : ccmn w0, #0x0, #0x0, CC                   : ccmn.cc %w0 $0x00 $0x00
+3a423841 : ccmn w2, #0x2, #0x1, CC                   : ccmn.cc %w2 $0x02 $0x01
+3a443882 : ccmn w4, #0x4, #0x2, CC                   : ccmn.cc %w4 $0x04 $0x02
+3a4638c3 : ccmn w6, #0x6, #0x3, CC                   : ccmn.cc %w6 $0x06 $0x03
+3a483904 : ccmn w8, #0x8, #0x4, CC                   : ccmn.cc %w8 $0x08 $0x04
+3a4a3925 : ccmn w9, #0xa, #0x5, CC                   : ccmn.cc %w9 $0x0a $0x05
+3a4c3966 : ccmn w11, #0xc, #0x6, CC                  : ccmn.cc %w11 $0x0c $0x06
+3a4e39a7 : ccmn w13, #0xe, #0x7, CC                  : ccmn.cc %w13 $0x0e $0x07
+3a5039e8 : ccmn w15, #0x10, #0x8, CC                 : ccmn.cc %w15 $0x10 $0x08
+3a513a28 : ccmn w17, #0x11, #0x8, CC                 : ccmn.cc %w17 $0x11 $0x08
+3a533a69 : ccmn w19, #0x13, #0x9, CC                 : ccmn.cc %w19 $0x13 $0x09
+3a553aaa : ccmn w21, #0x15, #0xa, CC                 : ccmn.cc %w21 $0x15 $0x0a
+3a573acb : ccmn w22, #0x17, #0xb, CC                 : ccmn.cc %w22 $0x17 $0x0b
+3a593b0c : ccmn w24, #0x19, #0xc, CC                 : ccmn.cc %w24 $0x19 $0x0c
+3a5b3b4d : ccmn w26, #0x1b, #0xd, CC                 : ccmn.cc %w26 $0x1b $0x0d
+3a5f3bcf : ccmn w30, #0x1f, #0xf, CC                 : ccmn.cc %w30 $0x1f $0x0f
+3a404800 : ccmn w0, #0x0, #0x0, MI                   : ccmn.mi %w0 $0x00 $0x00
+3a424841 : ccmn w2, #0x2, #0x1, MI                   : ccmn.mi %w2 $0x02 $0x01
+3a444882 : ccmn w4, #0x4, #0x2, MI                   : ccmn.mi %w4 $0x04 $0x02
+3a4648c3 : ccmn w6, #0x6, #0x3, MI                   : ccmn.mi %w6 $0x06 $0x03
+3a484904 : ccmn w8, #0x8, #0x4, MI                   : ccmn.mi %w8 $0x08 $0x04
+3a4a4925 : ccmn w9, #0xa, #0x5, MI                   : ccmn.mi %w9 $0x0a $0x05
+3a4c4966 : ccmn w11, #0xc, #0x6, MI                  : ccmn.mi %w11 $0x0c $0x06
+3a4e49a7 : ccmn w13, #0xe, #0x7, MI                  : ccmn.mi %w13 $0x0e $0x07
+3a5049e8 : ccmn w15, #0x10, #0x8, MI                 : ccmn.mi %w15 $0x10 $0x08
+3a514a28 : ccmn w17, #0x11, #0x8, MI                 : ccmn.mi %w17 $0x11 $0x08
+3a534a69 : ccmn w19, #0x13, #0x9, MI                 : ccmn.mi %w19 $0x13 $0x09
+3a554aaa : ccmn w21, #0x15, #0xa, MI                 : ccmn.mi %w21 $0x15 $0x0a
+3a574acb : ccmn w22, #0x17, #0xb, MI                 : ccmn.mi %w22 $0x17 $0x0b
+3a594b0c : ccmn w24, #0x19, #0xc, MI                 : ccmn.mi %w24 $0x19 $0x0c
+3a5b4b4d : ccmn w26, #0x1b, #0xd, MI                 : ccmn.mi %w26 $0x1b $0x0d
+3a5f4bcf : ccmn w30, #0x1f, #0xf, MI                 : ccmn.mi %w30 $0x1f $0x0f
+3a405800 : ccmn w0, #0x0, #0x0, PL                   : ccmn.pl %w0 $0x00 $0x00
+3a425841 : ccmn w2, #0x2, #0x1, PL                   : ccmn.pl %w2 $0x02 $0x01
+3a445882 : ccmn w4, #0x4, #0x2, PL                   : ccmn.pl %w4 $0x04 $0x02
+3a4658c3 : ccmn w6, #0x6, #0x3, PL                   : ccmn.pl %w6 $0x06 $0x03
+3a485904 : ccmn w8, #0x8, #0x4, PL                   : ccmn.pl %w8 $0x08 $0x04
+3a4a5925 : ccmn w9, #0xa, #0x5, PL                   : ccmn.pl %w9 $0x0a $0x05
+3a4c5966 : ccmn w11, #0xc, #0x6, PL                  : ccmn.pl %w11 $0x0c $0x06
+3a4e59a7 : ccmn w13, #0xe, #0x7, PL                  : ccmn.pl %w13 $0x0e $0x07
+3a5059e8 : ccmn w15, #0x10, #0x8, PL                 : ccmn.pl %w15 $0x10 $0x08
+3a515a28 : ccmn w17, #0x11, #0x8, PL                 : ccmn.pl %w17 $0x11 $0x08
+3a535a69 : ccmn w19, #0x13, #0x9, PL                 : ccmn.pl %w19 $0x13 $0x09
+3a555aaa : ccmn w21, #0x15, #0xa, PL                 : ccmn.pl %w21 $0x15 $0x0a
+3a575acb : ccmn w22, #0x17, #0xb, PL                 : ccmn.pl %w22 $0x17 $0x0b
+3a595b0c : ccmn w24, #0x19, #0xc, PL                 : ccmn.pl %w24 $0x19 $0x0c
+3a5b5b4d : ccmn w26, #0x1b, #0xd, PL                 : ccmn.pl %w26 $0x1b $0x0d
+3a5f5bcf : ccmn w30, #0x1f, #0xf, PL                 : ccmn.pl %w30 $0x1f $0x0f
+3a406800 : ccmn w0, #0x0, #0x0, VS                   : ccmn.vs %w0 $0x00 $0x00
+3a426841 : ccmn w2, #0x2, #0x1, VS                   : ccmn.vs %w2 $0x02 $0x01
+3a446882 : ccmn w4, #0x4, #0x2, VS                   : ccmn.vs %w4 $0x04 $0x02
+3a4668c3 : ccmn w6, #0x6, #0x3, VS                   : ccmn.vs %w6 $0x06 $0x03
+3a486904 : ccmn w8, #0x8, #0x4, VS                   : ccmn.vs %w8 $0x08 $0x04
+3a4a6925 : ccmn w9, #0xa, #0x5, VS                   : ccmn.vs %w9 $0x0a $0x05
+3a4c6966 : ccmn w11, #0xc, #0x6, VS                  : ccmn.vs %w11 $0x0c $0x06
+3a4e69a7 : ccmn w13, #0xe, #0x7, VS                  : ccmn.vs %w13 $0x0e $0x07
+3a5069e8 : ccmn w15, #0x10, #0x8, VS                 : ccmn.vs %w15 $0x10 $0x08
+3a516a28 : ccmn w17, #0x11, #0x8, VS                 : ccmn.vs %w17 $0x11 $0x08
+3a536a69 : ccmn w19, #0x13, #0x9, VS                 : ccmn.vs %w19 $0x13 $0x09
+3a556aaa : ccmn w21, #0x15, #0xa, VS                 : ccmn.vs %w21 $0x15 $0x0a
+3a576acb : ccmn w22, #0x17, #0xb, VS                 : ccmn.vs %w22 $0x17 $0x0b
+3a596b0c : ccmn w24, #0x19, #0xc, VS                 : ccmn.vs %w24 $0x19 $0x0c
+3a5b6b4d : ccmn w26, #0x1b, #0xd, VS                 : ccmn.vs %w26 $0x1b $0x0d
+3a5f6bcf : ccmn w30, #0x1f, #0xf, VS                 : ccmn.vs %w30 $0x1f $0x0f
+3a407800 : ccmn w0, #0x0, #0x0, VC                   : ccmn.vc %w0 $0x00 $0x00
+3a427841 : ccmn w2, #0x2, #0x1, VC                   : ccmn.vc %w2 $0x02 $0x01
+3a447882 : ccmn w4, #0x4, #0x2, VC                   : ccmn.vc %w4 $0x04 $0x02
+3a4678c3 : ccmn w6, #0x6, #0x3, VC                   : ccmn.vc %w6 $0x06 $0x03
+3a487904 : ccmn w8, #0x8, #0x4, VC                   : ccmn.vc %w8 $0x08 $0x04
+3a4a7925 : ccmn w9, #0xa, #0x5, VC                   : ccmn.vc %w9 $0x0a $0x05
+3a4c7966 : ccmn w11, #0xc, #0x6, VC                  : ccmn.vc %w11 $0x0c $0x06
+3a4e79a7 : ccmn w13, #0xe, #0x7, VC                  : ccmn.vc %w13 $0x0e $0x07
+3a5079e8 : ccmn w15, #0x10, #0x8, VC                 : ccmn.vc %w15 $0x10 $0x08
+3a517a28 : ccmn w17, #0x11, #0x8, VC                 : ccmn.vc %w17 $0x11 $0x08
+3a537a69 : ccmn w19, #0x13, #0x9, VC                 : ccmn.vc %w19 $0x13 $0x09
+3a557aaa : ccmn w21, #0x15, #0xa, VC                 : ccmn.vc %w21 $0x15 $0x0a
+3a577acb : ccmn w22, #0x17, #0xb, VC                 : ccmn.vc %w22 $0x17 $0x0b
+3a597b0c : ccmn w24, #0x19, #0xc, VC                 : ccmn.vc %w24 $0x19 $0x0c
+3a5b7b4d : ccmn w26, #0x1b, #0xd, VC                 : ccmn.vc %w26 $0x1b $0x0d
+3a5f7bcf : ccmn w30, #0x1f, #0xf, VC                 : ccmn.vc %w30 $0x1f $0x0f
+3a408800 : ccmn w0, #0x0, #0x0, HI                   : ccmn.hi %w0 $0x00 $0x00
+3a428841 : ccmn w2, #0x2, #0x1, HI                   : ccmn.hi %w2 $0x02 $0x01
+3a448882 : ccmn w4, #0x4, #0x2, HI                   : ccmn.hi %w4 $0x04 $0x02
+3a4688c3 : ccmn w6, #0x6, #0x3, HI                   : ccmn.hi %w6 $0x06 $0x03
+3a488904 : ccmn w8, #0x8, #0x4, HI                   : ccmn.hi %w8 $0x08 $0x04
+3a4a8925 : ccmn w9, #0xa, #0x5, HI                   : ccmn.hi %w9 $0x0a $0x05
+3a4c8966 : ccmn w11, #0xc, #0x6, HI                  : ccmn.hi %w11 $0x0c $0x06
+3a4e89a7 : ccmn w13, #0xe, #0x7, HI                  : ccmn.hi %w13 $0x0e $0x07
+3a5089e8 : ccmn w15, #0x10, #0x8, HI                 : ccmn.hi %w15 $0x10 $0x08
+3a518a28 : ccmn w17, #0x11, #0x8, HI                 : ccmn.hi %w17 $0x11 $0x08
+3a538a69 : ccmn w19, #0x13, #0x9, HI                 : ccmn.hi %w19 $0x13 $0x09
+3a558aaa : ccmn w21, #0x15, #0xa, HI                 : ccmn.hi %w21 $0x15 $0x0a
+3a578acb : ccmn w22, #0x17, #0xb, HI                 : ccmn.hi %w22 $0x17 $0x0b
+3a598b0c : ccmn w24, #0x19, #0xc, HI                 : ccmn.hi %w24 $0x19 $0x0c
+3a5b8b4d : ccmn w26, #0x1b, #0xd, HI                 : ccmn.hi %w26 $0x1b $0x0d
+3a5f8bcf : ccmn w30, #0x1f, #0xf, HI                 : ccmn.hi %w30 $0x1f $0x0f
+3a409800 : ccmn w0, #0x0, #0x0, LS                   : ccmn.ls %w0 $0x00 $0x00
+3a429841 : ccmn w2, #0x2, #0x1, LS                   : ccmn.ls %w2 $0x02 $0x01
+3a449882 : ccmn w4, #0x4, #0x2, LS                   : ccmn.ls %w4 $0x04 $0x02
+3a4698c3 : ccmn w6, #0x6, #0x3, LS                   : ccmn.ls %w6 $0x06 $0x03
+3a489904 : ccmn w8, #0x8, #0x4, LS                   : ccmn.ls %w8 $0x08 $0x04
+3a4a9925 : ccmn w9, #0xa, #0x5, LS                   : ccmn.ls %w9 $0x0a $0x05
+3a4c9966 : ccmn w11, #0xc, #0x6, LS                  : ccmn.ls %w11 $0x0c $0x06
+3a4e99a7 : ccmn w13, #0xe, #0x7, LS                  : ccmn.ls %w13 $0x0e $0x07
+3a5099e8 : ccmn w15, #0x10, #0x8, LS                 : ccmn.ls %w15 $0x10 $0x08
+3a519a28 : ccmn w17, #0x11, #0x8, LS                 : ccmn.ls %w17 $0x11 $0x08
+3a539a69 : ccmn w19, #0x13, #0x9, LS                 : ccmn.ls %w19 $0x13 $0x09
+3a559aaa : ccmn w21, #0x15, #0xa, LS                 : ccmn.ls %w21 $0x15 $0x0a
+3a579acb : ccmn w22, #0x17, #0xb, LS                 : ccmn.ls %w22 $0x17 $0x0b
+3a599b0c : ccmn w24, #0x19, #0xc, LS                 : ccmn.ls %w24 $0x19 $0x0c
+3a5b9b4d : ccmn w26, #0x1b, #0xd, LS                 : ccmn.ls %w26 $0x1b $0x0d
+3a5f9bcf : ccmn w30, #0x1f, #0xf, LS                 : ccmn.ls %w30 $0x1f $0x0f
+3a40a800 : ccmn w0, #0x0, #0x0, GE                   : ccmn.ge %w0 $0x00 $0x00
+3a42a841 : ccmn w2, #0x2, #0x1, GE                   : ccmn.ge %w2 $0x02 $0x01
+3a44a882 : ccmn w4, #0x4, #0x2, GE                   : ccmn.ge %w4 $0x04 $0x02
+3a46a8c3 : ccmn w6, #0x6, #0x3, GE                   : ccmn.ge %w6 $0x06 $0x03
+3a48a904 : ccmn w8, #0x8, #0x4, GE                   : ccmn.ge %w8 $0x08 $0x04
+3a4aa925 : ccmn w9, #0xa, #0x5, GE                   : ccmn.ge %w9 $0x0a $0x05
+3a4ca966 : ccmn w11, #0xc, #0x6, GE                  : ccmn.ge %w11 $0x0c $0x06
+3a4ea9a7 : ccmn w13, #0xe, #0x7, GE                  : ccmn.ge %w13 $0x0e $0x07
+3a50a9e8 : ccmn w15, #0x10, #0x8, GE                 : ccmn.ge %w15 $0x10 $0x08
+3a51aa28 : ccmn w17, #0x11, #0x8, GE                 : ccmn.ge %w17 $0x11 $0x08
+3a53aa69 : ccmn w19, #0x13, #0x9, GE                 : ccmn.ge %w19 $0x13 $0x09
+3a55aaaa : ccmn w21, #0x15, #0xa, GE                 : ccmn.ge %w21 $0x15 $0x0a
+3a57aacb : ccmn w22, #0x17, #0xb, GE                 : ccmn.ge %w22 $0x17 $0x0b
+3a59ab0c : ccmn w24, #0x19, #0xc, GE                 : ccmn.ge %w24 $0x19 $0x0c
+3a5bab4d : ccmn w26, #0x1b, #0xd, GE                 : ccmn.ge %w26 $0x1b $0x0d
+3a5fabcf : ccmn w30, #0x1f, #0xf, GE                 : ccmn.ge %w30 $0x1f $0x0f
+3a40b800 : ccmn w0, #0x0, #0x0, LT                   : ccmn.lt %w0 $0x00 $0x00
+3a42b841 : ccmn w2, #0x2, #0x1, LT                   : ccmn.lt %w2 $0x02 $0x01
+3a44b882 : ccmn w4, #0x4, #0x2, LT                   : ccmn.lt %w4 $0x04 $0x02
+3a46b8c3 : ccmn w6, #0x6, #0x3, LT                   : ccmn.lt %w6 $0x06 $0x03
+3a48b904 : ccmn w8, #0x8, #0x4, LT                   : ccmn.lt %w8 $0x08 $0x04
+3a4ab925 : ccmn w9, #0xa, #0x5, LT                   : ccmn.lt %w9 $0x0a $0x05
+3a4cb966 : ccmn w11, #0xc, #0x6, LT                  : ccmn.lt %w11 $0x0c $0x06
+3a4eb9a7 : ccmn w13, #0xe, #0x7, LT                  : ccmn.lt %w13 $0x0e $0x07
+3a50b9e8 : ccmn w15, #0x10, #0x8, LT                 : ccmn.lt %w15 $0x10 $0x08
+3a51ba28 : ccmn w17, #0x11, #0x8, LT                 : ccmn.lt %w17 $0x11 $0x08
+3a53ba69 : ccmn w19, #0x13, #0x9, LT                 : ccmn.lt %w19 $0x13 $0x09
+3a55baaa : ccmn w21, #0x15, #0xa, LT                 : ccmn.lt %w21 $0x15 $0x0a
+3a57bacb : ccmn w22, #0x17, #0xb, LT                 : ccmn.lt %w22 $0x17 $0x0b
+3a59bb0c : ccmn w24, #0x19, #0xc, LT                 : ccmn.lt %w24 $0x19 $0x0c
+3a5bbb4d : ccmn w26, #0x1b, #0xd, LT                 : ccmn.lt %w26 $0x1b $0x0d
+3a5fbbcf : ccmn w30, #0x1f, #0xf, LT                 : ccmn.lt %w30 $0x1f $0x0f
+3a40c800 : ccmn w0, #0x0, #0x0, GT                   : ccmn.gt %w0 $0x00 $0x00
+3a42c841 : ccmn w2, #0x2, #0x1, GT                   : ccmn.gt %w2 $0x02 $0x01
+3a44c882 : ccmn w4, #0x4, #0x2, GT                   : ccmn.gt %w4 $0x04 $0x02
+3a46c8c3 : ccmn w6, #0x6, #0x3, GT                   : ccmn.gt %w6 $0x06 $0x03
+3a48c904 : ccmn w8, #0x8, #0x4, GT                   : ccmn.gt %w8 $0x08 $0x04
+3a4ac925 : ccmn w9, #0xa, #0x5, GT                   : ccmn.gt %w9 $0x0a $0x05
+3a4cc966 : ccmn w11, #0xc, #0x6, GT                  : ccmn.gt %w11 $0x0c $0x06
+3a4ec9a7 : ccmn w13, #0xe, #0x7, GT                  : ccmn.gt %w13 $0x0e $0x07
+3a50c9e8 : ccmn w15, #0x10, #0x8, GT                 : ccmn.gt %w15 $0x10 $0x08
+3a51ca28 : ccmn w17, #0x11, #0x8, GT                 : ccmn.gt %w17 $0x11 $0x08
+3a53ca69 : ccmn w19, #0x13, #0x9, GT                 : ccmn.gt %w19 $0x13 $0x09
+3a55caaa : ccmn w21, #0x15, #0xa, GT                 : ccmn.gt %w21 $0x15 $0x0a
+3a57cacb : ccmn w22, #0x17, #0xb, GT                 : ccmn.gt %w22 $0x17 $0x0b
+3a59cb0c : ccmn w24, #0x19, #0xc, GT                 : ccmn.gt %w24 $0x19 $0x0c
+3a5bcb4d : ccmn w26, #0x1b, #0xd, GT                 : ccmn.gt %w26 $0x1b $0x0d
+3a5fcbcf : ccmn w30, #0x1f, #0xf, GT                 : ccmn.gt %w30 $0x1f $0x0f
+3a40d800 : ccmn w0, #0x0, #0x0, LE                   : ccmn.le %w0 $0x00 $0x00
+3a42d841 : ccmn w2, #0x2, #0x1, LE                   : ccmn.le %w2 $0x02 $0x01
+3a44d882 : ccmn w4, #0x4, #0x2, LE                   : ccmn.le %w4 $0x04 $0x02
+3a46d8c3 : ccmn w6, #0x6, #0x3, LE                   : ccmn.le %w6 $0x06 $0x03
+3a48d904 : ccmn w8, #0x8, #0x4, LE                   : ccmn.le %w8 $0x08 $0x04
+3a4ad925 : ccmn w9, #0xa, #0x5, LE                   : ccmn.le %w9 $0x0a $0x05
+3a4cd966 : ccmn w11, #0xc, #0x6, LE                  : ccmn.le %w11 $0x0c $0x06
+3a4ed9a7 : ccmn w13, #0xe, #0x7, LE                  : ccmn.le %w13 $0x0e $0x07
+3a50d9e8 : ccmn w15, #0x10, #0x8, LE                 : ccmn.le %w15 $0x10 $0x08
+3a51da28 : ccmn w17, #0x11, #0x8, LE                 : ccmn.le %w17 $0x11 $0x08
+3a53da69 : ccmn w19, #0x13, #0x9, LE                 : ccmn.le %w19 $0x13 $0x09
+3a55daaa : ccmn w21, #0x15, #0xa, LE                 : ccmn.le %w21 $0x15 $0x0a
+3a57dacb : ccmn w22, #0x17, #0xb, LE                 : ccmn.le %w22 $0x17 $0x0b
+3a59db0c : ccmn w24, #0x19, #0xc, LE                 : ccmn.le %w24 $0x19 $0x0c
+3a5bdb4d : ccmn w26, #0x1b, #0xd, LE                 : ccmn.le %w26 $0x1b $0x0d
+3a5fdbcf : ccmn w30, #0x1f, #0xf, LE                 : ccmn.le %w30 $0x1f $0x0f
+3a40e800 : ccmn w0, #0x0, #0x0, AL                   : ccmn.al %w0 $0x00 $0x00
+3a42e841 : ccmn w2, #0x2, #0x1, AL                   : ccmn.al %w2 $0x02 $0x01
+3a44e882 : ccmn w4, #0x4, #0x2, AL                   : ccmn.al %w4 $0x04 $0x02
+3a46e8c3 : ccmn w6, #0x6, #0x3, AL                   : ccmn.al %w6 $0x06 $0x03
+3a48e904 : ccmn w8, #0x8, #0x4, AL                   : ccmn.al %w8 $0x08 $0x04
+3a4ae925 : ccmn w9, #0xa, #0x5, AL                   : ccmn.al %w9 $0x0a $0x05
+3a4ce966 : ccmn w11, #0xc, #0x6, AL                  : ccmn.al %w11 $0x0c $0x06
+3a4ee9a7 : ccmn w13, #0xe, #0x7, AL                  : ccmn.al %w13 $0x0e $0x07
+3a50e9e8 : ccmn w15, #0x10, #0x8, AL                 : ccmn.al %w15 $0x10 $0x08
+3a51ea28 : ccmn w17, #0x11, #0x8, AL                 : ccmn.al %w17 $0x11 $0x08
+3a53ea69 : ccmn w19, #0x13, #0x9, AL                 : ccmn.al %w19 $0x13 $0x09
+3a55eaaa : ccmn w21, #0x15, #0xa, AL                 : ccmn.al %w21 $0x15 $0x0a
+3a57eacb : ccmn w22, #0x17, #0xb, AL                 : ccmn.al %w22 $0x17 $0x0b
+3a59eb0c : ccmn w24, #0x19, #0xc, AL                 : ccmn.al %w24 $0x19 $0x0c
+3a5beb4d : ccmn w26, #0x1b, #0xd, AL                 : ccmn.al %w26 $0x1b $0x0d
+3a5febcf : ccmn w30, #0x1f, #0xf, AL                 : ccmn.al %w30 $0x1f $0x0f
+3a40f800 : ccmn w0, #0x0, #0x0, NV                   : ccmn.nv %w0 $0x00 $0x00
+3a42f841 : ccmn w2, #0x2, #0x1, NV                   : ccmn.nv %w2 $0x02 $0x01
+3a44f882 : ccmn w4, #0x4, #0x2, NV                   : ccmn.nv %w4 $0x04 $0x02
+3a46f8c3 : ccmn w6, #0x6, #0x3, NV                   : ccmn.nv %w6 $0x06 $0x03
+3a48f904 : ccmn w8, #0x8, #0x4, NV                   : ccmn.nv %w8 $0x08 $0x04
+3a4af925 : ccmn w9, #0xa, #0x5, NV                   : ccmn.nv %w9 $0x0a $0x05
+3a4cf966 : ccmn w11, #0xc, #0x6, NV                  : ccmn.nv %w11 $0x0c $0x06
+3a4ef9a7 : ccmn w13, #0xe, #0x7, NV                  : ccmn.nv %w13 $0x0e $0x07
+3a50f9e8 : ccmn w15, #0x10, #0x8, NV                 : ccmn.nv %w15 $0x10 $0x08
+3a51fa28 : ccmn w17, #0x11, #0x8, NV                 : ccmn.nv %w17 $0x11 $0x08
+3a53fa69 : ccmn w19, #0x13, #0x9, NV                 : ccmn.nv %w19 $0x13 $0x09
+3a55faaa : ccmn w21, #0x15, #0xa, NV                 : ccmn.nv %w21 $0x15 $0x0a
+3a57facb : ccmn w22, #0x17, #0xb, NV                 : ccmn.nv %w22 $0x17 $0x0b
+3a59fb0c : ccmn w24, #0x19, #0xc, NV                 : ccmn.nv %w24 $0x19 $0x0c
+3a5bfb4d : ccmn w26, #0x1b, #0xd, NV                 : ccmn.nv %w26 $0x1b $0x0d
+3a5ffbcf : ccmn w30, #0x1f, #0xf, NV                 : ccmn.nv %w30 $0x1f $0x0f
+
+# CRC32B  <Wd>, <Wn>, <Wm> (CRC32B-R.RR-32C_dp_2src)
+1ac24020 : crc32b w0, w1, w2                         : crc32b %w1 %w2 -> %w0
+1ac44062 : crc32b w2, w3, w4                         : crc32b %w3 %w4 -> %w2
+1ac640a4 : crc32b w4, w5, w6                         : crc32b %w5 %w6 -> %w4
+1ac840e6 : crc32b w6, w7, w8                         : crc32b %w7 %w8 -> %w6
+1aca4128 : crc32b w8, w9, w10                        : crc32b %w9 %w10 -> %w8
+1acb4149 : crc32b w9, w10, w11                       : crc32b %w10 %w11 -> %w9
+1acd418b : crc32b w11, w12, w13                      : crc32b %w12 %w13 -> %w11
+1acf41cd : crc32b w13, w14, w15                      : crc32b %w14 %w15 -> %w13
+1ad1420f : crc32b w15, w16, w17                      : crc32b %w16 %w17 -> %w15
+1ad34251 : crc32b w17, w18, w19                      : crc32b %w18 %w19 -> %w17
+1ad54293 : crc32b w19, w20, w21                      : crc32b %w20 %w21 -> %w19
+1ad742d5 : crc32b w21, w22, w23                      : crc32b %w22 %w23 -> %w21
+1ad842f6 : crc32b w22, w23, w24                      : crc32b %w23 %w24 -> %w22
+1ada4338 : crc32b w24, w25, w26                      : crc32b %w25 %w26 -> %w24
+1adc437a : crc32b w26, w27, w28                      : crc32b %w27 %w28 -> %w26
+1ac1401e : crc32b w30, w0, w1                        : crc32b %w0 %w1 -> %w30
+
+# CBNZ    <Xt>, #<imm> (CBNZ-R.I-64_compbranch)
+b5800000 : cbnz x0, #-0x100000                       : cbnz   $0x000000000ff00000 %x0
+b5900002 : cbnz x2, #-0xe0000                        : cbnz   $0x000000000ff20000 %x2
+b5a00004 : cbnz x4, #-0xc0000                        : cbnz   $0x000000000ff40000 %x4
+b5b00006 : cbnz x6, #-0xa0000                        : cbnz   $0x000000000ff60000 %x6
+b5c00008 : cbnz x8, #-0x80000                        : cbnz   $0x000000000ff80000 %x8
+b5d00009 : cbnz x9, #-0x60000                        : cbnz   $0x000000000ffa0000 %x9
+b5e0000b : cbnz x11, #-0x40000                       : cbnz   $0x000000000ffc0000 %x11
+b5f0000d : cbnz x13, #-0x20000                       : cbnz   $0x000000000ffe0000 %x13
+b500000f : cbnz x15, #0x0                            : cbnz   $0x0000000010000000 %x15
+b50ffff1 : cbnz x17, #0x1fffc                        : cbnz   $0x000000001001fffc %x17
+b51ffff3 : cbnz x19, #0x3fffc                        : cbnz   $0x000000001003fffc %x19
+b52ffff5 : cbnz x21, #0x5fffc                        : cbnz   $0x000000001005fffc %x21
+b53ffff6 : cbnz x22, #0x7fffc                        : cbnz   $0x000000001007fffc %x22
+b54ffff8 : cbnz x24, #0x9fffc                        : cbnz   $0x000000001009fffc %x24
+b55ffffa : cbnz x26, #0xbfffc                        : cbnz   $0x00000000100bfffc %x26
+b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffffc %x30
+
+# MSUB    <Xd>, <Xn>, <Xm>, <Xa> (MSUB-R.RRR-64A_dp_3src)
+9b028c20 : msub x0, x1, x2, x3                       : msub   %x1 %x2 %x3 -> %x0
+9b049462 : msub x2, x3, x4, x5                       : msub   %x3 %x4 %x5 -> %x2
+9b069ca4 : msub x4, x5, x6, x7                       : msub   %x5 %x6 %x7 -> %x4
+9b08a4e6 : msub x6, x7, x8, x9                       : msub   %x7 %x8 %x9 -> %x6
+9b0aad28 : msub x8, x9, x10, x11                     : msub   %x9 %x10 %x11 -> %x8
+9b0bb149 : msub x9, x10, x11, x12                    : msub   %x10 %x11 %x12 -> %x9
+9b0db98b : msub x11, x12, x13, x14                   : msub   %x12 %x13 %x14 -> %x11
+9b0fc1cd : msub x13, x14, x15, x16                   : msub   %x14 %x15 %x16 -> %x13
+9b11ca0f : msub x15, x16, x17, x18                   : msub   %x16 %x17 %x18 -> %x15
+9b13d251 : msub x17, x18, x19, x20                   : msub   %x18 %x19 %x20 -> %x17
+9b15da93 : msub x19, x20, x21, x22                   : msub   %x20 %x21 %x22 -> %x19
+9b17e2d5 : msub x21, x22, x23, x24                   : msub   %x22 %x23 %x24 -> %x21
+9b18e6f6 : msub x22, x23, x24, x25                   : msub   %x23 %x24 %x25 -> %x22
+9b1aef38 : msub x24, x25, x26, x27                   : msub   %x25 %x26 %x27 -> %x24
+9b1cf77a : msub x26, x27, x28, x29                   : msub   %x27 %x28 %x29 -> %x26
+9b01881e : msub x30, x0, x1, x2                      : msub   %x0 %x1 %x2 -> %x30
+
+# ORR     <Wd|SP>, <Wn>, #<imm> (ORR-R.RI-32_log_imm)
+32000020 : orr w0, w1, #0x1                          : orr    %w1 $0x00000001 -> %w0
+32040062 : orr w2, w3, #0x10000000                   : orr    %w3 $0x10000000 -> %w2
+320800a4 : orr w4, w5, #0x1000000                    : orr    %w5 $0x01000000 -> %w4
+320c00e6 : orr w6, w7, #0x100000                     : orr    %w7 $0x00100000 -> %w6
+32100128 : orr w8, w9, #0x10000                      : orr    %w9 $0x00010000 -> %w8
+32140149 : orr w9, w10, #0x1000                      : orr    %w10 $0x00001000 -> %w9
+3218018b : orr w11, w12, #0x100                      : orr    %w12 $0x00000100 -> %w11
+321c01cd : orr w13, w14, #0x10                       : orr    %w14 $0x00000010 -> %w13
+3200020f : orr w15, w16, #0x1                        : orr    %w16 $0x00000001 -> %w15
+3203ea51 : orr w17, w18, #0xeeeeeeee                 : orr    %w18 $0xeeeeeeee -> %w17
+3203ea93 : orr w19, w20, #0xeeeeeeee                 : orr    %w20 $0xeeeeeeee -> %w19
+3203ead5 : orr w21, w22, #0xeeeeeeee                 : orr    %w22 $0xeeeeeeee -> %w21
+3203eaf6 : orr w22, w23, #0xeeeeeeee                 : orr    %w23 $0xeeeeeeee -> %w22
+3203eb38 : orr w24, w25, #0xeeeeeeee                 : orr    %w25 $0xeeeeeeee -> %w24
+3203eb7a : orr w26, w27, #0xeeeeeeee                 : orr    %w27 $0xeeeeeeee -> %w26
+3203e81f : orr wsp, w0, #0xeeeeeeee                  : orr    %w0 $0xeeeeeeee -> %wsp
+
+# UMADDL  <Xd>, <Wn>, <Wm>, <Xa> (UMADDL-R.RRR-64WA_dp_3src)
+9ba20c20 : umaddl x0, w1, w2, x3                     : umaddl %w1 %w2 %x3 -> %x0
+9ba41462 : umaddl x2, w3, w4, x5                     : umaddl %w3 %w4 %x5 -> %x2
+9ba61ca4 : umaddl x4, w5, w6, x7                     : umaddl %w5 %w6 %x7 -> %x4
+9ba824e6 : umaddl x6, w7, w8, x9                     : umaddl %w7 %w8 %x9 -> %x6
+9baa2d28 : umaddl x8, w9, w10, x11                   : umaddl %w9 %w10 %x11 -> %x8
+9bab3149 : umaddl x9, w10, w11, x12                  : umaddl %w10 %w11 %x12 -> %x9
+9bad398b : umaddl x11, w12, w13, x14                 : umaddl %w12 %w13 %x14 -> %x11
+9baf41cd : umaddl x13, w14, w15, x16                 : umaddl %w14 %w15 %x16 -> %x13
+9bb14a0f : umaddl x15, w16, w17, x18                 : umaddl %w16 %w17 %x18 -> %x15
+9bb35251 : umaddl x17, w18, w19, x20                 : umaddl %w18 %w19 %x20 -> %x17
+9bb55a93 : umaddl x19, w20, w21, x22                 : umaddl %w20 %w21 %x22 -> %x19
+9bb762d5 : umaddl x21, w22, w23, x24                 : umaddl %w22 %w23 %x24 -> %x21
+9bb866f6 : umaddl x22, w23, w24, x25                 : umaddl %w23 %w24 %x25 -> %x22
+9bba6f38 : umaddl x24, w25, w26, x27                 : umaddl %w25 %w26 %x27 -> %x24
+9bbc777a : umaddl x26, w27, w28, x29                 : umaddl %w27 %w28 %x29 -> %x26
+9ba1081e : umaddl x30, w0, w1, x2                    : umaddl %w0 %w1 %x2 -> %x30
+
+# SBCS    <Xd>, <Xn>, <Xm> (SBCS-R.RR-64_addsub_carry)
+fa020020 : sbcs x0, x1, x2                           : sbcs   %x1 %x2 -> %x0
+fa040062 : sbcs x2, x3, x4                           : sbcs   %x3 %x4 -> %x2
+fa0600a4 : sbcs x4, x5, x6                           : sbcs   %x5 %x6 -> %x4
+fa0800e6 : sbcs x6, x7, x8                           : sbcs   %x7 %x8 -> %x6
+fa0a0128 : sbcs x8, x9, x10                          : sbcs   %x9 %x10 -> %x8
+fa0b0149 : sbcs x9, x10, x11                         : sbcs   %x10 %x11 -> %x9
+fa0d018b : sbcs x11, x12, x13                        : sbcs   %x12 %x13 -> %x11
+fa0f01cd : sbcs x13, x14, x15                        : sbcs   %x14 %x15 -> %x13
+fa11020f : sbcs x15, x16, x17                        : sbcs   %x16 %x17 -> %x15
+fa130251 : sbcs x17, x18, x19                        : sbcs   %x18 %x19 -> %x17
+fa150293 : sbcs x19, x20, x21                        : sbcs   %x20 %x21 -> %x19
+fa1702d5 : sbcs x21, x22, x23                        : sbcs   %x22 %x23 -> %x21
+fa1802f6 : sbcs x22, x23, x24                        : sbcs   %x23 %x24 -> %x22
+fa1a0338 : sbcs x24, x25, x26                        : sbcs   %x25 %x26 -> %x24
+fa1c037a : sbcs x26, x27, x28                        : sbcs   %x27 %x28 -> %x26
+fa01001e : sbcs x30, x0, x1                          : sbcs   %x0 %x1 -> %x30
+
+# LSLV    <Wd>, <Wn>, <Wm> (LSLV-R.RR-32_dp_2src)
+1ac22020 : lslv w0, w1, w2                           : lslv   %w1 %w2 -> %w0
+1ac42062 : lslv w2, w3, w4                           : lslv   %w3 %w4 -> %w2
+1ac620a4 : lslv w4, w5, w6                           : lslv   %w5 %w6 -> %w4
+1ac820e6 : lslv w6, w7, w8                           : lslv   %w7 %w8 -> %w6
+1aca2128 : lslv w8, w9, w10                          : lslv   %w9 %w10 -> %w8
+1acb2149 : lslv w9, w10, w11                         : lslv   %w10 %w11 -> %w9
+1acd218b : lslv w11, w12, w13                        : lslv   %w12 %w13 -> %w11
+1acf21cd : lslv w13, w14, w15                        : lslv   %w14 %w15 -> %w13
+1ad1220f : lslv w15, w16, w17                        : lslv   %w16 %w17 -> %w15
+1ad32251 : lslv w17, w18, w19                        : lslv   %w18 %w19 -> %w17
+1ad52293 : lslv w19, w20, w21                        : lslv   %w20 %w21 -> %w19
+1ad722d5 : lslv w21, w22, w23                        : lslv   %w22 %w23 -> %w21
+1ad822f6 : lslv w22, w23, w24                        : lslv   %w23 %w24 -> %w22
+1ada2338 : lslv w24, w25, w26                        : lslv   %w25 %w26 -> %w24
+1adc237a : lslv w26, w27, w28                        : lslv   %w27 %w28 -> %w26
+1ac1201e : lslv w30, w0, w1                          : lslv   %w0 %w1 -> %w30
+
+# CCMP    <Xn>, <Xm>, #<imm>, <cond> (CCMP-R.RI-64_condcmp_reg)
+fa410000 : ccmp x0, x1, #0x0, EQ                     : ccmp.eq %x0 %x1 $0x00
+fa430041 : ccmp x2, x3, #0x1, EQ                     : ccmp.eq %x2 %x3 $0x01
+fa450082 : ccmp x4, x5, #0x2, EQ                     : ccmp.eq %x4 %x5 $0x02
+fa4700c3 : ccmp x6, x7, #0x3, EQ                     : ccmp.eq %x6 %x7 $0x03
+fa490104 : ccmp x8, x9, #0x4, EQ                     : ccmp.eq %x8 %x9 $0x04
+fa4a0125 : ccmp x9, x10, #0x5, EQ                    : ccmp.eq %x9 %x10 $0x05
+fa4c0166 : ccmp x11, x12, #0x6, EQ                   : ccmp.eq %x11 %x12 $0x06
+fa4e01a7 : ccmp x13, x14, #0x7, EQ                   : ccmp.eq %x13 %x14 $0x07
+fa5001e8 : ccmp x15, x16, #0x8, EQ                   : ccmp.eq %x15 %x16 $0x08
+fa520228 : ccmp x17, x18, #0x8, EQ                   : ccmp.eq %x17 %x18 $0x08
+fa540269 : ccmp x19, x20, #0x9, EQ                   : ccmp.eq %x19 %x20 $0x09
+fa5602aa : ccmp x21, x22, #0xa, EQ                   : ccmp.eq %x21 %x22 $0x0a
+fa5702cb : ccmp x22, x23, #0xb, EQ                   : ccmp.eq %x22 %x23 $0x0b
+fa59030c : ccmp x24, x25, #0xc, EQ                   : ccmp.eq %x24 %x25 $0x0c
+fa5b034d : ccmp x26, x27, #0xd, EQ                   : ccmp.eq %x26 %x27 $0x0d
+fa4003cf : ccmp x30, x0, #0xf, EQ                    : ccmp.eq %x30 %x0 $0x0f
+fa411000 : ccmp x0, x1, #0x0, NE                     : ccmp.ne %x0 %x1 $0x00
+fa431041 : ccmp x2, x3, #0x1, NE                     : ccmp.ne %x2 %x3 $0x01
+fa451082 : ccmp x4, x5, #0x2, NE                     : ccmp.ne %x4 %x5 $0x02
+fa4710c3 : ccmp x6, x7, #0x3, NE                     : ccmp.ne %x6 %x7 $0x03
+fa491104 : ccmp x8, x9, #0x4, NE                     : ccmp.ne %x8 %x9 $0x04
+fa4a1125 : ccmp x9, x10, #0x5, NE                    : ccmp.ne %x9 %x10 $0x05
+fa4c1166 : ccmp x11, x12, #0x6, NE                   : ccmp.ne %x11 %x12 $0x06
+fa4e11a7 : ccmp x13, x14, #0x7, NE                   : ccmp.ne %x13 %x14 $0x07
+fa5011e8 : ccmp x15, x16, #0x8, NE                   : ccmp.ne %x15 %x16 $0x08
+fa521228 : ccmp x17, x18, #0x8, NE                   : ccmp.ne %x17 %x18 $0x08
+fa541269 : ccmp x19, x20, #0x9, NE                   : ccmp.ne %x19 %x20 $0x09
+fa5612aa : ccmp x21, x22, #0xa, NE                   : ccmp.ne %x21 %x22 $0x0a
+fa5712cb : ccmp x22, x23, #0xb, NE                   : ccmp.ne %x22 %x23 $0x0b
+fa59130c : ccmp x24, x25, #0xc, NE                   : ccmp.ne %x24 %x25 $0x0c
+fa5b134d : ccmp x26, x27, #0xd, NE                   : ccmp.ne %x26 %x27 $0x0d
+fa4013cf : ccmp x30, x0, #0xf, NE                    : ccmp.ne %x30 %x0 $0x0f
+fa412000 : ccmp x0, x1, #0x0, CS                     : ccmp.cs %x0 %x1 $0x00
+fa432041 : ccmp x2, x3, #0x1, CS                     : ccmp.cs %x2 %x3 $0x01
+fa452082 : ccmp x4, x5, #0x2, CS                     : ccmp.cs %x4 %x5 $0x02
+fa4720c3 : ccmp x6, x7, #0x3, CS                     : ccmp.cs %x6 %x7 $0x03
+fa492104 : ccmp x8, x9, #0x4, CS                     : ccmp.cs %x8 %x9 $0x04
+fa4a2125 : ccmp x9, x10, #0x5, CS                    : ccmp.cs %x9 %x10 $0x05
+fa4c2166 : ccmp x11, x12, #0x6, CS                   : ccmp.cs %x11 %x12 $0x06
+fa4e21a7 : ccmp x13, x14, #0x7, CS                   : ccmp.cs %x13 %x14 $0x07
+fa5021e8 : ccmp x15, x16, #0x8, CS                   : ccmp.cs %x15 %x16 $0x08
+fa522228 : ccmp x17, x18, #0x8, CS                   : ccmp.cs %x17 %x18 $0x08
+fa542269 : ccmp x19, x20, #0x9, CS                   : ccmp.cs %x19 %x20 $0x09
+fa5622aa : ccmp x21, x22, #0xa, CS                   : ccmp.cs %x21 %x22 $0x0a
+fa5722cb : ccmp x22, x23, #0xb, CS                   : ccmp.cs %x22 %x23 $0x0b
+fa59230c : ccmp x24, x25, #0xc, CS                   : ccmp.cs %x24 %x25 $0x0c
+fa5b234d : ccmp x26, x27, #0xd, CS                   : ccmp.cs %x26 %x27 $0x0d
+fa4023cf : ccmp x30, x0, #0xf, CS                    : ccmp.cs %x30 %x0 $0x0f
+fa413000 : ccmp x0, x1, #0x0, CC                     : ccmp.cc %x0 %x1 $0x00
+fa433041 : ccmp x2, x3, #0x1, CC                     : ccmp.cc %x2 %x3 $0x01
+fa453082 : ccmp x4, x5, #0x2, CC                     : ccmp.cc %x4 %x5 $0x02
+fa4730c3 : ccmp x6, x7, #0x3, CC                     : ccmp.cc %x6 %x7 $0x03
+fa493104 : ccmp x8, x9, #0x4, CC                     : ccmp.cc %x8 %x9 $0x04
+fa4a3125 : ccmp x9, x10, #0x5, CC                    : ccmp.cc %x9 %x10 $0x05
+fa4c3166 : ccmp x11, x12, #0x6, CC                   : ccmp.cc %x11 %x12 $0x06
+fa4e31a7 : ccmp x13, x14, #0x7, CC                   : ccmp.cc %x13 %x14 $0x07
+fa5031e8 : ccmp x15, x16, #0x8, CC                   : ccmp.cc %x15 %x16 $0x08
+fa523228 : ccmp x17, x18, #0x8, CC                   : ccmp.cc %x17 %x18 $0x08
+fa543269 : ccmp x19, x20, #0x9, CC                   : ccmp.cc %x19 %x20 $0x09
+fa5632aa : ccmp x21, x22, #0xa, CC                   : ccmp.cc %x21 %x22 $0x0a
+fa5732cb : ccmp x22, x23, #0xb, CC                   : ccmp.cc %x22 %x23 $0x0b
+fa59330c : ccmp x24, x25, #0xc, CC                   : ccmp.cc %x24 %x25 $0x0c
+fa5b334d : ccmp x26, x27, #0xd, CC                   : ccmp.cc %x26 %x27 $0x0d
+fa4033cf : ccmp x30, x0, #0xf, CC                    : ccmp.cc %x30 %x0 $0x0f
+fa414000 : ccmp x0, x1, #0x0, MI                     : ccmp.mi %x0 %x1 $0x00
+fa434041 : ccmp x2, x3, #0x1, MI                     : ccmp.mi %x2 %x3 $0x01
+fa454082 : ccmp x4, x5, #0x2, MI                     : ccmp.mi %x4 %x5 $0x02
+fa4740c3 : ccmp x6, x7, #0x3, MI                     : ccmp.mi %x6 %x7 $0x03
+fa494104 : ccmp x8, x9, #0x4, MI                     : ccmp.mi %x8 %x9 $0x04
+fa4a4125 : ccmp x9, x10, #0x5, MI                    : ccmp.mi %x9 %x10 $0x05
+fa4c4166 : ccmp x11, x12, #0x6, MI                   : ccmp.mi %x11 %x12 $0x06
+fa4e41a7 : ccmp x13, x14, #0x7, MI                   : ccmp.mi %x13 %x14 $0x07
+fa5041e8 : ccmp x15, x16, #0x8, MI                   : ccmp.mi %x15 %x16 $0x08
+fa524228 : ccmp x17, x18, #0x8, MI                   : ccmp.mi %x17 %x18 $0x08
+fa544269 : ccmp x19, x20, #0x9, MI                   : ccmp.mi %x19 %x20 $0x09
+fa5642aa : ccmp x21, x22, #0xa, MI                   : ccmp.mi %x21 %x22 $0x0a
+fa5742cb : ccmp x22, x23, #0xb, MI                   : ccmp.mi %x22 %x23 $0x0b
+fa59430c : ccmp x24, x25, #0xc, MI                   : ccmp.mi %x24 %x25 $0x0c
+fa5b434d : ccmp x26, x27, #0xd, MI                   : ccmp.mi %x26 %x27 $0x0d
+fa4043cf : ccmp x30, x0, #0xf, MI                    : ccmp.mi %x30 %x0 $0x0f
+fa415000 : ccmp x0, x1, #0x0, PL                     : ccmp.pl %x0 %x1 $0x00
+fa435041 : ccmp x2, x3, #0x1, PL                     : ccmp.pl %x2 %x3 $0x01
+fa455082 : ccmp x4, x5, #0x2, PL                     : ccmp.pl %x4 %x5 $0x02
+fa4750c3 : ccmp x6, x7, #0x3, PL                     : ccmp.pl %x6 %x7 $0x03
+fa495104 : ccmp x8, x9, #0x4, PL                     : ccmp.pl %x8 %x9 $0x04
+fa4a5125 : ccmp x9, x10, #0x5, PL                    : ccmp.pl %x9 %x10 $0x05
+fa4c5166 : ccmp x11, x12, #0x6, PL                   : ccmp.pl %x11 %x12 $0x06
+fa4e51a7 : ccmp x13, x14, #0x7, PL                   : ccmp.pl %x13 %x14 $0x07
+fa5051e8 : ccmp x15, x16, #0x8, PL                   : ccmp.pl %x15 %x16 $0x08
+fa525228 : ccmp x17, x18, #0x8, PL                   : ccmp.pl %x17 %x18 $0x08
+fa545269 : ccmp x19, x20, #0x9, PL                   : ccmp.pl %x19 %x20 $0x09
+fa5652aa : ccmp x21, x22, #0xa, PL                   : ccmp.pl %x21 %x22 $0x0a
+fa5752cb : ccmp x22, x23, #0xb, PL                   : ccmp.pl %x22 %x23 $0x0b
+fa59530c : ccmp x24, x25, #0xc, PL                   : ccmp.pl %x24 %x25 $0x0c
+fa5b534d : ccmp x26, x27, #0xd, PL                   : ccmp.pl %x26 %x27 $0x0d
+fa4053cf : ccmp x30, x0, #0xf, PL                    : ccmp.pl %x30 %x0 $0x0f
+fa416000 : ccmp x0, x1, #0x0, VS                     : ccmp.vs %x0 %x1 $0x00
+fa436041 : ccmp x2, x3, #0x1, VS                     : ccmp.vs %x2 %x3 $0x01
+fa456082 : ccmp x4, x5, #0x2, VS                     : ccmp.vs %x4 %x5 $0x02
+fa4760c3 : ccmp x6, x7, #0x3, VS                     : ccmp.vs %x6 %x7 $0x03
+fa496104 : ccmp x8, x9, #0x4, VS                     : ccmp.vs %x8 %x9 $0x04
+fa4a6125 : ccmp x9, x10, #0x5, VS                    : ccmp.vs %x9 %x10 $0x05
+fa4c6166 : ccmp x11, x12, #0x6, VS                   : ccmp.vs %x11 %x12 $0x06
+fa4e61a7 : ccmp x13, x14, #0x7, VS                   : ccmp.vs %x13 %x14 $0x07
+fa5061e8 : ccmp x15, x16, #0x8, VS                   : ccmp.vs %x15 %x16 $0x08
+fa526228 : ccmp x17, x18, #0x8, VS                   : ccmp.vs %x17 %x18 $0x08
+fa546269 : ccmp x19, x20, #0x9, VS                   : ccmp.vs %x19 %x20 $0x09
+fa5662aa : ccmp x21, x22, #0xa, VS                   : ccmp.vs %x21 %x22 $0x0a
+fa5762cb : ccmp x22, x23, #0xb, VS                   : ccmp.vs %x22 %x23 $0x0b
+fa59630c : ccmp x24, x25, #0xc, VS                   : ccmp.vs %x24 %x25 $0x0c
+fa5b634d : ccmp x26, x27, #0xd, VS                   : ccmp.vs %x26 %x27 $0x0d
+fa4063cf : ccmp x30, x0, #0xf, VS                    : ccmp.vs %x30 %x0 $0x0f
+fa417000 : ccmp x0, x1, #0x0, VC                     : ccmp.vc %x0 %x1 $0x00
+fa437041 : ccmp x2, x3, #0x1, VC                     : ccmp.vc %x2 %x3 $0x01
+fa457082 : ccmp x4, x5, #0x2, VC                     : ccmp.vc %x4 %x5 $0x02
+fa4770c3 : ccmp x6, x7, #0x3, VC                     : ccmp.vc %x6 %x7 $0x03
+fa497104 : ccmp x8, x9, #0x4, VC                     : ccmp.vc %x8 %x9 $0x04
+fa4a7125 : ccmp x9, x10, #0x5, VC                    : ccmp.vc %x9 %x10 $0x05
+fa4c7166 : ccmp x11, x12, #0x6, VC                   : ccmp.vc %x11 %x12 $0x06
+fa4e71a7 : ccmp x13, x14, #0x7, VC                   : ccmp.vc %x13 %x14 $0x07
+fa5071e8 : ccmp x15, x16, #0x8, VC                   : ccmp.vc %x15 %x16 $0x08
+fa527228 : ccmp x17, x18, #0x8, VC                   : ccmp.vc %x17 %x18 $0x08
+fa547269 : ccmp x19, x20, #0x9, VC                   : ccmp.vc %x19 %x20 $0x09
+fa5672aa : ccmp x21, x22, #0xa, VC                   : ccmp.vc %x21 %x22 $0x0a
+fa5772cb : ccmp x22, x23, #0xb, VC                   : ccmp.vc %x22 %x23 $0x0b
+fa59730c : ccmp x24, x25, #0xc, VC                   : ccmp.vc %x24 %x25 $0x0c
+fa5b734d : ccmp x26, x27, #0xd, VC                   : ccmp.vc %x26 %x27 $0x0d
+fa4073cf : ccmp x30, x0, #0xf, VC                    : ccmp.vc %x30 %x0 $0x0f
+fa418000 : ccmp x0, x1, #0x0, HI                     : ccmp.hi %x0 %x1 $0x00
+fa438041 : ccmp x2, x3, #0x1, HI                     : ccmp.hi %x2 %x3 $0x01
+fa458082 : ccmp x4, x5, #0x2, HI                     : ccmp.hi %x4 %x5 $0x02
+fa4780c3 : ccmp x6, x7, #0x3, HI                     : ccmp.hi %x6 %x7 $0x03
+fa498104 : ccmp x8, x9, #0x4, HI                     : ccmp.hi %x8 %x9 $0x04
+fa4a8125 : ccmp x9, x10, #0x5, HI                    : ccmp.hi %x9 %x10 $0x05
+fa4c8166 : ccmp x11, x12, #0x6, HI                   : ccmp.hi %x11 %x12 $0x06
+fa4e81a7 : ccmp x13, x14, #0x7, HI                   : ccmp.hi %x13 %x14 $0x07
+fa5081e8 : ccmp x15, x16, #0x8, HI                   : ccmp.hi %x15 %x16 $0x08
+fa528228 : ccmp x17, x18, #0x8, HI                   : ccmp.hi %x17 %x18 $0x08
+fa548269 : ccmp x19, x20, #0x9, HI                   : ccmp.hi %x19 %x20 $0x09
+fa5682aa : ccmp x21, x22, #0xa, HI                   : ccmp.hi %x21 %x22 $0x0a
+fa5782cb : ccmp x22, x23, #0xb, HI                   : ccmp.hi %x22 %x23 $0x0b
+fa59830c : ccmp x24, x25, #0xc, HI                   : ccmp.hi %x24 %x25 $0x0c
+fa5b834d : ccmp x26, x27, #0xd, HI                   : ccmp.hi %x26 %x27 $0x0d
+fa4083cf : ccmp x30, x0, #0xf, HI                    : ccmp.hi %x30 %x0 $0x0f
+fa419000 : ccmp x0, x1, #0x0, LS                     : ccmp.ls %x0 %x1 $0x00
+fa439041 : ccmp x2, x3, #0x1, LS                     : ccmp.ls %x2 %x3 $0x01
+fa459082 : ccmp x4, x5, #0x2, LS                     : ccmp.ls %x4 %x5 $0x02
+fa4790c3 : ccmp x6, x7, #0x3, LS                     : ccmp.ls %x6 %x7 $0x03
+fa499104 : ccmp x8, x9, #0x4, LS                     : ccmp.ls %x8 %x9 $0x04
+fa4a9125 : ccmp x9, x10, #0x5, LS                    : ccmp.ls %x9 %x10 $0x05
+fa4c9166 : ccmp x11, x12, #0x6, LS                   : ccmp.ls %x11 %x12 $0x06
+fa4e91a7 : ccmp x13, x14, #0x7, LS                   : ccmp.ls %x13 %x14 $0x07
+fa5091e8 : ccmp x15, x16, #0x8, LS                   : ccmp.ls %x15 %x16 $0x08
+fa529228 : ccmp x17, x18, #0x8, LS                   : ccmp.ls %x17 %x18 $0x08
+fa549269 : ccmp x19, x20, #0x9, LS                   : ccmp.ls %x19 %x20 $0x09
+fa5692aa : ccmp x21, x22, #0xa, LS                   : ccmp.ls %x21 %x22 $0x0a
+fa5792cb : ccmp x22, x23, #0xb, LS                   : ccmp.ls %x22 %x23 $0x0b
+fa59930c : ccmp x24, x25, #0xc, LS                   : ccmp.ls %x24 %x25 $0x0c
+fa5b934d : ccmp x26, x27, #0xd, LS                   : ccmp.ls %x26 %x27 $0x0d
+fa4093cf : ccmp x30, x0, #0xf, LS                    : ccmp.ls %x30 %x0 $0x0f
+fa41a000 : ccmp x0, x1, #0x0, GE                     : ccmp.ge %x0 %x1 $0x00
+fa43a041 : ccmp x2, x3, #0x1, GE                     : ccmp.ge %x2 %x3 $0x01
+fa45a082 : ccmp x4, x5, #0x2, GE                     : ccmp.ge %x4 %x5 $0x02
+fa47a0c3 : ccmp x6, x7, #0x3, GE                     : ccmp.ge %x6 %x7 $0x03
+fa49a104 : ccmp x8, x9, #0x4, GE                     : ccmp.ge %x8 %x9 $0x04
+fa4aa125 : ccmp x9, x10, #0x5, GE                    : ccmp.ge %x9 %x10 $0x05
+fa4ca166 : ccmp x11, x12, #0x6, GE                   : ccmp.ge %x11 %x12 $0x06
+fa4ea1a7 : ccmp x13, x14, #0x7, GE                   : ccmp.ge %x13 %x14 $0x07
+fa50a1e8 : ccmp x15, x16, #0x8, GE                   : ccmp.ge %x15 %x16 $0x08
+fa52a228 : ccmp x17, x18, #0x8, GE                   : ccmp.ge %x17 %x18 $0x08
+fa54a269 : ccmp x19, x20, #0x9, GE                   : ccmp.ge %x19 %x20 $0x09
+fa56a2aa : ccmp x21, x22, #0xa, GE                   : ccmp.ge %x21 %x22 $0x0a
+fa57a2cb : ccmp x22, x23, #0xb, GE                   : ccmp.ge %x22 %x23 $0x0b
+fa59a30c : ccmp x24, x25, #0xc, GE                   : ccmp.ge %x24 %x25 $0x0c
+fa5ba34d : ccmp x26, x27, #0xd, GE                   : ccmp.ge %x26 %x27 $0x0d
+fa40a3cf : ccmp x30, x0, #0xf, GE                    : ccmp.ge %x30 %x0 $0x0f
+fa41b000 : ccmp x0, x1, #0x0, LT                     : ccmp.lt %x0 %x1 $0x00
+fa43b041 : ccmp x2, x3, #0x1, LT                     : ccmp.lt %x2 %x3 $0x01
+fa45b082 : ccmp x4, x5, #0x2, LT                     : ccmp.lt %x4 %x5 $0x02
+fa47b0c3 : ccmp x6, x7, #0x3, LT                     : ccmp.lt %x6 %x7 $0x03
+fa49b104 : ccmp x8, x9, #0x4, LT                     : ccmp.lt %x8 %x9 $0x04
+fa4ab125 : ccmp x9, x10, #0x5, LT                    : ccmp.lt %x9 %x10 $0x05
+fa4cb166 : ccmp x11, x12, #0x6, LT                   : ccmp.lt %x11 %x12 $0x06
+fa4eb1a7 : ccmp x13, x14, #0x7, LT                   : ccmp.lt %x13 %x14 $0x07
+fa50b1e8 : ccmp x15, x16, #0x8, LT                   : ccmp.lt %x15 %x16 $0x08
+fa52b228 : ccmp x17, x18, #0x8, LT                   : ccmp.lt %x17 %x18 $0x08
+fa54b269 : ccmp x19, x20, #0x9, LT                   : ccmp.lt %x19 %x20 $0x09
+fa56b2aa : ccmp x21, x22, #0xa, LT                   : ccmp.lt %x21 %x22 $0x0a
+fa57b2cb : ccmp x22, x23, #0xb, LT                   : ccmp.lt %x22 %x23 $0x0b
+fa59b30c : ccmp x24, x25, #0xc, LT                   : ccmp.lt %x24 %x25 $0x0c
+fa5bb34d : ccmp x26, x27, #0xd, LT                   : ccmp.lt %x26 %x27 $0x0d
+fa40b3cf : ccmp x30, x0, #0xf, LT                    : ccmp.lt %x30 %x0 $0x0f
+fa41c000 : ccmp x0, x1, #0x0, GT                     : ccmp.gt %x0 %x1 $0x00
+fa43c041 : ccmp x2, x3, #0x1, GT                     : ccmp.gt %x2 %x3 $0x01
+fa45c082 : ccmp x4, x5, #0x2, GT                     : ccmp.gt %x4 %x5 $0x02
+fa47c0c3 : ccmp x6, x7, #0x3, GT                     : ccmp.gt %x6 %x7 $0x03
+fa49c104 : ccmp x8, x9, #0x4, GT                     : ccmp.gt %x8 %x9 $0x04
+fa4ac125 : ccmp x9, x10, #0x5, GT                    : ccmp.gt %x9 %x10 $0x05
+fa4cc166 : ccmp x11, x12, #0x6, GT                   : ccmp.gt %x11 %x12 $0x06
+fa4ec1a7 : ccmp x13, x14, #0x7, GT                   : ccmp.gt %x13 %x14 $0x07
+fa50c1e8 : ccmp x15, x16, #0x8, GT                   : ccmp.gt %x15 %x16 $0x08
+fa52c228 : ccmp x17, x18, #0x8, GT                   : ccmp.gt %x17 %x18 $0x08
+fa54c269 : ccmp x19, x20, #0x9, GT                   : ccmp.gt %x19 %x20 $0x09
+fa56c2aa : ccmp x21, x22, #0xa, GT                   : ccmp.gt %x21 %x22 $0x0a
+fa57c2cb : ccmp x22, x23, #0xb, GT                   : ccmp.gt %x22 %x23 $0x0b
+fa59c30c : ccmp x24, x25, #0xc, GT                   : ccmp.gt %x24 %x25 $0x0c
+fa5bc34d : ccmp x26, x27, #0xd, GT                   : ccmp.gt %x26 %x27 $0x0d
+fa40c3cf : ccmp x30, x0, #0xf, GT                    : ccmp.gt %x30 %x0 $0x0f
+fa41d000 : ccmp x0, x1, #0x0, LE                     : ccmp.le %x0 %x1 $0x00
+fa43d041 : ccmp x2, x3, #0x1, LE                     : ccmp.le %x2 %x3 $0x01
+fa45d082 : ccmp x4, x5, #0x2, LE                     : ccmp.le %x4 %x5 $0x02
+fa47d0c3 : ccmp x6, x7, #0x3, LE                     : ccmp.le %x6 %x7 $0x03
+fa49d104 : ccmp x8, x9, #0x4, LE                     : ccmp.le %x8 %x9 $0x04
+fa4ad125 : ccmp x9, x10, #0x5, LE                    : ccmp.le %x9 %x10 $0x05
+fa4cd166 : ccmp x11, x12, #0x6, LE                   : ccmp.le %x11 %x12 $0x06
+fa4ed1a7 : ccmp x13, x14, #0x7, LE                   : ccmp.le %x13 %x14 $0x07
+fa50d1e8 : ccmp x15, x16, #0x8, LE                   : ccmp.le %x15 %x16 $0x08
+fa52d228 : ccmp x17, x18, #0x8, LE                   : ccmp.le %x17 %x18 $0x08
+fa54d269 : ccmp x19, x20, #0x9, LE                   : ccmp.le %x19 %x20 $0x09
+fa56d2aa : ccmp x21, x22, #0xa, LE                   : ccmp.le %x21 %x22 $0x0a
+fa57d2cb : ccmp x22, x23, #0xb, LE                   : ccmp.le %x22 %x23 $0x0b
+fa59d30c : ccmp x24, x25, #0xc, LE                   : ccmp.le %x24 %x25 $0x0c
+fa5bd34d : ccmp x26, x27, #0xd, LE                   : ccmp.le %x26 %x27 $0x0d
+fa40d3cf : ccmp x30, x0, #0xf, LE                    : ccmp.le %x30 %x0 $0x0f
+fa41e000 : ccmp x0, x1, #0x0, AL                     : ccmp.al %x0 %x1 $0x00
+fa43e041 : ccmp x2, x3, #0x1, AL                     : ccmp.al %x2 %x3 $0x01
+fa45e082 : ccmp x4, x5, #0x2, AL                     : ccmp.al %x4 %x5 $0x02
+fa47e0c3 : ccmp x6, x7, #0x3, AL                     : ccmp.al %x6 %x7 $0x03
+fa49e104 : ccmp x8, x9, #0x4, AL                     : ccmp.al %x8 %x9 $0x04
+fa4ae125 : ccmp x9, x10, #0x5, AL                    : ccmp.al %x9 %x10 $0x05
+fa4ce166 : ccmp x11, x12, #0x6, AL                   : ccmp.al %x11 %x12 $0x06
+fa4ee1a7 : ccmp x13, x14, #0x7, AL                   : ccmp.al %x13 %x14 $0x07
+fa50e1e8 : ccmp x15, x16, #0x8, AL                   : ccmp.al %x15 %x16 $0x08
+fa52e228 : ccmp x17, x18, #0x8, AL                   : ccmp.al %x17 %x18 $0x08
+fa54e269 : ccmp x19, x20, #0x9, AL                   : ccmp.al %x19 %x20 $0x09
+fa56e2aa : ccmp x21, x22, #0xa, AL                   : ccmp.al %x21 %x22 $0x0a
+fa57e2cb : ccmp x22, x23, #0xb, AL                   : ccmp.al %x22 %x23 $0x0b
+fa59e30c : ccmp x24, x25, #0xc, AL                   : ccmp.al %x24 %x25 $0x0c
+fa5be34d : ccmp x26, x27, #0xd, AL                   : ccmp.al %x26 %x27 $0x0d
+fa40e3cf : ccmp x30, x0, #0xf, AL                    : ccmp.al %x30 %x0 $0x0f
+fa41f000 : ccmp x0, x1, #0x0, NV                     : ccmp.nv %x0 %x1 $0x00
+fa43f041 : ccmp x2, x3, #0x1, NV                     : ccmp.nv %x2 %x3 $0x01
+fa45f082 : ccmp x4, x5, #0x2, NV                     : ccmp.nv %x4 %x5 $0x02
+fa47f0c3 : ccmp x6, x7, #0x3, NV                     : ccmp.nv %x6 %x7 $0x03
+fa49f104 : ccmp x8, x9, #0x4, NV                     : ccmp.nv %x8 %x9 $0x04
+fa4af125 : ccmp x9, x10, #0x5, NV                    : ccmp.nv %x9 %x10 $0x05
+fa4cf166 : ccmp x11, x12, #0x6, NV                   : ccmp.nv %x11 %x12 $0x06
+fa4ef1a7 : ccmp x13, x14, #0x7, NV                   : ccmp.nv %x13 %x14 $0x07
+fa50f1e8 : ccmp x15, x16, #0x8, NV                   : ccmp.nv %x15 %x16 $0x08
+fa52f228 : ccmp x17, x18, #0x8, NV                   : ccmp.nv %x17 %x18 $0x08
+fa54f269 : ccmp x19, x20, #0x9, NV                   : ccmp.nv %x19 %x20 $0x09
+fa56f2aa : ccmp x21, x22, #0xa, NV                   : ccmp.nv %x21 %x22 $0x0a
+fa57f2cb : ccmp x22, x23, #0xb, NV                   : ccmp.nv %x22 %x23 $0x0b
+fa59f30c : ccmp x24, x25, #0xc, NV                   : ccmp.nv %x24 %x25 $0x0c
+fa5bf34d : ccmp x26, x27, #0xd, NV                   : ccmp.nv %x26 %x27 $0x0d
+fa40f3cf : ccmp x30, x0, #0xf, NV                    : ccmp.nv %x30 %x0 $0x0f
+
+# CBZ     <Wt>, #<imm> (CBZ-R.I-32_compbranch)
+34800000 : cbz w0, #-0x100000                        : cbz    $0x000000000ff00000 %w0
+34900002 : cbz w2, #-0xe0000                         : cbz    $0x000000000ff20000 %w2
+34a00004 : cbz w4, #-0xc0000                         : cbz    $0x000000000ff40000 %w4
+34b00006 : cbz w6, #-0xa0000                         : cbz    $0x000000000ff60000 %w6
+34c00008 : cbz w8, #-0x80000                         : cbz    $0x000000000ff80000 %w8
+34d00009 : cbz w9, #-0x60000                         : cbz    $0x000000000ffa0000 %w9
+34e0000b : cbz w11, #-0x40000                        : cbz    $0x000000000ffc0000 %w11
+34f0000d : cbz w13, #-0x20000                        : cbz    $0x000000000ffe0000 %w13
+3400000f : cbz w15, #0x0                             : cbz    $0x0000000010000000 %w15
+340ffff1 : cbz w17, #0x1fffc                         : cbz    $0x000000001001fffc %w17
+341ffff3 : cbz w19, #0x3fffc                         : cbz    $0x000000001003fffc %w19
+342ffff5 : cbz w21, #0x5fffc                         : cbz    $0x000000001005fffc %w21
+343ffff6 : cbz w22, #0x7fffc                         : cbz    $0x000000001007fffc %w22
+344ffff8 : cbz w24, #0x9fffc                         : cbz    $0x000000001009fffc %w24
+345ffffa : cbz w26, #0xbfffc                         : cbz    $0x00000000100bfffc %w26
+347ffffe : cbz w30, #0xffffc                         : cbz    $0x00000000100ffffc %w30
+
+# LSRV    <Wd>, <Wn>, <Wm> (LSRV-R.RR-32_dp_2src)
+1ac22420 : lsrv w0, w1, w2                           : lsrv   %w1 %w2 -> %w0
+1ac42462 : lsrv w2, w3, w4                           : lsrv   %w3 %w4 -> %w2
+1ac624a4 : lsrv w4, w5, w6                           : lsrv   %w5 %w6 -> %w4
+1ac824e6 : lsrv w6, w7, w8                           : lsrv   %w7 %w8 -> %w6
+1aca2528 : lsrv w8, w9, w10                          : lsrv   %w9 %w10 -> %w8
+1acb2549 : lsrv w9, w10, w11                         : lsrv   %w10 %w11 -> %w9
+1acd258b : lsrv w11, w12, w13                        : lsrv   %w12 %w13 -> %w11
+1acf25cd : lsrv w13, w14, w15                        : lsrv   %w14 %w15 -> %w13
+1ad1260f : lsrv w15, w16, w17                        : lsrv   %w16 %w17 -> %w15
+1ad32651 : lsrv w17, w18, w19                        : lsrv   %w18 %w19 -> %w17
+1ad52693 : lsrv w19, w20, w21                        : lsrv   %w20 %w21 -> %w19
+1ad726d5 : lsrv w21, w22, w23                        : lsrv   %w22 %w23 -> %w21
+1ad826f6 : lsrv w22, w23, w24                        : lsrv   %w23 %w24 -> %w22
+1ada2738 : lsrv w24, w25, w26                        : lsrv   %w25 %w26 -> %w24
+1adc277a : lsrv w26, w27, w28                        : lsrv   %w27 %w28 -> %w26
+1ac1241e : lsrv w30, w0, w1                          : lsrv   %w0 %w1 -> %w30
+
+# CSNEG   <Wd>, <Wn>, <Wm>, <cond> (CSNEG-R.RR-32_condsel)
+5a820420 : csneg w0, w1, w2, EQ                      : csneg  %w1 %w2 eq -> %w0
+5a840462 : csneg w2, w3, w4, EQ                      : csneg  %w3 %w4 eq -> %w2
+5a8604a4 : csneg w4, w5, w6, EQ                      : csneg  %w5 %w6 eq -> %w4
+5a8804e6 : csneg w6, w7, w8, EQ                      : csneg  %w7 %w8 eq -> %w6
+5a8a0528 : csneg w8, w9, w10, EQ                     : csneg  %w9 %w10 eq -> %w8
+5a8b0549 : csneg w9, w10, w11, EQ                    : csneg  %w10 %w11 eq -> %w9
+5a8d058b : csneg w11, w12, w13, EQ                   : csneg  %w12 %w13 eq -> %w11
+5a8f05cd : csneg w13, w14, w15, EQ                   : csneg  %w14 %w15 eq -> %w13
+5a91060f : csneg w15, w16, w17, EQ                   : csneg  %w16 %w17 eq -> %w15
+5a930651 : csneg w17, w18, w19, EQ                   : csneg  %w18 %w19 eq -> %w17
+5a950693 : csneg w19, w20, w21, EQ                   : csneg  %w20 %w21 eq -> %w19
+5a9706d5 : csneg w21, w22, w23, EQ                   : csneg  %w22 %w23 eq -> %w21
+5a9806f6 : csneg w22, w23, w24, EQ                   : csneg  %w23 %w24 eq -> %w22
+5a9a0738 : csneg w24, w25, w26, EQ                   : csneg  %w25 %w26 eq -> %w24
+5a9c077a : csneg w26, w27, w28, EQ                   : csneg  %w27 %w28 eq -> %w26
+5a81041e : csneg w30, w0, w1, EQ                     : csneg  %w0 %w1 eq -> %w30
+5a821420 : csneg w0, w1, w2, NE                      : csneg  %w1 %w2 ne -> %w0
+5a841462 : csneg w2, w3, w4, NE                      : csneg  %w3 %w4 ne -> %w2
+5a8614a4 : csneg w4, w5, w6, NE                      : csneg  %w5 %w6 ne -> %w4
+5a8814e6 : csneg w6, w7, w8, NE                      : csneg  %w7 %w8 ne -> %w6
+5a8a1528 : csneg w8, w9, w10, NE                     : csneg  %w9 %w10 ne -> %w8
+5a8b1549 : csneg w9, w10, w11, NE                    : csneg  %w10 %w11 ne -> %w9
+5a8d158b : csneg w11, w12, w13, NE                   : csneg  %w12 %w13 ne -> %w11
+5a8f15cd : csneg w13, w14, w15, NE                   : csneg  %w14 %w15 ne -> %w13
+5a91160f : csneg w15, w16, w17, NE                   : csneg  %w16 %w17 ne -> %w15
+5a931651 : csneg w17, w18, w19, NE                   : csneg  %w18 %w19 ne -> %w17
+5a951693 : csneg w19, w20, w21, NE                   : csneg  %w20 %w21 ne -> %w19
+5a9716d5 : csneg w21, w22, w23, NE                   : csneg  %w22 %w23 ne -> %w21
+5a9816f6 : csneg w22, w23, w24, NE                   : csneg  %w23 %w24 ne -> %w22
+5a9a1738 : csneg w24, w25, w26, NE                   : csneg  %w25 %w26 ne -> %w24
+5a9c177a : csneg w26, w27, w28, NE                   : csneg  %w27 %w28 ne -> %w26
+5a81141e : csneg w30, w0, w1, NE                     : csneg  %w0 %w1 ne -> %w30
+5a822420 : csneg w0, w1, w2, CS                      : csneg  %w1 %w2 cs -> %w0
+5a842462 : csneg w2, w3, w4, CS                      : csneg  %w3 %w4 cs -> %w2
+5a8624a4 : csneg w4, w5, w6, CS                      : csneg  %w5 %w6 cs -> %w4
+5a8824e6 : csneg w6, w7, w8, CS                      : csneg  %w7 %w8 cs -> %w6
+5a8a2528 : csneg w8, w9, w10, CS                     : csneg  %w9 %w10 cs -> %w8
+5a8b2549 : csneg w9, w10, w11, CS                    : csneg  %w10 %w11 cs -> %w9
+5a8d258b : csneg w11, w12, w13, CS                   : csneg  %w12 %w13 cs -> %w11
+5a8f25cd : csneg w13, w14, w15, CS                   : csneg  %w14 %w15 cs -> %w13
+5a91260f : csneg w15, w16, w17, CS                   : csneg  %w16 %w17 cs -> %w15
+5a932651 : csneg w17, w18, w19, CS                   : csneg  %w18 %w19 cs -> %w17
+5a952693 : csneg w19, w20, w21, CS                   : csneg  %w20 %w21 cs -> %w19
+5a9726d5 : csneg w21, w22, w23, CS                   : csneg  %w22 %w23 cs -> %w21
+5a9826f6 : csneg w22, w23, w24, CS                   : csneg  %w23 %w24 cs -> %w22
+5a9a2738 : csneg w24, w25, w26, CS                   : csneg  %w25 %w26 cs -> %w24
+5a9c277a : csneg w26, w27, w28, CS                   : csneg  %w27 %w28 cs -> %w26
+5a81241e : csneg w30, w0, w1, CS                     : csneg  %w0 %w1 cs -> %w30
+5a823420 : csneg w0, w1, w2, CC                      : csneg  %w1 %w2 cc -> %w0
+5a843462 : csneg w2, w3, w4, CC                      : csneg  %w3 %w4 cc -> %w2
+5a8634a4 : csneg w4, w5, w6, CC                      : csneg  %w5 %w6 cc -> %w4
+5a8834e6 : csneg w6, w7, w8, CC                      : csneg  %w7 %w8 cc -> %w6
+5a8a3528 : csneg w8, w9, w10, CC                     : csneg  %w9 %w10 cc -> %w8
+5a8b3549 : csneg w9, w10, w11, CC                    : csneg  %w10 %w11 cc -> %w9
+5a8d358b : csneg w11, w12, w13, CC                   : csneg  %w12 %w13 cc -> %w11
+5a8f35cd : csneg w13, w14, w15, CC                   : csneg  %w14 %w15 cc -> %w13
+5a91360f : csneg w15, w16, w17, CC                   : csneg  %w16 %w17 cc -> %w15
+5a933651 : csneg w17, w18, w19, CC                   : csneg  %w18 %w19 cc -> %w17
+5a953693 : csneg w19, w20, w21, CC                   : csneg  %w20 %w21 cc -> %w19
+5a9736d5 : csneg w21, w22, w23, CC                   : csneg  %w22 %w23 cc -> %w21
+5a9836f6 : csneg w22, w23, w24, CC                   : csneg  %w23 %w24 cc -> %w22
+5a9a3738 : csneg w24, w25, w26, CC                   : csneg  %w25 %w26 cc -> %w24
+5a9c377a : csneg w26, w27, w28, CC                   : csneg  %w27 %w28 cc -> %w26
+5a81341e : csneg w30, w0, w1, CC                     : csneg  %w0 %w1 cc -> %w30
+5a824420 : csneg w0, w1, w2, MI                      : csneg  %w1 %w2 mi -> %w0
+5a844462 : csneg w2, w3, w4, MI                      : csneg  %w3 %w4 mi -> %w2
+5a8644a4 : csneg w4, w5, w6, MI                      : csneg  %w5 %w6 mi -> %w4
+5a8844e6 : csneg w6, w7, w8, MI                      : csneg  %w7 %w8 mi -> %w6
+5a8a4528 : csneg w8, w9, w10, MI                     : csneg  %w9 %w10 mi -> %w8
+5a8b4549 : csneg w9, w10, w11, MI                    : csneg  %w10 %w11 mi -> %w9
+5a8d458b : csneg w11, w12, w13, MI                   : csneg  %w12 %w13 mi -> %w11
+5a8f45cd : csneg w13, w14, w15, MI                   : csneg  %w14 %w15 mi -> %w13
+5a91460f : csneg w15, w16, w17, MI                   : csneg  %w16 %w17 mi -> %w15
+5a934651 : csneg w17, w18, w19, MI                   : csneg  %w18 %w19 mi -> %w17
+5a954693 : csneg w19, w20, w21, MI                   : csneg  %w20 %w21 mi -> %w19
+5a9746d5 : csneg w21, w22, w23, MI                   : csneg  %w22 %w23 mi -> %w21
+5a9846f6 : csneg w22, w23, w24, MI                   : csneg  %w23 %w24 mi -> %w22
+5a9a4738 : csneg w24, w25, w26, MI                   : csneg  %w25 %w26 mi -> %w24
+5a9c477a : csneg w26, w27, w28, MI                   : csneg  %w27 %w28 mi -> %w26
+5a81441e : csneg w30, w0, w1, MI                     : csneg  %w0 %w1 mi -> %w30
+5a825420 : csneg w0, w1, w2, PL                      : csneg  %w1 %w2 pl -> %w0
+5a845462 : csneg w2, w3, w4, PL                      : csneg  %w3 %w4 pl -> %w2
+5a8654a4 : csneg w4, w5, w6, PL                      : csneg  %w5 %w6 pl -> %w4
+5a8854e6 : csneg w6, w7, w8, PL                      : csneg  %w7 %w8 pl -> %w6
+5a8a5528 : csneg w8, w9, w10, PL                     : csneg  %w9 %w10 pl -> %w8
+5a8b5549 : csneg w9, w10, w11, PL                    : csneg  %w10 %w11 pl -> %w9
+5a8d558b : csneg w11, w12, w13, PL                   : csneg  %w12 %w13 pl -> %w11
+5a8f55cd : csneg w13, w14, w15, PL                   : csneg  %w14 %w15 pl -> %w13
+5a91560f : csneg w15, w16, w17, PL                   : csneg  %w16 %w17 pl -> %w15
+5a935651 : csneg w17, w18, w19, PL                   : csneg  %w18 %w19 pl -> %w17
+5a955693 : csneg w19, w20, w21, PL                   : csneg  %w20 %w21 pl -> %w19
+5a9756d5 : csneg w21, w22, w23, PL                   : csneg  %w22 %w23 pl -> %w21
+5a9856f6 : csneg w22, w23, w24, PL                   : csneg  %w23 %w24 pl -> %w22
+5a9a5738 : csneg w24, w25, w26, PL                   : csneg  %w25 %w26 pl -> %w24
+5a9c577a : csneg w26, w27, w28, PL                   : csneg  %w27 %w28 pl -> %w26
+5a81541e : csneg w30, w0, w1, PL                     : csneg  %w0 %w1 pl -> %w30
+5a826420 : csneg w0, w1, w2, VS                      : csneg  %w1 %w2 vs -> %w0
+5a846462 : csneg w2, w3, w4, VS                      : csneg  %w3 %w4 vs -> %w2
+5a8664a4 : csneg w4, w5, w6, VS                      : csneg  %w5 %w6 vs -> %w4
+5a8864e6 : csneg w6, w7, w8, VS                      : csneg  %w7 %w8 vs -> %w6
+5a8a6528 : csneg w8, w9, w10, VS                     : csneg  %w9 %w10 vs -> %w8
+5a8b6549 : csneg w9, w10, w11, VS                    : csneg  %w10 %w11 vs -> %w9
+5a8d658b : csneg w11, w12, w13, VS                   : csneg  %w12 %w13 vs -> %w11
+5a8f65cd : csneg w13, w14, w15, VS                   : csneg  %w14 %w15 vs -> %w13
+5a91660f : csneg w15, w16, w17, VS                   : csneg  %w16 %w17 vs -> %w15
+5a936651 : csneg w17, w18, w19, VS                   : csneg  %w18 %w19 vs -> %w17
+5a956693 : csneg w19, w20, w21, VS                   : csneg  %w20 %w21 vs -> %w19
+5a9766d5 : csneg w21, w22, w23, VS                   : csneg  %w22 %w23 vs -> %w21
+5a9866f6 : csneg w22, w23, w24, VS                   : csneg  %w23 %w24 vs -> %w22
+5a9a6738 : csneg w24, w25, w26, VS                   : csneg  %w25 %w26 vs -> %w24
+5a9c677a : csneg w26, w27, w28, VS                   : csneg  %w27 %w28 vs -> %w26
+5a81641e : csneg w30, w0, w1, VS                     : csneg  %w0 %w1 vs -> %w30
+5a827420 : csneg w0, w1, w2, VC                      : csneg  %w1 %w2 vc -> %w0
+5a847462 : csneg w2, w3, w4, VC                      : csneg  %w3 %w4 vc -> %w2
+5a8674a4 : csneg w4, w5, w6, VC                      : csneg  %w5 %w6 vc -> %w4
+5a8874e6 : csneg w6, w7, w8, VC                      : csneg  %w7 %w8 vc -> %w6
+5a8a7528 : csneg w8, w9, w10, VC                     : csneg  %w9 %w10 vc -> %w8
+5a8b7549 : csneg w9, w10, w11, VC                    : csneg  %w10 %w11 vc -> %w9
+5a8d758b : csneg w11, w12, w13, VC                   : csneg  %w12 %w13 vc -> %w11
+5a8f75cd : csneg w13, w14, w15, VC                   : csneg  %w14 %w15 vc -> %w13
+5a91760f : csneg w15, w16, w17, VC                   : csneg  %w16 %w17 vc -> %w15
+5a937651 : csneg w17, w18, w19, VC                   : csneg  %w18 %w19 vc -> %w17
+5a957693 : csneg w19, w20, w21, VC                   : csneg  %w20 %w21 vc -> %w19
+5a9776d5 : csneg w21, w22, w23, VC                   : csneg  %w22 %w23 vc -> %w21
+5a9876f6 : csneg w22, w23, w24, VC                   : csneg  %w23 %w24 vc -> %w22
+5a9a7738 : csneg w24, w25, w26, VC                   : csneg  %w25 %w26 vc -> %w24
+5a9c777a : csneg w26, w27, w28, VC                   : csneg  %w27 %w28 vc -> %w26
+5a81741e : csneg w30, w0, w1, VC                     : csneg  %w0 %w1 vc -> %w30
+5a828420 : csneg w0, w1, w2, HI                      : csneg  %w1 %w2 hi -> %w0
+5a848462 : csneg w2, w3, w4, HI                      : csneg  %w3 %w4 hi -> %w2
+5a8684a4 : csneg w4, w5, w6, HI                      : csneg  %w5 %w6 hi -> %w4
+5a8884e6 : csneg w6, w7, w8, HI                      : csneg  %w7 %w8 hi -> %w6
+5a8a8528 : csneg w8, w9, w10, HI                     : csneg  %w9 %w10 hi -> %w8
+5a8b8549 : csneg w9, w10, w11, HI                    : csneg  %w10 %w11 hi -> %w9
+5a8d858b : csneg w11, w12, w13, HI                   : csneg  %w12 %w13 hi -> %w11
+5a8f85cd : csneg w13, w14, w15, HI                   : csneg  %w14 %w15 hi -> %w13
+5a91860f : csneg w15, w16, w17, HI                   : csneg  %w16 %w17 hi -> %w15
+5a938651 : csneg w17, w18, w19, HI                   : csneg  %w18 %w19 hi -> %w17
+5a958693 : csneg w19, w20, w21, HI                   : csneg  %w20 %w21 hi -> %w19
+5a9786d5 : csneg w21, w22, w23, HI                   : csneg  %w22 %w23 hi -> %w21
+5a9886f6 : csneg w22, w23, w24, HI                   : csneg  %w23 %w24 hi -> %w22
+5a9a8738 : csneg w24, w25, w26, HI                   : csneg  %w25 %w26 hi -> %w24
+5a9c877a : csneg w26, w27, w28, HI                   : csneg  %w27 %w28 hi -> %w26
+5a81841e : csneg w30, w0, w1, HI                     : csneg  %w0 %w1 hi -> %w30
+5a829420 : csneg w0, w1, w2, LS                      : csneg  %w1 %w2 ls -> %w0
+5a849462 : csneg w2, w3, w4, LS                      : csneg  %w3 %w4 ls -> %w2
+5a8694a4 : csneg w4, w5, w6, LS                      : csneg  %w5 %w6 ls -> %w4
+5a8894e6 : csneg w6, w7, w8, LS                      : csneg  %w7 %w8 ls -> %w6
+5a8a9528 : csneg w8, w9, w10, LS                     : csneg  %w9 %w10 ls -> %w8
+5a8b9549 : csneg w9, w10, w11, LS                    : csneg  %w10 %w11 ls -> %w9
+5a8d958b : csneg w11, w12, w13, LS                   : csneg  %w12 %w13 ls -> %w11
+5a8f95cd : csneg w13, w14, w15, LS                   : csneg  %w14 %w15 ls -> %w13
+5a91960f : csneg w15, w16, w17, LS                   : csneg  %w16 %w17 ls -> %w15
+5a939651 : csneg w17, w18, w19, LS                   : csneg  %w18 %w19 ls -> %w17
+5a959693 : csneg w19, w20, w21, LS                   : csneg  %w20 %w21 ls -> %w19
+5a9796d5 : csneg w21, w22, w23, LS                   : csneg  %w22 %w23 ls -> %w21
+5a9896f6 : csneg w22, w23, w24, LS                   : csneg  %w23 %w24 ls -> %w22
+5a9a9738 : csneg w24, w25, w26, LS                   : csneg  %w25 %w26 ls -> %w24
+5a9c977a : csneg w26, w27, w28, LS                   : csneg  %w27 %w28 ls -> %w26
+5a81941e : csneg w30, w0, w1, LS                     : csneg  %w0 %w1 ls -> %w30
+5a82a420 : csneg w0, w1, w2, GE                      : csneg  %w1 %w2 ge -> %w0
+5a84a462 : csneg w2, w3, w4, GE                      : csneg  %w3 %w4 ge -> %w2
+5a86a4a4 : csneg w4, w5, w6, GE                      : csneg  %w5 %w6 ge -> %w4
+5a88a4e6 : csneg w6, w7, w8, GE                      : csneg  %w7 %w8 ge -> %w6
+5a8aa528 : csneg w8, w9, w10, GE                     : csneg  %w9 %w10 ge -> %w8
+5a8ba549 : csneg w9, w10, w11, GE                    : csneg  %w10 %w11 ge -> %w9
+5a8da58b : csneg w11, w12, w13, GE                   : csneg  %w12 %w13 ge -> %w11
+5a8fa5cd : csneg w13, w14, w15, GE                   : csneg  %w14 %w15 ge -> %w13
+5a91a60f : csneg w15, w16, w17, GE                   : csneg  %w16 %w17 ge -> %w15
+5a93a651 : csneg w17, w18, w19, GE                   : csneg  %w18 %w19 ge -> %w17
+5a95a693 : csneg w19, w20, w21, GE                   : csneg  %w20 %w21 ge -> %w19
+5a97a6d5 : csneg w21, w22, w23, GE                   : csneg  %w22 %w23 ge -> %w21
+5a98a6f6 : csneg w22, w23, w24, GE                   : csneg  %w23 %w24 ge -> %w22
+5a9aa738 : csneg w24, w25, w26, GE                   : csneg  %w25 %w26 ge -> %w24
+5a9ca77a : csneg w26, w27, w28, GE                   : csneg  %w27 %w28 ge -> %w26
+5a81a41e : csneg w30, w0, w1, GE                     : csneg  %w0 %w1 ge -> %w30
+5a82b420 : csneg w0, w1, w2, LT                      : csneg  %w1 %w2 lt -> %w0
+5a84b462 : csneg w2, w3, w4, LT                      : csneg  %w3 %w4 lt -> %w2
+5a86b4a4 : csneg w4, w5, w6, LT                      : csneg  %w5 %w6 lt -> %w4
+5a88b4e6 : csneg w6, w7, w8, LT                      : csneg  %w7 %w8 lt -> %w6
+5a8ab528 : csneg w8, w9, w10, LT                     : csneg  %w9 %w10 lt -> %w8
+5a8bb549 : csneg w9, w10, w11, LT                    : csneg  %w10 %w11 lt -> %w9
+5a8db58b : csneg w11, w12, w13, LT                   : csneg  %w12 %w13 lt -> %w11
+5a8fb5cd : csneg w13, w14, w15, LT                   : csneg  %w14 %w15 lt -> %w13
+5a91b60f : csneg w15, w16, w17, LT                   : csneg  %w16 %w17 lt -> %w15
+5a93b651 : csneg w17, w18, w19, LT                   : csneg  %w18 %w19 lt -> %w17
+5a95b693 : csneg w19, w20, w21, LT                   : csneg  %w20 %w21 lt -> %w19
+5a97b6d5 : csneg w21, w22, w23, LT                   : csneg  %w22 %w23 lt -> %w21
+5a98b6f6 : csneg w22, w23, w24, LT                   : csneg  %w23 %w24 lt -> %w22
+5a9ab738 : csneg w24, w25, w26, LT                   : csneg  %w25 %w26 lt -> %w24
+5a9cb77a : csneg w26, w27, w28, LT                   : csneg  %w27 %w28 lt -> %w26
+5a81b41e : csneg w30, w0, w1, LT                     : csneg  %w0 %w1 lt -> %w30
+5a82c420 : csneg w0, w1, w2, GT                      : csneg  %w1 %w2 gt -> %w0
+5a84c462 : csneg w2, w3, w4, GT                      : csneg  %w3 %w4 gt -> %w2
+5a86c4a4 : csneg w4, w5, w6, GT                      : csneg  %w5 %w6 gt -> %w4
+5a88c4e6 : csneg w6, w7, w8, GT                      : csneg  %w7 %w8 gt -> %w6
+5a8ac528 : csneg w8, w9, w10, GT                     : csneg  %w9 %w10 gt -> %w8
+5a8bc549 : csneg w9, w10, w11, GT                    : csneg  %w10 %w11 gt -> %w9
+5a8dc58b : csneg w11, w12, w13, GT                   : csneg  %w12 %w13 gt -> %w11
+5a8fc5cd : csneg w13, w14, w15, GT                   : csneg  %w14 %w15 gt -> %w13
+5a91c60f : csneg w15, w16, w17, GT                   : csneg  %w16 %w17 gt -> %w15
+5a93c651 : csneg w17, w18, w19, GT                   : csneg  %w18 %w19 gt -> %w17
+5a95c693 : csneg w19, w20, w21, GT                   : csneg  %w20 %w21 gt -> %w19
+5a97c6d5 : csneg w21, w22, w23, GT                   : csneg  %w22 %w23 gt -> %w21
+5a98c6f6 : csneg w22, w23, w24, GT                   : csneg  %w23 %w24 gt -> %w22
+5a9ac738 : csneg w24, w25, w26, GT                   : csneg  %w25 %w26 gt -> %w24
+5a9cc77a : csneg w26, w27, w28, GT                   : csneg  %w27 %w28 gt -> %w26
+5a81c41e : csneg w30, w0, w1, GT                     : csneg  %w0 %w1 gt -> %w30
+5a82d420 : csneg w0, w1, w2, LE                      : csneg  %w1 %w2 le -> %w0
+5a84d462 : csneg w2, w3, w4, LE                      : csneg  %w3 %w4 le -> %w2
+5a86d4a4 : csneg w4, w5, w6, LE                      : csneg  %w5 %w6 le -> %w4
+5a88d4e6 : csneg w6, w7, w8, LE                      : csneg  %w7 %w8 le -> %w6
+5a8ad528 : csneg w8, w9, w10, LE                     : csneg  %w9 %w10 le -> %w8
+5a8bd549 : csneg w9, w10, w11, LE                    : csneg  %w10 %w11 le -> %w9
+5a8dd58b : csneg w11, w12, w13, LE                   : csneg  %w12 %w13 le -> %w11
+5a8fd5cd : csneg w13, w14, w15, LE                   : csneg  %w14 %w15 le -> %w13
+5a91d60f : csneg w15, w16, w17, LE                   : csneg  %w16 %w17 le -> %w15
+5a93d651 : csneg w17, w18, w19, LE                   : csneg  %w18 %w19 le -> %w17
+5a95d693 : csneg w19, w20, w21, LE                   : csneg  %w20 %w21 le -> %w19
+5a97d6d5 : csneg w21, w22, w23, LE                   : csneg  %w22 %w23 le -> %w21
+5a98d6f6 : csneg w22, w23, w24, LE                   : csneg  %w23 %w24 le -> %w22
+5a9ad738 : csneg w24, w25, w26, LE                   : csneg  %w25 %w26 le -> %w24
+5a9cd77a : csneg w26, w27, w28, LE                   : csneg  %w27 %w28 le -> %w26
+5a81d41e : csneg w30, w0, w1, LE                     : csneg  %w0 %w1 le -> %w30
+5a82e420 : csneg w0, w1, w2, AL                      : csneg  %w1 %w2 al -> %w0
+5a84e462 : csneg w2, w3, w4, AL                      : csneg  %w3 %w4 al -> %w2
+5a86e4a4 : csneg w4, w5, w6, AL                      : csneg  %w5 %w6 al -> %w4
+5a88e4e6 : csneg w6, w7, w8, AL                      : csneg  %w7 %w8 al -> %w6
+5a8ae528 : csneg w8, w9, w10, AL                     : csneg  %w9 %w10 al -> %w8
+5a8be549 : csneg w9, w10, w11, AL                    : csneg  %w10 %w11 al -> %w9
+5a8de58b : csneg w11, w12, w13, AL                   : csneg  %w12 %w13 al -> %w11
+5a8fe5cd : csneg w13, w14, w15, AL                   : csneg  %w14 %w15 al -> %w13
+5a91e60f : csneg w15, w16, w17, AL                   : csneg  %w16 %w17 al -> %w15
+5a93e651 : csneg w17, w18, w19, AL                   : csneg  %w18 %w19 al -> %w17
+5a95e693 : csneg w19, w20, w21, AL                   : csneg  %w20 %w21 al -> %w19
+5a97e6d5 : csneg w21, w22, w23, AL                   : csneg  %w22 %w23 al -> %w21
+5a98e6f6 : csneg w22, w23, w24, AL                   : csneg  %w23 %w24 al -> %w22
+5a9ae738 : csneg w24, w25, w26, AL                   : csneg  %w25 %w26 al -> %w24
+5a9ce77a : csneg w26, w27, w28, AL                   : csneg  %w27 %w28 al -> %w26
+5a81e41e : csneg w30, w0, w1, AL                     : csneg  %w0 %w1 al -> %w30
+5a82f420 : csneg w0, w1, w2, NV                      : csneg  %w1 %w2 nv -> %w0
+5a84f462 : csneg w2, w3, w4, NV                      : csneg  %w3 %w4 nv -> %w2
+5a86f4a4 : csneg w4, w5, w6, NV                      : csneg  %w5 %w6 nv -> %w4
+5a88f4e6 : csneg w6, w7, w8, NV                      : csneg  %w7 %w8 nv -> %w6
+5a8af528 : csneg w8, w9, w10, NV                     : csneg  %w9 %w10 nv -> %w8
+5a8bf549 : csneg w9, w10, w11, NV                    : csneg  %w10 %w11 nv -> %w9
+5a8df58b : csneg w11, w12, w13, NV                   : csneg  %w12 %w13 nv -> %w11
+5a8ff5cd : csneg w13, w14, w15, NV                   : csneg  %w14 %w15 nv -> %w13
+5a91f60f : csneg w15, w16, w17, NV                   : csneg  %w16 %w17 nv -> %w15
+5a93f651 : csneg w17, w18, w19, NV                   : csneg  %w18 %w19 nv -> %w17
+5a95f693 : csneg w19, w20, w21, NV                   : csneg  %w20 %w21 nv -> %w19
+5a97f6d5 : csneg w21, w22, w23, NV                   : csneg  %w22 %w23 nv -> %w21
+5a98f6f6 : csneg w22, w23, w24, NV                   : csneg  %w23 %w24 nv -> %w22
+5a9af738 : csneg w24, w25, w26, NV                   : csneg  %w25 %w26 nv -> %w24
+5a9cf77a : csneg w26, w27, w28, NV                   : csneg  %w27 %w28 nv -> %w26
+5a81f41e : csneg w30, w0, w1, NV                     : csneg  %w0 %w1 nv -> %w30
+
+# CCMP    <Wn>, <Wm>, #<imm>, <cond> (CCMP-R.RI-32_condcmp_reg)
+7a410000 : ccmp w0, w1, #0x0, EQ                     : ccmp.eq %w0 %w1 $0x00
+7a430041 : ccmp w2, w3, #0x1, EQ                     : ccmp.eq %w2 %w3 $0x01
+7a450082 : ccmp w4, w5, #0x2, EQ                     : ccmp.eq %w4 %w5 $0x02
+7a4700c3 : ccmp w6, w7, #0x3, EQ                     : ccmp.eq %w6 %w7 $0x03
+7a490104 : ccmp w8, w9, #0x4, EQ                     : ccmp.eq %w8 %w9 $0x04
+7a4a0125 : ccmp w9, w10, #0x5, EQ                    : ccmp.eq %w9 %w10 $0x05
+7a4c0166 : ccmp w11, w12, #0x6, EQ                   : ccmp.eq %w11 %w12 $0x06
+7a4e01a7 : ccmp w13, w14, #0x7, EQ                   : ccmp.eq %w13 %w14 $0x07
+7a5001e8 : ccmp w15, w16, #0x8, EQ                   : ccmp.eq %w15 %w16 $0x08
+7a520228 : ccmp w17, w18, #0x8, EQ                   : ccmp.eq %w17 %w18 $0x08
+7a540269 : ccmp w19, w20, #0x9, EQ                   : ccmp.eq %w19 %w20 $0x09
+7a5602aa : ccmp w21, w22, #0xa, EQ                   : ccmp.eq %w21 %w22 $0x0a
+7a5702cb : ccmp w22, w23, #0xb, EQ                   : ccmp.eq %w22 %w23 $0x0b
+7a59030c : ccmp w24, w25, #0xc, EQ                   : ccmp.eq %w24 %w25 $0x0c
+7a5b034d : ccmp w26, w27, #0xd, EQ                   : ccmp.eq %w26 %w27 $0x0d
+7a4003cf : ccmp w30, w0, #0xf, EQ                    : ccmp.eq %w30 %w0 $0x0f
+7a411000 : ccmp w0, w1, #0x0, NE                     : ccmp.ne %w0 %w1 $0x00
+7a431041 : ccmp w2, w3, #0x1, NE                     : ccmp.ne %w2 %w3 $0x01
+7a451082 : ccmp w4, w5, #0x2, NE                     : ccmp.ne %w4 %w5 $0x02
+7a4710c3 : ccmp w6, w7, #0x3, NE                     : ccmp.ne %w6 %w7 $0x03
+7a491104 : ccmp w8, w9, #0x4, NE                     : ccmp.ne %w8 %w9 $0x04
+7a4a1125 : ccmp w9, w10, #0x5, NE                    : ccmp.ne %w9 %w10 $0x05
+7a4c1166 : ccmp w11, w12, #0x6, NE                   : ccmp.ne %w11 %w12 $0x06
+7a4e11a7 : ccmp w13, w14, #0x7, NE                   : ccmp.ne %w13 %w14 $0x07
+7a5011e8 : ccmp w15, w16, #0x8, NE                   : ccmp.ne %w15 %w16 $0x08
+7a521228 : ccmp w17, w18, #0x8, NE                   : ccmp.ne %w17 %w18 $0x08
+7a541269 : ccmp w19, w20, #0x9, NE                   : ccmp.ne %w19 %w20 $0x09
+7a5612aa : ccmp w21, w22, #0xa, NE                   : ccmp.ne %w21 %w22 $0x0a
+7a5712cb : ccmp w22, w23, #0xb, NE                   : ccmp.ne %w22 %w23 $0x0b
+7a59130c : ccmp w24, w25, #0xc, NE                   : ccmp.ne %w24 %w25 $0x0c
+7a5b134d : ccmp w26, w27, #0xd, NE                   : ccmp.ne %w26 %w27 $0x0d
+7a4013cf : ccmp w30, w0, #0xf, NE                    : ccmp.ne %w30 %w0 $0x0f
+7a412000 : ccmp w0, w1, #0x0, CS                     : ccmp.cs %w0 %w1 $0x00
+7a432041 : ccmp w2, w3, #0x1, CS                     : ccmp.cs %w2 %w3 $0x01
+7a452082 : ccmp w4, w5, #0x2, CS                     : ccmp.cs %w4 %w5 $0x02
+7a4720c3 : ccmp w6, w7, #0x3, CS                     : ccmp.cs %w6 %w7 $0x03
+7a492104 : ccmp w8, w9, #0x4, CS                     : ccmp.cs %w8 %w9 $0x04
+7a4a2125 : ccmp w9, w10, #0x5, CS                    : ccmp.cs %w9 %w10 $0x05
+7a4c2166 : ccmp w11, w12, #0x6, CS                   : ccmp.cs %w11 %w12 $0x06
+7a4e21a7 : ccmp w13, w14, #0x7, CS                   : ccmp.cs %w13 %w14 $0x07
+7a5021e8 : ccmp w15, w16, #0x8, CS                   : ccmp.cs %w15 %w16 $0x08
+7a522228 : ccmp w17, w18, #0x8, CS                   : ccmp.cs %w17 %w18 $0x08
+7a542269 : ccmp w19, w20, #0x9, CS                   : ccmp.cs %w19 %w20 $0x09
+7a5622aa : ccmp w21, w22, #0xa, CS                   : ccmp.cs %w21 %w22 $0x0a
+7a5722cb : ccmp w22, w23, #0xb, CS                   : ccmp.cs %w22 %w23 $0x0b
+7a59230c : ccmp w24, w25, #0xc, CS                   : ccmp.cs %w24 %w25 $0x0c
+7a5b234d : ccmp w26, w27, #0xd, CS                   : ccmp.cs %w26 %w27 $0x0d
+7a4023cf : ccmp w30, w0, #0xf, CS                    : ccmp.cs %w30 %w0 $0x0f
+7a413000 : ccmp w0, w1, #0x0, CC                     : ccmp.cc %w0 %w1 $0x00
+7a433041 : ccmp w2, w3, #0x1, CC                     : ccmp.cc %w2 %w3 $0x01
+7a453082 : ccmp w4, w5, #0x2, CC                     : ccmp.cc %w4 %w5 $0x02
+7a4730c3 : ccmp w6, w7, #0x3, CC                     : ccmp.cc %w6 %w7 $0x03
+7a493104 : ccmp w8, w9, #0x4, CC                     : ccmp.cc %w8 %w9 $0x04
+7a4a3125 : ccmp w9, w10, #0x5, CC                    : ccmp.cc %w9 %w10 $0x05
+7a4c3166 : ccmp w11, w12, #0x6, CC                   : ccmp.cc %w11 %w12 $0x06
+7a4e31a7 : ccmp w13, w14, #0x7, CC                   : ccmp.cc %w13 %w14 $0x07
+7a5031e8 : ccmp w15, w16, #0x8, CC                   : ccmp.cc %w15 %w16 $0x08
+7a523228 : ccmp w17, w18, #0x8, CC                   : ccmp.cc %w17 %w18 $0x08
+7a543269 : ccmp w19, w20, #0x9, CC                   : ccmp.cc %w19 %w20 $0x09
+7a5632aa : ccmp w21, w22, #0xa, CC                   : ccmp.cc %w21 %w22 $0x0a
+7a5732cb : ccmp w22, w23, #0xb, CC                   : ccmp.cc %w22 %w23 $0x0b
+7a59330c : ccmp w24, w25, #0xc, CC                   : ccmp.cc %w24 %w25 $0x0c
+7a5b334d : ccmp w26, w27, #0xd, CC                   : ccmp.cc %w26 %w27 $0x0d
+7a4033cf : ccmp w30, w0, #0xf, CC                    : ccmp.cc %w30 %w0 $0x0f
+7a414000 : ccmp w0, w1, #0x0, MI                     : ccmp.mi %w0 %w1 $0x00
+7a434041 : ccmp w2, w3, #0x1, MI                     : ccmp.mi %w2 %w3 $0x01
+7a454082 : ccmp w4, w5, #0x2, MI                     : ccmp.mi %w4 %w5 $0x02
+7a4740c3 : ccmp w6, w7, #0x3, MI                     : ccmp.mi %w6 %w7 $0x03
+7a494104 : ccmp w8, w9, #0x4, MI                     : ccmp.mi %w8 %w9 $0x04
+7a4a4125 : ccmp w9, w10, #0x5, MI                    : ccmp.mi %w9 %w10 $0x05
+7a4c4166 : ccmp w11, w12, #0x6, MI                   : ccmp.mi %w11 %w12 $0x06
+7a4e41a7 : ccmp w13, w14, #0x7, MI                   : ccmp.mi %w13 %w14 $0x07
+7a5041e8 : ccmp w15, w16, #0x8, MI                   : ccmp.mi %w15 %w16 $0x08
+7a524228 : ccmp w17, w18, #0x8, MI                   : ccmp.mi %w17 %w18 $0x08
+7a544269 : ccmp w19, w20, #0x9, MI                   : ccmp.mi %w19 %w20 $0x09
+7a5642aa : ccmp w21, w22, #0xa, MI                   : ccmp.mi %w21 %w22 $0x0a
+7a5742cb : ccmp w22, w23, #0xb, MI                   : ccmp.mi %w22 %w23 $0x0b
+7a59430c : ccmp w24, w25, #0xc, MI                   : ccmp.mi %w24 %w25 $0x0c
+7a5b434d : ccmp w26, w27, #0xd, MI                   : ccmp.mi %w26 %w27 $0x0d
+7a4043cf : ccmp w30, w0, #0xf, MI                    : ccmp.mi %w30 %w0 $0x0f
+7a415000 : ccmp w0, w1, #0x0, PL                     : ccmp.pl %w0 %w1 $0x00
+7a435041 : ccmp w2, w3, #0x1, PL                     : ccmp.pl %w2 %w3 $0x01
+7a455082 : ccmp w4, w5, #0x2, PL                     : ccmp.pl %w4 %w5 $0x02
+7a4750c3 : ccmp w6, w7, #0x3, PL                     : ccmp.pl %w6 %w7 $0x03
+7a495104 : ccmp w8, w9, #0x4, PL                     : ccmp.pl %w8 %w9 $0x04
+7a4a5125 : ccmp w9, w10, #0x5, PL                    : ccmp.pl %w9 %w10 $0x05
+7a4c5166 : ccmp w11, w12, #0x6, PL                   : ccmp.pl %w11 %w12 $0x06
+7a4e51a7 : ccmp w13, w14, #0x7, PL                   : ccmp.pl %w13 %w14 $0x07
+7a5051e8 : ccmp w15, w16, #0x8, PL                   : ccmp.pl %w15 %w16 $0x08
+7a525228 : ccmp w17, w18, #0x8, PL                   : ccmp.pl %w17 %w18 $0x08
+7a545269 : ccmp w19, w20, #0x9, PL                   : ccmp.pl %w19 %w20 $0x09
+7a5652aa : ccmp w21, w22, #0xa, PL                   : ccmp.pl %w21 %w22 $0x0a
+7a5752cb : ccmp w22, w23, #0xb, PL                   : ccmp.pl %w22 %w23 $0x0b
+7a59530c : ccmp w24, w25, #0xc, PL                   : ccmp.pl %w24 %w25 $0x0c
+7a5b534d : ccmp w26, w27, #0xd, PL                   : ccmp.pl %w26 %w27 $0x0d
+7a4053cf : ccmp w30, w0, #0xf, PL                    : ccmp.pl %w30 %w0 $0x0f
+7a416000 : ccmp w0, w1, #0x0, VS                     : ccmp.vs %w0 %w1 $0x00
+7a436041 : ccmp w2, w3, #0x1, VS                     : ccmp.vs %w2 %w3 $0x01
+7a456082 : ccmp w4, w5, #0x2, VS                     : ccmp.vs %w4 %w5 $0x02
+7a4760c3 : ccmp w6, w7, #0x3, VS                     : ccmp.vs %w6 %w7 $0x03
+7a496104 : ccmp w8, w9, #0x4, VS                     : ccmp.vs %w8 %w9 $0x04
+7a4a6125 : ccmp w9, w10, #0x5, VS                    : ccmp.vs %w9 %w10 $0x05
+7a4c6166 : ccmp w11, w12, #0x6, VS                   : ccmp.vs %w11 %w12 $0x06
+7a4e61a7 : ccmp w13, w14, #0x7, VS                   : ccmp.vs %w13 %w14 $0x07
+7a5061e8 : ccmp w15, w16, #0x8, VS                   : ccmp.vs %w15 %w16 $0x08
+7a526228 : ccmp w17, w18, #0x8, VS                   : ccmp.vs %w17 %w18 $0x08
+7a546269 : ccmp w19, w20, #0x9, VS                   : ccmp.vs %w19 %w20 $0x09
+7a5662aa : ccmp w21, w22, #0xa, VS                   : ccmp.vs %w21 %w22 $0x0a
+7a5762cb : ccmp w22, w23, #0xb, VS                   : ccmp.vs %w22 %w23 $0x0b
+7a59630c : ccmp w24, w25, #0xc, VS                   : ccmp.vs %w24 %w25 $0x0c
+7a5b634d : ccmp w26, w27, #0xd, VS                   : ccmp.vs %w26 %w27 $0x0d
+7a4063cf : ccmp w30, w0, #0xf, VS                    : ccmp.vs %w30 %w0 $0x0f
+7a417000 : ccmp w0, w1, #0x0, VC                     : ccmp.vc %w0 %w1 $0x00
+7a437041 : ccmp w2, w3, #0x1, VC                     : ccmp.vc %w2 %w3 $0x01
+7a457082 : ccmp w4, w5, #0x2, VC                     : ccmp.vc %w4 %w5 $0x02
+7a4770c3 : ccmp w6, w7, #0x3, VC                     : ccmp.vc %w6 %w7 $0x03
+7a497104 : ccmp w8, w9, #0x4, VC                     : ccmp.vc %w8 %w9 $0x04
+7a4a7125 : ccmp w9, w10, #0x5, VC                    : ccmp.vc %w9 %w10 $0x05
+7a4c7166 : ccmp w11, w12, #0x6, VC                   : ccmp.vc %w11 %w12 $0x06
+7a4e71a7 : ccmp w13, w14, #0x7, VC                   : ccmp.vc %w13 %w14 $0x07
+7a5071e8 : ccmp w15, w16, #0x8, VC                   : ccmp.vc %w15 %w16 $0x08
+7a527228 : ccmp w17, w18, #0x8, VC                   : ccmp.vc %w17 %w18 $0x08
+7a547269 : ccmp w19, w20, #0x9, VC                   : ccmp.vc %w19 %w20 $0x09
+7a5672aa : ccmp w21, w22, #0xa, VC                   : ccmp.vc %w21 %w22 $0x0a
+7a5772cb : ccmp w22, w23, #0xb, VC                   : ccmp.vc %w22 %w23 $0x0b
+7a59730c : ccmp w24, w25, #0xc, VC                   : ccmp.vc %w24 %w25 $0x0c
+7a5b734d : ccmp w26, w27, #0xd, VC                   : ccmp.vc %w26 %w27 $0x0d
+7a4073cf : ccmp w30, w0, #0xf, VC                    : ccmp.vc %w30 %w0 $0x0f
+7a418000 : ccmp w0, w1, #0x0, HI                     : ccmp.hi %w0 %w1 $0x00
+7a438041 : ccmp w2, w3, #0x1, HI                     : ccmp.hi %w2 %w3 $0x01
+7a458082 : ccmp w4, w5, #0x2, HI                     : ccmp.hi %w4 %w5 $0x02
+7a4780c3 : ccmp w6, w7, #0x3, HI                     : ccmp.hi %w6 %w7 $0x03
+7a498104 : ccmp w8, w9, #0x4, HI                     : ccmp.hi %w8 %w9 $0x04
+7a4a8125 : ccmp w9, w10, #0x5, HI                    : ccmp.hi %w9 %w10 $0x05
+7a4c8166 : ccmp w11, w12, #0x6, HI                   : ccmp.hi %w11 %w12 $0x06
+7a4e81a7 : ccmp w13, w14, #0x7, HI                   : ccmp.hi %w13 %w14 $0x07
+7a5081e8 : ccmp w15, w16, #0x8, HI                   : ccmp.hi %w15 %w16 $0x08
+7a528228 : ccmp w17, w18, #0x8, HI                   : ccmp.hi %w17 %w18 $0x08
+7a548269 : ccmp w19, w20, #0x9, HI                   : ccmp.hi %w19 %w20 $0x09
+7a5682aa : ccmp w21, w22, #0xa, HI                   : ccmp.hi %w21 %w22 $0x0a
+7a5782cb : ccmp w22, w23, #0xb, HI                   : ccmp.hi %w22 %w23 $0x0b
+7a59830c : ccmp w24, w25, #0xc, HI                   : ccmp.hi %w24 %w25 $0x0c
+7a5b834d : ccmp w26, w27, #0xd, HI                   : ccmp.hi %w26 %w27 $0x0d
+7a4083cf : ccmp w30, w0, #0xf, HI                    : ccmp.hi %w30 %w0 $0x0f
+7a419000 : ccmp w0, w1, #0x0, LS                     : ccmp.ls %w0 %w1 $0x00
+7a439041 : ccmp w2, w3, #0x1, LS                     : ccmp.ls %w2 %w3 $0x01
+7a459082 : ccmp w4, w5, #0x2, LS                     : ccmp.ls %w4 %w5 $0x02
+7a4790c3 : ccmp w6, w7, #0x3, LS                     : ccmp.ls %w6 %w7 $0x03
+7a499104 : ccmp w8, w9, #0x4, LS                     : ccmp.ls %w8 %w9 $0x04
+7a4a9125 : ccmp w9, w10, #0x5, LS                    : ccmp.ls %w9 %w10 $0x05
+7a4c9166 : ccmp w11, w12, #0x6, LS                   : ccmp.ls %w11 %w12 $0x06
+7a4e91a7 : ccmp w13, w14, #0x7, LS                   : ccmp.ls %w13 %w14 $0x07
+7a5091e8 : ccmp w15, w16, #0x8, LS                   : ccmp.ls %w15 %w16 $0x08
+7a529228 : ccmp w17, w18, #0x8, LS                   : ccmp.ls %w17 %w18 $0x08
+7a549269 : ccmp w19, w20, #0x9, LS                   : ccmp.ls %w19 %w20 $0x09
+7a5692aa : ccmp w21, w22, #0xa, LS                   : ccmp.ls %w21 %w22 $0x0a
+7a5792cb : ccmp w22, w23, #0xb, LS                   : ccmp.ls %w22 %w23 $0x0b
+7a59930c : ccmp w24, w25, #0xc, LS                   : ccmp.ls %w24 %w25 $0x0c
+7a5b934d : ccmp w26, w27, #0xd, LS                   : ccmp.ls %w26 %w27 $0x0d
+7a4093cf : ccmp w30, w0, #0xf, LS                    : ccmp.ls %w30 %w0 $0x0f
+7a41a000 : ccmp w0, w1, #0x0, GE                     : ccmp.ge %w0 %w1 $0x00
+7a43a041 : ccmp w2, w3, #0x1, GE                     : ccmp.ge %w2 %w3 $0x01
+7a45a082 : ccmp w4, w5, #0x2, GE                     : ccmp.ge %w4 %w5 $0x02
+7a47a0c3 : ccmp w6, w7, #0x3, GE                     : ccmp.ge %w6 %w7 $0x03
+7a49a104 : ccmp w8, w9, #0x4, GE                     : ccmp.ge %w8 %w9 $0x04
+7a4aa125 : ccmp w9, w10, #0x5, GE                    : ccmp.ge %w9 %w10 $0x05
+7a4ca166 : ccmp w11, w12, #0x6, GE                   : ccmp.ge %w11 %w12 $0x06
+7a4ea1a7 : ccmp w13, w14, #0x7, GE                   : ccmp.ge %w13 %w14 $0x07
+7a50a1e8 : ccmp w15, w16, #0x8, GE                   : ccmp.ge %w15 %w16 $0x08
+7a52a228 : ccmp w17, w18, #0x8, GE                   : ccmp.ge %w17 %w18 $0x08
+7a54a269 : ccmp w19, w20, #0x9, GE                   : ccmp.ge %w19 %w20 $0x09
+7a56a2aa : ccmp w21, w22, #0xa, GE                   : ccmp.ge %w21 %w22 $0x0a
+7a57a2cb : ccmp w22, w23, #0xb, GE                   : ccmp.ge %w22 %w23 $0x0b
+7a59a30c : ccmp w24, w25, #0xc, GE                   : ccmp.ge %w24 %w25 $0x0c
+7a5ba34d : ccmp w26, w27, #0xd, GE                   : ccmp.ge %w26 %w27 $0x0d
+7a40a3cf : ccmp w30, w0, #0xf, GE                    : ccmp.ge %w30 %w0 $0x0f
+7a41b000 : ccmp w0, w1, #0x0, LT                     : ccmp.lt %w0 %w1 $0x00
+7a43b041 : ccmp w2, w3, #0x1, LT                     : ccmp.lt %w2 %w3 $0x01
+7a45b082 : ccmp w4, w5, #0x2, LT                     : ccmp.lt %w4 %w5 $0x02
+7a47b0c3 : ccmp w6, w7, #0x3, LT                     : ccmp.lt %w6 %w7 $0x03
+7a49b104 : ccmp w8, w9, #0x4, LT                     : ccmp.lt %w8 %w9 $0x04
+7a4ab125 : ccmp w9, w10, #0x5, LT                    : ccmp.lt %w9 %w10 $0x05
+7a4cb166 : ccmp w11, w12, #0x6, LT                   : ccmp.lt %w11 %w12 $0x06
+7a4eb1a7 : ccmp w13, w14, #0x7, LT                   : ccmp.lt %w13 %w14 $0x07
+7a50b1e8 : ccmp w15, w16, #0x8, LT                   : ccmp.lt %w15 %w16 $0x08
+7a52b228 : ccmp w17, w18, #0x8, LT                   : ccmp.lt %w17 %w18 $0x08
+7a54b269 : ccmp w19, w20, #0x9, LT                   : ccmp.lt %w19 %w20 $0x09
+7a56b2aa : ccmp w21, w22, #0xa, LT                   : ccmp.lt %w21 %w22 $0x0a
+7a57b2cb : ccmp w22, w23, #0xb, LT                   : ccmp.lt %w22 %w23 $0x0b
+7a59b30c : ccmp w24, w25, #0xc, LT                   : ccmp.lt %w24 %w25 $0x0c
+7a5bb34d : ccmp w26, w27, #0xd, LT                   : ccmp.lt %w26 %w27 $0x0d
+7a40b3cf : ccmp w30, w0, #0xf, LT                    : ccmp.lt %w30 %w0 $0x0f
+7a41c000 : ccmp w0, w1, #0x0, GT                     : ccmp.gt %w0 %w1 $0x00
+7a43c041 : ccmp w2, w3, #0x1, GT                     : ccmp.gt %w2 %w3 $0x01
+7a45c082 : ccmp w4, w5, #0x2, GT                     : ccmp.gt %w4 %w5 $0x02
+7a47c0c3 : ccmp w6, w7, #0x3, GT                     : ccmp.gt %w6 %w7 $0x03
+7a49c104 : ccmp w8, w9, #0x4, GT                     : ccmp.gt %w8 %w9 $0x04
+7a4ac125 : ccmp w9, w10, #0x5, GT                    : ccmp.gt %w9 %w10 $0x05
+7a4cc166 : ccmp w11, w12, #0x6, GT                   : ccmp.gt %w11 %w12 $0x06
+7a4ec1a7 : ccmp w13, w14, #0x7, GT                   : ccmp.gt %w13 %w14 $0x07
+7a50c1e8 : ccmp w15, w16, #0x8, GT                   : ccmp.gt %w15 %w16 $0x08
+7a52c228 : ccmp w17, w18, #0x8, GT                   : ccmp.gt %w17 %w18 $0x08
+7a54c269 : ccmp w19, w20, #0x9, GT                   : ccmp.gt %w19 %w20 $0x09
+7a56c2aa : ccmp w21, w22, #0xa, GT                   : ccmp.gt %w21 %w22 $0x0a
+7a57c2cb : ccmp w22, w23, #0xb, GT                   : ccmp.gt %w22 %w23 $0x0b
+7a59c30c : ccmp w24, w25, #0xc, GT                   : ccmp.gt %w24 %w25 $0x0c
+7a5bc34d : ccmp w26, w27, #0xd, GT                   : ccmp.gt %w26 %w27 $0x0d
+7a40c3cf : ccmp w30, w0, #0xf, GT                    : ccmp.gt %w30 %w0 $0x0f
+7a41d000 : ccmp w0, w1, #0x0, LE                     : ccmp.le %w0 %w1 $0x00
+7a43d041 : ccmp w2, w3, #0x1, LE                     : ccmp.le %w2 %w3 $0x01
+7a45d082 : ccmp w4, w5, #0x2, LE                     : ccmp.le %w4 %w5 $0x02
+7a47d0c3 : ccmp w6, w7, #0x3, LE                     : ccmp.le %w6 %w7 $0x03
+7a49d104 : ccmp w8, w9, #0x4, LE                     : ccmp.le %w8 %w9 $0x04
+7a4ad125 : ccmp w9, w10, #0x5, LE                    : ccmp.le %w9 %w10 $0x05
+7a4cd166 : ccmp w11, w12, #0x6, LE                   : ccmp.le %w11 %w12 $0x06
+7a4ed1a7 : ccmp w13, w14, #0x7, LE                   : ccmp.le %w13 %w14 $0x07
+7a50d1e8 : ccmp w15, w16, #0x8, LE                   : ccmp.le %w15 %w16 $0x08
+7a52d228 : ccmp w17, w18, #0x8, LE                   : ccmp.le %w17 %w18 $0x08
+7a54d269 : ccmp w19, w20, #0x9, LE                   : ccmp.le %w19 %w20 $0x09
+7a56d2aa : ccmp w21, w22, #0xa, LE                   : ccmp.le %w21 %w22 $0x0a
+7a57d2cb : ccmp w22, w23, #0xb, LE                   : ccmp.le %w22 %w23 $0x0b
+7a59d30c : ccmp w24, w25, #0xc, LE                   : ccmp.le %w24 %w25 $0x0c
+7a5bd34d : ccmp w26, w27, #0xd, LE                   : ccmp.le %w26 %w27 $0x0d
+7a40d3cf : ccmp w30, w0, #0xf, LE                    : ccmp.le %w30 %w0 $0x0f
+7a41e000 : ccmp w0, w1, #0x0, AL                     : ccmp.al %w0 %w1 $0x00
+7a43e041 : ccmp w2, w3, #0x1, AL                     : ccmp.al %w2 %w3 $0x01
+7a45e082 : ccmp w4, w5, #0x2, AL                     : ccmp.al %w4 %w5 $0x02
+7a47e0c3 : ccmp w6, w7, #0x3, AL                     : ccmp.al %w6 %w7 $0x03
+7a49e104 : ccmp w8, w9, #0x4, AL                     : ccmp.al %w8 %w9 $0x04
+7a4ae125 : ccmp w9, w10, #0x5, AL                    : ccmp.al %w9 %w10 $0x05
+7a4ce166 : ccmp w11, w12, #0x6, AL                   : ccmp.al %w11 %w12 $0x06
+7a4ee1a7 : ccmp w13, w14, #0x7, AL                   : ccmp.al %w13 %w14 $0x07
+7a50e1e8 : ccmp w15, w16, #0x8, AL                   : ccmp.al %w15 %w16 $0x08
+7a52e228 : ccmp w17, w18, #0x8, AL                   : ccmp.al %w17 %w18 $0x08
+7a54e269 : ccmp w19, w20, #0x9, AL                   : ccmp.al %w19 %w20 $0x09
+7a56e2aa : ccmp w21, w22, #0xa, AL                   : ccmp.al %w21 %w22 $0x0a
+7a57e2cb : ccmp w22, w23, #0xb, AL                   : ccmp.al %w22 %w23 $0x0b
+7a59e30c : ccmp w24, w25, #0xc, AL                   : ccmp.al %w24 %w25 $0x0c
+7a5be34d : ccmp w26, w27, #0xd, AL                   : ccmp.al %w26 %w27 $0x0d
+7a40e3cf : ccmp w30, w0, #0xf, AL                    : ccmp.al %w30 %w0 $0x0f
+7a41f000 : ccmp w0, w1, #0x0, NV                     : ccmp.nv %w0 %w1 $0x00
+7a43f041 : ccmp w2, w3, #0x1, NV                     : ccmp.nv %w2 %w3 $0x01
+7a45f082 : ccmp w4, w5, #0x2, NV                     : ccmp.nv %w4 %w5 $0x02
+7a47f0c3 : ccmp w6, w7, #0x3, NV                     : ccmp.nv %w6 %w7 $0x03
+7a49f104 : ccmp w8, w9, #0x4, NV                     : ccmp.nv %w8 %w9 $0x04
+7a4af125 : ccmp w9, w10, #0x5, NV                    : ccmp.nv %w9 %w10 $0x05
+7a4cf166 : ccmp w11, w12, #0x6, NV                   : ccmp.nv %w11 %w12 $0x06
+7a4ef1a7 : ccmp w13, w14, #0x7, NV                   : ccmp.nv %w13 %w14 $0x07
+7a50f1e8 : ccmp w15, w16, #0x8, NV                   : ccmp.nv %w15 %w16 $0x08
+7a52f228 : ccmp w17, w18, #0x8, NV                   : ccmp.nv %w17 %w18 $0x08
+7a54f269 : ccmp w19, w20, #0x9, NV                   : ccmp.nv %w19 %w20 $0x09
+7a56f2aa : ccmp w21, w22, #0xa, NV                   : ccmp.nv %w21 %w22 $0x0a
+7a57f2cb : ccmp w22, w23, #0xb, NV                   : ccmp.nv %w22 %w23 $0x0b
+7a59f30c : ccmp w24, w25, #0xc, NV                   : ccmp.nv %w24 %w25 $0x0c
+7a5bf34d : ccmp w26, w27, #0xd, NV                   : ccmp.nv %w26 %w27 $0x0d
+7a40f3cf : ccmp w30, w0, #0xf, NV                    : ccmp.nv %w30 %w0 $0x0f
+
+# MADD    <Xd>, <Xn>, <Xm>, <Xa> (MADD-R.RRR-64A_dp_3src)
+9b020c20 : madd x0, x1, x2, x3                       : madd   %x1 %x2 %x3 -> %x0
+9b041462 : madd x2, x3, x4, x5                       : madd   %x3 %x4 %x5 -> %x2
+9b061ca4 : madd x4, x5, x6, x7                       : madd   %x5 %x6 %x7 -> %x4
+9b0824e6 : madd x6, x7, x8, x9                       : madd   %x7 %x8 %x9 -> %x6
+9b0a2d28 : madd x8, x9, x10, x11                     : madd   %x9 %x10 %x11 -> %x8
+9b0b3149 : madd x9, x10, x11, x12                    : madd   %x10 %x11 %x12 -> %x9
+9b0d398b : madd x11, x12, x13, x14                   : madd   %x12 %x13 %x14 -> %x11
+9b0f41cd : madd x13, x14, x15, x16                   : madd   %x14 %x15 %x16 -> %x13
+9b114a0f : madd x15, x16, x17, x18                   : madd   %x16 %x17 %x18 -> %x15
+9b135251 : madd x17, x18, x19, x20                   : madd   %x18 %x19 %x20 -> %x17
+9b155a93 : madd x19, x20, x21, x22                   : madd   %x20 %x21 %x22 -> %x19
+9b1762d5 : madd x21, x22, x23, x24                   : madd   %x22 %x23 %x24 -> %x21
+9b1866f6 : madd x22, x23, x24, x25                   : madd   %x23 %x24 %x25 -> %x22
+9b1a6f38 : madd x24, x25, x26, x27                   : madd   %x25 %x26 %x27 -> %x24
+9b1c777a : madd x26, x27, x28, x29                   : madd   %x27 %x28 %x29 -> %x26
+9b01081e : madd x30, x0, x1, x2                      : madd   %x0 %x1 %x2 -> %x30
+
+# ADC     <Wd>, <Wn>, <Wm> (ADC-R.RR-32_addsub_carry)
+1a020020 : adc w0, w1, w2                            : adc    %w1 %w2 -> %w0
+1a040062 : adc w2, w3, w4                            : adc    %w3 %w4 -> %w2
+1a0600a4 : adc w4, w5, w6                            : adc    %w5 %w6 -> %w4
+1a0800e6 : adc w6, w7, w8                            : adc    %w7 %w8 -> %w6
+1a0a0128 : adc w8, w9, w10                           : adc    %w9 %w10 -> %w8
+1a0b0149 : adc w9, w10, w11                          : adc    %w10 %w11 -> %w9
+1a0d018b : adc w11, w12, w13                         : adc    %w12 %w13 -> %w11
+1a0f01cd : adc w13, w14, w15                         : adc    %w14 %w15 -> %w13
+1a11020f : adc w15, w16, w17                         : adc    %w16 %w17 -> %w15
+1a130251 : adc w17, w18, w19                         : adc    %w18 %w19 -> %w17
+1a150293 : adc w19, w20, w21                         : adc    %w20 %w21 -> %w19
+1a1702d5 : adc w21, w22, w23                         : adc    %w22 %w23 -> %w21
+1a1802f6 : adc w22, w23, w24                         : adc    %w23 %w24 -> %w22
+1a1a0338 : adc w24, w25, w26                         : adc    %w25 %w26 -> %w24
+1a1c037a : adc w26, w27, w28                         : adc    %w27 %w28 -> %w26
+1a01001e : adc w30, w0, w1                           : adc    %w0 %w1 -> %w30
+
+# CCMN    <Wn>, <Wm>, #<imm>, <cond> (CCMN-R.RI-32_condcmp_reg)
+3a410000 : ccmn w0, w1, #0x0, EQ                     : ccmn.eq %w0 %w1 $0x00
+3a430041 : ccmn w2, w3, #0x1, EQ                     : ccmn.eq %w2 %w3 $0x01
+3a450082 : ccmn w4, w5, #0x2, EQ                     : ccmn.eq %w4 %w5 $0x02
+3a4700c3 : ccmn w6, w7, #0x3, EQ                     : ccmn.eq %w6 %w7 $0x03
+3a490104 : ccmn w8, w9, #0x4, EQ                     : ccmn.eq %w8 %w9 $0x04
+3a4a0125 : ccmn w9, w10, #0x5, EQ                    : ccmn.eq %w9 %w10 $0x05
+3a4c0166 : ccmn w11, w12, #0x6, EQ                   : ccmn.eq %w11 %w12 $0x06
+3a4e01a7 : ccmn w13, w14, #0x7, EQ                   : ccmn.eq %w13 %w14 $0x07
+3a5001e8 : ccmn w15, w16, #0x8, EQ                   : ccmn.eq %w15 %w16 $0x08
+3a520228 : ccmn w17, w18, #0x8, EQ                   : ccmn.eq %w17 %w18 $0x08
+3a540269 : ccmn w19, w20, #0x9, EQ                   : ccmn.eq %w19 %w20 $0x09
+3a5602aa : ccmn w21, w22, #0xa, EQ                   : ccmn.eq %w21 %w22 $0x0a
+3a5702cb : ccmn w22, w23, #0xb, EQ                   : ccmn.eq %w22 %w23 $0x0b
+3a59030c : ccmn w24, w25, #0xc, EQ                   : ccmn.eq %w24 %w25 $0x0c
+3a5b034d : ccmn w26, w27, #0xd, EQ                   : ccmn.eq %w26 %w27 $0x0d
+3a4003cf : ccmn w30, w0, #0xf, EQ                    : ccmn.eq %w30 %w0 $0x0f
+3a411000 : ccmn w0, w1, #0x0, NE                     : ccmn.ne %w0 %w1 $0x00
+3a431041 : ccmn w2, w3, #0x1, NE                     : ccmn.ne %w2 %w3 $0x01
+3a451082 : ccmn w4, w5, #0x2, NE                     : ccmn.ne %w4 %w5 $0x02
+3a4710c3 : ccmn w6, w7, #0x3, NE                     : ccmn.ne %w6 %w7 $0x03
+3a491104 : ccmn w8, w9, #0x4, NE                     : ccmn.ne %w8 %w9 $0x04
+3a4a1125 : ccmn w9, w10, #0x5, NE                    : ccmn.ne %w9 %w10 $0x05
+3a4c1166 : ccmn w11, w12, #0x6, NE                   : ccmn.ne %w11 %w12 $0x06
+3a4e11a7 : ccmn w13, w14, #0x7, NE                   : ccmn.ne %w13 %w14 $0x07
+3a5011e8 : ccmn w15, w16, #0x8, NE                   : ccmn.ne %w15 %w16 $0x08
+3a521228 : ccmn w17, w18, #0x8, NE                   : ccmn.ne %w17 %w18 $0x08
+3a541269 : ccmn w19, w20, #0x9, NE                   : ccmn.ne %w19 %w20 $0x09
+3a5612aa : ccmn w21, w22, #0xa, NE                   : ccmn.ne %w21 %w22 $0x0a
+3a5712cb : ccmn w22, w23, #0xb, NE                   : ccmn.ne %w22 %w23 $0x0b
+3a59130c : ccmn w24, w25, #0xc, NE                   : ccmn.ne %w24 %w25 $0x0c
+3a5b134d : ccmn w26, w27, #0xd, NE                   : ccmn.ne %w26 %w27 $0x0d
+3a4013cf : ccmn w30, w0, #0xf, NE                    : ccmn.ne %w30 %w0 $0x0f
+3a412000 : ccmn w0, w1, #0x0, CS                     : ccmn.cs %w0 %w1 $0x00
+3a432041 : ccmn w2, w3, #0x1, CS                     : ccmn.cs %w2 %w3 $0x01
+3a452082 : ccmn w4, w5, #0x2, CS                     : ccmn.cs %w4 %w5 $0x02
+3a4720c3 : ccmn w6, w7, #0x3, CS                     : ccmn.cs %w6 %w7 $0x03
+3a492104 : ccmn w8, w9, #0x4, CS                     : ccmn.cs %w8 %w9 $0x04
+3a4a2125 : ccmn w9, w10, #0x5, CS                    : ccmn.cs %w9 %w10 $0x05
+3a4c2166 : ccmn w11, w12, #0x6, CS                   : ccmn.cs %w11 %w12 $0x06
+3a4e21a7 : ccmn w13, w14, #0x7, CS                   : ccmn.cs %w13 %w14 $0x07
+3a5021e8 : ccmn w15, w16, #0x8, CS                   : ccmn.cs %w15 %w16 $0x08
+3a522228 : ccmn w17, w18, #0x8, CS                   : ccmn.cs %w17 %w18 $0x08
+3a542269 : ccmn w19, w20, #0x9, CS                   : ccmn.cs %w19 %w20 $0x09
+3a5622aa : ccmn w21, w22, #0xa, CS                   : ccmn.cs %w21 %w22 $0x0a
+3a5722cb : ccmn w22, w23, #0xb, CS                   : ccmn.cs %w22 %w23 $0x0b
+3a59230c : ccmn w24, w25, #0xc, CS                   : ccmn.cs %w24 %w25 $0x0c
+3a5b234d : ccmn w26, w27, #0xd, CS                   : ccmn.cs %w26 %w27 $0x0d
+3a4023cf : ccmn w30, w0, #0xf, CS                    : ccmn.cs %w30 %w0 $0x0f
+3a413000 : ccmn w0, w1, #0x0, CC                     : ccmn.cc %w0 %w1 $0x00
+3a433041 : ccmn w2, w3, #0x1, CC                     : ccmn.cc %w2 %w3 $0x01
+3a453082 : ccmn w4, w5, #0x2, CC                     : ccmn.cc %w4 %w5 $0x02
+3a4730c3 : ccmn w6, w7, #0x3, CC                     : ccmn.cc %w6 %w7 $0x03
+3a493104 : ccmn w8, w9, #0x4, CC                     : ccmn.cc %w8 %w9 $0x04
+3a4a3125 : ccmn w9, w10, #0x5, CC                    : ccmn.cc %w9 %w10 $0x05
+3a4c3166 : ccmn w11, w12, #0x6, CC                   : ccmn.cc %w11 %w12 $0x06
+3a4e31a7 : ccmn w13, w14, #0x7, CC                   : ccmn.cc %w13 %w14 $0x07
+3a5031e8 : ccmn w15, w16, #0x8, CC                   : ccmn.cc %w15 %w16 $0x08
+3a523228 : ccmn w17, w18, #0x8, CC                   : ccmn.cc %w17 %w18 $0x08
+3a543269 : ccmn w19, w20, #0x9, CC                   : ccmn.cc %w19 %w20 $0x09
+3a5632aa : ccmn w21, w22, #0xa, CC                   : ccmn.cc %w21 %w22 $0x0a
+3a5732cb : ccmn w22, w23, #0xb, CC                   : ccmn.cc %w22 %w23 $0x0b
+3a59330c : ccmn w24, w25, #0xc, CC                   : ccmn.cc %w24 %w25 $0x0c
+3a5b334d : ccmn w26, w27, #0xd, CC                   : ccmn.cc %w26 %w27 $0x0d
+3a4033cf : ccmn w30, w0, #0xf, CC                    : ccmn.cc %w30 %w0 $0x0f
+3a414000 : ccmn w0, w1, #0x0, MI                     : ccmn.mi %w0 %w1 $0x00
+3a434041 : ccmn w2, w3, #0x1, MI                     : ccmn.mi %w2 %w3 $0x01
+3a454082 : ccmn w4, w5, #0x2, MI                     : ccmn.mi %w4 %w5 $0x02
+3a4740c3 : ccmn w6, w7, #0x3, MI                     : ccmn.mi %w6 %w7 $0x03
+3a494104 : ccmn w8, w9, #0x4, MI                     : ccmn.mi %w8 %w9 $0x04
+3a4a4125 : ccmn w9, w10, #0x5, MI                    : ccmn.mi %w9 %w10 $0x05
+3a4c4166 : ccmn w11, w12, #0x6, MI                   : ccmn.mi %w11 %w12 $0x06
+3a4e41a7 : ccmn w13, w14, #0x7, MI                   : ccmn.mi %w13 %w14 $0x07
+3a5041e8 : ccmn w15, w16, #0x8, MI                   : ccmn.mi %w15 %w16 $0x08
+3a524228 : ccmn w17, w18, #0x8, MI                   : ccmn.mi %w17 %w18 $0x08
+3a544269 : ccmn w19, w20, #0x9, MI                   : ccmn.mi %w19 %w20 $0x09
+3a5642aa : ccmn w21, w22, #0xa, MI                   : ccmn.mi %w21 %w22 $0x0a
+3a5742cb : ccmn w22, w23, #0xb, MI                   : ccmn.mi %w22 %w23 $0x0b
+3a59430c : ccmn w24, w25, #0xc, MI                   : ccmn.mi %w24 %w25 $0x0c
+3a5b434d : ccmn w26, w27, #0xd, MI                   : ccmn.mi %w26 %w27 $0x0d
+3a4043cf : ccmn w30, w0, #0xf, MI                    : ccmn.mi %w30 %w0 $0x0f
+3a415000 : ccmn w0, w1, #0x0, PL                     : ccmn.pl %w0 %w1 $0x00
+3a435041 : ccmn w2, w3, #0x1, PL                     : ccmn.pl %w2 %w3 $0x01
+3a455082 : ccmn w4, w5, #0x2, PL                     : ccmn.pl %w4 %w5 $0x02
+3a4750c3 : ccmn w6, w7, #0x3, PL                     : ccmn.pl %w6 %w7 $0x03
+3a495104 : ccmn w8, w9, #0x4, PL                     : ccmn.pl %w8 %w9 $0x04
+3a4a5125 : ccmn w9, w10, #0x5, PL                    : ccmn.pl %w9 %w10 $0x05
+3a4c5166 : ccmn w11, w12, #0x6, PL                   : ccmn.pl %w11 %w12 $0x06
+3a4e51a7 : ccmn w13, w14, #0x7, PL                   : ccmn.pl %w13 %w14 $0x07
+3a5051e8 : ccmn w15, w16, #0x8, PL                   : ccmn.pl %w15 %w16 $0x08
+3a525228 : ccmn w17, w18, #0x8, PL                   : ccmn.pl %w17 %w18 $0x08
+3a545269 : ccmn w19, w20, #0x9, PL                   : ccmn.pl %w19 %w20 $0x09
+3a5652aa : ccmn w21, w22, #0xa, PL                   : ccmn.pl %w21 %w22 $0x0a
+3a5752cb : ccmn w22, w23, #0xb, PL                   : ccmn.pl %w22 %w23 $0x0b
+3a59530c : ccmn w24, w25, #0xc, PL                   : ccmn.pl %w24 %w25 $0x0c
+3a5b534d : ccmn w26, w27, #0xd, PL                   : ccmn.pl %w26 %w27 $0x0d
+3a4053cf : ccmn w30, w0, #0xf, PL                    : ccmn.pl %w30 %w0 $0x0f
+3a416000 : ccmn w0, w1, #0x0, VS                     : ccmn.vs %w0 %w1 $0x00
+3a436041 : ccmn w2, w3, #0x1, VS                     : ccmn.vs %w2 %w3 $0x01
+3a456082 : ccmn w4, w5, #0x2, VS                     : ccmn.vs %w4 %w5 $0x02
+3a4760c3 : ccmn w6, w7, #0x3, VS                     : ccmn.vs %w6 %w7 $0x03
+3a496104 : ccmn w8, w9, #0x4, VS                     : ccmn.vs %w8 %w9 $0x04
+3a4a6125 : ccmn w9, w10, #0x5, VS                    : ccmn.vs %w9 %w10 $0x05
+3a4c6166 : ccmn w11, w12, #0x6, VS                   : ccmn.vs %w11 %w12 $0x06
+3a4e61a7 : ccmn w13, w14, #0x7, VS                   : ccmn.vs %w13 %w14 $0x07
+3a5061e8 : ccmn w15, w16, #0x8, VS                   : ccmn.vs %w15 %w16 $0x08
+3a526228 : ccmn w17, w18, #0x8, VS                   : ccmn.vs %w17 %w18 $0x08
+3a546269 : ccmn w19, w20, #0x9, VS                   : ccmn.vs %w19 %w20 $0x09
+3a5662aa : ccmn w21, w22, #0xa, VS                   : ccmn.vs %w21 %w22 $0x0a
+3a5762cb : ccmn w22, w23, #0xb, VS                   : ccmn.vs %w22 %w23 $0x0b
+3a59630c : ccmn w24, w25, #0xc, VS                   : ccmn.vs %w24 %w25 $0x0c
+3a5b634d : ccmn w26, w27, #0xd, VS                   : ccmn.vs %w26 %w27 $0x0d
+3a4063cf : ccmn w30, w0, #0xf, VS                    : ccmn.vs %w30 %w0 $0x0f
+3a417000 : ccmn w0, w1, #0x0, VC                     : ccmn.vc %w0 %w1 $0x00
+3a437041 : ccmn w2, w3, #0x1, VC                     : ccmn.vc %w2 %w3 $0x01
+3a457082 : ccmn w4, w5, #0x2, VC                     : ccmn.vc %w4 %w5 $0x02
+3a4770c3 : ccmn w6, w7, #0x3, VC                     : ccmn.vc %w6 %w7 $0x03
+3a497104 : ccmn w8, w9, #0x4, VC                     : ccmn.vc %w8 %w9 $0x04
+3a4a7125 : ccmn w9, w10, #0x5, VC                    : ccmn.vc %w9 %w10 $0x05
+3a4c7166 : ccmn w11, w12, #0x6, VC                   : ccmn.vc %w11 %w12 $0x06
+3a4e71a7 : ccmn w13, w14, #0x7, VC                   : ccmn.vc %w13 %w14 $0x07
+3a5071e8 : ccmn w15, w16, #0x8, VC                   : ccmn.vc %w15 %w16 $0x08
+3a527228 : ccmn w17, w18, #0x8, VC                   : ccmn.vc %w17 %w18 $0x08
+3a547269 : ccmn w19, w20, #0x9, VC                   : ccmn.vc %w19 %w20 $0x09
+3a5672aa : ccmn w21, w22, #0xa, VC                   : ccmn.vc %w21 %w22 $0x0a
+3a5772cb : ccmn w22, w23, #0xb, VC                   : ccmn.vc %w22 %w23 $0x0b
+3a59730c : ccmn w24, w25, #0xc, VC                   : ccmn.vc %w24 %w25 $0x0c
+3a5b734d : ccmn w26, w27, #0xd, VC                   : ccmn.vc %w26 %w27 $0x0d
+3a4073cf : ccmn w30, w0, #0xf, VC                    : ccmn.vc %w30 %w0 $0x0f
+3a418000 : ccmn w0, w1, #0x0, HI                     : ccmn.hi %w0 %w1 $0x00
+3a438041 : ccmn w2, w3, #0x1, HI                     : ccmn.hi %w2 %w3 $0x01
+3a458082 : ccmn w4, w5, #0x2, HI                     : ccmn.hi %w4 %w5 $0x02
+3a4780c3 : ccmn w6, w7, #0x3, HI                     : ccmn.hi %w6 %w7 $0x03
+3a498104 : ccmn w8, w9, #0x4, HI                     : ccmn.hi %w8 %w9 $0x04
+3a4a8125 : ccmn w9, w10, #0x5, HI                    : ccmn.hi %w9 %w10 $0x05
+3a4c8166 : ccmn w11, w12, #0x6, HI                   : ccmn.hi %w11 %w12 $0x06
+3a4e81a7 : ccmn w13, w14, #0x7, HI                   : ccmn.hi %w13 %w14 $0x07
+3a5081e8 : ccmn w15, w16, #0x8, HI                   : ccmn.hi %w15 %w16 $0x08
+3a528228 : ccmn w17, w18, #0x8, HI                   : ccmn.hi %w17 %w18 $0x08
+3a548269 : ccmn w19, w20, #0x9, HI                   : ccmn.hi %w19 %w20 $0x09
+3a5682aa : ccmn w21, w22, #0xa, HI                   : ccmn.hi %w21 %w22 $0x0a
+3a5782cb : ccmn w22, w23, #0xb, HI                   : ccmn.hi %w22 %w23 $0x0b
+3a59830c : ccmn w24, w25, #0xc, HI                   : ccmn.hi %w24 %w25 $0x0c
+3a5b834d : ccmn w26, w27, #0xd, HI                   : ccmn.hi %w26 %w27 $0x0d
+3a4083cf : ccmn w30, w0, #0xf, HI                    : ccmn.hi %w30 %w0 $0x0f
+3a419000 : ccmn w0, w1, #0x0, LS                     : ccmn.ls %w0 %w1 $0x00
+3a439041 : ccmn w2, w3, #0x1, LS                     : ccmn.ls %w2 %w3 $0x01
+3a459082 : ccmn w4, w5, #0x2, LS                     : ccmn.ls %w4 %w5 $0x02
+3a4790c3 : ccmn w6, w7, #0x3, LS                     : ccmn.ls %w6 %w7 $0x03
+3a499104 : ccmn w8, w9, #0x4, LS                     : ccmn.ls %w8 %w9 $0x04
+3a4a9125 : ccmn w9, w10, #0x5, LS                    : ccmn.ls %w9 %w10 $0x05
+3a4c9166 : ccmn w11, w12, #0x6, LS                   : ccmn.ls %w11 %w12 $0x06
+3a4e91a7 : ccmn w13, w14, #0x7, LS                   : ccmn.ls %w13 %w14 $0x07
+3a5091e8 : ccmn w15, w16, #0x8, LS                   : ccmn.ls %w15 %w16 $0x08
+3a529228 : ccmn w17, w18, #0x8, LS                   : ccmn.ls %w17 %w18 $0x08
+3a549269 : ccmn w19, w20, #0x9, LS                   : ccmn.ls %w19 %w20 $0x09
+3a5692aa : ccmn w21, w22, #0xa, LS                   : ccmn.ls %w21 %w22 $0x0a
+3a5792cb : ccmn w22, w23, #0xb, LS                   : ccmn.ls %w22 %w23 $0x0b
+3a59930c : ccmn w24, w25, #0xc, LS                   : ccmn.ls %w24 %w25 $0x0c
+3a5b934d : ccmn w26, w27, #0xd, LS                   : ccmn.ls %w26 %w27 $0x0d
+3a4093cf : ccmn w30, w0, #0xf, LS                    : ccmn.ls %w30 %w0 $0x0f
+3a41a000 : ccmn w0, w1, #0x0, GE                     : ccmn.ge %w0 %w1 $0x00
+3a43a041 : ccmn w2, w3, #0x1, GE                     : ccmn.ge %w2 %w3 $0x01
+3a45a082 : ccmn w4, w5, #0x2, GE                     : ccmn.ge %w4 %w5 $0x02
+3a47a0c3 : ccmn w6, w7, #0x3, GE                     : ccmn.ge %w6 %w7 $0x03
+3a49a104 : ccmn w8, w9, #0x4, GE                     : ccmn.ge %w8 %w9 $0x04
+3a4aa125 : ccmn w9, w10, #0x5, GE                    : ccmn.ge %w9 %w10 $0x05
+3a4ca166 : ccmn w11, w12, #0x6, GE                   : ccmn.ge %w11 %w12 $0x06
+3a4ea1a7 : ccmn w13, w14, #0x7, GE                   : ccmn.ge %w13 %w14 $0x07
+3a50a1e8 : ccmn w15, w16, #0x8, GE                   : ccmn.ge %w15 %w16 $0x08
+3a52a228 : ccmn w17, w18, #0x8, GE                   : ccmn.ge %w17 %w18 $0x08
+3a54a269 : ccmn w19, w20, #0x9, GE                   : ccmn.ge %w19 %w20 $0x09
+3a56a2aa : ccmn w21, w22, #0xa, GE                   : ccmn.ge %w21 %w22 $0x0a
+3a57a2cb : ccmn w22, w23, #0xb, GE                   : ccmn.ge %w22 %w23 $0x0b
+3a59a30c : ccmn w24, w25, #0xc, GE                   : ccmn.ge %w24 %w25 $0x0c
+3a5ba34d : ccmn w26, w27, #0xd, GE                   : ccmn.ge %w26 %w27 $0x0d
+3a40a3cf : ccmn w30, w0, #0xf, GE                    : ccmn.ge %w30 %w0 $0x0f
+3a41b000 : ccmn w0, w1, #0x0, LT                     : ccmn.lt %w0 %w1 $0x00
+3a43b041 : ccmn w2, w3, #0x1, LT                     : ccmn.lt %w2 %w3 $0x01
+3a45b082 : ccmn w4, w5, #0x2, LT                     : ccmn.lt %w4 %w5 $0x02
+3a47b0c3 : ccmn w6, w7, #0x3, LT                     : ccmn.lt %w6 %w7 $0x03
+3a49b104 : ccmn w8, w9, #0x4, LT                     : ccmn.lt %w8 %w9 $0x04
+3a4ab125 : ccmn w9, w10, #0x5, LT                    : ccmn.lt %w9 %w10 $0x05
+3a4cb166 : ccmn w11, w12, #0x6, LT                   : ccmn.lt %w11 %w12 $0x06
+3a4eb1a7 : ccmn w13, w14, #0x7, LT                   : ccmn.lt %w13 %w14 $0x07
+3a50b1e8 : ccmn w15, w16, #0x8, LT                   : ccmn.lt %w15 %w16 $0x08
+3a52b228 : ccmn w17, w18, #0x8, LT                   : ccmn.lt %w17 %w18 $0x08
+3a54b269 : ccmn w19, w20, #0x9, LT                   : ccmn.lt %w19 %w20 $0x09
+3a56b2aa : ccmn w21, w22, #0xa, LT                   : ccmn.lt %w21 %w22 $0x0a
+3a57b2cb : ccmn w22, w23, #0xb, LT                   : ccmn.lt %w22 %w23 $0x0b
+3a59b30c : ccmn w24, w25, #0xc, LT                   : ccmn.lt %w24 %w25 $0x0c
+3a5bb34d : ccmn w26, w27, #0xd, LT                   : ccmn.lt %w26 %w27 $0x0d
+3a40b3cf : ccmn w30, w0, #0xf, LT                    : ccmn.lt %w30 %w0 $0x0f
+3a41c000 : ccmn w0, w1, #0x0, GT                     : ccmn.gt %w0 %w1 $0x00
+3a43c041 : ccmn w2, w3, #0x1, GT                     : ccmn.gt %w2 %w3 $0x01
+3a45c082 : ccmn w4, w5, #0x2, GT                     : ccmn.gt %w4 %w5 $0x02
+3a47c0c3 : ccmn w6, w7, #0x3, GT                     : ccmn.gt %w6 %w7 $0x03
+3a49c104 : ccmn w8, w9, #0x4, GT                     : ccmn.gt %w8 %w9 $0x04
+3a4ac125 : ccmn w9, w10, #0x5, GT                    : ccmn.gt %w9 %w10 $0x05
+3a4cc166 : ccmn w11, w12, #0x6, GT                   : ccmn.gt %w11 %w12 $0x06
+3a4ec1a7 : ccmn w13, w14, #0x7, GT                   : ccmn.gt %w13 %w14 $0x07
+3a50c1e8 : ccmn w15, w16, #0x8, GT                   : ccmn.gt %w15 %w16 $0x08
+3a52c228 : ccmn w17, w18, #0x8, GT                   : ccmn.gt %w17 %w18 $0x08
+3a54c269 : ccmn w19, w20, #0x9, GT                   : ccmn.gt %w19 %w20 $0x09
+3a56c2aa : ccmn w21, w22, #0xa, GT                   : ccmn.gt %w21 %w22 $0x0a
+3a57c2cb : ccmn w22, w23, #0xb, GT                   : ccmn.gt %w22 %w23 $0x0b
+3a59c30c : ccmn w24, w25, #0xc, GT                   : ccmn.gt %w24 %w25 $0x0c
+3a5bc34d : ccmn w26, w27, #0xd, GT                   : ccmn.gt %w26 %w27 $0x0d
+3a40c3cf : ccmn w30, w0, #0xf, GT                    : ccmn.gt %w30 %w0 $0x0f
+3a41d000 : ccmn w0, w1, #0x0, LE                     : ccmn.le %w0 %w1 $0x00
+3a43d041 : ccmn w2, w3, #0x1, LE                     : ccmn.le %w2 %w3 $0x01
+3a45d082 : ccmn w4, w5, #0x2, LE                     : ccmn.le %w4 %w5 $0x02
+3a47d0c3 : ccmn w6, w7, #0x3, LE                     : ccmn.le %w6 %w7 $0x03
+3a49d104 : ccmn w8, w9, #0x4, LE                     : ccmn.le %w8 %w9 $0x04
+3a4ad125 : ccmn w9, w10, #0x5, LE                    : ccmn.le %w9 %w10 $0x05
+3a4cd166 : ccmn w11, w12, #0x6, LE                   : ccmn.le %w11 %w12 $0x06
+3a4ed1a7 : ccmn w13, w14, #0x7, LE                   : ccmn.le %w13 %w14 $0x07
+3a50d1e8 : ccmn w15, w16, #0x8, LE                   : ccmn.le %w15 %w16 $0x08
+3a52d228 : ccmn w17, w18, #0x8, LE                   : ccmn.le %w17 %w18 $0x08
+3a54d269 : ccmn w19, w20, #0x9, LE                   : ccmn.le %w19 %w20 $0x09
+3a56d2aa : ccmn w21, w22, #0xa, LE                   : ccmn.le %w21 %w22 $0x0a
+3a57d2cb : ccmn w22, w23, #0xb, LE                   : ccmn.le %w22 %w23 $0x0b
+3a59d30c : ccmn w24, w25, #0xc, LE                   : ccmn.le %w24 %w25 $0x0c
+3a5bd34d : ccmn w26, w27, #0xd, LE                   : ccmn.le %w26 %w27 $0x0d
+3a40d3cf : ccmn w30, w0, #0xf, LE                    : ccmn.le %w30 %w0 $0x0f
+3a41e000 : ccmn w0, w1, #0x0, AL                     : ccmn.al %w0 %w1 $0x00
+3a43e041 : ccmn w2, w3, #0x1, AL                     : ccmn.al %w2 %w3 $0x01
+3a45e082 : ccmn w4, w5, #0x2, AL                     : ccmn.al %w4 %w5 $0x02
+3a47e0c3 : ccmn w6, w7, #0x3, AL                     : ccmn.al %w6 %w7 $0x03
+3a49e104 : ccmn w8, w9, #0x4, AL                     : ccmn.al %w8 %w9 $0x04
+3a4ae125 : ccmn w9, w10, #0x5, AL                    : ccmn.al %w9 %w10 $0x05
+3a4ce166 : ccmn w11, w12, #0x6, AL                   : ccmn.al %w11 %w12 $0x06
+3a4ee1a7 : ccmn w13, w14, #0x7, AL                   : ccmn.al %w13 %w14 $0x07
+3a50e1e8 : ccmn w15, w16, #0x8, AL                   : ccmn.al %w15 %w16 $0x08
+3a52e228 : ccmn w17, w18, #0x8, AL                   : ccmn.al %w17 %w18 $0x08
+3a54e269 : ccmn w19, w20, #0x9, AL                   : ccmn.al %w19 %w20 $0x09
+3a56e2aa : ccmn w21, w22, #0xa, AL                   : ccmn.al %w21 %w22 $0x0a
+3a57e2cb : ccmn w22, w23, #0xb, AL                   : ccmn.al %w22 %w23 $0x0b
+3a59e30c : ccmn w24, w25, #0xc, AL                   : ccmn.al %w24 %w25 $0x0c
+3a5be34d : ccmn w26, w27, #0xd, AL                   : ccmn.al %w26 %w27 $0x0d
+3a40e3cf : ccmn w30, w0, #0xf, AL                    : ccmn.al %w30 %w0 $0x0f
+3a41f000 : ccmn w0, w1, #0x0, NV                     : ccmn.nv %w0 %w1 $0x00
+3a43f041 : ccmn w2, w3, #0x1, NV                     : ccmn.nv %w2 %w3 $0x01
+3a45f082 : ccmn w4, w5, #0x2, NV                     : ccmn.nv %w4 %w5 $0x02
+3a47f0c3 : ccmn w6, w7, #0x3, NV                     : ccmn.nv %w6 %w7 $0x03
+3a49f104 : ccmn w8, w9, #0x4, NV                     : ccmn.nv %w8 %w9 $0x04
+3a4af125 : ccmn w9, w10, #0x5, NV                    : ccmn.nv %w9 %w10 $0x05
+3a4cf166 : ccmn w11, w12, #0x6, NV                   : ccmn.nv %w11 %w12 $0x06
+3a4ef1a7 : ccmn w13, w14, #0x7, NV                   : ccmn.nv %w13 %w14 $0x07
+3a50f1e8 : ccmn w15, w16, #0x8, NV                   : ccmn.nv %w15 %w16 $0x08
+3a52f228 : ccmn w17, w18, #0x8, NV                   : ccmn.nv %w17 %w18 $0x08
+3a54f269 : ccmn w19, w20, #0x9, NV                   : ccmn.nv %w19 %w20 $0x09
+3a56f2aa : ccmn w21, w22, #0xa, NV                   : ccmn.nv %w21 %w22 $0x0a
+3a57f2cb : ccmn w22, w23, #0xb, NV                   : ccmn.nv %w22 %w23 $0x0b
+3a59f30c : ccmn w24, w25, #0xc, NV                   : ccmn.nv %w24 %w25 $0x0c
+3a5bf34d : ccmn w26, w27, #0xd, NV                   : ccmn.nv %w26 %w27 $0x0d
+3a40f3cf : ccmn w30, w0, #0xf, NV                    : ccmn.nv %w30 %w0 $0x0f
+
+# EON     <Xd>, <Xn>, <Xm>, <extend> #<imm> (EON-R.RRI-64_log_shift)
+ca220020 : eon x0, x1, x2, LSL #0                    : eon    %x1 %x2 lsl $0x00 -> %x0
+ca240862 : eon x2, x3, x4, LSL #2                    : eon    %x3 %x4 lsl $0x02 -> %x2
+ca2610a4 : eon x4, x5, x6, LSL #4                    : eon    %x5 %x6 lsl $0x04 -> %x4
+ca2818e6 : eon x6, x7, x8, LSL #6                    : eon    %x7 %x8 lsl $0x06 -> %x6
+ca2a2128 : eon x8, x9, x10, LSL #8                   : eon    %x9 %x10 lsl $0x08 -> %x8
+ca2b2949 : eon x9, x10, x11, LSL #10                 : eon    %x10 %x11 lsl $0x0a -> %x9
+ca2d318b : eon x11, x12, x13, LSL #12                : eon    %x12 %x13 lsl $0x0c -> %x11
+ca2f39cd : eon x13, x14, x15, LSL #14                : eon    %x14 %x15 lsl $0x0e -> %x13
+ca31420f : eon x15, x16, x17, LSL #16                : eon    %x16 %x17 lsl $0x10 -> %x15
+ca334651 : eon x17, x18, x19, LSL #17                : eon    %x18 %x19 lsl $0x11 -> %x17
+ca354e93 : eon x19, x20, x21, LSL #19                : eon    %x20 %x21 lsl $0x13 -> %x19
+ca3756d5 : eon x21, x22, x23, LSL #21                : eon    %x22 %x23 lsl $0x15 -> %x21
+ca385ef6 : eon x22, x23, x24, LSL #23                : eon    %x23 %x24 lsl $0x17 -> %x22
+ca3a6738 : eon x24, x25, x26, LSL #25                : eon    %x25 %x26 lsl $0x19 -> %x24
+ca3c6f7a : eon x26, x27, x28, LSL #27                : eon    %x27 %x28 lsl $0x1b -> %x26
+ca217c1e : eon x30, x0, x1, LSL #31                  : eon    %x0 %x1 lsl $0x1f -> %x30
+ca620020 : eon x0, x1, x2, LSR #0                    : eon    %x1 %x2 lsr $0x00 -> %x0
+ca640862 : eon x2, x3, x4, LSR #2                    : eon    %x3 %x4 lsr $0x02 -> %x2
+ca6610a4 : eon x4, x5, x6, LSR #4                    : eon    %x5 %x6 lsr $0x04 -> %x4
+ca6818e6 : eon x6, x7, x8, LSR #6                    : eon    %x7 %x8 lsr $0x06 -> %x6
+ca6a2128 : eon x8, x9, x10, LSR #8                   : eon    %x9 %x10 lsr $0x08 -> %x8
+ca6b2949 : eon x9, x10, x11, LSR #10                 : eon    %x10 %x11 lsr $0x0a -> %x9
+ca6d318b : eon x11, x12, x13, LSR #12                : eon    %x12 %x13 lsr $0x0c -> %x11
+ca6f39cd : eon x13, x14, x15, LSR #14                : eon    %x14 %x15 lsr $0x0e -> %x13
+ca71420f : eon x15, x16, x17, LSR #16                : eon    %x16 %x17 lsr $0x10 -> %x15
+ca734651 : eon x17, x18, x19, LSR #17                : eon    %x18 %x19 lsr $0x11 -> %x17
+ca754e93 : eon x19, x20, x21, LSR #19                : eon    %x20 %x21 lsr $0x13 -> %x19
+ca7756d5 : eon x21, x22, x23, LSR #21                : eon    %x22 %x23 lsr $0x15 -> %x21
+ca785ef6 : eon x22, x23, x24, LSR #23                : eon    %x23 %x24 lsr $0x17 -> %x22
+ca7a6738 : eon x24, x25, x26, LSR #25                : eon    %x25 %x26 lsr $0x19 -> %x24
+ca7c6f7a : eon x26, x27, x28, LSR #27                : eon    %x27 %x28 lsr $0x1b -> %x26
+ca617c1e : eon x30, x0, x1, LSR #31                  : eon    %x0 %x1 lsr $0x1f -> %x30
+caa20020 : eon x0, x1, x2, ASR #0                    : eon    %x1 %x2 asr $0x00 -> %x0
+caa40862 : eon x2, x3, x4, ASR #2                    : eon    %x3 %x4 asr $0x02 -> %x2
+caa610a4 : eon x4, x5, x6, ASR #4                    : eon    %x5 %x6 asr $0x04 -> %x4
+caa818e6 : eon x6, x7, x8, ASR #6                    : eon    %x7 %x8 asr $0x06 -> %x6
+caaa2128 : eon x8, x9, x10, ASR #8                   : eon    %x9 %x10 asr $0x08 -> %x8
+caab2949 : eon x9, x10, x11, ASR #10                 : eon    %x10 %x11 asr $0x0a -> %x9
+caad318b : eon x11, x12, x13, ASR #12                : eon    %x12 %x13 asr $0x0c -> %x11
+caaf39cd : eon x13, x14, x15, ASR #14                : eon    %x14 %x15 asr $0x0e -> %x13
+cab1420f : eon x15, x16, x17, ASR #16                : eon    %x16 %x17 asr $0x10 -> %x15
+cab34651 : eon x17, x18, x19, ASR #17                : eon    %x18 %x19 asr $0x11 -> %x17
+cab54e93 : eon x19, x20, x21, ASR #19                : eon    %x20 %x21 asr $0x13 -> %x19
+cab756d5 : eon x21, x22, x23, ASR #21                : eon    %x22 %x23 asr $0x15 -> %x21
+cab85ef6 : eon x22, x23, x24, ASR #23                : eon    %x23 %x24 asr $0x17 -> %x22
+caba6738 : eon x24, x25, x26, ASR #25                : eon    %x25 %x26 asr $0x19 -> %x24
+cabc6f7a : eon x26, x27, x28, ASR #27                : eon    %x27 %x28 asr $0x1b -> %x26
+caa17c1e : eon x30, x0, x1, ASR #31                  : eon    %x0 %x1 asr $0x1f -> %x30
+cae20020 : eon x0, x1, x2, ROR #0                    : eon    %x1 %x2 ror $0x00 -> %x0
+cae40862 : eon x2, x3, x4, ROR #2                    : eon    %x3 %x4 ror $0x02 -> %x2
+cae610a4 : eon x4, x5, x6, ROR #4                    : eon    %x5 %x6 ror $0x04 -> %x4
+cae818e6 : eon x6, x7, x8, ROR #6                    : eon    %x7 %x8 ror $0x06 -> %x6
+caea2128 : eon x8, x9, x10, ROR #8                   : eon    %x9 %x10 ror $0x08 -> %x8
+caeb2949 : eon x9, x10, x11, ROR #10                 : eon    %x10 %x11 ror $0x0a -> %x9
+caed318b : eon x11, x12, x13, ROR #12                : eon    %x12 %x13 ror $0x0c -> %x11
+caef39cd : eon x13, x14, x15, ROR #14                : eon    %x14 %x15 ror $0x0e -> %x13
+caf1420f : eon x15, x16, x17, ROR #16                : eon    %x16 %x17 ror $0x10 -> %x15
+caf34651 : eon x17, x18, x19, ROR #17                : eon    %x18 %x19 ror $0x11 -> %x17
+caf54e93 : eon x19, x20, x21, ROR #19                : eon    %x20 %x21 ror $0x13 -> %x19
+caf756d5 : eon x21, x22, x23, ROR #21                : eon    %x22 %x23 ror $0x15 -> %x21
+caf85ef6 : eon x22, x23, x24, ROR #23                : eon    %x23 %x24 ror $0x17 -> %x22
+cafa6738 : eon x24, x25, x26, ROR #25                : eon    %x25 %x26 ror $0x19 -> %x24
+cafc6f7a : eon x26, x27, x28, ROR #27                : eon    %x27 %x28 ror $0x1b -> %x26
+cae17c1e : eon x30, x0, x1, ROR #31                  : eon    %x0 %x1 ror $0x1f -> %x30
+
+# RBIT    <Wd>, <Wn> (RBIT-R.R-32_dp_1src)
+5ac00020 : rbit w0, w1                               : rbit   %w1 -> %w0
+5ac00062 : rbit w2, w3                               : rbit   %w3 -> %w2
+5ac000a4 : rbit w4, w5                               : rbit   %w5 -> %w4
+5ac000e6 : rbit w6, w7                               : rbit   %w7 -> %w6
+5ac00128 : rbit w8, w9                               : rbit   %w9 -> %w8
+5ac00149 : rbit w9, w10                              : rbit   %w10 -> %w9
+5ac0018b : rbit w11, w12                             : rbit   %w12 -> %w11
+5ac001cd : rbit w13, w14                             : rbit   %w14 -> %w13
+5ac0020f : rbit w15, w16                             : rbit   %w16 -> %w15
+5ac00251 : rbit w17, w18                             : rbit   %w18 -> %w17
+5ac00293 : rbit w19, w20                             : rbit   %w20 -> %w19
+5ac002d5 : rbit w21, w22                             : rbit   %w22 -> %w21
+5ac002f6 : rbit w22, w23                             : rbit   %w23 -> %w22
+5ac00338 : rbit w24, w25                             : rbit   %w25 -> %w24
+5ac0037a : rbit w26, w27                             : rbit   %w27 -> %w26
+5ac0001e : rbit w30, w0                              : rbit   %w0 -> %w30
+
+# ORN     <Xd>, <Xn>, <Xm>, <extend> #<imm> (ORN-R.RRI-64_log_shift)
+aa220020 : orn x0, x1, x2, LSL #0                    : orn    %x1 %x2 lsl $0x00 -> %x0
+aa240862 : orn x2, x3, x4, LSL #2                    : orn    %x3 %x4 lsl $0x02 -> %x2
+aa2610a4 : orn x4, x5, x6, LSL #4                    : orn    %x5 %x6 lsl $0x04 -> %x4
+aa2818e6 : orn x6, x7, x8, LSL #6                    : orn    %x7 %x8 lsl $0x06 -> %x6
+aa2a2128 : orn x8, x9, x10, LSL #8                   : orn    %x9 %x10 lsl $0x08 -> %x8
+aa2b2949 : orn x9, x10, x11, LSL #10                 : orn    %x10 %x11 lsl $0x0a -> %x9
+aa2d318b : orn x11, x12, x13, LSL #12                : orn    %x12 %x13 lsl $0x0c -> %x11
+aa2f39cd : orn x13, x14, x15, LSL #14                : orn    %x14 %x15 lsl $0x0e -> %x13
+aa31420f : orn x15, x16, x17, LSL #16                : orn    %x16 %x17 lsl $0x10 -> %x15
+aa334651 : orn x17, x18, x19, LSL #17                : orn    %x18 %x19 lsl $0x11 -> %x17
+aa354e93 : orn x19, x20, x21, LSL #19                : orn    %x20 %x21 lsl $0x13 -> %x19
+aa3756d5 : orn x21, x22, x23, LSL #21                : orn    %x22 %x23 lsl $0x15 -> %x21
+aa385ef6 : orn x22, x23, x24, LSL #23                : orn    %x23 %x24 lsl $0x17 -> %x22
+aa3a6738 : orn x24, x25, x26, LSL #25                : orn    %x25 %x26 lsl $0x19 -> %x24
+aa3c6f7a : orn x26, x27, x28, LSL #27                : orn    %x27 %x28 lsl $0x1b -> %x26
+aa217c1e : orn x30, x0, x1, LSL #31                  : orn    %x0 %x1 lsl $0x1f -> %x30
+aa620020 : orn x0, x1, x2, LSR #0                    : orn    %x1 %x2 lsr $0x00 -> %x0
+aa640862 : orn x2, x3, x4, LSR #2                    : orn    %x3 %x4 lsr $0x02 -> %x2
+aa6610a4 : orn x4, x5, x6, LSR #4                    : orn    %x5 %x6 lsr $0x04 -> %x4
+aa6818e6 : orn x6, x7, x8, LSR #6                    : orn    %x7 %x8 lsr $0x06 -> %x6
+aa6a2128 : orn x8, x9, x10, LSR #8                   : orn    %x9 %x10 lsr $0x08 -> %x8
+aa6b2949 : orn x9, x10, x11, LSR #10                 : orn    %x10 %x11 lsr $0x0a -> %x9
+aa6d318b : orn x11, x12, x13, LSR #12                : orn    %x12 %x13 lsr $0x0c -> %x11
+aa6f39cd : orn x13, x14, x15, LSR #14                : orn    %x14 %x15 lsr $0x0e -> %x13
+aa71420f : orn x15, x16, x17, LSR #16                : orn    %x16 %x17 lsr $0x10 -> %x15
+aa734651 : orn x17, x18, x19, LSR #17                : orn    %x18 %x19 lsr $0x11 -> %x17
+aa754e93 : orn x19, x20, x21, LSR #19                : orn    %x20 %x21 lsr $0x13 -> %x19
+aa7756d5 : orn x21, x22, x23, LSR #21                : orn    %x22 %x23 lsr $0x15 -> %x21
+aa785ef6 : orn x22, x23, x24, LSR #23                : orn    %x23 %x24 lsr $0x17 -> %x22
+aa7a6738 : orn x24, x25, x26, LSR #25                : orn    %x25 %x26 lsr $0x19 -> %x24
+aa7c6f7a : orn x26, x27, x28, LSR #27                : orn    %x27 %x28 lsr $0x1b -> %x26
+aa617c1e : orn x30, x0, x1, LSR #31                  : orn    %x0 %x1 lsr $0x1f -> %x30
+aaa20020 : orn x0, x1, x2, ASR #0                    : orn    %x1 %x2 asr $0x00 -> %x0
+aaa40862 : orn x2, x3, x4, ASR #2                    : orn    %x3 %x4 asr $0x02 -> %x2
+aaa610a4 : orn x4, x5, x6, ASR #4                    : orn    %x5 %x6 asr $0x04 -> %x4
+aaa818e6 : orn x6, x7, x8, ASR #6                    : orn    %x7 %x8 asr $0x06 -> %x6
+aaaa2128 : orn x8, x9, x10, ASR #8                   : orn    %x9 %x10 asr $0x08 -> %x8
+aaab2949 : orn x9, x10, x11, ASR #10                 : orn    %x10 %x11 asr $0x0a -> %x9
+aaad318b : orn x11, x12, x13, ASR #12                : orn    %x12 %x13 asr $0x0c -> %x11
+aaaf39cd : orn x13, x14, x15, ASR #14                : orn    %x14 %x15 asr $0x0e -> %x13
+aab1420f : orn x15, x16, x17, ASR #16                : orn    %x16 %x17 asr $0x10 -> %x15
+aab34651 : orn x17, x18, x19, ASR #17                : orn    %x18 %x19 asr $0x11 -> %x17
+aab54e93 : orn x19, x20, x21, ASR #19                : orn    %x20 %x21 asr $0x13 -> %x19
+aab756d5 : orn x21, x22, x23, ASR #21                : orn    %x22 %x23 asr $0x15 -> %x21
+aab85ef6 : orn x22, x23, x24, ASR #23                : orn    %x23 %x24 asr $0x17 -> %x22
+aaba6738 : orn x24, x25, x26, ASR #25                : orn    %x25 %x26 asr $0x19 -> %x24
+aabc6f7a : orn x26, x27, x28, ASR #27                : orn    %x27 %x28 asr $0x1b -> %x26
+aaa17c1e : orn x30, x0, x1, ASR #31                  : orn    %x0 %x1 asr $0x1f -> %x30
+aae20020 : orn x0, x1, x2, ROR #0                    : orn    %x1 %x2 ror $0x00 -> %x0
+aae40862 : orn x2, x3, x4, ROR #2                    : orn    %x3 %x4 ror $0x02 -> %x2
+aae610a4 : orn x4, x5, x6, ROR #4                    : orn    %x5 %x6 ror $0x04 -> %x4
+aae818e6 : orn x6, x7, x8, ROR #6                    : orn    %x7 %x8 ror $0x06 -> %x6
+aaea2128 : orn x8, x9, x10, ROR #8                   : orn    %x9 %x10 ror $0x08 -> %x8
+aaeb2949 : orn x9, x10, x11, ROR #10                 : orn    %x10 %x11 ror $0x0a -> %x9
+aaed318b : orn x11, x12, x13, ROR #12                : orn    %x12 %x13 ror $0x0c -> %x11
+aaef39cd : orn x13, x14, x15, ROR #14                : orn    %x14 %x15 ror $0x0e -> %x13
+aaf1420f : orn x15, x16, x17, ROR #16                : orn    %x16 %x17 ror $0x10 -> %x15
+aaf34651 : orn x17, x18, x19, ROR #17                : orn    %x18 %x19 ror $0x11 -> %x17
+aaf54e93 : orn x19, x20, x21, ROR #19                : orn    %x20 %x21 ror $0x13 -> %x19
+aaf756d5 : orn x21, x22, x23, ROR #21                : orn    %x22 %x23 ror $0x15 -> %x21
+aaf85ef6 : orn x22, x23, x24, ROR #23                : orn    %x23 %x24 ror $0x17 -> %x22
+aafa6738 : orn x24, x25, x26, ROR #25                : orn    %x25 %x26 ror $0x19 -> %x24
+aafc6f7a : orn x26, x27, x28, ROR #27                : orn    %x27 %x28 ror $0x1b -> %x26
+aae17c1e : orn x30, x0, x1, ROR #31                  : orn    %x0 %x1 ror $0x1f -> %x30
+
+# REV     <Xd>, <Xn> (REV-R.R-64_dp_1src)
+dac00c20 : rev x0, x1                                : rev    %x1 -> %x0
+dac00c62 : rev x2, x3                                : rev    %x3 -> %x2
+dac00ca4 : rev x4, x5                                : rev    %x5 -> %x4
+dac00ce6 : rev x6, x7                                : rev    %x7 -> %x6
+dac00d28 : rev x8, x9                                : rev    %x9 -> %x8
+dac00d49 : rev x9, x10                               : rev    %x10 -> %x9
+dac00d8b : rev x11, x12                              : rev    %x12 -> %x11
+dac00dcd : rev x13, x14                              : rev    %x14 -> %x13
+dac00e0f : rev x15, x16                              : rev    %x16 -> %x15
+dac00e51 : rev x17, x18                              : rev    %x18 -> %x17
+dac00e93 : rev x19, x20                              : rev    %x20 -> %x19
+dac00ed5 : rev x21, x22                              : rev    %x22 -> %x21
+dac00ef6 : rev x22, x23                              : rev    %x23 -> %x22
+dac00f38 : rev x24, x25                              : rev    %x25 -> %x24
+dac00f7a : rev x26, x27                              : rev    %x27 -> %x26
+dac00c1e : rev x30, x0                               : rev    %x0 -> %x30
+
+# LSRV    <Xd>, <Xn>, <Xm> (LSRV-R.RR-64_dp_2src)
+9ac22420 : lsrv x0, x1, x2                           : lsrv   %x1 %x2 -> %x0
+9ac42462 : lsrv x2, x3, x4                           : lsrv   %x3 %x4 -> %x2
+9ac624a4 : lsrv x4, x5, x6                           : lsrv   %x5 %x6 -> %x4
+9ac824e6 : lsrv x6, x7, x8                           : lsrv   %x7 %x8 -> %x6
+9aca2528 : lsrv x8, x9, x10                          : lsrv   %x9 %x10 -> %x8
+9acb2549 : lsrv x9, x10, x11                         : lsrv   %x10 %x11 -> %x9
+9acd258b : lsrv x11, x12, x13                        : lsrv   %x12 %x13 -> %x11
+9acf25cd : lsrv x13, x14, x15                        : lsrv   %x14 %x15 -> %x13
+9ad1260f : lsrv x15, x16, x17                        : lsrv   %x16 %x17 -> %x15
+9ad32651 : lsrv x17, x18, x19                        : lsrv   %x18 %x19 -> %x17
+9ad52693 : lsrv x19, x20, x21                        : lsrv   %x20 %x21 -> %x19
+9ad726d5 : lsrv x21, x22, x23                        : lsrv   %x22 %x23 -> %x21
+9ad826f6 : lsrv x22, x23, x24                        : lsrv   %x23 %x24 -> %x22
+9ada2738 : lsrv x24, x25, x26                        : lsrv   %x25 %x26 -> %x24
+9adc277a : lsrv x26, x27, x28                        : lsrv   %x27 %x28 -> %x26
+9ac1241e : lsrv x30, x0, x1                          : lsrv   %x0 %x1 -> %x30
+
+# REV16   <Wd>, <Wn> (REV16-R.R-32_dp_1src)
+5ac00420 : rev16 w0, w1                              : rev16  %w1 -> %w0
+5ac00462 : rev16 w2, w3                              : rev16  %w3 -> %w2
+5ac004a4 : rev16 w4, w5                              : rev16  %w5 -> %w4
+5ac004e6 : rev16 w6, w7                              : rev16  %w7 -> %w6
+5ac00528 : rev16 w8, w9                              : rev16  %w9 -> %w8
+5ac00549 : rev16 w9, w10                             : rev16  %w10 -> %w9
+5ac0058b : rev16 w11, w12                            : rev16  %w12 -> %w11
+5ac005cd : rev16 w13, w14                            : rev16  %w14 -> %w13
+5ac0060f : rev16 w15, w16                            : rev16  %w16 -> %w15
+5ac00651 : rev16 w17, w18                            : rev16  %w18 -> %w17
+5ac00693 : rev16 w19, w20                            : rev16  %w20 -> %w19
+5ac006d5 : rev16 w21, w22                            : rev16  %w22 -> %w21
+5ac006f6 : rev16 w22, w23                            : rev16  %w23 -> %w22
+5ac00738 : rev16 w24, w25                            : rev16  %w25 -> %w24
+5ac0077a : rev16 w26, w27                            : rev16  %w27 -> %w26
+5ac0041e : rev16 w30, w0                             : rev16  %w0 -> %w30
+
+# UMSUBL  <Xd>, <Wn>, <Wm>, <Xa> (UMSUBL-R.RRR-64WA_dp_3src)
+9ba28c20 : umsubl x0, w1, w2, x3                     : umsubl %w1 %w2 %x3 -> %x0
+9ba49462 : umsubl x2, w3, w4, x5                     : umsubl %w3 %w4 %x5 -> %x2
+9ba69ca4 : umsubl x4, w5, w6, x7                     : umsubl %w5 %w6 %x7 -> %x4
+9ba8a4e6 : umsubl x6, w7, w8, x9                     : umsubl %w7 %w8 %x9 -> %x6
+9baaad28 : umsubl x8, w9, w10, x11                   : umsubl %w9 %w10 %x11 -> %x8
+9babb149 : umsubl x9, w10, w11, x12                  : umsubl %w10 %w11 %x12 -> %x9
+9badb98b : umsubl x11, w12, w13, x14                 : umsubl %w12 %w13 %x14 -> %x11
+9bafc1cd : umsubl x13, w14, w15, x16                 : umsubl %w14 %w15 %x16 -> %x13
+9bb1ca0f : umsubl x15, w16, w17, x18                 : umsubl %w16 %w17 %x18 -> %x15
+9bb3d251 : umsubl x17, w18, w19, x20                 : umsubl %w18 %w19 %x20 -> %x17
+9bb5da93 : umsubl x19, w20, w21, x22                 : umsubl %w20 %w21 %x22 -> %x19
+9bb7e2d5 : umsubl x21, w22, w23, x24                 : umsubl %w22 %w23 %x24 -> %x21
+9bb8e6f6 : umsubl x22, w23, w24, x25                 : umsubl %w23 %w24 %x25 -> %x22
+9bbaef38 : umsubl x24, w25, w26, x27                 : umsubl %w25 %w26 %x27 -> %x24
+9bbcf77a : umsubl x26, w27, w28, x29                 : umsubl %w27 %w28 %x29 -> %x26
+9ba1881e : umsubl x30, w0, w1, x2                    : umsubl %w0 %w1 %x2 -> %x30
+
+# ANDS    <Xd>, <Xn>, #<imm> (ANDS-R.RI-64S_log_imm)
+f2000020 : ands x0, x1, #0x100000001                 : ands   %x1 $0x0000000100000001 -> %x0
+f2040062 : ands x2, x3, #0x1000000010000000          : ands   %x3 $0x1000000010000000 -> %x2
+f20800a4 : ands x4, x5, #0x100000001000000           : ands   %x5 $0x0100000001000000 -> %x4
+f20c00e6 : ands x6, x7, #0x10000000100000            : ands   %x7 $0x0010000000100000 -> %x6
+f2100128 : ands x8, x9, #0x1000000010000             : ands   %x9 $0x0001000000010000 -> %x8
+f2140149 : ands x9, x10, #0x100000001000             : ands   %x10 $0x0000100000001000 -> %x9
+f218018b : ands x11, x12, #0x10000000100             : ands   %x12 $0x0000010000000100 -> %x11
+f21c01cd : ands x13, x14, #0x1000000010              : ands   %x14 $0x0000001000000010 -> %x13
+f200020f : ands x15, x16, #0x100000001               : ands   %x16 $0x0000000100000001 -> %x15
+f203ea51 : ands x17, x18, #0xeeeeeeeeeeeeeeee        : ands   %x18 $0xeeeeeeeeeeeeeeee -> %x17
+f203ea93 : ands x19, x20, #0xeeeeeeeeeeeeeeee        : ands   %x20 $0xeeeeeeeeeeeeeeee -> %x19
+f203ead5 : ands x21, x22, #0xeeeeeeeeeeeeeeee        : ands   %x22 $0xeeeeeeeeeeeeeeee -> %x21
+f203eaf6 : ands x22, x23, #0xeeeeeeeeeeeeeeee        : ands   %x23 $0xeeeeeeeeeeeeeeee -> %x22
+f203eb38 : ands x24, x25, #0xeeeeeeeeeeeeeeee        : ands   %x25 $0xeeeeeeeeeeeeeeee -> %x24
+f203eb7a : ands x26, x27, #0xeeeeeeeeeeeeeeee        : ands   %x27 $0xeeeeeeeeeeeeeeee -> %x26
+f203e81e : ands x30, x0, #0xeeeeeeeeeeeeeeee         : ands   %x0 $0xeeeeeeeeeeeeeeee -> %x30


### PR DESCRIPTION
As part of #2626, exhaustive tests for the instructions that use GPR
registers have been generated. Some of these tests have revealed issues
with the current implementation of several of these instructions. This
patch is the first of several and contains all of the tests that validate
existing instructions as correct.

issues: #2626