### PR TITLE
i#5356: Add drwrap control inversion option

### DIFF
--- a/ext/drwrap/drwrap.h
+++ b/ext/drwrap/drwrap.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2021 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2022 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /* drwrap: DynamoRIO Function Wrapping and Replacing Extension
@@ -66,6 +66,9 @@ DR_EXPORT
  * normally) but each call must be paired with a corresponding call to
  * drwrap_exit().
  *
+ * Some drwrap behavior must be set by calling drwrap_set_global_flags() *before*
+ * calling this routine.
+ *
  * \return whether successful.
  */
 bool
@@ -77,6 +80,34 @@ DR_EXPORT
  */
 void
 drwrap_exit(void);
+
+/***************************************************************************
+ * CONTROL INVERSION
+ */
+
+/**
+ * When #drwrap_global_flags_t #DRWRAP_INVERT_CONTROL is set, the user
+ * must call this function from a drmgr analysis event handler
+ * (typically registered with
+ * drmgr_register_bb_instrumentation_event()).  For best results the
+ * calling handler should use a priority of
+ * #DRMGR_PRIORITY_INSERT_DRWRAP.
+ */
+dr_emit_flags_t
+drwrap_invoke_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
+                       bool translating, OUT void **user_data);
+
+/**
+ * When #drwrap_global_flags_t #DRWRAP_INVERT_CONTROL is set, the user
+ * must call this function from a drmgr insertion event handler
+ * (typically registered with
+ * drmgr_register_bb_instrumentation_event()).  For best results the
+ * calling handler should use a priority of
+ * #DRMGR_PRIORITY_INSERT_DRWRAP.
+ */
+dr_emit_flags_t
+drwrap_invoke_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
+                     bool for_trace, bool translating, void *user_data);
 
 /***************************************************************************
  * FUNCTION REPLACING
@@ -751,6 +782,16 @@ typedef enum {
      * Once set, this flag cannot be unset.
      */
     DRWRAP_FAST_CLEANCALLS = 0x08,
+    /**
+     * This flag must only be set before calling drwrap_init().  If set, drwrap will not
+     * register for the drmgr analysis or insertion events.  The user must instead
+     * explicitly invoke drwrap_invoke_analysis() and drwrap_invoke_insert() from its
+     * own handler for those events.  This "inverted control" mode is provided for
+     * better compatibility with drbbdup where the user wishes to only perform wrapping
+     * in a subset of the drbbdup cases.  Only wrapping is supported this way, not
+     * replacing, at this time.
+     */
+    DRWRAP_INVERT_CONTROL = 0x10,
 } drwrap_global_flags_t;
 
 DR_EXPORT

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2594,6 +2594,15 @@ use_DynamoRIO_extension(client.drbbdup-analysis-test.dll drmgr)
 use_DynamoRIO_extension(client.drbbdup-analysis-test.dll drreg)
 use_DynamoRIO_extension(client.drbbdup-analysis-test.dll drbbdup)
 
+tobuild_appdll(client.drbbdup-drwrap-test client-interface/drbbdup-drwrap-test.c)
+get_target_path_for_execution(bbdupwrap_libpath
+  client.drbbdup-drwrap-test.appdll "${location_suffix}")
+tobuild_ci(client.drbbdup-drwrap-test client-interface/drbbdup-drwrap-test.c "" ""
+  "${bbdupwrap_libpath}")
+use_DynamoRIO_extension(client.drbbdup-drwrap-test.dll drmgr)
+use_DynamoRIO_extension(client.drbbdup-drwrap-test.dll drbbdup)
+use_DynamoRIO_extension(client.drbbdup-drwrap-test.dll drwrap)
+
 if (ARM)
   tobuild_ci(client.predicate-test client-interface/predicate-test.c "" "" "")
   use_DynamoRIO_extension(client.predicate-test.dll drmgr)

--- a/suite/tests/client-interface/drbbdup-drwrap-test.appdll.c
+++ b/suite/tests/client-interface/drbbdup-drwrap-test.appdll.c
@@ -1,0 +1,80 @@
+/* **********************************************************
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Test wrapping functionality using a library w/ exported routines
+ * so they're easy for the client to locate.
+ */
+
+#include "tools.h"
+
+int EXPORT
+wrapme(int x)
+{
+    print("%s: arg %d\n", __FUNCTION__, x);
+    return x;
+}
+
+int
+run_tests(void)
+{
+    print("first wrapme returned %d\n", wrapme(2));
+    /* Signal the client to switch modes. */
+#ifdef WINDOWS
+    __nop();
+    __nop();
+    __nop();
+    __nop();
+#else
+    __asm__ __volatile__("nop; nop; nop; nop");
+#endif
+    print("second wrapme returned %d\n", wrapme(2));
+}
+
+#ifdef WINDOWS
+BOOL APIENTRY
+DllMain(HANDLE hModule, DWORD reason_for_call, LPVOID Reserved)
+{
+    switch (reason_for_call) {
+    case DLL_PROCESS_ATTACH: run_tests(); break;
+    case DLL_PROCESS_DETACH: break;
+    case DLL_THREAD_ATTACH: break;
+    case DLL_THREAD_DETACH: break;
+    }
+    return TRUE;
+}
+#else
+int __attribute__((constructor)) so_init(void)
+{
+    run_tests();
+    return 0;
+}
+#endif

