### PR TITLE
i#5328: Fix broken docs release.

### DIFF
--- a/api/docs/CMake_rundoxygen.cmake
+++ b/api/docs/CMake_rundoxygen.cmake
@@ -186,11 +186,13 @@ if (embeddable)
         "<object type=\"image/svg+xml\" data=\"/images/"
         string "${string}")
     # Ensure that strings that look like Jekyll tags are not interpreted as such.
-    # We add the Jekyll raw-endraw tags around "{%" and "%}" separately.
-    string(REGEX REPLACE "{%" "jekyll_raw_tag{%jekyll_endraw_tag" string "${string}")
-    string(REGEX REPLACE "%}" "jekyll_raw_tag%}jekyll_endraw_tag" string "${string}")
-    string(REGEX REPLACE "jekyll_raw_tag" "{% raw %}" string "${string}")
-    string(REGEX REPLACE "jekyll_endraw_tag" "{% endraw %}" string "${string}")
+    # We add the Jekyll raw-endraw tags around "{%" and "%}" separately. We use
+    # a random suffix for jekyll_raw_tag and jekyll_endraw_tag to reduce the
+    # possibility of a conflict with an actual use of these strings.
+    string(REGEX REPLACE "{%" "jekyll_raw_tag_f00d{%jekyll_endraw_tag_f00d" string "${string}")
+    string(REGEX REPLACE "%}" "jekyll_raw_tag_f00d%}jekyll_endraw_tag_f00d" string "${string}")
+    string(REGEX REPLACE "jekyll_raw_tag_f00d" "{% raw %}" string "${string}")
+    string(REGEX REPLACE "jekyll_endraw_tag_f00d" "{% endraw %}" string "${string}")
     # Collect type info for keyword searches with direct anchor links (else the
     # search finds the page but the user then has to manually search within the long
     # page -- and there are no doygen options to split each onto its own page).

--- a/api/docs/CMake_rundoxygen.cmake
+++ b/api/docs/CMake_rundoxygen.cmake
@@ -186,6 +186,10 @@ if (embeddable)
         "<object type=\"image/svg+xml\" data=\"/images/"
         string "${string}")
 
+    string(REGEX REPLACE "{%" "jekyll_raw_tag{%jekyll_endraw_tag" string "${string}")
+    string(REGEX REPLACE "%}" "jekyll_raw_tag%}jekyll_endraw_tag" string "${string}")
+    string(REGEX REPLACE "jekyll_raw_tag" "{% raw %}" string "${string}")
+    string(REGEX REPLACE "jekyll_endraw_tag" "{% endraw %}" string "${string}")
     # Collect type info for keyword searches with direct anchor links (else the
     # search finds the page but the user then has to manually search within the long
     # page -- and there are no doygen options to split each onto its own page).

--- a/api/docs/CMake_rundoxygen.cmake
+++ b/api/docs/CMake_rundoxygen.cmake
@@ -193,6 +193,7 @@ if (embeddable)
     string(REGEX REPLACE "%}" "jekyll_raw_tag_f00d%}jekyll_endraw_tag_f00d" string "${string}")
     string(REGEX REPLACE "jekyll_raw_tag_f00d" "{% raw %}" string "${string}")
     string(REGEX REPLACE "jekyll_endraw_tag_f00d" "{% endraw %}" string "${string}")
+
     # Collect type info for keyword searches with direct anchor links (else the
     # search finds the page but the user then has to manually search within the long
     # page -- and there are no doygen options to split each onto its own page).

--- a/api/docs/CMake_rundoxygen.cmake
+++ b/api/docs/CMake_rundoxygen.cmake
@@ -185,7 +185,8 @@ if (embeddable)
         "<object type=\"image/svg\\+xml\" data=\""
         "<object type=\"image/svg+xml\" data=\"/images/"
         string "${string}")
-
+    # Ensure that strings that look like Jekyll tags are not interpreted as such.
+    # We add the Jekyll raw-endraw tags around "{%" and "%}" separately.
     string(REGEX REPLACE "{%" "jekyll_raw_tag{%jekyll_endraw_tag" string "${string}")
     string(REGEX REPLACE "%}" "jekyll_raw_tag%}jekyll_endraw_tag" string "${string}")
     string(REGEX REPLACE "jekyll_raw_tag" "{% raw %}" string "${string}")

