### PR TITLE
i#2007: Enable static dr$sim tests on AArch64

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015-2021 Google, Inc.    All rights reserved.
+# Copyright (c) 2015-2022 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -235,10 +235,8 @@ set_property(GLOBAL PROPERTY DynamoRIO_drmemtrace_build_dir
 
 # We have one more example of a standalone launcher that uses raw2trace to catch
 # link errors (xref i#1409).  We just build it to test the linking; no test.
-# XXX i#2007: a binutils error causes static dynamorio to fail to link on AArch64.
-# We'll enable this once Travis and others have a fixed binutils.
 # XXX i#1997: static DR is not fully supported on Mac yet.
-if (NOT AARCH64 AND NOT APPLE)
+if (NOT APPLE)
   add_executable(opcode_mix_launcher
     tools/opcode_mix_launcher.cpp
     )
@@ -531,10 +529,9 @@ if (BUILD_TESTS)
     add_win32_flags(tool.drcacheoff.burst_aarch64_sys)
   endif ()
 
-  # FIXME i#2007: fails to link on A64
   # XXX i#1997: dynamorio_static is not supported on Mac yet
   # FIXME i#2949: gcc 7.3 fails to link certain configs
-  if (NOT AARCH64 AND NOT APPLE AND NOT DISABLE_FOR_BUG_2949)
+  if (NOT APPLE AND NOT DISABLE_FOR_BUG_2949)
     # Tests for the cache miss analyzer.
     add_executable(tool.drcachesim.miss_analyzer_unit_test tests/cache_miss_analyzer_test.cpp)
     if (ZLIB_FOUND)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3646,11 +3646,10 @@ if (BUILD_CLIENTS)
       torunonly_drcacheoff(burst_aarch64_sys tool.drcacheoff.burst_aarch64_sys "" "@-simulator_type@basic_counts" "")
     endif ()
 
-    # FIXME i#2007: fails to link on A64
     # XXX i#1551: startstop API is NYI on ARM
     # XXX i#1997: dynamorio_static is not supported on Mac yet
     # FIXME i#2949: gcc 7.3 fails to link certain configs
-    if (NOT AARCH64 AND NOT ARM AND NOT APPLE AND NOT DISABLE_FOR_BUG_2949)
+    if (NOT ARM AND NOT APPLE AND NOT DISABLE_FOR_BUG_2949)
       set(tool.drcacheoff.burst_static_nodr ON)
       torunonly_drcacheoff(burst_static tool.drcacheoff.burst_static "" "" "")
 

--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -154,8 +154,7 @@ test_rseq_call_once(bool force_restart_in, int *completions_out, int *restarts_o
         "cmpb $0, %[force_restart]\n\t"
         "jz 7f\n\t"
         /* For -test_mode invariant_checker: expect a signal after ud2a.
-         * (An alternative is to add decoding to invariant_checker but with
-         * i#2007 and other problems that liimts the test.)
+         * (An alternative is to add decoding to invariant_checker.)
          */
         "prefetcht2 1\n\t"
         "ud2a\n\t"


### PR DESCRIPTION
Our test machines now have a new-enough toolchain to get past a
linking bug that blocked building and running a dozen drcachesim tests
with statically-linked DR on AArch64.  We enable them all here, which
helps bridge the testing gap with x86.

Issue: #2007, #4474
Fixes #2007