### PR TITLE
i#5376: Fix drwrap reattach failing to clear flags

### DIFF
--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -1056,6 +1056,7 @@ drwrap_exit(void)
     dr_rwlock_destroy(post_call_rwlock);
     dr_recurlock_destroy(wrap_lock);
     wrap_lock = NULL; /* For early drwrap_set_global_flags() after re-attach. */
+    global_flags = 0; /* For re-attach. */
     drmgr_exit();
 
     while (post_call_notify_list != NULL) {

--- a/suite/tests/client-interface/drbbdup-drwrap-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-drwrap-test.dll.c
@@ -169,6 +169,19 @@ dr_init(client_id_t id)
     CHECK(!res, "DRWRAP_INVERT_CONTROL after drwrap_init should fail");
     drwrap_exit();
 
+    /* Test drwrap re-attach for flags. */
+    res = drwrap_init();
+    CHECK(res, "drwrap_init failed");
+    res = drwrap_set_global_flags(DRWRAP_SAFE_READ_RETADDR);
+    CHECK(res, "setting flag should succeed");
+    drwrap_exit();
+    res = drwrap_init();
+    CHECK(res, "drwrap_init failed");
+    res = drwrap_set_global_flags(DRWRAP_SAFE_READ_RETADDR);
+    CHECK(res, "setting flag 2nd time should succeed");
+    drwrap_exit();
+
+    /* Now set up for this test. */
     res = drwrap_set_global_flags(DRWRAP_INVERT_CONTROL);
     CHECK(res, "DRWRAP_INVERT_CONTROL failed");
     res = drwrap_init();


### PR DESCRIPTION
Fixes a drwrap reattach bug by resetting global_flags to 0.

Adds a test case to the drbbdup-drwrap-test.

Fixes #5376