### PR TITLE
i#4134 drbbdup: Avoid 2nd scratch via max_case_encoding

### DIFF
--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc.   All rights reserved.
+ * Copyright (c) 2020-2022 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -301,6 +301,12 @@ typedef struct {
      * set to true.
      */
     bool is_stat_enabled;
+    /**
+     * Gives an upper bound on the value of all case encodings.  This is used to
+     * optimize the dispatch code on AArchXX: in particular, an upper bound <256
+     * avoids an extra scratch register.  Set to 0 to indicate there is no bound.
+     */
+    uintptr_t max_case_encoding;
 } drbbdup_options_t;
 
 /**

--- a/suite/tests/client-interface/drbbdup-no-encode-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-no-encode-test.dll.c
@@ -120,6 +120,8 @@ dr_init(client_id_t id)
     opts.instrument_instr = instrument_instr;
     opts.runtime_case_opnd = OPND_CREATE_ABSMEM(&case_encoding, OPSZ_PTR);
     opts.atomic_load_encoding = false;
+    /* Test optimizations with case comparisons. */
+    opts.max_case_encoding = 1;
     opts.user_data = USER_DATA_VAL;
     opts.non_default_case_limit = 1;
 


### PR DESCRIPTION
Adds a new drbbdup option max_case_encoding.  When the value is small,
we can avoid a 2nd scratch register for aarchxx, since we can fit all
encodings in immediates inside compare instructions.

Adds a sanity check.
Confirmed visually in the debug logs that the 2nd scratch is gone:
Before:
```
  --------------------------------------------------
  after instrumentation:
  TAG  0x0000ffff868340c0
   +0    m4 @0x0000fffd428950e8  f900b781   str    %x1 -> +0x0168(%x28)[8byte]
   +4    m4 @0x0000fffd42894da0  d53b4200   mrs    %nzcv -> %x0
   +8    m4 @0x0000fffd42894cd8  f900af80   str    %x0 -> +0x0158(%x28)[8byte]
   +12   m4 @0x0000fffd42894c58  d28c1000   movz   $0x6080 lsl $0x00 -> %x0
   +16   m4 @0x0000fffd42894bd8  f2a85000   movk   %x0 $0x4280 lsl $0x10 -> %x0
   +20   m4 @0x0000fffd42894b10  f2dfffe0   movk   %x0 $0xffff lsl $0x20 -> %x0
   +24   m4 @0x0000fffd42894a48  f9400000   ldr    (%x0)[8byte] -> %x0
   +28   m4 @0x0000fffd42894e20  f9400000   <label>
   +28   m4 @0x0000fffd42894980  f100041f   subs   %x0 $0x0000000000000001 lsl $0x0000000000000000 -> %xzr
   +32   m4 @0x0000fffd42894900  54000001   b.ne   @0x0000fffd42894fa0[8byte]
  --------------------------------------------------
```
After:
```
  --------------------------------------------------
  after instrumentation:
  TAG  0x0000ffff9aedf0c0
   +0    m4 @0x0000fffd56f400e8  d53b4200   mrs    %nzcv -> %x0
   +4    m4 @0x0000fffd56f3fda0  f900af80   str    %x0 -> +0x0158(%x28)[8byte]
   +8    m4 @0x0000fffd56f3fcd8  d2821000   movz   $0x1080 lsl $0x00 -> %x0
   +12   m4 @0x0000fffd56f3fc58  f2aadd60   movk   %x0 $0x56eb lsl $0x10 -> %x0
   +16   m4 @0x0000fffd56f3fbd8  f2dfffe0   movk   %x0 $0xffff lsl $0x20 -> %x0
   +20   m4 @0x0000fffd56f3fb10  f9400000   ldr    (%x0)[8byte] -> %x0
   +24   m4 @0x0000fffd56f3fe20  f9400000   <label>
   +24   m4 @0x0000fffd56f3fa48  f100041f   subs   %x0 $0x0000000000000001 lsl $0x0000000000000000 -> %xzr
   +28   m4 @0x0000fffd56f3f980  54000001   b.ne   @0x0000fffd56f3ffa0[8byte]
  --------------------------------------------------
```

Issue: #4134