### PR TITLE
i#5345: Add missing SYSCALL and SYSRET operands

### DIFF
--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1980,6 +1980,12 @@ const instr_info_t * const op_instr[] =
 #define xbp TYPE_XREG, REG_EBP
 #define xcx TYPE_XREG, REG_ECX
 
+#ifdef X64
+#   define r11 TYPE_REG, DR_REG_R11
+#else
+/* Keep ifdefs out of the table. */
+#   define r11 TYPE_NONE, OPSZ_NA
+#endif
 #define cs  TYPE_REG, SEG_CS
 #define ss  TYPE_REG, SEG_SS
 #define ds  TYPE_REG, SEG_DS
@@ -2417,10 +2423,10 @@ const instr_info_t second_byte[] = {
   {OP_lsl, 0x0f0310, "lsl", Gv, xx, Ew, xx, xx, mrm, fWZ, END_LIST},
   {INVALID, 0x0f0410, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
   /* XXX: writes ss and cs */
-  {OP_syscall, 0x0f0510, "syscall", xcx, xx, xx, xx, xx, no, x, NA}, /* AMD/x64 only */
+  {OP_syscall, 0x0f0510, "syscall", xcx, r11, xx, xx, xx, no, x, NA}, /* AMD/x64 only */
   {OP_clts, 0x0f0610, "clts", xx, xx, xx, xx, xx, no, x, END_LIST},
   /* XXX: writes ss and cs */
-  {OP_sysret, 0x0f0710, "sysret", xx, xx, xx, xx, xx, no, x, NA}, /* AMD/x64 only */
+  {OP_sysret, 0x0f0710, "sysret", xx, xx, xcx, r11, xx, no, x, NA}, /* AMD/x64 only */
   /* 08 */
   {OP_invd, 0x0f0810, "invd", xx, xx, xx, xx, xx, no, x, END_LIST},
   {OP_wbinvd, 0x0f0910, "wbinvd", xx, xx, xx, xx, xx, no, x, END_LIST},

--- a/core/ir/x86/instr_create_api.h
+++ b/core/ir/x86/instr_create_api.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -511,7 +511,6 @@
 #define INSTR_CREATE_fincstp(dc) instr_create_0dst_0src((dc), OP_fincstp)
 #define INSTR_CREATE_fnclex(dc) instr_create_0dst_0src((dc), OP_fnclex)
 #define INSTR_CREATE_fninit(dc) instr_create_0dst_0src((dc), OP_fninit)
-#define INSTR_CREATE_sysret(dc) instr_create_0dst_0src((dc), OP_sysret)
 #define INSTR_CREATE_femms(dc) instr_create_0dst_0src((dc), OP_femms)
 #define INSTR_CREATE_swapgs(dc) instr_create_0dst_0src((dc), OP_swapgs)
 #define INSTR_CREATE_vmcall(dc) instr_create_0dst_0src((dc), OP_vmcall)
@@ -924,6 +923,11 @@
 #define INSTR_CREATE_invlpga(dc)                                          \
     instr_create_0dst_2src((dc), OP_invlpga, opnd_create_reg(DR_REG_XAX), \
                            opnd_create_reg(DR_REG_ECX))
+#ifdef X64
+#    define INSTR_CREATE_sysret(dc)                                          \
+        instr_create_0dst_2src((dc), OP_sysret, opnd_create_reg(DR_REG_XCX), \
+                               opnd_create_reg(DR_REG_R11))
+#endif
 /* no destination, 3 implicit sources */
 #define INSTR_CREATE_wrmsr(dc)                                          \
     instr_create_0dst_3src((dc), OP_wrmsr, opnd_create_reg(DR_REG_EDX), \
@@ -1166,8 +1170,6 @@
     instr_create_1dst_0src((dc), OP_lahf, opnd_create_reg(DR_REG_AH))
 #define INSTR_CREATE_sysenter(dc) \
     instr_create_1dst_0src((dc), OP_sysenter, opnd_create_reg(DR_REG_XSP))
-#define INSTR_CREATE_syscall(dc) \
-    instr_create_1dst_0src((dc), OP_syscall, opnd_create_reg(DR_REG_XCX))
 #define INSTR_CREATE_salc(dc) \
     instr_create_1dst_0src((dc), OP_salc, opnd_create_reg(DR_REG_AL))
 /** @} */ /* end doxygen group */
@@ -4478,6 +4480,8 @@
 /** @} */ /* end doxygen group */
 
 /* 2 implicit destinations, no sources */
+/** @name 2 implicit destinations, no sources */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
 /**
  * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
  * supplying any implicit operands.
@@ -4486,6 +4490,12 @@
 #define INSTR_CREATE_rdtsc(dc)                                          \
     instr_create_2dst_0src((dc), OP_rdtsc, opnd_create_reg(DR_REG_EDX), \
                            opnd_create_reg(DR_REG_EAX))
+#ifdef X64
+#    define INSTR_CREATE_syscall(dc)                                          \
+        instr_create_2dst_0src((dc), OP_syscall, opnd_create_reg(DR_REG_XCX), \
+                               opnd_create_reg(DR_REG_R11))
+#endif
+/** @} */ /* end doxygen group */
 
 /* 2 destinations: 1 implicit, 1 source */
 /** @name 2 destinations: 1 implicit, 1 source */


### PR DESCRIPTION
Adds missing r11 destination for SYSCALL.
Adds missing rcx and r11 sources for SYSRET.
Updates the creation macros.

Fixes #5345