### PR TITLE
Fix incorrect AArch64 name INST_CREATE_stlr

### DIFF
--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -669,7 +669,11 @@
 #define INSTR_CREATE_strh(dc, mem, rt) instr_create_1dst_1src(dc, OP_strh, mem, rt)
 #define INSTR_CREATE_stur(dc, mem, rt) instr_create_1dst_1src(dc, OP_stur, mem, rt)
 #define INSTR_CREATE_sturh(dc, mem, rt) instr_create_1dst_1src(dc, OP_sturh, mem, rt)
-#define INST_CREATE_stlr(dc, mem, rt) instr_create_1dst_1src(dc, OP_stlr, mem, rt)
+#define INSTR_CREATE_stlr(dc, mem, rt) instr_create_1dst_1src(dc, OP_stlr, mem, rt)
+/* This incorrect name was exported in official releases, so to avoid breaking
+ * potential existing uses we keep it as an alias.
+ */
+#define INST_CREATE_stlr INSTR_CREATE_stlr
 #define INSTR_CREATE_stxr(dc, mem, rs, rt) \
     instr_create_2dst_1src(dc, OP_stxr, mem, rs, rt)
 #define INSTR_CREATE_stxrb(dc, mem, rs, rt) \

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2021 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2022 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -659,8 +659,8 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
                                      OPND_CREATE_INT(-value)));
         }
         MINSERT(ilist, where,
-                INST_CREATE_stlr(drcontext, OPND_CREATE_MEMPTR(reg1, 0),
-                                 opnd_create_reg(reg2)));
+                INSTR_CREATE_stlr(drcontext, OPND_CREATE_MEMPTR(reg1, 0),
+                                  opnd_create_reg(reg2)));
 #    else /* ARM */
         /* TODO: This counter update has not been tested on a ARM_32 machine. */
         MINSERT(ilist, where,


### PR DESCRIPTION
Corrects INST_CREATE_stlr to INSTR_CREATE_stlr.  Leaves an alias with
the old, incorrect name in case there are any uses outside of this
repository.