### PR TITLE
Improve core dump diagnostics

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -7011,7 +7011,8 @@ os_request_fatal_coredump(const char *msg)
     /* To enable getting a coredump just make sure that rlimits are
      * not preventing getting one, e.g. ulimit -c unlimited
      */
-    SYSLOG_INTERNAL_ERROR("Crashing the process deliberately for a core dump!");
+    SYSLOG_INTERNAL_ERROR("Crashing the process deliberately for a core dump for: |%s|",
+                          msg);
     os_terminate_via_signal(NULL, 0 /*no cleanup*/, SIGSEGV);
     ASSERT_NOT_REACHED();
 }

--- a/core/utils.c
+++ b/core/utils.c
@@ -601,9 +601,6 @@ deadlock_avoidance_lock(mutex_t *lock, bool acquired, bool ownable)
                 bool both_client = (first_client && lock->rank == dr_client_mutex_rank);
                 if (dcontext->thread_owned_locks->last_lock->rank >= lock->rank &&
                     !first_client /*FIXME PR 198871: remove */ && !both_client) {
-                    /* like syslog don't synchronize options for dumpcore_mask */
-                    if (TEST(DUMPCORE_DEADLOCK, DYNAMO_OPTION(dumpcore_mask)))
-                        os_dump_core("rank order violation");
                     /* report rank order violation */
                     SYSLOG_INTERNAL_NO_OPTION_SYNCH(
                         SYSLOG_CRITICAL,
@@ -611,6 +608,9 @@ deadlock_avoidance_lock(mutex_t *lock, bool acquired, bool ownable)
                         dcontext->thread_owned_locks->last_lock->name,
                         d_r_get_thread_id());
                     dump_owned_locks(dcontext);
+                    /* like syslog don't synchronize options for dumpcore_mask */
+                    if (TEST(DUMPCORE_DEADLOCK, DYNAMO_OPTION(dumpcore_mask)))
+                        os_dump_core("rank order violation");
                 }
                 ASSERT((dcontext->thread_owned_locks->last_lock->rank < lock->rank ||
                         first_client /*FIXME PR 198871: remove */


### PR DESCRIPTION
Includes the message for the reason for an internally-triggered core
dump, which was previously lost on Linux.

Re-orders rank order violation output so that two involved locks are
idenfitied prior to asking for a core dump.