--- a/suite/tests/client-interface/drbbdup-drwrap-test.c
+++ b/suite/tests/client-interface/drbbdup-drwrap-test.c
@@ -1,0 +1,75 @@
+/* **********************************************************
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "tools.h"
+#ifdef UNIX
+#    include "dlfcn.h"
+#endif
+
+static void
+load_library(const char *path)
+{
+#ifdef WINDOWS
+    HANDLE lib = LoadLibrary(path);
+    if (lib == NULL) {
+        print("error loading library %s\n", path);
+    } else {
+        print("loaded library\n");
+        FreeLibrary(lib);
+    }
+#else
+    void *lib = dlopen(path, RTLD_LAZY | RTLD_LOCAL);
+    if (lib == NULL) {
+        print("error loading library %s: %s\n", path, dlerror());
+    } else {
+        print("loaded library\n");
+        dlclose(lib);
+    }
+#endif
+}
+
+int
+main(int argc, char *argv[])
+{
+#ifdef WINDOWS
+    load_library("client.drbbdup-drwrap-test.appdll.dll");
+#else
+    /* We don't have "." on LD_LIBRARY_PATH path so we take in abs path */
+    if (argc < 2) {
+        print("need to pass in lib path\n");
+        return 1;
+    }
+    load_library(argv[1]);
+#endif
+    print("thank you for testing the client interface\n");
+    return 0;
+}

