### PR TITLE
i#3862: parse /etc/ld.so.conf

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -181,6 +181,7 @@ set(CORE_SRCS
   translate.c
   annotations.c
   jit_opt.c
+  fnmatch.c
   )
 
 if (UNIX)

--- a/core/fnmatch.c
+++ b/core/fnmatch.c
@@ -1,0 +1,166 @@
+#include <fnmatch.h>
+#include <string.h>
+
+#include "globals.h"
+
+static const char *
+rangematch(const char *pattern, char input, int flags)
+{
+    char c, end;
+    int invert = 0;
+    int match = 0;
+
+    /* '!' or '^' following the '[' means the matching should be inverted. */
+    if (*pattern == '!' || *pattern == '^') {
+        invert = 1;
+        ++pattern;
+    }
+
+    while ((c = *pattern++)) {
+        /* Handle character escaping. */
+        if (c == '\\' && !(flags & FNM_NOESCAPE)) {
+            c = *pattern++;
+        }
+
+        /* Check for null termination. */
+        if (c == '\0') {
+            return NULL;
+        }
+
+        /* Match against the character range. */
+        if (*pattern == '-' && (end = (*pattern + 1)) && end != ']') {
+            pattern += 2;
+
+            /* Handle character escaping. */
+            if (end == '\\' && !(flags & FNM_NOESCAPE)) {
+                end = *pattern++;
+            }
+
+            /* Check for null termination. */
+            if (end == '\0') {
+                return NULL;
+            }
+
+            /* Check whether the input is within the character range. */
+            if (c <= input && input < end) {
+                match = 1;
+            }
+        } else if (c == input) {
+            match = 1;
+        }
+    }
+
+    if (invert) {
+        match = !match;
+    }
+
+    return match ? pattern : NULL;
+}
+
+int fnmatch(const char *pattern, const char *string, int flags)
+{
+    const char *start = string;
+    char c, input;
+
+    while ((c = *pattern++)) {
+        switch (c) {
+        case '?':
+            if (*string == '\0') {
+                return FNM_NOMATCH;
+            }
+
+            if (*string == '/' && (flags & FNM_PATHNAME)) {
+                return FNM_NOMATCH;
+            }
+
+            if (*string == '.' && (flags & FNM_PERIOD) &&
+                (string == start ||
+                ((flags & FNM_PATHNAME) && *(string - 1) == '/'))) {
+                return FNM_NOMATCH;
+            }
+
+            ++string;
+            break;
+        case '*':
+            /* Collapse a sequence of stars. */
+            while (c == '*') {
+                c = *++pattern;
+            }
+
+            if (*string == '.' && (flags & FNM_PERIOD) &&
+                (string == start ||
+                ((flags & FNM_PATHNAME) && *(string - 1) == '/'))) {
+                return FNM_NOMATCH;
+            }
+
+            /* Handle pattern with * at the end. */
+            if (c == '\0') {
+                if (flags & FNM_PATHNAME) {
+                    return strchr(string, '/') ? FNM_NOMATCH : 0;
+                }
+
+                return 0;
+            }
+
+            /* Handle pattern with * before / while handling paths. */
+            if (c == '/' && flags & FNM_PATHNAME) {
+                if ((string = strchr(string, '/'))) {
+                    return FNM_NOMATCH;
+                }
+
+                break;
+            }
+
+            /* Handle any other variant through recursion. */
+            while ((input = *string)) {
+                if (fnmatch(pattern, string, flags & ~FNM_PERIOD) == 0) {
+                    return 0;
+                }
+
+                if (input == '/' && flags & FNM_PATHNAME) {
+                    break;
+                }
+
+                ++string;
+            }
+
+            return FNM_NOMATCH;
+        case '[':
+            if (*string == '\0') {
+                return FNM_NOMATCH;
+            }
+
+            if (*string == '/' && flags & FNM_PATHNAME) {
+                return FNM_NOMATCH;
+            }
+
+            if (!(pattern = rangematch(pattern, *string, flags))) {
+                return FNM_NOMATCH;
+            }
+
+            ++string;
+            break;
+        case '\\':
+            if (!(flags & FNM_NOESCAPE)) {
+                if ((c = *pattern++)) {
+                    c = '\\';
+                    --pattern;
+                }
+            }
+
+            /* fallthrough */
+        default:
+            if (c != *string++) {
+                return FNM_NOMATCH;
+            }
+
+            break;
+        }
+    }
+
+    if (*string != '\0') {
+        return FNM_NOMATCH;
+    }
+
+    return 0;
+}

--- a/core/globals.h
+++ b/core/globals.h
@@ -1103,6 +1103,8 @@ utf16_to_utf8_size(const wchar_t *src, size_t max_chars,
 #    define tolower d_r_tolower
 #    undef strcasecmp
 #    define strcasecmp d_r_strcasecmp
+#    undef strncasecmp
+#    define strncasecmp d_r_strncasecmp
 #    undef strtoul
 #    define strtoul d_r_strtoul
 #endif
@@ -1132,6 +1134,8 @@ int
 tolower(int c);
 int
 strcasecmp(const char *left, const char *right);
+int
+strncasecmp(const char *left, const char *right, size_t n);
 unsigned long
 strtoul(const char *str, char **end, int base);
 

--- a/core/string.c
+++ b/core/string.c
@@ -289,6 +289,22 @@ d_r_strcasecmp(const char *left, const char *right)
     return 0;
 }
 
