### PR TITLE
i#4134 drbbdup: Remove superfluous dr_defines include

### DIFF
--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -30,7 +30,6 @@
  * DAMAGE.
  */
 
-#include "dr_defines.h"
 #include "dr_api.h"
 #include "drmgr.h"
 #include "drreg.h"


### PR DESCRIPTION
Removes the include of dr_defines.h before dr_api.h in drbbdup.c.
This superfluous include (it's already included by dr_api.h) breaks
building drbbdup with some toolchains that embed DynamoRIO, preventing
its use for #3995.

Issue: #4134, #3995