### PR TITLE
Share duplicate CHECK macros in client-interface tests

### DIFF
--- a/suite/tests/api/startstop_avx512lazy.dll.c
+++ b/suite/tests/api/startstop_avx512lazy.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,14 +33,6 @@
 #include "dr_api.h"
 #include "client_tools.h"
 #include <string.h>
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 DR_EXPORT void
 dr_init(client_id_t id)

--- a/suite/tests/client-interface/app_args.dll.c
+++ b/suite/tests/client-interface/app_args.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -34,14 +34,6 @@
 #include "drmgr.h"
 #include "client_tools.h"
 #include <string.h> /* memset */
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 #define ARG_BUF_SIZE 4
 #define ARG_STR_BUF_SIZE 400

--- a/suite/tests/client-interface/avx512lazy.dll.c
+++ b/suite/tests/client-interface/avx512lazy.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -42,14 +42,6 @@
 #        error "Compiler provided __AVX512F__ define not set"
 #    endif
 #endif
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 /* This library assumes a single-threaded test. */
 static bool seen_before;

--- a/suite/tests/client-interface/drbbdup-analysis-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-analysis-test.dll.c
@@ -36,18 +36,11 @@
  */
 
 #include "dr_api.h"
+#include "client_tools.h"
 #include "drmgr.h"
 #include "drbbdup.h"
 
 #define TEST_NOTE_VAL (void *)767LL
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 static bool instrum_called = false;
 static bool test_label_persisted = false;
@@ -117,7 +110,7 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
             test_label_persisted = true;
         } else if (instr_is_app(instr)) {
             bool is_label = is_test_label(instr_get_prev(where));
-            CHECK(is_label, "prev instr should be test label")
+            CHECK(is_label, "prev instr should be test label");
         }
         break;
     default: CHECK(false, "invalid encoding");

--- a/suite/tests/client-interface/drbbdup-no-encode-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-no-encode-test.dll.c
@@ -36,16 +36,9 @@
  */
 
 #include "dr_api.h"
+#include "client_tools.h"
 #include "drmgr.h"
 #include "drbbdup.h"
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 #define USER_DATA_VAL (void *)222
 static uintptr_t case_encoding = 1;

--- a/suite/tests/client-interface/drbbdup-nonzero-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-nonzero-test.dll.c
@@ -35,16 +35,9 @@
  */
 
 #include "dr_api.h"
+#include "client_tools.h"
 #include "drmgr.h"
 #include "drbbdup.h"
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 #define USER_DATA_VAL (void *)222
 static uintptr_t case_encoding = 1;

--- a/suite/tests/client-interface/drbbdup-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-test.dll.c
@@ -33,16 +33,9 @@
 /* Tests the drbbdup extension. */
 
 #include "dr_api.h"
+#include "client_tools.h"
 #include "drmgr.h"
 #include "drbbdup.h"
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 #define USER_DATA_VAL (void *)222
 #define ORIG_ANALYSIS_VAL (void *)555

--- a/suite/tests/client-interface/drcontainers-test.dll.c
+++ b/suite/tests/client-interface/drcontainers-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,17 +33,10 @@
 /* Tests the drcontainers extension */
 
 #include "dr_api.h"
+#include "client_tools.h"
 #include "drvector.h"
 #include "hashtable.h"
 #include "stdint.h"
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 static void
 test_vector(void)

--- a/suite/tests/client-interface/drmgr-test.dll.c
+++ b/suite/tests/client-interface/drmgr-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -41,14 +41,6 @@
 #ifdef UNIX
 #    include <signal.h>
 #endif
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 /* CLS tests: easiest to assume a single thread (the 2nd thread the
  * app creates, in this case) hitting callbacks and use global data to

--- a/suite/tests/client-interface/drmodtrack-test.dll.cpp
+++ b/suite/tests/client-interface/drmodtrack-test.dll.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,14 +43,6 @@
 #    pragma warning(disable : 4100) /* unreferenced formal parameter */
 #    pragma warning(disable : 4127) /* conditional expression is constant */
 #endif
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 static client_id_t client_id;
 

