### PR TITLE
i#5362: Disable null sanitizer for stats dumping functions.

### DIFF
--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -156,6 +156,16 @@ typedef char bool;
 #    define INLINE_FORCED inline
 #    define WEAK __attribute__((weak))
 #    define NOINLINE __attribute__((noinline))
+/* The null sanitizer adds is-null checks for pointer dereferences. As part
+ * of this, it stores and retrieves pointers from the stack frame. Each
+ * pointer dereference uses a different stack location. So, if there are too
+ * many pointer dereferences in a function (like dump_global_stats and
+ * dump_thread_stats) it will increase the size of the stack frame a lot
+ * (127KB and 147KB respectively for the mentioned examples) when the null
+ * sanitizer is enabled. The following macro lets us disable this check for
+ * methods annotated with it.
+ */
+#    define DISABLE_NULL_SANITIZER __attribute__((no_sanitize("null")))
 #endif
 
 /* We want a consistent size so we stay away from MAX_PATH.

--- a/core/utils.c
+++ b/core/utils.c
@@ -3042,6 +3042,7 @@ stats_thread_exit(dcontext_t *dcontext)
     }
 }
 
+DISABLE_NULL_SANITIZER
 void
 dump_thread_stats(dcontext_t *dcontext, bool raw)
 {
@@ -3100,6 +3101,7 @@ dump_thread_stats(dcontext_t *dcontext, bool raw)
 #    endif
 }
 
+DISABLE_NULL_SANITIZER
 void
 dump_global_stats(bool raw)
 {

--- a/core/utils.h
+++ b/core/utils.h
@@ -1427,7 +1427,8 @@ extern mutex_t do_threshold_mutex;
          */                                                                            \
         ASSERT(                                                                        \
             (try_pointer) == &global_try_except || (try_pointer) == NULL ||            \
-            (try_pointer) == &get_thread_private_dcontext()->try_except ||             \
+            (get_thread_private_dcontext() != NULL &&                                  \
+             (try_pointer) == &get_thread_private_dcontext()->try_except) ||           \
             (try_pointer) == /* A currently-native thread: */                          \
                 &thread_lookup(IF_UNIX_ELSE(get_sys_thread_id(), d_r_get_thread_id())) \
                      ->dcontext->try_except);                                          \


### PR DESCRIPTION
dump_global_stats and dump_thread_stats print stats to logs. They have multiple
pointer dereferences for each stat. The null sanitizer in UBSan adds an is-null
check before each pointer dereference. As part of this, it stores and retrieves
the pointer from a location on the current stack frame. Each pointer dereference
uses a different location on the stack. This causes a huge increase in the
frame size for functions like dump_global_stats and dump_thread_stats (127 KB
and 147 KB respectively observed) which have a lot of pointer dereferences. We
annotate such functions with the added annotation to disable the null sanitizer
check.
https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#available-checks

Tried adding the annotation to various other functions too, but the gains were
relatively low:
dump_global_stats: 127KB to 8B
dump_local_stats: 147KB to 16B
build_bb_ilist: 12.8KB to 1KB
instr_encode_arch: 2.3KB to 0.5KB
common_heap_alloc: 5KB to 0.7KB
recreate_app_state_internal: 8.6KB to 5.1KB

Also fixes a null pointer dereference in an assert statement.

The null sanitizer fix is more relevant for when we want DR logs, as the major
stack space savings come from the dump_*_stats functions.

Fixes: #5362