### PR TITLE
i#5356 bbdup-wrap: Add extended drbbdup instrumentation callback

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -129,7 +129,7 @@ changes:
  - Nothing yet (placeholder).
 
 Further non-compatibility-affecting changes include:
- - Added a new field instrument_instr_ex to #drbbdup_options_t.
+ - Added new fields analyze_case_ex and instrument_instr_ex to #drbbdup_options_t.
 
 The changes between version 9.0.1 and 9.0.0 include the following compatibility
 changes:

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -124,8 +124,12 @@ Dr. Memory Framework (DRMF) in the same package as DynamoRIO.  DRMF
 provides the umbra, drsyscall, and drsymcache Extensions for use by
 clients.
 
-The changes between version \DR_VERSION and 9.0.1 include the following changes:
+The changes between version \DR_VERSION and 9.0.1 include the following compatibility
+changes:
  - Nothing yet (placeholder).
+
+Further non-compatibility-affecting changes include:
+ - Added a new field instrument_instr_ex to #drbbdup_options_t.
 
 The changes between version 9.0.1 and 9.0.0 include the following compatibility
 changes:

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -158,6 +158,20 @@ typedef void (*drbbdup_analyze_case_t)(void *drcontext, void *tag, instrlist_t *
                                        IN void **case_analysis_data);
 
 /**
+ * Identical to #drbbdup_analyze_case_t except for two extra parameters, "for_trace"
+ * and "translating", and the return value.  These all match the same parameters and
+ * return values used with #drmgr_analysis_cb_t and dr_register_bb_event().
+ * The returned flags will be merged in the same manner as for #drmgr_analysis_cb_t.
+ *
+ */
+typedef dr_emit_flags_t (*drbbdup_analyze_case_ex_t)(void *drcontext, void *tag,
+                                                     instrlist_t *bb, bool for_trace,
+                                                     bool translating, uintptr_t encoding,
+                                                     void *user_data,
+                                                     void *orig_analysis_data,
+                                                     IN void **case_analysis_data);
+
+/**
  * Destroys analysis data \p case_analysis_data for the case with encoding \p encoding.
  *
  * The function is not invoked by drbbdup if \p case_analysis_data was set to NULL by the
@@ -320,6 +334,11 @@ typedef struct {
      * avoids an extra scratch register.  Set to 0 to indicate there is no bound.
      */
     uintptr_t max_case_encoding;
+    /**
+     * Identical to analyze_case but taking extra parameters and with a return value.
+     * Only one of this field or the analyze_case field can be set.
+     */
+    drbbdup_analyze_case_ex_t analyze_case_ex;
     /**
      * Identical to instrument_instr but taking extra parameters and with a return value.
      * Either this or the instrument_instr field must be set.

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -205,6 +205,18 @@ typedef void (*drbbdup_instrument_instr_t)(void *drcontext, void *tag, instrlist
                                            void *orig_analysis_data,
                                            void *case_analysis_data);
 
+/**
+ * Identical to #drbbdup_instrument_instr_t except for two extra parameters, "for_trace"
+ * and "translating", and the return value.  These all match the same parameters and
+ * return values used with #drmgr_insertion_cb_t and dr_register_bb_event().
+ * The returned flags will be merged in the same manner as for #drmgr_insertion_cb_t.
+ *
+ */
+typedef dr_emit_flags_t (*drbbdup_instrument_instr_ex_t)(
+    void *drcontext, void *tag, instrlist_t *bb, instr_t *instr, instr_t *where,
+    bool for_trace, bool translating, uintptr_t encoding, void *user_data,
+    void *orig_analysis_data, void *case_analysis_data);
+
 /***************************************************************************
  * INIT
  */
@@ -255,7 +267,7 @@ typedef struct {
     drbbdup_destroy_case_analysis_t destroy_case_analysis;
     /**
      * A user-defined call-back function that instruments an instruction with respect to a
-     * particular case.
+     * particular case.  Either this or the instrument_instr_ex field must be set.
      */
     drbbdup_instrument_instr_t instrument_instr;
     /**
@@ -308,6 +320,11 @@ typedef struct {
      * avoids an extra scratch register.  Set to 0 to indicate there is no bound.
      */
     uintptr_t max_case_encoding;
+    /**
+     * Identical to instrument_instr but taking extra parameters and with a return value.
+     * Either this or the instrument_instr field must be set.
+     */
+    drbbdup_instrument_instr_ex_t instrument_instr_ex;
 } drbbdup_options_t;
 
 /**

--- a/suite/tests/client-interface/drbbdup-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-test.dll.c
@@ -219,6 +219,7 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
         dr_insert_clean_call(drcontext, bb, where, print_case, false, 1,
                              OPND_CREATE_INTPTR(encoding));
     }
+    return DR_EMIT_DEFAULT;
 }
 
 static void

--- a/suite/tests/client-interface/drbbdup-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-test.dll.c
@@ -254,8 +254,9 @@ event_exit(void)
     /* Sanity check that the _ex parameters are passed.
      * We'd like to test the dr_emit_flags_t return value too but it's not
      * easy to do that.
+     * XXX i#1668,i#2974: x86-only because traces are not yet implemented on aarchxx.
      */
-    CHECK(count_for_trace > 0, "for_trace was never passed");
+    IF_X86(CHECK(count_for_trace > 0, "for_trace was never passed"));
 
     drmgr_exit();
 }


### PR DESCRIPTION
Adds a new field to the drbbdup options that points at an
instrumentation handler that takes in the "for_trace" and
"translating" parameters and returns dr_emit_flags_t.  Either the
original or this one must be set.

Adds a simple sanity check of the parameters.  Testing the return
value is difficult, unfortunately.

Issue: #5356, #3995, #4134