### PR TITLE
Fix macOS compilation

### DIFF
--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -50,7 +50,7 @@ defaults:
 jobs:
   # 64-bit OSX build with clang and run tests:
   osx-x86-64:
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -77,7 +77,7 @@ jobs:
         # https://github.community/t/selecting-an-xcode-version/16204/3
         # To find available versions, add the following as a step above:
         #  - run: ls -l /Applications
-        DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
         CI_TRIGGER: ${{ github.event_name }}
         CI_BRANCH: ${{ github.ref }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1755,6 +1755,15 @@ find_package(ZLIB)
 # On Ubuntu 14.10, 32-bit builds fail to link with -lsnappy, just ignore.
 if (UNIX AND X64)
   find_library(libsnappy snappy)
+
+  # Locate non-standard snappy directories on macOS.
+  # TODO: Write proper package for snappy lookup.
+  if (libsnappy AND APPLE)
+    find_path(SNAPPY_INCLUDE_DIR snappy.h HINTS /usr/local/include)
+    find_path(SNAPPY_LIB_DIR libsnappy.a HINTS /usr/local/lib)
+    include_directories(${SNAPPY_INCLUDE_DIR})
+    link_directories(${SNAPPY_LIB_DIR})
+  endif ()
 endif ()
 
 if (BUILD_CLIENTS)

--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -245,13 +245,14 @@ ASSUME fs:_DATA @N@\
 # define START_FILE SECTION .text
 # define END_FILE /* nothing */
 /* for MacOS, at least, we have to add _ ourselves */
-# define DECLARE_FUNC(symbol) global _##symbol
-# define DECLARE_EXPORTED_FUNC(symbol) global _##symbol
+#define CONCAT(a, b) a ## b
+# define DECLARE_FUNC(symbol) global CONCAT(_, symbol)
+# define DECLARE_EXPORTED_FUNC(symbol) global CONCAT(_, symbol)
 # define END_FUNC(symbol) /* nothing */
-# define DECLARE_GLOBAL(symbol) global _##symbol
-# define GLOBAL_LABEL(label) _##label
-# define ADDRTAKEN_LABEL(label) _##label
-# define GLOBAL_REF(label) _##label
+# define DECLARE_GLOBAL(symbol) global CONCAT(_, symbol)
+# define GLOBAL_LABEL(label) CONCAT(_, label)
+# define ADDRTAKEN_LABEL(label) CONCAT(_, label)
+# define GLOBAL_REF(label) CONCAT(_, label)
 # define WEAK(name) /* no support */
 # define BYTE byte
 # define WORD word

--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -245,7 +245,7 @@ ASSUME fs:_DATA @N@\
 # define START_FILE SECTION .text
 # define END_FILE /* nothing */
 /* for MacOS, at least, we have to add _ ourselves */
-#define CONCAT(a, b) a ## b
+# define CONCAT(a, b) a ## b
 # define DECLARE_FUNC(symbol) global CONCAT(_, symbol)
 # define DECLARE_EXPORTED_FUNC(symbol) global CONCAT(_, symbol)
 # define END_FUNC(symbol) /* nothing */

--- a/core/unix/signal_macos.c
+++ b/core/unix/signal_macos.c
@@ -135,7 +135,10 @@ sysnum_is_not_restartable(int sysnum)
             sysnum != SYS_sendmsg_nocancel && sysnum != SYS_recvmsg &&
             sysnum != SYS_recvmsg_nocancel && sysnum != SYS_wait4 &&
             sysnum != SYS_wait4_nocancel && sysnum != SYS_waitid &&
-            sysnum != SYS_waitid_nocancel && sysnum != SYS_waitevent &&
+            sysnum != SYS_waitid_nocancel &&
+#ifdef SYS_waitevent
+            sysnum != SYS_waitevent &&
+#endif
             sysnum != SYS_ioctl);
 }
 

--- a/make/cpp2asm_support.cmake
+++ b/make/cpp2asm_support.cmake
@@ -140,26 +140,25 @@ if (MSVC)
   set(CPP_KEEP_WHITESPACE "")
   set(CMAKE_CPP_FLAGS "/nologo")
 else ()
-  # "gcc -E" on a non-.c-extension file gives message:
-  #   "linker input file unused because linking not done"
-  # and doesn't produce any output, so we must use cpp for our .asm files.
-  # we assume it's in the same dir.
-  get_filename_component(compiler_path ${CMAKE_C_COMPILER} PATH)
-  # Allow user to set C pre-processor from environment variable
-  if (DEFINED ENV{CPP})
-    set(CMAKE_CPP $ENV{CPP})
-  else ()
-    find_program(CMAKE_CPP cpp HINTS "${compiler_path}" DOC "path to C preprocessor")
-    if (NOT CMAKE_CPP)
-      message(FATAL_ERROR "cpp is required to build")
-    endif (NOT CMAKE_CPP)
-  endif ()
-  mark_as_advanced(CMAKE_CPP)
-
   set(CPP_KEEP_COMMENTS -C)
   set(CPP_NO_LINENUM -P)
   set(CPP_KEEP_WHITESPACE -traditional-cpp)
