### PR TITLE
i#2626: Fix operand clashes in AArch64 codec

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1242,7 +1242,7 @@ encode_opnd_lsl(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 static inline bool
 decode_opnd_h_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    *opnd = opnd_create_immed_int(VECTOR_ELEM_WIDTH_HALF, OPSZ_2b);
+    *opnd = opnd_create_immed_int(VECTOR_ELEM_WIDTH_HALF, OPSZ_1);
     return true;
 }
 
@@ -1252,7 +1252,7 @@ encode_opnd_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     if (!opnd_is_immed_int(opnd))
         return false;
 
-    if (opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_HALF)
+    if ((opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_HALF) && (opnd_get_size(opnd) == OPSZ_1))
         return true;
     return false;
 }
@@ -3324,11 +3324,11 @@ static inline bool
 decode_opnd_sd_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
     if (((enc >> 22) & 1) == 0) {
-        *opnd = opnd_create_immed_int(VECTOR_ELEM_WIDTH_SINGLE, OPSZ_2b);
+        *opnd = opnd_create_immed_int(VECTOR_ELEM_WIDTH_SINGLE, OPSZ_1);
         return true;
     }
     if (((enc >> 22) & 1) == 1) {
-        *opnd = opnd_create_immed_int(VECTOR_ELEM_WIDTH_DOUBLE, OPSZ_2b);
+        *opnd = opnd_create_immed_int(VECTOR_ELEM_WIDTH_DOUBLE, OPSZ_1);
         return true;
     }
     return false;
@@ -3340,11 +3340,11 @@ encode_opnd_sd_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out
     if (!opnd_is_immed_int(opnd))
         return false;
 
-    if (opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_SINGLE) {
+    if ((opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_SINGLE) && (opnd_get_size(opnd) == OPSZ_1)) {
         *enc_out = 0;
         return true;
     }
-    if (opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_DOUBLE) {
+    if ((opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_DOUBLE) && (opnd_get_size(opnd) == OPSZ_1)) {
         *enc_out = 1 << 22;
         return true;
     }

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1252,7 +1252,8 @@ encode_opnd_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     if (!opnd_is_immed_int(opnd))
         return false;
 
-    if ((opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_HALF) && (opnd_get_size(opnd) == OPSZ_1))
+    if ((opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_HALF) &&
+        (opnd_get_size(opnd) == OPSZ_1))
         return true;
     return false;
 }
@@ -3340,11 +3341,13 @@ encode_opnd_sd_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out
     if (!opnd_is_immed_int(opnd))
         return false;
 
-    if ((opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_SINGLE) && (opnd_get_size(opnd) == OPSZ_1)) {
+    if ((opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_SINGLE) &&
+        (opnd_get_size(opnd) == OPSZ_1)) {
         *enc_out = 0;
         return true;
     }
-    if ((opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_DOUBLE) && (opnd_get_size(opnd) == OPSZ_1)) {
+    if ((opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_DOUBLE) &&
+        (opnd_get_size(opnd) == OPSZ_1)) {
         *enc_out = 1 << 22;
         return true;
     }

--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -64,6 +64,7 @@ x001111011110001000000xxxxxxxxxx  n   116   fcvtmu  wx0 : h5
 x001111011100001000000xxxxxxxxxx  n   120   fcvtnu  wx0 : h5
 0111111001111001101010xxxxxxxxxx  n   120   fcvtnu   h0 : h5
 0x0011110xxxxxxx111111xxxxxxxxxx  n   125   fcvtzs  dq0 : dq5 bhsd_immh_sz immhb_fxp
+0x10111011111001101110xxxxxxxxxx  n   126   fcvtzu  dq0 : dq5 h_sz
 0x1011110xxxxxxx111111xxxxxxxxxx  n   126   fcvtzu  dq0 : dq5 bhsd_immh_sz immhb_fxp
 0x101110010xxxxx001111xxxxxxxxxx  n   127     fdiv  dq0 : dq5 dq16 h_sz
 0x001110010xxxxx001101xxxxxxxxxx  n   129     fmax  dq0 : dq5 dq16 h_sz

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -3356,6 +3356,15 @@ d2400441 : eor    x1, x2, #0x3            : eor    %x2 $0x0000000000000003 -> %x
 2f20fd6a : fcvtzu v10.2s, v11.2s, #32               : fcvtzu %d11 $0x02 $0x20 -> %d10
 2f2bffbc : fcvtzu v28.2s, v29.2s, #21               : fcvtzu %d29 $0x02 $0x15 -> %d28
 2f21fffe : fcvtzu v30.2s, v31.2s, #31               : fcvtzu %d31 $0x02 $0x1f -> %d30
+7f7ffc20 : fcvtzu d0, d1, #1                        : fcvtzu %d1 $0x01 -> %d0
+2ef9b862 : fcvtzu v2.4h, v3.4h                      : fcvtzu %d3 $0x01 -> %d2
+6ef9b862 : fcvtzu v2.8h, v3.8h                      : fcvtzu %q3 $0x01 -> %q2
+7f7efc62 : fcvtzu d2, d3, #2                        : fcvtzu %d3 $0x02 -> %d2
+2ea1b862 : fcvtzu v2.2s, v3.2s                      : fcvtzu %d3 $0x02 -> %d2
+6ea1b862 : fcvtzu v2.4s, v3.4s                      : fcvtzu %q3 $0x02 -> %q2
+7f7dfc62 : fcvtzu d2, d3, #3                        : fcvtzu %d3 $0x03 -> %d2
+6ee1b862 : fcvtzu v2.2d, v3.2d                      : fcvtzu %q3 $0x03 -> %q2
+7f7cfc62 : fcvtzu d2, d3, #4                        : fcvtzu %d3 $0x04 -> %d2
 
 2e573f09 : fdiv v9.4h, v24.4h, v23.4h               : fdiv   %d24 %d23 $0x01 -> %d9
 6e573f09 : fdiv v9.8h, v24.8h, v23.8h               : fdiv   %q24 %q23 $0x01 -> %q9


### PR DESCRIPTION
The current functions for encoding and decoding
vector element size operands using immediate int
enums clashes with operands representing actual
immediate ints.

Issue: #2626