### PR TITLE
i#5340: Swap TEB fields to private values during detach

### DIFF
--- a/core/win32/loader.c
+++ b/core/win32/loader.c
@@ -800,7 +800,6 @@ void
 restore_peb_pointer_for_thread(dcontext_t *dcontext)
 {
     PEB *tgt_peb = get_own_peb();
-    ASSERT_NOT_TESTED();
     ASSERT(INTERNAL_OPTION(private_peb));
     ASSERT(private_peb_initialized);
     ASSERT(tgt_peb != NULL);


### PR DESCRIPTION
Adds a missing swap to private TEB fields on
dr_app_stop_and_cleanup*(), and a swap back to app fields on detaching
thread cleanup.

This fixes problems using droption on client exit in drcachesim tests
for #4139.

Issue: #4139, #5340
Fixes #5340