### PR TITLE
i#1034: Eliminate signed char assumptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -774,6 +774,9 @@ if (UNIX)
   set(BASE_CONLY_FLAGS "${BASE_CONLY_FLAGS} -std=gnu99")
   # disable strict aliasing opt in gcc 3.3.3 -- gives warnings and makes bad assumptions
   set(BASE_CFLAGS "${BASE_CFLAGS} -fno-strict-aliasing")
+  # Ensure DR is interoperable with other toolchains: do not assume char is signed
+  # (see i#1034 where this caused problems in the past).
+  set(BASE_CFLAGS "${BASE_CFLAGS} -funsigned-char")
   # Ubuntu defaults to -fstack-protector these days, which depends on app TLS.
   CHECK_C_COMPILER_FLAG("-fno-stack-protector" no_stack_protector_avail)
   if (no_stack_protector_avail)

--- a/api/docs/code_style.dox
+++ b/api/docs/code_style.dox
@@ -231,6 +231,7 @@ simple scalar type function parameters as `const`.
   };
   ```
 
+-# Do not assume that `char` is signed: use our `sbyte` typedef for a signed one-byte type.
 
 
 # Commenting Conventions

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -351,7 +351,8 @@ online_instru_t::instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t
     entry.size = 0;
     for (i = 0; i < num_delay_instrs; i++) {
         // Fill instr size into bundle entry
-        entry.length[entry.size++] = (char)instr_length(drcontext, delay_instrs[i]);
+        entry.length[entry.size++] =
+            (unsigned char)instr_length(drcontext, delay_instrs[i]);
         // Instrument to add an INSTR_BUNDLE entry if bundle is full or last instr
         if (entry.size == sizeof(entry.length) || i == num_delay_instrs - 1) {
             insert_save_type_and_size(drcontext, ilist, where, reg_ptr, reg_tmp,

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -3534,12 +3534,12 @@ create_int_syscall_instr(dcontext_t *dcontext)
          * to avoid tripping up Sygate. */
         return INSTR_CREATE_call(dcontext, opnd_create_pc(int_syscall_address));
     } else {
-        return INSTR_CREATE_int(dcontext, opnd_create_immed_int((char)0x2e, OPSZ_1));
+        return INSTR_CREATE_int(dcontext, opnd_create_immed_int(sbyte)0x2e, OPSZ_1));
     }
 #    else
     /* if uninitialized just guess int, we'll patch up later */
 
-    return INSTR_CREATE_int(dcontext, opnd_create_immed_int((char)0x80, OPSZ_1));
+    return INSTR_CREATE_int(dcontext, opnd_create_immed_int((sbyte)0x80, OPSZ_1));
 #    endif
 }
 #endif
@@ -3550,7 +3550,7 @@ create_syscall_instr(dcontext_t *dcontext)
     int method = get_syscall_method();
 #ifdef AARCHXX
     if (method == SYSCALL_METHOD_SVC || method == SYSCALL_METHOD_UNINITIALIZED) {
-        return INSTR_CREATE_svc(dcontext, opnd_create_immed_int((char)0x0, OPSZ_1));
+        return INSTR_CREATE_svc(dcontext, opnd_create_immed_int((sbyte)0x0, OPSZ_1));
     }
 #elif defined(X86)
     if (method == SYSCALL_METHOD_INT || method == SYSCALL_METHOD_UNINITIALIZED) {
@@ -4777,7 +4777,7 @@ emit_do_syscall_common(dcontext_t *dcontext, generated_code_t *code, byte *pc,
         if (interrupt != 0) {
 #ifdef X86
             syscall = INSTR_CREATE_int(dcontext,
-                                       opnd_create_immed_int((char)interrupt, OPSZ_1));
+                                       opnd_create_immed_int((sbyte)interrupt, OPSZ_1));
 #endif
             IF_ARM(ASSERT_NOT_REACHED());
         } else
@@ -5036,7 +5036,7 @@ emit_do_vmkuw_syscall(dcontext_t *dcontext, generated_code_t *code, byte *pc,
                       uint *syscall_offs /*OUT*/)
 {
     instr_t *gateway = INSTR_CREATE_int(
-        dcontext, opnd_create_immed_int((char)VMKUW_SYSCALL_GATEWAY, OPSZ_1));
+        dcontext, opnd_create_immed_int((sbyte)VMKUW_SYSCALL_GATEWAY, OPSZ_1));
     return emit_do_syscall_common(dcontext, code, pc, fcache_return_pc, false,
                                   thread_shared, false, gateway, syscall_offs);
 }

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -3534,7 +3534,7 @@ create_int_syscall_instr(dcontext_t *dcontext)
          * to avoid tripping up Sygate. */
         return INSTR_CREATE_call(dcontext, opnd_create_pc(int_syscall_address));
     } else {
-        return INSTR_CREATE_int(dcontext, opnd_create_immed_int(sbyte)0x2e, OPSZ_1));
+        return INSTR_CREATE_int(dcontext, opnd_create_immed_int((sbyte)0x2e, OPSZ_1));
     }
 #    else
     /* if uninitialized just guess int, we'll patch up later */

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -965,8 +965,8 @@ bb_process_ubr(dcontext_t *dcontext, build_bb_t *bb)
                 /* we hooked deep need to add the int 2e instruction */
                 /* can't use create_syscall_instr because of case 5217 hack */
                 ASSERT(get_syscall_method() == SYSCALL_METHOD_INT);
-                bb->instr =
-                    INSTR_CREATE_int(dcontext, opnd_create_immed_int((char)0x2e, OPSZ_1));
+                bb->instr = INSTR_CREATE_int(dcontext,
+                                             opnd_create_immed_int((sbyte)0x2e, OPSZ_1));
                 if (bb->record_translation)
                     instr_set_translation(bb->instr, translation);
                 ASSERT(instr_is_syscall(bb->instr) &&

--- a/core/ir/x86/decode.c
+++ b/core/ir/x86/decode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -420,7 +420,7 @@ read_immed(byte *pc, decode_info_t *di, opnd_size_t size, ptr_int_t *result)
      */
     switch (size) {
     case OPSZ_1:
-        *result = (ptr_int_t)(char)*pc; /* sign-extend */
+        *result = (ptr_int_t)(sbyte)*pc; /* sign-extend */
         pc++;
         break;
     case OPSZ_2:
@@ -584,7 +584,7 @@ read_modrm(byte *pc, decode_info_t *di)
         } else if (di->mod == 1) {
             /* 1-byte disp */
             di->has_disp = true;
-            di->disp = (int)(char)*pc; /* sign-extend */
+            di->disp = (int)(sbyte)*pc; /* sign-extend */
             pc++;
         } else {
             di->has_disp = false;
@@ -617,7 +617,7 @@ read_modrm(byte *pc, decode_info_t *di)
         } else if (di->mod == 1) {
             /* 1-byte disp */
             di->has_disp = true;
-            di->disp = (int)(char)*pc; /* sign-extend */
+            di->disp = (int)(sbyte)*pc; /* sign-extend */
             pc++;
         } else {
             di->has_disp = false;

--- a/core/ir/x86/decode_fast.c
+++ b/core/ir/x86/decode_fast.c
@@ -119,7 +119,7 @@ static const byte fixed_length[256] = {
    use this table if we've seen a operand-size prefix byte to adjust
    the fixed_length from dword to word.
  */
-static const signed char immed_adjustment[256] = {
+static const sbyte immed_adjustment[256] = {
     0, 0,  0, 0, 0, -2, 0, 0,  0,  0,  0,  0,  0,  -2, 0,  0, /* 0 */
     0, 0,  0, 0, 0, -2, 0, 0,  0,  0,  0,  0,  0,  -2, 0,  0, /* 1 */
     0, 0,  0, 0, 0, -2, 0, 0,  0,  0,  0,  0,  0,  -2, 0,  0, /* 2 */
@@ -143,7 +143,7 @@ static const signed char immed_adjustment[256] = {
 
 #ifdef X64
 /* for x64 Intel, Jz is always a 64-bit addr ("f64" in Intel table) */
-static const signed char immed_adjustment_intel64[256] = {
+static const sbyte immed_adjustment_intel64[256] = {
     0, 0,  0, 0, 0, -2, 0, 0,  0,  0,  0,  0,  0,  -2, 0,  0, /* 0 */
     0, 0,  0, 0, 0, -2, 0, 0,  0,  0,  0,  0,  0,  -2, 0,  0, /* 1 */
     0, 0,  0, 0, 0, -2, 0, 0,  0,  0,  0,  0,  0,  -2, 0,  0, /* 2 */
@@ -171,7 +171,7 @@ static const signed char immed_adjustment_intel64[256] = {
  * indexed by the 1st (primary) opcode byte.
  * The value here is doubled for x64 mode.
  */
-static const signed char disp_adjustment[256] = {
+static const sbyte disp_adjustment[256] = {
     0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0 */
     0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 1 */
     0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 2 */
@@ -199,7 +199,7 @@ static const signed char disp_adjustment[256] = {
  * default-size adjustments (positive numbers) and rex.w-prefix-based
  * adjustments (negative numbers, to be made positive when applied).
  */
-static const char x64_adjustment[256] = {
+static const sbyte x64_adjustment[256] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0, /* 0 */
     0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0, /* 1 */
     0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0, /* 2 */

--- a/core/ir/x86/decode_fast.c
+++ b/core/ir/x86/decode_fast.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1665,7 +1665,7 @@ decode_cti(void *drcontext, byte *pc, instr_t *instr)
         instr_set_num_opnds(dcontext, instr, 2, 2);
         instr_set_dst(instr, 0, opnd_create_reg(REG_XSP));
         instr_set_dst(instr, 1, opnd_create_base_disp(REG_XSP, REG_NULL, 0, 0, OPSZ_4));
-        instr_set_src(instr, 0, opnd_create_immed_int((char)byte1, OPSZ_1));
+        instr_set_src(instr, 0, opnd_create_immed_int((sbyte)byte1, OPSZ_1));
         instr_set_src(instr, 1, opnd_create_reg(REG_XSP));
         instr_set_raw_bits(instr, start_pc, sz);
         instr_set_rip_rel_pos(instr, rip_rel_pos);

--- a/core/ir/x86/encode.c
+++ b/core/ir/x86/encode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2628,7 +2628,7 @@ encode_cti(instr_t *instr, byte *copy_pc, byte *final_pc,
                           "encode_cti error: target beyond 8-bit reach");
             return NULL;
         }
-        *((char *)pc) = (char)offset;
+        *((sbyte *)pc) = (sbyte)offset;
         pc++;
     } else {
         /* 32-bit offset */
@@ -2717,7 +2717,7 @@ copy_and_re_relativize_raw_instr(dcontext_t *dcontext, instr_t *instr, byte *dst
         /* We only support non-4-byte rip-rel disps for 1-byte instr-final (jcc_short). */
         if (rip_rel_pos + 1 == instr->length) {
             ASSERT(CHECK_TRUNCATE_TYPE_sbyte(new_offs));
-            *((char *)dst_pc) = (char)new_offs;
+            *((sbyte *)dst_pc) = (sbyte)new_offs;
         } else {
             ASSERT(rip_rel_pos + 4 <= instr->length);
             ASSERT(CHECK_TRUNCATE_TYPE_int(new_offs));

--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -1092,7 +1092,7 @@ gen_syscall(void *dc, instrlist_t *ilist, int sysnum, uint num_opnds, opnd_t *ar
 #        ifdef X64
     APP(ilist, INSTR_CREATE_syscall(dc));
 #        else
-    APP(ilist, INSTR_CREATE_int(dc, OPND_CREATE_INT8((char)0x80)));
+    APP(ilist, INSTR_CREATE_int(dc, OPND_CREATE_INT8((sbyte)0x80)));
 #        endif
 #    else
     /* FIXME i#1551: NYI on ARM */

--- a/core/utils.c
+++ b/core/utils.c
@@ -2546,7 +2546,7 @@ strcasecmp_with_wildcards(const char *regexp, const char *consider)
             return -1;
         } else if (*consider == '\0')
             return 1;
-        ASSERT(*regexp != EOF && *consider != EOF);
+        ASSERT((sbyte)*regexp != EOF && (sbyte)*consider != EOF);
         cr = (char)tolower(*regexp);
         cc = (char)tolower(*consider);
         if (cr != '?' && cr != cc) {

--- a/core/win32/inject.c
+++ b/core/win32/inject.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -435,8 +435,8 @@ enum {
 #define RAW_INSERT_INT8(pos, value)                    \
     do {                                               \
         ASSERT(CHECK_TRUNCATE_TYPE_sbyte((int)value)); \
-        *(char *)(pos) = (char)(value);                \
-        (pos) += sizeof(char);                         \
+        *(sbyte *)(pos) = (sbyte)(value);              \
+        (pos) += sizeof(sbyte);                        \
     } while (0)
 
 #define RAW_PUSH_INT64(pos, value)                                                 \
@@ -1296,7 +1296,7 @@ inject_gencode_mapped_helper(HANDLE phandle, char *dynamo_path, uint64 hook_loca
         *cur_local_pos++ = MOV_IMM8_2_RM8;
         *cur_local_pos++ = MOV_deref_disp8_EAX_2_EAX_RM;
         RAW_INSERT_INT8(cur_local_pos, i);
-        RAW_INSERT_INT8(cur_local_pos, (char)hook_buf[i]);
+        RAW_INSERT_INT8(cur_local_pos, (sbyte)hook_buf[i]);
     }
 
     /* Call DR earliest-takeover routine w/ retaddr pointing at hooked

--- a/suite/tests/api/drdecode_x86.c
+++ b/suite/tests/api/drdecode_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -54,7 +54,8 @@ test_disasm_style(void)
     byte *pc, *end;
     instrlist_t *ilist = instrlist_create(GD);
     instrlist_append(ilist,
-                     INSTR_CREATE_mov_st(GD, OPND_CREATE_MEM32(REG_XCX, 37),
+                     /* With a negative displacement we stress signed type handling. */
+                     INSTR_CREATE_mov_st(GD, OPND_CREATE_MEM32(REG_XCX, -3),
                                          opnd_create_reg(REG_EAX)));
     instrlist_append(
         ilist, INSTR_CREATE_mov_imm(GD, opnd_create_reg(REG_EDI), OPND_CREATE_INT32(17)));

--- a/suite/tests/api/drdecode_x86.template
+++ b/suite/tests/api/drdecode_x86.template
@@ -1,12 +1,12 @@
 #ifdef X64
- 89 41 25             mov    %eax -> 0x25(%rcx)[4byte]
+ 89 41 fd             mov    %eax -> 0xfffffffd(%rcx)[4byte]
  bf 11 00 00 00       mov    $0x00000011 -> %edi
- 89 41 25             mov    dword ptr [rcx+0x25], eax
+ 89 41 fd             mov    dword ptr [rcx-0x03], eax
  bf 11 00 00 00       mov    edi, 0x00000011
 #else
- 89 41 25             mov    %eax -> 0x25(%ecx)[4byte]
+ 89 41 fd             mov    %eax -> 0xfffffffd(%ecx)[4byte]
  bf 11 00 00 00       mov    $0x00000011 -> %edi
- 89 41 25             mov    dword ptr [ecx+0x25], eax
+ 89 41 fd             mov    dword ptr [ecx-0x03], eax
  bf 11 00 00 00       mov    edi, 0x00000011
 #endif
 done

--- a/suite/tests/tools.c
+++ b/suite/tests/tools.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -453,7 +453,7 @@ nolibc_memset(void *dst, int val, size_t size)
     size_t i;
     char *buf = (char *)dst;
     for (i = 0; i < size; i++) {
-        buf[i] = (char)val;
+        buf[i] = (sbyte)val;
     }
 }
 


### PR DESCRIPTION
Updates pieces of the code that used "char" and assumed it was signed
to use "sbyte" instead.

Adds "-funsigned-char" to the base compiler flags to really ensure the
code base is free of assumptions and to further ensure it is
interoperable with other toolchains that use "-funsigned-char".

Adds a note to the style guide.

Tweaks the drdecode_x86 test to fail without the fixes here in the x86
decoder.

Fixes #1034