### PR TITLE
i#4928: Isolate libc write to avoid hangs

### DIFF
--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * *******************************************************************************/
 
@@ -1427,13 +1427,21 @@ static const redirect_import_t redirect_imports[] = {
     { "free", (app_pc)redirect_free },
     { "realloc", (app_pc)redirect_realloc },
     { "strdup", (app_pc)redirect_strdup },
-/* TODO i#4243: we should also redirect functions including:
- * + malloc_usable_size, memalign, valloc, mallinfo, mallopt, etc.
- * + tcmalloc: tc_malloc, tc_free, etc.
- * + __libc_malloc, __libc_free, etc.
- * + OSX: malloc_zone_malloc, etc.?  Or just malloc_create_zone?
- * + C++ operators in case they don't just call libc malloc?
- */
+    /* TODO i#4243: we should also redirect functions including:
+     * + malloc_usable_size, memalign, valloc, mallinfo, mallopt, etc.
+     * + tcmalloc: tc_malloc, tc_free, etc.
+     * + __libc_malloc, __libc_free, etc.
+     * + OSX: malloc_zone_malloc, etc.?  Or just malloc_create_zone?
+     * + C++ operators in case they don't just call libc malloc?
+     */
+    /* We redirect these for fd isolation. */
+    { "open", (app_pc)os_open_protected },
+    { "close", (app_pc)os_close_protected },
+    /* These libc routines can call pthread functions and cause hangs (i#4928) so
+     * we use our syscall wrappers instead.
+     */
+    { "read", (app_pc)os_read },
+    { "write", (app_pc)os_write },
 #if defined(LINUX) && !defined(ANDROID)
     { "__tls_get_addr", (app_pc)redirect___tls_get_addr },
     { "___tls_get_addr", (app_pc)redirect____tls_get_addr },

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -326,17 +326,12 @@ for (my $i = 0; $i <= $#lines; ++$i) {
             # FIXME i#2417: fix flaky/regressed AArch64 tests
             %ignore_failures_64 = ('code_api|linux.sigsuspend' => 1,
                                    'code_api|pthreads.pthreads_exit' => 1,
-                                   'code_api|tool.drcachesim.invariants' => 1, # i#2892
                                    'code_api|tool.histogram.offline' => 1, # i#3980
                                    'code_api|linux.fib-conflict' => 1,
                                    'code_api|linux.fib-conflict-early' => 1,
                                    'code_api|linux.mangle_asynch' => 1,
                                    'code_api|tool.drcachesim.phys' => 1, # i#4922
-                                   'code_api|tool.drcachesim.TLB-threads' => 1, # i#4928
-                                   'code_api|tool.drcachesim.threads' => 1, # i#4928
                                    'code_api,tracedump_text,tracedump_origins,syntax_intel|common.loglevel' => 1, # i#1807
-                                   'code_api|tool.drcachesim.threads-with-config-file' => 1, # i#4954
-                                   'code_api|tool.drcachesim.coherence' => 1, # i#2417
                                    );
             if ($is_32) {
                 $issue_no = "#2416";


### PR DESCRIPTION
Adds private loader redirection of open, close, read, and write to
DR's syscall-wrapper versions (plus file descriptor isolation, for
open and close).  The libc write invokes pthread code for cancel
features, and we are not able to create a private libpthread or
isolate pthread resources (#956) which leads to poor interactions with
application pthread uses and observed hangs.

Tested on the AArch64 Jenkins machine where these tests all hung every
5 to 10 runs in release build before and now they succeed 20,000 times
in a row:
```
--------------------------------------------------
derek@dynamorio:~/dr/build_rel$ for i in sim.threads\$ sim.TLB-threads sim.coherence sim.threads-with; do echo $i; ctest --repeat-until-fail 20000 -R $i > RUN-$i 2>&1; done
sim.threads$
sim.TLB-threads
sim.coherence
sim.threads-with
derek@dynamorio:~/dr/build_rel$ grep -c Passed RUN-*
RUN-sim.coherence:20000
RUN-sim.threads$:20000
RUN-sim.threads-with:20000
RUN-sim.TLB-threads:20000
derek@dynamorio:~/dr/build_rel$ grep failed RUN-*
RUN-sim.coherence:100% tests passed, 0 tests failed out of 1
RUN-sim.threads$:100% tests passed, 0 tests failed out of 1
RUN-sim.threads-with:100% tests passed, 0 tests failed out of 1
RUN-sim.TLB-threads:100% tests passed, 0 tests failed out of 1
--------------------------------------------------
```

While at it, removes drcachesim.invariants which was tested as well
and has no failures.

Issue: #4928, #4954, #2417, #956
Fixes #4928
Fixes #4954
Fixes #2892