### PR TITLE
i#5352 perf regression: Point at 9.0.1 release

### DIFF
--- a/api/docs/download.dox
+++ b/api/docs/download.dox
@@ -50,17 +50,17 @@ The source code is available:
 
 For the very latest changes since the last official release, you can download \ref page_weekly_builds.
 
-The [9.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_9.0.0):
+The [9.0.1 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_9.0.1):
 
-  - [DynamoRIO-Windows-9.0.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.0/DynamoRIO-Windows-9.0.0.zip)
+  - [DynamoRIO-Windows-9.0.1.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-Windows-9.0.1.zip)
 
-  - [DynamoRIO-Linux-9.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.0/DynamoRIO-Linux-9.0.0.tar.gz)
+  - [DynamoRIO-Linux-9.0.1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-Linux-9.0.1.tar.gz)
 
-  - [DynamoRIO-ARM-Linux-EABIHF-9.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.0/DynamoRIO-ARM-Linux-EABIHF-9.0.0.tar.gz)
+  - [DynamoRIO-ARM-Linux-EABIHF-9.0.1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-ARM-Linux-EABIHF-9.0.1.tar.gz)
 
-  - [DynamoRIO-ARM-Android-EABI-9.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.0/DynamoRIO-ARM-Android-EABI-9.0.0.tar.gz)
+  - [DynamoRIO-ARM-Android-EABI-9.0.1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-ARM-Android-EABI-9.0.1.tar.gz)
 
-  - [DynamoRIO-AArch64-Linux-9.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.0/DynamoRIO-AArch64-Linux-9.0.0.tar.gz)
+  - [DynamoRIO-AArch64-Linux-9.0.1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-AArch64-Linux-9.0.1.tar.gz)
 
 The prior [8.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_8.0.0-1):
 

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -124,7 +124,10 @@ Dr. Memory Framework (DRMF) in the same package as DynamoRIO.  DRMF
 provides the umbra, drsyscall, and drsymcache Extensions for use by
 clients.
 
-The changes between version \DR_VERSION and 9.0.0 include the following compatibility
+The changes between version \DR_VERSION and 9.0.1 include the following changes:
+ - Nothing yet (placeholder).
+
+The changes between version 9.0.1 and 9.0.0 include the following compatibility
 changes:
  - Introduced a new CMake option called BUILD_PACKAGE to skip glibc
    compatibility checks. This is off by default such that building DynamoRIO


### PR DESCRIPTION
We put out a 9.0.1 bugfix release for the #5352 performance regression
on Windows.  Here we update the direct download links.

Also updates the changelog, which includes a couple of minor features
added since 9.0.0.  We stick with 9.0.1 despite that for simplicity.
The only compatibility change affects just those building DR from
sources and so is less relevant for versioning.

Issue: #5352