### PR TITLE
i#5130: improve glibc import checks and make them optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,11 @@ endif (UNIX)
 
 # many are core-specific
 
+# whether this build of DynamoRIO is meant for distribution, in which case
+# glibc should not have any too-recent imports. See core/CMake_readelf.cmake
+# for more information.
+option(BUILD_PACKAGE "build DynamoRIO for packaging purposes by performing glibc checks" ON)
+
 # configurations that also have defines
 option(DRSTATS_DEMO "build DRstats without the no-longer-supported Run, etc. controls" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,8 +145,9 @@ endif (UNIX)
 
 # whether this build of DynamoRIO is meant for distribution, in which case
 # glibc should not have any too-recent imports. See core/CMake_readelf.cmake
-# for more information.
-option(BUILD_PACKAGE "build DynamoRIO for packaging purposes by performing glibc checks" ON)
+# for more information. This is off by default, but gets set by
+# make/package.cmake.
+option(BUILD_PACKAGE "build DynamoRIO for packaging purposes by performing glibc checks" OFF)
 
 # configurations that also have defines
 option(DRSTATS_DEMO "build DRstats without the no-longer-supported Run, etc. controls" ON)

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -131,7 +131,6 @@ changes:
    from source is straight-forward to do on rolling release Linux
    distributions, and enabled by make/package.cmake when building a
    distributable version of DynamoRIO.
- - (Nothing so far: this is a placeholder.)
 
 Further non-compatibility-affecting changes include:
  - Added alias support to droption.

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -126,6 +126,11 @@ clients.
 
 The changes between version \DR_VERSION and 9.0.0 include the following compatibility
 changes:
+ - Introduced a new CMake option called BUILD_PACKAGE to skip glibc
+   compatibility checks. This is off by default such that building DynamoRIO
+   from source is straight-forward to do on rolling release Linux
+   distributions, and enabled by make/package.cmake when building a
+   distributable version of DynamoRIO.
  - (Nothing so far: this is a placeholder.)
 
 Further non-compatibility-affecting changes include:

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -661,7 +661,7 @@ if (UNIX)
         ARGS -D lib_fileloc=${CMAKE_CURRENT_BINARY_DIR}/${locvar_name}
              -D check_textrel=${check_textrel}
              -D check_deps=${check_deps}
-             -D check_libc=OFF
+             -D check_libc=${BUILD_PACKAGE}
              -D check_interp=ON
              -D READELF_EXECUTABLE=${READELF_EXECUTABLE}
              -P ${CMAKE_CURRENT_SOURCE_DIR}/CMake_readelf.cmake
@@ -931,7 +931,7 @@ if (UNIX)
       ARGS -D lib_fileloc=${CMAKE_CURRENT_BINARY_DIR}/${locvar_name}
            -D check_textrel=ON
            -D check_deps=OFF
-           -D check_libc=ON
+           -D check_libc=${BUILD_PACKAGE}
            -D check_interp=ON
            -D READELF_EXECUTABLE=${READELF_EXECUTABLE}
            -P ${CMAKE_CURRENT_SOURCE_DIR}/CMake_readelf.cmake

--- a/core/CMake_readelf.cmake
+++ b/core/CMake_readelf.cmake
@@ -145,7 +145,7 @@ if (check_libc)
     set (glibc_version_regexp " GLOBAL [ A-Z]* UND [^\n]*@GLIBC_([0-9]+\\.[0-9]+)")
     string(REGEX MATCHALL "${glibc_version_regexp}" imports "${string}")
 
-    foreach(import ${imports})
+    foreach (import ${imports})
       string(REGEX MATCH "${glibc_version_regexp}" match "${import}")
       set(version ${CMAKE_MATCH_1})
 

--- a/core/CMake_readelf.cmake
+++ b/core/CMake_readelf.cmake
@@ -129,8 +129,8 @@ if (check_libc)
   endif (readelf_result OR readelf_error)
 
   if (BUILD_PACKAGE)
-    # Avoid dependences beyond glibc 2.4 (2.17 on AArch64) for maximum backward
-    # portability without going to extremes with a fixed toolchain (xref i#1504):
+    # Avoid dependences beyond glibc 2.17 for maximum backward portability without going to
+    # extremes with a fixed toolchain (xref i#1504):
     execute_process(COMMAND
       ${READELF_EXECUTABLE} -h ${${lib_file}}
       OUTPUT_VARIABLE file_header_result

--- a/core/CMake_readelf.cmake
+++ b/core/CMake_readelf.cmake
@@ -129,8 +129,8 @@ if (check_libc)
   endif (readelf_result OR readelf_error)
 
   if (BUILD_PACKAGE)
-    # Avoid dependences beyond glibc 2.17 for maximum backward portability without going to
-    # extremes with a fixed toolchain (xref i#1504):
+    # Avoid dependences beyond the oldest well-supported version of glibc for maximum backward
+    # portability without going to extremes with a fixed toolchain (xref i#1504):
     execute_process(COMMAND
       ${READELF_EXECUTABLE} -h ${${lib_file}}
       OUTPUT_VARIABLE file_header_result

--- a/core/CMake_readelf.cmake
+++ b/core/CMake_readelf.cmake
@@ -145,11 +145,10 @@ if (check_libc)
     #  * Ubuntu 16.04 LTS (Xenial), which is on glibc 2.23
     #
     # Therefore, we want to support at least glibc 2.17.
-    if (file_header_result MATCHES "AArch64")
-      set (glibc_version "2.17")
-    else ()
-      set (glibc_version "2.17")
-    endif ()
+    #
+    # The glibc version is independent of the architecture. For instance, RHEL 7 for AArch64 also
+    # ships glibc 2.17 as of writing.
+    set (glibc_version "2.17")
 
     set (glibc_version_regexp " GLOBAL [ A-Z]* UND [^\n]*@GLIBC_([0-9]+\\.[0-9]+)")
     string(REGEX MATCHALL "${glibc_version_regexp}" imports "${string}")

--- a/core/CMake_readelf.cmake
+++ b/core/CMake_readelf.cmake
@@ -139,7 +139,7 @@ if (check_libc)
     if (file_header_result MATCHES "AArch64")
       set (glibc_version "2.17")
     else ()
-      set (glibc_version "2.4")
+      set (glibc_version "2.17")
     endif ()
 
     set (glibc_version_regexp " GLOBAL [ A-Z]* UND [^\n]*@GLIBC_([0-9]+\\.[0-9]+)")

--- a/core/CMake_readelf.cmake
+++ b/core/CMake_readelf.cmake
@@ -136,6 +136,15 @@ if (check_libc)
       OUTPUT_VARIABLE file_header_result
       )
 
+    # To determine the minimum version of glibc that we should support for packaging, we should
+    # check the Linux distributions that are known not to be rolling releases and offer long
+    # support, and then check the oldest option available that is not yet EOL. As of writing,
+    # these are:
+    #  * Debian Stretch, which is on glibc 2.24
+    #  * CentOS 7/RHEL 7, which is on glibc 2.17
+    #  * Ubuntu 16.04 LTS (Xenial), which is on glibc 2.23
+    #
+    # Therefore, we want to support at least glibc 2.17.
     if (file_header_result MATCHES "AArch64")
       set (glibc_version "2.17")
     else ()

--- a/make/package.cmake
+++ b/make/package.cmake
@@ -44,6 +44,9 @@
 cmake_minimum_required(VERSION 3.7)
 set(CTEST_SOURCE_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}/..")
 
+# ensure that we check glibc for version incompatibilities.
+SET(BUILD_PACKAGE ON CACHE BOOL "build DynamoRIO for packaging purposes by performing glibc checks")
+
 # arguments are a ;-separated list (must escape as \; from ctest_run_script())
 # required args:
 set(arg_build "")      # build #

--- a/make/package.cmake
+++ b/make/package.cmake
@@ -44,9 +44,6 @@
 cmake_minimum_required(VERSION 3.7)
 set(CTEST_SOURCE_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}/..")
 
-# ensure that we check glibc for version incompatibilities.
-SET(BUILD_PACKAGE ON CACHE BOOL "build DynamoRIO for packaging purposes by performing glibc checks")
-
 # arguments are a ;-separated list (must escape as \; from ctest_run_script())
 # required args:
 set(arg_build "")      # build #
@@ -166,6 +163,7 @@ set(base_cache "
   ${base_cache}
   BUILD_NUMBER:STRING=${arg_build}
   UNIQUE_BUILD_NUMBER:STRING=${arg_ubuild}
+  BUILD_PACKAGE:BOOL=ON
   ${arg_cacheappend}
   ")
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -198,7 +198,7 @@ foreach (deploytgt drconfig drrun drinject)
       ARGS -D lib_fileloc=${CMAKE_CURRENT_BINARY_DIR}/${locvar_name}
            -D check_textrel=ON
            -D check_deps=OFF
-           -D check_libc=ON
+           -D check_libc=${BUILD_PACKAGE}
            -D READELF_EXECUTABLE=${READELF_EXECUTABLE}
            -P ${PROJECT_SOURCE_DIR}/core/CMake_readelf.cmake
       VERBATIM # recommended: p260


### PR DESCRIPTION
This addresses issue #5130 in the following ways:

- Improve the glibc import checking code by using a regex to match all imports, and then for each import extract the version and use CMake's version comparison functionality to match the version. This allows us to write the desired glibc version as a string such as "2.4", instead of having to write a regular expression that matches everything greater than 2.4 or in general the desired version.
- Introduce a `BUILD_PACKAGE` option that is `ON` by default, but can be turned off when invoking `cmake` as follows: `cmake -DBUILD_PACKAGE=OFF ..`. This is important for rolling release distributions where glibc 2.32 is currently stable and these checks prevent drrun from building.
- Bump the glibc version to 2.17. After checking multiple distributions with long support times (typically Debian and CentOS, and Ubuntu LTS being a close one), I found that the oldest versions that are still supported as of writing are Debian Stretch, CentOS 7, RHEL 7, and Ubuntu 16.04 LTS (Xenial). These ship glibc [2.24](https://packages.debian.org/source/stretch/glibc), glibc [2.17](https://centos.pkgs.org/7/centos-x86_64/glibc-2.17-317.el7.x86_64.rpm.html) glibc [2.17](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.0_release_notes/sect-red_hat_enterprise_linux-7.0_release_notes-compiler_and_tools-glibc) and glibc [2.23](https://launchpad.net/ubuntu/xenial/+source/glibc) respectively. According to the [release page of glibc](https://ftp.gnu.org/gnu/glibc/) the release date of glibc 2.17 is 2012-12-25.

In addition, I am keeping around the glibc version separation between AArch64 and non-AArch64, just in case they diverge again.