--- a/api/docs/scatter_gather_emulation.dox
+++ b/api/docs/scatter_gather_emulation.dox
@@ -151,7 +151,10 @@ any client that needs it, including drcachesim. This support was added by
 
 As an example, the following are the expansions of some instructions.
 
-Expansion for `vpgatherdd 0x00402039(,%xmm11,4)[4byte] %xmm13 -> %xmm12 %xmm13`
+Expansion for
+```
+vpgatherdd 0x00402039(,%xmm11,4)[4byte] %xmm13 -> %xmm12 %xmm13
+```
 
 
 ```
@@ -252,10 +255,13 @@ Expansion for `vpgatherdd 0x00402039(,%xmm11,4)[4byte] %xmm13 -> %xmm12 %xmm13`
  +455  m4 @0x00007fdb2ac5d900  65 48 a1 e0 00 00 00 mov    %gs:0x000000e0[8byte] -> %rax        // Restore aflags using drreg.
                                00 00 00 00
  +466  m4 @0x00007fdb2ac5d818                       <label>
- ```
+```
 
 
-Expansion for `vpscatterdd {%k1} %xmm10 -> 0x00402039(,%xmm11,4)[4byte] %k1`
+Expansion for
+```
+vpscatterdd {%k1} %xmm10 -> 0x00402039(,%xmm11,4)[4byte] %k1
+```
 
 
 ```
@@ -368,7 +374,7 @@ Expansion for `vpscatterdd {%k1} %xmm10 -> 0x00402039(,%xmm11,4)[4byte] %k1`
  +489  m4 @0x00007fdb2ac0cc20  65 48 a1 e0 00 00 00 mov    %gs:0x000000e0[8byte] -> %rax        // Restore aflags using drreg.
                                00 00 00 00
  +500  m4 @0x00007fdb2ac0baa0                       <label>
- ```
+```
 
 As shown by the above expanded scatter and gather sequences, we require scratch
 registers for the expansion. The GPR scratch registers are obtained using

--- a/api/docs/scatter_gather_emulation.dox
+++ b/api/docs/scatter_gather_emulation.dox
@@ -61,7 +61,7 @@ be complete.
 
 
 ```
-{%raw %}vpscatterdd {%k1} %xmm10 -> %rax(,%xmm11,4)[4byte] %k1{%endraw %}
+{% raw %}vpscatterdd {%k1} %xmm10 -> %rax(,%xmm11,4)[4byte] %k1{% endraw %}
 ```
 
 Above is an AVX512 scatter instruction that writes 32-bit doublewords from the 128-
