### PR TITLE
i#5320: Fix error handling in in x86 decode_modrm

### DIFF
--- a/core/ir/x86/decode.c
+++ b/core/ir/x86/decode.c
@@ -1755,6 +1755,8 @@ decode_modrm(decode_info_t *di, byte optype, opnd_size_t opsize, opnd_t *reg_opn
         int compressed_disp_scale = 0;
         if (di->evex_encoded) {
             compressed_disp_scale = decode_get_compressed_disp_scale(di);
+            if (compressed_disp_scale == -1)
+                return false;
             needs_full_disp = disp % compressed_disp_scale != 0;
         }
         force_full_disp = !needs_full_disp && di->has_disp && disp >= INT8_MIN &&

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1034,7 +1034,7 @@ test_modrm_invalid(void *dc)
 {
 /* Decoding succeeds on 32-bits. */
 #ifdef X64
-    /* Fuzzer-generated random data (i5320). */
+    /* Fuzzer-generated random data (i#5320). */
     byte data[16] = { 0x62, 0x03, 0xa5, 0x62, 0x03, 0xa5 };
     instr_t *instr = instr_create(dc);
     byte *end = decode(dc, data, instr);

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1028,6 +1028,18 @@ test_modrm16(void *dc)
     test_modrm16_helper(dc, DR_REG_BX, DR_REG_NULL, 0x80, 5);
 }
 
+/* Just check that decoding fails silently on invalid data. */
+static void
+test_modrm_invalid(void *dc)
+{
+    /* Fuzzer-generated random data (i5320). */
+    byte data[16] = {0x62, 0x03, 0xa5, 0x62, 0x03, 0xa5};
+    instr_t *instr = instr_create(dc);
+    byte *end = decode(dc, data, instr);
+    ASSERT(end == NULL);
+    instr_destroy(dc, instr);
+}
+
 /* PR 215143: auto-magically add size prefixes */
 static void
 test_size_changes(void *dc)
@@ -2529,6 +2541,8 @@ main(int argc, char *argv[])
 #ifndef X64
     test_modrm16(dcontext);
 #endif
+
+    test_modrm_invalid(dcontext);
 
     test_size_changes(dcontext);
 

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1033,7 +1033,7 @@ static void
 test_modrm_invalid(void *dc)
 {
     /* Fuzzer-generated random data (i5320). */
-    byte data[16] = {0x62, 0x03, 0xa5, 0x62, 0x03, 0xa5};
+    byte data[16] = { 0x62, 0x03, 0xa5, 0x62, 0x03, 0xa5 };
     instr_t *instr = instr_create(dc);
     byte *end = decode(dc, data, instr);
     ASSERT(end == NULL);

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1032,12 +1032,15 @@ test_modrm16(void *dc)
 static void
 test_modrm_invalid(void *dc)
 {
+/* Decoding succeeds on 32-bits. */
+#ifdef X64
     /* Fuzzer-generated random data (i5320). */
     byte data[16] = { 0x62, 0x03, 0xa5, 0x62, 0x03, 0xa5 };
     instr_t *instr = instr_create(dc);
     byte *end = decode(dc, data, instr);
     ASSERT(end == NULL);
     instr_destroy(dc, instr);
+#endif
 }
 
 /* PR 215143: auto-magically add size prefixes */

--- a/suite/tests/api/ir_x86.templatex
+++ b/suite/tests/api/ir_x86.templatex
@@ -1,4 +1,4 @@
-<Invalid VSIB register encoding encountered>
+(<Invalid VSIB register encoding encountered>
 <Invalid AVX-512 vector length encountered.>
-(<Application .*api\.ir.*AVX-512 was detected at PC 0x[0-9a-f]+. AVX-512 is not fully supported yet.>
+)?(<Application .*api\.ir.*AVX-512 was detected at PC 0x[0-9a-f]+. AVX-512 is not fully supported yet.>
 )?all done

--- a/suite/tests/api/ir_x86.templatex
+++ b/suite/tests/api/ir_x86.templatex
@@ -1,2 +1,4 @@
+<Invalid VSIB register encoding encountered>
+<Invalid AVX-512 vector length encountered.>
 (<Application .*api\.ir.*AVX-512 was detected at PC 0x[0-9a-f]+. AVX-512 is not fully supported yet.>
 )?all done


### PR DESCRIPTION
Fix the following error reported during fuzzing:

core/ir/x86/decode.c:1758:36: runtime error: division of
    -2147483648 by -1 cannot be represented in type 'int'
  in decode_modrm core/ir/x86/decode.c:1758:36
  in decode_operand core/ir/x86/decode.c
  in decode_common core/ir/x86/decode.c:2574:18
  in decode core/ir/x86/decode.c:2695:12

Issues: #5320
