### PR TITLE
i#5352: Fix Windows performance regression

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -133,11 +133,15 @@ changes:
    distributable version of DynamoRIO.
 
 Further non-compatibility-affecting changes include:
+ - Fixed a significant performance regression between 8.0.0 and 9.0.0
+   (between 8.0.18740 and 8.0.18747) affecting Windows programs with
+   varying indirect branches on hot code paths.
  - Added alias support to droption.
  - The drcpusim option -blacklist was renamed to -blocklist but the old name
    is still accepted.
  - Added droption_parser_t::clear_values() for re-setting accumulating option
    values on re-attach for statically linked clients.
+ - Added the count of cache exits to #dr_statistics_t.
 
 The changes between version 9.0.0 and 8.0.0 include the following compatibility
 changes:

--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1149,7 +1149,7 @@ dispatch_exit_fcache(dcontext_t *dcontext)
          * Do not bother to try to update on an exit due to a signal
          * (so signals_pending>0; for <0 we're in the handler).
          */
-        if (IF_UNIX_ELSE(dcontext->signals_pending <= 0, false)) {
+        if (IF_UNIX_ELSE(dcontext->signals_pending <= 0, true)) {
             SELF_PROTECT_LOCAL(dcontext, WRITABLE);
             /* update IBL target table if target is a valid IBT */
             /* FIXME: This is good for modularity but adds
@@ -1338,8 +1338,11 @@ dispatch_exit_fcache_stats(dcontext_t *dcontext)
     }
 #endif
 
+    /* A count of cache exits is a useful enough metric to gauge performance
+     * problems that we pay for a counter in release build.
+     */
+    RSTATS_INC(num_exits);
 #if defined(DEBUG) || defined(KSTATS)
-    STATS_INC(num_exits);
     ASSERT(dcontext->last_exit != NULL);
 
     /* special exits that aren't from real fragments */

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -865,6 +865,8 @@ typedef struct _dr_stats_t {
     uint64 peak_vmm_blocks_reach_special_mmap;
     /** Signals delivered to native threads. */
     uint64 num_native_signals;
+    /** Number of exits from the code cache. */
+    uint64 num_cache_exits;
 } dr_stats_t;
 
 /**

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -677,7 +677,7 @@ STATS_DEF("Waits due to shared cache barrier", num_wait_shared_barrier)
 
 STATS_DEF("Entrance hooks to DR", num_entering_DR)
 STATS_DEF("Exit hooks from DR", num_exiting_DR)
-STATS_DEF("Fcache exits, total", num_exits)
+RSTATS_DEF("Fcache exits, total", num_exits)
 STATS_DEF("Fcache exits, coarse-grain fragments", num_exits_coarse)
 STATS_DEF("Fcache exits, coarse-grain targeting trace head", num_exits_coarse_trace_head)
 STATS_DEF("Fcache exits, fine targeting th coarse", num_exits_fine2th_coarse)

--- a/core/utils.c
+++ b/core/utils.c
@@ -4570,31 +4570,33 @@ stats_get_snapshot(dr_stats_t *drstats)
     }
     drstats->peak_num_threads = GLOBAL_STAT(peak_num_threads);
     drstats->num_threads_created = GLOBAL_STAT(num_threads_created);
-    if (drstats->size > offsetof(dr_stats_t, synchs_not_at_safe_spot)) {
-        drstats->synchs_not_at_safe_spot = GLOBAL_STAT(synchs_not_at_safe_spot);
-    }
-    if (drstats->size > offsetof(dr_stats_t, peak_vmm_blocks_unreach_heap)) {
-        /* These fields were added all at once. */
-        drstats->peak_vmm_blocks_unreach_heap = GLOBAL_STAT(peak_vmm_blocks_unreach_heap);
-        drstats->peak_vmm_blocks_unreach_stack =
-            GLOBAL_STAT(peak_vmm_blocks_unreach_stack);
-        drstats->peak_vmm_blocks_unreach_special_heap =
-            GLOBAL_STAT(peak_vmm_blocks_unreach_special_heap);
-        drstats->peak_vmm_blocks_unreach_special_mmap =
-            GLOBAL_STAT(peak_vmm_blocks_unreach_special_mmap);
-        drstats->peak_vmm_blocks_reach_heap = GLOBAL_STAT(peak_vmm_blocks_reach_heap);
-        drstats->peak_vmm_blocks_reach_cache = GLOBAL_STAT(peak_vmm_blocks_reach_cache);
-        drstats->peak_vmm_blocks_reach_special_heap =
-            GLOBAL_STAT(peak_vmm_blocks_reach_special_heap);
-        drstats->peak_vmm_blocks_reach_special_mmap =
-            GLOBAL_STAT(peak_vmm_blocks_reach_special_mmap);
-    }
-    if (drstats->size > offsetof(dr_stats_t, num_native_signals)) {
+    if (drstats->size <= offsetof(dr_stats_t, synchs_not_at_safe_spot))
+        return true;
+    drstats->synchs_not_at_safe_spot = GLOBAL_STAT(synchs_not_at_safe_spot);
+    if (drstats->size <= offsetof(dr_stats_t, peak_vmm_blocks_unreach_heap))
+        return true;
+    /* These fields were added all at once. */
+    drstats->peak_vmm_blocks_unreach_heap = GLOBAL_STAT(peak_vmm_blocks_unreach_heap);
+    drstats->peak_vmm_blocks_unreach_stack = GLOBAL_STAT(peak_vmm_blocks_unreach_stack);
+    drstats->peak_vmm_blocks_unreach_special_heap =
+        GLOBAL_STAT(peak_vmm_blocks_unreach_special_heap);
+    drstats->peak_vmm_blocks_unreach_special_mmap =
+        GLOBAL_STAT(peak_vmm_blocks_unreach_special_mmap);
+    drstats->peak_vmm_blocks_reach_heap = GLOBAL_STAT(peak_vmm_blocks_reach_heap);
+    drstats->peak_vmm_blocks_reach_cache = GLOBAL_STAT(peak_vmm_blocks_reach_cache);
+    drstats->peak_vmm_blocks_reach_special_heap =
+        GLOBAL_STAT(peak_vmm_blocks_reach_special_heap);
+    drstats->peak_vmm_blocks_reach_special_mmap =
+        GLOBAL_STAT(peak_vmm_blocks_reach_special_mmap);
+    if (drstats->size <= offsetof(dr_stats_t, num_native_signals))
+        return true;
 #ifdef UNIX
-        drstats->num_native_signals = GLOBAL_STAT(num_native_signals);
+    drstats->num_native_signals = GLOBAL_STAT(num_native_signals);
 #else
-        drstats->num_native_signals = 0;
+    drstats->num_native_signals = 0;
 #endif
-    }
+    if (drstats->size <= offsetof(dr_stats_t, num_cache_exits))
+        return true;
+    drstats->num_cache_exits = GLOBAL_STAT(num_exits);
     return true;
 }

--- a/suite/tests/api/detach.c
+++ b/suite/tests/api/detach.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -72,6 +72,26 @@ func_2(void)
 NOINLINE void
 func_3(void)
 {
+    /* A workload with indirect branches to help serve as a performance test
+     * by checking the cache exits (xref #5352).
+     */
+    double res = 0.;
+    /* Run enough iterations to distinguish good from bad exit counts. */
+    for (int i = 0; i < 10 * COMPUTE_ITERS; i++) {
+        /* Create multiple return points so a single trace doesn't capture them
+         * all, to test table lookups (as in i#5352).
+         */
+        if (i % 4 == 0)
+            res += cos(1. / (double)(i % 4));
+        else if (i % 4 == 1)
+            res += cos(1. / (double)(i % 4));
+        else if (i % 4 == 2)
+            res += cos(1. / (double)(i % 4));
+        else if (i % 4 == 3)
+            res += cos(1. / (double)(i % 4));
+    }
+    if (res == 0.)
+        print("result is 0\n");
 }
 NOINLINE void
 func_4(void)
@@ -217,6 +237,10 @@ main(void)
     dr_stats_t stats = { sizeof(dr_stats_t) };
     dr_app_stop_and_cleanup_with_stats(&stats);
     assert(stats.basic_block_count > 0);
+    /* Sanity check: we expect <10K exits but we allow some leniency to avoid flakiness.
+     * On a repeat of i#5352 we would see >500K exits.
+     */
+    assert(stats.num_cache_exits < 15000);
 
     VPRINT("signaling native\n");
     signal_cond_var(go_native);


### PR DESCRIPTION
Fixes a failure to add indirect branch targets to the lookup table on
Windows, a regression due to commit 638fb10 (PR #4886).

Adds a regression test.  Since small-enough pure performance tests on
test VM's are difficult to keep non-flaky, we instead check the count
of cache exits as a proxy for performance.  We turn the total exit
count into a release-build statistic, paying the cost of that one
counter.  (This stat should be useful for other purposes as well.)  We
add a workload with several separate calls (to avoid trace capture of
one target) in a loop to the api.detach test as a convenient test for
programmatically grabbing the stats and checking the resulting count.

Manually tested on the Botan library program from the original
reported problem: the big slowdown disappears with this fix.

Fixes #5352