@@ -158,7 +158,7 @@ vpgatherdd 0x00402039(,%xmm11,4)[4byte] %xmm13 -> %xmm12 %xmm13
 
 
 ```
-{%raw %} +0    m4 @0x00007fdb2ac5e6a0  65 48 a3 e0 00 00 00 mov    %rax -> %gs:0x000000e0[8byte]
+{% raw %} +0    m4 @0x00007fdb2ac5e6a0  65 48 a3 e0 00 00 00 mov    %rax -> %gs:0x000000e0[8byte]
                                00 00 00 00
  +11   m4 @0x00007fdb2ac5eac0  9f                   lahf    -> %ah
  +12   m4 @0x00007fdb2ac5ea40  0f 90 c0             seto    -> %al                              // Spill aflags using drreg.
@@ -254,18 +254,18 @@ vpgatherdd 0x00402039(,%xmm11,4)[4byte] %xmm13 -> %xmm12 %xmm13
  +454  m4 @0x00007fdb2ac5d9e8  9e                   sahf   %ah
  +455  m4 @0x00007fdb2ac5d900  65 48 a1 e0 00 00 00 mov    %gs:0x000000e0[8byte] -> %rax        // Restore aflags using drreg.
                                00 00 00 00
- +466  m4 @0x00007fdb2ac5d818                       <label>{%endraw %}
+ +466  m4 @0x00007fdb2ac5d818                       <label>{% endraw %}
  ```
 
 
 Expansion for
 ```
-{%raw %}vpscatterdd {%k1} %xmm10 -> 0x00402039(,%xmm11,4)[4byte] %k1{%endraw %}
+{% raw %}vpscatterdd {%k1} %xmm10 -> 0x00402039(,%xmm11,4)[4byte] %k1{% endraw %}
 ```
 
 
 ```
-{%raw %} +0    m4 @0x00007fdb2ac106e0  65 48 a3 e0 00 00 00 mov    %rax -> %gs:0x000000e0[8byte]
+{% raw %} +0    m4 @0x00007fdb2ac106e0  65 48 a3 e0 00 00 00 mov    %rax -> %gs:0x000000e0[8byte]
                                00 00 00 00
  +11   m4 @0x00007fdb2ac10760  9f                   lahf    -> %ah
  +12   m4 @0x00007fdb2ac107e0  0f 90 c0             seto    -> %al                              // Spill aflags using drreg.
@@ -373,7 +373,7 @@ Expansion for
  +488  m4 @0x00007fdb2ac0b8b8  9e                   sahf   %ah
  +489  m4 @0x00007fdb2ac0cc20  65 48 a1 e0 00 00 00 mov    %gs:0x000000e0[8byte] -> %rax        // Restore aflags using drreg.
                                00 00 00 00
- +500  m4 @0x00007fdb2ac0baa0                       <label>{%endraw %}
+ +500  m4 @0x00007fdb2ac0baa0                       <label>{% endraw %}
 ```
 
 As shown by the above expanded scatter and gather sequences, we require scratch

--- a/api/docs/scatter_gather_emulation.dox
+++ b/api/docs/scatter_gather_emulation.dox
@@ -61,7 +61,7 @@ be complete.
 
 
 ```
-vpscatterdd {%k1} %xmm10 -> %rax(,%xmm11,4)[4byte] %k1
+{%raw %}vpscatterdd {%k1} %xmm10 -> %rax(,%xmm11,4)[4byte] %k1{%endraw %}
 ```
 
 Above is an AVX512 scatter instruction that writes 32-bit doublewords from the 128-
@@ -151,11 +151,14 @@ any client that needs it, including drcachesim. This support was added by
 
 As an example, the following are the expansions of some instructions.
 
-Expansion for `vpgatherdd 0x00402039(,%xmm11,4)[4byte] %xmm13 -> %xmm12 %xmm13`
+Expansion for
+```
+vpgatherdd 0x00402039(,%xmm11,4)[4byte] %xmm13 -> %xmm12 %xmm13
+```
 
 
 ```
- +0    m4 @0x00007fdb2ac5e6a0  65 48 a3 e0 00 00 00 mov    %rax -> %gs:0x000000e0[8byte]
+{%raw %} +0    m4 @0x00007fdb2ac5e6a0  65 48 a3 e0 00 00 00 mov    %rax -> %gs:0x000000e0[8byte]
                                00 00 00 00
  +11   m4 @0x00007fdb2ac5eac0  9f                   lahf    -> %ah
  +12   m4 @0x00007fdb2ac5ea40  0f 90 c0             seto    -> %al                              // Spill aflags using drreg.
@@ -251,15 +254,18 @@ Expansion for `vpgatherdd 0x00402039(,%xmm11,4)[4byte] %xmm13 -> %xmm12 %xmm13`
  +454  m4 @0x00007fdb2ac5d9e8  9e                   sahf   %ah
  +455  m4 @0x00007fdb2ac5d900  65 48 a1 e0 00 00 00 mov    %gs:0x000000e0[8byte] -> %rax        // Restore aflags using drreg.
                                00 00 00 00
- +466  m4 @0x00007fdb2ac5d818                       <label>
+ +466  m4 @0x00007fdb2ac5d818                       <label>{%endraw %}
  ```
 
 