+/* Private strncasecmp. */
+int
+d_r_strncasecmp(const char *left, const char *right, size_t n)
+{
+    size_t i;
+    for (i = 0; i < n && (left[i] != '\0' || right[i] != '\0'); i++) {
+        int l = tolower(left[i]);
+        int r = tolower(right[i]);
+        if (l < r)
+            return -1;
+        if (l > r)
+            return 1;
+    }
+    return 0;
+}
+
 /* Private strtoul.  Actual parsing is implemented in io.c.  We use plain
  * "unsigned long" to match libc prototype regardless of our internal typedefs.
  *

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -834,6 +834,110 @@ privload_search_rpath(privmod_t *mod, bool runpath, const char *name,
     return false;
 }
 
+bool
+privload_parse_ld_conf(glob_t *search_paths, const char *config_path)
+{
+    file_t file;
+    char *line = NULL;
+    size_t len = 0;
+    ssize_t nread;
+
+    /* Ensure the arguments are not NULL. */
+    if (!search_paths || !config_path) {
+        return false;
+    }
+
+    /* Open the config file as read-only. */
+    file = os_open(config_path, OS_OPEN_READ);
+
+    if (file == INVALID_FILE) {
+        return false;
+    }
+
+    while ((nread = os_getline(&line, &len, file)) >= 0) {
+        /* Remove the newline. */
+        char *end = strchr(line, '\n');
+
+        if (end) {
+            *end = '\0';
+        }
+
+        /* Ignore comments. */
+        if (line[0] == '#') {
+            continue;
+        }
+
+        /* Handle the include directive by recursively parsing the included
+         * config file.
+         */
+        size_t nbytes = strlen("include");
+
+        if (nread < nbytes) {
+            nbytes = nread;
+        }
+
+        if (strncasecmp(line, "include", nbytes) == 0) {
+            glob_t includes = { 0 };
+
+            /* Locate the path that should be included. */
+            char *include_path = line + nbytes;
+
+            /* Make sure there is some form of whitespace after the include
+             * directive.
+             */
+            include_path = strchr(include_path, ' ');
+
+            if (!include_path) {
+                continue;
+            }
+
+            while (*include_path && *include_path == ' ') {
+                ++include_path;
+            }
+
+            /* We have enough room in the string to prefix it with "/etc/". */
+            size_t count = strlen("/etc/");
+            strncpy(include_path - count, "/etc/", count);
+
+            /* Glob the path. */
+            if (os_glob(include_path, 0, NULL, &includes) < 0) {
+                continue;
+            }
+
+            /* Recursively parse the included config files. */
+            for (size_t i = 0; i < includes.gl_pathc; ++i) {
+                 if (!privload_parse_ld_conf(search_paths, includes.gl_pathv[i])) {
+                      os_close(file);
+
+                      return false;
+                 }
+            }
+
+            os_globfree(&includes);
+
+            continue;
+        }
+
+        /* We only care about directories. */
+        int flags = GLOB_MARK | GLOB_ONLYDIR;
+
+        /* Append the path, if it is not the first path. */
+        if (search_paths->gl_pathv) {
+            flags |= GLOB_APPEND;
+        }
+
+        os_glob(line, flags, NULL, search_paths);
+    }
+
+    if (line) {
+        heap_free(GLOBAL_DCONTEXT, line, len HEAPACCT(ACCT_OTHER));
+    }
+
+    os_close(file);
+
+    return true;
+}
+
 static bool
 privload_locate(const char *name, privmod_t *dep,
                 char *filename OUT /* buffer size is MAXIMUM_PATH */,
@@ -904,7 +1008,38 @@ privload_locate(const char *name, privmod_t *dep,
     if (dep != NULL && privload_search_rpath(dep, true /*runpath*/, name, filename))
         return true;
 
-    /* 5) XXX i#460: We use our system paths instead of /etc/ld.so.cache. */
+    /* 5) Try parsing /etc/ld.so.conf */
+    glob_t search_paths = { 0 };
+
+    if (privload_parse_ld_conf(&search_paths, "/etc/ld.so.conf")) {
+        for (i = 0; i < search_paths.gl_pathc; ++i) {
+            /* First try -xarch_root for emulation. */
+            if (!IS_STRING_OPTION_EMPTY(xarch_root)) {
+                string_option_read_lock();
+                snprintf(filename, MAXIMUM_PATH, "%s/%s/%s", DYNAMO_OPTION(xarch_root),
+                    search_paths.gl_pathv[i], name);
+                filename[MAXIMUM_PATH - 1] = '\0';
+                string_option_read_unlock();
+
+                if (os_file_exists(filename, false /*!is_dir*/) &&
+                    module_file_has_module_header(filename)) {
+                    return true;
+                }
+            }
+
+            snprintf(filename, MAXIMUM_PATH, "%s/%s", search_paths.gl_pathv[i], name);
+            /* NULL_TERMINATE_BUFFER(filename) */
+            filename[MAXIMUM_PATH - 1] = 0;
+            LOG(GLOBAL, LOG_LOADER, 2, "%s: looking for %s\n", __FUNCTION__, filename);
+
+            if (os_file_exists(filename, false /*!is_dir*/) &&
+                module_file_has_module_header(filename)) {
+                return true;
+            }
+        }
+    }
+
+    /* 6) Fallback to the array of fixed system paths. */
     for (i = 0; i < NUM_SYSTEM_LIB_PATHS; i++) {
         /* First try -xarch_root for emulation. */
         if (!IS_STRING_OPTION_EMPTY(xarch_root)) {

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -276,6 +276,11 @@ os_glob(const char *pattern, int flags, int (*errfunc)(const char *path, int err
 void
 os_globfree(glob_t *glob);
 
+ssize_t
+os_getdelim(char **lineptr, size_t *n, int delim, file_t file);
+ssize_t
+os_getline(char **lineptr, size_t *n, file_t file);
+
 /* in signal.c */
 struct _kernel_sigaction_t;
 typedef struct _kernel_sigaction_t kernel_sigaction_t;

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -269,6 +269,13 @@ os_walk_address_space(memquery_iter_t *iter, bool add_modules);
 bool
 is_sigreturn_syscall_number(int sysnum);
 
+#include <glob.h>
+
+int
+os_glob(const char *pattern, int flags, int (*errfunc)(const char *path, int errno), glob_t *glob);
+void
+os_globfree(glob_t *glob);
+
 /* in signal.c */
 struct _kernel_sigaction_t;
 typedef struct _kernel_sigaction_t kernel_sigaction_t;


### PR DESCRIPTION
This addresses issue #3862 (originally #460) by implementing code that parses the search paths in `/etc/ld.so.conf` for the private loader on Linux.

The `/etc/ld.so.conf` file consists of one or more lines, where a line may be a search path, an include directive to include another configuration file or where a line may start with '#' if it is a comment. The include directives support globbing (see `man 3 glob` and `man 7 glob` for more information).

Some notes about compatibility:

- Alpine is a musl-based distribution, and the dynamic linker used by Alpine instead may look for`/etc/ld-musl-$(ARCH).path`. For instance, on x86-64, it would look for `/etc/ld-musl-x86_64.path`. The format seems to be slightly different from `/etc/ld.so.conf`. If the file is not present, musl simply defaults to "/lib:/usr/local/lib:/usr/lib". See also: https://www.musl-libc.org/doc/1.0.0/manual.html
- Android uses bionic as its libc and instead looks for `/system/etc/ld.config.txt`. See also: https://android.googlesource.com/platform/bionic/+/master/linker/ld.config.format.md
- While the FreeBSD man pages do seem to mention the existence of `/etc/ld.so.conf`, the default seems to be that the dynamic linker on FreeBSD looks for the `ldconfig_paths` and `ldconfig32_paths` keys in `/etc/defaults/rc.conf`.
- Mac OS X does not seem to have `/etc/ld.so.conf` either, but `man dyld` seems to provide some useful hints.

We probably want to open new issues referring to #3862 and #460 for the other cases.

This PR implements the following:

- The `strncasecmp` function to match the `include` directive. On second thought, `strncmp` may work well enough, but it doesn't hurt to be case-insensitive.
- The `fnmatch` function, which is required to implement `glob`. The `fnmatch` lets us match a given string against a pattern including character ranges (e.g. `[a-z]`), the any character (denoted as `?`) and wildcards (denoted as '*'). Furthermore, multiple wildcards may be present.
- The `glob` function which uses `fnmatch` function and the Unix-specific directory iterator code that is currently present in DynamoRIO to match all found filenames against a given pattern.
- The `getdelim` and `getline` functions which help us parse the config files line-by-line.
- The `privload_parse_ld_conf` function which parses `/etc/ld.so.conf` and any included config files and constructs an array of search paths by piggybacking on the `glob` function, which can be used to append search paths to an array of search paths.
- Finally, the `privload_locate` function has been extended to use the `privload_parse_ld_conf`, and otherwise falls back to the fixed array of system paths (see compatibility notes).

While the `ld.so.conf` parsing itself is straight-forward on any POSIX system due to the existence of `glob` and `getline`, DynamoRIO originally did not provide these functions as the private loader cannot rely on libc, and it would be helpful to have a thorough review of the implementation of these functions.

I have tested this on:
 - My desktop running Gentoo where `libgcc_s.so.1` is located in /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0` by running: `./bin64/drrun -c ./api/bin/libempty.so -- ls`. Before these changes, it was necessary to specify the correct path using the `LD_LIBRARY_PATH` environment variable.
 - Ubuntu 20.04 LTS by running: `./bin64/drrun -c /api/bin/libempty.so -- ls` to be sure that there are no regressions introduced by this PR.