### PR TITLE
i#4922: Fix tool.drcachesim.phys on AArch64.

### DIFF
--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -298,6 +298,8 @@ private:
 class online_instru_t : public instru_t {
 public:
     online_instru_t(void (*insert_load_buf)(void *, instrlist_t *, instr_t *, reg_id_t),
+                    void (*insert_update_buf_ptr)(void *, instrlist_t *, instr_t *,
+                                                  reg_id_t, dr_pred_type_t, int),
                     bool memref_needs_info, drvector_t *reg_vector);
     virtual ~online_instru_t();
 
@@ -354,6 +356,8 @@ private:
     insert_save_type_and_size(void *drcontext, instrlist_t *ilist, instr_t *where,
                               reg_id_t base, reg_id_t scratch, ushort type, ushort size,
                               int adjust);
+    void (*insert_update_buf_ptr_)(void *, instrlist_t *, instr_t *, reg_id_t,
+                                   dr_pred_type_t, int);
 };
 
 class offline_instru_t : public instru_t {

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -356,6 +356,8 @@ private:
     insert_save_type_and_size(void *drcontext, instrlist_t *ilist, instr_t *where,
                               reg_id_t base, reg_id_t scratch, ushort type, ushort size,
                               int adjust);
+
+protected:
     void (*insert_update_buf_ptr_)(void *, instrlist_t *, instr_t *, reg_id_t,
                                    dr_pred_type_t, int);
 };

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -332,7 +332,7 @@ online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
     // Note that we need this handling here only for instrument_instr. In some
     // cases, tracer.cpp delays instrument_instr for instructions that do not
     // have any memref. When it actually does it, the trace entries for many
-    // instructions are written together, which may cause use to exceed the
+    // instructions are written together, which may cause us to exceed the
     // MAX_IMM_DISP_STUR.
     if (adjust + sizeof(trace_entry_t) > MAX_IMM_DISP_STUR) {
         insert_update_buf_ptr_(drcontext, ilist, where, reg_ptr, DR_PRED_NONE, adjust);

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -41,7 +41,7 @@
 #include <limits.h> /* for USHRT_MAX */
 #include <stddef.h> /* for offsetof */
 
-#define MAX_OFFSET_IMM_STUR 255
+#define MAX_IMM_DISP_STUR 255
 
 online_instru_t::online_instru_t(void (*insert_load_buf)(void *, instrlist_t *, instr_t *,
                                                          reg_id_t),
@@ -327,14 +327,14 @@ online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
 #ifdef AARCH64
     // Update the trace buffer pointer if we are about to exceed the maximum
     // immediate displacement allowed by OP_stur. As sizeof(trace_entry_t) = 12,
-    // every other pc write to the trace buffer will not be 8-byte aligned,
-    // therefore will have to use OP_stur.
+    // every other entry in the trace buffer will have an addr field whose
+    // address is not 8-byte aligned. Therefore, we will have to use OP_stur.
     // Note that we need this handling here only for instrument_instr. In some
     // cases, tracer.cpp delays instrument_instr for instructions that do not
     // have any memref. When it actually does it, the trace entries for many
     // instructions are written together, which may cause use to exceed the
-    // MAX_OFFSET_IMM_STUR.
-    if (adjust + sizeof(trace_entry_t) > MAX_OFFSET_IMM_STUR) {
+    // MAX_IMM_DISP_STUR.
+    if (adjust + sizeof(trace_entry_t) > MAX_IMM_DISP_STUR) {
         insert_update_buf_ptr_(drcontext, ilist, where, reg_ptr, DR_PRED_NONE, adjust);
         adjust = 0;
     }

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -41,10 +41,16 @@
 #include <limits.h> /* for USHRT_MAX */
 #include <stddef.h> /* for offsetof */
 
+#define MAX_OFFSET_IMM_STUR 255
+
 online_instru_t::online_instru_t(void (*insert_load_buf)(void *, instrlist_t *, instr_t *,
                                                          reg_id_t),
+                                 void (*insert_update_buf_ptr)(void *, instrlist_t *,
+                                                               instr_t *, reg_id_t,
+                                                               dr_pred_type_t, int),
                                  bool memref_needs_info, drvector_t *reg_vector)
     : instru_t(insert_load_buf, memref_needs_info, reg_vector, sizeof(trace_entry_t))
+    , insert_update_buf_ptr_(insert_update_buf_ptr)
 {
 }
 
@@ -318,7 +324,21 @@ online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
                                   int adjust, instr_t *app)
 {
     bool repstr_expanded = *bb_field != 0; // Avoid cl warning C4800.
-
+#ifdef AARCH64
+    // Update the trace buffer pointer if we are about to exceed the maximum
+    // immediate displacement allowed by OP_stur. As sizeof(trace_entry_t) = 12,
+    // every other pc write to the trace buffer will not be 8-byte aligned,
+    // therefore will have to use OP_stur.
+    // Note that we need this handling here only for instrument_instr. In some
+    // cases, tracer.cpp delays instrument_instr for instructions that do not
+    // have any memref. When it actually does it, the trace entries for many
+    // instructions are written together, which may cause use to exceed the
+    // MAX_OFFSET_IMM_STUR.
+    if (adjust + sizeof(trace_entry_t) > MAX_OFFSET_IMM_STUR) {
+        insert_update_buf_ptr_(drcontext, ilist, where, reg_ptr, DR_PRED_NONE, adjust);
+        adjust = 0;
+    }
+#endif
     DR_ASSERT(instr_is_app(app));
     app_pc pc = instr_get_app_pc(app);
     reg_id_t reg_tmp;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -75,7 +75,7 @@
         }                                  \
     } while (0)
 
-static online_instru_t instru(NULL, false, NULL);
+static online_instru_t instru(NULL, NULL, false, NULL);
 
 int
 trace_metadata_writer_t::write_thread_exit(byte *buffer, thread_id_t tid)

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -2148,8 +2148,9 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
         /* we use placement new for better isolation */
         DR_ASSERT(MAX_INSTRU_SIZE >= sizeof(online_instru_t));
         placement = dr_global_alloc(MAX_INSTRU_SIZE);
-        instru = new (placement) online_instru_t(
-            insert_load_buf_ptr, op_L0_filter.get_value(), &scratch_reserve_vec);
+        instru = new (placement)
+            online_instru_t(insert_load_buf_ptr, insert_update_buf_ptr,
+                            op_L0_filter.get_value(), &scratch_reserve_vec);
         if (!ipc_pipe.set_name(op_ipc_name.get_value().c_str()))
             DR_ASSERT(false);
 #ifdef UNIX

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -330,7 +330,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'code_api|linux.fib-conflict' => 1,
                                    'code_api|linux.fib-conflict-early' => 1,
                                    'code_api|linux.mangle_asynch' => 1,
-                                   'code_api|tool.drcachesim.phys' => 1, # i#4922
                                    'code_api,tracedump_text,tracedump_origins,syntax_intel|common.loglevel' => 1, # i#1807
                                    );
             if ($is_32) {


### PR DESCRIPTION
Fixes the incorrect usage of OP_stur in tool.drcachesim.phys test on AArch64.
This was caused by delaying instrumentation for too many instructions, so that
when we finally did instrument them, we exceeded the  maximum immediate
displacement allowed by OP_stur. Our code needs to use OP_stur because the
trace_entry_t has a size of 12 bytes, meaning that every other entry in the buffer
will have a non-8-byte-aligned address for the `addr` field.

Grants the online_instr_t class the ability to update the trace buffer pointer
by passing the required function to it.

Also removes the test from the ignore list for AArch64.

Fixes: #4922