### PR TITLE
i#4134: Add atomic increment for drbbdup inits

### DIFF
--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -1753,8 +1753,12 @@ drbbdup_init(drbbdup_options_t *ops_in)
     int count = dr_atomic_add32_return_sum(&drbbdup_init_count, 1);
 
     /* Return with error if drbbdup has already been initialised. */
-    if (count != 1)
+    if (count != 1) {
+        /* XXX: We do not revert back the counter and therefore consider this error as
+         * fatal! */
+        ASSERT(false, "drbbdup has already been initialised");
         return DRBBDUP_ERROR_ALREADY_INITIALISED;
+    }
 
     if (!drbbdup_check_options(ops_in))
         return DRBBDUP_ERROR_INVALID_PARAMETER;

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -64,10 +64,11 @@ typedef enum {
     DRBBDUP_ERROR_INVALID_OPND,            /**< Operation failed: invalid case opnd. */
     DRBBDUP_ERROR_CASE_ALREADY_REGISTERED, /**< Operation failed: already registered. */
     DRBBDUP_ERROR_CASE_LIMIT_REACHED,      /**< Operation failed: case limit reached. */
-    DRBBDUP_ERROR_ALREADY_INITIALISED,     /**< DRBBDUP can only be initialised once. */
-    DRBBDUP_ERROR,                         /**< Operation failed. */
-    DRBBDUP_ERROR_UNSET_FEATURE,           /**< Operation failed: feature not set. */
-    DRBBDUP_ERROR_NOT_INITIALIZED,         /**< Operation failed: not initialized. */
+    DRBBDUP_ERROR_ALREADY_INITIALISED, /**< DRBBDUP can only be initialised once. This is
+                                          a fatal error. */
+    DRBBDUP_ERROR,                     /**< Operation failed. */
+    DRBBDUP_ERROR_UNSET_FEATURE,       /**< Operation failed: feature not set. */
+    DRBBDUP_ERROR_NOT_INITIALIZED,     /**< Operation failed: not initialized. */
 } drbbdup_status_t;
 
 /***************************************************************************


### PR DESCRIPTION
Makes increment/decrement operations atomic, using dr_atomic_add32_return_sum(), when tracking number of drbbdup inits. (Note, atm, only one drbbdup init is allowed).

Issue: #4134 