--- a/suite/tests/client-interface/drreg-cross.dll.c
+++ b/suite/tests/client-interface/drreg-cross.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -36,14 +36,6 @@
 #include "drmgr.h"
 #include "drreg.h"
 #include "client_tools.h"
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 /* This test assumes that DR has a global lock around bb creation,
  * allowing us to use a global var here.

--- a/suite/tests/client-interface/drreg-end-restore.dll.c
+++ b/suite/tests/client-interface/drreg-end-restore.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,18 +33,11 @@
 /* Tests drreg when the user performs end of basic block restoration. */
 
 #include "dr_api.h"
+#include "client_tools.h"
 #include "drmgr.h"
 #include "drreg.h"
 #include "drutil.h"
 #include <string.h> /* memcpy */
-
-#define CHECK(x, msg)                        \
-    do {                                     \
-        if (!(x)) {                          \
-            dr_fprintf(STDERR, "%s\n", msg); \
-            dr_abort();                      \
-        }                                    \
-    } while (0);
 
 #ifdef X86
 #    define TEST_REG DR_REG_XDI

--- a/suite/tests/client-interface/drreg-flow.dll.c
+++ b/suite/tests/client-interface/drreg-flow.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,18 +33,11 @@
 /* Tests the combination of drreg and drutil, along with other inserted control flow */
 
 #include "dr_api.h"
+#include "client_tools.h"
 #include "drmgr.h"
 #include "drreg.h"
 #include "drutil.h"
 #include <string.h> /* memcpy */
-
-#define CHECK(x, msg)                        \
-    do {                                     \
-        if (!(x)) {                          \
-            dr_fprintf(STDERR, "%s\n", msg); \
-            dr_abort();                      \
-        }                                    \
-    } while (0);
 
 static bool verbose;
 

--- a/suite/tests/client-interface/drreg-test.dll.c
+++ b/suite/tests/client-interface/drreg-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,14 +39,6 @@
 #include "client_tools.h"
 #include "drreg-test-shared.h"
 #include <string.h> /* memset */
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 #define MAGIC_VAL 0xabcd
 

--- a/suite/tests/client-interface/drutil-test.dll.c
+++ b/suite/tests/client-interface/drutil-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,14 +37,6 @@
 #include "drutil.h"
 #include "client_tools.h"
 #include <string.h> /* memcpy */
-
-#define CHECK(x, msg)                        \
-    do {                                     \
-        if (!(x)) {                          \
-            dr_fprintf(STDERR, "%s\n", msg); \
-            dr_abort();                      \
-        }                                    \
-    } while (0);
 
 static bool verbose;
 

--- a/suite/tests/client-interface/drwrap-drreg-test.dll.c
+++ b/suite/tests/client-interface/drwrap-drreg-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2021-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,18 +33,11 @@
 /* Tests the drwrap and drreg extensions used in concert. */
 
 #include "dr_api.h"
+#include "client_tools.h"
 #include "drwrap.h"
 #include "drreg.h"
 #include "drmgr.h"
 #include <string.h> /* memset */
-
-#define CHECK(x, msg)                        \
-    do {                                     \
-        if (!(x)) {                          \
-            dr_fprintf(STDERR, "%s\n", msg); \
-            dr_abort();                      \
-        }                                    \
-    } while (0);
 
 #define SENTINEL 0xbeef
 

--- a/suite/tests/client-interface/drwrap-test.dll.c
+++ b/suite/tests/client-interface/drwrap-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,17 +33,10 @@
 /* Tests the drwrap extension */
 
 #include "dr_api.h"
+#include "client_tools.h"
 #include "drwrap.h"
 #include "drmgr.h"
 #include <string.h> /* memset */
-
-#define CHECK(x, msg)                        \
-    do {                                     \
-        if (!(x)) {                          \
-            dr_fprintf(STDERR, "%s\n", msg); \
-            dr_abort();                      \
-        }                                    \
-    } while (0);
 
 #define DRWRAP_NATIVE_PARAM 0xdeadbeef
 

--- a/suite/tests/client-interface/drx-scattergather.dll.c
+++ b/suite/tests/client-interface/drx-scattergather.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,19 +33,12 @@
 /* TODO i#2985: Test the future drx_expand_scatter_gather() extension using drmgr. */
 
 #include "dr_api.h"
