### PR TITLE
Only check for AVX instructions on x86

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,7 +592,7 @@ set(INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 set(proc_supports_avx OFF)
 set(proc_supports_avx2 OFF)
 set(proc_supports_avx512 OFF)
-if (UNIX)
+if (X86 AND UNIX)
   set(CFLAGS_AVX "-mavx")
   # BMI2 instructions are typically also supported on AVX2 processors.
   set(CFLAGS_AVX2 "-mavx2 -mbmi2")


### PR DESCRIPTION
On Arm, the configure process outputs warnings for not finding AVX support, but that's to be expected on Arm.

-- WARNING: Compiler or processor do not support AVX. Skipping tests
-- WARNING: Compiler or processor do not support AVX2. Skipping tests
-- WARNING: Compiler or processor do not support AVX-512. Skipping tests

Only probe for AVX on x86 platforms, which avoids the warnings elsewhere.