--- a/suite/tests/client-interface/drbbdup-drwrap-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-drwrap-test.dll.c
@@ -1,0 +1,187 @@
+/* **********************************************************
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Tests the drbbdup extension when combined with drrwap but using drwrap
+ * in only a subset of the cases.
+ */
+
+#include "dr_api.h"
+#include "drmgr.h"
+#include "drbbdup.h"
+#include "drwrap.h"
+#include <string.h>
+
+#define CHECK(x, msg)                                                                \
+    do {                                                                             \
+        if (!(x)) {                                                                  \
+            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
+            dr_abort();                                                              \
+        }                                                                            \
+    } while (0);
+
+/* We assume the app is single-threaded for this test. */
+static uintptr_t case_encoding = 0;
+
+static uintptr_t
+set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
+               bool *enable_dups, bool *enable_dynamic_handling, void *user_data)
+{
+    drbbdup_status_t res;
+
+    CHECK(enable_dups != NULL, "should not be NULL");
+    CHECK(enable_dynamic_handling != NULL, "should not be NULL");
+
+    res = drbbdup_register_case_encoding(drbbdup_ctx, 1);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to register case 1");
+
+    *enable_dups = true;
+    *enable_dynamic_handling = false; /* disable dynamic handling */
+    return 0;                         /* return default case */
+}
+
+static void
+event_analyse_case(void *drcontext, void *tag, instrlist_t *bb, uintptr_t encoding,
+                   void *user_data, void *orig_analysis_data, void **case_analysis_data)
+{
+    if (encoding == 0) {
+        int consec_nop_count = 0;
+        for (instr_t *inst = instrlist_first_app(bb); inst != NULL;
+             inst = instr_get_next_app(inst)) {
+            if (instr_get_opcode(inst) == OP_nop)
+                ++consec_nop_count;
+            else {
+                if (consec_nop_count == 4) {
+                    /* Time to switch modes. */
+                    case_encoding = 1;
+                }
+                consec_nop_count = 0;
+            }
+        }
+    }
+    if (encoding == 1) {
+        /* drwrap guarantees it doesn't need "for_trace", "translating", or
+         * a non-DR_EMIT_DEFAULT return value for drwrap_wrap().
+         */
+        drwrap_invoke_analysis(drcontext, tag, bb, /*for_trace=*/false,
+                               /*translating=*/false, case_analysis_data);
+    }
+}
+
+static void
+event_instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
+                       instr_t *where, uintptr_t encoding, void *user_data,
+                       void *orig_analysis_data, void *case_analysis_data)
+{
+    if (encoding == 1) {
+        /* drwrap guarantees it doesn't need "for_trace", "translating", or
+         * a non-DR_EMIT_DEFAULT return value for drwrap_wrap().
+         */
+        drwrap_invoke_insert(drcontext, tag, bb, instr, /*for_trace=*/false,
+                             /*translating=*/false, case_analysis_data);
+    }
+}
+
+static void
+wrap_pre(void *wrapcxt, OUT void **user_data)
+{
+    bool ok;
+    CHECK(wrapcxt != NULL && user_data != NULL, "invalid arg");
+    ok = drwrap_set_arg(wrapcxt, 0, (void *)42);
+    CHECK(ok, "set_arg error");
+}
+
+static void
+wrap_post(void *wrapcxt, void *user_data)
+{
+    /* Nothing yet. */
+}
+
+static void
+event_module_load(void *drcontext, const module_data_t *mod, bool loaded)
+{
+    if (strstr(dr_module_preferred_name(mod), "client.drbbdup-drwrap-test.appdll.") ==
+        NULL)
+        return;
+    app_pc target = (app_pc)dr_get_proc_address(mod->handle, "wrapme");
+    CHECK(target != NULL, "cannot find lib export");
+    bool res = drwrap_wrap(target, wrap_pre, wrap_post);
+    CHECK(res, "wrap failed");
+}
+
+static void
+event_exit(void)
+{
+    bool res = drmgr_unregister_module_load_event(event_module_load);
+    CHECK(res, "drmgr_unregister_event_module_load failed");
+    drwrap_exit();
+    drbbdup_status_t status = drbbdup_exit();
+    CHECK(status == DRBBDUP_SUCCESS, "drbbdup exit failed");
+    drmgr_exit();
+}
+
+DR_EXPORT void
+dr_init(client_id_t id)
+{
+    drmgr_init();
+
+    drbbdup_options_t opts = { 0 };
+    opts.struct_size = sizeof(drbbdup_options_t);
+    opts.set_up_bb_dups = set_up_bb_dups;
+    opts.analyze_case = event_analyse_case;
+    opts.instrument_instr = event_instrument_instr;
+    opts.runtime_case_opnd = OPND_CREATE_ABSMEM(&case_encoding, OPSZ_PTR);
+    opts.atomic_load_encoding = false;
+    opts.max_case_encoding = 1;
+    opts.non_default_case_limit = 1;
+
+    drbbdup_status_t status = drbbdup_init(&opts);
+    CHECK(status == DRBBDUP_SUCCESS, "drbbdup init failed");
+
+    dr_register_exit_event(event_exit);
+
+    /* Make sure requesting inversion fails *after* drwrap_init().
+     * This also stresses drwrap re-attach via init;exit;init.
+     */
+    bool res = drwrap_init();
+    CHECK(res, "drwrap_init failed");
+    res = drwrap_set_global_flags(DRWRAP_INVERT_CONTROL);
+    CHECK(!res, "DRWRAP_INVERT_CONTROL after drwrap_init should fail");
+    drwrap_exit();
+
+    res = drwrap_set_global_flags(DRWRAP_INVERT_CONTROL);
+    CHECK(res, "DRWRAP_INVERT_CONTROL failed");
+    res = drwrap_init();
+    CHECK(res, "drwrap_init failed");
+
+    res = drmgr_register_module_load_event(event_module_load);
+    CHECK(res, "drmgr_register_event_module_load failed");
+}

--- a/suite/tests/client-interface/drbbdup-drwrap-test.expect
+++ b/suite/tests/client-interface/drbbdup-drwrap-test.expect
@@ -1,0 +1,6 @@
+wrapme: arg 2
+first wrapme returned 2
+wrapme: arg 42
+second wrapme returned 42
+loaded library
+thank you for testing the client interface


### PR DESCRIPTION
Adds a new global flag to drwrap which inverts control such that the
client must explicitly invoke drwrap's app2app and instrumentation
handlers.  This lets a client use drbbdup with drwrap only applying to
a subset of the cases.

Given missing pieces in drbbdup, only drwrap wrapping is supported
this way: not drwrap replacing.  (For full support, we would need to
add app2app event support inside drbbdup, as well as support for
returning other than DR_EMIT_DEFAULT for the various instrumentation
handlers.)

Adds a new test drbbdup-drwrap-test which wraps a function in only one
of its drbbdup cases.

The new test includes a check for drwrap_set_global_flags() being
called after drwrap_init() by having a
drwrap_init;drwrap_exit;drwrap_init sequence.  This revealed several
missing unregister calls in drwrap_exit, which we fix here.  These are
not assumed to affect full re-attach since drmgr resets its state
completely; they cause a use-after-free here because drwrap but not
drmgr was reset and we had two thread exit handlers.

Issue: #3995, #5356
Fixes #5356