-Expansion for `vpscatterdd {%k1} %xmm10 -> 0x00402039(,%xmm11,4)[4byte] %k1`
+Expansion for
+```
+{%raw %}vpscatterdd {%k1} %xmm10 -> 0x00402039(,%xmm11,4)[4byte] %k1{%endraw %}
+```
 
 
 ```
- +0    m4 @0x00007fdb2ac106e0  65 48 a3 e0 00 00 00 mov    %rax -> %gs:0x000000e0[8byte]
+{%raw %} +0    m4 @0x00007fdb2ac106e0  65 48 a3 e0 00 00 00 mov    %rax -> %gs:0x000000e0[8byte]
                                00 00 00 00
  +11   m4 @0x00007fdb2ac10760  9f                   lahf    -> %ah
  +12   m4 @0x00007fdb2ac107e0  0f 90 c0             seto    -> %al                              // Spill aflags using drreg.
@@ -367,8 +373,8 @@ Expansion for `vpscatterdd {%k1} %xmm10 -> 0x00402039(,%xmm11,4)[4byte] %k1`
  +488  m4 @0x00007fdb2ac0b8b8  9e                   sahf   %ah
  +489  m4 @0x00007fdb2ac0cc20  65 48 a1 e0 00 00 00 mov    %gs:0x000000e0[8byte] -> %rax        // Restore aflags using drreg.
                                00 00 00 00
- +500  m4 @0x00007fdb2ac0baa0                       <label>
- ```
+ +500  m4 @0x00007fdb2ac0baa0                       <label>{%endraw %}
+```
 
 As shown by the above expanded scatter and gather sequences, we require scratch
 registers for the expansion. The GPR scratch registers are obtained using

--- a/api/docs/scatter_gather_emulation.dox
+++ b/api/docs/scatter_gather_emulation.dox
@@ -61,7 +61,7 @@ be complete.
 
 
 ```
-{% raw %}vpscatterdd {%k1} %xmm10 -> %rax(,%xmm11,4)[4byte] %k1{% endraw %}
+vpscatterdd {%k1} %xmm10 -> %rax(,%xmm11,4)[4byte] %k1
 ```
 
 Above is an AVX512 scatter instruction that writes 32-bit doublewords from the 128-
@@ -151,14 +151,11 @@ any client that needs it, including drcachesim. This support was added by
 
 As an example, the following are the expansions of some instructions.
 
-Expansion for
-```
-vpgatherdd 0x00402039(,%xmm11,4)[4byte] %xmm13 -> %xmm12 %xmm13
-```
+Expansion for `vpgatherdd 0x00402039(,%xmm11,4)[4byte] %xmm13 -> %xmm12 %xmm13`
 
 
 ```
-{% raw %} +0    m4 @0x00007fdb2ac5e6a0  65 48 a3 e0 00 00 00 mov    %rax -> %gs:0x000000e0[8byte]
+ +0    m4 @0x00007fdb2ac5e6a0  65 48 a3 e0 00 00 00 mov    %rax -> %gs:0x000000e0[8byte]
                                00 00 00 00
  +11   m4 @0x00007fdb2ac5eac0  9f                   lahf    -> %ah
  +12   m4 @0x00007fdb2ac5ea40  0f 90 c0             seto    -> %al                              // Spill aflags using drreg.
@@ -254,18 +251,15 @@ vpgatherdd 0x00402039(,%xmm11,4)[4byte] %xmm13 -> %xmm12 %xmm13
  +454  m4 @0x00007fdb2ac5d9e8  9e                   sahf   %ah
  +455  m4 @0x00007fdb2ac5d900  65 48 a1 e0 00 00 00 mov    %gs:0x000000e0[8byte] -> %rax        // Restore aflags using drreg.
                                00 00 00 00
- +466  m4 @0x00007fdb2ac5d818                       <label>{% endraw %}
+ +466  m4 @0x00007fdb2ac5d818                       <label>
  ```
 
 
-Expansion for
-```
-{% raw %}vpscatterdd {%k1} %xmm10 -> 0x00402039(,%xmm11,4)[4byte] %k1{% endraw %}
-```
+Expansion for `vpscatterdd {%k1} %xmm10 -> 0x00402039(,%xmm11,4)[4byte] %k1`
 
 
 ```