+#include "client_tools.h"
 #include "drmgr.h"
 #include "drreg.h"
 #include "drx.h"
 #include "drx-scattergather-shared.h"
 #include <limits.h>
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 static uint64 global_sg_count;
 

--- a/suite/tests/client-interface/drx-test.dll.c
+++ b/suite/tests/client-interface/drx-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -36,14 +36,6 @@
 #include "drx.h"
 #include "client_tools.h"
 #include "string.h"
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 static client_id_t client_id;
 

--- a/suite/tests/client-interface/drx_buf-test.dll.c
+++ b/suite/tests/client-interface/drx_buf-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -35,17 +35,10 @@
 #include <string.h>
 #include <stdlib.h>
 #include "dr_api.h"
+#include "client_tools.h"
 #include "drmgr.h"
 #include "drx.h"
 #include "drx_buf-test-shared.h"
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 #define CIRCULAR_FAST_SZ DRX_BUF_FAST_CIRCULAR_BUFSZ
 #define CIRCULAR_SLOW_SZ 256

--- a/suite/tests/client-interface/drxmgr-test.dll.c
+++ b/suite/tests/client-interface/drxmgr-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,17 +33,10 @@
 /* Tests the drx extension with drmgr */
 
 #include "dr_api.h"
+#include "client_tools.h"
 #include "drmgr.h"
 #include "drreg.h"
 #include "drx.h"
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 static uint counterA;
 static uint counterB;

--- a/suite/tests/client-interface/emulation_api_simple.dll.c
+++ b/suite/tests/client-interface/emulation_api_simple.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021 Google, Inc.   All rights reserved.
+ * Copyright (c) 2021-2022 Google, Inc.   All rights reserved.
  * Copyright (c) 2018 ARM Limited. All rights reserved.
  * **********************************************************
  *
@@ -48,15 +48,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_log(dr_get_current_drcontext(), DR_LOG_ALL, 1,                        \
-                   "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg);             \
-            /* NOCHECK dr_abort(); */                                                \
-        }                                                                            \
-    } while (0);
 #define PRE instrlist_preinsert
 
 /* These are atomically incremented for precise counts. */

--- a/suite/tests/client-interface/mangle_suspend.dll.c
+++ b/suite/tests/client-interface/mangle_suspend.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -41,14 +41,6 @@
 #include <string.h> /* memset */
 
 #define MAX_RESUME_COUNT 10
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 static byte *add_instr_pc = NULL;
 

--- a/suite/tests/client-interface/predicate-test.dll.c
+++ b/suite/tests/client-interface/predicate-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,14 +38,6 @@
 #include "drutil.h"
 #include "drreg.h"
 #include <string.h> /* memset */
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 #define MINSERT instrlist_meta_preinsert
 

--- a/suite/tests/client-interface/reg_size_test.dll.c
+++ b/suite/tests/client-interface/reg_size_test.dll.c
@@ -1,13 +1,6 @@
 #include "dr_api.h"
+#include "client_tools.h"
 #include "string.h"
-
-#define CHECK(x, msg)                                                                \
-    do {                                                                             \
-        if (!(x)) {                                                                  \
-            dr_fprintf(STDERR, "CHECK failed %s:%d: %s\n", __FILE__, __LINE__, msg); \
-            dr_abort();                                                              \
-        }                                                                            \
-    } while (0);
 
 DR_EXPORT void
 dr_client_main(client_id_t id, int argc, const char *argv[])

--- a/suite/tests/client_tools.h
+++ b/suite/tests/client_tools.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2013-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * *******************************************************************************/
 
@@ -58,6 +58,8 @@
                       dr_abort(), 0)                                                 \
                    : 0))
 #define ASSERT(x) ASSERT_MSG(x, "")
+/* Same as ASSERT_MSG, but kept separate due to existing uses across many files. */
+#define CHECK(x, msg) ASSERT_MSG(x, msg)
 
 /* Redefine DR_ASSERT* to alias ASSERT*.  This makes it easier to import sample
  * clients into the test suite. */


### PR DESCRIPTION
Moves the CHECK macro defined in quite a few tests into
client_tools.h for sharing.