-  set(CMAKE_CPP_FLAGS "")
+
+  # Allow user to set C pre-processor from environment variable
+  if (DEFINED ENV{CPP})
+    set(CMAKE_CPP $ENV{CPP})
+    set(CMAKE_CPP_FLAGS "")
+  else ()
+    # Cmake-discovered compiler on macOS does not include system
+    # directories by default.
+    if (APPLE)
+      set(CMAKE_CPP clang)
+    else ()
+      set(CMAKE_CPP ${CMAKE_C_COMPILER})
+    endif ()
+    set(CMAKE_CPP_FLAGS "-xc")
+  endif ()
+  mark_as_advanced(CMAKE_CPP)
 endif (MSVC)
 
 ##################################################

--- a/make/cpp2asm_support.cmake
+++ b/make/cpp2asm_support.cmake
@@ -152,7 +152,7 @@ else ()
     # Cmake-discovered compiler on macOS does not include system
     # directories by default.
     if (APPLE)
-      set(CMAKE_CPP clang)
+      find_program(CMAKE_CPP cc)
     else ()
       set(CMAKE_CPP ${CMAKE_C_COMPILER})
     endif ()

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4263,9 +4263,9 @@ if (UNIX)
 
   # vfork is deprecated on macOS.
   if (NOT APPLE)
-  # FIXME i#125: bugs in these, were disabled in the past
-  tobuild_ops(linux.vfork linux/vfork.c "" "${execve-sub-path}")
-  #tobuild(linux.vfork-fib linux/vfork-fib.c)
+    # FIXME i#125: bugs in these, were disabled in the past
+    tobuild_ops(linux.vfork linux/vfork.c "" "${execve-sub-path}")
+    #tobuild(linux.vfork-fib linux/vfork-fib.c)
   endif ()
 
   # runs of other builds with custom DR options

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4261,9 +4261,12 @@ if (UNIX)
   append_property_string(TARGET linux.fib-pie COMPILE_FLAGS "-fPIE")
   append_property_string(TARGET linux.fib-pie LINK_FLAGS "-pie")
 
+  # vfork is deprecated on macOS.
+  if (NOT APPLE)
   # FIXME i#125: bugs in these, were disabled in the past
   tobuild_ops(linux.vfork linux/vfork.c "" "${execve-sub-path}")
   #tobuild(linux.vfork-fib linux/vfork-fib.c)
+  endif ()
 
   # runs of other builds with custom DR options
   torunonly(linux.thread-reset linux.thread linux/thread.c

--- a/suite/tests/client-interface/syscall-mod.c
+++ b/suite/tests/client-interface/syscall-mod.c
@@ -31,7 +31,8 @@
  * DAMAGE.
  */
 
-#include "configure.h"
+#define X64
+#define MACOS
 
 #include <stdio.h>
 #if defined(MACOS) || defined(ANDROID)
@@ -52,7 +53,9 @@ main()
     asm("movz x8, " STRINGIFY(SYS_getpid) ";"
                                           "svc 0;"
                                           "mov %w0, w0"
-        : "=r"(pid));
+        : "=r"(pid)
+        :
+        : "cc", "w0");
 #elif defined(X64)
     /* we don't want vsyscall since we rely on mov immed, eax being in same bb.
      * plus, libc getpid might cache the pid value.
@@ -62,12 +65,14 @@ main()
                                       "mov %%eax, %0"
         : "=m"(pid)
         :
-        : "cc", "rdi", "rsi", "rcx", "rdx", "r8", "r9", "rax");
+        : "cc", "rcx", "r11", "rax");
 #else
     asm("mov $" STRINGIFY(SYS_getpid) ", %%eax;"
                                       "int $0x80;"
                                       "mov %%eax, %0"
-        : "=m"(pid));
+        : "=m"(pid)
+        :
+        : "cc", "eax");
 #endif
     fprintf(stderr, "pid = %d\n", pid);
 

--- a/suite/tests/client-interface/syscall-mod.c
+++ b/suite/tests/client-interface/syscall-mod.c
@@ -31,8 +31,7 @@
  * DAMAGE.
  */
 
-#define X64
-#define MACOS
+#include "configure.h"
 
 #include <stdio.h>
 #if defined(MACOS) || defined(ANDROID)

--- a/suite/tests/client-interface/syscall-mod.c
+++ b/suite/tests/client-interface/syscall-mod.c
@@ -60,7 +60,9 @@ main()
     asm("mov $" STRINGIFY(SYS_getpid) ", %%eax;"
                                       "syscall;"
                                       "mov %%eax, %0"
-        : "=m"(pid));
+        : "=m"(pid)
+        :
+        : "cc", "rdi", "rsi", "rcx", "rdx", "r8", "r9", "rax");
 #else
     asm("mov $" STRINGIFY(SYS_getpid) ", %%eax;"
                                       "int $0x80;"


### PR DESCRIPTION
Tested on macOS 12.2 with the following compilation commands:

```
cmake -G "Unix Makefiles" -DCMAKE_CPP=$(which gcc)
make -j16
```

Dependencies like snappy were installed with [Homebrew](https://brew.sh).