### PR TITLE
i#4134 drbbdup: Add acquire semantics to case loading

### DIFF
--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc.   All rights reserved.
+ * Copyright (c) 2020-2022 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -272,8 +272,8 @@ typedef struct {
      */
     opnd_t runtime_case_opnd;
     /**
-     * Instructs drbbdup whether or not the loading of the runtime case should be
-     * locked/atomic.
+     * Instructs drbbdup whether or not the loading of the runtime case should use
+     * release-acquire semantics.
      */
     bool atomic_load_encoding;
     /**

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -551,9 +551,9 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
 
     /* check whether we can add lock */
     if (TEST(DRX_COUNTER_LOCK, flags)) {
-#ifdef ARM
-        /* FIXME i#1551: implement for ARM */
-        ASSERT(false, "DRX_COUNTER_LOCK not implemented for ARM");
+#ifdef AARCHXX
+        /* TODO i#1551,i#1569: implement for AArchXX. */
+        ASSERT(false, "DRX_COUNTER_LOCK not implemented for AArchXX");
         return false;
 #endif
         if (IF_NOT_X64(is_64 ||) /* 64-bit counter in 32-bit mode */
@@ -588,6 +588,9 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
         OPND_CREATE_INT_32OR8(value));
     if (TEST(DRX_COUNTER_LOCK, flags))
         instr = LOCK(instr);
+    /* On x86, for DRX_COUNTER_REL_ACQ, we don't need to do anything as the
+     * ISA provides release-acquire semantics for regular stores and loads.
+     */
     MINSERT(ilist, where, instr);
 
 #    ifndef X64
@@ -662,7 +665,6 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
                 INSTR_CREATE_stlr(drcontext, OPND_CREATE_MEMPTR(reg1, 0),
                                   opnd_create_reg(reg2)));
 #    else /* ARM */
-        /* TODO: This counter update has not been tested on a ARM_32 machine. */
         MINSERT(ilist, where,
                 XINST_CREATE_load(drcontext, opnd_create_reg(reg2),
                                   OPND_CREATE_MEMPTR(reg1, 0)));

--- a/suite/tests/client-interface/drbbdup-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-test.dll.c
@@ -264,6 +264,8 @@ dr_init(client_id_t id)
     opts.destroy_case_analysis = destroy_analysis;
     opts.instrument_instr = instrument_instr;
     opts.runtime_case_opnd = OPND_CREATE_ABSMEM(&encode_val, OPSZ_PTR);
+    /* Though single-threaded, we sanity-check the atomic load feature. */
+    opts.atomic_load_encoding = true;
     opts.user_data = USER_DATA_VAL;
     opts.non_default_case_limit = 2;
     opts.is_stat_enabled = true;


### PR DESCRIPTION
Updates drbbdup_options_t.atomic_load_encoding to provide acquire
semantics, which is all that's generally needed for a load of a flag.

Implements the option on AArchXX (nothing to do on x86).

Adds a sanity test to one of the existing tests, ensuring the code
generated at least executes succesfully in one thread.

Issue: #4134