### PR TITLE
i#2502 locks: Fix bug in ATOMIC_MAX on AArchXX

### DIFF
--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1185,7 +1185,7 @@ atomic_aligned_read_int64(volatile int64 *var)
         ASSERT(sizeof(type) == sizeof(maxvar));                                     \
         ASSERT(sizeof(type) == sizeof(curvar));                                     \
         do {                                                                        \
-            atomic_max__maxval = (maxvar);                                          \
+            atomic_max__maxval = atomic_aligned_read_int((int *)&(maxvar));         \
         } while (atomic_max__maxval < atomic_max__curval &&                         \
                  !atomic_compare_exchange_int((int *)&(maxvar), atomic_max__maxval, \
                                               atomic_max__curval));                 \
@@ -1200,7 +1200,7 @@ atomic_aligned_read_int64(volatile int64 *var)
             ASSERT(sizeof(type) == sizeof(maxvar));                                    \
             ASSERT(sizeof(type) == sizeof(curvar));                                    \
             do {                                                                       \
-                atomic_max__maxval = (maxvar);                                         \
+                atomic_max__maxval = atomic_aligned_read_int64((int64 *)&(maxvar));    \
             } while (atomic_max__maxval < atomic_max__curval &&                        \
                      !atomic_compare_exchange_int64(                                   \
                          (int64 *)&(maxvar), atomic_max__maxval, atomic_max__curval)); \


### PR DESCRIPTION
Adds a missing load-acquire in a loop in ATOMIC_MAX that causes hangs
in RSTATS_ADD_PEAK.

Tested on the client.annotation-concurrency test on AArch64 where
without this fix it hangs under release-build plain DR every ~100
runs.  With the fix, there is no hang in 20K runs.

Issue: #2502, #4928