### PR TITLE
add support for the encls/enclu/enclv instructions

### DIFF
--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -6931,7 +6931,7 @@ const instr_info_t mod_extensions[][2] = {
 /* Naturally all of these have modrm bytes even if they have no explicit operands */
 const instr_info_t rm_extensions[][8] = {
   { /* rm extension 0 */
-    {OP_enclv,    0xc00f0131, "enclv", eax, ebx, eax, ebx, ecx, mrm|xop, x, exop[0x100]},
+    {OP_enclv,    0xc00f0171, "enclv", eax, ebx, eax, ebx, ecx, mrm|xop, x, exop[0x100]},
     {OP_vmcall,   0xc10f0171, "vmcall",   xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
     {OP_vmlaunch, 0xc20f0171, "vmlaunch", xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
     {OP_vmresume, 0xc30f0171, "vmresume", xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
@@ -6949,7 +6949,7 @@ const instr_info_t rm_extensions[][8] = {
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_encls,  0xcf0f0131, "encls", eax, ebx, eax, ebx, ecx, mrm|xop, x, exop[0xfe]},
+    {OP_encls,  0xcf0f0171, "encls", eax, ebx, eax, ebx, ecx, mrm|xop, x, exop[0xfe]},
   },
   { /* rm extension 2 */
     {OP_swapgs, 0xf80f0177, "swapgs", xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
@@ -10575,9 +10575,9 @@ const instr_info_t extra_operands[] =
     {OP_CONTD, 0x663a2548, "vpternlogq cont'd", xx, xx, We, xx, xx, mrm|evex|reqp, x, tevexwb[188][3]},
     {OP_CONTD, 0x663a2558, "vpternlogq cont'd", xx, xx, Mq, xx, xx, mrm|evex|reqp, x, END_LIST},
     /* 254 */
-    {OP_CONTD, 0xcf0f0131, "<encls cont'd>", ecx, edx, edx, xx, xx, mrm, x, END_LIST},
+    {OP_CONTD, 0xcf0f0171, "<encls cont'd>", ecx, edx, edx, xx, xx, mrm, x, END_LIST},
     {OP_CONTD, 0xd70f0172, "<enclu cont'd>", ecx, edx, edx, xx, xx, mrm, x, END_LIST},
-    {OP_CONTD, 0xc00f0131, "<enclv cont'd>", ecx, edx, edx, xx, xx, mrm, x, END_LIST},
+    {OP_CONTD, 0xc00f0171, "<enclv cont'd>", ecx, edx, edx, xx, xx, mrm, x, END_LIST},
 };
 
 /* clang-format on */

--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -6931,7 +6931,7 @@ const instr_info_t mod_extensions[][2] = {
 /* Naturally all of these have modrm bytes even if they have no explicit operands */
 const instr_info_t rm_extensions[][8] = {
   { /* rm extension 0 */
-    {OP_enclv,    0xc00f0131, "enclv", eax, ebx, eax, ebx, ecx, xop, x, exop[0x100]},
+    {OP_enclv,    0xc00f0131, "enclv", eax, ebx, eax, ebx, ecx, mrm_xop, x, exop[0x100]},
     {OP_vmcall,   0xc10f0171, "vmcall",   xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
     {OP_vmlaunch, 0xc20f0171, "vmlaunch", xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
     {OP_vmresume, 0xc30f0171, "vmresume", xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
@@ -6949,7 +6949,7 @@ const instr_info_t rm_extensions[][8] = {
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_encls,  0xcf0f0131, "encls", eax, ebx, eax, ebx, ecx, xop, x, exop[0xfe]},
+    {OP_encls,  0xcf0f0131, "encls", eax, ebx, eax, ebx, ecx, mrm_xop, x, exop[0xfe]},
   },
   { /* rm extension 2 */
     {OP_swapgs, 0xf80f0177, "swapgs", xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
@@ -6983,7 +6983,7 @@ const instr_info_t rm_extensions[][8] = {
      */
     {OP_xend,   0xd50f0172, "xend", eax, xx, xx, xx, xx, mrm|predcx, x, NA},
     {OP_xtest,  0xd60f0172, "xtest", xx, xx, xx, xx, xx, mrm, fW6, NA},
-    {OP_enclu,  0xd70f0172, "enclu", eax, ebx, eax, ebx, ecx, xop, x, exop[0xff]},
+    {OP_enclu,  0xd70f0172, "enclu", eax, ebx, eax, ebx, ecx, mrm_xop, x, exop[0xff]},
   },
   { /* rm extension 5 */
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},

--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -1603,6 +1603,11 @@ const instr_info_t * const op_instr[] =
    /* Intel MPK extensions */
    /* OP_rdpkru       */    &rm_extensions[5][6],
    /* OP_wrpkru       */    &rm_extensions[5][7],
+
+   /* Intel Software Guard eXtension. */
+   /* OP_encls        */    &rm_extensions[1][7],
+   /* OP_enclu        */    &rm_extensions[4][7],
+   /* OP_enclv        */    &rm_extensions[0][0],
 };
 
 
@@ -6926,8 +6931,7 @@ const instr_info_t mod_extensions[][2] = {
 /* Naturally all of these have modrm bytes even if they have no explicit operands */
 const instr_info_t rm_extensions[][8] = {
   { /* rm extension 0 */
-    {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-
+    {OP_enclv,    0xc00f0131, "enclv", eax, ebx, eax, ebx, ecx, xop, x, exop[0x100]},
     {OP_vmcall,   0xc10f0171, "vmcall",   xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
     {OP_vmlaunch, 0xc20f0171, "vmlaunch", xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
     {OP_vmresume, 0xc30f0171, "vmresume", xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
@@ -6945,7 +6949,7 @@ const instr_info_t rm_extensions[][8] = {
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_encls,  0xcf0f0131, "encls", eax, ebx, eax, ebx, ecx, xop, x, exop[0xfe]},
   },
   { /* rm extension 2 */
     {OP_swapgs, 0xf80f0177, "swapgs", xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
@@ -6979,7 +6983,7 @@ const instr_info_t rm_extensions[][8] = {
      */
     {OP_xend,   0xd50f0172, "xend", eax, xx, xx, xx, xx, mrm|predcx, x, NA},
     {OP_xtest,  0xd60f0172, "xtest", xx, xx, xx, xx, xx, mrm, fW6, NA},
-    {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_enclu,  0xd70f0172, "enclu", eax, ebx, eax, ebx, ecx, xop, x, exop[0xff]},
   },
   { /* rm extension 5 */
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
@@ -10570,6 +10574,10 @@ const instr_info_t extra_operands[] =
     /* 252 */
     {OP_CONTD, 0x663a2548, "vpternlogq cont'd", xx, xx, We, xx, xx, mrm|evex|reqp, x, tevexwb[188][3]},
     {OP_CONTD, 0x663a2558, "vpternlogq cont'd", xx, xx, Mq, xx, xx, mrm|evex|reqp, x, END_LIST},
+    /* 254 */
+    {OP_CONTD, 0x000000, "<encls cont'd>", ecx, edx, edx, xx, xx, no, x, END_LIST},
+    {OP_CONTD, 0x000000, "<enclu cont'd>", ecx, edx, edx, xx, xx, no, x, END_LIST},
+    {OP_CONTD, 0x000000, "<enclv cont'd>", ecx, edx, edx, xx, xx, no, x, END_LIST},
 };
 
 /* clang-format on */

--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -6931,7 +6931,7 @@ const instr_info_t mod_extensions[][2] = {
 /* Naturally all of these have modrm bytes even if they have no explicit operands */
 const instr_info_t rm_extensions[][8] = {
   { /* rm extension 0 */
-    {OP_enclv,    0xc00f0131, "enclv", eax, ebx, eax, ebx, ecx, mrm_xop, x, exop[0x100]},
+    {OP_enclv,    0xc00f0131, "enclv", eax, ebx, eax, ebx, ecx, mrm|xop, x, exop[0x100]},
     {OP_vmcall,   0xc10f0171, "vmcall",   xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
     {OP_vmlaunch, 0xc20f0171, "vmlaunch", xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
     {OP_vmresume, 0xc30f0171, "vmresume", xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
@@ -6949,7 +6949,7 @@ const instr_info_t rm_extensions[][8] = {
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_encls,  0xcf0f0131, "encls", eax, ebx, eax, ebx, ecx, mrm_xop, x, exop[0xfe]},
+    {OP_encls,  0xcf0f0131, "encls", eax, ebx, eax, ebx, ecx, mrm|xop, x, exop[0xfe]},
   },
   { /* rm extension 2 */
     {OP_swapgs, 0xf80f0177, "swapgs", xx, xx, xx, xx, xx, mrm|o64, x, END_LIST},
@@ -6983,7 +6983,7 @@ const instr_info_t rm_extensions[][8] = {
      */
     {OP_xend,   0xd50f0172, "xend", eax, xx, xx, xx, xx, mrm|predcx, x, NA},
     {OP_xtest,  0xd60f0172, "xtest", xx, xx, xx, xx, xx, mrm, fW6, NA},
-    {OP_enclu,  0xd70f0172, "enclu", eax, ebx, eax, ebx, ecx, mrm_xop, x, exop[0xff]},
+    {OP_enclu,  0xd70f0172, "enclu", eax, ebx, eax, ebx, ecx, mrm|xop, x, exop[0xff]},
   },
   { /* rm extension 5 */
     {INVALID,   0x0f0131, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
@@ -10575,9 +10575,9 @@ const instr_info_t extra_operands[] =
     {OP_CONTD, 0x663a2548, "vpternlogq cont'd", xx, xx, We, xx, xx, mrm|evex|reqp, x, tevexwb[188][3]},
     {OP_CONTD, 0x663a2558, "vpternlogq cont'd", xx, xx, Mq, xx, xx, mrm|evex|reqp, x, END_LIST},
     /* 254 */
-    {OP_CONTD, 0x000000, "<encls cont'd>", ecx, edx, edx, xx, xx, no, x, END_LIST},
-    {OP_CONTD, 0x000000, "<enclu cont'd>", ecx, edx, edx, xx, xx, no, x, END_LIST},
-    {OP_CONTD, 0x000000, "<enclv cont'd>", ecx, edx, edx, xx, xx, no, x, END_LIST},
+    {OP_CONTD, 0xcf0f0131, "<encls cont'd>", ecx, edx, edx, xx, xx, mrm, x, END_LIST},
+    {OP_CONTD, 0xd70f0172, "<enclu cont'd>", ecx, edx, edx, xx, xx, mrm, x, END_LIST},
+    {OP_CONTD, 0xc00f0131, "<enclv cont'd>", ecx, edx, edx, xx, xx, mrm, x, END_LIST},
 };
 
 /* clang-format on */

--- a/core/ir/x86/instr_create_api.h
+++ b/core/ir/x86/instr_create_api.h
@@ -5039,6 +5039,26 @@
                            opnd_create_reg(DR_REG_EBX), opnd_create_reg(DR_REG_ECX), \
                            opnd_create_reg(DR_REG_EDX), opnd_create_reg(DR_REG_EAX), \
                            opnd_create_reg(DR_REG_ECX))
+
+/* 3 implicit destinations, 1 source */
+#define INSTR_CREATE_encls(dc)                                                       \
+    instr_create_4dst_4src((dc), OP_encls, opnd_create_reg(DR_REG_EAX),              \
+                           opnd_create_reg(DR_REG_EBX), opnd_create_reg(DR_REG_ECX), \
+                           opnd_create_reg(DR_REG_EDX), opnd_create_reg(DR_REG_EAX), \
+                           opnd_create_reg(DR_REG_EBX), opnd_create_reg(DR_REG_ECX), \
+                           opnd_create_reg(DR_REG_EDX))
+#define INSTR_CREATE_enclu(dc)                                                       \
+    instr_create_4dst_4src((dc), OP_enclu, opnd_create_reg(DR_REG_EAX),              \
+                           opnd_create_reg(DR_REG_EBX), opnd_create_reg(DR_REG_ECX), \
+                           opnd_create_reg(DR_REG_EDX), opnd_create_reg(DR_REG_EAX), \
+                           opnd_create_reg(DR_REG_EBX), opnd_create_reg(DR_REG_ECX), \
+                           opnd_create_reg(DR_REG_EDX))
+#define INSTR_CREATE_enclv(dc)                                                       \
+    instr_create_4dst_4src((dc), OP_enclv, opnd_create_reg(DR_REG_EAX),              \
+                           opnd_create_reg(DR_REG_EBX), opnd_create_reg(DR_REG_ECX), \
+                           opnd_create_reg(DR_REG_EDX), opnd_create_reg(DR_REG_EAX), \
+                           opnd_create_reg(DR_REG_EBX), opnd_create_reg(DR_REG_ECX), \
+                           opnd_create_reg(DR_REG_EDX))
 /** @} */ /* end doxygen group */
 
 /* 3 implicit destinations, 3 implicit sources */

--- a/core/ir/x86/instr_create_api.h
+++ b/core/ir/x86/instr_create_api.h
@@ -5033,7 +5033,7 @@
     instr_create_3dst_0src((dc), OP_rdtscp, opnd_create_reg(DR_REG_EDX), \
                            opnd_create_reg(DR_REG_EAX), opnd_create_reg(DR_REG_ECX))
 
-/* 3 implicit destinations, 1 source */
+/* 4 implicit destinations, 2 implicit sources */
 #define INSTR_CREATE_cpuid(dc)                                                       \
     instr_create_4dst_2src((dc), OP_cpuid, opnd_create_reg(DR_REG_EAX),              \
                            opnd_create_reg(DR_REG_EBX), opnd_create_reg(DR_REG_ECX), \

--- a/core/ir/x86/instr_create_api.h
+++ b/core/ir/x86/instr_create_api.h
@@ -5040,7 +5040,7 @@
                            opnd_create_reg(DR_REG_EDX), opnd_create_reg(DR_REG_EAX), \
                            opnd_create_reg(DR_REG_ECX))
 
-/* 3 implicit destinations, 1 source */
+/* 4 implicit destinations, 4 implicit sources */
 #define INSTR_CREATE_encls(dc)                                                       \
     instr_create_4dst_4src((dc), OP_encls, opnd_create_reg(DR_REG_EAX),              \
                            opnd_create_reg(DR_REG_EBX), opnd_create_reg(DR_REG_ECX), \

--- a/core/ir/x86/opcode_api.h
+++ b/core/ir/x86/opcode_api.h
@@ -1593,6 +1593,11 @@ enum {
     /* 1421 */ OP_rdpkru, /**< IA-32/AMD64 MPK rdpkru opcode. */
     /* 1422 */ OP_wrpkru, /**< IA-32/AMD64 MPK wrpkru opcode. */
 
+    /* Intel Software Guard eXtension. */
+    /* 1423 */ OP_encls, /**< IA-32/AMD64 SGX encls opcode. */
+    /* 1424 */ OP_enclu, /**< IA-32/AMD64 SGX enclu opcode. */
+    /* 1425 */ OP_enclv, /**< IA-32/AMD64 SGX enclv opcode. */
+
     OP_AFTER_LAST,
     OP_FIRST = OP_add,           /**< First real opcode. */
     OP_LAST = OP_AFTER_LAST - 1, /**< Last real opcode. */

--- a/suite/tests/api/ir_x86_0args.h
+++ b/suite/tests/api/ir_x86_0args.h
@@ -144,6 +144,10 @@ OPCODE(skinit, skinit, skinit, 0)
 OPCODE(invlpga, invlpga, invlpga, 0)
 OPCODE(rdtscp, rdtscp, rdtscp, 0)
 
+OPCODE(encls, encls, encls, 0)
+OPCODE(enclu, enclu, enclu, 0)
+OPCODE(enclv, enclv, enclv, 0)
+
 OPCODE(LABEL, LABEL, label, 0)
 OPCODE(out, out, out_1, 0)
 OPCODE(out4, out, out_4, 0)


### PR DESCRIPTION
This PR adds support for the `encls`, `enclu` and `enclv` instructions as described by [chapter 41 "SGX Instruction References"](https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3d-part-4-manual.pdf) in volume 3D of the Intel 64 and IA-32 Architectures Software Developer's Manual. These are used in **s**upervisor mode, **u**ser mode and **V**MM mode respectively.

These instructions are somewhat similar to `cpuid`, in that they accept all have a leaf function that can be specified through the `eax` register. However, unlike `cpuid`, the `ebx`, `ecx` and `edx` can both be used as inputs and outputs depending on the specific leaf function.

While Intel SGX is usable on a select set of Intel CPUs, it is usable both in 32-bit and 64-bit mode on those CPUs.

This PR is as follows:

* Implement `encls`, `enclu` and `enclv` in the decoder for x86.
* Add `INSTR_CREATE` macros for `encls`, `enclu` and `enclv`.
* Add test cases for `encls`, `enclu` and `enclv`.