-{% raw %} +0    m4 @0x00007fdb2ac106e0  65 48 a3 e0 00 00 00 mov    %rax -> %gs:0x000000e0[8byte]
+ +0    m4 @0x00007fdb2ac106e0  65 48 a3 e0 00 00 00 mov    %rax -> %gs:0x000000e0[8byte]
                                00 00 00 00
  +11   m4 @0x00007fdb2ac10760  9f                   lahf    -> %ah
  +12   m4 @0x00007fdb2ac107e0  0f 90 c0             seto    -> %al                              // Spill aflags using drreg.
@@ -373,8 +367,8 @@ Expansion for
  +488  m4 @0x00007fdb2ac0b8b8  9e                   sahf   %ah
  +489  m4 @0x00007fdb2ac0cc20  65 48 a1 e0 00 00 00 mov    %gs:0x000000e0[8byte] -> %rax        // Restore aflags using drreg.
                                00 00 00 00
- +500  m4 @0x00007fdb2ac0baa0                       <label>{% endraw %}
-```
+ +500  m4 @0x00007fdb2ac0baa0                       <label>
+ ```
 
 As shown by the above expanded scatter and gather sequences, we require scratch
 registers for the expansion. The GPR scratch registers are obtained using

--- a/clients/drdisas/drdisas.dox
+++ b/clients/drdisas/drdisas.dox
@@ -42,7 +42,7 @@ Here are some examples:
 $ bin64/drdisas 62 e2 f5 47 40 41 37
  62 e2 f5 47 40 41 37 vpmullq zmm16 {k7}, zmm17, [rcx+0x00000dc0]
 $ bin64/drdisas -mode x86 -no_show_bytes -syntax dr 62 e2 f5 47 40 41 37
-{%raw %}vpmullq {%k7} %zmm17 0x00000dc0(%ecx)[64byte] -> %zmm16{%endraw %}
+vpmullq {%k7} %zmm17 0x00000dc0(%ecx)[64byte] -> %zmm16
 \endcode
 
 Cross-architecture decoding in the same binary is not yet supported.

--- a/clients/drdisas/drdisas.dox
+++ b/clients/drdisas/drdisas.dox
@@ -42,7 +42,7 @@ Here are some examples:
 $ bin64/drdisas 62 e2 f5 47 40 41 37
  62 e2 f5 47 40 41 37 vpmullq zmm16 {k7}, zmm17, [rcx+0x00000dc0]
 $ bin64/drdisas -mode x86 -no_show_bytes -syntax dr 62 e2 f5 47 40 41 37
-{% raw %}vpmullq {%k7} %zmm17 0x00000dc0(%ecx)[64byte] -> %zmm16{% endraw %}
+{%raw %}vpmullq {%k7} %zmm17 0x00000dc0(%ecx)[64byte] -> %zmm16{%endraw %}
 \endcode
 
 Cross-architecture decoding in the same binary is not yet supported.

--- a/clients/drdisas/drdisas.dox
+++ b/clients/drdisas/drdisas.dox
@@ -42,7 +42,7 @@ Here are some examples:
 $ bin64/drdisas 62 e2 f5 47 40 41 37
  62 e2 f5 47 40 41 37 vpmullq zmm16 {k7}, zmm17, [rcx+0x00000dc0]
 $ bin64/drdisas -mode x86 -no_show_bytes -syntax dr 62 e2 f5 47 40 41 37
-{%raw %}vpmullq {%k7} %zmm17 0x00000dc0(%ecx)[64byte] -> %zmm16{%endraw %}
+{% raw %}vpmullq {%k7} %zmm17 0x00000dc0(%ecx)[64byte] -> %zmm16{% endraw %}
 \endcode
 
 Cross-architecture decoding in the same binary is not yet supported.


### PR DESCRIPTION
Fixes the dynamorio.org docs release by addressing
the unexpected Jekyll tag string "{%" that is present
as part of the scatter and gather instruction
disassembly.

Adds the raw-endraw pair around "{%" and "%}" to
prevent them from being interpreted as tag-start
and tag-end respectively.

Also removes the old workaround of adding raw-endraw
in docx itself, from drdisas.dox.

Tested locally that this fix works.

Fixes: #5328