### PR TITLE
i#5304: Ignore reachability for instr_is_encoding_possible()

### DIFF
--- a/core/ir/arm/encode.c
+++ b/core/ir/arm/encode.c
@@ -1373,12 +1373,14 @@ encode_abspc_ok(decode_info_t *di, opnd_size_t size_immed, opnd_t opnd, bool is_
         bool res = false;
         if (negated) {
             res = (delta < 0 &&
-                   encode_immed_ok(di, size_immed, -delta, scale, false /*unsigned*/,
-                                   negated));
+                   (!di->check_reachable ||
+                    encode_immed_ok(di, size_immed, -delta, scale, false /*unsigned*/,
+                                    negated)));
         } else {
             res = (delta >= 0 &&
-                   encode_immed_ok(di, size_immed, delta, scale, false /*unsigned*/,
-                                   negated));
+                   (!di->check_reachable ||
+                    encode_immed_ok(di, size_immed, delta, scale, false /*unsigned*/,
+                                    negated)));
         }
         if (res) {
             di->check_wb_base = DR_REG_PC;

--- a/core/ir/encode_shared.c
+++ b/core/ir/encode_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -99,6 +99,7 @@ get_encoding_info(instr_t *instr)
     const instr_info_t *info = instr_get_instr_info(instr);
     decode_info_t di;
     decode_info_init_for_instr(&di, instr);
+    di.check_reachable = false;
 
     while (!encoding_possible(&di, instr, info)) {
         info = get_next_instr_info(info);

--- a/core/ir/encode_shared.c
+++ b/core/ir/encode_shared.c
@@ -99,7 +99,7 @@ get_encoding_info(instr_t *instr)
     const instr_info_t *info = instr_get_instr_info(instr);
     decode_info_t di;
     decode_info_init_for_instr(&di, instr);
-    di.check_reachable = false;
+    IF_AARCHXX(di.check_reachable = false;)
 
     while (!encoding_possible(&di, instr, info)) {
         info = get_next_instr_info(info);


### PR DESCRIPTION
On ARM, instr_is_encoding_possible() was checking reachabilty, yet it
took no target encode address, causing it to fail for any but very
small addresses.  We remove the reachability checks to solve this.

The test for #5302 in a forthcoming PR adds a regression test for
this.

Fixes #5304