### PR TITLE
i#4923: Add missing rseq mangling translation case

### DIFF
--- a/core/translate.c
+++ b/core/translate.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -175,6 +175,18 @@ instr_is_rseq_mangling(dcontext_t *dcontext, instr_t *inst)
         opnd_is_base_disp(instr_get_src(inst, 0))) {
         reg_id_t dst = opnd_get_reg(instr_get_dst(inst, 0));
         opnd_t memref = instr_get_src(inst, 0);
+        int disp = opnd_get_disp(memref);
+        if (reg_is_gpr(dst) && reg_is_pointer_sized(dst) &&
+            opnd_get_index(memref) == DR_REG_NULL &&
+            disp ==
+                offsetof(dcontext_t, rseq_entry_state) +
+                    sizeof(reg_t) * (dst - DR_REG_START_GPR))
+            return true;
+    } else if (instr_get_opcode(inst) == IF_X86_ELSE(OP_mov_st, OP_str) &&
+               opnd_is_reg(instr_get_src(inst, 0)) &&
+               opnd_is_base_disp(instr_get_dst(inst, 0))) {
+        reg_id_t dst = opnd_get_reg(instr_get_src(inst, 0));
+        opnd_t memref = instr_get_dst(inst, 0);
         int disp = opnd_get_disp(memref);
         if (reg_is_gpr(dst) && reg_is_pointer_sized(dst) &&
             opnd_get_index(memref) == DR_REG_NULL &&

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -332,7 +332,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'code_api|linux.fib-conflict-early' => 1,
                                    'code_api|linux.mangle_asynch' => 1,
                                    'code_api|tool.drcachesim.phys' => 1, # i#4922
-                                   'code_api|api.rseq' => 1, # i#4923
                                    'code_api|tool.drcachesim.TLB-threads' => 1, # i#4928
                                    'code_api|tool.drcachesim.threads' => 1, # i#4928
                                    'code_api,tracedump_text,tracedump_origins,syntax_intel|common.loglevel' => 1, # i#1807


### PR DESCRIPTION
Adds translation of the save of input registers to rseq sequences.

This fixes a hang on detach in the api.ir test on AArch64, which we
remove from the flaky list here.

Manually tested by running api.rseq 200x on the Jenkins machine.
Previously the test failed every single time there.

Issue: #4923, #4316, #4669
Fixes #4923