### PR TITLE
i#4134 drbbdup: Avoid flags preservation for 2 cases

### DIFF
--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -1006,7 +1006,7 @@ drbbdup_insert_dispatch(void *drcontext, instrlist_t *bb, instr_t *where,
         /* Use an aflags-less jump-if-zero. */
         avoid_flags = true;
         if (current_case->encoding != 0) {
-            /* Invert the compare. */
+            /* Invert the compare to ensure comparison with zero. */
             ASSERT(manager->default_case.encoding == 0, "not zero-vs-nonzero");
             current_case = &manager->default_case;
             jmp_if_equal = true;

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -80,6 +80,7 @@ typedef enum {
 
 /* A scratch register used by drbbdup's dispatcher. */
 #define DRBBDUP_SCRATCH_REG IF_X86_ELSE(DR_REG_XAX, DR_REG_R0)
+#define DRBBDUP_SCRATCH_REG_NO_FLAGS IF_X86_ELSE(DR_REG_XCX, DR_REG_R0)
 #ifdef AARCHXX
 /* RISC architectures need a 2nd scratch register. */
 #    define DRBBDUP_SCRATCH_REG2 DR_REG_R1
@@ -101,6 +102,7 @@ typedef struct {
     bool enable_dynamic_handling; /* Denotes whether to dynamically generate cases. */
     bool are_flags_dead;      /* Denotes whether flags are dead at the start of a bb. */
     bool is_scratch_reg_dead; /* Denotes whether DRBBDUP_SCRATCH_REG is dead at start. */
+    reg_id_t scratch_reg;
 #ifdef AARCHXX
     bool is_scratch_reg2_dead; /* Whether DRBBDUP_SCRATCH_REG2 is dead at start. */
 #endif
@@ -226,6 +228,27 @@ drbbdup_count(drbbdup_manager_t *manager)
     return count;
 }
 
+/* Returns whether there are only two cases and one has a zero encoding. */
+static bool
+drbbdup_case_zero_vs_nonzero(drbbdup_manager_t *manager)
+{
+    ASSERT(manager != NULL, "should not be NULL");
+    if (manager->enable_dynamic_handling)
+        return false; /* More cases could be added. */
+    uintptr_t nondefault_encoding = 0;
+    bool found = false;
+    for (int i = 0; i < opts.non_default_case_limit; i++) {
+        if (manager->cases[i].is_defined) {
+            if (found)
+                return false;
+            found = true;
+            nondefault_encoding = manager->cases[i].encoding;
+        }
+    }
+    ASSERT(found, "must be one non-default case");
+    return nondefault_encoding == 0 || manager->default_case.encoding == 0;
+}
+
 /* Clone from original instrlist, but place duplication in bb. */
 static void
 drbbdup_add_copy(void *drcontext, instrlist_t *bb, instrlist_t *orig_bb)
@@ -256,6 +279,7 @@ drbbdup_create_manager(void *drcontext, void *tag, instrlist_t *bb)
     manager->enable_dup = true;
     manager->enable_dynamic_handling = true;
     manager->is_gen = false;
+    manager->scratch_reg = DRBBDUP_SCRATCH_REG;
 
     ASSERT(opts.set_up_bb_dups != NULL, "set up call-back cannot be NULL");
     manager->default_case.encoding =
@@ -690,12 +714,12 @@ drbbdup_insert_landing_restoration(void *drcontext, instrlist_t *bb, instr_t *wh
 {
     if (!manager->are_flags_dead) {
         drbbdup_restore_register(drcontext, bb, where, DRBBDUP_FLAG_REG_SLOT,
-                                 DRBBDUP_SCRATCH_REG);
-        dr_restore_arith_flags_from_reg(drcontext, bb, where, DRBBDUP_SCRATCH_REG);
+                                 manager->scratch_reg);
+        dr_restore_arith_flags_from_reg(drcontext, bb, where, manager->scratch_reg);
     }
     if (!manager->is_scratch_reg_dead) {
         drbbdup_restore_register(drcontext, bb, where, DRBBDUP_SCRATCH_REG_SLOT,
-                                 DRBBDUP_SCRATCH_REG);
+                                 manager->scratch_reg);
     }
 #ifdef AARCHXX
     if (!manager->is_scratch_reg2_dead) {
@@ -727,12 +751,18 @@ drbbdup_encode_runtime_case(void *drcontext, drbbdup_per_thread *pt, void *tag,
      * manually perform the spilling for finer control across branches used by the
      * dispatcher.
      */
-    drreg_are_aflags_dead(drcontext, where, &manager->are_flags_dead);
-    drreg_is_register_dead(drcontext, DRBBDUP_SCRATCH_REG, where,
+    if (drbbdup_case_zero_vs_nonzero(manager)) {
+        manager->are_flags_dead = true; /* Not used, so don't restore. */
+        manager->scratch_reg = DRBBDUP_SCRATCH_REG_NO_FLAGS;
+    } else {
+        drreg_are_aflags_dead(drcontext, where, &manager->are_flags_dead);
+        manager->scratch_reg = DRBBDUP_SCRATCH_REG;
+    }
+    drreg_is_register_dead(drcontext, manager->scratch_reg, where,
                            &manager->is_scratch_reg_dead);
     if (!manager->is_scratch_reg_dead) {
         drbbdup_spill_register(drcontext, bb, where, DRBBDUP_SCRATCH_REG_SLOT,
-                               DRBBDUP_SCRATCH_REG);
+                               manager->scratch_reg);
     }
 #ifdef AARCHXX
     drreg_is_register_dead(drcontext, DRBBDUP_SCRATCH_REG2, where,
@@ -746,12 +776,12 @@ drbbdup_encode_runtime_case(void *drcontext, drbbdup_per_thread *pt, void *tag,
     }
 #endif
     if (!manager->are_flags_dead) {
-        dr_save_arith_flags_to_reg(drcontext, bb, where, DRBBDUP_SCRATCH_REG);
+        dr_save_arith_flags_to_reg(drcontext, bb, where, manager->scratch_reg);
         drbbdup_spill_register(drcontext, bb, where, DRBBDUP_FLAG_REG_SLOT,
-                               DRBBDUP_SCRATCH_REG);
+                               manager->scratch_reg);
         if (!manager->is_scratch_reg_dead) {
             drbbdup_restore_register(drcontext, bb, where, DRBBDUP_SCRATCH_REG_SLOT,
-                                     DRBBDUP_SCRATCH_REG);
+                                     manager->scratch_reg);
         }
     }
 
@@ -777,7 +807,7 @@ drbbdup_encode_runtime_case(void *drcontext, drbbdup_per_thread *pt, void *tag,
     /* Load the encoding to the scratch register. */
     /* FIXME i#4134: Perform lock if opts.atomic_load_encoding is set. */
     opnd_t case_opnd = opts.runtime_case_opnd;
-    opnd_t scratch_reg_opnd = opnd_create_reg(DRBBDUP_SCRATCH_REG);
+    opnd_t scratch_reg_opnd = opnd_create_reg(manager->scratch_reg);
 #ifdef AARCHXX
     if (opnd_is_rel_addr(case_opnd)) {
         /* Work around two problems:
@@ -789,24 +819,63 @@ drbbdup_encode_runtime_case(void *drcontext, drbbdup_per_thread *pt, void *tag,
          */
         instrlist_insert_mov_immed_ptrsz(drcontext, (ptr_int_t)opnd_get_addr(case_opnd),
                                          scratch_reg_opnd, bb, where, NULL, NULL);
-        case_opnd = OPND_CREATE_MEMPTR(DRBBDUP_SCRATCH_REG, 0);
+        case_opnd = OPND_CREATE_MEMPTR(manager->scratch_reg, 0);
     }
 #endif
     instr_t *instr = XINST_CREATE_load(drcontext, scratch_reg_opnd, case_opnd);
     instrlist_meta_preinsert(bb, where, instr);
 }
 
+/* If avoid_flags and current_case->encoding == 0, uses a compare that does not
+ * affect the flags.
+ */
 static void
 drbbdup_insert_compare_encoding_and_branch(void *drcontext, instrlist_t *bb,
                                            instr_t *where, drbbdup_case_t *current_case,
-                                           reg_id_t reg_encoding, bool jmp_if_equal,
-                                           instr_t *jmp_label)
+                                           bool avoid_flags, reg_id_t reg_encoding,
+                                           bool jmp_if_equal, instr_t *jmp_label)
 {
 #ifdef X86
+    if (avoid_flags && current_case->encoding == 0) {
+        /* JECXZ is a slow instruction on modern processors.  But, it avoids spilling and
+         * restoring the flags.  In some quick SPEC2006 tests, a trivial client with no
+         * instrumentation was slower with JECXZ than with flag preservation on bzip2
+         * test, but faster on mcf test (more memory pressure).  With more
+         * instrumentation the mcf result might hold on typical clients and apps; more
+         * experimentation is needed.  For now we keep JECXZ as the default; we can make
+         * it under an option or remove it if we find evidence that mcf w/ a trivial
+         * client is the outlier.
+         */
+        ASSERT(reg_encoding == DR_REG_XCX, "scratch must be xcx");
+        /* To avoid any problems with reach we use landing pads. */
+        if (jmp_if_equal) {
+            /* We could use "LEA xcx+1; LOOP" for a "JECXNZ" but I measured it and
+             * it is quite slow: LOOP is much worse than JECXZ apparently.
+             * We document that is is better to have the default case be the non-zero
+             * one, landing in the else below with fewer jumps.
+             */
+            instr_t *dojmp = INSTR_CREATE_label(drcontext);
+            instr_t *nojmp = INSTR_CREATE_label(drcontext);
+            instrlist_meta_preinsert(
+                bb, where, INSTR_CREATE_jecxz(drcontext, opnd_create_instr(dojmp)));
+            instrlist_meta_preinsert(
+                bb, where, XINST_CREATE_jump(drcontext, opnd_create_instr(nojmp)));
+            instrlist_meta_preinsert(bb, where, dojmp);
+            instrlist_meta_preinsert(
+                bb, where, XINST_CREATE_jump(drcontext, opnd_create_instr(jmp_label)));
+            instrlist_meta_preinsert(bb, where, nojmp);
+        } else {
+            instr_t *nojmp = INSTR_CREATE_label(drcontext);
+            instrlist_meta_preinsert(
+                bb, where, INSTR_CREATE_jecxz(drcontext, opnd_create_instr(nojmp)));
+            instrlist_meta_preinsert(
+                bb, where, XINST_CREATE_jump(drcontext, opnd_create_instr(jmp_label)));
+            instrlist_meta_preinsert(bb, where, nojmp);
+        }
+        return;
+    }
 #    ifdef X86_64
-    /* XXX: We could use an immediate for small values.
-     * We could also use jecxz and avoid flags altogether for zero values.
-     */
+    /* XXX: We could use an immediate for small values. */
     opnd_t opnd = opnd_create_abs_addr(&current_case->encoding, OPSZ_PTR);
     instrlist_meta_preinsert(
         bb, where, XINST_CREATE_cmp(drcontext, opnd, opnd_create_reg(reg_encoding)));
@@ -819,11 +888,7 @@ drbbdup_insert_compare_encoding_and_branch(void *drcontext, instrlist_t *bb,
                              INSTR_CREATE_jcc(drcontext, jmp_if_equal ? OP_jz : OP_jnz,
                                               opnd_create_instr(jmp_label)));
 #elif defined(AARCHXX)
-    bool inserted = false;
-    if (current_case->encoding == 0) {
-        /* XXX: CBZ does not touch the flags, so we could avoid the flags save if
-         * this is the only case.
-         */
+    if (avoid_flags && current_case->encoding == 0) {
 #    ifdef AARCH64
         if (jmp_if_equal) {
             instrlist_meta_preinsert(bb, where,
@@ -836,7 +901,7 @@ drbbdup_insert_compare_encoding_and_branch(void *drcontext, instrlist_t *bb,
                                                        opnd_create_instr(jmp_label),
                                                        opnd_create_reg(reg_encoding)));
         }
-        inserted = true;
+        return;
 #    else
         if (dr_get_isa_mode(drcontext) == DR_ISA_ARM_THUMB &&
             reg_encoding <= DR_REG_R7) { /* CBZ can't take r8+ */
@@ -856,11 +921,11 @@ drbbdup_insert_compare_encoding_and_branch(void *drcontext, instrlist_t *bb,
             instrlist_meta_preinsert(
                 bb, where, XINST_CREATE_jump(drcontext, opnd_create_instr(jmp_label)));
             instrlist_meta_preinsert(bb, where, nojmp);
-            inserted = true;
+            return;
         }
 #    endif
     }
-    if (!inserted && current_case->encoding < 256) {
+    if (current_case->encoding < 256) {
         /* Various larger immediates can be handled but it varies by ISA and mode.
          * XXX: Should DR provide utilities to help figure out whether an integer
          * will fit in a compare immediate?
@@ -872,25 +937,22 @@ drbbdup_insert_compare_encoding_and_branch(void *drcontext, instrlist_t *bb,
             bb, where,
             XINST_CREATE_jump_cond(drcontext, jmp_if_equal ? DR_PRED_EQ : DR_PRED_NE,
                                    opnd_create_instr(jmp_label)));
-        inserted = true;
+        return;
     }
-    if (!inserted) {
-        /* TODO i#4134: Add a user-set flag promising that runtime case values are
-         * always <256 so we know we don't need this 2nd scratch register; then
-         * assert if we end up here and the flag is set.
-         */
-        instrlist_insert_mov_immed_ptrsz(drcontext, current_case->encoding,
-                                         opnd_create_reg(DRBBDUP_SCRATCH_REG2), bb, where,
-                                         NULL, NULL);
-        instrlist_meta_preinsert(bb, where,
-                                 XINST_CREATE_cmp(drcontext,
-                                                  opnd_create_reg(reg_encoding),
-                                                  opnd_create_reg(DRBBDUP_SCRATCH_REG2)));
-        instrlist_meta_preinsert(
-            bb, where,
-            XINST_CREATE_jump_cond(drcontext, jmp_if_equal ? DR_PRED_EQ : DR_PRED_NE,
-                                   opnd_create_instr(jmp_label)));
-    }
+    /* TODO i#4134: Add a user-set flag promising that runtime case values are
+     * always <256 so we know we don't need this 2nd scratch register; then
+     * assert if we end up here and the flag is set.
+     */
+    instrlist_insert_mov_immed_ptrsz(drcontext, current_case->encoding,
+                                     opnd_create_reg(DRBBDUP_SCRATCH_REG2), bb, where,
+                                     NULL, NULL);
+    instrlist_meta_preinsert(bb, where,
+                             XINST_CREATE_cmp(drcontext, opnd_create_reg(reg_encoding),
+                                              opnd_create_reg(DRBBDUP_SCRATCH_REG2)));
+    instrlist_meta_preinsert(
+        bb, where,
+        XINST_CREATE_jump_cond(drcontext, jmp_if_equal ? DR_PRED_EQ : DR_PRED_NE,
+                               opnd_create_instr(jmp_label)));
 #endif
 }
 
@@ -908,9 +970,20 @@ drbbdup_insert_dispatch(void *drcontext, instrlist_t *bb, instr_t *where,
 
     /* If runtime encoding not equal to encoding of current case, just jump to next.
      */
+    bool jmp_if_equal = false, avoid_flags = false;
+    if (drbbdup_case_zero_vs_nonzero(manager)) {
+        /* Use an aflags-less jump-if-zero. */
+        avoid_flags = true;
+        if (current_case->encoding != 0) {
+            /* Invert the compare. */
+            ASSERT(manager->default_case.encoding == 0, "not zero-vs-nonzero");
+            current_case = &manager->default_case;
+            jmp_if_equal = true;
+        }
+    }
     drbbdup_insert_compare_encoding_and_branch(drcontext, bb, where, current_case,
-                                               DRBBDUP_SCRATCH_REG,
-                                               false /*=jmp_if_equal*/, next_label);
+                                               avoid_flags, manager->scratch_reg,
+                                               jmp_if_equal, next_label);
 
     /* If fall-through, restore regs back to their original values. */
     drbbdup_insert_landing_restoration(drcontext, bb, where, manager);
@@ -950,7 +1023,7 @@ drbbdup_insert_dynamic_handling(void *drcontext, app_pc translation_pc, void *ta
                                 drbbdup_manager_t *manager)
 {
     instr_t *instr;
-    opnd_t drbbdup_opnd = opnd_create_reg(DRBBDUP_SCRATCH_REG);
+    opnd_t drbbdup_opnd = opnd_create_reg(manager->scratch_reg);
 
     instr_t *done_label = INSTR_CREATE_label(drcontext);
 
@@ -962,11 +1035,11 @@ drbbdup_insert_dynamic_handling(void *drcontext, app_pc translation_pc, void *ta
         /* Jump if runtime encoding matches default encoding.
          * Unknown encoding encountered upon fall-through.
          */
-        drbbdup_insert_compare_encoding_and_branch(drcontext, bb, where, default_case,
-                                                   DRBBDUP_SCRATCH_REG,
-                                                   true /*=jmp_if_equal*/, done_label);
+        drbbdup_insert_compare_encoding_and_branch(
+            drcontext, bb, where, default_case, false /*avoid_flags*/,
+            manager->scratch_reg, true /*=jmp_if_equal*/, done_label);
 
-        /* We need DRBBDUP_SCRATCH_REG. Bail on keeping the encoding in the register. */
+        /* We need manager->scratch_reg. Bail on keeping the encoding in the register. */
         opnd_t encoding_opnd =
             drbbdup_get_tls_raw_slot_opnd(drcontext, DRBBDUP_ENCODING_SLOT);
         instr = XINST_CREATE_store(drcontext, encoding_opnd, drbbdup_opnd);
@@ -985,7 +1058,7 @@ drbbdup_insert_dynamic_handling(void *drcontext, app_pc translation_pc, void *ta
             /* Register hit. */
             uint hash = drbbdup_get_hitcount_hash((intptr_t)translation_pc);
             opnd_t hit_count_opnd =
-                OPND_CREATE_MEM16(DRBBDUP_SCRATCH_REG, hash * sizeof(ushort));
+                OPND_CREATE_MEM16(manager->scratch_reg, hash * sizeof(ushort));
 #ifdef X86
             instr = INSTR_CREATE_sub(drcontext, hit_count_opnd,
                                      opnd_create_immed_uint(1, OPSZ_2));
@@ -1328,7 +1401,7 @@ drbbdup_prepare_redirect(dr_mcontext_t *mcontext, drbbdup_manager_t *manager,
         mcontext->xflags = dr_merge_arith_flags(mcontext->xflags, val);
     }
     if (!manager->is_scratch_reg_dead) {
-        reg_set_value(DRBBDUP_SCRATCH_REG, mcontext,
+        reg_set_value(manager->scratch_reg, mcontext,
                       (reg_t)drbbdup_get_tls_raw_slot_val(DRBBDUP_SCRATCH_REG_SLOT));
     }
 
@@ -1370,6 +1443,7 @@ drbbdup_handle_new_case()
     ASSERT(manager->enable_dup, "duplication should be enabled");
     ASSERT(new_encoding != manager->default_case.encoding,
            "unhandled encoding cannot be the default case");
+    ASSERT(manager->scratch_reg == DRBBDUP_SCRATCH_REG, "must have main scratch reg");
 
     /* Could have been turned off potentially by another thread. */
     if (manager->enable_dynamic_handling) {

--- a/ext/drbbdup/drbbdup.dox
+++ b/ext/drbbdup/drbbdup.dox
@@ -87,6 +87,11 @@ default case as well as register additional case encodings via
 disable duplication for this particular basic block by falsifying a flag that is
 provided to the call-back function.
 
+When only two cases are used, the default and one additional, and the
+encoding value for one of them is zero, drbbdup is able to generate
+faster case dispatch code.  To produce optimal code for x86, it is best to
+have the default case use the non-zero encoding.
+
 \section sec_drbbdup_analysis Case Analysis
 
 There are two types of analysis call-back functions that are supported by drbbdup.
@@ -122,8 +127,12 @@ current runtime case encoding and dispatch control accordingly.
 The #drbbdup_insert_encode_t call-back may also be set to NULL which results in the
 dispatcher not attempting the construction of the runtime case at every start of
 a basic block execution. In such cases, it is expected that the client directly
-sets the runtime encoding directly and updates the value on demand. The drbbdup extension
+sets the runtime encoding and updates the value on demand. The drbbdup extension
 guarantees that it does not modify the set encoding on its own accord.
+
+A PC-relative case encoding operand is supported on AArchXX, with
+drbbdup adding code to obtain the linear address and so avoid
+reachability problems.
 
 \section sec_drbbdup_instrum Case Instrumentation
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2574,6 +2574,11 @@ use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drmgr)
 use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drreg)
 use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drbbdup)
 
+tobuild_ci(client.drbbdup-nonzero-test client-interface/drbbdup-nonzero-test.c "" "" "")
+use_DynamoRIO_extension(client.drbbdup-nonzero-test.dll drmgr)
+use_DynamoRIO_extension(client.drbbdup-nonzero-test.dll drreg)
+use_DynamoRIO_extension(client.drbbdup-nonzero-test.dll drbbdup)
+
 tobuild_ci(client.drbbdup-analysis-test client-interface/drbbdup-analysis-test.c "" "" "")
 use_DynamoRIO_extension(client.drbbdup-analysis-test.dll drmgr)
 use_DynamoRIO_extension(client.drbbdup-analysis-test.dll drreg)
@@ -4853,6 +4858,7 @@ if (NOT ANDROID AND AARCHXX)
     code_api|client.destructor
     code_api|client.drbbdup-test
     code_api|client.drbbdup-no-encode-test
+    code_api|client.drbbdup-nonzero-test
     code_api|client.drbbdup-analysis-test
     code_api|client.drcontainers-test
     code_api|client.drmodtrack-test

--- a/suite/tests/client-interface/drbbdup-nonzero-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-nonzero-test.dll.c
@@ -1,0 +1,130 @@
+/* **********************************************************
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Similar to drbbdup-no-encode-test, but we have a non-zero default and a zero
+ * non-default case, to test optimizations in encoding comparison checks.
+ */
+
+#include "dr_api.h"
+#include "drmgr.h"
+#include "drbbdup.h"
+
+#define CHECK(x, msg)                                                                \
+    do {                                                                             \
+        if (!(x)) {                                                                  \
+            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
+            dr_abort();                                                              \
+        }                                                                            \
+    } while (0);
+
+#define USER_DATA_VAL (void *)222
+static uintptr_t case_encoding = 1;
+static bool instrum_called = false;
+
+static uintptr_t
+set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
+               bool *enable_dups, bool *enable_dynamic_handling, void *user_data)
+{
+    drbbdup_status_t res;
+
+    CHECK(enable_dups != NULL, "should not be NULL");
+    CHECK(enable_dynamic_handling != NULL, "should not be NULL");
+    CHECK(user_data == USER_DATA_VAL, "user data does not match");
+
+    res = drbbdup_register_case_encoding(drbbdup_ctx, 0); /* zero non-default case */
+    CHECK(res == DRBBDUP_SUCCESS, "failed to register case 1");
+
+    *enable_dups = true;
+    *enable_dynamic_handling = false; /* disable dynamic handling */
+    return 1;                         /* return non-zero default case */
+}
+
+static void
+print_case(uintptr_t case_val)
+{
+    dr_fprintf(STDERR, "case %u\n", case_val);
+}
+
+static void
+instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
+                 instr_t *where, uintptr_t encoding, void *user_data,
+                 void *orig_analysis_data, void *analysis_data)
+{
+    bool is_start;
+    drbbdup_status_t res;
+
+    CHECK(user_data == USER_DATA_VAL, "user data does not match");
+    CHECK(orig_analysis_data == NULL, "orig analysis data should be NULL");
+    CHECK(analysis_data == NULL, "analysis should be NULL");
+
+    res = drbbdup_is_first_instr(drcontext, instr, &is_start);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is start");
+
+    if (is_start && encoding != 1) {
+        dr_insert_clean_call(drcontext, bb, where, print_case, false, 1,
+                             OPND_CREATE_INTPTR(encoding));
+    } else {
+        instrum_called = true;
+    }
+}
+
+static void
+event_exit(void)
+{
+    drbbdup_status_t res = drbbdup_exit();
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup exit failed");
+    CHECK(case_encoding = 1, "encoding has be 1");
+    CHECK(instrum_called, "instrumentation was not inserted");
+
+    drmgr_exit();
+}
+
+DR_EXPORT void
+dr_init(client_id_t id)
+{
+    drmgr_init();
+
+    drbbdup_options_t opts = { 0 };
+    opts.struct_size = sizeof(drbbdup_options_t);
+    opts.set_up_bb_dups = set_up_bb_dups;
+    opts.instrument_instr = instrument_instr;
+    opts.runtime_case_opnd = OPND_CREATE_ABSMEM(&case_encoding, OPSZ_PTR);
+    opts.atomic_load_encoding = false;
+    /* Test optimizations with case comparisons. */
+    opts.max_case_encoding = 1;
+    opts.user_data = USER_DATA_VAL;
+    opts.non_default_case_limit = 1;
+
+    drbbdup_status_t res = drbbdup_init(&opts);
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup init failed");
+    dr_register_exit_event(event_exit);
+}

--- a/suite/tests/client-interface/drbbdup-nonzero-test.expect
+++ b/suite/tests/client-interface/drbbdup-nonzero-test.expect
@@ -1,0 +1,1 @@
+Hello, world!


### PR DESCRIPTION
When there are just 2 drbbdup cases and one has an encoding of zero,
we can use a flags-free jump-if-register-is-zero for our dispatch,
avoiding flags preservation costs.

Applies this to x86 as well by switching to the xcx scratch register
and using JECXZ.  JECXZ is relatively slow on modern processors.  I
measure its performance, and it depends on the application whether it
out-performs savings the flags.  I left it as the default with hopes
that it will help more often than not on larger clients and
applications, but we can remove it if that is not borne out in future
evaluations.

The existing no-encode-test meets the criteria and serves as a test.

Before:
```
  --------------------------------------------------
  after instrumentation:
  TAG  0x0000ffff868340c0
   +0    m4 @0x0000fffd428950e8  f900b781   str    %x1 -> +0x0168(%x28)[8byte]
   +4    m4 @0x0000fffd42894da0  d53b4200   mrs    %nzcv -> %x0
   +8    m4 @0x0000fffd42894cd8  f900af80   str    %x0 -> +0x0158(%x28)[8byte]
   +12   m4 @0x0000fffd42894c58  d28c1000   movz   $0x6080 lsl $0x00 -> %x0
   +16   m4 @0x0000fffd42894bd8  f2a85000   movk   %x0 $0x4280 lsl $0x10 -> %x0
   +20   m4 @0x0000fffd42894b10  f2dfffe0   movk   %x0 $0xffff lsl $0x20 -> %x0
   +24   m4 @0x0000fffd42894a48  f9400000   ldr    (%x0)[8byte] -> %x0
   +28   m4 @0x0000fffd42894e20  f9400000   <label>
   +28   m4 @0x0000fffd42894980  f100041f   subs   %x0 $0x0000000000000001 lsl $0x0000000000000000 -> %xzr
   +32   m4 @0x0000fffd42894900  54000001   b.ne   @0x0000fffd42894fa0[8byte]
  --------------------------------------------------
```
After:
```
  --------------------------------------------------
  after instrumentation:
  TAG  0x0000ffffa53f20c0
   +0    m4 @0x0000fffd614530e8  f900b781   str    %x1 -> +0x0168(%x28)[8byte]
   +4    m4 @0x0000fffd61452da0  d28a1000   movz   $0x5080 lsl $0x00 -> %x0
   +8    m4 @0x0000fffd61452cd8  f2ac2780   movk   %x0 $0x613c lsl $0x10 -> %x0
   +12   m4 @0x0000fffd61452c58  f2dfffe0   movk   %x0 $0xffff lsl $0x20 -> %x0
   +16   m4 @0x0000fffd61452bd8  f9400000   ldr    (%x0)[8byte] -> %x0
   +20   m4 @0x0000fffd61452e20  f9400000   <label>
   +20   m4 @0x0000fffd61452b10  b4000000   cbz    @0x0000fffd61452fa0[8byte] %x0
  --------------------------------------------------
```

Issue: #4134